### PR TITLE
Add structured preview proxy failure logging

### DIFF
--- a/internal/api/gateway/preview_gateway.go
+++ b/internal/api/gateway/preview_gateway.go
@@ -624,15 +624,19 @@ func acceptsHTMLDocument(accept string) bool {
 }
 
 func (g *Gateway) proxyToWorker(w http.ResponseWriter, r *http.Request, orgID, previewID uuid.UUID) {
+	originalReq := r
 	runtime, err := g.store.GetActivePreviewRuntime(r.Context(), orgID, previewID)
 	if err != nil {
-		g.logger.Warn().Err(err).Str("preview_id", previewID.String()).Msg("failed to resolve active preview runtime")
+		addPreviewProxyLogFields(g.logger.Warn().Err(err), r, orgID, previewID, nil, "").
+			Msg("failed to resolve active preview runtime")
 		writeRuntimeUnavailable(w)
 		return
 	}
+	upstreamPath := previewWorkerProxyPath(previewID, r.URL.Path)
 	targetURL, err := url.Parse(runtime.EndpointURL)
 	if err != nil || targetURL.Scheme == "" || targetURL.Host == "" || (targetURL.Scheme != "http" && targetURL.Scheme != "https") {
-		g.logger.Warn().Err(err).Str("preview_id", previewID.String()).Str("endpoint_url", runtime.EndpointURL).Msg("failed to parse preview runtime endpoint url")
+		addPreviewProxyLogFields(g.logger.Warn().Err(err), r, orgID, previewID, runtime, upstreamPath).
+			Msg("failed to parse preview runtime endpoint url")
 		writeRuntimeUnavailable(w)
 		return
 	}
@@ -646,7 +650,8 @@ func (g *Gateway) proxyToWorker(w http.ResponseWriter, r *http.Request, orgID, p
 		ExpiresAt:    time.Now().Add(30 * time.Second),
 	})
 	if err != nil {
-		g.logger.Warn().Err(err).Str("preview_id", previewID.String()).Msg("failed to sign preview worker token")
+		addPreviewProxyLogFields(g.logger.Warn().Err(err), r, orgID, previewID, runtime, upstreamPath).
+			Msg("failed to sign preview worker token")
 		http.Error(w, "preview unavailable", http.StatusBadGateway)
 		return
 	}
@@ -655,7 +660,7 @@ func (g *Gateway) proxyToWorker(w http.ResponseWriter, r *http.Request, orgID, p
 		Director: func(req *http.Request) {
 			req.URL.Scheme = targetURL.Scheme
 			req.URL.Host = targetURL.Host
-			req.URL.Path = fmt.Sprintf("/internal/preview/%s/proxy%s", previewID.String(), req.URL.Path)
+			req.URL.Path = upstreamPath
 			req.Host = targetURL.Host
 			req.RequestURI = ""
 			stripPreviewCookie(req)
@@ -684,12 +689,60 @@ func (g *Gateway) proxyToWorker(w http.ResponseWriter, r *http.Request, orgID, p
 
 			return nil
 		},
-		ErrorHandler: func(w http.ResponseWriter, r *http.Request, err error) {
-			g.logger.Warn().Err(err).Str("preview_id", previewID.String()).Msg("proxy error")
+		ErrorHandler: func(w http.ResponseWriter, _ *http.Request, err error) {
+			addPreviewProxyLogFields(g.logger.Warn().Err(err), originalReq, orgID, previewID, runtime, upstreamPath).
+				Msg("proxy error")
 			http.Error(w, "preview unavailable", http.StatusBadGateway)
 		},
 	}
 	proxy.ServeHTTP(w, r)
+}
+
+func previewWorkerProxyPath(previewID uuid.UUID, requestPath string) string {
+	return fmt.Sprintf("/internal/preview/%s/proxy%s", previewID.String(), requestPath)
+}
+
+func addPreviewProxyLogFields(event *zerolog.Event, r *http.Request, orgID, previewID uuid.UUID, runtime *models.PreviewRuntime, upstreamPath string) *zerolog.Event {
+	requestPath := ""
+	requestHost := ""
+	requestMethod := ""
+	queryPresent := false
+	secFetchDest := ""
+	if r != nil {
+		requestHost = r.Host
+		requestMethod = r.Method
+		secFetchDest = r.Header.Get("Sec-Fetch-Dest")
+		if r.URL != nil {
+			requestPath = r.URL.Path
+			queryPresent = r.URL.RawQuery != ""
+		}
+	}
+
+	event = event.
+		Str("org_id", orgID.String()).
+		Str("preview_id", previewID.String()).
+		Str("request_method", requestMethod).
+		Str("request_host", requestHost).
+		Str("request_path", requestPath).
+		Bool("query_present", queryPresent).
+		Str("sec_fetch_dest", secFetchDest).
+		Str("upstream_path", upstreamPath)
+
+	if runtime == nil {
+		return event
+	}
+
+	return event.
+		Str("runtime_id", runtime.ID.String()).
+		Int("runtime_epoch", runtime.RuntimeEpoch).
+		Str("runtime_status", string(runtime.Status)).
+		Str("worker_node_id", runtime.WorkerNodeID).
+		Str("endpoint_url", runtime.EndpointURL).
+		Str("preview_handle", runtime.PreviewHandle).
+		Int("primary_port", runtime.PrimaryPort).
+		Time("runtime_lease_expires_at", runtime.LeaseExpiresAt).
+		Time("runtime_last_heartbeat_at", runtime.LastHeartbeatAt).
+		Str("runtime_unavailable_reason", string(runtime.UnavailableReason))
 }
 
 func translateWorkerRuntimeMismatch(resp *http.Response) bool {

--- a/internal/api/gateway/preview_gateway_test.go
+++ b/internal/api/gateway/preview_gateway_test.go
@@ -6,6 +6,7 @@ import (
 	"compress/gzip"
 	"encoding/json"
 	"io"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -1075,6 +1076,83 @@ func TestGateway_ProxyToWorker_RoutesByRuntimeEndpoint(t *testing.T) {
 	gw.proxyToWorker(rr, req, orgID, previewID)
 	require.Equal(t, http.StatusOK, rr.Code, "proxyToWorker should relay successful worker responses")
 	require.Equal(t, "ok", rr.Body.String(), "proxyToWorker should relay the worker response body")
+	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
+}
+
+func TestGateway_ProxyToWorker_LogsRequestAndRuntimeOnProxyError(t *testing.T) {
+	t.Parallel()
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err, "test listener should bind a local port")
+	defer listener.Close()
+
+	accepted := make(chan struct{})
+	go func() {
+		conn, acceptErr := listener.Accept()
+		if acceptErr == nil {
+			_ = conn.Close()
+		}
+		close(accepted)
+	}()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "pgxmock pool should be created")
+	defer mock.Close()
+
+	orgID := uuid.New()
+	previewID := uuid.New()
+	runtimeID := uuid.New()
+	now := time.Now().UTC()
+	endpointURL := "http://" + listener.Addr().String()
+	var logs bytes.Buffer
+	store := db.NewPreviewStore(mock)
+	gw := NewGateway(GatewayConfig{
+		Store:              store,
+		WorkerSelector:     preview.NewWorkerSelector(db.NewNodeStore(mock), store),
+		Logger:             zerolog.New(&logs),
+		AppOrigin:          "https://app.143.dev",
+		PreviewTokenSecret: "preview-secret",
+	})
+
+	mock.ExpectQuery("SELECT .+ FROM preview_runtimes").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(pgxmock.NewRows([]string{
+			"id", "org_id", "preview_instance_id", "runtime_epoch", "worker_node_id",
+			"endpoint_url", "preview_handle", "primary_port", "status", "lease_expires_at",
+			"last_heartbeat_at", "drain_requested_at", "stopped_at", "error", "unavailable_reason", "created_at", "updated_at",
+		}).AddRow(
+			runtimeID, orgID, previewID, 7, "worker-runtime",
+			endpointURL, "handle-1", 8080, string(models.PreviewRuntimeStatusReady), now.Add(time.Minute),
+			now, nil, nil, "", "", now, now,
+		))
+
+	req := httptest.NewRequest(http.MethodGet, "/static/js/ApplicationRoutes.chunk.js?cache=miss", nil)
+	req.Host = previewID.String() + ".preview.143.dev"
+	req.Header.Set("Sec-Fetch-Dest", "script")
+	rr := httptest.NewRecorder()
+
+	gw.proxyToWorker(rr, req, orgID, previewID)
+	<-accepted
+
+	require.Equal(t, http.StatusBadGateway, rr.Code, "proxyToWorker should return a bad gateway when the worker connection drops")
+	require.NotEmpty(t, logs.String(), "proxy error should emit a structured log")
+
+	var event map[string]any
+	require.NoError(t, json.Unmarshal(bytes.TrimSpace(logs.Bytes()), &event), "proxy error log should be valid JSON")
+	require.Equal(t, "proxy error", event["message"], "proxy error log should keep the event message")
+	require.Equal(t, previewID.String(), event["preview_id"], "proxy error log should include preview id")
+	require.Equal(t, orgID.String(), event["org_id"], "proxy error log should include org id")
+	require.Equal(t, http.MethodGet, event["request_method"], "proxy error log should include request method")
+	require.Equal(t, "/static/js/ApplicationRoutes.chunk.js", event["request_path"], "proxy error log should include request path without query string")
+	require.Equal(t, true, event["query_present"], "proxy error log should record whether a query string was present without logging it")
+	require.Equal(t, "script", event["sec_fetch_dest"], "proxy error log should include fetch destination for asset classification")
+	require.Equal(t, runtimeID.String(), event["runtime_id"], "proxy error log should include runtime id")
+	require.Equal(t, float64(7), event["runtime_epoch"], "proxy error log should include runtime epoch")
+	require.Equal(t, "worker-runtime", event["worker_node_id"], "proxy error log should include worker node id")
+	require.Equal(t, endpointURL, event["endpoint_url"], "proxy error log should include worker endpoint url")
+	require.Equal(t, "handle-1", event["preview_handle"], "proxy error log should include provider preview handle")
+	require.Equal(t, float64(8080), event["primary_port"], "proxy error log should include primary port")
+	require.Equal(t, "/internal/preview/"+previewID.String()+"/proxy/static/js/ApplicationRoutes.chunk.js", event["upstream_path"], "proxy error log should include rewritten upstream path")
 	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
 }
 

--- a/internal/api/handlers/internal_preview.go
+++ b/internal/api/handlers/internal_preview.go
@@ -449,21 +449,23 @@ func (h *InternalPreviewHandler) Proxy(w http.ResponseWriter, r *http.Request) {
 	orgID := middleware.OrgIDFromContext(r.Context())
 
 	if isWebSocketUpgrade(r) {
-		h.handleWebSocketProxy(w, r, orgID, previewID)
+		h.handleWebSocketProxy(w, r, orgID, previewID, claims)
 		return
 	}
-	h.handleHTTPProxy(w, r, orgID, previewID)
+	h.handleHTTPProxy(w, r, orgID, previewID, claims)
 }
 
-func (h *InternalPreviewHandler) handleHTTPProxy(w http.ResponseWriter, r *http.Request, orgID, previewID uuid.UUID) {
+func (h *InternalPreviewHandler) handleHTTPProxy(w http.ResponseWriter, r *http.Request, orgID, previewID uuid.UUID, claims *auth.PreviewTokenClaims) {
+	originalReq := r
+	backendPath := trimInternalPreviewProxyPath(r.URL.Path, previewID)
+	if backendPath == "" {
+		backendPath = "/"
+	}
 	proxy := &httputil.ReverseProxy{
 		Director: func(req *http.Request) {
 			req.URL.Scheme = "http"
 			req.URL.Host = "preview-target"
-			req.URL.Path = trimInternalPreviewProxyPath(req.URL.Path, previewID)
-			if req.URL.Path == "" {
-				req.URL.Path = "/"
-			}
+			req.URL.Path = backendPath
 			req.RequestURI = ""
 			req.Host = "preview-target"
 			req.Header.Del("Authorization")
@@ -475,17 +477,23 @@ func (h *InternalPreviewHandler) handleHTTPProxy(w http.ResponseWriter, r *http.
 			previewID: previewID,
 		},
 		ErrorHandler: func(w http.ResponseWriter, r *http.Request, err error) {
-			h.logger.Warn().Err(err).Str("preview_id", previewID.String()).Msg("internal preview proxy error")
+			addInternalPreviewProxyLogFields(h.logger.Warn().Err(err), originalReq, orgID, previewID, claims, backendPath).
+				Msg("internal preview proxy error")
 			http.Error(w, "preview unavailable", http.StatusBadGateway)
 		},
 	}
 	proxy.ServeHTTP(w, r)
 }
 
-func (h *InternalPreviewHandler) handleWebSocketProxy(w http.ResponseWriter, r *http.Request, orgID, previewID uuid.UUID) {
+func (h *InternalPreviewHandler) handleWebSocketProxy(w http.ResponseWriter, r *http.Request, orgID, previewID uuid.UUID, claims *auth.PreviewTokenClaims) {
+	backendPath := trimInternalPreviewProxyPath(r.URL.Path, previewID)
+	if backendPath == "" {
+		backendPath = "/"
+	}
 	backendConn, err := h.manager.DialPreview(r.Context(), orgID, previewID)
 	if err != nil {
-		h.logger.Warn().Err(err).Str("preview_id", previewID.String()).Msg("internal websocket dial failed")
+		addInternalPreviewProxyLogFields(h.logger.Warn().Err(err), r, orgID, previewID, claims, backendPath).
+			Msg("internal websocket dial failed")
 		http.Error(w, "preview unavailable", http.StatusBadGateway)
 		return
 	}
@@ -505,7 +513,8 @@ func (h *InternalPreviewHandler) handleWebSocketProxy(w http.ResponseWriter, r *
 
 	backendReq := cloneWebSocketRequestForInternalProxy(r, previewID)
 	if err := backendReq.Write(backendConn); err != nil {
-		h.logger.Warn().Err(err).Msg("internal websocket: failed to forward upgrade request")
+		addInternalPreviewProxyLogFields(h.logger.Warn().Err(err), r, orgID, previewID, claims, backendPath).
+			Msg("internal websocket: failed to forward upgrade request")
 		return
 	}
 	if clientBuf.Reader.Buffered() > 0 {
@@ -527,6 +536,45 @@ func (h *InternalPreviewHandler) handleWebSocketProxy(w http.ResponseWriter, r *
 		h.logger.Debug().Err(err).Str("preview_id", previewID.String()).Msg("internal websocket client->backend copy ended")
 	}
 	<-done
+}
+
+func addInternalPreviewProxyLogFields(event *zerolog.Event, r *http.Request, orgID, previewID uuid.UUID, claims *auth.PreviewTokenClaims, backendPath string) *zerolog.Event {
+	requestPath := ""
+	requestHost := ""
+	requestMethod := ""
+	queryPresent := false
+	secFetchDest := ""
+	if r != nil {
+		requestHost = r.Host
+		requestMethod = r.Method
+		secFetchDest = r.Header.Get("Sec-Fetch-Dest")
+		if r.URL != nil {
+			requestPath = r.URL.Path
+			queryPresent = r.URL.RawQuery != ""
+		}
+	}
+
+	event = event.
+		Str("org_id", orgID.String()).
+		Str("preview_id", previewID.String()).
+		Str("request_method", requestMethod).
+		Str("request_host", requestHost).
+		Str("request_path", requestPath).
+		Bool("query_present", queryPresent).
+		Str("sec_fetch_dest", secFetchDest).
+		Str("backend_path", backendPath)
+
+	if claims == nil {
+		return event
+	}
+
+	event = event.
+		Str("target_node_id", claims.TargetNodeID).
+		Int("runtime_epoch", claims.RuntimeEpoch)
+	if claims.RuntimeID != nil {
+		event = event.Str("runtime_id", claims.RuntimeID.String())
+	}
+	return event
 }
 
 type internalPreviewTransport struct {

--- a/internal/api/handlers/internal_preview_test.go
+++ b/internal/api/handlers/internal_preview_test.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"bufio"
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -747,6 +748,78 @@ func TestInternalPreviewHandler_ProxyHTTP_Success(t *testing.T) {
 	handler.Proxy(rr, req)
 	require.Equal(t, http.StatusOK, rr.Code, "Proxy should relay successful HTTP responses from the preview backend")
 	require.Equal(t, "ok", rr.Body.String(), "Proxy should relay the preview backend response body")
+	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
+}
+
+func TestInternalPreviewHandler_ProxyHTTP_LogsRequestAndRuntimeOnProxyError(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "pgxmock pool should be created")
+	defer mock.Close()
+
+	orgID := uuid.New()
+	sessionID := uuid.New()
+	userID := uuid.New()
+	previewID := uuid.New()
+	runtimeID := uuid.New()
+	now := time.Now().UTC()
+
+	clientConn, serverConn := net.Pipe()
+	defer clientConn.Close()
+
+	requestRead := make(chan struct{})
+	go func() {
+		defer serverConn.Close()
+		_, _ = http.ReadRequest(bufio.NewReader(serverConn))
+		close(requestRead)
+	}()
+
+	store := db.NewPreviewStore(mock)
+	manager := previewsvc.NewManager(previewsvc.ManagerConfig{
+		Store:        store,
+		Provider:     internalPreviewTestProvider{dialFn: func(context.Context, string) (previewsvc.PreviewStream, error) { return clientConn, nil }},
+		Logger:       zerolog.Nop(),
+		WorkerNodeID: "worker-1",
+	})
+	var logs bytes.Buffer
+	handler := NewInternalPreviewHandler(&PreviewHandler{logger: zerolog.Nop()}, manager, "worker-1", "worker-secret", zerolog.New(&logs))
+
+	mock.ExpectQuery("SELECT .+ FROM preview_instances WHERE id").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(
+			pgxmock.NewRows(previewInstanceTestCols).
+				AddRow(newActivePreviewRow(previewID, sessionID, orgID, userID, now)...),
+		)
+
+	req := httptest.NewRequest(http.MethodGet, "/internal/preview/"+previewID.String()+"/proxy/static/js/ApplicationRoutes.chunk.js?cache=miss", nil)
+	req = withPreviewRouteParam(req, previewID.String())
+	req.Host = "100.124.235.85:8080"
+	req.Header.Set("Sec-Fetch-Dest", "script")
+	req.Header.Set("Authorization", internalPreviewAuthHeader(t, auth.PreviewTokenClaims{
+		OrgID: orgID, PreviewID: &previewID, TargetNodeID: "worker-1", RuntimeID: &runtimeID, RuntimeEpoch: 3, Action: "proxy", ExpiresAt: time.Now().Add(time.Minute),
+	}))
+	rr := httptest.NewRecorder()
+
+	handler.Proxy(rr, req)
+	<-requestRead
+
+	require.Equal(t, http.StatusBadGateway, rr.Code, "Proxy should return a bad gateway when the preview backend drops the connection")
+	require.NotEmpty(t, logs.String(), "internal proxy error should emit a structured log")
+
+	var event map[string]any
+	require.NoError(t, json.Unmarshal(bytes.TrimSpace(logs.Bytes()), &event), "internal proxy error log should be valid JSON")
+	require.Equal(t, "internal preview proxy error", event["message"], "internal proxy error log should keep the event message")
+	require.Equal(t, previewID.String(), event["preview_id"], "internal proxy error log should include preview id")
+	require.Equal(t, orgID.String(), event["org_id"], "internal proxy error log should include org id")
+	require.Equal(t, http.MethodGet, event["request_method"], "internal proxy error log should include request method")
+	require.Equal(t, "/internal/preview/"+previewID.String()+"/proxy/static/js/ApplicationRoutes.chunk.js", event["request_path"], "internal proxy error log should include internal request path without query string")
+	require.Equal(t, true, event["query_present"], "internal proxy error log should record whether a query string was present without logging it")
+	require.Equal(t, "script", event["sec_fetch_dest"], "internal proxy error log should include fetch destination")
+	require.Equal(t, "/static/js/ApplicationRoutes.chunk.js", event["backend_path"], "internal proxy error log should include trimmed backend path")
+	require.Equal(t, runtimeID.String(), event["runtime_id"], "internal proxy error log should include runtime id")
+	require.Equal(t, float64(3), event["runtime_epoch"], "internal proxy error log should include runtime epoch")
+	require.Equal(t, "worker-1", event["target_node_id"], "internal proxy error log should include token target node")
 	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
 }
 


### PR DESCRIPTION
## Summary
- Adds structured logging to preview proxy failures in the app gateway and internal preview handler.
- Includes request metadata and runtime/target-node context so future chunk-load or proxy failures are easier to diagnose.
- Adds regression tests covering the new log fields on proxy error paths.

## Testing
- Unit tests added for gateway proxy error logging and internal preview proxy error logging.
- Existing targeted Go test coverage for the changed packages passed locally.