### PR TITLE
Fix orphan dot in session timestamps row when repo/branch wraps

### DIFF
--- a/frontend/src/app/(dashboard)/sessions/[id]/page-pr-creation.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/page-pr-creation.test.tsx
@@ -90,6 +90,18 @@ describe('SessionDetailPage PR creation', () => {
     expect(screen.getByText('5m 30s')).toBeInTheDocument();
   });
 
+  it('keeps the repo branch separator attached so duration does not start with an orphan dot', async () => {
+    renderWithProviders(<SessionDetailContent id="session-abcdef12-3456-7890" />);
+    await screen.findAllByText('Fixed TypeError by adding null check');
+
+    const repoBranch = screen.getByText((_, element) =>
+      element?.tagName.toLowerCase() === 'span' &&
+      element.textContent === 'assembledhq/143 · 143/feature-session-details·' &&
+      element.querySelector('[aria-hidden="true"]')?.textContent === '·',
+    );
+    expect(repoBranch.nextElementSibling?.textContent).toMatch(/^5m 30s/);
+  });
+
   it('shows pass selector when session has diff_history with multiple passes', async () => {
     const pass1Diff = 'diff --git a/src/app.ts b/src/app.ts\n--- a/src/app.ts\n+++ b/src/app.ts\n@@ -1,3 +1,4 @@\n import express from "express";\n+import cors from "cors";\n const app = express();\n app.listen(3000);';
     const pass2Diff = 'diff --git a/src/app.ts b/src/app.ts\n--- a/src/app.ts\n+++ b/src/app.ts\n@@ -1,3 +1,4 @@\n import express from "express";\n+import cors from "cors";\n const app = express();\n app.listen(3000);\ndiff --git a/src/new.ts b/src/new.ts\n--- /dev/null\n+++ b/src/new.ts\n@@ -0,0 +1 @@\n+export const x = 1;';

--- a/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
@@ -877,18 +877,18 @@ function OverviewTab({ session, members, prStatus }: { session: Session; members
         {/* Timestamps + audit — secondary reference data, single unified row */}
         <div className="flex items-center gap-x-1.5 gap-y-1 flex-wrap text-xs text-muted-foreground">
           {repoBranchLabel && (
-            <>
-              <span>{repoBranchLabel}</span>
-              <span aria-hidden="true" className="text-muted-foreground/50">·</span>
-            </>
+            <span>
+              {repoBranchLabel}
+              <span aria-hidden="true" className="ml-1.5 text-muted-foreground/50">·</span>
+            </span>
           )}
           {terminalSessionStatuses.has(session.status) &&
             !((session.status === "failed" || session.status === "cancelled") &&
               !hasMeaningfulDuration(session.started_at, session.completed_at)) && (
-            <>
-              <span>{formatDuration(session.started_at, session.completed_at)}</span>
-              <span aria-hidden="true" className="text-muted-foreground/50">·</span>
-            </>
+            <span>
+              {formatDuration(session.started_at, session.completed_at)}
+              <span aria-hidden="true" className="ml-1.5 text-muted-foreground/50">·</span>
+            </span>
           )}
           <span>
             {!isActive && session.completed_at ? (


### PR DESCRIPTION
## Summary
Fix a UI wrapping bug where the dot separator (`·`) could render on its own line, making it appear like the duration started with a dot (e.g., “· 17m 54s”). The change updates how separators are grouped in `session-detail-content.tsx` and adds a regression test.

## Changes
- **frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx**
  - Updated the timestamps/audit row rendering to attach the `·` separator inside the same inline container as the preceding metadata (repo/branch label and duration), instead of rendering it as a standalone flex child.
  - Adjusted styling to keep spacing consistent using `ml-1.5` on the separator within the grouped element.
- **frontend/src/app/(dashboard)/sessions/[id]/page-pr-creation.test.tsx**
  - Added a regression test (`keeps the repo branch separator attached so duration does not start with an orphan dot`) to ensure the separator does not become an orphan when the repo/branch wraps.

## Test plan
- Ran:
  - `npm run test -- --run src/app/\(dashboard\)/sessions/\[id\]/page-pr-creation.test.tsx -t "orphan dot"`
  - `npm run typecheck`
  - `npm run lint`
  - `npm run build`

[143.dev](https://143.dev) | [session b415c10e](https://143.dev/sessions/b415c10e-44e6-4e1e-aa2e-fa2f66192591)

Preview: https://143.dev/previews/github/assembledhq/143/pull/1453