### PR TITLE
Add Docs link to homepage navigation and footer

### DIFF
--- a/frontend/src/components/landing/footer.test.tsx
+++ b/frontend/src/components/landing/footer.test.tsx
@@ -1,0 +1,13 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import Footer from "./footer";
+
+describe("Footer", () => {
+  it("links to the public docs from the project links", () => {
+    render(<Footer isDark={false} />);
+
+    const docsLink = screen.getByRole("link", { name: "Docs" });
+
+    expect(docsLink).toHaveAttribute("href", "/docs");
+  });
+});

--- a/frontend/src/components/landing/footer.tsx
+++ b/frontend/src/components/landing/footer.tsx
@@ -56,6 +56,14 @@ export default function Footer({ isDark }: FooterProps) {
                   </Link>
                 </li>
                 <li>
+                  <Link
+                    href="/docs"
+                    className={`${type.footerLink} ${isDark ? "text-white/30 hover:text-white/60" : "text-slate-500 hover:text-slate-700"} transition-colors`}
+                  >
+                    Docs
+                  </Link>
+                </li>
+                <li>
                   <a
                     href="https://github.com/assembledhq/143"
                     target="_blank"

--- a/frontend/src/components/landing/hero-section.test.tsx
+++ b/frontend/src/components/landing/hero-section.test.tsx
@@ -1,0 +1,19 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import HeroSection from "./hero-section";
+
+vi.mock("./hero-canvas", () => ({
+  default: () => <div data-testid="hero-canvas" />,
+  DARK: { bg: "#08080f" },
+  LIGHT: { bg: "#FAFAFB" },
+}));
+
+describe("HeroSection", () => {
+  it("links to the public docs from the homepage navigation", () => {
+    render(<HeroSection isDark={false} />);
+
+    const docsLink = screen.getByRole("link", { name: "Docs" });
+
+    expect(docsLink).toHaveAttribute("href", "/docs");
+  });
+});

--- a/frontend/src/components/landing/hero-section.tsx
+++ b/frontend/src/components/landing/hero-section.tsx
@@ -41,6 +41,17 @@ export default function HeroSection({ isDark }: HeroSectionProps) {
           <Button
             asChild
             variant="ghost"
+            className={`${type.button} ${
+              isDark
+                ? "text-white/60 hover:bg-white/5 hover:text-white"
+                : "text-slate-600 hover:bg-slate-900/5 hover:text-slate-900"
+            }`}
+          >
+            <Link href="/docs">Docs</Link>
+          </Button>
+          <Button
+            asChild
+            variant="ghost"
             className={`hidden ${type.button} sm:inline-flex ${
               isDark
                 ? "text-white/60 hover:bg-white/5 hover:text-white"


### PR DESCRIPTION
## Summary

Added `/docs` discovery to the homepage:

- Top landing nav now includes a visible `Docs` link: [hero-section.tsx](/home/sandbox/143/frontend/src/components/landing/hero-section.tsx:40)
- Footer Project links now include `Docs`: [footer.tsx](/home/sandbox/143/frontend/src/components/landing/footer.tsx:58)
- Added regression tests for both links.

Verification passed from `frontend/`:
- `npm run test:ci -- src/components/landing/hero-section.test.tsx src/components/landing/footer.test.tsx`
- `npm run typecheck`
- `npm run lint`
- `npm run build`

Build still emits the existing Next.js middleware deprecation warning, but completes successfully.

## Test plan

Validated by automated agent run.


[143.dev](https://143.dev) | [session a3ec226d](https://143.dev/sessions/a3ec226d-5ba8-4998-91c7-cfc8af584ebe)

Preview: https://143.dev/previews/github/assembledhq/143/pull/1136