### PR TITLE
Skip unchanged preview CPU saves on blur

### DIFF
--- a/docs/design/implemented/96-runtime-network-settings-placement.md
+++ b/docs/design/implemented/96-runtime-network-settings-placement.md
@@ -1,7 +1,7 @@
 # Runtime / Sandbox Settings
 
 > **Status:** Implemented
-> **Last reviewed:** 2026-06-10
+> **Last reviewed:** 2026-06-11
 
 143 currently exposes shared sandbox runtime controls across multiple settings pages. Static egress lives under Organization -> General, preview capacity lives on General, and coding-agent execution limits live under Platform -> Coding agents. That split makes each individual setting understandable in isolation, but it hides the product model: these settings all affect how 143 creates, schedules, networks, and retains sandbox runtimes for an organization.
 
@@ -50,7 +50,7 @@ The page should be admin-only, matching the current access level for General, LL
 Owns org-wide network policy for new and hydrated sandboxes.
 
 Controls:
-- `Use static egress IP for sessions and previews` switch.
+- `Static egress IP` switch.
 - Copyable public IP row.
 - Generic availability message when static egress cannot be used.
 - Optional future links to setup docs or operator diagnostics.
@@ -63,6 +63,7 @@ UI:
 - Use `section` with a compact `h2`, matching General settings.
 - Use `Card` and `CardContent`.
 - Use `Label` and `Switch` for the toggle.
+- Put explanatory copy in a question-mark tooltip next to the label.
 - Use `CopyButton` for the public IP.
 - Use semantic muted text, not warning-heavy styling, unless enabling the setting failed.
 - Use `AutosaveIndicator` in the section header.
@@ -78,19 +79,18 @@ Wireframe:
 Sandbox network                                      Saved
 
 [Card]
-  Use static egress IP for sessions and previews       [switch]
-  Uses a stable public IP for new and hydrated sandboxes.
+  Static egress IP [?]                                 [switch]
   Static egress is not currently available for new sandbox starts.
 
   Public IP   203.0.113.10                             [copy icon]
 ```
 
-### 2. Capacity Limits
+### 2. Usage Limits
 
 Owns the org-level controls that determine how many runtimes users can consume.
 
 Controls:
-- `Concurrent coding-agent runs`
+- `Concurrent agent runs`
 - `Active previews per user`
 
 Existing settings/API:
@@ -101,32 +101,32 @@ Existing settings/API:
 UI:
 - Use one `Card`.
 - Use a two-column responsive layout on desktop and stacked rows on mobile.
-- Use `Label`, `Input type="number"`, and short help text.
+- Use `Label`, `Input type="number"`, question-mark tooltips for explanations, and visible helper text only for max values.
 - Use `useAutosaveNumericField` for clamping and commit-on-blur behavior, matching existing General and Coding agents patterns.
 - Use constants from `settings-constants.ts` where available.
 
 Wireframe:
 
 ```text
-Capacity limits                                      Saved
+Usage limits                                        Saved
 
 [Card]
-  Concurrent coding-agent runs
+  Concurrent agent runs [?]
   [ 5 ]
-  Limits how many agent turns can run for the org at once.
+  Max 25
 
-  Active previews per user
+  Active previews per user [?]
   [ 4 ]
-  Limits how many previews one user can keep running at once.
+  Max 20
 ```
 
-### 3. Session Runtime
+### 3. Sessions
 
 Owns defaults that shape individual coding-agent sandbox runs.
 
 Controls:
-- `Maximum session duration`
-- `Sandbox tab tools` toggle, if product wants this to live with runtime controls instead of Coding agents.
+- `Maximum session length`
+- `Agent tab tools` toggle, if product wants this to live with runtime controls instead of Coding agents.
 
 Existing settings/API:
 - `settings.max_session_duration_seconds`
@@ -136,31 +136,30 @@ Existing settings/API:
 UI:
 - Use `Card` and `CardContent`.
 - For duration, use `Input type="number"` in minutes and write seconds to the API, matching the current Coding agents implementation.
-- For tab tools, use `Switch`, `Label`, and concise helper copy.
+- For tab tools, use `Switch`, `Label`, and a question-mark tooltip.
 - If tab tools stays on Coding agents, this section should contain only the duration control in the first pass.
 
 Wireframe:
 
 ```text
-Session runtime                                     Saved
+Sessions                                            Saved
 
 [Card]
-  Maximum session duration
+  Maximum session length [?]
   [ 25 ] minutes
-  Stops long-running turns after the configured org limit.
+  Max 120 minutes
 
-  Sandbox tab tools                                  [switch]
-  Allows agent tabs in the same session to coordinate through the 143 tools CLI.
+  Agent tab tools [?]                                [switch]
 ```
 
-### 4. Lifecycle Defaults
+### 4. Cleanup Defaults
 
 Owns cleanup and retention policies for runtime artifacts.
 
 Controls:
-- Default idle preview cleanup window.
-- Default sandbox retention after completed runs.
-- Whether previews may hold a sandbox after a session turn completes.
+- `Idle preview timeout`.
+- `Keep completed sessions for`.
+- `Keep sandbox while preview is active`.
 
 Settings shape:
 
@@ -183,6 +182,7 @@ API/schema impact:
 
 UI:
 - Use `Card`, `Input`, `Switch`, and `AutosaveIndicator`.
+- Put explanatory copy in question-mark tooltips and keep only max-value helper text below numeric inputs.
 - Do not expose worker cleanup implementation details.
 
 ### 5. Resource Defaults
@@ -221,51 +221,8 @@ API/schema impact:
 UI:
 - Use `Select` for tier choices.
 - Use `Switch` for `allow_repo_resource_requests`.
-- Use `Badge` for read-only resolved CPU/memory/disk summaries if shown.
+- Show preview CPU limits in CPU cores in the UI, while saving the existing `preview_max_cpu_millis` field.
 - Avoid raw tables unless showing a tier comparison; if a comparison is needed, use shared `Table` components.
-
-### 6. Runtime Diagnostics
-
-Provides a product-safe read-only summary that helps admins understand whether runtime features are available without exposing fleet internals.
-
-Rows:
-- Static egress: `Available` / `Unavailable`
-- Agent runs: active count against the configured org concurrency limit
-- Active previews: active count against the configured per-user limit
-- Capacity: `Normal` / `Limited`
-
-API/schema impact:
-- `GET /api/v1/settings/runtime/status` returns a sanitized org-scoped status payload:
-
-```json
-{
-  "data": {
-    "static_egress": {
-      "available": true,
-      "enabled": false,
-      "public_ip": "203.0.113.10"
-    },
-    "capacity": {
-      "state": "normal",
-      "active_agent_runs": 2,
-      "max_concurrent_agent_runs": 5,
-      "active_previews": 3,
-      "max_previews_per_user": 4
-    }
-  }
-}
-```
-
-Rules:
-- Do not include worker hostnames, node IDs, static-egress-capable counts, WireGuard state, or deployment generation.
-- Use typed string status fields in `internal/models`, with validation tests.
-- Every query behind the endpoint must be org-scoped.
-
-UI:
-- Use a compact `Card`.
-- Use `Badge` for state labels.
-- Use `Table` only if there are enough rows to scan; otherwise use stacked rows with `border-border` separators.
-- Use `EmptyState` only if diagnostics are unavailable because the feature is not configured.
 
 ## Implementation
 
@@ -274,13 +231,15 @@ UI:
 - Sandbox network static egress toggle.
 - Copyable static egress public IP.
 - Product-safe static egress availability copy that does not expose worker capability diagnostics.
-- Concurrent coding-agent run limit.
+- Concurrent agent run limit.
 - Active previews per user.
-- Maximum session duration.
-- Sandbox tab tools.
-- Lifecycle defaults for completed-session retention, idle preview TTL, and preview sandbox hold behavior.
+- Maximum session length.
+- Agent tab tools.
+- Cleanup defaults for completed-session retention, idle preview timeout, and keeping the sandbox while a preview is active.
 - Resource defaults for agent tier, preview tier, preview max tier, and repo resource request policy.
-- Sanitized runtime diagnostics for static egress and capacity.
+- Preview CPU limits shown in CPU cores while stored as millicores in `settings.sandbox_resources.preview_max_cpu_millis`.
+
+The Runtime settings page intentionally does not include a runtime diagnostics section. Current capacity and fleet state belong in operational tooling or purpose-built status surfaces, not in the editable settings page.
 
 Keep these controls where they are:
 
@@ -297,7 +256,7 @@ The implementation also:
 - Added a browser-title rule for `Runtime settings`.
 - Removed duplicated runtime controls from General and Coding agents.
 - Added compact links from Coding agents and Preview to Runtime.
-- Added focused backend and frontend coverage for the new page, old-page removals, sidebar, role guards, page title, lifecycle/resource validation, and runtime status.
+- Added focused backend and frontend coverage for the new page, old-page removals, sidebar, role guards, page title, lifecycle/resource validation, tooltip copy, and CPU unit conversion.
 
 ## Component Guidance
 
@@ -308,9 +267,7 @@ Use the same settings primitives already used by General, Coding agents, and Pre
 - Section headers outside cards using `h2 className="text-xs font-medium text-foreground"`.
 - `AutosaveIndicator` in section headers for editable sections.
 - `Card`, `CardContent`, and only use `CardHeader`/`CardTitle` when a card contains multiple independently titled subsections.
-- `Label`, `Input`, `Switch`, `Select`, `Badge`, `Button`, `CopyButton`.
-- Shared `Table` components for diagnostic tables only.
-- `EmptyState` for missing configuration states.
+- `Label`, `Input`, `Switch`, `Select`, `Button`, `Tooltip`, and `CopyButton`.
 - `AlertDialog` only for destructive lifecycle controls if future cleanup actions are added.
 
 Layout rules:
@@ -318,6 +275,7 @@ Layout rules:
 - Keep card content compact.
 - Use stacked mobile rows; do not rely on desktop-only table layouts.
 - Keep all copy operational and short.
+- Put field explanations in question-mark tooltips; keep visible helper text only for max values.
 - Avoid nested cards.
 
 ## API and Schema Summary
@@ -328,25 +286,24 @@ Reusable fields:
 
 | UI control | Existing setting/API |
 |---|---|
-| Static egress toggle | `settings.sandbox_network.static_egress_enabled` |
+| Static egress IP | `settings.sandbox_network.static_egress_enabled` |
 | Static egress public IP/status | `GET /api/v1/settings/network` |
-| Concurrent coding-agent runs | `settings.max_concurrent_runs` |
-| Maximum session duration | `settings.max_session_duration_seconds` |
+| Concurrent agent runs | `settings.max_concurrent_runs` |
+| Maximum session length | `settings.max_session_duration_seconds` |
 | Active previews per user | `settings.preview_max_previews_per_user` |
-| Sandbox tab tools | `settings.coding_agent_tab_tools_enabled` |
-| Completed session retention | `settings.sandbox_lifecycle.completed_session_retention_minutes` |
-| Idle preview TTL | `settings.sandbox_lifecycle.idle_preview_ttl_minutes` |
-| Preview holds sandbox | `settings.sandbox_lifecycle.preview_holds_sandbox` |
-| Agent default tier | `settings.sandbox_resources.agent_default_tier` |
-| Preview default tier | `settings.sandbox_resources.preview_default_tier` |
-| Repo resource request policy | `settings.sandbox_resources.allow_repo_resource_requests` |
-| Preview max tier | `settings.sandbox_resources.preview_max_tier` |
-| Preview CPU request max | `settings.sandbox_resources.preview_max_cpu_millis` |
-| Preview memory request max | `settings.sandbox_resources.preview_max_memory_mib` |
-| Preview ephemeral disk request max | `settings.sandbox_resources.preview_max_ephemeral_disk_mib` |
-| Runtime diagnostics | `GET /api/v1/settings/runtime/status` |
+| Agent tab tools | `settings.coding_agent_tab_tools_enabled` |
+| Keep completed sessions for | `settings.sandbox_lifecycle.completed_session_retention_minutes` |
+| Idle preview timeout | `settings.sandbox_lifecycle.idle_preview_ttl_minutes` |
+| Keep sandbox while preview is active | `settings.sandbox_lifecycle.preview_holds_sandbox` |
+| Agent sandbox size | `settings.sandbox_resources.agent_default_tier` |
+| Preview sandbox size | `settings.sandbox_resources.preview_default_tier` |
+| Allow repository resource requests | `settings.sandbox_resources.allow_repo_resource_requests` |
+| Largest preview size | `settings.sandbox_resources.preview_max_tier` |
+| Preview CPU limit | `settings.sandbox_resources.preview_max_cpu_millis` |
+| Preview memory limit | `settings.sandbox_resources.preview_max_memory_mib` |
+| Preview disk limit | `settings.sandbox_resources.preview_max_ephemeral_disk_mib` |
 
-Resource tiers are typed backend enum strings: `small`, `standard`, and `large`. Runtime status uses org-scoped active session and active preview counters and does not return worker internals.
+Resource tiers are typed backend enum strings: `small`, `standard`, and `large`. The UI displays CPU as cores for readability, then converts to millicores when patching the existing API field.
 
 Remaining future enhancement:
 - If repo-declared resource requests need exact CPU/memory/disk summaries in the UI, expose read-only resolved tier metadata safely from a runtime endpoint rather than duplicating infrastructure constants in the frontend.

--- a/frontend/src/app/(dashboard)/settings/runtime/page.test.tsx
+++ b/frontend/src/app/(dashboard)/settings/runtime/page.test.tsx
@@ -258,6 +258,36 @@ describe("RuntimeSettingsPage", () => {
     expect(cpuLimit).toHaveValue(2);
   });
 
+  it("does not round and save an unchanged preview CPU value on blur", async () => {
+    settingsGetMock.mockResolvedValue({
+      data: {
+        id: "org-1",
+        name: "Test Org",
+        settings: {
+          sandbox_resources: {
+            preview_max_cpu_millis: 333,
+          },
+        },
+        created_at: "2026-05-01T12:00:00Z",
+        updated_at: "2026-05-01T12:00:00Z",
+      },
+    });
+    renderWithProviders(<RuntimeSettingsPage />);
+
+    const user = userEvent.setup();
+    const cpuLimit = await screen.findByLabelText("Preview CPU limit");
+    await waitFor(() => {
+      expect(cpuLimit).toHaveValue(0.33);
+    });
+    settingsUpdateMock.mockClear();
+
+    await user.click(cpuLimit);
+    await user.tab();
+
+    expect(settingsUpdateMock).not.toHaveBeenCalled();
+    expect(cpuLimit).toHaveValue(0.33);
+  });
+
   it("saves lifecycle defaults", async () => {
     settingsUpdateMock
       .mockResolvedValueOnce({

--- a/frontend/src/app/(dashboard)/settings/runtime/page.test.tsx
+++ b/frontend/src/app/(dashboard)/settings/runtime/page.test.tsx
@@ -100,32 +100,53 @@ describe("RuntimeSettingsPage", () => {
     expect(await screen.findByRole("heading", { name: "Runtime" })).toBeInTheDocument();
     expect(screen.getByText("Configure sandbox networking, capacity, and lifecycle defaults.")).toBeInTheDocument();
     expect(screen.getByText("Sandbox network")).toBeInTheDocument();
-    expect(screen.getByText("Capacity limits")).toBeInTheDocument();
-    expect(screen.getByText("Session runtime")).toBeInTheDocument();
-    expect(screen.getByText("Lifecycle defaults")).toBeInTheDocument();
+    expect(screen.getByText("Usage limits")).toBeInTheDocument();
+    expect(screen.getByText("Sessions")).toBeInTheDocument();
+    expect(screen.getByText("Cleanup defaults")).toBeInTheDocument();
     expect(screen.getByText("Resource defaults")).toBeInTheDocument();
+    expect(
+      screen.queryByText("These settings apply to sandbox runtimes across coding-agent sessions and previews."),
+    ).not.toBeInTheDocument();
+    expect(screen.queryByText("Runtime diagnostics")).not.toBeInTheDocument();
+    expect(settingsRuntimeStatusMock).not.toHaveBeenCalled();
 
     await waitFor(() => {
-      expect(screen.getByLabelText("Use static egress IP for sessions and previews")).toBeChecked();
+      expect(screen.getByLabelText("Static egress IP")).toBeChecked();
     });
     expect(screen.getAllByText("203.0.113.10").length).toBeGreaterThan(0);
-    expect(screen.getByLabelText("Concurrent coding-agent runs")).toHaveValue(5);
+    expect(screen.getByLabelText("Concurrent agent runs")).toHaveValue(5);
     expect(screen.getByLabelText("Active previews per user")).toHaveValue(7);
-    expect(screen.getByLabelText("Maximum session duration")).toHaveValue(25);
-    expect(screen.getByLabelText("Sandbox tab tools")).not.toBeChecked();
-    expect(screen.getByLabelText("Completed session retention")).toHaveValue(120);
-    expect(screen.getByLabelText("Idle preview TTL")).toHaveValue(300);
-    expect(screen.getByLabelText("Preview holds sandbox")).not.toBeChecked();
-    expect(screen.getByRole("combobox", { name: "Agent default tier" })).toHaveTextContent("Standard");
-    expect(screen.getByRole("combobox", { name: "Preview default tier" })).toHaveTextContent("Small");
-    expect(screen.getByLabelText("Allow repo resource requests")).not.toBeChecked();
-    expect(screen.getByRole("combobox", { name: "Preview max tier" })).toHaveTextContent("Large");
-    expect(screen.getByLabelText("Preview CPU request max")).toHaveValue(1500);
-    expect(screen.getByLabelText("Preview memory request max")).toHaveValue(4096);
-    expect(screen.getByLabelText("Preview ephemeral disk request max")).toHaveValue(6144);
-    expect(screen.getByText("4 / 5")).toBeInTheDocument();
-    expect(screen.getByText("3 / 7")).toBeInTheDocument();
-    expect(screen.getByText("Limited")).toBeInTheDocument();
+    expect(screen.getByLabelText("Maximum session length")).toHaveValue(25);
+    expect(screen.getByLabelText("Agent tab tools")).not.toBeChecked();
+    expect(screen.getByLabelText("Keep completed sessions for")).toHaveValue(120);
+    expect(screen.getByLabelText("Idle preview timeout")).toHaveValue(300);
+    expect(screen.getByLabelText("Keep sandbox while preview is active")).not.toBeChecked();
+    expect(screen.getByRole("combobox", { name: "Agent sandbox size" })).toHaveTextContent("Standard");
+    expect(screen.getByRole("combobox", { name: "Preview sandbox size" })).toHaveTextContent("Small");
+    expect(screen.getByLabelText("Allow repository resource requests")).not.toBeChecked();
+    expect(screen.getByRole("combobox", { name: "Largest preview size" })).toHaveTextContent("Large");
+    expect(screen.getByLabelText("Preview CPU limit")).toHaveValue(1.5);
+    expect(screen.getByLabelText("Preview memory limit")).toHaveValue(4096);
+    expect(screen.getByLabelText("Preview disk limit")).toHaveValue(6144);
+    expect(screen.getByText("Max 25")).toBeInTheDocument();
+    expect(screen.getByText("Max 2 cores")).toBeInTheDocument();
+  });
+
+  it("moves field explanations into question mark tooltips", async () => {
+    renderWithProviders(<RuntimeSettingsPage />);
+
+    expect(
+      await screen.findByRole("button", { name: "About static egress IP" }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "About concurrent agent runs" })).toBeInTheDocument();
+    expect(screen.queryByText("Uses a stable public IP for new and hydrated sandboxes.")).not.toBeInTheDocument();
+    expect(screen.queryByText("Limits how many agent turns can run for the org at once.")).not.toBeInTheDocument();
+
+    const user = userEvent.setup();
+    await user.hover(screen.getByRole("button", { name: "About static egress IP" }));
+    expect(
+      await screen.findAllByText("Routes new and resumed sandboxes through one stable public IP so allowlists work."),
+    ).not.toHaveLength(0);
   });
 
   it("saves runtime settings through the existing org settings API", async () => {
@@ -163,14 +184,14 @@ describe("RuntimeSettingsPage", () => {
     renderWithProviders(<RuntimeSettingsPage />);
 
     const user = userEvent.setup();
-    await user.click(await screen.findByLabelText("Use static egress IP for sessions and previews"));
+    await user.click(await screen.findByLabelText("Static egress IP"));
     await waitFor(() => {
       expect(settingsUpdateMock).toHaveBeenCalledWith({
         settings: { sandbox_network: { static_egress_enabled: false } },
       });
     });
 
-    await user.click(screen.getByLabelText("Sandbox tab tools"));
+    await user.click(screen.getByLabelText("Agent tab tools"));
     await waitFor(() => {
       expect(settingsUpdateMock).toHaveBeenCalledWith({
         settings: { coding_agent_tab_tools_enabled: true },
@@ -182,7 +203,7 @@ describe("RuntimeSettingsPage", () => {
     renderWithProviders(<RuntimeSettingsPage />);
 
     const user = userEvent.setup();
-    const concurrentRuns = await screen.findByLabelText("Concurrent coding-agent runs");
+    const concurrentRuns = await screen.findByLabelText("Concurrent agent runs");
     await user.click(concurrentRuns);
     await user.keyboard("{Control>}a{/Control}8");
     await user.tab();
@@ -193,7 +214,7 @@ describe("RuntimeSettingsPage", () => {
       });
     });
 
-    const sessionDuration = screen.getByLabelText("Maximum session duration");
+    const sessionDuration = screen.getByLabelText("Maximum session length");
     await user.click(sessionDuration);
     await user.keyboard("{Control>}a{/Control}30");
     await user.tab();
@@ -214,6 +235,27 @@ describe("RuntimeSettingsPage", () => {
         settings: { preview_max_previews_per_user: 20 },
       });
     });
+  });
+
+  it("saves preview CPU limits as millicores while showing cores", async () => {
+    renderWithProviders(<RuntimeSettingsPage />);
+
+    const user = userEvent.setup();
+    const cpuLimit = await screen.findByLabelText("Preview CPU limit");
+    await waitFor(() => {
+      expect(cpuLimit).toHaveValue(1.5);
+    });
+
+    await user.click(cpuLimit);
+    await user.keyboard("{Control>}a{/Control}2.25");
+    await user.tab();
+
+    await waitFor(() => {
+      expect(settingsUpdateMock).toHaveBeenCalledWith({
+        settings: { sandbox_resources: { preview_max_cpu_millis: 2000 } },
+      });
+    });
+    expect(cpuLimit).toHaveValue(2);
   });
 
   it("saves lifecycle defaults", async () => {
@@ -251,7 +293,7 @@ describe("RuntimeSettingsPage", () => {
     renderWithProviders(<RuntimeSettingsPage />);
 
     const user = userEvent.setup();
-    const retention = await screen.findByLabelText("Completed session retention");
+    const retention = await screen.findByLabelText("Keep completed sessions for");
     await user.click(retention);
     await user.keyboard("{Control>}a{/Control}90");
     await user.tab();
@@ -262,7 +304,7 @@ describe("RuntimeSettingsPage", () => {
       });
     });
 
-    await user.click(screen.getByLabelText("Preview holds sandbox"));
+    await user.click(screen.getByLabelText("Keep sandbox while preview is active"));
     await waitFor(() => {
       expect(settingsUpdateMock).toHaveBeenCalledWith({
         settings: { sandbox_lifecycle: { preview_holds_sandbox: true } },
@@ -313,7 +355,7 @@ describe("RuntimeSettingsPage", () => {
     renderWithProviders(<RuntimeSettingsPage />);
 
     const user = userEvent.setup();
-    await user.click(await screen.findByRole("combobox", { name: "Agent default tier" }));
+    await user.click(await screen.findByRole("combobox", { name: "Agent sandbox size" }));
     await user.click(await screen.findByRole("option", { name: "Large" }));
 
     await waitFor(() => {
@@ -322,14 +364,14 @@ describe("RuntimeSettingsPage", () => {
       });
     });
 
-    await user.click(screen.getByLabelText("Allow repo resource requests"));
+    await user.click(screen.getByLabelText("Allow repository resource requests"));
     await waitFor(() => {
       expect(settingsUpdateMock).toHaveBeenCalledWith({
         settings: { sandbox_resources: { allow_repo_resource_requests: true } },
       });
     });
 
-    const memoryMax = screen.getByLabelText("Preview memory request max");
+    const memoryMax = screen.getByLabelText("Preview memory limit");
     await user.click(memoryMax);
     await user.keyboard("{Control>}a{/Control}99999");
     await user.tab();
@@ -362,7 +404,7 @@ describe("RuntimeSettingsPage", () => {
     renderWithProviders(<RuntimeSettingsPage />);
 
     await waitFor(() => {
-      expect(screen.getByLabelText("Use static egress IP for sessions and previews")).not.toBeChecked();
+      expect(screen.getByLabelText("Static egress IP")).not.toBeChecked();
     });
     expect(
       screen.queryByText("Static egress is not currently available for new sandbox starts."),

--- a/frontend/src/app/(dashboard)/settings/runtime/page.tsx
+++ b/frontend/src/app/(dashboard)/settings/runtime/page.tsx
@@ -143,6 +143,7 @@ function usePreviewCPUField({
   const [lastSentMillis, setLastSentMillis] = useState(serverMillis);
   const debounceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const pendingMillisRef = useRef<number | null>(null);
+  const hasEditedRef = useRef(false);
 
   if (serverMillis !== trackedServerMillis) {
     setTrackedServerMillis(serverMillis);
@@ -176,6 +177,7 @@ function usePreviewCPUField({
 
   const onChange = (event: ChangeEvent<HTMLInputElement>) => {
     const raw = event.target.value;
+    hasEditedRef.current = true;
     setLocal(raw);
     if (raw.trim() === "") return;
     const parsed = Number.parseFloat(raw);
@@ -196,16 +198,22 @@ function usePreviewCPUField({
       clearTimeout(debounceTimerRef.current);
       debounceTimerRef.current = null;
     }
+    if (!hasEditedRef.current) {
+      pendingMillisRef.current = null;
+      return;
+    }
     const parsed = Number.parseFloat(local);
     if (Number.isNaN(parsed)) {
       setLocal(formatCPUCores(serverMillis));
       setLastSentMillis(serverMillis);
       pendingMillisRef.current = null;
+      hasEditedRef.current = false;
       return;
     }
     const clampedMillis = clampMillis(parsed);
     setLocal(formatCPUCores(clampedMillis));
     pendingMillisRef.current = null;
+    hasEditedRef.current = false;
     if (clampedMillis !== lastSentMillis) dispatch(clampedMillis);
   };
 

--- a/frontend/src/app/(dashboard)/settings/runtime/page.tsx
+++ b/frontend/src/app/(dashboard)/settings/runtime/page.tsx
@@ -1,17 +1,19 @@
 "use client";
 
+import { useEffect, useRef, useState, type ChangeEvent } from "react";
 import { useQuery } from "@tanstack/react-query";
-import { Network } from "lucide-react";
+import { CircleHelp } from "lucide-react";
 import { AutosaveIndicator } from "@/components/AutosaveIndicator";
 import { CopyButton } from "@/components/copy-button";
 import { PageContainer } from "@/components/page-container";
 import { PageHeader } from "@/components/page-header";
-import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Switch } from "@/components/ui/switch";
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { useAutosaveNumericField } from "@/hooks/useAutosaveNumericField";
 import { useOrgSettingsAutosave } from "@/hooks/use-org-settings-autosave";
 import { usePageTitle } from "@/hooks/use-page-title";
@@ -49,11 +51,25 @@ const DEFAULT_EXECUTION_SETTINGS = {
   max_session_duration_seconds: 25 * 60,
 };
 
-const RESOURCE_TIERS: { value: SandboxResourceTier; label: string; description: string }[] = [
-  { value: "small", label: "Small", description: "Lower CPU and memory for lightweight tasks." },
-  { value: "standard", label: "Standard", description: "Default runtime resources for most work." },
-  { value: "large", label: "Large", description: "Higher CPU and memory for heavier builds." },
+const CPU_MILLIS_PER_CORE = 1000;
+const CPU_MILLIS_STEP = 250;
+
+const RESOURCE_TIERS: { value: SandboxResourceTier; label: string }[] = [
+  { value: "small", label: "Small" },
+  { value: "standard", label: "Standard" },
+  { value: "large", label: "Large" },
 ];
+
+function formatCPUCores(millis: number): string {
+  const cores = millis / CPU_MILLIS_PER_CORE;
+  return Number.isInteger(cores)
+    ? String(cores)
+    : cores.toFixed(2).replace(/0+$/, "").replace(/\.$/, "");
+}
+
+function cpuCoresToMillis(cores: number): number {
+  return Math.round((cores * CPU_MILLIS_PER_CORE) / CPU_MILLIS_STEP) * CPU_MILLIS_STEP;
+}
 
 function useOrgSettingsQuery() {
   return useQuery<SingleResponse<Organization>>({
@@ -75,6 +91,125 @@ function SectionHeader({
       {status ? <AutosaveIndicator status={status} /> : null}
     </div>
   );
+}
+
+function SettingLabel({
+  htmlFor,
+  label,
+  tooltip,
+}: {
+  htmlFor: string;
+  label: string;
+  tooltip: string;
+}) {
+  const ariaLabel = `About ${label.charAt(0).toLowerCase()}${label.slice(1)}`;
+
+  return (
+    <div className="flex items-center gap-1.5">
+      <Label htmlFor={htmlFor}>{label}</Label>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon"
+            className="h-5 w-5 rounded-full text-muted-foreground hover:text-foreground"
+            aria-label={ariaLabel}
+          >
+            <CircleHelp className="h-3.5 w-3.5" />
+          </Button>
+        </TooltipTrigger>
+        <TooltipContent side="top" sideOffset={6} className="max-w-72">
+          {tooltip}
+        </TooltipContent>
+      </Tooltip>
+    </div>
+  );
+}
+
+function MaxHint({ children }: { children: string }) {
+  return <p className="text-xs text-muted-foreground">{children}</p>;
+}
+
+function usePreviewCPUField({
+  serverMillis,
+  autosave,
+}: {
+  serverMillis: number;
+  autosave: ReturnType<typeof useOrgSettingsAutosave>;
+}) {
+  const [trackedServerMillis, setTrackedServerMillis] = useState(serverMillis);
+  const [local, setLocal] = useState(() => formatCPUCores(serverMillis));
+  const [lastSentMillis, setLastSentMillis] = useState(serverMillis);
+  const debounceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const pendingMillisRef = useRef<number | null>(null);
+
+  if (serverMillis !== trackedServerMillis) {
+    setTrackedServerMillis(serverMillis);
+    const hasPendingEdit = local !== formatCPUCores(lastSentMillis);
+    if (serverMillis !== lastSentMillis && !hasPendingEdit) {
+      setLocal(formatCPUCores(serverMillis));
+      setLastSentMillis(serverMillis);
+    }
+  }
+
+  useEffect(() => {
+    return () => {
+      if (debounceTimerRef.current) {
+        clearTimeout(debounceTimerRef.current);
+        debounceTimerRef.current = null;
+      }
+    };
+  }, []);
+
+  const clampMillis = (cores: number) =>
+    clampNumber(
+      cpuCoresToMillis(cores),
+      MIN_PREVIEW_MAX_CPU_MILLIS,
+      MAX_PREVIEW_MAX_CPU_MILLIS,
+    );
+
+  const dispatch = (millis: number) => {
+    setLastSentMillis(millis);
+    autosave.save({ settings: { sandbox_resources: { preview_max_cpu_millis: millis } } });
+  };
+
+  const onChange = (event: ChangeEvent<HTMLInputElement>) => {
+    const raw = event.target.value;
+    setLocal(raw);
+    if (raw.trim() === "") return;
+    const parsed = Number.parseFloat(raw);
+    if (Number.isNaN(parsed)) return;
+    const clampedMillis = clampMillis(parsed);
+    pendingMillisRef.current = clampedMillis;
+    if (debounceTimerRef.current) clearTimeout(debounceTimerRef.current);
+    debounceTimerRef.current = setTimeout(() => {
+      debounceTimerRef.current = null;
+      const millis = pendingMillisRef.current;
+      pendingMillisRef.current = null;
+      if (millis !== null) dispatch(millis);
+    }, 400);
+  };
+
+  const onBlur = () => {
+    if (debounceTimerRef.current) {
+      clearTimeout(debounceTimerRef.current);
+      debounceTimerRef.current = null;
+    }
+    const parsed = Number.parseFloat(local);
+    if (Number.isNaN(parsed)) {
+      setLocal(formatCPUCores(serverMillis));
+      setLastSentMillis(serverMillis);
+      pendingMillisRef.current = null;
+      return;
+    }
+    const clampedMillis = clampMillis(parsed);
+    setLocal(formatCPUCores(clampedMillis));
+    pendingMillisRef.current = null;
+    if (clampedMillis !== lastSentMillis) dispatch(clampedMillis);
+  };
+
+  return { value: local, onChange, onBlur };
 }
 
 function ResourceTierSelect({
@@ -126,10 +261,11 @@ function SandboxNetworkSection() {
         <CardContent className="space-y-4">
           <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
             <div className="space-y-1">
-              <Label htmlFor="static-egress-enabled">Use static egress IP for sessions and previews</Label>
-              <p className="text-xs text-muted-foreground">
-                Uses a stable public IP for new and hydrated sandboxes.
-              </p>
+              <SettingLabel
+                htmlFor="static-egress-enabled"
+                label="Static egress IP"
+                tooltip="Routes new and resumed sandboxes through one stable public IP so allowlists work."
+              />
               {enabled && networkStatusResponse && !available && (
                 <p className="text-xs text-muted-foreground">
                   Static egress is not currently available for new sandbox starts.
@@ -149,7 +285,7 @@ function SandboxNetworkSection() {
                   },
                 });
               }}
-              aria-label="Use static egress IP for sessions and previews"
+              aria-label="Static egress IP"
             />
           </div>
           <div className="flex flex-wrap items-center gap-2 rounded-md border border-border bg-muted/30 px-3 py-2">
@@ -193,11 +329,15 @@ function CapacityLimitsSection() {
 
   return (
     <section className="space-y-3">
-      <SectionHeader title="Capacity limits" status={autosave.status} />
+      <SectionHeader title="Usage limits" status={autosave.status} />
       <Card>
         <CardContent className="grid gap-4 md:grid-cols-2">
           <div className="space-y-2">
-            <Label htmlFor="max-concurrent-runs">Concurrent coding-agent runs</Label>
+            <SettingLabel
+              htmlFor="max-concurrent-runs"
+              label="Concurrent agent runs"
+              tooltip="Maximum number of coding-agent turns that can run for this organization at the same time."
+            />
             <Input
               id="max-concurrent-runs"
               type="number"
@@ -208,12 +348,14 @@ function CapacityLimitsSection() {
               onChange={concurrentRunsField.onChange}
               onBlur={concurrentRunsField.onBlur}
             />
-            <p className="text-xs text-muted-foreground">
-              Limits how many agent turns can run for the org at once.
-            </p>
+            <MaxHint>{`Max ${MAX_CONCURRENT_RUNS}`}</MaxHint>
           </div>
           <div className="space-y-2">
-            <Label htmlFor="preview-max-previews-per-user">Active previews per user</Label>
+            <SettingLabel
+              htmlFor="preview-max-previews-per-user"
+              label="Active previews per user"
+              tooltip="Maximum number of preview environments one user can keep running at the same time."
+            />
             <Input
               id="preview-max-previews-per-user"
               type="number"
@@ -224,9 +366,7 @@ function CapacityLimitsSection() {
               onChange={maxPreviewsPerUserField.onChange}
               onBlur={maxPreviewsPerUserField.onBlur}
             />
-            <p className="text-xs text-muted-foreground">
-              Limits how many previews one user can keep running at once.
-            </p>
+            <MaxHint>{`Max ${MAX_PREVIEW_MAX_PREVIEWS_PER_USER}`}</MaxHint>
           </div>
         </CardContent>
       </Card>
@@ -270,12 +410,16 @@ function LifecycleDefaultsSection() {
 
   return (
     <section className="space-y-3">
-      <SectionHeader title="Lifecycle defaults" status={autosave.status} />
+      <SectionHeader title="Cleanup defaults" status={autosave.status} />
       <Card>
         <CardContent className="space-y-4">
           <div className="grid gap-4 md:grid-cols-2">
             <div className="space-y-2">
-              <Label htmlFor="completed-session-retention">Completed session retention</Label>
+              <SettingLabel
+                htmlFor="completed-session-retention"
+                label="Keep completed sessions for"
+                tooltip="How long completed session sandboxes stay available before cleanup."
+              />
               <div className="flex items-center gap-2">
                 <Input
                   id="completed-session-retention"
@@ -289,12 +433,14 @@ function LifecycleDefaultsSection() {
                 />
                 <span className="text-xs text-muted-foreground">minutes</span>
               </div>
-              <p className="text-xs text-muted-foreground">
-                Keeps completed sandbox state available before cleanup.
-              </p>
+              <MaxHint>{`Max ${MAX_COMPLETED_SESSION_RETENTION_MINUTES} minutes`}</MaxHint>
             </div>
             <div className="space-y-2">
-              <Label htmlFor="idle-preview-ttl">Idle preview TTL</Label>
+              <SettingLabel
+                htmlFor="idle-preview-ttl"
+                label="Idle preview timeout"
+                tooltip="Stops a preview sandbox after it sits idle for this long."
+              />
               <div className="flex items-center gap-2">
                 <Input
                   id="idle-preview-ttl"
@@ -308,17 +454,16 @@ function LifecycleDefaultsSection() {
                 />
                 <span className="text-xs text-muted-foreground">minutes</span>
               </div>
-              <p className="text-xs text-muted-foreground">
-                Stops idle preview sandboxes after the configured window.
-              </p>
+              <MaxHint>{`Max ${MAX_IDLE_PREVIEW_TTL_MINUTES} minutes`}</MaxHint>
             </div>
           </div>
           <div className="flex flex-col gap-3 rounded-md border border-border p-3 sm:flex-row sm:items-center sm:justify-between">
             <div className="space-y-1">
-              <Label htmlFor="preview-holds-sandbox">Preview holds sandbox</Label>
-              <p className="text-xs text-muted-foreground">
-                Keeps the preview sandbox allocated while the preview remains active.
-              </p>
+              <SettingLabel
+                htmlFor="preview-holds-sandbox"
+                label="Keep sandbox while preview is active"
+                tooltip="Keeps the sandbox allocated for as long as the preview is running, even if the coding session has finished."
+              />
             </div>
             <Switch
               id="preview-holds-sandbox"
@@ -326,7 +471,7 @@ function LifecycleDefaultsSection() {
               onCheckedChange={(checked) => {
                 autosave.save({ settings: { sandbox_lifecycle: { preview_holds_sandbox: checked } } });
               }}
-              aria-label="Preview holds sandbox"
+              aria-label="Keep sandbox while preview is active"
             />
           </div>
         </CardContent>
@@ -352,12 +497,9 @@ function ResourceDefaultsSection() {
   const previewMaxEphemeralDiskMiB =
     resources.preview_max_ephemeral_disk_mib ?? DEFAULT_PREVIEW_MAX_EPHEMERAL_DISK_MIB;
 
-  const previewMaxCPUField = useAutosaveNumericField({
-    serverValue: previewMaxCPUMillis,
+  const previewMaxCPUField = usePreviewCPUField({
+    serverMillis: previewMaxCPUMillis,
     autosave,
-    toPatch: (value) => ({ settings: { sandbox_resources: { preview_max_cpu_millis: value } } }),
-    clamp: (value) =>
-      clampNumber(value, MIN_PREVIEW_MAX_CPU_MILLIS, MAX_PREVIEW_MAX_CPU_MILLIS),
   });
   const previewMaxMemoryField = useAutosaveNumericField({
     serverValue: previewMaxMemoryMiB,
@@ -387,53 +529,57 @@ function ResourceDefaultsSection() {
         <CardContent className="space-y-4">
           <div className="grid gap-4 md:grid-cols-2">
             <div className="space-y-2">
-              <Label htmlFor="agent-default-tier">Agent default tier</Label>
+              <SettingLabel
+                htmlFor="agent-default-tier"
+                label="Agent sandbox size"
+                tooltip="Default sandbox size for new coding-agent sessions."
+              />
               <ResourceTierSelect
                 id="agent-default-tier"
-                label="Agent default tier"
+                label="Agent sandbox size"
                 value={agentDefaultTier}
                 onChange={(value) => {
                   autosave.save({ settings: { sandbox_resources: { agent_default_tier: value } } });
                 }}
               />
-              <p className="text-xs text-muted-foreground">
-                Default sandbox size for new coding-agent sessions.
-              </p>
             </div>
             <div className="space-y-2">
-              <Label htmlFor="preview-default-tier">Preview default tier</Label>
+              <SettingLabel
+                htmlFor="preview-default-tier"
+                label="Preview sandbox size"
+                tooltip="Default sandbox size for previews when the repository does not request one."
+              />
               <ResourceTierSelect
                 id="preview-default-tier"
-                label="Preview default tier"
+                label="Preview sandbox size"
                 value={previewDefaultTier}
                 onChange={(value) => {
                   autosave.save({ settings: { sandbox_resources: { preview_default_tier: value } } });
                 }}
               />
-              <p className="text-xs text-muted-foreground">
-                Default sandbox size for previews when repo config does not request one.
-              </p>
             </div>
             <div className="space-y-2">
-              <Label htmlFor="preview-max-tier">Preview max tier</Label>
+              <SettingLabel
+                htmlFor="preview-max-tier"
+                label="Largest preview size"
+                tooltip="Largest sandbox size a repository preview config can request."
+              />
               <ResourceTierSelect
                 id="preview-max-tier"
-                label="Preview max tier"
+                label="Largest preview size"
                 value={previewMaxTier}
                 onChange={(value) => {
                   autosave.save({ settings: { sandbox_resources: { preview_max_tier: value } } });
                 }}
               />
-              <p className="text-xs text-muted-foreground">
-                Highest resource tier previews may request from repo configuration.
-              </p>
             </div>
             <div className="flex flex-col gap-3 rounded-md border border-border p-3 sm:flex-row sm:items-center sm:justify-between">
               <div className="space-y-1">
-                <Label htmlFor="allow-repo-resource-requests">Allow repo resource requests</Label>
-                <p className="text-xs text-muted-foreground">
-                  Allows repository preview config to request CPU, memory, and disk up to the org limits.
-                </p>
+                <SettingLabel
+                  htmlFor="allow-repo-resource-requests"
+                  label="Allow repository resource requests"
+                  tooltip="Lets repository preview config request CPU, memory, and disk up to the organization limits."
+                />
               </div>
               <Switch
                 id="allow-repo-resource-requests"
@@ -443,30 +589,37 @@ function ResourceDefaultsSection() {
                     settings: { sandbox_resources: { allow_repo_resource_requests: checked } },
                   });
                 }}
-                aria-label="Allow repo resource requests"
+                aria-label="Allow repository resource requests"
               />
             </div>
             <div className="space-y-2">
-              <Label htmlFor="preview-max-cpu-millis">Preview CPU request max</Label>
+              <SettingLabel
+                htmlFor="preview-max-cpu-millis"
+                label="Preview CPU limit"
+                tooltip="Largest CPU request a repository preview config can make, shown in CPU cores."
+              />
               <div className="flex items-center gap-2">
                 <Input
                   id="preview-max-cpu-millis"
                   type="number"
-                  inputMode="numeric"
-                  min={MIN_PREVIEW_MAX_CPU_MILLIS}
-                  max={MAX_PREVIEW_MAX_CPU_MILLIS}
+                  inputMode="decimal"
+                  min={MIN_PREVIEW_MAX_CPU_MILLIS / CPU_MILLIS_PER_CORE}
+                  max={MAX_PREVIEW_MAX_CPU_MILLIS / CPU_MILLIS_PER_CORE}
+                  step={CPU_MILLIS_STEP / CPU_MILLIS_PER_CORE}
                   value={previewMaxCPUField.value}
                   onChange={previewMaxCPUField.onChange}
                   onBlur={previewMaxCPUField.onBlur}
                 />
-                <span className="text-xs text-muted-foreground">millicores</span>
+                <span className="text-xs text-muted-foreground">cores</span>
               </div>
-              <p className="text-xs text-muted-foreground">
-                Hard platform cap is {MAX_PREVIEW_MAX_CPU_MILLIS} millicores.
-              </p>
+              <MaxHint>{`Max ${formatCPUCores(MAX_PREVIEW_MAX_CPU_MILLIS)} cores`}</MaxHint>
             </div>
             <div className="space-y-2">
-              <Label htmlFor="preview-max-memory-mib">Preview memory request max</Label>
+              <SettingLabel
+                htmlFor="preview-max-memory-mib"
+                label="Preview memory limit"
+                tooltip="Largest memory request a repository preview config can make."
+              />
               <div className="flex items-center gap-2">
                 <Input
                   id="preview-max-memory-mib"
@@ -480,12 +633,14 @@ function ResourceDefaultsSection() {
                 />
                 <span className="text-xs text-muted-foreground">MiB</span>
               </div>
-              <p className="text-xs text-muted-foreground">
-                Hard platform cap is {MAX_PREVIEW_MAX_MEMORY_MIB} MiB.
-              </p>
+              <MaxHint>{`Max ${MAX_PREVIEW_MAX_MEMORY_MIB} MiB`}</MaxHint>
             </div>
             <div className="space-y-2">
-              <Label htmlFor="preview-max-ephemeral-disk-mib">Preview ephemeral disk request max</Label>
+              <SettingLabel
+                htmlFor="preview-max-ephemeral-disk-mib"
+                label="Preview disk limit"
+                tooltip="Largest temporary disk request a repository preview config can make."
+              />
               <div className="flex items-center gap-2">
                 <Input
                   id="preview-max-ephemeral-disk-mib"
@@ -499,9 +654,7 @@ function ResourceDefaultsSection() {
                 />
                 <span className="text-xs text-muted-foreground">MiB</span>
               </div>
-              <p className="text-xs text-muted-foreground">
-                Hard platform cap is {MAX_PREVIEW_MAX_EPHEMERAL_DISK_MIB} MiB.
-              </p>
+              <MaxHint>{`Max ${MAX_PREVIEW_MAX_EPHEMERAL_DISK_MIB} MiB`}</MaxHint>
             </div>
           </div>
         </CardContent>
@@ -528,11 +681,15 @@ function SessionRuntimeSection() {
 
   return (
     <section className="space-y-3">
-      <SectionHeader title="Session runtime" status={autosave.status} />
+      <SectionHeader title="Sessions" status={autosave.status} />
       <Card>
         <CardContent className="space-y-4">
           <div className="max-w-[560px] space-y-2">
-            <Label htmlFor="max-session-minutes">Maximum session duration</Label>
+            <SettingLabel
+              htmlFor="max-session-minutes"
+              label="Maximum session length"
+              tooltip="Stops a coding-agent turn when it runs longer than this organization limit."
+            />
             <div className="flex items-center gap-2">
               <Input
                 id="max-session-minutes"
@@ -546,16 +703,15 @@ function SessionRuntimeSection() {
               />
               <span className="text-xs text-muted-foreground">minutes</span>
             </div>
-            <p className="text-xs text-muted-foreground">
-              Stops long-running turns after the configured org limit.
-            </p>
+            <MaxHint>{`Max ${MAX_SESSION_DURATION_MINUTES} minutes`}</MaxHint>
           </div>
           <div className="flex flex-col gap-3 rounded-md border border-border p-3 sm:flex-row sm:items-center sm:justify-between">
             <div className="space-y-1">
-              <Label htmlFor="sandbox-tab-tools">Sandbox tab tools</Label>
-              <p className="text-xs text-muted-foreground">
-                Allows agent tabs in the same session to coordinate through the 143 tools CLI.
-              </p>
+              <SettingLabel
+                htmlFor="sandbox-tab-tools"
+                label="Agent tab tools"
+                tooltip="Lets agent tabs in the same session coordinate with each other through the 143 tools CLI."
+              />
             </div>
             <Switch
               id="sandbox-tab-tools"
@@ -563,81 +719,9 @@ function SessionRuntimeSection() {
               onCheckedChange={(checked) => {
                 autosave.save({ settings: { coding_agent_tab_tools_enabled: checked } });
               }}
-              aria-label="Sandbox tab tools"
+              aria-label="Agent tab tools"
             />
           </div>
-        </CardContent>
-      </Card>
-    </section>
-  );
-}
-
-function RuntimeDiagnosticsSection() {
-  const { data: runtimeStatusResponse } = useQuery({
-    queryKey: queryKeys.settings.runtimeStatus,
-    queryFn: () => api.settings.getRuntimeStatus(),
-  });
-
-  const runtimeStatus = runtimeStatusResponse?.data;
-  const staticEgress = runtimeStatus?.static_egress;
-  const capacity = runtimeStatus?.capacity;
-  const staticEgressAvailable = staticEgress?.available ?? false;
-  const staticEgressEnabled = staticEgress?.enabled ?? false;
-  const capacityState = capacity?.state === "limited" ? "Limited" : "Normal";
-
-  const rows = [
-    {
-      label: "Static egress",
-      value: staticEgressAvailable ? "Available" : "Unavailable",
-      detail: staticEgressEnabled ? "Enabled for new sandbox starts" : "Disabled for new sandbox starts",
-      tone: staticEgressAvailable ? "default" : "secondary",
-    },
-    {
-      label: "Agent runs",
-      value: capacity
-        ? `${capacity.active_agent_runs} / ${capacity.max_concurrent_agent_runs}`
-        : "Loading",
-      detail: "Active coding-agent runs against the org concurrency limit",
-      tone: "secondary",
-    },
-    {
-      label: "Active previews",
-      value: capacity
-        ? `${capacity.active_previews} / ${capacity.max_previews_per_user}`
-        : "Loading",
-      detail: "Active previews against the per-user limit",
-      tone: "secondary",
-    },
-    {
-      label: "Capacity",
-      value: capacityState,
-      detail: capacity?.state === "limited" ? "One or more runtime limits is currently saturated" : "Runtime capacity is within configured limits",
-      tone: capacity?.state === "limited" ? "destructive" : "default",
-    },
-  ] satisfies {
-    label: string;
-    value: string;
-    detail: string;
-    tone: "default" | "secondary" | "destructive";
-  }[];
-
-  return (
-    <section className="space-y-3">
-      <SectionHeader title="Runtime diagnostics" />
-      <Card>
-        <CardContent className="divide-y divide-border/60 p-0">
-          {rows.map((row) => (
-            <div
-              key={row.label}
-              className="grid gap-2 px-4 py-3 sm:grid-cols-[minmax(0,180px)_minmax(0,1fr)_auto] sm:items-center"
-            >
-              <div className="text-xs font-medium text-foreground">{row.label}</div>
-              <div className="text-xs text-muted-foreground">{row.detail}</div>
-              <div>
-                <Badge variant={row.tone}>{row.value}</Badge>
-              </div>
-            </div>
-          ))}
         </CardContent>
       </Card>
     </section>
@@ -649,24 +733,19 @@ export default function RuntimeSettingsPage() {
 
   return (
     <PageContainer size="default">
-      <div className="space-y-8">
-        <PageHeader
-          title="Runtime"
-          description="Configure sandbox networking, capacity, and lifecycle defaults."
-        />
-        <div className="grid gap-3 rounded-md border border-border bg-muted/30 px-3 py-3 text-xs text-muted-foreground md:grid-cols-[auto_minmax(0,1fr)]">
-          <Network className="h-4 w-4 text-muted-foreground" />
-          <p>
-            These settings apply to sandbox runtimes across coding-agent sessions and previews.
-          </p>
+      <TooltipProvider delayDuration={150}>
+        <div className="space-y-8">
+          <PageHeader
+            title="Runtime"
+            description="Configure sandbox networking, capacity, and lifecycle defaults."
+          />
+          <SandboxNetworkSection />
+          <CapacityLimitsSection />
+          <SessionRuntimeSection />
+          <LifecycleDefaultsSection />
+          <ResourceDefaultsSection />
         </div>
-        <SandboxNetworkSection />
-        <CapacityLimitsSection />
-        <SessionRuntimeSection />
-        <LifecycleDefaultsSection />
-        <ResourceDefaultsSection />
-        <RuntimeDiagnosticsSection />
-      </div>
+      </TooltipProvider>
     </PageContainer>
   );
 }


### PR DESCRIPTION
## Summary
- prevent the Preview CPU field from rounding and autosaving when a user focuses and blurs an unchanged legacy value
- keep the existing cores-to-millicores UI conversion for intentional edits
- add a regression test covering the no-op blur case

## Testing
- Unit test coverage added for the unchanged Preview CPU blur path