### PR TITLE
Restart previews in place from the preview-domain holding page

### DIFF
--- a/frontend/src/app/(dashboard)/previews/[id]/page.test.tsx
+++ b/frontend/src/app/(dashboard)/previews/[id]/page.test.tsx
@@ -7,6 +7,7 @@ import { server } from "@/test/mocks/server";
 import {
   PREVIEW_BOOTSTRAP_COMPLETE_EVENT,
   PREVIEW_BOOTSTRAP_READY_EVENT,
+  PREVIEW_LAUNCH_COMPLETE_EVENT,
 } from "@/lib/preview-bootstrap";
 import { PreviewLandingContent } from "./page";
 
@@ -105,6 +106,102 @@ describe("PreviewLandingPage launch mode", () => {
     } finally {
       Object.defineProperty(window, "location", {
         value: originalLocation,
+        writable: true,
+        configurable: true,
+      });
+    }
+  });
+
+  it("notifies the opener and closes in popup mode instead of navigating", async () => {
+    searchParams = new URLSearchParams("launch=1&popup=1");
+
+    const originalLocation = window.location;
+    const locationMock = { href: "" };
+    let bootstrapCalls = 0;
+    const openerPostMessage = vi.fn();
+    Object.defineProperty(window, "opener", {
+      value: { postMessage: openerPostMessage },
+      writable: true,
+      configurable: true,
+    });
+    const closeSpy = vi.spyOn(window, "close").mockImplementation(() => {});
+
+    server.use(
+      http.get("*/api/v1/previews/target-1", () =>
+        HttpResponse.json({
+          data: {
+            target_id: "target-1",
+            preview_id: "prev-1",
+            repository_id: "repo-1",
+            repository_full_name: "acme/web",
+            branch: "feature/preview",
+            commit_sha: "529975ce1faa2961ef3f23abde2418bf561116d9",
+            source_type: "pull_request",
+            status: "ready",
+            current_phase: "ready",
+            stable_url: "https://143.dev/previews/target-1",
+            preview_url: "https://target-1.preview.143.dev",
+          },
+        }),
+      ),
+      http.post("*/api/v1/previews/prev-1/bootstrap", () => {
+        bootstrapCalls += 1;
+        return HttpResponse.json({
+          data: {
+            token: "bootstrap-token",
+            preview_id: "prev-1",
+          },
+        });
+      }),
+    );
+
+    try {
+      renderLaunchPage();
+
+      await screen.findByText("Opening preview");
+      act(() => {
+        window.dispatchEvent(
+          new MessageEvent("message", {
+            origin: "https://target-1.preview.143.dev",
+            data: { type: PREVIEW_BOOTSTRAP_READY_EVENT },
+          }),
+        );
+      });
+
+      await waitFor(() => {
+        expect(bootstrapCalls).toBe(1);
+      });
+      Object.defineProperty(window, "location", {
+        value: locationMock,
+        writable: true,
+        configurable: true,
+      });
+
+      act(() => {
+        window.dispatchEvent(
+          new MessageEvent("message", {
+            origin: "https://target-1.preview.143.dev",
+            data: { type: PREVIEW_BOOTSTRAP_COMPLETE_EVENT },
+          }),
+        );
+      });
+
+      await waitFor(() => {
+        expect(openerPostMessage).toHaveBeenCalledWith(
+          { type: PREVIEW_LAUNCH_COMPLETE_EVENT, url: "https://target-1.preview.143.dev" },
+          "https://target-1.preview.143.dev",
+        );
+      });
+      expect(closeSpy).toHaveBeenCalled();
+      expect(locationMock.href).toBe("");
+    } finally {
+      Object.defineProperty(window, "location", {
+        value: originalLocation,
+        writable: true,
+        configurable: true,
+      });
+      Object.defineProperty(window, "opener", {
+        value: null,
         writable: true,
         configurable: true,
       });

--- a/frontend/src/app/(dashboard)/previews/[id]/page.tsx
+++ b/frontend/src/app/(dashboard)/previews/[id]/page.tsx
@@ -18,6 +18,7 @@ import {
   PREVIEW_BOOTSTRAP_COMPLETE_EVENT,
   PREVIEW_BOOTSTRAP_READY_EVENT,
   PREVIEW_BOOTSTRAP_TOKEN_EVENT,
+  PREVIEW_LAUNCH_COMPLETE_EVENT,
 } from "@/lib/preview-bootstrap";
 import { safeExternalUrl } from "@/lib/utils";
 import { pollMs } from "@/lib/poll-intervals";
@@ -35,6 +36,10 @@ export function PreviewLandingContent({ id }: { id: string }) {
   const searchParams = useSearchParams();
   const queryClient = useQueryClient();
   const launchMode = searchParams.get("launch") === "1";
+  // Popup mode: this page was opened by the preview-domain control overlay,
+  // which stays put and waits for a launch-complete message instead of being
+  // navigated away from.
+  const popupMode = launchMode && searchParams.get("popup") === "1";
   const iframeRef = useRef<HTMLIFrameElement>(null);
   const bootstrappedPreviewIdRef = useRef<string | null>(null);
   const launchStartAttemptedRef = useRef<string | null>(null);
@@ -108,6 +113,17 @@ export function PreviewLandingContent({ id }: { id: string }) {
       if (event.origin !== previewOrigin) return;
       if (event.data?.type === PREVIEW_BOOTSTRAP_COMPLETE_EVENT) {
         if (bootstrappedPreviewIdRef.current === activePreviewId) {
+          if (popupMode && window.opener) {
+            // Include the preview URL so an overlay served on an alias host
+            // (runtime instance ID vs stable target ID) can navigate to the
+            // host the session cookie was actually minted for.
+            (window.opener as Window).postMessage(
+              { type: PREVIEW_LAUNCH_COMPLETE_EVENT, url: previewUrl },
+              previewOrigin,
+            );
+            window.close();
+            return;
+          }
           window.location.href = previewUrl;
         }
         return;
@@ -133,7 +149,7 @@ export function PreviewLandingContent({ id }: { id: string }) {
 
     window.addEventListener("message", handleMessage);
     return () => window.removeEventListener("message", handleMessage);
-  }, [bootstrapPreview, isReady, launchMode, preview?.preview_id, previewOrigin, previewUrl]);
+  }, [bootstrapPreview, isReady, launchMode, popupMode, preview?.preview_id, previewOrigin, previewUrl]);
 
   if (launchMode) {
     const launchError =

--- a/frontend/src/lib/preview-bootstrap.ts
+++ b/frontend/src/lib/preview-bootstrap.ts
@@ -1,6 +1,10 @@
 export const PREVIEW_BOOTSTRAP_READY_EVENT = "preview_bootstrap_ready";
 export const PREVIEW_BOOTSTRAP_TOKEN_EVENT = "preview_bootstrap_token";
 export const PREVIEW_BOOTSTRAP_COMPLETE_EVENT = "preview_bootstrap_complete";
+// Sent to window.opener (the preview-domain control overlay) when a popup
+// launch finishes the bootstrap handshake. Mirrored in the gateway overlay
+// script (internal/api/gateway/preview_gateway.go).
+export const PREVIEW_LAUNCH_COMPLETE_EVENT = "preview_launch_complete";
 
 export function previewOriginFromURL(previewURL: string): string | undefined {
   try {

--- a/internal/api/gateway/preview_gateway.go
+++ b/internal/api/gateway/preview_gateway.go
@@ -151,6 +151,8 @@ func (g *Gateway) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		g.serveBootstrapPage(w, r)
 	case r.Method == http.MethodPost && r.URL.Path == "/bootstrap/exchange":
 		g.handleBootstrapExchange(w, r, previewID)
+	case r.Method == http.MethodGet && r.URL.Path == previewControlStatusPath:
+		g.servePreviewControlStatus(w, r, previewID)
 	default:
 		g.handleProxy(w, r, previewID)
 	}
@@ -455,6 +457,16 @@ func (g *Gateway) servePreviewControlOverlay(w http.ResponseWriter, r *http.Requ
 		return
 	}
 	statusURL := g.previewStatusURL(previewID)
+	cfg, err := json.Marshal(map[string]any{
+		"appOrigin":     g.resolvedAppOrigin(),
+		"controlUrl":    controlURL,
+		"statusPath":    previewControlStatusPath,
+		"restartable":   data.Restartable,
+		"initialStatus": string(data.Status),
+	})
+	if err != nil {
+		cfg = []byte("null")
+	}
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
 	w.Header().Set("Cache-Control", "no-store")
 	w.WriteHeader(http.StatusOK)
@@ -468,6 +480,7 @@ func (g *Gateway) servePreviewControlOverlay(w http.ResponseWriter, r *http.Requ
 		stdhtml.EscapeString(controlURL),
 		stdhtml.EscapeString(data.ActionLabel),
 		stdhtml.EscapeString(statusURL),
+		cfg,
 	); err != nil {
 		g.logger.Warn().Err(err).Str("preview_id", previewID.String()).Msg("failed to write preview control overlay")
 	}
@@ -479,13 +492,15 @@ type previewControlOverlayData struct {
 	StatusLine  string
 	ActionLabel string
 	AutoLaunch  bool
+	Restartable bool
+	Status      models.PreviewStatus
 }
 
 func (g *Gateway) previewControlOverlayData(r *http.Request, previewID uuid.UUID) previewControlOverlayData {
 	fallback := previewControlOverlayData{
-		Title:       "Start preview",
-		Description: "This preview is not connected in this browser yet. Start it from 143; when it is ready, the preview opens here.",
-		StatusLine:  "Status: Not connected",
+		Title:       "Preview not connected",
+		Description: "Start the preview from 143 and it will open here.",
+		StatusLine:  "Not connected",
 		ActionLabel: "Start preview",
 	}
 	if g.store == nil {
@@ -498,24 +513,74 @@ func (g *Gateway) previewControlOverlayData(r *http.Request, previewID uuid.UUID
 		}
 		return fallback
 	}
-	statusLine := "Status: " + previewStatusLabel(instance.Status)
+	label := previewStatusLabel(instance.Status)
+	statusLine := label
 	if instance.StoppedAt != nil {
-		statusLine += " · stopped " + instance.StoppedAt.UTC().Format("Jan 2, 2006 15:04 MST")
+		statusLine += " · " + instance.StoppedAt.UTC().Format("Jan 2, 2006 15:04 MST")
 	}
 	if instance.Status.IsActive() {
 		return previewControlOverlayData{
 			Title:       "Open preview",
-			Description: "This preview is running, but this browser is not connected yet. 143 will connect it and open the preview here.",
+			Description: "This preview is running — opening it through 143.",
 			StatusLine:  statusLine,
 			ActionLabel: "Open preview",
 			AutoLaunch:  true,
+			Status:      instance.Status,
 		}
 	}
 	return previewControlOverlayData{
-		Title:       "Restart preview",
-		Description: "This preview is stopped. Restart it from 143; when it is ready, the preview opens here.",
+		Title:       "Preview " + strings.ToLower(label),
+		Description: "Restart it to pick up where you left off — this page reconnects automatically.",
 		StatusLine:  statusLine,
 		ActionLabel: "Restart preview",
+		Restartable: true,
+		Status:      instance.Status,
+	}
+}
+
+// previewControlStatusResponse is the unauthenticated status payload polled by
+// the control overlay while a restart is in flight. It exposes only what the
+// overlay itself already renders without auth: the status and stop time.
+type previewControlStatusResponse struct {
+	Status    string  `json:"status"`
+	Label     string  `json:"label"`
+	Active    bool    `json:"active"`
+	StoppedAt *string `json:"stopped_at,omitempty"`
+}
+
+func (g *Gateway) servePreviewControlStatus(w http.ResponseWriter, r *http.Request, previewID uuid.UUID) {
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Cache-Control", "no-store")
+	writeNotFound := func() {
+		w.WriteHeader(http.StatusNotFound)
+		_ = json.NewEncoder(w).Encode(models.ErrorResponse{
+			Error: models.ErrorDetail{Code: "PREVIEW_NOT_FOUND", Message: "preview not found"},
+		})
+	}
+	if g.store == nil {
+		writeNotFound()
+		return
+	}
+	instance, err := g.store.GetPreviewForPublicHost(r.Context(), previewID)
+	if err != nil {
+		if !errors.Is(err, pgx.ErrNoRows) {
+			g.logger.Warn().Err(err).Str("preview_id", previewID.String()).Msg("failed to load preview control status")
+		}
+		writeNotFound()
+		return
+	}
+	resp := previewControlStatusResponse{
+		Status: string(instance.Status),
+		Label:  previewStatusLabel(instance.Status),
+		Active: instance.Status.IsActive(),
+	}
+	if instance.StoppedAt != nil {
+		stoppedAt := instance.StoppedAt.UTC().Format(time.RFC3339)
+		resp.StoppedAt = &stoppedAt
+	}
+	w.WriteHeader(http.StatusOK)
+	if err := json.NewEncoder(w).Encode(resp); err != nil {
+		g.logger.Warn().Err(err).Str("preview_id", previewID.String()).Msg("failed to write preview control status")
 	}
 }
 
@@ -545,11 +610,15 @@ func (g *Gateway) previewControlURL(previewID uuid.UUID) string {
 }
 
 func (g *Gateway) previewStatusURL(previewID uuid.UUID) string {
+	return g.resolvedAppOrigin() + "/previews/" + previewID.String()
+}
+
+func (g *Gateway) resolvedAppOrigin() string {
 	appOrigin := strings.TrimRight(g.appOrigin, "/")
 	if appOrigin == "" {
-		appOrigin = "https://143.dev"
+		return "https://143.dev"
 	}
-	return appOrigin + "/previews/" + previewID.String()
+	return appOrigin
 }
 
 const previewControlOverlayHTML = `<!DOCTYPE html>
@@ -569,26 +638,151 @@ p { margin: 10px 0 0; font-size: 14px; line-height: 1.5; color: color-mix(in srg
 .actions { display: flex; gap: 10px; margin-top: 20px; flex-wrap: wrap; }
 a { display: inline-flex; align-items: center; justify-content: center; min-height: 36px; border-radius: 8px; padding: 0 14px; font-size: 14px; font-weight: 600; text-decoration: none; }
 .primary { background: CanvasText; color: Canvas; }
+.primary[aria-disabled="true"] { opacity: 0.6; pointer-events: none; }
 .secondary { border: 1px solid color-mix(in srgb, CanvasText 16%%, transparent); color: CanvasText; }
 </style>
 </head>
 <body>
 <main class="panel">
 <p class="eyebrow">143 preview</p>
-<h1>%s</h1>
-<p>%s</p>
-<p class="status">%s</p>
+<h1 id="pv-title">%s</h1>
+<p id="pv-desc">%s</p>
+<p class="status" id="pv-status">%s</p>
 <div class="actions">
-<a class="primary" href="%s">%s</a>
+<a class="primary" id="pv-action" href="%s">%s</a>
 <a class="secondary" href="%s">View status and logs</a>
 </div>
 </main>
+<script>window.__143PreviewControl = %s;</script>
+<script>
+(function() {
+  "use strict";
+  var cfg = window.__143PreviewControl;
+  if (!cfg || !cfg.restartable) return;
+  var titleEl = document.getElementById("pv-title");
+  var descEl = document.getElementById("pv-desc");
+  var statusEl = document.getElementById("pv-status");
+  var actionEl = document.getElementById("pv-action");
+  var original = {
+    title: titleEl.textContent,
+    desc: descEl.textContent,
+    status: statusEl.textContent,
+    action: actionEl.textContent
+  };
+  var restarting = false;
+  var popup = null;
+  var pollTimer = null;
+  var activeSince = 0;
+
+  function setPanel(title, desc, status) {
+    titleEl.textContent = title;
+    descEl.textContent = desc;
+    statusEl.textContent = status;
+    document.title = title;
+  }
+
+  function stopPolling() {
+    if (pollTimer) {
+      clearInterval(pollTimer);
+      pollTimer = null;
+    }
+  }
+
+  function enableAction() {
+    restarting = false;
+    actionEl.textContent = original.action;
+    actionEl.removeAttribute("aria-disabled");
+  }
+
+  function resetPanel() {
+    stopPolling();
+    enableAction();
+    setPanel(original.title, original.desc, original.status);
+  }
+
+  function fallbackLaunch() {
+    stopPolling();
+    window.location.href = cfg.controlUrl;
+  }
+
+  // The popup posts this once it has connected the browser to the restarted
+  // preview (the session cookie is set at that point). The cookie is scoped
+  // to the host in data.url; when this overlay is on an alias host (runtime
+  // instance ID vs stable target ID) we must navigate there instead of
+  // reloading in place.
+  window.addEventListener("message", function(event) {
+    if (event.origin !== cfg.appOrigin) return;
+    var data = event.data;
+    if (!data || data.type !== "preview_launch_complete") return;
+    stopPolling();
+    statusEl.textContent = "Connected";
+    var dest = null;
+    try { dest = new URL(data.url); } catch (e) {}
+    if (dest && (dest.protocol === "https:" || dest.protocol === "http:") && dest.origin !== window.location.origin) {
+      window.location.href = dest.href;
+      return;
+    }
+    window.location.reload();
+  });
+
+  function poll() {
+    fetch(cfg.statusPath, {cache: "no-store"}).then(function(resp) {
+      return resp.ok ? resp.json() : null;
+    }).then(function(state) {
+      if (!state || !restarting) return;
+      if (state.status === cfg.initialStatus) {
+        // The restart has not been picked up yet. If the popup was closed
+        // without starting anything, put the panel back.
+        if (popup && popup.closed) resetPanel();
+        return;
+      }
+      if (state.status === "failed") {
+        stopPolling();
+        enableAction();
+        setPanel("Preview failed to start", "Check status and logs for details, then try restarting again.", state.label);
+        return;
+      }
+      if (state.active && state.status !== "starting") {
+        // Ready. The popup finishes the browser handshake and notifies us;
+        // if it is gone or stuck, fall back to the full launch flow.
+        if (!activeSince) activeSince = Date.now();
+        if (!popup || popup.closed || Date.now() - activeSince > 15000) {
+          fallbackLaunch();
+          return;
+        }
+        statusEl.textContent = "Connecting this browser…";
+        return;
+      }
+      statusEl.textContent = state.label + "…";
+    }).catch(function() {});
+  }
+
+  actionEl.addEventListener("click", function(event) {
+    event.preventDefault();
+    if (restarting) return;
+    popup = window.open(cfg.controlUrl + "&popup=1", "143-preview-launch", "popup=yes,width=440,height=400");
+    if (!popup) {
+      // Popup blocked: fall back to the full-page launch flow.
+      window.location.href = cfg.controlUrl;
+      return;
+    }
+    restarting = true;
+    activeSince = 0;
+    setPanel("Restarting preview", "Keep this tab open — the preview opens here when it is ready.", "Restart requested…");
+    actionEl.textContent = "Restarting…";
+    actionEl.setAttribute("aria-disabled", "true");
+    pollTimer = setInterval(poll, 2500);
+    poll();
+  });
+})();
+</script>
 </body>
 </html>`
 
 const (
 	previewPlatformPathPrefix = "/__143_"
 	previewHeartbeatPath      = previewPlatformPathPrefix + "heartbeat"
+	previewControlStatusPath  = previewPlatformPathPrefix + "control/status"
 )
 
 func shouldRecordPreviewLastPath(r *http.Request) bool {

--- a/internal/api/gateway/preview_gateway_test.go
+++ b/internal/api/gateway/preview_gateway_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/assembledhq/143/internal/models"
 	"github.com/assembledhq/143/internal/services/preview"
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
 	"github.com/pashagolub/pgxmock/v4"
 	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/require"
@@ -701,9 +702,90 @@ func TestGateway_ServeHTTP_Proxy_NoCookieStoppedTarget(t *testing.T) {
 	gw.ServeHTTP(w, req)
 
 	require.Equal(t, http.StatusOK, w.Code, "stopped direct preview visits should render the lightweight control overlay")
+	require.Contains(t, w.Body.String(), "Preview stopped", "stopped target overlay should state the terminal status in the title")
 	require.Contains(t, w.Body.String(), "Restart preview", "stopped target overlay should expose the restart action")
-	require.Contains(t, w.Body.String(), "Status: Stopped", "stopped target overlay should show the terminal status")
-	require.Contains(t, w.Body.String(), "May 26, 2026 20:05 UTC", "stopped target overlay should show when the preview stopped")
+	require.Contains(t, w.Body.String(), "Stopped · May 26, 2026 20:05 UTC", "stopped target overlay should show when the preview stopped")
+	require.Contains(t, w.Body.String(), `"restartable":true`, "stopped target overlay should enable the in-place restart script")
+	require.NotContains(t, w.Body.String(), "%!", "overlay template verbs should match the formatted arguments")
+	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
+}
+
+func TestGateway_ServeHTTP_ControlStatus_StoppedTarget(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "pgxmock pool should be created")
+	defer mock.Close()
+
+	now := time.Date(2026, 5, 26, 20, 15, 0, 0, time.UTC)
+	stoppedAt := now.Add(-10 * time.Minute)
+	targetID := uuid.New()
+	previewID := uuid.New()
+	orgID := uuid.New()
+	userID := uuid.New()
+	sessionID := uuid.New()
+
+	mock.ExpectQuery("SELECT .+ FROM preview_instances").
+		WithArgs(pgxmock.AnyArg()).
+		WillReturnRows(
+			pgxmock.NewRows(previewGatewayInstanceColumns).AddRow(
+				previewGatewayInstanceRow(previewID, sessionID, &targetID, orgID, userID, models.PreviewStatusStopped, now, &stoppedAt)...,
+			),
+		)
+
+	gw := NewGateway(GatewayConfig{
+		Store:     db.NewPreviewStore(mock),
+		Logger:    zerolog.Nop(),
+		AppOrigin: "https://app.143.dev",
+	})
+	req := httptest.NewRequest(http.MethodGet, "/__143_control/status", nil)
+	req.Host = targetID.String() + ".preview.143.dev"
+	w := httptest.NewRecorder()
+
+	gw.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code, "control status should be readable without a preview session")
+	require.Contains(t, w.Header().Get("Content-Type"), "application/json", "control status should be JSON")
+
+	var body struct {
+		Status    string  `json:"status"`
+		Label     string  `json:"label"`
+		Active    bool    `json:"active"`
+		StoppedAt *string `json:"stopped_at"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &body), "control status body should decode")
+	require.Equal(t, "stopped", body.Status, "control status should report the raw status")
+	require.Equal(t, "Stopped", body.Label, "control status should report the human label")
+	require.False(t, body.Active, "stopped previews should not report active")
+	require.NotNil(t, body.StoppedAt, "control status should include the stop time")
+	require.Equal(t, stoppedAt.Format(time.RFC3339), *body.StoppedAt, "control status stop time should be RFC3339")
+	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
+}
+
+func TestGateway_ServeHTTP_ControlStatus_UnknownTarget(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "pgxmock pool should be created")
+	defer mock.Close()
+
+	mock.ExpectQuery("SELECT .+ FROM preview_instances").
+		WithArgs(pgxmock.AnyArg()).
+		WillReturnError(pgx.ErrNoRows)
+
+	gw := NewGateway(GatewayConfig{
+		Store:     db.NewPreviewStore(mock),
+		Logger:    zerolog.Nop(),
+		AppOrigin: "https://app.143.dev",
+	})
+	req := httptest.NewRequest(http.MethodGet, "/__143_control/status", nil)
+	req.Host = uuid.New().String() + ".preview.143.dev"
+	w := httptest.NewRecorder()
+
+	gw.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusNotFound, w.Code, "unknown previews should return not found")
+	require.Contains(t, w.Body.String(), "PREVIEW_NOT_FOUND", "unknown previews should return a typed error")
 	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
 }
 
@@ -802,7 +884,7 @@ func TestGateway_ServeHTTP_Proxy_StaleStoppedTargetCookieShowsRestart(t *testing
 	require.Contains(t, w.Header().Values("Set-Cookie")[0], "preview_session=;", "stale preview cookie should be cleared")
 	require.Contains(t, w.Header().Values("Set-Cookie")[0], "Max-Age=0", "cleared preview cookie should expire immediately")
 	require.Contains(t, w.Body.String(), "Restart preview", "stopped target overlay should expose the restart action")
-	require.Contains(t, w.Body.String(), "Status: Stopped", "stopped target overlay should show terminal status")
+	require.Contains(t, w.Body.String(), "Preview stopped", "stopped target overlay should show terminal status")
 	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
 }
 


### PR DESCRIPTION
## What changed

When a preview is stopped, its holding page (`{id}.preview.143.dev`) previously bounced the user to the main app (`/previews/{id}?launch=1`) to restart, and its copy was redundant ("Restart preview" twice, "stopped" three times).

- **In-place restart with live progress.** The restart button now opens the existing app launch flow in a small popup and keeps the user on the preview page. The overlay flips to a "Restarting preview" state and polls a new gateway endpoint (`GET /__143_control/status`) every 2.5s for live status. When the popup finishes the cookie bootstrap it posts `preview_launch_complete` (with the preview URL) back to the overlay and closes itself; the overlay reloads straight into the preview — or navigates to the cookie's host when the overlay is on an alias host (runtime instance ID vs stable target ID), which would otherwise 403.
- **Streamlined copy.** State in the title ("Preview stopped" / "Preview failed"), action on the button, single status line ("Stopped · Jun 10, 2026 06:19 UTC").

## Why the popup

The preview domain deliberately has no auth context, and the app session cookie is `SameSite=Lax`, so it is only sent on top-level navigations to the app origin — an iframe or a fetch from the overlay cannot authenticate. A popup is a top-level window, so it carries the session and reuses the existing authenticated launch/bootstrap flow unchanged. Restart authority stays entirely behind the app session.

## Security notes for review

- The new status endpoint is unauthenticated, but it returns only what the overlay already rendered without auth (status label, stop time) — no new information exposed to URL holders.
- The overlay config is embedded via `json.Marshal` (escapes `<`/`>`/`&`); all other template args go through `html.EscapeString`, and a test asserts no `%!` verb/arg drift in the `Fprintf` template.
- Both postMessage directions are origin-checked; the navigation URL from the completion message is restricted to http/https.

## Fallbacks

Popup blocked → previous full-page redirect flow. Popup closed mid-restart → fallback redirect once ready. Popup closed without restarting → panel resets. Restart fails → error copy with the button re-enabled. JS disabled → the button is a plain link with the old behavior.

## Testing

- New gateway tests for the status endpoint (stopped + unknown target); overlay assertions updated.
- New frontend test for popup mode (notifies opener, closes, does not navigate).
- `go test ./internal/api/gateway/`, `make lint` (0 issues), `tsc`, eslint, and the adjacent preview suites (72 tests) all pass.
- Worth a manual check: restarting while logged out — the popup shows login, and the flow resumes only if login redirects back to `/previews/{id}?launch=1&popup=1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
