### PR TITLE
Clarify Preview bundle modal repo selection and stored secrets vs delivery outputs

### DIFF
--- a/docs/design/implemented/88-preview-settings-page.md
+++ b/docs/design/implemented/88-preview-settings-page.md
@@ -153,19 +153,20 @@ Use the same form for creating and editing.
 Fields:
 
 1. Repository
-   - Fixed to the selected repository for `New bundle`.
+   - Selectable for `New bundle`, defaulting to the currently filtered repository so admins can choose the target repo without leaving the dialog.
    - Read-only or disabled for `Edit`; moving bundles between repos is out of scope.
 2. Bundle name
    - Required.
    - Trim whitespace.
-3. Secret values
+3. Stored secrets
    - Structured key/value rows.
    - Key input should normalize to a conservative env-style identifier only when the output is env-like; otherwise allow source keys that match existing resolver behavior.
    - Value input should be `type="password"`.
    - Existing secret values must not be fetched or shown. Editing should require re-entering any changed value.
-4. Outputs
+4. Delivery outputs
    - Structured rows for env outputs.
    - File outputs can start with an advanced JSON editor if a full builder is too large for this pass, but the list row must still render safe output summaries.
+   - Copy should make clear that environment variables and generated files are alternative delivery methods for the same stored secrets. Users need at least one delivery method, but do not need both.
    - Validate output path rules client-side where possible, but rely on backend validation as source of truth.
 5. Actions
    - `Test bundle`

--- a/frontend/src/app/(dashboard)/settings/previews/page.test.tsx
+++ b/frontend/src/app/(dashboard)/settings/previews/page.test.tsx
@@ -48,7 +48,7 @@ describe("PreviewSettingsPage", () => {
 
     renderWithProviders(<PreviewSettingsPage />);
 
-    await userEvent.click(await screen.findByRole("combobox", { name: /repository/i }));
+    await userEvent.click(await screen.findByRole("combobox", { name: /filter by repository/i }));
     await userEvent.click(await screen.findByRole("option", { name: "assembledhq/docs" }));
 
     expect((await screen.findAllByText("docs-preview"))[0]).toBeInTheDocument();
@@ -84,7 +84,7 @@ describe("PreviewSettingsPage", () => {
 
     await userEvent.click(await screen.findByRole("button", { name: /new bundle/i }));
     await userEvent.type(screen.getByLabelText("Bundle name"), "staging");
-    await userEvent.type(screen.getByLabelText("Secret key"), "API_TOKEN");
+    await userEvent.type(screen.getByLabelText("Secret name"), "API_TOKEN");
     await userEvent.type(screen.getByLabelText("Secret value"), "super-secret");
     await userEvent.click(screen.getByRole("button", { name: /save/i }));
 
@@ -110,6 +110,54 @@ describe("PreviewSettingsPage", () => {
     expect(screen.queryByText("super-secret")).not.toBeInTheDocument();
   }, 10000);
 
+  it("lets users choose the bundle repository inside the create dialog", async () => {
+    let savedPath = "";
+    let savedBody: unknown;
+    server.use(
+      http.get("*/api/v1/repositories", () => HttpResponse.json({ data: repos, meta: {} })),
+      http.get("*/api/v1/repositories/:id/preview-secret-bundles", () => HttpResponse.json({ data: [], meta: {} })),
+      http.get("*/api/v1/previews/api-tokens", () => HttpResponse.json({ data: [], meta: {} })),
+      http.post("*/api/v1/repositories/repo-2/preview-secret-bundles", async ({ request }) => {
+        savedPath = new URL(request.url).pathname;
+        savedBody = await request.json();
+        return HttpResponse.json({ data: bundle("bundle-2", "repo-2", "docs-preview") });
+      }),
+    );
+
+    renderWithProviders(<PreviewSettingsPage />);
+
+    await userEvent.click(await screen.findByRole("button", { name: /new bundle/i }));
+    await userEvent.click(screen.getByRole("combobox", { name: "Bundle repository" }));
+    await userEvent.click(await screen.findByRole("option", { name: "assembledhq/docs" }));
+    await userEvent.type(screen.getByLabelText("Bundle name"), "docs-preview");
+    await userEvent.type(screen.getByLabelText("Secret name"), "API_TOKEN");
+    await userEvent.type(screen.getByLabelText("Secret value"), "super-secret");
+    await userEvent.click(screen.getByRole("button", { name: /save/i }));
+
+    await waitFor(() => {
+      expect(savedPath).toBe("/api/v1/repositories/repo-2/preview-secret-bundles");
+    });
+    expect(savedBody).toMatchObject({ name: "docs-preview" });
+  }, 10000);
+
+  it("explains stored secrets and generated file outputs as separate delivery choices", async () => {
+    server.use(
+      http.get("*/api/v1/repositories", () => HttpResponse.json({ data: repos, meta: {} })),
+      http.get("*/api/v1/repositories/repo-1/preview-secret-bundles", () => HttpResponse.json({ data: [], meta: {} })),
+      http.get("*/api/v1/previews/api-tokens", () => HttpResponse.json({ data: [], meta: {} })),
+    );
+
+    renderWithProviders(<PreviewSettingsPage />);
+
+    await userEvent.click(await screen.findByRole("button", { name: /new bundle/i }));
+
+    expect(screen.getByText("Stored secrets")).toBeInTheDocument();
+    expect(screen.getByText("Generated files")).toBeInTheDocument();
+    expect(screen.getByText(/Choose at least one delivery method/i)).toBeInTheDocument();
+    expect(screen.getByLabelText("Stored secrets help")).toBeInTheDocument();
+    expect(screen.getByLabelText("Generated files help")).toBeInTheDocument();
+  });
+
   it("does not expose file-only preview secrets as environment variables", async () => {
     let savedBody: unknown;
     server.use(
@@ -126,10 +174,10 @@ describe("PreviewSettingsPage", () => {
 
     await userEvent.click(await screen.findByRole("button", { name: /new bundle/i }));
     await userEvent.type(screen.getByLabelText("Bundle name"), "file-only");
-    await userEvent.type(screen.getByLabelText("Secret key"), "API_TOKEN");
+    await userEvent.type(screen.getByLabelText("Secret name"), "API_TOKEN");
     await userEvent.type(screen.getByLabelText("Secret value"), "super-secret");
     await userEvent.click(screen.getByLabelText("Expose as env"));
-    fireEvent.change(screen.getByLabelText("File outputs JSON"), {
+    fireEvent.change(screen.getByLabelText("Generated files JSON"), {
       target: {
         value: '[{"type":"file","path":"development.conf.json","format":"json","content":{"token":"secret:API_TOKEN"}}]',
       },
@@ -162,7 +210,7 @@ describe("PreviewSettingsPage", () => {
 
     await userEvent.click(await screen.findByRole("button", { name: /new bundle/i }));
     await userEvent.type(screen.getByLabelText("Bundle name"), "no-outputs");
-    await userEvent.type(screen.getByLabelText("Secret key"), "API_TOKEN");
+    await userEvent.type(screen.getByLabelText("Secret name"), "API_TOKEN");
     await userEvent.type(screen.getByLabelText("Secret value"), "super-secret");
     // Uncheck the only env output row so outputs will be empty
     await userEvent.click(screen.getByLabelText("Expose as env"));
@@ -172,7 +220,7 @@ describe("PreviewSettingsPage", () => {
     expect(screen.getByRole("button", { name: /save/i })).toBeDisabled();
     expect(screen.getByRole("button", { name: /save/i })).toHaveAttribute(
       "title",
-      "At least one env or file output is required",
+      "Choose at least one delivery method: environment variables or generated files",
     );
   }, 10000);
 

--- a/frontend/src/app/(dashboard)/settings/previews/page.tsx
+++ b/frontend/src/app/(dashboard)/settings/previews/page.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useMemo, useState, type FormEvent, type ReactNode } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useQueryState } from "nuqs";
-import { Copy, KeyRound, Pencil, Plus, TestTube2, Trash2 } from "lucide-react";
+import { Copy, HelpCircle, KeyRound, Pencil, Plus, TestTube2, Trash2 } from "lucide-react";
 
 import { EmptyState } from "@/components/empty-state";
 import { PageContainer } from "@/components/page-container";
@@ -41,6 +41,7 @@ import {
 } from "@/components/ui/select";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 import { Textarea } from "@/components/ui/textarea";
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { usePageTitle } from "@/hooks/use-page-title";
 import { api, ApiError } from "@/lib/api";
 import { notify as toast } from "@/lib/notify";
@@ -69,6 +70,7 @@ type BundleDialogMode =
   | { type: "edit"; bundle: PreviewSecretBundleSummary };
 
 type BundleFormState = {
+  repositoryId: string;
   name: string;
   rows: SecretValueRow[];
   fileOutputsJSON: string;
@@ -79,8 +81,8 @@ function makeRow(overrides?: Partial<Omit<SecretValueRow, "rowId">>): SecretValu
   return { rowId: crypto.randomUUID(), key: "", value: "", exposeAsEnv: true, ...overrides };
 }
 
-function makeEmptyBundleForm(): BundleFormState {
-  return { name: "", rows: [makeRow()], fileOutputsJSON: "" };
+function makeEmptyBundleForm(repositoryId = ""): BundleFormState {
+  return { repositoryId, name: "", rows: [makeRow()], fileOutputsJSON: "" };
 }
 
 export default function PreviewSettingsPage() {
@@ -151,6 +153,8 @@ function PreviewSecretsSection() {
     },
     onSuccess: (_data, { repositoryId }) => {
       toast.success("Preview secret bundle saved");
+      setSelectedRepositoryId(repositoryId);
+      void setRepoParam(repositoryId);
       closeBundleDialog();
       void queryClient.invalidateQueries({ queryKey: queryKeys.repositories.previewSecretBundles(repositoryId) });
     },
@@ -188,7 +192,7 @@ function PreviewSecretsSection() {
 
   function openCreateDialog() {
     setDialogMode({ type: "create" });
-    setForm(makeEmptyBundleForm());
+    setForm(makeEmptyBundleForm(effectiveSelectedRepositoryId));
     setFormError(null);
   }
 
@@ -197,6 +201,7 @@ function PreviewSecretsSection() {
     const fileOuts = fileOutputsFromBundle(bundle);
     const envRows = envNamesFromBundle(bundle).map((key) => makeRow({ key, exposeAsEnv: true }));
     setForm({
+      repositoryId: bundle.repository_id,
       name: bundle.name,
       rows: envRows.length > 0 ? envRows : [makeRow({ exposeAsEnv: false })],
       fileOutputsJSON: fileOuts.length > 0 ? JSON.stringify(fileOuts, null, 2) : "",
@@ -206,7 +211,7 @@ function PreviewSecretsSection() {
 
   function closeBundleDialog() {
     setDialogMode(null);
-    setForm(makeEmptyBundleForm());
+    setForm(makeEmptyBundleForm(effectiveSelectedRepositoryId));
     setFormError(null);
   }
 
@@ -238,8 +243,12 @@ function PreviewSecretsSection() {
       setFormError(body.message);
       return;
     }
+    if (!form.repositoryId) {
+      setFormError("Choose a repository for this bundle.");
+      return;
+    }
     setFormError(null);
-    saveMutation.mutate({ mode: dialogMode, body, repositoryId: effectiveSelectedRepositoryId });
+    saveMutation.mutate({ mode: dialogMode, body, repositoryId: form.repositoryId });
   }
 
   return (
@@ -249,14 +258,14 @@ function PreviewSecretsSection() {
           <h2 id="preview-secrets-heading" className="text-sm font-semibold text-foreground">Preview secrets</h2>
           <p className="text-xs text-muted-foreground">Repo-scoped secret bundles used at preview runtime.</p>
         </div>
-        <Button type="button" onClick={openCreateDialog} disabled={!effectiveSelectedRepositoryId}>
+        <Button type="button" onClick={openCreateDialog} disabled={activeRepositories.length === 0}>
           <Plus className="h-4 w-4" />
           New bundle
         </Button>
       </div>
 
       <div className="max-w-md space-y-1.5">
-        <Label htmlFor="preview-repository-select">Repository</Label>
+        <Label htmlFor="preview-repository-select">Filter by repository</Label>
         <Select
           value={effectiveSelectedRepositoryId}
           onValueChange={(value) => {
@@ -301,6 +310,7 @@ function PreviewSecretsSection() {
       <BundleDialog
         mode={dialogMode}
         form={form}
+        repositories={activeRepositories}
         repositoryName={selectedRepository?.full_name ?? ""}
         error={formError}
         saving={saveMutation.isPending}
@@ -470,6 +480,7 @@ function BundleActions({
 function BundleDialog({
   mode,
   form,
+  repositories,
   repositoryName,
   error,
   saving,
@@ -484,6 +495,7 @@ function BundleDialog({
 }: {
   mode: BundleDialogMode | null;
   form: BundleFormState;
+  repositories: Repository[];
   repositoryName: string;
   error: string | null;
   saving: boolean;
@@ -501,11 +513,11 @@ function BundleDialog({
   const editHasFileOutputs = editBundle ? editBundle.outputs.some((o) => o.type === "file") : false;
   const hasFilledValue = form.rows.some((row) => row.key.trim() && row.value);
   const hasOutput = form.rows.some((row) => row.key.trim() && row.value && row.exposeAsEnv) || form.fileOutputsJSON.trim().length > 0;
-  const canSave = Boolean(form.name.trim()) && hasFilledValue && hasOutput;
+  const canSave = Boolean(form.repositoryId) && Boolean(form.name.trim()) && hasFilledValue && hasOutput;
   const saveTooltip = isEdit && !hasFilledValue
     ? "Re-enter at least one secret value to save changes"
     : !hasOutput
-      ? "At least one env or file output is required"
+      ? "Choose at least one delivery method: environment variables or generated files"
       : undefined;
 
   return (
@@ -521,8 +533,25 @@ function BundleDialog({
         <form className="space-y-5" onSubmit={onSubmit}>
           <div className="grid gap-4 sm:grid-cols-2">
             <div className="space-y-1.5">
-              <Label htmlFor="bundle-repository">Repository</Label>
-              <Input id="bundle-repository" value={repositoryName} disabled />
+              <Label htmlFor={isEdit ? "bundle-repository" : "bundle-repository-select"}>Bundle repository</Label>
+              {isEdit ? (
+                <Input id="bundle-repository" value={repositoryName} disabled />
+              ) : (
+                <Select
+                  value={form.repositoryId}
+                  onValueChange={(repositoryId) => onFormChange({ ...form, repositoryId })}
+                  disabled={repositories.length === 0}
+                >
+                  <SelectTrigger id="bundle-repository-select">
+                    <SelectValue placeholder="Choose repository" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {repositories.map((repo) => (
+                      <SelectItem key={repo.id} value={repo.id}>{repo.full_name}</SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              )}
             </div>
             <div className="space-y-1.5">
               <Label htmlFor="bundle-name">Bundle name</Label>
@@ -537,9 +566,17 @@ function BundleDialog({
           </div>
 
           <div className="space-y-2">
-            <div>
-              <Label>Secret values</Label>
-              <p className="text-xs text-muted-foreground">Editing requires re-entering the values you want this bundle to contain.</p>
+            <div className="space-y-1">
+              <div className="flex items-center gap-1.5">
+                <Label>Stored secrets</Label>
+                <HelpTooltip
+                  label="Stored secrets help"
+                  content="These are the encrypted values 143 stores for this bundle. Previews can receive them as environment variables or use them when 143 generates config files."
+                />
+              </div>
+              <p className="text-xs text-muted-foreground">
+                Add the secret names and values once. Values are encrypted and are not shown again after saving.
+              </p>
             </div>
             <div className="space-y-2">
               {form.rows.map((row, index) => (
@@ -548,7 +585,7 @@ function BundleDialog({
                     value={row.key}
                     onChange={(event) => onRowChange(index, { key: normalizeEnvKey(event.target.value) })}
                     placeholder="API_TOKEN"
-                    aria-label={index === 0 ? "Secret key" : `Secret key ${index + 1}`}
+                    aria-label={index === 0 ? "Secret name" : `Secret name ${index + 1}`}
                     autoComplete="off"
                   />
                   <Input
@@ -565,7 +602,7 @@ function BundleDialog({
                       onCheckedChange={(checked) => onRowChange(index, { exposeAsEnv: checked === true })}
                       aria-label={index === 0 ? "Expose as env" : `Expose as env ${index + 1}`}
                     />
-                    Env output
+                    Send as env var
                   </Label>
                   <Button type="button" variant="outline" size="icon" onClick={() => onRowRemove(index)} aria-label={`Remove secret row ${index + 1}`}>
                     <Trash2 className="h-4 w-4" />
@@ -580,12 +617,22 @@ function BundleDialog({
           </div>
 
           <div className="space-y-1.5">
-            <Label htmlFor="file-outputs">File outputs JSON</Label>
+            <div className="flex items-center gap-1.5">
+              <Label htmlFor="file-outputs">Generated files</Label>
+              <HelpTooltip
+                label="Generated files help"
+                content="Use this only when the preview app expects a file such as .env or development.conf.json. The JSON describes files and can reference stored secrets like secret:API_TOKEN."
+              />
+            </div>
+            <p className="text-xs text-muted-foreground">
+              Choose at least one delivery method: send stored secrets as environment variables above, or define generated files here. You do not need both.
+            </p>
             <Textarea
               id="file-outputs"
               value={form.fileOutputsJSON}
               onChange={(event) => onFormChange({ ...form, fileOutputsJSON: event.target.value })}
               placeholder={'[{"type":"file","path":"development.conf.json","format":"json","content":{"token":"secret:API_TOKEN"}}]'}
+              aria-label="Generated files JSON"
               className="min-h-24 font-mono text-xs"
               spellCheck={false}
             />
@@ -874,6 +921,23 @@ function LabeledMobileValue({ label, children }: { label: string; children: Reac
       <p className="text-xs font-medium text-muted-foreground">{label}</p>
       <div className="text-sm text-foreground">{children}</div>
     </div>
+  );
+}
+
+function HelpTooltip({ label, content }: { label: string; content: ReactNode }) {
+  return (
+    <TooltipProvider delayDuration={150}>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Button type="button" variant="ghost" size="icon" className="h-6 w-6 text-muted-foreground" aria-label={label}>
+            <HelpCircle className="h-3.5 w-3.5" />
+          </Button>
+        </TooltipTrigger>
+        <TooltipContent side="top" sideOffset={6} className="max-w-80">
+          {content}
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
   );
 }
 


### PR DESCRIPTION
## Summary
Update the Preview bundle modal and the page-level repository filter to make repository selection and bundle inputs clearer. Also rename “secret values”/“outputs” to “stored secrets”/“delivery outputs” and add guidance that users should choose either env var delivery or generated files (not both).

## Changes
- **frontend/src/app/(dashboard)/settings/previews/page.tsx**
  - Add a selectable **“Bundle repository”** field in the **Create** bundle flow (defaults to the currently filtered repository).
  - Keep **Edit** bundle repository **read-only/disabled** to prevent moving bundles between repos.
  - Rename page repository selector label to **“Filter by repository”**.
  - Rename bundle fields:
    - **Secret values → Stored secrets**
    - **Outputs → Delivery outputs**
  - Add help tooltips explaining stored secrets and delivery outputs.
  - Update UI copy/validation messaging to clarify delivery must be **env vars or generated files** (at least one), not both.
- **frontend/src/app/(dashboard)/settings/previews/page.test.tsx**
  - Update tests to reflect the new **“Filter by repository”** label and **“Secret name”** field label.
  - Add coverage to verify the **Create** dialog allows choosing the target bundle repository and submits to the correct repo endpoint.
- **docs/design/implemented/88-preview-settings-page.md**
  - Bring the implemented design doc in line with the updated modal/page behavior and terminology, including the delivery-method clarification.

## Test plan
- `npm test -- --run 'src/app/(dashboard)/settings/previews/page.test.tsx'`
- `npm run typecheck`
- `npm run lint`
- `npm run build`

[143.dev](https://143.dev) | [session 8646f029](https://143.dev/sessions/8646f029-b3e1-4db5-a704-fbeafea46ed0)

Preview: https://143.dev/previews/github/assembledhq/143/pull/1163