### PR TITLE
Fix Runtime Settings layout: move repository resource requests below resource limits row

### DIFF
--- a/docs/design/implemented/96-runtime-network-settings-placement.md
+++ b/docs/design/implemented/96-runtime-network-settings-placement.md
@@ -274,6 +274,7 @@ Layout rules:
 - Use `space-y-6` or `space-y-8` at the page level, matching existing settings pages.
 - Keep card content compact.
 - Use stacked mobile rows; do not rely on desktop-only table layouts.
+- In Resource defaults, keep the repository resource request policy as its own row below the tier and numeric resource limit grid.
 - Keep all copy operational and short.
 - Put field explanations in question-mark tooltips; keep visible helper text only for max values.
 - Avoid nested cards.

--- a/frontend/src/app/(dashboard)/settings/runtime/page.test.tsx
+++ b/frontend/src/app/(dashboard)/settings/runtime/page.test.tsx
@@ -149,6 +149,23 @@ describe("RuntimeSettingsPage", () => {
     ).not.toHaveLength(0);
   });
 
+  it("places repository resource requests below the resource limits in a separate row", async () => {
+    renderWithProviders(<RuntimeSettingsPage />);
+
+    const diskLimit = await screen.findByLabelText("Preview disk limit");
+    const repositoryRequests = screen.getByLabelText("Allow repository resource requests");
+    const resourceGrid = screen.getByTestId("resource-defaults-grid");
+    const repositoryRequestsRow = screen.getByTestId("repository-resource-requests-row");
+
+    expect(
+      diskLimit.compareDocumentPosition(repositoryRequests) & Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+    expect(resourceGrid).not.toContainElement(repositoryRequestsRow);
+    expect(
+      resourceGrid.compareDocumentPosition(repositoryRequestsRow) & Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+  });
+
   it("saves runtime settings through the existing org settings API", async () => {
     settingsUpdateMock
       .mockResolvedValueOnce({

--- a/frontend/src/app/(dashboard)/settings/runtime/page.tsx
+++ b/frontend/src/app/(dashboard)/settings/runtime/page.tsx
@@ -535,7 +535,7 @@ function ResourceDefaultsSection() {
       <SectionHeader title="Resource defaults" status={autosave.status} />
       <Card>
         <CardContent className="space-y-4">
-          <div className="grid gap-4 md:grid-cols-2">
+          <div data-testid="resource-defaults-grid" className="grid gap-4 md:grid-cols-2">
             <div className="space-y-2">
               <SettingLabel
                 htmlFor="agent-default-tier"
@@ -579,25 +579,6 @@ function ResourceDefaultsSection() {
                 onChange={(value) => {
                   autosave.save({ settings: { sandbox_resources: { preview_max_tier: value } } });
                 }}
-              />
-            </div>
-            <div className="flex flex-col gap-3 rounded-md border border-border p-3 sm:flex-row sm:items-center sm:justify-between">
-              <div className="space-y-1">
-                <SettingLabel
-                  htmlFor="allow-repo-resource-requests"
-                  label="Allow repository resource requests"
-                  tooltip="Lets repository preview config request CPU, memory, and disk up to the organization limits."
-                />
-              </div>
-              <Switch
-                id="allow-repo-resource-requests"
-                checked={allowRepoResourceRequests}
-                onCheckedChange={(checked) => {
-                  autosave.save({
-                    settings: { sandbox_resources: { allow_repo_resource_requests: checked } },
-                  });
-                }}
-                aria-label="Allow repository resource requests"
               />
             </div>
             <div className="space-y-2">
@@ -664,6 +645,28 @@ function ResourceDefaultsSection() {
               </div>
               <MaxHint>{`Max ${MAX_PREVIEW_MAX_EPHEMERAL_DISK_MIB} MiB`}</MaxHint>
             </div>
+          </div>
+          <div
+            data-testid="repository-resource-requests-row"
+            className="flex flex-col gap-3 rounded-md border border-border p-3 sm:flex-row sm:items-center sm:justify-between"
+          >
+            <div className="space-y-1">
+              <SettingLabel
+                htmlFor="allow-repo-resource-requests"
+                label="Allow repository resource requests"
+                tooltip="Lets repository preview config request CPU, memory, and disk up to the organization limits."
+              />
+            </div>
+            <Switch
+              id="allow-repo-resource-requests"
+              checked={allowRepoResourceRequests}
+              onCheckedChange={(checked) => {
+                autosave.save({
+                  settings: { sandbox_resources: { allow_repo_resource_requests: checked } },
+                });
+              }}
+              aria-label="Allow repository resource requests"
+            />
           </div>
         </CardContent>
       </Card>


### PR DESCRIPTION
## Summary
Updated the Runtime Settings page layout to fix toggle placement for “Allow repository resource requests” (per the design rule in the related design note). This keeps the toggle visually and semantically aligned as its own row below the resource limits grid.

## Changes
- **frontend/src/app/(dashboard)/settings/runtime/page.tsx**
  - Moved **“Allow repository resource requests”** out of the **two-column resource defaults grid**.
  - Added a dedicated bordered row for the repository toggle **below** the resource limits/grid.
  - Added `data-testid="resource-defaults-grid"` and `data-testid="repository-resource-requests-row"` to support the regression test.
- **frontend/src/app/(dashboard)/settings/runtime/page.test.tsx**
  - Added regression test asserting the repository requests row is rendered **after** the disk limit control and **not inside** the resource defaults grid.
- **docs/design/implemented/96-runtime-network-settings-placement.md**
  - Updated the placement rule to explicitly keep the repository resource request policy as its own row below the tier + numeric resource limit grid.

## Test plan
- `npm test -- --run src/app/\(dashboard\)/settings/runtime/page.test.tsx`
- `npm run typecheck`
- `npm run lint`
- `npm run build`

[143.dev](https://143.dev) | [session 8452877d](https://143.dev/sessions/8452877d-5905-41d8-a8b8-3ee2fb264d31)

Preview: https://143.dev/previews/github/assembledhq/143/pull/1364