### PR TITLE
Remove navbar preview count polling and badge; add regression test

### DIFF
--- a/frontend/src/components/authenticated-layout.test.tsx
+++ b/frontend/src/components/authenticated-layout.test.tsx
@@ -72,6 +72,31 @@ describe("AuthenticatedLayout", () => {
     expect(screen.getAllByRole("link", { name: "Autopilot" }).find((link) => link.getAttribute("href") === "/autopilot")).toBeDefined();
   });
 
+  it("does not fetch preview counts for the primary navigation", async () => {
+    let previewListRequests = 0;
+    server.use(
+      http.get("/api/v1/previews", () => {
+        previewListRequests += 1;
+        return HttpResponse.json({
+          data: [],
+          meta: { counts: { running: 3 } },
+        });
+      })
+    );
+
+    renderWithProviders(
+      <AuthenticatedLayout>
+        <div>content</div>
+      </AuthenticatedLayout>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("Test Org")).toBeInTheDocument();
+    });
+    expect(previewListRequests).toBe(0);
+    expect(screen.getAllByRole("link", { name: "Previews" }).find((link) => link.getAttribute("href") === "/previews")).toBeDefined();
+  });
+
   it("uses a slightly narrower default sidebar width", () => {
     const { container } = renderWithProviders(
       <AuthenticatedLayout>

--- a/frontend/src/components/authenticated-layout.tsx
+++ b/frontend/src/components/authenticated-layout.tsx
@@ -46,7 +46,7 @@ import {
   PopoverTrigger,
 } from "@/components/ui/popover";
 import { useAuth } from "@/hooks/use-auth";
-import { useQuery, useQueryClient, type QueryClient } from "@tanstack/react-query";
+import { useQueryClient, type QueryClient } from "@tanstack/react-query";
 import { api } from "@/lib/api";
 import { notify as toast } from "@/lib/notify";
 import { queryKeys } from "@/lib/query-keys";
@@ -59,7 +59,6 @@ import { CreateSessionDialog } from "@/components/create-session-dialog";
 import { ResizeHandle } from "@/components/resize-handle";
 import { usePersistedPanelWidth } from "@/hooks/use-persisted-panel-width";
 import { Kbd } from "@/components/ui/kbd";
-import { pollMs } from "@/lib/poll-intervals";
 
 type SidebarUser = NonNullable<ReturnType<typeof useAuth>["user"]>;
 
@@ -166,12 +165,6 @@ function SidebarBody({
     : "py-[7px] text-xs";
   const iconBtnClasses = isMobile ? "h-11 w-11" : "h-7 w-7";
   const iconSize = isMobile ? "h-5 w-5" : "h-4 w-4";
-  const previewsBadgeQuery = useQuery({
-    queryKey: ["previews", "nav-running-count"],
-    queryFn: () => api.previews.list({ scope: "running", limit: 1 }),
-    refetchInterval: pollMs(60000),
-  });
-  const runningPreviewCount = previewsBadgeQuery.data?.meta?.counts?.running ?? 0;
 
   return (
     <>
@@ -260,11 +253,6 @@ function SidebarBody({
             >
               <item.icon className="h-4 w-4 shrink-0" />
               <span className="flex-1">{item.label}</span>
-              {item.href === "/previews" && runningPreviewCount > 0 ? (
-                <span className="rounded-full bg-primary px-1.5 py-0.5 text-xs font-semibold leading-none text-primary-foreground">
-                  {runningPreviewCount}
-                </span>
-              ) : null}
             </Link>
           );
         })}
@@ -345,13 +333,6 @@ function CompactSidebarRail({
   onCreateSession,
   onLogout,
 }: CompactSidebarRailProps) {
-  const previewsBadgeQuery = useQuery({
-    queryKey: ["previews", "nav-running-count"],
-    queryFn: () => api.previews.list({ scope: "running", limit: 1 }),
-    refetchInterval: pollMs(60000),
-  });
-  const runningPreviewCount = previewsBadgeQuery.data?.meta?.counts?.running ?? 0;
-
   return (
     <TooltipProvider>
       <aside
@@ -410,9 +391,6 @@ function CompactSidebarRail({
                   )}
                 >
                   <item.icon className="h-4 w-4" />
-                  {item.href === "/previews" && runningPreviewCount > 0 ? (
-                    <span className="absolute right-1 top-1 h-1.5 w-1.5 rounded-full bg-primary" />
-                  ) : null}
                 </Link>
               </TooltipTrigger>
                 <TooltipContent side="right" sideOffset={8}>{item.label}</TooltipContent>


### PR DESCRIPTION
## Summary
Removed the “Previews” running count badge from the main authenticated navigation. This eliminates the background polling request that only existed to populate the badge (and the compact sidebar rail dot), improving network usage and UI consistency.

## Changes
- `frontend/src/components/authenticated-layout.tsx`
  - Removed the React Query polling for `api.previews.list({ scope: "running", limit: 1 })` (60s refetch interval).
  - Removed rendering of the running-count badge for the `/previews` nav item.
  - Removed the corresponding polling logic from `CompactSidebarRail` so the compact rail dot/count is no longer driven by network polling.
  - Dropped unused imports related to polling (`pollMs`).
- `frontend/src/components/authenticated-layout.test.tsx`
  - Added `does not fetch preview counts for the primary navigation` regression test:
    - Stubs `GET /api/v1/previews` and asserts it is **never called** during initial render.
    - Confirms the “Previews” nav link still exists and points to `/previews`.

## Test plan
- `npm test -- authenticated-layout.test.tsx`
- `npm run typecheck`
- `npm run lint`
- `npm run build`

[143.dev](https://143.dev) | [session 8deb5c31](https://143.dev/sessions/8deb5c31-0e49-47c8-b7f9-06097eb44521)

Preview: https://143.dev/previews/github/assembledhq/143/pull/1400