### PR TITLE
Share worker fingerprint input lists between deploy gate and rollover

### DIFF
--- a/deploy/deploy_config_test.go
+++ b/deploy/deploy_config_test.go
@@ -413,17 +413,112 @@ func TestWorkerDeployFingerprintsAreSeparatedByBlastRadius(t *testing.T) {
 	require.Contains(t, workerProcess, "worker", "worker process fingerprint should target the worker service")
 
 	require.NotContains(t, supportServices, "fingerprint_files \\\n        /opt/143/docker-compose.worker.yml", "support-service fingerprint should not hash the entire worker compose file")
-	require.Contains(t, supportServices, "chrome", "support-service fingerprint should include the chrome service block")
-	require.Contains(t, supportServices, "gvisor-check", "support-service fingerprint should include the gVisor check service block")
-	require.Contains(t, supportServices, "sandbox-dns", "support-service fingerprint should include the sandbox DNS service block")
-	require.Contains(t, supportServices, "docker-compose.dns-probe.yml", "support-service fingerprint should include the DNS probe compose file")
+	require.Contains(t, supportServices, "$WORKER_SUPPORT_SERVICE_COMPOSE_SERVICES", "support-service fingerprint should hash the shared support compose service list")
+	require.Contains(t, supportServices, "$WORKER_SUPPORT_SERVICE_FINGERPRINT_FILES", "support-service fingerprint should hash the shared support file list")
 
-	require.Contains(t, hostRuntime, "reconcile-worker-host.sh", "host-runtime fingerprint should include worker host reconciliation")
-	require.Contains(t, hostRuntime, "sandbox-firewall.sh", "host-runtime fingerprint should include sandbox firewall rules")
-	require.Contains(t, hostRuntime, "sandbox-resolv-conf.sh", "host-runtime fingerprint should include sandbox resolv.conf generation")
+	supportComposeServices := extractFingerprintListVar(t, deploy, "WORKER_SUPPORT_SERVICE_COMPOSE_SERVICES")
+	require.Contains(t, supportComposeServices, "chrome", "support-service fingerprint should include the chrome service block")
+	require.Contains(t, supportComposeServices, "gvisor-check", "support-service fingerprint should include the gVisor check service block")
+	require.Contains(t, supportComposeServices, "sandbox-dns", "support-service fingerprint should include the sandbox DNS service block")
+	supportFiles := extractFingerprintListVar(t, deploy, "WORKER_SUPPORT_SERVICE_FINGERPRINT_FILES")
+	require.Contains(t, supportFiles, "Dockerfile.dnsmasq", "support-service fingerprint should include the dnsmasq Dockerfile")
+	require.Contains(t, supportFiles, "docker-compose.dns-probe.yml", "support-service fingerprint should include the DNS probe compose file")
 
-	require.Contains(t, dockerDaemon, "install-docker-dns.sh", "docker-daemon fingerprint should include Docker DNS installation")
-	require.Contains(t, dockerDaemon, "install-log-rotation.sh", "docker-daemon fingerprint should include Docker log rotation installation")
+	require.Contains(t, hostRuntime, "$WORKER_HOST_RUNTIME_FINGERPRINT_FILES", "host-runtime fingerprint should hash the shared host-runtime file list")
+	hostRuntimeFiles := extractFingerprintListVar(t, deploy, "WORKER_HOST_RUNTIME_FINGERPRINT_FILES")
+	require.Contains(t, hostRuntimeFiles, "reconcile-worker-host.sh", "host-runtime fingerprint should include worker host reconciliation")
+	require.Contains(t, hostRuntimeFiles, "sandbox-firewall.sh", "host-runtime fingerprint should include sandbox firewall rules")
+	require.Contains(t, hostRuntimeFiles, "sandbox-resolv-conf.sh", "host-runtime fingerprint should include sandbox resolv.conf generation")
+	require.Contains(t, hostRuntimeFiles, "install-static-egress-worker.sh", "host-runtime fingerprint should include static egress WireGuard installation")
+
+	require.Contains(t, dockerDaemon, "$WORKER_DOCKER_DAEMON_FINGERPRINT_FILES", "docker-daemon fingerprint should hash the shared docker-daemon file list")
+	dockerDaemonFiles := extractFingerprintListVar(t, deploy, "WORKER_DOCKER_DAEMON_FINGERPRINT_FILES")
+	require.Contains(t, dockerDaemonFiles, "install-docker-dns.sh", "docker-daemon fingerprint should include Docker DNS installation")
+	require.Contains(t, dockerDaemonFiles, "install-log-rotation.sh", "docker-daemon fingerprint should include Docker log rotation installation")
+}
+
+// extractFingerprintListVar returns the canonical (single, top-level)
+// definition of one of the shared worker fingerprint input lists. The
+// negative character class skips the detached-rollover heredoc line that
+// re-binds the variable to itself ('$WORKER_...').
+func extractFingerprintListVar(t *testing.T, deployText, name string) string {
+	t.Helper()
+
+	re := regexp.MustCompile(`(?m)^` + regexp.QuoteMeta(name) + `='([^'$][^']*)'$`)
+	matches := re.FindAllStringSubmatch(deployText, -1)
+	require.Len(t, matches, 1, "deploy.sh should define %s exactly once as the canonical fingerprint input list", name)
+	return matches[0][1]
+}
+
+// Regression test for the routine-deploy failure loop: the staged fingerprint
+// gate and the blue/green rollover each used to carry their own hardcoded
+// fingerprint input lists. When the lists diverged (install-static-egress-
+// worker.sh was added to the gate's host-runtime list but not the rollover's),
+// every routine deploy failed with "host-runtime config changed": the gate
+// repaired the on-host baseline to a hash the rollover never computed, and a
+// maintenance deploy wrote the rollover's hash back, re-arming the failure.
+func TestWorkerFingerprintInputListsAreSharedBetweenGateAndRollover(t *testing.T) {
+	t.Parallel()
+
+	deployScript, err := os.ReadFile("../deploy/scripts/deploy.sh")
+	require.NoError(t, err, "test should read deploy.sh")
+	deploy := string(deployScript)
+
+	gate := extractTopLevelShellBlock(t, deploy, "fingerprint_candidate_files", "\nREMOTE\n}")
+	rollover := extractShellFunction(t, deploy, "worker_support_service_fingerprint", "ensure_routine_worker_fingerprints_compatible")
+
+	listVars := []string{
+		"WORKER_HOST_RUNTIME_FINGERPRINT_FILES",
+		"WORKER_DOCKER_DAEMON_FINGERPRINT_FILES",
+		"WORKER_SUPPORT_SERVICE_FINGERPRINT_FILES",
+		"WORKER_SUPPORT_SERVICE_COMPOSE_SERVICES",
+	}
+	for _, name := range listVars {
+		extractFingerprintListVar(t, deploy, name)
+		require.Contains(t, gate, "$"+name, "staged fingerprint gate should consume the shared %s list", name)
+		require.Contains(t, rollover, "$"+name, "blue/green rollover fingerprints should consume the shared %s list", name)
+		require.Equal(t, 2, strings.Count(deploy, "remote_env_assignment "+name+" "), "both the gate and the main remote payload should receive %s over SSH", name)
+		require.Contains(t, deploy, name+"='$"+name+"'", "detached rollover script should bake the shared %s list because it runs in a fresh process", name)
+	}
+}
+
+// The staged gate repairs the persisted fingerprint baseline using
+// fingerprint_candidate_files while the rollover recomputes it with
+// fingerprint_files. The repaired baseline only satisfies the rollover if the
+// two implementations hash identical files to identical digests — pin that
+// here so a format change in either copy fails at PR time, not on the fleet.
+func TestGateAndRolloverFingerprintImplementationsAgree(t *testing.T) {
+	t.Parallel()
+
+	deployScript, err := os.ReadFile("../deploy/scripts/deploy.sh")
+	require.NoError(t, err, "test should read deploy.sh")
+	deploy := string(deployScript)
+
+	gateFn := extractTopLevelShellFunction(t, deploy, "fingerprint_candidate_files", "fingerprint_active_files")
+	rolloverFn := extractShellFunction(t, deploy, "fingerprint_files", "compose_service_fingerprint")
+
+	tmpDir := t.TempDir()
+	first := filepath.Join(tmpDir, "reconcile-worker-host.sh")
+	second := filepath.Join(tmpDir, "sandbox-firewall.sh")
+	require.NoError(t, os.WriteFile(first, []byte("echo reconcile\n"), 0o755), "test should seed first fingerprinted file")
+	require.NoError(t, os.WriteFile(second, []byte("echo firewall\n"), 0o755), "test should seed second fingerprinted file")
+
+	script := gateFn + rolloverFn + `
+set -euo pipefail
+gate="$(fingerprint_candidate_files "$FILE_ONE" "$FILE_TWO")"
+rollover="$(fingerprint_files "$FILE_ONE" "$FILE_TWO")"
+printf '%s\n%s\n' "$gate" "$rollover"
+`
+
+	cmd := exec.Command("bash", "-c", script)
+	cmd.Env = append(os.Environ(), "FILE_ONE="+first, "FILE_TWO="+second)
+	output, err := cmd.CombinedOutput()
+	require.NoError(t, err, "fingerprint implementations should execute successfully: %s", output)
+
+	lines := strings.Split(strings.TrimSpace(string(output)), "\n")
+	require.Len(t, lines, 2, "comparison script should print both fingerprints")
+	require.Len(t, lines[0], 64, "gate fingerprint should be a sha256 hex digest")
+	require.Equal(t, lines[0], lines[1], "gate and rollover must compute identical fingerprints for identical files or routine deploys fail on a repaired baseline")
 }
 
 func TestStagedFingerprintIgnoresCandidateFilename(t *testing.T) {
@@ -486,6 +581,18 @@ func TestStagedFingerprintGateRepairsStaleBaselineWhenCandidateMatchesActive(t *
 
 	cmd := exec.Command("bash", "-c", gateScript)
 	cmd.Env = append(os.Environ(), "DEPLOY_MODE=routine")
+	// The gate reads the shared fingerprint input lists from its environment
+	// (deploy.sh passes them over SSH); feed it the real lists, retargeted at
+	// the temp directory.
+	for _, name := range []string{
+		"WORKER_HOST_RUNTIME_FINGERPRINT_FILES",
+		"WORKER_DOCKER_DAEMON_FINGERPRINT_FILES",
+		"WORKER_SUPPORT_SERVICE_FINGERPRINT_FILES",
+		"WORKER_SUPPORT_SERVICE_COMPOSE_SERVICES",
+	} {
+		value := extractFingerprintListVar(t, string(deployScript), name)
+		cmd.Env = append(cmd.Env, name+"="+strings.ReplaceAll(value, "/opt/143", tmpDir))
+	}
 	output, err := cmd.CombinedOutput()
 	require.NoError(t, err, "staged fingerprint gate should allow stale baseline repair when candidate matches active files: %s", output)
 	require.Contains(t, string(output), "stored worker support-service fingerprint is stale", "gate should explain stale support fingerprint repair")

--- a/deploy/scripts/deploy.sh
+++ b/deploy/scripts/deploy.sh
@@ -138,14 +138,35 @@ apply_static_egress_worker_host_map() {
   done
 }
 
+# Canonical worker fingerprint input lists, shared by the staged fingerprint
+# gate and the blue/green rollover (including the detached rollover script).
+# Both sides MUST hash the same inputs: the gate repairs the persisted
+# baseline from these lists, and the rollover compares its own computation
+# against that baseline. If they diverge, every routine deploy fails with
+# "config changed" even when nothing changed — the gate writes one hash, the
+# rollover expects another, and DEPLOY_MODE=maintenance just re-arms the loop.
+WORKER_HOST_RUNTIME_FINGERPRINT_FILES='/opt/143/deploy/scripts/reconcile-worker-host.sh /opt/143/deploy/scripts/sandbox-firewall.sh /opt/143/deploy/scripts/sandbox-resolv-conf.sh /opt/143/deploy/scripts/install-static-egress-worker.sh'
+WORKER_DOCKER_DAEMON_FINGERPRINT_FILES='/opt/143/deploy/scripts/install-docker-dns.sh /opt/143/deploy/scripts/install-log-rotation.sh'
+WORKER_SUPPORT_SERVICE_FINGERPRINT_FILES='/opt/143/Dockerfile.dnsmasq /opt/143/docker-compose.dns-probe.yml'
+WORKER_SUPPORT_SERVICE_COMPOSE_SERVICES='chrome gvisor-check sandbox-dns'
+
 run_worker_staged_fingerprint_gate() {
   if [ "$ROLE" != "worker" ]; then
     return 0
   fi
   ssh "${SSH_OPTS[@]}" deploy@"$HOST" \
     "$(remote_env_assignment DEPLOY_MODE "${DEPLOY_MODE:-routine}")" \
+    "$(remote_env_assignment WORKER_HOST_RUNTIME_FINGERPRINT_FILES "$WORKER_HOST_RUNTIME_FINGERPRINT_FILES")" \
+    "$(remote_env_assignment WORKER_DOCKER_DAEMON_FINGERPRINT_FILES "$WORKER_DOCKER_DAEMON_FINGERPRINT_FILES")" \
+    "$(remote_env_assignment WORKER_SUPPORT_SERVICE_FINGERPRINT_FILES "$WORKER_SUPPORT_SERVICE_FINGERPRINT_FILES")" \
+    "$(remote_env_assignment WORKER_SUPPORT_SERVICE_COMPOSE_SERVICES "$WORKER_SUPPORT_SERVICE_COMPOSE_SERVICES")" \
     'bash -s' <<'REMOTE'
 set -euo pipefail
+
+: "${WORKER_HOST_RUNTIME_FINGERPRINT_FILES:?deploy.sh must pass the shared host-runtime fingerprint file list}"
+: "${WORKER_DOCKER_DAEMON_FINGERPRINT_FILES:?deploy.sh must pass the shared docker-daemon fingerprint file list}"
+: "${WORKER_SUPPORT_SERVICE_FINGERPRINT_FILES:?deploy.sh must pass the shared support-service fingerprint file list}"
+: "${WORKER_SUPPORT_SERVICE_COMPOSE_SERVICES:?deploy.sh must pass the shared support-service compose service list}"
 
 fingerprint_candidate_files() {
   local selected=()
@@ -247,50 +268,44 @@ worker_process_config_fingerprint() {
   compose_service_fingerprint /opt/143/docker-compose.worker.yml worker
 }
 
+# The shared *_FINGERPRINT_FILES / *_COMPOSE_SERVICES lists are intentionally
+# expanded unquoted: they are space-separated lists of paths/services.
 worker_support_service_fingerprint() {
   {
-    compose_service_fingerprint /opt/143/docker-compose.worker.yml chrome gvisor-check sandbox-dns
-    fingerprint_candidate_files \
-      /opt/143/Dockerfile.dnsmasq \
-      /opt/143/docker-compose.dns-probe.yml
+    # shellcheck disable=SC2086
+    compose_service_fingerprint /opt/143/docker-compose.worker.yml $WORKER_SUPPORT_SERVICE_COMPOSE_SERVICES
+    # shellcheck disable=SC2086
+    fingerprint_candidate_files $WORKER_SUPPORT_SERVICE_FINGERPRINT_FILES
   } | sha256sum | awk '{print $1}'
 }
 
 worker_active_support_service_fingerprint() {
   {
-    compose_service_active_fingerprint /opt/143/docker-compose.worker.yml chrome gvisor-check sandbox-dns
-    fingerprint_active_files \
-      /opt/143/Dockerfile.dnsmasq \
-      /opt/143/docker-compose.dns-probe.yml
+    # shellcheck disable=SC2086
+    compose_service_active_fingerprint /opt/143/docker-compose.worker.yml $WORKER_SUPPORT_SERVICE_COMPOSE_SERVICES
+    # shellcheck disable=SC2086
+    fingerprint_active_files $WORKER_SUPPORT_SERVICE_FINGERPRINT_FILES
   } | sha256sum | awk '{print $1}'
 }
 
 worker_host_runtime_fingerprint() {
-  fingerprint_candidate_files \
-    /opt/143/deploy/scripts/reconcile-worker-host.sh \
-    /opt/143/deploy/scripts/sandbox-firewall.sh \
-    /opt/143/deploy/scripts/sandbox-resolv-conf.sh \
-    /opt/143/deploy/scripts/install-static-egress-worker.sh
+  # shellcheck disable=SC2086
+  fingerprint_candidate_files $WORKER_HOST_RUNTIME_FINGERPRINT_FILES
 }
 
 worker_active_host_runtime_fingerprint() {
-  fingerprint_active_files \
-    /opt/143/deploy/scripts/reconcile-worker-host.sh \
-    /opt/143/deploy/scripts/sandbox-firewall.sh \
-    /opt/143/deploy/scripts/sandbox-resolv-conf.sh \
-    /opt/143/deploy/scripts/install-static-egress-worker.sh
+  # shellcheck disable=SC2086
+  fingerprint_active_files $WORKER_HOST_RUNTIME_FINGERPRINT_FILES
 }
 
 worker_docker_daemon_fingerprint() {
-  fingerprint_candidate_files \
-    /opt/143/deploy/scripts/install-docker-dns.sh \
-    /opt/143/deploy/scripts/install-log-rotation.sh
+  # shellcheck disable=SC2086
+  fingerprint_candidate_files $WORKER_DOCKER_DAEMON_FINGERPRINT_FILES
 }
 
 worker_active_docker_daemon_fingerprint() {
-  fingerprint_active_files \
-    /opt/143/deploy/scripts/install-docker-dns.sh \
-    /opt/143/deploy/scripts/install-log-rotation.sh
+  # shellcheck disable=SC2086
+  fingerprint_active_files $WORKER_DOCKER_DAEMON_FINGERPRINT_FILES
 }
 
 repair_stale_worker_fingerprint() {
@@ -785,6 +800,10 @@ ssh "${SSH_OPTS[@]}" deploy@"$HOST" \
   "$(remote_env_assignment DEPLOY_DOCKER_PRUNE "${DEPLOY_DOCKER_PRUNE:-1}")" \
   "$(remote_env_assignment DOCKER_PRUNE_UNTIL "${DOCKER_PRUNE_UNTIL:-24h}")" \
   "$(remote_env_assignment DEPLOY_DOCKER_VOLUME_PRUNE "${DEPLOY_DOCKER_VOLUME_PRUNE:-0}")" \
+  "$(remote_env_assignment WORKER_HOST_RUNTIME_FINGERPRINT_FILES "$WORKER_HOST_RUNTIME_FINGERPRINT_FILES")" \
+  "$(remote_env_assignment WORKER_DOCKER_DAEMON_FINGERPRINT_FILES "$WORKER_DOCKER_DAEMON_FINGERPRINT_FILES")" \
+  "$(remote_env_assignment WORKER_SUPPORT_SERVICE_FINGERPRINT_FILES "$WORKER_SUPPORT_SERVICE_FINGERPRINT_FILES")" \
+  "$(remote_env_assignment WORKER_SUPPORT_SERVICE_COMPOSE_SERVICES "$WORKER_SUPPORT_SERVICE_COMPOSE_SERVICES")" \
   bash << 'REMOTE'
   set -euo pipefail
   cd /opt/143
@@ -1450,26 +1469,27 @@ ssh "${SSH_OPTS[@]}" deploy@"$HOST" \
     compose_service_fingerprint /opt/143/docker-compose.worker.yml worker
   }
 
+  # These fingerprints must match the staged fingerprint gate's computation
+  # exactly, so both read the shared *_FINGERPRINT_FILES / *_COMPOSE_SERVICES
+  # lists (passed via SSH env here, baked into the detached rollover script).
+  # The lists are space-separated, hence the intentional unquoted expansion.
   worker_support_service_fingerprint() {
     {
-      compose_service_fingerprint /opt/143/docker-compose.worker.yml chrome gvisor-check sandbox-dns
-      fingerprint_files \
-        /opt/143/Dockerfile.dnsmasq \
-        /opt/143/docker-compose.dns-probe.yml
+      # shellcheck disable=SC2086
+      compose_service_fingerprint /opt/143/docker-compose.worker.yml $WORKER_SUPPORT_SERVICE_COMPOSE_SERVICES
+      # shellcheck disable=SC2086
+      fingerprint_files $WORKER_SUPPORT_SERVICE_FINGERPRINT_FILES
     } | sha256sum | awk '{print $1}'
   }
 
   worker_host_runtime_fingerprint() {
-    fingerprint_files \
-      /opt/143/deploy/scripts/reconcile-worker-host.sh \
-      /opt/143/deploy/scripts/sandbox-firewall.sh \
-      /opt/143/deploy/scripts/sandbox-resolv-conf.sh
+    # shellcheck disable=SC2086
+    fingerprint_files $WORKER_HOST_RUNTIME_FINGERPRINT_FILES
   }
 
   worker_docker_daemon_fingerprint() {
-    fingerprint_files \
-      /opt/143/deploy/scripts/install-docker-dns.sh \
-      /opt/143/deploy/scripts/install-log-rotation.sh
+    # shellcheck disable=SC2086
+    fingerprint_files $WORKER_DOCKER_DAEMON_FINGERPRINT_FILES
   }
 
   ensure_routine_worker_fingerprints_compatible() {
@@ -2058,6 +2078,10 @@ WORKER_BLUE_GREEN_PREFLIGHT_ATTEMPTS='${WORKER_BLUE_GREEN_PREFLIGHT_ATTEMPTS:-}'
 WORKER_BLUE_GREEN_PREFLIGHT_RETRY_DELAY_SECONDS='${WORKER_BLUE_GREEN_PREFLIGHT_RETRY_DELAY_SECONDS:-}'
 WORKER_BASE_NODE_ID='${WORKER_BASE_NODE_ID:-}'
 WORKER_DRAIN_TIMEOUT='${WORKER_DRAIN_TIMEOUT:-}'
+WORKER_HOST_RUNTIME_FINGERPRINT_FILES='$WORKER_HOST_RUNTIME_FINGERPRINT_FILES'
+WORKER_DOCKER_DAEMON_FINGERPRINT_FILES='$WORKER_DOCKER_DAEMON_FINGERPRINT_FILES'
+WORKER_SUPPORT_SERVICE_FINGERPRINT_FILES='$WORKER_SUPPORT_SERVICE_FINGERPRINT_FILES'
+WORKER_SUPPORT_SERVICE_COMPOSE_SERVICES='$WORKER_SUPPORT_SERVICE_COMPOSE_SERVICES'
 
 # Always write a status file so the verify step has a deterministic signal.
 # If we exit before the success line writes "ok", the trap leaves "fail".


### PR DESCRIPTION
## Problem

Every routine worker deploy was failing on all six workers with:

```
ERROR: worker host-runtime config changed during routine deploy; run DEPLOY_MODE=maintenance after reviewing active runtime impact.
current=0648c72c… candidate=40a00aa…
```

— even with no host-runtime changes, and even after running maintenance deploys.

The root cause was that `deploy.sh` carried **two hardcoded copies** of the worker fingerprint input lists, and they had diverged: #1033 added `install-static-egress-worker.sh` to the staged gate's host-runtime list (4 files) but not to the blue/green rollover's copy (3 files). That created a permanent failure loop:

1. A maintenance/successful deploy ends with the rollover persisting its **3-file** hash as the baseline.
2. The next routine deploy's staged gate (added in #1283) computes a **4-file** candidate, sees a mismatch, confirms staged == active, and "repairs" the baseline to the 4-file hash.
3. The detached rollover then computes its **3-file** hash, fails against the repaired baseline, and the deploy dies.
4. `DEPLOY_MODE=maintenance` writes the 3-file hash back — re-arming the loop.

## Fix

- Define the four fingerprint input lists (`WORKER_HOST_RUNTIME_FINGERPRINT_FILES`, `WORKER_DOCKER_DAEMON_FINGERPRINT_FILES`, `WORKER_SUPPORT_SERVICE_FINGERPRINT_FILES`, `WORKER_SUPPORT_SERVICE_COMPOSE_SERVICES`) **once** at the top of `deploy.sh`.
- Pass them into both SSH payloads via `remote_env_assignment`, with `:?` guards in the gate so a missing/empty list fails loudly.
- Bake them into the detached rollover script alongside the other bound vars (it runs as a fresh detached process).
- Both payloads' fingerprint functions now expand the shared lists — which inherently adds the missing `install-static-egress-worker.sh` to the rollover's host-runtime fingerprint.

## Tests

- `TestWorkerFingerprintInputListsAreSharedBetweenGateAndRollover` — each list is defined exactly once, consumed by both the gate and the rollover, passed over SSH to both payloads, and baked into the detached script. A second hardcoded copy is now a test failure.
- `TestGateAndRolloverFingerprintImplementationsAgree` — executes `fingerprint_candidate_files` (gate) and `fingerprint_files` (rollover) in real bash against identical files and asserts identical digests. This equivalence is what makes a gate-repaired baseline satisfy the rollover; it was previously true only by accident.
- Updated the blast-radius and gate-repair tests to pin membership on the canonical lists (now including `install-static-egress-worker.sh`) and to feed the executable gate test the real lists via env, same as production.

## Reviewer notes

- **No on-host cleanup needed.** Worker baselines currently hold the gate-repaired 4-file hash, which the fixed rollover reproduces; a host still on a 3-file baseline self-heals via the gate's repair path. The next routine deploy should go green on all workers without maintenance mode.
- If a worker still fails with this error after merge, the `current=`/`candidate=` hashes now indicate genuine host drift rather than the script disagreeing with itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)