### PR TITLE
Fix linear issues

### DIFF
--- a/internal/api/handlers/sessions.go
+++ b/internal/api/handlers/sessions.go
@@ -3470,6 +3470,7 @@ func (h *SessionHandler) CreateManual(w http.ResponseWriter, r *http.Request) {
 			SessionTitle:            title,
 			BranchName:              body.Branch,
 			ReferenceText:           linearReferenceText(body.References),
+			RepositoryID:            repoID,
 			UserID:                  userID,
 			LinearPrivate:           body.LinearPrivate,
 			LinearStateSyncDisabled: body.LinearStateSyncDisabled,

--- a/internal/api/handlers/sessions_linear_test.go
+++ b/internal/api/handlers/sessions_linear_test.go
@@ -262,11 +262,21 @@ func TestSessionHandler_CreateManual_LinearLinkerSuccess(t *testing.T) {
 	defer mock.Close()
 
 	orgID := uuid.New()
+	repoID := uuid.New()
 	now := time.Now()
 	runID := uuid.New()
 	messageID := int64(1)
 	jobID := uuid.New()
 
+	mock.ExpectQuery("SELECT .+ FROM repositories WHERE id").
+		WithArgs(repoID, orgID).
+		WillReturnRows(
+			pgxmock.NewRows(repoColumns()).AddRow(
+				repoID, orgID, uuid.New(), int64(1001), "acme/app", "main",
+				false, nil, nil, "https://github.com/acme/app.git", int64(99), "active",
+				nil, nil, []byte(`{}`), now, now,
+			),
+		)
 	mock.ExpectQuery("SELECT .+ FROM organizations WHERE id").
 		WithArgs(pgxmock.AnyArg()).
 		WillReturnRows(pgxmock.NewRows([]string{"id", "name", "settings", "created_at", "updated_at"}).
@@ -312,7 +322,7 @@ func TestSessionHandler_CreateManual_LinearLinkerSuccess(t *testing.T) {
 	// reference uses a real picker kind ("app") whose display we set to
 	// the Linear key — looksLikeLinearReference scans the display string
 	// regardless of kind.
-	body := `{"message":"","agent_type":"claude_code","references":[{"kind":"app","id":"linear","display":"ACS-1234"}]}`
+	body := `{"message":"","agent_type":"claude_code","repository_id":"` + repoID.String() + `","references":[{"kind":"app","id":"linear","display":"ACS-1234"}]}`
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/sessions/manual", strings.NewReader(body))
 	ctx := middleware.WithOrgID(req.Context(), orgID)
 	req = req.WithContext(ctx)
@@ -323,6 +333,8 @@ func TestSessionHandler_CreateManual_LinearLinkerSuccess(t *testing.T) {
 	require.Equal(t, http.StatusCreated, w.Code, "linker success path should still create the session")
 	require.Equal(t, 1, linker.called, "the handler should call the linker exactly once per create")
 	require.Equal(t, orgID, linker.gotIn.OrgID)
+	require.NotNil(t, linker.gotIn.RepositoryID, "explicit manual repository selection should be passed to the Linear linker")
+	require.Equal(t, repoID, *linker.gotIn.RepositoryID, "Linear linker should receive the user-selected manual session repository")
 	require.Contains(t, linker.gotIn.ReferenceText, "ACS-1234", "the reference text should be threaded through to the linker")
 	require.NoError(t, mock.ExpectationsWereMet())
 }

--- a/internal/db/session_issue_links.go
+++ b/internal/db/session_issue_links.go
@@ -139,6 +139,52 @@ func (s *SessionIssueLinkStore) CreateAllowingNullRepo(
 	return linkID, nil
 }
 
+// CreateAllowingRepositoryMismatch is the manual-session override path. The
+// session's selected repository remains authoritative for the sandbox, while
+// the linked issue can still provide context even when Linear associates it
+// with a different repository.
+func (s *SessionIssueLinkStore) CreateAllowingRepositoryMismatch(
+	ctx context.Context,
+	orgID, sessionID, issueID uuid.UUID,
+	role models.SessionIssueLinkRole,
+	position int,
+	addedByUserID *uuid.UUID,
+) (uuid.UUID, error) {
+	query := `
+		INSERT INTO session_issue_links (
+			org_id, session_id, issue_id, role, position, added_by_user_id
+		)
+		SELECT @org_id, s.id, i.id, @role, @position, @added_by_user_id
+		FROM sessions s
+		JOIN issues i ON i.id = @issue_id AND i.org_id = @org_id
+		WHERE s.id = @session_id
+		  AND s.org_id = @org_id
+		  AND s.deleted_at IS NULL
+		ON CONFLICT (session_id, issue_id) DO NOTHING
+		RETURNING id`
+
+	var linkID uuid.UUID
+	err := s.db.QueryRow(ctx, query, pgx.NamedArgs{
+		"org_id":           orgID,
+		"session_id":       sessionID,
+		"issue_id":         issueID,
+		"role":             role,
+		"position":         position,
+		"added_by_user_id": addedByUserID,
+	}).Scan(&linkID)
+	if errors.Is(err, pgx.ErrNoRows) {
+		existing, lookupErr := s.lookupLinkID(ctx, orgID, sessionID, issueID)
+		if lookupErr == nil {
+			return existing, nil
+		}
+		return uuid.Nil, ErrInvalidSessionIssueLink
+	}
+	if err != nil {
+		return uuid.Nil, fmt.Errorf("insert session issue link (manual repo override): %w", err)
+	}
+	return linkID, nil
+}
+
 func (s *SessionIssueLinkStore) lookupLinkID(ctx context.Context, orgID, sessionID, issueID uuid.UUID) (uuid.UUID, error) {
 	var linkID uuid.UUID
 	err := s.db.QueryRow(ctx, `

--- a/internal/db/session_issue_links_test.go
+++ b/internal/db/session_issue_links_test.go
@@ -135,6 +135,29 @@ func TestSessionIssueLinkStore_CreateAllowingNullRepo_ReturnsExistingOnConflict(
 	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
 }
 
+func TestSessionIssueLinkStore_CreateAllowingRepositoryMismatch_SkipsRepoMatch(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "should create mock pool")
+	defer mock.Close()
+
+	store := NewSessionIssueLinkStore(mock)
+	orgID := uuid.New()
+	sessionID := uuid.New()
+	issueID := uuid.New()
+	linkID := uuid.New()
+
+	mock.ExpectQuery(`INSERT INTO session_issue_links[\s\S]+WHERE s\.id = @session_id[\s\S]+AND s\.deleted_at IS NULL\s+ON CONFLICT`).
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(pgxmock.NewRows([]string{"id"}).AddRow(linkID))
+
+	got, err := store.CreateAllowingRepositoryMismatch(context.Background(), orgID, sessionID, issueID, models.SessionIssueLinkRolePrimary, 0, nil)
+	require.NoError(t, err, "CreateAllowingRepositoryMismatch should allow manual sessions to link issues from a different repo")
+	require.Equal(t, linkID, got, "CreateAllowingRepositoryMismatch should return the inserted link id")
+	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
+}
+
 func TestSessionIssueLinkSelectColumns_UsesLinearIdentifierForExternalID(t *testing.T) {
 	t.Parallel()
 

--- a/internal/services/linear/create_path.go
+++ b/internal/services/linear/create_path.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"sort"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -32,6 +33,7 @@ type CreateInput struct {
 	SessionTitle            string
 	BranchName              string
 	ReferenceText           string
+	RepositoryID            *uuid.UUID
 	UserID                  *uuid.UUID
 	LinearPrivate           bool
 	LinearStateSyncDisabled bool
@@ -142,7 +144,8 @@ func (s *Service) ResolveAndLinkAtCreate(ctx context.Context, in CreateInput) (C
 		return CreateResult{PrepareInline: false}, nil
 	}
 
-	linkID, err := s.LinkResolved(ctx, in.OrgID, in.SessionID, resolved, models.SessionIssueLinkRolePrimary, 0, in.UserID)
+	linkOpts := LinkOptions{AllowRepositoryMismatch: in.RepositoryID != nil}
+	linkID, err := s.LinkResolvedWithOptions(ctx, in.OrgID, in.SessionID, resolved, models.SessionIssueLinkRolePrimary, 0, in.UserID, linkOpts)
 	if err != nil {
 		// Link write rejected (e.g. explicit repo mismatch). Skip primary
 		// linking; do not block the session, but warn so audit can pick up.
@@ -336,6 +339,9 @@ func (s *Service) enqueueLinearWorker(ctx context.Context, in CreateInput, jobTy
 		"identifiers": identifiers,
 		"refs":        linkRefsFromDetected(hits),
 	}
+	if in.RepositoryID != nil {
+		payload["allow_repository_mismatch"] = true
+	}
 	if in.UserID != nil {
 		payload["user_id"] = in.UserID.String()
 	}
@@ -380,6 +386,10 @@ func (s *Service) PrepareLinearPrimary(ctx context.Context, orgID, sessionID uui
 }
 
 func (s *Service) PrepareLinearPrimaryRefs(ctx context.Context, orgID, sessionID uuid.UUID, refs []LinkRef, userID *uuid.UUID) error {
+	return s.PrepareLinearPrimaryRefsWithOptions(ctx, orgID, sessionID, refs, userID, LinkOptions{})
+}
+
+func (s *Service) PrepareLinearPrimaryRefsWithOptions(ctx context.Context, orgID, sessionID uuid.UUID, refs []LinkRef, userID *uuid.UUID, linkOpts LinkOptions) error {
 	if len(refs) == 0 {
 		if err := s.sessions.SetLinearPrepareState(ctx, orgID, sessionID, models.LinearPrepareStateNone); err != nil {
 			return fmt.Errorf("clear linear prepare state: %w", err)
@@ -407,7 +417,7 @@ func (s *Service) PrepareLinearPrimaryRefs(ctx context.Context, orgID, sessionID
 		return err
 	}
 
-	linkID, err := s.LinkResolved(ctx, orgID, sessionID, resolved, models.SessionIssueLinkRolePrimary, 0, userID)
+	linkID, err := s.LinkResolvedWithOptions(ctx, orgID, sessionID, resolved, models.SessionIssueLinkRolePrimary, 0, userID, linkOpts)
 	if err != nil {
 		// Same retry contract as the resolve path above: leave the row in
 		// "pending" until the prepare job is truly exhausted.
@@ -431,7 +441,7 @@ func (s *Service) PrepareLinearPrimaryRefs(ctx context.Context, orgID, sessionID
 			Msg("worker prepare_linear_primary: failed to persist linear identifier hint; branch naming will fall back to non-linear slug")
 	}
 
-	s.linkRelatedRefs(ctx, orgID, sessionID, refs[1:], userID)
+	s.linkRelatedRefs(ctx, orgID, sessionID, refs[1:], userID, linkOpts)
 
 	if err := s.sessions.SetLinearPrepareState(ctx, orgID, sessionID, models.LinearPrepareStateReady); err != nil {
 		return err
@@ -462,6 +472,19 @@ func (s *Service) MarkLinearPrepareFailed(ctx context.Context, orgID, sessionID 
 	return s.sessions.SetLinearPrepareStateIfNotReady(ctx, orgID, sessionID, models.LinearPrepareStateFailed)
 }
 
+func (s *Service) MarkLinearPrepareFailedWithError(ctx context.Context, orgID, sessionID uuid.UUID, message string) error {
+	if s == nil || s.sessions == nil {
+		return nil
+	}
+	if err := s.sessions.SetLinearPrepareStateIfNotReady(ctx, orgID, sessionID, models.LinearPrepareStateFailed); err != nil {
+		return err
+	}
+	if strings.TrimSpace(message) == "" {
+		return nil
+	}
+	return s.sessions.UpdateResult(ctx, orgID, sessionID, models.SessionStatusFailed, &models.SessionResult{Error: &message})
+}
+
 // LinkRelatedLinearIssues is the worker-side catch-up path after the primary
 // has already been prepared inline. The payload includes the primary first so
 // old workers and dedupe keys stay stable; this method intentionally skips it
@@ -474,19 +497,19 @@ func (s *Service) LinkRelatedLinearRefs(ctx context.Context, orgID, sessionID uu
 	if len(refs) <= 1 {
 		return nil
 	}
-	s.linkRelatedRefs(ctx, orgID, sessionID, refs[1:], userID)
+	s.linkRelatedRefs(ctx, orgID, sessionID, refs[1:], userID, LinkOptions{})
 	s.notifyLinksChanged(ctx, orgID, sessionID, "refreshed")
 	return nil
 }
 
-func (s *Service) linkRelatedRefs(ctx context.Context, orgID, sessionID uuid.UUID, refs []LinkRef, userID *uuid.UUID) {
+func (s *Service) linkRelatedRefs(ctx context.Context, orgID, sessionID uuid.UUID, refs []LinkRef, userID *uuid.UUID, linkOpts LinkOptions) {
 	for i, ref := range refs {
 		related, err := s.ResolvePrimary(ctx, orgID, ref.detected())
 		if err != nil {
 			s.logger.Warn().Err(err).Str("identifier", ref.Identifier).Msg("failed to resolve related linear issue")
 			continue
 		}
-		if _, err := s.LinkResolved(ctx, orgID, sessionID, related, models.SessionIssueLinkRoleRelated, i+1, userID); err != nil {
+		if _, err := s.LinkResolvedWithOptions(ctx, orgID, sessionID, related, models.SessionIssueLinkRoleRelated, i+1, userID, linkOpts); err != nil {
 			s.logger.Warn().Err(err).Str("identifier", ref.Identifier).Msg("failed to link related linear issue")
 		}
 	}

--- a/internal/services/linear/create_path_test.go
+++ b/internal/services/linear/create_path_test.go
@@ -405,6 +405,45 @@ func TestResolveAndLinkAtCreate(t *testing.T) {
 		require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
 	})
 
+	t.Run("manual repository override links mismatched linear repo inline", func(t *testing.T) {
+		t.Parallel()
+
+		mock, err := pgxmock.NewPool()
+		require.NoError(t, err, "should create mock pool")
+		defer mock.Close()
+
+		now := time.Now().UTC()
+		orgID := uuid.New()
+		sessionID := uuid.New()
+		selectedRepoID := uuid.New()
+		linearRepoID := uuid.New()
+		issueID := uuid.New()
+		linkID := uuid.New()
+		fetched := fetchedIssueForTest("ACS-123")
+		fetched.RepositoryID = &linearRepoID
+		provider := newFakeProviderStateStore()
+		svc := newCreatePathService(mock, createPathClient{fetch: map[string]*FetchedIssue{"ACS-123": fetched}}, provider)
+
+		expectIssueUpsert(t, mock, issueID, now)
+		mock.ExpectQuery(`INSERT INTO session_issue_links[\s\S]+WHERE s\.id = @session_id[\s\S]+AND s\.deleted_at IS NULL\s+ON CONFLICT`).
+			WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+			WillReturnRows(pgxmock.NewRows([]string{"id"}).AddRow(linkID))
+		expectPrepareStateUpdate(t, mock, 1)
+
+		got, err := svc.ResolveAndLinkAtCreate(context.Background(), CreateInput{
+			OrgID:        orgID,
+			SessionID:    sessionID,
+			MessageBody:  "please start from https://linear.app/acme/issue/ACS-123",
+			RepositoryID: &selectedRepoID,
+		})
+		require.NoError(t, err, "manual repository selection should override Linear's repository association")
+		require.Equal(t, CreateResult{PrepareInline: true, PrimaryIdentifier: "ACS-123", PrimaryTitle: "Fix ACS-123"}, got, "manual repository override should still return primary metadata")
+		state, err := provider.Get(context.Background(), orgID, linkID)
+		require.NoError(t, err, "provider state should be persisted for the overridden link")
+		require.Equal(t, "manual_repository_override", state.LinkAuditReason, "provider state should record the manual repo override")
+		require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
+	})
+
 	t.Run("resolved primary enqueues linked milestone", func(t *testing.T) {
 		t.Parallel()
 

--- a/internal/services/linear/service.go
+++ b/internal/services/linear/service.go
@@ -885,6 +885,10 @@ type ResolvedIssue struct {
 	LocalID    uuid.UUID
 }
 
+type LinkOptions struct {
+	AllowRepositoryMismatch bool
+}
+
 // LinkResolved inserts (or upserts) the link row, applies the null-repo
 // carve-out, persists provider_state.team_id and link_audit_reason, and
 // returns the resulting link id.
@@ -896,13 +900,33 @@ func (s *Service) LinkResolved(
 	position int,
 	addedByUserID *uuid.UUID,
 ) (uuid.UUID, error) {
-	linkID, err := s.links.CreateAllowingNullRepo(ctx, orgID, sessionID, resolved.LocalID, role, position, addedByUserID)
+	return s.LinkResolvedWithOptions(ctx, orgID, sessionID, resolved, role, position, addedByUserID, LinkOptions{})
+}
+
+func (s *Service) LinkResolvedWithOptions(
+	ctx context.Context,
+	orgID, sessionID uuid.UUID,
+	resolved *ResolvedIssue,
+	role models.SessionIssueLinkRole,
+	position int,
+	addedByUserID *uuid.UUID,
+	opts LinkOptions,
+) (uuid.UUID, error) {
+	var linkID uuid.UUID
+	var err error
+	if opts.AllowRepositoryMismatch {
+		linkID, err = s.links.CreateAllowingRepositoryMismatch(ctx, orgID, sessionID, resolved.LocalID, role, position, addedByUserID)
+	} else {
+		linkID, err = s.links.CreateAllowingNullRepo(ctx, orgID, sessionID, resolved.LocalID, role, position, addedByUserID)
+	}
 	if err != nil {
 		return uuid.Nil, err
 	}
 	auditReason := ""
 	if resolved.Issue.RepositoryID == nil {
 		auditReason = "linear_null_repo_carveout"
+	} else if opts.AllowRepositoryMismatch {
+		auditReason = "manual_repository_override"
 	}
 	if err := s.providerState.Merge(ctx, orgID, linkID, db.LinearProviderState{
 		Identifier:         resolved.Identifier,

--- a/internal/worker/handlers.go
+++ b/internal/worker/handlers.go
@@ -1351,6 +1351,9 @@ func newRunAgentHandler(stores *Stores, services *Services, logger zerolog.Logge
 			// Don't start blind. Surface to the user via the recoverable
 			// failure path so they can retry.
 			errMsg := "Linear context could not be loaded. Retry the session to fetch it again."
+			if run.Error != nil && strings.TrimSpace(*run.Error) != "" {
+				errMsg = *run.Error
+			}
 			_ = stores.Sessions.UpdateResult(ctx, orgID, runID, models.SessionStatusFailed, &models.SessionResult{Error: &errMsg})
 			return &FatalError{Err: fmt.Errorf("linear pre-start preparation failed")}
 		}
@@ -3578,11 +3581,12 @@ func bootstrapAgentCommand(prompt string) string {
 func newPrepareLinearPrimaryHandler(svc *linear.Service, logger zerolog.Logger) JobHandler {
 	return func(ctx context.Context, jobType string, payload json.RawMessage) error {
 		var input struct {
-			OrgID       string           `json:"org_id"`
-			SessionID   string           `json:"session_id"`
-			Identifiers []string         `json:"identifiers"`
-			Refs        []linear.LinkRef `json:"refs,omitempty"`
-			UserID      string           `json:"user_id,omitempty"`
+			OrgID                   string           `json:"org_id"`
+			SessionID               string           `json:"session_id"`
+			Identifiers             []string         `json:"identifiers"`
+			Refs                    []linear.LinkRef `json:"refs,omitempty"`
+			UserID                  string           `json:"user_id,omitempty"`
+			AllowRepositoryMismatch bool             `json:"allow_repository_mismatch,omitempty"`
 		}
 		if err := json.Unmarshal(payload, &input); err != nil {
 			return fmt.Errorf("unmarshal prepare_linear_primary payload: %w", err)
@@ -3614,6 +3618,7 @@ func newPrepareLinearPrimaryHandler(svc *linear.Service, logger zerolog.Logger) 
 		if len(refs) == 0 {
 			refs = linearRefsFromIdentifiers(input.Identifiers)
 		}
+		invalidLinkMessage := "Linear issue could not be linked to this session's repository. The Linear issue appears to belong to another repository; choose the matching repository or start a manual session with your intended repository selected."
 		jobctx.RegisterDeadLetterHook(ctx, func(hookCtx context.Context, _ error) {
 			if err := svc.MarkLinearPrepareFailed(hookCtx, orgID, sessionID); err != nil {
 				logger.Warn().Err(err).
@@ -3621,7 +3626,7 @@ func newPrepareLinearPrimaryHandler(svc *linear.Service, logger zerolog.Logger) 
 					Msg("prepare_linear_primary dead-letter hook failed to mark prepare state failed")
 			}
 		})
-		if err := svc.PrepareLinearPrimaryRefs(ctx, orgID, sessionID, refs, userID); err != nil {
+		if err := svc.PrepareLinearPrimaryRefsWithOptions(ctx, orgID, sessionID, refs, userID, linear.LinkOptions{AllowRepositoryMismatch: input.AllowRepositoryMismatch}); err != nil {
 			logger.Warn().Err(err).Str("session_id", sessionID.String()).Msg("prepare_linear_primary failed")
 			if errors.Is(err, linear.ErrIntegrationNotFound) {
 				// Integration was disconnected/removed between enqueue and
@@ -3642,6 +3647,14 @@ func newPrepareLinearPrimaryHandler(svc *linear.Service, logger zerolog.Logger) 
 				// don't fire the dead-letter hook minutes after the user
 				// already saw "Reconnect" in settings.
 				return &FatalError{Err: err}
+			}
+			if errors.Is(err, db.ErrInvalidSessionIssueLink) {
+				if markErr := svc.MarkLinearPrepareFailedWithError(ctx, orgID, sessionID, invalidLinkMessage); markErr != nil {
+					logger.Warn().Err(markErr).
+						Str("session_id", sessionID.String()).
+						Msg("prepare_linear_primary failed to persist invalid-link message")
+				}
+				return &FatalError{Err: fmt.Errorf("%s: %w", invalidLinkMessage, err)}
 			}
 			return &RetryableError{Err: err}
 		}

--- a/internal/worker/handlers_test.go
+++ b/internal/worker/handlers_test.go
@@ -59,6 +59,70 @@ func (workerLinearCredentialReader) Get(context.Context, uuid.UUID, models.Provi
 	return &models.DecryptedCredential{Config: models.LinearConfig{AccessToken: "linear-token"}}, nil
 }
 
+type workerLinearClient struct {
+	fetch map[string]*linearservice.FetchedIssue
+	err   error
+}
+
+func (c workerLinearClient) FetchIssue(_ context.Context, identifier string) (*linearservice.FetchedIssue, error) {
+	if c.err != nil {
+		return nil, c.err
+	}
+	return c.fetch[identifier], nil
+}
+
+func (c workerLinearClient) ListTeamKeys(context.Context) ([]linearservice.TeamKeyInfo, error) {
+	return nil, c.err
+}
+
+func (c workerLinearClient) CreateOrUpdateAttachment(context.Context, linearservice.AttachmentWriteInput) (linearservice.AttachmentResult, error) {
+	return linearservice.AttachmentResult{}, c.err
+}
+
+func (c workerLinearClient) CreateComment(context.Context, string, string) (string, error) {
+	return "", c.err
+}
+
+func (c workerLinearClient) UpdateComment(context.Context, string, string) error {
+	return c.err
+}
+
+func (c workerLinearClient) FindRecentBotCommentByURL(context.Context, string, string) (string, error) {
+	return "", c.err
+}
+
+func (c workerLinearClient) WorkflowStateForType(context.Context, string, []string, string) (*linearservice.WorkflowState, error) {
+	return nil, c.err
+}
+
+func (c workerLinearClient) UpdateIssueState(context.Context, string, string) error {
+	return c.err
+}
+
+func (c workerLinearClient) IssueRecentHumanEdits(context.Context, string, time.Time) (bool, error) {
+	return false, c.err
+}
+
+func (c workerLinearClient) HasGitHubIntegrationAttachment(context.Context, string) (bool, error) {
+	return false, c.err
+}
+
+func (c workerLinearClient) AgentActivityCreate(context.Context, linearservice.AgentActivityInput) (linearservice.AgentActivityResult, error) {
+	return linearservice.AgentActivityResult{}, c.err
+}
+
+func (c workerLinearClient) AgentSessionUpdate(context.Context, linearservice.AgentSessionUpdateInput) error {
+	return c.err
+}
+
+func (c workerLinearClient) AgentSessionGet(context.Context, string) (*linearservice.FetchedAgentSession, error) {
+	return nil, c.err
+}
+
+func (c workerLinearClient) FetchComment(context.Context, string) (*linearservice.FetchedComment, error) {
+	return nil, c.err
+}
+
 // workerLinearIntegrationRecorder doubles as IntegrationReader and
 // IntegrationWriter so unauthorized-flow tests can both feed an active row
 // to MarkIntegrationUnauthorized's pre-write lookup and assert the resulting
@@ -828,6 +892,7 @@ func TestLinearJobHandlers(t *testing.T) {
 
 		stores, mock := newTestStores(t)
 		defer mock.Close()
+		stores.SessionIssueLinks = db.NewSessionIssueLinkStore(mock)
 
 		orgID := uuid.New()
 		sessionID := uuid.New()
@@ -858,6 +923,7 @@ func TestLinearJobHandlers(t *testing.T) {
 
 		stores, mock := newTestStores(t)
 		defer mock.Close()
+		stores.SessionIssueLinks = db.NewSessionIssueLinkStore(mock)
 
 		orgID := uuid.New()
 		sessionID := uuid.New()
@@ -885,6 +951,84 @@ func TestLinearJobHandlers(t *testing.T) {
 			WillReturnResult(pgxmock.NewResult("UPDATE", 1))
 		jobctx.RunDeadLetterHooks(handlerCtx, err)
 		require.NoError(t, mock.ExpectationsWereMet(), "dead-letter hook should mark prepare state failed after retries exhaust")
+	})
+
+	t.Run("prepare_linear_primary dead-letters fatally on invalid session issue link", func(t *testing.T) {
+		t.Parallel()
+
+		stores, mock := newTestStores(t)
+		defer mock.Close()
+		stores.SessionIssueLinks = db.NewSessionIssueLinkStore(mock)
+
+		orgID := uuid.New()
+		sessionID := uuid.New()
+		issueID := uuid.New()
+		handlerCtx := jobctx.WithDeadLetterHooks(context.Background())
+		svc := linearservice.NewService(linearservice.Config{
+			Sessions:     stores.Sessions,
+			Integrations: workerLinearIntegrationReader{},
+			Credentials:  workerLinearCredentialReader{},
+			Issues:       stores.Issues,
+			Links:        stores.SessionIssueLinks,
+			ClientFactory: func(context.Context, string) (linearservice.Client, error) {
+				return workerLinearClient{fetch: map[string]*linearservice.FetchedIssue{
+					"ACS-123": {
+						ID:            "linear-ACS-123",
+						Identifier:    "ACS-123",
+						Title:         "Fix ACS-123",
+						Description:   "issue body",
+						URL:           "https://linear.app/acme/issue/ACS-123",
+						StateName:     "Todo",
+						StateType:     "unstarted",
+						TeamID:        "team-1",
+						TeamKey:       "ACS",
+						WorkspaceSlug: "acme",
+					},
+				}}, nil
+			},
+			Logger: zerolog.Nop(),
+		})
+
+		mock.ExpectQuery("INSERT INTO issues").
+			WithArgs(
+				pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
+				pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
+				pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
+				pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
+			).
+			WillReturnRows(pgxmock.NewRows([]string{"id", "created_at", "updated_at"}).AddRow(issueID, time.Now(), time.Now()))
+		mock.ExpectQuery("INSERT INTO session_issue_links").
+			WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+			WillReturnError(pgx.ErrNoRows)
+		mock.ExpectQuery("SELECT id FROM session_issue_links").
+			WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+			WillReturnError(pgx.ErrNoRows)
+		mock.ExpectExec("UPDATE sessions[\\s\\S]+SET linear_prepare_state[\\s\\S]+linear_prepare_state <>").
+			WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+			WillReturnResult(pgxmock.NewResult("UPDATE", 1))
+		mock.ExpectQuery("(?s).*UPDATE sessions.*RETURNING.*").
+			WithArgs(workerAnyArgs(11)...).
+			WillReturnRows(pgxmock.NewRows(workerSessionColumns).AddRow(
+				workerSessionRowWithLinearPrepareState(sessionID, issueID, orgID, models.SessionStatusFailed, "failed")...,
+			))
+		handler := newPrepareLinearPrimaryHandler(svc, zerolog.Nop())
+		payload := json.RawMessage(`{"org_id":"` + orgID.String() + `","session_id":"` + sessionID.String() + `","identifiers":["ACS-123"]}`)
+
+		err := handler(handlerCtx, "prepare_linear_primary", payload)
+		require.Error(t, err, "invalid session issue links should surface as a handler error")
+		require.Contains(t, err.Error(), "Linear issue could not be linked", "invalid-link fatal error should explain the repository mismatch")
+		var fatal *FatalError
+		require.ErrorAs(t, err, &fatal, "invalid session issue links are permanent and must dead-letter immediately")
+		require.ErrorIs(t, err, db.ErrInvalidSessionIssueLink, "fatal wrapper should preserve the invalid-link sentinel")
+		var retryable *RetryableError
+		require.False(t, errors.As(err, &retryable), "invalid session issue links must not be classified as retryable")
+		require.NoError(t, mock.ExpectationsWereMet(), "fatal invalid-link handling should persist the specific message without retrying")
+
+		mock.ExpectExec("UPDATE sessions[\\s\\S]+SET linear_prepare_state[\\s\\S]+linear_prepare_state <>").
+			WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+			WillReturnResult(pgxmock.NewResult("UPDATE", 1))
+		jobctx.RunDeadLetterHooks(handlerCtx, err)
+		require.NoError(t, mock.ExpectationsWereMet(), "dead-letter hook should keep prepare state failed after the synchronous message write")
 	})
 
 	t.Run("prepare_linear_primary dead-letters fatally on missing integration", func(t *testing.T) {


### PR DESCRIPTION
I didn’t find any discrete correctness or maintainability issues in this change relative to `origin/main`.

The manual-session repo override path is wired through the linker and the new worker failure path is exercised by tests. Residual risk is mostly around behavioral policy: the new override intentionally relaxes Linear repo matching for any session that supplies a repository ID, so if that policy needs to stay limited to manual sessions only, that should be enforced at the call site rather than in the shared linear service.