### PR TITLE
Fix worker deploy fingerprint staging

### DIFF
--- a/deploy/deploy_config_test.go
+++ b/deploy/deploy_config_test.go
@@ -425,6 +425,76 @@ func TestWorkerDeployFingerprintsAreSeparatedByBlastRadius(t *testing.T) {
 	require.Contains(t, dockerDaemon, "install-log-rotation.sh", "docker-daemon fingerprint should include Docker log rotation installation")
 }
 
+func TestStagedFingerprintIgnoresCandidateFilename(t *testing.T) {
+	t.Parallel()
+
+	deployScript, err := os.ReadFile("../deploy/scripts/deploy.sh")
+	require.NoError(t, err, "test should read deploy.sh")
+	functionBody := extractTopLevelShellFunction(t, string(deployScript), "fingerprint_candidate_files", "compose_service_fingerprint")
+
+	tmpDir := t.TempDir()
+	supportFile := filepath.Join(tmpDir, "support.conf")
+	script := functionBody + `
+set -euo pipefail
+printf 'same support-service config\n' > "$SUPPORT_FILE"
+active="$(fingerprint_candidate_files "$SUPPORT_FILE")"
+cp "$SUPPORT_FILE" "$SUPPORT_FILE.new"
+candidate="$(fingerprint_candidate_files "$SUPPORT_FILE")"
+printf '%s\n%s\n' "$active" "$candidate"
+`
+
+	cmd := exec.Command("bash", "-c", script)
+	cmd.Env = append(os.Environ(), "SUPPORT_FILE="+supportFile)
+	output, err := cmd.CombinedOutput()
+	require.NoError(t, err, "staged fingerprint helper should execute successfully: %s", output)
+
+	lines := strings.Split(strings.TrimSpace(string(output)), "\n")
+	require.Equal(t, []string{lines[0], lines[0]}, lines, "staging an identical .new file should not change the candidate fingerprint")
+}
+
+func TestStagedFingerprintGateRepairsStaleBaselineWhenCandidateMatchesActive(t *testing.T) {
+	t.Parallel()
+
+	deployScript, err := os.ReadFile("../deploy/scripts/deploy.sh")
+	require.NoError(t, err, "test should read deploy.sh")
+	gateScript := extractTopLevelShellBlock(t, string(deployScript), "fingerprint_candidate_files", "\nREMOTE\n}")
+
+	tmpDir := t.TempDir()
+	gateScript = strings.ReplaceAll(gateScript, "/opt/143", tmpDir)
+	require.NoError(t, os.MkdirAll(filepath.Join(tmpDir, "deploy", "scripts"), 0o755), "test should create deploy script directory")
+
+	compose := `services:
+  chrome:
+    image: chromedp/headless-shell:latest
+  gvisor-check:
+    image: docker:27-cli
+  sandbox-dns:
+    image: 143-sandbox-dns:local
+  worker:
+    image: ghcr.io/assembledhq/143-server:${IMAGE_TAG:-latest}
+`
+	require.NoError(t, os.WriteFile(filepath.Join(tmpDir, "docker-compose.worker.yml"), []byte(compose), 0o644), "test should seed active worker compose")
+	require.NoError(t, os.WriteFile(filepath.Join(tmpDir, "docker-compose.worker.yml.new"), []byte(compose), 0o644), "test should seed identical staged worker compose")
+	require.NoError(t, os.WriteFile(filepath.Join(tmpDir, "Dockerfile.dnsmasq"), []byte("FROM alpine:3.20\n"), 0o644), "test should seed active dnsmasq Dockerfile")
+	require.NoError(t, os.WriteFile(filepath.Join(tmpDir, "Dockerfile.dnsmasq.new"), []byte("FROM alpine:3.20\n"), 0o644), "test should seed identical staged dnsmasq Dockerfile")
+	require.NoError(t, os.WriteFile(filepath.Join(tmpDir, "docker-compose.dns-probe.yml"), []byte("services:\n  dns-probe:\n    image: alpine:3.20\n"), 0o644), "test should seed active DNS probe compose")
+	require.NoError(t, os.WriteFile(filepath.Join(tmpDir, "docker-compose.dns-probe.yml.new"), []byte("services:\n  dns-probe:\n    image: alpine:3.20\n"), 0o644), "test should seed identical staged DNS probe compose")
+
+	fingerprintFile := filepath.Join(tmpDir, ".worker-support-services.v2.fingerprint")
+	require.NoError(t, os.WriteFile(fingerprintFile, []byte("stale-baseline\n"), 0o644), "test should seed a stale persisted support fingerprint")
+
+	cmd := exec.Command("bash", "-c", gateScript)
+	cmd.Env = append(os.Environ(), "DEPLOY_MODE=routine")
+	output, err := cmd.CombinedOutput()
+	require.NoError(t, err, "staged fingerprint gate should allow stale baseline repair when candidate matches active files: %s", output)
+	require.Contains(t, string(output), "stored worker support-service fingerprint is stale", "gate should explain stale support fingerprint repair")
+
+	repaired, err := os.ReadFile(fingerprintFile)
+	require.NoError(t, err, "test should read repaired support fingerprint")
+	require.NotEqual(t, "stale-baseline\n", string(repaired), "gate should update stale support fingerprint metadata")
+	require.Len(t, strings.TrimSpace(string(repaired)), 64, "repaired support fingerprint should be a sha256 hex digest")
+}
+
 func TestRoutineWorkerDeployBlocksOnlyRuntimeFingerprints(t *testing.T) {
 	t.Parallel()
 
@@ -641,6 +711,22 @@ func extractShellFunction(t *testing.T, script, startFunc, nextFunc string) stri
 	require.NotEqual(t, -1, start, "deploy.sh should define %s", startFunc)
 	end := strings.Index(script[start:], "  "+nextFunc+"() {")
 	require.NotEqual(t, -1, end, "deploy.sh should define %s after %s", nextFunc, startFunc)
+	return script[start : start+end]
+}
+
+func extractTopLevelShellFunction(t *testing.T, script, startFunc, nextFunc string) string {
+	t.Helper()
+
+	return extractTopLevelShellBlock(t, script, startFunc, nextFunc+"() {")
+}
+
+func extractTopLevelShellBlock(t *testing.T, script, startFunc, endMarker string) string {
+	t.Helper()
+
+	start := strings.Index(script, startFunc+"() {")
+	require.NotEqual(t, -1, start, "deploy.sh should define %s", startFunc)
+	end := strings.Index(script[start:], endMarker)
+	require.NotEqual(t, -1, end, "deploy.sh should contain marker %q after %s", endMarker, startFunc)
 	return script[start : start+end]
 }
 

--- a/deploy/scripts/deploy.sh
+++ b/deploy/scripts/deploy.sh
@@ -148,12 +148,35 @@ run_worker_staged_fingerprint_gate() {
 set -euo pipefail
 
 fingerprint_candidate_files() {
-  local existing=()
+  local selected=()
   local path
   for path in "$@"; do
     if [ -e "${path}.new" ]; then
-      existing+=("${path}.new")
+      selected+=("$path:${path}.new")
     elif [ -e "$path" ]; then
+      selected+=("$path:$path")
+    fi
+  done
+  if [ "${#selected[@]}" -eq 0 ]; then
+    echo "none"
+    return 0
+  fi
+  {
+    local entry logical_path selected_path file_hash
+    for entry in "${selected[@]}"; do
+      logical_path="${entry%%:*}"
+      selected_path="${entry#*:}"
+      file_hash="$(sha256sum "$selected_path" | awk '{print $1}')"
+      printf '%s  %s\n' "$file_hash" "$logical_path"
+    done
+  } | sha256sum | awk '{print $1}'
+}
+
+fingerprint_active_files() {
+  local existing=()
+  local path
+  for path in "$@"; do
+    if [ -e "$path" ]; then
       existing+=("$path")
     fi
   done
@@ -161,7 +184,13 @@ fingerprint_candidate_files() {
     echo "none"
     return 0
   fi
-  sha256sum "${existing[@]}" | sha256sum | awk '{print $1}'
+  {
+    local selected_path file_hash
+    for selected_path in "${existing[@]}"; do
+      file_hash="$(sha256sum "$selected_path" | awk '{print $1}')"
+      printf '%s  %s\n' "$file_hash" "$selected_path"
+    done
+  } | sha256sum | awk '{print $1}'
 }
 
 compose_service_fingerprint() {
@@ -191,6 +220,29 @@ compose_service_fingerprint() {
   } | sha256sum | awk '{print $1}'
 }
 
+compose_service_active_fingerprint() {
+  local compose_file="$1"
+  shift
+  if [ ! -e "$compose_file" ]; then
+    printf 'missing:%s\n' "$compose_file" | sha256sum | awk '{print $1}'
+    return 0
+  fi
+  {
+    local svc
+    for svc in "$@"; do
+      printf -- '--- %s:%s ---\n' "$compose_file" "$svc"
+      awk -v svc="$svc" '
+        /^  [A-Za-z0-9_.-]+:/ {
+          current=$1
+          sub(/:$/, "", current)
+          in_service=(current == svc)
+        }
+        in_service { print }
+      ' "$compose_file"
+    done
+  } | sha256sum | awk '{print $1}'
+}
+
 worker_process_config_fingerprint() {
   compose_service_fingerprint /opt/143/docker-compose.worker.yml worker
 }
@@ -204,8 +256,25 @@ worker_support_service_fingerprint() {
   } | sha256sum | awk '{print $1}'
 }
 
+worker_active_support_service_fingerprint() {
+  {
+    compose_service_active_fingerprint /opt/143/docker-compose.worker.yml chrome gvisor-check sandbox-dns
+    fingerprint_active_files \
+      /opt/143/Dockerfile.dnsmasq \
+      /opt/143/docker-compose.dns-probe.yml
+  } | sha256sum | awk '{print $1}'
+}
+
 worker_host_runtime_fingerprint() {
   fingerprint_candidate_files \
+    /opt/143/deploy/scripts/reconcile-worker-host.sh \
+    /opt/143/deploy/scripts/sandbox-firewall.sh \
+    /opt/143/deploy/scripts/sandbox-resolv-conf.sh \
+    /opt/143/deploy/scripts/install-static-egress-worker.sh
+}
+
+worker_active_host_runtime_fingerprint() {
+  fingerprint_active_files \
     /opt/143/deploy/scripts/reconcile-worker-host.sh \
     /opt/143/deploy/scripts/sandbox-firewall.sh \
     /opt/143/deploy/scripts/sandbox-resolv-conf.sh \
@@ -218,11 +287,30 @@ worker_docker_daemon_fingerprint() {
     /opt/143/deploy/scripts/install-log-rotation.sh
 }
 
+worker_active_docker_daemon_fingerprint() {
+  fingerprint_active_files \
+    /opt/143/deploy/scripts/install-docker-dns.sh \
+    /opt/143/deploy/scripts/install-log-rotation.sh
+}
+
+repair_stale_worker_fingerprint() {
+  local label="$1" file="$2" expected="$3" candidate="$4" active="$5"
+  if [ "$expected" != "$candidate" ] && [ "$candidate" = "$active" ]; then
+    echo "WARNING: stored worker $label fingerprint is stale; repairing baseline because staged candidate matches active files." >&2
+    printf '%s\n' "$candidate" > "$file"
+    return 0
+  fi
+  return 1
+}
+
 mode="${DEPLOY_MODE:-routine}"
 worker_process_fingerprint="$(worker_process_config_fingerprint)"
 support_fingerprint="$(worker_support_service_fingerprint)"
 host_runtime_fingerprint="$(worker_host_runtime_fingerprint)"
 docker_daemon_fingerprint="$(worker_docker_daemon_fingerprint)"
+active_support_fingerprint="$(worker_active_support_service_fingerprint)"
+active_host_runtime_fingerprint="$(worker_active_host_runtime_fingerprint)"
+active_docker_daemon_fingerprint="$(worker_active_docker_daemon_fingerprint)"
 
 worker_process_expected="$worker_process_fingerprint"
 support_expected="$support_fingerprint"
@@ -235,19 +323,31 @@ docker_daemon_expected="$docker_daemon_fingerprint"
 [ ! -f /opt/143/.worker-docker-daemon.fingerprint ] || docker_daemon_expected="$(cat /opt/143/.worker-docker-daemon.fingerprint)"
 
 if [ "$mode" = "routine" ] && [ "$support_expected" != "$support_fingerprint" ]; then
-  echo "ERROR: worker support-service config changed during routine deploy; run DEPLOY_MODE=maintenance after reviewing active runtime impact." >&2
-  echo "current=$support_expected candidate=$support_fingerprint" >&2
-  exit 1
+  if repair_stale_worker_fingerprint "support-service" /opt/143/.worker-support-services.v2.fingerprint "$support_expected" "$support_fingerprint" "$active_support_fingerprint"; then
+    support_expected="$support_fingerprint"
+  else
+    echo "ERROR: worker support-service config changed during routine deploy; run DEPLOY_MODE=maintenance after reviewing active runtime impact." >&2
+    echo "current=$support_expected candidate=$support_fingerprint" >&2
+    exit 1
+  fi
 fi
 if [ "$mode" = "routine" ] && [ "$host_runtime_expected" != "$host_runtime_fingerprint" ]; then
-  echo "ERROR: worker host-runtime config changed during routine deploy; run DEPLOY_MODE=maintenance after reviewing active runtime impact." >&2
-  echo "current=$host_runtime_expected candidate=$host_runtime_fingerprint" >&2
-  exit 1
+  if repair_stale_worker_fingerprint "host-runtime" /opt/143/.worker-host-runtime.fingerprint "$host_runtime_expected" "$host_runtime_fingerprint" "$active_host_runtime_fingerprint"; then
+    host_runtime_expected="$host_runtime_fingerprint"
+  else
+    echo "ERROR: worker host-runtime config changed during routine deploy; run DEPLOY_MODE=maintenance after reviewing active runtime impact." >&2
+    echo "current=$host_runtime_expected candidate=$host_runtime_fingerprint" >&2
+    exit 1
+  fi
 fi
 if [ "$mode" = "routine" ] && [ "$docker_daemon_expected" != "$docker_daemon_fingerprint" ]; then
-  echo "ERROR: worker docker-daemon config changed during routine deploy; run DEPLOY_MODE=maintenance after reviewing active runtime impact." >&2
-  echo "current=$docker_daemon_expected candidate=$docker_daemon_fingerprint" >&2
-  exit 1
+  if repair_stale_worker_fingerprint "docker-daemon" /opt/143/.worker-docker-daemon.fingerprint "$docker_daemon_expected" "$docker_daemon_fingerprint" "$active_docker_daemon_fingerprint"; then
+    docker_daemon_expected="$docker_daemon_fingerprint"
+  else
+    echo "ERROR: worker docker-daemon config changed during routine deploy; run DEPLOY_MODE=maintenance after reviewing active runtime impact." >&2
+    echo "current=$docker_daemon_expected candidate=$docker_daemon_fingerprint" >&2
+    exit 1
+  fi
 fi
 REMOTE
 }


### PR DESCRIPTION
## Summary
- Normalize staged worker fingerprinting so identical `.new` files hash the same as their active counterparts.
- Repair stale persisted worker fingerprints when the staged candidate already matches the active files.
- Add regression tests for both the filename-normalization bug and the stale-baseline recovery path.

## Testing
- `go test ./deploy -count=1`
- `go vet ./...`
- `go build ./...`
- `go test ./...`