### PR TITLE
Add Mezmo as a per-org connectable integration

### DIFF
--- a/frontend/src/app/(dashboard)/settings/integrations/page.tsx
+++ b/frontend/src/app/(dashboard)/settings/integrations/page.tsx
@@ -726,6 +726,9 @@ function IntegrationDetailSheet({
   isSyncingRepos,
   onReplaceNotionToken,
   onReplaceCircleCIToken,
+  onReplaceMezmoCredentials,
+  mezmoDataset,
+  mezmoBaseURL,
 }: {
   provider: IntegrationKey | null;
   open: boolean;
@@ -742,6 +745,9 @@ function IntegrationDetailSheet({
   isSyncingRepos: boolean;
   onReplaceNotionToken: () => void;
   onReplaceCircleCIToken: () => void;
+  onReplaceMezmoCredentials: () => void;
+  mezmoDataset?: string;
+  mezmoBaseURL?: string;
 }) {
   if (!provider) return null;
   const meta = getIntegrationByKey(provider);
@@ -804,6 +810,21 @@ function IntegrationDetailSheet({
               <Button size="sm" variant="outline" onClick={onReplaceCircleCIToken}>Replace credentials</Button>
             </div>
           ) : null}
+          {provider === "mezmo" ? (
+            <div className="space-y-3">
+              <h3 className="text-sm font-medium">Connection settings</h3>
+              <dl className="grid grid-cols-[auto_1fr] gap-x-4 gap-y-1 text-sm">
+                <dt className="text-muted-foreground">Base URL</dt>
+                <dd className="truncate">{mezmoBaseURL || "https://api.mezmo.com (default)"}</dd>
+                <dt className="text-muted-foreground">Dataset</dt>
+                <dd className="truncate">{mezmoDataset || "All datasets"}</dd>
+              </dl>
+              <p className="text-sm text-muted-foreground">
+                Replace the Mezmo service key, base URL, or dataset used for production log queries.
+              </p>
+              <Button size="sm" variant="outline" onClick={onReplaceMezmoCredentials}>Replace credentials</Button>
+            </div>
+          ) : null}
 
           {isConnected ? (
             <>
@@ -827,6 +848,10 @@ type TokenDialogField = {
   label: string;
   placeholder?: string;
   type?: "text" | "password";
+  // When true, the field may be left blank and does not gate the submit
+  // button. Used for provider settings like Mezmo's base URL and dataset that
+  // fall back to sensible defaults server-side.
+  optional?: boolean;
   help?: ReactNode;
   tooltip?: {
     ariaLabel: string;
@@ -856,7 +881,7 @@ function TokenDialog({ open, onOpenChange, title, description, fields, submittin
     onOpenChange(next);
   };
   const trimmedValues = Object.fromEntries(fields.map((f) => [f.id, (values[f.id] ?? "").trim()]));
-  const ready = fields.every((f) => trimmedValues[f.id] !== "");
+  const ready = fields.every((f) => f.optional || trimmedValues[f.id] !== "");
 
   return (
     <AlertDialog open={open} onOpenChange={handleOpenChange}>
@@ -979,6 +1004,21 @@ export default function IntegrationsPage() {
     },
   });
 
+  const [mezmoDialogOpen, setMezmoDialogOpen] = useState(false);
+  const [mezmoError, setMezmoError] = useState<string | null>(null);
+  const mezmoConnectMutation = useMutation({
+    mutationFn: ({ apiKey, baseUrl, dataset }: { apiKey: string; baseUrl: string; dataset: string }) =>
+      api.integrations.connectMezmo(apiKey, baseUrl, dataset),
+    onSuccess: () => {
+      setMezmoDialogOpen(false);
+      setMezmoError(null);
+      queryClient.invalidateQueries({ queryKey: ["integrations"] });
+    },
+    onError: (err: Error) => {
+      setMezmoError(err.message || "Failed to connect Mezmo. Check your service key.");
+    },
+  });
+
   const githubIntegration = integrationsResp?.data?.find(
     (integration) => integration.provider === "github" && integration.status === "active"
   );
@@ -1006,6 +1046,9 @@ export default function IntegrationsPage() {
   const circleciIntegration = integrationsResp?.data?.find(
     (integration) => integration.provider === "circleci" && integration.status === "active"
   );
+  const mezmoIntegration = integrationsResp?.data?.find(
+    (integration) => integration.provider === "mezmo" && integration.status === "active"
+  );
   const repositories = repositoriesResp?.data ?? [];
   const activeRepositories = repositories.filter((repo) => repo.status === "active");
   const connected = {
@@ -1015,6 +1058,7 @@ export default function IntegrationsPage() {
     slack: Boolean(slackIntegration),
     notion: Boolean(notionIntegration),
     circleci: Boolean(circleciIntegration),
+    mezmo: Boolean(mezmoIntegration),
   } satisfies Partial<Record<IntegrationKey, boolean>>;
 
   return (
@@ -1042,6 +1086,8 @@ export default function IntegrationsPage() {
         notionLoading={notionConnectMutation.isPending}
         circleciConnected={Boolean(circleciIntegration)}
         circleciLoading={circleciConnectMutation.isPending}
+        mezmoConnected={Boolean(mezmoIntegration)}
+        mezmoLoading={mezmoConnectMutation.isPending}
         onConnectGitHub={() => api.integrations.loginGitHub()}
         onConnectSentry={() => api.auth.loginSentry()}
         onConnectLinear={() => api.integrations.loginLinear()}
@@ -1053,6 +1099,10 @@ export default function IntegrationsPage() {
         onConnectCircleCI={() => {
           setCircleciError(null);
           setCircleciDialogOpen(true);
+        }}
+        onConnectMezmo={() => {
+          setMezmoError(null);
+          setMezmoDialogOpen(true);
         }}
         onManageGitHub={isAdmin ? () => setSelectedIntegration("github") : undefined}
         onManageIntegration={isAdmin ? (provider) => setSelectedIntegration(provider) : undefined}
@@ -1067,6 +1117,11 @@ export default function IntegrationsPage() {
           circleci: circleciIntegration ? (
             <p className="mt-1.5 text-xs text-muted-foreground">
               {circleciIntegration.circleci_project_slug ? `Project: ${circleciIntegration.circleci_project_slug}` : "Flaky-test context is enabled"}
+            </p>
+          ) : undefined,
+          mezmo: mezmoIntegration ? (
+            <p className="mt-1.5 text-xs text-muted-foreground">
+              {mezmoIntegration.mezmo_dataset ? `Dataset: ${mezmoIntegration.mezmo_dataset}` : "Production log queries are enabled"}
             </p>
           ) : undefined,
         }}
@@ -1102,6 +1157,12 @@ export default function IntegrationsPage() {
           setCircleciError(null);
           setCircleciDialogOpen(true);
         }}
+        onReplaceMezmoCredentials={() => {
+          setMezmoError(null);
+          setMezmoDialogOpen(true);
+        }}
+        mezmoDataset={mezmoIntegration?.mezmo_dataset}
+        mezmoBaseURL={mezmoIntegration?.mezmo_base_url}
       />
 
       <TokenDialog
@@ -1177,6 +1238,54 @@ export default function IntegrationsPage() {
         error={circleciError}
         onSubmit={(values) =>
           circleciConnectMutation.mutate({ token: values.token, projectSlug: values.projectSlug })
+        }
+      />
+
+      <TokenDialog
+        open={mezmoDialogOpen}
+        onOpenChange={setMezmoDialogOpen}
+        title="Connect Mezmo"
+        description={
+          <>
+            Paste a Mezmo service key so agents can query your production logs.
+            Create one under{" "}
+            <a
+              href="https://app.mezmo.com/profile/api"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="underline"
+            >
+              Organization → API Keys
+            </a>
+            . Base URL and dataset are optional — leave them blank to use the
+            Mezmo defaults.
+          </>
+        }
+        fields={[
+          { id: "apiKey", label: "Service Key", placeholder: "Mezmo service key" },
+          {
+            id: "baseUrl",
+            label: "Base URL (optional)",
+            placeholder: "https://api.mezmo.com",
+            type: "text",
+            optional: true,
+            tooltip: {
+              ariaLabel: "When to set a custom Mezmo base URL",
+              content: "Only needed for self-hosted or regional Mezmo deployments. Leave blank to use https://api.mezmo.com.",
+            },
+          },
+          {
+            id: "dataset",
+            label: "Dataset (optional)",
+            placeholder: "e.g. production",
+            type: "text",
+            optional: true,
+          },
+        ]}
+        submitting={mezmoConnectMutation.isPending}
+        error={mezmoError}
+        onSubmit={(values) =>
+          mezmoConnectMutation.mutate({ apiKey: values.apiKey, baseUrl: values.baseUrl, dataset: values.dataset })
         }
       />
     </PageContainer>

--- a/frontend/src/components/integration-connection-cards.test.tsx
+++ b/frontend/src/components/integration-connection-cards.test.tsx
@@ -39,6 +39,8 @@ describe("integration connection cards", () => {
         onConnectNotion={vi.fn()}
         circleciConnected={false}
         onConnectCircleCI={vi.fn()}
+        mezmoConnected={false}
+        onConnectMezmo={vi.fn()}
       />
     );
 
@@ -52,6 +54,59 @@ describe("integration connection cards", () => {
 
     expect(onConnectSentry).toHaveBeenCalledTimes(1);
     expect(onConnectLinear).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders the Mezmo card and triggers connect", async () => {
+    const user = userEvent.setup();
+    const onConnectMezmo = vi.fn();
+
+    renderWithProviders(
+      <AdditionalIntegrationCards
+        sentryConnected={false}
+        linearConnected={false}
+        linearLoading={false}
+        slackConnected={false}
+        notionConnected={false}
+        onConnectSentry={vi.fn()}
+        onConnectLinear={vi.fn()}
+        onConnectSlack={vi.fn()}
+        onConnectNotion={vi.fn()}
+        circleciConnected={false}
+        onConnectCircleCI={vi.fn()}
+        mezmoConnected={false}
+        onConnectMezmo={onConnectMezmo}
+      />
+    );
+
+    expect(screen.getByText("Mezmo")).toBeInTheDocument();
+    expect(screen.getByAltText("Mezmo logo")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Connect Mezmo" }));
+
+    expect(onConnectMezmo).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows a Disconnect button for Mezmo when connected with a handler", () => {
+    renderWithProviders(
+      <AdditionalIntegrationCards
+        sentryConnected={false}
+        linearConnected={false}
+        linearLoading={false}
+        slackConnected={false}
+        notionConnected={false}
+        onConnectSentry={vi.fn()}
+        onConnectLinear={vi.fn()}
+        onConnectSlack={vi.fn()}
+        onConnectNotion={vi.fn()}
+        circleciConnected={false}
+        onConnectCircleCI={vi.fn()}
+        mezmoConnected
+        onConnectMezmo={vi.fn()}
+        onDisconnect={vi.fn()}
+      />
+    );
+
+    expect(screen.getByRole("button", { name: "Disconnect Mezmo" })).toBeInTheDocument();
   });
 
   it("shows connected repo names when GitHub is connected", () => {
@@ -144,6 +199,8 @@ describe("integration connection cards", () => {
         onConnectNotion={vi.fn()}
         circleciConnected={false}
         onConnectCircleCI={vi.fn()}
+        mezmoConnected={false}
+        onConnectMezmo={vi.fn()}
       />
     );
 
@@ -164,6 +221,8 @@ describe("integration connection cards", () => {
         onConnectNotion={vi.fn()}
         circleciConnected={false}
         onConnectCircleCI={vi.fn()}
+        mezmoConnected={false}
+        onConnectMezmo={vi.fn()}
       />
     );
 
@@ -186,6 +245,8 @@ describe("integration connection cards", () => {
         onConnectNotion={vi.fn()}
         circleciConnected={false}
         onConnectCircleCI={vi.fn()}
+        mezmoConnected={false}
+        onConnectMezmo={vi.fn()}
       />
     );
 
@@ -209,6 +270,8 @@ describe("integration connection cards", () => {
         onConnectNotion={vi.fn()}
         circleciConnected={false}
         onConnectCircleCI={vi.fn()}
+        mezmoConnected={false}
+        onConnectMezmo={vi.fn()}
       />
     );
 
@@ -288,6 +351,8 @@ describe("integration connection cards", () => {
         onConnectNotion={vi.fn()}
         circleciConnected={false}
         onConnectCircleCI={vi.fn()}
+        mezmoConnected={false}
+        onConnectMezmo={vi.fn()}
         onDisconnect={vi.fn()}
       />
     );
@@ -333,6 +398,8 @@ describe("integration connection cards", () => {
         onConnectNotion={vi.fn()}
         circleciConnected={false}
         onConnectCircleCI={vi.fn()}
+        mezmoConnected={false}
+        onConnectMezmo={vi.fn()}
       />
     );
 
@@ -369,6 +436,8 @@ describe("integration connection cards", () => {
         onConnectNotion={vi.fn()}
         circleciConnected={false}
         onConnectCircleCI={vi.fn()}
+        mezmoConnected={false}
+        onConnectMezmo={vi.fn()}
         readOnly
       />
     );
@@ -396,6 +465,8 @@ describe("integration connection cards", () => {
         onConnectNotion={vi.fn()}
         circleciConnected={false}
         onConnectCircleCI={vi.fn()}
+        mezmoConnected={false}
+        onConnectMezmo={vi.fn()}
         onDisconnect={vi.fn()}
         readOnly
       />

--- a/frontend/src/components/integration-connection-cards.tsx
+++ b/frontend/src/components/integration-connection-cards.tsx
@@ -60,12 +60,15 @@ type AdditionalIntegrationCardsProps = IntegrationCallbacks & {
   notionLoading?: boolean;
   circleciConnected: boolean;
   circleciLoading?: boolean;
+  mezmoConnected: boolean;
+  mezmoLoading?: boolean;
   summaries?: Partial<Record<IntegrationKey, ReactNode>>;
   onConnectSentry: () => void;
   onConnectLinear: () => void;
   onConnectSlack: () => void;
   onConnectNotion: () => void;
   onConnectCircleCI: () => void;
+  onConnectMezmo: () => void;
 };
 
 // readOnly hides connect/disconnect buttons on every card and the per-repo
@@ -182,7 +185,6 @@ const DISCONNECT_DESCRIPTIONS: Record<IntegrationKey, string> = {
   slack: "This will disconnect Slack from your organization. Channel monitoring will stop.",
   notion: "This will disconnect Notion from your organization. Product docs will no longer sync.",
   circleci: "This will disconnect CircleCI from your organization. Flaky-test data will no longer be available to agents.",
-  victorialogs: "This will disconnect VictoriaLogs from your organization. Production log queries will no longer be available to agents.",
   mezmo: "This will disconnect Mezmo from your organization. Production log queries will no longer be available to agents.",
 };
 
@@ -443,6 +445,7 @@ function optionalDescriptorsFromProps(
     { key: "slack", connected: p.slackConnected, summary: p.summaries?.slack, onConnect: p.onConnectSlack },
     { key: "notion", connected: p.notionConnected, loading: p.notionLoading, summary: p.summaries?.notion, onConnect: p.onConnectNotion },
     { key: "circleci", connected: p.circleciConnected, loading: p.circleciLoading, summary: p.summaries?.circleci, onConnect: p.onConnectCircleCI },
+    { key: "mezmo", connected: p.mezmoConnected, loading: p.mezmoLoading, summary: p.summaries?.mezmo, onConnect: p.onConnectMezmo },
   ];
 }
 

--- a/frontend/src/components/setup-checklist.tsx
+++ b/frontend/src/components/setup-checklist.tsx
@@ -223,6 +223,7 @@ export function SetupChecklist() {
   const slackIntegration = integrations.find((integration) => integration.provider === "slack" && integration.status === "active");
   const notionIntegration = integrations.find((integration) => integration.provider === "notion" && integration.status === "active");
   const circleciIntegration = integrations.find((integration) => integration.provider === "circleci" && integration.status === "active");
+  const mezmoIntegration = integrations.find((integration) => integration.provider === "mezmo" && integration.status === "active");
 
   const githubConnected = Boolean(githubIntegration);
   const githubReady = githubConnected && repositories.length > 0;
@@ -253,12 +254,14 @@ export function SetupChecklist() {
             slackConnected={Boolean(slackIntegration)}
             notionConnected={Boolean(notionIntegration)}
             circleciConnected={Boolean(circleciIntegration)}
+            mezmoConnected={Boolean(mezmoIntegration)}
             linearLoading={false}
             onConnectSentry={() => api.auth.loginSentry()}
             onConnectLinear={() => api.integrations.loginLinear()}
             onConnectSlack={() => api.integrations.loginSlack()}
             onConnectNotion={() => { /* Notion requires token input — use the Integrations page */ }}
             onConnectCircleCI={() => { /* CircleCI requires token + slug input — use the Integrations page */ }}
+            onConnectMezmo={() => { /* Mezmo requires service-key input — use the Integrations page */ }}
             onDisconnect={(provider) => disconnectMutation.mutate(provider)}
             disconnectingProvider={disconnectMutation.isPending ? disconnectMutation.variables : null}
             disconnectErrorProvider={disconnectMutation.isError ? disconnectMutation.variables ?? null : null}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -723,6 +723,12 @@ export const api = {
         auth_token: authToken,
         project_slug: projectSlug,
       }),
+    connectMezmo: (apiKey: string, baseUrl?: string, dataset?: string) =>
+      post<import('./types').SingleResponse<import('./types').Integration>>('/api/v1/integrations/mezmo/connect', {
+        api_key: apiKey,
+        base_url: baseUrl ?? '',
+        dataset: dataset ?? '',
+      }),
     disconnect: (provider: string) => del(`/api/v1/integrations/${provider}/disconnect`),
     syncGitHub: () => post<{ data: { repos_synced: number; repos_seen?: number; errors: number } }>('/api/v1/integrations/github/sync'),
     listGitHubRepositories: (installationId?: number) => {

--- a/frontend/src/lib/integrations.test.ts
+++ b/frontend/src/lib/integrations.test.ts
@@ -10,7 +10,6 @@ describe("INTEGRATIONS", () => {
     "slack",
     "notion",
     "circleci",
-    "victorialogs",
     "mezmo",
   ] as const satisfies readonly IntegrationKey[];
 
@@ -41,7 +40,6 @@ describe("getIntegrationByKey", () => {
     "slack",
     "notion",
     "circleci",
-    "victorialogs",
     "mezmo",
   ] as IntegrationKey[])(
     "returns the correct integration for %s",

--- a/frontend/src/lib/integrations.ts
+++ b/frontend/src/lib/integrations.ts
@@ -1,4 +1,4 @@
-export type IntegrationKey = "github" | "sentry" | "linear" | "slack" | "notion" | "circleci" | "victorialogs" | "mezmo";
+export type IntegrationKey = "github" | "sentry" | "linear" | "slack" | "notion" | "circleci" | "mezmo";
 
 export type IntegrationDefinition = {
   key: IntegrationKey;
@@ -43,12 +43,6 @@ export const INTEGRATIONS: IntegrationDefinition[] = [
     name: "CircleCI",
     description: "Surface flaky tests so agents can investigate and fix them.",
     logoSrc: "/integrations/circleci.svg",
-  },
-  {
-    key: "victorialogs",
-    name: "VictoriaLogs",
-    description: "Query and search log data from VictoriaLogs.",
-    logoSrc: "/integrations/victorialogs.svg",
   },
   {
     key: "mezmo",

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -233,6 +233,8 @@ export interface Integration {
   notion_workspace_id?: string;
   notion_workspace_name?: string;
   circleci_project_slug?: string;
+  mezmo_dataset?: string;
+  mezmo_base_url?: string;
   /**
    * Surfaced by the backend when a provider rejects our access token (e.g.
    * Linear returns 401). Populated by deriveIntegrationStatus on the server

--- a/internal/api/handlers/integrations.go
+++ b/internal/api/handlers/integrations.go
@@ -62,6 +62,11 @@ const (
 type integrationCredentialStore interface {
 	Get(ctx context.Context, orgID uuid.UUID, provider models.ProviderName) (*models.DecryptedCredential, error)
 	Upsert(ctx context.Context, orgID uuid.UUID, cfg models.ProviderConfig) error
+	// Disable marks the singleton (label="") credential for a provider as
+	// disabled so it stops being injected into sandboxes. Disconnect calls this
+	// so revoking an integration in the UI actually revokes runtime access, not
+	// just the integration row's status. Re-connecting re-activates it via Upsert.
+	Disable(ctx context.Context, orgID uuid.UUID, provider models.ProviderName) error
 }
 
 // githubAppService provides GitHub App installation tokens for fetching repos.
@@ -495,7 +500,7 @@ func (h *IntegrationHandler) deriveSafeCredentialMetadata(ctx context.Context, i
 	}
 
 	switch integration.Provider {
-	case models.IntegrationProviderNotion, models.IntegrationProviderCircleCI:
+	case models.IntegrationProviderNotion, models.IntegrationProviderCircleCI, models.IntegrationProviderMezmo:
 	default:
 		return
 	}
@@ -516,6 +521,13 @@ func (h *IntegrationHandler) deriveSafeCredentialMetadata(ctx context.Context, i
 	case models.CircleCIConfig:
 		if cfg.ProjectSlug != "" {
 			integration.CircleCIProjectSlug = integrationStringPtr(cfg.ProjectSlug)
+		}
+	case models.MezmoConfig:
+		if cfg.Dataset != "" {
+			integration.MezmoDataset = integrationStringPtr(cfg.Dataset)
+		}
+		if cfg.BaseURL != "" {
+			integration.MezmoBaseURL = integrationStringPtr(cfg.BaseURL)
 		}
 	}
 }
@@ -597,6 +609,19 @@ func (h *IntegrationHandler) DisconnectIntegration(w http.ResponseWriter, r *htt
 				writeError(w, r, http.StatusInternalServerError, "UPDATE_FAILED", "failed to disconnect github installation links", err)
 				return
 			}
+		}
+	}
+
+	// Disable the stored org credential so sandboxes stop receiving this
+	// provider's secrets. The sandbox env-injection path reads org_credentials
+	// (status != 'disabled') independently of integrations.status, so without
+	// this a "disconnected" provider would keep being injected and remain
+	// usable by agents. Reconnecting re-activates the row via Upsert. No-op for
+	// providers whose credentials don't live in org_credentials (e.g. GitHub).
+	if h.credentialStore != nil {
+		if err := h.credentialStore.Disable(r.Context(), orgID, models.ProviderName(provider)); err != nil {
+			writeError(w, r, http.StatusInternalServerError, "UPDATE_FAILED", "failed to disable integration credential", err)
+			return
 		}
 	}
 
@@ -2996,4 +3021,125 @@ func (h *IntegrationHandler) validateCircleCIToken(ctx context.Context, token st
 	}
 	_, _ = io.Copy(io.Discard, resp.Body)
 	return nil
+}
+
+// mezmoDefaultBaseURL is the public Mezmo API host. Kept in sync with the
+// runtime provider default in internal/services/integration.NewMezmoProvider.
+const mezmoDefaultBaseURL = "https://api.mezmo.com"
+
+// ConnectMezmo accepts a Mezmo service key (plus optional base URL and dataset),
+// validates it against the log-search endpoint, stores the credential, and
+// creates an active integration record. Mezmo uses a paste-the-key flow because
+// its log-query API authenticates with a service key rather than OAuth. The
+// stored credential is injected into sandboxes as MEZMO_* env vars by the
+// orchestrator (see internal/services/agent/env.go) so the agent's 143-tools
+// log commands query this org's Mezmo with its own key.
+func (h *IntegrationHandler) ConnectMezmo(w http.ResponseWriter, r *http.Request) {
+	orgID := middleware.OrgIDFromContext(r.Context())
+
+	var req struct {
+		APIKey  string `json:"api_key"`
+		BaseURL string `json:"base_url"`
+		Dataset string `json:"dataset"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, r, http.StatusBadRequest, "INVALID_JSON", "invalid request body")
+		return
+	}
+	req.APIKey = strings.TrimSpace(req.APIKey)
+	req.BaseURL = strings.TrimRight(strings.TrimSpace(req.BaseURL), "/")
+	req.Dataset = strings.TrimSpace(req.Dataset)
+	if req.APIKey == "" {
+		writeError(w, r, http.StatusBadRequest, "MISSING_API_KEY", "api_key is required")
+		return
+	}
+	if req.BaseURL != "" {
+		if u, err := url.Parse(req.BaseURL); err != nil || u.Scheme == "" || u.Host == "" {
+			writeError(w, r, http.StatusBadRequest, "INVALID_BASE_URL", "base_url must be an absolute URL (e.g. https://api.mezmo.com)")
+			return
+		}
+	}
+
+	cfg := models.MezmoConfig{
+		APIKey:  req.APIKey,
+		BaseURL: req.BaseURL,
+		Dataset: req.Dataset,
+	}
+	if err := h.validateMezmoToken(r.Context(), cfg); err != nil {
+		writeError(w, r, http.StatusBadRequest, "INVALID_TOKEN", "failed to validate Mezmo key: "+err.Error())
+		return
+	}
+
+	if err := h.credentialStore.Upsert(r.Context(), orgID, cfg); err != nil {
+		writeError(w, r, http.StatusInternalServerError, "CREDENTIAL_SAVE_FAILED", "failed to save Mezmo credentials", err)
+		return
+	}
+
+	integration, created, err := h.ensureIntegration(r.Context(), orgID, models.IntegrationProviderMezmo)
+	if err != nil {
+		writeError(w, r, http.StatusInternalServerError, "CONNECT_MEZMO_FAILED", "failed to create Mezmo integration", err)
+		return
+	}
+	h.deriveIntegrationStatus(r.Context(), &integration, map[models.IntegrationProvider]bool{
+		models.IntegrationProviderMezmo: true,
+	})
+
+	if created {
+		writeJSON(w, http.StatusCreated, models.SingleResponse[models.Integration]{Data: integration})
+		return
+	}
+	writeJSON(w, http.StatusOK, models.SingleResponse[models.Integration]{Data: integration})
+}
+
+// validateMezmoToken issues a minimal log search against the Mezmo API to
+// confirm the service key is accepted. It mirrors the auth path the runtime
+// provider uses (POST /v1/logs/search with a `servicekey` header — see
+// internal/services/integration/log_http.go).
+func (h *IntegrationHandler) validateMezmoToken(ctx context.Context, cfg models.MezmoConfig) error {
+	baseURL := cfg.BaseURL
+	if baseURL == "" {
+		baseURL = mezmoDefaultBaseURL
+	}
+	now := time.Now()
+	body := map[string]any{
+		"query":      "*",
+		"start_time": now.Add(-time.Minute).Format(time.RFC3339Nano),
+		"end_time":   now.Format(time.RFC3339Nano),
+		"limit":      1,
+	}
+	if cfg.Dataset != "" {
+		body["dataset"] = cfg.Dataset
+	}
+	data, err := json.Marshal(body)
+	if err != nil {
+		return err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, baseURL+"/v1/logs/search", bytes.NewReader(data))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("servicekey", cfg.APIKey)
+
+	resp, err := h.client.Do(req)
+	if err != nil {
+		return fmt.Errorf("request failed: %w", err)
+	}
+	defer resp.Body.Close()
+	_, _ = io.Copy(io.Discard, resp.Body)
+
+	// We're validating the key, not the query. Only an auth rejection is a
+	// definitive "bad key", and a 5xx means Mezmo is unhealthy right now (worth
+	// surfacing so the user retries). Any other 4xx (e.g. an unknown dataset, an
+	// unsupported query shape, or a 429 rate-limit) means the key was accepted
+	// and the request reached the API, so we let the connection succeed rather
+	// than block a valid key on a query-shape quirk.
+	switch {
+	case resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden:
+		return fmt.Errorf("invalid or expired key")
+	case resp.StatusCode >= 500:
+		return fmt.Errorf("mezmo API returned %d", resp.StatusCode)
+	default:
+		return nil
+	}
 }

--- a/internal/api/handlers/integrations_test.go
+++ b/internal/api/handlers/integrations_test.go
@@ -72,6 +72,7 @@ func (f fakeGitHubMembershipStore) Get(context.Context, uuid.UUID, uuid.UUID) (m
 type fakeIntegrationCredentialStore struct {
 	credentials map[models.ProviderName]*models.DecryptedCredential
 	err         error
+	disabled    *[]models.ProviderName
 }
 
 func (f fakeIntegrationCredentialStore) Get(_ context.Context, _ uuid.UUID, provider models.ProviderName) (*models.DecryptedCredential, error) {
@@ -86,6 +87,16 @@ func (f fakeIntegrationCredentialStore) Get(_ context.Context, _ uuid.UUID, prov
 }
 
 func (f fakeIntegrationCredentialStore) Upsert(context.Context, uuid.UUID, models.ProviderConfig) error {
+	return nil
+}
+
+func (f fakeIntegrationCredentialStore) Disable(_ context.Context, _ uuid.UUID, provider models.ProviderName) error {
+	if f.err != nil {
+		return f.err
+	}
+	if f.disabled != nil {
+		*f.disabled = append(*f.disabled, provider)
+	}
 	return nil
 }
 
@@ -265,13 +276,23 @@ func TestIntegrationHandler_ListIntegrations_DerivesSafeCredentialMetadata(t *te
 					ProjectSlug: "gh/acme/api",
 				},
 			},
+			models.ProviderMezmo: {
+				OrgID:    orgID,
+				Provider: models.ProviderMezmo,
+				Config: models.MezmoConfig{
+					APIKey:  "secret-mezmo-key",
+					BaseURL: "https://logs.acme.com",
+					Dataset: "prod",
+				},
+			},
 		},
 	}
 	handler := NewIntegrationHandler(store, credentialStore, "", "", "http://localhost:8080", "http://localhost:3000")
 
 	rows := pgxmock.NewRows([]string{"id", "org_id", "provider", "config", "status", "last_synced_at", "created_at"}).
 		AddRow(uuid.New(), orgID, "notion", json.RawMessage(`{}`), "active", nil, now).
-		AddRow(uuid.New(), orgID, "circleci", json.RawMessage(`{}`), "active", nil, now)
+		AddRow(uuid.New(), orgID, "circleci", json.RawMessage(`{}`), "active", nil, now).
+		AddRow(uuid.New(), orgID, "mezmo", json.RawMessage(`{}`), "active", nil, now)
 	mock.ExpectQuery("SELECT .+ FROM integrations WHERE org_id").
 		WithArgs(pgxmock.AnyArg()).
 		WillReturnRows(rows)
@@ -285,15 +306,17 @@ func TestIntegrationHandler_ListIntegrations_DerivesSafeCredentialMetadata(t *te
 	require.Equal(t, http.StatusOK, w.Code, "list integrations should succeed")
 	var resp models.ListResponse[models.Integration]
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp), "response should decode as integration list")
-	require.Len(t, resp.Data, 2, "response should include both integrations")
+	require.Len(t, resp.Data, 3, "response should include all integrations")
 
-	var notionIntegration, circleciIntegration *models.Integration
+	var notionIntegration, circleciIntegration, mezmoIntegration *models.Integration
 	for i := range resp.Data {
 		switch resp.Data[i].Provider {
 		case models.IntegrationProviderNotion:
 			notionIntegration = &resp.Data[i]
 		case models.IntegrationProviderCircleCI:
 			circleciIntegration = &resp.Data[i]
+		case models.IntegrationProviderMezmo:
+			mezmoIntegration = &resp.Data[i]
 		}
 	}
 	require.NotNil(t, notionIntegration, "Notion integration should be present in response")
@@ -302,8 +325,14 @@ func TestIntegrationHandler_ListIntegrations_DerivesSafeCredentialMetadata(t *te
 	require.NotNil(t, circleciIntegration, "CircleCI integration should be present in response")
 	require.NotNil(t, circleciIntegration.CircleCIProjectSlug, "CircleCI project slug should be derived from credential metadata")
 	require.Equal(t, "gh/acme/api", *circleciIntegration.CircleCIProjectSlug, "CircleCI project slug should be exposed without token data")
+	require.NotNil(t, mezmoIntegration, "Mezmo integration should be present in response")
+	require.NotNil(t, mezmoIntegration.MezmoDataset, "Mezmo dataset should be derived from credential metadata")
+	require.Equal(t, "prod", *mezmoIntegration.MezmoDataset, "Mezmo dataset should be exposed without key data")
+	require.NotNil(t, mezmoIntegration.MezmoBaseURL, "Mezmo base URL should be derived from credential metadata")
+	require.Equal(t, "https://logs.acme.com", *mezmoIntegration.MezmoBaseURL, "Mezmo base URL should be exposed without key data")
 	require.NotContains(t, w.Body.String(), "secret-notion-token", "response should not expose Notion token")
 	require.NotContains(t, w.Body.String(), "secret-circle-token", "response should not expose CircleCI token")
+	require.NotContains(t, w.Body.String(), "secret-mezmo-key", "response should not expose Mezmo key")
 	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
 }
 
@@ -496,6 +525,83 @@ func TestIntegrationHandler_DisconnectIntegration_GitHubRepoDisconnectError(t *t
 	require.Equal(t, http.StatusInternalServerError, w.Code, "disconnect integration should surface github repo disconnect failures")
 	require.Contains(t, w.Body.String(), "UPDATE_FAILED", "disconnect integration should return update failed on github repo disconnect errors")
 	require.NoError(t, mock.ExpectationsWereMet(), "all integration-store expectations should be met")
+}
+
+// Disconnecting a credential-backed provider must disable the stored org
+// credential, not just flip the integration row to inactive — otherwise the
+// sandbox env-injection path (which reads org_credentials, not integrations)
+// keeps handing the secret to agents after the user thinks they revoked it.
+func TestIntegrationHandler_DisconnectIntegration_DisablesCredential(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "pgxmock pool should initialize")
+	defer mock.Close()
+
+	orgID := uuid.New()
+	integrationID := uuid.New()
+	now := time.Now().UTC()
+	store := db.NewIntegrationStore(mock)
+
+	disabled := make([]models.ProviderName, 0, 1)
+	credentialStore := fakeIntegrationCredentialStore{disabled: &disabled}
+	handler := NewIntegrationHandler(store, credentialStore, "", "", "http://localhost:8080", "http://localhost:3000")
+
+	rows := pgxmock.NewRows([]string{"id", "org_id", "provider", "config", "status", "last_synced_at", "created_at"}).
+		AddRow(integrationID, orgID, "mezmo", []byte(`{}`), "active", nil, now)
+	mock.ExpectQuery("SELECT .+ FROM integrations WHERE org_id").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(rows)
+	mock.ExpectExec("UPDATE integrations SET status = @status WHERE id = @id AND org_id = @org_id").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
+
+	req := httptest.NewRequest(http.MethodDelete, "/api/v1/integrations/mezmo/disconnect", nil)
+	req = req.WithContext(middleware.WithOrgID(req.Context(), orgID))
+	w := httptest.NewRecorder()
+
+	handler.DisconnectIntegration(w, req)
+
+	require.Equal(t, http.StatusNoContent, w.Code, "disconnect should succeed")
+	require.Equal(t, []models.ProviderName{models.ProviderMezmo}, disabled,
+		"disconnect should disable the stored mezmo credential so it stops being injected")
+	require.NoError(t, mock.ExpectationsWereMet(), "all integration-store expectations should be met")
+}
+
+// A credential-disable failure must fail the disconnect rather than silently
+// leaving an injectable secret behind.
+func TestIntegrationHandler_DisconnectIntegration_CredentialDisableError(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "pgxmock pool should initialize")
+	defer mock.Close()
+
+	orgID := uuid.New()
+	integrationID := uuid.New()
+	now := time.Now().UTC()
+	store := db.NewIntegrationStore(mock)
+
+	credentialStore := fakeIntegrationCredentialStore{err: context.DeadlineExceeded}
+	handler := NewIntegrationHandler(store, credentialStore, "", "", "http://localhost:8080", "http://localhost:3000")
+
+	rows := pgxmock.NewRows([]string{"id", "org_id", "provider", "config", "status", "last_synced_at", "created_at"}).
+		AddRow(integrationID, orgID, "mezmo", []byte(`{}`), "active", nil, now)
+	mock.ExpectQuery("SELECT .+ FROM integrations WHERE org_id").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(rows)
+	mock.ExpectExec("UPDATE integrations SET status = @status WHERE id = @id AND org_id = @org_id").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
+
+	req := httptest.NewRequest(http.MethodDelete, "/api/v1/integrations/mezmo/disconnect", nil)
+	req = req.WithContext(middleware.WithOrgID(req.Context(), orgID))
+	w := httptest.NewRecorder()
+
+	handler.DisconnectIntegration(w, req)
+
+	require.Equal(t, http.StatusInternalServerError, w.Code, "a credential-disable failure must fail the disconnect")
+	require.Contains(t, w.Body.String(), "UPDATE_FAILED")
 }
 
 // ──────────────────────────────────────────────────────────────────────────────
@@ -3266,6 +3372,291 @@ func TestIntegrationHandler_ConnectCircleCI_InvalidToken(t *testing.T) {
 	w := httptest.NewRecorder()
 
 	handler.ConnectCircleCI(w, req)
+
+	require.Equal(t, http.StatusBadRequest, w.Code)
+	require.Contains(t, w.Body.String(), "INVALID_TOKEN")
+}
+
+func TestIntegrationHandler_ConnectMezmo_Success(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err)
+	defer mock.Close()
+
+	orgID := uuid.New()
+	integrationID := uuid.New()
+	now := time.Now()
+
+	store := db.NewIntegrationStore(mock)
+	credentialStore := db.NewOrgCredentialStore(mock, nil)
+
+	transport := roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		require.Equal(t, "https://api.mezmo.com/v1/logs/search", req.URL.String())
+		require.Equal(t, "mezmo_key", req.Header.Get("servicekey"))
+
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     make(http.Header),
+			Body:       io.NopCloser(bytes.NewBufferString(`{"lines":[]}`)),
+		}, nil
+	})
+
+	handler := NewIntegrationHandler(
+		store, credentialStore, "", "", "http://localhost:8080", "http://localhost:3000",
+	)
+	handler.client = &http.Client{Transport: transport}
+
+	mock.ExpectQuery("INSERT INTO org_credentials").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(pgxmock.NewRows([]string{"id"}).AddRow(uuid.New()))
+
+	mock.ExpectQuery("SELECT .+ FROM integrations .+ provider = @provider .+ status IN \\('active', 'error'\\)").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(pgxmock.NewRows([]string{"id", "org_id", "provider", "config", "status", "last_synced_at", "created_at"}))
+
+	mock.ExpectQuery("INSERT INTO integrations").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(pgxmock.NewRows([]string{"id", "created_at"}).AddRow(integrationID, now))
+
+	body := `{"api_key":"mezmo_key","dataset":"prod"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/integrations/mezmo/connect", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	req = req.WithContext(middleware.WithOrgID(req.Context(), orgID))
+	w := httptest.NewRecorder()
+
+	handler.ConnectMezmo(w, req)
+
+	require.Equal(t, http.StatusCreated, w.Code, "body=%s", w.Body.String())
+	require.Contains(t, w.Body.String(), `"provider":"mezmo"`)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestIntegrationHandler_ConnectMezmo_MissingAPIKey(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err)
+	defer mock.Close()
+
+	store := db.NewIntegrationStore(mock)
+	handler := NewIntegrationHandler(store, nil, "", "", "http://localhost:8080", "http://localhost:3000")
+
+	body := `{"dataset":"prod"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/integrations/mezmo/connect", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	req = req.WithContext(middleware.WithOrgID(req.Context(), uuid.New()))
+	w := httptest.NewRecorder()
+
+	handler.ConnectMezmo(w, req)
+
+	require.Equal(t, http.StatusBadRequest, w.Code)
+	require.Contains(t, w.Body.String(), "MISSING_API_KEY")
+}
+
+func TestIntegrationHandler_ConnectMezmo_RejectsMalformedBaseURL(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err)
+	defer mock.Close()
+
+	store := db.NewIntegrationStore(mock)
+	handler := NewIntegrationHandler(store, nil, "", "", "http://localhost:8080", "http://localhost:3000")
+
+	body := `{"api_key":"key","base_url":"not-a-url"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/integrations/mezmo/connect", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	req = req.WithContext(middleware.WithOrgID(req.Context(), uuid.New()))
+	w := httptest.NewRecorder()
+
+	handler.ConnectMezmo(w, req)
+
+	require.Equal(t, http.StatusBadRequest, w.Code)
+	require.Contains(t, w.Body.String(), "INVALID_BASE_URL")
+}
+
+func TestIntegrationHandler_ConnectMezmo_HonorsCustomBaseURL(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err)
+	defer mock.Close()
+
+	orgID := uuid.New()
+	integrationID := uuid.New()
+	now := time.Now()
+
+	store := db.NewIntegrationStore(mock)
+	credentialStore := db.NewOrgCredentialStore(mock, nil)
+
+	transport := roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		require.Equal(t, "https://logs.example.com/v1/logs/search", req.URL.String(),
+			"validation should target the operator-supplied base URL")
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     make(http.Header),
+			Body:       io.NopCloser(bytes.NewBufferString(`{"lines":[]}`)),
+		}, nil
+	})
+
+	handler := NewIntegrationHandler(store, credentialStore, "", "", "http://localhost:8080", "http://localhost:3000")
+	handler.client = &http.Client{Transport: transport}
+
+	mock.ExpectQuery("INSERT INTO org_credentials").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(pgxmock.NewRows([]string{"id"}).AddRow(uuid.New()))
+	mock.ExpectQuery("SELECT .+ FROM integrations .+ provider = @provider .+ status IN \\('active', 'error'\\)").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(pgxmock.NewRows([]string{"id", "org_id", "provider", "config", "status", "last_synced_at", "created_at"}))
+	mock.ExpectQuery("INSERT INTO integrations").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(pgxmock.NewRows([]string{"id", "created_at"}).AddRow(integrationID, now))
+
+	body := `{"api_key":"mezmo_key","base_url":"https://logs.example.com/"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/integrations/mezmo/connect", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	req = req.WithContext(middleware.WithOrgID(req.Context(), orgID))
+	w := httptest.NewRecorder()
+
+	handler.ConnectMezmo(w, req)
+
+	require.Equal(t, http.StatusCreated, w.Code, "body=%s", w.Body.String())
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestIntegrationHandler_ConnectMezmo_InvalidToken(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err)
+	defer mock.Close()
+
+	store := db.NewIntegrationStore(mock)
+
+	transport := roundTripFunc(func(_ *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusForbidden,
+			Header:     make(http.Header),
+			Body:       io.NopCloser(bytes.NewBufferString(`{"error":"forbidden"}`)),
+		}, nil
+	})
+
+	handler := NewIntegrationHandler(store, nil, "", "", "http://localhost:8080", "http://localhost:3000")
+	handler.client = &http.Client{Transport: transport}
+
+	body := `{"api_key":"bad"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/integrations/mezmo/connect", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	req = req.WithContext(middleware.WithOrgID(req.Context(), uuid.New()))
+	w := httptest.NewRecorder()
+
+	handler.ConnectMezmo(w, req)
+
+	require.Equal(t, http.StatusBadRequest, w.Code)
+	require.Contains(t, w.Body.String(), "INVALID_TOKEN")
+}
+
+func TestIntegrationHandler_ConnectMezmo_InvalidJSON(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err)
+	defer mock.Close()
+
+	store := db.NewIntegrationStore(mock)
+	handler := NewIntegrationHandler(store, nil, "", "", "http://localhost:8080", "http://localhost:3000")
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/integrations/mezmo/connect", bytes.NewBufferString(`{bad json`))
+	req.Header.Set("Content-Type", "application/json")
+	req = req.WithContext(middleware.WithOrgID(req.Context(), uuid.New()))
+	w := httptest.NewRecorder()
+
+	handler.ConnectMezmo(w, req)
+
+	require.Equal(t, http.StatusBadRequest, w.Code)
+	require.Contains(t, w.Body.String(), "INVALID_JSON")
+}
+
+// A 4xx that isn't an auth rejection (e.g. an unknown dataset or a query-shape
+// quirk) means the key was accepted, so connect should still succeed — we
+// validate the key, not the probe query.
+func TestIntegrationHandler_ConnectMezmo_AcceptsNonAuth4xx(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err)
+	defer mock.Close()
+
+	orgID := uuid.New()
+	integrationID := uuid.New()
+	now := time.Now()
+
+	store := db.NewIntegrationStore(mock)
+	credentialStore := db.NewOrgCredentialStore(mock, nil)
+
+	transport := roundTripFunc(func(_ *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusBadRequest,
+			Header:     make(http.Header),
+			Body:       io.NopCloser(bytes.NewBufferString(`{"error":"unknown dataset"}`)),
+		}, nil
+	})
+
+	handler := NewIntegrationHandler(store, credentialStore, "", "", "http://localhost:8080", "http://localhost:3000")
+	handler.client = &http.Client{Transport: transport}
+
+	mock.ExpectQuery("INSERT INTO org_credentials").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(pgxmock.NewRows([]string{"id"}).AddRow(uuid.New()))
+	mock.ExpectQuery("SELECT .+ FROM integrations .+ provider = @provider .+ status IN \\('active', 'error'\\)").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(pgxmock.NewRows([]string{"id", "org_id", "provider", "config", "status", "last_synced_at", "created_at"}))
+	mock.ExpectQuery("INSERT INTO integrations").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(pgxmock.NewRows([]string{"id", "created_at"}).AddRow(integrationID, now))
+
+	body := `{"api_key":"mezmo_key","dataset":"does-not-exist"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/integrations/mezmo/connect", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	req = req.WithContext(middleware.WithOrgID(req.Context(), orgID))
+	w := httptest.NewRecorder()
+
+	handler.ConnectMezmo(w, req)
+
+	require.Equal(t, http.StatusCreated, w.Code, "body=%s", w.Body.String())
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+// A 5xx means Mezmo is unhealthy; block the connect so the user retries rather
+// than persisting a credential we couldn't verify against a working API.
+func TestIntegrationHandler_ConnectMezmo_RejectsServerError(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err)
+	defer mock.Close()
+
+	store := db.NewIntegrationStore(mock)
+
+	transport := roundTripFunc(func(_ *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusBadGateway,
+			Header:     make(http.Header),
+			Body:       io.NopCloser(bytes.NewBufferString(`{"error":"upstream"}`)),
+		}, nil
+	})
+
+	handler := NewIntegrationHandler(store, nil, "", "", "http://localhost:8080", "http://localhost:3000")
+	handler.client = &http.Client{Transport: transport}
+
+	body := `{"api_key":"mezmo_key"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/integrations/mezmo/connect", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	req = req.WithContext(middleware.WithOrgID(req.Context(), uuid.New()))
+	w := httptest.NewRecorder()
+
+	handler.ConnectMezmo(w, req)
 
 	require.Equal(t, http.StatusBadRequest, w.Code)
 	require.Contains(t, w.Body.String(), "INVALID_TOKEN")

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -1339,6 +1339,8 @@ func NewRouter(cfg *config.Config, pool *pgxpool.Pool, logger zerolog.Logger, se
 				r.Delete("/api/v1/integrations/notion/disconnect", integrationHandler.DisconnectIntegration)
 				r.Post("/api/v1/integrations/circleci/connect", integrationHandler.ConnectCircleCI)
 				r.Delete("/api/v1/integrations/circleci/disconnect", integrationHandler.DisconnectIntegration)
+				r.Post("/api/v1/integrations/mezmo/connect", integrationHandler.ConnectMezmo)
+				r.Delete("/api/v1/integrations/mezmo/disconnect", integrationHandler.DisconnectIntegration)
 
 				// Eval write routes (admin-only — creating tasks shapes org-wide eval setup).
 				r.Post("/api/v1/evals/tasks", evalHandler.CreateTask)

--- a/internal/models/credentials.go
+++ b/internal/models/credentials.go
@@ -289,6 +289,17 @@ type CircleCIConfig struct {
 	ProjectSlug string `json:"project_slug"`
 }
 
+// MezmoConfig stores a Mezmo service key plus optional base URL (for
+// self-hosted/enterprise endpoints, defaults to https://api.mezmo.com) and an
+// optional dataset used to scope log queries. This is the persisted credential
+// shape; the runtime provider config lives in
+// internal/services/integration.MezmoConfig, mirroring the CircleCI split.
+type MezmoConfig struct {
+	APIKey  string `json:"api_key"` // #nosec G117 -- JSON config field
+	BaseURL string `json:"base_url,omitempty"`
+	Dataset string `json:"dataset,omitempty"`
+}
+
 type OpenAIChatGPTConfig struct {
 	AccessToken  string    `json:"access_token"`       // #nosec G117 -- JSON config field
 	RefreshToken string    `json:"refresh_token"`      // #nosec G117 -- JSON config field
@@ -349,6 +360,7 @@ func (c GitHubOAuthConfig) Provider() ProviderName   { return ProviderGitHubOAut
 func (c SentryConfig) Provider() ProviderName        { return ProviderSentry }
 func (c LinearConfig) Provider() ProviderName        { return ProviderLinear }
 func (c CircleCIConfig) Provider() ProviderName      { return ProviderCircleCI }
+func (c MezmoConfig) Provider() ProviderName         { return ProviderMezmo }
 func (c SlackConfig) Provider() ProviderName         { return ProviderSlack }
 func (c NotionConfig) Provider() ProviderName        { return ProviderNotion }
 func (c OpenAIChatGPTConfig) Provider() ProviderName { return ProviderOpenAIChatGPT }
@@ -523,6 +535,13 @@ func (c CircleCIConfig) Validate() error {
 	return nil
 }
 
+func (c MezmoConfig) Validate() error {
+	if c.APIKey == "" {
+		return errors.New("api_key is required")
+	}
+	return nil
+}
+
 func (c OpenAIChatGPTConfig) Validate() error {
 	if c.AccessToken == "" {
 		return errors.New("access_token is required")
@@ -655,6 +674,14 @@ func (c CircleCIConfig) MaskedSummary() CredentialSummary {
 	}
 }
 
+func (c MezmoConfig) MaskedSummary() CredentialSummary {
+	return CredentialSummary{
+		Provider:   ProviderMezmo,
+		Configured: true,
+		MaskedKey:  MaskKey(c.APIKey),
+	}
+}
+
 func (c OpenAIChatGPTConfig) MaskedSummary() CredentialSummary {
 	return CredentialSummary{
 		Provider:    ProviderOpenAIChatGPT,
@@ -773,6 +800,12 @@ func ParseProviderConfig(provider ProviderName, data []byte) (ProviderConfig, er
 		var cfg CircleCIConfig
 		if err := json.Unmarshal(data, &cfg); err != nil {
 			return nil, fmt.Errorf("parse circleci config: %w", err)
+		}
+		return cfg, nil
+	case ProviderMezmo:
+		var cfg MezmoConfig
+		if err := json.Unmarshal(data, &cfg); err != nil {
+			return nil, fmt.Errorf("parse mezmo config: %w", err)
 		}
 		return cfg, nil
 	default:

--- a/internal/models/credentials_test.go
+++ b/internal/models/credentials_test.go
@@ -807,6 +807,52 @@ func TestParseProviderConfig_Notion_Invalid(t *testing.T) {
 	require.Error(t, err)
 }
 
+func TestMaskedSummary_Mezmo(t *testing.T) {
+	t.Parallel()
+
+	cfg := MezmoConfig{APIKey: "mezmo_service_key_12345"}
+	summary := cfg.MaskedSummary()
+
+	require.Equal(t, ProviderMezmo, summary.Provider, "summary should have correct provider")
+	require.True(t, summary.Configured, "summary should be configured")
+	require.Equal(t, MaskKey("mezmo_service_key_12345"), summary.MaskedKey, "summary should mask the api key")
+	require.NotContains(t, summary.MaskedKey, "mezmo_service_key_12345", "summary must not leak the raw key")
+}
+
+func TestMezmoConfig_Validate(t *testing.T) {
+	t.Parallel()
+
+	require.NoError(t, MezmoConfig{APIKey: "key"}.Validate())
+	require.NoError(t, MezmoConfig{APIKey: "key", BaseURL: "https://logs.example.com", Dataset: "prod"}.Validate())
+	require.Error(t, MezmoConfig{APIKey: ""}.Validate())
+}
+
+func TestMezmoConfig_Provider(t *testing.T) {
+	t.Parallel()
+	require.Equal(t, ProviderMezmo, MezmoConfig{}.Provider())
+}
+
+func TestParseProviderConfig_Mezmo(t *testing.T) {
+	t.Parallel()
+
+	input := `{"api_key":"mezmo_key","base_url":"https://logs.example.com","dataset":"prod"}`
+	cfg, err := ParseProviderConfig(ProviderMezmo, []byte(input))
+	require.NoError(t, err)
+
+	mc, ok := cfg.(MezmoConfig)
+	require.True(t, ok, "config should be MezmoConfig")
+	require.Equal(t, "mezmo_key", mc.APIKey)
+	require.Equal(t, "https://logs.example.com", mc.BaseURL)
+	require.Equal(t, "prod", mc.Dataset)
+}
+
+func TestParseProviderConfig_Mezmo_Invalid(t *testing.T) {
+	t.Parallel()
+
+	_, err := ParseProviderConfig(ProviderMezmo, []byte(`{bad json`))
+	require.Error(t, err)
+}
+
 func TestIsCodingAgentProvider(t *testing.T) {
 	t.Parallel()
 

--- a/internal/models/enum_db_sync_test.go
+++ b/internal/models/enum_db_sync_test.go
@@ -167,6 +167,7 @@ func TestEnumValuesMatchCheckConstraints(t *testing.T) {
 			IntegrationProviderGitHub, IntegrationProviderSentry,
 			IntegrationProviderLinear, IntegrationProviderSlack,
 			IntegrationProviderNotion, IntegrationProviderCircleCI,
+			IntegrationProviderMezmo,
 		),
 		// issue_source.go
 		"issues_source": toStrings(

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -79,6 +79,8 @@ type Integration struct {
 	NotionWorkspaceID           *string             `db:"-" json:"notion_workspace_id,omitempty"`
 	NotionWorkspaceName         *string             `db:"-" json:"notion_workspace_name,omitempty"`
 	CircleCIProjectSlug         *string             `db:"-" json:"circleci_project_slug,omitempty"`
+	MezmoDataset                *string             `db:"-" json:"mezmo_dataset,omitempty"`
+	MezmoBaseURL                *string             `db:"-" json:"mezmo_base_url,omitempty"`
 	// AuthError is a derived view of the auth-failure markers stamped into
 	// config jsonb when a provider rejects our access token (currently only
 	// Linear). Populated by ListIntegrations / Get* paths via deriveIntegrationStatus

--- a/internal/services/agent/env.go
+++ b/internal/services/agent/env.go
@@ -459,12 +459,14 @@ func (e *AgentEnv) ShedAuthRejectedWithContext(ctx context.Context, orgID uuid.U
 	shedder.MarkAuthRejected(rec.credID)
 }
 
-// integrationCredentials holds the resolved Sentry, Linear, and Notion configs for an org.
+// integrationCredentials holds the resolved Sentry, Linear, Notion, CircleCI,
+// and Mezmo configs for an org.
 type integrationCredentials struct {
 	Sentry   *models.SentryConfig
 	Linear   *models.LinearConfig
 	Notion   *models.NotionConfig
 	CircleCI *models.CircleCIConfig
+	Mezmo    *models.MezmoConfig
 }
 
 type integrationCredentialProvider interface {
@@ -476,6 +478,7 @@ var integrationProviderNames = []models.ProviderName{
 	models.ProviderLinear,
 	models.ProviderNotion,
 	models.ProviderCircleCI,
+	models.ProviderMezmo,
 }
 
 // fetchIntegrationCredentials retrieves integration configs for an org from
@@ -531,6 +534,11 @@ func (ic *integrationCredentials) apply(creds map[models.ProviderName]*models.De
 	if cred := creds[models.ProviderCircleCI]; cred != nil {
 		if cfg, ok := cred.Config.(models.CircleCIConfig); ok {
 			ic.CircleCI = &cfg
+		}
+	}
+	if cred := creds[models.ProviderMezmo]; cred != nil {
+		if cfg, ok := cred.Config.(models.MezmoConfig); ok {
+			ic.Mezmo = &cfg
 		}
 	}
 }
@@ -666,6 +674,17 @@ func (e *AgentEnv) Resolve(ctx context.Context, orgID uuid.UUID, agentType model
 		}
 		if ic.CircleCI.ProjectSlug != "" {
 			merged["CIRCLECI_PROJECT_SLUG"] = ic.CircleCI.ProjectSlug
+		}
+	}
+	if ic.Mezmo != nil {
+		if ic.Mezmo.APIKey != "" {
+			merged["MEZMO_API_KEY"] = ic.Mezmo.APIKey
+		}
+		if ic.Mezmo.BaseURL != "" {
+			merged["MEZMO_BASE_URL"] = ic.Mezmo.BaseURL
+		}
+		if ic.Mezmo.Dataset != "" {
+			merged["MEZMO_DATASET"] = ic.Mezmo.Dataset
 		}
 	}
 

--- a/internal/services/agent/env_test.go
+++ b/internal/services/agent/env_test.go
@@ -418,6 +418,7 @@ func TestAgentEnvResolveExportsCredentialsAndIntegrations(t *testing.T) {
 					models.ProviderSentry: {Config: models.SentryConfig{AccessToken: "sentry-token", OrgSlug: "assembled"}},
 					models.ProviderLinear: {Config: models.LinearConfig{AccessToken: "linear-token"}},
 					models.ProviderNotion: {Config: models.NotionConfig{AccessToken: "notion-token"}},
+					models.ProviderMezmo:  {Config: models.MezmoConfig{APIKey: "mezmo-key", BaseURL: "https://logs.example.com", Dataset: "prod"}},
 				},
 			},
 			expected: map[string]string{
@@ -427,6 +428,9 @@ func TestAgentEnvResolveExportsCredentialsAndIntegrations(t *testing.T) {
 				"SENTRY_ORG_SLUG":     "assembled",
 				"LINEAR_ACCESS_TOKEN": "linear-token",
 				"NOTION_ACCESS_TOKEN": "notion-token",
+				"MEZMO_API_KEY":       "mezmo-key",
+				"MEZMO_BASE_URL":      "https://logs.example.com",
+				"MEZMO_DATASET":       "prod",
 			},
 		},
 		{
@@ -489,6 +493,7 @@ func TestAgentEnvFetchIntegrationCredentialsUsesBatchLookup(t *testing.T) {
 			models.ProviderLinear:   {Config: models.LinearConfig{AccessToken: "linear-token"}},
 			models.ProviderNotion:   {Config: models.NotionConfig{AccessToken: "notion-token"}},
 			models.ProviderCircleCI: {Config: models.CircleCIConfig{AuthToken: "circle-token", ProjectSlug: "gh/acme/repo"}},
+			models.ProviderMezmo:    {Config: models.MezmoConfig{APIKey: "mezmo-key"}},
 		},
 	}
 	env := NewAgentEnv(AgentEnvDeps{
@@ -503,12 +508,14 @@ func TestAgentEnvFetchIntegrationCredentialsUsesBatchLookup(t *testing.T) {
 		models.ProviderLinear,
 		models.ProviderNotion,
 		models.ProviderCircleCI,
+		models.ProviderMezmo,
 	}, orgCreds.batch, "fetchIntegrationCredentials should request all integrations in one batch")
 	require.Empty(t, orgCreds.getCalls, "fetchIntegrationCredentials should not issue per-provider Get calls")
 	require.NotNil(t, creds.Sentry, "fetchIntegrationCredentials should decode Sentry from batch results")
 	require.NotNil(t, creds.Linear, "fetchIntegrationCredentials should decode Linear from batch results")
 	require.NotNil(t, creds.Notion, "fetchIntegrationCredentials should decode Notion from batch results")
 	require.NotNil(t, creds.CircleCI, "fetchIntegrationCredentials should decode CircleCI from batch results")
+	require.NotNil(t, creds.Mezmo, "fetchIntegrationCredentials should decode Mezmo from batch results")
 }
 
 // fakeLinearTokens implements LinearTokenResolver for env tests. The

--- a/migrations/000164_integrations_mezmo.down.sql
+++ b/migrations/000164_integrations_mezmo.down.sql
@@ -1,0 +1,11 @@
+-- Revert to the pre-mezmo provider set. Any existing 'mezmo' integration rows
+-- must be removed before this runs, or VALIDATE will fail.
+ALTER TABLE integrations
+    DROP CONSTRAINT IF EXISTS chk_integrations_provider;
+
+ALTER TABLE integrations
+    ADD CONSTRAINT chk_integrations_provider CHECK (provider IN (
+        'github', 'sentry', 'linear', 'slack', 'notion', 'circleci'
+    )) NOT VALID;
+
+ALTER TABLE integrations VALIDATE CONSTRAINT chk_integrations_provider;

--- a/migrations/000164_integrations_mezmo.up.sql
+++ b/migrations/000164_integrations_mezmo.up.sql
@@ -1,0 +1,14 @@
+-- Add 'mezmo' to the integrations.provider CHECK constraint.
+-- Uses NOT VALID + VALIDATE CONSTRAINT so the re-add doesn't hold an ACCESS
+-- EXCLUSIVE lock while scanning the table: NOT VALID applies to new writes
+-- immediately, then VALIDATE rescans existing rows under a weaker lock.
+-- Widening the allowed set, so existing rows already satisfy it.
+ALTER TABLE integrations
+    DROP CONSTRAINT IF EXISTS chk_integrations_provider;
+
+ALTER TABLE integrations
+    ADD CONSTRAINT chk_integrations_provider CHECK (provider IN (
+        'github', 'sentry', 'linear', 'slack', 'notion', 'circleci', 'mezmo'
+    )) NOT VALID;
+
+ALTER TABLE integrations VALIDATE CONSTRAINT chk_integrations_provider;


### PR DESCRIPTION
## Overview

Mezmo (a read-only log provider) already existed in the 143-tools backend but **could not be connected from the integrations page** — the optional-cards list omitted it, and there was no connect handler, stored credential, or runtime wiring. This makes Mezmo a fully working, per-org integration mirroring the **CircleCI** paste-a-token flow end-to-end.

## What changed

### Backend
- **`models.MezmoConfig`** stored credential (`api_key` + optional `base_url`/`dataset`) with `Provider`/`Validate`/`MaskedSummary` + a `ParseProviderConfig` case.
- **`ConnectMezmo` handler** with `validateMezmoToken` (probes `/v1/logs/search` with the `servicekey` header). Validation rejects only `401/403` (bad key) and `5xx` (Mezmo unhealthy); other `4xx` (unknown dataset, query quirk, `429`) still connect — we validate the key, not the probe query.
- `deriveSafeCredentialMetadata` surfaces `dataset` + `base_url` (**never** the key); routes registered admin-only.
- **Per-org runtime injection** of `MEZMO_API_KEY`/`MEZMO_BASE_URL`/`MEZMO_DATASET` into each sandbox in `env.go`, so the agent's `143-tools log` commands query the org's Mezmo with its own key.
- **Migration 000164** adds `mezmo` to `chk_integrations_provider` (`NOT VALID` + `VALIDATE` to avoid a long `ACCESS EXCLUSIVE` lock).

### Disconnect now revokes access (cross-provider fix)
`DisconnectIntegration` previously only flipped `integrations.status` to inactive, but the sandbox env-injection path reads `org_credentials` (`status != 'disabled'`) **independently** of `integrations.status` — so a "disconnected" provider kept being injected into sandboxes. Disconnect now also calls `credentialStore.Disable(orgID, provider)`. This is a generic handler, so it **also closes the same latent gap for CircleCI/Notion/Sentry/Linear**. Reconnecting re-activates the row via `Upsert`. Fails hard if the disable errors, so we never report a disconnect that didn't revoke.

### Frontend
- Mezmo card + 3-field connect dialog (key required; base URL + dataset optional via a new `TokenDialog` `optional` flag), connected summary, and a manage-sheet panel showing base URL/dataset with a Replace-credentials button.
- `connectMezmo` API client + `mezmo_dataset`/`mezmo_base_url` types.
- **Removed the dangling VictoriaLogs frontend entry** — it was half-wired the same way but has an infra-shaped config (query URL, signing key, multi-tenant mode) that doesn't fit a per-org paste-token UI, so it stays env-only on the backend.

## Reviewer notes
- The disconnect change affects **all** credential-backed providers, not just Mezmo — intentional, and the desired behavior (disconnect == revoke). No-op for GitHub (creds aren't in `org_credentials`).
- `base_url` accepts an arbitrary absolute host by design (admin-only; supports self-hosted/regional Mezmo). Not restricted.

## Testing
- **Backend:** `MezmoConfig` validate/parse/masked; `ConnectMezmo` success / missing-key / malformed-base-URL / custom-base-URL / invalid-token / server-error / non-auth-4xx; disconnect-disables-credential (+ disable-error path); env injection; enum↔DB CHECK sync.
- **Frontend:** card render + connect/disconnect, integrations list, setup-checklist.
- `make lint` (0 issues), full `go build ./...`, `tsc --noEmit`, eslint, vitest — all green.
- **Still needs a running stack (not done here):** live `make migrate-up`, and the end-to-end UI + disconnect-revokes-the-env-var flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
