### PR TITLE
[codex] Avoid usage summary self-join

### DIFF
--- a/internal/api/handlers/usage_test.go
+++ b/internal/api/handlers/usage_test.go
@@ -172,10 +172,16 @@ func TestUsageHandler_GetSummary(t *testing.T) {
 		WillReturnRows(pgxmock.NewRows([]string{"cpu_limit", "memory_limit_mb", "disk_limit_mb", "minutes", "sessions"}).
 			AddRow(2.0, 4096, 10240, 42.5, 5))
 
-	// Peak concurrent
-	mock.ExpectQuery("SELECT COALESCE\\(MAX\\(concurrent\\)").
+	// Peak concurrent interval scan. If the legacy self-join runs instead, this
+	// expectation will fail and protect the GET /api/v1/usage path.
+	mock.ExpectQuery("SELECT started_at, COALESCE\\(stopped_at, now\\(\\)\\) AS stopped_at").
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
-		WillReturnRows(pgxmock.NewRows([]string{"peak"}).AddRow(2))
+		WillReturnRows(
+			pgxmock.NewRows([]string{"started_at", "stopped_at"}).
+				AddRow(time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC), time.Date(2026, 4, 1, 0, 30, 0, 0, time.UTC)).
+				AddRow(time.Date(2026, 4, 1, 0, 15, 0, 0, time.UTC), time.Date(2026, 4, 1, 0, 45, 0, 0, time.UTC)).
+				AddRow(time.Date(2026, 4, 1, 0, 45, 0, 0, time.UTC), time.Date(2026, 4, 1, 1, 0, 0, 0, time.UTC)),
+		)
 
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/usage?start=2026-04-01T00:00:00Z&end=2026-05-01T00:00:00Z", nil)
 	ctx := middleware.WithOrgID(req.Context(), orgID)
@@ -184,15 +190,29 @@ func TestUsageHandler_GetSummary(t *testing.T) {
 
 	handler.GetSummary(rr, req)
 
-	require.Equal(t, http.StatusOK, rr.Code)
+	require.Equal(t, http.StatusOK, rr.Code, "GetSummary should return OK for a valid usage range")
 
 	var resp models.SingleResponse[models.UsageSummary]
 	err = json.NewDecoder(rr.Body).Decode(&resp)
-	require.NoError(t, err)
-	require.Equal(t, 42.5, resp.Data.TotalContainerMinutes)
-	require.Equal(t, 5, resp.Data.TotalSessions)
-	require.Equal(t, 3, resp.Data.PeakConcurrent) // 2 peers + 1
-	require.NoError(t, mock.ExpectationsWereMet())
+	require.NoError(t, err, "response body should be valid JSON")
+	require.Equal(t, models.UsageSummary{
+		OrgID:                 orgID,
+		PeriodStart:           time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC),
+		PeriodEnd:             time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC),
+		TotalContainerMinutes: 42.5,
+		TotalSessions:         5,
+		PeakConcurrent:        2,
+		ByCapacity: []models.CapacityBucket{
+			{
+				CPULimit:         2.0,
+				MemoryLimitMB:    4096,
+				DiskLimitMB:      10240,
+				ContainerMinutes: 42.5,
+				SessionCount:     5,
+			},
+		},
+	}, resp.Data, "response should preserve the usage summary shape and values")
+	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
 }
 
 func TestUsageHandler_ListBySession(t *testing.T) {

--- a/internal/db/container_usage_store.go
+++ b/internal/db/container_usage_store.go
@@ -119,35 +119,34 @@ func (s *ContainerUsageStore) GetUsageSummary(ctx context.Context, orgID uuid.UU
 		return nil, fmt.Errorf("iterate capacity buckets: %w", err)
 	}
 
-	// Peak concurrent containers (sampled by overlapping time ranges).
-	// NOTE: This self-join is O(n^2) in the number of events per org per period.
-	// Acceptable for <10K events/period; replace with a rollup table at higher scale.
-	var peakConcurrent int
-	err = s.db.QueryRow(ctx, `
-		SELECT COALESCE(MAX(concurrent), 0)
-		FROM (
-			SELECT COUNT(*) AS concurrent
-			FROM container_usage_events e1
-			JOIN container_usage_events e2
-			  ON e2.org_id = e1.org_id
-			 AND e2.started_at <= COALESCE(e1.stopped_at, now())
-			 AND COALESCE(e2.stopped_at, now()) >= e1.started_at
-			 AND e2.started_at < @end
-			 AND e2.id != e1.id
-			WHERE e1.org_id = @org_id AND e1.started_at >= @start AND e1.started_at < @end
-			GROUP BY e1.id
-		) sub`,
+	// Peak concurrent containers from bounded event intervals. This avoids the
+	// legacy O(n^2) self-join while preserving inclusive boundary semantics.
+	intervalRows, err := s.db.Query(ctx, `
+		SELECT started_at, COALESCE(stopped_at, now()) AS stopped_at
+		FROM container_usage_events
+		WHERE org_id = @org_id
+		  AND started_at < @end
+		  AND COALESCE(stopped_at, now()) >= @start
+		ORDER BY started_at`,
 		pgx.NamedArgs{"org_id": orgID, "start": start, "end": end},
-	).Scan(&peakConcurrent)
+	)
 	if err != nil {
-		return nil, fmt.Errorf("query peak concurrent: %w", err)
+		return nil, fmt.Errorf("query peak concurrent intervals: %w", err)
 	}
-	// The self-join counts overlapping peers; add 1 for the container itself.
-	// Use totalSessions > 0 (not peakConcurrent > 0) so that a single
-	// non-overlapping container correctly reports peak = 1.
-	if totalSessions > 0 {
-		peakConcurrent++
+	defer intervalRows.Close()
+
+	intervals := make([]timeInterval, 0)
+	for intervalRows.Next() {
+		var interval timeInterval
+		if err := intervalRows.Scan(&interval.start, &interval.stop); err != nil {
+			return nil, fmt.Errorf("scan peak concurrent interval: %w", err)
+		}
+		intervals = append(intervals, interval)
 	}
+	if err := intervalRows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate peak concurrent intervals: %w", err)
+	}
+	peakConcurrent := computePeakConcurrent(intervals)
 
 	return &models.UsageSummary{
 		OrgID:                 orgID,

--- a/internal/db/container_usage_store_test.go
+++ b/internal/db/container_usage_store_test.go
@@ -97,22 +97,116 @@ func TestContainerUsageStore_GetUsageSummary(t *testing.T) {
 				AddRow(4.0, 8192, 20480, 25.5, 2),
 		)
 
-	// Peak concurrent query — args ordered by first appearance in SQL:
-	// @end (e2 filter in JOIN), @org_id (WHERE), @start (WHERE).
-	mock.ExpectQuery("SELECT COALESCE\\(MAX\\(concurrent\\)").
-		WithArgs(end, orgID, start).
-		WillReturnRows(pgxmock.NewRows([]string{"peak"}).AddRow(3))
+	// Peak concurrent query scans bounded intervals for the org/range. If the
+	// legacy self-join runs instead, this expectation will fail.
+	mock.ExpectQuery("SELECT started_at, COALESCE\\(stopped_at, now\\(\\)\\) AS stopped_at").
+		WithArgs(orgID, end, start).
+		WillReturnRows(
+			pgxmock.NewRows([]string{"started_at", "stopped_at"}).
+				AddRow(start.Add(0*time.Minute), start.Add(10*time.Minute)).
+				AddRow(start.Add(5*time.Minute), start.Add(15*time.Minute)).
+				AddRow(start.Add(7*time.Minute), start.Add(20*time.Minute)).
+				AddRow(start.Add(30*time.Minute), start.Add(40*time.Minute)),
+		)
 
 	summary, err := store.GetUsageSummary(context.Background(), orgID, start, end)
-	require.NoError(t, err)
-	require.Equal(t, 125.5, summary.TotalContainerMinutes)
-	require.Equal(t, 10, summary.TotalSessions)
-	require.Equal(t, 4, summary.PeakConcurrent) // 3 peers + 1 self
-	require.Len(t, summary.ByCapacity, 2)
-	require.Equal(t, 2.0, summary.ByCapacity[0].CPULimit)
-	require.Equal(t, 4096, summary.ByCapacity[0].MemoryLimitMB)
-	require.Equal(t, 10240, summary.ByCapacity[0].DiskLimitMB)
-	require.NoError(t, mock.ExpectationsWereMet())
+	require.NoError(t, err, "GetUsageSummary should return the aggregate usage summary")
+	require.Equal(t, 125.5, summary.TotalContainerMinutes, "summary should preserve total container minutes")
+	require.Equal(t, 10, summary.TotalSessions, "summary should preserve total sessions")
+	require.Equal(t, 3, summary.PeakConcurrent, "summary should compute peak concurrency from scanned intervals")
+	require.Len(t, summary.ByCapacity, 2, "summary should include capacity buckets")
+	require.Equal(t, 2.0, summary.ByCapacity[0].CPULimit, "summary should preserve capacity bucket CPU")
+	require.Equal(t, 4096, summary.ByCapacity[0].MemoryLimitMB, "summary should preserve capacity bucket memory")
+	require.Equal(t, 10240, summary.ByCapacity[0].DiskLimitMB, "summary should preserve capacity bucket disk")
+	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
+}
+
+func TestContainerUsageStore_GetUsageSummary_EmptyPeakIntervals(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "should create mock pool")
+	defer mock.Close()
+
+	store := NewContainerUsageStore(mock)
+	orgID := uuid.New()
+	start := time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC)
+	end := start.Add(24 * time.Hour)
+
+	mock.ExpectQuery("SELECT COALESCE\\(SUM").
+		WithArgs(orgID, start, end).
+		WillReturnRows(pgxmock.NewRows([]string{"total_minutes", "total_sessions"}).AddRow(0.0, 0))
+	mock.ExpectQuery("SELECT cpu_limit, memory_limit_mb, disk_limit_mb").
+		WithArgs(orgID, start, end).
+		WillReturnRows(pgxmock.NewRows([]string{"cpu_limit", "memory_limit_mb", "disk_limit_mb", "minutes", "sessions"}))
+	mock.ExpectQuery("SELECT started_at, COALESCE\\(stopped_at, now\\(\\)\\) AS stopped_at").
+		WithArgs(orgID, end, start).
+		WillReturnRows(pgxmock.NewRows([]string{"started_at", "stopped_at"}))
+
+	summary, err := store.GetUsageSummary(context.Background(), orgID, start, end)
+	require.NoError(t, err, "GetUsageSummary should allow an empty usage range")
+	require.Equal(t, 0, summary.PeakConcurrent, "empty interval scans should report zero peak concurrency")
+	require.Empty(t, summary.ByCapacity, "empty usage range should return no capacity buckets")
+	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
+}
+
+func TestComputePeakConcurrent(t *testing.T) {
+	t.Parallel()
+
+	base := time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC)
+	tests := []struct {
+		name      string
+		intervals []timeInterval
+		expected  int
+	}{
+		{
+			name:      "empty intervals",
+			intervals: nil,
+			expected:  0,
+		},
+		{
+			name: "single interval",
+			intervals: []timeInterval{
+				{start: base, stop: base.Add(10 * time.Minute)},
+			},
+			expected: 1,
+		},
+		{
+			name: "non-overlapping intervals",
+			intervals: []timeInterval{
+				{start: base, stop: base.Add(10 * time.Minute)},
+				{start: base.Add(20 * time.Minute), stop: base.Add(30 * time.Minute)},
+				{start: base.Add(40 * time.Minute), stop: base.Add(50 * time.Minute)},
+			},
+			expected: 1,
+		},
+		{
+			name: "partially overlapping intervals",
+			intervals: []timeInterval{
+				{start: base, stop: base.Add(20 * time.Minute)},
+				{start: base.Add(5 * time.Minute), stop: base.Add(15 * time.Minute)},
+				{start: base.Add(10 * time.Minute), stop: base.Add(30 * time.Minute)},
+			},
+			expected: 3,
+		},
+		{
+			name: "same-boundary intervals count as overlapping",
+			intervals: []timeInterval{
+				{start: base, stop: base.Add(10 * time.Minute)},
+				{start: base.Add(10 * time.Minute), stop: base.Add(20 * time.Minute)},
+			},
+			expected: 2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			actual := computePeakConcurrent(tt.intervals)
+			require.Equal(t, tt.expected, actual, "computePeakConcurrent should return the expected interval overlap peak")
+		})
+	}
 }
 
 func TestContainerUsageStore_ListBySession(t *testing.T) {


### PR DESCRIPTION
## Summary

- Replace the legacy `GetUsageSummary` peak-concurrency self-join with a bounded interval scan plus the existing Go sweep-line peak helper.
- Add DB tests that fail if the self-join query is executed and cover empty, single, non-overlapping, partially overlapping, and same-boundary peak intervals.
- Keep `GET /api/v1/usage` response shape and values covered by the handler test.

## Why

The old peak-concurrency query joined `container_usage_events` to itself, making the legacy usage summary path O(n^2) over event volume. Fetching relevant intervals and computing the max overlap in Go keeps the database query bounded and shifts peak calculation to O(n log n) sorting.

## Validation

- `go test ./internal/db -run 'TestContainerUsageStore_GetUsageSummary|Test.*Peak'`
- `go test ./internal/api/handlers -run TestUsageHandler_GetSummary`
- `go vet ./...`
- `go build ./...`
- `go test ./...`