### PR TITLE
Reject unsupported Mezmo dataset scopes in Mezmo integration

### DIFF
--- a/frontend/src/app/(dashboard)/settings/integrations/page.test.tsx
+++ b/frontend/src/app/(dashboard)/settings/integrations/page.test.tsx
@@ -571,7 +571,7 @@ describe("IntegrationsPage", () => {
     );
   });
 
-  it("helps users find Mezmo service keys and datasets while connecting", async () => {
+  it("helps users find Mezmo service keys while connecting", async () => {
     integrationsListMock.mockResolvedValueOnce({ data: [], meta: {} });
 
     renderWithProviders(<IntegrationsPage />);
@@ -586,10 +586,7 @@ describe("IntegrationsPage", () => {
       "https://app.mezmo.com/",
     );
 
-    await user.hover(within(dialog).getByRole("button", { name: "Where to find the Mezmo dataset" }));
-
-    expect(await screen.findByRole("tooltip")).toHaveTextContent(
-      "In Mezmo Log Analysis, open Search, then use the dataset selector near the top of the log viewer. Copy that selected dataset name exactly. Leave blank to query across the default Mezmo scope.",
-    );
+    expect(within(dialog).queryByLabelText("Dataset (optional)")).not.toBeInTheDocument();
+    expect(within(dialog).queryByRole("button", { name: "Where to find the Mezmo dataset" })).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/app/(dashboard)/settings/integrations/page.tsx
+++ b/frontend/src/app/(dashboard)/settings/integrations/page.tsx
@@ -727,7 +727,6 @@ function IntegrationDetailSheet({
   onReplaceNotionToken,
   onReplaceCircleCIToken,
   onReplaceMezmoCredentials,
-  mezmoDataset,
   mezmoBaseURL,
 }: {
   provider: IntegrationKey | null;
@@ -746,7 +745,6 @@ function IntegrationDetailSheet({
   onReplaceNotionToken: () => void;
   onReplaceCircleCIToken: () => void;
   onReplaceMezmoCredentials: () => void;
-  mezmoDataset?: string;
   mezmoBaseURL?: string;
 }) {
   if (!provider) return null;
@@ -816,11 +814,9 @@ function IntegrationDetailSheet({
               <dl className="grid grid-cols-[auto_1fr] gap-x-4 gap-y-1 text-sm">
                 <dt className="text-muted-foreground">Base URL</dt>
                 <dd className="truncate">{mezmoBaseURL || "https://api.mezmo.com (default)"}</dd>
-                <dt className="text-muted-foreground">Dataset</dt>
-                <dd className="truncate">{mezmoDataset || "All datasets"}</dd>
               </dl>
               <p className="text-sm text-muted-foreground">
-                Replace the Mezmo service key, base URL, or dataset used for production log queries.
+                Replace the Mezmo service key or base URL used for production log queries.
               </p>
               <Button size="sm" variant="outline" onClick={onReplaceMezmoCredentials}>Replace credentials</Button>
             </div>
@@ -1007,8 +1003,8 @@ export default function IntegrationsPage() {
   const [mezmoDialogOpen, setMezmoDialogOpen] = useState(false);
   const [mezmoError, setMezmoError] = useState<string | null>(null);
   const mezmoConnectMutation = useMutation({
-    mutationFn: ({ apiKey, baseUrl, dataset }: { apiKey: string; baseUrl: string; dataset: string }) =>
-      api.integrations.connectMezmo(apiKey, baseUrl, dataset),
+    mutationFn: ({ apiKey, baseUrl }: { apiKey: string; baseUrl: string }) =>
+      api.integrations.connectMezmo(apiKey, baseUrl),
     onSuccess: () => {
       setMezmoDialogOpen(false);
       setMezmoError(null);
@@ -1121,7 +1117,7 @@ export default function IntegrationsPage() {
           ) : undefined,
           mezmo: mezmoIntegration ? (
             <p className="mt-1.5 text-xs text-muted-foreground">
-              {mezmoIntegration.mezmo_dataset ? `Dataset: ${mezmoIntegration.mezmo_dataset}` : "Production log queries are enabled"}
+              Production log queries are enabled
             </p>
           ) : undefined,
         }}
@@ -1161,7 +1157,6 @@ export default function IntegrationsPage() {
           setMezmoError(null);
           setMezmoDialogOpen(true);
         }}
-        mezmoDataset={mezmoIntegration?.mezmo_dataset}
         mezmoBaseURL={mezmoIntegration?.mezmo_base_url}
       />
 
@@ -1257,8 +1252,7 @@ export default function IntegrationsPage() {
             >
               Open Mezmo
             </a>
-            . Base URL and dataset are optional; leave them blank to use the
-            default Mezmo search scope.
+            . Base URL is optional; leave it blank to use the default Mezmo API host.
           </>
         }
         fields={[
@@ -1274,22 +1268,11 @@ export default function IntegrationsPage() {
               content: "Only needed for self-hosted or regional Mezmo deployments. Leave blank to use https://api.mezmo.com.",
             },
           },
-          {
-            id: "dataset",
-            label: "Dataset (optional)",
-            placeholder: "e.g. production",
-            type: "text",
-            optional: true,
-            tooltip: {
-              ariaLabel: "Where to find the Mezmo dataset",
-              content: "In Mezmo Log Analysis, open Search, then use the dataset selector near the top of the log viewer. Copy that selected dataset name exactly. Leave blank to query across the default Mezmo scope.",
-            },
-          },
         ]}
         submitting={mezmoConnectMutation.isPending}
         error={mezmoError}
         onSubmit={(values) =>
-          mezmoConnectMutation.mutate({ apiKey: values.apiKey, baseUrl: values.baseUrl, dataset: values.dataset })
+          mezmoConnectMutation.mutate({ apiKey: values.apiKey, baseUrl: values.baseUrl })
         }
       />
     </PageContainer>

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -719,11 +719,10 @@ export const api = {
         auth_token: authToken,
         project_slug: projectSlug,
       }),
-    connectMezmo: (apiKey: string, baseUrl?: string, dataset?: string) =>
+    connectMezmo: (apiKey: string, baseUrl?: string) =>
       post<import('./types').SingleResponse<import('./types').Integration>>('/api/v1/integrations/mezmo/connect', {
         api_key: apiKey,
         base_url: baseUrl ?? '',
-        dataset: dataset ?? '',
       }),
     disconnect: (provider: string) => del(`/api/v1/integrations/${provider}/disconnect`),
     syncGitHub: () => post<{ data: { repos_synced: number; repos_seen?: number; errors: number } }>('/api/v1/integrations/github/sync'),

--- a/internal/api/handlers/integrations.go
+++ b/internal/api/handlers/integrations.go
@@ -523,9 +523,6 @@ func (h *IntegrationHandler) deriveSafeCredentialMetadata(ctx context.Context, i
 			integration.CircleCIProjectSlug = integrationStringPtr(cfg.ProjectSlug)
 		}
 	case models.MezmoConfig:
-		if cfg.Dataset != "" {
-			integration.MezmoDataset = integrationStringPtr(cfg.Dataset)
-		}
 		if cfg.BaseURL != "" {
 			integration.MezmoBaseURL = integrationStringPtr(cfg.BaseURL)
 		}
@@ -3027,13 +3024,13 @@ func (h *IntegrationHandler) validateCircleCIToken(ctx context.Context, token st
 // runtime provider default in internal/services/integration.NewMezmoProvider.
 const mezmoDefaultBaseURL = "https://api.mezmo.com"
 
-// ConnectMezmo accepts a Mezmo service key (plus optional base URL and dataset),
-// validates it against the log-search endpoint, stores the credential, and
-// creates an active integration record. Mezmo uses a paste-the-key flow because
-// its log-query API authenticates with a service key rather than OAuth. The
-// stored credential is injected into sandboxes as MEZMO_* env vars by the
-// orchestrator (see internal/services/agent/env.go) so the agent's 143-tools
-// log commands query this org's Mezmo with its own key.
+// ConnectMezmo accepts a Mezmo access token or legacy service key (plus optional
+// base URL), validates it against the export endpoint, stores the
+// credential, and creates an active integration record. Mezmo uses a
+// paste-the-key flow because its log-query API authenticates with a long-lived
+// token rather than OAuth. The stored credential is injected into sandboxes as
+// MEZMO_* env vars by the orchestrator (see internal/services/agent/env.go) so
+// the agent's 143-tools log commands query this org's Mezmo with its own key.
 func (h *IntegrationHandler) ConnectMezmo(w http.ResponseWriter, r *http.Request) {
 	orgID := middleware.OrgIDFromContext(r.Context())
 
@@ -3051,6 +3048,10 @@ func (h *IntegrationHandler) ConnectMezmo(w http.ResponseWriter, r *http.Request
 	req.Dataset = strings.TrimSpace(req.Dataset)
 	if req.APIKey == "" {
 		writeError(w, r, http.StatusBadRequest, "MISSING_API_KEY", "api_key is required")
+		return
+	}
+	if req.Dataset != "" {
+		writeError(w, r, http.StatusBadRequest, "UNSUPPORTED_DATASET", "Mezmo dataset scoping is not supported by the current export API; leave dataset blank")
 		return
 	}
 	if req.BaseURL != "" {
@@ -3091,55 +3092,70 @@ func (h *IntegrationHandler) ConnectMezmo(w http.ResponseWriter, r *http.Request
 	writeJSON(w, http.StatusOK, models.SingleResponse[models.Integration]{Data: integration})
 }
 
-// validateMezmoToken issues a minimal log search against the Mezmo API to
-// confirm the service key is accepted. It mirrors the auth path the runtime
-// provider uses (POST /v1/logs/search with a `servicekey` header — see
-// internal/services/integration/log_http.go).
+// validateMezmoToken issues a minimal export request against the Mezmo API to
+// confirm the key is accepted. It mirrors the runtime provider's documented
+// GET /v2/export path and prefers the current Authorization token auth, with a
+// fallback for legacy service keys.
 func (h *IntegrationHandler) validateMezmoToken(ctx context.Context, cfg models.MezmoConfig) error {
 	baseURL := cfg.BaseURL
 	if baseURL == "" {
 		baseURL = mezmoDefaultBaseURL
 	}
 	now := time.Now()
-	body := map[string]any{
-		"query":      "*",
-		"start_time": now.Add(-time.Minute).Format(time.RFC3339Nano),
-		"end_time":   now.Format(time.RFC3339Nano),
-		"limit":      1,
-	}
-	if cfg.Dataset != "" {
-		body["dataset"] = cfg.Dataset
-	}
-	data, err := json.Marshal(body)
-	if err != nil {
-		return err
-	}
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, baseURL+"/v1/logs/search", bytes.NewReader(data))
-	if err != nil {
-		return err
-	}
-	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("servicekey", cfg.APIKey)
+	values := url.Values{}
+	values.Set("query", "*")
+	values.Set("from", strconv.FormatInt(now.Add(-time.Minute).Unix(), 10))
+	values.Set("to", strconv.FormatInt(now.Unix(), 10))
+	values.Set("size", "1")
+	values.Set("prefer", "tail")
 
-	resp, err := h.client.Do(req)
+	statusCode, err := h.validateMezmoTokenRequest(ctx, baseURL, values, "Authorization", "Token "+cfg.APIKey)
 	if err != nil {
 		return fmt.Errorf("request failed: %w", err)
 	}
-	defer resp.Body.Close()
-	_, _ = io.Copy(io.Discard, resp.Body)
+	if statusCode == http.StatusUnauthorized || statusCode == http.StatusForbidden {
+		fallbackStatus, fallbackErr := h.validateMezmoTokenRequest(ctx, baseURL, values, "servicekey", cfg.APIKey)
+		if fallbackErr != nil {
+			return fmt.Errorf("request failed: %w", fallbackErr)
+		}
+		statusCode = fallbackStatus
+	}
 
 	// We're validating the key, not the query. Only an auth rejection is a
-	// definitive "bad key", and a 5xx means Mezmo is unhealthy right now (worth
-	// surfacing so the user retries). Any other 4xx (e.g. an unknown dataset, an
-	// unsupported query shape, or a 429 rate-limit) means the key was accepted
-	// and the request reached the API, so we let the connection succeed rather
-	// than block a valid key on a query-shape quirk.
+	// definitive "bad key", 404/405 means the configured endpoint is wrong or
+	// no longer serves the export API, and a 5xx means Mezmo is unhealthy right
+	// now (worth surfacing so the user retries). Other 4xx responses can be
+	// query-shape/rate-limit quirks after auth, so do not block a valid key.
 	switch {
-	case resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden:
+	case statusCode == http.StatusUnauthorized || statusCode == http.StatusForbidden:
 		return fmt.Errorf("invalid or expired key")
-	case resp.StatusCode >= 500:
-		return fmt.Errorf("mezmo API returned %d", resp.StatusCode)
+	case statusCode == http.StatusNotFound || statusCode == http.StatusMethodNotAllowed:
+		return fmt.Errorf("mezmo API endpoint not found")
+	case statusCode >= 500:
+		return fmt.Errorf("mezmo API returned %d", statusCode)
 	default:
 		return nil
 	}
+}
+
+func (h *IntegrationHandler) validateMezmoTokenRequest(ctx context.Context, baseURL string, values url.Values, authHeader, authValue string) (int, error) {
+	endpoint := strings.TrimRight(baseURL, "/") + "/v2/export"
+	if encoded := values.Encode(); encoded != "" {
+		endpoint += "?" + encoded
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return 0, err
+	}
+	req.Header.Set(authHeader, authValue)
+
+	resp, err := h.client.Do(req)
+	if err != nil {
+		return 0, err
+	}
+	defer resp.Body.Close()
+	if _, err := io.Copy(io.Discard, resp.Body); err != nil {
+		return 0, err
+	}
+	return resp.StatusCode, nil
 }

--- a/internal/api/handlers/integrations_test.go
+++ b/internal/api/handlers/integrations_test.go
@@ -326,8 +326,7 @@ func TestIntegrationHandler_ListIntegrations_DerivesSafeCredentialMetadata(t *te
 	require.NotNil(t, circleciIntegration.CircleCIProjectSlug, "CircleCI project slug should be derived from credential metadata")
 	require.Equal(t, "gh/acme/api", *circleciIntegration.CircleCIProjectSlug, "CircleCI project slug should be exposed without token data")
 	require.NotNil(t, mezmoIntegration, "Mezmo integration should be present in response")
-	require.NotNil(t, mezmoIntegration.MezmoDataset, "Mezmo dataset should be derived from credential metadata")
-	require.Equal(t, "prod", *mezmoIntegration.MezmoDataset, "Mezmo dataset should be exposed without key data")
+	require.Nil(t, mezmoIntegration.MezmoDataset, "Mezmo dataset should not be exposed because dataset scoping is unsupported")
 	require.NotNil(t, mezmoIntegration.MezmoBaseURL, "Mezmo base URL should be derived from credential metadata")
 	require.Equal(t, "https://logs.acme.com", *mezmoIntegration.MezmoBaseURL, "Mezmo base URL should be exposed without key data")
 	require.NotContains(t, w.Body.String(), "secret-notion-token", "response should not expose Notion token")
@@ -3392,8 +3391,12 @@ func TestIntegrationHandler_ConnectMezmo_Success(t *testing.T) {
 	credentialStore := db.NewOrgCredentialStore(mock, nil)
 
 	transport := roundTripFunc(func(req *http.Request) (*http.Response, error) {
-		require.Equal(t, "https://api.mezmo.com/v1/logs/search", req.URL.String())
-		require.Equal(t, "mezmo_key", req.Header.Get("servicekey"))
+		require.Equal(t, http.MethodGet, req.Method, "validation should use the documented Mezmo export method")
+		require.Equal(t, "https", req.URL.Scheme, "validation should use the default Mezmo API scheme")
+		require.Equal(t, "api.mezmo.com", req.URL.Host, "validation should use the default Mezmo API host")
+		require.Equal(t, "/v2/export", req.URL.Path, "validation should use the documented Mezmo export path")
+		require.Equal(t, "Token mezmo_key", req.Header.Get("Authorization"), "validation should send the documented Mezmo access-token auth header")
+		require.Equal(t, "1", req.URL.Query().Get("size"), "validation should request a minimal export")
 
 		return &http.Response{
 			StatusCode: http.StatusOK,
@@ -3419,7 +3422,7 @@ func TestIntegrationHandler_ConnectMezmo_Success(t *testing.T) {
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
 		WillReturnRows(pgxmock.NewRows([]string{"id", "created_at"}).AddRow(integrationID, now))
 
-	body := `{"api_key":"mezmo_key","dataset":"prod"}`
+	body := `{"api_key":"mezmo_key"}`
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/integrations/mezmo/connect", bytes.NewBufferString(body))
 	req.Header.Set("Content-Type", "application/json")
 	req = req.WithContext(middleware.WithOrgID(req.Context(), orgID))
@@ -3491,7 +3494,7 @@ func TestIntegrationHandler_ConnectMezmo_HonorsCustomBaseURL(t *testing.T) {
 	credentialStore := db.NewOrgCredentialStore(mock, nil)
 
 	transport := roundTripFunc(func(req *http.Request) (*http.Response, error) {
-		require.Equal(t, "https://logs.example.com/v1/logs/search", req.URL.String(),
+		require.Equal(t, "https://logs.example.com/v2/export", req.URL.Scheme+"://"+req.URL.Host+req.URL.Path,
 			"validation should target the operator-supplied base URL")
 		return &http.Response{
 			StatusCode: http.StatusOK,
@@ -3578,9 +3581,65 @@ func TestIntegrationHandler_ConnectMezmo_InvalidJSON(t *testing.T) {
 	require.Contains(t, w.Body.String(), "INVALID_JSON")
 }
 
-// A 4xx that isn't an auth rejection (e.g. an unknown dataset or a query-shape
-// quirk) means the key was accepted, so connect should still succeed — we
-// validate the key, not the probe query.
+func TestIntegrationHandler_ConnectMezmo_RejectsDataset(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "test should create pgx mock")
+	defer mock.Close()
+
+	store := db.NewIntegrationStore(mock)
+	handler := NewIntegrationHandler(store, nil, "", "", "http://localhost:8080", "http://localhost:3000")
+
+	body := `{"api_key":"mezmo_key","dataset":"production"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/integrations/mezmo/connect", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	req = req.WithContext(middleware.WithOrgID(req.Context(), uuid.New()))
+	w := httptest.NewRecorder()
+
+	handler.ConnectMezmo(w, req)
+
+	require.Equal(t, http.StatusBadRequest, w.Code, "ConnectMezmo should reject unsupported dataset scopes")
+	require.Contains(t, w.Body.String(), "UNSUPPORTED_DATASET", "response should identify unsupported dataset scope")
+}
+
+func TestIntegrationHandler_ConnectMezmo_RejectsNotFound(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "test should create pgx mock")
+	defer mock.Close()
+
+	store := db.NewIntegrationStore(mock)
+
+	transport := roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		require.Equal(t, "/v2/export", req.URL.Path, "validation should probe the documented Mezmo export endpoint")
+		return &http.Response{
+			StatusCode: http.StatusNotFound,
+			Header:     make(http.Header),
+			Body:       io.NopCloser(bytes.NewBufferString(`{"error":"No Resource Found"}`)),
+		}, nil
+	})
+
+	handler := NewIntegrationHandler(store, nil, "", "", "http://localhost:8080", "http://localhost:3000")
+	handler.client = &http.Client{Transport: transport}
+
+	body := `{"api_key":"mezmo_key"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/integrations/mezmo/connect", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	req = req.WithContext(middleware.WithOrgID(req.Context(), uuid.New()))
+	w := httptest.NewRecorder()
+
+	handler.ConnectMezmo(w, req)
+
+	require.Equal(t, http.StatusBadRequest, w.Code, "missing Mezmo endpoint should reject the connection")
+	require.Contains(t, w.Body.String(), "INVALID_TOKEN", "response should identify validation failure")
+	require.Contains(t, w.Body.String(), "mezmo API endpoint not found", "response should explain that the endpoint probe failed")
+}
+
+// A 4xx that isn't an auth rejection (e.g. a query-shape quirk) means the key
+// was accepted, so connect should still succeed — we validate the key, not the
+// probe query.
 func TestIntegrationHandler_ConnectMezmo_AcceptsNonAuth4xx(t *testing.T) {
 	t.Parallel()
 
@@ -3616,7 +3675,7 @@ func TestIntegrationHandler_ConnectMezmo_AcceptsNonAuth4xx(t *testing.T) {
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
 		WillReturnRows(pgxmock.NewRows([]string{"id", "created_at"}).AddRow(integrationID, now))
 
-	body := `{"api_key":"mezmo_key","dataset":"does-not-exist"}`
+	body := `{"api_key":"mezmo_key"}`
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/integrations/mezmo/connect", bytes.NewBufferString(body))
 	req.Header.Set("Content-Type", "application/json")
 	req = req.WithContext(middleware.WithOrgID(req.Context(), orgID))

--- a/internal/models/credentials.go
+++ b/internal/models/credentials.go
@@ -290,9 +290,10 @@ type CircleCIConfig struct {
 }
 
 // MezmoConfig stores a Mezmo service key plus optional base URL (for
-// self-hosted/enterprise endpoints, defaults to https://api.mezmo.com) and an
-// optional dataset used to scope log queries. This is the persisted credential
-// shape; the runtime provider config lives in
+// self-hosted/enterprise endpoints, defaults to https://api.mezmo.com). Dataset
+// is retained only to parse older saved credentials; new connections reject it
+// because Mezmo's documented v2 export API does not support dataset scoping.
+// This is the persisted credential shape; the runtime provider config lives in
 // internal/services/integration.MezmoConfig, mirroring the CircleCI split.
 type MezmoConfig struct {
 	APIKey  string `json:"api_key"` // #nosec G117 -- JSON config field

--- a/internal/services/integration/log_http.go
+++ b/internal/services/integration/log_http.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -302,6 +303,8 @@ type MezmoProvider struct {
 	client *http.Client
 }
 
+const mezmoExportPath = "/v2/export"
+
 func NewMezmoProvider(cfg MezmoConfig) *MezmoProvider {
 	client := cfg.HTTPClient
 	if client == nil {
@@ -324,23 +327,17 @@ func (p *MezmoProvider) QueryLogs(ctx context.Context, req LogQueryRequest) (*Lo
 	if p.cfg.APIKey == "" {
 		return nil, ErrLogProviderUnconfigured
 	}
+	if strings.TrimSpace(p.cfg.Dataset) != "" {
+		return nil, fmt.Errorf("mezmo dataset scoping is not supported by /v2/export; reconnect Mezmo without a dataset")
+	}
 	limit := intValue(req.Limit, LogDefaultLimit)
-	body := map[string]any{
-		"query":      req.Query,
-		"start_time": start.Format(time.RFC3339Nano),
-		"end_time":   end.Format(time.RFC3339Nano),
-		"limit":      limit + 1,
-	}
-	if p.cfg.Dataset != "" {
-		body["dataset"] = p.cfg.Dataset
-	}
-	records, err := p.post(ctx, "/v1/logs/search", body)
-	if err != nil {
-		return nil, err
-	}
 	direction := LogDirectionDesc
 	if req.Direction != nil {
 		direction = *req.Direction
+	}
+	records, err := p.get(ctx, mezmoExportPath, mezmoExportValues(req.Query, start, end, limit+1, direction))
+	if err != nil {
+		return nil, err
 	}
 	entries := normalizeLogRecords(models.ProviderMezmo, records, req.Fields, req.IncludeRaw)
 	sortLogEntries(entries, direction)
@@ -380,18 +377,38 @@ func (p *MezmoProvider) QueryLogStats(context.Context, LogStatsRequest) (*LogSta
 	return nil, ErrLogStatsUnsupported
 }
 
-func (p *MezmoProvider) post(ctx context.Context, path string, body map[string]any) ([]map[string]any, error) {
-	data, err := json.Marshal(body)
-	if err != nil {
-		return nil, err
+func mezmoExportValues(query string, start, end time.Time, size int, direction LogDirection) url.Values {
+	values := url.Values{}
+	values.Set("from", strconv.FormatInt(start.Unix(), 10))
+	values.Set("to", strconv.FormatInt(end.Unix(), 10))
+	values.Set("size", strconv.Itoa(size))
+	values.Set("query", query)
+	if direction == LogDirectionAsc {
+		values.Set("prefer", "head")
+	} else {
+		values.Set("prefer", "tail")
 	}
+	return values
+}
+
+func (p *MezmoProvider) get(ctx context.Context, path string, values url.Values) ([]map[string]any, error) {
+	records, err := p.getWithAuth(ctx, path, values, "Authorization", "Token "+p.cfg.APIKey)
+	if errors.Is(err, ErrLogProviderUnauthorized) {
+		return p.getWithAuth(ctx, path, values, "servicekey", p.cfg.APIKey)
+	}
+	return records, err
+}
+
+func (p *MezmoProvider) getWithAuth(ctx context.Context, path string, values url.Values, authHeader, authValue string) ([]map[string]any, error) {
 	endpoint := strings.TrimRight(p.cfg.BaseURL, "/") + path
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(data))
+	if encoded := values.Encode(); encoded != "" {
+		endpoint += "?" + encoded
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
 	if err != nil {
 		return nil, err
 	}
-	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("servicekey", p.cfg.APIKey)
+	req.Header.Set(authHeader, authValue)
 	return doLogHTTPRequest(p.client, req)
 }
 

--- a/internal/services/integration/log_test.go
+++ b/internal/services/integration/log_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -489,7 +490,7 @@ func TestMezmoProviderNormalizesLogEntries(t *testing.T) {
 	t.Parallel()
 
 	// Mezmo returns results under a "lines" key.
-	mezmoBody, _ := json.Marshal(map[string]any{
+	mezmoBody, err := json.Marshal(map[string]any{
 		"lines": []map[string]any{
 			{
 				"timestamp": "2026-05-28T12:00:00Z",
@@ -499,10 +500,12 @@ func TestMezmoProviderNormalizesLogEntries(t *testing.T) {
 			},
 		},
 	})
+	require.NoError(t, err, "test should build a valid Mezmo response")
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write(mezmoBody)
+		_, writeErr := w.Write(mezmoBody)
+		require.NoError(t, writeErr, "test server should write Mezmo response")
 	}))
 	defer server.Close()
 
@@ -516,12 +519,89 @@ func TestMezmoProviderNormalizesLogEntries(t *testing.T) {
 		Query: "level:error",
 		Since: durationPtr(time.Hour),
 	})
-	require.NoError(t, err)
+	require.NoError(t, err, "QueryLogs should accept a Mezmo lines response")
 	require.Len(t, result.Entries, 1, "should return one normalized entry")
-	require.Equal(t, "connection refused", result.Entries[0].Message)
-	require.Equal(t, "error", result.Entries[0].Level)
-	require.Equal(t, "api", result.Entries[0].Service)
-	require.Equal(t, models.ProviderMezmo, result.Entries[0].Provider)
+	require.Equal(t, "connection refused", result.Entries[0].Message, "entry message should be normalized from Mezmo payload")
+	require.Equal(t, "error", result.Entries[0].Level, "entry level should be normalized from Mezmo payload")
+	require.Equal(t, "api", result.Entries[0].Service, "entry service should be normalized from Mezmo payload")
+	require.Equal(t, models.ProviderMezmo, result.Entries[0].Provider, "entry provider should identify Mezmo")
+}
+
+func TestMezmoProviderUsesExportAPI(t *testing.T) {
+	t.Parallel()
+
+	start := time.Date(2026, 6, 10, 4, 0, 0, 0, time.UTC)
+	end := time.Date(2026, 6, 10, 5, 0, 0, 0, time.UTC)
+	limit := 2
+	direction := LogDirectionAsc
+
+	mezmoBody, err := json.Marshal(map[string]any{
+		"lines": []map[string]any{
+			{
+				"timestamp": start.Add(time.Minute).Format(time.RFC3339),
+				"message":   "first match",
+			},
+		},
+	})
+	require.NoError(t, err, "test should build a valid Mezmo response")
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodGet, r.Method, "Mezmo log queries should use the documented export method")
+		require.Equal(t, "/v2/export", r.URL.Path, "Mezmo log queries should use the documented v2 export path")
+		require.Equal(t, "Token test-key", r.Header.Get("Authorization"), "Mezmo log queries should send the documented access-token auth header")
+
+		query := r.URL.Query()
+		require.Equal(t, strconv.FormatInt(start.Unix(), 10), query.Get("from"), "Mezmo export should receive the lower time bound as a unix timestamp")
+		require.Equal(t, strconv.FormatInt(end.Unix(), 10), query.Get("to"), "Mezmo export should receive the upper time bound as a unix timestamp")
+		require.Equal(t, "3", query.Get("size"), "Mezmo export should request one extra record for truncation detection")
+		require.Equal(t, "head", query.Get("prefer"), "ascending queries should ask Mezmo for the first matching lines")
+		require.Equal(t, "service:api", query.Get("query"), "Mezmo export should receive the provider-native query")
+
+		w.Header().Set("Content-Type", "application/json")
+		_, writeErr := w.Write(mezmoBody)
+		require.NoError(t, writeErr, "test server should write Mezmo response")
+	}))
+	defer server.Close()
+
+	provider := NewMezmoProvider(MezmoConfig{
+		APIKey:     "test-key",
+		BaseURL:    server.URL,
+		HTTPClient: server.Client(),
+	})
+
+	result, err := provider.QueryLogs(context.Background(), LogQueryRequest{
+		Query:     "service:api",
+		StartTime: &start,
+		EndTime:   &end,
+		Limit:     &limit,
+		Direction: &direction,
+	})
+	require.NoError(t, err, "QueryLogs should query Mezmo export successfully")
+	require.Len(t, result.Entries, 1, "QueryLogs should return the exported line")
+	require.Equal(t, "first match", result.Entries[0].Message, "QueryLogs should normalize the exported line")
+}
+
+func TestMezmoProviderRejectsDatasetScope(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Fail(t, "Mezmo provider should reject dataset scopes before sending a request")
+	}))
+	defer server.Close()
+
+	provider := NewMezmoProvider(MezmoConfig{
+		APIKey:     "test-key",
+		BaseURL:    server.URL,
+		Dataset:    "production",
+		HTTPClient: server.Client(),
+	})
+
+	_, err := provider.QueryLogs(context.Background(), LogQueryRequest{
+		Query: "service:api",
+		Since: durationPtr(time.Hour),
+	})
+	require.Error(t, err, "QueryLogs should reject unsupported Mezmo dataset scopes")
+	require.Contains(t, err.Error(), "dataset scoping is not supported", "error should explain that Mezmo dataset scoping is unsupported")
 }
 
 func TestVictoriaLogsListFieldsNative(t *testing.T) {


### PR DESCRIPTION
## Summary
- Remove Mezmo dataset scoping from the connect flow and integration metadata so the UI no longer advertises an unsupported option.
- Reject dataset values on Mezmo connect and runtime queries with an explicit error instead of silently broadening to the default export scope.
- Update Mezmo log querying to use the documented `GET /v2/export` endpoint and keep legacy auth fallback behavior.

## Testing
- Added unit coverage for Mezmo export request construction, dataset rejection, and connection validation.
- Added frontend test coverage to verify the Mezmo connect dialog no longer shows dataset controls.
- Verified `go vet`, `go build`, `go test`, `npm run typecheck`, `npm run lint`, and `npm run build` pass.