### PR TITLE
Clarify static egress WireGuard prerequisite

### DIFF
--- a/deploy/deploy_config_test.go
+++ b/deploy/deploy_config_test.go
@@ -919,6 +919,7 @@ func TestStaticEgressDeployWiring(t *testing.T) {
 	require.Contains(t, syncText, "egress_host_count", "static egress sync should count egress inventory entries before mutating production secrets")
 	require.Contains(t, syncText, "exactly one egress:<host>", "static egress sync should require exactly one gateway host in FLEET_HOSTS")
 	require.Contains(t, syncText, "duplicate worker:<host>", "static egress sync should reject duplicate worker inventory entries before generating WireGuard peers")
+	require.Contains(t, syncText, "brew install wireguard-tools", "static egress sync should explain how to install the local WireGuard CLI prerequisite")
 	require.Contains(t, syncText, "STATIC_EGRESS_GATEWAY_PRIVATE_KEY", "static egress sync should generate or preserve the gateway private key")
 	require.Contains(t, syncText, "STATIC_EGRESS_GATEWAY_PUBLIC_KEY", "static egress sync should derive the gateway public key")
 	require.Contains(t, syncText, "STATIC_EGRESS_WORKER_HOSTS", "static egress sync should update the generated worker private-key map")

--- a/deploy/deploy_config_test.go
+++ b/deploy/deploy_config_test.go
@@ -926,6 +926,7 @@ func TestStaticEgressDeployWiring(t *testing.T) {
 	require.Contains(t, syncText, "STATIC_EGRESS_WORKER_PEERS", "static egress sync should update the derived gateway peer list")
 	require.Contains(t, syncText, "PROVISION_WORKER_HOST", "static egress sync should validate provision-worker is backed by FLEET_HOSTS")
 	require.Contains(t, syncText, "sops --encrypt", "static egress sync should write updated generated config back to encrypted production secrets only in apply mode")
+	require.Contains(t, syncText, "--filename-override \"$ENC_FILE\"", "static egress sync should encrypt temp files using .env.production.enc creation rules")
 	require.Contains(t, syncText, "Commit $ENC_FILE after provisioning succeeds", "static egress sync should remind operators to commit generated encrypted secrets after provisioning succeeds")
 
 	provisionEgressScript, err := os.ReadFile("../deploy/scripts/provision-egress.sh")

--- a/deploy/scripts/sync-static-egress-secrets.sh
+++ b/deploy/scripts/sync-static-egress-secrets.sh
@@ -292,7 +292,7 @@ if [ "$APPLY" -ne 1 ]; then
   exit 0
 fi
 
-sops --encrypt --input-type dotenv --output-type dotenv "$tmp_env" > "$tmp_env.enc"
+sops --encrypt --filename-override "$ENC_FILE" --input-type dotenv --output-type dotenv "$tmp_env" > "$tmp_env.enc"
 mv "$tmp_env.enc" "$ENC_FILE"
 echo "Updated $ENC_FILE with generated static egress config."
 echo "Commit $ENC_FILE after provisioning succeeds so generated gateway and worker keys are preserved."

--- a/deploy/scripts/sync-static-egress-secrets.sh
+++ b/deploy/scripts/sync-static-egress-secrets.sh
@@ -149,7 +149,11 @@ if [ -z "$static_public_ip" ]; then
   echo "Static egress is not configured; STATIC_EGRESS_PUBLIC_IP is empty."
   exit 0
 fi
-require_command wg
+if ! command -v wg >/dev/null 2>&1; then
+  echo "ERROR: WireGuard tools are required to generate static egress keys, but 'wg' was not found." >&2
+  echo "Install locally with: brew install wireguard-tools" >&2
+  exit 1
+fi
 
 fleet_hosts="$(dotenv_get FLEET_HOSTS "$tmp_env")"
 if [ -z "$fleet_hosts" ]; then


### PR DESCRIPTION
## Summary

- Replace the generic `wg is required` static egress sync error with an actionable WireGuard tools prerequisite message
- Tell macOS operators to install the local CLI with `brew install wireguard-tools`
- Add deploy wiring coverage so the provisioning message stays clear

## Verification

- `go test ./deploy -run TestStaticEgressDeployWiring`
- `bash -n deploy/scripts/sync-static-egress-secrets.sh`
- `go vet ./...`
- `git diff --check`