### PR TITLE
Fix button opacity flash when session actions enter loading state

### DIFF
--- a/frontend/src/app/(dashboard)/sessions/[id]/page.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/page.test.tsx
@@ -4779,6 +4779,49 @@ describe('SessionDetailPage', () => {
     });
   });
 
+  it('keeps Create PR at full opacity while the request is queueing', async () => {
+    let releaseCreatePR: (() => void) | undefined;
+    const createPRResponse = new Promise<Response>((resolve) => {
+      releaseCreatePR = () => resolve(HttpResponse.json({ status: 'queued' }, { status: 202 }));
+    });
+
+    const sessionWithDiff: Session = {
+      ...mockSessions[0],
+      status: 'completed',
+      diff: '--- a/file.ts\n+++ b/file.ts\n@@ -1 +1 @@\n-old\n+new',
+      diff_stats: { added: 1, removed: 1, files_changed: 1 },
+      snapshot_key: 'snap-abc',
+    };
+
+    server.use(
+      http.get('/api/v1/sessions/:id', () => {
+        return HttpResponse.json({ data: sessionWithDiff } satisfies SingleResponse<Session>);
+      }),
+      http.get('/api/v1/sessions/:id/pr', () => {
+        return HttpResponse.json(
+          { error: { code: 'NOT_FOUND', message: 'pull request not found' } },
+          { status: 404 },
+        );
+      }),
+      http.post('/api/v1/sessions/:id/pr', async () => {
+        return createPRResponse;
+      }),
+    );
+
+    renderWithProviders(<SessionDetailContent id="session-abcdef12-3456-7890" />);
+
+    const user = userEvent.setup();
+    const createPRButton = await screen.findByRole('button', { name: /Create PR/ });
+    await user.click(createPRButton);
+
+    const queueingButton = await screen.findByRole('button', { name: /Queueing PR/ });
+    expect(queueingButton).toBeDisabled();
+    expect(queueingButton).toHaveAttribute('data-loading', 'true');
+    expect(queueingButton).toHaveClass('disabled:data-[loading=true]:opacity-100');
+
+    releaseCreatePR?.();
+  });
+
   it('does not queue duplicate create PR requests from the keyboard while one is pending', async () => {
     let createPRCalls = 0;
 

--- a/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
@@ -5273,17 +5273,16 @@ export function SessionDetailContent({ id }: { id: string }) {
                       variant="outline"
                       size="sm"
                       className="h-7 rounded-r-none border-r-0 text-xs gap-1.5"
+                      loading={prActionSpinning}
                       disabled={prActionDisabled}
                       title={prActionTitle ? `${prActionTitle} (p c)` : `${prActionLabel} (p c)`}
                       onClick={() => createPRMutation.mutate(undefined)}
                     >
-                      {prActionSpinning ? (
-                        <Loader2 className="h-3 w-3 animate-spin" />
-                      ) : prState === "failed" || localPRActionError ? (
+                      {!prActionSpinning && (prState === "failed" || localPRActionError ? (
                         <AlertTriangle className="h-3 w-3" />
                       ) : (
                         <GitPullRequest className="h-3 w-3" />
-                      )}
+                      ))}
                       {prActionLabel}
                     </Button>
                     <DropdownMenu>

--- a/frontend/src/components/preview/preview-panel.test.tsx
+++ b/frontend/src/components/preview/preview-panel.test.tsx
@@ -1154,6 +1154,25 @@ describe("PreviewPanel component", () => {
     expect(mockRestart).not.toHaveBeenCalled();
   });
 
+  it("keeps Retry Preview at full opacity while retrying", async () => {
+    const user = userEvent.setup();
+    mockGet.mockResolvedValue(makePreviewStatus({ status: "failed" }));
+    mockEnsure.mockReturnValue(new Promise(() => {}));
+
+    renderWithProviders(<PreviewPanel {...DEFAULT_PROPS} />);
+
+    const retryButton = await screen.findByRole("button", {
+      name: "Retry Preview",
+    });
+    await user.click(retryButton);
+
+    expect(retryButton).toBeDisabled();
+    expect(retryButton).toHaveAttribute("data-loading", "true");
+    expect(retryButton).toHaveClass(
+      "disabled:data-[loading=true]:opacity-100",
+    );
+  });
+
   /* ---------- Mutation error banner ---------- */
 
   it("shows mutation error banner when start fails", async () => {

--- a/frontend/src/components/ui/button.test.tsx
+++ b/frontend/src/components/ui/button.test.tsx
@@ -22,6 +22,16 @@ describe('Button', () => {
     expect(container.querySelector('[data-slot="button-spinner"]')).toBeInTheDocument();
   });
 
+  it('keeps loading buttons at full opacity', () => {
+    renderWithProviders(
+      <Button loading>Submit</Button>,
+    );
+
+    const button = screen.getByRole('button', { name: 'Submit' });
+    expect(button).toHaveAttribute('data-loading', 'true');
+    expect(button).toHaveClass('disabled:data-[loading=true]:opacity-100');
+  });
+
   it('does not show a spinner when not loading', () => {
     const { container } = renderWithProviders(
       <Button>Submit</Button>,

--- a/frontend/src/components/ui/button.tsx
+++ b/frontend/src/components/ui/button.tsx
@@ -6,7 +6,7 @@ import { Slot } from "radix-ui"
 import { cn } from "@/lib/utils"
 
 const buttonVariants = cva(
-  "inline-flex cursor-pointer items-center justify-center gap-1.5 whitespace-nowrap rounded-md text-xs font-medium transition-[color,background-color,background-image,border-color,box-shadow,transform] duration-100 ease-[cubic-bezier(0.16,1,0.3,1)] disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/40 focus-visible:ring-2 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
+  "inline-flex cursor-pointer items-center justify-center gap-1.5 whitespace-nowrap rounded-md text-xs font-medium transition-[color,background-color,background-image,border-color,box-shadow,transform] duration-100 ease-[cubic-bezier(0.16,1,0.3,1)] disabled:pointer-events-none disabled:opacity-50 disabled:data-[loading=true]:opacity-100 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/40 focus-visible:ring-2 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
   {
     variants: {
       variant: {
@@ -74,6 +74,7 @@ function Button({
       data-slot="button"
       data-variant={variant}
       data-size={size}
+      data-loading={loading ? "true" : undefined}
       className={cn(buttonVariants({ variant, size, className }), isDisabled && "pointer-events-none")}
       disabled={!asChild ? isDisabled : undefined}
       aria-disabled={isDisabled || undefined}


### PR DESCRIPTION
## Summary
When session actions like **Create PR** transition into a loading/queued state, the shared `Button` styles caused the disabled state to briefly apply `opacity-50`, creating a noticeable fade. This change keeps opacity at **100%** specifically when the button is both `disabled` and `loading`, and adds coverage for the regression.

## Changes
- **frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx**
  - Set `loading={prActionSpinning}` on the Create PR button so the spinner/loading styling is driven by the shared Button component.
  - Simplified icon rendering to avoid showing the loader icon via inline conditional when `loading` is active.
- **frontend/src/components/ui/button.tsx**
  - Updated button styling to use `disabled:data-[loading=true]:opacity-100`, while preserving the normal `disabled:opacity-50` for non-loading disabled buttons.
- **frontend/src/app/(dashboard)/sessions/[id]/page.test.tsx**
  - Added a test asserting **Queueing PR** stays full opacity during the queued request (`data-loading=true` + `disabled`).
- **frontend/src/components/ui/button.test.tsx**
  - Added/adjusted tests to verify the new disabled+loading opacity behavior.
- **frontend/src/components/preview/preview-panel.test.tsx**
  - Updated related expectations around button loading/disabled rendering.

## Test plan
- Ran the frontend unit/integration test suite (including the updated session detail and button component tests) to verify:
  - The loading button remains disabled.
  - The loading indicator attributes/classes are applied.
  - Opacity remains at 100% during the pending/queued state.

[143.dev](https://143.dev) | [session f0c6beb3](https://143.dev/sessions/f0c6beb3-215d-4eb0-92f8-22601e988fc5)

Preview: https://143.dev/previews/github/assembledhq/143/pull/1207