### PR TITLE
Show in-app reconnect overlay when a preview session expires

### DIFF
--- a/internal/api/gateway/preview_gateway.go
+++ b/internal/api/gateway/preview_gateway.go
@@ -1421,15 +1421,29 @@ const activityHeartbeatScript = `
   var expired = false;
   var countdownTimer = null;
 
+  // Capture the native fetch at init, before the previewed app's bundles run.
+  // Apps that wrap window.fetch with an auth interceptor often throw or redirect
+  // on 401, which would hide the expiry signal from us; binding it now keeps the
+  // watchdog reading the real response status.
+  var nativeFetch = (window.fetch && window.fetch.bind(window)) || null;
+
   function reconnect() {
     // A top-level reload re-issues a navigation request, so the gateway serves
     // the full control overlay (status, logs, Restart + auto-reconnect).
+    if (countdownTimer) { clearInterval(countdownTimer); countdownTimer = null; }
     window.location.reload();
   }
 
   function sendHeartbeat() {
     if (expired) return;
-    fetch("/__143_heartbeat?t=" + Date.now(), {
+    var url = "/__143_heartbeat?t=" + Date.now();
+    if (!nativeFetch) {
+      // Pre-fetch browsers: keep the idle timer alive but we cannot read a
+      // status, so expiry recovery is unavailable (a reload still works).
+      new Image().src = url;
+      return;
+    }
+    nativeFetch(url, {
       cache: "no-store",
       credentials: "same-origin"
     }).then(function(resp) {

--- a/internal/api/gateway/preview_gateway.go
+++ b/internal/api/gateway/preview_gateway.go
@@ -1399,6 +1399,16 @@ func writeRuntimeUnavailable(w http.ResponseWriter) {
 // activity heartbeats while the preview tab is visible. This keeps the
 // idle timeout tracker accurate even when the user is just viewing (not
 // navigating) the preview.
+//
+// The heartbeat doubles as a session watchdog: it is sent with fetch (not a
+// fire-and-forget Image) so we can observe a 401 PREVIEW_SESSION_EXPIRED. A
+// running SPA whose preview session has lapsed (idle past the sliding window,
+// or the instance was recycled) would otherwise just see every fetch/asset
+// 401 and render a blank screen with no way to recover. When we detect that
+// 401 we surface an in-app reconnect overlay (a Reconnect button plus a short
+// auto-reconnect countdown). Reconnecting is a top-level reload, which re-issues
+// a navigation request — the gateway then serves the full control overlay
+// (status, logs, Restart + auto-reconnect handshake) defined above.
 const activityHeartbeatScript = `
 (function() {
   "use strict";
@@ -1406,17 +1416,97 @@ const activityHeartbeatScript = `
   window.__143_heartbeat = true;
 
   var INTERVAL_MS = 30000; // 30 seconds
+  var RECONNECT_SECONDS = 5; // auto-reconnect countdown once expiry is detected
   var timer = null;
+  var expired = false;
+  var countdownTimer = null;
+
+  function reconnect() {
+    // A top-level reload re-issues a navigation request, so the gateway serves
+    // the full control overlay (status, logs, Restart + auto-reconnect).
+    window.location.reload();
+  }
 
   function sendHeartbeat() {
-    var img = new Image();
-    img.src = "/__143_heartbeat?t=" + Date.now();
+    if (expired) return;
+    fetch("/__143_heartbeat?t=" + Date.now(), {
+      cache: "no-store",
+      credentials: "same-origin"
+    }).then(function(resp) {
+      // 401 is the gateway's PREVIEW_SESSION_EXPIRED signal. Network errors are
+      // transient (offline, proxy blip) and must not trigger a recovery loop.
+      if (resp && resp.status === 401) onExpired();
+    }).catch(function() {});
+  }
+
+  function onExpired() {
+    if (expired) return;
+    expired = true;
+    if (timer) { clearInterval(timer); timer = null; }
+    renderOverlay();
+  }
+
+  function renderOverlay() {
+    if (document.getElementById("__143-preview-reconnect")) return;
+    var host = document.createElement("div");
+    host.id = "__143-preview-reconnect";
+    host.style.cssText = "position:fixed;inset:0;z-index:2147483647;";
+    // Shadow DOM isolates our styles from the previewed app's CSS.
+    var root = host.attachShadow ? host.attachShadow({mode: "open"}) : host;
+    root.innerHTML =
+      "<style>" +
+      ":host,*{box-sizing:border-box}" +
+      ".scrim{position:fixed;inset:0;display:grid;place-items:center;" +
+      "background:color-mix(in srgb, black 55%, transparent);" +
+      "font-family:ui-sans-serif,system-ui,-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif}" +
+      ".panel{color-scheme:light dark;width:min(92vw,380px);border-radius:12px;padding:24px;" +
+      "background:Canvas;color:CanvasText;border:1px solid color-mix(in srgb,CanvasText 14%,transparent);" +
+      "box-shadow:0 18px 60px color-mix(in srgb,black 45%,transparent)}" +
+      ".eyebrow{margin:0 0 8px;font-size:12px;color:color-mix(in srgb,CanvasText 56%,transparent)}" +
+      "h1{margin:0;font-size:20px;line-height:1.2}" +
+      "p{margin:10px 0 0;font-size:14px;line-height:1.5;color:color-mix(in srgb,CanvasText 68%,transparent)}" +
+      ".count{margin-top:14px;font-weight:600;color:CanvasText;font-size:13px}" +
+      "button{margin-top:20px;width:100%;min-height:38px;border-radius:8px;border:0;cursor:pointer;" +
+      "font-size:14px;font-weight:600;background:CanvasText;color:Canvas}" +
+      "</style>" +
+      "<div class='scrim'><div class='panel'>" +
+      "<p class='eyebrow'>143 preview</p>" +
+      "<h1>Preview disconnected</h1>" +
+      "<p>This preview's session expired — it may have been idle or restarted. Reconnect to pick up where you left off.</p>" +
+      "<p class='count' id='pv-count'></p>" +
+      "<button id='pv-reconnect' type='button'>Reconnect now</button>" +
+      "</div></div>";
+    (document.body || document.documentElement).appendChild(host);
+
+    var btn = root.querySelector("#pv-reconnect");
+    var countEl = root.querySelector("#pv-count");
+    if (btn) btn.addEventListener("click", reconnect);
+
+    var remaining = RECONNECT_SECONDS;
+    function paint() {
+      if (!countEl) return;
+      countEl.textContent = remaining > 0
+        ? "Reconnecting in " + remaining + "s…"
+        : "Reconnecting…";
+    }
+    paint();
+    countdownTimer = setInterval(function() {
+      // Only count down while the tab is visible so a backgrounded tab does not
+      // silently reload itself out from under the user.
+      if (document.visibilityState !== "visible") return;
+      remaining -= 1;
+      paint();
+      if (remaining <= 0) {
+        clearInterval(countdownTimer);
+        reconnect();
+      }
+    }, 1000);
   }
 
   function onVisibilityChange() {
     if (document.visibilityState === "visible") {
       sendHeartbeat();
-      if (!timer) {
+      if (!expired && !timer) {
         timer = setInterval(sendHeartbeat, INTERVAL_MS);
       }
     } else {

--- a/internal/api/gateway/preview_gateway_test.go
+++ b/internal/api/gateway/preview_gateway_test.go
@@ -400,6 +400,25 @@ func TestInjectScriptsIntoHTML_GzipResponse(t *testing.T) {
 	require.Contains(t, string(body), preview.ComponentResolverScript, "modified HTML should include the component resolver script")
 }
 
+func TestActivityHeartbeatScriptWatchesForSessionExpiry(t *testing.T) {
+	t.Parallel()
+
+	// The heartbeat must use fetch (not a fire-and-forget Image) so it can read
+	// the gateway's 401 PREVIEW_SESSION_EXPIRED status, and it must surface an
+	// in-app reconnect overlay with a button. A regression here reintroduces the
+	// silent blank-screen-on-expiry failure mode.
+	require.Contains(t, activityHeartbeatScript, `fetch("/__143_heartbeat`,
+		"heartbeat must use fetch so it can observe the expiry status code")
+	require.Contains(t, activityHeartbeatScript, "resp.status === 401",
+		"heartbeat must react to the gateway's 401 expiry signal")
+	require.Contains(t, activityHeartbeatScript, "__143-preview-reconnect",
+		"expiry must render the in-app reconnect overlay")
+	require.Contains(t, activityHeartbeatScript, "pv-reconnect",
+		"the reconnect overlay must expose a reconnect button")
+	require.Contains(t, activityHeartbeatScript, "window.location.reload()",
+		"reconnecting must reload so the gateway serves the full control overlay")
+}
+
 func TestInjectScriptsIntoHTML_OversizedCompressedBodyPassesThroughUnchanged(t *testing.T) {
 	t.Parallel()
 

--- a/internal/api/gateway/preview_gateway_test.go
+++ b/internal/api/gateway/preview_gateway_test.go
@@ -407,8 +407,14 @@ func TestActivityHeartbeatScriptWatchesForSessionExpiry(t *testing.T) {
 	// the gateway's 401 PREVIEW_SESSION_EXPIRED status, and it must surface an
 	// in-app reconnect overlay with a button. A regression here reintroduces the
 	// silent blank-screen-on-expiry failure mode.
-	require.Contains(t, activityHeartbeatScript, `fetch("/__143_heartbeat`,
-		"heartbeat must use fetch so it can observe the expiry status code")
+	require.Contains(t, activityHeartbeatScript, "window.fetch.bind(window)",
+		"heartbeat must capture native fetch at init so app fetch wrappers cannot hide the 401")
+	require.Contains(t, activityHeartbeatScript, "nativeFetch(url",
+		"heartbeat must probe via the captured native fetch")
+	require.Contains(t, activityHeartbeatScript, "/__143_heartbeat?t=",
+		"heartbeat must hit the gateway heartbeat endpoint")
+	require.Contains(t, activityHeartbeatScript, "new Image().src = url",
+		"heartbeat must fall back to an Image keep-alive when fetch is unavailable")
 	require.Contains(t, activityHeartbeatScript, "resp.status === 401",
 		"heartbeat must react to the gateway's 401 expiry signal")
 	require.Contains(t, activityHeartbeatScript, "__143-preview-reconnect",


### PR DESCRIPTION
## What

When a running preview's access session lapses (idle past the 30-min sliding window, or the instance gets recycled), the previewed SPA's `fetch`/asset requests all start returning `401 PREVIEW_SESSION_EXPIRED`. The app has no handler for that, so the user just sees a **blank screen with no way to recover**. The rich control overlay (Restart + auto-reconnect) only renders on a fresh top-level navigation — which the user has no reason to trigger.

This fixes it in the gateway's injected script (the one place that runs *inside* the previewed app without touching the app's own code):

- **Heartbeat now uses `fetch`** (`credentials: same-origin`) instead of a fire-and-forget `Image`, so the client can observe the gateway's `401` expiry status. The old `Image().src` approach couldn't read a response code, so expiry was invisible.
- **On detecting the `401`, render a Shadow-DOM reconnect overlay** — style-isolated from the previewed app — with a **"Reconnect now"** button and a 5s auto-reconnect countdown that only ticks while the tab is visible. Reconnecting is a top-level `location.reload()`, which re-issues a navigation request, so the gateway serves the **existing** `servePreviewControlOverlay` (status, logs, Restart + popup reconnect handshake). The new code only *detects and surfaces*; it reuses all the existing restart machinery.

The existing `visibilitychange → visible` handler already fires a heartbeat on tab refocus, so returning to a blanked-out tab now shows the overlay immediately rather than staying blank.

## Why not a button in the JSON error?

The `401 PREVIEW_SESSION_EXPIRED` body is consumed by the app's `fetch`/XHR code and never rendered — a button there can't be clicked. The injected overlay *is* the user-facing button.

## Recovery behavior

Button + auto-reconnect: overlay with a manual "Reconnect now" button **and** a short auto-reload countdown (visible-only). Reloading lands on the existing Restart-preview overlay, so there's no risk of a silent reload loop (that overlay is served directly, without the injected watcher).

## Testing

- New `TestActivityHeartbeatScriptWatchesForSessionExpiry` locks in the `fetch` + `401`-reaction + reconnect-button + reload behavior against regression.
- `go test ./internal/api/gateway/`, `go vet`, and `make lint` (golangci-lint v2) all pass.

## Notes for reviewer

- Scope is gateway-only — no changes to arbitrary previewed app code.
- Applies to pages served after deploy; an already-open expired tab still needs one reload to pick up the new script.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
