### PR TITLE
Harden Claude Code OAuth refresh harvesting

### DIFF
--- a/internal/services/agent/orchestrator.go
+++ b/internal/services/agent/orchestrator.go
@@ -39,6 +39,11 @@ const (
 	defaultMaxConcurrent    = 10
 	mentionIndexWarmTimeout = 2 * time.Second
 	planModePrefix          = "[PLAN_MODE]\n"
+
+	// Claude Code access tokens are short-lived. A sandbox credential with an
+	// expiration far beyond this bound is more likely corrupted or synthetic
+	// than a valid CLI refresh result.
+	maxClaudeCodeHarvestedTokenLifetime = 24 * time.Hour
 )
 
 // ErrConcurrencyLimit is returned when an org has reached its maximum
@@ -278,6 +283,12 @@ type ClaudeCodeAuthProvider interface {
 // to the org fallback after their first 8h of token life.
 type ClaudeCodeAuthRefresher interface {
 	RefreshTokenByID(ctx context.Context, scope models.Scope, credID uuid.UUID) (*models.AnthropicSubscription, error)
+}
+
+// ClaudeCodeAuthTokenStore persists Claude Code OAuth tokens that were
+// refreshed by the Claude Code CLI inside the sandbox.
+type ClaudeCodeAuthTokenStore interface {
+	StoreTokenByID(ctx context.Context, scope models.Scope, credID uuid.UUID, sub models.AnthropicSubscription) (bool, error)
 }
 
 // CredentialProvider abstracts retrieving org-scoped provider credentials.
@@ -2582,6 +2593,12 @@ func (o *Orchestrator) RunAgent(ctx context.Context, run *models.Session) error 
 	// No-ops cleanly for agent types whose auth flows do not pass through
 	// the unified resolver (e.g. Codex subscription via codexauth.Service).
 	result, err, _ = o.retrySessionOnCredentialRateLimit(ctx, run, primaryThreadID, turnNumber, sandboxCfg, sandbox, adapter, execCtx, prompt, result, err, false, log)
+	if _, harvestErr := o.harvestClaudeCodeCredentials(ctx, run, sandbox, authBillingMode, log); harvestErr != nil {
+		log.Warn().
+			Err(harvestErr).
+			Str("session_id", run.ID.String()).
+			Msg("failed to harvest Claude Code OAuth credentials from sandbox")
+	}
 	if !parseCredentialFailureSignal(result, time.Now()).RateLimited {
 		o.shedOnRunResult(ctx, run.AgentType, run.OrgID, run.TriggeredByUserID, result, err, log)
 	}
@@ -3981,6 +3998,12 @@ func (o *Orchestrator) ContinueSession(ctx context.Context, session *models.Sess
 	// rate-limit or auth-rejected signals. Same semantics as the entry-turn
 	// path above; see shedOnRunResult.
 	result, err, _ = o.retrySessionOnCredentialRateLimit(ctx, session, threadID, messageTurnNumber, sandboxCfg, sandbox, adapter, execCtx, prompt, result, err, true, log)
+	if _, harvestErr := o.harvestClaudeCodeCredentials(ctx, session, sandbox, authBillingMode, log); harvestErr != nil {
+		log.Warn().
+			Err(harvestErr).
+			Str("session_id", session.ID.String()).
+			Msg("failed to harvest Claude Code OAuth credentials from sandbox")
+	}
 	if !parseCredentialFailureSignal(result, time.Now()).RateLimited {
 		o.shedOnRunResult(ctx, session.AgentType, session.OrgID, session.TriggeredByUserID, result, err, log)
 	}
@@ -5481,17 +5504,26 @@ func cloneStringMap(in map[string]string) map[string]string {
 // uses; we translate from the space-separated `scope` response string when
 // the tokens are issued. If Anthropic ever changes this format, update this
 // marshal block and the AnthropicSubscription struct together.
-func (o *Orchestrator) injectClaudeCodeAuth(ctx context.Context, orgID uuid.UUID, sandbox *Sandbox) (bool, string, error) {
+func (o *Orchestrator) injectClaudeCodeAuth(ctx context.Context, orgID uuid.UUID, userID *uuid.UUID, sandbox *Sandbox) (bool, string, error) {
 	if o.claudeCodeAuth == nil {
 		return false, "", nil
 	}
 
-	sub, _, err := o.claudeCodeAuth.GetValidToken(ctx, orgID)
+	sub, credID, err := o.claudeCodeAuth.GetValidToken(ctx, orgID)
 	if err != nil {
 		return false, "", fmt.Errorf("get claude code subscription token: %w", err)
 	}
 	if sub == nil {
 		return false, "", nil
+	}
+	if credID != nil && o.env != nil {
+		o.env.recordCredentialPick(orgID, userID, models.ProviderAnthropic, models.DecryptedCodingCredential{
+			ID:       *credID,
+			OrgID:    orgID,
+			Provider: models.ProviderAnthropicSubscription,
+			Status:   models.CodingCredentialStatusActive,
+			Config:   models.FromAnthropicSubscription(*sub),
+		})
 	}
 
 	injected, err := o.writeClaudeCodeAuth(ctx, orgID, sandbox, *sub)
@@ -5554,6 +5586,159 @@ func (o *Orchestrator) writeClaudeCodeAuth(ctx context.Context, orgID uuid.UUID,
 		Msg("injected claude subscription credentials into sandbox")
 
 	return true, nil
+}
+
+func (o *Orchestrator) harvestClaudeCodeCredentials(ctx context.Context, session *models.Session, sandbox *Sandbox, billingMode TokenBillingMode, log zerolog.Logger) (bool, error) {
+	if o == nil || session == nil || sandbox == nil {
+		return false, nil
+	}
+	if session.AgentType != models.AgentTypeClaudeCode || billingMode != TokenBillingModeSubscription {
+		return false, nil
+	}
+	if o.env == nil || o.provider == nil || o.claudeCodeAuth == nil {
+		return false, nil
+	}
+	store, ok := o.claudeCodeAuth.(ClaudeCodeAuthTokenStore)
+	if !ok {
+		return false, nil
+	}
+
+	rec, ok := o.env.lookupRecentPickRecord(session.OrgID, session.TriggeredByUserID, models.ProviderAnthropic)
+	if !ok || rec.credID == uuid.Nil {
+		return false, nil
+	}
+
+	scope := models.Scope{OrgID: session.OrgID}
+	var existing *models.AnthropicSubscription
+	if rec.credential != nil {
+		if rec.credential.Provider != models.ProviderAnthropicSubscription {
+			return false, nil
+		}
+		scope = rec.credential.Scope()
+		if cfg, ok := rec.credential.Config.(models.AnthropicSubscriptionConfig); ok {
+			existing = &models.AnthropicSubscription{
+				AccessToken:   cfg.AccessToken,
+				RefreshToken:  cfg.RefreshToken,
+				ExpiresAt:     cfg.ExpiresAt,
+				AccountType:   cfg.AccountType,
+				RateLimitTier: cfg.RateLimitTier,
+				Scopes:        cfg.Scopes,
+			}
+		}
+	}
+
+	credsPath := path.Join(sandbox.HomeDir, ".claude", ".credentials.json")
+	raw, err := o.provider.ReadFile(ctx, sandbox, credsPath)
+	if err != nil {
+		if isSandboxFileMissing(err) {
+			return false, nil
+		}
+		return false, fmt.Errorf("read claude credentials: %w", err)
+	}
+
+	sub, err := parseClaudeCodeCredentialsFile(raw, existing)
+	if err != nil {
+		return false, err
+	}
+	if existing != nil && !anthropicSubscriptionChanged(*existing, sub) {
+		return false, nil
+	}
+	stored, err := store.StoreTokenByID(ctx, scope, rec.credID, sub)
+	if err != nil {
+		return false, fmt.Errorf("store harvested claude credentials: %w", err)
+	}
+	if !stored {
+		return false, nil
+	}
+
+	scopeKind := "org"
+	if scope.IsPersonal() {
+		scopeKind = "personal"
+	}
+	log.Info().
+		Str("cred_id", rec.credID.String()).
+		Str("scope", scopeKind).
+		Msg("harvested refreshed Claude Code OAuth token from sandbox")
+	return true, nil
+}
+
+func parseClaudeCodeCredentialsFile(raw []byte, existing *models.AnthropicSubscription) (models.AnthropicSubscription, error) {
+	var payload struct {
+		ClaudeAiOAuth struct {
+			AccessToken      string   `json:"accessToken"`
+			RefreshToken     string   `json:"refreshToken"`
+			ExpiresAt        int64    `json:"expiresAt"`
+			Scopes           []string `json:"scopes"`
+			SubscriptionType string   `json:"subscriptionType"`
+			RateLimitTier    string   `json:"rateLimitTier"`
+		} `json:"claudeAiOauth"`
+	}
+	if err := json.Unmarshal(raw, &payload); err != nil {
+		return models.AnthropicSubscription{}, fmt.Errorf("parse claude credentials: %w", err)
+	}
+
+	oauth := payload.ClaudeAiOAuth
+	if oauth.AccessToken == "" {
+		return models.AnthropicSubscription{}, errors.New("sandbox Claude credentials missing access token")
+	}
+	if oauth.RefreshToken == "" {
+		if existing == nil || existing.RefreshToken == "" {
+			return models.AnthropicSubscription{}, errors.New("sandbox Claude credentials missing refresh token")
+		}
+		oauth.RefreshToken = existing.RefreshToken
+	}
+	if oauth.ExpiresAt <= 0 {
+		return models.AnthropicSubscription{}, errors.New("sandbox Claude credentials missing expiration")
+	}
+
+	sub := models.AnthropicSubscription{
+		AccessToken:   oauth.AccessToken,
+		RefreshToken:  oauth.RefreshToken,
+		ExpiresAt:     time.UnixMilli(oauth.ExpiresAt),
+		AccountType:   oauth.SubscriptionType,
+		RateLimitTier: oauth.RateLimitTier,
+		Scopes:        oauth.Scopes,
+	}
+	if existing != nil {
+		if sub.AccountType == "" {
+			sub.AccountType = existing.AccountType
+		}
+		if sub.RateLimitTier == "" {
+			sub.RateLimitTier = existing.RateLimitTier
+		}
+		if len(sub.Scopes) == 0 {
+			sub.Scopes = existing.Scopes
+		}
+	}
+	if sub.IsExpired() {
+		return models.AnthropicSubscription{}, errors.New("sandbox Claude credentials are expired")
+	}
+	if time.Until(sub.ExpiresAt) > maxClaudeCodeHarvestedTokenLifetime {
+		return models.AnthropicSubscription{}, errors.New("sandbox Claude credentials expiration is implausibly far in the future")
+	}
+	if existing != nil && anthropicSubscriptionChanged(*existing, sub) && !sub.ExpiresAt.After(existing.ExpiresAt) {
+		return models.AnthropicSubscription{}, errors.New("sandbox Claude credentials changed without a later expiration")
+	}
+	return sub, nil
+}
+
+func anthropicSubscriptionChanged(existing, next models.AnthropicSubscription) bool {
+	if existing.AccessToken != next.AccessToken ||
+		existing.RefreshToken != next.RefreshToken ||
+		existing.ExpiresAt.UnixMilli() != next.ExpiresAt.UnixMilli() ||
+		existing.AccountType != next.AccountType ||
+		existing.RateLimitTier != next.RateLimitTier {
+		return true
+	}
+	if len(existing.Scopes) != len(next.Scopes) {
+		return true
+	}
+	for i := range existing.Scopes {
+		if existing.Scopes[i] != next.Scopes[i] {
+			return true
+		}
+	}
+	return false
 }
 
 func (o *Orchestrator) injectUnifiedClaudeCodeAuth(ctx context.Context, orgID uuid.UUID, userID *uuid.UUID, sandbox *Sandbox) (bool, string, error) {
@@ -5657,7 +5842,7 @@ func (o *Orchestrator) ensureClaudeCodeAuth(ctx context.Context, run *models.Ses
 		return TokenBillingModeSubscription, nil
 	}
 
-	injected, accountType, err = o.injectClaudeCodeAuth(ctx, run.OrgID, sandbox)
+	injected, accountType, err = o.injectClaudeCodeAuth(ctx, run.OrgID, run.TriggeredByUserID, sandbox)
 	if err != nil {
 		if fallbackErr := o.prepareClaudeCodeAPIKeyFallback(ctx, run, sandbox, env); fallbackErr == nil {
 			o.logger.Warn().

--- a/internal/services/agent/orchestrator_internal_test.go
+++ b/internal/services/agent/orchestrator_internal_test.go
@@ -234,6 +234,8 @@ type testInternalSandboxProvider struct {
 	execErr    error
 	execStderr string
 	execCalls  []string
+	readFiles  map[string][]byte
+	readErr    error
 	writes     map[string][]byte
 }
 
@@ -255,7 +257,16 @@ func (p *testInternalSandboxProvider) Exec(_ context.Context, _ *Sandbox, cmd st
 	return p.execExit, p.execErr
 }
 
-func (p *testInternalSandboxProvider) ReadFile(context.Context, *Sandbox, string) ([]byte, error) {
+func (p *testInternalSandboxProvider) ReadFile(_ context.Context, _ *Sandbox, path string) ([]byte, error) {
+	if p.readErr != nil {
+		return nil, p.readErr
+	}
+	if data, ok := p.readFiles[path]; ok {
+		return append([]byte(nil), data...), nil
+	}
+	if data, ok := p.writes[path]; ok {
+		return append([]byte(nil), data...), nil
+	}
 	return nil, nil
 }
 
@@ -318,8 +329,12 @@ func (p *testInternalQueuedCodingCredentialProvider) PickRunnableMulti(_ context
 }
 
 type testInternalClaudeCodeAuthProvider struct {
-	sub *models.AnthropicSubscription
-	id  uuid.UUID
+	sub         *models.AnthropicSubscription
+	id          uuid.UUID
+	storedScope models.Scope
+	storedID    uuid.UUID
+	storedSub   *models.AnthropicSubscription
+	storeErr    error
 }
 
 func (p testInternalClaudeCodeAuthProvider) HasActiveSubscription(context.Context, uuid.UUID) (bool, error) {
@@ -332,6 +347,16 @@ func (p testInternalClaudeCodeAuthProvider) GetValidToken(context.Context, uuid.
 	}
 	id := p.id
 	return p.sub, &id, nil
+}
+
+func (p *testInternalClaudeCodeAuthProvider) StoreTokenByID(_ context.Context, scope models.Scope, credID uuid.UUID, sub models.AnthropicSubscription) (bool, error) {
+	if p.storeErr != nil {
+		return false, p.storeErr
+	}
+	p.storedScope = scope
+	p.storedID = credID
+	p.storedSub = &sub
+	return true, nil
 }
 
 type testInternalOrgStore struct {
@@ -810,6 +835,146 @@ func TestSetupFreshSandbox_ReturnsResolvedAuthBillingMode(t *testing.T) {
 
 	require.NoError(t, err, "setupFreshSandbox should succeed for a fresh Claude subscription run")
 	require.Equal(t, TokenBillingModeSubscription, billingMode, "setupFreshSandbox should return the auth-selected billing mode for fresh runs")
+}
+
+func TestHarvestClaudeCodeCredentials_StoresSandboxRefreshedToken(t *testing.T) {
+	t.Parallel()
+
+	orgID := uuid.MustParse("19191919-1919-1919-1919-191919191919")
+	userID := uuid.MustParse("29292929-2929-2929-2929-292929292929")
+	credID := uuid.MustParse("39393939-3939-3939-3939-393939393939")
+	expiresAt := time.Now().Add(2 * time.Hour).Truncate(time.Millisecond)
+	credsPath := "/home/sandbox/.claude/.credentials.json"
+	credsJSON, err := json.Marshal(map[string]interface{}{
+		"claudeAiOauth": map[string]interface{}{
+			"accessToken":      "refreshed-access",
+			"refreshToken":     "refreshed-refresh",
+			"expiresAt":        expiresAt.UnixMilli(),
+			"scopes":           []string{"user:profile", "user:inference", "user:sessions:claude_code"},
+			"subscriptionType": "claude_max",
+			"rateLimitTier":    "default_claude_max_20x",
+		},
+	})
+	require.NoError(t, err, "test credentials JSON should marshal")
+
+	provider := &testInternalSandboxProvider{readFiles: map[string][]byte{credsPath: credsJSON}}
+	auth := &testInternalClaudeCodeAuthProvider{}
+	env := NewAgentEnv(AgentEnvDeps{
+		Provider: provider,
+		Logger:   zerolog.Nop(),
+	})
+	picked := models.DecryptedCodingCredential{
+		ID:       credID,
+		OrgID:    orgID,
+		UserID:   &userID,
+		Provider: models.ProviderAnthropicSubscription,
+		Status:   models.CodingCredentialStatusActive,
+		Config: models.AnthropicSubscriptionConfig{
+			AccessToken:  "old-access",
+			RefreshToken: "old-refresh",
+			ExpiresAt:    time.Now().Add(time.Hour),
+		},
+	}
+	env.recordCredentialPick(orgID, &userID, models.ProviderAnthropic, picked)
+	orch := &Orchestrator{
+		env:            env,
+		provider:       provider,
+		logger:         zerolog.Nop(),
+		claudeCodeAuth: auth,
+	}
+	session := &models.Session{
+		ID:                uuid.MustParse("49494949-4949-4949-4949-494949494949"),
+		OrgID:             orgID,
+		AgentType:         models.AgentTypeClaudeCode,
+		TriggeredByUserID: &userID,
+	}
+
+	stored, err := orch.harvestClaudeCodeCredentials(context.Background(), session, &Sandbox{ID: "sandbox-1", HomeDir: "/home/sandbox"}, TokenBillingModeSubscription, zerolog.Nop())
+
+	require.NoError(t, err, "harvesting refreshed Claude credentials should not fail")
+	require.True(t, stored, "harvesting should report that refreshed credentials were persisted")
+	require.Equal(t, models.Scope{OrgID: orgID, UserID: &userID}, auth.storedScope, "harvesting should store against the selected credential scope")
+	require.Equal(t, credID, auth.storedID, "harvesting should store against the selected credential id")
+	require.NotNil(t, auth.storedSub, "harvesting should persist the refreshed subscription")
+	require.Equal(t, "refreshed-access", auth.storedSub.AccessToken, "harvesting should persist the refreshed access token")
+	require.Equal(t, "refreshed-refresh", auth.storedSub.RefreshToken, "harvesting should persist the refreshed refresh token")
+	require.Equal(t, expiresAt, auth.storedSub.ExpiresAt, "harvesting should persist the refreshed expiration")
+	require.Equal(t, "claude_max", auth.storedSub.AccountType, "harvesting should persist the refreshed account type")
+	require.Equal(t, "default_claude_max_20x", auth.storedSub.RateLimitTier, "harvesting should persist the refreshed rate limit tier")
+	require.Equal(t, []string{"user:profile", "user:inference", "user:sessions:claude_code"}, auth.storedSub.Scopes, "harvesting should persist refreshed scopes")
+}
+
+func TestHarvestClaudeCodeCredentials_RejectsAbsurdFutureExpiration(t *testing.T) {
+	t.Parallel()
+
+	orgID := uuid.MustParse("59595959-5959-5959-5959-595959595959")
+	userID := uuid.MustParse("69696969-6969-6969-6969-696969696969")
+	credID := uuid.MustParse("79797979-7979-7979-7979-797979797979")
+	credsPath := "/home/sandbox/.claude/.credentials.json"
+	credsJSON, err := json.Marshal(map[string]interface{}{
+		"claudeAiOauth": map[string]interface{}{
+			"accessToken":  "fake-access",
+			"refreshToken": "fake-refresh",
+			"expiresAt":    time.Now().Add(10 * 365 * 24 * time.Hour).UnixMilli(),
+		},
+	})
+	require.NoError(t, err, "test credentials JSON should marshal")
+
+	provider := &testInternalSandboxProvider{readFiles: map[string][]byte{credsPath: credsJSON}}
+	auth := &testInternalClaudeCodeAuthProvider{}
+	env := NewAgentEnv(AgentEnvDeps{Provider: provider, Logger: zerolog.Nop()})
+	env.recordCredentialPick(orgID, &userID, models.ProviderAnthropic, models.DecryptedCodingCredential{
+		ID:       credID,
+		OrgID:    orgID,
+		UserID:   &userID,
+		Provider: models.ProviderAnthropicSubscription,
+		Status:   models.CodingCredentialStatusActive,
+		Config: models.AnthropicSubscriptionConfig{
+			AccessToken:  "old-access",
+			RefreshToken: "old-refresh",
+			ExpiresAt:    time.Now().Add(time.Hour),
+		},
+	})
+	orch := &Orchestrator{env: env, provider: provider, logger: zerolog.Nop(), claudeCodeAuth: auth}
+	session := &models.Session{ID: uuid.New(), OrgID: orgID, AgentType: models.AgentTypeClaudeCode, TriggeredByUserID: &userID}
+
+	stored, err := orch.harvestClaudeCodeCredentials(context.Background(), session, &Sandbox{ID: "sandbox-1", HomeDir: "/home/sandbox"}, TokenBillingModeSubscription, zerolog.Nop())
+
+	require.Error(t, err, "harvesting should reject implausibly long-lived sandbox credentials")
+	require.False(t, stored, "harvesting should not persist implausible credentials")
+	require.Nil(t, auth.storedSub, "harvesting should not store rejected credentials")
+}
+
+func TestHarvestClaudeCodeCredentials_LegacyInjectedUnchangedTokenNoOps(t *testing.T) {
+	t.Parallel()
+
+	orgID := uuid.MustParse("89898989-8989-8989-8989-898989898989")
+	userID := uuid.MustParse("99999999-9999-9999-9999-999999999999")
+	credID := uuid.MustParse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
+	sub := &models.AnthropicSubscription{
+		AccessToken:   "legacy-access",
+		RefreshToken:  "legacy-refresh",
+		ExpiresAt:     time.Now().Add(time.Hour).Truncate(time.Millisecond),
+		AccountType:   "claude_pro",
+		RateLimitTier: "default",
+		Scopes:        []string{"user:profile", "user:inference"},
+	}
+	provider := &testInternalSandboxProvider{}
+	auth := &testInternalClaudeCodeAuthProvider{sub: sub, id: credID}
+	env := NewAgentEnv(AgentEnvDeps{Provider: provider, Logger: zerolog.Nop()})
+	orch := &Orchestrator{env: env, provider: provider, logger: zerolog.Nop(), claudeCodeAuth: auth}
+	sandbox := &Sandbox{ID: "sandbox-1", HomeDir: "/home/sandbox"}
+
+	injected, _, err := orch.injectClaudeCodeAuth(context.Background(), orgID, &userID, sandbox)
+	require.NoError(t, err, "legacy Claude auth injection should succeed")
+	require.True(t, injected, "legacy Claude auth injection should write sandbox credentials")
+
+	session := &models.Session{ID: uuid.New(), OrgID: orgID, AgentType: models.AgentTypeClaudeCode, TriggeredByUserID: &userID}
+	stored, err := orch.harvestClaudeCodeCredentials(context.Background(), session, sandbox, TokenBillingModeSubscription, zerolog.Nop())
+
+	require.NoError(t, err, "harvesting unchanged legacy credentials should not fail")
+	require.False(t, stored, "harvesting unchanged legacy credentials should no-op")
+	require.Nil(t, auth.storedSub, "harvesting should not store unchanged legacy credentials")
 }
 
 func TestCreateAssistantMessage_CarriesThreadID(t *testing.T) {

--- a/internal/services/claudecodeauth/service.go
+++ b/internal/services/claudecodeauth/service.go
@@ -106,6 +106,10 @@ const (
 	// the flow (or the row was resurrected by a replay attempt), so we
 	// force them to re-initiate and get a fresh verifier + state.
 	pendingAuthTTL = 10 * time.Minute
+
+	// harvestedTokenMaxLifetime bounds sandbox-originated Claude Code tokens
+	// before they are persisted back to the credential store.
+	harvestedTokenMaxLifetime = 24 * time.Hour
 )
 
 // defaultScopes is the minimum set of OAuth scopes the Claude Code CLI
@@ -723,11 +727,96 @@ func (s *Service) RefreshTokenByID(ctx context.Context, scope models.Scope, cred
 		return nil, fmt.Errorf("store refreshed credential: %w", err)
 	}
 
-	s.logger.Debug().
+	s.logger.Info().
 		Str("cred_id", credID.String()).
 		Msg("Claude Code OAuth token refreshed")
 
 	return newSub, nil
+}
+
+// StoreTokenByID persists a Claude Code OAuth token that was refreshed by an
+// external Claude Code CLI process. Scope must match the credential owner.
+func (s *Service) StoreTokenByID(ctx context.Context, scope models.Scope, credID uuid.UUID, sub models.AnthropicSubscription) (bool, error) {
+	if s.credentials == nil {
+		return false, errors.New("credential store is not configured")
+	}
+	if sub.AccessToken == "" {
+		return false, errors.New("access_token is required")
+	}
+	if sub.RefreshToken == "" {
+		return false, errors.New("refresh_token is required")
+	}
+	if sub.ExpiresAt.IsZero() {
+		return false, errors.New("expires_at is required")
+	}
+	if sub.IsExpired() {
+		return false, errors.New("expires_at must be in the future")
+	}
+	if time.Until(sub.ExpiresAt) > harvestedTokenMaxLifetime {
+		return false, errors.New("expires_at is implausibly far in the future")
+	}
+
+	mu := s.credRefreshMu(credID)
+	mu.Lock()
+	defer mu.Unlock()
+
+	cred, err := s.credentials.GetByID(ctx, scope, credID)
+	if err != nil {
+		return false, fmt.Errorf("get credential: %w", err)
+	}
+	cfg, ok := cred.Config.(models.AnthropicConfig)
+	if !ok || cfg.Subscription == nil {
+		return false, fmt.Errorf("credential is not an Anthropic subscription")
+	}
+	current := cfg.Subscription
+	if !harvestedSubscriptionIsNewer(*current, sub) {
+		return false, nil
+	}
+
+	if s.profileURL == "" {
+		return false, errors.New("profile URL is required to validate harvested Claude token")
+	}
+	profile, err := s.fetchProfile(ctx, sub.AccessToken)
+	if err != nil {
+		return false, fmt.Errorf("validate harvested Claude token: %w", err)
+	}
+	if profile != nil {
+		if profile.Organization.OrganizationType != "" {
+			sub.AccountType = profile.Organization.OrganizationType
+		}
+		if profile.Organization.RateLimitTier != "" {
+			sub.RateLimitTier = profile.Organization.RateLimitTier
+		}
+	}
+
+	if err := s.credentials.UpsertByID(ctx, scope, credID, models.AnthropicConfig{Subscription: &sub}); err != nil {
+		return false, fmt.Errorf("store claude subscription credential: %w", err)
+	}
+	return true, nil
+}
+
+func harvestedSubscriptionIsNewer(current, harvested models.AnthropicSubscription) bool {
+	if !harvested.ExpiresAt.After(current.ExpiresAt) {
+		return false
+	}
+	return current.AccessToken != harvested.AccessToken ||
+		current.RefreshToken != harvested.RefreshToken ||
+		current.ExpiresAt.UnixMilli() != harvested.ExpiresAt.UnixMilli() ||
+		current.AccountType != harvested.AccountType ||
+		current.RateLimitTier != harvested.RateLimitTier ||
+		!stringSlicesEqual(current.Scopes, harvested.Scopes)
+}
+
+func stringSlicesEqual(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
 }
 
 func isClaudeRefreshTokenReused(body []byte) bool {

--- a/internal/services/claudecodeauth/service_test.go
+++ b/internal/services/claudecodeauth/service_test.go
@@ -557,6 +557,128 @@ func TestRefreshTokenByID_HappyPath(t *testing.T) {
 	}
 }
 
+func TestRefreshTokenByID_LogsSuccessfulRefreshAtInfo(t *testing.T) {
+	t.Parallel()
+
+	store := newMockCredentialStore()
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"access_token":"new-access","refresh_token":"new-refresh","expires_in":3600}`))
+	}))
+	defer ts.Close()
+
+	var logs bytes.Buffer
+	logger := zerolog.New(&logs).Level(zerolog.InfoLevel)
+	svc := NewService(store, logger)
+	svc.SetTokenURL(ts.URL)
+	svc.SetProfileURL("")
+
+	orgID := uuid.New()
+	credID := seedActiveSub(t, store, orgID, "team-a", "old-access", "old-refresh", time.Now().Add(-time.Minute))
+
+	_, err := svc.RefreshTokenByID(context.Background(), models.Scope{OrgID: orgID}, credID)
+	require.NoError(t, err, "RefreshTokenByID should refresh the expired subscription")
+	require.Contains(t, logs.String(), "Claude Code OAuth token refreshed", "successful refresh should be logged at info level")
+	require.Contains(t, logs.String(), credID.String(), "successful refresh log should include credential id")
+}
+
+func TestStoreTokenByID_PersistsHarvestedSubscription(t *testing.T) {
+	t.Parallel()
+
+	store := newMockCredentialStore()
+	profileTS := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "Bearer harvested-access", r.Header.Get("Authorization"), "StoreTokenByID should validate the harvested token")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"organization":{"organization_type":"claude_max","rate_limit_tier":"default_claude_max_20x"}}`))
+	}))
+	defer profileTS.Close()
+
+	svc := NewService(store, zerolog.Nop())
+	svc.SetProfileURL(profileTS.URL)
+	orgID := uuid.New()
+	userID := uuid.New()
+	scope := models.Scope{OrgID: orgID, UserID: &userID}
+	credID, err := store.UpsertWithLabel(context.Background(), scope, &userID, "personal-claude", models.AnthropicConfig{
+		Subscription: &models.AnthropicSubscription{
+			AccessToken:  "old-access",
+			RefreshToken: "old-refresh",
+			ExpiresAt:    time.Now().Add(time.Hour),
+		},
+	})
+	require.NoError(t, err, "seed subscription should be stored")
+
+	expiresAt := time.Now().Add(2 * time.Hour).Truncate(time.Millisecond)
+	sub := models.AnthropicSubscription{
+		AccessToken:   "harvested-access",
+		RefreshToken:  "harvested-refresh",
+		ExpiresAt:     expiresAt,
+		AccountType:   "claude_max",
+		RateLimitTier: "default_claude_max_20x",
+		Scopes:        []string{"user:profile", "user:inference"},
+	}
+
+	stored, err := svc.StoreTokenByID(context.Background(), scope, *credID, sub)
+
+	require.NoError(t, err, "StoreTokenByID should persist harvested Claude credentials")
+	require.True(t, stored, "StoreTokenByID should report when harvested credentials were persisted")
+	cred := store.creds[*credID]
+	require.NotNil(t, cred, "stored credential should still exist")
+	cfg, ok := cred.Config.(models.AnthropicConfig)
+	require.True(t, ok, "stored credential config should remain AnthropicConfig")
+	require.NotNil(t, cfg.Subscription, "stored credential should contain a subscription")
+	require.Equal(t, sub, *cfg.Subscription, "stored credential should contain the harvested subscription")
+}
+
+func TestStoreTokenByID_RejectsInvalidHarvestedAccessToken(t *testing.T) {
+	t.Parallel()
+
+	store := newMockCredentialStore()
+	profileTS := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "Bearer harvested-access", r.Header.Get("Authorization"), "StoreTokenByID should validate the harvested token")
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+	}))
+	defer profileTS.Close()
+
+	svc := NewService(store, zerolog.Nop())
+	svc.SetProfileURL(profileTS.URL)
+	orgID := uuid.New()
+	credID := seedActiveSub(t, store, orgID, "team-a", "old-access", "old-refresh", time.Now().Add(time.Hour))
+
+	stored, err := svc.StoreTokenByID(context.Background(), models.Scope{OrgID: orgID}, credID, models.AnthropicSubscription{
+		AccessToken:  "harvested-access",
+		RefreshToken: "harvested-refresh",
+		ExpiresAt:    time.Now().Add(2 * time.Hour),
+	})
+
+	require.Error(t, err, "StoreTokenByID should reject a harvested token that Anthropic does not accept")
+	require.False(t, stored, "StoreTokenByID should report no write for rejected harvested credentials")
+	cfg := store.creds[credID].Config.(models.AnthropicConfig)
+	require.Equal(t, "old-access", cfg.Subscription.AccessToken, "StoreTokenByID should not overwrite with an invalid harvested token")
+	require.Equal(t, "old-refresh", cfg.Subscription.RefreshToken, "StoreTokenByID should preserve the existing refresh token after validation failure")
+}
+
+func TestStoreTokenByID_DoesNotOverwriteNewerStoredToken(t *testing.T) {
+	t.Parallel()
+
+	store := newMockCredentialStore()
+	svc := NewService(store, zerolog.Nop())
+	svc.SetProfileURL("")
+	orgID := uuid.New()
+	credID := seedActiveSub(t, store, orgID, "team-a", "newer-access", "newer-refresh", time.Now().Add(3*time.Hour))
+
+	stored, err := svc.StoreTokenByID(context.Background(), models.Scope{OrgID: orgID}, credID, models.AnthropicSubscription{
+		AccessToken:  "older-harvested-access",
+		RefreshToken: "older-harvested-refresh",
+		ExpiresAt:    time.Now().Add(2 * time.Hour),
+	})
+
+	require.NoError(t, err, "StoreTokenByID should no-op when the DB already has a newer token")
+	require.False(t, stored, "StoreTokenByID should report no write for stale harvested credentials")
+	cfg := store.creds[credID].Config.(models.AnthropicConfig)
+	require.Equal(t, "newer-access", cfg.Subscription.AccessToken, "StoreTokenByID should preserve the newer stored access token")
+	require.Equal(t, "newer-refresh", cfg.Subscription.RefreshToken, "StoreTokenByID should preserve the newer stored refresh token")
+}
+
 func TestRefreshTokenByID_PreservesRefreshTokenWhenEmpty(t *testing.T) {
 	t.Parallel()
 	store := newMockCredentialStore()


### PR DESCRIPTION
## Summary
- Harvest refreshed Claude Code OAuth tokens from the sandbox after agent runs and continue sessions
- Persist harvested tokens back to the selected credential scope only when they are newer and validated
- Add fail-closed checks for malformed, expired, or implausibly long-lived sandbox tokens
- Log successful server-side Claude refreshes at info level so they are visible in production logs
- Cover the refresh, harvest, and stale-token no-op paths with regression tests

## Testing
- Added unit tests for sandbox harvest, profile validation, stale-token no-op behavior, and invalid token rejection
- Verified the touched Go packages and full repo checks pass, including vet, build, and the full test suite