### PR TITLE
Bypass retry window for stale continue_session sandbox recovery

### DIFF
--- a/internal/worker/handlers.go
+++ b/internal/worker/handlers.go
@@ -1949,7 +1949,7 @@ func newContinueSessionHandler(stores *Stores, services *Services, logger zerolo
 					Str("session_id", sessionID.String()).
 					Err(err).
 					Msg("continue_session cleared stale orphan container_id; retrying against the clean row")
-				return &RetryableError{Err: err, RetryAfter: &retryAfter}
+				return &RetryableError{Err: err, RetryAfter: &retryAfter, BypassMaxRetryDuration: true}
 			}
 			if errors.Is(err, agent.ErrSandboxOnDifferentNode) {
 				// We claimed a job whose session sandbox lives on a sibling

--- a/internal/worker/handlers_test.go
+++ b/internal/worker/handlers_test.go
@@ -6037,6 +6037,7 @@ func TestContinueSessionHandler_StaleSandboxClearDeadLetterFailsSessionAndThread
 	require.Error(t, err, "stale sandbox clear should ask the worker to retry")
 	var retryable *RetryableError
 	require.ErrorAs(t, err, &retryable, "stale sandbox clear should remain retryable before queue exhaustion")
+	require.True(t, retryable.BypassMaxRetryDuration, "continue_session stale sandbox clear should retry even when the job was created before the generic retry window")
 	require.NoError(t, mock.ExpectationsWereMet(), "stale-clear retry should not mark the session failed before dead-letter")
 
 	errMsg := "Session stopped after cleaning up a stale sandbox but the retry could not be scheduled."


### PR DESCRIPTION
## Summary
- Ensure `continue_session` stale-sandbox recovery bypasses the generic max retry duration, matching `run_agent` behavior.
- Add a regression test to lock in the retryable flag for the stale-orphan path.

## Testing
- `go test ./internal/worker -run 'TestContinueSessionHandler_StaleSandboxClearDeadLetterFailsSessionAndThread|TestRunAgentHandler_StaleSandboxClearRetriesPastJobAgeAndFailsOnDeadLetter' -count=1`
- `go vet ./...`
- `go build ./...`
- `go test ./...`