### PR TITLE
Fix Autopilot issue title links for Linear webhook and add coverage

### DIFF
--- a/frontend/src/app/(dashboard)/autopilot/page.test.tsx
+++ b/frontend/src/app/(dashboard)/autopilot/page.test.tsx
@@ -497,4 +497,112 @@ describe("AutopilotPage", () => {
     expect(screen.queryByText(/737e9a4c/)).not.toBeInTheDocument();
     expect(screen.queryByText(/60685fba/)).not.toBeInTheDocument();
   });
+
+  it("links issue titles to external issue URLs when available", async () => {
+    mockSettings({
+      default_agent_type: "codex",
+      product_context: {
+        philosophy: "Ship reliability first.",
+        direction: "Payments hardening this quarter.",
+        focus_areas: ["auth"],
+        avoid_areas: [],
+      },
+    });
+    mockStatus({
+      is_running: false,
+      issues_reviewed: 0,
+      success_rate: 0,
+      success_count: 0,
+      total_delegated: 0,
+    });
+    mockLatestPlan(null);
+    mockDocuments([]);
+    mockIntegrations([
+      {
+        id: "github-1",
+        org_id: "org-1",
+        provider: "github",
+        status: "active",
+        created_at: "2026-03-20T00:00:00Z",
+      },
+    ]);
+    mockRepositories([
+      {
+        id: "repo-1",
+        org_id: "org-1",
+        integration_id: "integration-1",
+        github_id: 1,
+        full_name: "acme/app",
+        default_branch: "main",
+        private: true,
+        clone_url: "https://github.com/acme/app.git",
+        installation_id: 1,
+        status: "active",
+        settings: {},
+        created_at: "2026-03-20T00:00:00Z",
+        updated_at: "2026-03-20T00:00:00Z",
+      },
+    ]);
+    mockAgentReadiness();
+    server.use(
+      http.get("/api/v1/autopilot/queue", () =>
+        HttpResponse.json({
+          data: [
+            {
+              id: "issue-linked",
+              rank: 1,
+              source: { type: "linear", key: "VIR-321" },
+              title: "Open linked Linear issue",
+              issue_url: "https://linear.app/acme/issue/VIR-321/open-linked-linear-issue",
+              repo: { id: "repo-1", name: "acme/app" },
+              issue_status: "open",
+              customer_impact: { label: "Medium", count: 4 },
+              implementation_ease: "High",
+              low_hanging_fruit: {
+                label: "High",
+                reasons: ["eligible for automation"],
+                cluster_size: 1,
+              },
+              display_run_state: "not_started",
+              available_action: "start_run",
+            },
+            {
+              id: "issue-unlinked",
+              rank: 2,
+              source: { type: "sentry", key: "SENTRY-321" },
+              title: "Plain unlinked issue",
+              issue_url: "javascript:alert(1)",
+              repo: { id: "repo-1", name: "acme/app" },
+              issue_status: "open",
+              customer_impact: { label: "Low", count: 0 },
+              implementation_ease: "Medium",
+              low_hanging_fruit: {
+                label: "Low",
+                reasons: [],
+                cluster_size: 1,
+              },
+              display_run_state: "not_started",
+              available_action: "start_run",
+            },
+          ],
+          meta: {
+            summary: {
+              top_issue_id: "issue-linked",
+              autorunnable_count: 2,
+              needs_review_count: 0,
+              open_pr_count: 0,
+              active_run_count: 0,
+              ranked_issue_count: 2,
+            },
+          },
+        } satisfies AutopilotQueueResponse))
+    );
+
+    renderWithProviders(<AutopilotPage />);
+
+    const linkedTitle = await screen.findByRole("link", { name: "Open linked Linear issue" });
+    expect(linkedTitle).toHaveAttribute("href", "https://linear.app/acme/issue/VIR-321/open-linked-linear-issue");
+    expect(linkedTitle).toHaveAttribute("target", "_blank");
+    expect(screen.getByText("Plain unlinked issue").closest("a")).toBeNull();
+  });
 });

--- a/frontend/src/components/autopilot/autopilot-page-content.tsx
+++ b/frontend/src/components/autopilot/autopilot-page-content.tsx
@@ -25,6 +25,7 @@ import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { api } from "@/lib/api";
 import type { AutopilotQueueRow, AutopilotRunState } from "@/lib/types";
+import { safeExternalUrl } from "@/lib/utils";
 
 const ALL_VALUE = "all";
 
@@ -350,7 +351,7 @@ function QueueTable({
               <TableRow key={row.id}>
                 <TableCell className="font-medium text-muted-foreground">#{row.rank}</TableCell>
                 <TableCell className="whitespace-normal">
-                  <div className="font-medium text-foreground">{row.title}</div>
+                  <IssueTitle row={row} />
                   <div className="mt-1 flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
                     <span>{row.repo?.name ?? "No repo"}</span>
                     <span>{row.issue_status}</span>
@@ -389,6 +390,25 @@ function QueueTable({
         </div>
       )}
     </div>
+  );
+}
+
+function IssueTitle({ row }: { row: AutopilotQueueRow }) {
+  const issueUrl = safeExternalUrl(row.issue_url);
+  if (!issueUrl) {
+    return <div className="font-medium text-foreground">{row.title}</div>;
+  }
+
+  return (
+    <a
+      href={issueUrl}
+      target="_blank"
+      rel="noreferrer"
+      className="inline-flex min-w-0 items-center gap-1 font-medium text-foreground underline-offset-4 hover:underline"
+    >
+      <span>{row.title}</span>
+      <ArrowUpRight className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+    </a>
   );
 }
 

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -353,6 +353,7 @@ export interface AutopilotQueueRow {
   rank: number;
   source: { type: string; key: string };
   title: string;
+  issue_url?: string;
   repo?: { id: string; name: string };
   issue_status: string;
   customer_impact: { label: string; count: number };

--- a/internal/db/autopilot_queue.go
+++ b/internal/db/autopilot_queue.go
@@ -45,6 +45,7 @@ type autopilotQueueDBRow struct {
 	SourceType             string `db:"source_type"`
 	SourceKey              string `db:"source_key"`
 	Title                  string `db:"title"`
+	IssueURL               sql.NullString
 	RepoID                 sql.NullString
 	RepoName               sql.NullString
 	IssueStatus            string   `db:"issue_status"`
@@ -102,6 +103,7 @@ func (s *AutopilotQueueStore) ListQueue(ctx context.Context, orgID uuid.UUID, fi
 			&row.SourceType,
 			&row.SourceKey,
 			&row.Title,
+			&row.IssueURL,
 			&row.RepoID,
 			&row.RepoName,
 			&row.IssueStatus,
@@ -244,6 +246,16 @@ func buildAutopilotQueueQuery(orgID uuid.UUID, filters AutopilotQueueFilters, li
 				i.external_id AS source_key,
 				i.source AS source_type,
 				i.title,
+				COALESCE(
+					i.raw_data->>'url',
+					i.raw_data->>'permalink',
+					i.raw_data->>'web_url',
+					i.raw_data->>'webUrl',
+					i.raw_data->>'external_url',
+					i.raw_data#>>'{data,url}',
+					i.raw_data#>>'{data,issue,url}',
+					i.raw_data#>>'{data,issue,permalink}'
+				) AS issue_url,
 				i.repository_id AS repo_id,
 				r.full_name AS repo_name,
 				i.status AS issue_status,
@@ -373,6 +385,7 @@ func buildAutopilotQueueQuery(orgID uuid.UUID, filters AutopilotQueueFilters, li
 			i.source_type,
 			i.source_key,
 			i.title,
+			i.issue_url,
 			i.repo_id,
 			i.repo_name,
 			i.issue_status,
@@ -427,6 +440,10 @@ func (r autopilotQueueDBRow) toModel() models.AutopilotQueueRow {
 			Reasons:     r.LowHangingFruitReasons,
 			ClusterSize: int(r.ClusterSize),
 		},
+	}
+	if r.IssueURL.Valid && strings.TrimSpace(r.IssueURL.String) != "" {
+		issueURL := strings.TrimSpace(r.IssueURL.String)
+		row.IssueURL = &issueURL
 	}
 	if r.RepoID.Valid && r.RepoName.Valid {
 		row.Repo = &models.AutopilotRepoRef{ID: uuid.MustParse(r.RepoID.String), Name: r.RepoName.String}

--- a/internal/db/autopilot_queue_test.go
+++ b/internal/db/autopilot_queue_test.go
@@ -41,14 +41,14 @@ func TestAutopilotQueueStore_ListQueue(t *testing.T) {
 				mock.ExpectQuery("FROM issues i").
 					WithArgs(pgx.NamedArgs{"org_id": orgID, "limit": 11, "offset": 0, "manual_source": models.IssueSourceManual}).
 					WillReturnRows(pgxmock.NewRows([]string{
-						"id", "rank", "source_type", "source_key", "title", "repo_id", "repo_name", "issue_status",
+						"id", "rank", "source_type", "source_key", "title", "issue_url", "repo_id", "repo_name", "issue_status",
 						"customer_impact_label", "customer_impact_count", "implementation_ease", "low_hanging_fruit_label",
 						"low_hanging_fruit_reasons", "cluster_size", "session_id", "session_title", "session_updated_at",
 						"session_status", "session_origin", "session_started_at", "session_completed_at", "pr_id", "pr_number",
 						"pr_url", "pr_status", "pr_merged_at", "sort_score", "impact_score", "ease_score", "last_seen_at",
 					}).AddRow(
 						issueID.String(), int64(1), "sentry", "SENTRY-123", "Auth token expiry causes retry loop",
-						repoID.String(), "acme/api", "triaged", "High", 42, "High", "Very high",
+						"https://sentry.io/organizations/acme/issues/123", repoID.String(), "acme/api", "triaged", "High", 42, "High", "Very high",
 						[]string{"high customer impact", "straightforward implementation", "recent activity"}, int64(1),
 						sessionID.String(), "Fix auth token expiry", now, "running", "automation", now.Add(-10*time.Minute), nil,
 						prID.String(), 12, "https://github.com/acme/api/pull/12", "open", nil,
@@ -62,6 +62,7 @@ func TestAutopilotQueueStore_ListQueue(t *testing.T) {
 						Rank:        1,
 						Source:      models.AutopilotIssueSource{Type: models.IssueSourceSentry, Key: "SENTRY-123"},
 						Title:       "Auth token expiry causes retry loop",
+						IssueURL:    ptrString("https://sentry.io/organizations/acme/issues/123"),
 						Repo:        &models.AutopilotRepoRef{ID: repoID, Name: "acme/api"},
 						IssueStatus: "triaged",
 						CustomerImpact: models.AutopilotCustomerImpact{
@@ -205,6 +206,7 @@ func TestBuildAutopilotQueueQuery(t *testing.T) {
 			expectedSnippets: []string{
 				"SELECT\n\t\t\ti.id,\n\t\t\ti.rank,\n\t\t\ti.source_type",
 				"i.source <> @manual_source",
+				"i.raw_data#>>'{data,url}'",
 			},
 			expectedArgs: pgx.NamedArgs{
 				"org_id":        orgID,
@@ -265,5 +267,9 @@ func TestBuildAutopilotQueueQuery(t *testing.T) {
 }
 
 func ptrTime(v time.Time) *time.Time {
+	return &v
+}
+
+func ptrString(v string) *string {
 	return &v
 }

--- a/internal/models/autopilot_queue.go
+++ b/internal/models/autopilot_queue.go
@@ -126,6 +126,7 @@ type AutopilotQueueRow struct {
 	Rank                 int                      `json:"rank"`
 	Source               AutopilotIssueSource     `json:"source"`
 	Title                string                   `json:"title"`
+	IssueURL             *string                  `json:"issue_url,omitempty"`
 	Repo                 *AutopilotRepoRef        `json:"repo,omitempty"`
 	IssueStatus          IssueStatus              `json:"issue_status"`
 	CustomerImpact       AutopilotCustomerImpact  `json:"customer_impact"`

--- a/internal/services/linear/create_path_test.go
+++ b/internal/services/linear/create_path_test.go
@@ -161,6 +161,55 @@ func expectLinearLinkInsert(t *testing.T, mock pgxmock.PgxPoolIface, linkID uuid
 		WillReturnRows(pgxmock.NewRows([]string{"id"}).AddRow(linkID))
 }
 
+func TestUpsertLinearIssueStoresIssueURL(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "should create mock pool")
+	defer mock.Close()
+
+	issueID := uuid.New()
+	now := time.Now().UTC()
+	mock.ExpectQuery("INSERT INTO issues").
+		WithArgs(
+			pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
+			pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), rawDataURLArg{expectedURL: "https://linear.app/acme/issue/ACS-123"},
+			pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
+			pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
+		).
+		WillReturnRows(pgxmock.NewRows([]string{"id", "created_at", "updated_at"}).AddRow(issueID, now, now))
+
+	svc := &Service{issues: db.NewIssueStore(mock)}
+	got, err := svc.upsertLinearIssue(context.Background(), uuid.New(), uuid.New(), fetchedIssueForTest("ACS-123"))
+
+	require.NoError(t, err, "upsertLinearIssue should not return an error")
+	require.Equal(t, issueID, got, "upsertLinearIssue should return the stored issue ID")
+	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
+}
+
+type rawDataURLArg struct {
+	expectedURL string
+}
+
+func (a rawDataURLArg) Match(v interface{}) bool {
+	var raw []byte
+	switch typed := v.(type) {
+	case json.RawMessage:
+		raw = typed
+	case []byte:
+		raw = typed
+	default:
+		return false
+	}
+	var payload struct {
+		URL string `json:"url"`
+	}
+	if err := json.Unmarshal(raw, &payload); err != nil {
+		return false
+	}
+	return payload.URL == a.expectedURL
+}
+
 func expectPrepareStateUpdate(t *testing.T, mock pgxmock.PgxPoolIface, rowsAffected int64) {
 	t.Helper()
 	mock.ExpectExec("UPDATE sessions[\\s\\S]+SET linear_prepare_state").

--- a/internal/services/linear/service.go
+++ b/internal/services/linear/service.go
@@ -961,6 +961,18 @@ func (s *Service) upsertLinearIssue(ctx context.Context, orgID, integrationID uu
 		title = fetched.Identifier + ": " + fetched.Title
 	}
 	desc := fetched.Description
+	rawData, err := json.Marshal(struct {
+		ID         string `json:"id"`
+		Identifier string `json:"identifier"`
+		URL        string `json:"url,omitempty"`
+	}{
+		ID:         fetched.ID,
+		Identifier: fetched.Identifier,
+		URL:        fetched.URL,
+	})
+	if err != nil {
+		return uuid.Nil, fmt.Errorf("marshal linear issue raw data: %w", err)
+	}
 	issue := &models.Issue{
 		OrgID:               orgID,
 		ExternalID:          fetched.ID,
@@ -969,6 +981,7 @@ func (s *Service) upsertLinearIssue(ctx context.Context, orgID, integrationID uu
 		RepositoryID:        fetched.RepositoryID,
 		Title:               title,
 		Description:         &desc,
+		RawData:             rawData,
 		Status:              "open",
 		FirstSeenAt:         now,
 		LastSeenAt:          now,


### PR DESCRIPTION
## Summary
Autopilot now reliably links issue titles to external issue URLs, including when Linear webhook payloads are provided in raw form. It also persists enough fetched Linear metadata (id/identifier/url) so the UI can generate `issue_url` consistently.

## Changes
- **Autopilot queue URL extraction**
  - Updated `internal/db/autopilot_queue.go` to extract the queue URL from **Linear webhook raw data at `data.url`**.
  - Adjusted related model/mapping in `internal/models/autopilot_queue.go`.
- **Persist Linear fetched issue raw payload**
  - Updated Linear queue fetch/persistence in `internal/services/linear/service.go` so fetched issues store a small `raw_data` payload containing **`id`, `identifier`, and `url`**.
  - Ensures fetched Linear issues can produce a valid `issue_url` for the UI.
- **Backend tests**
  - Added/expanded coverage in `internal/db/autopilot_queue_test.go` for the webhook raw URL path.
  - Added focused coverage in `internal/services/linear/create_path_test.go` and `internal/services/linear/service.go` for the persisted raw payload behavior.
- **Frontend tests**
  - Updated `frontend/src/components/autopilot/autopilot-page-content.tsx` to render **issue titles as external links** when `issue_url` is available.
  - Added a new test in `frontend/src/app/(dashboard)/autopilot/page.test.tsx` verifying the link `href` and `_blank` target for Linear-backed queue items.
  - Updated shared types in `frontend/src/lib/types.ts` to support the new/consistent URL data flow.

## Test plan
- `go vet ./...`
- `go build ./...`
- `go test ./...`
- Focused DB + Linear tests (webhook raw URL + Linear raw_data persistence)
- Frontend checks for the Autopilot UI change: test, typecheck, lint, build
- Note: Go commands were run with `GOTMPDIR=/home/sandbox/143/.tmp-go` to avoid `/var/tmp` size issues in this environment.

[143.dev](https://143.dev) | [session fd45e6ba](https://143.dev/sessions/fd45e6ba-b757-47ae-982f-674d40fb83dd)

Preview: https://143.dev/previews/github/assembledhq/143/pull/1272