### PR TITLE
Make Linear creator attribution lookup deterministic (VIR-139 follow-up)

### DIFF
--- a/internal/db/user_store_test.go
+++ b/internal/db/user_store_test.go
@@ -200,7 +200,7 @@ func TestUserStore_GetByOrgAndEmail(t *testing.T) {
 			name:        "returns org user when primary email matches case insensitively",
 			lookupEmail: "Creator@Example.com",
 			setupMock: func(mock pgxmock.PgxPoolIface, userID, orgID uuid.UUID, now time.Time) {
-				mock.ExpectQuery(`(?s)SELECT .+ FROM users WHERE org_id = .+COALESCE\(secondary_emails`).
+				mock.ExpectQuery(`(?s)SELECT .+ FROM users WHERE org_id = .+COALESCE\(secondary_emails.+ORDER BY.+LIMIT 1`).
 					WithArgs(orgID, pgxmock.AnyArg()).
 					WillReturnRows(
 						pgxmock.NewRows(userColumns).
@@ -213,7 +213,7 @@ func TestUserStore_GetByOrgAndEmail(t *testing.T) {
 			lookupEmail: "12345+alice@users.noreply.github.com",
 			setupMock: func(mock pgxmock.PgxPoolIface, userID, orgID uuid.UUID, now time.Time) {
 				noreply := "12345+alice@users.noreply.github.com"
-				mock.ExpectQuery(`(?s)SELECT .+ FROM users WHERE org_id = .+COALESCE\(secondary_emails`).
+				mock.ExpectQuery(`(?s)SELECT .+ FROM users WHERE org_id = .+COALESCE\(secondary_emails.+ORDER BY.+LIMIT 1`).
 					WithArgs(orgID, pgxmock.AnyArg()).
 					WillReturnRows(
 						pgxmock.NewRows(userColumns).
@@ -225,7 +225,7 @@ func TestUserStore_GetByOrgAndEmail(t *testing.T) {
 			name:        "returns org user when secondary email matches",
 			lookupEmail: "alice@company.com",
 			setupMock: func(mock pgxmock.PgxPoolIface, userID, orgID uuid.UUID, now time.Time) {
-				mock.ExpectQuery(`(?s)SELECT .+ FROM users WHERE org_id = .+COALESCE\(secondary_emails`).
+				mock.ExpectQuery(`(?s)SELECT .+ FROM users WHERE org_id = .+COALESCE\(secondary_emails.+ORDER BY.+LIMIT 1`).
 					WithArgs(orgID, pgxmock.AnyArg()).
 					WillReturnRows(
 						pgxmock.NewRows(userColumns).
@@ -237,7 +237,7 @@ func TestUserStore_GetByOrgAndEmail(t *testing.T) {
 			name:        "returns error when no org user matches either email column",
 			lookupEmail: "unknown@example.com",
 			setupMock: func(mock pgxmock.PgxPoolIface, userID, orgID uuid.UUID, now time.Time) {
-				mock.ExpectQuery(`(?s)SELECT .+ FROM users WHERE org_id = .+COALESCE\(secondary_emails`).
+				mock.ExpectQuery(`(?s)SELECT .+ FROM users WHERE org_id = .+COALESCE\(secondary_emails.+ORDER BY.+LIMIT 1`).
 					WithArgs(orgID, pgxmock.AnyArg()).
 					WillReturnRows(pgxmock.NewRows(userColumns))
 			},

--- a/internal/db/users.go
+++ b/internal/db/users.go
@@ -245,6 +245,24 @@ func (s *UserStore) GetByEmail(ctx context.Context, email string) (models.User, 
 	return pgx.CollectOneRow(rows, pgx.RowToStructByName[models.User])
 }
 
+// GetByOrgAndEmail resolves a single org member by an email that may be their
+// primary, GitHub noreply, or one of their secondary emails. Nothing enforces
+// that an address is unique across users within an org (a secondary email could
+// collide with another member's primary), so the match is deterministically
+// tie-broken: a primary-email match wins over a github-noreply match, which
+// wins over a secondary-email match, and `created_at` (then `id`) breaks any
+// remaining tie so the same caller always resolves to the same user.
+//
+// secondary_emails are stored pre-lowercased by AddSecondaryEmail, so the array
+// comparison below compares against already-lowercased elements rather than
+// re-lowering each element.
+//
+// No dedicated email index is needed: the org_id predicate is served by
+// idx_users_org_id, which bounds the scan to a single org's members (a small
+// set), and the OR over the three email columns is then evaluated within that
+// subset. This lookup runs at session-creation frequency, so adding expression
+// or GIN indexes here would cost write amplification on every users write for a
+// scan the planner would not choose anyway.
 func (s *UserStore) GetByOrgAndEmail(ctx context.Context, orgID uuid.UUID, email string) (models.User, error) {
 	query := fmt.Sprintf(`
 		SELECT %s
@@ -252,7 +270,13 @@ func (s *UserStore) GetByOrgAndEmail(ctx context.Context, orgID uuid.UUID, email
 		WHERE org_id = @org_id
 		  AND (LOWER(email) = LOWER(@email)
 		       OR LOWER(github_noreply_email) = LOWER(@email)
-		       OR LOWER(@email) = ANY(COALESCE(secondary_emails, '{}'::text[])))`, userSelectColumns)
+		       OR LOWER(@email) = ANY(COALESCE(secondary_emails, '{}'::text[])))
+		ORDER BY
+		  (LOWER(email) = LOWER(@email)) DESC,
+		  (LOWER(github_noreply_email) = LOWER(@email)) DESC,
+		  created_at ASC,
+		  id ASC
+		LIMIT 1`, userSelectColumns)
 
 	rows, err := s.db.Query(ctx, query, pgx.NamedArgs{"org_id": orgID, "email": email})
 	if err != nil {

--- a/internal/integration/user_store_test.go
+++ b/internal/integration/user_store_test.go
@@ -1,0 +1,82 @@
+//go:build integration
+
+package integration
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/stretchr/testify/require"
+
+	"github.com/assembledhq/143/internal/db"
+)
+
+// insertUserWithEmails inserts a user with an explicit primary email, optional
+// secondary_emails, and an explicit created_at so GetByOrgAndEmail tie-break
+// ordering is deterministic and observable. Raw SQL (rather than a store
+// helper) because nothing in UserStore lets a test backdate created_at or seed
+// a secondary email without going through the OAuth/invite handlers.
+func insertUserWithEmails(t *testing.T, pool *pgxpool.Pool, orgID uuid.UUID, primary string, secondary []string, createdAt time.Time) uuid.UUID {
+	t.Helper()
+	var id uuid.UUID
+	err := pool.QueryRow(context.Background(), `
+		INSERT INTO users (org_id, email, name, role, secondary_emails, created_at)
+		VALUES ($1, $2, $3, 'member', $4, $5)
+		RETURNING id
+	`, orgID, primary, "Test "+primary, secondary, createdAt).Scan(&id)
+	require.NoError(t, err, "insert user with emails")
+	return id
+}
+
+// TestGetByOrgAndEmail_PrimaryMatchWinsOverSecondaryCollision proves the
+// priority tie-break in GetByOrgAndEmail against a real Postgres: nothing
+// enforces that an address is unique across users within an org, so a lookup
+// address can be one user's primary email and an *older* user's secondary
+// email simultaneously. A plain `created_at ASC` would pick the older
+// secondary-only match; the priority ordering must prefer the primary match.
+func TestGetByOrgAndEmail_PrimaryMatchWinsOverSecondaryCollision(t *testing.T) {
+	pool := setup(t)
+	orgID := seedOrg(t, pool)
+
+	base := time.Now().UTC().Truncate(time.Second)
+	// Created earlier, matches only via its secondary_emails array.
+	secondaryUser := insertUserWithEmails(t, pool, orgID,
+		"personal@example.com", []string{"shared@example.com"}, base.Add(-time.Hour))
+	// Created later, owns the address as its primary email.
+	primaryUser := insertUserWithEmails(t, pool, orgID,
+		"shared@example.com", nil, base)
+
+	store := db.NewUserStore(pool)
+	got, err := store.GetByOrgAndEmail(context.Background(), orgID, "Shared@Example.com")
+	require.NoError(t, err, "lookup should resolve a matching org user")
+	require.Equal(t, primaryUser, got.ID,
+		"a primary-email match must win over an older user that only matches on a secondary email")
+	require.NotEqual(t, secondaryUser, got.ID)
+}
+
+// TestGetByOrgAndEmail_DeterministicOnEqualPriority proves that when two users
+// match at the same priority tier (both via a secondary-email collision), the
+// resolution is stable across repeated lookups — the older row always wins —
+// so creator attribution can never flap between two candidate users.
+func TestGetByOrgAndEmail_DeterministicOnEqualPriority(t *testing.T) {
+	pool := setup(t)
+	orgID := seedOrg(t, pool)
+
+	base := time.Now().UTC().Truncate(time.Second)
+	older := insertUserWithEmails(t, pool, orgID,
+		"a@example.com", []string{"shared@example.com"}, base.Add(-time.Hour))
+	newer := insertUserWithEmails(t, pool, orgID,
+		"b@example.com", []string{"shared@example.com"}, base)
+
+	store := db.NewUserStore(pool)
+	for i := 0; i < 3; i++ {
+		got, err := store.GetByOrgAndEmail(context.Background(), orgID, "shared@example.com")
+		require.NoError(t, err, "lookup should resolve a matching org user")
+		require.Equal(t, older, got.ID,
+			"equal-priority secondary collisions must tie-break on created_at so lookups are deterministic")
+		require.NotEqual(t, newer, got.ID)
+	}
+}


### PR DESCRIPTION
## Summary
Follow-up hardening for the Linear issue-creator → session-trigger attribution merged in [#1387](https://github.com/assembledhq/143/pull/1387). Addresses review findings on `UserStore.GetByOrgAndEmail`.

The lookup ended in `pgx.CollectOneRow` with **no `ORDER BY`**. Nothing enforces that an email is unique across users within an org — a `secondary_emails` entry can collide with another member's primary email — so on a collision the row returned was **nondeterministic**, meaning a Linear-triggered session could be attributed to the wrong user (and flap between candidates run to run).

## Changes
- **`internal/db/users.go`**
  - `GetByOrgAndEmail`: add a deterministic priority + stable tie-break — **primary-email match > github-noreply match > secondary-email match**, then `created_at ASC`, then `id ASC`, `LIMIT 1`. The same input now always resolves to the same user.
  - Document the lowercase-on-write coupling (`secondary_emails` are stored pre-lowercased by `AddSecondaryEmail`, so the array comparison is sound) and why **no dedicated email index is added**: `idx_users_org_id` already bounds the scan to one org's members (a small set), and the lookup runs at session-creation frequency — speculative expression/GIN indexes would only add write amplification for a scan the planner wouldn't choose.
- **`internal/db/user_store_test.go`**: pin the `ORDER BY … LIMIT 1` shape in the existing pgxmock expectations so the deterministic clause can't be silently dropped.
- **`internal/integration/user_store_test.go`** (new, real-Postgres): 
  - `TestGetByOrgAndEmail_PrimaryMatchWinsOverSecondaryCollision` — a primary-email match must win over an *older* user that only matches via a secondary email.
  - `TestGetByOrgAndEmail_DeterministicOnEqualPriority` — equal-priority secondary collisions tie-break on `created_at` and are stable across repeated lookups.

## Review findings addressed
| # | Finding | Resolution |
|---|---------|-----------|
| 1 | Ambiguous match when two users share an email (correctness) | Deterministic priority + `created_at`/`id` tie-break |
| 2 | `secondary_emails` unindexed (performance) | Documented why no index is warranted (org_id bounds the scan); not a real hotspot |
| 3 | Implicit lowercase-on-write coupling | Documented on the function |

## Test plan
- `go test ./internal/db/... ./internal/worker/... ./internal/services/linear/... ./internal/api/handlers/...` — pass
- `make test-integration` (real Postgres) — pass
- Verified the new integration test **fails** when the `ORDER BY` priority is reverted, confirming it guards the fix
- `make lint` — 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)