### PR TITLE
Make session retry resume from the latest saved progress by default

### DIFF
--- a/frontend/src/app/(dashboard)/sessions/[id]/page.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/page.test.tsx
@@ -3848,6 +3848,8 @@ describe('SessionDetailPage', () => {
       failure_category: 'test_failure',
       failure_next_steps: ['Check logs', 'Retry with debug'],
       failure_retry_advised: true,
+      sandbox_state: 'snapshotted',
+      snapshot_key: 'snapshot/test',
     };
 
     server.use(
@@ -3861,7 +3863,7 @@ describe('SessionDetailPage', () => {
     expect(screen.getByText('test_failure')).toBeInTheDocument();
     expect(screen.getByText('Check logs')).toBeInTheDocument();
     expect(screen.getByText('Retry with debug')).toBeInTheDocument();
-    expect(screen.getByText('Retry')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /^Retry$/i })).toBeInTheDocument();
   });
 
   it('shows duration for completed session', async () => {
@@ -8181,21 +8183,23 @@ describe('SessionDetailPage', () => {
     expect(screen.queryByText('Unknown user')).not.toBeInTheDocument();
   });
 
-  it('calls retry API when Retry button is clicked on failed session', async () => {
-    let retryCalled = false;
+  it('calls checkpoint retry API when primary retry button is clicked on failed session', async () => {
+    let retryBody: unknown;
 
     const failedSession: Session = {
       ...mockSessions[1],
       failure_explanation: 'Something broke',
       failure_retry_advised: true,
+      sandbox_state: 'snapshotted',
+      snapshot_key: 'snapshot/test',
     };
 
     server.use(
       http.get('/api/v1/sessions/:id', () => {
         return HttpResponse.json({ data: failedSession } satisfies SingleResponse<Session>);
       }),
-      http.post('/api/v1/sessions/:id/retry', () => {
-        retryCalled = true;
+      http.post('/api/v1/sessions/:id/retry', async ({ request }) => {
+        retryBody = await request.json();
         return HttpResponse.json({ data: { ...failedSession, status: 'pending' } });
       }),
     );
@@ -8204,11 +8208,73 @@ describe('SessionDetailPage', () => {
     await screen.findByText('Failure details');
 
     const user = userEvent.setup();
-    const retryButton = screen.getByText('Retry');
+    const retryButton = screen.getByRole('button', { name: /^Retry$/i });
     await user.click(retryButton);
 
     await waitFor(() => {
-      expect(retryCalled).toBe(true);
+      expect(retryBody).toEqual({ mode: 'checkpoint' });
+    });
+  });
+
+  it('disables checkpoint retry without a checkpoint but keeps start-over available', async () => {
+    const failedSession: Session = {
+      ...mockSessions[1],
+      failure_explanation: 'Something broke',
+      failure_retry_advised: true,
+      sandbox_state: 'none',
+      snapshot_key: undefined,
+    };
+
+    server.use(
+      http.get('/api/v1/sessions/:id', () => {
+        return HttpResponse.json({ data: failedSession } satisfies SingleResponse<Session>);
+      }),
+    );
+
+    renderWithProviders(<SessionDetailContent id="session-98765432-abcd-ef01" />);
+    await screen.findByText('Failure details');
+
+    expect(screen.getByRole('button', { name: /^Retry$/i })).toBeDisabled();
+
+    const user = userEvent.setup();
+    await user.click(screen.getByRole('button', { name: /More retry actions/i }));
+    expect(await screen.findByRole('menuitem', { name: /Start over from beginning/i })).toBeInTheDocument();
+  });
+
+  it('requires confirmation before posting start-over retry mode', async () => {
+    let retryBody: unknown;
+    const failedSession: Session = {
+      ...mockSessions[1],
+      failure_explanation: 'Something broke',
+      failure_retry_advised: true,
+      sandbox_state: 'none',
+      snapshot_key: undefined,
+    };
+
+    server.use(
+      http.get('/api/v1/sessions/:id', () => {
+        return HttpResponse.json({ data: failedSession } satisfies SingleResponse<Session>);
+      }),
+      http.post('/api/v1/sessions/:id/retry', async ({ request }) => {
+        retryBody = await request.json();
+        return HttpResponse.json({ data: { ...failedSession, status: 'pending' } });
+      }),
+    );
+
+    renderWithProviders(<SessionDetailContent id="session-98765432-abcd-ef01" />);
+    await screen.findByText('Failure details');
+
+    const user = userEvent.setup();
+    await user.click(screen.getByRole('button', { name: /More retry actions/i }));
+    await user.click(await screen.findByRole('menuitem', { name: /Start over from beginning/i }));
+
+    expect(screen.getByRole('alertdialog')).toBeInTheDocument();
+    expect(retryBody).toBeUndefined();
+
+    await user.click(screen.getByRole('button', { name: /^Start over$/i }));
+
+    await waitFor(() => {
+      expect(retryBody).toEqual({ mode: 'start_over' });
     });
   });
 

--- a/frontend/src/app/(dashboard)/sessions/[id]/page.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/page.test.tsx
@@ -5691,6 +5691,7 @@ describe('SessionDetailPage', () => {
       ...mockSessions[1],
       failure_category: 'codex_auth_expired',
       failure_explanation: 'Codex token expired',
+      failure_retry_advised: true,
       agent_type: 'codex',
     };
 
@@ -5707,8 +5708,37 @@ describe('SessionDetailPage', () => {
     renderWithProviders(<SessionDetailContent id="session-98765432-abcd-ef01" />);
     await screen.findByText('Failure details');
     expect(
-      await screen.findByText(/ChatGPT connected/),
+      await screen.findByText('ChatGPT connected — open the retry menu and choose Start over from beginning.'),
     ).toBeInTheDocument();
+  });
+
+  it('points codex auth users to Retry when saved progress exists', async () => {
+    const codexAuthSession: Session = {
+      ...mockSessions[1],
+      failure_category: 'codex_auth_expired',
+      failure_explanation: 'Codex token expired',
+      failure_retry_advised: true,
+      agent_type: 'codex',
+      sandbox_state: 'snapshotted',
+      snapshot_key: 'snapshot/test',
+    };
+
+    server.use(
+      http.get('/api/v1/sessions/:id', () => {
+        return HttpResponse.json({ data: codexAuthSession } satisfies SingleResponse<Session>);
+      }),
+      http.get('/api/v1/settings/codex-auth/status', ({ request }) => {
+        expect(new URL(request.url).searchParams.get('scope')).toBe('personal');
+        return HttpResponse.json({ data: { status: 'completed' } });
+      }),
+    );
+
+    renderWithProviders(<SessionDetailContent id="session-98765432-abcd-ef01" />);
+    await screen.findByText('Failure details');
+    expect(
+      await screen.findByText('ChatGPT connected — click Retry to continue this session.'),
+    ).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /^Retry$/i })).toBeEnabled();
   });
 
   it('can toggle the detail panel visibility', async () => {

--- a/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
@@ -609,7 +609,9 @@ function OverviewTab({ session, members, prStatus }: { session: Session; members
             {isCodexAuthFailure && isCodexAuthenticated && (
               <p className="text-xs text-emerald-600 dark:text-emerald-400 flex items-center gap-1.5">
                 <CheckCircle2 className="h-3.5 w-3.5" />
-                ChatGPT connected — click Retry to re-run this session.
+                {checkpointRetryUnavailable
+                  ? "ChatGPT connected — open the retry menu and choose Start over from beginning."
+                  : "ChatGPT connected — click Retry to continue this session."}
               </p>
             )}
           </CardContent>

--- a/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
@@ -131,7 +131,7 @@ import {
   readStoredViewedThreadIds,
   writeStoredViewedThreadIds,
 } from "@/lib/session-thread-views";
-import type { HumanInputAnswerBody, HumanInputRequest, ListResponse, Organization, OrgSettings, ReviewLoopFixMode, Session, SessionDetail, SessionInputCommand, SessionInputReference, SessionLog, SessionMessage, SessionReviewComment, SessionReviewLoop, SessionThread, SessionThreadFileEvent, SessionTimelineEntry, ThreadMessageWindowResponse, User, CodexAuthStatus, PullRequestHealthResponse, SingleResponse } from "@/lib/types";
+import type { HumanInputAnswerBody, HumanInputRequest, ListResponse, Organization, OrgSettings, ReviewLoopFixMode, Session, SessionDetail, SessionInputCommand, SessionInputReference, SessionLog, SessionMessage, SessionReviewComment, SessionReviewLoop, SessionRetryMode, SessionThread, SessionThreadFileEvent, SessionTimelineEntry, ThreadMessageWindowResponse, User, CodexAuthStatus, PullRequestHealthResponse, SingleResponse } from "@/lib/types";
 import { AgentTabStrip, computeThreadOverlap } from "./agent-tab-strip";
 import {
   ThreadAttributionFilter,
@@ -480,6 +480,7 @@ function isPRAuthInterceptDetails(value: unknown): value is PRAuthInterceptDetai
 function OverviewTab({ session, members, prStatus }: { session: Session; members: User[]; prStatus?: string | null }) {
   const queryClient = useQueryClient();
   const [showDeviceCodeModal, setShowDeviceCodeModal] = useState(false);
+  const [showStartOverRetryDialog, setShowStartOverRetryDialog] = useState(false);
 
   const isCodexAuthFailure = session.failure_category === FAILURE_CATEGORY_CODEX_AUTH;
 
@@ -491,11 +492,13 @@ function OverviewTab({ session, members, prStatus }: { session: Session; members
   const isCodexAuthenticated = codexAuthResponse?.data?.status === "completed";
 
   const retryMutation = useMutation({
-    mutationFn: () => api.sessions.retry(session.id),
+    mutationFn: (mode: SessionRetryMode) => api.sessions.retry(session.id, { mode }),
     onSuccess: () => {
+      setShowStartOverRetryDialog(false);
       queryClient.invalidateQueries({ queryKey: ["session", session.id] });
     },
   });
+  const checkpointRetryUnavailable = !session.snapshot_key || session.sandbox_state === "destroyed";
 
   const status = getDisplayStatus(session.status, prStatus);
   const isActive = !terminalSessionStatuses.has(session.status);
@@ -542,17 +545,41 @@ function OverviewTab({ session, members, prStatus }: { session: Session; members
                 )}
               </CardTitle>
               {session.failure_retry_advised && (
-                <DisabledTooltip disabled={retryMutation.isPending} content="Retrying session...">
-                  <Button
-                    size="xs"
-                    variant="outline"
-                    onClick={() => retryMutation.mutate()}
-                    disabled={retryMutation.isPending}
+                <div className="inline-flex">
+                  <DisabledTooltip
+                    disabled={retryMutation.isPending || checkpointRetryUnavailable}
+                    content={checkpointRetryUnavailable ? "No saved progress is available." : "Retrying session..."}
                   >
-                    <RefreshCw className={`mr-1.5 h-3 w-3 ${retryMutation.isPending ? "animate-spin" : ""}`} />
-                    {retryMutation.isPending ? "Retrying..." : "Retry"}
-                  </Button>
-                </DisabledTooltip>
+                    <Button
+                      size="xs"
+                      variant="outline"
+                      className="rounded-r-none border-r-0"
+                      onClick={() => retryMutation.mutate("checkpoint")}
+                      disabled={retryMutation.isPending || checkpointRetryUnavailable}
+                    >
+                      <RefreshCw className={`mr-1.5 h-3 w-3 ${retryMutation.isPending ? "animate-spin" : ""}`} />
+                      {retryMutation.isPending ? "Retrying..." : "Retry"}
+                    </Button>
+                  </DisabledTooltip>
+                  <DropdownMenu>
+                    <DropdownMenuTrigger asChild>
+                      <Button
+                        size="xs"
+                        variant="outline"
+                        className="rounded-l-none px-2"
+                        aria-label="More retry actions"
+                        disabled={retryMutation.isPending}
+                      >
+                        <ChevronDown className="h-3 w-3" />
+                      </Button>
+                    </DropdownMenuTrigger>
+                    <DropdownMenuContent align="end">
+                      <DropdownMenuItem onClick={() => setShowStartOverRetryDialog(true)}>
+                        Start over from beginning
+                      </DropdownMenuItem>
+                    </DropdownMenuContent>
+                  </DropdownMenu>
+                </div>
               )}
             </div>
           </CardHeader>
@@ -586,6 +613,25 @@ function OverviewTab({ session, members, prStatus }: { session: Session; members
               </p>
             )}
           </CardContent>
+          <AlertDialog open={showStartOverRetryDialog} onOpenChange={setShowStartOverRetryDialog}>
+            <AlertDialogContent>
+              <AlertDialogHeader>
+                <AlertDialogTitle>Start over from beginning?</AlertDialogTitle>
+                <AlertDialogDescription>
+                  This clears the current visible retry result and starts the session again from its original base.
+                </AlertDialogDescription>
+              </AlertDialogHeader>
+              <AlertDialogFooter>
+                <AlertDialogCancel disabled={retryMutation.isPending}>Cancel</AlertDialogCancel>
+                <AlertDialogAction
+                  onClick={() => retryMutation.mutate("start_over")}
+                  disabled={retryMutation.isPending}
+                >
+                  Start over
+                </AlertDialogAction>
+              </AlertDialogFooter>
+            </AlertDialogContent>
+          </AlertDialog>
         </Card>
       )}
       {showDeviceCodeModal && (

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -437,8 +437,8 @@ export const api = {
       ),
     endSession: (sessionId: string) =>
       post<import('./types').SingleResponse<import('./types').Session>>(`/api/v1/sessions/${sessionId}/end`),
-    retry: (sessionId: string) =>
-      post<import('./types').SingleResponse<import('./types').Session>>(`/api/v1/sessions/${sessionId}/retry`),
+    retry: (sessionId: string, body?: import('./types').RetrySessionRequest) =>
+      post<import('./types').SingleResponse<import('./types').Session>>(`/api/v1/sessions/${sessionId}/retry`, body ?? {}),
     cancelSession: (sessionId: string) =>
       post<import('./types').SingleResponse<import('./types').Session>>(`/api/v1/sessions/${sessionId}/cancel`),
     archive: (sessionId: string) =>

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -421,6 +421,12 @@ export interface Session {
   created_at: string;
 }
 
+export type SessionRetryMode = 'checkpoint' | 'start_over';
+
+export interface RetrySessionRequest {
+  mode?: SessionRetryMode;
+}
+
 export interface PRSummary {
   status: string;
   ci_status: string;

--- a/frontend/src/test/mocks/handlers.ts
+++ b/frontend/src/test/mocks/handlers.ts
@@ -804,8 +804,10 @@ export const handlers = [
     return HttpResponse.json({ data: { ...mockSessions[0], status: 'cancelled' } });
   }),
 
-  http.post('/api/v1/sessions/:id/retry', () => {
-    return HttpResponse.json({ data: { ...mockSessions[0], status: 'pending' } });
+  http.post('/api/v1/sessions/:id/retry', async ({ request }) => {
+    const body = await request.json().catch(() => ({ mode: 'checkpoint' }));
+    const mode = typeof body === 'object' && body && 'mode' in body ? body.mode : 'checkpoint';
+    return HttpResponse.json({ data: { ...mockSessions[0], status: mode === 'checkpoint' ? 'running' : 'pending' } });
   }),
 
   http.get('/api/v1/users/me/github-status', () => {

--- a/internal/api/handlers/session_linking_test.go
+++ b/internal/api/handlers/session_linking_test.go
@@ -288,7 +288,7 @@ func TestSessionHandler_RetrySession_EnrichesLinks(t *testing.T) {
 			),
 		)
 
-	req := httptest.NewRequest(http.MethodPost, "/api/v1/sessions/"+sessionID.String()+"/retry", nil)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/sessions/"+sessionID.String()+"/retry", strings.NewReader(`{"mode":"start_over"}`))
 	rctx := chi.NewRouteContext()
 	rctx.URLParams.Add("id", sessionID.String())
 	ctx := context.WithValue(req.Context(), chi.RouteCtxKey, rctx)

--- a/internal/api/handlers/sessions.go
+++ b/internal/api/handlers/sessions.go
@@ -949,7 +949,11 @@ func (h *SessionHandler) TriggerFix(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusCreated, models.SingleResponse[models.Session]{Data: *run})
 }
 
-// RetrySession resets a failed session back to pending and re-enqueues it.
+const retryCheckpointTranscriptNote = "Retrying from the latest saved progress."
+
+// RetrySession retries a failed session. The default mode resumes from the
+// latest durable checkpoint; start_over preserves the old destructive rerun
+// path for explicit user selection.
 func (h *SessionHandler) RetrySession(w http.ResponseWriter, r *http.Request) {
 	orgID := middleware.OrgIDFromContext(r.Context())
 	sessionID, err := uuid.Parse(chi.URLParam(r, "id"))
@@ -958,6 +962,40 @@ func (h *SessionHandler) RetrySession(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	mode, err := parseRetrySessionMode(r)
+	if err != nil {
+		writeError(w, r, http.StatusBadRequest, "INVALID_RETRY_MODE", "invalid retry mode", err)
+		return
+	}
+
+	switch mode {
+	case models.SessionRetryModeCheckpoint:
+		h.retrySessionFromCheckpoint(w, r, orgID, sessionID)
+	case models.SessionRetryModeStartOver:
+		h.retrySessionStartOver(w, r, orgID, sessionID)
+	default:
+		writeError(w, r, http.StatusBadRequest, "INVALID_RETRY_MODE", "invalid retry mode")
+	}
+}
+
+func parseRetrySessionMode(r *http.Request) (models.SessionRetryMode, error) {
+	var req models.RetrySessionRequest
+	if r.Body != nil {
+		decoder := json.NewDecoder(r.Body)
+		if err := decoder.Decode(&req); err != nil && !errors.Is(err, io.EOF) {
+			return "", err
+		}
+	}
+	if req.Mode == "" {
+		req.Mode = models.SessionRetryModeCheckpoint
+	}
+	if err := req.Mode.Validate(); err != nil {
+		return "", err
+	}
+	return req.Mode, nil
+}
+
+func (h *SessionHandler) retrySessionStartOver(w http.ResponseWriter, r *http.Request, orgID, sessionID uuid.UUID) {
 	if err := h.runStore.ResetForRetry(r.Context(), orgID, sessionID); err != nil {
 		if errors.Is(err, db.ErrSessionNotFound) {
 			writeError(w, r, http.StatusNotFound, "NOT_FOUND", "session not found")
@@ -998,7 +1036,8 @@ func (h *SessionHandler) RetrySession(w http.ResponseWriter, r *http.Request) {
 
 	sessionIDStr := sessionID.String()
 	retryDetails := sessionAuditSnapshot(&session, nil, map[string]any{
-		"job_type": "run_agent",
+		"job_type":   "run_agent",
+		"retry_mode": string(models.SessionRetryModeStartOver),
 		"changes": map[string]any{
 			"status": auditChange("failed", session.Status),
 		},
@@ -1006,6 +1045,132 @@ func (h *SessionHandler) RetrySession(w http.ResponseWriter, r *http.Request) {
 	emitUserAuditWithSession(h.audit, r, models.AuditActionSessionRetried, models.AuditResourceSession, &sessionIDStr, &sessionID, nil,
 		marshalAuditDetails(h.logger, retryDetails))
 	writeJSON(w, http.StatusOK, models.SingleResponse[models.Session]{Data: session})
+}
+
+func (h *SessionHandler) retrySessionFromCheckpoint(w http.ResponseWriter, r *http.Request, orgID, sessionID uuid.UUID) {
+	session, err := h.runStore.GetByID(r.Context(), orgID, sessionID)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) || errors.Is(err, db.ErrSessionNotFound) {
+			writeError(w, r, http.StatusNotFound, "NOT_FOUND", "session not found")
+			return
+		}
+		writeError(w, r, http.StatusInternalServerError, "FETCH_FAILED", "failed to fetch session", err)
+		return
+	}
+	if session.Status != models.SessionStatusFailed {
+		writeError(w, r, http.StatusConflict, "NOT_FAILED", "session is not in failed status")
+		return
+	}
+	if session.SnapshotKey == nil || strings.TrimSpace(*session.SnapshotKey) == "" || session.SandboxState == models.SandboxStateDestroyed {
+		writeError(w, r, http.StatusConflict, "CHECKPOINT_UNAVAILABLE", "No saved progress is available.")
+		return
+	}
+	if session.PendingSnapshotKey != nil && strings.TrimSpace(*session.PendingSnapshotKey) != "" {
+		writeError(w, r, http.StatusConflict, "CHECKPOINT_PENDING", "checkpoint upload is still pending")
+		return
+	}
+
+	targetThread, err := h.threadStore.GetRetryTarget(r.Context(), orgID, sessionID)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			writeError(w, r, http.StatusConflict, "NO_RETRY_THREAD", "no visible retry thread is available")
+			return
+		}
+		writeError(w, r, http.StatusInternalServerError, "THREAD_LOOKUP_FAILED", "failed to find retry thread", err)
+		return
+	}
+
+	claimedSession, err := h.runStore.ClaimForResume(r.Context(), orgID, sessionID)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			writeError(w, r, http.StatusConflict, "CHECKPOINT_UNAVAILABLE", "No saved progress is available.")
+			return
+		}
+		writeError(w, r, http.StatusInternalServerError, "RETRY_FAILED", "failed to claim session for checkpoint retry", err)
+		return
+	}
+
+	claimedThread, err := h.claimRetryThread(r.Context(), orgID, sessionID, targetThread)
+	if err != nil {
+		h.revertCheckpointRetry(r.Context(), orgID, sessionID, uuid.Nil, models.ThreadStatus(""))
+		if errors.Is(err, db.ErrThreadRunningLimitReached) || errors.Is(err, pgx.ErrNoRows) {
+			writeError(w, r, http.StatusConflict, "THREAD_NOT_RETRYABLE", "retry thread is not available")
+			return
+		}
+		writeError(w, r, http.StatusInternalServerError, "THREAD_CLAIM_FAILED", "failed to claim retry thread", err)
+		return
+	}
+
+	messageThreadID := claimedThread.ID
+	note := models.SessionMessage{
+		SessionID:  sessionID,
+		OrgID:      orgID,
+		ThreadID:   &messageThreadID,
+		TurnNumber: claimedThread.CurrentTurn + 1,
+		Role:       models.MessageRoleAssistant,
+		Content:    retryCheckpointTranscriptNote,
+	}
+	if err := h.messageStore.Create(r.Context(), &note); err != nil {
+		h.revertCheckpointRetry(r.Context(), orgID, sessionID, claimedThread.ID, targetThread.Status)
+		writeError(w, r, http.StatusInternalServerError, "MESSAGE_FAILED", "failed to add retry transcript note", err)
+		return
+	}
+
+	dedupeKey := db.ContinueSessionDedupeKey(claimedThread.ID)
+	payload := map[string]string{
+		"session_id": sessionID.String(),
+		"thread_id":  claimedThread.ID.String(),
+		"org_id":     orgID.String(),
+	}
+	if _, err := h.jobStore.EnqueueWithTarget(r.Context(), orgID, "agent", "continue_session", payload, 5, &dedupeKey, models.SessionWorkerTarget(&claimedSession)); err != nil {
+		h.revertCheckpointRetry(r.Context(), orgID, sessionID, claimedThread.ID, targetThread.Status)
+		writeError(w, r, http.StatusInternalServerError, "ENQUEUE_FAILED", "failed to enqueue session continuation job", err)
+		return
+	}
+
+	h.enrichSessionLinks(r.Context(), orgID, &claimedSession)
+	sessionIDStr := sessionID.String()
+	retryDetails := sessionAuditSnapshot(&claimedSession, nil, map[string]any{
+		"job_type":   "continue_session",
+		"retry_mode": string(models.SessionRetryModeCheckpoint),
+		"thread_id":  claimedThread.ID.String(),
+		"changes": map[string]any{
+			"status": auditChange(session.Status, claimedSession.Status),
+		},
+	})
+	emitUserAuditWithSession(h.audit, r, models.AuditActionSessionRetried, models.AuditResourceSession, &sessionIDStr, &sessionID, nil,
+		marshalAuditDetails(h.logger, retryDetails))
+	writeJSON(w, http.StatusOK, models.SingleResponse[models.Session]{Data: claimedSession})
+}
+
+func (h *SessionHandler) claimRetryThread(ctx context.Context, orgID, sessionID uuid.UUID, targetThread models.SessionThread) (models.SessionThread, error) {
+	if targetThread.Status == models.ThreadStatusIdle {
+		return h.threadStore.ClaimIdleForSession(ctx, orgID, sessionID, targetThread.ID, models.MaxRunningThreadsPerSession)
+	}
+	if retryThreadStatusResumable(targetThread.Status) {
+		return h.threadStore.ClaimForResumeInSession(ctx, orgID, sessionID, targetThread.ID, models.MaxRunningThreadsPerSession)
+	}
+	return models.SessionThread{}, pgx.ErrNoRows
+}
+
+func retryThreadStatusResumable(status models.ThreadStatus) bool {
+	for _, resumable := range models.ResumableThreadStatuses {
+		if status == resumable {
+			return true
+		}
+	}
+	return false
+}
+
+func (h *SessionHandler) revertCheckpointRetry(ctx context.Context, orgID, sessionID, threadID uuid.UUID, previousThreadStatus models.ThreadStatus) {
+	if err := h.runStore.UpdateStatus(ctx, orgID, sessionID, models.SessionStatusFailed); err != nil {
+		h.logger.Warn().Err(err).Str("session_id", sessionID.String()).Msg("failed to revert checkpoint retry session status")
+	}
+	if threadID != uuid.Nil && previousThreadStatus != "" {
+		if err := h.threadStore.UpdateStatus(ctx, orgID, threadID, previousThreadStatus); err != nil {
+			h.logger.Warn().Err(err).Str("thread_id", threadID.String()).Msg("failed to revert checkpoint retry thread status")
+		}
+	}
 }
 
 // GetLogs returns all logs for a run as a JSON array.

--- a/internal/api/handlers/sessions_test.go
+++ b/internal/api/handlers/sessions_test.go
@@ -671,6 +671,139 @@ func sessionAnyArgs(count int) []interface{} {
 	return args
 }
 
+type capturingJSONArg struct {
+	dest *[]byte
+}
+
+func (c capturingJSONArg) Match(v interface{}) bool {
+	switch b := v.(type) {
+	case json.RawMessage:
+		*c.dest = append((*c.dest)[:0], b...)
+	case []byte:
+		*c.dest = append((*c.dest)[:0], b...)
+	case string:
+		*c.dest = append((*c.dest)[:0], []byte(b)...)
+	default:
+		return false
+	}
+	return true
+}
+
+var sessionThreadHandlerColumns = []string{
+	"id", "session_id", "org_id", "agent_type", "model_override",
+	"label", "instructions", "file_scope", "status", "agent_session_id", "current_turn", "last_activity_at",
+	"result_summary", "diff", "failure_explanation", "failure_category",
+	"started_at", "completed_at", "created_at", "archived_at",
+	"base_snapshot_key", "cost_cents", "pending_message_count", "cancel_requested_at",
+}
+
+func sessionThreadHandlerRow(threadID, sessionID, orgID uuid.UUID, status models.ThreadStatus, turn int, now time.Time) []interface{} {
+	return []interface{}{
+		threadID, sessionID, orgID, models.AgentTypeClaudeCode, nil,
+		"Main", nil, nil, status, nil, turn, &now,
+		nil, nil, nil, nil,
+		nil, nil, now, nil,
+		nil, float64(0), 0, nil,
+	}
+}
+
+func retrySessionRow(sessionID, orgID uuid.UUID, status models.SessionStatus, snapshotKey *string, pendingSnapshotKey *string, sandboxState models.SandboxState, diffStats json.RawMessage, now time.Time) []interface{} {
+	values := map[string]interface{}{
+		"id":                             sessionID,
+		"primary_issue_id":               nil,
+		"org_id":                         orgID,
+		"origin":                         models.SessionOriginManual,
+		"interaction_mode":               models.SessionInteractionModeInteractive,
+		"validation_policy":              models.SessionValidationPolicyOnTurnComplete,
+		"agent_type":                     models.AgentTypeClaudeCode,
+		"status":                         status,
+		"autonomy_level":                 models.SessionAutonomySemi,
+		"token_mode":                     models.SessionTokenModeLow,
+		"complexity_tier":                nil,
+		"container_id":                   nil,
+		"worker_node_id":                 nil,
+		"turn_holding_container":         false,
+		"started_at":                     nil,
+		"completed_at":                   nil,
+		"token_usage":                    nil,
+		"failure_explanation":            nil,
+		"failure_category":               nil,
+		"failure_next_steps":             nil,
+		"failure_retry_advised":          false,
+		"parent_session_id":              nil,
+		"revision_context":               nil,
+		"error":                          nil,
+		"result_summary":                 nil,
+		"diff":                           ptr("diff --git a/file b/file"),
+		"pm_plan_id":                     nil,
+		"title":                          nil,
+		"pm_approach":                    nil,
+		"pm_reasoning":                   nil,
+		"project_task_id":                nil,
+		"model_override":                 nil,
+		"reasoning_effort":               nil,
+		"triggered_by_user_id":           nil,
+		"agent_session_id":               nil,
+		"current_turn":                   1,
+		"last_activity_at":               now,
+		"sandbox_state":                  sandboxState,
+		"snapshot_key":                   snapshotKey,
+		"pending_snapshot_key":           pendingSnapshotKey,
+		"pending_snapshot_set_at":        nil,
+		"runtime_soft_deadline_at":       nil,
+		"runtime_hard_deadline_at":       nil,
+		"runtime_last_progress_at":       nil,
+		"runtime_last_progress_type":     models.RuntimeProgressType(""),
+		"runtime_last_progress_strength": models.RuntimeProgressStrength(""),
+		"runtime_extension_count":        0,
+		"runtime_extension_seconds":      0,
+		"runtime_stop_reason":            models.RuntimeStopReason(""),
+		"runtime_graceful_stop_at":       nil,
+		"checkpointed_at":                nil,
+		"checkpoint_kind":                models.CheckpointKind(""),
+		"checkpoint_capability":          models.CheckpointCapability(""),
+		"checkpoint_size_bytes":          int64(0),
+		"checkpoint_error":               nil,
+		"recovery_state":                 models.RecoveryState(""),
+		"recovery_queued_at":             nil,
+		"recovery_started_at":            nil,
+		"recovery_attempt_count":         0,
+		"target_branch":                  nil,
+		"working_branch":                 nil,
+		"base_commit_sha":                nil,
+		"repository_id":                  nil,
+		"diff_stats":                     diffStats,
+		"diff_history":                   json.RawMessage(`[{"files_changed":1}]`),
+		"input_manifest":                 nil,
+		"archived_at":                    nil,
+		"archived_by_user_id":            nil,
+		"automation_run_id":              nil,
+		"pr_creation_state":              models.PRCreationStateIdle,
+		"pr_creation_error":              nil,
+		"pr_push_state":                  models.PRPushStateIdle,
+		"pr_push_error":                  nil,
+		"branch_creation_state":          models.BranchCreationStateIdle,
+		"branch_creation_error":          nil,
+		"branch_url":                     nil,
+		"diff_collected_at":              nil,
+		"latest_diff_snapshot_id":        nil,
+		"has_unpushed_changes":           false,
+		"linear_private":                 false,
+		"linear_state_sync_disabled":     false,
+		"linear_identifier_hint":         nil,
+		"linear_prepare_state":           models.LinearPrepareStateNone,
+		"deleted_at":                     nil,
+		"git_identity_source":            nil,
+		"git_identity_user_id":           nil,
+		"created_at":                     now,
+	}
+	row := make([]interface{}, len(sessionColumns))
+	for i, column := range sessionColumns {
+		row[i] = values[column]
+	}
+	return row
+}
+
 func expectManualSessionCreate(mock pgxmock.PgxPoolIface, runID uuid.UUID, now time.Time) {
 	mock.ExpectBegin()
 	mock.ExpectQuery("INSERT INTO sessions").
@@ -8130,6 +8263,193 @@ func TestSessionHandler_PushChangesToPR_SnapshotNotCaptured(t *testing.T) {
 	require.Equal(t, http.StatusConflict, w.Code, "should return 409 when no snapshot was captured")
 	require.Contains(t, w.Body.String(), "SNAPSHOT_NOT_CAPTURED", "error code should indicate missing checkpoint")
 	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
+}
+
+func TestSessionHandler_RetrySession_DefaultsToCheckpoint(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "pgxmock pool should be created")
+	defer mock.Close()
+
+	now := time.Now().UTC()
+	orgID := uuid.New()
+	userID := uuid.New()
+	sessionID := uuid.New()
+	threadID := uuid.New()
+	snapshotKey := "snapshots/session.tar"
+	diffStats := json.RawMessage(`{"files_changed":7}`)
+	handler := newSessionHandler(t, mock)
+	handler.SetAuditEmitter(db.NewAuditEmitter(db.NewAuditLogStore(mock), zerolog.Nop()))
+
+	mock.ExpectQuery("SELECT .+ FROM sessions").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(pgxmock.NewRows(sessionColumns).AddRow(retrySessionRow(sessionID, orgID, models.SessionStatusFailed, &snapshotKey, nil, models.SandboxStateSnapshotted, diffStats, now)...))
+	mock.ExpectQuery("session_messages").
+		WithArgs(sessionAnyArgs(2)...).
+		WillReturnRows(pgxmock.NewRows(sessionThreadHandlerColumns).AddRow(sessionThreadHandlerRow(threadID, sessionID, orgID, models.ThreadStatusFailed, 2, now)...))
+	mock.ExpectQuery("UPDATE sessions").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(pgxmock.NewRows(sessionColumns).AddRow(retrySessionRow(sessionID, orgID, models.SessionStatusRunning, &snapshotKey, nil, models.SandboxStateSnapshotted, diffStats, now)...))
+	mock.ExpectQuery("UPDATE session_threads").
+		WithArgs(sessionAnyArgs(5)...).
+		WillReturnRows(pgxmock.NewRows(sessionThreadHandlerColumns).AddRow(sessionThreadHandlerRow(threadID, sessionID, orgID, models.ThreadStatusRunning, 2, now)...))
+	mock.ExpectQuery("INSERT INTO session_messages").
+		WithArgs(sessionAnyArgs(11)...).
+		WillReturnRows(pgxmock.NewRows([]string{"id", "created_at"}).AddRow(int64(42), now))
+
+	var jobPayload []byte
+	mock.ExpectQuery("INSERT INTO jobs").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), capturingArg(&jobPayload), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(pgxmock.NewRows([]string{"id"}).AddRow(uuid.New()))
+
+	var auditDetails []byte
+	mock.ExpectQuery("INSERT INTO audit_logs").
+		WithArgs(
+			pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
+			pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), capturingJSONArg{dest: &auditDetails},
+			pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
+		).
+		WillReturnRows(pgxmock.NewRows([]string{"id", "created_at"}).AddRow(int64(1), now))
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/sessions/"+sessionID.String()+"/retry", nil)
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("id", sessionID.String())
+	ctx := context.WithValue(req.Context(), chi.RouteCtxKey, rctx)
+	ctx = middleware.WithOrgID(ctx, orgID)
+	ctx = middleware.WithUser(ctx, &models.User{ID: userID, OrgID: orgID})
+	req = req.WithContext(ctx)
+	w := httptest.NewRecorder()
+
+	handler.RetrySession(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code, "checkpoint retry should return the claimed running session: %s", w.Body.String())
+
+	var resp models.SingleResponse[models.Session]
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp), "response should decode as a session response")
+	require.Equal(t, models.SessionStatusRunning, resp.Data.Status, "checkpoint retry should mark the session running")
+	require.JSONEq(t, string(diffStats), string(resp.Data.DiffStats), "checkpoint retry should preserve existing diff stats")
+
+	var payload map[string]string
+	require.NoError(t, json.Unmarshal(jobPayload, &payload), "job payload should decode as string map")
+	require.Equal(t, sessionID.String(), payload["session_id"], "continue_session payload should include the session id")
+	require.Equal(t, threadID.String(), payload["thread_id"], "continue_session payload should include the retry thread id")
+
+	var details map[string]any
+	require.NoError(t, json.Unmarshal(auditDetails, &details), "audit details should decode as an object")
+	require.Equal(t, string(models.SessionRetryModeCheckpoint), details["retry_mode"], "audit details should record checkpoint retry mode")
+	require.Equal(t, "continue_session", details["job_type"], "audit details should record continue_session job type")
+	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
+}
+
+func TestSessionHandler_RetrySession_CheckpointRejectsMissingSnapshot(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "pgxmock pool should be created")
+	defer mock.Close()
+
+	now := time.Now().UTC()
+	orgID := uuid.New()
+	sessionID := uuid.New()
+	diffStats := json.RawMessage(`{"files_changed":7}`)
+	handler := newSessionHandler(t, mock)
+
+	mock.ExpectQuery("SELECT .+ FROM sessions").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(pgxmock.NewRows(sessionColumns).AddRow(retrySessionRow(sessionID, orgID, models.SessionStatusFailed, nil, nil, models.SandboxStateNone, diffStats, now)...))
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/sessions/"+sessionID.String()+"/retry", strings.NewReader(`{"mode":"checkpoint"}`))
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("id", sessionID.String())
+	ctx := context.WithValue(req.Context(), chi.RouteCtxKey, rctx)
+	ctx = middleware.WithOrgID(ctx, orgID)
+	req = req.WithContext(ctx)
+	w := httptest.NewRecorder()
+
+	handler.RetrySession(w, req)
+
+	require.Equal(t, http.StatusConflict, w.Code, "checkpoint retry should reject sessions without a saved checkpoint")
+	require.Contains(t, w.Body.String(), "CHECKPOINT_UNAVAILABLE", "error response should explain the missing checkpoint")
+	require.NoError(t, mock.ExpectationsWereMet(), "checkpoint retry should not issue any diff-clearing update")
+}
+
+func TestSessionHandler_RetrySession_StartOverUsesRunAgent(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "pgxmock pool should be created")
+	defer mock.Close()
+
+	now := time.Now().UTC()
+	orgID := uuid.New()
+	sessionID := uuid.New()
+	handler := newSessionHandler(t, mock)
+	diffStats := json.RawMessage(`{"files_changed":7}`)
+
+	mock.ExpectQuery("SELECT status FROM sessions").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(pgxmock.NewRows([]string{"status"}).AddRow("failed"))
+	mock.ExpectExec("UPDATE sessions").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
+
+	var jobPayload []byte
+	mock.ExpectQuery("INSERT INTO jobs").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), capturingArg(&jobPayload), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(pgxmock.NewRows([]string{"id"}).AddRow(uuid.New()))
+	mock.ExpectQuery("SELECT .+ FROM sessions").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(pgxmock.NewRows(sessionColumns).AddRow(retrySessionRow(sessionID, orgID, models.SessionStatusPending, nil, nil, models.SandboxStateNone, nil, now)...))
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/sessions/"+sessionID.String()+"/retry", strings.NewReader(`{"mode":"start_over"}`))
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("id", sessionID.String())
+	ctx := context.WithValue(req.Context(), chi.RouteCtxKey, rctx)
+	ctx = middleware.WithOrgID(ctx, orgID)
+	req = req.WithContext(ctx)
+	w := httptest.NewRecorder()
+
+	handler.RetrySession(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code, "start-over retry should succeed for a failed session")
+
+	var payload map[string]string
+	require.NoError(t, json.Unmarshal(jobPayload, &payload), "job payload should decode as string map")
+	require.Equal(t, sessionID.String(), payload["session_id"], "run_agent payload should include the session id")
+	require.Empty(t, payload["thread_id"], "start-over retry should not enqueue a thread-scoped continuation")
+
+	var resp models.SingleResponse[models.Session]
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp), "response should decode as a session response")
+	require.Nil(t, resp.Data.DiffStats, "start-over retry should return cleared diff stats")
+	require.NotEqual(t, string(diffStats), string(resp.Data.DiffStats), "start-over retry should not preserve prior diff stats")
+	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
+}
+
+func TestSessionHandler_RetrySession_InvalidMode(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "pgxmock pool should be created")
+	defer mock.Close()
+
+	orgID := uuid.New()
+	sessionID := uuid.New()
+	handler := newSessionHandler(t, mock)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/sessions/"+sessionID.String()+"/retry", strings.NewReader(`{"mode":"fresh"}`))
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("id", sessionID.String())
+	ctx := context.WithValue(req.Context(), chi.RouteCtxKey, rctx)
+	ctx = middleware.WithOrgID(ctx, orgID)
+	req = req.WithContext(ctx)
+	w := httptest.NewRecorder()
+
+	handler.RetrySession(w, req)
+
+	require.Equal(t, http.StatusBadRequest, w.Code, "invalid retry mode should return 400")
+	require.Contains(t, w.Body.String(), "INVALID_RETRY_MODE", "error response should identify retry mode validation failures")
+	require.NoError(t, mock.ExpectationsWereMet(), "invalid mode should not hit the database")
 }
 
 func TestSessionHandler_PushChangesToPR_SessionNotFound(t *testing.T) {

--- a/internal/db/session_thread_store.go
+++ b/internal/db/session_thread_store.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -36,6 +37,14 @@ const sessionThreadListColumns = `id, session_id, org_id, agent_type, model_over
 	failure_explanation, failure_category,
 	started_at, completed_at, created_at, archived_at,
 	base_snapshot_key, cost_cents, pending_message_count, cancel_requested_at`
+
+func qualifiedSessionThreadSelectColumns(alias string) string {
+	columns := strings.Split(sessionThreadSelectColumns, ",")
+	for i, column := range columns {
+		columns[i] = alias + "." + strings.TrimSpace(column)
+	}
+	return strings.Join(columns, ", ")
+}
 
 // ErrThreadLimitReached is returned when the maximum number of threads per session
 // has been reached and a new thread cannot be created.
@@ -106,6 +115,47 @@ func (s *SessionThreadStore) ListBySession(ctx context.Context, orgID, sessionID
 		return nil, fmt.Errorf("query session threads: %w", err)
 	}
 	return pgx.CollectRows(rows, pgx.RowToStructByName[models.SessionThread])
+}
+
+func (s *SessionThreadStore) GetRetryTarget(ctx context.Context, orgID, sessionID uuid.UUID) (models.SessionThread, error) {
+	query := `
+		WITH failed_thread AS (
+			SELECT ` + sessionThreadSelectColumns + `
+			FROM session_threads
+			WHERE org_id = @org_id
+			  AND session_id = @session_id
+			  AND archived_at IS NULL
+			  AND status = 'failed'
+			ORDER BY COALESCE(completed_at, last_activity_at, created_at) DESC, created_at DESC
+			LIMIT 1
+		), latest_user_thread AS (
+			SELECT ` + qualifiedSessionThreadSelectColumns("t") + `
+			FROM session_threads t
+			JOIN session_messages m
+			  ON m.thread_id = t.id
+			 AND m.org_id = t.org_id
+			 AND m.session_id = t.session_id
+			 AND m.role = 'user'
+			WHERE t.org_id = @org_id
+			  AND t.session_id = @session_id
+			  AND t.archived_at IS NULL
+			ORDER BY m.created_at DESC, m.id DESC
+			LIMIT 1
+		)
+		SELECT * FROM failed_thread
+		UNION ALL
+		SELECT * FROM latest_user_thread
+		WHERE NOT EXISTS (SELECT 1 FROM failed_thread)
+		LIMIT 1`
+
+	rows, err := s.db.Query(ctx, query, pgx.NamedArgs{
+		"org_id":     orgID,
+		"session_id": sessionID,
+	})
+	if err != nil {
+		return models.SessionThread{}, fmt.Errorf("query retry target thread: %w", err)
+	}
+	return pgx.CollectOneRow(rows, pgx.RowToStructByName[models.SessionThread])
 }
 
 func (s *SessionThreadStore) CountBySession(ctx context.Context, orgID, sessionID uuid.UUID) (int, error) {

--- a/internal/db/session_thread_store_test.go
+++ b/internal/db/session_thread_store_test.go
@@ -251,6 +251,72 @@ func TestSessionThreadStore_ListBySession_SelectsArchivedAt(t *testing.T) {
 	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
 }
 
+func TestSessionThreadStore_GetRetryTarget(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		rowStatus  models.ThreadStatus
+		expectErr  bool
+		queryMatch string
+	}{
+		{
+			name:       "prefers latest failed visible thread",
+			rowStatus:  models.ThreadStatusFailed,
+			queryMatch: `(?s)WITH failed_thread AS.*status = 'failed'.*latest_user_thread AS.*session_messages.*role = 'user'.*SELECT \* FROM failed_thread.*UNION ALL.*SELECT \* FROM latest_user_thread.*LIMIT 1`,
+		},
+		{
+			name:       "falls back to latest visible thread with user message",
+			rowStatus:  models.ThreadStatusCompleted,
+			queryMatch: `(?s)WITH failed_thread AS.*latest_user_thread AS.*session_messages.*SELECT \* FROM failed_thread.*UNION ALL.*SELECT \* FROM latest_user_thread.*LIMIT 1`,
+		},
+		{
+			name:       "returns error when no retry target exists",
+			expectErr:  true,
+			queryMatch: `(?s)WITH failed_thread AS.*latest_user_thread AS.*LIMIT 1`,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			mock, err := pgxmock.NewPool()
+			require.NoError(t, err, "should create mock pool")
+			defer mock.Close()
+
+			store := NewSessionThreadStore(mock)
+			orgID := uuid.New()
+			sessionID := uuid.New()
+			threadID := uuid.New()
+			now := time.Now()
+
+			rows := pgxmock.NewRows(sessionThreadTestColumns)
+			if !tt.expectErr {
+				row := newSessionThreadRow(threadID, sessionID, orgID, "Backend", now)
+				row[8] = tt.rowStatus
+				rows.AddRow(row...)
+			}
+
+			mock.ExpectQuery(tt.queryMatch).
+				WithArgs(anyArgs(2)...).
+				WillReturnRows(rows)
+
+			thread, err := store.GetRetryTarget(context.Background(), orgID, sessionID)
+			if tt.expectErr {
+				require.Error(t, err, "GetRetryTarget should return an error when no visible retry target exists")
+				require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
+				return
+			}
+			require.NoError(t, err, "GetRetryTarget should not return an error for a retryable session")
+			require.Equal(t, threadID, thread.ID, "GetRetryTarget should return the selected thread")
+			require.Equal(t, tt.rowStatus, thread.Status, "GetRetryTarget should preserve the selected thread status")
+			require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
+		})
+	}
+}
+
 func TestSessionThreadStore_ListStuckRunningThreads(t *testing.T) {
 	t.Parallel()
 

--- a/internal/integration/session_retry_test.go
+++ b/internal/integration/session_retry_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -49,7 +50,7 @@ func TestIntegration_RetrySession_ResetsAndReenqueues(t *testing.T) {
 
 	req := buildAuthedRequest(http.MethodPost,
 		"/api/v1/sessions/"+session.ID.String()+"/retry",
-		nil, orgID, &user, map[string]string{"id": session.ID.String()})
+		strings.NewReader(`{"mode":"start_over"}`), orgID, &user, map[string]string{"id": session.ID.String()})
 
 	rec := httptest.NewRecorder()
 	handler.RetrySession(rec, req)

--- a/internal/models/session_enums.go
+++ b/internal/models/session_enums.go
@@ -127,6 +127,23 @@ func (m SessionInteractionMode) Validate() error {
 	}
 }
 
+// SessionRetryMode controls how a failed session retry is dispatched.
+type SessionRetryMode string
+
+const (
+	SessionRetryModeCheckpoint SessionRetryMode = "checkpoint"
+	SessionRetryModeStartOver  SessionRetryMode = "start_over"
+)
+
+func (m SessionRetryMode) Validate() error {
+	switch m {
+	case SessionRetryModeCheckpoint, SessionRetryModeStartOver:
+		return nil
+	default:
+		return fmt.Errorf("invalid SessionRetryMode: %q", m)
+	}
+}
+
 // SessionValidationPolicy captures when validation should run for a session.
 type SessionValidationPolicy string
 

--- a/internal/models/session_enums_test.go
+++ b/internal/models/session_enums_test.go
@@ -153,6 +153,34 @@ func TestSessionInteractionMode_Validate(t *testing.T) {
 	}
 }
 
+func TestSessionRetryMode_Validate(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		value     SessionRetryMode
+		expectErr bool
+	}{
+		{name: "checkpoint", value: SessionRetryModeCheckpoint},
+		{name: "start over", value: SessionRetryModeStartOver},
+		{name: "invalid", value: SessionRetryMode("fresh"), expectErr: true},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := tt.value.Validate()
+			if tt.expectErr {
+				require.Error(t, err, "Validate should reject unknown retry modes")
+				return
+			}
+			require.NoError(t, err, "Validate should accept known retry modes")
+		})
+	}
+}
+
 func TestSessionValidationPolicy_Validate(t *testing.T) {
 	t.Parallel()
 

--- a/internal/models/session_retry.go
+++ b/internal/models/session_retry.go
@@ -1,0 +1,7 @@
+package models
+
+// RetrySessionRequest is the optional body for POST /api/v1/sessions/{id}/retry.
+// An omitted mode defaults to SessionRetryModeCheckpoint at the handler layer.
+type RetrySessionRequest struct {
+	Mode SessionRetryMode `json:"mode,omitempty"`
+}


### PR DESCRIPTION
## Summary
- Add an explicit retry mode API so failed sessions default to a safe resume path while preserving the existing destructive restart path behind `Start over from beginning`
- Route the default retry flow through the latest available thread and continue-session worker instead of resetting the session state
- Update the session detail UI to split retry actions, disable the primary action when no saved progress is available, and require confirmation for start-over
- Add backend, integration, and frontend test coverage for the new retry behavior and UI states

## Testing
- Added unit and handler tests for retry mode validation, checkpoint-style retry selection, and start-over behavior
- Added frontend tests for the split retry action, disabled state, and confirmation flow
- Verified the change with backend checks and frontend typecheck, lint, and production build