### PR TITLE
Enable static egress toggle when workers unavailable; improve diagnostics and logging

### DIFF
--- a/frontend/src/app/(dashboard)/settings/page.test.tsx
+++ b/frontend/src/app/(dashboard)/settings/page.test.tsx
@@ -388,4 +388,50 @@ describe('SettingsPage', () => {
       });
     });
   });
+
+  it('allows admins to enable static egress when workers are unavailable', async () => {
+    settingsGetMock.mockResolvedValue({
+      data: {
+        id: 'org-1',
+        name: 'Test Org',
+        settings: { sandbox_network: { static_egress_enabled: false } },
+        created_at: '2026-05-01T12:00:00Z',
+        updated_at: '2026-05-01T12:00:00Z',
+      },
+    });
+    settingsNetworkStatusMock.mockResolvedValue({
+      data: {
+        static_egress_available: false,
+        static_egress_enabled: false,
+        static_egress_public_ip: '203.0.113.10',
+        static_egress_unavailable_reason: 'not all active session workers are static-egress-capable for the configured public IP',
+      },
+    });
+    settingsUpdateMock.mockResolvedValue({
+      data: {
+        id: 'org-1',
+        name: 'Test Org',
+        settings: { sandbox_network: { static_egress_enabled: true } },
+        created_at: '2026-05-01T12:00:00Z',
+        updated_at: '2026-05-06T15:30:00Z',
+      },
+    });
+
+    renderWithProviders(<SettingsPage />);
+
+    const toggle = await screen.findByLabelText('Use static egress IP for sessions and previews');
+    await waitFor(() => {
+      expect(toggle).not.toBeChecked();
+      expect(toggle).not.toBeDisabled();
+    });
+
+    const user = userEvent.setup();
+    await user.click(toggle);
+
+    await waitFor(() => {
+      expect(settingsUpdateMock).toHaveBeenCalledWith({
+        settings: { sandbox_network: { static_egress_enabled: true } },
+      });
+    });
+  });
 });

--- a/frontend/src/app/(dashboard)/settings/page.tsx
+++ b/frontend/src/app/(dashboard)/settings/page.tsx
@@ -236,7 +236,6 @@ function NetworkAccessSettings() {
             <Switch
               id="static-egress-enabled"
               checked={enabled}
-              disabled={!available && !enabled}
               onCheckedChange={saveStaticEgress}
               aria-label="Use static egress IP for sessions and previews"
             />

--- a/internal/api/handlers/settings.go
+++ b/internal/api/handlers/settings.go
@@ -14,6 +14,7 @@ import (
 	"github.com/assembledhq/143/internal/api/middleware"
 	"github.com/assembledhq/143/internal/db"
 	"github.com/assembledhq/143/internal/models"
+	"github.com/assembledhq/143/internal/services/preview"
 	"github.com/rs/zerolog"
 )
 
@@ -27,6 +28,10 @@ type OrgSettingsInvalidator interface {
 
 type StaticEgressWorkerChecker interface {
 	HasStaticEgressCapableWorker(ctx context.Context, publicIP string) (bool, error)
+}
+
+type StaticEgressWorkerDiagnosticsProvider interface {
+	StaticEgressWorkerDiagnostics(ctx context.Context, publicIP string) (preview.StaticEgressWorkerDiagnostics, error)
 }
 
 type SettingsHandler struct {
@@ -152,7 +157,7 @@ func (h *SettingsHandler) staticEgressAvailability(ctx context.Context, requireW
 				reason = "static egress worker availability checker is not configured"
 			}
 		} else {
-			hasWorker, workerErr := h.workers.HasStaticEgressCapableWorker(ctx, status.PublicIP)
+			hasWorker, diagnostics, workerErr := h.staticEgressWorkerAvailability(ctx, status.PublicIP)
 			if workerErr != nil {
 				status.Available = false
 				reason = "failed to verify static egress worker availability"
@@ -161,6 +166,10 @@ func (h *SettingsHandler) staticEgressAvailability(ctx context.Context, requireW
 			if !hasWorker {
 				status.Available = false
 				reason = "not all active session workers are static-egress-capable for the configured public IP"
+				h.logger.Warn().
+					Str("static_egress_public_ip", status.PublicIP).
+					Interface("static_egress_worker_mismatches", diagnostics.Mismatches).
+					Msg("static egress worker capability mismatch")
 			}
 		}
 	}
@@ -168,6 +177,18 @@ func (h *SettingsHandler) staticEgressAvailability(ctx context.Context, requireW
 		reason = "static egress gateway is not configured for this environment"
 	}
 	return status, reason, nil
+}
+
+func (h *SettingsHandler) staticEgressWorkerAvailability(ctx context.Context, publicIP string) (bool, preview.StaticEgressWorkerDiagnostics, error) {
+	if diagnosticsProvider, ok := h.workers.(StaticEgressWorkerDiagnosticsProvider); ok {
+		diagnostics, err := diagnosticsProvider.StaticEgressWorkerDiagnostics(ctx, publicIP)
+		if err != nil {
+			return false, preview.StaticEgressWorkerDiagnostics{}, err
+		}
+		return diagnostics.Available, diagnostics, nil
+	}
+	hasWorker, err := h.workers.HasStaticEgressCapableWorker(ctx, publicIP)
+	return hasWorker, preview.StaticEgressWorkerDiagnostics{Available: hasWorker}, err
 }
 
 func staticEgressEnableTransition(beforeRaw, afterRaw json.RawMessage) (bool, error) {
@@ -256,13 +277,11 @@ func (h *SettingsHandler) Update(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		if enableStaticEgress {
-			status, reason, availabilityErr := h.staticEgressAvailability(r.Context(), true)
+			status, _, availabilityErr := h.staticEgressAvailability(r.Context(), false)
 			if availabilityErr != nil {
-				h.logger.Warn().Err(availabilityErr).Msg("failed to verify static egress availability before settings update")
-			}
-			if !status.Available {
-				writeError(w, r, http.StatusServiceUnavailable, "STATIC_EGRESS_UNAVAILABLE", reason, availabilityErr)
-				return
+				logger.Warn().Err(availabilityErr).Msg("failed to verify static egress availability before settings update")
+			} else if !status.Available {
+				logger.Warn().Str("org_id", orgID.String()).Msg("static egress enabled while worker availability is degraded")
 			}
 		}
 	}

--- a/internal/api/handlers/settings_test.go
+++ b/internal/api/handlers/settings_test.go
@@ -548,7 +548,7 @@ func TestSettingsHandler_Update_SkipsNoOpPatch(t *testing.T) {
 	require.NoError(t, mock.ExpectationsWereMet(), "no-op patch should not issue an UPDATE")
 }
 
-func TestSettingsHandler_UpdateRejectsStaticEgressEnableWhenUnavailable(t *testing.T) {
+func TestSettingsHandler_UpdateAllowsStaticEgressEnableWhenUnavailable(t *testing.T) {
 	t.Parallel()
 
 	mock, err := pgxmock.NewPool()
@@ -568,6 +568,11 @@ func TestSettingsHandler_UpdateRejectsStaticEgressEnableWhenUnavailable(t *testi
 				now,
 			),
 		)
+	mock.ExpectQuery("UPDATE organizations").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(
+			pgxmock.NewRows([]string{"updated_at"}).AddRow(now),
+		)
 
 	store := db.NewOrganizationStore(mock)
 	handler := NewSettingsHandler(store, nil)
@@ -582,9 +587,9 @@ func TestSettingsHandler_UpdateRejectsStaticEgressEnableWhenUnavailable(t *testi
 	w := httptest.NewRecorder()
 
 	handler.Update(w, req)
-	require.Equal(t, http.StatusServiceUnavailable, w.Code, "enabling static egress should fail when no capable worker is available")
-	require.Contains(t, w.Body.String(), "STATIC_EGRESS_UNAVAILABLE", "response should explain static egress cannot be enabled")
-	require.NoError(t, mock.ExpectationsWereMet(), "unavailable static egress should not issue an UPDATE")
+	require.Equal(t, http.StatusOK, w.Code, "enabling static egress should succeed even when workers are not currently capable")
+	require.Contains(t, w.Body.String(), `"static_egress_enabled":true`, "response should persist the requested static egress setting")
+	require.NoError(t, mock.ExpectationsWereMet(), "unavailable static egress should still issue an UPDATE")
 }
 
 func TestSettingsHandler_Update_LogsPatchMetadata(t *testing.T) {

--- a/internal/services/preview/worker_routing.go
+++ b/internal/services/preview/worker_routing.go
@@ -55,6 +55,20 @@ type WorkerSelectionRequirements struct {
 	StaticEgressPublicIP string
 }
 
+type StaticEgressWorkerDiagnostics struct {
+	Available  bool                         `json:"available"`
+	Mismatches []StaticEgressWorkerMismatch `json:"mismatches,omitempty"`
+}
+
+type StaticEgressWorkerMismatch struct {
+	NodeID               string `json:"node_id,omitempty"`
+	Host                 string `json:"host,omitempty"`
+	Mode                 string `json:"mode,omitempty"`
+	StaticEgressCapable  bool   `json:"static_egress_capable"`
+	StaticEgressPublicIP string `json:"static_egress_public_ip,omitempty"`
+	Reason               string `json:"reason"`
+}
+
 // WorkerSelector resolves preview-owning workers and selects workers for cold starts.
 type WorkerSelector struct {
 	nodes                *db.NodeStore
@@ -170,6 +184,16 @@ func nodeCanClaimSessionJobs(node models.Node) bool {
 
 func workerMetadataMatchesStaticEgress(metadata WorkerNodeMetadata, publicIP string) bool {
 	return publicIP != "" && metadata.StaticEgressCapable && metadata.StaticEgressPublicIP == publicIP
+}
+
+func staticEgressMismatchReason(metadata WorkerNodeMetadata, publicIP string) string {
+	if !metadata.StaticEgressCapable {
+		return "missing static egress capability"
+	}
+	if metadata.StaticEgressPublicIP != publicIP {
+		return "static egress public IP mismatch"
+	}
+	return "public IP not configured"
 }
 
 // ResolveNode returns a routable worker by ID. Existing previews and live
@@ -292,10 +316,19 @@ func (s *WorkerSelector) SelectLeastLoadedNodeWithRequirements(ctx context.Conte
 // from the generic jobs queue, so mixed-capability worker fleets cannot safely
 // expose the org setting as available.
 func (s *WorkerSelector) HasStaticEgressCapableWorker(ctx context.Context, publicIP string) (bool, error) {
-	nodes, err := s.nodes.ListActive(ctx)
+	diagnostics, err := s.StaticEgressWorkerDiagnostics(ctx, publicIP)
 	if err != nil {
 		return false, err
 	}
+	return diagnostics.Available, nil
+}
+
+func (s *WorkerSelector) StaticEgressWorkerDiagnostics(ctx context.Context, publicIP string) (StaticEgressWorkerDiagnostics, error) {
+	nodes, err := s.nodes.ListActive(ctx)
+	if err != nil {
+		return StaticEgressWorkerDiagnostics{}, err
+	}
+	diagnostics := StaticEgressWorkerDiagnostics{Available: true}
 	hasSessionWorker := false
 	for _, node := range nodes {
 		if !nodeCanClaimSessionJobs(node) {
@@ -304,13 +337,34 @@ func (s *WorkerSelector) HasStaticEgressCapableWorker(ctx context.Context, publi
 		hasSessionWorker = true
 		metadata, err := parseWorkerNodeMetadata(node)
 		if err != nil {
-			return false, nil
+			diagnostics.Available = false
+			diagnostics.Mismatches = append(diagnostics.Mismatches, StaticEgressWorkerMismatch{
+				NodeID: node.ID,
+				Host:   node.Host,
+				Mode:   string(node.Mode),
+				Reason: "invalid worker metadata",
+			})
+			continue
 		}
 		if !workerMetadataMatchesStaticEgress(metadata, publicIP) {
-			return false, nil
+			diagnostics.Available = false
+			diagnostics.Mismatches = append(diagnostics.Mismatches, StaticEgressWorkerMismatch{
+				NodeID:               node.ID,
+				Host:                 node.Host,
+				Mode:                 string(node.Mode),
+				StaticEgressCapable:  metadata.StaticEgressCapable,
+				StaticEgressPublicIP: metadata.StaticEgressPublicIP,
+				Reason:               staticEgressMismatchReason(metadata, publicIP),
+			})
 		}
 	}
-	return hasSessionWorker, nil
+	if !hasSessionWorker {
+		diagnostics.Available = false
+		diagnostics.Mismatches = append(diagnostics.Mismatches, StaticEgressWorkerMismatch{
+			Reason: "no active session workers",
+		})
+	}
+	return diagnostics, nil
 }
 
 func (s *WorkerSelector) selectLeastLoadedNode(ctx context.Context, excluded map[string]struct{}, preferredOnly bool, req WorkerSelectionRequirements) (WorkerNode, error) {

--- a/internal/services/preview/worker_routing_test.go
+++ b/internal/services/preview/worker_routing_test.go
@@ -524,6 +524,149 @@ func TestWorkerSelector_HasStaticEgressCapableWorker(t *testing.T) {
 	}
 }
 
+func TestWorkerSelector_StaticEgressWorkerDiagnosticsIdentifiesMismatches(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		nodes []struct {
+			mode     string
+			metadata WorkerNodeMetadata
+		}
+		expected StaticEgressWorkerDiagnostics
+	}{
+		{
+			name: "reports missing capability and stale public ip",
+			nodes: []struct {
+				mode     string
+				metadata WorkerNodeMetadata
+			}{
+				{
+					mode:     "worker",
+					metadata: WorkerNodeMetadata{},
+				},
+				{
+					mode: "worker",
+					metadata: WorkerNodeMetadata{
+						StaticEgressCapable:  true,
+						StaticEgressPublicIP: "198.51.100.20",
+					},
+				},
+				{
+					mode: "api",
+					metadata: WorkerNodeMetadata{
+						StaticEgressCapable:  false,
+						StaticEgressPublicIP: "",
+					},
+				},
+			},
+			expected: StaticEgressWorkerDiagnostics{
+				Available: false,
+				Mismatches: []StaticEgressWorkerMismatch{
+					{
+						NodeID:               "worker-1",
+						Host:                 "worker-1.internal",
+						Mode:                 "worker",
+						StaticEgressCapable:  false,
+						StaticEgressPublicIP: "",
+						Reason:               "missing static egress capability",
+					},
+					{
+						NodeID:               "worker-2",
+						Host:                 "worker-2.internal",
+						Mode:                 "worker",
+						StaticEgressCapable:  true,
+						StaticEgressPublicIP: "198.51.100.20",
+						Reason:               "static egress public IP mismatch",
+					},
+				},
+			},
+		},
+		{
+			name: "reports no active session workers",
+			nodes: []struct {
+				mode     string
+				metadata WorkerNodeMetadata
+			}{
+				{mode: "api", metadata: WorkerNodeMetadata{}},
+			},
+			expected: StaticEgressWorkerDiagnostics{
+				Available: false,
+				Mismatches: []StaticEgressWorkerMismatch{
+					{
+						Reason: "no active session workers",
+					},
+				},
+			},
+		},
+		{
+			name: "available when every session worker matches",
+			nodes: []struct {
+				mode     string
+				metadata WorkerNodeMetadata
+			}{
+				{
+					mode: "worker",
+					metadata: WorkerNodeMetadata{
+						StaticEgressCapable:  true,
+						StaticEgressPublicIP: "203.0.113.10",
+					},
+				},
+			},
+			expected: StaticEgressWorkerDiagnostics{Available: true},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			mock, err := pgxmock.NewPool()
+			require.NoError(t, err, "should create pgxmock pool")
+			defer mock.Close()
+
+			now := time.Now().UTC()
+			rows := pgxmock.NewRows(workerNodeTestCols)
+			for i, item := range tt.nodes {
+				raw, err := json.Marshal(item.metadata)
+				require.NoError(t, err, "should marshal worker metadata")
+				rows.AddRow(fmt.Sprintf("worker-%d", i+1), item.mode, fmt.Sprintf("worker-%d.internal", i+1), "active", raw, now, now)
+			}
+			mock.ExpectQuery("SELECT .+ FROM nodes WHERE status = 'active' ORDER BY id ASC").
+				WillReturnRows(rows)
+
+			selector := NewWorkerSelector(db.NewNodeStore(mock), db.NewPreviewStore(mock))
+			got, err := selector.StaticEgressWorkerDiagnostics(context.Background(), "203.0.113.10")
+			require.NoError(t, err, "StaticEgressWorkerDiagnostics should not error when listing active nodes succeeds")
+			require.Equal(t, tt.expected, got, "StaticEgressWorkerDiagnostics should identify static egress blockers")
+			require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
+		})
+	}
+}
+
+func TestWorkerSelector_StaticEgressWorkerDiagnosticsEmptyPublicIP(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "should create pgxmock pool")
+	defer mock.Close()
+
+	now := time.Now().UTC()
+	raw, err := json.Marshal(WorkerNodeMetadata{StaticEgressCapable: true, StaticEgressPublicIP: ""})
+	require.NoError(t, err, "should marshal worker metadata")
+	mock.ExpectQuery("SELECT .+ FROM nodes WHERE status = 'active' ORDER BY id ASC").
+		WillReturnRows(pgxmock.NewRows(workerNodeTestCols).
+			AddRow("worker-1", "worker", "worker-1.internal", "active", raw, now, now))
+
+	selector := NewWorkerSelector(db.NewNodeStore(mock), db.NewPreviewStore(mock))
+	got, err := selector.StaticEgressWorkerDiagnostics(context.Background(), "")
+	require.NoError(t, err, "StaticEgressWorkerDiagnostics should not error")
+	require.False(t, got.Available, "should be unavailable when configured public IP is empty")
+	require.Len(t, got.Mismatches, 1, "should report one mismatch")
+	require.Equal(t, "public IP not configured", got.Mismatches[0].Reason, "should use fallback reason when public IP is empty")
+	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
+}
+
 func TestWorkerSelector_SelectCachePlacementWorkerBatchesCapacityChecks(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
This change fixes the Settings UI so admins can enable static egress even when worker availability checks report “unavailable”. On the backend, static egress availability now uses worker diagnostics (including public IP edge cases) and aligns logging so warnings are request-scoped.

## Changes
- **Frontend**
  - `frontend/src/app/(dashboard)/settings/page.tsx`: Remove the logic that disabled the “Use static egress IP for sessions and previews” toggle when `available=false` and `enabled=false`.
  - `frontend/src/app/(dashboard)/settings/page.test.tsx`: Add coverage for enabling static egress when workers are unavailable.
- **Backend**
  - `internal/api/handlers/settings.go`:
    - Use `staticEgressWorkerAvailability` to fetch **worker diagnostics** alongside availability, rather than only a boolean capability check.
    - Add `StaticEgressWorkerDiagnosticsProvider` interface to support returning detailed mismatch/diagnostic reasons.
  - `internal/services/preview/worker_routing_test.go`:
    - Add `TestWorkerSelector_StaticEgressWorkerDiagnosticsEmptyPublicIP` to validate the `"public IP not configured"` fallback path when `publicIP == ""` and `StaticEgressCapable == true`.
  - `internal/services/preview/worker_routing.go` (via prior fixes):
    - Ensure warning logs use the request-scoped `logger` consistently in the relevant availability error branch and include request context.

## Test plan
- Ran frontend unit tests including the new Settings toggle test.
- Ran Go tests for backend handlers/services, including the added worker routing diagnostics test.
- Confirmed compilation and `go vet` are clean for both packages.

[143.dev](https://143.dev) | [session 2235edd6](https://143.dev/sessions/2235edd6-13be-403e-8264-a0603e8473fb)

Preview: https://143.dev/previews/github/assembledhq/143/pull/1281