### PR TITLE
Add stale-while-revalidate caching for session mention indexes

### DIFF
--- a/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
@@ -1133,8 +1133,25 @@ function SessionComposer({
     queryFn: () => api.sessions.composerFiles(sessionId, deferredMentionQuery),
     enabled: showMentionPicker,
     staleTime: 30 * 1000,
+    // Keep the previous query's results rendered while the next keystroke's
+    // request is in flight so the picker doesn't blank out between queries.
+    placeholderData: (previous) => previous,
   });
   const fileMentions = useMemo(() => fileMentionsQuery.data?.data ?? [], [fileMentionsQuery.data]);
+
+  const mentionWarmQueryClient = useQueryClient();
+  useEffect(() => {
+    // Warm the backend's mention index as soon as the composer mounts: the
+    // empty-q request returns [] immediately but kicks off the workspace
+    // walk server-side, so the index is (usually) hot by the time the user
+    // opens the @-picker with a real query.
+    if (!repositoryId) return;
+    void mentionWarmQueryClient.prefetchQuery({
+      queryKey: queryKeys.sessions.composerFiles(sessionId, ""),
+      queryFn: () => api.sessions.composerFiles(sessionId, ""),
+      staleTime: 30 * 1000,
+    });
+  }, [mentionWarmQueryClient, sessionId, repositoryId]);
 
   const slashCommandsQuery = useSessionComposerSlashCommands({
     agentType,

--- a/internal/api/handlers/session_composer.go
+++ b/internal/api/handlers/session_composer.go
@@ -34,6 +34,10 @@ const sessionComposerSlashCommandLimit = 30
 const sessionComposerTreeCacheTTL = 30 * time.Second
 const sessionComposerCommandContentCacheTTL = 5 * time.Minute
 
+// sessionComposerMentionWarmTimeout bounds the background mention-index
+// build kicked off by the picker-open (empty-q) warm request.
+const sessionComposerMentionWarmTimeout = 60 * time.Second
+
 type sessionComposerRepoTreeService interface {
 	GetInstallationToken(ctx context.Context, installationID int64) (string, error)
 	ListRepositoryTree(ctx context.Context, token, owner, repo, branch string) ([]models.RepositoryTreeEntry, error)
@@ -278,7 +282,7 @@ func (h *SessionComposerHandler) warmSessionMentionIndex(r *http.Request) {
 				h.logger.Warn().Interface("panic", rec).Str("session_id", sessionID.String()).Msg("panic warming session mention index")
 			}
 		}()
-		ctx, cancel := context.WithTimeout(detached, defaultMentionIndexWarmTimeout)
+		ctx, cancel := context.WithTimeout(detached, sessionComposerMentionWarmTimeout)
 		defer cancel()
 
 		session, err := h.workspace.loadSession(ctx, orgID, sessionID)
@@ -297,8 +301,6 @@ func (h *SessionComposerHandler) warmSessionMentionIndex(r *http.Request) {
 		}
 	}()
 }
-
-const defaultMentionIndexWarmTimeout = 60 * time.Second
 
 func (h *SessionComposerHandler) ListSessionFileMentions(w http.ResponseWriter, r *http.Request) {
 	query := strings.TrimSpace(r.URL.Query().Get("q"))

--- a/internal/api/handlers/session_composer.go
+++ b/internal/api/handlers/session_composer.go
@@ -245,9 +245,68 @@ func rankSessionComposerIndexEntries(query string, entries []workspace.MentionIn
 	return results
 }
 
+// sessionMentionIndexKeys returns the exact cache key for the session's
+// current workspace source plus the cross-turn stale alias. The exact key
+// drops SnapshotKey when a live container will serve the build, mirroring
+// resolveReaderForSession's source selection.
+func (h *SessionComposerHandler) sessionMentionIndexKeys(session *models.Session) (string, string) {
+	cacheSession := *session
+	if session.ContainerID != nil && *session.ContainerID != "" && h.workspace.fileReader != nil {
+		cacheSession.SnapshotKey = nil
+	}
+	return workspace.SessionMentionIndexCacheKey(&cacheSession), workspace.SessionMentionIndexStaleCacheKey(session)
+}
+
+// warmSessionMentionIndex builds the session's mention index in the
+// background so a subsequent non-empty query is served from cache. Invoked
+// from the empty-q request the composer fires as soon as the @-picker opens
+// (and from the composer-mount prefetch), so the ~seconds-long workspace walk
+// overlaps with the user typing instead of blocking the first ranked
+// response. Best-effort: every failure is silent because the caller has
+// already responded.
+func (h *SessionComposerHandler) warmSessionMentionIndex(r *http.Request) {
+	sessionID, err := uuid.Parse(chi.URLParam(r, "id"))
+	if err != nil {
+		return
+	}
+	orgID := middleware.OrgIDFromContext(r.Context())
+	detached := context.WithoutCancel(r.Context())
+
+	go func() {
+		defer func() {
+			if rec := recover(); rec != nil {
+				h.logger.Warn().Interface("panic", rec).Str("session_id", sessionID.String()).Msg("panic warming session mention index")
+			}
+		}()
+		ctx, cancel := context.WithTimeout(detached, defaultMentionIndexWarmTimeout)
+		defer cancel()
+
+		session, err := h.workspace.loadSession(ctx, orgID, sessionID)
+		if err != nil {
+			return
+		}
+		reader, _, err := h.workspace.resolveReaderForSession(ctx, &session)
+		if err != nil {
+			return
+		}
+		cacheKey, staleKey := h.sessionMentionIndexKeys(&session)
+		if _, _, err := h.mentionIndexes.GetOrBuildStale(ctx, cacheKey, staleKey, func(ctx context.Context) (workspace.MentionIndex, error) {
+			return workspace.BuildMentionIndex(ctx, reader)
+		}); err != nil {
+			h.logger.Debug().Err(err).Str("session_id", sessionID.String()).Msg("failed to warm session mention index")
+		}
+	}()
+}
+
+const defaultMentionIndexWarmTimeout = 60 * time.Second
+
 func (h *SessionComposerHandler) ListSessionFileMentions(w http.ResponseWriter, r *http.Request) {
 	query := strings.TrimSpace(r.URL.Query().Get("q"))
 	if query == "" {
+		// The composer fires an empty-q request the moment the @-picker
+		// opens; use it to start building the index before the first
+		// character of the actual query arrives.
+		h.warmSessionMentionIndex(r)
 		writeJSON(w, http.StatusOK, models.ListResponse[models.SessionInputReference]{Data: []models.SessionInputReference{}})
 		return
 	}
@@ -278,12 +337,8 @@ func (h *SessionComposerHandler) ListSessionFileMentions(w http.ResponseWriter, 
 		return
 	}
 
-	cacheSession := session
-	if session.ContainerID != nil && *session.ContainerID != "" && h.workspace.fileReader != nil {
-		cacheSession.SnapshotKey = nil
-	}
-	cacheKey := workspace.SessionMentionIndexCacheKey(&cacheSession)
-	index, err := h.mentionIndexes.GetOrBuild(r.Context(), cacheKey, func(ctx context.Context) (workspace.MentionIndex, error) {
+	cacheKey, staleKey := h.sessionMentionIndexKeys(&session)
+	index, stale, err := h.mentionIndexes.GetOrBuildStale(r.Context(), cacheKey, staleKey, func(ctx context.Context) (workspace.MentionIndex, error) {
 		return workspace.BuildMentionIndex(ctx, reader)
 	})
 	if err != nil {
@@ -297,6 +352,9 @@ func (h *SessionComposerHandler) ListSessionFileMentions(w http.ResponseWriter, 
 			writeError(w, r, http.StatusInternalServerError, "SNAPSHOT_UNAVAILABLE", "session workspace could not be loaded")
 		}
 		return
+	}
+	if stale {
+		h.logger.Debug().Str("session_id", sessionID.String()).Msg("served stale session mention index while refreshing in background")
 	}
 
 	writeJSON(w, http.StatusOK, models.ListResponse[models.SessionInputReference]{

--- a/internal/api/handlers/session_composer_test.go
+++ b/internal/api/handlers/session_composer_test.go
@@ -427,6 +427,67 @@ func TestSessionComposerHandler_ListSessionFileMentions(t *testing.T) {
 		require.NoError(t, mock.ExpectationsWereMet(), "database expectations should be met")
 	})
 
+	t.Run("serves the cross-turn stale index immediately while refreshing in the background", func(t *testing.T) {
+		t.Parallel()
+
+		mock, err := pgxmock.NewPool()
+		require.NoError(t, err, "pgxmock pool should be created")
+		defer mock.Close()
+
+		orgID := uuid.New()
+		sessionID := uuid.New()
+		containerID := "ctr-live-stale"
+		setupSessionMockWithSnapshot(mock, orgID, sessionID, &containerID, nil)
+
+		// Block the live workspace walk so the test fails (times out the
+		// request assertion below) if the handler tries a synchronous
+		// rebuild instead of serving the warmed alias.
+		buildRelease := make(chan struct{})
+		defer close(buildRelease)
+		handler := NewSessionComposerHandlerWithWorkspace(
+			nil,
+			db.NewSessionStore(mock),
+			nil,
+			&mockFileReader{
+				listDirFn: func(ctx context.Context, gotContainerID, workDir, dirPath string) ([]sandbox.FileEntry, error) {
+					select {
+					case <-buildRelease:
+					case <-ctx.Done():
+					}
+					return []sandbox.FileEntry{}, nil
+				},
+			},
+			nil,
+			nil,
+			zerolog.Nop(),
+		)
+
+		// Simulate the orchestrator's turn-complete warm of the session
+		// alias; the exact live key (turn/generation churn) is left cold.
+		staleSession := models.Session{ID: sessionID, OrgID: orgID}
+		err = handler.mentionIndexes.Warm(context.Background(), workspace.SessionMentionIndexStaleCacheKey(&staleSession), workspace.MentionIndex{
+			Entries: []workspace.MentionIndexEntry{
+				{Kind: string(models.SessionInputReferenceKindFile), Path: "docs/from-previous-turn.md"},
+			},
+		})
+		require.NoError(t, err, "stale alias mention index should warm successfully")
+
+		req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/api/v1/sessions/%s/composer/files?q=previous", sessionID), nil)
+		req = req.WithContext(middleware.WithOrgID(req.Context(), orgID))
+		w := httptest.NewRecorder()
+
+		withSessionComposerRoute(handler.ListSessionFileMentions).ServeHTTP(w, req)
+		require.Equal(t, http.StatusOK, w.Code, "mention search should serve the stale alias without waiting for a rebuild")
+
+		var resp models.ListResponse[models.SessionInputReference]
+		err = json.Unmarshal(w.Body.Bytes(), &resp)
+		require.NoError(t, err, "response should decode")
+		require.Equal(t, []models.SessionInputReference{
+			{Kind: models.SessionInputReferenceKindFile, Token: "@docs/from-previous-turn.md", Path: "docs/from-previous-turn.md", Display: "docs/from-previous-turn.md"},
+		}, resp.Data, "mention search should return the previous turn's index when the exact key is cold")
+		require.NoError(t, mock.ExpectationsWereMet(), "database expectations should be met")
+	})
+
 	t.Run("returns NO_SANDBOX when the referenced snapshot is missing", func(t *testing.T) {
 		t.Parallel()
 

--- a/internal/api/handlers/session_composer_test.go
+++ b/internal/api/handlers/session_composer_test.go
@@ -488,6 +488,60 @@ func TestSessionComposerHandler_ListSessionFileMentions(t *testing.T) {
 		require.NoError(t, mock.ExpectationsWereMet(), "database expectations should be met")
 	})
 
+	t.Run("warms the mention index in the background on the picker-open empty query", func(t *testing.T) {
+		t.Parallel()
+
+		mock, err := pgxmock.NewPool()
+		require.NoError(t, err, "pgxmock pool should be created")
+		defer mock.Close()
+
+		orgID := uuid.New()
+		sessionID := uuid.New()
+		containerID := "ctr-warm"
+		setupSessionMockWithSnapshot(mock, orgID, sessionID, &containerID, nil)
+
+		handler := NewSessionComposerHandlerWithWorkspace(
+			nil,
+			db.NewSessionStore(mock),
+			nil,
+			&mockFileReader{
+				listDirFn: func(ctx context.Context, gotContainerID, workDir, dirPath string) ([]sandbox.FileEntry, error) {
+					if dirPath == "." {
+						return []sandbox.FileEntry{{Type: "file", Path: "docs/warmed.md"}}, nil
+					}
+					return []sandbox.FileEntry{}, nil
+				},
+			},
+			nil,
+			nil,
+			zerolog.Nop(),
+		)
+
+		req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/api/v1/sessions/%s/composer/files?q=", sessionID), nil)
+		req = req.WithContext(middleware.WithOrgID(req.Context(), orgID))
+		w := httptest.NewRecorder()
+
+		withSessionComposerRoute(handler.ListSessionFileMentions).ServeHTTP(w, req)
+		require.Equal(t, http.StatusOK, w.Code, "the empty-q warm request should respond immediately")
+
+		var resp models.ListResponse[models.SessionInputReference]
+		err = json.Unmarshal(w.Body.Bytes(), &resp)
+		require.NoError(t, err, "response should decode")
+		require.Empty(t, resp.Data, "the empty-q request should return no suggestions")
+
+		// The warm runs after the response; probe the cache via the stale
+		// alias with a builder that fails, so the probe only succeeds once
+		// the background build has populated the cache.
+		staleKey := workspace.SessionMentionIndexStaleCacheKey(&models.Session{ID: sessionID, OrgID: orgID})
+		require.Eventually(t, func() bool {
+			index, err := handler.mentionIndexes.GetOrBuild(context.Background(), staleKey, func(ctx context.Context) (workspace.MentionIndex, error) {
+				return workspace.MentionIndex{}, context.DeadlineExceeded
+			})
+			return err == nil && len(index.Entries) == 1 && index.Entries[0].Path == "docs/warmed.md"
+		}, 5*time.Second, 10*time.Millisecond, "the empty-q request should build the mention index in the background")
+		require.NoError(t, mock.ExpectationsWereMet(), "the warm should have loaded the session")
+	})
+
 	t.Run("returns NO_SANDBOX when the referenced snapshot is missing", func(t *testing.T) {
 		t.Parallel()
 

--- a/internal/services/agent/orchestrator.go
+++ b/internal/services/agent/orchestrator.go
@@ -37,7 +37,13 @@ import (
 
 const (
 	defaultMaxConcurrent    = 10
-	mentionIndexWarmTimeout = 2 * time.Second
+	// mentionIndexWarmTimeout bounds the proactive mention-index build at
+	// turn-complete. The build walks the whole workspace through a Docker
+	// exec and takes several seconds on large repos; the warm always runs
+	// off the request path (async goroutine or post-terminal cleanup), so a
+	// generous budget costs nothing and an undersized one silently produces
+	// a cold cache for the composer's @-mention picker.
+	mentionIndexWarmTimeout = 60 * time.Second
 	planModePrefix          = "[PLAN_MODE]\n"
 
 	// Claude Code access tokens are short-lived. A sandbox credential with an
@@ -924,6 +930,13 @@ func (o *Orchestrator) warmMentionIndexFromSandbox(ctx context.Context, session 
 	}
 	if err := o.mentionIndexes.Warm(ctx, workspace.SessionMentionIndexCacheKey(&cacheSession), index); err != nil {
 		log.Warn().Err(err).Str("snapshot_key", snapshotKey).Msg("failed to warm proactive mention index")
+	}
+	// Also warm the cross-turn stale alias. The exact key above is
+	// snapshot-flavored and the composer handler looks up a live-flavored
+	// key while the container is still running, so without the alias this
+	// warm never reaches the @-mention picker's cache lookups.
+	if err := o.mentionIndexes.Warm(ctx, workspace.SessionMentionIndexStaleCacheKey(&cacheSession), index); err != nil {
+		log.Warn().Err(err).Str("snapshot_key", snapshotKey).Msg("failed to warm proactive mention index alias")
 	}
 }
 

--- a/internal/services/sandbox/docker_filereader.go
+++ b/internal/services/sandbox/docker_filereader.go
@@ -154,25 +154,24 @@ func (d *DockerFileReader) ListDirRecursive(ctx context.Context, containerID, wo
 	return appendFindEntries(nil, absPath, stdout, maxEntries), nil
 }
 
+// recursiveFindScript labels each path as dir/file via two find passes piped
+// through sed, instead of one pass through a shell while-read loop. The shell
+// loop cost ~100µs per entry in busybox ash (read + stat + printf per line),
+// which is multiple seconds on 50k+ entry workspaces; sed processes the same
+// stream at C speed. The root dir itself is emitted by the -type d pass and
+// filtered out by appendFindEntries. The sed replacements contain a literal
+// tab to match the "kind\tpath" wire format.
 const recursiveFindScript = `root=$1
 limit=$2
 shift 2
-count=0
-find "$root" "$@" \( -type d -o -type f \) -print | while IFS= read -r path; do
-  if [ "$path" = "$root" ]; then
-    continue
-  fi
-  if [ "$limit" -gt 0 ] && [ "$count" -ge "$limit" ]; then
-    break
-  fi
-  count=$((count + 1))
-  if [ -d "$path" ]; then
-    kind=dir
-  else
-    kind=file
-  fi
-  printf '%s\t%s\n' "$kind" "$path"
-done`
+if [ "$limit" -le 0 ]; then
+  limit=2147483646
+fi
+limit=$((limit + 1))
+{
+  find "$root" "$@" -type d -print | sed "s|^|dir	|"
+  find "$root" "$@" -type f -print | sed "s|^|file	|"
+} | head -n "$limit"`
 
 func recursiveFindArgv(absPath string, ignoredDirNames []string, maxEntries int) []string {
 	argv := []string{"sh", "-c", recursiveFindScript, "find-recursive", absPath, strconv.Itoa(maxEntries)}

--- a/internal/services/sandbox/docker_filereader_test.go
+++ b/internal/services/sandbox/docker_filereader_test.go
@@ -7,6 +7,9 @@ import (
 	"encoding/binary"
 	"fmt"
 	"net"
+	"os"
+	"os/exec"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -229,6 +232,53 @@ func TestDockerFileReader_ListDir(t *testing.T) {
 			require.NoError(t, err, "ListDir should not return an error")
 			require.Equal(t, tt.expected, entries, "ListDir should return the expected entries")
 		})
+	}
+}
+
+// TestRecursiveFindScript_RealShell runs the actual script through a real
+// shell against a temp tree, since the Docker-level tests only assert against
+// mocked exec output. Guards the busybox-portable pieces: positional arg
+// handling after shift, prune args via "$@", literal-tab sed labels, and the
+// head-based entry cap.
+func TestRecursiveFindScript_RealShell(t *testing.T) {
+	t.Parallel()
+
+	if _, err := exec.LookPath("sh"); err != nil {
+		t.Skip("sh not available on this host")
+	}
+
+	root := t.TempDir()
+	for _, dir := range []string{"docs", "src", "node_modules/pkg"} {
+		require.NoError(t, os.MkdirAll(filepath.Join(root, dir), 0o755), "test tree directories should be created")
+	}
+	for _, file := range []string{"README.md", "docs/guide.md", "src/app.ts", "node_modules/pkg/index.js"} {
+		require.NoError(t, os.WriteFile(filepath.Join(root, file), nil, 0o644), "test tree files should be created")
+	}
+
+	run := func(maxEntries int) []FileEntry {
+		argv := recursiveFindArgv(root, []string{"node_modules", ".git"}, maxEntries)
+		out, err := exec.Command(argv[0], argv[1:]...).Output()
+		require.NoError(t, err, "recursive find script should exit zero")
+		return appendFindEntries(nil, root, string(out), maxEntries)
+	}
+
+	unlimited := run(0)
+	byPath := map[string]string{}
+	for _, entry := range unlimited {
+		byPath[entry.Path] = entry.Type
+	}
+	require.Equal(t, map[string]string{
+		"docs":          "dir",
+		"src":           "dir",
+		"README.md":     "file",
+		"docs/guide.md": "file",
+		"src/app.ts":    "file",
+	}, byPath, "the script should label kinds, exclude the root itself, and prune ignored directories")
+
+	capped := run(3)
+	require.Len(t, capped, 3, "the head-based cap should bound the entry count")
+	for _, entry := range capped {
+		require.NotContains(t, entry.Path, "node_modules", "pruned directories should never appear in capped output")
 	}
 }
 

--- a/internal/services/workspace/mention_index.go
+++ b/internal/services/workspace/mention_index.go
@@ -242,6 +242,20 @@ func clampMentionIndexBlob(index MentionIndex, maxBlobBytes int) (MentionIndex, 
 	return index, nil
 }
 
+// SessionMentionIndexStaleCacheKey identifies the most recently built index
+// for a session regardless of which container, snapshot, turn, or workspace
+// generation produced it. The exact key (SessionMentionIndexCacheKey) churns
+// on every completed turn, so the picker would otherwise pay a full rebuild
+// each time the composer is opened; this alias lets the handler serve the
+// previous turn's index immediately while a background refresh repopulates
+// the exact key.
+func SessionMentionIndexStaleCacheKey(session *models.Session) string {
+	if session == nil {
+		return "session-mention-index:v1:unknown:latest"
+	}
+	return fmt.Sprintf("session-mention-index:v1:%s:%s:latest", session.OrgID, session.ID)
+}
+
 func SessionMentionIndexCacheKey(session *models.Session) string {
 	if session == nil {
 		return "session-mention-index:v1:unknown"

--- a/internal/services/workspace/mention_index_cache.go
+++ b/internal/services/workspace/mention_index_cache.go
@@ -17,19 +17,24 @@ import (
 
 const defaultMentionIndexRedisTTL = 24 * time.Hour
 const defaultMentionIndexLocalMaxItems = 128
+const defaultMentionIndexRefreshTimeout = 60 * time.Second
 
 type MentionIndexCacheConfig struct {
 	Redis         *cache.Client
 	Logger        zerolog.Logger
 	RedisTTL      time.Duration
 	LocalMaxItems int
+	// RefreshTimeout bounds background rebuilds kicked off by
+	// GetOrBuildStale and RefreshInBackground.
+	RefreshTimeout time.Duration
 }
 
 type MentionIndexCache struct {
-	redis         *cache.Client
-	logger        zerolog.Logger
-	redisTTL      time.Duration
-	localMaxItems int
+	redis          *cache.Client
+	logger         zerolog.Logger
+	redisTTL       time.Duration
+	localMaxItems  int
+	refreshTimeout time.Duration
 
 	mu      sync.Mutex
 	entries map[string]*list.Element
@@ -49,13 +54,17 @@ func NewMentionIndexCache(cfg MentionIndexCacheConfig) *MentionIndexCache {
 	if cfg.LocalMaxItems <= 0 {
 		cfg.LocalMaxItems = defaultMentionIndexLocalMaxItems
 	}
+	if cfg.RefreshTimeout <= 0 {
+		cfg.RefreshTimeout = defaultMentionIndexRefreshTimeout
+	}
 	return &MentionIndexCache{
-		redis:         cfg.Redis,
-		logger:        cfg.Logger,
-		redisTTL:      cfg.RedisTTL,
-		localMaxItems: cfg.LocalMaxItems,
-		entries:       make(map[string]*list.Element),
-		lru:           list.New(),
+		redis:          cfg.Redis,
+		logger:         cfg.Logger,
+		redisTTL:       cfg.RedisTTL,
+		localMaxItems:  cfg.LocalMaxItems,
+		refreshTimeout: cfg.RefreshTimeout,
+		entries:        make(map[string]*list.Element),
+		lru:            list.New(),
 	}
 }
 
@@ -93,6 +102,114 @@ func (c *MentionIndexCache) GetOrBuild(ctx context.Context, key string, build fu
 		return MentionIndex{}, err
 	}
 	return value.(MentionIndex), nil
+}
+
+// GetOrBuildStale is GetOrBuild with stale-while-revalidate semantics. When
+// the exact key misses but staleKey (a session-scoped alias maintained across
+// turns) holds a previously built index, the stale index is returned
+// immediately and a background rebuild repopulates the exact key. The bool
+// result reports whether the returned index was stale.
+func (c *MentionIndexCache) GetOrBuildStale(ctx context.Context, key, staleKey string, build func(context.Context) (MentionIndex, error)) (MentionIndex, bool, error) {
+	if key == "" {
+		return MentionIndex{}, false, errors.New("mention index cache key is required")
+	}
+	if build == nil {
+		return MentionIndex{}, false, errors.New("mention index builder is required")
+	}
+
+	if index, ok := c.getLocal(key); ok {
+		return index, false, nil
+	}
+
+	type lookupResult struct {
+		index MentionIndex
+		stale bool
+	}
+
+	value, err, _ := c.sf.Do(key, func() (interface{}, error) {
+		if index, ok := c.getLocal(key); ok {
+			return lookupResult{index: index}, nil
+		}
+		if index, ok := c.getShared(ctx, key); ok {
+			c.putLocal(key, index)
+			return lookupResult{index: index}, nil
+		}
+		if staleKey != "" {
+			if index, ok := c.getLocal(staleKey); ok {
+				c.RefreshInBackground(key, staleKey, build)
+				return lookupResult{index: index, stale: true}, nil
+			}
+			if index, ok := c.getShared(ctx, staleKey); ok {
+				c.putLocal(staleKey, index)
+				c.RefreshInBackground(key, staleKey, build)
+				return lookupResult{index: index, stale: true}, nil
+			}
+		}
+		index, err := build(ctx)
+		if err != nil {
+			return lookupResult{}, err
+		}
+		c.store(ctx, key, staleKey, index)
+		return lookupResult{index: index}, nil
+	})
+	if err != nil {
+		return MentionIndex{}, false, err
+	}
+	result := value.(lookupResult)
+	return result.index, result.stale, nil
+}
+
+// RefreshInBackground rebuilds the index for key on a detached context and
+// stores it under both key and staleKey. Concurrent refreshes for the same
+// key coalesce via singleflight, and the rebuild is skipped entirely when the
+// key is already cached (locally or in Redis), so callers may invoke this on
+// every stale serve without stampeding the workspace reader.
+func (c *MentionIndexCache) RefreshInBackground(key, staleKey string, build func(context.Context) (MentionIndex, error)) {
+	if c == nil || key == "" || build == nil {
+		return
+	}
+	go func() {
+		defer func() {
+			if r := recover(); r != nil {
+				c.logger.Warn().Interface("panic", r).Str("key", key).Msg("panic refreshing mention index in background")
+			}
+		}()
+		ctx, cancel := context.WithTimeout(context.Background(), c.refreshTimeout)
+		defer cancel()
+		_, _, _ = c.sf.Do("refresh:"+key, func() (interface{}, error) {
+			if _, ok := c.getLocal(key); ok {
+				return nil, nil
+			}
+			if index, ok := c.getShared(ctx, key); ok {
+				c.putLocal(key, index)
+				return nil, nil
+			}
+			index, err := build(ctx)
+			if err != nil {
+				c.logger.Warn().Err(err).Str("key", key).Msg("failed to refresh mention index in background")
+				return nil, nil
+			}
+			c.store(ctx, key, staleKey, index)
+			return nil, nil
+		})
+	}()
+}
+
+// store writes the index under the exact key and, when set, the stale alias,
+// in both the local LRU and the shared Redis cache. Shared-cache write
+// failures are logged but never surfaced — the caller already has the index.
+func (c *MentionIndexCache) store(ctx context.Context, key, staleKey string, index MentionIndex) {
+	c.putLocal(key, index)
+	if err := c.putShared(ctx, key, index); err != nil {
+		c.logger.Warn().Err(err).Str("key", key).Msg("failed to write rebuilt mention index to shared cache")
+	}
+	if staleKey == "" || staleKey == key {
+		return
+	}
+	c.putLocal(staleKey, index)
+	if err := c.putShared(ctx, staleKey, index); err != nil {
+		c.logger.Warn().Err(err).Str("key", staleKey).Msg("failed to write rebuilt mention index to shared cache")
+	}
 }
 
 func (c *MentionIndexCache) Warm(ctx context.Context, key string, index MentionIndex) error {

--- a/internal/services/workspace/mention_index_cache.go
+++ b/internal/services/workspace/mention_index_cache.go
@@ -19,13 +19,20 @@ const defaultMentionIndexRedisTTL = 24 * time.Hour
 const defaultMentionIndexLocalMaxItems = 128
 const defaultMentionIndexRefreshTimeout = 60 * time.Second
 
+// mentionIndexRefreshFailureBackoff suppresses repeated background rebuild
+// attempts for a key after one fails. Without it, every stale serve against
+// a workspace that can no longer be read (e.g. a reaped container) would
+// spawn a doomed rebuild. Keyed by the exact cache key, which churns each
+// turn, so a new turn always gets a fresh attempt.
+const mentionIndexRefreshFailureBackoff = 30 * time.Second
+
 type MentionIndexCacheConfig struct {
 	Redis         *cache.Client
 	Logger        zerolog.Logger
 	RedisTTL      time.Duration
 	LocalMaxItems int
-	// RefreshTimeout bounds background rebuilds kicked off by
-	// GetOrBuildStale and RefreshInBackground.
+	// RefreshTimeout bounds the background rebuilds GetOrBuildStale kicks
+	// off when it serves a stale index.
 	RefreshTimeout time.Duration
 }
 
@@ -36,10 +43,11 @@ type MentionIndexCache struct {
 	localMaxItems  int
 	refreshTimeout time.Duration
 
-	mu      sync.Mutex
-	entries map[string]*list.Element
-	lru     *list.List
-	sf      singleflight.Group
+	mu              sync.Mutex
+	entries         map[string]*list.Element
+	lru             *list.List
+	refreshFailures map[string]time.Time
+	sf              singleflight.Group
 }
 
 type mentionIndexCacheEntry struct {
@@ -58,13 +66,14 @@ func NewMentionIndexCache(cfg MentionIndexCacheConfig) *MentionIndexCache {
 		cfg.RefreshTimeout = defaultMentionIndexRefreshTimeout
 	}
 	return &MentionIndexCache{
-		redis:          cfg.Redis,
-		logger:         cfg.Logger,
-		redisTTL:       cfg.RedisTTL,
-		localMaxItems:  cfg.LocalMaxItems,
-		refreshTimeout: cfg.RefreshTimeout,
-		entries:        make(map[string]*list.Element),
-		lru:            list.New(),
+		redis:           cfg.Redis,
+		logger:          cfg.Logger,
+		redisTTL:        cfg.RedisTTL,
+		localMaxItems:   cfg.LocalMaxItems,
+		refreshTimeout:  cfg.RefreshTimeout,
+		entries:         make(map[string]*list.Element),
+		lru:             list.New(),
+		refreshFailures: make(map[string]time.Time),
 	}
 }
 
@@ -136,12 +145,12 @@ func (c *MentionIndexCache) GetOrBuildStale(ctx context.Context, key, staleKey s
 		}
 		if staleKey != "" {
 			if index, ok := c.getLocal(staleKey); ok {
-				c.RefreshInBackground(key, staleKey, build)
+				c.refreshInBackground(key, staleKey, build)
 				return lookupResult{index: index, stale: true}, nil
 			}
 			if index, ok := c.getShared(ctx, staleKey); ok {
 				c.putLocal(staleKey, index)
-				c.RefreshInBackground(key, staleKey, build)
+				c.refreshInBackground(key, staleKey, build)
 				return lookupResult{index: index, stale: true}, nil
 			}
 		}
@@ -159,13 +168,17 @@ func (c *MentionIndexCache) GetOrBuildStale(ctx context.Context, key, staleKey s
 	return result.index, result.stale, nil
 }
 
-// RefreshInBackground rebuilds the index for key on a detached context and
+// refreshInBackground rebuilds the index for key on a detached context and
 // stores it under both key and staleKey. Concurrent refreshes for the same
-// key coalesce via singleflight, and the rebuild is skipped entirely when the
-// key is already cached (locally or in Redis), so callers may invoke this on
+// key coalesce via singleflight, the rebuild is skipped entirely when the
+// key is already cached (locally or in Redis), and a failed rebuild backs
+// off for mentionIndexRefreshFailureBackoff — so callers may invoke this on
 // every stale serve without stampeding the workspace reader.
-func (c *MentionIndexCache) RefreshInBackground(key, staleKey string, build func(context.Context) (MentionIndex, error)) {
+func (c *MentionIndexCache) refreshInBackground(key, staleKey string, build func(context.Context) (MentionIndex, error)) {
 	if c == nil || key == "" || build == nil {
+		return
+	}
+	if c.refreshRecentlyFailed(key, time.Now()) {
 		return
 	}
 	go func() {
@@ -187,12 +200,40 @@ func (c *MentionIndexCache) RefreshInBackground(key, staleKey string, build func
 			index, err := build(ctx)
 			if err != nil {
 				c.logger.Warn().Err(err).Str("key", key).Msg("failed to refresh mention index in background")
+				c.recordRefreshFailure(key, time.Now())
 				return nil, nil
 			}
+			c.clearRefreshFailure(key)
 			c.store(ctx, key, staleKey, index)
 			return nil, nil
 		})
 	}()
+}
+
+func (c *MentionIndexCache) refreshRecentlyFailed(key string, now time.Time) bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	failedAt, ok := c.refreshFailures[key]
+	return ok && now.Sub(failedAt) < mentionIndexRefreshFailureBackoff
+}
+
+func (c *MentionIndexCache) recordRefreshFailure(key string, now time.Time) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	// Prune expired entries while we hold the lock so the map stays bounded
+	// by the number of keys that failed within the backoff window.
+	for k, failedAt := range c.refreshFailures {
+		if now.Sub(failedAt) >= mentionIndexRefreshFailureBackoff {
+			delete(c.refreshFailures, k)
+		}
+	}
+	c.refreshFailures[key] = now
+}
+
+func (c *MentionIndexCache) clearRefreshFailure(key string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	delete(c.refreshFailures, key)
 }
 
 // store writes the index under the exact key and, when set, the stale alias,

--- a/internal/services/workspace/mention_index_test.go
+++ b/internal/services/workspace/mention_index_test.go
@@ -2,6 +2,7 @@ package workspace
 
 import (
 	"context"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -180,6 +181,100 @@ func TestSessionMentionIndexCacheKey_LiveWorkspaceUsesGenerationNotActivity(t *t
 
 	second.WorkspaceGeneration = 13
 	require.NotEqual(t, SessionMentionIndexCacheKey(first), SessionMentionIndexCacheKey(&second), "live mention index keys should change when the workspace generation changes")
+}
+
+func TestSessionMentionIndexStaleCacheKey_StableAcrossTurnsAndSources(t *testing.T) {
+	t.Parallel()
+
+	orgID := uuid.New()
+	sessionID := uuid.New()
+	containerID := "ctr-live"
+	snapshotKey := "snapshots/o/s/workspace.tar.zst"
+
+	live := &models.Session{ID: sessionID, OrgID: orgID, ContainerID: &containerID, CurrentTurn: 4, WorkspaceGeneration: 12}
+	nextTurn := *live
+	nextTurn.CurrentTurn = 5
+	nextTurn.WorkspaceGeneration = 13
+	snapshotted := &models.Session{ID: sessionID, OrgID: orgID, SnapshotKey: &snapshotKey}
+
+	require.NotEqual(t, SessionMentionIndexCacheKey(live), SessionMentionIndexCacheKey(&nextTurn), "exact keys churn across turns by design")
+	require.Equal(t, SessionMentionIndexStaleCacheKey(live), SessionMentionIndexStaleCacheKey(&nextTurn), "stale alias must survive turn and generation churn")
+	require.Equal(t, SessionMentionIndexStaleCacheKey(live), SessionMentionIndexStaleCacheKey(snapshotted), "stale alias must be identical for live and snapshot workspace sources")
+}
+
+func TestMentionIndexCache_GetOrBuildStale_ServesStaleAliasAndRefreshes(t *testing.T) {
+	t.Parallel()
+
+	c := NewMentionIndexCache(MentionIndexCacheConfig{Logger: zerolog.Nop()})
+
+	staleKey := "session-mention-index:v1:o:s:latest"
+	exactKey := "session-mention-index:v1:o:s:live:ctr:turn:5:workspace:9"
+	staleIndex := MentionIndex{Entries: []MentionIndexEntry{{Kind: "file", Path: "old/path.go"}}}
+	freshIndex := MentionIndex{Entries: []MentionIndexEntry{{Kind: "file", Path: "new/path.go"}}}
+
+	require.NoError(t, c.Warm(context.Background(), staleKey, staleIndex), "warming the stale alias should succeed")
+
+	buildRelease := make(chan struct{})
+	var buildCalls atomic.Int32
+	build := func(ctx context.Context) (MentionIndex, error) {
+		buildCalls.Add(1)
+		<-buildRelease
+		return freshIndex, nil
+	}
+
+	got, stale, err := c.GetOrBuildStale(context.Background(), exactKey, staleKey, build)
+	require.NoError(t, err, "stale lookup should not error")
+	require.True(t, stale, "an exact-key miss with a warm alias should be reported as stale")
+	require.Equal(t, staleIndex, got, "the stale alias index should be returned immediately without waiting for the build")
+
+	close(buildRelease)
+	require.Eventually(t, func() bool {
+		index, ok := c.getLocal(exactKey)
+		return ok && len(index.Entries) == 1 && index.Entries[0].Path == "new/path.go"
+	}, 5*time.Second, 10*time.Millisecond, "the background refresh should repopulate the exact key")
+	require.Eventually(t, func() bool {
+		index, ok := c.getLocal(staleKey)
+		return ok && len(index.Entries) == 1 && index.Entries[0].Path == "new/path.go"
+	}, 5*time.Second, 10*time.Millisecond, "the background refresh should also update the stale alias")
+	require.Equal(t, int32(1), buildCalls.Load(), "the refresh should build exactly once")
+
+	got, stale, err = c.GetOrBuildStale(context.Background(), exactKey, staleKey, func(ctx context.Context) (MentionIndex, error) {
+		t.Error("builder should not run once the exact key is fresh")
+		return MentionIndex{}, nil
+	})
+	require.NoError(t, err, "fresh lookup should not error")
+	require.False(t, stale, "a fresh exact-key hit should not be reported as stale")
+	require.Equal(t, freshIndex, got, "subsequent lookups should serve the refreshed index")
+}
+
+func TestMentionIndexCache_GetOrBuildStale_BuildsSynchronouslyWhenCold(t *testing.T) {
+	t.Parallel()
+
+	c := NewMentionIndexCache(MentionIndexCacheConfig{Logger: zerolog.Nop()})
+
+	staleKey := "session-mention-index:v1:o:s2:latest"
+	firstKey := "session-mention-index:v1:o:s2:live:ctr:turn:1:workspace:1"
+	secondKey := "session-mention-index:v1:o:s2:live:ctr:turn:2:workspace:2"
+	built := MentionIndex{Entries: []MentionIndexEntry{{Kind: "file", Path: "a.go"}}}
+
+	got, stale, err := c.GetOrBuildStale(context.Background(), firstKey, staleKey, func(ctx context.Context) (MentionIndex, error) {
+		return built, nil
+	})
+	require.NoError(t, err, "cold build should succeed")
+	require.False(t, stale, "a synchronous cold build is not stale")
+	require.Equal(t, built, got, "cold build should return the built index")
+
+	// A new exact key (turn churn) must be served from the alias the cold
+	// build populated, without blocking on the rebuild.
+	blocked := make(chan struct{})
+	t.Cleanup(func() { close(blocked) })
+	got, stale, err = c.GetOrBuildStale(context.Background(), secondKey, staleKey, func(ctx context.Context) (MentionIndex, error) {
+		<-blocked
+		return built, nil
+	})
+	require.NoError(t, err, "stale lookup after turn churn should not error")
+	require.True(t, stale, "turn churn should be absorbed by the stale alias")
+	require.Equal(t, built, got, "the alias should serve the previous turn's index")
 }
 
 func TestMentionIndexCache_GetOrBuild_UsesRedisAndLocalHotCache(t *testing.T) {

--- a/internal/services/workspace/mention_index_test.go
+++ b/internal/services/workspace/mention_index_test.go
@@ -277,6 +277,41 @@ func TestMentionIndexCache_GetOrBuildStale_BuildsSynchronouslyWhenCold(t *testin
 	require.Equal(t, built, got, "the alias should serve the previous turn's index")
 }
 
+func TestMentionIndexCache_GetOrBuildStale_BacksOffAfterFailedRefresh(t *testing.T) {
+	t.Parallel()
+
+	c := NewMentionIndexCache(MentionIndexCacheConfig{Logger: zerolog.Nop()})
+
+	staleKey := "session-mention-index:v1:o:s3:latest"
+	exactKey := "session-mention-index:v1:o:s3:live:ctr:turn:3:workspace:3"
+	staleIndex := MentionIndex{Entries: []MentionIndexEntry{{Kind: "file", Path: "old.go"}}}
+	require.NoError(t, c.Warm(context.Background(), staleKey, staleIndex), "warming the stale alias should succeed")
+
+	var buildCalls atomic.Int32
+	failingBuild := func(ctx context.Context) (MentionIndex, error) {
+		buildCalls.Add(1)
+		return MentionIndex{}, context.DeadlineExceeded
+	}
+
+	got, stale, err := c.GetOrBuildStale(context.Background(), exactKey, staleKey, failingBuild)
+	require.NoError(t, err, "the stale serve should succeed even though the refresh will fail")
+	require.True(t, stale, "the alias should be served while the refresh runs")
+	require.Equal(t, staleIndex, got, "the stale alias index should be returned")
+
+	require.Eventually(t, func() bool {
+		return c.refreshRecentlyFailed(exactKey, time.Now())
+	}, 5*time.Second, 10*time.Millisecond, "the failed refresh should be recorded for backoff")
+	require.Equal(t, int32(1), buildCalls.Load(), "the failing refresh should have built exactly once")
+
+	got, stale, err = c.GetOrBuildStale(context.Background(), exactKey, staleKey, failingBuild)
+	require.NoError(t, err, "subsequent stale serves should still succeed during backoff")
+	require.True(t, stale, "the alias should still be served during backoff")
+	require.Equal(t, staleIndex, got, "the stale alias index should still be returned during backoff")
+	require.Never(t, func() bool {
+		return buildCalls.Load() > 1
+	}, 200*time.Millisecond, 20*time.Millisecond, "no second rebuild should be attempted within the backoff window")
+}
+
 func TestMentionIndexCache_GetOrBuild_UsesRedisAndLocalHotCache(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

Implements stale-while-revalidate semantics for the session mention index cache to improve the @-mention picker's responsiveness. When the exact cache key misses but a cross-turn stale alias is available, the handler now returns the previous turn's index immediately while triggering a background refresh, eliminating the need to rebuild the index on every turn completion.

## Key Changes

- **New `GetOrBuildStale` method** in `MentionIndexCache`: Returns stale cached results immediately while refreshing in the background, with a boolean flag indicating staleness
- **New `RefreshInBackground` method**: Asynchronously rebuilds the index with timeout protection and panic recovery; coalesces concurrent refreshes via singleflight
- **Cross-turn stale alias key**: Added `SessionMentionIndexStaleCacheKey()` that remains stable across turns, generations, and workspace sources (live vs. snapshot)
- **Handler integration**: Updated `SessionComposerHandler` to use the new stale-aware lookup and proactively warm the mention index when the @-picker opens (empty query)
- **Frontend prefetch**: Added `useEffect` to prefetch the mention index as soon as the composer mounts, overlapping the workspace walk with user interaction
- **Orchestrator warming**: Extended turn-complete mention index warming to populate both the exact key and the stale alias; increased timeout from 2s to 60s to accommodate large repositories
- **Performance optimization**: Rewrote `recursiveFindScript` in `DockerFileReader` to use two piped `find` passes with `sed` instead of a shell while-read loop, reducing per-entry overhead from ~100µs to C-speed processing

## Implementation Details

- The stale alias is session-scoped (`org:session:latest`) and survives turn/generation churn and source changes (live container vs. snapshot)
- Background refreshes are bounded by `RefreshTimeout` (default 60s) to prevent unbounded workspace walks
- Shared cache write failures are logged but never surfaced to callers (they already have the index)
- The handler logs when serving stale results for observability
- Singleflight prevents cache stampedes when multiple requests trigger concurrent refreshes for the same key

https://claude.ai/code/session_01FNW88Wj7NMMwXBKggSjFh3