### PR TITLE
Add bounded retries to go mod download to reduce CI flakes from module proxy errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,6 +72,17 @@ jobs:
       - uses: actions/setup-go@v6
         with:
           go-version: ${{ env.GO_VERSION }}
+      - name: Download Go modules
+        run: |
+          for attempt in 1 2 3; do
+            go mod download && exit 0
+            if [ "$attempt" -eq 3 ]; then
+              echo "::error::go mod download failed after 3 attempts; check Go module proxy/network availability."
+              exit 1
+            fi
+            echo "::warning::go mod download failed, likely due to a transient network issue. Retrying after attempt ${attempt}/3..."
+            sleep 5
+          done
       - name: Multi-tenancy guardrails (schema + stores)
         run: make lint-tenancy
       - name: golangci-lint


### PR DESCRIPTION
## Summary
This updates the CI workflow to retry only the Go module download step (`go mod download`) to mitigate transient failures from the Go module proxy (e.g., `proxy.golang.org ... INTERNAL_ERROR`). The goal is to keep `golangci-lint` output “fail-fast” while reducing unnecessary CI reruns.

## Changes
- **.github/workflows/ci.yml**
  - Added a **“Download Go modules”** step before `make lint-tenancy` / `golangci-lint`.
  - Runs `go mod download` up to **3 attempts** with a short delay between tries.
  - Emits clear warnings on intermediate failures and an explicit error if all attempts fail, suggesting proxy/network issues.

## Test plan
- Verified the workflow change by validating the CI job progression includes the new module download step and that failures now surface as a module-proxy/network issue during dependency fetching rather than later as misleading lint/typecheck errors.

[143.dev](https://143.dev) | [session 2970e263](https://143.dev/sessions/2970e263-2825-4cb6-81d6-14cff15e987d)

Preview: https://143.dev/previews/github/assembledhq/143/pull/1284