### PR TITLE
Make automation title emoji inline trigger and adjust layout

### DIFF
--- a/frontend/src/app/(dashboard)/automations/[id]/page.test.tsx
+++ b/frontend/src/app/(dashboard)/automations/[id]/page.test.tsx
@@ -116,7 +116,10 @@ describe("AutomationDetailPage", () => {
     await waitFor(() => {
       expect(screen.getByText("Weekly audit")).toBeInTheDocument();
     });
-    expect(screen.getByRole("button", { name: "Change automation emoji" })).toHaveTextContent("🧪");
+    const headerEmoji = screen.getByRole("button", { name: "Change automation emoji" });
+    expect(headerEmoji).toHaveTextContent("🧪");
+    expect(headerEmoji).toHaveClass("h-auto", "p-0", "align-baseline");
+    expect(headerEmoji).not.toHaveClass("size-9");
 
     await userEvent.setup().click(screen.getByRole("button", { name: "Edit" }));
 

--- a/frontend/src/app/(dashboard)/automations/[id]/page.tsx
+++ b/frontend/src/app/(dashboard)/automations/[id]/page.tsx
@@ -651,18 +651,18 @@ export default function AutomationDetailPage() {
         </Sheet>
         <PageHeader
           title={
-            <span className="inline-flex min-w-0 items-center gap-3">
+            <span className="inline-flex min-w-0 items-center gap-2">
               {canManage ? (
                 <AutomationEmojiPicker
                   value={automation.icon_value || "⚙️"}
                   onChange={(iconValue) => iconMutation.mutate(iconValue)}
-                  trigger="icon"
+                  trigger="inline"
                   triggerLabel="Change automation emoji"
                   disabled={iconMutation.isPending}
                 />
               ) : (
                 <span
-                  className="flex h-9 w-9 shrink-0 items-center justify-center rounded-md border border-border bg-card text-lg leading-none"
+                  className="shrink-0 align-baseline text-[0.95em] leading-none"
                   aria-label={`Automation icon for ${automation.name}`}
                 >
                   {automation.icon_value || "⚙️"}

--- a/frontend/src/components/automation-emoji-picker.tsx
+++ b/frontend/src/components/automation-emoji-picker.tsx
@@ -161,7 +161,7 @@ export function AutomationEmojiPicker({
   className?: string;
   open?: boolean;
   onOpenChange?: (open: boolean) => void;
-  trigger?: "select" | "icon";
+  trigger?: "select" | "icon" | "inline";
   triggerLabel?: string;
   disabled?: boolean;
 }) {
@@ -208,7 +208,21 @@ export function AutomationEmojiPicker({
   return (
     <Popover open={pickerOpen} onOpenChange={setPickerOpen}>
       <PopoverTrigger asChild>
-        {trigger === "icon" ? (
+        {trigger === "inline" ? (
+          <Button
+            type="button"
+            variant="ghost"
+            aria-label={triggerLabel}
+            disabled={disabled}
+            className={cn(
+              "h-auto min-h-0 rounded-sm p-0 align-baseline text-[0.95em] font-semibold leading-none hover:bg-transparent hover:text-foreground",
+              "focus-visible:ring-2 focus-visible:ring-ring/40",
+              className,
+            )}
+          >
+            {selected.emoji}
+          </Button>
+        ) : trigger === "icon" ? (
           <Button
             type="button"
             variant="outline"


### PR DESCRIPTION
## Summary
Updated the automation header emoji picker to behave like an inline title control (similar to Notion) instead of a separate framed icon button. This improves visual alignment/spacing and keeps the emoji tightly coupled to the title.

## Changes
- **frontend/src/components/automation-emoji-picker.tsx**
  - Added a new `trigger="inline"` option.
  - Implemented an inline/ghost `Button` trigger with baseline alignment and title-sized typography.
- **frontend/src/app/(dashboard)/automations/[id]/page.tsx**
  - Switched the header emoji picker to `trigger="inline"`.
  - Reduced header title spacing (`gap-3` → `gap-2`) and changed the non-admin icon presentation to match inline sizing/alignment.
- **frontend/src/app/(dashboard)/automations/[id]/page.test.tsx**
  - Added assertions that the header emoji uses the inline trigger styling/classes and is **not** the separate framed icon button.

## Test plan
- `npm test -- --run 'src/app/(dashboard)/automations/[id]/page.test.tsx'`
- `npm run typecheck`
- `npm run lint`
- `npm run build`

[143.dev](https://143.dev) | [session 256492a2](https://143.dev/sessions/256492a2-601a-4fa2-8a83-b579c95efc2d)

Preview: https://143.dev/previews/github/assembledhq/143/pull/1228