### PR TITLE
Fix ReviewDiffView file jump skipping by clearing scroll-sync skip flag

### DIFF
--- a/frontend/src/components/code-review/review-diff-view.test.tsx
+++ b/frontend/src/components/code-review/review-diff-view.test.tsx
@@ -57,6 +57,9 @@ vi.mock("./diff-pane", () => ({
         <button onClick={() => (props.onActiveFileChange as (index: number) => void)(1)}>
           ReportActiveFile
         </button>
+        <button onClick={() => (props.onActiveFileChange as (index: number) => void)(2)}>
+          ReportTargetFile
+        </button>
       </div>
     );
   }),
@@ -182,6 +185,90 @@ describe("ReviewDiffView", () => {
     fireEvent.click(screen.getByText("ReportActiveFile"));
 
     expect(mockScrollToFile).not.toHaveBeenCalled();
+  });
+
+  it("ignores intermediate scroll sync while jumping to a selected file", () => {
+    function Harness() {
+      const [activeFileIndex, setActiveFileIndex] = useState(0);
+
+      return (
+        <>
+          <button onClick={() => setActiveFileIndex(2)}>SelectFile</button>
+          <ReviewDiffView
+            {...defaultProps({
+              files: [
+                makeDiffFile("src/a.ts"),
+                makeDiffFile("src/b.ts"),
+                makeDiffFile("src/c.ts"),
+              ],
+              activeFileIndex,
+              onFileChange: setActiveFileIndex,
+            })}
+          />
+        </>
+      );
+    }
+
+    render(<Harness />);
+    expect(screen.getByTestId("toolbar-file-position")).toHaveTextContent("1 of 3");
+
+    mockScrollToFile.mockClear();
+    fireEvent.click(screen.getByText("SelectFile"));
+
+    expect(mockScrollToFile).toHaveBeenCalledWith(2);
+    expect(screen.getByTestId("toolbar-file-position")).toHaveTextContent("3 of 3");
+
+    fireEvent.click(screen.getByText("ReportActiveFile"));
+    expect(screen.getByTestId("toolbar-file-position")).toHaveTextContent("3 of 3");
+
+    fireEvent.click(screen.getByText("ReportTargetFile"));
+    expect(screen.getByTestId("toolbar-file-position")).toHaveTextContent("3 of 3");
+  });
+
+  it("does not leave a stale skip flag after confirming the scroll target", () => {
+    // Regression: when confirming the pending scroll target, handleVisibleFileChange
+    // called onFileChange(index) even though activeFileIndex was already at that value.
+    // React bailed out (same state), so the effect never ran and skipNextScrollToFileRef
+    // stayed true, causing the very next sidebar jump to silently skip scrollToFile.
+    function Harness() {
+      const [activeFileIndex, setActiveFileIndex] = useState(0);
+
+      return (
+        <>
+          <button onClick={() => setActiveFileIndex(2)}>SelectFile2</button>
+          <button onClick={() => setActiveFileIndex(0)}>SelectFile0</button>
+          <ReviewDiffView
+            {...defaultProps({
+              files: [
+                makeDiffFile("src/a.ts"),
+                makeDiffFile("src/b.ts"),
+                makeDiffFile("src/c.ts"),
+              ],
+              activeFileIndex,
+              onFileChange: setActiveFileIndex,
+            })}
+          />
+        </>
+      );
+    }
+
+    render(<Harness />);
+
+    // Jump to file 2 via sidebar
+    mockScrollToFile.mockClear();
+    fireEvent.click(screen.getByText("SelectFile2"));
+    expect(mockScrollToFile).toHaveBeenCalledWith(2);
+    expect(screen.getByTestId("toolbar-file-position")).toHaveTextContent("3 of 3");
+
+    // Scroll animation completes — scroll pane confirms file 2 is visible
+    fireEvent.click(screen.getByText("ReportTargetFile"));
+    expect(screen.getByTestId("toolbar-file-position")).toHaveTextContent("3 of 3");
+
+    // Immediately jump to file 0 via sidebar — must not be silently ignored
+    mockScrollToFile.mockClear();
+    fireEvent.click(screen.getByText("SelectFile0"));
+    expect(mockScrollToFile).toHaveBeenCalledWith(0);
+    expect(screen.getByTestId("toolbar-file-position")).toHaveTextContent("1 of 3");
   });
 
   it("renders empty state when files is empty", () => {

--- a/frontend/src/components/code-review/review-diff-view.tsx
+++ b/frontend/src/components/code-review/review-diff-view.tsx
@@ -66,6 +66,9 @@ export const ReviewDiffView = memo(function ReviewDiffView({
 }: ReviewDiffViewProps) {
   const diffPaneRef = useRef<DiffPaneHandle>(null);
   const skipNextScrollToFileRef = useRef(false);
+  const previousActiveFileIndexRef = useRef(activeFileIndex);
+  const pendingScrollTargetIndexRef = useRef<number | null>(null);
+  const pendingScrollTargetTimeoutRef = useRef<number | null>(null);
   const [showKeyboardHelp, setShowKeyboardHelp] = useState(false);
   const [explorerMode, setExplorerMode] = useState(false);
   const [explorerInitialPath, setExplorerInitialPath] = useState<string | undefined>(undefined);
@@ -135,19 +138,57 @@ export const ReviewDiffView = memo(function ReviewDiffView({
 
   // activeFileIndex can change from outside (sidebar file-tree click), so scroll via effect rather than only inside handleFileSelect.
   useEffect(() => {
+    const previousActiveFileIndex = previousActiveFileIndexRef.current;
+    previousActiveFileIndexRef.current = activeFileIndex;
+
     if (skipNextScrollToFileRef.current) {
       skipNextScrollToFileRef.current = false;
       return;
     }
+
+    if (previousActiveFileIndex !== activeFileIndex) {
+      pendingScrollTargetIndexRef.current = activeFileIndex;
+      if (pendingScrollTargetTimeoutRef.current != null) {
+        window.clearTimeout(pendingScrollTargetTimeoutRef.current);
+      }
+      pendingScrollTargetTimeoutRef.current = window.setTimeout(() => {
+        pendingScrollTargetIndexRef.current = null;
+        pendingScrollTargetTimeoutRef.current = null;
+      }, 2000);
+    }
+
     diffPaneRef.current?.scrollToFile(activeFileIndex);
   }, [activeFileIndex]);
 
+  useEffect(() => {
+    return () => {
+      if (pendingScrollTargetTimeoutRef.current != null) {
+        window.clearTimeout(pendingScrollTargetTimeoutRef.current);
+      }
+    };
+  }, []);
+
   const handleVisibleFileChange = useCallback(
     (index: number) => {
+      const pendingTargetIndex = pendingScrollTargetIndexRef.current;
+      if (pendingTargetIndex != null) {
+        if (index !== pendingTargetIndex) {
+          return;
+        }
+        pendingScrollTargetIndexRef.current = null;
+        if (pendingScrollTargetTimeoutRef.current != null) {
+          window.clearTimeout(pendingScrollTargetTimeoutRef.current);
+          pendingScrollTargetTimeoutRef.current = null;
+        }
+        // Skip: onFileChange would be a no-op, so no effect run to clear skipNextScrollToFileRef.
+        if (index === activeFileIndex) {
+          return;
+        }
+      }
       skipNextScrollToFileRef.current = true;
       onFileChange(index);
     },
-    [onFileChange]
+    [onFileChange, activeFileIndex]
   );
 
   const toggleViewMode = useCallback(() => {


### PR DESCRIPTION
## Summary
This updates `ReviewDiffView` handling for the “files changed” panel so selecting a target file always results in the expected `scrollToFile` call. It also adds regression tests to prevent intermediate scroll-sync events from incorrectly skipping the next sidebar jump.

## Changes
- **frontend/src/components/code-review/review-diff-view.tsx**
  - Adjusted the scroll synchronization/confirmation logic so a pending “skip next scroll” flag can’t remain set after confirming the intended scroll target.
- **frontend/src/components/code-review/review-diff-view.test.tsx**
  - Added a test ensuring intermediate scroll sync is ignored while jumping to a selected file.
  - Added a regression test ensuring the skip flag is cleared after confirming the scroll target, so the next sidebar click doesn’t get silently ignored.

## Test plan
- Ran the frontend test suite; **all 34 tests pass** (including the newly added `ReviewDiffView` regression coverage).

[143.dev](https://143.dev) | [session e35b7ffe](https://143.dev/sessions/e35b7ffe-ad34-462d-83cf-af96c64d2e3a)

Preview: https://143.dev/previews/github/assembledhq/143/pull/1408