### PR TITLE
Add Claude Opus 4.8 model support across Amp, Pi, and Claude Code

### DIFF
--- a/frontend/src/app/(dashboard)/settings/agent/page.tsx
+++ b/frontend/src/app/(dashboard)/settings/agent/page.tsx
@@ -8,7 +8,7 @@ import { api } from "@/lib/api";
 import { apiKeyHelp, ORG_PROVIDER_OPTIONS } from "@/lib/coding-auth-metadata";
 import { captureError } from "@/lib/errors";
 import { useAuth } from "@/hooks/use-auth";
-import { AVAILABLE_AMP_MODES, AVAILABLE_PI_MODELS, PI_MODEL_CLAUDE_OPUS_47 } from "@/lib/model-constants";
+import { AVAILABLE_AMP_MODES, AVAILABLE_PI_MODELS, PI_MODEL_CLAUDE_OPUS_48 } from "@/lib/model-constants";
 import { queryKeys } from "@/lib/query-keys";
 import type { CodingAuth, ListResponse, Organization, OrgSettings, SingleResponse } from "@/lib/types";
 import { CodingAuthStack } from "@/components/coding-auth-stack";
@@ -139,7 +139,7 @@ export default function AgentPage() {
   const [insertionMode, setInsertionMode] = useState<InsertionMode>("next_fallback");
   const [renameValue, setRenameValue] = useState("");
   const [ampMode, setAmpMode] = useState<string>(AVAILABLE_AMP_MODES[0] ?? "smart");
-  const [piModel, setPiModel] = useState<string>(PI_MODEL_CLAUDE_OPUS_47);
+  const [piModel, setPiModel] = useState<string>(PI_MODEL_CLAUDE_OPUS_48);
 
   const { data: codingAuthsResponse } = useQuery<ListResponse<CodingAuth>>({
     queryKey: ["coding-auths"],
@@ -271,7 +271,7 @@ export default function AgentPage() {
     setAuthType("subscription");
     setInsertionMode("next_fallback");
     setAmpMode(AVAILABLE_AMP_MODES[0] ?? "smart");
-    setPiModel(PI_MODEL_CLAUDE_OPUS_47);
+    setPiModel(PI_MODEL_CLAUDE_OPUS_48);
   }
 
   function openAddModal(nextProvider: ModalProvider) {

--- a/frontend/src/lib/model-constants.test.ts
+++ b/frontend/src/lib/model-constants.test.ts
@@ -4,6 +4,7 @@ import {
   AVAILABLE_CODEX_MODELS,
   AVAILABLE_CLAUDE_CODE_MODELS,
   AVAILABLE_GEMINI_CLI_MODELS,
+  AVAILABLE_PI_MODELS,
   DEFAULT_PM_MODEL,
   DEFAULT_LLM_MODEL,
   CODEX_MODEL_GPT_5_4,
@@ -19,6 +20,7 @@ describe("model constants", () => {
 
   it("includes latest Claude Code models", () => {
     expect(AVAILABLE_CLAUDE_CODE_MODELS).toEqual([
+      "claude-opus-4-8",
       "claude-opus-4-7",
       "claude-opus-4-6",
       "claude-sonnet-4-6",
@@ -33,6 +35,17 @@ describe("model constants", () => {
       "gemini-3-flash-preview",
       "gemini-2.5-pro",
       "gemini-2.5-flash",
+    ]);
+  });
+
+  it("includes latest Pi curated models", () => {
+    expect(AVAILABLE_PI_MODELS).toEqual([
+      "anthropic/claude-opus-4-8",
+      "anthropic/claude-opus-4-7",
+      "anthropic/claude-sonnet-4-6",
+      "anthropic/claude-haiku-4-5",
+      "openai/gpt-5.4",
+      "google/gemini-2.5-pro",
     ]);
   });
 
@@ -61,7 +74,7 @@ describe("model constants", () => {
 
   it("LLM_MODELS_BY_PROVIDER maps providers to their models", () => {
     expect(Object.keys(LLM_MODELS_BY_PROVIDER)).toEqual(["anthropic", "openai", "gemini", "openrouter"]);
-    expect(LLM_MODELS_BY_PROVIDER.anthropic.models).toEqual(["claude-opus-4-7", "claude-sonnet-4-6", "claude-haiku-4-5"]);
+    expect(LLM_MODELS_BY_PROVIDER.anthropic.models).toEqual(["claude-opus-4-8", "claude-opus-4-7", "claude-sonnet-4-6", "claude-haiku-4-5"]);
     expect(LLM_MODELS_BY_PROVIDER.openai.models).toEqual(["gpt-5.4", "gpt-5.4-mini", "gpt-5.4-nano"]);
     expect(LLM_MODELS_BY_PROVIDER.gemini.models).toEqual(["gemini-3.1-pro", "gemini-3-flash", "gemini-2.5-pro", "gemini-2.5-flash"]);
   });

--- a/frontend/src/lib/model-constants.ts
+++ b/frontend/src/lib/model-constants.ts
@@ -1,3 +1,4 @@
+export const CLAUDE_CODE_MODEL_OPUS_48 = "claude-opus-4-8";
 export const CLAUDE_CODE_MODEL_OPUS_47 = "claude-opus-4-7";
 export const CLAUDE_CODE_MODEL_OPUS_46 = "claude-opus-4-6";
 export const CLAUDE_CODE_MODEL_SONNET_46 = "claude-sonnet-4-6";
@@ -5,6 +6,7 @@ export const CLAUDE_CODE_MODEL_SONNET_45 = "claude-sonnet-4-5";
 export const CLAUDE_CODE_MODEL_HAIKU_45 = "claude-haiku-4-5";
 
 export const AVAILABLE_CLAUDE_CODE_MODELS = [
+  CLAUDE_CODE_MODEL_OPUS_48,
   CLAUDE_CODE_MODEL_OPUS_47,
   CLAUDE_CODE_MODEL_OPUS_46,
   CLAUDE_CODE_MODEL_SONNET_46,
@@ -61,8 +63,9 @@ export const AVAILABLE_AMP_MODES = [
 ] as const;
 
 // Pi accepts provider/model patterns. Curated short list; PI_MODEL_CUSTOM
-// lets users opt into Pi's full multi-provider catalog. Opus 4.7 leads the
+// lets users opt into Pi's full multi-provider catalog. Opus 4.8 leads the
 // list as the current top model and matches the adapter's hardcoded fallback.
+export const PI_MODEL_CLAUDE_OPUS_48 = "anthropic/claude-opus-4-8";
 export const PI_MODEL_CLAUDE_OPUS_47 = "anthropic/claude-opus-4-7";
 export const PI_MODEL_CLAUDE_SONNET_46 = "anthropic/claude-sonnet-4-6";
 export const PI_MODEL_CLAUDE_HAIKU_45 = "anthropic/claude-haiku-4-5";
@@ -70,6 +73,7 @@ export const PI_MODEL_GPT_5_4 = "openai/gpt-5.4";
 export const PI_MODEL_GEMINI_2_5_PRO = "google/gemini-2.5-pro";
 
 export const AVAILABLE_PI_MODELS = [
+  PI_MODEL_CLAUDE_OPUS_48,
   PI_MODEL_CLAUDE_OPUS_47,
   PI_MODEL_CLAUDE_SONNET_46,
   PI_MODEL_CLAUDE_HAIKU_45,
@@ -88,12 +92,13 @@ export const DEFAULT_PM_MODEL = CODEX_MODEL_GPT_5_4;
 // from GET /api/v1/settings/llm-models (served by models.LLMModelsByProvider()
 // in internal/models/agent_model_constants.go). Keep both in sync.
 export const LLM_MODELS_BY_PROVIDER: Record<string, { label: string; models: readonly string[] }> = {
-  anthropic: { label: "Anthropic", models: ["claude-opus-4-7", "claude-sonnet-4-6", "claude-haiku-4-5"] },
+  anthropic: { label: "Anthropic", models: ["claude-opus-4-8", "claude-opus-4-7", "claude-sonnet-4-6", "claude-haiku-4-5"] },
   openai: { label: "OpenAI", models: ["gpt-5.4", "gpt-5.4-mini", "gpt-5.4-nano"] },
   gemini: { label: "Gemini", models: ["gemini-3.1-pro", "gemini-3-flash", "gemini-2.5-pro", "gemini-2.5-flash"] },
   openrouter: {
     label: "OpenRouter",
     models: [
+      "claude-opus-4-8",
       "claude-opus-4-7",
       "claude-sonnet-4-6",
       "claude-haiku-4-5",

--- a/internal/llm/registry.go
+++ b/internal/llm/registry.go
@@ -24,6 +24,12 @@ type providerModel struct {
 var defaultChains = map[ModelName][]providerModel{
 	// Anthropic models — primary: Anthropic API, cross-provider fallback, then OpenRouter.
 	// Ordered most-capable → least-capable within the Claude 4 family.
+	"claude-opus-4-8": {
+		{ProviderName: "anthropic", ModelID: "claude-opus-4-8"},
+		{ProviderName: "openai_chat", ModelID: "gpt-5.4"},
+		{ProviderName: "openai_responses", ModelID: "gpt-5.4"},
+		{ProviderName: "openrouter", ModelID: "anthropic/claude-opus-4-8"},
+	},
 	"claude-opus-4-7": {
 		{ProviderName: "anthropic", ModelID: "claude-opus-4-7"},
 		{ProviderName: "openai_chat", ModelID: "gpt-5.4"},
@@ -68,7 +74,7 @@ var defaultChains = map[ModelName][]providerModel{
 	// provider-specific API identifier (Gemini 3.x models ship as "-preview" strings).
 	"gemini-3.1-pro": {
 		{ProviderName: "gemini", ModelID: "gemini-3.1-pro-preview"},
-		{ProviderName: "anthropic", ModelID: "claude-opus-4-7"},
+		{ProviderName: "anthropic", ModelID: "claude-opus-4-8"},
 		{ProviderName: "openai_chat", ModelID: "gpt-5.4"},
 		{ProviderName: "openai_responses", ModelID: "gpt-5.4"},
 		{ProviderName: "openrouter", ModelID: "google/gemini-3.1-pro-preview"},

--- a/internal/models/agent_model_constants.go
+++ b/internal/models/agent_model_constants.go
@@ -33,10 +33,11 @@ const (
 var AvailableAmpModes = []string{AmpModeSmart, AmpModeDeep, AmpModeLarge, AmpModeRush}
 
 // Pi accepts provider/model patterns. Curated short list; users with niche needs
-// can override per-session via PI_MODEL_CUSTOM in agent_config. Opus 4.7 is
+// can override per-session via PI_MODEL_CUSTOM in agent_config. Opus 4.8 is
 // listed first because it's the current top model and doubles as the hardcoded
 // default in piStreamingConfig.BuildCmd when no PI_MODEL is set.
 const (
+	PiModelClaudeOpus48   = "anthropic/claude-opus-4-8"
 	PiModelClaudeOpus47   = "anthropic/claude-opus-4-7"
 	PiModelClaudeSonnet46 = "anthropic/claude-sonnet-4-6"
 	PiModelClaudeHaiku45  = "anthropic/claude-haiku-4-5"
@@ -45,6 +46,7 @@ const (
 )
 
 var AvailablePiModels = []string{
+	PiModelClaudeOpus48,
 	PiModelClaudeOpus47,
 	PiModelClaudeSonnet46,
 	PiModelClaudeHaiku45,
@@ -53,6 +55,7 @@ var AvailablePiModels = []string{
 }
 
 const (
+	ClaudeCodeModelOpus48   = "claude-opus-4-8"
 	ClaudeCodeModelOpus47   = "claude-opus-4-7"
 	ClaudeCodeModelOpus46   = "claude-opus-4-6"
 	ClaudeCodeModelSonnet46 = "claude-sonnet-4-6"
@@ -60,7 +63,7 @@ const (
 	ClaudeCodeModelHaiku45  = "claude-haiku-4-5"
 )
 
-var AvailableClaudeCodeModels = []string{ClaudeCodeModelOpus47, ClaudeCodeModelOpus46, ClaudeCodeModelSonnet46, ClaudeCodeModelSonnet45, ClaudeCodeModelHaiku45}
+var AvailableClaudeCodeModels = []string{ClaudeCodeModelOpus48, ClaudeCodeModelOpus47, ClaudeCodeModelOpus46, ClaudeCodeModelSonnet46, ClaudeCodeModelSonnet45, ClaudeCodeModelHaiku45}
 
 const (
 	GeminiCLIModelGemini31ProPreview  = "gemini-3.1-pro-preview"
@@ -295,7 +298,7 @@ func ValidateModelForAgentType(agentType AgentType, model string) error {
 			return fmt.Errorf("model must be non-empty for agent type %s", AgentTypePi)
 		}
 		if !strings.Contains(model, "/") {
-			return fmt.Errorf("pi model %q must be in the form \"provider/model\" (e.g. %s)", model, PiModelClaudeOpus47)
+			return fmt.Errorf("pi model %q must be in the form \"provider/model\" (e.g. %s)", model, PiModelClaudeOpus48)
 		}
 	default:
 		return fmt.Errorf("unknown agent type: %s", agentType)
@@ -335,6 +338,7 @@ const DefaultLLMModel = "gpt-5.4-mini"
 // Keep in sync with frontend/src/lib/model-constants.ts (LLM_MODELS_BY_PROVIDER).
 // Models are listed most-capable → least-capable within each provider family.
 var AvailableLLMModels = []string{
+	"claude-opus-4-8",
 	"claude-opus-4-7",
 	"claude-sonnet-4-6",
 	"claude-haiku-4-5",
@@ -357,11 +361,11 @@ var AvailableLLMModels = []string{
 // GET /api/v1/settings/llm-models endpoint.
 func LLMModelsByProvider() map[string][]string {
 	return map[string][]string{
-		"anthropic": {"claude-opus-4-7", "claude-sonnet-4-6", "claude-haiku-4-5"},
+		"anthropic": {"claude-opus-4-8", "claude-opus-4-7", "claude-sonnet-4-6", "claude-haiku-4-5"},
 		"openai":    {"gpt-5.4", "gpt-5.4-mini", "gpt-5.4-nano"},
 		"gemini":    {"gemini-3.1-pro", "gemini-3-flash", "gemini-2.5-pro", "gemini-2.5-flash"},
 		"openrouter": {
-			"claude-opus-4-7", "claude-sonnet-4-6", "claude-haiku-4-5",
+			"claude-opus-4-8", "claude-opus-4-7", "claude-sonnet-4-6", "claude-haiku-4-5",
 			"gpt-5.4", "gpt-5.4-mini", "gpt-5.4-nano",
 			"gemini-3.1-pro", "gemini-3-flash", "gemini-2.5-pro", "gemini-2.5-flash",
 			// OpenRouter-exclusive Qwen models.

--- a/internal/models/agent_model_constants_test.go
+++ b/internal/models/agent_model_constants_test.go
@@ -26,7 +26,7 @@ func TestClaudeCodeModelConstants(t *testing.T) {
 	t.Parallel()
 
 	require.Equal(t,
-		[]string{ClaudeCodeModelOpus47, ClaudeCodeModelOpus46, ClaudeCodeModelSonnet46, ClaudeCodeModelSonnet45, ClaudeCodeModelHaiku45},
+		[]string{ClaudeCodeModelOpus48, ClaudeCodeModelOpus47, ClaudeCodeModelOpus46, ClaudeCodeModelSonnet46, ClaudeCodeModelSonnet45, ClaudeCodeModelHaiku45},
 		AvailableClaudeCodeModels,
 		"AvailableClaudeCodeModels should be ordered by capability",
 	)
@@ -82,7 +82,7 @@ func TestLLMModelConstants(t *testing.T) {
 	t.Parallel()
 
 	require.Equal(t, []string{
-		"claude-opus-4-7", "claude-sonnet-4-6", "claude-haiku-4-5",
+		"claude-opus-4-8", "claude-opus-4-7", "claude-sonnet-4-6", "claude-haiku-4-5",
 		"gpt-5.4", "gpt-5.4-mini", "gpt-5.4-nano",
 		"gemini-3.1-pro", "gemini-3-flash", "gemini-2.5-pro", "gemini-2.5-flash",
 		"qwen3-235b-a22b", "qwen3-32b",
@@ -98,7 +98,7 @@ func TestLLMModelsByProvider(t *testing.T) {
 	require.Contains(t, byProvider, "openai")
 	require.Contains(t, byProvider, "gemini")
 	require.Contains(t, byProvider, "openrouter")
-	require.Equal(t, []string{"claude-opus-4-7", "claude-sonnet-4-6", "claude-haiku-4-5"}, byProvider["anthropic"])
+	require.Equal(t, []string{"claude-opus-4-8", "claude-opus-4-7", "claude-sonnet-4-6", "claude-haiku-4-5"}, byProvider["anthropic"])
 	require.Equal(t, []string{"gpt-5.4", "gpt-5.4-mini", "gpt-5.4-nano"}, byProvider["openai"])
 	require.Equal(t, []string{"gemini-3.1-pro", "gemini-3-flash", "gemini-2.5-pro", "gemini-2.5-flash"}, byProvider["gemini"])
 	require.Contains(t, byProvider["openrouter"], "gemini-3.1-pro", "openrouter should proxy the latest gemini models too")
@@ -211,13 +211,13 @@ func TestAgentTypeForModel(t *testing.T) {
 	}{
 		{"", ""},
 		{CodexModelGPT54, AgentTypeCodex},
-		{ClaudeCodeModelOpus47, AgentTypeClaudeCode},
+		{ClaudeCodeModelOpus48, AgentTypeClaudeCode},
 		{GeminiCLIModelGemini25Pro, AgentTypeGeminiCLI},
 		{AmpModeSmart, AgentTypeAmp},
 		// Curated Pi entry contains "/" — must resolve to Pi via the curated
 		// lookup (not the slash heuristic) so we keep precedence stable if a
 		// non-Pi agent later registers a slash-shaped model.
-		{PiModelClaudeOpus47, AgentTypePi},
+		{PiModelClaudeOpus48, AgentTypePi},
 		// Slash heuristic only fires after every curated list misses.
 		{"moonshot/kimi-k2", AgentTypePi},
 		{"unknown-model", ""},
@@ -232,9 +232,9 @@ func TestValidatePMModel(t *testing.T) {
 
 	require.NoError(t, ValidatePMModel(""), "empty pm_model is allowed (caller falls back to default)")
 	require.NoError(t, ValidatePMModel(CodexModelGPT54))
-	require.NoError(t, ValidatePMModel(ClaudeCodeModelOpus47))
+	require.NoError(t, ValidatePMModel(ClaudeCodeModelOpus48))
 	require.NoError(t, ValidatePMModel(AmpModeSmart))
-	require.NoError(t, ValidatePMModel(PiModelClaudeOpus47))
+	require.NoError(t, ValidatePMModel(PiModelClaudeOpus48))
 	// Custom Pi provider/model — accepted with parity to ValidateModelForAgentType.
 	require.NoError(t, ValidatePMModel("moonshot/kimi-k2"))
 
@@ -289,7 +289,7 @@ func TestValidateSettingsModels(t *testing.T) {
 		{
 			name: "accepts pi model as pm model",
 			settings: OrgSettings{
-				PMModel: PiModelClaudeOpus47,
+				PMModel: PiModelClaudeOpus48,
 			},
 		},
 		{

--- a/internal/services/agent/adapters/pi.go
+++ b/internal/services/agent/adapters/pi.go
@@ -91,14 +91,14 @@ var piStreamingConfig = streamingAgentConfig{
 		return fmt.Sprintf(
 			"pi -p \"$(cat '%s')\" --mode json --api-key \"${PI_API_KEY}\" --model \"${PI_MODEL_CUSTOM:-${PI_MODEL:-%s}}\"",
 			escapedPromptPath,
-			models.PiModelClaudeOpus47,
+			models.PiModelClaudeOpus48,
 		)
 	},
 	BuildResumeCmd: func(escapedPromptPath, escapedResumeSessionID string) string {
 		return fmt.Sprintf(
 			"pi -p \"$(cat '%s')\" --mode json --api-key \"${PI_API_KEY}\" --model \"${PI_MODEL_CUSTOM:-${PI_MODEL:-%s}}\" --session '%s'",
 			escapedPromptPath,
-			models.PiModelClaudeOpus47,
+			models.PiModelClaudeOpus48,
 			escapedResumeSessionID,
 		)
 	},

--- a/internal/services/agent/adapters/pi_test.go
+++ b/internal/services/agent/adapters/pi_test.go
@@ -291,7 +291,7 @@ func TestPiAdapter_ShellModelResolution(t *testing.T) {
 
 	// Same expansion pattern the adapter emits; isolated so we can drive it
 	// through bash with different env var combinations.
-	const expr = `echo "${PI_MODEL_CUSTOM:-${PI_MODEL:-anthropic/claude-opus-4-7}}"`
+	const expr = `echo "${PI_MODEL_CUSTOM:-${PI_MODEL:-anthropic/claude-opus-4-8}}"`
 
 	tests := []struct {
 		name string
@@ -301,7 +301,7 @@ func TestPiAdapter_ShellModelResolution(t *testing.T) {
 		{
 			name: "falls back to default when nothing set",
 			env:  nil,
-			want: "anthropic/claude-opus-4-7",
+			want: "anthropic/claude-opus-4-8",
 		},
 		{
 			name: "uses PI_MODEL when only PI_MODEL is set",

--- a/internal/services/agent/token_usage_cost.go
+++ b/internal/services/agent/token_usage_cost.go
@@ -38,8 +38,10 @@ var codexCreditRates = map[string]tokenRate{
 }
 
 var anthropicRates = map[string]tokenRate{
+	models.ClaudeCodeModelOpus48:   {inputPerMTok: 5.00, cachedInputPerMTok: 0.50, cacheCreationPerMTok: 6.25, outputPerMTok: 25.00, unit: TokenCostUnitUSD, detail: "anthropic_api_pricing"},
 	models.ClaudeCodeModelOpus47:   {inputPerMTok: 5.00, cachedInputPerMTok: 0.50, cacheCreationPerMTok: 6.25, outputPerMTok: 25.00, unit: TokenCostUnitUSD, detail: "anthropic_api_pricing"},
 	models.ClaudeCodeModelOpus46:   {inputPerMTok: 5.00, cachedInputPerMTok: 0.50, cacheCreationPerMTok: 6.25, outputPerMTok: 25.00, unit: TokenCostUnitUSD, detail: "anthropic_api_pricing"},
+	models.PiModelClaudeOpus48:     {inputPerMTok: 5.00, cachedInputPerMTok: 0.50, cacheCreationPerMTok: 6.25, outputPerMTok: 25.00, unit: TokenCostUnitUSD, detail: "anthropic_api_pricing"},
 	models.PiModelClaudeOpus47:     {inputPerMTok: 5.00, cachedInputPerMTok: 0.50, cacheCreationPerMTok: 6.25, outputPerMTok: 25.00, unit: TokenCostUnitUSD, detail: "anthropic_api_pricing"},
 	models.ClaudeCodeModelSonnet46: {inputPerMTok: 3.00, cachedInputPerMTok: 0.30, cacheCreationPerMTok: 3.75, outputPerMTok: 15.00, unit: TokenCostUnitUSD, detail: "anthropic_api_pricing"},
 	models.PiModelClaudeSonnet46:   {inputPerMTok: 3.00, cachedInputPerMTok: 0.30, cacheCreationPerMTok: 3.75, outputPerMTok: 15.00, unit: TokenCostUnitUSD, detail: "anthropic_api_pricing"},


### PR DESCRIPTION
## Summary
Updated the frontend and backend to recognize and use the latest Claude Opus 4.8 model for Pi and Claude Code. This keeps model dropdowns and provider registries aligned with the most recent documentation and ensures the correct default is selected.

## Changes
- **frontend/src/app/(dashboard)/settings/agent/page.tsx**
  - Switch Pi default from `PI_MODEL_CLAUDE_OPUS_47` to `PI_MODEL_CLAUDE_OPUS_48`.
- **frontend/src/lib/model-constants.ts**
  - Add/adjust model constants and include `claude-opus-4-8` in the curated Claude Code and Pi model lists.
- **frontend/src/lib/model-constants.test.ts**
  - Extend expectations for:
    - Claude Code available models to include `claude-opus-4-8`
    - Pi curated available models to include `anthropic/claude-opus-4-8`
    - Anthropic provider model mapping to include `claude-opus-4-8`
- **internal/llm/registry.go**
  - Update model/provider registry to include Opus 4.8 entries used by the app.
- **internal/models/agent_model_constants.go** and **internal/models/agent_model_constants_test.go**
  - Add Opus 4.8 constants and corresponding unit test coverage.
- **internal/services/agent/adapters/pi.go** and **internal/services/agent/adapters/pi_test.go**
  - Ensure Pi adapter selects/handles the new Opus 4.8 model correctly.
- **internal/services/agent/token_usage_cost.go**
  - Update token/cost handling mappings to account for Opus 4.8 where applicable.

## Test plan
- Ran/updated unit tests for model constants, registry, and Pi adapter (including expectations for the new Opus 4.8 model).
- No documentation-only changes were reintroduced; the prior docs cleanup was left as-is.

[143.dev](https://143.dev) | [session 6b41ae0e](https://143.dev/sessions/6b41ae0e-e1e5-4a59-b9bb-ac44d3bd540b)

Preview: https://143.dev/previews/github/assembledhq/143/pull/1206