### PR TITLE
Bootstrap branch preview opens before navigating to preview origin

### DIFF
--- a/frontend/src/app/(dashboard)/previews/[id]/page.tsx
+++ b/frontend/src/app/(dashboard)/previews/[id]/page.tsx
@@ -2,10 +2,11 @@
 
 import { use } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { AlertTriangle, ExternalLink, GitBranch, GitPullRequest, KeyRound, RotateCw, Square } from "lucide-react";
+import { AlertTriangle, GitBranch, GitPullRequest, KeyRound, RotateCw, Square } from "lucide-react";
 
 import { PageContainer } from "@/components/page-container";
 import { PageHeader } from "@/components/page-header";
+import { OpenPreviewButton } from "@/components/preview/open-preview-button";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
@@ -70,20 +71,10 @@ export default function PreviewLandingPage({
           <Card>
             <CardContent className="pt-4 pb-4">
               <div className="flex items-center gap-3">
-                <a
-                  href={safeExternalUrl(preview!.preview_url)}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="flex-1 truncate font-mono text-sm text-foreground underline-offset-4 hover:underline"
-                >
+                <p className="flex-1 truncate font-mono text-sm text-foreground">
                   {preview!.preview_url}
-                </a>
-                <Button asChild size="sm">
-                  <a href={safeExternalUrl(preview!.preview_url)} target="_blank" rel="noopener noreferrer">
-                    <ExternalLink className="h-4 w-4" />
-                    Open preview
-                  </a>
-                </Button>
+                </p>
+                <OpenPreviewButton previewId={preview?.preview_id} previewUrl={preview?.preview_url} size="sm" />
               </div>
             </CardContent>
           </Card>

--- a/frontend/src/app/(dashboard)/previews/github/[owner]/[repo]/pull/[number]/page.test.tsx
+++ b/frontend/src/app/(dashboard)/previews/github/[owner]/[repo]/pull/[number]/page.test.tsx
@@ -1,0 +1,101 @@
+import { act } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { http, HttpResponse } from "msw";
+
+import { renderWithProviders, screen, userEvent, waitFor } from "@/test/test-utils";
+import { server } from "@/test/mocks/server";
+import {
+  PREVIEW_BOOTSTRAP_COMPLETE_EVENT,
+  PREVIEW_BOOTSTRAP_READY_EVENT,
+} from "@/lib/preview-bootstrap";
+import { PullRequestPreviewContent } from "./page";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("PullRequestPreviewPage", () => {
+  it("bootstraps preview access before opening the preview origin", async () => {
+    let bootstrapCalls = 0;
+    const openedWindow = {
+      close: vi.fn(),
+      document: {
+        close: vi.fn(),
+        write: vi.fn(),
+      },
+      location: {
+        href: "about:blank",
+      },
+      opener: null,
+    } as unknown as Window;
+    const openSpy = vi.spyOn(window, "open").mockReturnValue(openedWindow);
+
+    server.use(
+      http.get("*/api/v1/previews/github/acme/web/pull/42", () =>
+        HttpResponse.json({
+          data: {
+            target_id: "target-1",
+            preview_id: "prev-1",
+            repository_id: "repo-1",
+            repository_full_name: "acme/web",
+            branch: "feature/preview",
+            commit_sha: "529975ce1faa2961ef3f23abde2418bf561116d9",
+            source_type: "pull_request",
+            status: "ready",
+            current_phase: "ready",
+            stable_url: "https://143.dev/previews/github/acme/web/pull/42",
+            preview_url: "https://prev-1.preview.143.dev",
+            pull_request_url: "https://github.com/acme/web/pull/42",
+          },
+        }),
+      ),
+      http.post("*/api/v1/previews/prev-1/bootstrap", () => {
+        bootstrapCalls += 1;
+        return HttpResponse.json({
+          data: {
+            token: "bootstrap-token",
+            preview_id: "prev-1",
+          },
+        });
+      }),
+    );
+
+    renderWithProviders(<PullRequestPreviewContent owner="acme" repo="web" number="42" />);
+
+    await userEvent.click(await screen.findByRole("button", { name: /open preview/i }));
+
+    expect(openSpy).toHaveBeenCalledWith("about:blank", "_blank");
+    expect(screen.getByTitle("Preview bootstrap")).toHaveAttribute(
+      "src",
+      "https://prev-1.preview.143.dev/bootstrap",
+    );
+    expect(openedWindow.location.href).toBe("about:blank");
+
+    act(() => {
+      window.dispatchEvent(
+        new MessageEvent("message", {
+          origin: "https://prev-1.preview.143.dev",
+          data: { type: PREVIEW_BOOTSTRAP_READY_EVENT },
+        }),
+      );
+    });
+
+    await waitFor(() => {
+      expect(bootstrapCalls).toBe(1);
+    });
+    expect(openedWindow.location.href).toBe("about:blank");
+
+    act(() => {
+      window.dispatchEvent(
+        new MessageEvent("message", {
+          origin: "https://prev-1.preview.143.dev",
+          data: { type: PREVIEW_BOOTSTRAP_COMPLETE_EVENT },
+        }),
+      );
+    });
+
+    await waitFor(() => {
+      expect(openedWindow.location.href).toBe("https://prev-1.preview.143.dev");
+    });
+  });
+});

--- a/frontend/src/app/(dashboard)/previews/github/[owner]/[repo]/pull/[number]/page.tsx
+++ b/frontend/src/app/(dashboard)/previews/github/[owner]/[repo]/pull/[number]/page.tsx
@@ -2,10 +2,11 @@
 
 import { use } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { AlertTriangle, ExternalLink, GitBranch, GitPullRequest, RotateCw } from "lucide-react";
+import { AlertTriangle, GitBranch, GitPullRequest, RotateCw } from "lucide-react";
 
 import { PageContainer } from "@/components/page-container";
 import { PageHeader } from "@/components/page-header";
+import { OpenPreviewButton } from "@/components/preview/open-preview-button";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
@@ -19,6 +20,18 @@ export default function PullRequestPreviewPage({
   params: Promise<{ owner: string; repo: string; number: string }>;
 }) {
   const { owner, repo, number } = use(params);
+  return <PullRequestPreviewContent owner={owner} repo={repo} number={number} />;
+}
+
+export function PullRequestPreviewContent({
+  owner,
+  repo,
+  number,
+}: {
+  owner: string;
+  repo: string;
+  number: string;
+}) {
   const queryClient = useQueryClient();
   const queryKey = ["branch-preview-pr", owner, repo, number];
   const previewQuery = useQuery<SingleResponse<BranchPreviewResponse>>({
@@ -150,13 +163,8 @@ export default function PullRequestPreviewPage({
                 ) : null}
 
                 <div className="flex flex-col gap-2 sm:flex-row">
-                  {safeExternalUrl(preview.preview_url) ? (
-                    <Button asChild>
-                      <a href={safeExternalUrl(preview.preview_url)} target="_blank" rel="noopener noreferrer">
-                        <ExternalLink className="h-4 w-4" />
-                        Open preview
-                      </a>
-                    </Button>
+                  {safeExternalUrl(preview.preview_url) && preview.preview_id ? (
+                    <OpenPreviewButton previewId={preview.preview_id} previewUrl={preview.preview_url} />
                   ) : null}
                   {safeExternalUrl(preview.pull_request_url) ? (
                     <Button asChild variant="outline">

--- a/frontend/src/app/(dashboard)/previews/links/[link_type]/[...slug]/page.tsx
+++ b/frontend/src/app/(dashboard)/previews/links/[link_type]/[...slug]/page.tsx
@@ -2,10 +2,11 @@
 
 import { use } from "react";
 import { useQuery } from "@tanstack/react-query";
-import { ExternalLink, GitBranch } from "lucide-react";
+import { GitBranch } from "lucide-react";
 
 import { PageContainer } from "@/components/page-container";
 import { PageHeader } from "@/components/page-header";
+import { OpenPreviewButton } from "@/components/preview/open-preview-button";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
@@ -55,13 +56,8 @@ export default function PreviewStableLinkPage({
                   </div>
                 </div>
                 <div className="flex flex-col gap-2 sm:flex-row">
-                  {safeExternalUrl(preview.preview_url) ? (
-                    <Button asChild>
-                      <a href={safeExternalUrl(preview.preview_url)} target="_blank" rel="noopener noreferrer">
-                        <ExternalLink className="h-4 w-4" />
-                        Open preview
-                      </a>
-                    </Button>
+                  {safeExternalUrl(preview.preview_url) && preview.preview_id ? (
+                    <OpenPreviewButton previewId={preview.preview_id} previewUrl={preview.preview_url} />
                   ) : null}
                   <Button asChild variant="outline">
                     <a href={`/previews/${preview.preview_id ?? preview.target_id}`}>

--- a/frontend/src/components/preview/open-preview-button.tsx
+++ b/frontend/src/components/preview/open-preview-button.tsx
@@ -1,0 +1,201 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useRef, useState, type ComponentProps } from "react";
+import { useMutation } from "@tanstack/react-query";
+import { ExternalLink, Loader2 } from "lucide-react";
+import { toast } from "sonner";
+
+import { Button } from "@/components/ui/button";
+import { api } from "@/lib/api";
+import {
+  buildPreviewBootstrapSrc,
+  PREVIEW_BOOTSTRAP_COMPLETE_EVENT,
+  PREVIEW_BOOTSTRAP_READY_EVENT,
+  PREVIEW_BOOTSTRAP_TOKEN_EVENT,
+  previewOriginFromURL,
+} from "@/lib/preview-bootstrap";
+import { safeExternalUrl } from "@/lib/utils";
+
+const BOOTSTRAP_TIMEOUT_MS = 15_000;
+
+type PendingOpen = {
+  previewID: string;
+  previewURL: string;
+  origin: string;
+  popup: Window | null;
+  tokenRequested: boolean;
+};
+
+export type OpenPreviewButtonProps = {
+  previewId: string | undefined | null;
+  previewUrl: string | undefined | null;
+  label?: string;
+  disabled?: boolean;
+  variant?: ComponentProps<typeof Button>["variant"];
+  size?: ComponentProps<typeof Button>["size"];
+  className?: string;
+};
+
+export function OpenPreviewButton({
+  previewId,
+  previewUrl,
+  label = "Open preview",
+  disabled,
+  variant,
+  size,
+  className,
+}: OpenPreviewButtonProps) {
+  const iframeRef = useRef<HTMLIFrameElement | null>(null);
+  const pendingRef = useRef<PendingOpen | null>(null);
+  const timeoutRef = useRef<number | null>(null);
+  const [iframeSrc, setIframeSrc] = useState<string | undefined>();
+  const [isOpening, setIsOpening] = useState(false);
+
+  const safePreviewURL = useMemo(() => safeExternalUrl(previewUrl), [previewUrl]);
+  const previewOrigin = useMemo(
+    () => (safePreviewURL ? previewOriginFromURL(safePreviewURL) : undefined),
+    [safePreviewURL],
+  );
+
+  const clearTimeoutRef = useCallback(() => {
+    if (timeoutRef.current !== null) {
+      window.clearTimeout(timeoutRef.current);
+      timeoutRef.current = null;
+    }
+  }, []);
+
+  const resetPendingOpen = useCallback(() => {
+    clearTimeoutRef();
+    pendingRef.current = null;
+    setIframeSrc(undefined);
+    setIsOpening(false);
+  }, [clearTimeoutRef]);
+
+  const failOpen = useCallback(
+    (message: string) => {
+      const pending = pendingRef.current;
+      pending?.popup?.close();
+      resetPendingOpen();
+      toast.error(message);
+    },
+    [resetPendingOpen],
+  );
+
+  const bootstrapMutation = useMutation({
+    mutationFn: (id: string) => api.previews.bootstrap(id),
+    onSuccess: (response) => {
+      const pending = pendingRef.current;
+      const token = response.data.token;
+      if (!pending || !token) return;
+
+      const contentWindow = iframeRef.current?.contentWindow;
+      if (!contentWindow) {
+        failOpen("Could not connect to the preview. Try opening it again.");
+        return;
+      }
+      contentWindow.postMessage(
+        { type: PREVIEW_BOOTSTRAP_TOKEN_EVENT, token },
+        pending.origin,
+      );
+    },
+    onError: (error) => {
+      failOpen(error instanceof Error ? error.message : "Could not create preview access.");
+    },
+  });
+
+  const openPreview = useCallback(() => {
+    if (!previewId || !safePreviewURL || !previewOrigin) {
+      toast.error("Preview link is unavailable.");
+      return;
+    }
+
+    let popup: Window | null = null;
+    try {
+      popup = window.open("about:blank", "_blank");
+      if (popup) {
+        popup.opener = null;
+        popup.document.write("<!doctype html><title>Opening preview</title><p>Opening preview...</p>");
+        popup.document.close();
+      }
+    } catch {
+      popup = null;
+    }
+
+    if (!popup) {
+      toast.error("Your browser blocked the preview tab. Allow pop-ups and try again.");
+      return;
+    }
+
+    clearTimeoutRef();
+    const nextPending: PendingOpen = {
+      previewID: previewId,
+      previewURL: safePreviewURL,
+      origin: previewOrigin,
+      popup,
+      tokenRequested: false,
+    };
+    pendingRef.current = nextPending;
+    setIsOpening(true);
+    setIframeSrc(buildPreviewBootstrapSrc(previewOrigin));
+    timeoutRef.current = window.setTimeout(() => {
+      failOpen("Preview bootstrap timed out. Try opening it again.");
+    }, BOOTSTRAP_TIMEOUT_MS);
+  }, [clearTimeoutRef, failOpen, previewId, previewOrigin, safePreviewURL]);
+
+  useEffect(() => {
+    const handleMessage = (event: MessageEvent) => {
+      const pending = pendingRef.current;
+      if (!pending || event.origin !== pending.origin) return;
+
+      if (event.data?.type === PREVIEW_BOOTSTRAP_READY_EVENT) {
+        if (pending.tokenRequested) return;
+        pending.tokenRequested = true;
+        bootstrapMutation.mutate(pending.previewID);
+        return;
+      }
+
+      if (event.data?.type === PREVIEW_BOOTSTRAP_COMPLETE_EVENT) {
+        if (pending.popup) {
+          pending.popup.location.href = pending.previewURL;
+        }
+        resetPendingOpen();
+      }
+    };
+
+    window.addEventListener("message", handleMessage);
+    return () => window.removeEventListener("message", handleMessage);
+  }, [bootstrapMutation, resetPendingOpen]);
+
+  useEffect(() => {
+    return () => {
+      clearTimeoutRef();
+      pendingRef.current?.popup?.close();
+      pendingRef.current = null;
+    };
+  }, [clearTimeoutRef]);
+
+  return (
+    <>
+      <Button
+        type="button"
+        variant={variant}
+        size={size}
+        className={className}
+        onClick={openPreview}
+        disabled={disabled || isOpening || !previewId || !safePreviewURL || !previewOrigin}
+      >
+        {isOpening ? <Loader2 className="h-4 w-4 animate-spin" /> : <ExternalLink className="h-4 w-4" />}
+        {isOpening ? "Opening..." : label}
+      </Button>
+      {iframeSrc ? (
+        <iframe
+          ref={iframeRef}
+          src={iframeSrc}
+          title="Preview bootstrap"
+          className="sr-only"
+          aria-hidden="true"
+        />
+      ) : null}
+    </>
+  );
+}

--- a/frontend/src/components/preview/preview-panel.tsx
+++ b/frontend/src/components/preview/preview-panel.tsx
@@ -52,12 +52,16 @@ import { ConsoleBadge } from "./console-badge";
 import { DesignModeOverlay } from "./design-mode-overlay";
 import { ErrorBoundary } from "@/components/error-boundary";
 import { TTLWarning } from "./ttl-warning";
+import {
+  buildPreviewBootstrapSrc,
+  PREVIEW_BOOTSTRAP_READY_EVENT,
+  PREVIEW_BOOTSTRAP_TOKEN_EVENT,
+} from "@/lib/preview-bootstrap";
 
-export const PREVIEW_BOOTSTRAP_READY_EVENT = "preview_bootstrap_ready";
-export const PREVIEW_BOOTSTRAP_TOKEN_EVENT = "preview_bootstrap_token";
+export { PREVIEW_BOOTSTRAP_READY_EVENT, PREVIEW_BOOTSTRAP_TOKEN_EVENT };
 
 export function buildPreviewIframeSrc(previewOrigin: string): string {
-  return `${previewOrigin}/bootstrap`;
+  return buildPreviewBootstrapSrc(previewOrigin);
 }
 
 export interface PreviewPanelProps {

--- a/frontend/src/lib/preview-bootstrap.ts
+++ b/frontend/src/lib/preview-bootstrap.ts
@@ -1,0 +1,17 @@
+export const PREVIEW_BOOTSTRAP_READY_EVENT = "preview_bootstrap_ready";
+export const PREVIEW_BOOTSTRAP_TOKEN_EVENT = "preview_bootstrap_token";
+export const PREVIEW_BOOTSTRAP_COMPLETE_EVENT = "preview_bootstrap_complete";
+
+export function previewOriginFromURL(previewURL: string): string | undefined {
+  try {
+    const parsed = new URL(previewURL);
+    if (parsed.protocol !== "https:") return undefined;
+    return parsed.origin;
+  } catch {
+    return undefined;
+  }
+}
+
+export function buildPreviewBootstrapSrc(previewOrigin: string): string {
+  return `${previewOrigin.replace(/\/+$/, "")}/bootstrap`;
+}

--- a/internal/api/gateway/preview_gateway.go
+++ b/internal/api/gateway/preview_gateway.go
@@ -199,6 +199,9 @@ const bootstrapHTML = `<!DOCTYPE html>
       credentials: 'same-origin'
     }).then(function(resp) {
       if (resp.ok) {
+        if (window.parent !== window) {
+          window.parent.postMessage({type: 'preview_bootstrap_complete'}, appOrigin);
+        }
         window.location.href = '/';
       } else {
         document.body.textContent = 'Bootstrap failed: ' + resp.status;

--- a/internal/api/gateway/preview_gateway_test.go
+++ b/internal/api/gateway/preview_gateway_test.go
@@ -536,6 +536,7 @@ func TestGateway_ServeHTTP_BootstrapPage(t *testing.T) {
 	require.Contains(t, w.Header().Get("Content-Type"), "text/html")
 	require.Contains(t, w.Body.String(), "https://app.143.dev")
 	require.Contains(t, w.Body.String(), "preview_bootstrap_token")
+	require.Contains(t, w.Body.String(), "preview_bootstrap_complete", "bootstrap page should notify the parent after the gateway sets the preview session cookie")
 }
 
 func TestGateway_ServeHTTP_BootstrapExchange_MissingToken(t *testing.T) {


### PR DESCRIPTION
## Summary
- Route branch, PR, and stable preview entrypoints through a shared bootstrap flow instead of linking directly to the raw preview origin.
- Add a reusable `OpenPreviewButton` that opens a blank tab, completes preview bootstrap, then navigates after the gateway sets the session cookie.
- Teach the preview gateway bootstrap page to emit a completion event after successful cookie exchange.
- Add regression coverage for the PR preview page and the gateway bootstrap HTML.

## Testing
- Added a new frontend regression test for the PR preview open flow.
- Added gateway HTML coverage for the bootstrap completion signal.
- Verified locally with frontend typecheck, lint, and production build, plus `go vet`, `go build`, and `go test` across the repo.