### PR TITLE
Mark exact target lines in formatted code review comments using diff context

### DIFF
--- a/docs/design/implemented/36-code-review-display.md
+++ b/docs/design/implemented/36-code-review-display.md
@@ -342,10 +342,12 @@ When the user clicks "Send to agent", comments are formatted as a chat message:
 Please address the following code review comments:
 
 1. src/components/diff-viewer.tsx:11
-   "This should handle the null case for `foo`. Consider adding a guard clause."
+   Target line: `src/components/diff-viewer.tsx:11` (new side)
+   Requested change: "This should handle the null case for `foo`. Consider adding a guard clause."
 
 2. src/lib/api.ts:45
-   "Use consistent error format here — see the pattern in sessions.ts"
+   Target line: `src/lib/api.ts:45` (new side)
+   Requested change: "Use consistent error format here — see the pattern in sessions.ts"
 ```
 
 This message appears in the chat panel and triggers a new agent turn. The agent can then make changes and produce a new diff, starting the review cycle again.

--- a/frontend/src/lib/diff-parser.ts
+++ b/frontend/src/lib/diff-parser.ts
@@ -299,7 +299,9 @@ function parseHunks(lines: string[]): DiffHunk[] {
 
 /**
  * Extract a diff hunk context (~3 lines before and after) around a specific line.
- * Used when formatting review comments for the agent.
+ * Used when formatting review comments for the agent. The target line is marked
+ * so review messages do not leave the agent guessing which surrounding line the
+ * comment applies to.
  */
 export function getDiffHunkContext(
   files: DiffFile[],
@@ -323,7 +325,13 @@ export function getDiffHunkContext(
 
     const formatted = contextLines.map((line) => {
       const prefix = line.type === "add" ? "+" : line.type === "remove" ? "-" : " ";
-      return `${prefix} ${line.content}`;
+      const reviewedLineNumber = side === "new" ? line.newLineNumber : line.oldLineNumber;
+      const fallbackLineNumber = side === "new" ? line.oldLineNumber : line.newLineNumber;
+      const displayedLineNumber = reviewedLineNumber ?? fallbackLineNumber;
+      const lineSide = reviewedLineNumber !== null ? side : side === "new" ? "old" : "new";
+      const marker = reviewedLineNumber === lineNumber ? ">>>" : "   ";
+      const lineLabel = displayedLineNumber === null ? "?" : String(displayedLineNumber);
+      return `${marker} ${lineSide} ${lineLabel} ${prefix} ${line.content}`;
     });
 
     return formatted.join("\n");

--- a/frontend/src/lib/format-review-message.test.ts
+++ b/frontend/src/lib/format-review-message.test.ts
@@ -59,7 +59,7 @@ describe("formatReviewMessage", () => {
   it("formats a single comment with file, line, and body", () => {
     const result = formatReviewMessage([makeComment()], diffFiles, "");
     expect(result).toContain("1. **src/app.ts:10** (new side)");
-    expect(result).toContain('Comment: "Fix this bug"');
+    expect(result).toContain('Requested change: "Fix this bug"');
   });
 
   it("includes diff hunk context when available", () => {
@@ -67,6 +67,13 @@ describe("formatReviewMessage", () => {
     expect(result).toContain("```");
     expect(result).toContain("+ const b = 2;");
     expect(result).toContain("  const a = 1;");
+  });
+
+  it("marks the exact reviewed line inside diff context", () => {
+    const result = formatReviewMessage([makeComment()], diffFiles, "");
+    expect(result).toContain("Target line: `src/app.ts:10` (new side)");
+    expect(result).toContain(">>> new 10 + const b = 2;");
+    expect(result).toContain("    new 9   const a = 1;");
   });
 
   it("formats multiple comments with numbered list", () => {
@@ -98,7 +105,7 @@ describe("formatReviewMessage", () => {
   it("handles multi-line comment bodies with indentation", () => {
     const comment = makeComment({ body: "Line one\nLine two\nLine three" });
     const result = formatReviewMessage([comment], diffFiles, "");
-    expect(result).toContain('Comment: "Line one\n   Line two\n   Line three"');
+    expect(result).toContain('Requested change: "Line one\n   Line two\n   Line three"');
   });
 
   it("skips diff hunk when file not found in diffFiles", () => {

--- a/frontend/src/lib/format-review-message.ts
+++ b/frontend/src/lib/format-review-message.ts
@@ -19,6 +19,7 @@ export function formatReviewMessage(
     parts.push("Please address the following code review comments:\n");
     openComments.forEach((c, i) => {
       parts.push(`${i + 1}. **${c.file_path}:${c.line_number}** (${c.diff_side} side)`);
+      parts.push(`   Target line: \`${c.file_path}:${c.line_number}\` (${c.diff_side} side)`);
       const hunk = getDiffHunkContext(diffFiles, c.file_path, c.line_number, c.diff_side as "old" | "new");
       if (hunk) {
         parts.push("   ```");
@@ -26,7 +27,7 @@ export function formatReviewMessage(
         parts.push("   ```");
       }
       const indented = c.body.replace(/\n/g, "\n   ");
-      parts.push(`   Comment: "${indented}"\n`);
+      parts.push(`   Requested change: "${indented}"\n`);
     });
   }
 

--- a/internal/api/handlers/session_review_comments.go
+++ b/internal/api/handlers/session_review_comments.go
@@ -362,8 +362,9 @@ func (h *SessionReviewCommentHandler) SendToAgent(w http.ResponseWriter, r *http
 	sb.WriteString("Please address the following code review comments:\n\n")
 	for i, c := range open {
 		sb.WriteString(fmt.Sprintf("%d. **%s:%d** (%s side)\n", i+1, c.FilePath, c.LineNumber, c.DiffSide))
+		sb.WriteString(fmt.Sprintf("   Target line: `%s:%d` (%s side)\n", c.FilePath, c.LineNumber, c.DiffSide))
 		indented := strings.ReplaceAll(c.Body, "\n", "\n   ")
-		sb.WriteString(fmt.Sprintf("   Comment: \"%s\"\n\n", indented))
+		sb.WriteString(fmt.Sprintf("   Requested change: \"%s\"\n\n", indented))
 	}
 	message := strings.TrimSpace(sb.String())
 

--- a/internal/api/handlers/session_review_comments_test.go
+++ b/internal/api/handlers/session_review_comments_test.go
@@ -611,6 +611,8 @@ func TestSessionReviewCommentHandler_SendToAgent(t *testing.T) {
 		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
 		require.Contains(t, resp.Data.Message, "Fix error handling")
 		require.Contains(t, resp.Data.Message, "src/app.ts:10")
+		require.Contains(t, resp.Data.Message, "Target line: `src/app.ts:10` (new side)")
+		require.Contains(t, resp.Data.Message, "Requested change: \"Fix error handling\"")
 		// Resolved comment should not be included
 		require.NotContains(t, resp.Data.Message, "Already fixed")
 	})


### PR DESCRIPTION
## Summary
This update improves agent-directed code review messages by explicitly marking the exact target line within the provided diff hunk context. It addresses the “don’t leave the agent guessing” problem and improves reviewer-to-agent accuracy.

## Changes
- **docs/design/implemented/36-code-review-display.md**
  - Updated the example formatting to include **“Target line: …”** and **“Requested change: …”** text.
- **frontend/src/lib/diff-parser.ts**
  - Enhanced `getDiffHunkContext()` to label hunks with the reviewed line marker (`>>>`) and include whether the context line is on the `new` or `old` side along with a stable displayed line number.
- **frontend/src/lib/format-review-message.ts**
  - Adjusted formatted output wording so comment bodies are emitted under **“Requested change:”** (reflected by tests).
- **frontend/src/lib/format-review-message.test.ts**
  - Updated expectations for the new **“Requested change:”** wording.
  - Added a test to assert the exact reviewed line is marked inside the diff context (expects `>>>` line and surrounding context).

## Test plan
- Ran the frontend unit tests for `formatReviewMessage` and confirmed updated/new assertions pass:
  - `frontend/src/lib/format-review-message.test.ts`
- Verified the diff context formatting includes the target-line marker by checking the newly added test coverage.

[143.dev](https://143.dev) | [session e26c7e1d](https://143.dev/sessions/e26c7e1d-fc5f-4d1e-86d9-11b068609ee3)

Preview: https://143.dev/previews/github/assembledhq/143/pull/1346