### PR TITLE
Stop tearing down healthy previews on transient worker auth failures

### DIFF
--- a/frontend/src/components/preview/open-preview-button.test.tsx
+++ b/frontend/src/components/preview/open-preview-button.test.tsx
@@ -45,9 +45,10 @@ describe("OpenPreviewButton", () => {
 
     await user.click(screen.getByRole("button", { name: "Open preview" }));
 
-    expect(documentWrite).toHaveBeenCalledWith(
-      "<!doctype html><title>Opening preview</title><p>Opening preview...</p>",
-    );
+    expect(documentWrite).toHaveBeenCalledTimes(1);
+    const writtenDoc = documentWrite.mock.calls[0][0] as string;
+    expect(writtenDoc).toContain("Opening preview");
+    expect(writtenDoc).toContain("class=\"spinner\"");
 
     await act(async () => {
       await new Promise((resolve) => window.setTimeout(resolve, 5_100));

--- a/frontend/src/components/preview/open-preview-button.tsx
+++ b/frontend/src/components/preview/open-preview-button.tsx
@@ -16,6 +16,14 @@ import {
 
 const BOOTSTRAP_TIMEOUT_MS = 5_000;
 
+// Document shown in the popup while the preview connects. Once the bootstrap
+// handshake completes we navigate the popup to the preview origin; because that
+// is a cross-origin load the opener cannot observe its progress, so this
+// placeholder stays visible until the preview's first bytes arrive (which can
+// take a few seconds while a cold worker wakes up). A styled spinner + copy
+// makes that wait read as intentional instead of a frozen "Opening preview..."
+const OPENING_PREVIEW_DOCUMENT = `<!doctype html><html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1"><title>Opening preview</title><style>:root{color-scheme:light dark}html,body{height:100%;margin:0}body{font-family:ui-sans-serif,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif;display:grid;place-items:center;background:Canvas;color:CanvasText}main{text-align:center;padding:24px}.spinner{width:28px;height:28px;margin:0 auto 16px;border-radius:50%;border:3px solid color-mix(in srgb,CanvasText 18%,transparent);border-top-color:CanvasText;animation:spin .8s linear infinite}h1{font-size:16px;font-weight:600;margin:0}p{font-size:13px;margin:8px 0 0;color:color-mix(in srgb,CanvasText 62%,transparent)}@keyframes spin{to{transform:rotate(360deg)}}</style></head><body><main><div class="spinner" role="status" aria-label="Connecting"></div><h1>Opening preview…</h1><p>Connecting to your preview — this can take a few moments while it wakes up.</p></main></body></html>`;
+
 type BootstrapToken = {
   token: string;
   preview_id?: string;
@@ -122,7 +130,7 @@ export function usePreviewLauncher(bootstrapPreview?: (previewId: string) => Pro
         popup = window.open("about:blank", "_blank");
         if (popup) {
           popup.opener = null;
-          popup.document.write("<!doctype html><title>Opening preview</title><p>Opening preview...</p>");
+          popup.document.write(OPENING_PREVIEW_DOCUMENT);
           popup.document.close();
         }
       } catch {

--- a/internal/api/gateway/preview_gateway.go
+++ b/internal/api/gateway/preview_gateway.go
@@ -77,6 +77,24 @@ const runtimeCacheTTL = 5 * time.Second
 // asset request issued an UPDATE on preview_instances.
 const accessRecordInterval = 15 * time.Second
 
+// previewProxyTokenTTL bounds the lifetime of the bearer token the gateway
+// mints for each proxied worker request. A fresh token is minted on every
+// request, so it only needs to outlive a single in-flight request — but we size
+// it to comfortably span an interactive preview's working window so that
+// long-lived connections (WebSocket/HMR, SSE) authorized once at handshake time
+// never trip on an expired token, even on a slow or busy worker.
+//
+// We deliberately keep it bounded rather than effectively infinite (e.g.
+// weeks): the token is a static, unrevocable bearer whose only early
+// invalidation is a runtime epoch bump on recycle, so a finite TTL caps the
+// replay window if a token ever leaks (logs, worker memory, a compromised hop).
+// 60 minutes is far longer than any single request or handshake yet still a
+// tight blast radius. Previously this was 30s, which let a slow worker response
+// outlive the token: the worker then rejected the in-flight request as "invalid
+// preview token", and the gateway mistook that auth failure for an unreachable
+// endpoint and tore down a perfectly healthy preview.
+const previewProxyTokenTTL = 60 * time.Minute
+
 // Gateway serves the preview origin (e.g., <preview-id>.preview.143.dev).
 // It validates preview access, proxies HTTP and WebSocket traffic, and
 // injects security headers. It does NOT use the main app session middleware.
@@ -1038,7 +1056,7 @@ func (g *Gateway) proxyToWorker(w http.ResponseWriter, r *http.Request, orgID, p
 		RuntimeEpoch: runtime.RuntimeEpoch,
 		PreviewID:    &previewID,
 		Action:       "proxy",
-		ExpiresAt:    time.Now().Add(30 * time.Second),
+		ExpiresAt:    time.Now().Add(previewProxyTokenTTL),
 	})
 	if err != nil {
 		addPreviewProxyLogFields(g.logger.Warn().Err(err), r, orgID, previewID, runtime, upstreamPath).
@@ -1060,14 +1078,25 @@ func (g *Gateway) proxyToWorker(w http.ResponseWriter, r *http.Request, orgID, p
 		},
 		ModifyResponse: func(resp *http.Response) error {
 			if translated, workerCode, workerMessage, workerStatus := g.translateWorkerPreviewFailure(resp, previewID, isNavigationRequest(originalReq)); translated {
-				// The worker no longer recognizes this runtime epoch; drop
-				// the cached runtime so the next request re-resolves.
+				// Always drop the cached runtime so the next request
+				// re-resolves and re-mints a fresh token.
 				g.evictCachedRuntime(previewID)
-				g.markRuntimeEndpointUnreachable(r.Context(), orgID, previewID, runtime, previewWorkerFailureReason(workerCode, workerMessage))
+				// A routing mismatch (the worker recycled the epoch or no
+				// longer owns this runtime) is genuine evidence the cached
+				// runtime is stale, so mark it lost. A token-level auth
+				// failure ("invalid preview token") is NOT — an expired or
+				// mis-signed proxy token says nothing about runtime health,
+				// and marking it lost would kill a working preview. Evict and
+				// let the next request retry with a new token instead.
+				markedLost := previewWorkerFailureMarksRuntimeLost(workerCode)
+				if markedLost {
+					g.markRuntimeEndpointUnreachable(r.Context(), orgID, previewID, runtime, previewWorkerFailureReason(workerCode, workerMessage))
+				}
 				addPreviewProxyLogFields(g.logger.Warn(), originalReq, orgID, previewID, runtime, upstreamPath).
 					Str("worker_error_code", workerCode).
 					Str("worker_error_message", workerMessage).
 					Int("worker_status", workerStatus).
+					Bool("runtime_marked_lost", markedLost).
 					Msg("translated preview worker auth/routing failure")
 				return nil
 			}
@@ -1152,6 +1181,22 @@ func shouldMarkRuntimeLostOnProxyError(err error) bool {
 		}
 	}
 	return false
+}
+
+// previewWorkerFailureMarksRuntimeLost reports whether a translated worker
+// failure code is evidence that the cached runtime is genuinely stale — a
+// recycled epoch or a worker that no longer owns it — and should be marked
+// lost. Token-level auth failures (UNAUTHORIZED / "invalid preview token") are
+// transient: an expired or mis-signed proxy token does not mean the runtime is
+// unreachable, so those only evict the cache and let the next request retry
+// with a freshly minted token rather than tearing down a healthy preview.
+func previewWorkerFailureMarksRuntimeLost(workerCode string) bool {
+	switch workerCode {
+	case "WRONG_PREVIEW_WORKER", "PREVIEW_RUNTIME_MISMATCH":
+		return true
+	default:
+		return false
+	}
 }
 
 func previewProxyErrorReason(err error) string {

--- a/internal/api/gateway/preview_gateway_test.go
+++ b/internal/api/gateway/preview_gateway_test.go
@@ -1734,9 +1734,11 @@ func TestGateway_ProxyToWorker_LogsTranslatedWorkerFailureMessage(t *testing.T) 
 			workerServer.URL, "handle-1", 3000, string(models.PreviewRuntimeStatusReady), now.Add(time.Minute),
 			now, nil, nil, "", "", now, now,
 		))
-	mock.ExpectExec("WITH lost AS[\\s\\S]+unavailable_reason = @unavailable_reason[\\s\\S]+UPDATE preview_instances").
-		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
-		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
+	// A token-level auth failure must NOT mark the runtime lost — there is no
+	// MarkPreviewRuntimeLost exec expectation, and runtime_marked_lost is
+	// asserted false below. Tearing down a healthy runtime on a transient
+	// "invalid preview token" (e.g. a token that expired mid-flight against a
+	// slow worker) would kill a working preview.
 
 	req := httptest.NewRequest(http.MethodGet, "/assets/app.js", nil)
 	req.Host = previewID.String() + ".preview.143.dev"
@@ -1763,6 +1765,7 @@ func TestGateway_ProxyToWorker_LogsTranslatedWorkerFailureMessage(t *testing.T) 
 	require.Equal(t, runtimeID.String(), translated["runtime_id"], "gateway log should include runtime id")
 	require.Equal(t, "worker-runtime", translated["worker_node_id"], "gateway log should include runtime worker node")
 	require.Equal(t, workerServer.URL, translated["endpoint_url"], "gateway log should include runtime endpoint")
+	require.Equal(t, false, translated["runtime_marked_lost"], "token-level auth failures must not mark the runtime lost")
 	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
 }
 


### PR DESCRIPTION
## What

Fixes the "Opening preview…" hang (~30s) followed by a spurious **"Preview not connected"** that left previews dead until restart.

Three changes:
1. **Don't mark a healthy runtime `lost` on a token-level `401`.** Only genuine routing-mismatch codes (`WRONG_PREVIEW_WORKER` / `PREVIEW_RUNTIME_MISMATCH`) now tear down the runtime. A token-level `UNAUTHORIZED` ("invalid preview token") only evicts the runtime cache and lets the next request retry with a fresh token.
2. **Proxy token TTL `30s → 60min`** (`previewProxyTokenTTL`).
3. **Styled spinner interstitial** in the launch popup instead of bare `Opening preview...` text.

## Why

Diagnosed against prod for preview `56dc57fb-…`:
- `preview_instances`: `status=unavailable`, `unavailable_reason=endpoint_unreachable` — but the `preview_runtimes` row showed `last_heartbeat_at` only ~5s stale and `lease_expires_at` in the future, i.e. **the runtime was alive and heartbeating** when it was killed.
- Gateway logs: worker returned `401 UNAUTHORIZED / "invalid preview token"` for `GET /`; the gateway then *"translated preview worker auth/routing failure"* → served "Preview not connected" **and** *"marked preview runtime lost after endpoint became unreachable."*

Root cause: the proxy token was minted with a **30s** expiry (`time.Now().Add(30 * time.Second)`). When the worker was slow to respond, the token expired in flight; the worker rejected the now-expired token as "invalid preview token"; and the gateway misread that token-level auth failure as an unreachable endpoint, tearing down a perfectly healthy preview. The 60min TTL removes the race; the mark-lost guard ensures a transient/auth `401` can never destroy a working runtime.

The token is minted per request and is **gateway→worker only** (set server-side in the proxy `Director`, never reaches the browser), so a longer-but-bounded TTL is a safe trade: it comfortably spans an interactive preview's working window (including once-authorized WebSocket/HMR/SSE connections) while keeping a tight replay window for a static, unrevocable bearer.

## Tests
- `TranslatesWorkerRuntimeMismatch` still asserts mismatch codes mark the runtime lost.
- `LogsTranslatedWorkerFailureMessage` now asserts `runtime_marked_lost: false` (no `MarkPreviewRuntimeLost` exec) for `UNAUTHORIZED`.
- `TranslatesMarkedWorkerAuthFailureAndEvictsRuntimeCache` proves the next request self-heals after cache eviction.
- Frontend test asserts the new spinner interstitial.
- `make lint` clean; gateway/handlers/auth Go tests and frontend vitest/eslint/tsc pass.

## Reviewer notes
- `translateWorkerPreviewFailure` and `previewWorkerFailureMarksRuntimeLost` independently list the same worker codes and must stay in sync if a new "runtime genuinely gone" code is added.
- Residual failure mode (out of scope here): if a worker host's **clock runs ahead**, fresh tokens can look pre-expired → persistent `401`. The 60min TTL absorbs modest skew, but large skew needs fixing at the host (verify `date` across worker hosts). Worker hosts also don't appear to ship logs to central VictoriaLogs, which hid the worker-side validate error during diagnosis.

🤖 Generated with [Claude Code](https://claude.com/claude-code)