### PR TITLE
Fix preview bootstrap timeout handling and diagnostics

### DIFF
--- a/frontend/src/app/(dashboard)/previews/[id]/page.test.tsx
+++ b/frontend/src/app/(dashboard)/previews/[id]/page.test.tsx
@@ -1,6 +1,7 @@
 import { act } from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { http, HttpResponse } from "msw";
+import userEvent from "@testing-library/user-event";
 
 import { renderWithProviders, screen, waitFor } from "@/test/test-utils";
 import { server } from "@/test/mocks/server";
@@ -151,6 +152,8 @@ describe("PreviewLandingPage launch mode", () => {
   });
 
   it("stops showing opening state when preview bootstrap does not respond", async () => {
+    const user = userEvent.setup();
+    let restartCalls = 0;
     server.use(
       http.get("*/api/v1/previews/target-1", () =>
         HttpResponse.json({
@@ -169,6 +172,24 @@ describe("PreviewLandingPage launch mode", () => {
           },
         }),
       ),
+      http.post("*/api/v1/previews/prev-1/start-latest", () => {
+        restartCalls += 1;
+        return HttpResponse.json({
+          data: {
+            target_id: "target-1",
+            preview_id: "prev-2",
+            repository_id: "repo-1",
+            repository_full_name: "acme/web",
+            branch: "feature/preview",
+            commit_sha: "529975ce1faa2961ef3f23abde2418bf561116d9",
+            source_type: "pull_request",
+            status: "starting",
+            current_phase: "start_services",
+            stable_url: "https://143.dev/previews/target-1",
+            preview_url: "https://target-1.preview.143.dev",
+          },
+        });
+      }),
     );
 
     renderLaunchPage();
@@ -183,6 +204,12 @@ describe("PreviewLandingPage launch mode", () => {
       expect(screen.getByText("Preview could not open")).toBeInTheDocument();
     });
     expect(screen.getByText("Preview bootstrap timed out. Try opening it again.")).toBeInTheDocument();
+    const retry = screen.getByRole("button", { name: "Retry preview" });
+    expect(retry).toBeEnabled();
+
+    await user.click(retry);
+
+    expect(restartCalls).toBe(1);
   }, 10_000);
 
   it("notifies the opener and closes in popup mode instead of navigating", async () => {

--- a/frontend/src/app/(dashboard)/previews/[id]/page.test.tsx
+++ b/frontend/src/app/(dashboard)/previews/[id]/page.test.tsx
@@ -150,6 +150,41 @@ describe("PreviewLandingPage launch mode", () => {
     }
   });
 
+  it("stops showing opening state when preview bootstrap does not respond", async () => {
+    server.use(
+      http.get("*/api/v1/previews/target-1", () =>
+        HttpResponse.json({
+          data: {
+            target_id: "target-1",
+            preview_id: "prev-1",
+            repository_id: "repo-1",
+            repository_full_name: "acme/web",
+            branch: "feature/preview",
+            commit_sha: "529975ce1faa2961ef3f23abde2418bf561116d9",
+            source_type: "pull_request",
+            status: "ready",
+            current_phase: "ready",
+            stable_url: "https://143.dev/previews/target-1",
+            preview_url: "https://target-1.preview.143.dev",
+          },
+        }),
+      ),
+    );
+
+    renderLaunchPage();
+
+    expect(await screen.findByText("Opening preview")).toBeInTheDocument();
+
+    await act(async () => {
+      await new Promise((resolve) => window.setTimeout(resolve, 5_100));
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("Preview could not open")).toBeInTheDocument();
+    });
+    expect(screen.getByText("Preview bootstrap timed out. Try opening it again.")).toBeInTheDocument();
+  }, 10_000);
+
   it("notifies the opener and closes in popup mode instead of navigating", async () => {
     searchParams = new URLSearchParams("launch=1&popup=1");
 

--- a/frontend/src/app/(dashboard)/previews/[id]/page.tsx
+++ b/frontend/src/app/(dashboard)/previews/[id]/page.tsx
@@ -48,6 +48,8 @@ import {
 import { cn, safeExternalUrl } from "@/lib/utils";
 import { pollMs } from "@/lib/poll-intervals";
 
+const PREVIEW_LAUNCH_BOOTSTRAP_TIMEOUT_MS = 5_000;
+
 type PreviewStepTone = "complete" | "active" | "failed" | "pending";
 
 function previewUnavailableRecoveryCopy(unavailableReason?: string) {
@@ -142,6 +144,7 @@ export function PreviewLandingContent({ id }: { id: string }) {
   const launchError =
     bootstrapError ??
     (preview?.status === "failed" ? preview.error || "Preview failed to start." : null);
+  const commandIsFailed = isFailed || Boolean(bootstrapError);
 
   const shouldStartForLaunch =
     launchMode &&
@@ -161,11 +164,21 @@ export function PreviewLandingContent({ id }: { id: string }) {
   useEffect(() => {
     if (!launchMode || !previewOrigin || !previewUrl || !preview?.preview_id || !isReady) return;
     const activePreviewId = preview.preview_id;
+    let completed = false;
+    let timedOut = false;
+    const timeout = window.setTimeout(() => {
+      if (completed) return;
+      timedOut = true;
+      bootstrappedPreviewIdRef.current = null;
+      setBootstrapError("Preview bootstrap timed out. Try opening it again.");
+    }, PREVIEW_LAUNCH_BOOTSTRAP_TIMEOUT_MS);
 
     const handleMessage = (event: MessageEvent) => {
       if (event.origin !== previewOrigin) return;
       if (event.data?.type === PREVIEW_BOOTSTRAP_COMPLETE_EVENT) {
-        if (bootstrappedPreviewIdRef.current === activePreviewId) {
+        if (!timedOut && bootstrappedPreviewIdRef.current === activePreviewId) {
+          completed = true;
+          window.clearTimeout(timeout);
           if (popupMode && window.opener) {
             (window.opener as Window).postMessage(
               { type: PREVIEW_LAUNCH_COMPLETE_EVENT, url: previewUrl },
@@ -185,6 +198,7 @@ export function PreviewLandingContent({ id }: { id: string }) {
       setBootstrapError(null);
       bootstrapPreview.mutate(activePreviewId, {
         onSuccess: (data) => {
+          if (timedOut) return;
           iframeRef.current?.contentWindow?.postMessage(
             { type: PREVIEW_BOOTSTRAP_TOKEN_EVENT, token: data.data.token },
             previewOrigin,
@@ -198,7 +212,10 @@ export function PreviewLandingContent({ id }: { id: string }) {
     };
 
     window.addEventListener("message", handleMessage);
-    return () => window.removeEventListener("message", handleMessage);
+    return () => {
+      window.clearTimeout(timeout);
+      window.removeEventListener("message", handleMessage);
+    };
   }, [bootstrapPreview, isReady, launchMode, popupMode, preview?.preview_id, previewOrigin, previewUrl]);
 
   const startLatest = () => {
@@ -260,7 +277,7 @@ export function PreviewLandingContent({ id }: { id: string }) {
                   launchMode={launchMode}
                   isReady={isReady}
                   isStarting={isStarting}
-                  isFailed={isFailed}
+                  isFailed={commandIsFailed}
                   isExpired={isExpired}
                   launchError={launchError}
                   stoppedAtText={stoppedAtText}
@@ -281,7 +298,7 @@ export function PreviewLandingContent({ id }: { id: string }) {
                   </div>
                 ) : null}
 
-                <PreviewProgress preview={preview} prominent={isStarting || isFailed} />
+                <PreviewProgress preview={preview} prominent={isStarting || commandIsFailed} />
 
 
                 {unavailableRecovery ? (
@@ -686,9 +703,9 @@ function getCommandTitle({
   isFailed: boolean;
   isExpired: boolean;
 }) {
+  if (launchMode && isFailed) return "Preview could not open";
   if (launchMode && isReady) return "Opening preview";
   if (launchMode && isStarting) return "Opening when ready";
-  if (launchMode && isFailed) return "Preview could not open";
   if (isReady) return "Preview is ready";
   if (isStarting) return "Starting preview";
   if (isFailed) return "Preview failed";
@@ -711,9 +728,9 @@ function getCommandDescription({
   isExpired: boolean;
   stoppedAtText: string | null;
 }) {
+  if (launchMode && isFailed) return "This preview failed to start. Retry to try opening it again.";
   if (launchMode && isReady) return "Connecting this browser to the running preview.";
   if (launchMode && isStarting) return "This preview will open automatically when it is ready.";
-  if (launchMode && isFailed) return "This preview failed to start. Retry to try opening it again.";
   if (isReady) return "Open the running branch preview, or use preview actions for lifecycle controls.";
   if (isStarting) return "Preparing the branch runtime. The preview will be available after readiness checks pass.";
   if (isFailed) return "Retry the preview from this page, then use details only if the failure needs investigation.";

--- a/frontend/src/app/(dashboard)/previews/[id]/page.tsx
+++ b/frontend/src/app/(dashboard)/previews/[id]/page.tsx
@@ -419,7 +419,7 @@ function PreviewCommandState({
       </div>
 
       <div className="flex gap-2 md:justify-end">
-        {isReady && previewUrl ? (
+        {isReady && previewUrl && !isFailed ? (
           launchMode ? (
             <Button type="button" disabled className="w-full sm:w-auto">
               <Loader2 className="h-4 w-4 animate-spin" />

--- a/frontend/src/components/preview/open-preview-button.test.tsx
+++ b/frontend/src/components/preview/open-preview-button.test.tsx
@@ -1,0 +1,60 @@
+import { act } from "react";
+import { describe, expect, it, vi, afterEach } from "vitest";
+import userEvent from "@testing-library/user-event";
+import { toast } from "sonner";
+
+import { renderWithProviders, screen } from "@/test/test-utils";
+import { OpenPreviewButton } from "./open-preview-button";
+
+vi.mock("sonner", () => ({
+  toast: {
+    error: vi.fn(),
+  },
+}));
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+});
+
+describe("OpenPreviewButton", () => {
+  it("closes the placeholder popup when bootstrap does not respond quickly", async () => {
+    const user = userEvent.setup();
+    const close = vi.fn();
+    const documentWrite = vi.fn();
+    const documentClose = vi.fn();
+    const popup = {
+      opener: window,
+      close,
+      document: {
+        write: documentWrite,
+        close: documentClose,
+      },
+      location: {
+        href: "",
+      },
+    } as unknown as Window;
+    vi.spyOn(window, "open").mockReturnValue(popup);
+
+    renderWithProviders(
+      <OpenPreviewButton
+        previewId="prev-1"
+        previewUrl="https://prev-1.preview.143.dev"
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Open preview" }));
+
+    expect(documentWrite).toHaveBeenCalledWith(
+      "<!doctype html><title>Opening preview</title><p>Opening preview...</p>",
+    );
+
+    await act(async () => {
+      await new Promise((resolve) => window.setTimeout(resolve, 5_100));
+    });
+
+    expect(close).toHaveBeenCalled();
+    expect(toast.error).toHaveBeenCalledWith("Preview bootstrap timed out. Try opening it again.");
+    expect(screen.getByRole("button", { name: "Open preview" })).toBeEnabled();
+  }, 10_000);
+});

--- a/frontend/src/components/preview/open-preview-button.tsx
+++ b/frontend/src/components/preview/open-preview-button.tsx
@@ -14,7 +14,7 @@ import {
   PREVIEW_BOOTSTRAP_TOKEN_EVENT,
 } from "@/lib/preview-bootstrap";
 
-const BOOTSTRAP_TIMEOUT_MS = 15_000;
+const BOOTSTRAP_TIMEOUT_MS = 5_000;
 
 type BootstrapToken = {
   token: string;

--- a/internal/api/gateway/preview_gateway.go
+++ b/internal/api/gateway/preview_gateway.go
@@ -1059,13 +1059,14 @@ func (g *Gateway) proxyToWorker(w http.ResponseWriter, r *http.Request, orgID, p
 			req.Header.Set("Authorization", "Bearer "+token)
 		},
 		ModifyResponse: func(resp *http.Response) error {
-			if translated, workerCode, workerStatus := g.translateWorkerPreviewFailure(resp, previewID, isNavigationRequest(originalReq)); translated {
+			if translated, workerCode, workerMessage, workerStatus := g.translateWorkerPreviewFailure(resp, previewID, isNavigationRequest(originalReq)); translated {
 				// The worker no longer recognizes this runtime epoch; drop
 				// the cached runtime so the next request re-resolves.
 				g.evictCachedRuntime(previewID)
-				g.markRuntimeEndpointUnreachable(r.Context(), orgID, previewID, runtime, "preview runtime endpoint mismatch")
+				g.markRuntimeEndpointUnreachable(r.Context(), orgID, previewID, runtime, previewWorkerFailureReason(workerCode, workerMessage))
 				addPreviewProxyLogFields(g.logger.Warn(), originalReq, orgID, previewID, runtime, upstreamPath).
 					Str("worker_error_code", workerCode).
+					Str("worker_error_message", workerMessage).
 					Int("worker_status", workerStatus).
 					Msg("translated preview worker auth/routing failure")
 				return nil
@@ -1214,22 +1215,22 @@ func addPreviewProxyLogFields(event *zerolog.Event, r *http.Request, orgID, prev
 		Str("runtime_unavailable_reason", string(runtime.UnavailableReason))
 }
 
-func (g *Gateway) translateWorkerPreviewFailure(resp *http.Response, previewID uuid.UUID, navigation bool) (bool, string, int) {
+func (g *Gateway) translateWorkerPreviewFailure(resp *http.Response, previewID uuid.UUID, navigation bool) (bool, string, string, int) {
 	if resp.StatusCode != http.StatusForbidden && resp.StatusCode != http.StatusUnauthorized {
-		return false, "", resp.StatusCode
+		return false, "", "", resp.StatusCode
 	}
 	originalStatus := resp.StatusCode
 	body, err := io.ReadAll(resp.Body)
 	_ = resp.Body.Close()
 	if err != nil {
 		resp.Body = io.NopCloser(bytes.NewReader(body))
-		return false, "", originalStatus
+		return false, "", "", originalStatus
 	}
 
 	var parsed models.ErrorResponse
 	if err := json.Unmarshal(body, &parsed); err != nil {
 		resp.Body = io.NopCloser(bytes.NewReader(body))
-		return false, "", originalStatus
+		return false, "", "", originalStatus
 	}
 	workerMarked := resp.Header.Get(auth.PreviewWorkerErrorHeader) == "1"
 	workerCode := parsed.Error.Code
@@ -1245,7 +1246,7 @@ func (g *Gateway) translateWorkerPreviewFailure(resp *http.Response, previewID u
 	}
 	if !shouldTranslate {
 		resp.Body = io.NopCloser(bytes.NewReader(body))
-		return false, "", originalStatus
+		return false, "", "", originalStatus
 	}
 
 	var replacement []byte
@@ -1275,7 +1276,32 @@ func (g *Gateway) translateWorkerPreviewFailure(resp *http.Response, previewID u
 	resp.Header.Set("Cache-Control", "no-store")
 	resp.ContentLength = int64(len(replacement))
 	resp.Body = io.NopCloser(bytes.NewReader(replacement))
-	return true, workerCode, originalStatus
+	return true, workerCode, sanitizeWorkerPreviewFailureMessage(workerMessage), originalStatus
+}
+
+func sanitizeWorkerPreviewFailureMessage(message string) string {
+	message = strings.ReplaceAll(message, "\n", " ")
+	message = strings.ReplaceAll(message, "\r", " ")
+	message = strings.TrimSpace(message)
+	if len(message) > 240 {
+		return message[:240]
+	}
+	return message
+}
+
+func previewWorkerFailureReason(code, message string) string {
+	reason := "preview worker auth/routing failure"
+	if code != "" {
+		reason += ": " + code
+	}
+	if message != "" {
+		reason += " " + sanitizeWorkerPreviewFailureMessage(message)
+	}
+	const maxReasonLen = 320
+	if len(reason) > maxReasonLen {
+		return reason[:maxReasonLen]
+	}
+	return reason
 }
 
 func writeRuntimeUnavailable(w http.ResponseWriter) {

--- a/internal/api/gateway/preview_gateway_test.go
+++ b/internal/api/gateway/preview_gateway_test.go
@@ -1688,6 +1688,84 @@ func TestGateway_ProxyToWorker_TranslatesMarkedWorkerAuthFailureAndEvictsRuntime
 	require.NoError(t, mock.ExpectationsWereMet(), "translated worker auth failures should evict the runtime cache")
 }
 
+func TestGateway_ProxyToWorker_LogsTranslatedWorkerFailureMessage(t *testing.T) {
+	t.Parallel()
+
+	workerServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set(auth.PreviewWorkerErrorHeader, "1")
+		w.WriteHeader(http.StatusUnauthorized)
+		err := json.NewEncoder(w).Encode(models.ErrorResponse{
+			Error: models.ErrorDetail{
+				Code:    "UNAUTHORIZED",
+				Message: "invalid preview token",
+			},
+		})
+		require.NoError(t, err, "worker auth failure response should encode")
+	}))
+	defer workerServer.Close()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "pgxmock pool should be created")
+	defer mock.Close()
+
+	orgID := uuid.New()
+	previewID := uuid.New()
+	runtimeID := uuid.New()
+	now := time.Now().UTC()
+	var logs bytes.Buffer
+	store := db.NewPreviewStore(mock)
+	gw := NewGateway(GatewayConfig{
+		Store:              store,
+		WorkerSelector:     preview.NewWorkerSelector(db.NewNodeStore(mock), store),
+		Logger:             zerolog.New(&logs),
+		AppOrigin:          "https://app.143.dev",
+		PreviewTokenSecret: "preview-secret",
+	})
+
+	mock.ExpectQuery("SELECT .+ FROM preview_runtimes").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(pgxmock.NewRows([]string{
+			"id", "org_id", "preview_instance_id", "runtime_epoch", "worker_node_id",
+			"endpoint_url", "preview_handle", "primary_port", "status", "lease_expires_at",
+			"last_heartbeat_at", "drain_requested_at", "stopped_at", "error", "unavailable_reason", "created_at", "updated_at",
+		}).AddRow(
+			runtimeID, orgID, previewID, 1, "worker-runtime",
+			workerServer.URL, "handle-1", 3000, string(models.PreviewRuntimeStatusReady), now.Add(time.Minute),
+			now, nil, nil, "", "", now, now,
+		))
+	mock.ExpectExec("WITH lost AS[\\s\\S]+unavailable_reason = @unavailable_reason[\\s\\S]+UPDATE preview_instances").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
+
+	req := httptest.NewRequest(http.MethodGet, "/assets/app.js", nil)
+	req.Host = previewID.String() + ".preview.143.dev"
+	rr := httptest.NewRecorder()
+
+	gw.proxyToWorker(rr, req, orgID, previewID)
+	require.Equal(t, http.StatusServiceUnavailable, rr.Code, "translated worker auth failures should be hidden from preview users")
+
+	lines := bytes.Split(bytes.TrimSpace(logs.Bytes()), []byte("\n"))
+	require.GreaterOrEqual(t, len(lines), 1, "translated worker failure should emit structured logs")
+	var translated map[string]any
+	for _, line := range lines {
+		var event map[string]any
+		require.NoError(t, json.Unmarshal(line, &event), "gateway log line should be valid JSON")
+		if event["message"] == "translated preview worker auth/routing failure" {
+			translated = event
+			break
+		}
+	}
+	require.NotNil(t, translated, "gateway should log translated worker auth/routing failures")
+	require.Equal(t, "UNAUTHORIZED", translated["worker_error_code"], "gateway log should include worker error code")
+	require.Equal(t, "invalid preview token", translated["worker_error_message"], "gateway log should include safe worker error message")
+	require.Equal(t, float64(http.StatusUnauthorized), translated["worker_status"], "gateway log should include original worker status")
+	require.Equal(t, runtimeID.String(), translated["runtime_id"], "gateway log should include runtime id")
+	require.Equal(t, "worker-runtime", translated["worker_node_id"], "gateway log should include runtime worker node")
+	require.Equal(t, workerServer.URL, translated["endpoint_url"], "gateway log should include runtime endpoint")
+	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
+}
+
 func TestGateway_ProxyToWorker_PreservesUnmarkedAppUnauthorized(t *testing.T) {
 	t.Parallel()
 

--- a/internal/api/handlers/internal_preview.go
+++ b/internal/api/handlers/internal_preview.go
@@ -516,14 +516,10 @@ func (h *InternalPreviewHandler) authorizePreviewAction(w http.ResponseWriter, r
 	return previewID, claims, true
 }
 
-// runtimeClaimsValid checks proxy token claims against the active runtime
+// runtimeClaimsValidation checks proxy token claims against the active runtime
 // through a short TTL cache. A cached match is trusted; a miss or mismatch
 // always re-resolves from the DB before rejecting, so a freshly recycled
 // preview (new runtime epoch) is never penalized by a stale cache entry.
-func (h *InternalPreviewHandler) runtimeClaimsValid(ctx context.Context, claims *auth.PreviewTokenClaims, previewID uuid.UUID) bool {
-	return h.runtimeClaimsValidation(ctx, claims, previewID).valid
-}
-
 type runtimeClaimsValidationResult struct {
 	valid       bool
 	failureKind string

--- a/internal/api/handlers/internal_preview.go
+++ b/internal/api/handlers/internal_preview.go
@@ -85,26 +85,45 @@ func (h *InternalPreviewHandler) authorize(w http.ResponseWriter, r *http.Reques
 	tokenStr := strings.TrimSpace(strings.TrimPrefix(r.Header.Get("Authorization"), "Bearer "))
 	if tokenStr == "" {
 		markPreviewWorkerError(w)
+		h.logPreviewAuthorizationRejected(r, "missing_token", action, nil, nil)
 		writeError(w, r, http.StatusUnauthorized, "UNAUTHORIZED", "missing authorization token")
 		return nil, false
 	}
 	claims, err := h.keyring.Validate(tokenStr)
 	if err != nil {
 		markPreviewWorkerError(w)
+		h.logPreviewAuthorizationRejected(r, "invalid_token", action, nil, err)
 		writeError(w, r, http.StatusUnauthorized, "UNAUTHORIZED", "invalid preview token", err)
 		return nil, false
 	}
 	if claims.TargetNodeID != h.nodeID {
 		markPreviewWorkerError(w)
+		h.logPreviewAuthorizationRejected(r, "wrong_worker", action, claims, nil)
 		writeError(w, r, http.StatusForbidden, "WRONG_PREVIEW_WORKER", "preview token targets a different worker")
 		return nil, false
 	}
 	if claims.Action != action {
 		markPreviewWorkerError(w)
+		h.logPreviewAuthorizationRejected(r, "action_mismatch", action, claims, nil)
 		writeError(w, r, http.StatusForbidden, "PREVIEW_ACTION_MISMATCH", "preview token is not valid for this action")
 		return nil, false
 	}
 	return claims, true
+}
+
+func (h *InternalPreviewHandler) logPreviewAuthorizationRejected(r *http.Request, failureKind, requestedAction string, claims *auth.PreviewTokenClaims, err error) {
+	event := h.logger.Warn()
+	if err != nil {
+		event = event.Err(err)
+	}
+	event = addInternalPreviewRequestLogFields(event, r).
+		Str("failure_kind", failureKind).
+		Str("requested_preview_action", requestedAction).
+		Str("local_worker_node_id", h.nodeID)
+	if claims != nil {
+		event = addPreviewTokenClaimLogFields(event, claims)
+	}
+	event.Msg("internal preview authorization rejected")
 }
 
 func markPreviewWorkerError(w http.ResponseWriter) {
@@ -475,17 +494,21 @@ func (h *InternalPreviewHandler) authorizePreviewAction(w http.ResponseWriter, r
 	}
 	if claims.PreviewID == nil || *claims.PreviewID != previewID {
 		markPreviewWorkerError(w)
+		h.logPreviewRuntimeAuthorizationRejected(r, "preview_mismatch", action, previewID, claims, runtimeClaimsValidationResult{})
 		writeError(w, r, http.StatusForbidden, "PREVIEW_MISMATCH", "preview token does not match the requested preview")
 		return uuid.Nil, nil, false
 	}
 	if action == "proxy" && (claims.RuntimeID == nil || claims.RuntimeEpoch <= 0) {
 		markPreviewWorkerError(w)
+		h.logPreviewRuntimeAuthorizationRejected(r, "missing_runtime_identity", action, previewID, claims, runtimeClaimsValidationResult{})
 		writeError(w, r, http.StatusForbidden, "PREVIEW_RUNTIME_MISMATCH", "preview token does not match an active runtime")
 		return uuid.Nil, nil, false
 	}
 	if action == "proxy" && h.preview != nil && h.preview.store != nil {
-		if !h.runtimeClaimsValid(r.Context(), claims, previewID) {
+		result := h.runtimeClaimsValidation(r.Context(), claims, previewID)
+		if !result.valid {
 			markPreviewWorkerError(w)
+			h.logPreviewRuntimeAuthorizationRejected(r, result.failureKind, action, previewID, claims, result)
 			writeError(w, r, http.StatusForbidden, "PREVIEW_RUNTIME_MISMATCH", "preview token does not match an active runtime")
 			return uuid.Nil, nil, false
 		}
@@ -498,6 +521,19 @@ func (h *InternalPreviewHandler) authorizePreviewAction(w http.ResponseWriter, r
 // always re-resolves from the DB before rejecting, so a freshly recycled
 // preview (new runtime epoch) is never penalized by a stale cache entry.
 func (h *InternalPreviewHandler) runtimeClaimsValid(ctx context.Context, claims *auth.PreviewTokenClaims, previewID uuid.UUID) bool {
+	return h.runtimeClaimsValidation(ctx, claims, previewID).valid
+}
+
+type runtimeClaimsValidationResult struct {
+	valid       bool
+	failureKind string
+	dbErr       error
+	active      *models.PreviewRuntime
+	cacheHit    bool
+	cached      *runtimeAuthEntry
+}
+
+func (h *InternalPreviewHandler) runtimeClaimsValidation(ctx context.Context, claims *auth.PreviewTokenClaims, previewID uuid.UUID) runtimeClaimsValidationResult {
 	matches := func(entry *runtimeAuthEntry) bool {
 		return entry.runtimeID == *claims.RuntimeID &&
 			entry.runtimeEpoch == claims.RuntimeEpoch &&
@@ -508,11 +544,11 @@ func (h *InternalPreviewHandler) runtimeClaimsValid(ctx context.Context, claims 
 	entry, ok := h.runtimeAuthCache[previewID]
 	h.runtimeAuthMu.RUnlock()
 	if ok && now.Before(entry.validUntil) && matches(entry) {
-		return true
+		return runtimeClaimsValidationResult{valid: true, cacheHit: true, cached: entry}
 	}
 	runtime, err := h.preview.store.GetActivePreviewRuntime(ctx, claims.OrgID, previewID)
 	if err != nil {
-		return false
+		return runtimeClaimsValidationResult{failureKind: "active_runtime_lookup_failed", dbErr: err, cacheHit: ok, cached: entry}
 	}
 	entry = &runtimeAuthEntry{
 		validUntil:   now.Add(runtimeAuthCacheTTL),
@@ -527,7 +563,91 @@ func (h *InternalPreviewHandler) runtimeClaimsValid(ctx context.Context, claims 
 	}
 	h.runtimeAuthCache[previewID] = entry
 	h.runtimeAuthMu.Unlock()
-	return matches(entry)
+	if matches(entry) {
+		return runtimeClaimsValidationResult{valid: true, active: runtime}
+	}
+	return runtimeClaimsValidationResult{failureKind: "runtime_mismatch", active: runtime, cacheHit: ok}
+}
+
+func (h *InternalPreviewHandler) logPreviewRuntimeAuthorizationRejected(r *http.Request, failureKind, requestedAction string, previewID uuid.UUID, claims *auth.PreviewTokenClaims, result runtimeClaimsValidationResult) {
+	if failureKind == "" {
+		failureKind = "runtime_mismatch"
+	}
+	event := h.logger.Warn()
+	if result.dbErr != nil {
+		event = event.Err(result.dbErr)
+	}
+	event = addInternalPreviewRequestLogFields(event, r).
+		Str("failure_kind", failureKind).
+		Str("requested_preview_action", requestedAction).
+		Str("preview_id", previewID.String()).
+		Str("local_worker_node_id", h.nodeID).
+		Bool("runtime_auth_cache_hit", result.cacheHit)
+	if claims != nil {
+		event = addPreviewTokenClaimLogFields(event, claims).
+			Str("claimed_worker_node_id", claims.TargetNodeID)
+	}
+	if result.cached != nil {
+		event = event.
+			Str("cached_runtime_id", result.cached.runtimeID.String()).
+			Int("cached_runtime_epoch", result.cached.runtimeEpoch).
+			Str("cached_worker_node_id", result.cached.workerNodeID).
+			Time("cached_runtime_valid_until", result.cached.validUntil)
+	}
+	if result.active != nil {
+		event = event.
+			Str("active_runtime_id", result.active.ID.String()).
+			Int("active_runtime_epoch", result.active.RuntimeEpoch).
+			Str("active_worker_node_id", result.active.WorkerNodeID).
+			Str("active_endpoint_url", result.active.EndpointURL).
+			Str("active_preview_handle", result.active.PreviewHandle).
+			Int("active_primary_port", result.active.PrimaryPort).
+			Str("active_runtime_status", string(result.active.Status)).
+			Time("active_runtime_lease_expires_at", result.active.LeaseExpiresAt).
+			Time("active_runtime_last_heartbeat_at", result.active.LastHeartbeatAt)
+	}
+	event.Msg("internal preview runtime authorization rejected")
+}
+
+func addInternalPreviewRequestLogFields(event *zerolog.Event, r *http.Request) *zerolog.Event {
+	requestMethod := ""
+	requestHost := ""
+	requestPath := ""
+	queryPresent := false
+	if r != nil {
+		requestMethod = r.Method
+		requestHost = r.Host
+		if r.URL != nil {
+			requestPath = r.URL.Path
+			queryPresent = r.URL.RawQuery != ""
+		}
+	}
+	return event.
+		Str("request_method", requestMethod).
+		Str("request_host", requestHost).
+		Str("request_path", requestPath).
+		Bool("query_present", queryPresent)
+}
+
+func addPreviewTokenClaimLogFields(event *zerolog.Event, claims *auth.PreviewTokenClaims) *zerolog.Event {
+	event = event.
+		Str("org_id", claims.OrgID.String()).
+		Str("target_worker_node_id", claims.TargetNodeID).
+		Str("token_action", claims.Action).
+		Time("token_expires_at", claims.ExpiresAt)
+	if claims.SessionID != nil {
+		event = event.Str("session_id", claims.SessionID.String())
+	}
+	if claims.PreviewID != nil {
+		event = event.Str("preview_id", claims.PreviewID.String())
+	}
+	if claims.RuntimeID != nil {
+		event = event.Str("claimed_runtime_id", claims.RuntimeID.String())
+	}
+	if claims.RuntimeEpoch > 0 {
+		event = event.Int("claimed_runtime_epoch", claims.RuntimeEpoch)
+	}
+	return event
 }
 
 func (h *InternalPreviewHandler) Proxy(w http.ResponseWriter, r *http.Request) {

--- a/internal/api/handlers/internal_preview_test.go
+++ b/internal/api/handlers/internal_preview_test.go
@@ -149,6 +149,17 @@ func mustJSONBody(t *testing.T, v any) string {
 	return string(payload)
 }
 
+func decodeSingleLogEvent(t *testing.T, logs *bytes.Buffer) map[string]any {
+	t.Helper()
+
+	require.NotEmpty(t, logs.String(), "expected a structured log event")
+	lines := bytes.Split(bytes.TrimSpace(logs.Bytes()), []byte("\n"))
+	require.Len(t, lines, 1, "expected exactly one structured log event")
+	var event map[string]any
+	require.NoError(t, json.Unmarshal(lines[0], &event), "structured log event should be valid JSON")
+	return event
+}
+
 func TestInternalPreviewHandler_AuthorizeFailures(t *testing.T) {
 	t.Parallel()
 
@@ -215,6 +226,122 @@ func TestInternalPreviewHandler_AuthorizeFailures(t *testing.T) {
 			require.NoError(t, json.NewDecoder(rr.Body).Decode(&resp), "authorize should return a JSON error")
 			require.Equal(t, tt.wantCode, resp.Error.Code, "authorize should return the expected error code")
 			require.Equal(t, "1", rr.Header().Get(auth.PreviewWorkerErrorHeader), "worker auth failures should be marked for the public gateway")
+		})
+	}
+}
+
+func TestInternalPreviewHandler_AuthorizeFailures_LogDiagnosticFields(t *testing.T) {
+	t.Parallel()
+
+	orgID := uuid.New()
+	previewID := uuid.New()
+	runtimeID := uuid.New()
+	sessionID := uuid.New()
+
+	tests := []struct {
+		name         string
+		header       string
+		wantFailure  string
+		wantFields   map[string]any
+		absentFields []string
+	}{
+		{
+			name:        "missing token",
+			wantFailure: "missing_token",
+			absentFields: []string{
+				"preview_token",
+				"token",
+				"authorization",
+			},
+		},
+		{
+			name:        "invalid token",
+			header:      "Bearer not-a-token",
+			wantFailure: "invalid_token",
+			wantFields: map[string]any{
+				"error": "preview token is not valid for any configured secret: invalid token format",
+			},
+			absentFields: []string{
+				"preview_token",
+				"token",
+				"authorization",
+			},
+		},
+		{
+			name: "wrong worker target",
+			header: internalPreviewAuthHeader(t, auth.PreviewTokenClaims{
+				OrgID:        orgID,
+				SessionID:    &sessionID,
+				PreviewID:    &previewID,
+				RuntimeID:    &runtimeID,
+				RuntimeEpoch: 3,
+				TargetNodeID: "worker-2",
+				Action:       "proxy",
+				ExpiresAt:    time.Now().Add(time.Minute),
+			}),
+			wantFailure: "wrong_worker",
+			wantFields: map[string]any{
+				"org_id":                   orgID.String(),
+				"session_id":               sessionID.String(),
+				"preview_id":               previewID.String(),
+				"claimed_runtime_id":       runtimeID.String(),
+				"claimed_runtime_epoch":    float64(3),
+				"local_worker_node_id":     "worker-1",
+				"target_worker_node_id":    "worker-2",
+				"token_action":             "proxy",
+				"requested_preview_action": "start",
+			},
+		},
+		{
+			name: "wrong action",
+			header: internalPreviewAuthHeader(t, auth.PreviewTokenClaims{
+				OrgID:        orgID,
+				SessionID:    &sessionID,
+				TargetNodeID: "worker-1",
+				Action:       "stop",
+				ExpiresAt:    time.Now().Add(time.Minute),
+			}),
+			wantFailure: "action_mismatch",
+			wantFields: map[string]any{
+				"org_id":                   orgID.String(),
+				"session_id":               sessionID.String(),
+				"local_worker_node_id":     "worker-1",
+				"target_worker_node_id":    "worker-1",
+				"token_action":             "stop",
+				"requested_preview_action": "start",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var logs bytes.Buffer
+			handler := NewInternalPreviewHandler(&PreviewHandler{logger: zerolog.Nop()}, nil, "worker-1", "worker-secret", zerolog.New(&logs))
+			req := httptest.NewRequest(http.MethodPost, "/internal/preview/start", nil)
+			req.Host = "worker.internal"
+			if tt.header != "" {
+				req.Header.Set("Authorization", tt.header)
+			}
+			rr := httptest.NewRecorder()
+
+			_, ok := handler.authorize(rr, req, "start")
+			require.False(t, ok, "authorize should reject invalid preview tokens")
+
+			event := decodeSingleLogEvent(t, &logs)
+			require.Equal(t, "internal preview authorization rejected", event["message"], "auth rejection log should use the expected event message")
+			require.Equal(t, tt.wantFailure, event["failure_kind"], "auth rejection log should classify the failure")
+			require.Equal(t, "POST", event["request_method"], "auth rejection log should include request method")
+			require.Equal(t, "/internal/preview/start", event["request_path"], "auth rejection log should include request path")
+			require.Equal(t, "worker.internal", event["request_host"], "auth rejection log should include request host")
+			for field, expected := range tt.wantFields {
+				require.Equal(t, expected, event[field], "auth rejection log should include "+field)
+			}
+			for _, field := range tt.absentFields {
+				require.NotContains(t, event, field, "auth rejection log must not include sensitive "+field)
+			}
 		})
 	}
 }
@@ -388,6 +515,69 @@ func TestInternalPreviewHandler_AuthorizePreviewActionRejectsStaleRuntime(t *tes
 	var resp models.ErrorResponse
 	require.NoError(t, json.NewDecoder(rr.Body).Decode(&resp), "authorizePreviewAction should return a JSON error")
 	require.Equal(t, "PREVIEW_RUNTIME_MISMATCH", resp.Error.Code, "authorizePreviewAction should report runtime identity mismatch")
+	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
+}
+
+func TestInternalPreviewHandler_AuthorizePreviewActionLogsStaleRuntimeDetails(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "pgxmock pool should be created")
+	defer mock.Close()
+
+	orgID := uuid.New()
+	previewID := uuid.New()
+	runtimeID := uuid.New()
+	staleRuntimeID := uuid.New()
+	now := time.Now().UTC()
+
+	var logs bytes.Buffer
+	store := db.NewPreviewStore(mock)
+	handler := NewInternalPreviewHandler(&PreviewHandler{store: store, logger: zerolog.Nop()}, nil, "worker-1", "worker-secret", zerolog.New(&logs))
+
+	mock.ExpectQuery("SELECT .+ FROM preview_runtimes").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(pgxmock.NewRows([]string{
+			"id", "org_id", "preview_instance_id", "runtime_epoch", "worker_node_id",
+			"endpoint_url", "preview_handle", "primary_port", "status", "lease_expires_at",
+			"last_heartbeat_at", "drain_requested_at", "stopped_at", "error", "unavailable_reason", "created_at", "updated_at",
+		}).AddRow(
+			runtimeID, orgID, previewID, 2, "worker-1",
+			"http://worker-1.internal", "handle-1", 3000, string(models.PreviewRuntimeStatusReady), now.Add(time.Minute),
+			now, nil, nil, "", "", now, now,
+		))
+
+	req := httptest.NewRequest(http.MethodGet, "/internal/preview/"+previewID.String()+"/proxy", nil)
+	req = withPreviewRouteParam(req, previewID.String())
+	req.Header.Set("Authorization", internalPreviewAuthHeader(t, auth.PreviewTokenClaims{
+		OrgID:        orgID,
+		PreviewID:    &previewID,
+		TargetNodeID: "worker-1",
+		RuntimeID:    &staleRuntimeID,
+		RuntimeEpoch: 1,
+		Action:       "proxy",
+		ExpiresAt:    time.Now().Add(time.Minute),
+	}))
+	rr := httptest.NewRecorder()
+
+	_, _, ok := handler.authorizePreviewAction(rr, req, "proxy")
+	require.False(t, ok, "authorizePreviewAction should reject proxy tokens for stale runtimes")
+
+	event := decodeSingleLogEvent(t, &logs)
+	require.Equal(t, "internal preview runtime authorization rejected", event["message"], "runtime rejection log should use the expected event message")
+	require.Equal(t, "runtime_mismatch", event["failure_kind"], "runtime rejection log should classify stale runtime claims")
+	require.Equal(t, orgID.String(), event["org_id"], "runtime rejection log should include org id")
+	require.Equal(t, previewID.String(), event["preview_id"], "runtime rejection log should include preview id")
+	require.Equal(t, "proxy", event["requested_preview_action"], "runtime rejection log should include requested action")
+	require.Equal(t, "proxy", event["token_action"], "runtime rejection log should include token action")
+	require.Equal(t, staleRuntimeID.String(), event["claimed_runtime_id"], "runtime rejection log should include claimed runtime id")
+	require.Equal(t, float64(1), event["claimed_runtime_epoch"], "runtime rejection log should include claimed runtime epoch")
+	require.Equal(t, "worker-1", event["claimed_worker_node_id"], "runtime rejection log should include claimed worker")
+	require.Equal(t, runtimeID.String(), event["active_runtime_id"], "runtime rejection log should include active runtime id")
+	require.Equal(t, float64(2), event["active_runtime_epoch"], "runtime rejection log should include active runtime epoch")
+	require.Equal(t, "worker-1", event["active_worker_node_id"], "runtime rejection log should include active worker")
+	require.Equal(t, "http://worker-1.internal", event["active_endpoint_url"], "runtime rejection log should include active endpoint URL")
+	require.Equal(t, "ready", event["active_runtime_status"], "runtime rejection log should include active runtime status")
 	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
 }
 


### PR DESCRIPTION
## Summary
- Stop showing the launch spinner as ready once preview bootstrap times out, and surface the retry state instead
- Shorten popup/bootstrap timeouts so stale launch attempts fail fast
- Add safer diagnostics for worker auth failures and runtime mismatches, including structured logs and sanitized error messages
- Cover the timeout and logging paths with frontend and backend tests

## Testing
- Added unit tests for preview launch timeout retry behavior
- Added UI tests for the open-preview button timeout flow
- Added backend handler and gateway tests for authorization and translated worker failure logging