### PR TITLE
Fix missing “Fix tests” CTA by using repairable failed-check helper across UI and backend

### DIFF
--- a/docs/design/implemented/61-pr-state-sync-and-repair-actions.md
+++ b/docs/design/implemented/61-pr-state-sync-and-repair-actions.md
@@ -195,7 +195,7 @@ Show `Resolve conflicts` when:
 
 Show `Fix tests` when:
 
-- one or more latest checks are classified as failing test checks
+- one or more latest checks failed. Test-classified failures still drive the `failing_test_count` summary and copy, but failed lint/build/unknown checks are also repairable because GitHub often names test jobs generically.
 
 If both are true:
 
@@ -253,7 +253,7 @@ Recommended behavior:
 
 - if a fresh summary sync is in progress, show a lightweight syncing state and suppress repair buttons until eligibility is known
 - if mergeability remains `mergeability_pending` after retry, do not show `Resolve conflicts` yet; keep the Merge action visible but disabled in a neutral checking state
-- if failed checks cannot yet be confidently classified as `test`, do not show `Fix tests`; show the blocker summary without an agent-action CTA
+- if failed checks are present but cannot be confidently classified, still show `Fix tests` and pass the failed check names, provider, URL, summary, annotations, and log excerpt when available
 - if the health snapshot is older than a defined freshness threshold, show the row as stale and trigger a refresh rather than reusing old button eligibility
 
 The system should prefer temporarily hiding a button over showing an incorrect repair action against stale state.
@@ -484,7 +484,7 @@ and classify failed checks into:
 - `deploy`
 - `unknown`
 
-Only `test` failures should drive the `Fix tests` button in v1.
+Any failed check can drive the `Fix tests` repair action. The category is still stored so summary copy and future routing can distinguish test, lint, build, deploy, and unknown failures.
 
 ## Data Model
 

--- a/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
@@ -155,7 +155,7 @@ import {
   type UseSessionKeyboardShortcutsOptions,
 } from "@/hooks/use-session-keyboard-shortcuts";
 import { prMergedAccent } from "@/lib/pr-status-styles";
-import { deriveCreatePRActionState, derivePushChangesActionState } from "@/lib/session-pr-action-state";
+import { deriveCreatePRActionState, derivePushChangesActionState, hasRepairableFailedChecks } from "@/lib/session-pr-action-state";
 import { cn, sessionTitle, formatTimeAgo } from "@/lib/utils";
 import { activeSet, workingStatusesSet } from "@/lib/session-status-groups";
 import { MobileSessionTopBar } from "./mobile-session-top-bar";
@@ -5113,7 +5113,7 @@ export function SessionDetailContent({ id }: { id: string }) {
       canCreate: canCreatePR && localPRState === "idle" && !createPRMutation.isPending,
       canView: !!prData?.data?.github_pr_url,
       canPush: canShipPR && builderReviewAllowsPR && hasPR && prStatus === "open" && !!session?.has_unpushed_changes && hasSnapshot && !isRunning && localPushState === "idle" && !pushChangesMutation.isPending,
-      canFixTests: canManagePR && !!prHealth?.can_fix_tests && pendingPRAction === null,
+      canFixTests: canManagePR && hasRepairableFailedChecks(prHealth) && pendingPRAction === null,
       canResolveConflicts: canManagePR && !!prHealth?.can_resolve_conflicts && pendingPRAction === null,
       canMerge: canManagePR && prHealthAllowsMerge(prHealth) && pendingPRAction === null,
       onCreate: createPRFromKeyboard,

--- a/frontend/src/components/pr-health-banner.test.tsx
+++ b/frontend/src/components/pr-health-banner.test.tsx
@@ -73,6 +73,33 @@ describe("PRHealthBanner", () => {
     expect(button).toHaveAttribute("title", "GitHub is not allowing this PR to merge yet.");
   });
 
+  it("shows Fix tests for failed checks even when the legacy failing test count is zero", async () => {
+    const onFixTests = vi.fn();
+    renderWithProviders(
+      <PRHealthBanner
+        health={{
+          ...baseHealth,
+          checks_confirmed: true,
+          can_fix_tests: false,
+          failing_test_count: 0,
+          checks: [{ name: "backend", category: "unknown", status: "failed" }],
+          summary: "PR #42 has a failing CI check.",
+        }}
+        pendingAction={null}
+        repairError={null}
+        mergeAuthRequired={false}
+        onFixTests={onFixTests}
+        onResolveConflicts={vi.fn()}
+        onMerge={vi.fn()}
+      />,
+    );
+
+    const button = screen.getByRole("button", { name: "Fix tests" });
+    expect(button).not.toBeDisabled();
+    await userEvent.setup().click(button);
+    expect(onFixTests).toHaveBeenCalledTimes(1);
+  });
+
   it("shows pending mergeability as a disabled Merge button state", () => {
     renderWithProviders(
       <PRHealthBanner

--- a/frontend/src/components/pr-health-banner.tsx
+++ b/frontend/src/components/pr-health-banner.tsx
@@ -11,7 +11,7 @@ import { DisabledTooltip } from "@/components/ui/disabled-tooltip";
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "@/components/ui/dropdown-menu";
 import { HoverCard, HoverCardContent, HoverCardTrigger } from "@/components/ui/hover-card";
 import { SyncTimeText } from "@/components/sync-time-text";
-import { deriveMergeActionState, deriveMergeWhenReadyActionState } from "@/lib/session-pr-action-state";
+import { deriveMergeActionState, deriveMergeWhenReadyActionState, hasRepairableFailedChecks } from "@/lib/session-pr-action-state";
 
 // PRBannerAction names every action the banner can launch. The pending value
 // is shared across buttons so they can disable each other while one is in
@@ -79,7 +79,7 @@ export function PRHealthBanner({
     .map((check) => ({ ...check, status: normalizeCheckStatus(check.status) }))
     .sort((a, b) => statusRank(a.status) - statusRank(b.status) || a.name.localeCompare(b.name));
   const canShowResolveConflictsButton = health.can_resolve_conflicts && !activeRepairState.suppressResolveConflicts;
-  const canShowFixTestsButton = health.can_fix_tests && !activeRepairState.suppressFixTests;
+  const canShowFixTestsButton = hasRepairableFailedChecks({ ...health, checks: orderedChecks }) && !activeRepairState.suppressFixTests;
   const mergeAction = deriveMergeActionState({
     health: { ...health, checks: orderedChecks },
     hasActiveRepair: activeRepairState.suppressMerge,

--- a/frontend/src/lib/session-pr-action-state.test.ts
+++ b/frontend/src/lib/session-pr-action-state.test.ts
@@ -6,6 +6,7 @@ import {
   deriveMergeActionState,
   deriveMergeWhenReadyActionState,
   derivePushChangesActionState,
+  hasRepairableFailedChecks,
 } from "./session-pr-action-state";
 
 const baseHealth: PullRequestHealthResponse = {
@@ -37,6 +38,35 @@ const baseHealth: PullRequestHealthResponse = {
 };
 
 describe("session PR action state", () => {
+  it("detects repairable failed checks from flags, counts, or check summaries", () => {
+    const tests = [
+      {
+        name: "backend flag",
+        health: { ...baseHealth, can_fix_tests: true },
+        expected: true,
+      },
+      {
+        name: "legacy count",
+        health: { ...baseHealth, failing_test_count: 1 },
+        expected: true,
+      },
+      {
+        name: "failed check",
+        health: { ...baseHealth, checks: [{ name: "backend", category: "unknown" as const, status: "failed" as const }] },
+        expected: true,
+      },
+      {
+        name: "passing checks",
+        health: baseHealth,
+        expected: false,
+      },
+    ];
+
+    for (const tt of tests) {
+      expect(hasRepairableFailedChecks(tt.health), `${tt.name} should map repairable failed-check state`).toBe(tt.expected);
+    }
+  });
+
   it("maps create PR lifecycle blockers into visible disabled states", () => {
     const base = {
       canShipPR: true,

--- a/frontend/src/lib/session-pr-action-state.ts
+++ b/frontend/src/lib/session-pr-action-state.ts
@@ -1,5 +1,14 @@
 import type { PullRequestHealthResponse } from "./types";
 
+type RepairableFailedChecksInput = Pick<PullRequestHealthResponse, "can_fix_tests" | "failing_test_count" | "checks">;
+
+export function hasRepairableFailedChecks(health: RepairableFailedChecksInput | null | undefined): boolean {
+  if (!health) {
+    return false;
+  }
+  return health.can_fix_tests || health.failing_test_count > 0 || (health.checks ?? []).some((check) => check.status === "failed");
+}
+
 export type LifecycleActionState = {
   visible: boolean;
   disabled: boolean;

--- a/internal/services/github/pr_health_service.go
+++ b/internal/services/github/pr_health_service.go
@@ -268,7 +268,7 @@ func (s *PRService) populateActiveRepairs(ctx context.Context, pr models.PullReq
 
 func derivePullRequestRepairActions(resp *models.PullRequestHealthResponse) {
 	resp.CanResolveConflicts = resp.HasConflicts || resp.MergeState == models.PullRequestMergeStateConflicted
-	resp.CanFixTests = resp.FailingTestCount > 0
+	resp.CanFixTests = resp.FailingTestCount > 0 || checkSummariesHaveFailedCheck(resp.Checks)
 	// CanMerge is the green-light counterpart to the repair flags: GitHub has
 	// confirmed the branch is mergeable and the check state is authoritative.
 	// Once GitHub health has been loaded, zero checks means "no CI rules
@@ -289,6 +289,22 @@ func checksAllowMerge(checksConfirmed bool, checks []models.PullRequestCheckSumm
 		}
 	}
 	return true
+}
+
+func healthSummaryHasRepairableFailedChecks(summary models.PullRequestHealthSummary) bool {
+	if summary.FailingTestCount > 0 {
+		return true
+	}
+	return checkSummariesHaveFailedCheck(summary.Checks)
+}
+
+func checkSummariesHaveFailedCheck(checks []models.PullRequestCheckSummary) bool {
+	for _, check := range checks {
+		if classifyStoredCheckStatus(check) == models.PullRequestCheckStatusFailed {
+			return true
+		}
+	}
+	return false
 }
 
 func (s *PRService) SyncPullRequestState(ctx context.Context, orgID, pullRequestID uuid.UUID) error {
@@ -482,9 +498,6 @@ func (s *PRService) EnrichPullRequestHealth(ctx context.Context, orgID, pullRequ
 	payloadChecks := make([]failingCheckPayload, 0)
 	for _, check := range checkRuns {
 		category := classifyCheckRunCategory(check.Name)
-		if category != models.PullRequestCheckCategoryTest {
-			continue
-		}
 		if normalizeCheckRunStatus(check) != models.PullRequestCheckStatusFailed {
 			continue
 		}
@@ -546,7 +559,7 @@ func (s *PRService) StartPullRequestRepair(ctx context.Context, orgID, pullReque
 			return nil, fmt.Errorf("pull request does not currently require conflict resolution")
 		}
 	case models.PullRequestRepairActionTypeFixTests:
-		if summary.FailingTestCount == 0 {
+		if !healthSummaryHasRepairableFailedChecks(summary) {
 			return nil, fmt.Errorf("pull request does not currently have failing tests")
 		}
 		if snapshot.EnrichmentStatus != models.PullRequestHealthEnrichmentStatusReady {

--- a/internal/services/github/pr_health_service_test.go
+++ b/internal/services/github/pr_health_service_test.go
@@ -1344,6 +1344,16 @@ func TestPRHealthServiceHelpers(t *testing.T) {
 	require.True(t, resp.CanResolveConflicts, "derivePullRequestRepairActions should enable conflict repair for conflicted PRs")
 	require.True(t, resp.CanFixTests, "derivePullRequestRepairActions should enable test repair for failing checks")
 
+	resp = &models.PullRequestHealthResponse{
+		MergeState:       models.PullRequestMergeStateClean,
+		FailingTestCount: 0,
+		Checks: []models.PullRequestCheckSummary{
+			{Name: "backend", Category: models.PullRequestCheckCategoryUnknown, Status: models.PullRequestCheckStatusFailed},
+		},
+	}
+	derivePullRequestRepairActions(resp)
+	require.True(t, resp.CanFixTests, "derivePullRequestRepairActions should enable repair for failed checks without a legacy failing-test count")
+
 	first := "first"
 	second := "second"
 	require.Equal(t, "value", firstNonEmpty("", "value", "other"), "firstNonEmpty should return the first non-empty string")
@@ -2041,6 +2051,64 @@ func TestPRServiceReconcileAndRepairBranchCoverage(t *testing.T) {
 				require.Contains(t, err.Error(), tt.wantErr, "StartPullRequestRepair should describe why the repair action is ineligible")
 			})
 		}
+	})
+
+	t.Run("start fix tests accepts failed check summaries without legacy test count", func(t *testing.T) {
+		t.Parallel()
+
+		mock, err := pgxmock.NewPool()
+		require.NoError(t, err, "should create pgx mock pool")
+		defer mock.Close()
+
+		service := &PRService{
+			pullRequests: db.NewPullRequestStore(mock),
+			sessions:     db.NewSessionStore(mock),
+			logger:       zerolog.New(io.Discard),
+		}
+
+		orgID := uuid.New()
+		pullRequestID := uuid.New()
+		now := time.Now().UTC()
+		summary := models.PullRequestHealthSummary{
+			MergeState:       models.PullRequestMergeStateClean,
+			FailingTestCount: 0,
+			Checks: []models.PullRequestCheckSummary{
+				{Name: "backend", Category: models.PullRequestCheckCategoryUnknown, Status: models.PullRequestCheckStatusFailed},
+			},
+		}
+		summaryJSON, err := json.Marshal(summary)
+		require.NoError(t, err, "should marshal health summary")
+
+		mock.ExpectQuery("SELECT .+ FROM pull_requests WHERE id").
+			WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+			WillReturnRows(pgxmock.NewRows(prTestPullRequestColumns).AddRow(
+				pullRequestID, nil, orgID, 42, "https://github.com/assembledhq/143/pull/42", "assembledhq/143",
+				"Fix bug", (*string)(nil), "open", "pending", "app", "", nil, nil, nil,
+				models.PullRequestMergeStateUnknown, false, 0, false, &now, int64(5), models.PullRequestMergeWhenReadyStateOff, (*uuid.UUID)(nil), (*time.Time)(nil), "", (*int64)(nil), "", (*time.Time)(nil), (*time.Time)(nil), now, now,
+			))
+		mock.ExpectQuery("SELECT .+ FROM pull_request_health_current WHERE org_id = .+ AND pull_request_id = .+").
+			WithArgs(pgx.NamedArgs{"org_id": orgID, "pull_request_id": pullRequestID}).
+			WillReturnRows(pgxmock.NewRows(prHealthCurrentTestColumns).AddRow(
+				pullRequestID, orgID, int64(5), "head", "base", summaryJSON, summaryJSON, models.PullRequestHealthEnrichmentStatusReady, nil, now, now,
+			))
+		mock.ExpectQuery("SELECT .+ FROM pull_request_health_snapshots WHERE org_id = .+ AND pull_request_id = .+ AND version = .+").
+			WithArgs(pgx.NamedArgs{"org_id": orgID, "pull_request_id": pullRequestID, "version": int64(5)}).
+			WillReturnRows(pgxmock.NewRows(prHealthSnapshotTestColumns).AddRow(
+				pullRequestID, orgID, int64(5), "head", "base", summaryJSON, nil, nil, 0, models.PullRequestHealthEnrichmentStatusReady, nil, now,
+			))
+		mock.ExpectQuery("SELECT .+ FROM pull_request_repair_runs").
+			WithArgs(pgx.NamedArgs{
+				"org_id":          orgID,
+				"pull_request_id": pullRequestID,
+				"action_type":     models.PullRequestRepairActionTypeFixTests,
+				"health_version":  int64(5),
+			}).
+			WillReturnRows(pgxmock.NewRows(prRepairRunTestColumns))
+
+		_, err = service.StartPullRequestRepair(context.Background(), orgID, pullRequestID, uuid.New(), models.PullRequestRepairActionTypeFixTests)
+		require.Error(t, err, "StartPullRequestRepair should still require a canonical session after accepting the failed check state")
+		require.Contains(t, err.Error(), "pull request is not linked to a canonical session", "StartPullRequestRepair should pass failed-check validation before requiring session context")
+		require.NoError(t, mock.ExpectationsWereMet(), "all failed-check repair expectations should be met")
 	})
 }
 

--- a/internal/services/github/pr_health_test.go
+++ b/internal/services/github/pr_health_test.go
@@ -629,7 +629,7 @@ func TestDerivePullRequestRepairActions(t *testing.T) {
 			expectCanMerge: true,
 		},
 		{
-			name: "clean PR with a failing check is not mergeable",
+			name: "clean PR with a failing check is not mergeable and offers fix tests",
 			input: models.PullRequestHealthResponse{
 				Status:     "open",
 				MergeState: models.PullRequestMergeStateClean,
@@ -637,7 +637,8 @@ func TestDerivePullRequestRepairActions(t *testing.T) {
 					{Name: "lint", Category: models.PullRequestCheckCategoryLint, Status: models.PullRequestCheckStatusFailed},
 				},
 			},
-			expectCanMerge: false,
+			expectCanFixTests: true,
+			expectCanMerge:    false,
 		},
 		{
 			name: "clean PR with only passed checks is still mergeable",


### PR DESCRIPTION
## Summary
Consolidated the “should we show Fix tests?” eligibility logic into a shared frontend helper and updated both the PR health banner and keyboard/action state to use it. On the backend, renamed health helpers for clearer intent and align naming with “repairable failed checks”, addressing cases where the CTA could be suppressed incorrectly when checks fail but aren’t confidently classified as “test”.

## Changes
- **frontend/src/lib/session-pr-action-state.ts**
  - Added `hasRepairableFailedChecks` and used it when deriving `canFixTests`.
- **frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx**
  - Switched `canFixTests` to `canManagePR && hasRepairableFailedChecks(prHealth) && pendingPRAction === null`.
- **frontend/src/lib/session-pr-action-state.test.ts**
  - Added direct unit coverage for `hasRepairableFailedChecks`.
- **frontend/src/components/pr-health-banner.tsx / pr-health-banner.test.tsx**
  - Updated banner logic to follow the shared helper so both banner and CTA state are consistent.
- **internal/services/github/pr_health_service.go**
  - Renamed helper functions to make intent clearer:
    - `healthSummaryHasRepairableFailedChecks`
    - `checkSummariesHaveFailedCheck`
- **internal/services/github/pr_health_service_test.go / pr_health_test.go**
  - Kept/updated backend regression coverage to match the renamed helpers and the expanded “repairable” criteria.

- **docs/design/implemented/61-pr-state-sync-and-repair-actions.md**
  - Updated the design notes to reflect that the `Fix tests` repair action is driven by *any failed check*, while still preserving failure category for copy/routing.

## Test plan
- `npm test -- --run src/lib/session-pr-action-state.test.ts src/components/pr-health-banner.test.tsx`
- `npm run typecheck`
- `npm run lint`
- `npm run build`
- `go vet ./...`
- `go build ./...`
- `go test ./...`

[143.dev](https://143.dev) | [session a8970398](https://143.dev/sessions/a8970398-6306-4620-bf90-d9dd0519b746)

Preview: https://143.dev/previews/github/assembledhq/143/pull/1263