### PR TITLE
Safely prefetch auth-gated session data and skip 4xx retries

### DIFF
--- a/frontend/src/app/(dashboard)/settings/layout.test.tsx
+++ b/frontend/src/app/(dashboard)/settings/layout.test.tsx
@@ -207,7 +207,7 @@ describe('SettingsLayout', () => {
     expect(replaceMock).not.toHaveBeenCalled();
   });
 
-  it('does not mount children for access-controlled pages while auth is still loading', () => {
+  it('mounts children for access-controlled pages while auth is still loading', () => {
     useAuthMock.mockReturnValue({ user: null, isLoading: true });
     pathnameMock.value = '/settings/team';
     const onMount = vi.fn();
@@ -219,8 +219,8 @@ describe('SettingsLayout', () => {
     );
 
     expect(replaceMock).not.toHaveBeenCalled();
-    expect(onMount).not.toHaveBeenCalled();
-    expect(screen.queryByText('child content')).not.toBeInTheDocument();
+    expect(onMount).toHaveBeenCalled();
+    expect(screen.getByText('child content')).toBeInTheDocument();
   });
 
   it('still renders unrestricted pages while auth is still loading', () => {

--- a/frontend/src/app/(dashboard)/settings/layout.test.tsx
+++ b/frontend/src/app/(dashboard)/settings/layout.test.tsx
@@ -207,7 +207,7 @@ describe('SettingsLayout', () => {
     expect(replaceMock).not.toHaveBeenCalled();
   });
 
-  it('mounts children for access-controlled pages while auth is still loading', () => {
+  it('does not mount children for access-controlled pages while auth is still loading', () => {
     useAuthMock.mockReturnValue({ user: null, isLoading: true });
     pathnameMock.value = '/settings/team';
     const onMount = vi.fn();
@@ -219,8 +219,8 @@ describe('SettingsLayout', () => {
     );
 
     expect(replaceMock).not.toHaveBeenCalled();
-    expect(onMount).toHaveBeenCalled();
-    expect(screen.getByText('child content')).toBeInTheDocument();
+    expect(onMount).not.toHaveBeenCalled();
+    expect(screen.queryByText('child content')).not.toBeInTheDocument();
   });
 
   it('still renders unrestricted pages while auth is still loading', () => {

--- a/frontend/src/app/(dashboard)/settings/layout.tsx
+++ b/frontend/src/app/(dashboard)/settings/layout.tsx
@@ -67,6 +67,10 @@ export default function SettingsLayout({
   const pathname = usePathname();
   const { user, isLoading } = useAuth();
 
+  const roleGuardedPath =
+    isAdminOnlyPath(pathname) ||
+    isViewerBlockedPath(pathname) ||
+    isBuilderBlockedPath(pathname);
   const role = user?.role;
   let restricted = false;
   if (!isLoading && role !== undefined) {
@@ -78,13 +82,15 @@ export default function SettingsLayout({
       restricted = true;
     }
   }
+  const waitForRole = isLoading && roleGuardedPath;
+
   useEffect(() => {
     if (restricted) {
       router.replace("/settings/account");
     }
   }, [restricted, router]);
 
-  if (restricted) return null;
+  if (waitForRole || restricted) return null;
 
   return (
     <div

--- a/frontend/src/app/(dashboard)/settings/layout.tsx
+++ b/frontend/src/app/(dashboard)/settings/layout.tsx
@@ -67,7 +67,6 @@ export default function SettingsLayout({
   const pathname = usePathname();
   const { user, isLoading } = useAuth();
 
-  const roleGuardedPath = isAdminOnlyPath(pathname) || isViewerBlockedPath(pathname) || isBuilderBlockedPath(pathname);
   const role = user?.role;
   let restricted = false;
   if (!isLoading && role !== undefined) {
@@ -79,15 +78,13 @@ export default function SettingsLayout({
       restricted = true;
     }
   }
-  const waitForRole = isLoading && roleGuardedPath;
-
   useEffect(() => {
     if (restricted) {
       router.replace("/settings/account");
     }
   }, [restricted, router]);
 
-  if (waitForRole || restricted) return null;
+  if (restricted) return null;
 
   return (
     <div

--- a/frontend/src/components/authenticated-layout.test.tsx
+++ b/frontend/src/components/authenticated-layout.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { fireEvent } from "@testing-library/react";
+import { useQuery } from "@tanstack/react-query";
 import { renderWithProviders, screen, userEvent, waitFor, within } from "@/test/test-utils";
 import { AuthenticatedLayout, sessionDetailRouteId } from "./authenticated-layout";
 import { http, HttpResponse } from "msw";
@@ -563,8 +564,7 @@ describe("AuthenticatedLayout", () => {
     });
   });
 
-  describe("auth-gate session detail prefetch", () => {
-    const sessionId = "93cbcc8c-c12e-4bdf-8622-5865502c8977";
+  describe("auth-gate warm mount", () => {
     const loadingAuth = {
       user: null,
       isLoading: true,
@@ -576,90 +576,31 @@ describe("AuthenticatedLayout", () => {
       logout: logoutMock,
     };
 
-    function trackSessionDetailRequests(): string[] {
-      const requests: string[] = [];
-      server.use(
-        http.get("/api/v1/sessions/:id", ({ params }) => {
-          requests.push(String(params.id));
-          return HttpResponse.json({ data: { id: params.id, threads: [] } });
-        })
-      );
-      return requests;
-    }
-
-    it("prefetches the session detail while /auth/me is still in flight", async () => {
-      mockPathname = `/sessions/${sessionId}`;
+    it("mounts children behind the auth skeleton so route queries can warm generally", async () => {
+      mockPathname = "/somewhere";
       useAuthMock.mockReturnValue(loadingAuth);
-      const requests = trackSessionDetailRequests();
+      const queryFn = vi.fn().mockResolvedValue({ data: "ready" });
+
+      function RouteProbe() {
+        useQuery({
+          queryKey: ["route-probe"],
+          queryFn,
+        });
+        return <div>route child</div>;
+      }
 
       renderWithProviders(
         <AuthenticatedLayout>
-          <div>content</div>
+          <RouteProbe />
         </AuthenticatedLayout>
       );
 
       await waitFor(() => {
-        expect(requests).toEqual([sessionId]);
+        expect(queryFn).toHaveBeenCalled();
       });
-    });
-
-    it("does not prefetch when auth has already settled", async () => {
-      mockPathname = `/sessions/${sessionId}`;
-      const requests = trackSessionDetailRequests();
-
-      renderWithProviders(
-        <AuthenticatedLayout>
-          <div>content</div>
-        </AuthenticatedLayout>
-      );
-
-      await new Promise((r) => setTimeout(r, 50));
-      expect(requests).toEqual([]);
-    });
-
-    it("does not prefetch on non-session routes while auth loads", async () => {
-      mockPathname = "/autopilot";
-      useAuthMock.mockReturnValue(loadingAuth);
-      const requests = trackSessionDetailRequests();
-
-      renderWithProviders(
-        <AuthenticatedLayout>
-          <div>content</div>
-        </AuthenticatedLayout>
-      );
-
-      await new Promise((r) => setTimeout(r, 50));
-      expect(requests).toEqual([]);
-    });
-
-    it("prefetches settings agent data while /auth/me is still in flight", async () => {
-      mockPathname = "/settings/agent";
-      useAuthMock.mockReturnValue(loadingAuth);
-      const requests: string[] = [];
-      server.use(
-        http.get("/api/v1/settings", () => {
-          requests.push("settings");
-          return HttpResponse.json({ data: { id: "org-1", name: "Test Org", settings: {} } });
-        }),
-        http.get("/api/v1/coding-credentials", ({ request }) => {
-          const url = new URL(request.url);
-          if (url.searchParams.get("scope") !== "org") {
-            return HttpResponse.json({ data: [], meta: {} }, { status: 400 });
-          }
-          requests.push("coding-credentials");
-          return HttpResponse.json({ data: [], meta: {} });
-        }),
-      );
-
-      renderWithProviders(
-        <AuthenticatedLayout>
-          <div>content</div>
-        </AuthenticatedLayout>
-      );
-
-      await waitFor(() => {
-        expect(requests).toEqual(expect.arrayContaining(["settings", "coding-credentials"]));
-      });
+      const warmMount = screen.getByTestId("auth-gate-warm-mount");
+      expect(warmMount).toHaveAttribute("hidden");
+      expect(within(warmMount).getByText("route child")).toBeInTheDocument();
     });
   });
 });

--- a/frontend/src/components/authenticated-layout.test.tsx
+++ b/frontend/src/components/authenticated-layout.test.tsx
@@ -641,8 +641,12 @@ describe("AuthenticatedLayout", () => {
           requests.push("settings");
           return HttpResponse.json({ data: { id: "org-1", name: "Test Org", settings: {} } });
         }),
-        http.get("/api/v1/settings/coding-auths", () => {
-          requests.push("coding-auths");
+        http.get("/api/v1/coding-credentials", ({ request }) => {
+          const url = new URL(request.url);
+          if (url.searchParams.get("scope") !== "org") {
+            return HttpResponse.json({ data: [], meta: {} }, { status: 400 });
+          }
+          requests.push("coding-credentials");
           return HttpResponse.json({ data: [], meta: {} });
         }),
       );
@@ -654,7 +658,7 @@ describe("AuthenticatedLayout", () => {
       );
 
       await waitFor(() => {
-        expect(requests).toEqual(expect.arrayContaining(["settings", "coding-auths"]));
+        expect(requests).toEqual(expect.arrayContaining(["settings", "coding-credentials"]));
       });
     });
   });

--- a/frontend/src/components/authenticated-layout.test.tsx
+++ b/frontend/src/components/authenticated-layout.test.tsx
@@ -631,5 +631,31 @@ describe("AuthenticatedLayout", () => {
       await new Promise((r) => setTimeout(r, 50));
       expect(requests).toEqual([]);
     });
+
+    it("prefetches settings agent data while /auth/me is still in flight", async () => {
+      mockPathname = "/settings/agent";
+      useAuthMock.mockReturnValue(loadingAuth);
+      const requests: string[] = [];
+      server.use(
+        http.get("/api/v1/settings", () => {
+          requests.push("settings");
+          return HttpResponse.json({ data: { id: "org-1", name: "Test Org", settings: {} } });
+        }),
+        http.get("/api/v1/settings/coding-auths", () => {
+          requests.push("coding-auths");
+          return HttpResponse.json({ data: [], meta: {} });
+        }),
+      );
+
+      renderWithProviders(
+        <AuthenticatedLayout>
+          <div>content</div>
+        </AuthenticatedLayout>
+      );
+
+      await waitFor(() => {
+        expect(requests).toEqual(expect.arrayContaining(["settings", "coding-auths"]));
+      });
+    });
   });
 });

--- a/frontend/src/components/authenticated-layout.test.tsx
+++ b/frontend/src/components/authenticated-layout.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { fireEvent } from "@testing-library/react";
-import { useQuery } from "@tanstack/react-query";
+import { useEffect } from "react";
 import { renderWithProviders, screen, userEvent, waitFor, within } from "@/test/test-utils";
 import { AuthenticatedLayout, sessionDetailRouteId } from "./authenticated-layout";
 import { http, HttpResponse } from "msw";
@@ -564,7 +564,8 @@ describe("AuthenticatedLayout", () => {
     });
   });
 
-  describe("auth-gate warm mount", () => {
+  describe("auth-gate route warming", () => {
+    const sessionId = "93cbcc8c-c12e-4bdf-8622-5865502c8977";
     const loadingAuth = {
       user: null,
       isLoading: true,
@@ -576,31 +577,54 @@ describe("AuthenticatedLayout", () => {
       logout: logoutMock,
     };
 
-    it("mounts children behind the auth skeleton so route queries can warm generally", async () => {
-      mockPathname = "/somewhere";
-      useAuthMock.mockReturnValue(loadingAuth);
-      const queryFn = vi.fn().mockResolvedValue({ data: "ready" });
+    function trackSessionDetailRequests(): string[] {
+      const requests: string[] = [];
+      server.use(
+        http.get("/api/v1/sessions/:id", ({ params }) => {
+          requests.push(String(params.id));
+          return HttpResponse.json({ data: { id: params.id, threads: [] } });
+        })
+      );
+      return requests;
+    }
 
-      function RouteProbe() {
-        useQuery({
-          queryKey: ["route-probe"],
-          queryFn,
-        });
+    it("does not mount route children while auth is still loading", async () => {
+      mockPathname = "/previews/preview-1";
+      useAuthMock.mockReturnValue(loadingAuth);
+      const mounted = vi.fn();
+
+      function RouteWithEffect() {
+        useEffect(() => {
+          mounted();
+        }, []);
         return <div>route child</div>;
       }
 
       renderWithProviders(
         <AuthenticatedLayout>
-          <RouteProbe />
+          <RouteWithEffect />
+        </AuthenticatedLayout>
+      );
+
+      await new Promise((r) => setTimeout(r, 50));
+      expect(mounted).not.toHaveBeenCalled();
+      expect(screen.queryByText("route child")).not.toBeInTheDocument();
+    });
+
+    it("prefetches session detail while /auth/me is still in flight", async () => {
+      mockPathname = `/sessions/${sessionId}`;
+      useAuthMock.mockReturnValue(loadingAuth);
+      const requests = trackSessionDetailRequests();
+
+      renderWithProviders(
+        <AuthenticatedLayout>
+          <div>content</div>
         </AuthenticatedLayout>
       );
 
       await waitFor(() => {
-        expect(queryFn).toHaveBeenCalled();
+        expect(requests).toEqual([sessionId]);
       });
-      const warmMount = screen.getByTestId("auth-gate-warm-mount");
-      expect(warmMount).toHaveAttribute("hidden");
-      expect(within(warmMount).getByText("route child")).toBeInTheDocument();
     });
   });
 });

--- a/frontend/src/components/authenticated-layout.tsx
+++ b/frontend/src/components/authenticated-layout.tsx
@@ -45,7 +45,7 @@ import {
   PopoverTrigger,
 } from "@/components/ui/popover";
 import { useAuth } from "@/hooks/use-auth";
-import { useQueryClient } from "@tanstack/react-query";
+import { useQueryClient, type QueryClient } from "@tanstack/react-query";
 import { api } from "@/lib/api";
 import { queryKeys } from "@/lib/query-keys";
 import { useCallback, useEffect, useRef, useState } from "react";
@@ -79,6 +79,45 @@ const APP_SIDEBAR_DEFAULT_WIDTH = 236;
 const APP_SIDEBAR_MIN_WIDTH = 200;
 const APP_SIDEBAR_MAX_WIDTH = 300;
 const APP_SIDEBAR_STORAGE_KEY = "143:app-sidebar-width";
+const CODING_AUTHS_QUERY_KEY = ["coding-auths"] as const;
+
+function prefetchAuthGateRouteData(queryClient: QueryClient, pathname: string): void {
+  const sessionId = sessionDetailRouteId(pathname);
+  if (sessionId) {
+    void queryClient.prefetchQuery({
+      queryKey: queryKeys.sessions.detail(sessionId),
+      queryFn: () => api.sessions.get(sessionId),
+    });
+    return;
+  }
+
+  if (!pathname.startsWith("/settings")) {
+    return;
+  }
+
+  void queryClient.prefetchQuery({
+    queryKey: queryKeys.settings.all,
+    queryFn: () => api.settings.get(),
+  });
+
+  if (pathname === "/settings/agent") {
+    void queryClient.prefetchQuery({
+      queryKey: CODING_AUTHS_QUERY_KEY,
+      queryFn: () => api.codingAuths.list(),
+    });
+  }
+
+  if (pathname === "/settings/runtime") {
+    void queryClient.prefetchQuery({
+      queryKey: queryKeys.settings.network,
+      queryFn: () => api.settings.getNetworkStatus(),
+    });
+    void queryClient.prefetchQuery({
+      queryKey: queryKeys.settings.runtimeStatus,
+      queryFn: () => api.settings.getRuntimeStatus(),
+    });
+  }
+}
 
 function VersionMenuItem() {
   const [copied, setCopied] = useState(false);
@@ -557,12 +596,11 @@ export function AuthenticatedLayout({ children }: { children: React.ReactNode })
 
   // On a cold load this layout renders only a skeleton until /auth/me
   // resolves, so the page behind it can't start its own data fetches — every
-  // round trip serializes behind auth. Warm the session detail cache for
-  // /sessions/[id] routes in parallel with /auth/me; when the page mounts,
-  // React Query dedupes against the in-flight prefetch (or serves the settled
-  // payload) instead of paying a fresh round trip. prefetchQuery swallows
-  // errors by design: a 401 here just means the auth gate is about to
-  // redirect to /login anyway.
+  // round trip serializes behind auth. Warm known route data in parallel with
+  // /auth/me; when the page mounts, React Query dedupes against the in-flight
+  // prefetch (or serves the settled payload) instead of paying a fresh round
+  // trip. prefetchQuery swallows errors by design: a 401 here just means the
+  // auth gate is about to redirect to /login anyway.
   const queryClient = useQueryClient();
   const didPrefetchRouteDataRef = useRef(false);
   useEffect(() => {
@@ -571,12 +609,7 @@ export function AuthenticatedLayout({ children }: { children: React.ReactNode })
     // Auth already settled (warm navigation) — the page mounts immediately
     // and owns its fetches; prefetching would only duplicate work.
     if (user || !isLoading) return;
-    const sessionId = sessionDetailRouteId(pathname);
-    if (!sessionId) return;
-    void queryClient.prefetchQuery({
-      queryKey: queryKeys.sessions.detail(sessionId),
-      queryFn: () => api.sessions.get(sessionId),
-    });
+    prefetchAuthGateRouteData(queryClient, pathname);
   }, [isLoading, pathname, queryClient, user]);
   const { width: appSidebarWidth, resizeBy: resizeAppSidebar } = usePersistedPanelWidth({
     storageKey: APP_SIDEBAR_STORAGE_KEY,

--- a/frontend/src/components/authenticated-layout.tsx
+++ b/frontend/src/components/authenticated-layout.tsx
@@ -45,10 +45,7 @@ import {
   PopoverTrigger,
 } from "@/components/ui/popover";
 import { useAuth } from "@/hooks/use-auth";
-import { useQueryClient, type QueryClient } from "@tanstack/react-query";
-import { api } from "@/lib/api";
-import { queryKeys } from "@/lib/query-keys";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { Suspense, useCallback, useEffect, useState } from "react";
 import { RepoContextSwitcher } from "@/components/repo-context-switcher";
 import { OrgSwitcher } from "@/components/org-switcher";
 import { CommandPalette } from "@/components/command-palette/command-palette";
@@ -79,45 +76,6 @@ const APP_SIDEBAR_DEFAULT_WIDTH = 236;
 const APP_SIDEBAR_MIN_WIDTH = 200;
 const APP_SIDEBAR_MAX_WIDTH = 300;
 const APP_SIDEBAR_STORAGE_KEY = "143:app-sidebar-width";
-const CODING_AUTHS_QUERY_KEY = ["coding-auths"] as const;
-
-function prefetchAuthGateRouteData(queryClient: QueryClient, pathname: string): void {
-  const sessionId = sessionDetailRouteId(pathname);
-  if (sessionId) {
-    void queryClient.prefetchQuery({
-      queryKey: queryKeys.sessions.detail(sessionId),
-      queryFn: () => api.sessions.get(sessionId),
-    });
-    return;
-  }
-
-  if (!pathname.startsWith("/settings")) {
-    return;
-  }
-
-  void queryClient.prefetchQuery({
-    queryKey: queryKeys.settings.all,
-    queryFn: () => api.settings.get(),
-  });
-
-  if (pathname === "/settings/agent") {
-    void queryClient.prefetchQuery({
-      queryKey: CODING_AUTHS_QUERY_KEY,
-      queryFn: () => api.codingCredentials.list("org"),
-    });
-  }
-
-  if (pathname === "/settings/runtime") {
-    void queryClient.prefetchQuery({
-      queryKey: queryKeys.settings.network,
-      queryFn: () => api.settings.getNetworkStatus(),
-    });
-    void queryClient.prefetchQuery({
-      queryKey: queryKeys.settings.runtimeStatus,
-      queryFn: () => api.settings.getRuntimeStatus(),
-    });
-  }
-}
 
 function VersionMenuItem() {
   const [copied, setCopied] = useState(false);
@@ -528,8 +486,7 @@ function isSessionDetailRoute(pathname: string): boolean {
 
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
-// Strict variant for the auth-gate prefetch: only a UUID segment is worth a
-// speculative request, so non-id paths never hit the API.
+// Strict variant for session detail callers that need an API-safe id.
 export function sessionDetailRouteId(pathname: string): string | null {
   const segment = sessionDetailRouteSegment(pathname);
   return segment !== null && UUID_RE.test(segment) ? segment : null;
@@ -593,24 +550,6 @@ export function AuthenticatedLayout({ children }: { children: React.ReactNode })
   const [paletteOpen, setPaletteOpen] = useState(false);
   const [createOpen, setCreateOpen] = useState(false);
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
-
-  // On a cold load this layout renders only a skeleton until /auth/me
-  // resolves, so the page behind it can't start its own data fetches — every
-  // round trip serializes behind auth. Warm known route data in parallel with
-  // /auth/me; when the page mounts, React Query dedupes against the in-flight
-  // prefetch (or serves the settled payload) instead of paying a fresh round
-  // trip. prefetchQuery swallows errors by design: a 401 here just means the
-  // auth gate is about to redirect to /login anyway.
-  const queryClient = useQueryClient();
-  const didPrefetchRouteDataRef = useRef(false);
-  useEffect(() => {
-    if (didPrefetchRouteDataRef.current) return;
-    didPrefetchRouteDataRef.current = true;
-    // Auth already settled (warm navigation) — the page mounts immediately
-    // and owns its fetches; prefetching would only duplicate work.
-    if (user || !isLoading) return;
-    prefetchAuthGateRouteData(queryClient, pathname);
-  }, [isLoading, pathname, queryClient, user]);
   const { width: appSidebarWidth, resizeBy: resizeAppSidebar } = usePersistedPanelWidth({
     storageKey: APP_SIDEBAR_STORAGE_KEY,
     defaultWidth: APP_SIDEBAR_DEFAULT_WIDTH,
@@ -697,59 +636,64 @@ export function AuthenticatedLayout({ children }: { children: React.ReactNode })
 
   if (showLoadingSkeleton) {
     return (
-      <div className="fixed inset-0 flex h-dvh overflow-hidden overscroll-none bg-background">
-        {/* Compact rail placeholder — holds space between md and xl so no layout shift on load */}
-        <div className="hidden md:flex xl:hidden h-full w-14 shrink-0 flex-col items-center border-r border-sidebar-border bg-sidebar py-2" />
-        <aside
-          data-testid="app-sidebar"
-          style={{ "--app-sidebar-w": `${appSidebarWidth}px` } as React.CSSProperties}
-          className={cn(
-            "hidden xl:flex bg-sidebar border-r border-sidebar-border flex-col w-[var(--app-sidebar-w)]"
-          )}
-        >
-          <div className="px-4 py-4">
-            <div className="h-5 w-20 rounded bg-muted animate-pulse" />
-          </div>
-          <nav className="flex-1 px-2 space-y-0.5">
-            {Array.from({ length: 3 }).map((_, i) => (
-              <div key={i} className="flex items-center gap-2.5 px-2.5 py-2">
-                <div className="h-4 w-4 rounded bg-muted animate-pulse" />
-                <div className="h-3.5 rounded bg-muted animate-pulse" style={{ width: `${60 + i * 12}px` }} />
-              </div>
-            ))}
-          </nav>
-          <div className="px-2 pb-3">
-            <div className="flex items-center gap-2 px-2.5 py-2">
-              <div className="h-5 w-5 rounded-full bg-muted animate-pulse" />
-              <div className="h-3.5 w-20 rounded bg-muted animate-pulse" />
-            </div>
-          </div>
-        </aside>
-        <div className="hidden xl:block">
-          <ResizeHandle onResize={resizeAppSidebar} testId="app-sidebar-resize-handle" />
+      <>
+        <div hidden aria-hidden="true" data-testid="auth-gate-warm-mount">
+          <Suspense fallback={null}>{children}</Suspense>
         </div>
-        <div className="flex flex-1 min-w-0 flex-col">
-          <header className="md:hidden flex h-14 items-center gap-2 border-b border-sidebar-border bg-sidebar px-3">
-            <div className="h-6 w-6 rounded bg-muted animate-pulse" />
-            <div className="ml-auto h-6 w-6 rounded bg-muted animate-pulse" />
-            <div className="h-6 w-6 rounded bg-muted animate-pulse" />
-          </header>
-          <main className="flex-1 overflow-auto overscroll-contain bg-background">
-            <div className="max-w-none px-4 sm:px-6 lg:px-10 py-5 sm:py-6 space-y-4">
-              <div className="h-7 w-40 rounded bg-muted animate-pulse" />
-              <div className="space-y-3">
-                <div className="h-4 w-full rounded bg-muted animate-pulse" />
-                <div className="h-4 w-3/4 rounded bg-muted animate-pulse" />
-              </div>
-              <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
-                {Array.from({ length: 3 }).map((_, i) => (
-                  <div key={i} className="h-24 rounded-lg border border-border bg-muted/30 animate-pulse" />
-                ))}
+        <div className="fixed inset-0 flex h-dvh overflow-hidden overscroll-none bg-background">
+          {/* Compact rail placeholder — holds space between md and xl so no layout shift on load */}
+          <div className="hidden md:flex xl:hidden h-full w-14 shrink-0 flex-col items-center border-r border-sidebar-border bg-sidebar py-2" />
+          <aside
+            data-testid="app-sidebar"
+            style={{ "--app-sidebar-w": `${appSidebarWidth}px` } as React.CSSProperties}
+            className={cn(
+              "hidden xl:flex bg-sidebar border-r border-sidebar-border flex-col w-[var(--app-sidebar-w)]"
+            )}
+          >
+            <div className="px-4 py-4">
+              <div className="h-5 w-20 rounded bg-muted animate-pulse" />
+            </div>
+            <nav className="flex-1 px-2 space-y-0.5">
+              {Array.from({ length: 3 }).map((_, i) => (
+                <div key={i} className="flex items-center gap-2.5 px-2.5 py-2">
+                  <div className="h-4 w-4 rounded bg-muted animate-pulse" />
+                  <div className="h-3.5 rounded bg-muted animate-pulse" style={{ width: `${60 + i * 12}px` }} />
+                </div>
+              ))}
+            </nav>
+            <div className="px-2 pb-3">
+              <div className="flex items-center gap-2 px-2.5 py-2">
+                <div className="h-5 w-5 rounded-full bg-muted animate-pulse" />
+                <div className="h-3.5 w-20 rounded bg-muted animate-pulse" />
               </div>
             </div>
-          </main>
+          </aside>
+          <div className="hidden xl:block">
+            <ResizeHandle onResize={resizeAppSidebar} testId="app-sidebar-resize-handle" />
+          </div>
+          <div className="flex flex-1 min-w-0 flex-col">
+            <header className="md:hidden flex h-14 items-center gap-2 border-b border-sidebar-border bg-sidebar px-3">
+              <div className="h-6 w-6 rounded bg-muted animate-pulse" />
+              <div className="ml-auto h-6 w-6 rounded bg-muted animate-pulse" />
+              <div className="h-6 w-6 rounded bg-muted animate-pulse" />
+            </header>
+            <main className="flex-1 overflow-auto overscroll-contain bg-background">
+              <div className="max-w-none px-4 sm:px-6 lg:px-10 py-5 sm:py-6 space-y-4">
+                <div className="h-7 w-40 rounded bg-muted animate-pulse" />
+                <div className="space-y-3">
+                  <div className="h-4 w-full rounded bg-muted animate-pulse" />
+                  <div className="h-4 w-3/4 rounded bg-muted animate-pulse" />
+                </div>
+                <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+                  {Array.from({ length: 3 }).map((_, i) => (
+                    <div key={i} className="h-24 rounded-lg border border-border bg-muted/30 animate-pulse" />
+                  ))}
+                </div>
+              </div>
+            </main>
+          </div>
         </div>
-      </div>
+      </>
     );
   }
 

--- a/frontend/src/components/authenticated-layout.tsx
+++ b/frontend/src/components/authenticated-layout.tsx
@@ -103,7 +103,7 @@ function prefetchAuthGateRouteData(queryClient: QueryClient, pathname: string): 
   if (pathname === "/settings/agent") {
     void queryClient.prefetchQuery({
       queryKey: CODING_AUTHS_QUERY_KEY,
-      queryFn: () => api.codingAuths.list(),
+      queryFn: () => api.codingCredentials.list("org"),
     });
   }
 

--- a/frontend/src/components/authenticated-layout.tsx
+++ b/frontend/src/components/authenticated-layout.tsx
@@ -45,7 +45,10 @@ import {
   PopoverTrigger,
 } from "@/components/ui/popover";
 import { useAuth } from "@/hooks/use-auth";
-import { Suspense, useCallback, useEffect, useState } from "react";
+import { useQueryClient, type QueryClient } from "@tanstack/react-query";
+import { api } from "@/lib/api";
+import { queryKeys } from "@/lib/query-keys";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { RepoContextSwitcher } from "@/components/repo-context-switcher";
 import { OrgSwitcher } from "@/components/org-switcher";
 import { CommandPalette } from "@/components/command-palette/command-palette";
@@ -76,6 +79,16 @@ const APP_SIDEBAR_DEFAULT_WIDTH = 236;
 const APP_SIDEBAR_MIN_WIDTH = 200;
 const APP_SIDEBAR_MAX_WIDTH = 300;
 const APP_SIDEBAR_STORAGE_KEY = "143:app-sidebar-width";
+
+function prefetchAuthGateRouteData(queryClient: QueryClient, pathname: string): void {
+  const sessionId = sessionDetailRouteId(pathname);
+  if (!sessionId) return;
+
+  void queryClient.prefetchQuery({
+    queryKey: queryKeys.sessions.detail(sessionId),
+    queryFn: () => api.sessions.get(sessionId),
+  });
+}
 
 function VersionMenuItem() {
   const [copied, setCopied] = useState(false);
@@ -550,6 +563,17 @@ export function AuthenticatedLayout({ children }: { children: React.ReactNode })
   const [paletteOpen, setPaletteOpen] = useState(false);
   const [createOpen, setCreateOpen] = useState(false);
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
+  const queryClient = useQueryClient();
+  const prefetchedPathRef = useRef<string | null>(null);
+  useEffect(() => {
+    // Keep auth-gate warming to explicit, idempotent query preloads. Rendering
+    // route children here would also run mount effects and mutations before
+    // auth/role gates settle.
+    if (user || !isLoading) return;
+    if (prefetchedPathRef.current === pathname) return;
+    prefetchedPathRef.current = pathname;
+    prefetchAuthGateRouteData(queryClient, pathname);
+  }, [isLoading, pathname, queryClient, user]);
   const { width: appSidebarWidth, resizeBy: resizeAppSidebar } = usePersistedPanelWidth({
     storageKey: APP_SIDEBAR_STORAGE_KEY,
     defaultWidth: APP_SIDEBAR_DEFAULT_WIDTH,
@@ -636,64 +660,59 @@ export function AuthenticatedLayout({ children }: { children: React.ReactNode })
 
   if (showLoadingSkeleton) {
     return (
-      <>
-        <div hidden aria-hidden="true" data-testid="auth-gate-warm-mount">
-          <Suspense fallback={null}>{children}</Suspense>
-        </div>
-        <div className="fixed inset-0 flex h-dvh overflow-hidden overscroll-none bg-background">
-          {/* Compact rail placeholder — holds space between md and xl so no layout shift on load */}
-          <div className="hidden md:flex xl:hidden h-full w-14 shrink-0 flex-col items-center border-r border-sidebar-border bg-sidebar py-2" />
-          <aside
-            data-testid="app-sidebar"
-            style={{ "--app-sidebar-w": `${appSidebarWidth}px` } as React.CSSProperties}
-            className={cn(
-              "hidden xl:flex bg-sidebar border-r border-sidebar-border flex-col w-[var(--app-sidebar-w)]"
-            )}
-          >
-            <div className="px-4 py-4">
-              <div className="h-5 w-20 rounded bg-muted animate-pulse" />
+      <div className="fixed inset-0 flex h-dvh overflow-hidden overscroll-none bg-background">
+        {/* Compact rail placeholder — holds space between md and xl so no layout shift on load */}
+        <div className="hidden md:flex xl:hidden h-full w-14 shrink-0 flex-col items-center border-r border-sidebar-border bg-sidebar py-2" />
+        <aside
+          data-testid="app-sidebar"
+          style={{ "--app-sidebar-w": `${appSidebarWidth}px` } as React.CSSProperties}
+          className={cn(
+            "hidden xl:flex bg-sidebar border-r border-sidebar-border flex-col w-[var(--app-sidebar-w)]"
+          )}
+        >
+          <div className="px-4 py-4">
+            <div className="h-5 w-20 rounded bg-muted animate-pulse" />
+          </div>
+          <nav className="flex-1 px-2 space-y-0.5">
+            {Array.from({ length: 3 }).map((_, i) => (
+              <div key={i} className="flex items-center gap-2.5 px-2.5 py-2">
+                <div className="h-4 w-4 rounded bg-muted animate-pulse" />
+                <div className="h-3.5 rounded bg-muted animate-pulse" style={{ width: `${60 + i * 12}px` }} />
+              </div>
+            ))}
+          </nav>
+          <div className="px-2 pb-3">
+            <div className="flex items-center gap-2 px-2.5 py-2">
+              <div className="h-5 w-5 rounded-full bg-muted animate-pulse" />
+              <div className="h-3.5 w-20 rounded bg-muted animate-pulse" />
             </div>
-            <nav className="flex-1 px-2 space-y-0.5">
-              {Array.from({ length: 3 }).map((_, i) => (
-                <div key={i} className="flex items-center gap-2.5 px-2.5 py-2">
-                  <div className="h-4 w-4 rounded bg-muted animate-pulse" />
-                  <div className="h-3.5 rounded bg-muted animate-pulse" style={{ width: `${60 + i * 12}px` }} />
-                </div>
-              ))}
-            </nav>
-            <div className="px-2 pb-3">
-              <div className="flex items-center gap-2 px-2.5 py-2">
-                <div className="h-5 w-5 rounded-full bg-muted animate-pulse" />
-                <div className="h-3.5 w-20 rounded bg-muted animate-pulse" />
+          </div>
+        </aside>
+        <div className="hidden xl:block">
+          <ResizeHandle onResize={resizeAppSidebar} testId="app-sidebar-resize-handle" />
+        </div>
+        <div className="flex flex-1 min-w-0 flex-col">
+          <header className="md:hidden flex h-14 items-center gap-2 border-b border-sidebar-border bg-sidebar px-3">
+            <div className="h-6 w-6 rounded bg-muted animate-pulse" />
+            <div className="ml-auto h-6 w-6 rounded bg-muted animate-pulse" />
+            <div className="h-6 w-6 rounded bg-muted animate-pulse" />
+          </header>
+          <main className="flex-1 overflow-auto overscroll-contain bg-background">
+            <div className="max-w-none px-4 sm:px-6 lg:px-10 py-5 sm:py-6 space-y-4">
+              <div className="h-7 w-40 rounded bg-muted animate-pulse" />
+              <div className="space-y-3">
+                <div className="h-4 w-full rounded bg-muted animate-pulse" />
+                <div className="h-4 w-3/4 rounded bg-muted animate-pulse" />
+              </div>
+              <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+                {Array.from({ length: 3 }).map((_, i) => (
+                  <div key={i} className="h-24 rounded-lg border border-border bg-muted/30 animate-pulse" />
+                ))}
               </div>
             </div>
-          </aside>
-          <div className="hidden xl:block">
-            <ResizeHandle onResize={resizeAppSidebar} testId="app-sidebar-resize-handle" />
-          </div>
-          <div className="flex flex-1 min-w-0 flex-col">
-            <header className="md:hidden flex h-14 items-center gap-2 border-b border-sidebar-border bg-sidebar px-3">
-              <div className="h-6 w-6 rounded bg-muted animate-pulse" />
-              <div className="ml-auto h-6 w-6 rounded bg-muted animate-pulse" />
-              <div className="h-6 w-6 rounded bg-muted animate-pulse" />
-            </header>
-            <main className="flex-1 overflow-auto overscroll-contain bg-background">
-              <div className="max-w-none px-4 sm:px-6 lg:px-10 py-5 sm:py-6 space-y-4">
-                <div className="h-7 w-40 rounded bg-muted animate-pulse" />
-                <div className="space-y-3">
-                  <div className="h-4 w-full rounded bg-muted animate-pulse" />
-                  <div className="h-4 w-3/4 rounded bg-muted animate-pulse" />
-                </div>
-                <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
-                  {Array.from({ length: 3 }).map((_, i) => (
-                    <div key={i} className="h-24 rounded-lg border border-border bg-muted/30 animate-pulse" />
-                  ))}
-                </div>
-              </div>
-            </main>
-          </div>
+          </main>
         </div>
-      </>
+      </div>
     );
   }
 

--- a/frontend/src/components/providers.test.tsx
+++ b/frontend/src/components/providers.test.tsx
@@ -1,7 +1,7 @@
 import { renderWithProviders, screen } from "@/test/test-utils";
 import { useQueryClient } from "@tanstack/react-query";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { Providers } from "./providers";
+import { Providers, shouldRetryQuery } from "./providers";
 
 function QueryDefaultsProbe() {
   const queryClient = useQueryClient();
@@ -49,5 +49,16 @@ describe("Providers", () => {
         refetchOnWindowFocus: false,
       }),
     );
+  });
+
+  it("does not retry deterministic client errors", () => {
+    expect(shouldRetryQuery(0, { status: 403 })).toBe(false);
+    expect(shouldRetryQuery(1, { status: 404 })).toBe(false);
+  });
+
+  it("retries transient query errors only within the app retry budget", () => {
+    expect(shouldRetryQuery(0, { status: 500 })).toBe(true);
+    expect(shouldRetryQuery(1, new Error("network reset"))).toBe(true);
+    expect(shouldRetryQuery(2, new Error("network reset"))).toBe(false);
   });
 });

--- a/frontend/src/components/providers.tsx
+++ b/frontend/src/components/providers.tsx
@@ -9,6 +9,21 @@ import { DocumentTitle } from "@/components/document-title";
 
 export const DEFAULT_QUERY_STALE_TIME_MS = 30_000;
 export const DEFAULT_QUERY_GC_TIME_MS = 10 * 60_000;
+const DEFAULT_QUERY_RETRY_LIMIT = 2;
+
+function errorStatus(error: unknown): number | null {
+  if (typeof error !== "object" || error === null) return null;
+  const status = (error as { status?: unknown }).status;
+  return typeof status === "number" ? status : null;
+}
+
+export function shouldRetryQuery(failureCount: number, error: unknown): boolean {
+  const status = errorStatus(error);
+  if (status !== null && status >= 400 && status < 500) {
+    return false;
+  }
+  return failureCount < DEFAULT_QUERY_RETRY_LIMIT;
+}
 
 export function Providers({ children }: { children: React.ReactNode }) {
   const [queryClient] = useState(
@@ -16,7 +31,7 @@ export function Providers({ children }: { children: React.ReactNode }) {
       new QueryClient({
         defaultOptions: {
           queries: {
-            retry: 2,
+            retry: shouldRetryQuery,
             staleTime: DEFAULT_QUERY_STALE_TIME_MS,
             gcTime: DEFAULT_QUERY_GC_TIME_MS,
             refetchOnWindowFocus: false,

--- a/frontend/src/lib/api.test.ts
+++ b/frontend/src/lib/api.test.ts
@@ -1207,10 +1207,11 @@ describe('api client', () => {
       try {
         await api.issues.list();
       } catch (err: unknown) {
-        const error = err as { name: string; code: string; message: string };
+        const error = err as { name: string; code: string; message: string; status: number };
         expect(error.name).toBe('ApiError');
         expect(error.code).toBe('BAD_REQUEST');
         expect(error.message).toBe('bad request');
+        expect(error.status).toBe(400);
       }
     });
 

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -4,7 +4,12 @@ import { normalizeAPIResponse } from './api-normalize';
 const API_BASE = process.env.NEXT_PUBLIC_API_URL || '';
 
 export class ApiError extends Error {
-  constructor(public code: string, message: string, public details?: unknown) {
+  constructor(
+    public code: string,
+    message: string,
+    public details?: unknown,
+    public status?: number,
+  ) {
     super(message);
     this.name = 'ApiError';
   }
@@ -87,7 +92,8 @@ async function request<T>(path: string, options?: RequestInit): Promise<T> {
     throw new ApiError(
       body?.error?.code || 'UNKNOWN',
       body?.error?.message || res.statusText,
-      body?.error?.details
+      body?.error?.details,
+      res.status,
     );
   }
 
@@ -145,7 +151,8 @@ async function uploadFile(file: File): Promise<{ url: string; file_name: string;
     throw new ApiError(
       body?.error?.code || 'UNKNOWN',
       body?.error?.message || res.statusText,
-      body?.error?.details
+      body?.error?.details,
+      res.status,
     );
   }
 


### PR DESCRIPTION
## Summary
- Preserve HTTP status on `ApiError` and make the global TanStack Query retry policy skip deterministic 4xx API responses while keeping transient retries.
- Keep auth-gate warming limited to explicit, idempotent React Query preloads: prefetch `/sessions/<uuid>` detail data while `/auth/me` is still resolving.
- Avoid mounting route children behind the auth skeleton so page effects, redirects, and mutations do not run before auth and role gates settle.
- Restore coverage for role-guarded settings pages so protected settings children stay unmounted during auth loading.

## Testing
- `npm test -- authenticated-layout.test.tsx settings/layout.test.tsx --run`
- `npm test -- providers.test.tsx api.test.ts --run`
- `npm run typecheck`
- `npm run lint`
- `npm run build`
