### PR TITLE
Keep Start button showing spinner during pending navigation after session creation (VIR-122)

### DIFF
--- a/frontend/AGENTS.md
+++ b/frontend/AGENTS.md
@@ -327,6 +327,36 @@ Primary action buttons (Save, Submit) must always be **right-aligned** using `ju
 </div>
 ```
 
+### Submit Buttons That Navigate
+
+When a submit/create mutation navigates to a different page on success, do **not** rely only on `mutation.isPending` for the button loading state. React Query clears `isPending` once the mutation settles, but `router.push()`/`router.replace()` can take another render before the current page unmounts. Keep a local navigation-pending flag so the button stays disabled and visibly loading until the user is off the screen.
+
+```tsx
+const [isNavigatingAfterSubmit, setIsNavigatingAfterSubmit] = useState(false);
+
+const mutation = useMutation({
+  mutationFn: submitForm,
+  onMutate: () => {
+    setIsNavigatingAfterSubmit(false);
+  },
+  onSuccess: (response) => {
+    setIsNavigatingAfterSubmit(true);
+    router.push(`/items/${response.data.id}`);
+  },
+  onError: () => {
+    setIsNavigatingAfterSubmit(false);
+  },
+});
+
+const isSubmitting = mutation.isPending || isNavigatingAfterSubmit;
+
+<Button onClick={() => mutation.mutate()} disabled={!canSubmit || isSubmitting}>
+  {isSubmitting ? "Creating..." : "Create item"}
+</Button>
+```
+
+If the successful action closes a dialog before navigation, the submit button is already off screen; this extra flag is most important for full-page forms and any still-visible CTA that initiates cross-page navigation.
+
 ## Modal & Dialog Patterns
 
 ### Modal Action Layout

--- a/frontend/src/app/(dashboard)/projects/new/page.test.tsx
+++ b/frontend/src/app/(dashboard)/projects/new/page.test.tsx
@@ -1,4 +1,5 @@
-import { describe, it, expect, vi } from "vitest";
+import { beforeEach, describe, it, expect, vi } from "vitest";
+import { act } from "@testing-library/react";
 import { renderWithProviders, screen, userEvent, waitFor } from "@/test/test-utils";
 import { server } from "@/test/mocks/server";
 import { http, HttpResponse } from "msw";
@@ -7,6 +8,14 @@ import NewProjectPage from "./page";
 const pushMock = vi.fn();
 const replaceMock = vi.fn();
 const currentUserRole = vi.hoisted(() => ({ value: "member" }));
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
+}
 
 vi.mock("next/navigation", () => ({
   useRouter: () => ({
@@ -24,8 +33,13 @@ vi.mock("@/hooks/use-auth", () => ({
 }));
 
 describe("NewProjectPage", () => {
-  it("submits the selected base branch from the branch picker", async () => {
+  beforeEach(() => {
+    pushMock.mockReset();
+    replaceMock.mockReset();
     currentUserRole.value = "member";
+  });
+
+  it("submits the selected base branch from the branch picker", async () => {
     const user = userEvent.setup();
     let requestBody: Record<string, unknown> | null = null;
 
@@ -94,5 +108,58 @@ describe("NewProjectPage", () => {
     await waitFor(() => {
       expect(replaceMock).toHaveBeenCalledWith("/projects");
     });
+  });
+
+  it("keeps the create button loading after project creation succeeds while navigation is pending", async () => {
+    const user = userEvent.setup();
+    const createProject = deferred<Response>();
+
+    server.use(
+      http.get("*/api/v1/settings", () => HttpResponse.json({
+        data: {
+          id: "org-1",
+          name: "Acme",
+          settings: { default_agent_type: "codex" },
+        },
+      })),
+      http.get("*/api/v1/repositories", () => HttpResponse.json({
+        data: [
+          {
+            id: "repo-1",
+            org_id: "org-1",
+            full_name: "acme/api",
+            default_branch: "main",
+            github_id: 1,
+            created_at: "2026-01-01T00:00:00Z",
+            updated_at: "2026-01-01T00:00:00Z",
+          },
+        ],
+        meta: {},
+      })),
+      http.post("*/api/v1/projects", async () => createProject.promise),
+    );
+
+    renderWithProviders(<NewProjectPage />);
+
+    await user.type(screen.getByLabelText("Title"), "Keep loading");
+    await user.type(screen.getByLabelText("Goal"), "Keep create button loading until navigation");
+    await user.click(screen.getAllByRole("combobox")[0]);
+    await user.click(await screen.findByText("acme/api"));
+
+    const createButton = screen.getByRole("button", { name: "Create project" });
+    await user.click(createButton);
+
+    expect(createButton).toBeDisabled();
+
+    await act(async () => {
+      createProject.resolve(HttpResponse.json({ data: { id: "proj-1" } }));
+      await createProject.promise;
+    });
+
+    await waitFor(() => {
+      expect(pushMock).toHaveBeenCalledWith("/projects/proj-1");
+    });
+    expect(createButton).toBeDisabled();
+    expect(createButton).toHaveTextContent("Creating...");
   });
 });

--- a/frontend/src/app/(dashboard)/projects/new/page.tsx
+++ b/frontend/src/app/(dashboard)/projects/new/page.tsx
@@ -74,6 +74,7 @@ export default function NewProjectPage() {
   const [agentType, setAgentType] = useState("");
   const [selectedModel, setSelectedModel] = useState("");
   const [hasGenerated, setHasGenerated] = useState(false);
+  const [isNavigatingAfterCreate, setIsNavigatingAfterCreate] = useState(false);
 
   // Advanced section
   const [showAdvanced, setShowAdvanced] = useState(false);
@@ -142,8 +143,15 @@ export default function NewProjectPage() {
         agent_type: agentType || undefined,
         model: selectedModel || undefined,
       }),
+    onMutate: () => {
+      setIsNavigatingAfterCreate(false);
+    },
     onSuccess: (response) => {
+      setIsNavigatingAfterCreate(true);
       router.push(`/projects/${response.data.id}`);
+    },
+    onError: () => {
+      setIsNavigatingAfterCreate(false);
     },
   });
 
@@ -168,6 +176,7 @@ export default function NewProjectPage() {
     title.trim().length > 0 &&
     goal.trim().length > 0 &&
     repositoryId.length > 0;
+  const isCreatingProject = createMutation.isPending || isNavigatingAfterCreate;
 
   return (
     <div className="p-6 max-w-2xl mx-auto">
@@ -462,9 +471,9 @@ export default function NewProjectPage() {
           <div className="flex items-center gap-3 pt-2">
             <Button
               onClick={() => createMutation.mutate()}
-              disabled={!canSubmit || createMutation.isPending}
+              disabled={!canSubmit || isCreatingProject}
             >
-              {createMutation.isPending ? (
+              {isCreatingProject ? (
                 <>
                   <Loader2 className="mr-2 h-4 w-4 animate-spin" />
                   Creating...

--- a/frontend/src/app/(dashboard)/sessions/new/manual-session-create-page-content.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/new/manual-session-create-page-content.test.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { act } from "@testing-library/react";
 import { fireEvent, renderWithProviders, screen, userEvent, waitFor } from "@/test/test-utils";
 import { ManualSessionCreatePageContent } from "./manual-session-create-page-content";
 
@@ -43,6 +44,7 @@ const mocks = vi.hoisted(() => ({
   createSessionMock: vi.fn().mockResolvedValue({
     data: { id: "new-sess" },
   }),
+  routerPushMock: vi.fn(),
   addOptimisticSessionMock: vi.fn().mockReturnValue("optimistic-1"),
   removeOptimisticSessionMock: vi.fn(),
   markOptimisticResolvedMock: vi.fn(),
@@ -157,7 +159,7 @@ vi.mock("@/lib/errors", () => ({
 
 vi.mock("next/navigation", () => ({
   useRouter: () => ({
-    push: vi.fn(),
+    push: mocks.routerPushMock,
     replace: vi.fn(),
     prefetch: vi.fn(),
   }),
@@ -556,6 +558,33 @@ describe("ManualSessionCreatePageContent", () => {
       );
     });
     expect(mocks.addOptimisticSessionMock).toHaveBeenCalledWith("Manual Session");
+  });
+
+  it("keeps the start button loading after create succeeds while navigation is pending", async () => {
+    const user = userEvent.setup();
+    const createSession = deferred<{ data: { id: string } }>();
+    mocks.createSessionMock.mockImplementationOnce(() => createSession.promise);
+
+    renderWithProviders(<ManualSessionCreatePageContent />);
+
+    const textarea = await screen.findByRole("textbox", { name: "Manual session prompt" });
+    await user.type(textarea, "Investigate slow checkout");
+
+    const startButton = screen.getByRole("button", { name: "Start session" });
+    await user.click(startButton);
+
+    expect(startButton).toBeDisabled();
+
+    await act(async () => {
+      createSession.resolve({ data: { id: "new-sess" } });
+      await createSession.promise;
+    });
+
+    await waitFor(() => {
+      expect(mocks.routerPushMock).toHaveBeenCalledWith("/sessions/new-sess");
+    });
+    expect(startButton).toBeDisabled();
+    expect(startButton.querySelector(".animate-spin")).not.toBeNull();
   });
 
   it("shows slash command suggestions when the user types a slash trigger", async () => {

--- a/frontend/src/app/(dashboard)/settings/evals/new/page.test.tsx
+++ b/frontend/src/app/(dashboard)/settings/evals/new/page.test.tsx
@@ -1,0 +1,85 @@
+import { act } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { http, HttpResponse } from "msw";
+import { renderWithProviders, screen, userEvent, waitFor } from "@/test/test-utils";
+import { server } from "@/test/mocks/server";
+import CreateEvalTaskPage from "./page";
+
+const pushMock = vi.fn();
+
+vi.mock("next/link", () => ({
+  default: ({ children, href, ...props }: React.ComponentProps<"a"> & { href: string }) => (
+    <a href={href} {...props}>{children}</a>
+  ),
+}));
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: pushMock }),
+}));
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
+}
+
+describe("CreateEvalTaskPage", () => {
+  beforeEach(() => {
+    pushMock.mockReset();
+  });
+
+  it("keeps the create button loading after eval creation succeeds while navigation is pending", async () => {
+    const user = userEvent.setup();
+    const createEval = deferred<Response>();
+
+    server.use(
+      http.get("*/api/v1/repositories", () => HttpResponse.json({
+        data: [
+          {
+            id: "repo-1",
+            org_id: "org-1",
+            full_name: "acme/api",
+            default_branch: "main",
+            github_id: 1,
+            created_at: "2026-01-01T00:00:00Z",
+            updated_at: "2026-01-01T00:00:00Z",
+          },
+        ],
+        meta: {},
+      })),
+      http.post("*/api/v1/evals/tasks", async () => createEval.promise),
+    );
+
+    renderWithProviders(<CreateEvalTaskPage />);
+
+    await user.click(screen.getByRole("combobox"));
+    await user.click(await screen.findByText("acme/api"));
+    await user.type(screen.getByLabelText("Base commit SHA"), "abcdef1234567890");
+    await user.click(screen.getByRole("button", { name: "Next" }));
+
+    await user.type(await screen.findByLabelText("Name"), "Checkout regression");
+    await user.type(screen.getByLabelText("Description"), "Verifies checkout fixes");
+    await user.type(screen.getByLabelText("Issue description"), "Checkout fails after deploy");
+    await user.click(screen.getByRole("button", { name: "Next" }));
+
+    await user.click(screen.getByRole("button", { name: "Next" }));
+
+    const createButton = screen.getByRole("button", { name: "Create eval task" });
+    await user.click(createButton);
+
+    expect(createButton).toBeDisabled();
+
+    await act(async () => {
+      createEval.resolve(HttpResponse.json({ data: { id: "eval-1" } }));
+      await createEval.promise;
+    });
+
+    await waitFor(() => {
+      expect(pushMock).toHaveBeenCalledWith("/settings/evals/eval-1");
+    });
+    expect(createButton).toBeDisabled();
+    expect(createButton).toHaveTextContent("Creating...");
+  });
+});

--- a/frontend/src/app/(dashboard)/settings/evals/new/page.tsx
+++ b/frontend/src/app/(dashboard)/settings/evals/new/page.tsx
@@ -85,6 +85,7 @@ export default function CreateEvalTaskPage() {
   // Step 3: Scoring
   const [criteria, setCriteria] = useState<CriterionForm[]>([emptyCriterion()]);
   const [passThreshold, setPassThreshold] = useState(0.7);
+  const [isNavigatingAfterCreate, setIsNavigatingAfterCreate] = useState(false);
 
   const { data: reposResponse } = useQuery<ListResponse<Repository>>({
     queryKey: queryKeys.repositories.all,
@@ -110,11 +111,19 @@ export default function CreateEvalTaskPage() {
           .map((t) => t.trim())
           .filter(Boolean),
       }),
+    onMutate: () => {
+      setIsNavigatingAfterCreate(false);
+    },
     onSuccess: (response) => {
       queryClient.invalidateQueries({ queryKey: queryKeys.evals.tasks() });
+      setIsNavigatingAfterCreate(true);
       router.push(`/settings/evals/${response.data.id}`);
     },
+    onError: () => {
+      setIsNavigatingAfterCreate(false);
+    },
   });
+  const isCreatingEvalTask = createMutation.isPending || isNavigatingAfterCreate;
 
   const stepLabels = ["Source", "Problem", "Scoring", "Review"];
 
@@ -358,8 +367,8 @@ export default function CreateEvalTaskPage() {
               )}
               <div className="flex justify-between">
                 <Button variant="outline" onClick={() => setStep(3)}>Back</Button>
-                <Button onClick={() => createMutation.mutate()} disabled={createMutation.isPending}>
-                  {createMutation.isPending ? "Creating..." : "Create eval task"}
+                <Button onClick={() => createMutation.mutate()} disabled={isCreatingEvalTask}>
+                  {isCreatingEvalTask ? "Creating..." : "Create eval task"}
                 </Button>
               </div>
             </CardContent>

--- a/frontend/src/components/manual-session-composer.tsx
+++ b/frontend/src/components/manual-session-composer.tsx
@@ -334,6 +334,7 @@ export function ManualSessionComposer({
   const [userSelectedRepoId, setUserSelectedRepoId] = useState<string | null>(initialRepoId ?? null);
   const [branchByRepoId, setBranchByRepoId] = useState<Record<string, string>>({});
   const [creationError, setCreationError] = useState<string | null>(null);
+  const [isNavigatingAfterCreate, setIsNavigatingAfterCreate] = useState(false);
   const [caretPosition, setCaretPosition] = useState(0);
   const [selectedTriggerIndex, setSelectedTriggerIndex] = useState(0);
   const [triggerDismissed, setTriggerDismissed] = useState(false);
@@ -725,6 +726,7 @@ export function ManualSessionComposer({
       }),
     onMutate: () => {
       setCreationError(null);
+      setIsNavigatingAfterCreate(false);
       const rawTitle = message.trim().length > 0
         ? message.trim()
         : references.find((reference) => referenceCarriesLinearRef(reference))?.display ?? "";
@@ -743,6 +745,7 @@ export function ManualSessionComposer({
       // session once the refetch lands. See OptimisticSession.resolvedId.
       markOptimisticResolved(context.optimisticId, response.data.id);
       queryClient.invalidateQueries({ queryKey: queryKeys.sessions.all });
+      setIsNavigatingAfterCreate(true);
       onCreated(response.data.id);
     },
     onError: (error, _variables, context) => {
@@ -753,9 +756,11 @@ export function ManualSessionComposer({
       setCreationError(
         error instanceof Error ? error.message : "Could not start session. Please try again.",
       );
+      setIsNavigatingAfterCreate(false);
       submittingRef.current = false;
     },
   });
+  const isCreatingSession = createManualSessionMutation.isPending || isNavigatingAfterCreate;
 
   function submitManualSession() {
     if (submittingRef.current) return;
@@ -1273,7 +1278,7 @@ export function ManualSessionComposer({
                 }}
                 placeholder={placeholder}
                 rows={1}
-                disabled={createManualSessionMutation.isPending}
+                disabled={isCreatingSession}
                 className={cn(
                   "min-h-[44px] resize-none border-none bg-transparent px-0 py-2 shadow-none placeholder:text-muted-foreground/60 focus-visible:ring-0 disabled:opacity-60 disabled:cursor-not-allowed",
                   textareaClassName,
@@ -1432,11 +1437,11 @@ export function ManualSessionComposer({
                         type="button"
                         size="icon"
                         onClick={submitManualSession}
-                        disabled={!hasSubmittableInput || createManualSessionMutation.isPending}
+                        disabled={!hasSubmittableInput || isCreatingSession}
                         className="ml-auto h-8 w-8 rounded-full"
                         aria-label="Start session"
                       >
-                        {createManualSessionMutation.isPending ? (
+                        {isCreatingSession ? (
                           <Loader2 className="h-4 w-4 animate-spin" />
                         ) : (
                           <ArrowUp className="h-4 w-4" />
@@ -1485,11 +1490,11 @@ export function ManualSessionComposer({
                       type="button"
                       size="icon"
                       onClick={submitManualSession}
-                      disabled={!hasSubmittableInput || createManualSessionMutation.isPending}
+                      disabled={!hasSubmittableInput || isCreatingSession}
                       className="ml-auto h-8 w-8 rounded-full"
                       aria-label="Start session"
                     >
-                      {createManualSessionMutation.isPending ? (
+                      {isCreatingSession ? (
                         <Loader2 className="h-4 w-4 animate-spin" />
                       ) : (
                         <ArrowUp className="h-4 w-4" />


### PR DESCRIPTION
## Summary
When a manual session is created successfully, we now keep the Start/submit UI in a “submitting”/disabled state until navigation completes, preventing the prompt/button from re-enabling briefly. This implements VIR-122 and is covered by a new regression test.

## Changes
- **frontend/src/components/manual-session-composer.tsx**
  - Added `isNavigatingAfterCreate` state.
  - Set/cleared this state around the successful `createSession` flow so the button remains disabled and the spinner remains visible until the route change unmounts the page.
- **frontend/src/app/(dashboard)/sessions/new/manual-session-create-page-content.test.tsx**
  - Updated router mock to use a shared `routerPushMock`.
  - Added a regression test asserting:
    - the Start button stays disabled after `createSession` resolves
    - the spinner is still present while navigation is pending
    - `router.push("/sessions/<id>")` is called.

## Test plan
- `npm test -- --run 'src/app/(dashboard)/sessions/new/manual-session-create-page-content.test.tsx'`
- `npm run typecheck`
- `npm run lint`
- `npm run build`

[143.dev](https://143.dev) | [session 4895fcb8](https://143.dev/sessions/4895fcb8-e070-40e7-8c47-ba8850342cd5)

Preview: https://143.dev/previews/github/assembledhq/143/pull/1208