### PR TITLE
Fix automations edit UI layout: inline timezone, larger goal textarea, advanced settings collapse

### DIFF
--- a/frontend/src/app/(dashboard)/automations/[id]/page.test.tsx
+++ b/frontend/src/app/(dashboard)/automations/[id]/page.test.tsx
@@ -128,8 +128,8 @@ describe("AutomationDetailPage", () => {
     const hourTrigger = screen.getByLabelText("Run at hour");
     const minuteTrigger = screen.getByLabelText("Run at minute");
 
-    expect(scheduleRow).toHaveClass("flex-wrap");
-    expect(timezoneButton).toHaveClass("w-full", "sm:w-auto");
+    expect(scheduleRow).not.toHaveClass("flex-wrap");
+    expect(timezoneButton).toHaveClass("w-[12.5rem]", "max-w-full");
     expect(intervalUnitTrigger).toHaveClass("h-9", "text-xs", "max-sm:text-base");
     expect(hourTrigger).toHaveClass("h-9", "text-xs", "max-sm:text-base");
     expect(minuteTrigger).toHaveClass("h-9", "text-xs", "max-sm:text-base");
@@ -139,6 +139,69 @@ describe("AutomationDetailPage", () => {
     expect(runEveryText).toHaveClass("text-xs", "font-medium", "leading-none", "text-muted-foreground");
     expect(atText).toHaveClass("text-xs", "font-medium", "leading-none", "text-muted-foreground");
     expect(screen.queryByText(/Run time is in/i)).not.toBeInTheDocument();
+  });
+
+  it("keeps advanced automation controls collapsed by default", async () => {
+    server.use(
+      http.get("*/api/v1/automations/auto-1", () => HttpResponse.json({
+        data: {
+          id: "auto-1",
+          org_id: "org-1",
+          repository_id: "repo-1",
+          name: "Weekly audit",
+          goal: "Check release health",
+          scope: "",
+          interval_value: 1,
+          interval_unit: "weeks",
+          base_branch: "main",
+          enabled: true,
+          timezone: "UTC",
+          last_run_at: null,
+          next_run_at: null,
+          priority: 50,
+          created_at: "2026-01-01T00:00:00Z",
+          updated_at: "2026-01-01T00:00:00Z",
+        },
+      })),
+      http.get("*/api/v1/automations/auto-1/runs*", () => HttpResponse.json({ data: [], meta: {} })),
+      http.get("*/api/v1/automations/auto-1/stats*", () => HttpResponse.json({
+        data: {
+          since: "2026-01-01T00:00:00Z",
+          until: "2026-01-31T00:00:00Z",
+          buckets: [],
+          totals: {
+            total: 0,
+            completed: 0,
+            completed_noop: 0,
+            failed: 0,
+            skipped: 0,
+            running: 0,
+            pending: 0,
+            success_rate: 0,
+            avg_duration_seconds: 0,
+          },
+        },
+      })),
+    );
+
+    renderWithProviders(<AutomationDetailPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Weekly audit")).toBeInTheDocument();
+    });
+
+    await userEvent.setup().click(screen.getByRole("button", { name: "Edit" }));
+
+    expect(screen.getByLabelText("Goal")).toHaveAttribute("rows", "9");
+    expect(screen.queryByRole("combobox", { name: "Model" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Base branch" })).not.toBeInTheDocument();
+    expect(screen.queryByLabelText("Review passes")).not.toBeInTheDocument();
+
+    await userEvent.setup().click(screen.getByRole("button", { name: "Advanced settings" }));
+
+    expect(screen.getByRole("combobox", { name: "Model" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Base branch" })).toBeInTheDocument();
+    expect(screen.getByLabelText("Review passes")).toBeInTheDocument();
   });
 
   it("updates the browser tab title with the automation name", async () => {
@@ -577,6 +640,7 @@ describe("AutomationDetailPage", () => {
     });
 
     await user.click(screen.getByRole("button", { name: "Edit" }));
+    await user.click(screen.getByRole("button", { name: "Advanced settings" }));
     await user.click(await screen.findByRole("button", { name: "Base branch" }));
     await user.type(await screen.findByPlaceholderText("Search branches..."), "ops");
     await user.click(await screen.findByText("release/ops"));
@@ -1173,6 +1237,7 @@ describe("AutomationDetailPage", () => {
     });
 
     await user.click(screen.getByRole("button", { name: "Edit" }));
+    await user.click(screen.getByRole("button", { name: "Advanced settings" }));
     await user.click(screen.getByRole("combobox", { name: "Model" }));
     await user.click(await screen.findByText("claude-sonnet-4-6"));
     await user.click(screen.getByRole("button", { name: "Save changes" }));
@@ -1274,6 +1339,7 @@ describe("AutomationDetailPage", () => {
     });
 
     await user.click(screen.getByRole("button", { name: "Edit" }));
+    await user.click(screen.getByRole("button", { name: "Advanced settings" }));
     await user.click(await screen.findByRole("button", { name: "Base branch" }));
     await user.type(await screen.findByPlaceholderText("Search branches..."), "ops");
     await user.click(await screen.findByText("release/ops"));
@@ -1370,6 +1436,7 @@ describe("AutomationDetailPage", () => {
     });
 
     await user.click(screen.getByRole("button", { name: "Edit" }));
+    await user.click(screen.getByRole("button", { name: "Advanced settings" }));
     await user.click(screen.getByRole("combobox", { name: "Reasoning" }));
     await user.click(await screen.findByText("High"));
     await user.click(screen.getByRole("button", { name: "Save changes" }));

--- a/frontend/src/app/(dashboard)/automations/[id]/page.tsx
+++ b/frontend/src/app/(dashboard)/automations/[id]/page.tsx
@@ -3,11 +3,12 @@
 import { useMemo, useRef, useState, type ReactNode } from "react";
 import dynamic from "next/dynamic";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
-import { Play, Pause, Loader2, Minus, Plus, Settings2 } from "lucide-react";
+import { ChevronDown, Play, Pause, Loader2, Minus, Plus, Settings2 } from "lucide-react";
 import { useParams, useRouter } from "next/navigation";
 import Link from "next/link";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import {
@@ -193,7 +194,7 @@ function SettingsTab({
           repositoryId={automation.repository_id ?? undefined}
           branch={baseBranch?.trim() || automation.base_branch || undefined}
           agentType={effectiveAgentType}
-          rows={3}
+          rows={9}
           ariaInvalid={goalLength.isTooLong}
         />
         <p className={cn("text-xs", goalLength.isTooLong ? "text-destructive" : "text-muted-foreground")}>
@@ -256,7 +257,7 @@ function SettingsTab({
               </SelectContent>
             </Select>
           </div>
-          <div className="flex flex-wrap items-start gap-2 sm:items-center">
+          <div className="grid grid-cols-[auto_5rem_auto_5rem_minmax(0,12.5rem)] items-center gap-2">
             <span className="text-xs font-medium leading-none text-muted-foreground">At</span>
             <Select value={intervalRunHour} onValueChange={setIntervalRunHour}>
               <SelectTrigger className="h-9 w-20" aria-label="Run at hour">
@@ -287,95 +288,109 @@ function SettingsTab({
               value={timezone}
               onChange={setTimezone}
               detected={detectedTimezone}
-              className="w-full sm:w-auto"
+              className="w-[12.5rem] max-w-full"
             />
           </div>
         </div>
       </div>
-      <div className="space-y-1.5">
-        <Label htmlFor="automation-model">Model</Label>
-        <AutomationModelSelect
-          id="automation-model"
-          ariaLabel="Model"
-          value={model}
-          onValueChange={setModel}
-        />
-      </div>
-      {showReasoningSelector ? (
-        <div className="space-y-1.5">
-          <Label htmlFor="automation-reasoning">Reasoning</Label>
-          <Select
-            value={reasoningEffort || "__default__"}
-            onValueChange={(value) => setReasoningEffort(value === "__default__" ? "" : toCodingAgentReasoningEffort(value))}
-          >
-            <SelectTrigger id="automation-reasoning" aria-label="Reasoning">
-              <SelectValue placeholder="Default reasoning" />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value="__default__">Default reasoning</SelectItem>
-              {reasoningOptions.map((option) => (
-                <SelectItem key={option.value} value={option.value}>
-                  {option.label}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-        </div>
-      ) : null}
-      <div className="space-y-1.5">
-        <Label>Base branch</Label>
-        <BranchPicker
-          repositoryId={automation.repository_id ?? ""}
-          value={baseBranch}
-          defaultBranch={automation.base_branch}
-          onValueChange={setBaseBranch}
-          label="Base branch"
-          buttonClassName="w-full justify-between"
-          contentClassName="w-[var(--radix-popover-trigger-width)]"
-        />
-      </div>
-      <div className="space-y-1.5">
-        <Label htmlFor="pre-pr-review-loops">Pre-PR review</Label>
-        <div className="flex items-center gap-2">
+      <Collapsible className="rounded-md border border-border">
+        <CollapsibleTrigger asChild>
           <Button
             type="button"
-            variant="outline"
-            size="icon"
-            aria-label="Decrease review passes"
-            onClick={() => setPrePRReviewLoops((value) => Math.max(0, value - 1))}
-            disabled={!canManage || !supportsNativeReviewLoop}
+            variant="ghost"
+            className="group h-10 w-full justify-between rounded-md px-3 text-left"
           >
-            <Minus className="h-4 w-4" />
+            <span>Advanced settings</span>
+            <ChevronDown className="h-4 w-4 text-muted-foreground transition-transform group-data-[state=open]:rotate-180" />
           </Button>
-          <Input
-            id="pre-pr-review-loops"
-            aria-label="Review passes"
-            type="number"
-            min={0}
-            max={5}
-            value={effectivePrePRReviewLoops}
-            onChange={(e) => {
-              const parsed = parseInt(e.target.value, 10);
-              setPrePRReviewLoops(Number.isNaN(parsed) ? 0 : Math.min(5, Math.max(0, parsed)));
-            }}
-            disabled={!canManage || !supportsNativeReviewLoop}
-            className="w-20 text-center"
-          />
-          <Button
-            type="button"
-            variant="outline"
-            size="icon"
-            aria-label="Increase review passes"
-            onClick={() => setPrePRReviewLoops((value) => Math.min(5, value + 1))}
-            disabled={!canManage || !supportsNativeReviewLoop}
-          >
-            <Plus className="h-4 w-4" />
-          </Button>
-        </div>
-        <p className="text-xs text-muted-foreground">
-          {prePRReviewDescription}
-        </p>
-      </div>
+        </CollapsibleTrigger>
+        <CollapsibleContent className="space-y-4 border-t border-border p-3">
+          <div className="space-y-1.5">
+            <Label htmlFor="automation-model">Model</Label>
+            <AutomationModelSelect
+              id="automation-model"
+              ariaLabel="Model"
+              value={model}
+              onValueChange={setModel}
+            />
+          </div>
+          {showReasoningSelector ? (
+            <div className="space-y-1.5">
+              <Label htmlFor="automation-reasoning">Reasoning</Label>
+              <Select
+                value={reasoningEffort || "__default__"}
+                onValueChange={(value) => setReasoningEffort(value === "__default__" ? "" : toCodingAgentReasoningEffort(value))}
+              >
+                <SelectTrigger id="automation-reasoning" aria-label="Reasoning">
+                  <SelectValue placeholder="Default reasoning" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="__default__">Default reasoning</SelectItem>
+                  {reasoningOptions.map((option) => (
+                    <SelectItem key={option.value} value={option.value}>
+                      {option.label}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+          ) : null}
+          <div className="space-y-1.5">
+            <Label>Base branch</Label>
+            <BranchPicker
+              repositoryId={automation.repository_id ?? ""}
+              value={baseBranch}
+              defaultBranch={automation.base_branch}
+              onValueChange={setBaseBranch}
+              label="Base branch"
+              buttonClassName="w-full justify-between"
+              contentClassName="w-[var(--radix-popover-trigger-width)]"
+            />
+          </div>
+          <div className="space-y-1.5">
+            <Label htmlFor="pre-pr-review-loops">Pre-PR review</Label>
+            <div className="flex items-center gap-2">
+              <Button
+                type="button"
+                variant="outline"
+                size="icon"
+                aria-label="Decrease review passes"
+                onClick={() => setPrePRReviewLoops((value) => Math.max(0, value - 1))}
+                disabled={!canManage || !supportsNativeReviewLoop}
+              >
+                <Minus className="h-4 w-4" />
+              </Button>
+              <Input
+                id="pre-pr-review-loops"
+                aria-label="Review passes"
+                type="number"
+                min={0}
+                max={5}
+                value={effectivePrePRReviewLoops}
+                onChange={(e) => {
+                  const parsed = parseInt(e.target.value, 10);
+                  setPrePRReviewLoops(Number.isNaN(parsed) ? 0 : Math.min(5, Math.max(0, parsed)));
+                }}
+                disabled={!canManage || !supportsNativeReviewLoop}
+                className="w-20 text-center"
+              />
+              <Button
+                type="button"
+                variant="outline"
+                size="icon"
+                aria-label="Increase review passes"
+                onClick={() => setPrePRReviewLoops((value) => Math.min(5, value + 1))}
+                disabled={!canManage || !supportsNativeReviewLoop}
+              >
+                <Plus className="h-4 w-4" />
+              </Button>
+            </div>
+            <p className="text-xs text-muted-foreground">
+              {prePRReviewDescription}
+            </p>
+          </div>
+        </CollapsibleContent>
+      </Collapsible>
       {canManage && (
         <div className="flex items-center gap-3 pt-2">
           <Button


### PR DESCRIPTION
## Summary
Adjusted the automation edit page UI to eliminate form layout issues and reduce visual noise: timezone controls no longer wrap, the goal editor is larger, and model/review/base-branch fields are tucked under a collapsed “Advanced settings” section. Updated and extended the existing page tests to cover the new default/expanded states.

## Changes
- `frontend/src/app/(dashboard)/automations/[id]/page.tsx`
  - Increased the Goal textarea to 9 rows for better editing ergonomics.
  - Kept the timezone picker inline with schedule time controls and forced a fixed `12.5rem` width with truncation (`w-[12.5rem] max-w-full`) to prevent wrapping/taller schedule rows.
  - Moved “Model”, “Reasoning”, “Base branch”, and “Pre-PR review” inputs under a collapsed **Advanced settings** panel, and ensured they’re only rendered when expanded.
- `frontend/src/app/(dashboard)/automations/[id]/page.test.tsx`
  - Updated timezone/layout assertions (no `flex-wrap`, fixed width classes for the timezone button).
  - Added a test verifying advanced controls are collapsed by default and appear after clicking **Advanced settings**.
  - Tweaked an existing interaction flow to include expanding **Advanced settings** before asserting advanced fields.

## Test plan
- `npm run test -- 'src/app/(dashboard)/automations/[id]/page.test.tsx'`
- `npm run typecheck`
- `npm run lint`
- `npm run build`

[143.dev](https://143.dev) | [session 13db47df](https://143.dev/sessions/13db47df-643e-44e9-8039-e15eb5241839)

Preview: https://143.dev/previews/github/assembledhq/143/pull/1177