### PR TITLE
Preserve session failure details during resume claims and handle Claude invalid_grant refreshes

### DIFF
--- a/internal/api/handlers/sessions_test.go
+++ b/internal/api/handlers/sessions_test.go
@@ -4986,7 +4986,7 @@ func TestSessionHandler_SendMessage(t *testing.T) {
 				mock.ExpectQuery("UPDATE sessions SET status").
 					WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
 					WillReturnRows(pgxmock.NewRows(sessionColumns))
-				mock.ExpectQuery(`UPDATE sessions\s+SET status = 'running', completed_at = NULL,\s+error = NULL,\s+failure_explanation = NULL,\s+failure_category = NULL,\s+failure_next_steps = NULL,\s+failure_retry_advised = false,\s+last_activity_at = now\(\)\s+WHERE id = @id AND org_id = @org_id AND status = ANY\(@statuses\)\s+AND sandbox_state != 'destroyed'\s+RETURNING`).
+				mock.ExpectQuery(`UPDATE sessions\s+SET status = 'running', completed_at = NULL,\s+last_activity_at = now\(\)\s+WHERE id = @id AND org_id = @org_id AND status = ANY\(@statuses\)\s+AND sandbox_state != 'destroyed'\s+RETURNING`).
 					WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
 					WillReturnRows(
 						addSessionRow(pgxmock.NewRows(sessionColumns),
@@ -5066,7 +5066,7 @@ func TestSessionHandler_SendMessage(t *testing.T) {
 				mock.ExpectQuery("UPDATE sessions SET status").
 					WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
 					WillReturnRows(pgxmock.NewRows(sessionColumns))
-				mock.ExpectQuery(`UPDATE sessions\s+SET status = 'running', completed_at = NULL,\s+error = NULL,\s+failure_explanation = NULL,\s+failure_category = NULL,\s+failure_next_steps = NULL,\s+failure_retry_advised = false,\s+last_activity_at = now\(\)\s+WHERE id = @id AND org_id = @org_id AND status = ANY\(@statuses\)\s+AND sandbox_state != 'destroyed'\s+RETURNING`).
+				mock.ExpectQuery(`UPDATE sessions\s+SET status = 'running', completed_at = NULL,\s+last_activity_at = now\(\)\s+WHERE id = @id AND org_id = @org_id AND status = ANY\(@statuses\)\s+AND sandbox_state != 'destroyed'\s+RETURNING`).
 					WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
 					WillReturnRows(
 						addSessionRow(pgxmock.NewRows(sessionColumns),
@@ -5132,7 +5132,7 @@ func TestSessionHandler_SendMessage(t *testing.T) {
 				mock.ExpectQuery("UPDATE sessions SET status").
 					WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
 					WillReturnRows(pgxmock.NewRows(sessionColumns))
-				mock.ExpectQuery(`UPDATE sessions\s+SET status = 'running', completed_at = NULL,\s+error = NULL,\s+failure_explanation = NULL,\s+failure_category = NULL,\s+failure_next_steps = NULL,\s+failure_retry_advised = false,\s+last_activity_at = now\(\)\s+WHERE id = @id AND org_id = @org_id AND status = ANY\(@statuses\)\s+AND sandbox_state != 'destroyed'\s+RETURNING`).
+				mock.ExpectQuery(`UPDATE sessions\s+SET status = 'running', completed_at = NULL,\s+last_activity_at = now\(\)\s+WHERE id = @id AND org_id = @org_id AND status = ANY\(@statuses\)\s+AND sandbox_state != 'destroyed'\s+RETURNING`).
 					WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
 					WillReturnRows(
 						addSessionRow(pgxmock.NewRows(sessionColumns),
@@ -5198,7 +5198,7 @@ func TestSessionHandler_SendMessage(t *testing.T) {
 				mock.ExpectQuery("UPDATE sessions SET status").
 					WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
 					WillReturnRows(pgxmock.NewRows(sessionColumns))
-				mock.ExpectQuery(`UPDATE sessions\s+SET status = 'running', completed_at = NULL,\s+error = NULL,\s+failure_explanation = NULL,\s+failure_category = NULL,\s+failure_next_steps = NULL,\s+failure_retry_advised = false,\s+last_activity_at = now\(\)\s+WHERE id = @id AND org_id = @org_id AND status = ANY\(@statuses\)\s+AND sandbox_state != 'destroyed'\s+RETURNING`).
+				mock.ExpectQuery(`UPDATE sessions\s+SET status = 'running', completed_at = NULL,\s+last_activity_at = now\(\)\s+WHERE id = @id AND org_id = @org_id AND status = ANY\(@statuses\)\s+AND sandbox_state != 'destroyed'\s+RETURNING`).
 					WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
 					WillReturnRows(
 						addSessionRow(pgxmock.NewRows(sessionColumns),

--- a/internal/api/handlers/sessions_test.go
+++ b/internal/api/handlers/sessions_test.go
@@ -4986,7 +4986,7 @@ func TestSessionHandler_SendMessage(t *testing.T) {
 				mock.ExpectQuery("UPDATE sessions SET status").
 					WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
 					WillReturnRows(pgxmock.NewRows(sessionColumns))
-				mock.ExpectQuery("UPDATE sessions\\s+SET status = 'running', completed_at = NULL, last_activity_at = now\\(\\)\\s+WHERE id = @id AND org_id = @org_id AND status = ANY\\(@statuses\\)\\s+AND sandbox_state != 'destroyed'\\s+RETURNING").
+				mock.ExpectQuery(`UPDATE sessions\s+SET status = 'running', completed_at = NULL,\s+error = NULL,\s+failure_explanation = NULL,\s+failure_category = NULL,\s+failure_next_steps = NULL,\s+failure_retry_advised = false,\s+last_activity_at = now\(\)\s+WHERE id = @id AND org_id = @org_id AND status = ANY\(@statuses\)\s+AND sandbox_state != 'destroyed'\s+RETURNING`).
 					WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
 					WillReturnRows(
 						addSessionRow(pgxmock.NewRows(sessionColumns),
@@ -5066,7 +5066,7 @@ func TestSessionHandler_SendMessage(t *testing.T) {
 				mock.ExpectQuery("UPDATE sessions SET status").
 					WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
 					WillReturnRows(pgxmock.NewRows(sessionColumns))
-				mock.ExpectQuery("UPDATE sessions\\s+SET status = 'running', completed_at = NULL, last_activity_at = now\\(\\)\\s+WHERE id = @id AND org_id = @org_id AND status = ANY\\(@statuses\\)\\s+AND sandbox_state != 'destroyed'\\s+RETURNING").
+				mock.ExpectQuery(`UPDATE sessions\s+SET status = 'running', completed_at = NULL,\s+error = NULL,\s+failure_explanation = NULL,\s+failure_category = NULL,\s+failure_next_steps = NULL,\s+failure_retry_advised = false,\s+last_activity_at = now\(\)\s+WHERE id = @id AND org_id = @org_id AND status = ANY\(@statuses\)\s+AND sandbox_state != 'destroyed'\s+RETURNING`).
 					WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
 					WillReturnRows(
 						addSessionRow(pgxmock.NewRows(sessionColumns),
@@ -5132,7 +5132,7 @@ func TestSessionHandler_SendMessage(t *testing.T) {
 				mock.ExpectQuery("UPDATE sessions SET status").
 					WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
 					WillReturnRows(pgxmock.NewRows(sessionColumns))
-				mock.ExpectQuery("UPDATE sessions\\s+SET status = 'running', completed_at = NULL, last_activity_at = now\\(\\)\\s+WHERE id = @id AND org_id = @org_id AND status = ANY\\(@statuses\\)\\s+AND sandbox_state != 'destroyed'\\s+RETURNING").
+				mock.ExpectQuery(`UPDATE sessions\s+SET status = 'running', completed_at = NULL,\s+error = NULL,\s+failure_explanation = NULL,\s+failure_category = NULL,\s+failure_next_steps = NULL,\s+failure_retry_advised = false,\s+last_activity_at = now\(\)\s+WHERE id = @id AND org_id = @org_id AND status = ANY\(@statuses\)\s+AND sandbox_state != 'destroyed'\s+RETURNING`).
 					WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
 					WillReturnRows(
 						addSessionRow(pgxmock.NewRows(sessionColumns),
@@ -5198,7 +5198,7 @@ func TestSessionHandler_SendMessage(t *testing.T) {
 				mock.ExpectQuery("UPDATE sessions SET status").
 					WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
 					WillReturnRows(pgxmock.NewRows(sessionColumns))
-				mock.ExpectQuery("UPDATE sessions\\s+SET status = 'running', completed_at = NULL, last_activity_at = now\\(\\)\\s+WHERE id = @id AND org_id = @org_id AND status = ANY\\(@statuses\\)\\s+AND sandbox_state != 'destroyed'\\s+RETURNING").
+				mock.ExpectQuery(`UPDATE sessions\s+SET status = 'running', completed_at = NULL,\s+error = NULL,\s+failure_explanation = NULL,\s+failure_category = NULL,\s+failure_next_steps = NULL,\s+failure_retry_advised = false,\s+last_activity_at = now\(\)\s+WHERE id = @id AND org_id = @org_id AND status = ANY\(@statuses\)\s+AND sandbox_state != 'destroyed'\s+RETURNING`).
 					WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
 					WillReturnRows(
 						addSessionRow(pgxmock.NewRows(sessionColumns),

--- a/internal/db/session_store.go
+++ b/internal/db/session_store.go
@@ -1076,7 +1076,7 @@ func (s *SessionStore) UpdateStatus(ctx context.Context, orgID, runID uuid.UUID,
 		// Clear completed_at so a resumed session doesn't display as "completed"
 		// while actively running. Duration is computed from started_at, so that is
 		// also refreshed to reflect the current run.
-		query = `UPDATE sessions SET status = @status, started_at = now(), completed_at = NULL, last_activity_at = now() WHERE id = @id AND org_id = @org_id AND deleted_at IS NULL`
+		query = `UPDATE sessions SET status = @status, started_at = now(), completed_at = NULL, error = NULL, failure_explanation = NULL, failure_category = NULL, failure_next_steps = NULL, failure_retry_advised = false, last_activity_at = now() WHERE id = @id AND org_id = @org_id AND deleted_at IS NULL`
 	} else if status == models.SessionStatusCompleted || status == models.SessionStatusFailed || status == models.SessionStatusCancelled {
 		query = `UPDATE sessions SET status = @status, completed_at = now(), last_activity_at = now() WHERE id = @id AND org_id = @org_id AND deleted_at IS NULL`
 	}
@@ -1163,6 +1163,10 @@ func (s *SessionStore) updateResultRow(ctx context.Context, db DBTX, orgID, runI
 		    result_summary = @result_summary,
 		    diff = COALESCE(@diff, diff),
 		    error = @error,
+		    failure_explanation = NULL,
+		    failure_category = NULL,
+		    failure_next_steps = NULL,
+		    failure_retry_advised = false,
 		    base_commit_sha = COALESCE(@base_commit_sha, base_commit_sha),
 		    diff_collected_at = COALESCE(@diff_collected_at, diff_collected_at),
 		    diff_stats = COALESCE(@diff_stats, diff_stats),
@@ -1242,7 +1246,13 @@ func (s *SessionStore) ListTerminalEndedBefore(ctx context.Context, before time.
 func (s *SessionStore) ClaimIdle(ctx context.Context, orgID, sessionID uuid.UUID) (models.Session, error) {
 	query := `
 		UPDATE sessions
-		SET status = 'running', started_at = now(), completed_at = NULL, last_activity_at = now()
+		SET status = 'running', started_at = now(), completed_at = NULL,
+		    error = NULL,
+		    failure_explanation = NULL,
+		    failure_category = NULL,
+		    failure_next_steps = NULL,
+		    failure_retry_advised = false,
+		    last_activity_at = now()
 		WHERE id = @id AND org_id = @org_id AND status = 'idle'
 		  AND sandbox_state != 'destroyed'
 		RETURNING ` + sessionSelectColumns
@@ -1272,7 +1282,13 @@ func (s *SessionStore) ClaimIdle(ctx context.Context, orgID, sessionID uuid.UUID
 func (s *SessionStore) ClaimForResume(ctx context.Context, orgID, sessionID uuid.UUID) (models.Session, error) {
 	query := `
 		UPDATE sessions
-		SET status = 'running', completed_at = NULL, last_activity_at = now()
+		SET status = 'running', completed_at = NULL,
+		    error = NULL,
+		    failure_explanation = NULL,
+		    failure_category = NULL,
+		    failure_next_steps = NULL,
+		    failure_retry_advised = false,
+		    last_activity_at = now()
 		WHERE id = @id AND org_id = @org_id AND status = ANY(@statuses)
 		  AND sandbox_state != 'destroyed'
 		RETURNING ` + sessionSelectColumns
@@ -1577,6 +1593,10 @@ func (s *SessionStore) updateTurnCompleteRow(ctx context.Context, db DBTX, orgID
 		    result_summary = @result_summary,
 		    diff = COALESCE(@diff, diff),
 		    error = @error,
+		    failure_explanation = NULL,
+		    failure_category = NULL,
+		    failure_next_steps = NULL,
+		    failure_retry_advised = false,
 		    base_commit_sha = COALESCE(@base_commit_sha, base_commit_sha),
 		    diff_collected_at = COALESCE(@diff_collected_at, diff_collected_at),
 		    diff_stats = COALESCE(@diff_stats, diff_stats),

--- a/internal/db/session_store.go
+++ b/internal/db/session_store.go
@@ -1283,11 +1283,6 @@ func (s *SessionStore) ClaimForResume(ctx context.Context, orgID, sessionID uuid
 	query := `
 		UPDATE sessions
 		SET status = 'running', completed_at = NULL,
-		    error = NULL,
-		    failure_explanation = NULL,
-		    failure_category = NULL,
-		    failure_next_steps = NULL,
-		    failure_retry_advised = false,
 		    last_activity_at = now()
 		WHERE id = @id AND org_id = @org_id AND status = ANY(@statuses)
 		  AND sandbox_state != 'destroyed'

--- a/internal/db/session_store_test.go
+++ b/internal/db/session_store_test.go
@@ -1236,7 +1236,7 @@ func TestSessionStore_ClaimForResume(t *testing.T) {
 			name: "resumes completed session successfully",
 			setupMock: func(mock pgxmock.PgxPoolIface) {
 				now := time.Now()
-				mock.ExpectQuery(`UPDATE sessions\s+SET status = 'running', completed_at = NULL,\s+error = NULL,\s+failure_explanation = NULL,\s+failure_category = NULL,\s+failure_next_steps = NULL,\s+failure_retry_advised = false,\s+last_activity_at = now\(\)\s+WHERE id = @id AND org_id = @org_id AND status = ANY\(@statuses\)\s+AND sandbox_state != 'destroyed'\s+RETURNING`).
+				mock.ExpectQuery(`UPDATE sessions\s+SET status = 'running', completed_at = NULL,\s+last_activity_at = now\(\)\s+WHERE id = @id AND org_id = @org_id AND status = ANY\(@statuses\)\s+AND sandbox_state != 'destroyed'\s+RETURNING`).
 					WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
 					WillReturnRows(
 						pgxmock.NewRows(sessionTestColumns).AddRow(
@@ -1249,7 +1249,7 @@ func TestSessionStore_ClaimForResume(t *testing.T) {
 		{
 			name: "returns error when no matching row",
 			setupMock: func(mock pgxmock.PgxPoolIface) {
-				mock.ExpectQuery(`UPDATE sessions\s+SET status = 'running', completed_at = NULL,\s+error = NULL,\s+failure_explanation = NULL,\s+failure_category = NULL,\s+failure_next_steps = NULL,\s+failure_retry_advised = false,\s+last_activity_at = now\(\)\s+WHERE id = @id AND org_id = @org_id AND status = ANY\(@statuses\)\s+AND sandbox_state != 'destroyed'\s+RETURNING`).
+				mock.ExpectQuery(`UPDATE sessions\s+SET status = 'running', completed_at = NULL,\s+last_activity_at = now\(\)\s+WHERE id = @id AND org_id = @org_id AND status = ANY\(@statuses\)\s+AND sandbox_state != 'destroyed'\s+RETURNING`).
 					WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
 					WillReturnRows(pgxmock.NewRows(sessionTestColumns))
 			},
@@ -1261,7 +1261,7 @@ func TestSessionStore_ClaimForResume(t *testing.T) {
 				now := time.Now()
 				row := newAgentSessionRow(uuid.New(), uuid.New(), uuid.New(), now)
 				row[4] = models.SessionStatusRunning
-				mock.ExpectQuery(`UPDATE sessions\s+SET status = 'running', completed_at = NULL,\s+error = NULL,\s+failure_explanation = NULL,\s+failure_category = NULL,\s+failure_next_steps = NULL,\s+failure_retry_advised = false,\s+last_activity_at = now\(\)\s+WHERE id = @id AND org_id = @org_id AND status = ANY\(@statuses\)\s+AND sandbox_state != 'destroyed'\s+RETURNING`).
+				mock.ExpectQuery(`UPDATE sessions\s+SET status = 'running', completed_at = NULL,\s+last_activity_at = now\(\)\s+WHERE id = @id AND org_id = @org_id AND status = ANY\(@statuses\)\s+AND sandbox_state != 'destroyed'\s+RETURNING`).
 					WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
 					WillReturnRows(
 						pgxmock.NewRows(sessionTestColumns).AddRow(row...),
@@ -1275,7 +1275,7 @@ func TestSessionStore_ClaimForResume(t *testing.T) {
 				now := time.Now()
 				row := newAgentSessionRow(uuid.New(), uuid.New(), uuid.New(), now)
 				row[4] = models.SessionStatusRunning
-				mock.ExpectQuery(`UPDATE sessions\s+SET status = 'running', completed_at = NULL,\s+error = NULL,\s+failure_explanation = NULL,\s+failure_category = NULL,\s+failure_next_steps = NULL,\s+failure_retry_advised = false,\s+last_activity_at = now\(\)\s+WHERE id = @id AND org_id = @org_id AND status = ANY\(@statuses\)\s+AND sandbox_state != 'destroyed'\s+RETURNING`).
+				mock.ExpectQuery(`UPDATE sessions\s+SET status = 'running', completed_at = NULL,\s+last_activity_at = now\(\)\s+WHERE id = @id AND org_id = @org_id AND status = ANY\(@statuses\)\s+AND sandbox_state != 'destroyed'\s+RETURNING`).
 					WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
 					WillReturnRows(
 						pgxmock.NewRows(sessionTestColumns).AddRow(row...),

--- a/internal/db/session_store_test.go
+++ b/internal/db/session_store_test.go
@@ -982,6 +982,37 @@ func TestSessionStore_UpdateResult_PersistsModelUsed(t *testing.T) {
 	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
 }
 
+func TestSessionStore_UpdateResultClearsStaleFailureDetails(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "should create mock pool")
+	defer mock.Close()
+
+	store := NewSessionStore(mock)
+	orgID := uuid.New()
+	sessionID := uuid.New()
+	now := time.Now()
+
+	mock.ExpectQuery(`UPDATE sessions[\s\S]+failure_explanation = NULL[\s\S]+failure_category = NULL[\s\S]+failure_next_steps = NULL[\s\S]+failure_retry_advised = false`).
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
+			pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
+			pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
+			pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
+			pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(
+			pgxmock.NewRows(sessionTestColumns).AddRow(
+				newAgentSessionRow(sessionID, uuid.New(), orgID, now)...,
+			),
+		)
+
+	err = store.UpdateResult(context.Background(), orgID, sessionID, models.SessionStatusCompleted, &models.SessionResult{
+		ResultSummary: stringPtr("new successful result"),
+	})
+	require.NoError(t, err, "UpdateResult should clear stale failure details while persisting a new result")
+	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
+}
+
 func TestSessionStore_UpdateStatus_PublishesAndQueriesTerminalCleanup(t *testing.T) {
 	t.Parallel()
 
@@ -1025,7 +1056,7 @@ func TestSessionStore_SettersAndUpdateStatusError(t *testing.T) {
 	store.SetLogger(zerolog.Nop())
 	store.SetStreams(nil)
 
-	mock.ExpectQuery("UPDATE sessions SET status = @status, started_at = now\\(\\), completed_at = NULL, last_activity_at = now\\(\\) WHERE id = @id AND org_id = @org_id AND deleted_at IS NULL RETURNING").
+	mock.ExpectQuery(`UPDATE sessions SET status = @status, started_at = now\(\), completed_at = NULL, error = NULL, failure_explanation = NULL, failure_category = NULL, failure_next_steps = NULL, failure_retry_advised = false, last_activity_at = now\(\) WHERE id = @id AND org_id = @org_id AND deleted_at IS NULL RETURNING`).
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
 		WillReturnError(context.DeadlineExceeded)
 
@@ -1205,7 +1236,7 @@ func TestSessionStore_ClaimForResume(t *testing.T) {
 			name: "resumes completed session successfully",
 			setupMock: func(mock pgxmock.PgxPoolIface) {
 				now := time.Now()
-				mock.ExpectQuery("UPDATE sessions\\s+SET status = 'running', completed_at = NULL, last_activity_at = now\\(\\)\\s+WHERE id = @id AND org_id = @org_id AND status = ANY\\(@statuses\\)\\s+AND sandbox_state != 'destroyed'\\s+RETURNING").
+				mock.ExpectQuery(`UPDATE sessions\s+SET status = 'running', completed_at = NULL,\s+error = NULL,\s+failure_explanation = NULL,\s+failure_category = NULL,\s+failure_next_steps = NULL,\s+failure_retry_advised = false,\s+last_activity_at = now\(\)\s+WHERE id = @id AND org_id = @org_id AND status = ANY\(@statuses\)\s+AND sandbox_state != 'destroyed'\s+RETURNING`).
 					WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
 					WillReturnRows(
 						pgxmock.NewRows(sessionTestColumns).AddRow(
@@ -1218,7 +1249,7 @@ func TestSessionStore_ClaimForResume(t *testing.T) {
 		{
 			name: "returns error when no matching row",
 			setupMock: func(mock pgxmock.PgxPoolIface) {
-				mock.ExpectQuery("UPDATE sessions\\s+SET status = 'running', completed_at = NULL, last_activity_at = now\\(\\)\\s+WHERE id = @id AND org_id = @org_id AND status = ANY\\(@statuses\\)\\s+AND sandbox_state != 'destroyed'\\s+RETURNING").
+				mock.ExpectQuery(`UPDATE sessions\s+SET status = 'running', completed_at = NULL,\s+error = NULL,\s+failure_explanation = NULL,\s+failure_category = NULL,\s+failure_next_steps = NULL,\s+failure_retry_advised = false,\s+last_activity_at = now\(\)\s+WHERE id = @id AND org_id = @org_id AND status = ANY\(@statuses\)\s+AND sandbox_state != 'destroyed'\s+RETURNING`).
 					WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
 					WillReturnRows(pgxmock.NewRows(sessionTestColumns))
 			},
@@ -1230,7 +1261,7 @@ func TestSessionStore_ClaimForResume(t *testing.T) {
 				now := time.Now()
 				row := newAgentSessionRow(uuid.New(), uuid.New(), uuid.New(), now)
 				row[4] = models.SessionStatusRunning
-				mock.ExpectQuery("UPDATE sessions\\s+SET status = 'running', completed_at = NULL, last_activity_at = now\\(\\)\\s+WHERE id = @id AND org_id = @org_id AND status = ANY\\(@statuses\\)\\s+AND sandbox_state != 'destroyed'\\s+RETURNING").
+				mock.ExpectQuery(`UPDATE sessions\s+SET status = 'running', completed_at = NULL,\s+error = NULL,\s+failure_explanation = NULL,\s+failure_category = NULL,\s+failure_next_steps = NULL,\s+failure_retry_advised = false,\s+last_activity_at = now\(\)\s+WHERE id = @id AND org_id = @org_id AND status = ANY\(@statuses\)\s+AND sandbox_state != 'destroyed'\s+RETURNING`).
 					WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
 					WillReturnRows(
 						pgxmock.NewRows(sessionTestColumns).AddRow(row...),
@@ -1244,7 +1275,7 @@ func TestSessionStore_ClaimForResume(t *testing.T) {
 				now := time.Now()
 				row := newAgentSessionRow(uuid.New(), uuid.New(), uuid.New(), now)
 				row[4] = models.SessionStatusRunning
-				mock.ExpectQuery("UPDATE sessions\\s+SET status = 'running', completed_at = NULL, last_activity_at = now\\(\\)\\s+WHERE id = @id AND org_id = @org_id AND status = ANY\\(@statuses\\)\\s+AND sandbox_state != 'destroyed'\\s+RETURNING").
+				mock.ExpectQuery(`UPDATE sessions\s+SET status = 'running', completed_at = NULL,\s+error = NULL,\s+failure_explanation = NULL,\s+failure_category = NULL,\s+failure_next_steps = NULL,\s+failure_retry_advised = false,\s+last_activity_at = now\(\)\s+WHERE id = @id AND org_id = @org_id AND status = ANY\(@statuses\)\s+AND sandbox_state != 'destroyed'\s+RETURNING`).
 					WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
 					WillReturnRows(
 						pgxmock.NewRows(sessionTestColumns).AddRow(row...),
@@ -1584,6 +1615,28 @@ func TestSessionStore_UpdateTurnComplete(t *testing.T) {
 	err = store.UpdateTurnComplete(context.Background(), uuid.New(), uuid.New(), 2, result, "agent-123", "snap-key")
 	require.NoError(t, err)
 	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestSessionStore_UpdateTurnCompleteClearsStaleFailureDetails(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "should create mock pool")
+	defer mock.Close()
+
+	store := NewSessionStore(mock)
+
+	mock.ExpectExec(`UPDATE sessions[\s\S]+SET status = 'idle'[\s\S]+failure_explanation = NULL[\s\S]+failure_category = NULL[\s\S]+failure_next_steps = NULL[\s\S]+failure_retry_advised = false`).
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
+			pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
+			pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
+
+	err = store.UpdateTurnComplete(context.Background(), uuid.New(), uuid.New(), 3, &models.SessionResult{
+		ResultSummary: stringPtr("turn recovered"),
+	}, "agent-456", "snap-key")
+	require.NoError(t, err, "UpdateTurnComplete should clear stale failure details when a turn succeeds")
+	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
 }
 
 func TestSessionStore_ListStaleIdleSessions(t *testing.T) {

--- a/internal/services/claudecodeauth/service.go
+++ b/internal/services/claudecodeauth/service.go
@@ -672,11 +672,12 @@ func (s *Service) RefreshTokenByID(ctx context.Context, scope models.Scope, cred
 		return nil, fmt.Errorf("read refresh response: %w", err)
 	}
 
-	if resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden {
-		if strings.Contains(string(body), "refresh_token_reused") {
-			s.logger.Warn().Str("cred_id", credID.String()).Msg("refresh token already used by another client; access token may still be valid")
-			return nil, fmt.Errorf("refresh token already used by another client")
-		}
+	if isClaudeRefreshTokenReused(body) {
+		s.logger.Warn().Str("cred_id", credID.String()).Msg("refresh token already used by another client; access token may still be valid")
+		return nil, fmt.Errorf("refresh token already used by another client")
+	}
+
+	if resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden || isClaudeInvalidGrant(body) {
 		if err := s.credentials.UpdateStatusByID(ctx, scope, credID, models.CodingCredentialStatusInvalid); err != nil {
 			s.logger.Warn().Err(err).Str("cred_id", credID.String()).Msg("failed to update credential status")
 		}
@@ -727,6 +728,20 @@ func (s *Service) RefreshTokenByID(ctx context.Context, scope models.Scope, cred
 		Msg("Claude Code OAuth token refreshed")
 
 	return newSub, nil
+}
+
+func isClaudeRefreshTokenReused(body []byte) bool {
+	return strings.Contains(string(body), "refresh_token_reused")
+}
+
+func isClaudeInvalidGrant(body []byte) bool {
+	var payload struct {
+		Error string `json:"error"`
+	}
+	if err := json.Unmarshal(body, &payload); err == nil && payload.Error == "invalid_grant" {
+		return true
+	}
+	return strings.Contains(string(body), `"invalid_grant"`)
 }
 
 // maxRoundRobinAttempts caps how many distinct credentials GetValidToken

--- a/internal/services/claudecodeauth/service_test.go
+++ b/internal/services/claudecodeauth/service_test.go
@@ -677,6 +677,30 @@ func TestRefreshTokenByID_UnauthorizedMarksInvalid(t *testing.T) {
 	}
 }
 
+func TestRefreshTokenByID_InvalidGrantBadRequestMarksInvalid(t *testing.T) {
+	t.Parallel()
+	store := newMockCredentialStore()
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"error":"invalid_grant","error_description":"Refresh token not found or invalid"}`))
+	}))
+	defer ts.Close()
+
+	svc := NewService(store, zerolog.Nop())
+	svc.SetTokenURL(ts.URL)
+	svc.SetProfileURL("")
+
+	orgID := uuid.New()
+	credID := seedActiveSub(t, store, orgID, "team-a", "old-access", "old-refresh", time.Now().Add(-time.Minute))
+
+	_, err := svc.RefreshTokenByID(context.Background(), models.Scope{OrgID: orgID}, credID)
+	require.Error(t, err, "RefreshTokenByID should fail when Anthropic rejects the refresh grant")
+	require.Contains(t, err.Error(), "refresh token revoked", "RefreshTokenByID should classify invalid_grant as revoked")
+	require.Equal(t, models.CredentialStatusInvalid, store.creds[credID].Status, "RefreshTokenByID should mark invalid_grant credentials invalid")
+}
+
 func TestRefreshTokenByID_NoRefreshToken(t *testing.T) {
 	t.Parallel()
 	store := newMockCredentialStore()

--- a/internal/worker/handlers_linear_agent_prompted_test.go
+++ b/internal/worker/handlers_linear_agent_prompted_test.go
@@ -646,7 +646,7 @@ func TestPromptedResumedTerminalSessionRestoresOriginalStatusWhenContinueEnqueue
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
 		WillReturnRows(pgxmock.NewRows([]string{"id", "org_id", "status", "current_turn"}).
 			AddRow(sessionID, orgID, models.SessionStatusCompleted, 7))
-	mock.ExpectQuery("(?s)UPDATE sessions\\s+SET status = 'running', completed_at = NULL, last_activity_at = now\\(\\)").
+	mock.ExpectQuery(`(?s)UPDATE sessions\s+SET status = 'running', completed_at = NULL,\s+error = NULL,\s+failure_explanation = NULL,\s+failure_category = NULL,\s+failure_next_steps = NULL,\s+failure_retry_advised = false,\s+last_activity_at = now\(\)`).
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
 		WillReturnRows(pgxmock.NewRows(workerSessionColumns).
 			AddRow(workerSessionRow(sessionID, issueID, orgID, models.SessionStatusRunning, 7, nil, nil)...))

--- a/internal/worker/handlers_linear_agent_prompted_test.go
+++ b/internal/worker/handlers_linear_agent_prompted_test.go
@@ -646,7 +646,7 @@ func TestPromptedResumedTerminalSessionRestoresOriginalStatusWhenContinueEnqueue
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
 		WillReturnRows(pgxmock.NewRows([]string{"id", "org_id", "status", "current_turn"}).
 			AddRow(sessionID, orgID, models.SessionStatusCompleted, 7))
-	mock.ExpectQuery(`(?s)UPDATE sessions\s+SET status = 'running', completed_at = NULL,\s+error = NULL,\s+failure_explanation = NULL,\s+failure_category = NULL,\s+failure_next_steps = NULL,\s+failure_retry_advised = false,\s+last_activity_at = now\(\)`).
+	mock.ExpectQuery(`(?s)UPDATE sessions\s+SET status = 'running', completed_at = NULL,\s+last_activity_at = now\(\)`).
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
 		WillReturnRows(pgxmock.NewRows(workerSessionColumns).
 			AddRow(workerSessionRow(sessionID, issueID, orgID, models.SessionStatusRunning, 7, nil, nil)...))
@@ -665,7 +665,6 @@ func TestPromptedResumedTerminalSessionRestoresOriginalStatusWhenContinueEnqueue
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
 		WillReturnRows(pgxmock.NewRows(workerSessionColumns).
 			AddRow(workerSessionRow(sessionID, issueID, orgID, models.SessionStatusCompleted, 7, nil, nil)...))
-
 	deps := LinearAgentEventHandlerDeps{
 		Stores: &Stores{
 			Sessions:        db.NewSessionStore(mock),


### PR DESCRIPTION
**Summary**
- Stop `ClaimForResume` from clearing `error` and `failure_*` fields so terminal session failures remain visible if a follow-up enqueue fails.
- Clear stale failure details only on the paths that actually transition a session into active work.
- Treat Anthropic `invalid_grant` refresh responses as revoked credentials and mark the Claude subscription invalid immediately.
- Add tests covering the resume-claim behavior and the Claude auth refresh failure case.

**Testing**
- Added and updated unit tests for session resume behavior, handler expectations, and Claude auth refresh handling.
- Local verification passed: `go vet ./...`, `go build ./...`, `make lint-tenancy`, and `go test ./...`.