### PR TITLE
Fetch thread logs in parallel with the message window

### DIFF
--- a/frontend/src/app/(dashboard)/sessions/[id]/page-parallel-logs.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/page-parallel-logs.test.tsx
@@ -1,0 +1,197 @@
+// Parallel logs bootstrap: thread logs should start loading (latest-turns
+// window) alongside the message window instead of waiting for messages to
+// finish, then converge on the precise visible-turns window.
+import { describe, it, expect, vi } from 'vitest';
+import { http, HttpResponse } from 'msw';
+import { renderWithProviders, screen, waitFor } from '@/test/test-utils';
+import { server } from '@/test/mocks/server';
+import { mockSessions } from '@/test/mocks/handlers';
+import { SessionDetailContent } from './session-detail-content';
+import type { Session, SessionMessage, SingleResponse, ListResponse, SessionLog } from '@/lib/types';
+import { installSessionDetailPageTestHooks } from './session-detail-test-kit';
+
+const { toast } = vi.hoisted(() => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+const { routerPush } = vi.hoisted(() => ({
+  routerPush: vi.fn(),
+}));
+
+vi.mock('@/lib/notify', () => ({
+  notify: toast,
+}));
+
+vi.mock('@/components/markdown', () => ({
+  MarkdownContent: ({ content, className }: { content: string; className?: string }) => (
+    <div className={className}>{content}</div>
+  ),
+}));
+
+vi.mock('@/components/session-keyboard-help-overlay', () => ({
+  SessionKeyboardHelpOverlay: ({ open }: { open: boolean }) => (
+    open ? <div role="dialog" aria-label="Session keyboard shortcuts" /> : null
+  ),
+}));
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({
+    push: routerPush,
+  }),
+  useSearchParams: () => new URLSearchParams(),
+}));
+
+vi.mock('next/link', () => ({
+  default: ({ children, href, ...props }: React.ComponentProps<'a'> & { href: string }) => (
+    <a href={href} {...props}>{children}</a>
+  ),
+}));
+
+vi.mock('next/image', () => ({
+  default: ({ src, alt, className, width, height }: { src: string; alt: string; className?: string; width?: number; height?: number }) => (
+    <span data-next-image={src} aria-label={alt} className={className} data-width={width} data-height={height} />
+  ),
+}));
+
+installSessionDetailPageTestHooks({ toast, routerPush });
+
+const threadId = 'thread-main';
+
+function threadedSession(id: string): Session {
+  return {
+    ...mockSessions[0],
+    id,
+    status: 'idle',
+    completed_at: undefined,
+    sandbox_state: 'snapshotted',
+    threads: [
+      {
+        id: threadId,
+        session_id: id,
+        org_id: 'org-1',
+        agent_type: 'codex',
+        label: 'Main',
+        status: 'idle',
+        current_turn: 1,
+        created_at: '2026-02-17T07:00:00Z',
+        cost_cents: 0,
+        pending_message_count: 0,
+      },
+    ],
+  };
+}
+
+type LoggedLogRequest = { latestTurns: string | null; turnNumbers: string | null };
+
+describe('SessionDetailPage parallel thread logs', () => {
+  it('fetches a latest-turns logs window while messages are still loading, then converges on visible turns', async () => {
+    const session = threadedSession('session-parallel-logs');
+
+    let releaseMessages = () => {};
+    const messagesBlocked = new Promise<void>((resolve) => {
+      releaseMessages = resolve;
+    });
+    const logRequests: LoggedLogRequest[] = [];
+
+    server.use(
+      http.get(`/api/v1/sessions/${session.id}`, () => {
+        return HttpResponse.json({ data: session } satisfies SingleResponse<Session>);
+      }),
+      http.get(`/api/v1/sessions/${session.id}/threads/:threadId/messages`, async () => {
+        await messagesBlocked;
+        return HttpResponse.json({
+          data: [
+            {
+              id: 1,
+              session_id: session.id,
+              org_id: 'org-1',
+              thread_id: threadId,
+              turn_number: 1,
+              role: 'assistant',
+              content: 'Main reply',
+              created_at: '2026-02-17T07:02:00Z',
+            },
+          ] as SessionMessage[],
+          meta: {},
+        } satisfies ListResponse<SessionMessage>);
+      }),
+      http.get(`/api/v1/sessions/${session.id}/threads/:threadId/logs`, ({ request }) => {
+        const url = new URL(request.url);
+        logRequests.push({
+          latestTurns: url.searchParams.get('latest_turns'),
+          turnNumbers: url.searchParams.get('turn_numbers'),
+        });
+        return HttpResponse.json({ data: [] as SessionLog[], meta: {} } satisfies ListResponse<SessionLog>);
+      }),
+    );
+
+    renderWithProviders(<SessionDetailContent id={session.id} />);
+
+    // The bootstrap logs window goes out while the messages response is
+    // still blocked — the two round trips overlap instead of serializing.
+    await waitFor(() => {
+      expect(logRequests).toEqual([{ latestTurns: '60', turnNumbers: null }]);
+    });
+
+    releaseMessages();
+    await screen.findByText('Main reply');
+
+    // Once the loaded messages pin down the visible turns, the query
+    // converges on the precise window.
+    await waitFor(() => {
+      expect(logRequests.at(-1)).toEqual({ latestTurns: null, turnNumbers: '1' });
+    });
+  });
+
+  it('uses only the precise turn window once messages are already loaded', async () => {
+    const session = threadedSession('session-precise-logs');
+    const logRequests: LoggedLogRequest[] = [];
+
+    server.use(
+      http.get(`/api/v1/sessions/${session.id}`, () => {
+        return HttpResponse.json({ data: session } satisfies SingleResponse<Session>);
+      }),
+      http.get(`/api/v1/sessions/${session.id}/threads/:threadId/messages`, () => {
+        return HttpResponse.json({
+          data: [
+            {
+              id: 1,
+              session_id: session.id,
+              org_id: 'org-1',
+              thread_id: threadId,
+              turn_number: 1,
+              role: 'assistant',
+              content: 'Main reply',
+              created_at: '2026-02-17T07:02:00Z',
+            },
+          ] as SessionMessage[],
+          meta: {},
+        } satisfies ListResponse<SessionMessage>);
+      }),
+      http.get(`/api/v1/sessions/${session.id}/threads/:threadId/logs`, ({ request }) => {
+        const url = new URL(request.url);
+        logRequests.push({
+          latestTurns: url.searchParams.get('latest_turns'),
+          turnNumbers: url.searchParams.get('turn_numbers'),
+        });
+        return HttpResponse.json({ data: [] as SessionLog[], meta: {} } satisfies ListResponse<SessionLog>);
+      }),
+    );
+
+    renderWithProviders(<SessionDetailContent id={session.id} />);
+    await screen.findByText('Main reply');
+
+    await waitFor(() => {
+      expect(logRequests.at(-1)).toEqual({ latestTurns: null, turnNumbers: '1' });
+    });
+    // The bootstrap window may or may not have fired depending on timing, but
+    // it must never fire again after the precise window is established.
+    const precise = logRequests.filter((request) => request.turnNumbers !== null);
+    const bootstrapAfterPrecise = logRequests.indexOf(precise[0]) >= 0
+      ? logRequests.slice(logRequests.indexOf(precise[0])).filter((request) => request.latestTurns !== null)
+      : [];
+    expect(bootstrapAfterPrecise).toEqual([]);
+  });
+});

--- a/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
@@ -1914,6 +1914,12 @@ const MAX_FILE_SIZE = 10 * 1024 * 1024; // 10 MB
 const SCROLL_NEAR_BOTTOM_THRESHOLD = 100;
 const SCROLL_POSITION_SAVE_DEBOUNCE_MS = 150;
 const THREAD_MESSAGE_WINDOW_LIMIT = 60;
+// First-paint logs window fetched in parallel with the message window, before
+// the loaded messages have resolved which exact turns are visible. Sized to
+// cover at least the turns a full message window can span (every turn carries
+// one or more messages, so 60 messages never span more than 60 turns).
+const THREAD_LOG_BOOTSTRAP_TURNS = THREAD_MESSAGE_WINDOW_LIMIT;
+const THREAD_LOG_BOOTSTRAP_TURNS_KEY = `latest:${THREAD_LOG_BOOTSTRAP_TURNS}`;
 // Sliding window for live SSE logs that may not be visible in persisted log
 // queries yet. The buffer lives in React Query so remounting the chat panel
 // cannot drop the transcript during the SSE-to-DB handoff.
@@ -2112,11 +2118,21 @@ function ChatPanel({
     [activeThread, threadMessages],
   );
   const visibleThreadLogTurnsKey = visibleThreadLogTurns.join(",");
+  // Until the message window resolves which turns are visible, fetch the
+  // thread's latest turns of logs instead of waiting — this runs in parallel
+  // with the messages fetch instead of serializing one round trip behind the
+  // other. Over-fetched turns are harmless: mergeVisibleThreadLogs filters
+  // persisted logs down to the turns of the loaded messages.
+  const threadLogsBootstrapMode = !threadMessagesQuery.isFetched;
   const activeThreadLogsQueryKey = useMemo(
     () => activeThreadId
-      ? threadLogsWindowQueryKey(sessionId, activeThreadId, visibleThreadLogTurnsKey)
+      ? threadLogsWindowQueryKey(
+          sessionId,
+          activeThreadId,
+          threadLogsBootstrapMode ? THREAD_LOG_BOOTSTRAP_TURNS_KEY : visibleThreadLogTurnsKey,
+        )
       : ["session", sessionId, "thread", "none", "logs"] as const,
-    [activeThreadId, sessionId, visibleThreadLogTurnsKey],
+    [activeThreadId, sessionId, threadLogsBootstrapMode, visibleThreadLogTurnsKey],
   );
   const liveLogsQueryKey = useMemo(
     () => activeThreadId
@@ -2130,9 +2146,23 @@ function ChatPanel({
     queryFn: () => api.sessions.getThreadLogs(
       sessionId,
       activeThreadId!,
-      visibleThreadLogTurns.length > 0 ? { turnNumbers: visibleThreadLogTurns } : {},
+      threadLogsBootstrapMode
+        ? { latestTurns: THREAD_LOG_BOOTSTRAP_TURNS }
+        : visibleThreadLogTurns.length > 0 ? { turnNumbers: visibleThreadLogTurns } : {},
     ),
-    enabled: !!activeThreadId && threadMessagesQuery.isFetched,
+    enabled: !!activeThreadId,
+    // Carry the previous window across key changes within the same thread
+    // (bootstrap → precise turns, or the visible turn set growing) so tool
+    // entries don't blink out while the next window loads. Windows from a
+    // different thread must not carry over: their logs can share turn numbers
+    // with the new thread's messages and would survive the visible-turns
+    // filter.
+    placeholderData: (previousData, previousQuery) => {
+      if (!previousQuery || !activeThreadId) return undefined;
+      const threadScopedPrefix = queryKeys.sessions.threadLogs(sessionId, activeThreadId);
+      const previousPrefix = previousQuery.queryKey.slice(0, threadScopedPrefix.length);
+      return JSON.stringify(previousPrefix) === JSON.stringify(threadScopedPrefix) ? previousData : undefined;
+    },
     refetchInterval: activeThread && workingStatusesSet.has(activeThread.status) ? SESSION_DETAIL_ACTIVE_REFETCH_INTERVAL_MS : false,
   });
   const liveLogsQuery = useQuery({

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -501,11 +501,15 @@ export const api = {
       const qs = searchParams.toString();
       return get<import('./types').ThreadMessageWindowResponse>(`/api/v1/sessions/${sessionId}/threads/${threadId}/messages${qs ? `?${qs}` : ''}`);
     },
-    getThreadLogs: (sessionId: string, threadId: string, params: { turnNumbers?: number[] } = {}) => {
+    getThreadLogs: (sessionId: string, threadId: string, params: { turnNumbers?: number[]; latestTurns?: number } = {}) => {
       const searchParams = new URLSearchParams();
       const turnNumbers = Array.from(new Set((params.turnNumbers ?? []).filter((turn) => Number.isInteger(turn) && turn >= 0))).sort((a, b) => a - b);
       if (turnNumbers.length > 0) {
         searchParams.set('turn_numbers', turnNumbers.join(','));
+      } else if (params.latestTurns && Number.isInteger(params.latestTurns) && params.latestTurns > 0) {
+        // Bootstrap mode: fetch the thread's most recent N turns of logs
+        // before the message window has resolved which turns are visible.
+        searchParams.set('latest_turns', String(params.latestTurns));
       }
       const qs = searchParams.toString();
       return get<import('./types').ListResponse<import('./types').SessionLog>>(`/api/v1/sessions/${sessionId}/threads/${threadId}/logs${qs ? `?${qs}` : ''}`);

--- a/internal/api/handlers/session_threads.go
+++ b/internal/api/handlers/session_threads.go
@@ -798,7 +798,10 @@ func (h *SessionThreadHandler) GetThreadLogs(w http.ResponseWriter, r *http.Requ
 		return
 	}
 
-	opts := db.SessionLogFilterOptions{TurnNumbers: parseTurnNumbers(r.URL.Query().Get("turn_numbers"))}
+	opts := db.SessionLogFilterOptions{
+		TurnNumbers: parseTurnNumbers(r.URL.Query().Get("turn_numbers")),
+		LatestTurns: parseLatestTurns(r.URL.Query().Get("latest_turns")),
+	}
 	logs, err := h.svc.GetLogs(r.Context(), orgID, sessionID, threadID, opts)
 	if err != nil {
 		if errors.Is(err, thread.ErrThreadNotFound) {
@@ -813,6 +816,24 @@ func (h *SessionThreadHandler) GetThreadLogs(w http.ResponseWriter, r *http.Requ
 	}
 
 	writeJSON(w, http.StatusOK, models.ListResponse[models.SessionLog]{Data: logs})
+}
+
+// maxLatestTurns bounds the latest_turns parameter so a client cannot turn
+// the bounded bootstrap query back into an unbounded full-thread scan.
+const maxLatestTurns = 200
+
+func parseLatestTurns(raw string) int {
+	if raw == "" {
+		return 0
+	}
+	value, err := strconv.Atoi(strings.TrimSpace(raw))
+	if err != nil || value <= 0 {
+		return 0
+	}
+	if value > maxLatestTurns {
+		return maxLatestTurns
+	}
+	return value
 }
 
 func parseTurnNumbers(raw string) []int {

--- a/internal/api/handlers/session_threads_test.go
+++ b/internal/api/handlers/session_threads_test.go
@@ -169,8 +169,9 @@ func (m *mockMessageStore) ListWindowByThread(ctx context.Context, orgID, thread
 }
 
 type mockLogStore struct {
-	listByThreadFn      func(ctx context.Context, orgID, threadID uuid.UUID) ([]models.SessionLog, error)
-	listByThreadTurnsFn func(ctx context.Context, orgID, threadID uuid.UUID, turnNumbers []int) ([]models.SessionLog, error)
+	listByThreadFn            func(ctx context.Context, orgID, threadID uuid.UUID) ([]models.SessionLog, error)
+	listByThreadTurnsFn       func(ctx context.Context, orgID, threadID uuid.UUID, turnNumbers []int) ([]models.SessionLog, error)
+	listByThreadLatestTurnsFn func(ctx context.Context, orgID, threadID uuid.UUID, latestTurns int) ([]models.SessionLog, error)
 }
 
 func (m *mockLogStore) ListByThread(ctx context.Context, orgID, threadID uuid.UUID) ([]models.SessionLog, error) {
@@ -183,6 +184,13 @@ func (m *mockLogStore) ListByThread(ctx context.Context, orgID, threadID uuid.UU
 func (m *mockLogStore) ListByThreadTurns(ctx context.Context, orgID, threadID uuid.UUID, turnNumbers []int) ([]models.SessionLog, error) {
 	if m.listByThreadTurnsFn != nil {
 		return m.listByThreadTurnsFn(ctx, orgID, threadID, turnNumbers)
+	}
+	return nil, nil
+}
+
+func (m *mockLogStore) ListByThreadLatestTurns(ctx context.Context, orgID, threadID uuid.UUID, latestTurns int) ([]models.SessionLog, error) {
+	if m.listByThreadLatestTurnsFn != nil {
+		return m.listByThreadLatestTurnsFn(ctx, orgID, threadID, latestTurns)
 	}
 	return nil, nil
 }
@@ -1949,6 +1957,42 @@ func TestSessionThreadHandler_GetThreadLogs(t *testing.T) {
 			expectedLen:  1,
 		},
 		{
+			name:           "success with latest turns window",
+			sessionIDParam: sessionID.String(),
+			threadIDParam:  threadID.String(),
+			setupDeps: func(deps *threadTestDeps) {
+				deps.threadStore.getByIDFn = func(_ context.Context, _, _ uuid.UUID) (models.SessionThread, error) {
+					return models.SessionThread{ID: threadID, SessionID: sessionID, OrgID: orgID}, nil
+				}
+				deps.logStore.listByThreadLatestTurnsFn = func(_ context.Context, gotOrgID, gotThreadID uuid.UUID, latestTurns int) ([]models.SessionLog, error) {
+					require.Equal(t, orgID, gotOrgID, "log lookup should be scoped to the request organization")
+					require.Equal(t, threadID, gotThreadID, "log lookup should target the requested thread")
+					require.Equal(t, 50, latestTurns, "log lookup should pass the requested latest-turns window")
+					return []models.SessionLog{
+						{ID: 3, SessionID: sessionID, ThreadID: &threadID, Level: "info", Message: "latest turn", TurnNumber: 12, Timestamp: now},
+					}, nil
+				}
+			},
+			expectedCode: http.StatusOK,
+			expectedLen:  1,
+		},
+		{
+			name:           "latest turns clamped to the server cap",
+			sessionIDParam: sessionID.String(),
+			threadIDParam:  threadID.String(),
+			setupDeps: func(deps *threadTestDeps) {
+				deps.threadStore.getByIDFn = func(_ context.Context, _, _ uuid.UUID) (models.SessionThread, error) {
+					return models.SessionThread{ID: threadID, SessionID: sessionID, OrgID: orgID}, nil
+				}
+				deps.logStore.listByThreadLatestTurnsFn = func(_ context.Context, _, _ uuid.UUID, latestTurns int) ([]models.SessionLog, error) {
+					require.Equal(t, maxLatestTurns, latestTurns, "oversized latest_turns should be clamped, not honored")
+					return []models.SessionLog{}, nil
+				}
+			},
+			expectedCode: http.StatusOK,
+			expectedLen:  0,
+		},
+		{
 			name:           "invalid session ID",
 			sessionIDParam: "bad-id",
 			threadIDParam:  threadID.String(),
@@ -1989,6 +2033,12 @@ func TestSessionThreadHandler_GetThreadLogs(t *testing.T) {
 			if tt.name == "success with turn filter" {
 				target += "?turn_numbers=7,6,7,5,bad"
 			}
+			if tt.name == "success with latest turns window" {
+				target += "?latest_turns=50"
+			}
+			if tt.name == "latest turns clamped to the server cap" {
+				target += "?latest_turns=99999"
+			}
 			req := threadRequest(http.MethodGet, target, "", orgID, map[string]string{"id": tt.sessionIDParam, "tid": tt.threadIDParam})
 			w := httptest.NewRecorder()
 
@@ -2016,4 +2066,15 @@ func TestParseTurnNumbersRejectsOverflow(t *testing.T) {
 	turnNumbers := parseTurnNumbers("1,2147483647,2147483648,999999999999999999999999999999")
 
 	require.Equal(t, []int{1, 2147483647}, turnNumbers, "turn parsing should reject values that cannot fit in the database integer column")
+}
+
+func TestParseLatestTurns(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t, 0, parseLatestTurns(""), "empty input should disable the latest-turns window")
+	require.Equal(t, 0, parseLatestTurns("bad"), "non-numeric input should disable the latest-turns window")
+	require.Equal(t, 0, parseLatestTurns("-5"), "negative input should disable the latest-turns window")
+	require.Equal(t, 0, parseLatestTurns("0"), "zero should disable the latest-turns window")
+	require.Equal(t, 50, parseLatestTurns(" 50 "), "valid input should parse with surrounding whitespace")
+	require.Equal(t, maxLatestTurns, parseLatestTurns("99999"), "oversized input should clamp to the server cap")
 }

--- a/internal/db/session_log_store_test.go
+++ b/internal/db/session_log_store_test.go
@@ -355,6 +355,46 @@ func TestSessionLogStore_ListByThreadTurns(t *testing.T) {
 	require.NoError(t, mock.ExpectationsWereMet(), "ListByThreadTurns should apply the expected SQL filter")
 }
 
+func TestSessionLogStore_ListByThreadLatestTurns(t *testing.T) {
+	t.Parallel()
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "pgx mock should initialize")
+	defer mock.Close()
+
+	store := NewSessionLogStore(mock)
+	orgID := uuid.New()
+	threadID := uuid.New()
+	sessionID := uuid.New()
+	now := time.Now()
+
+	mock.ExpectQuery(`SELECT .+ FROM session_logs sl WHERE sl.thread_id = @thread_id AND sl.org_id = @org_id AND sl.turn_number > \( SELECT COALESCE\(MAX\(inner_sl.turn_number\), 0\) - @latest_turns`).
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(
+			pgxmock.NewRows(logColumns).
+				AddRow(newLogRow(1, sessionID, now)...),
+		)
+
+	logs, err := store.ListByThreadLatestTurns(context.Background(), orgID, threadID, 50)
+	require.NoError(t, err, "ListByThreadLatestTurns should not return an error")
+	require.Len(t, logs, 1, "ListByThreadLatestTurns should return matching log entries")
+	require.Equal(t, int64(1), logs[0].ID, "ListByThreadLatestTurns should scan the returned log")
+	require.NoError(t, mock.ExpectationsWereMet(), "ListByThreadLatestTurns should anchor on the thread's max turn")
+}
+
+func TestSessionLogStore_ListByThreadLatestTurnsNonPositive(t *testing.T) {
+	t.Parallel()
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "pgx mock should initialize")
+	defer mock.Close()
+
+	store := NewSessionLogStore(mock)
+
+	logs, err := store.ListByThreadLatestTurns(context.Background(), uuid.New(), uuid.New(), 0)
+	require.NoError(t, err, "non-positive window should be a no-op, not an error")
+	require.Empty(t, logs, "non-positive window should return no logs without querying")
+	require.NoError(t, mock.ExpectationsWereMet(), "non-positive window must not hit the database")
+}
+
 func TestSessionLogStore_DeleteExpired(t *testing.T) {
 	t.Parallel()
 	mock, err := pgxmock.NewPool()

--- a/internal/db/session_logs.go
+++ b/internal/db/session_logs.go
@@ -20,6 +20,11 @@ type SessionLogStore struct {
 
 type SessionLogFilterOptions struct {
 	TurnNumbers []int
+	// LatestTurns limits results to the N highest turn numbers present for
+	// the thread. The session detail page uses it to fetch a useful first
+	// window of logs in parallel with the message window, before it knows
+	// which exact turns are visible. Ignored when TurnNumbers is set.
+	LatestTurns int
 }
 
 func NewSessionLogStore(db DBTX) *SessionLogStore {
@@ -176,6 +181,35 @@ func (s *SessionLogStore) ListByThreadTurns(ctx context.Context, orgID, threadID
 	})
 	if err != nil {
 		return nil, fmt.Errorf("query thread logs by turns: %w", err)
+	}
+	return pgx.CollectRows(rows, pgx.RowToStructByName[models.SessionLog])
+}
+
+// ListByThreadLatestTurns returns the thread's logs for its latestTurns
+// highest turn numbers. The subquery anchors on the thread's max turn so a
+// thread with sparse turn numbering still returns its most recent activity.
+func (s *SessionLogStore) ListByThreadLatestTurns(ctx context.Context, orgID, threadID uuid.UUID, latestTurns int) ([]models.SessionLog, error) {
+	if latestTurns <= 0 {
+		return []models.SessionLog{}, nil
+	}
+	query := `
+		SELECT sl.id, sl.session_id, sl.org_id, sl.thread_id, sl.timestamp, sl.level, sl.message, sl.metadata, sl.turn_number
+		FROM session_logs sl
+		WHERE sl.thread_id = @thread_id AND sl.org_id = @org_id
+		  AND sl.turn_number > (
+			SELECT COALESCE(MAX(inner_sl.turn_number), 0) - @latest_turns
+			FROM session_logs inner_sl
+			WHERE inner_sl.thread_id = @thread_id AND inner_sl.org_id = @org_id
+		  )
+		ORDER BY sl.id ASC`
+
+	rows, err := s.db.Query(ctx, query, pgx.NamedArgs{
+		"thread_id":    threadID,
+		"org_id":       orgID,
+		"latest_turns": latestTurns,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("query thread logs by latest turns: %w", err)
 	}
 	return pgx.CollectRows(rows, pgx.RowToStructByName[models.SessionLog])
 }

--- a/internal/services/thread/service.go
+++ b/internal/services/thread/service.go
@@ -146,6 +146,7 @@ type threadStoreWithProvenance interface {
 type LogStore interface {
 	ListByThread(ctx context.Context, orgID, threadID uuid.UUID) ([]models.SessionLog, error)
 	ListByThreadTurns(ctx context.Context, orgID, threadID uuid.UUID, turnNumbers []int) ([]models.SessionLog, error)
+	ListByThreadLatestTurns(ctx context.Context, orgID, threadID uuid.UUID, latestTurns int) ([]models.SessionLog, error)
 }
 
 // JobStore defines the job DB operations needed by the thread service.
@@ -1524,9 +1525,12 @@ func (s *Service) GetLogs(ctx context.Context, orgID, sessionID, threadID uuid.U
 	}
 
 	var logs []models.SessionLog
-	if len(opts.TurnNumbers) > 0 {
+	switch {
+	case len(opts.TurnNumbers) > 0:
 		logs, err = s.logStore.ListByThreadTurns(ctx, orgID, threadID, opts.TurnNumbers)
-	} else {
+	case opts.LatestTurns > 0:
+		logs, err = s.logStore.ListByThreadLatestTurns(ctx, orgID, threadID, opts.LatestTurns)
+	default:
 		logs, err = s.logStore.ListByThread(ctx, orgID, threadID)
 	}
 	if err != nil {

--- a/internal/services/thread/service_test.go
+++ b/internal/services/thread/service_test.go
@@ -173,8 +173,9 @@ func (m *mockMessageStore) ListWindowByThread(ctx context.Context, orgID, thread
 }
 
 type mockLogStore struct {
-	listByThreadFn      func(ctx context.Context, orgID, threadID uuid.UUID) ([]models.SessionLog, error)
-	listByThreadTurnsFn func(ctx context.Context, orgID, threadID uuid.UUID, turnNumbers []int) ([]models.SessionLog, error)
+	listByThreadFn            func(ctx context.Context, orgID, threadID uuid.UUID) ([]models.SessionLog, error)
+	listByThreadTurnsFn       func(ctx context.Context, orgID, threadID uuid.UUID, turnNumbers []int) ([]models.SessionLog, error)
+	listByThreadLatestTurnsFn func(ctx context.Context, orgID, threadID uuid.UUID, latestTurns int) ([]models.SessionLog, error)
 }
 
 func (m *mockLogStore) ListByThread(ctx context.Context, orgID, threadID uuid.UUID) ([]models.SessionLog, error) {
@@ -187,6 +188,13 @@ func (m *mockLogStore) ListByThread(ctx context.Context, orgID, threadID uuid.UU
 func (m *mockLogStore) ListByThreadTurns(ctx context.Context, orgID, threadID uuid.UUID, turnNumbers []int) ([]models.SessionLog, error) {
 	if m.listByThreadTurnsFn != nil {
 		return m.listByThreadTurnsFn(ctx, orgID, threadID, turnNumbers)
+	}
+	return nil, nil
+}
+
+func (m *mockLogStore) ListByThreadLatestTurns(ctx context.Context, orgID, threadID uuid.UUID, latestTurns int) ([]models.SessionLog, error) {
+	if m.listByThreadLatestTurnsFn != nil {
+		return m.listByThreadLatestTurnsFn(ctx, orgID, threadID, latestTurns)
 	}
 	return nil, nil
 }
@@ -3223,6 +3231,38 @@ func TestService_GetLogs(t *testing.T) {
 			expectLen: 1,
 		},
 		{
+			name: "success with latest turns window",
+			setupDeps: func(deps *testDeps) {
+				deps.threadStore.getByIDFn = func(_ context.Context, _, _ uuid.UUID) (models.SessionThread, error) {
+					return models.SessionThread{ID: threadID, SessionID: sessionID, OrgID: orgID}, nil
+				}
+				deps.logStore.listByThreadLatestTurnsFn = func(_ context.Context, gotOrgID, gotThreadID uuid.UUID, latestTurns int) ([]models.SessionLog, error) {
+					require.Equal(t, orgID, gotOrgID, "latest-turns log lookup should preserve org scope")
+					require.Equal(t, threadID, gotThreadID, "latest-turns log lookup should preserve thread scope")
+					require.Equal(t, 50, latestTurns, "latest-turns log lookup should pass the requested window")
+					return []models.SessionLog{{ID: 9}}, nil
+				}
+			},
+			expectLen: 1,
+		},
+		{
+			name: "turn filter wins over latest turns",
+			setupDeps: func(deps *testDeps) {
+				deps.threadStore.getByIDFn = func(_ context.Context, _, _ uuid.UUID) (models.SessionThread, error) {
+					return models.SessionThread{ID: threadID, SessionID: sessionID, OrgID: orgID}, nil
+				}
+				deps.logStore.listByThreadTurnsFn = func(_ context.Context, _, _ uuid.UUID, turns []int) ([]models.SessionLog, error) {
+					require.Equal(t, []int{5, 6}, turns, "explicit turns should take precedence")
+					return []models.SessionLog{{ID: 6}}, nil
+				}
+				deps.logStore.listByThreadLatestTurnsFn = func(_ context.Context, _, _ uuid.UUID, _ int) ([]models.SessionLog, error) {
+					t.Fatal("latest-turns lookup must not run when explicit turn numbers are provided")
+					return nil, nil
+				}
+			},
+			expectLen: 1,
+		},
+		{
 			name: "thread not found",
 			setupDeps: func(deps *testDeps) {
 				deps.threadStore.getByIDFn = func(_ context.Context, _, _ uuid.UUID) (models.SessionThread, error) {
@@ -3273,6 +3313,13 @@ func TestService_GetLogs(t *testing.T) {
 			opts := db.SessionLogFilterOptions{}
 			if tt.name == "success with turn filter" {
 				opts.TurnNumbers = []int{5, 6}
+			}
+			if tt.name == "success with latest turns window" {
+				opts.LatestTurns = 50
+			}
+			if tt.name == "turn filter wins over latest turns" {
+				opts.TurnNumbers = []int{5, 6}
+				opts.LatestTurns = 50
 			}
 			logs, err := svc.GetLogs(context.Background(), orgID, sessionID, threadID, opts)
 			if tt.expectErr != nil {


### PR DESCRIPTION
## Why

Last of the session detail latency series ([#1329](https://github.com/assembledhq/143/pull/1329), [#1330](https://github.com/assembledhq/143/pull/1330), [#1331](https://github.com/assembledhq/143/pull/1331)). The thread logs query was explicitly gated on `threadMessagesQuery.isFetched` — it needs loaded messages to compute the visible turn numbers — so tool-call detail always paid one extra serial round trip, while production logs show the endpoint answering in ~10ms.

## What

**Backend** — a bounded bootstrap mode for the logs endpoint:
- `GET /sessions/{id}/threads/{tid}/logs?latest_turns=N` returns logs for the thread's N highest turn numbers (anchored on the thread's max turn, so sparse numbering still returns recent activity). Clamped server-side at 200 so the parameter can't recreate an unbounded full-thread scan. `turn_numbers` takes precedence when both are sent.
- New `SessionLogStore.ListByThreadLatestTurns` (org-scoped), service opts plumbing, handler param parsing.

**Frontend** — overlap instead of serialize:
- While the message window is in flight, the logs query fetches `latest_turns=60` (sized to the message window limit — 60 messages can never span more than 60 turns). Over-fetched turns were already filtered client-side by `mergeVisibleThreadLogs`, so this is safe by construction.
- Once messages land, the query key converges on the precise visible-turns window. `placeholderData` carries the previous window across **same-thread** key changes so tool entries don't blink out during the switch (this also fixes the existing blink when the visible turn set grows mid-session). Cross-thread carry-over is rejected — another thread's logs could share turn numbers and survive the visibility filter.

## Testing

- Go: store test for the new query (incl. non-positive no-op), service precedence tests (latest-turns window; explicit turns win), handler tests (`latest_turns=50` pass-through, clamp at 99999), `parseLatestTurns` unit cases. Full `internal/db`, `internal/services/thread`, `internal/api/handlers` packages pass; `make lint` clean.
- Frontend: new `page-parallel-logs.test.tsx` — bootstrap request fires **while the messages response is blocked**, then converges on `turn_numbers`; no bootstrap refetch after the precise window is established. Transcript/agent-tabs/composer/review-mode/performance suites — 93 passed. `tsc` + `eslint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)