### PR TITLE
Surface failed per-host deploy logs in CI output and artifacts

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -167,9 +167,21 @@ jobs:
           WORKER_DEPLOY_DETACH: "1"
           WORKER_BLUE_GREEN_PORT_START: "8080"
           WORKER_BLUE_GREEN_PORT_END: "8087"
+          # Stable path (instead of mktemp) so the upload step below can
+          # capture every per-host log when any deploy fails.
+          DEPLOY_FLEET_LOG_DIR: /tmp/deploy-fleet-logs
         run: |
           chmod +x deploy/scripts/deploy.sh deploy/scripts/deploy-fleet.sh
           ./deploy/scripts/deploy-fleet.sh ~/.ssh/deploy-key "${{ github.sha }}"
+
+      - name: Upload per-host deploy logs
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: deploy-fleet-logs
+          path: /tmp/deploy-fleet-logs/
+          if-no-files-found: ignore
+          retention-days: 14
 
       - name: Verify worker rollover
         if: steps.deploy_latest.outputs.should_deploy == 'true'

--- a/deploy/deploy_config_test.go
+++ b/deploy/deploy_config_test.go
@@ -288,6 +288,8 @@ func TestFleetDeployDefaultsToUserFacingRuntimeRoles(t *testing.T) {
 	require.Contains(t, fleetText, `DEPLOY_JOBS="${DEPLOY_JOBS:-4}"`, "fleet deploy should default to a bounded four-node deploy fan-out")
 	require.Contains(t, fleetText, `xargs -n1 -P "$DEPLOY_JOBS"`, "fleet deploy should deploy matching nodes concurrently instead of serializing the whole fleet")
 	require.Contains(t, fleetText, `LOG_DIR="$(mktemp -d /tmp/deploy-fleet.XXXXXX)"`, "parallel fleet deploy should keep per-host logs inspectable after failures")
+	require.Contains(t, fleetText, `LOG_DIR="$DEPLOY_FLEET_LOG_DIR"`, "fleet deploy should honor a stable log dir override so CI can upload per-host logs as an artifact")
+	require.Contains(t, fleetText, `dump_failed_logs`, "fleet deploy should print failed hosts' log tails so CI output is introspectable without the runner's /tmp")
 	require.Contains(t, fleetText, `deploy_one()`, "fleet deploy should isolate single-host deploy behavior so parallel fan-out keeps role and host context")
 	require.Contains(t, fleetText, `FAILED: one or more deploys failed`, "fleet deploy should finish pending parallel deploys and then fail loudly when any host fails")
 	require.Contains(t, fleetText, `DEPLOY_JOBS=1`, "fleet deploy should document how to recover the old one-host-at-a-time rollout behavior")
@@ -295,6 +297,8 @@ func TestFleetDeployDefaultsToUserFacingRuntimeRoles(t *testing.T) {
 	workflow, err := os.ReadFile("../.github/workflows/deploy.yml")
 	require.NoError(t, err, "test should read the deploy workflow")
 	require.Contains(t, string(workflow), `./deploy/scripts/deploy-fleet.sh ~/.ssh/deploy-key "${{ github.sha }}"`, "CI should use deploy-fleet's default app/worker role set for routine main-branch deploys")
+	require.Contains(t, string(workflow), `DEPLOY_FLEET_LOG_DIR: /tmp/deploy-fleet-logs`, "CI should pin the fleet log dir so the artifact upload step can find per-host logs")
+	require.Contains(t, string(workflow), `uses: actions/upload-artifact@v4`, "CI should upload per-host deploy logs on failure; the runner's /tmp vanishes when the job ends")
 
 	makefile, err := os.ReadFile("../Makefile")
 	require.NoError(t, err, "test should read Makefile")
@@ -427,6 +431,56 @@ echo "$role@$ip deployed by fake script"
 	require.NotEqual(t, -1, appIndex, "order log should include the same-host app deploy")
 	require.NotEqual(t, -1, workerIndex, "order log should include the same-host worker deploy")
 	require.Less(t, appIndex, workerIndex, "same-host deploys should preserve FLEET_HOSTS order")
+}
+
+func TestDeployFleetPrintsFailedHostLogs(t *testing.T) {
+	t.Parallel()
+
+	tempDir := t.TempDir()
+	scriptDir := filepath.Join(tempDir, "deploy", "scripts")
+	require.NoError(t, os.MkdirAll(scriptDir, 0o755), "test should create a temporary deploy script directory")
+
+	fleetScript, err := os.ReadFile("../deploy/scripts/deploy-fleet.sh")
+	require.NoError(t, err, "test should read deploy-fleet.sh")
+	fleetScriptPath := filepath.Join(scriptDir, "deploy-fleet.sh")
+	require.NoError(t, os.WriteFile(fleetScriptPath, fleetScript, 0o755), "test should copy deploy-fleet.sh into the temporary layout")
+
+	fakeDeploy := `#!/usr/bin/env bash
+set -euo pipefail
+role="$1"
+ip="$2"
+if [ "$role" = "worker" ]; then
+  echo "remote gate said: config changed during routine deploy on $ip"
+  exit 1
+fi
+echo "healthy $role deploy detail that must stay out of failure output"
+`
+	require.NoError(t, os.WriteFile(filepath.Join(scriptDir, "deploy.sh"), []byte(fakeDeploy), 0o755), "test should install a fake deploy.sh")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	logDir := filepath.Join(tempDir, "fleet-logs")
+	summaryPath := filepath.Join(tempDir, "step-summary.md")
+	cmd := exec.CommandContext(ctx, "bash", fleetScriptPath, "fake-key", "test-tag", "app,worker")
+	cmd.Env = append(os.Environ(),
+		"DEPLOY_JOBS=2",
+		"FLEET_HOSTS=app:10.0.0.1,worker:10.0.0.2",
+		"DEPLOY_FLEET_LOG_DIR="+logDir,
+		"GITHUB_ACTIONS=true",
+		"GITHUB_STEP_SUMMARY="+summaryPath,
+	)
+	output, err := cmd.CombinedOutput()
+	require.Error(t, err, "deploy-fleet should exit non-zero when a host fails: %s", string(output))
+	text := string(output)
+	require.Contains(t, text, "remote gate said: config changed during routine deploy on 10.0.0.2", "fleet output should include the failed host's log so CI failures are introspectable")
+	require.Contains(t, text, "::group::FAILED worker-10.0.0.2", "fleet output should wrap failed logs in a collapsible GitHub Actions group")
+	require.NotContains(t, text, "healthy app deploy detail", "fleet output should not dump logs of hosts that deployed cleanly")
+	require.FileExists(t, filepath.Join(logDir, "worker-10.0.0.2.log"), "fleet deploy should write per-host logs into the pinned artifact dir")
+
+	summary, err := os.ReadFile(summaryPath)
+	require.NoError(t, err, "fleet deploy should append failures to the GitHub step summary")
+	require.Contains(t, string(summary), "remote gate said: config changed during routine deploy on 10.0.0.2", "step summary should carry the failed host's log tail")
 }
 
 func indexOfString(values []string, target string) int {

--- a/deploy/deploy_config_test.go
+++ b/deploy/deploy_config_test.go
@@ -460,7 +460,14 @@ echo "healthy $role deploy detail that must stay out of failure output"
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
+	// Pre-seed the pinned log dir with a previous run's failure; the script
+	// must clear it instead of re-dumping it alongside this run's failures.
 	logDir := filepath.Join(tempDir, "fleet-logs")
+	require.NoError(t, os.MkdirAll(logDir, 0o755), "test should create the pinned log dir")
+	staleLog := filepath.Join(logDir, "app-9.9.9.9.log")
+	require.NoError(t, os.WriteFile(staleLog, []byte("stale failure from a previous run\n"), 0o644), "test should seed a stale per-host log")
+	require.NoError(t, os.WriteFile(staleLog+".failed", nil, 0o644), "test should seed a stale failure marker")
+
 	summaryPath := filepath.Join(tempDir, "step-summary.md")
 	cmd := exec.CommandContext(ctx, "bash", fleetScriptPath, "fake-key", "test-tag", "app,worker")
 	cmd.Env = append(os.Environ(),
@@ -475,7 +482,9 @@ echo "healthy $role deploy detail that must stay out of failure output"
 	text := string(output)
 	require.Contains(t, text, "remote gate said: config changed during routine deploy on 10.0.0.2", "fleet output should include the failed host's log so CI failures are introspectable")
 	require.Contains(t, text, "::group::FAILED worker-10.0.0.2", "fleet output should wrap failed logs in a collapsible GitHub Actions group")
+	require.Contains(t, text, "::stop-commands::", "fleet output should fence dumped remote log content so the runner does not interpret ::-prefixed lines as workflow commands")
 	require.NotContains(t, text, "healthy app deploy detail", "fleet output should not dump logs of hosts that deployed cleanly")
+	require.NotContains(t, text, "stale failure from a previous run", "fleet deploy should clear prior-run state from a reused pinned log dir before deploying")
 	require.FileExists(t, filepath.Join(logDir, "worker-10.0.0.2.log"), "fleet deploy should write per-host logs into the pinned artifact dir")
 
 	summary, err := os.ReadFile(summaryPath)

--- a/deploy/scripts/deploy-fleet.sh
+++ b/deploy/scripts/deploy-fleet.sh
@@ -90,7 +90,14 @@ fi
 echo "Reading fleet from FLEET_HOSTS..."
 echo "Deploying roles: $REQUESTED_ROLES"
 echo "Deploying up to $DEPLOY_JOBS node(s) concurrently. Set DEPLOY_JOBS=1 for serial deploys."
-LOG_DIR="$(mktemp -d /tmp/deploy-fleet.XXXXXX)"
+# DEPLOY_FLEET_LOG_DIR pins per-host logs to a stable path so CI can upload
+# them as an artifact; ephemeral runners lose /tmp the moment the job ends.
+if [ -n "${DEPLOY_FLEET_LOG_DIR:-}" ]; then
+  LOG_DIR="$DEPLOY_FLEET_LOG_DIR"
+  mkdir -p "$LOG_DIR"
+else
+  LOG_DIR="$(mktemp -d /tmp/deploy-fleet.XXXXXX)"
+fi
 HOSTS=()
 HOST_GROUP_FILES=()
 TARGET_COUNT=0
@@ -139,8 +146,49 @@ deploy_one() {
   if "$SCRIPT_DIR/deploy.sh" "$role" "$ip" "$SSH_KEY" "$TAG" >"$log" 2>&1; then
     echo "--- OK: $role@$ip ---"
   else
-    echo "--- FAILED: $role@$ip (log: $log) ---" >&2
+    echo "--- FAILED: $role@$ip (log tail printed after all deploys finish) ---" >&2
+    touch "$log.failed"
     return 1
+  fi
+}
+
+# Print the tail of every failed host's log after the parallel fan-out
+# finishes. Dumping from the parent (not deploy_one) keeps concurrent
+# failures from interleaving their logs. On GitHub Actions each log is
+# wrapped in a collapsible ::group:: and also appended to the job summary.
+DEPLOY_FAIL_LOG_LINES="${DEPLOY_FAIL_LOG_LINES:-200}"
+dump_failed_logs() {
+  local marker failed_log name
+  for marker in "$LOG_DIR"/*.log.failed; do
+    [ -e "$marker" ] || continue
+    failed_log="${marker%.failed}"
+    name="$(basename "$failed_log" .log)"
+    echo ""
+    if [ -n "${GITHUB_ACTIONS:-}" ]; then
+      echo "::group::FAILED $name — last $DEPLOY_FAIL_LOG_LINES log lines"
+    else
+      echo "===== FAILED $name — last $DEPLOY_FAIL_LOG_LINES log lines (full log: $failed_log) ====="
+    fi
+    tail -n "$DEPLOY_FAIL_LOG_LINES" "$failed_log"
+    if [ -n "${GITHUB_ACTIONS:-}" ]; then
+      echo "::endgroup::"
+    fi
+  done
+  if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
+    {
+      echo "## Deploy failures"
+      for marker in "$LOG_DIR"/*.log.failed; do
+        [ -e "$marker" ] || continue
+        failed_log="${marker%.failed}"
+        name="$(basename "$failed_log" .log)"
+        echo "<details><summary><code>$name</code> — last $DEPLOY_FAIL_LOG_LINES log lines</summary>"
+        echo ""
+        echo '```'
+        tail -n "$DEPLOY_FAIL_LOG_LINES" "$failed_log"
+        echo '```'
+        echo "</details>"
+      done
+    } >> "$GITHUB_STEP_SUMMARY"
   fi
 }
 
@@ -161,6 +209,7 @@ echo "Deploying ${#HOST_GROUP_FILES[@]} node(s), $DEPLOY_JOBS at a time (logs: $
 if printf '%s\n' "${HOST_GROUP_FILES[@]}" | xargs -n1 -P "$DEPLOY_JOBS" bash -c 'deploy_group "$1"' deploy-group; then
   echo "Fleet deployment complete."
 else
+  dump_failed_logs
   echo "FAILED: one or more deploys failed; see logs in $LOG_DIR." >&2
   exit 1
 fi

--- a/deploy/scripts/deploy-fleet.sh
+++ b/deploy/scripts/deploy-fleet.sh
@@ -92,9 +92,14 @@ echo "Deploying roles: $REQUESTED_ROLES"
 echo "Deploying up to $DEPLOY_JOBS node(s) concurrently. Set DEPLOY_JOBS=1 for serial deploys."
 # DEPLOY_FLEET_LOG_DIR pins per-host logs to a stable path so CI can upload
 # them as an artifact; ephemeral runners lose /tmp the moment the job ends.
+# A pinned dir can outlive a run (local use, non-ephemeral machines), so
+# clear generated state from prior runs: stale .failed markers would dump a
+# previous run's failures, and stale host-*.targets files are appended to,
+# which would double up deploy targets.
 if [ -n "${DEPLOY_FLEET_LOG_DIR:-}" ]; then
   LOG_DIR="$DEPLOY_FLEET_LOG_DIR"
   mkdir -p "$LOG_DIR"
+  rm -f "$LOG_DIR"/*.log "$LOG_DIR"/*.log.failed "$LOG_DIR"/host-*.targets
 else
   LOG_DIR="$(mktemp -d /tmp/deploy-fleet.XXXXXX)"
 fi
@@ -158,7 +163,7 @@ deploy_one() {
 # wrapped in a collapsible ::group:: and also appended to the job summary.
 DEPLOY_FAIL_LOG_LINES="${DEPLOY_FAIL_LOG_LINES:-200}"
 dump_failed_logs() {
-  local marker failed_log name
+  local marker failed_log name resume_token
   for marker in "$LOG_DIR"/*.log.failed; do
     [ -e "$marker" ] || continue
     failed_log="${marker%.failed}"
@@ -166,11 +171,16 @@ dump_failed_logs() {
     echo ""
     if [ -n "${GITHUB_ACTIONS:-}" ]; then
       echo "::group::FAILED $name — last $DEPLOY_FAIL_LOG_LINES log lines"
+      # Dumped content is remote host output; stop the runner from
+      # interpreting any ::-prefixed log lines as workflow commands.
+      resume_token="deploy-log-$$-$RANDOM"
+      echo "::stop-commands::$resume_token"
     else
       echo "===== FAILED $name — last $DEPLOY_FAIL_LOG_LINES log lines (full log: $failed_log) ====="
     fi
     tail -n "$DEPLOY_FAIL_LOG_LINES" "$failed_log"
     if [ -n "${GITHUB_ACTIONS:-}" ]; then
+      echo "::$resume_token::"
       echo "::endgroup::"
     fi
   done


### PR DESCRIPTION
## Problem

When a fleet deploy fails in CI, the job log only shows `FAILED: worker@<ip> (log: /tmp/deploy-fleet.XXXXXX/...)` — paths on an ephemeral runner that are gone the moment the job ends. Today's all-workers failure (run [27373140498](https://github.com/assembledhq/143/actions/runs/27373140498)) was the worker fingerprint gate firing after 8ac9d4972 changed `reconcile-worker-host.sh`, but the gate's actionable error message ("run DEPLOY_MODE=maintenance") was invisible.

## Changes

- **deploy-fleet.sh**: failed targets are marked with a `<log>.failed` sentinel; after the parallel fan-out completes, the parent prints the last `DEPLOY_FAIL_LOG_LINES` (default 200) lines of each failed host's log. Dumping from the parent prevents concurrent failures from interleaving. On GitHub Actions each dump is a collapsible `::group::` and is also appended to the job step summary, so the real error shows on the run's front page. Successful hosts' logs are not dumped.
- **deploy.yml**: the fleet step pins `DEPLOY_FLEET_LOG_DIR=/tmp/deploy-fleet-logs`, and a new `if: failure()` step uploads the directory as a `deploy-fleet-logs` artifact (14-day retention) so full logs survive the runner even beyond the tails.
- **deploy_config_test.go**: pins the new contract (log-dir override, dump function, workflow env + artifact step) and adds `TestDeployFleetPrintsFailedHostLogs`, which executes the real script with a failing fake `deploy.sh` and asserts the failed host's log content reaches stdout (wrapped in a `::group::`) and the step summary, while clean hosts' logs stay out of the failure output.

## Testing

- `go test ./deploy/` — all pass, including the two pre-existing executable fleet tests and the new failure-dump test.
- `bash -n deploy/scripts/deploy-fleet.sh`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
