### PR TITLE
[codex] Handle review clean sentinels in review loop output

### DIFF
--- a/docs/design/implemented/78-review-agent-loops.md
+++ b/docs/design/implemented/78-review-agent-loops.md
@@ -361,7 +361,9 @@ For `passIndex` from `1..max_review_passes`:
 4. Run the selected agent's native review command in that thread.
 5. Ask the same agent whether the latest review is clean; if it is not clean,
    the agent fixes the issues in that turn.
-6. If the agent reports `REVIEW_CLEAN`, mark the loop `clean` and stop.
+6. If the agent reports an unambiguous `REVIEW_CLEAN` sentinel as its own line
+   or as a first-line directive, including in the review pass output itself,
+   mark the loop `clean` and stop without sending another continuation prompt.
 7. If the agent made fixes, capture the fix summary and continue to the next
    review pass.
 

--- a/internal/db/review_loops.go
+++ b/internal/db/review_loops.go
@@ -291,6 +291,8 @@ func (s *SessionReviewLoopStore) MarkPassClean(ctx context.Context, orgID, loopI
 		UPDATE session_review_loop_passes
 		SET status = 'clean',
 		    agent_decision = @agent_decision,
+		    review_output = COALESCE(review_output, @summary),
+		    review_completed_at = COALESCE(review_completed_at, now()),
 		    summary = @summary
 		WHERE id = @id AND org_id = @org_id`, orgID, passID, pgx.NamedArgs{
 		"agent_decision": decision,
@@ -310,6 +312,8 @@ func (s *SessionReviewLoopStore) MarkPassCleanAndEnqueueOpenPR(ctx context.Conte
 			UPDATE session_review_loop_passes
 			SET status = 'clean',
 			    agent_decision = @agent_decision,
+			    review_output = COALESCE(review_output, @summary),
+			    review_completed_at = COALESCE(review_completed_at, now()),
 			    summary = @summary
 			WHERE id = @id AND org_id = @org_id`, orgID, passID, pgx.NamedArgs{
 			"agent_decision": decision,

--- a/internal/services/reviewloop/service.go
+++ b/internal/services/reviewloop/service.go
@@ -221,6 +221,16 @@ func (s *Service) OnThreadTurnComplete(ctx context.Context, orgID, threadID uuid
 	summary := strings.TrimSpace(assistantSummary)
 	switch pass.Status {
 	case models.ReviewLoopPassStatusReviewing:
+		decision, err := parseDecision(summary)
+		if err == nil && decision == models.ReviewLoopDecisionClean {
+			if loop.AutomationRunID != nil {
+				return s.store.MarkPassCleanAndEnqueueOpenPR(ctx, orgID, loop.ID, pass.ID, decision, summary, automationOpenPRPayload(loop), automationOpenPRDedupeKey(loop.SessionID))
+			}
+			if err := s.store.MarkPassClean(ctx, orgID, loop.ID, pass.ID, decision, summary); err != nil {
+				return err
+			}
+			return nil
+		}
 		msg, err := s.sendPlain(ctx, loop, prompts.ReviewLoopDecisionPrompt(), nil, withContinuationDedupeKey(reviewLoopContinuationDedupeKey(loop.ID, pass.ID, "decision")))
 		if err != nil {
 			_ = s.failLoop(ctx, orgID, loop, fmt.Sprintf("failed to request review decision: %s", err))
@@ -421,13 +431,42 @@ func (s *Service) sendPlain(ctx context.Context, loop models.SessionReviewLoop, 
 }
 
 func parseDecision(summary string) (models.ReviewLoopDecision, error) {
-	switch strings.TrimSpace(summary) {
-	case string(models.ReviewLoopDecisionClean):
+	hasClean := containsDecisionSentinel(summary, models.ReviewLoopDecisionClean)
+	hasNeedsFix := containsDecisionSentinel(summary, models.ReviewLoopDecisionNeedsFix)
+	switch {
+	case hasClean && !hasNeedsFix:
 		return models.ReviewLoopDecisionClean, nil
-	case string(models.ReviewLoopDecisionNeedsFix):
+	case hasNeedsFix && !hasClean:
 		return models.ReviewLoopDecisionNeedsFix, nil
 	default:
 		return "", ErrUnrecognizedDecision
+	}
+}
+
+func containsDecisionSentinel(summary string, decision models.ReviewLoopDecision) bool {
+	sentinel := string(decision)
+	lines := strings.Split(strings.ReplaceAll(summary, "\r\n", "\n"), "\n")
+	for i, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == sentinel {
+			return true
+		}
+		if i == 0 && strings.HasPrefix(trimmed, sentinel) && isDecisionDirectiveBoundary(trimmed, len(sentinel)) {
+			return true
+		}
+	}
+	return false
+}
+
+func isDecisionDirectiveBoundary(line string, sentinelLen int) bool {
+	if len(line) == sentinelLen {
+		return true
+	}
+	switch line[sentinelLen] {
+	case ':', '-', ' ', '\t':
+		return true
+	default:
+		return false
 	}
 }
 

--- a/internal/services/reviewloop/service_test.go
+++ b/internal/services/reviewloop/service_test.go
@@ -274,6 +274,44 @@ func TestService_OnThreadTurnCompleteCleanAutomationLoopEnqueuesOpenPR(t *testin
 	require.Equal(t, []string{"clean_open_pr"}, store.events, "clean automation review should durably queue PR creation with the terminal state")
 }
 
+func TestService_OnThreadTurnCompleteReviewOutputWithCleanSentinelStopsLoop(t *testing.T) {
+	t.Parallel()
+
+	orgID := uuid.New()
+	sessionID := uuid.New()
+	threadID := uuid.New()
+	loopID := uuid.New()
+	passID := uuid.New()
+	store := &fakeReviewLoopStore{
+		runningLoop: models.SessionReviewLoop{
+			ID:        loopID,
+			OrgID:     orgID,
+			SessionID: sessionID,
+			ThreadID:  &threadID,
+			Status:    models.ReviewLoopStatusRunning,
+			AgentType: models.AgentTypeCodex,
+			MaxPasses: 2,
+		},
+		latestPass: models.SessionReviewLoopPass{
+			ID:        passID,
+			OrgID:     orgID,
+			LoopID:    loopID,
+			SessionID: sessionID,
+			PassIndex: 1,
+			Status:    models.ReviewLoopPassStatusReviewing,
+		},
+	}
+	threads := &fakeThreadService{message: models.SessionMessage{ID: 10, SessionID: sessionID, OrgID: orgID, ThreadID: &threadID}}
+	svc := NewService(store, threads)
+
+	err := svc.OnThreadTurnComplete(context.Background(), orgID, threadID, "No remaining correctness bugs.\n\nREVIEW_CLEAN")
+
+	require.NoError(t, err, "review output containing the clean sentinel should complete the loop")
+	require.Equal(t, models.ReviewLoopDecisionClean, store.cleanDecision, "review output clean sentinel should be persisted")
+	require.Equal(t, loopID, store.cleanLoopID, "review output clean sentinel should mark the loop clean")
+	require.Empty(t, threads.sent, "review output clean sentinel should not enqueue a redundant decision prompt")
+}
+
 func TestService_OnThreadTurnCompleteCleanAutomationLoopIsAtomicWithOpenPR(t *testing.T) {
 	t.Parallel()
 
@@ -351,7 +389,7 @@ func TestService_OnThreadTurnCompleteAutomationPassLimitEnqueuesOpenPRGate(t *te
 	require.Equal(t, []string{"needs_human_open_pr"}, store.events, "pass-limit automation review should durably queue the PR gate with the terminal state")
 }
 
-func TestService_OnThreadTurnCompleteAutomationDecisionFailureEnqueuesOpenPRGate(t *testing.T) {
+func TestService_OnThreadTurnCompleteAutomationDecisionTextWithCleanSentinelEnqueuesOpenPR(t *testing.T) {
 	t.Parallel()
 
 	orgID := uuid.New()
@@ -384,9 +422,10 @@ func TestService_OnThreadTurnCompleteAutomationDecisionFailureEnqueuesOpenPRGate
 
 	err := svc.OnThreadTurnComplete(context.Background(), orgID, threadID, "REVIEW_CLEAN with commentary")
 
-	require.ErrorIs(t, err, ErrUnrecognizedDecision, "invalid automation review decision should still return the decision error")
-	require.Equal(t, loopID, store.failedLoopID, "invalid automation review decision should mark the loop failed")
-	require.Equal(t, []string{"failed_open_pr"}, store.events, "invalid automation review decision should durably queue the PR gate")
+	require.NoError(t, err, "automation review decision containing the clean sentinel should complete without error")
+	require.Equal(t, models.ReviewLoopDecisionClean, store.cleanDecision, "clean decision should be persisted from explanatory text")
+	require.Equal(t, loopID, store.cleanLoopID, "clean decision should mark the loop clean")
+	require.Equal(t, []string{"clean_open_pr"}, store.events, "clean automation review should durably queue PR creation with the terminal state")
 }
 
 func TestService_OnThreadTurnCompleteEmptyDecisionFailsLoop(t *testing.T) {
@@ -483,7 +522,7 @@ func TestService_OnThreadTurnFailedAutomationEnqueuesOpenPRGate(t *testing.T) {
 	require.Equal(t, []string{"failed_open_pr"}, store.events, "automation review-loop failure should requeue the PR gate")
 }
 
-func TestParseDecisionRequiresExactSentinel(t *testing.T) {
+func TestParseDecisionFindsUnambiguousSentinel(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
@@ -494,8 +533,10 @@ func TestParseDecisionRequiresExactSentinel(t *testing.T) {
 	}{
 		{name: "clean", summary: " REVIEW_CLEAN\n", expected: models.ReviewLoopDecisionClean},
 		{name: "needs fix", summary: "\nNEEDS_FIX_PASS ", expected: models.ReviewLoopDecisionNeedsFix},
+		{name: "clean with explanatory text", summary: "No remaining issues.\n\nREVIEW_CLEAN", expected: models.ReviewLoopDecisionClean},
+		{name: "needs fix first line directive", summary: "NEEDS_FIX_PASS: fixed the regression.", expected: models.ReviewLoopDecisionNeedsFix},
 		{name: "ambiguous", summary: "NEEDS_FIX_PASS, not REVIEW_CLEAN", expectErr: true},
-		{name: "explanatory", summary: "REVIEW_CLEAN because all checks passed", expectErr: true},
+		{name: "negated clean mention", summary: "I cannot mark this REVIEW_CLEAN because issue X remains.", expectErr: true},
 	}
 
 	for _, tt := range tests {
@@ -504,10 +545,10 @@ func TestParseDecisionRequiresExactSentinel(t *testing.T) {
 
 			got, err := parseDecision(tt.summary)
 			if tt.expectErr {
-				require.ErrorIs(t, err, ErrUnrecognizedDecision, "parseDecision should reject non-exact or ambiguous decision text")
+				require.ErrorIs(t, err, ErrUnrecognizedDecision, "parseDecision should reject ambiguous decision text")
 				return
 			}
-			require.NoError(t, err, "parseDecision should accept exact sentinel text")
+			require.NoError(t, err, "parseDecision should accept unambiguous sentinel text")
 			require.Equal(t, tt.expected, got, "parseDecision should return the expected sentinel")
 		})
 	}


### PR DESCRIPTION
## Summary
- Stop review loops immediately when review output includes an asserted `REVIEW_CLEAN` sentinel.
- Accept clean/fix sentinels only as standalone lines or first-line directives to avoid false positives from negated mentions.
- Preserve review output timestamps when a clean sentinel terminalizes a pass early.
- Update the review-loop design doc and regression tests for the narrowed sentinel policy.

## Root Cause
Review-loop decision parsing previously required the entire decision response to equal the sentinel, and the reviewing phase did not inspect review output for a clean sentinel. That let a review pass emit `REVIEW_CLEAN` while the platform still sent another continuation prompt.

## Validation
- `go test ./internal/services/reviewloop`
- `go vet ./...`
- `go build ./...`
- `go test ./...`