### PR TITLE
Fix queued sibling thread review drains in agent orchestrator

### DIFF
--- a/internal/services/agent/orchestrator.go
+++ b/internal/services/agent/orchestrator.go
@@ -3908,15 +3908,11 @@ func (o *Orchestrator) drainQueuedMessagesAfterProcessedID(ctx context.Context, 
 		if m.Role != models.MessageRoleUser || m.ID <= processedMessageID {
 			continue
 		}
-		// On the thread path, a queued message is bound to the same thread —
-		// we drain only the matching thread's queue. On the session path
-		// threadID is nil and we accept any user message that matches the
-		// session-level scope (no thread).
-		if threadID != nil {
-			if m.ThreadID == nil || *m.ThreadID != *threadID {
-				continue
-			}
-		} else if m.ThreadID != nil {
+		// On the session path threadID is nil and we accept only a
+		// session-level queued message. On the thread path, any newer user
+		// message is drainable: SendMessage can queue a sibling thread while
+		// another thread owns the shared parent session.
+		if threadID == nil && m.ThreadID != nil {
 			continue
 		}
 		queued = &messages[i]
@@ -3939,19 +3935,20 @@ func (o *Orchestrator) drainQueuedMessagesAfterProcessedID(ctx context.Context, 
 		return
 	}
 
-	if threadID != nil && o.sessionThreads != nil {
-		if err := o.sessionThreads.ClearPendingMessages(ctx, session.OrgID, *threadID); err != nil {
-			log.Warn().Err(err).Str("thread_id", threadID.String()).Msg("failed to clear pending_message_count after drain")
+	queuedThreadID := queued.ThreadID
+	if queuedThreadID != nil && o.sessionThreads != nil {
+		if err := o.sessionThreads.ClearPendingMessages(ctx, session.OrgID, *queuedThreadID); err != nil {
+			log.Warn().Err(err).Str("thread_id", queuedThreadID.String()).Msg("failed to clear pending_message_count after drain")
 		}
 	}
 	payload := map[string]string{
 		"session_id": session.ID.String(),
 		"org_id":     session.OrgID.String(),
 	}
-	if threadID != nil {
-		payload["thread_id"] = threadID.String()
+	if queuedThreadID != nil {
+		payload["thread_id"] = queuedThreadID.String()
 	}
-	if requestID := o.answerQueuedHumanInputRequest(ctx, session, queued, threadID, log); requestID != nil {
+	if requestID := o.answerQueuedHumanInputRequest(ctx, session, queued, queuedThreadID, log); requestID != nil {
 		payload["human_input_request_id"] = requestID.String()
 	}
 	dedupeKey := continueSessionDrainDedupeKey(session.ID, processedMessageID)

--- a/internal/services/agent/orchestrator_drain_internal_test.go
+++ b/internal/services/agent/orchestrator_drain_internal_test.go
@@ -383,7 +383,7 @@ func TestDrainQueuedMessages_LinearPromptedRunningSessionContract(t *testing.T) 
 	require.Equal(t, continueSessionDrainDedupeKey(sessionID, processedID), jobs.enqueues[0].dedupeKey, "drain must use the drain-specific dedupe key — reusing the active continue_session key would collide with the still-running job")
 }
 
-func TestDrainQueuedMessages_ThreadScopeIgnoresOtherThreads(t *testing.T) {
+func TestDrainQueuedMessages_ThreadScopeDrainsQueuedSiblingThread(t *testing.T) {
 	t.Parallel()
 
 	orgID := uuid.New()
@@ -403,8 +403,10 @@ func TestDrainQueuedMessages_ThreadScopeIgnoresOtherThreads(t *testing.T) {
 
 	o.drainQueuedMessages(context.Background(), &models.Session{ID: sessionID, OrgID: orgID}, processed, &threadA, zerolog.Nop())
 
-	require.Empty(t, jobs.enqueues, "drain must ignore newer messages on a different thread")
-	require.Empty(t, threads.clearedThreadIDs, "no clear should fire when there is nothing to drain")
+	require.Equal(t, []uuid.UUID{threadB}, threads.clearedThreadIDs, "pending_message_count must be cleared for the queued sibling thread")
+	require.Len(t, jobs.enqueues, 1, "thread-scope drain must enqueue continue_session for a queued sibling thread")
+	payload := jobs.enqueues[0].payload.(map[string]string)
+	require.Equal(t, threadB.String(), payload["thread_id"], "thread-scope drain must target the queued sibling thread")
 }
 
 func TestDrainQueuedMessages_ThreadScopeClearsAndEnqueues(t *testing.T) {


### PR DESCRIPTION
## Summary
- Allow the post-turn drain to pick up queued sibling-thread messages instead of only same-thread queue entries.
- Clear `pending_message_count` and enqueue `continue_session` for the queued thread that actually owns the message.
- Add a regression test covering the sibling-thread review case that was stranded in production.

## Testing
- Added/updated unit coverage in `internal/services/agent/orchestrator_drain_internal_test.go`.
- Verified `go vet ./...`, `go build ./...`, and `go test ./...` pass.