### PR TITLE
Add PWA manifest/viewport metadata and tests for 143.dev

### DIFF
--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -1,6 +1,6 @@
 import { GeistSans } from "geist/font/sans";
 import { GeistMono } from "geist/font/mono";
-import type { Metadata } from "next";
+import type { Metadata, Viewport } from "next";
 import { Providers } from "@/components/providers";
 import { AppToaster } from "@/components/ui/app-toaster";
 import "./globals.css";
@@ -11,6 +11,18 @@ export const metadata: Metadata = {
     default: "143",
     template: "143 | %s",
   },
+  manifest: "/manifest.webmanifest",
+  icons: {
+    icon: [{ url: "/icon.svg", type: "image/svg+xml" }],
+    shortcut: [{ url: "/icon.svg", type: "image/svg+xml" }],
+  },
+};
+
+export const viewport: Viewport = {
+  themeColor: [
+    { media: "(prefers-color-scheme: light)", color: "#091f33" },
+    { media: "(prefers-color-scheme: dark)", color: "#091f33" },
+  ],
 };
 
 export default function RootLayout({

--- a/frontend/src/app/manifest.ts
+++ b/frontend/src/app/manifest.ts
@@ -1,0 +1,28 @@
+import type { MetadataRoute } from "next";
+
+export default function manifest(): MetadataRoute.Manifest {
+  return {
+    name: "143",
+    short_name: "143",
+    description: "Shared coding-agent infrastructure for engineering teams.",
+    start_url: "/",
+    scope: "/",
+    display: "standalone",
+    theme_color: "#091f33",
+    background_color: "#091f33",
+    icons: [
+      {
+        src: "/icon.svg",
+        sizes: "any",
+        type: "image/svg+xml",
+        purpose: "any",
+      },
+      {
+        src: "/icon.svg",
+        sizes: "any",
+        type: "image/svg+xml",
+        purpose: "maskable",
+      },
+    ],
+  };
+}

--- a/frontend/src/app/pwa-metadata.test.ts
+++ b/frontend/src/app/pwa-metadata.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it, vi } from "vitest";
+import manifest from "./manifest";
+import { metadata, viewport } from "./layout";
+
+vi.mock("geist/font/sans", () => ({
+  GeistSans: { variable: "font-sans" },
+}));
+
+vi.mock("geist/font/mono", () => ({
+  GeistMono: { variable: "font-mono" },
+}));
+
+describe("PWA metadata", () => {
+  it("exposes Chrome branding colors and icons", () => {
+    const appManifest = manifest();
+
+    expect(metadata.manifest).toBe("/manifest.webmanifest");
+    expect(metadata.icons).toEqual({
+      icon: [{ url: "/icon.svg", type: "image/svg+xml" }],
+      shortcut: [{ url: "/icon.svg", type: "image/svg+xml" }],
+    });
+    expect(viewport.themeColor).toEqual([
+      { media: "(prefers-color-scheme: light)", color: "#091f33" },
+      { media: "(prefers-color-scheme: dark)", color: "#091f33" },
+    ]);
+    expect(appManifest).toMatchObject({
+      name: "143",
+      short_name: "143",
+      theme_color: "#091f33",
+      background_color: "#091f33",
+      display: "standalone",
+    });
+    expect(appManifest.icons).toEqual([
+      {
+        src: "/icon.svg",
+        sizes: "any",
+        type: "image/svg+xml",
+        purpose: "any",
+      },
+      {
+        src: "/icon.svg",
+        sizes: "any",
+        type: "image/svg+xml",
+        purpose: "maskable",
+      },
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
This change wires up PWA-related metadata (manifest link, icons, and consistent theme/branding colors) so the 143.dev page is correctly recognized when installed and better aligns with Chrome’s caching/appearance expectations. It also adds a focused unit test to lock in the manifest and metadata values.

## Changes
- **`frontend/src/app/layout.tsx`**
  - Added `metadata.manifest` and `metadata.icons` pointing to `/manifest.webmanifest` and `/icon.svg`.
  - Introduced a `viewport` export with `themeColor` set to `#091f33` for both light and dark modes.
- **`frontend/src/app/manifest.ts`** (new)
  - Added Next.js manifest route returning name/description, display mode, start URL/scope, theme/background colors, and icon entries.
- **`frontend/src/app/pwa-metadata.test.ts`** (new)
  - Added Vitest coverage to assert `layout` metadata/icons/viewport values and manifest output.

## Test plan
- Ran the frontend unit test suite (Vitest) and verified `frontend/src/app/pwa-metadata.test.ts` passes.

[143.dev](https://143.dev) | [session 21cc109d](https://143.dev/sessions/21cc109d-30c5-4df9-ace0-f91fbe452ff5)

Preview: https://143.dev/previews/github/assembledhq/143/pull/1186