### PR TITLE
Improve static egress probe-image pull error messaging

### DIFF
--- a/deploy/scripts/install-static-egress-worker.sh
+++ b/deploy/scripts/install-static-egress-worker.sh
@@ -95,7 +95,18 @@ ip route show table "$TABLE_ID" | grep -F "dev $WG_INTERFACE" >/dev/null
 
 if [ "${STATIC_EGRESS_SKIP_PROBES:-false}" != "true" ]; then
   if ! docker image inspect "$PROBE_IMAGE" >/dev/null 2>&1; then
-    docker pull "$PROBE_IMAGE" >/dev/null
+    # This script runs as root, which has no ghcr.io registry credentials, so
+    # this pull only works for public images. Private probe images must be
+    # pre-pulled by deploy.sh as the deploy user.
+    if ! pull_output="$(docker pull "$PROBE_IMAGE" 2>&1)"; then
+      echo "ERROR: static egress probe image '$PROBE_IMAGE' is not present locally and the pull failed:" >&2
+      echo "       ${pull_output}" >&2
+      echo "       Pull it as the deploy user (which is logged in to ghcr.io) and re-run:" >&2
+      echo "         docker pull $PROBE_IMAGE" >&2
+      echo "       deploy.sh pre-pulls STATIC_EGRESS_PROBE_IMAGE before reconciliation; if this keeps" >&2
+      echo "       failing, check that /opt/143/.env pins the same tag the deploy pre-pulled." >&2
+      exit 1
+    fi
   fi
   if ! observed_ip="$(docker run --rm --network "$STATIC_EGRESS_NETWORK" \
     --name "143-static-egress-probe-$$" \


### PR DESCRIPTION
## Summary

Improved error messaging when static egress worker probe image cannot be pulled. Instead of reporting a bare registry error, the script now clearly indicates that the image must be pre-pulled as the deploy user (which has ghcr.io credentials), and checks that `/opt/143/.env` pins the same tag deploy.sh pre-pulled.

## What changed

- `deploy/scripts/install-static-egress-worker.sh`: wrapped the best-effort `docker pull` fallback with better error handling
  - Keeps the pull attempt (required by existing test and still works for public images)
  - On pull failure, reports the actual error plus actionable guidance
  - Guides operators to pull as deploy@host, verify tag matching in `/opt/143/.env`, and note that deploy.sh pre-pulls before reconciliation

## Context

This fixes the operator experience from tonight's incident where a failed probe-image pull showed only `error from registry: unauthorized` without context. With this change, the error message will immediately indicate the root cause and how to resolve it.

## Test plan

- [x] `TestStaticEgressDeployWiring` passes (asserts on script contents including the pull line)
- [x] Syntax check passes (`bash -n`)
- Deploy to test fleet with a mismatch between deploy-pulled tag and `/opt/143/.env` tag to verify error messaging is clear

🤖 Generated with [Claude Code](https://claude.com/claude-code)
