### PR TITLE
Stabilize frontend settings tests

### DIFF
--- a/frontend/src/app/(dashboard)/settings/agent/page.test.tsx
+++ b/frontend/src/app/(dashboard)/settings/agent/page.test.tsx
@@ -230,7 +230,7 @@ describe("Agent settings page", () => {
 	        },
 	      });
 	    });
-	  });
+	  }, 10000);
 
 	  it("creates Amp auth and defaults in a single coding-auth request", async () => {
     const user = userEvent.setup();

--- a/frontend/src/app/(dashboard)/settings/api-keys/page.test.tsx
+++ b/frontend/src/app/(dashboard)/settings/api-keys/page.test.tsx
@@ -181,8 +181,8 @@ describe("APIKeysSettingsPage", () => {
   it("renders token lifecycle metadata and confirms revocation", async () => {
     const tokens: APIToken[] = [
       token("active-token", "production", {}),
-      token("expired-token", "old deploy", { expires_at: "2020-01-01T00:00:00Z" }),
-      token("revoked-token", "leaked key", { revoked_at: "2026-02-01T00:00:00Z" }),
+      token("expired-token", "old deploy", { expires_at: "2020-01-01T12:00:00Z" }),
+      token("revoked-token", "leaked key", { revoked_at: "2026-02-01T12:00:00Z" }),
     ];
     let revokedTokenID = "";
     server.use(


### PR DESCRIPTION
## Summary
- Increase the Agent settings test timeout to avoid intermittent async failures
- Use noon UTC timestamps in API key lifecycle fixtures to keep date rendering stable across timezones

## Testing
- Not run (not requested)