### PR TITLE
Tune PR-ready green success token and align DiffStatsBadge to semantic success color

### DIFF
--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -50,7 +50,7 @@
   --accent: oklch(0.95 0.003 260);
   --accent-foreground: oklch(0.205 0 0);
   --destructive: oklch(0.577 0.245 27.325);
-  --success: oklch(0.552 0.145 148.215);
+  --success: oklch(0.605 0.165 149);
   --success-foreground: oklch(0.985 0 0);
   --warning: oklch(0.666 0.179 58.3);
   --warning-foreground: oklch(0.985 0 0);

--- a/frontend/src/app/theme-colors.test.ts
+++ b/frontend/src/app/theme-colors.test.ts
@@ -21,10 +21,10 @@ function tokenValue(css: string, selector: string, token: string): string {
 }
 
 describe("theme color tokens", () => {
-  it("uses GitHub's open pull request green for the light success token", () => {
+  it("uses a lighter app success green that stays close to diff additions", () => {
     const css = readFileSync(cssPath, "utf8");
 
-    expect(tokenValue(css, ":root", "--success"), "light success should match GitHub's #1f883d open PR emphasis color in OKLCH").toBe("oklch(0.552 0.145 148.215)");
+    expect(tokenValue(css, ":root", "--success"), "light success should be brighter than the previous GitHub open PR green without adding another status hue").toBe("oklch(0.605 0.165 149)");
     expect(tokenValue(css, "@theme inline", "--color-success"), "Tailwind success should resolve through the semantic palette token").toBe("var(--success)");
   });
 });

--- a/frontend/src/components/code-review/diff-stats-badge.test.tsx
+++ b/frontend/src/components/code-review/diff-stats-badge.test.tsx
@@ -1,0 +1,13 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { DiffStatsBadge } from "./diff-stats-badge";
+
+describe("DiffStatsBadge", () => {
+  it("renders additions with the semantic success token", () => {
+    render(<DiffStatsBadge added={150} removed={49} />);
+
+    expect(screen.getByText("+150"), "additions should align with the PR-ready success color").toHaveClass("text-success");
+    expect(screen.getByText("-49"), "removals should keep the destructive red treatment").toHaveClass("text-red-600", "dark:text-red-400");
+  });
+});

--- a/frontend/src/components/code-review/diff-stats-badge.tsx
+++ b/frontend/src/components/code-review/diff-stats-badge.tsx
@@ -12,7 +12,7 @@ export function DiffStatsBadge({ added, removed, onClick, className }: DiffStats
 
   const content = (
     <span className={cn("inline-flex items-center gap-1 text-xs font-mono", className)}>
-      <span className="text-green-600 dark:text-green-400">+{added}</span>
+      <span className="text-success">+{added}</span>
       <span className="text-red-600 dark:text-red-400">-{removed}</span>
     </span>
   );


### PR DESCRIPTION
## Summary
This updates the light-theme `--success` color to a brighter “PR ready” green for better visual contrast and closer alignment with diff/addition semantics. It also ensures `DiffStatsBadge` uses the semantic `text-success` token so the ready-to-merge indicator and `+{added}` share the same color meaning.

## Changes
- **frontend/src/app/globals.css**
  - Updated `--success` (light theme) from `oklch(0.552 0.145 148.215)` to `oklch(0.605 0.165 149)`.
- **frontend/src/app/theme-colors.test.ts**
  - Adjusted the assertion to verify the new brighter `--success` OKLCH value.
- **frontend/src/components/code-review/diff-stats-badge.tsx**
  - Switched additions styling from `text-green-600 dark:text-green-400` to semantic `text-success`.
- **frontend/src/components/code-review/diff-stats-badge.test.tsx**
  - Added a test to lock that `+{added}` renders with the `text-success` class.

## Test plan
- Ran focused test suite (Vitest) including the new badge test
- `npm run typecheck`
- `npm run lint`
- `npm run build`

[143.dev](https://143.dev) | [session b557ab8c](https://143.dev/sessions/b557ab8c-e28e-43cd-8fe8-2817d3906ecf)

Preview: https://143.dev/previews/github/assembledhq/143/pull/1350