### PR TITLE
Remove desktop “Review N files” button and use Changes tab file list as review entry point

### DIFF
--- a/frontend/src/app/(dashboard)/sessions/[id]/page.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/page.test.tsx
@@ -7217,9 +7217,8 @@ describe('SessionDetailPage', () => {
     const changesTab = screen.getByRole('tab', { name: /^Changes/ });
     await user.click(changesTab);
 
-    // Click "Review 1 file" button to enter review mode
-    const reviewButton = await screen.findByText(/Review 1 file/);
-    await user.click(reviewButton);
+    expect(screen.queryByRole('button', { name: /Review 1 file/ })).not.toBeInTheDocument();
+    await user.click(await screen.findByRole('button', { name: /app\.ts/ }));
 
     // Should show the file content in the review diff view
     expect((await screen.findAllByText('src/app.ts')).length).toBeGreaterThan(0);
@@ -7829,7 +7828,7 @@ describe('SessionDetailPage', () => {
     expect(screen.getByTitle('Hide details')).toBeInTheDocument();
   });
 
-  it('shows review file count in Changes tab and file click works', async () => {
+  it('uses the Changes tab file list as the desktop review entry point', async () => {
     const sessionWithDiff: Session = {
       ...mockSessions[0],
       diff: 'diff --git a/src/app.ts b/src/app.ts\n--- a/src/app.ts\n+++ b/src/app.ts\n@@ -1,3 +1,4 @@\n import express from "express";\n+import cors from "cors";\n const app = express();\n app.listen(3000);\ndiff --git a/src/new.ts b/src/new.ts\n--- /dev/null\n+++ b/src/new.ts\n@@ -0,0 +1 @@\n+export const x = 1;',
@@ -7845,8 +7844,10 @@ describe('SessionDetailPage', () => {
     const changesTab = screen.getByRole('tab', { name: /^Changes/ });
     await user.click(changesTab);
 
-    // Should show "Review 2 files" button
-    expect(await screen.findByText(/Review 2 files/)).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /Review 2 files/ })).not.toBeInTheDocument();
+    await user.click(await screen.findByRole('button', { name: /app\.ts/ }));
+
+    expect((await screen.findAllByText('src/app.ts')).length).toBeGreaterThan(0);
   });
 
   it('keeps the review diff file set aligned with the Changes tab attribution filter', async () => {
@@ -7970,10 +7971,10 @@ describe('SessionDetailPage', () => {
     await user.click(within(changesPanel).getByRole('combobox'));
     await user.click(await screen.findByRole('option', { name: 'Touched by Codex' }));
 
-    expect(await screen.findByText('Review 2 files')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Review 2 files' })).not.toBeInTheDocument();
     expect(screen.queryByText(/^automation-model-select\.tsx$/)).not.toBeInTheDocument();
 
-    await user.click(screen.getByRole('button', { name: 'Review 2 files' }));
+    await user.click(await screen.findByRole('button', { name: /app\.ts/ }));
 
     expect(await screen.findByText('frontend/src/app.ts')).toBeInTheDocument();
     expect(screen.getByText('frontend/src/lib/helpers.ts')).toBeInTheDocument();

--- a/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
@@ -881,19 +881,6 @@ const ChangesTab = memo(function ChangesTab({
               <p className="mt-1 text-amber-900/80 dark:text-amber-100/80">{diffTruncationText}</p>
             </div>
           ) : null}
-          {!isMobile ? (
-            <div className="px-4 py-3">
-              <Button
-                type="button"
-                variant="outline"
-                onClick={() => onOpenReview()}
-                className="w-full gap-2 text-xs"
-              >
-                <FileCode2 className="h-3.5 w-3.5" />
-                Review {filteredFiles.length} {filteredFiles.length === 1 ? "file" : "files"}
-              </Button>
-            </div>
-          ) : null}
           <div className="flex-1 overflow-hidden">
             <FileTree
               files={filteredFiles}


### PR DESCRIPTION
## Summary
Removed the desktop “Review N files” button from the session detail page. Review mode is now entered by clicking a file in the Changes tab, keeping the selected diff set consistent with the tab’s attribution-filtered file list.

## Changes
- **frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx**
  - Removed the non-mobile “Review N files” button UI that called `onOpenReview()`.
  - Routed desktop users to the existing behavior: clicking a file in the Changes tab opens the diff reader.
- **frontend/src/app/(dashboard)/sessions/[id]/page.test.tsx**
  - Updated tests to assert the “Review 1/2 files” buttons are no longer present.
  - Updated review-mode navigation in tests to click a file (e.g., `app.ts`) instead of the removed button.
  - Ensured tests still verify the diff file set stays aligned with the Changes tab attribution filter.

## Test plan
- `npm test -- --run 'src/app/(dashboard)/sessions/[id]/page.test.tsx' -t 'desktop review entry point|enters review mode|aligned with the Changes tab attribution filter'`
- `npm run typecheck`
- `npm run lint`
- `npm run build`

[143.dev](https://143.dev) | [session 6dadbb24](https://143.dev/sessions/6dadbb24-4542-48d3-a456-c6efc511067a)

Preview: https://143.dev/previews/github/assembledhq/143/pull/1178