### PR TITLE
Fix worker image retention expiry typing

### DIFF
--- a/internal/db/node_store.go
+++ b/internal/db/node_store.go
@@ -520,7 +520,7 @@ func (s *NodeStore) RetainActiveExecutorImages(ctx context.Context, params Retai
 		INSERT INTO worker_image_retention (
 			image, build_sha, node_id, executor_id, deploy_id, reason, expires_at
 		)
-		SELECT DISTINCT image, build_sha, host_node_id, id, @deploy_id, @reason, @expires_at::timestamptz
+		SELECT DISTINCT image, build_sha, host_node_id, id, @deploy_id, @reason, CAST(@expires_at AS timestamptz)
 		FROM session_executors
 		WHERE host_node_id = @node_id
 		  AND status IN ('starting', 'running', 'draining')
@@ -529,7 +529,7 @@ func (s *NodeStore) RetainActiveExecutorImages(ctx context.Context, params Retai
 			"node_id":    params.NodeID,
 			"deploy_id":  params.DeployID,
 			"reason":     params.Reason,
-			"expires_at": params.ExpiresAt.UTC(),
+			"expires_at": pgtype.Timestamptz{Time: params.ExpiresAt.UTC(), Valid: true},
 		})
 	if err != nil {
 		return 0, fmt.Errorf("retain active executor images: %w", err)

--- a/internal/db/node_store_test.go
+++ b/internal/db/node_store_test.go
@@ -20,6 +20,13 @@ var nodeStoreTestCols = []string{
 	"drain_requested_at", "drain_budget_expires_at", "drain_requested_by", "drain_reason",
 }
 
+type timestamptzArg struct{}
+
+func (timestamptzArg) Match(v interface{}) bool {
+	_, ok := v.(pgtype.Timestamptz)
+	return ok
+}
+
 func TestNodeStore_GetByID(t *testing.T) {
 	t.Parallel()
 
@@ -285,8 +292,8 @@ func TestNodeStore_RetainActiveExecutorImagesCastsExpiry(t *testing.T) {
 	require.NoError(t, err, "pgxmock pool should be created")
 	defer mock.Close()
 
-	mock.ExpectExec("INSERT INTO worker_image_retention[\\s\\S]+@expires_at::timestamptz[\\s\\S]+FROM session_executors").
-		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+	mock.ExpectExec("INSERT INTO worker_image_retention[\\s\\S]+CAST\\(@expires_at AS timestamptz\\)[\\s\\S]+FROM session_executors").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), timestamptzArg{}, pgxmock.AnyArg()).
 		WillReturnResult(pgxmock.NewResult("INSERT", 2))
 
 	store := NewNodeStore(mock)


### PR DESCRIPTION
### Motivation
- Deploys were failing when `worker-deployctl retain-images` tried to insert retention rows because Postgres rejected an untyped expiry expression with: `column "expires_at" is of type timestamp with time zone but expression is of type text` (SQLSTATE 42804).\
- The intent is to ensure the `expires_at` value is sent as a proper timestamptz to avoid type inference errors during the insert-select from `session_executors`.

### Description
- Changed the insert-select in `NodeStore.RetainActiveExecutorImages` to use an explicit SQL cast `CAST(@expires_at AS timestamptz)` for the `expires_at` column.\
- Bound the expiry argument as `pgtype.Timestamptz{Time: ..., Valid: true}` instead of a plain `time.Time` so the driver sends a typed timestamptz parameter.\
- Updated the regression test `TestNodeStore_RetainActiveExecutorImagesCastsExpiry` to assert the SQL contains the explicit `CAST(... AS timestamptz)` and added a `timestamptzArg` matcher that verifies the argument is a `pgtype.Timestamptz`.

### Testing
- Ran `go test ./internal/db -run TestNodeStore_RetainActiveExecutorImagesCastsExpiry -count=1` and the targeted test passed.\
- Ran `go vet ./...` and `go build ./...` with no issues.\
- Ran full test suite `go test ./...` and all packages completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1d0943086c8320802d174f4d418b60)