### PR TITLE
Ignore WireGuard interfaces during worker IP auto-detection

### DIFF
--- a/deploy/deploy_config_test.go
+++ b/deploy/deploy_config_test.go
@@ -817,6 +817,7 @@ func TestWorkerProvisioningHandlesAddressingEdgeCases(t *testing.T) {
 	require.Contains(t, string(provisionScript), `worker-${WORKER_PRIVATE_IP//./-}`, "provision.sh's NODE_ID default should use the full dotted-to-dash IP so workers across multiple /24s don't collide on \"worker-<last-octet>\"")
 	require.NotContains(t, string(provisionScript), `worker-${WORKER_PRIVATE_IP##*.}`, "provision.sh should not fall back to the last-octet-only default — it collides across /24s")
 	require.Contains(t, string(provisionScript), "private IPv4 addresses on real interfaces", "provision.sh should detect multi-homed hosts and require the operator to set WORKER_PRIVATE_IP explicitly rather than silently picking a NIC")
+	require.Contains(t, string(provisionScript), `docker|br-|veth|virbr|lo|wg`, "provision.sh should ignore static-egress WireGuard interfaces when auto-detecting the app-reachable worker IP")
 }
 
 func TestTailscaleReadyPrivateServiceBinding(t *testing.T) {

--- a/deploy/scripts/provision.sh
+++ b/deploy/scripts/provision.sh
@@ -309,14 +309,14 @@ resolve_worker_identity() {
     else
       echo "Auto-detecting WORKER_PRIVATE_IP via SSH..."
       # Enumerate every private IPv4 on a real network interface, deliberately
-      # skipping docker/bridge/veth/loopback. A naive "first private IPv4"
+      # skipping docker/bridge/veth/WireGuard/loopback. A naive "first private IPv4"
       # filter would silently return 172.17.0.1 (docker0) on hosts where the
       # bridge enumerates before the NIC, and `ip route get 1.1.1.1` returns
       # the *public* IP because the default route goes through the public NIC.
       # We collect candidates (no awk `exit`) so multi-homed hosts surface as
       # an error rather than silently picking whichever NIC enumerates first.
       WORKER_PRIVATE_IP_CANDIDATES="$(ssh "${SSH_OPTS[@]}" root@"$HOST" \
-        'ip -4 -o addr show | awk "\$2 !~ /^(docker|br-|veth|virbr|lo)/ && /inet (10\\.|172\\.(1[6-9]|2[0-9]|3[0-1])\\.|192\\.168\\.)/ { split(\$4, a, \"/\"); print a[1] }"')"
+        'ip -4 -o addr show | awk "\$2 !~ /^(docker|br-|veth|virbr|lo|wg)/ && /inet (10\\.|172\\.(1[6-9]|2[0-9]|3[0-1])\\.|192\\.168\\.)/ { split(\$4, a, \"/\"); print a[1] }"')"
     fi
     CANDIDATE_COUNT="$(printf '%s\n' "$WORKER_PRIVATE_IP_CANDIDATES" | grep -c . || true)"
     if [ "$CANDIDATE_COUNT" -eq 0 ]; then


### PR DESCRIPTION
## Summary
- Exclude `wg*` interfaces from worker private IP discovery so static-egress tunnels do not appear as the app-reachable address
- Add a regression test covering the provisioning script’s interface filter

## Testing
- `go test ./deploy -run TestWorkerProvisioningHandlesAddressingEdgeCases -count=1`
- `go test ./deploy -count=1`
- `go vet ./...`
- `go build ./...`
- `go test ./...`