### PR TITLE
Make preview proxying fast and let stopped session previews restart

### DIFF
--- a/internal/api/gateway/preview_gateway.go
+++ b/internal/api/gateway/preview_gateway.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"compress/flate"
 	"compress/gzip"
+	"context"
 	"crypto/hmac"
 	"crypto/sha256"
 	"encoding/base64"
@@ -43,10 +44,35 @@ type sessionCacheEntry struct {
 // sessionCache is a simple TTL cache for access session lookups.
 const sessionCacheTTL = 10 * time.Second
 
+// accessSessionTTL is the sliding lifetime of a preview access session. Each
+// extension pushes expires_at this far out. The initial (bootstrap-token)
+// expiry minted by the manager is intentionally shorter; the first proxied
+// request after exchange extends it to the full sliding window.
+const accessSessionTTL = 30 * time.Minute
+
 // expiryExtendThreshold controls how often we extend the DB session expiry.
 // We only extend when the remaining time is below this threshold, avoiding
 // a DB write on every single request.
-const expiryExtendThreshold = 2 * time.Minute
+const expiryExtendThreshold = 10 * time.Minute
+
+// runtimeCacheEntry caches the active preview runtime so an asset burst does
+// not issue a DB query per proxied request. Entries are evicted on upstream
+// proxy errors and runtime mismatches so a recycled preview re-resolves
+// promptly.
+type runtimeCacheEntry struct {
+	validUntil time.Time
+	runtime    *models.PreviewRuntime
+}
+
+// runtimeCacheTTL bounds how long a cached runtime is trusted. Kept short so
+// a recycle (new runtime epoch) is picked up within one TTL even if no
+// eviction signal fires.
+const runtimeCacheTTL = 5 * time.Second
+
+// accessRecordInterval throttles preview last-access writes. Idle-timeout
+// tracking only needs coarse granularity; without the throttle every proxied
+// asset request issued an UPDATE on preview_instances.
+const accessRecordInterval = 15 * time.Second
 
 // Gateway serves the preview origin (e.g., <preview-id>.preview.143.dev).
 // It validates preview access, proxies HTTP and WebSocket traffic, and
@@ -66,6 +92,20 @@ type Gateway struct {
 	// sessionCache avoids a DB round-trip on every proxied request.
 	sessionCacheMu sync.RWMutex
 	sessionCache   map[uuid.UUID]*sessionCacheEntry
+
+	// runtimeCache avoids resolving the active runtime per proxied request.
+	runtimeCacheMu sync.RWMutex
+	runtimeCache   map[uuid.UUID]*runtimeCacheEntry
+
+	// accessRecordedAt throttles last-access writes per preview.
+	accessRecordMu   sync.Mutex
+	accessRecordedAt map[uuid.UUID]time.Time
+
+	// proxyTransport is shared across proxied requests so upstream worker
+	// connections are kept alive and reused. http.DefaultTransport caps idle
+	// connections at 2 per host, which serializes the ~80-request asset burst
+	// of a dev-server page load.
+	proxyTransport http.RoundTripper
 }
 
 // GatewayConfig holds initialization options.
@@ -108,19 +148,76 @@ func (g *Gateway) putCachedSession(id uuid.UUID, entry *sessionCacheEntry) {
 	g.sessionCache[id] = entry
 }
 
+// cachedActiveRuntime resolves the active runtime for a preview through a
+// short TTL cache. The previewID alone is a safe cache key: it is bound to
+// the org by the HMAC-verified session cookie before this is called.
+func (g *Gateway) cachedActiveRuntime(ctx context.Context, orgID, previewID uuid.UUID) (*models.PreviewRuntime, error) {
+	now := time.Now()
+	g.runtimeCacheMu.RLock()
+	entry, ok := g.runtimeCache[previewID]
+	g.runtimeCacheMu.RUnlock()
+	if ok && now.Before(entry.validUntil) {
+		return entry.runtime, nil
+	}
+	runtime, err := g.store.GetActivePreviewRuntime(ctx, orgID, previewID)
+	if err != nil {
+		return nil, err
+	}
+	g.runtimeCacheMu.Lock()
+	if len(g.runtimeCache) > 4096 {
+		// Safety valve against unbounded growth across many short-lived
+		// previews; entries repopulate on the next request.
+		g.runtimeCache = make(map[uuid.UUID]*runtimeCacheEntry)
+	}
+	g.runtimeCache[previewID] = &runtimeCacheEntry{validUntil: now.Add(runtimeCacheTTL), runtime: runtime}
+	g.runtimeCacheMu.Unlock()
+	return runtime, nil
+}
+
+// evictCachedRuntime drops a cached runtime so the next request re-resolves.
+func (g *Gateway) evictCachedRuntime(previewID uuid.UUID) {
+	g.runtimeCacheMu.Lock()
+	defer g.runtimeCacheMu.Unlock()
+	delete(g.runtimeCache, previewID)
+}
+
+// recordAccessThrottled records preview activity for idle-timeout tracking at
+// most once per accessRecordInterval per preview.
+func (g *Gateway) recordAccessThrottled(ctx context.Context, orgID, previewID uuid.UUID) {
+	now := time.Now()
+	g.accessRecordMu.Lock()
+	last, ok := g.accessRecordedAt[previewID]
+	if ok && now.Sub(last) < accessRecordInterval {
+		g.accessRecordMu.Unlock()
+		return
+	}
+	if len(g.accessRecordedAt) > 4096 {
+		g.accessRecordedAt = make(map[uuid.UUID]time.Time)
+	}
+	g.accessRecordedAt[previewID] = now
+	g.accessRecordMu.Unlock()
+
+	if err := g.manager.RecordAccess(ctx, orgID, previewID); err != nil {
+		g.logger.Warn().Err(err).Str("preview_id", previewID.String()).Msg("failed to record access")
+	}
+}
+
 // NewGateway creates a new preview gateway.
 func NewGateway(cfg GatewayConfig) *Gateway {
 	return &Gateway{
-		store:        cfg.Store,
-		manager:      cfg.Manager,
-		workerSelect: cfg.WorkerSelector,
-		hmrWatcher:   cfg.HMRWatcher,
-		logger:       cfg.Logger,
-		appOrigin:    cfg.AppOrigin,
-		cookieSecret: cfg.CookieSecret,
-		tokenSecret:  cfg.PreviewTokenSecret,
-		secureCookie: strings.HasPrefix(cfg.PreviewOriginTemplate, "https://"),
-		sessionCache: make(map[uuid.UUID]*sessionCacheEntry),
+		store:            cfg.Store,
+		manager:          cfg.Manager,
+		workerSelect:     cfg.WorkerSelector,
+		hmrWatcher:       cfg.HMRWatcher,
+		logger:           cfg.Logger,
+		appOrigin:        cfg.AppOrigin,
+		cookieSecret:     cfg.CookieSecret,
+		tokenSecret:      cfg.PreviewTokenSecret,
+		secureCookie:     strings.HasPrefix(cfg.PreviewOriginTemplate, "https://"),
+		sessionCache:     make(map[uuid.UUID]*sessionCacheEntry),
+		runtimeCache:     make(map[uuid.UUID]*runtimeCacheEntry),
+		accessRecordedAt: make(map[uuid.UUID]time.Time),
+		proxyTransport:   newGatewayProxyTransport(),
 		cspHeader: strings.Join([]string{
 			"default-src 'self' blob: data:",
 			"script-src 'self' 'unsafe-inline' 'unsafe-eval'",
@@ -132,9 +229,19 @@ func NewGateway(cfg GatewayConfig) *Gateway {
 			"object-src 'none'",
 			"base-uri 'none'",
 			"frame-ancestors " + cfg.AppOrigin,
-			"worker-src 'none'",
+			"worker-src 'self' blob:",
 		}, "; "),
 	}
+}
+
+// newGatewayProxyTransport builds the shared upstream transport for worker
+// proxying with a per-host idle pool sized for dev-server asset bursts.
+func newGatewayProxyTransport() *http.Transport {
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	transport.MaxIdleConns = 256
+	transport.MaxIdleConnsPerHost = 128
+	transport.IdleConnTimeout = 90 * time.Second
+	return transport
 }
 
 // ServeHTTP implements http.Handler. Each request is routed based on the Host
@@ -299,6 +406,10 @@ func (g *Gateway) handleProxy(w http.ResponseWriter, r *http.Request, previewID 
 	// Read and validate the session cookie.
 	cookie, err := r.Cookie(g.cookieName())
 	if err != nil {
+		if !isNavigationRequest(r) {
+			writePreviewSessionExpired(w)
+			return
+		}
 		g.servePreviewControlOverlay(w, r, previewID)
 		return
 	}
@@ -353,7 +464,7 @@ func (g *Gateway) handleProxy(w http.ResponseWriter, r *http.Request, previewID 
 	// Only extend the DB session expiry when close to expiration, avoiding
 	// a DB write on every single request.
 	if time.Until(cached.expiresAt) < expiryExtendThreshold {
-		newExpiry := now.Add(5 * time.Minute)
+		newExpiry := now.Add(accessSessionTTL)
 		if err := g.store.ExtendAccessSessionExpiry(r.Context(), orgID, accessSessionID, newExpiry); err != nil {
 			if errors.Is(err, db.ErrSessionRevoked) {
 				// Session was revoked between cache fill and extend — evict
@@ -379,17 +490,13 @@ func (g *Gateway) handleProxy(w http.ResponseWriter, r *http.Request, previewID 
 	// URL does not overwrite last_path (which is used for navigation restore).
 	if r.URL.Path == previewHeartbeatPath {
 		// Still record access for idle timeout tracking.
-		if err := g.manager.RecordAccess(r.Context(), orgID, runtimePreviewID); err != nil {
-			g.logger.Warn().Err(err).Str("preview_id", runtimePreviewID.String()).Msg("failed to record access")
-		}
+		g.recordAccessThrottled(r.Context(), orgID, runtimePreviewID)
 		w.WriteHeader(http.StatusNoContent)
 		return
 	}
 
 	// Record activity for idle timeout tracking.
-	if err := g.manager.RecordAccess(r.Context(), orgID, runtimePreviewID); err != nil {
-		g.logger.Warn().Err(err).Str("preview_id", runtimePreviewID.String()).Msg("failed to record access")
-	}
+	g.recordAccessThrottled(r.Context(), orgID, runtimePreviewID)
 	if shouldRecordPreviewLastPath(r) {
 		if err := g.manager.RecordLastPath(r.Context(), orgID, runtimePreviewID, r.URL.Path); err != nil {
 			g.logger.Warn().Err(err).Str("preview_id", runtimePreviewID.String()).Msg("failed to record last path")
@@ -406,7 +513,43 @@ func (g *Gateway) handleProxy(w http.ResponseWriter, r *http.Request, previewID 
 // auth error.
 func (g *Gateway) serveStaleSessionOverlay(w http.ResponseWriter, r *http.Request, previewID uuid.UUID) {
 	g.clearPreviewSessionCookie(w)
+	if !isNavigationRequest(r) {
+		// Fetch/XHR and asset loads can neither render the overlay nor follow
+		// a cross-origin redirect to it; HTML-instead-of-JSON silently wedges
+		// SPAs. Fail loudly so the app (or its error handling) reloads.
+		writePreviewSessionExpired(w)
+		return
+	}
 	g.servePreviewControlOverlay(w, r, previewID)
+}
+
+// isNavigationRequest reports whether a request is a browser navigation
+// (top-level document or frame) that can meaningfully receive the HTML
+// control overlay or follow a redirect to the launcher.
+func isNavigationRequest(r *http.Request) bool {
+	switch r.Header.Get("Sec-Fetch-Dest") {
+	case "document", "iframe", "frame":
+		return true
+	case "":
+		// Non-browser clients and very old browsers: sniff the Accept header.
+		return acceptsHTMLDocument(r.Header.Get("Accept"))
+	default:
+		return false
+	}
+}
+
+// writePreviewSessionExpired responds with a JSON 401 for non-navigation
+// requests whose preview access session is missing or no longer honorable.
+func writePreviewSessionExpired(w http.ResponseWriter) {
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Cache-Control", "no-store")
+	w.WriteHeader(http.StatusUnauthorized)
+	_ = json.NewEncoder(w).Encode(models.ErrorResponse{
+		Error: models.ErrorDetail{
+			Code:    "PREVIEW_SESSION_EXPIRED",
+			Message: "preview session is no longer valid; reload the page to reconnect",
+		},
+	})
 }
 
 func (g *Gateway) clearPreviewSessionCookie(w http.ResponseWriter) {
@@ -807,8 +950,16 @@ func acceptsHTMLDocument(accept string) bool {
 
 func (g *Gateway) proxyToWorker(w http.ResponseWriter, r *http.Request, orgID, previewID uuid.UUID) {
 	originalReq := r
-	runtime, err := g.store.GetActivePreviewRuntime(r.Context(), orgID, previewID)
+	runtime, err := g.cachedActiveRuntime(r.Context(), orgID, previewID)
 	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) && isNavigationRequest(r) {
+			// The session cookie outlives the preview's idle timeout: a
+			// returning visitor with a valid session can land on a stopped
+			// preview. Serve the control overlay (restart/relaunch) instead
+			// of a raw runtime-unavailable error.
+			g.servePreviewControlOverlay(w, r, previewID)
+			return
+		}
 		addPreviewProxyLogFields(g.logger.Warn().Err(err), r, orgID, previewID, nil, "").
 			Msg("failed to resolve active preview runtime")
 		writeRuntimeUnavailable(w)
@@ -839,6 +990,7 @@ func (g *Gateway) proxyToWorker(w http.ResponseWriter, r *http.Request, orgID, p
 	}
 
 	proxy := &httputil.ReverseProxy{
+		Transport: g.proxyTransport,
 		Director: func(req *http.Request) {
 			req.URL.Scheme = targetURL.Scheme
 			req.URL.Host = targetURL.Host
@@ -850,6 +1002,9 @@ func (g *Gateway) proxyToWorker(w http.ResponseWriter, r *http.Request, orgID, p
 		},
 		ModifyResponse: func(resp *http.Response) error {
 			if translateWorkerRuntimeMismatch(resp) {
+				// The worker no longer recognizes this runtime epoch; drop
+				// the cached runtime so the next request re-resolves.
+				g.evictCachedRuntime(previewID)
 				return nil
 			}
 
@@ -872,6 +1027,7 @@ func (g *Gateway) proxyToWorker(w http.ResponseWriter, r *http.Request, orgID, p
 			return nil
 		},
 		ErrorHandler: func(w http.ResponseWriter, _ *http.Request, err error) {
+			g.evictCachedRuntime(previewID)
 			addPreviewProxyLogFields(g.logger.Warn().Err(err), originalReq, orgID, previewID, runtime, upstreamPath).
 				Msg("proxy error")
 			http.Error(w, "preview unavailable", http.StatusBadGateway)

--- a/internal/api/gateway/preview_gateway_test.go
+++ b/internal/api/gateway/preview_gateway_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"compress/flate"
 	"compress/gzip"
+	"context"
 	"encoding/json"
 	"io"
 	"net"
@@ -658,6 +659,7 @@ func TestGateway_ServeHTTP_Proxy_NoCookie(t *testing.T) {
 	gw := NewGateway(GatewayConfig{AppOrigin: "https://app.143.dev"})
 	previewID := uuid.New()
 	req := httptest.NewRequest(http.MethodGet, "/some-page", nil)
+	req.Header.Set("Sec-Fetch-Dest", "document")
 	req.Host = previewID.String() + ".preview.143.dev"
 	w := httptest.NewRecorder()
 
@@ -697,6 +699,7 @@ func TestGateway_ServeHTTP_Proxy_NoCookieStoppedTarget(t *testing.T) {
 		AppOrigin: "https://app.143.dev",
 	})
 	req := httptest.NewRequest(http.MethodGet, "/some-page", nil)
+	req.Header.Set("Sec-Fetch-Dest", "document")
 	req.Host = targetID.String() + ".preview.143.dev"
 	w := httptest.NewRecorder()
 
@@ -818,6 +821,7 @@ func TestGateway_ServeHTTP_Proxy_NoCookieActiveTargetRedirectsToLaunch(t *testin
 		AppOrigin: "https://app.143.dev",
 	})
 	req := httptest.NewRequest(http.MethodGet, "/some-page", nil)
+	req.Header.Set("Sec-Fetch-Dest", "document")
 	req.Host = targetID.String() + ".preview.143.dev"
 	w := httptest.NewRecorder()
 
@@ -875,6 +879,7 @@ func TestGateway_ServeHTTP_Proxy_StaleStoppedTargetCookieShowsRestart(t *testing
 		CookieSecret: secret,
 	})
 	req := httptest.NewRequest(http.MethodGet, "/some-page", nil)
+	req.Header.Set("Sec-Fetch-Dest", "document")
 	req.Host = targetID.String() + ".preview.143.dev"
 	req.AddCookie(&http.Cookie{Name: "preview_session", Value: encodeCookieValue(secret, orgID, targetID, accessSessionID)})
 	w := httptest.NewRecorder()
@@ -929,6 +934,7 @@ func TestGateway_ServeHTTP_Proxy_RevokedTargetCookieRedirectsToLaunch(t *testing
 		CookieSecret: secret,
 	})
 	req := httptest.NewRequest(http.MethodGet, "/some-page", nil)
+	req.Header.Set("Sec-Fetch-Dest", "document")
 	req.Host = targetID.String() + ".preview.143.dev"
 	req.AddCookie(&http.Cookie{Name: "preview_session", Value: encodeCookieValue(secret, orgID, targetID, accessSessionID)})
 	w := httptest.NewRecorder()
@@ -1022,6 +1028,7 @@ func TestGateway_ServeHTTP_Proxy_RechecksRevokedCachedSession(t *testing.T) {
 		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
 
 	firstReq := httptest.NewRequest(http.MethodGet, "/__143_heartbeat", nil)
+	firstReq.Header.Set("Sec-Fetch-Dest", "document")
 	firstReq.Host = previewID.String() + ".preview.143.dev"
 	firstReq.AddCookie(&http.Cookie{Name: "preview_session", Value: cookieVal})
 	firstResp := httptest.NewRecorder()
@@ -1047,6 +1054,7 @@ func TestGateway_ServeHTTP_Proxy_RechecksRevokedCachedSession(t *testing.T) {
 		)
 
 	secondReq := httptest.NewRequest(http.MethodGet, "/__143_heartbeat", nil)
+	secondReq.Header.Set("Sec-Fetch-Dest", "document")
 	secondReq.Host = previewID.String() + ".preview.143.dev"
 	secondReq.AddCookie(&http.Cookie{Name: "preview_session", Value: cookieVal})
 	secondResp := httptest.NewRecorder()
@@ -1098,6 +1106,7 @@ func TestGateway_ServeHTTP_Proxy_ExpiredSameInstanceCookieShowsRestart(t *testin
 		CookieSecret: secret,
 	})
 	req := httptest.NewRequest(http.MethodGet, "/some-page", nil)
+	req.Header.Set("Sec-Fetch-Dest", "document")
 	req.Host = previewID.String() + ".preview.143.dev"
 	req.AddCookie(&http.Cookie{Name: "preview_session", Value: encodeCookieValue(secret, orgID, previewID, accessSessionID)})
 	w := httptest.NewRecorder()
@@ -1150,6 +1159,7 @@ func TestGateway_ServeHTTP_Proxy_ExpiredSameInstanceCookieActivePreviewRedirects
 		CookieSecret: secret,
 	})
 	req := httptest.NewRequest(http.MethodGet, "/some-page", nil)
+	req.Header.Set("Sec-Fetch-Dest", "document")
 	req.Host = previewID.String() + ".preview.143.dev"
 	req.AddCookie(&http.Cookie{Name: "preview_session", Value: encodeCookieValue(secret, orgID, previewID, accessSessionID)})
 	w := httptest.NewRecorder()
@@ -1536,5 +1546,282 @@ func TestGateway_ProxyToWorker_InvalidRuntimeEndpoint(t *testing.T) {
 
 	gw.proxyToWorker(rr, req, orgID, previewID)
 	require.Equal(t, http.StatusServiceUnavailable, rr.Code, "proxyToWorker should return unavailable when the runtime endpoint is invalid")
+	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
+}
+
+func TestGateway_ServeHTTP_Proxy_NoCookieFetchGets401JSON(t *testing.T) {
+	t.Parallel()
+
+	gw := NewGateway(GatewayConfig{AppOrigin: "https://app.143.dev"})
+	previewID := uuid.New()
+	req := httptest.NewRequest(http.MethodGet, "/api/data", nil)
+	req.Host = previewID.String() + ".preview.143.dev"
+	req.Header.Set("Sec-Fetch-Dest", "empty")
+	w := httptest.NewRecorder()
+
+	gw.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusUnauthorized, w.Code, "fetch requests without a preview session should get a JSON 401 instead of overlay HTML")
+	require.Contains(t, w.Header().Get("Content-Type"), "application/json", "non-navigation auth failures should be JSON")
+	require.Contains(t, w.Body.String(), "PREVIEW_SESSION_EXPIRED", "non-navigation auth failures should carry a machine-readable code")
+}
+
+func TestGateway_ServeHTTP_Proxy_ExpiredCookieFetchGets401JSON(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "pgxmock pool should be created")
+	defer mock.Close()
+
+	now := time.Now().UTC()
+	previewID := uuid.New()
+	orgID := uuid.New()
+	userID := uuid.New()
+	accessSessionID := uuid.New()
+	secret := []byte("test-secret")
+
+	mock.ExpectQuery("SELECT .+ FROM preview_access_sessions").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(
+			pgxmock.NewRows([]string{
+				"id", "org_id", "user_id", "preview_instance_id",
+				"session_token_hash", "issued_at", "expires_at", "revoked_at", "last_accessed_at", "created_at",
+			}).AddRow(accessSessionID, orgID, userID, previewID, "hash", now.Add(-time.Hour), now.Add(-time.Minute), nil, now.Add(-time.Hour), now.Add(-time.Hour)),
+		)
+
+	gw := NewGateway(GatewayConfig{
+		Store:        db.NewPreviewStore(mock),
+		Logger:       zerolog.Nop(),
+		AppOrigin:    "https://app.143.dev",
+		CookieSecret: secret,
+	})
+	req := httptest.NewRequest(http.MethodGet, "/api/data", nil)
+	req.Header.Set("Sec-Fetch-Dest", "empty")
+	req.Host = previewID.String() + ".preview.143.dev"
+	req.AddCookie(&http.Cookie{Name: "preview_session", Value: encodeCookieValue(secret, orgID, previewID, accessSessionID)})
+	w := httptest.NewRecorder()
+
+	gw.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusUnauthorized, w.Code, "expired sessions on fetch requests should get a JSON 401, not overlay HTML")
+	require.Contains(t, w.Header().Get("Content-Type"), "application/json", "stale-session fetch responses should be JSON")
+	require.Contains(t, w.Body.String(), "PREVIEW_SESSION_EXPIRED", "stale-session fetch responses should carry a machine-readable code")
+	require.Contains(t, w.Header().Values("Set-Cookie")[0], "preview_session=;", "expired preview cookie should still be cleared")
+	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
+}
+
+func TestIsNavigationRequest(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name      string
+		fetchDest string
+		accept    string
+		want      bool
+	}{
+		{"top-level document", "document", "", true},
+		{"iframe", "iframe", "", true},
+		{"fetch", "empty", "application/json", false},
+		{"script", "script", "", false},
+		{"legacy browser navigation", "", "text/html,application/xhtml+xml", true},
+		{"legacy client fetch", "", "application/json", false},
+		{"no headers at all", "", "", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			req := httptest.NewRequest(http.MethodGet, "/x", nil)
+			if tc.fetchDest != "" {
+				req.Header.Set("Sec-Fetch-Dest", tc.fetchDest)
+			}
+			if tc.accept != "" {
+				req.Header.Set("Accept", tc.accept)
+			}
+			require.Equal(t, tc.want, isNavigationRequest(req), "isNavigationRequest should classify %q/%q", tc.fetchDest, tc.accept)
+		})
+	}
+}
+
+func TestGateway_ProxyToWorker_CachesRuntimeAcrossRequests(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "pgxmock pool should be created")
+	defer mock.Close()
+
+	orgID := uuid.New()
+	previewID := uuid.New()
+	now := time.Now().UTC()
+
+	workerServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, writeErr := io.WriteString(w, "ok")
+		require.NoError(t, writeErr, "worker test server should write a response body")
+	}))
+	defer workerServer.Close()
+
+	store := db.NewPreviewStore(mock)
+	gw := NewGateway(GatewayConfig{
+		Store:              store,
+		Logger:             zerolog.Nop(),
+		AppOrigin:          "https://app.143.dev",
+		PreviewTokenSecret: "preview-secret",
+	})
+
+	// Exactly one runtime lookup is expected for two proxied requests: the
+	// second request must be served from the runtime cache.
+	mock.ExpectQuery("SELECT .+ FROM preview_runtimes").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(
+			pgxmock.NewRows([]string{
+				"id", "org_id", "preview_instance_id", "runtime_epoch", "worker_node_id",
+				"endpoint_url", "preview_handle", "primary_port", "status", "lease_expires_at",
+				"last_heartbeat_at", "drain_requested_at", "stopped_at", "error", "unavailable_reason", "created_at", "updated_at",
+			}).AddRow(
+				uuid.New(), orgID, previewID, 1, "worker-1",
+				workerServer.URL, "handle-1", 3000, string(models.PreviewRuntimeStatusReady), now.Add(time.Minute),
+				now, nil, nil, "", "", now, now,
+			),
+		)
+
+	for i := 0; i < 2; i++ {
+		req := httptest.NewRequest(http.MethodGet, "/assets/app.js", nil)
+		rr := httptest.NewRecorder()
+		gw.proxyToWorker(rr, req, orgID, previewID)
+		require.Equal(t, http.StatusOK, rr.Code, "proxied request %d should succeed", i+1)
+	}
+	require.NoError(t, mock.ExpectationsWereMet(), "second request should hit the runtime cache instead of the database")
+}
+
+func TestGateway_ProxyToWorker_EvictsRuntimeCacheOnProxyError(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "pgxmock pool should be created")
+	defer mock.Close()
+
+	orgID := uuid.New()
+	previewID := uuid.New()
+	now := time.Now().UTC()
+
+	// A server that is immediately closed: every proxy attempt fails.
+	workerServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	workerServer.Close()
+
+	runtimeRows := func() *pgxmock.Rows {
+		return pgxmock.NewRows([]string{
+			"id", "org_id", "preview_instance_id", "runtime_epoch", "worker_node_id",
+			"endpoint_url", "preview_handle", "primary_port", "status", "lease_expires_at",
+			"last_heartbeat_at", "drain_requested_at", "stopped_at", "error", "unavailable_reason", "created_at", "updated_at",
+		}).AddRow(
+			uuid.New(), orgID, previewID, 1, "worker-1",
+			workerServer.URL, "handle-1", 3000, string(models.PreviewRuntimeStatusReady), now.Add(time.Minute),
+			now, nil, nil, "", "", now, now,
+		)
+	}
+
+	store := db.NewPreviewStore(mock)
+	gw := NewGateway(GatewayConfig{
+		Store:              store,
+		Logger:             zerolog.Nop(),
+		AppOrigin:          "https://app.143.dev",
+		PreviewTokenSecret: "preview-secret",
+	})
+
+	// Two runtime lookups expected: each failed proxy evicts the cache entry,
+	// so the follow-up request re-resolves instead of reusing a dead runtime.
+	mock.ExpectQuery("SELECT .+ FROM preview_runtimes").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(runtimeRows())
+	mock.ExpectQuery("SELECT .+ FROM preview_runtimes").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(runtimeRows())
+
+	for i := 0; i < 2; i++ {
+		req := httptest.NewRequest(http.MethodGet, "/assets/app.js", nil)
+		rr := httptest.NewRecorder()
+		gw.proxyToWorker(rr, req, orgID, previewID)
+		require.Equal(t, http.StatusBadGateway, rr.Code, "proxied request %d should fail against the closed worker", i+1)
+	}
+	require.NoError(t, mock.ExpectationsWereMet(), "proxy errors should evict the runtime cache so the next request re-resolves")
+}
+
+func TestGateway_RecordAccessThrottled(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "pgxmock pool should be created")
+	defer mock.Close()
+
+	orgID := uuid.New()
+	previewID := uuid.New()
+
+	store := db.NewPreviewStore(mock)
+	manager := preview.NewManager(preview.ManagerConfig{Store: store, Logger: zerolog.Nop()})
+	gw := NewGateway(GatewayConfig{Store: store, Manager: manager, Logger: zerolog.Nop()})
+
+	mock.ExpectExec("UPDATE preview_instances SET last_accessed_at").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
+
+	gw.recordAccessThrottled(context.Background(), orgID, previewID)
+	gw.accessRecordMu.Lock()
+	first := gw.accessRecordedAt[previewID]
+	gw.accessRecordMu.Unlock()
+	require.False(t, first.IsZero(), "first call should stamp the throttle map")
+
+	gw.recordAccessThrottled(context.Background(), orgID, previewID)
+	gw.accessRecordMu.Lock()
+	second := gw.accessRecordedAt[previewID]
+	gw.accessRecordMu.Unlock()
+	require.Equal(t, first, second, "a second call within the interval should be throttled and not re-stamp")
+	require.NoError(t, mock.ExpectationsWereMet(), "only one access UPDATE should reach the database")
+}
+
+func TestGateway_ProxyToWorker_NavigationToStoppedPreviewShowsOverlay(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "pgxmock pool should be created")
+	defer mock.Close()
+
+	now := time.Now().UTC()
+	stoppedAt := now.Add(-20 * time.Minute)
+	orgID := uuid.New()
+	userID := uuid.New()
+	sessionID := uuid.New()
+	previewID := uuid.New()
+
+	// No active runtime rows: the preview idled out while the visitor's
+	// access session was still valid.
+	mock.ExpectQuery("SELECT .+ FROM preview_runtimes").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(pgxmock.NewRows([]string{
+			"id", "org_id", "preview_instance_id", "runtime_epoch", "worker_node_id",
+			"endpoint_url", "preview_handle", "primary_port", "status", "lease_expires_at",
+			"last_heartbeat_at", "drain_requested_at", "stopped_at", "error", "unavailable_reason", "created_at", "updated_at",
+		}))
+	// Overlay state lookup.
+	mock.ExpectQuery("SELECT .+ FROM preview_instances").
+		WithArgs(pgxmock.AnyArg()).
+		WillReturnRows(
+			pgxmock.NewRows(previewGatewayInstanceColumns).AddRow(
+				previewGatewayInstanceRow(previewID, sessionID, nil, orgID, userID, models.PreviewStatusStopped, now, &stoppedAt)...,
+			),
+		)
+
+	gw := NewGateway(GatewayConfig{
+		Store:     db.NewPreviewStore(mock),
+		Logger:    zerolog.Nop(),
+		AppOrigin: "https://app.143.dev",
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/some-page", nil)
+	req.Header.Set("Sec-Fetch-Dest", "document")
+	rr := httptest.NewRecorder()
+
+	gw.proxyToWorker(rr, req, orgID, previewID)
+
+	require.Equal(t, http.StatusOK, rr.Code, "navigations to a stopped preview with a valid session should get the control overlay")
+	require.Contains(t, rr.Body.String(), "Restart preview", "the overlay should expose the restart action")
 	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
 }

--- a/internal/api/handlers/branch_previews.go
+++ b/internal/api/handlers/branch_previews.go
@@ -61,6 +61,16 @@ type BranchPreviewHandler struct {
 	// same immutable SHA so a burst of requests for an uncached SHA results in
 	// exactly one GitHub API call rather than N.
 	configFetchGroup singleflight.Group
+	// sessionRestarter serves restart/start-latest for previews without a
+	// branch target (session previews), which the branch-target flow rejects.
+	sessionRestarter sessionPreviewRestarter
+}
+
+// sessionPreviewRestarter restarts the preview attached to a session. It is
+// implemented by PreviewHandler and wired in by the router so the generic
+// preview restart endpoints can serve session previews (no branch target).
+type sessionPreviewRestarter interface {
+	RestartSessionPreview(ctx context.Context, orgID, userID, sessionID uuid.UUID, body startPreviewRequest) (*models.PreviewInstance, string, *previewHTTPError)
 }
 
 func NewBranchPreviewHandler(previews *db.PreviewStore, repos *db.RepositoryStore, github branchPreviewGitHub, manager *preview.Manager, baseURL, previewOriginTemplate string) *BranchPreviewHandler {
@@ -77,6 +87,10 @@ func NewBranchPreviewHandler(previews *db.PreviewStore, repos *db.RepositoryStor
 func (h *BranchPreviewHandler) SetWorkerRuntime(jobs *db.JobStore, selector *preview.WorkerSelector) {
 	h.jobs = jobs
 	h.selector = selector
+}
+
+func (h *BranchPreviewHandler) SetSessionPreviewRestarter(restarter sessionPreviewRestarter) {
+	h.sessionRestarter = restarter
 }
 
 func (h *BranchPreviewHandler) SetPreviewCachePrewarm(enabled bool, priority int) {
@@ -909,20 +923,22 @@ func (h *BranchPreviewHandler) Get(w http.ResponseWriter, r *http.Request) {
 		writeError(w, r, http.StatusInternalServerError, "PREVIEW_LOOKUP_FAILED", "failed to load preview", err)
 		return
 	}
-	resp := branchPreviewResponse{
-		TargetID:     previewTargetIDValue(instance.PreviewTargetID),
-		PreviewID:    &instance.ID,
-		Status:       string(instance.Status),
-		CurrentPhase: instance.CurrentPhase,
-		StableURL:    h.stableURL(instance.ID.String()),
-		ExpiresAt:    &instance.ExpiresAt,
-		StoppedAt:    instance.StoppedAt,
+	if instance.PreviewTargetID == nil && instance.SessionID != uuid.Nil && !instance.Status.IsActive() {
+		// Restarting a stopped session preview starts a fresh instance under
+		// the same session. Follow the session's current active preview so
+		// clients polling the old instance ID converge on the replacement.
+		current, currentErr := h.previews.GetActivePreviewForSession(r.Context(), orgID, instance.SessionID)
+		if currentErr != nil && !errors.Is(currentErr, pgx.ErrNoRows) {
+			writeError(w, r, http.StatusInternalServerError, "PREVIEW_LOOKUP_FAILED", "failed to load preview", currentErr)
+			return
+		}
+		if currentErr == nil && current != nil {
+			instance = current
+		}
 	}
+	resp := h.previewInstanceResponse(instance)
 	if instance.PreviewTargetID != nil {
 		resp.StableURL = h.stableURL(instance.PreviewTargetID.String())
-	}
-	if url := h.previewURL(instance.ID); url != "" {
-		resp.PreviewURL = &url
 	}
 	if instance.PreviewTargetID != nil {
 		target, targetErr := h.previews.GetPreviewTarget(r.Context(), orgID, *instance.PreviewTargetID)
@@ -1134,6 +1150,10 @@ func (h *BranchPreviewHandler) Restart(w http.ResponseWriter, r *http.Request) {
 	if !ok {
 		return
 	}
+	if target == nil {
+		h.restartSessionPreviewInstance(w, r, orgID, userID, active)
+		return
+	}
 	if !previewTokenAllows(r.Context(), "previews:create", target.RepositoryID) {
 		writeError(w, r, http.StatusForbidden, "PREVIEW_TOKEN_FORBIDDEN", "preview API token is not scoped to restart this preview")
 		return
@@ -1167,8 +1187,12 @@ func (h *BranchPreviewHandler) StartLatest(w http.ResponseWriter, r *http.Reques
 		writeError(w, r, http.StatusUnauthorized, "UNAUTHORIZED", "authentication required")
 		return
 	}
-	target, repo, _, ok := h.resolveTargetRepoAndActive(w, r, orgID)
+	target, repo, active, ok := h.resolveTargetRepoAndActive(w, r, orgID)
 	if !ok {
+		return
+	}
+	if target == nil {
+		h.restartSessionPreviewInstance(w, r, orgID, userID, active)
 		return
 	}
 	if !previewTokenAllows(r.Context(), "previews:create", target.RepositoryID) {
@@ -1289,6 +1313,62 @@ func (h *BranchPreviewHandler) MintBootstrapToken(w http.ResponseWriter, r *http
 	}})
 }
 
+// previewInstanceResponse builds the instance-derived fields of a preview
+// response. Callers with a branch target layer the target fields (repository,
+// branch, stable URL slug) on top; for session previews this is the complete
+// response.
+func (h *BranchPreviewHandler) previewInstanceResponse(instance *models.PreviewInstance) branchPreviewResponse {
+	resp := branchPreviewResponse{
+		TargetID:     previewTargetIDValue(instance.PreviewTargetID),
+		PreviewID:    &instance.ID,
+		Status:       string(instance.Status),
+		Error:        instance.Error,
+		CurrentPhase: instance.CurrentPhase,
+		StableURL:    h.stableURL(instance.ID.String()),
+		ExpiresAt:    &instance.ExpiresAt,
+		StoppedAt:    instance.StoppedAt,
+	}
+	if url := h.previewURL(instance.ID); url != "" {
+		resp.PreviewURL = &url
+	}
+	return resp
+}
+
+// restartSessionPreviewInstance handles restart/start-latest for a preview
+// instance that is not attached to a branch target (a session preview): it
+// restarts the session's preview — starting a fresh instance when the old one
+// is stopped — and responds with the resulting instance so pollers can follow
+// its ID.
+func (h *BranchPreviewHandler) restartSessionPreviewInstance(w http.ResponseWriter, r *http.Request, orgID, userID uuid.UUID, instance *models.PreviewInstance) {
+	// Preview API tokens are scoped to branch previews; do not let them drive
+	// session restarts.
+	if middleware.PreviewAPITokenFromContext(r.Context()) != nil {
+		writeError(w, r, http.StatusForbidden, "PREVIEW_TOKEN_FORBIDDEN", "preview API tokens cannot restart session previews")
+		return
+	}
+	if h.sessionRestarter == nil || instance.SessionID == uuid.Nil {
+		writeError(w, r, http.StatusConflict, "PREVIEW_HAS_NO_TARGET", "preview is not attached to a branch target")
+		return
+	}
+	// Starting a preview hydrates a sandbox and waits for readiness (same
+	// WriteTimeout-overrun risk as the session-scoped restart endpoint).
+	clearWriteDeadline(w, r)
+	restarted, _, restartErr := h.sessionRestarter.RestartSessionPreview(r.Context(), orgID, userID, instance.SessionID, startPreviewRequest{})
+	if restartErr != nil {
+		writePreviewHTTPError(w, r, restartErr)
+		return
+	}
+	resp := h.previewInstanceResponse(restarted)
+	h.decoratePreviewResponse(r.Context(), orgID, &resp)
+	writeJSON(w, http.StatusOK, models.SingleResponse[branchPreviewResponse]{Data: resp})
+}
+
+// resolveTargetRepoAndActive resolves the {preview_id} route param — an
+// instance ID or a stable target ID — to its branch target, repository, and
+// active instance, writing the error response itself when resolution fails.
+// Special case: for a session preview (an instance with no branch target) it
+// returns ok=true with a nil target and the instance; callers must route that
+// to the session restart flow instead of dereferencing the target.
 func (h *BranchPreviewHandler) resolveTargetRepoAndActive(w http.ResponseWriter, r *http.Request, orgID uuid.UUID) (*models.PreviewTarget, models.Repository, *models.PreviewInstance, bool) {
 	id, err := uuid.Parse(chi.URLParam(r, "preview_id"))
 	if err != nil {
@@ -1301,8 +1381,9 @@ func (h *BranchPreviewHandler) resolveTargetRepoAndActive(w http.ResponseWriter,
 	if instanceErr == nil {
 		active = instance
 		if instance.PreviewTargetID == nil {
-			writeError(w, r, http.StatusConflict, "PREVIEW_HAS_NO_TARGET", "preview is not attached to a branch target")
-			return nil, models.Repository{}, nil, false
+			// Session preview (no branch target): hand the instance back with
+			// a nil target so the caller can route to the session restart flow.
+			return nil, models.Repository{}, instance, true
 		}
 		target, err = h.previews.GetPreviewTarget(r.Context(), orgID, *instance.PreviewTargetID)
 	} else if errors.Is(instanceErr, pgx.ErrNoRows) {

--- a/internal/api/handlers/branch_previews_test.go
+++ b/internal/api/handlers/branch_previews_test.go
@@ -1423,3 +1423,252 @@ func TestBranchPreviewExpiresAt_ExactMaximumPassesThrough(t *testing.T) {
 	require.False(t, got.Before(lo), "exact maximum TTL should pass through (lower bound)")
 	require.False(t, got.After(hi), "exact maximum TTL should pass through (upper bound)")
 }
+
+type fakeSessionPreviewRestarter struct {
+	instance   *models.PreviewInstance
+	action     string
+	err        *previewHTTPError
+	gotOrg     uuid.UUID
+	gotUser    uuid.UUID
+	gotSession uuid.UUID
+	calls      int
+}
+
+func (f *fakeSessionPreviewRestarter) RestartSessionPreview(_ context.Context, orgID, userID, sessionID uuid.UUID, _ startPreviewRequest) (*models.PreviewInstance, string, *previewHTTPError) {
+	f.calls++
+	f.gotOrg, f.gotUser, f.gotSession = orgID, userID, sessionID
+	if f.err != nil {
+		return nil, "", f.err
+	}
+	return f.instance, f.action, nil
+}
+
+func sessionPreviewInstanceRow(previewID, sessionID, orgID, userID uuid.UUID, status models.PreviewStatus, now time.Time, stoppedAt *time.Time) []any {
+	return []any{
+		previewID, sessionID, (*uuid.UUID)(nil), orgID, userID, "", "", status,
+		"", "", "", "", 0,
+		"", "", now, now, stoppedAt,
+		"", 0, 0, 10240, nil, nil, "", nil, "", now, now, now, nil,
+		(*int64)(nil), (*time.Time)(nil), "",
+		false,
+	}
+}
+
+func TestBranchPreviewHandler_RestartDelegatesSessionPreviews(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "pgx mock should initialize")
+	defer mock.Close()
+
+	orgID := uuid.New()
+	userID := uuid.New()
+	sessionID := uuid.New()
+	oldPreviewID := uuid.New()
+	newPreviewID := uuid.New()
+	now := time.Now()
+	stoppedAt := now.Add(-10 * time.Minute)
+
+	// resolveTargetRepoAndActive: GetPreviewInstance → stopped session preview
+	mock.ExpectQuery("SELECT .+ FROM preview_instances WHERE").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(pgxmock.NewRows(branchPreviewInstanceTestCols).AddRow(
+			sessionPreviewInstanceRow(oldPreviewID, sessionID, orgID, userID, models.PreviewStatusStopped, now, &stoppedAt)...,
+		))
+
+	restarter := &fakeSessionPreviewRestarter{
+		instance: &models.PreviewInstance{
+			ID:        newPreviewID,
+			SessionID: sessionID,
+			OrgID:     orgID,
+			Status:    models.PreviewStatusStarting,
+			ExpiresAt: now.Add(30 * time.Minute),
+		},
+		action: "started",
+	}
+
+	handler := NewBranchPreviewHandler(
+		db.NewPreviewStore(mock),
+		db.NewRepositoryStore(mock),
+		fakeBranchPreviewGitHub{token: "ghs_test", head: "abc123"},
+		nil,
+		"https://app.143.dev",
+		"https://{id}.preview.143.dev",
+	)
+	handler.SetSessionPreviewRestarter(restarter)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/previews/"+oldPreviewID.String()+"/restart", nil)
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("preview_id", oldPreviewID.String())
+	ctx := context.WithValue(req.Context(), chi.RouteCtxKey, rctx)
+	ctx = middleware.WithOrgID(ctx, orgID)
+	ctx = middleware.WithUser(ctx, &models.User{ID: userID, OrgID: orgID})
+	req = req.WithContext(ctx)
+	rr := httptest.NewRecorder()
+
+	handler.Restart(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code, "Restart should delegate session previews to the session restart flow")
+	require.Equal(t, 1, restarter.calls, "the session restarter should be invoked exactly once")
+	require.Equal(t, sessionID, restarter.gotSession, "the restarter should receive the preview's session ID")
+	require.Equal(t, userID, restarter.gotUser, "the restarter should receive the requesting user")
+
+	var resp models.SingleResponse[branchPreviewResponse]
+	require.NoError(t, json.NewDecoder(rr.Body).Decode(&resp), "Restart should return a preview response")
+	require.NotNil(t, resp.Data.PreviewID, "Restart should return the resulting instance ID")
+	require.Equal(t, newPreviewID, *resp.Data.PreviewID, "Restart should surface the fresh instance so pollers can follow it")
+	require.Equal(t, string(models.PreviewStatusStarting), resp.Data.Status, "Restart should surface the fresh instance status")
+	require.NotNil(t, resp.Data.PreviewURL, "Restart should include the new preview URL")
+	require.Contains(t, *resp.Data.PreviewURL, newPreviewID.String(), "the preview URL should point at the fresh instance host")
+	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
+}
+
+func TestBranchPreviewHandler_RestartSessionPreviewWithoutRestarterConflicts(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "pgx mock should initialize")
+	defer mock.Close()
+
+	orgID := uuid.New()
+	userID := uuid.New()
+	sessionID := uuid.New()
+	previewID := uuid.New()
+	now := time.Now()
+
+	mock.ExpectQuery("SELECT .+ FROM preview_instances WHERE").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(pgxmock.NewRows(branchPreviewInstanceTestCols).AddRow(
+			sessionPreviewInstanceRow(previewID, sessionID, orgID, userID, models.PreviewStatusStopped, now, nil)...,
+		))
+
+	handler := NewBranchPreviewHandler(
+		db.NewPreviewStore(mock),
+		db.NewRepositoryStore(mock),
+		fakeBranchPreviewGitHub{token: "ghs_test", head: "abc123"},
+		nil,
+		"https://app.143.dev",
+		"https://{id}.preview.143.dev",
+	)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/previews/"+previewID.String()+"/restart", nil)
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("preview_id", previewID.String())
+	ctx := context.WithValue(req.Context(), chi.RouteCtxKey, rctx)
+	ctx = middleware.WithOrgID(ctx, orgID)
+	ctx = middleware.WithUser(ctx, &models.User{ID: userID, OrgID: orgID})
+	req = req.WithContext(ctx)
+	rr := httptest.NewRecorder()
+
+	handler.Restart(rr, req)
+
+	require.Equal(t, http.StatusConflict, rr.Code, "Restart without a wired session restarter should keep the no-target conflict")
+	require.Contains(t, rr.Body.String(), "PREVIEW_HAS_NO_TARGET", "the conflict should carry the no-target code")
+	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
+}
+
+func TestBranchPreviewHandler_RestartSessionPreviewRejectsPreviewAPIToken(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "pgx mock should initialize")
+	defer mock.Close()
+
+	orgID := uuid.New()
+	userID := uuid.New()
+	sessionID := uuid.New()
+	previewID := uuid.New()
+	now := time.Now()
+
+	mock.ExpectQuery("SELECT .+ FROM preview_instances WHERE").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(pgxmock.NewRows(branchPreviewInstanceTestCols).AddRow(
+			sessionPreviewInstanceRow(previewID, sessionID, orgID, userID, models.PreviewStatusStopped, now, nil)...,
+		))
+
+	restarter := &fakeSessionPreviewRestarter{}
+	handler := NewBranchPreviewHandler(
+		db.NewPreviewStore(mock),
+		db.NewRepositoryStore(mock),
+		fakeBranchPreviewGitHub{token: "ghs_test", head: "abc123"},
+		nil,
+		"https://app.143.dev",
+		"https://{id}.preview.143.dev",
+	)
+	handler.SetSessionPreviewRestarter(restarter)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/previews/"+previewID.String()+"/restart", nil)
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("preview_id", previewID.String())
+	ctx := context.WithValue(req.Context(), chi.RouteCtxKey, rctx)
+	ctx = middleware.WithOrgID(ctx, orgID)
+	ctx = middleware.WithUser(ctx, &models.User{ID: userID, OrgID: orgID})
+	ctx = middleware.WithPreviewAPIToken(ctx, &models.PreviewAPIToken{
+		OrgID:  orgID,
+		Scopes: []string{"previews:read", "previews:create", "previews:stop"},
+	})
+	req = req.WithContext(ctx)
+	rr := httptest.NewRecorder()
+
+	handler.Restart(rr, req)
+
+	require.Equal(t, http.StatusForbidden, rr.Code, "preview API tokens must not drive session preview restarts")
+	require.Equal(t, 0, restarter.calls, "the session restarter should not be invoked for token-authenticated requests")
+	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
+}
+
+func TestBranchPreviewHandler_GetFollowsActiveSessionPreview(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "pgx mock should initialize")
+	defer mock.Close()
+
+	orgID := uuid.New()
+	userID := uuid.New()
+	sessionID := uuid.New()
+	oldPreviewID := uuid.New()
+	newPreviewID := uuid.New()
+	now := time.Now()
+	stoppedAt := now.Add(-10 * time.Minute)
+
+	// Get: GetPreviewInstance → old stopped session preview
+	mock.ExpectQuery("SELECT .+ FROM preview_instances").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(pgxmock.NewRows(branchPreviewInstanceTestCols).AddRow(
+			sessionPreviewInstanceRow(oldPreviewID, sessionID, orgID, userID, models.PreviewStatusStopped, now, &stoppedAt)...,
+		))
+	// Get: GetActivePreviewForSession → fresh starting instance for the session
+	mock.ExpectQuery("SELECT .+ FROM preview_instances").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(pgxmock.NewRows(branchPreviewInstanceTestCols).AddRow(
+			sessionPreviewInstanceRow(newPreviewID, sessionID, orgID, userID, models.PreviewStatusStarting, now, nil)...,
+		))
+
+	handler := NewBranchPreviewHandler(
+		db.NewPreviewStore(mock),
+		db.NewRepositoryStore(mock),
+		fakeBranchPreviewGitHub{token: "ghs_test", head: "abc123"},
+		nil,
+		"https://app.143.dev",
+		"https://{id}.preview.143.dev",
+	)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/previews/"+oldPreviewID.String(), nil)
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("preview_id", oldPreviewID.String())
+	ctx := context.WithValue(req.Context(), chi.RouteCtxKey, rctx)
+	ctx = middleware.WithOrgID(ctx, orgID)
+	req = req.WithContext(ctx)
+	rr := httptest.NewRecorder()
+
+	handler.Get(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code, "Get should succeed for a stopped session preview")
+	var resp models.SingleResponse[branchPreviewResponse]
+	require.NoError(t, json.NewDecoder(rr.Body).Decode(&resp), "Get should return a preview response")
+	require.NotNil(t, resp.Data.PreviewID, "Get should return an instance ID")
+	require.Equal(t, newPreviewID, *resp.Data.PreviewID, "Get should follow the session's current active preview so pollers converge on the replacement")
+	require.Equal(t, string(models.PreviewStatusStarting), resp.Data.Status, "Get should surface the replacement's status")
+	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
+}

--- a/internal/api/handlers/internal_preview.go
+++ b/internal/api/handlers/internal_preview.go
@@ -1,7 +1,7 @@
 package handlers
 
 import (
-	"bufio"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -9,6 +9,8 @@ import (
 	"net/http"
 	"net/http/httputil"
 	"strings"
+	"sync"
+	"time"
 
 	"github.com/assembledhq/143/internal/api/middleware"
 	"github.com/assembledhq/143/internal/auth"
@@ -20,6 +22,19 @@ import (
 	"github.com/rs/zerolog"
 )
 
+// runtimeAuthEntry caches the active runtime identity used to validate proxy
+// token claims, so the per-request DB check in authorizePreviewAction only
+// fires once per TTL per preview.
+type runtimeAuthEntry struct {
+	validUntil   time.Time
+	runtimeID    uuid.UUID
+	runtimeEpoch int
+	workerNodeID string
+}
+
+// runtimeAuthCacheTTL bounds how long a cached runtime identity is trusted.
+const runtimeAuthCacheTTL = 5 * time.Second
+
 // InternalPreviewHandler handles authenticated app->worker preview RPC.
 type InternalPreviewHandler struct {
 	preview   *PreviewHandler
@@ -29,15 +44,27 @@ type InternalPreviewHandler struct {
 	nodeID    string
 	secret    string
 	logger    zerolog.Logger
+
+	// runtimeAuthCache short-circuits the per-request active-runtime check.
+	runtimeAuthMu    sync.RWMutex
+	runtimeAuthCache map[uuid.UUID]*runtimeAuthEntry
+
+	// previewTransports pools upstream connections into preview containers,
+	// keyed by preview ID. Without pooling, every proxied request resolved
+	// the preview from the DB and dialed a fresh container connection.
+	transportMu       sync.Mutex
+	previewTransports map[uuid.UUID]*http.Transport
 }
 
 func NewInternalPreviewHandler(preview *PreviewHandler, manager *previewsvc.Manager, nodeID, secret string, logger zerolog.Logger) *InternalPreviewHandler {
 	return &InternalPreviewHandler{
-		preview: preview,
-		manager: manager,
-		nodeID:  nodeID,
-		secret:  secret,
-		logger:  logger,
+		preview:           preview,
+		manager:           manager,
+		nodeID:            nodeID,
+		secret:            secret,
+		logger:            logger,
+		runtimeAuthCache:  make(map[uuid.UUID]*runtimeAuthEntry),
+		previewTransports: make(map[uuid.UUID]*http.Transport),
 	}
 }
 
@@ -137,6 +164,7 @@ func (h *InternalPreviewHandler) StopPreview(w http.ResponseWriter, r *http.Requ
 		writeError(w, r, http.StatusInternalServerError, "PREVIEW_STOP_FAILED", "failed to stop preview", err)
 		return
 	}
+	h.evictPreviewTransport(previewID)
 	writeJSON(w, http.StatusOK, models.SingleResponse[map[string]string]{Data: map[string]string{"status": "stopped"}})
 }
 
@@ -171,6 +199,7 @@ func (h *InternalPreviewHandler) RecyclePreview(w http.ResponseWriter, r *http.R
 		writePreviewHTTPError(w, r, previewErr)
 		return
 	}
+	h.evictPreviewTransport(previewID)
 	writeJSON(w, http.StatusOK, models.SingleResponse[map[string]string]{Data: map[string]string{"status": "restarting"}})
 }
 
@@ -428,16 +457,49 @@ func (h *InternalPreviewHandler) authorizePreviewAction(w http.ResponseWriter, r
 		return uuid.Nil, nil, false
 	}
 	if action == "proxy" && h.preview != nil && h.preview.store != nil {
-		runtime, err := h.preview.store.GetActivePreviewRuntime(r.Context(), claims.OrgID, previewID)
-		if err != nil ||
-			runtime.ID != *claims.RuntimeID ||
-			runtime.RuntimeEpoch != claims.RuntimeEpoch ||
-			runtime.WorkerNodeID != claims.TargetNodeID {
+		if !h.runtimeClaimsValid(r.Context(), claims, previewID) {
 			writeError(w, r, http.StatusForbidden, "PREVIEW_RUNTIME_MISMATCH", "preview token does not match an active runtime")
 			return uuid.Nil, nil, false
 		}
 	}
 	return previewID, claims, true
+}
+
+// runtimeClaimsValid checks proxy token claims against the active runtime
+// through a short TTL cache. A cached match is trusted; a miss or mismatch
+// always re-resolves from the DB before rejecting, so a freshly recycled
+// preview (new runtime epoch) is never penalized by a stale cache entry.
+func (h *InternalPreviewHandler) runtimeClaimsValid(ctx context.Context, claims *auth.PreviewTokenClaims, previewID uuid.UUID) bool {
+	matches := func(entry *runtimeAuthEntry) bool {
+		return entry.runtimeID == *claims.RuntimeID &&
+			entry.runtimeEpoch == claims.RuntimeEpoch &&
+			entry.workerNodeID == claims.TargetNodeID
+	}
+	now := time.Now()
+	h.runtimeAuthMu.RLock()
+	entry, ok := h.runtimeAuthCache[previewID]
+	h.runtimeAuthMu.RUnlock()
+	if ok && now.Before(entry.validUntil) && matches(entry) {
+		return true
+	}
+	runtime, err := h.preview.store.GetActivePreviewRuntime(ctx, claims.OrgID, previewID)
+	if err != nil {
+		return false
+	}
+	entry = &runtimeAuthEntry{
+		validUntil:   now.Add(runtimeAuthCacheTTL),
+		runtimeID:    runtime.ID,
+		runtimeEpoch: runtime.RuntimeEpoch,
+		workerNodeID: runtime.WorkerNodeID,
+	}
+	h.runtimeAuthMu.Lock()
+	if len(h.runtimeAuthCache) > 4096 {
+		// Safety valve against unbounded growth across short-lived previews.
+		h.runtimeAuthCache = make(map[uuid.UUID]*runtimeAuthEntry)
+	}
+	h.runtimeAuthCache[previewID] = entry
+	h.runtimeAuthMu.Unlock()
+	return matches(entry)
 }
 
 func (h *InternalPreviewHandler) Proxy(w http.ResponseWriter, r *http.Request) {
@@ -471,11 +533,7 @@ func (h *InternalPreviewHandler) handleHTTPProxy(w http.ResponseWriter, r *http.
 			req.Header.Del("Authorization")
 			stripPreviewAccessCookies(req)
 		},
-		Transport: &internalPreviewTransport{
-			manager:   h.manager,
-			orgID:     orgID,
-			previewID: previewID,
-		},
+		Transport: h.previewTransport(orgID, previewID),
 		ErrorHandler: func(w http.ResponseWriter, r *http.Request, err error) {
 			addInternalPreviewProxyLogFields(h.logger.Warn().Err(err), originalReq, orgID, previewID, claims, backendPath).
 				Msg("internal preview proxy error")
@@ -483,6 +541,60 @@ func (h *InternalPreviewHandler) handleHTTPProxy(w http.ResponseWriter, r *http.
 		},
 	}
 	proxy.ServeHTTP(w, r)
+}
+
+// previewTransport returns the pooled upstream transport for a preview,
+// creating it on first use. Pooled connections are keyed per preview so
+// container streams are reused across requests instead of dialed fresh each
+// time. Connections to a torn-down container close on the container side and
+// fall out of the pool, so a recycle converges on the new container without
+// explicit invalidation; eviction hooks just tighten the window.
+func (h *InternalPreviewHandler) previewTransport(orgID, previewID uuid.UUID) http.RoundTripper {
+	h.transportMu.Lock()
+	defer h.transportMu.Unlock()
+	if transport, ok := h.previewTransports[previewID]; ok {
+		return transport
+	}
+	transport := &http.Transport{
+		DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
+			conn, err := h.manager.DialPreview(ctx, orgID, previewID)
+			if err != nil {
+				return nil, fmt.Errorf("dial preview: %w", err)
+			}
+			return conn, nil
+		},
+		MaxIdleConns:        128,
+		MaxIdleConnsPerHost: 128,
+		IdleConnTimeout:     60 * time.Second,
+		// Preserve end-to-end content negotiation: the browser's own
+		// Accept-Encoding is forwarded by the gateway, and the previous
+		// raw-conn transport never decompressed bodies.
+		DisableCompression: true,
+	}
+	if len(h.previewTransports) > 1024 {
+		// Safety valve against unbounded growth across short-lived previews.
+		for id, old := range h.previewTransports {
+			old.CloseIdleConnections()
+			delete(h.previewTransports, id)
+		}
+	}
+	h.previewTransports[previewID] = transport
+	return transport
+}
+
+// evictPreviewTransport drops the pooled transport for a preview and closes
+// its idle connections. Called when the preview is stopped or recycled on
+// this worker.
+func (h *InternalPreviewHandler) evictPreviewTransport(previewID uuid.UUID) {
+	h.transportMu.Lock()
+	transport, ok := h.previewTransports[previewID]
+	if ok {
+		delete(h.previewTransports, previewID)
+	}
+	h.transportMu.Unlock()
+	if ok {
+		transport.CloseIdleConnections()
+	}
 }
 
 func (h *InternalPreviewHandler) handleWebSocketProxy(w http.ResponseWriter, r *http.Request, orgID, previewID uuid.UUID, claims *auth.PreviewTokenClaims) {
@@ -575,44 +687,6 @@ func addInternalPreviewProxyLogFields(event *zerolog.Event, r *http.Request, org
 		event = event.Str("runtime_id", claims.RuntimeID.String())
 	}
 	return event
-}
-
-type internalPreviewTransport struct {
-	manager   *previewsvc.Manager
-	orgID     uuid.UUID
-	previewID uuid.UUID
-}
-
-type connClosingBody struct {
-	io.ReadCloser
-	conn net.Conn
-}
-
-func (b *connClosingBody) Close() error {
-	bodyErr := b.ReadCloser.Close()
-	connErr := b.conn.Close()
-	if bodyErr != nil {
-		return bodyErr
-	}
-	return connErr
-}
-
-func (t *internalPreviewTransport) RoundTrip(req *http.Request) (*http.Response, error) {
-	conn, err := t.manager.DialPreview(req.Context(), t.orgID, t.previewID)
-	if err != nil {
-		return nil, fmt.Errorf("dial preview: %w", err)
-	}
-	if err := req.Write(conn); err != nil {
-		_ = conn.Close()
-		return nil, fmt.Errorf("write request: %w", err)
-	}
-	resp, err := http.ReadResponse(bufio.NewReader(conn), req)
-	if err != nil {
-		_ = conn.Close()
-		return nil, fmt.Errorf("read response: %w", err)
-	}
-	resp.Body = &connClosingBody{ReadCloser: resp.Body, conn: conn}
-	return resp, nil
 }
 
 func cloneWebSocketRequestForInternalProxy(req *http.Request, previewID uuid.UUID) *http.Request {

--- a/internal/api/handlers/internal_preview_test.go
+++ b/internal/api/handlers/internal_preview_test.go
@@ -266,11 +266,11 @@ func TestInternalPreviewHandler_AuthorizePreviewActionRejectsStaleRuntime(t *tes
 		WillReturnRows(pgxmock.NewRows([]string{
 			"id", "org_id", "preview_instance_id", "runtime_epoch", "worker_node_id",
 			"endpoint_url", "preview_handle", "primary_port", "status", "lease_expires_at",
-			"last_heartbeat_at", "drain_requested_at", "stopped_at", "error", "created_at", "updated_at",
+			"last_heartbeat_at", "drain_requested_at", "stopped_at", "error", "unavailable_reason", "created_at", "updated_at",
 		}).AddRow(
 			runtimeID, orgID, previewID, 2, "worker-1",
 			"http://worker-1.internal", "handle-1", 3000, string(models.PreviewRuntimeStatusReady), now.Add(time.Minute),
-			now, nil, nil, "", now, now,
+			now, nil, nil, "", "", now, now,
 		))
 
 	req := httptest.NewRequest(http.MethodGet, "/internal/preview/"+previewID.String()+"/proxy", nil)
@@ -871,36 +871,6 @@ func TestInternalPreviewHandler_ProxyWebSocket_HijackUnsupported(t *testing.T) {
 	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
 }
 
-type closeTrackingConn struct {
-	net.Conn
-	closed bool
-}
-
-func (c *closeTrackingConn) Close() error {
-	c.closed = true
-	if c.Conn != nil {
-		return c.Conn.Close()
-	}
-	return nil
-}
-
-type errReadCloser struct{ err error }
-
-func (errReadCloser) Read([]byte) (int, error) { return 0, io.EOF }
-func (e errReadCloser) Close() error           { return e.err }
-
-func TestConnClosingBody_ClosePrefersBodyError(t *testing.T) {
-	t.Parallel()
-
-	conn := &closeTrackingConn{}
-	body := &connClosingBody{ReadCloser: errReadCloser{err: errors.New("body close failed")}, conn: conn}
-
-	err := body.Close()
-	require.Error(t, err, "connClosingBody should surface body close failures")
-	require.Contains(t, err.Error(), "body close failed", "connClosingBody should prefer the body close error")
-	require.True(t, conn.closed, "connClosingBody should still close the underlying connection")
-}
-
 func TestCopyWithHMRSnoopToClient_ForwardsTraffic(t *testing.T) {
 	t.Parallel()
 
@@ -928,4 +898,133 @@ func TestCopyWithHMRSnoopToClient_ForwardsTraffic(t *testing.T) {
 
 func ptrUUID(id uuid.UUID) *uuid.UUID {
 	return &id
+}
+
+func TestInternalPreviewHandler_AuthorizePreviewActionCachesRuntimeLookup(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "pgxmock pool should be created")
+	defer mock.Close()
+
+	orgID := uuid.New()
+	previewID := uuid.New()
+	runtimeID := uuid.New()
+	now := time.Now().UTC()
+
+	store := db.NewPreviewStore(mock)
+	handler := NewInternalPreviewHandler(&PreviewHandler{store: store, logger: zerolog.Nop()}, nil, "worker-1", "worker-secret", zerolog.Nop())
+
+	// Exactly one runtime lookup for two authorized requests: the second one
+	// must be validated against the cache.
+	mock.ExpectQuery("SELECT .+ FROM preview_runtimes").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(pgxmock.NewRows([]string{
+			"id", "org_id", "preview_instance_id", "runtime_epoch", "worker_node_id",
+			"endpoint_url", "preview_handle", "primary_port", "status", "lease_expires_at",
+			"last_heartbeat_at", "drain_requested_at", "stopped_at", "error", "unavailable_reason", "created_at", "updated_at",
+		}).AddRow(
+			runtimeID, orgID, previewID, 1, "worker-1",
+			"http://worker-1.internal", "handle-1", 3000, string(models.PreviewRuntimeStatusReady), now.Add(time.Minute),
+			now, nil, nil, "", "", now, now,
+		))
+
+	for i := 0; i < 2; i++ {
+		req := httptest.NewRequest(http.MethodGet, "/internal/preview/"+previewID.String()+"/proxy", nil)
+		req = withPreviewRouteParam(req, previewID.String())
+		req.Header.Set("Authorization", internalPreviewAuthHeader(t, auth.PreviewTokenClaims{
+			OrgID:        orgID,
+			PreviewID:    &previewID,
+			TargetNodeID: "worker-1",
+			RuntimeID:    &runtimeID,
+			RuntimeEpoch: 1,
+			Action:       "proxy",
+			ExpiresAt:    time.Now().Add(time.Minute),
+		}))
+		rr := httptest.NewRecorder()
+
+		_, _, ok := handler.authorizePreviewAction(rr, req, "proxy")
+		require.True(t, ok, "request %d with valid runtime claims should authorize", i+1)
+	}
+	require.NoError(t, mock.ExpectationsWereMet(), "second authorization should hit the runtime cache instead of the database")
+}
+
+func TestInternalPreviewHandler_AuthorizePreviewActionRefreshesStaleCacheOnMismatch(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "pgxmock pool should be created")
+	defer mock.Close()
+
+	orgID := uuid.New()
+	previewID := uuid.New()
+	oldRuntimeID := uuid.New()
+	newRuntimeID := uuid.New()
+	now := time.Now().UTC()
+
+	store := db.NewPreviewStore(mock)
+	handler := NewInternalPreviewHandler(&PreviewHandler{store: store, logger: zerolog.Nop()}, nil, "worker-1", "worker-secret", zerolog.Nop())
+
+	runtimeRow := func(id uuid.UUID, epoch int) *pgxmock.Rows {
+		return pgxmock.NewRows([]string{
+			"id", "org_id", "preview_instance_id", "runtime_epoch", "worker_node_id",
+			"endpoint_url", "preview_handle", "primary_port", "status", "lease_expires_at",
+			"last_heartbeat_at", "drain_requested_at", "stopped_at", "error", "unavailable_reason", "created_at", "updated_at",
+		}).AddRow(
+			id, orgID, previewID, epoch, "worker-1",
+			"http://worker-1.internal", "handle-1", 3000, string(models.PreviewRuntimeStatusReady), now.Add(time.Minute),
+			now, nil, nil, "", "", now, now,
+		)
+	}
+
+	// First request populates the cache with epoch 1; the second request
+	// carries epoch-2 claims (fresh recycle) and must trigger a re-resolve
+	// instead of being rejected against the stale cache entry.
+	mock.ExpectQuery("SELECT .+ FROM preview_runtimes").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(runtimeRow(oldRuntimeID, 1))
+	mock.ExpectQuery("SELECT .+ FROM preview_runtimes").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(runtimeRow(newRuntimeID, 2))
+
+	authorize := func(runtimeID uuid.UUID, epoch int) bool {
+		req := httptest.NewRequest(http.MethodGet, "/internal/preview/"+previewID.String()+"/proxy", nil)
+		req = withPreviewRouteParam(req, previewID.String())
+		req.Header.Set("Authorization", internalPreviewAuthHeader(t, auth.PreviewTokenClaims{
+			OrgID:        orgID,
+			PreviewID:    &previewID,
+			TargetNodeID: "worker-1",
+			RuntimeID:    &runtimeID,
+			RuntimeEpoch: epoch,
+			Action:       "proxy",
+			ExpiresAt:    time.Now().Add(time.Minute),
+		}))
+		rr := httptest.NewRecorder()
+		_, _, ok := handler.authorizePreviewAction(rr, req, "proxy")
+		return ok
+	}
+
+	require.True(t, authorize(oldRuntimeID, 1), "epoch-1 claims should authorize against the live epoch-1 runtime")
+	require.True(t, authorize(newRuntimeID, 2), "epoch-2 claims should re-resolve past the stale cache entry and authorize")
+	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
+}
+
+func TestInternalPreviewHandler_PreviewTransportPoolsPerPreview(t *testing.T) {
+	t.Parallel()
+
+	handler := newInternalPreviewTestHandler(nil)
+	orgID := uuid.New()
+	previewID := uuid.New()
+	otherPreviewID := uuid.New()
+
+	first := handler.previewTransport(orgID, previewID)
+	second := handler.previewTransport(orgID, previewID)
+	require.Same(t, first, second, "repeated requests for the same preview should reuse the pooled transport")
+
+	other := handler.previewTransport(orgID, otherPreviewID)
+	require.NotSame(t, first, other, "distinct previews must not share a transport (their dialers target different containers)")
+
+	handler.evictPreviewTransport(previewID)
+	third := handler.previewTransport(orgID, previewID)
+	require.NotSame(t, first, third, "eviction should drop the pooled transport so a fresh one is built")
 }

--- a/internal/api/handlers/preview.go
+++ b/internal/api/handlers/preview.go
@@ -170,11 +170,14 @@ func (h *PreviewHandler) isLocalWorker(worker preview.WorkerNode) bool {
 }
 
 func (h *PreviewHandler) writeWorkerClientError(w http.ResponseWriter, r *http.Request, err error) {
+	writePreviewHTTPError(w, r, workerClientHTTPError(err))
+}
+
+func workerClientHTTPError(err error) *previewHTTPError {
 	if reqErr, ok := preview.AsWorkerRequestError(err); ok {
-		writeError(w, r, reqErr.StatusCode, reqErr.Code, reqErr.Message)
-		return
+		return newPreviewHTTPError(reqErr.StatusCode, reqErr.Code, reqErr.Message, nil)
 	}
-	writeError(w, r, http.StatusBadGateway, "PREVIEW_WORKER_REQUEST_FAILED", "preview worker request failed", err)
+	return newPreviewHTTPError(http.StatusBadGateway, "PREVIEW_WORKER_REQUEST_FAILED", "preview worker request failed", err)
 }
 
 // =============================================================================
@@ -1337,55 +1340,84 @@ func (h *PreviewHandler) RestartPreview(w http.ResponseWriter, r *http.Request) 
 		writePreviewHTTPError(w, r, reqErr)
 		return
 	}
-	instance, activeErr := h.lookupActivePreviewForRequest(r.Context(), orgID, sessionID)
-	if activeErr != nil {
-		writePreviewHTTPError(w, r, activeErr)
+	userID, ok := previewRequestUserID(r.Context(), middleware.UserFromContext(r.Context()))
+	if !ok {
+		writeError(w, r, http.StatusUnauthorized, "UNAUTHORIZED", "authentication required")
 		return
+	}
+	instance, action, restartErr := h.RestartSessionPreview(r.Context(), orgID, userID, sessionID, body)
+	if restartErr != nil {
+		writePreviewHTTPError(w, r, restartErr)
+		return
+	}
+	switch action {
+	case sessionPreviewRestartStarted, sessionPreviewRestartAlreadyStarting:
+		writeJSON(w, http.StatusAccepted, models.SingleResponse[ensurePreviewResponse]{
+			Data: ensurePreviewResponse{Action: action, Instance: instance},
+		})
+	default:
+		writeJSON(w, http.StatusOK, models.SingleResponse[map[string]string]{Data: map[string]string{"status": "restarting"}})
+	}
+}
+
+// Actions returned by RestartSessionPreview.
+const (
+	sessionPreviewRestartStarted         = "started"
+	sessionPreviewRestartAlreadyStarting = "already_starting"
+	sessionPreviewRestartRestarting      = "restarting"
+)
+
+// RestartSessionPreview restarts the preview for a session regardless of its
+// current state: with no active instance (stopped, failed, expired, or never
+// started) a fresh preview is started — re-hydrating the sandbox if needed —
+// while an active instance is recycled in place. It returns the resulting
+// instance and the action taken. Used by the session-scoped restart endpoint
+// and by the generic preview restart endpoint for previews without a branch
+// target.
+func (h *PreviewHandler) RestartSessionPreview(ctx context.Context, orgID, userID, sessionID uuid.UUID, body startPreviewRequest) (*models.PreviewInstance, string, *previewHTTPError) {
+	if h.manager == nil {
+		return nil, "", newPreviewHTTPError(http.StatusNotImplemented, "PREVIEW_NOT_AVAILABLE", "preview manager is not configured on this worker", nil)
+	}
+	instance, activeErr := h.lookupActivePreviewForRequest(ctx, orgID, sessionID)
+	if activeErr != nil {
+		return nil, "", activeErr
 	}
 	if instance == nil {
-		user := middleware.UserFromContext(r.Context())
-		started, _, startErr := h.startPreviewFromRequest(r.Context(), orgID, user.ID, sessionID, body)
+		started, _, startErr := h.startPreviewFromRequest(ctx, orgID, userID, sessionID, body)
 		if startErr != nil {
-			writePreviewHTTPError(w, r, startErr)
-			return
+			return nil, "", startErr
 		}
-		writeJSON(w, http.StatusAccepted, models.SingleResponse[ensurePreviewResponse]{
-			Data: ensurePreviewResponse{Action: "started", Instance: started},
-		})
-		return
+		return started, sessionPreviewRestartStarted, nil
 	}
 	if instance.Status == models.PreviewStatusStarting {
-		writeJSON(w, http.StatusAccepted, models.SingleResponse[ensurePreviewResponse]{
-			Data: ensurePreviewResponse{Action: "already_starting", Instance: instance},
-		})
-		return
+		return instance, sessionPreviewRestartAlreadyStarting, nil
 	}
 
 	if h.workerRoutingEnabled() {
-		worker, err := h.resolvePreviewWorker(r.Context(), instance.WorkerNodeID)
+		worker, err := h.resolvePreviewWorker(ctx, instance.WorkerNodeID)
 		if err != nil {
-			writeError(w, r, http.StatusBadGateway, "PREVIEW_WORKER_RESOLUTION_FAILED", "failed to resolve preview worker", err)
-			return
+			return nil, "", newPreviewHTTPError(http.StatusBadGateway, "PREVIEW_WORKER_RESOLUTION_FAILED", "failed to resolve preview worker", err)
 		}
 		if h.isLocalWorker(worker) {
-			if recycleErr := h.recyclePreviewInstance(r.Context(), orgID, instance, body); recycleErr != nil {
-				writePreviewHTTPError(w, r, recycleErr)
-				return
+			if recycleErr := h.recyclePreviewInstance(ctx, orgID, instance, body); recycleErr != nil {
+				return nil, "", recycleErr
 			}
 		} else {
-			if err := h.workerClient.RecyclePreview(r.Context(), worker, orgID, instance.ID, body.Config); err != nil {
-				h.writeWorkerClientError(w, r, err)
-				return
+			if err := h.workerClient.RecyclePreview(ctx, worker, orgID, instance.ID, body.Config); err != nil {
+				return nil, "", workerClientHTTPError(err)
 			}
 		}
 	} else {
-		if recycleErr := h.recyclePreviewInstance(r.Context(), orgID, instance, body); recycleErr != nil {
-			writePreviewHTTPError(w, r, recycleErr)
-			return
+		if recycleErr := h.recyclePreviewInstance(ctx, orgID, instance, body); recycleErr != nil {
+			return nil, "", recycleErr
 		}
 	}
 
-	writeJSON(w, http.StatusOK, models.SingleResponse[map[string]string]{Data: map[string]string{"status": "restarting"}})
+	// Re-read so callers that render the instance see the post-recycle state.
+	if refreshed, err := h.store.GetPreviewInstance(ctx, orgID, instance.ID); err == nil {
+		instance = refreshed
+	}
+	return instance, sessionPreviewRestartRestarting, nil
 }
 
 // =============================================================================

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -745,6 +745,7 @@ func NewRouter(cfg *config.Config, pool *pgxpool.Pool, logger zerolog.Logger, se
 	previewHandler.SetWorkerRuntime(workerSelector, workerClient, cfg.NodeID)
 	previewHandler.SetStaticEgressRuntime(orgStore, agent.ResolveStaticEgressRuntimeConfig(cfg.StaticEgressPublicIP))
 	branchPreviewHandler.SetWorkerRuntime(jobStore, workerSelector)
+	branchPreviewHandler.SetSessionPreviewRestarter(previewHandler)
 	branchPreviewHandler.SetPreviewCachePrewarm(cfg.PreviewCachePrewarmEnabled, cfg.PreviewCachePrewarmPriority)
 	branchPreviewHandler.SetStaticEgressSettings(orgStore, cfg.StaticEgressPublicIP)
 	branchPreviewHandler.SetAPITokenStore(previewAPITokenStore)

--- a/internal/services/preview/manager.go
+++ b/internal/services/preview/manager.go
@@ -1429,7 +1429,10 @@ func (m *Manager) MintBootstrapToken(ctx context.Context, orgID, userID, preview
 		UserID:            userID,
 		PreviewInstanceID: previewID,
 		SessionTokenHash:  tokenHash,
-		ExpiresAt:         time.Now().Add(5 * time.Minute),
+		// Deliberately short: this initial window only needs to cover token
+		// redemption. The gateway extends the session to its full sliding
+		// lifetime (accessSessionTTL) on the first proxied request.
+		ExpiresAt: time.Now().Add(5 * time.Minute),
 	}
 
 	if err := m.store.CreateAccessSession(ctx, sess); err != nil {


### PR DESCRIPTION
## Why

Debugged a prod preview that sat on a loading spinner: the platform was healthy, but a dev-server page load fans out ~80 chunk requests and **every proxied request cost ~4 DB round-trips + 1–2 fresh dials**:

- gateway: `GetActivePreviewRuntime` (uncached) + `RecordAccess` UPDATE per request, proxied over `http.DefaultTransport` (2 idle conns/host → the asset burst serializes)
- worker: `GetActivePreviewRuntime` again per request, then `DialPreview` per request (`GetPreviewInstance` + a fresh container connection, closed after each response)

That put warm page loads at 15–30s. While reproducing, the preview idled out and exposed a second bug: **stopped session previews cannot be restarted** — the launcher calls `/previews/{id}/restart`/`start-latest`, which are branch-target-only and 409 with `PREVIEW_HAS_NO_TARGET` (all prod previews are session previews). Finally, 5-minute access sessions expired out from under idle tabs, and stale XHRs received overlay HTML (200) — silently wedging SPAs.

## What changed

**Session previews are restartable from the launcher**
- `Restart`/`StartLatest` route target-less instances to a new `PreviewHandler.RestartSessionPreview` (extracted from the session-scoped restart handler): recycle in place when active, fresh start (sandbox re-hydration) when stopped. Preview API tokens are rejected from session restarts.
- `GET /previews/{id}` on a terminal session instance follows the session's current active preview, so the launcher's polling converges on the replacement instance ID — no frontend changes needed.
- `resolveTargetRepoAndActive` now returns `ok=true` with a nil target for session previews (documented contract) instead of writing the 409 itself.

**Per-request proxy overhead removed**
- Gateway: 5s TTL runtime cache (evicted on proxy error / runtime-epoch mismatch), `RecordAccess` throttled to one write per preview per 15s, shared upstream transport with a 128-conn idle pool.
- Worker: same 5s cache in `authorizePreviewAction` — with a fresh re-resolve on mismatch so a just-recycled preview (new epoch) is never falsely 403'd — and per-preview pooled `http.Transport`s into containers (evicted on stop/recycle), replacing the dial-per-request custom RoundTripper.

**Session lifetime + failure modes**
- Access sessions slide at 30 min (`accessSessionTTL`, extend threshold 10 min). The initial 5-min mint window now only covers bootstrap-token redemption; the first proxied request extends it.
- Stale/missing sessions on non-navigation requests (`Sec-Fetch-Dest` not document/iframe; Accept-sniff fallback for legacy clients) get `401 {"code":"PREVIEW_SESSION_EXPIRED"}` instead of overlay HTML.
- New case: a valid cookie can now outlive the preview idle timeout — navigations to a stopped preview get the restart overlay instead of a raw 503.
- CSP `worker-src 'none'` → `'self' blob:` so previewed apps can use web workers.

## Reviewer notes

- **API semantic change:** `GET /previews/{id}` for a terminal session instance can return a different `preview_id` (the replacement). The launcher is the only consumer that polls this today.
- **Behavior change:** non-browser clients without `Accept: text/html` (e.g. curl) now get 401 JSON instead of a 302 to the launcher.
- **Known trade-off:** a POST written to a pooled container connection that died mid-window fails once with 502 (Go only auto-retries idempotent requests). Window is small (60s idle timeout, peer-close pruning, stop/recycle eviction); documented at the transport.
- Pre-existing test bug fixed: `AuthorizePreviewActionRejectsStaleRuntime` mocked a runtime row missing `unavailable_reason`, so it passed via scan error rather than the real mismatch path.

## Testing

- 14 new tests: runtime-cache hit/eviction (pgxmock strict expectations catch extra DB calls), access throttle, navigation classification, both JSON-401 paths, stopped-preview overlay, session restart delegation / conflict fallback / token rejection, Get-follow, worker auth-cache + stale-cache refresh, transport pooling/eviction.
- Existing gateway tests updated only to add the headers real browser navigations send.
- Full `go test ./internal/...` green; `make lint` 0 issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
