### PR TITLE
Allow mixed preview bundles with env vars and one file

### DIFF
--- a/docs/design/future/87-preview-secret-bundles.md
+++ b/docs/design/future/87-preview-secret-bundles.md
@@ -118,8 +118,8 @@ Use the simplest repo-facing shape:
 }
 ```
 
-Only `bundle` and `services` are required. `env` and `files` are optional non-secret hints that let 143 show a useful setup checklist before the bundle exists.
-When `files` is present, `services` must include every preview service because generated files are written into the shared workspace. If an env var should go only to a backend service, use a separate env-only bundle.
+Only `bundle` and `services` are required. `env` and `files` are optional non-secret hints that let 143 show a useful setup checklist before the bundle exists. A managed bundle may deliver multiple environment variables and one generated file.
+When `files` is present, `services` must include every preview service because the generated file is written into the shared workspace. If an env var should go only to a backend service, use a separate env-only bundle.
 
 Recommended field names:
 
@@ -129,7 +129,7 @@ Recommended field names:
 | `bundle` | Use one named bundle handle. | Short, stable, and easy to understand in code review. |
 | `services` | Use instead of `inject_into`. | It describes the outcome without implementation language. |
 | `env` | Optional list of secret env var names the repo expects. | Lets 143 prefill setup and explain missing values without putting values in Git. |
-| `files` | Optional list of generated secret config files the repo expects. | Makes file-based apps discoverable without committing the file contents. |
+| `files` | Optional generated secret config file the repo expects. | Makes file-based apps discoverable without committing the file contents; V1 admin bundles support one file output. |
 | `mode` | Avoid in new config. | A required enum like `managed_bundle` adds ceremony without helping the repo author. |
 | `credentials` | Keep as a backward-compatible alias. | Existing preview config already uses it, but it reads more like login credentials than app config secrets. |
 | `credential_set` | Deprecate in favor of `bundle`. | `bundle` covers env vars, files, and external sources. |

--- a/docs/public/guides/previews.mdx
+++ b/docs/public/guides/previews.mdx
@@ -292,7 +292,7 @@ For new configs, reference a named secret bundle. The repo declares only the bun
 }
 ```
 
-An org admin creates the `repo-dev` bundle outside the repo. The bundle can deliver env vars and generated files. For example, a file output can render a whole JSON document from one managed secret value:
+An org admin creates the `repo-dev` bundle outside the repo. The bundle can deliver multiple env vars and one generated file. For example, a file output can render a whole JSON document from one managed secret value:
 
 ```json
 {
@@ -328,7 +328,7 @@ The older `preview.credentials` shape is still accepted for an env-var-only mana
 
 In both models, the config only references admin-managed values by name and allowlists which outputs may be injected. Secret values are not committed to git.
 
-Scope env secrets to the smallest service list with `services` or legacy `inject_into`. A frontend service usually should not receive server-only secrets because public frontend frameworks can expose environment variables in browser bundles. File outputs are workspace-wide, so a bundle that generates files must list every preview service.
+Scope env secrets to the smallest service list with `services` or legacy `inject_into`. A frontend service usually should not receive server-only secrets because public frontend frameworks can expose environment variables in browser bundles. The file output is workspace-wide, so a bundle that generates a file must list every preview service.
 
 <Callout type="warning" title="Connected previews">
 Any preview with `preview.secrets`, `preview.credentials.mode` other than `none`, or `preview.network.destinations` is treated as connected. Connected previews pin launch behavior to the base branch so a session diff cannot change commands, ports, env handling, secret bundle names, or generated secret file paths while secrets are in scope.

--- a/docs/public/reference/preview-config.mdx
+++ b/docs/public/reference/preview-config.mdx
@@ -120,9 +120,9 @@ New preview configs should prefer `preview.secrets`. The legacy `preview.credent
 <ConfigField name="preview.secrets.bundle" type="string" required description="Name of the admin-managed preview secret bundle." />
 <ConfigField name="preview.secrets.services" type="string[]" required description="Service names that receive env outputs from the bundle. File outputs are workspace-wide and must list every preview service." />
 <ConfigField name="preview.secrets.env" type="string[]" description="Non-secret hint listing required env var names." />
-<ConfigField name="preview.secrets.files" type="string[]" description="Non-secret hint listing generated secret file paths, such as `development.conf.json`." />
+<ConfigField name="preview.secrets.files" type="string[]" description="Non-secret hint listing the generated secret file path, such as `development.conf.json`. V1 admin bundles support one file output." />
 
-`preview.secrets` may be a single object or an array of objects. The repo config never contains secret values. It only declares the bundle name, service scope, and expected output names.
+`preview.secrets` may be a single object or an array of objects. The repo config never contains secret values. It only declares the bundle name, service scope, and expected output names. A bundle may deliver multiple environment variables and one generated file.
 
 Admin-managed bundle outputs support:
 

--- a/frontend/src/app/(dashboard)/settings/previews/page.test.tsx
+++ b/frontend/src/app/(dashboard)/settings/previews/page.test.tsx
@@ -143,7 +143,7 @@ describe("PreviewSettingsPage", () => {
 
     await userEvent.click(await screen.findByRole("button", { name: /new bundle/i }));
 
-    expect(screen.getByRole("tablist", { name: "Delivery method" })).toBeInTheDocument();
+    expect(screen.getByRole("tablist", { name: "Bundle output editor" })).toBeInTheDocument();
     expect(screen.getByRole("tab", { name: "Environment variables" })).toHaveAttribute("aria-selected", "true");
     expect(screen.getByRole("tab", { name: "Secret file" })).toHaveAttribute("aria-selected", "false");
     expect(screen.getByText("Stored secrets")).toBeInTheDocument();
@@ -200,6 +200,65 @@ describe("PreviewSettingsPage", () => {
     });
   }, 10000);
 
+  it("saves multiple environment variables and one secret file in the same bundle", async () => {
+    let savedBody: unknown;
+    server.use(
+      http.get("*/api/v1/repositories", () => HttpResponse.json({ data: repos, meta: {} })),
+      http.get("*/api/v1/repositories/repo-1/preview-secret-bundles", () => HttpResponse.json({ data: [], meta: {} })),
+      http.get("*/api/v1/previews/api-tokens", () => HttpResponse.json({ data: [], meta: {} })),
+      http.post("*/api/v1/repositories/repo-1/preview-secret-bundles", async ({ request }) => {
+        savedBody = await request.json();
+        return HttpResponse.json({ data: bundle("bundle-2", "repo-1", "mixed") });
+      }),
+    );
+
+    renderWithProviders(<PreviewSettingsPage />);
+
+    await userEvent.click(await screen.findByRole("button", { name: /new bundle/i }));
+    await userEvent.type(screen.getByLabelText("Bundle name"), "mixed");
+    await userEvent.type(screen.getByLabelText("Secret name"), "DATABASE_URL");
+    await userEvent.type(screen.getByLabelText("Secret value"), "postgres://dev");
+    await userEvent.click(screen.getByRole("button", { name: "Add value" }));
+    await userEvent.type(screen.getByLabelText("Secret name 2"), "GOOGLE_DRIVE_REFRESH_TOKEN");
+    await userEvent.type(screen.getByLabelText("Secret value 2"), "refresh-token");
+    await userEvent.click(screen.getByRole("tab", { name: "Secret file" }));
+    await userEvent.type(screen.getByLabelText("Secret file path"), "development.conf.json");
+    await userEvent.click(screen.getByRole("combobox", { name: "Secret file type" }));
+    await userEvent.click(await screen.findByRole("option", { name: "JSON" }));
+    fireEvent.change(screen.getByLabelText("Secret file contents"), { target: { value: '{"api":"secret"}' } });
+    await userEvent.click(screen.getByRole("button", { name: /save/i }));
+
+    await waitFor(() => {
+      expect(savedBody).toEqual({
+        name: "mixed",
+        source: {
+          type: "managed",
+          values: {
+            DATABASE_URL: "postgres://dev",
+            GOOGLE_DRIVE_REFRESH_TOKEN: "refresh-token",
+            SECRET_FILE_CONTENT: '{"api":"secret"}',
+          },
+        },
+        outputs: [
+          {
+            type: "env",
+            values: {
+              DATABASE_URL: "secret:DATABASE_URL",
+              GOOGLE_DRIVE_REFRESH_TOKEN: "secret:GOOGLE_DRIVE_REFRESH_TOKEN",
+            },
+          },
+          {
+            type: "file",
+            path: "development.conf.json",
+            format: "json",
+            value: "secret:SECRET_FILE_CONTENT",
+          },
+        ],
+        exposure_policy: "preview_runtime",
+      });
+    });
+  }, 10000);
+
   it("uses the shared tooltip for disabled Save guidance", async () => {
     server.use(
       http.get("*/api/v1/repositories", () => HttpResponse.json({ data: repos, meta: {} })),
@@ -238,10 +297,10 @@ describe("PreviewSettingsPage", () => {
     expect(screen.getByRole("button", { name: /save/i })).toBeDisabled();
 
     await userEvent.hover(screen.getByText("Save").closest("span")!);
-    expect(await screen.findByRole("tooltip")).toHaveTextContent("Add at least one secret name and value");
+    expect(await screen.findByRole("tooltip")).toHaveTextContent("Add at least one environment variable or secret file");
   });
 
-  it("warns when editing a legacy bundle that has both env and file outputs", async () => {
+  it("allows editing a bundle that has both env and file outputs", async () => {
     const dualBundle = {
       id: "bundle-dual",
       repository_id: "repo-1",
@@ -268,10 +327,11 @@ describe("PreviewSettingsPage", () => {
 
     await userEvent.click((await screen.findAllByRole("button", { name: /edit dual-delivery/i }))[0]);
 
-    expect(screen.getByText(/uses both env vars and a secret file/i)).toBeInTheDocument();
+    expect(screen.getByText(/Add one or more environment variables and optionally one generated file/i)).toBeInTheDocument();
+    expect(screen.queryByText(/the other will be removed on save/i)).not.toBeInTheDocument();
   });
 
-  it("hides the re-enter file hint when switching to env delivery mode on a file bundle", async () => {
+  it("keeps the file-preservation hint available when editing a file bundle", async () => {
     const fileBundle = {
       id: "bundle-file",
       repository_id: "repo-1",
@@ -299,7 +359,7 @@ describe("PreviewSettingsPage", () => {
 
     await userEvent.click(screen.getByRole("tab", { name: "Environment variables" }));
 
-    expect(screen.queryByText(/leave the file contents blank/i)).not.toBeInTheDocument();
+    expect(screen.getByText(/leave the file contents blank/i)).toBeInTheDocument();
   });
 
   it("rejects invalid JSON in secret file contents when format is JSON", async () => {

--- a/frontend/src/app/(dashboard)/settings/previews/page.tsx
+++ b/frontend/src/app/(dashboard)/settings/previews/page.tsx
@@ -258,7 +258,7 @@ function PreviewSecretsSection() {
 
   useEffect(() => {
     const timeoutID = window.setTimeout(() => {
-      if (!dialogMode || form.deliveryMode !== "file" || form.fileFormat !== "json" || !form.fileContent) {
+      if (!dialogMode || form.fileFormat !== "json" || !form.fileContent) {
         setJSONValidationError(null);
         return;
       }
@@ -271,7 +271,7 @@ function PreviewSecretsSection() {
     }, JSON_FILE_VALIDATION_DEBOUNCE_MS);
 
     return () => window.clearTimeout(timeoutID);
-  }, [dialogMode, form.deliveryMode, form.fileContent, form.fileFormat]);
+  }, [dialogMode, form.fileContent, form.fileFormat]);
 
   function updateRow(index: number, patch: Partial<SecretValueRow>) {
     setForm((current) => ({
@@ -565,23 +565,25 @@ function BundleDialog({
   const isEdit = mode?.type === "edit";
   const editBundle = mode?.type === "edit" ? mode.bundle : null;
   const editHasFileOutputs = editBundle ? editBundle.outputs.some((o) => o.type === "file") : false;
-  const editHasEnvOutputs = editBundle ? editBundle.outputs.some((o) => o.type === "env") : false;
-  const editHasBothOutputs = editHasFileOutputs && editHasEnvOutputs;
-  const hasFilledValue = form.rows.some((row) => row.key.trim() && row.value);
-  const canPreserveFileContent = isEdit && editHasFileOutputs && form.deliveryMode === "file" && !form.fileContent;
+  const existingEnvNames = new Set(editBundle ? envNamesFromBundle(editBundle) : []);
+  const hasEnvOutput = form.rows.some((row) => {
+    const key = row.key.trim();
+    return key && (Boolean(row.value) || (isEdit && existingEnvNames.has(key)));
+  });
+  const wantsFileOutput = Boolean(form.filePath.trim()) || Boolean(form.fileContent);
+  const canPreserveFileContent = isEdit && editHasFileOutputs && Boolean(form.filePath.trim()) && !form.fileContent;
   const hasFileOutput = Boolean(form.filePath.trim()) && (Boolean(form.fileContent) || canPreserveFileContent);
   const canSave = Boolean(form.repositoryId)
     && Boolean(form.name.trim())
-    && (form.deliveryMode === "env" ? hasFilledValue : hasFileOutput);
-  const saveTooltip = form.deliveryMode === "file" && !form.filePath.trim()
+    && (hasEnvOutput || hasFileOutput)
+    && (!wantsFileOutput || hasFileOutput);
+  const saveTooltip = form.fileContent && !form.filePath.trim()
     ? "Add the secret file path before saving"
-    : form.deliveryMode === "file" && !form.fileContent && !canPreserveFileContent
+    : form.filePath.trim() && !form.fileContent && !canPreserveFileContent
       ? "Paste the secret file contents before saving"
-      : form.deliveryMode === "env" && isEdit && !hasFilledValue
-        ? "Re-enter at least one secret value to save changes"
-        : form.deliveryMode === "env" && !hasFilledValue
-          ? "Add at least one secret name and value"
-          : undefined;
+      : !hasEnvOutput && !hasFileOutput
+        ? "Add at least one environment variable or secret file"
+        : undefined;
 
   return (
     <Dialog open={Boolean(mode)} onOpenChange={onOpenChange}>
@@ -589,12 +591,10 @@ function BundleDialog({
         <DialogHeader>
           <DialogTitle>{isEdit ? "Edit bundle" : "New bundle"}</DialogTitle>
           <DialogDescription>
-            Secret values are not shown again after creation.
-            {editHasBothOutputs
-              ? " This bundle uses both env vars and a secret file. Choose which delivery method to keep — the other will be removed on save."
-              : editHasFileOutputs && form.deliveryMode === "file"
-                ? " Leave the file contents blank to keep the encrypted file already stored, or paste new contents to replace it."
-                : null}
+            Secret values are not shown again after creation. Add one or more environment variables and optionally one generated file.
+            {editHasFileOutputs
+              ? " Leave the file contents blank to keep the encrypted file already stored, or paste new contents to replace it."
+              : null}
           </DialogDescription>
         </DialogHeader>
         <form className="space-y-5" onSubmit={onSubmit}>
@@ -636,14 +636,14 @@ function BundleDialog({
             value={form.deliveryMode}
             onValueChange={(value) => onFormChange({ ...form, deliveryMode: value as BundleDeliveryMode })}
           >
-            <TabsList aria-label="Delivery method" className="w-full sm:w-fit">
+            <TabsList aria-label="Bundle output editor" className="w-full sm:w-fit">
               <TabsTrigger value="env">Environment variables</TabsTrigger>
               <TabsTrigger value="file">Secret file</TabsTrigger>
             </TabsList>
             <TabsContent value="env" className="space-y-4">
               <StoredSecretsFields
                 rows={form.rows}
-                description="Each secret name becomes an environment variable in the preview runtime."
+                description="Each secret name becomes an environment variable in the preview runtime. Existing values can stay blank unless you want to replace them."
                 onRowChange={onRowChange}
                 onRowAdd={onRowAdd}
                 onRowRemove={onRowRemove}
@@ -1123,66 +1123,70 @@ function buildBundleRequest(
     return new Error("Bundle name is required.");
   }
 
-  const values: Record<string, string> = {};
-  let outputs: PreviewSecretBundleOutput[] = [];
-  if (form.deliveryMode === "file") {
-    const path = form.filePath.trim();
-    if (!path) {
+  const sourceValues: Record<string, string> = {};
+  const outputs: PreviewSecretBundleOutput[] = [];
+  const existingEnvNames = new Set(mode.type === "edit" ? envNamesFromBundle(mode.bundle) : []);
+  const envValues: Record<string, string> = {};
+
+  for (const row of form.rows) {
+    const key = row.key.trim();
+    if (!key && !row.value) continue;
+    if (!key || (!row.value && (mode.type === "create" || !existingEnvNames.has(key)))) {
+      return new Error("Each new secret value needs both a key and a value.");
+    }
+    envValues[key] = `secret:${key}`;
+    if (row.value) {
+      sourceValues[key] = row.value;
+    }
+  }
+  if (Object.keys(envValues).length > 0) {
+    outputs.push({ type: "env" as const, values: envValues });
+  }
+
+  const filePath = form.filePath.trim();
+  const wantsFileOutput = Boolean(filePath) || Boolean(form.fileContent);
+  if (wantsFileOutput) {
+    if (!filePath) {
       return new Error("Secret file path is required.");
     }
     const fileOutput: PreviewSecretBundleOutput = {
       type: "file",
-      path,
+      path: filePath,
       format: form.fileFormat,
       value: `secret:${SECRET_FILE_KEY}`,
     };
-    if (!form.fileContent) {
-      if (mode.type === "edit") {
-        return {
-          name,
-          outputs: [fileOutput],
-          exposure_policy: "preview_runtime",
-        };
-      }
+    const canPreserveFileContent = mode.type === "edit"
+      && fileOutputsFromBundle(mode.bundle).length > 0
+      && !form.fileContent;
+    if (!form.fileContent && !canPreserveFileContent) {
       return new Error("Secret file contents are required.");
     }
-    if (form.fileFormat === "json") {
-      try {
-        JSON.parse(form.fileContent);
-      } catch {
-        return new Error(SECRET_FILE_JSON_ERROR);
+    if (form.fileContent) {
+      if (form.fileFormat === "json") {
+        try {
+          JSON.parse(form.fileContent);
+        } catch {
+          return new Error(SECRET_FILE_JSON_ERROR);
+        }
       }
+      sourceValues[SECRET_FILE_KEY] = form.fileContent;
     }
-    values[SECRET_FILE_KEY] = form.fileContent;
-    outputs = [fileOutput];
-  } else {
-    for (const row of form.rows) {
-      const key = row.key.trim();
-      if (!key && !row.value) continue;
-      if (!key || !row.value) {
-        return new Error("Each secret value needs both a key and a value.");
-      }
-      values[key] = row.value;
-    }
-    if (Object.keys(values).length === 0) {
-      return new Error("At least one secret value is required.");
-    }
-    const envValues = form.rows.reduce<Record<string, string>>((acc, row) => {
-      const key = row.key.trim();
-      if (key && row.value) {
-        acc[key] = `secret:${key}`;
-      }
-      return acc;
-    }, {});
-    outputs = Object.keys(envValues).length > 0 ? [{ type: "env" as const, values: envValues }] : [];
+    outputs.push(fileOutput);
   }
 
-  return {
+  if (outputs.length === 0) {
+    return new Error("At least one environment variable or secret file is required.");
+  }
+
+  const body: PreviewSecretBundlePatchRequest | PreviewSecretBundleUpsertRequest = {
     name,
-    source: { type: "managed", values },
     outputs,
     exposure_policy: "preview_runtime",
   };
+  if (Object.keys(sourceValues).length > 0 || mode.type === "create") {
+    body.source = { type: "managed", values: sourceValues };
+  }
+  return body;
 }
 
 function envNamesFromBundle(bundle: PreviewSecretBundleSummary): string[] {

--- a/internal/api/handlers/preview_secret_bundles.go
+++ b/internal/api/handlers/preview_secret_bundles.go
@@ -214,10 +214,13 @@ func (h *PreviewSecretBundleHandler) Patch(w http.ResponseWriter, r *http.Reques
 		name = *body.Name
 	}
 	if body.Source != nil {
-		source = *body.Source
+		source = mergePreviewSecretBundleSource(source, *body.Source)
 	}
 	if body.Outputs != nil {
 		outputs = *body.Outputs
+	}
+	if body.Source != nil || body.Outputs != nil {
+		source = prunePreviewSecretBundleSource(source, outputs)
 	}
 	exposurePolicy := existing.ExposurePolicy
 	if body.ExposurePolicy != nil {
@@ -489,6 +492,7 @@ func validatePreviewSecretBundleRequest(body previewSecretBundleUpsertRequest) [
 	if body.ExposurePolicy != "" && body.ExposurePolicy != "preview_runtime" {
 		errs = append(errs, `exposure_policy must be "preview_runtime"`)
 	}
+	fileOutputCount := 0
 	for i, output := range body.Outputs {
 		switch output.Type {
 		case "env":
@@ -496,6 +500,10 @@ func validatePreviewSecretBundleRequest(body previewSecretBundleUpsertRequest) [
 				errs = append(errs, "outputs["+strconv.Itoa(i)+"].values is required for env outputs")
 			}
 		case "file":
+			fileOutputCount++
+			if fileOutputCount > 1 {
+				errs = append(errs, "only one file output is supported")
+			}
 			if output.Path == "" {
 				errs = append(errs, "outputs["+strconv.Itoa(i)+"].path is required for file outputs")
 			}
@@ -517,6 +525,75 @@ func validatePreviewSecretBundleRequest(body previewSecretBundleUpsertRequest) [
 		}
 	}
 	return errs
+}
+
+func mergePreviewSecretBundleSource(existing, incoming models.PreviewSecretBundleSource) models.PreviewSecretBundleSource {
+	merged := models.PreviewSecretBundleSource{
+		Type:   incoming.Type,
+		Values: make(map[string]string, len(existing.Values)+len(incoming.Values)),
+	}
+	for key, value := range existing.Values {
+		merged.Values[key] = value
+	}
+	for key, value := range incoming.Values {
+		merged.Values[key] = value
+	}
+	return merged
+}
+
+func prunePreviewSecretBundleSource(source models.PreviewSecretBundleSource, outputs []models.PreviewSecretBundleOutput) models.PreviewSecretBundleSource {
+	refs := previewSecretBundleSourceRefs(outputs)
+	if len(refs) == 0 {
+		source.Values = nil
+		return source
+	}
+	pruned := make(map[string]string, len(refs))
+	for key := range refs {
+		if value, ok := source.Values[key]; ok {
+			pruned[key] = value
+		}
+	}
+	source.Values = pruned
+	return source
+}
+
+func previewSecretBundleSourceRefs(outputs []models.PreviewSecretBundleOutput) map[string]struct{} {
+	refs := make(map[string]struct{})
+	for _, output := range outputs {
+		collectPreviewSecretExpressionRef(output.Value, refs)
+		for _, expr := range output.Values {
+			collectPreviewSecretExpressionRef(expr, refs)
+		}
+		if len(output.Content) > 0 {
+			var content any
+			if err := json.Unmarshal(output.Content, &content); err == nil {
+				collectPreviewSecretContentRefs(content, refs)
+			}
+		}
+	}
+	return refs
+}
+
+func collectPreviewSecretContentRefs(value any, refs map[string]struct{}) {
+	switch typed := value.(type) {
+	case map[string]any:
+		for _, child := range typed {
+			collectPreviewSecretContentRefs(child, refs)
+		}
+	case []any:
+		for _, child := range typed {
+			collectPreviewSecretContentRefs(child, refs)
+		}
+	case string:
+		collectPreviewSecretExpressionRef(typed, refs)
+	}
+}
+
+func collectPreviewSecretExpressionRef(expr string, refs map[string]struct{}) {
+	key, ok := strings.CutPrefix(expr, "secret:")
+	if ok && key != "" {
+		refs[key] = struct{}{}
+	}
 }
 
 func isSafePreviewSecretFilePath(raw string) bool {

--- a/internal/api/handlers/preview_secret_bundles_test.go
+++ b/internal/api/handlers/preview_secret_bundles_test.go
@@ -20,18 +20,18 @@ import (
 )
 
 type fakePreviewSecretBundleStore struct {
-	upsertInput    *db.UpsertPreviewSecretBundleInput
-	replaceID      uuid.UUID
-	replaceInput   *db.UpsertPreviewSecretBundleInput
-	replaceErr     error
-	disabledName   string
-	disabledUser   uuid.UUID
-	row            models.PreviewSecretBundle
-	getByIDErr     error
-	source         models.PreviewSecretBundleSource
-	decryptSrcErr  error
-	outputs        []models.PreviewSecretBundleOutput
-	decryptOutErr  error
+	upsertInput   *db.UpsertPreviewSecretBundleInput
+	replaceID     uuid.UUID
+	replaceInput  *db.UpsertPreviewSecretBundleInput
+	replaceErr    error
+	disabledName  string
+	disabledUser  uuid.UUID
+	row           models.PreviewSecretBundle
+	getByIDErr    error
+	source        models.PreviewSecretBundleSource
+	decryptSrcErr error
+	outputs       []models.PreviewSecretBundleOutput
+	decryptOutErr error
 }
 
 func (s *fakePreviewSecretBundleStore) Upsert(_ context.Context, _ uuid.UUID, in db.UpsertPreviewSecretBundleInput) (*models.PreviewSecretBundle, error) {
@@ -122,6 +122,109 @@ func TestPreviewSecretBundleHandler_PatchByIDMergesExistingBundle(t *testing.T) 
 	require.Equal(t, "repo-renamed", store.replaceInput.Name, "Patch should apply the requested rename")
 	require.Equal(t, store.source, store.replaceInput.Source, "Patch should preserve source when omitted")
 	require.Equal(t, store.outputs, store.replaceInput.Outputs, "Patch should preserve outputs when omitted")
+}
+
+func TestPreviewSecretBundleHandler_PatchByIDMergesManagedSourceValues(t *testing.T) {
+	t.Parallel()
+
+	orgID := uuid.New()
+	repoID := uuid.New()
+	userID := uuid.New()
+	bundleID := uuid.New()
+	store := &fakePreviewSecretBundleStore{
+		row: models.PreviewSecretBundle{
+			ID:              bundleID,
+			OrgID:           orgID,
+			RepositoryID:    repoID,
+			Name:            "repo-dev",
+			SourceType:      "managed",
+			ExposurePolicy:  "preview_runtime",
+			CreatedByUserID: userID,
+			CreatedAt:       time.Now(),
+		},
+		source: models.PreviewSecretBundleSource{Type: "managed", Values: map[string]string{
+			"DATABASE_URL":        "postgres://old",
+			"SECRET_FILE_CONTENT": `{"token":"old"}`,
+		}},
+		outputs: []models.PreviewSecretBundleOutput{
+			{Type: "env", Values: map[string]string{"DATABASE_URL": "secret:DATABASE_URL"}},
+			{Type: "file", Path: "development.conf.json", Format: "json", Value: "secret:SECRET_FILE_CONTENT"},
+		},
+	}
+	handler := NewPreviewSecretBundleHandler(store)
+	body := bytes.NewBufferString(`{
+		"source": {"type": "managed", "values": {"GOOGLE_DRIVE_REFRESH_TOKEN": "refresh-token"}},
+		"outputs": [
+			{"type": "env", "values": {
+				"DATABASE_URL": "secret:DATABASE_URL",
+				"GOOGLE_DRIVE_REFRESH_TOKEN": "secret:GOOGLE_DRIVE_REFRESH_TOKEN"
+			}},
+			{"type": "file", "path": "development.conf.json", "format": "json", "value": "secret:SECRET_FILE_CONTENT"}
+		]
+	}`)
+	req := previewSecretBundleRequest(http.MethodPatch, "/api/v1/preview-secret-bundles/"+bundleID.String(), body, orgID, userID)
+	addURLParam(req, "id", bundleID.String())
+	rr := httptest.NewRecorder()
+
+	handler.Patch(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code, "Patch should return success when adding an env var to a bundle with a preserved file")
+	require.NotNil(t, store.replaceInput, "Patch should pass a replacement input")
+	require.Equal(t, map[string]string{
+		"DATABASE_URL":               "postgres://old",
+		"GOOGLE_DRIVE_REFRESH_TOKEN": "refresh-token",
+		"SECRET_FILE_CONTENT":        `{"token":"old"}`,
+	}, store.replaceInput.Source.Values, "Patch should merge new managed values with existing encrypted source values")
+}
+
+func TestPreviewSecretBundleHandler_PatchByIDPrunesRemovedManagedSourceValues(t *testing.T) {
+	t.Parallel()
+
+	orgID := uuid.New()
+	repoID := uuid.New()
+	userID := uuid.New()
+	bundleID := uuid.New()
+	store := &fakePreviewSecretBundleStore{
+		row: models.PreviewSecretBundle{
+			ID:              bundleID,
+			OrgID:           orgID,
+			RepositoryID:    repoID,
+			Name:            "repo-dev",
+			SourceType:      "managed",
+			ExposurePolicy:  "preview_runtime",
+			CreatedByUserID: userID,
+			CreatedAt:       time.Now(),
+		},
+		source: models.PreviewSecretBundleSource{Type: "managed", Values: map[string]string{
+			"DATABASE_URL":               "postgres://old",
+			"GOOGLE_DRIVE_REFRESH_TOKEN": "refresh-token",
+			"SECRET_FILE_CONTENT":        `{"token":"old"}`,
+		}},
+		outputs: []models.PreviewSecretBundleOutput{
+			{Type: "env", Values: map[string]string{
+				"DATABASE_URL":               "secret:DATABASE_URL",
+				"GOOGLE_DRIVE_REFRESH_TOKEN": "secret:GOOGLE_DRIVE_REFRESH_TOKEN",
+			}},
+			{Type: "file", Path: "development.conf.json", Format: "json", Value: "secret:SECRET_FILE_CONTENT"},
+		},
+	}
+	handler := NewPreviewSecretBundleHandler(store)
+	body := bytes.NewBufferString(`{
+		"outputs": [
+			{"type": "env", "values": {"DATABASE_URL": "secret:DATABASE_URL"}}
+		]
+	}`)
+	req := previewSecretBundleRequest(http.MethodPatch, "/api/v1/preview-secret-bundles/"+bundleID.String(), body, orgID, userID)
+	addURLParam(req, "id", bundleID.String())
+	rr := httptest.NewRecorder()
+
+	handler.Patch(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code, "Patch should return success when removing env and file outputs")
+	require.NotNil(t, store.replaceInput, "Patch should pass a replacement input")
+	require.Equal(t, map[string]string{
+		"DATABASE_URL": "postgres://old",
+	}, store.replaceInput.Source.Values, "Patch should remove managed values no longer referenced by active outputs")
 }
 
 func TestPreviewSecretBundleHandler_PatchByIDReturnsConflictForNameCollision(t *testing.T) {
@@ -335,6 +438,46 @@ func TestPreviewSecretBundleHandler_UpsertRejectsInvalidJSONFileValue(t *testing
 
 	require.Equal(t, http.StatusBadRequest, rr.Code, "Upsert should reject invalid JSON file secret values before saving")
 	require.Nil(t, store.upsertInput, "Upsert should not save invalid preview secret bundle output configuration")
+}
+
+func TestPreviewSecretBundleHandler_UpsertRejectsMultipleFileOutputs(t *testing.T) {
+	t.Parallel()
+
+	orgID := uuid.New()
+	repoID := uuid.New()
+	userID := uuid.New()
+	store := &fakePreviewSecretBundleStore{}
+	handler := NewPreviewSecretBundleHandler(store)
+	body := bytes.NewBufferString(`{
+		"name": "repo-dev",
+		"source": {"type": "managed", "values": {
+			"development_conf_json": "{\"token\":\"ok\"}",
+			"service_account_json": "{\"client_email\":\"dev@example.com\"}"
+		}},
+		"outputs": [
+			{
+				"type": "file",
+				"path": "development.conf.json",
+				"format": "json",
+				"value": "secret:development_conf_json"
+			},
+			{
+				"type": "file",
+				"path": "service-account.json",
+				"format": "json",
+				"value": "secret:service_account_json"
+			}
+		]
+	}`)
+	req := previewSecretBundleRequest(http.MethodPost, "/api/v1/repositories/"+repoID.String()+"/preview-secret-bundles", body, orgID, userID)
+	addURLParam(req, "id", repoID.String())
+	rr := httptest.NewRecorder()
+
+	handler.Upsert(rr, req)
+
+	require.Equal(t, http.StatusBadRequest, rr.Code, "Upsert should reject more than one file output per bundle")
+	require.Contains(t, rr.Body.String(), "INVALID_PREVIEW_SECRET_BUNDLE", "response should identify the invalid bundle request")
+	require.Nil(t, store.upsertInput, "Upsert should not save bundle output configuration with multiple files")
 }
 
 func TestPreviewSecretBundleHandler_DeletePassesUserForInactiveSuccessor(t *testing.T) {


### PR DESCRIPTION
## Summary
- Updated preview secret bundles so one bundle can carry multiple environment variables plus one generated file.
- Adjusted the preview settings UI, request building, and validation to support mixed env/file bundles.
- Added backend pruning so PATCH removes source values that are no longer referenced by active outputs, preventing stale secrets from lingering in `source_config`.
- Refreshed preview bundle docs to match the supported model.

## Testing
- Added and ran frontend coverage for mixed env+file creation and updated edit-state behavior.
- Added backend tests for merging preserved values, pruning removed values, and rejecting multiple file outputs.
- Verified with `go vet ./...`, `go build ./...`, and `go test ./...`.
- Verified frontend `typecheck`, `lint`, and `build` passed.