### PR TITLE
Speed up frontend CI: threads pool, affected tests on main, 12h full runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,10 @@ on:
   push:
     branches: [main]
   schedule:
-    - cron: "17 10 * * *"
+    # Twice daily: the scheduled run is the only place the full frontend
+    # suite executes with coverage, so cap the exposure window for a
+    # cross-cutting break that affected-test runs missed to ~12 hours.
+    - cron: "17 10,22 * * *"
   workflow_dispatch:
 
 concurrency:
@@ -202,6 +205,28 @@ jobs:
           git rev-parse --verify "${PR_BASE_SHA}^{commit}"
           git branch -f pr-base "${PR_BASE_SHA}"
 
+      # Main pushes run affected tests against the previous main SHA instead
+      # of the full suite: the merged PR already ran the same affected set,
+      # and the full suite (~10 min on a 2-core runner) was burning that time
+      # on every merge. The twice-daily scheduled run still executes the full
+      # suite with coverage as the backstop. github.event.before is all
+      # zeros on branch creation and unreachable after a force push, so fall
+      # back to the full suite when it can't be resolved.
+      - name: Materialize push base ref (main push only)
+        if: github.event_name == 'push'
+        working-directory: ${{ github.workspace }}
+        env:
+          PUSH_BASE_SHA: ${{ github.event.before }}
+        run: |
+          if [ "$PUSH_BASE_SHA" != "0000000000000000000000000000000000000000" ] \
+            && git rev-parse --verify --quiet "${PUSH_BASE_SHA}^{commit}"; then
+            git branch -f push-base "$PUSH_BASE_SHA"
+            echo "FRONTEND_FULL_RUN=false" >> "$GITHUB_ENV"
+          else
+            echo "push base $PUSH_BASE_SHA unavailable; running full suite"
+            echo "FRONTEND_FULL_RUN=true" >> "$GITHUB_ENV"
+          fi
+
       - run: npm ci
 
       - name: Run affected tests (PR)
@@ -209,10 +234,15 @@ jobs:
         timeout-minutes: 10
         run: npx vitest run --changed=pr-base --passWithNoTests
 
-      - name: Run full tests (main)
+      - name: Run affected tests (main)
         if: github.event_name == 'push'
         timeout-minutes: 10
-        run: npx vitest run --reporter=dot
+        run: |
+          if [ "$FRONTEND_FULL_RUN" = "true" ]; then
+            npx vitest run --reporter=dot
+          else
+            npx vitest run --changed=push-base --passWithNoTests --reporter=dot
+          fi
 
       - name: Run full tests with coverage (scheduled/manual)
         if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'

--- a/frontend/src/app/(dashboard)/settings/account/page.test.tsx
+++ b/frontend/src/app/(dashboard)/settings/account/page.test.tsx
@@ -190,7 +190,17 @@ describe("Account settings page", () => {
     expect(screen.getByPlaceholderText("pi_...")).toBeInTheDocument();
   });
 
-  it("posts new personal auths against the unified API with scope=personal", async () => {
+  // This test drives the full add-auth flow through the Radix dialog (open →
+  // pick agent → pick auth type → fill label + api key → submit), the
+  // heaviest interaction sequence in the file. It runs in ~1.5s on an idle
+  // machine but scales with CPU contention: under the threads pool several
+  // files share the 2-core CI runner, and the default 5s budget is tight for
+  // this many sequential Radix interactions when they collide. The 12s budget
+  // matches the comparably-heavy flow in page-pr-creation.test.tsx. (Trimming
+  // user-event's per-keystroke delay / pointer-events check was measured and
+  // made no difference — the cost is dialog rendering and async waits, not
+  // typing — so the budget is the fix.)
+  it("posts new personal auths against the unified API with scope=personal", { timeout: 12_000 }, async () => {
     const user = userEvent.setup();
     let createBody: Record<string, unknown> | null = null;
     server.use(

--- a/frontend/src/ci-guardrails.test.ts
+++ b/frontend/src/ci-guardrails.test.ts
@@ -52,8 +52,8 @@ describe("frontend CI guardrails", () => {
     const affectedTestsStep = frontendTestJob.match(
       /      - name: Run affected tests \(PR\)\n[\s\S]*?(?=\n      - name:|\n  [a-z0-9-]+:|\n$)/
     )?.[0];
-    const fullMainStep = frontendTestJob.match(
-      /      - name: Run full tests \(main\)\n[\s\S]*?(?=\n      - name:|\n  [a-z0-9-]+:|\n$)/
+    const mainTestsStep = frontendTestJob.match(
+      /      - name: Run affected tests \(main\)\n[\s\S]*?(?=\n      - name:|\n  [a-z0-9-]+:|\n$)/
     )?.[0];
     const fullCoverageStep = frontendTestJob.match(
       /      - name: Run full tests with coverage \(scheduled\/manual\)\n[\s\S]*?(?=\n      - name:|\n  [a-z0-9-]+:|\n$)/
@@ -64,14 +64,25 @@ describe("frontend CI guardrails", () => {
     expect(affectedTestsStep).not.toContain("--coverage");
     expect(frontendTestJob).not.toContain("diff-cover");
 
-    expect(fullMainStep).toBeDefined();
-    expect(fullMainStep).toContain("if: github.event_name == 'push'");
-    expect(fullMainStep).not.toContain("--coverage");
+    expect(mainTestsStep).toBeDefined();
+    expect(mainTestsStep).toContain("if: github.event_name == 'push'");
+    expect(mainTestsStep).toContain("--changed=push-base");
+    expect(mainTestsStep).not.toContain("--coverage");
 
     expect(fullCoverageStep).toBeDefined();
     expect(fullCoverageStep).toContain("github.event_name == 'schedule'");
     expect(fullCoverageStep).toContain("github.event_name == 'workflow_dispatch'");
     expect(fullCoverageStep).toContain("--coverage");
+
+    // The scheduled coverage run is the only full-suite execution, so it
+    // must fire at least twice a day to bound the exposure window for
+    // breakage that affected-test runs missed.
+    const cronLines = workflow.match(/- cron: "[^"]+"/g) ?? [];
+    expect(cronLines.length).toBeGreaterThan(0);
+    for (const line of cronLines) {
+      const hourField = line.match(/- cron: "\S+ (\S+) /)?.[1] ?? "";
+      expect(hourField.split(",").length).toBeGreaterThanOrEqual(2);
+    }
   });
 
   it("splits Vitest tests into node and jsdom projects", () => {

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -43,6 +43,9 @@ export default defineConfig({
   test: {
     globals: true,
     css: false,
+    // Vitest 4 defaults to the forks pool; threads runs this suite ~20%
+    // faster end-to-end with identical results.
+    pool: 'threads',
     testTimeout: 5_000,
     hookTimeout: 10_000,
     reporters: process.env.CI ? ['dot'] : ['default'],


### PR DESCRIPTION
## Why

The full frontend test suite was taking 10–11 minutes on every push to `main`, riding the job's `timeout-minutes: 10` line (the example that prompted this hit the 10-minute timeout). That burned a 2-core runner per merge even though the merged PR had just run the same affected-test set, and the full run never actually gated deploys — `deploy.yml` triggers on push independently, and `main` has no required status checks.

## What changed

- **Vitest threads pool** ([vitest.config.ts](https://github.com/assembledhq/143/blob/claude/reverent-hopper-ef5120/frontend/vitest.config.ts)) — `pool: 'threads'` is ~20% faster than Vitest 4's `forks` default, with identical results (measured 60s vs 76s wall locally on the full suite).
- **Affected tests on main pushes** ([ci.yml](https://github.com/assembledhq/143/blob/claude/reverent-hopper-ef5120/.github/workflows/ci.yml)) — main pushes now run `--changed` against the previous main SHA (`github.event.before`) instead of the full suite, falling back to the full suite when that SHA can't be resolved (branch creation / force push). Typical merge drops from ~10.5 min to ~1–2 min of runner time.
- **Twice-daily full run** — the scheduled full-suite + coverage run moved from nightly (`17 10 * * *`) to every 12 hours (`17 10,22 * * *`), so a cross-cutting break that affected-test runs miss surfaces within ~12 hours instead of ~24.
- **Guardrail test updated** ([ci-guardrails.test.ts](https://github.com/assembledhq/143/blob/claude/reverent-hopper-ef5120/frontend/src/ci-guardrails.test.ts)) — pins the new main step (`--changed=push-base`) and asserts the schedule fires at least twice a day.
- **Account-settings add-auth test** ([page.test.tsx](https://github.com/assembledhq/143/blob/claude/reverent-hopper-ef5120/frontend/src/app/(dashboard)/settings/account/page.test.tsx)) — given a 12s budget (matching the comparably-heavy `page-pr-creation` flow). It's the heaviest interaction sequence in the file (~1.5s idle) but scales with CPU contention, so the default 5s flaked when the threads pool runs several files at once on 2 cores.

## Notes for reviewers

- **No deploy-safety tradeoff.** The full main run was never a deploy gate (see above), so dropping it on push changes no gate. If you *want* tests to hard-gate deploys, that's a separate `deploy.yml` / branch-protection change.
- **Account test fix is a budget bump, not a micro-opt.** I hypothesized the ~36 keystrokes were the bottleneck and tested `userEvent.setup({ delay: null, pointerEventsCheck: 0 })` with a controlled interleaved A/B — it was within noise (no benefit; the cost is dialog rendering + async waits, not typing), so I dropped it and kept only the timeout. The commit comment records this so it isn't re-litigated.
- **Verification caveat.** The threads-pool full suite passed 2281/2281 on a quiet machine; the account test passed 8/8 in an isolated stress loop. I could not get a clean *full-suite* local run afterward — the dev machine was under heavy load (bare render-only tests taking 5–6s), which produces cascading false timeouts. CI's dedicated cores are the real check; please confirm the frontend-test job is green here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
