### PR TITLE
Surface preview RPC auth-failure cause and harden deploy preflight

### DIFF
--- a/cmd/worker-deployctl/main.go
+++ b/cmd/worker-deployctl/main.go
@@ -77,6 +77,7 @@ func runPreviewAuthCheck(ctx context.Context, store *db.NodeStore, cfg *config.C
 	timeout := fs.Duration("timeout", 5*time.Second, "per-node HTTP timeout")
 	concurrency := fs.Int("concurrency", 16, "maximum concurrent auth-check probes")
 	nodeID := fs.String("node-id", "", "optional worker node id to probe")
+	failOnSkipped := fs.Bool("fail-on-skipped", false, "exit non-zero if any active preview-capable node could not be verified")
 	jsonOut := fs.Bool("json", false, "emit JSON")
 	_ = fs.Parse(args)
 
@@ -92,15 +93,32 @@ func runPreviewAuthCheck(ctx context.Context, store *db.NodeStore, cfg *config.C
 	if err != nil {
 		exitErr("%v", err)
 	}
-	checked, err := probePreviewRPCAuthNodes(probeNodes, keyring, *timeout, *concurrency, &http.Client{})
+	checked, skipped, err := probePreviewRPCAuthNodes(probeNodes, keyring, *timeout, *concurrency, &http.Client{})
 	if err != nil {
 		exitErr("%v", err)
 	}
+	// An unverified *active* node is the one that can serve preview traffic
+	// with a secret we never checked — surface those distinctly from benign
+	// draining/dead skips.
+	activeSkipped := make([]string, 0, len(skipped))
+	for _, s := range skipped {
+		fmt.Fprintf(os.Stderr, "worker-deployctl: preview RPC auth-check did not verify node %s (%s)\n", s.ID, s.Reason)
+		if s.Active {
+			activeSkipped = append(activeSkipped, s.ID)
+		}
+	}
+	failed := *failOnSkipped && len(activeSkipped) > 0
 	writeOutput(map[string]any{
-		"ok":            true,
-		"checked_count": len(checked),
-		"checked_nodes": checked,
+		"ok":             !failed,
+		"checked_count":  len(checked),
+		"checked_nodes":  checked,
+		"skipped_count":  len(skipped),
+		"skipped_nodes":  skipped,
+		"active_skipped": activeSkipped,
 	}, *jsonOut)
+	if failed {
+		exitErr("preview RPC auth-check could not verify %d active preview node(s): %s", len(activeSkipped), strings.Join(activeSkipped, ", "))
+	}
 }
 
 type previewAuthProbeNode struct {
@@ -151,12 +169,22 @@ func selectPreviewAuthProbeNodes(nodes []models.Node, nodeID string) ([]previewA
 	return probeNodes, nil
 }
 
-func probePreviewRPCAuthNodes(nodes []previewAuthProbeNode, keyring auth.PreviewTokenKeyring, timeout time.Duration, concurrency int, client *http.Client) ([]string, error) {
+// skippedPreviewAuthNode records a preview-capable node whose auth-check could
+// not be performed. Active nodes that are skipped are the dangerous case: the
+// gateway may be routing preview traffic to them with a secret we never
+// verified. Non-active (draining/dead) skips are benign — the node is leaving.
+type skippedPreviewAuthNode struct {
+	ID     string `json:"id"`
+	Reason string `json:"reason"`
+	Active bool   `json:"active"`
+}
+
+func probePreviewRPCAuthNodes(nodes []previewAuthProbeNode, keyring auth.PreviewTokenKeyring, timeout time.Duration, concurrency int, client *http.Client) ([]string, []skippedPreviewAuthNode, error) {
 	if len(nodes) == 0 {
-		return []string{}, nil
+		return []string{}, nil, nil
 	}
 	if timeout <= 0 {
-		return nil, fmt.Errorf("preview RPC auth-check timeout must be positive")
+		return nil, nil, fmt.Errorf("preview RPC auth-check timeout must be positive")
 	}
 	if concurrency <= 0 {
 		concurrency = 1
@@ -171,7 +199,11 @@ func probePreviewRPCAuthNodes(nodes []previewAuthProbeNode, keyring auth.Preview
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
+	now := time.Now().UTC()
 	checked := make([]bool, len(nodes))
+	// A non-empty skipReasons[idx] marks a node that was unreachable but
+	// tolerated; each goroutine writes only its own index so no lock is needed.
+	skipReasons := make([]string, len(nodes))
 	jobs := make(chan int)
 	errCh := make(chan error, 1)
 	var wg sync.WaitGroup
@@ -187,8 +219,9 @@ func probePreviewRPCAuthNodes(nodes []previewAuthProbeNode, keyring auth.Preview
 				if err := probePreviewRPCAuthNode(ctx, client, keyring, nodes[idx], timeout); err != nil {
 					var unreachable previewAuthUnreachableError
 					if errors.As(err, &unreachable) {
-						if tolerateUnreachablePreviewAuthNode(nodes[idx], time.Now().UTC()) {
-							fmt.Fprintf(os.Stderr, "worker-deployctl: skipping unreachable stale/draining preview RPC auth-check node %s (%s): %v\n", nodes[idx].ID, nodes[idx].BaseURL, err)
+						if reason, tolerate := previewAuthNodeSkipReason(nodes[idx], now); tolerate {
+							fmt.Fprintf(os.Stderr, "worker-deployctl: skipping unreachable preview RPC auth-check node %s (%s): %s: %v\n", nodes[idx].ID, nodes[idx].BaseURL, reason, err)
+							skipReasons[idx] = reason
 							continue
 						}
 					}
@@ -217,24 +250,41 @@ sendJobs:
 
 	select {
 	case err := <-errCh:
-		return nil, err
+		return nil, nil, err
 	default:
 	}
 
 	checkedIDs := make([]string, 0, len(nodes))
-	for idx, ok := range checked {
-		if ok {
+	skipped := make([]skippedPreviewAuthNode, 0)
+	for idx := range nodes {
+		switch {
+		case checked[idx]:
 			checkedIDs = append(checkedIDs, nodes[idx].ID)
+		case skipReasons[idx] != "":
+			skipped = append(skipped, skippedPreviewAuthNode{
+				ID:     nodes[idx].ID,
+				Reason: skipReasons[idx],
+				Active: nodes[idx].Status == models.NodeStatusActive,
+			})
 		}
 	}
-	return checkedIDs, nil
+	return checkedIDs, skipped, nil
 }
 
-func tolerateUnreachablePreviewAuthNode(node previewAuthProbeNode, now time.Time) bool {
+// previewAuthNodeSkipReason reports whether an unreachable node may be skipped
+// without failing the probe, and a human reason. A draining/dead node is
+// leaving, so skipping it is safe. An active node that has stopped heartbeating
+// is most likely already gone but not yet reaped; we tolerate it so a single
+// wedged node can't block every deploy, but the caller can still escalate a
+// skipped *active* node via --fail-on-skipped.
+func previewAuthNodeSkipReason(node previewAuthProbeNode, now time.Time) (string, bool) {
 	if node.Status != models.NodeStatusActive {
-		return true
+		return fmt.Sprintf("node status is %s (not active)", node.Status), true
 	}
-	return now.Sub(node.LastHeartbeatAt) > previewAuthFreshHeartbeatWindow
+	if age := now.Sub(node.LastHeartbeatAt); age > previewAuthFreshHeartbeatWindow {
+		return fmt.Sprintf("active node heartbeat is stale (%s old)", age.Round(time.Second)), true
+	}
+	return "", false
 }
 
 func probePreviewRPCAuthNode(ctx context.Context, client *http.Client, keyring auth.PreviewTokenKeyring, node previewAuthProbeNode, timeout time.Duration) error {

--- a/cmd/worker-deployctl/main_test.go
+++ b/cmd/worker-deployctl/main_test.go
@@ -102,10 +102,11 @@ func TestProbePreviewRPCAuthNodes_UsesBoundedConcurrency(t *testing.T) {
 	client := &http.Client{Transport: roundTripper}
 
 	start := time.Now()
-	checked, err := probePreviewRPCAuthNodes(nodes, keyring, time.Second, 6, client)
+	checked, skipped, err := probePreviewRPCAuthNodes(nodes, keyring, time.Second, 6, client)
 	elapsed := time.Since(start)
 
 	require.NoError(t, err, "probePreviewRPCAuthNodes should accept healthy nodes")
+	require.Empty(t, skipped, "probePreviewRPCAuthNodes should not skip reachable nodes")
 	require.Equal(t, expected, checked, "probePreviewRPCAuthNodes should report checked nodes in input order")
 	require.GreaterOrEqual(t, atomic.LoadInt32(&roundTripper.maxInFlight), int32(2), "probePreviewRPCAuthNodes should send more than one probe at a time")
 	require.Less(t, elapsed, 500*time.Millisecond, "probePreviewRPCAuthNodes should not serialize per-node latency")
@@ -137,10 +138,17 @@ func TestProbePreviewRPCAuthNodes_SkipsUnreachableNodes(t *testing.T) {
 		keyring: keyring,
 	}}
 
-	checked, err := probePreviewRPCAuthNodes(nodes, keyring, 20*time.Millisecond, 2, client)
+	checked, skipped, err := probePreviewRPCAuthNodes(nodes, keyring, 20*time.Millisecond, 2, client)
 
 	require.NoError(t, err, "probePreviewRPCAuthNodes should not fail deploy compatibility on unreachable workers")
 	require.Empty(t, checked, "probePreviewRPCAuthNodes should not mark timed-out nodes as checked")
+	require.Len(t, skipped, 2, "probePreviewRPCAuthNodes should record tolerated unreachable nodes")
+	skippedByID := make(map[string]skippedPreviewAuthNode, len(skipped))
+	for _, s := range skipped {
+		skippedByID[s.ID] = s
+	}
+	require.False(t, skippedByID["worker-slow"].Active, "a draining node should be recorded as non-active")
+	require.True(t, skippedByID["worker-fast"].Active, "a stale-but-active node should be recorded as active so --fail-on-skipped can escalate it")
 }
 
 func TestProbePreviewRPCAuthNodes_FailsOnFreshActiveUnreachableNode(t *testing.T) {
@@ -160,7 +168,7 @@ func TestProbePreviewRPCAuthNodes_FailsOnFreshActiveUnreachableNode(t *testing.T
 		keyring: keyring,
 	}}
 
-	_, err = probePreviewRPCAuthNodes(nodes, keyring, 20*time.Millisecond, 1, client)
+	_, _, err = probePreviewRPCAuthNodes(nodes, keyring, 20*time.Millisecond, 1, client)
 
 	require.Error(t, err, "probePreviewRPCAuthNodes should fail when a fresh active worker cannot answer")
 	require.Contains(t, err.Error(), "preview RPC auth-check unreachable", "probePreviewRPCAuthNodes should identify the unreachable worker")
@@ -183,7 +191,7 @@ func TestProbePreviewRPCAuthNodes_FailsOnAuthRejection(t *testing.T) {
 		statusByHost: map[string]int{"worker-rejects.internal": http.StatusUnauthorized},
 	}}
 
-	_, err = probePreviewRPCAuthNodes(nodes, keyring, time.Second, 1, client)
+	_, _, err = probePreviewRPCAuthNodes(nodes, keyring, time.Second, 1, client)
 
 	require.Error(t, err, "probePreviewRPCAuthNodes should fail when a worker rejects the signed token")
 	require.Contains(t, err.Error(), "status=401", "probePreviewRPCAuthNodes should include the rejection status")
@@ -218,4 +226,43 @@ func TestSelectPreviewAuthProbeNodesFiltersByNodeID(t *testing.T) {
 	_, err = selectPreviewAuthProbeNodes(nodes, "missing-worker")
 	require.Error(t, err, "selectPreviewAuthProbeNodes should reject an unknown node id")
 	require.Contains(t, err.Error(), "missing-worker", "selectPreviewAuthProbeNodes should name the missing node")
+}
+
+func TestPreviewAuthNodeSkipReason(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now().UTC()
+	cases := []struct {
+		name         string
+		node         previewAuthProbeNode
+		wantTolerate bool
+	}{
+		{
+			name:         "active and fresh is not tolerated",
+			node:         previewAuthProbeNode{Status: models.NodeStatusActive, LastHeartbeatAt: now},
+			wantTolerate: false,
+		},
+		{
+			name:         "active but stale is tolerated",
+			node:         previewAuthProbeNode{Status: models.NodeStatusActive, LastHeartbeatAt: now.Add(-previewAuthFreshHeartbeatWindow - time.Minute)},
+			wantTolerate: true,
+		},
+		{
+			name:         "draining is tolerated",
+			node:         previewAuthProbeNode{Status: models.NodeStatusDraining, LastHeartbeatAt: now},
+			wantTolerate: true,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			reason, tolerate := previewAuthNodeSkipReason(tc.node, now)
+			require.Equal(t, tc.wantTolerate, tolerate, "tolerate decision should match expectation")
+			if tolerate {
+				require.NotEmpty(t, reason, "a tolerated node should carry a human reason")
+			} else {
+				require.Empty(t, reason, "a non-tolerated node should not carry a reason")
+			}
+		})
+	}
 }

--- a/deploy/scripts/deploy.sh
+++ b/deploy/scripts/deploy.sh
@@ -1107,8 +1107,19 @@ ssh "${SSH_OPTS[@]}" deploy@"$HOST" \
 
   preview_rpc_auth_preflight() {
     local cid="$1"
+    # The app-side probe signs with the candidate's secret and validates against
+    # every active preview worker — the only place a worker with a divergent
+    # secret (stale bundle / incomplete rotation) is caught. Fail the deploy on
+    # any unverified *active* worker rather than silently tolerating it; set
+    # PREVIEW_RPC_AUTH_STRICT=0 to fall back to best-effort in an emergency.
+    local strict_flag="--fail-on-skipped"
+    if [ "${PREVIEW_RPC_AUTH_STRICT:-1}" != "1" ]; then
+      strict_flag=""
+      echo "PREVIEW_RPC_AUTH_STRICT=0: preview RPC auth-check will not fail on unverified active workers."
+    fi
     echo "Running preview RPC auth compatibility check from candidate api container ${cid:0:12}..."
-    docker exec "$cid" /docker-entrypoint.sh /bin/worker-deployctl preview-auth-check --json
+    # shellcheck disable=SC2086 # $strict_flag is an optional single flag or empty
+    docker exec "$cid" /docker-entrypoint.sh /bin/worker-deployctl preview-auth-check --json $strict_flag
   }
 
   # rolling_deploy_service SERVICE — roll a single service with zero-downtime:

--- a/internal/api/gateway/preview_gateway.go
+++ b/internal/api/gateway/preview_gateway.go
@@ -1059,15 +1059,16 @@ func (g *Gateway) proxyToWorker(w http.ResponseWriter, r *http.Request, orgID, p
 			req.Header.Set("Authorization", "Bearer "+token)
 		},
 		ModifyResponse: func(resp *http.Response) error {
-			if translated, workerCode, workerMessage, workerStatus := g.translateWorkerPreviewFailure(resp, previewID, isNavigationRequest(originalReq)); translated {
+			if failure := g.translateWorkerPreviewFailure(resp, previewID, isNavigationRequest(originalReq)); failure.translated {
 				// The worker no longer recognizes this runtime epoch; drop
 				// the cached runtime so the next request re-resolves.
 				g.evictCachedRuntime(previewID)
-				g.markRuntimeEndpointUnreachable(r.Context(), orgID, previewID, runtime, previewWorkerFailureReason(workerCode, workerMessage))
+				g.markRuntimeEndpointUnreachable(r.Context(), orgID, previewID, runtime, previewWorkerFailureReason(failure.code, failure.message, failure.authDetail))
 				addPreviewProxyLogFields(g.logger.Warn(), originalReq, orgID, previewID, runtime, upstreamPath).
-					Str("worker_error_code", workerCode).
-					Str("worker_error_message", workerMessage).
-					Int("worker_status", workerStatus).
+					Str("worker_error_code", failure.code).
+					Str("worker_error_message", failure.message).
+					Str("worker_auth_detail", failure.authDetail).
+					Int("worker_status", failure.status).
 					Msg("translated preview worker auth/routing failure")
 				return nil
 			}
@@ -1215,24 +1216,37 @@ func addPreviewProxyLogFields(event *zerolog.Event, r *http.Request, orgID, prev
 		Str("runtime_unavailable_reason", string(runtime.UnavailableReason))
 }
 
-func (g *Gateway) translateWorkerPreviewFailure(resp *http.Response, previewID uuid.UUID, navigation bool) (bool, string, string, int) {
+// workerPreviewFailure describes a worker-originated auth/routing rejection that
+// the gateway translated into a runtime-unavailable response.
+type workerPreviewFailure struct {
+	translated bool
+	code       string
+	message    string
+	authDetail string
+	status     int
+}
+
+func (g *Gateway) translateWorkerPreviewFailure(resp *http.Response, previewID uuid.UUID, navigation bool) workerPreviewFailure {
 	if resp.StatusCode != http.StatusForbidden && resp.StatusCode != http.StatusUnauthorized {
-		return false, "", "", resp.StatusCode
+		return workerPreviewFailure{status: resp.StatusCode}
 	}
 	originalStatus := resp.StatusCode
 	body, err := io.ReadAll(resp.Body)
 	_ = resp.Body.Close()
 	if err != nil {
 		resp.Body = io.NopCloser(bytes.NewReader(body))
-		return false, "", "", originalStatus
+		return workerPreviewFailure{status: originalStatus}
 	}
 
 	var parsed models.ErrorResponse
 	if err := json.Unmarshal(body, &parsed); err != nil {
 		resp.Body = io.NopCloser(bytes.NewReader(body))
-		return false, "", "", originalStatus
+		return workerPreviewFailure{status: originalStatus}
 	}
 	workerMarked := resp.Header.Get(auth.PreviewWorkerErrorHeader) == "1"
+	// Capture the worker's coarse auth-failure class before we replace the
+	// response headers below; the worker only sets it on token rejections.
+	authDetail := sanitizeWorkerPreviewFailureMessage(resp.Header.Get(auth.PreviewWorkerAuthDetailHeader))
 	workerCode := parsed.Error.Code
 	workerMessage := parsed.Error.Message
 	shouldTranslate := false
@@ -1246,7 +1260,7 @@ func (g *Gateway) translateWorkerPreviewFailure(resp *http.Response, previewID u
 	}
 	if !shouldTranslate {
 		resp.Body = io.NopCloser(bytes.NewReader(body))
-		return false, "", "", originalStatus
+		return workerPreviewFailure{status: originalStatus}
 	}
 
 	var replacement []byte
@@ -1276,7 +1290,13 @@ func (g *Gateway) translateWorkerPreviewFailure(resp *http.Response, previewID u
 	resp.Header.Set("Cache-Control", "no-store")
 	resp.ContentLength = int64(len(replacement))
 	resp.Body = io.NopCloser(bytes.NewReader(replacement))
-	return true, workerCode, sanitizeWorkerPreviewFailureMessage(workerMessage), originalStatus
+	return workerPreviewFailure{
+		translated: true,
+		code:       workerCode,
+		message:    sanitizeWorkerPreviewFailureMessage(workerMessage),
+		authDetail: authDetail,
+		status:     originalStatus,
+	}
 }
 
 func sanitizeWorkerPreviewFailureMessage(message string) string {
@@ -1289,13 +1309,16 @@ func sanitizeWorkerPreviewFailureMessage(message string) string {
 	return message
 }
 
-func previewWorkerFailureReason(code, message string) string {
+func previewWorkerFailureReason(code, message, authDetail string) string {
 	reason := "preview worker auth/routing failure"
 	if code != "" {
 		reason += ": " + code
 	}
 	if message != "" {
 		reason += " " + sanitizeWorkerPreviewFailureMessage(message)
+	}
+	if authDetail != "" {
+		reason += " (" + sanitizeWorkerPreviewFailureMessage(authDetail) + ")"
 	}
 	const maxReasonLen = 320
 	if len(reason) > maxReasonLen {

--- a/internal/api/gateway/preview_gateway_test.go
+++ b/internal/api/gateway/preview_gateway_test.go
@@ -2329,3 +2329,18 @@ func TestGateway_ProxyToWorker_NavigationToStoppedPreviewShowsOverlay(t *testing
 	require.Contains(t, rr.Body.String(), "Restart preview", "the overlay should expose the restart action")
 	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
 }
+
+func TestPreviewWorkerFailureReasonIncludesAuthDetail(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t,
+		"preview worker auth/routing failure: UNAUTHORIZED invalid preview token (bad_signature)",
+		previewWorkerFailureReason("UNAUTHORIZED", "invalid preview token", "bad_signature"),
+		"the stored runtime reason should carry the coarse auth-failure class for app-side diagnosis",
+	)
+	require.Equal(t,
+		"preview worker auth/routing failure: UNAUTHORIZED invalid preview token",
+		previewWorkerFailureReason("UNAUTHORIZED", "invalid preview token", ""),
+		"an absent auth detail should leave the reason unchanged for backward compatibility",
+	)
+}

--- a/internal/api/handlers/internal_preview.go
+++ b/internal/api/handlers/internal_preview.go
@@ -85,6 +85,7 @@ func (h *InternalPreviewHandler) authorize(w http.ResponseWriter, r *http.Reques
 	tokenStr := strings.TrimSpace(strings.TrimPrefix(r.Header.Get("Authorization"), "Bearer "))
 	if tokenStr == "" {
 		markPreviewWorkerError(w)
+		w.Header().Set(auth.PreviewWorkerAuthDetailHeader, "missing")
 		h.logPreviewAuthorizationRejected(r, "missing_token", action, nil, nil)
 		writeError(w, r, http.StatusUnauthorized, "UNAUTHORIZED", "missing authorization token")
 		return nil, false
@@ -92,6 +93,11 @@ func (h *InternalPreviewHandler) authorize(w http.ResponseWriter, r *http.Reques
 	claims, err := h.keyring.Validate(tokenStr)
 	if err != nil {
 		markPreviewWorkerError(w)
+		// Surface a coarse, non-sensitive failure class on the trusted
+		// worker→gateway hop so the app-side logs (which ship reliably) can
+		// distinguish a divergent secret (bad_signature) from clock skew
+		// (expired) without leaking crypto detail to the browser.
+		w.Header().Set(auth.PreviewWorkerAuthDetailHeader, auth.ClassifyPreviewTokenError(err))
 		h.logPreviewAuthorizationRejected(r, "invalid_token", action, nil, err)
 		writeError(w, r, http.StatusUnauthorized, "UNAUTHORIZED", "invalid preview token", err)
 		return nil, false
@@ -679,7 +685,10 @@ func (h *InternalPreviewHandler) handleHTTPProxy(w http.ResponseWriter, r *http.
 		},
 		Transport: h.previewTransport(orgID, previewID),
 		ModifyResponse: func(resp *http.Response) error {
+			// Strip control-plane markers a previewed app might set so it can't
+			// spoof a worker auth/routing failure to the public gateway.
 			resp.Header.Del(auth.PreviewWorkerErrorHeader)
+			resp.Header.Del(auth.PreviewWorkerAuthDetailHeader)
 			return nil
 		},
 		ErrorHandler: func(w http.ResponseWriter, r *http.Request, err error) {

--- a/internal/auth/preview_token.go
+++ b/internal/auth/preview_token.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha256"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -17,6 +18,42 @@ import (
 // worker routing/auth failures from ordinary responses returned by previewed
 // applications.
 const PreviewWorkerErrorHeader = "X-143-Preview-Worker-Error"
+
+// PreviewWorkerAuthDetailHeader carries a coarse, non-sensitive classification
+// of why a preview token failed validation (e.g. "bad_signature", "expired").
+// It travels only on the trusted worker→gateway hop and is consumed by the
+// public preview gateway for diagnostics; the gateway never forwards it to the
+// browser. Distinguishing a signature mismatch (divergent secret) from an
+// expired token (clock skew) from the app side — whose logs ship reliably —
+// turns an opaque "invalid preview token" into an actionable cause.
+const PreviewWorkerAuthDetailHeader = "X-143-Preview-Worker-Auth-Detail"
+
+// Sentinel errors classifying preview token validation failures. They carry the
+// legacy human strings so existing log output and assertions keep matching,
+// while errors.Is enables structured classification via ClassifyPreviewTokenError.
+var (
+	ErrPreviewTokenMalformed    = errors.New("invalid token format")
+	ErrPreviewTokenBadSignature = errors.New("invalid signature")
+	ErrPreviewTokenExpired      = errors.New("token expired")
+)
+
+// ClassifyPreviewTokenError maps a validation error to a coarse, non-sensitive
+// detail label suitable for logs and the worker auth-detail header. It returns
+// "" for a nil error and "unknown" for an unrecognized failure.
+func ClassifyPreviewTokenError(err error) string {
+	switch {
+	case err == nil:
+		return ""
+	case errors.Is(err, ErrPreviewTokenExpired):
+		return "expired"
+	case errors.Is(err, ErrPreviewTokenBadSignature):
+		return "bad_signature"
+	case errors.Is(err, ErrPreviewTokenMalformed):
+		return "malformed"
+	default:
+		return "unknown"
+	}
+}
 
 // PreviewTokenClaims scopes internal preview control-plane calls.
 type PreviewTokenClaims struct {
@@ -80,7 +117,10 @@ func (k PreviewTokenKeyring) Validate(token string) (*PreviewTokenClaims, error)
 		if err == nil {
 			return claims, nil
 		}
-		if firstErr == nil || !strings.Contains(err.Error(), "invalid signature") {
+		// Prefer a non-signature error (expired/malformed) when reporting: a
+		// matching-secret-but-expired token is far more diagnostic than the
+		// signature mismatches from every other configured secret.
+		if firstErr == nil || !errors.Is(err, ErrPreviewTokenBadSignature) {
 			firstErr = err
 		}
 	}
@@ -106,18 +146,18 @@ func GeneratePreviewToken(secret string, claims PreviewTokenClaims) (string, err
 func ValidatePreviewToken(secret, token string) (*PreviewTokenClaims, error) {
 	dotIdx := strings.LastIndexByte(token, '.')
 	if dotIdx < 0 {
-		return nil, fmt.Errorf("invalid token format")
+		return nil, ErrPreviewTokenMalformed
 	}
 	payloadB64 := token[:dotIdx]
 	sigB64 := token[dotIdx+1:]
 
 	payload, err := base64.RawURLEncoding.DecodeString(payloadB64)
 	if err != nil {
-		return nil, fmt.Errorf("decode payload: %w", err)
+		return nil, fmt.Errorf("decode payload: %v: %w", err, ErrPreviewTokenMalformed)
 	}
 	sig, err := base64.RawURLEncoding.DecodeString(sigB64)
 	if err != nil {
-		return nil, fmt.Errorf("decode signature: %w", err)
+		return nil, fmt.Errorf("decode signature: %v: %w", err, ErrPreviewTokenMalformed)
 	}
 
 	mac := hmac.New(sha256.New, []byte(secret))
@@ -125,15 +165,15 @@ func ValidatePreviewToken(secret, token string) (*PreviewTokenClaims, error) {
 		return nil, fmt.Errorf("compute HMAC: %w", err)
 	}
 	if !hmac.Equal(sig, mac.Sum(nil)) {
-		return nil, fmt.Errorf("invalid signature")
+		return nil, ErrPreviewTokenBadSignature
 	}
 
 	var claims PreviewTokenClaims
 	if err := json.Unmarshal(payload, &claims); err != nil {
-		return nil, fmt.Errorf("decode claims: %w", err)
+		return nil, fmt.Errorf("decode claims: %v: %w", err, ErrPreviewTokenMalformed)
 	}
 	if time.Now().After(claims.ExpiresAt) {
-		return nil, fmt.Errorf("token expired")
+		return nil, ErrPreviewTokenExpired
 	}
 	return &claims, nil
 }

--- a/internal/auth/preview_token_test.go
+++ b/internal/auth/preview_token_test.go
@@ -2,6 +2,7 @@ package auth
 
 import (
 	"encoding/base64"
+	"errors"
 	"testing"
 	"time"
 
@@ -125,4 +126,86 @@ func TestValidatePreviewToken_InvalidFormatAndPayload(t *testing.T) {
 	tokenSig := base64.RawURLEncoding.EncodeToString([]byte("signature"))
 	_, err = ValidatePreviewToken("secret", tokenPayload+"."+tokenSig)
 	require.Error(t, err, "ValidatePreviewToken should reject non-JSON payloads")
+}
+
+func TestValidatePreviewTokenClassifiesFailures(t *testing.T) {
+	t.Parallel()
+
+	previewID := uuid.New()
+	signed := func(secret string, exp time.Time) string {
+		token, err := GeneratePreviewToken(secret, PreviewTokenClaims{
+			OrgID:        uuid.New(),
+			TargetNodeID: "worker-1",
+			PreviewID:    &previewID,
+			Action:       "proxy",
+			ExpiresAt:    exp,
+		})
+		require.NoError(t, err, "GeneratePreviewToken should sign the test token")
+		return token
+	}
+
+	tests := []struct {
+		name       string
+		token      string
+		validate   func(token string) (*PreviewTokenClaims, error)
+		wantErr    error
+		wantDetail string
+	}{
+		{
+			name:       "bad signature",
+			token:      signed("right-secret", time.Now().Add(time.Minute)),
+			validate:   func(tok string) (*PreviewTokenClaims, error) { return ValidatePreviewToken("wrong-secret", tok) },
+			wantErr:    ErrPreviewTokenBadSignature,
+			wantDetail: "bad_signature",
+		},
+		{
+			name:       "expired",
+			token:      signed("right-secret", time.Now().Add(-time.Minute)),
+			validate:   func(tok string) (*PreviewTokenClaims, error) { return ValidatePreviewToken("right-secret", tok) },
+			wantErr:    ErrPreviewTokenExpired,
+			wantDetail: "expired",
+		},
+		{
+			name:       "malformed",
+			token:      "not-a-token",
+			validate:   func(tok string) (*PreviewTokenClaims, error) { return ValidatePreviewToken("right-secret", tok) },
+			wantErr:    ErrPreviewTokenMalformed,
+			wantDetail: "malformed",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := tc.validate(tc.token)
+			require.Error(t, err, "validation should fail")
+			require.ErrorIs(t, err, tc.wantErr, "error should classify as the expected sentinel")
+			require.Equal(t, tc.wantDetail, ClassifyPreviewTokenError(err), "ClassifyPreviewTokenError should map to the expected detail")
+		})
+	}
+
+	require.Equal(t, "", ClassifyPreviewTokenError(nil), "nil error should classify as empty")
+	require.Equal(t, "unknown", ClassifyPreviewTokenError(errors.New("boom")), "unrecognized error should classify as unknown")
+}
+
+func TestKeyringValidatePrefersExpiredOverSignatureMismatch(t *testing.T) {
+	t.Parallel()
+
+	// Token signed with secret-b but expired. A keyring whose first secret is
+	// secret-a (signature mismatch) and second is secret-b (expired) should
+	// report the expired classification — the diagnostic that matters.
+	token, err := GeneratePreviewToken("secret-b", PreviewTokenClaims{
+		OrgID:        uuid.New(),
+		TargetNodeID: "worker-1",
+		Action:       "proxy",
+		ExpiresAt:    time.Now().Add(-time.Minute),
+	})
+	require.NoError(t, err, "GeneratePreviewToken should sign the test token")
+
+	keyring, err := NewPreviewTokenKeyring([]string{"secret-a", "secret-b"})
+	require.NoError(t, err, "NewPreviewTokenKeyring should accept the test secrets")
+
+	_, err = keyring.Validate(token)
+	require.Error(t, err, "keyring should reject an expired token")
+	require.ErrorIs(t, err, ErrPreviewTokenExpired, "keyring should preserve the expired classification through its wrapper")
+	require.Equal(t, "expired", ClassifyPreviewTokenError(err), "expired should win over signature mismatches from other secrets")
 }


### PR DESCRIPTION
## Why

A preview was failing with **`preview worker auth/routing failure: UNAUTHORIZED invalid preview token`**. The error was opaque to diagnose: the worker only returns a generic `"invalid preview token"`, so neither the app-side logs (which ship reliably) nor the stored `preview_runtimes.unavailable_reason` could distinguish the two real causes — a **divergent secret** (bad HMAC signature) vs **clock skew** (token expired against the 30s TTL). Investigation showed `#1422` didn't cause it; it only made the stored reason accurate (previously every such failure was masked as `"preview runtime endpoint mismatch"`).

This PR makes the cause visible app-side and hardens the deploy gate that should catch a misconfigured worker.

## Fix #1 — surface the auth-failure cause

- `internal/auth/preview_token.go`: typed sentinels (`ErrPreviewTokenMalformed/BadSignature/Expired`), `ClassifyPreviewTokenError()`, and the `X-143-Preview-Worker-Auth-Detail` header. `keyring.Validate` now prefers the `expired` classification over signature mismatches from other secrets. Legacy error strings preserved (existing assertions unchanged).
- `internal/api/handlers/internal_preview.go`: `authorize()` sets the coarse, non-sensitive detail header (`bad_signature` / `expired` / `malformed` / `missing`) on rejection; the sandbox proxy strips it so a previewed app can't spoof a worker auth failure.
- `internal/api/gateway/preview_gateway.go`: captures that header (travels worker→gateway only, never to the browser) and folds it into the `translated preview worker auth/routing failure` log (`worker_auth_detail`) and the stored `unavailable_reason`, e.g. `...invalid preview token (bad_signature)`.

**Result:** the next occurrence is diagnosable in one query — `bad_signature` → secret mismatch, `expired` → clock skew.

## Fix #2 — preflight no longer silently tolerates unverifiable workers

- `cmd/worker-deployctl/main.go`: `probePreviewRPCAuthNodes` returns the skipped nodes (reason + `active` flag) instead of dropping them; `preview-auth-check` reports `skipped_nodes`/`active_skipped` and takes `--fail-on-skipped`, which exits non-zero when an **active** preview worker couldn't be verified. Draining/dead nodes stay tolerated so a leaving node can't block a deploy.
- `deploy/scripts/deploy.sh`: the app-side all-nodes preflight (the only cross-secret gate) passes `--fail-on-skipped` by default; `PREVIEW_RPC_AUTH_STRICT=0` is the escape hatch.

**Known limitation:** the worker self-probe signs *and* validates with the same host's secret, so it structurally can't detect app↔worker divergence — only the app-side probe can. Noted in a code comment; fully closing it is a larger cross-host change.

## Testing

`go build`, `go vet`, `go test` (auth, gateway, handlers, worker-deployctl, deploy), and `make lint` (`golangci-lint run ./...`) all pass with 0 issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)