### PR TITLE
preview: set HomeDir on reused session sandboxes so package-manager cache restores

### DIFF
--- a/internal/api/handlers/preview.go
+++ b/internal/api/handlers/preview.go
@@ -358,10 +358,15 @@ func (h *PreviewHandler) acquireSandbox(ctx context.Context, orgID uuid.UUID, se
 	// fall through to hydrate/expired instead of attaching to a dead ID.
 	if session.ContainerID != nil && *session.ContainerID != "" &&
 		session.SandboxState == models.SandboxStateRunning {
+		// HomeDir matches the orchestrator/hydrate path so the home-rooted
+		// package-manager cache (npm's ~/.npm, etc.) can restore. Without it,
+		// reused session sandboxes fail package-manager cache restore with
+		// "sandbox home dir is required" and re-download deps every launch.
 		candidate := &agent.Sandbox{
 			ID:        *session.ContainerID,
 			Provider:  "docker",
 			WorkDir:   workDir,
+			HomeDir:   agent.DefaultSandboxConfig().HomeDir,
 			SessionID: session.ID.String(),
 			OrgID:     session.OrgID.String(),
 			Purpose:   "preview",

--- a/internal/services/preview/manager.go
+++ b/internal/services/preview/manager.go
@@ -2458,7 +2458,7 @@ func (m *Manager) rebuildLegacyRecycleInput(ctx context.Context, instance *model
 		SessionID:     instance.SessionID,
 		OrgID:         instance.OrgID,
 		UserID:        instance.UserID,
-		Sandbox:       &agent.Sandbox{ID: *session.ContainerID, Provider: instance.Provider, WorkDir: "/workspace"},
+		Sandbox:       &agent.Sandbox{ID: *session.ContainerID, Provider: instance.Provider, WorkDir: "/workspace", HomeDir: agent.DefaultSandboxConfig().HomeDir},
 		Config:        cfg,
 		RepositoryID:  uuidPointerValue(session.RepositoryID),
 		BaseCommitSHA: instance.BaseCommitSHA,

--- a/internal/services/preview/start_runner.go
+++ b/internal/services/preview/start_runner.go
@@ -1127,10 +1127,14 @@ func (r *StartRunner) acquireSandbox(ctx context.Context, orgID uuid.UUID, sessi
 		if ownerCheck := r.checkLiveContainerWorker(session.WorkerNodeID); ownerCheck.Err != nil {
 			return ownerCheck
 		}
+		// HomeDir is required for the home-rooted package-manager cache
+		// (npm's ~/.npm, etc.) to restore on reused session sandboxes;
+		// see the prewarm-source construction above which sets it too.
 		candidate := &agent.Sandbox{
 			ID:        *session.ContainerID,
 			Provider:  "docker",
 			WorkDir:   workDir,
+			HomeDir:   agent.DefaultSandboxConfig().HomeDir,
 			SessionID: session.ID.String(),
 			OrgID:     session.OrgID.String(),
 			Purpose:   "preview",


### PR DESCRIPTION
## Problem

Preview package-manager caching is completely broken on the **session-reuse path**. The logs show:

```
preview phase failed: package_manager_cache_restore: dependency cache restore: sandbox home dir is required
preview package-manager cache restore failed: dependency cache restore: sandbox home dir is required
```

The package-manager cache (npm's `~/.npm`, and pnpm/yarn/bun/pip/etc.) is rooted at the sandbox **HOME** dir (`models.PreviewCacheRootHomeDir`), and `dependencyCacheRootDir` returns `"sandbox home dir is required"` when `sb.HomeDir == ""`. The reuse-path sandbox objects were constructed with only `WorkDir` set, so every `package_manager_cache_restore` failed and previews re-downloaded **all** dependencies from the network on every launch.

The work-dir-rooted **dependency cache** (node_modules) was unaffected, which is why only the package-manager cache restore failed in the logs.

## Fix

Populate `HomeDir` (matching `agent.DefaultSandboxConfig()`, which is how the reused session container is actually built) on the three reuse-path sandbox constructions that omitted it. The hydrate path and the prewarm-source construction already set it — these just bring the reuse path in line:

- `handlers.acquireSandbox` (`internal/api/handlers/preview.go`) — the "Using existing session sandbox" path
- `StartRunner.acquireSandbox` (`internal/services/preview/start_runner.go`)
- `Manager.rebuildLegacyRecycleInput` (`internal/services/preview/manager.go`)

## Release note

Fixes preview package-manager cache restore failing with "sandbox home dir is required" on reused session sandboxes, which forced cold dependency downloads on every preview launch.

## Tests

No new tests. Verified `go build` and existing targeted tests pass (`PackageManagerCache|DependencyCache|RecycleInput|Sandbox|Reuse` in `internal/services/preview`, and `Preview*Reuse|AcquireSandbox` in `internal/api/handlers`). The change populates a struct field on the existing-container reuse path; behavior is otherwise unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
