### PR TITLE
Brighten the open PR success green

### DIFF
--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -50,7 +50,7 @@
   --accent: oklch(0.95 0.003 260);
   --accent-foreground: oklch(0.205 0 0);
   --destructive: oklch(0.577 0.245 27.325);
-  --success: oklch(0.527 0.154 150);
+  --success: oklch(0.552 0.145 148.215);
   --success-foreground: oklch(0.985 0 0);
   --warning: oklch(0.666 0.179 58.3);
   --warning-foreground: oklch(0.985 0 0);

--- a/frontend/src/app/theme-colors.test.ts
+++ b/frontend/src/app/theme-colors.test.ts
@@ -1,0 +1,30 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const cssPath = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "globals.css");
+
+function tokenValue(css: string, selector: string, token: string): string {
+  const selectorStart = css.indexOf(`${selector} {`);
+  expect(selectorStart, `${selector} should define theme tokens`).toBeGreaterThanOrEqual(0);
+
+  const blockStart = css.indexOf("{", selectorStart);
+  const blockEnd = css.indexOf("\n}", blockStart);
+  expect(blockEnd, `${selector} token block should be closed`).toBeGreaterThan(blockStart);
+
+  const block = css.slice(blockStart + 1, blockEnd);
+  const match = block.match(new RegExp(`\\s${token}:\\s*([^;]+);`));
+  expect(match, `${token} should be defined in ${selector}`).not.toBeNull();
+  return match![1].trim();
+}
+
+describe("theme color tokens", () => {
+  it("uses GitHub's open pull request green for the light success token", () => {
+    const css = readFileSync(cssPath, "utf8");
+
+    expect(tokenValue(css, ":root", "--success"), "light success should match GitHub's #1f883d open PR emphasis color in OKLCH").toBe("oklch(0.552 0.145 148.215)");
+    expect(tokenValue(css, "@theme inline", "--color-success"), "Tailwind success should resolve through the semantic palette token").toBe("var(--success)");
+  });
+});


### PR DESCRIPTION
## Summary
- Lighten the shared `success` token so open PR and success states read closer to GitHub’s PR green.
- Keep the color within the semantic palette by continuing to route UI usage through `success` and `success-foreground`.
- Add a regression test to pin the theme token value.

## Testing
- `npm test -- --run src/app/theme-colors.test.ts`
- `npm run typecheck`
- `npm run lint`
- `npm run build`