### PR TITLE
Clarify Mezmo connector setup and dataset location

### DIFF
--- a/frontend/src/app/(dashboard)/settings/integrations/page.test.tsx
+++ b/frontend/src/app/(dashboard)/settings/integrations/page.test.tsx
@@ -570,4 +570,26 @@ describe("IntegrationsPage", () => {
       "Use the API project slug from CircleCI. OAuth projects usually look like gh/org/repo; GitHub App projects can use a circleci/... slug.",
     );
   });
+
+  it("helps users find Mezmo service keys and datasets while connecting", async () => {
+    integrationsListMock.mockResolvedValueOnce({ data: [], meta: {} });
+
+    renderWithProviders(<IntegrationsPage />);
+
+    const user = userEvent.setup();
+    await user.click(await screen.findByRole("button", { name: "Connect Mezmo" }));
+
+    const dialog = await screen.findByRole("alertdialog", { name: "Connect Mezmo" });
+    expect(dialog).toHaveTextContent("Open Mezmo, select the right organization, then go to Settings > Organization > API Keys. Create a service key there so agents can query production logs.");
+    expect(within(dialog).getByRole("link", { name: "Open Mezmo" })).toHaveAttribute(
+      "href",
+      "https://app.mezmo.com/",
+    );
+
+    await user.hover(within(dialog).getByRole("button", { name: "Where to find the Mezmo dataset" }));
+
+    expect(await screen.findByRole("tooltip")).toHaveTextContent(
+      "In Mezmo Log Analysis, open Search, then use the dataset selector near the top of the log viewer. Copy that selected dataset name exactly. Leave blank to query across the default Mezmo scope.",
+    );
+  });
 });

--- a/frontend/src/app/(dashboard)/settings/integrations/page.tsx
+++ b/frontend/src/app/(dashboard)/settings/integrations/page.tsx
@@ -1247,18 +1247,18 @@ export default function IntegrationsPage() {
         title="Connect Mezmo"
         description={
           <>
-            Paste a Mezmo service key so agents can query your production logs.
-            Create one under{" "}
+            Open Mezmo, select the right organization, then go to Settings &gt;
+            Organization &gt; API Keys. Create a service key there so agents can query production logs.{" "}
             <a
-              href="https://app.mezmo.com/profile/api"
+              href="https://app.mezmo.com/"
               target="_blank"
               rel="noopener noreferrer"
               className="underline"
             >
-              Organization → API Keys
+              Open Mezmo
             </a>
-            . Base URL and dataset are optional — leave them blank to use the
-            Mezmo defaults.
+            . Base URL and dataset are optional; leave them blank to use the
+            default Mezmo search scope.
           </>
         }
         fields={[
@@ -1280,6 +1280,10 @@ export default function IntegrationsPage() {
             placeholder: "e.g. production",
             type: "text",
             optional: true,
+            tooltip: {
+              ariaLabel: "Where to find the Mezmo dataset",
+              content: "In Mezmo Log Analysis, open Search, then use the dataset selector near the top of the log viewer. Copy that selected dataset name exactly. Leave blank to query across the default Mezmo scope.",
+            },
           },
         ]}
         submitting={mezmoConnectMutation.isPending}


### PR DESCRIPTION
## Summary
- Reword the Mezmo connect dialog to point users to the stable Mezmo app entry point and the documented `Settings > Organization > API Keys` path
- Add a Dataset tooltip that explains where to find the dataset selector in Mezmo Log Analysis
- Add UI test coverage for the updated link text and dataset guidance

## Testing
- Added a focused UI test for the Mezmo connector dialog
- Verified the frontend with the existing unit/UI checks in the app