### PR TITLE
Fix preview sandbox retries for worker ownership races

### DIFF
--- a/internal/db/session_store.go
+++ b/internal/db/session_store.go
@@ -2421,6 +2421,26 @@ func (s *SessionStore) PeekContainerID(ctx context.Context, orgID, sessionID uui
 	return containerID, nil
 }
 
+// PeekContainerOwnership returns the current container_id and worker_node_id
+// using a narrow lookup for sandbox race handling. Empty strings represent
+// NULL values or a missing row.
+func (s *SessionStore) PeekContainerOwnership(ctx context.Context, orgID, sessionID uuid.UUID) (containerID string, workerNodeID string, err error) {
+	query := `SELECT COALESCE(container_id, ''), COALESCE(worker_node_id, '')
+		FROM sessions
+		WHERE id = @id AND org_id = @org_id AND deleted_at IS NULL`
+	err = s.db.QueryRow(ctx, query, pgx.NamedArgs{
+		"id":     sessionID,
+		"org_id": orgID,
+	}).Scan(&containerID, &workerNodeID)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return "", "", nil
+		}
+		return "", "", fmt.Errorf("peek container ownership: %w", err)
+	}
+	return containerID, workerNodeID, nil
+}
+
 // PublishHydratedContainerID is the preview-hydrate CAS: a preview has just
 // created a container from the session's snapshot and wants to publish its
 // ID so a concurrent ContinueSession can attach to the same container.

--- a/internal/services/preview/start_runner.go
+++ b/internal/services/preview/start_runner.go
@@ -27,6 +27,8 @@ import (
 
 const previewNoConfigMessage = "This repo has no .143/config.json committed with a preview section. Add one (see docs/guides/previews.md) so the preview knows what command to run."
 
+var ErrSandboxBusy = errors.New("session sandbox is busy")
+
 // StartRunner completes durable preview startup jobs after the API has
 // reserved the preview row and enqueued start_preview.
 type StartRunner struct {
@@ -303,6 +305,14 @@ func (r *StartRunner) StartReservedPreview(ctx context.Context, payload StartPre
 		if errors.Is(acq.Err, agent.ErrStaleSandboxIDCleared) {
 			return fmt.Errorf("%s: %w", acq.ErrCodeOr("STALE_SANDBOX_CLEARED"), acq.Err)
 		}
+		if errors.Is(acq.Err, agent.ErrSandboxOnDifferentNode) {
+			r.registerSandboxBusyDeadLetter(ctx, reservation)
+			return fmt.Errorf("%s: %w", acq.ErrCodeOr("SANDBOX_WRONG_NODE"), acq.Err)
+		}
+		if acq.ErrCode == "SANDBOX_BUSY" {
+			r.registerSandboxBusyDeadLetter(ctx, reservation)
+			return fmt.Errorf("%s: %w: %v", acq.ErrCode, ErrSandboxBusy, acq.Err)
+		}
 		r.abort(ctx, reservation, "", fmt.Sprintf("acquire sandbox: %v", acq.Err))
 		return fmt.Errorf("%s: %w", acq.ErrCodeOr("PREVIEW_HYDRATE_FAILED"), acq.Err)
 	}
@@ -397,6 +407,21 @@ func (r *StartRunner) registerCapacityDeadLetter(ctx context.Context, reservatio
 	})
 }
 
+func (r *StartRunner) registerSandboxBusyDeadLetter(ctx context.Context, reservation *models.PreviewInstance) {
+	if r == nil || r.manager == nil || reservation == nil {
+		return
+	}
+	jobctx.RegisterDeadLetterHook(ctx, func(hookCtx context.Context, deadLetterErr error) {
+		if deadLetterErr != nil {
+			r.logger.Warn().Err(deadLetterErr).
+				Str("preview_id", reservation.ID.String()).
+				Str("session_id", reservation.SessionID.String()).
+				Msg("preview start dead-lettered after sandbox-busy retries")
+		}
+		r.manager.AbortReservation(hookCtx, reservation, "", "Preview could not start because the session sandbox stayed busy. Try again after the current agent turn finishes.")
+	})
+}
+
 func (r *StartRunner) abort(ctx context.Context, reservation *models.PreviewInstance, hydratedID, reason string) {
 	if r.manager == nil || reservation == nil {
 		return
@@ -472,6 +497,9 @@ func (r *StartRunner) acquireSandbox(ctx context.Context, orgID uuid.UUID, sessi
 	workDir := r.resolveSandboxWorkDir(ctx, session)
 	if session.ContainerID != nil && *session.ContainerID != "" &&
 		session.SandboxState == models.SandboxStateRunning {
+		if ownerCheck := r.checkLiveContainerWorker(session.WorkerNodeID); ownerCheck.Err != nil {
+			return ownerCheck
+		}
 		candidate := &agent.Sandbox{
 			ID:        *session.ContainerID,
 			Provider:  "docker",
@@ -509,11 +537,14 @@ func (r *StartRunner) acquireSandbox(ctx context.Context, orgID uuid.UUID, sessi
 	sandboxCfg.Purpose = "preview_hydrate"
 	ApplyResourceLimitsToSandboxConfig(&sandboxCfg, cfg)
 
-	winningID, freshErr := r.sessions.PeekContainerID(ctx, orgID, session.ID)
+	winningID, winningWorkerID, freshErr := r.sessions.PeekContainerOwnership(ctx, orgID, session.ID)
 	switch {
 	case freshErr != nil:
 		r.logger.Warn().Err(freshErr).Str("session_id", session.ID.String()).Msg("preview hydrate: pre-hydrate peek failed; falling through to CAS race detection")
 	case winningID != "":
+		if ownerCheck := r.checkLiveContainerWorker(&winningWorkerID); ownerCheck.Err != nil {
+			return ownerCheck
+		}
 		if cleared, clearErr := r.clearStalePreviewContainer(ctx, orgID, session, winningID, workDir); clearErr != nil {
 			return acquireSandboxResult{ErrCode: "STALE_SANDBOX_CLEAR_FAILED", Err: clearErr}
 		} else if cleared {
@@ -557,6 +588,29 @@ func (r *StartRunner) acquireSandbox(ctx context.Context, orgID uuid.UUID, sessi
 	}
 
 	return acquireSandboxResult{Sandbox: sandbox, Hydrated: true}
+}
+
+func (r *StartRunner) checkLiveContainerWorker(workerNodeID *string) acquireSandboxResult {
+	if r == nil || r.nodeID == "" {
+		return acquireSandboxResult{}
+	}
+	owner := ""
+	if workerNodeID != nil {
+		owner = strings.TrimSpace(*workerNodeID)
+	}
+	if owner == "" {
+		return acquireSandboxResult{
+			ErrCode: "SANDBOX_BUSY",
+			Err:     fmt.Errorf("%w: session sandbox worker ownership is not recorded yet", ErrSandboxBusy),
+		}
+	}
+	if owner != r.nodeID {
+		return acquireSandboxResult{
+			ErrCode: "SANDBOX_WRONG_NODE",
+			Err:     fmt.Errorf("%w: session sandbox belongs to worker %s", agent.ErrSandboxOnDifferentNode, owner),
+		}
+	}
+	return acquireSandboxResult{}
 }
 
 func (r *StartRunner) clearStalePreviewContainer(ctx context.Context, orgID uuid.UUID, session *models.Session, containerID, workDir string) (bool, error) {

--- a/internal/services/preview/start_runner_test.go
+++ b/internal/services/preview/start_runner_test.go
@@ -205,9 +205,9 @@ func TestStartRunnerAcquireSandbox_ClearsStaleContainerIDBeforeHydrateRetry(t *t
 		SnapshotKey:  &snapshotKey,
 	}
 
-	mock.ExpectQuery(`SELECT COALESCE\(container_id, ''\)\s+FROM sessions`).
+	mock.ExpectQuery(`SELECT COALESCE\(container_id, ''\), COALESCE\(worker_node_id, ''\)\s+FROM sessions`).
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
-		WillReturnRows(pgxmock.NewRows([]string{"container_id"}).AddRow(staleContainerID))
+		WillReturnRows(pgxmock.NewRows([]string{"container_id", "worker_node_id"}).AddRow(staleContainerID, ""))
 	mock.ExpectExec(`UPDATE sessions\s+SET container_id = NULL,\s+worker_node_id = NULL,\s+turn_holding_container = FALSE`).
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
 		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
@@ -219,6 +219,62 @@ func TestStartRunnerAcquireSandbox_ClearsStaleContainerIDBeforeHydrateRetry(t *t
 	require.Nil(t, result.Sandbox, "stale cleanup should not hydrate in the same attempt")
 	require.Equal(t, []string{staleContainerID, staleContainerID}, provider.probedIDs, "runner should probe the recorded container before clearing it")
 	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
+}
+
+func TestStartRunnerAcquireSandbox_DoesNotProbeContainerOwnedByDifferentWorker(t *testing.T) {
+	t.Parallel()
+
+	orgID := uuid.New()
+	sessionID := uuid.New()
+	containerID := "container-on-other-worker"
+	workerNodeID := "worker-a"
+	provider := &acquireSandboxProvider{aliveByID: map[string]bool{containerID: false}}
+	runner := &StartRunner{
+		sandboxProvider: provider,
+		nodeID:          "worker-b",
+		logger:          zerolog.Nop(),
+	}
+	session := &models.Session{
+		ID:           sessionID,
+		OrgID:        orgID,
+		ContainerID:  &containerID,
+		WorkerNodeID: &workerNodeID,
+		SandboxState: models.SandboxStateRunning,
+	}
+
+	result := runner.acquireSandbox(context.Background(), orgID, session, nil)
+
+	require.ErrorIs(t, result.Err, agent.ErrSandboxOnDifferentNode, "live containers owned by another worker should be retried on that worker")
+	require.Equal(t, "SANDBOX_WRONG_NODE", result.ErrCode, "wrong-node live containers should use a stable preview error code")
+	require.Empty(t, provider.probedIDs, "runner must not probe a container on the local Docker daemon when another worker owns it")
+	require.Nil(t, result.Sandbox, "wrong-node acquisition should not return a sandbox")
+}
+
+func TestStartRunnerAcquireSandbox_WaitsForWorkerOwnershipBeforeProbe(t *testing.T) {
+	t.Parallel()
+
+	orgID := uuid.New()
+	sessionID := uuid.New()
+	containerID := "container-with-pending-owner"
+	provider := &acquireSandboxProvider{aliveByID: map[string]bool{containerID: false}}
+	runner := &StartRunner{
+		sandboxProvider: provider,
+		nodeID:          "worker-b",
+		logger:          zerolog.Nop(),
+	}
+	session := &models.Session{
+		ID:           sessionID,
+		OrgID:        orgID,
+		ContainerID:  &containerID,
+		SandboxState: models.SandboxStateRunning,
+	}
+
+	result := runner.acquireSandbox(context.Background(), orgID, session, nil)
+
+	require.ErrorIs(t, result.Err, ErrSandboxBusy, "live containers without worker ownership should be retried until ownership is visible")
+	require.Equal(t, "SANDBOX_BUSY", result.ErrCode, "pending worker ownership should keep the sandbox-busy retry contract")
+	require.Empty(t, provider.probedIDs, "runner must not probe a live container before worker ownership is known")
+	require.Nil(t, result.Sandbox, "pending worker ownership should not return a sandbox")
 }
 
 type acquireSandboxSnapshotStore struct{}

--- a/internal/worker/handlers.go
+++ b/internal/worker/handlers.go
@@ -142,6 +142,20 @@ func sandboxCapacityRetryTarget(ctx context.Context, stores *Stores, logger zero
 	return nil, true
 }
 
+func previewBusyRetryTarget(ctx context.Context, stores *Stores, logger zerolog.Logger, orgID, sessionID uuid.UUID) *string {
+	if stores == nil || stores.Sessions == nil {
+		return nil
+	}
+	session, err := stores.Sessions.GetByID(ctx, orgID, sessionID)
+	if err != nil {
+		logger.Warn().Err(err).
+			Str("session_id", sessionID.String()).
+			Msg("failed to load session worker target for sandbox-busy preview retry")
+		return nil
+	}
+	return models.SessionWorkerTarget(&session)
+}
+
 func registerStaleSandboxDeadLetter(ctx context.Context, stores *Stores, logger zerolog.Logger, session models.Session, threadID *uuid.UUID, jobType string) {
 	if stores == nil || stores.Sessions == nil {
 		return
@@ -649,6 +663,34 @@ func newStartPreviewHandler(stores *Stores, services *Services, logger zerolog.L
 					Dur("retry_after", retryAfter).
 					Msg("preview cleared stale sandbox container_id; retrying start_preview")
 				return &RetryableError{Err: err, RetryAfter: &retryAfter, BypassMaxRetryDuration: true}
+			}
+			if errors.Is(err, agent.ErrSandboxOnDifferentNode) {
+				retryAfter := 2 * time.Second
+				targetNodeID := previewBusyRetryTarget(ctx, stores, logger, input.OrgID, input.SessionID)
+				logEvent := logger.Info().
+					Err(err).
+					Str("preview_id", input.PreviewID.String()).
+					Str("session_id", input.SessionID.String()).
+					Dur("retry_after", retryAfter)
+				if targetNodeID != nil {
+					logEvent = logEvent.Str("target_node_id", *targetNodeID)
+				}
+				logEvent.Msg("preview sandbox is on another worker; retrying start_preview on the recorded owner")
+				return &RetryableError{Err: err, RetryAfter: &retryAfter, BypassMaxRetryDuration: true, TargetNodeID: targetNodeID}
+			}
+			if errors.Is(err, previewsvc.ErrSandboxBusy) {
+				retryAfter := 2 * time.Second
+				targetNodeID := previewBusyRetryTarget(ctx, stores, logger, input.OrgID, input.SessionID)
+				logEvent := logger.Info().
+					Err(err).
+					Str("preview_id", input.PreviewID.String()).
+					Str("session_id", input.SessionID.String()).
+					Dur("retry_after", retryAfter)
+				if targetNodeID != nil {
+					logEvent = logEvent.Str("target_node_id", *targetNodeID)
+				}
+				logEvent.Msg("preview sandbox is busy; retrying start_preview")
+				return &RetryableError{Err: err, RetryAfter: &retryAfter, TargetNodeID: targetNodeID}
 			}
 			enqueueSlackNotificationSubscribers(ctx, stores, logger, input.OrgID, slackNotificationFanoutInput{
 				EventKind: "preview.failed",

--- a/internal/worker/handlers_test.go
+++ b/internal/worker/handlers_test.go
@@ -3548,6 +3548,127 @@ func TestStartPreviewHandler_StaleSandboxClearedRetries(t *testing.T) {
 	require.Equal(t, payload, starter.payload, "start_preview handler should pass the decoded payload")
 }
 
+func TestStartPreviewHandler_SandboxBusyRetries(t *testing.T) {
+	t.Parallel()
+
+	logger := zerolog.Nop()
+	starter := &mockPreviewStarter{err: fmt.Errorf("SANDBOX_BUSY: %w: another process attached first", previewsvc.ErrSandboxBusy)}
+	handler := newStartPreviewHandler(nil, &Services{PreviewStarter: starter}, logger)
+
+	payload := previewsvc.StartPreviewJobPayload{
+		OrgID:     uuid.New(),
+		UserID:    uuid.New(),
+		SessionID: uuid.New(),
+		PreviewID: uuid.New(),
+	}
+	raw, err := json.Marshal(payload)
+	require.NoError(t, err, "start_preview payload should marshal")
+
+	err = handler(context.Background(), models.JobTypeStartPreview, raw)
+
+	var retryable *RetryableError
+	require.ErrorAs(t, err, &retryable, "sandbox-busy preview starts should requeue instead of dead-lettering")
+	require.ErrorIs(t, retryable.Err, previewsvc.ErrSandboxBusy, "retryable error should preserve the sandbox-busy sentinel")
+	require.NotNil(t, retryable.RetryAfter, "sandbox-busy retry should use an explicit short delay")
+	require.Equal(t, 2*time.Second, *retryable.RetryAfter, "sandbox-busy retry should run after the competing holder publishes or releases")
+	require.True(t, starter.called, "start_preview handler should call the preview starter before deciding retry behavior")
+	require.Equal(t, payload, starter.payload, "start_preview handler should pass the decoded payload")
+}
+
+func TestStartPreviewHandler_SandboxBusyTargetsRecordedWorker(t *testing.T) {
+	t.Parallel()
+
+	stores, mock := newTestStores(t)
+	defer mock.Close()
+
+	orgID := uuid.New()
+	sessionID := uuid.New()
+	previewID := uuid.New()
+	userID := uuid.New()
+	workerNodeID := "worker-recorded"
+	containerID := "container-on-recorded-worker"
+	snapshotKey := "snapshots/test/session.tar"
+
+	row := workerSessionRow(sessionID, uuid.Nil, orgID, models.SessionStatusRunning, 1, nil, &snapshotKey)
+	setWorkerSessionColumnValue(row, "container_id", &containerID)
+	setWorkerSessionColumnValue(row, "worker_node_id", &workerNodeID)
+	setWorkerSessionColumnValue(row, "sandbox_state", string(models.SandboxStateRunning))
+	mock.ExpectQuery("SELECT .* FROM sessions").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(
+			pgxmock.NewRows(workerSessionColumns).AddRow(row...),
+		)
+
+	logger := zerolog.Nop()
+	starter := &mockPreviewStarter{err: fmt.Errorf("SANDBOX_BUSY: %w: another process attached first", previewsvc.ErrSandboxBusy)}
+	handler := newStartPreviewHandler(stores, &Services{PreviewStarter: starter}, logger)
+
+	payload := previewsvc.StartPreviewJobPayload{
+		OrgID:     orgID,
+		UserID:    userID,
+		SessionID: sessionID,
+		PreviewID: previewID,
+	}
+	raw, err := json.Marshal(payload)
+	require.NoError(t, err, "start_preview payload should marshal")
+
+	err = handler(context.Background(), models.JobTypeStartPreview, raw)
+
+	var retryable *RetryableError
+	require.ErrorAs(t, err, &retryable, "sandbox-busy preview starts should requeue onto the session owner")
+	require.NotNil(t, retryable.TargetNodeID, "sandbox-busy retry should pin to the worker that owns the live session sandbox")
+	require.Equal(t, workerNodeID, *retryable.TargetNodeID, "sandbox-busy retry should target the recorded session worker")
+	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
+}
+
+func TestStartPreviewHandler_SandboxWrongNodeTargetsRecordedWorker(t *testing.T) {
+	t.Parallel()
+
+	stores, mock := newTestStores(t)
+	defer mock.Close()
+
+	orgID := uuid.New()
+	sessionID := uuid.New()
+	previewID := uuid.New()
+	userID := uuid.New()
+	workerNodeID := "worker-recorded"
+	containerID := "container-on-recorded-worker"
+	snapshotKey := "snapshots/test/session.tar"
+
+	row := workerSessionRow(sessionID, uuid.Nil, orgID, models.SessionStatusRunning, 1, nil, &snapshotKey)
+	setWorkerSessionColumnValue(row, "container_id", &containerID)
+	setWorkerSessionColumnValue(row, "worker_node_id", &workerNodeID)
+	setWorkerSessionColumnValue(row, "sandbox_state", string(models.SandboxStateRunning))
+	mock.ExpectQuery("SELECT .* FROM sessions").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(
+			pgxmock.NewRows(workerSessionColumns).AddRow(row...),
+		)
+
+	logger := zerolog.Nop()
+	starter := &mockPreviewStarter{err: fmt.Errorf("SANDBOX_WRONG_NODE: %w", agent.ErrSandboxOnDifferentNode)}
+	handler := newStartPreviewHandler(stores, &Services{PreviewStarter: starter}, logger)
+
+	payload := previewsvc.StartPreviewJobPayload{
+		OrgID:     orgID,
+		UserID:    userID,
+		SessionID: sessionID,
+		PreviewID: previewID,
+	}
+	raw, err := json.Marshal(payload)
+	require.NoError(t, err, "start_preview payload should marshal")
+
+	err = handler(context.Background(), models.JobTypeStartPreview, raw)
+
+	var retryable *RetryableError
+	require.ErrorAs(t, err, &retryable, "wrong-node preview starts should requeue onto the session owner")
+	require.ErrorIs(t, retryable.Err, agent.ErrSandboxOnDifferentNode, "retry should preserve the wrong-node sentinel")
+	require.NotNil(t, retryable.TargetNodeID, "wrong-node retry should pin to the worker that owns the live session sandbox")
+	require.Equal(t, workerNodeID, *retryable.TargetNodeID, "wrong-node retry should target the recorded session worker")
+	require.True(t, retryable.BypassMaxRetryDuration, "wrong-node retry should bypass the generic retry window")
+	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
+}
+
 func TestStartPreviewHandler_PreviewCapacityRetriesTargetsAvailableWorker(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- Add a narrow session ownership lookup so preview startup can tell whether a live sandbox is owned by the current worker before probing Docker.
- Treat sandbox-busy and wrong-node preview acquisition races as retryable instead of fatal.
- Keep preview retries pinned to the recorded worker when ownership is known, and add regression coverage for the new race paths.

## Testing
- `go vet ./...`
- `go build ./...`
- `go test ./...`