### PR TITLE
[codex] Handle sandbox auth push failures

### DIFF
--- a/internal/services/github/pr.go
+++ b/internal/services/github/pr.go
@@ -326,6 +326,11 @@ const (
 	// and this error fires when even the lease check fails (a true concurrent
 	// write between ls-remote and push).
 	PushRejectedPRMessage = "GitHub rejected the push because the remote branch changed during the attempt. Try again, or delete the branch on GitHub if it was created outside this session."
+	// SandboxAuthUnavailablePRMessage is shown when 143 cannot prepare the
+	// sandbox credential socket needed for git push. Keep it distinct from the
+	// GitHub permissions fallback because these failures are often runtime or
+	// auth-broker setup issues rather than user/repo access problems.
+	SandboxAuthUnavailablePRMessage = "143 could not prepare GitHub credentials for this push."
 )
 
 // WaitForPostPRSnapshotUploads blocks until every in-flight post-PR snapshot
@@ -378,6 +383,11 @@ var ErrNoChanges = errors.New("no changes to push")
 // failures so the worker can surface a targeted user-facing message instead
 // of the catch-all "Check GitHub access or repo permissions" fallback.
 var ErrPushRejected = errors.New("git push rejected by remote")
+
+// ErrSandboxAuthUnavailable is returned when the host cannot prepare the
+// sandbox credential socket used by git-credential. This is a 143 runtime/auth
+// setup issue, not proof that the user lacks GitHub repository access.
+var ErrSandboxAuthUnavailable = errors.New("sandbox auth unavailable")
 
 // identityResolver returns a resolver wired with the PRService's current
 // dependencies. Lazily built on first use and cached; any Set* mutator
@@ -1147,10 +1157,10 @@ func (s *PRService) SyncSessionTitle(ctx context.Context, session *models.Sessio
 // or URL. The sandbox snapshot already has
 // `credential.helper=!143-tools git-credential` baked into .git/config (set by
 // git-bootstrap during the original agent run); we open a fresh listener
-// keyed by a per-push UUID and bind-mount it into the container so the helper
-// resolves to a live token. Using a per-push UUID (rather than the session
-// ID) avoids kicking the agent run's listener — important when a preview
-// hold is keeping the agent's container alive across turns.
+// lease and bind-mount it into the container so the helper resolves to a live
+// token. The sandbox auth API is keyed by session ID; the lease client
+// generates holder IDs internally so concurrent session users do not close
+// each other's listener.
 //
 // pushResult captures what pushSessionBranch produced on a successful push:
 // the new HEAD SHA from the remote (parsed from the script's stdout sentinel),
@@ -1174,7 +1184,7 @@ func (s *PRService) pushSessionBranch(
 	snapshotKey, branchName, commitMsg, authorName, authorEmail string,
 ) (*pushResult, error) {
 	if s.sandboxAuth == nil {
-		return nil, fmt.Errorf("PRService: sandbox auth socket not configured")
+		return nil, fmt.Errorf("%w: sandbox auth socket not configured", ErrSandboxAuthUnavailable)
 	}
 
 	cfg := agent.DefaultSandboxConfig()
@@ -1190,15 +1200,13 @@ func (s *PRService) pushSessionBranch(
 		cfg.WorkDir = fmt.Sprintf("%s/%s", cfg.HomeDir, slug)
 	}
 
-	// Open a per-push credential listener. Keyed by a fresh UUID so it can't
-	// collide with the agent run's listener (still active when a preview is
-	// holding the original container alive across turns).
-	pushID := uuid.New()
-	socketPath, err := s.sandboxAuth.Listen(ctx, pushID, run, repo, orgSettings)
+	// Open a credential listener lease for this session. The lease-backed auth
+	// server keeps this independent from any still-active agent listener.
+	socketPath, err := s.sandboxAuth.Listen(ctx, run.ID, run, repo, orgSettings)
 	if err != nil {
-		return nil, fmt.Errorf("open sandbox auth socket: %w", err)
+		return nil, fmt.Errorf("%w: open sandbox auth socket: %w", ErrSandboxAuthUnavailable, err)
 	}
-	defer s.sandboxAuth.Close(pushID)
+	defer s.sandboxAuth.Close(run.ID)
 	cfg.AuthSocketPath = socketPath
 	cfg.Env[sandboxauth.SocketEnvVar] = sandboxauth.SandboxSocketPath
 	// GitNameEnvVar / GitEmailEnvVar are intentionally NOT set: those are

--- a/internal/services/github/pr_test.go
+++ b/internal/services/github/pr_test.go
@@ -4376,6 +4376,7 @@ type fakeSandboxAuth struct {
 	listenCount   int
 	closeCount    int
 	lastListenKey uuid.UUID
+	lastCloseKey  uuid.UUID
 }
 
 func (f *fakeSandboxAuth) Listen(_ context.Context, sessionID uuid.UUID, _ *models.Session, _ *models.Repository, _ models.OrgSettings) (string, error) {
@@ -4387,8 +4388,9 @@ func (f *fakeSandboxAuth) Listen(_ context.Context, sessionID uuid.UUID, _ *mode
 	return f.socketPath, nil
 }
 
-func (f *fakeSandboxAuth) Close(_ uuid.UUID) {
+func (f *fakeSandboxAuth) Close(sessionID uuid.UUID) {
 	f.closeCount++
+	f.lastCloseKey = sessionID
 }
 
 // TestPushSessionBranch_RetryOnRejection_Succeeds locks in the self-healing
@@ -4539,11 +4541,12 @@ func TestPushSessionBranch_AuthSocketWired(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	// Listener keyed by a fresh per-push UUID, NOT the session ID — that's
-	// what keeps a still-active agent listener (e.g. preview holding the
-	// agent container alive) from being yanked.
-	require.Equal(t, 1, auth.listenCount)
-	require.NotEqual(t, run.ID, auth.lastListenKey, "auth listener must be keyed by a per-push UUID, not the session ID")
+	// The auth server API is session-keyed. Its lease client generates a
+	// separate holder ID internally, so PR push callers must pass the real
+	// session ID or the broker rejects the prepared session.
+	require.Equal(t, 1, auth.listenCount, "pushSessionBranch should open one auth listener")
+	require.Equal(t, run.ID, auth.lastListenKey, "auth listener should be keyed by the session ID")
+	require.Equal(t, run.ID, auth.lastCloseKey, "auth listener close should release the same session key")
 
 	// The sandbox config the provider saw must carry the host socket path
 	// + the in-container env var that 143-tools git-credential reads.
@@ -4554,6 +4557,37 @@ func TestPushSessionBranch_AuthSocketWired(t *testing.T) {
 	// never runs. The push script sets identity directly via `git config`.
 	require.NotContains(t, provider.lastConfig.Env, sandboxauth.GitNameEnvVar)
 	require.NotContains(t, provider.lastConfig.Env, sandboxauth.GitEmailEnvVar)
+}
+
+func TestPushSessionBranch_AuthSocketListenFailureWrapsSentinel(t *testing.T) {
+	t.Parallel()
+
+	provider := &prTestSandboxProvider{}
+	auth := &fakeSandboxAuth{listenErr: errors.New("broker mismatch")}
+	svc := &PRService{
+		sandboxProvider: provider,
+		snapshots:       &prTestSnapshotStore{payload: []byte("snapshot")},
+		sandboxAuth:     auth,
+		logger:          zerolog.Nop(),
+	}
+
+	_, err := svc.pushSessionBranch(
+		context.Background(),
+		&models.Session{ID: uuid.New(), OrgID: uuid.New()},
+		&models.Repository{FullName: "owner/repo"},
+		models.OrgSettings{},
+		"snapshots/key.tar",
+		"143/abc/fix",
+		"commit message",
+		"Bot",
+		"bot@example.com",
+	)
+
+	require.ErrorIs(t, err, ErrSandboxAuthUnavailable, "pushSessionBranch should classify auth socket listener failures")
+	require.Contains(t, err.Error(), "open sandbox auth socket", "pushSessionBranch should preserve auth socket context")
+	require.Equal(t, 1, auth.listenCount, "pushSessionBranch should attempt to open the auth listener once")
+	require.Equal(t, 0, auth.closeCount, "pushSessionBranch should not close a listener that never opened")
+	require.Equal(t, 0, provider.destroyed, "pushSessionBranch should not destroy a sandbox when hydrate never started")
 }
 
 func TestPushSessionBranch_RequiresSandboxAuth(t *testing.T) {
@@ -4572,6 +4606,7 @@ func TestPushSessionBranch_RequiresSandboxAuth(t *testing.T) {
 		"k", "b", "m", "n", "e@x",
 	)
 	require.Error(t, err)
+	require.ErrorIs(t, err, ErrSandboxAuthUnavailable, "pushSessionBranch should preserve the sandbox auth sentinel")
 	require.Contains(t, err.Error(), "sandbox auth socket not configured")
 }
 

--- a/internal/worker/handlers.go
+++ b/internal/worker/handlers.go
@@ -7936,6 +7936,8 @@ func userFacingPRError(err error) string {
 		return "This PR predates branch tracking; create a new PR to push follow-up changes."
 	case errors.Is(err, ghservice.ErrPushRejected):
 		return ghservice.PushRejectedPRMessage
+	case errors.Is(err, ghservice.ErrSandboxAuthUnavailable):
+		return ghservice.SandboxAuthUnavailablePRMessage
 	default:
 		return "Check GitHub access or repo permissions and try again."
 	}

--- a/internal/worker/handlers_test.go
+++ b/internal/worker/handlers_test.go
@@ -4276,6 +4276,11 @@ func TestUserFacingPRError(t *testing.T) {
 			want: "GitHub rejected the push because the remote branch changed during the attempt. Try again, or delete the branch on GitHub if it was created outside this session.",
 		},
 		{
+			name: "sandbox auth unavailable",
+			err:  fmt.Errorf("open sandbox auth socket: %w", ghservice.ErrSandboxAuthUnavailable),
+			want: "143 could not prepare GitHub credentials for this push.",
+		},
+		{
 			name: "generic fallback",
 			err:  errors.New("boom"),
 			want: "Check GitHub access or repo permissions and try again.",


### PR DESCRIPTION
## Summary

- Fix PR push credential-socket setup to use the real session ID with the sandbox auth lease client.
- Add a specific sandbox-auth unavailable sentinel so these runtime failures no longer show the generic GitHub permissions fallback.
- Trim the user-facing copy to: `143 could not prepare GitHub credentials for this push.`

## Root Cause

`PRService.pushSessionBranch` opened the sandbox auth listener with a random per-push UUID, but the broker validates the listener key against the session's ID. That mismatch caused PR push jobs to fail before reaching GitHub, then the worker mapped the error to a misleading repo-permissions message.

## Validation

- `go vet ./...`
- `go build ./...`
- `go test ./...`