### PR TITLE
Raise preview memory cap and per-topology defaults

### DIFF
--- a/internal/services/preview/config.go
+++ b/internal/services/preview/config.go
@@ -56,12 +56,20 @@ const (
 	DefaultInstallTimeoutSeconds = 420
 	MaxInstallTimeoutSeconds     = 1800
 
-	DefaultPreviewDiskMiB      = 10 * 1024
-	DefaultSingleServiceMemory = 384
-	DefaultMultiServiceMemory  = 768
-	DefaultInfraServiceMemory  = 1024
+	DefaultPreviewDiskMiB = 10 * 1024
+	// Per-topology memory defaults (MiB). Large frontend dev servers (e.g. an
+	// rspack/webpack build running alongside a backend service) routinely need
+	// several GiB; the previous 384/768/1024 defaults caused the dev server to
+	// be OOM-killed mid-response, truncating bundles and serving a blank page.
+	DefaultSingleServiceMemory = 1024
+	DefaultMultiServiceMemory  = 2048
+	DefaultInfraServiceMemory  = 4096
 	MaxPreviewCPUMillis        = 2000
-	MaxPreviewMemoryMiB        = 1024
+	// MaxPreviewMemoryMiB is the ceiling a repo may request via
+	// preview.resources.{requests,limits}.memory in .143/config.json. Defaults
+	// stay modest (above) to bound per-worker capacity; repos that need more
+	// opt in explicitly up to this cap.
+	MaxPreviewMemoryMiB        = 8192
 	MaxPreviewEphemeralDiskMiB = 10 * 1024
 )
 
@@ -834,6 +842,15 @@ func pathDir(clean string) string {
 	return clean[:idx]
 }
 
+// memoryLimitLabel renders MaxPreviewMemoryMiB as a human-friendly limit string
+// for validation messages (e.g. "8Gi"), so the messages track the constant.
+func memoryLimitLabel() string {
+	if MaxPreviewMemoryMiB%1024 == 0 {
+		return fmt.Sprintf("%dGi", MaxPreviewMemoryMiB/1024)
+	}
+	return fmt.Sprintf("%dMi", MaxPreviewMemoryMiB)
+}
+
 func validatePreviewResources(resources models.PreviewResourceRequirements) []string {
 	var errs []string
 
@@ -870,10 +887,10 @@ func validatePreviewResources(resources models.PreviewResourceRequirements) []st
 		errs = append(errs, "preview.resources.limits.cpu must be at most 2 cores")
 	}
 	if reqMemorySet && reqMemory > MaxPreviewMemoryMiB {
-		errs = append(errs, "preview.resources.requests.memory must be at most 1Gi")
+		errs = append(errs, fmt.Sprintf("preview.resources.requests.memory must be at most %s", memoryLimitLabel()))
 	}
 	if limitMemorySet && limitMemory > MaxPreviewMemoryMiB {
-		errs = append(errs, "preview.resources.limits.memory must be at most 1Gi")
+		errs = append(errs, fmt.Sprintf("preview.resources.limits.memory must be at most %s", memoryLimitLabel()))
 	}
 	if reqDiskSet && reqDisk > MaxPreviewEphemeralDiskMiB {
 		errs = append(errs, "preview.resources.requests.ephemeral-storage must be at most 10Gi")

--- a/internal/services/preview/config_test.go
+++ b/internal/services/preview/config_test.go
@@ -843,8 +843,8 @@ func TestValidateConfig_Resources(t *testing.T) {
 		},
 		{
 			name:       "memory exceeds cap",
-			resources:  models.PreviewResourceRequirements{Limits: models.PreviewResourceList{Memory: "2Gi"}},
-			wantErrSub: "at most 1Gi",
+			resources:  models.PreviewResourceRequirements{Limits: models.PreviewResourceList{Memory: "16Gi"}},
+			wantErrSub: "at most 8Gi",
 		},
 		{
 			name:       "storage exceeds cap",
@@ -1521,14 +1521,14 @@ func TestResolveResourceLimits(t *testing.T) {
 			cfg: models.PreviewConfig{
 				Services: map[string]models.ServiceConfig{"app": {}},
 			},
-			expected: models.ResourceLimits{MemoryMiB: 384, CPUMillis: 500, DiskMiB: 10 * 1024},
+			expected: models.ResourceLimits{MemoryMiB: 1024, CPUMillis: 500, DiskMiB: 10 * 1024},
 		},
 		{
 			name: "multi service without managed infrastructure uses standard preview tier",
 			cfg: models.PreviewConfig{
 				Services: map[string]models.ServiceConfig{"a": {}, "b": {}},
 			},
-			expected: models.ResourceLimits{MemoryMiB: 768, CPUMillis: 1000, DiskMiB: 10 * 1024},
+			expected: models.ResourceLimits{MemoryMiB: 2048, CPUMillis: 1000, DiskMiB: 10 * 1024},
 		},
 		{
 			name: "multi service with managed infrastructure uses heavy preview tier",
@@ -1538,7 +1538,7 @@ func TestResolveResourceLimits(t *testing.T) {
 					"db": {Template: "postgres-17"},
 				},
 			},
-			expected: models.ResourceLimits{MemoryMiB: 1024, CPUMillis: 2000, DiskMiB: 10 * 1024},
+			expected: models.ResourceLimits{MemoryMiB: 4096, CPUMillis: 2000, DiskMiB: 10 * 1024},
 		},
 		{
 			name: "requests override topology defaults when limits are omitted",
@@ -1587,7 +1587,7 @@ func TestApplyResourceLimitsToSandboxConfig(t *testing.T) {
 
 	ApplyResourceLimitsToSandboxConfig(&sandboxCfg, cfg)
 
-	require.Equal(t, 1024, sandboxCfg.MemoryLimitMB, "sandbox config should use the preview topology memory tier")
+	require.Equal(t, 4096, sandboxCfg.MemoryLimitMB, "sandbox config should use the preview topology memory tier")
 	require.Equal(t, 2.0, sandboxCfg.CPULimit, "sandbox config should convert preview millicores into CPU cores")
 	require.Equal(t, 10, sandboxCfg.DiskLimitGB, "sandbox config should round preview disk MiB up to whole GiB")
 }


### PR DESCRIPTION
## What

Raises preview container memory limits:

- `MaxPreviewMemoryMiB` (per-repo opt-in ceiling): **1Gi → 8Gi**
- Per-topology defaults: single-service **384 → 1024 MiB**, multi-service **768 → 2048 MiB**, infra-backed **1024 → 4096 MiB**
- The memory-cap validation message now derives from the constant via a new `memoryLimitLabel()` helper (no more hardcoded `"1Gi"`)
- Resource-tier tests updated to the new defaults/ceiling

## Why

Preview containers were hard-capped at 1 GiB with 384/768/1024 MiB defaults. For a large frontend (an rspack/webpack dev server running alongside a backend service), that's not enough — the dev server gets OOM-killed by the cgroup limit *mid-response* while serving large JS bundles, so the browser receives truncated chunks and the SPA never boots → **blank white screen**.

Diagnosed on a live Assembled preview (multi-service tier, 768 MiB):

- Browser: HTML loads 200, but the app's own large JS chunks (`app~0.bundle.js`, big vendor chunks) return 503 / hang. Direct fetch of `app~0.bundle.js` received **1,114,301 of 1,359,094** advertised bytes before the connection reset.
- Caddy + the API preview-gateway logged `httputil: ReverseProxy read error during body copy: unexpected EOF`, only on the large `/static/js/vendors-*` chunks — i.e. the container dev server closed the socket mid-body.
- The instance reached `ready` and "compiled successfully", so it's a *serve-time* OOM, not a build failure. That session had churned through ~10 mostly-`failed` instances at 768/384 MiB.

## Reviewer notes

- **Defaults are now higher for every preview**, so each reserves more RAM and fewer run concurrently per worker host (the limit is a hard cgroup cap → oversubscription OOMs rather than throttles). If we'd prefer to keep defaults conservative and make larger memory strictly opt-in, we can revert just the three `Default*ServiceMemory` bumps and keep only the `MaxPreviewMemoryMiB` ceiling raise.
- Repos can now opt up to 8Gi via `preview.resources.{requests,limits}.memory` in `.143/config.json` (previously rejected above 1Gi).
- Existing previews won't pick up the new tier until recreated — the limit is baked into the `preview_instances` row at reservation time.

## Test

- `go build ./internal/services/preview/` ✓
- `go test ./internal/services/preview/...` ✓
- `make lint` → 0 issues
