### PR TITLE
Fix docs sidebar width and focus clipping by overriding Fumadocs layout CSS

### DIFF
--- a/frontend/src/app/(landing)/docs/layout.test.tsx
+++ b/frontend/src/app/(landing)/docs/layout.test.tsx
@@ -12,4 +12,20 @@ describe("PublicDocsLayout", () => {
     expect(source).toContain("tabs={false}");
     expect(source).not.toContain('tabMode="top"');
   });
+
+  it("keeps the desktop docs sidebar compact", () => {
+    const source = fs.readFileSync(path.join(currentDir, "layout.tsx"), "utf8");
+    const css = fs.readFileSync(path.join(currentDir, "../../globals.css"), "utf8");
+
+    expect(source).toContain("docs-fumadocs-layout");
+    expect(css).toContain("#nd-docs-layout.docs-fumadocs-layout");
+    expect(css).toContain("--fd-sidebar-width: 244px");
+  });
+
+  it("keeps focused sidebar links away from the scroll viewport clip edge", () => {
+    const source = fs.readFileSync(path.join(currentDir, "../../globals.css"), "utf8");
+
+    expect(source).toContain("#nd-sidebar [data-radix-scroll-area-viewport]");
+    expect(source).toContain("padding-inline: 1.125rem");
+  });
 });

--- a/frontend/src/app/(landing)/docs/layout.tsx
+++ b/frontend/src/app/(landing)/docs/layout.tsx
@@ -16,7 +16,7 @@ export default function PublicDocsLayout({ children }: { children: ReactNode }) 
           prefetch: false,
         }}
         containerProps={{
-          className: "bg-background",
+          className: "docs-fumadocs-layout bg-background",
         }}
       >
         {children}

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -233,6 +233,19 @@
   }
 }
 
+@layer components {
+  @media (min-width: 48rem) {
+    #nd-docs-layout.docs-fumadocs-layout {
+      --fd-sidebar-width: 244px;
+    }
+  }
+
+  #nd-sidebar [data-radix-scroll-area-viewport],
+  #nd-sidebar-mobile [data-radix-scroll-area-viewport] {
+    padding-inline: 1.125rem;
+  }
+}
+
 /* Working / "AI thinking" status indicator. A slow gradient sweep on the dot
    reads as ongoing thought rather than a 1Hz network ping. The accompanying
    halo breathes at half speed so the two cycles never sync. */


### PR DESCRIPTION
## Summary
This change ensures the docs layout sidebar stays compact and prevents focused links/buttons from being clipped. It does so by adding a docs-owned class and a higher-specificity, scoped CSS override that beats Fumadocs’ default `#nd-docs-layout:has(...)` width rule.

## Changes
- **`frontend/src/app/(landing)/docs/layout.tsx`**
  - Add `docs-fumadocs-layout` to the docs layout container `className` to scope our override.
- **`frontend/src/app/globals.css`**
  - Add a `@layer components` override for `#nd-docs-layout.docs-fumadocs-layout` (desktop) to set `--fd-sidebar-width: 244px`, overriding Fumadocs defaults.
  - Add scoped padding for the Radix scroll viewport inside `#nd-sidebar` / `#nd-sidebar-mobile` to move focused items away from the clip edge.
- **`frontend/src/app/(landing)/docs/layout.test.tsx`**
  - Update regression tests to assert the presence of the specific override selector and the expected `--fd-sidebar-width` contract.

## Test plan
- `npm test -- --run 'src/app/(landing)/docs/layout.test.tsx'`
- `npm run typecheck`
- `npm run lint`
- `npm run build`

[143.dev](https://143.dev) | [session f041cc6a](https://143.dev/sessions/f041cc6a-aa0b-4265-871b-59a62d26ea9c)

Preview: https://143.dev/previews/github/assembledhq/143/pull/1130