### PR TITLE
Add make provision-workers target for batch worker provisioning

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -449,7 +449,14 @@ provision-egress:
 # then runs provision.sh for each worker host. Use after enabling/repairing
 # static egress so every worker rewrites /etc/143/static-egress-capable and
 # starts advertising static_egress_capable in its node metadata.
-# Honors REPROVISION=true (tears down and rebuilds each worker).
+#
+# On an already-running fleet you must pass REPROVISION=true: provision.sh
+# aborts when services are already running, so plain mode only works for
+# fresh hosts. REPROVISION=true serially tears down and rebuilds each worker
+# (drains active jobs first; one worker down at a time). Reprovisioning can
+# orphan old `nodes` rows when NODE_IDs change — see the reprovision notes
+# above provision-worker. A mid-fleet failure stops the loop; rerun to
+# resume (secrets sync and gateway provisioning are idempotent).
 # Usage:
 #   make provision-workers
 #   make provision-workers REPROVISION=true

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 SANDBOX_STAMP := sandbox/.build-stamp
 SANDBOX_SOURCES := sandbox/Dockerfile sandbox/versions.json
 
-.PHONY: dev dev-ngrok dev-local dev-frontend-only setup test test-race test-coverage test-pr test-coverage-diff test-main test-integration migrate-up migrate-down build frontend-dev frontend-lint frontend-typecheck frontend-check lint lint-bootstrap lint-schema lint-stores lint-tenancy hooks-install hooks-uninstall secrets-setup secrets-encrypt secrets-decrypt secrets-edit secrets-rotate provision-app provision-worker provision-egress provision-db provision-logging provision-redis tailscale-enroll repair-deploy-sudoers repair-worker-host spin-down-worker deploy deploy-app deploy-worker deploy-worker-preflight deploy-db deploy-logging deploy-fleet logs logs-query setup-readonly-user db-psql db-query
+.PHONY: dev dev-ngrok dev-local dev-frontend-only setup test test-race test-coverage test-pr test-coverage-diff test-main test-integration migrate-up migrate-down build frontend-dev frontend-lint frontend-typecheck frontend-check lint lint-bootstrap lint-schema lint-stores lint-tenancy hooks-install hooks-uninstall secrets-setup secrets-encrypt secrets-decrypt secrets-edit secrets-rotate provision-app provision-worker provision-workers provision-egress provision-db provision-logging provision-redis tailscale-enroll repair-deploy-sudoers repair-worker-host spin-down-worker deploy deploy-app deploy-worker deploy-worker-preflight deploy-db deploy-logging deploy-fleet logs logs-query setup-readonly-user db-psql db-query
 
 GOLANGCI_LINT_VERSION ?= v2.10.1
 GOLANGCI_LINT_BIN := $(CURDIR)/bin/golangci-lint
@@ -443,6 +443,31 @@ provision-egress:
 	@test -n "$(EGRESS_SSH_KEY)" || { echo "EGRESS_SSH_KEY could not be auto-detected. Set EGRESS_SSH_KEY=<path> or SSH_KEY=<path>."; exit 1; }
 	@deploy/scripts/sync-static-egress-secrets.sh --apply
 	@deploy/scripts/provision-egress.sh "$(HOST)" "$(EGRESS_SSH_KEY)"
+
+# Provision (or re-provision) every worker:<host> in FLEET_HOSTS in one pass.
+# Syncs per-worker WireGuard secrets and provisions the egress gateway once,
+# then runs provision.sh for each worker host. Use after enabling/repairing
+# static egress so every worker rewrites /etc/143/static-egress-capable and
+# starts advertising static_egress_capable in its node metadata.
+# Honors REPROVISION=true (tears down and rebuilds each worker).
+# Usage:
+#   make provision-workers
+#   make provision-workers REPROVISION=true
+#   make provision-workers SSH_USER=ubuntu EGRESS_SSH_KEY=~/Downloads/143-john.pem
+provision-workers:
+	$(check-ssh-key)
+	@test -n "$(EGRESS_SSH_KEY)" || { echo "EGRESS_SSH_KEY could not be auto-detected. Set EGRESS_SSH_KEY=<path> or SSH_KEY=<path>."; exit 1; }
+	@deploy/scripts/sync-static-egress-secrets.sh --apply
+	@deploy/scripts/provision-egress.sh "" "$(EGRESS_SSH_KEY)"
+	@$(read-fleet-hosts); \
+	HOSTS="$$(echo "$$FLEET" | tr ',' '\n' | grep '^worker:' | cut -d: -f2)"; \
+	if [ -z "$$HOSTS" ]; then \
+		echo "ERROR: no worker:<host> entries in FLEET_HOSTS."; exit 1; \
+	fi; \
+	for h in $$HOSTS; do \
+		echo "=== provisioning worker $$h ==="; \
+		./deploy/scripts/provision.sh worker "$$h" $(SSH_KEY) $(if $(REPROVISION),--reprovision) || { echo "FAILED on $$h"; exit 1; }; \
+	done
 
 provision-db:
 	@test -n "$(HOST)" || { echo "HOST is required. Usage: make provision-db HOST=<ip> [SSH_KEY=<path>]"; exit 1; }


### PR DESCRIPTION
## What

Adds a `provision-workers` (plural) make target that provisions every `worker:<host>` in `FLEET_HOSTS` in a single command.

## Why

Provisioning all workers — e.g. after enabling or repairing static egress — required running `make provision-worker HOST=<ip>` once per host. Each invocation redundantly re-ran `sync-static-egress-secrets.sh` and re-provisioned the egress gateway. With ~6 workers this is slow and easy to get wrong.

This came up while debugging a preview failure: `Static egress is enabled, but no preview workers are verified for 34.203.146.140`. The root cause was that no worker had written `/etc/143/static-egress-capable`, so none advertised `static_egress_capable` in their node metadata. The fix is to (re)provision every worker — hence wanting a one-shot command.

## How

The new target:
1. Runs `sync-static-egress-secrets.sh --apply` **once** — this already generates a stable WireGuard keypair for *all* worker hosts in `FLEET_HOSTS` (the `PROVISION_WORKER_HOST` env var is only a validation guard, not a per-host filter).
2. Runs `provision-egress.sh` **once** to provision the gateway with all worker peers.
3. Loops `provision.sh worker <host>` over each `worker:` entry resolved from `FLEET_HOSTS`.

Honors `REPROVISION=true` and the usual `SSH_USER` / `EGRESS_SSH_KEY` overrides.

```
make provision-workers
make provision-workers REPROVISION=true
```

## Reviewer notes

- `provision-worker` (singular) is unchanged; the existing single-host workflow still works.
- Makefile-only change plus a `.PHONY` entry. Verified the recipe parses and resolves with `make -n provision-workers`.
- Reuses the existing `read-fleet-hosts` / `check-ssh-key` helpers and mirrors the ordering of the singular target (sync → gateway → worker).

🤖 Generated with [Claude Code](https://claude.com/claude-code)