### PR TITLE
Treat Codex upstream transport drops as retryable and log abnormal exits

### DIFF
--- a/internal/services/agent/adapters/codex.go
+++ b/internal/services/agent/adapters/codex.go
@@ -238,6 +238,30 @@ func (a *CodexAdapter) Execute(ctx context.Context, sandbox *agent.Sandbox, prom
 		if filteredStderr != "" {
 			result.Error += ": " + filteredStderr
 		}
+
+		// Surface abnormal exits to the structured logger (and thus
+		// VictoriaLogs). Codex's raw stderr otherwise lands only in per-session
+		// logs, so fleet-wide queries — e.g. transport-blip blast radius across
+		// sessions/hosts — have nothing to match. We reuse filteredStderr, which
+		// is already refresh-token- and benign-line-filtered, so no secrets or
+		// Reconnecting... spam ship; the snippet is truncated to bound ingest.
+		// This fires per codex exec, so it also captures intermediate failures
+		// (e.g. a resume that the orchestrator recovers via fallback) that never
+		// reach the terminal FailureService classification.
+		snippet := filteredStderr
+		if len(snippet) > 600 {
+			snippet = snippet[:600]
+		}
+		a.logger.Warn().
+			Str("session_id", sandbox.SessionID).
+			Str("org_id", sandbox.OrgID).
+			Str("agent", "codex").
+			Int("exit_code", exitCode).
+			Bool("resume", prompt.Continuation).
+			Bool("transport_failure", agent.IsUpstreamTransportError(result.Error)).
+			Str("egress_mode", sandbox.Metadata[agent.SandboxMetadataEgressMode]).
+			Str("stderr_snippet", snippet).
+			Msg("codex CLI exited abnormally")
 	}
 
 	// Collect the git diff from the sandbox.

--- a/internal/services/agent/failure.go
+++ b/internal/services/agent/failure.go
@@ -149,7 +149,24 @@ func (s *FailureService) classifyFailure(run *models.Session) *FailureSummary {
 		}
 	}
 
-	// 4. Build failure
+	// 4. Upstream transport failure reaching the agent's model backend. These
+	// are connection-level failures sending the request (DNS, TLS, egress, or a
+	// dropped response stream) rather than HTTP error responses, so they surface
+	// as "error sending request for url", a dropped responses stream, or the
+	// codex rmcp transport worker quitting ("transport channel closed"). They're
+	// transient network/egress blips — often hit when resuming a stale session —
+	// so advise a retry instead of falling through to the unhelpful default.
+	if IsUpstreamTransportError(errorMsg) {
+		return &FailureSummary{
+			Explanation:  "The agent lost its network connection to the model backend before finishing. This is a transient infrastructure issue (sandbox egress or an upstream blip), not a problem with the fix.",
+			Category:     FailureCategoryTooling,
+			SubType:      "upstream_transport",
+			NextSteps:    []string{"Retry the run — transport drops are usually transient", "Check the model provider's status page if it keeps happening", "If it persists, verify the sandbox's network egress to the model backend"},
+			RetryAdvised: true,
+		}
+	}
+
+	// 5. Build failure
 	if containsAny(errorMsg, "build failed", "compilation error", "syntax error") {
 		return &FailureSummary{
 			Explanation:  "The agent's changes caused a build failure. The generated code had compilation or syntax errors that prevented a successful build.",
@@ -160,7 +177,7 @@ func (s *FailureService) classifyFailure(run *models.Session) *FailureSummary {
 		}
 	}
 
-	// 5. Empty diff with no error — agent couldn't figure out what to change
+	// 6. Empty diff with no error — agent couldn't figure out what to change
 	if diff == "" && errorMsg == "" {
 		return &FailureSummary{
 			Explanation:  "The agent was unable to produce a code change. It could not identify the right files to modify or determine a clear fix for this issue.",
@@ -171,7 +188,7 @@ func (s *FailureService) classifyFailure(run *models.Session) *FailureSummary {
 		}
 	}
 
-	// 6. Test regression (check result_summary and error for test failure signals)
+	// 7. Test regression (check result_summary and error for test failure signals)
 	if containsAny(errorMsg, "test failed", "test regression", "tests failed") ||
 		containsAny(resultSummary, "test failed", "test regression", "tests failed") {
 		return &FailureSummary{
@@ -183,7 +200,7 @@ func (s *FailureService) classifyFailure(run *models.Session) *FailureSummary {
 		}
 	}
 
-	// 7. Security violation
+	// 8. Security violation
 	if containsAny(errorMsg, "security violation", "security scan", "vulnerability") ||
 		containsAny(resultSummary, "security violation", "security scan", "vulnerability") {
 		return &FailureSummary{
@@ -195,7 +212,7 @@ func (s *FailureService) classifyFailure(run *models.Session) *FailureSummary {
 		}
 	}
 
-	// 8. Large diff — likely too complex
+	// 9. Large diff — likely too complex
 	if diff != "" && countLines(diff) > 500 {
 		return &FailureSummary{
 			Explanation:  "The agent produced a very large change spanning many lines. Changes of this size are often unreliable and may indicate the issue requires a more targeted approach.",
@@ -206,7 +223,7 @@ func (s *FailureService) classifyFailure(run *models.Session) *FailureSummary {
 		}
 	}
 
-	// 9. Default — not enough signal to classify specifically
+	// 10. Default — not enough signal to classify specifically
 	return &FailureSummary{
 		Explanation:  "The agent was unable to produce a successful fix. There wasn't enough context to determine a clear solution for this issue.",
 		Category:     "context",
@@ -228,6 +245,18 @@ func (s *FailureService) UpdateRunWithFailure(ctx context.Context, orgID, runID 
 		Msg("updated agent run with failure analysis")
 
 	return nil
+}
+
+// IsUpstreamTransportError reports whether an error string describes a
+// connection-level failure reaching the agent's model backend (DNS, TLS,
+// egress, or a dropped response stream) rather than an HTTP error response.
+// Shared by classifyFailure and the codex adapter's abnormal-exit logging so
+// both recognize the same transport-blip shape from a single source of truth.
+func IsUpstreamTransportError(errorMsg string) bool {
+	return containsAny(strings.ToLower(errorMsg),
+		"error sending request for url",
+		"stream disconnected before completion",
+		"transport channel closed")
 }
 
 // containsAny checks if s contains any of the given substrings.

--- a/internal/services/agent/failure_test.go
+++ b/internal/services/agent/failure_test.go
@@ -105,6 +105,24 @@ func TestClassifyFailure(t *testing.T) {
 			wantRetryAdvised: true,
 		},
 		{
+			name: "codex responses stream disconnected",
+			run: models.Session{
+				Error: strPtr(`{"type":"turn.failed","error":{"message":"stream disconnected before completion: error sending request for url (https://chatgpt.com/backend-api/codex/responses)"}}`),
+			},
+			wantCategory:     "tooling",
+			wantSubType:      "upstream_transport",
+			wantRetryAdvised: true,
+		},
+		{
+			name: "codex rmcp transport channel closed on resume",
+			run: models.Session{
+				Error: strPtr(`restored-workspace fallback after stale agent resume failed: codex CLI exited with code 1: 2026-06-15T09:17:28Z ERROR rmcp::transport::worker: worker quit with fatal: Transport channel closed, when Client(HttpRequest(HttpRequest("http/request failed: error sending request for url (https://chatgpt.com/backend-api/wham/apps)")))`),
+			},
+			wantCategory:     "tooling",
+			wantSubType:      "upstream_transport",
+			wantRetryAdvised: true,
+		},
+		{
 			name: "build failure",
 			run: models.Session{
 				Error: strPtr("build failed: exit code 1"),


### PR DESCRIPTION
## Why

A Codex session ([980b6306](https://143.dev/sessions/980b6306-8928-4d19-bb86-e8caf1b58b45)) failed when its connection to the model backend dropped mid-stream while resuming a stale 3-day-old session. The terminal error in `sessions.error` was:

```
restored-workspace fallback after stale agent resume failed: codex CLI exited with code 1:
... ERROR rmcp::transport::worker: worker quit with fatal: Transport channel closed,
when Client(HttpRequest(... error sending request for url (https://chatgpt.com/backend-api/wham/apps)))
```

These are **transport-level** send failures (DNS/TLS/egress/dropped stream) reaching `chatgpt.com/backend-api/*` — not auth (401) and not an upstream 5xx. They are transient, but `classifyFailure` had no branch for them, so the session fell through to the default classification (`RetryAdvised: false`) and surfaced a recoverable blip as a hard failure.

Separately, Codex CLI stderr only lands in per-session logs, so there was no way to query transport-failure blast radius across sessions/hosts in VictoriaLogs.

## What

- **`failure.go`** — new `upstream_transport` branch in `classifyFailure` for connection-level model-backend failures → category `tooling`, `RetryAdvised: true`. Extracted a shared `IsUpstreamTransportError` predicate so the classifier and adapter match the same shapes from one source of truth.
- **`codex.go`** — emit a structured `codex CLI exited abnormally` zerolog line on non-zero exits with `session_id`, `org_id`, `exit_code`, `resume`, `transport_failure`, `egress_mode`, and a refresh-token-/benign-filtered, 600-char-truncated `stderr_snippet`. Fires per exec, so it also captures intermediate resume failures the orchestrator recovers via the restored-workspace fallback (which never reach the terminal `FailureService` classification). Raw stderr is deliberately **not** shipped (verbosity/secrets); only the filtered snippet.
- **`failure_test.go`** — cover both the `/codex/responses` stream-disconnect and the rmcp `Transport channel closed` resume-failure shapes, using the literal errors from the affected session.

## Querying once deployed

```
make logs-query Q='_msg:"codex CLI exited abnormally" AND _time:[now-1h,now]'
```

then slice by `transport_failure` / `egress_mode` / `session_id` to distinguish a sandbox-egress problem from an upstream OpenAI blip.

## Testing

- `go test ./internal/services/agent/ ./internal/services/agent/adapters/` — pass
- `go build ./internal/services/agent/...`, `gofmt`, `go vet` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
