### PR TITLE
Self-heal leaked sandbox-dns endpoints; stop misreporting reconcile failures as sudoers

### DIFF
--- a/deploy/scripts/deploy.sh
+++ b/deploy/scripts/deploy.sh
@@ -58,6 +58,18 @@ repair_deploy_sudoers() {
   bash "$SCRIPT_DIR/repair-deploy-sudoers.sh" "$ROLE" "$HOST" "$SSH_KEY"
 }
 
+# repair-deploy-sudoers.sh can ONLY fix one thing: a missing/incorrect NOPASSWD
+# grant for the deploy user. It reaches the host over root SSH, which is disabled
+# on the fleet, so it is a dead end for every other failure. Only route to it
+# when the remote command actually tripped the sudo policy — otherwise a real
+# error inside the invoked script (e.g. a leaked docker network endpoint) gets
+# misreported as a sudoers problem and the operator is sent chasing root SSH that
+# will never work. These signatures are what `sudo -n` prints when it refuses.
+is_sudoers_failure() {
+  printf '%s' "$1" | grep -qiE \
+    'sudo: (a password is required|sorry, a password is required|no tty present)|not allowed to execute|is not in the sudoers file'
+}
+
 warn_log_rotation_skipped() {
   echo "WARNING: docker log rotation was not updated on this deploy; continuing."
   echo "  The service deploy will continue, but local Docker json-file logs may remain unbounded."
@@ -636,19 +648,43 @@ if [ "$ROLE" = "worker" ]; then
     ssh "${SSH_OPTS[@]}" deploy@"$HOST" \
       "docker pull \"$static_egress_probe_image\""
   fi
-  if ! run_worker_host_reconcile; then
-    echo "reconcile-worker-host.sh failed under deploy+sudo; trying no-teardown deploy sudoers repair..."
-    if repair_deploy_sudoers; then
-      echo "Retrying worker host reconciliation after sudoers repair..."
-      run_worker_host_reconcile
+  # Capture the reconcile output (while still streaming it live via tee) so we
+  # can tell a sudoers refusal apart from a genuine reconcile error. PIPESTATUS
+  # gives us the ssh exit status, which propagates the remote script's exit code;
+  # tee almost never fails. set +e keeps the failing pipeline from aborting the
+  # script before we classify it.
+  reconcile_log="$(mktemp)"
+  set +e
+  run_worker_host_reconcile 2>&1 | tee "$reconcile_log"
+  reconcile_rc="${PIPESTATUS[0]}"
+  set -e
+  if [ "$reconcile_rc" -ne 0 ]; then
+    if is_sudoers_failure "$(cat "$reconcile_log")"; then
+      echo "reconcile-worker-host.sh blocked by missing deploy sudoers; trying no-teardown deploy sudoers repair..."
+      if repair_deploy_sudoers; then
+        echo "Retrying worker host reconciliation after sudoers repair..."
+        run_worker_host_reconcile
+      else
+        echo "ERROR: reconcile-worker-host.sh was blocked by sudoers and repair via root SSH did not complete."
+        echo "  Run once from a machine with root SSH access:"
+        echo "    make repair-deploy-sudoers ROLE=$ROLE HOST=$HOST SSH_KEY=$SSH_KEY"
+        echo "  Then re-run the deploy."
+        rm -f "$reconcile_log"
+        exit 1
+      fi
     else
-      echo "ERROR: reconcile-worker-host.sh failed and sudoers repair via root SSH did not complete."
-      echo "  Run once from a machine with root SSH access:"
-      echo "    make repair-deploy-sudoers ROLE=$ROLE HOST=$HOST SSH_KEY=$SSH_KEY"
-      echo "  Then re-run the deploy."
+      echo "ERROR: reconcile-worker-host.sh failed on $HOST. This is NOT a sudoers problem"
+      echo "  (the deploy sudo grant ran); the underlying reconcile error is printed above."
+      echo "  Common cause: a leaked docker network endpoint holding sandbox-dns's pinned IP"
+      echo "  (\"Address already in use\"). reconcile-worker-host.sh now self-heals that on retry;"
+      echo "  if it persists, on the host run: docker network inspect 143-sandbox, then"
+      echo "  docker network disconnect -f 143-sandbox <stale-endpoint>, and re-run the deploy."
+      echo "  If instead you see an SSH 'Permission denied (publickey)', run: make sync-keys APPLY=true"
+      rm -f "$reconcile_log"
       exit 1
     fi
   fi
+  rm -f "$reconcile_log"
 fi
 
 if [ "$ROLE" = "app" ] && [ "$ALLOW_DEPLOY_DOCKER_DAEMON_RESTART" != "1" ]; then

--- a/deploy/scripts/reconcile-worker-host.sh
+++ b/deploy/scripts/reconcile-worker-host.sh
@@ -80,6 +80,58 @@ ensure_bridge() {
   fi
 }
 
+# sandbox-dns is pinned to fixed addresses (172.30.0.2 on the sandbox bridge,
+# 172.31.0.2 on the static-egress bridge) so the resolv.conf files can hard-code
+# the resolver. Because the IPs never change, a single leaked libnetwork
+# endpoint still holding one of them — left behind by a daemon hiccup or an
+# ungraceful blue/green drain — makes every later recreate fail with
+# "failed to set up container networking: Address already in use" and wedges
+# ALL future deploys on the host until the endpoint is cleared by hand. This
+# helper finds whichever endpoint currently owns a pinned IP and force-detaches
+# it so the recreate can reclaim the address.
+disconnect_endpoint_for_ip() {
+  local network="$1"
+  local ip="$2"
+  local endpoint
+
+  endpoint="$(docker network inspect "$network" \
+    -f '{{range .Containers}}{{.Name}} {{.IPv4Address}}{{"\n"}}{{end}}' 2>/dev/null \
+    | awk -v want="$ip/" 'index($2, want) == 1 {print $1}' | head -n1)"
+  if [ -n "$endpoint" ]; then
+    echo "Detaching stale endpoint '$endpoint' holding $ip on $network..." >&2
+    docker network disconnect -f "$network" "$endpoint" >/dev/null 2>&1 || true
+  fi
+}
+
+clear_sandbox_dns_endpoints() {
+  # Remove the prior container (if any) and drop leaked endpoints by name and by
+  # pinned IP. The by-IP pass catches ghost endpoints whose owning container was
+  # removed uncleanly and no longer matches the container name.
+  docker rm -f 143-sandbox-dns-1 >/dev/null 2>&1 || true
+  docker network disconnect -f "$SANDBOX_NETWORK" 143-sandbox-dns-1 >/dev/null 2>&1 || true
+  docker network disconnect -f "$STATIC_EGRESS_NETWORK" 143-sandbox-dns-1 >/dev/null 2>&1 || true
+  disconnect_endpoint_for_ip "$SANDBOX_NETWORK" 172.30.0.2
+  disconnect_endpoint_for_ip "$STATIC_EGRESS_NETWORK" "$STATIC_EGRESS_DNS_IP"
+}
+
+# Per-turn sandbox run containers (143-worker-run-*) should be removed when a
+# coding turn ends; leftovers accumulate stale libnetwork endpoints on the
+# sandbox bridge and feed the leaked-endpoint failure handled above. Sweep only
+# NON-running containers so in-flight coding turns are never touched.
+sweep_stopped_worker_run_containers() {
+  local stale
+  stale="$(docker ps -a \
+    --filter 'name=143-worker-run-' \
+    --filter 'status=exited' \
+    --filter 'status=created' \
+    --filter 'status=dead' \
+    --format '{{.ID}}' 2>/dev/null || true)"
+  if [ -n "$stale" ]; then
+    echo "Removing stale (non-running) worker-run sandbox containers..." >&2
+    printf '%s\n' "$stale" | xargs -r docker rm -f >/dev/null 2>&1 || true
+  fi
+}
+
 ensure_static_egress_dns() {
   local compose_dir
   local compose_file
@@ -98,9 +150,17 @@ ensure_static_egress_dns() {
   # Fresh SSH provisioning verifies static egress before the full worker
   # compose stack is started, so make the pinned sandbox DNS IP available
   # without starting the worker service early.
+  #
+  # Try a normal graceful recreate first (least disruptive to sandbox DNS); only
+  # if it fails do we force-clear the leaked endpoints and retry once, so
+  # healthy hosts never pay an extra DNS blip.
   (
     cd "$compose_dir"
-    docker compose -f "$compose_file" up -d --build --no-deps sandbox-dns
+    if ! docker compose -f "$compose_file" up -d --build --no-deps sandbox-dns; then
+      echo "sandbox-dns recreate failed; clearing leaked sandbox-dns network endpoints and retrying once..." >&2
+      clear_sandbox_dns_endpoints
+      docker compose -f "$compose_file" up -d --build --no-deps sandbox-dns
+    fi
   )
 }
 
@@ -119,6 +179,10 @@ if ! docker network inspect "$DEFAULT_NETWORK" >/dev/null 2>&1; then
   docker network create --driver bridge \
     --label managed-by=143 "$DEFAULT_NETWORK"
 fi
+
+# Reclaim sandbox-bridge endpoints leaked by ended coding turns before they
+# accumulate and starve the pinned sandbox-dns addresses.
+sweep_stopped_worker_run_containers
 
 # Install iptables-persistent so the egress block survives reboots. This is
 # best-effort because some minimal images prompt or temporarily lack apt locks;


### PR DESCRIPTION
## Problem

Worker fleet deploys keep wedging on individual hosts. The headline error in the logs is misleading — it reports a sudoers problem and tells you to run `make repair-deploy-sudoers` over root SSH (which is disabled on the fleet, so it fails with `Permission denied`). The **actual** failure is one line earlier:

```
Container 143-sandbox-dns-1 Recreate ... Starting
Error response from daemon: failed to set up container networking: Address already in use
```

`sandbox-dns` is pinned to fixed IPs (`172.30.0.2` on `143-sandbox`, `172.31.0.2` on `143-sandbox-static-egress`) so the resolv.conf files can hard-code the resolver. Because the IPs never change, a single **leaked libnetwork endpoint** still holding one of those addresses — left by a daemon hiccup or an ungraceful blue/green drain (note the orphan `143-worker-run-*` containers in the logs) — makes **every subsequent** `docker compose up sandbox-dns` fail deterministically. Once a host enters this state it stays wedged on every deploy until the endpoint is cleared by hand. That's the "happens consistently for a week or two" pattern.

The misclassification in `deploy.sh` compounded it: any non-zero reconcile exit was treated as missing sudoers, so the real cause was never surfaced and the operator chased a dead-end repair.

## Changes

**`reconcile-worker-host.sh` — self-heal the leaked endpoint**
- `ensure_static_egress_dns()` tries the normal graceful recreate first (least disruptive to sandbox DNS); only on failure does it force-clear leaked endpoints and retry once, so healthy hosts never pay an extra DNS blip.
- `clear_sandbox_dns_endpoints()` removes the prior container and detaches leaked endpoints **by container name and by pinned IP** — the by-IP pass (`disconnect_endpoint_for_ip`) catches ghost endpoints whose owning container was removed uncleanly and no longer matches the name.
- `sweep_stopped_worker_run_containers()` reclaims leftover `143-worker-run-*` sandbox containers to stop the endpoint churn — **only non-running ones** (`exited`/`created`/`dead`), so in-flight coding turns are never touched.

**`deploy.sh` — classify the failure instead of blaming sudoers**
- `is_sudoers_failure()` matches the exact strings `sudo -n` prints when it actually refuses.
- The reconcile call streams output live via `tee` and captures it (exit code from `PIPESTATUS[0]`). Only a genuine sudo refusal routes to `repair_deploy_sudoers`; every other failure prints the real reconcile error plus targeted next steps (clear the stale endpoint, or `make sync-keys APPLY=true` for a pubkey issue).

## Why this is self-applying

`deploy.sh` scp's the new `reconcile-worker-host.sh` to each host and makes it live **before** running it, so deploying this branch pushes the self-healing reconcile and clears the wedged endpoint on the same deploy — broken hosts repair themselves.

## Testing

- `bash -n` passes on both scripts.
- Control flow traced by hand against the deploy/reconcile path. No shellcheck in CI and no unit harness covers this path; happy to add a `*_test.sh` exercising `is_sudoers_failure` classification (matching the existing `deploy/scripts/*_test.sh` style) if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)