### PR TITLE
Enrich session preview responses with runtime metadata

### DIFF
--- a/internal/AGENTS.md
+++ b/internal/AGENTS.md
@@ -35,6 +35,7 @@ The existing test `internal/db/tenancy_test.go` is a third layer of defense: it 
 **Default to immutability.** When transforming data, return a new struct value rather than mutating the input in place.
 
 - Return a new struct (or `*T` constructed with `&T{...}`) from transformation functions instead of taking a pointer and writing through it.
+- For response-building or enrichment helpers, prefer idempotent functions that accept the current response value and return an enriched copy. This keeps handler state flow explicit and makes repeated calls safe.
 - Build new slices with `append` onto a fresh slice rather than mutating an argument; same for maps — copy then write.
 - Avoid setter methods that mutate the receiver — prefer `WithFoo(v) T` style that returns a copy.
 - Don't expose mutable references across package boundaries. If you must return a slice/map, return a copy or document that the caller must not mutate it.

--- a/internal/api/handlers/branch_previews.go
+++ b/internal/api/handlers/branch_previews.go
@@ -1200,6 +1200,12 @@ func (h *BranchPreviewHandler) Get(w http.ResponseWriter, r *http.Request) {
 			resp.SourceURL = target.SourceURL
 			resp.RequestID = derefStrPtr(target.RequestID)
 		}
+	} else {
+		resp = h.enrichSessionPreviewResponse(r.Context(), orgID, resp)
+		if resp.RepositoryID != uuid.Nil && !previewTokenAllows(r.Context(), "previews:read", resp.RepositoryID) {
+			writeError(w, r, http.StatusForbidden, "PREVIEW_TOKEN_FORBIDDEN", "preview API token is not scoped to read this preview")
+			return
+		}
 	}
 	h.decoratePreviewResponse(r.Context(), orgID, &resp)
 	writeJSON(w, http.StatusOK, models.SingleResponse[branchPreviewResponse]{Data: resp})
@@ -1686,8 +1692,39 @@ func (h *BranchPreviewHandler) restartSessionPreviewInstance(w http.ResponseWrit
 		return
 	}
 	resp := h.previewInstanceResponse(restarted)
+	resp = h.enrichSessionPreviewResponse(r.Context(), orgID, resp)
 	h.decoratePreviewResponse(r.Context(), orgID, &resp)
 	writeJSON(w, http.StatusOK, models.SingleResponse[branchPreviewResponse]{Data: resp})
+}
+
+func (h *BranchPreviewHandler) enrichSessionPreviewResponse(ctx context.Context, orgID uuid.UUID, resp branchPreviewResponse) branchPreviewResponse {
+	if h == nil || h.previews == nil || resp.PreviewID == nil || resp.TargetID != uuid.Nil {
+		return resp
+	}
+	summary, err := h.previews.GetSessionPreviewSummary(ctx, orgID, *resp.PreviewID)
+	if err != nil {
+		if !errors.Is(err, pgx.ErrNoRows) {
+			zerolog.Ctx(ctx).Warn().Err(err).Str("preview_id", resp.PreviewID.String()).Msg("failed to enrich session preview response")
+		}
+		return resp
+	}
+	enriched := resp
+	enriched.TargetID = summary.TargetID
+	enriched.RepositoryID = summary.RepositoryID
+	enriched.RepositoryFullName = summary.RepositoryFullName
+	enriched.Branch = summary.Branch
+	enriched.CommitSHA = summary.CommitSHA
+	enriched.PreviewConfigName = summary.PreviewConfigName
+	enriched.SourceType = summary.SourceType
+	enriched.SourceID = summary.SourceID
+	enriched.SourceURL = summary.SourceURL
+	enriched.StoppedReason = summary.StoppedReason
+	enriched.Resumable = summary.Resumable
+	enriched.ResumeEstimateSeconds = summary.ResumeEstimateSeconds
+	if enriched.CreatedAt == nil {
+		enriched.CreatedAt = &summary.CreatedAt
+	}
+	return enriched
 }
 
 // resolveTargetRepoAndActive resolves the {preview_id} route param — an

--- a/internal/api/handlers/branch_previews_test.go
+++ b/internal/api/handlers/branch_previews_test.go
@@ -1771,3 +1771,212 @@ func TestBranchPreviewHandler_GetFollowsActiveSessionPreview(t *testing.T) {
 	require.Equal(t, string(models.PreviewStatusStarting), resp.Data.Status, "Get should surface the replacement's status")
 	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
 }
+
+func TestBranchPreviewHandler_GetEnrichesSessionPreviewMetadata(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "pgx mock should initialize")
+	defer mock.Close()
+
+	orgID := uuid.New()
+	userID := uuid.New()
+	sessionID := uuid.New()
+	previewID := uuid.New()
+	repoID := uuid.New()
+	now := time.Now()
+	expiresAt := now.Add(30 * time.Minute)
+	branch := "143/7c2ade9e/the-preview-failure-looks-like-dependency-installation-is"
+	commit := "99d637f392f9051fdb9d5b7d9304ce4fab607b79"
+
+	mock.ExpectQuery("SELECT .+ FROM preview_instances").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(pgxmock.NewRows(branchPreviewInstanceTestCols).AddRow(
+			sessionPreviewInstanceRow(previewID, sessionID, orgID, userID, models.PreviewStatusUnavailable, now, &now)...,
+		))
+	mock.ExpectQuery("SELECT .+ FROM preview_instances").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(pgxmock.NewRows(branchPreviewInstanceTestCols))
+	mock.ExpectQuery("JOIN sessions sess ON sess\\.id = pi\\.session_id").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(pgxmock.NewRows(branchPreviewSummaryTestCols()).AddRow(
+			previewID, &previewID, repoID, "assembledhq/assembled", branch, commit,
+			"", models.PreviewSourceTypeSession, sessionID.String(), "", "unavailable", now,
+			now, &expiresAt, &now, "", "unavailable", "preview runtime endpoint mismatch",
+			false, (*int)(nil),
+		))
+
+	handler := NewBranchPreviewHandler(
+		db.NewPreviewStore(mock),
+		db.NewRepositoryStore(mock),
+		fakeBranchPreviewGitHub{token: "ghs_test", head: "abc123"},
+		nil,
+		"https://app.143.dev",
+		"https://{id}.preview.143.dev",
+	)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/previews/"+previewID.String(), nil)
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("preview_id", previewID.String())
+	ctx := context.WithValue(req.Context(), chi.RouteCtxKey, rctx)
+	ctx = middleware.WithOrgID(ctx, orgID)
+	req = req.WithContext(ctx)
+	rr := httptest.NewRecorder()
+
+	handler.Get(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code, "Get should succeed for a session preview")
+	var resp models.SingleResponse[branchPreviewResponse]
+	require.NoError(t, json.NewDecoder(rr.Body).Decode(&resp), "Get should return a preview response")
+	require.Equal(t, previewID, resp.Data.TargetID, "session preview detail should use the runtime preview ID as the target ID")
+	require.Equal(t, repoID, resp.Data.RepositoryID, "session preview detail should include the owning session repository ID")
+	require.Equal(t, "assembledhq/assembled", resp.Data.RepositoryFullName, "session preview detail should include the repository full name")
+	require.Equal(t, branch, resp.Data.Branch, "session preview detail should include the session branch")
+	require.Equal(t, commit, resp.Data.CommitSHA, "session preview detail should include the session base commit")
+	require.Equal(t, models.PreviewSourceTypeSession, resp.Data.SourceType, "session preview detail should identify the source as a session")
+	require.Equal(t, sessionID.String(), resp.Data.SourceID, "session preview detail should include the owning session ID")
+	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
+}
+
+func TestBranchPreviewHandler_GetSessionPreviewRejectsTokenWithoutRepositoryAccess(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		withAuth func(context.Context, uuid.UUID, uuid.UUID) context.Context
+	}{
+		{
+			name: "preview API token",
+			withAuth: func(ctx context.Context, orgID, otherRepoID uuid.UUID) context.Context {
+				return middleware.WithPreviewAPIToken(ctx, &models.PreviewAPIToken{
+					OrgID:         orgID,
+					Scopes:        []string{"previews:read"},
+					RepositoryIDs: []uuid.UUID{otherRepoID},
+				})
+			},
+		},
+		{
+			name: "external API token",
+			withAuth: func(ctx context.Context, orgID, otherRepoID uuid.UUID) context.Context {
+				return middleware.WithAPIIdentity(ctx, &models.APIClient{ID: uuid.New(), OrgID: orgID}, &models.APIToken{
+					ID:            uuid.New(),
+					OrgID:         orgID,
+					Scopes:        []string{"previews:read"},
+					RepositoryIDs: []uuid.UUID{otherRepoID},
+				})
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			mock, err := pgxmock.NewPool()
+			require.NoError(t, err, "pgx mock should initialize")
+			defer mock.Close()
+
+			orgID := uuid.New()
+			userID := uuid.New()
+			sessionID := uuid.New()
+			previewID := uuid.New()
+			repoID := uuid.New()
+			otherRepoID := uuid.New()
+			now := time.Now()
+			expiresAt := now.Add(30 * time.Minute)
+
+			mock.ExpectQuery("SELECT .+ FROM preview_instances").
+				WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+				WillReturnRows(pgxmock.NewRows(branchPreviewInstanceTestCols).AddRow(
+					sessionPreviewInstanceRow(previewID, sessionID, orgID, userID, models.PreviewStatusUnavailable, now, &now)...,
+				))
+			mock.ExpectQuery("SELECT .+ FROM preview_instances").
+				WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+				WillReturnRows(pgxmock.NewRows(branchPreviewInstanceTestCols))
+			mock.ExpectQuery("JOIN sessions sess ON sess\\.id = pi\\.session_id").
+				WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+				WillReturnRows(pgxmock.NewRows(branchPreviewSummaryTestCols()).AddRow(
+					previewID, &previewID, repoID, "assembledhq/assembled", "feature/session-preview", "abc123",
+					"", models.PreviewSourceTypeSession, sessionID.String(), "", "unavailable", now,
+					now, &expiresAt, &now, "", "unavailable", "preview runtime endpoint mismatch",
+					false, (*int)(nil),
+				))
+
+			handler := NewBranchPreviewHandler(
+				db.NewPreviewStore(mock),
+				db.NewRepositoryStore(mock),
+				fakeBranchPreviewGitHub{},
+				nil,
+				"https://app.143.dev",
+				"https://{id}.preview.143.dev",
+			)
+
+			req := httptest.NewRequest(http.MethodGet, "/api/v1/previews/"+previewID.String(), nil)
+			rctx := chi.NewRouteContext()
+			rctx.URLParams.Add("preview_id", previewID.String())
+			ctx := context.WithValue(req.Context(), chi.RouteCtxKey, rctx)
+			ctx = middleware.WithOrgID(ctx, orgID)
+			ctx = tt.withAuth(ctx, orgID, otherRepoID)
+			req = req.WithContext(ctx)
+			rr := httptest.NewRecorder()
+
+			handler.Get(rr, req)
+
+			require.Equal(t, http.StatusForbidden, rr.Code, "Get should reject token access to session previews in another repository")
+			require.Contains(t, rr.Body.String(), "PREVIEW_TOKEN_FORBIDDEN", "session preview access failure should use the preview token forbidden code")
+			require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
+		})
+	}
+}
+
+func TestBranchPreviewHandler_EnrichSessionPreviewResponseReturnsCopy(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "pgx mock should initialize")
+	defer mock.Close()
+
+	orgID := uuid.New()
+	sessionID := uuid.New()
+	previewID := uuid.New()
+	repoID := uuid.New()
+	now := time.Now()
+	expiresAt := now.Add(30 * time.Minute)
+	previewURL := "https://" + previewID.String() + ".preview.143.dev"
+	base := branchPreviewResponse{
+		PreviewID:  &previewID,
+		Status:     string(models.PreviewStatusUnavailable),
+		Error:      "preview runtime endpoint mismatch",
+		StableURL:  "https://app.143.dev/previews/" + previewID.String(),
+		PreviewURL: &previewURL,
+		ExpiresAt:  &expiresAt,
+		StoppedAt:  &now,
+	}
+	original := base
+
+	mock.ExpectQuery("JOIN sessions sess ON sess\\.id = pi\\.session_id").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(pgxmock.NewRows(branchPreviewSummaryTestCols()).AddRow(
+			previewID, &previewID, repoID, "assembledhq/assembled", "feature/session-preview", "abc123",
+			"", models.PreviewSourceTypeSession, sessionID.String(), "", "unavailable", now,
+			now, &expiresAt, &now, "", "unavailable", "preview runtime endpoint mismatch",
+			false, (*int)(nil),
+		))
+
+	handler := NewBranchPreviewHandler(
+		db.NewPreviewStore(mock),
+		db.NewRepositoryStore(mock),
+		fakeBranchPreviewGitHub{},
+		nil,
+		"https://app.143.dev",
+		"https://{id}.preview.143.dev",
+	)
+
+	enriched := handler.enrichSessionPreviewResponse(context.Background(), orgID, base)
+
+	require.Equal(t, original, base, "enrichSessionPreviewResponse should not mutate the input response")
+	require.Equal(t, previewID, enriched.TargetID, "enriched copy should use the runtime preview ID as the target ID")
+	require.Equal(t, repoID, enriched.RepositoryID, "enriched copy should include the owning session repository ID")
+	require.Equal(t, "assembledhq/assembled", enriched.RepositoryFullName, "enriched copy should include repository metadata")
+	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
+}

--- a/internal/db/preview_store.go
+++ b/internal/db/preview_store.go
@@ -432,6 +432,41 @@ func (s *PreviewStore) ListBranchPreviewIndex(ctx context.Context, orgID uuid.UU
 	return pgx.CollectRows(rows, pgx.RowToStructByName[models.BranchPreviewSummary])
 }
 
+// GetSessionPreviewSummary returns target-shaped metadata for a runtime-only
+// session preview. Session previews do not have preview_targets rows, so the
+// preview instance ID acts as the stable list/detail ID.
+func (s *PreviewStore) GetSessionPreviewSummary(ctx context.Context, orgID, previewID uuid.UUID) (*models.BranchPreviewSummary, error) {
+	rows, err := s.db.Query(ctx, `
+		SELECT pi.id AS target_id, pi.id AS preview_id,
+			sess.repository_id, repo.full_name AS repository_full_name,
+			COALESCE(sess.working_branch, sess.target_branch, '') AS branch,
+			COALESCE(NULLIF(pi.base_commit_sha, ''), sess.base_commit_sha, '') AS commit_sha,
+			'' AS preview_config_name,
+			'session' AS source_type, sess.id::text AS source_id, '' AS source_url,
+			pi.status AS status,
+			pi.created_at, pi.created_at AS sort_created_at,
+			pi.expires_at, pi.stopped_at, COALESCE(pi.stopped_reason, '') AS stopped_reason,
+			COALESCE(pi.current_phase, '') AS current_phase, COALESCE(pi.error, '') AS error,
+			false AS resumable, NULL::integer AS resume_estimate_seconds
+		FROM preview_instances pi
+		JOIN sessions sess ON sess.id = pi.session_id AND sess.org_id = pi.org_id
+		JOIN repositories repo ON repo.id = sess.repository_id AND repo.org_id = sess.org_id
+		WHERE pi.id = @preview_id
+		  AND pi.org_id = @org_id
+		  AND pi.preview_target_id IS NULL
+		  AND pi.session_id IS NOT NULL`,
+		pgx.NamedArgs{"org_id": orgID, "preview_id": previewID},
+	)
+	if err != nil {
+		return nil, fmt.Errorf("query session preview summary: %w", err)
+	}
+	row, err := pgx.CollectOneRow(rows, pgx.RowToStructByName[models.BranchPreviewSummary])
+	if err != nil {
+		return nil, fmt.Errorf("get session preview summary: %w", err)
+	}
+	return &row, nil
+}
+
 func (s *PreviewStore) CountBranchPreviewIndexScopes(ctx context.Context, orgID uuid.UUID, filters BranchPreviewIndexFilters) (map[string]int, error) {
 	query := fmt.Sprintf(`WITH target_previews AS (
 			SELECT target.id AS target_id, target.org_id, target.repository_id, repo.full_name AS repository_full_name,

--- a/internal/db/preview_store_test.go
+++ b/internal/db/preview_store_test.go
@@ -771,6 +771,56 @@ func TestPreviewStore_ListBranchPreviewIndex_IncludesRuntimeOnlySessionPreview(t
 	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
 }
 
+func TestPreviewStore_GetSessionPreviewSummary(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "pgxmock pool should be created")
+	defer mock.Close()
+
+	store := NewPreviewStore(mock)
+	orgID := uuid.New()
+	repoID := uuid.New()
+	previewID := uuid.New()
+	sessionID := uuid.New()
+	now := time.Now().UTC().Truncate(time.Millisecond)
+	expiresAt := now.Add(30 * time.Minute)
+
+	rows := pgxmock.NewRows(branchPreviewSummaryTestCols()).AddRow(
+		previewID, &previewID, repoID, "acme/app", "feature/session-preview", "abc123", "",
+		models.PreviewSourceTypeSession, sessionID.String(), "",
+		string(models.PreviewStatusUnavailable), now, now, &expiresAt, &now, "",
+		"unavailable", "preview runtime endpoint mismatch", false, (*int)(nil),
+	)
+
+	mock.ExpectQuery("JOIN sessions sess ON sess\\.id = pi\\.session_id").
+		WithArgs(previewAnyArgs(2)...).
+		WillReturnRows(rows)
+
+	summary, err := store.GetSessionPreviewSummary(context.Background(), orgID, previewID)
+
+	require.NoError(t, err, "GetSessionPreviewSummary should return runtime-only session preview metadata")
+	require.Equal(t, &models.BranchPreviewSummary{
+		TargetID:           previewID,
+		PreviewID:          &previewID,
+		RepositoryID:       repoID,
+		RepositoryFullName: "acme/app",
+		Branch:             "feature/session-preview",
+		CommitSHA:          "abc123",
+		SourceType:         models.PreviewSourceTypeSession,
+		SourceID:           sessionID.String(),
+		Status:             string(models.PreviewStatusUnavailable),
+		CreatedAt:          now,
+		SortCreatedAt:      now,
+		ExpiresAt:          &expiresAt,
+		StoppedAt:          &now,
+		CurrentPhase:       "unavailable",
+		Error:              "preview runtime endpoint mismatch",
+		Resumable:          false,
+	}, summary, "GetSessionPreviewSummary should project session preview rows into branch preview summaries")
+	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
+}
+
 func TestPreviewStore_CountBranchPreviewIndexScopes_ResumableUsesWarmCachePredicate(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- Add a session preview summary query so runtime-only previews can be projected into the standard branch preview shape.
- Enrich preview GET and restart responses with session-backed metadata without mutating the original response value.
- Reject preview token reads when a session preview resolves to a repository outside the token scope.
- Document the idempotent response-enrichment pattern in `internal/AGENTS.md`.

## Testing
- Added store coverage for `GetSessionPreviewSummary`.
- Added handler coverage for session preview enrichment, token-scope rejection, and copy semantics.
- Existing test suite updates validate the new response flow at the API and DB layers.