### PR TITLE
Adjust team settings UI sizing, fix GitHub auto-join messaging, and improve CLI join accessibility

### DIFF
--- a/frontend/src/components/cli-join-tokens-card.test.tsx
+++ b/frontend/src/components/cli-join-tokens-card.test.tsx
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import { http, HttpResponse } from "msw";
+import { renderWithProviders, screen } from "@/test/test-utils";
+import { server } from "@/test/mocks/server";
+import { CLIJoinTokensCard } from "./cli-join-tokens-card";
+
+describe("CLIJoinTokensCard", () => {
+  it("renders the title without a leading icon", async () => {
+    server.use(
+      http.get("/api/v1/org/join-tokens", () => HttpResponse.json({ data: [], meta: {} })),
+    );
+
+    renderWithProviders(<CLIJoinTokensCard />);
+
+    const heading = await screen.findByRole("heading", { name: "CLI install links" });
+    expect(heading.previousElementSibling).toBeNull();
+  });
+
+  it("keeps the create-link controls the same height", async () => {
+    server.use(
+      http.get("/api/v1/org/join-tokens", () => HttpResponse.json({ data: [], meta: {} })),
+    );
+
+    renderWithProviders(<CLIJoinTokensCard />);
+
+    expect(await screen.findByLabelText("Link name")).toHaveClass("h-9");
+    expect(screen.getByRole("combobox", { name: "Role granted" })).toHaveClass("h-9");
+    expect(screen.getByRole("button", { name: "Create link" })).toHaveClass("h-9");
+  });
+});

--- a/frontend/src/components/cli-join-tokens-card.tsx
+++ b/frontend/src/components/cli-join-tokens-card.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { Check, Copy, Terminal } from "lucide-react";
+import { Check, Copy } from "lucide-react";
 import { api } from "@/lib/api";
 import { captureError } from "@/lib/errors";
 import { Badge } from "@/components/ui/badge";
@@ -96,10 +96,7 @@ export function CLIJoinTokensCard() {
 
   return (
     <section className="space-y-3">
-      <div className="flex items-center gap-1.5">
-        <Terminal className="size-3.5 text-muted-foreground" />
-        <h2 className="text-xs font-medium text-foreground">CLI install links</h2>
-      </div>
+      <h2 className="text-xs font-medium text-foreground">CLI install links</h2>
       <p className="text-xs text-muted-foreground">
         Anyone with this link can install 143-tools and join this org by
         signing in with GitHub — one command, no pre-registration. Share it in
@@ -123,9 +120,9 @@ export function CLIJoinTokensCard() {
               />
             </div>
             <div className="space-y-1.5">
-              <Label>Role granted</Label>
+              <Label htmlFor="join-token-role">Role granted</Label>
               <Select value={role} onValueChange={setRole}>
-                <SelectTrigger className="w-full sm:w-32">
+                <SelectTrigger id="join-token-role" className="h-9 w-full sm:w-32">
                   <SelectValue />
                 </SelectTrigger>
                 <SelectContent>
@@ -136,7 +133,7 @@ export function CLIJoinTokensCard() {
               </Select>
             </div>
             <Button
-              size="sm"
+              className="h-9"
               disabled={createMutation.isPending}
               onClick={() => createMutation.mutate()}
             >

--- a/frontend/src/components/settings/verified-domains-section.test.tsx
+++ b/frontend/src/components/settings/verified-domains-section.test.tsx
@@ -26,6 +26,7 @@ function mockDomains(domains: DomainFixture[]) {
   server.use(
     http.get("/api/v1/team/domains", () => HttpResponse.json({ data: enriched, meta: {} })),
     http.get("/api/v1/team/github-orgs", () => HttpResponse.json({ github_orgs: [] })),
+    http.get("/api/v1/team/github/status", () => HttpResponse.json({ data: { connected: false } })),
   );
 }
 
@@ -36,6 +37,29 @@ describe("VerifiedDomainsSection", () => {
 
     expect(await screen.findByText(/People who match these rules join as members automatically/)).toBeInTheDocument();
     expect(await screen.findByText(/No domains yet/)).toBeInTheDocument();
+  });
+
+  it("keeps the add-domain controls the same height", async () => {
+    mockDomains([]);
+    renderWithProviders(<VerifiedDomainsSection />);
+
+    const input = await screen.findByLabelText("Domain to verify");
+    const button = screen.getByRole("button", { name: "Add domain" });
+
+    expect(input).toHaveClass("h-9");
+    expect(button).toHaveClass("h-9");
+  });
+
+  it("does not ask connected GitHub users to reconnect when no organization installation is available", async () => {
+    mockDomains([]);
+    server.use(
+      http.get("/api/v1/team/github/status", () => HttpResponse.json({ data: { connected: true } })),
+    );
+
+    renderWithProviders(<VerifiedDomainsSection />);
+
+    expect(await screen.findByText(/Install the GitHub App on a GitHub organization/)).toBeInTheDocument();
+    expect(screen.queryByText(/Connect GitHub to enable organization-based auto-join/)).not.toBeInTheDocument();
   });
 
   it("shows the DNS record instructions for a pending domain", async () => {

--- a/frontend/src/components/settings/verified-domains-section.tsx
+++ b/frontend/src/components/settings/verified-domains-section.tsx
@@ -21,7 +21,7 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
-import type { GitHubOrgAutoJoin, GitHubOrgAutoJoinResponse, ListResponse, OrganizationDomain } from "@/lib/types";
+import type { GitHubInviteStatus, GitHubOrgAutoJoin, GitHubOrgAutoJoinResponse, ListResponse, OrganizationDomain, SingleResponse } from "@/lib/types";
 
 // copyText writes to the clipboard, falling back to the legacy
 // execCommand path when the async Clipboard API is unavailable —
@@ -100,6 +100,11 @@ export function VerifiedDomainsSection() {
     queryFn: () => api.team.listGitHubOrgs(),
   });
   const githubOrgs = githubOrgData?.github_orgs ?? [];
+  const { data: githubStatusData } = useQuery<SingleResponse<GitHubInviteStatus>>({
+    queryKey: ["team-github-status"],
+    queryFn: () => api.team.githubInviteStatus(),
+  });
+  const githubConnected = githubStatusData?.data.connected ?? false;
 
   const invalidate = () => {
     void queryClient.invalidateQueries({ queryKey: queryKeys.team.domains });
@@ -188,7 +193,11 @@ export function VerifiedDomainsSection() {
             ) : githubOrgs.length === 0 ? (
               <div className="flex items-center gap-2 px-4 py-3 text-xs text-muted-foreground">
                 <Github className="h-3.5 w-3.5" />
-                <span>Connect GitHub to enable organization-based auto-join.</span>
+                <span>
+                  {githubConnected
+                    ? "Install the GitHub App on a GitHub organization to enable organization-based auto-join."
+                    : "Connect GitHub to enable organization-based auto-join."}
+                </span>
               </div>
             ) : (
               githubOrgs.map((org) => {
@@ -255,7 +264,7 @@ export function VerifiedDomainsSection() {
               aria-label="Domain to verify"
             />
             <Button
-              size="sm"
+              className="h-9"
               onClick={handleAdd}
               disabled={addMutation.isPending || !newDomain.trim()}
             >


### PR DESCRIPTION
## Summary
This update refines Team settings UI spacing and behavior for better consistency and clearer GitHub auto-join guidance. It also removes the terminal icon from the CLI install links header, fixes an accessibility label on the CLI role select, and adds/updates tests for the affected UI.

## Changes
- **`frontend/src/components/settings/verified-domains-section.tsx`**
  - Adjusted the GitHub auto-join empty state messaging: when the user’s GitHub is already connected but **no eligible GitHub org installations** exist, the UI now instructs them to **install the GitHub App on a GitHub organization** (instead of prompting to “Connect GitHub”).
- **`frontend/src/components/cli-join-tokens-card.tsx`**
  - Removed the terminal icon from the **“CLI install links”** section title.
  - Matched the visual height of the **“Create link”** button to adjacent form controls by applying `className="h-9"`.
  - Improved accessibility by adding `htmlFor="join-token-role"` to the **Role granted** `<Label>`.
  - Ensured the role `<SelectTrigger>` uses `id="join-token-role"` and has consistent height (`h-9`).
- **`frontend/src/components/settings/verified-domains-section.test.tsx`**
  - Added tests to verify domain verification controls keep consistent heights (`h-9` for input + “Add domain” button).
  - Added a test covering the GitHub auto-join messaging when connected but no org installation is available.
- **`frontend/src/components/cli-join-tokens-card.test.tsx`**
  - Updated/added coverage for the CLI install links card behavior, including the new CLI install links card test.

## Test plan
- `npm test -- --run src/components/settings/verified-domains-section.test.tsx`
- `npm test -- --run src/components/cli-join-tokens-card.test.tsx`
- `npm run typecheck`
- `npm run lint`
- `npm run build`

[143.dev](https://143.dev) | [session 01395e99](https://143.dev/sessions/01395e99-69eb-4089-b703-96e3f502afa9)

Preview: https://143.dev/previews/github/assembledhq/143/pull/1371