### PR TITLE
Give user settings endpoint JSON merge-patch semantics

### DIFF
--- a/frontend/AGENTS.md
+++ b/frontend/AGENTS.md
@@ -464,6 +464,16 @@ Always include `dark:` variants for banners that use **hardcoded Tailwind color 
 
 When in doubt, write the immutable version first. It's almost always fast enough and it sidesteps a whole class of stale-render and cache-corruption bugs.
 
+## Settings Mutations: Patch, Don't Replace
+
+Settings-style endpoints (user settings, org settings, per-resource preference documents) use **JSON merge-patch semantics** (RFC 7386): omitted fields keep their stored value, `null` clears a field, and nested objects merge per key. `PATCH /api/v1/auth/me/settings` works this way.
+
+- **Send only the fields the user changed.** A toggle sends `{ diff_viewer_full_screen: true }` — nothing else.
+- **Clear a field with an explicit `null`**, not by omitting it: `{ coding_agent_model_default: null }`.
+- **Never rebuild the full settings document from the React Query cache** (`{ ...user.settings, changed_field: value }`) and send it as the mutation body. The local cache can be stale, so the write clobbers concurrent edits made in another tab or surface (cross-tab last-write-wins). This was the old contract for `/auth/me/settings` and it caused exactly that bug.
+- **When adding a new settings-style endpoint, give it merge-patch semantics on the backend** rather than full-document replace, so callers are never forced into the cache-merge pattern. See `UserStore.MergeSettings` + `models.ApplyUserSettingsMergePatch` for the server-side reference implementation, and the backend rule in `internal/AGENTS.md`.
+- If multiple rapid edits to the same patch field are coalesced client-side (in-flight + queued refs), **merge queued patches per key** instead of replacing the queue, so edits to different keys all land.
+
 ## Error Reporting (Sentry)
 
 Errors are reported to Sentry via `@sentry/nextjs`. Three layers handle this automatically:
@@ -514,3 +524,4 @@ Use the `tags` parameter to add searchable context (feature name, endpoint, comp
 9. **Flat cards** — Cards should always have `shadow-sm` (provided by the Card component). Don't override with `shadow-none`.
 10. **Missing transitions** — Interactive elements (radio cards, buttons, rows) need `transition-all duration-150`.
 11. **Insufficient header-to-scroll-area spacing** — Fixed header sections above scrollable content must have at least `pb-3` (12px) bottom padding. Using `pb-2` or less causes the scroll area to overlap with the last header element (e.g., filter tabs, buttons), clipping their bottom border or active indicator.
+12. **Full-document settings writes** — Never spread the cached settings object into a mutation body to "preserve" unchanged fields. Settings endpoints are merge patches; send only the changed fields (see "Settings Mutations: Patch, Don't Replace").

--- a/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
@@ -3264,10 +3264,10 @@ export function SessionDetailContent({ id }: { id: string }) {
     !isMobileReviewViewport &&
     (diffFullScreenOverride ?? user?.settings?.diff_viewer_full_screen ?? false);
   const { mutate: persistDiffFullScreen } = useMutation({
-    // PATCH /auth/me/settings replaces the whole settings JSONB, so merge the
-    // existing fields in rather than sending the flag alone.
+    // PATCH /auth/me/settings is a merge patch, so the flag travels alone and
+    // can't clobber settings edited concurrently elsewhere.
     mutationFn: (fullScreen: boolean) =>
-      api.auth.updateSettings({ ...(user?.settings ?? {}), diff_viewer_full_screen: fullScreen }),
+      api.auth.updateSettings({ diff_viewer_full_screen: fullScreen }),
     onSuccess: (response) => {
       queryClient.setQueryData(["auth", "me"], { data: response.data });
     },
@@ -3278,12 +3278,8 @@ export function SessionDetailContent({ id }: { id: string }) {
   const toggleDiffFullScreen = useCallback(() => {
     const next = !isDiffFullScreen;
     setDiffFullScreenOverride(next);
-    // Don't persist before the user document has loaded — the merge above
-    // would wipe the other settings fields.
-    if (user) {
-      persistDiffFullScreen(next);
-    }
-  }, [isDiffFullScreen, user, persistDiffFullScreen]);
+    persistDiffFullScreen(next);
+  }, [isDiffFullScreen, persistDiffFullScreen]);
 
   const activeThreadDelivery = activeThread?.inbox_delivery;
   const activeThreadHasRecoverableInbox =

--- a/frontend/src/app/(dashboard)/settings/account/page.test.tsx
+++ b/frontend/src/app/(dashboard)/settings/account/page.test.tsx
@@ -383,9 +383,10 @@ describe("Account settings page", () => {
             codex: "high",
           },
         },
+        // Merge-patch endpoint: the queued save carries only the agent that
+        // changed while the first request was in flight.
         {
           coding_agent_reasoning_defaults: {
-            codex: "high",
             claude_code: "max",
           },
         },
@@ -449,9 +450,10 @@ describe("Account settings page", () => {
             codex: "high",
           },
         },
+        // Merge-patch endpoint: the queued save carries only the agent that
+        // changed while the first request was in flight.
         {
           coding_agent_reasoning_defaults: {
-            codex: "high",
             claude_code: "max",
           },
         },

--- a/frontend/src/app/(dashboard)/settings/account/page.tsx
+++ b/frontend/src/app/(dashboard)/settings/account/page.tsx
@@ -206,6 +206,11 @@ function CredentialList({
 // (Codex + Claude Code today).
 type PersonalAuthType = "subscription" | "api_key";
 
+// Local display map of reasoning defaults (no nulls) vs the wire patch sent
+// to the merge-patch settings endpoint (null clears an agent's entry).
+type ReasoningDefaults = ReturnType<typeof getCodingAgentReasoningDefaultsFromSettings>;
+type ReasoningDefaultsPatch = NonNullable<UserSettingsUpdateRequest["coding_agent_reasoning_defaults"]>;
+
 export default function AccountPage() {
   const { user } = useAuth();
   const queryClient = useQueryClient();
@@ -220,9 +225,9 @@ export default function AccountPage() {
   const [showCodexModal, setShowCodexModal] = useState(false);
   const [showClaudeModal, setShowClaudeModal] = useState(false);
   const [pendingDefaultModel, setPendingDefaultModel] = useState<string | null>(null);
-  const [pendingReasoningDefaults, setPendingReasoningDefaults] = useState<UserSettingsUpdateRequest["coding_agent_reasoning_defaults"] | null>(null);
+  const [pendingReasoningDefaults, setPendingReasoningDefaults] = useState<ReasoningDefaults | null>(null);
   const reasoningSaveInFlightRef = useRef(false);
-  const queuedReasoningDefaultsRef = useRef<UserSettingsUpdateRequest["coding_agent_reasoning_defaults"] | null>(null);
+  const queuedReasoningDefaultsRef = useRef<ReasoningDefaultsPatch | null>(null);
 
   // Personal stack — the user's own credentials, ordered by priority.
   const { data: personalResp } = useQuery<ListResponse<CodingCredentialSummary>>({
@@ -241,10 +246,6 @@ export default function AccountPage() {
   const storedReasoningDefaults = getCodingAgentReasoningDefaultsFromSettings(user?.settings);
   const effectiveReasoningDefaults = pendingReasoningDefaults ?? storedReasoningDefaults;
   const effectiveDefaultModel = pendingDefaultModel ?? user?.settings?.coding_agent_model_default ?? "";
-  const hasEffectiveReasoningDefaults = Object.keys(effectiveReasoningDefaults).length > 0;
-  // Not editable on this page (toggled from the diff viewer toolbar), but it
-  // must ride along with every settings PATCH or it would be wiped.
-  const storedDiffFullScreen = user?.settings?.diff_viewer_full_screen ?? false;
 
   const createMutation = useMutation({
     mutationFn: () =>
@@ -293,17 +294,13 @@ export default function AccountPage() {
   });
 
   const updateReasoningDefaultsMutation = useMutation({
-    // PATCH replaces the whole settings document, so every settings mutation
-    // on this page must carry the fields it isn't editing.
-    mutationFn: (defaults: UserSettingsUpdateRequest["coding_agent_reasoning_defaults"]) =>
-      api.auth.updateSettings({
-        ...(effectiveDefaultModel ? { coding_agent_model_default: effectiveDefaultModel } : {}),
-        ...(defaults && Object.keys(defaults).length > 0 ? { coding_agent_reasoning_defaults: defaults } : {}),
-        ...(storedDiffFullScreen ? { diff_viewer_full_screen: true } : {}),
-      }),
-    onMutate: (defaults) => {
+    // The settings endpoint is a JSON merge patch, so each save carries only
+    // the per-agent entries that changed (null clears an entry back to the
+    // built-in default).
+    mutationFn: (patch: ReasoningDefaultsPatch) =>
+      api.auth.updateSettings({ coding_agent_reasoning_defaults: patch }),
+    onMutate: () => {
       reasoningSaveInFlightRef.current = true;
-      setPendingReasoningDefaults(defaults);
     },
     onSuccess: (response) => {
       queryClient.setQueryData(["auth", "me"], { data: response.data });
@@ -331,22 +328,28 @@ export default function AccountPage() {
     },
   });
 
-  function saveReasoningDefaults(defaults: UserSettingsUpdateRequest["coding_agent_reasoning_defaults"]) {
-    setPendingReasoningDefaults(defaults);
+  function saveReasoningDefault(agentType: keyof ReasoningDefaultsPatch, effort: ReasoningDefaults[keyof ReasoningDefaults] | null) {
+    const nextDefaults = { ...effectiveReasoningDefaults };
+    if (effort) {
+      nextDefaults[agentType] = effort;
+    } else {
+      delete nextDefaults[agentType];
+    }
+    setPendingReasoningDefaults(nextDefaults);
     if (reasoningSaveInFlightRef.current) {
-      queuedReasoningDefaultsRef.current = defaults;
+      // Merge queued entries per agent so rapid edits to different agents
+      // all land instead of the last patch replacing the queue.
+      queuedReasoningDefaultsRef.current = { ...queuedReasoningDefaultsRef.current, [agentType]: effort };
       return;
     }
-    updateReasoningDefaultsMutation.mutate(defaults);
+    updateReasoningDefaultsMutation.mutate({ [agentType]: effort });
   }
 
   const updateDefaultModelMutation = useMutation({
+    // Merge-patch endpoint: send just the model, with null clearing the
+    // stored default when the user picks "Default".
     mutationFn: (model: string) =>
-      api.auth.updateSettings({
-        ...(model ? { coding_agent_model_default: model } : {}),
-        ...(hasEffectiveReasoningDefaults ? { coding_agent_reasoning_defaults: effectiveReasoningDefaults } : {}),
-        ...(storedDiffFullScreen ? { diff_viewer_full_screen: true } : {}),
-      }),
+      api.auth.updateSettings({ coding_agent_model_default: model || null }),
     onMutate: (model) => {
       setPendingDefaultModel(model);
     },
@@ -520,13 +523,7 @@ export default function AccountPage() {
                       value={defaultReasoning || "__default__"}
                       onValueChange={(value) => {
                         const nextValue = value === "__default__" ? "" : toCodingAgentReasoningEffort(value);
-                        const nextDefaults = { ...effectiveReasoningDefaults };
-                        if (nextValue) {
-                          nextDefaults[agentType as "codex" | "claude_code"] = nextValue;
-                        } else {
-                          delete nextDefaults[agentType as "codex" | "claude_code"];
-                        }
-                        saveReasoningDefaults(nextDefaults);
+                        saveReasoningDefault(agentType as "codex" | "claude_code", nextValue || null);
                       }}
                     >
                       <SelectTrigger

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -63,7 +63,16 @@ export interface ThreadMessageWindowResponse {
   meta: ThreadMessageWindowMeta;
 }
 
-export type UserSettingsUpdateRequest = UserSettings;
+// PATCH /api/v1/auth/me/settings is an RFC 7386 JSON merge patch: omitted
+// fields keep their stored value, null clears a field, and nested objects
+// merge per key. Send only the fields being changed — never a full settings
+// document rebuilt from the query cache, which would clobber concurrent
+// edits from other tabs.
+export interface UserSettingsUpdateRequest {
+  coding_agent_model_default?: string | null;
+  coding_agent_reasoning_defaults?: Partial<Record<"codex" | "claude_code", "low" | "medium" | "high" | "xhigh" | "max" | null>> | null;
+  diff_viewer_full_screen?: boolean | null;
+}
 
 export interface AuthProviders {
   github: boolean;

--- a/internal/AGENTS.md
+++ b/internal/AGENTS.md
@@ -43,6 +43,12 @@ The existing test `internal/db/tenancy_test.go` is a third layer of defense: it 
 
 When in doubt, write the immutable version first. It's almost always fast enough, and it eliminates an entire class of aliasing and data-race bugs (especially important for anything shared across goroutines).
 
+## Settings Documents: Merge Patch, Not Replace
+
+Endpoints that update a JSONB settings/preferences document (user settings, org settings, and anything similar added later) must accept an **RFC 7386 JSON merge patch**, not a full replacement document: omitted fields keep their stored value, `null` clears a field, nested objects merge per key. Full-document replace forces clients to rebuild the body from their local cache, which silently clobbers concurrent edits from other tabs (cross-tab last-write-wins).
+
+Apply the patch server-side as a read-merge-write inside a transaction with the row locked (`SELECT ... FOR UPDATE`) so concurrent patches compose, and validate the merged document before committing. Reference implementation: `UserStore.MergeSettings` (`internal/db/users.go`) + `models.ApplyUserSettingsMergePatch` (`internal/models/user_settings.go`), wired up in `AuthHandler.UpdateSettings`. The frontend-side rules live in `frontend/AGENTS.md` ("Settings Mutations: Patch, Don't Replace").
+
 ## No N+1 Queries
 
 Never query the database inside a loop. Always batch using `ANY()`, JOINs, or bulk fetches. If a batch store method doesn't exist yet, create one using the `ANY()` pattern in the db package.

--- a/internal/api/handlers/auth.go
+++ b/internal/api/handlers/auth.go
@@ -160,7 +160,11 @@ func (h *AuthHandler) Me(w http.ResponseWriter, r *http.Request) {
 	}})
 }
 
-// UpdateSettings updates the authenticated user's personal settings document.
+// UpdateSettings applies an RFC 7386 JSON merge patch to the authenticated
+// user's personal settings document: omitted fields keep their stored value,
+// null clears a field, and nested objects merge per key. Callers send only
+// the fields they are changing — never a full document rebuilt from a client
+// cache, which would let concurrent edits from another tab clobber each other.
 func (h *AuthHandler) UpdateSettings(w http.ResponseWriter, r *http.Request) {
 	user := middleware.UserFromContext(r.Context())
 	if user == nil {
@@ -173,18 +177,24 @@ func (h *AuthHandler) UpdateSettings(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	var body models.UserSettings
-	decoder := json.NewDecoder(r.Body)
-	decoder.DisallowUnknownFields()
-	if err := decoder.Decode(&body); err != nil {
+	patch, err := io.ReadAll(r.Body)
+	if err != nil {
 		writeError(w, r, http.StatusBadRequest, "INVALID_BODY", "invalid request body")
 		return
 	}
-	if err := body.Validate(); err != nil {
+	var patchObject map[string]json.RawMessage
+	if err := json.Unmarshal(patch, &patchObject); err != nil || patchObject == nil {
+		writeError(w, r, http.StatusBadRequest, "INVALID_BODY", "invalid request body")
+		return
+	}
+	// Applying the patch to an empty document exercises the same key and
+	// value validation as the real merge, so bad patches fail with a 400
+	// before we open the merge transaction.
+	if _, err := models.ApplyUserSettingsMergePatch(nil, patch); err != nil {
 		writeError(w, r, http.StatusBadRequest, "INVALID_USER_SETTINGS", err.Error())
 		return
 	}
-	if err := h.userStore.UpdateSettings(r.Context(), user.ID, body); err != nil {
+	if _, err := h.userStore.MergeSettings(r.Context(), user.ID, patch); err != nil {
 		writeError(w, r, http.StatusInternalServerError, "USER_SETTINGS_UPDATE_FAILED", "failed to update user settings", err)
 		return
 	}

--- a/internal/api/handlers/auth_test.go
+++ b/internal/api/handlers/auth_test.go
@@ -1056,9 +1056,14 @@ func TestAuthHandler_UpdateSettings(t *testing.T) {
 	now := time.Now()
 	settings := []byte(`{"coding_agent_reasoning_defaults":{"claude_code":"max"}}`)
 
+	mock.ExpectBegin()
+	mock.ExpectQuery("SELECT settings FROM users WHERE id = @id FOR UPDATE").
+		WithArgs(userID).
+		WillReturnRows(pgxmock.NewRows([]string{"settings"}).AddRow(json.RawMessage(`{}`)))
 	mock.ExpectExec("UPDATE users SET settings = @settings").
 		WithArgs(pgxmock.AnyArg(), userID).
 		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
+	mock.ExpectCommit()
 	mock.ExpectQuery(`SELECT .+ FROM users\s+WHERE id = @id`).
 		WithArgs(userID).
 		WillReturnRows(pgxmock.NewRows([]string{
@@ -1155,9 +1160,25 @@ func TestAuthHandler_UpdateSettings_ErrorPaths(t *testing.T) {
 			expectedBody: "INVALID_BODY",
 		},
 		{
+			name:         "returns invalid body for non-object patch",
+			handler:      newAuthHandlerWithUserStore(t, nil),
+			body:         `[{"diff_viewer_full_screen":true}]`,
+			setupCtx:     withAuthUser,
+			expectedCode: http.StatusBadRequest,
+			expectedBody: "INVALID_BODY",
+		},
+		{
 			name:         "returns invalid settings for unsupported effort",
 			handler:      newAuthHandlerWithUserStore(t, nil),
 			body:         `{"coding_agent_reasoning_defaults":{"codex":"max"}}`,
+			setupCtx:     withAuthUser,
+			expectedCode: http.StatusBadRequest,
+			expectedBody: "INVALID_USER_SETTINGS",
+		},
+		{
+			name:         "returns invalid settings for unknown patch field",
+			handler:      newAuthHandlerWithUserStore(t, nil),
+			body:         `{"not_a_setting":null}`,
 			setupCtx:     withAuthUser,
 			expectedCode: http.StatusBadRequest,
 			expectedBody: "INVALID_USER_SETTINGS",
@@ -1169,9 +1190,14 @@ func TestAuthHandler_UpdateSettings_ErrorPaths(t *testing.T) {
 				require.NoError(t, err, "should create pgxmock pool without error")
 				t.Cleanup(func() { mock.Close() })
 				userID := authCoverageUserID
+				mock.ExpectBegin()
+				mock.ExpectQuery("SELECT settings FROM users WHERE id = @id FOR UPDATE").
+					WithArgs(userID).
+					WillReturnRows(pgxmock.NewRows([]string{"settings"}).AddRow(json.RawMessage(`{}`)))
 				mock.ExpectExec("UPDATE users SET settings = @settings").
 					WithArgs(pgxmock.AnyArg(), userID).
 					WillReturnError(errors.New("write failed"))
+				mock.ExpectRollback()
 				return NewAuthHandler(&config.Config{}, nil, db.NewUserStore(mock), nil, nil, nil)
 			}(),
 			body:         `{"coding_agent_reasoning_defaults":{"claude_code":"max"}}`,
@@ -1186,9 +1212,14 @@ func TestAuthHandler_UpdateSettings_ErrorPaths(t *testing.T) {
 				require.NoError(t, err, "should create pgxmock pool without error")
 				t.Cleanup(func() { mock.Close() })
 				userID := authCoverageUserID
+				mock.ExpectBegin()
+				mock.ExpectQuery("SELECT settings FROM users WHERE id = @id FOR UPDATE").
+					WithArgs(userID).
+					WillReturnRows(pgxmock.NewRows([]string{"settings"}).AddRow(json.RawMessage(`{}`)))
 				mock.ExpectExec("UPDATE users SET settings = @settings").
 					WithArgs(pgxmock.AnyArg(), userID).
 					WillReturnResult(pgxmock.NewResult("UPDATE", 1))
+				mock.ExpectCommit()
 				mock.ExpectQuery(`SELECT .+ FROM users\s+WHERE id = @id`).
 					WithArgs(userID).
 					WillReturnError(errors.New("reload failed"))

--- a/internal/db/tenancy_test.go
+++ b/internal/db/tenancy_test.go
@@ -103,6 +103,10 @@ func TestMultiTenancyAudit(t *testing.T) {
 		// "users WHERE id = @id" without org_id must add its own exemption
 		// (with its own justification) rather than silently piggybacking.
 		{"users", "where id = @id`"},
+		// MergeSettings: user-scoped settings merge locks the user row by
+		// primary key inside the patch transaction. Same backtick anchoring
+		// rationale as the exemption above.
+		{"users", "where id = @id for update`"},
 
 		{"organization_memberships", "count(*) from organization_memberships where user_id"}, // CountForUser: user-scoped aggregate; the membership set IS the authoritative org list
 		{"coding_credentials", "where status = 'pending_auth'"},                              // JanitorDeletePendingAuthOlderThan: cross-org system cleanup of expired OAuth handshakes

--- a/internal/db/user_store_test.go
+++ b/internal/db/user_store_test.go
@@ -2,6 +2,7 @@ package db
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"testing"
 	"time"
@@ -617,7 +618,7 @@ func TestUserStore_LinkGoogleAccount(t *testing.T) {
 	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
 }
 
-func TestUserStore_UpdateSettings(t *testing.T) {
+func TestUserStore_MergeSettings(t *testing.T) {
 	t.Parallel()
 
 	mock, err := pgxmock.NewPool()
@@ -626,64 +627,73 @@ func TestUserStore_UpdateSettings(t *testing.T) {
 
 	store := NewUserStore(mock)
 	userID := uuid.New()
-	settings := models.UserSettings{
-		CodingAgentReasoningDefaults: map[models.AgentType]models.ReasoningEffort{
-			models.AgentTypeClaudeCode: models.ReasoningEffortMax,
-		},
-	}
 
+	mock.ExpectBegin()
+	mock.ExpectQuery("SELECT settings FROM users WHERE id = @id FOR UPDATE").
+		WithArgs(userID).
+		WillReturnRows(pgxmock.NewRows([]string{"settings"}).
+			AddRow(json.RawMessage(`{"coding_agent_model_default":"claude-opus-4-7"}`)))
 	mock.ExpectExec("UPDATE users SET settings = @settings").
 		WithArgs(pgxmock.AnyArg(), userID).
 		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
+	mock.ExpectCommit()
 
-	err = store.UpdateSettings(context.Background(), userID, settings)
-	require.NoError(t, err, "UpdateSettings should not return an error")
+	merged, err := store.MergeSettings(context.Background(), userID, json.RawMessage(`{"coding_agent_reasoning_defaults":{"claude_code":"max"}}`))
+	require.NoError(t, err, "MergeSettings should not return an error")
+	require.Equal(t, models.UserSettings{
+		CodingAgentModelDefault: "claude-opus-4-7",
+		CodingAgentReasoningDefaults: map[models.AgentType]models.ReasoningEffort{
+			models.AgentTypeClaudeCode: models.ReasoningEffortMax,
+		},
+	}, merged, "MergeSettings should keep stored fields the patch didn't touch")
 	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
 }
 
-func TestUserStore_UpdateSettings_ErrorPaths(t *testing.T) {
+func TestUserStore_MergeSettings_ErrorPaths(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
 		name      string
-		settings  models.UserSettings
+		patch     json.RawMessage
 		setupMock func(mock pgxmock.PgxPoolIface, userID uuid.UUID)
 		wantErr   string
 	}{
 		{
-			name: "returns marshal error for invalid settings",
-			settings: models.UserSettings{
-				CodingAgentReasoningDefaults: map[models.AgentType]models.ReasoningEffort{
-					models.AgentTypeCodex: models.ReasoningEffortMax,
-				},
+			name:  "returns merge error for invalid patch values",
+			patch: json.RawMessage(`{"coding_agent_reasoning_defaults":{"codex":"max"}}`),
+			setupMock: func(mock pgxmock.PgxPoolIface, userID uuid.UUID) {
+				mock.ExpectBegin()
+				mock.ExpectQuery("SELECT settings FROM users WHERE id = @id FOR UPDATE").
+					WithArgs(userID).
+					WillReturnRows(pgxmock.NewRows([]string{"settings"}).AddRow(json.RawMessage(`{}`)))
+				mock.ExpectRollback()
 			},
-			wantErr: "marshal user settings",
+			wantErr: "merge user settings",
 		},
 		{
-			name: "returns exec error",
-			settings: models.UserSettings{
-				CodingAgentReasoningDefaults: map[models.AgentType]models.ReasoningEffort{
-					models.AgentTypeClaudeCode: models.ReasoningEffortMax,
-				},
-			},
+			name:  "returns exec error",
+			patch: json.RawMessage(`{"coding_agent_reasoning_defaults":{"claude_code":"max"}}`),
 			setupMock: func(mock pgxmock.PgxPoolIface, userID uuid.UUID) {
+				mock.ExpectBegin()
+				mock.ExpectQuery("SELECT settings FROM users WHERE id = @id FOR UPDATE").
+					WithArgs(userID).
+					WillReturnRows(pgxmock.NewRows([]string{"settings"}).AddRow(json.RawMessage(`{}`)))
 				mock.ExpectExec("UPDATE users SET settings = @settings").
 					WithArgs(pgxmock.AnyArg(), userID).
 					WillReturnError(errors.New("write failed"))
+				mock.ExpectRollback()
 			},
 			wantErr: "update user settings",
 		},
 		{
-			name: "returns no rows when user is missing",
-			settings: models.UserSettings{
-				CodingAgentReasoningDefaults: map[models.AgentType]models.ReasoningEffort{
-					models.AgentTypeClaudeCode: models.ReasoningEffortMax,
-				},
-			},
+			name:  "returns no rows when user is missing",
+			patch: json.RawMessage(`{"coding_agent_reasoning_defaults":{"claude_code":"max"}}`),
 			setupMock: func(mock pgxmock.PgxPoolIface, userID uuid.UUID) {
-				mock.ExpectExec("UPDATE users SET settings = @settings").
-					WithArgs(pgxmock.AnyArg(), userID).
-					WillReturnResult(pgxmock.NewResult("UPDATE", 0))
+				mock.ExpectBegin()
+				mock.ExpectQuery("SELECT settings FROM users WHERE id = @id FOR UPDATE").
+					WithArgs(userID).
+					WillReturnRows(pgxmock.NewRows([]string{"settings"}))
+				mock.ExpectRollback()
 			},
 			wantErr: pgx.ErrNoRows.Error(),
 		},
@@ -704,9 +714,9 @@ func TestUserStore_UpdateSettings_ErrorPaths(t *testing.T) {
 				tt.setupMock(mock, userID)
 			}
 
-			err = store.UpdateSettings(context.Background(), userID, tt.settings)
-			require.Error(t, err, "UpdateSettings should return the expected error")
-			require.Contains(t, err.Error(), tt.wantErr, "UpdateSettings should describe the failure")
+			_, err = store.MergeSettings(context.Background(), userID, tt.patch)
+			require.Error(t, err, "MergeSettings should return the expected error")
+			require.Contains(t, err.Error(), tt.wantErr, "MergeSettings should describe the failure")
 			require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
 		})
 	}

--- a/internal/db/users.go
+++ b/internal/db/users.go
@@ -3,6 +3,7 @@ package db
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"time"
 
@@ -274,26 +275,51 @@ func (s *UserStore) CreateWithPassword(ctx context.Context, user *models.User) e
 	return row.Scan(&user.ID, &user.CreatedAt)
 }
 
-// UpdateSettings replaces the user's settings JSONB document.
+// MergeSettings applies an RFC 7386 JSON merge patch to the user's settings
+// JSONB document and returns the merged result. The read-merge-write runs in
+// a transaction holding the row lock, so concurrent patches from other tabs
+// compose instead of overwriting each other (the old replace-the-document
+// contract made every writer clobber whatever it hadn't read).
 //
 // lint:allow-no-orgid reason="user-scoped self-settings update by primary key"
-func (s *UserStore) UpdateSettings(ctx context.Context, userID uuid.UUID, settings models.UserSettings) error {
-	encodedSettings, err := settings.MarshalJSONB()
-	if err != nil {
-		return fmt.Errorf("marshal user settings: %w", err)
+func (s *UserStore) MergeSettings(ctx context.Context, userID uuid.UUID, patch json.RawMessage) (models.UserSettings, error) {
+	starter, ok := s.db.(TxStarter)
+	if !ok {
+		return models.UserSettings{}, fmt.Errorf("user store db does not support transactions")
 	}
-	query := `UPDATE users SET settings = @settings WHERE id = @id`
-	tag, err := s.db.Exec(ctx, query, pgx.NamedArgs{
+	tx, err := starter.Begin(ctx)
+	if err != nil {
+		return models.UserSettings{}, fmt.Errorf("begin settings merge: %w", err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	var current json.RawMessage
+	row := tx.QueryRow(ctx, `SELECT settings FROM users WHERE id = @id FOR UPDATE`, pgx.NamedArgs{"id": userID})
+	if err := row.Scan(&current); err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return models.UserSettings{}, pgx.ErrNoRows
+		}
+		return models.UserSettings{}, fmt.Errorf("load user settings for merge: %w", err)
+	}
+
+	merged, err := models.ApplyUserSettingsMergePatch(current, patch)
+	if err != nil {
+		return models.UserSettings{}, fmt.Errorf("merge user settings: %w", err)
+	}
+	encodedSettings, err := merged.MarshalJSONB()
+	if err != nil {
+		return models.UserSettings{}, fmt.Errorf("marshal user settings: %w", err)
+	}
+	if _, err := tx.Exec(ctx, `UPDATE users SET settings = @settings WHERE id = @id`, pgx.NamedArgs{
 		"settings": encodedSettings,
 		"id":       userID,
-	})
-	if err != nil {
-		return fmt.Errorf("update user settings: %w", err)
+	}); err != nil {
+		return models.UserSettings{}, fmt.Errorf("update user settings: %w", err)
 	}
-	if tag.RowsAffected() == 0 {
-		return pgx.ErrNoRows
+	if err := tx.Commit(ctx); err != nil {
+		return models.UserSettings{}, fmt.Errorf("commit settings merge: %w", err)
 	}
-	return nil
+	return merged, nil
 }
 
 // UpsertFromGoogle creates or updates a user based on their Google subject ID.

--- a/internal/models/user_settings.go
+++ b/internal/models/user_settings.go
@@ -4,6 +4,9 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"reflect"
+	"strings"
+	"sync"
 )
 
 // UserSettings is the strongly-typed representation of users.settings JSONB.
@@ -40,6 +43,76 @@ func (s UserSettings) MarshalJSONB() (json.RawMessage, error) {
 		return nil, fmt.Errorf("marshal user settings: %w", err)
 	}
 	return encoded, nil
+}
+
+// userSettingsJSONKeys returns the set of top-level JSON keys a settings
+// merge patch may reference, derived from the UserSettings struct tags so it
+// can't drift when fields are added.
+var userSettingsJSONKeys = sync.OnceValue(func() map[string]struct{} {
+	keys := map[string]struct{}{}
+	t := reflect.TypeOf(UserSettings{})
+	for i := 0; i < t.NumField(); i++ {
+		name, _, _ := strings.Cut(t.Field(i).Tag.Get("json"), ",")
+		if name != "" && name != "-" {
+			keys[name] = struct{}{}
+		}
+	}
+	return keys
+})
+
+// ApplyUserSettingsMergePatch applies an RFC 7386 JSON merge patch to the
+// current settings document and returns the validated result. Keys absent
+// from the patch keep their stored value, null clears the stored value, and
+// nested objects merge per key — so callers send only the fields they are
+// changing instead of rebuilding the whole document client-side.
+func ApplyUserSettingsMergePatch(current, patch json.RawMessage) (UserSettings, error) {
+	var patchDoc map[string]any
+	if err := json.Unmarshal(patch, &patchDoc); err != nil || patchDoc == nil {
+		return UserSettings{}, fmt.Errorf("settings patch must be a JSON object")
+	}
+	for key := range patchDoc {
+		if _, ok := userSettingsJSONKeys()[key]; !ok {
+			return UserSettings{}, fmt.Errorf("unknown settings field %q", key)
+		}
+	}
+	currentDoc := map[string]any{}
+	if len(current) > 0 {
+		if err := json.Unmarshal(current, &currentDoc); err != nil {
+			return UserSettings{}, fmt.Errorf("unmarshal current user settings: %w", err)
+		}
+	}
+	merged, err := json.Marshal(mergeJSONObjects(currentDoc, patchDoc))
+	if err != nil {
+		return UserSettings{}, fmt.Errorf("marshal merged user settings: %w", err)
+	}
+	return ParseUserSettings(merged)
+}
+
+// mergeJSONObjects implements the RFC 7386 merge rules for two decoded JSON
+// objects: null patch values delete the key, object values merge recursively,
+// and everything else replaces the target value.
+func mergeJSONObjects(target, patch map[string]any) map[string]any {
+	merged := make(map[string]any, len(target)+len(patch))
+	for key, value := range target {
+		merged[key] = value
+	}
+	for key, value := range patch {
+		if value == nil {
+			delete(merged, key)
+			continue
+		}
+		patchObj, ok := value.(map[string]any)
+		if !ok {
+			merged[key] = value
+			continue
+		}
+		targetObj, ok := merged[key].(map[string]any)
+		if !ok {
+			targetObj = map[string]any{}
+		}
+		merged[key] = mergeJSONObjects(targetObj, patchObj)
+	}
+	return merged
 }
 
 // Validate returns an error if any user setting is invalid.

--- a/internal/models/user_settings_test.go
+++ b/internal/models/user_settings_test.go
@@ -79,6 +79,106 @@ func TestParseUserSettings(t *testing.T) {
 	}
 }
 
+func TestApplyUserSettingsMergePatch(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		current json.RawMessage
+		patch   json.RawMessage
+		want    UserSettings
+		wantErr string
+	}{
+		{
+			name:    "sets a field without touching the others",
+			current: json.RawMessage(`{"coding_agent_model_default":"claude-opus-4-7","coding_agent_reasoning_defaults":{"codex":"xhigh"}}`),
+			patch:   json.RawMessage(`{"diff_viewer_full_screen":true}`),
+			want: UserSettings{
+				CodingAgentModelDefault: "claude-opus-4-7",
+				CodingAgentReasoningDefaults: map[AgentType]ReasoningEffort{
+					AgentTypeCodex: ReasoningEffortXHigh,
+				},
+				DiffViewerFullScreen: true,
+			},
+		},
+		{
+			name:    "merges nested reasoning defaults per agent",
+			current: json.RawMessage(`{"coding_agent_reasoning_defaults":{"codex":"xhigh"}}`),
+			patch:   json.RawMessage(`{"coding_agent_reasoning_defaults":{"claude_code":"max"}}`),
+			want: UserSettings{
+				CodingAgentReasoningDefaults: map[AgentType]ReasoningEffort{
+					AgentTypeCodex:      ReasoningEffortXHigh,
+					AgentTypeClaudeCode: ReasoningEffortMax,
+				},
+			},
+		},
+		{
+			name:    "null clears a top-level field",
+			current: json.RawMessage(`{"coding_agent_model_default":"claude-opus-4-7","diff_viewer_full_screen":true}`),
+			patch:   json.RawMessage(`{"coding_agent_model_default":null}`),
+			want:    UserSettings{DiffViewerFullScreen: true},
+		},
+		{
+			name:    "null clears a nested reasoning default",
+			current: json.RawMessage(`{"coding_agent_reasoning_defaults":{"codex":"xhigh","claude_code":"max"}}`),
+			patch:   json.RawMessage(`{"coding_agent_reasoning_defaults":{"codex":null}}`),
+			want: UserSettings{
+				CodingAgentReasoningDefaults: map[AgentType]ReasoningEffort{
+					AgentTypeClaudeCode: ReasoningEffortMax,
+				},
+			},
+		},
+		{
+			name:  "applies to an empty current document",
+			patch: json.RawMessage(`{"diff_viewer_full_screen":true}`),
+			want:  UserSettings{DiffViewerFullScreen: true},
+		},
+		{
+			name:    "empty patch is a no-op",
+			current: json.RawMessage(`{"diff_viewer_full_screen":true}`),
+			patch:   json.RawMessage(`{}`),
+			want:    UserSettings{DiffViewerFullScreen: true},
+		},
+		{
+			name:    "rejects non-object patch",
+			patch:   json.RawMessage(`"settings"`),
+			wantErr: "must be a JSON object",
+		},
+		{
+			name:    "rejects null patch",
+			patch:   json.RawMessage(`null`),
+			wantErr: "must be a JSON object",
+		},
+		{
+			name:    "rejects unknown patch field",
+			patch:   json.RawMessage(`{"unknown":null}`),
+			wantErr: `unknown settings field "unknown"`,
+		},
+		{
+			name:    "rejects invalid merged value",
+			current: json.RawMessage(`{"coding_agent_reasoning_defaults":{"claude_code":"max"}}`),
+			patch:   json.RawMessage(`{"coding_agent_reasoning_defaults":{"codex":"max"}}`),
+			wantErr: "is not supported",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := ApplyUserSettingsMergePatch(tt.current, tt.patch)
+			if tt.wantErr != "" {
+				require.Error(t, err, "ApplyUserSettingsMergePatch should reject the patch")
+				require.Contains(t, err.Error(), tt.wantErr, "ApplyUserSettingsMergePatch should explain the rejection")
+				return
+			}
+			require.NoError(t, err, "ApplyUserSettingsMergePatch should accept the patch")
+			require.Equal(t, tt.want, got, "ApplyUserSettingsMergePatch should return the merged settings")
+		})
+	}
+}
+
 func TestUserSettings_MarshalJSONB(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## What changed

`PATCH /api/v1/auth/me/settings` now accepts an **RFC 7386 JSON merge patch** instead of a full replacement document: omitted fields keep their stored value, `null` clears a field, and nested objects (the per-agent reasoning map) merge per key.

- **Backend**
  - `models.ApplyUserSettingsMergePatch` implements the merge: rejects non-object patches and unknown fields (key set derived from the struct's JSON tags so it can't drift), validates the merged document via the existing `ParseUserSettings`.
  - `UserStore.MergeSettings` replaces the blind whole-document `UPDATE` with a read-merge-write inside a transaction holding the user row lock (`SELECT … FOR UPDATE`), so concurrent patches compose even when requests overlap.
  - The handler pre-validates the patch against an empty document so bad patches fail with a 400 before the transaction opens; error codes (`INVALID_BODY` / `INVALID_USER_SETTINGS`) are unchanged.
- **Frontend**
  - `UserSettingsUpdateRequest` is now a real patch type (`| null` on every field).
  - All three call sites send only the fields they change: the diff-viewer toggle sends just the flag, the model default sends `{ coding_agent_model_default: model || null }`, and reasoning saves send a single per-agent entry (`null` clears it). The cache-spread merge and the "don't persist before user loads" guard are gone.
  - The reasoning-save coalescing queue now **merges queued entries per agent** instead of replacing the queue — required once patches became partial, so rapid edits to different agents all land.
- **Docs**: `frontend/AGENTS.md` gains a "Settings Mutations: Patch, Don't Replace" section (+ anti-pattern entry); `internal/AGENTS.md` gains the backend rule (merge-patch + row lock for settings-document endpoints) pointing at this implementation as the reference.

## Why

Every settings mutation previously rebuilt the whole document from the local React Query cache, so a concurrent edit in another tab could be clobbered (cross-tab last-write-wins). A frontend-only fix would have left the server-side read-modify-write race; the row-locked server-side merge closes it structurally.

## Notes for review

- Clearing a field changed semantics: omission used to clear (whole-doc replace); now an explicit `null` does. Both UI clear paths (model default → "Default", reasoning level → "Default") send the null.
- The multi-tenancy audit needed a surgical exemption for the new `FOR UPDATE` select (user-scoped by primary key), following the file's backtick-anchoring convention.
- Pre-existing caveat, unchanged by this PR but now also affecting writes: `ParseUserSettings` rejects unknown fields, so removing a field from `UserSettings` requires a migration to strip the key from stored documents.
- Verified: `make lint` (0 issues), `go test ./internal/...`, `tsc --noEmit`, `eslint --max-warnings=0`, vitest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
