### PR TITLE
Remove “Top opportunity” card from Autopilot summary strip

### DIFF
--- a/docs/design/implemented/75-autopilot-issue-and-run-queue.md
+++ b/docs/design/implemented/75-autopilot-issue-and-run-queue.md
@@ -127,7 +127,7 @@ default.
 │ Status: Autopilot mode · analyzed 18m ago · 6 runs active           │
 ├──────────────────────────────────────────────────────────────────────┤
 │ Summary strip:                                                       │
-│ [Top opportunity] [Auto-runnable now] [Needs review] [PRs open]     │
+│ [Auto-runnable now] [Needs review] [Connected work]                 │
 ├──────────────────────────────────────────────────────────────────────┤
 │ Filters: Source | Status | Auto-run state | Repo | Owner | Search   │
 ├──────────────────────────────────────────────────────────────────────┤
@@ -158,19 +158,18 @@ Examples:
 
 ### 2. Summary strip
 
-Use a compact row of 3-4 cards, not a hero.
+Use a compact row of aggregate cards, not a hero. Do not duplicate the top
+ranked issue here; the ranked issue table already carries the opportunity list.
 
 Recommended cards:
 
-- `Top opportunity` — the current highest-ranked issue, with cluster count if
-  related issues contributed to the ranking
 - `Auto-runnable now` — count of issues above the autorun threshold with no
   active run
 - `Needs review` — issues whose latest run is blocked on approval/guidance
-- `PRs open` — issues with a live PR from the latest linked session
+- `Connected work` — active runs plus live PRs from the latest linked sessions
 
-This preserves the "Autopilot has an opinion" feel without making the whole page
-read like a narrative briefing.
+This keeps the page's top summary operational while the ranked table remains the
+place to inspect specific opportunities.
 
 ### 3. Filters and controls
 

--- a/frontend/src/components/autopilot/autopilot-page-content.test.tsx
+++ b/frontend/src/components/autopilot/autopilot-page-content.test.tsx
@@ -84,6 +84,15 @@ vi.mock("@/components/autopilot-proposal-card", () => ({
 }));
 
 describe("AutopilotPageContent", () => {
+  it("shows aggregate summary cards without duplicating the top opportunity", async () => {
+    renderWithProviders(<AutopilotPageContent />);
+
+    expect(await screen.findByText("Auto-runnable now")).toBeInTheDocument();
+    expect(screen.getByText("Needs review")).toBeInTheDocument();
+    expect(screen.getByText("Connected work")).toBeInTheDocument();
+    expect(screen.queryByText("Top opportunity")).not.toBeInTheDocument();
+  });
+
   it("lets the queue table keep normal column widths on mobile", async () => {
     renderWithProviders(<AutopilotPageContent />);
 

--- a/frontend/src/components/autopilot/autopilot-page-content.tsx
+++ b/frontend/src/components/autopilot/autopilot-page-content.tsx
@@ -5,7 +5,7 @@ import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { parseAsString, useQueryState } from "nuqs";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { AlertCircle, ArrowUpRight, CheckCircle2, Clock3, GitPullRequest, Play, RotateCcw, Search, SlidersHorizontal } from "lucide-react";
+import { AlertCircle, ArrowUpRight, Clock3, GitPullRequest, Play, RotateCcw, Search, SlidersHorizontal } from "lucide-react";
 import { PageContainer } from "@/components/page-container";
 import { PageHeader } from "@/components/page-header";
 import { AutopilotConfigFooter } from "./autopilot-config-footer";
@@ -119,7 +119,6 @@ export function AutopilotPageContent() {
 
   const rows = queue?.data ?? [];
   const summary = queue?.meta.summary;
-  const topIssue = rows.find((row) => row.id === summary?.top_issue_id) ?? rows[0];
   const statusLine = buildStatusLine(viewModel.statusLine, summary);
 
   return (
@@ -136,7 +135,7 @@ export function AutopilotPageContent() {
           }
         />
 
-        <SummaryStrip topIssue={topIssue} summary={summary} />
+        <SummaryStrip summary={summary} />
 
         <QueueFilters
           source={source}
@@ -198,14 +197,8 @@ export function AutopilotPageContent() {
   );
 }
 
-function SummaryStrip({ topIssue, summary }: { topIssue?: AutopilotQueueRow; summary?: { autorunnable_count: number; needs_review_count: number; open_pr_count: number; active_run_count: number; ranked_issue_count: number } }) {
+function SummaryStrip({ summary }: { summary?: { autorunnable_count: number; needs_review_count: number; open_pr_count: number; active_run_count: number; ranked_issue_count: number } }) {
   const cards = [
-    {
-      label: "Top opportunity",
-      value: topIssue ? topIssue.title : "None",
-      detail: topIssue ? `${topIssue.low_hanging_fruit.label} fit · ${sourceDisplayText(topIssue)}` : "No ranked issues right now",
-      icon: CheckCircle2,
-    },
     {
       label: "Auto-runnable now",
       value: String(summary?.autorunnable_count ?? 0),
@@ -227,7 +220,7 @@ function SummaryStrip({ topIssue, summary }: { topIssue?: AutopilotQueueRow; sum
   ];
 
   return (
-    <div className="grid gap-3 md:grid-cols-4">
+    <div className="grid gap-3 md:grid-cols-3">
       {cards.map((card) => {
         const Icon = card.icon;
         return (


### PR DESCRIPTION
## Summary
Removed the “Top opportunity” summary card from the Autopilot page. The summary strip now only shows aggregate cards in a 3-column layout to avoid duplicating the ranked opportunity content already present in the table.

## Changes
- **docs/design/implemented/75-autopilot-issue-and-run-queue.md**
  - Updated the summary strip spec to remove `Top opportunity`
  - Added/updated aggregate cards: `Auto-runnable now`, `Needs review`, `Connected work`
- **frontend/src/components/autopilot/autopilot-page-content.tsx**
  - Adjusted the summary strip rendering to show only the aggregate cards (and omit “Top opportunity”)
- **frontend/src/components/autopilot/autopilot-page-content.test.tsx**
  - Added a regression test asserting:
    - `Auto-runnable now`, `Needs review`, and `Connected work` are present
    - `Top opportunity` is not present

## Test plan
- `npm test -- autopilot-page-content.test.tsx`
- `npm run typecheck`
- `npm run lint`
- `npm run build`

[143.dev](https://143.dev) | [session 2561e452](https://143.dev/sessions/2561e452-d6f2-4d42-a7d5-2bc42bbd2d66)

Preview: https://143.dev/previews/github/assembledhq/143/pull/1227