### PR TITLE
Recompute session diffs when the adapter returns none

### DIFF
--- a/internal/services/agent/orchestrator.go
+++ b/internal/services/agent/orchestrator.go
@@ -5086,12 +5086,13 @@ func (o *Orchestrator) buildRunResult(ctx context.Context, run *models.Session, 
 
 	headSHA := o.captureCurrentHeadSHA(ctx, sandbox)
 	workspaceDirty := o.captureWorkspaceDirty(ctx, sandbox)
+	diff := o.resultDiffOrWorkspaceFallback(ctx, run, sandbox, result.Diff)
 
 	return &models.SessionResult{
 		TokenUsage:         tokenUsage,
 		ModelUsed:          modelUsed,
 		ResultSummary:      strPtr(result.Summary),
-		Diff:               strPtr(result.Diff),
+		Diff:               strPtr(diff),
 		Error:              strPtr(result.Error),
 		DiffBaseCommitSHA:  run.BaseCommitSHA,
 		DiffHeadCommitSHA:  headSHA,
@@ -5099,6 +5100,30 @@ func (o *Orchestrator) buildRunResult(ctx context.Context, run *models.Session, 
 		DiffCollectedAt:    timePtr(time.Now().UTC()),
 		DiffSource:         "turn_complete",
 	}
+}
+
+func (o *Orchestrator) resultDiffOrWorkspaceFallback(ctx context.Context, run *models.Session, sandbox *Sandbox, resultDiff string) string {
+	if strings.TrimSpace(resultDiff) != "" || run == nil {
+		return resultDiff
+	}
+	baseCommitSHA := derefString(run.BaseCommitSHA)
+	if baseCommitSHA == "" {
+		return resultDiff
+	}
+	targetBranch := derefString(run.TargetBranch)
+	diff, err := o.collectWorkspaceDiff(ctx, sandbox, baseCommitSHA, targetBranch)
+	if err != nil {
+		if !errors.Is(err, errNoBaseCommitSHA) {
+			o.logger.Warn().
+				Err(err).
+				Str("session_id", run.ID.String()).
+				Str("base_commit_sha", baseCommitSHA).
+				Str("target_branch", targetBranch).
+				Msg("failed to recompute workspace diff after empty agent result diff")
+		}
+		return resultDiff
+	}
+	return diff
 }
 
 func (o *Orchestrator) captureCurrentHeadSHA(ctx context.Context, sandbox *Sandbox) *string {

--- a/internal/services/agent/orchestrator_test.go
+++ b/internal/services/agent/orchestrator_test.go
@@ -3867,6 +3867,57 @@ func TestRunAgent_PersistsDiffWorkspaceDirtyOnResult(t *testing.T) {
 	require.True(t, last.result.DiffWorkspaceDirty, "RunAgent should persist whether the session workspace still had uncommitted changes")
 }
 
+func TestRunAgent_RecomputesDiffWhenAdapterLeavesDiffEmpty(t *testing.T) {
+	t.Parallel()
+
+	orgID := testOrg()
+	issue := testIssue(orgID)
+	run := testRun(orgID, issue.ID)
+	run.TargetBranch = strPtr("main")
+	expectedDiff := "diff --git a/main.go b/main.go\n--- a/main.go\n+++ b/main.go\n@@ -1 +1 @@\n-old\n+new\n"
+
+	d := defaultDeps()
+	d.adapter.executeFn = func(ctx context.Context, sandbox *agent.Sandbox, prompt *agent.AgentPrompt, logCh chan<- agent.LogEntry) (*agent.AgentResult, error) {
+		return &agent.AgentResult{
+			Summary:  "done",
+			ExitCode: 0,
+		}, nil
+	}
+
+	headCalls := 0
+	d.provider.ExecFn = func(ctx context.Context, sb *agent.Sandbox, cmd string, stdout, stderr io.Writer) (int, error) {
+		switch cmd {
+		case "git rev-parse HEAD":
+			headCalls++
+			if headCalls == 1 {
+				_, _ = io.WriteString(stdout, "base123\n")
+			} else {
+				_, _ = io.WriteString(stdout, "result456\n")
+			}
+		case "git rev-parse --is-inside-work-tree":
+			_, _ = io.WriteString(stdout, "true\n")
+		case "git fetch --quiet --no-tags origin 'main'":
+			return 0, nil
+		case "git merge-base 'origin/main' HEAD":
+			_, _ = io.WriteString(stdout, "base123\n")
+		case "git diff --find-renames --binary base123 -- .":
+			_, _ = io.WriteString(stdout, expectedDiff)
+		case "git ls-files --others --exclude-standard -- .":
+			return 0, nil
+		}
+		return 0, nil
+	}
+
+	err := buildOrchestrator(d).RunAgent(context.Background(), run)
+	require.NoError(t, err, "RunAgent should succeed when the orchestrator can recompute the diff")
+
+	results := d.sessions.getResultUpdates()
+	require.NotEmpty(t, results, "RunAgent should persist a final result update")
+	last := results[len(results)-1]
+	require.NotNil(t, last.result.Diff, "RunAgent should persist the recomputed diff when the adapter leaves it empty")
+	require.Equal(t, expectedDiff, *last.result.Diff, "RunAgent should persist the fallback diff computed from the session base commit")
+}
+
 func TestRunAgent_UsesDesignatedWorkingBranchForSandboxAndSession(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- Recompute the session diff from the sandbox workspace when the agent adapter returns an empty diff.
- Preserve the adapter-provided diff when it is present, and fall back only when the run has a base commit to compare against.
- Log recomputation failures without blocking result persistence.
- Add coverage for the empty-diff fallback path in `RunAgent`.

## Testing
- Added a unit test that verifies the orchestrator persists a recomputed diff when the adapter result leaves `Diff` empty.
- Existing agent orchestration coverage continues to pass for diff persistence and workspace state handling.