### PR TITLE
Fix race in SSE stream test by using lockedRecorder for ResponseRecorder access

### DIFF
--- a/internal/api/handlers/sessions_test.go
+++ b/internal/api/handlers/sessions_test.go
@@ -3213,7 +3213,7 @@ func TestSessionHandler_StreamLogsViaRedis_StatusPayloadIncludesThreads(t *testi
 				AddRow(sessionHandlerThreadRow(threadID, runID, orgID, "Main", models.ThreadStatusRunning, 2, now)...),
 		)
 
-	rec := httptest.NewRecorder()
+	rec := newLockedRecorder()
 	sw := sse.NewWriter(rec)
 	require.NotNil(t, sw, "SSE writer should initialize")
 
@@ -3224,7 +3224,7 @@ func TestSessionHandler_StreamLogsViaRedis_StatusPayloadIncludesThreads(t *testi
 	}()
 
 	require.Eventually(t, func() bool {
-		return strings.Contains(rec.Body.String(), "event: status")
+		return strings.Contains(rec.BodyString(), "event: status")
 	}, 2*time.Second, 20*time.Millisecond, "Redis stream helper should emit the initial status event")
 	cancel()
 
@@ -3239,7 +3239,7 @@ func TestSessionHandler_StreamLogsViaRedis_StatusPayloadIncludesThreads(t *testi
 		ID      uuid.UUID              `json:"id"`
 		Threads []models.SessionThread `json:"threads"`
 	}
-	require.NoError(t, json.Unmarshal([]byte(extractSSEData(t, rec.Body.String(), "status")), &payload), "status event data should decode as SessionDetail")
+	require.NoError(t, json.Unmarshal([]byte(extractSSEData(t, rec.BodyString(), "status")), &payload), "status event data should decode as SessionDetail")
 	require.Equal(t, runID, payload.ID, "status payload should preserve the session id")
 	require.Equal(t, []models.SessionThread{{
 		ID:                  threadID,


### PR DESCRIPTION
## Summary
This change fixes a data race in the SSE stream test caused by concurrently writing to and reading `httptest.ResponseRecorder`’s buffer. The test now uses the existing `lockedRecorder` and reads via `BodyString()` to ensure mutex protection while the SSE writer emits events.

## Changes
- **internal/api/handlers/sessions_test.go**
  - Updated `TestSessionHandler_StreamLogsViaRedis_StatusPayloadIncludesThreads` to use `newLockedRecorder()` instead of `httptest.NewRecorder()`.
  - Switched polling and JSON extraction from `rec.Body.String()` to `rec.BodyString()` so reads are synchronized with concurrent SSE writes.

## Test plan
- Ran: `go test ./internal/api/handlers -run TestSessionHandler_StreamLogsViaRedis_StatusPayloadIncludesThreads -count=1`
- Ran: `go vet ./...`
- Ran: `go build ./...`
- Ran: `go test ./...`

[143.dev](https://143.dev) | [session 7edfb30d](https://143.dev/sessions/7edfb30d-5d4b-4ef2-843d-def25dfcccf0)

Preview: https://143.dev/previews/github/assembledhq/143/pull/1147