### PR TITLE
Move “Refresh preview” into freshness callout and prevent action/text overlap

### DIFF
--- a/frontend/src/components/preview/preview-panel.test.tsx
+++ b/frontend/src/components/preview/preview-panel.test.tsx
@@ -1453,9 +1453,12 @@ describe("PreviewPanel component", () => {
     expect(
       screen.getByText("Restart the preview to see the latest session changes."),
     ).toBeInTheDocument();
+    const freshnessCallout = screen.getByTestId("preview-freshness-callout");
+    const refreshButton = screen.getByRole("button", { name: "Refresh preview" });
+    expect(freshnessCallout).toContainElement(refreshButton);
     expect(screen.getByRole("link", { name: "Open Preview" })).toBeInTheDocument();
 
-    await user.click(screen.getByRole("button", { name: "Refresh preview" }));
+    await user.click(refreshButton);
 
     await waitFor(() => {
       expect(mockEnsure).toHaveBeenCalledTimes(1);

--- a/frontend/src/components/preview/preview-panel.tsx
+++ b/frontend/src/components/preview/preview-panel.tsx
@@ -883,22 +883,7 @@ export function PreviewPanel({
               </div>
             </div>
 
-            <div className="flex shrink-0 items-center gap-2">
-              {isPreviewOutOfDate && (
-                <Button
-                  size="sm"
-                  variant="default"
-                  onClick={() => startMutation.mutate()}
-                  disabled={isMutating}
-                  loading={startMutation.isPending}
-                >
-                  {!startMutation.isPending && (
-                    <RefreshCw className="size-3.5" />
-                  )}
-                  Refresh preview
-                </Button>
-              )}
-
+            <div className="flex max-w-full shrink-0 flex-wrap items-center justify-start gap-2 sm:justify-end">
               {isReady && (
                 <TooltipProvider>
                   <Tooltip>
@@ -971,30 +956,49 @@ export function PreviewPanel({
             <div
               data-testid="preview-freshness-callout"
               className={cn(
-                "flex items-start gap-2 rounded-md border px-2.5 py-2 text-xs",
+                "flex flex-col gap-3 rounded-md border px-2.5 py-2 text-xs sm:flex-row sm:items-center sm:justify-between",
                 isPreviewOutOfDate
                   ? "border-amber-500/25 bg-amber-500/10 text-amber-800 dark:text-amber-200"
                   : "border-border bg-muted/40 text-muted-foreground",
               )}
             >
-              {isPreviewOutOfDate ? (
-                <AlertTriangle className="mt-0.5 size-3.5 shrink-0" />
-              ) : (
-                <RefreshCw
-                  className={cn(
-                    "mt-0.5 size-3.5 shrink-0",
-                    startMutation.isPending && "animate-spin",
-                  )}
-                />
-              )}
-              <div className="min-w-0">
-                <div className="font-medium">{freshnessCalloutText}</div>
-                {isPreviewOutOfDate && (
-                  <div className="text-muted-foreground">
-                    Restart the preview to see the latest session changes.
-                  </div>
+              <div className="flex min-w-0 items-start gap-2">
+                {isPreviewOutOfDate ? (
+                  <AlertTriangle className="mt-0.5 size-3.5 shrink-0" />
+                ) : (
+                  <RefreshCw
+                    className={cn(
+                      "mt-0.5 size-3.5 shrink-0",
+                      startMutation.isPending && "animate-spin",
+                    )}
+                  />
                 )}
+                <div className="min-w-0">
+                  <div className="font-medium">{freshnessCalloutText}</div>
+                  {isPreviewOutOfDate && (
+                    <div className="text-muted-foreground">
+                      Restart the preview to see the latest session changes.
+                    </div>
+                  )}
+                </div>
               </div>
+              {isPreviewOutOfDate && (
+                <div className="flex shrink-0 justify-start sm:justify-end">
+                  <Button
+                    size="sm"
+                    variant="default"
+                    className="w-full sm:w-auto"
+                    onClick={() => startMutation.mutate()}
+                    disabled={isMutating}
+                    loading={startMutation.isPending}
+                  >
+                    {!startMutation.isPending && (
+                      <RefreshCw className="size-3.5" />
+                    )}
+                    Refresh preview
+                  </Button>
+                </div>
+              )}
             </div>
           )}
         </div>


### PR DESCRIPTION
## Summary
Updated the PreviewPanel layout so the “Refresh preview” action is rendered inside the “New changes available” freshness callout. This prevents the button from overlapping the callout text on smaller widths by using responsive flex wrapping.

## Changes
- **frontend/src/components/preview/preview-panel.tsx**
  - Moved the **Refresh preview** button into the `data-testid="preview-freshness-callout"` card (shown when `isPreviewOutOfDate`).
  - Adjusted the callout container to use responsive layout (`flex-col` on small screens, `flex-row` on `sm+`) so the action wraps cleanly instead of overlapping text.
- **frontend/src/components/preview/preview-panel.test.tsx**
  - Updated assertions to verify the refresh button is contained within the freshness callout card (`preview-freshness-callout`).
  - Updated the click interaction to use the button reference obtained from that containment check.

## Test plan
- `npm test -- preview-panel.test.tsx`
- `npm run typecheck`
- `npm run lint`
- `npm run build`

[143.dev](https://143.dev) | [session de8abf5a](https://143.dev/sessions/de8abf5a-d163-42bd-a656-391235f4c79f)

Preview: https://143.dev/previews/github/assembledhq/143/pull/1199