### PR TITLE
Prefetch the stored thread's message window in parallel with session detail

### DIFF
--- a/frontend/src/app/(dashboard)/sessions/[id]/page-warm-start.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/page-warm-start.test.tsx
@@ -1,0 +1,176 @@
+// Warm-start prefetch behavior: the session detail page should start loading
+// the stored active thread's message window in parallel with the session
+// detail fetch, instead of serializing messages behind detail → thread
+// selection → ChatPanel mount.
+import { describe, it, expect, vi } from 'vitest';
+import { http, HttpResponse } from 'msw';
+import { renderWithProviders, screen, waitFor } from '@/test/test-utils';
+import { server } from '@/test/mocks/server';
+import { mockSessions, mockMembers } from '@/test/mocks/handlers';
+import { SessionDetailContent } from './session-detail-content';
+import { writeStoredSessionActiveThread, writeStoredSessionAnchorPosition } from '@/lib/session-open-position';
+import { writeCachedViewerScope } from '@/lib/viewer-scope-cache';
+import type { Session, SessionMessage, SingleResponse, ListResponse } from '@/lib/types';
+import { installSessionDetailPageTestHooks } from './session-detail-test-kit';
+
+const { toast } = vi.hoisted(() => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+const { routerPush } = vi.hoisted(() => ({
+  routerPush: vi.fn(),
+}));
+
+vi.mock('@/lib/notify', () => ({
+  notify: toast,
+}));
+
+vi.mock('@/components/markdown', () => ({
+  MarkdownContent: ({ content, className }: { content: string; className?: string }) => (
+    <div className={className}>{content}</div>
+  ),
+}));
+
+vi.mock('@/components/session-keyboard-help-overlay', () => ({
+  SessionKeyboardHelpOverlay: ({ open }: { open: boolean }) => (
+    open ? <div role="dialog" aria-label="Session keyboard shortcuts" /> : null
+  ),
+}));
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({
+    push: routerPush,
+  }),
+  useSearchParams: () => new URLSearchParams(),
+}));
+
+vi.mock('next/link', () => ({
+  default: ({ children, href, ...props }: React.ComponentProps<'a'> & { href: string }) => (
+    <a href={href} {...props}>{children}</a>
+  ),
+}));
+
+vi.mock('next/image', () => ({
+  default: ({ src, alt, className, width, height }: { src: string; alt: string; className?: string; width?: number; height?: number }) => (
+    <span data-next-image={src} aria-label={alt} className={className} data-width={width} data-height={height} />
+  ),
+}));
+
+installSessionDetailPageTestHooks({ toast, routerPush });
+
+const sessionId = mockSessions[0].id;
+const viewerScope = { userId: mockMembers[0].id, orgId: mockMembers[0].org_id ?? null };
+
+function blockSessionDetail(): { detailRequests: () => number; releaseDetail: () => void } {
+  let requests = 0;
+  let release = () => {};
+  const blocked = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  server.use(
+    http.get(`/api/v1/sessions/${sessionId}`, async () => {
+      requests += 1;
+      await blocked;
+      return HttpResponse.json({
+        data: { ...mockSessions[0], threads: [] },
+      } satisfies SingleResponse<Session>);
+    }),
+  );
+  return { detailRequests: () => requests, releaseDetail: release };
+}
+
+describe('SessionDetailPage warm-start message prefetch', () => {
+  it('fetches the stored thread message window while session detail is still in flight', async () => {
+    const threadId = 'thread-warm-1';
+    writeCachedViewerScope(window.localStorage, viewerScope);
+    writeStoredSessionActiveThread(window.localStorage, sessionId, viewerScope, threadId);
+
+    const messageRequests: string[] = [];
+    server.use(
+      http.get(`/api/v1/sessions/${sessionId}/threads/${threadId}/messages`, ({ request }) => {
+        messageRequests.push(new URL(request.url).searchParams.get('position') ?? '');
+        return HttpResponse.json({
+          data: [] as SessionMessage[],
+          meta: {},
+        } satisfies ListResponse<SessionMessage>);
+      }),
+    );
+    const { detailRequests, releaseDetail } = blockSessionDetail();
+
+    renderWithProviders(<SessionDetailContent id={sessionId} />);
+
+    // The message window request fires while the detail response is still
+    // blocked — proof the two round trips overlap instead of serializing.
+    await waitFor(() => {
+      expect(messageRequests).toEqual(['latest']);
+    });
+    expect(detailRequests()).toBe(1);
+
+    releaseDetail();
+    await screen.findAllByText('Fixed TypeError by adding null check');
+  });
+
+  it('anchors the prefetched window to the stored reading position when one exists', async () => {
+    const threadId = 'thread-warm-2';
+    writeCachedViewerScope(window.localStorage, viewerScope);
+    writeStoredSessionActiveThread(window.localStorage, sessionId, viewerScope, threadId);
+    writeStoredSessionAnchorPosition(
+      window.localStorage,
+      sessionId,
+      viewerScope,
+      { anchor: { kind: 'message', id: 42 }, offsetPx: 0, scrollTopFallback: 0 },
+      threadId,
+    );
+
+    const anchorParams: Array<{ position: string | null; anchorMessageId: string | null }> = [];
+    server.use(
+      http.get(`/api/v1/sessions/${sessionId}/threads/${threadId}/messages`, ({ request }) => {
+        const url = new URL(request.url);
+        anchorParams.push({
+          position: url.searchParams.get('position'),
+          anchorMessageId: url.searchParams.get('anchor_message_id'),
+        });
+        return HttpResponse.json({
+          data: [] as SessionMessage[],
+          meta: {},
+        } satisfies ListResponse<SessionMessage>);
+      }),
+    );
+    const { releaseDetail } = blockSessionDetail();
+
+    renderWithProviders(<SessionDetailContent id={sessionId} />);
+
+    await waitFor(() => {
+      expect(anchorParams).toEqual([{ position: 'around', anchorMessageId: '42' }]);
+    });
+
+    releaseDetail();
+    await screen.findAllByText('Fixed TypeError by adding null check');
+  });
+
+  it('does not prefetch when no thread is stored for the session', async () => {
+    writeCachedViewerScope(window.localStorage, viewerScope);
+
+    let messageRequests = 0;
+    server.use(
+      http.get(`/api/v1/sessions/${sessionId}/threads/:threadId/messages`, () => {
+        messageRequests += 1;
+        return HttpResponse.json({
+          data: [] as SessionMessage[],
+          meta: {},
+        } satisfies ListResponse<SessionMessage>);
+      }),
+    );
+    const { releaseDetail } = blockSessionDetail();
+
+    renderWithProviders(<SessionDetailContent id={sessionId} />);
+
+    await new Promise((r) => setTimeout(r, 50));
+    expect(messageRequests).toBe(0);
+
+    releaseDetail();
+    await screen.findAllByText('Fixed TypeError by adding null check');
+  });
+});

--- a/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
@@ -129,6 +129,7 @@ import {
   writeStoredSessionActiveThread,
   writeStoredSessionScrollPosition,
 } from "@/lib/session-open-position";
+import { readCachedViewerScope } from "@/lib/viewer-scope-cache";
 import {
   readStoredViewedThreadIds,
   writeStoredViewedThreadIds,
@@ -3313,6 +3314,40 @@ export function SessionDetailContent({ id }: { id: string }) {
   const currentTitle = session ? sessionTitle(session) : "";
 
   const queryClient = useQueryClient();
+
+  // Warm the stored active thread's first message window in parallel with the
+  // session detail fetch. Without this, the messages request can't start
+  // until the detail payload arrives, the thread-selection effect runs, and
+  // ChatPanel mounts — a full extra round trip on every page open even
+  // though the server answers in single-digit milliseconds. The stored
+  // thread id (and, pre-auth, the cached viewer scope) is a hint: if it
+  // turns out stale, the normal resolution flow corrects the selection and
+  // this prefetch is just unused cache. ChatPanel's useInfiniteQuery shares
+  // the exact query key, so React Query dedupes against the in-flight fetch.
+  const didPrefetchThreadMessagesRef = useRef(false);
+  useEffect(() => {
+    if (didPrefetchThreadMessagesRef.current || typeof window === "undefined") return;
+    didPrefetchThreadMessagesRef.current = true;
+    const scope: SessionScrollViewerScope | null = user
+      ? { userId: user.id, orgId: getActiveOrgId() ?? user.org_id }
+      : readCachedViewerScope(window.localStorage);
+    if (!scope) return;
+    const storedThreadId = readStoredSessionActiveThread(window.localStorage, id, scope);
+    if (!storedThreadId) return;
+    const anchor = readStoredSessionAnchorPosition(window.localStorage, id, scope, storedThreadId);
+    void queryClient.prefetchInfiniteQuery({
+      queryKey: threadMessageWindowQueryKey(id, storedThreadId, anchor?.anchor.id ?? null),
+      queryFn: () =>
+        api.sessions.getThreadMessageWindow(
+          id,
+          storedThreadId,
+          anchor
+            ? { position: "around", anchorMessageId: anchor.anchor.id, limit: THREAD_MESSAGE_WINDOW_LIMIT }
+            : { position: "latest", limit: THREAD_MESSAGE_WINDOW_LIMIT },
+        ),
+      initialPageParam: undefined as string | undefined,
+    });
+  }, [id, queryClient, user]);
 
   // Full-screen diff viewer. The preference lives on the user settings
   // document so it sticks across sessions; mobile review already fills the

--- a/frontend/src/hooks/use-auth.test.ts
+++ b/frontend/src/hooks/use-auth.test.ts
@@ -26,6 +26,7 @@ vi.mock('@/lib/api', () => ({
 }));
 
 import { useAuth, useAuthProviders } from './use-auth';
+import { readCachedViewerScope } from '@/lib/viewer-scope-cache';
 
 function createWrapper() {
   const queryClient = createTestQueryClient();
@@ -161,6 +162,44 @@ describe('useAuth', () => {
     });
 
     expect(result.current.user?.settings?.coding_agent_reasoning_defaults?.codex).toBe('xhigh');
+  });
+
+  it('caches the viewer scope in localStorage when auth/me resolves', async () => {
+    window.localStorage.clear();
+    meMock.mockResolvedValue({
+      data: { id: 'user-7', org_id: 'org-9', email: 'test@test.com', name: 'Test' },
+    });
+
+    const { result } = renderHook(() => useAuth(), { wrapper: createWrapper() });
+
+    await waitFor(() => {
+      expect(result.current.isAuthenticated).toBe(true);
+    });
+
+    expect(readCachedViewerScope(window.localStorage)).toEqual({
+      userId: 'user-7',
+      orgId: 'org-9',
+    });
+  });
+
+  it('prefers the per-tab active org over the home org when caching the scope', async () => {
+    window.localStorage.clear();
+    window.sessionStorage.setItem('active_org_id', 'org-tab');
+    meMock.mockResolvedValue({
+      data: { id: 'user-7', org_id: 'org-9', email: 'test@test.com', name: 'Test' },
+    });
+
+    const { result } = renderHook(() => useAuth(), { wrapper: createWrapper() });
+
+    await waitFor(() => {
+      expect(result.current.isAuthenticated).toBe(true);
+    });
+
+    expect(readCachedViewerScope(window.localStorage)).toEqual({
+      userId: 'user-7',
+      orgId: 'org-tab',
+    });
+    window.sessionStorage.removeItem('active_org_id');
   });
 });
 

--- a/frontend/src/hooks/use-auth.test.ts
+++ b/frontend/src/hooks/use-auth.test.ts
@@ -128,10 +128,15 @@ describe('useAuth', () => {
       configurable: true,
     });
 
+    // /auth/me resolving above cached the viewer scope; logout must drop it
+    // so the next user on this browser starts without the previous identity.
+    expect(readCachedViewerScope(window.localStorage)).not.toBeNull();
+
     await result.current.logout();
 
     expect(logoutMock).toHaveBeenCalledTimes(1);
     expect(window.location.href).toBe('/');
+    expect(readCachedViewerScope(window.localStorage)).toBeNull();
 
     // Restore original location
     Object.defineProperty(window, 'location', {

--- a/frontend/src/hooks/use-auth.ts
+++ b/frontend/src/hooks/use-auth.ts
@@ -1,6 +1,8 @@
 "use client";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { api } from "@/lib/api";
+import { getActiveOrgId } from "@/lib/active-org";
+import { writeCachedViewerScope } from "@/lib/viewer-scope-cache";
 
 // Duck-typed 401 check. The backend's `writeError` helper is the single
 // source of truth for this contract: every 401 response carries
@@ -21,7 +23,21 @@ export function useAuth() {
 
   const { data, isLoading, isFetching, error, refetch } = useQuery({
     queryKey: ["auth", "me"],
-    queryFn: () => api.auth.me(),
+    queryFn: async () => {
+      const response = await api.auth.me();
+      // Persist the viewer identity so warm-start paths (prefetching
+      // user/org-scoped state before the next cold load's /auth/me resolves)
+      // can reconstruct localStorage keys. Same composition as the page-level
+      // viewerScope: per-tab active org first, then the user's home org.
+      const me = response.data;
+      if (me && typeof window !== "undefined") {
+        writeCachedViewerScope(window.localStorage, {
+          userId: me.id,
+          orgId: getActiveOrgId() ?? me.org_id ?? null,
+        });
+      }
+      return response;
+    },
     // Only treat a confirmed 401 as terminal. Network blips and 5xx
     // (e.g. during a rolling deploy) retry a few times instead of
     // instantly logging the user out.

--- a/frontend/src/hooks/use-auth.ts
+++ b/frontend/src/hooks/use-auth.ts
@@ -2,7 +2,7 @@
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { api } from "@/lib/api";
 import { getActiveOrgId } from "@/lib/active-org";
-import { writeCachedViewerScope } from "@/lib/viewer-scope-cache";
+import { clearCachedViewerScope, writeCachedViewerScope } from "@/lib/viewer-scope-cache";
 
 // Duck-typed 401 check. The backend's `writeError` helper is the single
 // source of truth for this contract: every 401 response carries
@@ -60,6 +60,9 @@ export function useAuth() {
   const logout = async () => {
     await api.auth.logout();
     queryClient.clear();
+    // Drop the warm-start identity hint so a different user on this browser
+    // can't trigger prefetches keyed off the previous user's stored state.
+    clearCachedViewerScope(window.localStorage);
     window.location.href = "/";
   };
 

--- a/frontend/src/lib/viewer-scope-cache.test.ts
+++ b/frontend/src/lib/viewer-scope-cache.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from "vitest";
+import { readCachedViewerScope, writeCachedViewerScope } from "./viewer-scope-cache";
+
+function memoryStorage(): Pick<Storage, "getItem" | "setItem"> & { store: Map<string, string> } {
+  const store = new Map<string, string>();
+  return {
+    store,
+    getItem: (key: string) => store.get(key) ?? null,
+    setItem: (key: string, value: string) => {
+      store.set(key, value);
+    },
+  };
+}
+
+describe("viewer-scope-cache", () => {
+  it("round-trips a viewer scope", () => {
+    const storage = memoryStorage();
+    writeCachedViewerScope(storage, { userId: "user-1", orgId: "org-1" });
+    expect(readCachedViewerScope(storage)).toEqual({ userId: "user-1", orgId: "org-1" });
+  });
+
+  it("normalizes a missing org to null", () => {
+    const storage = memoryStorage();
+    writeCachedViewerScope(storage, { userId: "user-1" });
+    expect(readCachedViewerScope(storage)).toEqual({ userId: "user-1", orgId: null });
+  });
+
+  it("returns null when nothing is cached", () => {
+    expect(readCachedViewerScope(memoryStorage())).toBeNull();
+  });
+
+  it("rejects malformed payloads", () => {
+    const storage = memoryStorage();
+    storage.store.set("143:last-viewer-scope", "not-json{");
+    expect(readCachedViewerScope(storage)).toBeNull();
+
+    storage.store.set("143:last-viewer-scope", JSON.stringify({ version: 2, userId: "user-1" }));
+    expect(readCachedViewerScope(storage)).toBeNull();
+
+    storage.store.set("143:last-viewer-scope", JSON.stringify({ version: 1, userId: "" }));
+    expect(readCachedViewerScope(storage)).toBeNull();
+  });
+
+  it("does not write an empty user id", () => {
+    const storage = memoryStorage();
+    writeCachedViewerScope(storage, { userId: "", orgId: "org-1" });
+    expect(storage.store.size).toBe(0);
+  });
+});

--- a/frontend/src/lib/viewer-scope-cache.test.ts
+++ b/frontend/src/lib/viewer-scope-cache.test.ts
@@ -1,13 +1,16 @@
 import { describe, it, expect } from "vitest";
-import { readCachedViewerScope, writeCachedViewerScope } from "./viewer-scope-cache";
+import { clearCachedViewerScope, readCachedViewerScope, writeCachedViewerScope } from "./viewer-scope-cache";
 
-function memoryStorage(): Pick<Storage, "getItem" | "setItem"> & { store: Map<string, string> } {
+function memoryStorage(): Pick<Storage, "getItem" | "setItem" | "removeItem"> & { store: Map<string, string> } {
   const store = new Map<string, string>();
   return {
     store,
     getItem: (key: string) => store.get(key) ?? null,
     setItem: (key: string, value: string) => {
       store.set(key, value);
+    },
+    removeItem: (key: string) => {
+      store.delete(key);
     },
   };
 }
@@ -45,5 +48,12 @@ describe("viewer-scope-cache", () => {
     const storage = memoryStorage();
     writeCachedViewerScope(storage, { userId: "", orgId: "org-1" });
     expect(storage.store.size).toBe(0);
+  });
+
+  it("clears a cached scope", () => {
+    const storage = memoryStorage();
+    writeCachedViewerScope(storage, { userId: "user-1", orgId: "org-1" });
+    clearCachedViewerScope(storage);
+    expect(readCachedViewerScope(storage)).toBeNull();
   });
 });

--- a/frontend/src/lib/viewer-scope-cache.ts
+++ b/frontend/src/lib/viewer-scope-cache.ts
@@ -1,0 +1,59 @@
+import type { SessionScrollViewerScope } from "./session-open-position";
+
+// Last-known viewer identity, persisted by use-auth whenever /auth/me
+// resolves. Warm-start code paths (e.g. prefetching the active thread's
+// message window before auth settles) need it to reconstruct localStorage
+// keys that are scoped by user/org. It is a hint, not a source of truth:
+// consumers must tolerate the authenticated scope coming back different —
+// optimistic work keyed off a stale scope is simply discarded.
+const VIEWER_SCOPE_CACHE_KEY = "143:last-viewer-scope";
+
+interface StoredViewerScope {
+  version: 1;
+  userId: string;
+  orgId: string | null;
+}
+
+export function readCachedViewerScope(
+  storage: Pick<Storage, "getItem">,
+): SessionScrollViewerScope | null {
+  let raw: string | null;
+  try {
+    raw = storage.getItem(VIEWER_SCOPE_CACHE_KEY);
+  } catch {
+    return null;
+  }
+  if (!raw) return null;
+
+  try {
+    const parsed = JSON.parse(raw) as Partial<StoredViewerScope>;
+    if (parsed.version !== 1 || typeof parsed.userId !== "string" || parsed.userId.length === 0) {
+      return null;
+    }
+    return {
+      userId: parsed.userId,
+      orgId: typeof parsed.orgId === "string" && parsed.orgId.length > 0 ? parsed.orgId : null,
+    };
+  } catch {
+    return null;
+  }
+}
+
+export function writeCachedViewerScope(
+  storage: Pick<Storage, "setItem">,
+  scope: SessionScrollViewerScope,
+): void {
+  if (scope.userId.length === 0) return;
+
+  const normalizedValue = JSON.stringify({
+    version: 1,
+    userId: scope.userId,
+    orgId: scope.orgId ?? null,
+  } satisfies StoredViewerScope);
+
+  try {
+    storage.setItem(VIEWER_SCOPE_CACHE_KEY, normalizedValue);
+  } catch {
+    // Quota or privacy-mode errors just lose the warm-start hint.
+  }
+}

--- a/frontend/src/lib/viewer-scope-cache.ts
+++ b/frontend/src/lib/viewer-scope-cache.ts
@@ -57,3 +57,13 @@ export function writeCachedViewerScope(
     // Quota or privacy-mode errors just lose the warm-start hint.
   }
 }
+
+// Called on logout so the next user on this browser can't trigger
+// prefetches keyed off the previous user's stored state.
+export function clearCachedViewerScope(storage: Pick<Storage, "removeItem">): void {
+  try {
+    storage.removeItem(VIEWER_SCOPE_CACHE_KEY);
+  } catch {
+    // Best-effort: a stale hint only ever costs a wasted, access-checked fetch.
+  }
+}


### PR DESCRIPTION
## Why

Part of the session detail latency series ([#1329](https://github.com/assembledhq/143/pull/1329) covered the auth gate). The conversation pane today serializes three round trips after the page mounts:

1. `GET /sessions/{id}` resolves
2. the thread-selection effect picks the active thread (also gated on auth/viewer scope)
3. `ChatPanel` mounts and only then fetches `GET .../threads/{tid}/messages`

Production logs show each request answering in <25ms server-side while the client spends ~1–2s walking this chain.

## What

- **`viewer-scope-cache.ts` (new):** `use-auth` persists the last-known viewer identity (user id + active org, same composition as the page's `viewerScope`) to localStorage whenever `/auth/me` succeeds.
- **`SessionDetailContent`:** on mount, read the stored active thread for this session (the id is already persisted per user/org scope) and `prefetchInfiniteQuery` its first message window — including the stored reading-position anchor, so the key matches exactly — in parallel with the session detail fetch. `ChatPanel`'s `useInfiniteQuery` shares the key and dedupes against the in-flight prefetch.
- The cached scope and stored thread id are **hints**: if auth comes back as a different user, or the thread no longer exists, the existing resolution flow corrects the selection and the prefetched window is just unused cache. No behavioral change for first-ever visits (nothing stored → no prefetch).

## Testing

- New `page-warm-start.test.tsx`: message window request fires **while the session detail response is still blocked** (proves the overlap); anchored-window variant asserts `position=around&anchor_message_id`; no-stored-thread variant asserts no request.
- `use-auth` tests for the scope cache (including per-tab active-org precedence); unit tests for the cache codec.
- Ran `page-overview`, `page-agent-tabs`, and the performance chunk — 53 passed, no regressions. `tsc` + `eslint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)