### PR TITLE
Move preview install marker directory creation after cleanup

### DIFF
--- a/internal/services/preview/providers/docker_preview.go
+++ b/internal/services/preview/providers/docker_preview.go
@@ -1098,7 +1098,6 @@ func (d *DockerPreviewProvider) previewInstallPathExists(ctx context.Context, sb
 
 func buildPreviewInstallCommand(install *models.PreviewInstallConfig, markerPath string) (string, error) {
 	var parts []string
-	parts = append(parts, "mkdir -p .143/cache/preview-install")
 	if len(install.CleanPaths) > 0 {
 		cleanArgs := make([]string, 0, len(install.CleanPaths))
 		for _, cleanPath := range install.CleanPaths {
@@ -1110,6 +1109,7 @@ func buildPreviewInstallCommand(install *models.PreviewInstallConfig, markerPath
 		}
 		parts = append(parts, "rm -rf -- "+strings.Join(cleanArgs, " "))
 	}
+	parts = append(parts, "mkdir -p .143/cache/preview-install")
 
 	escapedCmd := make([]string, 0, len(install.Command))
 	for _, arg := range install.Command {

--- a/internal/services/preview/providers/docker_preview_test.go
+++ b/internal/services/preview/providers/docker_preview_test.go
@@ -1271,6 +1271,26 @@ func TestStartPreview_PreviewInstallFailureStopsBeforeServices(t *testing.T) {
 	}, failures[0].tail, "observer should receive the install output tail")
 }
 
+func TestBuildPreviewInstallCommand_RecreatesMarkerDirAfterCleanup(t *testing.T) {
+	t.Parallel()
+
+	cmd, err := buildPreviewInstallCommand(&models.PreviewInstallConfig{
+		Command:    []string{"bash", ".143/preview-install.sh"},
+		CleanPaths: []string{".143/cache", "node_modules"},
+	}, ".143/cache/preview-install/cache-key.done")
+	require.NoError(t, err, "buildPreviewInstallCommand should accept repo-local clean paths")
+
+	cleanIndex := strings.Index(cmd, "rm -rf -- .143/cache node_modules")
+	mkdirAfterCleanIndex := strings.LastIndex(cmd, "mkdir -p .143/cache/preview-install")
+	markerIndex := strings.Index(cmd, "printf 'ok\\n' > ")
+	require.NotEqual(t, -1, cleanIndex, "install command should clean declared paths")
+	require.NotEqual(t, -1, mkdirAfterCleanIndex, "install command should create the marker directory")
+	require.NotEqual(t, -1, markerIndex, "install command should write the success marker")
+	require.Contains(t, cmd, ".143/cache/preview-install/cache-key.done", "install command should write the expected marker path")
+	require.Greater(t, mkdirAfterCleanIndex, cleanIndex, "install command should recreate the marker directory after cleanup")
+	require.Less(t, mkdirAfterCleanIndex, markerIndex, "install command should recreate the marker directory before writing the marker")
+}
+
 func previewInstallTestConfig() *models.PreviewConfig {
 	return &models.PreviewConfig{
 		Name:    "test-app",


### PR DESCRIPTION
## Summary
- Reorder the generated `preview.install` shell command so repo-declared cleanup runs before recreating `.143/cache/preview-install`.
- Add a regression test that covers configs which clean `.143/cache`, preventing the platform-owned install marker from being deleted before it is written.

## Testing
- Added a focused unit test for the preview install command builder.
- Existing preview provider tests continue to cover install success, cache hits, and failure handling.
- Not run (not requested)