### PR TITLE
Update previews docs for “managed credential set” legacy preview.credentials guidance

### DIFF
--- a/docs/public/guides/previews.mdx
+++ b/docs/public/guides/previews.mdx
@@ -233,7 +233,7 @@ The value stored for `development_conf_json` should be the raw JSON document, in
 
 Use `format: "raw"` for non-JSON file blobs such as PEM blocks or certificates. User-provided base64 is only needed when the application itself expects base64; it is not needed to protect JSON from shell quoting.
 
-The older `preview.credentials` shape is still accepted for env-var-only credential sets:
+The older `preview.credentials` shape is still accepted for an env-var-only managed credential set:
 
 ```json
 {


### PR DESCRIPTION
## Summary
Adjust the legacy `preview.credentials` documentation to include the expected wording “managed credential set”. This fixes the failing public docs test that asserts this exact phrase.

## Changes
- **docs/public/guides/previews.mdx**
  - Updated the legacy `preview.credentials` guidance sentence to read “env-var-only managed credential set” (aligns with test expectations).

## Test plan
- `npm run test -- src/lib/docs/public-docs.test.ts`
- `npm run typecheck`
- `npm run lint`
- `npm run build`

[143.dev](https://143.dev) | [session fcee3524](https://143.dev/sessions/fcee3524-9c71-40a1-8af1-75886a99f188)

Preview: https://143.dev/previews/github/assembledhq/143/pull/1141