### PR TITLE
Add stale-deploy cancellation with in-lock freshness recheck

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -100,15 +100,35 @@ jobs:
       group: deploy-fleet
       cancel-in-progress: false
     steps:
+      - name: Confirm this SHA is still latest main after deploy lock
+        id: deploy_latest
+        env:
+          GH_TOKEN: ${{ github.token }}
+          EXPECTED_SHA: ${{ github.sha }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          latest_sha="$(gh api "repos/$REPO/commits/main" --jq .sha)"
+          if [ "$latest_sha" = "$EXPECTED_SHA" ]; then
+            echo "This run is still latest main after acquiring deploy lock; continuing deploy for $EXPECTED_SHA."
+            echo "should_deploy=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "Skipping stale deploy for $EXPECTED_SHA after acquiring deploy lock; latest main is $latest_sha."
+            echo "should_deploy=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - uses: actions/checkout@v6
+        if: steps.deploy_latest.outputs.should_deploy == 'true'
 
       - name: Install sops and age
+        if: steps.deploy_latest.outputs.should_deploy == 'true'
         run: |
           curl -fsSL https://github.com/getsops/sops/releases/download/v3.9.4/sops-v3.9.4.linux.amd64 -o /usr/local/bin/sops
           chmod +x /usr/local/bin/sops
           curl -fsSL https://dl.filippo.io/age/latest?for=linux/amd64 | tar xz -C /usr/local/bin --strip-components=1
 
       - name: Write SSH key and age key
+        if: steps.deploy_latest.outputs.should_deploy == 'true'
         run: |
           mkdir -p ~/.ssh ~/.config/sops/age
           echo "${{ secrets.DEPLOY_SSH_KEY }}" > ~/.ssh/deploy-key
@@ -117,6 +137,7 @@ jobs:
           chmod 600 ~/.config/sops/age/keys.txt
 
       - name: Decrypt FLEET_HOSTS
+        if: steps.deploy_latest.outputs.should_deploy == 'true'
         # Decrypt once and propagate to later steps via $GITHUB_ENV so both
         # `Deploy fleet` (deploy-fleet.sh accepts FLEET_HOSTS from env) and
         # `Verify worker rollover` skip the SOPS round-trip.
@@ -132,6 +153,7 @@ jobs:
           echo "FLEET_HOSTS=$fleet_hosts" >> "$GITHUB_ENV"
 
       - name: Deploy fleet
+        if: steps.deploy_latest.outputs.should_deploy == 'true'
         # WORKER_DEPLOY_DETACH=1 makes deploy.sh kick off the worker rollover
         # as a host-side background process and return immediately, so the
         # SSH session (= a billed CI minute) doesn't sit idle for the up-to-
@@ -150,6 +172,7 @@ jobs:
           ./deploy/scripts/deploy-fleet.sh ~/.ssh/deploy-key "${{ github.sha }}"
 
       - name: Verify worker rollover
+        if: steps.deploy_latest.outputs.should_deploy == 'true'
         # The detached rollover writes /var/log/143/deploy-worker-<sha>.status
         # with content "ok" on success or "fail: ..." on failure. Poll each
         # worker host until we see one of those, or until the budget expires.

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,16 +4,6 @@ on:
   push:
     branches: [main]
 
-# A worker drain can hold a deploy job for up to ~45 minutes while in-flight
-# coding turns finish. Queue overlapping deploys instead of running them in
-# parallel — two concurrent deploys would race on `docker compose up
-# --force-recreate` against the same fleet hosts. cancel-in-progress is false
-# because deploy.sh isn't safe to interrupt mid-flight (it would leave a
-# half-rolled host).
-concurrency:
-  group: deploy-fleet
-  cancel-in-progress: false
-
 env:
   REGISTRY: ghcr.io
 
@@ -23,6 +13,9 @@ jobs:
     permissions:
       contents: read
       packages: write
+    concurrency:
+      group: deploy-build-${{ github.ref }}-${{ matrix.name }}
+      cancel-in-progress: true
     strategy:
       matrix:
         include:
@@ -70,9 +63,42 @@ jobs:
           cache-from: type=registry,ref=${{ matrix.image }}:buildcache
           cache-to: type=registry,ref=${{ matrix.image }}:buildcache,mode=max
 
-  deploy:
+  predeploy-latest:
     needs: build
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      should_deploy: ${{ steps.latest.outputs.should_deploy }}
+    steps:
+      - name: Confirm this SHA is still latest main
+        id: latest
+        env:
+          GH_TOKEN: ${{ github.token }}
+          EXPECTED_SHA: ${{ github.sha }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          latest_sha="$(gh api "repos/$REPO/commits/main" --jq .sha)"
+          if [ "$latest_sha" = "$EXPECTED_SHA" ]; then
+            echo "This run is latest main; continuing deploy for $EXPECTED_SHA."
+            echo "should_deploy=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "Skipping stale deploy for $EXPECTED_SHA; latest main is $latest_sha."
+            echo "should_deploy=false" >> "$GITHUB_OUTPUT"
+          fi
+
+  deploy:
+    needs: [build, predeploy-latest]
+    if: needs.predeploy-latest.outputs.should_deploy == 'true'
+    runs-on: ubuntu-latest
+    # A worker drain can hold a deploy job for up to ~45 minutes while
+    # in-flight coding turns finish. Queue overlapping deploys instead of
+    # running them in parallel. cancel-in-progress is false because deploy.sh
+    # isn't safe to interrupt mid-flight.
+    concurrency:
+      group: deploy-fleet
+      cancel-in-progress: false
     steps:
       - uses: actions/checkout@v6
 

--- a/deploy/deploy_config_test.go
+++ b/deploy/deploy_config_test.go
@@ -550,6 +550,14 @@ func TestCIDeployCancelsStaleBuildsButNotActiveDeploys(t *testing.T) {
 	require.Contains(t, deployJob, "if: needs.predeploy-latest.outputs.should_deploy == 'true'", "deploy job should skip stale SHAs")
 	require.Contains(t, deployJob, "group: deploy-fleet", "deploy job should serialize fleet deploys")
 	require.Contains(t, deployJob, "cancel-in-progress: false", "deploy job should never cancel an active production deploy")
+	require.Contains(t, deployJob, "id: deploy_latest", "deploy job should re-check freshness after acquiring the deploy lock")
+	require.Contains(t, deployJob, `gh api "repos/$REPO/commits/main" --jq .sha`, "deploy job should compare the run SHA to latest main after acquiring the deploy lock")
+	deployFreshnessIndex := strings.Index(deployJob, "id: deploy_latest")
+	deployCheckoutIndex := strings.Index(deployJob, "uses: actions/checkout@v6")
+	require.NotEqual(t, -1, deployFreshnessIndex, "deploy job should define an in-lock freshness check")
+	require.NotEqual(t, -1, deployCheckoutIndex, "deploy job should checkout before deploying")
+	require.Less(t, deployFreshnessIndex, deployCheckoutIndex, "deploy job should re-check freshness before any deploy setup or SSH work")
+	require.GreaterOrEqual(t, strings.Count(deployJob, "if: steps.deploy_latest.outputs.should_deploy == 'true'"), 6, "all deploy setup, deploy, and verification steps should skip stale SHAs detected after acquiring the deploy lock")
 }
 
 func TestWorkerGVisorPreflightPullsHealthImageOnlyWhenMissing(t *testing.T) {

--- a/deploy/deploy_config_test.go
+++ b/deploy/deploy_config_test.go
@@ -514,6 +514,44 @@ func TestCIDeployConfiguresWorkerBlueGreenPortRange(t *testing.T) {
 	require.Contains(t, workflowText, "generation binds a free port while old worker generations keep serving", "workflow comment should document why the port range is required")
 }
 
+func TestCIDeployCancelsStaleBuildsButNotActiveDeploys(t *testing.T) {
+	t.Parallel()
+
+	workflow, err := os.ReadFile("../.github/workflows/deploy.yml")
+	require.NoError(t, err, "test should read deploy workflow")
+	workflowText := string(workflow)
+
+	jobsIndex := strings.Index(workflowText, "\njobs:")
+	require.NotEqual(t, -1, jobsIndex, "deploy workflow should define jobs")
+	workflowHeader := workflowText[:jobsIndex]
+	require.NotContains(t, workflowHeader, "\nconcurrency:", "deploy workflow should not use workflow-level concurrency because stale build cancellation must not cancel active deploys")
+
+	buildIndex := strings.Index(workflowText, "\n  build:")
+	predeployIndex := strings.Index(workflowText, "\n  predeploy-latest:")
+	deployIndex := strings.Index(workflowText, "\n  deploy:")
+	require.NotEqual(t, -1, buildIndex, "deploy workflow should define the build job")
+	require.NotEqual(t, -1, predeployIndex, "deploy workflow should define the predeploy freshness gate")
+	require.NotEqual(t, -1, deployIndex, "deploy workflow should define the deploy job")
+	require.Less(t, buildIndex, predeployIndex, "predeploy freshness gate should run after build")
+	require.Less(t, predeployIndex, deployIndex, "deploy should run after the freshness gate")
+
+	buildJob := workflowText[buildIndex:predeployIndex]
+	require.Contains(t, buildJob, `group: deploy-build-${{ github.ref }}-${{ matrix.name }}`, "build job should cancel stale builds independently per image")
+	require.Contains(t, buildJob, "cancel-in-progress: true", "build job should cancel in-progress stale image builds")
+
+	predeployJob := workflowText[predeployIndex:deployIndex]
+	require.Contains(t, predeployJob, "should_deploy", "predeploy freshness gate should expose a should_deploy output")
+	require.Contains(t, predeployJob, `gh api "repos/$REPO/commits/main" --jq .sha`, "predeploy freshness gate should compare the run SHA to latest main")
+	require.Contains(t, predeployJob, `echo "should_deploy=true" >> "$GITHUB_OUTPUT"`, "predeploy freshness gate should allow latest main to deploy")
+	require.Contains(t, predeployJob, `echo "should_deploy=false" >> "$GITHUB_OUTPUT"`, "predeploy freshness gate should skip stale deploys")
+
+	deployJob := workflowText[deployIndex:]
+	require.Contains(t, deployJob, "needs: [build, predeploy-latest]", "deploy job should wait for both image builds and freshness gate")
+	require.Contains(t, deployJob, "if: needs.predeploy-latest.outputs.should_deploy == 'true'", "deploy job should skip stale SHAs")
+	require.Contains(t, deployJob, "group: deploy-fleet", "deploy job should serialize fleet deploys")
+	require.Contains(t, deployJob, "cancel-in-progress: false", "deploy job should never cancel an active production deploy")
+}
+
 func TestWorkerGVisorPreflightPullsHealthImageOnlyWhenMissing(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- Move deploy serialization to the `deploy` job and add cancelable per-image build concurrency.
- Add a predeploy freshness gate plus an in-lock `main` recheck after the deploy lock is acquired, so stale SHAs do not reach fleet deployment.
- Add config tests that lock in the new workflow shape and gating behavior.

## Testing
- `go test -count=1 ./deploy`
- `go vet ./...`
- `go build ./...`
- `go test ./...`