### PR TITLE
Fix failed preview retry to start a new preview

### DIFF
--- a/frontend/src/components/preview/preview-panel.test.tsx
+++ b/frontend/src/components/preview/preview-panel.test.tsx
@@ -1020,6 +1020,24 @@ describe("PreviewPanel component", () => {
     });
   });
 
+  it("starts a new preview when retrying after a failed preview", async () => {
+    const user = userEvent.setup();
+    mockGet.mockResolvedValue(makePreviewStatus({ status: "failed" }));
+
+    renderWithProviders(<PreviewPanel {...DEFAULT_PROPS} />);
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Retry Preview" })).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole("button", { name: "Retry Preview" }));
+
+    await waitFor(() => {
+      expect(mockStart).toHaveBeenCalledWith("sess-1");
+    });
+    expect(mockRestart).not.toHaveBeenCalled();
+  });
+
   /* ---------- Mutation error banner ---------- */
 
   it("shows mutation error banner when start fails", async () => {

--- a/frontend/src/components/preview/preview-panel.tsx
+++ b/frontend/src/components/preview/preview-panel.tsx
@@ -871,12 +871,12 @@ export function PreviewPanel({
               {status === "failed" && (
                 <Button
                   size="sm"
-                  onClick={() => restartMutation.mutate()}
+                  onClick={() => startMutation.mutate()}
                   disabled={isMutating}
-                  loading={restartMutation.isPending}
+                  loading={startMutation.isPending}
                 >
-                  {!restartMutation.isPending && <RotateCw className="size-3.5" />}
-                  Restart Preview
+                  {!startMutation.isPending && <RotateCw className="size-3.5" />}
+                  Retry Preview
                 </Button>
               )}
             </div>


### PR DESCRIPTION
## Summary
- Change the failed-preview CTA to retry by starting a new preview instead of calling restart on a terminal preview.
- Add a regression test covering the failed-preview retry flow.

## Testing
- Added a unit test asserting failed previews call `start` and do not call `restart`.
- Frontend validation was covered in the branch work: typecheck, lint, build, and the focused preview-panel test passed.