### PR TITLE
Process GitHub status webhooks for PR health sync

### DIFF
--- a/internal/api/handlers/webhooks.go
+++ b/internal/api/handlers/webhooks.go
@@ -79,6 +79,8 @@ func (h *WebhookHandler) HandleGitHub(w http.ResponseWriter, r *http.Request) {
 		h.handleCheckSuite(w, r, body)
 	case "check_run":
 		h.handleCheckRun(w, r, body)
+	case "status":
+		h.handleStatus(w, r, body)
 	default:
 		writeJSON(w, http.StatusOK, map[string]string{"status": "ignored", "event": event})
 	}
@@ -446,6 +448,33 @@ func (h *WebhookHandler) handleCheckRun(w http.ResponseWriter, r *http.Request, 
 
 	if err := h.prService.HandleCheckRunEvent(r.Context(), event); err != nil {
 		writeError(w, r, http.StatusInternalServerError, "CHECK_RUN_FAILED", "failed to process check_run event", err)
+		return
+	}
+
+	writeJSON(w, http.StatusOK, map[string]string{"status": "processed"})
+}
+
+func (h *WebhookHandler) handleStatus(w http.ResponseWriter, r *http.Request, body []byte) {
+	if h.prService == nil {
+		writeJSON(w, http.StatusOK, map[string]string{"status": "ignored", "reason": "pr_service_not_configured"})
+		return
+	}
+
+	var event ghservice.StatusEvent
+	if err := json.Unmarshal(body, &event); err != nil {
+		writeError(w, r, http.StatusBadRequest, "INVALID_JSON", "failed to parse status event")
+		return
+	}
+	owner, ok := h.githubWebhookRepoActiveOwner(w, r, event.Repository.ID)
+	if !ok {
+		return
+	}
+	if owner.OrgID != uuid.Nil {
+		event.OwnerOrgID = &owner.OrgID
+	}
+
+	if err := h.prService.HandleStatusEvent(r.Context(), event); err != nil {
+		writeError(w, r, http.StatusInternalServerError, "STATUS_FAILED", "failed to process status event", err)
 		return
 	}
 

--- a/internal/api/handlers/webhooks_test.go
+++ b/internal/api/handlers/webhooks_test.go
@@ -236,6 +236,18 @@ func TestWebhook_HandleGitHub(t *testing.T) {
 			expectedBody: "pr_service_not_configured",
 		},
 		{
+			name:    "status event ignored when pr service not configured",
+			secret:  "test-secret",
+			event:   "status",
+			payload: `{"state":"failure","sha":"head-sha","context":"ci/circleci: frontend_lint_format_license"}`,
+			signature: func(secret string, body []byte) string {
+				return computeTestSignature(secret, body)
+			},
+			setupMock:    func(mock pgxmock.PgxPoolIface) {},
+			expectedCode: http.StatusOK,
+			expectedBody: "pr_service_not_configured",
+		},
+		{
 			name:   "installation_repositories event removes repos",
 			secret: "test-secret",
 			event:  "installation_repositories",

--- a/internal/db/pull_requests.go
+++ b/internal/db/pull_requests.go
@@ -204,6 +204,26 @@ func (s *PullRequestStore) GetByOrgRepoAndNumber(ctx context.Context, orgID uuid
 	return pgx.CollectOneRow(rows, pgx.RowToStructByName[models.PullRequest])
 }
 
+func (s *PullRequestStore) ListOpenByOrgRepoAndHeadSHA(ctx context.Context, orgID uuid.UUID, repo, headSHA string) ([]models.PullRequest, error) {
+	query := `
+		SELECT ` + prSelectColumns + `
+		FROM pull_requests
+		WHERE org_id = @org_id
+		  AND github_repo = @github_repo
+		  AND head_sha = @head_sha
+		  AND status = 'open'`
+
+	rows, err := s.db.Query(ctx, query, pgx.NamedArgs{
+		"org_id":      orgID,
+		"github_repo": repo,
+		"head_sha":    headSHA,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("query open pull requests by org, repo, and head SHA: %w", err)
+	}
+	return pgx.CollectRows(rows, pgx.RowToStructByName[models.PullRequest])
+}
+
 func (s *PullRequestStore) UpdateReviewStatus(ctx context.Context, orgID, id uuid.UUID, reviewStatus models.PullRequestReviewStatus) error {
 	query := `UPDATE pull_requests SET review_status = @review_status, updated_at = now() WHERE id = @id AND org_id = @org_id`
 	_, err := s.db.Exec(ctx, query, pgx.NamedArgs{

--- a/internal/db/pull_requests_test.go
+++ b/internal/db/pull_requests_test.go
@@ -94,6 +94,49 @@ func TestPullRequestStore_GetByOrgRepoAndNumber(t *testing.T) {
 	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
 }
 
+func TestPullRequestStore_ListOpenByOrgRepoAndHeadSHA(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "pgxmock pool should initialize")
+	defer mock.Close()
+
+	store := NewPullRequestStore(mock)
+
+	cols := []string{
+		"id", "session_id", "org_id", "github_pr_number", "github_pr_url", "github_repo",
+		"title", "body", "status", "review_status", "authored_by", "ci_status", "head_sha", "head_ref", "base_sha",
+		"merge_state", "has_conflicts", "failing_test_count", "needs_agent_action", "github_state_synced_at",
+		"health_version", "merge_when_ready_state", "merge_when_ready_requested_by", "merge_when_ready_requested_at",
+		"merge_when_ready_head_sha", "merge_when_ready_health_version", "merge_when_ready_error",
+		"merge_when_ready_updated_at", "merged_at", "created_at", "updated_at",
+	}
+
+	prID := uuid.New()
+	sessionID := uuid.New()
+	orgID := uuid.New()
+	now := time.Now()
+	headSHA := "head-sha"
+
+	mock.ExpectQuery("SELECT .+ FROM pull_requests WHERE org_id = .+ AND github_repo = .+ AND head_sha = .+ AND status = 'open'").
+		WithArgs(pgx.NamedArgs{"org_id": orgID, "github_repo": "org/repo", "head_sha": headSHA}).
+		WillReturnRows(
+			pgxmock.NewRows(cols).
+				AddRow(prID, &sessionID, orgID, 42, "https://github.com/org/repo/pull/42", "org/repo",
+					"Fix bug", ptrStr("Description"), "open", "pending", "user1", "", &headSHA, nil, nil,
+					models.PullRequestMergeStateUnknown, false, 0, false, nil, int64(0),
+					models.PullRequestMergeWhenReadyStateOff, nil, nil, "", nil, "", nil, nil, now, now),
+		)
+
+	prs, err := store.ListOpenByOrgRepoAndHeadSHA(context.Background(), orgID, "org/repo", headSHA)
+	require.NoError(t, err, "ListOpenByOrgRepoAndHeadSHA should find open PRs for the org/repo/head SHA")
+	require.Len(t, prs, 1, "ListOpenByOrgRepoAndHeadSHA should return the matching PR")
+	require.Equal(t, prID, prs[0].ID, "ListOpenByOrgRepoAndHeadSHA should preserve the PR id")
+	require.Equal(t, orgID, prs[0].OrgID, "ListOpenByOrgRepoAndHeadSHA should preserve the owning org")
+	require.Equal(t, &headSHA, prs[0].HeadSHA, "ListOpenByOrgRepoAndHeadSHA should return the matching head SHA")
+	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
+}
+
 func TestPullRequestStore_UpdateCIStatus(t *testing.T) {
 	t.Parallel()
 

--- a/internal/services/github/pr.go
+++ b/internal/services/github/pr.go
@@ -3715,3 +3715,52 @@ func (s *PRService) HandleCheckRunEvent(ctx context.Context, event CheckRunEvent
 
 	return nil
 }
+
+// StatusEvent represents a GitHub commit status webhook payload.
+type StatusEvent struct {
+	State      string     `json:"state"`
+	SHA        string     `json:"sha"`
+	Context    string     `json:"context"`
+	OwnerOrgID *uuid.UUID `json:"-"`
+	Repository struct {
+		ID       int64  `json:"id"`
+		FullName string `json:"full_name"`
+	} `json:"repository"`
+}
+
+// HandleStatusEvent processes classic commit status webhooks, used by providers
+// such as CircleCI, and refreshes repairable PR state for matching PR heads.
+func (s *PRService) HandleStatusEvent(ctx context.Context, event StatusEvent) error {
+	if strings.TrimSpace(event.SHA) == "" || strings.TrimSpace(event.Repository.FullName) == "" {
+		return nil
+	}
+	if event.OwnerOrgID == nil {
+		s.logger.Debug().
+			Str("repo", event.Repository.FullName).
+			Str("head_sha", event.SHA).
+			Msg("ignoring status event without resolved repository owner")
+		return nil
+	}
+
+	prs, err := s.pullRequests.ListOpenByOrgRepoAndHeadSHA(ctx, *event.OwnerOrgID, event.Repository.FullName, event.SHA)
+	if err != nil {
+		return err
+	}
+	scope := statusSyncScope(event.Context, event.State)
+	for _, pr := range prs {
+		s.enqueuePullRequestStateSyncWithScope(ctx, pr, scope)
+	}
+	return nil
+}
+
+func statusSyncScope(contextName, state string) string {
+	contextName = strings.TrimSpace(contextName)
+	if contextName == "" {
+		contextName = "unknown"
+	}
+	state = strings.ToLower(strings.TrimSpace(state))
+	if state == "" {
+		state = "unknown"
+	}
+	return fmt.Sprintf("status:%s:%s", contextName, state)
+}

--- a/internal/services/github/pr_handlers_test.go
+++ b/internal/services/github/pr_handlers_test.go
@@ -2227,6 +2227,54 @@ func TestHandleCheckRunEvent_CompletedEnqueuesHealthSync(t *testing.T) {
 	require.NoError(t, jobMock.ExpectationsWereMet(), "check run completion should enqueue a scoped health sync")
 }
 
+func TestHandleStatusEvent_EnqueuesHealthSyncForHeadSHA(t *testing.T) {
+	t.Parallel()
+
+	orgID := uuid.New()
+	prID := uuid.New()
+	sessionID := uuid.New()
+	now := time.Now()
+
+	prMock := newMockPool(t)
+	jobMock := newMockPool(t)
+	svc := &PRService{
+		pullRequests: db.NewPullRequestStore(prMock),
+		jobs:         db.NewJobStore(jobMock),
+		logger:       zerolog.Nop(),
+	}
+
+	prMock.ExpectQuery("SELECT .+ FROM pull_requests WHERE org_id = .+ AND github_repo = .+ AND head_sha = .+ AND status = 'open'").
+		WithArgs(pgx.NamedArgs{"org_id": orgID, "github_repo": "testorg/testrepo", "head_sha": "head-sha"}).
+		WillReturnRows(
+			pgxmock.NewRows(handlerPRColumns).
+				AddRow(handlerPRRow(prID, &sessionID, orgID, "testorg/testrepo", now)...),
+		)
+	dedupeKey := pullRequestStateSyncDedupeKey(prID, "status:ci/circleci: frontend_lint_format_license:failure")
+	jobMock.ExpectQuery("INSERT INTO jobs").
+		WithArgs(pgx.NamedArgs{
+			"org_id":     orgID,
+			"queue":      prHealthSyncQueue,
+			"job_type":   prHealthSyncJobType,
+			"payload":    pgxmock.AnyArg(),
+			"priority":   6,
+			"dedupe_key": &dedupeKey,
+		}).
+		WillReturnRows(pgxmock.NewRows([]string{"id"}).AddRow(uuid.New()))
+
+	event := StatusEvent{
+		State:      "failure",
+		SHA:        "head-sha",
+		Context:    "ci/circleci: frontend_lint_format_license",
+		OwnerOrgID: &orgID,
+	}
+	event.Repository.FullName = "testorg/testrepo"
+
+	err := svc.HandleStatusEvent(context.Background(), event)
+	require.NoError(t, err, "HandleStatusEvent should enqueue a health sync for matching open PR heads")
+	require.NoError(t, prMock.ExpectationsWereMet(), "all pull request expectations should be met")
+	require.NoError(t, jobMock.ExpectationsWereMet(), "status event should enqueue a scoped health sync")
+}
+
 func TestHandleCheckSuiteEvent_PRNotFound(t *testing.T) {
 	t.Parallel()
 

--- a/internal/services/github/pr_health.go
+++ b/internal/services/github/pr_health.go
@@ -15,7 +15,7 @@ import (
 // Tests are indeterminate when any test-category check_run is queued, waiting,
 // or in progress. Callers use these flags to avoid clobbering prior actionable
 // state on the same head SHA with a transient-blank snapshot.
-func detectIndeterminateSignals(mergeable *bool, githubState string, checkRuns []gitHubCheckRun) (mergeStateIndeterminate, testsIndeterminate bool) {
+func detectIndeterminateSignals(mergeable *bool, githubState string, checkRuns []gitHubCheckRun, commitStatuses []gitHubCommitStatus) (mergeStateIndeterminate, testsIndeterminate bool) {
 	state := strings.ToLower(strings.TrimSpace(githubState))
 	mergeStateIndeterminate = mergeable == nil && !isDefinitiveNullMergeabilityState(state)
 	for _, check := range checkRuns {
@@ -24,6 +24,15 @@ func detectIndeterminateSignals(mergeable *bool, githubState string, checkRuns [
 		}
 		switch strings.ToLower(strings.TrimSpace(check.Status)) {
 		case "in_progress", "queued", "waiting":
+			testsIndeterminate = true
+			return
+		}
+	}
+	for _, status := range commitStatuses {
+		if classifyCheckRunCategory(status.Context) != models.PullRequestCheckCategoryTest {
+			continue
+		}
+		if normalizeCommitStatus(status) == models.PullRequestCheckStatusPending {
 			testsIndeterminate = true
 			return
 		}
@@ -146,6 +155,29 @@ func normalizeCheckRunStatus(check gitHubCheckRun) models.PullRequestCheckStatus
 			return models.PullRequestCheckStatusFailed
 		}
 		return models.PullRequestCheckStatusPending
+	}
+}
+
+func normalizeCommitStatus(status gitHubCommitStatus) models.PullRequestCheckStatus {
+	switch strings.ToLower(strings.TrimSpace(status.State)) {
+	case "success":
+		return models.PullRequestCheckStatusPassed
+	case "failure", "error":
+		return models.PullRequestCheckStatusFailed
+	default:
+		return models.PullRequestCheckStatusPending
+	}
+}
+
+func commitStatusProvider(context string) string {
+	name := strings.ToLower(strings.TrimSpace(context))
+	switch {
+	case strings.Contains(name, "circleci"):
+		return "circleci"
+	case strings.Contains(name, "github"):
+		return "github"
+	default:
+		return "github_status"
 	}
 }
 

--- a/internal/services/github/pr_health_service.go
+++ b/internal/services/github/pr_health_service.go
@@ -59,6 +59,11 @@ type gitHubCheckRunsResponse struct {
 	CheckRuns []gitHubCheckRun `json:"check_runs"`
 }
 
+type gitHubCombinedStatusResponse struct {
+	State    string               `json:"state"`
+	Statuses []gitHubCommitStatus `json:"statuses"`
+}
+
 type gitHubBranchResponse struct {
 	Protected  bool `json:"protected"`
 	Protection struct {
@@ -90,6 +95,13 @@ type gitHubCheckRun struct {
 		AnnotationsCount int    `json:"annotations_count"`
 		AnnotationsURL   string `json:"annotations_url"`
 	} `json:"output"`
+}
+
+type gitHubCommitStatus struct {
+	Context     string `json:"context"`
+	State       string `json:"state"`
+	TargetURL   string `json:"target_url"`
+	Description string `json:"description"`
 }
 
 type gitHubCheckRunAnnotation struct {
@@ -364,9 +376,18 @@ func (s *PRService) SyncPullRequestState(ctx context.Context, orgID, pullRequest
 	if err != nil {
 		return err
 	}
+	commitStatuses, err := s.listCommitStatusesForRef(ctx, token, owner, repoName, details.Head.SHA)
+	if err != nil {
+		s.logger.Warn().
+			Err(err).
+			Str("pull_request_id", pullRequestID.String()).
+			Str("head_sha", details.Head.SHA).
+			Msg("failed to fetch GitHub commit statuses during pull request health sync")
+		commitStatuses = nil
+	}
 
 	requiredChecksConfigured := false
-	if len(checkRuns) == 0 {
+	if len(checkRuns) == 0 && len(commitStatuses) == 0 {
 		requiredChecksConfigured, err = s.branchRequiresStatusChecksCached(ctx, orgID.String(), token, owner, repoName, details.Base.Ref)
 		if err != nil {
 			return err
@@ -403,10 +424,25 @@ func (s *PRService) SyncPullRequestState(ctx context.Context, orgID, pullRequest
 			Summary:    firstNonEmpty(check.Output.Title, truncateText(stripWhitespace(check.Output.Summary), 240)),
 		})
 	}
+	for _, status := range commitStatuses {
+		category := classifyCheckRunCategory(status.Context)
+		checkStatus := normalizeCommitStatus(status)
+		if category == models.PullRequestCheckCategoryTest && checkStatus == models.PullRequestCheckStatusFailed {
+			summary.FailingTestCount++
+		}
+		summary.Checks = append(summary.Checks, models.PullRequestCheckSummary{
+			Name:       status.Context,
+			Category:   category,
+			Status:     checkStatus,
+			Provider:   commitStatusProvider(status.Context),
+			DetailsURL: status.TargetURL,
+			Summary:    truncateText(stripWhitespace(status.Description), 240),
+		})
+	}
 	summary.ChecksConfirmed = determineChecksConfirmed(summary.Checks, requiredChecksConfigured)
-	summary.NeedsAgentAction = summary.HasConflicts || summary.FailingTestCount > 0
+	summary.NeedsAgentAction = summary.HasConflicts || healthSummaryHasRepairableFailedChecks(summary)
 
-	mergeStateIndeterminate, testsIndeterminate := detectIndeterminateSignals(details.Mergeable, details.MergeableState, checkRuns)
+	mergeStateIndeterminate, testsIndeterminate := detectIndeterminateSignals(details.Mergeable, details.MergeableState, checkRuns, commitStatuses)
 	if mergeStateIndeterminate || testsIndeterminate {
 		if prior != nil && shouldSkipIndeterminateSnapshotWrite(mergeStateIndeterminate, testsIndeterminate, details.Head.SHA, summary.FailingTestCount, *prior) {
 			s.logger.Debug().
@@ -486,6 +522,15 @@ func (s *PRService) EnrichPullRequestHealth(ctx context.Context, orgID, pullRequ
 	if err != nil {
 		return err
 	}
+	commitStatuses, err := s.listCommitStatusesForRef(ctx, token, owner, repoName, details.Head.SHA)
+	if err != nil {
+		s.logger.Warn().
+			Err(err).
+			Str("pull_request_id", pullRequestID.String()).
+			Str("head_sha", details.Head.SHA).
+			Msg("failed to fetch GitHub commit statuses during pull request health enrichment")
+		commitStatuses = nil
+	}
 
 	conflictPayload, err := json.Marshal(map[string]any{
 		"pull_request_id":  pr.ID,
@@ -530,6 +575,18 @@ func (s *PRService) EnrichPullRequestHealth(ctx context.Context, orgID, pullRequ
 			DetailsURL:  firstNonEmpty(check.DetailsURL, check.HTMLURL),
 			LogExcerpt:  truncateText(stripWhitespace(firstNonEmpty(check.Output.Text, check.Output.Summary)), 1200),
 			Annotations: annotations,
+		})
+	}
+	for _, status := range commitStatuses {
+		if normalizeCommitStatus(status) != models.PullRequestCheckStatusFailed {
+			continue
+		}
+		payloadChecks = append(payloadChecks, failingCheckPayload{
+			Name:       status.Context,
+			Category:   classifyCheckRunCategory(status.Context),
+			Provider:   commitStatusProvider(status.Context),
+			Summary:    truncateText(stripWhitespace(status.Description), 240),
+			DetailsURL: status.TargetURL,
 		})
 	}
 
@@ -957,6 +1014,19 @@ func (s *PRService) listCheckRunsForRef(ctx context.Context, token, owner, repo,
 	return dedupeCheckRunsByName(resp.CheckRuns), nil
 }
 
+func (s *PRService) listCommitStatusesForRef(ctx context.Context, token, owner, repo, ref string) ([]gitHubCommitStatus, error) {
+	path := fmt.Sprintf("/repos/%s/%s/commits/%s/status", owner, repo, ref)
+	body, err := s.doGitHubRequest(ctx, token, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, err
+	}
+	var resp gitHubCombinedStatusResponse
+	if err := json.Unmarshal(body, &resp); err != nil {
+		return nil, fmt.Errorf("decode GitHub commit statuses: %w", err)
+	}
+	return dedupeCommitStatusesByContext(resp.Statuses), nil
+}
+
 func (s *PRService) branchRequiresStatusChecks(ctx context.Context, token, owner, repo, branch string) (bool, error) {
 	path := fmt.Sprintf("/repos/%s/%s/branches/%s", owner, repo, url.PathEscape(branch))
 	body, err := s.doGitHubRequest(ctx, token, http.MethodGet, path, nil)
@@ -1049,6 +1119,26 @@ func dedupeCheckRunsByName(checkRuns []gitHubCheckRun) []gitHubCheckRun {
 		if bestIdx[key] == i {
 			deduped = append(deduped, check)
 		}
+	}
+	return deduped
+}
+
+func dedupeCommitStatusesByContext(statuses []gitHubCommitStatus) []gitHubCommitStatus {
+	if len(statuses) <= 1 {
+		return statuses
+	}
+	seen := make(map[string]struct{}, len(statuses))
+	deduped := make([]gitHubCommitStatus, 0, len(statuses))
+	for _, status := range statuses {
+		key := strings.ToLower(strings.TrimSpace(status.Context))
+		if key == "" {
+			key = strings.ToLower(strings.TrimSpace(status.TargetURL))
+		}
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		deduped = append(deduped, status)
 	}
 	return deduped
 }

--- a/internal/services/github/pr_health_service_test.go
+++ b/internal/services/github/pr_health_service_test.go
@@ -53,6 +53,45 @@ func (a repairJobPayloadArg) Match(value interface{}) bool {
 		payload["health_version"] == float64(a.wantHealthVersion)
 }
 
+type pullRequestHealthSummaryArg struct {
+	wantCheckName        string
+	wantCheckStatus      models.PullRequestCheckStatus
+	wantCheckCategory    models.PullRequestCheckCategory
+	wantFailingTestCount int
+	wantNeedsAgentAction bool
+	wantChecksConfirmed  bool
+}
+
+func (a pullRequestHealthSummaryArg) Match(value interface{}) bool {
+	var payload []byte
+	switch v := value.(type) {
+	case []byte:
+		payload = v
+	case string:
+		payload = []byte(v)
+	default:
+		return false
+	}
+
+	var summary models.PullRequestHealthSummary
+	if err := json.Unmarshal(payload, &summary); err != nil {
+		return false
+	}
+	if summary.FailingTestCount != a.wantFailingTestCount ||
+		summary.NeedsAgentAction != a.wantNeedsAgentAction ||
+		summary.ChecksConfirmed != a.wantChecksConfirmed {
+		return false
+	}
+	for _, check := range summary.Checks {
+		if check.Name == a.wantCheckName &&
+			check.Status == a.wantCheckStatus &&
+			check.Category == a.wantCheckCategory {
+			return true
+		}
+	}
+	return false
+}
+
 func TestPRServiceBuildPullRequestHealthResponseUsesCurrentSummaryForRepairActions(t *testing.T) {
 	t.Parallel()
 
@@ -839,6 +878,124 @@ func TestPRServiceSyncPullRequestState(t *testing.T) {
 	err = service.SyncPullRequestState(context.Background(), orgID, pullRequestID)
 	require.NoError(t, err, "SyncPullRequestState should synchronize GitHub pull request state")
 	require.NoError(t, mock.ExpectationsWereMet(), "all sync expectations should be met")
+}
+
+func TestPRServiceSyncPullRequestStateIncludesCommitStatuses(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "should create pgx mock pool")
+	defer mock.Close()
+
+	orgID := uuid.New()
+	pullRequestID := uuid.New()
+	repoID := uuid.New()
+	integrationID := uuid.New()
+	now := time.Now().UTC()
+	statusSummary := pullRequestHealthSummaryArg{
+		wantCheckName:        "ci/circleci: frontend_lint_format_license",
+		wantCheckStatus:      models.PullRequestCheckStatusFailed,
+		wantCheckCategory:    models.PullRequestCheckCategoryLint,
+		wantFailingTestCount: 0,
+		wantNeedsAgentAction: true,
+		wantChecksConfirmed:  true,
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/repos/assembledhq/143/pulls/42":
+			_, _ = w.Write([]byte(`{"number":42,"html_url":"https://github.com/assembledhq/143/pull/42","state":"open","mergeable":true,"mergeable_state":"blocked","head":{"ref":"feature","sha":"head-status"},"base":{"ref":"main","sha":"base-status"}}`))
+		case "/repos/assembledhq/143/commits/head-status/check-runs":
+			_, _ = w.Write([]byte(`{"check_runs":[]}`))
+		case "/repos/assembledhq/143/commits/head-status/status":
+			_, _ = w.Write([]byte(`{"state":"failure","total_count":2,"statuses":[{"context":"ci/circleci: frontend_lint_format_license","state":"failure","target_url":"https://circleci.com/gh/assembledhq/143/123","description":"Your tests failed on CircleCI"},{"context":"ci/circleci: frontend_build","state":"success","target_url":"https://circleci.com/gh/assembledhq/143/124","description":"Your tests passed on CircleCI!"}]}`))
+		case "/repos/assembledhq/143/branches/main":
+			_, _ = w.Write([]byte(`{"protected":true,"protection":{"required_status_checks":{"contexts":["ci/circleci: frontend_lint_format_license"]}}}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	mock.ExpectQuery("SELECT .+ FROM pull_requests WHERE id").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(pgxmock.NewRows(prTestPullRequestColumns).AddRow(
+			pullRequestID, nil, orgID, 42, "https://github.com/assembledhq/143/pull/42", "assembledhq/143",
+			"Fix bug", (*string)(nil), "open", "pending", "app", "", nil, nil, nil,
+			models.PullRequestMergeStateUnknown, false, 0, false, (*time.Time)(nil), int64(0), models.PullRequestMergeWhenReadyStateOff, (*uuid.UUID)(nil), (*time.Time)(nil), "", (*int64)(nil), "", (*time.Time)(nil), (*time.Time)(nil), now, now,
+		))
+	mock.ExpectQuery("SELECT .+ FROM repositories WHERE org_id = .+ AND full_name = .+ AND status = 'active'").
+		WithArgs(pgx.NamedArgs{"org_id": orgID, "full_name": "assembledhq/143"}).
+		WillReturnRows(pgxmock.NewRows(prTestRepoColumns).AddRow(
+			repoID, orgID, integrationID, int64(1), "assembledhq/143", "main", false, nil, nil, "https://github.com/assembledhq/143.git", int64(123), "active", nil, nil, []byte(`{}`), now, now,
+		))
+	mock.ExpectQuery("SELECT .+ FROM pull_request_health_current").
+		WithArgs(pgx.NamedArgs{"org_id": orgID, "pull_request_id": pullRequestID}).
+		WillReturnRows(pgxmock.NewRows(prHealthCurrentTestColumns))
+	mock.ExpectBegin()
+	mock.ExpectQuery("SELECT .+ FROM pull_request_health_current").
+		WithArgs(pgx.NamedArgs{"org_id": orgID, "pull_request_id": pullRequestID}).
+		WillReturnRows(pgxmock.NewRows(prHealthCurrentTestColumns))
+	mock.ExpectExec("INSERT INTO pull_request_health_snapshots").
+		WithArgs(pgx.NamedArgs{
+			"pull_request_id":   pullRequestID,
+			"org_id":            orgID,
+			"version":           int64(1),
+			"head_sha":          "head-status",
+			"base_sha":          "base-status",
+			"summary_json":      statusSummary,
+			"enrichment_status": models.PullRequestHealthEnrichmentStatusNotRequested,
+		}).
+		WillReturnResult(pgxmock.NewResult("INSERT", 1))
+	mock.ExpectExec("UPDATE pull_request_repair_runs").
+		WithArgs(pgx.NamedArgs{"org_id": orgID, "pull_request_id": pullRequestID, "version": int64(1), "head_sha": "head-status"}).
+		WillReturnResult(pgxmock.NewResult("UPDATE", 0))
+	mock.ExpectExec("INSERT INTO pull_request_health_current").
+		WithArgs(pgx.NamedArgs{
+			"pull_request_id":      pullRequestID,
+			"org_id":               orgID,
+			"version":              int64(1),
+			"head_sha":             "head-status",
+			"base_sha":             "base-status",
+			"summary_json":         statusSummary,
+			"summary_preview_json": pgxmock.AnyArg(),
+			"enrichment_status":    models.PullRequestHealthEnrichmentStatusNotRequested,
+			"enriched_at":          (*time.Time)(nil),
+			"created_at":           pgxmock.AnyArg(),
+			"updated_at":           pgxmock.AnyArg(),
+		}).
+		WillReturnResult(pgxmock.NewResult("INSERT", 1))
+	mock.ExpectExec("UPDATE pull_requests").
+		WithArgs(pgx.NamedArgs{
+			"pull_request_id":    pullRequestID,
+			"org_id":             orgID,
+			"head_sha":           "head-status",
+			"base_sha":           "base-status",
+			"merge_state":        models.PullRequestMergeStateBlocked,
+			"has_conflicts":      false,
+			"failing_test_count": 0,
+			"needs_agent_action": true,
+			"version":            int64(1),
+		}).
+		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
+	mock.ExpectCommit()
+	mock.ExpectExec("UPDATE pull_requests SET ci_status").
+		WithArgs(pgx.NamedArgs{"id": pullRequestID, "org_id": orgID, "ci_status": models.PullRequestCIStatusFailure}).
+		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
+
+	service := &PRService{
+		tokenProvider: &Service{cache: map[int64]*cachedToken{}},
+		pullRequests:  db.NewPullRequestStore(mock),
+		repos:         db.NewRepositoryStore(mock),
+		logger:        zerolog.New(io.Discard),
+		baseURL:       server.URL,
+		httpClient:    server.Client(),
+	}
+	service.tokenProvider.cache[123] = &cachedToken{Token: "install-token", ExpiresAt: time.Now().Add(time.Hour)}
+
+	err = service.SyncPullRequestState(context.Background(), orgID, pullRequestID)
+	require.NoError(t, err, "SyncPullRequestState should preserve CircleCI commit statuses as repairable checks")
+	require.NoError(t, mock.ExpectationsWereMet(), "all status-only sync expectations should be met")
 }
 
 // When GitHub reports a PR closed-and-merged but our DB still has it open, the
@@ -2466,6 +2623,8 @@ func TestPRServiceDirectErrorBranches(t *testing.T) {
 			_, _ = w.Write([]byte(`{bad json`))
 		case "/repos/assembledhq/143/commits/head/check-runs":
 			_, _ = w.Write([]byte(`{bad json`))
+		case "/repos/assembledhq/143/commits/head/status":
+			_, _ = w.Write([]byte(`{bad json`))
 		case "/repos/assembledhq/143/check-runs/1/annotations":
 			_, _ = w.Write([]byte(`{bad json`))
 		default:
@@ -2483,6 +2642,10 @@ func TestPRServiceDirectErrorBranches(t *testing.T) {
 	_, err = service.listCheckRunsForRef(context.Background(), "token", "assembledhq", "143", "head")
 	require.Error(t, err, "listCheckRunsForRef should reject malformed GitHub JSON")
 	require.Contains(t, err.Error(), "decode GitHub check runs", "listCheckRunsForRef should wrap decode failures")
+
+	_, err = service.listCommitStatusesForRef(context.Background(), "token", "assembledhq", "143", "head")
+	require.Error(t, err, "listCommitStatusesForRef should reject malformed GitHub JSON")
+	require.Contains(t, err.Error(), "decode GitHub commit statuses", "listCommitStatusesForRef should wrap decode failures")
 
 	_, err = service.fetchCheckRunAnnotations(context.Background(), "token", "assembledhq", "143", 1)
 	require.Error(t, err, "fetchCheckRunAnnotations should reject malformed GitHub JSON")

--- a/internal/services/github/pr_health_test.go
+++ b/internal/services/github/pr_health_test.go
@@ -109,6 +109,7 @@ func TestDetectIndeterminateSignals(t *testing.T) {
 		mergeable        *bool
 		githubState      string
 		checkRuns        []gitHubCheckRun
+		commitStatuses   []gitHubCommitStatus
 		expectMergeIndet bool
 		expectTestsIndet bool
 	}{
@@ -173,6 +174,16 @@ func TestDetectIndeterminateSignals(t *testing.T) {
 			expectTestsIndet: true,
 		},
 		{
+			name:        "pending test commit status is indeterminate",
+			mergeable:   boolPtr(true),
+			githubState: "clean",
+			commitStatuses: []gitHubCommitStatus{
+				{Context: "ci/circleci: frontend_test", State: "pending"},
+			},
+			expectMergeIndet: false,
+			expectTestsIndet: true,
+		},
+		{
 			name:        "in-progress lint check is not test indeterminate",
 			mergeable:   boolPtr(true),
 			githubState: "clean",
@@ -188,7 +199,7 @@ func TestDetectIndeterminateSignals(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			mergeIndet, testsIndet := detectIndeterminateSignals(tt.mergeable, tt.githubState, tt.checkRuns)
+			mergeIndet, testsIndet := detectIndeterminateSignals(tt.mergeable, tt.githubState, tt.checkRuns, tt.commitStatuses)
 			require.Equal(t, tt.expectMergeIndet, mergeIndet, "merge state indeterminate flag should match")
 			require.Equal(t, tt.expectTestsIndet, testsIndet, "tests indeterminate flag should match")
 		})


### PR DESCRIPTION
## Summary
- Handle GitHub `status` webhooks and route them into PR health sync
- Add pull request lookup by org, repo, and head SHA for open PRs
- Include commit statuses in PR health sync and enrichment so legacy CI providers are reflected in repair actions
- Cover the new webhook path and status-driven health flow with unit tests

## Testing
- Added unit tests for webhook handling, pull request lookup, status event processing, and health summary behavior
- Not run (not requested)