### PR TITLE
Add searchable Slack monitored channel selector in Integrations settings

### DIFF
--- a/frontend/src/app/(dashboard)/settings/integrations/page.test.tsx
+++ b/frontend/src/app/(dashboard)/settings/integrations/page.test.tsx
@@ -11,6 +11,8 @@ const {
   linearAgentMappingsMock,
   updateLinearAgentMock,
   upsertLinearAgentMappingMock,
+  listSlackChannelsMock,
+  updateSlackChannelsMock,
   githubConnectMock,
   currentUserMock,
   ApiErrorMock,
@@ -31,6 +33,8 @@ const {
     linearAgentMappingsMock: vi.fn(),
     updateLinearAgentMock: vi.fn(),
     upsertLinearAgentMappingMock: vi.fn(),
+    listSlackChannelsMock: vi.fn(),
+    updateSlackChannelsMock: vi.fn(),
     githubConnectMock: vi.fn(),
     currentUserMock: {
       id: "user-1",
@@ -62,6 +66,8 @@ vi.mock("@/lib/api", () => ({
       listLinearAgentMappings: linearAgentMappingsMock,
       updateLinearAgentSettings: updateLinearAgentMock,
       upsertLinearAgentMapping: upsertLinearAgentMappingMock,
+      listSlackChannels: listSlackChannelsMock,
+      updateSlackChannels: updateSlackChannelsMock,
     },
     repositories: {
       list: repositoriesListMock,
@@ -128,6 +134,8 @@ describe("IntegrationsPage", () => {
     linearAgentMappingsMock.mockResolvedValue({ data: [], meta: {} });
     updateLinearAgentMock.mockResolvedValue(undefined);
     upsertLinearAgentMappingMock.mockResolvedValue({ data: {}, meta: {} });
+    listSlackChannelsMock.mockResolvedValue({ data: [] });
+    updateSlackChannelsMock.mockResolvedValue(undefined);
     claimGitHubRepositoriesMock.mockRejectedValue(
       new ApiErrorMock("GITHUB_USER_AUTH_REQUIRED", "Connect your GitHub account before claiming repositories"),
     );
@@ -401,6 +409,115 @@ describe("IntegrationsPage", () => {
         repository_id: "repo-143",
       });
     });
+  });
+
+  it("filters monitored Slack channels in the Slack manage sidesheet", async () => {
+    integrationsListMock.mockResolvedValueOnce({
+      data: [
+        {
+          id: "integration-slack",
+          org_id: "org-1",
+          provider: "slack",
+          status: "active",
+          created_at: "2026-01-01T00:00:00Z",
+        },
+      ],
+      meta: {},
+    });
+    listSlackChannelsMock.mockResolvedValue({
+      data: [
+        { id: "chan-1", name: "engineering", selected: true },
+        { id: "chan-2", name: "customer-success", selected: false },
+        { id: "chan-3", name: "random", selected: false },
+      ],
+    });
+
+    renderWithProviders(<IntegrationsPage />);
+
+    const user = userEvent.setup();
+    await user.click(await screen.findByRole("button", { name: "Manage Slack" }));
+    const sheet = await screen.findByRole("dialog", { name: "Slack" });
+    await within(sheet).findByText("#engineering");
+
+    await user.type(within(sheet).getByPlaceholderText("Search channels..."), "customer");
+
+    expect(within(sheet).getByText("#customer-success")).toBeInTheDocument();
+    expect(within(sheet).queryByText("#engineering")).not.toBeInTheDocument();
+    expect(within(sheet).queryByText("#random")).not.toBeInTheDocument();
+
+    await user.click(within(sheet).getByRole("option", { name: "Monitor #customer-success" }));
+
+    await waitFor(() => {
+      expect(updateSlackChannelsMock).toHaveBeenCalledWith(["chan-1", "chan-2"]);
+    });
+  });
+
+  it("deselects a monitored Slack channel in the Slack manage sidesheet", async () => {
+    integrationsListMock.mockResolvedValueOnce({
+      data: [
+        {
+          id: "integration-slack",
+          org_id: "org-1",
+          provider: "slack",
+          status: "active",
+          created_at: "2026-01-01T00:00:00Z",
+        },
+      ],
+      meta: {},
+    });
+    listSlackChannelsMock.mockResolvedValue({
+      data: [
+        { id: "chan-1", name: "engineering", selected: true },
+        { id: "chan-2", name: "customer-success", selected: false },
+      ],
+    });
+
+    renderWithProviders(<IntegrationsPage />);
+
+    const user = userEvent.setup();
+    await user.click(await screen.findByRole("button", { name: "Manage Slack" }));
+    const sheet = await screen.findByRole("dialog", { name: "Slack" });
+    await within(sheet).findByText("#engineering");
+
+    await user.click(within(sheet).getByRole("option", { name: "Monitor #engineering" }));
+
+    await waitFor(() => {
+      expect(updateSlackChannelsMock).toHaveBeenCalledWith([]);
+    });
+  });
+
+  it("shows empty state when Slack channel search matches nothing", async () => {
+    integrationsListMock.mockResolvedValueOnce({
+      data: [
+        {
+          id: "integration-slack",
+          org_id: "org-1",
+          provider: "slack",
+          status: "active",
+          created_at: "2026-01-01T00:00:00Z",
+        },
+      ],
+      meta: {},
+    });
+    listSlackChannelsMock.mockResolvedValue({
+      data: [
+        { id: "chan-1", name: "engineering", selected: true },
+        { id: "chan-2", name: "customer-success", selected: false },
+      ],
+    });
+
+    renderWithProviders(<IntegrationsPage />);
+
+    const user = userEvent.setup();
+    await user.click(await screen.findByRole("button", { name: "Manage Slack" }));
+    const sheet = await screen.findByRole("dialog", { name: "Slack" });
+    await within(sheet).findByText("#engineering");
+
+    await user.type(within(sheet).getByPlaceholderText("Search channels..."), "zzznomatch");
+
+    expect(within(sheet).queryByText("#engineering")).not.toBeInTheDocument();
+    expect(within(sheet).queryByText("#customer-success")).not.toBeInTheDocument();
+    expect(within(sheet).getByText("No channels found.")).toBeInTheDocument();
   });
 
   it("shows Notion workspace and CircleCI project metadata on connected cards", async () => {

--- a/frontend/src/app/(dashboard)/settings/integrations/page.tsx
+++ b/frontend/src/app/(dashboard)/settings/integrations/page.tsx
@@ -10,10 +10,17 @@ import { PageHeader } from "@/components/page-header";
 import { PageContainer } from "@/components/page-container";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
-import { Checkbox } from "@/components/ui/checkbox";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Separator } from "@/components/ui/separator";
+import {
+  Command,
+  CommandCheckItem,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandList,
+} from "@/components/ui/command";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import {
   Sheet,
@@ -381,21 +388,25 @@ function SlackChannelPicker() {
         <p className="text-sm text-muted-foreground">No channels found.</p>
       ) : (
         <div className="space-y-3">
-          <div className="grid max-h-[24rem] gap-2 overflow-y-auto pr-1">
-            {channels.map((ch) => (
-              <Label
-                key={ch.id}
-                className="flex cursor-pointer items-center gap-2 rounded-md border border-border px-3 py-2 transition-colors hover:bg-muted/50"
-              >
-                <Checkbox
-                  checked={selected.has(ch.id)}
-                  onCheckedChange={() => toggle(ch.id)}
-                  aria-label={`Monitor #${ch.name}`}
-                />
-                <span className="text-sm font-medium">#{ch.name}</span>
-              </Label>
-            ))}
-          </div>
+          <Command className="rounded-md border border-border">
+            <CommandInput placeholder="Search channels..." />
+            <CommandList className="max-h-[24rem]">
+              <CommandEmpty>No channels found.</CommandEmpty>
+              <CommandGroup>
+                {channels.map((ch) => (
+                  <CommandCheckItem
+                    key={ch.id}
+                    checked={selected.has(ch.id)}
+                    value={`${ch.name} #${ch.name}`}
+                    aria-label={`Monitor #${ch.name}`}
+                    onSelect={() => toggle(ch.id)}
+                  >
+                    <span className="truncate font-medium">#{ch.name}</span>
+                  </CommandCheckItem>
+                ))}
+              </CommandGroup>
+            </CommandList>
+          </Command>
           <p className="text-xs text-muted-foreground">
             {selected.size} channel{selected.size !== 1 ? "s" : ""} selected
           </p>


### PR DESCRIPTION
## Summary
This change adds a searchable channel picker to the Slack “Manage” sidesheet, so users can quickly filter and modify which Slack channels are monitored. It leverages existing Slack settings components and extends coverage with new tests.

## Changes
- Updated `frontend/src/app/(dashboard)/settings/integrations/page.tsx` to:
  - Load monitored Slack channels via `listSlackChannels`.
  - Provide a searchable UI (“Search channels...”) within the Slack manage dialog.
  - Update monitored channel selection via `updateSlackChannels` when users select/deselect channels.
- Updated `frontend/src/app/(dashboard)/settings/integrations/page.test.tsx` to add tests that:
  - Filter the monitored channel list in the Slack manage sidesheet.
  - Verify selection changes call `updateSlackChannels` with the expected channel IDs.

## Test plan
- Ran the frontend unit tests for the Integrations settings page, including the new Slack manage sidesheet filtering/selection test cases.

[143.dev](https://143.dev) | [session 0ad86756](https://143.dev/sessions/0ad86756-1f80-47fc-9747-8ddeea32fa87)

Preview: https://143.dev/previews/github/assembledhq/143/pull/1244