### PR TITLE
Adjust spacing above changed-files summary in FileTree sidebar

### DIFF
--- a/frontend/src/components/code-review/file-tree.test.tsx
+++ b/frontend/src/components/code-review/file-tree.test.tsx
@@ -128,6 +128,15 @@ describe("FileTree", () => {
     expect(screen.getByText("3 files changed")).toBeInTheDocument();
   });
 
+  it("adds top spacing above the changed-files summary in the sidebar", () => {
+    render(
+      <FileTree files={files} activeFileIndex={0} onFileSelect={vi.fn()} />
+    );
+
+    const summary = screen.getByText("3 files changed");
+    expect(summary.parentElement).toHaveClass("pt-3");
+  });
+
   it("calls onFileSelect when a file is clicked", async () => {
     const onFileSelect = vi.fn();
     const user = userEvent.setup();

--- a/frontend/src/components/code-review/file-tree.tsx
+++ b/frontend/src/components/code-review/file-tree.tsx
@@ -262,7 +262,7 @@ export const FileTree = memo(function FileTree({
 
   return (
     <div className="flex flex-col h-full">
-      <div className={cn("px-4 pb-3", variant === "sheet" && "pt-1")}>
+      <div className={cn("px-4 pb-3 pt-3", variant === "sheet" && "pt-1")}>
         <p className="text-xs font-medium text-muted-foreground/70 uppercase tracking-wider mb-2">
           {files.length} files changed
         </p>


### PR DESCRIPTION
## Summary
This updates the spacing for the “X files changed” header in the FileTree sidebar to match the right-panel vertical rhythm. It also preserves the existing mobile/sheet override so layout doesn’t regress in that variant.

## Changes
- **frontend/src/components/code-review/file-tree.tsx**
  - Added `pt-3` to the changed-files summary container (`cn("px-4 pb-3 pt-3", variant === "sheet" && "pt-1")`) to ensure consistent top padding in the standard sidebar.
  - Kept the `variant === "sheet"` behavior intact by retaining the `pt-1` override.
- **frontend/src/components/code-review/file-tree.test.tsx**
  - Added a regression test asserting the “3 files changed” summary’s parent container has `pt-3`.

## Test plan
- `npm test -- file-tree.test.tsx --run`
- `npm run typecheck`
- `npm run lint`
- `npm run build`

[143.dev](https://143.dev) | [session b21d9e09](https://143.dev/sessions/b21d9e09-00f4-470e-991d-667ac8428965)

Preview: https://143.dev/previews/github/assembledhq/143/pull/1222