### PR TITLE
Cache preview build artifacts (turbo) post-ready so warm launches skip workspace rebuilds

### DIFF
--- a/docs/public/reference/preview-config.mdx
+++ b/docs/public/reference/preview-config.mdx
@@ -67,6 +67,8 @@ Use `preview.default` to auto-select one config. If there are multiple configs a
 <ConfigField name="preview.install.verify_paths" type="string[]" description="Repo-relative paths that must exist before a cached install can be reused." />
 <ConfigField name="preview.install.cache.enabled" type="boolean" defaultValue="true" description="Set false to opt out of dependency artifact caching." />
 <ConfigField name="preview.install.cache.paths" type="string[]" description="Additive repo-relative dependency/build cache paths. Effective paths are clean_paths + cache.paths + inferred paths, excluding platform-owned install markers." />
+<ConfigField name="preview.install.cache.build.enabled" type="boolean" defaultValue="true" description="Set false to opt out of build-artifact caching (incremental build caches saved after services report ready)." />
+<ConfigField name="preview.install.cache.build.paths" type="string[]" description="Additive repo-relative build cache paths (globs allowed). Effective paths are build.paths + inferred Turborepo cache dirs next to each JS lockfile." />
 <ConfigField name="preview.install.timeout_seconds" type="integer" defaultValue="420" description="Maximum install duration. Max 1800." />
 
 Do not cache source directories, secret files, `.git`, `.143/cache`, `.143/cache/preview-install`, or any parent/glob path that can include preview install markers. For large repos, prefer narrow `cache.paths` or `cache.enabled: false`; use `preview.resources.limits.ephemeral-storage` for the final extracted dependency footprint, not as the primary cache correctness mechanism.
@@ -80,6 +82,10 @@ Inferred dependency cache paths:
 | `go.mod`, `go.sum` | `vendor` |
 
 Inference is relative to the dependency file directory. For example, `services/api/poetry.lock` infers `services/api/.venv`, and `go.mod` infers `vendor`. Do not cache source directories, secret files, `.git`, or `.143/cache/preview-install`. For stale dependencies, change lockfiles, clear the preview cache when an admin cache API is available, or temporarily set `cache.enabled: false`.
+
+### Build-artifact cache
+
+Separately from install artifacts, 143 caches incremental build output that services produce while booting (for example Turborepo's local task cache). JS lockfiles infer `node_modules/.cache/turbo` and `.turbo/cache` next to each lockfile; add other tool caches (such as `.next/cache`) via `preview.install.cache.build.paths`. The build cache is restored after the install phase and saved asynchronously once services report ready, using a latest-wins slot per preview config: the build tool's own content hashing makes a stale blob degrade to partial cache hits, never wrong output. Only cache directories whose build tool verifies entries by content hash.
 
 ## Service fields
 

--- a/internal/api/handlers/preview.go
+++ b/internal/api/handlers/preview.go
@@ -919,6 +919,14 @@ func (h *PreviewHandler) startPreviewFromRequest(ctx context.Context, orgID, use
 					cachePlacements = append(cachePlacements, preview.WorkerCachePlacement{Kind: models.PreviewCacheKindPackageManager, PlacementKey: computedPlacementKey})
 				}
 			}
+			if paths, enabled := preview.ResolvePreviewBuildCachePaths(body.Config.Install); enabled && len(paths) > 0 {
+				buildCacheKey, keyErr := preview.ComputePreviewBuildCacheKey(orgID, repoID, body.Config.Name, configDigest, body.Config.Install, paths)
+				if keyErr != nil {
+					h.logger.Warn().Err(keyErr).Str("session_id", sessionID.String()).Msg("failed to compute preview build cache placement key")
+				} else {
+					cachePlacements = append(cachePlacements, preview.WorkerCachePlacement{Kind: models.PreviewCacheKindBuildArtifact, PlacementKey: buildCacheKey})
+				}
+			}
 		}
 		if len(cachePlacements) == 0 {
 			computedPlacementKey, placementErr := preview.ComputePreviewDependencyCacheRepoPlacementKey(orgID, repoID)

--- a/internal/metrics/preview.go
+++ b/internal/metrics/preview.go
@@ -33,6 +33,10 @@ type PreviewMetrics struct {
 	PackageManagerCacheSaves       otelmetric.Int64Counter
 	PackageManagerRestoreDuration  otelmetric.Float64Histogram
 	PackageManagerSaveDuration     otelmetric.Float64Histogram
+	BuildCacheRestores             otelmetric.Int64Counter
+	BuildCacheSaves                otelmetric.Int64Counter
+	BuildCacheRestoreDuration      otelmetric.Float64Histogram
+	BuildCacheSaveDuration         otelmetric.Float64Histogram
 	PrewarmRuns                    otelmetric.Int64Counter
 	PrewarmRunDuration             otelmetric.Float64Histogram
 	SchedulerDecisions             otelmetric.Int64Counter
@@ -62,6 +66,10 @@ func getPreviewMetrics() *PreviewMetrics {
 		pmSaves, _ := meter.Int64Counter("preview.session.package_manager_cache.saves", otelmetric.WithUnit("{save}"))
 		pmRestoreDuration, _ := meter.Float64Histogram("preview.session.package_manager_cache.restore_duration", otelmetric.WithUnit("s"))
 		pmSaveDuration, _ := meter.Float64Histogram("preview.session.package_manager_cache.save_duration", otelmetric.WithUnit("s"))
+		buildRestores, _ := meter.Int64Counter("preview.session.build_cache.restores", otelmetric.WithUnit("{restore}"))
+		buildSaves, _ := meter.Int64Counter("preview.session.build_cache.saves", otelmetric.WithUnit("{save}"))
+		buildRestoreDuration, _ := meter.Float64Histogram("preview.session.build_cache.restore_duration", otelmetric.WithUnit("s"))
+		buildSaveDuration, _ := meter.Float64Histogram("preview.session.build_cache.save_duration", otelmetric.WithUnit("s"))
 		prewarmRuns, _ := meter.Int64Counter("preview.cache_prewarm.runs", otelmetric.WithUnit("{run}"))
 		prewarmRunDuration, _ := meter.Float64Histogram("preview.cache_prewarm.run_duration", otelmetric.WithUnit("s"))
 		schedulerDecisions, _ := meter.Int64Counter("preview.session.dependency_cache.scheduler_decisions", otelmetric.WithUnit("{decision}"))
@@ -87,6 +95,10 @@ func getPreviewMetrics() *PreviewMetrics {
 			PackageManagerCacheSaves:       pmSaves,
 			PackageManagerRestoreDuration:  pmRestoreDuration,
 			PackageManagerSaveDuration:     pmSaveDuration,
+			BuildCacheRestores:             buildRestores,
+			BuildCacheSaves:                buildSaves,
+			BuildCacheRestoreDuration:      buildRestoreDuration,
+			BuildCacheSaveDuration:         buildSaveDuration,
 			PrewarmRuns:                    prewarmRuns,
 			PrewarmRunDuration:             prewarmRunDuration,
 			SchedulerDecisions:             schedulerDecisions,
@@ -253,6 +265,30 @@ func RecordSessionPackageManagerCacheSave(ctx context.Context, orgID, result str
 	m.PackageManagerCacheSaves.Add(ctx, 1, attrs)
 	if m.PackageManagerSaveDuration != nil && duration > 0 {
 		m.PackageManagerSaveDuration.Record(ctx, duration.Seconds(), attrs)
+	}
+}
+
+func RecordSessionBuildCacheRestore(ctx context.Context, orgID, result string, duration time.Duration) {
+	m := getPreviewMetrics()
+	if m == nil || m.BuildCacheRestores == nil {
+		return
+	}
+	attrs := otelmetric.WithAttributes(attribute.String("org.id", orgID), attribute.String("result", result))
+	m.BuildCacheRestores.Add(ctx, 1, attrs)
+	if m.BuildCacheRestoreDuration != nil && duration > 0 {
+		m.BuildCacheRestoreDuration.Record(ctx, duration.Seconds(), attrs)
+	}
+}
+
+func RecordSessionBuildCacheSave(ctx context.Context, orgID, result string, duration time.Duration) {
+	m := getPreviewMetrics()
+	if m == nil || m.BuildCacheSaves == nil {
+		return
+	}
+	attrs := otelmetric.WithAttributes(attribute.String("org.id", orgID), attribute.String("result", result))
+	m.BuildCacheSaves.Add(ctx, 1, attrs)
+	if m.BuildCacheSaveDuration != nil && duration > 0 {
+		m.BuildCacheSaveDuration.Record(ctx, duration.Seconds(), attrs)
 	}
 }
 

--- a/internal/models/preview.go
+++ b/internal/models/preview.go
@@ -419,11 +419,23 @@ type PreviewInstallCacheConfig struct {
 	Paths          []string                          `json:"paths,omitempty"`
 	PackageManager *PreviewPackageManagerCacheConfig `json:"package_manager,omitempty"`
 	Prewarm        *PreviewInstallPrewarmCacheConfig `json:"prewarm,omitempty"`
+	Build          *PreviewBuildCacheConfig          `json:"build,omitempty"`
 }
 
 type PreviewPackageManagerCacheConfig struct {
 	Enabled *bool    `json:"enabled,omitempty"`
 	Include []string `json:"include,omitempty"`
+	Paths   []string `json:"paths,omitempty"`
+}
+
+// PreviewBuildCacheConfig controls caching of incremental build artifacts
+// (e.g. Turborepo's local cache) that services populate while booting. Unlike
+// the install-artifact cache, build caches are saved after services report
+// ready and use latest-wins keying: the build tool is trusted to content-hash
+// its own entries, so a stale blob degrades to partial hits rather than wrong
+// output.
+type PreviewBuildCacheConfig struct {
+	Enabled *bool    `json:"enabled,omitempty"`
 	Paths   []string `json:"paths,omitempty"`
 }
 
@@ -436,6 +448,7 @@ type PreviewCacheKind string
 const (
 	PreviewCacheKindInstallArtifact PreviewCacheKind = "install_artifact"
 	PreviewCacheKindPackageManager  PreviewCacheKind = "package_manager"
+	PreviewCacheKindBuildArtifact   PreviewCacheKind = "build_artifact"
 )
 
 type PreviewCacheRoot string

--- a/internal/services/preview/config.go
+++ b/internal/services/preview/config.go
@@ -778,10 +778,22 @@ func validatePreviewInstallConfig(install *models.PreviewInstallConfig) []string
 				errs = append(errs, validatePreviewPackageManagerCachePath(field, path)...)
 			}
 		}
+		if install.Cache.Build != nil {
+			for i, path := range install.Cache.Build.Paths {
+				field := fmt.Sprintf("preview.install.cache.build.paths[%d]", i)
+				errs = append(errs, validatePreviewDependencyCachePath(field, path, true)...)
+			}
+		}
 	}
 	if paths, enabled := ResolvePreviewInstallCachePaths(install); enabled {
 		for i, path := range paths {
 			field := fmt.Sprintf("preview.install effective cache path[%d]", i)
+			errs = append(errs, validatePreviewDependencyCachePath(field, path, true)...)
+		}
+	}
+	if paths, enabled := ResolvePreviewBuildCachePaths(install); enabled {
+		for i, path := range paths {
+			field := fmt.Sprintf("preview.install effective build cache path[%d]", i)
 			errs = append(errs, validatePreviewDependencyCachePath(field, path, true)...)
 		}
 	}
@@ -919,6 +931,75 @@ func ResolvePreviewInstallCachePaths(install *models.PreviewInstallConfig) ([]st
 	}
 	sort.Strings(paths)
 	return paths, len(paths) > 0
+}
+
+// ResolvePreviewBuildCachePaths returns the effective build-artifact cache
+// paths and whether build caching is enabled for this install config. Build
+// caching is default-on when dependency caching is on and a path can be
+// inferred: JS lockfiles imply Turborepo's local cache locations next to the
+// lockfile. Explicit paths come from preview.install.cache.build.paths.
+func ResolvePreviewBuildCachePaths(install *models.PreviewInstallConfig) ([]string, bool) {
+	if install == nil || len(install.Lockfiles) == 0 {
+		return nil, false
+	}
+	if install.Cache != nil && install.Cache.Enabled != nil && !*install.Cache.Enabled {
+		return nil, false
+	}
+	if install.Cache != nil && install.Cache.Build != nil && install.Cache.Build.Enabled != nil && !*install.Cache.Build.Enabled {
+		return nil, false
+	}
+	seen := make(map[string]struct{})
+	var paths []string
+	add := func(raw string) {
+		clean := filepath.ToSlash(filepath.Clean(strings.TrimSpace(raw)))
+		if clean == "" || clean == "." {
+			return
+		}
+		if dependencyCachePathTargetsPreviewInstallMarkers(clean) || dependencyCachePathTargetsPlatformCache(clean) {
+			return
+		}
+		if _, ok := seen[clean]; ok {
+			return
+		}
+		seen[clean] = struct{}{}
+		paths = append(paths, clean)
+	}
+	if install.Cache != nil && install.Cache.Build != nil {
+		for _, path := range install.Cache.Build.Paths {
+			add(path)
+		}
+	}
+	for _, lockfile := range install.Lockfiles {
+		for _, inferred := range inferPreviewBuildCachePaths(lockfile) {
+			add(inferred)
+		}
+	}
+	sort.Strings(paths)
+	return paths, len(paths) > 0
+}
+
+// inferPreviewBuildCachePaths maps a JS lockfile to the Turborepo local cache
+// directories used by turbo >=1.9 (node_modules/.cache/turbo) and older or
+// explicitly configured setups (.turbo/cache), rooted at the lockfile's
+// directory.
+func inferPreviewBuildCachePaths(lockfile string) []string {
+	clean := filepath.ToSlash(filepath.Clean(strings.TrimSpace(lockfile)))
+	if clean == "" || clean == "." {
+		return nil
+	}
+	switch filepath.Base(clean) {
+	case "package-lock.json", "npm-shrinkwrap.json", "pnpm-lock.yaml", "yarn.lock", "bun.lock", "bun.lockb":
+	default:
+		return nil
+	}
+	dir := pathDir(clean)
+	join := func(p string) string {
+		if dir == "." {
+			return p
+		}
+		return dir + "/" + p
+	}
+	return []string{join("node_modules/.cache/turbo"), join(".turbo/cache")}
 }
 
 func ResolvePreviewInstallPackageManagerCachePaths(install *models.PreviewInstallConfig) ([]string, []string, bool) {

--- a/internal/services/preview/config_test.go
+++ b/internal/services/preview/config_test.go
@@ -2018,3 +2018,101 @@ func TestCommittedDogfoodFrontendScriptBindsExternally(t *testing.T) {
 		dir = parent
 	}
 }
+
+func TestResolvePreviewBuildCachePaths(t *testing.T) {
+	t.Parallel()
+
+	disabled := false
+	tests := []struct {
+		name    string
+		install *models.PreviewInstallConfig
+		want    []string
+		enabled bool
+	}{
+		{
+			name:    "nil install disables build caching",
+			install: nil,
+			enabled: false,
+		},
+		{
+			name: "infers turbo cache dirs from root javascript lockfile",
+			install: &models.PreviewInstallConfig{
+				Lockfiles: []string{"package-lock.json"},
+			},
+			want:    []string{".turbo/cache", "node_modules/.cache/turbo"},
+			enabled: true,
+		},
+		{
+			name: "infers turbo cache dirs next to nested lockfile",
+			install: &models.PreviewInstallConfig{
+				Lockfiles: []string{"frontend/pnpm-lock.yaml"},
+			},
+			want:    []string{"frontend/.turbo/cache", "frontend/node_modules/.cache/turbo"},
+			enabled: true,
+		},
+		{
+			name: "non javascript lockfiles infer nothing",
+			install: &models.PreviewInstallConfig{
+				Lockfiles: []string{"go.mod", "poetry.lock"},
+			},
+			enabled: false,
+		},
+		{
+			name: "explicit build paths are added and deduplicated",
+			install: &models.PreviewInstallConfig{
+				Lockfiles: []string{"package-lock.json"},
+				Cache: &models.PreviewInstallCacheConfig{
+					Build: &models.PreviewBuildCacheConfig{
+						Paths: []string{".next/cache", "node_modules/.cache/turbo"},
+					},
+				},
+			},
+			want:    []string{".next/cache", ".turbo/cache", "node_modules/.cache/turbo"},
+			enabled: true,
+		},
+		{
+			name: "cache disabled flag disables build caching",
+			install: &models.PreviewInstallConfig{
+				Lockfiles: []string{"package-lock.json"},
+				Cache:     &models.PreviewInstallCacheConfig{Enabled: &disabled},
+			},
+			enabled: false,
+		},
+		{
+			name: "build disabled flag disables build caching",
+			install: &models.PreviewInstallConfig{
+				Lockfiles: []string{"package-lock.json"},
+				Cache: &models.PreviewInstallCacheConfig{
+					Build: &models.PreviewBuildCacheConfig{Enabled: &disabled},
+				},
+			},
+			enabled: false,
+		},
+		{
+			name: "platform cache paths are excluded",
+			install: &models.PreviewInstallConfig{
+				Lockfiles: []string{"go.mod"},
+				Cache: &models.PreviewInstallCacheConfig{
+					Build: &models.PreviewBuildCacheConfig{
+						Paths: []string{".143/cache/turbo", "target/debug/incremental"},
+					},
+				},
+			},
+			want:    []string{"target/debug/incremental"},
+			enabled: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, enabled := ResolvePreviewBuildCachePaths(tt.install)
+			require.Equal(t, tt.enabled, enabled, "enabled flag should match")
+			if tt.enabled {
+				require.Equal(t, tt.want, got, "effective build cache paths should match")
+			} else {
+				require.Empty(t, got, "disabled build caching should resolve no paths")
+			}
+		})
+	}
+}

--- a/internal/services/preview/dependency_cache.go
+++ b/internal/services/preview/dependency_cache.go
@@ -50,6 +50,10 @@ type DependencyCacheHit struct {
 
 type DependencyCacheSaveResult struct {
 	SizeBytes int64
+	// Unchanged reports that the staged archive's checksum matched
+	// PreviewPathCacheSaveSpec.SkipIfChecksum, so upload and DB upsert were
+	// skipped because the stored blob already holds identical content.
+	Unchanged bool
 }
 
 type DependencyCacheMetadata struct {
@@ -77,6 +81,14 @@ type PreviewPathCacheSaveSpec struct {
 	CacheKey string
 	Paths    []string
 	Metadata DependencyCacheMetadata
+	// ExcludePaths are subtrees omitted from the archive. Used to keep paths
+	// owned by another cache kind (e.g. build caches living inside
+	// node_modules) out of this kind's blobs.
+	ExcludePaths []string
+	// SkipIfChecksum short-circuits the save when the staged archive hashes to
+	// this value: the caller restored a blob with this checksum earlier in the
+	// same launch, so re-uploading would store identical bytes.
+	SkipIfChecksum string
 }
 
 type DependencyCacheConfig struct {
@@ -349,13 +361,30 @@ func (c *SharedDependencyCache) SavePathCache(ctx context.Context, sb *agent.San
 	for _, p := range existing {
 		args = append(args, dependencyCacheShellPathArg(p))
 	}
-	archiveCmd := fmt.Sprintf("cd %s && tar czf - -- %s", shellQuote(rootDir), strings.Join(args, " "))
+	excludeArgs := make([]string, 0, len(spec.ExcludePaths))
+	for _, p := range sortedNormalizedDependencyPaths(spec.ExcludePaths) {
+		clean, err := cleanDependencyCachePathForRoot(spec.Root, p, true)
+		if err != nil {
+			continue
+		}
+		// Quote the whole flag so glob patterns reach tar literally instead of
+		// being expanded by the shell.
+		excludeArgs = append(excludeArgs, shellQuote("--exclude="+filepath.ToSlash(clean)))
+	}
+	excludeExpr := ""
+	if len(excludeArgs) > 0 {
+		excludeExpr = strings.Join(excludeArgs, " ") + " "
+	}
+	archiveCmd := fmt.Sprintf("cd %s && tar czf - %s-- %s", shellQuote(rootDir), excludeExpr, strings.Join(args, " "))
 	var stderr bytes.Buffer
 	staged, err := c.stageSandboxArchive(ctx, sb, archiveCmd, &stderr)
 	if err != nil {
 		return DependencyCacheSaveResult{}, err
 	}
 	defer staged.cleanup()
+	if spec.SkipIfChecksum != "" && staged.checksum == spec.SkipIfChecksum {
+		return DependencyCacheSaveResult{SizeBytes: staged.sizeBytes, Unchanged: true}, nil
+	}
 	stats, err := validateDependencyCacheArchive(staged.path, existing)
 	if err != nil {
 		return DependencyCacheSaveResult{}, fmt.Errorf("dependency cache save: validate archive: %w", err)
@@ -379,6 +408,14 @@ func (c *SharedDependencyCache) SavePathCache(ctx context.Context, sb *agent.San
 		return DependencyCacheSaveResult{}, fmt.Errorf("dependency cache save: marshal metadata: %w", err)
 	}
 	blobKey := c.blobKeyForChecksum(metadata.OrgID, metadata.RepoID, spec.Kind, spec.CacheKey, staged.checksum)
+	// Snapshot the entry being replaced so its checksum-addressed blob can be
+	// deleted after the upsert. Latest-wins kinds (build_artifact) overwrite
+	// the same row on every content change, which would otherwise leak one
+	// orphaned blob per save.
+	var priorBlobKey string
+	if prior, err := c.store.FindDependencyCache(ctx, metadata.OrgID, metadata.RepoID, spec.Kind, spec.CacheKey); err == nil && prior != nil {
+		priorBlobKey = prior.BlobKey
+	}
 	// Concurrent saves for the same key are intentionally lock-free. Blob
 	// objects are checksum-addressed so each DB upsert points at the exact
 	// payload whose checksum is recorded in metadata.
@@ -408,6 +445,16 @@ func (c *SharedDependencyCache) SavePathCache(ctx context.Context, sb *agent.San
 	}
 	if err := c.store.UpsertDependencyCache(ctx, entry); err != nil {
 		return DependencyCacheSaveResult{}, fmt.Errorf("dependency cache save: upsert db: %w", err)
+	}
+	if priorBlobKey != "" && priorBlobKey != blobKey {
+		// Best-effort: a concurrent restore of the replaced blob on another
+		// worker may fail mid-download and fall back to a cold start.
+		if err := c.blobStore.Delete(ctx, priorBlobKey); err != nil && !errors.Is(err, storage.ErrSnapshotNotFound) {
+			c.logger.Warn().Err(err).Str("blob_key", priorBlobKey).Msg("failed to delete superseded dependency cache blob")
+		}
+		if err := c.blobStore.Delete(ctx, priorBlobKey+".sha256"); err != nil && !errors.Is(err, storage.ErrSnapshotNotFound) {
+			c.logger.Warn().Err(err).Str("blob_key", priorBlobKey+".sha256").Msg("failed to delete superseded dependency cache checksum")
+		}
 	}
 	c.writeLocalBlobFromFile(ctx, &DependencyCacheHit{Entry: *entry, BlobKey: blobKey}, staged.path, staged.sizeBytes, staged.checksum)
 	return DependencyCacheSaveResult{SizeBytes: staged.sizeBytes}, nil

--- a/internal/services/preview/dependency_cache_keys.go
+++ b/internal/services/preview/dependency_cache_keys.go
@@ -18,6 +18,7 @@ import (
 
 const PreviewDependencyCacheRuntimeVersion = "preview-dependency-cache-v1"
 const PreviewPackageManagerCacheRuntimeVersion = "preview-package-manager-cache-v1"
+const PreviewBuildCacheRuntimeVersion = "preview-build-cache-v1"
 
 type PreviewInstallLockfileKey struct {
 	Path   string `json:"path"`
@@ -132,6 +133,37 @@ func ComputePreviewDependencyCachePlacementKey(orgID, repoID uuid.UUID, configNa
 	key, err := stableJSONSHA256(payload)
 	if err != nil {
 		return "", fmt.Errorf("marshal dependency cache placement key: %w", err)
+	}
+	return key, nil
+}
+
+// ComputePreviewBuildCacheKey returns the latest-wins key for the
+// build-artifact cache. Unlike install-artifact keys it deliberately excludes
+// lockfile contents and sandbox identity: build tools (e.g. turbo) content-hash
+// their own cache entries, so a single blob per (org, repo, config, install,
+// paths) slot that is overwritten after every ready preview maximizes hit rate,
+// and a stale blob degrades to partial build-tool hits rather than wrong
+// output.
+func ComputePreviewBuildCacheKey(orgID, repoID uuid.UUID, configName, configDigest string, install *models.PreviewInstallConfig, effectivePaths []string) (string, error) {
+	payload := previewDependencyCachePlacementKey{
+		RuntimeVersion: PreviewBuildCacheRuntimeVersion,
+		OrgID:          orgID,
+		RepoID:         repoID,
+		ConfigName:     strings.TrimSpace(configName),
+		ConfigDigest:   strings.TrimSpace(configDigest),
+		EffectivePaths: sortedNormalizedDependencyPaths(effectivePaths),
+	}
+	if install != nil {
+		payload.InstallCommand = append([]string(nil), install.Command...)
+		payload.InstallCwd = install.Cwd
+		if payload.InstallCwd == "" {
+			payload.InstallCwd = "."
+		}
+		payload.LockfilePaths = sortedNormalizedDependencyPaths(install.Lockfiles)
+	}
+	key, err := stableJSONSHA256(payload)
+	if err != nil {
+		return "", fmt.Errorf("marshal build cache key: %w", err)
 	}
 	return key, nil
 }

--- a/internal/services/preview/dependency_cache_keys_test.go
+++ b/internal/services/preview/dependency_cache_keys_test.go
@@ -178,3 +178,38 @@ func TestBuildDependencyCacheTarValidationCommand(t *testing.T) {
 	require.Contains(t, cmd, "bad=1", "extract validation should reject entries outside effective cache paths")
 	require.Contains(t, cmd, "tar xzf", "extract command should still extract after validation")
 }
+
+func TestComputePreviewBuildCacheKey_LatestWinsAcrossLockfileContents(t *testing.T) {
+	t.Parallel()
+
+	orgID := uuid.New()
+	repoID := uuid.New()
+	install := &models.PreviewInstallConfig{
+		Command:   []string{"npm", "ci"},
+		Lockfiles: []string{"package-lock.json"},
+	}
+	paths := []string{"node_modules/.cache/turbo", ".turbo/cache"}
+
+	key1, err := ComputePreviewBuildCacheKey(orgID, repoID, "app", "digest-a", install, paths)
+	require.NoError(t, err, "build cache key should compute")
+	require.NotEmpty(t, key1, "build cache key should not be empty")
+
+	// Same inputs must produce the same slot: the key intentionally ignores
+	// lockfile contents so one latest-wins blob is reused across dependency
+	// bumps.
+	key2, err := ComputePreviewBuildCacheKey(orgID, repoID, "app", "digest-a", install, paths)
+	require.NoError(t, err, "build cache key should recompute")
+	require.Equal(t, key1, key2, "identical inputs should map to the same latest-wins slot")
+
+	differentPaths, err := ComputePreviewBuildCacheKey(orgID, repoID, "app", "digest-a", install, []string{"frontend/.turbo/cache"})
+	require.NoError(t, err, "build cache key should compute for different paths")
+	require.NotEqual(t, key1, differentPaths, "different effective paths should map to a different slot")
+
+	differentDigest, err := ComputePreviewBuildCacheKey(orgID, repoID, "app", "digest-b", install, paths)
+	require.NoError(t, err, "build cache key should compute for different config digest")
+	require.NotEqual(t, key1, differentDigest, "config changes should map to a different slot")
+
+	placementKey, err := ComputePreviewDependencyCachePlacementKey(orgID, repoID, "app", "digest-a", install, paths)
+	require.NoError(t, err, "dependency placement key should compute")
+	require.NotEqual(t, key1, placementKey, "build cache keys must not collide with dependency placement keys")
+}

--- a/internal/services/preview/dependency_cache_test.go
+++ b/internal/services/preview/dependency_cache_test.go
@@ -817,3 +817,160 @@ func TestSharedDependencyCache_RestoreLocalBlobSurvivesConcurrentEviction(t *tes
 	require.NoFileExists(t, localPath, "test should simulate local LRU eviction during restore cleanup")
 	require.Contains(t, strings.Join(baseExec.calls(), "\n"), "tar xzf -", "Restore should still extract from a stable local blob reader")
 }
+
+func TestSharedDependencyCache_SavePathCacheExcludesSubtrees(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	orgID := uuid.New()
+	repoID := uuid.New()
+	cacheKey := strings.Repeat("b", 64)
+	payload := makeDependencyCacheTarGz(t, map[string]string{"node_modules/.bin/next": "next"})
+	now := time.Now().UTC()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "pgx mock should initialize")
+	defer mock.Close()
+
+	mock.ExpectQuery("SELECT (.+) FROM preview_dependency_cache").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(pgxmock.NewRows([]string{
+			"id", "org_id", "repo_id", "cache_kind", "cache_key", "placement_key", "blob_key", "size_bytes", "metadata", "last_used_at", "created_at",
+		}))
+	mock.ExpectQuery("INSERT INTO preview_dependency_cache").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(pgxmock.NewRows([]string{
+			"id", "org_id", "repo_id", "cache_kind", "cache_key", "placement_key", "blob_key", "size_bytes", "metadata", "last_used_at", "created_at",
+		}).
+			AddRow(uuid.New(), orgID, repoID, models.PreviewCacheKindInstallArtifact, cacheKey, "placement", "deps/"+cacheKey+".tar.gz", int64(len(payload)), []byte(`{}`), now, now))
+
+	exec := &dependencyCacheExec{payload: payload}
+	cache, err := NewDependencyCache(DependencyCacheConfig{
+		Store:     db.NewPreviewStore(mock),
+		Executor:  exec,
+		BlobStore: newMemorySnapshotStore(),
+		Logger:    zerolog.Nop(),
+		Prefix:    "deps",
+	})
+	require.NoError(t, err, "dependency cache should initialize")
+
+	_, err = cache.SavePathCache(ctx, &agent.Sandbox{WorkDir: "/workspace/repo"}, PreviewPathCacheSaveSpec{
+		Kind:         models.PreviewCacheKindInstallArtifact,
+		Root:         models.PreviewCacheRootWorkDir,
+		CacheKey:     cacheKey,
+		Paths:        []string{"node_modules"},
+		ExcludePaths: []string{"node_modules/.cache/turbo", ".turbo/cache"},
+		Metadata: DependencyCacheMetadata{
+			OrgID:        orgID,
+			RepoID:       repoID,
+			PlacementKey: "placement",
+		},
+	})
+	require.NoError(t, err, "SavePathCache should succeed with excludes")
+
+	calls := strings.Join(exec.calls(), "\n")
+	require.Contains(t, calls, "'--exclude=node_modules/.cache/turbo'", "archive command should exclude the build cache subtree")
+	require.Contains(t, calls, "'--exclude=.turbo/cache'", "archive command should exclude every requested subtree")
+	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
+}
+
+func TestSharedDependencyCache_SavePathCacheSkipsUploadWhenChecksumUnchanged(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	orgID := uuid.New()
+	repoID := uuid.New()
+	cacheKey := strings.Repeat("c", 64)
+	payload := makeDependencyCacheTarGz(t, map[string]string{"node_modules/.cache/turbo/abc": "entry"})
+	sum := sha256.Sum256(payload)
+	checksum := fmt.Sprintf("%x", sum[:])
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "pgx mock should initialize")
+	defer mock.Close()
+	// No DB expectations: an unchanged archive must not touch the store.
+
+	blobStore := newMemorySnapshotStore()
+	cache, err := NewDependencyCache(DependencyCacheConfig{
+		Store:     db.NewPreviewStore(mock),
+		Executor:  &dependencyCacheExec{payload: payload},
+		BlobStore: blobStore,
+		Logger:    zerolog.Nop(),
+		Prefix:    "deps",
+	})
+	require.NoError(t, err, "dependency cache should initialize")
+
+	result, err := cache.SavePathCache(ctx, &agent.Sandbox{WorkDir: "/workspace/repo"}, PreviewPathCacheSaveSpec{
+		Kind:           models.PreviewCacheKindBuildArtifact,
+		Root:           models.PreviewCacheRootWorkDir,
+		CacheKey:       cacheKey,
+		Paths:          []string{"node_modules/.cache/turbo"},
+		SkipIfChecksum: checksum,
+		Metadata: DependencyCacheMetadata{
+			OrgID:  orgID,
+			RepoID: repoID,
+		},
+	})
+	require.NoError(t, err, "SavePathCache should succeed when content is unchanged")
+	require.True(t, result.Unchanged, "matching checksum should report the save as unchanged")
+	require.Empty(t, blobStore.blobs, "unchanged content must not be re-uploaded")
+	require.NoError(t, mock.ExpectationsWereMet(), "no database writes should happen for unchanged content")
+}
+
+func TestSharedDependencyCache_SavePathCacheDeletesSupersededBlob(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	orgID := uuid.New()
+	repoID := uuid.New()
+	cacheKey := strings.Repeat("d", 64)
+	payload := makeDependencyCacheTarGz(t, map[string]string{"node_modules/.cache/turbo/abc": "entry"})
+	now := time.Now().UTC()
+	oldBlobKey := "deps/" + orgID.String() + "/" + repoID.String() + "/build_artifact/" + cacheKey + "/oldchecksum.tar.gz"
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "pgx mock should initialize")
+	defer mock.Close()
+
+	mock.ExpectQuery("SELECT (.+) FROM preview_dependency_cache").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(pgxmock.NewRows([]string{
+			"id", "org_id", "repo_id", "cache_kind", "cache_key", "placement_key", "blob_key", "size_bytes", "metadata", "last_used_at", "created_at",
+		}).
+			AddRow(uuid.New(), orgID, repoID, models.PreviewCacheKindBuildArtifact, cacheKey, "placement", oldBlobKey, int64(10), []byte(`{}`), now, now))
+	mock.ExpectQuery("INSERT INTO preview_dependency_cache").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(pgxmock.NewRows([]string{
+			"id", "org_id", "repo_id", "cache_kind", "cache_key", "placement_key", "blob_key", "size_bytes", "metadata", "last_used_at", "created_at",
+		}).
+			AddRow(uuid.New(), orgID, repoID, models.PreviewCacheKindBuildArtifact, cacheKey, "placement", "deps/new.tar.gz", int64(len(payload)), []byte(`{}`), now, now))
+
+	blobStore := newMemorySnapshotStore()
+	require.NoError(t, blobStore.Save(ctx, oldBlobKey, bytes.NewReader([]byte("old"))), "old blob should exist before the save")
+	require.NoError(t, blobStore.Save(ctx, oldBlobKey+".sha256", bytes.NewReader([]byte("oldchecksum"))), "old checksum sidecar should exist before the save")
+
+	cache, err := NewDependencyCache(DependencyCacheConfig{
+		Store:     db.NewPreviewStore(mock),
+		Executor:  &dependencyCacheExec{payload: payload},
+		BlobStore: blobStore,
+		Logger:    zerolog.Nop(),
+		Prefix:    "deps",
+	})
+	require.NoError(t, err, "dependency cache should initialize")
+
+	_, err = cache.SavePathCache(ctx, &agent.Sandbox{WorkDir: "/workspace/repo"}, PreviewPathCacheSaveSpec{
+		Kind:     models.PreviewCacheKindBuildArtifact,
+		Root:     models.PreviewCacheRootWorkDir,
+		CacheKey: cacheKey,
+		Paths:    []string{"node_modules/.cache/turbo"},
+		Metadata: DependencyCacheMetadata{
+			OrgID:        orgID,
+			RepoID:       repoID,
+			PlacementKey: "placement",
+		},
+	})
+	require.NoError(t, err, "SavePathCache should succeed")
+	require.Empty(t, blobStore.blobs[oldBlobKey], "superseded latest-wins blob should be deleted after the upsert")
+	require.Empty(t, blobStore.blobs[oldBlobKey+".sha256"], "superseded checksum sidecar should be deleted after the upsert")
+	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
+}

--- a/internal/services/preview/manager.go
+++ b/internal/services/preview/manager.go
@@ -1126,6 +1126,29 @@ func (o *managerServiceObserver) OnPackageManagerCacheSave(status string, cacheK
 	o.writeDependencyCacheLog("warn", msg, cacheKey, sizeBytes)
 }
 
+func (o *managerServiceObserver) OnBuildCacheRestore(status string, cacheKey string, sizeBytes int64, err error) {
+	switch status {
+	case "disabled", "miss", "restore_failed", "restored", "key_failed":
+	default:
+		return
+	}
+	level := "info"
+	msg := fmt.Sprintf("preview build cache %s", status)
+	if err != nil {
+		level = "warn"
+		msg = fmt.Sprintf("preview build cache restore failed: %v", err)
+	}
+	o.writeDependencyCacheLog(level, msg, cacheKey, sizeBytes)
+}
+
+func (o *managerServiceObserver) OnBuildCacheSave(status string, cacheKey string, sizeBytes int64, err error) {
+	if status != "save_failed" {
+		return
+	}
+	msg := fmt.Sprintf("preview build cache save failed: %v", err)
+	o.writeDependencyCacheLog("warn", msg, cacheKey, sizeBytes)
+}
+
 func (o *managerServiceObserver) writeDependencyCacheLog(level, msg, cacheKey string, sizeBytes int64) {
 	ctx, cancel := context.WithTimeout(context.Background(), observerWriteTimeout)
 	defer cancel()

--- a/internal/services/preview/provider.go
+++ b/internal/services/preview/provider.go
@@ -150,6 +150,8 @@ type CacheObserver interface {
 	OnDependencyCacheSave(status string, cacheKey string, sizeBytes int64, err error)
 	OnPackageManagerCacheRestore(status string, cacheKey string, sizeBytes int64, err error)
 	OnPackageManagerCacheSave(status string, cacheKey string, sizeBytes int64, err error)
+	OnBuildCacheRestore(status string, cacheKey string, sizeBytes int64, err error)
+	OnBuildCacheSave(status string, cacheKey string, sizeBytes int64, err error)
 }
 
 // InfraSnapshot is the current state of a platform infrastructure container.

--- a/internal/services/preview/providers/docker_preview.go
+++ b/internal/services/preview/providers/docker_preview.go
@@ -135,6 +135,15 @@ type previewState struct {
 	primaryPort int
 
 	deferredCacheSaves []func()
+
+	// Build-artifact cache slot for this launch. The fields are written once
+	// during the install phase (before service goroutines start) and read by
+	// the post-ready save, so they need no locking. buildCacheSaveOnce
+	// guarantees a single save regardless of which readiness path triggers it.
+	buildCacheKey              string
+	buildCachePaths            []string
+	buildCacheRestoredChecksum string
+	buildCacheSaveOnce         sync.Once
 }
 
 // serviceState tracks a running application service process.
@@ -327,6 +336,12 @@ func (d *DockerPreviewProvider) StartPreview(ctx context.Context, sb *agent.Sand
 			return phaseErr
 		}
 
+		// Phase 4.5: Restore boot-time build caches (e.g. turbo's local cache)
+		// after install — install commands like `npm ci` wipe node_modules and
+		// would delete a tree restored earlier — and before services start so
+		// boot-time builds get cache hits. Failures degrade to a cold build.
+		d.restorePreviewBuildCache(ctx, state, cfg.Install, opts, observer)
+
 		// Phase 5: Write generated runtime secret files after install so install
 		// hooks cannot read preview-runtime app secrets.
 		if err := d.writeRuntimeSecretFiles(ctx, sb, cfg.RuntimeSecretFiles); err != nil {
@@ -451,6 +466,9 @@ func (d *DockerPreviewProvider) StartPreview(ctx context.Context, sb *agent.Sand
 					}
 					cancel()
 				}
+				// All services finished their readiness window: boot-time
+				// builds are done, so capture the build cache now.
+				d.savePreviewBuildCache(svcCtx, state, cfg.Install, opts, observer)
 			}()
 			return nil
 		}
@@ -485,6 +503,9 @@ func (d *DockerPreviewProvider) StartPreview(ctx context.Context, sb *agent.Sand
 				d.warmPrimaryRoute(svcCtx, state, name, svcCfg.Port, svcCfg.Ready.HTTPPath)
 			}
 		}
+		// All services are ready: boot-time builds are done, so capture the
+		// build cache now.
+		d.savePreviewBuildCache(svcCtx, state, cfg.Install, opts, observer)
 		return nil
 	}(); err != nil {
 		d.cleanupState(handle)
@@ -1454,11 +1475,30 @@ func (d *DockerPreviewProvider) saveDependencyCache(ctx context.Context, state *
 		LockfileHashes: lockHashes,
 		Lockfiles:      lockfiles,
 	}
+	// Build caches (e.g. turbo's dir inside node_modules) belong to the
+	// build_artifact kind: keeping them out of install-artifact blobs avoids
+	// archiving a concurrently-restored subtree and keeps the two kinds'
+	// invalidation independent.
+	excludePaths, _ := preview.ResolvePreviewBuildCachePaths(install)
 	save := func() {
 		saveCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 10*time.Minute)
 		defer cancel()
 		started := time.Now()
-		result, err := d.dependencyCache.Save(saveCtx, state.sandbox, cacheKey, paths, metadata)
+		pathCache, hasPathCache := d.dependencyCache.(preview.PreviewPathCache)
+		var result preview.DependencyCacheSaveResult
+		var err error
+		if hasPathCache {
+			result, err = pathCache.SavePathCache(saveCtx, state.sandbox, preview.PreviewPathCacheSaveSpec{
+				Kind:         models.PreviewCacheKindInstallArtifact,
+				Root:         models.PreviewCacheRootWorkDir,
+				CacheKey:     cacheKey,
+				Paths:        paths,
+				Metadata:     metadata,
+				ExcludePaths: excludePaths,
+			})
+		} else {
+			result, err = d.dependencyCache.Save(saveCtx, state.sandbox, cacheKey, paths, metadata)
+		}
 		if err != nil {
 			notifyDependencyCacheSave(observer, "save_failed", cacheKey, 0, err)
 			metrics.RecordSessionDependencyCacheSave(saveCtx, opts.OrgID.String(), "save_failed", time.Since(started))
@@ -1473,6 +1513,136 @@ func (d *DockerPreviewProvider) saveDependencyCache(ctx context.Context, state *
 		return
 	}
 	save()
+}
+
+// restorePreviewBuildCache restores the latest build-artifact blob (e.g.
+// Turborepo's local cache) into the sandbox workdir. It runs after the install
+// phase so install commands that wipe node_modules cannot delete the restored
+// tree, and before services start so boot-time builds get cache hits.
+func (d *DockerPreviewProvider) restorePreviewBuildCache(ctx context.Context, state *previewState, install *models.PreviewInstallConfig, opts preview.StartPreviewOptions, observer preview.ServiceObserver) {
+	pathCache, hasPathCache := d.dependencyCache.(preview.PreviewPathCache)
+	if d.dependencyCache == nil || !hasPathCache || opts.OrgID == uuid.Nil || opts.RepositoryID == uuid.Nil {
+		notifyBuildCacheRestore(observer, "disabled", "", 0, nil)
+		if opts.OrgID != uuid.Nil {
+			metrics.RecordSessionBuildCacheRestore(ctx, opts.OrgID.String(), "disabled", 0)
+		}
+		return
+	}
+	paths, enabled := preview.ResolvePreviewBuildCachePaths(install)
+	if !enabled {
+		notifyBuildCacheRestore(observer, "disabled", "", 0, nil)
+		metrics.RecordSessionBuildCacheRestore(ctx, opts.OrgID.String(), "disabled", 0)
+		return
+	}
+	configDigest := opts.ConfigDigest
+	if configDigest == "" {
+		if digest, digestErr := preview.ComputePreviewConfigDigest(state.config); digestErr == nil {
+			configDigest = digest
+		}
+	}
+	cacheKey, err := preview.ComputePreviewBuildCacheKey(opts.OrgID, opts.RepositoryID, state.config.Name, configDigest, install, paths)
+	if err != nil {
+		notifyBuildCacheRestore(observer, "key_failed", "", 0, err)
+		metrics.RecordSessionBuildCacheRestore(ctx, opts.OrgID.String(), "key_failed", 0)
+		d.logger.Warn().Err(err).Msg("preview build cache key unavailable; continuing cold")
+		return
+	}
+	state.buildCacheKey = cacheKey
+	state.buildCachePaths = paths
+
+	lookupStarted := time.Now()
+	notifyPhaseStart(observer, "build_cache_lookup")
+	hit, findErr := pathCache.FindPathCache(ctx, opts.OrgID, opts.RepositoryID, models.PreviewCacheKindBuildArtifact, cacheKey)
+	notifyPhaseEnd(observer, "build_cache_lookup", findErr)
+	metrics.RecordSessionPreviewPhaseDuration(ctx, opts.OrgID.String(), "build_cache_lookup", time.Since(lookupStarted))
+	if findErr != nil {
+		notifyBuildCacheRestore(observer, "restore_failed", cacheKey, 0, findErr)
+		metrics.RecordSessionBuildCacheRestore(ctx, opts.OrgID.String(), "restore_failed", time.Since(lookupStarted))
+		d.logger.Warn().Err(findErr).Str("cache_key", cacheKey).Msg("preview build cache lookup failed; continuing cold")
+		return
+	}
+	if hit == nil {
+		notifyBuildCacheRestore(observer, "miss", cacheKey, 0, nil)
+		metrics.RecordSessionBuildCacheRestore(ctx, opts.OrgID.String(), "miss", time.Since(lookupStarted))
+		d.logger.Info().Str("cache_key", cacheKey).Msg("preview build cache miss")
+		return
+	}
+	restoreStarted := time.Now()
+	notifyPhaseStart(observer, "build_cache_restore")
+	restoreErr := pathCache.RestorePathCache(ctx, state.sandbox, hit, models.PreviewCacheRootWorkDir)
+	notifyPhaseEnd(observer, "build_cache_restore", restoreErr)
+	metrics.RecordSessionPreviewPhaseDuration(ctx, opts.OrgID.String(), "build_cache_restore", time.Since(restoreStarted))
+	if restoreErr != nil {
+		notifyBuildCacheRestore(observer, "restore_failed", cacheKey, hit.Entry.SizeBytes, restoreErr)
+		metrics.RecordSessionBuildCacheRestore(ctx, opts.OrgID.String(), "restore_failed", time.Since(restoreStarted))
+		d.logger.Warn().Err(restoreErr).Str("cache_key", cacheKey).Msg("preview build cache restore failed; continuing cold")
+		return
+	}
+	var restoredMeta preview.DependencyCacheMetadata
+	if err := json.Unmarshal(hit.Entry.Metadata, &restoredMeta); err == nil {
+		state.buildCacheRestoredChecksum = restoredMeta.ChecksumSHA256
+	}
+	notifyBuildCacheRestore(observer, "restored", cacheKey, hit.Entry.SizeBytes, nil)
+	metrics.RecordSessionBuildCacheRestore(ctx, opts.OrgID.String(), "restored", time.Since(restoreStarted))
+	d.logger.Info().Str("cache_key", cacheKey).Int64("size_bytes", hit.Entry.SizeBytes).Msg("preview build cache restored")
+}
+
+// savePreviewBuildCache archives the build-artifact paths once services have
+// reported ready — the only point in a launch where boot-time builds (turbo
+// and friends) have populated their caches. The key is latest-wins: each save
+// overwrites the same slot, and the build tool's own content hashing makes a
+// stale blob degrade to partial hits rather than wrong output. SkipIfChecksum
+// avoids re-uploading when the tree is byte-identical to what was restored.
+func (d *DockerPreviewProvider) savePreviewBuildCache(ctx context.Context, state *previewState, install *models.PreviewInstallConfig, opts preview.StartPreviewOptions, observer preview.ServiceObserver) {
+	state.buildCacheSaveOnce.Do(func() {
+		pathCache, hasPathCache := d.dependencyCache.(preview.PreviewPathCache)
+		if d.dependencyCache == nil || !hasPathCache || install == nil || state.buildCacheKey == "" || len(state.buildCachePaths) == 0 {
+			notifyBuildCacheSave(observer, "skipped", state.buildCacheKey, 0, nil)
+			if opts.OrgID != uuid.Nil {
+				metrics.RecordSessionBuildCacheSave(context.Background(), opts.OrgID.String(), "skipped", 0)
+			}
+			return
+		}
+		metadata := preview.DependencyCacheMetadata{
+			Kind:           models.PreviewCacheKindBuildArtifact,
+			Root:           models.PreviewCacheRootWorkDir,
+			OrgID:          opts.OrgID,
+			RepoID:         opts.RepositoryID,
+			SessionID:      opts.SessionID,
+			PlacementKey:   state.buildCacheKey,
+			InstallCommand: append([]string(nil), install.Command...),
+			EffectivePaths: append([]string(nil), state.buildCachePaths...),
+		}
+		go func() {
+			saveCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 10*time.Minute)
+			defer cancel()
+			started := time.Now()
+			result, err := pathCache.SavePathCache(saveCtx, state.sandbox, preview.PreviewPathCacheSaveSpec{
+				Kind:           models.PreviewCacheKindBuildArtifact,
+				Root:           models.PreviewCacheRootWorkDir,
+				CacheKey:       state.buildCacheKey,
+				Paths:          state.buildCachePaths,
+				Metadata:       metadata,
+				SkipIfChecksum: state.buildCacheRestoredChecksum,
+			})
+			switch {
+			case err != nil:
+				notifyBuildCacheSave(observer, "save_failed", state.buildCacheKey, 0, err)
+				metrics.RecordSessionBuildCacheSave(saveCtx, opts.OrgID.String(), "save_failed", time.Since(started))
+				d.logger.Warn().Err(err).Str("cache_key", state.buildCacheKey).Msg("preview build cache save failed")
+			case result.Unchanged:
+				notifyBuildCacheSave(observer, "unchanged", state.buildCacheKey, result.SizeBytes, nil)
+				metrics.RecordSessionBuildCacheSave(saveCtx, opts.OrgID.String(), "unchanged", time.Since(started))
+			case result.SizeBytes == 0:
+				notifyBuildCacheSave(observer, "skipped_no_paths", state.buildCacheKey, 0, nil)
+				metrics.RecordSessionBuildCacheSave(saveCtx, opts.OrgID.String(), "skipped_no_paths", time.Since(started))
+			default:
+				notifyBuildCacheSave(observer, "saved", state.buildCacheKey, result.SizeBytes, nil)
+				metrics.RecordSessionBuildCacheSave(saveCtx, opts.OrgID.String(), "saved", time.Since(started))
+				d.logger.Info().Str("cache_key", state.buildCacheKey).Int64("size_bytes", result.SizeBytes).Msg("preview build cache saved")
+			}
+		}()
+	})
 }
 
 func (d *DockerPreviewProvider) computePreviewInstallCacheKey(ctx context.Context, sb *agent.Sandbox, install *models.PreviewInstallConfig) (string, error) {
@@ -1699,6 +1869,22 @@ func notifyPackageManagerCacheSave(observer preview.ServiceObserver, status stri
 		return
 	}
 	cacheObserver.OnPackageManagerCacheSave(status, cacheKey, sizeBytes, err)
+}
+
+func notifyBuildCacheRestore(observer preview.ServiceObserver, status string, cacheKey string, sizeBytes int64, err error) {
+	cacheObserver, ok := observer.(preview.CacheObserver)
+	if !ok || cacheObserver == nil {
+		return
+	}
+	cacheObserver.OnBuildCacheRestore(status, cacheKey, sizeBytes, err)
+}
+
+func notifyBuildCacheSave(observer preview.ServiceObserver, status string, cacheKey string, sizeBytes int64, err error) {
+	cacheObserver, ok := observer.(preview.CacheObserver)
+	if !ok || cacheObserver == nil {
+		return
+	}
+	cacheObserver.OnBuildCacheSave(status, cacheKey, sizeBytes, err)
 }
 
 // =============================================================================

--- a/internal/services/preview/providers/docker_preview_test.go
+++ b/internal/services/preview/providers/docker_preview_test.go
@@ -642,6 +642,8 @@ type recordingObserver struct {
 	cacheSaves         []recordedCacheEvent
 	pmCacheRestores    []recordedCacheEvent
 	pmCacheSaves       []recordedCacheEvent
+	buildCacheRestores []recordedCacheEvent
+	buildCacheSaves    []recordedCacheEvent
 	phaseStarts        []string
 	phaseEnds          []string
 }
@@ -697,6 +699,18 @@ func (r *recordingObserver) OnPackageManagerCacheSave(status string, cacheKey st
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	r.pmCacheSaves = append(r.pmCacheSaves, recordedCacheEvent{status: status, cacheKey: cacheKey, sizeBytes: sizeBytes, err: err})
+}
+
+func (r *recordingObserver) OnBuildCacheRestore(status string, cacheKey string, sizeBytes int64, err error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.buildCacheRestores = append(r.buildCacheRestores, recordedCacheEvent{status: status, cacheKey: cacheKey, sizeBytes: sizeBytes, err: err})
+}
+
+func (r *recordingObserver) OnBuildCacheSave(status string, cacheKey string, sizeBytes int64, err error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.buildCacheSaves = append(r.buildCacheSaves, recordedCacheEvent{status: status, cacheKey: cacheKey, sizeBytes: sizeBytes, err: err})
 }
 
 func (r *recordingObserver) OnPhaseStart(name string) {
@@ -784,6 +798,18 @@ func (r *recordingObserver) packageManagerCacheRestores() []recordedCacheEvent {
 	return append([]recordedCacheEvent(nil), r.pmCacheRestores...)
 }
 
+func (r *recordingObserver) buildCacheRestoreEvents() []recordedCacheEvent {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return append([]recordedCacheEvent(nil), r.buildCacheRestores...)
+}
+
+func (r *recordingObserver) buildCacheSaveEvents() []recordedCacheEvent {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return append([]recordedCacheEvent(nil), r.buildCacheSaves...)
+}
+
 func (r *recordingObserver) packageManagerCacheSaves() []recordedCacheEvent {
 	r.mu.Lock()
 	defer r.mu.Unlock()
@@ -803,25 +829,29 @@ func (r *recordingObserver) phasesEnded() []string {
 }
 
 type fakeDependencyCache struct {
-	mu           sync.Mutex
-	findHit      *preview.DependencyCacheHit
-	findErr      error
-	restoreErr   error
-	saveErr      error
-	pmFindHit    *preview.DependencyCacheHit
-	pmFindErr    error
-	pmRestoreErr error
-	pmSaveErr    error
-	finds        int
-	restores     int
-	saves        int
-	savePaths    []string
-	pathFinds    map[models.PreviewCacheKind]int
-	pathRestores map[models.PreviewCacheKind]int
-	pathSaves    map[models.PreviewCacheKind]int
-	restoreRoots []models.PreviewCacheRoot
-	saveSpecs    []preview.PreviewPathCacheSaveSpec
-	saveStarted  chan models.PreviewCacheKind
+	mu              sync.Mutex
+	findHit         *preview.DependencyCacheHit
+	findErr         error
+	restoreErr      error
+	saveErr         error
+	pmFindHit       *preview.DependencyCacheHit
+	pmFindErr       error
+	pmRestoreErr    error
+	pmSaveErr       error
+	buildFindHit    *preview.DependencyCacheHit
+	buildFindErr    error
+	buildRestoreErr error
+	buildSaveErr    error
+	finds           int
+	restores        int
+	saves           int
+	savePaths       []string
+	pathFinds       map[models.PreviewCacheKind]int
+	pathRestores    map[models.PreviewCacheKind]int
+	pathSaves       map[models.PreviewCacheKind]int
+	restoreRoots    []models.PreviewCacheRoot
+	saveSpecs       []preview.PreviewPathCacheSaveSpec
+	saveStarted     chan models.PreviewCacheKind
 }
 
 func (f *fakeDependencyCache) Find(context.Context, uuid.UUID, uuid.UUID, string) (*preview.DependencyCacheHit, error) {
@@ -852,18 +882,23 @@ func (f *fakeDependencyCache) FindPathCache(_ context.Context, _ uuid.UUID, _ uu
 	switch kind {
 	case models.PreviewCacheKindPackageManager:
 		return f.pmFindHit, f.pmFindErr
+	case models.PreviewCacheKindBuildArtifact:
+		return f.buildFindHit, f.buildFindErr
 	default:
 		f.finds++
 		return f.findHit, f.findErr
 	}
 }
 
-func (f *fakeDependencyCache) RestorePathCache(_ context.Context, _ *agent.Sandbox, _ *preview.DependencyCacheHit, root models.PreviewCacheRoot) error {
+func (f *fakeDependencyCache) RestorePathCache(_ context.Context, _ *agent.Sandbox, hit *preview.DependencyCacheHit, root models.PreviewCacheRoot) error {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	kind := models.PreviewCacheKindInstallArtifact
 	if root == models.PreviewCacheRootHomeDir {
 		kind = models.PreviewCacheKindPackageManager
+	}
+	if hit != nil && hit.Entry.CacheKind != "" {
+		kind = hit.Entry.CacheKind
 	}
 	if f.pathRestores == nil {
 		f.pathRestores = map[models.PreviewCacheKind]int{}
@@ -873,6 +908,8 @@ func (f *fakeDependencyCache) RestorePathCache(_ context.Context, _ *agent.Sandb
 	switch kind {
 	case models.PreviewCacheKindPackageManager:
 		return f.pmRestoreErr
+	case models.PreviewCacheKindBuildArtifact:
+		return f.buildRestoreErr
 	default:
 		f.restores++
 		return f.restoreErr
@@ -896,6 +933,8 @@ func (f *fakeDependencyCache) SavePathCache(_ context.Context, _ *agent.Sandbox,
 	switch spec.Kind {
 	case models.PreviewCacheKindPackageManager:
 		return preview.DependencyCacheSaveResult{SizeBytes: 456}, f.pmSaveErr
+	case models.PreviewCacheKindBuildArtifact:
+		return preview.DependencyCacheSaveResult{SizeBytes: 789}, f.buildSaveErr
 	default:
 		f.saves++
 		f.savePaths = append([]string(nil), spec.Paths...)
@@ -2375,10 +2414,9 @@ func TestStartPreview_PackageManagerAndDependencyCacheSavesAreIndependent(t *tes
 	require.NotNil(t, handle, "StartPreview should return a handle")
 
 	require.Eventually(t, func() bool {
-		_, _, saves, _, specs := cache.pathCounts()
+		_, _, saves, _, _ := cache.pathCounts()
 		return saves[models.PreviewCacheKindInstallArtifact] == 1 &&
-			saves[models.PreviewCacheKindPackageManager] == 1 &&
-			len(specs) == 2
+			saves[models.PreviewCacheKindPackageManager] == 1
 	}, 2*time.Second, 10*time.Millisecond, "both cache kinds should attempt independent saves after install")
 
 	_, _, saves, _, specs := cache.pathCounts()
@@ -2798,4 +2836,153 @@ func TestWaitForReadiness_BoundsExecPerAttempt(t *testing.T) {
 	// Generous upper bound so this isn't flaky on a loaded CI host but small
 	// enough to catch the regression where the loop stalls on a hung Exec.
 	require.Less(t, elapsed, 30*time.Second, "readiness loop didn't honor its timeout under a hung Exec")
+}
+
+func TestStartPreview_BuildCacheRestoresAfterInstallAndSavesPostReady(t *testing.T) {
+	t.Parallel()
+
+	release := make(chan struct{})
+	exec := &fakeServiceExecutor{
+		execStreamFn: func(ctx context.Context, cmd string, _ func([]byte)) (int, error) {
+			select {
+			case <-release:
+			case <-ctx.Done():
+			}
+			return 0, nil
+		},
+		execFn: func(_ context.Context, _ string) (int, error) {
+			return 0, nil
+		},
+		readFileFn: func(_ context.Context, path string) ([]byte, error) {
+			switch path {
+			case "package-lock.json":
+				return []byte(`{"lockfileVersion":3}`), nil
+			default:
+				return []byte("ok"), nil
+			}
+		},
+	}
+	cache := &fakeDependencyCache{
+		findHit: &preview.DependencyCacheHit{},
+		buildFindHit: &preview.DependencyCacheHit{
+			Entry: models.PreviewDependencyCache{
+				CacheKind: models.PreviewCacheKindBuildArtifact,
+				SizeBytes: 999,
+				Metadata:  []byte(`{"checksum_sha256":"prior-checksum"}`),
+			},
+		},
+	}
+	d := NewDockerPreviewProvider(previewReachableClient(), exec, zerolog.Nop(), WithPreviewDialer(successfulPreviewDialer), WithDependencyCache(cache))
+	obs := &recordingObserver{}
+
+	handle, err := d.StartPreview(context.Background(), &agent.Sandbox{ID: "sb", WorkDir: "/workspace/repo"}, previewInstallTestConfig(), preview.StartPreviewOptions{
+		OrgID:        uuid.New(),
+		RepositoryID: uuid.New(),
+		SessionID:    uuid.New(),
+	}, obs)
+	require.NoError(t, err, "StartPreview should succeed with a build cache hit")
+	require.NotNil(t, handle, "StartPreview should return a handle")
+
+	finds, restores, _, _, _ := cache.pathCounts()
+	require.Equal(t, 1, finds[models.PreviewCacheKindBuildArtifact], "build cache should be looked up once after install")
+	require.Equal(t, 1, restores[models.PreviewCacheKindBuildArtifact], "build cache hit should restore into the workdir")
+
+	restoreEvents := obs.buildCacheRestoreEvents()
+	require.Len(t, restoreEvents, 1, "observer should receive one build cache restore event")
+	require.Equal(t, "restored", restoreEvents[0].status, "observer should report a restored build cache hit")
+
+	// The post-ready save runs asynchronously once readiness completes.
+	require.Eventually(t, func() bool {
+		_, _, saves, _, _ := cache.pathCounts()
+		return saves[models.PreviewCacheKindBuildArtifact] == 1
+	}, 5*time.Second, 10*time.Millisecond, "build cache should be saved once services report ready")
+
+	_, _, _, _, specs := cache.pathCounts()
+	var buildSpec *preview.PreviewPathCacheSaveSpec
+	for i := range specs {
+		if specs[i].Kind == models.PreviewCacheKindBuildArtifact {
+			buildSpec = &specs[i]
+		}
+	}
+	require.NotNil(t, buildSpec, "build cache save spec should be recorded")
+	require.Equal(t, models.PreviewCacheRootWorkDir, buildSpec.Root, "build cache should archive workdir-relative paths")
+	require.Contains(t, buildSpec.Paths, "node_modules/.cache/turbo", "build cache should include the inferred turbo cache dir")
+	require.Contains(t, buildSpec.Paths, ".turbo/cache", "build cache should include the legacy turbo cache dir")
+	require.Equal(t, "prior-checksum", buildSpec.SkipIfChecksum, "post-ready save should skip upload when content matches the restored blob")
+
+	require.Eventually(t, func() bool {
+		return len(obs.buildCacheSaveEvents()) == 1
+	}, 5*time.Second, 10*time.Millisecond, "observer should receive one build cache save event")
+	require.Equal(t, "saved", obs.buildCacheSaveEvents()[0].status, "observer should report the post-ready save")
+
+	close(release)
+	require.NoError(t, d.StopPreview(context.Background(), handle.Handle), "StopPreview should clean up the started preview")
+}
+
+func TestStartPreview_DependencyCacheSaveExcludesBuildCachePaths(t *testing.T) {
+	t.Parallel()
+
+	// Cold start: no install marker, install runs, and the post-install
+	// dependency save must exclude turbo's dirs so the install-artifact blob
+	// never absorbs build cache content.
+	release := make(chan struct{})
+	exec := &fakeServiceExecutor{
+		execStreamFn: func(ctx context.Context, cmd string, _ func([]byte)) (int, error) {
+			if strings.Contains(cmd, "'npm' 'ci'") {
+				return 0, nil
+			}
+			select {
+			case <-release:
+			case <-ctx.Done():
+			}
+			return 0, nil
+		},
+		execFn: func(_ context.Context, cmd string) (int, error) {
+			if strings.Contains(cmd, "test -f") || strings.Contains(cmd, "test -e") {
+				return 1, nil
+			}
+			return 0, nil
+		},
+		readFileFn: func(_ context.Context, path string) ([]byte, error) {
+			switch path {
+			case "package-lock.json":
+				return []byte(`{"lockfileVersion":3}`), nil
+			default:
+				return []byte("ok"), nil
+			}
+		},
+	}
+	cache := &fakeDependencyCache{}
+	d := NewDockerPreviewProvider(previewReachableClient(), exec, zerolog.Nop(), WithPreviewDialer(successfulPreviewDialer), WithDependencyCache(cache))
+	obs := &recordingObserver{}
+
+	handle, err := d.StartPreview(context.Background(), &agent.Sandbox{ID: "sb", WorkDir: "/workspace/repo"}, previewInstallTestConfig(), preview.StartPreviewOptions{
+		OrgID:        uuid.New(),
+		RepositoryID: uuid.New(),
+		SessionID:    uuid.New(),
+	}, obs)
+	require.NoError(t, err, "StartPreview should succeed on a cold install")
+	require.NotNil(t, handle, "StartPreview should return a handle")
+
+	require.Eventually(t, func() bool {
+		_, _, _, _, specs := cache.pathCounts()
+		for _, spec := range specs {
+			if spec.Kind == models.PreviewCacheKindInstallArtifact {
+				return true
+			}
+		}
+		return false
+	}, 5*time.Second, 10*time.Millisecond, "cold install should save the dependency cache")
+
+	_, _, _, _, specs := cache.pathCounts()
+	for _, spec := range specs {
+		if spec.Kind != models.PreviewCacheKindInstallArtifact {
+			continue
+		}
+		require.Contains(t, spec.ExcludePaths, "node_modules/.cache/turbo", "dependency save should exclude the turbo cache subtree")
+		require.Contains(t, spec.ExcludePaths, ".turbo/cache", "dependency save should exclude the legacy turbo cache subtree")
+	}
+
+	close(release)
+	require.NoError(t, d.StopPreview(context.Background(), handle.Handle), "StopPreview should clean up the started preview")
 }


### PR DESCRIPTION
## Problem

Session previews restore the dependency and package-manager caches, but Turborepo still reported `cache miss` for every workspace package on each launch (seen on session `7c2ade9e`): ~30–60s of rollup/turbo builds before the dev server can come up.

Root cause is save timing: the install-artifact cache is archived immediately after the install command finishes — before any service starts — so `node_modules/.cache/turbo` is always empty in the blob. On warm launches the save is skipped entirely (`skipped_fresh_restore`), so the turbo cache populated during boot died with each sandbox. The system was stuck at "deps warm, builds cold".

## What changed

New preview cache kind `build_artifact` (no migration: `cache_kind` is a plain text column with kind-scoped unique indexes):

- **Paths**: `preview.install.cache.build.paths` plus inferred Turborepo dirs next to each JS lockfile (`node_modules/.cache/turbo`, `.turbo/cache`). Opt out via `cache.build.enabled: false`.
- **Latest-wins keying**: `ComputePreviewBuildCacheKey` hashes org/repo/config name/config digest/install command/lockfile *paths*/effective paths — deliberately not lockfile contents or sandbox image. One slot per config, overwritten on every save. Safe because build tools content-hash their own entries: a stale blob degrades to partial hits, never wrong output.
- **Restore** runs as phase 4.5 in `StartPreview` — after install (so `npm ci` can't wipe the restored tree), before services start (so boot-time builds hit).
- **Save** runs asynchronously once services report ready (standard: after all ready; progressive: at the end of the background support-service loop), guarded by a per-launch `sync.Once`. `SkipIfChecksum` skips upload/upsert when the archive matches the restored blob.
- **Kind separation**: install-artifact saves now pass the build paths as quoted tar `--exclude` flags, so dependency blobs never absorb (or race with) the turbo subtree inside `node_modules`.
- **Blob hygiene**: `SavePathCache` deletes the superseded checksum-addressed blob after a latest-wins overwrite, preventing one orphaned blob per content-changing save.
- **Placement**: the start handler adds a `build_artifact` placement entry so the worker scheduler prefers nodes holding the blob in their local L1.
- Observer events (`OnBuildCacheRestore`/`OnBuildCacheSave`) feed preview logs; metrics land in `preview.session.build_cache.*`. Docs updated in `docs/public/reference/preview-config.mdx`.

## Reviewer notes

- `SkipIfChecksum` is best-effort (tar output isn't guaranteed byte-identical across runs); worst case is a redundant upload, and the `unchanged` vs `saved` metric split will show how often it helps.
- The post-ready save can race a live HMR rebuild writing turbo entries; tar then exits non-zero and the save is logged as `save_failed` and retried next launch.
- The existing LRU cleaner and locations machinery are kind-agnostic, so `build_artifact` rows expire with no changes.
- First launch per repo/config after deploy still builds cold (it populates the slot); the win shows from the second launch. Watch `preview.session.build_cache.restores{result="restored"}` and frontend logs for turbo `cache hit, replaying logs`.

## Testing

- New unit tests: build-path resolution/inference, latest-wins key semantics, tar exclude flags, checksum-skip, superseded-blob deletion, and two `StartPreview`-level tests (restore-then-post-ready-save with hit; cold-install dependency save excludes build paths).
- `go build ./...`, `make lint` (0 issues), and uncached runs of the `preview`, `providers`, `handlers`, `metrics`, `db`, and `models` suites all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
