### PR TITLE
[codex] Rename agent capabilities design doc

### DIFF
--- a/docs/design/future/103-agent-capabilities.md
+++ b/docs/design/future/103-agent-capabilities.md
@@ -1,4 +1,4 @@
-# Design: Agent Run Capabilities
+# Design: Agent Capabilities
 
 > **Status:** Not Started | **Last reviewed:** 2026-06-16
 


### PR DESCRIPTION
## Summary

- Rename the agent capabilities design doc from `102-automation-capabilities.md` to `103-agent-capabilities.md`.
- Update the document title from `Agent Run Capabilities` to `Agent Capabilities`.
- Use `103` because latest `main` already has `102-preview-index-current-targets.md`.

## Validation

- Pulled latest `origin/main` before branching.
- Verified future design doc numbering.
- Ran Markdown whitespace checks with `git diff --check` and a no-index check for the renamed file.
- Confirmed the file is ASCII-only.

No code tests run; doc-only rename.