### PR TITLE
Keep Fumadocs main navigation visible inside section pages

### DIFF
--- a/docs/design/future/85-public-docs-fumadocs/product-design.md
+++ b/docs/design/future/85-public-docs-fumadocs/product-design.md
@@ -54,6 +54,8 @@ Top-level docs groups:
 
 The sidebar should show only public docs pages. Internal design docs should never appear in this tree.
 
+The sidebar should keep the top-level docs groups visible while browsing inside a group. Section folders should stay in a single Fumadocs tree instead of using separate root navigation scopes.
+
 The docs home page should be a functional index, not a marketing page. It should show:
 
 - A short description of what the docs cover.

--- a/docs/public/getting-started/meta.json
+++ b/docs/public/getting-started/meta.json
@@ -1,6 +1,5 @@
 {
   "title": "Get started",
   "description": "First successful workflow with 143.",
-  "root": true,
   "pages": ["index", "connect-github", "start-a-session", "review-and-ship"]
 }

--- a/docs/public/guides/meta.json
+++ b/docs/public/guides/meta.json
@@ -1,6 +1,5 @@
 {
   "title": "Guides",
   "description": "Task-based guides for configuring and using 143.",
-  "root": true,
   "pages": ["index", "repo-config", "previews", "linear-agent", "autopilot", "coding-agent-auth"]
 }

--- a/docs/public/reference/meta.json
+++ b/docs/public/reference/meta.json
@@ -1,6 +1,5 @@
 {
   "title": "Reference",
   "description": "Field-level references for configuring and operating 143.",
-  "root": true,
   "pages": ["index", "repo-config-schema", "preview-config", "environment-variables"]
 }

--- a/docs/public/self-hosting/meta.json
+++ b/docs/public/self-hosting/meta.json
@@ -1,6 +1,5 @@
 {
   "title": "Self-hosting",
   "description": "Run 143 on your own infrastructure.",
-  "root": true,
   "pages": ["index", "github-app-setup", "platform-llm", "production-deployment-checklist", "worker-capacity-tuning"]
 }

--- a/frontend/src/lib/docs/public-docs.test.ts
+++ b/frontend/src/lib/docs/public-docs.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
+import getStartedMeta from "../../../../docs/public/getting-started/meta.json";
+import guidesMeta from "../../../../docs/public/guides/meta.json";
 import rootDocsMeta from "../../../../docs/public/meta.json";
+import referenceMeta from "../../../../docs/public/reference/meta.json";
+import selfHostingMeta from "../../../../docs/public/self-hosting/meta.json";
 import {
   DOCS_BASE_PATH,
   getAllPublicDocs,
@@ -20,6 +24,17 @@ describe("public docs source", () => {
     expect(pages).not.toContain("---Guides---");
     expect(pages).not.toContain("---Self-hosting---");
     expect(pages).not.toContain("---Reference---");
+  });
+
+  it("keeps section pages in one navigable sidebar tree", () => {
+    const sectionMetas = [
+      getStartedMeta,
+      guidesMeta,
+      selfHostingMeta,
+      referenceMeta,
+    ];
+
+    expect(sectionMetas.every((meta) => !("root" in meta))).toBe(true);
   });
 
   it("lists curated public docs with stable urls and metadata", () => {


### PR DESCRIPTION
## Summary
- Removed `root: true` from the public docs section metadata so the top-level docs groups stay visible while browsing within a section.
- Added a regression test to lock in the shared sidebar tree behavior.
- Updated the public docs design note to capture the intended navigation model.

## Testing
- Added and ran a focused unit test for the public docs metadata/navigation shape.
- Verified the frontend with `typecheck`, `lint`, and `build`.
- Checked the docs UI locally in the browser to confirm `Get started`, `Guides`, `Self-hosting`, and `Reference` remain visible on section pages.