### PR TITLE
Fix empty session transcript after completed agent runs

### DIFF
--- a/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.test.ts
+++ b/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.test.ts
@@ -5,6 +5,7 @@ import {
   formatDuration,
   getInitialComposerSelectedModel,
   getPendingEditableThreadUpdate,
+  getVisibleThreadLogTurns,
   hasCleanReviewLoopForSnapshot,
   invalidateSessionHumanInputRequests,
   trackInFlightAgentUpdate,
@@ -214,6 +215,24 @@ describe("thread message windows", () => {
       [log(10, 1), log(20, 1)],
       [],
     ).map((item) => item.id)).toEqual([10, 20]);
+  });
+
+  it("includes the execution turn for completed threads without assistant messages", () => {
+    expect(getVisibleThreadLogTurns(
+      [message(1, 0)],
+      {
+        id: "thread-1",
+        session_id: "session-1",
+        org_id: "org-1",
+        agent_type: "codex",
+        label: "Main",
+        status: "completed",
+        current_turn: 0,
+        created_at: start,
+        cost_cents: 0,
+        pending_message_count: 0,
+      },
+    )).toEqual([0, 1]);
   });
 });
 

--- a/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
@@ -1961,6 +1961,14 @@ function loadedTurnNumbers(messages: SessionMessage[]): number[] {
   return Array.from(new Set(messages.map((message) => message.turn_number))).sort((a, b) => a - b);
 }
 
+export function getVisibleThreadLogTurns(messages: SessionMessage[], thread?: SessionThread): number[] {
+  const turns = new Set(loadedTurnNumbers(messages));
+  if (thread && thread.status !== "idle" && Number.isInteger(thread.current_turn) && thread.current_turn >= 0) {
+    turns.add(thread.current_turn + 1);
+  }
+  return Array.from(turns).sort((a, b) => a - b);
+}
+
 function threadMessageWindowQueryKey(sessionId: string, threadId: string): readonly unknown[] {
   return [...queryKeys.sessions.threadMessages(sessionId, threadId), "window"];
 }
@@ -2086,17 +2094,10 @@ function ChatPanel({
   const threadMessages = useMemo(() => {
     return flattenThreadMessageWindows(threadMessagesQuery.data?.pages);
   }, [threadMessagesQuery.data?.pages]);
-  const loadedThreadTurns = useMemo(() => loadedTurnNumbers(threadMessages), [threadMessages]);
-  const activeThreadLogTurn = activeThread && workingStatusesSet.has(activeThread.status)
-    ? activeThread.current_turn + 1
-    : null;
-  const visibleThreadLogTurns = useMemo(() => {
-    const turns = new Set(loadedThreadTurns);
-    if (activeThreadLogTurn !== null) {
-      turns.add(activeThreadLogTurn);
-    }
-    return Array.from(turns).sort((a, b) => a - b);
-  }, [activeThreadLogTurn, loadedThreadTurns]);
+  const visibleThreadLogTurns = useMemo(
+    () => getVisibleThreadLogTurns(threadMessages, activeThread),
+    [activeThread, threadMessages],
+  );
   const visibleThreadLogTurnsKey = visibleThreadLogTurns.join(",");
 
   const threadLogsQuery = useQuery({
@@ -2197,7 +2198,7 @@ function ChatPanel({
       const loadedThreadLogs = filterThreadLogsForLoadedMessages(
         threadLogsQuery.data?.data ?? [],
         threadMessages,
-        activeThreadLogTurn !== null ? [activeThreadLogTurn] : [],
+        visibleThreadLogTurns,
       );
       return sortTimelineEntries([...buildTimeline(
         mergePendingMessages(threadMessages, optimisticForCurrentView),
@@ -2223,7 +2224,7 @@ function ChatPanel({
       created_at: session.created_at,
     };
     return [{ kind: "message" as const, data: syntheticMsg }, ...entries];
-  }, [activeThreadId, activeThreadLogTurn, optimisticMessages, threadMessages, threadLogsQuery.data?.data, timelineQuery.data?.data, issueQuery.data?.data?.description, sessionId, session.org_id, session.created_at, humanInputQuery.data?.data]);
+  }, [activeThreadId, optimisticMessages, threadMessages, threadLogsQuery.data?.data, timelineQuery.data?.data, issueQuery.data?.data?.description, sessionId, session.org_id, session.created_at, humanInputQuery.data?.data, visibleThreadLogTurns]);
 
   // Walk baseTimelineEntries once when it changes to derive the dedup keys
   // used to filter streamedLogs. Splitting this out of the timelineEntries


### PR DESCRIPTION
## Summary
- Include the thread execution turn when building the visible log window for any non-idle thread, not just while it is actively running.
- This restores persisted agent logs for completed sessions whose transcript only has the initial user turn but whose logs live on the next turn.
- Added a regression test covering completed threads with no assistant message.

## Testing
- `npm run test -- session-detail-content.test.ts --run`
- `npm run typecheck`
- `npm run lint`
- `npm run build`