### PR TITLE
Fix overlapping session detail toggle on narrow screens

### DIFF
--- a/frontend/src/app/(dashboard)/sessions/[id]/page.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/page.test.tsx
@@ -748,6 +748,14 @@ describe('SessionDetailPage', () => {
     expect(screen.getByTestId('session-detail-header-bar')).toHaveClass('h-full');
   });
 
+  it('clips crowded session header metadata before it can overlap the detail toggle', async () => {
+    renderWithProviders(<SessionDetailContent id="session-abcdef12-3456-7890" />);
+    await screen.findAllByText('Fixed TypeError by adding null check');
+
+    expect(screen.getByTestId('session-header-summary')).toHaveClass('overflow-hidden');
+    expect(screen.getByTestId('session-header-actions')).toHaveClass('shrink-0');
+  });
+
   it('uses a dedicated mobile close button that does not compete with PR actions', async () => {
     vi.mocked(window.matchMedia).mockImplementation((query: string) => ({
       matches: query === '(max-width: 767px)',

--- a/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
@@ -5309,7 +5309,10 @@ export function SessionDetailContent({ id }: { id: string }) {
                 SESSION_HEADER_HEIGHT_CLASSNAME,
               )}
             >
-              <div className="min-w-0 flex-1 flex items-center gap-2">
+              <div
+                data-testid="session-header-summary"
+                className="min-w-0 flex-1 overflow-hidden flex items-center gap-2"
+              >
                 {isEditingTitle ? (
                   <div className="min-w-0 flex-1 flex items-center gap-2">
                     <Input
@@ -5377,7 +5380,7 @@ export function SessionDetailContent({ id }: { id: string }) {
                 )}
                 <LinkedIssueChips session={session} />
               </div>
-              <div className="flex items-center gap-2" data-testid="session-header-actions">
+              <div className="flex shrink-0 items-center gap-2" data-testid="session-header-actions">
                 <DisabledTooltip disabled={centerMode === "review" && showDetailPanel} content={detailToggleTitle}>
                   <Button
                     variant="ghost"


### PR DESCRIPTION
## Summary
Fixes a small-width layout issue where the session header metadata could overlap the “detail toggle” action. The header summary area now clips overflow and the action area is prevented from shrinking, and a regression test was added to guard against future CSS/layout regressions.

## Changes
- **frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx**
  - Updated the session header metadata container to use `overflow-hidden` (`data-testid="session-header-summary"`) so it can’t render on top of the toggle at narrow widths.
  - Updated the detail toggle/action container to be non-shrinking (`className` now includes `shrink-0`) to keep it usable even when space is tight.
- **frontend/src/app/(dashboard)/sessions/[id]/page.test.tsx**
  - Added regression test **“clips crowded session header metadata before it can overlap the detail toggle”** verifying:
    - `session-header-summary` has `overflow-hidden`
    - `session-header-actions` has `shrink-0`

## Test plan
- Ran the new focused regression test.
- Verified:
  - `npm run typecheck`
  - `npm run lint`
  - `npm run build`

[143.dev](https://143.dev) | [session ccecc6fe](https://143.dev/sessions/ccecc6fe-c6a8-4022-97ca-aa71f22cf23d)

Preview: https://143.dev/previews/github/assembledhq/143/pull/1149