### PR TITLE
Route Sentry connects through the backend OAuth start

### DIFF
--- a/frontend/src/app/(dashboard)/settings/integrations/page.tsx
+++ b/frontend/src/app/(dashboard)/settings/integrations/page.tsx
@@ -1089,7 +1089,7 @@ export default function IntegrationsPage() {
         mezmoConnected={Boolean(mezmoIntegration)}
         mezmoLoading={mezmoConnectMutation.isPending}
         onConnectGitHub={() => api.integrations.loginGitHub()}
-        onConnectSentry={() => api.auth.loginSentry()}
+        onConnectSentry={() => api.integrations.loginSentry()}
         onConnectLinear={() => api.integrations.loginLinear()}
         onConnectSlack={() => api.integrations.loginSlack()}
         onConnectNotion={() => {

--- a/frontend/src/components/setup-checklist.tsx
+++ b/frontend/src/components/setup-checklist.tsx
@@ -256,7 +256,7 @@ export function SetupChecklist() {
             circleciConnected={Boolean(circleciIntegration)}
             mezmoConnected={Boolean(mezmoIntegration)}
             linearLoading={false}
-            onConnectSentry={() => api.auth.loginSentry()}
+            onConnectSentry={() => api.integrations.loginSentry()}
             onConnectLinear={() => api.integrations.loginLinear()}
             onConnectSlack={() => api.integrations.loginSlack()}
             onConnectNotion={() => { /* Notion requires token input — use the Integrations page */ }}

--- a/frontend/src/lib/api.test.ts
+++ b/frontend/src/lib/api.test.ts
@@ -1411,7 +1411,7 @@ describe('api client', () => {
       expect(loc.href).toBe('/api/v1/auth/google/login?invitation=inv-456&return_to=%2Fintegrations');
     });
 
-    it('loginSentry redirects to Sentry OAuth', () => {
+    it('loginSentry redirects to backend Sentry OAuth start', () => {
       const loc = { href: '' };
       Object.defineProperty(window, 'location', {
         value: loc,
@@ -1420,7 +1420,19 @@ describe('api client', () => {
       });
 
       api.auth.loginSentry();
-      expect(loc.href).toContain('https://sentry.io/oauth/authorize/');
+      expect(loc.href).toBe('/api/v1/integrations/sentry/login');
+    });
+
+    it('integration loginSentry redirects to backend Sentry OAuth start', () => {
+      const loc = { href: '' };
+      Object.defineProperty(window, 'location', {
+        value: loc,
+        writable: true,
+        configurable: true,
+      });
+
+      api.integrations.loginSentry();
+      expect(loc.href).toBe('/api/v1/integrations/sentry/login');
     });
 
     it('loginLinear redirects to backend Linear OAuth start', () => {

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -2,8 +2,6 @@ import { getActiveOrgId, ORG_MEMBERSHIP_REVOKED_EVENT } from './active-org';
 import { normalizeAPIResponse } from './api-normalize';
 
 const API_BASE = process.env.NEXT_PUBLIC_API_URL || '';
-const SENTRY_CLIENT_ID = process.env.NEXT_PUBLIC_SENTRY_CLIENT_ID || '';
-const SENTRY_REDIRECT_URI = process.env.NEXT_PUBLIC_SENTRY_REDIRECT_URI || '';
 
 export class ApiError extends Error {
   constructor(public code: string, message: string, public details?: unknown) {
@@ -178,12 +176,7 @@ export const api = {
       window.location.href = `${API_BASE}/api/v1/auth/google/login${qs ? `?${qs}` : ''}`;
     },
     loginSentry: () => {
-      const params = new URLSearchParams({
-        client_id: SENTRY_CLIENT_ID,
-        response_type: 'code',
-        redirect_uri: SENTRY_REDIRECT_URI,
-      });
-      window.location.href = `https://sentry.io/oauth/authorize/?${params.toString()}`;
+      window.location.href = `${API_BASE}/api/v1/integrations/sentry/login`;
     },
     loginEmail: (email: string, password: string) =>
       post<import('./types').SingleResponse<import('./types').User>>('/api/v1/auth/login', { email, password }),
@@ -706,6 +699,9 @@ export const api = {
     },
     loginLinear: () => {
       window.location.href = `${API_BASE}/api/v1/integrations/linear/login`;
+    },
+    loginSentry: () => {
+      window.location.href = `${API_BASE}/api/v1/integrations/sentry/login`;
     },
     connectLinear: () => post<import('./types').SingleResponse<import('./types').Integration>>('/api/v1/integrations/linear/connect'),
     loginSlack: () => {


### PR DESCRIPTION
## Summary
- Send Sentry connect flows through `/api/v1/integrations/sentry/login` instead of building the Sentry authorize URL in the browser.
- Update the Integrations page and setup checklist to use the backend-backed flow.
- Add coverage for both Sentry redirect helpers in the API client tests.

## Testing
- Updated unit tests for the Sentry redirect behavior.
- Not run (not requested)