### PR TITLE
Refine LLM settings page header text and update related tests

### DIFF
--- a/frontend/src/app/(dashboard)/settings/llm/page.test.tsx
+++ b/frontend/src/app/(dashboard)/settings/llm/page.test.tsx
@@ -88,9 +88,13 @@ describe("LLMPage", () => {
       expect(screen.getByRole("heading", { name: /LLM/i, level: 1 })).toBeInTheDocument();
     });
     expect(
-      screen.getByText(/Configure the app-level LLMs used for extra features like PR descriptions/i),
+      screen.getByText(
+        /Configure app-level LLMs for PR descriptions, session titles, validation, and project generation\. These are separate from coding agents on the Agent page/i,
+      ),
     ).toBeInTheDocument();
-    expect(screen.getByText(/These models are separate from the coding agents configured on the Agent page/i)).toBeInTheDocument();
+    expect(
+      screen.queryByText(/These models are separate from the coding agents configured on the Agent page/i),
+    ).not.toBeInTheDocument();
   });
 
   it("renders provider keys section", async () => {

--- a/frontend/src/app/(dashboard)/settings/llm/page.tsx
+++ b/frontend/src/app/(dashboard)/settings/llm/page.tsx
@@ -243,8 +243,7 @@ export default function LLMPage() {
       <div className="space-y-6">
         <PageHeader
           title="LLM"
-          description="Configure the app-level LLMs used for extra features like PR descriptions, session titles, validation, and project generation."
-          subtitle="These models are separate from the coding agents configured on the Agent page."
+          description="Configure app-level LLMs for PR descriptions, session titles, validation, and project generation. These are separate from coding agents on the Agent page."
         />
 
         {!hasPlatformLLM && (


### PR DESCRIPTION
## Summary
This updates the LLM settings page header to use a single, clearer description sentence (fixing punctuation/wording) and removes the now-defunct subtitle. The associated test assertions were updated to match the new UI copy.

## Changes
- **frontend/src/app/(dashboard)/settings/llm/page.tsx**
  - Updated `PageHeader` props: merged the previous `description` + `subtitle` into one `description` string with a period and adjusted wording.
  - Removed the `subtitle` text entirely from the header.
- **frontend/src/app/(dashboard)/settings/llm/page.test.tsx**
  - Updated expectations to:
    - Assert the new combined header description text.
    - Ensure the old subtitle text is no longer present (`queryByText` + `not.toBeInTheDocument`).

## Test plan
- `npm test -- --run 'src/app/(dashboard)/settings/llm/page.test.tsx'`
- `npm run typecheck`
- `npm run lint`
- `npm run build`

[143.dev](https://143.dev) | [session 2afcf047](https://143.dev/sessions/2afcf047-f13f-4eb8-8ee0-3a15b451d780)

Preview: https://143.dev/previews/github/assembledhq/143/pull/1370