### PR TITLE
Fix docs layout overflow and footer leakage

### DIFF
--- a/frontend/src/app/(landing)/docs/[[...slug]]/page.test.tsx
+++ b/frontend/src/app/(landing)/docs/[[...slug]]/page.test.tsx
@@ -1,0 +1,14 @@
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const currentDir = path.dirname(fileURLToPath(import.meta.url));
+
+describe("PublicDocsPage", () => {
+  it("disables the generated previous-next footer", () => {
+    const source = fs.readFileSync(path.join(currentDir, "page.tsx"), "utf8");
+
+    expect(source).toContain("footer={{ enabled: false }}");
+  });
+});

--- a/frontend/src/app/(landing)/docs/[[...slug]]/page.tsx
+++ b/frontend/src/app/(landing)/docs/[[...slug]]/page.tsx
@@ -50,7 +50,7 @@ export default async function PublicDocsPage({ params }: DocsPageProps) {
   const MdxContent = page.data.body;
 
   return (
-    <DocsPage toc={page.data.toc} tableOfContent={{ single: false }}>
+    <DocsPage toc={page.data.toc} tableOfContent={{ single: false }} footer={{ enabled: false }}>
       <DocsTitle>{page.data.title}</DocsTitle>
       <DocsDescription>{page.data.description}</DocsDescription>
       <DocsBody>

--- a/frontend/src/app/(landing)/docs/layout.test.tsx
+++ b/frontend/src/app/(landing)/docs/layout.test.tsx
@@ -1,0 +1,15 @@
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const currentDir = path.dirname(fileURLToPath(import.meta.url));
+
+describe("PublicDocsLayout", () => {
+  it("disables generated top tabs so they cannot cover the docs body", () => {
+    const source = fs.readFileSync(path.join(currentDir, "layout.tsx"), "utf8");
+
+    expect(source).toContain("tabs={false}");
+    expect(source).not.toContain('tabMode="top"');
+  });
+});

--- a/frontend/src/app/(landing)/docs/layout.tsx
+++ b/frontend/src/app/(landing)/docs/layout.tsx
@@ -10,7 +10,7 @@ export default function PublicDocsLayout({ children }: { children: ReactNode }) 
       <DocsLayout
         {...docsLayoutOptions()}
         tree={source.getPageTree()}
-        tabMode="top"
+        tabs={false}
         sidebar={{
           defaultOpenLevel: 1,
           prefetch: false,

--- a/frontend/src/components/docs/docs-theme-switch.tsx
+++ b/frontend/src/components/docs/docs-theme-switch.tsx
@@ -1,0 +1,14 @@
+"use client";
+
+import { ThemeSwitch, type ThemeSwitchProps } from "fumadocs-ui/layouts/shared/slots/theme-switch";
+
+export function DocsThemeSwitch({ className: _className, ...props }: ThemeSwitchProps) {
+  void _className;
+
+  return (
+    <ThemeSwitch
+      {...props}
+      className="h-8 rounded-lg border border-border bg-background p-0.5 shadow-sm *:rounded-md"
+    />
+  );
+}

--- a/frontend/src/lib/docs/layout.test.tsx
+++ b/frontend/src/lib/docs/layout.test.tsx
@@ -19,4 +19,10 @@ describe("docsLayoutOptions", () => {
       sectionLinks.every((link) => "on" in link && link.on === "nav")
     ).toBe(true);
   });
+
+  it("uses a docs-owned theme switch instead of the Fumadocs sidebar default", () => {
+    const slots = docsLayoutOptions().slots ?? {};
+
+    expect(slots.themeSwitch).toBeDefined();
+  });
 });

--- a/frontend/src/lib/docs/layout.tsx
+++ b/frontend/src/lib/docs/layout.tsx
@@ -1,5 +1,6 @@
 import type { BaseLayoutProps } from "fumadocs-ui/layouts/shared";
 import { BookOpen, Github } from "lucide-react";
+import { DocsThemeSwitch } from "@/components/docs/docs-theme-switch";
 
 export function docsLayoutOptions(): BaseLayoutProps {
   return {
@@ -49,6 +50,9 @@ export function docsLayoutOptions(): BaseLayoutProps {
         icon: <Github className="size-4" aria-hidden="true" />,
       },
     ],
+    slots: {
+      themeSwitch: DocsThemeSwitch,
+    },
     themeSwitch: {
       enabled: true,
     },


### PR DESCRIPTION
## Summary
- Disable Fumadocs-generated top tabs in the docs shell so the article content is no longer covered.
- Remove the built-in previous/next footer from public docs pages.
- Replace the sidebar theme switch with a docs-owned wrapper to give the toggle a clean full-width border.
- Add focused regression tests for the docs layout and page shell behavior.

## Testing
- Added unit coverage for the docs layout and page config changes.
- Verified the frontend typecheck and lint pass.
- Verified the production frontend build completes successfully.
- Checked the docs page locally to confirm the article body renders and the stray footer is gone.