### PR TITLE
Expand Codex diagnostic hiding and annotate session logs

### DIFF
--- a/frontend/src/lib/timeline.test.ts
+++ b/frontend/src/lib/timeline.test.ts
@@ -105,7 +105,7 @@ describe("buildTimeline", () => {
     expect(result[0].kind).toBe("log");
   });
 
-  it("keeps recoverable Codex apply_patch diagnostics behind the log toggle", () => {
+  it("does not classify raw Codex-looking errors without backend visibility metadata", () => {
     const logs = [
       makeLog({
         id: 1,
@@ -116,21 +116,43 @@ describe("buildTimeline", () => {
     ];
     const result = buildTimeline([], logs);
     expect(result).toHaveLength(1);
-    expect(result[0].kind).toBe("log");
+    expect(result[0].kind).toBe("error");
   });
 
-  it("keeps recoverable Codex apply_patch diagnostics with top-level context behind the log toggle", () => {
+  it("keeps backend-classified Codex diagnostics behind the log toggle", () => {
     const logs = [
       makeLog({
         id: 1,
         created_at: "2026-01-01T00:00:01Z",
         level: "error",
         message: "2026-05-22T05:52:30.204805Z ERROR codex_core::tools::router: error=apply_patch verification failed: Failed to find expected lines in /home/sandbox/143/internal/db/autopilot_queue.go:\nfunc ptrTime(t time.Time) *time.Time {\n\treturn &t\n}",
+        metadata: { visibility: "hidden", diagnostic_class: "benign_runtime_diagnostic", diagnostic_source: "codex" },
+      }),
+      makeLog({
+        id: 2,
+        created_at: "2026-01-01T00:00:02Z",
+        level: "error",
+        message: "Reconnecting... 2/5 (stream disconnected before completion: failed to lookup address information: Try again)",
+        metadata: { visibility: "hidden", diagnostic_class: "benign_runtime_diagnostic", diagnostic_source: "codex" },
+      }),
+      makeLog({
+        id: 3,
+        created_at: "2026-01-01T00:00:03Z",
+        level: "error",
+        message: "2026-06-12T08:54:38.209896Z ERROR codex_api::endpoint::responses_websocket: failed to connect to websocket: IO error: failed to lookup address information: Try again, url: wss://chatgpt.com/backend-api/codex/responses",
+        metadata: { visibility: "hidden", diagnostic_class: "benign_runtime_diagnostic", diagnostic_source: "codex" },
+      }),
+      makeLog({
+        id: 4,
+        created_at: "2026-01-01T00:00:04Z",
+        level: "error",
+        message: "2026-06-12T02:31:46.399958Z ERROR codex_models_manager::manager: failed to refresh available models: timeout waiting for child process to exit",
+        metadata: { visibility: "hidden", diagnostic_class: "benign_runtime_diagnostic", diagnostic_source: "codex" },
       }),
     ];
     const result = buildTimeline([], logs);
-    expect(result).toHaveLength(1);
-    expect(result[0].kind).toBe("log");
+    expect(result).toHaveLength(4);
+    expect(result.map((entry) => entry.kind)).toEqual(["log", "log", "log", "log"]);
   });
 
   it("shows streamed assistant output logs as assistant_output when no persisted message exists", () => {

--- a/frontend/src/lib/timeline.ts
+++ b/frontend/src/lib/timeline.ts
@@ -37,15 +37,8 @@ function metadataString(metadata: SessionLog["metadata"] | null | undefined, key
   return typeof value === "string" ? value : undefined;
 }
 
-function isRecoverableCodexRouterDiagnostic(message: string): boolean {
-  return message.includes("codex_core::tools::router:") && (
-    message.includes("write_stdin failed: stdin is closed for this session") ||
-    message.includes("apply_patch verification failed: Failed to find expected lines")
-  );
-}
-
 function isHiddenLog(log: SessionLog): boolean {
-  return metadataString(log.metadata, "visibility") === "hidden" || isRecoverableCodexRouterDiagnostic(log.message);
+  return metadataString(log.metadata, "visibility") === "hidden";
 }
 
 function isToolResultLog(item: TaggedTimelineItem | undefined): item is Extract<TaggedTimelineItem, { source: "log" }> {

--- a/internal/agentdiagnostics/codex.go
+++ b/internal/agentdiagnostics/codex.go
@@ -1,0 +1,83 @@
+package agentdiagnostics
+
+import (
+	"strings"
+	"time"
+)
+
+// ClassifyBenignCodexDiagnostic identifies Codex CLI/runtime diagnostics that
+// are useful for debugging but should not be rendered as user-facing failures.
+func ClassifyBenignCodexDiagnostic(msg string) (kind string, multiline bool, ok bool) {
+	trimmed := strings.TrimSpace(msg)
+	if strings.Contains(trimmed, "codex_core::tools::router:") {
+		switch {
+		case strings.Contains(trimmed, "write_stdin failed:"):
+			if strings.Contains(trimmed, "stdin is closed for this session") {
+				return "closed_stdin", false, true
+			}
+			return "write_stdin_failed", false, true
+		case strings.Contains(trimmed, "apply_patch verification failed: Failed to find expected lines"):
+			return "apply_patch_verification_failed", true, true
+		case strings.Contains(trimmed, "failed to parse function arguments:"):
+			return "tool_argument_parse_failed", false, true
+		case strings.Contains(trimmed, "unable to process image at"):
+			return "tool_image_processing_failed", false, true
+		}
+	}
+	if isRecoverableCodexResponsesWebsocketDiagnostic(trimmed) {
+		return "responses_websocket_retry", false, true
+	}
+	if strings.Contains(trimmed, "codex_core_skills::loader: failed to stat skills path") {
+		return "skills_loader_missing_path", false, true
+	}
+	if strings.Contains(trimmed, "codex_models_manager::manager: failed to refresh available models:") {
+		return "models_refresh_failed", false, true
+	}
+	if trimmed == "Reading additional input from stdin..." {
+		return "stdin_notice", false, true
+	}
+	return "", false, false
+}
+
+func IsBenignCodexDiagnostic(msg string) bool {
+	_, _, ok := ClassifyBenignCodexDiagnostic(msg)
+	return ok
+}
+
+func IsCodexLogRecordStart(trimmed string) bool {
+	fields := strings.Fields(trimmed)
+	if len(fields) >= 3 {
+		if _, err := time.Parse(time.RFC3339Nano, fields[0]); err == nil &&
+			isCodexLogLevel(fields[1]) &&
+			isCodexRustTarget(fields[2]) {
+			return true
+		}
+	}
+	return len(fields) >= 2 && isCodexLogLevel(fields[0]) && isCodexRustTarget(fields[1])
+}
+
+func isRecoverableCodexResponsesWebsocketDiagnostic(msg string) bool {
+	trimmed := strings.TrimSpace(msg)
+	if strings.HasPrefix(trimmed, "Reconnecting... ") &&
+		strings.Contains(trimmed, "stream disconnected before completion:") {
+		return true
+	}
+	return strings.Contains(trimmed, "codex_api::endpoint::responses_websocket:") &&
+		strings.Contains(trimmed, "failed to connect to websocket:")
+}
+
+func isCodexRustTarget(value string) bool {
+	return strings.HasPrefix(value, "codex_core::") ||
+		strings.HasPrefix(value, "codex_api::") ||
+		strings.HasPrefix(value, "codex_core_skills::") ||
+		strings.HasPrefix(value, "codex_models_manager::")
+}
+
+func isCodexLogLevel(value string) bool {
+	switch value {
+	case "ERROR", "WARN", "INFO", "DEBUG", "TRACE":
+		return true
+	default:
+		return false
+	}
+}

--- a/internal/api/handlers/sessions.go
+++ b/internal/api/handlers/sessions.go
@@ -1829,11 +1829,12 @@ func writeSessionLogSSEEvent(sw *sse.Writer, log models.SessionLog) error {
 }
 
 func writeSessionLogSSEEventWithID(sw *sse.Writer, streamID string, log models.SessionLog) error {
-	if err := sw.WriteDataID(streamID, log); err != nil {
+	payload := models.NewSessionLogResponse(log)
+	if err := sw.WriteDataID(streamID, payload); err != nil {
 		return err
 	}
 	if eventType, ok := humanInputSSEEventType(log); ok {
-		if err := sw.WriteEventID(eventType, streamID, log); err != nil {
+		if err := sw.WriteEventID(eventType, streamID, payload); err != nil {
 			return err
 		}
 	}

--- a/internal/models/session_log_response.go
+++ b/internal/models/session_log_response.go
@@ -5,6 +5,7 @@ import (
 	"time"
 	"unicode/utf8"
 
+	"github.com/assembledhq/143/internal/agentdiagnostics"
 	"github.com/google/uuid"
 )
 
@@ -50,13 +51,14 @@ type SessionTimelineResponseEntry struct {
 
 func NewSessionLogResponse(log SessionLog) SessionLogResponse {
 	message, truncated := previewSessionLogMessage(log.Message)
+	metadata := responseSessionLogMetadata(log)
 	return SessionLogResponse{
 		ID:               log.ID,
 		SessionID:        log.SessionID,
 		ThreadID:         log.ThreadID,
 		Level:            log.Level,
 		Message:          message,
-		Metadata:         log.Metadata,
+		Metadata:         metadata,
 		TurnNumber:       log.TurnNumber,
 		CreatedAt:        log.Timestamp,
 		MessageBytes:     len([]byte(log.Message)),
@@ -72,7 +74,7 @@ func NewSessionLogDetailResponse(log SessionLog) SessionLogDetailResponse {
 		ThreadID:     log.ThreadID,
 		Level:        log.Level,
 		Message:      log.Message,
-		Metadata:     log.Metadata,
+		Metadata:     responseSessionLogMetadata(log),
 		TurnNumber:   log.TurnNumber,
 		CreatedAt:    log.Timestamp,
 		MessageBytes: len([]byte(log.Message)),
@@ -136,4 +138,36 @@ func previewSessionLogMessage(message string) (string, bool) {
 		preview = preview[:len(preview)-1]
 	}
 	return preview, true
+}
+
+func responseSessionLogMetadata(log SessionLog) json.RawMessage {
+	kind, _, ok := agentdiagnostics.ClassifyBenignCodexDiagnostic(log.Message)
+	if !ok {
+		return log.Metadata
+	}
+
+	var metadata map[string]any
+	if len(log.Metadata) > 0 {
+		if err := json.Unmarshal(log.Metadata, &metadata); err != nil {
+			metadata = nil
+		}
+	}
+	if metadata == nil {
+		metadata = make(map[string]any)
+	}
+	metadata["visibility"] = "hidden"
+	if _, exists := metadata["diagnostic_class"]; !exists {
+		metadata["diagnostic_class"] = "benign_runtime_diagnostic"
+	}
+	if _, exists := metadata["diagnostic_source"]; !exists {
+		metadata["diagnostic_source"] = "codex"
+	}
+	if _, exists := metadata["diagnostic_kind"]; !exists {
+		metadata["diagnostic_kind"] = kind
+	}
+	out, err := json.Marshal(metadata)
+	if err != nil {
+		return log.Metadata
+	}
+	return out
 }

--- a/internal/models/session_log_response_test.go
+++ b/internal/models/session_log_response_test.go
@@ -1,6 +1,7 @@
 package models
 
 import (
+	"encoding/json"
 	"strings"
 	"testing"
 	"time"
@@ -67,6 +68,50 @@ func TestNewSessionLogResponse(t *testing.T) {
 			require.Equal(t, now, resp.CreatedAt, "response should map timestamp to created_at")
 		})
 	}
+}
+
+func TestNewSessionLogResponseAnnotatesBenignCodexDiagnostics(t *testing.T) {
+	t.Parallel()
+
+	log := SessionLog{
+		ID:        43,
+		SessionID: uuid.New(),
+		OrgID:     uuid.New(),
+		Timestamp: time.Now(),
+		Level:     SessionLogLevelError,
+		Message:   "Reconnecting... 2/5 (stream disconnected before completion: failed to lookup address information: Try again)",
+	}
+
+	resp := NewSessionLogResponse(log)
+
+	var metadata map[string]string
+	require.NoError(t, json.Unmarshal(resp.Metadata, &metadata), "response metadata should be valid JSON")
+	require.Equal(t, "hidden", metadata["visibility"], "benign Codex diagnostics should be marked hidden in API responses")
+	require.Equal(t, "benign_runtime_diagnostic", metadata["diagnostic_class"], "response should identify benign diagnostic class")
+	require.Equal(t, "codex", metadata["diagnostic_source"], "response should identify diagnostic source")
+	require.Equal(t, "responses_websocket_retry", metadata["diagnostic_kind"], "response should include the classifier kind")
+}
+
+func TestNewSessionLogResponseOverridesVisibilityForBenignCodexDiagnostics(t *testing.T) {
+	t.Parallel()
+
+	log := SessionLog{
+		ID:        44,
+		SessionID: uuid.New(),
+		OrgID:     uuid.New(),
+		Timestamp: time.Now(),
+		Level:     SessionLogLevelError,
+		Message:   "Reconnecting... 2/5 (stream disconnected before completion: failed to lookup address information: Try again)",
+		Metadata:  json.RawMessage(`{"visibility":"visible","diagnostic_kind":"custom"}`),
+	}
+
+	resp := NewSessionLogResponse(log)
+
+	var metadata map[string]string
+	require.NoError(t, json.Unmarshal(resp.Metadata, &metadata), "response metadata should be valid JSON")
+	require.Equal(t, "hidden", metadata["visibility"], "benign Codex diagnostics should stay hidden even if raw metadata disagrees")
+	require.Equal(t, "custom", metadata["diagnostic_kind"], "response annotation should not overwrite existing diagnostic kind")
+	require.Equal(t, "benign_runtime_diagnostic", metadata["diagnostic_class"], "response should fill missing diagnostic class")
 }
 
 func TestNewSessionLogDetailResponse(t *testing.T) {

--- a/internal/services/agent/adapters/codex.go
+++ b/internal/services/agent/adapters/codex.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/rs/zerolog"
 
+	"github.com/assembledhq/143/internal/agentdiagnostics"
 	"github.com/assembledhq/143/internal/models"
 	"github.com/assembledhq/143/internal/services/agent"
 )
@@ -229,7 +230,7 @@ func (a *CodexAdapter) Execute(ctx context.Context, sandbox *agent.Sandbox, prom
 	// Filter refresh-token errors once and reuse the result.
 	var filteredStderr string
 	if len(stderr) > 0 {
-		filteredStderr = emitCodexStderrLogs(stderr, logCh)
+		filteredStderr = emitCodexStderrLogs(stderr, exitCode, logCh)
 	}
 
 	if exitCode != 0 {
@@ -433,6 +434,15 @@ func parseCodexStreamLine(line []byte, result *agent.AgentResult, logCh chan<- a
 		// Suppress refresh-token errors entirely — they are expected when
 		// tokens are shared and showing them is alarming and unhelpful.
 		if isRefreshTokenError(msg) {
+			return
+		}
+		if kind, _, ok := agentdiagnostics.ClassifyBenignCodexDiagnostic(msg); ok {
+			logCh <- agent.LogEntry{
+				Timestamp: time.Now(),
+				Level:     "debug",
+				Message:   msg,
+				Metadata:  codexHiddenDiagnosticMetadata(kind),
+			}
 			return
 		}
 		logCh <- agent.LogEntry{
@@ -721,7 +731,7 @@ func filterCodexStderrLines(stderr string) string {
 	return strings.Join(visible, "\n")
 }
 
-func emitCodexStderrLogs(stderr []byte, logCh chan<- agent.LogEntry) string {
+func emitCodexStderrLogs(stderr []byte, exitCode int, logCh chan<- agent.LogEntry) string {
 	visible, hidden := splitCodexStderrDiagnostics(string(stderr))
 	for _, diagnostic := range hidden {
 		logCh <- agent.LogEntry{
@@ -733,6 +743,15 @@ func emitCodexStderrLogs(stderr []byte, logCh chan<- agent.LogEntry) string {
 	}
 	filtered := strings.Join(visible, "\n")
 	if filtered != "" {
+		if exitCode == 0 {
+			logCh <- agent.LogEntry{
+				Timestamp: time.Now(),
+				Level:     "debug",
+				Message:   filtered,
+				Metadata:  codexHiddenDiagnosticMetadata("codex_stderr_success"),
+			}
+			return ""
+		}
 		logCh <- agent.LogEntry{
 			Timestamp: time.Now(),
 			Level:     "error",
@@ -759,7 +778,7 @@ func splitCodexStderrDiagnostics(stderr string) ([]string, []codexHiddenDiagnost
 		if isRefreshTokenError(line) {
 			continue
 		}
-		if kind, multiline, ok := classifyBenignCodexDiagnostic(line); ok {
+		if kind, multiline, ok := agentdiagnostics.ClassifyBenignCodexDiagnostic(line); ok {
 			block := []string{line}
 			if multiline {
 				for i+1 < len(lines) && isCodexDiagnosticContinuation(lines[i+1]) {
@@ -780,49 +799,12 @@ func splitCodexStderrDiagnostics(stderr string) ([]string, []codexHiddenDiagnost
 	return visible, hidden
 }
 
-func classifyBenignCodexDiagnostic(msg string) (kind string, multiline bool, ok bool) {
-	trimmed := strings.TrimSpace(msg)
-	if strings.Contains(trimmed, "codex_core::tools::router:") &&
-		strings.Contains(trimmed, "write_stdin failed: stdin is closed for this session") {
-		return "closed_stdin", false, true
-	}
-	if strings.Contains(trimmed, "codex_core::tools::router:") &&
-		strings.Contains(trimmed, "apply_patch verification failed: Failed to find expected lines") {
-		return "apply_patch_verification_failed", true, true
-	}
-	if trimmed == "Reading additional input from stdin..." {
-		return "stdin_notice", false, true
-	}
-	return "", false, false
-}
-
 func isCodexDiagnosticContinuation(line string) bool {
 	trimmed := strings.TrimSpace(line)
 	if trimmed == "" {
 		return false
 	}
-	return !isCodexLogRecordStart(trimmed)
-}
-
-func isCodexLogRecordStart(trimmed string) bool {
-	fields := strings.Fields(trimmed)
-	if len(fields) >= 3 {
-		if _, err := time.Parse(time.RFC3339Nano, fields[0]); err == nil &&
-			isCodexLogLevel(fields[1]) &&
-			strings.HasPrefix(fields[2], "codex_core::") {
-			return true
-		}
-	}
-	return len(fields) >= 2 && isCodexLogLevel(fields[0]) && strings.HasPrefix(fields[1], "codex_core::")
-}
-
-func isCodexLogLevel(value string) bool {
-	switch value {
-	case "ERROR", "WARN", "INFO", "DEBUG", "TRACE":
-		return true
-	default:
-		return false
-	}
+	return !agentdiagnostics.IsCodexLogRecordStart(trimmed)
 }
 
 func codexHiddenDiagnosticMetadata(kind string) map[string]interface{} {

--- a/internal/services/agent/adapters/codex_test.go
+++ b/internal/services/agent/adapters/codex_test.go
@@ -1384,7 +1384,7 @@ func TestEmitCodexStderrLogs_FlagsBenignDiagnosticsHidden(t *testing.T) {
 	logCh := make(chan agent.LogEntry, 10)
 	input := "2026-05-16T02:59:58.624143Z ERROR codex_core::tools::router: error=write_stdin failed: stdin is closed for this session; rerun exec_command with tty=true to keep stdin open"
 
-	filtered := emitCodexStderrLogs([]byte(input), logCh)
+	filtered := emitCodexStderrLogs([]byte(input), 1, logCh)
 	close(logCh)
 
 	var logs []agent.LogEntry
@@ -1412,7 +1412,7 @@ func TestEmitCodexStderrLogs_FlagsApplyPatchVerificationDiagnosticHidden(t *test
 		"      : trimmedMessage;\n" +
 		"    const optimisticID = optimisticMessageIDRef.current--;"
 
-	filtered := emitCodexStderrLogs([]byte(input), logCh)
+	filtered := emitCodexStderrLogs([]byte(input), 1, logCh)
 	close(logCh)
 
 	var logs []agent.LogEntry
@@ -1426,6 +1426,140 @@ func TestEmitCodexStderrLogs_FlagsApplyPatchVerificationDiagnosticHidden(t *test
 	require.Equal(t, input, logs[0].Message, "hidden diagnostic should preserve the full multiline message")
 	require.Equal(t, "hidden", logs[0].Metadata["visibility"], "hidden diagnostic should be marked hidden from the user")
 	require.Equal(t, "apply_patch_verification_failed", logs[0].Metadata["diagnostic_kind"], "hidden diagnostic should identify the matched kind")
+}
+
+func TestEmitCodexStderrLogs_FlagsRecoverableWebsocketDiagnosticHidden(t *testing.T) {
+	t.Parallel()
+
+	logCh := make(chan agent.LogEntry, 10)
+	input := "2026-06-12T08:54:38.209896Z ERROR codex_api::endpoint::responses_websocket: failed to connect to websocket: IO error: failed to lookup address information: Try again, url: wss://chatgpt.com/backend-api/codex/responses"
+
+	filtered := emitCodexStderrLogs([]byte(input), 1, logCh)
+	close(logCh)
+
+	var logs []agent.LogEntry
+	for entry := range logCh {
+		logs = append(logs, entry)
+	}
+
+	require.Empty(t, filtered, "recoverable websocket retry diagnostic should not be returned as visible stderr")
+	require.Len(t, logs, 1, "recoverable websocket diagnostic should be retained as one hidden log")
+	require.Equal(t, "debug", logs[0].Level, "hidden diagnostic should be emitted below user-visible error severity")
+	require.Equal(t, input, logs[0].Message, "hidden diagnostic should preserve the original message")
+	require.Equal(t, "hidden", logs[0].Metadata["visibility"], "hidden diagnostic should be marked hidden from the user")
+	require.Equal(t, "responses_websocket_retry", logs[0].Metadata["diagnostic_kind"], "hidden diagnostic should identify the matched kind")
+}
+
+func TestEmitCodexStderrLogs_HidesUnknownStderrWhenCodexSucceeds(t *testing.T) {
+	t.Parallel()
+
+	logCh := make(chan agent.LogEntry, 10)
+	input := "warning: background cleanup took longer than expected"
+
+	filtered := emitCodexStderrLogs([]byte(input), 0, logCh)
+	close(logCh)
+
+	var logs []agent.LogEntry
+	for entry := range logCh {
+		logs = append(logs, entry)
+	}
+
+	require.Empty(t, filtered, "stderr from a successful Codex run should not be returned as visible stderr")
+	require.Len(t, logs, 1, "successful-run stderr should be retained as a hidden diagnostic")
+	require.Equal(t, "debug", logs[0].Level, "successful-run stderr should be emitted below user-visible error severity")
+	require.Equal(t, "hidden", logs[0].Metadata["visibility"], "successful-run stderr should be hidden from the user")
+	require.Equal(t, "codex_stderr_success", logs[0].Metadata["diagnostic_kind"], "successful-run stderr should have a generic diagnostic kind")
+}
+
+func TestEmitCodexStderrLogs_KeepsUnknownStderrVisibleWhenCodexFails(t *testing.T) {
+	t.Parallel()
+
+	logCh := make(chan agent.LogEntry, 10)
+	input := "fatal: codex could not complete"
+
+	filtered := emitCodexStderrLogs([]byte(input), 1, logCh)
+	close(logCh)
+
+	var logs []agent.LogEntry
+	for entry := range logCh {
+		logs = append(logs, entry)
+	}
+
+	require.Equal(t, input, filtered, "stderr from a failed Codex run should remain visible")
+	require.Len(t, logs, 1, "failed-run stderr should be emitted as a visible log")
+	require.Equal(t, "error", logs[0].Level, "failed-run stderr should keep error severity")
+	require.Nil(t, logs[0].Metadata, "failed-run stderr should not be marked hidden")
+}
+
+func TestEmitCodexStderrLogs_StopsMultilineDiagnosticAtCodexAPIRecord(t *testing.T) {
+	t.Parallel()
+
+	logCh := make(chan agent.LogEntry, 10)
+	input := "2026-05-22T05:52:30.204805Z ERROR codex_core::tools::router: error=apply_patch verification failed: Failed to find expected lines in /home/sandbox/143/internal/models/automation_test.go:\n" +
+		"        tests := []struct {\n" +
+		"                name string\n" +
+		"        }\n" +
+		"2026-06-12T08:54:38.209896Z ERROR codex_api::endpoint::responses_websocket: failed to connect to websocket: IO error: failed to lookup address information: Try again, url: wss://chatgpt.com/backend-api/codex/responses"
+
+	filtered := emitCodexStderrLogs([]byte(input), 1, logCh)
+	close(logCh)
+
+	var logs []agent.LogEntry
+	for entry := range logCh {
+		logs = append(logs, entry)
+	}
+
+	require.Empty(t, filtered, "known benign diagnostics should not be returned as visible stderr")
+	require.Len(t, logs, 2, "separate benign diagnostics should be retained as separate hidden logs")
+	require.Equal(t, "apply_patch_verification_failed", logs[0].Metadata["diagnostic_kind"], "first hidden diagnostic should be the apply_patch context mismatch")
+	require.Equal(t, "responses_websocket_retry", logs[1].Metadata["diagnostic_kind"], "second hidden diagnostic should be the websocket retry")
+	require.NotContains(t, logs[0].Message, "responses_websocket", "multiline apply_patch diagnostic should stop before the next codex_api record")
+}
+
+func TestParseCodexStreamLine_FlagsRecoverableReconnectErrorHidden(t *testing.T) {
+	t.Parallel()
+
+	result := &agent.AgentResult{}
+	logCh := make(chan agent.LogEntry, 100)
+	var summaryParts []string
+	lastByType := make(map[string]string)
+
+	line := []byte(`{"type":"error","error":"Reconnecting... 2/5 (stream disconnected before completion: failed to lookup address information: Try again)"}`)
+	parseCodexStreamLine(line, result, logCh, &summaryParts, lastByType, new(string))
+	close(logCh)
+
+	var logs []agent.LogEntry
+	for entry := range logCh {
+		logs = append(logs, entry)
+	}
+
+	require.Len(t, logs, 1, "recoverable reconnect stream event should still be retained as a hidden log")
+	require.Equal(t, "debug", logs[0].Level, "recoverable reconnect stream event should not be emitted as a visible error")
+	require.Equal(t, "hidden", logs[0].Metadata["visibility"], "recoverable reconnect stream event should be marked hidden from the user")
+	require.Equal(t, "responses_websocket_retry", logs[0].Metadata["diagnostic_kind"], "recoverable reconnect stream event should identify the matched kind")
+}
+
+func TestParseCodexStreamLine_FlagsGenericReconnectErrorHidden(t *testing.T) {
+	t.Parallel()
+
+	result := &agent.AgentResult{}
+	logCh := make(chan agent.LogEntry, 100)
+	var summaryParts []string
+	lastByType := make(map[string]string)
+
+	line := []byte(`{"type":"error","error":"Reconnecting... 4/5 (stream disconnected before completion: An error occurred while processing your request. Please try again.)"}`)
+	parseCodexStreamLine(line, result, logCh, &summaryParts, lastByType, new(string))
+	close(logCh)
+
+	var logs []agent.LogEntry
+	for entry := range logCh {
+		logs = append(logs, entry)
+	}
+
+	require.Len(t, logs, 1, "recoverable reconnect stream event should still be retained as a hidden log")
+	require.Equal(t, "debug", logs[0].Level, "recoverable reconnect stream event should not be emitted as a visible error")
+	require.Equal(t, "hidden", logs[0].Metadata["visibility"], "recoverable reconnect stream event should be marked hidden from the user")
+	require.Equal(t, "responses_websocket_retry", logs[0].Metadata["diagnostic_kind"], "recoverable reconnect stream event should identify the matched kind")
 }
 
 func TestParseCodexStreamLine_SuppressesRefreshTokenError(t *testing.T) {

--- a/internal/services/sessiontimeline/timeline.go
+++ b/internal/services/sessiontimeline/timeline.go
@@ -5,6 +5,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/assembledhq/143/internal/agentdiagnostics"
 	"github.com/assembledhq/143/internal/models"
 	"github.com/google/uuid"
 )
@@ -248,13 +249,7 @@ func metadataType(log *models.SessionLog) string {
 }
 
 func isHiddenLog(log *models.SessionLog) bool {
-	return parseMetadata(log.Metadata).Visibility == "hidden" || isRecoverableCodexRouterDiagnostic(log.Message)
-}
-
-func isRecoverableCodexRouterDiagnostic(message string) bool {
-	return strings.Contains(message, "codex_core::tools::router:") &&
-		(strings.Contains(message, "write_stdin failed: stdin is closed for this session") ||
-			strings.Contains(message, "apply_patch verification failed: Failed to find expected lines"))
+	return parseMetadata(log.Metadata).Visibility == "hidden" || agentdiagnostics.IsBenignCodexDiagnostic(log.Message)
 }
 
 func parseMetadata(raw json.RawMessage) logMetadata {

--- a/internal/services/sessiontimeline/timeline_test.go
+++ b/internal/services/sessiontimeline/timeline_test.go
@@ -311,6 +311,56 @@ func TestComposeTimeline_EmitsErrorAndGenericLogEntries(t *testing.T) {
 	require.Equal(t, models.SessionTimelineKindLog, result[1].Kind, "non-visible logs should render as generic log entries")
 }
 
+func TestComposeTimeline_KeepsRecoverableCodexWebsocketDiagnosticsHidden(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		message string
+	}{
+		{
+			name:    "reconnecting retry status",
+			message: "Reconnecting... 2/5 (stream disconnected before completion: failed to lookup address information: Try again)",
+		},
+		{
+			name:    "responses websocket record",
+			message: "2026-06-12T08:54:38.209896Z ERROR codex_api::endpoint::responses_websocket: failed to connect to websocket: IO error: failed to lookup address information: Try again, url: wss://chatgpt.com/backend-api/codex/responses",
+		},
+		{
+			name:    "generic reconnect status",
+			message: "Reconnecting... 4/5 (stream disconnected before completion: An error occurred while processing your request. Please try again.)",
+		},
+		{
+			name:    "tool router argument parse",
+			message: "2026-06-05T22:47:06.079306Z ERROR codex_core::tools::router: error=failed to parse function arguments: missing field `cmd` at line 1 column 125",
+		},
+		{
+			name:    "skills loader missing optional reference",
+			message: "2026-06-07T13:04:57.108170Z ERROR codex_core_skills::loader: failed to stat skills path /home/sandbox/.codex/.tmp/plugins/plugins/google-drive/skills/google-docs/references/reference-foreground-guard.md: No such file or directory",
+		},
+		{
+			name:    "model refresh timeout",
+			message: "2026-06-12T02:31:46.399958Z ERROR codex_models_manager::manager: failed to refresh available models: timeout waiting for child process to exit",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			logs := []models.SessionLog{
+				makeLog(t, func(log *models.SessionLog) {
+					log.ID = 1
+				}, "2026-01-01T00:00:01Z", "error", tt.message),
+			}
+
+			result := Compose(nil, logs)
+			require.Len(t, result, 1, "recoverable Codex websocket diagnostics should remain available as timeline logs")
+			require.Equal(t, models.SessionTimelineKindLog, result[0].Kind, "recoverable Codex websocket diagnostics should not render as visible errors")
+		})
+	}
+}
+
 func TestComposeTimeline_IncludesHumanInputRequests(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- Move Codex benign diagnostic classification into a shared helper and broaden it to cover websocket retries, skills loader misses, model refresh timeouts, and other recoverable runtime noise.
- Mark benign Codex diagnostics as hidden in session log responses so the frontend can keep them behind the log toggle without relying on raw message matching.
- Update Codex adapter and session timeline handling to emit the new metadata consistently.

## Testing
- Added and updated unit tests for diagnostic classification, stderr filtering, session log response metadata, and timeline rendering behavior.