### PR TITLE
Fix frontend deploy by including Fumadocs inputs before npm ci

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -9,6 +9,8 @@ coverage.html
 frontend/node_modules
 frontend/.next
 frontend/coverage
-docs/
 *.md
 !README.md
+docs/*
+!docs/public
+!docs/public/**

--- a/Dockerfile.frontend
+++ b/Dockerfile.frontend
@@ -4,6 +4,8 @@
 FROM node:22-alpine AS builder
 WORKDIR /app
 COPY frontend/package.json frontend/package-lock.json ./
+COPY frontend/source.config.ts ./
+COPY docs/public /docs/public
 RUN npm ci
 COPY frontend/ .
 ARG BUILD_SHA=dev

--- a/deploy/deploy_config_test.go
+++ b/deploy/deploy_config_test.go
@@ -24,6 +24,31 @@ func TestFrontendContainerBindsAllInterfaces(t *testing.T) {
 	require.Contains(t, string(dockerfile), "ENV HOSTNAME=0.0.0.0", "frontend image should default Next standalone to bind all interfaces")
 }
 
+func TestFrontendDockerfileCopiesFumadocsInputsBeforeInstall(t *testing.T) {
+	t.Parallel()
+
+	dockerfile, err := os.ReadFile("../Dockerfile.frontend")
+	require.NoError(t, err, "test should read the frontend Dockerfile")
+	dockerfileText := string(dockerfile)
+	sourceConfigCopyIndex := strings.Index(dockerfileText, "COPY frontend/source.config.ts ./")
+	publicDocsCopyIndex := strings.Index(dockerfileText, "COPY docs/public /docs/public")
+	npmCIIndex := strings.Index(dockerfileText, "RUN npm ci")
+
+	require.NotEqual(t, -1, sourceConfigCopyIndex, "frontend image should copy the Fumadocs source config before install scripts run")
+	require.NotEqual(t, -1, publicDocsCopyIndex, "frontend image should copy public docs before Fumadocs install scripts run")
+	require.NotEqual(t, -1, npmCIIndex, "frontend image should install dependencies with npm ci")
+	require.Less(t, sourceConfigCopyIndex, npmCIIndex, "source.config.ts should be available before npm ci runs postinstall")
+	require.Less(t, publicDocsCopyIndex, npmCIIndex, "docs/public should be available before npm ci runs postinstall")
+
+	dockerignore, err := os.ReadFile("../.dockerignore")
+	require.NoError(t, err, "test should read the root Docker ignore file")
+	dockerignoreText := string(dockerignore)
+	require.NotContains(t, dockerignoreText, "\ndocs/\n", "docker build context should not exclude the entire docs tree because docs/public is needed by the frontend image")
+	require.Contains(t, dockerignoreText, "docs/*", "docker build context should continue excluding non-public docs by default")
+	require.Contains(t, dockerignoreText, "!docs/public", "docker build context should include the public docs directory")
+	require.Contains(t, dockerignoreText, "!docs/public/**", "docker build context should include public docs files for Fumadocs generation")
+}
+
 func TestPreviewWildcardTLSUsesCloudflareDNSChallenge(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- Copy `frontend/source.config.ts` and `docs/public` into the frontend image before `npm ci` so Fumadocs postinstall can run during the Docker build
- Adjust the root `.dockerignore` to exclude internal docs while still allowing `docs/public` into the build context
- Add a deploy regression test to lock in the Dockerfile ordering and build-context rules

## Testing
- Added/ran a regression test covering the Fumadocs install inputs and Docker ignore rules
- Verified frontend install and production build succeed locally
- Verified Go vet, Go build, and Go test pass