### PR TITLE
Include turn zero messages in session transcripts

### DIFF
--- a/docs/design/implemented/101-session-transcript-refactor.md
+++ b/docs/design/implemented/101-session-transcript-refactor.md
@@ -107,6 +107,10 @@ Cursor rules:
   direction the cursor came from.
 - When an `around` anchor is provided but not found, the server falls back to
   `latest` and sets `anchor_found: false`.
+- Initial user prompts are persisted as turn 0 and are included in transcript
+  windows when the messages include is enabled. Logs and human-input requests
+  remain positive-turn-only so historical turn-0 runtime noise does not render
+  as conversation content.
 
 Response shape:
 

--- a/internal/db/session_transcript_store.go
+++ b/internal/db/session_transcript_store.go
@@ -155,7 +155,7 @@ func (s *SessionTranscriptStore) listDistinctTurns(
 		SELECT DISTINCT turn_number FROM (
 			` + strings.Join(branches, "\nUNION\n") + `
 		) t
-		WHERE turn_number > 0
+		WHERE turn_number >= 0
 		` + whereClause + `
 		ORDER BY turn_number ` + orderDir + `
 		LIMIT @limit`
@@ -239,6 +239,7 @@ func (s *SessionTranscriptStore) fetchEntriesForTurns(
 		FROM session_logs
 		WHERE org_id = @org_id AND thread_id = @thread_id
 		  AND turn_number = ANY(@turns)
+		  AND turn_number > 0
 		ORDER BY turn_number ASC, id ASC`
 
 		logRows, err := s.db.Query(ctx, logQuery, pgx.NamedArgs{
@@ -279,6 +280,7 @@ func (s *SessionTranscriptStore) fetchEntriesForTurns(
 		FROM session_human_input_requests
 		WHERE org_id = @org_id AND thread_id = @thread_id
 		  AND turn_number = ANY(@turns)
+		  AND turn_number > 0
 		ORDER BY turn_number ASC, created_at ASC, id ASC`
 
 		hirRows, err := s.db.Query(ctx, hirQuery, pgx.NamedArgs{
@@ -892,13 +894,13 @@ func transcriptTurnSelectBranches(include TranscriptInclude) []string {
 				WHERE org_id = @org_id AND thread_id = @thread_id`)
 	}
 	if include.Tools || include.System {
-		logFilter := ""
+		logFilter := " AND turn_number > 0"
 		toolLogPredicate := "(level = 'tool_use' OR metadata->>'type' = 'tool_result')"
 		switch {
 		case include.Tools && !include.System:
-			logFilter = " AND " + toolLogPredicate
+			logFilter += " AND " + toolLogPredicate
 		case include.System && !include.Tools:
-			logFilter = " AND NOT " + toolLogPredicate
+			logFilter += " AND NOT " + toolLogPredicate
 		}
 		branches = append(branches, `
 			SELECT turn_number FROM session_logs
@@ -907,7 +909,7 @@ func transcriptTurnSelectBranches(include TranscriptInclude) []string {
 	if include.HumanInputs {
 		branches = append(branches, `
 			SELECT turn_number FROM session_human_input_requests
-				WHERE org_id = @org_id AND thread_id = @thread_id`)
+				WHERE org_id = @org_id AND thread_id = @thread_id AND turn_number > 0`)
 	}
 	return branches
 }

--- a/internal/db/session_transcript_store_test.go
+++ b/internal/db/session_transcript_store_test.go
@@ -1,12 +1,17 @@
 package db
 
 import (
+	"context"
+	"encoding/json"
 	"math"
 	"sort"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/pashagolub/pgxmock/v4"
 	"github.com/stretchr/testify/require"
 
 	"github.com/assembledhq/143/internal/models"
@@ -257,6 +262,90 @@ func TestTranscriptEntryKindConstants(t *testing.T) {
 	require.Equal(t, models.TranscriptEntryKind("tool_use"), models.TranscriptEntryKindToolUse)
 	require.Equal(t, models.TranscriptEntryKind("log"), models.TranscriptEntryKindLog)
 	require.Equal(t, models.TranscriptEntryKind("human_input"), models.TranscriptEntryKindHumanInput)
+}
+
+func TestSessionTranscriptStore_ListThreadWindowIncludesTurnZeroInitialMessage(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "mock pool should be created")
+	defer mock.Close()
+
+	store := NewSessionTranscriptStore(mock)
+	orgID := uuid.New()
+	threadID := uuid.New()
+	sessionID := uuid.New()
+	turns := []int32{0, 1}
+	now := time.Now().UTC()
+	turnOneTime := now.Add(time.Second)
+
+	mock.ExpectQuery(`SELECT DISTINCT turn_number FROM \(.+session_messages.+session_logs.+\) t\s+WHERE turn_number >= 0`).
+		WithArgs(pgx.NamedArgs{
+			"org_id":    orgID,
+			"thread_id": threadID,
+			"limit":     DefaultTranscriptLimitTurns + 1,
+		}).
+		WillReturnRows(pgxmock.NewRows([]string{"turn_number"}).
+			AddRow(1).
+			AddRow(0))
+
+	mock.ExpectQuery(`SELECT .+ FROM session_messages.+turn_number = ANY\(@turns\)`).
+		WithArgs(pgx.NamedArgs{
+			"org_id":    orgID,
+			"thread_id": threadID,
+			"turns":     turns,
+		}).
+		WillReturnRows(pgxmock.NewRows([]string{"id", "session_id", "org_id", "thread_id", "user_id", "turn_number", "role", "content", "attachments", "references", "commands", "token_usage", "source", "created_at"}).
+			AddRow(int64(10), sessionID, orgID, &threadID, nil, 0, models.MessageRoleUser, "initial prompt", nil, nil, nil, nil, "", now).
+			AddRow(int64(11), sessionID, orgID, &threadID, nil, 1, models.MessageRoleAssistant, "assistant response", nil, nil, nil, nil, "", turnOneTime))
+
+	mock.ExpectQuery(`SELECT .+ FROM session_logs.+turn_number = ANY\(@turns\).+turn_number > 0`).
+		WithArgs(pgx.NamedArgs{
+			"org_id":    orgID,
+			"thread_id": threadID,
+			"turns":     turns,
+		}).
+		WillReturnRows(pgxmock.NewRows([]string{"id", "session_id", "org_id", "thread_id", "timestamp", "level", "message", "metadata", "turn_number"}).
+			AddRow(int64(101), sessionID, orgID, &threadID, turnOneTime.Add(time.Millisecond), models.SessionLogLevelInfo, "turn one log", json.RawMessage(`{}`), 1))
+
+	mock.ExpectQuery(`SELECT id\s+FROM session_messages\s+WHERE org_id = @org_id AND thread_id = @thread_id AND role = 'assistant'`).
+		WithArgs(pgx.NamedArgs{"org_id": orgID, "thread_id": threadID}).
+		WillReturnRows(pgxmock.NewRows([]string{"id"}).AddRow(int64(11)))
+
+	mock.ExpectQuery(`SELECT entry_kind, source_id, message_id, hiq_uuid, level, metadata`).
+		WithArgs(pgx.NamedArgs{"org_id": orgID, "thread_id": threadID}).
+		WillReturnRows(pgxmock.NewRows([]string{"entry_kind", "source_id", "message_id", "hiq_uuid", "level", "metadata"}).
+			AddRow(models.TranscriptEntryKindLog, int64(101), nil, nil, models.SessionLogLevelInfo, json.RawMessage(`{}`)))
+
+	window, err := store.ListThreadWindow(context.Background(), orgID, threadID, SessionTranscriptWindowOptions{
+		Include: TranscriptInclude{Messages: true, System: true},
+	})
+	require.NoError(t, err, "ListThreadWindow should include the initial prompt without error")
+	require.False(t, window.HasOlder, "turn zero and turn one should fit in the default latest window")
+	require.Equal(t, int64(11), window.LatestAssistantMessageID, "latest assistant metadata should still point at the assistant response")
+	require.Equal(t, "log_101", window.LiveEdgeEntryID, "live edge metadata should ignore turn-zero history and use the latest positive-turn entry")
+
+	gotKinds := make([]models.TranscriptEntryKind, 0, len(window.Rows))
+	gotTurns := make([]int, 0, len(window.Rows))
+	gotContents := make([]string, 0, len(window.Rows))
+	for _, row := range window.Rows {
+		gotKinds = append(gotKinds, row.EntryKindHint)
+		gotTurns = append(gotTurns, row.TurnNumber)
+		if row.Message != nil {
+			gotContents = append(gotContents, row.Message.Content)
+		}
+		if row.Log != nil {
+			gotContents = append(gotContents, row.Log.Message)
+		}
+	}
+	require.Equal(t, []models.TranscriptEntryKind{
+		models.TranscriptEntryKindMessage,
+		models.TranscriptEntryKindMessage,
+		models.TranscriptEntryKindLog,
+	}, gotKinds, "window should include turn-zero message and positive-turn log entries")
+	require.Equal(t, []int{0, 1, 1}, gotTurns, "turn-zero should appear only for the initial message")
+	require.Equal(t, []string{"initial prompt", "assistant response", "turn one log"}, gotContents, "turn-zero log noise should stay out of the transcript")
+	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
 }
 
 func TestTranscriptTurnSelectBranchesFiltersLogIncludes(t *testing.T) {


### PR DESCRIPTION
## Summary
- Include the initial user prompt at turn 0 in transcript windows when messages are requested
- Keep logs and human-input requests positive-turn-only so runtime noise stays out of conversation history
- Update the session transcript design doc and add a regression test for the mixed turn window

## Testing
- Added a unit test covering `ListThreadWindow` with a turn 0 prompt plus positive-turn assistant and log entries
- Not run (not requested)