### PR TITLE
[codex] Avoid usage summary peak self-join

### DIFF
--- a/docs/design/implemented/46-billing-usage-dashboard.md
+++ b/docs/design/implemented/46-billing-usage-dashboard.md
@@ -11,7 +11,7 @@ PR #244 added `container_usage_events` persistence and a summary endpoint (`GET 
 - **Time-series data** — hourly buckets that the frontend aggregates into days using the viewer's timezone
 - **Dimensional breakdowns** — by user, capacity tier, exit reason
 - **LLM token tracking** — already captured per-session and per-message, but not aggregated for dashboard display
-- **Fast queries** — the raw events table with self-joins won't scale past ~50K events; a materialized rollup avoids O(n²) peak-concurrent scans on every page load
+- **Fast queries** — repeated raw-event aggregation won't scale past ~50K events; a materialized rollup avoids rescanning event intervals on every page load
 - **Export** — CSV download for external billing systems and finance workflows
 
 ## Data Layer
@@ -59,7 +59,7 @@ CREATE INDEX idx_usage_hourly_org_user_hour
 ```
 
 **Why a rollup table instead of live aggregation:**
-- The existing `GetUsageSummary` peak-concurrent query is O(n²) via self-join — unusable for dashboards that need per-day data for 30-90 days
+- The original `GetUsageSummary` peak-concurrent query was O(n²) via self-join; the legacy path now uses an interval sweep, but rollups are still the right shape for dashboard-scale per-day and per-breakdown reads
 - A rollup makes all dashboard queries O(hours) regardless of event count
 - The rollup job is idempotent: `INSERT ... ON CONFLICT DO UPDATE`, safe to re-run
 
@@ -471,7 +471,7 @@ queryKeys.usage = {
 
 ### Why not query raw events directly?
 
-The peak concurrent calculation in `GetUsageSummary` uses a self-join that is O(n²). For an org with 10K events/month, running this per-day for 30 days would mean 30 × O(10K²/30²) ≈ 30 × O(111K) comparisons. The rollup pre-computes this once.
+The legacy `GetUsageSummary` path now avoids the original O(n²) peak-concurrent self-join by fetching only event intervals that overlap the requested range and computing the peak with a Go sweep-line pass. Dashboard queries still read rollups so repeated per-day and per-breakdown views do not rescan raw events on every page load.
 
 ### Rollup staleness
 

--- a/internal/api/handlers/usage_test.go
+++ b/internal/api/handlers/usage_test.go
@@ -172,10 +172,13 @@ func TestUsageHandler_GetSummary(t *testing.T) {
 		WillReturnRows(pgxmock.NewRows([]string{"cpu_limit", "memory_limit_mb", "disk_limit_mb", "minutes", "sessions"}).
 			AddRow(2.0, 4096, 10240, 42.5, 5))
 
-	// Peak concurrent
-	mock.ExpectQuery("SELECT COALESCE\\(MAX\\(concurrent\\)").
+	// Peak concurrent intervals
+	mock.ExpectQuery("SELECT started_at, COALESCE\\(stopped_at, now\\(\\)\\) AS stopped_at").
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
-		WillReturnRows(pgxmock.NewRows([]string{"peak"}).AddRow(2))
+		WillReturnRows(pgxmock.NewRows([]string{"started_at", "stopped_at"}).
+			AddRow(time.Date(2026, 4, 1, 1, 0, 0, 0, time.UTC), time.Date(2026, 4, 1, 4, 0, 0, 0, time.UTC)).
+			AddRow(time.Date(2026, 4, 1, 2, 0, 0, 0, time.UTC), time.Date(2026, 4, 1, 5, 0, 0, 0, time.UTC)).
+			AddRow(time.Date(2026, 4, 1, 3, 0, 0, 0, time.UTC), time.Date(2026, 4, 1, 6, 0, 0, 0, time.UTC)))
 
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/usage?start=2026-04-01T00:00:00Z&end=2026-05-01T00:00:00Z", nil)
 	ctx := middleware.WithOrgID(req.Context(), orgID)
@@ -184,15 +187,21 @@ func TestUsageHandler_GetSummary(t *testing.T) {
 
 	handler.GetSummary(rr, req)
 
-	require.Equal(t, http.StatusOK, rr.Code)
+	require.Equal(t, http.StatusOK, rr.Code, "GetSummary should return OK for a valid usage request")
 
 	var resp models.SingleResponse[models.UsageSummary]
 	err = json.NewDecoder(rr.Body).Decode(&resp)
-	require.NoError(t, err)
-	require.Equal(t, 42.5, resp.Data.TotalContainerMinutes)
-	require.Equal(t, 5, resp.Data.TotalSessions)
-	require.Equal(t, 3, resp.Data.PeakConcurrent) // 2 peers + 1
-	require.NoError(t, mock.ExpectationsWereMet())
+	require.NoError(t, err, "GetSummary response should decode as a single usage summary")
+	require.Equal(t, 42.5, resp.Data.TotalContainerMinutes, "GetSummary should preserve total container minutes")
+	require.Equal(t, 5, resp.Data.TotalSessions, "GetSummary should preserve total session count")
+	require.Equal(t, 3, resp.Data.PeakConcurrent, "GetSummary should preserve peak concurrent value")
+	require.Len(t, resp.Data.ByCapacity, 1, "GetSummary should preserve capacity buckets")
+	require.Equal(t, 2.0, resp.Data.ByCapacity[0].CPULimit, "GetSummary should preserve capacity CPU limit")
+	require.Equal(t, 4096, resp.Data.ByCapacity[0].MemoryLimitMB, "GetSummary should preserve capacity memory")
+	require.Equal(t, 10240, resp.Data.ByCapacity[0].DiskLimitMB, "GetSummary should preserve capacity disk")
+	require.Equal(t, 42.5, resp.Data.ByCapacity[0].ContainerMinutes, "GetSummary should preserve capacity minutes")
+	require.Equal(t, 5, resp.Data.ByCapacity[0].SessionCount, "GetSummary should preserve capacity sessions")
+	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
 }
 
 func TestUsageHandler_ListBySession(t *testing.T) {

--- a/internal/db/container_usage_store.go
+++ b/internal/db/container_usage_store.go
@@ -119,35 +119,34 @@ func (s *ContainerUsageStore) GetUsageSummary(ctx context.Context, orgID uuid.UU
 		return nil, fmt.Errorf("iterate capacity buckets: %w", err)
 	}
 
-	// Peak concurrent containers (sampled by overlapping time ranges).
-	// NOTE: This self-join is O(n^2) in the number of events per org per period.
-	// Acceptable for <10K events/period; replace with a rollup table at higher scale.
-	var peakConcurrent int
-	err = s.db.QueryRow(ctx, `
-		SELECT COALESCE(MAX(concurrent), 0)
-		FROM (
-			SELECT COUNT(*) AS concurrent
-			FROM container_usage_events e1
-			JOIN container_usage_events e2
-			  ON e2.org_id = e1.org_id
-			 AND e2.started_at <= COALESCE(e1.stopped_at, now())
-			 AND COALESCE(e2.stopped_at, now()) >= e1.started_at
-			 AND e2.started_at < @end
-			 AND e2.id != e1.id
-			WHERE e1.org_id = @org_id AND e1.started_at >= @start AND e1.started_at < @end
-			GROUP BY e1.id
-		) sub`,
+	// Peak concurrent containers. Fetch only intervals that overlap the period,
+	// then compute the peak with a sweep-line pass instead of an O(n^2) self-join.
+	peakRows, err := s.db.Query(ctx, `
+		SELECT started_at, COALESCE(stopped_at, now()) AS stopped_at
+		FROM container_usage_events
+		WHERE org_id = @org_id
+		  AND COALESCE(stopped_at, now()) >= @start
+		  AND started_at < @end
+		ORDER BY started_at, stopped_at`,
 		pgx.NamedArgs{"org_id": orgID, "start": start, "end": end},
-	).Scan(&peakConcurrent)
+	)
 	if err != nil {
-		return nil, fmt.Errorf("query peak concurrent: %w", err)
+		return nil, fmt.Errorf("query peak intervals: %w", err)
 	}
-	// The self-join counts overlapping peers; add 1 for the container itself.
-	// Use totalSessions > 0 (not peakConcurrent > 0) so that a single
-	// non-overlapping container correctly reports peak = 1.
-	if totalSessions > 0 {
-		peakConcurrent++
+	defer peakRows.Close()
+
+	intervals := make([]timeInterval, 0)
+	for peakRows.Next() {
+		var startedAt, stoppedAt time.Time
+		if err := peakRows.Scan(&startedAt, &stoppedAt); err != nil {
+			return nil, fmt.Errorf("scan peak interval: %w", err)
+		}
+		intervals = append(intervals, timeInterval{start: startedAt, stop: stoppedAt})
 	}
+	if err := peakRows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate peak intervals: %w", err)
+	}
+	peakConcurrent := computePeakConcurrent(intervals)
 
 	return &models.UsageSummary{
 		OrgID:                 orgID,

--- a/internal/db/container_usage_store_test.go
+++ b/internal/db/container_usage_store_test.go
@@ -97,22 +97,84 @@ func TestContainerUsageStore_GetUsageSummary(t *testing.T) {
 				AddRow(4.0, 8192, 20480, 25.5, 2),
 		)
 
-	// Peak concurrent query — args ordered by first appearance in SQL:
-	// @end (e2 filter in JOIN), @org_id (WHERE), @start (WHERE).
-	mock.ExpectQuery("SELECT COALESCE\\(MAX\\(concurrent\\)").
-		WithArgs(end, orgID, start).
-		WillReturnRows(pgxmock.NewRows([]string{"peak"}).AddRow(3))
+	// Peak concurrent intervals. This expectation intentionally matches the
+	// bounded interval fetch, not the old self-join aggregate.
+	mock.ExpectQuery("SELECT started_at, COALESCE\\(stopped_at, now\\(\\)\\) AS stopped_at").
+		WithArgs(orgID, start, end).
+		WillReturnRows(pgxmock.NewRows([]string{"started_at", "stopped_at"}).
+			AddRow(start.Add(1*time.Hour), start.Add(3*time.Hour)).
+			AddRow(start.Add(2*time.Hour), start.Add(4*time.Hour)).
+			AddRow(start.Add(2*time.Hour), start.Add(5*time.Hour)).
+			AddRow(start.Add(3*time.Hour), start.Add(6*time.Hour)))
 
 	summary, err := store.GetUsageSummary(context.Background(), orgID, start, end)
-	require.NoError(t, err)
-	require.Equal(t, 125.5, summary.TotalContainerMinutes)
-	require.Equal(t, 10, summary.TotalSessions)
-	require.Equal(t, 4, summary.PeakConcurrent) // 3 peers + 1 self
-	require.Len(t, summary.ByCapacity, 2)
-	require.Equal(t, 2.0, summary.ByCapacity[0].CPULimit)
-	require.Equal(t, 4096, summary.ByCapacity[0].MemoryLimitMB)
-	require.Equal(t, 10240, summary.ByCapacity[0].DiskLimitMB)
-	require.NoError(t, mock.ExpectationsWereMet())
+	require.NoError(t, err, "GetUsageSummary should not return an error")
+	require.Equal(t, 125.5, summary.TotalContainerMinutes, "GetUsageSummary should preserve total minutes")
+	require.Equal(t, 10, summary.TotalSessions, "GetUsageSummary should preserve total session count")
+	require.Equal(t, 4, summary.PeakConcurrent, "GetUsageSummary should compute peak concurrency from fetched intervals")
+	require.Len(t, summary.ByCapacity, 2, "GetUsageSummary should return all capacity buckets")
+	require.Equal(t, 2.0, summary.ByCapacity[0].CPULimit, "GetUsageSummary should preserve capacity CPU limit")
+	require.Equal(t, 4096, summary.ByCapacity[0].MemoryLimitMB, "GetUsageSummary should preserve capacity memory")
+	require.Equal(t, 10240, summary.ByCapacity[0].DiskLimitMB, "GetUsageSummary should preserve capacity disk")
+	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
+}
+
+func TestContainerUsageStore_GetUsageSummaryPeakConcurrent(t *testing.T) {
+	t.Parallel()
+
+	base := time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC)
+	tests := []struct {
+		name      string
+		intervals []timeInterval
+		expected  int
+	}{
+		{
+			name:      "empty",
+			intervals: nil,
+			expected:  0,
+		},
+		{
+			name: "single",
+			intervals: []timeInterval{
+				{start: base, stop: base.Add(10 * time.Minute)},
+			},
+			expected: 1,
+		},
+		{
+			name: "non-overlapping",
+			intervals: []timeInterval{
+				{start: base, stop: base.Add(10 * time.Minute)},
+				{start: base.Add(20 * time.Minute), stop: base.Add(30 * time.Minute)},
+			},
+			expected: 1,
+		},
+		{
+			name: "partially overlapping",
+			intervals: []timeInterval{
+				{start: base, stop: base.Add(30 * time.Minute)},
+				{start: base.Add(10 * time.Minute), stop: base.Add(40 * time.Minute)},
+				{start: base.Add(35 * time.Minute), stop: base.Add(50 * time.Minute)},
+			},
+			expected: 2,
+		},
+		{
+			name: "same-boundary intervals count as concurrent",
+			intervals: []timeInterval{
+				{start: base, stop: base.Add(10 * time.Minute)},
+				{start: base.Add(10 * time.Minute), stop: base.Add(20 * time.Minute)},
+			},
+			expected: 2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			actual := computePeakConcurrent(tt.intervals)
+			require.Equal(t, tt.expected, actual, "peak concurrency should match overlapping interval semantics")
+		})
+	}
 }
 
 func TestContainerUsageStore_ListBySession(t *testing.T) {


### PR DESCRIPTION
## Summary
- Replace the legacy `GetUsageSummary` peak-concurrency self-join with a bounded interval fetch plus the existing Go sweep-line peak calculation.
- Update usage summary and handler tests to expect the interval query and preserve the public response shape/values.
- Update the billing usage dashboard design note so it no longer describes the legacy summary path as self-join-backed.

## Why
The old peak query joined `container_usage_events` to itself, making the legacy summary path O(n²) in the number of period events. The new query only reads intervals overlapping the requested org/time range and computes the max overlap in Go.

## Verification
- Wrote the query/peak tests first and confirmed they failed against the old self-join.
- `go test ./internal/db -run 'TestContainerUsageStore_GetUsageSummary|Test.*Peak'` passed.
- `go test ./internal/api/handlers -run TestUsageHandler_GetSummary` passed.
- `go vet ./...` passed.
- `go build ./...` passed.
- `go test ./...` failed in unrelated `internal/db/session_store_test.go` tests:
  - `TestSessionStore_UpdateTurnCompleteClearsStaleFailureDetails`: expected 16 mock args, got 13.
  - `TestSessionStore_UpdateResultClearsStaleFailureDetails`: expected 14 mock args, got 11.