### PR TITLE
Fix backend lint on main: remove unused previewAPITokenTestCols

### DIFF
--- a/internal/api/handlers/branch_previews_test.go
+++ b/internal/api/handlers/branch_previews_test.go
@@ -871,12 +871,6 @@ func TestBranchPreviewHandler_CreateReusesSessionPreviewWhenCommitSHAsMatch(t *t
 	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
 }
 
-// previewAPITokenTestCols mirrors the column order in previewAPITokenColumns.
-var previewAPITokenTestCols = []string{
-	"id", "org_id", "name", "token_hash", "scopes", "repository_ids",
-	"created_by_user_id", "last_used_at", "revoked_at", "created_at",
-}
-
 func TestBranchPreviewHandler_APITokenManagementEndpointsAreDeprecated(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
main's Backend Lint is currently red: [#1382](https://github.com/assembledhq/143/pull/1382) removed both usages of `previewAPITokenTestCols` in `branch_previews_test.go` but left the declaration, tripping golangci-lint's `unused` check. Every open PR inherits the failure via its merge commit (surfaced on [#1361](https://github.com/assembledhq/143/pull/1361)).

Removes the dead var. Verified on this branch: `make lint` → 0 issues, and the branch-preview handler tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)