### PR TITLE
Implement Slackbot Product Surface components and update design doc

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -442,6 +442,7 @@ func main() {
 			AutomationRuns:      automationRunStore,
 			ReviewLoops:         db.NewSessionReviewLoopStore(pool),
 			SessionIssueLinks:   db.NewSessionIssueLinkStore(pool),
+			Previews:            previewStore,
 			SlackInstallations:  db.NewSlackInstallationStore(pool),
 			SlackUserLinks:      db.NewSlackUserLinkStore(pool),
 			SlackChannels:       db.NewSlackChannelSettingsStore(pool),

--- a/cmd/server/session_executor_main.go
+++ b/cmd/server/session_executor_main.go
@@ -290,6 +290,7 @@ func buildSessionExecutorRuntime(ctx context.Context, cfg *config.Config, pool *
 		AutomationRuns:      automationRunStore,
 		ReviewLoops:         db.NewSessionReviewLoopStore(pool),
 		SessionIssueLinks:   db.NewSessionIssueLinkStore(pool),
+		Previews:            db.NewPreviewStore(pool),
 	}
 	if services.LinearAgentDeps != nil {
 		services.LinearAgentDeps.Stores = stores

--- a/docs/design/future/92-slackbot-product-surface.md
+++ b/docs/design/future/92-slackbot-product-surface.md
@@ -1,7 +1,7 @@
 # 92 - Slackbot Product Surface
 
 > **Status:** Partially implemented
-> **Last reviewed:** 2026-05-30
+> **Last reviewed:** 2026-05-31
 >
 > **Depends on:** Slack OAuth integration, session/job creation APIs, durable preview control plane, human input requests, and notification delivery primitives.
 
@@ -61,8 +61,10 @@ The current implementation provides the first usable Slackbot backend surface, b
 - Slack App Home renders sections for start, pending responses, recent Slack-started sessions, active previews, recent automation runs, organization display, and Slack connection basics.
 - App Home can open a start-session modal, and modal submission starts a normal Slack-origin session.
 - Slack-started mention, DM, slash, and App Home sessions create or continue canonical 143 sessions with `origin = slack`.
+- Slack thread reuse checks the linked session status and starts a fresh session instead of continuing terminal non-resumable sessions.
 - Slack thread links persist team, channel/DM, thread key, permalink, triggering Slack user, mapped 143 user, and team-session flag in `slack_session_links`.
 - Slack user mapping supports self-linking from the authenticated product API and best-effort email matching from Slack profile data when scopes allow it.
+- Admin Slack user mapping APIs support creating, replacing, and deleting `admin_linked` Slack-to-143 user mappings.
 - Channel settings persist default repository, default branch, response visibility, allowed actions, and notification subscription JSON.
 - Authenticated Slack settings APIs expose bot install metadata, bot reinstall, bot-visible channels with connected settings, channel setting updates, user-link listing, self-link, and self-unlink.
 - Slack thread context, detected references, and file metadata are bounded and included in the initial session prompt.
@@ -72,6 +74,7 @@ The current implementation provides the first usable Slackbot backend surface, b
 - Slack notifications can fan out to subscribed channels or configured Slack user DMs from channel setting subscription JSON.
 - Implemented notification event paths include session completion/failure, automation completion/failure through session completion hooks, PR opened, preview ready/failed, and human-input requested.
 - Preview actions are wired for open, refresh/restart, stop, and extend. Refresh/restart currently both recycle the preview.
+- Slack preview actions use a shared Slack authorization service for channel capability checks, mapped-user membership roles, and the narrow unmapped-user allowance for originating team sessions.
 - Slack channel invite setup posts a channel-visible setup message with configure/start actions.
 - Stored Slack inbound payloads redact known transient/secret fields such as `response_url`, `trigger_id`, and `token`.
 - Slackbot metrics exist for inbound events, session starts, outbound messages, Slack API failures, and interaction actions.
@@ -97,19 +100,18 @@ The current implementation provides the first usable Slackbot backend surface, b
 - `preview.stale` is not emitted.
 - Automation notification content is still basic and does not consistently include run result, PR links, preview links, and next actions.
 - Notification subscription management is only raw channel setting JSON; there is no Slack-native or richer product management flow.
-- Preview notification actions do not yet prove that an unmapped user is acting only on the originating team session.
+- Preview actions that are not tied to a Slack-originating team session, such as App Home preview controls or standalone preview notifications without session identity, still require a mapped authorized 143 user.
 - Channel configuration from Slack does not manage notification subscriptions.
 - The setup message's App Home action currently opens the start-session flow rather than switching Slack to App Home.
 - Slack-started sessions can be initiated by App Home, slash command, mention, and DM, but not generally by a "start work" button from arbitrary notifications/session updates.
-- Thread reuse does not check whether the linked session is resumable before continuing it.
-- If a linked Slack thread should start a new non-resumable session, there is no separate new-thread-message pointer model.
+- If a linked Slack thread starts a fresh session after a non-resumable terminal session, the link is repointed to the new session; there is still no separate historical new-thread-message pointer model.
 - Team sessions are stored but not clearly surfaced in Slack or 143 as "started from Slack without a mapped 143 user."
 - Slack session creation uses DB stores directly rather than the same higher-level creation service as `/sessions/new`.
 - Direct preview creation for PR, branch, commit, or repository is not implemented.
 - Slack preview creation for a session is currently an agent continuation prompt, not a direct durable preview-control-plane create call.
 - `Open preview` links to the 143 preview page, not necessarily a short-lived isolated preview-origin URL.
-- Admin-managed Slack user mapping APIs are missing.
-- RBAC enforcement is partial. Preview controls check role in some paths, but session start, PR requests, and other user-specific actions need consistent mapped-user authorization.
+- Admin-managed Slack user mapping APIs exist at the backend/API layer; richer product UI still needs to expose them.
+- RBAC enforcement is partial. Preview controls now use shared mapped-user/channel/team-session authorization, but session start, PR requests, and other user-specific actions need the same consistent mapped-user authorization.
 - User-authored PR creation from Slack is not implemented.
 - Slack install resolution is team/app based and does not fully handle enterprise-aware multi-org Slack workspaces.
 - Slash commands always enqueue a session; they do not open missing-context modals.
@@ -514,6 +516,8 @@ Admin/settings APIs should stay under normal app auth and RBAC.
 - `GET /api/v1/integrations/slack/channels`: Slack channels visible to bot, with connected settings.
 - `PATCH /api/v1/integrations/slack/channels/{slack_channel_id}`: set default repository, allowed actions, notification subscriptions.
 - `GET /api/v1/integrations/slack/user-links`: list Slack user mappings.
+- `POST /api/v1/integrations/slack/user-links`: admin-managed create/replace Slack user mapping with `source = admin_linked`.
+- `DELETE /api/v1/integrations/slack/user-links/{id}`: admin-managed delete for a Slack user mapping.
 - `POST /api/v1/integrations/slack/user-links/me`: link current 143 user to Slack user.
 - `DELETE /api/v1/integrations/slack/user-links/me`: unlink current user.
 
@@ -718,7 +722,7 @@ Handler responsibilities:
 1. Load channel settings and user mapping.
 2. Fetch thread context with `conversations.replies` when useful and permitted.
 3. Resolve repository/preview/session references.
-4. Create or resume a 143 session.
+4. Create or resume a 143 session. Existing Slack thread links continue active or resumable sessions; terminal non-resumable sessions start a fresh session and repoint the Slack thread link.
 5. Persist `slack_session_links`.
 6. Post/update the Slack ack message with the session URL.
 7. Enqueue normal `run_agent` / `continue_session` work.

--- a/internal/api/handlers/integrations.go
+++ b/internal/api/handlers/integrations.go
@@ -1941,6 +1941,92 @@ func (h *IntegrationHandler) ListSlackUserLinks(w http.ResponseWriter, r *http.R
 	writeJSON(w, http.StatusOK, models.ListResponse[models.SlackUserLink]{Data: links, Meta: models.PaginationMeta{}})
 }
 
+func (h *IntegrationHandler) UpsertSlackUserLinkAdmin(w http.ResponseWriter, r *http.Request) {
+	orgID := middleware.OrgIDFromContext(r.Context())
+	if h.slackInstallationStore == nil || h.slackUserLinkStore == nil {
+		writeError(w, r, http.StatusServiceUnavailable, "SLACKBOT_NOT_CONFIGURED", "slack user links are not configured")
+		return
+	}
+	if h.memberships == nil {
+		writeError(w, r, http.StatusServiceUnavailable, "MEMBERSHIP_STORE_NOT_CONFIGURED", "membership validation is not configured")
+		return
+	}
+	var body struct {
+		UserID           uuid.UUID `json:"user_id"`
+		SlackUserID      string    `json:"slack_user_id"`
+		SlackEmail       string    `json:"slack_email"`
+		SlackDisplayName string    `json:"slack_display_name"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeError(w, r, http.StatusBadRequest, "INVALID_BODY", "invalid request body")
+		return
+	}
+	body.SlackUserID = strings.TrimSpace(body.SlackUserID)
+	body.SlackEmail = strings.TrimSpace(body.SlackEmail)
+	body.SlackDisplayName = strings.TrimSpace(body.SlackDisplayName)
+	if body.UserID == uuid.Nil {
+		writeError(w, r, http.StatusBadRequest, "MISSING_USER_ID", "user_id is required")
+		return
+	}
+	if body.SlackUserID == "" {
+		writeError(w, r, http.StatusBadRequest, "MISSING_SLACK_USER_ID", "slack_user_id is required")
+		return
+	}
+	if _, err := h.memberships.Get(r.Context(), body.UserID, orgID); err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			writeError(w, r, http.StatusBadRequest, "USER_NOT_IN_ORG", "user_id must belong to the current org")
+			return
+		}
+		writeError(w, r, http.StatusInternalServerError, "MEMBERSHIP_LOOKUP_FAILED", "failed to validate user membership", err)
+		return
+	}
+	installation, err := h.slackInstallationStore.GetActiveByOrg(r.Context(), orgID)
+	if err != nil {
+		writeError(w, r, http.StatusNotFound, "SLACK_NOT_CONNECTED", "slack bot is not connected", err)
+		return
+	}
+	var emailPtr *string
+	if body.SlackEmail != "" {
+		emailPtr = &body.SlackEmail
+	}
+	link := &models.SlackUserLink{
+		OrgID:               orgID,
+		SlackInstallationID: installation.ID,
+		UserID:              &body.UserID,
+		SlackTeamID:         installation.TeamID,
+		SlackUserID:         body.SlackUserID,
+		SlackEmail:          emailPtr,
+		SlackDisplayName:    body.SlackDisplayName,
+	}
+	if err := h.slackUserLinkStore.UpsertAdminLink(r.Context(), link); err != nil {
+		writeError(w, r, http.StatusInternalServerError, "SLACK_USER_LINK_FAILED", "failed to upsert slack user link", err)
+		return
+	}
+	writeJSON(w, http.StatusOK, models.SingleResponse[models.SlackUserLink]{Data: *link})
+}
+
+func (h *IntegrationHandler) DeleteSlackUserLinkAdmin(w http.ResponseWriter, r *http.Request) {
+	orgID := middleware.OrgIDFromContext(r.Context())
+	if h.slackUserLinkStore == nil {
+		writeError(w, r, http.StatusServiceUnavailable, "SLACKBOT_NOT_CONFIGURED", "slack user links are not configured")
+		return
+	}
+	linkID, err := uuid.Parse(chi.URLParam(r, "id"))
+	if err != nil {
+		writeError(w, r, http.StatusBadRequest, "INVALID_LINK_ID", "id must be a valid UUID")
+		return
+	}
+	if err := h.slackUserLinkStore.DeleteByID(r.Context(), orgID, linkID); err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			writeError(w, r, http.StatusNotFound, "SLACK_USER_LINK_NOT_FOUND", "slack user link not found")
+			return
+		}
+		writeError(w, r, http.StatusInternalServerError, "SLACK_USER_LINK_DELETE_FAILED", "failed to delete slack user link", err)
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
+}
+
 func (h *IntegrationHandler) LinkSlackUserMe(w http.ResponseWriter, r *http.Request) {
 	orgID := middleware.OrgIDFromContext(r.Context())
 	user := middleware.UserFromContext(r.Context())

--- a/internal/api/handlers/integrations_test.go
+++ b/internal/api/handlers/integrations_test.go
@@ -1359,6 +1359,120 @@ func TestIntegrationHandler_LinkSlackUserMeRejectsEmailMismatch(t *testing.T) {
 	require.NoError(t, mock.ExpectationsWereMet(), "Slack self-link should not upsert a mismatched Slack identity")
 }
 
+func TestIntegrationHandler_UpsertSlackUserLinkAdmin(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "pgx mock should initialize")
+	defer mock.Close()
+
+	orgID := uuid.New()
+	userID := uuid.New()
+	installationID := uuid.New()
+	integrationID := uuid.New()
+	linkID := uuid.New()
+	now := time.Now()
+	email := "eng@example.com"
+	handler := NewIntegrationHandler(
+		db.NewIntegrationStore(mock),
+		nil,
+		"", "", "http://localhost:8080", "http://localhost:3000",
+		WithIntegrationMembershipStore(fakeGitHubMembershipStore{membership: models.OrganizationMembership{
+			UserID: userID,
+			OrgID:  orgID,
+			Role:   models.RoleMember,
+		}}),
+	)
+	handler.slackInstallationStore = db.NewSlackInstallationStore(mock)
+	handler.slackUserLinkStore = db.NewSlackUserLinkStore(mock)
+
+	expectSlackInstallationByOrg(mock, orgID, installationID, integrationID)
+	mock.ExpectQuery(`ON CONFLICT \(org_id, slack_team_id, slack_user_id\)`).
+		WithArgs(
+			pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
+			pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
+		).
+		WillReturnRows(pgxmock.NewRows([]string{
+			"id", "org_id", "slack_installation_id", "user_id", "slack_team_id", "slack_user_id",
+			"slack_email", "slack_display_name", "source", "linked_at", "created_at", "updated_at",
+		}).AddRow(
+			linkID, orgID, installationID, &userID, "T123", "U123", &email, "Eng User",
+			models.SlackUserLinkSourceAdminLinked, &now, now, now,
+		))
+
+	body := strings.NewReader(fmt.Sprintf(`{"user_id":%q,"slack_user_id":"U123","slack_email":"eng@example.com","slack_display_name":"Eng User"}`, userID.String()))
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/integrations/slack/user-links", body)
+	req = req.WithContext(middleware.WithOrgID(req.Context(), orgID))
+	rr := httptest.NewRecorder()
+
+	handler.UpsertSlackUserLinkAdmin(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code, "admin Slack user-link upsert should return OK")
+	var resp models.SingleResponse[models.SlackUserLink]
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &resp), "Slack user-link response should be valid JSON")
+	require.Equal(t, models.SlackUserLinkSourceAdminLinked, resp.Data.Source, "admin upsert should mark the link as admin linked")
+	require.Equal(t, &userID, resp.Data.UserID, "admin upsert should link the requested user")
+	require.NoError(t, mock.ExpectationsWereMet(), "admin Slack user-link upsert should satisfy database expectations")
+}
+
+func TestIntegrationHandler_DeleteSlackUserLinkAdmin(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "pgx mock should initialize")
+	defer mock.Close()
+
+	orgID := uuid.New()
+	linkID := uuid.New()
+	handler := NewIntegrationHandler(db.NewIntegrationStore(mock), nil, "", "", "http://localhost:8080", "http://localhost:3000")
+	handler.slackUserLinkStore = db.NewSlackUserLinkStore(mock)
+
+	mock.ExpectExec(`DELETE FROM slack_user_links`).
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnResult(pgxmock.NewResult("DELETE", 1))
+
+	req := httptest.NewRequest(http.MethodDelete, "/api/v1/integrations/slack/user-links/"+linkID.String(), nil)
+	req = req.WithContext(middleware.WithOrgID(req.Context(), orgID))
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("id", linkID.String())
+	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
+	rr := httptest.NewRecorder()
+
+	handler.DeleteSlackUserLinkAdmin(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code, "admin Slack user-link delete should return OK")
+	require.NoError(t, mock.ExpectationsWereMet(), "admin Slack user-link delete should satisfy database expectations")
+}
+
+func TestIntegrationHandler_DeleteSlackUserLinkAdmin_NotFound(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "pgx mock should initialize")
+	defer mock.Close()
+
+	orgID := uuid.New()
+	linkID := uuid.New()
+	handler := NewIntegrationHandler(db.NewIntegrationStore(mock), nil, "", "", "http://localhost:8080", "http://localhost:3000")
+	handler.slackUserLinkStore = db.NewSlackUserLinkStore(mock)
+
+	mock.ExpectExec(`DELETE FROM slack_user_links`).
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnResult(pgxmock.NewResult("DELETE", 0))
+
+	req := httptest.NewRequest(http.MethodDelete, "/api/v1/integrations/slack/user-links/"+linkID.String(), nil)
+	req = req.WithContext(middleware.WithOrgID(req.Context(), orgID))
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("id", linkID.String())
+	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
+	rr := httptest.NewRecorder()
+
+	handler.DeleteSlackUserLinkAdmin(rr, req)
+
+	require.Equal(t, http.StatusNotFound, rr.Code, "admin Slack user-link delete should return 404 for non-existent link")
+	require.NoError(t, mock.ExpectationsWereMet(), "admin Slack user-link delete not-found should satisfy database expectations")
+}
+
 func TestIntegrationHandler_PatchSlackChannelSettingsRejectsForeignRepository(t *testing.T) {
 	t.Parallel()
 

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -1287,6 +1287,8 @@ func NewRouter(cfg *config.Config, pool *pgxpool.Pool, logger zerolog.Logger, se
 				r.Patch("/api/v1/integrations/slack/channels", integrationHandler.UpdateSlackChannels)
 				r.Patch("/api/v1/integrations/slack/channels/{slack_channel_id}", integrationHandler.PatchSlackChannelSettings)
 				r.Get("/api/v1/integrations/slack/user-links", integrationHandler.ListSlackUserLinks)
+				r.Post("/api/v1/integrations/slack/user-links", integrationHandler.UpsertSlackUserLinkAdmin)
+				r.Delete("/api/v1/integrations/slack/user-links/{id}", integrationHandler.DeleteSlackUserLinkAdmin)
 				r.Delete("/api/v1/integrations/github/disconnect", integrationHandler.DisconnectIntegration)
 				r.Delete("/api/v1/integrations/sentry/disconnect", integrationHandler.DisconnectIntegration)
 				r.Delete("/api/v1/integrations/linear/disconnect", integrationHandler.DisconnectIntegration)

--- a/internal/db/slackbot.go
+++ b/internal/db/slackbot.go
@@ -315,6 +315,47 @@ func (s *SlackUserLinkStore) UpsertEmailMatch(ctx context.Context, link *models.
 	return nil
 }
 
+func (s *SlackUserLinkStore) UpsertAdminLink(ctx context.Context, link *models.SlackUserLink) error {
+	rows, err := s.db.Query(ctx, `
+		INSERT INTO slack_user_links (
+			org_id, slack_installation_id, user_id, slack_team_id, slack_user_id,
+			slack_email, slack_display_name, source, linked_at
+		)
+		VALUES (
+			@org_id, @slack_installation_id, @user_id, @slack_team_id, @slack_user_id,
+			@slack_email, @slack_display_name, 'admin_linked', now()
+		)
+		ON CONFLICT (org_id, slack_team_id, slack_user_id)
+		DO UPDATE SET
+			slack_installation_id = EXCLUDED.slack_installation_id,
+			user_id = EXCLUDED.user_id,
+			slack_email = EXCLUDED.slack_email,
+			slack_display_name = EXCLUDED.slack_display_name,
+			source = 'admin_linked',
+			linked_at = now(),
+			updated_at = now()
+		RETURNING id, org_id, slack_installation_id, user_id, slack_team_id, slack_user_id,
+			slack_email, slack_display_name, source, linked_at, created_at, updated_at`,
+		pgx.NamedArgs{
+			"org_id":                link.OrgID,
+			"slack_installation_id": link.SlackInstallationID,
+			"user_id":               link.UserID,
+			"slack_team_id":         link.SlackTeamID,
+			"slack_user_id":         link.SlackUserID,
+			"slack_email":           link.SlackEmail,
+			"slack_display_name":    link.SlackDisplayName,
+		})
+	if err != nil {
+		return fmt.Errorf("upsert slack admin link: %w", err)
+	}
+	updated, err := pgx.CollectOneRow(rows, pgx.RowToStructByName[models.SlackUserLink])
+	if err != nil {
+		return fmt.Errorf("scan slack admin link: %w", err)
+	}
+	*link = updated
+	return nil
+}
+
 func (s *SlackUserLinkStore) DeleteSelfLink(ctx context.Context, orgID, userID uuid.UUID, teamID string) error {
 	_, err := s.db.Exec(ctx, `
 		DELETE FROM slack_user_links
@@ -324,6 +365,21 @@ func (s *SlackUserLinkStore) DeleteSelfLink(ctx context.Context, orgID, userID u
 		  AND source = 'self_linked'`,
 		pgx.NamedArgs{"org_id": orgID, "user_id": userID, "slack_team_id": teamID})
 	return err
+}
+
+func (s *SlackUserLinkStore) DeleteByID(ctx context.Context, orgID, id uuid.UUID) error {
+	tag, err := s.db.Exec(ctx, `
+		DELETE FROM slack_user_links
+		WHERE org_id = @org_id
+		  AND id = @id`,
+		pgx.NamedArgs{"org_id": orgID, "id": id})
+	if err != nil {
+		return err
+	}
+	if tag.RowsAffected() == 0 {
+		return pgx.ErrNoRows
+	}
+	return nil
 }
 
 type SlackChannelSettingsStore struct {

--- a/internal/db/slackbot_test.go
+++ b/internal/db/slackbot_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/assembledhq/143/internal/models"
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
 	"github.com/pashagolub/pgxmock/v4"
 	"github.com/stretchr/testify/require"
 )
@@ -54,4 +55,92 @@ func TestSlackInboundEventStore_CreateReceivedUsesPartialConflictPredicate(t *te
 	require.NoError(t, err, "CreateReceived should insert inbound event")
 	require.True(t, inserted, "CreateReceived should report inserted event")
 	require.NoError(t, mock.ExpectationsWereMet(), "CreateReceived should use the partial unique-index conflict predicate")
+}
+
+func TestSlackUserLinkStore_UpsertAdminLink(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "pgx mock should initialize")
+	defer mock.Close()
+
+	orgID := uuid.New()
+	installationID := uuid.New()
+	userID := uuid.New()
+	linkID := uuid.New()
+	now := time.Now()
+	email := "eng@example.com"
+	store := NewSlackUserLinkStore(mock)
+
+	mock.ExpectQuery(`ON CONFLICT \(org_id, slack_team_id, slack_user_id\)`).
+		WithArgs(
+			pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
+			pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
+		).
+		WillReturnRows(pgxmock.NewRows([]string{
+			"id", "org_id", "slack_installation_id", "user_id", "slack_team_id", "slack_user_id",
+			"slack_email", "slack_display_name", "source", "linked_at", "created_at", "updated_at",
+		}).AddRow(
+			linkID, orgID, installationID, &userID, "T123", "U123", &email, "Eng User",
+			models.SlackUserLinkSourceAdminLinked, &now, now, now,
+		))
+
+	link := &models.SlackUserLink{
+		OrgID:               orgID,
+		SlackInstallationID: installationID,
+		UserID:              &userID,
+		SlackTeamID:         "T123",
+		SlackUserID:         "U123",
+		SlackEmail:          &email,
+		SlackDisplayName:    "Eng User",
+	}
+
+	err = store.UpsertAdminLink(context.Background(), link)
+
+	require.NoError(t, err, "UpsertAdminLink should persist admin-managed mapping")
+	require.Equal(t, models.SlackUserLinkSourceAdminLinked, link.Source, "UpsertAdminLink should mark mapping as admin linked")
+	require.Equal(t, linkID, link.ID, "UpsertAdminLink should scan the stored link")
+	require.NoError(t, mock.ExpectationsWereMet(), "UpsertAdminLink should satisfy expected SQL")
+}
+
+func TestSlackUserLinkStore_DeleteByID(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "pgx mock should initialize")
+	defer mock.Close()
+
+	orgID := uuid.New()
+	linkID := uuid.New()
+	store := NewSlackUserLinkStore(mock)
+
+	mock.ExpectExec(`DELETE FROM slack_user_links`).
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnResult(pgxmock.NewResult("DELETE", 1))
+
+	err = store.DeleteByID(context.Background(), orgID, linkID)
+
+	require.NoError(t, err, "DeleteByID should delete an org-scoped Slack user link")
+	require.NoError(t, mock.ExpectationsWereMet(), "DeleteByID should satisfy expected SQL")
+}
+
+func TestSlackUserLinkStore_DeleteByID_NotFound(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "pgx mock should initialize")
+	defer mock.Close()
+
+	orgID := uuid.New()
+	linkID := uuid.New()
+	store := NewSlackUserLinkStore(mock)
+
+	mock.ExpectExec(`DELETE FROM slack_user_links`).
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnResult(pgxmock.NewResult("DELETE", 0))
+
+	err = store.DeleteByID(context.Background(), orgID, linkID)
+
+	require.ErrorIs(t, err, pgx.ErrNoRows, "DeleteByID should return ErrNoRows when no link is found")
+	require.NoError(t, mock.ExpectationsWereMet(), "DeleteByID not-found should satisfy expected SQL")
 }

--- a/internal/services/slackbot/authorization.go
+++ b/internal/services/slackbot/authorization.go
@@ -1,0 +1,155 @@
+package slackbot
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/assembledhq/143/internal/models"
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+)
+
+type Capability string
+
+const (
+	CapabilitySession    Capability = "session"
+	CapabilityPreview    Capability = "preview"
+	CapabilityPRRequest  Capability = "pr_request"
+	CapabilityHumanInput Capability = "human_input"
+)
+
+type SlackUserLinkStore interface {
+	GetBySlackUser(ctx context.Context, orgID uuid.UUID, teamID, slackUserID string) (models.SlackUserLink, error)
+}
+
+type MembershipStore interface {
+	Get(ctx context.Context, userID, orgID uuid.UUID) (models.OrganizationMembership, error)
+}
+
+type SlackChannelStore interface {
+	GetByChannel(ctx context.Context, orgID uuid.UUID, teamID, channelID string) (models.SlackChannelSettings, error)
+}
+
+type Authorizer struct {
+	links       SlackUserLinkStore
+	memberships MembershipStore
+	channels    SlackChannelStore
+}
+
+type ActionRequest struct {
+	OrgID       uuid.UUID
+	TeamID      string
+	ChannelID   string
+	SlackUserID string
+
+	Capability   Capability
+	AllowedRoles []models.Role
+
+	RequireMapped            bool
+	AllowUnmappedTeamSession bool
+	IsOriginatingTeamSession bool
+}
+
+type Decision struct {
+	MappedUserID *uuid.UUID
+	Role         models.Role
+	TeamSession  bool
+}
+
+func NewAuthorizer(links SlackUserLinkStore, memberships MembershipStore, channels SlackChannelStore) *Authorizer {
+	return &Authorizer{links: links, memberships: memberships, channels: channels}
+}
+
+func (a *Authorizer) Authorize(ctx context.Context, req ActionRequest) (Decision, error) {
+	if req.OrgID == uuid.Nil {
+		return Decision{}, fmt.Errorf("slack authorization requires org_id")
+	}
+	if req.SlackUserID == "" {
+		return Decision{}, fmt.Errorf("slack authorization requires slack user")
+	}
+	if err := a.authorizeChannelCapability(ctx, req); err != nil {
+		return Decision{}, err
+	}
+
+	link, err := a.resolveUserLink(ctx, req)
+	if err != nil {
+		if !errors.Is(err, pgx.ErrNoRows) {
+			return Decision{}, err
+		}
+		return a.authorizeUnmapped(req)
+	}
+	if link.UserID == nil {
+		return a.authorizeUnmapped(req)
+	}
+	if len(req.AllowedRoles) == 0 {
+		return Decision{MappedUserID: link.UserID, TeamSession: false}, nil
+	}
+	if a.memberships == nil {
+		return Decision{}, fmt.Errorf("slack authorization requires membership store for role-gated action")
+	}
+	membership, err := a.memberships.Get(ctx, *link.UserID, req.OrgID)
+	if err != nil {
+		return Decision{}, fmt.Errorf("load slack mapped user membership: %w", err)
+	}
+	if !roleAllowed(membership.Role, req.AllowedRoles) {
+		return Decision{}, fmt.Errorf("slack action requires one of roles %v", req.AllowedRoles)
+	}
+	return Decision{MappedUserID: link.UserID, Role: membership.Role, TeamSession: false}, nil
+}
+
+func (a *Authorizer) authorizeChannelCapability(ctx context.Context, req ActionRequest) error {
+	if a.channels == nil || req.ChannelID == "" || req.Capability == "" {
+		return nil
+	}
+	settings, err := a.channels.GetByChannel(ctx, req.OrgID, req.TeamID, req.ChannelID)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil
+		}
+		return fmt.Errorf("load slack channel settings: %w", err)
+	}
+	if !stringSliceContains(settings.AllowedActions, string(req.Capability)) {
+		return fmt.Errorf("slack channel does not allow %s actions", req.Capability)
+	}
+	return nil
+}
+
+func (a *Authorizer) resolveUserLink(ctx context.Context, req ActionRequest) (models.SlackUserLink, error) {
+	if a.links == nil {
+		return models.SlackUserLink{}, pgx.ErrNoRows
+	}
+	link, err := a.links.GetBySlackUser(ctx, req.OrgID, req.TeamID, req.SlackUserID)
+	if err != nil {
+		return models.SlackUserLink{}, fmt.Errorf("resolve slack user link: %w", err)
+	}
+	return link, nil
+}
+
+func (a *Authorizer) authorizeUnmapped(req ActionRequest) (Decision, error) {
+	if req.RequireMapped {
+		return Decision{}, fmt.Errorf("slack action requires a linked 143 user")
+	}
+	if req.AllowUnmappedTeamSession && req.IsOriginatingTeamSession {
+		return Decision{TeamSession: true}, nil
+	}
+	return Decision{}, fmt.Errorf("slack action requires originating team session or linked 143 user")
+}
+
+func roleAllowed(role models.Role, allowed []models.Role) bool {
+	for _, candidate := range allowed {
+		if role == candidate {
+			return true
+		}
+	}
+	return false
+}
+
+func stringSliceContains(values []string, target string) bool {
+	for _, value := range values {
+		if value == target {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/services/slackbot/authorization_test.go
+++ b/internal/services/slackbot/authorization_test.go
@@ -1,0 +1,183 @@
+package slackbot
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/assembledhq/143/internal/models"
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/stretchr/testify/require"
+)
+
+type stubUserLinkStore struct {
+	link models.SlackUserLink
+	err  error
+}
+
+func (s stubUserLinkStore) GetBySlackUser(_ context.Context, _ uuid.UUID, _, _ string) (models.SlackUserLink, error) {
+	return s.link, s.err
+}
+
+type stubMembershipStore struct {
+	membership models.OrganizationMembership
+	err        error
+}
+
+func (s stubMembershipStore) Get(_ context.Context, _ uuid.UUID, _ uuid.UUID) (models.OrganizationMembership, error) {
+	return s.membership, s.err
+}
+
+type stubChannelStore struct {
+	settings models.SlackChannelSettings
+	err      error
+}
+
+func (s stubChannelStore) GetByChannel(_ context.Context, _ uuid.UUID, _, _ string) (models.SlackChannelSettings, error) {
+	return s.settings, s.err
+}
+
+func TestAuthorizerAuthorize(t *testing.T) {
+	t.Parallel()
+
+	orgID := uuid.New()
+	userID := uuid.New()
+
+	tests := []struct {
+		name      string
+		input     ActionRequest
+		links     SlackUserLinkStore
+		members   MembershipStore
+		channels  SlackChannelStore
+		expected  Decision
+		expectErr bool
+	}{
+		{
+			name: "mapped member may run allowed channel action",
+			input: ActionRequest{
+				OrgID:         orgID,
+				TeamID:        "T1",
+				ChannelID:     "C1",
+				SlackUserID:   "U1",
+				Capability:    CapabilityPreview,
+				RequireMapped: true,
+				AllowedRoles:  []models.Role{models.RoleAdmin, models.RoleMember, models.RoleBuilder},
+			},
+			links: stubUserLinkStore{link: models.SlackUserLink{UserID: &userID}},
+			members: stubMembershipStore{membership: models.OrganizationMembership{
+				UserID: userID,
+				OrgID:  orgID,
+				Role:   models.RoleMember,
+			}},
+			channels: stubChannelStore{settings: models.SlackChannelSettings{AllowedActions: []string{string(CapabilityPreview)}}},
+			expected: Decision{
+				MappedUserID: &userID,
+				Role:         models.RoleMember,
+				TeamSession:  false,
+			},
+		},
+		{
+			name: "viewer is rejected for member action",
+			input: ActionRequest{
+				OrgID:         orgID,
+				TeamID:        "T1",
+				ChannelID:     "C1",
+				SlackUserID:   "U1",
+				Capability:    CapabilityPreview,
+				RequireMapped: true,
+				AllowedRoles:  []models.Role{models.RoleAdmin, models.RoleMember, models.RoleBuilder},
+			},
+			links: stubUserLinkStore{link: models.SlackUserLink{UserID: &userID}},
+			members: stubMembershipStore{membership: models.OrganizationMembership{
+				UserID: userID,
+				OrgID:  orgID,
+				Role:   models.RoleViewer,
+			}},
+			channels:  stubChannelStore{settings: models.SlackChannelSettings{AllowedActions: []string{string(CapabilityPreview)}}},
+			expectErr: true,
+		},
+		{
+			name: "unmapped user may operate originating team session when channel allows capability",
+			input: ActionRequest{
+				OrgID:                    orgID,
+				TeamID:                   "T1",
+				ChannelID:                "C1",
+				SlackUserID:              "U1",
+				Capability:               CapabilityPreview,
+				AllowUnmappedTeamSession: true,
+				IsOriginatingTeamSession: true,
+			},
+			links:    stubUserLinkStore{err: pgx.ErrNoRows},
+			channels: stubChannelStore{settings: models.SlackChannelSettings{AllowedActions: []string{string(CapabilityPreview)}}},
+			expected: Decision{
+				MappedUserID: nil,
+				Role:         "",
+				TeamSession:  true,
+			},
+		},
+		{
+			name: "unmapped user cannot operate non-originating team session",
+			input: ActionRequest{
+				OrgID:                    orgID,
+				TeamID:                   "T1",
+				ChannelID:                "C1",
+				SlackUserID:              "U1",
+				Capability:               CapabilityPreview,
+				AllowUnmappedTeamSession: true,
+				IsOriginatingTeamSession: false,
+			},
+			links:     stubUserLinkStore{err: pgx.ErrNoRows},
+			channels:  stubChannelStore{settings: models.SlackChannelSettings{AllowedActions: []string{string(CapabilityPreview)}}},
+			expectErr: true,
+		},
+		{
+			name: "channel capability denial rejects action before role grants",
+			input: ActionRequest{
+				OrgID:         orgID,
+				TeamID:        "T1",
+				ChannelID:     "C1",
+				SlackUserID:   "U1",
+				Capability:    CapabilityPreview,
+				RequireMapped: true,
+				AllowedRoles:  []models.Role{models.RoleAdmin, models.RoleMember, models.RoleBuilder},
+			},
+			links: stubUserLinkStore{link: models.SlackUserLink{UserID: &userID}},
+			members: stubMembershipStore{membership: models.OrganizationMembership{
+				UserID: userID,
+				OrgID:  orgID,
+				Role:   models.RoleAdmin,
+			}},
+			channels:  stubChannelStore{settings: models.SlackChannelSettings{AllowedActions: []string{string(CapabilitySession)}}},
+			expectErr: true,
+		},
+		{
+			name: "unexpected link store error is propagated",
+			input: ActionRequest{
+				OrgID:       orgID,
+				TeamID:      "T1",
+				ChannelID:   "C1",
+				SlackUserID: "U1",
+				Capability:  CapabilityPreview,
+			},
+			links:     stubUserLinkStore{err: errors.New("database unavailable")},
+			channels:  stubChannelStore{settings: models.SlackChannelSettings{AllowedActions: []string{string(CapabilityPreview)}}},
+			expectErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			authorizer := NewAuthorizer(tt.links, tt.members, tt.channels)
+			actual, err := authorizer.Authorize(context.Background(), tt.input)
+			if tt.expectErr {
+				require.Error(t, err, "Authorize should reject invalid Slack action")
+				return
+			}
+			require.NoError(t, err, "Authorize should allow valid Slack action")
+			require.Equal(t, tt.expected, actual, "Authorize should return the expected identity decision")
+		})
+	}
+}

--- a/internal/worker/handlers.go
+++ b/internal/worker/handlers.go
@@ -35,6 +35,7 @@ import (
 	previewsvc "github.com/assembledhq/143/internal/services/preview"
 	"github.com/assembledhq/143/internal/services/prioritization"
 	reviewloopsvc "github.com/assembledhq/143/internal/services/reviewloop"
+	slackbotsvc "github.com/assembledhq/143/internal/services/slackbot"
 	"github.com/assembledhq/143/internal/version"
 )
 
@@ -421,6 +422,7 @@ type Stores struct {
 	AutomationRuns      *db.AutomationRunStore // nil-safe: automations feature disabled if nil
 	ReviewLoops         *db.SessionReviewLoopStore
 	SessionIssueLinks   *db.SessionIssueLinkStore // nil-safe: needed for Linear milestones
+	Previews            *db.PreviewStore
 	SlackInstallations  *db.SlackInstallationStore
 	SlackUserLinks      *db.SlackUserLinkStore
 	SlackChannels       *db.SlackChannelSettingsStore
@@ -1442,40 +1444,46 @@ func newSlackStartOrContinueSessionHandler(stores *Stores, services *Services, l
 			if getErr != nil {
 				return fmt.Errorf("get linked slack session: %w", getErr)
 			}
-			msg := &models.SessionMessage{
-				SessionID:  session.ID,
-				OrgID:      orgID,
-				ThreadID:   session.PrimaryThreadID,
-				UserID:     mappedUserID,
-				TurnNumber: session.CurrentTurn,
-				Role:       models.MessageRoleUser,
-				Content:    renderSlackPrompt(payload.Text, permalink, threadMessages, contextRefs, contextFiles),
+			if slackShouldContinueLinkedSession(session.Status) {
+				msg := &models.SessionMessage{
+					SessionID:  session.ID,
+					OrgID:      orgID,
+					ThreadID:   session.PrimaryThreadID,
+					UserID:     mappedUserID,
+					TurnNumber: session.CurrentTurn,
+					Role:       models.MessageRoleUser,
+					Content:    renderSlackPrompt(payload.Text, permalink, threadMessages, contextRefs, contextFiles),
+				}
+				if err := stores.SessionMessages.Create(ctx, msg); err != nil {
+					return fmt.Errorf("create slack follow-up message: %w", err)
+				}
+				scopeID := session.ID
+				if session.PrimaryThreadID != nil {
+					scopeID = *session.PrimaryThreadID
+				}
+				dedupeKey := db.ContinueSessionDedupeKey(scopeID)
+				continuePayload := map[string]string{
+					"org_id":     orgID.String(),
+					"session_id": session.ID.String(),
+				}
+				if session.PrimaryThreadID != nil {
+					continuePayload["thread_id"] = session.PrimaryThreadID.String()
+				}
+				if _, err := stores.Jobs.Enqueue(ctx, orgID, "agent", "continue_session", continuePayload, 5, &dedupeKey); err != nil {
+					return fmt.Errorf("enqueue slack session continuation: %w", err)
+				}
+				ackText := slackSessionAckText(services, session.ID, "Continuing")
+				if posted, err := slackClient.PostMessage(ctx, slackCfg.AccessToken, payload.ChannelID, threadTS, ackText); err != nil {
+					logger.Warn().Err(err).Str("session_id", session.ID.String()).Msg("failed to post Slack continuation acknowledgement")
+				} else {
+					recordSlackOutbound(ctx, stores, services, logger, existingLink, posted.Timestamp, models.SlackOutboundMessageKindAck, "sent", ackText)
+				}
+				return stores.SlackInboundEvents.MarkProcessed(ctx, orgID, inboundID)
 			}
-			if err := stores.SessionMessages.Create(ctx, msg); err != nil {
-				return fmt.Errorf("create slack follow-up message: %w", err)
-			}
-			scopeID := session.ID
-			if session.PrimaryThreadID != nil {
-				scopeID = *session.PrimaryThreadID
-			}
-			dedupeKey := db.ContinueSessionDedupeKey(scopeID)
-			continuePayload := map[string]string{
-				"org_id":     orgID.String(),
-				"session_id": session.ID.String(),
-			}
-			if session.PrimaryThreadID != nil {
-				continuePayload["thread_id"] = session.PrimaryThreadID.String()
-			}
-			if _, err := stores.Jobs.Enqueue(ctx, orgID, "agent", "continue_session", continuePayload, 5, &dedupeKey); err != nil {
-				return fmt.Errorf("enqueue slack session continuation: %w", err)
-			}
-			ackText := slackSessionAckText(services, session.ID, "Continuing")
-			if posted, err := slackClient.PostMessage(ctx, slackCfg.AccessToken, payload.ChannelID, threadTS, ackText); err != nil {
-				logger.Warn().Err(err).Str("session_id", session.ID.String()).Msg("failed to post Slack continuation acknowledgement")
-			} else {
-				recordSlackOutbound(ctx, stores, services, logger, existingLink, posted.Timestamp, models.SlackOutboundMessageKindAck, "sent", ackText)
-			}
-			return stores.SlackInboundEvents.MarkProcessed(ctx, orgID, inboundID)
+			logger.Info().
+				Str("session_id", session.ID.String()).
+				Str("status", string(session.Status)).
+				Msg("linked Slack session is not resumable; starting a new session for thread")
 		}
 		if linkErr != nil && !errors.Is(linkErr, pgx.ErrNoRows) {
 			return fmt.Errorf("get slack session link: %w", linkErr)
@@ -1627,6 +1635,10 @@ func slackStartSessionLinkThreadTS(payload models.SlackStartSessionJobPayload, r
 	default:
 		return payload.MessageTS
 	}
+}
+
+func slackShouldContinueLinkedSession(status models.SessionStatus) bool {
+	return status.CanAddThread()
 }
 
 func slackSourceHasMessagePermalink(source string) bool {
@@ -2183,7 +2195,11 @@ func renderSlackNotification(services *Services, input models.SlackSendNotificat
 		})
 	}
 	if input.PreviewID != "" {
-		value, _ := json.Marshal(map[string]string{"org_id": input.OrgID, "preview_id": input.PreviewID})
+		valueFields := map[string]string{"org_id": input.OrgID, "preview_id": input.PreviewID}
+		if input.SessionID != "" {
+			valueFields["session_id"] = input.SessionID
+		}
+		value, _ := json.Marshal(valueFields)
 		elements = append(elements, map[string]any{
 			"type":      "button",
 			"action_id": "slack_open_preview",
@@ -3105,48 +3121,43 @@ func handleSlackPreviewAction(ctx context.Context, stores *Stores, services *Ser
 }
 
 func authorizeSlackPreviewAction(ctx context.Context, stores *Stores, input models.SlackInteractionJobPayload, orgID uuid.UUID) error {
-	if input.UserID == "" {
-		return fmt.Errorf("slack preview action requires a Slack user")
+	if stores == nil {
+		return fmt.Errorf("slack preview action dependencies are not configured")
 	}
-	if stores != nil && stores.SlackChannels != nil && input.ChannelID != "" {
-		settings, err := stores.SlackChannels.GetByChannel(ctx, orgID, input.TeamID, input.ChannelID)
-		if err != nil && !errors.Is(err, pgx.ErrNoRows) {
-			return fmt.Errorf("load slack channel settings for preview action: %w", err)
-		}
-		if err == nil && !stringSliceContains(settings.AllowedActions, "preview") {
-			return fmt.Errorf("slack preview action is not allowed in this channel")
-		}
+	var value struct {
+		SessionID string `json:"session_id"`
 	}
-	if stores != nil && stores.SlackUserLinks != nil {
-		link, err := stores.SlackUserLinks.GetBySlackUser(ctx, orgID, input.TeamID, input.UserID)
+	if input.Value != "" {
+		_ = json.Unmarshal([]byte(input.Value), &value)
+	}
+	isOriginatingTeamSession := false
+	if value.SessionID != "" && stores.SlackSessionLinks != nil {
+		sessionID, err := uuid.Parse(value.SessionID)
 		if err != nil {
-			if errors.Is(err, pgx.ErrNoRows) {
-				return nil
-			}
-			return fmt.Errorf("resolve slack user for preview action: %w", err)
+			return fmt.Errorf("parse slack preview action session_id: %w", err)
 		}
-		if link.UserID == nil {
-			return nil
-		}
-		if stores.Memberships != nil {
-			membership, err := stores.Memberships.Get(ctx, *link.UserID, orgID)
-			if err != nil {
-				return fmt.Errorf("load linked user membership for preview action: %w", err)
-			}
-			if membership.Role == models.RoleViewer {
-				return fmt.Errorf("slack preview action requires a non-viewer 143 role")
-			}
-		} else if stores.Users != nil {
-			user, err := stores.Users.GetByID(ctx, orgID, *link.UserID)
-			if err != nil {
-				return fmt.Errorf("load linked user for preview action: %w", err)
-			}
-			if user.Role == models.RoleViewer {
-				return fmt.Errorf("slack preview action requires a non-viewer 143 role")
-			}
+		link, err := stores.SlackSessionLinks.GetBySession(ctx, orgID, sessionID)
+		if err != nil && !errors.Is(err, pgx.ErrNoRows) {
+			return fmt.Errorf("load slack session link for preview action: %w", err)
+		} else if err == nil {
+			isOriginatingTeamSession = link.TeamSession &&
+				link.SlackTeamID == input.TeamID &&
+				link.SlackChannelID == input.ChannelID
 		}
 	}
-	return nil
+	authorizer := slackbotsvc.NewAuthorizer(stores.SlackUserLinks, stores.Memberships, stores.SlackChannels)
+	_, err := authorizer.Authorize(ctx, slackbotsvc.ActionRequest{
+		OrgID:                    orgID,
+		TeamID:                   input.TeamID,
+		ChannelID:                input.ChannelID,
+		SlackUserID:              input.UserID,
+		Capability:               slackbotsvc.CapabilityPreview,
+		AllowedRoles:             []models.Role{models.RoleAdmin, models.RoleMember, models.RoleBuilder},
+		RequireMapped:            !isOriginatingTeamSession,
+		AllowUnmappedTeamSession: true,
+		IsOriginatingTeamSession: isOriginatingTeamSession,
+	})
+	return err
 }
 
 func stringSliceContains(values []string, target string) bool {

--- a/internal/worker/handlers_test.go
+++ b/internal/worker/handlers_test.go
@@ -239,6 +239,34 @@ func TestSlackThreadRoutingBySource(t *testing.T) {
 	}
 }
 
+func TestSlackShouldContinueLinkedSession(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		status   models.SessionStatus
+		expected bool
+	}{
+		{name: "pending linked session continues", status: models.SessionStatusPending, expected: true},
+		{name: "running linked session continues", status: models.SessionStatusRunning, expected: true},
+		{name: "idle linked session continues", status: models.SessionStatusIdle, expected: true},
+		{name: "completed linked session is resumable", status: models.SessionStatusCompleted, expected: true},
+		{name: "failed linked session is resumable", status: models.SessionStatusFailed, expected: true},
+		{name: "cancelled linked session is resumable", status: models.SessionStatusCancelled, expected: true},
+		{name: "skipped linked session starts fresh", status: models.SessionStatusSkipped, expected: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			actual := slackShouldContinueLinkedSession(tt.status)
+
+			require.Equal(t, tt.expected, actual, "Slack thread reuse should follow session resumability")
+		})
+	}
+}
+
 type workerLinearCredentialReader struct{}
 
 func (workerLinearCredentialReader) Get(context.Context, uuid.UUID, models.ProviderName) (*models.DecryptedCredential, error) {


### PR DESCRIPTION
## Summary

Updated [docs/design/future/92-slackbot-product-surface.md](/home/sandbox/143/docs/design/future/92-slackbot-product-surface.md) to reflect the implemented areas:

- Bumped `Last reviewed` to `2026-05-31`.
- Clarified implemented admin Slack user mapping APIs.
- Clarified implemented preview authorization behavior.
- Clarified implemented Slack thread resumability behavior.
- Added admin mapping endpoints to the Authenticated Product APIs section.
- Reworded remaining work so completed behavior is not listed as missing.

## Test plan

Validated by automated agent run.


[143.dev](https://143.dev) | [session 1a72f42b](https://143.dev/sessions/1a72f42b-e4c4-4055-bc66-ac9d1f00fc0c)

Preview: https://143.dev/previews/github/assembledhq/143/pull/1234