### PR TITLE
Add optimistic UI for review comment creation to prevent duplicate/missing diffs

### DIFF
--- a/frontend/src/hooks/use-review-comments.test.tsx
+++ b/frontend/src/hooks/use-review-comments.test.tsx
@@ -1,0 +1,142 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { createElement, type ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ListResponse, SessionReviewComment, SingleResponse } from "@/lib/types";
+import { api } from "@/lib/api";
+import { useReviewComments } from "./use-review-comments";
+
+vi.mock("@/lib/api", () => ({
+  api: {
+    sessions: {
+      listReviewComments: vi.fn(),
+      createReviewComment: vi.fn(),
+      updateReviewComment: vi.fn(),
+      deleteReviewComment: vi.fn(),
+    },
+  },
+}));
+
+function makeWrapper(client: QueryClient) {
+  const Wrapper = ({ children }: { children: ReactNode }) =>
+    createElement(QueryClientProvider, { client }, children);
+  Wrapper.displayName = "TestQueryClientProvider";
+  return Wrapper;
+}
+
+function makeComment(overrides: Partial<SessionReviewComment> = {}): SessionReviewComment {
+  return {
+    id: "comment-1",
+    session_id: "session-1",
+    org_id: "org-1",
+    user_id: "user-1",
+    file_path: "src/app.ts",
+    line_number: 12,
+    diff_side: "new",
+    body: "Saved comment",
+    resolved: false,
+    pass_number: 1,
+    created_at: "2026-06-11T00:00:00.000Z",
+    updated_at: "2026-06-11T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+describe("useReviewComments", () => {
+  let queryClient: QueryClient;
+  const mockedAPI = vi.mocked(api.sessions);
+
+  beforeEach(() => {
+    queryClient = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false },
+        mutations: { retry: false },
+      },
+    });
+    vi.clearAllMocks();
+  });
+
+  it("shows a submitted comment before the create request finishes", async () => {
+    let resolveCreate: (value: SingleResponse<SessionReviewComment>) => void = () => {};
+    let serverComments: SessionReviewComment[] = [];
+    mockedAPI.listReviewComments.mockImplementation(async () => ({
+      data: serverComments,
+      meta: {},
+    } satisfies ListResponse<SessionReviewComment>));
+    mockedAPI.createReviewComment.mockReturnValue(
+      new Promise((resolve) => {
+        resolveCreate = resolve;
+      }),
+    );
+
+    const { result } = renderHook(() => useReviewComments("session-1"), {
+      wrapper: makeWrapper(queryClient),
+    });
+
+    await waitFor(() => expect(result.current.comments).toEqual([]));
+
+    act(() => {
+      result.current.createComment({
+        file_path: "src/app.ts",
+        line_number: 12,
+        side: "new",
+        body: "Saved comment",
+      });
+    });
+
+    await waitFor(() =>
+      expect(result.current.comments).toEqual([
+        expect.objectContaining({
+          file_path: "src/app.ts",
+          line_number: 12,
+          diff_side: "new",
+          body: "Saved comment",
+          resolved: false,
+        }),
+      ]),
+    );
+    expect(result.current.comments[0]?.id).toMatch(/^pending-/);
+
+    act(() => {
+      serverComments = [makeComment()];
+      resolveCreate({ data: serverComments[0] });
+    });
+
+    await waitFor(() => expect(result.current.comments[0]?.id).toBe("comment-1"));
+    expect(mockedAPI.createReviewComment).toHaveBeenCalledTimes(1);
+  });
+
+  it("removes the optimistic comment when the create request fails", async () => {
+    let rejectCreate!: (reason: Error) => void;
+    mockedAPI.listReviewComments.mockResolvedValue({ data: [], meta: {} } satisfies ListResponse<SessionReviewComment>);
+    mockedAPI.createReviewComment.mockReturnValue(
+      new Promise((_resolve, reject) => {
+        rejectCreate = reject;
+      }),
+    );
+
+    const { result } = renderHook(() => useReviewComments("session-1"), {
+      wrapper: makeWrapper(queryClient),
+    });
+
+    await waitFor(() => expect(result.current.comments).toEqual([]));
+
+    act(() => {
+      result.current.createComment({
+        file_path: "src/app.ts",
+        line_number: 12,
+        side: "new",
+        body: "Optimistic comment",
+      });
+    });
+
+    await waitFor(() => expect(result.current.comments).toHaveLength(1));
+    expect(result.current.comments[0]?.id).toMatch(/^pending-/);
+
+    act(() => {
+      rejectCreate(new Error("server error"));
+    });
+
+    await waitFor(() => expect(result.current.comments).toHaveLength(0));
+  });
+});

--- a/frontend/src/hooks/use-review-comments.ts
+++ b/frontend/src/hooks/use-review-comments.ts
@@ -1,7 +1,7 @@
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
-import { useMemo, useCallback } from "react";
+import { useMemo, useCallback, useRef } from "react";
 import { api } from "@/lib/api";
-import type { SessionReviewComment } from "@/lib/types";
+import type { ListResponse, SessionReviewComment } from "@/lib/types";
 
 /** Key for grouping comments by file + line + side */
 export type DiffSide = "old" | "new";
@@ -38,6 +38,7 @@ export interface UseReviewCommentsResult {
 
 export function useReviewComments(sessionId: string): UseReviewCommentsResult {
   const queryClient = useQueryClient();
+  const pendingIDCounter = useRef(0);
   const queryKey = useMemo(
     () => ["session", sessionId, "review-comments"],
     [sessionId]
@@ -84,7 +85,56 @@ export function useReviewComments(sessionId: string): UseReviewCommentsResult {
       side?: DiffSide;
       body: string;
     }) => api.sessions.createReviewComment(sessionId, body),
-    onSuccess: invalidate,
+    onMutate: async (body) => {
+      await queryClient.cancelQueries({ queryKey });
+      pendingIDCounter.current += 1;
+      const optimisticID = `pending-${Date.now()}-${pendingIDCounter.current}`;
+      const now = new Date().toISOString();
+      const optimisticComment: SessionReviewComment = {
+        id: optimisticID,
+        session_id: sessionId,
+        org_id: "",
+        user_id: "",
+        file_path: body.file_path,
+        line_number: body.line_number,
+        diff_side: body.side ?? "new",
+        body: body.body,
+        resolved: false,
+        pass_number: 1,
+        created_at: now,
+        updated_at: now,
+      };
+
+      queryClient.setQueryData<ListResponse<SessionReviewComment>>(queryKey, (previous) => ({
+        data: [...(previous?.data ?? []), optimisticComment],
+        meta: previous?.meta ?? {},
+      }));
+
+      return { optimisticID };
+    },
+    onSuccess: (response, _variables, context) => {
+      queryClient.setQueryData<ListResponse<SessionReviewComment>>(queryKey, (previous) => {
+        if (!previous) {
+          return { data: [response.data], meta: {} };
+        }
+        return {
+          ...previous,
+          data: previous.data.map((comment) =>
+            comment.id === context?.optimisticID ? response.data : comment
+          ),
+        };
+      });
+    },
+    onError: (_error, _variables, context) => {
+      queryClient.setQueryData<ListResponse<SessionReviewComment>>(queryKey, (previous) => {
+        if (!previous) return previous;
+        return {
+          ...previous,
+          data: previous.data.filter((comment) => comment.id !== context?.optimisticID),
+        };
+      });
+    },
+    onSettled: invalidate,
   });
   const { mutate: createReviewComment, isPending: isCreating } = createMutation;
 


### PR DESCRIPTION
## Summary
This change adds an optimistic UI entry when creating a session review comment, so the comment appears immediately while the server request is in flight. It also reconciles the optimistic item with the real response (or removes it on error) to avoid duplicate or missing diff rendering.

## Changes
- **frontend/src/hooks/use-review-comments.ts**
  - Added `pendingIDCounter` via `useRef` to generate unique optimistic comment IDs per mutation.
  - Implemented `onMutate` to:
    - Cancel in-flight queries for the review comment list.
    - Insert an optimistic `SessionReviewComment` into the React Query cache for `["session", sessionId, "review-comments"]`.
  - Implemented `onSuccess` to replace the optimistic comment (by `optimisticID`) with the server response.
  - Implemented `onError` to remove the optimistic comment if creation fails.
  - Kept existing cache refresh behavior via `onSettled: invalidate`.
- **frontend/src/hooks/use-review-comments.test.tsx**
  - Added tests covering optimistic insertion and proper reconciliation/removal behavior.

## Test plan
- Ran the new hook tests in `frontend/src/hooks/use-review-comments.test.tsx` to verify:
  - The optimistic comment is added before the API resolves.
  - The optimistic entry is replaced with the server response on success.
  - The optimistic entry is removed on error.

[143.dev](https://143.dev) | [session 757f5caa](https://143.dev/sessions/757f5caa-fabf-4d8d-a8cd-df7333422780)

Preview: https://143.dev/previews/github/assembledhq/143/pull/1349