### PR TITLE
Flatten startup failure diagnostics into a single alert panel

### DIFF
--- a/frontend/src/components/preview/preview-panel.test.tsx
+++ b/frontend/src/components/preview/preview-panel.test.tsx
@@ -718,11 +718,12 @@ describe("PreviewPanel component", () => {
       expect(screen.getByText("Preview failed to start")).toBeInTheDocument();
     });
 
-    const diagnosticSurface = screen.getByRole("group", {
-      name: "Preview startup diagnostics",
-    });
+    const diagnosticSurface = screen.getByRole("alert");
     const startupLogRegion = screen.getByLabelText("Preview startup error logs");
     expect(diagnosticSurface).toContainElement(startupLogRegion);
+    expect(
+      screen.queryByRole("group", { name: "Preview startup diagnostics" }),
+    ).not.toBeInTheDocument();
     expect(screen.getByText("Startup summary")).toBeInTheDocument();
     expect(startupLogRegion).toHaveTextContent(summary);
     expect(startupLogRegion).toHaveClass("max-h-28");

--- a/frontend/src/components/preview/preview-panel.tsx
+++ b/frontend/src/components/preview/preview-panel.tsx
@@ -1161,66 +1161,63 @@ export function PreviewPanel({
             errorSurfaceClassNames.container,
           )}
         >
-          <CardContent className="space-y-3 p-3">
-            <div className="flex items-start gap-2.5">
-              <div className="mt-0.5 flex size-6 shrink-0 items-center justify-center rounded-full border border-destructive/20 bg-background/80 text-destructive">
-                <AlertTriangle className="size-3.5" aria-hidden="true" />
-              </div>
-              <div className="min-w-0">
-                <div className="text-sm font-medium leading-5 text-foreground">
-                  Preview failed to start
+          <CardContent className="space-y-3.5 p-4">
+            <div className="flex items-start justify-between gap-3">
+              <div className="flex min-w-0 items-start gap-2.5">
+                <div className="mt-0.5 flex size-6 shrink-0 items-center justify-center rounded-full border border-destructive/20 bg-background/80 text-destructive">
+                  <AlertTriangle className="size-3.5" aria-hidden="true" />
                 </div>
-                <div className="text-xs leading-5 text-muted-foreground">
-                  The app never became reachable during startup.
+                <div className="min-w-0">
+                  <div className="text-sm font-medium leading-5 text-foreground">
+                    Preview failed to start
+                  </div>
+                  <div className="text-xs leading-5 text-muted-foreground">
+                    The app never became reachable during startup.
+                  </div>
                 </div>
               </div>
+              {visibleStartupErrorLogs &&
+                (startupErrorLogs ||
+                  previewLogsQuery.isLoading ||
+                  previewLogsQuery.isError) && (
+                  <Button
+                    variant="ghost"
+                    size="xs"
+                    className="h-7 shrink-0 px-2 text-xs text-muted-foreground hover:text-foreground"
+                    aria-expanded={showFullStartupLogs}
+                    aria-controls={startupErrorLogsId}
+                    onClick={() => setShowFullStartupLogs((open) => !open)}
+                  >
+                    {showFullStartupLogs
+                      ? "Show startup summary"
+                      : "View full error log"}
+                    <ChevronDown
+                      className={cn(
+                        "size-3 transition-transform duration-200",
+                        showFullStartupLogs && "rotate-180",
+                      )}
+                      aria-hidden="true"
+                    />
+                  </Button>
+                )}
             </div>
 
             {visibleStartupErrorLogs && (
-              <div
-                role="group"
-                aria-label="Preview startup diagnostics"
-                className="overflow-hidden rounded-md border border-destructive/15 bg-background/80 shadow-sm"
-              >
-                <div className="flex min-h-9 items-center justify-between gap-2 border-b border-border/60 px-3 py-1.5">
-                  <div className="flex min-w-0 items-center gap-2">
-                    <span
-                      className="size-1.5 shrink-0 rounded-full bg-destructive"
-                      aria-hidden="true"
-                    />
-                    <div className="truncate text-xs font-medium text-foreground">
-                      {showFullStartupLogs ? "Full error log" : "Startup summary"}
-                    </div>
+              <div className="border-t border-destructive/10 pt-3">
+                <div className="mb-1.5 flex min-w-0 items-center gap-2">
+                  <span
+                    className="size-1.5 shrink-0 rounded-full bg-destructive"
+                    aria-hidden="true"
+                  />
+                  <div className="truncate text-xs font-medium text-foreground">
+                    {showFullStartupLogs ? "Full error log" : "Startup summary"}
                   </div>
-                  {(startupErrorLogs ||
-                    previewLogsQuery.isLoading ||
-                    previewLogsQuery.isError) && (
-                    <Button
-                      variant="ghost"
-                      size="xs"
-                      className="h-6 shrink-0 px-2 text-xs text-muted-foreground hover:text-foreground"
-                      aria-expanded={showFullStartupLogs}
-                      aria-controls={startupErrorLogsId}
-                      onClick={() => setShowFullStartupLogs((open) => !open)}
-                    >
-                      {showFullStartupLogs
-                        ? "Show startup summary"
-                        : "View full error log"}
-                      <ChevronDown
-                        className={cn(
-                          "size-3 transition-transform duration-200",
-                          showFullStartupLogs && "rotate-180",
-                        )}
-                        aria-hidden="true"
-                      />
-                    </Button>
-                  )}
                 </div>
                 <pre
                   id={startupErrorLogsId}
                   aria-label="Preview startup error logs"
                   className={cn(
-                    "whitespace-pre-wrap break-words px-3 py-2.5 font-mono text-xs leading-5 text-foreground/85",
+                    "whitespace-pre-wrap break-words font-mono text-xs leading-5 text-foreground/85",
                     showFullStartupLogs
                       ? "max-h-[min(56vh,28rem)] overflow-y-auto"
                       : "max-h-28 overflow-hidden [mask-image:linear-gradient(to_bottom,black_75%,transparent_100%)]",


### PR DESCRIPTION
## Summary
This change updates the Preview Panel UI so failed preview startup diagnostics render as one cohesive alert surface instead of a nested bordered card. It improves visual hierarchy and keeps the “View full error log” control in the panel header area.

## Changes
- **frontend/src/components/preview/preview-panel.tsx**
  - Reworked the startup failure diagnostics layout to render inside a single **`role="alert"`** panel.
  - Removed the nested diagnostics/card container previously labeled **`Preview startup diagnostics`**.
  - Moved the “View full error log” / “Show startup summary” toggle into the main alert header area (toggle remains accessible from the panel).
  - Added subtle divider/structure changes so the summary and log region sit within the same destructive alert surface.
- **frontend/src/components/preview/preview-panel.test.tsx**
  - Updated regression assertions to expect an **`alert`** role container for startup diagnostics.
  - Added an assertion that the separate `Preview startup diagnostics` group is **not** rendered.
  - Confirmed startup log region remains labeled and contains the expected summary text.

## Test plan
- `npm test -- preview-panel.test.tsx --run`
- `npm run typecheck`
- `npm run lint`
- `npm run build` (Next.js middleware deprecation warning may appear, but build completes successfully)

[143.dev](https://143.dev) | [session d0f5cef3](https://143.dev/sessions/d0f5cef3-7fdc-4a55-b827-341041202779)

Preview: https://143.dev/previews/github/assembledhq/143/pull/1174