### PR TITLE
Bootstrap preview opens through the preview iframe flow

### DIFF
--- a/frontend/src/components/preview/open-preview-button.tsx
+++ b/frontend/src/components/preview/open-preview-button.tsx
@@ -12,11 +12,14 @@ import {
   PREVIEW_BOOTSTRAP_COMPLETE_EVENT,
   PREVIEW_BOOTSTRAP_READY_EVENT,
   PREVIEW_BOOTSTRAP_TOKEN_EVENT,
-  previewOriginFromURL,
 } from "@/lib/preview-bootstrap";
-import { safeExternalUrl } from "@/lib/utils";
 
 const BOOTSTRAP_TIMEOUT_MS = 15_000;
+
+type BootstrapToken = {
+  token: string;
+  preview_id?: string;
+};
 
 type PendingOpen = {
   previewID: string;
@@ -34,6 +37,7 @@ export type OpenPreviewButtonProps = {
   variant?: ComponentProps<typeof Button>["variant"];
   size?: ComponentProps<typeof Button>["size"];
   className?: string;
+  bootstrapPreview?: (previewId: string) => Promise<BootstrapToken>;
 };
 
 export function OpenPreviewButton({
@@ -44,6 +48,7 @@ export function OpenPreviewButton({
   variant,
   size,
   className,
+  bootstrapPreview,
 }: OpenPreviewButtonProps) {
   const iframeRef = useRef<HTMLIFrameElement | null>(null);
   const pendingRef = useRef<PendingOpen | null>(null);
@@ -51,11 +56,9 @@ export function OpenPreviewButton({
   const [iframeSrc, setIframeSrc] = useState<string | undefined>();
   const [isOpening, setIsOpening] = useState(false);
 
-  const safePreviewURL = useMemo(() => safeExternalUrl(previewUrl), [previewUrl]);
-  const previewOrigin = useMemo(
-    () => (safePreviewURL ? previewOriginFromURL(safePreviewURL) : undefined),
-    [safePreviewURL],
-  );
+  const safePreview = useMemo(() => parsePreviewURL(previewUrl), [previewUrl]);
+  const safePreviewURL = safePreview?.href;
+  const previewOrigin = safePreview?.origin;
 
   const clearTimeoutRef = useCallback(() => {
     if (timeoutRef.current !== null) {
@@ -82,10 +85,11 @@ export function OpenPreviewButton({
   );
 
   const bootstrapMutation = useMutation({
-    mutationFn: (id: string) => api.previews.bootstrap(id),
+    mutationFn: (id: string) =>
+      bootstrapPreview ? bootstrapPreview(id) : api.previews.bootstrap(id).then((response) => response.data),
     onSuccess: (response) => {
       const pending = pendingRef.current;
-      const token = response.data.token;
+      const token = response.token;
       if (!pending || !token) return;
 
       const contentWindow = iframeRef.current?.contentWindow;
@@ -197,5 +201,29 @@ export function OpenPreviewButton({
         />
       ) : null}
     </>
+  );
+}
+
+function parsePreviewURL(url: string | undefined | null): { href: string; origin: string } | undefined {
+  if (!url) return undefined;
+  try {
+    const parsed = new URL(url);
+    if (parsed.protocol === "https:" || isLocalPreviewHTTP(parsed)) {
+      return { href: url, origin: parsed.origin };
+    }
+  } catch {
+    return undefined;
+  }
+  return undefined;
+}
+
+function isLocalPreviewHTTP(parsed: URL): boolean {
+  if (parsed.protocol !== "http:") return false;
+  return (
+    parsed.hostname === "localhost" ||
+    parsed.hostname === "127.0.0.1" ||
+    parsed.hostname === "[::1]" ||
+    parsed.hostname.endsWith(".localhost") ||
+    parsed.hostname.endsWith(".test")
   );
 }

--- a/frontend/src/components/preview/preview-panel.test.tsx
+++ b/frontend/src/components/preview/preview-panel.test.tsx
@@ -1,6 +1,8 @@
+import { act } from "react";
 import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
 import {
   buildPreviewIframeSrc,
+  PREVIEW_BOOTSTRAP_COMPLETE_EVENT,
   PREVIEW_BOOTSTRAP_READY_EVENT,
   PREVIEW_BOOTSTRAP_TOKEN_EVENT,
   PreviewPanel,
@@ -564,20 +566,60 @@ describe("PreviewPanel component", () => {
     );
   });
 
-  it("renders a prominent preview link instead of viewport preset buttons in ready state", async () => {
+  it("bootstraps preview access before opening from the ready state", async () => {
     mockGet.mockResolvedValue(makePreviewStatus({ status: "ready" }));
+    const openedWindow = {
+      close: vi.fn(),
+      document: {
+        close: vi.fn(),
+        write: vi.fn(),
+      },
+      location: {
+        href: "about:blank",
+      },
+      opener: null,
+    } as unknown as Window;
+    const openSpy = vi.spyOn(window, "open").mockReturnValue(openedWindow);
 
     const { container } = renderWithProviders(
       <PreviewPanel {...DEFAULT_PROPS} />,
     );
 
-    await waitFor(() => {
-      expect(screen.getByRole("link", { name: /Open Preview/i })).toBeInTheDocument();
+    await userEvent.click(await screen.findByRole("button", { name: "Open Preview" }));
+
+    expect(openSpy).toHaveBeenCalledWith("about:blank", "_blank");
+    expect(screen.getByTitle("Preview bootstrap")).toHaveAttribute(
+      "src",
+      "http://prev-1.preview.test/bootstrap",
+    );
+    expect(openedWindow.location.href).toBe("about:blank");
+
+    act(() => {
+      window.dispatchEvent(
+        new MessageEvent("message", {
+          data: { type: PREVIEW_BOOTSTRAP_READY_EVENT },
+          origin: "http://prev-1.preview.test",
+        }),
+      );
     });
 
-    const previewLink = screen.getByRole("link", { name: /Open Preview/i });
-    expect(previewLink).toHaveAttribute("href", "http://prev-1.preview.test");
-    expect(previewLink).toHaveAttribute("target", "_blank");
+    await waitFor(() => {
+      expect(mockBootstrap).toHaveBeenCalledWith("sess-1");
+    });
+    expect(openedWindow.location.href).toBe("about:blank");
+
+    act(() => {
+      window.dispatchEvent(
+        new MessageEvent("message", {
+          data: { type: PREVIEW_BOOTSTRAP_COMPLETE_EVENT },
+          origin: "http://prev-1.preview.test",
+        }),
+      );
+    });
+
+    await waitFor(() => {
+      expect(openedWindow.location.href).toBe("http://prev-1.preview.test");
+    });
     expect(screen.queryByRole("button", { name: /^Stop$/ })).not.toBeInTheDocument();
     expect(screen.queryByRole("button", { name: /^Restart$/ })).not.toBeInTheDocument();
 
@@ -586,6 +628,8 @@ describe("PreviewPanel component", () => {
       ".flex.items-center.gap-0\\.5.rounded-md.border",
     );
     expect(presetContainer).not.toBeInTheDocument();
+
+    openSpy.mockRestore();
   });
 
   it("renders ConsoleBadge in ready state", async () => {
@@ -1599,7 +1643,7 @@ describe("PreviewPanel component", () => {
     const freshnessCallout = screen.getByTestId("preview-freshness-callout");
     const refreshButton = screen.getByRole("button", { name: "Refresh preview" });
     expect(freshnessCallout).toContainElement(refreshButton);
-    expect(screen.getByRole("link", { name: "Open Preview" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Open Preview" })).toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "Retry preview" })).not.toBeInTheDocument();
 
     await user.click(refreshButton);

--- a/frontend/src/components/preview/preview-panel.tsx
+++ b/frontend/src/components/preview/preview-panel.tsx
@@ -13,7 +13,6 @@ import {
   Play,
   Square,
   RotateCw,
-  ExternalLink,
   Monitor,
   Loader2,
   AlertTriangle,
@@ -61,13 +60,19 @@ import { ConsoleBadge } from "./console-badge";
 import { DesignModeOverlay } from "./design-mode-overlay";
 import { ErrorBoundary } from "@/components/error-boundary";
 import { TTLWarning } from "./ttl-warning";
+import { OpenPreviewButton } from "./open-preview-button";
 import {
   buildPreviewBootstrapSrc,
+  PREVIEW_BOOTSTRAP_COMPLETE_EVENT,
   PREVIEW_BOOTSTRAP_READY_EVENT,
   PREVIEW_BOOTSTRAP_TOKEN_EVENT,
 } from "@/lib/preview-bootstrap";
 
-export { PREVIEW_BOOTSTRAP_READY_EVENT, PREVIEW_BOOTSTRAP_TOKEN_EVENT };
+export {
+  PREVIEW_BOOTSTRAP_COMPLETE_EVENT,
+  PREVIEW_BOOTSTRAP_READY_EVENT,
+  PREVIEW_BOOTSTRAP_TOKEN_EVENT,
+};
 
 export function buildPreviewIframeSrc(previewOrigin: string): string {
   return buildPreviewBootstrapSrc(previewOrigin);
@@ -1017,16 +1022,13 @@ export function PreviewPanel({
               )}
 
               {isReady && previewOrigin && (
-                <Button size="sm" asChild>
-                  <a
-                    href={previewOrigin}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                  >
-                    <ExternalLink className="size-3.5" />
-                    Open Preview
-                  </a>
-                </Button>
+                <OpenPreviewButton
+                  previewId={instance?.id}
+                  previewUrl={previewOrigin}
+                  label="Open Preview"
+                  size="sm"
+                  bootstrapPreview={() => api.sessions.preview.bootstrap(sessionId)}
+                />
               )}
 
               {shouldShowRetryPreview && (


### PR DESCRIPTION
## Summary
- Replace the ready-state preview link with the existing bootstrap/open-preview flow so previews are opened only after bootstrap completes.
- Add preview URL parsing that only accepts safe HTTPS or local HTTP origins.
- Extend preview panel coverage to verify the bootstrap handshake and the new open button behavior.

## Testing
- Updated component tests to cover the ready-state bootstrap sequence and completion behavior.
- Updated preview panel assertions to expect a button instead of a direct link in the ready state.
- Not run (not requested).