### PR TITLE
Implement 143-tools local install and team auth (design doc 96)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,6 @@ node_modules/
 # Claude local settings
 .claude/settings.local.json
 .claude/worktrees/
+
+# 143-tools CLI cross-compile output (make build-cli)
+dist/

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,20 @@ RUN --mount=type=cache,target=/go/pkg/mod \
     CGO_ENABLED=0 go build -o /bin/deploy-guardrail ./cmd/deploy-guardrail && \
     CGO_ENABLED=0 go build -o /bin/worker-deployctl ./cmd/worker-deployctl
 
+# Cross-compile the 143-tools CLI for laptop installs (darwin/linux ×
+# amd64/arm64) and generate the checksums.txt the installer verifies. Served
+# by the Go server from /opt/143/cli via /install.sh and /download/143-tools/*.
+# Keep the matrix in sync with `make build-cli` and cli_distribution.go.
+RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    mkdir -p /opt/143/cli && \
+    for platform in darwin/amd64 darwin/arm64 linux/amd64 linux/arm64; do \
+      GOOS=${platform%/*} GOARCH=${platform#*/} CGO_ENABLED=0 \
+      go build -trimpath -ldflags "-X github.com/assembledhq/143/internal/version.BuildSHA=${BUILD_SHA}" \
+        -o /opt/143/cli/143-tools-${platform%/*}-${platform#*/} ./cmd/tools; \
+    done && \
+    cd /opt/143/cli && sha256sum 143-tools-* > checksums.txt
+
 # Stage 2: Runtime
 FROM debian:bookworm-slim
 WORKDIR /app
@@ -41,6 +55,7 @@ COPY --from=go-builder /bin/migrate-coding-credentials-anthropic-split /bin/migr
 COPY --from=go-builder /bin/deploy-guardrail /bin/deploy-guardrail
 COPY --from=go-builder /bin/worker-deployctl /bin/worker-deployctl
 COPY --from=go-builder /app/migrations /migrations
+COPY --from=go-builder /opt/143/cli /opt/143/cli
 
 # Copy entrypoint and encrypted production secrets
 COPY docker-entrypoint.sh /docker-entrypoint.sh

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 SANDBOX_STAMP := sandbox/.build-stamp
 SANDBOX_SOURCES := sandbox/Dockerfile sandbox/versions.json
 
-.PHONY: dev dev-ngrok dev-local dev-frontend-only setup test test-race test-coverage test-pr test-coverage-diff test-main test-integration migrate-up migrate-down build frontend-dev frontend-lint frontend-typecheck frontend-check lint lint-bootstrap lint-schema lint-stores lint-tenancy hooks-install hooks-uninstall secrets-setup secrets-encrypt secrets-decrypt secrets-edit secrets-rotate provision-app provision-worker provision-workers provision-egress provision-db provision-logging provision-redis tailscale-enroll repair-deploy-sudoers repair-worker-host spin-down-worker deploy deploy-app deploy-worker deploy-worker-preflight deploy-db deploy-logging deploy-fleet logs logs-query setup-readonly-user db-psql db-query
+.PHONY: dev dev-ngrok dev-local dev-frontend-only setup test test-race test-coverage test-pr test-coverage-diff test-main test-integration migrate-up migrate-down build build-cli frontend-dev frontend-lint frontend-typecheck frontend-check lint lint-bootstrap lint-schema lint-stores lint-tenancy hooks-install hooks-uninstall secrets-setup secrets-encrypt secrets-decrypt secrets-edit secrets-rotate provision-app provision-worker provision-workers provision-egress provision-db provision-logging provision-redis tailscale-enroll repair-deploy-sudoers repair-worker-host spin-down-worker deploy deploy-app deploy-worker deploy-worker-preflight deploy-db deploy-logging deploy-fleet logs logs-query setup-readonly-user db-psql db-query
 
 GOLANGCI_LINT_VERSION ?= v2.10.1
 GOLANGCI_LINT_BIN := $(CURDIR)/bin/golangci-lint
@@ -161,6 +161,31 @@ build:
 	go build -ldflags "$(LDFLAGS)" -o bin/server ./cmd/server
 	go build -o bin/migrate ./cmd/migrate
 	go build -o bin/migrate-coding-credentials-anthropic-split ./cmd/migrate-coding-credentials-anthropic-split
+
+# Cross-compile the 143-tools CLI for laptop installs. Outputs to dist/cli/
+# plus a checksums.txt the installer script verifies against. The server
+# image bakes this directory in at /opt/143/cli (see Dockerfile) and serves
+# it from /download/143-tools/*. The platform matrix must stay in sync with
+# cliPlatforms in internal/api/handlers/cli_distribution.go.
+CLI_DIST_DIR := dist/cli
+CLI_PLATFORMS := darwin/amd64 darwin/arm64 linux/amd64 linux/arm64
+
+build-cli:
+	rm -rf $(CLI_DIST_DIR)
+	mkdir -p $(CLI_DIST_DIR)
+	@set -e; for platform in $(CLI_PLATFORMS); do \
+		os=$${platform%/*}; arch=$${platform#*/}; \
+		echo "building $(CLI_DIST_DIR)/143-tools-$$os-$$arch"; \
+		CGO_ENABLED=0 GOOS=$$os GOARCH=$$arch \
+			go build -trimpath -ldflags "$(LDFLAGS)" \
+			-o $(CLI_DIST_DIR)/143-tools-$$os-$$arch ./cmd/tools; \
+	done
+	@cd $(CLI_DIST_DIR) && if command -v sha256sum >/dev/null 2>&1; then \
+		sha256sum 143-tools-* > checksums.txt; \
+	else \
+		shasum -a 256 143-tools-* > checksums.txt; \
+	fi
+	@echo "wrote $(CLI_DIST_DIR)/checksums.txt"
 
 frontend-dev:
 	cd frontend && npm run dev

--- a/cmd/tools/main.go
+++ b/cmd/tools/main.go
@@ -1,13 +1,20 @@
 // Command 143-tools provides CLI access to integration tools (Sentry, Linear,
-// Notion, Slack) and to sandbox-internal helpers (git credential helper, gh
+// Notion, Slack), to sandbox-internal helpers (git credential helper, gh
 // token wrapper, post-clone bootstrap) for coding agents running inside
-// sandboxes.
+// sandboxes, and — on laptops — to the 143 server itself via browser login.
 //
-// Usage (integration tools):
+// Usage (integration tools — direct mode in sandboxes, server-proxied on
+// logged-in laptops; backend selected automatically):
 //
-//	SENTRY_AUTH_TOKEN=... LINEAR_ACCESS_TOKEN=... 143-tools <namespace> <action> [--flag value ...]
 //	143-tools sentry list_errors --severity high --limit 10
 //	143-tools --help
+//
+// Usage (laptop):
+//
+//	143-tools login [--server URL] [--join TOKEN] [--no-browser]
+//	143-tools whoami | logout | update
+//	143-tools preview create --wait
+//	143-tools mcp serve                    # stdio MCP gateway for local agents
 //
 // Usage (sandbox infrastructure — invoked by git/gh/orchestrator, not the agent):
 //
@@ -17,19 +24,9 @@
 package main
 
 import (
-	"os"
-
-	"github.com/assembledhq/143/internal/services/mcp"
-	"github.com/assembledhq/143/internal/services/sandboxauth"
+	"github.com/assembledhq/143/internal/cli"
 )
 
 func main() {
-	// Sandbox-side subcommands are dispatched first so they don't get
-	// confused with integration tool names. They have no overlap with the
-	// agent-facing namespaces, but explicit dispatch is clearer than relying
-	// on naming convention.
-	if handled, code := sandboxauth.HandleSubcommand(os.Args[1:], os.Stdin, os.Stdout, os.Stderr); handled {
-		os.Exit(code)
-	}
-	mcp.MainCLI()
+	cli.Main()
 }

--- a/deploy/Caddyfile
+++ b/deploy/Caddyfile
@@ -139,6 +139,37 @@ www.{$DOMAIN:143.dev} {
 			}
 		}
 	}
+	# 143-tools CLI distribution. These routes are served by the Go server
+	# (not the Next.js frontend) but live outside /api because they are
+	# fetched by `curl | sh`, not the JSON API client. Must appear before the
+	# bare frontend fallthrough below. Self-hosters with their own proxy need
+	# the same rules — see docs/design for the install flow.
+	@cli_dist path /install.sh /install/* /download/*
+	handle @cli_dist {
+		handle @safe {
+			reverse_proxy {
+				dynamic a {
+					name api
+					port 8080
+					refresh 2s
+				}
+				lb_retries 5
+				import upstream_defaults
+			}
+		}
+		handle {
+			reverse_proxy {
+				dynamic a {
+					name api
+					port 8080
+					refresh 2s
+				}
+				lb_retries 0
+				import upstream_defaults
+			}
+		}
+	}
+
 	handle {
 		handle @safe {
 			reverse_proxy {

--- a/deploy/deploy_config_test.go
+++ b/deploy/deploy_config_test.go
@@ -127,6 +127,41 @@ func TestPreviewWildcardTLSUsesCloudflareDNSChallenge(t *testing.T) {
 	require.Contains(t, string(provisionScript), "NEXT_PUBLIC_PREVIEW_ORIGIN_TEMPLATE=%s", "fresh app provisioning should project the frontend preview-origin fallback into /opt/143/.env on the app host")
 }
 
+// TestCLIDistributionRoutesProxyToAPI pins the Caddyfile rules that send the
+// 143-tools installer and download routes to the Go server instead of the
+// Next.js frontend fallthrough. Without these, `curl https://143.com/install.sh`
+// would return the frontend's 404 page — the install one-liner depends on it.
+func TestCLIDistributionRoutesProxyToAPI(t *testing.T) {
+	t.Parallel()
+
+	caddyfile, err := os.ReadFile("../deploy/Caddyfile")
+	require.NoError(t, err, "test should read the Caddyfile")
+	caddyText := string(caddyfile)
+
+	// Anchor to the line-start occurrence: the www. and *.preview. site
+	// headers contain "{$DOMAIN:143.dev}" as a substring and appear first.
+	mainStart := strings.Index(caddyText, "\n{$DOMAIN:143.dev} {")
+	require.NotEqual(t, -1, mainStart, "Caddyfile should contain the main site block")
+	mainBlock := extractCaddySiteBlock(t, caddyText[mainStart:], "{$DOMAIN:143.dev}")
+	require.Contains(t, mainBlock, "@cli_dist path /install.sh /install/* /download/*",
+		"main site block should match the CLI installer and download paths")
+	require.Contains(t, mainBlock, "handle @cli_dist",
+		"main site block should have an explicit handle for CLI distribution routes")
+
+	cliDistIndex := strings.Index(mainBlock, "handle @cli_dist")
+	apiIndex := strings.Index(mainBlock, "handle /api/*")
+	frontendFallthroughIndex := strings.LastIndex(mainBlock, "\thandle {")
+	require.NotEqual(t, -1, cliDistIndex, "handle @cli_dist must exist in the main site block")
+	require.NotEqual(t, -1, apiIndex, "handle /api/* must exist in the main site block")
+	require.NotEqual(t, -1, frontendFallthroughIndex, "frontend fallthrough handle must exist in the main site block")
+	require.Less(t, cliDistIndex, frontendFallthroughIndex,
+		"CLI distribution handle must appear before the frontend fallthrough, or Caddy routes installs to Next.js")
+
+	cliDistBlock := mainBlock[cliDistIndex:frontendFallthroughIndex]
+	require.Contains(t, cliDistBlock, "name api", "CLI distribution routes must proxy to the api upstream")
+	require.Contains(t, cliDistBlock, "port 8080", "CLI distribution routes must target the main API port")
+}
+
 func TestPreviewWildcardProxyDoesNotUseMainAppPassiveHealth(t *testing.T) {
 	t.Parallel()
 

--- a/docs/design/implemented/96-cli-local-install-and-team-auth.md
+++ b/docs/design/implemented/96-cli-local-install-and-team-auth.md
@@ -1,6 +1,34 @@
 # Design: 143-tools Local Install & Team Auth
 
-> **Status:** Not Started | **Last reviewed:** 2026-06-09
+> **Status:** Implemented | **Last reviewed:** 2026-06-09
+
+## Implementation notes (2026-06-09)
+
+All four phases shipped. Deltas from the text below:
+
+- **Migration numbers**: 000164 was taken by the Mezmo integration while this
+  doc was in review, so the Phase 2 tables landed as `000165_cli_auth` and
+  Phase 3 as `000166_org_join_tokens`.
+- **Version-skew enforcement**: `/api/v1/cli/version` + the 426
+  `CLI_UPDATE_REQUIRED` gate (`middleware.CLIVersionGate`) are implemented;
+  enforcement engages only when `CLI_MIN_SUPPORTED_VERSION` is set to an
+  orderable version. Git-SHA builds (the current default for
+  `version.BuildSHA`) are never blocked — comparing SHAs is meaningless. The
+  CLI's "newer CLI available" hint compares against `/api/v1/cli/version`
+  during `whoami`/`update` rather than reading a header off every response.
+- **Per-token join rate limiting**: no dedicated limiter was added. Join
+  validation only ever runs inside the GitHub OAuth callback (a full OAuth
+  round-trip with a state cookie per attempt) behind the global per-IP rate
+  limiter, which throttles enumeration harder than a per-token bucket would.
+- **Secret scanning**: the repo runs no secret scanner today; the `143u_`/
+  `143j_` patterns are documented in `docs/guides/cli-install.md` for teams
+  that do, and the sandbox log-redaction layer strips both shapes.
+- **Key files**: distribution `internal/api/handlers/cli_distribution.go`
+  (+ `assets/install.sh.tmpl`); login flow `internal/api/handlers/auth_cli.go`;
+  gateway `internal/api/handlers/cli_tools.go` +
+  `internal/services/mcp/org_registry.go`; laptop CLI `internal/cli/`;
+  stores `internal/db/{user_cli_tokens,cli_auth_codes,org_join_tokens}.go`;
+  UI `frontend/src/components/cli-{join-tokens,sessions}-card.tsx`.
 
 ## Goal
 

--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -6,6 +6,7 @@ How-tos for people using 143 to act on their repos. These apply whether you're u
 
 - **[Repo config](repo-config.md)** — set up `.143/config.json`, understand each top-level section, and use the field reference at the bottom of the guide.
 - **[Preview environments](previews.md)** — configure `.143/config.json` so 143 can serve a live iframed preview of your app from inside a session.
+- **[CLI install](cli-install.md)** — install `143-tools` on your laptop, log in with GitHub, and wire your local coding agents to the org's integrations.
 
 ---
 

--- a/docs/guides/cli-install.md
+++ b/docs/guides/cli-install.md
@@ -1,0 +1,76 @@
+# Installing the 143-tools CLI
+
+`143-tools` is the laptop-side companion to 143: one binary that logs into
+your 143 server with GitHub, exposes every integration your org has
+connected to your local coding agents (via MCP or shell commands), and
+drives previews from your checkout.
+
+## Install
+
+Ask an org admin for the install link (Settings → Team → CLI install links),
+or use the tokenless form if you already have a 143 account:
+
+```bash
+# With a join link (also creates your account + org membership on first login):
+curl -fsSL https://YOUR-SERVER/install/143j_XXXXXXXX | sh
+
+# Tokenless (existing users, new laptop):
+curl -fsSL https://YOUR-SERVER/install.sh | sh
+```
+
+The installer detects your OS/arch (darwin/linux × amd64/arm64), verifies
+the binary checksum, installs to `~/.local/bin/143-tools`, writes
+`~/.config/143-tools/config.json` with the server URL baked in, and chains
+straight into `143-tools login` — your browser opens for GitHub sign-in as
+the install finishes.
+
+## Day-2 commands
+
+```bash
+143-tools whoami                  # user, org, role, token prefix, server
+143-tools logout                  # revokes this device's token server-side
+143-tools update                  # re-download the binary from the server
+143-tools preview create --wait   # repo/branch inferred from the cwd → prints the preview URL
+```
+
+## Local agent gateway
+
+Register the CLI as an MCP server with your coding agent:
+
+```bash
+claude mcp add 143 -- 143-tools mcp serve
+```
+
+Every integration tool the org has connected (Sentry, Linear, Notion,
+CircleCI, Mezmo, previews, ...) becomes available to the agent. Tool calls
+execute on the 143 server with org credentials — no provider tokens ever
+land on your machine — and each call is audited per-user. Agents that
+prefer shell tools can also invoke `143-tools <namespace> <action>`
+directly; both paths share the same backend.
+
+## Self-hosting note: reverse-proxy rules
+
+The install and download routes are served by the Go API server but live
+outside `/api`. The bundled production Caddyfile already routes them; if
+you run your own proxy, send these paths to the API upstream (before any
+frontend fallthrough), HTTPS-only:
+
+```text
+/install.sh   → api:8080
+/install/*    → api:8080
+/download/*   → api:8080
+```
+
+Also make sure your proxy/access logs redact the `/install/{token}` path
+segment — the join token deliberately rides in the URL.
+
+## Token hygiene
+
+- Join tokens (`143j_...`) grant org membership only — never API access.
+  They are multi-use, revocable one-click from the Team settings page, and
+  support optional expiry / max-uses.
+- CLI tokens (`143u_...`) are per-user, per-device, stored hashed, and have
+  a 90-day sliding expiry. Revoke a device from Settings → My settings →
+  CLI sessions.
+- If you run secret scanning (gitleaks, GitHub custom patterns), register
+  the patterns `143u_[A-Za-z0-9_-]{8,}` and `143j_[A-Za-z0-9]{12,64}`.

--- a/docs/self-hosting/README.md
+++ b/docs/self-hosting/README.md
@@ -9,5 +9,6 @@ For general usage docs that apply regardless of who's hosting, see [`../guides/`
 - **[GitHub App setup](github-app-setup.md)** — create your own GitHub OAuth App + GitHub App and wire them into your deployment.
 - **[Production deployment checklist](production-deployment-checklist.md)** — minimum steps to deploy the 143 backend + frontend in production.
 - **[Platform LLM](platform-llm.md)** — configure the small background-features model (session titles, PR descriptions, validation, prioritization).
+- **[CLI install](../guides/cli-install.md#self-hosting-note-reverse-proxy-rules)** — reverse-proxy rules for the `143-tools` installer/download routes (only needed if you replace the bundled Caddyfile).
 
 For local development (running 143 on your laptop while working on the codebase), see [`../local-development.md`](../local-development.md) instead.

--- a/frontend/src/app/(dashboard)/settings/account/page.tsx
+++ b/frontend/src/app/(dashboard)/settings/account/page.tsx
@@ -9,6 +9,7 @@ import { apiKeyHelp, PERSONAL_PROVIDER_OPTIONS, personalProviderToAgent, type Pe
 import { captureError } from "@/lib/errors";
 import { APIKeyHelpTooltip } from "@/components/api-key-help-tooltip";
 import { ClaudeCodeAuthModal } from "@/components/claude-code-auth-modal";
+import { CLISessionsCard } from "@/components/cli-sessions-card";
 import { CodexDeviceCodeModal } from "@/components/codex-device-code-modal";
 import { CodingAuthDialog } from "@/components/coding-auth-dialog";
 import { EmptyState } from "@/components/empty-state";
@@ -468,6 +469,8 @@ export default function AccountPage() {
             />
           </CardContent>
         </Card>
+
+        <CLISessionsCard />
 
         <Card>
           <CardHeader>

--- a/frontend/src/app/(dashboard)/settings/team/page.tsx
+++ b/frontend/src/app/(dashboard)/settings/team/page.tsx
@@ -38,6 +38,7 @@ import {
 } from "@/components/ui/command";
 import { PageHeader } from "@/components/page-header";
 import { PageContainer } from "@/components/page-container";
+import { CLIJoinTokensCard } from "@/components/cli-join-tokens-card";
 import { useAuth } from "@/hooks/use-auth";
 import { AuditLogTrigger } from "@/components/audit/audit-log-trigger";
 import { roleLabel } from "@/lib/roles";
@@ -511,6 +512,9 @@ export default function TeamSettingsPage() {
           </Card>
         </section>
       )}
+
+      {/* CLI install links (admin-only: creating one hands out membership) */}
+      {canManageTeam && <CLIJoinTokensCard />}
 
       {/* Invite Member Dialog */}
       {canManageTeam && (

--- a/frontend/src/components/cli-join-tokens-card.tsx
+++ b/frontend/src/components/cli-join-tokens-card.tsx
@@ -1,0 +1,211 @@
+"use client";
+
+import { useState } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { Check, Copy, Terminal } from "lucide-react";
+import { api } from "@/lib/api";
+import { captureError } from "@/lib/errors";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  AlertDialog,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import { roleLabel } from "@/lib/roles";
+import type { CreatedJoinToken, JoinToken, ListResponse } from "@/lib/types";
+
+function statusBadge(status: JoinToken["status"]) {
+  if (status === "active") {
+    return <Badge variant="outline" className="ml-2">active</Badge>;
+  }
+  return (
+    <Badge variant="secondary" className="ml-2 text-muted-foreground">
+      {status}
+    </Badge>
+  );
+}
+
+// CLIJoinTokensCard is the admin "CLI install link" surface on the Members
+// settings page: create a join link, copy the one-liner, list and revoke
+// active links. The plaintext token is only available in the create
+// response, so the copy affordance lives in the post-create dialog.
+export function CLIJoinTokensCard() {
+  const queryClient = useQueryClient();
+  const [name, setName] = useState("");
+  const [role, setRole] = useState("member");
+  const [created, setCreated] = useState<CreatedJoinToken | null>(null);
+  const [copied, setCopied] = useState(false);
+  const [error, setError] = useState("");
+
+  const { data } = useQuery<ListResponse<JoinToken>>({
+    queryKey: ["cli", "join-tokens"],
+    queryFn: () => api.cli.listJoinTokens(),
+  });
+  const tokens = data?.data ?? [];
+
+  const createMutation = useMutation({
+    mutationFn: () =>
+      api.cli.createJoinToken({ name: name.trim() || undefined, role }),
+    onSuccess: (resp) => {
+      setCreated(resp.data);
+      setName("");
+      setError("");
+      void queryClient.invalidateQueries({ queryKey: ["cli", "join-tokens"] });
+    },
+    onError: (err) => {
+      captureError(err);
+      setError("Failed to create the install link.");
+    },
+  });
+
+  const revokeMutation = useMutation({
+    mutationFn: (id: string) => api.cli.revokeJoinToken(id),
+    onSuccess: () =>
+      queryClient.invalidateQueries({ queryKey: ["cli", "join-tokens"] }),
+    onError: (err) => {
+      captureError(err);
+      setError("Failed to revoke the install link.");
+    },
+  });
+
+  const copyInstallCommand = async () => {
+    if (!created) return;
+    try {
+      await navigator.clipboard.writeText(created.install_command);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch (err) {
+      captureError(err);
+    }
+  };
+
+  return (
+    <section className="space-y-3">
+      <div className="flex items-center gap-1.5">
+        <Terminal className="size-3.5 text-muted-foreground" />
+        <h2 className="text-xs font-medium text-foreground">CLI install links</h2>
+      </div>
+      <p className="text-xs text-muted-foreground">
+        Anyone with this link can install 143-tools and join this org by
+        signing in with GitHub — one command, no pre-registration. Share it in
+        Slack; revoke it here any time.
+      </p>
+      {error && (
+        <div className="rounded-md bg-destructive/10 px-3 py-2 text-xs text-destructive">
+          {error}
+        </div>
+      )}
+      <Card>
+        <CardContent className="space-y-3 p-4">
+          <div className="flex flex-col gap-2 sm:flex-row sm:items-end">
+            <div className="flex-1 space-y-1.5">
+              <Label htmlFor="join-token-name">Link name</Label>
+              <Input
+                id="join-token-name"
+                placeholder="Eng team link, June 2026"
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+              />
+            </div>
+            <div className="space-y-1.5">
+              <Label>Role granted</Label>
+              <Select value={role} onValueChange={setRole}>
+                <SelectTrigger className="w-full sm:w-32">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="member">Member</SelectItem>
+                  <SelectItem value="builder">Builder</SelectItem>
+                  <SelectItem value="viewer">Viewer</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+            <Button
+              size="sm"
+              disabled={createMutation.isPending}
+              onClick={() => createMutation.mutate()}
+            >
+              Create link
+            </Button>
+          </div>
+
+          {tokens.length > 0 && (
+            <div className="divide-y divide-border rounded-md border">
+              {tokens.map((token) => (
+                <div
+                  key={token.id}
+                  className="flex flex-col gap-2 px-3 py-2 sm:flex-row sm:items-center sm:justify-between"
+                >
+                  <div className="min-w-0">
+                    <div className="flex items-center text-xs font-medium">
+                      <span className="truncate">
+                        {token.name || `${token.token_prefix}…`}
+                      </span>
+                      {statusBadge(token.status)}
+                    </div>
+                    <div className="text-xs text-muted-foreground">
+                      <code>{token.token_prefix}…</code> · grants{" "}
+                      {roleLabel(token.role)} · used {token.use_count}
+                      {token.max_uses != null ? ` of ${token.max_uses}` : ""}{" "}
+                      times
+                    </div>
+                  </div>
+                  {token.status === "active" && (
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      className="text-destructive hover:text-destructive"
+                      disabled={revokeMutation.isPending}
+                      onClick={() => revokeMutation.mutate(token.id)}
+                    >
+                      Revoke
+                    </Button>
+                  )}
+                </div>
+              ))}
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      <AlertDialog open={created !== null} onOpenChange={(open) => !open && setCreated(null)}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Install link created</AlertDialogTitle>
+            <AlertDialogDescription>
+              Copy the one-liner below and share it with your team. The full
+              link is shown only once — after this dialog closes, only its
+              prefix remains visible.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <div className="flex items-center gap-2">
+            <code className="block flex-1 overflow-x-auto whitespace-nowrap rounded-md bg-muted px-3 py-2 text-xs">
+              {created?.install_command}
+            </code>
+            <Button variant="outline" size="sm" onClick={copyInstallCommand}>
+              {copied ? <Check className="size-3.5" /> : <Copy className="size-3.5" />}
+            </Button>
+          </div>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Done</AlertDialogCancel>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </section>
+  );
+}

--- a/frontend/src/components/cli-sessions-card.tsx
+++ b/frontend/src/components/cli-sessions-card.tsx
@@ -1,0 +1,99 @@
+"use client";
+
+import { useState } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { Laptop } from "lucide-react";
+import { api } from "@/lib/api";
+import { captureError } from "@/lib/errors";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import type { CliToken, ListResponse } from "@/lib/types";
+
+function formatWhen(value?: string | null): string {
+  if (!value) return "never";
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return "unknown";
+  return date.toLocaleString();
+}
+
+// CLISessionsCard lists the user's own 143-tools device tokens (one per
+// laptop, minted by `143-tools login`) with revoke. Lives on the account
+// settings page; revoking a device instantly cuts its local agents off from
+// every integration.
+export function CLISessionsCard() {
+  const queryClient = useQueryClient();
+  const [error, setError] = useState("");
+
+  const { data, isLoading } = useQuery<ListResponse<CliToken>>({
+    queryKey: ["cli", "tokens"],
+    queryFn: () => api.cli.listCliTokens(),
+  });
+  const tokens = data?.data ?? [];
+
+  const revokeMutation = useMutation({
+    mutationFn: (id: string) => api.cli.revokeCliToken(id),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ["cli", "tokens"] }),
+    onError: (err) => {
+      captureError(err);
+      setError("Failed to revoke the CLI session.");
+    },
+  });
+
+  return (
+    <section className="space-y-3">
+      <div className="flex items-center gap-1.5">
+        <Laptop className="size-3.5 text-muted-foreground" />
+        <h2 className="text-xs font-medium text-foreground">CLI sessions</h2>
+      </div>
+      <p className="text-xs text-muted-foreground">
+        Devices logged in with <code>143-tools login</code>. Revoking a device
+        signs its CLI out and cuts its local agents off immediately.
+      </p>
+      {error && (
+        <div className="rounded-md bg-destructive/10 px-3 py-2 text-xs text-destructive">
+          {error}
+        </div>
+      )}
+      <Card>
+        <CardContent className="p-0">
+          {isLoading ? (
+            <div className="px-4 py-3 text-xs text-muted-foreground">Loading…</div>
+          ) : tokens.length === 0 ? (
+            <div className="px-4 py-3 text-xs text-muted-foreground">
+              No CLI sessions. Install 143-tools and run{" "}
+              <code>143-tools login</code> to add one.
+            </div>
+          ) : (
+            <div className="divide-y divide-border">
+              {tokens.map((token) => (
+                <div
+                  key={token.id}
+                  className="flex flex-col gap-2 px-4 py-3 sm:flex-row sm:items-center sm:justify-between"
+                >
+                  <div className="min-w-0">
+                    <div className="truncate text-xs font-medium">
+                      {token.device_name || "Unknown device"}
+                    </div>
+                    <div className="text-xs text-muted-foreground">
+                      <code>{token.token_prefix}…</code> · last used{" "}
+                      {formatWhen(token.last_used_at)}
+                    </div>
+                  </div>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    className="text-destructive hover:text-destructive sm:ml-4"
+                    disabled={revokeMutation.isPending}
+                    onClick={() => revokeMutation.mutate(token.id)}
+                  >
+                    Revoke
+                  </Button>
+                </div>
+              ))}
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    </section>
+  );
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -876,6 +876,18 @@ export const api = {
         `/api/v1/team/github/users?q=${encodeURIComponent(q)}`,
       ),
   },
+  cli: {
+    // Org join links for the `curl .../install/<token> | sh` onboarding flow (admin-only).
+    listJoinTokens: () =>
+      get<import('./types').ListResponse<import('./types').JoinToken>>('/api/v1/org/join-tokens'),
+    createJoinToken: (body: { name?: string; role?: string; max_uses?: number; expires_in_days?: number }) =>
+      post<import('./types').SingleResponse<import('./types').CreatedJoinToken>>('/api/v1/org/join-tokens', body),
+    revokeJoinToken: (id: string) => del<void>(`/api/v1/org/join-tokens/${id}`),
+    // The caller's own CLI device tokens (any authenticated user).
+    listCliTokens: () =>
+      get<import('./types').ListResponse<import('./types').CliToken>>('/api/v1/auth/cli-tokens'),
+    revokeCliToken: (id: string) => del<void>(`/api/v1/auth/cli-tokens/${id}`),
+  },
   projects: {
     list: (params?: { status?: string; cursor?: string; limit?: number; repository_id?: string; search?: string; proposed_by_pm?: boolean; created_by?: string; created_by_ids?: string[]; include_archived?: boolean; only_archived?: boolean }) => {
       const searchParams = new URLSearchParams();

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -1267,6 +1267,46 @@ export interface InvitationResponse {
   created_at: string;
 }
 
+// JoinToken is a multi-use, revocable org join link backing the CLI install
+// one-liner (`curl .../install/<token> | sh`). Only the display prefix is
+// ever returned after creation.
+export interface JoinToken {
+  id: string;
+  token_prefix: string;
+  name: string;
+  role: string;
+  max_uses?: number | null;
+  use_count: number;
+  expires_at?: string | null;
+  status: 'active' | 'revoked' | 'expired' | 'exhausted';
+  created_at: string;
+}
+
+// CreatedJoinToken is the create response: the plaintext token and the
+// ready-to-paste install command, shown exactly once.
+export interface CreatedJoinToken {
+  id: string;
+  token: string;
+  token_prefix: string;
+  role: string;
+  name: string;
+  expires_at?: string | null;
+  max_uses?: number | null;
+  install_command: string;
+}
+
+// CliToken is one row in the user's own "CLI sessions" list — a per-device
+// credential minted by `143-tools login`.
+export interface CliToken {
+  id: string;
+  token_prefix: string;
+  device_name: string;
+  expires_at: string;
+  last_used_at?: string | null;
+  last_used_ip?: string | null;
+  created_at: string;
+}
+
 // PendingInvitationForUser is the invitee-facing shape: the recipient of an
 // invitation only needs to know which org they're being invited into, by whom,
 // at what role, and when it expires. The token is intentionally omitted —

--- a/internal/api/handlers/assets/install.sh.tmpl
+++ b/internal/api/handlers/assets/install.sh.tmpl
@@ -1,0 +1,92 @@
+#!/bin/sh
+# 143-tools installer — served by the 143 server with the server URL (and an
+# optional org join token) templated in, so there is nothing to configure
+# after `| sh`.
+#
+# The entire body is wrapped in a function invoked on the last line: a
+# connection that drops mid-download executes nothing rather than half a
+# script.
+set -eu
+
+main() {
+	SERVER_URL='{{.ServerURL}}'
+	JOIN_TOKEN='{{.JoinToken}}'
+
+	os=$(uname -s)
+	arch=$(uname -m)
+	case "$os" in
+		Darwin) os=darwin ;;
+		Linux) os=linux ;;
+		*) echo "143-tools: unsupported OS: $os (darwin and linux only)" >&2; exit 1 ;;
+	esac
+	case "$arch" in
+		x86_64 | amd64) arch=amd64 ;;
+		arm64 | aarch64) arch=arm64 ;;
+		*) echo "143-tools: unsupported architecture: $arch (amd64 and arm64 only)" >&2; exit 1 ;;
+	esac
+
+	tmp=$(mktemp -d)
+	trap 'rm -rf "$tmp"' EXIT
+
+	echo "Downloading 143-tools ($os/$arch) from $SERVER_URL ..."
+	curl -fsSL "$SERVER_URL/download/143-tools/$os/$arch" -o "$tmp/143-tools"
+	curl -fsSL "$SERVER_URL/download/143-tools/checksums.txt" -o "$tmp/checksums.txt"
+
+	expected=$(awk -v f="143-tools-$os-$arch" '$2 == f || $2 == "*" f { print $1 }' "$tmp/checksums.txt")
+	if [ -z "$expected" ]; then
+		echo "143-tools: no checksum for 143-tools-$os-$arch in checksums.txt" >&2
+		exit 1
+	fi
+	if command -v sha256sum >/dev/null 2>&1; then
+		actual=$(sha256sum "$tmp/143-tools" | awk '{ print $1 }')
+	else
+		actual=$(shasum -a 256 "$tmp/143-tools" | awk '{ print $1 }')
+	fi
+	if [ "$actual" != "$expected" ]; then
+		echo "143-tools: checksum mismatch (expected $expected, got $actual)" >&2
+		exit 1
+	fi
+
+	chmod +x "$tmp/143-tools"
+	bin_dir="$HOME/.local/bin"
+	if mkdir -p "$bin_dir" 2>/dev/null && [ -w "$bin_dir" ]; then
+		mv "$tmp/143-tools" "$bin_dir/143-tools"
+	else
+		bin_dir="/usr/local/bin"
+		echo "~/.local/bin is not writable — installing to $bin_dir (sudo may prompt) ..."
+		sudo mv "$tmp/143-tools" "$bin_dir/143-tools"
+	fi
+	echo "Installed $bin_dir/143-tools"
+
+	case ":$PATH:" in
+		*":$bin_dir:"*) ;;
+		*) echo "NOTE: $bin_dir is not on your PATH — add it to your shell profile." ;;
+	esac
+
+	# Write (or merge into) ~/.config/143-tools/config.json. An existing
+	# login token for this server is preserved, so re-running the installer
+	# upgrades the binary in place.
+	if [ -n "$JOIN_TOKEN" ]; then
+		"$bin_dir/143-tools" setup --server "$SERVER_URL" --join "$JOIN_TOKEN"
+	else
+		"$bin_dir/143-tools" setup --server "$SERVER_URL"
+	fi
+
+	# Chain into login when a human is at the keyboard. Login waits on a
+	# loopback socket, not stdin, so running under `curl | sh` (stdin is the
+	# pipe) is fine — but CI and provisioning scripts get a hint instead.
+	# The probe OPENS /dev/tty rather than testing existence: on Linux the
+	# device node exists even in CI, but opening it fails without a
+	# controlling terminal.
+	if ! { : < /dev/tty; } 2>/dev/null; then
+		echo "No TTY detected — run '143-tools login' to authenticate."
+		return 0
+	fi
+	if "$bin_dir/143-tools" whoami --local >/dev/null 2>&1; then
+		echo "Already logged in to $SERVER_URL — run '143-tools whoami' to confirm."
+		return 0
+	fi
+	"$bin_dir/143-tools" login
+}
+
+main "$@"

--- a/internal/api/handlers/auth.go
+++ b/internal/api/handlers/auth.go
@@ -46,6 +46,13 @@ type AuthHandler struct {
 	// http.DefaultClient (production) or a locally-scoped client with a
 	// short timeout (the noreply-email probe).
 	httpClient *http.Client
+	// CLI login flow stores (see auth_cli.go). Nil unless wired via
+	// SetCLIAuthStores; the CLI endpoints fail with a configuration error
+	// and the OAuth callback skips its CLI branch in that case.
+	cliAuthCodes *db.CLIAuthCodeStore
+	cliTokens    *db.UserCLITokenStore
+	joinTokens   *db.OrgJoinTokenStore
+	orgStore     *db.OrganizationStore
 }
 
 // SetGitHubURLsForTest overrides the GitHub API and OAuth base URLs and
@@ -521,6 +528,11 @@ func (h *AuthHandler) Callback(w http.ResponseWriter, r *http.Request) {
 
 	// Account linking: try GitHub ID → email → create new.
 	pendingInvite := readAndClearPendingInvitationCookie(w, r)
+	// CLI login handshake + join token, set by /auth/cli/start. Both nil/""
+	// for ordinary web logins, in which case every branch below behaves
+	// exactly as before.
+	cliIntent := readAndClearCLILoginIntent(w, r)
+	pendingJoin := readAndClearPendingJoinCookie(w, r)
 
 	existingUser, err := h.userStore.GetByGitHubID(r.Context(), ghUser.ID)
 	if err == nil {
@@ -535,8 +547,16 @@ func (h *AuthHandler) Callback(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		h.claimPendingInvitationForExistingUser(r, pendingInvite, email, ghUser.Login, existingUser.ID)
+		// An existing user carrying a join token for an org they're not in
+		// gets the membership granted; already-a-member or a bad token is a
+		// no-op (matches ClaimInvitation's best-effort posture).
+		h.applyJoinTokenForExistingUser(r, pendingJoin, &existingUser)
 		h.storeGitHubToken(r, &existingUser, tokenResp)
 		h.emitAuthEvent(r, &existingUser, models.AuditActionAuthLogin)
+		if cliIntent != nil {
+			h.createSessionAndFinishCLILogin(w, r, &existingUser, cliIntent)
+			return
+		}
 		h.createSessionAndRedirect(w, r, &existingUser)
 		return
 	}
@@ -548,8 +568,13 @@ func (h *AuthHandler) Callback(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		h.claimPendingInvitationForExistingUser(r, pendingInvite, email, ghUser.Login, emailUser.ID)
+		h.applyJoinTokenForExistingUser(r, pendingJoin, &emailUser)
 		h.storeGitHubToken(r, &emailUser, tokenResp)
 		h.emitAuthEvent(r, &emailUser, models.AuditActionAuthLogin)
+		if cliIntent != nil {
+			h.createSessionAndFinishCLILogin(w, r, &emailUser, cliIntent)
+			return
+		}
 		h.createSessionAndRedirect(w, r, &emailUser)
 		return
 	}
@@ -586,11 +611,56 @@ func (h *AuthHandler) Callback(w http.ResponseWriter, r *http.Request) {
 			}
 			h.storeGitHubToken(r, createdUser, tokenResp)
 			h.emitAuthEvent(r, createdUser, models.AuditActionAuthRegister)
+			if cliIntent != nil {
+				h.finishCLILoginWithSession(w, r, createdUser, sessionToken, cliIntent)
+				return
+			}
 			h.redirectWithSession(w, r, sessionToken)
 			return
 		}
 		// Invalid invitation (wrong email, expired, etc.) — fall through to
 		// a default signup so the user isn't stranded.
+	}
+
+	// New user with a join token: JIT-provision them into the token's org.
+	// Unlike the invitation flow above, an invalid/exhausted token FAILS
+	// CLOSED — no user is created. A forgiving fallback would silently log
+	// the CLI into a fresh single-member org, which is strictly worse than
+	// the error for someone trying to join a team.
+	if pendingJoin != "" {
+		user := &models.User{
+			Email:              email,
+			Name:               displayName,
+			GitHubID:           &ghUser.ID,
+			GitHubLogin:        &ghUser.Login,
+			GitHubNoreplyEmail: &noreplyEmail,
+			AvatarURL:          &ghUser.AvatarURL,
+		}
+		createdUser, sessionToken, usedToken, joinErr, createErr := h.createJoinedUser(
+			r.Context(),
+			pendingJoin,
+			user,
+			func(ctx context.Context, userStore *db.UserStore, joinedUser *models.User) error {
+				return userStore.UpsertFromGitHub(ctx, joinedUser)
+			},
+		)
+		if createErr != nil {
+			writeError(w, r, http.StatusInternalServerError, "USER_UPSERT_FAILED", "failed to create account", createErr)
+			return
+		}
+		if joinErr != nil {
+			h.failCLILogin(w, r, cliIntent, joinErr.code, joinErr.message)
+			return
+		}
+		h.emitJoinTokenUsed(r, createdUser.ID, usedToken, string(createdUser.Role))
+		h.storeGitHubToken(r, createdUser, tokenResp)
+		h.emitAuthEvent(r, createdUser, models.AuditActionAuthRegister)
+		if cliIntent != nil {
+			h.finishCLILoginWithSession(w, r, createdUser, sessionToken, cliIntent)
+			return
+		}
+		h.redirectWithSession(w, r, sessionToken)
+		return
 	}
 
 	user := &models.User{
@@ -611,6 +681,10 @@ func (h *AuthHandler) Callback(w http.ResponseWriter, r *http.Request) {
 
 	h.storeGitHubToken(r, user, tokenResp)
 	h.emitAuthEvent(r, user, models.AuditActionAuthRegister)
+	if cliIntent != nil {
+		h.finishCLILoginWithSession(w, r, user, sessionToken, cliIntent)
+		return
+	}
 	h.redirectWithSession(w, r, sessionToken)
 }
 

--- a/internal/api/handlers/auth_cli.go
+++ b/internal/api/handlers/auth_cli.go
@@ -1,0 +1,597 @@
+package handlers
+
+import (
+	"context"
+	"crypto/sha256"
+	"crypto/subtle"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/rs/zerolog"
+
+	"github.com/assembledhq/143/internal/api/middleware"
+	"github.com/assembledhq/143/internal/db"
+	"github.com/assembledhq/143/internal/models"
+)
+
+// CLI login handshake cookies, set by CLIStart and consumed by the GitHub
+// OAuth callback. Same short-lived HttpOnly pattern as pending_invitation.
+const (
+	cliPortCookie      = "cli_port"
+	cliChallengeCookie = "cli_challenge"
+	cliDeviceCookie    = "cli_device"
+	pendingJoinCookie  = "pending_join"
+
+	cliCookieMaxAge = 600 // seconds; one OAuth round-trip with margin
+)
+
+// cliChallengePattern: the challenge is SHA-256(verifier) hex from the CLI.
+var cliChallengePattern = regexp.MustCompile(`^[0-9a-fA-F]{64}$`)
+
+// maxCLIDeviceNameLength caps the hostname the CLI sends at login.
+const maxCLIDeviceNameLength = 64
+
+// SetCLIAuthStores wires the stores backing the CLI login flow. The org
+// store is used to name the org in the exchange response ("Logged in as
+// @octocat (Acme Org)"); the join-token store powers JIT provisioning in
+// the OAuth callback.
+func (h *AuthHandler) SetCLIAuthStores(
+	authCodes *db.CLIAuthCodeStore,
+	cliTokens *db.UserCLITokenStore,
+	joinTokens *db.OrgJoinTokenStore,
+	orgs *db.OrganizationStore,
+) {
+	h.cliAuthCodes = authCodes
+	h.cliTokens = cliTokens
+	h.joinTokens = joinTokens
+	h.orgStore = orgs
+}
+
+// CLIStart begins the browser-based CLI login. It validates the loopback
+// port + PKCE-style challenge from the CLI, stashes them (plus the optional
+// join token and device name) in short-lived cookies, and redirects into
+// the existing GitHub OAuth Login handler. The browser carries the cookies
+// through GitHub and back to the callback, which closes the loop against
+// the CLI's loopback listener.
+func (h *AuthHandler) CLIStart(w http.ResponseWriter, r *http.Request) {
+	if h.cfg.DemoMode || h.cfg.GitHubOAuthClientID == "" {
+		writeError(w, r, http.StatusConflict, "GITHUB_OAUTH_DISABLED",
+			"CLI login requires GitHub OAuth, which is not enabled on this server")
+		return
+	}
+
+	port, err := strconv.Atoi(r.URL.Query().Get("port"))
+	if err != nil || port < 1024 || port > 65535 {
+		writeError(w, r, http.StatusBadRequest, "INVALID_CLI_PORT", "port must be an integer in [1024, 65535]")
+		return
+	}
+
+	challenge := strings.ToLower(strings.TrimSpace(r.URL.Query().Get("challenge")))
+	if !cliChallengePattern.MatchString(challenge) {
+		writeError(w, r, http.StatusBadRequest, "INVALID_CLI_CHALLENGE", "challenge must be 64 hex characters (SHA-256 of the verifier)")
+		return
+	}
+
+	device := sanitizeCLIDeviceName(r.URL.Query().Get("device"))
+
+	join := strings.TrimSpace(r.URL.Query().Get("join"))
+	if join != "" && !joinTokenPathPattern.MatchString(join) {
+		writeError(w, r, http.StatusBadRequest, "INVALID_JOIN_TOKEN", "join token is malformed")
+		return
+	}
+
+	setCLICookie(w, cliPortCookie, strconv.Itoa(port))
+	setCLICookie(w, cliChallengeCookie, challenge)
+	if device != "" {
+		setCLICookie(w, cliDeviceCookie, device)
+	}
+	if join != "" {
+		setCLICookie(w, pendingJoinCookie, join)
+	}
+
+	h.Login(w, r)
+}
+
+// cliLoginIntent is the CLI handshake state recovered from the cookies set
+// by CLIStart, present on the OAuth callback only for CLI-initiated logins.
+type cliLoginIntent struct {
+	port      int
+	challenge string
+	device    string
+}
+
+// loopbackURL builds the redirect target on the CLI's loopback listener.
+// Hardcodes 127.0.0.1 — never "localhost", which can resolve unexpectedly.
+func (i *cliLoginIntent) loopbackURL(query string) string {
+	return fmt.Sprintf("http://127.0.0.1:%d/callback?%s", i.port, query)
+}
+
+// readAndClearCLILoginIntent pops the CLI handshake cookies. Clearing is
+// unconditional so a stale aborted flow can't leak into the next web login.
+// Returns nil when this is not a CLI-initiated login or the cookie values
+// fail re-validation (cookies are client-controlled — never trust them more
+// than the query params they came from).
+func readAndClearCLILoginIntent(w http.ResponseWriter, r *http.Request) *cliLoginIntent {
+	portRaw := popCookie(w, r, cliPortCookie)
+	challenge := popCookie(w, r, cliChallengeCookie)
+	device := sanitizeCLIDeviceName(popCookie(w, r, cliDeviceCookie))
+	if portRaw == "" || challenge == "" {
+		return nil
+	}
+	port, err := strconv.Atoi(portRaw)
+	if err != nil || port < 1024 || port > 65535 || !cliChallengePattern.MatchString(challenge) {
+		return nil
+	}
+	return &cliLoginIntent{port: port, challenge: strings.ToLower(challenge), device: device}
+}
+
+// readAndClearPendingJoinCookie pops the pending_join cookie, re-applying
+// the syntactic gate (cookies are client-controlled).
+func readAndClearPendingJoinCookie(w http.ResponseWriter, r *http.Request) string {
+	join := popCookie(w, r, pendingJoinCookie)
+	if join == "" || !joinTokenPathPattern.MatchString(join) {
+		return ""
+	}
+	return join
+}
+
+// createSessionAndFinishCLILogin is the CLI-branch analogue of
+// createSessionAndRedirect: the user already exists, so the session is
+// created via the pool, then the loopback handoff completes the CLI login.
+func (h *AuthHandler) createSessionAndFinishCLILogin(w http.ResponseWriter, r *http.Request, user *models.User, intent *cliLoginIntent) {
+	sessionToken, err := h.persistSessionTx(r.Context(), h.pool, user)
+	if err != nil {
+		h.renderCLIErrorPage(w, r, "failed to create session — return to your terminal and retry `143-tools login`", err)
+		return
+	}
+	h.finishCLILoginWithSession(w, r, user, sessionToken, intent)
+}
+
+// finishCLILoginWithSession installs the normal web session + CSRF cookies
+// (the user just completed a full OAuth login — leaving them signed into
+// the web app too is free and expected), mints the one-time code, and
+// redirects the browser to the CLI's loopback listener. The browser never
+// sees the real token — only this short-lived code, which the CLI exchanges
+// together with its verifier via a direct POST.
+func (h *AuthHandler) finishCLILoginWithSession(w http.ResponseWriter, r *http.Request, user *models.User, sessionToken string, intent *cliLoginIntent) {
+	if !h.writeSessionAndCSRFCookies(w, r, sessionToken) {
+		return
+	}
+	if h.cliAuthCodes == nil {
+		h.renderCLIErrorPage(w, r, "CLI login is not configured on this server", errors.New("cli auth code store not wired"))
+		return
+	}
+
+	code, err := db.GenerateCLIAuthCode()
+	if err != nil {
+		h.renderCLIErrorPage(w, r, "failed to mint login code — return to your terminal and retry `143-tools login`", err)
+		return
+	}
+
+	authCode := &models.CLIAuthCode{
+		CodeHash:   db.HashCLIAuthCode(code),
+		Challenge:  intent.challenge,
+		UserID:     user.ID,
+		OrgID:      h.resolveCLILoginOrg(r.Context(), user.ID),
+		DeviceName: intent.device,
+		ExpiresAt:  time.Now().Add(db.CLIAuthCodeTTL),
+	}
+	if err := h.cliAuthCodes.Create(r.Context(), authCode); err != nil {
+		h.renderCLIErrorPage(w, r, "failed to persist login code — return to your terminal and retry `143-tools login`", err)
+		return
+	}
+
+	http.Redirect(w, r, intent.loopbackURL("code="+code), http.StatusTemporaryRedirect)
+}
+
+// resolveCLILoginOrg picks the org recorded on the auth-code row: the
+// user's persisted last org, falling back to their oldest membership —
+// the same chain sessions use. Nil for zero-membership users, who can
+// still complete login.
+func (h *AuthHandler) resolveCLILoginOrg(ctx context.Context, userID uuid.UUID) *uuid.UUID {
+	if h.userStore != nil {
+		if lastOrgID, err := h.userStore.GetLastOrgID(ctx, userID); err == nil && lastOrgID != nil {
+			if h.memberships != nil {
+				if _, err := h.memberships.Get(ctx, userID, *lastOrgID); err == nil {
+					return lastOrgID
+				}
+			}
+		}
+	}
+	if h.memberships != nil {
+		if m, err := h.memberships.OldestForUser(ctx, userID); err == nil {
+			orgID := m.OrgID
+			return &orgID
+		}
+	}
+	return nil
+}
+
+// failCLILogin reports a terminal CLI-login failure. With a live loopback
+// intent the browser is redirected to the CLI (which prints the message and
+// exits non-zero, and renders its own "return to terminal" page); without
+// one, a minimal server-rendered page is the fallback.
+func (h *AuthHandler) failCLILogin(w http.ResponseWriter, r *http.Request, intent *cliLoginIntent, code, message string) {
+	if intent != nil {
+		q := url.Values{"error": {code}, "message": {message}}
+		http.Redirect(w, r, intent.loopbackURL(q.Encode()), http.StatusTemporaryRedirect)
+		return
+	}
+	renderCLIMessagePage(w, http.StatusForbidden, message)
+}
+
+// renderCLIErrorPage logs the underlying failure and shows the browser a
+// terminal-shaped error page. Used when the loopback handoff itself cannot
+// proceed (we may not have a usable port to redirect to).
+func (h *AuthHandler) renderCLIErrorPage(w http.ResponseWriter, r *http.Request, message string, err error) {
+	zerolog.Ctx(r.Context()).Error().Err(err).Msg("cli login failed")
+	renderCLIMessagePage(w, http.StatusInternalServerError, message)
+}
+
+func renderCLIMessagePage(w http.ResponseWriter, status int, message string) {
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	w.WriteHeader(status)
+	// Template-free: message is composed of fixed server-side strings only.
+	fmt.Fprintf(w, `<!doctype html><meta charset="utf-8"><title>143 CLI login</title>
+<body style="font-family: system-ui, sans-serif; max-width: 40rem; margin: 4rem auto;">
+<h1 style="font-size:1.2rem">143 CLI login</h1><p>%s</p></body>`, message)
+}
+
+// CLIExchange swaps a one-time code + verifier for a personal CLI token.
+// Registered OUTSIDE the CSRF-wrapped auth group: the CLI has no CSRF
+// cookie/header, and the one-time code + verifier binding is a strictly
+// stronger anti-forgery guarantee than the double-submit cookie.
+func (h *AuthHandler) CLIExchange(w http.ResponseWriter, r *http.Request) {
+	if h.cliAuthCodes == nil || h.cliTokens == nil {
+		writeError(w, r, http.StatusInternalServerError, "CLI_AUTH_NOT_CONFIGURED", "CLI login is not configured on this server")
+		return
+	}
+
+	var body struct {
+		Code     string `json:"code"`
+		Verifier string `json:"verifier"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil || body.Code == "" || body.Verifier == "" {
+		writeError(w, r, http.StatusBadRequest, "INVALID_BODY", "code and verifier are required")
+		return
+	}
+
+	authCode, err := h.cliAuthCodes.Consume(r.Context(), db.HashCLIAuthCode(body.Code))
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			writeError(w, r, http.StatusGone, "CLI_CODE_EXPIRED", "login code is invalid, expired, or already used — retry `143-tools login`")
+			return
+		}
+		writeError(w, r, http.StatusInternalServerError, "CLI_EXCHANGE_FAILED", "failed to look up login code", err)
+		return
+	}
+
+	// Verifier binding: SHA-256(verifier) must equal the challenge the CLI
+	// sent at /cli/start. This prevents another local process that raced to
+	// read the loopback redirect from redeeming the code. The row is already
+	// consumed at this point — a failed binding burns the code, by design.
+	verifierSum := sha256.Sum256([]byte(body.Verifier))
+	if subtle.ConstantTimeCompare([]byte(hex.EncodeToString(verifierSum[:])), []byte(strings.ToLower(authCode.Challenge))) != 1 {
+		writeError(w, r, http.StatusBadRequest, "CLI_VERIFIER_MISMATCH", "verifier does not match the login challenge")
+		return
+	}
+
+	user, err := h.userStore.GetByIDGlobal(r.Context(), authCode.UserID)
+	if err != nil {
+		writeError(w, r, http.StatusInternalServerError, "CLI_EXCHANGE_FAILED", "failed to load user", err)
+		return
+	}
+
+	rawToken, err := db.GenerateUserCLIToken()
+	if err != nil {
+		writeError(w, r, http.StatusInternalServerError, "CLI_EXCHANGE_FAILED", "failed to mint token", err)
+		return
+	}
+	cliToken := &models.UserCLIToken{
+		UserID:      user.ID,
+		TokenHash:   db.HashAPIToken(rawToken),
+		TokenPrefix: db.UserCLITokenDisplayPrefix(rawToken),
+		DeviceName:  authCode.DeviceName,
+		LastOrgID:   authCode.OrgID,
+		ExpiresAt:   time.Now().Add(db.UserCLITokenTTL),
+	}
+	if err := h.cliTokens.Create(r.Context(), cliToken); err != nil {
+		writeError(w, r, http.StatusInternalServerError, "CLI_EXCHANGE_FAILED", "failed to persist token", err)
+		return
+	}
+
+	var orgPayload map[string]any
+	if authCode.OrgID != nil {
+		h.emitCLITokenEvent(r, &user, *authCode.OrgID, cliToken, models.AuditActionAuthCLILogin)
+		if h.orgStore != nil {
+			if org, orgErr := h.orgStore.GetByID(r.Context(), *authCode.OrgID); orgErr == nil {
+				orgPayload = map[string]any{"id": org.ID, "name": org.Name}
+			}
+		}
+	}
+
+	writeJSON(w, http.StatusOK, map[string]any{
+		"data": map[string]any{
+			"token":        rawToken,
+			"token_id":     cliToken.ID,
+			"token_prefix": cliToken.TokenPrefix,
+			"expires_at":   cliToken.ExpiresAt,
+			"user": map[string]any{
+				"id":           user.ID,
+				"email":        user.Email,
+				"name":         user.Name,
+				"github_login": user.GitHubLogin,
+			},
+			"org": orgPayload,
+		},
+	})
+}
+
+// ListCLITokens returns the caller's own CLI tokens (device, prefix,
+// last-used) for the self-service "CLI sessions" surface. Zero-membership
+// safe: token management must survive losing your last org.
+func (h *AuthHandler) ListCLITokens(w http.ResponseWriter, r *http.Request) {
+	user := middleware.UserFromContext(r.Context())
+	if user == nil {
+		writeError(w, r, http.StatusUnauthorized, "UNAUTHORIZED", "not authenticated")
+		return
+	}
+	if h.cliTokens == nil {
+		writeError(w, r, http.StatusInternalServerError, "CLI_AUTH_NOT_CONFIGURED", "CLI tokens are not configured on this server")
+		return
+	}
+	tokens, err := h.cliTokens.ListByUser(r.Context(), user.ID)
+	if err != nil {
+		writeError(w, r, http.StatusInternalServerError, "CLI_TOKEN_LIST_FAILED", "failed to list CLI tokens", err)
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"data": tokens})
+}
+
+// RevokeCLIToken revokes one of the caller's own CLI tokens. `143-tools
+// logout` calls this with its current token before clearing local config.
+func (h *AuthHandler) RevokeCLIToken(w http.ResponseWriter, r *http.Request) {
+	user := middleware.UserFromContext(r.Context())
+	if user == nil {
+		writeError(w, r, http.StatusUnauthorized, "UNAUTHORIZED", "not authenticated")
+		return
+	}
+	if h.cliTokens == nil {
+		writeError(w, r, http.StatusInternalServerError, "CLI_AUTH_NOT_CONFIGURED", "CLI tokens are not configured on this server")
+		return
+	}
+	id, err := uuid.Parse(strings.TrimSpace(chi.URLParam(r, "id")))
+	if err != nil {
+		writeError(w, r, http.StatusBadRequest, "INVALID_TOKEN_ID", "token id must be a UUID")
+		return
+	}
+	revoked, err := h.cliTokens.Revoke(r.Context(), user.ID, id)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			writeError(w, r, http.StatusNotFound, "CLI_TOKEN_NOT_FOUND", "CLI token not found")
+			return
+		}
+		writeError(w, r, http.StatusInternalServerError, "CLI_TOKEN_REVOKE_FAILED", "failed to revoke CLI token", err)
+		return
+	}
+	if revoked.LastOrgID != nil {
+		h.emitCLITokenEvent(r, user, *revoked.LastOrgID, &revoked, models.AuditActionAuthCLILogout)
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"data": map[string]string{"status": "revoked"}})
+}
+
+func (h *AuthHandler) emitCLITokenEvent(r *http.Request, user *models.User, orgID uuid.UUID, token *models.UserCLIToken, action models.AuditAction) {
+	if h.audit == nil {
+		return
+	}
+	tokenID := token.ID.String()
+	details, _ := json.Marshal(map[string]any{
+		"token_prefix": token.TokenPrefix,
+		"device_name":  token.DeviceName,
+	})
+	params := db.UserActionParams{
+		OrgID:        orgID,
+		UserID:       user.ID,
+		Action:       action,
+		ResourceType: models.AuditResourceCLIToken,
+		ResourceID:   &tokenID,
+		Details:      details,
+	}
+	if ua := r.UserAgent(); ua != "" {
+		params.UserAgent = &ua
+	}
+	if ip := parseClientIP(r); ip != nil {
+		params.IPAddress = ip
+	}
+	h.audit.EmitUserAction(r.Context(), params)
+}
+
+// --- join-token JIT provisioning (Phase 3) ---
+
+// applyJoinTokenForExistingUser grants an existing user membership in the
+// join token's org. Already-a-member is a no-op that does NOT burn a use;
+// invalid tokens are logged and ignored (the token was a no-op for an
+// existing user anyway — they still log in normally). Mirrors
+// claimPendingInvitationForExistingUser's best-effort posture.
+func (h *AuthHandler) applyJoinTokenForExistingUser(r *http.Request, joinToken string, user *models.User) {
+	if joinToken == "" || h.joinTokens == nil {
+		return
+	}
+	log := zerolog.Ctx(r.Context())
+
+	preview, err := h.joinTokens.GetActiveByToken(r.Context(), joinToken)
+	if err != nil {
+		if !errors.Is(err, pgx.ErrNoRows) {
+			log.Warn().Err(err).Msg("join token lookup failed during oauth login")
+		} else {
+			log.Info().Str("user_id", user.ID.String()).Msg("invalid join token presented by existing user; ignoring")
+		}
+		return
+	}
+	if h.memberships != nil {
+		if _, err := h.memberships.Get(r.Context(), user.ID, preview.OrgID); err == nil {
+			return // already a member — no-op, no use consumed
+		}
+	}
+
+	tx, err := h.pool.Begin(r.Context())
+	if err != nil {
+		log.Warn().Err(err).Msg("join token grant: begin failed")
+		return
+	}
+	defer func() { _ = tx.Rollback(r.Context()) }()
+
+	consumed, err := db.NewOrgJoinTokenStore(tx).ConsumeByToken(r.Context(), joinToken)
+	if err != nil {
+		// Raced out of uses or revoked between preview and consume.
+		log.Info().Err(err).Str("user_id", user.ID.String()).Msg("join token consume failed for existing user; ignoring")
+		return
+	}
+	effectiveRole, err := db.NewOrganizationMembershipStore(tx).GrantAtLeast(r.Context(), user.ID, consumed.OrgID, consumed.Role)
+	if err != nil {
+		log.Warn().Err(err).Msg("join token grant failed for existing user")
+		return
+	}
+	if err := tx.Commit(r.Context()); err != nil {
+		log.Warn().Err(err).Msg("join token grant: commit failed")
+		return
+	}
+	h.emitJoinTokenUsed(r, user.ID, &consumed, effectiveRole)
+}
+
+// createJoinedUser atomically consumes a join token, creates the OAuth user,
+// grants the membership, and issues the initial session — mirroring
+// acceptInvitationAndUpsertUser. The returned *invitationError (reusing the
+// struct for its status/code/message shape) is non-nil when the token is
+// invalid/exhausted: the caller fails closed for new users, because a
+// forgiving fallback would silently log the CLI into a fresh single-member
+// org — strictly worse than the error for someone trying to join a team.
+func (h *AuthHandler) createJoinedUser(
+	ctx context.Context,
+	joinToken string,
+	user *models.User,
+	upsert oauthUserUpsertFunc,
+) (*models.User, string, *models.OrgJoinToken, *invitationError, error) {
+	if h.pool == nil {
+		return nil, "", nil, nil, fmt.Errorf("auth handler pool is not configured")
+	}
+
+	tx, err := h.pool.Begin(ctx)
+	if err != nil {
+		return nil, "", nil, nil, fmt.Errorf("begin join transaction: %w", err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	consumed, err := db.NewOrgJoinTokenStore(tx).ConsumeByToken(ctx, joinToken)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, "", nil, &invitationError{
+				status:  http.StatusForbidden,
+				code:    "JOIN_TOKEN_INVALID",
+				message: "this join link is expired or revoked — ask your admin for a new one",
+			}, nil
+		}
+		return nil, "", nil, nil, fmt.Errorf("consume join token: %w", err)
+	}
+
+	user.OrgID = consumed.OrgID
+	user.Role = consumed.Role
+	if err := upsert(ctx, db.NewUserStore(tx), user); err != nil {
+		return nil, "", nil, nil, fmt.Errorf("upsert joined oauth user: %w", err)
+	}
+
+	effectiveRole, err := db.NewOrganizationMembershipStore(tx).GrantAtLeast(ctx, user.ID, consumed.OrgID, consumed.Role)
+	if err != nil {
+		return nil, "", nil, nil, fmt.Errorf("grant joined membership: %w", err)
+	}
+	user.Role = models.Role(effectiveRole)
+
+	sessionToken, err := h.persistSessionTx(ctx, tx, user)
+	if err != nil {
+		return nil, "", nil, nil, fmt.Errorf("create join session: %w", err)
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return nil, "", nil, nil, fmt.Errorf("commit join transaction: %w", err)
+	}
+	return user, sessionToken, &consumed, nil, nil
+}
+
+func (h *AuthHandler) emitJoinTokenUsed(r *http.Request, userID uuid.UUID, token *models.OrgJoinToken, effectiveRole string) {
+	if h.audit == nil || token == nil {
+		return
+	}
+	tokenID := token.ID.String()
+	details, _ := json.Marshal(map[string]any{
+		"token_prefix":   token.TokenPrefix,
+		"token_name":     token.Name,
+		"granted_role":   token.Role,
+		"effective_role": effectiveRole,
+		"use_count":      token.UseCount,
+	})
+	h.audit.EmitUserAction(r.Context(), db.UserActionParams{
+		OrgID:        token.OrgID,
+		UserID:       userID,
+		Action:       models.AuditActionOrgJoinTokenUsed,
+		ResourceType: models.AuditResourceOrgJoinToken,
+		ResourceID:   &tokenID,
+		Details:      details,
+	})
+}
+
+// --- small shared helpers ---
+
+func sanitizeCLIDeviceName(raw string) string {
+	raw = strings.TrimSpace(raw)
+	var b strings.Builder
+	for _, r := range raw {
+		if r < 0x20 || r == 0x7f {
+			continue
+		}
+		b.WriteRune(r)
+	}
+	out := b.String()
+	if len(out) > maxCLIDeviceNameLength {
+		out = out[:maxCLIDeviceNameLength]
+	}
+	return out
+}
+
+func setCLICookie(w http.ResponseWriter, name, value string) {
+	http.SetCookie(w, &http.Cookie{
+		Name:     name,
+		Value:    value,
+		Path:     "/",
+		MaxAge:   cliCookieMaxAge,
+		HttpOnly: true,
+		SameSite: http.SameSiteLaxMode,
+	})
+}
+
+// popCookie reads and unconditionally clears a cookie. Returns "" when
+// absent.
+func popCookie(w http.ResponseWriter, r *http.Request, name string) string {
+	cookie, err := r.Cookie(name)
+	if err != nil || cookie.Value == "" {
+		return ""
+	}
+	http.SetCookie(w, &http.Cookie{
+		Name:     name,
+		Value:    "",
+		Path:     "/",
+		MaxAge:   -1,
+		HttpOnly: true,
+	})
+	return cookie.Value
+}

--- a/internal/api/handlers/auth_cli_test.go
+++ b/internal/api/handlers/auth_cli_test.go
@@ -1,0 +1,324 @@
+package handlers
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/pashagolub/pgxmock/v4"
+	"github.com/stretchr/testify/require"
+
+	"github.com/assembledhq/143/internal/config"
+	"github.com/assembledhq/143/internal/db"
+)
+
+func newCLIAuthTestHandler(t *testing.T, mock pgxmock.PgxPoolIface) *AuthHandler {
+	t.Helper()
+	cfg := &config.Config{
+		GitHubOAuthClientID:    "client-id",
+		BaseURL:                "http://localhost:8080",
+		FrontendURL:            "http://frontend.test",
+		GitHubOAuthRedirectURI: "http://localhost:8080/api/v1/auth/github/callback",
+	}
+	var pool db.TxStarter
+	var userStore *db.UserStore
+	var sessionStore *db.AuthSessionStore
+	var authCodes *db.CLIAuthCodeStore
+	var cliTokens *db.UserCLITokenStore
+	var joinTokens *db.OrgJoinTokenStore
+	if mock != nil {
+		pool = mock
+		userStore = db.NewUserStore(mock)
+		sessionStore = db.NewAuthSessionStore(mock)
+		authCodes = db.NewCLIAuthCodeStore(mock)
+		cliTokens = db.NewUserCLITokenStore(mock)
+		joinTokens = db.NewOrgJoinTokenStore(mock)
+	}
+	h := NewAuthHandler(cfg, pool, userStore, sessionStore, nil, nil)
+	h.SetCLIAuthStores(authCodes, cliTokens, joinTokens, nil)
+	return h
+}
+
+func TestCLIStartValidatesInputsAndSetsCookies(t *testing.T) {
+	t.Parallel()
+	h := newCLIAuthTestHandler(t, nil)
+
+	challenge := strings.Repeat("ab", 32) // 64 hex chars
+	target := "/api/v1/auth/cli/start?port=51234&challenge=" + challenge +
+		"&device=my-laptop&join=143j_Ab3x9kQ2mP4r"
+	w := httptest.NewRecorder()
+	h.CLIStart(w, httptest.NewRequest(http.MethodGet, target, nil))
+
+	require.Equal(t, http.StatusTemporaryRedirect, w.Code)
+	require.Contains(t, w.Header().Get("Location"), "github.com/login/oauth/authorize",
+		"cli/start should chain into the GitHub OAuth login redirect")
+
+	cookies := map[string]string{}
+	for _, c := range w.Result().Cookies() {
+		cookies[c.Name] = c.Value
+		if c.Name == "cli_port" || c.Name == "cli_challenge" || c.Name == "pending_join" {
+			require.True(t, c.HttpOnly, "%s cookie must be HttpOnly", c.Name)
+		}
+	}
+	require.Equal(t, "51234", cookies["cli_port"])
+	require.Equal(t, challenge, cookies["cli_challenge"])
+	require.Equal(t, "my-laptop", cookies["cli_device"])
+	require.Equal(t, "143j_Ab3x9kQ2mP4r", cookies["pending_join"])
+}
+
+func TestCLIStartRejectsBadInputs(t *testing.T) {
+	t.Parallel()
+	h := newCLIAuthTestHandler(t, nil)
+	challenge := strings.Repeat("ab", 32)
+
+	cases := []struct {
+		name  string
+		query string
+		code  string
+	}{
+		{"missing port", "challenge=" + challenge, "INVALID_CLI_PORT"},
+		{"privileged port", "port=80&challenge=" + challenge, "INVALID_CLI_PORT"},
+		{"port out of range", "port=70000&challenge=" + challenge, "INVALID_CLI_PORT"},
+		{"missing challenge", "port=51234", "INVALID_CLI_CHALLENGE"},
+		{"short challenge", "port=51234&challenge=abcd", "INVALID_CLI_CHALLENGE"},
+		{"non-hex challenge", "port=51234&challenge=" + strings.Repeat("zz", 32), "INVALID_CLI_CHALLENGE"},
+		{"malformed join token", "port=51234&challenge=" + challenge + "&join=not-a-token", "INVALID_JOIN_TOKEN"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			w := httptest.NewRecorder()
+			h.CLIStart(w, httptest.NewRequest(http.MethodGet, "/api/v1/auth/cli/start?"+tc.query, nil))
+			require.Equal(t, http.StatusBadRequest, w.Code)
+			require.Contains(t, w.Body.String(), tc.code)
+		})
+	}
+}
+
+func TestCLIStartRefusesWhenGitHubOAuthUnavailable(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name string
+		cfg  *config.Config
+	}{
+		{"demo mode", &config.Config{DemoMode: true, GitHubOAuthClientID: "client-id"}},
+		{"no oauth app", &config.Config{}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			h := NewAuthHandler(tc.cfg, nil, nil, nil, nil, nil)
+			w := httptest.NewRecorder()
+			h.CLIStart(w, httptest.NewRequest(http.MethodGet, "/api/v1/auth/cli/start?port=51234&challenge="+strings.Repeat("ab", 32), nil))
+			require.Equal(t, http.StatusConflict, w.Code)
+			require.Contains(t, w.Body.String(), "GITHUB_OAUTH_DISABLED")
+		})
+	}
+}
+
+func TestReadAndClearCLILoginIntentRevalidatesCookieValues(t *testing.T) {
+	t.Parallel()
+
+	challenge := strings.Repeat("cd", 32)
+	cases := []struct {
+		name    string
+		cookies map[string]string
+		wantNil bool
+	}{
+		{"valid", map[string]string{"cli_port": "52000", "cli_challenge": challenge, "cli_device": "laptop"}, false},
+		{"no cookies", map[string]string{}, true},
+		{"port tampered", map[string]string{"cli_port": "80", "cli_challenge": challenge}, true},
+		{"challenge tampered", map[string]string{"cli_port": "52000", "cli_challenge": "zz"}, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			r := httptest.NewRequest(http.MethodGet, "/callback", nil)
+			for name, value := range tc.cookies {
+				r.AddCookie(&http.Cookie{Name: name, Value: value})
+			}
+			w := httptest.NewRecorder()
+			intent := readAndClearCLILoginIntent(w, r)
+			if tc.wantNil {
+				require.Nil(t, intent)
+				return
+			}
+			require.NotNil(t, intent)
+			require.Equal(t, 52000, intent.port)
+			require.Equal(t, challenge, intent.challenge)
+			require.Equal(t, "laptop", intent.device)
+			require.Equal(t, "http://127.0.0.1:52000/callback?code=x", intent.loopbackURL("code=x"))
+		})
+	}
+}
+
+func TestCLIExchangeRejectsInvalidBody(t *testing.T) {
+	t.Parallel()
+	h := newCLIAuthTestHandler(t, newPgxMock(t))
+
+	for _, body := range []string{``, `{}`, `{"code":"x"}`, `{"verifier":"y"}`} {
+		w := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/auth/cli/exchange", strings.NewReader(body))
+		h.CLIExchange(w, req)
+		require.Equal(t, http.StatusBadRequest, w.Code, "body %q", body)
+		require.Contains(t, w.Body.String(), "INVALID_BODY")
+	}
+}
+
+func TestCLIExchangeExpiredCodeReturns410(t *testing.T) {
+	t.Parallel()
+	mock := newPgxMock(t)
+	h := newCLIAuthTestHandler(t, mock)
+
+	// Consume's guarded UPDATE matches no rows for unknown/expired/used codes.
+	mock.ExpectQuery(`UPDATE cli_auth_codes SET consumed_at = now\(\)`).
+		WithArgs(pgxmock.AnyArg()).
+		WillReturnRows(pgxmock.NewRows(cliAuthCodeTestColumns()))
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/auth/cli/exchange",
+		strings.NewReader(`{"code":"deadbeef","verifier":"v"}`))
+	h.CLIExchange(w, req)
+
+	require.Equal(t, http.StatusGone, w.Code)
+	require.Contains(t, w.Body.String(), "CLI_CODE_EXPIRED")
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestCLIExchangeVerifierMismatchReturns400(t *testing.T) {
+	t.Parallel()
+	mock := newPgxMock(t)
+	h := newCLIAuthTestHandler(t, mock)
+
+	rightVerifier := "right-verifier"
+	sum := sha256.Sum256([]byte(rightVerifier))
+	challenge := hex.EncodeToString(sum[:])
+
+	rows := pgxmock.NewRows(cliAuthCodeTestColumns()).AddRow(
+		uuid.New(), "code-hash", challenge, uuid.New(), nil, "laptop",
+		time.Now().Add(time.Minute), nil, time.Now(),
+	)
+	mock.ExpectQuery(`UPDATE cli_auth_codes SET consumed_at = now\(\)`).
+		WithArgs(pgxmock.AnyArg()).
+		WillReturnRows(rows)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/auth/cli/exchange",
+		strings.NewReader(`{"code":"deadbeef","verifier":"wrong-verifier"}`))
+	h.CLIExchange(w, req)
+
+	require.Equal(t, http.StatusBadRequest, w.Code)
+	require.Contains(t, w.Body.String(), "CLI_VERIFIER_MISMATCH")
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+// TestCallbackCLIBranchRedirectsToLoopbackWithCode runs the OAuth callback
+// for an existing GitHub user carrying CLI-intent cookies and asserts the
+// browser is sent to the CLI's loopback listener with a one-time code —
+// never a credential.
+func TestCallbackCLIBranchRedirectsToLoopbackWithCode(t *testing.T) {
+	t.Parallel()
+	mock := newPgxMock(t)
+	h := newCLIAuthTestHandler(t, mock)
+
+	userID := uuid.New()
+	orgID := uuid.New()
+	now := time.Now()
+
+	github := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/login/oauth/access_token":
+			_, _ = w.Write([]byte(`{"access_token":"ghu_token","token_type":"bearer","scope":"user:email"}`))
+		case "/user":
+			_, _ = w.Write([]byte(`{"id":42,"login":"octocat","name":"Octo Cat","email":"octo@example.com","avatar_url":"https://example.com/a.png"}`))
+		case "/user/emails":
+			_, _ = w.Write([]byte(`[{"email":"42+octocat@users.noreply.github.com","verified":true}]`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer github.Close()
+	h.SetGitHubURLsForTest(github.URL, github.URL, github.Client())
+
+	userColumns := []string{"id", "org_id", "email", "name", "role", "github_id", "github_login",
+		"github_noreply_email", "avatar_url", "password_hash", "google_id", "created_at"}
+
+	// 1. Existing-user lookup by GitHub ID.
+	mock.ExpectQuery(`(?s)SELECT .+ FROM users\s+WHERE github_id = @github_id`).
+		WithArgs(int64(42)).
+		WillReturnRows(pgxmock.NewRows(userColumns).AddRow(
+			userID, orgID, "octo@example.com", "Octo Cat", "member", ptrTo(int64(42)), ptrTo("octocat"),
+			nil, nil, nil, nil, now,
+		))
+	// 2. Profile refresh upsert.
+	mock.ExpectQuery(`INSERT INTO users`).
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
+			pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(pgxmock.NewRows([]string{"id", "created_at"}).AddRow(userID, now))
+	// 3. Web session mint (persistSessionTx): last-org hint + session insert.
+	expectUserLastOrgLookup(mock, userID, nil)
+	mock.ExpectQuery("INSERT INTO auth_sessions").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(pgxmock.NewRows([]string{"id", "created_at"}).AddRow(uuid.New(), now))
+	// 4. resolveCLILoginOrg consults the last-org hint again.
+	expectUserLastOrgLookup(mock, userID, nil)
+	// 5. Auth-code insert (preceded by the opportunistic GC delete).
+	mock.ExpectExec(`DELETE FROM cli_auth_codes`).
+		WillReturnResult(pgxmock.NewResult("DELETE", 0))
+	mock.ExpectQuery(`INSERT INTO cli_auth_codes`).
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(pgxmock.NewRows(cliAuthCodeTestColumns()).AddRow(
+			uuid.New(), "hash", strings.Repeat("ab", 32), userID, nil, "laptop",
+			now.Add(time.Minute), nil, now,
+		))
+
+	challenge := strings.Repeat("ab", 32)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/auth/github/callback?code=gh-code&state=state-1", nil)
+	req.AddCookie(&http.Cookie{Name: "github_oauth_state", Value: "state-1"})
+	req.AddCookie(&http.Cookie{Name: "cli_port", Value: "52123"})
+	req.AddCookie(&http.Cookie{Name: "cli_challenge", Value: challenge})
+	req.AddCookie(&http.Cookie{Name: "cli_device", Value: "laptop"})
+	w := httptest.NewRecorder()
+
+	h.Callback(w, req)
+
+	require.Equal(t, http.StatusTemporaryRedirect, w.Code, "body: %s", w.Body.String())
+	location, err := url.Parse(w.Header().Get("Location"))
+	require.NoError(t, err)
+	require.Equal(t, "127.0.0.1:52123", location.Host, "must redirect to the hardcoded loopback host")
+	require.Equal(t, "/callback", location.Path)
+	code := location.Query().Get("code")
+	require.NotEmpty(t, code, "loopback redirect must carry the one-time code")
+	require.NotContains(t, w.Header().Get("Location"), "143u_", "the browser must never see a real token")
+
+	// The web session cookie is still installed alongside the CLI handoff.
+	var sawSession bool
+	for _, c := range w.Result().Cookies() {
+		if c.Name == "session_token" && c.Value != "" {
+			sawSession = true
+		}
+	}
+	require.True(t, sawSession, "CLI login should also sign the user into the web app")
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func newPgxMock(t *testing.T) pgxmock.PgxPoolIface {
+	t.Helper()
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err)
+	t.Cleanup(mock.Close)
+	return mock
+}
+
+func ptrTo[T any](v T) *T { return &v }
+
+func cliAuthCodeTestColumns() []string {
+	return []string{"id", "code_hash", "challenge", "user_id", "org_id",
+		"device_name", "expires_at", "consumed_at", "created_at"}
+}

--- a/internal/api/handlers/cli_distribution.go
+++ b/internal/api/handlers/cli_distribution.go
@@ -1,0 +1,162 @@
+package handlers
+
+import (
+	"bufio"
+	_ "embed"
+	"net/http"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"sync"
+	"text/template"
+
+	"github.com/go-chi/chi/v5"
+
+	"github.com/assembledhq/143/internal/version"
+)
+
+//go:embed assets/install.sh.tmpl
+var installScriptTemplate string
+
+// joinTokenPathPattern is the syntactic gate for the /install/{join_token}
+// path segment. This is untrusted input templated into a script the user
+// pipes to `sh`, so anything outside this charset is treated as a potential
+// shell-injection vector and 404s. Existence/validity of the token is
+// deliberately NOT checked here — a revoked link should still install the
+// binary; the join is validated at login.
+var joinTokenPathPattern = regexp.MustCompile(`^143j_[A-Za-z0-9]{12,64}$`)
+
+// cliPlatforms whitelists the {os}/{arch} pairs the download route serves.
+// Must stay in sync with the `make build-cli` cross-compile matrix.
+var cliPlatforms = map[string]bool{
+	"darwin/amd64": true,
+	"darwin/arm64": true,
+	"linux/amd64":  true,
+	"linux/arm64":  true,
+}
+
+// CLIDistributionHandler serves the 143-tools installer script, the
+// cross-compiled binaries, and the CLI version endpoint. Binaries live as
+// static files under distDir (baked into the server image at /opt/143/cli);
+// the install script is a Go template so the server can inject its own base
+// URL — and, on /install/{join_token}, the join token — making install +
+// auth a single zero-config command.
+type CLIDistributionHandler struct {
+	baseURL      string
+	distDir      string
+	minSupported string
+	tmpl         *template.Template
+
+	// checksums caches the parsed checksums.txt (filename → sha256 hex).
+	// Loaded once on first download: the dist dir is immutable for the
+	// lifetime of the server image.
+	checksumsOnce sync.Once
+	checksums     map[string]string
+}
+
+func NewCLIDistributionHandler(baseURL, distDir, minSupportedVersion string) *CLIDistributionHandler {
+	tmpl := template.Must(template.New("install.sh").Parse(installScriptTemplate))
+	return &CLIDistributionHandler{
+		baseURL:      strings.TrimRight(baseURL, "/"),
+		distDir:      distDir,
+		minSupported: minSupportedVersion,
+		tmpl:         tmpl,
+	}
+}
+
+// InstallScript serves the templated installer. With a {join_token} path
+// segment the token is templated into the config-write step; the segment is
+// syntactically validated (see joinTokenPathPattern) because it ends up
+// inside a script piped to sh.
+func (h *CLIDistributionHandler) InstallScript(w http.ResponseWriter, r *http.Request) {
+	joinToken := chi.URLParam(r, "join_token")
+	if joinToken != "" && !joinTokenPathPattern.MatchString(joinToken) {
+		http.NotFound(w, r)
+		return
+	}
+
+	w.Header().Set("Content-Type", "text/x-shellscript; charset=utf-8")
+	w.Header().Set("Cache-Control", "no-store")
+	_ = h.tmpl.Execute(w, map[string]string{
+		"ServerURL": h.baseURL,
+		"JoinToken": joinToken,
+	})
+}
+
+// DownloadBinary streams the 143-tools binary for the requested platform and
+// sets X-Checksum-Sha256 so clients (the `update` command) can verify without
+// a second round-trip. Unknown platform pairs 404.
+func (h *CLIDistributionHandler) DownloadBinary(w http.ResponseWriter, r *http.Request) {
+	osName := chi.URLParam(r, "os")
+	arch := chi.URLParam(r, "arch")
+	if !cliPlatforms[osName+"/"+arch] {
+		http.NotFound(w, r)
+		return
+	}
+
+	name := "143-tools-" + osName + "-" + arch
+	path := filepath.Join(h.distDir, name)
+	if _, err := os.Stat(path); err != nil {
+		http.NotFound(w, r)
+		return
+	}
+	if sum := h.checksumFor(name); sum != "" {
+		w.Header().Set("X-Checksum-Sha256", sum)
+	}
+	w.Header().Set("Content-Type", "application/octet-stream")
+	w.Header().Set("Content-Disposition", `attachment; filename="143-tools"`)
+	http.ServeFile(w, r, path)
+}
+
+// Checksums serves the checksums.txt the installer verifies against.
+func (h *CLIDistributionHandler) Checksums(w http.ResponseWriter, r *http.Request) {
+	path := filepath.Join(h.distDir, "checksums.txt")
+	if _, err := os.Stat(path); err != nil {
+		http.NotFound(w, r)
+		return
+	}
+	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+	http.ServeFile(w, r, path)
+}
+
+// Version reports the server's build version and the minimum CLI version it
+// supports. min_supported is enforced by middleware.CLIVersionGate, not just
+// advisory — see the config field doc for the orderable-version caveat.
+func (h *CLIDistributionHandler) Version(w http.ResponseWriter, r *http.Request) {
+	writeJSON(w, http.StatusOK, map[string]any{
+		"data": map[string]string{
+			"version":       version.BuildSHA,
+			"min_supported": h.minSupported,
+		},
+	})
+}
+
+func (h *CLIDistributionHandler) checksumFor(name string) string {
+	h.checksumsOnce.Do(func() {
+		h.checksums = parseChecksumsFile(filepath.Join(h.distDir, "checksums.txt"))
+	})
+	return h.checksums[name]
+}
+
+// parseChecksumsFile reads a sha256sum-format file ("<hex>  <name>" per
+// line, with shasum's optional binary-mode "*" prefix on the name). Missing
+// or malformed files yield an empty map — the download route then simply
+// omits the checksum header.
+func parseChecksumsFile(path string) map[string]string {
+	sums := make(map[string]string)
+	f, err := os.Open(path) // #nosec G304 -- path is server-config dist dir, not user input
+	if err != nil {
+		return sums
+	}
+	defer f.Close()
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		fields := strings.Fields(scanner.Text())
+		if len(fields) != 2 || len(fields[0]) != 64 {
+			continue
+		}
+		sums[strings.TrimPrefix(fields[1], "*")] = fields[0]
+	}
+	return sums
+}

--- a/internal/api/handlers/cli_distribution_test.go
+++ b/internal/api/handlers/cli_distribution_test.go
@@ -1,0 +1,133 @@
+package handlers
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/stretchr/testify/require"
+)
+
+func newCLIDistTestRouter(t *testing.T, distDir string) http.Handler {
+	t.Helper()
+	h := NewCLIDistributionHandler("https://143.example.com", distDir, "1.0.0")
+	r := chi.NewRouter()
+	r.Get("/install.sh", h.InstallScript)
+	r.Get("/install/{join_token}", h.InstallScript)
+	r.Get("/download/143-tools/checksums.txt", h.Checksums)
+	r.Get("/download/143-tools/{os}/{arch}", h.DownloadBinary)
+	r.Get("/api/v1/cli/version", h.Version)
+	return r
+}
+
+func writeCLIDistFixture(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	// sha256("hello\n")
+	const helloSum = "5891b5b522d5df086d0ff0b110fbd9d21bb4fc7163af34d08286a2e846f6be03"
+	for _, name := range []string{"143-tools-darwin-arm64", "143-tools-linux-amd64"} {
+		require.NoError(t, os.WriteFile(filepath.Join(dir, name), []byte("hello\n"), 0o755))
+	}
+	checksums := helloSum + "  143-tools-darwin-arm64\n" + helloSum + "  143-tools-linux-amd64\n"
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "checksums.txt"), []byte(checksums), 0o644))
+	return dir
+}
+
+func TestInstallScriptTemplatesServerURL(t *testing.T) {
+	t.Parallel()
+	router := newCLIDistTestRouter(t, t.TempDir())
+
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/install.sh", nil))
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	body := rec.Body.String()
+	require.Contains(t, body, `SERVER_URL='https://143.example.com'`)
+	require.Contains(t, body, `JOIN_TOKEN=''`, "tokenless install should template an empty join token")
+	// The dropped-connection guard: nothing executes unless the final line arrived.
+	require.True(t, strings.HasSuffix(strings.TrimSpace(body), `main "$@"`),
+		"script body must be wrapped in a function invoked on the last line")
+}
+
+func TestInstallScriptTemplatesValidJoinToken(t *testing.T) {
+	t.Parallel()
+	router := newCLIDistTestRouter(t, t.TempDir())
+
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/install/143j_Ab3x9kQ2mP4r", nil))
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Contains(t, rec.Body.String(), `JOIN_TOKEN='143j_Ab3x9kQ2mP4r'`)
+}
+
+func TestInstallScriptRejectsMalformedJoinTokens(t *testing.T) {
+	t.Parallel()
+	router := newCLIDistTestRouter(t, t.TempDir())
+
+	// Each of these is untrusted input that would be templated into a script
+	// piped to sh — anything outside the strict charset must 404.
+	malformed := []string{
+		"/install/notatoken",
+		"/install/143j_short",                      // under 12 chars after the prefix
+		"/install/143j_has'quote12",                // quote breaks out of single-quoting
+		"/install/143j_has%24dollar12",             // $ (encoded)
+		"/install/143j_" + strings.Repeat("a", 65), // over 64 chars
+		"/install/143u_AbcdefGhijkl",               // wrong prefix (CLI token, not join token)
+	}
+	for _, path := range malformed {
+		rec := httptest.NewRecorder()
+		router.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, path, nil))
+		require.Equal(t, http.StatusNotFound, rec.Code, "expected 404 for %s", path)
+	}
+}
+
+func TestDownloadBinaryServesWhitelistedPlatformsWithChecksumHeader(t *testing.T) {
+	t.Parallel()
+	router := newCLIDistTestRouter(t, writeCLIDistFixture(t))
+
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/download/143-tools/darwin/arm64", nil))
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Equal(t, "hello\n", rec.Body.String())
+	require.Equal(t,
+		"5891b5b522d5df086d0ff0b110fbd9d21bb4fc7163af34d08286a2e846f6be03",
+		rec.Header().Get("X-Checksum-Sha256"))
+
+	for _, path := range []string{
+		"/download/143-tools/windows/amd64",
+		"/download/143-tools/darwin/mips",
+		"/download/143-tools/darwin/..", // traversal shapes must not reach the filesystem
+	} {
+		rec := httptest.NewRecorder()
+		router.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, path, nil))
+		require.Equal(t, http.StatusNotFound, rec.Code, "expected 404 for %s", path)
+	}
+}
+
+func TestDownloadBinaryMissingDistDir404s(t *testing.T) {
+	t.Parallel()
+	router := newCLIDistTestRouter(t, filepath.Join(t.TempDir(), "does-not-exist"))
+
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/download/143-tools/linux/amd64", nil))
+	require.Equal(t, http.StatusNotFound, rec.Code)
+
+	rec = httptest.NewRecorder()
+	router.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/download/143-tools/checksums.txt", nil))
+	require.Equal(t, http.StatusNotFound, rec.Code)
+}
+
+func TestCLIVersionEndpoint(t *testing.T) {
+	t.Parallel()
+	router := newCLIDistTestRouter(t, t.TempDir())
+
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/api/v1/cli/version", nil))
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Contains(t, rec.Body.String(), `"min_supported":"1.0.0"`)
+	require.Contains(t, rec.Body.String(), `"version"`)
+}

--- a/internal/api/handlers/cli_tools.go
+++ b/internal/api/handlers/cli_tools.go
@@ -1,0 +1,215 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/rs/zerolog"
+
+	"github.com/assembledhq/143/internal/api/middleware"
+	"github.com/assembledhq/143/internal/db"
+	"github.com/assembledhq/143/internal/models"
+	"github.com/assembledhq/143/internal/services/mcp"
+)
+
+// cliToolsCredentialProvider is the slice of OrgCredentialStore the gateway
+// needs: one batched read of the org's integration credentials.
+type cliToolsCredentialProvider interface {
+	GetAllIntegrations(ctx context.Context, orgID uuid.UUID, providers []models.ProviderName) (map[models.ProviderName]*models.DecryptedCredential, error)
+}
+
+// cliToolsLinearTokenResolver mirrors agent.LinearTokenResolver: it returns
+// a currently-valid Linear access token, refreshing server-side when needed.
+type cliToolsLinearTokenResolver interface {
+	GetValidAccessToken(ctx context.Context, orgID uuid.UUID) (string, error)
+}
+
+// CLIToolsHandler is the local agent gateway: it exposes the org's
+// integration tool registry to logged-in CLIs, executing every call
+// server-side with org credentials (which never land on laptops) and a
+// per-user audit event per call. Revoking a user's CLI token — or removing
+// them from the org — instantly cuts their local agents off from every
+// integration.
+type CLIToolsHandler struct {
+	credentials  cliToolsCredentialProvider
+	linearTokens cliToolsLinearTokenResolver
+	audit        *db.AuditEmitter
+	logger       zerolog.Logger
+}
+
+func NewCLIToolsHandler(credentials cliToolsCredentialProvider, logger zerolog.Logger) *CLIToolsHandler {
+	return &CLIToolsHandler{credentials: credentials, logger: logger}
+}
+
+// SetLinearTokenResolver wires refresh-aware Linear token resolution.
+// Optional: without it, Linear tools use the stored access token as-is.
+func (h *CLIToolsHandler) SetLinearTokenResolver(resolver cliToolsLinearTokenResolver) {
+	h.linearTokens = resolver
+}
+
+func (h *CLIToolsHandler) SetAuditEmitter(audit *db.AuditEmitter) {
+	h.audit = audit
+}
+
+var cliToolsProviderNames = []models.ProviderName{
+	models.ProviderSentry,
+	models.ProviderLinear,
+	models.ProviderNotion,
+	models.ProviderCircleCI,
+	models.ProviderMezmo,
+}
+
+// buildOrgToolSource assembles the per-request tool registry from the org's
+// connected integrations. Built per request rather than cached: credential
+// rotation, integration connects/disconnects, and Linear token refresh all
+// take effect immediately, and registry construction is cheap (no I/O —
+// the constructors just capture config).
+func (h *CLIToolsHandler) buildOrgToolSource(ctx context.Context, orgID uuid.UUID) (*mcp.ToolRegistry, error) {
+	creds, err := h.credentials.GetAllIntegrations(ctx, orgID, cliToolsProviderNames)
+	if err != nil {
+		return nil, err
+	}
+
+	var orgCreds mcp.OrgCredentials
+	if cred := creds[models.ProviderSentry]; cred != nil {
+		if cfg, ok := cred.Config.(models.SentryConfig); ok {
+			orgCreds.Sentry = &cfg
+		}
+	}
+	if cred := creds[models.ProviderNotion]; cred != nil {
+		if cfg, ok := cred.Config.(models.NotionConfig); ok {
+			orgCreds.Notion = &cfg
+		}
+	}
+	if cred := creds[models.ProviderCircleCI]; cred != nil {
+		if cfg, ok := cred.Config.(models.CircleCIConfig); ok {
+			orgCreds.CircleCI = &cfg
+		}
+	}
+	if cred := creds[models.ProviderMezmo]; cred != nil {
+		if cfg, ok := cred.Config.(models.MezmoConfig); ok {
+			orgCreds.Mezmo = &cfg
+		}
+	}
+
+	// Linear: prefer the refresh-aware resolver so a near-expiring token is
+	// rotated before use; fall back to the stored access token for wiring
+	// (tests) without a resolver.
+	switch {
+	case h.linearTokens != nil:
+		token, tokenErr := h.linearTokens.GetValidAccessToken(ctx, orgID)
+		if tokenErr != nil {
+			h.logger.Warn().Err(tokenErr).Str("org_id", orgID.String()).
+				Msg("cli tools: linear token resolution failed; linear tools unavailable this request")
+		} else {
+			orgCreds.LinearAccessToken = token
+		}
+	default:
+		if cred := creds[models.ProviderLinear]; cred != nil {
+			if cfg, ok := cred.Config.(models.LinearConfig); ok {
+				orgCreds.LinearAccessToken = cfg.AccessToken
+			}
+		}
+	}
+
+	return mcp.NewToolRegistry(mcp.BuildRegistryFromOrg(orgCreds)), nil
+}
+
+// ListTools returns the tool definitions available to this org's local
+// agents. The CLI's MCP server fetches this at startup instead of
+// hardcoding a list, so availability mirrors the org's connected
+// integrations.
+func (h *CLIToolsHandler) ListTools(w http.ResponseWriter, r *http.Request) {
+	orgID := middleware.OrgIDFromContext(r.Context())
+	if orgID == uuid.Nil {
+		writeError(w, r, http.StatusForbidden, "NO_ACTIVE_ORG", "no active organization")
+		return
+	}
+	source, err := h.buildOrgToolSource(r.Context(), orgID)
+	if err != nil {
+		writeError(w, r, http.StatusInternalServerError, "CLI_TOOLS_UNAVAILABLE", "failed to load org integrations", err)
+		return
+	}
+	tools := source.ListTools()
+	if tools == nil {
+		tools = []mcp.Tool{}
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"data": map[string]any{"tools": tools}})
+}
+
+type cliToolInvokeRequest struct {
+	Tool string          `json:"tool"`
+	Args json.RawMessage `json:"args"`
+}
+
+// Invoke executes one tool call with the org's server-side credentials and
+// emits a per-user `cli.tool_invoked` audit event. The event records the
+// tool name but never the args — args can contain sensitive content (issue
+// text, log queries) that doesn't belong in a retained audit row.
+func (h *CLIToolsHandler) Invoke(w http.ResponseWriter, r *http.Request) {
+	user := middleware.UserFromContext(r.Context())
+	orgID := middleware.OrgIDFromContext(r.Context())
+	if user == nil || orgID == uuid.Nil {
+		writeError(w, r, http.StatusForbidden, "NO_ACTIVE_ORG", "no active organization")
+		return
+	}
+
+	var body cliToolInvokeRequest
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil || strings.TrimSpace(body.Tool) == "" {
+		writeError(w, r, http.StatusBadRequest, "INVALID_BODY", "tool is required")
+		return
+	}
+	if body.Args == nil {
+		body.Args = json.RawMessage(`{}`)
+	}
+
+	source, err := h.buildOrgToolSource(r.Context(), orgID)
+	if err != nil {
+		writeError(w, r, http.StatusInternalServerError, "CLI_TOOLS_UNAVAILABLE", "failed to load org integrations", err)
+		return
+	}
+	if !toolExists(source.ListTools(), body.Tool) {
+		writeError(w, r, http.StatusNotFound, "TOOL_NOT_FOUND",
+			"unknown tool — it may belong to an integration this org has not connected")
+		return
+	}
+
+	h.emitToolInvoked(r, user.ID, orgID, body.Tool)
+
+	result := source.CallTool(r.Context(), body.Tool, body.Args)
+	writeJSON(w, http.StatusOK, map[string]any{"data": result})
+}
+
+func toolExists(tools []mcp.Tool, name string) bool {
+	for _, t := range tools {
+		if t.Name == name {
+			return true
+		}
+	}
+	return false
+}
+
+func (h *CLIToolsHandler) emitToolInvoked(r *http.Request, userID, orgID uuid.UUID, toolName string) {
+	if h.audit == nil {
+		return
+	}
+	details, _ := json.Marshal(map[string]any{"tool": toolName})
+	params := db.UserActionParams{
+		OrgID:        orgID,
+		UserID:       userID,
+		Action:       models.AuditActionCLIToolInvoked,
+		ResourceType: models.AuditResourceCLITool,
+		ResourceID:   &toolName,
+		Details:      details,
+	}
+	if ua := r.UserAgent(); ua != "" {
+		params.UserAgent = &ua
+	}
+	if ip := parseClientIP(r); ip != nil {
+		params.IPAddress = ip
+	}
+	h.audit.EmitUserAction(r.Context(), params)
+}

--- a/internal/api/handlers/cli_tools_test.go
+++ b/internal/api/handlers/cli_tools_test.go
@@ -1,0 +1,111 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/require"
+
+	"github.com/assembledhq/143/internal/api/middleware"
+	"github.com/assembledhq/143/internal/models"
+)
+
+type fakeCredentialProvider struct {
+	creds map[models.ProviderName]*models.DecryptedCredential
+}
+
+func (f *fakeCredentialProvider) GetAllIntegrations(_ context.Context, _ uuid.UUID, _ []models.ProviderName) (map[models.ProviderName]*models.DecryptedCredential, error) {
+	return f.creds, nil
+}
+
+func cliToolsRequestContext(r *http.Request) *http.Request {
+	user := &models.User{ID: uuid.New(), Email: "dev@example.com"}
+	ctx := middleware.WithUser(r.Context(), user)
+	ctx = middleware.WithOrgID(ctx, uuid.New())
+	ctx = middleware.WithActiveRole(ctx, "member")
+	return r.WithContext(ctx)
+}
+
+func TestCLIToolsListMirrorsConnectedIntegrations(t *testing.T) {
+	t.Parallel()
+
+	// Only Sentry connected: the tool list must include sentry tools and no
+	// notion/linear tools.
+	h := NewCLIToolsHandler(&fakeCredentialProvider{
+		creds: map[models.ProviderName]*models.DecryptedCredential{
+			models.ProviderSentry: {Config: models.SentryConfig{AccessToken: "tok", OrgSlug: "acme"}},
+		},
+	}, zerolog.Nop())
+
+	rec := httptest.NewRecorder()
+	h.ListTools(rec, cliToolsRequestContext(httptest.NewRequest(http.MethodGet, "/api/v1/cli/tools", nil)))
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	body := rec.Body.String()
+	require.Contains(t, body, "sentry_list_errors")
+	require.NotContains(t, body, "notion_", "unconnected integrations must not surface tools")
+	require.NotContains(t, body, "linear_", "unconnected integrations must not surface tools")
+	require.NotContains(t, body, "tok", "credentials must never appear in the tool list")
+}
+
+func TestCLIToolsListEmptyOrgReturnsEmptyList(t *testing.T) {
+	t.Parallel()
+	h := NewCLIToolsHandler(&fakeCredentialProvider{creds: map[models.ProviderName]*models.DecryptedCredential{}}, zerolog.Nop())
+
+	rec := httptest.NewRecorder()
+	h.ListTools(rec, cliToolsRequestContext(httptest.NewRequest(http.MethodGet, "/api/v1/cli/tools", nil)))
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	var resp struct {
+		Data struct {
+			Tools []json.RawMessage `json:"tools"`
+		} `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	require.Empty(t, resp.Data.Tools)
+}
+
+func TestCLIToolsInvokeUnknownTool404s(t *testing.T) {
+	t.Parallel()
+	h := NewCLIToolsHandler(&fakeCredentialProvider{creds: map[models.ProviderName]*models.DecryptedCredential{}}, zerolog.Nop())
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/cli/tools/invoke",
+		strings.NewReader(`{"tool":"notion_search_documents","args":{}}`))
+	h.Invoke(rec, cliToolsRequestContext(req))
+
+	require.Equal(t, http.StatusNotFound, rec.Code)
+	require.Contains(t, rec.Body.String(), "TOOL_NOT_FOUND")
+}
+
+func TestCLIToolsInvokeRejectsMissingTool(t *testing.T) {
+	t.Parallel()
+	h := NewCLIToolsHandler(&fakeCredentialProvider{creds: map[models.ProviderName]*models.DecryptedCredential{}}, zerolog.Nop())
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/cli/tools/invoke", strings.NewReader(`{}`))
+	h.Invoke(rec, cliToolsRequestContext(req))
+
+	require.Equal(t, http.StatusBadRequest, rec.Code)
+	require.Contains(t, rec.Body.String(), "INVALID_BODY")
+}
+
+func TestCLIToolsRequireActiveOrg(t *testing.T) {
+	t.Parallel()
+	h := NewCLIToolsHandler(&fakeCredentialProvider{creds: map[models.ProviderName]*models.DecryptedCredential{}}, zerolog.Nop())
+
+	// No org in context (zero-membership user): both endpoints refuse.
+	rec := httptest.NewRecorder()
+	h.ListTools(rec, httptest.NewRequest(http.MethodGet, "/api/v1/cli/tools", nil))
+	require.Equal(t, http.StatusForbidden, rec.Code)
+
+	rec = httptest.NewRecorder()
+	h.Invoke(rec, httptest.NewRequest(http.MethodPost, "/api/v1/cli/tools/invoke", strings.NewReader(`{"tool":"x"}`)))
+	require.Equal(t, http.StatusForbidden, rec.Code)
+}

--- a/internal/api/handlers/join_tokens.go
+++ b/internal/api/handlers/join_tokens.go
@@ -1,0 +1,212 @@
+package handlers
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+
+	"github.com/assembledhq/143/internal/api/middleware"
+	"github.com/assembledhq/143/internal/db"
+	"github.com/assembledhq/143/internal/models"
+)
+
+// JoinTokenHandler exposes admin CRUD for org join tokens — the multi-use
+// links behind `curl -fsSL .../install/<token> | sh`. Routes are registered
+// in the admin-only group; the handler itself only adds input validation
+// and the one-time plaintext-token response.
+type JoinTokenHandler struct {
+	store   *db.OrgJoinTokenStore
+	audit   *db.AuditEmitter
+	baseURL string
+}
+
+func NewJoinTokenHandler(store *db.OrgJoinTokenStore, baseURL string) *JoinTokenHandler {
+	return &JoinTokenHandler{store: store, baseURL: strings.TrimRight(baseURL, "/")}
+}
+
+func (h *JoinTokenHandler) SetAuditEmitter(audit *db.AuditEmitter) {
+	h.audit = audit
+}
+
+type createJoinTokenRequest struct {
+	Name          string `json:"name"`
+	Role          string `json:"role"`
+	MaxUses       *int   `json:"max_uses,omitempty"`
+	ExpiresInDays *int   `json:"expires_in_days,omitempty"`
+}
+
+// joinTokenView is the list/create response row: everything an admin needs
+// to recognize and manage a link, never the hash.
+type joinTokenView struct {
+	ID          uuid.UUID              `json:"id"`
+	TokenPrefix string                 `json:"token_prefix"`
+	Name        string                 `json:"name"`
+	Role        models.Role            `json:"role"`
+	MaxUses     *int                   `json:"max_uses,omitempty"`
+	UseCount    int                    `json:"use_count"`
+	ExpiresAt   *time.Time             `json:"expires_at,omitempty"`
+	Status      models.JoinTokenStatus `json:"status"`
+	CreatedAt   time.Time              `json:"created_at"`
+}
+
+func joinTokenViewOf(t models.OrgJoinToken, now time.Time) joinTokenView {
+	return joinTokenView{
+		ID:          t.ID,
+		TokenPrefix: t.TokenPrefix,
+		Name:        t.Name,
+		Role:        t.Role,
+		MaxUses:     t.MaxUses,
+		UseCount:    t.UseCount,
+		ExpiresAt:   t.ExpiresAt,
+		Status:      t.Status(now),
+		CreatedAt:   t.CreatedAt,
+	}
+}
+
+// Create mints a join token and returns the plaintext exactly once, along
+// with the ready-to-paste install one-liner.
+func (h *JoinTokenHandler) Create(w http.ResponseWriter, r *http.Request) {
+	user := middleware.UserFromContext(r.Context())
+	orgID := middleware.OrgIDFromContext(r.Context())
+	if user == nil || orgID == uuid.Nil {
+		writeError(w, r, http.StatusUnauthorized, "UNAUTHORIZED", "not authenticated")
+		return
+	}
+
+	var body createJoinTokenRequest
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeError(w, r, http.StatusBadRequest, "INVALID_BODY", "invalid JSON body")
+		return
+	}
+	role := models.Role(strings.TrimSpace(body.Role))
+	if role == "" {
+		role = models.RoleMember
+	}
+	if err := role.Validate(); err != nil {
+		writeError(w, r, http.StatusBadRequest, "INVALID_ROLE", "role must be one of admin, member, builder, viewer")
+		return
+	}
+	if body.MaxUses != nil && *body.MaxUses < 1 {
+		writeError(w, r, http.StatusBadRequest, "INVALID_MAX_USES", "max_uses must be at least 1")
+		return
+	}
+	if body.ExpiresInDays != nil && (*body.ExpiresInDays < 1 || *body.ExpiresInDays > 365) {
+		writeError(w, r, http.StatusBadRequest, "INVALID_EXPIRY", "expires_in_days must be between 1 and 365")
+		return
+	}
+
+	rawToken, err := db.GenerateOrgJoinToken()
+	if err != nil {
+		writeError(w, r, http.StatusInternalServerError, "JOIN_TOKEN_CREATE_FAILED", "failed to generate token", err)
+		return
+	}
+
+	token := &models.OrgJoinToken{
+		OrgID:           orgID,
+		TokenHash:       db.HashAPIToken(rawToken),
+		TokenPrefix:     db.OrgJoinTokenDisplayPrefix(rawToken),
+		Role:            role,
+		Name:            strings.TrimSpace(body.Name),
+		CreatedByUserID: user.ID,
+		MaxUses:         body.MaxUses,
+	}
+	if body.ExpiresInDays != nil {
+		expiresAt := time.Now().AddDate(0, 0, *body.ExpiresInDays)
+		token.ExpiresAt = &expiresAt
+	}
+	if err := h.store.Create(r.Context(), token); err != nil {
+		writeError(w, r, http.StatusInternalServerError, "JOIN_TOKEN_CREATE_FAILED", "failed to create join token", err)
+		return
+	}
+
+	h.emitJoinTokenEvent(r, user.ID, token, models.AuditActionOrgJoinTokenCreated)
+
+	writeJSON(w, http.StatusCreated, map[string]any{
+		"data": map[string]any{
+			"id":              token.ID,
+			"token":           rawToken,
+			"token_prefix":    token.TokenPrefix,
+			"role":            token.Role,
+			"name":            token.Name,
+			"expires_at":      token.ExpiresAt,
+			"max_uses":        token.MaxUses,
+			"install_command": fmt.Sprintf("curl -fsSL %s/install/%s | sh", h.baseURL, rawToken),
+		},
+	})
+}
+
+// List returns the org's join tokens with derived lifecycle status.
+func (h *JoinTokenHandler) List(w http.ResponseWriter, r *http.Request) {
+	orgID := middleware.OrgIDFromContext(r.Context())
+	if orgID == uuid.Nil {
+		writeError(w, r, http.StatusUnauthorized, "UNAUTHORIZED", "not authenticated")
+		return
+	}
+	tokens, err := h.store.List(r.Context(), orgID)
+	if err != nil {
+		writeError(w, r, http.StatusInternalServerError, "JOIN_TOKEN_LIST_FAILED", "failed to list join tokens", err)
+		return
+	}
+	now := time.Now()
+	views := make([]joinTokenView, 0, len(tokens))
+	for _, t := range tokens {
+		views = append(views, joinTokenViewOf(t, now))
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"data": views})
+}
+
+// Revoke kills a join link. One click here is the mitigation for the
+// token's deliberate exposure in URLs and shell history.
+func (h *JoinTokenHandler) Revoke(w http.ResponseWriter, r *http.Request) {
+	user := middleware.UserFromContext(r.Context())
+	orgID := middleware.OrgIDFromContext(r.Context())
+	if user == nil || orgID == uuid.Nil {
+		writeError(w, r, http.StatusUnauthorized, "UNAUTHORIZED", "not authenticated")
+		return
+	}
+	id, err := uuid.Parse(strings.TrimSpace(chi.URLParam(r, "id")))
+	if err != nil {
+		writeError(w, r, http.StatusBadRequest, "INVALID_TOKEN_ID", "token id must be a UUID")
+		return
+	}
+	token, err := h.store.Revoke(r.Context(), orgID, id, user.ID)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			writeError(w, r, http.StatusNotFound, "JOIN_TOKEN_NOT_FOUND", "join token not found or already revoked")
+			return
+		}
+		writeError(w, r, http.StatusInternalServerError, "JOIN_TOKEN_REVOKE_FAILED", "failed to revoke join token", err)
+		return
+	}
+	h.emitJoinTokenEvent(r, user.ID, &token, models.AuditActionOrgJoinTokenRevoked)
+	writeJSON(w, http.StatusOK, map[string]any{"data": joinTokenViewOf(token, time.Now())})
+}
+
+func (h *JoinTokenHandler) emitJoinTokenEvent(r *http.Request, userID uuid.UUID, token *models.OrgJoinToken, action models.AuditAction) {
+	if h.audit == nil {
+		return
+	}
+	tokenID := token.ID.String()
+	details, _ := json.Marshal(map[string]any{
+		"token_prefix": token.TokenPrefix,
+		"token_name":   token.Name,
+		"role":         token.Role,
+		"max_uses":     token.MaxUses,
+		"expires_at":   token.ExpiresAt,
+	})
+	h.audit.EmitUserAction(r.Context(), db.UserActionParams{
+		OrgID:        token.OrgID,
+		UserID:       userID,
+		Action:       action,
+		ResourceType: models.AuditResourceOrgJoinToken,
+		ResourceID:   &tokenID,
+		Details:      details,
+	})
+}

--- a/internal/api/handlers/legacy_user_fields_lint_test.go
+++ b/internal/api/handlers/legacy_user_fields_lint_test.go
@@ -52,6 +52,13 @@ func TestHandlersMustNotReadLegacyUserFields(t *testing.T) {
 		"auth_signup.go:OrgID": "signup assigns user.OrgID on the new user row before insert; not a read",
 		"auth_signup.go:Role":  "signup assigns user.Role on the new user row before insert; not a read",
 
+		// Join-token JIT provisioning mirrors auth_signup: it assigns
+		// user.OrgID / user.Role on the freshly-created user row before
+		// insert (then syncs Role to the GrantAtLeast effective role). All
+		// writes, not reads.
+		"auth_cli.go:OrgID": "JIT join assigns user.OrgID on the new user row before insert; not a read",
+		"auth_cli.go:Role":  "JIT join assigns user.Role before insert and syncs the GrantAtLeast effective role; not a read",
+
 		// Auth handlers return the user back to the client (e.g. /auth/me,
 		// signup response body, invitation claim response). The legacy
 		// fields exist on the wire contract for the compat window and are

--- a/internal/api/handlers/org_id_lint_test.go
+++ b/internal/api/handlers/org_id_lint_test.go
@@ -37,6 +37,14 @@ func TestHandlersMustUseOrgIDFromContext(t *testing.T) {
 		"AuthHandler.Register":         "public, pre-auth",
 		"AuthHandler.EmailLogin":       "public, pre-auth",
 		"TeamHandler.AcceptInvitation": "public, token-based (no auth middleware)",
+		"AuthHandler.CLIStart":         "public, pre-auth (CLI browser-login start; chains into GitHub OAuth)",
+		"AuthHandler.CLIExchange":      "public, pre-auth (one-time code + verifier exchange; org comes from the code row)",
+
+		// CLI distribution — public installer/binary routes, no auth.
+		"CLIDistributionHandler.InstallScript":  "public installer script",
+		"CLIDistributionHandler.DownloadBinary": "public binary download",
+		"CLIDistributionHandler.Checksums":      "public checksum file",
+		"CLIDistributionHandler.Version":        "public version endpoint",
 
 		// Webhook routes — signature-verified, not session-authenticated.
 		"WebhookHandler.HandleGitHub":          "external webhook, signature auth",
@@ -59,6 +67,8 @@ func TestHandlersMustUseOrgIDFromContext(t *testing.T) {
 		"AuthHandler.SetActiveOrg":           "user-scoped preference write; validates membership directly instead of using request org context",
 		"AuthHandler.ClaimInvitation":        "grants membership in a different org than the active one; target org comes from the invitation token, not the request context",
 		"AuthHandler.ListPendingInvitations": "user-scoped query spanning all orgs the user is invited to",
+		"AuthHandler.ListCLITokens":          "user-scoped: a user's CLI device tokens span orgs, like auth_sessions",
+		"AuthHandler.RevokeCLIToken":         "user-scoped self-service revocation; ownership enforced by user_id in the store query",
 		"AuthHandler.AcceptInvitationByID":   "invitee-scoped accept; org context comes from the invitation row itself, not the request",
 		"AuthHandler.DeclineInvitationByID":  "invitee-scoped decline; org context comes from the invitation row itself, not the request",
 		"OrganizationsHandler.Create":        "creates a new org; runs outside OrgContext, no pre-existing org to scope against",

--- a/internal/api/handlers/team.go
+++ b/internal/api/handlers/team.go
@@ -56,6 +56,12 @@ type teamSessionStore interface {
 	DeleteByUserID(ctx context.Context, userID uuid.UUID) error
 }
 
+// teamCLITokenStore revokes a removed member's CLI credentials when they
+// have no memberships left.
+type teamCLITokenStore interface {
+	RevokeAllForUser(ctx context.Context, userID uuid.UUID) (int64, error)
+}
+
 // teamInvitationStore is the interface for invitation operations.
 type teamInvitationStore interface {
 	Create(ctx context.Context, inv *models.Invitation) error
@@ -102,6 +108,13 @@ type TeamHandler struct {
 	emailSender  email.Sender
 	frontendURL  string
 	audit        *db.AuditEmitter
+	cliTokens    teamCLITokenStore
+}
+
+// SetCLITokenStore wires CLI-token revocation into member removal. Optional;
+// when nil, removal skips the CLI-token sweep.
+func (h *TeamHandler) SetCLITokenStore(cliTokens teamCLITokenStore) {
+	h.cliTokens = cliTokens
 }
 
 // SetGitHubIntegration wires the integration store and GitHub App service so
@@ -341,6 +354,15 @@ func (h *TeamHandler) RemoveMember(w http.ResponseWriter, r *http.Request) {
 	} else if remaining == 0 {
 		if err := h.sessions.DeleteByUserID(r.Context(), memberID); err != nil {
 			zerolog.Ctx(r.Context()).Warn().Err(err).Msg("failed to delete sessions for removed user")
+		}
+		// CLI tokens resolve org access through memberships, so they are
+		// already inert for a zero-membership user — revoking them too cuts
+		// the credential entirely (and clears the user's "CLI sessions"
+		// list) instead of leaving live-looking tokens around.
+		if h.cliTokens != nil {
+			if _, err := h.cliTokens.RevokeAllForUser(r.Context(), memberID); err != nil {
+				zerolog.Ctx(r.Context()).Warn().Err(err).Msg("failed to revoke CLI tokens for removed user")
+			}
 		}
 	}
 

--- a/internal/api/middleware/auth.go
+++ b/internal/api/middleware/auth.go
@@ -122,6 +122,7 @@ type AuthStores struct {
 	Memberships      *db.OrganizationMembershipStore
 	PreviewAPITokens *db.PreviewAPITokenStore
 	APITokens        *db.APITokenStore
+	UserCLITokens    *db.UserCLITokenStore
 	Audit            *db.AuditEmitter
 }
 
@@ -167,6 +168,11 @@ func handleToken(w http.ResponseWriter, r *http.Request, next http.Handler, stor
 		// terminal — logs the user out. Surface transient errors as 503 so
 		// the useAuth retry path handles them.
 		if errors.Is(err, pgx.ErrNoRows) {
+			if !cookieBased && stores.UserCLITokens != nil && strings.HasPrefix(token, db.UserCLITokenPrefix) {
+				if handleUserCLIToken(w, r, next, stores, logger, token) {
+					return
+				}
+			}
 			if !cookieBased && stores.APITokens != nil && strings.HasPrefix(token, "143_sk_") {
 				if handleGeneralAPIToken(w, r, next, stores, logger, token) {
 					return
@@ -269,6 +275,79 @@ func handleToken(w http.ResponseWriter, r *http.Request, next http.Handler, stor
 		recorder.SetResolvedIdentity(activeOrgID, user.ID)
 	}
 	next.ServeHTTP(w, r.WithContext(ctx))
+}
+
+// handleUserCLIToken authenticates a "143u_" bearer token from the 143-tools
+// CLI. CLI tokens are user-scoped session-equivalents: the request gets the
+// same user context a session cookie would, and active-org resolution runs
+// the identical header → last_org_id → oldest-membership chain. Returns true
+// when the request was handled (success or terminal error); false to let the
+// caller fall through to other token types.
+func handleUserCLIToken(w http.ResponseWriter, r *http.Request, next http.Handler, stores AuthStores, logger zerolog.Logger, rawToken string) bool {
+	cliToken, err := stores.UserCLITokens.GetActiveByToken(r.Context(), rawToken)
+	if err != nil {
+		if !errors.Is(err, pgx.ErrNoRows) {
+			logger.Warn().Err(err).Msg("auth: cli token lookup failed")
+			writeError(w, http.StatusServiceUnavailable, "SERVICE_UNAVAILABLE", "cli token lookup failed")
+			return true
+		}
+		return false
+	}
+
+	user, err := stores.Users.GetByIDGlobal(r.Context(), cliToken.UserID)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			writeError(w, http.StatusUnauthorized, "UNAUTHORIZED", "user not found")
+			return true
+		}
+		logger.Warn().Err(err).Msg("auth: cli token user lookup failed")
+		writeError(w, http.StatusServiceUnavailable, "SERVICE_UNAVAILABLE", "user lookup failed")
+		return true
+	}
+
+	// Reuse the session resolution chain by projecting the token's
+	// last_org_id hint into a synthetic session value. The semantics are
+	// deliberately identical — see UserCLIToken doc.
+	resolution, err := resolveActiveMembership(r, stores, user.ID, models.AuthSession{LastOrgID: cliToken.LastOrgID})
+	if err != nil {
+		logger.Warn().Err(err).Str("user_id", user.ID.String()).Msg("auth: cli token membership resolution failed")
+		writeError(w, http.StatusInternalServerError, "MEMBERSHIP_RESOLUTION_FAILED", "failed to resolve active membership")
+		return true
+	}
+	if resolution.membershipRevoked {
+		w.Header().Set(RevokedOrgHeader, RevokedOrgHeaderValue)
+	}
+
+	if !resolution.fromHeader && resolution.orgID != uuid.Nil &&
+		(cliToken.LastOrgID == nil || *cliToken.LastOrgID != resolution.orgID) {
+		if updateErr := stores.UserCLITokens.UpdateLastOrgID(r.Context(), cliToken.ID, &resolution.orgID); updateErr != nil {
+			logger.Warn().Err(updateErr).Msg("auth: failed to persist cli token last_org_id")
+		}
+	}
+
+	// Throttled usage stamp doubling as the sliding-expiry write: extend
+	// expires_at to now()+TTL at most once per minute so active devices
+	// never hit the 90-day wall while the hot path stays read-mostly.
+	if cliToken.LastUsedAt == nil || time.Since(*cliToken.LastUsedAt) > time.Minute {
+		if touchErr := stores.UserCLITokens.TouchUsage(r.Context(), cliToken.ID, remoteAddrIP(r), time.Now().Add(db.UserCLITokenTTL)); touchErr != nil {
+			logger.Warn().Err(touchErr).Msg("auth: cli token usage stamp failed")
+		}
+	}
+
+	// Legacy single-org compat sync, mirroring the session path.
+	if resolution.role != "" {
+		user.Role = models.Role(resolution.role)
+		user.OrgID = resolution.orgID
+	}
+
+	ctx := WithUser(r.Context(), &user)
+	ctx = WithOrgID(ctx, resolution.orgID)
+	ctx = WithActiveRole(ctx, resolution.role)
+	if recorder, ok := w.(resolvedIdentityRecorder); ok {
+		recorder.SetResolvedIdentity(resolution.orgID, user.ID)
+	}
+	next.ServeHTTP(w, r.WithContext(ctx))
+	return true
 }
 
 func handleGeneralAPIToken(w http.ResponseWriter, r *http.Request, next http.Handler, stores AuthStores, logger zerolog.Logger, rawToken string) bool {

--- a/internal/api/middleware/cli_version.go
+++ b/internal/api/middleware/cli_version.go
@@ -1,0 +1,89 @@
+package middleware
+
+import (
+	"net/http"
+	"strconv"
+	"strings"
+)
+
+// cliUserAgentPrefix is how the 143-tools CLI identifies itself. The version
+// segment after the slash is the CLI's embedded build version.
+const cliUserAgentPrefix = "143-tools/"
+
+// CLIUpdateRequiredCode is the error code returned with 426 when a CLI below
+// the server's minimum supported version makes an authenticated request.
+const CLIUpdateRequiredCode = "CLI_UPDATE_REQUIRED"
+
+// CLIVersionGate rejects requests from a 143-tools CLI older than
+// minSupported with 426 CLI_UPDATE_REQUIRED, giving breaking API changes a
+// clean failure mode that names the fix (`143-tools update`) instead of a
+// confusing downstream error.
+//
+// Enforcement only engages when both the configured minimum and the CLI's
+// advertised version are orderable (dotted numerics, e.g. "1.4.0"). Git-SHA
+// and "dev" builds are never blocked — comparing them is meaningless — so
+// enforcement is effectively opt-in for deployments that tag CLI releases.
+// Non-CLI user agents pass through untouched.
+func CLIVersionGate(minSupported string) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if minSupported != "" {
+				if v, ok := strings.CutPrefix(r.UserAgent(), cliUserAgentPrefix); ok {
+					if cmp, comparable := compareCLIVersions(v, minSupported); comparable && cmp < 0 {
+						writeError(w, http.StatusUpgradeRequired, CLIUpdateRequiredCode,
+							"this CLI version is no longer supported — run `143-tools update`")
+						return
+					}
+				}
+			}
+			next.ServeHTTP(w, r)
+		})
+	}
+}
+
+// compareCLIVersions compares two dotted-numeric versions ("1.4.0" style,
+// with an optional leading "v"). Returns (-1|0|1, true) when both parse, or
+// (0, false) when either side is not orderable (git SHA, "dev", empty).
+func compareCLIVersions(a, b string) (int, bool) {
+	av, ok := parseDottedVersion(a)
+	if !ok {
+		return 0, false
+	}
+	bv, ok := parseDottedVersion(b)
+	if !ok {
+		return 0, false
+	}
+	for i := 0; i < len(av) || i < len(bv); i++ {
+		var x, y int
+		if i < len(av) {
+			x = av[i]
+		}
+		if i < len(bv) {
+			y = bv[i]
+		}
+		if x != y {
+			if x < y {
+				return -1, true
+			}
+			return 1, true
+		}
+	}
+	return 0, true
+}
+
+func parseDottedVersion(s string) ([]int, bool) {
+	s = strings.TrimPrefix(strings.TrimSpace(s), "v")
+	if s == "" {
+		return nil, false
+	}
+	parts := strings.Split(s, ".")
+	nums := make([]int, 0, len(parts))
+	for _, p := range parts {
+		n, err := strconv.Atoi(p)
+		if err != nil || n < 0 {
+			return nil, false
+		}
+		nums = append(nums, n)
+	}
+	return nums, true
+}

--- a/internal/api/middleware/cli_version_test.go
+++ b/internal/api/middleware/cli_version_test.go
@@ -1,0 +1,72 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCompareCLIVersions(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		a, b       string
+		want       int
+		comparable bool
+	}{
+		{"1.4.0", "1.4.0", 0, true},
+		{"1.3.9", "1.4.0", -1, true},
+		{"2.0", "1.9.9", 1, true},
+		{"v1.4", "1.4.0", 0, true},
+		{"1.4.1", "1.4", 1, true},
+		{"dev", "1.0.0", 0, false},
+		{"a1b2c3d", "1.0.0", 0, false}, // git SHA — never orderable
+		{"1.0.0", "", 0, false},
+	}
+	for _, tc := range cases {
+		got, comparable := compareCLIVersions(tc.a, tc.b)
+		require.Equal(t, tc.comparable, comparable, "comparable(%q, %q)", tc.a, tc.b)
+		if comparable {
+			require.Equal(t, tc.want, got, "compare(%q, %q)", tc.a, tc.b)
+		}
+	}
+}
+
+func TestCLIVersionGate(t *testing.T) {
+	t.Parallel()
+
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	cases := []struct {
+		name         string
+		minSupported string
+		userAgent    string
+		wantStatus   int
+	}{
+		{"stale CLI blocked", "1.4.0", "143-tools/1.3.0", http.StatusUpgradeRequired},
+		{"current CLI passes", "1.4.0", "143-tools/1.4.0", http.StatusOK},
+		{"newer CLI passes", "1.4.0", "143-tools/2.0.0", http.StatusOK},
+		{"sha-versioned CLI never blocked", "1.4.0", "143-tools/a1b2c3d", http.StatusOK},
+		{"dev CLI never blocked", "1.4.0", "143-tools/dev", http.StatusOK},
+		{"non-CLI user agent untouched", "1.4.0", "Mozilla/5.0", http.StatusOK},
+		{"enforcement off by default", "", "143-tools/0.0.1", http.StatusOK},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			rec := httptest.NewRecorder()
+			req := httptest.NewRequest(http.MethodGet, "/api/v1/auth/me", nil)
+			req.Header.Set("User-Agent", tc.userAgent)
+			CLIVersionGate(tc.minSupported)(next).ServeHTTP(rec, req)
+			require.Equal(t, tc.wantStatus, rec.Code)
+			if tc.wantStatus == http.StatusUpgradeRequired {
+				require.Contains(t, rec.Body.String(), CLIUpdateRequiredCode)
+				require.Contains(t, rec.Body.String(), "143-tools update", "the 426 must name the fix")
+			}
+		})
+	}
+}

--- a/internal/api/middleware/logging.go
+++ b/internal/api/middleware/logging.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/assembledhq/143/internal/models"
@@ -69,6 +70,19 @@ func (rw *responseWriter) captureErrorDetails(responseBody []byte) {
 	rw.errorResponse = &response
 }
 
+// RedactLogPath strips secrets that ride in URL path segments before the
+// path is logged. Today that is only the /install/{join_token} installer
+// route: the join token is a credential-shaped value that deliberately lives
+// in the URL (so `curl <url> | sh` needs no arguments), and the trade-off
+// documented in the design is that the server's own request log must not
+// retain it.
+func RedactLogPath(path string) string {
+	if strings.HasPrefix(path, "/install/") && len(path) > len("/install/") {
+		return "/install/:token"
+	}
+	return path
+}
+
 func Logging(logger zerolog.Logger, reporter observability.Reporter) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -86,7 +100,7 @@ func Logging(logger zerolog.Logger, reporter observability.Reporter) func(http.H
 
 			logEvent.
 				Str("method", r.Method).
-				Str("path", r.URL.Path).
+				Str("path", RedactLogPath(r.URL.Path)).
 				Str("request_id", chiMiddleware.GetReqID(r.Context())).
 				Int("status", rw.status).
 				Str("status_class", strconv.Itoa(rw.status/100)+"xx").
@@ -115,7 +129,7 @@ func Logging(logger zerolog.Logger, reporter observability.Reporter) func(http.H
 func buildRequestErrorEvent(r *http.Request, rw *responseWriter) observability.RequestErrorEvent {
 	event := observability.RequestErrorEvent{
 		Method:    r.Method,
-		Path:      r.URL.Path,
+		Path:      RedactLogPath(r.URL.Path),
 		Route:     routePattern(r),
 		RequestID: chiMiddleware.GetReqID(r.Context()),
 		Status:    rw.status,

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -185,6 +185,16 @@ func NewRouter(cfg *config.Config, pool *pgxpool.Pool, logger zerolog.Logger, se
 		healthHandler.SetRedisHealthCheck(redisClient.Healthy)
 	}
 	authHandler := handlers.NewAuthHandler(cfg, pool, userStore, authSessionStore, invitationStore, membershipStore)
+	// CLI login flow stores (browser-based `143-tools login`, join-token JIT).
+	cliAuthCodeStore := db.NewCLIAuthCodeStore(pool)
+	userCLITokenStore := db.NewUserCLITokenStore(pool)
+	orgJoinTokenStore := db.NewOrgJoinTokenStore(pool)
+	authHandler.SetCLIAuthStores(cliAuthCodeStore, userCLITokenStore, orgJoinTokenStore, orgStore)
+	joinTokenHandler := handlers.NewJoinTokenHandler(orgJoinTokenStore, cfg.BaseURL)
+	// Local agent gateway: executes integration tools server-side for
+	// logged-in CLIs, so org credentials never land on laptops.
+	cliToolsHandler := handlers.NewCLIToolsHandler(credentialStore, logger)
+	cliToolsHandler.SetAuditEmitter(auditEmitter)
 	organizationsHandler := handlers.NewOrganizationsHandler(pool)
 	repoHandler := handlers.NewRepositoryHandler(repoStore)
 	if prService != nil {
@@ -340,6 +350,9 @@ func NewRouter(cfg *config.Config, pool *pgxpool.Pool, logger zerolog.Logger, se
 		})
 	}
 	sessionHandler.SetLinearLinker(linearService)
+	// Refresh-aware Linear tokens for the local agent gateway, same resolver
+	// the sandbox env injection uses.
+	cliToolsHandler.SetLinearTokenResolver(linearService)
 	// Wire the inline team-key refresh hook so the Linear OAuth callback
 	// can populate the allowlist synchronously before falling back to the
 	// worker enqueue. See HandleLinearOAuthCallback for the two-tier
@@ -489,6 +502,7 @@ func NewRouter(cfg *config.Config, pool *pgxpool.Pool, logger zerolog.Logger, se
 	}
 	teamHandler := handlers.NewTeamHandler(userStore, membershipStore, authSessionStore, invitationStore, orgStore, cfg.FrontendURL, emailSender)
 	teamHandler.SetRepositoryStore(repoStore)
+	teamHandler.SetCLITokenStore(userCLITokenStore)
 	apiClientHandler := handlers.NewAPIClientHandler(apiClientStore, apiTokenStore)
 	apiClientHandler.SetLogger(logger)
 	if cfg.GitHubAppID != 0 && cfg.GitHubAppPrivateKey != "" {
@@ -797,6 +811,17 @@ func NewRouter(cfg *config.Config, pool *pgxpool.Pool, logger zerolog.Logger, se
 	apiRoutes.Use(middleware.RateLimit(middleware.DefaultRateLimitConfig()))
 
 	apiRoutes.Group(func(r chi.Router) {
+		// CLI distribution routes (no auth — fetched by `curl | sh` and the
+		// CLI's update command, not the JSON API client). Served outside
+		// /api/v1 except for the version endpoint; the production Caddyfile
+		// routes /install* and /download/* to this server explicitly.
+		cliDistHandler := handlers.NewCLIDistributionHandler(cfg.BaseURL, cfg.CLIDistDir, cfg.CLIMinSupportedVersion)
+		r.Get("/install.sh", cliDistHandler.InstallScript)
+		r.Get("/install/{join_token}", cliDistHandler.InstallScript)
+		r.Get("/download/143-tools/checksums.txt", cliDistHandler.Checksums)
+		r.Get("/download/143-tools/{os}/{arch}", cliDistHandler.DownloadBinary)
+		r.Get("/api/v1/cli/version", cliDistHandler.Version)
+
 		// Webhook routes (no auth — called by external services, signature verified per-provider)
 		r.Route("/api/v1/webhooks", func(r chi.Router) {
 			r.Post("/github", webhookHandler.HandleGitHub)
@@ -829,6 +854,14 @@ func NewRouter(cfg *config.Config, pool *pgxpool.Pool, logger zerolog.Logger, se
 		// bucket only — exactly the guarantee this public route needs.
 		r.With(middleware.ClaimRateLimit(10)).Post("/api/v1/team/invitations/accept", teamHandler.AcceptInvitation)
 
+		// CLI code-for-token exchange. Deliberately OUTSIDE the CSRF-wrapped
+		// auth group: the CLI has no CSRF cookie/header, and the one-time
+		// code + verifier binding is a strictly stronger anti-forgery
+		// guarantee than the double-submit cookie. Same 10/min brute-force
+		// budget as the invitation endpoints — each request names an opaque
+		// code the server looks up.
+		r.With(middleware.ClaimRateLimit(10)).Post("/api/v1/auth/cli/exchange", authHandler.CLIExchange)
+
 		// Auth routes (no auth). CSRF still wraps this group so safe public
 		// auth reads warm the double-submit cookie before email login/register.
 		r.Group(func(r chi.Router) {
@@ -836,6 +869,10 @@ func NewRouter(cfg *config.Config, pool *pgxpool.Pool, logger zerolog.Logger, se
 			r.Get("/api/v1/auth/providers", authHandler.Providers)
 			r.Get("/api/v1/auth/github/login", authHandler.Login)
 			r.Get("/api/v1/auth/github/callback", authHandler.Callback)
+			// CLI browser-login entry point: stores the loopback port /
+			// challenge / join cookies and chains into the GitHub Login
+			// redirect above.
+			r.Get("/api/v1/auth/cli/start", authHandler.CLIStart)
 			r.Get("/api/v1/auth/google/login", authHandler.GoogleLogin)
 			r.Get("/api/v1/auth/google/callback", authHandler.GoogleCallback)
 			r.Post("/api/v1/auth/register", authHandler.Register)
@@ -856,8 +893,10 @@ func NewRouter(cfg *config.Config, pool *pgxpool.Pool, logger zerolog.Logger, se
 				Memberships:      membershipStore,
 				PreviewAPITokens: previewAPITokenStore,
 				APITokens:        apiTokenStore,
+				UserCLITokens:    userCLITokenStore,
 				Audit:            auditEmitter,
 			}, []byte(cfg.CSRFSigningKey), logger))
+			r.Use(middleware.CLIVersionGate(cfg.CLIMinSupportedVersion))
 			r.Use(middleware.LogContext(logger))
 			r.Use(externalAPIRateLimiter.Middleware())
 			r.Use(middleware.ExternalAPIIdempotency(apiIdempotencyStore, logger))
@@ -878,6 +917,12 @@ func NewRouter(cfg *config.Config, pool *pgxpool.Pool, logger zerolog.Logger, se
 			r.Get("/api/v1/auth/memberships", authHandler.Memberships)
 			r.Post("/api/v1/auth/active-org", authHandler.SetActiveOrg)
 			r.Post("/api/v1/auth/logout", authHandler.Logout)
+			// Self-service CLI token management (list devices, revoke).
+			// Zero-membership-safe: a user removed from their last org must
+			// still be able to see and kill their own CLI credentials, and
+			// `143-tools logout` must work for them.
+			r.Get("/api/v1/auth/cli-tokens", authHandler.ListCLITokens)
+			r.Delete("/api/v1/auth/cli-tokens/{id}", authHandler.RevokeCLIToken)
 			// GitHub App setup callbacks are validated against a signed setup
 			// intent inside the handler. Keep them outside OrgContext so a
 			// stale active org in another tab cannot block linking to the
@@ -1034,6 +1079,13 @@ func NewRouter(cfg *config.Config, pool *pgxpool.Pool, logger zerolog.Logger, se
 			r.Group(func(r chi.Router) {
 				r.Use(middleware.OrgContext)
 				r.Use(middleware.RequireRole("admin", "builder", "member"))
+
+				// Local agent gateway: tool list + server-proxied execution for
+				// `143-tools mcp serve` and local CLI tool calls. Builder-tier
+				// like the rest of the create-and-iterate surface; viewers
+				// cannot reach integration write tools.
+				r.Get("/api/v1/cli/tools", cliToolsHandler.ListTools)
+				r.Post("/api/v1/cli/tools/invoke", cliToolsHandler.Invoke)
 
 				// Coding-agents config reads. Builders and members can view what's
 				// configured (so /settings/agent renders read-only when needed);
@@ -1288,6 +1340,13 @@ func NewRouter(cfg *config.Config, pool *pgxpool.Pool, logger zerolog.Logger, se
 				// admin-only here.
 				r.Patch("/api/v1/team/members/{id}/role", teamHandler.ChangeRole)
 				r.Delete("/api/v1/team/members/{id}", teamHandler.RemoveMember)
+
+				// Org join links for zero-config CLI onboarding
+				// (curl .../install/<token> | sh). Admin-only: creating one
+				// hands out org membership.
+				r.Post("/api/v1/org/join-tokens", joinTokenHandler.Create)
+				r.Get("/api/v1/org/join-tokens", joinTokenHandler.List)
+				r.Delete("/api/v1/org/join-tokens/{id}", joinTokenHandler.Revoke)
 				r.Get("/api/v1/team/invitations", teamHandler.ListInvitations)
 				r.Post("/api/v1/team/invitations", teamHandler.CreateInvitation)
 				r.Delete("/api/v1/team/invitations/{id}", teamHandler.RevokeInvitation)

--- a/internal/cli/client.go
+++ b/internal/cli/client.go
@@ -1,0 +1,110 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/assembledhq/143/internal/version"
+)
+
+// Client is the minimal authenticated HTTP client for the 143 server. Every
+// request carries the bearer token, a `143-tools/<version>` User-Agent (the
+// server's CLIVersionGate keys on it), and the active-org header when set.
+type Client struct {
+	baseURL string
+	token   string
+	orgID   string
+	http    *http.Client
+}
+
+func NewClient(cfg Config) *Client {
+	return &Client{
+		baseURL: strings.TrimRight(cfg.ServerURL, "/"),
+		token:   cfg.Token,
+		orgID:   cfg.OrgID,
+		http:    &http.Client{Timeout: 60 * time.Second},
+	}
+}
+
+// APIError is a structured error response from the server.
+type APIError struct {
+	Status  int
+	Code    string
+	Message string
+}
+
+func (e *APIError) Error() string {
+	if e.Code != "" {
+		return fmt.Sprintf("%s: %s", e.Code, e.Message)
+	}
+	return fmt.Sprintf("server returned HTTP %d", e.Status)
+}
+
+// Do issues a JSON request and decodes the response into out (which may be
+// nil). Non-2xx responses are returned as *APIError with the server's error
+// code/message when present.
+func (c *Client) Do(ctx context.Context, method, path string, body, out any) error {
+	var reqBody io.Reader
+	if body != nil {
+		data, err := json.Marshal(body)
+		if err != nil {
+			return fmt.Errorf("encode request: %w", err)
+		}
+		reqBody = bytes.NewReader(data)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, method, c.baseURL+path, reqBody)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("User-Agent", "143-tools/"+version.BuildSHA)
+	req.Header.Set("Accept", "application/json")
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	if c.token != "" {
+		req.Header.Set("Authorization", "Bearer "+c.token)
+	}
+	if c.orgID != "" {
+		req.Header.Set("X-Active-Org-ID", c.orgID)
+	}
+
+	resp, err := c.http.Do(req) // #nosec G704 -- baseURL comes from the user's own config
+	if err != nil {
+		return fmt.Errorf("request %s %s: %w", method, path, err)
+	}
+	defer resp.Body.Close()
+
+	data, err := io.ReadAll(io.LimitReader(resp.Body, 32<<20))
+	if err != nil {
+		return fmt.Errorf("read response: %w", err)
+	}
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		apiErr := &APIError{Status: resp.StatusCode}
+		var envelope struct {
+			Error struct {
+				Code    string `json:"code"`
+				Message string `json:"message"`
+			} `json:"error"`
+		}
+		if jsonErr := json.Unmarshal(data, &envelope); jsonErr == nil {
+			apiErr.Code = envelope.Error.Code
+			apiErr.Message = envelope.Error.Message
+		}
+		return apiErr
+	}
+
+	if out != nil {
+		if err := json.Unmarshal(data, out); err != nil {
+			return fmt.Errorf("decode response: %w", err)
+		}
+	}
+	return nil
+}

--- a/internal/cli/commands.go
+++ b/internal/cli/commands.go
@@ -1,0 +1,273 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/assembledhq/143/internal/services/sandboxauth"
+	"github.com/assembledhq/143/internal/version"
+)
+
+// HandleSubcommand dispatches the laptop-side 143-tools commands. Returns
+// handled=false when args don't name one of them, so the caller falls
+// through to the integration-tool dispatch.
+func HandleSubcommand(args []string, stdout, stderr io.Writer) (handled bool, exitCode int) {
+	if len(args) == 0 {
+		return false, 0
+	}
+	switch args[0] {
+	case "login":
+		if refuseInSandbox(args[0], stderr) {
+			return true, 1
+		}
+		return true, runLogin(args[1:], stdout, stderr)
+	case "logout":
+		return true, runLogout(args[1:], stdout, stderr)
+	case "whoami":
+		return true, runWhoami(args[1:], stdout, stderr)
+	case "update":
+		if refuseInSandbox(args[0], stderr) {
+			return true, 1
+		}
+		return true, runUpdate(args[1:], stdout, stderr)
+	case "setup":
+		if refuseInSandbox(args[0], stderr) {
+			return true, 1
+		}
+		return true, runSetup(args[1:], stdout, stderr)
+	case "preview":
+		return true, runPreview(args[1:], stdout, stderr)
+	case "mcp":
+		if len(args) >= 2 && args[1] == "serve" {
+			return true, runMCPServe(stderr)
+		}
+		fmt.Fprintln(stderr, "Usage: 143-tools mcp serve")
+		return true, 1
+	}
+	return false, 0
+}
+
+// InSandbox reports whether this process is running inside a 143 sandbox.
+// Same signal the sandbox-side git/auth commands key on (the auth socket),
+// plus the internal API token every sandbox injects.
+func InSandbox() bool {
+	return os.Getenv(sandboxauth.SocketEnvVar) != "" || os.Getenv("INTERNAL_API_TOKEN") != ""
+}
+
+// refuseInSandbox blocks credential-minting and self-replacement commands
+// inside sandboxes: agents must never be able to mint user credentials
+// (login/setup) or swap out the tool binary under the orchestrator (update).
+func refuseInSandbox(command string, stderr io.Writer) bool {
+	if !InSandbox() {
+		return false
+	}
+	fmt.Fprintf(stderr, "error: `143-tools %s` is disabled inside sandboxes\n", command)
+	return true
+}
+
+// runSetup writes (or merges) the config file. Called by the install script
+// with the server URL — and join token, on tokened installs — templated by
+// the server. An existing login token for the same server is preserved so
+// re-running the installer upgrades in place.
+func runSetup(args []string, stdout, stderr io.Writer) int {
+	var server, join string
+	for i := 0; i < len(args); i++ {
+		switch args[i] {
+		case "--server":
+			if i+1 >= len(args) {
+				fmt.Fprintln(stderr, "error: --server requires a value")
+				return 1
+			}
+			i++
+			server = strings.TrimRight(args[i], "/")
+		case "--join":
+			if i+1 >= len(args) {
+				fmt.Fprintln(stderr, "error: --join requires a value")
+				return 1
+			}
+			i++
+			join = args[i]
+		case "--help", "-h":
+			fmt.Fprintln(stdout, "Usage: 143-tools setup --server URL [--join TOKEN]")
+			return 0
+		default:
+			fmt.Fprintf(stderr, "error: unknown flag %q\n", args[i])
+			return 1
+		}
+	}
+	if server == "" {
+		fmt.Fprintln(stderr, "error: --server is required")
+		return 1
+	}
+
+	cfg, err := LoadConfig()
+	if err != nil {
+		fmt.Fprintf(stderr, "error: %s\n", err)
+		return 1
+	}
+	if cfg.ServerURL != server {
+		// Pointing at a different server invalidates the old credential
+		// locally (it still exists server-side; logout would revoke it).
+		cfg.Token = ""
+		cfg.OrgID = ""
+	}
+	cfg.ServerURL = server
+	if join != "" {
+		cfg.PendingJoinToken = join
+	}
+	if err := SaveConfig(cfg); err != nil {
+		fmt.Fprintf(stderr, "error: %s\n", err)
+		return 1
+	}
+	fmt.Fprintf(stdout, "Configured server %s\n", server)
+	return 0
+}
+
+// runLogout revokes the current CLI token server-side, then clears it from
+// the config file.
+func runLogout(_ []string, stdout, stderr io.Writer) int {
+	cfg, err := LoadConfig()
+	if err != nil {
+		fmt.Fprintf(stderr, "error: %s\n", err)
+		return 1
+	}
+	if cfg.Token == "" {
+		fmt.Fprintln(stdout, "Not logged in.")
+		return 0
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	client := NewClient(cfg)
+
+	// Find our own token row by prefix to revoke it server-side. Best
+	// effort: clearing the local credential is the part logout must not
+	// fail at.
+	var resp struct {
+		Data []struct {
+			ID          string `json:"id"`
+			TokenPrefix string `json:"token_prefix"`
+		} `json:"data"`
+	}
+	if err := client.Do(ctx, http.MethodGet, "/api/v1/auth/cli-tokens", nil, &resp); err == nil {
+		for _, t := range resp.Data {
+			if strings.HasPrefix(cfg.Token, t.TokenPrefix) {
+				if err := client.Do(ctx, http.MethodDelete, "/api/v1/auth/cli-tokens/"+t.ID, nil, nil); err != nil {
+					fmt.Fprintf(stderr, "note: could not revoke token server-side: %s\n", err)
+				}
+				break
+			}
+		}
+	} else {
+		fmt.Fprintf(stderr, "note: could not revoke token server-side: %s\n", err)
+	}
+
+	cfg.Token = ""
+	cfg.OrgID = ""
+	if err := SaveConfig(cfg); err != nil {
+		fmt.Fprintf(stderr, "error: %s\n", err)
+		return 1
+	}
+	fmt.Fprintln(stdout, "Logged out.")
+	return 0
+}
+
+// runWhoami prints the authenticated identity. `--local` only checks the
+// config file (used by the installer to decide whether to chain into login)
+// and never touches the network.
+func runWhoami(args []string, stdout, stderr io.Writer) int {
+	local := false
+	for _, a := range args {
+		if a == "--local" {
+			local = true
+		}
+	}
+
+	cfg, err := LoadConfig()
+	if err != nil {
+		fmt.Fprintf(stderr, "error: %s\n", err)
+		return 1
+	}
+	if cfg.ServerURL == "" || cfg.Token == "" {
+		fmt.Fprintln(stderr, "Not logged in — run `143-tools login`.")
+		return 1
+	}
+	if local {
+		fmt.Fprintf(stdout, "Logged in to %s (token %s...)\n", cfg.ServerURL, tokenPrefixForDisplay(cfg.Token))
+		return 0
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	client := NewClient(cfg)
+
+	var me struct {
+		Data struct {
+			Email       string  `json:"email"`
+			Name        string  `json:"name"`
+			GitHubLogin *string `json:"github_login"`
+		} `json:"data"`
+	}
+	if err := client.Do(ctx, http.MethodGet, "/api/v1/auth/me", nil, &me); err != nil {
+		fmt.Fprintf(stderr, "error: %s\n", err)
+		return 1
+	}
+
+	identity := me.Data.Name
+	if me.Data.GitHubLogin != nil && *me.Data.GitHubLogin != "" {
+		identity = "@" + *me.Data.GitHubLogin
+	}
+	fmt.Fprintf(stdout, "User:    %s (%s)\n", identity, me.Data.Email)
+
+	var memberships struct {
+		Data struct {
+			ActiveOrgID string `json:"active_org_id"`
+			ActiveRole  string `json:"active_role"`
+			Memberships []struct {
+				OrgID   string `json:"org_id"`
+				OrgName string `json:"org_name"`
+			} `json:"memberships"`
+		} `json:"data"`
+	}
+	if err := client.Do(ctx, http.MethodGet, "/api/v1/auth/memberships", nil, &memberships); err == nil {
+		for _, m := range memberships.Data.Memberships {
+			if m.OrgID == memberships.Data.ActiveOrgID {
+				fmt.Fprintf(stdout, "Org:     %s (%s)\n", m.OrgName, memberships.Data.ActiveRole)
+				break
+			}
+		}
+	}
+	fmt.Fprintf(stdout, "Token:   %s...\n", tokenPrefixForDisplay(cfg.Token))
+	fmt.Fprintf(stdout, "Server:  %s\n", cfg.ServerURL)
+
+	printUpdateHintIfStale(ctx, client, stdout)
+	return 0
+}
+
+// printUpdateHintIfStale compares the CLI's embedded build version against
+// the server's and prints the one-line update hint on mismatch.
+func printUpdateHintIfStale(ctx context.Context, client *Client, stdout io.Writer) {
+	var resp struct {
+		Data struct {
+			Version string `json:"version"`
+		} `json:"data"`
+	}
+	if err := client.Do(ctx, http.MethodGet, "/api/v1/cli/version", nil, &resp); err != nil {
+		return
+	}
+	if resp.Data.Version != "" && resp.Data.Version != version.BuildSHA {
+		fmt.Fprintln(stdout, "\nA newer CLI is available — run `143-tools update`.")
+	}
+}
+
+func tokenPrefixForDisplay(token string) string {
+	if len(token) <= 13 {
+		return token
+	}
+	return token[:13]
+}

--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -1,0 +1,92 @@
+// Package cli implements the laptop-side commands of 143-tools: browser
+// login, token management, self-update, the server-proxied MCP gateway, and
+// the cwd-aware preview commands. Sandbox-side behavior (env-credential
+// tools, git helpers) lives in internal/services/mcp and
+// internal/services/sandboxauth and is unaffected — the same binary serves
+// both worlds, selected automatically by which credentials are present.
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// ConfigVersion is the current config-file schema version. The field exists
+// so the format can evolve (the obvious future change is multi-server
+// profiles keyed by server URL) without making the first migration a
+// breaking change.
+const ConfigVersion = 1
+
+// Config is ~/.config/143-tools/config.json. Token is the personal
+// "143u_..." CLI credential; mode 0600 because of it.
+type Config struct {
+	Version   int    `json:"version"`
+	ServerURL string `json:"server_url"`
+	Token     string `json:"token,omitempty"`
+	OrgID     string `json:"org_id,omitempty"`
+	// PendingJoinToken carries the join token from a tokened installer
+	// invocation until login consumes it. Cleared on successful login.
+	PendingJoinToken string `json:"pending_join_token,omitempty"`
+}
+
+// ConfigPath resolves the config file location, honoring XDG_CONFIG_HOME.
+func ConfigPath() (string, error) {
+	if dir := os.Getenv("XDG_CONFIG_HOME"); dir != "" {
+		return filepath.Join(dir, "143-tools", "config.json"), nil
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("resolve home directory: %w", err)
+	}
+	return filepath.Join(home, ".config", "143-tools", "config.json"), nil
+}
+
+// LoadConfig reads the config file. A missing file returns an empty config
+// and no error — callers distinguish "not set up" by ServerURL == "".
+func LoadConfig() (Config, error) {
+	path, err := ConfigPath()
+	if err != nil {
+		return Config{}, err
+	}
+	data, err := os.ReadFile(path) // #nosec G304 -- fixed well-known config path
+	if err != nil {
+		if os.IsNotExist(err) {
+			return Config{}, nil
+		}
+		return Config{}, fmt.Errorf("read config: %w", err)
+	}
+	var cfg Config
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		return Config{}, fmt.Errorf("parse %s: %w", path, err)
+	}
+	return cfg, nil
+}
+
+// SaveConfig writes the config atomically with mode 0600 (it holds a
+// credential). The parent directory is created as needed.
+func SaveConfig(cfg Config) error {
+	path, err := ConfigPath()
+	if err != nil {
+		return err
+	}
+	if cfg.Version == 0 {
+		cfg.Version = ConfigVersion
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return fmt.Errorf("create config directory: %w", err)
+	}
+	data, err := json.MarshalIndent(cfg, "", "  ")
+	if err != nil {
+		return fmt.Errorf("encode config: %w", err)
+	}
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, append(data, '\n'), 0o600); err != nil {
+		return fmt.Errorf("write config: %w", err)
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		return fmt.Errorf("replace config: %w", err)
+	}
+	return nil
+}

--- a/internal/cli/login.go
+++ b/internal/cli/login.go
@@ -1,0 +1,311 @@
+package cli
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"os"
+	"os/exec"
+	"runtime"
+	"strings"
+	"time"
+)
+
+// loginWait bounds how long `143-tools login` waits for the browser flow.
+const loginWait = 5 * time.Minute
+
+type loginOptions struct {
+	server    string
+	join      string
+	noBrowser bool
+}
+
+// callbackResult is what the loopback listener receives from the browser
+// redirect: a one-time code on success, or an error code + message.
+type callbackResult struct {
+	code    string
+	errCode string
+	errMsg  string
+}
+
+func runLogin(args []string, stdout, stderr io.Writer) int {
+	opts := loginOptions{}
+	for i := 0; i < len(args); i++ {
+		switch args[i] {
+		case "--server":
+			if i+1 >= len(args) {
+				fmt.Fprintln(stderr, "error: --server requires a value")
+				return 1
+			}
+			i++
+			opts.server = args[i]
+		case "--join":
+			if i+1 >= len(args) {
+				fmt.Fprintln(stderr, "error: --join requires a value")
+				return 1
+			}
+			i++
+			opts.join = args[i]
+		case "--no-browser":
+			opts.noBrowser = true
+		case "--help", "-h":
+			fmt.Fprintln(stdout, "Usage: 143-tools login [--server URL] [--join TOKEN] [--no-browser]")
+			return 0
+		default:
+			fmt.Fprintf(stderr, "error: unknown flag %q\n", args[i])
+			return 1
+		}
+	}
+
+	cfg, err := LoadConfig()
+	if err != nil {
+		fmt.Fprintf(stderr, "error: %s\n", err)
+		return 1
+	}
+	if opts.server != "" {
+		cfg.ServerURL = strings.TrimRight(opts.server, "/")
+	}
+	if cfg.ServerURL == "" {
+		fmt.Fprintln(stderr, "error: no server configured — run `143-tools login --server https://your-143-server`")
+		return 1
+	}
+	join := opts.join
+	if join == "" {
+		join = cfg.PendingJoinToken
+	}
+
+	// PKCE-style binding: the challenge rides through the browser, the
+	// verifier never leaves this process. Only the holder of the verifier
+	// can redeem the one-time code.
+	var verifierRaw [32]byte
+	if _, err := rand.Read(verifierRaw[:]); err != nil {
+		fmt.Fprintf(stderr, "error: generate verifier: %s\n", err)
+		return 1
+	}
+	verifier := hex.EncodeToString(verifierRaw[:])
+	challengeSum := sha256.Sum256([]byte(verifier))
+	challenge := hex.EncodeToString(challengeSum[:])
+
+	// Loopback listener on a random port. 127.0.0.1 hardcoded — never
+	// "localhost", which can resolve unexpectedly.
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		fmt.Fprintf(stderr, "error: start loopback listener: %s\n", err)
+		return 1
+	}
+	defer listener.Close()
+	port := listener.Addr().(*net.TCPAddr).Port
+
+	device, _ := os.Hostname()
+
+	startURL := buildStartURL(cfg.ServerURL, port, challenge, device, join)
+	if opts.noBrowser {
+		fmt.Fprintf(stdout, "Open this URL in your browser to log in:\n\n  %s\n\n", startURL)
+	} else {
+		fmt.Fprintln(stdout, "Opening your browser to complete login ...")
+		if err := openBrowser(startURL); err != nil {
+			fmt.Fprintf(stdout, "Could not open a browser automatically. Open this URL:\n\n  %s\n\n", startURL)
+		}
+	}
+
+	result, err := waitForCallback(listener, loginWait)
+	if err != nil {
+		fmt.Fprintf(stderr, "error: %s\n", err)
+		return 1
+	}
+	if result.errCode != "" {
+		msg := result.errMsg
+		if msg == "" {
+			msg = result.errCode
+		}
+		fmt.Fprintf(stderr, "login failed: %s\n", msg)
+		return 1
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	exchange, err := exchangeCode(ctx, cfg.ServerURL, result.code, verifier)
+	if err != nil {
+		fmt.Fprintf(stderr, "error: token exchange failed: %s\n", err)
+		return 1
+	}
+
+	cfg.Token = exchange.Token
+	cfg.PendingJoinToken = ""
+	if exchange.Org != nil {
+		cfg.OrgID = exchange.Org.ID
+	}
+	if err := SaveConfig(cfg); err != nil {
+		fmt.Fprintf(stderr, "error: %s\n", err)
+		return 1
+	}
+
+	// The new token is confirmed working (the exchange minted it and the
+	// config write succeeded) — now retire older tokens for this device so
+	// the "CLI sessions" list stays one row per device.
+	revokeStaleDeviceTokens(ctx, cfg, exchange.TokenID, device, stderr)
+
+	identity := exchange.User.Name
+	if exchange.User.GitHubLogin != nil && *exchange.User.GitHubLogin != "" {
+		identity = "@" + *exchange.User.GitHubLogin
+	}
+	if exchange.Org != nil {
+		fmt.Fprintf(stdout, "Logged in as %s (%s)\n", identity, exchange.Org.Name)
+	} else {
+		fmt.Fprintf(stdout, "Logged in as %s\n", identity)
+	}
+	return 0
+}
+
+func buildStartURL(server string, port int, challenge, device, join string) string {
+	params := url.Values{
+		"port":      {fmt.Sprintf("%d", port)},
+		"challenge": {challenge},
+	}
+	if device != "" {
+		params.Set("device", device)
+	}
+	if join != "" {
+		params.Set("join", join)
+	}
+	return server + "/api/v1/auth/cli/start?" + params.Encode()
+}
+
+// waitForCallback serves exactly one /callback request on the loopback
+// listener and returns its parameters. The handler responds with a tiny
+// "you can close this tab" page so the browser side ends cleanly.
+func waitForCallback(listener net.Listener, timeout time.Duration) (callbackResult, error) {
+	resultCh := make(chan callbackResult, 1)
+
+	server := &http.Server{
+		ReadHeaderTimeout: 10 * time.Second,
+		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path != "/callback" {
+				http.NotFound(w, r)
+				return
+			}
+			q := r.URL.Query()
+			res := callbackResult{
+				code:    q.Get("code"),
+				errCode: q.Get("error"),
+				errMsg:  q.Get("message"),
+			}
+			w.Header().Set("Content-Type", "text/html; charset=utf-8")
+			if res.errCode != "" {
+				w.WriteHeader(http.StatusForbidden)
+				fmt.Fprint(w, loginPage("Login failed", "Return to your terminal for details."))
+			} else {
+				fmt.Fprint(w, loginPage("You're in", "You can close this tab and return to your terminal."))
+			}
+			select {
+			case resultCh <- res:
+			default: // a second hit on /callback after the first resolves — drop it
+			}
+		}),
+	}
+	go func() { _ = server.Serve(listener) }()
+	defer func() {
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+		_ = server.Shutdown(ctx)
+	}()
+
+	select {
+	case res := <-resultCh:
+		return res, nil
+	case <-time.After(timeout):
+		return callbackResult{}, errors.New("timed out waiting for browser login (5 minutes) — re-run `143-tools login`")
+	}
+}
+
+func loginPage(title, body string) string {
+	return fmt.Sprintf(`<!doctype html><meta charset="utf-8"><title>143 CLI login</title>
+<body style="font-family: system-ui, sans-serif; max-width: 40rem; margin: 4rem auto;">
+<h1 style="font-size:1.2rem">%s</h1><p>%s</p></body>`, title, body)
+}
+
+type exchangeUser struct {
+	ID          string  `json:"id"`
+	Email       string  `json:"email"`
+	Name        string  `json:"name"`
+	GitHubLogin *string `json:"github_login"`
+}
+
+type exchangeOrg struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+}
+
+type exchangeResponse struct {
+	Token       string       `json:"token"`
+	TokenID     string       `json:"token_id"`
+	TokenPrefix string       `json:"token_prefix"`
+	ExpiresAt   time.Time    `json:"expires_at"`
+	User        exchangeUser `json:"user"`
+	Org         *exchangeOrg `json:"org"`
+}
+
+func exchangeCode(ctx context.Context, server, code, verifier string) (*exchangeResponse, error) {
+	client := NewClient(Config{ServerURL: server})
+	var resp struct {
+		Data exchangeResponse `json:"data"`
+	}
+	err := client.Do(ctx, http.MethodPost, "/api/v1/auth/cli/exchange",
+		map[string]string{"code": code, "verifier": verifier}, &resp)
+	if err != nil {
+		return nil, err
+	}
+	if resp.Data.Token == "" {
+		return nil, errors.New("server returned no token")
+	}
+	return &resp.Data, nil
+}
+
+// revokeStaleDeviceTokens lists the user's CLI tokens and revokes the ones
+// sharing this device name, keeping the freshly-minted one. Best-effort:
+// failures leave harmless extra rows in the sessions list, never a broken
+// login.
+func revokeStaleDeviceTokens(ctx context.Context, cfg Config, keepTokenID, device string, stderr io.Writer) {
+	if device == "" {
+		return
+	}
+	client := NewClient(cfg)
+	var resp struct {
+		Data []struct {
+			ID         string `json:"id"`
+			DeviceName string `json:"device_name"`
+		} `json:"data"`
+	}
+	if err := client.Do(ctx, http.MethodGet, "/api/v1/auth/cli-tokens", nil, &resp); err != nil {
+		fmt.Fprintf(stderr, "note: could not list older CLI sessions: %s\n", err)
+		return
+	}
+	for _, t := range resp.Data {
+		if t.DeviceName != device || t.ID == keepTokenID {
+			continue
+		}
+		if err := client.Do(ctx, http.MethodDelete, "/api/v1/auth/cli-tokens/"+t.ID, nil, nil); err != nil {
+			fmt.Fprintf(stderr, "note: could not revoke older CLI session %s: %s\n", t.ID, err)
+		}
+	}
+}
+
+// openBrowser launches the platform's default browser at url.
+func openBrowser(targetURL string) error {
+	switch runtime.GOOS {
+	case "darwin":
+		return exec.Command("open", targetURL).Start()
+	case "linux":
+		return exec.Command("xdg-open", targetURL).Start()
+	default:
+		return fmt.Errorf("unsupported platform %s", runtime.GOOS)
+	}
+}

--- a/internal/cli/main.go
+++ b/internal/cli/main.go
@@ -1,0 +1,130 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/assembledhq/143/internal/services/mcp"
+	"github.com/assembledhq/143/internal/services/sandboxauth"
+)
+
+// Main is the 143-tools entry point. Dispatch order:
+//
+//  1. Sandbox infrastructure subcommands (git-credential, auth-token, ...).
+//  2. Laptop commands (login, logout, whoami, update, setup, preview, mcp).
+//  3. Integration tools (`143-tools <namespace> <action>`), with the
+//     execution backend selected automatically: sandbox env credentials
+//     present → direct mode (existing behavior, unchanged); config-file
+//     token present → server-proxied mode. Same binary, no flags.
+func Main() {
+	args, overrides := extractGlobalFlags(os.Args[1:])
+
+	if handled, code := sandboxauth.HandleSubcommand(args, os.Stdin, os.Stdout, os.Stderr); handled {
+		os.Exit(code)
+	}
+	if handled, code := HandleSubcommand(args, os.Stdout, os.Stderr); handled {
+		os.Exit(code)
+	}
+
+	source, err := selectToolSource(context.Background(), overrides)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %s\n", err)
+		os.Exit(1)
+	}
+	os.Exit(mcp.RunCLI(context.Background(), source, args, os.Stdout, os.Stderr))
+}
+
+// globalOverrides are the leading `--token` / `--server` flags accepted
+// before any subcommand, for scripted use (CI jobs that inject a token
+// without writing a config file). Credential precedence: sandbox env vars →
+// --token flag → config file.
+type globalOverrides struct {
+	token  string
+	server string
+}
+
+// extractGlobalFlags strips leading --token/--server flags (both `--flag
+// value` and `--flag=value` forms) from args. Only leading flags are
+// consumed — flags after the first positional argument belong to the
+// subcommand or tool being invoked.
+func extractGlobalFlags(args []string) ([]string, globalOverrides) {
+	var overrides globalOverrides
+	for len(args) > 0 {
+		switch {
+		case args[0] == "--token" && len(args) > 1:
+			overrides.token = args[1]
+			args = args[2:]
+		case strings.HasPrefix(args[0], "--token="):
+			overrides.token = strings.TrimPrefix(args[0], "--token=")
+			args = args[1:]
+		case args[0] == "--server" && len(args) > 1:
+			overrides.server = args[1]
+			args = args[2:]
+		case strings.HasPrefix(args[0], "--server="):
+			overrides.server = strings.TrimPrefix(args[0], "--server=")
+			args = args[1:]
+		default:
+			return args, overrides
+		}
+	}
+	return args, overrides
+}
+
+// runMCPServe starts the stdio MCP server local agents register with
+// (`claude mcp add 143 -- 143-tools mcp serve`). Backend selection follows
+// the same rule as the CLI tool dispatch.
+func runMCPServe(stderr io.Writer) int {
+	source, err := selectToolSource(context.Background(), globalOverrides{})
+	if err != nil {
+		fmt.Fprintf(stderr, "error: %s\n", err)
+		return 1
+	}
+	server := mcp.NewServerWithSource(source, stderr)
+	if err := server.Serve(context.Background(), os.Stdin, os.Stdout); err != nil {
+		fmt.Fprintf(stderr, "error: %s\n", err)
+		return 1
+	}
+	return 0
+}
+
+// selectToolSource picks the execution backend. Inside a sandbox — or
+// whenever provider env credentials are present — tools run directly with
+// those credentials (the existing model). Otherwise, a logged-in config
+// proxies every call through the 143 server, where org credentials live
+// and per-user audit happens.
+func selectToolSource(ctx context.Context, overrides globalOverrides) (mcp.ToolSource, error) {
+	envRegistry := mcp.BuildRegistryFromEnv(os.Stderr)
+	direct := mcp.NewToolRegistry(envRegistry)
+	if InSandbox() || len(direct.ListTools()) > 0 {
+		return direct, nil
+	}
+
+	cfg, err := LoadConfig()
+	if err != nil {
+		return nil, err
+	}
+	if overrides.token != "" {
+		cfg.Token = overrides.token
+	}
+	if overrides.server != "" {
+		cfg.ServerURL = strings.TrimRight(overrides.server, "/")
+	}
+	if cfg.ServerURL == "" || cfg.Token == "" {
+		// No env credentials and no login: return the (empty) direct
+		// registry so help output explains how to configure, matching the
+		// historical behavior of running outside a sandbox.
+		return direct, nil
+	}
+
+	fetchCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+	remote, err := NewRemoteToolSource(fetchCtx, cfg)
+	if err != nil {
+		return nil, fmt.Errorf("connect to %s: %w (try `143-tools login`)", cfg.ServerURL, err)
+	}
+	return remote, nil
+}

--- a/internal/cli/preview.go
+++ b/internal/cli/preview.go
@@ -1,0 +1,222 @@
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os/exec"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/assembledhq/143/internal/services/mcp"
+)
+
+// previewWaitTimeout bounds `preview create --wait`.
+const previewWaitTimeout = 15 * time.Minute
+
+// runPreview implements the human-facing preview commands. `create` infers
+// repository and branch from the cwd's git context, so on a laptop inside a
+// checkout the whole command is just `143-tools preview create --wait`.
+func runPreview(args []string, stdout, stderr io.Writer) int {
+	if len(args) == 0 || args[0] == "--help" || args[0] == "-h" {
+		fmt.Fprintln(stdout, `Usage:
+  143-tools preview create [--repo NAME] [--branch NAME] [--wait]
+  143-tools preview status <preview-id>
+  143-tools preview list
+  143-tools preview stop <preview-id>
+
+create infers --repo from the cwd's git remote and --branch from HEAD when omitted.`)
+		return 0
+	}
+
+	cfg, err := LoadConfig()
+	if err != nil {
+		fmt.Fprintf(stderr, "error: %s\n", err)
+		return 1
+	}
+	if cfg.Token == "" || cfg.ServerURL == "" {
+		fmt.Fprintln(stderr, "error: not logged in — run `143-tools login`")
+		return 1
+	}
+	executor := &previewToolExecutor{client: NewClient(cfg)}
+	ctx, cancel := context.WithTimeout(context.Background(), previewWaitTimeout)
+	defer cancel()
+
+	switch args[0] {
+	case "create":
+		return runPreviewCreate(ctx, executor, args[1:], stdout, stderr)
+	case "status":
+		if len(args) < 2 {
+			fmt.Fprintln(stderr, "Usage: 143-tools preview status <preview-id>")
+			return 1
+		}
+		return printToolResult(executor.status(ctx, mustJSON(map[string]string{"preview_id": args[1]})), stdout, stderr)
+	case "list":
+		return printToolResult(executor.list(ctx), stdout, stderr)
+	case "stop":
+		if len(args) < 2 {
+			fmt.Fprintln(stderr, "Usage: 143-tools preview stop <preview-id>")
+			return 1
+		}
+		return printToolResult(executor.stop(ctx, mustJSON(map[string]string{"preview_id": args[1]})), stdout, stderr)
+	default:
+		fmt.Fprintf(stderr, "error: unknown preview subcommand %q\n", args[0])
+		return 1
+	}
+}
+
+func runPreviewCreate(ctx context.Context, executor *previewToolExecutor, args []string, stdout, stderr io.Writer) int {
+	var repo, branch string
+	wait := false
+	for i := 0; i < len(args); i++ {
+		switch args[i] {
+		case "--repo":
+			if i+1 >= len(args) {
+				fmt.Fprintln(stderr, "error: --repo requires a value")
+				return 1
+			}
+			i++
+			repo = args[i]
+		case "--branch":
+			if i+1 >= len(args) {
+				fmt.Fprintln(stderr, "error: --branch requires a value")
+				return 1
+			}
+			i++
+			branch = args[i]
+		case "--wait":
+			wait = true
+		default:
+			fmt.Fprintf(stderr, "error: unknown flag %q\n", args[i])
+			return 1
+		}
+	}
+
+	if repo == "" {
+		inferred, err := gitRemoteRepoName()
+		if err != nil {
+			fmt.Fprintf(stderr, "error: --repo not given and could not infer it from the cwd: %s\n", err)
+			return 1
+		}
+		repo = inferred
+	}
+	if branch == "" {
+		inferred, err := gitCurrentBranch()
+		if err != nil {
+			fmt.Fprintf(stderr, "error: --branch not given and could not infer it from the cwd: %s\n", err)
+			return 1
+		}
+		branch = inferred
+	}
+
+	fmt.Fprintf(stdout, "Creating preview of %s @ %s ...\n", repo, branch)
+	result := executor.create(ctx, mustJSON(map[string]string{"repository": repo, "branch": branch}))
+	if result.IsError {
+		return printToolResult(result, stdout, stderr)
+	}
+
+	var created previewView
+	if err := json.Unmarshal([]byte(firstText(result)), &created); err != nil {
+		return printToolResult(result, stdout, stderr)
+	}
+
+	if !wait {
+		if created.PreviewURL != nil && *created.PreviewURL != "" {
+			fmt.Fprintf(stdout, "Preview %s (%s): %s\n", created.PreviewID, created.Status, *created.PreviewURL)
+		} else {
+			fmt.Fprintf(stdout, "Preview %s is %s — `143-tools preview status %s` to follow it.\n",
+				created.PreviewID, created.Status, created.PreviewID)
+		}
+		return 0
+	}
+
+	// --wait: poll status until the preview is live or fails.
+	for {
+		select {
+		case <-ctx.Done():
+			fmt.Fprintf(stderr, "error: timed out waiting for preview %s\n", created.PreviewID)
+			return 1
+		case <-time.After(3 * time.Second):
+		}
+
+		statusResult := executor.status(ctx, mustJSON(map[string]string{"preview_id": created.PreviewID}))
+		if statusResult.IsError {
+			return printToolResult(statusResult, stdout, stderr)
+		}
+		var current previewView
+		if err := json.Unmarshal([]byte(firstText(statusResult)), &current); err != nil {
+			return printToolResult(statusResult, stdout, stderr)
+		}
+		switch current.Status {
+		case "running":
+			url := ""
+			if current.PreviewURL != nil {
+				url = *current.PreviewURL
+			}
+			fmt.Fprintf(stdout, "Preview is live: %s\n", url)
+			return 0
+		case "failed", "stopped":
+			fmt.Fprintf(stderr, "error: preview %s: %s\n", current.Status, current.Error)
+			return 1
+		default:
+			phase := current.CurrentPhase
+			if phase == "" {
+				phase = current.Status
+			}
+			fmt.Fprintf(stdout, "  ... %s\n", phase)
+		}
+	}
+}
+
+func printToolResult(result *mcp.ToolCallResult, stdout, stderr io.Writer) int {
+	if result.IsError {
+		fmt.Fprintln(stderr, firstText(result))
+		return 1
+	}
+	fmt.Fprintln(stdout, firstText(result))
+	return 0
+}
+
+func firstText(result *mcp.ToolCallResult) string {
+	if len(result.Content) == 0 {
+		return ""
+	}
+	return result.Content[0].Text
+}
+
+// gitRemoteURLPattern extracts "owner/repo" from https and ssh remote URLs.
+var gitRemoteURLPattern = regexp.MustCompile(`(?:github\.com[:/])([^/]+/[^/]+?)(?:\.git)?$`)
+
+// gitRemoteRepoName reads the cwd's origin remote and extracts the
+// "owner/repo" name the server-side repository resolution expects.
+func gitRemoteRepoName() (string, error) {
+	out, err := exec.Command("git", "remote", "get-url", "origin").Output()
+	if err != nil {
+		return "", fmt.Errorf("not inside a git checkout with an `origin` remote")
+	}
+	remote := strings.TrimSpace(string(out))
+	m := gitRemoteURLPattern.FindStringSubmatch(remote)
+	if m == nil {
+		return "", fmt.Errorf("could not parse repository name from remote %q", remote)
+	}
+	return m[1], nil
+}
+
+func gitCurrentBranch() (string, error) {
+	out, err := exec.Command("git", "rev-parse", "--abbrev-ref", "HEAD").Output()
+	if err != nil {
+		return "", fmt.Errorf("not inside a git checkout")
+	}
+	branch := strings.TrimSpace(string(out))
+	if branch == "" || branch == "HEAD" {
+		return "", fmt.Errorf("detached HEAD — pass --branch explicitly")
+	}
+	return branch, nil
+}
+
+func mustJSON(v any) json.RawMessage {
+	data, _ := json.Marshal(v)
+	return data
+}

--- a/internal/cli/preview_tools.go
+++ b/internal/cli/preview_tools.go
@@ -1,0 +1,279 @@
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/assembledhq/143/internal/services/mcp"
+)
+
+// previewToolExecutor implements the platform preview tools
+// (preview_create/status/list/stop) as thin client-side wrappers over the
+// existing /api/v1/previews* REST endpoints, which already work under
+// bearer auth. preview_create accepts a repository *name* (agents don't
+// know UUIDs) and resolves it against the org's repositories, and returns
+// immediately — agents poll preview_status rather than holding a long-lived
+// tool call.
+type previewToolExecutor struct {
+	client *Client
+}
+
+func (e *previewToolExecutor) handles(name string) bool {
+	switch name {
+	case "preview_create", "preview_status", "preview_list", "preview_stop":
+		return true
+	}
+	return false
+}
+
+func (e *previewToolExecutor) tools() []mcp.Tool {
+	return []mcp.Tool{
+		{
+			Name: "preview_create",
+			Description: "Create (or reuse) a live preview environment for a branch of one of the org's repositories. " +
+				"Returns {preview_id, preview_url, status} immediately — poll preview_status until status is \"running\". " +
+				"The branch must already be pushed to the remote (previews build from the pushed repo, not the local working tree).",
+			InputSchema: mcp.ToolSchema{
+				Type: "object",
+				Properties: map[string]mcp.SchemaProperty{
+					"repository": {Type: "string", Description: `Repository name, e.g. "acme/webapp" or just "webapp"`},
+					"branch":     {Type: "string", Description: "Branch name (must exist on the remote)"},
+				},
+				Required: []string{"repository", "branch"},
+			},
+		},
+		{
+			Name:        "preview_status",
+			Description: "Get the current status of a preview environment. Returns status, preview_url when live, and any error.",
+			InputSchema: mcp.ToolSchema{
+				Type: "object",
+				Properties: map[string]mcp.SchemaProperty{
+					"preview_id": {Type: "string", Description: "The preview ID returned by preview_create"},
+				},
+				Required: []string{"preview_id"},
+			},
+		},
+		{
+			Name:        "preview_list",
+			Description: "List the org's branch preview environments with their statuses and URLs.",
+			InputSchema: mcp.ToolSchema{Type: "object"},
+		},
+		{
+			Name:        "preview_stop",
+			Description: "Stop a running preview environment.",
+			InputSchema: mcp.ToolSchema{
+				Type: "object",
+				Properties: map[string]mcp.SchemaProperty{
+					"preview_id": {Type: "string", Description: "The preview ID to stop"},
+				},
+				Required: []string{"preview_id"},
+			},
+		},
+	}
+}
+
+func (e *previewToolExecutor) call(ctx context.Context, name string, args json.RawMessage) *mcp.ToolCallResult {
+	switch name {
+	case "preview_create":
+		return e.create(ctx, args)
+	case "preview_status":
+		return e.status(ctx, args)
+	case "preview_list":
+		return e.list(ctx)
+	case "preview_stop":
+		return e.stop(ctx, args)
+	}
+	return mcp.ErrorResult(fmt.Sprintf("unknown preview tool %q", name))
+}
+
+// previewView is the slice of the server's branch-preview response surfaced
+// to agents: enough to act on, nothing to parse around.
+type previewView struct {
+	PreviewID    string  `json:"preview_id"`
+	Repository   string  `json:"repository,omitempty"`
+	Branch       string  `json:"branch,omitempty"`
+	Status       string  `json:"status"`
+	PreviewURL   *string `json:"preview_url"`
+	CurrentPhase string  `json:"current_phase,omitempty"`
+	Error        string  `json:"error,omitempty"`
+}
+
+// branchPreviewWire mirrors the fields of the server's branch-preview
+// response this executor consumes.
+type branchPreviewWire struct {
+	TargetID           string  `json:"target_id"`
+	PreviewID          *string `json:"preview_id"`
+	RepositoryFullName string  `json:"repository_full_name"`
+	Branch             string  `json:"branch"`
+	Status             string  `json:"status"`
+	PreviewURL         *string `json:"preview_url"`
+	CurrentPhase       string  `json:"current_phase"`
+	Error              string  `json:"error"`
+}
+
+func (w branchPreviewWire) view() previewView {
+	id := w.TargetID
+	if w.PreviewID != nil && *w.PreviewID != "" {
+		id = *w.PreviewID
+	}
+	return previewView{
+		PreviewID:    id,
+		Repository:   w.RepositoryFullName,
+		Branch:       w.Branch,
+		Status:       w.Status,
+		PreviewURL:   w.PreviewURL,
+		CurrentPhase: w.CurrentPhase,
+		Error:        w.Error,
+	}
+}
+
+func (e *previewToolExecutor) create(ctx context.Context, args json.RawMessage) *mcp.ToolCallResult {
+	var params struct {
+		Repository string `json:"repository"`
+		Branch     string `json:"branch"`
+	}
+	if err := json.Unmarshal(args, &params); err != nil || params.Repository == "" || params.Branch == "" {
+		return mcp.ErrorResult("repository and branch are required")
+	}
+
+	repoID, repoFullName, err := e.resolveRepository(ctx, params.Repository)
+	if err != nil {
+		return mcp.ErrorResult(err.Error())
+	}
+
+	// Branch-existence preflight: the #1 failure mode for local use is a
+	// branch that only exists in the local working tree. A distinct error
+	// naming the fix lets agents recover without guessing.
+	if exists, checkErr := e.branchExists(ctx, repoID, params.Branch); checkErr == nil && !exists {
+		return mcp.ErrorResult(fmt.Sprintf(
+			"BRANCH_NOT_PUSHED: branch %q does not exist on the remote for %s — run `git push -u origin %s` first, then retry",
+			params.Branch, repoFullName, params.Branch))
+	}
+
+	var resp struct {
+		Data branchPreviewWire `json:"data"`
+	}
+	err = e.client.Do(ctx, http.MethodPost, "/api/v1/previews",
+		map[string]string{"repository_id": repoID, "branch": params.Branch}, &resp)
+	if err != nil {
+		return mcp.ErrorResult(fmt.Sprintf("preview create failed: %s", err))
+	}
+	return jsonResult(resp.Data.view())
+}
+
+func (e *previewToolExecutor) status(ctx context.Context, args json.RawMessage) *mcp.ToolCallResult {
+	var params struct {
+		PreviewID string `json:"preview_id"`
+	}
+	if err := json.Unmarshal(args, &params); err != nil || params.PreviewID == "" {
+		return mcp.ErrorResult("preview_id is required")
+	}
+	var resp struct {
+		Data branchPreviewWire `json:"data"`
+	}
+	if err := e.client.Do(ctx, http.MethodGet, "/api/v1/previews/"+params.PreviewID, nil, &resp); err != nil {
+		return mcp.ErrorResult(fmt.Sprintf("preview status failed: %s", err))
+	}
+	return jsonResult(resp.Data.view())
+}
+
+func (e *previewToolExecutor) list(ctx context.Context) *mcp.ToolCallResult {
+	var resp struct {
+		Data []branchPreviewWire `json:"data"`
+	}
+	if err := e.client.Do(ctx, http.MethodGet, "/api/v1/previews", nil, &resp); err != nil {
+		return mcp.ErrorResult(fmt.Sprintf("preview list failed: %s", err))
+	}
+	views := make([]previewView, 0, len(resp.Data))
+	for _, p := range resp.Data {
+		views = append(views, p.view())
+	}
+	return jsonResult(views)
+}
+
+func (e *previewToolExecutor) stop(ctx context.Context, args json.RawMessage) *mcp.ToolCallResult {
+	var params struct {
+		PreviewID string `json:"preview_id"`
+	}
+	if err := json.Unmarshal(args, &params); err != nil || params.PreviewID == "" {
+		return mcp.ErrorResult("preview_id is required")
+	}
+	if err := e.client.Do(ctx, http.MethodPost, "/api/v1/previews/"+params.PreviewID+"/stop", nil, nil); err != nil {
+		return mcp.ErrorResult(fmt.Sprintf("preview stop failed: %s", err))
+	}
+	return jsonResult(map[string]string{"preview_id": params.PreviewID, "status": "stopping"})
+}
+
+// resolveRepository matches a human/agent-supplied name against the org's
+// repositories: exact full_name ("acme/webapp") first, then unique
+// short-name ("webapp"). Ambiguity and misses return errors that name the
+// candidates so agents can self-correct.
+func (e *previewToolExecutor) resolveRepository(ctx context.Context, name string) (id, fullName string, err error) {
+	var resp struct {
+		Data []struct {
+			ID       string `json:"id"`
+			FullName string `json:"full_name"`
+		} `json:"data"`
+	}
+	if err := e.client.Do(ctx, http.MethodGet, "/api/v1/repositories", nil, &resp); err != nil {
+		return "", "", fmt.Errorf("list repositories: %w", err)
+	}
+
+	name = strings.TrimSpace(name)
+	var matches []struct{ id, fullName string }
+	for _, repo := range resp.Data {
+		if strings.EqualFold(repo.FullName, name) {
+			return repo.ID, repo.FullName, nil
+		}
+		if parts := strings.SplitN(repo.FullName, "/", 2); len(parts) == 2 && strings.EqualFold(parts[1], name) {
+			matches = append(matches, struct{ id, fullName string }{repo.ID, repo.FullName})
+		}
+	}
+	switch len(matches) {
+	case 1:
+		return matches[0].id, matches[0].fullName, nil
+	case 0:
+		available := make([]string, 0, len(resp.Data))
+		for _, repo := range resp.Data {
+			available = append(available, repo.FullName)
+		}
+		return "", "", fmt.Errorf("repository %q not found — connected repositories: %s", name, strings.Join(available, ", "))
+	default:
+		candidates := make([]string, 0, len(matches))
+		for _, m := range matches {
+			candidates = append(candidates, m.fullName)
+		}
+		return "", "", fmt.Errorf("repository %q is ambiguous — use the full name: %s", name, strings.Join(candidates, ", "))
+	}
+}
+
+// branchExists checks the remote for the branch. Errors are swallowed by
+// the caller (the create call itself will surface a real failure) — this
+// is purely the fast-path for the BRANCH_NOT_PUSHED hint.
+func (e *previewToolExecutor) branchExists(ctx context.Context, repoID, branch string) (bool, error) {
+	var resp struct {
+		Data []struct {
+			Name string `json:"name"`
+		} `json:"data"`
+	}
+	if err := e.client.Do(ctx, http.MethodGet, "/api/v1/repositories/"+repoID+"/branches", nil, &resp); err != nil {
+		return false, err
+	}
+	for _, b := range resp.Data {
+		if b.Name == branch {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func jsonResult(v any) *mcp.ToolCallResult {
+	data, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		return mcp.ErrorResult(fmt.Sprintf("encode result: %s", err))
+	}
+	return mcp.TextResult(string(data))
+}

--- a/internal/cli/remote.go
+++ b/internal/cli/remote.go
@@ -1,0 +1,63 @@
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/assembledhq/143/internal/services/mcp"
+)
+
+// RemoteToolSource implements mcp.ToolSource against the 143 server's local
+// agent gateway. Integration tools are listed from GET /api/v1/cli/tools at
+// construction (so availability mirrors the org's connected integrations)
+// and executed via POST /api/v1/cli/tools/invoke with the user's bearer
+// token — org credentials never exist on this machine. Platform preview
+// tools are layered on top and execute client-side against the public
+// /api/v1/previews* REST endpoints, which already work under bearer auth.
+type RemoteToolSource struct {
+	client  *Client
+	tools   []mcp.Tool
+	preview *previewToolExecutor
+}
+
+// NewRemoteToolSource fetches the org's tool list and assembles the source.
+func NewRemoteToolSource(ctx context.Context, cfg Config) (*RemoteToolSource, error) {
+	client := NewClient(cfg)
+	var resp struct {
+		Data struct {
+			Tools []mcp.Tool `json:"tools"`
+		} `json:"data"`
+	}
+	if err := client.Do(ctx, http.MethodGet, "/api/v1/cli/tools", nil, &resp); err != nil {
+		return nil, fmt.Errorf("fetch tool list: %w", err)
+	}
+
+	preview := &previewToolExecutor{client: client}
+	return &RemoteToolSource{
+		client:  client,
+		tools:   append(resp.Data.Tools, preview.tools()...),
+		preview: preview,
+	}, nil
+}
+
+func (s *RemoteToolSource) ListTools() []mcp.Tool {
+	return s.tools
+}
+
+func (s *RemoteToolSource) CallTool(ctx context.Context, name string, args json.RawMessage) *mcp.ToolCallResult {
+	if s.preview.handles(name) {
+		return s.preview.call(ctx, name, args)
+	}
+
+	var resp struct {
+		Data mcp.ToolCallResult `json:"data"`
+	}
+	err := s.client.Do(ctx, http.MethodPost, "/api/v1/cli/tools/invoke",
+		map[string]any{"tool": name, "args": args}, &resp)
+	if err != nil {
+		return mcp.ErrorResult(fmt.Sprintf("tool invocation failed: %s", err))
+	}
+	return &resp.Data
+}

--- a/internal/cli/update.go
+++ b/internal/cli/update.go
@@ -89,7 +89,7 @@ func runUpdate(_ []string, stdout, stderr io.Writer) int {
 
 	hasher := sha256.New()
 	if _, err := io.Copy(io.MultiWriter(tmp, hasher), resp.Body); err != nil {
-		tmp.Close()
+		_ = tmp.Close()
 		fmt.Fprintf(stderr, "error: download failed: %s\n", err)
 		return 1
 	}
@@ -107,7 +107,9 @@ func runUpdate(_ []string, stdout, stderr io.Writer) int {
 		fmt.Fprintln(stderr, "warning: server sent no checksum header; installing unverified")
 	}
 
-	if err := os.Chmod(tmpPath, 0o755); err != nil { // #nosec G302 -- executable binary
+	// 0755 is required: this staged file becomes the 143-tools executable.
+	err = os.Chmod(tmpPath, 0o755) // #nosec G302 -- executable binary, not a data file
+	if err != nil {
 		fmt.Fprintf(stderr, "error: %s\n", err)
 		return 1
 	}

--- a/internal/cli/update.go
+++ b/internal/cli/update.go
@@ -1,0 +1,121 @@
+package cli
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"runtime"
+	"time"
+
+	"github.com/assembledhq/143/internal/version"
+)
+
+// runUpdate re-downloads the binary for this platform from the configured
+// server and atomically replaces the running executable. The server sets
+// X-Checksum-Sha256 on the download; the replacement is verified against it
+// before the swap.
+func runUpdate(_ []string, stdout, stderr io.Writer) int {
+	cfg, err := LoadConfig()
+	if err != nil {
+		fmt.Fprintf(stderr, "error: %s\n", err)
+		return 1
+	}
+	if cfg.ServerURL == "" {
+		fmt.Fprintln(stderr, "error: no server configured — run `143-tools login --server <url>` first")
+		return 1
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+
+	// Version skew check: skip the download when already current.
+	client := NewClient(cfg)
+	var versionResp struct {
+		Data struct {
+			Version string `json:"version"`
+		} `json:"data"`
+	}
+	if err := client.Do(ctx, http.MethodGet, "/api/v1/cli/version", nil, &versionResp); err == nil {
+		if versionResp.Data.Version != "" && versionResp.Data.Version == version.BuildSHA {
+			fmt.Fprintf(stdout, "Already up to date (%s).\n", version.BuildSHA)
+			return 0
+		}
+	}
+
+	exe, err := os.Executable()
+	if err != nil {
+		fmt.Fprintf(stderr, "error: locate current binary: %s\n", err)
+		return 1
+	}
+	exe, err = filepath.EvalSymlinks(exe)
+	if err != nil {
+		fmt.Fprintf(stderr, "error: resolve current binary: %s\n", err)
+		return 1
+	}
+
+	downloadURL := fmt.Sprintf("%s/download/143-tools/%s/%s", cfg.ServerURL, runtime.GOOS, runtime.GOARCH)
+	fmt.Fprintf(stdout, "Downloading %s ...\n", downloadURL)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, downloadURL, nil)
+	if err != nil {
+		fmt.Fprintf(stderr, "error: %s\n", err)
+		return 1
+	}
+	req.Header.Set("User-Agent", "143-tools/"+version.BuildSHA)
+	resp, err := (&http.Client{Timeout: 5 * time.Minute}).Do(req) // #nosec G704 -- server URL comes from the user's own config
+	if err != nil {
+		fmt.Fprintf(stderr, "error: download failed: %s\n", err)
+		return 1
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		fmt.Fprintf(stderr, "error: download failed: HTTP %d\n", resp.StatusCode)
+		return 1
+	}
+
+	// Stage next to the target so the final rename is same-filesystem atomic.
+	tmp, err := os.CreateTemp(filepath.Dir(exe), ".143-tools-update-*")
+	if err != nil {
+		fmt.Fprintf(stderr, "error: stage update: %s\n", err)
+		return 1
+	}
+	tmpPath := tmp.Name()
+	defer os.Remove(tmpPath)
+
+	hasher := sha256.New()
+	if _, err := io.Copy(io.MultiWriter(tmp, hasher), resp.Body); err != nil {
+		tmp.Close()
+		fmt.Fprintf(stderr, "error: download failed: %s\n", err)
+		return 1
+	}
+	if err := tmp.Close(); err != nil {
+		fmt.Fprintf(stderr, "error: stage update: %s\n", err)
+		return 1
+	}
+
+	if expected := resp.Header.Get("X-Checksum-Sha256"); expected != "" {
+		if actual := hex.EncodeToString(hasher.Sum(nil)); actual != expected {
+			fmt.Fprintf(stderr, "error: checksum mismatch (expected %s, got %s) — aborting update\n", expected, actual)
+			return 1
+		}
+	} else {
+		fmt.Fprintln(stderr, "warning: server sent no checksum header; installing unverified")
+	}
+
+	if err := os.Chmod(tmpPath, 0o755); err != nil { // #nosec G302 -- executable binary
+		fmt.Fprintf(stderr, "error: %s\n", err)
+		return 1
+	}
+	if err := os.Rename(tmpPath, exe); err != nil {
+		fmt.Fprintf(stderr, "error: replace binary: %s\n", err)
+		return 1
+	}
+
+	fmt.Fprintf(stdout, "Updated %s\n", exe)
+	return 0
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -52,6 +52,19 @@ type Config struct {
 	// only if you also regenerate the bcrypt hash in the seed.
 	DemoEmail    string `env:"DEMO_EMAIL"    envDefault:"preview-admin@143.dev"`
 	DemoPassword string `env:"DEMO_PASSWORD" envDefault:"preview"`
+	// CLIDistDir is the directory holding the cross-compiled 143-tools
+	// binaries plus checksums.txt, baked into the server image by the
+	// Dockerfile cli stage. The /install.sh and /download/143-tools/*
+	// routes serve from here; they 404 when the directory is absent
+	// (e.g. `go run` in local dev without `make build-cli`).
+	CLIDistDir string `env:"CLI_DIST_DIR" envDefault:"/opt/143/cli"`
+	// CLIMinSupportedVersion, when set to an orderable version (dotted
+	// numerics, e.g. "1.4.0"), causes authenticated requests from a CLI
+	// advertising an older `User-Agent: 143-tools/<version>` to fail with
+	// 426 CLI_UPDATE_REQUIRED so breaking API changes have a clean failure
+	// mode. Empty (the default) disables enforcement; non-orderable CLI
+	// versions (git SHAs, "dev") are never blocked.
+	CLIMinSupportedVersion string `env:"CLI_MIN_SUPPORTED_VERSION"`
 	// WorkerProcessCount controls how many worker loops run inside a single
 	// server process when MODE is "worker" or "all". Increase this on larger
 	// hosts to process more jobs/sandboxes in parallel.

--- a/internal/db/cli_auth_codes.go
+++ b/internal/db/cli_auth_codes.go
@@ -1,0 +1,103 @@
+package db
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/assembledhq/143/internal/models"
+)
+
+// CLIAuthCodeTTL bounds the window between the browser completing OAuth and
+// the CLI exchanging the one-time code. 60 seconds covers the loopback
+// redirect plus one HTTP round-trip with a wide margin while keeping a
+// leaked code (browser history, proxy log) useless almost immediately —
+// and the verifier binding makes even a live code unredeemable by anyone
+// but the CLI that started the flow.
+const CLIAuthCodeTTL = 60 * time.Second
+
+const cliAuthCodeColumns = `id, code_hash, challenge, user_id, org_id,
+	device_name, expires_at, consumed_at, created_at`
+
+// GenerateCLIAuthCode returns a fresh one-time code (32 bytes of entropy,
+// hex) for the loopback redirect. Only its SHA-256 is persisted.
+func GenerateCLIAuthCode() (string, error) {
+	var raw [32]byte
+	if _, err := rand.Read(raw[:]); err != nil {
+		return "", fmt.Errorf("generate cli auth code: %w", err)
+	}
+	return hex.EncodeToString(raw[:]), nil
+}
+
+// HashCLIAuthCode is the deterministic lookup hash for one-time codes. Plain
+// SHA-256 hex (no prefix): the codes are single-purpose and never co-mingle
+// with the "sha256:"-prefixed token hashes.
+func HashCLIAuthCode(code string) string {
+	sum := sha256.Sum256([]byte(code))
+	return hex.EncodeToString(sum[:])
+}
+
+// CLIAuthCodeStore persists the one-time codes bridging the OAuth callback
+// to the CLI loopback exchange. The rows must survive across server
+// replicas (rolling deploys), which is why this is a table and not memory.
+type CLIAuthCodeStore struct {
+	db DBTX
+}
+
+func NewCLIAuthCodeStore(db DBTX) *CLIAuthCodeStore {
+	return &CLIAuthCodeStore{db: db}
+}
+
+// Create inserts a handshake row and opportunistically garbage-collects
+// long-expired ones. The GC rides on insert because login traffic is the
+// only thing that creates garbage here — no background job needed.
+//
+// lint:allow-no-orgid reason="60-second pre-auth handshake row; user/org are payload columns resolved by the callback, not a tenancy scope"
+func (s *CLIAuthCodeStore) Create(ctx context.Context, code *models.CLIAuthCode) error {
+	// Best-effort GC; an error here must not block a login.
+	_, _ = s.db.Exec(ctx, `DELETE FROM cli_auth_codes WHERE expires_at < now() - interval '1 hour'`)
+
+	query := fmt.Sprintf(`INSERT INTO cli_auth_codes (
+		code_hash, challenge, user_id, org_id, device_name, expires_at
+	) VALUES (
+		@code_hash, @challenge, @user_id, @org_id, @device_name, @expires_at
+	) RETURNING %s`, cliAuthCodeColumns)
+	rows, err := s.db.Query(ctx, query, pgx.NamedArgs{
+		"code_hash":   code.CodeHash,
+		"challenge":   code.Challenge,
+		"user_id":     code.UserID,
+		"org_id":      code.OrgID,
+		"device_name": code.DeviceName,
+		"expires_at":  code.ExpiresAt,
+	})
+	if err != nil {
+		return fmt.Errorf("create cli auth code: %w", err)
+	}
+	row, err := pgx.CollectOneRow(rows, pgx.RowToStructByName[models.CLIAuthCode])
+	if err != nil {
+		return fmt.Errorf("scan cli auth code: %w", err)
+	}
+	*code = row
+	return nil
+}
+
+// Consume atomically marks an unconsumed, unexpired code as used and returns
+// it. pgx.ErrNoRows means the code is unknown, already consumed, or expired —
+// the caller cannot distinguish, by design (a single 410 covers all three).
+//
+// lint:allow-no-orgid reason="single-use redemption by opaque code hash during the pre-auth exchange"
+func (s *CLIAuthCodeStore) Consume(ctx context.Context, codeHash string) (models.CLIAuthCode, error) {
+	query := fmt.Sprintf(`UPDATE cli_auth_codes SET consumed_at = now()
+		WHERE code_hash = @code_hash AND consumed_at IS NULL AND expires_at > now()
+		RETURNING %s`, cliAuthCodeColumns)
+	rows, err := s.db.Query(ctx, query, pgx.NamedArgs{"code_hash": codeHash})
+	if err != nil {
+		return models.CLIAuthCode{}, fmt.Errorf("consume cli auth code: %w", err)
+	}
+	return pgx.CollectOneRow(rows, pgx.RowToStructByName[models.CLIAuthCode])
+}

--- a/internal/db/migrations_test.go
+++ b/internal/db/migrations_test.go
@@ -61,6 +61,21 @@ func TestMigrationsAllowBuilderRole(t *testing.T) {
 		"membership role constraint should validate separately to reduce lock pressure")
 }
 
+// TestOrgJoinTokensRoleCheckPinsTypedEnum pins the org_join_tokens role
+// CHECK constraint to the models.Role vocabulary, per the project standard
+// for CHECK-constraint columns: if a new role is added to the enum, this
+// test fails until a migration widens the constraint to match.
+func TestOrgJoinTokensRoleCheckPinsTypedEnum(t *testing.T) {
+	t.Parallel()
+
+	body, err := os.ReadFile("../../migrations/000166_org_join_tokens.up.sql")
+	require.NoError(t, err, "test should read the org join tokens migration")
+
+	sql := string(body)
+	require.Contains(t, sql, "chk_org_join_tokens_role CHECK (role IN ('admin', 'member', 'builder', 'viewer'))",
+		"org_join_tokens role constraint must match models.ValidRoles; widen it in a new migration when the enum grows")
+}
+
 // TestCopyCodingCredentialsMigrationStampsTeamDefaultMarker locks the
 // step-3 INSERT to write `team_default_origin_user_id = uc.user_id`. The
 // down migration's orphan check and the dual-write mirror's cleanup both

--- a/internal/db/org_join_tokens.go
+++ b/internal/db/org_join_tokens.go
@@ -1,0 +1,157 @@
+package db
+
+import (
+	"context"
+	"crypto/rand"
+	"fmt"
+	"math/big"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+
+	"github.com/assembledhq/143/internal/models"
+)
+
+// OrgJoinTokenPrefix is the distinctive prefix for join tokens. Like the
+// "143u_" CLI-token prefix it exists partly so leaked tokens are
+// machine-findable by secret scanners.
+const OrgJoinTokenPrefix = "143j_"
+
+// joinTokenRandomLength is the length of the random part. The alphabet is
+// strictly alphanumeric (no base64 '-'/'_') because the token travels as a
+// path segment in /install/{join_token}, whose syntactic gate is
+// ^143j_[A-Za-z0-9]{12,64}$. 24 chars over a 62-symbol alphabet ≈ 143 bits.
+const joinTokenRandomLength = 24
+
+const joinTokenAlphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789"
+
+const orgJoinTokenColumns = `id, org_id, token_hash, token_prefix, role, name,
+	created_by_user_id, max_uses, use_count, expires_at, revoked_at,
+	revoked_by_user_id, created_at` // #nosec G101 -- SQL column list, not a credential
+
+// GenerateOrgJoinToken returns a fresh "143j_..." join token whose random
+// part is strictly alphanumeric so it survives URL-path templating and zsh
+// word-splitting without quoting.
+func GenerateOrgJoinToken() (string, error) {
+	out := make([]byte, joinTokenRandomLength)
+	max := big.NewInt(int64(len(joinTokenAlphabet)))
+	for i := range out {
+		n, err := rand.Int(rand.Reader, max)
+		if err != nil {
+			return "", fmt.Errorf("generate org join token: %w", err)
+		}
+		out[i] = joinTokenAlphabet[n.Int64()]
+	}
+	return OrgJoinTokenPrefix + string(out), nil
+}
+
+// OrgJoinTokenDisplayPrefix returns "143j_" plus the first 8 random chars
+// for UI display.
+func OrgJoinTokenDisplayPrefix(token string) string {
+	if len(token) <= len(OrgJoinTokenPrefix)+8 {
+		return token
+	}
+	return token[:len(OrgJoinTokenPrefix)+8]
+}
+
+// OrgJoinTokenStore persists multi-use org join links.
+type OrgJoinTokenStore struct {
+	db DBTX
+}
+
+func NewOrgJoinTokenStore(db DBTX) *OrgJoinTokenStore {
+	return &OrgJoinTokenStore{db: db}
+}
+
+func (s *OrgJoinTokenStore) Create(ctx context.Context, token *models.OrgJoinToken) error {
+	query := fmt.Sprintf(`INSERT INTO org_join_tokens (
+		org_id, token_hash, token_prefix, role, name, created_by_user_id, max_uses, expires_at
+	) VALUES (
+		@org_id, @token_hash, @token_prefix, @role, @name, @created_by_user_id, @max_uses, @expires_at
+	) RETURNING %s`, orgJoinTokenColumns)
+	rows, err := s.db.Query(ctx, query, pgx.NamedArgs{
+		"org_id":             token.OrgID,
+		"token_hash":         token.TokenHash,
+		"token_prefix":       token.TokenPrefix,
+		"role":               token.Role,
+		"name":               token.Name,
+		"created_by_user_id": token.CreatedByUserID,
+		"max_uses":           token.MaxUses,
+		"expires_at":         token.ExpiresAt,
+	})
+	if err != nil {
+		return fmt.Errorf("create org join token: %w", err)
+	}
+	row, err := pgx.CollectOneRow(rows, pgx.RowToStructByName[models.OrgJoinToken])
+	if err != nil {
+		return fmt.Errorf("scan org join token: %w", err)
+	}
+	*token = row
+	return nil
+}
+
+func (s *OrgJoinTokenStore) List(ctx context.Context, orgID uuid.UUID) ([]models.OrgJoinToken, error) {
+	query := fmt.Sprintf(`SELECT %s FROM org_join_tokens
+		WHERE org_id = @org_id ORDER BY created_at DESC, id DESC`, orgJoinTokenColumns)
+	rows, err := s.db.Query(ctx, query, pgx.NamedArgs{"org_id": orgID})
+	if err != nil {
+		return nil, fmt.Errorf("list org join tokens: %w", err)
+	}
+	return pgx.CollectRows(rows, pgx.RowToStructByName[models.OrgJoinToken])
+}
+
+// Revoke marks a join token revoked. Returns pgx.ErrNoRows when the token
+// doesn't exist in this org or is already revoked.
+func (s *OrgJoinTokenStore) Revoke(ctx context.Context, orgID, id, revokedBy uuid.UUID) (models.OrgJoinToken, error) {
+	query := fmt.Sprintf(`UPDATE org_join_tokens
+		SET revoked_at = now(), revoked_by_user_id = @revoked_by
+		WHERE id = @id AND org_id = @org_id AND revoked_at IS NULL
+		RETURNING %s`, orgJoinTokenColumns)
+	rows, err := s.db.Query(ctx, query, pgx.NamedArgs{"id": id, "org_id": orgID, "revoked_by": revokedBy})
+	if err != nil {
+		return models.OrgJoinToken{}, fmt.Errorf("revoke org join token: %w", err)
+	}
+	return pgx.CollectOneRow(rows, pgx.RowToStructByName[models.OrgJoinToken])
+}
+
+// ConsumeByToken atomically validates a raw join token and increments its
+// use counter in one statement: not revoked, not expired, and under
+// max_uses. Zero rows updated means the token is invalid or just raced out
+// of uses — the caller treats both as JOIN_TOKEN_INVALID. Run inside the
+// same transaction that creates the membership so an aborted join never
+// burns a use.
+//
+// lint:allow-no-orgid reason="pre-auth redemption by opaque token hash; the returned row carries org_id and the membership write is scoped to it"
+func (s *OrgJoinTokenStore) ConsumeByToken(ctx context.Context, rawToken string) (models.OrgJoinToken, error) {
+	query := fmt.Sprintf(`UPDATE org_join_tokens
+		SET use_count = use_count + 1
+		WHERE token_hash = @token_hash
+		  AND revoked_at IS NULL
+		  AND (expires_at IS NULL OR expires_at > now())
+		  AND (max_uses IS NULL OR use_count < max_uses)
+		RETURNING %s`, orgJoinTokenColumns)
+	rows, err := s.db.Query(ctx, query, pgx.NamedArgs{"token_hash": HashAPIToken(rawToken)})
+	if err != nil {
+		return models.OrgJoinToken{}, fmt.Errorf("consume org join token: %w", err)
+	}
+	return pgx.CollectOneRow(rows, pgx.RowToStructByName[models.OrgJoinToken])
+}
+
+// GetActiveByToken resolves a raw join token to its row when currently
+// valid, without consuming a use. Used for the existing-member no-op check:
+// someone already in the org shouldn't burn a use just by logging in with a
+// join link.
+//
+// lint:allow-no-orgid reason="pre-auth lookup by opaque token hash; org scoping is carried by the returned row"
+func (s *OrgJoinTokenStore) GetActiveByToken(ctx context.Context, rawToken string) (models.OrgJoinToken, error) {
+	query := fmt.Sprintf(`SELECT %s FROM org_join_tokens
+		WHERE token_hash = @token_hash
+		  AND revoked_at IS NULL
+		  AND (expires_at IS NULL OR expires_at > now())
+		  AND (max_uses IS NULL OR use_count < max_uses)`, orgJoinTokenColumns)
+	rows, err := s.db.Query(ctx, query, pgx.NamedArgs{"token_hash": HashAPIToken(rawToken)})
+	if err != nil {
+		return models.OrgJoinToken{}, fmt.Errorf("get org join token: %w", err)
+	}
+	return pgx.CollectOneRow(rows, pgx.RowToStructByName[models.OrgJoinToken])
+}

--- a/internal/db/org_join_tokens_test.go
+++ b/internal/db/org_join_tokens_test.go
@@ -1,0 +1,41 @@
+package db
+
+import (
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestGenerateOrgJoinTokenMatchesInstallPathGate pins the generator's output
+// to the /install/{join_token} syntactic gate
+// (^143j_[A-Za-z0-9]{12,64}$ in internal/api/handlers/cli_distribution.go).
+// A generator drift toward base64 charsets ('-', '_') would mint tokens the
+// installer route 404s.
+func TestGenerateOrgJoinTokenMatchesInstallPathGate(t *testing.T) {
+	t.Parallel()
+
+	gate := regexp.MustCompile(`^143j_[A-Za-z0-9]{12,64}$`)
+	seen := make(map[string]bool)
+	for i := 0; i < 64; i++ {
+		token, err := GenerateOrgJoinToken()
+		require.NoError(t, err)
+		require.Regexp(t, gate, token)
+		require.False(t, seen[token], "tokens must be unique")
+		seen[token] = true
+	}
+}
+
+func TestUserCLITokenGeneration(t *testing.T) {
+	t.Parallel()
+
+	token, err := GenerateUserCLIToken()
+	require.NoError(t, err)
+	require.True(t, strings.HasPrefix(token, UserCLITokenPrefix))
+	require.Equal(t, token[:13], UserCLITokenDisplayPrefix(token), `display prefix is "143u_" + 8 chars`)
+
+	// Hashing matches the api_tokens scheme so the hash itself is the
+	// deterministic lookup key.
+	require.True(t, strings.HasPrefix(HashAPIToken(token), "sha256:"))
+}

--- a/internal/db/user_cli_tokens.go
+++ b/internal/db/user_cli_tokens.go
@@ -1,0 +1,203 @@
+package db
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/base64"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+
+	"github.com/assembledhq/143/internal/models"
+)
+
+// UserCLITokenPrefix is the distinctive prefix routing bearer auth to the
+// user_cli_tokens table (vs. "143_sk_" org API tokens). It also makes leaked
+// tokens machine-findable — register it with secret scanners.
+const UserCLITokenPrefix = "143u_"
+
+// UserCLITokenTTL is the sliding-expiry window. Authenticated use extends
+// expires_at back out to now()+TTL (piggybacked on the throttled
+// last_used_* write), so active devices never get logged out while a laptop
+// idle for the full window does.
+const UserCLITokenTTL = 90 * 24 * time.Hour
+
+const userCLITokenColumns = `id, user_id, token_hash, token_prefix, device_name,
+	last_org_id, expires_at, last_used_at, last_used_ip, revoked_at, created_at` // #nosec G101 -- SQL column list, not a credential
+
+// GenerateUserCLIToken returns a fresh "143u_..." bearer token (32 bytes of
+// entropy, URL-safe base64). The raw value is shown to the CLI exactly once;
+// only the hash is persisted.
+func GenerateUserCLIToken() (string, error) {
+	var raw [32]byte
+	if _, err := rand.Read(raw[:]); err != nil {
+		return "", fmt.Errorf("generate user cli token: %w", err)
+	}
+	return UserCLITokenPrefix + base64.RawURLEncoding.EncodeToString(raw[:]), nil
+}
+
+// UserCLITokenDisplayPrefix returns the prefix stored for UI display:
+// "143u_" plus the first 8 characters of the random part.
+func UserCLITokenDisplayPrefix(token string) string {
+	if len(token) <= len(UserCLITokenPrefix)+8 {
+		return token
+	}
+	return token[:len(UserCLITokenPrefix)+8]
+}
+
+// UserCLITokenStore persists per-user CLI credentials. All methods are
+// user-scoped rather than org-scoped: a user's CLI tokens follow them across
+// orgs (like auth_sessions) and active-org resolution happens per-request in
+// the auth middleware.
+type UserCLITokenStore struct {
+	db DBTX
+}
+
+func NewUserCLITokenStore(db DBTX) *UserCLITokenStore {
+	return &UserCLITokenStore{db: db}
+}
+
+// Create inserts a freshly-minted CLI token row.
+//
+// lint:allow-no-orgid reason="user-scoped credential row; org resolution happens per-request via memberships, mirroring auth_sessions"
+func (s *UserCLITokenStore) Create(ctx context.Context, token *models.UserCLIToken) error {
+	query := fmt.Sprintf(`INSERT INTO user_cli_tokens (
+		user_id, token_hash, token_prefix, device_name, last_org_id, expires_at
+	) VALUES (
+		@user_id, @token_hash, @token_prefix, @device_name, @last_org_id, @expires_at
+	) RETURNING %s`, userCLITokenColumns)
+	rows, err := s.db.Query(ctx, query, pgx.NamedArgs{
+		"user_id":      token.UserID,
+		"token_hash":   token.TokenHash,
+		"token_prefix": token.TokenPrefix,
+		"device_name":  token.DeviceName,
+		"last_org_id":  token.LastOrgID,
+		"expires_at":   token.ExpiresAt,
+	})
+	if err != nil {
+		return fmt.Errorf("create user cli token: %w", err)
+	}
+	row, err := pgx.CollectOneRow(rows, pgx.RowToStructByName[models.UserCLIToken])
+	if err != nil {
+		return fmt.Errorf("scan user cli token: %w", err)
+	}
+	*token = row
+	return nil
+}
+
+// GetActiveByToken resolves a raw bearer token to its active row. The hash
+// is deterministic, so it is the lookup key; revoked and expired rows are
+// excluded in SQL so the caller only ever sees a usable credential.
+//
+// lint:allow-no-orgid reason="pre-auth lookup by opaque bearer token; the row identifies the user, org scoping happens downstream in the middleware"
+func (s *UserCLITokenStore) GetActiveByToken(ctx context.Context, rawToken string) (models.UserCLIToken, error) {
+	query := fmt.Sprintf(`SELECT %s FROM user_cli_tokens
+		WHERE token_hash = @token_hash
+		  AND revoked_at IS NULL
+		  AND expires_at > now()`, userCLITokenColumns)
+	rows, err := s.db.Query(ctx, query, pgx.NamedArgs{"token_hash": HashAPIToken(rawToken)})
+	if err != nil {
+		return models.UserCLIToken{}, fmt.Errorf("get user cli token: %w", err)
+	}
+	return pgx.CollectOneRow(rows, pgx.RowToStructByName[models.UserCLIToken])
+}
+
+// TouchUsage stamps last_used_* and slides expires_at forward. Callers
+// throttle this (once per minute) so the hot auth path doesn't write a row
+// per request.
+//
+// lint:allow-no-orgid reason="usage stamp on a user-scoped credential identified by primary key during request auth"
+func (s *UserCLITokenStore) TouchUsage(ctx context.Context, id uuid.UUID, ip string, expiresAt time.Time) error {
+	_, err := s.db.Exec(ctx, `UPDATE user_cli_tokens
+		SET last_used_at = now(), last_used_ip = @ip, expires_at = @expires_at
+		WHERE id = @id AND revoked_at IS NULL`,
+		pgx.NamedArgs{"id": id, "ip": ip, "expires_at": expiresAt})
+	if err != nil {
+		return fmt.Errorf("touch user cli token: %w", err)
+	}
+	return nil
+}
+
+// UpdateLastOrgID persists the active-org hint, mirroring
+// auth_sessions.last_org_id semantics.
+//
+// lint:allow-no-orgid reason="writes the active-org hint itself; row is user-scoped and identified by primary key"
+func (s *UserCLITokenStore) UpdateLastOrgID(ctx context.Context, id uuid.UUID, orgID *uuid.UUID) error {
+	_, err := s.db.Exec(ctx, `UPDATE user_cli_tokens SET last_org_id = @org_id WHERE id = @id`,
+		pgx.NamedArgs{"id": id, "org_id": orgID})
+	if err != nil {
+		return fmt.Errorf("update user cli token last_org_id: %w", err)
+	}
+	return nil
+}
+
+// ListByUser returns the caller's non-revoked CLI tokens, newest first, for
+// the self-service "CLI sessions" surface. Expired rows are included so the
+// UI can show "expired" rather than having devices silently vanish.
+//
+// lint:allow-no-orgid reason="self-service listing scoped to the authenticated user's own tokens"
+func (s *UserCLITokenStore) ListByUser(ctx context.Context, userID uuid.UUID) ([]models.UserCLIToken, error) {
+	query := fmt.Sprintf(`SELECT %s FROM user_cli_tokens
+		WHERE user_id = @user_id AND revoked_at IS NULL
+		ORDER BY created_at DESC, id DESC`, userCLITokenColumns)
+	rows, err := s.db.Query(ctx, query, pgx.NamedArgs{"user_id": userID})
+	if err != nil {
+		return nil, fmt.Errorf("list user cli tokens: %w", err)
+	}
+	return pgx.CollectRows(rows, pgx.RowToStructByName[models.UserCLIToken])
+}
+
+// Revoke marks one of the caller's own tokens revoked. The user_id guard
+// makes the operation self-service-safe: you can only revoke what you own.
+// Returns pgx.ErrNoRows when the row doesn't exist, isn't theirs, or is
+// already revoked.
+//
+// lint:allow-no-orgid reason="self-service revocation scoped to the authenticated user's own token"
+func (s *UserCLITokenStore) Revoke(ctx context.Context, userID, id uuid.UUID) (models.UserCLIToken, error) {
+	query := fmt.Sprintf(`UPDATE user_cli_tokens SET revoked_at = now()
+		WHERE id = @id AND user_id = @user_id AND revoked_at IS NULL
+		RETURNING %s`, userCLITokenColumns)
+	rows, err := s.db.Query(ctx, query, pgx.NamedArgs{"id": id, "user_id": userID})
+	if err != nil {
+		return models.UserCLIToken{}, fmt.Errorf("revoke user cli token: %w", err)
+	}
+	return pgx.CollectOneRow(rows, pgx.RowToStructByName[models.UserCLIToken])
+}
+
+// RevokeOtherDeviceTokens revokes the user's other tokens carrying the same
+// device name, keeping keepID. Called by the CLI after a re-login is
+// confirmed working, so the "CLI sessions" list stays one-row-per-device
+// instead of accreting duplicates.
+//
+// lint:allow-no-orgid reason="device dedup across the authenticated user's own tokens"
+func (s *UserCLITokenStore) RevokeOtherDeviceTokens(ctx context.Context, userID uuid.UUID, deviceName string, keepID uuid.UUID) (int64, error) {
+	if deviceName == "" {
+		return 0, nil
+	}
+	tag, err := s.db.Exec(ctx, `UPDATE user_cli_tokens SET revoked_at = now()
+		WHERE user_id = @user_id AND device_name = @device_name
+		  AND id <> @keep_id AND revoked_at IS NULL`,
+		pgx.NamedArgs{"user_id": userID, "device_name": deviceName, "keep_id": keepID})
+	if err != nil {
+		return 0, fmt.Errorf("revoke other device cli tokens: %w", err)
+	}
+	return tag.RowsAffected(), nil
+}
+
+// RevokeAllForUser revokes every active CLI token a user holds. Called when
+// a member removal leaves the user with zero memberships: bearer auth would
+// already resolve no org for them, but cutting the credential entirely is
+// the belt-and-suspenders the design calls for.
+//
+// lint:allow-no-orgid reason="offboarding sweep keyed by globally-unique user_id, invoked by the member-removal handler after org checks"
+func (s *UserCLITokenStore) RevokeAllForUser(ctx context.Context, userID uuid.UUID) (int64, error) {
+	tag, err := s.db.Exec(ctx, `UPDATE user_cli_tokens SET revoked_at = now()
+		WHERE user_id = @user_id AND revoked_at IS NULL`,
+		pgx.NamedArgs{"user_id": userID})
+	if err != nil {
+		return 0, fmt.Errorf("revoke all user cli tokens: %w", err)
+	}
+	return tag.RowsAffected(), nil
+}

--- a/internal/models/audit_enums.go
+++ b/internal/models/audit_enums.go
@@ -126,6 +126,14 @@ const (
 	AuditActionAuthLogout   AuditAction = "auth.logout"
 	AuditActionAuthRegister AuditAction = "auth.register"
 
+	// CLI auth + local agent gateway actions
+	AuditActionAuthCLILogin        AuditAction = "auth.cli_login"
+	AuditActionAuthCLILogout       AuditAction = "auth.cli_logout"
+	AuditActionOrgJoinTokenCreated AuditAction = "org.join_token_created" // #nosec G101 -- audit action name
+	AuditActionOrgJoinTokenRevoked AuditAction = "org.join_token_revoked" // #nosec G101 -- audit action name
+	AuditActionOrgJoinTokenUsed    AuditAction = "org.join_token_used"    // #nosec G101 -- audit action name
+	AuditActionCLIToolInvoked      AuditAction = "cli.tool_invoked"
+
 	// Eval actions
 	AuditActionEvalTaskCreated  AuditAction = "eval_task.created"
 	AuditActionEvalTaskUpdated  AuditAction = "eval_task.updated"
@@ -175,6 +183,9 @@ func (a AuditAction) Validate() error {
 		AuditActionPreviewSecretBundleUpdated, AuditActionPreviewSecretBundleDeleted,
 		AuditActionPreviewSecretBundleRevealed, AuditActionPreviewSecretBundleResolved, AuditActionPreviewSecretBundleFailed,
 		AuditActionAuthLogin, AuditActionAuthLogout, AuditActionAuthRegister,
+		AuditActionAuthCLILogin, AuditActionAuthCLILogout,
+		AuditActionOrgJoinTokenCreated, AuditActionOrgJoinTokenRevoked, AuditActionOrgJoinTokenUsed,
+		AuditActionCLIToolInvoked,
 		AuditActionEvalTaskCreated, AuditActionEvalTaskUpdated, AuditActionEvalTaskArchived,
 		AuditActionEvalRunStarted, AuditActionEvalRunCompleted, AuditActionEvalBatchStarted,
 		AuditActionAPIClientCreated, AuditActionAPIClientUpdated, AuditActionAPIClientDisabled,
@@ -211,7 +222,10 @@ const (
 	AuditResourceOrganization         AuditResourceType = "organization"
 	AuditResourcePreviewSecretBundle  AuditResourceType = "preview_secret_bundle" // #nosec G101 -- not a credential
 	AuditResourceAPIClient            AuditResourceType = "api_client"
-	AuditResourceAPIToken             AuditResourceType = "api_token" // #nosec G101 -- audit resource type
+	AuditResourceAPIToken             AuditResourceType = "api_token"      // #nosec G101 -- audit resource type
+	AuditResourceCLIToken             AuditResourceType = "cli_token"      // #nosec G101 -- audit resource type
+	AuditResourceOrgJoinToken         AuditResourceType = "org_join_token" // #nosec G101 -- audit resource type
+	AuditResourceCLITool              AuditResourceType = "cli_tool"
 )
 
 func (t AuditResourceType) Validate() error {
@@ -223,7 +237,8 @@ func (t AuditResourceType) Validate() error {
 		AuditResourceSessionReviewComment, AuditResourcePMDocument, AuditResourcePMDocumentSet,
 		AuditResourceEvalTask, AuditResourceEvalRun, AuditResourceEvalBatch,
 		AuditResourceAutomation, AuditResourceOrganization, AuditResourcePreviewSecretBundle,
-		AuditResourceAPIClient, AuditResourceAPIToken:
+		AuditResourceAPIClient, AuditResourceAPIToken,
+		AuditResourceCLIToken, AuditResourceOrgJoinToken, AuditResourceCLITool:
 		return nil
 	default:
 		return fmt.Errorf("invalid AuditResourceType: %q", t)

--- a/internal/models/cli_token.go
+++ b/internal/models/cli_token.go
@@ -1,0 +1,100 @@
+package models
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// UserCLIToken is a per-user, per-device CLI credential minted by the
+// browser login flow (`143-tools login`). It acts *as the user* — org
+// resolution flows through memberships exactly like a session — which is
+// why it is a separate table from api_tokens (those belong to org API
+// clients with explicit scopes).
+//
+// TokenHash is the deterministic "sha256:"+hex of the raw "143u_..." token
+// and doubles as the lookup key; the raw token is returned exactly once at
+// mint time and never stored. Expiry is sliding: authenticated use pushes
+// ExpiresAt back out (see middleware), so only genuinely idle devices age
+// out. Revocation, not expiry, is the operational control.
+type UserCLIToken struct {
+	ID          uuid.UUID  `db:"id" json:"id"`
+	UserID      uuid.UUID  `db:"user_id" json:"user_id"`
+	TokenHash   string     `db:"token_hash" json:"-"`
+	TokenPrefix string     `db:"token_prefix" json:"token_prefix"`
+	DeviceName  string     `db:"device_name" json:"device_name"`
+	LastOrgID   *uuid.UUID `db:"last_org_id" json:"last_org_id,omitempty"`
+	ExpiresAt   time.Time  `db:"expires_at" json:"expires_at"`
+	LastUsedAt  *time.Time `db:"last_used_at" json:"last_used_at,omitempty"`
+	LastUsedIP  *string    `db:"last_used_ip" json:"last_used_ip,omitempty"`
+	RevokedAt   *time.Time `db:"revoked_at" json:"revoked_at,omitempty"`
+	CreatedAt   time.Time  `db:"created_at" json:"created_at"`
+}
+
+// CLIAuthCode is the one-time handshake row bridging the browser OAuth
+// callback to the CLI's loopback listener. The browser only ever sees the
+// raw code (never a credential); the CLI exchanges it — bound to its PKCE
+// style verifier via Challenge = SHA-256(verifier) — for a UserCLIToken.
+// Rows are single-use and expire 60 seconds after mint.
+//
+// OrgID is nullable: it is resolved like sessions (last_org_id → oldest
+// membership), and a zero-membership user can still complete login.
+type CLIAuthCode struct {
+	ID         uuid.UUID  `db:"id" json:"id"`
+	CodeHash   string     `db:"code_hash" json:"-"`
+	Challenge  string     `db:"challenge" json:"-"`
+	UserID     uuid.UUID  `db:"user_id" json:"user_id"`
+	OrgID      *uuid.UUID `db:"org_id" json:"org_id,omitempty"`
+	DeviceName string     `db:"device_name" json:"device_name"`
+	ExpiresAt  time.Time  `db:"expires_at" json:"expires_at"`
+	ConsumedAt *time.Time `db:"consumed_at" json:"consumed_at,omitempty"`
+	CreatedAt  time.Time  `db:"created_at" json:"created_at"`
+}
+
+// OrgJoinToken is a multi-use, revocable join link: it grants exactly one
+// right — "a GitHub-authenticated person may become a member of this org at
+// Role" — and never API access. Every person who redeems one still ends up
+// with their own user row and their own CLI token, preserving per-user
+// audit and surgical offboarding.
+type OrgJoinToken struct {
+	ID              uuid.UUID  `db:"id" json:"id"`
+	OrgID           uuid.UUID  `db:"org_id" json:"org_id"`
+	TokenHash       string     `db:"token_hash" json:"-"`
+	TokenPrefix     string     `db:"token_prefix" json:"token_prefix"`
+	Role            Role       `db:"role" json:"role"`
+	Name            string     `db:"name" json:"name"`
+	CreatedByUserID uuid.UUID  `db:"created_by_user_id" json:"created_by_user_id"`
+	MaxUses         *int       `db:"max_uses" json:"max_uses,omitempty"`
+	UseCount        int        `db:"use_count" json:"use_count"`
+	ExpiresAt       *time.Time `db:"expires_at" json:"expires_at,omitempty"`
+	RevokedAt       *time.Time `db:"revoked_at" json:"revoked_at,omitempty"`
+	RevokedByUserID *uuid.UUID `db:"revoked_by_user_id" json:"revoked_by_user_id,omitempty"`
+	CreatedAt       time.Time  `db:"created_at" json:"created_at"`
+}
+
+// JoinTokenStatus summarizes a join token's lifecycle for list UIs.
+type JoinTokenStatus string
+
+const (
+	JoinTokenStatusActive    JoinTokenStatus = "active"
+	JoinTokenStatusRevoked   JoinTokenStatus = "revoked"
+	JoinTokenStatusExpired   JoinTokenStatus = "expired"
+	JoinTokenStatusExhausted JoinTokenStatus = "exhausted"
+)
+
+// Status derives the display status from the token's lifecycle columns.
+// Precedence: revoked > expired > exhausted > active — a revoked token stays
+// "revoked" even after its expiry passes, since revocation was the operator
+// action that ended it.
+func (t OrgJoinToken) Status(now time.Time) JoinTokenStatus {
+	switch {
+	case t.RevokedAt != nil:
+		return JoinTokenStatusRevoked
+	case t.ExpiresAt != nil && now.After(*t.ExpiresAt):
+		return JoinTokenStatusExpired
+	case t.MaxUses != nil && t.UseCount >= *t.MaxUses:
+		return JoinTokenStatusExhausted
+	default:
+		return JoinTokenStatusActive
+	}
+}

--- a/internal/models/cli_token_test.go
+++ b/internal/models/cli_token_test.go
@@ -1,0 +1,38 @@
+package models
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestOrgJoinTokenStatus(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now()
+	past := now.Add(-time.Hour)
+	future := now.Add(time.Hour)
+	three := 3
+
+	cases := []struct {
+		name  string
+		token OrgJoinToken
+		want  JoinTokenStatus
+	}{
+		{"fresh unlimited", OrgJoinToken{}, JoinTokenStatusActive},
+		{"under max uses", OrgJoinToken{MaxUses: &three, UseCount: 2}, JoinTokenStatusActive},
+		{"exhausted", OrgJoinToken{MaxUses: &three, UseCount: 3}, JoinTokenStatusExhausted},
+		{"expired", OrgJoinToken{ExpiresAt: &past}, JoinTokenStatusExpired},
+		{"not yet expired", OrgJoinToken{ExpiresAt: &future}, JoinTokenStatusActive},
+		{"revoked", OrgJoinToken{RevokedAt: &past}, JoinTokenStatusRevoked},
+		{"revoked wins over expired", OrgJoinToken{RevokedAt: &past, ExpiresAt: &past}, JoinTokenStatusRevoked},
+		{"expired wins over exhausted", OrgJoinToken{ExpiresAt: &past, MaxUses: &three, UseCount: 3}, JoinTokenStatusExpired},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tc.want, tc.token.Status(now))
+		})
+	}
+}

--- a/internal/services/agent/providers/docker.go
+++ b/internal/services/agent/providers/docker.go
@@ -15,6 +15,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"regexp"
 	"sort"
 	"strings"
 	"time"
@@ -1011,11 +1012,18 @@ func (d *DockerProvider) Exec(ctx context.Context, sb *agent.Sandbox, cmd string
 	return inspectResp.ExitCode, nil
 }
 
+// cliTokenPattern matches the distinctive 143-credential prefixes (user CLI
+// tokens "143u_", org join tokens "143j_") wherever they appear in logged
+// command lines. The prefixes exist partly so leaked tokens are
+// machine-findable — the log layer must therefore strip them before
+// shipping.
+var cliTokenPattern = regexp.MustCompile(`143[uj]_[A-Za-z0-9_-]{8,}`)
+
 func redactSandboxCommandForLog(cmd string) string {
 	if strings.Contains(cmd, "__143_SECRET_FILE__") {
 		return "[redacted preview secret file write]"
 	}
-	return cmd
+	return cliTokenPattern.ReplaceAllString(cmd, "143?_***")
 }
 
 // ReadFile reads a file from the sandbox filesystem by exec-ing cat.
@@ -1593,10 +1601,11 @@ func shellEscape(s string) string {
 }
 
 // redactToken removes an auth token from a string so it is safe to surface in
-// error messages or logs.
+// error messages or logs. CLI/join-token shapes are stripped by pattern as
+// well, since those can appear without the caller knowing the exact value.
 func redactToken(s, token string) string {
 	if token != "" {
 		s = strings.ReplaceAll(s, token, "***")
 	}
-	return s
+	return cliTokenPattern.ReplaceAllString(s, "143?_***")
 }

--- a/internal/services/mcp/cli.go
+++ b/internal/services/mcp/cli.go
@@ -54,7 +54,7 @@ const (
 //	143-tools --help
 //	143-tools <namespace> --help
 //	143-tools <namespace> <action> --help
-func RunCLI(ctx context.Context, tr *ToolRegistry, args []string, stdout, stderr io.Writer) int {
+func RunCLI(ctx context.Context, tr ToolSource, args []string, stdout, stderr io.Writer) int {
 	commands := buildCLICommands(tr.ListTools())
 	if len(args) == 0 || args[0] == "--help" || args[0] == "-h" {
 		printCLIUsage(commands, stdout)

--- a/internal/services/mcp/org_registry.go
+++ b/internal/services/mcp/org_registry.go
@@ -1,0 +1,68 @@
+package mcp
+
+import (
+	"github.com/assembledhq/143/internal/models"
+	"github.com/assembledhq/143/internal/services/integration"
+)
+
+// OrgCredentials carries the resolved per-org integration configs used to
+// build a server-side tool registry for the local agent gateway
+// (POST /api/v1/cli/tools/invoke). This is the laptop-mode counterpart of
+// BuildRegistryFromEnv: same constructors, but credentials come from the
+// org's integrations table and never leave the server.
+//
+// LinearAccessToken is a plain string (not *models.LinearConfig) because the
+// caller is expected to run the refresh-aware resolver first — handing this
+// builder a possibly-stale config would push token-rotation concerns into
+// the wrong layer.
+type OrgCredentials struct {
+	Sentry            *models.SentryConfig
+	LinearAccessToken string
+	Notion            *models.NotionConfig
+	CircleCI          *models.CircleCIConfig
+	Mezmo             *models.MezmoConfig
+}
+
+// BuildRegistryFromOrg constructs an integration registry from org-resolved
+// credentials. Only connected integrations register tools, so the gateway's
+// tool list mirrors exactly what the org has connected — an org without
+// Notion doesn't surface Notion tools to local agents.
+func BuildRegistryFromOrg(c OrgCredentials) *integration.Registry {
+	reg := integration.NewRegistry()
+
+	if c.Sentry != nil && c.Sentry.AccessToken != "" {
+		reg.RegisterErrorTracker(integration.NewSentryErrorTracker(integration.SentryTrackerConfig{
+			AuthToken: c.Sentry.AccessToken,
+			OrgSlug:   c.Sentry.OrgSlug,
+		}))
+	}
+
+	if c.LinearAccessToken != "" {
+		reg.RegisterTaskManager(integration.NewLinearTaskManager(integration.LinearManagerConfig{
+			AuthToken: c.LinearAccessToken,
+		}))
+	}
+
+	if c.Notion != nil && c.Notion.AccessToken != "" {
+		reg.RegisterDocumentStore(integration.NewNotionDocumentStore(integration.NotionDocumentStoreConfig{
+			AuthToken: c.Notion.AccessToken,
+		}))
+	}
+
+	if c.CircleCI != nil && c.CircleCI.AuthToken != "" && c.CircleCI.ProjectSlug != "" {
+		reg.RegisterCITestInsights(integration.NewCircleCITestInsights(integration.CircleCIConfig{
+			AuthToken:   c.CircleCI.AuthToken,
+			ProjectSlug: c.CircleCI.ProjectSlug,
+		}))
+	}
+
+	if c.Mezmo != nil && c.Mezmo.APIKey != "" {
+		reg.RegisterLogProvider(integration.NewMezmoProvider(integration.MezmoConfig{
+			APIKey:  c.Mezmo.APIKey,
+			BaseURL: c.Mezmo.BaseURL,
+			Dataset: c.Mezmo.Dataset,
+		}))
+	}
+
+	return reg
+}

--- a/internal/services/mcp/server.go
+++ b/internal/services/mcp/server.go
@@ -29,7 +29,7 @@ const (
 // responses to stdout. Logging goes to a separate writer (typically stderr)
 // to keep the STDIO transport clean.
 type Server struct {
-	tools  *ToolRegistry
+	tools  ToolSource
 	logger io.Writer // stderr for diagnostic logging
 
 	mu          sync.Mutex
@@ -39,8 +39,16 @@ type Server struct {
 // NewServer creates a new MCP server backed by the given integration registry.
 // The logger should be stderr — stdout is reserved for JSON-RPC messages.
 func NewServer(reg *integration.Registry, logger io.Writer) *Server {
+	return NewServerWithSource(NewToolRegistry(reg), logger)
+}
+
+// NewServerWithSource creates an MCP server over any ToolSource — the local
+// integration registry in sandboxes, or the server-proxied source used by
+// `143-tools mcp serve` on laptops (where org credentials never exist
+// locally and every call flows through the 143 server).
+func NewServerWithSource(tools ToolSource, logger io.Writer) *Server {
 	return &Server{
-		tools:  NewToolRegistry(reg),
+		tools:  tools,
 		logger: logger,
 	}
 }

--- a/internal/services/mcp/tools.go
+++ b/internal/services/mcp/tools.go
@@ -52,6 +52,16 @@ func taskManagerUnauthorizedDetail(providerName string, err error) string {
 	return detail
 }
 
+// ToolSource is the dispatch surface shared by the MCP server and the CLI:
+// a listing of available tools plus a call entry point. Implemented by
+// ToolRegistry (direct execution with local credentials, the sandbox model)
+// and by the CLI's server-proxied source (laptop model — credentials stay
+// server-side and every call is audited per-user).
+type ToolSource interface {
+	ListTools() []Tool
+	CallTool(ctx context.Context, name string, args json.RawMessage) *ToolCallResult
+}
+
 // ToolRegistry builds MCP tool definitions from an integration registry and
 // dispatches tool calls to the appropriate integration method.
 type ToolRegistry struct {

--- a/migrations/000165_cli_auth.down.sql
+++ b/migrations/000165_cli_auth.down.sql
@@ -1,0 +1,4 @@
+DROP TABLE IF EXISTS cli_auth_codes;
+DROP INDEX IF EXISTS idx_user_cli_tokens_hash;
+DROP INDEX IF EXISTS idx_user_cli_tokens_user;
+DROP TABLE IF EXISTS user_cli_tokens;

--- a/migrations/000165_cli_auth.up.sql
+++ b/migrations/000165_cli_auth.up.sql
@@ -1,0 +1,45 @@
+-- CLI login flow state: per-user/per-device CLI credentials plus the
+-- short-lived one-time codes that bridge the browser OAuth callback to the
+-- CLI's loopback listener. See docs/design 96-cli-local-install-and-team-auth.
+
+-- Per-user, per-device CLI credentials. Stored hashed using the same
+-- deterministic "sha256:"+hex scheme as api_tokens, so token_hash itself is
+-- the lookup key. token_prefix is display-only and intentionally NOT unique
+-- (matches api_tokens, migration 000161).
+CREATE TABLE user_cli_tokens (
+    -- lint:no-org-id reason="user-scoped credential like auth_sessions; a user's CLI tokens follow them across orgs and active-org resolution happens per-request via memberships"
+    id                 UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id            UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    token_hash         TEXT NOT NULL,
+    token_prefix       TEXT NOT NULL,
+    device_name        TEXT NOT NULL DEFAULT '',
+    last_org_id        UUID REFERENCES organizations(id) ON DELETE SET NULL,
+    expires_at         TIMESTAMPTZ NOT NULL,
+    last_used_at       TIMESTAMPTZ,
+    last_used_ip       TEXT,
+    revoked_at         TIMESTAMPTZ,
+    created_at         TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_user_cli_tokens_user ON user_cli_tokens(user_id);
+CREATE UNIQUE INDEX idx_user_cli_tokens_hash ON user_cli_tokens(token_hash);
+
+-- One-time codes minted by the OAuth callback and exchanged by the CLI for a
+-- user_cli_tokens row. Stored in a table (not memory) so the handshake
+-- survives server replicas and rolling deploys. Rows are single-use
+-- (consumed_at set atomically on exchange), expire after 60 seconds, and are
+-- garbage-collected opportunistically on insert.
+CREATE TABLE cli_auth_codes (
+    -- lint:no-org-id reason="60-second user-scoped login handshake state; the nullable org_id column below records the resolved login org (a zero-membership user can still complete login)"
+    id             UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    code_hash      TEXT NOT NULL UNIQUE,
+    challenge      TEXT NOT NULL,
+    user_id        UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    org_id         UUID REFERENCES organizations(id) ON DELETE CASCADE,
+    device_name    TEXT NOT NULL DEFAULT '',
+    expires_at     TIMESTAMPTZ NOT NULL,
+    consumed_at    TIMESTAMPTZ,
+    created_at     TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_cli_auth_codes_expires ON cli_auth_codes(expires_at);

--- a/migrations/000166_org_join_tokens.down.sql
+++ b/migrations/000166_org_join_tokens.down.sql
@@ -1,0 +1,3 @@
+DROP INDEX IF EXISTS idx_org_join_tokens_hash;
+DROP INDEX IF EXISTS idx_org_join_tokens_org;
+DROP TABLE IF EXISTS org_join_tokens;

--- a/migrations/000166_org_join_tokens.up.sql
+++ b/migrations/000166_org_join_tokens.up.sql
@@ -1,0 +1,26 @@
+-- Multi-use, revocable org join links for zero-config CLI onboarding.
+-- Deliberately a new table rather than extending invitations: invitations
+-- are single-use and targeted at a person; join tokens are multi-use and
+-- untargeted ("a GitHub-authenticated person may become a member of this
+-- org"). They grant membership only — never API access.
+CREATE TABLE org_join_tokens (
+    id                 UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    org_id             UUID NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+    token_hash         TEXT NOT NULL,
+    token_prefix       TEXT NOT NULL,
+    role               TEXT NOT NULL DEFAULT 'member',
+    name               TEXT NOT NULL DEFAULT '',
+    created_by_user_id UUID NOT NULL REFERENCES users(id),
+    max_uses           INTEGER,
+    use_count          INTEGER NOT NULL DEFAULT 0,
+    expires_at         TIMESTAMPTZ,
+    revoked_at         TIMESTAMPTZ,
+    revoked_by_user_id UUID REFERENCES users(id),
+    created_at         TIMESTAMPTZ NOT NULL DEFAULT now(),
+    CONSTRAINT chk_org_join_tokens_role CHECK (role IN ('admin', 'member', 'builder', 'viewer'))
+);
+
+CREATE INDEX idx_org_join_tokens_org ON org_join_tokens(org_id);
+-- Lookup key is the deterministic hash; token_prefix is display-only and
+-- intentionally NOT unique (matches api_tokens, migration 000161).
+CREATE UNIQUE INDEX idx_org_join_tokens_hash ON org_join_tokens(token_hash);


### PR DESCRIPTION
## What

Implements [design doc 96](docs/design/implemented/96-cli-local-install-and-team-auth.md) end-to-end: anyone on a 143 team can install the `143-tools` CLI and authenticate with a single command —

```bash
curl -fsSL https://143.com/install/<JOIN_TOKEN> | sh
```

The installer downloads the binary, writes the config, and chains into `143-tools login`; the browser opens for GitHub sign-in, and users without a 143 account are JIT-provisioned into the org. The first consumer is engineers' local coding agents: `claude mcp add 143 -- 143-tools mcp serve` exposes every org-connected integration to local agents, with all tool calls executing server-side (org credentials never land on laptops) and per-user audit.

## How (by phase)

**Phase 1 — distribution.** `make build-cli` cross-compiles darwin/linux × amd64/arm64; the server image bakes binaries into `/opt/143/cli`. New public routes: `/install.sh`, `/install/{join_token}` (strict `^143j_[A-Za-z0-9]{12,64}$` gate — the segment is untrusted input templated into a script piped to `sh`), `/download/143-tools/{os}/{arch}` + checksums, `/api/v1/cli/version` with an enforced 426 `CLI_UPDATE_REQUIRED` gate. Caddyfile routes the new paths to the API upstream (before the frontend fallthrough, pinned by `deploy_config_test.go`); request logs redact `/install/:token`.

**Phase 2 — CLI tokens + login.** Migration `000165`: `user_cli_tokens` + `cli_auth_codes` (hashed with the existing `sha256:` scheme). Flow: `/auth/cli/start` (validates loopback port + PKCE-style challenge, stashes cookies, chains into GitHub OAuth) → callback mints a 60-second one-time code and redirects to `http://127.0.0.1:<port>/callback` (browser never sees a real token; web session still installed) → `/auth/cli/exchange` (outside CSRF; verifier binding via constant-time compare) returns the `143u_` token once. Bearer middleware gains a `143u_` branch with session-identical org resolution and a **sliding** 90-day expiry piggybacked on throttled `last_used_*` writes. New laptop CLI in `internal/cli/`: `login`, `logout`, `whoami`, `update` (checksum-verified atomic self-replace), `setup`, leading `--token`/`--server` flags, 0600 versioned config. Self-service token list/revoke endpoints are zero-membership-safe.

**Phase 3 — join tokens + JIT.** Migration `000166`: `org_join_tokens` with a role CHECK constraint + migration-pin test. Tokens grant membership only, consume uses atomically inside the same tx as user creation + `GrantAtLeast`, are a no-op (no use burned) for existing members, and **fail closed** for new users with an invalid token. Admin CRUD at `/api/v1/org/join-tokens` returns the plaintext + install one-liner exactly once. UI: "CLI install links" card on Team settings, "CLI sessions" card on account settings. Member removal revokes CLI tokens for users left with zero memberships.

**Phase 4 — local agent gateway.** `GET /api/v1/cli/tools` + `POST /api/v1/cli/tools/invoke` build the org's tool registry per-request from the integrations table (refresh-aware Linear tokens) and emit `cli.tool_invoked` audit events (tool name only, never args). `143-tools mcp serve` runs the existing stdio MCP server over a new `ToolSource` interface. Preview platform tools (`preview_create/status/list/stop`) wrap the existing previews REST API with repository-**name** resolution and a distinct `BRANCH_NOT_PUSHED` error naming the fix; `143-tools preview create --wait` infers repo/branch from the cwd. Backend selection is automatic (sandbox env → direct; config token → server-proxied); `login`/`update`/`setup` refuse to run inside sandboxes.

## Reviewer notes

- Migration numbers shifted from the doc's 000164 to **000165/000166** (000164 was taken by Mezmo); the doc's implementation-notes section records this and the other deltas (version-gate enforcement only engages for orderable versions; join brute-forcing is throttled by the OAuth round-trip + global IP limiter rather than a per-token bucket).
- The 426 gate (`CLI_MIN_SUPPORTED_VERSION`) defaults to off; git-SHA CLI builds are never blocked.
- Sandbox log redaction learned the `143u_`/`143j_` shapes; scanner patterns are documented in `docs/guides/cli-install.md`.
- Self-hosters replacing the bundled Caddyfile need the new `/install*` + `/download/*` proxy rules (documented).

## Testing

- `make lint` (golangci-lint + schema/store/org-id tenancy lints): 0 issues.
- Full `go test ./...` green, including new tests: callback→loopback E2E asserting the browser never sees a `143u_` token, exchange error paths (410/400/verifier mismatch), `cli/start` validation, version-gate table tests, installer-route 404s for malformed tokens, join-token generator↔route-gate pin, CHECK-constraint pin, Caddyfile ordering test.
- Frontend typecheck, eslint, and the touched page tests pass.
- Smoke-tested the built binary: config written 0600 with pending join token, `whoami --local` exit codes, sandbox login guardrail, preview help.

🤖 Generated with [Claude Code](https://claude.com/claude-code)