### PR TITLE
Ensure PM-delegated sessions start with an initial user turn message

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -1445,6 +1445,7 @@ func buildServices(
 	pmSvc.SetPMDocumentStore(pmDocumentStore)
 	pmSvc.SetSlackStores(integrationStore, credentialStore)
 	pmSvc.SetSessionLogStore(sessionLogStore)
+	pmSvc.SetSessionMessageStore(sessionMessageStore)
 	pmSvc.SetInternalAPI(cfg.BaseURL+"/api/v1/internal", cfg.SessionSecret)
 	pmSvc.SetSkillsBuilder(orchestrator)
 	threadSvc := threadservice.NewService(

--- a/internal/services/pm/execute.go
+++ b/internal/services/pm/execute.go
@@ -2,6 +2,8 @@ package pm
 
 import (
 	"context"
+	"fmt"
+	"strings"
 
 	"github.com/assembledhq/143/internal/db"
 	"github.com/assembledhq/143/internal/models"
@@ -80,6 +82,9 @@ func (s *Service) executePlan(ctx context.Context, orgID uuid.UUID, plan *Plan, 
 			task.Status = models.PMTaskStatusSkippedCapacity
 			continue
 		}
+		if err := s.createInitialDelegatedSessionMessage(ctx, orgID, run); err != nil {
+			s.logger.Error().Err(err).Str("session_id", run.ID.String()).Msg("failed to create initial PM-delegated session message")
+		}
 
 		for _, issueID := range task.IssueIDs {
 			if err := s.issues.UpdateStatus(ctx, orgID, issueID, models.IssueStatusTriaged); err != nil {
@@ -105,4 +110,26 @@ func (s *Service) executePlan(ctx context.Context, orgID uuid.UUID, plan *Plan, 
 		return err
 	}
 	return s.plans.Update(ctx, model)
+}
+
+func (s *Service) createInitialDelegatedSessionMessage(ctx context.Context, orgID uuid.UUID, run *models.Session) error {
+	if s.sessionMessages == nil || run == nil || run.PMApproach == nil {
+		return nil
+	}
+	content := strings.TrimSpace(*run.PMApproach)
+	if content == "" {
+		return nil
+	}
+	msg := &models.SessionMessage{
+		SessionID:  run.ID,
+		OrgID:      orgID,
+		ThreadID:   run.PrimaryThreadID,
+		TurnNumber: 0,
+		Role:       models.MessageRoleUser,
+		Content:    content,
+	}
+	if err := s.sessionMessages.Create(ctx, msg); err != nil {
+		return fmt.Errorf("create initial PM-delegated session message: %w", err)
+	}
+	return nil
 }

--- a/internal/services/pm/service.go
+++ b/internal/services/pm/service.go
@@ -125,6 +125,10 @@ type sessionLogStore interface {
 	Create(ctx context.Context, log *models.SessionLog) error
 }
 
+type sessionMessageStore interface {
+	Create(ctx context.Context, msg *models.SessionMessage) error
+}
+
 // SkillsBuilder generates integration skills docs for agents running in sandboxes.
 // This is satisfied by the Orchestrator which already builds skills docs from
 // org integration credentials.
@@ -137,6 +141,7 @@ type Service struct {
 	issues            issueStore
 	sessions          sessionStore
 	sessionLogs       sessionLogStore // nil-safe: if nil, PM session logs are not persisted
+	sessionMessages   sessionMessageStore
 	pullRequests      prStore
 	orgs              orgStore
 	repos             repoStore
@@ -451,6 +456,13 @@ func (s *Service) SetSlackStores(integrations integrationStore, credentials cred
 // SetSessionLogStore injects the session log store for PM agent log persistence.
 func (s *Service) SetSessionLogStore(store sessionLogStore) {
 	s.sessionLogs = store
+}
+
+// SetSessionMessageStore injects the session message store for PM-delegated
+// coding sessions. Nil-safe: if nil, delegated sessions fall back to metadata
+// fields only.
+func (s *Service) SetSessionMessageStore(store sessionMessageStore) {
+	s.sessionMessages = store
 }
 
 // SetInternalAPI configures the internal API URL and signing secret for sandbox-to-server

--- a/internal/services/pm/service_test.go
+++ b/internal/services/pm/service_test.go
@@ -43,6 +43,13 @@ func (m *mockSessionStore) CountRunningByOrg(ctx context.Context, orgID uuid.UUI
 }
 
 func (m *mockSessionStore) Create(ctx context.Context, run *models.Session) error {
+	if run.ID == uuid.Nil {
+		run.ID = uuid.New()
+	}
+	if run.PrimaryThreadID == nil {
+		threadID := uuid.New()
+		run.PrimaryThreadID = &threadID
+	}
 	m.created = append(m.created, run)
 	return nil
 }
@@ -62,6 +69,15 @@ func (m *mockSessionStore) UpdateResult(ctx context.Context, orgID, runID uuid.U
 }
 
 func (m *mockSessionStore) UpdatePMPlanID(ctx context.Context, orgID, runID, planID uuid.UUID) error {
+	return nil
+}
+
+type mockSessionMessageStore struct {
+	created []*models.SessionMessage
+}
+
+func (m *mockSessionMessageStore) Create(ctx context.Context, msg *models.SessionMessage) error {
+	m.created = append(m.created, msg)
 	return nil
 }
 
@@ -114,12 +130,13 @@ func TestExecutePlan_DelegatesWithinCapacity(t *testing.T) {
 	require.NoError(t, err, "should marshal settings")
 
 	svc := &Service{
-		issues:   &mockIssueStore{},
-		sessions: &mockSessionStore{},
-		orgs:     &mockOrgStore{org: models.Organization{ID: orgID, Settings: settingsJSON}},
-		jobs:     &mockJobStore{},
-		plans:    &mockPlanStore{},
-		logger:   zerolog.Nop(),
+		issues:          &mockIssueStore{},
+		sessions:        &mockSessionStore{},
+		sessionMessages: &mockSessionMessageStore{},
+		orgs:            &mockOrgStore{org: models.Organization{ID: orgID, Settings: settingsJSON}},
+		jobs:            &mockJobStore{},
+		plans:           &mockPlanStore{},
+		logger:          zerolog.Nop(),
 	}
 
 	plan := &Plan{
@@ -157,6 +174,15 @@ func TestExecutePlan_DelegatesWithinCapacity(t *testing.T) {
 	require.NotNil(t, runStore.created[0].Title, "session title should be set")
 	require.NotNil(t, runStore.created[0].PMApproach, "PM approach should be set")
 	require.NotNil(t, runStore.created[0].PMReasoning, "PM reasoning should be set")
+
+	messageStore := svc.sessionMessages.(*mockSessionMessageStore)
+	require.Len(t, messageStore.created, 1, "delegated PM sessions should include an initial user message")
+	require.Equal(t, runStore.created[0].ID, messageStore.created[0].SessionID, "initial user message should belong to delegated session")
+	require.Equal(t, orgID, messageStore.created[0].OrgID, "initial user message should be org-scoped")
+	require.Equal(t, runStore.created[0].PrimaryThreadID, messageStore.created[0].ThreadID, "initial user message should be attached to the primary thread")
+	require.Equal(t, 0, messageStore.created[0].TurnNumber, "initial user message should be turn zero")
+	require.Equal(t, models.MessageRoleUser, messageStore.created[0].Role, "initial PM message should render as a user message")
+	require.Equal(t, "Approach 1", messageStore.created[0].Content, "initial user message should use the PM approach")
 }
 
 func TestExecutePlan_ManualAutonomySkipsDelegation(t *testing.T) {


### PR DESCRIPTION
## Summary
PM-delegated coding sessions now persist an initial `turn_number=0` `user` session message derived from `PMApproach`, attached to the session’s primary thread. This ensures downstream consumers have a real starting user turn instead of relying only on metadata.

## Changes
- **cmd/server/main.go**
  - Injected `sessionMessageStore` into the PM service via `pmSvc.SetSessionMessageStore(...)` for production wiring.
- **internal/services/pm/execute.go**
  - During `executePlan`, added a call to `createInitialDelegatedSessionMessage(...)` so delegated sessions persist the first message before subsequent task actions.
  - Implemented `createInitialDelegatedSessionMessage(...)`:
    - No-ops when `sessionMessages` is nil, `run` is nil, `PMApproach` is nil/empty.
    - Creates a `models.SessionMessage` with `SessionID`, `OrgID`, `ThreadID=PrimaryThreadID`, `TurnNumber=0`, `Role=user`, and `Content=PMApproach`.
- **internal/services/pm/service.go**
  - Added `sessionMessageStore` interface and `sessionMessages` field to `Service`.
  - Added `SetSessionMessageStore(...)` (nil-safe fallback to metadata-only behavior).
- **internal/services/pm/service_test.go**
  - Added regression coverage verifying PM-created delegated sessions include the initial user message.

## Test plan
- Ran `go vet ./...`
- Ran `go build ./...`
- Ran `go test ./...` (including the added PM service regression test)

[143.dev](https://143.dev) | [session 6cca74f4](https://143.dev/sessions/6cca74f4-d39d-4c80-a68b-393e0d9700e6)

Preview: https://143.dev/previews/github/assembledhq/143/pull/1411