### PR TITLE
Disable log copy buttons until preview/error logs are loaded or available

### DIFF
--- a/frontend/src/components/preview/preview-panel.test.tsx
+++ b/frontend/src/components/preview/preview-panel.test.tsx
@@ -307,6 +307,11 @@ describe("PreviewPanel component", () => {
 
   it("keeps preview container logs hidden during startup until requested", async () => {
     const user = userEvent.setup();
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, "clipboard", {
+      value: { writeText },
+      configurable: true,
+    });
     mockGet.mockResolvedValue(
       makePreviewStatus({ status: "starting" }, [
         {
@@ -365,6 +370,42 @@ describe("PreviewPanel component", () => {
     );
     expect(screen.getByRole("button", { name: "Hide preview logs" })).toBeInTheDocument();
     expect(mockLogs).toHaveBeenCalledWith("sess-1", { tail: true });
+
+    await user.click(screen.getByRole("button", { name: "Copy preview logs" }));
+
+    expect(writeText).toHaveBeenCalledWith(
+      "[server] running database migrations\n[server] listening on :8080",
+    );
+  });
+
+  it("does not copy preview log loading text before logs load", async () => {
+    const user = userEvent.setup();
+    mockGet.mockResolvedValue(
+      makePreviewStatus({ status: "starting" }, [
+        {
+          id: "svc-1",
+          preview_instance_id: "prev-1",
+          service_name: "server",
+          role: "primary",
+          status: "starting",
+          command: ["go", "run", "."],
+          cwd: "",
+          port: 8080,
+          created_at: "2026-01-01T00:00:00Z",
+        },
+      ]),
+    );
+    mockLogs.mockReturnValue(new Promise(() => {}));
+
+    renderWithProviders(<PreviewPanel {...DEFAULT_PROPS} />);
+
+    await screen.findByText("Preparing preview");
+    await user.click(screen.getByRole("button", { name: "Show preview logs" }));
+
+    expect(screen.getByLabelText("Preview container logs")).toHaveTextContent(
+      "Loading preview logs...",
+    );
+    expect(screen.getByRole("button", { name: "Copy preview logs" })).toBeDisabled();
   });
 
   it("stacks startup phase tiles when the panel becomes narrow", async () => {
@@ -689,6 +730,11 @@ describe("PreviewPanel component", () => {
 
   it("lets users expand full startup logs for a failed preview", async () => {
     const user = userEvent.setup();
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, "clipboard", {
+      value: { writeText },
+      configurable: true,
+    });
     const summary =
       "preview service readiness probe failed: service \"server\" exited before becoming ready; last output: go: downloading google.golang.org/genproto/googleapis/rpc | [143-preview] running migrations... | Failed to create migrator…";
     const fullLog =
@@ -745,6 +791,31 @@ describe("PreviewPanel component", () => {
     expect(startupLogRegion).not.toHaveClass("overflow-hidden");
     expect(screen.getByRole("button", { name: "Show startup summary" })).toBeInTheDocument();
     expect(mockLogs).toHaveBeenCalledWith("sess-1");
+
+    await user.click(screen.getByRole("button", { name: "Copy error log" }));
+
+    expect(writeText).toHaveBeenCalledWith(fullLog);
+  });
+
+  it("does not copy startup error log loading text before logs load", async () => {
+    const user = userEvent.setup();
+    mockGet.mockResolvedValue(
+      makePreviewStatus({
+        status: "failed",
+        error: "preview service readiness probe failed",
+      }),
+    );
+    mockLogs.mockReturnValue(new Promise(() => {}));
+
+    renderWithProviders(<PreviewPanel {...DEFAULT_PROPS} />);
+
+    await screen.findByText("Preview failed to start");
+    await user.click(screen.getByRole("button", { name: "View full error log" }));
+
+    expect(screen.getByLabelText("Preview startup error logs")).toHaveTextContent(
+      "Loading error logs...",
+    );
+    expect(screen.getByRole("button", { name: "Copy error log" })).toBeDisabled();
   });
 
   it("does not show a standalone Failed badge when failure diagnostics are visible", async () => {

--- a/frontend/src/components/preview/preview-panel.tsx
+++ b/frontend/src/components/preview/preview-panel.tsx
@@ -25,6 +25,8 @@ import {
   X,
   ChevronDown,
   MoreHorizontal,
+  Copy,
+  Check,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
@@ -95,6 +97,7 @@ const STARTUP_PHASE_RAIL_STACK_WIDTH = 300;
 const STARTUP_PHASE_RAIL_COMPACT_WIDTH = 420;
 
 type StartupPhaseRailLayout = "default" | "compact" | "stacked";
+type CopiedLogTarget = "preview" | "error";
 
 function getStartupPhaseRailLayout(
   width: number,
@@ -428,10 +431,35 @@ export function PreviewPanel({
   const [mutationError, setMutationError] = useState<string | null>(null);
   const [showFullStartupLogs, setShowFullStartupLogs] = useState(false);
   const [showPreviewRuntimeLogs, setShowPreviewRuntimeLogs] = useState(false);
+  const [copiedLogTarget, setCopiedLogTarget] =
+    useState<CopiedLogTarget | null>(null);
   const [startupPhaseRailLayout, setStartupPhaseRailLayout] =
     useState<StartupPhaseRailLayout>("default");
   const startupErrorLogsId = useId();
   const previewRuntimeLogsId = useId();
+
+  useEffect(() => {
+    if (!copiedLogTarget) return;
+    const timer = window.setTimeout(() => setCopiedLogTarget(null), 2000);
+    return () => window.clearTimeout(timer);
+  }, [copiedLogTarget]);
+
+  const copyLogs = useCallback(
+    (target: CopiedLogTarget, logs: string) => {
+      if (!navigator.clipboard) {
+        console.error("Clipboard API is unavailable.");
+        return;
+      }
+
+      void navigator.clipboard
+        .writeText(logs)
+        .then(() => setCopiedLogTarget(target))
+        .catch((err: unknown) => {
+          console.error("Failed to copy preview logs.", err);
+        });
+    },
+    [],
+  );
 
   // Poll preview status every 3s when active
   const {
@@ -545,6 +573,14 @@ export function PreviewPanel({
     previewLogsQuery.isError,
     previewLogsQuery.isLoading,
   ]);
+  const canCopyPreviewRuntimeLogs =
+    !previewLogsQuery.isLoading &&
+    !previewLogsQuery.isError &&
+    visiblePreviewRuntimeLogs !== "No preview logs have been captured yet.";
+  const canCopyStartupErrorLogs =
+    !previewLogsQuery.isLoading &&
+    !previewLogsQuery.isError &&
+    startupErrorLogs.trim().length > 0;
 
   // Ensure preview
   const startMutation = useMutation({
@@ -1154,6 +1190,24 @@ export function PreviewPanel({
                   )}
                 />
               </Button>
+              {showPreviewRuntimeLogs && (
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon"
+                  className="h-7 w-7 text-muted-foreground hover:text-foreground"
+                  aria-label="Copy preview logs"
+                  title="Copy preview logs"
+                  disabled={!canCopyPreviewRuntimeLogs}
+                  onClick={() => copyLogs("preview", visiblePreviewRuntimeLogs)}
+                >
+                  {copiedLogTarget === "preview" ? (
+                    <Check className="size-3.5 text-emerald-500" aria-hidden="true" />
+                  ) : (
+                    <Copy className="size-3.5" aria-hidden="true" />
+                  )}
+                </Button>
+              )}
             </div>
             {showPreviewRuntimeLogs && (
               <pre
@@ -1223,14 +1277,36 @@ export function PreviewPanel({
 
             {visibleStartupErrorLogs && (
               <div className="border-t border-destructive/10 pt-3">
-                <div className="mb-1.5 flex min-w-0 items-center gap-2">
-                  <span
-                    className="size-1.5 shrink-0 rounded-full bg-destructive"
-                    aria-hidden="true"
-                  />
-                  <div className="truncate text-xs font-medium text-foreground">
-                    {showFullStartupLogs ? "Full error log" : "Startup summary"}
+                <div className="mb-1.5 flex min-w-0 items-center justify-between gap-2">
+                  <div className="flex min-w-0 items-center gap-2">
+                    <span
+                      className="size-1.5 shrink-0 rounded-full bg-destructive"
+                      aria-hidden="true"
+                    />
+                    <div className="truncate text-xs font-medium text-foreground">
+                      {showFullStartupLogs
+                        ? "Full error log"
+                        : "Startup summary"}
+                    </div>
                   </div>
+                  {showFullStartupLogs && (
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="icon"
+                      className="h-7 w-7 shrink-0 text-muted-foreground hover:text-foreground"
+                      aria-label="Copy error log"
+                      title="Copy error log"
+                      disabled={!canCopyStartupErrorLogs}
+                      onClick={() => copyLogs("error", visibleStartupErrorLogs)}
+                    >
+                      {copiedLogTarget === "error" ? (
+                        <Check className="size-3.5 text-emerald-500" aria-hidden="true" />
+                      ) : (
+                        <Copy className="size-3.5" aria-hidden="true" />
+                      )}
+                    </Button>
+                  )}
                 </div>
                 <pre
                   id={startupErrorLogsId}


### PR DESCRIPTION
## Summary
This change prevents users from copying placeholder/loading text in the PreviewPanel. Copy buttons are now disabled while logs are loading, when loading fails, or when there are no captured logs to copy.

## Changes
- **frontend/src/components/preview/preview-panel.tsx**
  - Disable **“Copy preview logs”** while preview logs are loading or unavailable.
  - Disable **“Copy error log”** while error logs are loading/failing or when no captured logs exist.
  - Ensures clipboard writes can only occur once real log content is present (avoids copying `Loading preview logs...`).
- **frontend/src/components/preview/preview-panel.test.tsx**
  - Added regression tests verifying:
    - Preview copy works after logs load successfully.
    - Copy buttons are disabled before preview logs finish loading.
    - Error copy works after full error logs are available.
    - Error copy is disabled before error logs finish loading.

## Test plan
- `npm run typecheck`: passed
- `npm run lint`: passed
- `npm run build`: passed
- Targeted PreviewPanel tests: passed (including the new regression cases)

[143.dev](https://143.dev) | [session 7a447f2e](https://143.dev/sessions/7a447f2e-45dc-4429-8526-5e968d729d93)

Preview: https://143.dev/previews/github/assembledhq/143/pull/1224