### PR TITLE
Rename top-level docs section items to Overview

### DIFF
--- a/frontend/src/lib/docs/sidebar-labels.ts
+++ b/frontend/src/lib/docs/sidebar-labels.ts
@@ -1,0 +1,24 @@
+import type { ReactNode } from "react";
+
+const sectionIndexPaths = new Set([
+  "getting-started/index.mdx",
+  "guides/index.mdx",
+  "self-hosting/index.mdx",
+  "reference/index.mdx",
+]);
+
+export function sidebarLabelForPageTreeFile(
+  filePath: string | undefined,
+  currentName: ReactNode
+): ReactNode {
+  if (!filePath) {
+    return currentName;
+  }
+
+  const normalizedPath = filePath.replaceAll("\\", "/");
+  if (sectionIndexPaths.has(normalizedPath)) {
+    return "Overview";
+  }
+
+  return currentName;
+}

--- a/frontend/src/lib/source.test.ts
+++ b/frontend/src/lib/source.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import { sidebarLabelForPageTreeFile } from "./docs/sidebar-labels";
+
+describe("docs source", () => {
+  it("labels section index pages as overview items in the sidebar", () => {
+    const tests = [
+      { filePath: "getting-started/index.mdx", currentName: "Get started" },
+      { filePath: "guides/index.mdx", currentName: "Guides" },
+      { filePath: "self-hosting/index.mdx", currentName: "Self-hosting" },
+      { filePath: "reference/index.mdx", currentName: "Reference" },
+    ];
+
+    for (const tt of tests) {
+      expect(sidebarLabelForPageTreeFile(tt.filePath, tt.currentName)).toBe(
+        "Overview"
+      );
+    }
+  });
+
+  it("keeps non-section page labels unchanged", () => {
+    expect(sidebarLabelForPageTreeFile("guides/repo-config.mdx", "Repo config")).toBe(
+      "Repo config"
+    );
+    expect(sidebarLabelForPageTreeFile("index.mdx", "143.dev docs")).toBe(
+      "143.dev docs"
+    );
+  });
+});

--- a/frontend/src/lib/source.ts
+++ b/frontend/src/lib/source.ts
@@ -1,7 +1,20 @@
 import { docs } from "collections/server";
 import { loader } from "fumadocs-core/source";
+import { sidebarLabelForPageTreeFile } from "@/lib/docs/sidebar-labels";
 
 export const source = loader({
   baseUrl: "/docs",
+  pageTree: {
+    transformers: [
+      {
+        file(node, filePath) {
+          return {
+            ...node,
+            name: sidebarLabelForPageTreeFile(filePath, node.name),
+          };
+        },
+      },
+    ],
+  },
   source: docs.toFumadocsSource(),
 });

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -17,6 +17,7 @@ const nodeTestFiles = [
   'src/lib/query-keys.test.ts',
   'src/lib/session-composer-mentions.test.ts',
   'src/lib/session-open-position.test.ts',
+  'src/lib/source.test.ts',
   'src/lib/sse.test.ts',
   'src/lib/syntax-highlighter.test.ts',
   'src/lib/timeline.test.ts',
@@ -36,6 +37,7 @@ export default defineConfig({
   resolve: {
     alias: {
       '@': path.resolve(__dirname, './src'),
+      'collections': path.resolve(__dirname, './.source'),
     },
   },
   test: {


### PR DESCRIPTION
## Summary
- Rename the first item in each top-level docs group from the duplicated section name to `Overview`
- Keep page titles and search metadata unchanged while adjusting only the sidebar tree label
- Add unit coverage for the sidebar label mapping and the Vitest alias needed to exercise the generated docs source

## Testing
- Added focused unit tests for the sidebar label helper
- Ran frontend typecheck, lint, production build, and targeted docs tests successfully
- Verified the docs sidebar locally in the browser