### PR TITLE
Fix capitalization of preview status badges and reuse shared formatter in PR previews

### DIFF
--- a/frontend/src/app/(dashboard)/previews/github/[owner]/[repo]/pull/[number]/page.test.tsx
+++ b/frontend/src/app/(dashboard)/previews/github/[owner]/[repo]/pull/[number]/page.test.tsx
@@ -99,6 +99,61 @@ describe("PullRequestPreviewPage", () => {
     });
   });
 
+  it("capitalizes preview status badges and phase labels", async () => {
+    server.use(
+      http.get("*/api/v1/previews/github/acme/web/pull/42", () =>
+        HttpResponse.json({
+          data: {
+            target_id: "target-1",
+            preview_id: "prev-1",
+            repository_id: "repo-1",
+            repository_full_name: "acme/web",
+            branch: "feature/preview",
+            commit_sha: "529975ce1faa2961ef3f23abde2418bf561116d9",
+            source_type: "pull_request",
+            status: "partially_ready",
+            current_phase: "start_services",
+            stable_url: "https://143.dev/previews/github/acme/web/pull/42",
+            preview_url: "https://prev-1.preview.143.dev",
+            services: [
+              {
+                id: "svc-1",
+                preview_instance_id: "prev-1",
+                service_name: "web",
+                role: "primary",
+                status: "starting",
+                command: ["npm", "run", "dev"],
+                cwd: ".",
+                port: 3000,
+                created_at: "2026-06-10T12:00:00Z",
+              },
+            ],
+            infrastructure: [
+              {
+                id: "infra-1",
+                preview_instance_id: "prev-1",
+                infra_name: "postgres",
+                template: "postgres",
+                container_id: "container-1",
+                status: "unhealthy",
+                host: "postgres",
+                port: 5432,
+                created_at: "2026-06-10T12:00:00Z",
+              },
+            ],
+          },
+        }),
+      ),
+    );
+
+    renderWithProviders(<PullRequestPreviewContent owner="acme" repo="web" number="42" />);
+
+    expect(await screen.findByText("Partially Ready")).toBeInTheDocument();
+    expect(screen.getByText("Start Services")).toBeInTheDocument();
+    expect(screen.getByText("Starting")).toBeInTheDocument();
+    expect(screen.getByText("Unhealthy")).toBeInTheDocument();
+  });
+
   it("does not auto-open stale previews and makes Start latest primary", async () => {
     let startLatestCalled = false;
     server.use(

--- a/frontend/src/app/(dashboard)/previews/github/[owner]/[repo]/pull/[number]/page.tsx
+++ b/frontend/src/app/(dashboard)/previews/github/[owner]/[repo]/pull/[number]/page.tsx
@@ -12,6 +12,7 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import { ErrorText } from "@/components/ui/error-notice";
 import { api } from "@/lib/api";
+import { formatPreviewStatus } from "@/lib/preview-types";
 import type { BranchPreviewResponse, SingleResponse } from "@/lib/types";
 import { safeExternalUrl } from "@/lib/utils";
 import { pollMs } from "@/lib/poll-intervals";
@@ -61,7 +62,7 @@ export function PullRequestPreviewContent({
 
   const preview = previewQuery.data?.data;
   const title = `${owner}/${repo}#${number}`;
-  const status = preview?.status.replaceAll("_", " ") ?? "Loading";
+  const status = preview?.status ? formatPreviewStatus(preview.status) : "Loading";
   const canStartLatest = preview?.target_id || preview?.preview_id;
   const isExpired = preview?.status === "expired";
   const launch = preview?.launch;
@@ -140,7 +141,7 @@ export function PullRequestPreviewContent({
                   </div>
                   <div>
                     <p className="text-muted-foreground">Phase</p>
-                    <p className="font-medium text-foreground">{preview.current_phase?.replaceAll("_", " ") ?? status}</p>
+                    <p className="font-medium text-foreground">{preview.current_phase ? formatPreviewStatus(preview.current_phase) : status}</p>
                   </div>
                 </div>
 
@@ -171,7 +172,7 @@ export function PullRequestPreviewContent({
                       {(preview.services ?? []).map((service) => (
                         <div key={service.id} className="flex items-center justify-between rounded-md border border-border px-3 py-2 text-sm">
                           <span className="truncate">{service.service_name}</span>
-                          <Badge variant={service.status === "ready" ? "default" : "secondary"}>{service.status.replaceAll("_", " ")}</Badge>
+                          <Badge variant={service.status === "ready" ? "default" : "secondary"}>{formatPreviewStatus(service.status)}</Badge>
                         </div>
                       ))}
                     </div>
@@ -180,7 +181,7 @@ export function PullRequestPreviewContent({
                       {(preview.infrastructure ?? []).map((infra) => (
                         <div key={infra.id} className="flex items-center justify-between rounded-md border border-border px-3 py-2 text-sm">
                           <span className="truncate">{infra.infra_name}</span>
-                          <Badge variant={infra.status === "healthy" ? "default" : "secondary"}>{infra.status.replaceAll("_", " ")}</Badge>
+                          <Badge variant={infra.status === "healthy" ? "default" : "secondary"}>{formatPreviewStatus(infra.status)}</Badge>
                         </div>
                       ))}
                     </div>

--- a/frontend/src/app/(dashboard)/previews/page.test.tsx
+++ b/frontend/src/app/(dashboard)/previews/page.test.tsx
@@ -180,6 +180,9 @@ describe("PreviewsPage", () => {
     ).toBeInTheDocument();
     expect(screen.getByText("Pool: 3 of 10 previews")).toBeInTheDocument();
     expect(screen.getAllByText("feature/warm-link")[0]).toBeInTheDocument();
+    expect(screen.getAllByText("Ready")[0]).toBeInTheDocument();
+    expect(screen.getAllByText("Stopped")[0]).toBeInTheDocument();
+    expect(screen.getAllByText("Failed")[0]).toBeInTheDocument();
     expect(screen.getByText("resumes in ~30s")).toBeInTheDocument();
     expect(screen.getByText("stopped after error")).toBeInTheDocument();
     expect(screen.getAllByText("assembledhq/docs · PR #17")[0]).toBeInTheDocument();

--- a/frontend/src/app/(dashboard)/previews/page.tsx
+++ b/frontend/src/app/(dashboard)/previews/page.tsx
@@ -42,6 +42,7 @@ import { useAuth } from "@/hooks/use-auth";
 import { usePageTitle } from "@/hooks/use-page-title";
 import { api } from "@/lib/api";
 import { pollMs } from "@/lib/poll-intervals";
+import { formatPreviewStatus } from "@/lib/preview-types";
 import { queryKeys } from "@/lib/query-keys";
 import type {
   BranchPreviewResponse,
@@ -112,8 +113,8 @@ function stoppedReasonLabel(
 }
 
 function statusLabel(preview: BranchPreviewResponse): string {
-  if (preview.status === "target_created") return "not started";
-  return preview.status.replaceAll("_", " ");
+  if (preview.status === "target_created") return "Not started";
+  return formatPreviewStatus(preview.status);
 }
 
 function relativeTime(value?: string): string {


### PR DESCRIPTION
## Summary
This updates the previews UI to consistently capitalize status/phase labels (e.g., “Partially Ready”, “Start Services”) by using a shared formatter. It also extends regression coverage to prevent future badge/label formatting drift.

## Changes
- **frontend/src/app/(dashboard)/previews/page.tsx**
  - Normalize index status badge rendering to show humanized, capitalized labels (e.g., Ready/Failed/Stopped/Not started).
- **frontend/src/app/(dashboard)/previews/github/[owner]/[repo]/pull/[number]/page.tsx**
  - Use `formatPreviewStatus` for PR preview header/status/phase/service/infrastructure labels instead of ad-hoc string replacements.
- **frontend/src/app/(dashboard)/previews/page.test.tsx**
  - Add/adjust tests to cover the badge capitalization regression.
- **frontend/src/app/(dashboard)/previews/github/[owner]/[repo]/pull/[number]/page.test.tsx**
  - Add a test asserting capitalized badge/phase labels are rendered (Partially Ready, Start Services, Starting, Unhealthy).

## Test plan
- `npm test -- --run 'src/app/(dashboard)/previews/page.test.tsx'`
- `npm test -- --run 'src/app/(dashboard)/previews/github/[owner]/[repo]/pull/[number]/page.test.tsx'`
- `npm run typecheck`
- `npm run lint`
- `npm run build`

[143.dev](https://143.dev) | [session b9ba29cf](https://143.dev/sessions/b9ba29cf-f149-4664-8ab0-e2d262f080a6)

Preview: https://143.dev/previews/github/assembledhq/143/pull/1426