### PR TITLE
Fix PR merge status transitions by typing PR statuses and using merged health as terminal

### DIFF
--- a/frontend/src/app/(dashboard)/sessions/[id]/linked-issue-chips.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/linked-issue-chips.test.tsx
@@ -12,7 +12,7 @@ function makeSession(overrides: Partial<Session>): Session {
     id: 'sess-1',
     org_id: 'org-1',
     agent_type: 'codex',
-    status: 'active',
+    status: 'idle',
     autonomy_level: 'auto',
     token_mode: 'standard',
     current_turn: 0,

--- a/frontend/src/app/(dashboard)/sessions/[id]/page.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/page.test.tsx
@@ -3758,6 +3758,47 @@ describe('SessionDetailPage', () => {
     expect(screen.queryByText('PR health')).not.toBeInTheDocument();
   });
 
+  it('uses merged health as terminal while the cached PR row still says open', async () => {
+    const prCreatedSession: Session = {
+      ...mockSessions[0],
+      status: 'pr_created',
+    };
+
+    server.use(
+      http.get('/api/v1/sessions/:id', () => {
+        return HttpResponse.json({
+          data: prCreatedSession,
+        } satisfies SingleResponse<Session>);
+      }),
+      http.get('/api/v1/sessions/:id/pr', () => {
+        return HttpResponse.json({
+          data: {
+            ...mockPR,
+            status: 'open',
+            merged_at: null,
+          },
+        } satisfies SingleResponse<PullRequest>);
+      }),
+      http.get('/api/v1/pull-requests/:id/health', () => {
+        return HttpResponse.json({
+          data: {
+            ...mockPRHealth,
+            status: 'merged',
+            can_merge: false,
+            summary: 'PR #42 was merged successfully.',
+          },
+        } satisfies SingleResponse<typeof mockPRHealth>);
+      }),
+    );
+
+    renderWithProviders(<SessionDetailContent id="session-abcdef12-3456-7890" />);
+
+    expect(await screen.findAllByText('PR merged')).toHaveLength(2);
+    expect(screen.getByText('PR #42 merged')).toBeInTheDocument();
+    expect(screen.getByText('PR #42 was merged successfully.')).toBeInTheDocument();
+    expect(screen.queryByText('PR health')).not.toBeInTheDocument();
+  });
+
   it('updates the header status when the PR stream reports a merge', async () => {
     const prCreatedSession: Session = {
       ...mockSessions[0],

--- a/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
@@ -131,7 +131,7 @@ import {
   readStoredViewedThreadIds,
   writeStoredViewedThreadIds,
 } from "@/lib/session-thread-views";
-import type { HumanInputAnswerBody, HumanInputRequest, ListResponse, Organization, OrgSettings, ReviewLoopFixMode, Session, SessionDetail, SessionInputCommand, SessionInputReference, SessionLog, SessionMessage, SessionReviewComment, SessionReviewLoop, SessionRetryMode, SessionThread, SessionThreadFileEvent, SessionTimelineEntry, ThreadInboxEvent, ThreadMessageWindowResponse, ThreadRuntimeEvent, ThreadStatus, User, CodexAuthStatus, PullRequestHealthResponse, SessionWorkspaceGenerationChangedEvent, SingleResponse } from "@/lib/types";
+import type { HumanInputAnswerBody, HumanInputRequest, ListResponse, Organization, OrgSettings, ReviewLoopFixMode, Session, SessionDetail, SessionInputCommand, SessionInputReference, SessionLog, SessionMessage, SessionReviewComment, SessionReviewLoop, SessionRetryMode, SessionStatus, SessionThread, SessionThreadFileEvent, SessionTimelineEntry, ThreadInboxEvent, ThreadMessageWindowResponse, ThreadRuntimeEvent, ThreadStatus, User, CodexAuthStatus, PullRequestHealthResponse, PullRequestStatus, SessionWorkspaceGenerationChangedEvent, SingleResponse } from "@/lib/types";
 import { AgentTabStrip, computeThreadOverlap } from "./agent-tab-strip";
 import {
   ThreadAttributionFilter,
@@ -240,7 +240,9 @@ export function invalidateSessionHumanInputRequests(queryClient: QueryInvalidato
   queryClient.invalidateQueries({ queryKey: ["session", sessionId, "human-input-requests"] });
 }
 
-const statusConfig: Record<string, { color: string; label: string }> = {
+type DisplayStatusKey = SessionStatus | "pr_merged" | "pr_closed";
+
+const statusConfig: Record<DisplayStatusKey, { color: string; label: string }> = {
   pending: { color: "bg-muted text-muted-foreground", label: "Pending" },
   running: { color: "bg-primary/10 text-primary", label: "Running" },
   idle: { color: "bg-primary/10 text-primary", label: "Idle" },
@@ -255,7 +257,7 @@ const statusConfig: Record<string, { color: string; label: string }> = {
   skipped: { color: "bg-muted text-muted-foreground", label: "Skipped" },
 };
 
-function getDisplayStatus(sessionStatus: string, prStatus?: string | null): { color: string; label: string } {
+function getDisplayStatus(sessionStatus: SessionStatus, prStatus?: PullRequestStatus | null): { color: string; label: string } {
   if (sessionStatus === "pr_created") {
     if (prStatus === "merged") {
       return statusConfig.pr_merged;
@@ -265,6 +267,16 @@ function getDisplayStatus(sessionStatus: string, prStatus?: string | null): { co
     }
   }
   return statusConfig[sessionStatus] || statusConfig.pending;
+}
+
+function deriveEffectivePRStatus(prStatus?: PullRequestStatus | null, healthStatus?: PullRequestStatus | null): PullRequestStatus | undefined {
+  if (healthStatus === "merged" || prStatus === "merged") {
+    return "merged";
+  }
+  if (healthStatus === "closed" || prStatus === "closed") {
+    return "closed";
+  }
+  return prStatus ?? undefined;
 }
 
 function hasMeaningfulDuration(startedAt?: string, completedAt?: string): boolean {
@@ -513,7 +525,7 @@ type PendingThreadPreview = Pick<
   "id" | "session_id" | "org_id" | "agent_type" | "label" | "status" | "current_turn" | "created_at" | "cost_cents" | "pending_message_count" | "cancel_requested_at" | "model_override" | "inbox_delivery"
 >;
 
-const terminalSessionStatuses = new Set(["completed", "pr_created", "failed", "cancelled", "skipped"]);
+const terminalSessionStatuses = new Set<SessionStatus>(["completed", "pr_created", "failed", "cancelled", "skipped"]);
 
 function mergePendingMessages(
   baseMessages: SessionMessage[],
@@ -574,7 +586,7 @@ function RuntimeRecoveryNotice({ border = "border-t" }: { border?: "border-t" | 
   );
 }
 
-function OverviewTab({ session, members, prStatus }: { session: Session; members: User[]; prStatus?: string | null }) {
+function OverviewTab({ session, members, prStatus }: { session: Session; members: User[]; prStatus?: PullRequestStatus | null }) {
   const queryClient = useQueryClient();
   const [showDeviceCodeModal, setShowDeviceCodeModal] = useState(false);
   const [showStartOverRetryDialog, setShowStartOverRetryDialog] = useState(false);
@@ -2922,7 +2934,7 @@ export function SessionDetailContent({ id }: { id: string }) {
   const canListTeamMembers = user?.role === "admin" || user?.role === "member";
   const canShipPR = user?.role === "admin" || user?.role === "member" || user?.role === "builder";
   const canManagePR = user?.role === "admin" || user?.role === "member";
-  const terminalStatuses = new Set(["completed", "pr_created", "failed", "cancelled", "skipped"]);
+  const terminalStatuses = new Set<SessionStatus>(["completed", "pr_created", "failed", "cancelled", "skipped"]);
   const [reviewParam, setReviewParam] = useQueryState("review");
   const [previewParam, setPreviewParam] = useQueryState("preview");
   const [resumePRParam, setResumePRParam] = useQueryState("resume_pr");
@@ -3549,7 +3561,8 @@ export function SessionDetailContent({ id }: { id: string }) {
     },
   });
   const prHealth = prHealthData?.data;
-  const prStatus = prData?.data?.status;
+  const rawPRStatus = prData?.data?.status;
+  const prStatus = deriveEffectivePRStatus(rawPRStatus, prHealth?.status);
   const prNumber = prData?.data?.github_pr_number;
   const closedPRNumber = prNumber;
   const closedPRLabel = closedPRNumber ? `PR #${closedPRNumber} closed` : "PR closed";
@@ -3794,7 +3807,7 @@ export function SessionDetailContent({ id }: { id: string }) {
       }
     };
   }, [apiBase, prData?.data?.status, pullRequestId, queryClient, isDocumentVisible, id]);
-  const previousSessionStatusRef = useRef<string | undefined>(undefined);
+  const previousSessionStatusRef = useRef<SessionStatus | undefined>(undefined);
   useEffect(() => {
     const currentStatus = session?.status;
     if (!session?.id || !currentStatus) {
@@ -3825,7 +3838,7 @@ export function SessionDetailContent({ id }: { id: string }) {
   const hasPR = !!prData?.data;
   const hasSnapshot = !!session?.snapshot_key;
   const hasSessionChanges = !!session?.diff || !!session?.diff_stats;
-  const isTerminalSession = terminalSessionStatuses.has(session?.status ?? "");
+  const isTerminalSession = session ? terminalSessionStatuses.has(session.status) : false;
   const showExpiredPRAction = hasSessionChanges && !hasSnapshot && !hasPR && isTerminalSession;
   const canManageSession = user?.role === "admin" || user?.role === "member" || user?.role === "builder";
   const canUseNativeReviewLoop = !!session && session.agent_type !== "pm_agent";

--- a/frontend/src/app/(dashboard)/sessions/sessions-page-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/sessions-page-content.tsx
@@ -36,7 +36,7 @@ import { AnimatedEllipsis } from "@/components/animated-ellipsis";
 import { AgentBadge } from "@/components/agent-badge";
 import { usePeopleFilter } from "@/hooks/use-people-filter";
 import { prMergedAccent } from "@/lib/pr-status-styles";
-import type { Session, SessionListItem, User } from "@/lib/types";
+import type { Session, SessionListItem, SessionStatus, User } from "@/lib/types";
 import {
   workingSet,
   filterToStatusParam as baseFilterToStatusParam,
@@ -47,7 +47,7 @@ import { getCountForTab, renderCount } from "@/lib/session-counts";
 // Status config
 // ---------------------------------------------------------------------------
 
-const statusConfig: Record<string, { dot: string; text: string; bg: string; label: string }> = {
+const statusConfig: Record<SessionStatus, { dot: string; text: string; bg: string; label: string }> = {
   pending: { dot: "bg-muted-foreground/50", text: "text-muted-foreground", bg: "bg-muted", label: "Pending" },
   running: { dot: "bg-primary", text: "text-primary", bg: "bg-primary/10", label: "Running" },
   idle: { dot: "bg-primary", text: "text-primary", bg: "bg-primary/10", label: "Idle" },
@@ -75,9 +75,9 @@ function filterToStatusParam(filter: string | null): string | undefined {
 // Inline cell components
 // ---------------------------------------------------------------------------
 
-function SessionStatusDot({ status }: { status: string }) {
+function SessionStatusDot({ status }: { status: SessionStatus }) {
   const working = workingSet.has(status);
-  const cfg = statusConfig[status] || statusConfig.pending;
+  const cfg = statusConfig[status];
   if (working) {
     return <StatusDot animate color="bg-primary" pingColor="bg-primary/60" />;
   }
@@ -109,7 +109,7 @@ function buildColumns(members: User[]): ColumnDef<Session>[] {
       size: 140,
       cell: ({ row }) => {
         const status = row.original.status;
-        const cfg = statusConfig[status] || statusConfig.pending;
+        const cfg = statusConfig[status];
         const working = workingSet.has(status);
         return (
           <div className="flex items-center gap-2">

--- a/frontend/src/lib/session-status-groups.ts
+++ b/frontend/src/lib/session-status-groups.ts
@@ -1,18 +1,20 @@
+import type { SessionStatus, ThreadStatus } from "./types";
+
 // Status groups — keep in sync with models.ActiveStatuses / DoneStatuses
 // in internal/models/session_enums.go.
 
-export const activeStatuses = ["pending", "running", "idle", "awaiting_input", "needs_human_guidance"];
-export const doneStatuses = ["completed", "pr_created", "failed", "cancelled", "skipped"];
+export const activeStatuses = ["pending", "running", "idle", "awaiting_input", "needs_human_guidance"] satisfies SessionStatus[];
+export const doneStatuses = ["completed", "pr_created", "failed", "cancelled", "skipped"] satisfies SessionStatus[];
 
 // "Working" means the agent is actively processing or about to: skeleton
 // shimmer, refetch polling, and "Agent is working..." indicators all key off
 // this set. Distinct from `activeStatuses`, which also counts idle/awaiting
 // states where the user holds the turn.
-export const workingStatuses = ["pending", "running", "awaiting_input"];
+export const workingStatuses = ["pending", "running", "awaiting_input"] satisfies SessionStatus[];
 
-export const activeSet = new Set(activeStatuses);
-export const workingSet = new Set(["pending", "running"]);
-export const workingStatusesSet = new Set(workingStatuses);
+export const activeSet = new Set<SessionStatus>(activeStatuses);
+export const workingSet = new Set<SessionStatus>(["pending", "running"]);
+export const workingStatusesSet = new Set<SessionStatus | ThreadStatus>(workingStatuses);
 
 /** Map a filter tab value to the comma-separated status string for the API. */
 export function filterToStatusParam(filter: string | null, extraPassthrough?: string[]): string | undefined {

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -54,7 +54,7 @@ export interface ThreadMessageWindowMeta {
   has_older: boolean;
   latest_assistant_message_id?: number;
   live_edge_message_id?: number;
-  thread_status: string;
+  thread_status: ThreadStatus;
 }
 
 export interface ThreadMessageWindowResponse {
@@ -330,6 +330,10 @@ export type AutopilotRunState =
   | 'failed'
   | 'skipped';
 
+export type PullRequestStatus = 'open' | 'closed' | 'merged';
+export type PullRequestReviewStatus = 'pending' | 'approved' | 'changes_requested';
+export type PullRequestCIStatus = '' | 'success' | 'failure' | 'pending';
+
 export type AutopilotQueueAction =
   | 'start_run'
   | 'view_run'
@@ -368,7 +372,7 @@ export interface AutopilotQueueRow {
     id: string;
     number: number;
     url: string;
-    status: string;
+    status: PullRequestStatus;
     merged_at?: string;
   };
   available_action: AutopilotQueueAction;
@@ -400,7 +404,7 @@ export interface Session {
   origin?: string;
   interaction_mode?: string;
   agent_type: string;
-  status: string;
+  status: SessionStatus;
   autonomy_level: string;
   token_mode: string;
   complexity_tier?: number;
@@ -492,8 +496,8 @@ export interface RetrySessionRequest {
 }
 
 export interface PRSummary {
-  status: string;
-  ci_status: string;
+  status: PullRequestStatus;
+  ci_status: PullRequestCIStatus;
   number: number;
   url: string;
 }
@@ -842,10 +846,10 @@ export interface PullRequest {
   github_repo: string;
   title: string;
   body: string;
-  status: string;
+  status: PullRequestStatus;
   branch_name: string;
-  review_status: string | null;
-  ci_status: string;
+  review_status: PullRequestReviewStatus | null;
+  ci_status: PullRequestCIStatus;
   merged_at: string | null;
   closed_at: string | null;
   created_at: string;
@@ -864,7 +868,7 @@ export interface PullRequestCheckSummary {
 export interface PullRequestActiveRepair {
   action_type: "fix_tests" | "resolve_conflicts";
   session_id: string;
-  session_status: string;
+  session_status: SessionStatus;
   health_version: number;
 }
 
@@ -873,7 +877,7 @@ export interface PullRequestHealthResponse {
   pull_request_number: number;
   repository: string;
   url: string;
-  status: string;
+  status: PullRequestStatus;
   head_sha: string;
   base_sha: string;
   health_version: number;
@@ -1333,7 +1337,7 @@ export interface RepoSummary {
   repository_id: string;
   full_name: string;
   active_session_count: number;
-  latest_session_status: string | null;
+  latest_session_status: SessionStatus | null;
   active_project_count: number;
 }
 
@@ -1931,7 +1935,7 @@ export interface AutomationRunSession {
   // Mirrors models.SessionStatus values; the row UI keys off this
   // (notably "needs_human_guidance") to choose between failure and
   // attention treatments.
-  status: string;
+  status: SessionStatus;
   diff_stats?: { added: number; removed: number; files_changed?: number };
   failure_explanation?: string;
   failure_category?: string;


### PR DESCRIPTION
## Summary
This change fixes the PR status UI showing an incorrect “open/orange” state during the merge flow. We now base the effective PR status on the merged health response (terminal), and tighten the frontend to use typed PR/session status unions instead of raw strings.

## Changes
- **Typed frontend status unions** for PR lifecycle/review/CI and reused `SessionStatus` across the PR + session surfaces involved in this flow.
- Updated the **effective PR status helper** to take/return `PullRequestStatus` (typed) rather than raw string statuses.
- Tightened related **session status config/sets** to align with the typed model and prevent invalid status combinations.
- **Fixed a test fixture** using a non-backend session status value (`active` → `idle`).
- Added coverage to ensure **merged health is used as terminal UI state even if cached PR row still says open**:
  - `frontend/src/app/(dashboard)/sessions/[id]/page.test.tsx`
- Updated/extended session PR UI logic and related components:
  - `frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx`
  - `frontend/src/app/(dashboard)/sessions/sessions-page-content.tsx`
  - `frontend/src/lib/session-status-groups.ts`
  - `frontend/src/lib/types.ts`

## Test plan
- Focused merged-health regression test (new/updated in `sessions/[id]/page.test.tsx`)
- `linked-issue-chips.test.tsx`
- `npm run typecheck`
- `npm run lint`
- `npm run build`

[143.dev](https://143.dev) | [session 8466cb20](https://143.dev/sessions/8466cb20-b6c4-41a8-8f03-a811e1c560c6)

Preview: https://143.dev/previews/github/assembledhq/143/pull/1212