### PR TITLE
Remove session header Preview action

### DIFF
--- a/frontend/src/app/(dashboard)/sessions/[id]/page-pr-health.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/page-pr-health.test.tsx
@@ -304,7 +304,7 @@ describe('SessionDetailPage PR health and merge', () => {
     expect(within(viewPRLink).queryByRole('button')).not.toBeInTheDocument();
   });
 
-  it('shows Preview and View PR actions in the session detail header actions', async () => {
+  it('keeps preview access in the tab instead of the session detail header actions', async () => {
     server.use(
       http.get('/api/v1/sessions/:id', () => {
         return HttpResponse.json({
@@ -322,10 +322,8 @@ describe('SessionDetailPage PR health and merge', () => {
 
     const actions = await screen.findByLabelText('Session detail actions');
 
-    expect(within(actions).getByRole('link', { name: 'Preview' })).toHaveAttribute(
-      'href',
-      '/previews/github/example/repo/pull/42?launch=1',
-    );
+    expect(screen.getByRole('tab', { name: 'Preview' })).toBeInTheDocument();
+    expect(within(actions).queryByRole('link', { name: 'Preview' })).not.toBeInTheDocument();
     expect(within(actions).getByRole('link', { name: 'View PR' })).toBeInTheDocument();
     expect(within(actions).queryByRole('button', { name: 'Open preview' })).not.toBeInTheDocument();
   });

--- a/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
@@ -330,18 +330,6 @@ export function getInitialComposerSelectedModel(thread: SessionThread): string {
   return thread.model_override ?? "";
 }
 
-function buildPRPreviewLaunchURL(prURL: string | null | undefined): string | null {
-  if (!prURL) return null;
-  try {
-    const url = new URL(prURL);
-    const [, owner, repo, segment, number] = url.pathname.split("/");
-    if (!owner || !repo || segment !== "pull" || !number) return null;
-    return `/previews/github/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/pull/${encodeURIComponent(number)}?launch=1`;
-  } catch {
-    return null;
-  }
-}
-
 export function hasCleanReviewLoopForSnapshot(loops: SessionReviewLoop[] | undefined, snapshotKey: string | undefined): boolean {
   if (!snapshotKey) return false;
   return (loops ?? []).some((loop) => loop.status === "clean" && loop.latest_checkpoint_key === snapshotKey);
@@ -3885,7 +3873,6 @@ export function SessionDetailContent({ id }: { id: string }) {
   // every render.
   const prevPRStateRef = useRef<string | undefined>(undefined);
   const prUrl = prData?.data?.github_pr_url;
-  const prPreviewLaunchURL = useMemo(() => buildPRPreviewLaunchURL(prUrl), [prUrl]);
   const serverPRState = session?.pr_creation_state;
   const localPRWaitingForServer =
     localPRState === "queued" &&
@@ -5598,14 +5585,6 @@ export function SessionDetailContent({ id }: { id: string }) {
                     {closedPRLabel}
                   </Badge>
                 )}
-                {prPreviewLaunchURL ? (
-                  <Button asChild size="sm" className="h-7 text-xs gap-1.5" title="Preview">
-                    <a href={prPreviewLaunchURL} target="_blank" rel="noopener noreferrer">
-                      <ExternalLink className="h-3 w-3" />
-                      Preview
-                    </a>
-                  </Button>
-                ) : null}
                 <Button asChild variant="outline" size="sm" className="h-7 text-xs gap-1.5" title="View PR (p v)">
                   <a href={prData.data.github_pr_url} target="_blank" rel="noopener noreferrer">
                     <ExternalLink className="h-3 w-3" />


### PR DESCRIPTION
## Summary

The session detail header exposed a Preview button while the same page already has a dedicated Preview tab, creating two different preview entry points in the same view. This removes the header-level Preview action so preview access is anchored in the tab, while keeping View PR available as the PR header action.

## Changes

- Remove the PR preview launch link from the session detail header actions.
- Delete the now-unused PR preview URL helper.
- Update the PR health test to assert the Preview tab remains available and the header action is absent.

## Validation

- `npm test -- page-pr-health.test.tsx --run`
- `npm run typecheck`
- `npm run lint`
- `npm run build`