### PR TITLE
Move Settings “Updated by” timestamp to low-priority audit footer

### DIFF
--- a/frontend/src/app/(dashboard)/settings/page.test.tsx
+++ b/frontend/src/app/(dashboard)/settings/page.test.tsx
@@ -138,7 +138,7 @@ describe('SettingsPage', () => {
     });
   });
 
-  it('uses the audit activity row as the only updated timestamp', async () => {
+  it('uses a low-priority activity footer as the only updated timestamp', async () => {
     settingsGetMock.mockResolvedValue({
       data: {
         id: 'org-1',
@@ -163,7 +163,8 @@ describe('SettingsPage', () => {
 
     renderWithProviders(<SettingsPage />);
 
-    expect(await screen.findByText(/Updated .* ago by System/)).toBeInTheDocument();
+    expect(await screen.findByText(/Last activity:/)).toBeInTheDocument();
+    expect(screen.getByText(/Updated .* ago by System/)).toBeInTheDocument();
     expect(screen.queryByText(/Updated at .*May 1, 2026.*12:00 PM UTC/)).not.toBeInTheDocument();
   });
 

--- a/frontend/src/app/(dashboard)/settings/page.tsx
+++ b/frontend/src/app/(dashboard)/settings/page.tsx
@@ -140,10 +140,6 @@ export default function SettingsPage() {
           title="General settings"
           description="Manage your organization."
         />
-        <AuditLogTrigger
-          filters={{ resource_type: "settings" }}
-          title="Settings activity"
-        />
 
         <section className="space-y-3">
           <div className="flex items-center justify-between">
@@ -167,6 +163,12 @@ export default function SettingsPage() {
         </section>
 
         {user?.role === "admin" && <PRAuthorshipSettings />}
+
+        <AuditLogTrigger
+          filters={{ resource_type: "settings" }}
+          title="Settings activity"
+          variant="footer"
+        />
       </div>
     </PageContainer>
   );

--- a/frontend/src/app/(dashboard)/settings/team/page.test.tsx
+++ b/frontend/src/app/(dashboard)/settings/team/page.test.tsx
@@ -11,6 +11,7 @@ const {
   revokeInvitationMock,
   githubInviteStatusMock,
   searchGitHubUsersMock,
+  auditLogsListMock,
   currentUserMock,
 } = vi.hoisted(() => ({
   listMembersMock: vi.fn().mockResolvedValue({
@@ -57,6 +58,7 @@ const {
   revokeInvitationMock: vi.fn().mockResolvedValue(undefined),
   githubInviteStatusMock: vi.fn().mockResolvedValue({ data: { connected: false } }),
   searchGitHubUsersMock: vi.fn().mockResolvedValue({ data: [], meta: {} }),
+  auditLogsListMock: vi.fn().mockResolvedValue({ data: [], meta: {} }),
   currentUserMock: {
     id: 'user-1',
     email: 'admin@example.com',
@@ -80,6 +82,9 @@ vi.mock('@/lib/api', () => ({
     auth: {
       me: vi.fn().mockResolvedValue({ data: { id: 'user-1', email: 'admin@example.com', name: 'Admin User', role: 'admin' } }),
     },
+    auditLogs: {
+      list: auditLogsListMock,
+    },
   },
 }));
 
@@ -100,6 +105,8 @@ describe('TeamSettingsPage', () => {
     revokeInvitationMock.mockClear();
     githubInviteStatusMock.mockClear();
     searchGitHubUsersMock.mockClear();
+    auditLogsListMock.mockReset();
+    auditLogsListMock.mockResolvedValue({ data: [], meta: {} });
     currentUserMock.id = 'user-1';
     currentUserMock.email = 'admin@example.com';
     currentUserMock.name = 'Admin User';
@@ -116,6 +123,27 @@ describe('TeamSettingsPage', () => {
     expect(screen.getByText('Member User')).toBeInTheDocument();
     expect(screen.getByText('admin@example.com')).toBeInTheDocument();
     expect(screen.getByText('member@example.com')).toBeInTheDocument();
+  });
+
+  it('renders team activity as a low-priority footer', async () => {
+    auditLogsListMock.mockResolvedValue({
+      data: [{
+        id: 'audit-team-1',
+        org_id: 'org-1',
+        actor_type: 'user',
+        actor_id: 'user-1',
+        user_id: 'user-1',
+        action: 'team.member.role_changed',
+        resource_type: 'team_member',
+        created_at: new Date(Date.now() - 3 * 60000).toISOString(),
+      }],
+      meta: {},
+    });
+
+    renderWithProviders(<TeamSettingsPage />);
+
+    expect(await screen.findByText(/Last activity:/)).toBeInTheDocument();
+    expect(screen.getByText(/Updated .* ago by Admin User/)).toBeInTheDocument();
   });
 
   it('renders the members in list format with column headers', async () => {

--- a/frontend/src/app/(dashboard)/settings/team/page.tsx
+++ b/frontend/src/app/(dashboard)/settings/team/page.tsx
@@ -294,11 +294,6 @@ export default function TeamSettingsPage() {
           title="Team"
           description="Manage your team members and roles."
         />
-        <AuditLogTrigger
-          filters={{ resource_type: "team_member" }}
-          members={members}
-          title="Team activity"
-        />
       {actionError && (
         <div className="rounded-md bg-destructive/10 px-3 py-2 text-xs text-destructive">
           {actionError}
@@ -520,6 +515,13 @@ export default function TeamSettingsPage() {
 
       {/* CLI install links (admin-only: creating one hands out membership) */}
       {canManageTeam && <CLIJoinTokensCard />}
+
+      <AuditLogTrigger
+        filters={{ resource_type: "team_member" }}
+        members={members}
+        title="Team activity"
+        variant="footer"
+      />
 
       {/* Invite Member Dialog */}
       {canManageTeam && (

--- a/frontend/src/components/audit/audit-log-trigger.test.tsx
+++ b/frontend/src/components/audit/audit-log-trigger.test.tsx
@@ -97,6 +97,31 @@ describe('AuditLogTrigger', () => {
     expect(container.querySelector('svg')).toBeNull();
   });
 
+  it('footer variant: renders as low-priority last activity text', async () => {
+    auditLogListMock.mockResolvedValue({
+      data: [{
+        id: 'audit-footer',
+        actor_type: 'user',
+        user_id: 'user-1',
+        action: 'settings.updated',
+        created_at: new Date(Date.now() - 2 * 60000).toISOString(),
+      }],
+      meta: {},
+    });
+
+    const { container } = renderWithProviders(
+      <AuditLogTrigger filters={{ resource_type: 'settings' }} members={mockMembers} variant="footer" />
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText(/Last activity:/)).toBeInTheDocument();
+      expect(screen.getByText(/Updated.*ago by Alice/)).toBeInTheDocument();
+    });
+
+    expect(container.querySelector('footer')).not.toBeNull();
+    expect(container.querySelector('svg')).not.toBeNull();
+  });
+
   it('default variant: renders the Clock icon and no separator', async () => {
     auditLogListMock.mockResolvedValue({
       data: [{

--- a/frontend/src/components/audit/audit-log-trigger.tsx
+++ b/frontend/src/components/audit/audit-log-trigger.tsx
@@ -23,8 +23,9 @@ interface AuditLogTriggerProps {
    * - `default`: standalone row with a leading Clock icon.
    * - `inline`: drops the icon, adds a leading middle-dot separator, and removes
    *   horizontal padding so the trigger reads as part of a surrounding sentence.
+   * - `footer`: muted page footer for low-priority settings activity metadata.
    */
-  variant?: "default" | "inline";
+  variant?: "default" | "inline" | "footer";
 }
 
 export function AuditLogTrigger({ filters, members: membersProp, title, variant = "default" }: AuditLogTriggerProps) {
@@ -69,6 +70,33 @@ export function AuditLogTrigger({ filters, members: membersProp, title, variant 
   })();
 
   const isInline = variant === "inline";
+  const isFooter = variant === "footer";
+
+  if (isFooter) {
+    return (
+      <footer className="flex border-t border-border/60 pt-4 text-xs text-muted-foreground">
+        <Button
+          variant="ghost"
+          size="xs"
+          onClick={() => setOpen(true)}
+          className="inline-flex h-auto items-center gap-1.5 px-1 py-0.5 text-xs font-normal text-muted-foreground transition-colors hover:text-foreground"
+        >
+          <Clock className="h-3 w-3" />
+          <span className="text-xs">Last activity:</span>
+          <span className="text-xs">
+            Updated {formatTimeAgo(latestEntry.created_at)} by {actorName}
+          </span>
+        </Button>
+        <AuditLogSidesheet
+          open={open}
+          onOpenChange={setOpen}
+          filters={filters}
+          title={title}
+          members={members}
+        />
+      </footer>
+    );
+  }
 
   return (
     <>


### PR DESCRIPTION
## Summary
Updated the Settings pages to render the “Settings activity” audit trigger in a low-priority footer, so the “Updated by” timestamp consistently reflects the intended activity source. Adjusted/extended the related tests to assert the new timestamp behavior.

## Changes
- `frontend/src/app/(dashboard)/settings/page.tsx`
  - Moved `<AuditLogTrigger ... />` to render with `variant="footer"` (from the main body) to ensure its activity is used as the only “updated” timestamp.
- `frontend/src/app/(dashboard)/settings/page.test.tsx`
  - Updated expectations:
    - Assert presence of the “Last activity:” footer text.
    - Keep asserting “Updated ... ago by System” is shown.
    - Ensure the prior “Updated at ...” text is not shown.
- `frontend/src/app/(dashboard)/settings/team/page.tsx`
  - Updated to support/align with the new low-priority footer audit rendering behavior (audit logs data mocked accordingly).
- `frontend/src/app/(dashboard)/settings/team/page.test.tsx`
  - Added `auditLogsListMock` and assertions to verify team activity appears as a low-priority footer.
- `frontend/src/components/audit/audit-log-trigger.tsx`
  - Adjusted logic to support the `variant="footer"` behavior for how the updated timestamp is derived/shown.
- `frontend/src/components/audit/audit-log-trigger.test.tsx`
  - Updated test coverage to match the new footer-based timestamp behavior.

## Test plan
- Ran the frontend unit tests for the updated pages/components (`settings` and `audit-log-trigger` test suites). No other test runs were required beyond these behavior and assertion updates.

[143.dev](https://143.dev) | [session 8bf8a847](https://143.dev/sessions/8bf8a847-6941-49a3-bb47-429994ad7938)

Preview: https://143.dev/previews/github/assembledhq/143/pull/1372