### PR TITLE
Share automation schedule formatter for hourly/day and update UI tests

### DIFF
--- a/frontend/src/app/(dashboard)/automations/[id]/page.tsx
+++ b/frontend/src/app/(dashboard)/automations/[id]/page.tsx
@@ -48,7 +48,7 @@ import {
 import { RunsTab } from "./runs-tab";
 import {
   browserTimezone,
-  formatRunAtWithTimezone,
+  formatAutomationSchedule,
   hourOptions,
   minuteOptions,
   splitRunAt,
@@ -533,10 +533,7 @@ export default function AutomationDetailPage() {
     );
   }
 
-  const scheduleTimezone = automation.timezone || "UTC";
-  const schedule = automation.schedule_type === "cron" && automation.cron_expression
-    ? `cron: ${automation.cron_expression} (${scheduleTimezone})`
-    : `every ${automation.interval_value ?? 1} ${automation.interval_unit ?? "days"}${automation.interval_run_at ? ` at ${formatRunAtWithTimezone(automation.interval_run_at, scheduleTimezone)}` : ""}`;
+  const schedule = formatAutomationSchedule(automation);
 
   const headerDescription = automation.enabled
     ? automation.next_run_at

--- a/frontend/src/app/(dashboard)/automations/page.test.tsx
+++ b/frontend/src/app/(dashboard)/automations/page.test.tsx
@@ -73,7 +73,7 @@ describe("AutomationsPage", () => {
     expect(title).toHaveClass("break-words", "leading-5");
     expect(screen.getByLabelText("Automation icon for Weekly release hardening sweep for mobile checkout reliability")).toHaveTextContent("🧪");
 
-    const schedule = screen.getByText(/every 2 weeks at/);
+    const schedule = screen.getByText(/Every 2 weeks at/);
     expect(schedule).toHaveClass("block", "break-words", "leading-5", "sm:max-w-[18rem]", "sm:text-right");
 
     const detailRow = screen.getByText(/Last run:/).parentElement;

--- a/frontend/src/app/(dashboard)/automations/page.tsx
+++ b/frontend/src/app/(dashboard)/automations/page.tsx
@@ -7,7 +7,7 @@ import Link from "next/link";
 import { api } from "@/lib/api";
 import { formatTimeAgo } from "@/lib/utils";
 import type { Automation } from "@/lib/types";
-import { formatRunAtWithTimezone } from "./schedule-time";
+import { formatAutomationSchedule } from "./schedule-time";
 import { Button } from "@/components/ui/button";
 import {
   DropdownMenu,
@@ -18,20 +18,6 @@ import {
 import { PageContainer } from "@/components/page-container";
 import { PageHeader } from "@/components/page-header";
 import { useAuth } from "@/hooks/use-auth";
-
-function formatSchedule(a: Automation): string {
-  const tz = a.timezone || "UTC";
-  if (a.schedule_type === "cron" && a.cron_expression) {
-    return `cron: ${a.cron_expression} (${tz})`;
-  }
-  const val = a.interval_value ?? 1;
-  const unit = a.interval_unit ?? "days";
-  const intervalText = `every ${val} ${val === 1 ? unit.replace(/s$/, "") : unit}`;
-  if (!a.interval_run_at) {
-    return intervalText;
-  }
-  return `${intervalText} at ${formatRunAtWithTimezone(a.interval_run_at, tz)}`;
-}
 
 function AutomationCard({ automation, canManage }: { automation: Automation; canManage: boolean }) {
   const queryClient = useQueryClient();
@@ -89,7 +75,7 @@ function AutomationCard({ automation, canManage }: { automation: Automation; can
                   {automation.name}
                 </h3>
                 <span className="block break-words text-xs leading-5 text-muted-foreground sm:max-w-[18rem] sm:text-right">
-                  {formatSchedule(automation)}
+                  {formatAutomationSchedule(automation)}
                 </span>
               </div>
               <div className="flex flex-col gap-1 text-xs text-muted-foreground sm:flex-row sm:flex-wrap sm:gap-x-3 sm:gap-y-1">

--- a/frontend/src/app/(dashboard)/automations/schedule-time.test.ts
+++ b/frontend/src/app/(dashboard)/automations/schedule-time.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from "vitest";
+import type { Automation } from "@/lib/types";
+import { formatAutomationSchedule } from "./schedule-time";
+
+function automation(overrides: Partial<Automation>): Automation {
+  return {
+    id: "auto-1",
+    org_id: "org-1",
+    name: "Automation",
+    goal: "Do work",
+    icon_type: "emoji",
+    icon_value: "⚙️",
+    execution_mode: "async",
+    max_concurrent: 1,
+    base_branch: "main",
+    identity_scope: "org",
+    pre_pr_review_loops: 0,
+    schedule_type: "interval",
+    enabled: true,
+    timezone: "UTC",
+    priority: 50,
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+describe("formatAutomationSchedule", () => {
+  it.each([
+    {
+      name: "hides the anchor time for hourly automations",
+      input: automation({
+        interval_value: 1,
+        interval_unit: "hours",
+        interval_run_at: "10:00",
+        timezone: "America/New_York",
+      }),
+      expected: "Every hour",
+    },
+    {
+      name: "hides the anchor time for multi-hour automations",
+      input: automation({
+        interval_value: 6,
+        interval_unit: "hours",
+        interval_run_at: "10:00",
+        timezone: "America/New_York",
+      }),
+      expected: "Every 6 hours",
+    },
+    {
+      name: "treats a 24 hour interval as daily and keeps the run time",
+      input: automation({
+        interval_value: 24,
+        interval_unit: "hours",
+        interval_run_at: "10:00",
+        timezone: "America/New_York",
+      }),
+      expected: "Daily at 10:00 AM (America/New_York)",
+    },
+    {
+      name: "formats one day as daily with the run time",
+      input: automation({
+        interval_value: 1,
+        interval_unit: "days",
+        interval_run_at: "09:15",
+        timezone: "America/Los_Angeles",
+      }),
+      expected: "Daily at 9:15 AM (America/Los_Angeles)",
+    },
+    {
+      name: "formats multi-day intervals with the run time",
+      input: automation({
+        interval_value: 2,
+        interval_unit: "days",
+        interval_run_at: "09:15",
+        timezone: "America/Los_Angeles",
+      }),
+      expected: "Every 2 days at 9:15 AM (America/Los_Angeles)",
+    },
+    {
+      name: "formats weekly intervals with the run time",
+      input: automation({
+        interval_value: 1,
+        interval_unit: "weeks",
+        interval_run_at: "09:15",
+        timezone: "UTC",
+      }),
+      expected: "Every week at 9:15 AM (UTC)",
+    },
+    {
+      name: "keeps cron expressions explicit",
+      input: automation({
+        schedule_type: "cron",
+        cron_expression: "0 9 * * 1",
+        timezone: "UTC",
+      }),
+      expected: "cron: 0 9 * * 1 (UTC)",
+    },
+  ])("$name", ({ input, expected }) => {
+    expect(formatAutomationSchedule(input)).toBe(expected);
+  });
+});

--- a/frontend/src/app/(dashboard)/automations/schedule-time.ts
+++ b/frontend/src/app/(dashboard)/automations/schedule-time.ts
@@ -1,3 +1,5 @@
+import type { Automation } from "@/lib/types";
+
 // Shared schedule-time helpers for the automation new/edit pages. The backend
 // stores interval_run_at as a "HH:MM" string aligned to 5 minutes (see
 // migration 88 chk_automations_interval_run_at_format). Keeping the option
@@ -66,4 +68,41 @@ export function formatRunAtWithTimezone(runAt: string, timezone: string): string
     parseInt(minute, 10),
   ).toLocaleTimeString(undefined, { hour: "numeric", minute: "2-digit" });
   return `${formatted} (${timezone})`;
+}
+
+type AutomationScheduleFields = Pick<
+  Automation,
+  | "schedule_type"
+  | "interval_value"
+  | "interval_unit"
+  | "interval_run_at"
+  | "cron_expression"
+  | "timezone"
+>;
+
+function intervalLabel(value: number, unit: NonNullable<Automation["interval_unit"]>): string {
+  if (unit === "hours" && value === 24) return "Daily";
+  if (unit === "days" && value === 1) return "Daily";
+  if (value === 1) return `Every ${unit.replace(/s$/, "")}`;
+  return `Every ${value} ${unit}`;
+}
+
+function shouldShowRunAt(value: number, unit: NonNullable<Automation["interval_unit"]>): boolean {
+  return unit !== "hours" || value >= 24;
+}
+
+export function formatAutomationSchedule(schedule: AutomationScheduleFields): string {
+  const timezone = schedule.timezone || "UTC";
+  if (schedule.schedule_type === "cron" && schedule.cron_expression) {
+    return `cron: ${schedule.cron_expression} (${timezone})`;
+  }
+
+  const value = schedule.interval_value ?? 1;
+  const unit = schedule.interval_unit ?? "days";
+  const label = intervalLabel(value, unit);
+  if (!schedule.interval_run_at || !shouldShowRunAt(value, unit)) {
+    return label;
+  }
+
+  return `${label} at ${formatRunAtWithTimezone(schedule.interval_run_at, timezone)}`;
 }


### PR DESCRIPTION
## Summary
Introduced a shared `formatAutomationSchedule` helper to generate consistent, human-friendly frequency text across the automations list and detail header. This fixes incorrect formatting for sub-day intervals by displaying `Every hour` / `Every 6 hours`, while preserving existing day-scale output like `Daily at 10:00 AM (America/New_York)`.

## Changes
- **frontend/src/app/(dashboard)/automations/schedule-time.ts**
  - Added `formatAutomationSchedule(automation)` to centralize schedule text formatting.
  - Updated formatting logic to:
    - Render sub-day intervals as “Every hour” / “Every N hours”.
    - Keep day-scale schedules as “Daily at … (Timezone)” (including timezone where applicable).
    - Continue supporting cron schedules and multi-day/week intervals.
- **frontend/src/app/(dashboard)/automations/page.tsx**
  - Replaced local schedule string builder with `formatAutomationSchedule` for the list cards.
  - Adjusted schedule casing to match the new formatter output.
- **frontend/src/app/(dashboard)/automations/[id]/page.tsx**
  - Replaced inline schedule construction with `formatAutomationSchedule` for the detail header description.
- **frontend/src/app/(dashboard)/automations/schedule-time.test.ts**
  - Added test coverage for hourly, multi-hour, 24-hour, daily, multi-day, weekly, and cron schedules.
- **frontend/src/app/(dashboard)/automations/page.test.tsx**
  - Updated expectations to match the new formatter output (e.g., `Every 2 weeks at ...`).

## Test plan
- `npm run test -- --run 'src/app/(dashboard)/automations/schedule-time.test.ts'`
- `npm run test -- --run 'src/app/(dashboard)/automations/page.test.tsx' 'src/app/(dashboard)/automations/[id]/page.test.tsx'`
- `npm run typecheck`
- `npm run lint`
- `npm run build`

[143.dev](https://143.dev) | [session 32ab6087](https://143.dev/sessions/32ab6087-5515-4f73-b29b-000f9f64766a)

Preview: https://143.dev/previews/github/assembledhq/143/pull/1229