### PR TITLE
Adjust mobile side sheet width to use more space while keeping a visible gutter

### DIFF
--- a/frontend/src/components/ui/sheet.test.tsx
+++ b/frontend/src/components/ui/sheet.test.tsx
@@ -18,6 +18,20 @@ describe("SheetContent", () => {
     expect(dialog.className).toContain("overflow-y-auto");
   });
 
+  it("uses most of the mobile viewport for side sheets while leaving modal context visible", async () => {
+    render(
+      <Sheet open>
+        <SheetContent>
+          <SheetTitle>Details</SheetTitle>
+          <SheetDescription>Wide mobile details</SheetDescription>
+        </SheetContent>
+      </Sheet>,
+    );
+
+    const dialog = await screen.findByRole("dialog");
+    expect(dialog.className).toContain("w-[calc(100vw-2rem)]");
+  });
+
   it("allows consumers to override overflow behavior when needed", async () => {
     render(
       <Sheet open>

--- a/frontend/src/components/ui/sheet.tsx
+++ b/frontend/src/components/ui/sheet.tsx
@@ -41,9 +41,9 @@ type SheetSide = "left" | "right" | "top" | "bottom"
 
 const sheetSideClasses: Record<SheetSide, string> = {
   right:
-    "inset-y-0 right-0 h-full w-3/4 border-l sm:max-w-md data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right",
+    "inset-y-0 right-0 h-full w-[calc(100vw-2rem)] border-l sm:max-w-md data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right",
   left:
-    "inset-y-0 left-0 h-full w-3/4 border-r sm:max-w-sm data-[state=closed]:slide-out-to-left data-[state=open]:slide-in-from-left",
+    "inset-y-0 left-0 h-full w-[calc(100vw-2rem)] border-r sm:max-w-sm data-[state=closed]:slide-out-to-left data-[state=open]:slide-in-from-left",
   top:
     "inset-x-0 top-0 max-h-[100svh] w-full border-b data-[state=closed]:slide-out-to-top data-[state=open]:slide-in-from-top",
   bottom:


### PR DESCRIPTION
## Summary
This updates `Sheet` side-panel sizing on mobile so left/right sheets use nearly the full viewport width instead of being capped at `w-3/4`. The change leaves a small modal gutter for better context and to match the intended mobile layout (ref. mobile side-sheet sizing fix / issue).

## Changes
- **`frontend/src/components/ui/sheet.tsx`**
  - Updated `sheetSideClasses` for:
    - `left`: from `w-3/4` to `w-[calc(100vw-2rem)]`
    - `right`: from `w-3/4` to `w-[calc(100vw-2rem)]`
  - Keeps `sm:max-w-*` constraints for larger screens unchanged.
- **`frontend/src/components/ui/sheet.test.tsx`**
  - Added regression test asserting the dialog uses `w-[calc(100vw-2rem)]` for mobile side sheets.

## Test plan
- `npm test -- --run src/components/ui/sheet.test.tsx`
- `npm run typecheck`
- `npm run lint`
- `npm run build`  
Note: `npm ci` reported existing dependency audit findings; no dependencies were changed in this PR.

[143.dev](https://143.dev) | [session 6b505f95](https://143.dev/sessions/6b505f95-9bf0-4c18-9792-b630930465ae)

Preview: https://143.dev/previews/github/assembledhq/143/pull/1429