### PR TITLE
Fix Claude subscription race: cross-host advisory lock + stale-grant retry

### DIFF
--- a/internal/db/coding_credentials.go
+++ b/internal/db/coding_credentials.go
@@ -1397,6 +1397,53 @@ func sameUUIDSet(a, b []uuid.UUID) bool {
 	return len(seen) == 0
 }
 
+// WithRefreshLock runs fn while holding a per-credential Postgres advisory
+// lock, serializing OAuth token refreshes across processes and hosts.
+// Subscription refresh tokens (Anthropic, OpenAI) are single-use: two hosts
+// refreshing the same credential concurrently make the loser's grant look
+// revoked, and the loser would then invalidate an otherwise healthy
+// credential. An in-process mutex can't prevent that; this lock can.
+//
+// The lock is transaction-scoped and the transaction does nothing else — fn
+// performs its reads/writes on ordinary pool connections, which the advisory
+// lock doesn't block. fn typically spans one HTTPS round-trip to the token
+// endpoint, so the transaction is held for a few seconds at most, bounded by
+// the caller's HTTP client timeout. fn's error is returned unwrapped so
+// callers' errors.Is/message checks see exactly what fn produced.
+//
+// Pool note: each in-flight call pins one pool connection for the lock while
+// fn acquires more for its own queries. Concurrency is bounded by the number
+// of distinct credentials refreshing at once (small — refreshes happen at
+// ~8h token expiry), but keep that 2x footprint in mind before reusing this
+// for anything high-frequency.
+//
+// lint:allow-no-orgid reason="advisory lock keyed by credential ID only; it reads/writes no rows — scope is enforced by every store call fn makes while holding it"
+func (s *CodingCredentialStore) WithRefreshLock(ctx context.Context, credID uuid.UUID, fn func(ctx context.Context) error) error {
+	tx, err := s.beginTx(ctx)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback(ctx) //nolint:errcheck
+
+	if _, err := tx.Exec(ctx,
+		`SELECT pg_advisory_xact_lock(hashtextextended($1, 0))`,
+		"coding_credential_refresh:"+credID.String(),
+	); err != nil {
+		return fmt.Errorf("acquire refresh lock: %w", err)
+	}
+
+	if err := fn(ctx); err != nil {
+		return err
+	}
+	// The transaction holds only the advisory lock — fn's writes are already
+	// durable on other connections. A commit failure here must not surface as
+	// a refresh failure (the caller could react by invalidating a credential
+	// that was in fact refreshed); the lock dies with the connection either
+	// way, and the deferred Rollback covers cleanup.
+	_ = tx.Commit(ctx)
+	return nil
+}
+
 // withScopeLock acquires a per-scope advisory lock to serialize stack-priority
 // updates inside the surrounding transaction. Without it, concurrent Create,
 // Reorder, and Move calls could compute from stale priorities and emit

--- a/internal/db/coding_credentials_test.go
+++ b/internal/db/coding_credentials_test.go
@@ -2,6 +2,7 @@ package db
 
 import (
 	"context"
+	"errors"
 	"math/rand/v2"
 	"sync"
 	"testing"
@@ -1322,4 +1323,65 @@ func TestMoveCodingCredentialInputValidate(t *testing.T) {
 			t.Errorf("%s: expected error, got nil", tc.name)
 		}
 	}
+}
+
+func TestWithRefreshLockRunsFnUnderAdvisoryLock(t *testing.T) {
+	t.Parallel()
+	store, mock := newMockCodingCredentialStore(t)
+	defer mock.Close()
+
+	mock.ExpectBegin()
+	mock.ExpectExec("pg_advisory_xact_lock").
+		WithArgs(codingAnyArgs(1)...).
+		WillReturnResult(pgxmock.NewResult("SELECT", 1))
+	mock.ExpectCommit()
+
+	ran := false
+	err := store.WithRefreshLock(context.Background(), uuid.New(), func(ctx context.Context) error {
+		ran = true
+		return nil
+	})
+	require.NoError(t, err, "WithRefreshLock should succeed when fn succeeds")
+	require.True(t, ran, "fn should run while the advisory lock is held")
+	require.NoError(t, mock.ExpectationsWereMet(), "lock should be taken inside a committed transaction")
+}
+
+func TestWithRefreshLockReturnsFnErrorUnwrapped(t *testing.T) {
+	t.Parallel()
+	store, mock := newMockCodingCredentialStore(t)
+	defer mock.Close()
+
+	mock.ExpectBegin()
+	mock.ExpectExec("pg_advisory_xact_lock").
+		WithArgs(codingAnyArgs(1)...).
+		WillReturnResult(pgxmock.NewResult("SELECT", 1))
+	mock.ExpectRollback()
+
+	sentinel := errors.New("refresh token revoked (status 401)")
+	err := store.WithRefreshLock(context.Background(), uuid.New(), func(ctx context.Context) error {
+		return sentinel
+	})
+	require.ErrorIs(t, err, sentinel, "fn errors must pass through unwrapped so callers' errors.Is checks still work")
+	require.NoError(t, mock.ExpectationsWereMet(), "a failed fn should roll the lock transaction back")
+}
+
+func TestWithRefreshLockSwallowsCommitError(t *testing.T) {
+	t.Parallel()
+	store, mock := newMockCodingCredentialStore(t)
+	defer mock.Close()
+
+	mock.ExpectBegin()
+	mock.ExpectExec("pg_advisory_xact_lock").
+		WithArgs(codingAnyArgs(1)...).
+		WillReturnResult(pgxmock.NewResult("SELECT", 1))
+	mock.ExpectCommit().WillReturnError(errors.New("connection reset"))
+	mock.ExpectRollback()
+
+	// fn's writes land on other connections, so a commit failure on the
+	// lock-only transaction must not surface as a refresh failure — the
+	// caller could react by invalidating a credential that was refreshed.
+	err := store.WithRefreshLock(context.Background(), uuid.New(), func(ctx context.Context) error {
+		return nil
+	})
+	require.NoError(t, err, "commit failure on the lock-only transaction should be swallowed")
 }

--- a/internal/db/scoped_credential_store.go
+++ b/internal/db/scoped_credential_store.go
@@ -160,6 +160,15 @@ func (s *ScopedCredentialStore) UpdateStatusByID(ctx context.Context, scope mode
 	return s.coding.UpdateStatus(ctx, scope, id, status)
 }
 
+// WithRefreshLock serializes OAuth token refreshes for one credential across
+// processes via the unified store's Postgres advisory lock. Satisfies the
+// auth services' optional RefreshLocker interface.
+//
+// lint:allow-no-orgid reason="advisory lock keyed by credential ID only; it reads/writes no rows — scope is enforced by every store call fn makes while holding it"
+func (s *ScopedCredentialStore) WithRefreshLock(ctx context.Context, credID uuid.UUID, fn func(ctx context.Context) error) error {
+	return s.coding.WithRefreshLock(ctx, credID, fn)
+}
+
 // ExistsForProviderByID is used by Disconnect to verify an id belongs to the
 // caller's scope before disabling. Includes disabled rows to distinguish
 // "not yours" from "already disconnected".

--- a/internal/services/agent/orchestrator.go
+++ b/internal/services/agent/orchestrator.go
@@ -300,6 +300,16 @@ type ClaudeCodeAuthTokenStore interface {
 	StoreTokenByID(ctx context.Context, scope models.Scope, credID uuid.UUID, sub models.AnthropicSubscription) (bool, error)
 }
 
+// ClaudeCodeInvalidSubscriptionProber reports whether a scope holds a Claude
+// subscription row that has been marked invalid (e.g. after Anthropic
+// rejected its token refresh). Optionally implemented by the auth provider;
+// the orchestrator uses it to fail a run with "your subscription was
+// invalidated — reconnect it" instead of the misleading "no credentials are
+// configured" when credential rows exist but none is usable.
+type ClaudeCodeInvalidSubscriptionProber interface {
+	HasInvalidSubscription(ctx context.Context, scope models.Scope) (bool, error)
+}
+
 // CredentialProvider abstracts retrieving org-scoped provider credentials.
 type CredentialProvider interface {
 	Get(ctx context.Context, orgID uuid.UUID, provider models.ProviderName) (*models.DecryptedCredential, error)
@@ -6075,6 +6085,22 @@ func (o *Orchestrator) ensureClaudeCodeAuth(ctx context.Context, run *models.Ses
 		return TokenBillingModeUnknown, fmt.Errorf("prepare claude code API-key fallback: %w", fallbackErr)
 	}
 
+	// Distinguish "never connected anything" from "a subscription exists but
+	// was invalidated" — telling a user who DID connect a subscription that
+	// no credentials are configured sends them hunting in the wrong place.
+	if o.claudeCodeInvalidSubscriptionExists(ctx, run) {
+		o.failRunWithCategory(ctx, run,
+			"claude subscription is marked invalid; reconnect required",
+			FailureCategoryClaudeCodeAuth,
+			"Your Claude subscription is no longer valid (its token was rejected or revoked), so it was removed from rotation. Reconnect it from the Agent settings page to continue.",
+			[]string{
+				"Reconnect your Claude subscription from the Agent settings page",
+				"Or add an Anthropic API key under Credentials",
+			},
+		)
+		return TokenBillingModeUnknown, fmt.Errorf("claude subscription invalid for claude code agent")
+	}
+
 	o.failRunWithCategory(ctx, run,
 		"no credentials configured for Claude Code: connect a Claude subscription or add an Anthropic API key",
 		FailureCategoryClaudeCodeAuth,
@@ -6085,6 +6111,36 @@ func (o *Orchestrator) ensureClaudeCodeAuth(ctx context.Context, run *models.Ses
 		},
 	)
 	return TokenBillingModeUnknown, fmt.Errorf("no credentials for claude code agent")
+}
+
+// claudeCodeInvalidSubscriptionExists probes whether the run's org (or the
+// triggering user's personal stack) holds a Claude subscription that has been
+// marked invalid. Best-effort: probe errors fall back to the generic
+// missing-credentials failure rather than blocking the run's error path.
+func (o *Orchestrator) claudeCodeInvalidSubscriptionExists(ctx context.Context, run *models.Session) bool {
+	prober, ok := o.claudeCodeAuth.(ClaudeCodeInvalidSubscriptionProber)
+	if !ok {
+		return false
+	}
+	scopes := []models.Scope{{OrgID: run.OrgID}}
+	if run.TriggeredByUserID != nil {
+		scopes = append(scopes, models.Scope{OrgID: run.OrgID, UserID: run.TriggeredByUserID})
+	}
+	for _, scope := range scopes {
+		invalid, err := prober.HasInvalidSubscription(ctx, scope)
+		if err != nil {
+			o.logger.Warn().
+				Err(err).
+				Str("org_id", run.OrgID.String()).
+				Str("session_id", run.ID.String()).
+				Msg("invalid-subscription probe failed; reporting generic missing-credentials failure")
+			continue
+		}
+		if invalid {
+			return true
+		}
+	}
+	return false
 }
 
 var errClaudeCodeFallbackUnavailable = errors.New("claude code API-key fallback unavailable")

--- a/internal/services/agent/orchestrator_test.go
+++ b/internal/services/agent/orchestrator_test.go
@@ -236,11 +236,13 @@ func (m *mockCodingCredentialProvider) MarkAuthRejected(id uuid.UUID) {
 
 // mockClaudeCodeAuthProvider implements agent.ClaudeCodeAuthProvider.
 type mockClaudeCodeAuthProvider struct {
-	sub       *models.AnthropicSubscription
-	credID    *uuid.UUID
-	hasSub    bool
-	hasSubErr error
-	tokenErr  error
+	sub           *models.AnthropicSubscription
+	credID        *uuid.UUID
+	hasSub        bool
+	hasSubErr     error
+	tokenErr      error
+	invalidSub    bool
+	invalidSubErr error
 }
 
 func (m *mockClaudeCodeAuthProvider) HasActiveSubscription(ctx context.Context, orgID uuid.UUID) (bool, error) {
@@ -252,6 +254,10 @@ func (m *mockClaudeCodeAuthProvider) GetValidToken(ctx context.Context, orgID uu
 		return nil, nil, m.tokenErr
 	}
 	return m.sub, m.credID, nil
+}
+
+func (m *mockClaudeCodeAuthProvider) HasInvalidSubscription(ctx context.Context, scope models.Scope) (bool, error) {
+	return m.invalidSub, m.invalidSubErr
 }
 
 type mockCredentialProvider struct {
@@ -5765,6 +5771,55 @@ func TestRunAgent_NoAgentEnvForUnknownType(t *testing.T) {
 	failures := d.sessions.getFailureUpdates()
 	require.Len(t, failures, 1)
 	require.Equal(t, string(agent.FailureCategoryClaudeCodeAuth), failures[0].category)
+}
+
+func TestRunAgent_InvalidClaudeSubscriptionFailsWithReconnectMessage(t *testing.T) {
+	t.Parallel()
+
+	orgID := testOrg()
+	issue := testIssue(orgID)
+	run := testRun(orgID, issue.ID)
+
+	d := defaultDeps()
+	// No usable credential anywhere, but the org holds a Claude subscription
+	// row that was marked invalid after a rejected token refresh. The run
+	// must fail with the reconnect guidance, not the misleading "no
+	// credentials are configured".
+	d.creds = &mockCredentialProvider{}
+	d.claudeCodeAuth = &mockClaudeCodeAuthProvider{invalidSub: true}
+
+	orch := buildOrchestrator(d)
+	err := orch.RunAgent(context.Background(), run)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "claude subscription invalid for claude code agent")
+
+	failures := d.sessions.getFailureUpdates()
+	require.Len(t, failures, 1)
+	require.Equal(t, string(agent.FailureCategoryClaudeCodeAuth), failures[0].category)
+	require.Contains(t, failures[0].explanation, "no longer valid",
+		"the explanation should say the subscription was invalidated")
+	require.Contains(t, failures[0].explanation, "Reconnect",
+		"the explanation should tell the user to reconnect")
+	require.NotContains(t, failures[0].explanation, "No Claude Code credentials are configured",
+		"a user who connected a subscription must not be told nothing is configured")
+}
+
+func TestRunAgent_InvalidSubscriptionProbeErrorFallsBackToGenericFailure(t *testing.T) {
+	t.Parallel()
+
+	orgID := testOrg()
+	issue := testIssue(orgID)
+	run := testRun(orgID, issue.ID)
+
+	d := defaultDeps()
+	d.creds = &mockCredentialProvider{}
+	d.claudeCodeAuth = &mockClaudeCodeAuthProvider{invalidSubErr: errors.New("db down")}
+
+	orch := buildOrchestrator(d)
+	err := orch.RunAgent(context.Background(), run)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "no credentials for claude code agent",
+		"a failed probe should fall back to the generic missing-credentials failure")
 }
 
 func TestRunAgent_CodexUsesAuthJsonNotEnvVar(t *testing.T) {

--- a/internal/services/claudecodeauth/service.go
+++ b/internal/services/claudecodeauth/service.go
@@ -614,6 +614,38 @@ func (s *Service) credRefreshMu(credID uuid.UUID) *sync.Mutex {
 	return val.(*sync.Mutex)
 }
 
+// RefreshLocker is optionally implemented by the credential store to
+// serialize token refreshes across processes. The in-process refreshMu only
+// protects a single process; Anthropic refresh tokens are single-use, so two
+// worker hosts refreshing the same credential concurrently make the loser
+// look revoked (invalid_grant) and would nuke an otherwise healthy
+// credential. Production wires *db.ScopedCredentialStore, which implements
+// this via a Postgres advisory lock.
+type RefreshLocker interface {
+	WithRefreshLock(ctx context.Context, credID uuid.UUID, fn func(ctx context.Context) error) error
+}
+
+// maxRefreshAttempts bounds the refresh loop in refreshTokenLocked. A second
+// attempt happens only when Anthropic rejects the refresh token but the
+// stored token has rotated since this attempt loaded it — i.e. the rejection
+// is stale, not a revocation.
+const maxRefreshAttempts = 2
+
+// runUnderRefreshLocks runs fn while holding the per-credential in-process
+// mutex and, when the store supports it, the cross-host advisory lock. Every
+// writer of a credential's token material (refresh, harvest write-back) must
+// go through here so single-use refresh tokens are never double-spent.
+func (s *Service) runUnderRefreshLocks(ctx context.Context, credID uuid.UUID, fn func(ctx context.Context) error) error {
+	mu := s.credRefreshMu(credID)
+	mu.Lock()
+	defer mu.Unlock()
+
+	if locker, ok := s.credentials.(RefreshLocker); ok {
+		return locker.WithRefreshLock(ctx, credID, fn)
+	}
+	return fn(ctx)
+}
+
 // RefreshTokenByID refreshes an expired access token for a specific credential.
 //
 // Scope must match the credential's owner — personal credentials require a
@@ -621,114 +653,171 @@ func (s *Service) credRefreshMu(credID uuid.UUID) *sync.Mutex {
 // from the picked credential's UserID (orchestrator.go); the legacy
 // org-fallback GetValidToken path constructs an org scope.
 func (s *Service) RefreshTokenByID(ctx context.Context, scope models.Scope, credID uuid.UUID) (*models.AnthropicSubscription, error) {
-	mu := s.credRefreshMu(credID)
-	mu.Lock()
-	defer mu.Unlock()
-
-	cred, err := s.credentials.GetByID(ctx, scope, credID)
+	var refreshed *models.AnthropicSubscription
+	err := s.runUnderRefreshLocks(ctx, credID, func(ctx context.Context) error {
+		sub, err := s.refreshTokenLocked(ctx, scope, credID)
+		refreshed = sub
+		return err
+	})
 	if err != nil {
-		return nil, fmt.Errorf("get credential: %w", err)
+		return nil, err
 	}
+	return refreshed, nil
+}
 
-	cfg, ok := cred.Config.(models.AnthropicSubscriptionConfig)
-	if !ok {
-		return nil, fmt.Errorf("credential is not an Anthropic subscription")
+// refreshTokenLocked does the actual refresh. Callers must hold the
+// per-credential in-process mutex and, when the store supports it, the
+// cross-host refresh lock — the re-read at the top of the loop is what turns
+// "another refresher beat us" into a cheap early return instead of a
+// double-spend of the single-use refresh token.
+func (s *Service) refreshTokenLocked(ctx context.Context, scope models.Scope, credID uuid.UUID) (*models.AnthropicSubscription, error) {
+	for attempt := 1; ; attempt++ {
+		cred, err := s.credentials.GetByID(ctx, scope, credID)
+		if err != nil {
+			return nil, fmt.Errorf("get credential: %w", err)
+		}
+
+		cfg, ok := cred.Config.(models.AnthropicSubscriptionConfig)
+		if !ok {
+			return nil, fmt.Errorf("credential is not an Anthropic subscription")
+		}
+
+		sub := cfg.AsAnthropicSubscription()
+
+		// After acquiring the locks, check if another refresher (goroutine,
+		// host, or a sandbox-harvest write-back) already rotated the token.
+		if !sub.NeedsRefresh(refreshWindow) && sub.AccessToken != "" {
+			return &sub, nil
+		}
+
+		if sub.RefreshToken == "" {
+			return nil, fmt.Errorf("no refresh token available — user must re-authenticate")
+		}
+
+		statusCode, body, err := s.postRefresh(ctx, sub.RefreshToken)
+		if err != nil {
+			return nil, err
+		}
+
+		reused := isClaudeRefreshTokenReused(body)
+		rejected := statusCode == http.StatusUnauthorized || statusCode == http.StatusForbidden || isClaudeInvalidGrant(body)
+
+		// A reuse/rejection only proves the token we SENT is dead. If the
+		// stored token rotated while this request was in flight (a sandbox
+		// harvest or another writer landed), the verdict is stale — retry
+		// once with the rotated token before acting on it.
+		if (reused || rejected) && attempt < maxRefreshAttempts && s.storedRefreshTokenRotated(ctx, scope, credID, sub.RefreshToken) {
+			s.logger.Warn().
+				Str("cred_id", credID.String()).
+				Int("status", statusCode).
+				Int("attempt", attempt).
+				Msg("refresh verdict was for a stale refresh token; retrying with the rotated token")
+			continue
+		}
+
+		if reused {
+			s.logger.Warn().Str("cred_id", credID.String()).Msg("refresh token already used by another client; access token may still be valid")
+			return nil, fmt.Errorf("refresh token already used by another client")
+		}
+
+		if rejected {
+			s.markCredentialInvalid(ctx, scope, credID,
+				fmt.Sprintf("token endpoint rejected refresh (status %d): %s", statusCode, redactedBody(body)))
+			return nil, fmt.Errorf("refresh token revoked (status %d)", statusCode)
+		}
+
+		if statusCode != http.StatusOK {
+			return nil, fmt.Errorf("refresh failed (status %d): %s", statusCode, redactedBody(body))
+		}
+
+		var tokenResp tokenExchangeResponse
+		if err := json.Unmarshal(body, &tokenResp); err != nil {
+			return nil, fmt.Errorf("parse refresh response: %w", err)
+		}
+		if tokenResp.AccessToken == "" {
+			return nil, fmt.Errorf("refresh response returned empty access_token")
+		}
+
+		newSub := &models.AnthropicSubscription{
+			AccessToken:   tokenResp.AccessToken,
+			RefreshToken:  tokenResp.RefreshToken,
+			ExpiresAt:     time.Now().Add(time.Duration(tokenResp.ExpiresIn) * time.Second),
+			AccountType:   sub.AccountType,
+			RateLimitTier: sub.RateLimitTier,
+			Scopes:        sub.Scopes,
+		}
+		// If the refresh response carries a fresh scope string, prefer it so
+		// scope changes (e.g. an added scope) are reflected.
+		if refreshed := parseScopes(tokenResp.Scope); len(refreshed) > 0 {
+			newSub.Scopes = refreshed
+		}
+		// Anthropic's refresh sometimes returns an empty refresh_token string,
+		// meaning "keep the old one". Avoid clobbering the stored value in that
+		// case — otherwise the next refresh has nothing to send.
+		if newSub.RefreshToken == "" {
+			newSub.RefreshToken = sub.RefreshToken
+		}
+
+		if err := s.credentials.UpsertByID(ctx, scope, credID, models.FromAnthropicSubscription(*newSub)); err != nil {
+			return nil, fmt.Errorf("store refreshed credential: %w", err)
+		}
+
+		s.logger.Info().
+			Str("cred_id", credID.String()).
+			Msg("Claude Code OAuth token refreshed")
+
+		return newSub, nil
 	}
+}
 
-	sub := cfg.AsAnthropicSubscription()
-
-	// After acquiring the lock, check if another goroutine already refreshed.
-	if !sub.NeedsRefresh(refreshWindow) && sub.AccessToken != "" {
-		return &sub, nil
-	}
-
-	if sub.RefreshToken == "" {
-		return nil, fmt.Errorf("no refresh token available — user must re-authenticate")
-	}
-
+// postRefresh POSTs a refresh_token grant to the token endpoint and returns
+// the raw status + bounded body for the caller to classify.
+func (s *Service) postRefresh(ctx context.Context, refreshToken string) (int, []byte, error) {
 	reqBody, err := json.Marshal(map[string]string{
 		"grant_type":    refreshGrantType,
-		"refresh_token": sub.RefreshToken,
+		"refresh_token": refreshToken,
 		"client_id":     s.clientID,
 	})
 	if err != nil {
-		return nil, fmt.Errorf("marshal refresh request: %w", err)
+		return 0, nil, fmt.Errorf("marshal refresh request: %w", err)
 	}
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, s.tokenURL, bytes.NewReader(reqBody))
 	if err != nil {
-		return nil, fmt.Errorf("create refresh request: %w", err)
+		return 0, nil, fmt.Errorf("create refresh request: %w", err)
 	}
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Accept", "application/json")
 
 	resp, err := s.httpClient.Do(req)
 	if err != nil {
-		return nil, fmt.Errorf("refresh request: %w", err)
+		return 0, nil, fmt.Errorf("refresh request: %w", err)
 	}
 	defer resp.Body.Close()
 
 	body, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseBytes))
 	if err != nil {
-		return nil, fmt.Errorf("read refresh response: %w", err)
+		return 0, nil, fmt.Errorf("read refresh response: %w", err)
 	}
+	return resp.StatusCode, body, nil
+}
 
-	if isClaudeRefreshTokenReused(body) {
-		s.logger.Warn().Str("cred_id", credID.String()).Msg("refresh token already used by another client; access token may still be valid")
-		return nil, fmt.Errorf("refresh token already used by another client")
+// storedRefreshTokenRotated re-reads the credential and reports whether its
+// stored refresh token differs from the one a just-rejected refresh sent.
+// True means another writer rotated the token mid-flight, so the rejection
+// says nothing about the credential's health. Read errors report false: when
+// we can't prove rotation, the caller falls through to its normal rejection
+// handling.
+func (s *Service) storedRefreshTokenRotated(ctx context.Context, scope models.Scope, credID uuid.UUID, sentToken string) bool {
+	cred, err := s.credentials.GetByID(ctx, scope, credID)
+	if err != nil {
+		return false
 	}
-
-	if resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden || isClaudeInvalidGrant(body) {
-		if err := s.credentials.UpdateStatusByID(ctx, scope, credID, models.CodingCredentialStatusInvalid); err != nil {
-			s.logger.Warn().Err(err).Str("cred_id", credID.String()).Msg("failed to update credential status")
-		}
-		// Drop the per-credential refresh mutex so sync.Map doesn't grow
-		// indefinitely as credentials churn through the "invalid" state.
-		s.refreshMu.Delete(credID.String())
-		return nil, fmt.Errorf("refresh token revoked (status %d)", resp.StatusCode)
+	cfg, ok := cred.Config.(models.AnthropicSubscriptionConfig)
+	if !ok {
+		return false
 	}
-
-	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("refresh failed (status %d): %s", resp.StatusCode, redactedBody(body))
-	}
-
-	var tokenResp tokenExchangeResponse
-	if err := json.Unmarshal(body, &tokenResp); err != nil {
-		return nil, fmt.Errorf("parse refresh response: %w", err)
-	}
-	if tokenResp.AccessToken == "" {
-		return nil, fmt.Errorf("refresh response returned empty access_token")
-	}
-
-	newSub := &models.AnthropicSubscription{
-		AccessToken:   tokenResp.AccessToken,
-		RefreshToken:  tokenResp.RefreshToken,
-		ExpiresAt:     time.Now().Add(time.Duration(tokenResp.ExpiresIn) * time.Second),
-		AccountType:   sub.AccountType,
-		RateLimitTier: sub.RateLimitTier,
-		Scopes:        sub.Scopes,
-	}
-	// If the refresh response carries a fresh scope string, prefer it so
-	// scope changes (e.g. an added scope) are reflected.
-	if refreshed := parseScopes(tokenResp.Scope); len(refreshed) > 0 {
-		newSub.Scopes = refreshed
-	}
-	// Anthropic's refresh sometimes returns an empty refresh_token string,
-	// meaning "keep the old one". Avoid clobbering the stored value in that
-	// case — otherwise the next refresh has nothing to send.
-	if newSub.RefreshToken == "" {
-		newSub.RefreshToken = sub.RefreshToken
-	}
-
-	if err := s.credentials.UpsertByID(ctx, scope, credID, models.FromAnthropicSubscription(*newSub)); err != nil {
-		return nil, fmt.Errorf("store refreshed credential: %w", err)
-	}
-
-	s.logger.Info().
-		Str("cred_id", credID.String()).
-		Msg("Claude Code OAuth token refreshed")
-
-	return newSub, nil
+	return cfg.RefreshToken != "" && cfg.RefreshToken != sentToken
 }
 
 // StoreTokenByID persists a Claude Code OAuth token that was refreshed by an
@@ -753,42 +842,46 @@ func (s *Service) StoreTokenByID(ctx context.Context, scope models.Scope, credID
 		return false, errors.New("expires_at is implausibly far in the future")
 	}
 
-	mu := s.credRefreshMu(credID)
-	mu.Lock()
-	defer mu.Unlock()
-
-	cred, err := s.credentials.GetByID(ctx, scope, credID)
-	if err != nil {
-		return false, fmt.Errorf("get credential: %w", err)
-	}
-	cfg, ok := cred.Config.(models.AnthropicSubscriptionConfig)
-	if !ok {
-		return false, fmt.Errorf("credential is not an Anthropic subscription")
-	}
-	if !harvestedSubscriptionIsNewer(cfg.AsAnthropicSubscription(), sub) {
-		return false, nil
-	}
-
-	if s.profileURL == "" {
-		return false, errors.New("profile URL is required to validate harvested Claude token")
-	}
-	profile, err := s.fetchProfile(ctx, sub.AccessToken)
-	if err != nil {
-		return false, fmt.Errorf("validate harvested Claude token: %w", err)
-	}
-	if profile != nil {
-		if profile.Organization.OrganizationType != "" {
-			sub.AccountType = profile.Organization.OrganizationType
+	// Harvest write-backs rotate the stored refresh token, so they take the
+	// same locks as RefreshTokenByID — otherwise a harvest landing while
+	// another host's refresh is mid-flight gets silently overwritten.
+	var stored bool
+	err := s.runUnderRefreshLocks(ctx, credID, func(ctx context.Context) error {
+		cred, err := s.credentials.GetByID(ctx, scope, credID)
+		if err != nil {
+			return fmt.Errorf("get credential: %w", err)
 		}
-		if profile.Organization.RateLimitTier != "" {
-			sub.RateLimitTier = profile.Organization.RateLimitTier
+		cfg, ok := cred.Config.(models.AnthropicSubscriptionConfig)
+		if !ok {
+			return fmt.Errorf("credential is not an Anthropic subscription")
 		}
-	}
+		if !harvestedSubscriptionIsNewer(cfg.AsAnthropicSubscription(), sub) {
+			return nil
+		}
 
-	if err := s.credentials.UpsertByID(ctx, scope, credID, models.FromAnthropicSubscription(sub)); err != nil {
-		return false, fmt.Errorf("store claude subscription credential: %w", err)
-	}
-	return true, nil
+		if s.profileURL == "" {
+			return errors.New("profile URL is required to validate harvested Claude token")
+		}
+		profile, err := s.fetchProfile(ctx, sub.AccessToken)
+		if err != nil {
+			return fmt.Errorf("validate harvested Claude token: %w", err)
+		}
+		if profile != nil {
+			if profile.Organization.OrganizationType != "" {
+				sub.AccountType = profile.Organization.OrganizationType
+			}
+			if profile.Organization.RateLimitTier != "" {
+				sub.RateLimitTier = profile.Organization.RateLimitTier
+			}
+		}
+
+		if err := s.credentials.UpsertByID(ctx, scope, credID, models.FromAnthropicSubscription(sub)); err != nil {
+			return fmt.Errorf("store claude subscription credential: %w", err)
+		}
+		stored = true
+		return nil
+	})
+	return stored, err
 }
 
 func harvestedSubscriptionIsNewer(current, harvested models.AnthropicSubscription) bool {
@@ -933,11 +1026,40 @@ func (s *Service) GetValidToken(ctx context.Context, orgID uuid.UUID) (*models.A
 // sync.Map memory across the process lifetime). Best-effort: a failed update
 // is logged, not fatal.
 func (s *Service) markCredentialInvalid(ctx context.Context, scope models.Scope, credID uuid.UUID, reason string) {
-	s.logger.Warn().Str("cred_id", credID.String()).Str("reason", reason).Msg("marking claude subscription credential invalid")
+	// Error-level on purpose: invalidation takes the credential out of
+	// rotation, so every session that depended on it starts failing. This
+	// line is the breadcrumb operators search for when a user reports
+	// "Claude auth suddenly stopped working".
+	s.logger.Error().
+		Str("org_id", scope.OrgID.String()).
+		Bool("personal", scope.IsPersonal()).
+		Str("cred_id", credID.String()).
+		Str("reason", reason).
+		Msg("marking claude subscription credential invalid")
 	if statusErr := s.credentials.UpdateStatusByID(ctx, scope, credID, models.CodingCredentialStatusInvalid); statusErr != nil {
-		s.logger.Warn().Err(statusErr).Str("cred_id", credID.String()).Msg("failed to mark credential invalid")
+		s.logger.Error().Err(statusErr).Str("cred_id", credID.String()).Msg("failed to mark credential invalid")
 	}
 	s.refreshMu.Delete(credID.String())
+}
+
+// HasInvalidSubscription reports whether the scope holds at least one labeled
+// subscription row whose status is invalid. The orchestrator uses this to
+// tell "you never connected a credential" apart from "your credential was
+// invalidated after a rejected refresh" when failing a Claude Code run.
+func (s *Service) HasInvalidSubscription(ctx context.Context, scope models.Scope) (bool, error) {
+	if s.credentials == nil {
+		return false, nil
+	}
+	creds, err := s.credentials.ListByProvider(ctx, scope, models.ProviderAnthropicSubscription)
+	if err != nil {
+		return false, fmt.Errorf("list anthropic subscriptions: %w", err)
+	}
+	for _, cred := range creds {
+		if cred.Label != "" && cred.Status == models.CredentialStatusInvalid {
+			return true, nil
+		}
+	}
+	return false, nil
 }
 
 // HasActiveSubscription reports whether the org has at least one active

--- a/internal/services/claudecodeauth/service_test.go
+++ b/internal/services/claudecodeauth/service_test.go
@@ -1995,3 +1995,236 @@ func TestInitiateOAuth_SameLabelAcrossScopes(t *testing.T) {
 	require.NoError(t, err)
 	require.NotEqual(t, orgRow.ID, personalRow.ID, "org and personal rows must be distinct credentials despite sharing the label")
 }
+
+// lockTrackingStore wraps the mock store with a RefreshLocker implementation
+// so tests can assert the service serializes refreshes through the store's
+// cross-host lock when it is available.
+type lockTrackingStore struct {
+	*mockCredentialStore
+	lockCalls int
+}
+
+func (s *lockTrackingStore) WithRefreshLock(_ context.Context, _ uuid.UUID, fn func(ctx context.Context) error) error {
+	s.lockCalls++
+	return fn(context.Background())
+}
+
+func TestRefreshTokenByID_UsesStoreRefreshLock(t *testing.T) {
+	t.Parallel()
+	store := &lockTrackingStore{mockCredentialStore: newMockCredentialStore()}
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"access_token":"new-access","refresh_token":"new-refresh","expires_in":3600}`))
+	}))
+	defer ts.Close()
+
+	svc := NewService(store, zerolog.Nop())
+	svc.SetTokenURL(ts.URL)
+	svc.SetProfileURL("")
+
+	orgID := uuid.New()
+	credID := seedActiveSub(t, store.mockCredentialStore, orgID, "team-a", "old-access", "old-refresh", time.Now().Add(-time.Minute))
+
+	newSub, err := svc.RefreshTokenByID(context.Background(), models.Scope{OrgID: orgID}, credID)
+	require.NoError(t, err, "refresh should succeed under the store lock")
+	require.Equal(t, "new-access", newSub.AccessToken)
+	require.Equal(t, 1, store.lockCalls, "the refresh should run inside the store's cross-host lock")
+}
+
+func TestRefreshTokenByID_RefreshLockErrorsPassThrough(t *testing.T) {
+	t.Parallel()
+	store := &lockTrackingStore{mockCredentialStore: newMockCredentialStore()}
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"error":"invalid_grant"}`))
+	}))
+	defer ts.Close()
+
+	svc := NewService(store, zerolog.Nop())
+	svc.SetTokenURL(ts.URL)
+	svc.SetProfileURL("")
+
+	orgID := uuid.New()
+	credID := seedActiveSub(t, store.mockCredentialStore, orgID, "team-a", "old-access", "old-refresh", time.Now().Add(-time.Minute))
+
+	_, err := svc.RefreshTokenByID(context.Background(), models.Scope{OrgID: orgID}, credID)
+	require.Error(t, err, "a real revocation should still fail under the store lock")
+	require.Contains(t, err.Error(), "refresh token revoked", "the revocation error must pass through the lock unwrapped")
+	require.Equal(t, models.CredentialStatusInvalid, store.creds[credID].Status, "an unrotated rejected token should still mark the credential invalid")
+}
+
+func TestRefreshTokenByID_StaleInvalidGrantRetriesWithRotatedToken(t *testing.T) {
+	t.Parallel()
+	store := newMockCredentialStore()
+
+	orgID := uuid.New()
+	credID := seedActiveSub(t, store, orgID, "team-a", "old-access", "old-refresh", time.Now().Add(-time.Minute))
+
+	var requests int
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		body, _ := io.ReadAll(r.Body)
+		var req map[string]string
+		_ = json.Unmarshal(body, &req)
+		w.Header().Set("Content-Type", "application/json")
+		switch requests {
+		case 1:
+			require.Equal(t, "old-refresh", req["refresh_token"], "first attempt should send the originally stored token")
+			// Simulate a sandbox harvest landing mid-flight: the stored
+			// refresh token rotates while Anthropic rejects the old one.
+			// The rotated access token is also expired so the retry has
+			// to do a real refresh rather than short-circuiting.
+			store.creds[credID].Config = models.AnthropicSubscriptionConfig{
+				AccessToken:  "rotated-access",
+				RefreshToken: "rotated-refresh",
+				ExpiresAt:    time.Now().Add(-time.Minute),
+				AccountType:  "claude_max",
+			}
+			w.WriteHeader(http.StatusBadRequest)
+			_, _ = w.Write([]byte(`{"error":"invalid_grant"}`))
+		default:
+			require.Equal(t, "rotated-refresh", req["refresh_token"], "retry should send the rotated token")
+			_, _ = w.Write([]byte(`{"access_token":"new-access","refresh_token":"new-refresh","expires_in":3600}`))
+		}
+	}))
+	defer ts.Close()
+
+	svc := NewService(store, zerolog.Nop())
+	svc.SetTokenURL(ts.URL)
+	svc.SetProfileURL("")
+
+	newSub, err := svc.RefreshTokenByID(context.Background(), models.Scope{OrgID: orgID}, credID)
+	require.NoError(t, err, "a stale rejection should retry with the rotated token instead of failing")
+	require.Equal(t, "new-access", newSub.AccessToken)
+	require.Equal(t, 2, requests, "exactly one retry should happen")
+	require.Equal(t, models.CredentialStatusActive, store.creds[credID].Status, "the credential must not be invalidated by a stale rejection")
+}
+
+func TestRefreshTokenByID_RotatedFreshTokenShortCircuits(t *testing.T) {
+	t.Parallel()
+	store := newMockCredentialStore()
+
+	orgID := uuid.New()
+	credID := seedActiveSub(t, store, orgID, "team-a", "old-access", "old-refresh", time.Now().Add(-time.Minute))
+
+	var requests int
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		// The harvested rotation carries a still-fresh access token, so the
+		// retry loop's re-read should return it without a second HTTP call.
+		store.creds[credID].Config = models.AnthropicSubscriptionConfig{
+			AccessToken:  "harvested-access",
+			RefreshToken: "harvested-refresh",
+			ExpiresAt:    time.Now().Add(time.Hour),
+			AccountType:  "claude_max",
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"error":"invalid_grant"}`))
+	}))
+	defer ts.Close()
+
+	svc := NewService(store, zerolog.Nop())
+	svc.SetTokenURL(ts.URL)
+	svc.SetProfileURL("")
+
+	newSub, err := svc.RefreshTokenByID(context.Background(), models.Scope{OrgID: orgID}, credID)
+	require.NoError(t, err, "a fresh harvested token should be returned without another refresh")
+	require.Equal(t, "harvested-access", newSub.AccessToken)
+	require.Equal(t, 1, requests, "the fresh harvested token must short-circuit the retry's HTTP call")
+	require.Equal(t, models.CredentialStatusActive, store.creds[credID].Status, "the credential must stay active")
+}
+
+func TestRefreshTokenByID_ReusedTokenRetriesWithRotatedToken(t *testing.T) {
+	t.Parallel()
+	store := newMockCredentialStore()
+
+	orgID := uuid.New()
+	credID := seedActiveSub(t, store, orgID, "team-a", "old-access", "old-refresh", time.Now().Add(-time.Minute))
+
+	var requests int
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		w.Header().Set("Content-Type", "application/json")
+		switch requests {
+		case 1:
+			store.creds[credID].Config = models.AnthropicSubscriptionConfig{
+				AccessToken:  "rotated-access",
+				RefreshToken: "rotated-refresh",
+				ExpiresAt:    time.Now().Add(-time.Minute),
+				AccountType:  "claude_max",
+			}
+			w.WriteHeader(http.StatusBadRequest)
+			_, _ = w.Write([]byte(`{"error":"refresh_token_reused"}`))
+		default:
+			_, _ = w.Write([]byte(`{"access_token":"new-access","refresh_token":"new-refresh","expires_in":3600}`))
+		}
+	}))
+	defer ts.Close()
+
+	svc := NewService(store, zerolog.Nop())
+	svc.SetTokenURL(ts.URL)
+	svc.SetProfileURL("")
+
+	newSub, err := svc.RefreshTokenByID(context.Background(), models.Scope{OrgID: orgID}, credID)
+	require.NoError(t, err, "a reuse rejection with a rotated stored token should retry instead of failing")
+	require.Equal(t, "new-access", newSub.AccessToken)
+	require.Equal(t, 2, requests)
+}
+
+func TestHasInvalidSubscription(t *testing.T) {
+	t.Parallel()
+	store := newMockCredentialStore()
+	svc := NewService(store, zerolog.Nop())
+
+	orgID := uuid.New()
+	scope := models.Scope{OrgID: orgID}
+
+	invalid, err := svc.HasInvalidSubscription(context.Background(), scope)
+	require.NoError(t, err)
+	require.False(t, invalid, "an empty scope has no invalid subscription")
+
+	credID := seedActiveSub(t, store, orgID, "team-a", "access", "refresh", time.Now().Add(time.Hour))
+	invalid, err = svc.HasInvalidSubscription(context.Background(), scope)
+	require.NoError(t, err)
+	require.False(t, invalid, "an active subscription is not invalid")
+
+	store.creds[credID].Status = models.CredentialStatusInvalid
+	invalid, err = svc.HasInvalidSubscription(context.Background(), scope)
+	require.NoError(t, err)
+	require.True(t, invalid, "an invalid subscription row should be reported")
+
+	otherOrg := models.Scope{OrgID: uuid.New()}
+	invalid, err = svc.HasInvalidSubscription(context.Background(), otherOrg)
+	require.NoError(t, err)
+	require.False(t, invalid, "another org's invalid row must not leak across scopes")
+}
+
+func TestStoreTokenByID_UsesStoreRefreshLock(t *testing.T) {
+	t.Parallel()
+	store := &lockTrackingStore{mockCredentialStore: newMockCredentialStore()}
+
+	profileTS := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"organization":{"organization_type":"claude_max","rate_limit_tier":"default_claude_max_20x"}}`))
+	}))
+	defer profileTS.Close()
+
+	svc := NewService(store, zerolog.Nop())
+	svc.SetProfileURL(profileTS.URL)
+
+	orgID := uuid.New()
+	scope := models.Scope{OrgID: orgID}
+	credID := seedActiveSub(t, store.mockCredentialStore, orgID, "team-a", "old-access", "old-refresh", time.Now().Add(time.Hour))
+
+	stored, err := svc.StoreTokenByID(context.Background(), scope, credID, models.AnthropicSubscription{
+		AccessToken:  "harvested-access",
+		RefreshToken: "harvested-refresh",
+		ExpiresAt:    time.Now().Add(2 * time.Hour),
+	})
+	require.NoError(t, err, "harvest write-back should succeed under the store lock")
+	require.True(t, stored)
+	require.Equal(t, 1, store.lockCalls, "harvest write-backs rotate the refresh token, so they must take the cross-host lock")
+}

--- a/internal/services/codexauth/service.go
+++ b/internal/services/codexauth/service.go
@@ -697,9 +697,8 @@ func (s *Service) RefreshTokenByID(ctx context.Context, scope models.Scope, cred
 			s.logger.Warn().Str("cred_id", credID.String()).Msg("refresh token already used by another client; access token may still be valid")
 			return nil, wrapAuthInvalid(fmt.Errorf("refresh token already used by another client"))
 		}
-		if err := s.credentials.UpdateStatusByID(ctx, scope, credID, models.CodingCredentialStatusInvalid); err != nil {
-			s.logger.Warn().Err(err).Str("cred_id", credID.String()).Msg("failed to update credential status")
-		}
+		s.markCredentialInvalid(ctx, scope, credID,
+			fmt.Sprintf("token endpoint rejected refresh (status %d)", resp.StatusCode))
 		return nil, wrapAuthInvalid(fmt.Errorf("refresh token revoked (status %d)", resp.StatusCode))
 	}
 
@@ -833,9 +832,18 @@ func (s *Service) GetValidToken(ctx context.Context, orgID uuid.UUID) (*models.O
 // caller's tried-map breaks the loop before lower-priority healthy
 // credentials are reached. Best-effort: a failed update is logged, not fatal.
 func (s *Service) markCredentialInvalid(ctx context.Context, scope models.Scope, credID uuid.UUID, reason string) {
-	s.logger.Warn().Str("cred_id", credID.String()).Str("reason", reason).Msg("marking codex credential invalid")
+	// Error-level on purpose: invalidation takes the credential out of
+	// rotation, so every session that depended on it starts failing. This
+	// line is the breadcrumb operators search for when a user reports
+	// "Codex auth suddenly stopped working".
+	s.logger.Error().
+		Str("org_id", scope.OrgID.String()).
+		Bool("personal", scope.IsPersonal()).
+		Str("cred_id", credID.String()).
+		Str("reason", reason).
+		Msg("marking codex credential invalid")
 	if statusErr := s.credentials.UpdateStatusByID(ctx, scope, credID, models.CodingCredentialStatusInvalid); statusErr != nil {
-		s.logger.Warn().Err(statusErr).Str("cred_id", credID.String()).Msg("failed to mark credential invalid")
+		s.logger.Error().Err(statusErr).Str("cred_id", credID.String()).Msg("failed to mark credential invalid")
 	}
 }
 


### PR DESCRIPTION
## What

Fixes the prod incident where concurrent worker hosts refreshing the same Anthropic OAuth credential would race at the ~8h token-expiry boundary, causing the losing host to hard-invalidate a healthy credential with `invalid_grant`, and leaving users seeing "No Claude Code credentials are configured" on subsequent sessions.

Root cause: Anthropic refresh tokens are single-use/rotating. The in-process `sync.Map` mutex only serializes within one process — two hosts can both enter `RefreshTokenByID` simultaneously and double-spend the same token.

## Changes

**Cross-host serialization** (`internal/db/coding_credentials.go`, `scoped_credential_store.go`):
- New `WithRefreshLock` on `CodingCredentialStore`: acquires a Postgres advisory lock (`pg_advisory_xact_lock`) scoped to one transaction, keyed on credential ID. The lock transaction pins one pool connection; `fn` runs on separate pool connections to avoid deadlock.
- `ScopedCredentialStore` passthrough satisfies the new optional `RefreshLocker` interface.

**Stale-rejection retry** (`internal/services/claudecodeauth/service.go`):
- `runUnderRefreshLocks`: shared helper composing in-process mutex + optional cross-host lock. Both `RefreshTokenByID` and `StoreTokenByID` go through it — harvest write-backs previously bypassed the cross-host lock and could overwrite a mid-flight refresh.
- `refreshTokenLocked`: on `invalid_grant` / `refresh_token_reused`, re-reads the stored refresh token. If it differs from what was sent, another writer already rotated it — retry once with the new token rather than hard-invalidating.
- `HasInvalidSubscription`: new method that reports whether any labeled Anthropic subscription row has status `invalid`.

**Better error messaging** (`internal/services/agent/orchestrator.go`):
- `ClaudeCodeInvalidSubscriptionProber` optional interface.
- `claudeCodeInvalidSubscriptionExists`: probes org + personal scope; falls back to generic message on error.
- `ensureClaudeCodeAuth` now emits "Your Claude subscription is no longer valid (its token was rejected or revoked), so it was removed from rotation. Reconnect it from the Agent settings page to continue." instead of the misleading "No Claude Code credentials are configured".

**Structured invalidation logging** (`claudecodeauth/service.go`, `codexauth/service.go`):
- `markCredentialInvalid` promoted to `Error`-level with `org_id`, `personal`, `cred_id`, `reason` fields on both services.

## Tests

- `TestWithRefreshLockRunsFnUnderAdvisoryLock` / `*ReturnsFnErrorUnwrapped` / `*SwallowsCommitError` — pgxmock unit tests for the advisory lock helper.
- `TestRefreshTokenByID_UsesStoreRefreshLock` — verifies `runUnderRefreshLocks` routes through the store's lock when `RefreshLocker` is implemented.
- `TestRefreshTokenByID_StaleInvalidGrantRetriesWithRotatedToken` / `*RotatedFreshTokenShortCircuits` / `*ReusedTokenRetriesWithRotatedToken` — cover all retry/short-circuit branches.
- `TestHasInvalidSubscription` — verifies the invalid-subscription probe.
- `TestStoreTokenByID_UsesStoreRefreshLock` — verifies harvest write-backs go through the lock.
- `TestRunAgent_InvalidClaudeSubscriptionFailsWithReconnectMessage` / `*ProbeErrorFallsBackToGenericFailure` — orchestrator integration.

## Not in this PR

- Codex parity: porting `runUnderRefreshLocks` + stale-rejection retry to `internal/services/codexauth/service.go`'s `RefreshTokenByID` (tracked separately).
- Real-Postgres integration test serializing two concurrent refreshes under the advisory lock (needs credential fixtures in `internal/integration/`).