### PR TITLE
Align compact rail settings icon placement and sizing

### DIFF
--- a/frontend/src/components/authenticated-layout.test.tsx
+++ b/frontend/src/components/authenticated-layout.test.tsx
@@ -106,7 +106,7 @@ describe("AuthenticatedLayout", () => {
     expect(compactRail).toHaveClass("w-14");
   });
 
-  it("keeps compact rail nav icons vertically aligned with desktop nav spacing", () => {
+  it("keeps compact rail icons consistent between quick actions and nav", () => {
     const { container } = renderWithProviders(
       <AuthenticatedLayout>
         <div>content</div>
@@ -114,18 +114,19 @@ describe("AuthenticatedLayout", () => {
     );
 
     const compactRail = container.querySelector("[data-testid='app-sidebar-rail']");
+    const quickActions = compactRail?.querySelector("div");
+    expect(quickActions).not.toBeNull();
+    const settingsQuickAction = within(quickActions as HTMLElement).getByRole("link", { name: "Settings" });
+    const settingsIcon = settingsQuickAction.querySelector("svg");
+    expect(settingsQuickAction).toHaveClass("h-7", "w-10");
+    expect(settingsIcon).toHaveClass("h-4", "w-4");
+
     const primaryNav = compactRail?.querySelector("nav");
     expect(primaryNav).not.toBeNull();
     expect(primaryNav).toHaveClass("gap-0.5");
 
     const sessionsLink = within(primaryNav as HTMLElement).getByRole("link", { name: "Sessions" });
     expect(sessionsLink).toHaveClass("h-[30px]", "w-10");
-
-    expect(within(primaryNav as HTMLElement).getByTestId("compact-sidebar-settings-divider")).toHaveClass("border-t");
-    const settingsLink = within(primaryNav as HTMLElement).getByRole("link", { name: "Settings" });
-    const settingsIcon = settingsLink.querySelector("svg");
-    expect(settingsLink).toHaveClass("h-[30px]", "w-10");
-    expect(settingsIcon).toHaveClass("h-4", "w-4");
   });
 
   it("keeps workspace and account actions reachable from the compact rail", async () => {

--- a/frontend/src/components/authenticated-layout.tsx
+++ b/frontend/src/components/authenticated-layout.tsx
@@ -353,6 +353,24 @@ function CompactSidebarRail({
           </Tooltip>
           <Tooltip>
             <TooltipTrigger asChild>
+              <Link
+                href="/settings"
+                aria-label="Settings"
+                aria-current={pathname.startsWith("/settings") ? "page" : undefined}
+                className={cn(
+                  "flex h-7 w-10 items-center justify-center rounded-md transition-colors duration-150",
+                  pathname.startsWith("/settings")
+                    ? "bg-sidebar-accent text-sidebar-accent-foreground"
+                    : "text-muted-foreground hover:bg-sidebar-accent/60 hover:text-sidebar-accent-foreground",
+                )}
+              >
+                <Settings className="h-4 w-4" />
+              </Link>
+            </TooltipTrigger>
+            <TooltipContent side="right" sideOffset={8}>Settings</TooltipContent>
+          </Tooltip>
+          <Tooltip>
+            <TooltipTrigger asChild>
               <Button
                 variant="ghost"
                 size="icon"
@@ -394,25 +412,6 @@ function CompactSidebarRail({
               </Tooltip>
             );
           })}
-          <div data-testid="compact-sidebar-settings-divider" className="my-1 w-7 border-t border-border/50" />
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <Link
-                href="/settings"
-                aria-label="Settings"
-                aria-current={pathname.startsWith("/settings") ? "page" : undefined}
-                className={cn(
-                  "flex h-[30px] w-10 items-center justify-center rounded-md transition-colors duration-150",
-                  pathname.startsWith("/settings")
-                    ? "bg-sidebar-accent text-sidebar-accent-foreground"
-                    : "text-muted-foreground hover:bg-sidebar-accent/60 hover:text-sidebar-accent-foreground",
-                )}
-              >
-                <Settings className="h-4 w-4" />
-              </Link>
-            </TooltipTrigger>
-            <TooltipContent side="right" sideOffset={8}>Settings</TooltipContent>
-          </Tooltip>
         </nav>
 
         <Popover>


### PR DESCRIPTION
### Motivation
- Make the compact (rail) and expanded sidebar visually consistent so icons (including Settings) keep the same size and predictable location when the navbar collapses. 

### Description
- Move the compact-rail Settings entry into the top quick-action cluster (with Search / New session) so Settings stays in the same visual zone as other small-rail actions (`frontend/src/components/authenticated-layout.tsx`).
- Keep Settings icon dimensions as `h-4 w-4` inside a `h-7 w-10` control so sizing matches nearby compact controls. 
- Remove the old mid-nav duplicate Settings entry and its divider to avoid two different visual placements. 
- Update the layout test to assert Settings is in the quick-action group and shares the compact sizing/spacing (`frontend/src/components/authenticated-layout.test.tsx`).

### Testing
- Ran the unit test file with `npm run test -- src/components/authenticated-layout.test.tsx` and all tests in that file passed after the change. 
- Ran full frontend verification commands `npm run typecheck`, `npm run lint`, and `npm run build`, and each completed successfully (typecheck/lint/build succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a17e2faff6c8320b9361ba82cd40f3b)