### PR TITLE
Fix preview secrets mask handling and add regression tests

### DIFF
--- a/frontend/src/app/(dashboard)/settings/previews/page.test.tsx
+++ b/frontend/src/app/(dashboard)/settings/previews/page.test.tsx
@@ -444,6 +444,35 @@ describe("PreviewSettingsPage", () => {
     });
   }, 10000);
 
+  it("preserves leading mask characters when replacing an existing environment secret", async () => {
+    let patchedBody: unknown;
+    server.use(
+      http.get("*/api/v1/repositories", () => HttpResponse.json({ data: repos, meta: {} })),
+      http.get("*/api/v1/repositories/repo-1/preview-secret-bundles", () => HttpResponse.json({
+        data: [bundle("bundle-1", "repo-1", "assembled-dev")],
+        meta: {},
+      })),
+      http.get("*/api/v1/previews/api-tokens", () => HttpResponse.json({ data: [], meta: {} })),
+      http.patch("*/api/v1/preview-secret-bundles/:bundleId", async ({ request }) => {
+        patchedBody = await request.json();
+        return HttpResponse.json({ data: bundle("bundle-1", "repo-1", "assembled-dev") });
+      }),
+    );
+
+    renderWithProviders(<PreviewSettingsPage />);
+
+    await userEvent.click((await screen.findAllByRole("button", { name: /edit assembled-dev/i }))[0]);
+    await userEvent.click(screen.getByLabelText("Secret value"));
+    await userEvent.type(screen.getByLabelText("Secret value"), "********TOKEN");
+    await userEvent.click(screen.getByRole("button", { name: /save/i }));
+
+    await waitFor(() => {
+      expect(patchedBody).toMatchObject({
+        source: { type: "managed", values: { DATABASE_URL: "********TOKEN" } },
+      });
+    });
+  }, 10000);
+
   it("preserves existing secret file contents when editing file bundle metadata", async () => {
     let patchedBody: unknown;
     const fileBundle = {
@@ -489,6 +518,47 @@ describe("PreviewSettingsPage", () => {
     });
   }, 10000);
 
+  it("preserves leading mask lines when replacing existing secret file contents", async () => {
+    let patchedBody: unknown;
+    const fileBundle = {
+      id: "bundle-file",
+      repository_id: "repo-1",
+      name: "file-bundle",
+      source_type: "managed",
+      exposure_policy: "preview_runtime",
+      outputs: [{ type: "file", path: "config.json", format: "raw" }],
+      created_by_user_id: "user-1",
+      created_at: "2026-05-27T00:00:00Z",
+    };
+
+    server.use(
+      http.get("*/api/v1/repositories", () => HttpResponse.json({ data: repos, meta: {} })),
+      http.get("*/api/v1/repositories/repo-1/preview-secret-bundles", () =>
+        HttpResponse.json({ data: [fileBundle], meta: {} }),
+      ),
+      http.get("*/api/v1/previews/api-tokens", () => HttpResponse.json({ data: [], meta: {} })),
+      http.patch("*/api/v1/preview-secret-bundles/:bundleId", async ({ request }) => {
+        patchedBody = await request.json();
+        return HttpResponse.json({ data: fileBundle });
+      }),
+    );
+
+    renderWithProviders(<PreviewSettingsPage />);
+
+    await userEvent.click((await screen.findAllByRole("button", { name: /edit file-bundle/i }))[0]);
+    await userEvent.click(screen.getByLabelText("Secret file contents"));
+    fireEvent.change(screen.getByLabelText("Secret file contents"), {
+      target: { value: "********\n********\n********\nactual-content" },
+    });
+    await userEvent.click(screen.getByRole("button", { name: /save/i }));
+
+    await waitFor(() => {
+      expect(patchedBody).toMatchObject({
+        source: { type: "managed", values: { SECRET_FILE_CONTENT: "********\n********\n********\nactual-content" } },
+      });
+    });
+  }, 10000);
+
   it("reveals existing secret file contents on explicit request", async () => {
     const fileBundle = {
       id: "bundle-file",
@@ -522,7 +592,8 @@ describe("PreviewSettingsPage", () => {
 
     await userEvent.click((await screen.findAllByRole("button", { name: /edit file-bundle/i }))[0]);
 
-    expect(screen.getByLabelText("Secret file contents")).toHaveValue("");
+    expect(screen.getByLabelText("Secret file contents")).toHaveValue("********\n********\n********");
+    expect(screen.getByLabelText("Secret file contents")).toHaveClass("[-webkit-text-security:disc]");
 
     expect(screen.queryByRole("button", { name: "Reveal contents" })).not.toBeInTheDocument();
 
@@ -557,7 +628,8 @@ describe("PreviewSettingsPage", () => {
 
     await userEvent.click((await screen.findAllByRole("button", { name: /edit env-bundle/i }))[0]);
 
-    expect(screen.getByLabelText("Secret value")).toHaveValue("");
+    expect(screen.getByLabelText("Secret value")).toHaveValue("********");
+    expect(screen.getByLabelText("Secret value")).toHaveAttribute("type", "password");
 
     await userEvent.click(screen.getByRole("button", { name: "Reveal secret value DATABASE_URL" }));
 

--- a/frontend/src/app/(dashboard)/settings/previews/page.tsx
+++ b/frontend/src/app/(dashboard)/settings/previews/page.tsx
@@ -63,6 +63,8 @@ const SCOPES = ["previews:create", "previews:read", "previews:stop"] as const;
 const SECRET_FILE_KEY = "SECRET_FILE_CONTENT";
 const JSON_FILE_VALIDATION_DEBOUNCE_MS = 400;
 const SECRET_FILE_JSON_ERROR = "Secret file contents must be valid JSON.";
+const MASKED_SECRET_PLACEHOLDER = "********";
+const MASKED_SECRET_FILE_PLACEHOLDER = `${MASKED_SECRET_PLACEHOLDER}\n${MASKED_SECRET_PLACEHOLDER}\n${MASKED_SECRET_PLACEHOLDER}`;
 
 type SecretValueRow = {
   /** Stable identity used as a React key — never sent to the server. */
@@ -718,6 +720,13 @@ function SecretFileFields({
   onReveal: () => void;
   onFormChange: (form: BundleFormState) => void;
 }) {
+  const [isReplacingFileContent, setIsReplacingFileContent] = useState(false);
+  const isMaskedFileContent = canReveal && !form.fileContent && !isReplacingFileContent;
+  const contentValue = isMaskedFileContent ? MASKED_SECRET_FILE_PLACEHOLDER : form.fileContent;
+  const contentPlaceholder = form.fileFormat === "json"
+    ? '{\n  "token": "paste-secret-value-here"\n}'
+    : "Paste the file contents here";
+
   return (
     <div className="space-y-4">
       <p className="text-xs text-muted-foreground">
@@ -769,11 +778,20 @@ function SecretFileFields({
         </div>
         <Textarea
           id="secret-file-content"
-          value={form.fileContent}
-          onChange={(event) => onFormChange({ ...form, fileContent: event.target.value })}
-          placeholder={form.fileFormat === "json" ? '{\n  "token": "paste-secret-value-here"\n}' : "Paste the file contents here"}
+          value={contentValue}
+          onFocus={(event) => {
+            if (isMaskedFileContent) {
+              setIsReplacingFileContent(true);
+              event.currentTarget.select();
+            }
+          }}
+          onChange={(event) => onFormChange({
+            ...form,
+            fileContent: event.target.value,
+          })}
+          placeholder={contentPlaceholder}
           aria-label="Secret file contents"
-          className="min-h-40 font-mono text-xs"
+          className={`min-h-40 font-mono text-xs${isMaskedFileContent ? " [-webkit-text-security:disc]" : ""}`}
           spellCheck={false}
         />
       </div>
@@ -804,6 +822,8 @@ function StoredSecretsFields({
   onRowRemove: (index: number) => void;
   onReveal: (target: RevealTarget) => void;
 }) {
+  const [replacingRowIds, setReplacingRowIds] = useState<Set<string>>(() => new Set());
+
   return (
     <div className="space-y-2">
       <div className="space-y-1">
@@ -821,6 +841,8 @@ function StoredSecretsFields({
           const key = row.key.trim();
           const canRevealRow = canReveal && Boolean(revealBundle) && Boolean(key);
           const isRevealed = revealedEnvRowIds.get(row.rowId) === key;
+          const isMaskedValue = canRevealRow && !isRevealed && !row.value && !replacingRowIds.has(row.rowId);
+          const value = isMaskedValue ? MASKED_SECRET_PLACEHOLDER : row.value;
 
           return (
             <div key={row.rowId} className="grid gap-2 sm:grid-cols-[minmax(0,1fr)_minmax(0,1fr)_auto_auto]">
@@ -832,8 +854,16 @@ function StoredSecretsFields({
                 autoComplete="off"
               />
               <Input
-                value={row.value}
-                onChange={(event) => onRowChange(index, { value: event.target.value })}
+                value={value}
+                onFocus={(event) => {
+                  if (isMaskedValue) {
+                    setReplacingRowIds((current) => new Set(current).add(row.rowId));
+                    event.currentTarget.select();
+                  }
+                }}
+                onChange={(event) => onRowChange(index, {
+                  value: event.target.value,
+                })}
                 placeholder="Secret value"
                 type={isRevealed ? "text" : "password"}
                 aria-label={index === 0 ? "Secret value" : `Secret value ${index + 1}`}


### PR DESCRIPTION
## Summary
Prevented masked-placeholder strings (e.g., `********` or multi-line mask) from being stripped when users replace existing Preview Secrets. The UI now detects when a user starts editing a masked field and preserves exactly what they typed, while saving untouched fields continues to keep the existing encrypted value.

## Changes
- Updated `frontend/src/app/(dashboard)/settings/previews/page.tsx`:
  - Track whether a user begins replacing a masked field.
  - When replacement begins, store the typed value verbatim (including leading `********` characters/lines).
  - When the masked field is not touched, preserve the existing encrypted value.
- Added regression coverage in `frontend/src/app/(dashboard)/settings/previews/page.test.tsx`:
  - Env secret replacement starting with `********`
  - Secret file replacement starting with the multi-line mask
  - Existing reveal and preserve behavior

## Test plan
- Ran focused preview settings tests (includes new regression cases)
- `npm run typecheck`
- `npm run lint`
- `npm run build`

[143.dev](https://143.dev) | [session 7fc0ab20](https://143.dev/sessions/7fc0ab20-a15a-426c-a1c0-ff852b566c42)

Preview: https://143.dev/previews/github/assembledhq/143/pull/1279