### PR TITLE
Merge Docker daemon hardening into one provisioning pass

### DIFF
--- a/deploy/deploy_config_test.go
+++ b/deploy/deploy_config_test.go
@@ -830,7 +830,8 @@ func TestDeployConfiguresDockerLogRotation(t *testing.T) {
 	provision, err := os.ReadFile("../deploy/scripts/provision.sh")
 	require.NoError(t, err, "test should read provision.sh")
 	provisionText := string(provision)
-	require.Contains(t, provisionText, "install-log-rotation.sh", "provision.sh should invoke install-log-rotation.sh after staging deploy/ so newly-provisioned hosts have rotation in place before services start (closes the provision-to-first-deploy unbounded-growth window)")
+	require.Contains(t, provisionText, "configure-docker-daemon.sh", "provision.sh should configure Docker daemon hardening through one helper so fresh hosts do not hit systemd start limits from sequential restarts")
+	require.NotContains(t, provisionText, `"/opt/143/deploy/scripts/install-log-rotation.sh $LOG_MAX_SIZE 5"`, "provision.sh must not invoke the log-rotation helper directly because the DNS helper would perform a second Docker restart on fresh hosts")
 	require.GreaterOrEqual(t, strings.Count(provisionText, "/usr/bin/chown -R deploy\\:deploy /opt/143/deploy/scripts"), 3, "provision.sh inline bootstraps for db, logging, and redis must allow deploy to fix root-owned deploy/scripts before syncing helpers")
 	// db/logging/redis bootstraps don't run bootstrap.sh, so each must
 	// install its own /etc/sudoers.d/99-deploy or the deploy+sudo path
@@ -948,13 +949,82 @@ func TestDeployPinsDockerDaemonDNSResolvers(t *testing.T) {
 	provision, err := os.ReadFile("../deploy/scripts/provision.sh")
 	require.NoError(t, err, "test should read provision.sh")
 	provisionText := string(provision)
-	require.Contains(t, provisionText, "install-docker-dns.sh 1.1.1.1 8.8.8.8 9.9.9.9", "provision.sh should pin DNS resolvers in /etc/docker/daemon.json before services start so newly-provisioned hosts don't inherit the host's single-upstream resolv.conf")
+	require.Contains(t, provisionText, "configure-docker-daemon.sh", "provision.sh should pin DNS resolvers as part of the single Docker daemon hardening pass before services start")
+	require.Contains(t, provisionText, "--dns 1.1.1.1 8.8.8.8 9.9.9.9", "provision.sh should pass three independent resolver operators into the daemon hardening helper")
+	require.NotContains(t, provisionText, `"/opt/143/deploy/scripts/install-docker-dns.sh 1.1.1.1 8.8.8.8 9.9.9.9"`, "provision.sh must not invoke the DNS helper directly because log rotation and DNS should share one Docker restart on fresh hosts")
 	require.GreaterOrEqual(t, strings.Count(provisionText, "/opt/143/deploy/scripts/install-docker-dns.sh *"), 3, "provision.sh inline bootstraps for db, logging, and redis must each grant deploy NOPASSWD sudo for install-docker-dns.sh")
 
 	repair, err := os.ReadFile("../deploy/scripts/repair-deploy-sudoers.sh")
 	require.NoError(t, err, "test should read repair-deploy-sudoers.sh")
 	repairText := string(repair)
 	require.Contains(t, repairText, "/opt/143/deploy/scripts/install-docker-dns.sh *", "repair-deploy-sudoers.sh should grant the install-docker-dns.sh sudoers entry — otherwise legacy-host repair via the no-teardown path leaves DNS pinning broken")
+}
+
+func TestConfigureDockerDaemonMergesHardeningInOnePass(t *testing.T) {
+	t.Parallel()
+
+	helper, err := os.ReadFile("../deploy/scripts/configure-docker-daemon.sh")
+	require.NoError(t, err, "test should read configure-docker-daemon.sh")
+	helperText := string(helper)
+	require.Contains(t, helperText, "systemctl reset-failed docker.service docker.socket", "configure-docker-daemon.sh should clear systemd start-rate limits before retrying Docker startup")
+	require.Contains(t, helperText, "systemctl restart docker", "configure-docker-daemon.sh should apply changed daemon config with a Docker restart")
+	require.Contains(t, helperText, "docker info", "configure-docker-daemon.sh should verify Docker is usable after restart")
+
+	tmp := t.TempDir()
+	daemonPath := filepath.Join(tmp, "daemon.json")
+	initial := `{
+  "runtimes": {
+    "runsc": {
+      "path": "/usr/bin/runsc",
+      "runtimeArgs": ["--ignore-cgroups", "--host-uds=open"]
+    }
+  },
+  "features": {
+    "containerd-snapshotter": true
+  }
+}`
+	require.NoError(t, os.WriteFile(daemonPath, []byte(initial), 0o640), "test should seed daemon.json with worker runtime and operator-owned keys")
+
+	cmd := exec.Command(
+		"bash",
+		"../deploy/scripts/configure-docker-daemon.sh",
+		"--log-max-size", "100m",
+		"--log-max-file", "5",
+		"--dns", "1.1.1.1", "8.8.8.8", "9.9.9.9",
+	)
+	cmd.Env = append(os.Environ(),
+		"DAEMON_JSON="+daemonPath,
+		"SKIP_DOCKER_RESTART=1",
+	)
+	output, err := cmd.CombinedOutput()
+	require.NoError(t, err, "configure-docker-daemon.sh should merge Docker hardening settings without requiring a live daemon: %s", string(output))
+
+	raw, err := os.ReadFile(daemonPath)
+	require.NoError(t, err, "test should read the merged daemon.json")
+
+	var merged map[string]any
+	require.NoError(t, json.Unmarshal(raw, &merged), "merged daemon.json should remain valid JSON")
+	require.Equal(t, "json-file", merged["log-driver"], "merged daemon.json should set the json-file log driver")
+	require.Equal(t, []any{"1.1.1.1", "8.8.8.8", "9.9.9.9"}, merged["dns"], "merged daemon.json should set the complete resolver list")
+
+	logOpts, ok := merged["log-opts"].(map[string]any)
+	require.True(t, ok, "merged daemon.json should include log-opts")
+	require.Equal(t, "100m", logOpts["max-size"], "merged daemon.json should set the requested max log size")
+	require.Equal(t, "5", logOpts["max-file"], "merged daemon.json should set the requested max log file count")
+
+	runtimes, ok := merged["runtimes"].(map[string]any)
+	require.True(t, ok, "merged daemon.json should preserve existing runtimes")
+	runsc, ok := runtimes["runsc"].(map[string]any)
+	require.True(t, ok, "merged daemon.json should preserve the runsc runtime block")
+	require.Equal(t, "/usr/bin/runsc", runsc["path"], "merged daemon.json should preserve runsc path")
+
+	features, ok := merged["features"].(map[string]any)
+	require.True(t, ok, "merged daemon.json should preserve unrelated operator-owned keys")
+	require.Equal(t, true, features["containerd-snapshotter"], "merged daemon.json should preserve unrelated nested values")
+
+	info, err := os.Stat(daemonPath)
+	require.NoError(t, err, "test should stat daemon.json after merge")
+	require.Equal(t, os.FileMode(0o640), info.Mode().Perm(), "configure-docker-daemon.sh should preserve daemon.json file permissions")
 }
 
 func TestProvisionWaitsForDockerDaemonBeforePullingImages(t *testing.T) {

--- a/deploy/scripts/configure-docker-daemon.sh
+++ b/deploy/scripts/configure-docker-daemon.sh
@@ -1,0 +1,152 @@
+#!/usr/bin/env bash
+# Configure Docker daemon host-wide settings in one atomic pass.
+#
+# Fresh provisioning needs several daemon.json hardening settings before the
+# first compose up: bounded json-file logs and a pinned multi-resolver DNS list.
+# Applying those with separate helpers can restart Docker multiple times on a
+# fresh host, tripping systemd's start-rate limit after bootstrap/gVisor also
+# touches the daemon. This helper merges the full desired daemon state and
+# restarts Docker at most once when the normalized file changes.
+
+set -euo pipefail
+
+DAEMON_JSON="${DAEMON_JSON:-/etc/docker/daemon.json}"
+LOG_MAX_SIZE=""
+LOG_MAX_FILE=""
+DNS_RESOLVERS=()
+
+usage() {
+  echo "Usage: $0 --log-max-size <size> --log-max-file <count> --dns <resolver> [<resolver>...]" >&2
+}
+
+is_ip_literal() {
+  local arg="$1"
+  if [[ "$arg" =~ ^([0-9]{1,3}\.){3}[0-9]{1,3}$ ]]; then
+    local IFS=.
+    local -a parts=($arg)
+    for p in "${parts[@]}"; do
+      if [ "$p" -lt 0 ] || [ "$p" -gt 255 ]; then
+        return 1
+      fi
+    done
+    return 0
+  fi
+  if [[ "$arg" =~ ^[0-9a-fA-F:]+$ && "$arg" == *:* ]]; then
+    return 0
+  fi
+  return 1
+}
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --log-max-size)
+      LOG_MAX_SIZE="${2:?--log-max-size requires a value}"
+      shift 2
+      ;;
+    --log-max-file)
+      LOG_MAX_FILE="${2:?--log-max-file requires a value}"
+      shift 2
+      ;;
+    --dns)
+      shift
+      while [ "$#" -gt 0 ] && [[ "$1" != --* ]]; do
+        DNS_RESOLVERS+=("$1")
+        shift
+      done
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "configure-docker-daemon: unknown option: $1" >&2
+      usage
+      exit 1
+      ;;
+  esac
+done
+
+if [ -z "$LOG_MAX_SIZE" ] || [ -z "$LOG_MAX_FILE" ] || [ "${#DNS_RESOLVERS[@]}" -eq 0 ]; then
+  usage
+  exit 1
+fi
+
+for resolver in "${DNS_RESOLVERS[@]}"; do
+  if ! is_ip_literal "$resolver"; then
+    echo "configure-docker-daemon: invalid resolver '$resolver' (must be a literal IPv4/IPv6 address)" >&2
+    exit 1
+  fi
+done
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "configure-docker-daemon: jq not installed — required for daemon.json merge. Install with: apt-get install -y jq" >&2
+  exit 1
+fi
+
+CURRENT='{}'
+if [ -s "$DAEMON_JSON" ]; then
+  if ! jq -e . "$DAEMON_JSON" >/dev/null 2>&1; then
+    echo "configure-docker-daemon: $DAEMON_JSON is not valid JSON; refusing to overwrite operator state. Fix manually and re-run." >&2
+    exit 1
+  fi
+  CURRENT="$(cat "$DAEMON_JSON")"
+fi
+
+DESIRED="$(printf '%s' "$CURRENT" | jq -S \
+  --arg max_size "$LOG_MAX_SIZE" \
+  --arg max_file "$LOG_MAX_FILE" \
+  --args '
+    . + {"log-driver": "json-file"}
+    | .["log-opts"] = ((.["log-opts"] // {}) + {"max-size": $max_size, "max-file": $max_file})
+    | . + {dns: $ARGS.positional}
+  ' -- "${DNS_RESOLVERS[@]}")"
+CURRENT_NORM="$(printf '%s' "$CURRENT" | jq -S .)"
+
+if [ "$CURRENT_NORM" = "$DESIRED" ]; then
+  echo "configure-docker-daemon: daemon.json already configured (log max-size=$LOG_MAX_SIZE max-file=$LOG_MAX_FILE; dns=${DNS_RESOLVERS[*]}); skipping docker restart."
+  exit 0
+fi
+
+echo "configure-docker-daemon: updating $DAEMON_JSON (log max-size=$LOG_MAX_SIZE max-file=$LOG_MAX_FILE; dns=${DNS_RESOLVERS[*]}) — docker daemon will be restarted once, all containers on this host will recycle."
+mkdir -p "$(dirname "$DAEMON_JSON")"
+TMP="$(mktemp "${DAEMON_JSON}.new.XXXXXX")"
+trap 'rm -f "$TMP"' EXIT
+printf '%s\n' "$DESIRED" > "$TMP"
+if [ -e "$DAEMON_JSON" ]; then
+  EXISTING_MODE="$(stat -c %a "$DAEMON_JSON" 2>/dev/null || stat -f %Lp "$DAEMON_JSON")"
+  chmod "$EXISTING_MODE" "$TMP"
+else
+  chmod 0644 "$TMP"
+fi
+mv "$TMP" "$DAEMON_JSON"
+trap - EXIT
+
+if [ "${SKIP_DOCKER_RESTART:-0}" = "1" ]; then
+  echo "configure-docker-daemon: SKIP_DOCKER_RESTART=1; not restarting docker."
+  exit 0
+fi
+
+restart_docker() {
+  systemctl reset-failed docker.service docker.socket >/dev/null 2>&1 || true
+  if systemctl restart docker; then
+    return 0
+  fi
+  systemctl reset-failed docker.service docker.socket >/dev/null 2>&1 || true
+  systemctl start docker
+}
+
+if ! restart_docker; then
+  echo "configure-docker-daemon: docker restart failed after daemon.json update." >&2
+  systemctl status docker --no-pager >&2 || true
+  journalctl -u docker --no-pager -n 100 >&2 || true
+  exit 1
+fi
+
+if ! docker info >/dev/null 2>&1; then
+  echo "configure-docker-daemon: docker did not become usable after restart." >&2
+  systemctl status docker --no-pager >&2 || true
+  journalctl -u docker --no-pager -n 100 >&2 || true
+  exit 1
+fi
+
+echo "configure-docker-daemon: docker restarted with daemon hardening config."

--- a/deploy/scripts/provision.sh
+++ b/deploy/scripts/provision.sh
@@ -484,29 +484,23 @@ if [ "$ROLE" = "app" ]; then
   scp "${SCP_OPTS[@]}" "$PROJECT_DIR/Dockerfile.caddy" root@"$HOST":/opt/143/
 fi
 scp "${SCP_OPTS[@]}" -r "$PROJECT_DIR/deploy" root@"$HOST":/opt/143/
-ssh "${SSH_OPTS[@]}" root@"$HOST" "chown -R deploy:deploy /opt/143 && chmod +x /opt/143/deploy/scripts/install-log-rotation.sh /opt/143/deploy/scripts/install-docker-dns.sh /opt/143/deploy/scripts/install-tailscale.sh /opt/143/deploy/scripts/reconcile-worker-host.sh"
+ssh "${SSH_OPTS[@]}" root@"$HOST" "chown -R deploy:deploy /opt/143 && chmod +x /opt/143/deploy/scripts/configure-docker-daemon.sh /opt/143/deploy/scripts/install-log-rotation.sh /opt/143/deploy/scripts/install-docker-dns.sh /opt/143/deploy/scripts/install-tailscale.sh /opt/143/deploy/scripts/reconcile-worker-host.sh"
 
-# Step 2a: Cap docker container log files (max-size/max-file in
-# /etc/docker/daemon.json) BEFORE step 5 starts services. Closes the
-# provision-to-first-deploy window where new containers would log
-# unboundedly. db gets a larger cap because postgres logs every
-# connection / slow query / lock wait, and the db host has no Vector log
-# shipping — the local docker log is the only copy of that trail.
+# Step 2a: Configure Docker daemon hardening in one pass BEFORE step 5
+# starts services. This pins bounded json-file logs and multi-provider DNS
+# resolvers while preserving existing daemon keys such as the worker runsc
+# runtime. Applying both settings through one helper avoids back-to-back
+# Docker restarts on fresh hosts, which can trip systemd's start-rate limit
+# after bootstrap/gVisor has already touched the daemon.
+#
+# db gets a larger log cap because postgres logs every connection / slow
+# query / lock wait, and the db host has no Vector log shipping — the local
+# docker log is the only copy of that trail.
 case "$ROLE" in
   db) LOG_MAX_SIZE="500m" ;;
   *)  LOG_MAX_SIZE="100m" ;;
 esac
-ssh "${SSH_OPTS[@]}" root@"$HOST" "/opt/143/deploy/scripts/install-log-rotation.sh $LOG_MAX_SIZE 5"
-
-# Step 2a (continued): Pin Docker daemon DNS to multiple independent
-# resolvers. Without this, the embedded resolver at 127.0.0.11 inherits the
-# host's resolv.conf — usually a single provider DNS — so one upstream
-# outage takes the whole fleet's container DNS down at once. The
-# 2026-05-07T04:15Z incident hit three workers simultaneously this way.
-# Order is fastest first; Docker's embedded resolver falls through to the
-# next on a SERVFAIL/timeout. Cloudflare + Google + Quad9 are independent
-# operators and networks.
-ssh "${SSH_OPTS[@]}" root@"$HOST" "/opt/143/deploy/scripts/install-docker-dns.sh 1.1.1.1 8.8.8.8 9.9.9.9"
+ssh "${SSH_OPTS[@]}" root@"$HOST" "/opt/143/deploy/scripts/configure-docker-daemon.sh --log-max-size $LOG_MAX_SIZE --log-max-file 5 --dns 1.1.1.1 8.8.8.8 9.9.9.9"
 wait_for_docker_daemon
 
 # Optional Tailscale enrollment. This runs before worker identity resolution


### PR DESCRIPTION
**Summary**
- Add `configure-docker-daemon.sh` to merge Docker log rotation and DNS pinning into a single daemon.json update.
- Update provisioning to use the new helper before services start, reducing back-to-back Docker restarts on fresh hosts.
- Preserve existing daemon.json state, including operator-owned keys and file permissions.
- Expand deploy tests to cover the new helper behavior and the updated provisioning flow.

**Testing**
- Added coverage for the provisioning script to verify it calls the combined helper and no longer invokes the old helpers directly.
- Added coverage for daemon.json merging to verify log settings, DNS resolvers, existing runtime config, and permissions are preserved.
- Not run (not requested)