### PR TITLE
Remove Previews page load flash by waiting for section queries and using stable placeholder data

### DIFF
--- a/frontend/src/app/(dashboard)/previews/page.test.tsx
+++ b/frontend/src/app/(dashboard)/previews/page.test.tsx
@@ -90,6 +90,14 @@ function installPreviewHandlers(
   );
 }
 
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
+}
+
 describe("PreviewsPage", () => {
   beforeEach(() => {
     currentUserRole.value = "member";
@@ -264,6 +272,29 @@ describe("PreviewsPage", () => {
     expect(
       screen.getByRole("link", { name: /create preview/i }),
     ).toHaveAttribute("href", "/previews/new");
+  });
+
+  it("keeps the initial preview content quiet until all sections resolve empty", async () => {
+    const previewsReleased = deferred<void>();
+    server.use(
+      http.get("*/api/v1/repositories", () =>
+        HttpResponse.json({ data: repositories, meta: {} }),
+      ),
+      http.get("*/api/v1/previews", async () => {
+        await previewsReleased.promise;
+        return HttpResponse.json({ data: [], meta });
+      }),
+    );
+
+    renderWithProviders(<PreviewsPage />);
+
+    expect(screen.queryByText("Loading previews...")).not.toBeInTheDocument();
+    expect(screen.queryByText("No previews are running.")).not.toBeInTheDocument();
+    expect(screen.queryByText("No previews yet")).not.toBeInTheDocument();
+
+    previewsReleased.resolve();
+
+    expect(await screen.findByText("No previews yet")).toBeInTheDocument();
   });
 
   it("shows a stable per-section error state instead of the empty state when the list API fails", async () => {

--- a/frontend/src/app/(dashboard)/previews/page.tsx
+++ b/frontend/src/app/(dashboard)/previews/page.tsx
@@ -417,6 +417,7 @@ export default function PreviewsPage() {
         limit: 50,
       }),
     refetchInterval: pollMs(5000),
+    placeholderData: (previous) => previous,
   });
   const resumableQuery = useQuery<
     ListResponse<BranchPreviewResponse> & { meta: PreviewListMeta }
@@ -430,6 +431,7 @@ export default function PreviewsPage() {
         limit: 50,
       }),
     refetchInterval: pollMs(30000),
+    placeholderData: (previous) => previous,
   });
   const recentQuery = useQuery<
     ListResponse<BranchPreviewResponse> & { meta: PreviewListMeta }
@@ -443,6 +445,7 @@ export default function PreviewsPage() {
         limit: 50,
       }),
     refetchInterval: pollMs(30000),
+    placeholderData: (previous) => previous,
   });
   const sectionQueries = [runningQuery, resumableQuery, recentQuery];
 
@@ -456,6 +459,9 @@ export default function PreviewsPage() {
   // refreshes them as soon as the backend recovers.
   const sectionFailed = (query: (typeof sectionQueries)[number]) =>
     query.data === undefined && (query.isError || query.errorUpdateCount > 0);
+  const previewSectionsSettled = sectionQueries.every(
+    (item) => item.data !== undefined || sectionFailed(item),
+  );
   // Only successfully settled, genuinely empty sections count toward the
   // page-level empty state; loading or failed sections must not flip the page
   // to "No previews yet".
@@ -535,7 +541,9 @@ export default function PreviewsPage() {
           </Select>
         </div>
 
-        {allEmpty ? (
+        {!previewSectionsSettled ? (
+          <div className="min-h-48" aria-hidden="true" />
+        ) : allEmpty ? (
           <EmptyState
             icon={MonitorPlay}
             title="No previews yet"
@@ -597,8 +605,14 @@ export default function PreviewsPage() {
                   </div>
                   <SectionRows
                     scope={section.scope}
-                    previews={section.scope === "recent" ? recentPreviews : (sectionQuery.data?.data ?? [])}
-                    isLoading={sectionQuery.isLoading && !sectionFailed(sectionQuery)}
+                    previews={
+                      section.scope === "recent"
+                        ? recentPreviews
+                        : (sectionQuery.data?.data ?? [])
+                    }
+                    isLoading={
+                      sectionQuery.isLoading && !sectionFailed(sectionQuery)
+                    }
                     isError={sectionFailed(sectionQuery)}
                     onRetry={() => sectionQuery.refetch()}
                     canMutate={canMutate}


### PR DESCRIPTION
## Summary
Previews page navigation is now deterministic and avoids the initial “Loading/empty” flash. Instead of relying on an arbitrary timeout, the page waits until all preview section queries have either loaded or are considered failed, and it keeps previous results visible during later refetches.

## Changes
- **frontend/src/app/(dashboard)/previews/page.tsx**
  - Added `placeholderData: (previous) => previous` to the section `useQuery` calls so subsequent refetches don’t temporarily clear the UI.
  - Introduced `previewSectionsSettled` to determine when section queries have resolved (`data !== undefined`) or are failed in a way that should stop treating the page as “still loading”.
  - Updated page empty-state rendering:
    - While sections are not settled yet, render a quiet placeholder (`<div className="min-h-48" aria-hidden="true" />`) instead of showing “No previews yet/empty” prematurely.
    - Only render the `EmptyState` when `allEmpty` is true *and* sections are settled.
- **frontend/src/app/(dashboard)/previews/page.test.tsx**
  - Added a test (`keeps the initial preview content quiet until all sections resolve empty`) using a deferred API response to ensure the initial empty state is not rendered until section queries resolve.

## Test plan
- `npm test -- --run "src/app/(dashboard)/previews/page.test.tsx"`
- `npm run typecheck`
- `npm run lint`
- `npm run build`

[143.dev](https://143.dev) | [session 43331e63](https://143.dev/sessions/43331e63-b482-494f-b325-6c211c0c977e)

Preview: https://143.dev/previews/github/assembledhq/143/pull/1388