### PR TITLE
Prevent duplicate ghost sessions by building stable thread/chrome state

### DIFF
--- a/frontend/src/app/(dashboard)/sessions/[id]/agent-tab-strip.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/agent-tab-strip.test.tsx
@@ -105,6 +105,51 @@ describe("AgentTabStrip", () => {
     expect(screen.getByRole("tooltip")).toHaveTextContent("1 message queued");
   });
 
+  it("disables the single-agent add button while a tab create is pending", () => {
+    const thread = makeThread({});
+
+    renderWithProviders(
+      <AgentTabStrip
+        threads={[thread]}
+        activeThreadId={thread.id}
+        viewedThreadIds={new Set([thread.id])}
+        overlapsByThreadId={new Map()}
+        statusConfig={statusConfig}
+        onActiveThreadChange={vi.fn()}
+        onAddTab={vi.fn()}
+        addTabPending
+        onRevertThread={vi.fn()}
+        onArchiveThread={vi.fn()}
+        archivePendingThreadId={null}
+      />,
+    );
+
+    expect(screen.getByRole("button", { name: "Add agent tab" })).toBeDisabled();
+  });
+
+  it("disables the multi-agent add button while a tab create is pending", () => {
+    const thread1 = makeThread({ id: "thread-1" });
+    const thread2 = makeThread({ id: "thread-2", label: "Codex 2" });
+
+    renderWithProviders(
+      <AgentTabStrip
+        threads={[thread1, thread2]}
+        activeThreadId={thread1.id}
+        viewedThreadIds={new Set([thread1.id, thread2.id])}
+        overlapsByThreadId={new Map()}
+        statusConfig={statusConfig}
+        onActiveThreadChange={vi.fn()}
+        onAddTab={vi.fn()}
+        addTabPending
+        onRevertThread={vi.fn()}
+        onArchiveThread={vi.fn()}
+        archivePendingThreadId={null}
+      />,
+    );
+
+    expect(screen.getByRole("button", { name: "Add agent tab" })).toBeDisabled();
+  });
+
   it("shows durable inbox delivery state in the tab tooltip", async () => {
     const user = userEvent.setup();
     const thread = makeThread({

--- a/frontend/src/app/(dashboard)/sessions/[id]/agent-tab-strip.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/agent-tab-strip.tsx
@@ -289,6 +289,7 @@ export function AgentTabStrip({
               aria-label="Add agent tab"
               title="Add agent tab (t)"
               onClick={onAddTab}
+              disabled={addTabPending}
             >
               <Plus className="h-3.5 w-3.5" />
             </Button>

--- a/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.test.ts
+++ b/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.test.ts
@@ -14,6 +14,7 @@ import {
   mergeSessionDetailStatusUpdate,
   mergeVisibleThreadLogs,
   trackInFlightAgentUpdate,
+  buildChromeThreads,
 } from "./session-detail-content";
 import type { SessionDetail, SessionLog, SessionMessage, SessionReviewLoop, SessionThread, ThreadMessageWindowResponse } from "@/lib/types";
 
@@ -215,6 +216,66 @@ describe("getInitialComposerSelectedModel", () => {
 
   it("uses the default composer selection when the created thread has no override", () => {
     expect(getInitialComposerSelectedModel(baseThread)).toBe("");
+  });
+});
+
+describe("buildChromeThreads", () => {
+  const baseThread: SessionThread = {
+    id: "thread-1",
+    session_id: "session-1",
+    org_id: "org-1",
+    agent_type: "codex",
+    label: "Main",
+    status: "idle",
+    current_turn: 0,
+    created_at: "2026-01-01T00:00:00.000Z",
+    cost_cents: 0,
+    pending_message_count: 0,
+  };
+
+  it("appends a pending preview while the matching real thread is not present", () => {
+    const pending = {
+      ...baseThread,
+      id: "__pending-thread__",
+      label: "Codex 2",
+      status: "pending" as const,
+      created_at: "2026-01-01T00:00:01.000Z",
+    };
+
+    expect(buildChromeThreads([baseThread], pending)).toEqual([baseThread, pending]);
+  });
+
+  it("drops the pending preview once the real created thread is in the session detail cache", () => {
+    const pending = {
+      ...baseThread,
+      id: "__pending-thread__",
+      label: "Codex 2",
+      status: "pending" as const,
+      model_override: "gpt-5.4",
+      created_at: "2026-01-01T00:00:01.000Z",
+    };
+    const created = {
+      ...baseThread,
+      id: "thread-2",
+      label: "Codex 2",
+      model_override: "gpt-5.4",
+      created_at: "2026-01-01T00:00:02.000Z",
+    };
+
+    expect(buildChromeThreads([baseThread, created], pending)).toEqual([baseThread, created]);
+  });
+
+  it("drops the pending preview when its id directly matches a thread (review-loop case)", () => {
+    const reviewThread = {
+      ...baseThread,
+      id: "thread-review-1",
+      label: "Review",
+      status: "pending" as const,
+      created_at: "2026-01-01T00:00:01.000Z",
+    };
+    const realThread = { ...baseThread, id: "thread-review-1", label: "Review" };
+
+    expect(buildChromeThreads([baseThread, realThread], reviewThread)).toEqual([baseThread, realThread]);
   });
 });
 

--- a/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
@@ -549,6 +549,29 @@ type PendingThreadPreview = Pick<
 
 const terminalSessionStatuses = new Set<SessionStatus>(["completed", "pr_created", "failed", "cancelled", "skipped"]);
 
+function threadMatchesPendingPreview(thread: SessionThread, pending: PendingThreadPreview): boolean {
+  return thread.id === pending.id || (
+    thread.session_id === pending.session_id &&
+    thread.agent_type === pending.agent_type &&
+    thread.label === pending.label &&
+    (thread.model_override ?? null) === (pending.model_override ?? null) &&
+    new Date(thread.created_at) >= new Date(pending.created_at)
+  );
+}
+
+export function buildChromeThreads(
+  threads: SessionThread[],
+  pendingThreadPreview: PendingThreadPreview | null,
+): SessionThread[] {
+  if (!pendingThreadPreview) {
+    return threads;
+  }
+  if (threads.some((thread) => threadMatchesPendingPreview(thread, pendingThreadPreview))) {
+    return threads;
+  }
+  return [...threads, pendingThreadPreview];
+}
+
 function mergePendingMessages(
   baseMessages: SessionMessage[],
   pendingMessages: SessionMessage[],
@@ -3305,12 +3328,10 @@ export function SessionDetailContent({ id }: { id: string }) {
   }, [diffRevisionKey, isDiffFetchedAfterMount, refetchDiff, sessionDiffPayload, shouldLoadDiff]);
   const threads = useMemo(() => session?.threads ?? [], [session?.threads]);
   const [pendingThreadPreview, setPendingThreadPreview] = useState<PendingThreadPreview | null>(null);
-  const chromeThreads = useMemo(() => {
-    if (!pendingThreadPreview || threads.some((thread) => thread.id === pendingThreadPreview.id)) {
-      return threads;
-    }
-    return [...threads, pendingThreadPreview];
-  }, [pendingThreadPreview, threads]);
+  const chromeThreads = useMemo(
+    () => buildChromeThreads(threads, pendingThreadPreview),
+    [pendingThreadPreview, threads],
+  );
   const nonInteractiveThreadIds = useMemo(
     () => new Set(pendingThreadPreview?.id === "__pending-thread__" ? [pendingThreadPreview.id] : []),
     [pendingThreadPreview],


### PR DESCRIPTION
## Summary
This change fixes duplicate “ghost” sessions in the session detail view by stabilizing how Chrome/thread UI state is derived, including handling pending tab creation previews safely. It also prevents users from triggering concurrent tab creates that can amplify the duplication.

## Changes
- **frontend/src/app/(dashboard)/sessions/[id]/agent-tab-strip.tsx**
  - Disable the **“Add agent tab”** button while `addTabPending` is true to prevent overlapping tab create actions.
- **frontend/src/app/(dashboard)/sessions/[id]/agent-tab-strip.test.tsx**
  - Added tests verifying both single-agent and multi-agent add buttons are disabled when `addTabPending` is set.
- **frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx**
  - Introduced/updated `buildChromeThreads` to append a pending preview thread only when the matching real thread is not present, avoiding duplicate/ghost session entries.
- **frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.test.ts**
  - Added unit tests for `buildChromeThreads` behavior around pending preview insertion.

## Test plan
- Ran frontend unit tests for the updated session detail and agent tab strip components:
  - `agent-tab-strip.test.tsx`
  - `session-detail-content.test.ts`
- Verified new expectations around disabling “Add agent tab” during pending create and correct pending-preview thread handling via `buildChromeThreads` tests.

[143.dev](https://143.dev) | [session 04afa6a5](https://143.dev/sessions/04afa6a5-af2b-402a-961e-efafa2627432)

Preview: https://143.dev/previews/github/assembledhq/143/pull/1285