### PR TITLE
Add PR/Push status to session cards with low performance impact

### DIFF
--- a/frontend/src/app/(dashboard)/sessions/session-sidebar.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/session-sidebar.test.tsx
@@ -1195,6 +1195,19 @@ describe('SessionSidebar', () => {
     expect(link).toHaveAttribute('href', '/sessions/s1?people=user-2%2Cuser-3');
   });
 
+  it('shows in-flight PR creation and push statuses on session rows', async () => {
+    serveSessions([
+      makeSession({ id: 's1', result_summary: 'Opening a pull request', pr_creation_state: 'queued' }),
+      makeSession({ id: 's2', result_summary: 'Updating an existing pull request', pr_push_state: 'pushing' }),
+    ]);
+
+    renderWithProviders(<SessionSidebar />);
+
+    await screen.findByText('Opening a pull request');
+    expect(screen.getByText('Creating PR')).toBeInTheDocument();
+    expect(screen.getByText('Pushing changes')).toBeInTheDocument();
+  });
+
   it('only serializes the filters that are actually set', async () => {
     serveSessions([
       makeSession({ id: 's1', result_summary: 'Status-only session' }),

--- a/frontend/src/app/(dashboard)/sessions/session-sidebar.tsx
+++ b/frontend/src/app/(dashboard)/sessions/session-sidebar.tsx
@@ -25,6 +25,7 @@ import { SessionLinearBadge as SharedSessionLinearBadge } from "@/components/ses
 import { NoReposWarning } from "@/components/no-repos-warning";
 import type { ListResponse, SessionCounts, SessionDetail, SessionListItem, SingleResponse, User } from "@/lib/types";
 import { prMergedAccent } from "@/lib/pr-status-styles";
+import { deriveSessionDisplayStatus } from "@/lib/session-display-status";
 import { provisionalSessionDetailFromListItem } from "@/lib/session-detail-cache";
 import { hasSessionKeyboardTransientSurface, isSessionKeyboardTextEntryTarget } from "@/hooks/use-session-keyboard-shortcuts";
 import {
@@ -1034,8 +1035,8 @@ export function SessionSidebar() {
 
         {displayedSessions.map((session) => {
           const isSelected = selectedId === session.id;
-          const cfg = statusConfig[session.status] || statusConfig.pending;
-          const isWorkingSession = workingSet.has(session.status);
+          const displayStatus = deriveSessionDisplayStatus(session);
+          const isWorkingSession = displayStatus.animated;
           const hasUnread = isUnread(session);
           const ts = session.completed_at || session.started_at || session.created_at;
           const isArchived = !!session.archived_at;
@@ -1131,8 +1132,8 @@ export function SessionSidebar() {
                         >
                           <div className="flex min-w-max items-center gap-1.5 pr-1">
                             <span className="text-xs text-muted-foreground shrink-0">
-                              <span>{cfg.label}</span>
-                              {isWorkingSession && <AnimatedEllipsis />}
+                              <span>{displayStatus.label}</span>
+                              {displayStatus.animated && <AnimatedEllipsis />}
                             </span>
                             {session.pm_plan_id && !session.triggered_by_user_id && (
                               <span className="inline-flex items-center rounded-full bg-primary/10 px-1.5 py-0.5 text-xs font-medium text-primary shrink-0">

--- a/frontend/src/app/(dashboard)/sessions/sessions-page-content.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/sessions-page-content.test.tsx
@@ -3,6 +3,7 @@ import { http, HttpResponse } from 'msw';
 import { renderWithProviders, screen } from '@/test/test-utils';
 import { server } from '@/test/mocks/server';
 import { SessionsPageContent } from './sessions-page-content';
+import type { SessionListItem } from '@/lib/types';
 
 const mockAuthState: {
   isAuthenticated: boolean;
@@ -26,6 +27,27 @@ vi.mock('next/navigation', () => ({
 vi.mock('@/hooks/use-auth', () => ({
   useAuth: () => mockAuthState,
 }));
+
+function makeSession(overrides: Partial<SessionListItem> = {}): SessionListItem {
+  return {
+    id: 'sess-1',
+    org_id: 'org-1',
+    agent_type: 'claude_code',
+    status: 'completed',
+    autonomy_level: 'full',
+    token_mode: 'standard',
+    current_turn: 1,
+    sandbox_state: 'snapshotted',
+    pr_creation_state: 'idle',
+    pr_push_state: 'idle',
+    created_at: '2026-02-17T07:00:00Z',
+    started_at: '2026-02-17T07:00:00Z',
+    completed_at: '2026-02-17T07:05:00Z',
+    last_activity_at: '2026-02-17T07:05:00Z',
+    result_summary: 'Test session',
+    ...overrides,
+  };
+}
 
 describe('SessionsPageContent', () => {
   beforeEach(() => {
@@ -74,5 +96,28 @@ describe('SessionsPageContent', () => {
 
     expect(await screen.findByText(/Fixed TypeError by adding null check/)).toBeInTheDocument();
     expect(teamRequestCount).toBe(0);
+  });
+
+  it('shows in-flight PR creation and push statuses in the sessions table', async () => {
+    server.use(
+      http.get('/api/v1/sessions', () => {
+        return HttpResponse.json({
+          data: [
+            makeSession({ id: 's1', result_summary: 'Opening a pull request', pr_creation_state: 'queued' }),
+            makeSession({ id: 's2', result_summary: 'Updating an existing pull request', pr_push_state: 'pushing' }),
+          ],
+          meta: {},
+        });
+      }),
+      http.get('/api/v1/sessions/counts', () => {
+        return HttpResponse.json({ data: { all: 2, active: 0, archived: 0, cap: 100 } });
+      }),
+    );
+
+    renderWithProviders(<SessionsPageContent />);
+
+    expect(await screen.findByText('Opening a pull request')).toBeInTheDocument();
+    expect(screen.getByText('Creating PR')).toBeInTheDocument();
+    expect(screen.getByText('Pushing changes')).toBeInTheDocument();
   });
 });

--- a/frontend/src/app/(dashboard)/sessions/sessions-page-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/sessions-page-content.tsx
@@ -35,31 +35,13 @@ import { StatusDot } from "@/components/status-dot";
 import { AnimatedEllipsis } from "@/components/animated-ellipsis";
 import { AgentBadge } from "@/components/agent-badge";
 import { usePeopleFilter } from "@/hooks/use-people-filter";
-import { prMergedAccent } from "@/lib/pr-status-styles";
 import { provisionalSessionDetailFromListItem } from "@/lib/session-detail-cache";
-import type { Session, SessionDetail, SessionListItem, SessionStatus, SingleResponse, User } from "@/lib/types";
+import { deriveSessionDisplayStatus, type SessionDisplayStatus } from "@/lib/session-display-status";
+import type { Session, SessionDetail, SessionListItem, SingleResponse, User } from "@/lib/types";
 import {
-  workingSet,
   filterToStatusParam as baseFilterToStatusParam,
 } from "@/lib/session-status-groups";
 import { getCountForTab, renderCount } from "@/lib/session-counts";
-
-// ---------------------------------------------------------------------------
-// Status config
-// ---------------------------------------------------------------------------
-
-const statusConfig: Record<SessionStatus, { dot: string; text: string; bg: string; label: string }> = {
-  pending: { dot: "bg-muted-foreground/50", text: "text-muted-foreground", bg: "bg-muted", label: "Pending" },
-  running: { dot: "bg-primary", text: "text-primary", bg: "bg-primary/10", label: "Running" },
-  idle: { dot: "bg-primary", text: "text-primary", bg: "bg-primary/10", label: "Idle" },
-  awaiting_input: { dot: "bg-warning", text: "text-warning", bg: "bg-warning/10", label: "Awaiting input" },
-  needs_human_guidance: { dot: "bg-attention", text: "text-attention", bg: "bg-attention/10", label: "Needs guidance" },
-  completed: { dot: "bg-success", text: "text-success", bg: "bg-success/10", label: "Completed" },
-  pr_created: { dot: prMergedAccent.dot, text: prMergedAccent.text, bg: prMergedAccent.bg, label: "PR created" },
-  failed: { dot: "bg-destructive", text: "text-destructive", bg: "bg-destructive/10", label: "Failed" },
-  cancelled: { dot: "bg-muted-foreground/50", text: "text-muted-foreground", bg: "bg-muted", label: "Cancelled" },
-  skipped: { dot: "bg-muted-foreground/30", text: "text-muted-foreground", bg: "bg-muted", label: "Skipped" },
-};
 
 const filterTabs = [
   { value: "all", label: "All" },
@@ -76,13 +58,11 @@ function filterToStatusParam(filter: string | null): string | undefined {
 // Inline cell components
 // ---------------------------------------------------------------------------
 
-function SessionStatusDot({ status }: { status: SessionStatus }) {
-  const working = workingSet.has(status);
-  const cfg = statusConfig[status];
-  if (working) {
+function SessionStatusDot({ displayStatus }: { displayStatus: SessionDisplayStatus }) {
+  if (displayStatus.animated) {
     return <StatusDot animate color="bg-primary" pingColor="bg-primary/60" />;
   }
-  return <StatusDot color={cfg.dot} />;
+  return <StatusDot color={displayStatus.dotClass} />;
 }
 
 function SortableHeader({ label, column }: { label: string; column: { toggleSorting: (desc?: boolean) => void; getIsSorted: () => false | "asc" | "desc" } }) {
@@ -109,15 +89,13 @@ function buildColumns(members: User[]): ColumnDef<Session>[] {
       header: ({ column }) => <SortableHeader label="Status" column={column} />,
       size: 140,
       cell: ({ row }) => {
-        const status = row.original.status;
-        const cfg = statusConfig[status];
-        const working = workingSet.has(status);
+        const displayStatus = deriveSessionDisplayStatus(row.original);
         return (
           <div className="flex items-center gap-2">
-            <SessionStatusDot status={status} />
-            <span className={`text-xs font-medium ${cfg.text}`}>
-              <span>{cfg.label}</span>
-              {working && <AnimatedEllipsis />}
+            <SessionStatusDot displayStatus={displayStatus} />
+            <span className={`text-xs font-medium ${displayStatus.textClass}`}>
+              <span>{displayStatus.label}</span>
+              {displayStatus.animated && <AnimatedEllipsis />}
             </span>
           </div>
         );

--- a/frontend/src/lib/session-display-status.test.ts
+++ b/frontend/src/lib/session-display-status.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "vitest";
+
+import { deriveSessionDisplayStatus } from "./session-display-status";
+import type { Session } from "./types";
+
+function makeSession(overrides: Partial<Session> = {}): Session {
+  return {
+    id: "session-1",
+    org_id: "org-1",
+    agent_type: "codex",
+    status: "completed",
+    autonomy_level: "semi",
+    token_mode: "standard",
+    current_turn: 1,
+    last_activity_at: "2026-01-01T00:00:00.000Z",
+    sandbox_state: "snapshotted",
+    pr_creation_state: "idle",
+    pr_push_state: "idle",
+    created_at: "2026-01-01T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+describe("deriveSessionDisplayStatus", () => {
+  it("uses the regular session status when no PR action is in flight", () => {
+    const status = deriveSessionDisplayStatus(makeSession({ status: "idle" }));
+
+    expect(status.label, "idle sessions should keep their normal status label").toBe("Idle");
+    expect(status.kind, "idle sessions should be classified as session status").toBe("session");
+    expect(status.animated, "idle sessions should not animate as an in-flight PR action").toBe(false);
+  });
+
+  it("shows PR creation while create PR is queued or pushing", () => {
+    const tests = [
+      { name: "queued", state: "queued" as const },
+      { name: "pushing", state: "pushing" as const },
+    ];
+
+    for (const tt of tests) {
+      const status = deriveSessionDisplayStatus(makeSession({ pr_creation_state: tt.state }));
+
+      expect(status.label, `${tt.name} PR creation should override the session status`).toBe("Creating PR");
+      expect(status.kind, `${tt.name} PR creation should identify the PR creation kind`).toBe("pr_creation");
+      expect(status.animated, `${tt.name} PR creation should animate`).toBe(true);
+    }
+  });
+
+  it("shows push changes while a PR push is queued or pushing", () => {
+    const tests = [
+      { name: "queued", state: "queued" as const },
+      { name: "pushing", state: "pushing" as const },
+    ];
+
+    for (const tt of tests) {
+      const status = deriveSessionDisplayStatus(makeSession({ pr_push_state: tt.state }));
+
+      expect(status.label, `${tt.name} PR push should override the session status`).toBe("Pushing changes");
+      expect(status.kind, `${tt.name} PR push should identify the PR push kind`).toBe("pr_push");
+      expect(status.animated, `${tt.name} PR push should animate`).toBe(true);
+    }
+  });
+
+  it("prioritizes PR pushes over PR creation when both are in flight", () => {
+    const status = deriveSessionDisplayStatus(makeSession({
+      pr_creation_state: "pushing",
+      pr_push_state: "queued",
+    }));
+
+    expect(status.label, "push changes should be the more specific in-flight status").toBe("Pushing changes");
+    expect(status.kind, "push changes should win over PR creation").toBe("pr_push");
+  });
+
+  it("does not let failed PR actions override the primary session status", () => {
+    const status = deriveSessionDisplayStatus(makeSession({
+      status: "completed",
+      pr_creation_state: "failed",
+      pr_push_state: "failed",
+    }));
+
+    expect(status.label, "failed PR actions should not make the whole session look failed").toBe("Completed");
+    expect(status.kind, "failed PR actions should leave the primary status as session status").toBe("session");
+  });
+});

--- a/frontend/src/lib/session-display-status.ts
+++ b/frontend/src/lib/session-display-status.ts
@@ -1,6 +1,6 @@
 import { prMergedAccent } from "./pr-status-styles";
 import { workingSet } from "./session-status-groups";
-import type { Session, SessionStatus } from "./types";
+import type { PRCreationState, PRPushState, Session, SessionStatus } from "./types";
 
 export type SessionDisplayStatusKind = "session" | "pr_creation" | "pr_push";
 
@@ -32,7 +32,7 @@ const prActionStatus = {
   bgClass: "bg-primary/10",
 };
 
-function isInFlightState(state?: string): boolean {
+function isInFlightState(state?: PRCreationState | PRPushState): boolean {
   return state === "queued" || state === "pushing";
 }
 

--- a/frontend/src/lib/session-display-status.ts
+++ b/frontend/src/lib/session-display-status.ts
@@ -1,0 +1,64 @@
+import { prMergedAccent } from "./pr-status-styles";
+import { workingSet } from "./session-status-groups";
+import type { Session, SessionStatus } from "./types";
+
+export type SessionDisplayStatusKind = "session" | "pr_creation" | "pr_push";
+
+export type SessionDisplayStatus = {
+  kind: SessionDisplayStatusKind;
+  label: string;
+  dotClass: string;
+  textClass: string;
+  bgClass: string;
+  animated: boolean;
+};
+
+const sessionStatusConfig: Record<SessionStatus, Omit<SessionDisplayStatus, "kind" | "animated">> = {
+  pending: { dotClass: "bg-muted-foreground/50", textClass: "text-muted-foreground", bgClass: "bg-muted", label: "Pending" },
+  running: { dotClass: "bg-primary", textClass: "text-primary", bgClass: "bg-primary/10", label: "Running" },
+  idle: { dotClass: "bg-primary", textClass: "text-primary", bgClass: "bg-primary/10", label: "Idle" },
+  awaiting_input: { dotClass: "bg-warning", textClass: "text-warning", bgClass: "bg-warning/10", label: "Awaiting input" },
+  needs_human_guidance: { dotClass: "bg-attention", textClass: "text-attention", bgClass: "bg-attention/10", label: "Needs guidance" },
+  completed: { dotClass: "bg-success", textClass: "text-success", bgClass: "bg-success/10", label: "Completed" },
+  pr_created: { dotClass: prMergedAccent.dot, textClass: prMergedAccent.text, bgClass: prMergedAccent.bg, label: "PR created" },
+  failed: { dotClass: "bg-destructive", textClass: "text-destructive", bgClass: "bg-destructive/10", label: "Failed" },
+  cancelled: { dotClass: "bg-muted-foreground/50", textClass: "text-muted-foreground", bgClass: "bg-muted", label: "Cancelled" },
+  skipped: { dotClass: "bg-muted-foreground/30", textClass: "text-muted-foreground", bgClass: "bg-muted", label: "Skipped" },
+};
+
+const prActionStatus = {
+  dotClass: "bg-primary",
+  textClass: "text-primary",
+  bgClass: "bg-primary/10",
+};
+
+function isInFlightState(state?: string): boolean {
+  return state === "queued" || state === "pushing";
+}
+
+export function deriveSessionDisplayStatus(session: Pick<Session, "status" | "pr_creation_state" | "pr_push_state">): SessionDisplayStatus {
+  if (isInFlightState(session.pr_push_state)) {
+    return {
+      kind: "pr_push",
+      label: "Pushing changes",
+      animated: true,
+      ...prActionStatus,
+    };
+  }
+
+  if (isInFlightState(session.pr_creation_state)) {
+    return {
+      kind: "pr_creation",
+      label: "Creating PR",
+      animated: true,
+      ...prActionStatus,
+    };
+  }
+
+  const config = sessionStatusConfig[session.status] ?? sessionStatusConfig.pending;
+  return {
+    kind: "session",
+    animated: workingSet.has(session.status),
+    ...config,
+  };
+}

--- a/frontend/src/lib/session-pr-action-state.ts
+++ b/frontend/src/lib/session-pr-action-state.ts
@@ -1,4 +1,4 @@
-import type { PullRequestHealthResponse } from "./types";
+import type { PRCreationState, PRPushState, PullRequestHealthResponse } from "./types";
 
 type RepairableFailedChecksInput = Pick<PullRequestHealthResponse, "can_fix_tests" | "failing_test_count" | "checks">;
 
@@ -34,7 +34,7 @@ export type CreatePRActionInput = {
   queueingPR: boolean;
   creatingPR: boolean;
   finalizingPR: boolean;
-  prState?: "idle" | "queued" | "pushing" | "succeeded" | "failed";
+  prState?: PRCreationState;
   prCreationError?: string;
   localError?: string;
   hasRecoverableError: boolean;
@@ -163,7 +163,7 @@ export type PushChangesActionInput = {
   ghBlocked: boolean;
   queueingPush: boolean;
   pushingChanges: boolean;
-  pushState?: "idle" | "queued" | "pushing" | "succeeded" | "failed";
+  pushState?: PRPushState;
   pushError?: string;
   localError?: string;
 };

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -461,11 +461,11 @@ export interface Session {
   recovery_queued_at?: string;
   recovery_started_at?: string;
   recovery_attempt_count?: number;
-  pr_creation_state?: "idle" | "queued" | "pushing" | "succeeded" | "failed";
+  pr_creation_state?: PRCreationState;
   pr_creation_error?: string;
-  pr_push_state?: "idle" | "queued" | "pushing" | "succeeded" | "failed";
+  pr_push_state?: PRPushState;
   pr_push_error?: string;
-  branch_creation_state?: "idle" | "queued" | "pushing" | "succeeded" | "failed";
+  branch_creation_state?: BranchCreationState;
   branch_creation_error?: string;
   branch_url?: string;
   has_unpushed_changes?: boolean;
@@ -2153,15 +2153,24 @@ export interface AutomationRun {
   session?: AutomationRunSession;
 }
 
-// Mirrors models.PRCreationState. Kept as a literal union so the row UI
-// gets exhaustiveness checks when branching on it (e.g. the "Creating PR…"
-// pill on completed_no_pr rows).
-export type PRCreationState =
+// Mirrors the session publish lifecycle enums in internal/models/session_enums.go.
+// Kept as a literal union so UI branches get exhaustiveness checks while only
+// accepting backend-defined enum values.
+export type SessionPublishState =
   | 'idle'
   | 'queued'
   | 'pushing'
   | 'succeeded'
   | 'failed';
+
+// Mirrors models.PRCreationState.
+export type PRCreationState = SessionPublishState;
+
+// Mirrors models.PRPushState.
+export type PRPushState = SessionPublishState;
+
+// Mirrors models.BranchCreationState.
+export type BranchCreationState = SessionPublishState;
 
 export interface AutomationRunSession {
   id: string;


### PR DESCRIPTION
## Summary
This change adds visible PR creation and push status labels to the session sidebar/cards by deriving a display status directly from existing `SessionListItem` fields. It avoids per-row fetching/polling to keep rendering performance stable, and adds test coverage for the new UI states.

## Changes
- `frontend/src/app/(dashboard)/sessions/session-sidebar.tsx`
  - Replaced `statusConfig[session.status]`/`workingSet` logic with `deriveSessionDisplayStatus(session)`.
  - Sidebar now shows a human-readable label (e.g., “Creating PR”, “Pushing changes”) and only animates the ellipsis when `displayStatus.animated` is true.
- `frontend/src/lib/session-display-status.ts`
  - Added `deriveSessionDisplayStatus(session)` to map `pr_creation_state` / `pr_push_state` (and existing session fields) into a consistent `{ label, animated }` display model.
- Tests
  - `frontend/src/app/(dashboard)/sessions/session-sidebar.test.tsx`: added a test asserting PR creation and push statuses appear on session rows.
  - `frontend/src/app/(dashboard)/sessions/sessions-page-content.tsx` + `.test.tsx`: updated/added coverage to ensure the new derived display status behaves correctly on the sessions page.
  - `frontend/src/lib/session-display-status.test.ts`: added unit tests for the status derivation logic.

## Test plan
- Ran frontend checks: Vitest (including the updated sidebar/page-content tests), `typecheck`, `lint`, and `build`.
- Verified the new UI test scenarios for “in-flight PR creation” (`pr_creation_state: queued`) and “push” (`pr_push_state: pushing`) render the expected labels.

[143.dev](https://143.dev) | [session 07f69a22](https://143.dev/sessions/07f69a22-b02a-49e2-829f-95712b512784)

Preview: https://143.dev/previews/github/assembledhq/143/pull/1354