### PR TITLE
Finish Slackbot Product Surface PR/metrics/DM visibility wiring

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -495,6 +495,7 @@ func main() {
 			ReviewLoops:         db.NewSessionReviewLoopStore(pool),
 			SessionIssueLinks:   db.NewSessionIssueLinkStore(pool),
 			Previews:            previewStore,
+			PullRequests:        pullRequestStore,
 			SlackInstallations:  db.NewSlackInstallationStore(pool),
 			SlackUserLinks:      db.NewSlackUserLinkStore(pool),
 			SlackChannels:       db.NewSlackChannelSettingsStore(pool),

--- a/cmd/server/session_executor_main.go
+++ b/cmd/server/session_executor_main.go
@@ -291,6 +291,7 @@ func buildSessionExecutorRuntime(ctx context.Context, cfg *config.Config, pool *
 		ReviewLoops:         db.NewSessionReviewLoopStore(pool),
 		SessionIssueLinks:   db.NewSessionIssueLinkStore(pool),
 		Previews:            db.NewPreviewStore(pool),
+		PullRequests:        pullRequestStore,
 	}
 	if services.LinearAgentDeps != nil {
 		services.LinearAgentDeps.Stores = stores

--- a/docs/design/future/92-slackbot-product-surface.md
+++ b/docs/design/future/92-slackbot-product-surface.md
@@ -1,7 +1,7 @@
 # 92 - Slackbot Product Surface
 
 > **Status:** Partially implemented
-> **Last reviewed:** 2026-05-31
+> **Last reviewed:** 2026-06-01
 >
 > **Depends on:** Slack OAuth integration, session/job creation APIs, durable preview control plane, human input requests, and notification delivery primitives.
 
@@ -69,6 +69,7 @@ The current implementation provides the first usable Slackbot backend surface, b
 - Authenticated Slack settings APIs expose bot install metadata, bot reinstall, bot-visible channels with connected settings, channel setting updates, user-link listing, self-link, and self-unlink.
 - Slack thread context, detected references, and file metadata are bounded and included in the initial session prompt.
 - Slack acks and final replies are posted back to Slack, and final replies truncate long assistant responses with a session link fallback.
+- Final Slack replies append concrete user-facing outcome context when available: branch URL, PR URL/status/CI state, preview URL/status, and compact diff stats.
 - Slack progress/final/human-input/notification messages are recorded in `slack_outbound_messages`.
 - Human-input requests can be delivered to the originating Slack thread and answered from Slack through choice buttons or a free-form modal by linked users.
 - Slack notifications can fan out to subscribed channels or configured Slack user DMs from channel setting subscription JSON.
@@ -76,8 +77,9 @@ The current implementation provides the first usable Slackbot backend surface, b
 - Preview actions are wired for open, refresh/restart, stop, and extend. Refresh/restart currently both recycle the preview.
 - Slack preview actions use a shared Slack authorization service for channel capability checks, mapped-user membership roles, and the narrow unmapped-user allowance for originating team sessions.
 - Slack channel invite setup posts a channel-visible setup message with configure/start actions.
+- Channel `response_visibility = dm` is honored for Slack-started session acks, progress updates, final replies, and human-input delivery. DM delivery opens a bot DM to the originating Slack user and falls back to the thread if a DM cannot be opened.
 - Stored Slack inbound payloads redact known transient/secret fields such as `response_url`, `trigger_id`, and `token`.
-- Slackbot metrics exist for inbound events, session starts, outbound messages, Slack API failures, and interaction actions.
+- Slackbot metrics exist for inbound events, session starts, outbound messages, Slack API failures, interaction actions, Slack Events API rate-limit signals, and Slack message update latency.
 
 ### Remaining Work
 
@@ -87,11 +89,11 @@ The current implementation provides the first usable Slackbot backend surface, b
 - App Home Slack connection health does not yet show detailed install health, scopes, or remediation state.
 - Repository selection is offered for some missing-repository starts, but there are no full missing-context flows for preview target, PR, branch, issue, Sentry, or session resolution.
 - Mention/DM context detection does not yet resolve repository, PR, issue, Sentry URL, preview URL, branch, or file paths into structured typed context. Most detected references are still prompt text.
-- Channel `response_visibility = dm` is stored but not fully honored across ack, progress, final, human-input, and notification delivery.
+- Channel `response_visibility = dm` is not yet applied to general notification delivery; notification destinations still come from subscription JSON.
 - Slack progress rendering is still coarse. Runtime/tool/test/command/preview milestones are not normalized into sparse Slack updates.
 - Slack progress updates are not debounced by a per-thread timing policy.
 - The initial ack message is not consistently updated into the terminal state; later progress/final messages may be separate.
-- Final Slack output does not consistently append concrete PR URLs, preview URLs/status, changed-file summaries, or next-action buttons.
+- Final Slack output does not yet include next-action buttons for all outcomes.
 - Human-input requests do not have assigned-user DM delivery because the durable request model has no assigned-user field.
 - Human-input routing does not distinguish sensitive/personal requests from team-thread requests.
 - Team sessions with no mapped user cannot yet be claimed and answered from Slack by any authorized 143 user.
@@ -119,7 +121,6 @@ The current implementation provides the first usable Slackbot backend surface, b
 - Raw Slack message text is stored in inbound event payloads for audit/retry visibility; private-message minimization has not been designed.
 - Session attribution is represented by `origin = slack` and `slack_session_links`, but there is no `session_attribution` row or `source_metadata` field carrying sanitized Slack source metadata.
 - Slack context enters sessions as prompt text rather than structured attachments/references.
-- Slackbot metrics do not yet include dedicated rate-limit counters or message update latency.
 
 ## Surfaces
 

--- a/internal/api/handlers/slackbot.go
+++ b/internal/api/handlers/slackbot.go
@@ -188,6 +188,7 @@ func (h *SlackbotHandler) Events(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 	case models.SlackInboundEventTypeAppRateLimited:
+		h.metrics.RecordRateLimit(r.Context(), "events_api")
 		h.logger.Warn().Str("team_id", envelope.TeamID).Msg("Slack app rate limited events delivery")
 	case models.SlackInboundEventTypeMemberJoined:
 		payload := models.SlackInteractionJobPayload{

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -77,3 +77,17 @@ func TestMemoryMetrics_RecordInjectionAndReinforcement(t *testing.T) {
 	m.RecordInjection(ctx, 5)
 	m.RecordReinforcement(ctx, 3)
 }
+
+func TestSlackbotMetrics_RecordObservabilityCounters(t *testing.T) {
+	t.Parallel()
+
+	m, err := NewSlackbotMetrics()
+	require.NoError(t, err)
+	require.NotNil(t, m)
+	require.NotNil(t, m.RateLimitsTotal)
+	require.NotNil(t, m.MessageUpdateLatency)
+
+	ctx := context.Background()
+	m.RecordRateLimit(ctx, "events_api")
+	m.RecordMessageUpdateLatency(ctx, "chat.update", "sent", 12.5)
+}

--- a/internal/metrics/slackbot.go
+++ b/internal/metrics/slackbot.go
@@ -13,6 +13,8 @@ type SlackbotMetrics struct {
 	OutboundMessagesTotal   otelmetric.Int64Counter
 	SlackAPIFailuresTotal   otelmetric.Int64Counter
 	InteractionActionsTotal otelmetric.Int64Counter
+	RateLimitsTotal         otelmetric.Int64Counter
+	MessageUpdateLatency    otelmetric.Float64Histogram
 }
 
 func NewSlackbotMetrics() (*SlackbotMetrics, error) {
@@ -37,12 +39,29 @@ func NewSlackbotMetrics() (*SlackbotMetrics, error) {
 	if err != nil {
 		return nil, err
 	}
+	rateLimits, err := meter.Int64Counter("slackbot.rate_limits",
+		otelmetric.WithDescription("Slack rate-limit signals observed by source"),
+		otelmetric.WithUnit("{event}"),
+	)
+	if err != nil {
+		return nil, err
+	}
+	updateLatency, err := meter.Float64Histogram("slackbot.message_update_latency_ms",
+		otelmetric.WithDescription("Latency for Slack message update API calls"),
+		otelmetric.WithUnit("ms"),
+		otelmetric.WithExplicitBucketBoundaries(25, 50, 100, 250, 500, 1000, 2500, 5000, 10000),
+	)
+	if err != nil {
+		return nil, err
+	}
 	return &SlackbotMetrics{
 		InboundEventsTotal:      inbound,
 		SessionStartsTotal:      starts,
 		OutboundMessagesTotal:   outbound,
 		SlackAPIFailuresTotal:   failures,
 		InteractionActionsTotal: actions,
+		RateLimitsTotal:         rateLimits,
+		MessageUpdateLatency:    updateLatency,
 	}, nil
 }
 
@@ -79,4 +98,18 @@ func (m *SlackbotMetrics) RecordInteractionAction(ctx context.Context, actionID,
 		return
 	}
 	m.InteractionActionsTotal.Add(ctx, 1, otelmetric.WithAttributes(attrString("action_id", actionID), attrString("outcome", outcome)))
+}
+
+func (m *SlackbotMetrics) RecordRateLimit(ctx context.Context, source string) {
+	if m == nil {
+		return
+	}
+	m.RateLimitsTotal.Add(ctx, 1, otelmetric.WithAttributes(attrString("source", source)))
+}
+
+func (m *SlackbotMetrics) RecordMessageUpdateLatency(ctx context.Context, method, outcome string, latencyMS float64) {
+	if m == nil {
+		return
+	}
+	m.MessageUpdateLatency.Record(ctx, latencyMS, otelmetric.WithAttributes(attrString("method", method), attrString("outcome", outcome)))
 }

--- a/internal/worker/handlers.go
+++ b/internal/worker/handlers.go
@@ -437,6 +437,7 @@ type Stores struct {
 	ReviewLoops         *db.SessionReviewLoopStore
 	SessionIssueLinks   *db.SessionIssueLinkStore // nil-safe: needed for Linear milestones
 	Previews            *db.PreviewStore
+	PullRequests        *db.PullRequestStore
 	SlackInstallations  *db.SlackInstallationStore
 	SlackUserLinks      *db.SlackUserLinkStore
 	SlackChannels       *db.SlackChannelSettingsStore
@@ -1515,10 +1516,11 @@ func newSlackStartOrContinueSessionHandler(stores *Stores, services *Services, l
 					return fmt.Errorf("enqueue slack session continuation: %w", err)
 				}
 				ackText := slackSessionAckText(services, session.ID, "Continuing")
-				if posted, err := slackClient.PostMessage(ctx, slackCfg.AccessToken, payload.ChannelID, threadTS, ackText); err != nil {
+				ackChannelID, ackThreadTS := slackDeliveryTarget(ctx, stores, slackClient, slackCfg.AccessToken, logger, existingLink, threadTS)
+				if posted, err := slackClient.PostMessage(ctx, slackCfg.AccessToken, ackChannelID, ackThreadTS, ackText); err != nil {
 					logger.Warn().Err(err).Str("session_id", session.ID.String()).Msg("failed to post Slack continuation acknowledgement")
 				} else {
-					recordSlackOutbound(ctx, stores, services, logger, existingLink, posted.Timestamp, models.SlackOutboundMessageKindAck, "sent", ackText)
+					recordSlackOutboundInChannel(ctx, stores, services, logger, existingLink, ackChannelID, posted.Timestamp, models.SlackOutboundMessageKindAck, "sent", ackText)
 				}
 				return stores.SlackInboundEvents.MarkProcessed(ctx, orgID, inboundID)
 			}
@@ -1600,15 +1602,16 @@ func newSlackStartOrContinueSessionHandler(stores *Stores, services *Services, l
 		ackBlocks := slackSessionAckBlocks(ctx, stores, logger, orgID, installationID, payload.TeamID, payload.ChannelID, session, ackText)
 		var posted ingestion.SlackPostedMessage
 		var postErr error
+		ackChannelID, ackThreadTS := slackDeliveryTarget(ctx, stores, slackClient, slackCfg.AccessToken, logger, *link, threadTS)
 		if len(ackBlocks) > 0 {
-			posted, postErr = slackClient.PostMessageWithBlocks(ctx, slackCfg.AccessToken, payload.ChannelID, threadTS, ackText, ackBlocks)
+			posted, postErr = slackClient.PostMessageWithBlocks(ctx, slackCfg.AccessToken, ackChannelID, ackThreadTS, ackText, ackBlocks)
 		} else {
-			posted, postErr = slackClient.PostMessage(ctx, slackCfg.AccessToken, payload.ChannelID, threadTS, ackText)
+			posted, postErr = slackClient.PostMessage(ctx, slackCfg.AccessToken, ackChannelID, ackThreadTS, ackText)
 		}
 		if postErr != nil {
 			logger.Warn().Err(postErr).Str("session_id", session.ID.String()).Msg("failed to post Slack session acknowledgement")
 		} else {
-			recordSlackOutbound(ctx, stores, services, logger, *link, posted.Timestamp, models.SlackOutboundMessageKindAck, "sent", ackText)
+			recordSlackOutboundInChannel(ctx, stores, services, logger, *link, ackChannelID, posted.Timestamp, models.SlackOutboundMessageKindAck, "sent", ackText)
 		}
 		return stores.SlackInboundEvents.MarkProcessed(ctx, orgID, inboundID)
 	}
@@ -1653,6 +1656,52 @@ func slackReplyThreadTS(threadTS string) string {
 		return ""
 	}
 	return threadTS
+}
+
+func slackChannelResponseVisibility(ctx context.Context, stores *Stores, logger zerolog.Logger, orgID uuid.UUID, teamID, channelID string) string {
+	if stores == nil || stores.SlackChannels == nil || channelID == "" {
+		return "thread"
+	}
+	settings, err := stores.SlackChannels.GetByChannel(ctx, orgID, teamID, channelID)
+	if err != nil {
+		if !errors.Is(err, pgx.ErrNoRows) {
+			logger.Warn().Err(err).Str("channel_id", channelID).Msg("failed to load Slack response visibility")
+		}
+		return "thread"
+	}
+	return slackNormalizeResponseVisibility(settings.ResponseVisibility)
+}
+
+func slackNormalizeResponseVisibility(value string) string {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "dm":
+		return "dm"
+	default:
+		return "thread"
+	}
+}
+
+func slackDeliveryTargetFromVisibility(link models.SlackSessionLink, replyThreadTS, responseVisibility, dmChannelID string) (string, string, bool) {
+	if slackNormalizeResponseVisibility(responseVisibility) == "dm" && link.SlackUserID != "" && dmChannelID != "" {
+		return dmChannelID, "", true
+	}
+	return link.SlackChannelID, replyThreadTS, false
+}
+
+func slackDeliveryTarget(ctx context.Context, stores *Stores, slackClient *ingestion.SlackAPIClient, accessToken string, logger zerolog.Logger, link models.SlackSessionLink, replyThreadTS string) (string, string) {
+	visibility := slackChannelResponseVisibility(ctx, stores, logger, link.OrgID, link.SlackTeamID, link.SlackChannelID)
+	if visibility != "dm" || link.SlackUserID == "" {
+		channelID, threadTS, _ := slackDeliveryTargetFromVisibility(link, replyThreadTS, visibility, "")
+		return channelID, threadTS
+	}
+	dmChannelID, err := slackClient.OpenDM(ctx, accessToken, link.SlackUserID)
+	if err != nil {
+		logger.Warn().Err(err).Str("slack_user_id", link.SlackUserID).Msg("failed to open Slack DM; falling back to thread reply")
+		channelID, threadTS, _ := slackDeliveryTargetFromVisibility(link, replyThreadTS, "thread", "")
+		return channelID, threadTS
+	}
+	channelID, threadTS, _ := slackDeliveryTargetFromVisibility(link, replyThreadTS, visibility, dmChannelID)
+	return channelID, threadTS
 }
 
 func slackStartSessionReplyThreadTS(payload models.SlackStartSessionJobPayload) string {
@@ -1948,6 +1997,10 @@ func slackHomeAutomationRunBlock(services *Services, items []db.SlackHomeAutomat
 }
 
 func recordSlackOutbound(ctx context.Context, stores *Stores, services *Services, logger zerolog.Logger, link models.SlackSessionLink, ts string, kind models.SlackOutboundMessageKind, status, text string) {
+	recordSlackOutboundInChannel(ctx, stores, services, logger, link, link.SlackChannelID, ts, kind, status, text)
+}
+
+func recordSlackOutboundInChannel(ctx context.Context, stores *Stores, services *Services, logger zerolog.Logger, link models.SlackSessionLink, channelID, ts string, kind models.SlackOutboundMessageKind, status, text string) {
 	if services != nil && services.SlackbotMetrics != nil {
 		services.SlackbotMetrics.RecordOutboundMessage(ctx, string(kind), status)
 	}
@@ -1959,7 +2012,7 @@ func recordSlackOutbound(ctx context.Context, stores *Stores, services *Services
 		OrgID:              link.OrgID,
 		SlackSessionLinkID: &link.ID,
 		SlackTeamID:        link.SlackTeamID,
-		SlackChannelID:     link.SlackChannelID,
+		SlackChannelID:     channelID,
 		SlackMessageTS:     ts,
 		MessageKind:        kind,
 		Status:             status,
@@ -2006,15 +2059,20 @@ func newSlackPostRunUpdateHandler(stores *Stores, services *Services, logger zer
 		if text == "" {
 			text = "143 session update"
 		}
+		channelID, threadTS := slackDeliveryTarget(ctx, stores, slackClient, slackCfg.AccessToken, logger, link, slackReplyThreadTS(link.SlackThreadTS))
 		if link.LatestStatusMessageTS != nil && *link.LatestStatusMessageTS != "" {
-			if err := slackClient.UpdateMessage(ctx, slackCfg.AccessToken, link.SlackChannelID, *link.LatestStatusMessageTS, text); err != nil {
+			updateStarted := time.Now()
+			if err := slackClient.UpdateMessage(ctx, slackCfg.AccessToken, channelID, *link.LatestStatusMessageTS, text); err == nil {
+				recordSlackMessageUpdateLatency(ctx, services, "chat.update", "sent", time.Since(updateStarted))
+				recordSlackOutboundInChannel(ctx, stores, services, logger, link, channelID, *link.LatestStatusMessageTS, models.SlackOutboundMessageKindProgress, "sent", text)
+				return nil
+			} else {
+				recordSlackMessageUpdateLatency(ctx, services, "chat.update", "failed", time.Since(updateStarted))
+				logger.Warn().Err(err).Str("session_id", sessionID.String()).Msg("failed to update Slack progress message; posting a new update")
 				recordSlackAPIFailure(ctx, services, "chat.update")
-				return err
 			}
-			recordSlackOutbound(ctx, stores, services, logger, link, *link.LatestStatusMessageTS, models.SlackOutboundMessageKindProgress, "sent", text)
-			return nil
 		}
-		posted, err := slackClient.PostMessage(ctx, slackCfg.AccessToken, link.SlackChannelID, slackReplyThreadTS(link.SlackThreadTS), text)
+		posted, err := slackClient.PostMessage(ctx, slackCfg.AccessToken, channelID, threadTS, text)
 		if err != nil {
 			recordSlackAPIFailure(ctx, services, "chat.postMessage")
 			return err
@@ -2024,7 +2082,7 @@ func newSlackPostRunUpdateHandler(stores *Stores, services *Services, logger zer
 				logger.Warn().Err(updateErr).Str("session_id", sessionID.String()).Msg("failed to save Slack status message timestamp")
 			}
 		}
-		recordSlackOutbound(ctx, stores, services, logger, link, posted.Timestamp, models.SlackOutboundMessageKindProgress, "sent", text)
+		recordSlackOutboundInChannel(ctx, stores, services, logger, link, channelID, posted.Timestamp, models.SlackOutboundMessageKindProgress, "sent", text)
 		return nil
 	}
 }
@@ -2062,20 +2120,24 @@ func newSlackPostFinalResponseHandler(stores *Stores, services *Services, logger
 		text := renderSlackFinal(services, msg.Content, sessionID)
 		if stores.Sessions != nil {
 			if session, sessionErr := stores.Sessions.GetByID(ctx, orgID, sessionID); sessionErr == nil {
-				text = appendSlackSessionOutcome(text, session)
+				text = appendSlackSessionOutcomeDetails(text, loadSlackSessionOutcomeDetails(ctx, stores, services, logger, session))
 			} else {
 				logger.Warn().Err(sessionErr).Str("session_id", sessionID.String()).Msg("failed to load session outcome for Slack final response")
 			}
 		}
+		channelID, threadTS := slackDeliveryTarget(ctx, stores, slackClient, slackCfg.AccessToken, logger, link, slackReplyThreadTS(link.SlackThreadTS))
 		if link.LatestStatusMessageTS != nil && *link.LatestStatusMessageTS != "" {
 			terminal := "Completed\nSession: " + slackSessionURL(services, sessionID)
-			if err := slackClient.UpdateMessage(ctx, slackCfg.AccessToken, link.SlackChannelID, *link.LatestStatusMessageTS, terminal); err != nil {
+			updateStarted := time.Now()
+			if err := slackClient.UpdateMessage(ctx, slackCfg.AccessToken, channelID, *link.LatestStatusMessageTS, terminal); err != nil {
+				recordSlackMessageUpdateLatency(ctx, services, "chat.update", "failed", time.Since(updateStarted))
 				logger.Warn().Err(err).Str("session_id", sessionID.String()).Msg("failed to update Slack progress message to terminal state")
 			} else {
-				recordSlackOutbound(ctx, stores, services, logger, link, *link.LatestStatusMessageTS, models.SlackOutboundMessageKindProgress, "sent", terminal)
+				recordSlackMessageUpdateLatency(ctx, services, "chat.update", "sent", time.Since(updateStarted))
+				recordSlackOutboundInChannel(ctx, stores, services, logger, link, channelID, *link.LatestStatusMessageTS, models.SlackOutboundMessageKindProgress, "sent", terminal)
 			}
 		}
-		posted, err := slackClient.PostMessage(ctx, slackCfg.AccessToken, link.SlackChannelID, slackReplyThreadTS(link.SlackThreadTS), text)
+		posted, err := slackClient.PostMessage(ctx, slackCfg.AccessToken, channelID, threadTS, text)
 		if err != nil {
 			recordSlackAPIFailure(ctx, services, "chat.postMessage")
 			return err
@@ -2085,7 +2147,7 @@ func newSlackPostFinalResponseHandler(stores *Stores, services *Services, logger
 				logger.Warn().Err(updateErr).Str("session_id", sessionID.String()).Msg("failed to save Slack final message timestamp")
 			}
 		}
-		recordSlackOutbound(ctx, stores, services, logger, link, posted.Timestamp, models.SlackOutboundMessageKindFinal, "sent", text)
+		recordSlackOutboundInChannel(ctx, stores, services, logger, link, channelID, posted.Timestamp, models.SlackOutboundMessageKindFinal, "sent", text)
 		return nil
 	}
 }
@@ -2125,12 +2187,13 @@ func newSlackDeliverHumanInputHandler(stores *Stores, services *Services, logger
 			return fmt.Errorf("unexpected slack credential type")
 		}
 		text, blocks := renderSlackHumanInput(services, req, sessionID)
-		posted, err := slackClient.PostMessageWithBlocks(ctx, slackCfg.AccessToken, link.SlackChannelID, slackReplyThreadTS(link.SlackThreadTS), text, blocks)
+		channelID, threadTS := slackDeliveryTarget(ctx, stores, slackClient, slackCfg.AccessToken, logger, link, slackReplyThreadTS(link.SlackThreadTS))
+		posted, err := slackClient.PostMessageWithBlocks(ctx, slackCfg.AccessToken, channelID, threadTS, text, blocks)
 		if err != nil {
 			recordSlackAPIFailure(ctx, services, "chat.postMessage")
 			return err
 		}
-		recordSlackOutbound(ctx, stores, services, logger, link, posted.Timestamp, models.SlackOutboundMessageKindHumanInput, "sent", text)
+		recordSlackOutboundInChannel(ctx, stores, services, logger, link, channelID, posted.Timestamp, models.SlackOutboundMessageKindHumanInput, "sent", text)
 		return nil
 	}
 }
@@ -2378,6 +2441,13 @@ func recordSlackAPIFailure(ctx context.Context, services *Services, method strin
 	services.SlackbotMetrics.RecordAPIFailure(ctx, method)
 }
 
+func recordSlackMessageUpdateLatency(ctx context.Context, services *Services, method, outcome string, duration time.Duration) {
+	if services == nil || services.SlackbotMetrics == nil {
+		return
+	}
+	services.SlackbotMetrics.RecordMessageUpdateLatency(ctx, method, outcome, float64(duration.Milliseconds()))
+}
+
 func enqueueSlackSessionNotifications(ctx context.Context, stores *Stores, logger zerolog.Logger, orgID, sessionID uuid.UUID, automationRunID *uuid.UUID, eventKind, title, body string) {
 	enqueueSlackNotificationSubscribers(ctx, stores, logger, orgID, slackNotificationFanoutInput{
 		EventKind: eventKind,
@@ -2540,7 +2610,7 @@ func newSlackHandleInteractionHandler(stores *Stores, services *Services, logger
 				return handleSlackStartSessionModal(ctx, stores, input)
 			}
 			if input.CallbackID == "slack_human_input_freeform_modal" {
-				return handleSlackHumanInputFreeformModal(ctx, stores, slackClient, input)
+				return handleSlackHumanInputFreeformModal(ctx, stores, services, slackClient, input)
 			}
 			if input.CallbackID == "slack_configure_channel_modal" {
 				return handleSlackConfigureChannelModal(ctx, stores, input)
@@ -2561,7 +2631,7 @@ func newSlackHandleInteractionHandler(stores *Stores, services *Services, logger
 		case "slack_open_preview":
 			return handleSlackOpenPreview(ctx, stores, services, slackClient, input)
 		case "slack_answer_human_input":
-			return handleSlackHumanInputAnswer(ctx, stores, slackClient, input)
+			return handleSlackHumanInputAnswer(ctx, stores, services, slackClient, input)
 		case "slack_answer_human_input_freeform":
 			return handleSlackHumanInputFreeformPrompt(ctx, stores, slackClient, input)
 		case "slack_member_joined_channel":
@@ -3285,7 +3355,7 @@ func slackHumanInputFreeformModal(privateMetadata string) ingestion.SlackHomeVie
 	}
 }
 
-func handleSlackHumanInputFreeformModal(ctx context.Context, stores *Stores, slackClient *ingestion.SlackAPIClient, input models.SlackInteractionJobPayload) error {
+func handleSlackHumanInputFreeformModal(ctx context.Context, stores *Stores, services *Services, slackClient *ingestion.SlackAPIClient, input models.SlackInteractionJobPayload) error {
 	var payload struct {
 		View struct {
 			PrivateMetadata string `json:"private_metadata"`
@@ -3307,10 +3377,10 @@ func handleSlackHumanInputFreeformModal(ctx context.Context, stores *Stores, sla
 		"request_id": value.RequestID,
 		"answer":     answer,
 	})
-	return handleSlackHumanInputAnswer(ctx, stores, slackClient, input)
+	return handleSlackHumanInputAnswer(ctx, stores, services, slackClient, input)
 }
 
-func handleSlackHumanInputAnswer(ctx context.Context, stores *Stores, slackClient *ingestion.SlackAPIClient, input models.SlackInteractionJobPayload) error {
+func handleSlackHumanInputAnswer(ctx context.Context, stores *Stores, services *Services, slackClient *ingestion.SlackAPIClient, input models.SlackInteractionJobPayload) error {
 	if stores == nil || stores.HumanInputRequests == nil || stores.SlackUserLinks == nil || stores.Jobs == nil {
 		return fmt.Errorf("slack human-input dependencies are not configured")
 	}
@@ -3346,9 +3416,12 @@ func handleSlackHumanInputAnswer(ctx context.Context, stores *Stores, slackClien
 		if cred, credErr := stores.Credentials.Get(ctx, orgID, models.ProviderSlack); credErr == nil {
 			if slackCfg, ok := cred.Config.(models.SlackConfig); ok {
 				updateText := fmt.Sprintf("Answered by <@%s>: %s", input.UserID, answer)
+				updateStarted := time.Now()
 				if err := slackClient.UpdateMessage(ctx, slackCfg.AccessToken, input.ChannelID, input.MessageTS, updateText); err != nil {
+					recordSlackMessageUpdateLatency(ctx, services, "chat.update", "failed", time.Since(updateStarted))
 					return fmt.Errorf("update Slack human-input message: %w", err)
 				}
+				recordSlackMessageUpdateLatency(ctx, services, "chat.update", "sent", time.Since(updateStarted))
 			}
 		} else {
 			return fmt.Errorf("get slack credentials: %w", credErr)
@@ -3395,23 +3468,108 @@ func renderSlackFinal(services *Services, content string, sessionID uuid.UUID) s
 	return trimmed + "\n\nSession: " + slackSessionURL(services, sessionID)
 }
 
+type slackSessionOutcomeDetails struct {
+	Session     models.Session
+	PullRequest *models.PullRequest
+	Preview     *models.PreviewInstance
+	PreviewURL  string
+}
+
+func loadSlackSessionOutcomeDetails(ctx context.Context, stores *Stores, services *Services, logger zerolog.Logger, session models.Session) slackSessionOutcomeDetails {
+	details := slackSessionOutcomeDetails{Session: session}
+	if stores == nil {
+		return details
+	}
+	if stores.PullRequests != nil {
+		pr, err := stores.PullRequests.GetBySessionID(ctx, session.OrgID, session.ID)
+		if err == nil {
+			details.PullRequest = &pr
+		} else if !errors.Is(err, pgx.ErrNoRows) {
+			logger.Warn().Err(err).Str("session_id", session.ID.String()).Msg("failed to load pull request for Slack final response")
+		}
+	}
+	if stores.Previews != nil {
+		preview, err := stores.Previews.GetActivePreviewForSession(ctx, session.OrgID, session.ID)
+		if err != nil && errors.Is(err, pgx.ErrNoRows) {
+			preview, err = stores.Previews.GetLatestFailedPreviewForSession(ctx, session.OrgID, session.ID)
+		}
+		if err != nil && errors.Is(err, pgx.ErrNoRows) {
+			preview, err = stores.Previews.GetLatestTerminalPreviewForSession(ctx, session.OrgID, session.ID)
+		}
+		if err == nil && preview != nil {
+			details.Preview = preview
+			details.PreviewURL = slackPreviewURL(services, preview.ID)
+		} else if err != nil && !errors.Is(err, pgx.ErrNoRows) {
+			logger.Warn().Err(err).Str("session_id", session.ID.String()).Msg("failed to load preview for Slack final response")
+		}
+	}
+	return details
+}
+
 func appendSlackSessionOutcome(text string, session models.Session) string {
+	return appendSlackSessionOutcomeDetails(text, slackSessionOutcomeDetails{Session: session})
+}
+
+func appendSlackSessionOutcomeDetails(text string, details slackSessionOutcomeDetails) string {
+	session := details.Session
 	lines := []string{}
 	if session.BranchURL != nil && strings.TrimSpace(*session.BranchURL) != "" {
 		lines = append(lines, "Branch: "+strings.TrimSpace(*session.BranchURL))
 	}
-	if session.PRCreationState == models.PRCreationStateSucceeded {
+	if details.PullRequest != nil && strings.TrimSpace(details.PullRequest.GitHubPRURL) != "" {
+		lines = append(lines, slackPullRequestOutcomeLine(*details.PullRequest))
+	} else if session.PRCreationState == models.PRCreationStateSucceeded {
 		lines = append(lines, "PR: opened")
 	} else if session.PRCreationState == models.PRCreationStateFailed && session.PRCreationError != nil && strings.TrimSpace(*session.PRCreationError) != "" {
 		lines = append(lines, "PR: failed - "+strings.TrimSpace(*session.PRCreationError))
 	}
-	if len(session.DiffStats) > 0 && string(session.DiffStats) != "null" {
-		lines = append(lines, "Changes: diff available in 143")
+	if details.Preview != nil && strings.TrimSpace(details.PreviewURL) != "" {
+		lines = append(lines, fmt.Sprintf("Preview: %s - %s", details.Preview.Status, details.PreviewURL))
+	}
+	if line := slackDiffStatsOutcomeLine(session.DiffStats); line != "" {
+		lines = append(lines, line)
 	}
 	if len(lines) == 0 {
 		return text
 	}
 	return strings.TrimSpace(text) + "\n\n" + strings.Join(lines, "\n")
+}
+
+func slackPullRequestOutcomeLine(pr models.PullRequest) string {
+	line := "PR: " + strings.TrimSpace(pr.GitHubPRURL)
+	metadata := []string{}
+	if pr.Status != "" {
+		metadata = append(metadata, string(pr.Status))
+	}
+	if pr.CIStatus != "" {
+		metadata = append(metadata, "CI "+string(pr.CIStatus))
+	}
+	if len(metadata) > 0 {
+		line += " (" + strings.Join(metadata, ", ") + ")"
+	}
+	return line
+}
+
+func slackDiffStatsOutcomeLine(raw json.RawMessage) string {
+	if len(raw) == 0 || string(raw) == "null" {
+		return ""
+	}
+	var stats struct {
+		FilesChanged int `json:"files_changed"`
+		Added        int `json:"added"`
+		Removed      int `json:"removed"`
+	}
+	if err := json.Unmarshal(raw, &stats); err != nil {
+		return "Changes: diff available in 143"
+	}
+	if stats.FilesChanged == 0 && stats.Added == 0 && stats.Removed == 0 {
+		return ""
+	}
+	fileLabel := "files"
+	if stats.FilesChanged == 1 {
+		fileLabel = "file"
+	}
+	return fmt.Sprintf("Changes: %d %s, +%d/-%d", stats.FilesChanged, fileLabel, stats.Added, stats.Removed)
 }
 
 func fetchSlackThreadContext(ctx context.Context, client *ingestion.SlackAPIClient, accessToken, channelID, threadTS string, logger zerolog.Logger) []ingestion.SlackMessage {

--- a/internal/worker/handlers.go
+++ b/internal/worker/handlers.go
@@ -1996,10 +1996,6 @@ func slackHomeAutomationRunBlock(services *Services, items []db.SlackHomeAutomat
 	}
 }
 
-func recordSlackOutbound(ctx context.Context, stores *Stores, services *Services, logger zerolog.Logger, link models.SlackSessionLink, ts string, kind models.SlackOutboundMessageKind, status, text string) {
-	recordSlackOutboundInChannel(ctx, stores, services, logger, link, link.SlackChannelID, ts, kind, status, text)
-}
-
 func recordSlackOutboundInChannel(ctx context.Context, stores *Stores, services *Services, logger zerolog.Logger, link models.SlackSessionLink, channelID, ts string, kind models.SlackOutboundMessageKind, status, text string) {
 	if services != nil && services.SlackbotMetrics != nil {
 		services.SlackbotMetrics.RecordOutboundMessage(ctx, string(kind), status)
@@ -3504,10 +3500,6 @@ func loadSlackSessionOutcomeDetails(ctx context.Context, stores *Stores, service
 		}
 	}
 	return details
-}
-
-func appendSlackSessionOutcome(text string, session models.Session) string {
-	return appendSlackSessionOutcomeDetails(text, slackSessionOutcomeDetails{Session: session})
 }
 
 func appendSlackSessionOutcomeDetails(text string, details slackSessionOutcomeDetails) string {

--- a/internal/worker/handlers_test.go
+++ b/internal/worker/handlers_test.go
@@ -239,6 +239,134 @@ func TestSlackThreadRoutingBySource(t *testing.T) {
 	}
 }
 
+func TestSlackDeliveryTargetFromVisibility(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name            string
+		link            models.SlackSessionLink
+		replyThreadTS   string
+		responseVis     string
+		dmChannelID     string
+		expectedChannel string
+		expectedThread  string
+		expectedDM      bool
+	}{
+		{
+			name: "thread visibility keeps source channel and thread",
+			link: models.SlackSessionLink{
+				SlackChannelID: "C123",
+				SlackUserID:    "U123",
+			},
+			replyThreadTS:   "1710000000.000000",
+			responseVis:     "thread",
+			expectedChannel: "C123",
+			expectedThread:  "1710000000.000000",
+		},
+		{
+			name: "dm visibility uses opened dm channel without thread",
+			link: models.SlackSessionLink{
+				SlackChannelID: "C123",
+				SlackUserID:    "U123",
+			},
+			replyThreadTS:   "1710000000.000000",
+			responseVis:     "dm",
+			dmChannelID:     "D123",
+			expectedChannel: "D123",
+			expectedDM:      true,
+		},
+		{
+			name: "dm visibility without a Slack user falls back to thread",
+			link: models.SlackSessionLink{
+				SlackChannelID: "C123",
+			},
+			replyThreadTS:   "1710000000.000000",
+			responseVis:     "dm",
+			dmChannelID:     "D123",
+			expectedChannel: "C123",
+			expectedThread:  "1710000000.000000",
+		},
+		{
+			name: "unknown visibility is treated as thread",
+			link: models.SlackSessionLink{
+				SlackChannelID: "C123",
+				SlackUserID:    "U123",
+			},
+			replyThreadTS:   "1710000000.000000",
+			responseVis:     "unexpected",
+			dmChannelID:     "D123",
+			expectedChannel: "C123",
+			expectedThread:  "1710000000.000000",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			channelID, threadTS, usedDM := slackDeliveryTargetFromVisibility(tt.link, tt.replyThreadTS, tt.responseVis, tt.dmChannelID)
+
+			require.Equal(t, tt.expectedChannel, channelID, "Slack delivery target should choose the expected channel")
+			require.Equal(t, tt.expectedThread, threadTS, "Slack delivery target should choose the expected thread")
+			require.Equal(t, tt.expectedDM, usedDM, "Slack delivery target should report whether DM routing was used")
+		})
+	}
+}
+
+func TestAppendSlackSessionOutcomeIncludesConcreteLinksAndDiffStats(t *testing.T) {
+	t.Parallel()
+
+	sessionID := uuid.New()
+	previewID := uuid.New()
+	branchURL := "https://github.com/acme/repo/tree/143/session"
+	text := appendSlackSessionOutcomeDetails("Done.", slackSessionOutcomeDetails{
+		Session: models.Session{
+			ID:              sessionID,
+			BranchURL:       &branchURL,
+			DiffStats:       json.RawMessage(`{"files_changed":3,"added":42,"removed":7}`),
+			PRCreationState: models.PRCreationStateSucceeded,
+		},
+		PullRequest: &models.PullRequest{
+			GitHubPRURL:    "https://github.com/acme/repo/pull/42",
+			GitHubPRNumber: 42,
+			GitHubRepo:     "acme/repo",
+			Status:         models.PullRequestStatusOpen,
+			CIStatus:       models.PullRequestCIStatusPending,
+		},
+		Preview: &models.PreviewInstance{
+			ID:     previewID,
+			Name:   "web",
+			Status: models.PreviewStatusReady,
+		},
+		PreviewURL: "https://143.test/previews/" + previewID.String(),
+	})
+
+	require.Contains(t, text, "PR: https://github.com/acme/repo/pull/42", "Slack outcome should include concrete PR URL")
+	require.Contains(t, text, "Preview: ready - https://143.test/previews/"+previewID.String(), "Slack outcome should include preview status and URL")
+	require.Contains(t, text, "Branch: https://github.com/acme/repo/tree/143/session", "Slack outcome should include branch URL")
+	require.Contains(t, text, "Changes: 3 files, +42/-7", "Slack outcome should summarize diff stats")
+}
+
+func TestAppendSlackSessionOutcomeFallsBackForPRStateWithoutRow(t *testing.T) {
+	t.Parallel()
+
+	text := appendSlackSessionOutcomeDetails("Done.", slackSessionOutcomeDetails{
+		Session: models.Session{
+			PRCreationState: models.PRCreationStateSucceeded,
+		},
+	})
+
+	require.Contains(t, text, "PR: opened", "Slack outcome should preserve existing fallback when PR row is unavailable")
+}
+
+func TestSlackDiffStatsOutcomeLineSuppressesAllZeros(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t, "", slackDiffStatsOutcomeLine(json.RawMessage(`{"files_changed":0,"added":0,"removed":0}`)), "zero diff stats should produce no output line")
+	require.Equal(t, "", slackDiffStatsOutcomeLine(json.RawMessage(`null`)), "null diff stats should produce no output line")
+	require.NotEmpty(t, slackDiffStatsOutcomeLine(json.RawMessage(`{"files_changed":1,"added":5,"removed":2}`)), "non-zero diff stats should produce an output line")
+}
+
 func TestSlackShouldContinueLinkedSession(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
This change completes missing backend wiring for the Slackbot “product surface” by adding the PR store to server/session execution runtimes, expanding Slackbot outbound behavior to include richer user-facing outcome context, and honoring `response_visibility=dm` for Slack-started sessions. It also updates Slackbot metrics coverage and test expectations around the newly implemented paths.

## Changes
- **cmd/server/main.go**
  - Added `PullRequests: pullRequestStore` to the dependency injection stores used by the server runtime.
- **cmd/server/session_executor_main.go**
  - Added `PullRequests: pullRequestStore` to the session executor runtime stores so session/job flows can resolve PR data.
- **internal/api/handlers/slackbot.go**
  - Ensured final Slack replies append available outcome context (e.g., PR URL/status/CI state, diff stats, preview/branch context).
  - Implemented honoring `response_visibility = dm` for Slack-started session acknowledgements, progress updates, final replies, and human-input delivery (DM first with thread fallback if DM cannot be opened).
- **internal/worker/handlers.go**
  - Updated worker handling to route outbound Slack events consistently with the `response_visibility` behavior.
- **internal/metrics/slackbot.go** and **internal/metrics/metrics_test.go**
  - Extended Slackbot metrics to reflect newly wired interaction/action/outbound paths (including Slack Events API coverage mentioned in the design doc).
  - Updated tests to match the new metrics behavior.
- **internal/worker/handlers_test.go**
  - Adjusted/added test cases to validate the new Slack DM visibility + fallback and PR/context inclusion behaviors.
- **docs/design/future/92-slackbot-product-surface.md**
  - Updated documentation status and concrete user-facing outcome context details and DM visibility guarantees.

## Test plan
- Ran unit tests for worker and metrics packages:
  - `internal/metrics/*` (including updated `metrics_test.go`)
  - `internal/worker/*` (including updated `handlers_test.go`)
- Verified that the updated Slackbot handler paths compile and that tests cover the new outbound context composition and `response_visibility=dm` delivery/fallback behavior.

[143.dev](https://143.dev) | [session 37506052](https://143.dev/sessions/37506052-45b6-4d21-93cb-1081689c50ed)

Preview: https://143.dev/previews/github/assembledhq/143/pull/1243