### PR TITLE
Reset runtime state when resuming sessions

### DIFF
--- a/internal/api/handlers/sessions_test.go
+++ b/internal/api/handlers/sessions_test.go
@@ -5574,7 +5574,7 @@ func TestSessionHandler_SendMessage(t *testing.T) {
 				mock.ExpectQuery("UPDATE sessions SET status").
 					WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
 					WillReturnRows(pgxmock.NewRows(sessionColumns))
-				mock.ExpectQuery(`UPDATE sessions\s+SET status = 'running', completed_at = NULL,\s+last_activity_at = now\(\)\s+WHERE id = @id AND org_id = @org_id AND status = ANY\(@statuses\)\s+AND sandbox_state != 'destroyed'\s+RETURNING`).
+				mock.ExpectQuery(`UPDATE sessions\s+SET status = 'running', started_at = now\(\), completed_at = NULL,\s+runtime_soft_deadline_at = NULL,\s+runtime_hard_deadline_at = NULL,\s+runtime_last_progress_at = NULL,\s+runtime_last_progress_type = '',\s+runtime_last_progress_strength = '',\s+runtime_extension_count = 0,\s+runtime_extension_seconds = 0,\s+runtime_stop_reason = '',\s+runtime_graceful_stop_at = NULL,\s+last_activity_at = now\(\)\s+WHERE id = @id AND org_id = @org_id AND status = ANY\(@statuses\)\s+AND sandbox_state != 'destroyed'\s+RETURNING`).
 					WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
 					WillReturnRows(
 						addSessionRow(pgxmock.NewRows(sessionColumns),
@@ -5654,7 +5654,7 @@ func TestSessionHandler_SendMessage(t *testing.T) {
 				mock.ExpectQuery("UPDATE sessions SET status").
 					WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
 					WillReturnRows(pgxmock.NewRows(sessionColumns))
-				mock.ExpectQuery(`UPDATE sessions\s+SET status = 'running', completed_at = NULL,\s+last_activity_at = now\(\)\s+WHERE id = @id AND org_id = @org_id AND status = ANY\(@statuses\)\s+AND sandbox_state != 'destroyed'\s+RETURNING`).
+				mock.ExpectQuery(`UPDATE sessions\s+SET status = 'running', started_at = now\(\), completed_at = NULL,\s+runtime_soft_deadline_at = NULL,\s+runtime_hard_deadline_at = NULL,\s+runtime_last_progress_at = NULL,\s+runtime_last_progress_type = '',\s+runtime_last_progress_strength = '',\s+runtime_extension_count = 0,\s+runtime_extension_seconds = 0,\s+runtime_stop_reason = '',\s+runtime_graceful_stop_at = NULL,\s+last_activity_at = now\(\)\s+WHERE id = @id AND org_id = @org_id AND status = ANY\(@statuses\)\s+AND sandbox_state != 'destroyed'\s+RETURNING`).
 					WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
 					WillReturnRows(
 						addSessionRow(pgxmock.NewRows(sessionColumns),
@@ -5720,7 +5720,7 @@ func TestSessionHandler_SendMessage(t *testing.T) {
 				mock.ExpectQuery("UPDATE sessions SET status").
 					WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
 					WillReturnRows(pgxmock.NewRows(sessionColumns))
-				mock.ExpectQuery(`UPDATE sessions\s+SET status = 'running', completed_at = NULL,\s+last_activity_at = now\(\)\s+WHERE id = @id AND org_id = @org_id AND status = ANY\(@statuses\)\s+AND sandbox_state != 'destroyed'\s+RETURNING`).
+				mock.ExpectQuery(`UPDATE sessions\s+SET status = 'running', started_at = now\(\), completed_at = NULL,\s+runtime_soft_deadline_at = NULL,\s+runtime_hard_deadline_at = NULL,\s+runtime_last_progress_at = NULL,\s+runtime_last_progress_type = '',\s+runtime_last_progress_strength = '',\s+runtime_extension_count = 0,\s+runtime_extension_seconds = 0,\s+runtime_stop_reason = '',\s+runtime_graceful_stop_at = NULL,\s+last_activity_at = now\(\)\s+WHERE id = @id AND org_id = @org_id AND status = ANY\(@statuses\)\s+AND sandbox_state != 'destroyed'\s+RETURNING`).
 					WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
 					WillReturnRows(
 						addSessionRow(pgxmock.NewRows(sessionColumns),
@@ -5786,7 +5786,7 @@ func TestSessionHandler_SendMessage(t *testing.T) {
 				mock.ExpectQuery("UPDATE sessions SET status").
 					WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
 					WillReturnRows(pgxmock.NewRows(sessionColumns))
-				mock.ExpectQuery(`UPDATE sessions\s+SET status = 'running', completed_at = NULL,\s+last_activity_at = now\(\)\s+WHERE id = @id AND org_id = @org_id AND status = ANY\(@statuses\)\s+AND sandbox_state != 'destroyed'\s+RETURNING`).
+				mock.ExpectQuery(`UPDATE sessions\s+SET status = 'running', started_at = now\(\), completed_at = NULL,\s+runtime_soft_deadline_at = NULL,\s+runtime_hard_deadline_at = NULL,\s+runtime_last_progress_at = NULL,\s+runtime_last_progress_type = '',\s+runtime_last_progress_strength = '',\s+runtime_extension_count = 0,\s+runtime_extension_seconds = 0,\s+runtime_stop_reason = '',\s+runtime_graceful_stop_at = NULL,\s+last_activity_at = now\(\)\s+WHERE id = @id AND org_id = @org_id AND status = ANY\(@statuses\)\s+AND sandbox_state != 'destroyed'\s+RETURNING`).
 					WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
 					WillReturnRows(
 						addSessionRow(pgxmock.NewRows(sessionColumns),

--- a/internal/db/session_store.go
+++ b/internal/db/session_store.go
@@ -156,6 +156,16 @@ const (
 	sessionDiffHistoryMaxBytes = 512 * 1024
 )
 
+const sessionResumeRuntimeResetAssignments = `runtime_soft_deadline_at = NULL,
+		    runtime_hard_deadline_at = NULL,
+		    runtime_last_progress_at = NULL,
+		    runtime_last_progress_type = '',
+		    runtime_last_progress_strength = '',
+		    runtime_extension_count = 0,
+		    runtime_extension_seconds = 0,
+		    runtime_stop_reason = '',
+		    runtime_graceful_stop_at = NULL`
+
 // sessionListColumns excludes raw diff payloads and large JSONB blobs
 // (diff_history) from list queries to avoid returning multi-megabyte payloads
 // when listing many sessions.
@@ -1394,13 +1404,14 @@ func (s *SessionStore) ClaimIdle(ctx context.Context, orgID, sessionID uuid.UUID
 // single source of truth.
 // Sessions whose sandbox snapshot has been destroyed cannot be resumed.
 func (s *SessionStore) ClaimForResume(ctx context.Context, orgID, sessionID uuid.UUID) (models.Session, error) {
-	query := `
+	query := fmt.Sprintf(`
 		UPDATE sessions
-		SET status = 'running', completed_at = NULL,
+		SET status = 'running', started_at = now(), completed_at = NULL,
+		    %s,
 		    last_activity_at = now()
 		WHERE id = @id AND org_id = @org_id AND status = ANY(@statuses)
 		  AND sandbox_state != 'destroyed'
-		RETURNING ` + sessionSelectColumns
+		RETURNING `+sessionSelectColumns, sessionResumeRuntimeResetAssignments)
 
 	rows, err := s.db.Query(ctx, query, pgx.NamedArgs{
 		"id":       sessionID,

--- a/internal/db/session_store_test.go
+++ b/internal/db/session_store_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"os"
+	"regexp"
 	"strings"
 	"testing"
 	"time"
@@ -46,6 +47,20 @@ func anyDBArgs(count int) []interface{} {
 		args[i] = pgxmock.AnyArg()
 	}
 	return args
+}
+
+func sqlFragmentPattern(fragment string) string {
+	fields := strings.Fields(fragment)
+	for i := range fields {
+		fields[i] = regexp.QuoteMeta(fields[i])
+	}
+	return strings.Join(fields, `\s+`)
+}
+
+func claimForResumeQueryPattern() string {
+	return `UPDATE sessions\s+SET status = 'running', started_at = now\(\), completed_at = NULL,\s+` +
+		sqlFragmentPattern(sessionResumeRuntimeResetAssignments) +
+		`,\s+last_activity_at = now\(\)\s+WHERE id = @id AND org_id = @org_id AND status = ANY\(@statuses\)\s+AND sandbox_state != 'destroyed'\s+RETURNING`
 }
 
 // newAgentSessionRow returns a completed-session row for mock queries. The
@@ -335,6 +350,23 @@ func TestSessionStore_QueryColumnsStayInSyncWithSessionModel(t *testing.T) {
 				)
 			}
 		})
+	}
+}
+
+func TestSessionStore_ResumeRuntimeResetCoversAllRuntimeColumns(t *testing.T) {
+	t.Parallel()
+
+	for _, column := range sessionTestColumns {
+		if !strings.HasPrefix(column, "runtime_") {
+			continue
+		}
+		require.Contains(
+			t,
+			sessionResumeRuntimeResetAssignments,
+			column+" =",
+			"ClaimForResume should reset %s so stale runtime-control fields cannot survive a resume claim",
+			column,
+		)
 	}
 }
 
@@ -1430,7 +1462,7 @@ func TestSessionStore_ClaimForResume(t *testing.T) {
 			name: "resumes completed session successfully",
 			setupMock: func(mock pgxmock.PgxPoolIface) {
 				now := time.Now()
-				mock.ExpectQuery(`UPDATE sessions\s+SET status = 'running', completed_at = NULL,\s+last_activity_at = now\(\)\s+WHERE id = @id AND org_id = @org_id AND status = ANY\(@statuses\)\s+AND sandbox_state != 'destroyed'\s+RETURNING`).
+				mock.ExpectQuery(claimForResumeQueryPattern()).
 					WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
 					WillReturnRows(
 						pgxmock.NewRows(sessionTestColumns).AddRow(
@@ -1443,7 +1475,7 @@ func TestSessionStore_ClaimForResume(t *testing.T) {
 		{
 			name: "returns error when no matching row",
 			setupMock: func(mock pgxmock.PgxPoolIface) {
-				mock.ExpectQuery(`UPDATE sessions\s+SET status = 'running', completed_at = NULL,\s+last_activity_at = now\(\)\s+WHERE id = @id AND org_id = @org_id AND status = ANY\(@statuses\)\s+AND sandbox_state != 'destroyed'\s+RETURNING`).
+				mock.ExpectQuery(claimForResumeQueryPattern()).
 					WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
 					WillReturnRows(pgxmock.NewRows(sessionTestColumns))
 			},
@@ -1455,7 +1487,7 @@ func TestSessionStore_ClaimForResume(t *testing.T) {
 				now := time.Now()
 				row := newAgentSessionRow(uuid.New(), uuid.New(), uuid.New(), now)
 				row[4] = models.SessionStatusRunning
-				mock.ExpectQuery(`UPDATE sessions\s+SET status = 'running', completed_at = NULL,\s+last_activity_at = now\(\)\s+WHERE id = @id AND org_id = @org_id AND status = ANY\(@statuses\)\s+AND sandbox_state != 'destroyed'\s+RETURNING`).
+				mock.ExpectQuery(claimForResumeQueryPattern()).
 					WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
 					WillReturnRows(
 						pgxmock.NewRows(sessionTestColumns).AddRow(row...),
@@ -1469,7 +1501,7 @@ func TestSessionStore_ClaimForResume(t *testing.T) {
 				now := time.Now()
 				row := newAgentSessionRow(uuid.New(), uuid.New(), uuid.New(), now)
 				row[4] = models.SessionStatusRunning
-				mock.ExpectQuery(`UPDATE sessions\s+SET status = 'running', completed_at = NULL,\s+last_activity_at = now\(\)\s+WHERE id = @id AND org_id = @org_id AND status = ANY\(@statuses\)\s+AND sandbox_state != 'destroyed'\s+RETURNING`).
+				mock.ExpectQuery(claimForResumeQueryPattern()).
 					WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
 					WillReturnRows(
 						pgxmock.NewRows(sessionTestColumns).AddRow(row...),
@@ -1483,7 +1515,7 @@ func TestSessionStore_ClaimForResume(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			mock, err := pgxmock.NewPool()
-			require.NoError(t, err)
+			require.NoError(t, err, "should create pgx mock pool")
 			defer mock.Close()
 
 			store := NewSessionStore(mock)
@@ -1491,11 +1523,11 @@ func TestSessionStore_ClaimForResume(t *testing.T) {
 
 			_, err = store.ClaimForResume(context.Background(), uuid.New(), uuid.New())
 			if tt.wantErr {
-				require.Error(t, err)
+				require.Error(t, err, "ClaimForResume should return an error when no session can be resumed")
 			} else {
-				require.NoError(t, err)
+				require.NoError(t, err, "ClaimForResume should resume the session")
 			}
-			require.NoError(t, mock.ExpectationsWereMet())
+			require.NoError(t, mock.ExpectationsWereMet(), "all session resume expectations should be met")
 		})
 	}
 }

--- a/internal/services/github/pr_health_service.go
+++ b/internal/services/github/pr_health_service.go
@@ -796,6 +796,9 @@ func (s *PRService) resumeRepairSession(ctx context.Context, pr models.PullReque
 		"workspace_mode":      string(workspaceMode),
 		"pull_request_number": pr.GitHubPRNumber,
 	}
+	if threadID != nil {
+		payload["thread_id"] = threadID.String()
+	}
 	if _, err := s.jobs.EnqueueInTxWithOpts(ctx, tx, pr.OrgID, db.EnqueueOpts{
 		Queue:        "agent",
 		JobType:      "continue_session",

--- a/internal/services/github/pr_health_service_test.go
+++ b/internal/services/github/pr_health_service_test.go
@@ -25,6 +25,34 @@ import (
 	"github.com/assembledhq/143/internal/services/agent"
 )
 
+type repairJobPayloadArg struct {
+	wantThreadID      uuid.UUID
+	wantPullRequestID uuid.UUID
+	wantAction        models.PullRequestRepairActionType
+	wantHealthVersion int64
+}
+
+func (a repairJobPayloadArg) Match(value interface{}) bool {
+	var payloadBytes []byte
+	switch v := value.(type) {
+	case []byte:
+		payloadBytes = v
+	case string:
+		payloadBytes = []byte(v)
+	default:
+		return false
+	}
+
+	var payload map[string]interface{}
+	if err := json.Unmarshal(payloadBytes, &payload); err != nil {
+		return false
+	}
+	return payload["thread_id"] == a.wantThreadID.String() &&
+		payload["pull_request_id"] == a.wantPullRequestID.String() &&
+		payload["command_type"] == string(a.wantAction) &&
+		payload["health_version"] == float64(a.wantHealthVersion)
+}
+
 func TestPRServiceBuildPullRequestHealthResponseUsesCurrentSummaryForRepairActions(t *testing.T) {
 	t.Parallel()
 
@@ -1436,10 +1464,15 @@ func TestPRServiceResumeRepairSession(t *testing.T) {
 					WillReturnRows(pgxmock.NewRows([]string{"id", "created_at", "updated_at"}).AddRow(uuid.New(), now, now))
 				mock.ExpectQuery("INSERT INTO jobs").
 					WithArgs(pgx.NamedArgs{
-						"org_id":     pr.OrgID,
-						"queue":      "agent",
-						"job_type":   "continue_session",
-						"payload":    pgxmock.AnyArg(),
+						"org_id":   pr.OrgID,
+						"queue":    "agent",
+						"job_type": "continue_session",
+						"payload": repairJobPayloadArg{
+							wantThreadID:      threadID,
+							wantPullRequestID: pr.ID,
+							wantAction:        models.PullRequestRepairActionTypeResolveConflicts,
+							wantHealthVersion: 9,
+						},
 						"priority":   5,
 						"dedupe_key": pgxmock.AnyArg(),
 					}).

--- a/internal/worker/handlers_linear_agent_prompted_test.go
+++ b/internal/worker/handlers_linear_agent_prompted_test.go
@@ -646,7 +646,7 @@ func TestPromptedResumedTerminalSessionRestoresOriginalStatusWhenContinueEnqueue
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
 		WillReturnRows(pgxmock.NewRows([]string{"id", "org_id", "status", "current_turn"}).
 			AddRow(sessionID, orgID, models.SessionStatusCompleted, 7))
-	mock.ExpectQuery(`(?s)UPDATE sessions\s+SET status = 'running', completed_at = NULL,\s+last_activity_at = now\(\)`).
+	mock.ExpectQuery(`(?s)UPDATE sessions\s+SET status = 'running', started_at = now\(\), completed_at = NULL,\s+runtime_soft_deadline_at = NULL,\s+runtime_hard_deadline_at = NULL,\s+runtime_last_progress_at = NULL,\s+runtime_last_progress_type = '',\s+runtime_last_progress_strength = '',\s+runtime_extension_count = 0,\s+runtime_extension_seconds = 0,\s+runtime_stop_reason = '',\s+runtime_graceful_stop_at = NULL,\s+last_activity_at = now\(\)`).
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
 		WillReturnRows(pgxmock.NewRows(workerSessionColumns).
 			AddRow(workerSessionRow(sessionID, issueID, orgID, models.SessionStatusRunning, 7, nil, nil)...))


### PR DESCRIPTION
## Summary
- Reset all runtime control fields, `started_at`, and `completed_at` when claiming a session for resume
- Include `thread_id` in repair-session job payloads when present
- Update tests to cover the expanded resume query and payload shape

## Testing
- Unit tests updated for session resume SQL and PR repair job payload assertions