### PR TITLE
Retry preview startup after clearing stale sandbox IDs

### DIFF
--- a/internal/services/preview/start_runner.go
+++ b/internal/services/preview/start_runner.go
@@ -300,6 +300,9 @@ func (r *StartRunner) StartReservedPreview(ctx context.Context, payload StartPre
 			r.registerCapacityDeadLetter(ctx, reservation)
 			return fmt.Errorf("%s: %w", acq.ErrCode, acq.Err)
 		}
+		if errors.Is(acq.Err, agent.ErrStaleSandboxIDCleared) {
+			return fmt.Errorf("%s: %w", acq.ErrCodeOr("STALE_SANDBOX_CLEARED"), acq.Err)
+		}
 		r.abort(ctx, reservation, "", fmt.Sprintf("acquire sandbox: %v", acq.Err))
 		return fmt.Errorf("%s: %w", acq.ErrCodeOr("PREVIEW_HYDRATE_FAILED"), acq.Err)
 	}
@@ -511,6 +514,11 @@ func (r *StartRunner) acquireSandbox(ctx context.Context, orgID uuid.UUID, sessi
 	case freshErr != nil:
 		r.logger.Warn().Err(freshErr).Str("session_id", session.ID.String()).Msg("preview hydrate: pre-hydrate peek failed; falling through to CAS race detection")
 	case winningID != "":
+		if cleared, clearErr := r.clearStalePreviewContainer(ctx, orgID, session, winningID, workDir); clearErr != nil {
+			return acquireSandboxResult{ErrCode: "STALE_SANDBOX_CLEAR_FAILED", Err: clearErr}
+		} else if cleared {
+			return acquireSandboxResult{ErrCode: "STALE_SANDBOX_CLEARED", Err: fmt.Errorf("%w", agent.ErrStaleSandboxIDCleared)}
+		}
 		return acquireSandboxResult{ErrCode: "SANDBOX_BUSY", Err: fmt.Errorf("another process attached to this session's sandbox first; please retry")}
 	}
 
@@ -549,6 +557,51 @@ func (r *StartRunner) acquireSandbox(ctx context.Context, orgID uuid.UUID, sessi
 	}
 
 	return acquireSandboxResult{Sandbox: sandbox, Hydrated: true}
+}
+
+func (r *StartRunner) clearStalePreviewContainer(ctx context.Context, orgID uuid.UUID, session *models.Session, containerID, workDir string) (bool, error) {
+	if r == nil || r.sandboxProvider == nil || r.sessions == nil || session == nil || containerID == "" {
+		return false, nil
+	}
+	candidate := &agent.Sandbox{
+		ID:        containerID,
+		Provider:  "docker",
+		WorkDir:   workDir,
+		SessionID: session.ID.String(),
+		OrgID:     session.OrgID.String(),
+		Purpose:   "preview_hydrate",
+	}
+	alive, inspectErr := r.sandboxProvider.IsAlive(ctx, candidate)
+	if inspectErr != nil {
+		r.logger.Warn().Err(inspectErr).
+			Str("session_id", session.ID.String()).
+			Str("container_id", containerID).
+			Msg("preview hydrate: stale container probe failed; leaving row for retry/reconciler")
+		return false, nil
+	}
+	if alive {
+		return false, nil
+	}
+	cleared, clearErr := r.sessions.ClearContainerID(ctx, orgID, session.ID, containerID)
+	if clearErr != nil {
+		r.logger.Warn().Err(clearErr).
+			Str("session_id", session.ID.String()).
+			Str("container_id", containerID).
+			Msg("preview hydrate: failed to clear stale container_id")
+		return false, fmt.Errorf("clear stale container_id: %w", clearErr)
+	}
+	if !cleared {
+		r.logger.Info().
+			Str("session_id", session.ID.String()).
+			Str("container_id", containerID).
+			Msg("preview hydrate: stale container clear lost CAS")
+		return false, nil
+	}
+	r.logger.Info().
+		Str("session_id", session.ID.String()).
+		Str("container_id", containerID).
+		Msg("preview hydrate: cleared stale container_id; retrying against clean row")
+	return true, nil
 }
 
 func (r *StartRunner) readWorkspacePreviewConfig(ctx context.Context, sb *agent.Sandbox, sessionID uuid.UUID, previewConfigName string) (*models.PreviewConfig, error) {

--- a/internal/services/preview/start_runner_test.go
+++ b/internal/services/preview/start_runner_test.go
@@ -7,9 +7,11 @@ import (
 	"testing"
 
 	"github.com/google/uuid"
+	"github.com/pashagolub/pgxmock/v4"
 	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/require"
 
+	"github.com/assembledhq/143/internal/db"
 	"github.com/assembledhq/143/internal/models"
 	"github.com/assembledhq/143/internal/repoconfig"
 	"github.com/assembledhq/143/internal/services/agent"
@@ -134,6 +136,101 @@ func TestNewStartRunner_SnapshotCacheDoesNotUseTypedNilInterface(t *testing.T) {
 	got, ok := withManagerCache.snapshotCache.(*SnapshotCache)
 	require.True(t, ok, "runner should receive the manager snapshot cache when config cache is omitted")
 	require.Same(t, cache, got, "runner should use the manager snapshot cache instead of a typed nil interface")
+}
+
+type acquireSandboxProvider struct {
+	aliveByID map[string]bool
+	probedIDs []string
+}
+
+func (p *acquireSandboxProvider) Name() string { return "fake" }
+func (p *acquireSandboxProvider) Create(context.Context, agent.SandboxConfig) (*agent.Sandbox, error) {
+	panic("not used")
+}
+func (p *acquireSandboxProvider) CloneRepo(context.Context, *agent.Sandbox, string, string, string) error {
+	panic("not used")
+}
+func (p *acquireSandboxProvider) Exec(context.Context, *agent.Sandbox, string, io.Writer, io.Writer) (int, error) {
+	panic("not used")
+}
+func (p *acquireSandboxProvider) ReadFile(context.Context, *agent.Sandbox, string) ([]byte, error) {
+	panic("not used")
+}
+func (p *acquireSandboxProvider) WriteFile(context.Context, *agent.Sandbox, string, []byte) error {
+	panic("not used")
+}
+func (p *acquireSandboxProvider) Destroy(context.Context, *agent.Sandbox) error {
+	panic("not used")
+}
+func (p *acquireSandboxProvider) IsAlive(_ context.Context, sb *agent.Sandbox) (bool, error) {
+	p.probedIDs = append(p.probedIDs, sb.ID)
+	return p.aliveByID[sb.ID], nil
+}
+func (p *acquireSandboxProvider) ConnectionInfo(context.Context, *agent.Sandbox) (*agent.SandboxConnectionInfo, error) {
+	panic("not used")
+}
+func (p *acquireSandboxProvider) Snapshot(context.Context, *agent.Sandbox) (io.ReadCloser, error) {
+	panic("not used")
+}
+func (p *acquireSandboxProvider) Restore(context.Context, *agent.Sandbox, io.Reader) error {
+	panic("not used")
+}
+func (p *acquireSandboxProvider) ExecStream(context.Context, *agent.Sandbox, string, func([]byte), io.Writer) (int, error) {
+	panic("not used")
+}
+
+func TestStartRunnerAcquireSandbox_ClearsStaleContainerIDBeforeHydrateRetry(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "pgx mock pool should be created")
+	defer mock.Close()
+
+	orgID := uuid.New()
+	sessionID := uuid.New()
+	staleContainerID := "stale-container"
+	snapshotKey := "snapshots/session.tar.zst"
+	provider := &acquireSandboxProvider{aliveByID: map[string]bool{staleContainerID: false}}
+	runner := &StartRunner{
+		sessions:        db.NewSessionStore(mock),
+		sandboxProvider: provider,
+		snapshots:       acquireSandboxSnapshotStore{},
+		logger:          zerolog.Nop(),
+	}
+	session := &models.Session{
+		ID:           sessionID,
+		OrgID:        orgID,
+		ContainerID:  &staleContainerID,
+		SandboxState: models.SandboxStateRunning,
+		SnapshotKey:  &snapshotKey,
+	}
+
+	mock.ExpectQuery(`SELECT COALESCE\(container_id, ''\)\s+FROM sessions`).
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(pgxmock.NewRows([]string{"container_id"}).AddRow(staleContainerID))
+	mock.ExpectExec(`UPDATE sessions\s+SET container_id = NULL,\s+worker_node_id = NULL,\s+turn_holding_container = FALSE`).
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
+
+	result := runner.acquireSandbox(context.Background(), orgID, session, nil)
+
+	require.ErrorIs(t, result.Err, agent.ErrStaleSandboxIDCleared, "stale container cleanup should ask the caller to retry")
+	require.Equal(t, "STALE_SANDBOX_CLEARED", result.ErrCode, "stale cleanup should return a stable preview error code")
+	require.Nil(t, result.Sandbox, "stale cleanup should not hydrate in the same attempt")
+	require.Equal(t, []string{staleContainerID, staleContainerID}, provider.probedIDs, "runner should probe the recorded container before clearing it")
+	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
+}
+
+type acquireSandboxSnapshotStore struct{}
+
+func (acquireSandboxSnapshotStore) Save(context.Context, string, io.Reader) error {
+	panic("not used")
+}
+func (acquireSandboxSnapshotStore) Load(context.Context, string, io.Writer) error {
+	panic("not used")
+}
+func (acquireSandboxSnapshotStore) Delete(context.Context, string) error {
+	panic("not used")
 }
 
 type fakePreviewStartupCache struct {

--- a/internal/worker/handlers.go
+++ b/internal/worker/handlers.go
@@ -605,6 +605,16 @@ func newStartPreviewHandler(stores *Stores, services *Services, logger zerolog.L
 					Msg("preview capacity reached; retrying start_preview")
 				return &RetryableError{Err: err, RetryAfter: &retryAfter, TargetNodeID: targetNodeID, ClearTargetNodeID: clearTarget}
 			}
+			if errors.Is(err, agent.ErrStaleSandboxIDCleared) {
+				retryAfter := 2 * time.Second
+				logger.Info().
+					Err(err).
+					Str("preview_id", input.PreviewID.String()).
+					Str("session_id", input.SessionID.String()).
+					Dur("retry_after", retryAfter).
+					Msg("preview cleared stale sandbox container_id; retrying start_preview")
+				return &RetryableError{Err: err, RetryAfter: &retryAfter, BypassMaxRetryDuration: true}
+			}
 			return &FatalError{Err: err}
 		}
 		return nil

--- a/internal/worker/handlers_test.go
+++ b/internal/worker/handlers_test.go
@@ -3307,6 +3307,34 @@ func TestStartPreviewHandler_PreviewCapacityRetries(t *testing.T) {
 	require.Equal(t, payload, starter.payload, "start_preview handler should pass the decoded payload")
 }
 
+func TestStartPreviewHandler_StaleSandboxClearedRetries(t *testing.T) {
+	t.Parallel()
+
+	logger := zerolog.Nop()
+	starter := &mockPreviewStarter{err: fmt.Errorf("cleared stale sandbox: %w", agent.ErrStaleSandboxIDCleared)}
+	handler := newStartPreviewHandler(nil, &Services{PreviewStarter: starter}, logger)
+
+	payload := previewsvc.StartPreviewJobPayload{
+		OrgID:     uuid.New(),
+		UserID:    uuid.New(),
+		SessionID: uuid.New(),
+		PreviewID: uuid.New(),
+	}
+	raw, err := json.Marshal(payload)
+	require.NoError(t, err, "start_preview payload should marshal")
+
+	err = handler(context.Background(), models.JobTypeStartPreview, raw)
+
+	var retryable *RetryableError
+	require.ErrorAs(t, err, &retryable, "stale sandbox cleanup should requeue start_preview instead of dead-lettering the preview")
+	require.ErrorIs(t, retryable.Err, agent.ErrStaleSandboxIDCleared, "retryable error should preserve the stale sandbox sentinel")
+	require.NotNil(t, retryable.RetryAfter, "stale sandbox retry should use an explicit short delay")
+	require.Equal(t, 2*time.Second, *retryable.RetryAfter, "stale sandbox retry should run after the cleanup settles")
+	require.True(t, retryable.BypassMaxRetryDuration, "stale sandbox retry should bypass the generic retry window")
+	require.True(t, starter.called, "start_preview handler should call the preview starter before deciding retry behavior")
+	require.Equal(t, payload, starter.payload, "start_preview handler should pass the decoded payload")
+}
+
 func TestStartPreviewHandler_PreviewCapacityRetriesTargetsAvailableWorker(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- Detect stale preview sandbox IDs during acquisition and clear the session row when the recorded container is no longer alive.
- Surface a dedicated `STALE_SANDBOX_CLEARED` preview error so the worker retries instead of treating the attempt as fatal.
- Add worker retry handling with a short delay and bypass the generic retry window for this recovery path.
- Cover the new cleanup and retry flow with unit tests in the preview runner and worker handler.

## Testing
- Added unit coverage for clearing a stale container ID before retrying preview hydration.
- Added unit coverage for requeueing `start_preview` when the stale-sandbox sentinel is returned.
- Not run (not requested)