### PR TITLE
Reduce diff padding for compact unified and split line gutters

### DIFF
--- a/frontend/src/components/code-review/context-expander.test.tsx
+++ b/frontend/src/components/code-review/context-expander.test.tsx
@@ -83,6 +83,35 @@ describe("ContextExpander", () => {
     expect(screen.getByTestId("context-expander-label")).toBeEmptyDOMElement();
   });
 
+  it("matches the compact unified diff gutter width", () => {
+    render(
+      <ContextExpander
+        kind="middle"
+        hiddenLineCount={15}
+        hiddenStart={6}
+        hiddenEnd={20}
+      />
+    );
+
+    expect(screen.getByTestId("context-expander-gutter-controls")).toHaveClass("w-[84px]");
+    expect(screen.getByTestId("context-expander-prefix-spacer")).toHaveClass("w-[16px]");
+  });
+
+  it("matches the compact split diff gutter width", () => {
+    render(
+      <ContextExpander
+        kind="middle"
+        viewMode="split"
+        hiddenLineCount={15}
+        hiddenStart={6}
+        hiddenEnd={20}
+      />
+    );
+
+    expect(screen.getByTestId("context-expander-gutter-controls")).toHaveClass("w-[58px]");
+    expect(screen.getByTestId("context-expander-prefix-spacer")).toHaveClass("w-0");
+  });
+
   it("is disabled when sessionId/filePath/startLine are missing", () => {
     render(<ContextExpander kind="middle" hiddenLineCount={10} hiddenStart={6} hiddenEnd={15} />);
     expect(screen.getByRole("button", { name: "Reveal context above" })).toBeDisabled();

--- a/frontend/src/components/code-review/context-expander.tsx
+++ b/frontend/src/components/code-review/context-expander.tsx
@@ -137,8 +137,8 @@ export function ContextExpander({
       ? `Reveal ${hiddenLineCount} hidden context lines`
       : "Reveal context below"
     : "Context expansion unavailable (sandbox not running)";
-  const gutterWidthClass = viewMode === "split" ? "w-[66px]" : "w-[100px]";
-  const prefixSpacerClass = viewMode === "split" ? "w-0" : "w-[20px]";
+  const gutterWidthClass = viewMode === "split" ? "w-[58px]" : "w-[84px]";
+  const prefixSpacerClass = viewMode === "split" ? "w-0" : "w-[16px]";
 
   function renderControl({
     direction,

--- a/frontend/src/components/code-review/diff-hunk.test.tsx
+++ b/frontend/src/components/code-review/diff-hunk.test.tsx
@@ -133,6 +133,9 @@ describe("DiffHunk", () => {
     expect(container.querySelector('[data-testid="inline-comment-composer-anchor"]')).toHaveClass(
       "sticky"
     );
+    expect(container.querySelector('[data-testid="inline-comment-composer-anchor"]')).toHaveClass(
+      "pl-[100px]"
+    );
   });
 
   it("does not render comment input when activeCommentLine does not match", () => {

--- a/frontend/src/components/code-review/diff-hunk.tsx
+++ b/frontend/src/components/code-review/diff-hunk.tsx
@@ -85,7 +85,7 @@ export function DiffHunk({
             {lineComments && lineComments.length > 0 && onUpdateComment && onDeleteComment && (
               <div
                 data-testid="inline-comment-thread-anchor"
-                className="sticky left-0 pl-[120px] pr-2"
+                className="sticky left-0 pl-[100px] pr-2"
               >
                 <CommentThread
                   comments={lineComments}
@@ -100,7 +100,7 @@ export function DiffHunk({
             {showInlineCommentComposer && isActiveCommentLine && onSubmitComment && onCancelComment && (
               <div
                 data-testid="inline-comment-composer-anchor"
-                className="sticky left-0 pl-[120px] pr-2"
+                className="sticky left-0 pl-[100px] pr-2"
               >
                 <CommentInput
                   className="max-w-[min(42rem,calc(100cqw-10rem))]"

--- a/frontend/src/components/code-review/diff-line.test.tsx
+++ b/frontend/src/components/code-review/diff-line.test.tsx
@@ -26,6 +26,12 @@ describe("DiffLineRow", () => {
     expect(screen.getByText("12")).toBeInTheDocument();
   });
 
+  it("uses compact line-number gutters so code has more horizontal room", () => {
+    render(<DiffLineRow line={makeLine({ oldLineNumber: 10, newLineNumber: 12 })} />);
+    expect(screen.getByText("10")).toHaveClass("w-[42px]", "pr-1");
+    expect(screen.getByText("12")).toHaveClass("w-[42px]", "pr-1");
+  });
+
   it("renders add line with + prefix", () => {
     const { container } = render(
       <DiffLineRow line={makeLine({ type: "add", oldLineNumber: null, newLineNumber: 3 })} />

--- a/frontend/src/components/code-review/diff-line.tsx
+++ b/frontend/src/components/code-review/diff-line.tsx
@@ -117,7 +117,7 @@ export function DiffLineRow({ line, filePath, highlightedContent, onAddComment, 
         onClick={(e) => handleLineNumberButtonClick(e, line.oldLineNumber, "L")}
         onKeyDown={handleLineNumberButtonKeyDown}
         className={cn(
-          "w-[50px] shrink-0 text-right pr-2 select-none text-xs text-muted-foreground/60 hover:text-primary cursor-pointer",
+          "w-[42px] shrink-0 text-right pr-1 select-none text-xs text-muted-foreground/60 hover:text-primary cursor-pointer",
           lineNumberStyles[line.type]
         )}
       >
@@ -129,14 +129,14 @@ export function DiffLineRow({ line, filePath, highlightedContent, onAddComment, 
         onClick={(e) => handleLineNumberButtonClick(e, line.newLineNumber, "R")}
         onKeyDown={handleLineNumberButtonKeyDown}
         className={cn(
-          "w-[50px] shrink-0 text-right pr-2 select-none text-xs text-muted-foreground/60 hover:text-primary cursor-pointer",
+          "w-[42px] shrink-0 text-right pr-1 select-none text-xs text-muted-foreground/60 hover:text-primary cursor-pointer",
           lineNumberStyles[line.type]
         )}
       >
         {line.newLineNumber ?? ""}
       </button>
       {/* Prefix (+/-/space) */}
-      <div className="w-[20px] shrink-0 text-center select-none text-muted-foreground/50">
+      <div className="w-[16px] shrink-0 text-center select-none text-muted-foreground/50">
         {linePrefix[line.type]}
       </div>
       {/* Content */}

--- a/frontend/src/components/code-review/split-diff-hunk.test.tsx
+++ b/frontend/src/components/code-review/split-diff-hunk.test.tsx
@@ -53,6 +53,14 @@ describe("SplitDiffHunk", () => {
     expect(elements.length).toBe(2);
   });
 
+  it("uses compact line-number gutters so split panes keep more code visible", () => {
+    const hunk = makeHunk([contextLine]);
+    render(<SplitDiffHunk hunk={hunk} filePath="src/app.ts" />);
+    const lineNumbers = screen.getAllByText("1");
+    expect(lineNumbers[0]).toHaveClass("w-[42px]", "pr-1");
+    expect(lineNumbers[1]).toHaveClass("w-[42px]", "pr-1");
+  });
+
   it("renders remove+add pair side by side", () => {
     const hunk = makeHunk([removeLine, addLine]);
     render(<SplitDiffHunk hunk={hunk} filePath="src/app.ts" />);

--- a/frontend/src/components/code-review/split-diff-hunk.tsx
+++ b/frontend/src/components/code-review/split-diff-hunk.tsx
@@ -131,7 +131,7 @@ const SplitLineCell = memo(function SplitLineCell({
   if (!line) {
     return (
       <div className={cn("flex text-xs font-mono leading-[20px] flex-1 min-w-0", bgStyles.empty)}>
-        <div className={cn("w-[50px] shrink-0 select-none", gutterBg.empty)} />
+        <div className={cn("w-[42px] shrink-0 select-none", gutterBg.empty)} />
         <div className="w-[16px] shrink-0" />
         <div className="flex-1 min-w-0">&nbsp;</div>
       </div>
@@ -191,7 +191,7 @@ const SplitLineCell = memo(function SplitLineCell({
       )}
       <div
         className={cn(
-          "w-[50px] shrink-0 text-right pr-2 select-none text-xs text-muted-foreground/60",
+          "w-[42px] shrink-0 text-right pr-1 select-none text-xs text-muted-foreground/60",
           gutterBg[type]
         )}
       >


### PR DESCRIPTION
## Summary
This change tightens the diff layout spacing to match the new compact gutter sizing. It updates unified/split gutter widths, prefix spacing, and inline comment anchor alignment so controls and context expanders remain visually consistent.

## Changes
- `frontend/src/components/code-review/context-expander.tsx`
  - Updated unified diff gutter width `w-[100px]` → `w-[84px]`
  - Updated prefix spacer `w-[20px]` → `w-[16px]`
  - Updated split diff gutter width `w-[66px]` → `w-[58px]` (prefix spacer remains `w-0`)
- `frontend/src/components/code-review/context-expander.test.tsx`
  - Added tests asserting compact unified and split gutter/prefix widths via class names
- `frontend/src/components/code-review/diff-hunk.tsx`
  - Adjusted inline comment anchor padding `pl-[120px]` → `pl-[100px]` to align with the tightened diff layout
- `frontend/src/components/code-review/diff-hunk.test.tsx`
  - Added assertion for the updated `pl-[100px]` class on the inline comment composer anchor
- `frontend/src/components/code-review/diff-line.tsx`, `frontend/src/components/code-review/diff-line.test.tsx`,
  `frontend/src/components/code-review/split-diff-hunk.tsx`, `frontend/src/components/code-review/split-diff-hunk.test.tsx`
  - Updated corresponding gutter/padding values and related sizing assertions to keep split hunk and line views aligned

## Test plan
- `npm test -- diff-line.test.tsx split-diff-hunk.test.tsx context-expander.test.tsx diff-hunk.test.tsx`
- `npm run typecheck`
- `npm run lint`
- `npm run build`

[143.dev](https://143.dev) | [session 317813cf](https://143.dev/sessions/317813cf-2c58-4bd0-b31d-c336b0d37d0c)

Preview: https://143.dev/previews/github/assembledhq/143/pull/1378