### PR TITLE
Preload session detail dynamic chunk so first session open is instant

### DIFF
--- a/frontend/src/app/(dashboard)/sessions/[id]/session-detail-page-client.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/session-detail-page-client.test.tsx
@@ -15,7 +15,14 @@ vi.mock("next/dynamic", () => ({
   },
 }));
 
-import { SessionDetailPageClient } from "./session-detail-page-client";
+const contentModule = vi.hoisted(() => ({ loaded: false }));
+
+vi.mock("./session-detail-content", () => {
+  contentModule.loaded = true;
+  return { SessionDetailContent: () => null };
+});
+
+import { preloadSessionDetailContent, SessionDetailPageClient } from "./session-detail-page-client";
 
 describe("SessionDetailPageClient", () => {
   it("renders the route skeleton while the split session detail module loads", () => {
@@ -23,5 +30,13 @@ describe("SessionDetailPageClient", () => {
 
     expect(screen.getByTestId("mock-dynamic-session-detail")).toBeInTheDocument();
     expect(screen.getByTestId("session-detail-loading-skeleton")).toBeInTheDocument();
+  });
+
+  it("loads the split session detail module when preloaded ahead of navigation", async () => {
+    expect(contentModule.loaded).toBe(false);
+
+    preloadSessionDetailContent();
+
+    await vi.waitFor(() => expect(contentModule.loaded).toBe(true));
   });
 });

--- a/frontend/src/app/(dashboard)/sessions/[id]/session-detail-page-client.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/session-detail-page-client.tsx
@@ -3,8 +3,20 @@
 import dynamic from "next/dynamic";
 import { SessionDetailLoadingSkeleton } from "./session-detail-loading-skeleton";
 
+const loadSessionDetailContent = () => import("./session-detail-content");
+
+// router.prefetch() only fetches the route's RSC payload and the small page
+// wrapper chunk — the ssr:false chunk below starts downloading (prod) or
+// compiling (dev) only when the page renders, so the first session open
+// stalls on it. List views call this from hover/idle handlers to warm the
+// chunk before the click; the bundler caches the promise, so repeat calls
+// and the dynamic() loader all share one fetch.
+export function preloadSessionDetailContent() {
+  void loadSessionDetailContent();
+}
+
 const SessionDetailContent = dynamic(
-  () => import("./session-detail-content").then((module) => module.SessionDetailContent),
+  () => loadSessionDetailContent().then((module) => module.SessionDetailContent),
   {
     ssr: false,
     loading: () => <SessionDetailLoadingSkeleton />,

--- a/frontend/src/app/(dashboard)/sessions/layout.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/layout.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { renderWithProviders, screen } from "@/test/test-utils";
 import SessionsLayout from "./layout";
 
@@ -35,9 +35,33 @@ vi.mock("./session-sidebar", () => ({
   SessionSidebar: () => <div data-testid="session-sidebar" />,
 }));
 
+const preloadSessionDetailContent = vi.hoisted(() => vi.fn());
+
+vi.mock("./[id]/session-detail-page-client", () => ({
+  preloadSessionDetailContent,
+}));
+
 describe("SessionsLayout", () => {
+  // jsdom has no requestIdleCallback; provide one that runs synchronously so
+  // the chunk warm-up path is exercised without waiting on the timeout
+  // fallback. Stubbed for the whole file (and unstubbed only after all
+  // per-test unmounts have run) so the effect cleanup's cancelIdleCallback
+  // call never lands after the stub is gone — even when a test fails.
+  beforeAll(() => {
+    vi.stubGlobal("requestIdleCallback", (cb: IdleRequestCallback) => {
+      cb({ didTimeout: false, timeRemaining: () => 50 });
+      return 1;
+    });
+    vi.stubGlobal("cancelIdleCallback", () => {});
+  });
+
+  afterAll(() => {
+    vi.unstubAllGlobals();
+  });
+
   beforeEach(() => {
     mockPathname = "/sessions";
+    preloadSessionDetailContent.mockClear();
   });
 
   it("shows the sidebar pane on mobile for the /sessions route", () => {
@@ -72,5 +96,15 @@ describe("SessionsLayout", () => {
     );
 
     expect(screen.getByTestId("sidebar-layout")).toHaveAttribute("data-mobile-show", "content");
+  });
+
+  it("warms the session detail chunk during idle time after mount", () => {
+    renderWithProviders(
+      <SessionsLayout>
+        <div>Child content</div>
+      </SessionsLayout>,
+    );
+
+    expect(preloadSessionDetailContent).toHaveBeenCalled();
   });
 });

--- a/frontend/src/app/(dashboard)/sessions/layout.tsx
+++ b/frontend/src/app/(dashboard)/sessions/layout.tsx
@@ -1,13 +1,29 @@
 "use client";
 
+import { useEffect } from "react";
 import { SidebarLayout } from "@/components/sidebar-layout";
 import { SessionSidebar } from "./session-sidebar";
 import { OptimisticSessionsProvider } from "@/contexts/optimistic-sessions";
 import { usePathname } from "next/navigation";
+import { preloadSessionDetailContent } from "./[id]/session-detail-page-client";
 
 export default function SessionsLayout({ children }: { children: React.ReactNode }) {
   const pathname = usePathname();
   const mobileShow = pathname === "/sessions" ? "sidebar" : "content";
+
+  // The detail view's heavy chunk sits behind a render-time dynamic import
+  // that router.prefetch never touches, so the first session open would pay
+  // its download/compile cost. Warm it during idle time from this layout,
+  // which wraps every sessions surface — including /sessions/new and touch
+  // devices that never fire the hover prefetches.
+  useEffect(() => {
+    if (typeof window.requestIdleCallback === "function") {
+      const handle = window.requestIdleCallback(() => preloadSessionDetailContent());
+      return () => window.cancelIdleCallback(handle);
+    }
+    const timeout = window.setTimeout(() => preloadSessionDetailContent(), 1000);
+    return () => window.clearTimeout(timeout);
+  }, []);
 
   return (
     <OptimisticSessionsProvider>

--- a/frontend/src/app/(dashboard)/sessions/session-sidebar.tsx
+++ b/frontend/src/app/(dashboard)/sessions/session-sidebar.tsx
@@ -27,6 +27,7 @@ import type { ListResponse, SessionCounts, SessionDetail, SessionListItem, Singl
 import { prMergedAccent } from "@/lib/pr-status-styles";
 import { deriveSessionDisplayStatus } from "@/lib/session-display-status";
 import { provisionalSessionDetailFromListItem } from "@/lib/session-detail-cache";
+import { preloadSessionDetailContent } from "./[id]/session-detail-page-client";
 import { hasSessionKeyboardTransientSurface, isSessionKeyboardTextEntryTarget } from "@/hooks/use-session-keyboard-shortcuts";
 import {
   workingSet,
@@ -788,6 +789,14 @@ export function SessionSidebar() {
     router.prefetch(href);
   }, [router]);
 
+  // Session rows also warm the detail view's render-time dynamic chunk,
+  // which router.prefetch skips — otherwise the first session open stalls
+  // on it. Non-session routes (e.g. /sessions/new) keep the plain prefetch.
+  const prefetchSessionRoute = useCallback((href: string) => {
+    router.prefetch(href);
+    preloadSessionDetailContent();
+  }, [router]);
+
   const toggleArchiveActiveSession = useCallback(() => {
     if (!activeSession) return;
     if (activeSession.archived_at) {
@@ -938,8 +947,8 @@ export function SessionSidebar() {
             ariaCurrent={isSelected ? "page" : undefined}
             onClick={() => handleSessionLinkClick(session)}
             onMouseDown={() => seedSessionDetailCache(session)}
-            onMouseEnter={() => prefetchRoute(sessionHref)}
-            onFocus={() => prefetchRoute(sessionHref)}
+            onMouseEnter={() => prefetchSessionRoute(sessionHref)}
+            onFocus={() => prefetchSessionRoute(sessionHref)}
             className={
               isSelected
                 ? "border-transparent bg-primary/5 shadow-none ring-0 md:border-transparent md:bg-primary/5 md:shadow-none"

--- a/frontend/src/app/(dashboard)/sessions/sessions-page-content.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/sessions-page-content.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { http, HttpResponse } from 'msw';
-import { renderWithProviders, screen } from '@/test/test-utils';
+import { fireEvent, renderWithProviders, screen } from '@/test/test-utils';
 import { server } from '@/test/mocks/server';
 import { SessionsPageContent } from './sessions-page-content';
 import type { SessionListItem } from '@/lib/types';
@@ -18,10 +18,16 @@ const mockAuthState: {
 };
 
 vi.mock('next/navigation', () => ({
-  useRouter: () => ({ push: vi.fn(), replace: vi.fn(), back: vi.fn() }),
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn(), back: vi.fn(), prefetch: vi.fn() }),
   useSearchParams: () => new URLSearchParams(),
   usePathname: () => '/sessions',
   useParams: () => ({}),
+}));
+
+const preloadSessionDetailContent = vi.hoisted(() => vi.fn());
+
+vi.mock('./[id]/session-detail-page-client', () => ({
+  preloadSessionDetailContent,
 }));
 
 vi.mock('@/hooks/use-auth', () => ({
@@ -119,5 +125,17 @@ describe('SessionsPageContent', () => {
     expect(await screen.findByText('Opening a pull request')).toBeInTheDocument();
     expect(screen.getByText('Creating PR')).toBeInTheDocument();
     expect(screen.getByText('Pushing changes')).toBeInTheDocument();
+  });
+
+  it('warms the session detail chunk when hovering a session row', async () => {
+    preloadSessionDetailContent.mockClear();
+
+    renderWithProviders(<SessionsPageContent />);
+
+    const row = (await screen.findByText(/Fixed TypeError by adding null check/)).closest('tr');
+    expect(row).not.toBeNull();
+    fireEvent.mouseEnter(row!);
+
+    expect(preloadSessionDetailContent).toHaveBeenCalled();
   });
 });

--- a/frontend/src/app/(dashboard)/sessions/sessions-page-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/sessions-page-content.tsx
@@ -36,6 +36,7 @@ import { AnimatedEllipsis } from "@/components/animated-ellipsis";
 import { AgentBadge } from "@/components/agent-badge";
 import { usePeopleFilter } from "@/hooks/use-people-filter";
 import { provisionalSessionDetailFromListItem } from "@/lib/session-detail-cache";
+import { preloadSessionDetailContent } from "./[id]/session-detail-page-client";
 import { deriveSessionDisplayStatus, type SessionDisplayStatus } from "@/lib/session-display-status";
 import type { Session, SessionDetail, SessionListItem, SingleResponse, User } from "@/lib/types";
 import {
@@ -449,10 +450,14 @@ export function SessionsPageContent() {
                     <TableRow
                       key={row.id}
                       className="cursor-pointer"
-                      // Prefetch the route on hover and seed the detail cache on
-                      // mousedown so the click navigates instantly to a seeded
-                      // skeleton instead of silently waiting on a server fetch.
-                      onMouseEnter={() => router.prefetch(`/sessions/${row.original.id}`)}
+                      // Prefetch the route and warm the detail view's dynamic
+                      // chunk on hover, and seed the detail cache on mousedown,
+                      // so the click navigates instantly to a seeded skeleton
+                      // instead of silently waiting on a server fetch.
+                      onMouseEnter={() => {
+                        router.prefetch(`/sessions/${row.original.id}`);
+                        preloadSessionDetailContent();
+                      }}
                       onMouseDown={() => seedSessionDetailCache(row.original)}
                       onClick={() => navigateToSession(row.original)}
                     >


### PR DESCRIPTION
## Problem

The first click from the sessions list into a session took a long time with no visible feedback; every later session open was fast.

Root cause: the session detail view sits behind a render-time dynamic import (`ssr: false`, split out in #1344), and `router.prefetch()` only fetches the route's RSC payload plus the tiny page wrapper (~9 KB) — never the detail chunk. So the first navigation paid the full ~250 KB chunk graph download in prod, and in dev (where `router.prefetch` is a no-op) the on-demand Turbopack compile: measured 7.1s for the first `/sessions/[id]` request vs 0.3s warm. Once loaded, the browser module cache makes every subsequent session open instant — exactly the observed first-slow-then-fast pattern.

## Fix

Export `preloadSessionDetailContent()` from `session-detail-page-client.tsx`, sharing the same import promise as the `dynamic()` loader (the bundler caches it, so all call sites and the loader resolve through one fetch). Warm it from three places:

- **Sessions layout, on idle** (`requestIdleCallback` with a `setTimeout` fallback) — covers every sessions surface including `/sessions/new` and touch devices that never fire hover prefetches.
- **Sessions table row hover** — alongside the existing `router.prefetch`.
- **Sidebar session row hover/focus** — via a new `prefetchSessionRoute`; the "New session" button keeps the plain route prefetch since it doesn't need the detail chunk.

Net bundle effect: the sessions layout chunk gains only the ~9 KB wrapper/skeleton module; the heavy chunk stays split and is fetched during idle time instead of on the critical click path.

## Tests

- Layout mount warms the chunk during idle (synchronous `requestIdleCallback` stub, installed file-wide so effect cleanup never outlives it).
- List-row hover triggers the preload.
- The preload export actually loads the split module (hoisted mock flag).

Verified: 77 tests across the touched files, `tsc --noEmit`, eslint, and a full production build all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
