### PR TITLE
Fix worker rollover deploy capacity and Postgres headroom

### DIFF
--- a/deploy/deploy_config_test.go
+++ b/deploy/deploy_config_test.go
@@ -344,6 +344,28 @@ func TestWorkerBlueGreenPreflightChecksCapacitySchemaAndSupportServices(t *testi
 	require.Contains(t, deploy, "impact --node-id", "worker deploy should emit a dry-run impact report for the old generation before routine drain")
 }
 
+func TestWorkerCapacityPreflightMeasuresIdleCPUMillicores(t *testing.T) {
+	t.Parallel()
+
+	deployScript, err := os.ReadFile("../deploy/scripts/deploy.sh")
+	require.NoError(t, err, "test should read deploy.sh")
+	preflight := extractShellFunction(t, string(deployScript), "worker_host_capacity_preflight", "worker_support_service_fingerprint")
+
+	require.Contains(t, preflight, "cpu_count", "worker capacity preflight should detect the number of online CPUs")
+	require.Contains(t, preflight, "* 1000 * cpu_count", "worker capacity preflight should convert idle CPU fraction into host-level millicores")
+	require.NotContains(t, preflight, "* 1000) / delta", "worker capacity preflight should not treat idle CPU percent as millicores")
+}
+
+func TestWorkerComposeCapsDatabasePool(t *testing.T) {
+	t.Parallel()
+
+	compose, err := os.ReadFile("../docker-compose.worker.yml")
+	require.NoError(t, err, "test should read worker compose")
+	composeText := string(compose)
+
+	require.Contains(t, composeText, "pool_max_conns=${WORKER_DATABASE_POOL_MAX_CONNS:-4}", "worker generations should cap pgx pool size so blue/green overlap cannot exhaust Postgres connections")
+}
+
 func TestWorkerDeployProtectsActiveExecutorImages(t *testing.T) {
 	t.Parallel()
 
@@ -851,6 +873,28 @@ func TestDeployConfiguresDockerLogRotation(t *testing.T) {
 	makefile, err := os.ReadFile("../Makefile")
 	require.NoError(t, err, "test should read Makefile")
 	require.Contains(t, string(makefile), "repair-deploy-sudoers:", "Makefile should expose the no-teardown sudoers repair as an operator target")
+}
+
+func TestProductionPostgresConnectionHeadroom(t *testing.T) {
+	t.Parallel()
+
+	conf, err := os.ReadFile("../deploy/postgres/postgresql.conf")
+	require.NoError(t, err, "test should read production PostgreSQL config")
+
+	require.Contains(t, string(conf), "max_connections = 200", "production Postgres should leave headroom for blue/green worker overlap and deploy-control clients")
+}
+
+func TestDBDeploySyncsMountedPostgresConfig(t *testing.T) {
+	t.Parallel()
+
+	deployScript, err := os.ReadFile("../deploy/scripts/deploy.sh")
+	require.NoError(t, err, "test should read deploy script")
+	deployText := string(deployScript)
+
+	require.Contains(t, deployText, `if [ "$ROLE" = "db" ]; then`, "db deploy should have role-specific sync for mounted Postgres config")
+	require.Contains(t, deployText, "$PROJECT_DIR/deploy/postgres/postgresql.conf", "db deploy should sync the mounted postgresql.conf")
+	require.Contains(t, deployText, "$PROJECT_DIR/deploy/postgres/pg_hba.conf", "db deploy should sync the mounted pg_hba.conf")
+	require.Contains(t, deployText, "mkdir -p /opt/143/deploy/postgres", "db deploy should ensure the mounted config directory exists")
 }
 
 func TestDeployPrunesDockerArtifactsAfterSuccessfulRollout(t *testing.T) {

--- a/deploy/postgres/postgresql.conf
+++ b/deploy/postgres/postgresql.conf
@@ -3,7 +3,7 @@
 # See docs/design/36-docker-agents-vps-architecture.md for scaling table.
 
 # -- Connections ---------------------------------------------------------------
-max_connections = 100
+max_connections = 200
 listen_addresses = '*'
 
 # -- Memory --------------------------------------------------------------------

--- a/deploy/scripts/deploy.sh
+++ b/deploy/scripts/deploy.sh
@@ -215,6 +215,11 @@ fi
 
 # Sync compose file so the remote always runs the latest version
 scp "${SCP_OPTS[@]}" "$PROJECT_DIR/$COMPOSE_FILE" deploy@"$HOST":/opt/143/
+if [ "$ROLE" = "db" ]; then
+  ssh "${SSH_OPTS[@]}" deploy@"$HOST" "mkdir -p /opt/143/deploy/postgres"
+  scp "${SCP_OPTS[@]}" "$PROJECT_DIR/deploy/postgres/postgresql.conf" deploy@"$HOST":/opt/143/deploy/postgres/
+  scp "${SCP_OPTS[@]}" "$PROJECT_DIR/deploy/postgres/pg_hba.conf" deploy@"$HOST":/opt/143/deploy/postgres/
+fi
 if [ "$ROLE" = "app" ] || [ "$ROLE" = "worker" ] || [ "$ROLE" = "logging" ]; then
   scp "${SCP_OPTS[@]}" "$PROJECT_DIR/docker-compose.vector.yml" deploy@"$HOST":/opt/143/
   ssh "${SSH_OPTS[@]}" deploy@"$HOST" "mkdir -p /opt/143/deploy /opt/143/deploy/scripts"
@@ -1057,7 +1062,7 @@ ssh "${SSH_OPTS[@]}" deploy@"$HOST" \
     local min_cpu="${WORKER_BLUE_GREEN_MIN_IDLE_CPU_MILLIS:-250}"
     local attempts="${WORKER_BLUE_GREEN_PREFLIGHT_ATTEMPTS:-3}"
     local retry_delay="${WORKER_BLUE_GREEN_PREFLIGHT_RETRY_DELAY_SECONDS:-2}"
-    local free_mem idle_cpu idle1 total1 idle2 total2 delta
+    local free_mem idle_cpu idle1 total1 idle2 total2 delta cpu_count
     local attempt
 
     if ! [[ "$attempts" =~ ^[0-9]+$ ]] || [ "$attempts" -lt 1 ]; then
@@ -1065,6 +1070,10 @@ ssh "${SSH_OPTS[@]}" deploy@"$HOST" \
     fi
     if ! [[ "$retry_delay" =~ ^[0-9]+$ ]]; then
       retry_delay=2
+    fi
+    cpu_count="$(nproc 2>/dev/null || getconf _NPROCESSORS_ONLN 2>/dev/null || echo 1)"
+    if ! [[ "$cpu_count" =~ ^[0-9]+$ ]] || [ "$cpu_count" -lt 1 ]; then
+      cpu_count=1
     fi
 
     for ((attempt = 1; attempt <= attempts; attempt++)); do
@@ -1080,7 +1089,7 @@ ssh "${SSH_OPTS[@]}" deploy@"$HOST" \
       if [ "$delta" -le 0 ]; then
         idle_cpu=0
       else
-        idle_cpu=$((((idle2 - idle1) * 1000) / delta))
+        idle_cpu=$((((idle2 - idle1) * 1000 * cpu_count) / delta))
       fi
 
       if [ "$free_mem" -ge "$min_mem" ] && [ "$idle_cpu" -ge "$min_cpu" ]; then

--- a/docker-compose.worker.yml
+++ b/docker-compose.worker.yml
@@ -98,7 +98,7 @@ services:
     # or the node could heartbeat without a preview_internal_base_url.
     # If any error below fires, run: make provision-worker HOST=<this-host>
     environment:
-      DATABASE_URL: postgres://onefortythree:${DB_PASSWORD}@${DB_HOST}:5432/onefortythree?sslmode=disable
+      DATABASE_URL: "postgres://onefortythree:${DB_PASSWORD}@${DB_HOST}:5432/onefortythree?sslmode=disable&pool_max_conns=${WORKER_DATABASE_POOL_MAX_CONNS:-4}"
       ENV: production
       MODE: worker
       CHROME_WS_URL: ${CHROME_WS_URL:-ws://chrome:9222}

--- a/docs/design/36-docker-agents-vps-architecture.md
+++ b/docs/design/36-docker-agents-vps-architecture.md
@@ -1331,7 +1331,7 @@ to unhealthy nodes.
 #### Connection Pooling (PgBouncer) — When You Need It
 
 When total connections across all nodes approach 80% of `max_connections` (default
-100). Each node's pgx pool defaults to ~10 connections, so with 8+ nodes you're
+200). Each node's pgx pool defaults to ~10 connections, so with 16+ nodes you're
 getting close.
 
 Add to `docker-compose.db.yml`:
@@ -2131,7 +2131,7 @@ pool, _ := pgxpool.New(ctx, pgbouncerURL)  // port 6432
 
 This uses 1 Postgres connection per node for pub/sub (N connections total) while
 all regular queries still go through PgBouncer. At 20 nodes, that's 20 direct
-connections — well within `max_connections=100`.
+connections — well within `max_connections=200`.
 
 ### Frontend Containerization
 
@@ -2196,7 +2196,7 @@ on VPS with NVMe SSDs. Scale the memory settings with VPS RAM.
 # deploy/postgres/postgresql.conf
 
 # ── Connections ──────────────────────────────────────────────────────
-max_connections = 100
+max_connections = 200
 listen_addresses = '*'
 
 # ── Memory ───────────────────────────────────────────────────────────

--- a/internal/db/node_store.go
+++ b/internal/db/node_store.go
@@ -520,7 +520,7 @@ func (s *NodeStore) RetainActiveExecutorImages(ctx context.Context, params Retai
 		INSERT INTO worker_image_retention (
 			image, build_sha, node_id, executor_id, deploy_id, reason, expires_at
 		)
-		SELECT DISTINCT image, build_sha, host_node_id, id, @deploy_id, @reason, @expires_at
+		SELECT DISTINCT image, build_sha, host_node_id, id, @deploy_id, @reason, @expires_at::timestamptz
 		FROM session_executors
 		WHERE host_node_id = @node_id
 		  AND status IN ('starting', 'running', 'draining')

--- a/internal/db/node_store_test.go
+++ b/internal/db/node_store_test.go
@@ -277,3 +277,26 @@ func TestNodeStore_WorkerDeployImpactListsRuntimeIdentities(t *testing.T) {
 	}, impact.Items, "WorkerDeployImpact should preserve affected runtime identities")
 	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
 }
+
+func TestNodeStore_RetainActiveExecutorImagesCastsExpiry(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "pgxmock pool should be created")
+	defer mock.Close()
+
+	mock.ExpectExec("INSERT INTO worker_image_retention[\\s\\S]+@expires_at::timestamptz[\\s\\S]+FROM session_executors").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnResult(pgxmock.NewResult("INSERT", 2))
+
+	store := NewNodeStore(mock)
+	count, err := store.RetainActiveExecutorImages(context.Background(), RetainWorkerImagesParams{
+		NodeID:    "worker-1",
+		DeployID:  "deploy-1",
+		Reason:    "test retention",
+		ExpiresAt: time.Now().UTC().Add(time.Hour),
+	})
+	require.NoError(t, err, "RetainActiveExecutorImages should retain active image rows")
+	require.Equal(t, int64(2), count, "RetainActiveExecutorImages should return inserted row count")
+	require.NoError(t, mock.ExpectationsWereMet(), "retention insert should cast expires_at for Postgres type inference")
+}


### PR DESCRIPTION
## Summary
- Increase production Postgres `max_connections` to `200` and update the architecture doc to match.
- Sync the mounted Postgres config files during `deploy-db` so the new connection limit is actually applied on deploy.
- Fix worker blue/green rollout issues by casting retained executor expiry timestamps correctly and capping worker pgx pools via `pool_max_conns`.
- Correct the worker host CPU preflight to measure idle CPU in host-level millicores.
- Add regression tests covering the deploy config, DB retention insert, and compose rendering.

## Testing
- `go vet ./...`
- `go build ./...`
- `go test ./...`
- Verified `docker compose config` renders `pool_max_conns=4` by default and respects `WORKER_DATABASE_POOL_MAX_CONNS=7` override.