### PR TITLE
Add Claude Fable 5 model support

### DIFF
--- a/frontend/src/lib/agents.ts
+++ b/frontend/src/lib/agents.ts
@@ -62,7 +62,7 @@ export const AGENTS: readonly AgentMeta[] = [
     label: "Claude Code",
     short: "CC",
     color: "#cc785c",
-    description: "Anthropic Claude (Opus, Sonnet, Haiku)",
+    description: "Anthropic Claude (Fable, Opus, Sonnet, Haiku)",
     providerKey: "anthropic",
     models: AVAILABLE_CLAUDE_CODE_MODELS,
     envVars: [

--- a/frontend/src/lib/model-constants.test.ts
+++ b/frontend/src/lib/model-constants.test.ts
@@ -20,6 +20,7 @@ describe("model constants", () => {
 
   it("includes latest Claude Code models", () => {
     expect(AVAILABLE_CLAUDE_CODE_MODELS).toEqual([
+      "claude-fable-5",
       "claude-opus-4-8",
       "claude-opus-4-7",
       "claude-opus-4-6",

--- a/frontend/src/lib/model-constants.ts
+++ b/frontend/src/lib/model-constants.ts
@@ -1,3 +1,4 @@
+export const CLAUDE_CODE_MODEL_FABLE_5 = "claude-fable-5";
 export const CLAUDE_CODE_MODEL_OPUS_48 = "claude-opus-4-8";
 export const CLAUDE_CODE_MODEL_OPUS_47 = "claude-opus-4-7";
 export const CLAUDE_CODE_MODEL_OPUS_46 = "claude-opus-4-6";
@@ -6,6 +7,7 @@ export const CLAUDE_CODE_MODEL_SONNET_45 = "claude-sonnet-4-5";
 export const CLAUDE_CODE_MODEL_HAIKU_45 = "claude-haiku-4-5";
 
 export const AVAILABLE_CLAUDE_CODE_MODELS = [
+  CLAUDE_CODE_MODEL_FABLE_5,
   CLAUDE_CODE_MODEL_OPUS_48,
   CLAUDE_CODE_MODEL_OPUS_47,
   CLAUDE_CODE_MODEL_OPUS_46,

--- a/internal/models/agent_model_constants.go
+++ b/internal/models/agent_model_constants.go
@@ -55,6 +55,7 @@ var AvailablePiModels = []string{
 }
 
 const (
+	ClaudeCodeModelFable5   = "claude-fable-5"
 	ClaudeCodeModelOpus48   = "claude-opus-4-8"
 	ClaudeCodeModelOpus47   = "claude-opus-4-7"
 	ClaudeCodeModelOpus46   = "claude-opus-4-6"
@@ -63,7 +64,7 @@ const (
 	ClaudeCodeModelHaiku45  = "claude-haiku-4-5"
 )
 
-var AvailableClaudeCodeModels = []string{ClaudeCodeModelOpus48, ClaudeCodeModelOpus47, ClaudeCodeModelOpus46, ClaudeCodeModelSonnet46, ClaudeCodeModelSonnet45, ClaudeCodeModelHaiku45}
+var AvailableClaudeCodeModels = []string{ClaudeCodeModelFable5, ClaudeCodeModelOpus48, ClaudeCodeModelOpus47, ClaudeCodeModelOpus46, ClaudeCodeModelSonnet46, ClaudeCodeModelSonnet45, ClaudeCodeModelHaiku45}
 
 const (
 	GeminiCLIModelGemini31ProPreview  = "gemini-3.1-pro-preview"

--- a/internal/models/agent_model_constants_test.go
+++ b/internal/models/agent_model_constants_test.go
@@ -26,7 +26,7 @@ func TestClaudeCodeModelConstants(t *testing.T) {
 	t.Parallel()
 
 	require.Equal(t,
-		[]string{ClaudeCodeModelOpus48, ClaudeCodeModelOpus47, ClaudeCodeModelOpus46, ClaudeCodeModelSonnet46, ClaudeCodeModelSonnet45, ClaudeCodeModelHaiku45},
+		[]string{ClaudeCodeModelFable5, ClaudeCodeModelOpus48, ClaudeCodeModelOpus47, ClaudeCodeModelOpus46, ClaudeCodeModelSonnet46, ClaudeCodeModelSonnet45, ClaudeCodeModelHaiku45},
 		AvailableClaudeCodeModels,
 		"AvailableClaudeCodeModels should be ordered by capability",
 	)

--- a/internal/services/agent/token_usage_cost.go
+++ b/internal/services/agent/token_usage_cost.go
@@ -38,6 +38,7 @@ var codexCreditRates = map[string]tokenRate{
 }
 
 var anthropicRates = map[string]tokenRate{
+	models.ClaudeCodeModelFable5:   {inputPerMTok: 10.00, cachedInputPerMTok: 1.00, cacheCreationPerMTok: 12.50, outputPerMTok: 50.00, unit: TokenCostUnitUSD, detail: "anthropic_api_pricing"},
 	models.ClaudeCodeModelOpus48:   {inputPerMTok: 5.00, cachedInputPerMTok: 0.50, cacheCreationPerMTok: 6.25, outputPerMTok: 25.00, unit: TokenCostUnitUSD, detail: "anthropic_api_pricing"},
 	models.ClaudeCodeModelOpus47:   {inputPerMTok: 5.00, cachedInputPerMTok: 0.50, cacheCreationPerMTok: 6.25, outputPerMTok: 25.00, unit: TokenCostUnitUSD, detail: "anthropic_api_pricing"},
 	models.ClaudeCodeModelOpus46:   {inputPerMTok: 5.00, cachedInputPerMTok: 0.50, cacheCreationPerMTok: 6.25, outputPerMTok: 25.00, unit: TokenCostUnitUSD, detail: "anthropic_api_pricing"},


### PR DESCRIPTION
## Summary
This PR adds support for the new Claude Fable 5 model across the codebase, including model constants, agent configuration, and token cost pricing.

## Key Changes
- Added `ClaudeCodeModelFable5` constant with value `"claude-fable-5"` to backend model constants
- Updated `AvailableClaudeCodeModels` list to include Fable 5 as the first (highest capability) model
- Added corresponding frontend constant `CLAUDE_CODE_MODEL_FABLE_5` and updated `AVAILABLE_CLAUDE_CODE_MODELS` array
- Updated Claude Code agent description to include "Fable" in the list of supported models
- Added token cost pricing for Fable 5 model:
  - Input: $10.00 per MTok
  - Cached input: $1.00 per MTok
  - Cache creation: $12.50 per MTok
  - Output: $50.00 per MTok
- Updated unit tests to reflect the new model in the available models list

## Implementation Details
- Fable 5 is positioned as the highest-capability model in the ordered list, reflecting its position in Anthropic's model hierarchy
- Token pricing follows Anthropic's published API pricing for the Fable model
- Changes are synchronized across both backend (Go) and frontend (TypeScript) codebases

https://claude.ai/code/session_01Li5imePti1BWtdUTFPcwRU