### PR TITLE
Cancel runtime policy stops when registry entry is missing

### DIFF
--- a/internal/services/agent/orchestrator.go
+++ b/internal/services/agent/orchestrator.go
@@ -2025,6 +2025,7 @@ func (o *Orchestrator) RunAgent(ctx context.Context, run *models.Session) error 
 	runtimeCfg := o.resolveRuntimeConfig(ctx, run.OrgID)
 	runtimeTracker := newRuntimeProgressTracker(runStartedAt)
 	runtimeController := newRuntimeController(runtimeCfg, o.sessions, o.jobs, o.cancels, log, run.OrgID, run.ID, o.maxConcurrent, o.isDraining, runtimeTracker)
+	runtimeController.SetStopFallback(cancel)
 	if err := o.beginRuntimeControl(ctx, runtimeController, run.OrgID, run.ID, models.SessionStatusPending, checkpointCapabilityForAgent(run.AgentType), runStartedAt, log); err != nil {
 		return err
 	}
@@ -2932,6 +2933,7 @@ func (o *Orchestrator) ContinueSession(ctx context.Context, session *models.Sess
 	runtimeCfg := o.resolveRuntimeConfig(ctx, session.OrgID)
 	runtimeTracker := newRuntimeProgressTracker(turnStartedAt)
 	runtimeController := newRuntimeController(runtimeCfg, o.sessions, o.jobs, o.cancels, log, session.OrgID, session.ID, o.maxConcurrent, o.isDraining, runtimeTracker)
+	runtimeController.SetStopFallback(cancel)
 	fallbackStatus := session.Status
 	if fallbackStatus == "" {
 		fallbackStatus = models.SessionStatusIdle

--- a/internal/services/agent/runtime.go
+++ b/internal/services/agent/runtime.go
@@ -356,6 +356,7 @@ type runtimeController struct {
 	maxConcurrent int
 	isDraining    func() bool
 	tracker       *runtimeProgressTracker
+	stopFallback  context.CancelCauseFunc
 
 	mu            sync.Mutex
 	startedAt     time.Time
@@ -387,6 +388,10 @@ func newRuntimeController(
 		isDraining:    isDraining,
 		tracker:       tracker,
 	}
+}
+
+func (c *runtimeController) SetStopFallback(cancel context.CancelCauseFunc) {
+	c.stopFallback = cancel
 }
 
 func (c *runtimeController) Begin(ctx context.Context, startedAt time.Time, capability models.CheckpointCapability) error {
@@ -425,7 +430,19 @@ func (c *runtimeController) RequestStop(reason StopReason) {
 	c.stopRequested = reason
 	c.mu.Unlock()
 	if c.cancels != nil {
-		c.cancels.RequestStop(c.sessionID, reason, c.cfg.GracefulShutdownWindow)
+		if !c.cancels.RequestStop(c.sessionID, reason, c.cfg.GracefulShutdownWindow) && c.stopFallback != nil {
+			c.logger.Warn().
+				Str("session_id", c.sessionID.String()).
+				Str("stop_reason", string(reason)).
+				Msg("runtime stop requested before cancel registry entry was available; cancelling execution context")
+			c.stopFallback(cancelCauseForStopReason(reason))
+		}
+	} else if c.stopFallback != nil {
+		c.logger.Warn().
+			Str("session_id", c.sessionID.String()).
+			Str("stop_reason", string(reason)).
+			Msg("runtime stop requested without cancel registry; cancelling execution context")
+		c.stopFallback(cancelCauseForStopReason(reason))
 	}
 	runtimeReason := stopReasonToRuntime(reason)
 	if runtimeReason != models.RuntimeStopReasonNone {

--- a/internal/services/agent/runtime_test.go
+++ b/internal/services/agent/runtime_test.go
@@ -465,6 +465,37 @@ func TestRuntimeController_RequestStopCancelsBeforePersistingStopMarker(t *testi
 	require.True(t, sessionStore.stopAfter[0].After(minStopAfter), "stop-after deadline should include graceful shutdown, checkpoint finalization, and watchdog slack")
 }
 
+func TestRuntimeController_RequestStopCancelsFallbackWhenRegistryHasNoEntry(t *testing.T) {
+	t.Parallel()
+
+	orgID := uuid.New()
+	sessionID := uuid.New()
+	sessionStore := &runtimeTestSessionStore{}
+	cancelCtx, cancel := context.WithCancelCause(context.Background())
+	controller := newRuntimeController(
+		runtimeConfig{
+			GracefulShutdownWindow:   time.Second,
+			CheckpointFinalizeWindow: time.Second,
+		},
+		sessionStore,
+		&runtimeTestJobStore{},
+		NewCancelRegistry(zerolog.Nop()),
+		zerolog.Nop(),
+		orgID,
+		sessionID,
+		0,
+		nil,
+		newRuntimeProgressTracker(time.Now()),
+	)
+	controller.SetStopFallback(cancel)
+
+	controller.RequestStop(StopReasonNoProgress)
+
+	require.ErrorIs(t, cancelCtx.Err(), context.Canceled, "RequestStop should cancel the fallback context when no registry entry exists")
+	require.ErrorIs(t, context.Cause(cancelCtx), context.Canceled, "fallback cancellation should use the runtime stop cause")
+	require.Equal(t, []models.RuntimeStopReason{models.RuntimeStopReasonNoProgress}, sessionStore.stopRequests, "RequestStop should still persist the stop reason")
+}
+
 func TestRuntimeController_RequestStopLogsActiveToolSummaries(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- Add a fallback cancel path from the runtime controller to the execution context when a stop is requested before the cancel registry entry exists.
- Wire the fallback into both `RunAgent` and `ContinueSession` so early soft-budget and no-progress stops still unwind the worker.
- Cover the missing-registry edge case with a regression test.

## Testing
- Added a focused unit test for the no-registry fallback path.
- Verified the change locally with Go vet, build, and test passes on the updated `main` base.