### PR TITLE
Shorten static egress preview no-workers message

### DIFF
--- a/internal/api/handlers/preview.go
+++ b/internal/api/handlers/preview.go
@@ -883,7 +883,7 @@ func (h *PreviewHandler) startPreviewFromRequest(ctx context.Context, orgID, use
 		case errors.Is(err, preview.ErrLegacySessionWorkerOwnership):
 			return nil, 0, newPreviewHTTPError(http.StatusConflict, "PREVIEW_WORKER_OWNERSHIP_REQUIRED", "live sandbox is missing worker ownership metadata; send a new message to rebuild it", nil)
 		case errors.Is(err, preview.ErrNoPreviewWorkers):
-			return nil, 0, newPreviewHTTPError(http.StatusServiceUnavailable, "PREVIEW_NO_WORKERS", "no preview-capable workers are available", nil)
+			return nil, 0, newPreviewHTTPError(http.StatusServiceUnavailable, "PREVIEW_NO_WORKERS", previewNoWorkersMessage(reqs), nil)
 		default:
 			return nil, 0, newPreviewHTTPError(http.StatusInternalServerError, "PREVIEW_WORKER_SELECTION_FAILED", "failed to select preview worker", err)
 		}
@@ -893,6 +893,16 @@ func (h *PreviewHandler) startPreviewFromRequest(ctx context.Context, orgID, use
 		return nil, 0, asyncErr
 	}
 	return instance, http.StatusAccepted, nil
+}
+
+func previewNoWorkersMessage(reqs preview.WorkerSelectionRequirements) string {
+	if !reqs.StaticEgressRequired {
+		return "no preview-capable workers are available"
+	}
+	if reqs.StaticEgressPublicIP == "" {
+		return "Static egress is enabled, but no public IP is configured. Disable static egress or configure STATIC_EGRESS_PUBLIC_IP."
+	}
+	return fmt.Sprintf("Static egress is enabled, but no preview workers are verified for %s. Disable static egress or provision workers.", reqs.StaticEgressPublicIP)
 }
 
 func (h *PreviewHandler) StartPreview(w http.ResponseWriter, r *http.Request) {

--- a/internal/api/handlers/preview_test.go
+++ b/internal/api/handlers/preview_test.go
@@ -1618,6 +1618,68 @@ func TestPreviewHandler_StartPreview_WorkerRoutedEnqueuesStartPreviewJob(t *test
 	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
 }
 
+func TestPreviewHandler_StartPreview_WorkerRoutedStaticEgressNoCapableWorkers(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "should create pgxmock pool")
+	defer mock.Close()
+
+	orgID := uuid.New()
+	userID := uuid.New()
+	sessionID := uuid.New()
+	now := time.Now().UTC()
+
+	sessionStore := db.NewSessionStore(mock)
+	previewStore := db.NewPreviewStore(mock)
+	nodeStore := db.NewNodeStore(mock)
+
+	mgr := preview.NewManager(preview.ManagerConfig{
+		Store:        previewStore,
+		Logger:       zerolog.Nop(),
+		WorkerNodeID: "api-node",
+	})
+	h := NewPreviewHandler(mgr, previewStore, sessionStore, nil, sandbox.NoOpFileReader{}, nil, nil, zerolog.Nop())
+	h.SetWorkerRuntime(preview.NewWorkerSelector(nodeStore, previewStore), preview.NewWorkerPreviewClient("test-secret"), "api-node")
+	h.SetStaticEgressRuntime(previewStaticEgressOrgStore{
+		settings: json.RawMessage(`{"sandbox_network":{"static_egress_enabled":true}}`),
+	}, agent.StaticEgressRuntimeConfig{PublicIP: "203.0.113.10"})
+
+	workerMeta, err := json.Marshal(preview.WorkerNodeMetadata{
+		PreviewCapable:         true,
+		PreviewInternalBaseURL: "http://worker-a.internal",
+	})
+	require.NoError(t, err, "should marshal worker metadata")
+
+	mock.ExpectQuery("SELECT .+ FROM sessions WHERE id").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(
+			pgxmock.NewRows(sessionRowColumns).
+				AddRow(sessionRowForHydrate(sessionID, orgID, nil, "none")...),
+		)
+	mock.ExpectQuery("SELECT .+ FROM preview_instances").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(pgxmock.NewRows(previewInstanceTestCols))
+	mock.ExpectQuery("SELECT .+ FROM nodes WHERE status = 'active' ORDER BY id ASC").
+		WillReturnRows(
+			pgxmock.NewRows(handlerNodeTestCols).
+				AddRow("worker-a", "worker", "worker-a", "active", workerMeta, now, now),
+		)
+
+	req := httptest.NewRequest(http.MethodPost, "/preview", strings.NewReader(""))
+	req = previewTestContextWithIDs(req, orgID, userID, sessionID.String())
+	w := httptest.NewRecorder()
+
+	h.StartPreview(w, req)
+
+	require.Equal(t, http.StatusServiceUnavailable, w.Code, "worker-routed start should fail when static egress has no eligible workers")
+	var resp models.ErrorResponse
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&resp), "response should decode as an error response")
+	require.Equal(t, "PREVIEW_NO_WORKERS", resp.Error.Code, "static-egress worker selection should keep the stable no-workers code")
+	require.Equal(t, "Static egress is enabled, but no preview workers are verified for 203.0.113.10. Disable static egress or provision workers.", resp.Error.Message, "static-egress worker selection should explain the real eligibility blocker")
+	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
+}
+
 func TestPreviewHandler_EnsurePreview_NoActiveWorkerRoutedStartsFresh(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- Shortened the `PREVIEW_NO_WORKERS` message when static egress is enabled so it is clearer and more concise.
- Kept the generic message for non-static-egress cases unchanged.
- Added a regression test covering the static-egress no-capable-workers path.

## Testing
- `go test ./internal/api/handlers`
- `go vet ./...`
- `go build ./...`
- `go test ./...`