### PR TITLE
Mark preview runtime lost on worker-closed-connection proxy errors

### DIFF
--- a/internal/api/gateway/preview_gateway.go
+++ b/internal/api/gateway/preview_gateway.go
@@ -1180,6 +1180,10 @@ func shouldMarkRuntimeLostOnProxyError(err error) bool {
 		"i/o timeout",
 		"no such host",
 		"eof",
+		// Worker tore down the connection without responding: a dead pooled
+		// keep-alive conn, or a write racing the worker's close.
+		"server closed idle connection",
+		"broken pipe",
 	} {
 		if strings.Contains(lower, marker) {
 			return true

--- a/internal/api/gateway/preview_gateway_test.go
+++ b/internal/api/gateway/preview_gateway_test.go
@@ -1502,6 +1502,8 @@ func TestShouldMarkRuntimeLostOnProxyError(t *testing.T) {
 	}{
 		{name: "connection refused is endpoint loss", err: &net.OpError{Op: "dial", Net: "tcp", Err: errors.New("connect: connection refused")}, want: true},
 		{name: "connection reset is endpoint loss", err: &net.OpError{Op: "read", Net: "tcp", Err: errors.New("read: connection reset by peer")}, want: true},
+		{name: "server closed idle connection is endpoint loss", err: errors.New("http: server closed idle connection"), want: true},
+		{name: "broken pipe is endpoint loss", err: &net.OpError{Op: "write", Net: "tcp", Err: errors.New("write: broken pipe")}, want: true},
 		{name: "client cancellation is not endpoint loss", err: context.Canceled, want: false},
 		{name: "deadline cancellation is not endpoint loss", err: context.DeadlineExceeded, want: false},
 	}


### PR DESCRIPTION
## Summary

`shouldMarkRuntimeLostOnProxyError` (in `internal/api/gateway/preview_gateway.go`) classifies which proxy errors mean the worker endpoint is gone, so the cached runtime is marked lost and re-resolved on the next request. It was missing two error strings the Go HTTP transport produces when the worker tears down the connection **without sending a response**:

- `http: server closed idle connection` — a pooled keep-alive connection (the gateway transport uses `MaxIdleConnsPerHost = 128`) to a worker that has since died.
- `broken pipe` — a request write that races the worker's close.

Both now mark the runtime lost like the other connection-loss markers (`connection refused`, `connection reset`, `eof`, …).

## Why this also fixes a flaky test

`TestGateway_ProxyToWorker_LogsRequestAndRuntimeOnProxyError` uses a TCP listener that accepts then immediately closes the connection. The resulting proxy error string is timing-dependent — usually `EOF`/`connection reset by peer`, but under `-race` and concurrent load the transport surfaces it as `http: server closed idle connection`. On those runs the mark-lost `Exec` was skipped, leaving a `pgxmock` expectation unmet. The test passed in isolation, which is why it only failed in CI.

## Testing

- `go test ./internal/api/gateway/ -run 'TestGateway_ProxyToWorker_LogsRequestAndRuntimeOnProxyError|TestShouldMarkRuntimeLostOnProxyError' -race -count=200` — green (previously failed within ~200 iterations).
- `make lint` — 0 issues.

Added `server closed idle connection` and `broken pipe` cases to the `TestShouldMarkRuntimeLostOnProxyError` table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
