### PR TITLE
Validate JSON secret files with debounce and preserve encrypted contents on PATCH

### DIFF
--- a/docs/design/implemented/88-preview-settings-page.md
+++ b/docs/design/implemented/88-preview-settings-page.md
@@ -142,7 +142,7 @@ Columns:
 | Bundle | Bundle name. Optionally include source type as subdued metadata. |
 | Outputs | Badges such as `env DATABASE_URL`, `env API_TOKEN`, `json development.conf.json`, `raw .env`. |
 | Last changed | `created_at` from the active version until a version-specific display timestamp exists. |
-| Actions | `Test`, `Edit`, `Delete`. Keep destructive action visually secondary. |
+| Actions | `Edit`, `Delete`. Keep destructive action visually secondary. |
 
 Do not display secret values. Do not display decrypted source data. List APIs should expose only bundle metadata and output names.
 
@@ -171,21 +171,14 @@ Fields:
    - Copy should make clear that users need one delivery method, not both.
    - Validate output path rules client-side where possible, but rely on backend validation as source of truth.
 5. Actions
-   - `Test bundle`
    - `Save`
    - `Cancel`
 
-For edit flows, prefer patching unchanged metadata without requiring plaintext secret re-entry when backend support exists. If backend support does not allow preserving encrypted values, make the form copy explicit by using an empty password field placeholder such as `Leave blank to keep existing value` only after the API can actually honor that behavior. Do not imply secret preservation before it exists.
+For edit flows, do not fetch or show plaintext secret values again. File-bundle edits can preserve the existing encrypted file by leaving the contents field blank; the frontend sends a metadata-only PATCH with outputs but no `source`, and the backend merges the existing decrypted source before saving the next active version. Pasting new file contents replaces the stored encrypted value. Environment-variable edits still require re-entering changed values until the UI has per-value preservation controls.
 
-### Testing a Bundle
+### Secret File Validation
 
-The `Test` action should call the id-based test endpoint for the active bundle. It should surface:
-
-- `Ready` as a success toast and/or badge.
-- Validation failures as an inline row error or toast with the backend's safe message.
-- Network/server failures through the shared error treatment.
-
-Test responses must not include secret values.
+Secret-file JSON validation is local to the editor. When the selected file format is `JSON`, validate the textarea contents on a short debounce as the admin types and surface parse errors inline instead of exposing a separate bundle-test action. The backend remains the source of truth on save.
 
 ### Delete Behavior
 

--- a/frontend/src/app/(dashboard)/settings/previews/page.test.tsx
+++ b/frontend/src/app/(dashboard)/settings/previews/page.test.tsx
@@ -55,9 +55,8 @@ describe("PreviewSettingsPage", () => {
     expect(bundleRequests).toEqual(expect.arrayContaining(["repo-1", "repo-2"]));
   });
 
-  it("creates, tests, and deletes preview secret bundles through repository-scoped APIs", async () => {
+  it("creates and deletes preview secret bundles through repository-scoped APIs", async () => {
     let savedBody: unknown;
-    let testedBundleID = "";
     let deletedPath = "";
     server.use(
       http.get("*/api/v1/repositories", () => HttpResponse.json({ data: repos, meta: {} })),
@@ -69,10 +68,6 @@ describe("PreviewSettingsPage", () => {
       http.post("*/api/v1/repositories/repo-1/preview-secret-bundles", async ({ request }) => {
         savedBody = await request.json();
         return HttpResponse.json({ data: bundle("bundle-2", "repo-1", "staging") });
-      }),
-      http.post("*/api/v1/preview-secret-bundles/:bundleId/test", ({ params }) => {
-        testedBundleID = String(params.bundleId);
-        return HttpResponse.json({ data: { status: "ready", bundle: bundle("bundle-1", "repo-1", "assembled-dev") } });
       }),
       http.delete("*/api/v1/repositories/repo-1/preview-secret-bundles/:name", ({ request }) => {
         deletedPath = new URL(request.url).pathname;
@@ -97,10 +92,7 @@ describe("PreviewSettingsPage", () => {
       });
     });
 
-    await userEvent.click((await screen.findAllByRole("button", { name: /test assembled-dev/i }))[0]);
-    await waitFor(() => {
-      expect(testedBundleID).toBe("bundle-1");
-    });
+    expect(screen.queryByRole("button", { name: /test assembled-dev/i })).not.toBeInTheDocument();
 
     await userEvent.click(screen.getAllByRole("button", { name: /delete assembled-dev/i })[0]);
     await userEvent.click(await screen.findByRole("button", { name: "Delete bundle" }));
@@ -303,11 +295,11 @@ describe("PreviewSettingsPage", () => {
 
     await userEvent.click((await screen.findAllByRole("button", { name: /edit file-bundle/i }))[0]);
 
-    expect(screen.getByText(/re-enter the file contents/i)).toBeInTheDocument();
+    expect(screen.getByText(/leave the file contents blank/i)).toBeInTheDocument();
 
     await userEvent.click(screen.getByRole("tab", { name: "Environment variables" }));
 
-    expect(screen.queryByText(/re-enter the file contents/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/leave the file contents blank/i)).not.toBeInTheDocument();
   });
 
   it("rejects invalid JSON in secret file contents when format is JSON", async () => {
@@ -329,6 +321,35 @@ describe("PreviewSettingsPage", () => {
     await userEvent.click(screen.getByRole("button", { name: /save/i }));
 
     expect(await screen.findByText(/must be valid JSON/i)).toBeInTheDocument();
+  });
+
+  it("debounces JSON validation while editing secret file contents", async () => {
+    server.use(
+      http.get("*/api/v1/repositories", () => HttpResponse.json({ data: repos, meta: {} })),
+      http.get("*/api/v1/repositories/repo-1/preview-secret-bundles", () => HttpResponse.json({ data: [], meta: {} })),
+      http.get("*/api/v1/previews/api-tokens", () => HttpResponse.json({ data: [], meta: {} })),
+    );
+
+    renderWithProviders(<PreviewSettingsPage />);
+
+    await userEvent.click(await screen.findByRole("button", { name: /new bundle/i }));
+    await userEvent.type(screen.getByLabelText("Bundle name"), "json-file");
+    await userEvent.click(screen.getByRole("tab", { name: "Secret file" }));
+    await userEvent.type(screen.getByLabelText("Secret file path"), "config.json");
+    await userEvent.click(screen.getByRole("combobox", { name: "Secret file type" }));
+    await userEvent.click(await screen.findByRole("option", { name: "JSON" }));
+
+    fireEvent.change(screen.getByLabelText("Secret file contents"), { target: { value: "not valid json{{" } });
+
+    await waitFor(() => {
+      expect(screen.getByText(/must be valid JSON/i)).toBeInTheDocument();
+    });
+
+    fireEvent.change(screen.getByLabelText("Secret file contents"), { target: { value: '{"token":"ok"}' } });
+
+    await waitFor(() => {
+      expect(screen.queryByText(/must be valid JSON/i)).not.toBeInTheDocument();
+    });
   });
 
   it("edits a preview secret bundle via the patch endpoint", async () => {
@@ -363,8 +384,52 @@ describe("PreviewSettingsPage", () => {
     });
   }, 10000);
 
-  it("keeps the id-based Test bundle action available inside the edit dialog", async () => {
-    let testedBundleID = "";
+  it("preserves existing secret file contents when editing file bundle metadata", async () => {
+    let patchedBody: unknown;
+    const fileBundle = {
+      id: "bundle-file",
+      repository_id: "repo-1",
+      name: "file-bundle",
+      source_type: "managed",
+      exposure_policy: "preview_runtime",
+      outputs: [{ type: "file", path: "config.json", format: "json" }],
+      created_by_user_id: "user-1",
+      created_at: "2026-05-27T00:00:00Z",
+    };
+
+    server.use(
+      http.get("*/api/v1/repositories", () => HttpResponse.json({ data: repos, meta: {} })),
+      http.get("*/api/v1/repositories/repo-1/preview-secret-bundles", () =>
+        HttpResponse.json({ data: [fileBundle], meta: {} }),
+      ),
+      http.get("*/api/v1/previews/api-tokens", () => HttpResponse.json({ data: [], meta: {} })),
+      http.patch("*/api/v1/preview-secret-bundles/:bundleId", async ({ request }) => {
+        patchedBody = await request.json();
+        return HttpResponse.json({ data: fileBundle });
+      }),
+    );
+
+    renderWithProviders(<PreviewSettingsPage />);
+
+    await userEvent.click((await screen.findAllByRole("button", { name: /edit file-bundle/i }))[0]);
+    fireEvent.change(screen.getByLabelText("Secret file path"), { target: { value: "development.conf.json" } });
+    await userEvent.click(screen.getByRole("button", { name: /save/i }));
+
+    await waitFor(() => {
+      expect(patchedBody).toEqual({
+        name: "file-bundle",
+        outputs: [{
+          type: "file",
+          path: "development.conf.json",
+          format: "json",
+          value: "secret:SECRET_FILE_CONTENT",
+        }],
+        exposure_policy: "preview_runtime",
+      });
+    });
+  }, 10000);
+
+  it("does not show a Test bundle action inside the edit dialog", async () => {
     server.use(
       http.get("*/api/v1/repositories", () => HttpResponse.json({ data: repos, meta: {} })),
       http.get("*/api/v1/repositories/repo-1/preview-secret-bundles", () => HttpResponse.json({
@@ -372,20 +437,13 @@ describe("PreviewSettingsPage", () => {
         meta: {},
       })),
       http.get("*/api/v1/previews/api-tokens", () => HttpResponse.json({ data: [], meta: {} })),
-      http.post("*/api/v1/preview-secret-bundles/:bundleId/test", ({ params }) => {
-        testedBundleID = String(params.bundleId);
-        return HttpResponse.json({ data: { status: "ready", bundle: bundle("bundle-1", "repo-1", "assembled-dev") } });
-      }),
     );
 
     renderWithProviders(<PreviewSettingsPage />);
 
     await userEvent.click((await screen.findAllByRole("button", { name: /edit assembled-dev/i }))[0]);
-    await userEvent.click(await screen.findByRole("button", { name: "Test bundle" }));
 
-    await waitFor(() => {
-      expect(testedBundleID).toBe("bundle-1");
-    });
+    expect(screen.queryByRole("button", { name: "Test bundle" })).not.toBeInTheDocument();
   });
 
   it("creates and revokes preview API tokens in the secondary section", async () => {

--- a/frontend/src/app/(dashboard)/settings/previews/page.tsx
+++ b/frontend/src/app/(dashboard)/settings/previews/page.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useMemo, useState, type FormEvent, type ReactNode } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useQueryState } from "nuqs";
-import { Copy, HelpCircle, KeyRound, Pencil, Plus, TestTube2, Trash2 } from "lucide-react";
+import { Copy, HelpCircle, KeyRound, Pencil, Plus, Trash2 } from "lucide-react";
 
 import { EmptyState } from "@/components/empty-state";
 import { PageContainer } from "@/components/page-container";
@@ -51,6 +51,7 @@ import type {
   ListResponse,
   PreviewAPIToken,
   PreviewSecretBundleOutput,
+  PreviewSecretBundlePatchRequest,
   PreviewSecretBundleSummary,
   PreviewSecretBundleUpsertRequest,
   Repository,
@@ -59,6 +60,8 @@ import type {
 const SCOPES = ["previews:create", "previews:read", "previews:stop"] as const;
 
 const SECRET_FILE_KEY = "SECRET_FILE_CONTENT";
+const JSON_FILE_VALIDATION_DEBOUNCE_MS = 400;
+const SECRET_FILE_JSON_ERROR = "Secret file contents must be valid JSON.";
 
 type SecretValueRow = {
   /** Stable identity used as a React key — never sent to the server. */
@@ -121,6 +124,7 @@ function PreviewSecretsSection() {
   const [dialogMode, setDialogMode] = useState<BundleDialogMode | null>(null);
   const [form, setForm] = useState<BundleFormState>(makeEmptyBundleForm);
   const [formError, setFormError] = useState<string | null>(null);
+  const [jsonValidationError, setJSONValidationError] = useState<string | null>(null);
   const [deleteTarget, setDeleteTarget] = useState<PreviewSecretBundleSummary | null>(null);
 
   const repositoriesQuery = useQuery<ListResponse<Repository>>({
@@ -160,11 +164,15 @@ function PreviewSecretsSection() {
   const bundles = bundlesQuery.data?.data ?? [];
 
   const saveMutation = useMutation({
-    mutationFn: ({ mode, body, repositoryId }: { mode: BundleDialogMode; body: PreviewSecretBundleUpsertRequest; repositoryId: string }) => {
+    mutationFn: ({ mode, body, repositoryId }: {
+      mode: BundleDialogMode;
+      body: PreviewSecretBundlePatchRequest | PreviewSecretBundleUpsertRequest;
+      repositoryId: string;
+    }) => {
       if (mode.type === "edit") {
         return api.repositories.previewSecretBundles.patch(mode.bundle.id, body);
       }
-      return api.repositories.previewSecretBundles.upsert(repositoryId, body);
+      return api.repositories.previewSecretBundles.upsert(repositoryId, body as PreviewSecretBundleUpsertRequest);
     },
     onSuccess: (_data, { repositoryId }) => {
       toast.success("Preview secret bundle saved");
@@ -175,20 +183,6 @@ function PreviewSecretsSection() {
     },
     onError: (error) => {
       setFormError(error instanceof ApiError ? error.message : "Preview secret bundle could not be saved.");
-    },
-  });
-
-  const testMutation = useMutation({
-    mutationFn: (bundleId: string) => api.repositories.previewSecretBundles.test(bundleId),
-    onSuccess: (response) => {
-      if (response.data.status === "ready") {
-        toast.success("Preview secret bundle is ready");
-      } else {
-        toast.error(response.data.error || "Preview secret bundle test failed");
-      }
-    },
-    onError: (error) => {
-      toast.error(error instanceof ApiError ? error.message : "Could not test preview secret bundle");
     },
   });
 
@@ -209,6 +203,7 @@ function PreviewSecretsSection() {
     setDialogMode({ type: "create" });
     setForm(makeEmptyBundleForm(effectiveSelectedRepositoryId));
     setFormError(null);
+    setJSONValidationError(null);
   }
 
   function openEditDialog(bundle: PreviewSecretBundleSummary) {
@@ -225,13 +220,32 @@ function PreviewSecretsSection() {
       fileContent: "",
     });
     setFormError(null);
+    setJSONValidationError(null);
   }
 
   function closeBundleDialog() {
     setDialogMode(null);
     setForm(makeEmptyBundleForm(effectiveSelectedRepositoryId));
     setFormError(null);
+    setJSONValidationError(null);
   }
+
+  useEffect(() => {
+    const timeoutID = window.setTimeout(() => {
+      if (!dialogMode || form.deliveryMode !== "file" || form.fileFormat !== "json" || !form.fileContent) {
+        setJSONValidationError(null);
+        return;
+      }
+      try {
+        JSON.parse(form.fileContent);
+        setJSONValidationError(null);
+      } catch {
+        setJSONValidationError(SECRET_FILE_JSON_ERROR);
+      }
+    }, JSON_FILE_VALIDATION_DEBOUNCE_MS);
+
+    return () => window.clearTimeout(timeoutID);
+  }, [dialogMode, form.deliveryMode, form.fileContent, form.fileFormat]);
 
   function updateRow(index: number, patch: Partial<SecretValueRow>) {
     setForm((current) => ({
@@ -256,9 +270,14 @@ function PreviewSecretsSection() {
   function handleSave(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
     if (!dialogMode) return;
-    const body = buildBundleRequest(form);
+    const body = buildBundleRequest(form, dialogMode);
     if (body instanceof Error) {
-      setFormError(body.message);
+      if (body.message === SECRET_FILE_JSON_ERROR) {
+        setJSONValidationError(SECRET_FILE_JSON_ERROR);
+        setFormError(null);
+      } else {
+        setFormError(body.message);
+      }
       return;
     }
     if (!form.repositoryId) {
@@ -266,6 +285,7 @@ function PreviewSecretsSection() {
       return;
     }
     setFormError(null);
+    setJSONValidationError(null);
     saveMutation.mutate({ mode: dialogMode, body, repositoryId: form.repositoryId });
   }
 
@@ -319,9 +339,7 @@ function PreviewSecretsSection() {
           repositoryName={selectedRepository?.full_name ?? ""}
           onCreate={openCreateDialog}
           onEdit={openEditDialog}
-          onTest={(bundle) => testMutation.mutate(bundle.id)}
           onDelete={setDeleteTarget}
-          testing={testMutation.isPending}
         />
       )}
 
@@ -330,7 +348,7 @@ function PreviewSecretsSection() {
         form={form}
         repositories={activeRepositories}
         repositoryName={selectedRepository?.full_name ?? ""}
-        error={formError}
+        error={formError ?? jsonValidationError}
         saving={saveMutation.isPending}
         onOpenChange={(open) => {
           if (!open) closeBundleDialog();
@@ -339,8 +357,6 @@ function PreviewSecretsSection() {
         onRowChange={updateRow}
         onRowAdd={addRow}
         onRowRemove={removeRow}
-        onTest={(bundle) => testMutation.mutate(bundle.id)}
-        testing={testMutation.isPending}
         onSubmit={handleSave}
       />
 
@@ -374,18 +390,14 @@ function BundleInventory({
   repositoryName,
   onCreate,
   onEdit,
-  onTest,
   onDelete,
-  testing,
 }: {
   bundles: PreviewSecretBundleSummary[];
   isLoading: boolean;
   repositoryName: string;
   onCreate: () => void;
   onEdit: (bundle: PreviewSecretBundleSummary) => void;
-  onTest: (bundle: PreviewSecretBundleSummary) => void;
   onDelete: (bundle: PreviewSecretBundleSummary) => void;
-  testing: boolean;
 }) {
   if (isLoading) {
     return (
@@ -435,7 +447,7 @@ function BundleInventory({
                 </TableCell>
                 <TableCell>{formatDate(bundle.created_at)}</TableCell>
                 <TableCell>
-                  <BundleActions bundle={bundle} onEdit={onEdit} onTest={onTest} onDelete={onDelete} testing={testing} align="end" />
+                  <BundleActions bundle={bundle} onEdit={onEdit} onDelete={onDelete} align="end" />
                 </TableCell>
               </TableRow>
             ))}
@@ -453,7 +465,7 @@ function BundleInventory({
               </div>
               <LabeledMobileValue label="Outputs"><OutputBadges bundle={bundle} /></LabeledMobileValue>
               <LabeledMobileValue label="Last changed">{formatDate(bundle.created_at)}</LabeledMobileValue>
-              <BundleActions bundle={bundle} onEdit={onEdit} onTest={onTest} onDelete={onDelete} testing={testing} />
+              <BundleActions bundle={bundle} onEdit={onEdit} onDelete={onDelete} />
             </div>
           </div>
         ))}
@@ -465,24 +477,16 @@ function BundleInventory({
 function BundleActions({
   bundle,
   onEdit,
-  onTest,
   onDelete,
-  testing,
   align = "start",
 }: {
   bundle: PreviewSecretBundleSummary;
   onEdit: (bundle: PreviewSecretBundleSummary) => void;
-  onTest: (bundle: PreviewSecretBundleSummary) => void;
   onDelete: (bundle: PreviewSecretBundleSummary) => void;
-  testing: boolean;
   align?: "start" | "end";
 }) {
   return (
     <div className={`flex flex-wrap gap-2${align === "end" ? " justify-end" : ""}`}>
-      <Button type="button" variant="outline" size="sm" onClick={() => onTest(bundle)} disabled={testing} aria-label={`Test ${bundle.name}`}>
-        <TestTube2 className="h-4 w-4" />
-        Test
-      </Button>
       <Button type="button" variant="outline" size="sm" onClick={() => onEdit(bundle)} aria-label={`Edit ${bundle.name}`}>
         <Pencil className="h-4 w-4" />
         Edit
@@ -507,8 +511,6 @@ function BundleDialog({
   onRowChange,
   onRowAdd,
   onRowRemove,
-  onTest,
-  testing,
   onSubmit,
 }: {
   mode: BundleDialogMode | null;
@@ -522,8 +524,6 @@ function BundleDialog({
   onRowChange: (index: number, patch: Partial<SecretValueRow>) => void;
   onRowAdd: () => void;
   onRowRemove: (index: number) => void;
-  onTest: (bundle: PreviewSecretBundleSummary) => void;
-  testing: boolean;
   onSubmit: (event: FormEvent<HTMLFormElement>) => void;
 }) {
   const isEdit = mode?.type === "edit";
@@ -532,13 +532,14 @@ function BundleDialog({
   const editHasEnvOutputs = editBundle ? editBundle.outputs.some((o) => o.type === "env") : false;
   const editHasBothOutputs = editHasFileOutputs && editHasEnvOutputs;
   const hasFilledValue = form.rows.some((row) => row.key.trim() && row.value);
-  const hasFileOutput = Boolean(form.filePath.trim()) && Boolean(form.fileContent);
+  const canPreserveFileContent = isEdit && editHasFileOutputs && form.deliveryMode === "file" && !form.fileContent;
+  const hasFileOutput = Boolean(form.filePath.trim()) && (Boolean(form.fileContent) || canPreserveFileContent);
   const canSave = Boolean(form.repositoryId)
     && Boolean(form.name.trim())
     && (form.deliveryMode === "env" ? hasFilledValue : hasFileOutput);
   const saveTooltip = form.deliveryMode === "file" && !form.filePath.trim()
     ? "Add the secret file path before saving"
-    : form.deliveryMode === "file" && !form.fileContent
+    : form.deliveryMode === "file" && !form.fileContent && !canPreserveFileContent
       ? "Paste the secret file contents before saving"
       : form.deliveryMode === "env" && isEdit && !hasFilledValue
         ? "Re-enter at least one secret value to save changes"
@@ -552,11 +553,11 @@ function BundleDialog({
         <DialogHeader>
           <DialogTitle>{isEdit ? "Edit bundle" : "New bundle"}</DialogTitle>
           <DialogDescription>
-            Secret values are only sent when you save and are not shown again after creation.
+            Secret values are not shown again after creation.
             {editHasBothOutputs
               ? " This bundle uses both env vars and a secret file. Choose which delivery method to keep — the other will be removed on save."
               : editHasFileOutputs && form.deliveryMode === "file"
-                ? " This bundle has file outputs — re-enter the file contents below to preserve them."
+                ? " Leave the file contents blank to keep the encrypted file already stored, or paste new contents to replace it."
                 : null}
           </DialogDescription>
         </DialogHeader>
@@ -620,17 +621,6 @@ function BundleDialog({
           {error ? <p className="text-sm text-destructive">{error}</p> : null}
 
           <DialogFooter>
-            {isEdit ? (
-              <Button
-                type="button"
-                variant="outline"
-                onClick={() => onTest(mode.bundle)}
-                disabled={testing}
-              >
-                <TestTube2 className="h-4 w-4" />
-                Test bundle
-              </Button>
-            ) : null}
             <DialogClose asChild>
               <Button type="button" variant="outline" disabled={saving}>Cancel</Button>
             </DialogClose>
@@ -1068,7 +1058,10 @@ function OutputBadges({ bundle }: { bundle: PreviewSecretBundleSummary }) {
   );
 }
 
-function buildBundleRequest(form: BundleFormState): PreviewSecretBundleUpsertRequest | Error {
+function buildBundleRequest(
+  form: BundleFormState,
+  mode: BundleDialogMode,
+): PreviewSecretBundlePatchRequest | PreviewSecretBundleUpsertRequest | Error {
   const name = form.name.trim();
   if (!name) {
     return new Error("Bundle name is required.");
@@ -1081,23 +1074,31 @@ function buildBundleRequest(form: BundleFormState): PreviewSecretBundleUpsertReq
     if (!path) {
       return new Error("Secret file path is required.");
     }
+    const fileOutput: PreviewSecretBundleOutput = {
+      type: "file",
+      path,
+      format: form.fileFormat,
+      value: `secret:${SECRET_FILE_KEY}`,
+    };
     if (!form.fileContent) {
+      if (mode.type === "edit") {
+        return {
+          name,
+          outputs: [fileOutput],
+          exposure_policy: "preview_runtime",
+        };
+      }
       return new Error("Secret file contents are required.");
     }
     if (form.fileFormat === "json") {
       try {
         JSON.parse(form.fileContent);
       } catch {
-        return new Error("Secret file contents must be valid JSON.");
+        return new Error(SECRET_FILE_JSON_ERROR);
       }
     }
     values[SECRET_FILE_KEY] = form.fileContent;
-    outputs = [{
-      type: "file",
-      path,
-      format: form.fileFormat,
-      value: `secret:${SECRET_FILE_KEY}`,
-    }];
+    outputs = [fileOutput];
   } else {
     for (const row of form.rows) {
       const key = row.key.trim();


### PR DESCRIPTION
## Summary
Updated the preview settings editor to validate secret-file JSON locally (debounced) and removed the separate “Test bundle” flow. Also clarified and aligned edit behavior so file-bundle PATCH requests can preserve existing encrypted source when contents are left blank.

## Changes
- **`docs/design/implemented/88-preview-settings-page.md`**
  - Removed “Test bundle” action from the design.
  - Added **Secret File Validation** section: debounce JSON parsing client-side for inline error reporting.
  - Reworded edit semantics to avoid fetching/showing plaintext secrets:
    - File-bundle edits: omit `source` when contents are left blank; frontend sends metadata-only PATCH with updated `outputs`.
    - Pasting new contents replaces the stored encrypted value.
    - Environment-variable edits still require re-entering changed values.
- **`frontend/src/app/(dashboard)/settings/previews/page.tsx`**
  - Implemented debounced JSON textarea validation and inline parse error feedback when file format is `JSON`.
  - Adjusted save/PATCH payload behavior to support preserving existing encrypted file contents by omitting `source` when not provided.
  - Removed UI/test wiring related to “Test bundle”.
- **`frontend/src/app/(dashboard)/settings/previews/page.test.tsx`**
  - Updated tests to cover **create + delete** without expecting the removed “test bundle” API call.

## Test plan
- `npm test -- --run src/app/\(dashboard\)/settings/previews/page.test.tsx`
- `npm run typecheck`
- `npm run lint`
- `npm run build`

Note: existing React `act(...)` warnings from Radix Select interactions may still appear in the preview settings test output, but the tests pass and no failures were introduced by this change.

[143.dev](https://143.dev) | [session c4227a90](https://143.dev/sessions/c4227a90-0926-4b7e-bef3-6498c4aa8438)

Preview: https://143.dev/previews/github/assembledhq/143/pull/1198