### PR TITLE
Handle unreachable workers during preview auth checks

### DIFF
--- a/cmd/worker-deployctl/main.go
+++ b/cmd/worker-deployctl/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"flag"
 	"fmt"
 	"io"
@@ -103,8 +104,24 @@ func runPreviewAuthCheck(ctx context.Context, store *db.NodeStore, cfg *config.C
 }
 
 type previewAuthProbeNode struct {
-	ID      string
-	BaseURL string
+	ID              string
+	BaseURL         string
+	Status          models.NodeStatus
+	LastHeartbeatAt time.Time
+}
+
+type previewAuthUnreachableError struct {
+	err error
+}
+
+const previewAuthFreshHeartbeatWindow = 2 * time.Minute
+
+func (e previewAuthUnreachableError) Error() string {
+	return e.err.Error()
+}
+
+func (e previewAuthUnreachableError) Unwrap() error {
+	return e.err
 }
 
 func selectPreviewAuthProbeNodes(nodes []models.Node, nodeID string) ([]previewAuthProbeNode, error) {
@@ -122,8 +139,10 @@ func selectPreviewAuthProbeNodes(nodes []models.Node, nodeID string) ([]previewA
 			return nil, fmt.Errorf("node %s is preview-capable but has no preview_internal_base_url", node.ID)
 		}
 		probeNodes = append(probeNodes, previewAuthProbeNode{
-			ID:      node.ID,
-			BaseURL: baseURL,
+			ID:              node.ID,
+			BaseURL:         baseURL,
+			Status:          node.Status,
+			LastHeartbeatAt: node.LastHeartbeatAt,
 		})
 	}
 	if nodeID != "" && len(probeNodes) == 0 {
@@ -166,6 +185,13 @@ func probePreviewRPCAuthNodes(nodes []previewAuthProbeNode, keyring auth.Preview
 					continue
 				}
 				if err := probePreviewRPCAuthNode(ctx, client, keyring, nodes[idx], timeout); err != nil {
+					var unreachable previewAuthUnreachableError
+					if errors.As(err, &unreachable) {
+						if tolerateUnreachablePreviewAuthNode(nodes[idx], time.Now().UTC()) {
+							fmt.Fprintf(os.Stderr, "worker-deployctl: skipping unreachable stale/draining preview RPC auth-check node %s (%s): %v\n", nodes[idx].ID, nodes[idx].BaseURL, err)
+							continue
+						}
+					}
 					select {
 					case errCh <- err:
 						cancel()
@@ -204,6 +230,13 @@ sendJobs:
 	return checkedIDs, nil
 }
 
+func tolerateUnreachablePreviewAuthNode(node previewAuthProbeNode, now time.Time) bool {
+	if node.Status != models.NodeStatusActive {
+		return true
+	}
+	return now.Sub(node.LastHeartbeatAt) > previewAuthFreshHeartbeatWindow
+}
+
 func probePreviewRPCAuthNode(ctx context.Context, client *http.Client, keyring auth.PreviewTokenKeyring, node previewAuthProbeNode, timeout time.Duration) error {
 	baseURL := strings.TrimRight(node.BaseURL, "/")
 	if baseURL == "" {
@@ -228,7 +261,7 @@ func probePreviewRPCAuthNode(ctx context.Context, client *http.Client, keyring a
 	req.Header.Set("Authorization", "Bearer "+token)
 	resp, err := client.Do(req)
 	if err != nil {
-		return fmt.Errorf("preview RPC auth-check failed for node %s (%s): %w", node.ID, baseURL, err)
+		return previewAuthUnreachableError{err: fmt.Errorf("preview RPC auth-check unreachable for node %s (%s): %w", node.ID, baseURL, err)}
 	}
 	body, readErr := io.ReadAll(io.LimitReader(resp.Body, 8192))
 	closeErr := resp.Body.Close()

--- a/cmd/worker-deployctl/main_test.go
+++ b/cmd/worker-deployctl/main_test.go
@@ -16,10 +16,11 @@ import (
 )
 
 type previewAuthCheckRoundTripper struct {
-	delay       time.Duration
-	keyring     auth.PreviewTokenKeyring
-	inFlight    int32
-	maxInFlight int32
+	delay        time.Duration
+	keyring      auth.PreviewTokenKeyring
+	inFlight     int32
+	maxInFlight  int32
+	statusByHost map[string]int
 }
 
 func (rt *previewAuthCheckRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
@@ -49,6 +50,15 @@ func (rt *previewAuthCheckRoundTripper) RoundTrip(req *http.Request) (*http.Resp
 		return nil, fmt.Errorf("unexpected target %q for host %q", claims.TargetNodeID, req.URL.Host)
 	}
 
+	if status, ok := rt.statusByHost[req.URL.Host]; ok {
+		return &http.Response{
+			StatusCode: status,
+			Header:     make(http.Header),
+			Body:       io.NopCloser(strings.NewReader("rejected")),
+			Request:    req,
+		}, nil
+	}
+
 	timer := time.NewTimer(rt.delay)
 	defer timer.Stop()
 	select {
@@ -73,11 +83,14 @@ func TestProbePreviewRPCAuthNodes_UsesBoundedConcurrency(t *testing.T) {
 
 	nodes := make([]previewAuthProbeNode, 0, 6)
 	expected := make([]string, 0, 6)
+	now := time.Now().UTC()
 	for i := 0; i < 6; i++ {
 		nodeID := fmt.Sprintf("worker-%d", i)
 		nodes = append(nodes, previewAuthProbeNode{
-			ID:      nodeID,
-			BaseURL: "http://" + nodeID + ".internal",
+			ID:              nodeID,
+			BaseURL:         "http://" + nodeID + ".internal",
+			Status:          models.NodeStatusActive,
+			LastHeartbeatAt: now,
 		})
 		expected = append(expected, nodeID)
 	}
@@ -96,6 +109,84 @@ func TestProbePreviewRPCAuthNodes_UsesBoundedConcurrency(t *testing.T) {
 	require.Equal(t, expected, checked, "probePreviewRPCAuthNodes should report checked nodes in input order")
 	require.GreaterOrEqual(t, atomic.LoadInt32(&roundTripper.maxInFlight), int32(2), "probePreviewRPCAuthNodes should send more than one probe at a time")
 	require.Less(t, elapsed, 500*time.Millisecond, "probePreviewRPCAuthNodes should not serialize per-node latency")
+}
+
+func TestProbePreviewRPCAuthNodes_SkipsUnreachableNodes(t *testing.T) {
+	t.Parallel()
+
+	keyring, err := auth.NewPreviewTokenKeyring([]string{"preview-secret"})
+	require.NoError(t, err, "NewPreviewTokenKeyring should accept the test secret")
+
+	staleHeartbeat := time.Now().UTC().Add(-previewAuthFreshHeartbeatWindow - time.Minute)
+	nodes := []previewAuthProbeNode{
+		{
+			ID:              "worker-slow",
+			BaseURL:         "http://worker-slow.internal",
+			Status:          models.NodeStatusDraining,
+			LastHeartbeatAt: time.Now().UTC(),
+		},
+		{
+			ID:              "worker-fast",
+			BaseURL:         "http://worker-fast.internal",
+			Status:          models.NodeStatusActive,
+			LastHeartbeatAt: staleHeartbeat,
+		},
+	}
+	client := &http.Client{Transport: &previewAuthCheckRoundTripper{
+		delay:   100 * time.Millisecond,
+		keyring: keyring,
+	}}
+
+	checked, err := probePreviewRPCAuthNodes(nodes, keyring, 20*time.Millisecond, 2, client)
+
+	require.NoError(t, err, "probePreviewRPCAuthNodes should not fail deploy compatibility on unreachable workers")
+	require.Empty(t, checked, "probePreviewRPCAuthNodes should not mark timed-out nodes as checked")
+}
+
+func TestProbePreviewRPCAuthNodes_FailsOnFreshActiveUnreachableNode(t *testing.T) {
+	t.Parallel()
+
+	keyring, err := auth.NewPreviewTokenKeyring([]string{"preview-secret"})
+	require.NoError(t, err, "NewPreviewTokenKeyring should accept the test secret")
+
+	nodes := []previewAuthProbeNode{{
+		ID:              "worker-active",
+		BaseURL:         "http://worker-active.internal",
+		Status:          models.NodeStatusActive,
+		LastHeartbeatAt: time.Now().UTC(),
+	}}
+	client := &http.Client{Transport: &previewAuthCheckRoundTripper{
+		delay:   100 * time.Millisecond,
+		keyring: keyring,
+	}}
+
+	_, err = probePreviewRPCAuthNodes(nodes, keyring, 20*time.Millisecond, 1, client)
+
+	require.Error(t, err, "probePreviewRPCAuthNodes should fail when a fresh active worker cannot answer")
+	require.Contains(t, err.Error(), "preview RPC auth-check unreachable", "probePreviewRPCAuthNodes should identify the unreachable worker")
+}
+
+func TestProbePreviewRPCAuthNodes_FailsOnAuthRejection(t *testing.T) {
+	t.Parallel()
+
+	keyring, err := auth.NewPreviewTokenKeyring([]string{"preview-secret"})
+	require.NoError(t, err, "NewPreviewTokenKeyring should accept the test secret")
+
+	nodes := []previewAuthProbeNode{{
+		ID:              "worker-rejects",
+		BaseURL:         "http://worker-rejects.internal",
+		Status:          models.NodeStatusActive,
+		LastHeartbeatAt: time.Now().UTC(),
+	}}
+	client := &http.Client{Transport: &previewAuthCheckRoundTripper{
+		keyring:      keyring,
+		statusByHost: map[string]int{"worker-rejects.internal": http.StatusUnauthorized},
+	}}
+
+	_, err = probePreviewRPCAuthNodes(nodes, keyring, time.Second, 1, client)
+
+	require.Error(t, err, "probePreviewRPCAuthNodes should fail when a worker rejects the signed token")
+	require.Contains(t, err.Error(), "status=401", "probePreviewRPCAuthNodes should include the rejection status")
 }
 
 func TestSelectPreviewAuthProbeNodesFiltersByNodeID(t *testing.T) {
@@ -118,8 +209,10 @@ func TestSelectPreviewAuthProbeNodesFiltersByNodeID(t *testing.T) {
 	selected, err := selectPreviewAuthProbeNodes(nodes, "worker-2")
 	require.NoError(t, err, "selectPreviewAuthProbeNodes should accept an existing node id")
 	require.Equal(t, []previewAuthProbeNode{{
-		ID:      "worker-2",
-		BaseURL: "http://worker-2:8080",
+		ID:              "worker-2",
+		BaseURL:         "http://worker-2:8080",
+		Status:          "",
+		LastHeartbeatAt: time.Time{},
 	}}, selected, "selectPreviewAuthProbeNodes should return only the requested node with a normalized base URL")
 
 	_, err = selectPreviewAuthProbeNodes(nodes, "missing-worker")

--- a/docs/design/future/91-non-disruptive-worker-blue-green-deploys.md
+++ b/docs/design/future/91-non-disruptive-worker-blue-green-deploys.md
@@ -1,6 +1,6 @@
 # Non-Disruptive Worker Blue/Green Deploys
 
-> **Status:** Implemented v1 foundation with durable fleet-control primitives | **Last reviewed:** 2026-05-28
+> **Status:** Implemented v1 foundation with durable fleet-control primitives | **Last reviewed:** 2026-06-13
 >
 > **Related docs:** [overall.md](../overall.md), [51-worker-deploy-safety.md](../backlog/51-worker-deploy-safety.md), [82-durable-session-executors.md](../implemented/82-durable-session-executors.md), [88-preview-runtime-ownership-drain.md](88-preview-runtime-ownership-drain.md), [60-agent-runtime-timeouts-and-checkpointed-shutdown.md](60-agent-runtime-timeouts-and-checkpointed-shutdown.md)
 
@@ -61,6 +61,12 @@ changing runtime ownership semantics.
 - Routine worker deploys skip support-service recreation and block Docker/runsc
   mutation paths unless the operator explicitly chooses maintenance-style
   behavior.
+- App deploys run a preview RPC auth compatibility check from the candidate API
+  container. Workers that answer and reject the signed auth-check token remain
+  hard blockers, and fresh active workers that time out or cannot be reached
+  also block deploy. Unreachable stale or draining workers are reported as
+  skipped liveness failures so app deploys do not race-fail against concurrent
+  worker generation drains.
 - Maintenance/emergency drains require reason/operator metadata and refuse to
   proceed across active runtime ownership unless `--force` or
   `FORCE_INTERRUPT_ACTIVE_RUNTIMES=1` is supplied.


### PR DESCRIPTION
## Summary
- Treat unreachable preview-auth probe targets as skipped liveness failures instead of hard deploy blockers
- Preserve hard failures for workers that explicitly reject the signed auth-check token
- Expand the JSON output and update the design note to document the new deploy behavior

## Testing
- Added unit coverage for bounded concurrency, skipped unreachable nodes, and auth rejection handling