### PR TITLE
Fix session overview layout by separating repo/branch label from timing metadata

### DIFF
--- a/frontend/src/app/(dashboard)/sessions/[id]/page-overview.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/page-overview.test.tsx
@@ -170,7 +170,13 @@ describe('SessionDetailPage overview and review loop', () => {
     renderWithProviders(<SessionDetailContent id="session-abcdef12-3456-7890" />);
     await screen.findAllByText('Fixed TypeError by adding null check');
 
-    expect(screen.getByText('assembledhq/143 · 143/feature-session-details')).toBeInTheDocument();
+    const repoBranchRow = screen.getByTestId('session-overview-repo-branch');
+    expect(repoBranchRow).toHaveTextContent('assembledhq/143 · 143/feature-session-details');
+    expect(repoBranchRow).not.toHaveTextContent(/feature-session-details\s*·/);
+
+    const metadataRow = screen.getByTestId('session-overview-timing');
+    expect(metadataRow).not.toHaveTextContent('assembledhq/143');
+    expect(metadataRow).toHaveTextContent(/Completed/);
   });
 
   it('renders the session Linear chip as an outbound link when only linear_identifier_hint is available', async () => {

--- a/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
@@ -874,14 +874,20 @@ function OverviewTab({ session, members, prStatus }: { session: Session; members
           </div>
         )}
 
-        {/* Timestamps + audit — secondary reference data, single unified row */}
-        <div className="flex items-center gap-x-1.5 gap-y-1 flex-wrap text-xs text-muted-foreground">
-          {repoBranchLabel && (
-            <span>
-              {repoBranchLabel}
-              <span aria-hidden="true" className="ml-1.5 text-muted-foreground/50">·</span>
-            </span>
-          )}
+        {repoBranchLabel && (
+          <div
+            data-testid="session-overview-repo-branch"
+            className="text-xs text-muted-foreground break-words"
+          >
+            {repoBranchLabel}
+          </div>
+        )}
+
+        {/* Timestamps + audit — secondary reference data, kept separate from long repo/branch labels */}
+        <div
+          data-testid="session-overview-timing"
+          className="flex items-center gap-x-1.5 gap-y-1 flex-wrap text-xs text-muted-foreground"
+        >
           {terminalSessionStatuses.has(session.status) &&
             !((session.status === "failed" || session.status === "cancelled") &&
               !hasMeaningfulDuration(session.started_at, session.completed_at)) && (


### PR DESCRIPTION
## Summary
The sessions dashboard overview was mixing long repo/branch labels with timing/audit metadata, which can break the intended user scan flow and make UI assertions flaky in tests. This change separates repo/branch into its own row while keeping timing/status details grouped, making the layout more reliable for both users and automated checks.

## Changes
- Updated `OverviewTab` in `session-detail-content.tsx` to render the repo/branch label in a dedicated container (`data-testid="session-overview-repo-branch"`) with wrapping enabled.
- Kept timing/status/audit metadata in a separate unified row (`data-testid="session-overview-timing"`) so it no longer shares the same visual line with the repo/branch text.
- Adjusted `page-overview.test.tsx` to assert:
  - repo/branch appears in `session-overview-repo-branch` and not in the timing row
  - timing row does not contain the repo/branch string and still shows expected status text (e.g., “Completed”).

## Validation
- Ran the frontend test for the session overview/review loop (`page-overview.test.tsx`) and confirmed it passes after the layout/test updates.

[143.dev](https://143.dev) | [session c17d9b25](https://143.dev/sessions/c17d9b25-3543-4417-8016-d65c4aecf763)

Preview: https://143.dev/previews/github/assembledhq/143/pull/1458