### PR TITLE
Add persisted full screen mode to the session diff viewer

### DIFF
--- a/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
@@ -2976,6 +2976,9 @@ export function SessionDetailContent({ id }: { id: string }) {
   const [reviewFixMode, setReviewFixMode] = useState<ReviewLoopFixMode>("minimal");
   const [detailWidth, setDetailWidth] = useState(DEFAULT_DETAIL);
   const [activeFileIndex, setActiveFileIndex] = useState(0);
+  // null means "follow the saved user-settings preference"; a boolean means
+  // the user toggled full screen in this session (and we persist it).
+  const [diffFullScreenOverride, setDiffFullScreenOverride] = useState<boolean | null>(null);
   const [isEditingTitle, setIsEditingTitle] = useState(false);
   const [draftTitle, setDraftTitle] = useState("");
   const [isMobileReviewViewport, setIsMobileReviewViewport] = useState(false);
@@ -3253,6 +3256,35 @@ export function SessionDetailContent({ id }: { id: string }) {
   const currentTitle = session ? sessionTitle(session) : "";
 
   const queryClient = useQueryClient();
+
+  // Full-screen diff viewer. The preference lives on the user settings
+  // document so it sticks across sessions; mobile review already fills the
+  // viewport, so the mode is desktop-only.
+  const isDiffFullScreen =
+    !isMobileReviewViewport &&
+    (diffFullScreenOverride ?? user?.settings?.diff_viewer_full_screen ?? false);
+  const { mutate: persistDiffFullScreen } = useMutation({
+    // PATCH /auth/me/settings replaces the whole settings JSONB, so merge the
+    // existing fields in rather than sending the flag alone.
+    mutationFn: (fullScreen: boolean) =>
+      api.auth.updateSettings({ ...(user?.settings ?? {}), diff_viewer_full_screen: fullScreen }),
+    onSuccess: (response) => {
+      queryClient.setQueryData(["auth", "me"], { data: response.data });
+    },
+    onError: () => {
+      toast.error("Couldn't save full screen preference");
+    },
+  });
+  const toggleDiffFullScreen = useCallback(() => {
+    const next = !isDiffFullScreen;
+    setDiffFullScreenOverride(next);
+    // Don't persist before the user document has loaded — the merge above
+    // would wipe the other settings fields.
+    if (user) {
+      persistDiffFullScreen(next);
+    }
+  }, [isDiffFullScreen, user, persistDiffFullScreen]);
+
   const activeThreadDelivery = activeThread?.inbox_delivery;
   const activeThreadHasRecoverableInbox =
     !!activeThreadDelivery &&
@@ -5712,9 +5744,16 @@ export function SessionDetailContent({ id }: { id: string }) {
               )}
             </div>
           ) : null}
-          {/* Review diff view — mounted only when active */}
+          {/* Review diff view — mounted only when active. Full screen lifts
+              the same mounted subtree into a viewport overlay (z-40 stays
+              below dialogs/sheets at z-50) so diff state survives toggling. */}
           {centerMode === "review" && (
-            <div className="h-full animate-in fade-in duration-150 flex flex-col">
+            <div
+              className={cn(
+                "animate-in fade-in duration-150 flex flex-col",
+                isDiffFullScreen ? "fixed inset-0 z-40 bg-background" : "h-full"
+              )}
+            >
               <div className="flex-1 min-h-0">
                 {isDiffDisplayLoading ? (
                   <div className="h-full w-full bg-muted/20 animate-pulse rounded-lg" />
@@ -5751,6 +5790,8 @@ export function SessionDetailContent({ id }: { id: string }) {
                     onDeleteComment={deleteComment}
                     diffSearchQuery={diffSearchQuery}
                     onDiffSearchChange={setDiffSearchQuery}
+                    isFullScreen={isDiffFullScreen}
+                    onToggleFullScreen={toggleDiffFullScreen}
                   />
                 )}
               </div>

--- a/frontend/src/app/(dashboard)/settings/account/page.tsx
+++ b/frontend/src/app/(dashboard)/settings/account/page.tsx
@@ -242,6 +242,9 @@ export default function AccountPage() {
   const effectiveReasoningDefaults = pendingReasoningDefaults ?? storedReasoningDefaults;
   const effectiveDefaultModel = pendingDefaultModel ?? user?.settings?.coding_agent_model_default ?? "";
   const hasEffectiveReasoningDefaults = Object.keys(effectiveReasoningDefaults).length > 0;
+  // Not editable on this page (toggled from the diff viewer toolbar), but it
+  // must ride along with every settings PATCH or it would be wiped.
+  const storedDiffFullScreen = user?.settings?.diff_viewer_full_screen ?? false;
 
   const createMutation = useMutation({
     mutationFn: () =>
@@ -290,10 +293,13 @@ export default function AccountPage() {
   });
 
   const updateReasoningDefaultsMutation = useMutation({
+    // PATCH replaces the whole settings document, so every settings mutation
+    // on this page must carry the fields it isn't editing.
     mutationFn: (defaults: UserSettingsUpdateRequest["coding_agent_reasoning_defaults"]) =>
       api.auth.updateSettings({
         ...(effectiveDefaultModel ? { coding_agent_model_default: effectiveDefaultModel } : {}),
         ...(defaults && Object.keys(defaults).length > 0 ? { coding_agent_reasoning_defaults: defaults } : {}),
+        ...(storedDiffFullScreen ? { diff_viewer_full_screen: true } : {}),
       }),
     onMutate: (defaults) => {
       reasoningSaveInFlightRef.current = true;
@@ -339,6 +345,7 @@ export default function AccountPage() {
       api.auth.updateSettings({
         ...(model ? { coding_agent_model_default: model } : {}),
         ...(hasEffectiveReasoningDefaults ? { coding_agent_reasoning_defaults: effectiveReasoningDefaults } : {}),
+        ...(storedDiffFullScreen ? { diff_viewer_full_screen: true } : {}),
       }),
     onMutate: (model) => {
       setPendingDefaultModel(model);

--- a/frontend/src/components/code-review/diff-toolbar.test.tsx
+++ b/frontend/src/components/code-review/diff-toolbar.test.tsx
@@ -121,6 +121,25 @@ describe("DiffToolbar", () => {
     expect(screen.queryByText("Split")).not.toBeInTheDocument();
   });
 
+  it("renders the full screen toggle when onToggleFullScreen is provided", async () => {
+    const user = userEvent.setup();
+    const onToggleFullScreen = vi.fn();
+    renderToolbar({ onToggleFullScreen });
+    const button = screen.getByRole("button", { name: "Enter full screen" });
+    await user.click(button);
+    expect(onToggleFullScreen).toHaveBeenCalled();
+  });
+
+  it("labels the full screen toggle as an exit while in full screen", () => {
+    renderToolbar({ onToggleFullScreen: vi.fn(), isFullScreen: true });
+    expect(screen.getByRole("button", { name: "Exit full screen" })).toBeInTheDocument();
+  });
+
+  it("does not render the full screen toggle without onToggleFullScreen", () => {
+    renderToolbar();
+    expect(screen.queryByRole("button", { name: "Enter full screen" })).not.toBeInTheDocument();
+  });
+
   it("does not render a dead mobile search control when search is unavailable", () => {
     renderToolbar({
       isMobile: true,

--- a/frontend/src/components/code-review/diff-toolbar.tsx
+++ b/frontend/src/components/code-review/diff-toolbar.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useRef, useEffect } from "react";
-import { ArrowLeft, ChevronLeft, ChevronRight, Columns2, FolderSearch, Rows3, Search, X, Files, MessageSquare } from "lucide-react";
+import { ArrowLeft, ChevronLeft, ChevronRight, Columns2, FolderSearch, Maximize2, Minimize2, Rows3, Search, X, Files, MessageSquare } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { cn } from "@/lib/utils";
@@ -24,6 +24,8 @@ interface DiffToolbarProps {
   canGoNext?: boolean;
   mobileChromeCollapsed?: boolean;
   onOpenComposer?: () => void;
+  isFullScreen?: boolean;
+  onToggleFullScreen?: () => void;
 }
 
 export function DiffToolbar({
@@ -43,6 +45,8 @@ export function DiffToolbar({
   canGoNext = false,
   mobileChromeCollapsed = false,
   onOpenComposer,
+  isFullScreen = false,
+  onToggleFullScreen,
 }: DiffToolbarProps) {
   const [showSearch, setShowSearch] = useState(false);
   const searchInputRef = useRef<HTMLInputElement>(null);
@@ -251,6 +255,19 @@ export function DiffToolbar({
               Split
             </button>
           </div>
+
+          {onToggleFullScreen && (
+            <Button
+              variant="ghost"
+              size="sm"
+              className={cn("h-7 w-7 p-0", isFullScreen && "text-primary")}
+              onClick={onToggleFullScreen}
+              title={isFullScreen ? "Exit full screen (Esc)" : "Full screen"}
+              aria-label={isFullScreen ? "Exit full screen" : "Enter full screen"}
+            >
+              {isFullScreen ? <Minimize2 className="h-3.5 w-3.5" /> : <Maximize2 className="h-3.5 w-3.5" />}
+            </Button>
+          )}
 
           {onBrowseRepo && (
             <Button

--- a/frontend/src/components/code-review/keyboard-help-overlay.test.tsx
+++ b/frontend/src/components/code-review/keyboard-help-overlay.test.tsx
@@ -29,7 +29,8 @@ describe("KeyboardHelpOverlay", () => {
     render(<KeyboardHelpOverlay open={true} onClose={vi.fn()} />);
     expect(screen.getByText("Next / previous file")).toBeInTheDocument();
     expect(screen.getByText("Toggle file tree panel")).toBeInTheDocument();
-    expect(screen.getAllByText("Back to conversation")).toHaveLength(2); // m and Esc
+    expect(screen.getByText("Back to conversation")).toBeInTheDocument(); // m
+    expect(screen.getByText("Exit full screen, then back to conversation")).toBeInTheDocument(); // Esc
   });
 
   it("calls onClose when close button is clicked", async () => {

--- a/frontend/src/components/code-review/keyboard-help-overlay.tsx
+++ b/frontend/src/components/code-review/keyboard-help-overlay.tsx
@@ -19,7 +19,7 @@ const shortcuts = [
   { key: "s", action: "Split diff view" },
   { key: "e", action: "Toggle repository explorer" },
   { key: "m", action: "Back to conversation" },
-  { key: "Esc", action: "Back to conversation" },
+  { key: "Esc", action: "Exit full screen, then back to conversation" },
   { key: "?", action: "Show this help" },
 ];
 

--- a/frontend/src/components/code-review/review-diff-view.test.tsx
+++ b/frontend/src/components/code-review/review-diff-view.test.tsx
@@ -306,6 +306,14 @@ describe("ReviewDiffView", () => {
     expect(props.onBack).toHaveBeenCalled();
   });
 
+  it("exits full screen on Escape instead of leaving review mode", () => {
+    const props = defaultProps({ isFullScreen: true, onToggleFullScreen: vi.fn() });
+    render(<ReviewDiffView {...props} />);
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(props.onToggleFullScreen).toHaveBeenCalled();
+    expect(props.onBack).not.toHaveBeenCalled();
+  });
+
   it("does not call onBack on Escape when in explorer mode", () => {
     const props = defaultProps();
     render(<ReviewDiffView {...props} />);

--- a/frontend/src/components/code-review/review-diff-view.tsx
+++ b/frontend/src/components/code-review/review-diff-view.tsx
@@ -38,6 +38,8 @@ interface ReviewDiffViewProps {
   /** Search query for filtering diff content */
   diffSearchQuery: string;
   onDiffSearchChange: (q: string) => void;
+  isFullScreen?: boolean;
+  onToggleFullScreen?: () => void;
 }
 
 export const ReviewDiffView = memo(function ReviewDiffView({
@@ -59,6 +61,8 @@ export const ReviewDiffView = memo(function ReviewDiffView({
   isMobile = false,
   onOpenFileList,
   onOpenComposer,
+  isFullScreen = false,
+  onToggleFullScreen,
 }: ReviewDiffViewProps) {
   const diffPaneRef = useRef<DiffPaneHandle>(null);
   const skipNextScrollToFileRef = useRef(false);
@@ -101,12 +105,18 @@ export const ReviewDiffView = memo(function ReviewDiffView({
       }
       if (!explorerMode && !activeCommentLine && !showKeyboardHelp) {
         e.preventDefault();
-        onBack();
+        // Full screen is an extra layer on top of review mode, so Escape
+        // peels it off first; a second Escape exits review entirely.
+        if (isFullScreen && onToggleFullScreen) {
+          onToggleFullScreen();
+        } else {
+          onBack();
+        }
       }
     }
     document.addEventListener("keydown", handleEscape);
     return () => document.removeEventListener("keydown", handleEscape);
-  }, [explorerMode, activeCommentLine, showKeyboardHelp, onBack]);
+  }, [explorerMode, activeCommentLine, showKeyboardHelp, onBack, isFullScreen, onToggleFullScreen]);
 
   const handleViewModeChange = useCallback((mode: ViewMode) => {
     if (isMobile) return;
@@ -268,6 +278,8 @@ export const ReviewDiffView = memo(function ReviewDiffView({
           onViewModeChange={handleViewModeChange}
           isMobile={isMobile}
           mobileChromeCollapsed={mobileChromeCollapsed}
+          isFullScreen={isFullScreen}
+          onToggleFullScreen={isMobile ? undefined : onToggleFullScreen}
         />
         <div className="flex-1 flex items-center justify-center py-12">
           <div className="text-center space-y-2 max-w-[280px]">
@@ -303,6 +315,8 @@ export const ReviewDiffView = memo(function ReviewDiffView({
         canGoPrev={isMobile && activeFileIndex > 0}
         canGoNext={isMobile && activeFileIndex < files.length - 1}
         mobileChromeCollapsed={mobileChromeCollapsed}
+        isFullScreen={isFullScreen}
+        onToggleFullScreen={isMobile ? undefined : onToggleFullScreen}
       />
       <DiffPane
         ref={diffPaneRef}

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -47,6 +47,7 @@ export interface User {
 export interface UserSettings {
   coding_agent_model_default?: string;
   coding_agent_reasoning_defaults?: Partial<Record<"codex" | "claude_code", "low" | "medium" | "high" | "xhigh" | "max">>;
+  diff_viewer_full_screen?: boolean;
 }
 
 export interface ThreadMessageWindowMeta {

--- a/internal/models/user_settings.go
+++ b/internal/models/user_settings.go
@@ -10,6 +10,7 @@ import (
 type UserSettings struct {
 	CodingAgentModelDefault      string                        `json:"coding_agent_model_default,omitempty"`
 	CodingAgentReasoningDefaults map[AgentType]ReasoningEffort `json:"coding_agent_reasoning_defaults,omitempty"`
+	DiffViewerFullScreen         bool                          `json:"diff_viewer_full_screen,omitempty"`
 }
 
 // ParseUserSettings deserializes the JSONB settings column into UserSettings.

--- a/internal/models/user_settings_test.go
+++ b/internal/models/user_settings_test.go
@@ -33,6 +33,11 @@ func TestParseUserSettings(t *testing.T) {
 			},
 		},
 		{
+			name: "parses diff viewer full screen preference",
+			raw:  json.RawMessage(`{"diff_viewer_full_screen":true}`),
+			want: UserSettings{DiffViewerFullScreen: true},
+		},
+		{
 			name:    "rejects malformed json",
 			raw:     json.RawMessage(`{"coding_agent_reasoning_defaults":`),
 			wantErr: true,
@@ -88,6 +93,18 @@ func TestUserSettings_MarshalJSONB(t *testing.T) {
 		}).MarshalJSONB()
 		require.NoError(t, err, "MarshalJSONB should accept valid settings")
 		require.JSONEq(t, `{"coding_agent_model_default":"claude-opus-4-7","coding_agent_reasoning_defaults":{"claude_code":"max"}}`, string(raw), "MarshalJSONB should encode the settings document")
+	})
+
+	t.Run("omits diff viewer full screen when false", func(t *testing.T) {
+		t.Parallel()
+
+		raw, err := (UserSettings{DiffViewerFullScreen: false}).MarshalJSONB()
+		require.NoError(t, err, "MarshalJSONB should accept zero-value settings")
+		require.JSONEq(t, `{}`, string(raw), "MarshalJSONB should omit the default full screen preference")
+
+		raw, err = (UserSettings{DiffViewerFullScreen: true}).MarshalJSONB()
+		require.NoError(t, err, "MarshalJSONB should accept full screen preference")
+		require.JSONEq(t, `{"diff_viewer_full_screen":true}`, string(raw), "MarshalJSONB should encode the full screen preference")
 	})
 
 	t.Run("rejects invalid settings", func(t *testing.T) {


### PR DESCRIPTION
## What

- Adds a full screen toggle to the diff viewer toolbar in the session conversation view. It lifts the already-mounted review subtree into a fixed viewport overlay, so scroll position, comments, and search state survive toggling. Escape peels off full screen first; a second Escape exits review mode as before.
- Persists the choice as `diff_viewer_full_screen` on the existing `users.settings` JSONB column (new typed field on `UserSettings`, no migration needed — `omitempty` means false is stored as absent). The diff viewer reopens in your last-chosen mode across sessions and devices.
- Desktop-only: mobile review already fills the viewport, so the toggle is suppressed there.

## Why

The diff viewer only occupies the center column of the session view, which can be cramped for reviewing the full breadth of changes.

## Reviewer notes

- `PATCH /api/v1/auth/me/settings` replaces the whole settings document. The session-view toggle merges the cached `user.settings` before writing, and the coding-agent default mutations on the account settings page now carry `diff_viewer_full_screen` through their PATCH bodies — previously they would have silently wiped any settings field they weren't editing (latent bug for every future setting).
- The overlay sits at `z-40`, above the detail panel (`z-10`) and below dialogs/sheets/keyboard-help (`z-50`), which render inside the full screen subtree.
- There is deliberately no control on the settings page — the preference is remembered from the toolbar toggle itself.
- Updated the keyboard help overlay's Esc entry to reflect the new layering.

## Testing

- Go: model parse/marshal tests for the new field; `make lint`, `go build ./...`, handler tests green.
- Frontend: new tests for the toolbar toggle and Escape layering; full suite (210 files, 2200+ tests), `tsc --noEmit`, and eslint all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)