### PR TITLE
Update 143 public docs homepage for engineering team benefits and fix regression test

### DIFF
--- a/docs/public/index.mdx
+++ b/docs/public/index.mdx
@@ -11,20 +11,40 @@ tags:
 llm_summary: Start here for public 143.dev documentation, including setup guides, repo configuration, previews, Linear, self-hosting, and reference material.
 ---
 
-Start with the shortest path to a reviewable change, then move into repo configuration, previews, integrations, and self-hosting only when those details become relevant. The docs are organized around what a team needs to make agent work predictable enough to trust.
+143 is built for engineering teams that want coding agents to feel like shared execution infrastructure, not a set of solo terminal sessions. It defaults to team-level workflows: shared context, sandboxed runs, visible diffs, live previews, pull requests, and a clear link back to the issue, error, or automation that started the work.
+
+The core idea is simple: keep agent work close to the systems engineers already trust. GitHub stays the source of truth for branches, PRs, review, CI, and merge rules. 143 owns the workflow around the agent: setup, context, credentials, sandbox execution, previews, follow-ups, auditability, and automation.
+
+- **A shared execution layer:** Sessions are visible to the team, not trapped in one developer's terminal. The transcript, sandbox, diff, validation output, preview, and PR state all live together.
+- **Live previews:** Run frontend or full-stack changes from inside the session so reviewers can click through the result before a PR is opened.
+- **Useful integrations:** Start work from GitHub, Linear or an API, and let agents query connected systems such as Sentry, logs, Slack, Notion, GitHub, and CI through `143-tools`.
+- **Team-level automation:** Autopilot can pick up eligible work when the repo, issue complexity, autonomy settings, and concurrency limits say it is safe. Manual kickoff stays available for anything risky or underspecified.
+- **Credential and provider control:** Configure personal and organization coding-agent auth without pasting provider keys into prompts, issues, or repo config.
+- **Self-hostable operations:** Run 143 on your own infrastructure with your GitHub App, Postgres, Redis, workers, logs, and LLM provider settings.
+
+Start with the shortest path to a reviewable change, then add repo configuration, previews, integrations, automation, and self-hosting only when those details become relevant.
 
 <Cards>
-  <Card title="Get started" href="/docs/getting-started" description="Connect GitHub, start a session, and review the first PR." />
-  <Card title="Guides" href="/docs/guides" description="Configure repos, previews, Linear, Autopilot, and agent auth." />
-  <Card title="Self-hosting" href="/docs/self-hosting" description="Run 143 on your own infrastructure." />
-  <Card title="Reference" href="/docs/reference" description="Field-level config references for operators and agents." />
+  <Card title="Get started" href="/docs/getting-started" description="Connect GitHub, start a session, inspect the diff, and open the first PR." />
+  <Card title="Guides" href="/docs/guides" description="Configure repo setup, previews, Linear, Autopilot, and coding-agent auth." />
+  <Card title="Self-hosting" href="/docs/self-hosting" description="Operate 143 with your own app, workers, data stores, secrets, and providers." />
+  <Card title="Reference" href="/docs/reference" description="Look up repo config, preview config, environment variables, API auth, and agent tools." />
 </Cards>
 
-## Popular guides
+## Good first path
 
-- [Repo config](/docs/guides/repo-config): define `.143/config.json` for setup, validation, and previews.
-- [Preview environments](/docs/guides/previews): run live app previews inside a session.
-- [Linear agent](/docs/guides/linear-agent): assign a Linear issue to `@143` and let it open a PR.
+- [Connect GitHub](/docs/getting-started/connect-github): install the GitHub App and import the repositories 143 can work in.
+- [Start a session](/docs/getting-started/start-a-session): choose a repo, branch, agent, prompt, and any files or screenshots the agent needs.
+- [Review and ship](/docs/getting-started/review-and-ship): inspect the transcript, diff, validation output, preview, and PR state before merging through normal repo rules.
+
+## Build toward production use
+
+- [Repo config](/docs/guides/repo-config): define deterministic setup, validation, and preview behavior in `.143/config.json`.
+- [Preview environments](/docs/guides/previews): run session and branch previews for UI and full-stack review.
+- [Linear agent](/docs/guides/linear-agent): assign or mention `@143` in Linear and keep progress tied to the issue.
+- [Autopilot](/docs/guides/autopilot): let eligible work run automatically behind visible gates.
+- [Coding-agent auth](/docs/guides/coding-agent-auth): configure personal and organization credentials for reliable agent execution.
+- [External API](/docs/reference/external-api): start sessions and automations from internal systems using scoped service-account tokens.
 - [Production deployment checklist](/docs/self-hosting/production-deployment-checklist): verify a self-hosted deployment before sending real work to agents.
 
 ## For AI agents

--- a/frontend/src/lib/docs/public-docs.test.ts
+++ b/frontend/src/lib/docs/public-docs.test.ts
@@ -138,6 +138,20 @@ describe("public docs source", () => {
     expect(raw.content).not.toContain("Design: Public Docs");
   });
 
+  it("keeps the homepage benefits bullets with team-level automation wording", () => {
+    const raw = getRawPublicDocBySlug([]);
+
+    expect(raw.content).toContain("built for engineering teams");
+    expect(raw.content).toContain("defaults to team-level workflows");
+    expect(raw.content).toContain("**A shared execution layer:**");
+    expect(raw.content).toContain("**Team-level automation:**");
+    expect(raw.content).toContain("Linear or an API");
+    expect(raw.content).toContain("self-host");
+    expect(raw.content).not.toContain("**Repo-specific contracts:**");
+    expect(raw.content).not.toContain("## Why teams use it");
+    expect(raw.content).not.toContain("**Controlled automation:**");
+  });
+
   it("keeps preview setup and secret guidance in the public preview docs", () => {
     const raw = getRawPublicDocBySlug(["guides", "previews"]);
 


### PR DESCRIPTION
## Summary
Reworked the public docs homepage intro to better frame 143 as “shared execution infrastructure” for engineering teams with default team-level workflows, while keeping the existing focus on reviewable, predictable agent work. Also updated the associated regression test to match the new homepage content.

## Changes
- **docs/public/index.mdx**
  - Replaced the introductory copy to lead with engineering-team value (shared context, sandboxed runs, visible diffs, live previews, PR linkage).
  - Emphasized GitHub as the source of truth for branches/PRs/CI/merge rules and clarified what 143 owns (workflow, context, credentials, execution, auditability).
  - Refreshed the benefit bullets and reordered/rewrote supporting messaging to align with “team-level automation” vs solo terminal sessions.
  - Adjusted card descriptions to reflect the current navigation and focus areas.
  - Removed the **“Repo-specific contracts”** bullet from the top benefits list.
- **frontend/src/lib/docs/public-docs.test.ts**
  - Updated the regression test assertions to reflect the new homepage text structure/content.

## Test plan
- `npm run test -- src/lib/docs/public-docs.test.ts`
- `npm run typecheck`
- `npm run lint`
- `npm run build`

[143.dev](https://143.dev) | [session acdb189e](https://143.dev/sessions/acdb189e-04c7-4aaf-affc-752996d70dae)

Preview: https://143.dev/previews/github/assembledhq/143/pull/1347