### PR TITLE
Run preview auth check through docker entrypoint

### DIFF
--- a/deploy/deploy_config_test.go
+++ b/deploy/deploy_config_test.go
@@ -651,6 +651,8 @@ func TestDeployRunsPreviewRPCAuthCheckBeforeCutoverAndWorkerDrain(t *testing.T) 
 
 	appProbeIndex := strings.Index(rollingBody, `preview_rpc_auth_preflight "$new_container"`)
 	require.NotEqual(t, -1, appProbeIndex, "app rolling deploy should run the preview RPC auth probe from the new api container")
+	previewAuthPreflightBody := extractShellFunction(t, deployText, "preview_rpc_auth_preflight", "rolling_deploy_service")
+	require.Contains(t, previewAuthPreflightBody, `docker exec "$cid" /docker-entrypoint.sh /bin/worker-deployctl preview-auth-check --json`, "app preview RPC auth probe should run through docker-entrypoint.sh so SOPS-decrypted production secrets are available to worker-deployctl")
 	appDrainIndex := strings.Index(rollingBody, `echo "Draining $old_count old $service container(s)`)
 	require.NotEqual(t, -1, appDrainIndex, "app rolling deploy should still drain old containers")
 	require.Less(t, appProbeIndex, appDrainIndex, "app rolling deploy should run preview RPC auth check before draining old api containers")

--- a/deploy/scripts/deploy.sh
+++ b/deploy/scripts/deploy.sh
@@ -1108,7 +1108,7 @@ ssh "${SSH_OPTS[@]}" deploy@"$HOST" \
   preview_rpc_auth_preflight() {
     local cid="$1"
     echo "Running preview RPC auth compatibility check from candidate api container ${cid:0:12}..."
-    docker exec "$cid" /bin/worker-deployctl preview-auth-check --json
+    docker exec "$cid" /docker-entrypoint.sh /bin/worker-deployctl preview-auth-check --json
   }
 
   # rolling_deploy_service SERVICE — roll a single service with zero-downtime:


### PR DESCRIPTION
## Summary
- Run the preview RPC auth preflight through `/docker-entrypoint.sh` so the candidate API container loads SOPS-decrypted production secrets before `worker-deployctl` runs.
- Add a test assertion to lock in the deploy script behavior.

## Testing
- Unit tests updated to verify the deploy script invokes `preview-auth-check` via `docker-entrypoint.sh`.