### PR TITLE
Quote remote deploy env assignments in deploy.sh

### DIFF
--- a/deploy/scripts/deploy.sh
+++ b/deploy/scripts/deploy.sh
@@ -93,6 +93,19 @@ run_worker_host_reconcile() {
     "sudo -n /opt/143/deploy/scripts/reconcile-worker-host.sh 143-sandbox"
 }
 
+remote_shell_quote() {
+  local value="$1"
+  printf "'"
+  printf '%s' "$value" | sed "s/'/'\\\\''/g"
+  printf "'"
+}
+
+remote_env_assignment() {
+  local key="$1" value="$2"
+  printf '%s=' "$key"
+  remote_shell_quote "$value"
+}
+
 # --- Refresh secrets from .env.production.enc ---
 if [ -z "${SOPS_AGE_KEY:-}" ]; then
   AGE_KEY_FILE="${SOPS_AGE_KEY_FILE:-$HOME/.config/sops/age/keys.txt}"
@@ -465,21 +478,24 @@ else
 fi
 
 ssh "${SSH_OPTS[@]}" deploy@"$HOST" \
-  "COMPOSE_FILE=$COMPOSE_FILE" "HEALTH_SERVICE=$HEALTH_SERVICE" "ROLE=$ROLE" "IMAGE_TAG=$TAG" \
-  "WORKER_DEPLOY_DETACH=${WORKER_DEPLOY_DETACH:-}" \
-  "WORKER_DEPLOY_DRAIN_TIMEOUT_SECONDS=${WORKER_DEPLOY_DRAIN_TIMEOUT_SECONDS:-}" \
-  "WORKER_BLUE_GREEN_PORT_START=${WORKER_BLUE_GREEN_PORT_START:-}" \
-  "WORKER_BLUE_GREEN_PORT_END=${WORKER_BLUE_GREEN_PORT_END:-}" \
-  "WORKER_BASE_NODE_ID=${WORKER_BASE_NODE_ID:-}" \
-  "WORKER_DRAIN_TIMEOUT=${WORKER_DRAIN_TIMEOUT:-}" \
-  "DEPLOY_MODE=${DEPLOY_MODE:-routine}" \
-  "DEPLOY_REQUESTED_BY=${DEPLOY_REQUESTED_BY:-deploy-script}" \
-  "DEPLOY_REASON=${DEPLOY_REASON:-routine worker rollout}" \
-  "FORCE_DEPLOY_WITH_ACTIVE_SESSIONS=${FORCE_DEPLOY_WITH_ACTIVE_SESSIONS:-}" \
-  "SESSION_EXECUTOR_DOCKER_NETWORK=${SESSION_EXECUTOR_DOCKER_NETWORK:-}" \
-  "DEPLOY_DOCKER_PRUNE=${DEPLOY_DOCKER_PRUNE:-1}" \
-  "DOCKER_PRUNE_UNTIL=${DOCKER_PRUNE_UNTIL:-24h}" \
-  "DEPLOY_DOCKER_VOLUME_PRUNE=${DEPLOY_DOCKER_VOLUME_PRUNE:-0}" \
+  "$(remote_env_assignment COMPOSE_FILE "$COMPOSE_FILE")" \
+  "$(remote_env_assignment HEALTH_SERVICE "$HEALTH_SERVICE")" \
+  "$(remote_env_assignment ROLE "$ROLE")" \
+  "$(remote_env_assignment IMAGE_TAG "$TAG")" \
+  "$(remote_env_assignment WORKER_DEPLOY_DETACH "${WORKER_DEPLOY_DETACH:-}")" \
+  "$(remote_env_assignment WORKER_DEPLOY_DRAIN_TIMEOUT_SECONDS "${WORKER_DEPLOY_DRAIN_TIMEOUT_SECONDS:-}")" \
+  "$(remote_env_assignment WORKER_BLUE_GREEN_PORT_START "${WORKER_BLUE_GREEN_PORT_START:-}")" \
+  "$(remote_env_assignment WORKER_BLUE_GREEN_PORT_END "${WORKER_BLUE_GREEN_PORT_END:-}")" \
+  "$(remote_env_assignment WORKER_BASE_NODE_ID "${WORKER_BASE_NODE_ID:-}")" \
+  "$(remote_env_assignment WORKER_DRAIN_TIMEOUT "${WORKER_DRAIN_TIMEOUT:-}")" \
+  "$(remote_env_assignment DEPLOY_MODE "${DEPLOY_MODE:-routine}")" \
+  "$(remote_env_assignment DEPLOY_REQUESTED_BY "${DEPLOY_REQUESTED_BY:-deploy-script}")" \
+  "$(remote_env_assignment DEPLOY_REASON "${DEPLOY_REASON:-routine worker rollout}")" \
+  "$(remote_env_assignment FORCE_DEPLOY_WITH_ACTIVE_SESSIONS "${FORCE_DEPLOY_WITH_ACTIVE_SESSIONS:-}")" \
+  "$(remote_env_assignment SESSION_EXECUTOR_DOCKER_NETWORK "${SESSION_EXECUTOR_DOCKER_NETWORK:-}")" \
+  "$(remote_env_assignment DEPLOY_DOCKER_PRUNE "${DEPLOY_DOCKER_PRUNE:-1}")" \
+  "$(remote_env_assignment DOCKER_PRUNE_UNTIL "${DOCKER_PRUNE_UNTIL:-24h}")" \
+  "$(remote_env_assignment DEPLOY_DOCKER_VOLUME_PRUNE "${DEPLOY_DOCKER_VOLUME_PRUNE:-0}")" \
   bash << 'REMOTE'
   set -euo pipefail
   cd /opt/143

--- a/deploy/scripts/deploy_remote_env_test.sh
+++ b/deploy/scripts/deploy_remote_env_test.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/../.." && pwd)"
+TMP_DIR="$(mktemp -d)"
+trap 'rc=$?; if [ "$rc" -ne 0 ]; then echo "--- deploy output ---" >&2; if [ -n "${OUTPUT_FILE:-}" ]; then cat "$OUTPUT_FILE" >&2 2>/dev/null || true; fi; echo "--- ssh capture ---" >&2; if [ -n "${CAPTURE_FILE:-}" ]; then cat "$CAPTURE_FILE" >&2 2>/dev/null || true; fi; fi; rm -rf "$TMP_DIR"; exit "$rc"' EXIT
+
+STUB_DIR="$TMP_DIR/stubs"
+mkdir -p "$STUB_DIR"
+
+cat >"$STUB_DIR/sops" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "${SOPS_STUB_OUTPUT:-}"
+EOF
+chmod +x "$STUB_DIR/sops"
+
+cat >"$STUB_DIR/scp" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+exit 0
+EOF
+chmod +x "$STUB_DIR/scp"
+
+cat >"$STUB_DIR/ssh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+capture_file="${SSH_CAPTURE_FILE:?}"
+
+{
+  printf 'ARGS:'
+  printf ' %q' "$@"
+  printf '\n'
+} >>"$capture_file"
+
+# Consume stdin for heredoc callers.
+stdin="$(cat)"
+
+remote_start=0
+index=1
+for arg in "$@"; do
+  if [ "$remote_start" -eq 1 ]; then
+    break
+  fi
+  case "$arg" in
+    deploy@*) remote_start=$((index + 1)) ;;
+  esac
+  index=$((index + 1))
+done
+
+if [ "$remote_start" -le "$#" ]; then
+  remote_args=("${@:$remote_start}")
+  if [ "${#remote_args[@]}" -gt 0 ]; then
+    remote_command=""
+    for arg in "${remote_args[@]}"; do
+      if [ -n "$remote_command" ]; then
+        remote_command="$remote_command "
+      fi
+      remote_command="$remote_command$arg"
+    done
+    printf 'REMOTE:%s\n' "$remote_command" >>"$capture_file"
+
+    last_index=$((${#remote_args[@]} - 1))
+    if [ "${remote_args[$last_index]}" = "bash" ]; then
+      probe_command="${remote_command% bash} printf remote-command-ok"
+      bash -c "$probe_command" >/dev/null
+    fi
+  fi
+fi
+
+printf '%s' "$stdin" >/dev/null
+exit 0
+EOF
+chmod +x "$STUB_DIR/ssh"
+
+HOME_DIR="$TMP_DIR/home"
+mkdir -p "$HOME_DIR/.config/sops/age"
+printf 'AGE-SECRET-KEY-test\n' >"$HOME_DIR/.config/sops/age/keys.txt"
+
+CAPTURE_FILE="$TMP_DIR/deploy.capture"
+: >"$CAPTURE_FILE"
+OUTPUT_FILE="$TMP_DIR/deploy.out"
+
+(
+  export HOME="$HOME_DIR"
+  export PATH="$STUB_DIR:$PATH"
+  export SOPS_STUB_OUTPUT=$'DB_PASSWORD=db-secret\nDB_HOST=10.0.0.3\nVICTORIALOGS_HOST=10.0.0.9\nCLOUDFLARE_API_TOKEN=cf-secret'
+  export SSH_CAPTURE_FILE="$CAPTURE_FILE"
+  export DB_PASSWORD="db-secret"
+  export DB_HOST="10.0.0.3"
+  export VICTORIALOGS_HOST="10.0.0.9"
+  export CLOUDFLARE_API_TOKEN="cf-secret"
+  unset DEPLOY_REASON
+
+  bash "$ROOT_DIR/deploy/scripts/deploy.sh" app 127.0.0.1 "$TMP_DIR/fake-key" >"$OUTPUT_FILE" 2>&1
+)
+
+grep -Fq "DEPLOY_REASON=\\'routine\\ worker\\ rollout\\'" "$CAPTURE_FILE"
+grep -q "REMOTE:.*DEPLOY_REASON='routine worker rollout' .* bash" "$CAPTURE_FILE"
+
+printf 'deploy remote env quoting test passed\n'


### PR DESCRIPTION
## Summary
- Fixed the deploy SSH command so remote environment assignments are shell-quoted before OpenSSH concatenates them.
- This prevents `DEPLOY_REASON=routine worker rollout` from splitting into `worker` as a remote command and breaking deploys.
- Added a regression test that stubs SSH and verifies the generated remote command is safe to execute.

## Testing
- `bash -n deploy/scripts/deploy.sh deploy/scripts/deploy-fleet.sh deploy/scripts/deploy_remote_env_test.sh`
- `bash deploy/scripts/deploy_remote_env_test.sh`
- `bash deploy/scripts/deploy_redis_test.sh`
- `bash deploy/scripts/logging_webhook_optional_test.sh`
- `bash deploy/scripts/worker_buckets_test.sh`
- `bash deploy/scripts/alertmanager_slack_relay_test.sh`
- `git diff --check`