### PR TITLE
[codex] Use typed assertion for Linear rate limit test

### DIFF
--- a/internal/services/integration/linear_test.go
+++ b/internal/services/integration/linear_test.go
@@ -3,7 +3,6 @@ package integration
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -629,7 +628,7 @@ func TestLinearTaskManager_DoGraphQL_RateLimitReturnsTypedError(t *testing.T) {
 	_, err := tm.GetTask(context.Background(), "ENG-123")
 	require.Error(t, err, "GetTask should surface a 429 from Linear")
 	var rl *LinearRateLimitError
-	require.True(t, errors.As(err, &rl),
+	require.ErrorAs(t, err, &rl,
 		"429 from Linear should map to *LinearRateLimitError so retry orchestration can read Retry-After")
 	require.Equal(t, "30", rl.RetryAfter, "RateLimitError should preserve the Retry-After header")
 }


### PR DESCRIPTION
## Summary

- Update the Linear rate-limit regression test to use `require.ErrorAs` for the expected `*LinearRateLimitError`.
- Remove the now-unused direct `errors` import.

## Why

The failing CI output was coming from a bare boolean assertion around `errors.As`, which made the typed-error expectation less direct and less diagnostic. The production code on current `main` already maps Linear 429 responses to `*LinearRateLimitError`; this keeps the regression test focused on that contract.

## Validation

- `go test ./internal/services/integration -run TestLinearTaskManager_DoGraphQL_RateLimitReturnsTypedError -count=1 -v`
- `go vet ./...`
- `go build ./...`
- `go test ./...`
- `go test ./internal/services/integration -cover -count=1`