### PR TITLE
Implement Merge When Ready UI with backend auto-merge and edge-case handling

### DIFF
--- a/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
@@ -3091,6 +3091,7 @@ export function SessionDetailContent({ id }: { id: string }) {
   const [localPushState, setLocalPushState] = useState<"idle" | "submitting" | "queued">("idle");
   const [localPushActionError, setLocalPushActionError] = useState<PRActionErrorState | null>(null);
   const [pendingPRAction, setPendingPRAction] = useState<"fix_tests" | "resolve_conflicts" | "merge" | null>(null);
+  const [pendingMergeWhenReady, setPendingMergeWhenReady] = useState(false);
   const [repairActionError, setRepairActionError] = useState<string | null>(null);
   const [prAuthPrompt, setPRAuthPrompt] = useState<PRAuthPromptState | null>(null);
   const resumeAttemptRef = useRef<string | null>(null);
@@ -3562,7 +3563,8 @@ export function SessionDetailContent({ id }: { id: string }) {
     staleTime: 30_000,
     refetchInterval: (query) => {
       const mergeState = query.state.data?.data?.merge_state;
-      return mergeState === "mergeability_pending" || mergeState === "unknown" ? 5_000 : false;
+      const mergeWhenReadyState = query.state.data?.data?.merge_when_ready?.state;
+      return mergeState === "mergeability_pending" || mergeState === "unknown" || mergeWhenReadyState === "queued" || mergeWhenReadyState === "merging" ? 5_000 : false;
     },
   });
   const prHealth = prHealthData?.data;
@@ -3747,6 +3749,30 @@ export function SessionDetailContent({ id }: { id: string }) {
       // the user reads the message the banner has already updated, so an
       // in-banner error would feel stale alongside the new state.
       const message = err instanceof ApiError ? err.message : "Failed to merge pull request";
+      toast.error(message);
+    },
+  });
+  const mergeWhenReadyMutation = useMutation({
+    mutationFn: async (action: "queue" | "cancel") => {
+      if (!pullRequestId) {
+        throw new Error("Pull request not found");
+      }
+      return action === "queue"
+        ? api.pullRequests.queueMergeWhenReady(pullRequestId)
+        : api.pullRequests.cancelMergeWhenReady(pullRequestId);
+    },
+    onMutate: () => {
+      setRepairActionError(null);
+      setPendingMergeWhenReady(true);
+    },
+    onSuccess: (_response, action) => {
+      setPendingMergeWhenReady(false);
+      void queryClient.invalidateQueries({ queryKey: ["pull-request", pullRequestId, "health"] });
+      toast.success(action === "queue" ? "Merge when ready enabled" : "Merge when ready cancelled");
+    },
+    onError: (err) => {
+      setPendingMergeWhenReady(false);
+      const message = err instanceof ApiError ? err.message : "Failed to update merge when ready";
       toast.error(message);
     },
   });
@@ -5186,6 +5212,18 @@ export function SessionDetailContent({ id }: { id: string }) {
     mergeMutation.mutate();
   }
 
+  function handleQueueMergeWhenReady() {
+    if (ghBlocked) {
+      setPRAuthPrompt({ purpose: "merge_pr" });
+      return;
+    }
+    mergeWhenReadyMutation.mutate("queue");
+  }
+
+  function handleCancelMergeWhenReady() {
+    mergeWhenReadyMutation.mutate("cancel");
+  }
+
   const prErrorNotice = prActionError ? {
     title: prErrorTitle(snapshotState, localPRActionError?.code),
     description: prActionError,
@@ -5432,9 +5470,12 @@ export function SessionDetailContent({ id }: { id: string }) {
                 pendingAction={pendingPRAction}
                 repairError={repairActionError}
                 mergeAuthRequired={ghBlocked}
+                mergeWhenReadyPending={pendingMergeWhenReady}
                 onFixTests={() => startRepairMutation.mutate("fix_tests")}
                 onResolveConflicts={() => startRepairMutation.mutate("resolve_conflicts")}
                 onMerge={handleMergeAction}
+                onQueueMergeWhenReady={handleQueueMergeWhenReady}
+                onCancelMergeWhenReady={handleCancelMergeWhenReady}
                 onOpenRepairSession={(sessionId) => router.push(`/sessions/${sessionId}`)}
                 reviewAction={canManageSession && canUseNativeReviewLoop ? {
                   disabled: reviewActionDisabled,

--- a/frontend/src/components/pr-health-banner-sync-copy.test.tsx
+++ b/frontend/src/components/pr-health-banner-sync-copy.test.tsx
@@ -32,6 +32,7 @@ const health: PullRequestHealthResponse = {
   failing_test_detail_available: false,
   obsolete_active_repair_sessions: false,
   active_repairs: [],
+  merge_when_ready: { state: "off" },
 };
 
 describe("PRHealthBanner sync copy", () => {

--- a/frontend/src/components/pr-health-banner.test.tsx
+++ b/frontend/src/components/pr-health-banner.test.tsx
@@ -32,6 +32,7 @@ const baseHealth: PullRequestHealthResponse = {
   failing_test_detail_available: false,
   obsolete_active_repair_sessions: false,
   active_repairs: [],
+  merge_when_ready: { state: "off" },
 };
 
 describe("PRHealthBanner", () => {
@@ -108,6 +109,7 @@ describe("PRHealthBanner", () => {
         onFixTests={vi.fn()}
         onResolveConflicts={vi.fn()}
         onMerge={vi.fn()}
+        onQueueMergeWhenReady={vi.fn()}
         reviewAction={{
           disabled: false,
           spinning: false,
@@ -155,10 +157,61 @@ describe("PRHealthBanner", () => {
       />,
     );
 
-    const labels = screen.getAllByRole("button").map((button) => button.textContent);
+    const labels = screen.getAllByRole("button")
+      .map((button) => button.textContent)
+      .filter((label) => label !== "");
     expect(labels).toEqual(
       ["Merge", "Resolve conflicts", "Review", "Push changes"],
     );
+  });
+
+  it("keeps merge disabled while allowing merge when ready from the dropdown", async () => {
+    const onQueue = vi.fn();
+    renderWithProviders(
+      <PRHealthBanner
+        health={{
+          ...baseHealth,
+          checks: [{ name: "Unit tests", category: "test", status: "pending" }],
+          checks_confirmed: true,
+          can_merge: false,
+        }}
+        pendingAction={null}
+        repairError={null}
+        mergeAuthRequired={false}
+        onFixTests={vi.fn()}
+        onResolveConflicts={vi.fn()}
+        onMerge={vi.fn()}
+        onQueueMergeWhenReady={onQueue}
+      />,
+    );
+
+    expect(screen.getByRole("button", { name: "Merge" })).toBeDisabled();
+    await userEvent.setup().click(screen.getByRole("button", { name: "More merge actions" }));
+    await userEvent.setup().click(await screen.findByRole("menuitem", { name: "Merge when ready" }));
+    expect(onQueue).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows queued merge when ready state and allows cancelling", async () => {
+    const onCancel = vi.fn();
+    renderWithProviders(
+      <PRHealthBanner
+        health={{
+          ...baseHealth,
+          merge_when_ready: { state: "queued", requested_head_sha: "head-sha" },
+        }}
+        pendingAction={null}
+        repairError={null}
+        mergeAuthRequired={false}
+        onFixTests={vi.fn()}
+        onResolveConflicts={vi.fn()}
+        onMerge={vi.fn()}
+        onCancelMergeWhenReady={onCancel}
+      />,
+    );
+
+    expect(screen.getByText("Merge when ready is on. Waiting for checks to pass.")).toBeInTheDocument();
+    await userEvent.setup().click(screen.getByRole("button", { name: "Cancel" }));
+    expect(onCancel).toHaveBeenCalledTimes(1);
   });
 
   it("shows the disabled Review action reason in a hover tooltip", async () => {

--- a/frontend/src/components/pr-health-banner.tsx
+++ b/frontend/src/components/pr-health-banner.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { AlertTriangle, CheckCircle2, ClipboardList, ExternalLink, GitMerge, GitPullRequest, Loader2, Upload, Wrench } from "lucide-react";
+import { AlertTriangle, CheckCircle2, ChevronDown, ClipboardList, ExternalLink, GitMerge, GitPullRequest, Loader2, Upload, Wrench } from "lucide-react";
 
 import type { PullRequestHealthResponse } from "@/lib/types";
 import { cn } from "@/lib/utils";
@@ -8,9 +8,10 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import { DisabledTooltip } from "@/components/ui/disabled-tooltip";
+import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "@/components/ui/dropdown-menu";
 import { HoverCard, HoverCardContent, HoverCardTrigger } from "@/components/ui/hover-card";
 import { SyncTimeText } from "@/components/sync-time-text";
-import { deriveMergeActionState } from "@/lib/session-pr-action-state";
+import { deriveMergeActionState, deriveMergeWhenReadyActionState } from "@/lib/session-pr-action-state";
 
 // PRBannerAction names every action the banner can launch. The pending value
 // is shared across buttons so they can disable each other while one is in
@@ -45,9 +46,12 @@ type PRHealthBannerProps = {
   pendingAction: PRBannerAction;
   repairError?: string | null;
   mergeAuthRequired?: boolean;
+  mergeWhenReadyPending?: boolean;
   onFixTests: () => void;
   onResolveConflicts: () => void;
   onMerge: () => void;
+  onQueueMergeWhenReady?: () => void;
+  onCancelMergeWhenReady?: () => void;
   onOpenRepairSession?: (sessionId: string) => void;
   pushChanges?: PushChangesAction;
   reviewAction?: ReviewPRAction;
@@ -59,9 +63,12 @@ export function PRHealthBanner({
   pendingAction,
   repairError,
   mergeAuthRequired = false,
+  mergeWhenReadyPending = false,
   onFixTests,
   onResolveConflicts,
   onMerge,
+  onQueueMergeWhenReady,
+  onCancelMergeWhenReady,
   onOpenRepairSession,
   pushChanges,
   reviewAction,
@@ -78,12 +85,20 @@ export function PRHealthBanner({
     hasActiveRepair: activeRepairState.suppressMerge,
     pendingAction,
   });
+  const mergeWhenReadyAction = deriveMergeWhenReadyActionState({
+    health: { ...health, checks: orderedChecks },
+    hasActiveRepair: activeRepairState.suppressMerge,
+    pendingAction,
+    pendingMergeWhenReady: mergeWhenReadyPending,
+  });
   const canShowMergeButton = mergeAction.visible;
+  const canShowMergeWhenReady = mergeWhenReadyAction.visible && Boolean(onQueueMergeWhenReady || onCancelMergeWhenReady);
   const hasActionableButton =
     !!activeRepairState.label ||
     canShowResolveConflictsButton ||
     canShowFixTestsButton ||
     canShowMergeButton ||
+    canShowMergeWhenReady ||
     !!reviewAction ||
     !!pushChanges ||
     !!activeRepairState.openSessionID;
@@ -198,22 +213,55 @@ export function PRHealthBanner({
                 )}
                 <div className="flex flex-wrap gap-2">
                   {canShowMergeButton && (
-                    <DisabledTooltip disabled={mergeAction.disabled} content={mergeAction.disabledReason}>
-                      <Button
-                        size="sm"
-                        variant="default"
-                        disabled={mergeAction.disabled}
-                        title={mergeAction.disabledReason ?? "Merge PR (p m)"}
-                        onClick={onMerge}
-                      >
-                        {mergeAction.spinning ? (
-                          <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />
-                        ) : (
-                          <GitMerge className="mr-1.5 h-3.5 w-3.5" />
-                        )}
-                        {mergeAction.label}
-                      </Button>
-                    </DisabledTooltip>
+                    <div className="inline-flex">
+                      <DisabledTooltip disabled={mergeAction.disabled} content={mergeAction.disabledReason}>
+                        <Button
+                          size="sm"
+                          variant="default"
+                          className={cn(canShowMergeWhenReady && "rounded-r-none border-r border-primary-foreground/20")}
+                          disabled={mergeAction.disabled}
+                          title={mergeAction.disabledReason ?? "Merge PR (p m)"}
+                          onClick={onMerge}
+                        >
+                          {mergeAction.spinning ? (
+                            <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />
+                          ) : (
+                            <GitMerge className="mr-1.5 h-3.5 w-3.5" />
+                          )}
+                          {mergeAction.label}
+                        </Button>
+                      </DisabledTooltip>
+                      {canShowMergeWhenReady && (
+                        <DropdownMenu>
+                          <DropdownMenuTrigger asChild>
+                            <Button
+                              size="icon"
+                              variant="default"
+                              className="h-9 w-8 rounded-l-none"
+                              disabled={mergeWhenReadyAction.disabled}
+                              title={mergeWhenReadyAction.disabledReason ?? "More merge actions"}
+                              aria-label="More merge actions"
+                            >
+                              {mergeWhenReadyAction.spinning ? (
+                                <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                              ) : (
+                                <ChevronDown className="h-3.5 w-3.5" />
+                              )}
+                            </Button>
+                          </DropdownMenuTrigger>
+                          <DropdownMenuContent align="start">
+                            <DropdownMenuItem
+                              onClick={health.merge_when_ready.state === "queued" ? onCancelMergeWhenReady : onQueueMergeWhenReady}
+                              disabled={mergeWhenReadyAction.disabled}
+                              title={mergeWhenReadyAction.disabledReason}
+                            >
+                              <GitMerge className="h-3.5 w-3.5" />
+                              {mergeWhenReadyAction.label}
+                            </DropdownMenuItem>
+                          </DropdownMenuContent>
+                        </DropdownMenu>
+                      )}
+                    </div>
                   )}
                   {canShowResolveConflictsButton && (
                     <DisabledTooltip disabled={pendingAction !== null} content="Wait for the current PR action to finish">
@@ -306,6 +354,26 @@ export function PRHealthBanner({
                   <p className="text-xs text-muted-foreground">
                     Connect your GitHub account to merge this pull request as yourself.
                   </p>
+                )}
+                {health.merge_when_ready.state === "queued" && (
+                  <div className="flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
+                    <span>Merge when ready is on. Waiting for checks to pass.</span>
+                    {onCancelMergeWhenReady && (
+                      <Button size="sm" variant="ghost" className="h-6 px-2 text-xs" onClick={onCancelMergeWhenReady} disabled={mergeWhenReadyPending}>
+                        Cancel
+                      </Button>
+                    )}
+                  </div>
+                )}
+                {health.merge_when_ready.state === "failed" && health.merge_when_ready.last_error && (
+                  <div className="flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
+                    <span>Merge when ready stopped: {health.merge_when_ready.last_error}</span>
+                    {onQueueMergeWhenReady && (
+                      <Button size="sm" variant="ghost" className="h-6 px-2 text-xs" onClick={onQueueMergeWhenReady} disabled={mergeWhenReadyAction.disabled || mergeWhenReadyPending}>
+                        Retry
+                      </Button>
+                    )}
+                  </div>
                 )}
               </div>
             )}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -235,6 +235,8 @@ export const api = {
     fixTests: (id: string) => post<import('./types').SingleResponse<import('./types').PullRequestRepairResponse>>(`/api/v1/pull-requests/${id}/repair/fix-tests`),
     resolveConflicts: (id: string) => post<import('./types').SingleResponse<import('./types').PullRequestRepairResponse>>(`/api/v1/pull-requests/${id}/repair/resolve-conflicts`),
     merge: (id: string) => post<import('./types').SingleResponse<import('./types').PullRequestMergeResponse>>(`/api/v1/pull-requests/${id}/merge`),
+    queueMergeWhenReady: (id: string) => post<import('./types').SingleResponse<import('./types').PullRequestMergeWhenReadyStatus>>(`/api/v1/pull-requests/${id}/merge-when-ready`),
+    cancelMergeWhenReady: (id: string) => del<import('./types').SingleResponse<import('./types').PullRequestMergeWhenReadyStatus>>(`/api/v1/pull-requests/${id}/merge-when-ready`),
   },
   previews: {
     list: (params?: { repository_id?: string; branch?: string; status?: string }) => {

--- a/frontend/src/lib/session-pr-action-state.test.ts
+++ b/frontend/src/lib/session-pr-action-state.test.ts
@@ -4,6 +4,7 @@ import type { PullRequestHealthResponse } from "./types";
 import {
   deriveCreatePRActionState,
   deriveMergeActionState,
+  deriveMergeWhenReadyActionState,
   derivePushChangesActionState,
 } from "./session-pr-action-state";
 
@@ -32,6 +33,7 @@ const baseHealth: PullRequestHealthResponse = {
   conflict_detail_available: false,
   failing_test_detail_available: false,
   active_repairs: [],
+  merge_when_ready: { state: "off" },
 };
 
 describe("session PR action state", () => {
@@ -134,6 +136,56 @@ describe("session PR action state", () => {
       expect(state.disabled, `${tt.name} should map Merge disabled state`).toBe(tt.disabled);
       expect(state.disabledReason, `${tt.name} should map Merge reason`).toBe(tt.reason);
       expect(state.label, `${tt.name} should map Merge label`).toBe(tt.label ?? "Merge");
+    }
+  });
+
+  it("maps merge-when-ready queueable and blocked states", () => {
+    const tests = [
+      {
+        name: "pending checks can queue",
+        health: { ...baseHealth, can_merge: false, checks: [{ name: "unit", category: "test" as const, status: "pending" as const }] },
+        visible: true,
+        disabled: false,
+        label: "Merge when ready",
+      },
+      {
+        name: "conflicts cannot queue",
+        health: { ...baseHealth, can_merge: false, has_conflicts: true },
+        visible: true,
+        disabled: true,
+        label: "Merge when ready",
+        reason: "Resolve conflicts before enabling merge when ready",
+      },
+      {
+        name: "failed checks cannot queue",
+        health: { ...baseHealth, can_merge: false, checks: [{ name: "unit", category: "test" as const, status: "failed" as const }] },
+        visible: true,
+        disabled: true,
+        label: "Merge when ready",
+        reason: "Fix failing checks before enabling merge when ready",
+      },
+      {
+        name: "queued can cancel",
+        health: { ...baseHealth, can_merge: false, merge_when_ready: { state: "queued" as const } },
+        visible: true,
+        disabled: false,
+        label: "Cancel merge when ready",
+      },
+      {
+        name: "cancelled can requeue",
+        health: { ...baseHealth, can_merge: false, merge_when_ready: { state: "cancelled" as const } },
+        visible: true,
+        disabled: false,
+        label: "Merge when ready",
+      },
+    ];
+
+    for (const tt of tests) {
+      const state = deriveMergeWhenReadyActionState({ health: tt.health, hasActiveRepair: false, pendingAction: null, pendingMergeWhenReady: false });
+      expect(state.visible, `${tt.name} should map visibility`).toBe(tt.visible);
+      expect(state.disabled, `${tt.name} should map disabled state`).toBe(tt.disabled);
+      expect(state.label, `${tt.name} should map label`).toBe(tt.label);
+      expect(state.disabledReason, `${tt.name} should map disabled reason`).toBe(tt.reason);
     }
   });
 });

--- a/frontend/src/lib/session-pr-action-state.ts
+++ b/frontend/src/lib/session-pr-action-state.ts
@@ -263,6 +263,10 @@ export type MergeActionInput = {
   pendingAction: "fix_tests" | "resolve_conflicts" | "merge" | null;
 };
 
+export type MergeWhenReadyActionInput = MergeActionInput & {
+  pendingMergeWhenReady: boolean;
+};
+
 export function deriveMergeActionState({ health, hasActiveRepair, pendingAction }: MergeActionInput): LabeledLifecycleActionState {
   if (health.status !== "open") {
     return { visible: false, disabled: false, label: "Merge", spinning: false };
@@ -359,4 +363,42 @@ export function deriveMergeActionState({ health, hasActiveRepair, pendingAction 
   }
 
   return { visible: true, disabled: false, label: "Merge", spinning: false };
+}
+
+export function deriveMergeWhenReadyActionState({ health, hasActiveRepair, pendingAction, pendingMergeWhenReady }: MergeWhenReadyActionInput): LabeledLifecycleActionState {
+  if (health.status !== "open") {
+    return { visible: false, disabled: false, label: "Merge when ready", spinning: false };
+  }
+
+  const current = health.merge_when_ready;
+  if (current?.state === "queued") {
+    return { visible: true, disabled: false, label: "Cancel merge when ready", spinning: pendingMergeWhenReady };
+  }
+  if (current?.state === "merging") {
+    return { visible: true, disabled: true, disabledReason: "Merging this pull request", label: "Merging when ready…", spinning: true };
+  }
+
+  const label = current?.state === "failed" ? "Retry merge when ready" : "Merge when ready";
+  if (pendingMergeWhenReady) {
+    return { visible: true, disabled: true, disabledReason: "Updating merge when ready", label, spinning: true };
+  }
+  if (pendingAction !== null) {
+    return { visible: true, disabled: true, disabledReason: "Wait for the current PR action to finish", label, spinning: false };
+  }
+  if (hasActiveRepair) {
+    return { visible: true, disabled: true, disabledReason: "Wait for the active repair session to finish before enabling merge when ready", label, spinning: false };
+  }
+  if (health.has_conflicts || health.can_resolve_conflicts || health.merge_state === "conflicted") {
+    return { visible: true, disabled: true, disabledReason: "Resolve conflicts before enabling merge when ready", label, spinning: false };
+  }
+  if (health.failing_test_count > 0 || health.can_fix_tests || (health.checks ?? []).some((check) => check.status === "failed")) {
+    return { visible: true, disabled: true, disabledReason: "Fix failing checks before enabling merge when ready", label, spinning: false };
+  }
+  if (!health.head_sha) {
+    return { visible: true, disabled: true, disabledReason: "Waiting for GitHub to report the pull request head", label, spinning: false };
+  }
+  if (health.can_merge) {
+    return { visible: false, disabled: false, label, spinning: false };
+  }
+  return { visible: true, disabled: false, label, spinning: false };
 }

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -870,6 +870,23 @@ export interface PullRequestActiveRepair {
   health_version: number;
 }
 
+export type PullRequestMergeWhenReadyState =
+  | "off"
+  | "queued"
+  | "merging"
+  | "succeeded"
+  | "failed"
+  | "cancelled";
+
+export interface PullRequestMergeWhenReadyStatus {
+  state: PullRequestMergeWhenReadyState;
+  requested_by_user_id?: string;
+  requested_at?: string;
+  requested_head_sha?: string;
+  requested_health_version?: number;
+  last_error?: string;
+}
+
 export interface PullRequestHealthResponse {
   pull_request_id: string;
   pull_request_number: number;
@@ -897,6 +914,7 @@ export interface PullRequestHealthResponse {
   conflict_detail_available: boolean;
   failing_test_detail_available: boolean;
   obsolete_active_repair_sessions?: boolean;
+  merge_when_ready: PullRequestMergeWhenReadyStatus;
 }
 
 export interface PullRequestRepairResponse {

--- a/frontend/src/test/mocks/handlers.ts
+++ b/frontend/src/test/mocks/handlers.ts
@@ -122,6 +122,7 @@ export const mockPRHealth: PullRequestHealthResponse = {
   enrichment_ready: true,
   conflict_detail_available: true,
   failing_test_detail_available: false,
+  merge_when_ready: { state: 'off' },
 };
 
 export const mockProjectDetail: ProjectDetail = {
@@ -438,6 +439,18 @@ export const handlers = [
         repair_action_type: 'resolve_conflicts',
       },
     } satisfies SingleResponse<PullRequestRepairResponse>);
+  }),
+
+  http.post('/api/v1/pull-requests/:id/merge-when-ready', () => {
+    return HttpResponse.json({
+      data: { state: 'queued', requested_head_sha: 'head-sha', requested_health_version: 1 },
+    } satisfies SingleResponse<import('@/lib/types').PullRequestMergeWhenReadyStatus>);
+  }),
+
+  http.delete('/api/v1/pull-requests/:id/merge-when-ready', () => {
+    return HttpResponse.json({
+      data: { state: 'cancelled', requested_head_sha: 'head-sha', requested_health_version: 1 },
+    } satisfies SingleResponse<import('@/lib/types').PullRequestMergeWhenReadyStatus>);
   }),
 
   http.get('/api/v1/sessions/:id/messages', () => {

--- a/internal/api/handlers/pull_requests.go
+++ b/internal/api/handlers/pull_requests.go
@@ -23,6 +23,8 @@ type pullRequestHealthService interface {
 	GetPullRequestHealth(ctx context.Context, orgID, pullRequestID uuid.UUID) (*models.PullRequestHealthResponse, error)
 	StartPullRequestRepair(ctx context.Context, orgID, pullRequestID, userID uuid.UUID, action models.PullRequestRepairActionType) (*models.PullRequestRepairResponse, error)
 	MergePullRequest(ctx context.Context, orgID, pullRequestID, userID uuid.UUID) (*models.PullRequestMergeResponse, error)
+	QueueMergeWhenReady(ctx context.Context, orgID, pullRequestID, userID uuid.UUID) (*models.PullRequestMergeWhenReadyStatus, error)
+	CancelMergeWhenReady(ctx context.Context, orgID, pullRequestID, userID uuid.UUID) (*models.PullRequestMergeWhenReadyStatus, error)
 }
 
 type pullRequestMembershipStore interface {
@@ -256,6 +258,58 @@ func (h *PullRequestHandler) Merge(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	writeJSON(w, http.StatusOK, models.SingleResponse[models.PullRequestMergeResponse]{Data: *resp})
+}
+
+func (h *PullRequestHandler) QueueMergeWhenReady(w http.ResponseWriter, r *http.Request) {
+	_ = middleware.OrgIDFromContext(r.Context())
+	h.mergeWhenReady(w, r, true)
+}
+
+func (h *PullRequestHandler) CancelMergeWhenReady(w http.ResponseWriter, r *http.Request) {
+	_ = middleware.OrgIDFromContext(r.Context())
+	h.mergeWhenReady(w, r, false)
+}
+
+func (h *PullRequestHandler) mergeWhenReady(w http.ResponseWriter, r *http.Request, queue bool) {
+	if h.service == nil {
+		writeError(w, r, http.StatusNotImplemented, "NOT_CONFIGURED", "pull request merge when ready is not configured")
+		return
+	}
+
+	orgID := middleware.OrgIDFromContext(r.Context())
+	user := middleware.UserFromContext(r.Context())
+	if user == nil {
+		writeError(w, r, http.StatusUnauthorized, "UNAUTHORIZED", "user not found in context")
+		return
+	}
+	pullRequestID, err := uuid.Parse(chi.URLParam(r, "id"))
+	if err != nil {
+		writeError(w, r, http.StatusBadRequest, "INVALID_ID", "invalid pull request ID")
+		return
+	}
+
+	var resp *models.PullRequestMergeWhenReadyStatus
+	if queue {
+		resp, err = h.service.QueueMergeWhenReady(r.Context(), orgID, pullRequestID, user.ID)
+	} else {
+		resp, err = h.service.CancelMergeWhenReady(r.Context(), orgID, pullRequestID, user.ID)
+	}
+	if err != nil {
+		switch {
+		case errors.Is(err, ghservice.ErrPullRequestMergeWhenReadyInProgress):
+			writeError(w, r, http.StatusConflict, "MERGE_WHEN_READY_IN_PROGRESS", "Merge when ready is already in progress", err)
+		case errors.Is(err, ghservice.ErrPullRequestMergeWhenReadyNotQueueable):
+			writeError(w, r, http.StatusConflict, "MERGE_WHEN_READY_NOT_QUEUEABLE", "Pull request cannot be queued for merge when ready", err)
+		case errors.Is(err, ghservice.ErrGitHubUserAuthRequired):
+			writeError(w, r, http.StatusConflict, "GITHUB_USER_AUTH_REQUIRED", "Connect your GitHub account to merge this pull request as yourself", err)
+		case errors.Is(err, ghservice.ErrGitHubUserAuthRepoAccessDenied):
+			writeError(w, r, http.StatusConflict, "GITHUB_USER_AUTH_REPO_ACCESS_DENIED", "your GitHub account cannot access this repository for merge", err)
+		default:
+			writeError(w, r, http.StatusInternalServerError, "MERGE_WHEN_READY_FAILED", "Failed to update merge when ready", err)
+		}
+		return
+	}
+	writeJSON(w, http.StatusOK, models.SingleResponse[models.PullRequestMergeWhenReadyStatus]{Data: *resp})
 }
 
 // classifyGitHubMergeError maps an error returned from the GitHub merge call

--- a/internal/api/handlers/pull_requests_test.go
+++ b/internal/api/handlers/pull_requests_test.go
@@ -46,9 +46,11 @@ func (r *lockedRecorder) BodyString() string {
 }
 
 type stubPullRequestHealthService struct {
-	getHealthFunc func(context.Context, uuid.UUID, uuid.UUID) (*models.PullRequestHealthResponse, error)
-	repairFunc    func(context.Context, uuid.UUID, uuid.UUID, uuid.UUID, models.PullRequestRepairActionType) (*models.PullRequestRepairResponse, error)
-	mergeFunc     func(context.Context, uuid.UUID, uuid.UUID, uuid.UUID) (*models.PullRequestMergeResponse, error)
+	getHealthFunc            func(context.Context, uuid.UUID, uuid.UUID) (*models.PullRequestHealthResponse, error)
+	repairFunc               func(context.Context, uuid.UUID, uuid.UUID, uuid.UUID, models.PullRequestRepairActionType) (*models.PullRequestRepairResponse, error)
+	mergeFunc                func(context.Context, uuid.UUID, uuid.UUID, uuid.UUID) (*models.PullRequestMergeResponse, error)
+	queueMergeWhenReadyFunc  func(context.Context, uuid.UUID, uuid.UUID, uuid.UUID) (*models.PullRequestMergeWhenReadyStatus, error)
+	cancelMergeWhenReadyFunc func(context.Context, uuid.UUID, uuid.UUID, uuid.UUID) (*models.PullRequestMergeWhenReadyStatus, error)
 }
 
 type stubPullRequestMembershipStore struct {
@@ -68,6 +70,20 @@ func (s *stubPullRequestHealthService) MergePullRequest(ctx context.Context, org
 		return nil, errors.New("merge not stubbed")
 	}
 	return s.mergeFunc(ctx, orgID, pullRequestID, userID)
+}
+
+func (s *stubPullRequestHealthService) QueueMergeWhenReady(ctx context.Context, orgID, pullRequestID, userID uuid.UUID) (*models.PullRequestMergeWhenReadyStatus, error) {
+	if s.queueMergeWhenReadyFunc == nil {
+		return nil, errors.New("queue merge when ready not stubbed")
+	}
+	return s.queueMergeWhenReadyFunc(ctx, orgID, pullRequestID, userID)
+}
+
+func (s *stubPullRequestHealthService) CancelMergeWhenReady(ctx context.Context, orgID, pullRequestID, userID uuid.UUID) (*models.PullRequestMergeWhenReadyStatus, error) {
+	if s.cancelMergeWhenReadyFunc == nil {
+		return nil, errors.New("cancel merge when ready not stubbed")
+	}
+	return s.cancelMergeWhenReadyFunc(ctx, orgID, pullRequestID, userID)
 }
 
 func (s *stubPullRequestMembershipStore) Get(ctx context.Context, userID, orgID uuid.UUID) (models.OrganizationMembership, error) {
@@ -592,8 +608,107 @@ func TestPullRequestHandler_Merge(t *testing.T) {
 	})
 }
 
+func TestPullRequestHandler_MergeWhenReady(t *testing.T) {
+	t.Parallel()
+
+	orgID := uuid.New()
+	userID := uuid.New()
+	prID := uuid.New()
+	now := time.Now().UTC()
+	healthVersion := int64(7)
+
+	t.Run("queues merge when ready", func(t *testing.T) {
+		t.Parallel()
+
+		svc := &stubPullRequestHealthService{
+			queueMergeWhenReadyFunc: func(_ context.Context, gotOrgID, gotPRID, gotUserID uuid.UUID) (*models.PullRequestMergeWhenReadyStatus, error) {
+				require.Equal(t, orgID, gotOrgID, "QueueMergeWhenReady should pass the active org ID")
+				require.Equal(t, prID, gotPRID, "QueueMergeWhenReady should pass the parsed pull request ID")
+				require.Equal(t, userID, gotUserID, "QueueMergeWhenReady should pass the current user ID")
+				return &models.PullRequestMergeWhenReadyStatus{
+					State:                  models.PullRequestMergeWhenReadyStateQueued,
+					RequestedByUserID:      &userID,
+					RequestedAt:            &now,
+					RequestedHeadSHA:       "head",
+					RequestedHealthVersion: &healthVersion,
+				}, nil
+			},
+		}
+
+		handler := NewPullRequestHandler(svc)
+		req := mergeWhenReadyRequest(http.MethodPost, prID.String(), &models.User{ID: userID, OrgID: orgID}, orgID)
+		rr := httptest.NewRecorder()
+		handler.QueueMergeWhenReady(rr, req)
+
+		require.Equal(t, http.StatusOK, rr.Code, "QueueMergeWhenReady should return 200 on success")
+		var resp models.SingleResponse[models.PullRequestMergeWhenReadyStatus]
+		require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &resp), "QueueMergeWhenReady should return valid JSON")
+		require.Equal(t, models.PullRequestMergeWhenReadyStateQueued, resp.Data.State, "QueueMergeWhenReady should serialize the queued state")
+		require.Equal(t, "head", resp.Data.RequestedHeadSHA, "QueueMergeWhenReady should serialize the requested head")
+	})
+
+	t.Run("cancels merge when ready", func(t *testing.T) {
+		t.Parallel()
+
+		svc := &stubPullRequestHealthService{
+			cancelMergeWhenReadyFunc: func(_ context.Context, gotOrgID, gotPRID, gotUserID uuid.UUID) (*models.PullRequestMergeWhenReadyStatus, error) {
+				require.Equal(t, orgID, gotOrgID, "CancelMergeWhenReady should pass the active org ID")
+				require.Equal(t, prID, gotPRID, "CancelMergeWhenReady should pass the parsed pull request ID")
+				require.Equal(t, userID, gotUserID, "CancelMergeWhenReady should pass the current user ID")
+				return &models.PullRequestMergeWhenReadyStatus{
+					State:                  models.PullRequestMergeWhenReadyStateCancelled,
+					RequestedByUserID:      &userID,
+					RequestedAt:            &now,
+					RequestedHeadSHA:       "head",
+					RequestedHealthVersion: &healthVersion,
+				}, nil
+			},
+		}
+
+		handler := NewPullRequestHandler(svc)
+		req := mergeWhenReadyRequest(http.MethodDelete, prID.String(), &models.User{ID: userID, OrgID: orgID}, orgID)
+		rr := httptest.NewRecorder()
+		handler.CancelMergeWhenReady(rr, req)
+
+		require.Equal(t, http.StatusOK, rr.Code, "CancelMergeWhenReady should return 200 on success")
+		var resp models.SingleResponse[models.PullRequestMergeWhenReadyStatus]
+		require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &resp), "CancelMergeWhenReady should return valid JSON")
+		require.Equal(t, models.PullRequestMergeWhenReadyStateCancelled, resp.Data.State, "CancelMergeWhenReady should serialize the cancelled state")
+	})
+
+	t.Run("requeue after cancellation is delegated to service", func(t *testing.T) {
+		t.Parallel()
+
+		called := false
+		svc := &stubPullRequestHealthService{
+			queueMergeWhenReadyFunc: func(context.Context, uuid.UUID, uuid.UUID, uuid.UUID) (*models.PullRequestMergeWhenReadyStatus, error) {
+				called = true
+				return &models.PullRequestMergeWhenReadyStatus{State: models.PullRequestMergeWhenReadyStateQueued}, nil
+			},
+		}
+
+		handler := NewPullRequestHandler(svc)
+		req := mergeWhenReadyRequest(http.MethodPost, prID.String(), &models.User{ID: userID, OrgID: orgID}, orgID)
+		rr := httptest.NewRecorder()
+		handler.QueueMergeWhenReady(rr, req)
+
+		require.Equal(t, http.StatusOK, rr.Code, "QueueMergeWhenReady should allow service-level re-queueing after cancellation")
+		require.True(t, called, "QueueMergeWhenReady should call the queue service even if prior state was cancelled")
+	})
+}
+
 func mergeRequest(pathID string, user *models.User, orgID uuid.UUID) *http.Request {
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/pull-requests/"+pathID+"/merge", nil)
+	req = req.WithContext(middleware.WithOrgID(req.Context(), orgID))
+	if user != nil {
+		req = req.WithContext(middleware.WithUser(req.Context(), user))
+	}
+	req = req.WithContext(withURLParam(req.Context(), "id", pathID))
+	return req
+}
+
+func mergeWhenReadyRequest(method, pathID string, user *models.User, orgID uuid.UUID) *http.Request {
+	req := httptest.NewRequest(method, "/api/v1/pull-requests/"+pathID+"/merge-when-ready", nil)
 	req = req.WithContext(middleware.WithOrgID(req.Context(), orgID))
 	if user != nil {
 		req = req.WithContext(middleware.WithUser(req.Context(), user))

--- a/internal/api/handlers/sessions_test.go
+++ b/internal/api/handlers/sessions_test.go
@@ -358,7 +358,9 @@ var sessionPullRequestColumns = []string{
 	"id", "session_id", "org_id", "github_pr_number", "github_pr_url", "github_repo",
 	"title", "body", "status", "review_status", "authored_by", "ci_status", "head_sha", "head_ref", "base_sha",
 	"merge_state", "has_conflicts", "failing_test_count", "needs_agent_action", "github_state_synced_at",
-	"health_version", "merged_at", "created_at", "updated_at",
+	"health_version", "merge_when_ready_state", "merge_when_ready_requested_by", "merge_when_ready_requested_at",
+	"merge_when_ready_head_sha", "merge_when_ready_health_version", "merge_when_ready_error",
+	"merge_when_ready_updated_at", "merged_at", "created_at", "updated_at",
 }
 
 func sessionPullRequestRow(prID uuid.UUID, sessionID *uuid.UUID, orgID uuid.UUID, repo string, now time.Time) []any {
@@ -384,6 +386,13 @@ func sessionPullRequestRow(prID uuid.UUID, sessionID *uuid.UUID, orgID uuid.UUID
 		false,
 		(*time.Time)(nil),
 		int64(0),
+		models.PullRequestMergeWhenReadyStateOff,
+		(*uuid.UUID)(nil),
+		(*time.Time)(nil),
+		"",
+		(*int64)(nil),
+		"",
+		(*time.Time)(nil),
 		(*time.Time)(nil),
 		now,
 		now,

--- a/internal/api/handlers/webhooks_test.go
+++ b/internal/api/handlers/webhooks_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/assembledhq/143/internal/config"
 	"github.com/assembledhq/143/internal/db"
+	"github.com/assembledhq/143/internal/models"
 	ghservice "github.com/assembledhq/143/internal/services/github"
 	"github.com/google/uuid"
 	"github.com/pashagolub/pgxmock/v4"
@@ -380,10 +381,14 @@ func TestWebhook_HandlePullRequestScopesLookupToActiveOwner(t *testing.T) {
 			"id", "session_id", "org_id", "github_pr_number", "github_pr_url", "github_repo",
 			"title", "body", "status", "review_status", "authored_by", "ci_status", "head_sha", "head_ref", "base_sha",
 			"merge_state", "has_conflicts", "failing_test_count", "needs_agent_action", "github_state_synced_at",
-			"health_version", "merged_at", "created_at", "updated_at",
+			"health_version", "merge_when_ready_state", "merge_when_ready_requested_by", "merge_when_ready_requested_at",
+			"merge_when_ready_head_sha", "merge_when_ready_health_version", "merge_when_ready_error",
+			"merge_when_ready_updated_at", "merged_at", "created_at", "updated_at",
 		}).AddRow(prID, nil, orgID, 42, "https://github.com/assembledhq/143/pull/42", "assembledhq/143",
 			"Fix bug", nil, "open", "pending", "app", "", nil, nil, nil,
-			"unknown", false, 0, false, nil, int64(0), nil, now, now))
+			"unknown", false, 0, false, nil, int64(0),
+			models.PullRequestMergeWhenReadyStateOff, nil, nil, "", nil, "", nil,
+			nil, now, now))
 
 	body := []byte(`{"action":"opened","number":42,"repository":{"id":1001,"full_name":"assembledhq/143"},"pull_request":{"head":{"sha":"abc"}}}`)
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/webhooks/github", strings.NewReader(string(body)))

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -1114,6 +1114,8 @@ func NewRouter(cfg *config.Config, pool *pgxpool.Pool, logger zerolog.Logger, se
 				r.Post("/api/v1/pull-requests/{id}/repair/fix-tests", pullRequestHandler.FixTests)
 				r.Post("/api/v1/pull-requests/{id}/repair/resolve-conflicts", pullRequestHandler.ResolveConflicts)
 				r.Post("/api/v1/pull-requests/{id}/merge", pullRequestHandler.Merge)
+				r.Post("/api/v1/pull-requests/{id}/merge-when-ready", pullRequestHandler.QueueMergeWhenReady)
+				r.Delete("/api/v1/pull-requests/{id}/merge-when-ready", pullRequestHandler.CancelMergeWhenReady)
 
 				// Automations (write)
 				r.Post("/api/v1/automations", automationHandler.Create)

--- a/internal/cluster/scheduler.go
+++ b/internal/cluster/scheduler.go
@@ -432,9 +432,9 @@ func (s *Scheduler) reapStrandedPendingSnapshots(ctx context.Context, now time.T
 }
 
 func (s *Scheduler) schedulePullRequestReconciliation(ctx context.Context, orgIDs []uuid.UUID, now time.Time) {
-	hourBucket := now.UTC().Format("2006010215")
+	tenMinuteBucket := now.UTC().Format("2006010215") + fmt.Sprintf("%d", now.UTC().Minute()/10)
 	for _, orgID := range orgIDs {
-		dedupeKey := fmt.Sprintf("reconcile_pull_request_state:%s:%s", orgID.String(), hourBucket)
+		dedupeKey := fmt.Sprintf("reconcile_pull_request_state:%s:%s", orgID.String(), tenMinuteBucket)
 		payload := map[string]any{
 			"org_id": orgID.String(),
 			"limit":  pullRequestReconcileBatch,

--- a/internal/cluster/scheduler_test.go
+++ b/internal/cluster/scheduler_test.go
@@ -172,7 +172,7 @@ func TestScheduler_SchedulePullRequestReconciliation(t *testing.T) {
 	require.Equal(t, orgIDs[0].String(), firstPayload["org_id"], "scheduler should include the target org ID in the reconciliation payload")
 	require.Equal(t, pullRequestReconcileBatch, firstPayload["limit"], "scheduler should include the configured reconciliation batch size")
 	require.Len(t, jobs.dedupeKeys, 2, "should compute one dedupe key per reconciliation job")
-	require.Contains(t, jobs.dedupeKeys[0], "reconcile_pull_request_state:"+orgIDs[0].String()+":2026042322", "dedupe key should include the org and UTC hour bucket")
+	require.Contains(t, jobs.dedupeKeys[0], "reconcile_pull_request_state:"+orgIDs[0].String()+":20260423220", "dedupe key should include the org and UTC ten-minute bucket")
 }
 
 func TestScheduler_ScheduleLinearTeamKeyRefresh_OncePerUTCDay(t *testing.T) {

--- a/internal/db/pull_request_store_test.go
+++ b/internal/db/pull_request_store_test.go
@@ -15,14 +15,18 @@ var prColumns = []string{
 	"id", "session_id", "org_id", "github_pr_number", "github_pr_url", "github_repo",
 	"title", "body", "status", "review_status", "authored_by", "ci_status", "head_sha", "head_ref", "base_sha",
 	"merge_state", "has_conflicts", "failing_test_count", "needs_agent_action", "github_state_synced_at",
-	"health_version", "merged_at", "created_at", "updated_at",
+	"health_version", "merge_when_ready_state", "merge_when_ready_requested_by", "merge_when_ready_requested_at",
+	"merge_when_ready_head_sha", "merge_when_ready_health_version", "merge_when_ready_error",
+	"merge_when_ready_updated_at", "merged_at", "created_at", "updated_at",
 }
 
 func newPRRow(id, sessionID, orgID uuid.UUID, now time.Time) []any {
 	return []any{
 		id, &sessionID, orgID, 42, "https://github.com/org/repo/pull/42", "org/repo",
 		"Fix bug", (*string)(nil), "open", "pending", "app", "", (*string)(nil), (*string)(nil), (*string)(nil),
-		models.PullRequestMergeStateUnknown, false, 0, false, (*time.Time)(nil), int64(0), (*time.Time)(nil), now, now,
+		models.PullRequestMergeStateUnknown, false, 0, false, (*time.Time)(nil), int64(0),
+		models.PullRequestMergeWhenReadyStateOff, (*uuid.UUID)(nil), (*time.Time)(nil), "", (*int64)(nil), "", (*time.Time)(nil),
+		(*time.Time)(nil), now, now,
 	}
 }
 

--- a/internal/db/pull_requests.go
+++ b/internal/db/pull_requests.go
@@ -3,6 +3,7 @@ package db
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
@@ -56,7 +57,13 @@ func (s *PullRequestStore) Create(ctx context.Context, pr *models.PullRequest) e
 const prSelectColumns = `id, session_id, org_id, github_pr_number, github_pr_url, github_repo,
 		       title, body, status, review_status, authored_by, ci_status, head_sha, head_ref, base_sha,
 		       merge_state, has_conflicts, failing_test_count, needs_agent_action, github_state_synced_at,
-		       health_version, merged_at, created_at, updated_at`
+		       health_version, merge_when_ready_state, merge_when_ready_requested_by, merge_when_ready_requested_at,
+		       merge_when_ready_head_sha, merge_when_ready_health_version, merge_when_ready_error,
+		       merge_when_ready_updated_at, merged_at, created_at, updated_at`
+
+const prMergeWhenReadyStatusColumns = `merge_when_ready_state, merge_when_ready_requested_by,
+	merge_when_ready_requested_at, merge_when_ready_head_sha, merge_when_ready_health_version,
+	merge_when_ready_error`
 
 func (s *PullRequestStore) GetByID(ctx context.Context, orgID, id uuid.UUID) (models.PullRequest, error) {
 	query := `
@@ -282,4 +289,161 @@ func (s *PullRequestStore) UpdateCIStatus(ctx context.Context, orgID, id uuid.UU
 		"ci_status": ciStatus,
 	})
 	return err
+}
+
+func (s *PullRequestStore) QueueMergeWhenReady(ctx context.Context, orgID, id, userID uuid.UUID, headSHA string, healthVersion int64) (models.PullRequestMergeWhenReadyStatus, error) {
+	query := `
+		UPDATE pull_requests
+		SET merge_when_ready_state = @state,
+			merge_when_ready_requested_by = @requested_by,
+			merge_when_ready_requested_at = now(),
+			merge_when_ready_head_sha = @head_sha,
+			merge_when_ready_health_version = @health_version,
+			merge_when_ready_error = '',
+			merge_when_ready_updated_at = now(),
+			updated_at = now()
+		WHERE id = @id
+		  AND org_id = @org_id
+		  AND merge_when_ready_state IN ('off', 'queued', 'failed', 'cancelled')
+		RETURNING ` + prMergeWhenReadyStatusColumns
+
+	return s.queryMergeWhenReadyStatus(ctx, query, pgx.NamedArgs{
+		"id":             id,
+		"org_id":         orgID,
+		"requested_by":   userID,
+		"head_sha":       headSHA,
+		"health_version": healthVersion,
+		"state":          models.PullRequestMergeWhenReadyStateQueued,
+	})
+}
+
+func (s *PullRequestStore) CancelMergeWhenReady(ctx context.Context, orgID, id uuid.UUID) (models.PullRequestMergeWhenReadyStatus, error) {
+	query := `
+		UPDATE pull_requests
+		SET merge_when_ready_state = @state,
+			merge_when_ready_error = '',
+			merge_when_ready_updated_at = now(),
+			updated_at = now()
+		WHERE id = @id
+		  AND org_id = @org_id
+		  AND merge_when_ready_state IN ('queued', 'failed', 'cancelled')
+		RETURNING ` + prMergeWhenReadyStatusColumns
+
+	return s.queryMergeWhenReadyStatus(ctx, query, pgx.NamedArgs{
+		"id":     id,
+		"org_id": orgID,
+		"state":  models.PullRequestMergeWhenReadyStateCancelled,
+	})
+}
+
+func (s *PullRequestStore) ClaimMergeWhenReadyForProcessing(ctx context.Context, orgID, id uuid.UUID, staleBefore time.Time) (bool, error) {
+	query := `
+		UPDATE pull_requests
+		SET merge_when_ready_state = @state,
+			merge_when_ready_error = '',
+			merge_when_ready_updated_at = now(),
+			updated_at = now()
+		WHERE id = @id
+		  AND org_id = @org_id
+		  AND (
+			merge_when_ready_state = 'queued'
+			OR (
+				merge_when_ready_state = 'merging'
+				AND merge_when_ready_updated_at < @stale_before
+			)
+		  )`
+
+	res, err := s.db.Exec(ctx, query, pgx.NamedArgs{
+		"id":           id,
+		"org_id":       orgID,
+		"state":        models.PullRequestMergeWhenReadyStateMerging,
+		"stale_before": staleBefore,
+	})
+	if err != nil {
+		return false, err
+	}
+	return res.RowsAffected() > 0, nil
+}
+
+func (s *PullRequestStore) MarkMergeWhenReadySucceeded(ctx context.Context, orgID, id uuid.UUID) error {
+	return s.markMergeWhenReadyTerminal(ctx, orgID, id, models.PullRequestMergeWhenReadyStateSucceeded, "")
+}
+
+func (s *PullRequestStore) MarkMergeWhenReadyFailed(ctx context.Context, orgID, id uuid.UUID, reason string) error {
+	return s.markMergeWhenReadyTerminal(ctx, orgID, id, models.PullRequestMergeWhenReadyStateFailed, reason)
+}
+
+func (s *PullRequestStore) markMergeWhenReadyTerminal(ctx context.Context, orgID, id uuid.UUID, state models.PullRequestMergeWhenReadyState, reason string) error {
+	query := `
+		UPDATE pull_requests
+		SET merge_when_ready_state = @state,
+			merge_when_ready_error = @reason,
+			merge_when_ready_updated_at = now(),
+			updated_at = now()
+		WHERE id = @id AND org_id = @org_id`
+	_, err := s.db.Exec(ctx, query, pgx.NamedArgs{
+		"id":     id,
+		"org_id": orgID,
+		"state":  state,
+		"reason": reason,
+	})
+	return err
+}
+
+func (s *PullRequestStore) ListMergeWhenReadyForProcessing(ctx context.Context, orgID uuid.UUID, staleBefore time.Time, limit int) ([]models.PullRequest, error) {
+	if limit <= 0 || limit > 200 {
+		limit = 50
+	}
+
+	query := `
+		SELECT ` + prSelectColumns + `
+		FROM pull_requests
+		WHERE org_id = @org_id
+		  AND status = 'open'
+		  AND (
+			merge_when_ready_state = 'queued'
+			OR (
+				merge_when_ready_state = 'merging'
+				AND merge_when_ready_updated_at < @stale_before
+			)
+		  )
+		ORDER BY merge_when_ready_updated_at ASC NULLS FIRST, updated_at ASC
+		LIMIT @limit`
+
+	rows, err := s.db.Query(ctx, query, pgx.NamedArgs{
+		"org_id":       orgID,
+		"stale_before": staleBefore,
+		"limit":        limit,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("list merge-when-ready pull requests for processing: %w", err)
+	}
+	return pgx.CollectRows(rows, pgx.RowToStructByName[models.PullRequest])
+}
+
+func (s *PullRequestStore) queryMergeWhenReadyStatus(ctx context.Context, query string, args pgx.NamedArgs) (models.PullRequestMergeWhenReadyStatus, error) {
+	rows, err := s.db.Query(ctx, query, args)
+	if err != nil {
+		return models.PullRequestMergeWhenReadyStatus{}, err
+	}
+	type row struct {
+		State                  models.PullRequestMergeWhenReadyState `db:"merge_when_ready_state"`
+		RequestedByUserID      *uuid.UUID                            `db:"merge_when_ready_requested_by"`
+		RequestedAt            *time.Time                            `db:"merge_when_ready_requested_at"`
+		RequestedHeadSHA       string                                `db:"merge_when_ready_head_sha"`
+		RequestedHealthVersion *int64                                `db:"merge_when_ready_health_version"`
+		LastError              string                                `db:"merge_when_ready_error"`
+	}
+	statusRow, err := pgx.CollectOneRow(rows, pgx.RowToStructByName[row])
+	if err != nil {
+		return models.PullRequestMergeWhenReadyStatus{}, err
+	}
+	return models.PullRequestMergeWhenReadyStatus{
+		State:                  statusRow.State,
+		RequestedByUserID:      statusRow.RequestedByUserID,
+		RequestedAt:            statusRow.RequestedAt,
+		RequestedHeadSHA:       statusRow.RequestedHeadSHA,
+		RequestedHealthVersion: statusRow.RequestedHealthVersion,
+		LastError:              statusRow.LastError,
+	}, nil
 }

--- a/internal/db/pull_requests_test.go
+++ b/internal/db/pull_requests_test.go
@@ -27,7 +27,9 @@ func TestPullRequestStore_GetByRepoAndNumber(t *testing.T) {
 		"id", "session_id", "org_id", "github_pr_number", "github_pr_url", "github_repo",
 		"title", "body", "status", "review_status", "authored_by", "ci_status", "head_sha", "head_ref", "base_sha",
 		"merge_state", "has_conflicts", "failing_test_count", "needs_agent_action", "github_state_synced_at",
-		"health_version", "merged_at", "created_at", "updated_at",
+		"health_version", "merge_when_ready_state", "merge_when_ready_requested_by", "merge_when_ready_requested_at",
+		"merge_when_ready_head_sha", "merge_when_ready_health_version", "merge_when_ready_error",
+		"merge_when_ready_updated_at", "merged_at", "created_at", "updated_at",
 	}
 
 	prID := uuid.New()
@@ -41,7 +43,8 @@ func TestPullRequestStore_GetByRepoAndNumber(t *testing.T) {
 			pgxmock.NewRows(cols).
 				AddRow(prID, &sessionID, orgID, 42, "https://github.com/org/repo/pull/42", "org/repo",
 					"Fix bug", ptrStr("Description"), "open", "pending", "user1", "", nil, nil, nil,
-					models.PullRequestMergeStateUnknown, false, 0, false, nil, int64(0), nil, now, now),
+					models.PullRequestMergeStateUnknown, false, 0, false, nil, int64(0),
+					models.PullRequestMergeWhenReadyStateOff, nil, nil, "", nil, "", nil, nil, now, now),
 		)
 
 	pr, err := store.GetByRepoAndNumber(context.Background(), "org/repo", 42)
@@ -64,7 +67,9 @@ func TestPullRequestStore_GetByOrgRepoAndNumber(t *testing.T) {
 		"id", "session_id", "org_id", "github_pr_number", "github_pr_url", "github_repo",
 		"title", "body", "status", "review_status", "authored_by", "ci_status", "head_sha", "head_ref", "base_sha",
 		"merge_state", "has_conflicts", "failing_test_count", "needs_agent_action", "github_state_synced_at",
-		"health_version", "merged_at", "created_at", "updated_at",
+		"health_version", "merge_when_ready_state", "merge_when_ready_requested_by", "merge_when_ready_requested_at",
+		"merge_when_ready_head_sha", "merge_when_ready_health_version", "merge_when_ready_error",
+		"merge_when_ready_updated_at", "merged_at", "created_at", "updated_at",
 	}
 
 	prID := uuid.New()
@@ -78,7 +83,8 @@ func TestPullRequestStore_GetByOrgRepoAndNumber(t *testing.T) {
 			pgxmock.NewRows(cols).
 				AddRow(prID, &sessionID, orgID, 42, "https://github.com/org/repo/pull/42", "org/repo",
 					"Fix bug", ptrStr("Description"), "open", "pending", "user1", "", nil, nil, nil,
-					models.PullRequestMergeStateUnknown, false, 0, false, nil, int64(0), nil, now, now),
+					models.PullRequestMergeStateUnknown, false, 0, false, nil, int64(0),
+					models.PullRequestMergeWhenReadyStateOff, nil, nil, "", nil, "", nil, nil, now, now),
 		)
 
 	pr, err := store.GetByOrgRepoAndNumber(context.Background(), orgID, "org/repo", 42)
@@ -122,7 +128,9 @@ func TestPullRequestStore_BatchGetBySessionIDs_Success(t *testing.T) {
 		"id", "session_id", "org_id", "github_pr_number", "github_pr_url", "github_repo",
 		"title", "body", "status", "review_status", "authored_by", "ci_status", "head_sha", "head_ref", "base_sha",
 		"merge_state", "has_conflicts", "failing_test_count", "needs_agent_action", "github_state_synced_at",
-		"health_version", "merged_at", "created_at", "updated_at",
+		"health_version", "merge_when_ready_state", "merge_when_ready_requested_by", "merge_when_ready_requested_at",
+		"merge_when_ready_head_sha", "merge_when_ready_health_version", "merge_when_ready_error",
+		"merge_when_ready_updated_at", "merged_at", "created_at", "updated_at",
 	}
 
 	orgID := uuid.New()
@@ -136,7 +144,8 @@ func TestPullRequestStore_BatchGetBySessionIDs_Success(t *testing.T) {
 			pgxmock.NewRows(cols).
 				AddRow(prID, &sessionID, orgID, 42, "https://github.com/org/repo/pull/42", "org/repo",
 					"Fix bug", ptrStr("body"), "open", "pending", "app", "success", nil, nil, nil,
-					models.PullRequestMergeStateUnknown, false, 0, false, nil, int64(0), nil, now, now),
+					models.PullRequestMergeStateUnknown, false, 0, false, nil, int64(0),
+					models.PullRequestMergeWhenReadyStateOff, nil, nil, "", nil, "", nil, nil, now, now),
 		)
 
 	result, err := store.BatchGetBySessionIDs(context.Background(), orgID, []uuid.UUID{sessionID})
@@ -283,4 +292,123 @@ func TestPullRequestStore_UpdateHeadSHA_NoRowReturnsErrNoRows(t *testing.T) {
 	err = store.UpdateHeadSHA(context.Background(), orgID, prID, "abc123def456")
 	require.ErrorIs(t, err, pgx.ErrNoRows, "UpdateHeadSHA should report drift when no PR row matched")
 	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
+}
+
+func TestPullRequestStore_QueueMergeWhenReady_RequeuesCancelledState(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "pgxmock pool should initialize")
+	defer mock.Close()
+
+	store := NewPullRequestStore(mock)
+	orgID := uuid.New()
+	prID := uuid.New()
+	userID := uuid.New()
+	now := time.Now().UTC()
+	version := int64(12)
+
+	mock.ExpectQuery("UPDATE pull_requests[\\s\\S]*merge_when_ready_state = @state[\\s\\S]*merge_when_ready_error = ''[\\s\\S]*WHERE id = @id AND org_id = @org_id[\\s\\S]*RETURNING").
+		WithArgs(pgx.NamedArgs{
+			"id":             prID,
+			"org_id":         orgID,
+			"requested_by":   userID,
+			"head_sha":       "head-new",
+			"health_version": version,
+			"state":          models.PullRequestMergeWhenReadyStateQueued,
+		}).
+		WillReturnRows(pgxmock.NewRows([]string{
+			"merge_when_ready_state",
+			"merge_when_ready_requested_by",
+			"merge_when_ready_requested_at",
+			"merge_when_ready_head_sha",
+			"merge_when_ready_health_version",
+			"merge_when_ready_error",
+		}).AddRow(models.PullRequestMergeWhenReadyStateQueued, &userID, &now, "head-new", &version, ""))
+
+	status, err := store.QueueMergeWhenReady(context.Background(), orgID, prID, userID, "head-new", version)
+	require.NoError(t, err, "QueueMergeWhenReady should allow re-queueing after cancellation")
+	require.Equal(t, models.PullRequestMergeWhenReadyStateQueued, status.State, "QueueMergeWhenReady should return the queued state")
+	require.Equal(t, userID, *status.RequestedByUserID, "QueueMergeWhenReady should replace the requesting user")
+	require.Equal(t, "head-new", status.RequestedHeadSHA, "QueueMergeWhenReady should replace the requested head SHA")
+	require.Empty(t, status.LastError, "QueueMergeWhenReady should clear prior cancellation or failure errors")
+	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
+}
+
+func TestPullRequestStore_CancelMergeWhenReady(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "pgxmock pool should initialize")
+	defer mock.Close()
+
+	store := NewPullRequestStore(mock)
+	orgID := uuid.New()
+	prID := uuid.New()
+	userID := uuid.New()
+	now := time.Now().UTC()
+	version := int64(12)
+
+	mock.ExpectQuery("UPDATE pull_requests[\\s\\S]*merge_when_ready_state = @state[\\s\\S]*WHERE id = @id AND org_id = @org_id[\\s\\S]*merge_when_ready_state IN \\('queued', 'failed', 'cancelled'\\)[\\s\\S]*RETURNING").
+		WithArgs(pgx.NamedArgs{
+			"id":     prID,
+			"org_id": orgID,
+			"state":  models.PullRequestMergeWhenReadyStateCancelled,
+		}).
+		WillReturnRows(pgxmock.NewRows([]string{
+			"merge_when_ready_state",
+			"merge_when_ready_requested_by",
+			"merge_when_ready_requested_at",
+			"merge_when_ready_head_sha",
+			"merge_when_ready_health_version",
+			"merge_when_ready_error",
+		}).AddRow(models.PullRequestMergeWhenReadyStateCancelled, &userID, &now, "head", &version, ""))
+
+	status, err := store.CancelMergeWhenReady(context.Background(), orgID, prID)
+	require.NoError(t, err, "CancelMergeWhenReady should mark queued intent cancelled")
+	require.Equal(t, models.PullRequestMergeWhenReadyStateCancelled, status.State, "CancelMergeWhenReady should return the cancelled state")
+	require.Equal(t, "head", status.RequestedHeadSHA, "CancelMergeWhenReady should preserve the cancelled request context")
+	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
+}
+
+func TestPullRequestStore_ClaimMergeWhenReadyForProcessing(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		rowsAffected int64
+		expected     bool
+	}{
+		{name: "claims queued intent", rowsAffected: 1, expected: true},
+		{name: "does not claim missing or fresh intent", rowsAffected: 0, expected: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			mock, err := pgxmock.NewPool()
+			require.NoError(t, err, "pgxmock pool should initialize")
+			defer mock.Close()
+
+			store := NewPullRequestStore(mock)
+			orgID := uuid.New()
+			prID := uuid.New()
+			staleBefore := time.Now().Add(-15 * time.Minute).UTC()
+
+			mock.ExpectExec("UPDATE pull_requests[\\s\\S]*merge_when_ready_state = @state[\\s\\S]*merge_when_ready_state = 'queued'[\\s\\S]*merge_when_ready_state = 'merging'[\\s\\S]*merge_when_ready_updated_at < @stale_before").
+				WithArgs(pgx.NamedArgs{
+					"id":           prID,
+					"org_id":       orgID,
+					"state":        models.PullRequestMergeWhenReadyStateMerging,
+					"stale_before": staleBefore,
+				}).
+				WillReturnResult(pgxmock.NewResult("UPDATE", tt.rowsAffected))
+
+			claimed, err := store.ClaimMergeWhenReadyForProcessing(context.Background(), orgID, prID, staleBefore)
+			require.NoError(t, err, "ClaimMergeWhenReadyForProcessing should not return database errors on successful exec")
+			require.Equal(t, tt.expected, claimed, "ClaimMergeWhenReadyForProcessing should report whether it claimed the intent")
+			require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
+		})
+	}
 }

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -674,17 +674,24 @@ type PullRequest struct {
 	// into formatBranchName) change later. Nullable for PRs created before
 	// migration 107 added the column — the push code falls back to
 	// recomputing in that case.
-	HeadRef             *string               `db:"head_ref" json:"head_ref,omitempty"`
-	BaseSHA             *string               `db:"base_sha" json:"base_sha,omitempty"`
-	MergeState          PullRequestMergeState `db:"merge_state" json:"merge_state"`
-	HasConflicts        bool                  `db:"has_conflicts" json:"has_conflicts"`
-	FailingTestCount    int                   `db:"failing_test_count" json:"failing_test_count"`
-	NeedsAgentAction    bool                  `db:"needs_agent_action" json:"needs_agent_action"`
-	GitHubStateSyncedAt *time.Time            `db:"github_state_synced_at" json:"github_state_synced_at,omitempty"`
-	HealthVersion       int64                 `db:"health_version" json:"health_version"`
-	MergedAt            *time.Time            `db:"merged_at" json:"merged_at,omitempty"`
-	CreatedAt           time.Time             `db:"created_at" json:"created_at"`
-	UpdatedAt           time.Time             `db:"updated_at" json:"updated_at"`
+	HeadRef                     *string                        `db:"head_ref" json:"head_ref,omitempty"`
+	BaseSHA                     *string                        `db:"base_sha" json:"base_sha,omitempty"`
+	MergeState                  PullRequestMergeState          `db:"merge_state" json:"merge_state"`
+	HasConflicts                bool                           `db:"has_conflicts" json:"has_conflicts"`
+	FailingTestCount            int                            `db:"failing_test_count" json:"failing_test_count"`
+	NeedsAgentAction            bool                           `db:"needs_agent_action" json:"needs_agent_action"`
+	GitHubStateSyncedAt         *time.Time                     `db:"github_state_synced_at" json:"github_state_synced_at,omitempty"`
+	HealthVersion               int64                          `db:"health_version" json:"health_version"`
+	MergeWhenReadyState         PullRequestMergeWhenReadyState `db:"merge_when_ready_state" json:"merge_when_ready_state"`
+	MergeWhenReadyRequestedBy   *uuid.UUID                     `db:"merge_when_ready_requested_by" json:"merge_when_ready_requested_by,omitempty"`
+	MergeWhenReadyRequestedAt   *time.Time                     `db:"merge_when_ready_requested_at" json:"merge_when_ready_requested_at,omitempty"`
+	MergeWhenReadyHeadSHA       string                         `db:"merge_when_ready_head_sha" json:"merge_when_ready_head_sha,omitempty"`
+	MergeWhenReadyHealthVersion *int64                         `db:"merge_when_ready_health_version" json:"merge_when_ready_health_version,omitempty"`
+	MergeWhenReadyError         string                         `db:"merge_when_ready_error" json:"merge_when_ready_error,omitempty"`
+	MergeWhenReadyUpdatedAt     *time.Time                     `db:"merge_when_ready_updated_at" json:"merge_when_ready_updated_at,omitempty"`
+	MergedAt                    *time.Time                     `db:"merged_at" json:"merged_at,omitempty"`
+	CreatedAt                   time.Time                      `db:"created_at" json:"created_at"`
+	UpdatedAt                   time.Time                      `db:"updated_at" json:"updated_at"`
 }
 
 // PRSummary is a lightweight view of a PR for inclusion in session list responses.

--- a/internal/models/pr_health.go
+++ b/internal/models/pr_health.go
@@ -98,6 +98,31 @@ func (s PullRequestHealthEnrichmentStatus) Validate() error {
 	}
 }
 
+type PullRequestMergeWhenReadyState string
+
+const (
+	PullRequestMergeWhenReadyStateOff       PullRequestMergeWhenReadyState = "off"
+	PullRequestMergeWhenReadyStateQueued    PullRequestMergeWhenReadyState = "queued"
+	PullRequestMergeWhenReadyStateMerging   PullRequestMergeWhenReadyState = "merging"
+	PullRequestMergeWhenReadyStateSucceeded PullRequestMergeWhenReadyState = "succeeded"
+	PullRequestMergeWhenReadyStateFailed    PullRequestMergeWhenReadyState = "failed"
+	PullRequestMergeWhenReadyStateCancelled PullRequestMergeWhenReadyState = "cancelled"
+)
+
+func (s PullRequestMergeWhenReadyState) Validate() error {
+	switch s {
+	case PullRequestMergeWhenReadyStateOff,
+		PullRequestMergeWhenReadyStateQueued,
+		PullRequestMergeWhenReadyStateMerging,
+		PullRequestMergeWhenReadyStateSucceeded,
+		PullRequestMergeWhenReadyStateFailed,
+		PullRequestMergeWhenReadyStateCancelled:
+		return nil
+	default:
+		return fmt.Errorf("invalid PullRequestMergeWhenReadyState: %q", s)
+	}
+}
+
 type PullRequestRepairActionType string
 
 const (
@@ -189,6 +214,16 @@ type PullRequestHealthResponse struct {
 	ConflictDetailAvailable      bool                              `json:"conflict_detail_available"`
 	FailingTestDetailAvailable   bool                              `json:"failing_test_detail_available"`
 	ObsoleteActiveRepairSessions bool                              `json:"obsolete_active_repair_sessions,omitempty"`
+	MergeWhenReady               PullRequestMergeWhenReadyStatus   `json:"merge_when_ready"`
+}
+
+type PullRequestMergeWhenReadyStatus struct {
+	State                  PullRequestMergeWhenReadyState `json:"state"`
+	RequestedByUserID      *uuid.UUID                     `json:"requested_by_user_id,omitempty"`
+	RequestedAt            *time.Time                     `json:"requested_at,omitempty"`
+	RequestedHeadSHA       string                         `json:"requested_head_sha,omitempty"`
+	RequestedHealthVersion *int64                         `json:"requested_health_version,omitempty"`
+	LastError              string                         `json:"last_error,omitempty"`
 }
 
 type PullRequestActiveRepair struct {

--- a/internal/models/pr_health_enums_test.go
+++ b/internal/models/pr_health_enums_test.go
@@ -95,6 +95,37 @@ func TestPullRequestHealthEnrichmentStatusValidate(t *testing.T) {
 	}
 }
 
+func TestPullRequestMergeWhenReadyStateValidate(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		state     PullRequestMergeWhenReadyState
+		expectErr bool
+	}{
+		{name: "off", state: PullRequestMergeWhenReadyStateOff},
+		{name: "queued", state: PullRequestMergeWhenReadyStateQueued},
+		{name: "merging", state: PullRequestMergeWhenReadyStateMerging},
+		{name: "succeeded", state: PullRequestMergeWhenReadyStateSucceeded},
+		{name: "failed", state: PullRequestMergeWhenReadyStateFailed},
+		{name: "cancelled", state: PullRequestMergeWhenReadyStateCancelled},
+		{name: "invalid", state: PullRequestMergeWhenReadyState("oops"), expectErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := tt.state.Validate()
+			if tt.expectErr {
+				require.Error(t, err, "Validate should reject unsupported merge-when-ready states")
+				return
+			}
+			require.NoError(t, err, "Validate should accept supported merge-when-ready states")
+		})
+	}
+}
+
 func TestPullRequestCheckStatusValidate(t *testing.T) {
 	t.Parallel()
 

--- a/internal/services/github/pr_handlers_test.go
+++ b/internal/services/github/pr_handlers_test.go
@@ -29,7 +29,9 @@ var handlerPRColumns = []string{
 	"id", "session_id", "org_id", "github_pr_number", "github_pr_url", "github_repo",
 	"title", "body", "status", "review_status", "authored_by", "ci_status", "head_sha", "head_ref", "base_sha",
 	"merge_state", "has_conflicts", "failing_test_count", "needs_agent_action", "github_state_synced_at",
-	"health_version", "merged_at", "created_at", "updated_at",
+	"health_version", "merge_when_ready_state", "merge_when_ready_requested_by", "merge_when_ready_requested_at",
+	"merge_when_ready_head_sha", "merge_when_ready_health_version", "merge_when_ready_error",
+	"merge_when_ready_updated_at", "merged_at", "created_at", "updated_at",
 }
 
 // sessionColumns matches the SELECT columns from SessionStore queries
@@ -67,7 +69,9 @@ func handlerPRRow(prID uuid.UUID, sessionID *uuid.UUID, orgID uuid.UUID, repo st
 	return []any{
 		prID, sessionID, orgID, 42, "https://github.com/" + repo + "/pull/42", repo,
 		"Fix bug", (*string)(nil), "open", "pending", "app", "", nil, nil, nil,
-		models.PullRequestMergeStateUnknown, false, 0, false, nil, int64(0), (*time.Time)(nil), now, now,
+		models.PullRequestMergeStateUnknown, false, 0, false, nil, int64(0),
+		models.PullRequestMergeWhenReadyStateOff, (*uuid.UUID)(nil), (*time.Time)(nil), "", (*int64)(nil), "", (*time.Time)(nil),
+		(*time.Time)(nil), now, now,
 	}
 }
 

--- a/internal/services/github/pr_health_service.go
+++ b/internal/services/github/pr_health_service.go
@@ -26,6 +26,7 @@ const (
 	prHealthSyncJobType      = "sync_pull_request_state"
 	prHealthReconcileJobType = "reconcile_pull_request_state"
 	prHealthEnrichJobType    = "enrich_pull_request_health"
+	prMergeWhenReadyJobType  = "merge_pull_request_when_ready"
 )
 
 var (
@@ -139,6 +140,14 @@ func (s *PRService) buildPullRequestHealthResponse(ctx context.Context, pr model
 		NeedsAgentAction:    pr.NeedsAgentAction,
 		GitHubStateSyncedAt: pr.GitHubStateSyncedAt,
 		HealthVersion:       pr.HealthVersion,
+		MergeWhenReady: models.PullRequestMergeWhenReadyStatus{
+			State:                  pr.MergeWhenReadyState,
+			RequestedByUserID:      pr.MergeWhenReadyRequestedBy,
+			RequestedAt:            pr.MergeWhenReadyRequestedAt,
+			RequestedHeadSHA:       pr.MergeWhenReadyHeadSHA,
+			RequestedHealthVersion: pr.MergeWhenReadyHealthVersion,
+			LastError:              pr.MergeWhenReadyError,
+		},
 	}
 	derivePullRequestRepairActions(resp)
 	if pr.HeadSHA != nil {
@@ -391,6 +400,7 @@ func (s *PRService) SyncPullRequestState(ctx context.Context, orgID, pullRequest
 	}
 
 	s.publishPullRequestUpdated(ctx, pr, current)
+	s.enqueueMergeWhenReadyProcessing(ctx, pr)
 	if mergeStateIndeterminate {
 		return ErrPullRequestMergeabilityPending
 	}
@@ -410,6 +420,13 @@ func (s *PRService) ReconcilePullRequestState(ctx context.Context, orgID uuid.UU
 			}
 			s.logger.Warn().Err(err).Str("pull_request_id", pr.ID.String()).Msg("failed to reconcile pull request health")
 		}
+	}
+	queued, err := s.pullRequests.ListMergeWhenReadyForProcessing(ctx, orgID, time.Now().Add(-mergeWhenReadyMergingStaleAfter), limit)
+	if err != nil {
+		return err
+	}
+	for _, pr := range queued {
+		s.enqueueMergeWhenReadyProcessing(ctx, pr)
 	}
 	return nil
 }
@@ -944,6 +961,24 @@ func (s *PRService) enqueuePullRequestHealthEnrichment(ctx context.Context, pr m
 	if err != nil {
 		s.logger.Warn().Err(err).Str("pull_request_id", pr.ID.String()).Msg("failed to enqueue pull request health enrichment")
 	}
+}
+
+func (s *PRService) enqueueMergeWhenReadyProcessing(ctx context.Context, pr models.PullRequest) {
+	if s.jobs == nil || !isMergeWhenReadyProcessable(pr, time.Now()) {
+		return
+	}
+	dedupeKey := fmt.Sprintf("%s:%s", prMergeWhenReadyJobType, pr.ID.String())
+	_, err := s.jobs.Enqueue(ctx, pr.OrgID, prHealthSyncQueue, prMergeWhenReadyJobType, map[string]string{
+		"org_id":          pr.OrgID.String(),
+		"pull_request_id": pr.ID.String(),
+	}, 7, &dedupeKey)
+	if err != nil {
+		s.logger.Warn().Err(err).Str("pull_request_id", pr.ID.String()).Msg("failed to enqueue merge-when-ready processing")
+	}
+}
+
+func isMergeWhenReadyProcessable(pr models.PullRequest, now time.Time) bool {
+	return pr.MergeWhenReadyState == models.PullRequestMergeWhenReadyStateQueued || isStaleMergeWhenReadyMerging(pr, now)
 }
 
 func (s *PRService) publishPullRequestUpdated(ctx context.Context, pr models.PullRequest, current models.PullRequestHealthCurrent) {

--- a/internal/services/github/pr_health_service_test.go
+++ b/internal/services/github/pr_health_service_test.go
@@ -478,7 +478,7 @@ func TestPRServiceGetPullRequestHealthEnqueuesSyncAndEnrichment(t *testing.T) {
 		WillReturnRows(pgxmock.NewRows(prTestPullRequestColumns).AddRow(
 			pullRequestID, nil, orgID, 42, "https://github.com/assembledhq/143/pull/42", "assembledhq/143",
 			"Fix bug", (*string)(nil), "open", "pending", "app", "", nil, nil, nil,
-			models.PullRequestMergeStateUnknown, false, 0, false, &stale, int64(2), (*time.Time)(nil), now, now,
+			models.PullRequestMergeStateUnknown, false, 0, false, &stale, int64(2), models.PullRequestMergeWhenReadyStateOff, (*uuid.UUID)(nil), (*time.Time)(nil), "", (*int64)(nil), "", (*time.Time)(nil), (*time.Time)(nil), now, now,
 		))
 	mock.ExpectQuery("INSERT INTO jobs").
 		WithArgs(pgx.NamedArgs{
@@ -562,14 +562,14 @@ func TestPRServiceGetPullRequestHealthEnqueuesFollowUpWhenInlineMergeabilityPend
 		WillReturnRows(pgxmock.NewRows(prTestPullRequestColumns).AddRow(
 			pullRequestID, nil, orgID, 42, "https://github.com/assembledhq/143/pull/42", "assembledhq/143",
 			"Pending mergeability", (*string)(nil), "open", "pending", "app", "", nil, nil, nil,
-			models.PullRequestMergeStateUnknown, false, 0, false, (*time.Time)(nil), int64(0), (*time.Time)(nil), now, now,
+			models.PullRequestMergeStateUnknown, false, 0, false, (*time.Time)(nil), int64(0), models.PullRequestMergeWhenReadyStateOff, (*uuid.UUID)(nil), (*time.Time)(nil), "", (*int64)(nil), "", (*time.Time)(nil), (*time.Time)(nil), now, now,
 		))
 	mock.ExpectQuery("SELECT .+ FROM pull_requests WHERE id").
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
 		WillReturnRows(pgxmock.NewRows(prTestPullRequestColumns).AddRow(
 			pullRequestID, nil, orgID, 42, "https://github.com/assembledhq/143/pull/42", "assembledhq/143",
 			"Pending mergeability", (*string)(nil), "open", "pending", "app", "", nil, nil, nil,
-			models.PullRequestMergeStateUnknown, false, 0, false, (*time.Time)(nil), int64(0), (*time.Time)(nil), now, now,
+			models.PullRequestMergeStateUnknown, false, 0, false, (*time.Time)(nil), int64(0), models.PullRequestMergeWhenReadyStateOff, (*uuid.UUID)(nil), (*time.Time)(nil), "", (*int64)(nil), "", (*time.Time)(nil), (*time.Time)(nil), now, now,
 		))
 	mock.ExpectQuery("SELECT .+ FROM repositories WHERE org_id = .+ AND full_name = .+ AND status = 'active'").
 		WithArgs(pgx.NamedArgs{"org_id": orgID, "full_name": "assembledhq/143"}).
@@ -644,7 +644,7 @@ func TestPRServiceGetPullRequestHealthEnqueuesFollowUpWhenInlineMergeabilityPend
 		WillReturnRows(pgxmock.NewRows(prTestPullRequestColumns).AddRow(
 			pullRequestID, nil, orgID, 42, "https://github.com/assembledhq/143/pull/42", "assembledhq/143",
 			"Pending mergeability", (*string)(nil), "open", "success", "app", "", &headSHA, &baseSHA, nil,
-			models.PullRequestMergeStateMergeabilityPending, false, 0, false, &now, int64(1), (*time.Time)(nil), now, now,
+			models.PullRequestMergeStateMergeabilityPending, false, 0, false, &now, int64(1), models.PullRequestMergeWhenReadyStateOff, (*uuid.UUID)(nil), (*time.Time)(nil), "", (*int64)(nil), "", (*time.Time)(nil), (*time.Time)(nil), now, now,
 		))
 	mock.ExpectQuery("SELECT .+ FROM pull_request_health_current WHERE org_id = .+ AND pull_request_id = .+").
 		WithArgs(pgx.NamedArgs{"org_id": orgID, "pull_request_id": pullRequestID}).
@@ -702,7 +702,7 @@ func TestPRServiceSyncPullRequestState(t *testing.T) {
 		WillReturnRows(pgxmock.NewRows(prTestPullRequestColumns).AddRow(
 			pullRequestID, nil, orgID, 42, "https://github.com/assembledhq/143/pull/42", "assembledhq/143",
 			"Fix bug", (*string)(nil), "open", "pending", "app", "", nil, nil, nil,
-			models.PullRequestMergeStateUnknown, false, 0, false, (*time.Time)(nil), int64(0), (*time.Time)(nil), now, now,
+			models.PullRequestMergeStateUnknown, false, 0, false, (*time.Time)(nil), int64(0), models.PullRequestMergeWhenReadyStateOff, (*uuid.UUID)(nil), (*time.Time)(nil), "", (*int64)(nil), "", (*time.Time)(nil), (*time.Time)(nil), now, now,
 		))
 	mock.ExpectQuery("SELECT .+ FROM repositories WHERE org_id = .+ AND full_name = .+ AND status = 'active'").
 		WithArgs(pgx.NamedArgs{"org_id": orgID, "full_name": "assembledhq/143"}).
@@ -812,7 +812,7 @@ func TestPRServiceSyncPullRequestStateSelfHealsMergedDrift(t *testing.T) {
 		WillReturnRows(pgxmock.NewRows(prTestPullRequestColumns).AddRow(
 			pullRequestID, (*uuid.UUID)(nil), orgID, 42, "https://github.com/assembledhq/143/pull/42", "assembledhq/143",
 			"Fix bug", (*string)(nil), "open", "pending", "app", "", nil, nil, nil,
-			models.PullRequestMergeStateUnknown, false, 0, false, (*time.Time)(nil), int64(0), (*time.Time)(nil), now, now,
+			models.PullRequestMergeStateUnknown, false, 0, false, (*time.Time)(nil), int64(0), models.PullRequestMergeWhenReadyStateOff, (*uuid.UUID)(nil), (*time.Time)(nil), "", (*int64)(nil), "", (*time.Time)(nil), (*time.Time)(nil), now, now,
 		))
 	mock.ExpectQuery("SELECT .+ FROM repositories WHERE org_id = .+ AND full_name = .+ AND status = 'active'").
 		WithArgs(pgx.NamedArgs{"org_id": orgID, "full_name": "assembledhq/143"}).
@@ -876,7 +876,7 @@ func TestPRServiceSyncPullRequestStateSelfHealsClosedWithoutMergeDrift(t *testin
 		WillReturnRows(pgxmock.NewRows(prTestPullRequestColumns).AddRow(
 			pullRequestID, (*uuid.UUID)(nil), orgID, 42, "https://github.com/assembledhq/143/pull/42", "assembledhq/143",
 			"Fix bug", (*string)(nil), "open", "pending", "app", "", nil, nil, nil,
-			models.PullRequestMergeStateUnknown, false, 0, false, (*time.Time)(nil), int64(0), (*time.Time)(nil), now, now,
+			models.PullRequestMergeStateUnknown, false, 0, false, (*time.Time)(nil), int64(0), models.PullRequestMergeWhenReadyStateOff, (*uuid.UUID)(nil), (*time.Time)(nil), "", (*int64)(nil), "", (*time.Time)(nil), (*time.Time)(nil), now, now,
 		))
 	mock.ExpectQuery("SELECT .+ FROM repositories WHERE org_id = .+ AND full_name = .+ AND status = 'active'").
 		WithArgs(pgx.NamedArgs{"org_id": orgID, "full_name": "assembledhq/143"}).
@@ -948,7 +948,7 @@ func TestPRServiceSyncPullRequestStateSkipsIndeterminateMergeRegression(t *testi
 		WillReturnRows(pgxmock.NewRows(prTestPullRequestColumns).AddRow(
 			pullRequestID, nil, orgID, 42, "https://github.com/assembledhq/143/pull/42", "assembledhq/143",
 			"Flaky PR", (*string)(nil), "open", "pending", "app", "", nil, nil, nil,
-			models.PullRequestMergeStateConflicted, true, 0, true, (*time.Time)(nil), int64(3), &now, now, now,
+			models.PullRequestMergeStateConflicted, true, 0, true, (*time.Time)(nil), int64(3), models.PullRequestMergeWhenReadyStateOff, (*uuid.UUID)(nil), (*time.Time)(nil), "", (*int64)(nil), "", (*time.Time)(nil), &now, now, now,
 		))
 	mock.ExpectQuery("SELECT .+ FROM repositories WHERE org_id = .+ AND full_name = .+ AND status = 'active'").
 		WithArgs(pgx.NamedArgs{"org_id": orgID, "full_name": "assembledhq/143"}).
@@ -1006,7 +1006,7 @@ func TestPRServiceSyncPullRequestStatePersistsMergeabilityPendingAndRequestsRetr
 		WillReturnRows(pgxmock.NewRows(prTestPullRequestColumns).AddRow(
 			pullRequestID, nil, orgID, 42, "https://github.com/assembledhq/143/pull/42", "assembledhq/143",
 			"Pending mergeability", (*string)(nil), "open", "pending", "app", "", nil, nil, nil,
-			models.PullRequestMergeStateUnknown, false, 0, false, (*time.Time)(nil), int64(0), (*time.Time)(nil), now, now,
+			models.PullRequestMergeStateUnknown, false, 0, false, (*time.Time)(nil), int64(0), models.PullRequestMergeWhenReadyStateOff, (*uuid.UUID)(nil), (*time.Time)(nil), "", (*int64)(nil), "", (*time.Time)(nil), (*time.Time)(nil), now, now,
 		))
 	mock.ExpectQuery("SELECT .+ FROM repositories WHERE org_id = .+ AND full_name = .+ AND status = 'active'").
 		WithArgs(pgx.NamedArgs{"org_id": orgID, "full_name": "assembledhq/143"}).
@@ -1128,7 +1128,7 @@ func TestPRServiceSyncPullRequestStateSkipsIndeterminateTestRegression(t *testin
 		WillReturnRows(pgxmock.NewRows(prTestPullRequestColumns).AddRow(
 			pullRequestID, nil, orgID, 42, "https://github.com/assembledhq/143/pull/42", "assembledhq/143",
 			"Tests rerun", (*string)(nil), "open", "pending", "app", "", nil, nil, nil,
-			models.PullRequestMergeStateClean, false, 2, true, (*time.Time)(nil), int64(4), &now, now, now,
+			models.PullRequestMergeStateClean, false, 2, true, (*time.Time)(nil), int64(4), models.PullRequestMergeWhenReadyStateOff, (*uuid.UUID)(nil), (*time.Time)(nil), "", (*int64)(nil), "", (*time.Time)(nil), &now, now, now,
 		))
 	mock.ExpectQuery("SELECT .+ FROM repositories WHERE org_id = .+ AND full_name = .+ AND status = 'active'").
 		WithArgs(pgx.NamedArgs{"org_id": orgID, "full_name": "assembledhq/143"}).
@@ -1188,7 +1188,7 @@ func TestPRServiceEnrichPullRequestHealth(t *testing.T) {
 		WillReturnRows(pgxmock.NewRows(prTestPullRequestColumns).AddRow(
 			pullRequestID, nil, orgID, 42, "https://github.com/assembledhq/143/pull/42", "assembledhq/143",
 			"Fix bug", (*string)(nil), "open", "pending", "app", "", nil, nil, nil,
-			models.PullRequestMergeStateUnknown, false, 1, true, (*time.Time)(nil), int64(5), (*time.Time)(nil), now, now,
+			models.PullRequestMergeStateUnknown, false, 1, true, (*time.Time)(nil), int64(5), models.PullRequestMergeWhenReadyStateOff, (*uuid.UUID)(nil), (*time.Time)(nil), "", (*int64)(nil), "", (*time.Time)(nil), (*time.Time)(nil), now, now,
 		))
 	mock.ExpectQuery("SELECT .+ FROM repositories WHERE org_id = .+ AND full_name = .+ AND status = 'active'").
 		WithArgs(pgx.NamedArgs{"org_id": orgID, "full_name": "assembledhq/143"}).
@@ -1260,7 +1260,7 @@ func TestPRServiceStartPullRequestRepairReusesExistingRun(t *testing.T) {
 		WillReturnRows(pgxmock.NewRows(prTestPullRequestColumns).AddRow(
 			pullRequestID, nil, orgID, 42, "https://github.com/assembledhq/143/pull/42", "assembledhq/143",
 			"Fix bug", (*string)(nil), "open", "pending", "app", "", nil, nil, nil,
-			models.PullRequestMergeStateUnknown, false, 0, false, &now, int64(5), (*time.Time)(nil), now, now,
+			models.PullRequestMergeStateUnknown, false, 0, false, &now, int64(5), models.PullRequestMergeWhenReadyStateOff, (*uuid.UUID)(nil), (*time.Time)(nil), "", (*int64)(nil), "", (*time.Time)(nil), (*time.Time)(nil), now, now,
 		))
 	mock.ExpectQuery("SELECT .+ FROM pull_request_health_current WHERE org_id = .+ AND pull_request_id = .+").
 		WithArgs(pgx.NamedArgs{"org_id": orgID, "pull_request_id": pullRequestID}).
@@ -1718,14 +1718,14 @@ func TestPRServiceGetPullRequestHealthInlineSyncAndStartRepairErrors(t *testing.
 			WillReturnRows(pgxmock.NewRows(prTestPullRequestColumns).AddRow(
 				pullRequestID, nil, orgID, 42, "https://github.com/assembledhq/143/pull/42", "assembledhq/143",
 				"Fix bug", (*string)(nil), "open", "pending", "app", "", nil, nil, nil,
-				models.PullRequestMergeStateUnknown, false, 0, false, (*time.Time)(nil), int64(0), (*time.Time)(nil), now, now,
+				models.PullRequestMergeStateUnknown, false, 0, false, (*time.Time)(nil), int64(0), models.PullRequestMergeWhenReadyStateOff, (*uuid.UUID)(nil), (*time.Time)(nil), "", (*int64)(nil), "", (*time.Time)(nil), (*time.Time)(nil), now, now,
 			))
 		mock.ExpectQuery("SELECT .+ FROM pull_requests WHERE id").
 			WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
 			WillReturnRows(pgxmock.NewRows(prTestPullRequestColumns).AddRow(
 				pullRequestID, nil, orgID, 42, "https://github.com/assembledhq/143/pull/42", "assembledhq/143",
 				"Fix bug", (*string)(nil), "open", "pending", "app", "", nil, nil, nil,
-				models.PullRequestMergeStateUnknown, false, 0, false, (*time.Time)(nil), int64(0), (*time.Time)(nil), now, now,
+				models.PullRequestMergeStateUnknown, false, 0, false, (*time.Time)(nil), int64(0), models.PullRequestMergeWhenReadyStateOff, (*uuid.UUID)(nil), (*time.Time)(nil), "", (*int64)(nil), "", (*time.Time)(nil), (*time.Time)(nil), now, now,
 			))
 		mock.ExpectQuery("SELECT .+ FROM repositories WHERE org_id = .+ AND full_name = .+ AND status = 'active'").
 			WithArgs(pgx.NamedArgs{"org_id": orgID, "full_name": "assembledhq/143"}).
@@ -1790,7 +1790,7 @@ func TestPRServiceGetPullRequestHealthInlineSyncAndStartRepairErrors(t *testing.
 			WillReturnRows(pgxmock.NewRows(prTestPullRequestColumns).AddRow(
 				pullRequestID, nil, orgID, 42, "https://github.com/assembledhq/143/pull/42", "assembledhq/143",
 				"Fix bug", (*string)(nil), "open", "pending", "app", "", strPtr("head-inline"), nil, strPtr("base-inline"),
-				models.PullRequestMergeStateConflicted, true, 1, true, &now, int64(1), (*time.Time)(nil), now, now,
+				models.PullRequestMergeStateConflicted, true, 1, true, &now, int64(1), models.PullRequestMergeWhenReadyStateOff, (*uuid.UUID)(nil), (*time.Time)(nil), "", (*int64)(nil), "", (*time.Time)(nil), (*time.Time)(nil), now, now,
 			))
 		mock.ExpectQuery("SELECT .+ FROM pull_request_health_current WHERE org_id = .+ AND pull_request_id = .+").
 			WithArgs(pgx.NamedArgs{"org_id": orgID, "pull_request_id": pullRequestID}).
@@ -1840,7 +1840,7 @@ func TestPRServiceGetPullRequestHealthInlineSyncAndStartRepairErrors(t *testing.
 			WillReturnRows(pgxmock.NewRows(prTestPullRequestColumns).AddRow(
 				pullRequestID, nil, orgID, 42, "https://github.com/assembledhq/143/pull/42", "assembledhq/143",
 				"Fix bug", (*string)(nil), "closed", "pending", "app", "", nil, nil, nil,
-				models.PullRequestMergeStateUnknown, false, 0, false, &now, int64(1), (*time.Time)(nil), now, now,
+				models.PullRequestMergeStateUnknown, false, 0, false, &now, int64(1), models.PullRequestMergeWhenReadyStateOff, (*uuid.UUID)(nil), (*time.Time)(nil), "", (*int64)(nil), "", (*time.Time)(nil), (*time.Time)(nil), now, now,
 			))
 		mock.ExpectQuery("SELECT .+ FROM pull_request_health_current WHERE org_id = .+ AND pull_request_id = .+").
 			WithArgs(pgx.NamedArgs{"org_id": orgID, "pull_request_id": pullRequestID}).
@@ -1874,7 +1874,7 @@ func TestPRServiceGetPullRequestHealthInlineSyncAndStartRepairErrors(t *testing.
 			WillReturnRows(pgxmock.NewRows(prTestPullRequestColumns).AddRow(
 				pullRequestID, nil, orgID, 42, "https://github.com/assembledhq/143/pull/42", "assembledhq/143",
 				"Fix bug", (*string)(nil), "open", "pending", "app", "", nil, nil, nil,
-				models.PullRequestMergeStateUnknown, false, 0, false, &now, int64(5), (*time.Time)(nil), now, now,
+				models.PullRequestMergeStateUnknown, false, 0, false, &now, int64(5), models.PullRequestMergeWhenReadyStateOff, (*uuid.UUID)(nil), (*time.Time)(nil), "", (*int64)(nil), "", (*time.Time)(nil), (*time.Time)(nil), now, now,
 			))
 		mock.ExpectQuery("SELECT .+ FROM pull_request_health_current WHERE org_id = .+ AND pull_request_id = .+").
 			WithArgs(pgx.NamedArgs{"org_id": orgID, "pull_request_id": pullRequestID}).
@@ -1923,18 +1923,21 @@ func TestPRServiceReconcileAndRepairBranchCoverage(t *testing.T) {
 			WillReturnRows(pgxmock.NewRows(prTestPullRequestColumns).AddRow(
 				prID, nil, orgID, 42, "https://github.com/assembledhq/143/pull/42", "assembledhq/143",
 				"Fix bug", (*string)(nil), "open", "pending", "app", "", nil, nil, nil,
-				models.PullRequestMergeStateUnknown, false, 0, false, &now, int64(1), (*time.Time)(nil), now, now,
+				models.PullRequestMergeStateUnknown, false, 0, false, &now, int64(1), models.PullRequestMergeWhenReadyStateOff, (*uuid.UUID)(nil), (*time.Time)(nil), "", (*int64)(nil), "", (*time.Time)(nil), (*time.Time)(nil), now, now,
 			))
 		mock.ExpectQuery("SELECT .+ FROM pull_requests WHERE id").
 			WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
 			WillReturnRows(pgxmock.NewRows(prTestPullRequestColumns).AddRow(
 				prID, nil, orgID, 42, "https://github.com/assembledhq/143/pull/42", "assembledhq/143",
 				"Fix bug", (*string)(nil), "open", "pending", "app", "", nil, nil, nil,
-				models.PullRequestMergeStateUnknown, false, 0, false, &now, int64(1), (*time.Time)(nil), now, now,
+				models.PullRequestMergeStateUnknown, false, 0, false, &now, int64(1), models.PullRequestMergeWhenReadyStateOff, (*uuid.UUID)(nil), (*time.Time)(nil), "", (*int64)(nil), "", (*time.Time)(nil), (*time.Time)(nil), now, now,
 			))
 		mock.ExpectQuery("SELECT .+ FROM repositories WHERE org_id = .+ AND full_name = .+ AND status = 'active'").
 			WithArgs(pgx.NamedArgs{"org_id": orgID, "full_name": "assembledhq/143"}).
 			WillReturnError(errors.New("repo failed"))
+		mock.ExpectQuery("SELECT .+ FROM pull_requests[\\s\\S]*merge_when_ready_state = 'queued'[\\s\\S]*merge_when_ready_state = 'merging'").
+			WithArgs(pgx.NamedArgs{"org_id": orgID, "stale_before": pgxmock.AnyArg(), "limit": 10}).
+			WillReturnRows(pgxmock.NewRows(prTestPullRequestColumns))
 
 		err = service.ReconcilePullRequestState(context.Background(), orgID, 10)
 		require.NoError(t, err, "ReconcilePullRequestState should continue when individual PR syncs fail")
@@ -1990,7 +1993,7 @@ func TestPRServiceReconcileAndRepairBranchCoverage(t *testing.T) {
 					WillReturnRows(pgxmock.NewRows(prTestPullRequestColumns).AddRow(
 						pullRequestID, nil, orgID, 42, "https://github.com/assembledhq/143/pull/42", "assembledhq/143",
 						"Fix bug", (*string)(nil), "open", "pending", "app", "", nil, nil, nil,
-						models.PullRequestMergeStateUnknown, false, 0, false, &now, int64(5), (*time.Time)(nil), now, now,
+						models.PullRequestMergeStateUnknown, false, 0, false, &now, int64(5), models.PullRequestMergeWhenReadyStateOff, (*uuid.UUID)(nil), (*time.Time)(nil), "", (*int64)(nil), "", (*time.Time)(nil), (*time.Time)(nil), now, now,
 					))
 				mock.ExpectQuery("SELECT .+ FROM pull_request_health_current WHERE org_id = .+ AND pull_request_id = .+").
 					WithArgs(pgx.NamedArgs{"org_id": orgID, "pull_request_id": pullRequestID}).

--- a/internal/services/github/pr_merge.go
+++ b/internal/services/github/pr_merge.go
@@ -17,6 +17,10 @@ import (
 // this to HTTP 409 so the UI can refresh its view of PR health.
 var ErrPullRequestNotMergeable = errors.New("pull request is not in a mergeable state")
 
+// ErrPullRequestHeadChanged is returned when an automated merge was scoped to
+// an earlier PR head SHA and the final pre-merge sync observes a different SHA.
+var ErrPullRequestHeadChanged = errors.New("pull request head changed")
+
 // ErrNoMergeMethodAllowed is returned when the repository has all merge
 // methods disabled — a misconfiguration the user must fix on GitHub.
 var ErrNoMergeMethodAllowed = errors.New("no merge method is allowed on this repository")
@@ -62,6 +66,10 @@ type gitHubMergeResponse struct {
 // Auth follows the same precedence as PR creation: user token when available
 // and accessible, app installation token otherwise.
 func (s *PRService) MergePullRequest(ctx context.Context, orgID, pullRequestID, userID uuid.UUID) (*models.PullRequestMergeResponse, error) {
+	return s.mergePullRequest(ctx, orgID, pullRequestID, userID, nil)
+}
+
+func (s *PRService) mergePullRequest(ctx context.Context, orgID, pullRequestID, userID uuid.UUID, expectedHeadSHA *string) (*models.PullRequestMergeResponse, error) {
 	pr, err := s.pullRequests.GetByID(ctx, orgID, pullRequestID)
 	if err != nil {
 		return nil, fmt.Errorf("load pull request: %w", err)
@@ -103,6 +111,9 @@ func (s *PRService) MergePullRequest(ctx context.Context, orgID, pullRequestID, 
 			Str("repo", pr.GitHubRepo).
 			Msg("pull request health reports CanMerge=true but is missing head SHA; refusing to merge without race-protection guard")
 		return nil, fmt.Errorf("%w: pull request health is missing head SHA", ErrPullRequestNotMergeable)
+	}
+	if err := validateExpectedMergeHead(health.HeadSHA, expectedHeadSHA); err != nil {
+		return nil, err
 	}
 
 	repo, err := s.repos.GetByFullName(ctx, orgID, pr.GitHubRepo)
@@ -202,6 +213,13 @@ func (s *PRService) MergePullRequest(ctx context.Context, orgID, pullRequestID, 
 		Message:     mergeResp.Message,
 		MergeMethod: method,
 	}, nil
+}
+
+func validateExpectedMergeHead(currentHeadSHA string, expectedHeadSHA *string) error {
+	if expectedHeadSHA == nil || *expectedHeadSHA == "" || currentHeadSHA == *expectedHeadSHA {
+		return nil
+	}
+	return fmt.Errorf("%w: expected %s, got %s", ErrPullRequestHeadChanged, *expectedHeadSHA, currentHeadSHA)
 }
 
 // selectMergeMethod picks a merge method honoring the repository's allow_*

--- a/internal/services/github/pr_merge_test.go
+++ b/internal/services/github/pr_merge_test.go
@@ -171,6 +171,36 @@ func TestMergePullRequestOnGitHubRejectsMalformedJSON(t *testing.T) {
 	require.Contains(t, err.Error(), "decode GitHub merge response", "mergePullRequestOnGitHub should wrap decode failures")
 }
 
+func TestValidateExpectedMergeHead(t *testing.T) {
+	t.Parallel()
+
+	expected := "queued-head"
+	tests := []struct {
+		name        string
+		currentHead string
+		expected    *string
+		expectErr   bool
+	}{
+		{name: "allows matching expected head", currentHead: "queued-head", expected: &expected},
+		{name: "allows direct merge without expected head", currentHead: "new-head", expected: nil},
+		{name: "allows empty expected head", currentHead: "new-head", expected: ptrString("")},
+		{name: "rejects changed head", currentHead: "new-head", expected: &expected, expectErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := validateExpectedMergeHead(tt.currentHead, tt.expected)
+			if tt.expectErr {
+				require.ErrorIs(t, err, ErrPullRequestHeadChanged, "validateExpectedMergeHead should reject a changed queued head")
+				return
+			}
+			require.NoError(t, err, "validateExpectedMergeHead should allow safe head states")
+		})
+	}
+}
+
 // TestGitHubAPIErrorMessage covers the Message() helper, which the HTTP
 // handler relies on to surface a useful message in the toast.
 func TestGitHubAPIErrorMessage(t *testing.T) {
@@ -311,14 +341,14 @@ func TestPRServiceMergePullRequestRunsMergedFollowUps(t *testing.T) {
 		WillReturnRows(pgxmock.NewRows(prTestPullRequestColumns).AddRow(
 			prID, &sessionID, orgID, 42, "https://github.com/assembledhq/143/pull/42", "assembledhq/143",
 			"Fix bug", (*string)(nil), "open", "pending", "app", "", nil, nil, nil,
-			models.PullRequestMergeStateUnknown, false, 0, false, (*time.Time)(nil), int64(0), (*time.Time)(nil), now, now,
+			models.PullRequestMergeStateUnknown, false, 0, false, (*time.Time)(nil), int64(0), models.PullRequestMergeWhenReadyStateOff, (*uuid.UUID)(nil), (*time.Time)(nil), "", (*int64)(nil), "", (*time.Time)(nil), (*time.Time)(nil), now, now,
 		))
 	prMock.ExpectQuery("SELECT .+ FROM pull_requests WHERE id").
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
 		WillReturnRows(pgxmock.NewRows(prTestPullRequestColumns).AddRow(
 			prID, &sessionID, orgID, 42, "https://github.com/assembledhq/143/pull/42", "assembledhq/143",
 			"Fix bug", (*string)(nil), "open", "pending", "app", "", nil, nil, nil,
-			models.PullRequestMergeStateUnknown, false, 0, false, (*time.Time)(nil), int64(0), (*time.Time)(nil), now, now,
+			models.PullRequestMergeStateUnknown, false, 0, false, (*time.Time)(nil), int64(0), models.PullRequestMergeWhenReadyStateOff, (*uuid.UUID)(nil), (*time.Time)(nil), "", (*int64)(nil), "", (*time.Time)(nil), (*time.Time)(nil), now, now,
 		))
 
 	repoMock.ExpectQuery("SELECT .+ FROM repositories WHERE org_id = .+ AND full_name = .+ AND status = 'active'").
@@ -386,7 +416,7 @@ func TestPRServiceMergePullRequestRunsMergedFollowUps(t *testing.T) {
 		WillReturnRows(pgxmock.NewRows(prTestPullRequestColumns).AddRow(
 			prID, &sessionID, orgID, 42, "https://github.com/assembledhq/143/pull/42", "assembledhq/143",
 			"Fix bug", (*string)(nil), "open", "pending", "app", "success", &headSHA, nil, &baseSHA,
-			models.PullRequestMergeStateClean, false, 0, false, &now, int64(1), (*time.Time)(nil), now, now,
+			models.PullRequestMergeStateClean, false, 0, false, &now, int64(1), models.PullRequestMergeWhenReadyStateOff, (*uuid.UUID)(nil), (*time.Time)(nil), "", (*int64)(nil), "", (*time.Time)(nil), (*time.Time)(nil), now, now,
 		))
 	prMock.ExpectQuery("SELECT .+ FROM pull_request_health_current").
 		WithArgs(pgx.NamedArgs{"org_id": orgID, "pull_request_id": prID}).

--- a/internal/services/github/pr_merge_when_ready.go
+++ b/internal/services/github/pr_merge_when_ready.go
@@ -1,0 +1,239 @@
+package github
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/assembledhq/143/internal/models"
+)
+
+var (
+	ErrPullRequestMergeWhenReadyNotQueueable = errors.New("pull request cannot be queued for merge when ready")
+	ErrPullRequestMergeWhenReadyInProgress   = errors.New("pull request merge when ready is already in progress")
+)
+
+const mergeWhenReadyMergingStaleAfter = 15 * time.Minute
+
+func (s *PRService) QueueMergeWhenReady(ctx context.Context, orgID, pullRequestID, userID uuid.UUID) (*models.PullRequestMergeWhenReadyStatus, error) {
+	pr, err := s.pullRequests.GetByID(ctx, orgID, pullRequestID)
+	if err != nil {
+		return nil, fmt.Errorf("load pull request: %w", err)
+	}
+	if pr.Status != models.PullRequestStatusOpen {
+		return nil, fmt.Errorf("%w: pull request status is %q", ErrPullRequestMergeWhenReadyNotQueueable, pr.Status)
+	}
+	if pr.MergeWhenReadyState == models.PullRequestMergeWhenReadyStateMerging {
+		return nil, ErrPullRequestMergeWhenReadyInProgress
+	}
+	if pr.MergeWhenReadyState == models.PullRequestMergeWhenReadyStateSucceeded {
+		return nil, fmt.Errorf("%w: pull request already merged", ErrPullRequestMergeWhenReadyNotQueueable)
+	}
+
+	health, err := s.currentMergeWhenReadyHealth(ctx, pr)
+	if err != nil {
+		return nil, err
+	}
+	if reason, queueable := mergeWhenReadyQueueability(health); !queueable {
+		return nil, fmt.Errorf("%w: %s", ErrPullRequestMergeWhenReadyNotQueueable, reason)
+	}
+	if err := s.ensureMergeWhenReadyAuthAvailable(ctx, orgID, pr, userID); err != nil {
+		return nil, err
+	}
+
+	status, err := s.pullRequests.QueueMergeWhenReady(ctx, orgID, pullRequestID, userID, health.HeadSHA, health.HealthVersion)
+	if err != nil {
+		return nil, fmt.Errorf("queue merge when ready: %w", err)
+	}
+
+	pr.MergeWhenReadyState = status.State
+	s.enqueueMergeWhenReadyProcessing(ctx, pr)
+	return &status, nil
+}
+
+func (s *PRService) CancelMergeWhenReady(ctx context.Context, orgID, pullRequestID, userID uuid.UUID) (*models.PullRequestMergeWhenReadyStatus, error) {
+	pr, err := s.pullRequests.GetByID(ctx, orgID, pullRequestID)
+	if err != nil {
+		return nil, fmt.Errorf("load pull request: %w", err)
+	}
+	switch pr.MergeWhenReadyState {
+	case models.PullRequestMergeWhenReadyStateMerging:
+		return nil, ErrPullRequestMergeWhenReadyInProgress
+	case models.PullRequestMergeWhenReadyStateSucceeded:
+		return nil, fmt.Errorf("%w: pull request already merged", ErrPullRequestMergeWhenReadyNotQueueable)
+	case models.PullRequestMergeWhenReadyStateOff:
+		status := mergeWhenReadyStatusFromPullRequest(pr)
+		return &status, nil
+	}
+
+	status, err := s.pullRequests.CancelMergeWhenReady(ctx, orgID, pullRequestID)
+	if err != nil {
+		return nil, fmt.Errorf("cancel merge when ready: %w", err)
+	}
+	return &status, nil
+}
+
+func (s *PRService) ProcessMergeWhenReady(ctx context.Context, orgID, pullRequestID uuid.UUID) error {
+	pr, err := s.pullRequests.GetByID(ctx, orgID, pullRequestID)
+	if err != nil {
+		return fmt.Errorf("load pull request: %w", err)
+	}
+	if pr.MergeWhenReadyState != models.PullRequestMergeWhenReadyStateQueued && !isStaleMergeWhenReadyMerging(pr, time.Now()) {
+		return nil
+	}
+	if pr.Status != models.PullRequestStatusOpen {
+		return s.pullRequests.MarkMergeWhenReadyFailed(ctx, orgID, pullRequestID, "Pull request is no longer open.")
+	}
+
+	if err := s.SyncPullRequestState(ctx, orgID, pullRequestID); err != nil && !errors.Is(err, ErrPullRequestMergeabilityPending) {
+		return fmt.Errorf("sync pull request before merge when ready: %w", err)
+	}
+
+	pr, err = s.pullRequests.GetByID(ctx, orgID, pullRequestID)
+	if err != nil {
+		return fmt.Errorf("reload pull request: %w", err)
+	}
+	if pr.MergeWhenReadyState != models.PullRequestMergeWhenReadyStateQueued && !isStaleMergeWhenReadyMerging(pr, time.Now()) {
+		return nil
+	}
+	health, err := s.buildPullRequestHealthResponse(ctx, pr)
+	if err != nil {
+		return fmt.Errorf("build pull request health: %w", err)
+	}
+	if pr.MergeWhenReadyHeadSHA != "" && health.HeadSHA != "" && pr.MergeWhenReadyHeadSHA != health.HeadSHA {
+		return s.pullRequests.MarkMergeWhenReadyFailed(ctx, orgID, pullRequestID, "PR head changed after merge when ready was enabled.")
+	}
+
+	if health.CanMerge {
+		if pr.MergeWhenReadyRequestedBy == nil {
+			return s.pullRequests.MarkMergeWhenReadyFailed(ctx, orgID, pullRequestID, "Merge when ready is missing the requesting user.")
+		}
+		claimed, err := s.pullRequests.ClaimMergeWhenReadyForProcessing(ctx, orgID, pullRequestID, time.Now().Add(-mergeWhenReadyMergingStaleAfter))
+		if err != nil {
+			return fmt.Errorf("mark merge when ready merging: %w", err)
+		}
+		if !claimed {
+			return nil
+		}
+		if _, err := s.mergePullRequest(ctx, orgID, pullRequestID, *pr.MergeWhenReadyRequestedBy, &pr.MergeWhenReadyHeadSHA); err != nil {
+			reason := mergeWhenReadyFailureMessage(err)
+			if markErr := s.pullRequests.MarkMergeWhenReadyFailed(ctx, orgID, pullRequestID, reason); markErr != nil {
+				return fmt.Errorf("merge when ready failed (%s), then marking failed failed: %w", reason, markErr)
+			}
+			return nil
+		}
+		return s.pullRequests.MarkMergeWhenReadySucceeded(ctx, orgID, pullRequestID)
+	}
+
+	if reason, queueable := mergeWhenReadyQueueability(health); !queueable {
+		return s.pullRequests.MarkMergeWhenReadyFailed(ctx, orgID, pullRequestID, reason)
+	}
+	return nil
+}
+
+func (s *PRService) ensureMergeWhenReadyAuthAvailable(ctx context.Context, orgID uuid.UUID, pr models.PullRequest, userID uuid.UUID) error {
+	orgSettings := models.OrgSettings{PRAuthorship: models.PRAuthorshipUserPreferred}
+	if s.orgs != nil {
+		org, err := s.orgs.GetByID(ctx, orgID)
+		if err != nil {
+			return fmt.Errorf("load org settings for merge when ready: %w", err)
+		}
+		parsed, err := models.ParseOrgSettings(org.Settings)
+		if err != nil {
+			return fmt.Errorf("parse org settings for merge when ready: %w", err)
+		}
+		orgSettings = parsed
+	}
+	if orgSettings.PRAuthorship != models.PRAuthorshipUserRequired {
+		return nil
+	}
+
+	repo, err := s.repos.GetByFullName(ctx, orgID, pr.GitHubRepo)
+	if err != nil {
+		return fmt.Errorf("load repository for merge when ready auth: %w", err)
+	}
+	resolverSession := &models.Session{OrgID: orgID, TriggeredByUserID: &userID}
+	if _, err := s.identityResolver().Resolve(ctx, resolverSession, &repo, orgSettings, ""); err != nil {
+		return err
+	}
+	return nil
+}
+
+func mergeWhenReadyStatusFromPullRequest(pr models.PullRequest) models.PullRequestMergeWhenReadyStatus {
+	return models.PullRequestMergeWhenReadyStatus{
+		State:                  pr.MergeWhenReadyState,
+		RequestedByUserID:      pr.MergeWhenReadyRequestedBy,
+		RequestedAt:            pr.MergeWhenReadyRequestedAt,
+		RequestedHeadSHA:       pr.MergeWhenReadyHeadSHA,
+		RequestedHealthVersion: pr.MergeWhenReadyHealthVersion,
+		LastError:              pr.MergeWhenReadyError,
+	}
+}
+
+func isStaleMergeWhenReadyMerging(pr models.PullRequest, now time.Time) bool {
+	return pr.MergeWhenReadyState == models.PullRequestMergeWhenReadyStateMerging &&
+		pr.MergeWhenReadyUpdatedAt != nil &&
+		pr.MergeWhenReadyUpdatedAt.Before(now.Add(-mergeWhenReadyMergingStaleAfter))
+}
+
+func (s *PRService) currentMergeWhenReadyHealth(ctx context.Context, pr models.PullRequest) (*models.PullRequestHealthResponse, error) {
+	if pr.GitHubStateSyncedAt == nil || pr.HealthVersion == 0 {
+		if err := s.SyncPullRequestState(ctx, pr.OrgID, pr.ID); err != nil && !errors.Is(err, ErrPullRequestMergeabilityPending) {
+			return nil, fmt.Errorf("sync pull request before queueing merge when ready: %w", err)
+		}
+		refreshed, err := s.pullRequests.GetByID(ctx, pr.OrgID, pr.ID)
+		if err != nil {
+			return nil, fmt.Errorf("reload pull request after sync: %w", err)
+		}
+		pr = refreshed
+	}
+	health, err := s.buildPullRequestHealthResponse(ctx, pr)
+	if err != nil {
+		return nil, fmt.Errorf("build pull request health: %w", err)
+	}
+	return health, nil
+}
+
+func mergeWhenReadyQueueability(health *models.PullRequestHealthResponse) (string, bool) {
+	if health.Status != models.PullRequestStatusOpen {
+		return "Pull request is no longer open.", false
+	}
+	if health.HeadSHA == "" {
+		return "Pull request head is not known yet.", false
+	}
+	if len(health.ActiveRepairs) > 0 {
+		return "Wait for the active repair session to finish before enabling merge when ready.", false
+	}
+	if health.HasConflicts || health.CanResolveConflicts || health.MergeState == models.PullRequestMergeStateConflicted {
+		return "Resolve conflicts before enabling merge when ready.", false
+	}
+	if health.FailingTestCount > 0 || health.CanFixTests {
+		return "Fix failing checks before enabling merge when ready.", false
+	}
+	for _, check := range health.Checks {
+		if check.Status == models.PullRequestCheckStatusFailed {
+			return "Fix failing checks before enabling merge when ready.", false
+		}
+	}
+	return "", true
+}
+
+func mergeWhenReadyFailureMessage(err error) string {
+	switch {
+	case errors.Is(err, ErrGitHubUserAuthRequired):
+		return "Connect your GitHub account to merge this pull request as yourself."
+	case errors.Is(err, ErrGitHubUserAuthRepoAccessDenied):
+		return "Your GitHub account cannot access this repository for merge."
+	case errors.Is(err, ErrNoMergeMethodAllowed):
+		return "Repository does not allow any merge method."
+	case errors.Is(err, ErrPullRequestNotMergeable):
+		return "Pull request is not in a mergeable state."
+	case errors.Is(err, ErrPullRequestHeadChanged):
+		return "PR head changed after merge when ready was enabled."
+	default:
+		return "Failed to merge pull request."
+	}
+}

--- a/internal/services/github/pr_merge_when_ready_test.go
+++ b/internal/services/github/pr_merge_when_ready_test.go
@@ -1,0 +1,208 @@
+package github
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/pashagolub/pgxmock/v4"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/require"
+
+	"github.com/assembledhq/143/internal/db"
+	"github.com/assembledhq/143/internal/models"
+)
+
+func TestPRServiceCancelMergeWhenReadyOffIsNoop(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "pgxmock pool should initialize")
+	defer mock.Close()
+
+	orgID := uuid.New()
+	prID := uuid.New()
+	now := time.Now().UTC()
+	row := newPRTestRow(prID, nil, orgID, "assembledhq/143", now, nil)
+	row[21] = models.PullRequestMergeWhenReadyStateOff
+
+	mock.ExpectQuery("SELECT .+ FROM pull_requests WHERE id").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(pgxmock.NewRows(prTestPullRequestColumns).AddRow(row...))
+
+	service := &PRService{
+		pullRequests: db.NewPullRequestStore(mock),
+		logger:       zerolog.New(io.Discard),
+	}
+
+	status, err := service.CancelMergeWhenReady(context.Background(), orgID, prID, uuid.New())
+	require.NoError(t, err, "CancelMergeWhenReady should treat off state as a no-op")
+	require.Equal(t, models.PullRequestMergeWhenReadyStateOff, status.State, "CancelMergeWhenReady should preserve off state")
+	require.NoError(t, mock.ExpectationsWereMet(), "cancel off should only load the pull request")
+}
+
+func TestPRServiceProcessMergeWhenReadyRecoversStaleMergingIntent(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "pgxmock pool should initialize")
+	defer mock.Close()
+
+	orgID := uuid.New()
+	prID := uuid.New()
+	userID := uuid.New()
+	now := time.Now().UTC()
+	staleUpdatedAt := now.Add(-mergeWhenReadyMergingStaleAfter - time.Minute)
+	row := newPRTestRow(prID, nil, orgID, "assembledhq/143", now, nil)
+	row[8] = models.PullRequestStatusClosed
+	row[21] = models.PullRequestMergeWhenReadyStateMerging
+	row[22] = &userID
+	row[27] = &staleUpdatedAt
+
+	mock.ExpectQuery("SELECT .+ FROM pull_requests WHERE id").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(pgxmock.NewRows(prTestPullRequestColumns).AddRow(row...))
+	mock.ExpectExec("UPDATE pull_requests[\\s\\S]*merge_when_ready_state = @state[\\s\\S]*merge_when_ready_error = @reason").
+		WithArgs(pgx.NamedArgs{
+			"id":     prID,
+			"org_id": orgID,
+			"state":  models.PullRequestMergeWhenReadyStateFailed,
+			"reason": "Pull request is no longer open.",
+		}).
+		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
+
+	service := &PRService{
+		pullRequests: db.NewPullRequestStore(mock),
+		logger:       zerolog.New(io.Discard),
+	}
+
+	err = service.ProcessMergeWhenReady(context.Background(), orgID, prID)
+	require.NoError(t, err, "ProcessMergeWhenReady should recover stale merging intents instead of leaving them stuck")
+	require.NoError(t, mock.ExpectationsWereMet(), "stale merging recovery should mark closed pull requests failed")
+}
+
+func TestPRServiceQueueMergeWhenReadyPreflightsUserRequiredGitHubAuth(t *testing.T) {
+	t.Parallel()
+
+	prMock, err := pgxmock.NewPool()
+	require.NoError(t, err, "pull request pgxmock pool should initialize")
+	defer prMock.Close()
+	repoMock, err := pgxmock.NewPool()
+	require.NoError(t, err, "repository pgxmock pool should initialize")
+	defer repoMock.Close()
+	orgMock, err := pgxmock.NewPool()
+	require.NoError(t, err, "organization pgxmock pool should initialize")
+	defer orgMock.Close()
+
+	orgID := uuid.New()
+	prID := uuid.New()
+	userID := uuid.New()
+	now := time.Now().UTC()
+	row := newPRTestRow(prID, nil, orgID, "assembledhq/143", now, nil)
+	row[12] = ptrString("head")
+	row[14] = ptrString("base")
+	row[19] = &now
+	row[20] = int64(7)
+
+	summaryJSON, err := json.Marshal(models.PullRequestHealthSummary{
+		MergeState:      models.PullRequestMergeStateBlocked,
+		ChecksConfirmed: true,
+	})
+	require.NoError(t, err, "health summary should marshal")
+
+	prMock.ExpectQuery("SELECT .+ FROM pull_requests WHERE id").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(pgxmock.NewRows(prTestPullRequestColumns).AddRow(row...))
+	prMock.ExpectQuery("SELECT .+ FROM pull_request_health_current WHERE org_id = .+ AND pull_request_id = .+").
+		WithArgs(pgx.NamedArgs{"org_id": orgID, "pull_request_id": prID}).
+		WillReturnRows(pgxmock.NewRows(prHealthCurrentTestColumns).AddRow(
+			prID, orgID, int64(7), "head", "base", summaryJSON, summaryJSON, models.PullRequestHealthEnrichmentStatusNotRequested, nil, now, now,
+		))
+	orgMock.ExpectQuery("SELECT .+ FROM organizations WHERE id = @id").
+		WithArgs(pgx.NamedArgs{"id": orgID}).
+		WillReturnRows(pgxmock.NewRows(prTestOrganizationColumns).AddRow(
+			orgID, "Acme", []byte(`{"pr_authorship":"user_required"}`), now, now,
+		))
+	repoMock.ExpectQuery("SELECT .+ FROM repositories WHERE org_id = .+ AND full_name = .+ AND status = 'active'").
+		WithArgs(pgx.NamedArgs{"org_id": orgID, "full_name": "assembledhq/143"}).
+		WillReturnRows(pgxmock.NewRows(prTestRepoColumns).AddRow(
+			uuid.New(), orgID, uuid.New(), int64(123), "assembledhq/143", "main", false, (*string)(nil), (*string)(nil), "https://github.com/assembledhq/143.git", int64(456), models.RepositoryStatusActive, &now, (*float64)(nil), []byte(`{}`), now, now,
+		))
+
+	service := &PRService{
+		pullRequests: db.NewPullRequestStore(prMock),
+		repos:        db.NewRepositoryStore(repoMock),
+		orgs:         db.NewOrganizationStore(orgMock),
+		logger:       zerolog.New(io.Discard),
+	}
+
+	_, err = service.QueueMergeWhenReady(context.Background(), orgID, prID, userID)
+	require.ErrorIs(t, err, ErrGitHubUserAuthRequired, "QueueMergeWhenReady should reject user-required orgs before creating queued intent")
+	require.NoError(t, prMock.ExpectationsWereMet(), "queue preflight should not write merge_when_ready state without usable user auth")
+	require.NoError(t, repoMock.ExpectationsWereMet(), "queue preflight should load repository for auth resolution")
+	require.NoError(t, orgMock.ExpectationsWereMet(), "queue preflight should load org authorship settings")
+}
+
+func TestPRServiceEnqueueMergeWhenReadyProcessingIncludesStaleMerging(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		state   models.PullRequestMergeWhenReadyState
+		updated *time.Time
+		wantJob bool
+	}{
+		{name: "queued", state: models.PullRequestMergeWhenReadyStateQueued, wantJob: true},
+		{name: "stale merging", state: models.PullRequestMergeWhenReadyStateMerging, updated: timePtr(time.Now().Add(-mergeWhenReadyMergingStaleAfter - time.Minute)), wantJob: true},
+		{name: "fresh merging", state: models.PullRequestMergeWhenReadyStateMerging, updated: timePtr(time.Now()), wantJob: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			mock, err := pgxmock.NewPool()
+			require.NoError(t, err, "pgxmock pool should initialize")
+			defer mock.Close()
+
+			orgID := uuid.New()
+			prID := uuid.New()
+			if tt.wantJob {
+				mock.ExpectQuery("INSERT INTO jobs").
+					WithArgs(pgx.NamedArgs{
+						"org_id":     orgID,
+						"queue":      "default",
+						"job_type":   "merge_pull_request_when_ready",
+						"payload":    pgxmock.AnyArg(),
+						"priority":   7,
+						"dedupe_key": pgxmock.AnyArg(),
+					}).
+					WillReturnRows(pgxmock.NewRows([]string{"id"}).AddRow(uuid.New()))
+			}
+
+			service := &PRService{
+				jobs:   db.NewJobStore(mock),
+				logger: zerolog.New(io.Discard),
+			}
+			service.enqueueMergeWhenReadyProcessing(context.Background(), models.PullRequest{
+				ID:                      prID,
+				OrgID:                   orgID,
+				MergeWhenReadyState:     tt.state,
+				MergeWhenReadyUpdatedAt: tt.updated,
+			})
+			require.NoError(t, mock.ExpectationsWereMet(), "enqueueMergeWhenReadyProcessing should match expected enqueue behavior")
+		})
+	}
+}
+
+func ptrString(v string) *string {
+	return &v
+}
+
+func timePtr(v time.Time) *time.Time {
+	return &v
+}

--- a/internal/services/github/pr_test.go
+++ b/internal/services/github/pr_test.go
@@ -66,7 +66,9 @@ var prTestPullRequestColumns = []string{
 	"id", "session_id", "org_id", "github_pr_number", "github_pr_url", "github_repo",
 	"title", "body", "status", "review_status", "authored_by", "ci_status", "head_sha", "head_ref", "base_sha",
 	"merge_state", "has_conflicts", "failing_test_count", "needs_agent_action", "github_state_synced_at",
-	"health_version", "merged_at", "created_at", "updated_at",
+	"health_version", "merge_when_ready_state", "merge_when_ready_requested_by", "merge_when_ready_requested_at",
+	"merge_when_ready_head_sha", "merge_when_ready_health_version", "merge_when_ready_error",
+	"merge_when_ready_updated_at", "merged_at", "created_at", "updated_at",
 }
 
 var prTestPreviewTargetColumns = []string{
@@ -111,6 +113,13 @@ func newPRTestRowWithTitle(prID uuid.UUID, sessionID *uuid.UUID, orgID uuid.UUID
 		false,
 		nil,
 		int64(0),
+		models.PullRequestMergeWhenReadyStateOff,
+		(*uuid.UUID)(nil),
+		(*time.Time)(nil),
+		"",
+		(*int64)(nil),
+		"",
+		(*time.Time)(nil),
 		(*time.Time)(nil),
 		now,
 		now,

--- a/internal/worker/handlers.go
+++ b/internal/worker/handlers.go
@@ -323,6 +323,7 @@ func RegisterHandlers(w *Worker, stores *Stores, services *Services, retentionCf
 		w.Register("sync_pull_request_state", newSyncPullRequestStateHandler(services, logger))
 		w.Register("reconcile_pull_request_state", newReconcilePullRequestStateHandler(services, logger))
 		w.Register("enrich_pull_request_health", newEnrichPullRequestHealthHandler(services, logger))
+		w.Register("merge_pull_request_when_ready", newMergePullRequestWhenReadyHandler(services, logger))
 		w.Register("analyze_failure", newAnalyzeFailureHandler(stores, services, logger))
 		w.Register("fork_session_thread", newForkSessionThreadHandler(stores, services, logger))
 		w.Register("revert_session_thread", newRevertSessionThreadHandler(stores, services, logger))
@@ -441,6 +442,7 @@ type prCreator interface {
 	SyncPullRequestState(ctx context.Context, orgID, pullRequestID uuid.UUID) error
 	ReconcilePullRequestState(ctx context.Context, orgID uuid.UUID, limit int) error
 	EnrichPullRequestHealth(ctx context.Context, orgID, pullRequestID uuid.UUID, version int64) error
+	ProcessMergeWhenReady(ctx context.Context, orgID, pullRequestID uuid.UUID) error
 	// WaitForPostPRSnapshotUploads blocks until any in-flight post-PR
 	// snapshot uploads (spawned by CreatePR) have either promoted or
 	// cleared their pending_snapshot_key. Called by the server's graceful
@@ -2193,6 +2195,31 @@ func newEnrichPullRequestHealthHandler(services *Services, logger zerolog.Logger
 			Int64("version", input.Version).
 			Msg("starting enrich_pull_request_health job")
 		return services.PR.EnrichPullRequestHealth(ctx, orgID, pullRequestID, input.Version)
+	}
+}
+
+func newMergePullRequestWhenReadyHandler(services *Services, logger zerolog.Logger) JobHandler {
+	return func(ctx context.Context, jobType string, payload json.RawMessage) error {
+		var input struct {
+			OrgID         string `json:"org_id"`
+			PullRequestID string `json:"pull_request_id"`
+		}
+		if err := json.Unmarshal(payload, &input); err != nil {
+			return fmt.Errorf("unmarshal merge_pull_request_when_ready payload: %w", err)
+		}
+		orgID, err := parseOrgID(input.OrgID, ctx)
+		if err != nil {
+			return fmt.Errorf("parse org ID: %w", err)
+		}
+		pullRequestID, err := uuid.Parse(input.PullRequestID)
+		if err != nil {
+			return fmt.Errorf("parse pull request ID: %w", err)
+		}
+		logger.Info().
+			Str("org_id", orgID.String()).
+			Str("pull_request_id", pullRequestID.String()).
+			Msg("starting merge_pull_request_when_ready job")
+		return services.PR.ProcessMergeWhenReady(ctx, orgID, pullRequestID)
 	}
 }
 

--- a/internal/worker/handlers_test.go
+++ b/internal/worker/handlers_test.go
@@ -2017,6 +2017,7 @@ type stubPRService struct {
 	syncPullRequestStateFn    func(context.Context, uuid.UUID, uuid.UUID) error
 	reconcilePullRequestFn    func(context.Context, uuid.UUID, int) error
 	enrichPullRequestHealthFn func(context.Context, uuid.UUID, uuid.UUID, int64) error
+	processMergeWhenReadyFn   func(context.Context, uuid.UUID, uuid.UUID) error
 }
 
 func (s *stubPRService) CreatePR(ctx context.Context, run *models.Session, params ...ghservice.CreatePRParams) (*models.PullRequest, error) {
@@ -2057,6 +2058,13 @@ func (s *stubPRService) ReconcilePullRequestState(ctx context.Context, orgID uui
 func (s *stubPRService) EnrichPullRequestHealth(ctx context.Context, orgID, pullRequestID uuid.UUID, version int64) error {
 	if s.enrichPullRequestHealthFn != nil {
 		return s.enrichPullRequestHealthFn(ctx, orgID, pullRequestID, version)
+	}
+	return nil
+}
+
+func (s *stubPRService) ProcessMergeWhenReady(ctx context.Context, orgID, pullRequestID uuid.UUID) error {
+	if s.processMergeWhenReadyFn != nil {
+		return s.processMergeWhenReadyFn(ctx, orgID, pullRequestID)
 	}
 	return nil
 }
@@ -2490,6 +2498,21 @@ func TestPullRequestHealthJobHandlers(t *testing.T) {
 			},
 			expectErr: "parse pull request ID",
 		},
+		{
+			name:    "merge when ready passes parsed ids",
+			payload: json.RawMessage(`{"org_id":"` + orgID.String() + `","pull_request_id":"` + prID.String() + `"}`),
+			handler: func(services *Services, logger zerolog.Logger) JobHandler {
+				return newMergePullRequestWhenReadyHandler(services, logger)
+			},
+		},
+		{
+			name:    "merge when ready rejects invalid payload",
+			payload: json.RawMessage(`oops`),
+			handler: func(services *Services, logger zerolog.Logger) JobHandler {
+				return newMergePullRequestWhenReadyHandler(services, logger)
+			},
+			expectErr: "unmarshal merge_pull_request_when_ready payload",
+		},
 	}
 
 	for _, tt := range tests {
@@ -2519,6 +2542,12 @@ func TestPullRequestHealthJobHandlers(t *testing.T) {
 						called.version = gotVersion
 						return nil
 					},
+					processMergeWhenReadyFn: func(_ context.Context, gotOrgID, gotPRID uuid.UUID) error {
+						called.mergeWhenReadyCalls++
+						called.orgID = gotOrgID
+						called.prID = gotPRID
+						return nil
+					},
 				},
 			}
 
@@ -2544,6 +2573,10 @@ func TestPullRequestHealthJobHandlers(t *testing.T) {
 				require.Equal(t, orgID, called.orgID, "enrich handler should parse and pass the org ID")
 				require.Equal(t, prID, called.prID, "enrich handler should parse and pass the pull request ID")
 				require.Equal(t, int64(9), called.version, "enrich handler should parse and pass the version")
+			case "merge when ready passes parsed ids":
+				require.Equal(t, 1, called.mergeWhenReadyCalls, "merge-when-ready handler should invoke the PR service once")
+				require.Equal(t, orgID, called.orgID, "merge-when-ready handler should parse and pass the org ID")
+				require.Equal(t, prID, called.prID, "merge-when-ready handler should parse and pass the pull request ID")
 			}
 		})
 	}
@@ -2573,13 +2606,14 @@ func TestSyncPullRequestStateHandlerDefersPendingMergeability(t *testing.T) {
 }
 
 type prHandlerCalls struct {
-	syncCalls      int
-	reconcileCalls int
-	enrichCalls    int
-	orgID          uuid.UUID
-	prID           uuid.UUID
-	limit          int
-	version        int64
+	syncCalls           int
+	reconcileCalls      int
+	enrichCalls         int
+	mergeWhenReadyCalls int
+	orgID               uuid.UUID
+	prID                uuid.UUID
+	limit               int
+	version             int64
 }
 
 func TestOpenPRHandler_SuccessMarksPushingAndSucceeded(t *testing.T) {

--- a/migrations/000157_pull_request_merge_when_ready.down.sql
+++ b/migrations/000157_pull_request_merge_when_ready.down.sql
@@ -1,0 +1,11 @@
+DROP INDEX IF EXISTS idx_pull_requests_merge_when_ready;
+
+ALTER TABLE pull_requests
+    DROP CONSTRAINT IF EXISTS chk_pull_requests_merge_when_ready_state,
+    DROP COLUMN IF EXISTS merge_when_ready_updated_at,
+    DROP COLUMN IF EXISTS merge_when_ready_error,
+    DROP COLUMN IF EXISTS merge_when_ready_health_version,
+    DROP COLUMN IF EXISTS merge_when_ready_head_sha,
+    DROP COLUMN IF EXISTS merge_when_ready_requested_at,
+    DROP COLUMN IF EXISTS merge_when_ready_requested_by,
+    DROP COLUMN IF EXISTS merge_when_ready_state;

--- a/migrations/000157_pull_request_merge_when_ready.up.sql
+++ b/migrations/000157_pull_request_merge_when_ready.up.sql
@@ -1,0 +1,18 @@
+ALTER TABLE pull_requests
+    ADD COLUMN merge_when_ready_state text NOT NULL DEFAULT 'off',
+    ADD COLUMN merge_when_ready_requested_by uuid NULL REFERENCES users(id),
+    ADD COLUMN merge_when_ready_requested_at timestamptz,
+    ADD COLUMN merge_when_ready_head_sha text NOT NULL DEFAULT '',
+    ADD COLUMN merge_when_ready_health_version bigint,
+    ADD COLUMN merge_when_ready_error text NOT NULL DEFAULT '',
+    ADD COLUMN merge_when_ready_updated_at timestamptz;
+
+ALTER TABLE pull_requests
+    ADD CONSTRAINT chk_pull_requests_merge_when_ready_state CHECK (merge_when_ready_state IN (
+        'off', 'queued', 'merging', 'succeeded', 'failed', 'cancelled'
+    )) NOT VALID;
+ALTER TABLE pull_requests VALIDATE CONSTRAINT chk_pull_requests_merge_when_ready_state;
+
+CREATE INDEX idx_pull_requests_merge_when_ready
+    ON pull_requests (org_id, merge_when_ready_state, updated_at)
+    WHERE merge_when_ready_state IN ('queued', 'merging');


### PR DESCRIPTION
## Summary
Adds a “Merge when ready” control to the session PR detail UI and wires it to new backend support for queueing/canceling merge-when-ready. Updates PR health polling to reflect merge-when-ready states and improve handling when GitHub auth is blocked.

## Changes
- **Frontend**
  - `frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx`
    - Added `pendingMergeWhenReady` UI state.
    - Extended PR health polling to refresh during `merge_when_ready` states (`queued`, `merging`) in addition to existing mergeability states.
    - Added `mergeWhenReadyMutation` to call queue/cancel endpoints and provide success/error toasts.
    - Added `handleQueueMergeWhenReady` / `handleCancelMergeWhenReady` handlers, including triggering the existing PR auth prompt when `ghBlocked` is true.
  - `frontend/src/components/pr-health-banner.tsx` (+ related tests)
    - Updated PR health banner to surface merge-when-ready status/actions consistent with the new backend behavior.
- **Backend**
  - `internal/api/handlers/pull_requests.go` (+ tests)
    - Added/extended HTTP handlers for queueing and canceling merge-when-ready.
  - `internal/services/github/pr_merge_when_ready.go` (+ tests)
    - Implemented merge-when-ready logic for efficient backend-driven auto-merge.
    - Added edge-case handling around merge states so the system transitions correctly without relying solely on frontend polling.
  - `internal/services/github/pr_health_service.go` and related model updates
    - Extended PR health data to include `merge_when_ready` state so the frontend can render accurate status.
  - `internal/worker/*`, `internal/cluster/*`, and DB layer updates
    - Ensured workers/scheduler and persistence support the new merge-when-ready workflow.
  - `migrations/000157_pull_request_merge_when_ready.{up,down}.sql`
    - Added required schema for storing merge-when-ready state.
- **Types and test coverage**
  - Updated shared types: `frontend/src/lib/types.ts`
  - Added/updated unit tests across UI components, API handlers, services, and DB stores (e.g., `pr_merge_when_ready_test.go`, `pull_requests_test.go`, `sessions_test.go`, `handlers_test.go`, etc.)

## Test plan
- Ran frontend component/unit tests for PR health banner behavior and action state handling (updated `.test.tsx` files).
- Ran backend unit/integration tests for:
  - merge-when-ready service behavior (`pr_merge_when_ready_test.go`)
  - API handler correctness (`pull_requests_test.go`, `webhooks_test.go`)
  - persistence and edge cases (`internal/db/pull_requests_test.go`)
- Verified the UI refresh behavior by checking that PR health polling continues during `merge_when_ready` transitions (`queued`/`merging`), and that queue/cancel mutations update banner state with appropriate success/error feedback.

[143.dev](https://143.dev) | [session dbcf7780](https://143.dev/sessions/dbcf7780-047c-4b12-b029-48fc6099816d)

Preview: https://143.dev/previews/github/assembledhq/143/pull/1214