### PR TITLE
Fix PR health “More merge actions” dropdown sizing and alignment

### DIFF
--- a/frontend/src/components/pr-health-banner.test.tsx
+++ b/frontend/src/components/pr-health-banner.test.tsx
@@ -191,6 +191,37 @@ describe("PRHealthBanner", () => {
     expect(onQueue).toHaveBeenCalledTimes(1);
   });
 
+  it("matches the Create PR split button sizing and menu alignment", async () => {
+    renderWithProviders(
+      <PRHealthBanner
+        health={{
+          ...baseHealth,
+          checks: [{ name: "Unit tests", category: "test", status: "pending" }],
+          checks_confirmed: true,
+          can_merge: false,
+        }}
+        pendingAction={null}
+        repairError={null}
+        mergeAuthRequired={false}
+        onFixTests={vi.fn()}
+        onResolveConflicts={vi.fn()}
+        onMerge={vi.fn()}
+        onQueueMergeWhenReady={vi.fn()}
+      />,
+    );
+
+    const moreActions = screen.getByRole("button", { name: "More merge actions" });
+    expect(moreActions).toHaveClass("h-7", "w-7", "rounded-l-none");
+    expect(moreActions).not.toHaveClass("h-9", "w-8");
+
+    await userEvent.setup().click(moreActions);
+    const menuItem = await screen.findByRole("menuitem", { name: "Merge when ready" });
+    expect(menuItem.closest("[data-slot='dropdown-menu-content']")).toHaveAttribute(
+      "data-align",
+      "end",
+    );
+  });
+
   it("shows queued merge when ready state and allows cancelling", async () => {
     const onCancel = vi.fn();
     renderWithProviders(

--- a/frontend/src/components/pr-health-banner.tsx
+++ b/frontend/src/components/pr-health-banner.tsx
@@ -237,7 +237,7 @@ export function PRHealthBanner({
                             <Button
                               size="icon"
                               variant="default"
-                              className="h-9 w-8 rounded-l-none"
+                              className="h-7 w-7 rounded-l-none"
                               disabled={mergeWhenReadyAction.disabled}
                               title={mergeWhenReadyAction.disabledReason ?? "More merge actions"}
                               aria-label="More merge actions"
@@ -249,7 +249,7 @@ export function PRHealthBanner({
                               )}
                             </Button>
                           </DropdownMenuTrigger>
-                          <DropdownMenuContent align="start">
+                          <DropdownMenuContent align="end">
                             <DropdownMenuItem
                               onClick={health.merge_when_ready.state === "queued" ? onCancelMergeWhenReady : onQueueMergeWhenReady}
                               disabled={mergeWhenReadyAction.disabled}


### PR DESCRIPTION
## Summary
This fixes the PR health banner’s “More merge actions” dropdown trigger so it visually matches the Create PR split button and opens with the same right-aligned dropdown behavior. Also added test coverage to prevent regressions in sizing and alignment.

## Changes
- **frontend/src/components/pr-health-banner.tsx**
  - Updated the “More merge actions” icon button classes from `h-9 w-8` to `h-7 w-7` to match the Create PR split button sizing.
  - Changed `<DropdownMenuContent align="start">` to `align="end"` so the dropdown opens like the Create PR/create branch dropdown.
- **frontend/src/components/pr-health-banner.test.tsx**
  - Added a test asserting:
    - The trigger button has `h-7 w-7` (and not the previous sizing classes).
    - The dropdown menu content uses `data-align="end"` when opened.

## Test plan
- `npm test -- pr-health-banner.test.tsx`
- `npm run typecheck`
- `npm run lint`
- `npm run build`

[143.dev](https://143.dev) | [session 22dcde7d](https://143.dev/sessions/22dcde7d-6cfe-4dd3-8d87-9a37c43b7428)

Preview: https://143.dev/previews/github/assembledhq/143/pull/1220