### PR TITLE
Fix previews index 500 (ambiguous status column) and stop the /previews loading/empty flicker

### DIFF
--- a/frontend/src/app/(dashboard)/previews/page.test.tsx
+++ b/frontend/src/app/(dashboard)/previews/page.test.tsx
@@ -266,6 +266,87 @@ describe("PreviewsPage", () => {
     ).toHaveAttribute("href", "/previews/new");
   });
 
+  it("shows a stable per-section error state instead of the empty state when the list API fails", async () => {
+    server.use(
+      http.get("*/api/v1/repositories", () =>
+        HttpResponse.json({ data: repositories, meta: {} }),
+      ),
+      http.get("*/api/v1/previews", () =>
+        HttpResponse.json(
+          {
+            error: {
+              code: "PREVIEW_LIST_FAILED",
+              message: "failed to count previews",
+            },
+          },
+          { status: 500 },
+        ),
+      ),
+    );
+
+    renderWithProviders(<PreviewsPage />);
+
+    expect(await screen.findAllByText("Failed to load previews.")).toHaveLength(
+      3,
+    );
+    expect(screen.queryByText("No previews yet")).not.toBeInTheDocument();
+    expect(screen.queryByText("Loading previews...")).not.toBeInTheDocument();
+
+    // Once the backend recovers, a manual retry repopulates the sections.
+    installPreviewHandlers({
+      running: [preview({ branch: "feature/recovered" })],
+      resumable: [],
+      recent: [],
+    });
+    await userEvent.click(screen.getAllByRole("button", { name: /retry/i })[0]);
+    expect(await screen.findAllByText("feature/recovered")).toHaveLength(2);
+  });
+
+  it("keeps previously loaded rows visible when interval refetches start failing", async () => {
+    let failing = false;
+    const failedRequests: string[] = [];
+    server.use(
+      http.get("*/api/v1/repositories", () =>
+        HttpResponse.json({ data: repositories, meta: {} }),
+      ),
+      http.get("*/api/v1/previews", ({ request }) => {
+        const url = new URL(request.url);
+        if (failing) {
+          failedRequests.push(url.search);
+          return HttpResponse.json(
+            {
+              error: {
+                code: "PREVIEW_LIST_FAILED",
+                message: "failed to count previews",
+              },
+            },
+            { status: 500 },
+          );
+        }
+        const scope = url.searchParams.get("scope");
+        return HttpResponse.json({
+          data:
+            scope === "running"
+              ? [preview({ branch: "feature/sticky-rows" })]
+              : [],
+          meta,
+        });
+      }),
+    );
+
+    renderWithProviders(<PreviewsPage />);
+    expect(await screen.findAllByText("feature/sticky-rows")).toHaveLength(2);
+
+    failing = true;
+    // Two failed polls guarantee the first error has settled into the query
+    // cache; stale rows must survive it rather than yield to an error card.
+    await waitFor(() => expect(failedRequests.length).toBeGreaterThanOrEqual(2));
+    expect(screen.getAllByText("feature/sticky-rows")).toHaveLength(2);
+    expect(
+      screen.queryByText("Failed to load previews."),
+    ).not.toBeInTheDocument();
+  });
+
   it("keeps mobile stacked row metadata available alongside the desktop table", async () => {
     installPreviewHandlers({
       running: [],

--- a/frontend/src/app/(dashboard)/previews/page.tsx
+++ b/frontend/src/app/(dashboard)/previews/page.tsx
@@ -129,6 +129,8 @@ function SectionRows({
   scope,
   previews,
   isLoading,
+  isError,
+  onRetry,
   canMutate,
   onStop,
   onRestart,
@@ -137,11 +139,27 @@ function SectionRows({
   scope: PreviewScope;
   previews: BranchPreviewResponse[];
   isLoading: boolean;
+  isError: boolean;
+  onRetry: () => void;
   canMutate: boolean;
   onStop: (preview: BranchPreviewResponse) => void;
   onRestart: (preview: BranchPreviewResponse) => void;
   onStartLatest: (preview: BranchPreviewResponse) => void;
 }) {
+  if (isError) {
+    return (
+      <Card>
+        <CardContent className="flex items-center justify-between gap-2 py-5 text-sm">
+          <span className="text-destructive">Failed to load previews.</span>
+          <Button size="sm" variant="outline" onClick={onRetry}>
+            <RotateCw className="h-4 w-4" />
+            Retry
+          </Button>
+        </CardContent>
+      </Card>
+    );
+  }
+
   if (isLoading) {
     return (
       <Card>
@@ -429,8 +447,20 @@ export default function PreviewsPage() {
   const sectionQueries = [runningQuery, resumableQuery, recentQuery];
 
   const firstMeta = sectionQueries.find((item) => item.data?.meta)?.data?.meta;
+  // A query that has only ever errored holds no data, and React Query resets
+  // no-data queries to pending (clearing the error) on every interval refetch.
+  // isError alone would therefore blink off for the duration of each poll —
+  // treat "errored and still no data" as a stable failed state instead.
+  // Sections that already hold rows keep showing them through refetch
+  // failures: stale-but-real previews beat an error card, and the poll loop
+  // refreshes them as soon as the backend recovers.
+  const sectionFailed = (query: (typeof sectionQueries)[number]) =>
+    query.data === undefined && (query.isError || query.errorUpdateCount > 0);
+  // Only successfully settled, genuinely empty sections count toward the
+  // page-level empty state; loading or failed sections must not flip the page
+  // to "No previews yet".
   const allEmpty = sectionQueries.every(
-    (item) => !item.isLoading && (item.data?.data.length ?? 0) === 0,
+    (item) => item.data !== undefined && item.data.data.length === 0,
   );
   const repositories = useMemo(
     () => repositoriesQuery.data?.data ?? [],
@@ -568,7 +598,9 @@ export default function PreviewsPage() {
                   <SectionRows
                     scope={section.scope}
                     previews={section.scope === "recent" ? recentPreviews : (sectionQuery.data?.data ?? [])}
-                    isLoading={sectionQuery.isLoading}
+                    isLoading={sectionQuery.isLoading && !sectionFailed(sectionQuery)}
+                    isError={sectionFailed(sectionQuery)}
+                    onRetry={() => sectionQuery.refetch()}
                     canMutate={canMutate}
                     onStop={(preview) => stopPreview.mutate(preview)}
                     onRestart={(preview) => restartPreview.mutate(preview)}

--- a/internal/db/preview_store.go
+++ b/internal/db/preview_store.go
@@ -413,9 +413,9 @@ func (s *PreviewStore) CountBranchPreviewIndexScopes(ctx context.Context, orgID 
 			       OR (regexp_match(target.source_id, '#([0-9]+)(@|$)'))[1] = regexp_replace(@q, '^#', ''))
 		)
 		SELECT
-			COUNT(*) FILTER (WHERE status IN %s)::int AS running,
+			COUNT(*) FILTER (WHERE latest.status IN %s)::int AS running,
 			COUNT(*) FILTER (WHERE %s)::int AS resumable,
-			COUNT(*) FILTER (WHERE status IN %s AND NOT %s AND created_at >= now() - interval '7 days')::int AS recent
+			COUNT(*) FILTER (WHERE latest.status IN %s AND NOT %s AND latest.created_at >= now() - interval '7 days')::int AS recent
 		FROM latest_targets target
 		LEFT JOIN LATERAL (SELECT target.status, target.created_at) latest ON TRUE`, activeStatusFilter, branchPreviewResumablePredicate, terminalStatusFilter, branchPreviewResumablePredicate)
 	var running, resumable, recent int

--- a/internal/integration/preview_index_test.go
+++ b/internal/integration/preview_index_test.go
@@ -1,0 +1,128 @@
+//go:build integration
+
+package integration
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/stretchr/testify/require"
+
+	"github.com/assembledhq/143/internal/db"
+	"github.com/assembledhq/143/internal/models"
+)
+
+// seedRepository inserts the integrations → repositories FK chain that
+// preview targets hang off. Raw SQL keeps the test independent of the GitHub
+// sync path that normally creates these rows.
+func seedRepository(t *testing.T, pool *pgxpool.Pool, orgID uuid.UUID, fullName string) uuid.UUID {
+	t.Helper()
+	var integrationID uuid.UUID
+	err := pool.QueryRow(context.Background(), `
+		INSERT INTO integrations (org_id, provider)
+		VALUES ($1, 'github')
+		RETURNING id
+	`, orgID).Scan(&integrationID)
+	require.NoError(t, err, "seed integration")
+
+	var repoID uuid.UUID
+	err = pool.QueryRow(context.Background(), `
+		INSERT INTO repositories (org_id, integration_id, github_id, full_name, clone_url, installation_id)
+		VALUES ($1, $2, $3, $4, $5, 1)
+		RETURNING id
+	`, orgID, integrationID, time.Now().UnixNano(), fullName,
+		fmt.Sprintf("https://github.com/%s.git", fullName)).Scan(&repoID)
+	require.NoError(t, err, "seed repository")
+	return repoID
+}
+
+// seedPreviewTargetWithInstance creates a preview target plus one runtime
+// attempt in the given status, mirroring what the branch preview launch path
+// persists.
+func seedPreviewTargetWithInstance(t *testing.T, store *db.PreviewStore, orgID, repoID, userID uuid.UUID, branch string, sourceType models.PreviewSourceType, sourceID string, status models.PreviewStatus) models.PreviewTarget {
+	t.Helper()
+	target := models.PreviewTarget{
+		OrgID:           orgID,
+		RepositoryID:    repoID,
+		Branch:          branch,
+		CommitSHA:       "abc123" + branch,
+		SourceType:      sourceType,
+		SourceID:        sourceID,
+		CreatedByUserID: userID,
+	}
+	require.NoError(t, store.CreatePreviewTarget(context.Background(), &target), "seed preview target")
+
+	instance := models.PreviewInstance{
+		PreviewTargetID: &target.ID,
+		OrgID:           orgID,
+		UserID:          userID,
+		ProfileName:     "bootstrap",
+		Status:          status,
+		Provider:        "docker",
+		ExpiresAt:       time.Now().Add(30 * time.Minute),
+		LastPath:        "/",
+		MemoryLimitMB:   512,
+		CPULimitMillis:  500,
+		DiskLimitMB:     10240,
+	}
+	require.NoError(t, store.CreateBranchPreviewInstance(context.Background(), &instance), "seed preview instance")
+	return target
+}
+
+// TestIntegration_PreviewIndex_ListAndCountScopes executes the previews index
+// list + scope-count SQL against real Postgres. The previews page polls both
+// queries every few seconds, so a SQL-level regression here takes the whole
+// /previews page down (it renders the 500 as an empty/loading flicker).
+// pgxmock unit tests cannot catch errors Postgres raises at plan time — this
+// suite exists precisely for bugs like the ambiguous "status" column reference
+// (SQLSTATE 42702) that shipped in the original count query.
+func TestIntegration_PreviewIndex_ListAndCountScopes(t *testing.T) {
+	pool := setup(t)
+
+	orgID := seedOrg(t, pool)
+	user := seedUser(t, pool, orgID)
+	repoID := seedRepository(t, pool, orgID, "acme/app")
+	store := db.NewPreviewStore(pool)
+
+	running := seedPreviewTargetWithInstance(t, store, orgID, repoID, user.ID,
+		"feature-running", models.PreviewSourceTypePullRequest, "acme/app#42@abc123", models.PreviewStatusReady)
+	stopped := seedPreviewTargetWithInstance(t, store, orgID, repoID, user.ID,
+		"feature-stopped", models.PreviewSourceTypeManual, "", models.PreviewStatusStopped)
+
+	scopeWant := map[string][]uuid.UUID{
+		"":          {running.ID, stopped.ID},
+		"running":   {running.ID},
+		"resumable": {}, // stopped target has no warm snapshot cache entry
+		"recent":    {stopped.ID},
+	}
+	for scope, want := range scopeWant {
+		summaries, err := store.ListBranchPreviewIndex(context.Background(), orgID, db.BranchPreviewIndexFilters{
+			Scope: scope,
+			Limit: 20,
+		})
+		require.NoError(t, err, "ListBranchPreviewIndex scope=%q", scope)
+		got := make([]uuid.UUID, 0, len(summaries))
+		for _, summary := range summaries {
+			got = append(got, summary.TargetID)
+		}
+		require.ElementsMatch(t, want, got, "scope=%q should return exactly the seeded targets in it", scope)
+	}
+
+	// The q filter has its own SQL surface (ILIKE branches plus the PR-number
+	// regexp on source_id) — execute it for real too.
+	byPRNumber, err := store.ListBranchPreviewIndex(context.Background(), orgID, db.BranchPreviewIndexFilters{
+		Query: "#42",
+		Limit: 20,
+	})
+	require.NoError(t, err, "ListBranchPreviewIndex with PR-number query")
+	require.Len(t, byPRNumber, 1, "q=#42 should match only the PR-sourced target")
+	require.Equal(t, running.ID, byPRNumber[0].TargetID)
+
+	counts, err := store.CountBranchPreviewIndexScopes(context.Background(), orgID, db.BranchPreviewIndexFilters{})
+	require.NoError(t, err, "CountBranchPreviewIndexScopes")
+	require.Equal(t, map[string]int{"running": 1, "resumable": 0, "recent": 1}, counts)
+}


### PR DESCRIPTION
## What

- **Backend:** qualify `latest.status` / `latest.created_at` in `CountBranchPreviewIndexScopes` (`internal/db/preview_store.go`). The count query joins the `latest_targets` CTE with a lateral alias that re-exposes the same column names, so the unqualified `COUNT(*) FILTER` references fail with `SQLSTATE 42702 (column reference "status" is ambiguous)`.
- **Frontend:** render preview list failures as a stable per-section "Failed to load previews." card with a Retry button instead of flip-flopping. Sections that already hold rows keep showing them through refetch failures; only successfully settled empty responses trigger the page-level "No previews yet" state.
- **Tests:** new `internal/integration/preview_index_test.go` runs `ListBranchPreviewIndex` (all scopes plus the PR-number search path) and `CountBranchPreviewIndexScopes` against real Postgres, plus two new jsdom tests for the error card/retry and stale-rows behavior.

## Why

Every `/api/v1/previews` request in prod has been 500ing since the previews index shipped (`make logs-query Q='previews'` shows `PREVIEW_LIST_FAILED ... column reference "status" is ambiguous` on every call). The visible symptom was the `/previews` page flipping between "Loading previews..." and "No previews yet" every few seconds: React Query resets a no-data errored query to `pending` (clearing the error) on each interval refetch, and the page treated errored sections as empty — so a hard outage masqueraded as an empty/loading flicker.

The SQL bug passed CI because the store tests use pgxmock, which never executes the query; the integration test fails with the exact prod error against the old query and is the regression guard for this class of bug.

## Reviewer notes

- The backend deploy is what stops the flipping; the frontend change is defense-in-depth so an API failure can never masquerade as "no previews" again.
- `sectionFailed` uses `data === undefined && (isError || errorUpdateCount > 0)` rather than `isError` alone — `errorUpdateCount` survives React Query's pending-reset between failing polls, which is what keeps the error card stable.
- Verified end to end against a live dev server with a mock backend toggled between healthy and 500: stable error cards mid-outage, stale rows persist when data was already loaded, and all sections self-heal on their next poll once the backend recovers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
