### PR TITLE
Paint session metadata in the loading skeleton instead of all shimmer

### DIFF
--- a/frontend/src/app/(dashboard)/sessions/[id]/page-overview.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/page-overview.test.tsx
@@ -127,7 +127,10 @@ describe('SessionDetailPage overview and review loop', () => {
       expect(detailRequests).toBe(1);
     });
     expect(screen.getByTestId('session-detail-loading-skeleton')).toBeInTheDocument();
-    expect(screen.queryByText('Provisional list title')).not.toBeInTheDocument();
+    // Metadata-first paint: the provisional row's title shows in the skeleton
+    // header immediately, while the data-bearing queries still wait for the
+    // authoritative payload.
+    expect(screen.getByText('Provisional list title')).toBeInTheDocument();
     expect(timelineRequests).toBe(0);
     expect(prRequests).toBe(0);
 

--- a/frontend/src/app/(dashboard)/sessions/[id]/page-overview.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/page-overview.test.tsx
@@ -128,9 +128,9 @@ describe('SessionDetailPage overview and review loop', () => {
     });
     expect(screen.getByTestId('session-detail-loading-skeleton')).toBeInTheDocument();
     // Metadata-first paint: the provisional row's title shows in the skeleton
-    // header immediately, while the data-bearing queries still wait for the
-    // authoritative payload.
-    expect(screen.getByText('Provisional list title')).toBeInTheDocument();
+    // headers (desktop and mobile) immediately, while the data-bearing
+    // queries still wait for the authoritative payload.
+    expect(screen.getAllByText('Provisional list title').length).toBeGreaterThanOrEqual(1);
     expect(timelineRequests).toBe(0);
     expect(prRequests).toBe(0);
 

--- a/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
@@ -3212,7 +3212,10 @@ export function SessionDetailContent({ id }: { id: string }) {
   const rawSession = data?.data;
   const isProvisionalSession = isProvisionalSessionDetail(rawSession);
   const session = isProvisionalSession ? undefined : rawSession;
-  usePageTitle(session ? sessionTitle(session) : null, "Session");
+  // Tab title from whatever payload is available — the provisional row's
+  // title matches what the user just clicked, so don't wait for the
+  // authoritative detail to label the tab.
+  usePageTitle(rawSession ? sessionTitle(rawSession) : null, "Session");
   const members = membersData?.data ?? [];
   const shouldLoadDiff = (
     !isProvisionalSession &&
@@ -5174,7 +5177,26 @@ export function SessionDetailContent({ id }: { id: string }) {
   });
 
   if (isLoading || (isProvisionalSession && !error)) {
-    return <SessionDetailLoadingSkeleton />;
+    // Metadata-first paint: the provisional row seeded by the sidebar (or a
+    // partially settled payload) already carries the title, status, and
+    // agent. Show those immediately and confine the shimmer to the parts we
+    // genuinely don't have yet, so opening a session never hides data the
+    // client already holds.
+    const provisionalStatus = rawSession ? getDisplayStatus(rawSession.status) : null;
+    return (
+      <SessionDetailLoadingSkeleton
+        metadata={
+          rawSession && provisionalStatus
+            ? {
+                title: sessionTitle(rawSession),
+                statusLabel: provisionalStatus.label,
+                statusColor: provisionalStatus.color,
+                agentType: rawSession.agent_type,
+              }
+            : null
+        }
+      />
+    );
   }
 
   if (error || !session) {

--- a/frontend/src/app/(dashboard)/sessions/[id]/session-detail-loading-skeleton.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/session-detail-loading-skeleton.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { render, screen, within } from "@testing-library/react";
 import { SessionDetailLoadingSkeleton } from "./session-detail-loading-skeleton";
 
 describe("SessionDetailLoadingSkeleton", () => {
@@ -27,6 +27,29 @@ describe("SessionDetailLoadingSkeleton", () => {
     const statusPill = screen.getByText("Running");
     expect(statusPill).toHaveClass("bg-primary/10", "text-primary");
     expect(screen.getByText("Claude Code")).toBeInTheDocument();
+  });
+
+  it("shows the title in the mobile top bar while the rest loads", () => {
+    render(
+      <SessionDetailLoadingSkeleton
+        metadata={{
+          title: "Fix the flaky deploy",
+          statusLabel: "Running",
+          statusColor: "bg-primary/10 text-primary",
+        }}
+      />,
+    );
+
+    const mobileBar = screen.getByTestId("session-detail-skeleton-mobile-top-bar");
+    expect(within(mobileBar).getByText("Fix the flaky deploy")).toBeInTheDocument();
+  });
+
+  it("renders an all-shimmer mobile top bar when no metadata is known", () => {
+    render(<SessionDetailLoadingSkeleton />);
+
+    const mobileBar = screen.getByTestId("session-detail-skeleton-mobile-top-bar");
+    expect(mobileBar).toBeInTheDocument();
+    expect(mobileBar).toHaveTextContent("");
   });
 
   it("keeps the conversation area as a skeleton even with metadata", () => {

--- a/frontend/src/app/(dashboard)/sessions/[id]/session-detail-loading-skeleton.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/session-detail-loading-skeleton.test.tsx
@@ -1,0 +1,45 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { SessionDetailLoadingSkeleton } from "./session-detail-loading-skeleton";
+
+describe("SessionDetailLoadingSkeleton", () => {
+  it("renders an all-shimmer header when no metadata is known", () => {
+    render(<SessionDetailLoadingSkeleton />);
+
+    expect(screen.getByTestId("session-detail-loading-skeleton")).toBeInTheDocument();
+    expect(screen.queryByRole("heading")).not.toBeInTheDocument();
+  });
+
+  it("renders known title, status, and agent in the header while the rest loads", () => {
+    render(
+      <SessionDetailLoadingSkeleton
+        metadata={{
+          title: "Fix the flaky deploy",
+          statusLabel: "Running",
+          statusColor: "bg-primary/10 text-primary",
+          agentType: "claude_code",
+        }}
+      />,
+    );
+
+    expect(screen.getByTestId("session-detail-loading-skeleton")).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Fix the flaky deploy" })).toBeInTheDocument();
+    const statusPill = screen.getByText("Running");
+    expect(statusPill).toHaveClass("bg-primary/10", "text-primary");
+    expect(screen.getByText("Claude Code")).toBeInTheDocument();
+  });
+
+  it("keeps the conversation area as a skeleton even with metadata", () => {
+    render(
+      <SessionDetailLoadingSkeleton
+        metadata={{
+          title: "Fix the flaky deploy",
+          statusLabel: "Running",
+          statusColor: "bg-primary/10 text-primary",
+        }}
+      />,
+    );
+
+    expect(screen.getByTestId("session-timeline-skeleton")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/app/(dashboard)/sessions/[id]/session-detail-loading-skeleton.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/session-detail-loading-skeleton.tsx
@@ -1,4 +1,5 @@
 import { cn } from "@/lib/utils";
+import { AgentBadge } from "@/components/agent-badge";
 
 export function SessionTimelineSkeleton() {
   const rows: { align: "left" | "right"; widths: string[] }[] = [
@@ -46,7 +47,24 @@ function SkeletonLine({ className }: { className: string }) {
   return <div className={cn("rounded bg-muted-foreground/15", className)} />;
 }
 
-export function SessionDetailLoadingSkeleton() {
+// Metadata that is already known while the rest of the page loads (from the
+// sidebar-seeded provisional cache or a settled detail payload). Rendering it
+// in the skeleton header means the user immediately sees what they opened,
+// instead of an all-shimmer page hiding data the client already has.
+// Precomputed strings (not the session object) so this component never needs
+// imports from session-detail-content — that would be an import cycle.
+export type SessionDetailSkeletonMetadata = {
+  title: string;
+  statusLabel: string;
+  statusColor: string;
+  agentType?: string | null;
+};
+
+export function SessionDetailLoadingSkeleton({
+  metadata,
+}: {
+  metadata?: SessionDetailSkeletonMetadata | null;
+}) {
   return (
     <div
       data-testid="session-detail-loading-skeleton"
@@ -55,10 +73,30 @@ export function SessionDetailLoadingSkeleton() {
     >
       <div className="flex min-w-0 flex-1 flex-col">
         <div className="hidden h-12 shrink-0 border-b border-border px-4 md:flex md:items-center md:justify-between">
-          <div className="min-w-0 flex-1 animate-pulse space-y-2">
-            <SkeletonLine className="h-4 w-2/5 max-w-[360px]" />
-            <SkeletonLine className="h-3 w-1/4 max-w-[220px]" />
-          </div>
+          {metadata ? (
+            // Mirrors the loaded header's title row (same type classes and
+            // status pill) so the swap to the real page does not shift layout.
+            <div className="flex min-w-0 flex-1 items-center gap-2">
+              <h1 className="text-sm font-medium text-foreground truncate">
+                {metadata.title}
+              </h1>
+              <span
+                className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium shrink-0 ${metadata.statusColor}`}
+              >
+                {metadata.statusLabel}
+              </span>
+              {metadata.agentType && (
+                <span className="hidden shrink-0 lg:inline-flex">
+                  <AgentBadge agentType={metadata.agentType} className="h-4 w-4" labelClassName="text-xs" />
+                </span>
+              )}
+            </div>
+          ) : (
+            <div className="min-w-0 flex-1 animate-pulse space-y-2">
+              <SkeletonLine className="h-4 w-2/5 max-w-[360px]" />
+              <SkeletonLine className="h-3 w-1/4 max-w-[220px]" />
+            </div>
+          )}
           <div className="flex shrink-0 gap-2 animate-pulse">
             <SkeletonLine className="h-8 w-8 rounded-md" />
             <SkeletonLine className="h-8 w-8 rounded-md" />

--- a/frontend/src/app/(dashboard)/sessions/[id]/session-detail-loading-skeleton.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/session-detail-loading-skeleton.tsx
@@ -72,6 +72,31 @@ export function SessionDetailLoadingSkeleton({
       className="flex h-full min-h-0 bg-background"
     >
       <div className="flex min-w-0 flex-1 flex-col">
+        {/* Mirrors MobileSessionTopBar's geometry (back button, title, two
+            icon buttons) so the swap to the real page does not shift layout.
+            The controls stay shimmer — they need session data to act — but
+            the title is real as soon as we know it. */}
+        <div
+          data-testid="session-detail-skeleton-mobile-top-bar"
+          className="flex shrink-0 items-center gap-1 border-b border-border bg-background/95 px-2 py-2 md:hidden"
+        >
+          <span className="animate-pulse">
+            <SkeletonLine className="h-9 w-9 rounded-md" />
+          </span>
+          {metadata ? (
+            <p className="min-w-0 flex-1 truncate text-sm font-medium text-foreground">
+              {metadata.title}
+            </p>
+          ) : (
+            <div className="min-w-0 flex-1 animate-pulse">
+              <SkeletonLine className="h-4 w-3/5 max-w-[240px]" />
+            </div>
+          )}
+          <span className="flex shrink-0 gap-1 animate-pulse">
+            <SkeletonLine className="h-9 w-9 rounded-md" />
+            <SkeletonLine className="h-9 w-9 rounded-md" />
+          </span>
+        </div>
         <div className="hidden h-12 shrink-0 border-b border-border px-4 md:flex md:items-center md:justify-between">
           {metadata ? (
             // Mirrors the loaded header's title row (same type classes and


### PR DESCRIPTION
## Why

Part of the session detail latency series ([#1329](https://github.com/assembledhq/143/pull/1329), [#1330](https://github.com/assembledhq/143/pull/1330)). Navigating from the sidebar already seeds the detail cache with the clicked row's data (provisional detail), but the page threw that away visually: the early return rendered a fully shimmering skeleton until the authoritative payload arrived, hiding the title/status/agent the client was already holding. "Metadata should show before the conversation" — it was available the whole time.

## What

- `SessionDetailLoadingSkeleton` accepts optional precomputed `metadata` (`title`, `statusLabel`, `statusColor`, `agentType`) and renders the real header row in place of the two shimmer bars. The markup mirrors the loaded header (same type classes and status pill), so the swap to the full page doesn't shift layout. Precomputed strings rather than the session object keep the skeleton free of imports from `session-detail-content` (import cycle).
- The early return now derives that metadata from `rawSession` (provisional or settled) via the existing `sessionTitle`/`getDisplayStatus` helpers. Shimmer stays for the conversation pane and side panel — the parts that genuinely have nothing to show.
- Browser tab title now uses the provisional payload too instead of the generic "Session".
- Updated the page-overview provisional-cache test, which previously asserted the old hide-everything behavior; the refetch semantics it guards are unchanged.

## Testing

- New skeleton unit tests: shimmer-only without metadata; real title/status pill/agent with metadata; conversation area stays skeleton.
- `page-overview`, `loading`, and skeleton suites — 31 passed. `tsc` + `eslint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)