### PR TITLE
Release pinned jobs from draining target nodes

### DIFF
--- a/internal/db/job_store_test.go
+++ b/internal/db/job_store_test.go
@@ -373,7 +373,7 @@ func TestJobStore_ClaimNextRunnable(t *testing.T) {
 				jobID := uuid.New()
 				orgID := uuid.New()
 				now := time.Now()
-				mock.ExpectQuery("WITH dead_target_nodes AS[\\s\\S]*next_job AS[\\s\\S]*RETURNING j.id, j.org_id, j.queue, j.job_type").
+				mock.ExpectQuery("WITH unavailable_target_nodes AS[\\s\\S]*next_job AS[\\s\\S]*RETURNING j.id, j.org_id, j.queue, j.job_type").
 					WithArgs(pgxmock.AnyArg(), "worker-1", "worker-1", lockToken, int(leaseDuration.Seconds())).
 					WillReturnRows(pgxmock.NewRows([]string{
 						"id", "org_id", "queue", "job_type", "payload", "priority", "status",
@@ -393,7 +393,7 @@ func TestJobStore_ClaimNextRunnable(t *testing.T) {
 				orgID := uuid.New()
 				now := time.Now()
 				completedAt := now.Add(time.Minute)
-				mock.ExpectQuery("WITH dead_target_nodes AS[\\s\\S]*next_job AS[\\s\\S]*RETURNING j.id, j.org_id, j.queue, j.job_type").
+				mock.ExpectQuery("WITH unavailable_target_nodes AS[\\s\\S]*next_job AS[\\s\\S]*RETURNING j.id, j.org_id, j.queue, j.job_type").
 					WithArgs(pgxmock.AnyArg(), "worker-1", "worker-1", lockToken, int(leaseDuration.Seconds())).
 					WillReturnRows(pgxmock.NewRows([]string{
 						"id", "org_id", "queue", "job_type", "payload", "priority", "status",
@@ -409,7 +409,7 @@ func TestJobStore_ClaimNextRunnable(t *testing.T) {
 		{
 			name: "returns nil when no pending job exists",
 			setupMock: func(mock pgxmock.PgxPoolIface, leaseDuration time.Duration, lockToken uuid.UUID) {
-				mock.ExpectQuery("WITH dead_target_nodes AS[\\s\\S]*next_job AS[\\s\\S]*RETURNING j.id, j.org_id, j.queue, j.job_type").
+				mock.ExpectQuery("WITH unavailable_target_nodes AS[\\s\\S]*next_job AS[\\s\\S]*RETURNING j.id, j.org_id, j.queue, j.job_type").
 					WithArgs(pgxmock.AnyArg(), "worker-1", "worker-1", lockToken, int(leaseDuration.Seconds())).
 					WillReturnError(pgx.ErrNoRows)
 			},
@@ -418,7 +418,7 @@ func TestJobStore_ClaimNextRunnable(t *testing.T) {
 		{
 			name: "returns query errors",
 			setupMock: func(mock pgxmock.PgxPoolIface, leaseDuration time.Duration, lockToken uuid.UUID) {
-				mock.ExpectQuery("WITH dead_target_nodes AS[\\s\\S]*next_job AS[\\s\\S]*RETURNING j.id, j.org_id, j.queue, j.job_type").
+				mock.ExpectQuery("WITH unavailable_target_nodes AS[\\s\\S]*next_job AS[\\s\\S]*RETURNING j.id, j.org_id, j.queue, j.job_type").
 					WithArgs(pgxmock.AnyArg(), "worker-1", "worker-1", lockToken, int(leaseDuration.Seconds())).
 					WillReturnError(errors.New("db down"))
 			},

--- a/internal/db/jobs.go
+++ b/internal/db/jobs.go
@@ -146,11 +146,9 @@ type EnqueueOpts struct {
 	// TargetNodeID, when set, restricts the job to be claimed by this
 	// specific worker node. Used for sandbox-bound jobs (continue_session,
 	// open_pr, run_agent for resume) where the work must execute on the
-	// same docker daemon as the session's recorded container_id. NULL
-	// means any worker can claim. The claim path falls back to "any worker"
-	// if the target node is unavailable in the `nodes` table — dead
-	// (permanently lost) or draining (rolling over, no longer claiming) —
-	// so a pinned job cannot starve when its node can no longer run it.
+	// same docker daemon as the session's recorded container_id. NULL means
+	// any worker can claim. See ClaimNextRunnable for the unavailable-node
+	// fallback that keeps a pinned job from starving.
 	TargetNodeID *string
 }
 
@@ -500,21 +498,11 @@ type jobExecer interface {
 // running with a renewable lease and fencing token. Returns nil, nil when no
 // runnable job exists.
 //
-// Node-affinity filter: jobs with target_node_id NULL can be claimed by any
-// worker (the common case). Jobs with target_node_id set can only be claimed
-// by the matching node OR if the target node is unavailable — dead
-// (status='dead' or stale heartbeat) or draining (status='draining'). The
-// fallback prevents starvation when a pinned worker can no longer run the job:
-//   - dead: the worker is permanently lost.
-//   - draining: the worker is rolling over and has stopped claiming new work,
-//     but keeps heartbeating to preserve healthy previews (see #1146/#1193).
-//     Without this, a turn pinned to a draining-but-heartbeating node sits
-//     pending until the node fully dies — minutes of dead air during every
-//     routine rollout. The claiming worker hydrates from the session snapshot,
-//     so releasing the pin is safe.
-//
-// The freshness threshold matches ReclaimLostRunningJobs's dead-node detection
-// so the two paths agree on what "dead" means.
+// Node-affinity filter: a job with target_node_id set is claimable only by
+// that node, or by any active worker once the target is unavailable — dead
+// (status='dead' or stale heartbeat) or draining. A draining node keeps
+// heartbeating to hold its previews, so without the draining case a pinned
+// turn starves until the node dies; the claimer hydrates from the snapshot.
 // lint:allow-no-orgid reason="worker queue consumer scans cross-org jobs by design"
 func (s *JobStore) ClaimNextRunnable(ctx context.Context, nodeID, ownerID string, lockToken uuid.UUID, leaseDuration time.Duration) (*models.Job, error) {
 	query := fmt.Sprintf(`
@@ -1051,7 +1039,9 @@ func (s *JobStore) DeadLetterWithLease(ctx context.Context, jobID, lockToken uui
 }
 
 // ReclaimLostRunningJobs requeues jobs whose lease expired or whose owner node
-// is considered dead.
+// is considered dead. Draining is intentionally not treated as dead here: a
+// running job on a draining node is reclaimed via lease expiry (or requeued by
+// the executor's own drain handler), so it never needs the node-status path.
 // lint:allow-no-orgid reason="recovery loop scans cross-org jobs by design"
 func (s *JobStore) ReclaimLostRunningJobs(ctx context.Context, staleBefore time.Time, limit int) (int64, error) {
 	query := `

--- a/internal/db/jobs.go
+++ b/internal/db/jobs.go
@@ -148,8 +148,9 @@ type EnqueueOpts struct {
 	// open_pr, run_agent for resume) where the work must execute on the
 	// same docker daemon as the session's recorded container_id. NULL
 	// means any worker can claim. The claim path falls back to "any worker"
-	// if the target node is marked dead in the `nodes` table, so a pinned
-	// job cannot starve when its node is permanently lost.
+	// if the target node is unavailable in the `nodes` table — dead
+	// (permanently lost) or draining (rolling over, no longer claiming) —
+	// so a pinned job cannot starve when its node can no longer run it.
 	TargetNodeID *string
 }
 
@@ -501,18 +502,26 @@ type jobExecer interface {
 //
 // Node-affinity filter: jobs with target_node_id NULL can be claimed by any
 // worker (the common case). Jobs with target_node_id set can only be claimed
-// by the matching node OR if the target node is dead (status='dead' or stale
-// heartbeat). The dead-node fallback prevents starvation when a pinned worker
-// is permanently lost — the job becomes claimable by anyone instead of
-// sitting forever. The freshness threshold matches ReclaimLostRunningJobs's
-// dead-node detection so the two paths agree on what "dead" means.
+// by the matching node OR if the target node is unavailable — dead
+// (status='dead' or stale heartbeat) or draining (status='draining'). The
+// fallback prevents starvation when a pinned worker can no longer run the job:
+//   - dead: the worker is permanently lost.
+//   - draining: the worker is rolling over and has stopped claiming new work,
+//     but keeps heartbeating to preserve healthy previews (see #1146/#1193).
+//     Without this, a turn pinned to a draining-but-heartbeating node sits
+//     pending until the node fully dies — minutes of dead air during every
+//     routine rollout. The claiming worker hydrates from the session snapshot,
+//     so releasing the pin is safe.
+//
+// The freshness threshold matches ReclaimLostRunningJobs's dead-node detection
+// so the two paths agree on what "dead" means.
 // lint:allow-no-orgid reason="worker queue consumer scans cross-org jobs by design"
 func (s *JobStore) ClaimNextRunnable(ctx context.Context, nodeID, ownerID string, lockToken uuid.UUID, leaseDuration time.Duration) (*models.Job, error) {
 	query := fmt.Sprintf(`
-		WITH dead_target_nodes AS (
+		WITH unavailable_target_nodes AS (
 			SELECT id
 			FROM nodes
-			WHERE status = 'dead' OR last_heartbeat_at < @dead_before
+			WHERE status IN ('dead', 'draining') OR last_heartbeat_at < @dead_before
 		),
 		claiming_node AS (
 			SELECT id
@@ -524,7 +533,7 @@ func (s *JobStore) ClaimNextRunnable(ctx context.Context, nodeID, ownerID string
 		next_job AS (
 			SELECT j.id
 			FROM jobs j
-			LEFT JOIN dead_target_nodes d ON d.id = j.target_node_id
+			LEFT JOIN unavailable_target_nodes d ON d.id = j.target_node_id
 			JOIN claiming_node cn ON TRUE
 			WHERE j.status = 'pending' AND j.run_at <= now()
 			  AND (

--- a/internal/integration/fixtures.go
+++ b/internal/integration/fixtures.go
@@ -70,10 +70,8 @@ func seedWorkerNode(t *testing.T, pool *pgxpool.Pool, nodeID string) {
 	}
 }
 
-// setNodeStatus forces a seeded node into a specific lifecycle status (e.g.
-// 'draining', 'dead') while leaving its heartbeat fresh — reproducing the
-// state a rolling deploy leaves behind: a node that has stopped claiming new
-// work but is still heartbeating to keep its previews alive.
+// setNodeStatus forces a seeded node into a status (e.g. 'draining') while
+// leaving its heartbeat fresh — the state a rolling deploy leaves behind.
 func setNodeStatus(t *testing.T, pool *pgxpool.Pool, nodeID, status string) {
 	t.Helper()
 	tag, err := pool.Exec(context.Background(),

--- a/internal/integration/fixtures.go
+++ b/internal/integration/fixtures.go
@@ -70,6 +70,22 @@ func seedWorkerNode(t *testing.T, pool *pgxpool.Pool, nodeID string) {
 	}
 }
 
+// setNodeStatus forces a seeded node into a specific lifecycle status (e.g.
+// 'draining', 'dead') while leaving its heartbeat fresh — reproducing the
+// state a rolling deploy leaves behind: a node that has stopped claiming new
+// work but is still heartbeating to keep its previews alive.
+func setNodeStatus(t *testing.T, pool *pgxpool.Pool, nodeID, status string) {
+	t.Helper()
+	tag, err := pool.Exec(context.Background(),
+		`UPDATE nodes SET status = $1 WHERE id = $2`, status, nodeID)
+	if err != nil {
+		t.Fatalf("set node %s status=%s: %v", nodeID, status, err)
+	}
+	if tag.RowsAffected() != 1 {
+		t.Fatalf("set node status: expected to update 1 row, updated %d (node %s seeded?)", tag.RowsAffected(), nodeID)
+	}
+}
+
 // sessionOpts tunes which fields seedSession overrides on the default session
 // row. Zero-valued fields fall back to sensible defaults that make the
 // resulting row a plausible target for the handlers under test (manual

--- a/internal/integration/session_retry_test.go
+++ b/internal/integration/session_retry_test.go
@@ -8,7 +8,9 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 
 	"github.com/assembledhq/143/internal/db"
@@ -120,4 +122,47 @@ func TestIntegration_RetrySession_RejectsNonFailedSession(t *testing.T) {
 
 	jobs := listJobs(t, pool, orgID)
 	require.Empty(t, jobs, "rejected retry must not enqueue any job")
+}
+
+// Releasing a pinned job from a draining node (jobs.ClaimNextRunnable) lets a
+// sibling worker pick it up while the draining node may still be mid-turn. The
+// safety net is ClearContainerID: its recovery clear must refuse while an
+// active sandbox holder exists, so the live turn isn't clobbered — the sibling
+// reverts to pending and retries instead.
+func TestIntegration_ClearContainerID_RefusesWhileSandboxHolderActive(t *testing.T) {
+	pool := setup(t)
+	orgID := seedOrg(t, pool)
+	session := seedSession(t, pool, orgID, sessionOpts{Status: "running"})
+	sessions := db.NewSessionStore(pool)
+	holders := db.NewSessionSandboxHolderStore(pool)
+
+	const containerID = "container-mid-turn"
+	if _, err := sessions.AcquireTurnHold(context.Background(), orgID, session.ID, containerID); err != nil {
+		t.Fatalf("acquire turn hold: %v", err)
+	}
+
+	holderID, leaseToken := uuid.New(), uuid.New()
+	_, err := holders.CreateActive(context.Background(), orgID, db.CreateSessionSandboxHolderParams{
+		SessionID:     session.ID,
+		ContainerID:   containerID,
+		HolderKind:    models.SessionSandboxHolderKindThreadRuntime,
+		HolderID:      holderID,
+		OwnerNodeID:   "drain-node",
+		LeaseToken:    leaseToken,
+		LeaseDuration: 30 * time.Second,
+	})
+	require.NoError(t, err)
+
+	cleared, err := sessions.ClearContainerID(context.Background(), orgID, session.ID, containerID)
+	require.NoError(t, err)
+	require.False(t, cleared, "ClearContainerID must not clear container_id while a turn holds the sandbox")
+
+	released, err := holders.ReleaseWithLease(context.Background(), orgID, session.ID,
+		models.SessionSandboxHolderKindThreadRuntime, holderID, leaseToken)
+	require.NoError(t, err)
+	require.True(t, released)
+
+	cleared, err = sessions.ClearContainerID(context.Background(), orgID, session.ID, containerID)
+	require.NoError(t, err)
+	require.True(t, cleared, "once the holder is released the orphaned container_id is safe to clear")
 }

--- a/internal/integration/worker_dispatch_test.go
+++ b/internal/integration/worker_dispatch_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/require"
 
@@ -154,4 +155,85 @@ func TestIntegration_WorkerDispatch_UnknownJobTypeDeadLetters(t *testing.T) {
 		}
 		return status == "failed" && lastError != nil && *lastError != ""
 	}, 5*time.Second, 25*time.Millisecond, "unknown job type must fail fast with an explanatory last_error — silent swallow is the worst outcome")
+}
+
+// TestIntegration_ClaimNextRunnable_DrainingTargetNodeReleasesPinnedJob is the
+// regression for the rollout-starvation incident: a continue_session turn was
+// pinned (target_node_id) to a worker generation that a routine rollout had put
+// into 'draining'. A draining node keeps heartbeating to preserve its previews,
+// so it never tripped the dead-node fallback — and because it had stopped
+// claiming new work, the turn sat 'pending' for many minutes until the node
+// finally died. The claim path must treat a draining target node as
+// unavailable and let a healthy worker hydrate the session from its snapshot.
+//
+// pgxmock can't catch this — it only matches the query string, not the SQL's
+// node-status semantics — so this has to run against real Postgres.
+func TestIntegration_ClaimNextRunnable_DrainingTargetNodeReleasesPinnedJob(t *testing.T) {
+	pool := setup(t)
+	orgID := seedOrg(t, pool)
+	session := seedSession(t, pool, orgID, sessionOpts{Status: "idle"})
+	store := db.NewJobStore(pool)
+
+	// Pin the job to a worker that is draining but still heartbeating —
+	// exactly the state a graceful rollover leaves behind.
+	drainingNode := "drain-node-" + session.ID.String()[:8]
+	seedWorkerNode(t, pool, drainingNode)
+	setNodeStatus(t, pool, drainingNode, "draining")
+
+	target := drainingNode
+	jobID, err := store.EnqueueWithOpts(context.Background(), orgID, db.EnqueueOpts{
+		Queue:        "agent",
+		JobType:      "continue_session",
+		Payload:      map[string]string{"session_id": session.ID.String(), "org_id": orgID.String()},
+		Priority:     5,
+		TargetNodeID: &target,
+	})
+	require.NoError(t, err)
+
+	// A different, healthy worker must be able to claim it.
+	claimer := "active-node-" + session.ID.String()[:8]
+	seedWorkerNode(t, pool, claimer)
+
+	job, err := store.ClaimNextRunnable(context.Background(), claimer, claimer, uuid.New(), 30*time.Second)
+	require.NoError(t, err)
+	require.NotNil(t, job, "a job pinned to a draining node must fall through to an active worker, not starve until the node dies")
+	require.Equal(t, jobID, job.ID, "the claimed job should be the one pinned to the draining node")
+}
+
+// TestIntegration_ClaimNextRunnable_HealthyTargetNodePinHoldsJob is the guard
+// rail for the fix above: a job pinned to a *healthy, active* worker must stay
+// pinned. Only the owning node can claim it — a sibling worker must not steal
+// sandbox-bound work off a live node (the original #811 cross-host bug). This
+// proves the draining release didn't widen into "any pin is claimable."
+func TestIntegration_ClaimNextRunnable_HealthyTargetNodePinHoldsJob(t *testing.T) {
+	pool := setup(t)
+	orgID := seedOrg(t, pool)
+	session := seedSession(t, pool, orgID, sessionOpts{Status: "idle"})
+	store := db.NewJobStore(pool)
+
+	ownerNode := "owner-node-" + session.ID.String()[:8]
+	seedWorkerNode(t, pool, ownerNode)
+
+	target := ownerNode
+	jobID, err := store.EnqueueWithOpts(context.Background(), orgID, db.EnqueueOpts{
+		Queue:        "agent",
+		JobType:      "continue_session",
+		Payload:      map[string]string{"session_id": session.ID.String(), "org_id": orgID.String()},
+		Priority:     5,
+		TargetNodeID: &target,
+	})
+	require.NoError(t, err)
+
+	// A sibling worker must NOT be able to claim the pinned job.
+	sibling := "sibling-node-" + session.ID.String()[:8]
+	seedWorkerNode(t, pool, sibling)
+	job, err := store.ClaimNextRunnable(context.Background(), sibling, sibling, uuid.New(), 30*time.Second)
+	require.NoError(t, err)
+	require.Nil(t, job, "a sibling worker must not claim a job pinned to a healthy owning node")
+
+	// The owning node still can.
+	owned, err := store.ClaimNextRunnable(context.Background(), ownerNode, ownerNode, uuid.New(), 30*time.Second)
+	require.NoError(t, err)
+	require.NotNil(t, owned, "the owning node must still be able to claim its pinned job")
+	require.Equal(t, jobID, owned.ID)
 }

--- a/internal/integration/worker_dispatch_test.go
+++ b/internal/integration/worker_dispatch_test.go
@@ -157,25 +157,16 @@ func TestIntegration_WorkerDispatch_UnknownJobTypeDeadLetters(t *testing.T) {
 	}, 5*time.Second, 25*time.Millisecond, "unknown job type must fail fast with an explanatory last_error — silent swallow is the worst outcome")
 }
 
-// TestIntegration_ClaimNextRunnable_DrainingTargetNodeReleasesPinnedJob is the
-// regression for the rollout-starvation incident: a continue_session turn was
-// pinned (target_node_id) to a worker generation that a routine rollout had put
-// into 'draining'. A draining node keeps heartbeating to preserve its previews,
-// so it never tripped the dead-node fallback — and because it had stopped
-// claiming new work, the turn sat 'pending' for many minutes until the node
-// finally died. The claim path must treat a draining target node as
-// unavailable and let a healthy worker hydrate the session from its snapshot.
-//
-// pgxmock can't catch this — it only matches the query string, not the SQL's
-// node-status semantics — so this has to run against real Postgres.
+// Regression for the rollout-starvation incident: a continue_session turn
+// pinned to a draining (but still heartbeating) node must fall through to an
+// active worker instead of sitting pending until the node dies. pgxmock can't
+// see node-status semantics, so this runs against real Postgres.
 func TestIntegration_ClaimNextRunnable_DrainingTargetNodeReleasesPinnedJob(t *testing.T) {
 	pool := setup(t)
 	orgID := seedOrg(t, pool)
 	session := seedSession(t, pool, orgID, sessionOpts{Status: "idle"})
 	store := db.NewJobStore(pool)
 
-	// Pin the job to a worker that is draining but still heartbeating —
-	// exactly the state a graceful rollover leaves behind.
 	drainingNode := "drain-node-" + session.ID.String()[:8]
 	seedWorkerNode(t, pool, drainingNode)
 	setNodeStatus(t, pool, drainingNode, "draining")
@@ -190,7 +181,6 @@ func TestIntegration_ClaimNextRunnable_DrainingTargetNodeReleasesPinnedJob(t *te
 	})
 	require.NoError(t, err)
 
-	// A different, healthy worker must be able to claim it.
 	claimer := "active-node-" + session.ID.String()[:8]
 	seedWorkerNode(t, pool, claimer)
 
@@ -198,13 +188,13 @@ func TestIntegration_ClaimNextRunnable_DrainingTargetNodeReleasesPinnedJob(t *te
 	require.NoError(t, err)
 	require.NotNil(t, job, "a job pinned to a draining node must fall through to an active worker, not starve until the node dies")
 	require.Equal(t, jobID, job.ID, "the claimed job should be the one pinned to the draining node")
+	require.NotNil(t, job.LockedByNodeID)
+	require.Equal(t, claimer, *job.LockedByNodeID, "the claim should be locked by the active worker that took it over")
 }
 
-// TestIntegration_ClaimNextRunnable_HealthyTargetNodePinHoldsJob is the guard
-// rail for the fix above: a job pinned to a *healthy, active* worker must stay
-// pinned. Only the owning node can claim it — a sibling worker must not steal
-// sandbox-bound work off a live node (the original #811 cross-host bug). This
-// proves the draining release didn't widen into "any pin is claimable."
+// Guard rail: a job pinned to a healthy active node stays pinned to its owner
+// (a sibling can't steal it), so the draining release didn't widen into "any
+// pin is claimable" (the #811 cross-host bug).
 func TestIntegration_ClaimNextRunnable_HealthyTargetNodePinHoldsJob(t *testing.T) {
 	pool := setup(t)
 	orgID := seedOrg(t, pool)

--- a/internal/worker/worker_test.go
+++ b/internal/worker/worker_test.go
@@ -101,7 +101,7 @@ func TestWorker_Poll(t *testing.T) {
 			name: "no pending jobs returns cleanly",
 			setupMock: func(t *testing.T, w *Worker, mock pgxmock.PgxPoolIface) {
 				t.Helper()
-				mock.ExpectQuery("WITH dead_target_nodes AS").
+				mock.ExpectQuery("WITH unavailable_target_nodes AS").
 					WithArgs(pgxmock.AnyArg(), "test-node", "test-node", pgxmock.AnyArg(), int(defaultLeaseDuration.Seconds())).
 					WillReturnError(pgx.ErrNoRows)
 			},
@@ -385,7 +385,7 @@ func TestWorker_Poll(t *testing.T) {
 				jobID := uuid.New()
 				orgID := uuid.New()
 				now := time.Now()
-				mock.ExpectQuery("WITH dead_target_nodes AS").
+				mock.ExpectQuery("WITH unavailable_target_nodes AS").
 					WithArgs(pgxmock.AnyArg(), "test-node", "test-node", pgxmock.AnyArg(), int(defaultLeaseDuration.Seconds())).
 					WillReturnRows(pgxmock.NewRows([]string{
 						"id", "org_id", "queue", "job_type", "payload", "priority", "status",
@@ -745,7 +745,7 @@ func TestWorker_Start_StopsOnContextCancel(t *testing.T) {
 	w.pollInterval = 10 * time.Millisecond
 	mock.MatchExpectationsInOrder(false)
 	for range 5 {
-		mock.ExpectQuery("WITH dead_target_nodes AS").
+		mock.ExpectQuery("WITH unavailable_target_nodes AS").
 			WithArgs(pgxmock.AnyArg(), "test-node", "test-node", pgxmock.AnyArg(), int(defaultLeaseDuration.Seconds())).
 			WillReturnError(pgx.ErrNoRows)
 	}
@@ -935,7 +935,7 @@ func expectClaimWithAttemptsAndTarget(mock pgxmock.PgxPoolIface, jobID, orgID uu
 	if targetNodeID != nil {
 		target = *targetNodeID
 	}
-	mock.ExpectQuery("WITH dead_target_nodes AS").
+	mock.ExpectQuery("WITH unavailable_target_nodes AS").
 		WithArgs(pgxmock.AnyArg(), "test-node", "test-node", pgxmock.AnyArg(), int(defaultLeaseDuration.Seconds())).
 		WillReturnRows(pgxmock.NewRows([]string{
 			"id", "org_id", "queue", "job_type", "payload", "priority", "status",


### PR DESCRIPTION
## Summary

A `continue_session` turn pins its job to the worker holding the session (`jobs.target_node_id`, from #811). `ClaimNextRunnable` only released a pinned job to another worker when the target node was **dead** (`status='dead'` or stale heartbeat). It did **not** account for a **draining** node.

During a routine worker rollout the old generation drains *gracefully*: it stops claiming new work but **keeps heartbeating to preserve healthy previews** (#1146/#1193). A turn enqueued in that window gets pinned to the draining node, which then:

- can't claim it itself — `claiming_node` requires `status='active'`, and
- never trips the dead-node fallback — it's still heartbeating, so it isn't "dead".

So the job sits `pending` until the node finally dies. Observed in production: a session's *"pull latest changes from the remote branch"* turn stuck **~17 minutes** with `attempts=0`, target pinned to a `draining` generation that a rollout had already replaced on the same host. It only recovered once the old node's heartbeat aged past the 90s dead threshold.

## Fix

Treat a `draining` target node as **unavailable** alongside `dead` in the claim fallback, so a healthy worker hydrates the session from its snapshot instead of waiting out the drain:

```sql
-- ClaimNextRunnable
WHERE status IN ('dead', 'draining') OR last_heartbeat_at < @dead_before
```

The worker already sets the `DeadTargetNode` recovery context for **any** cross-node claim (`worker.go` / `session_executor_runtime.go`), so the orchestrator's snapshot-rehydration path fires correctly for the draining case — no other code changes needed. `ReclaimLostRunningJobs` is unaffected: it already has a `lease_expires_at` fallback, and #1193 handles a session *running* on a draining node by requeuing it (and the requeued pending job now also benefits from this claim-side change).

The CTE is renamed `dead_target_nodes` → `unavailable_target_nodes` to match the broadened meaning.

## Testing

- New real-DB integration coverage in `internal/integration/worker_dispatch_test.go` (pgxmock can't see node-status semantics — it only matches the query string):
  - `..._DrainingTargetNodeReleasesPinnedJob` — a job pinned to a draining (but heartbeating) node **is** claimable by an active worker. Verified this **fails without the SQL change** and passes with it.
  - `..._HealthyTargetNodePinHoldsJob` — guard rail: a job pinned to a healthy active node stays pinned to its owner (a sibling can't steal it; the owner still can), so the release didn't widen into "any pin is claimable."
- `make lint` → 0 issues. `make test-integration` against a local Postgres → all dispatch + claim tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
