### PR TITLE
Fix PR error notice so session detail header expands instead of overlaying content

### DIFF
--- a/frontend/src/app/(dashboard)/sessions/[id]/page.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/page.test.tsx
@@ -4940,6 +4940,38 @@ describe('SessionDetailPage', () => {
     expect(within(alert).getByRole('button', { name: 'Retry' })).toBeInTheDocument();
   });
 
+  it('lets the detail header grow when showing a PR error notice', async () => {
+    const sessionWithPRFailure: Session = {
+      ...mockSessions[0],
+      status: 'completed',
+      diff: '--- a/file.ts\n+++ b/file.ts\n@@ -1 +1 @@\n-old\n+new',
+      diff_stats: { added: 1, removed: 1, files_changed: 1 },
+      snapshot_key: 'snap-abc',
+      pr_creation_state: 'failed',
+      pr_creation_error: 'No changes to push.',
+    };
+
+    server.use(
+      http.get('/api/v1/sessions/:id', () => {
+        return HttpResponse.json({ data: sessionWithPRFailure } satisfies SingleResponse<Session>);
+      }),
+      http.get('/api/v1/sessions/:id/pr', () => {
+        return HttpResponse.json(
+          { error: { code: 'NOT_FOUND', message: 'pull request not found' } },
+          { status: 404 },
+        );
+      }),
+    );
+
+    renderWithProviders(<SessionDetailContent id="session-abcdef12-3456-7890" />);
+
+    const alert = await screen.findByRole('alert');
+    expect(alert).toHaveTextContent("Couldn't create the PR");
+    expect(screen.getByTestId('session-detail-header')).toHaveClass('min-h-14');
+    expect(screen.getByTestId('session-detail-header')).not.toHaveClass('h-14');
+    expect(screen.getByTestId('session-detail-header-bar')).toHaveClass('h-14');
+  });
+
   it('shows the PR authorship modal and falls back to app mode when requested', async () => {
     const requestBodies: unknown[] = [];
 

--- a/frontend/src/app/(dashboard)/sessions/[id]/page.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/page.test.tsx
@@ -752,7 +752,7 @@ describe('SessionDetailPage', () => {
 
     expect(screen.getByTestId('session-main-header')).toHaveClass('h-14');
     expect(screen.getByTestId('session-detail-header')).toHaveClass('h-14');
-    expect(screen.getByTestId('session-detail-header-bar')).toHaveClass('h-full');
+    expect(screen.getByTestId('session-detail-header-bar')).toHaveClass('h-14');
   });
 
   it('clips crowded session header metadata before it can overlap the detail toggle', async () => {
@@ -1139,8 +1139,8 @@ describe('SessionDetailPage', () => {
 
     expect(mainHeader).toHaveClass('h-14', 'border-b');
     expect(detailHeader).toHaveClass('h-14', 'border-b');
-    expect(detailHeaderBar).toHaveClass('h-full');
-    expect(detailHeaderBar).not.toHaveClass('h-14');
+    expect(detailHeaderBar).toHaveClass('h-14');
+    expect(detailHeaderBar).not.toHaveClass('h-full');
   });
 
   it('shows the desktop agent tab row as soon as a second tab is being created', async () => {

--- a/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
@@ -5116,11 +5116,14 @@ export function SessionDetailContent({ id }: { id: string }) {
     >
       <div
         data-testid="session-detail-header"
-        className={cn("border-b border-border shrink-0", SESSION_HEADER_HEIGHT_CLASSNAME)}
+        className={cn(
+          "border-b border-border shrink-0",
+          prErrorNotice ? "min-h-14" : SESSION_HEADER_HEIGHT_CLASSNAME,
+        )}
       >
         <div
           data-testid="session-detail-header-bar"
-          className="flex h-full items-center gap-2 min-w-0 px-2"
+          className={cn("flex items-center gap-2 min-w-0 px-2", SESSION_HEADER_HEIGHT_CLASSNAME)}
         >
           <div
             ref={detailTabsRef}


### PR DESCRIPTION
## Summary
When a PR creation error notice is shown, the session detail header was constrained to a fixed `h-14`, causing the notice to overflow and cover the overview/tab content. This change allows the header to grow in the PR error state while keeping the compact tab row height.

## Changes
- **`frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx`**
  - Updated the session detail header wrapper (`data-testid="session-detail-header"`) to use:
    - normal state: existing `SESSION_HEADER_HEIGHT_CLASSNAME` (fixed `h-14`)
    - PR error state: `min-h-14` so the header can expand in normal document flow
  - Kept the inner header bar/tabs row (`data-testid="session-detail-header-bar"`) at fixed `h-14` to preserve the intended tab/header layout.
- **`frontend/src/app/(dashboard)/sessions/[id]/page.test.tsx`**
  - Added a test to verify that when `pr_creation_state` is `failed`, the header uses `min-h-14` (and not `h-14`), and the inner header bar remains `h-14`.

## Test plan
- Ran the frontend unit/component tests for `SessionDetailPage`, including the newly added test asserting the correct header classes in the PR error scenario.

[143.dev](https://143.dev) | [session 14d8cf47](https://143.dev/sessions/14d8cf47-841c-47f6-80f2-7f7b4d8e0f8c)

Preview: https://143.dev/previews/github/assembledhq/143/pull/1194