### PR TITLE
[codex] Fix sandbox auth socket rehydration

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -508,6 +508,7 @@ func main() {
 				sessionMessageStore, automationRunStore, evalBootstrapStore, snapshotStore, billingMetrics, cancelRegistry, threadCancelRegistry, orgSettingsCache, sandboxCapacity, redisClient, sessionStreams, fileReader)
 			if services != nil {
 				sandboxAuthShutdown = services.SandboxAuthShutdown
+				registerInternalSandboxAuthRoutes(router, services.SandboxAuthBroker, cfg, logger)
 				if previewManager != nil && pvProvider != nil {
 					var prewarmDependencyCache preview.PreviewPathCache
 					if pathCache, ok := dependencyCache.(preview.PreviewPathCache); ok {
@@ -1091,6 +1092,24 @@ func canBuildServices(cfg *config.Config, logger zerolog.Logger) bool {
 	return true
 }
 
+type internalSandboxAuthRouter interface {
+	Post(pattern string, h http.HandlerFunc)
+}
+
+func registerInternalSandboxAuthRoutes(router internalSandboxAuthRouter, broker handlers.InternalSandboxAuthBroker, cfg *config.Config, logger zerolog.Logger) {
+	if router == nil || broker == nil || cfg == nil {
+		return
+	}
+	keyring, err := auth.NewPreviewTokenKeyring(cfg.PreviewRPCSecrets)
+	if err != nil {
+		logger.Warn().Err(err).Msg("sandbox auth: preview RPC keyring is not configured; internal sandbox auth RPC unavailable")
+		return
+	}
+	handler := handlers.NewInternalSandboxAuthHandler(broker, cfg.NodeID, keyring, logger)
+	router.Post("/internal/sandbox-auth/acquire", handler.Acquire)
+	router.Post("/internal/sandbox-auth/release", handler.Release)
+}
+
 func validateSessionExecutorStartupConfig(cfg *config.Config) error {
 	if cfg == nil {
 		return fmt.Errorf("config is required")
@@ -1142,6 +1161,18 @@ func sessionExecutorBinds() []string {
 		"/var/run/143/sandbox-auth:/var/run/143/sandbox-auth",
 		"/etc/143:/etc/143:ro",
 	}
+}
+
+func sessionExecutorIDFromEnv() (uuid.UUID, bool, error) {
+	raw := strings.TrimSpace(os.Getenv("SESSION_EXECUTOR_ID"))
+	if raw == "" {
+		return uuid.Nil, false, nil
+	}
+	id, err := uuid.Parse(raw)
+	if err != nil {
+		return uuid.Nil, true, fmt.Errorf("parse SESSION_EXECUTOR_ID: %w", err)
+	}
+	return id, true, nil
 }
 
 func sessionExecutorGroupAddFromEnv() []string {
@@ -1327,21 +1358,55 @@ func buildServices(
 	}
 	identityResolver.SetUsers(userStore)
 	identityResolver.SetIntegrations(integrationStore)
-	var sandboxAuthServer *sandboxauth.Server
+	var (
+		sandboxAuthBroker       *sandboxauth.Broker
+		orchestratorSandboxAuth agent.SandboxAuthServer
+		prSandboxAuth           agent.SandboxAuthServer
+	)
 	if cfg.SandboxAuthSocketDir != "" {
-		if cfg.Env == "production" {
-			if err := sandboxauth.ValidateSocketDirForStartup(cfg.SandboxAuthSocketDir); err != nil {
-				logger.Error().
-					Err(err).
-					Str("socket_dir", cfg.SandboxAuthSocketDir).
-					Msg("sandbox auth: socket directory preflight failed — worker services disabled")
+		if executorID, ok, err := sessionExecutorIDFromEnv(); err != nil {
+			logger.Error().Err(err).Msg("sandbox auth: invalid session executor id — worker services disabled")
+			return nil
+		} else if ok {
+			if strings.TrimSpace(cfg.PreviewInternalBaseURL) == "" {
+				logger.Error().Msg("sandbox auth: PREVIEW_INTERNAL_BASE_URL is required for session executor remote broker access")
 				return nil
 			}
+			previewRPCKeyring, keyringErr := auth.NewPreviewTokenKeyring(cfg.PreviewRPCSecrets)
+			if keyringErr != nil {
+				logger.Error().Err(keyringErr).Msg("sandbox auth: preview RPC keyring is required for session executor remote broker access")
+				return nil
+			}
+			orchestratorSandboxAuth = sandboxauth.NewRemoteBrokerClient(sandboxauth.RemoteBrokerClientConfig{
+				BaseURL:  cfg.PreviewInternalBaseURL,
+				NodeID:   cfg.NodeID,
+				HolderID: executorID,
+				Keyring:  previewRPCKeyring,
+				Logger:   logger,
+			})
+			prSandboxAuth = orchestratorSandboxAuth
+			logger.Info().
+				Str("worker_base_url", cfg.PreviewInternalBaseURL).
+				Str("executor_id", executorID.String()).
+				Msg("sandbox auth: session executor will use worker-owned remote broker")
+		} else {
+			if cfg.Env == "production" {
+				if err := sandboxauth.ValidateSocketDirForStartup(cfg.SandboxAuthSocketDir); err != nil {
+					logger.Error().
+						Err(err).
+						Str("socket_dir", cfg.SandboxAuthSocketDir).
+						Msg("sandbox auth: socket directory preflight failed — worker services disabled")
+					return nil
+				}
+			}
+			sandboxAuthServer := sandboxauth.NewServer(identityResolver, cfg.SandboxAuthSocketDir, logger)
+			sandboxAuthBroker = sandboxauth.NewBroker(sandboxAuthServer, sessionStore, repoStore, orgStore, logger)
+			orchestratorSandboxAuth = sandboxauth.NewLeaseClient(sandboxAuthBroker, "worker-orchestrator", logger)
+			prSandboxAuth = sandboxauth.NewLeaseClient(sandboxAuthBroker, "worker-pr", logger)
+			logger.Info().
+				Str("socket_dir", cfg.SandboxAuthSocketDir).
+				Msg("sandbox auth: worker-owned credential socket broker enabled")
 		}
-		sandboxAuthServer = sandboxauth.NewServer(identityResolver, cfg.SandboxAuthSocketDir, logger)
-		logger.Info().
-			Str("socket_dir", cfg.SandboxAuthSocketDir).
-			Msg("sandbox auth: per-session credential socket bridge enabled")
 	} else {
 		logger.Warn().
 			Msg("sandbox auth: SANDBOX_AUTH_SOCKET_DIR is empty; per-session credential socket disabled — sandbox `git push` will require GITHUB_TOKEN env fallback")
@@ -1387,7 +1452,7 @@ func buildServices(
 		ThreadCancels:      threadCancelRegistry,
 		OrgSettingsCache:   orgSettingsCache,
 		IdentityResolver:   identityResolver,
-		SandboxAuth:        sandboxAuthServer,
+		SandboxAuth:        orchestratorSandboxAuth,
 		Users:              userStore,
 		EvalBootstraps:     evalBootstrapStore,
 		InternalAPIURL:     cfg.BaseURL + "/api/v1/internal",
@@ -1406,7 +1471,7 @@ func buildServices(
 		prService,
 		sandboxProvider,
 		snapshotStore,
-		sandboxAuthServer,
+		prSandboxAuth,
 		integrationStore,
 		userCredentialStore,
 		appUserAuthSvc,
@@ -1568,26 +1633,27 @@ func buildServices(
 	}
 
 	svc := &worker.Services{
-		Orchestrator:    orchestrator,
-		PR:              prService,
-		Failure:         failureSvc,
-		SandboxProvider: sandboxProvider,
-		ProjectTasks:    projectTaskUpdater,
-		AutomationRuns:  automationRunUpdater,
-		Prioritization:  prioritizationSvc,
-		PM:              pmSvc,
-		SlackSummarizer: slackSummarizer,
-		LLM:             llmClient,
-		GitHub:          ghSvc,
-		GitHubOrgRoster: ghSvc,
-		Snapshots:       snapshotStore,
-		TitleService:    titleService,
-		Linear:          linearService,
-		SlackbotMetrics: workerSlackbotMetrics,
-		FrontendURL:     cfg.FrontendURL,
-		ReviewLoops:     reviewLoopSvc,
-		RuntimeSampler:  runtimeSampler,
-		SandboxGC:       sandboxGC,
+		Orchestrator:      orchestrator,
+		PR:                prService,
+		Failure:           failureSvc,
+		SandboxProvider:   sandboxProvider,
+		ProjectTasks:      projectTaskUpdater,
+		AutomationRuns:    automationRunUpdater,
+		Prioritization:    prioritizationSvc,
+		PM:                pmSvc,
+		SlackSummarizer:   slackSummarizer,
+		LLM:               llmClient,
+		GitHub:            ghSvc,
+		GitHubOrgRoster:   ghSvc,
+		Snapshots:         snapshotStore,
+		TitleService:      titleService,
+		Linear:            linearService,
+		SlackbotMetrics:   workerSlackbotMetrics,
+		FrontendURL:       cfg.FrontendURL,
+		ReviewLoops:       reviewLoopSvc,
+		RuntimeSampler:    runtimeSampler,
+		SandboxGC:         sandboxGC,
+		SandboxAuthBroker: sandboxAuthBroker,
 	}
 	configureSessionExecutorDispatch(svc, cfg, pool, dockerCli, jobStore, logger)
 
@@ -1622,12 +1688,12 @@ func buildServices(
 			Logger:  logger,
 		}
 	}
-	if sandboxAuthServer != nil {
+	if sandboxAuthBroker != nil {
 		// Capture by value: the closure outlives buildServices, but the
-		// *Server pointer is stable for the process lifetime.
-		s := sandboxAuthServer
-		svc.SandboxAuthShutdown = s.Shutdown
-		svc.SandboxAuthSweep = s.SweepStaleSessionDirs
+		// *Broker pointer is stable for the process lifetime.
+		b := sandboxAuthBroker
+		svc.SandboxAuthShutdown = b.Shutdown
+		svc.SandboxAuthSweep = b.SweepStaleSessionDirs
 	}
 	return svc
 }

--- a/cmd/server/main_test.go
+++ b/cmd/server/main_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/require"
 
@@ -401,6 +402,25 @@ func TestSessionExecutorBindsIncludeStaticEgressCapabilityMount(t *testing.T) {
 	require.Equal(t, expected, sessionExecutorBinds(), "session executors should mount every host resource needed for sandbox creation")
 }
 
+func TestSessionExecutorIDFromEnv(t *testing.T) {
+	t.Setenv("SESSION_EXECUTOR_ID", "")
+	id, ok, err := sessionExecutorIDFromEnv()
+	require.NoError(t, err, "empty SESSION_EXECUTOR_ID should not error")
+	require.False(t, ok, "empty SESSION_EXECUTOR_ID should report no session executor")
+	require.Equal(t, uuid.Nil, id, "empty SESSION_EXECUTOR_ID should return nil uuid")
+
+	t.Setenv("SESSION_EXECUTOR_ID", "2af66543-71df-4d0c-911c-f2c77accaf4b")
+	id, ok, err = sessionExecutorIDFromEnv()
+	require.NoError(t, err, "valid SESSION_EXECUTOR_ID should parse")
+	require.True(t, ok, "valid SESSION_EXECUTOR_ID should report session executor mode")
+	require.Equal(t, "2af66543-71df-4d0c-911c-f2c77accaf4b", id.String(), "valid SESSION_EXECUTOR_ID should return parsed uuid")
+
+	t.Setenv("SESSION_EXECUTOR_ID", "not-a-uuid")
+	_, ok, err = sessionExecutorIDFromEnv()
+	require.Error(t, err, "invalid SESSION_EXECUTOR_ID should error")
+	require.True(t, ok, "invalid non-empty SESSION_EXECUTOR_ID should still report executor intent")
+}
+
 func TestBuildWorkerMetadataProvider_IncludesSandboxCapacity(t *testing.T) {
 	t.Parallel()
 
@@ -435,6 +455,37 @@ func TestMainStartupRunsRehydrateBeforeWorkers(t *testing.T) {
 	require.NotEqual(t, -1, startWorkers, "startup should still start process workers")
 	require.NotEqual(t, -1, rehydrate, "startup should still run sandbox auth rehydrate")
 	require.Less(t, rehydrate, startWorkers, "sandbox auth rehydrate/sweep must run before process workers can claim jobs")
+}
+
+func TestMainRegistersInternalSandboxAuthBrokerBeforeWorkers(t *testing.T) {
+	t.Parallel()
+
+	src, err := os.ReadFile("main.go")
+	require.NoError(t, err, "main.go should be readable for startup ordering regression test")
+
+	body := string(src)
+	registerBroker := strings.Index(body, "registerInternalSandboxAuthRoutes(router, services.SandboxAuthBroker")
+	startWorkers := strings.Index(body, "processWorkers = startProcessWorkers(")
+	require.NotEqual(t, -1, registerBroker, "startup should register internal sandbox auth broker routes")
+	require.NotEqual(t, -1, startWorkers, "startup should still start process workers")
+	require.Less(t, registerBroker, startWorkers, "internal sandbox auth broker routes must exist before session executors can be launched")
+}
+
+func TestBuildServicesSessionExecutorUsesRemoteSandboxAuthBroker(t *testing.T) {
+	t.Parallel()
+
+	src, err := os.ReadFile("main.go")
+	require.NoError(t, err, "main.go should be readable for sandbox auth broker wiring regression test")
+
+	body := string(src)
+	roleDetect := strings.Index(body, "sessionExecutorIDFromEnv()")
+	remoteClient := strings.Index(body, "sandboxauth.NewRemoteBrokerClient")
+	localServer := strings.Index(body, "sandboxauth.NewServer")
+	require.NotEqual(t, -1, roleDetect, "buildServices should detect session executor role")
+	require.NotEqual(t, -1, remoteClient, "session executors should use the remote sandbox auth broker client")
+	require.NotEqual(t, -1, localServer, "long-lived workers should still construct the local socket server")
+	require.Less(t, roleDetect, remoteClient, "session executor role detection should happen before constructing the remote broker client")
+	require.Less(t, remoteClient, localServer, "session executor branch should avoid falling through to local socket server construction")
 }
 
 func TestBuildServicesWiresLinearAgentWorkerDepsWithoutFeatureFlagGate(t *testing.T) {

--- a/docs/design/implemented/82-durable-session-executors.md
+++ b/docs/design/implemented/82-durable-session-executors.md
@@ -1,6 +1,6 @@
 # Durable Session Executors
 
-> **Status:** Enabled by default for worker-dispatched session turns | **Last reviewed:** 2026-05-28
+> **Status:** Enabled by default for worker-dispatched session turns | **Last reviewed:** 2026-06-16
 
 Long-running `run_agent` and `continue_session` jobs should not be owned by the deployable worker process for the full turn. The durable executor design splits workers into short-lived dispatchers and per-session executor containers that own one active session turn until it completes, checkpoints, drains, or fails.
 
@@ -19,6 +19,7 @@ Long-running `run_agent` and `continue_session` jobs should not be owned by the 
 - The handoff dispatcher creates an executor row, launches a Docker executor container, transfers the running job to `owner_kind=session_executor`, and preserves the existing `lock_token`. Launch and handoff failures mark the reserved executor failed; a launched container is force-removed if handoff does not land.
 - Worker poll treats `HandoffError` as successful dispatch and skips terminal writes.
 - `session-executor` is a first-class binary entrypoint that reuses the worker orchestrator dependencies without starting the API/router.
+- Session executors do not own sandbox GitHub auth socket listeners. They use signed worker RPC to acquire and release holder leases from the worker-owned sandbox auth broker, which keeps `/var/run/143/sandbox-auth/<session>/sock` alive until the final active holder releases.
 - Executor boot validates the executor row, running job state, `owner_kind=session_executor`, and matching lock token. It waits briefly for the dispatcher handoff to become visible because the container is launched before the handoff update.
 - Executors heartbeat every 10s, renew the job lease every 20s, and fence terminal writes by the preserved lock token plus executor owner id. Final job writes use bounded contexts detached from process SIGTERM so graceful exits can persist terminal state.
 - Executor SIGTERM marks the row `draining` and asks the orchestrator cancel registry for a typed `worker_drain` graceful stop. This path is explicitly not a user cancel: a drain interruption restores a retryable session status, records `runtime_stop_reason='worker_drain'`, snapshots the workspace when possible without advancing `current_turn`, and requeues the original job instead of closing it as succeeded or terminally marking the session `cancelled`.

--- a/docs/design/implemented/88-shared-sandbox-thread-runtimes.md
+++ b/docs/design/implemented/88-shared-sandbox-thread-runtimes.md
@@ -1,6 +1,6 @@
 # Design: Shared Sandbox Thread Runtimes
 
-> **Status:** Implemented | **Last reviewed:** 2026-05-27
+> **Status:** Implemented | **Last reviewed:** 2026-06-16
 >
 > **Related docs:** [overall.md](../overall.md), [68-sandbox-agent-tabs-and-threads.md](68-sandbox-agent-tabs-and-threads.md), [75-thread-runtime-handles-and-durable-inbox.md](../future/75-thread-runtime-handles-and-durable-inbox.md), [70-live-agent-command-handles.md](../future/70-live-agent-command-handles.md), [82-durable-session-executors.md](82-durable-session-executors.md), [60-agent-runtime-timeouts-and-checkpointed-shutdown.md](../future/60-agent-runtime-timeouts-and-checkpointed-shutdown.md), [44-sandbox-preview-server.md](44-sandbox-preview-server.md)
 
@@ -53,6 +53,9 @@ Implemented:
   generations, and terminal runtime status.
 - `session_sandbox_holders` stores leased holders for shared sandbox lifetime
   coordination.
+- sandbox GitHub auth sockets are leased through the worker-owned auth broker,
+  so one sibling runtime or executor finishing cannot close the shared
+  session socket while other holders still need `143-tools` GitHub auth.
 - thread message sends append durable inbox entries before worker enqueue when
   the thread service is wired with `ThreadInboxStore`.
 - same-thread sends to a running tab enqueue `deliver_thread_inbox` as a

--- a/docs/design/overall.md
+++ b/docs/design/overall.md
@@ -71,7 +71,7 @@ Vector -> VictoriaLogs / Grafana for centralized logs, dashboards, and alerts
 ### Runtime Plane
 
 - Workers run coding-agent jobs, continuation turns, preview starts, ingestion syncs, PM planning, automations, and repair work.
-- Sandboxes are the permission boundary for agent execution. They run with resource limits, gVisor isolation in production, controlled network policy, and per-session GitHub credential access through host-managed helpers rather than long-lived tokens in the container environment.
+- Sandboxes are the permission boundary for agent execution. They run with resource limits, gVisor isolation in production, controlled network policy, and per-session GitHub credential access through a worker-owned auth broker rather than long-lived tokens in the container environment.
 - The sandbox image installs the supported coding-agent CLIs, including Codex, Claude Code, OpenCode, Amp, and Pi. Runtime credentials are resolved from ordered personal/team auth stacks with health and rate-limit state tracked separately from credential config.
 - Long-running sessions survive routine deploys through durable session executors, leases, checkpointed recovery, snapshots, and worker drain/spin-down controls. See [implemented/82-durable-session-executors.md](implemented/82-durable-session-executors.md).
 - Multiple agent tabs can run inside one shared session sandbox when they should share a branch and filesystem. Independent PR streams should remain separate sessions. See [implemented/88-shared-sandbox-thread-runtimes.md](implemented/88-shared-sandbox-thread-runtimes.md).

--- a/internal/api/handlers/internal_sandbox_auth.go
+++ b/internal/api/handlers/internal_sandbox_auth.go
@@ -1,0 +1,160 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/rs/zerolog"
+
+	"github.com/assembledhq/143/internal/auth"
+	"github.com/assembledhq/143/internal/models"
+	"github.com/assembledhq/143/internal/services/sandboxauth"
+)
+
+type InternalSandboxAuthBroker interface {
+	Acquire(ctx context.Context, orgID, sessionID, holderID uuid.UUID) (string, error)
+	Release(ctx context.Context, orgID, sessionID, holderID uuid.UUID) error
+}
+
+type InternalSandboxAuthHandler struct {
+	broker  InternalSandboxAuthBroker
+	nodeID  string
+	keyring auth.PreviewTokenKeyring
+	logger  zerolog.Logger
+}
+
+func NewInternalSandboxAuthHandler(broker InternalSandboxAuthBroker, nodeID string, keyring auth.PreviewTokenKeyring, logger zerolog.Logger) *InternalSandboxAuthHandler {
+	return &InternalSandboxAuthHandler{
+		broker:  broker,
+		nodeID:  nodeID,
+		keyring: keyring,
+		logger:  logger,
+	}
+}
+
+func (h *InternalSandboxAuthHandler) Acquire(w http.ResponseWriter, r *http.Request) {
+	claims, ok := h.authorize(w, r, sandboxauth.BrokerActionAcquire)
+	if !ok {
+		return
+	}
+	var body sandboxauth.BrokerAcquireRequest
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeError(w, r, http.StatusBadRequest, "INVALID_BODY", "invalid request body", err)
+		return
+	}
+	if !h.validateRequestScope(w, r, claims, body.OrgID, body.SessionID, body.HolderID) {
+		return
+	}
+	if h.broker == nil {
+		writeError(w, r, http.StatusServiceUnavailable, "SANDBOX_AUTH_BROKER_UNAVAILABLE", "sandbox auth broker is not configured")
+		return
+	}
+	socketPath, err := h.broker.Acquire(r.Context(), body.OrgID, body.SessionID, body.HolderID)
+	if err != nil {
+		writeError(w, r, http.StatusInternalServerError, "SANDBOX_AUTH_ACQUIRE_FAILED", "failed to acquire sandbox auth socket", err)
+		return
+	}
+	writeJSON(w, http.StatusOK, models.SingleResponse[sandboxauth.BrokerAcquireResponse]{
+		Data: sandboxauth.BrokerAcquireResponse{SocketPath: socketPath},
+	})
+}
+
+func (h *InternalSandboxAuthHandler) Release(w http.ResponseWriter, r *http.Request) {
+	claims, ok := h.authorize(w, r, sandboxauth.BrokerActionRelease)
+	if !ok {
+		return
+	}
+	var body sandboxauth.BrokerReleaseRequest
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeError(w, r, http.StatusBadRequest, "INVALID_BODY", "invalid request body", err)
+		return
+	}
+	if !h.validateRequestScope(w, r, claims, body.OrgID, body.SessionID, body.HolderID) {
+		return
+	}
+	if h.broker == nil {
+		writeError(w, r, http.StatusServiceUnavailable, "SANDBOX_AUTH_BROKER_UNAVAILABLE", "sandbox auth broker is not configured")
+		return
+	}
+	if err := h.broker.Release(r.Context(), body.OrgID, body.SessionID, body.HolderID); err != nil {
+		writeError(w, r, http.StatusInternalServerError, "SANDBOX_AUTH_RELEASE_FAILED", "failed to release sandbox auth socket", err)
+		return
+	}
+	writeJSON(w, http.StatusOK, models.SingleResponse[sandboxauth.BrokerReleaseResponse]{
+		Data: sandboxauth.BrokerReleaseResponse{Released: true},
+	})
+}
+
+func (h *InternalSandboxAuthHandler) authorize(w http.ResponseWriter, r *http.Request, action string) (*auth.PreviewTokenClaims, bool) {
+	tokenStr := strings.TrimSpace(strings.TrimPrefix(r.Header.Get("Authorization"), "Bearer "))
+	if tokenStr == "" {
+		markPreviewWorkerError(w)
+		w.Header().Set(auth.PreviewWorkerAuthDetailHeader, "missing")
+		h.logAuthorizationRejected(r, "missing_token", action, nil, nil)
+		writeError(w, r, http.StatusUnauthorized, "UNAUTHORIZED", "missing authorization token")
+		return nil, false
+	}
+	claims, err := h.keyring.Validate(tokenStr)
+	if err != nil {
+		markPreviewWorkerError(w)
+		w.Header().Set(auth.PreviewWorkerAuthDetailHeader, auth.ClassifyPreviewTokenError(err))
+		h.logAuthorizationRejected(r, "invalid_token", action, nil, err)
+		writeError(w, r, http.StatusUnauthorized, "UNAUTHORIZED", "invalid sandbox auth token", err)
+		return nil, false
+	}
+	if claims.TargetNodeID != h.nodeID {
+		markPreviewWorkerError(w)
+		h.logAuthorizationRejected(r, "wrong_worker", action, claims, nil)
+		writeError(w, r, http.StatusForbidden, "WRONG_SANDBOX_AUTH_WORKER", "sandbox auth token targets a different worker")
+		return nil, false
+	}
+	if claims.Action != action {
+		markPreviewWorkerError(w)
+		h.logAuthorizationRejected(r, "action_mismatch", action, claims, nil)
+		writeError(w, r, http.StatusForbidden, "SANDBOX_AUTH_ACTION_MISMATCH", "sandbox auth token is not valid for this action")
+		return nil, false
+	}
+	return claims, true
+}
+
+func (h *InternalSandboxAuthHandler) validateRequestScope(w http.ResponseWriter, r *http.Request, claims *auth.PreviewTokenClaims, orgID, sessionID, holderID uuid.UUID) bool {
+	if orgID == uuid.Nil {
+		writeError(w, r, http.StatusBadRequest, "INVALID_ORG_ID", "org id is required")
+		return false
+	}
+	if sessionID == uuid.Nil {
+		writeError(w, r, http.StatusBadRequest, "INVALID_SESSION_ID", "session id is required")
+		return false
+	}
+	if holderID == uuid.Nil {
+		writeError(w, r, http.StatusBadRequest, "INVALID_HOLDER_ID", "holder id is required")
+		return false
+	}
+	if claims.OrgID != orgID {
+		writeError(w, r, http.StatusForbidden, "ORG_MISMATCH", "sandbox auth token org does not match request")
+		return false
+	}
+	if claims.SessionID == nil || *claims.SessionID != sessionID {
+		writeError(w, r, http.StatusForbidden, "SESSION_MISMATCH", "sandbox auth token does not match the requested session")
+		return false
+	}
+	return true
+}
+
+func (h *InternalSandboxAuthHandler) logAuthorizationRejected(r *http.Request, failureKind, requestedAction string, claims *auth.PreviewTokenClaims, err error) {
+	event := h.logger.Warn()
+	if err != nil {
+		event = event.Err(err)
+	}
+	event = addInternalPreviewRequestLogFields(event, r).
+		Str("failure_kind", failureKind).
+		Str("requested_sandbox_auth_action", requestedAction).
+		Str("local_worker_node_id", h.nodeID)
+	if claims != nil {
+		event = addPreviewTokenClaimLogFields(event, claims)
+	}
+	event.Msg("internal sandbox auth authorization rejected")
+}

--- a/internal/api/handlers/internal_sandbox_auth_test.go
+++ b/internal/api/handlers/internal_sandbox_auth_test.go
@@ -1,0 +1,198 @@
+package handlers
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/require"
+
+	"github.com/assembledhq/143/internal/auth"
+	"github.com/assembledhq/143/internal/models"
+	"github.com/assembledhq/143/internal/services/sandboxauth"
+)
+
+type internalSandboxAuthBrokerStub struct {
+	acquirePath string
+	acquireErr  error
+	releaseErr  error
+
+	acquireCalls int
+	releaseCalls int
+	orgID        uuid.UUID
+	sessionID    uuid.UUID
+	holderID     uuid.UUID
+}
+
+func (s *internalSandboxAuthBrokerStub) Acquire(_ context.Context, orgID, sessionID, holderID uuid.UUID) (string, error) {
+	s.acquireCalls++
+	s.orgID = orgID
+	s.sessionID = sessionID
+	s.holderID = holderID
+	if s.acquireErr != nil {
+		return "", s.acquireErr
+	}
+	return s.acquirePath, nil
+}
+
+func (s *internalSandboxAuthBrokerStub) Release(_ context.Context, orgID, sessionID, holderID uuid.UUID) error {
+	s.releaseCalls++
+	s.orgID = orgID
+	s.sessionID = sessionID
+	s.holderID = holderID
+	return s.releaseErr
+}
+
+func newInternalSandboxAuthTestHandler(t *testing.T, broker *internalSandboxAuthBrokerStub) (*InternalSandboxAuthHandler, auth.PreviewTokenKeyring) {
+	t.Helper()
+	keyring, err := auth.NewPreviewTokenKeyring([]string{"worker-secret"})
+	require.NoError(t, err, "test keyring should be valid")
+	return NewInternalSandboxAuthHandler(broker, "worker-1", keyring, zerolog.Nop()), keyring
+}
+
+func signedSandboxAuthRequest(t *testing.T, keyring auth.PreviewTokenKeyring, action string, claimsOrgID, claimsSessionID uuid.UUID, body any) *http.Request {
+	t.Helper()
+	payload, err := json.Marshal(body)
+	require.NoError(t, err, "test request body should marshal")
+	token, err := keyring.Generate(auth.PreviewTokenClaims{
+		OrgID:        claimsOrgID,
+		TargetNodeID: "worker-1",
+		SessionID:    &claimsSessionID,
+		Action:       action,
+		ExpiresAt:    time.Now().Add(time.Minute),
+	})
+	require.NoError(t, err, "test token should sign")
+	req := httptest.NewRequest(http.MethodPost, "/internal/sandbox-auth/acquire", bytes.NewReader(payload))
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Content-Type", "application/json")
+	return req
+}
+
+func TestInternalSandboxAuthHandler_AcquireAndRelease(t *testing.T) {
+	t.Parallel()
+
+	orgID := uuid.New()
+	sessionID := uuid.New()
+	holderID := uuid.New()
+	socketPath := "/var/run/143/sandbox-auth/" + sessionID.String() + "/sock"
+	broker := &internalSandboxAuthBrokerStub{acquirePath: socketPath}
+	handler, keyring := newInternalSandboxAuthTestHandler(t, broker)
+
+	acquireReq := signedSandboxAuthRequest(t, keyring, "sandbox_auth_acquire", orgID, sessionID, sandboxauth.BrokerAcquireRequest{
+		OrgID:     orgID,
+		SessionID: sessionID,
+		HolderID:  holderID,
+	})
+	acquireRR := httptest.NewRecorder()
+	handler.Acquire(acquireRR, acquireReq)
+	require.Equal(t, http.StatusOK, acquireRR.Code, "Acquire should return 200 for a valid signed request")
+	var acquireResp models.SingleResponse[sandboxauth.BrokerAcquireResponse]
+	require.NoError(t, json.Unmarshal(acquireRR.Body.Bytes(), &acquireResp), "Acquire response should be valid JSON")
+	require.Equal(t, socketPath, acquireResp.Data.SocketPath, "Acquire should return the broker socket path")
+	require.Equal(t, 1, broker.acquireCalls, "Acquire should call the broker once")
+	require.Equal(t, holderID, broker.holderID, "Acquire should pass the holder id to the broker")
+
+	releaseReq := signedSandboxAuthRequest(t, keyring, "sandbox_auth_release", orgID, sessionID, sandboxauth.BrokerReleaseRequest{
+		OrgID:     orgID,
+		SessionID: sessionID,
+		HolderID:  holderID,
+	})
+	releaseRR := httptest.NewRecorder()
+	handler.Release(releaseRR, releaseReq)
+	require.Equal(t, http.StatusOK, releaseRR.Code, "Release should return 200 for a valid signed request")
+	var releaseResp models.SingleResponse[sandboxauth.BrokerReleaseResponse]
+	require.NoError(t, json.Unmarshal(releaseRR.Body.Bytes(), &releaseResp), "Release response should be valid JSON")
+	require.True(t, releaseResp.Data.Released, "Release should acknowledge a successful release")
+	require.Equal(t, 1, broker.releaseCalls, "Release should call the broker once")
+	require.Equal(t, holderID, broker.holderID, "Release should pass the holder id to the broker")
+}
+
+func TestInternalSandboxAuthHandler_AcquireRejectsInvalidRequests(t *testing.T) {
+	t.Parallel()
+
+	orgID := uuid.New()
+	sessionID := uuid.New()
+	holderID := uuid.New()
+	broker := &internalSandboxAuthBrokerStub{acquirePath: "/tmp/sock"}
+	handler, keyring := newInternalSandboxAuthTestHandler(t, broker)
+
+	tests := []struct {
+		name           string
+		tokenAction    string
+		tokenOrgID     uuid.UUID
+		tokenSessionID uuid.UUID
+		body           sandboxauth.BrokerAcquireRequest
+		expectedStatus int
+	}{
+		{
+			name:           "wrong action",
+			tokenAction:    "sandbox_auth_release",
+			tokenOrgID:     orgID,
+			tokenSessionID: sessionID,
+			body:           sandboxauth.BrokerAcquireRequest{OrgID: orgID, SessionID: sessionID, HolderID: holderID},
+			expectedStatus: http.StatusForbidden,
+		},
+		{
+			name:           "org mismatch",
+			tokenAction:    "sandbox_auth_acquire",
+			tokenOrgID:     uuid.New(),
+			tokenSessionID: sessionID,
+			body:           sandboxauth.BrokerAcquireRequest{OrgID: orgID, SessionID: sessionID, HolderID: holderID},
+			expectedStatus: http.StatusForbidden,
+		},
+		{
+			name:           "session mismatch",
+			tokenAction:    "sandbox_auth_acquire",
+			tokenOrgID:     orgID,
+			tokenSessionID: uuid.New(),
+			body:           sandboxauth.BrokerAcquireRequest{OrgID: orgID, SessionID: sessionID, HolderID: holderID},
+			expectedStatus: http.StatusForbidden,
+		},
+		{
+			name:           "zero holder",
+			tokenAction:    "sandbox_auth_acquire",
+			tokenOrgID:     orgID,
+			tokenSessionID: sessionID,
+			body:           sandboxauth.BrokerAcquireRequest{OrgID: orgID, SessionID: sessionID},
+			expectedStatus: http.StatusBadRequest,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			req := signedSandboxAuthRequest(t, keyring, tt.tokenAction, tt.tokenOrgID, tt.tokenSessionID, tt.body)
+			rr := httptest.NewRecorder()
+			handler.Acquire(rr, req)
+			require.Equal(t, tt.expectedStatus, rr.Code, "Acquire should reject invalid signed requests before broker mutation")
+		})
+	}
+}
+
+func TestInternalSandboxAuthHandler_ReleaseSurfacesBrokerError(t *testing.T) {
+	t.Parallel()
+
+	orgID := uuid.New()
+	sessionID := uuid.New()
+	holderID := uuid.New()
+	broker := &internalSandboxAuthBrokerStub{releaseErr: errors.New("lost broker")}
+	handler, keyring := newInternalSandboxAuthTestHandler(t, broker)
+	req := signedSandboxAuthRequest(t, keyring, "sandbox_auth_release", orgID, sessionID, sandboxauth.BrokerReleaseRequest{
+		OrgID:     orgID,
+		SessionID: sessionID,
+		HolderID:  holderID,
+	})
+
+	rr := httptest.NewRecorder()
+	handler.Release(rr, req)
+	require.Equal(t, http.StatusInternalServerError, rr.Code, "Release should surface broker release failures")
+	require.Equal(t, 1, broker.releaseCalls, "Release should call broker before surfacing the failure")
+}

--- a/internal/api/handlers/org_id_lint_test.go
+++ b/internal/api/handlers/org_id_lint_test.go
@@ -62,6 +62,8 @@ func TestHandlersMustUseOrgIDFromContext(t *testing.T) {
 		"InternalSessionTabsHandler.SendMessage": "internal sandbox API, uses claims.OrgID and claims.SessionID",
 		"InternalSessionTabsHandler.Messages":    "internal sandbox API, uses claims.OrgID and claims.SessionID",
 		"InternalPreviewHandler.AuthCheck":       "internal worker deploy compatibility probe; validates signed target-node token and reads no org-scoped data",
+		"InternalSandboxAuthHandler.Acquire":     "internal worker RPC, uses signed token claims.OrgID plus claims.SessionID and holder id",
+		"InternalSandboxAuthHandler.Release":     "internal worker RPC, uses signed token claims.OrgID plus claims.SessionID and holder id",
 
 		// Authenticated but legitimately no org-scoped data access.
 		"AuthHandler.Me":                       "returns user from context only",

--- a/internal/services/agent/sandbox_auth_rehydrate.go
+++ b/internal/services/agent/sandbox_auth_rehydrate.go
@@ -46,6 +46,10 @@ type ContainerHoldingSessionLister interface {
 // matters — a wrong value persists until the next turn boundary.
 type OrgSettingsLoader func(ctx context.Context, orgID uuid.UUID) (models.OrgSettings, error)
 
+type SandboxAuthRehydrater interface {
+	Rehydrate(ctx context.Context, sessionID uuid.UUID, run *models.Session, repo *models.Repository, orgSettings models.OrgSettings) (socketPath string, err error)
+}
+
 // RehydrateSandboxAuthListeners is a one-shot startup pass that re-opens the
 // per-session GitHub credential socket listener for sessions whose containers
 // are still alive across a worker restart (preview holds keep them running).
@@ -181,8 +185,14 @@ func RehydrateSandboxAuthListeners(
 				settings = loaded
 			}
 
-			if _, err := sandboxAuth.Listen(ctx, run.ID, run, &repo, settings); err != nil {
-				rowLog.Warn().Err(err).
+			var listenErr error
+			if rehydrater, ok := sandboxAuth.(SandboxAuthRehydrater); ok {
+				_, listenErr = rehydrater.Rehydrate(ctx, run.ID, run, &repo, settings)
+			} else {
+				_, listenErr = sandboxAuth.Listen(ctx, run.ID, run, &repo, settings)
+			}
+			if listenErr != nil {
+				rowLog.Warn().Err(listenErr).
 					Str("container_id", containerID).
 					Msg("rehydrate: failed to re-open sandbox auth socket; next turn boundary will retry")
 				totalErrored++

--- a/internal/services/sandboxauth/broker.go
+++ b/internal/services/sandboxauth/broker.go
@@ -1,0 +1,331 @@
+package sandboxauth
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	"github.com/google/uuid"
+	"github.com/rs/zerolog"
+
+	"github.com/assembledhq/143/internal/models"
+)
+
+type brokerSocketServer interface {
+	Listen(ctx context.Context, sessionID uuid.UUID, run *models.Session, repo *models.Repository, orgSettings models.OrgSettings) (socketPath string, err error)
+	Close(sessionID uuid.UUID)
+	Shutdown()
+	SweepStaleSessionDirs(keep map[uuid.UUID]struct{})
+}
+
+type BrokerSessionStore interface {
+	GetByID(ctx context.Context, orgID, sessionID uuid.UUID) (models.Session, error)
+}
+
+type BrokerRepositoryStore interface {
+	GetByID(ctx context.Context, orgID, repoID uuid.UUID) (models.Repository, error)
+}
+
+type BrokerOrganizationStore interface {
+	GetByID(ctx context.Context, orgID uuid.UUID) (models.Organization, error)
+}
+
+// Broker is the worker-owned lease manager for sandbox GitHub auth sockets.
+// It keeps socket listener ownership in the long-lived worker process while
+// session executors and direct worker callers hold explicit leases. A session
+// socket closes only after the final holder releases, so one runtime ending
+// cannot unlink the socket out from under a sibling tab or PR push.
+type Broker struct {
+	server       brokerSocketServer
+	sessions     BrokerSessionStore
+	repositories BrokerRepositoryStore
+	orgs         BrokerOrganizationStore
+	logger       zerolog.Logger
+
+	mu     sync.Mutex
+	active map[uuid.UUID]*brokerEntry
+}
+
+type brokerEntry struct {
+	orgID      uuid.UUID
+	socketPath string
+	holders    map[uuid.UUID]int
+}
+
+func NewBroker(
+	server brokerSocketServer,
+	sessions BrokerSessionStore,
+	repositories BrokerRepositoryStore,
+	orgs BrokerOrganizationStore,
+	logger zerolog.Logger,
+) *Broker {
+	return &Broker{
+		server:       server,
+		sessions:     sessions,
+		repositories: repositories,
+		orgs:         orgs,
+		logger:       logger,
+		active:       make(map[uuid.UUID]*brokerEntry),
+	}
+}
+
+func (b *Broker) Acquire(ctx context.Context, orgID, sessionID, holderID uuid.UUID) (string, error) {
+	if b == nil || b.server == nil {
+		return "", fmt.Errorf("sandboxauth broker is not configured")
+	}
+	if orgID == uuid.Nil {
+		return "", fmt.Errorf("sandboxauth broker acquire: org id is required")
+	}
+	if sessionID == uuid.Nil {
+		return "", fmt.Errorf("sandboxauth broker acquire: session id is required")
+	}
+	if holderID == uuid.Nil {
+		return "", fmt.Errorf("sandboxauth broker acquire: holder id is required")
+	}
+	if socketPath, ok, err := b.attachExisting(orgID, sessionID, holderID); ok || err != nil {
+		return socketPath, err
+	}
+	if b.sessions == nil {
+		return "", fmt.Errorf("sandboxauth broker acquire: session store is not configured")
+	}
+	if b.repositories == nil {
+		return "", fmt.Errorf("sandboxauth broker acquire: repository store is not configured")
+	}
+	if b.orgs == nil {
+		return "", fmt.Errorf("sandboxauth broker acquire: organization store is not configured")
+	}
+
+	run, err := b.sessions.GetByID(ctx, orgID, sessionID)
+	if err != nil {
+		return "", fmt.Errorf("sandboxauth broker acquire: load session: %w", err)
+	}
+	if run.ID != sessionID {
+		return "", fmt.Errorf("sandboxauth broker acquire: loaded session id %s does not match requested session %s", run.ID, sessionID)
+	}
+	if run.OrgID != orgID {
+		return "", fmt.Errorf("sandboxauth broker acquire: loaded session org %s does not match requested org %s", run.OrgID, orgID)
+	}
+	if run.RepositoryID == nil || *run.RepositoryID == uuid.Nil {
+		return "", fmt.Errorf("sandboxauth broker acquire: session has no repository")
+	}
+	repo, err := b.repositories.GetByID(ctx, orgID, *run.RepositoryID)
+	if err != nil {
+		return "", fmt.Errorf("sandboxauth broker acquire: load repository: %w", err)
+	}
+	if repo.OrgID != orgID {
+		return "", fmt.Errorf("sandboxauth broker acquire: loaded repository org %s does not match requested org %s", repo.OrgID, orgID)
+	}
+	org, err := b.orgs.GetByID(ctx, orgID)
+	if err != nil {
+		return "", fmt.Errorf("sandboxauth broker acquire: load organization: %w", err)
+	}
+	settings, err := models.ParseOrgSettings(org.Settings)
+	if err != nil {
+		return "", fmt.Errorf("sandboxauth broker acquire: parse org settings: %w", err)
+	}
+	return b.AcquirePrepared(ctx, sessionID, holderID, &run, &repo, settings)
+}
+
+func (b *Broker) AcquirePrepared(
+	ctx context.Context,
+	sessionID uuid.UUID,
+	holderID uuid.UUID,
+	run *models.Session,
+	repo *models.Repository,
+	orgSettings models.OrgSettings,
+) (string, error) {
+	if holderID == uuid.Nil {
+		return "", fmt.Errorf("sandboxauth broker acquire: holder id is required")
+	}
+	if err := validatePreparedListen(sessionID, run, repo); err != nil {
+		return "", err
+	}
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if entry := b.active[sessionID]; entry != nil {
+		if entry.orgID != run.OrgID {
+			return "", fmt.Errorf("sandboxauth broker acquire: active session org %s does not match requested org %s", entry.orgID, run.OrgID)
+		}
+		entry.holders[holderID]++
+		return entry.socketPath, nil
+	}
+	socketPath, err := b.server.Listen(ctx, sessionID, run, repo, orgSettings)
+	if err != nil {
+		return "", err
+	}
+	b.active[sessionID] = &brokerEntry{
+		orgID:      run.OrgID,
+		socketPath: socketPath,
+		holders:    map[uuid.UUID]int{holderID: 1},
+	}
+	return socketPath, nil
+}
+
+// EnsurePrepared opens a listener for rehydration without taking a lease.
+// The next real holder that acquires the same session attaches to this
+// listener and the listener closes when that holder count drains to zero.
+func (b *Broker) EnsurePrepared(
+	ctx context.Context,
+	sessionID uuid.UUID,
+	run *models.Session,
+	repo *models.Repository,
+	orgSettings models.OrgSettings,
+) (string, error) {
+	if err := validatePreparedListen(sessionID, run, repo); err != nil {
+		return "", err
+	}
+	if b == nil || b.server == nil {
+		return "", fmt.Errorf("sandboxauth broker is not configured")
+	}
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if entry := b.active[sessionID]; entry != nil {
+		if entry.orgID != run.OrgID {
+			return "", fmt.Errorf("sandboxauth broker rehydrate: active session org %s does not match requested org %s", entry.orgID, run.OrgID)
+		}
+		return entry.socketPath, nil
+	}
+	socketPath, err := b.server.Listen(ctx, sessionID, run, repo, orgSettings)
+	if err != nil {
+		return "", err
+	}
+	b.active[sessionID] = &brokerEntry{
+		orgID:      run.OrgID,
+		socketPath: socketPath,
+		holders:    make(map[uuid.UUID]int),
+	}
+	return socketPath, nil
+}
+
+func (b *Broker) Release(ctx context.Context, orgID, sessionID, holderID uuid.UUID) error {
+	_ = ctx
+	if b == nil || b.server == nil {
+		return nil
+	}
+	if orgID == uuid.Nil {
+		return fmt.Errorf("sandboxauth broker release: org id is required")
+	}
+	if sessionID == uuid.Nil {
+		return fmt.Errorf("sandboxauth broker release: session id is required")
+	}
+	if holderID == uuid.Nil {
+		return fmt.Errorf("sandboxauth broker release: holder id is required")
+	}
+
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	entry := b.active[sessionID]
+	if entry == nil {
+		return nil
+	}
+	if entry.orgID != orgID {
+		return fmt.Errorf("sandboxauth broker release: active session org %s does not match requested org %s", entry.orgID, orgID)
+	}
+	b.releaseLocked(sessionID, holderID)
+	return nil
+}
+
+func (b *Broker) ReleaseHolder(sessionID, holderID uuid.UUID) error {
+	if b == nil || b.server == nil {
+		return nil
+	}
+	if sessionID == uuid.Nil {
+		return fmt.Errorf("sandboxauth broker release: session id is required")
+	}
+	if holderID == uuid.Nil {
+		return fmt.Errorf("sandboxauth broker release: holder id is required")
+	}
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.releaseLocked(sessionID, holderID)
+	return nil
+}
+
+func (b *Broker) Shutdown() {
+	if b == nil || b.server == nil {
+		return
+	}
+	b.mu.Lock()
+	for sessionID := range b.active {
+		b.server.Close(sessionID)
+	}
+	b.active = make(map[uuid.UUID]*brokerEntry)
+	b.mu.Unlock()
+	b.server.Shutdown()
+}
+
+func (b *Broker) SweepStaleSessionDirs(keep map[uuid.UUID]struct{}) {
+	if b == nil || b.server == nil {
+		return
+	}
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	merged := make(map[uuid.UUID]struct{}, len(keep)+len(b.active))
+	for id := range keep {
+		merged[id] = struct{}{}
+	}
+	for id := range b.active {
+		merged[id] = struct{}{}
+	}
+	b.server.SweepStaleSessionDirs(merged)
+}
+
+func (b *Broker) attachExisting(orgID, sessionID, holderID uuid.UUID) (string, bool, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	entry := b.active[sessionID]
+	if entry == nil {
+		return "", false, nil
+	}
+	if entry.orgID != orgID {
+		return "", true, fmt.Errorf("sandboxauth broker acquire: active session org %s does not match requested org %s", entry.orgID, orgID)
+	}
+	entry.holders[holderID]++
+	return entry.socketPath, true, nil
+}
+
+func (b *Broker) releaseLocked(sessionID, holderID uuid.UUID) {
+	entry := b.active[sessionID]
+	if entry == nil {
+		return
+	}
+	count := entry.holders[holderID]
+	if count <= 0 {
+		return
+	}
+	if count > 1 {
+		entry.holders[holderID] = count - 1
+		return
+	}
+	delete(entry.holders, holderID)
+	if len(entry.holders) > 0 {
+		return
+	}
+	delete(b.active, sessionID)
+	b.server.Close(sessionID)
+}
+
+func validatePreparedListen(sessionID uuid.UUID, run *models.Session, repo *models.Repository) error {
+	if sessionID == uuid.Nil {
+		return fmt.Errorf("sandboxauth broker listen: session id is required")
+	}
+	if run == nil {
+		return fmt.Errorf("sandboxauth broker listen: session is required")
+	}
+	if repo == nil {
+		return fmt.Errorf("sandboxauth broker listen: repository is required")
+	}
+	if run.ID != sessionID {
+		return fmt.Errorf("sandboxauth broker listen: run id %s does not match session id %s", run.ID, sessionID)
+	}
+	if run.OrgID == uuid.Nil {
+		return fmt.Errorf("sandboxauth broker listen: run org id is required")
+	}
+	if repo.OrgID != uuid.Nil && repo.OrgID != run.OrgID {
+		return fmt.Errorf("sandboxauth broker listen: repo org %s does not match run org %s", repo.OrgID, run.OrgID)
+	}
+	if run.RepositoryID != nil && *run.RepositoryID != uuid.Nil && repo.ID != uuid.Nil && *run.RepositoryID != repo.ID {
+		return fmt.Errorf("sandboxauth broker listen: repo id %s does not match run repository id %s", repo.ID, *run.RepositoryID)
+	}
+	return nil
+}

--- a/internal/services/sandboxauth/broker_protocol.go
+++ b/internal/services/sandboxauth/broker_protocol.go
@@ -1,0 +1,28 @@
+package sandboxauth
+
+import "github.com/google/uuid"
+
+const (
+	BrokerActionAcquire = "sandbox_auth_acquire"
+	BrokerActionRelease = "sandbox_auth_release"
+)
+
+type BrokerAcquireRequest struct {
+	OrgID     uuid.UUID `json:"org_id"`
+	SessionID uuid.UUID `json:"session_id"`
+	HolderID  uuid.UUID `json:"holder_id"`
+}
+
+type BrokerAcquireResponse struct {
+	SocketPath string `json:"socket_path"`
+}
+
+type BrokerReleaseRequest struct {
+	OrgID     uuid.UUID `json:"org_id"`
+	SessionID uuid.UUID `json:"session_id"`
+	HolderID  uuid.UUID `json:"holder_id"`
+}
+
+type BrokerReleaseResponse struct {
+	Released bool `json:"released"`
+}

--- a/internal/services/sandboxauth/broker_test.go
+++ b/internal/services/sandboxauth/broker_test.go
@@ -1,0 +1,287 @@
+package sandboxauth
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/require"
+
+	"github.com/assembledhq/143/internal/models"
+	"github.com/assembledhq/143/internal/services/github/identity"
+)
+
+type brokerSessionStoreStub struct {
+	mu      sync.Mutex
+	session models.Session
+	err     error
+	calls   int
+}
+
+func (s *brokerSessionStoreStub) GetByID(context.Context, uuid.UUID, uuid.UUID) (models.Session, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.calls++
+	if s.err != nil {
+		return models.Session{}, s.err
+	}
+	return s.session, nil
+}
+
+func (s *brokerSessionStoreStub) callCount() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.calls
+}
+
+type brokerRepositoryStoreStub struct {
+	repo models.Repository
+	err  error
+}
+
+func (s *brokerRepositoryStoreStub) GetByID(context.Context, uuid.UUID, uuid.UUID) (models.Repository, error) {
+	if s.err != nil {
+		return models.Repository{}, s.err
+	}
+	return s.repo, nil
+}
+
+type brokerOrganizationStoreStub struct {
+	org models.Organization
+	err error
+}
+
+func (s *brokerOrganizationStoreStub) GetByID(context.Context, uuid.UUID) (models.Organization, error) {
+	if s.err != nil {
+		return models.Organization{}, s.err
+	}
+	return s.org, nil
+}
+
+type lockedResolver struct {
+	mu         sync.Mutex
+	resolution *identity.Resolution
+	calls      int
+}
+
+func (r *lockedResolver) Resolve(context.Context, *models.Session, *models.Repository, models.OrgSettings, string) (*identity.Resolution, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.calls++
+	return r.resolution, nil
+}
+
+func newBrokerTestDeps(t *testing.T) (*Broker, uuid.UUID, uuid.UUID, uuid.UUID, *brokerSessionStoreStub) {
+	t.Helper()
+
+	orgID := uuid.New()
+	sessionID := uuid.New()
+	repoID := uuid.New()
+	sessionStore := &brokerSessionStoreStub{
+		session: models.Session{
+			ID:           sessionID,
+			OrgID:        orgID,
+			RepositoryID: &repoID,
+		},
+	}
+	repoStore := &brokerRepositoryStoreStub{
+		repo: models.Repository{
+			ID:             repoID,
+			OrgID:          orgID,
+			FullName:       "owner/repo",
+			InstallationID: 123,
+		},
+	}
+	settings, err := json.Marshal(models.OrgSettings{PRAuthorship: models.PRAuthorshipAppOnly})
+	require.NoError(t, err, "test org settings should marshal")
+	orgStore := &brokerOrganizationStoreStub{
+		org: models.Organization{ID: orgID, Settings: settings},
+	}
+	resolver := &lockedResolver{resolution: &identity.Resolution{Token: "ghs_test", Source: identity.SourceApp}}
+	server := NewServer(resolver, shortSocketDir(t), zerolog.Nop())
+	t.Cleanup(server.Shutdown)
+	return NewBroker(server, sessionStore, repoStore, orgStore, zerolog.Nop()), orgID, sessionID, repoID, sessionStore
+}
+
+func TestBroker_RefCountsHoldersAndClosesOnlyAfterLastRelease(t *testing.T) {
+	t.Parallel()
+
+	broker, orgID, sessionID, _, sessions := newBrokerTestDeps(t)
+	holderA := uuid.New()
+	holderB := uuid.New()
+
+	socketPath, err := broker.Acquire(context.Background(), orgID, sessionID, holderA)
+	require.NoError(t, err, "first acquire should open a sandbox auth listener")
+	secondPath, err := broker.Acquire(context.Background(), orgID, sessionID, holderB)
+	require.NoError(t, err, "second acquire should attach to the existing listener")
+	require.Equal(t, socketPath, secondPath, "concurrent holders for one session should share the deterministic socket")
+	require.Equal(t, 1, sessions.callCount(), "active broker entries should be reused without reloading session state")
+
+	resp, err := NewClient(socketPath).Get(context.Background(), ActionPush)
+	require.NoError(t, err, "socket should serve credentials while both holders are active")
+	require.Equal(t, "ghs_test", resp.Token, "socket should return resolver token")
+
+	require.NoError(t, broker.Release(context.Background(), orgID, sessionID, holderA), "releasing one holder should succeed")
+	resp, err = NewClient(socketPath).Get(context.Background(), ActionPush)
+	require.NoError(t, err, "socket should remain live until the final holder releases")
+	require.Equal(t, "ghs_test", resp.Token, "socket should still return credentials after partial release")
+
+	require.NoError(t, broker.Release(context.Background(), orgID, sessionID, holderB), "releasing the final holder should close the socket")
+	_, statErr := os.Stat(socketPath)
+	require.True(t, errors.Is(statErr, os.ErrNotExist), "socket file should be removed after the final holder releases")
+}
+
+func TestBroker_ReleaseUnknownHolderDoesNotCloseActiveSocket(t *testing.T) {
+	t.Parallel()
+
+	broker, orgID, sessionID, _, _ := newBrokerTestDeps(t)
+	holder := uuid.New()
+	socketPath, err := broker.Acquire(context.Background(), orgID, sessionID, holder)
+	require.NoError(t, err, "acquire should open a sandbox auth listener")
+
+	require.NoError(t, broker.Release(context.Background(), orgID, sessionID, uuid.New()), "unknown holder release should be idempotent")
+	resp, err := NewClient(socketPath).Get(context.Background(), ActionAPI)
+	require.NoError(t, err, "unknown holder release should not close the live listener")
+	require.Equal(t, "ghs_test", resp.Token, "socket should continue serving credentials after unknown release")
+
+	require.NoError(t, broker.Release(context.Background(), orgID, sessionID, holder), "known holder release should close the socket")
+}
+
+func TestBroker_SweepPreservesActiveLeases(t *testing.T) {
+	t.Parallel()
+
+	broker, orgID, sessionID, _, _ := newBrokerTestDeps(t)
+	holder := uuid.New()
+	socketPath, err := broker.Acquire(context.Background(), orgID, sessionID, holder)
+	require.NoError(t, err, "acquire should open a sandbox auth listener")
+
+	socketDir := filepath.Dir(filepath.Dir(socketPath))
+	staleSessionID := uuid.New()
+	staleDir := filepath.Join(socketDir, staleSessionID.String())
+	require.NoError(t, os.MkdirAll(staleDir, 0o750), "test should create a stale session dir")
+	require.NoError(t, os.WriteFile(filepath.Join(staleDir, SocketFileName), []byte("stale"), 0o600), "test should create a stale socket artifact")
+
+	broker.SweepStaleSessionDirs(map[uuid.UUID]struct{}{})
+
+	_, err = os.Stat(filepath.Dir(socketPath))
+	require.NoError(t, err, "sweep should preserve active broker session dirs even when keep is empty")
+	_, err = os.Stat(staleDir)
+	require.True(t, errors.Is(err, os.ErrNotExist), "sweep should remove unleased stale session dirs")
+	require.NoError(t, broker.Release(context.Background(), orgID, sessionID, holder), "release should close the active socket after sweep")
+}
+
+type countingBrokerServer struct {
+	mu          sync.Mutex
+	listenCalls int
+	closeCalls  int
+	socketPath  string
+}
+
+func (s *countingBrokerServer) Listen(context.Context, uuid.UUID, *models.Session, *models.Repository, models.OrgSettings) (string, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.listenCalls++
+	time.Sleep(5 * time.Millisecond)
+	return s.socketPath, nil
+}
+
+func (s *countingBrokerServer) Close(uuid.UUID) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.closeCalls++
+}
+
+func (s *countingBrokerServer) Shutdown() {}
+
+func (s *countingBrokerServer) SweepStaleSessionDirs(map[uuid.UUID]struct{}) {}
+
+func (s *countingBrokerServer) counts() (int, int) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.listenCalls, s.closeCalls
+}
+
+func TestBroker_ConcurrentAcquireCreatesOneListener(t *testing.T) {
+	t.Parallel()
+
+	orgID := uuid.New()
+	sessionID := uuid.New()
+	repoID := uuid.New()
+	sessionStore := &brokerSessionStoreStub{session: models.Session{ID: sessionID, OrgID: orgID, RepositoryID: &repoID}}
+	repoStore := &brokerRepositoryStoreStub{repo: models.Repository{ID: repoID, OrgID: orgID, FullName: "owner/repo", InstallationID: 123}}
+	orgStore := &brokerOrganizationStoreStub{org: models.Organization{ID: orgID}}
+	server := &countingBrokerServer{socketPath: "/tmp/143-auth-test/sock"}
+	broker := NewBroker(server, sessionStore, repoStore, orgStore, zerolog.Nop())
+
+	const holders = 16
+	var wg sync.WaitGroup
+	errCh := make(chan error, holders)
+	pathCh := make(chan string, holders)
+	holderIDs := make([]uuid.UUID, holders)
+	for i := 0; i < holders; i++ {
+		holderIDs[i] = uuid.New()
+		holderID := holderIDs[i]
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			socketPath, err := broker.Acquire(context.Background(), orgID, sessionID, holderID)
+			if err != nil {
+				errCh <- err
+				return
+			}
+			pathCh <- socketPath
+			errCh <- nil
+		}()
+	}
+	wg.Wait()
+	close(errCh)
+	close(pathCh)
+
+	for err := range errCh {
+		require.NoError(t, err, "concurrent acquire/release should not fail")
+	}
+	for socketPath := range pathCh {
+		require.Equal(t, server.socketPath, socketPath, "all holders should receive the same socket path")
+	}
+	listenCalls, closeCalls := server.counts()
+	require.Equal(t, 1, listenCalls, "broker should serialize concurrent acquires into one listener")
+	require.Equal(t, 0, closeCalls, "broker should not close before holders release")
+	for _, holderID := range holderIDs {
+		require.NoError(t, broker.Release(context.Background(), orgID, sessionID, holderID), "releasing acquired holders should succeed")
+	}
+	listenCalls, closeCalls = server.counts()
+	require.Equal(t, 1, listenCalls, "broker should not reopen during release")
+	require.Equal(t, 1, closeCalls, "broker should close once after the final concurrent holder releases")
+}
+
+func TestLeaseClient_ReleasesOneGeneratedHolderPerClose(t *testing.T) {
+	t.Parallel()
+
+	broker, orgID, sessionID, repoID, _ := newBrokerTestDeps(t)
+	repo := &models.Repository{ID: repoID, OrgID: orgID, FullName: "owner/repo", InstallationID: 123}
+	run := &models.Session{ID: sessionID, OrgID: orgID, RepositoryID: &repoID}
+	client := NewLeaseClient(broker, "test", zerolog.Nop())
+
+	socketPath, err := client.Listen(context.Background(), sessionID, run, repo, models.OrgSettings{})
+	require.NoError(t, err, "first local lease should open a listener")
+	secondPath, err := client.Listen(context.Background(), sessionID, run, repo, models.OrgSettings{})
+	require.NoError(t, err, "second local lease should attach to the same listener")
+	require.Equal(t, socketPath, secondPath, "local lease client should reuse the active socket path")
+
+	client.Close(sessionID)
+	conn, err := net.DialTimeout("unix", socketPath, time.Second)
+	require.NoError(t, err, "socket should still accept connections after one local close")
+	require.NoError(t, conn.Close(), "test connection should close cleanly")
+
+	client.Close(sessionID)
+	_, statErr := os.Stat(socketPath)
+	require.True(t, errors.Is(statErr, os.ErrNotExist), "socket file should be removed after all local leases close")
+}

--- a/internal/services/sandboxauth/lease_client.go
+++ b/internal/services/sandboxauth/lease_client.go
@@ -1,0 +1,123 @@
+package sandboxauth
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	"github.com/google/uuid"
+	"github.com/rs/zerolog"
+
+	"github.com/assembledhq/143/internal/models"
+)
+
+// LeaseClient adapts the broker's holder-scoped API to the older
+// agent.SandboxAuthServer shape used by the orchestrator and PR service.
+// Each Listen call gets a unique holder ID; Close releases one holder for
+// that session. This preserves refcount semantics even when an old-style
+// caller opens the same session socket more than once concurrently.
+type LeaseClient struct {
+	broker *Broker
+	owner  string
+	logger zerolog.Logger
+
+	mu      sync.Mutex
+	holders map[uuid.UUID][]uuid.UUID
+}
+
+func NewLeaseClient(broker *Broker, owner string, logger zerolog.Logger) *LeaseClient {
+	if owner == "" {
+		owner = "local"
+	}
+	return &LeaseClient{
+		broker:  broker,
+		owner:   owner,
+		logger:  logger,
+		holders: make(map[uuid.UUID][]uuid.UUID),
+	}
+}
+
+func (c *LeaseClient) Listen(
+	ctx context.Context,
+	sessionID uuid.UUID,
+	run *models.Session,
+	repo *models.Repository,
+	orgSettings models.OrgSettings,
+) (string, error) {
+	if c == nil || c.broker == nil {
+		return "", fmt.Errorf("sandboxauth lease client is not configured")
+	}
+	holderID := uuid.New()
+	socketPath, err := c.broker.AcquirePrepared(ctx, sessionID, holderID, run, repo, orgSettings)
+	if err != nil {
+		return "", err
+	}
+	c.mu.Lock()
+	c.holders[sessionID] = append(c.holders[sessionID], holderID)
+	c.mu.Unlock()
+	c.logger.Debug().
+		Str("owner", c.owner).
+		Str("session_id", sessionID.String()).
+		Str("holder_id", holderID.String()).
+		Msg("sandboxauth: local lease acquired")
+	return socketPath, nil
+}
+
+func (c *LeaseClient) Close(sessionID uuid.UUID) {
+	if c == nil || c.broker == nil {
+		return
+	}
+	holderID, ok := c.popHolder(sessionID)
+	if !ok {
+		c.logger.Debug().
+			Str("owner", c.owner).
+			Str("session_id", sessionID.String()).
+			Msg("sandboxauth: local lease close ignored; no holder recorded")
+		return
+	}
+	if err := c.broker.ReleaseHolder(sessionID, holderID); err != nil {
+		c.logger.Warn().
+			Err(err).
+			Str("owner", c.owner).
+			Str("session_id", sessionID.String()).
+			Str("holder_id", holderID.String()).
+			Msg("sandboxauth: failed to release local lease")
+		return
+	}
+	c.logger.Debug().
+		Str("owner", c.owner).
+		Str("session_id", sessionID.String()).
+		Str("holder_id", holderID.String()).
+		Msg("sandboxauth: local lease released")
+}
+
+func (c *LeaseClient) Rehydrate(
+	ctx context.Context,
+	sessionID uuid.UUID,
+	run *models.Session,
+	repo *models.Repository,
+	orgSettings models.OrgSettings,
+) (string, error) {
+	if c == nil || c.broker == nil {
+		return "", fmt.Errorf("sandboxauth lease client is not configured")
+	}
+	return c.broker.EnsurePrepared(ctx, sessionID, run, repo, orgSettings)
+}
+
+func (c *LeaseClient) popHolder(sessionID uuid.UUID) (uuid.UUID, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	holders := c.holders[sessionID]
+	if len(holders) == 0 {
+		return uuid.Nil, false
+	}
+	idx := len(holders) - 1
+	holderID := holders[idx]
+	holders = holders[:idx]
+	if len(holders) == 0 {
+		delete(c.holders, sessionID)
+	} else {
+		c.holders[sessionID] = holders
+	}
+	return holderID, true
+}

--- a/internal/services/sandboxauth/remote_broker_client.go
+++ b/internal/services/sandboxauth/remote_broker_client.go
@@ -1,0 +1,293 @@
+package sandboxauth
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/rs/zerolog"
+
+	"github.com/assembledhq/143/internal/auth"
+	"github.com/assembledhq/143/internal/models"
+)
+
+const (
+	remoteBrokerTokenTTL            = 30 * time.Second
+	remoteBrokerHTTPTimeout         = 30 * time.Second
+	remoteBrokerReleaseDelay        = 5 * time.Second
+	remoteBrokerAcquireAttempts     = 5
+	remoteBrokerAcquireInitialDelay = 100 * time.Millisecond
+	remoteBrokerAcquireMaxDelay     = time.Second
+)
+
+type RemoteBrokerClientConfig struct {
+	BaseURL             string
+	NodeID              string
+	HolderID            uuid.UUID
+	Keyring             auth.PreviewTokenKeyring
+	HTTPClient          *http.Client
+	AcquireRetryBackoff func(attempt int) time.Duration
+	Logger              zerolog.Logger
+}
+
+// RemoteBrokerClient is used inside durable session executor containers. It
+// never opens a local Unix listener; it acquires/releases a holder lease from
+// the long-lived worker process that owns the host socket directory.
+type RemoteBrokerClient struct {
+	baseURL    string
+	nodeID     string
+	holderID   uuid.UUID
+	keyring    auth.PreviewTokenKeyring
+	httpClient *http.Client
+	logger     zerolog.Logger
+	backoff    func(attempt int) time.Duration
+
+	mu       sync.Mutex
+	acquired map[uuid.UUID]remoteBrokerAcquiredSession
+}
+
+type remoteBrokerAcquiredSession struct {
+	orgID uuid.UUID
+	count int
+}
+
+func NewRemoteBrokerClient(cfg RemoteBrokerClientConfig) *RemoteBrokerClient {
+	httpClient := cfg.HTTPClient
+	if httpClient == nil {
+		httpClient = &http.Client{Timeout: remoteBrokerHTTPTimeout}
+	}
+	holderID := cfg.HolderID
+	if holderID == uuid.Nil {
+		holderID = uuid.New()
+	}
+	backoff := cfg.AcquireRetryBackoff
+	if backoff == nil {
+		backoff = defaultRemoteBrokerAcquireBackoff
+	}
+	return &RemoteBrokerClient{
+		baseURL:    strings.TrimRight(cfg.BaseURL, "/"),
+		nodeID:     cfg.NodeID,
+		holderID:   holderID,
+		keyring:    cfg.Keyring,
+		httpClient: httpClient,
+		logger:     cfg.Logger,
+		backoff:    backoff,
+		acquired:   make(map[uuid.UUID]remoteBrokerAcquiredSession),
+	}
+}
+
+func (c *RemoteBrokerClient) Listen(
+	ctx context.Context,
+	sessionID uuid.UUID,
+	run *models.Session,
+	_ *models.Repository,
+	_ models.OrgSettings,
+) (string, error) {
+	if c == nil {
+		return "", fmt.Errorf("sandboxauth remote broker client is nil")
+	}
+	if c.baseURL == "" {
+		return "", fmt.Errorf("sandboxauth remote broker client base url is empty")
+	}
+	if c.nodeID == "" {
+		return "", fmt.Errorf("sandboxauth remote broker client node id is empty")
+	}
+	if !c.keyring.Configured() {
+		return "", fmt.Errorf("sandboxauth remote broker client keyring is not configured")
+	}
+	if run == nil {
+		return "", fmt.Errorf("sandboxauth remote broker client requires session")
+	}
+	if sessionID == uuid.Nil || run.ID != sessionID {
+		return "", fmt.Errorf("sandboxauth remote broker client session mismatch: run=%s requested=%s", run.ID, sessionID)
+	}
+	if run.OrgID == uuid.Nil {
+		return "", fmt.Errorf("sandboxauth remote broker client requires org id")
+	}
+
+	body := BrokerAcquireRequest{
+		OrgID:     run.OrgID,
+		SessionID: sessionID,
+		HolderID:  c.holderID,
+	}
+	resp, err := c.doAcquire(ctx, run.OrgID, sessionID, body)
+	if err != nil {
+		return "", err
+	}
+	var payload models.SingleResponse[BrokerAcquireResponse]
+	if err := json.Unmarshal(resp, &payload); err != nil {
+		return "", fmt.Errorf("sandboxauth remote broker acquire: decode response: %w", err)
+	}
+	if payload.Data.SocketPath == "" {
+		return "", fmt.Errorf("sandboxauth remote broker acquire: worker returned empty socket path")
+	}
+	c.mu.Lock()
+	current := c.acquired[sessionID]
+	current.orgID = run.OrgID
+	current.count++
+	c.acquired[sessionID] = current
+	c.mu.Unlock()
+	return payload.Data.SocketPath, nil
+}
+
+func (c *RemoteBrokerClient) Close(sessionID uuid.UUID) {
+	if c == nil {
+		return
+	}
+	orgID, ok := c.consumeAcquire(sessionID)
+	if !ok {
+		c.logger.Debug().Str("session_id", sessionID.String()).Msg("sandboxauth remote broker close ignored; session was not acquired")
+		return
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), remoteBrokerReleaseDelay)
+	defer cancel()
+	body := BrokerReleaseRequest{
+		OrgID:     orgID,
+		SessionID: sessionID,
+		HolderID:  c.holderID,
+	}
+	if _, err := c.do(ctx, http.MethodPost, "/internal/sandbox-auth/release", BrokerActionRelease, orgID, sessionID, body); err != nil {
+		c.logger.Warn().Err(err).Str("session_id", sessionID.String()).Msg("sandboxauth remote broker release failed")
+	}
+}
+
+func (c *RemoteBrokerClient) consumeAcquire(sessionID uuid.UUID) (uuid.UUID, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	current := c.acquired[sessionID]
+	if current.count <= 0 {
+		return uuid.Nil, false
+	}
+	current.count--
+	if current.count == 0 {
+		delete(c.acquired, sessionID)
+	} else {
+		c.acquired[sessionID] = current
+	}
+	return current.orgID, true
+}
+
+func (c *RemoteBrokerClient) doAcquire(ctx context.Context, orgID, sessionID uuid.UUID, body BrokerAcquireRequest) ([]byte, error) {
+	var lastErr error
+	for attempt := 1; attempt <= remoteBrokerAcquireAttempts; attempt++ {
+		resp, err := c.do(ctx, http.MethodPost, "/internal/sandbox-auth/acquire", BrokerActionAcquire, orgID, sessionID, body)
+		if err == nil {
+			return resp, nil
+		}
+		lastErr = err
+		if attempt == remoteBrokerAcquireAttempts || !retryableRemoteBrokerAcquireError(err) {
+			break
+		}
+		delay := c.backoff(attempt)
+		if delay <= 0 {
+			continue
+		}
+		timer := time.NewTimer(delay)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return nil, ctx.Err()
+		case <-timer.C:
+		}
+	}
+	return nil, lastErr
+}
+
+func (c *RemoteBrokerClient) do(
+	ctx context.Context,
+	method string,
+	path string,
+	action string,
+	orgID uuid.UUID,
+	sessionID uuid.UUID,
+	body any,
+) ([]byte, error) {
+	payload, err := json.Marshal(body)
+	if err != nil {
+		return nil, fmt.Errorf("sandboxauth remote broker %s: marshal body: %w", action, err)
+	}
+	req, err := http.NewRequestWithContext(ctx, method, c.baseURL+path, bytes.NewReader(payload))
+	if err != nil {
+		return nil, fmt.Errorf("sandboxauth remote broker %s: build request: %w", action, err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	token, err := c.keyring.Generate(auth.PreviewTokenClaims{
+		OrgID:        orgID,
+		TargetNodeID: c.nodeID,
+		SessionID:    &sessionID,
+		Action:       action,
+		ExpiresAt:    time.Now().Add(remoteBrokerTokenTTL),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("sandboxauth remote broker %s: sign token: %w", action, err)
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("sandboxauth remote broker %s: request worker: %w", action, err)
+	}
+	defer resp.Body.Close()
+	data, readErr := io.ReadAll(io.LimitReader(resp.Body, 8192))
+	if readErr != nil {
+		return nil, fmt.Errorf("sandboxauth remote broker %s: read response: %w", action, readErr)
+	}
+	if resp.StatusCode >= 400 {
+		var errResp models.ErrorResponse
+		if err := json.Unmarshal(data, &errResp); err == nil && errResp.Error.Code != "" {
+			return nil, &RemoteBrokerRequestError{
+				Action:     action,
+				StatusCode: resp.StatusCode,
+				Code:       errResp.Error.Code,
+				Message:    errResp.Error.Message,
+			}
+		}
+		return nil, &RemoteBrokerRequestError{
+			Action:     action,
+			StatusCode: resp.StatusCode,
+			Message:    strings.TrimSpace(string(data)),
+		}
+	}
+	return data, nil
+}
+
+type RemoteBrokerRequestError struct {
+	Action     string
+	StatusCode int
+	Code       string
+	Message    string
+}
+
+func (e *RemoteBrokerRequestError) Error() string {
+	if e.Code != "" {
+		return fmt.Sprintf("sandboxauth remote broker %s failed with %d (%s): %s", e.Action, e.StatusCode, e.Code, e.Message)
+	}
+	return fmt.Sprintf("sandboxauth remote broker %s failed with %d: %s", e.Action, e.StatusCode, e.Message)
+}
+
+func retryableRemoteBrokerAcquireError(err error) bool {
+	var reqErr *RemoteBrokerRequestError
+	if errors.As(err, &reqErr) {
+		return reqErr.StatusCode == http.StatusTooManyRequests || reqErr.StatusCode >= 500
+	}
+	return true
+}
+
+func defaultRemoteBrokerAcquireBackoff(attempt int) time.Duration {
+	if attempt <= 0 {
+		return remoteBrokerAcquireInitialDelay
+	}
+	delay := remoteBrokerAcquireInitialDelay << (attempt - 1)
+	if delay > remoteBrokerAcquireMaxDelay {
+		return remoteBrokerAcquireMaxDelay
+	}
+	return delay
+}

--- a/internal/services/sandboxauth/remote_broker_client_test.go
+++ b/internal/services/sandboxauth/remote_broker_client_test.go
@@ -1,0 +1,168 @@
+package sandboxauth
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/require"
+
+	"github.com/assembledhq/143/internal/auth"
+	"github.com/assembledhq/143/internal/models"
+)
+
+func TestRemoteBrokerClient_AcquiresAndReleasesWithSignedWorkerRPC(t *testing.T) {
+	t.Parallel()
+
+	secret := "worker-secret"
+	keyring, err := auth.NewPreviewTokenKeyring([]string{secret})
+	require.NoError(t, err, "test keyring should be valid")
+
+	orgID := uuid.New()
+	sessionID := uuid.New()
+	holderID := uuid.New()
+	socketPath := "/var/run/143/sandbox-auth/" + sessionID.String() + "/" + SocketFileName
+	var sawAcquire atomic.Bool
+	releaseCh := make(chan BrokerReleaseRequest, 1)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		token := strings.TrimSpace(strings.TrimPrefix(r.Header.Get("Authorization"), "Bearer "))
+		claims, err := keyring.Validate(token)
+		require.NoError(t, err, "remote broker requests should carry a valid token")
+		require.Equal(t, orgID, claims.OrgID, "remote broker token should preserve org scope")
+		require.Equal(t, "worker-1", claims.TargetNodeID, "remote broker token should target the worker")
+		require.NotNil(t, claims.SessionID, "remote broker token should include the session id")
+		require.Equal(t, sessionID, *claims.SessionID, "remote broker token should preserve the session id")
+
+		switch r.URL.Path {
+		case "/internal/sandbox-auth/acquire":
+			require.Equal(t, "sandbox_auth_acquire", claims.Action, "acquire should sign the acquire action")
+			var body BrokerAcquireRequest
+			require.NoError(t, json.NewDecoder(r.Body).Decode(&body), "acquire should send a JSON body")
+			require.Equal(t, BrokerAcquireRequest{OrgID: orgID, SessionID: sessionID, HolderID: holderID}, body, "acquire should send holder-scoped request")
+			sawAcquire.Store(true)
+			w.WriteHeader(http.StatusOK)
+			require.NoError(t, json.NewEncoder(w).Encode(models.SingleResponse[BrokerAcquireResponse]{
+				Data: BrokerAcquireResponse{SocketPath: socketPath},
+			}), "acquire response should encode")
+		case "/internal/sandbox-auth/release":
+			require.Equal(t, "sandbox_auth_release", claims.Action, "release should sign the release action")
+			var body BrokerReleaseRequest
+			require.NoError(t, json.NewDecoder(r.Body).Decode(&body), "release should send a JSON body")
+			releaseCh <- body
+			w.WriteHeader(http.StatusOK)
+			require.NoError(t, json.NewEncoder(w).Encode(models.SingleResponse[BrokerReleaseResponse]{
+				Data: BrokerReleaseResponse{Released: true},
+			}), "release response should encode")
+		default:
+			t.Fatalf("unexpected remote broker path: %s", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	client := NewRemoteBrokerClient(RemoteBrokerClientConfig{
+		BaseURL:  server.URL,
+		NodeID:   "worker-1",
+		HolderID: holderID,
+		Keyring:  keyring,
+		Logger:   zerolog.Nop(),
+	})
+
+	gotSocketPath, err := client.Listen(context.Background(), sessionID, &models.Session{ID: sessionID, OrgID: orgID}, &models.Repository{}, models.OrgSettings{})
+	require.NoError(t, err, "remote broker client should acquire a socket")
+	require.Equal(t, socketPath, gotSocketPath, "remote broker client should return the worker socket path")
+	require.True(t, sawAcquire.Load(), "remote broker server should receive the acquire request")
+
+	client.Close(sessionID)
+	select {
+	case body := <-releaseCh:
+		require.Equal(t, BrokerReleaseRequest{OrgID: orgID, SessionID: sessionID, HolderID: holderID}, body, "release should send the same holder identity")
+	case <-time.After(time.Second):
+		t.Fatal("remote broker client should send a release request on Close")
+	}
+}
+
+func TestRemoteBrokerClient_CloseWithoutAcquireDoesNotCallWorker(t *testing.T) {
+	t.Parallel()
+
+	keyring, err := auth.NewPreviewTokenKeyring([]string{"worker-secret"})
+	require.NoError(t, err, "test keyring should be valid")
+
+	var calls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		calls.Add(1)
+	}))
+	defer server.Close()
+
+	client := NewRemoteBrokerClient(RemoteBrokerClientConfig{
+		BaseURL:  server.URL,
+		NodeID:   "worker-1",
+		HolderID: uuid.New(),
+		Keyring:  keyring,
+		Logger:   zerolog.Nop(),
+	})
+
+	client.Close(uuid.New())
+	require.Equal(t, int32(0), calls.Load(), "remote broker client should not release sessions it never acquired")
+}
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+func TestRemoteBrokerClient_AcquireRetriesUntilWorkerHTTPIsReady(t *testing.T) {
+	t.Parallel()
+
+	keyring, err := auth.NewPreviewTokenKeyring([]string{"worker-secret"})
+	require.NoError(t, err, "test keyring should be valid")
+
+	orgID := uuid.New()
+	sessionID := uuid.New()
+	holderID := uuid.New()
+	socketPath := "/var/run/143/sandbox-auth/" + sessionID.String() + "/" + SocketFileName
+	var calls atomic.Int32
+
+	httpClient := &http.Client{
+		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			call := calls.Add(1)
+			if call < 3 {
+				return nil, errors.New("dial tcp worker: connect: connection refused")
+			}
+			require.Equal(t, "/internal/sandbox-auth/acquire", req.URL.Path, "retry should preserve acquire path")
+			token := strings.TrimSpace(strings.TrimPrefix(req.Header.Get("Authorization"), "Bearer "))
+			claims, err := keyring.Validate(token)
+			require.NoError(t, err, "retry should preserve a valid worker token")
+			require.Equal(t, BrokerActionAcquire, claims.Action, "retry should preserve acquire action")
+			require.Equal(t, sessionID, *claims.SessionID, "retry should preserve session claim")
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     make(http.Header),
+				Body:       io.NopCloser(strings.NewReader(`{"data":{"socket_path":"` + socketPath + `"}}`)),
+			}, nil
+		}),
+	}
+	client := NewRemoteBrokerClient(RemoteBrokerClientConfig{
+		BaseURL:             "http://worker.internal",
+		NodeID:              "worker-1",
+		HolderID:            holderID,
+		Keyring:             keyring,
+		HTTPClient:          httpClient,
+		AcquireRetryBackoff: func(int) time.Duration { return 0 },
+	})
+
+	gotSocketPath, err := client.Listen(context.Background(), sessionID, &models.Session{ID: sessionID, OrgID: orgID}, &models.Repository{}, models.OrgSettings{})
+	require.NoError(t, err, "remote broker client should retry transient worker readiness failures")
+	require.Equal(t, socketPath, gotSocketPath, "remote broker client should return socket path after retry succeeds")
+	require.Equal(t, int32(3), calls.Load(), "remote broker client should retry until the worker is ready")
+}

--- a/internal/worker/handlers.go
+++ b/internal/worker/handlers.go
@@ -483,6 +483,11 @@ type MemoryReinforcer interface {
 	ReinforceMemories(ctx context.Context, orgID uuid.UUID, memoryIDs []uuid.UUID) error
 }
 
+type SandboxAuthBroker interface {
+	Acquire(ctx context.Context, orgID, sessionID, holderID uuid.UUID) (string, error)
+	Release(ctx context.Context, orgID, sessionID, holderID uuid.UUID) error
+}
+
 type prCreator interface {
 	CreatePR(ctx context.Context, run *models.Session, params ...ghservice.CreatePRParams) (*models.PullRequest, error)
 	CreateBranch(ctx context.Context, run *models.Session, params ...ghservice.CreatePRParams) (*ghservice.CreateBranchResult, error)
@@ -552,6 +557,9 @@ type Services struct {
 	// leftover dirs from prior worker generations don't accumulate. nil
 	// when no SandboxAuthSocketDir is configured.
 	SandboxAuthSweep func(keep map[uuid.UUID]struct{})
+	// SandboxAuthBroker is the worker-owned lease manager exposed through
+	// signed internal RPCs for detached session executors.
+	SandboxAuthBroker SandboxAuthBroker
 	// RuntimeSampler periodically polls per-container resource usage and
 	// records it as OTel histograms so operators can size SANDBOX_* limits
 	// against actual consumption rather than allocation. nil when sampling


### PR DESCRIPTION
## Summary

Fixes the auth socket outage mode by moving sandbox auth socket ownership into the long-lived worker and giving durable session executors a signed remote broker client instead of relying on the executor container to own `/run/143-auth/sock`.

## Root Cause

Durable session executors can outlive or restart independently from the daemon process that creates the sandbox auth Unix socket. When that daemon is down, sessions repeatedly see `/run/143-auth/sock` unavailable and cannot rehydrate credentials reliably.

## Changes

- Added a worker-owned sandbox auth broker with holder-scoped acquire/release leases.
- Added signed internal acquire/release HTTP endpoints for executor-to-worker coordination.
- Added a remote broker client for durable session executors, including bounded retry/backoff for worker startup races.
- Preserved local lease-client behavior for long-lived worker-owned execution paths.
- Updated server wiring, worker service assembly, design docs, and handler lint coverage.

## Validation

- `go test ./internal/services/sandboxauth -run TestRemoteBrokerClient_AcquireRetriesUntilWorkerHTTPIsReady -count=1`
- `go vet ./...`
- `go build ./...`
- `go test ./...`