### PR TITLE
Fallback to /proc when preview cleanup cannot use lsof

### DIFF
--- a/internal/services/preview/providers/docker_preview.go
+++ b/internal/services/preview/providers/docker_preview.go
@@ -549,7 +549,25 @@ func buildTerminateServiceProcessCmd(pid, port int) string {
 
 	var portPIDs string
 	if port > 0 {
-		portPIDs = fmt.Sprintf("if command -v lsof >/dev/null 2>&1; then lsof -ti :%d 2>/dev/null || true; fi", port)
+		portPIDs = fmt.Sprintf(`{
+	if command -v lsof >/dev/null 2>&1; then lsof -ti :%d 2>/dev/null || true; fi
+	port_hex="$(printf '%%04X' %d)"
+	for table in /proc/net/tcp /proc/net/tcp6; do
+		[ -r "$table" ] || continue
+		awk -v p="$port_hex" '$2 ~ ":" p "$" { print $10 }' "$table"
+	done | while IFS= read -r inode; do
+		[ -n "$inode" ] || continue
+		for fd in /proc/[0-9]*/fd/*; do
+			[ -e "$fd" ] || continue
+			target="$(readlink "$fd" 2>/dev/null || true)"
+			if [ "$target" = "socket:[$inode]" ]; then
+				pid="${fd#/proc/}"
+				pid="${pid%%%%/*}"
+				printf '%%s\n' "$pid"
+			fi
+		done
+	done
+}`, port, port)
 	} else {
 		portPIDs = ":"
 	}

--- a/internal/services/preview/providers/docker_preview_test.go
+++ b/internal/services/preview/providers/docker_preview_test.go
@@ -31,6 +31,14 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestMain(m *testing.M) {
+	if os.Getenv("GO_WANT_PREVIEW_PORT_LISTENER_HELPER") == "1" {
+		runPreviewPortListenerHelper()
+		return
+	}
+	os.Exit(m.Run())
+}
+
 type mockDockerPreviewClient struct {
 	createHostConfig       *container.HostConfig
 	createNetworkingConfig *network.NetworkingConfig
@@ -1704,8 +1712,8 @@ func TestBuildTerminateServiceProcessCmd_KillsPortWithoutLsof(t *testing.T) {
 		t.Skip("the /proc socket fallback is Linux-specific")
 	}
 
-	helper := exec.Command(os.Args[0], "-test.run=TestPreviewPortListenerHelper", "--")
-	helper.Env = append(os.Environ(), "GO_WANT_HELPER_PROCESS=1")
+	helper := exec.Command(os.Args[0], "-test.run=^$", "--")
+	helper.Env = append(os.Environ(), "GO_WANT_PREVIEW_PORT_LISTENER_HELPER=1")
 	stdout, err := helper.StdoutPipe()
 	require.NoError(t, err, "helper stdout pipe should be created")
 	helper.Stderr = os.Stderr
@@ -1737,10 +1745,7 @@ func TestBuildTerminateServiceProcessCmd_KillsPortWithoutLsof(t *testing.T) {
 	}
 }
 
-func TestPreviewPortListenerHelper(t *testing.T) {
-	if os.Getenv("GO_WANT_HELPER_PROCESS") != "1" {
-		return
-	}
+func runPreviewPortListenerHelper() {
 	ln, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)

--- a/internal/services/preview/providers/docker_preview_test.go
+++ b/internal/services/preview/providers/docker_preview_test.go
@@ -1,12 +1,17 @@
 package providers
 
 import (
+	"bufio"
 	"context"
 	"errors"
 	"fmt"
 	"io"
 	"net"
 	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strconv"
 	"strings"
 	"sync"
 	"testing"
@@ -1681,6 +1686,68 @@ func TestStopPreview_TerminatesServiceProcessesBeforeCleanup(t *testing.T) {
 	require.Contains(t, strings.Join(calls, "\n"), "4242", "termination command should target the recorded service PID")
 	require.Contains(t, strings.Join(calls, "\n"), ":3000", "termination command should target the ready service port")
 	require.Contains(t, strings.Join(calls, "\n"), ":9000", "termination command should still use the port when PID detection has not populated")
+}
+
+func TestBuildTerminateServiceProcessCmd_IncludesProcFallbackForMissingLsof(t *testing.T) {
+	t.Parallel()
+
+	cmd := buildTerminateServiceProcessCmd(0, 8080)
+
+	require.Contains(t, cmd, "/proc/net/tcp", "termination command should find listening sockets without lsof")
+	require.Contains(t, cmd, "/proc/[0-9]*/fd/*", "termination command should map socket inodes back to owning processes")
+}
+
+func TestBuildTerminateServiceProcessCmd_KillsPortWithoutLsof(t *testing.T) {
+	t.Parallel()
+
+	if runtime.GOOS != "linux" {
+		t.Skip("the /proc socket fallback is Linux-specific")
+	}
+
+	helper := exec.Command(os.Args[0], "-test.run=TestPreviewPortListenerHelper", "--")
+	helper.Env = append(os.Environ(), "GO_WANT_HELPER_PROCESS=1")
+	stdout, err := helper.StdoutPipe()
+	require.NoError(t, err, "helper stdout pipe should be created")
+	helper.Stderr = os.Stderr
+	require.NoError(t, helper.Start(), "helper listener should start")
+	defer func() {
+		if helper.Process != nil {
+			_ = helper.Process.Kill()
+		}
+	}()
+
+	scanner := bufio.NewScanner(stdout)
+	require.True(t, scanner.Scan(), "helper should print its listening port")
+	port, err := strconv.Atoi(strings.TrimSpace(scanner.Text()))
+	require.NoError(t, err, "helper should print a numeric port")
+
+	binDir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(binDir, "lsof"), []byte("#!/bin/sh\nexit 0\n"), 0o755), "fake lsof should be installed")
+	term := exec.Command("sh", "-c", buildTerminateServiceProcessCmd(0, port))
+	term.Env = append(os.Environ(), "PATH="+binDir+":"+os.Getenv("PATH"))
+	output, err := term.CombinedOutput()
+	require.NoError(t, err, "termination command should succeed without lsof output: %s", output)
+
+	done := make(chan error, 1)
+	go func() { done <- helper.Wait() }()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		require.Fail(t, "termination command should kill the listener discovered by port")
+	}
+}
+
+func TestPreviewPortListenerHelper(t *testing.T) {
+	if os.Getenv("GO_WANT_HELPER_PROCESS") != "1" {
+		return
+	}
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(2)
+	}
+	fmt.Println(ln.Addr().(*net.TCPAddr).Port)
+	select {}
 }
 
 // TestWaitForReadiness_FailsFastWhenServiceExited verifies that the readiness


### PR DESCRIPTION
## Summary
- Add a `/proc/net/tcp*` and `/proc/*/fd` fallback so preview stop/recycle can still find and kill service listeners when `lsof` is unavailable.
- Cover the new behavior with regression tests for the command string and an end-to-end port listener kill case.

## Testing
- `go test ./internal/services/preview/providers -run 'TestBuildTerminateServiceProcessCmd' -count=1`
- `go vet ./...`
- `go build ./...`
- `go test ./...`