### PR TITLE
Fix worker deploy lock inheritance and retry transient capacity checks

### DIFF
--- a/deploy/deploy_config_test.go
+++ b/deploy/deploy_config_test.go
@@ -337,6 +337,7 @@ func TestWorkerBlueGreenPreflightChecksCapacitySchemaAndSupportServices(t *testi
 	require.Contains(t, deploy, "worker_host_capacity_preflight", "worker deploy should run a local CPU/memory capacity preflight before starting green")
 	require.Contains(t, deploy, "WORKER_BLUE_GREEN_MIN_FREE_MEMORY_MB", "worker deploy should let operators set the minimum free memory needed for temporary worker overlap")
 	require.Contains(t, deploy, "WORKER_BLUE_GREEN_MIN_IDLE_CPU_MILLIS", "worker deploy should let operators set the minimum idle CPU budget needed for temporary worker overlap")
+	require.Contains(t, deploy, "WORKER_BLUE_GREEN_PREFLIGHT_ATTEMPTS", "worker deploy should retry transient capacity preflight failures before failing a routine rollout")
 	require.Contains(t, deploy, "worker_support_service_fingerprint", "worker deploy should fingerprint support-service config inputs during preflight")
 	require.Contains(t, deploy, "--support-services-fingerprint", "worker deploy preflight should pass support-service fingerprints into worker-deployctl")
 	require.Contains(t, deploy, "--expected-schema-version", "worker deploy preflight should pass the expected migration/schema version into worker-deployctl")
@@ -873,6 +874,7 @@ func TestDeployPrunesDockerArtifactsAfterSuccessfulRollout(t *testing.T) {
 	require.NotContains(t, deployText, "run_worker_deployctl_in_container", "detached worker rollovers should not embed worker-container-bound deploy control helpers")
 	require.Contains(t, deployText, `IMAGE_TAG='$IMAGE_TAG'`, "detached worker rollovers should bake IMAGE_TAG so the prune helper can protect the sandbox image")
 	require.Contains(t, deployText, `prune_docker_deploy_artifacts worker`, "detached worker rollovers should prune only after the new worker is healthy")
+	require.Contains(t, deployText, `flock -xo /tmp/143-deploy-worker.lock`, "detached worker rollovers should not let background drain watchers inherit the deploy lock")
 	require.Contains(t, deployText, `prune_docker_deploy_artifacts "$ROLE"`, "synchronous deploy paths should prune after the rollout and health checks succeed")
 	require.Contains(t, deployText, `DEPLOY_DOCKER_PRUNE=0`, "operators should have an explicit escape hatch for incident response or rollback-cache preservation")
 }

--- a/deploy/scripts/deploy.sh
+++ b/deploy/scripts/deploy.sh
@@ -486,6 +486,8 @@ ssh "${SSH_OPTS[@]}" deploy@"$HOST" \
   "$(remote_env_assignment WORKER_DEPLOY_DRAIN_TIMEOUT_SECONDS "${WORKER_DEPLOY_DRAIN_TIMEOUT_SECONDS:-}")" \
   "$(remote_env_assignment WORKER_BLUE_GREEN_PORT_START "${WORKER_BLUE_GREEN_PORT_START:-}")" \
   "$(remote_env_assignment WORKER_BLUE_GREEN_PORT_END "${WORKER_BLUE_GREEN_PORT_END:-}")" \
+  "$(remote_env_assignment WORKER_BLUE_GREEN_PREFLIGHT_ATTEMPTS "${WORKER_BLUE_GREEN_PREFLIGHT_ATTEMPTS:-}")" \
+  "$(remote_env_assignment WORKER_BLUE_GREEN_PREFLIGHT_RETRY_DELAY_SECONDS "${WORKER_BLUE_GREEN_PREFLIGHT_RETRY_DELAY_SECONDS:-}")" \
   "$(remote_env_assignment WORKER_BASE_NODE_ID "${WORKER_BASE_NODE_ID:-}")" \
   "$(remote_env_assignment WORKER_DRAIN_TIMEOUT "${WORKER_DRAIN_TIMEOUT:-}")" \
   "$(remote_env_assignment DEPLOY_MODE "${DEPLOY_MODE:-routine}")" \
@@ -1053,22 +1055,45 @@ ssh "${SSH_OPTS[@]}" deploy@"$HOST" \
   worker_host_capacity_preflight() {
     local min_mem="${WORKER_BLUE_GREEN_MIN_FREE_MEMORY_MB:-512}"
     local min_cpu="${WORKER_BLUE_GREEN_MIN_IDLE_CPU_MILLIS:-250}"
+    local attempts="${WORKER_BLUE_GREEN_PREFLIGHT_ATTEMPTS:-3}"
+    local retry_delay="${WORKER_BLUE_GREEN_PREFLIGHT_RETRY_DELAY_SECONDS:-2}"
     local free_mem idle_cpu idle1 total1 idle2 total2 delta
+    local attempt
 
-    free_mem="$(awk '/MemAvailable:/ {printf "%d", $2 / 1024}' /proc/meminfo 2>/dev/null || echo 0)"
-    read -r idle1 total1 < <(awk '/^cpu / {idle=$5; total=0; for (i=2; i<=NF; i++) total+=$i; print idle, total; exit}' /proc/stat)
-    sleep 1
-    read -r idle2 total2 < <(awk '/^cpu / {idle=$5; total=0; for (i=2; i<=NF; i++) total+=$i; print idle, total; exit}' /proc/stat)
-    idle1="${idle1:-0}"
-    total1="${total1:-0}"
-    idle2="${idle2:-0}"
-    total2="${total2:-0}"
-    delta=$((total2 - total1))
-    if [ "$delta" -le 0 ]; then
-      idle_cpu=0
-    else
-      idle_cpu=$((((idle2 - idle1) * 1000) / delta))
+    if ! [[ "$attempts" =~ ^[0-9]+$ ]] || [ "$attempts" -lt 1 ]; then
+      attempts=1
     fi
+    if ! [[ "$retry_delay" =~ ^[0-9]+$ ]]; then
+      retry_delay=2
+    fi
+
+    for ((attempt = 1; attempt <= attempts; attempt++)); do
+      free_mem="$(awk '/MemAvailable:/ {printf "%d", $2 / 1024}' /proc/meminfo 2>/dev/null || echo 0)"
+      read -r idle1 total1 < <(awk '/^cpu / {idle=$5; total=0; for (i=2; i<=NF; i++) total+=$i; print idle, total; exit}' /proc/stat)
+      sleep 1
+      read -r idle2 total2 < <(awk '/^cpu / {idle=$5; total=0; for (i=2; i<=NF; i++) total+=$i; print idle, total; exit}' /proc/stat)
+      idle1="${idle1:-0}"
+      total1="${total1:-0}"
+      idle2="${idle2:-0}"
+      total2="${total2:-0}"
+      delta=$((total2 - total1))
+      if [ "$delta" -le 0 ]; then
+        idle_cpu=0
+      else
+        idle_cpu=$((((idle2 - idle1) * 1000) / delta))
+      fi
+
+      if [ "$free_mem" -ge "$min_mem" ] && [ "$idle_cpu" -ge "$min_cpu" ]; then
+        WORKER_BLUE_GREEN_FREE_MEMORY_MB="$free_mem"
+        WORKER_BLUE_GREEN_IDLE_CPU_MILLIS="$idle_cpu"
+        return 0
+      fi
+
+      if [ "$attempt" -lt "$attempts" ]; then
+        echo "Worker capacity preflight attempt ${attempt}/${attempts} below threshold: free=${free_mem}MB min=${min_mem}MB idle=${idle_cpu}m min=${min_cpu}m; retrying..." >&2
+        sleep "$retry_delay"
+      fi
+    done
 
     if [ "$free_mem" -lt "$min_mem" ]; then
       echo "ERROR: insufficient free memory for worker blue/green overlap: free=${free_mem}MB min=${min_mem}MB" >&2
@@ -1078,8 +1103,6 @@ ssh "${SSH_OPTS[@]}" deploy@"$HOST" \
       echo "ERROR: insufficient idle CPU for worker blue/green overlap: idle=${idle_cpu}m min=${min_cpu}m" >&2
       return 1
     fi
-    WORKER_BLUE_GREEN_FREE_MEMORY_MB="$free_mem"
-    WORKER_BLUE_GREEN_IDLE_CPU_MILLIS="$idle_cpu"
   }
 
   worker_support_service_fingerprint() {
@@ -1629,6 +1652,8 @@ DEPLOY_DOCKER_VOLUME_PRUNE='${DEPLOY_DOCKER_VOLUME_PRUNE:-0}'
 WORKER_DEPLOY_DRAIN_TIMEOUT_SECONDS='${WORKER_DEPLOY_DRAIN_TIMEOUT_SECONDS:-}'
 WORKER_BLUE_GREEN_PORT_START='${WORKER_BLUE_GREEN_PORT_START:-}'
 WORKER_BLUE_GREEN_PORT_END='${WORKER_BLUE_GREEN_PORT_END:-}'
+WORKER_BLUE_GREEN_PREFLIGHT_ATTEMPTS='${WORKER_BLUE_GREEN_PREFLIGHT_ATTEMPTS:-}'
+WORKER_BLUE_GREEN_PREFLIGHT_RETRY_DELAY_SECONDS='${WORKER_BLUE_GREEN_PREFLIGHT_RETRY_DELAY_SECONDS:-}'
 WORKER_BASE_NODE_ID='${WORKER_BASE_NODE_ID:-}'
 WORKER_DRAIN_TIMEOUT='${WORKER_DRAIN_TIMEOUT:-}'
 
@@ -1663,7 +1688,7 @@ EOS
       # </dev/null + redirect: nothing tied back to the SSH stdio so SSH can
       #   close cleanly.
       setsid bash -c "
-        flock -x /tmp/143-deploy-worker.lock '$rollover_script' >>'$log_file' 2>&1
+        flock -xo /tmp/143-deploy-worker.lock '$rollover_script' >>'$log_file' 2>&1
         rm -f '$rollover_script'
       " </dev/null >/dev/null 2>&1 &
       disown


### PR DESCRIPTION
## Summary
- Close the detached worker deploy lock before executing the rollover script so background drain watchers cannot keep `/tmp/143-deploy-worker.lock` held after the main deploy finishes.
- Add configurable retries to the worker CPU/memory preflight so one noisy sample does not fail a routine blue/green rollout immediately.
- Extend deploy config coverage for the new lock-handling and preflight settings.

## Testing
- `go test ./deploy -run 'TestDeployPrunesDockerArtifactsAfterSuccessfulRollout|TestWorkerBlueGreenPreflightChecksCapacitySchemaAndSupportServices'`
- `bash -n deploy/scripts/deploy.sh`