### PR TITLE
Prefetch session detail while the auth gate blocks the page

### DIFF
--- a/frontend/src/components/authenticated-layout.test.tsx
+++ b/frontend/src/components/authenticated-layout.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { fireEvent } from "@testing-library/react";
 import { renderWithProviders, screen, userEvent, waitFor, within } from "@/test/test-utils";
-import { AuthenticatedLayout } from "./authenticated-layout";
+import { AuthenticatedLayout, sessionDetailRouteId } from "./authenticated-layout";
 import { http, HttpResponse } from "msw";
 import { server } from "@/test/mocks/server";
 
@@ -544,6 +544,92 @@ describe("AuthenticatedLayout", () => {
       // Drawer is still in the DOM after a deliberate wait.
       await new Promise((r) => setTimeout(r, 50));
       expect(screen.queryByRole("dialog")).toBeInTheDocument();
+    });
+  });
+
+  describe("sessionDetailRouteId", () => {
+    const sessionId = "93cbcc8c-c12e-4bdf-8622-5865502c8977";
+
+    it("extracts a uuid session id from a session detail path", () => {
+      expect(sessionDetailRouteId(`/sessions/${sessionId}`)).toBe(sessionId);
+    });
+
+    it("returns null for everything that is not /sessions/<uuid>", () => {
+      expect(sessionDetailRouteId("/autopilot")).toBeNull();
+      expect(sessionDetailRouteId("/sessions")).toBeNull();
+      expect(sessionDetailRouteId("/sessions/new")).toBeNull();
+      expect(sessionDetailRouteId("/sessions/not-a-uuid")).toBeNull();
+      expect(sessionDetailRouteId(`/sessions/${sessionId}/extra`)).toBeNull();
+    });
+  });
+
+  describe("auth-gate session detail prefetch", () => {
+    const sessionId = "93cbcc8c-c12e-4bdf-8622-5865502c8977";
+    const loadingAuth = {
+      user: null,
+      isLoading: true,
+      isFetching: true,
+      isAuthenticated: false,
+      isUnauthorized: false,
+      isTransientError: false,
+      refetchUser: vi.fn(),
+      logout: logoutMock,
+    };
+
+    function trackSessionDetailRequests(): string[] {
+      const requests: string[] = [];
+      server.use(
+        http.get("/api/v1/sessions/:id", ({ params }) => {
+          requests.push(String(params.id));
+          return HttpResponse.json({ data: { id: params.id, threads: [] } });
+        })
+      );
+      return requests;
+    }
+
+    it("prefetches the session detail while /auth/me is still in flight", async () => {
+      mockPathname = `/sessions/${sessionId}`;
+      useAuthMock.mockReturnValue(loadingAuth);
+      const requests = trackSessionDetailRequests();
+
+      renderWithProviders(
+        <AuthenticatedLayout>
+          <div>content</div>
+        </AuthenticatedLayout>
+      );
+
+      await waitFor(() => {
+        expect(requests).toEqual([sessionId]);
+      });
+    });
+
+    it("does not prefetch when auth has already settled", async () => {
+      mockPathname = `/sessions/${sessionId}`;
+      const requests = trackSessionDetailRequests();
+
+      renderWithProviders(
+        <AuthenticatedLayout>
+          <div>content</div>
+        </AuthenticatedLayout>
+      );
+
+      await new Promise((r) => setTimeout(r, 50));
+      expect(requests).toEqual([]);
+    });
+
+    it("does not prefetch on non-session routes while auth loads", async () => {
+      mockPathname = "/autopilot";
+      useAuthMock.mockReturnValue(loadingAuth);
+      const requests = trackSessionDetailRequests();
+
+      renderWithProviders(
+        <AuthenticatedLayout>
+          <div>content</div>
+        </AuthenticatedLayout>
+      );
+
+      await new Promise((r) => setTimeout(r, 50));
+      expect(requests).toEqual([]);
     });
   });
 });

--- a/frontend/src/components/authenticated-layout.tsx
+++ b/frontend/src/components/authenticated-layout.tsx
@@ -469,17 +469,26 @@ type MobileTopBarProps = {
   menuOpen: boolean;
 };
 
-function isSessionDetailRoute(pathname: string): boolean {
+// Returns the second path segment of a /sessions/<segment> route, or null
+// for anything else (including /sessions/new). Shared by the loose UI check
+// below and the strict prefetch guard so the route shape is parsed once.
+function sessionDetailRouteSegment(pathname: string): string | null {
   const segments = pathname.split("/").filter(Boolean);
-  return segments.length === 2 && segments[0] === "sessions" && segments[1] !== "new";
+  if (segments.length !== 2 || segments[0] !== "sessions" || segments[1] === "new") return null;
+  return segments[1];
+}
+
+function isSessionDetailRoute(pathname: string): boolean {
+  return sessionDetailRouteSegment(pathname) !== null;
 }
 
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
+// Strict variant for the auth-gate prefetch: only a UUID segment is worth a
+// speculative request, so non-id paths never hit the API.
 export function sessionDetailRouteId(pathname: string): string | null {
-  const segments = pathname.split("/").filter(Boolean);
-  if (segments.length !== 2 || segments[0] !== "sessions") return null;
-  return UUID_RE.test(segments[1]) ? segments[1] : null;
+  const segment = sessionDetailRouteSegment(pathname);
+  return segment !== null && UUID_RE.test(segment) ? segment : null;
 }
 
 function MobileTopBar({

--- a/frontend/src/components/authenticated-layout.tsx
+++ b/frontend/src/components/authenticated-layout.tsx
@@ -45,7 +45,10 @@ import {
   PopoverTrigger,
 } from "@/components/ui/popover";
 import { useAuth } from "@/hooks/use-auth";
-import { useCallback, useEffect, useState } from "react";
+import { useQueryClient } from "@tanstack/react-query";
+import { api } from "@/lib/api";
+import { queryKeys } from "@/lib/query-keys";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { RepoContextSwitcher } from "@/components/repo-context-switcher";
 import { OrgSwitcher } from "@/components/org-switcher";
 import { CommandPalette } from "@/components/command-palette/command-palette";
@@ -471,6 +474,14 @@ function isSessionDetailRoute(pathname: string): boolean {
   return segments.length === 2 && segments[0] === "sessions" && segments[1] !== "new";
 }
 
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+export function sessionDetailRouteId(pathname: string): string | null {
+  const segments = pathname.split("/").filter(Boolean);
+  if (segments.length !== 2 || segments[0] !== "sessions") return null;
+  return UUID_RE.test(segments[1]) ? segments[1] : null;
+}
+
 function MobileTopBar({
   onOpenMenu,
   onPaletteOpen,
@@ -529,6 +540,30 @@ export function AuthenticatedLayout({ children }: { children: React.ReactNode })
   const [paletteOpen, setPaletteOpen] = useState(false);
   const [createOpen, setCreateOpen] = useState(false);
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
+
+  // On a cold load this layout renders only a skeleton until /auth/me
+  // resolves, so the page behind it can't start its own data fetches — every
+  // round trip serializes behind auth. Warm the session detail cache for
+  // /sessions/[id] routes in parallel with /auth/me; when the page mounts,
+  // React Query dedupes against the in-flight prefetch (or serves the settled
+  // payload) instead of paying a fresh round trip. prefetchQuery swallows
+  // errors by design: a 401 here just means the auth gate is about to
+  // redirect to /login anyway.
+  const queryClient = useQueryClient();
+  const didPrefetchRouteDataRef = useRef(false);
+  useEffect(() => {
+    if (didPrefetchRouteDataRef.current) return;
+    didPrefetchRouteDataRef.current = true;
+    // Auth already settled (warm navigation) — the page mounts immediately
+    // and owns its fetches; prefetching would only duplicate work.
+    if (user || !isLoading) return;
+    const sessionId = sessionDetailRouteId(pathname);
+    if (!sessionId) return;
+    void queryClient.prefetchQuery({
+      queryKey: queryKeys.sessions.detail(sessionId),
+      queryFn: () => api.sessions.get(sessionId),
+    });
+  }, [isLoading, pathname, queryClient, user]);
   const { width: appSidebarWidth, resizeBy: resizeAppSidebar } = usePersistedPanelWidth({
     storageKey: APP_SIDEBAR_STORAGE_KEY,
     defaultWidth: APP_SIDEBAR_DEFAULT_WIDTH,


### PR DESCRIPTION
## Why

Debugging slow session detail page loads: production logs show every page-load API endpoint answering in under 40ms (session detail p50 4.3ms), so the latency is client-side serialization. On a cold load, `AuthenticatedLayout` renders only a skeleton until `/auth/me` resolves — the page behind it never mounts, so its queries can't start. The session detail fetch pays a full extra round trip serialized behind auth.

## What

- Add `sessionDetailRouteId(pathname)` to extract the session id from `/sessions/<uuid>` routes.
- While the auth gate is still loading on initial mount, `prefetchQuery` the session detail under the same query key the page uses (`queryKeys.sessions.detail(id)`). React Query dedupes the in-flight fetch when the page mounts, so no duplicate requests.
- Skipped entirely on warm navigations (auth already settled) — the page mounts immediately and owns its fetches, and the sidebar's hover-prefetch/cache seeding ([#1326](https://github.com/assembledhq/143/pull/1326)) already covers that path.
- A 401 racing the prefetch is harmless: `prefetchQuery` swallows errors and the auth gate redirects to /login as before.

## Part of a series

PR 1 of 4 attacking the cold-load waterfall (bundle → auth → session → messages → logs). Each PR is independent.

## Testing

- New tests: prefetch fires while `/auth/me` is in flight on a session detail route; no prefetch once auth settled; no prefetch on other routes; `sessionDetailRouteId` unit cases.
- `npx vitest run src/components/authenticated-layout.test.tsx` — 33 passed.
- `tsc --noEmit` and `eslint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)