### PR TITLE
Seamlessly replace ghost optimistic sessions during session creation handoff

### DIFF
--- a/frontend/src/app/(dashboard)/sessions/session-sidebar.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/session-sidebar.test.tsx
@@ -45,12 +45,13 @@ vi.mock('@/hooks/use-auth', () => ({
 }));
 
 const mockOptimisticSessions: { id: string; title: string; status: 'pending'; created_at: string; resolvedId?: string }[] = [];
+const mockRemoveOptimisticSession = vi.fn();
 
 vi.mock('@/contexts/optimistic-sessions', () => ({
   useOptimisticSessions: () => ({
     optimisticSessions: mockOptimisticSessions,
     addOptimisticSession: vi.fn(),
-    removeOptimisticSession: vi.fn(),
+    removeOptimisticSession: mockRemoveOptimisticSession,
     markOptimisticResolved: vi.fn(),
   }),
   OptimisticSessionsProvider: ({ children }: { children: React.ReactNode }) => children,
@@ -133,6 +134,7 @@ describe('SessionSidebar', () => {
     mockSelectedSegment = null;
     mockRouterPush.mockReset();
     mockRouterPrefetch.mockReset();
+    mockRemoveOptimisticSession.mockReset();
     mockOptimisticSessions.length = 0;
     mockAuthState.isAuthenticated = true;
     mockAuthState.user = { id: 'user-1' };
@@ -776,6 +778,53 @@ describe('SessionSidebar', () => {
     renderWithProviders(<SessionSidebar />);
 
     await screen.findByText('Real session');
+    expect(screen.queryByText('Optimistic placeholder')).not.toBeInTheDocument();
+  });
+
+  it('keeps resolved optimistic ownership during the real-session handoff', async () => {
+    serveSessions([makeSession({ id: 's-real', result_summary: 'Real session', status: 'pending' })]);
+    mockOptimisticSessions.push({
+      id: 'opt-1',
+      title: 'Optimistic placeholder',
+      status: 'pending',
+      created_at: new Date().toISOString(),
+      resolvedId: 's-real',
+    });
+
+    renderWithProviders(<SessionSidebar />);
+
+    const realSessionLink = await screen.findByRole('link', { name: /Real session/ });
+    expect(realSessionLink).toHaveAttribute('href', '/sessions/s-real');
+    expect(screen.queryByText('Optimistic placeholder')).not.toBeInTheDocument();
+    expect(screen.getAllByText('Real session')).toHaveLength(1);
+    expect(mockRemoveOptimisticSession).not.toHaveBeenCalled();
+  });
+
+  it('shows the real session exactly once after the fallback timer removes the optimistic entry', async () => {
+    serveSessions([makeSession({ id: 's-real', result_summary: 'Real session', status: 'pending' })]);
+    mockOptimisticSessions.push({
+      id: 'opt-1',
+      title: 'Optimistic placeholder',
+      status: 'pending',
+      created_at: new Date().toISOString(),
+      resolvedId: 's-real',
+    });
+
+    const { rerender } = renderWithProviders(<SessionSidebar />);
+
+    // Resolved row is showing the real session.
+    await screen.findByRole('link', { name: /Real session/ });
+    expect(screen.getAllByText('Real session')).toHaveLength(1);
+
+    // Simulate the fallback timer firing: the optimistic entry is removed from context.
+    mockOptimisticSessions.length = 0;
+    rerender(<SessionSidebar />);
+
+    // Real session still appears exactly once — no duplication or disappearance
+    // during the React key transition from optimistic.id → session.id.
+    await waitFor(() => {
+      expect(screen.getAllByText('Real session')).toHaveLength(1);
+    });
     expect(screen.queryByText('Optimistic placeholder')).not.toBeInTheDocument();
   });
 

--- a/frontend/src/app/(dashboard)/sessions/session-sidebar.tsx
+++ b/frontend/src/app/(dashboard)/sessions/session-sidebar.tsx
@@ -326,6 +326,11 @@ function CurrentSessionContextRow({
   );
 }
 
+type SidebarSessionRow =
+  | { kind: "optimistic"; renderKey: string; optimistic: OptimisticSession }
+  | { kind: "resolved"; renderKey: string; optimistic: OptimisticSession; session: SessionListItem }
+  | { kind: "session"; renderKey: string; session: SessionListItem };
+
 // ---------------------------------------------------------------------------
 // Sidebar component
 // ---------------------------------------------------------------------------
@@ -401,7 +406,7 @@ export function SessionSidebar() {
   });
   const members = useMemo<User[]>(() => membersData?.data ?? [], [membersData?.data]);
 
-  const { optimisticSessions, removeOptimisticSession } = useOptimisticSessions();
+  const { optimisticSessions } = useOptimisticSessions();
 
   const currentFilter = activeFilter ?? "all";
   const isArchivedView = currentFilter === "archived";
@@ -638,27 +643,45 @@ export function SessionSidebar() {
     }
     return displayedSessions[0]?.id ?? null;
   }, [activeSessionId, displayedSessions, hasNavigatedFromNewSessionDraft, isNewSession, selectedId, selectedSessionIsDisplayed]);
-  // Hide optimistic rows whose real session is already in the list — prevents
-  // the double-render flash between "optimistic added" and "server refetch
-  // lands". Resolved-but-not-yet-visible rows stay until the real row arrives.
-  const realIds = useMemo(() => new Set(displayedSessions.map((s) => s.id)), [displayedSessions]);
-  const visibleOptimistic = useMemo(
-    () => optimisticSessions.filter((os) => !(os.resolvedId && realIds.has(os.resolvedId))),
-    [optimisticSessions, realIds],
+  const realSessionsById = useMemo(
+    () => new Map(displayedSessions.map((session) => [session.id, session])),
+    [displayedSessions],
   );
-
-  // Garbage-collect resolved optimistic rows once we've observed their real
-  // counterpart in the list. Done in an effect so state updates happen after
-  // render. This also handles the failure case: if the real session later
-  // changes status (e.g. to "failed"), it's still in the list, so the
-  // optimistic stays hidden and gets cleaned up here.
-  useEffect(() => {
-    for (const os of optimisticSessions) {
-      if (os.resolvedId && realIds.has(os.resolvedId)) {
-        removeOptimisticSession(os.id);
-      }
+  const optimisticRows = useMemo<SidebarSessionRow[]>(
+    () =>
+      optimisticSessions.map((optimistic): SidebarSessionRow => {
+        const session = optimistic.resolvedId ? realSessionsById.get(optimistic.resolvedId) : undefined;
+        if (session) {
+          return { kind: "resolved", renderKey: optimistic.id, optimistic, session };
+        }
+        return { kind: "optimistic", renderKey: optimistic.id, optimistic };
+      }),
+    [optimisticSessions, realSessionsById],
+  );
+  const optimisticOwnedSessionIds = useMemo(
+    () =>
+      new Set(
+        optimisticRows
+          .filter((row): row is Extract<SidebarSessionRow, { kind: "resolved" }> => row.kind === "resolved")
+          .map((row) => row.session.id),
+      ),
+    [optimisticRows],
+  );
+  const sidebarSessionRows = useMemo<SidebarSessionRow[]>(
+    () => [
+      ...optimisticRows,
+      ...displayedSessions
+        .filter((session) => !optimisticOwnedSessionIds.has(session.id))
+        .map((session) => ({ kind: "session" as const, renderKey: session.id, session })),
+    ],
+    [displayedSessions, optimisticOwnedSessionIds, optimisticRows],
+  );
+  const sidebarRowsForCurrentFilter = useMemo<SidebarSessionRow[]>(() => {
+    if (currentFilter === "all" || currentFilter === "active") {
+      return sidebarSessionRows;
     }
-  }, [optimisticSessions, realIds, removeOptimisticSession]);
+    return displayedSessions.map((session) => ({ kind: "session", renderKey: session.id, session }));
+  }, [currentFilter, displayedSessions, sidebarSessionRows]);
 
   const counts = countsData?.data;
 
@@ -857,6 +880,135 @@ export function SessionSidebar() {
     return () => document.removeEventListener("keydown", handleDocumentKeyDown);
   }, [filterSuffix, focusSearch, moveActiveSession, router]);
 
+  const renderSavedSessionRow = (session: SessionListItem, renderKey: string) => {
+    const isSelected = selectedId === session.id;
+    const cfg = statusConfig[session.status] || statusConfig.pending;
+    const isWorkingSession = workingSet.has(session.status);
+    const hasUnread = isUnread(session);
+    const ts = session.completed_at || session.started_at || session.created_at;
+    const isArchived = !!session.archived_at;
+    const title = sessionTitle(session);
+    const sessionHref = `/sessions/${session.id}${filterSuffix}`;
+
+    return (
+      <SwipeActionRow
+        key={renderKey}
+        className="mb-0.5"
+        actionLabel={isArchived ? "Unarchive session" : "Archive session"}
+        actionText={isArchived ? "Restore" : "Archive"}
+        desktopActionVisibility="hover"
+        actionIcon={isArchived ? <ArchiveRestore className="h-4 w-4" /> : <Archive className="h-4 w-4" />}
+        onAction={() => {
+          if (isArchived) {
+            return unarchiveMutation.mutateAsync(session);
+          } else {
+            return archiveMutation.mutateAsync(session);
+          }
+        }}
+      >
+        <SessionSidebarOptionFrame
+          id={`session-sidebar-option-${session.id}`}
+          ariaSelected={currentActiveSessionId === session.id}
+          optionRef={(node) => {
+            if (node) {
+              optionRefs.current.set(session.id, node);
+            } else {
+              optionRefs.current.delete(session.id);
+            }
+          }}
+          onMouseDown={() => seedSessionDetailCache(session)}
+          className={cn(
+            "cursor-pointer",
+            currentActiveSessionId === session.id && !isSelected && "border-border/70 bg-muted/40 ring-1 ring-ring/20",
+            isSelected && "border-primary/25 bg-card shadow-sm ring-1 ring-primary/10",
+          )}
+          onClick={(event) => {
+            // Clicks on the frame padding (outside the inner link surface)
+            // should still open the session — a dead zone here reads as
+            // "click did nothing".
+            if (event.defaultPrevented || event.target !== event.currentTarget) {
+              return;
+            }
+            navigateToSession(session, sessionHref);
+          }}
+        >
+          <SessionSidebarRowSurface
+            href={sessionHref}
+            ariaCurrent={isSelected ? "page" : undefined}
+            onClick={() => handleSessionLinkClick(session)}
+            onMouseDown={() => seedSessionDetailCache(session)}
+            onMouseEnter={() => prefetchRoute(sessionHref)}
+            onFocus={() => prefetchRoute(sessionHref)}
+            className={
+              isSelected
+                ? "border-transparent bg-primary/5 shadow-none ring-0 md:border-transparent md:bg-primary/5 md:shadow-none"
+                : "hover:border-border/60 hover:bg-card md:hover:border-transparent md:hover:bg-muted/50"
+            }
+          >
+            <span
+              aria-hidden="true"
+              className={cn(
+                "absolute inset-y-2 left-1 w-0.5 rounded-full bg-primary/0 transition-colors duration-150",
+                isSelected && "bg-primary",
+              )}
+            />
+            <div className="flex items-start gap-2.5 min-w-0">
+              <div className="mt-1.5 shrink-0">
+                {isWorkingSession ? (
+                  <StatusDot animate color="bg-primary" pingColor="bg-primary/60" />
+                ) : hasUnread ? (
+                  <StatusDot color="bg-primary" />
+                ) : (
+                  <span className="inline-flex rounded-full h-2 w-2" />
+                )}
+              </div>
+
+              <div className="min-w-0 flex-1">
+                <div className="flex items-start justify-between gap-2">
+                  <p className={cn(
+                    "text-xs font-medium truncate leading-snug",
+                    hasUnread || isWorkingSession ? "text-foreground" : "text-muted-foreground"
+                  )}>
+                    {title}
+                  </p>
+                </div>
+                <div className="mt-0.5 flex min-w-0 items-center gap-2">
+                  <div
+                    data-testid={`session-row-meta-scroll-${session.id}`}
+                    className="min-w-0 flex-1 overflow-x-auto overflow-y-hidden scrollbar-hide"
+                  >
+                    <div className="flex min-w-max items-center gap-1.5 pr-1">
+                      <span className="text-xs text-muted-foreground shrink-0">
+                        <span>{cfg.label}</span>
+                        {isWorkingSession && <AnimatedEllipsis />}
+                      </span>
+                      {session.pm_plan_id && !session.triggered_by_user_id && (
+                        <span className="inline-flex items-center rounded-full bg-primary/10 px-1.5 py-0.5 text-xs font-medium text-primary shrink-0">
+                          PM
+                        </span>
+                      )}
+                      <SessionLinearBadge session={session} />
+                      <span className="text-xs text-muted-foreground/50 shrink-0">
+                        {formatTimeAgo(ts)}
+                      </span>
+                      <PRStatusBadge prSummary={session.pr_summary} />
+                      <SessionDiffBadge diffStats={session.diff_stats} />
+                    </div>
+                  </div>
+                </div>
+                {session.status === "failed" && (session.failure_explanation || session.error) && (
+                  <p className="text-xs text-destructive/70 truncate mt-0.5">
+                    {session.failure_explanation || session.error}
+                  </p>
+                )}
+              </div>
+            </div>
+          </SessionSidebarRowSurface>
+        </SessionSidebarOptionFrame>
+      </SwipeActionRow>
+    );
+  };
+
   return (
     <div className="w-full h-full border-r border-border bg-panel flex flex-col">
       {/* Header */}
@@ -1006,10 +1158,12 @@ export function SessionSidebar() {
           </div>
         )}
 
-        {(currentFilter === "all" || currentFilter === "active") &&
-          visibleOptimistic.map((os) => (
-            <OptimisticSessionRow key={os.id} session={os} />
-          ))}
+        {sidebarRowsForCurrentFilter.map((row) => {
+          if (row.kind === "optimistic") {
+            return <OptimisticSessionRow key={row.renderKey} session={row.optimistic} />;
+          }
+          return renderSavedSessionRow(row.session, row.renderKey);
+        })}
 
         {(!isResolved || isLoading) && (
           <div className="px-2 py-8 text-center text-xs text-muted-foreground">
@@ -1031,135 +1185,6 @@ export function SessionSidebar() {
             No sessions match this filter.
           </div>
         )}
-
-        {displayedSessions.map((session) => {
-          const isSelected = selectedId === session.id;
-          const cfg = statusConfig[session.status] || statusConfig.pending;
-          const isWorkingSession = workingSet.has(session.status);
-          const hasUnread = isUnread(session);
-          const ts = session.completed_at || session.started_at || session.created_at;
-          const isArchived = !!session.archived_at;
-          const title = sessionTitle(session);
-          const sessionHref = `/sessions/${session.id}${filterSuffix}`;
-
-          return (
-            <SwipeActionRow
-              key={session.id}
-              className="mb-0.5"
-              actionLabel={isArchived ? "Unarchive session" : "Archive session"}
-              actionText={isArchived ? "Restore" : "Archive"}
-              desktopActionVisibility="hover"
-              actionIcon={isArchived ? <ArchiveRestore className="h-4 w-4" /> : <Archive className="h-4 w-4" />}
-              onAction={() => {
-                if (isArchived) {
-                  return unarchiveMutation.mutateAsync(session);
-                } else {
-                  return archiveMutation.mutateAsync(session);
-                }
-              }}
-            >
-              <SessionSidebarOptionFrame
-                id={`session-sidebar-option-${session.id}`}
-                ariaSelected={currentActiveSessionId === session.id}
-                optionRef={(node) => {
-                  if (node) {
-                    optionRefs.current.set(session.id, node);
-                  } else {
-                    optionRefs.current.delete(session.id);
-                  }
-                }}
-                onMouseDown={() => seedSessionDetailCache(session)}
-                className={cn(
-                  "cursor-pointer",
-                  currentActiveSessionId === session.id && !isSelected && "border-border/70 bg-muted/40 ring-1 ring-ring/20",
-                  isSelected && "border-primary/25 bg-card shadow-sm ring-1 ring-primary/10",
-                )}
-                onClick={(event) => {
-                  // Clicks on the frame padding (outside the inner link surface)
-                  // should still open the session — a dead zone here reads as
-                  // "click did nothing".
-                  if (event.defaultPrevented || event.target !== event.currentTarget) {
-                    return;
-                  }
-                  navigateToSession(session, sessionHref);
-                }}
-              >
-                <SessionSidebarRowSurface
-                  href={sessionHref}
-                  ariaCurrent={isSelected ? "page" : undefined}
-                  onClick={() => handleSessionLinkClick(session)}
-                  onMouseDown={() => seedSessionDetailCache(session)}
-                  onMouseEnter={() => prefetchRoute(sessionHref)}
-                  onFocus={() => prefetchRoute(sessionHref)}
-                  className={
-                    isSelected
-                      ? "border-transparent bg-primary/5 shadow-none ring-0 md:border-transparent md:bg-primary/5 md:shadow-none"
-                      : "hover:border-border/60 hover:bg-card md:hover:border-transparent md:hover:bg-muted/50"
-                  }
-                >
-                  <span
-                    aria-hidden="true"
-                    className={cn(
-                      "absolute inset-y-2 left-1 w-0.5 rounded-full bg-primary/0 transition-colors duration-150",
-                      isSelected && "bg-primary",
-                    )}
-                  />
-                  <div className="flex items-start gap-2.5 min-w-0">
-                    <div className="mt-1.5 shrink-0">
-                      {isWorkingSession ? (
-                        <StatusDot animate color="bg-primary" pingColor="bg-primary/60" />
-                      ) : hasUnread ? (
-                        <StatusDot color="bg-primary" />
-                      ) : (
-                        <span className="inline-flex rounded-full h-2 w-2" />
-                      )}
-                    </div>
-
-                    <div className="min-w-0 flex-1">
-                      <div className="flex items-start justify-between gap-2">
-                        <p className={cn(
-                          "text-xs font-medium truncate leading-snug",
-                          hasUnread || isWorkingSession ? "text-foreground" : "text-muted-foreground"
-                        )}>
-                          {title}
-                        </p>
-                      </div>
-                      <div className="mt-0.5 flex min-w-0 items-center gap-2">
-                        <div
-                          data-testid={`session-row-meta-scroll-${session.id}`}
-                          className="min-w-0 flex-1 overflow-x-auto overflow-y-hidden scrollbar-hide"
-                        >
-                          <div className="flex min-w-max items-center gap-1.5 pr-1">
-                            <span className="text-xs text-muted-foreground shrink-0">
-                              <span>{cfg.label}</span>
-                              {isWorkingSession && <AnimatedEllipsis />}
-                            </span>
-                            {session.pm_plan_id && !session.triggered_by_user_id && (
-                              <span className="inline-flex items-center rounded-full bg-primary/10 px-1.5 py-0.5 text-xs font-medium text-primary shrink-0">
-                                PM
-                              </span>
-                            )}
-                            <SessionLinearBadge session={session} />
-                            <span className="text-xs text-muted-foreground/50 shrink-0">
-                              {formatTimeAgo(ts)}
-                            </span>
-                            <PRStatusBadge prSummary={session.pr_summary} />
-                            <SessionDiffBadge diffStats={session.diff_stats} />
-                          </div>
-                        </div>
-                      </div>
-                      {session.status === "failed" && (session.failure_explanation || session.error) && (
-                        <p className="text-xs text-destructive/70 truncate mt-0.5">
-                          {session.failure_explanation || session.error}
-                        </p>
-                      )}
-                    </div>
-                  </div>
-                </SessionSidebarRowSurface>
-              </SessionSidebarOptionFrame>
-            </SwipeActionRow>
-          );
-        })}
 
         {loadMoreMutation.isError && (
           <p className="px-2 py-2 text-center text-xs text-destructive/80">

--- a/frontend/src/components/manual-session-composer.tsx
+++ b/frontend/src/components/manual-session-composer.tsx
@@ -69,6 +69,7 @@ import { useSessionComposerSlashCommands } from "@/hooks/use-session-composer-sl
 import { useFileDropzone } from "@/hooks/use-file-dropzone";
 import { clearDraft, loadDraft, saveDraft } from "@/lib/session-draft";
 import { queryKeys } from "@/lib/query-keys";
+import { applyCreatedSessionToSessionListCaches } from "@/lib/session-list-cache";
 import { cn } from "@/lib/utils";
 import {
   agentTypeForModel,
@@ -744,6 +745,7 @@ export function ManualSessionComposer({
       // Keep the optimistic row visible — the sidebar swaps it for the real
       // session once the refetch lands. See OptimisticSession.resolvedId.
       markOptimisticResolved(context.optimisticId, response.data.id);
+      applyCreatedSessionToSessionListCaches(queryClient, response.data);
       queryClient.invalidateQueries({ queryKey: queryKeys.sessions.all });
       setIsNavigatingAfterCreate(true);
       onCreated(response.data.id);

--- a/frontend/src/contexts/optimistic-sessions.tsx
+++ b/frontend/src/contexts/optimistic-sessions.tsx
@@ -3,10 +3,10 @@
 import { createContext, useCallback, useContext, useEffect, useRef, useState } from "react";
 
 /**
- * Safety-net window after resolution before we force-remove a placeholder.
- * The sidebar normally GCs resolved rows as soon as the real session appears
- * in its list, but if the user's current filters exclude the new session (or
- * no sidebar is mounted), the placeholder would otherwise linger forever.
+ * How long to keep a resolved placeholder alive before force-removing it.
+ * The sidebar renders the real session data through the resolved row's stable
+ * key for this window, then the optimistic entry is dropped and the real
+ * session takes over via the regular session list path.
  * 10s comfortably exceeds a typical post-invalidation refetch.
  */
 const RESOLUTION_FALLBACK_MS = 10_000;

--- a/frontend/src/lib/session-list-cache.test.ts
+++ b/frontend/src/lib/session-list-cache.test.ts
@@ -1,7 +1,7 @@
 import { QueryClient } from "@tanstack/react-query";
 import { describe, expect, it } from "vitest";
 import type { ListResponse, SessionDetail, SessionListItem } from "./types";
-import { applySessionDetailToSessionListCaches } from "./session-list-cache";
+import { applyCreatedSessionToSessionListCaches, applySessionDetailToSessionListCaches } from "./session-list-cache";
 
 function makeSession(overrides: Partial<SessionListItem> = {}): SessionListItem {
   return {
@@ -83,6 +83,57 @@ describe("applySessionDetailToSessionListCaches", () => {
     expect(queryClient.getQueryData<ListResponse<SessionListItem>>(["sessions", null, "filtered", "archived", "mine", ""])?.data).toEqual([
       { ...makeSession(), archived_at: "2026-01-01T00:10:00.000Z", threads: undefined },
       other,
+    ]);
+  });
+});
+
+describe("applyCreatedSessionToSessionListCaches", () => {
+  it("prepends newly-created sessions to cached non-archived list responses", () => {
+    const queryClient = new QueryClient();
+    const created = makeSession({ id: "session-created", status: "pending" });
+    const existing = makeSession({ id: "session-existing" });
+
+    queryClient.setQueryData<ListResponse<SessionListItem>>(
+      ["sessions", null, "filtered", "all", "mine"],
+      { data: [existing], meta: {} },
+    );
+    queryClient.setQueryData<ListResponse<SessionListItem>>(
+      ["sessions", null, "filtered", "active", "mine"],
+      { data: [existing], meta: {} },
+    );
+    queryClient.setQueryData<ListResponse<SessionListItem>>(
+      ["sessions", null, "filtered", "archived", "mine"],
+      { data: [makeSession({ id: "archived-session", archived_at: "2026-01-01T00:10:00.000Z" })], meta: {} },
+    );
+
+    applyCreatedSessionToSessionListCaches(queryClient, created);
+
+    expect(queryClient.getQueryData<ListResponse<SessionListItem>>(["sessions", null, "filtered", "all", "mine"])?.data).toEqual([
+      created,
+      existing,
+    ]);
+    expect(queryClient.getQueryData<ListResponse<SessionListItem>>(["sessions", null, "filtered", "active", "mine"])?.data).toEqual([
+      created,
+      existing,
+    ]);
+    expect(queryClient.getQueryData<ListResponse<SessionListItem>>(["sessions", null, "filtered", "archived", "mine"])?.data).toEqual([
+      makeSession({ id: "archived-session", archived_at: "2026-01-01T00:10:00.000Z" }),
+    ]);
+  });
+
+  it("does not duplicate a session already present in cached list responses", () => {
+    const queryClient = new QueryClient();
+    const created = makeSession({ id: "session-created", status: "pending" });
+
+    queryClient.setQueryData<ListResponse<SessionListItem>>(
+      ["sessions", null, "filtered", "all", "mine"],
+      { data: [created], meta: {} },
+    );
+
+    applyCreatedSessionToSessionListCaches(queryClient, created);
+
+    expect(queryClient.getQueryData<ListResponse<SessionListItem>>(["sessions", null, "filtered", "all", "mine"])?.data).toEqual([
+      created,
     ]);
   });
 });

--- a/frontend/src/lib/session-list-cache.ts
+++ b/frontend/src/lib/session-list-cache.ts
@@ -1,6 +1,6 @@
 import type { QueryClient, QueryKey } from "@tanstack/react-query";
 import { queryKeys } from "./query-keys";
-import type { ListResponse, SessionDetail, SessionListItem } from "./types";
+import type { ListResponse, Session, SessionDetail, SessionListItem } from "./types";
 
 function isSessionListResponse(value: unknown): value is ListResponse<SessionListItem> {
   return (
@@ -54,5 +54,26 @@ export function applySessionDetailToSessionListCaches(queryClient: QueryClient, 
     if (changed) {
       queryClient.setQueryData(key, { ...current, data: nextData });
     }
+  }
+}
+
+export function applyCreatedSessionToSessionListCaches(queryClient: QueryClient, created: Session): void {
+  const cachedLists = queryClient.getQueriesData<ListResponse<SessionListItem>>({
+    queryKey: queryKeys.sessions.all,
+  });
+
+  for (const [key, current] of cachedLists) {
+    if (!isSessionListResponse(current) || isArchivedListKey(key)) {
+      continue;
+    }
+
+    if (current.data.some((session) => session.id === created.id)) {
+      continue;
+    }
+
+    queryClient.setQueryData(key, {
+      ...current,
+      data: [created, ...current.data],
+    });
   }
 }


### PR DESCRIPTION
## Summary
This change removes the “ghost”/duplicate optimistic session UI jump when a newly created session is handed off to the real session. It keeps the resolved optimistic ownership stable and ensures the real session appears exactly once, addressing issues around React key transitions and fallback removal timing.

## Changes
- **`frontend/src/app/(dashboard)/sessions/session-sidebar.tsx`**
  - Updated the session row rendering logic for resolved optimistic entries so the optimistic → real-session transition doesn’t cause duplication or flicker.
- **`frontend/src/contexts/optimistic-sessions.tsx`**
  - Adjusted optimistic session handling to support seamless handoff behavior (resolved optimistic ownership remains consistent until removal).
- **`frontend/src/components/manual-session-composer.tsx`**
  - Ensured manual session creation integrates with the updated optimistic handoff behavior.
- **`frontend/src/lib/session-list-cache.ts`**
  - Updated cache behavior to better support list updates during the handoff window.
- **Tests**
  - **`frontend/src/app/(dashboard)/sessions/session-sidebar.test.tsx`**
    - Added coverage for:
      - Keeping resolved optimistic ownership during the real-session handoff.
      - Ensuring the real session appears exactly once when the fallback timer removes the optimistic entry.
  - **`frontend/src/lib/session-list-cache.test.ts`**
    - Updated/extended tests for the adjusted session list caching behavior.

## Test plan
- Ran the frontend test suite (unit/integration via the existing Vitest + React Testing Library setup).
- Verified new session-sidebar tests covering the handoff window and the fallback removal path.

[143.dev](https://143.dev) | [session 6e1d06f0](https://143.dev/sessions/6e1d06f0-9ff0-46e2-834a-4534d4ca3fbe)

Preview: https://143.dev/previews/github/assembledhq/143/pull/1353