### PR TITLE
Remove duplicate “Updated at” timestamp from General Settings page

### DIFF
--- a/frontend/src/app/(dashboard)/settings/page.test.tsx
+++ b/frontend/src/app/(dashboard)/settings/page.test.tsx
@@ -138,7 +138,7 @@ describe('SettingsPage', () => {
     });
   });
 
-  it('updates the header timestamp after a successful settings save', async () => {
+  it('uses the audit activity row as the only updated timestamp', async () => {
     settingsGetMock.mockResolvedValue({
       data: {
         id: 'org-1',
@@ -148,32 +148,23 @@ describe('SettingsPage', () => {
         updated_at: '2026-05-01T12:00:00Z',
       },
     });
-    settingsUpdateMock.mockResolvedValue({
-      data: {
-        id: 'org-1',
-        name: 'Updated Org',
-        settings: {},
-        created_at: '2026-05-01T12:00:00Z',
-        updated_at: '2026-05-06T15:30:00Z',
-      },
+    auditLogsListMock.mockResolvedValue({
+      data: [{
+        id: 1,
+        org_id: 'org-1',
+        actor_type: 'system',
+        actor_id: 'system',
+        action: 'settings.updated',
+        resource_type: 'settings',
+        created_at: new Date(Date.now() - 3 * 60000).toISOString(),
+      }],
+      meta: {},
     });
 
     renderWithProviders(<SettingsPage />);
 
-    expect(await screen.findByText(/Updated at .*May 1, 2026.*12:00 PM UTC/)).toBeInTheDocument();
-
-    const input = screen.getByLabelText('Organization name');
-    const user = userEvent.setup();
-    await user.click(input);
-    await user.keyboard('{Control>}a{/Control}Updated Org');
-    await user.tab();
-
-    await waitFor(() => {
-      expect(settingsUpdateMock).toHaveBeenCalledWith({ name: 'Updated Org' });
-    });
-    await waitFor(() => {
-      expect(screen.getByText(/Updated at .*May 6, 2026.*3:30 PM UTC/)).toBeInTheDocument();
-    });
+    expect(await screen.findByText(/Updated .* ago by System/)).toBeInTheDocument();
+    expect(screen.queryByText(/Updated at .*May 1, 2026.*12:00 PM UTC/)).not.toBeInTheDocument();
   });
 
   it('uses the canonical organization returned by the server after saving settings', async () => {

--- a/frontend/src/app/(dashboard)/settings/page.tsx
+++ b/frontend/src/app/(dashboard)/settings/page.tsx
@@ -33,19 +33,6 @@ const DEFAULT_PREVIEW_MAX_PREVIEWS_PER_USER = 4;
 const MIN_PREVIEW_MAX_PREVIEWS_PER_USER = 1;
 const MAX_PREVIEW_MAX_PREVIEWS_PER_USER = 20;
 
-const settingsTimestampFormatter = new Intl.DateTimeFormat("en-US", {
-  dateStyle: "long",
-  timeStyle: "short",
-  timeZone: "UTC",
-});
-
-function formatUpdatedAt(updatedAt: string | undefined): string | undefined {
-  if (!updatedAt) return undefined;
-  const date = new Date(updatedAt);
-  if (Number.isNaN(date.getTime())) return undefined;
-  return `${settingsTimestampFormatter.format(date)} UTC`;
-}
-
 function useOrgSettingsAutosave() {
   const queryClient = useQueryClient();
   return useAutosave<SettingsPatch>({
@@ -316,10 +303,6 @@ export default function SettingsPage() {
         <PageHeader
           title="General settings"
           description="Manage your organization."
-          subtitle={(() => {
-            const formattedUpdatedAt = formatUpdatedAt(settings?.data?.updated_at);
-            return formattedUpdatedAt ? `Updated at ${formattedUpdatedAt}` : undefined;
-          })()}
         />
         <AuditLogTrigger
           filters={{ resource_type: "settings" }}


### PR DESCRIPTION
## Summary
Removed the header-level “Updated at … UTC” subtitle from the General settings page so the UI shows a single, consistent update indicator. The page now relies on the existing audit activity row (clock icon) instead, avoiding duplicate/conflicting timestamps.

## Changes
- `frontend/src/app/(dashboard)/settings/page.tsx`
  - Removed `formatUpdatedAt`/`settingsTimestampFormatter` and stopped rendering `PageHeader`’s `subtitle` based on `settings.data.updated_at`.
  - The only “last updated” display now comes from the `AuditLogTrigger`/audit activity row.
- `frontend/src/app/(dashboard)/settings/page.test.tsx`
  - Updated the focused test to assert:
    - the audit activity row shows the expected “Updated … ago by System” text
    - the header timestamp text (`Updated at …May … UTC`) is not present anymore
  - Switched the test setup from `settingsUpdateMock` timestamp assertions to `auditLogsListMock` assertions.

## Test plan
- `npm test -- --run 'src/app/(dashboard)/settings/page.test.tsx'`
- `npm run typecheck`
- `npm run lint`
- `npm run build`

[143.dev](https://143.dev) | [session 8ebaccca](https://143.dev/sessions/8ebaccca-291c-4fba-a547-4a212e87b2e6)

Preview: https://143.dev/previews/github/assembledhq/143/pull/1318