### PR TITLE
Normalize API and SSE payloads at the transport boundary

### DIFF
--- a/frontend/src/lib/api-normalize.test.ts
+++ b/frontend/src/lib/api-normalize.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from "vitest";
+import { normalizeAPIResponse } from "./api-normalize";
+
+describe("normalizeAPIResponse", () => {
+  it("normalizes session log timestamp aliases throughout API payloads", () => {
+    const payload = {
+      data: [
+        {
+          id: 1,
+          session_id: "session-1",
+          level: "info",
+          message: "working",
+          metadata: null,
+          turn_number: 1,
+          timestamp: "2026-01-01T00:00:01Z",
+        },
+      ],
+      meta: {},
+    };
+
+    expect(normalizeAPIResponse(payload)).toEqual({
+      data: [
+        {
+          ...payload.data[0],
+          created_at: "2026-01-01T00:00:01Z",
+        },
+      ],
+      meta: {},
+    });
+  });
+
+  it("fills nested session timeline timestamps from the parent entry", () => {
+    const payload = {
+      data: [
+        {
+          kind: "message",
+          created_at: "2026-01-01T00:00:01Z",
+          message: {
+            id: 1,
+            session_id: "session-1",
+            org_id: "org-1",
+            turn_number: 1,
+            role: "user",
+            content: "hello",
+          },
+        },
+        {
+          kind: "tool_group",
+          created_at: "2026-01-01T00:00:02Z",
+          tool_use: {
+            id: 2,
+            session_id: "session-1",
+            level: "tool_use",
+            message: "using tool",
+            metadata: null,
+            turn_number: 1,
+          },
+          tool_result: {
+            id: 3,
+            session_id: "session-1",
+            level: "output",
+            message: "result",
+            metadata: { type: "tool_result" },
+            turn_number: 1,
+          },
+        },
+      ],
+      meta: {},
+    };
+
+    const normalized = normalizeAPIResponse(payload) as {
+      data: Array<{
+        message?: { created_at?: string };
+        tool_use?: { created_at?: string };
+        tool_result?: { created_at?: string };
+      }>;
+    };
+
+    expect(normalized.data[0]?.message?.created_at).toBe("2026-01-01T00:00:01Z");
+    expect(normalized.data[1]?.tool_use?.created_at).toBe("2026-01-01T00:00:02Z");
+    expect(normalized.data[1]?.tool_result?.created_at).toBe("2026-01-01T00:00:02Z");
+  });
+
+  it("does not map unrelated timestamp fields to created_at", () => {
+    const payload = {
+      data: {
+        id: "event-1",
+        timestamp: "2026-01-01T00:00:01Z",
+        message: "not a session log",
+      },
+    };
+
+    expect(normalizeAPIResponse(payload)).toEqual(payload);
+  });
+});

--- a/frontend/src/lib/api-normalize.ts
+++ b/frontend/src/lib/api-normalize.ts
@@ -1,0 +1,109 @@
+type APIRecord = Record<string, unknown>;
+
+const TIMELINE_KINDS = new Set([
+  "message",
+  "assistant_output",
+  "tool_group",
+  "error",
+  "log",
+  "plan_output",
+  "plan_message",
+  "human_input",
+]);
+
+const TIMELINE_NESTED_TIMESTAMP_KEYS = [
+  "message",
+  "log",
+  "tool_use",
+  "tool_result",
+  "human_input_request",
+] as const;
+
+function isRecord(value: unknown): value is APIRecord {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function stringField(record: APIRecord, key: string): string | undefined {
+  const value = record[key];
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function withCreatedAt(record: APIRecord, fallback?: string): APIRecord {
+  if (stringField(record, "created_at")) {
+    return record;
+  }
+
+  const createdAt = stringField(record, "timestamp") ?? fallback;
+  if (!createdAt) {
+    return record;
+  }
+
+  return { ...record, created_at: createdAt };
+}
+
+function isSessionLogShape(record: APIRecord): boolean {
+  return (
+    typeof record.id === "number" &&
+    typeof record.session_id === "string" &&
+    typeof record.level === "string" &&
+    typeof record.message === "string" &&
+    typeof record.turn_number === "number"
+  );
+}
+
+function isTimelineEntryShape(record: APIRecord): boolean {
+  return typeof record.kind === "string" && TIMELINE_KINDS.has(record.kind);
+}
+
+function normalizeValue(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    let changed = false;
+    const normalized = value.map((item) => {
+      const next = normalizeValue(item);
+      if (next !== item) changed = true;
+      return next;
+    });
+    return changed ? normalized : value;
+  }
+
+  if (!isRecord(value)) {
+    return value;
+  }
+
+  let record = value;
+  for (const [key, child] of Object.entries(value)) {
+    const normalizedChild = normalizeValue(child);
+    if (normalizedChild !== child) {
+      if (record === value) record = { ...value };
+      record[key] = normalizedChild;
+    }
+  }
+
+  if (isTimelineEntryShape(record)) {
+    const entryCreatedAt = stringField(record, "created_at");
+    if (entryCreatedAt) {
+      for (const key of TIMELINE_NESTED_TIMESTAMP_KEYS) {
+        const child = record[key];
+        if (!isRecord(child)) continue;
+        const normalizedChild = withCreatedAt(child, entryCreatedAt);
+        if (normalizedChild !== child) {
+          if (record === value) record = { ...value };
+          record[key] = normalizedChild;
+        }
+      }
+    }
+  }
+
+  if (isSessionLogShape(record)) {
+    const normalizedLog = withCreatedAt(record);
+    if (normalizedLog !== record) {
+      record = normalizedLog;
+    }
+  }
+
+  return record;
+}
+
+export function normalizeAPIResponse<T>(value: T): T {
+  return normalizeValue(value) as T;
+}

--- a/frontend/src/lib/api.test.ts
+++ b/frontend/src/lib/api.test.ts
@@ -160,6 +160,47 @@ describe('api client', () => {
       expect(url.searchParams.get('triggered_by_user_ids')).toBe('user-1,user-2');
     });
 
+    it('normalizes timeline payloads at the API boundary', async () => {
+      server.use(
+        http.get('/api/v1/sessions/:id/timeline', () => {
+          return HttpResponse.json({
+            data: [
+              {
+                kind: 'message',
+                created_at: '2026-01-01T00:00:01Z',
+                message: {
+                  id: 1,
+                  session_id: 'session-1',
+                  org_id: 'org-1',
+                  turn_number: 1,
+                  role: 'user',
+                  content: 'hello',
+                },
+              },
+              {
+                kind: 'log',
+                created_at: '2026-01-01T00:00:02Z',
+                log: {
+                  id: 2,
+                  session_id: 'session-1',
+                  level: 'info',
+                  message: 'working',
+                  metadata: null,
+                  turn_number: 1,
+                },
+              },
+            ],
+            meta: {},
+          });
+        }),
+      );
+
+      const result = await api.sessions.getTimeline('session-1');
+
+      expect(result.data[0].message?.created_at).toBe('2026-01-01T00:00:01Z');
+      expect(result.data[1].log?.created_at).toBe('2026-01-01T00:00:02Z');
+    });
+
     it('fetches single session', async () => {
       const mockSession = {
         data: {

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,4 +1,5 @@
 import { getActiveOrgId, ORG_MEMBERSHIP_REVOKED_EVENT } from './active-org';
+import { normalizeAPIResponse } from './api-normalize';
 
 const API_BASE = process.env.NEXT_PUBLIC_API_URL || '';
 const SENTRY_CLIENT_ID = process.env.NEXT_PUBLIC_SENTRY_CLIENT_ID || '';
@@ -21,7 +22,7 @@ async function parseSuccessBody<T>(res: Response): Promise<T> {
     return undefined as T;
   }
 
-  return JSON.parse(text) as T;
+  return normalizeAPIResponse(JSON.parse(text)) as T;
 }
 
 function getCSRFToken(): string {

--- a/frontend/src/lib/sse.test.ts
+++ b/frontend/src/lib/sse.test.ts
@@ -33,6 +33,30 @@ describe("addSSEListener", () => {
     expect(handler).toHaveBeenCalledWith(payload);
   });
 
+  it("normalizes LOG events before invoking the handler", () => {
+    const source = createMockEventSource();
+    const handler = vi.fn();
+
+    addSSEListener(source as unknown as EventSource, SSE_EVENT.LOG, handler);
+
+    const payload = { id: 1, session_id: "s1", level: "info", message: "hi", metadata: null, turn_number: 1, timestamp: "2026-01-01T00:00:00Z" };
+    source._fire("message", JSON.stringify(payload));
+
+    expect(handler).toHaveBeenCalledWith({ ...payload, created_at: "2026-01-01T00:00:00Z" });
+  });
+
+  it("normalizes named human-input events before invoking the handler", () => {
+    const source = createMockEventSource();
+    const handler = vi.fn();
+
+    addSSEListener(source as unknown as EventSource, SSE_EVENT.HUMAN_INPUT_CREATED, handler);
+
+    const payload = { id: 12, session_id: "s1", level: "human_input", message: "created", metadata: { status: "pending" }, turn_number: 1, timestamp: "2026-01-01T00:00:00Z" };
+    source._fire("session_human_input.created", JSON.stringify(payload));
+
+    expect(handler).toHaveBeenCalledWith({ ...payload, created_at: "2026-01-01T00:00:00Z" });
+  });
+
   it("handles STATUS events via addEventListener", () => {
     const source = createMockEventSource();
     const handler = vi.fn();

--- a/frontend/src/lib/sse.ts
+++ b/frontend/src/lib/sse.ts
@@ -5,6 +5,7 @@ import type {
   SessionDetail,
   SessionLog,
 } from "./types";
+import { normalizeAPIResponse } from "./api-normalize";
 import { captureError } from "./errors";
 
 // EventSource cannot send custom headers like X-Active-Org-ID. The backend
@@ -117,7 +118,7 @@ export function addSSEListener<K extends keyof SSEEventPayloads>(
   if (event === SSE_EVENT.LOG) {
     source.onmessage = (e: MessageEvent) => {
       try {
-        handler(JSON.parse(e.data));
+        handler(normalizeAPIResponse(JSON.parse(e.data)) as SSEEventPayloads[K]);
       } catch (err) {
         captureError(err, { feature: "sse" });
       }
@@ -125,7 +126,7 @@ export function addSSEListener<K extends keyof SSEEventPayloads>(
   } else {
     source.addEventListener(event, ((e: MessageEvent) => {
       try {
-        handler(JSON.parse(e.data));
+        handler(normalizeAPIResponse(JSON.parse(e.data)) as SSEEventPayloads[K]);
       } catch (err) {
         captureError(err, { feature: "sse" });
       }


### PR DESCRIPTION
## Summary
- Added a shared frontend response normalizer and wired it into `api.ts` and `sse.ts` so session payloads are normalized once, close to ingestion.
- Covered the boundary with tests for API responses, SSE events, and timeline payloads.
- Kept `timeline.ts` focused on typed data instead of sprinkling defensive timestamp fallbacks through UI code.

## Testing
- `npm test -- --run src/lib/api-normalize.test.ts src/lib/api.test.ts src/lib/sse.test.ts src/lib/timeline.test.ts`
- `npm run typecheck`
- `npm run lint`
- `npm run build`