### PR TITLE
Preserve exact queued-message selection in continue-session repair flow

### DIFF
--- a/internal/services/agent/orchestrator.go
+++ b/internal/services/agent/orchestrator.go
@@ -10,6 +10,7 @@ import (
 	"net/url"
 	"path"
 	"regexp"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -754,6 +755,7 @@ type ContinueSessionOptions struct {
 	ResultAgentSessionID *string
 	PRRepair             *PRRepairContinueOptions
 	HumanInputRequestID  *uuid.UUID
+	QueuedMessageID      *int64
 
 	// ThreadID, when set, identifies the agent tab this turn belongs to.
 	// The orchestrator passes it to the thread cancel registry so a
@@ -1326,12 +1328,57 @@ const (
 )
 
 func latestUserMessage(messages []models.SessionMessage) *models.SessionMessage {
-	for i := len(messages) - 1; i >= 0; i-- {
-		if messages[i].Role == models.MessageRoleUser {
-			return &messages[i]
+	latest := -1
+	for i := range messages {
+		if messages[i].Role != models.MessageRoleUser {
+			continue
+		}
+		if latest == -1 || messageRowIsNewer(messages[i], messages[latest]) {
+			latest = i
 		}
 	}
-	return nil
+	if latest == -1 {
+		return nil
+	}
+	return &messages[latest]
+}
+
+func queuedUserMessageInScope(messages []models.SessionMessage, queuedMessageID int64, threadID *uuid.UUID) (*models.SessionMessage, error) {
+	for i := range messages {
+		m := messages[i]
+		if m.ID != queuedMessageID {
+			continue
+		}
+		if m.Role != models.MessageRoleUser {
+			return nil, fmt.Errorf("queued message %d has role %s, not user", queuedMessageID, m.Role)
+		}
+		if !messageMatchesThreadScope(m, threadID) {
+			return nil, fmt.Errorf("queued message %d is outside the requested thread scope", queuedMessageID)
+		}
+		return &messages[i], nil
+	}
+	return nil, fmt.Errorf("queued user message %d not found", queuedMessageID)
+}
+
+func messageRowIsNewer(candidate, current models.SessionMessage) bool {
+	if candidate.ID != 0 || current.ID != 0 {
+		if candidate.ID != current.ID {
+			return candidate.ID > current.ID
+		}
+	}
+	if !candidate.CreatedAt.IsZero() || !current.CreatedAt.IsZero() {
+		if !candidate.CreatedAt.Equal(current.CreatedAt) {
+			return candidate.CreatedAt.After(current.CreatedAt)
+		}
+	}
+	return true
+}
+
+func messageMatchesThreadScope(message models.SessionMessage, threadID *uuid.UUID) bool {
+	if threadID == nil {
+		return message.ThreadID == nil
+	}
+	return message.ThreadID != nil && *message.ThreadID == *threadID
 }
 
 func derefMessage(msg *models.SessionMessage) models.SessionMessage {
@@ -1534,42 +1581,35 @@ func waitForRetryableSnapshotSave(ctx context.Context, attempt int) error {
 // is that specific thread.
 //
 // The scoped form exists because session_messages.ListBySession orders rows by
-// (turn_number, id) — and per-thread turn counters are independent — so the
-// globally-last user row in the slice is not necessarily the last message the
-// user actually sent. ContinueSession must scope to the thread the worker
-// payload identified, otherwise a sibling thread with a higher turn_number
-// will steal the run.
+// (turn_number, id) — and per-thread turn counters are independent. Some repair
+// paths also write thread-bound messages with the session turn number.
+// The row id is therefore the chronological authority for "latest" inside the
+// requested scope.
 func latestUserMessageInScope(messages []models.SessionMessage, threadID *uuid.UUID) *models.SessionMessage {
-	matchesScope := func(m models.SessionMessage) bool {
-		if threadID == nil {
-			return m.ThreadID == nil
-		}
-		return m.ThreadID != nil && *m.ThreadID == *threadID
-	}
-	for i := len(messages) - 1; i >= 0; i-- {
+	latest := -1
+	for i := range messages {
 		m := messages[i]
 		if m.Role != models.MessageRoleUser {
 			continue
 		}
-		if !matchesScope(m) {
+		if !messageMatchesThreadScope(m, threadID) {
 			continue
 		}
-		return &messages[i]
+		if latest == -1 || messageRowIsNewer(m, messages[latest]) {
+			latest = i
+		}
 	}
-	return nil
+	if latest == -1 {
+		return nil
+	}
+	return &messages[latest]
 }
 
 func messagesInScope(messages []models.SessionMessage, threadID *uuid.UUID) []models.SessionMessage {
 	scoped := make([]models.SessionMessage, 0, len(messages))
 	for _, message := range messages {
-		if threadID == nil {
-			if message.ThreadID != nil {
-				continue
-			}
-		} else {
-			if message.ThreadID == nil || *message.ThreadID != *threadID {
-				continue
-			}
+		if !messageMatchesThreadScope(message, threadID) {
+			continue
 		}
 		scoped = append(scoped, message)
 	}
@@ -1595,19 +1635,45 @@ func unprocessedUserMessages(messages []models.SessionMessage, threadID *uuid.UU
 // rows are inserted before the in-flight turn's assistant row; when the drain
 // job starts, that assistant must not hide the queued users.
 func unprocessedUserMessagesThrough(messages []models.SessionMessage, threadID *uuid.UUID, latestUserMessageID int64) []models.SessionMessage {
-	matchesScope := func(m models.SessionMessage) bool {
-		if threadID == nil {
-			return m.ThreadID == nil
+	hasMessageIDs := false
+	for _, m := range messages {
+		if messageMatchesThreadScope(m, threadID) && m.ID != 0 {
+			hasMessageIDs = true
+			break
 		}
-		return m.ThreadID != nil && *m.ThreadID == *threadID
 	}
+	if hasMessageIDs {
+		var latestAssistantID int64
+		for _, m := range messages {
+			if !messageMatchesThreadScope(m, threadID) || m.ID > latestUserMessageID {
+				continue
+			}
+			if m.Role == models.MessageRoleAssistant && m.ID > latestAssistantID {
+				latestAssistantID = m.ID
+			}
+		}
+		var pending []models.SessionMessage
+		for _, m := range messages {
+			if !messageMatchesThreadScope(m, threadID) || m.ID > latestUserMessageID || m.ID <= latestAssistantID {
+				continue
+			}
+			if m.Role == models.MessageRoleUser {
+				pending = append(pending, m)
+			}
+		}
+		sort.Slice(pending, func(i, j int) bool {
+			return pending[i].ID < pending[j].ID
+		})
+		return pending
+	}
+
 	var pending []models.SessionMessage
 	for i := len(messages) - 1; i >= 0; i-- {
 		m := messages[i]
 		if m.ID > latestUserMessageID {
 			continue
 		}
-		if !matchesScope(m) {
+		if !messageMatchesThreadScope(m, threadID) {
 			continue
 		}
 		if m.Role == models.MessageRoleAssistant {
@@ -3043,7 +3109,14 @@ func (o *Orchestrator) ContinueSession(ctx context.Context, session *models.Sess
 	// without a thread hint) we preserve the legacy global lookup so a
 	// threaded session can still recover its in-flight turn.
 	var latestMsg *models.SessionMessage
-	if opts != nil && opts.ThreadID != nil {
+	if opts != nil && opts.QueuedMessageID != nil {
+		latestMsg, err = queuedUserMessageInScope(messages, *opts.QueuedMessageID, opts.ThreadID)
+		if err != nil {
+			log.Warn().Err(err).Int64("queued_message_id", *opts.QueuedMessageID).Msg("continue_session queued message selection failed")
+			o.failRun(ctx, session, fmt.Sprintf("select queued user message: %s", err))
+			return fmt.Errorf("select queued user message: %w", err)
+		}
+	} else if opts != nil && opts.ThreadID != nil {
 		latestMsg = latestUserMessageInScope(messages, opts.ThreadID)
 	} else {
 		latestMsg = latestUserMessage(messages)

--- a/internal/services/agent/orchestrator_helpers_internal_test.go
+++ b/internal/services/agent/orchestrator_helpers_internal_test.go
@@ -120,6 +120,27 @@ func TestLatestUserMessageInScope_ThreadScopedSelection(t *testing.T) {
 	require.Equal(t, "A turn 9", scopedA.Content, "scoped lookup should return thread A's most recent user when asked for thread A")
 }
 
+func TestLatestUserMessageInScope_UsesNewestMessageIDWithinThread(t *testing.T) {
+	t.Parallel()
+
+	threadID := uuid.New()
+
+	// Regression: PR repair used to insert a thread-bound message with the
+	// session turn number. That older repair message can therefore sort after
+	// a newer thread-local follow-up in ListBySession's (turn_number, id)
+	// ordering. The scoped selector must choose the newest row in the thread,
+	// not the last row in the DB ordering.
+	messages := []models.SessionMessage{
+		{ID: 5127, Role: models.MessageRoleUser, Content: "new design follow-up", ThreadID: &threadID, TurnNumber: 5},
+		{ID: 5113, Role: models.MessageRoleUser, Content: "old repair prompt", ThreadID: &threadID, TurnNumber: 27},
+		{ID: 5114, Role: models.MessageRoleAssistant, Content: "old repair reply", ThreadID: &threadID, TurnNumber: 27},
+	}
+
+	got := latestUserMessageInScope(messages, &threadID)
+	require.NotNil(t, got, "should find a user message in the thread")
+	require.Equal(t, "new design follow-up", got.Content, "scoped lookup should prefer the newest message row over an older higher-turn repair prompt")
+}
+
 func TestLatestUserMessageInScope_NoThreadFallback(t *testing.T) {
 	t.Parallel()
 
@@ -132,6 +153,23 @@ func TestLatestUserMessageInScope_NoThreadFallback(t *testing.T) {
 	got := latestUserMessageInScope(messages, nil)
 	require.NotNil(t, got)
 	require.Equal(t, "session-level", got.Content, "nil scope should ignore threaded messages and return the latest no-thread user")
+}
+
+func TestUnprocessedUserMessagesThrough_UsesMessageIDBoundaryWithinThread(t *testing.T) {
+	t.Parallel()
+
+	threadID := uuid.New()
+
+	messages := []models.SessionMessage{
+		{ID: 5127, Role: models.MessageRoleUser, Content: "new design follow-up", ThreadID: &threadID, TurnNumber: 5},
+		{ID: 5113, Role: models.MessageRoleUser, Content: "old repair prompt", ThreadID: &threadID, TurnNumber: 27},
+		{ID: 5114, Role: models.MessageRoleAssistant, Content: "old repair reply", ThreadID: &threadID, TurnNumber: 27},
+	}
+
+	got := unprocessedUserMessagesThrough(messages, &threadID, 5127)
+	require.Equal(t, []models.SessionMessage{
+		{ID: 5127, Role: models.MessageRoleUser, Content: "new design follow-up", ThreadID: &threadID, TurnNumber: 5},
+	}, got, "unprocessed lookup should ignore older high-turn assistant rows that sort after the newer user message")
 }
 
 func TestUnprocessedUserMessages_SessionScope(t *testing.T) {

--- a/internal/services/agent/orchestrator_test.go
+++ b/internal/services/agent/orchestrator_test.go
@@ -6433,6 +6433,54 @@ func TestContinueSession_RoutesToRequestedThreadAcrossSiblingTurns(t *testing.T)
 		"assistant reply must be tagged with the Codex 2 thread, not Main — pre-fix this was the load-bearing assertion that failed in prod")
 }
 
+func TestContinueSession_UsesQueuedMessageIDAsExactCarrier(t *testing.T) {
+	t.Parallel()
+
+	orgID := testOrg()
+	threadID := uuid.New()
+	queuedMessageID := int64(10)
+	issue := testIssue(orgID)
+	issue.Source = models.IssueSourceManual
+	session := testRun(orgID, issue.ID)
+	session.Origin = models.SessionOriginManual
+	session.InteractionMode = models.SessionInteractionModeInteractive
+	session.ValidationPolicy = models.SessionValidationPolicyOnSessionEnd
+	session.Status = models.SessionStatusIdle
+	session.CurrentTurn = 3
+	session.SnapshotKey = strPtr("snapshots/test/session.tar")
+
+	d := defaultDeps()
+	d.issues.issue = issue
+	d.messages.messages = []models.SessionMessage{
+		{ID: 9, SessionID: session.ID, OrgID: orgID, ThreadID: &threadID, TurnNumber: 2, Role: models.MessageRoleAssistant, Content: "previous reply"},
+		{ID: queuedMessageID, SessionID: session.ID, OrgID: orgID, ThreadID: &threadID, TurnNumber: 3, Role: models.MessageRoleUser, Content: "change the code from this queued message"},
+		{ID: 11, SessionID: session.ID, OrgID: orgID, ThreadID: &threadID, TurnNumber: 4, Role: models.MessageRoleUser, Content: "newer message that belongs to a later drain"},
+	}
+	d.provider.RestoreFn = func(ctx context.Context, sb *agent.Sandbox, reader io.Reader) error {
+		_, err := io.ReadAll(reader)
+		return err
+	}
+	d.provider.SnapshotFn = func(ctx context.Context, sb *agent.Sandbox) (io.ReadCloser, error) {
+		return io.NopCloser(bytes.NewReader([]byte("next-snapshot"))), nil
+	}
+	d.adapter.executeFn = func(ctx context.Context, sandbox *agent.Sandbox, prompt *agent.AgentPrompt, logCh chan<- agent.LogEntry) (*agent.AgentResult, error) {
+		require.Equal(t, "change the code from this queued message", prompt.UserMessage, "queued_message_id should make ContinueSession use the exact queued message instead of inferring the newest row")
+		return &agent.AgentResult{
+			Summary:  "queued reply",
+			ExitCode: 0,
+		}, nil
+	}
+	d.snapshots.data = map[string][]byte{
+		*session.SnapshotKey: []byte("restored-snapshot"),
+	}
+
+	err := buildOrchestrator(d).ContinueSession(context.Background(), session, &agent.ContinueSessionOptions{
+		ThreadID:        &threadID,
+		QueuedMessageID: &queuedMessageID,
+	})
+	require.NoError(t, err, "ContinueSession should process the exact queued message")
+}
+
 func TestContinueSession_FreshResumeClaudeTokenFailureFallsBackToAPIKey(t *testing.T) {
 	t.Parallel()
 

--- a/internal/services/github/pr_health_service.go
+++ b/internal/services/github/pr_health_service.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"strconv"
 	"strings"
 	"time"
 
@@ -761,16 +762,23 @@ func (s *PRService) resumeRepairSession(ctx context.Context, pr models.PullReque
 	if err != nil {
 		return nil, fmt.Errorf("list session threads for repair message: %w", err)
 	}
-	threadID, err := selectRepairThreadID(threads, requestedThreadID)
+	selectedThread, err := selectRepairThread(threads, requestedThreadID)
 	if err != nil {
 		return nil, err
+	}
+	var threadID *uuid.UUID
+	turnNumber := claimed.CurrentTurn + 1
+	if selectedThread != nil {
+		id := selectedThread.ID
+		threadID = &id
+		turnNumber = selectedThread.CurrentTurn + 1
 	}
 	msg := &models.SessionMessage{
 		SessionID:  claimed.ID,
 		OrgID:      pr.OrgID,
 		ThreadID:   threadID,
 		UserID:     &userID,
-		TurnNumber: claimed.CurrentTurn + 1,
+		TurnNumber: turnNumber,
 		Role:       models.MessageRoleUser,
 		Content:    shortPrompt,
 	}
@@ -806,6 +814,7 @@ func (s *PRService) resumeRepairSession(ctx context.Context, pr models.PullReque
 		"head_sha":            headSHA,
 		"workspace_mode":      string(workspaceMode),
 		"pull_request_number": pr.GitHubPRNumber,
+		"queued_message_id":   strconv.FormatInt(msg.ID, 10),
 	}
 	if threadID != nil {
 		payload["thread_id"] = threadID.String()
@@ -856,7 +865,27 @@ func (s *PRService) CompletePullRequestRepairRun(ctx context.Context, orgID, pul
 		}
 		return fmt.Errorf("load pull request health for repair completion event: %w", err)
 	}
+	if err := s.clearRepairRevisionContextIfIdle(ctx, pr, current); err != nil {
+		return err
+	}
 	s.publishPullRequestUpdated(ctx, pr, current)
+	return nil
+}
+
+func (s *PRService) clearRepairRevisionContextIfIdle(ctx context.Context, pr models.PullRequest, current models.PullRequestHealthCurrent) error {
+	if s.sessions == nil || s.pullRequests == nil || pr.SessionID == nil {
+		return nil
+	}
+	activeRuns, err := s.pullRequests.ListActiveRepairRunsByHead(ctx, pr.OrgID, pr.ID, current.HeadSHA)
+	if err != nil {
+		return fmt.Errorf("list active repair runs before clearing revision context: %w", err)
+	}
+	if len(activeRuns) > 0 {
+		return nil
+	}
+	if err := s.sessions.UpdateRevisionContext(ctx, pr.OrgID, *pr.SessionID, nil); err != nil {
+		return fmt.Errorf("clear repair revision context: %w", err)
+	}
 	return nil
 }
 
@@ -872,11 +901,20 @@ var ErrRepairAlreadyInProgress = errors.New("a repair session is already in prog
 var ErrRepairSessionBusy = errors.New("canonical pull request session is busy")
 
 func selectRepairThreadID(threads []models.SessionThread, requestedThreadID *uuid.UUID) (*uuid.UUID, error) {
+	thread, err := selectRepairThread(threads, requestedThreadID)
+	if err != nil || thread == nil {
+		return nil, err
+	}
+	id := thread.ID
+	return &id, nil
+}
+
+func selectRepairThread(threads []models.SessionThread, requestedThreadID *uuid.UUID) (*models.SessionThread, error) {
 	if requestedThreadID != nil {
-		for _, thread := range threads {
+		for i := range threads {
+			thread := threads[i]
 			if thread.ID == *requestedThreadID {
-				id := thread.ID
-				return &id, nil
+				return &thread, nil
 			}
 		}
 		return nil, ErrRepairThreadNotFound
@@ -884,8 +922,8 @@ func selectRepairThreadID(threads []models.SessionThread, requestedThreadID *uui
 	if len(threads) == 0 {
 		return nil, nil
 	}
-	id := threads[0].ID
-	return &id, nil
+	thread := threads[0]
+	return &thread, nil
 }
 
 func repairResponseMode(workspaceMode models.PullRequestRepairWorkspaceMode) string {

--- a/internal/services/github/pr_health_service_test.go
+++ b/internal/services/github/pr_health_service_test.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"testing"
 	"time"
 
@@ -30,6 +31,7 @@ type repairJobPayloadArg struct {
 	wantPullRequestID uuid.UUID
 	wantAction        models.PullRequestRepairActionType
 	wantHealthVersion int64
+	wantQueuedMessage int64
 }
 
 func (a repairJobPayloadArg) Match(value interface{}) bool {
@@ -50,7 +52,8 @@ func (a repairJobPayloadArg) Match(value interface{}) bool {
 	return payload["thread_id"] == a.wantThreadID.String() &&
 		payload["pull_request_id"] == a.wantPullRequestID.String() &&
 		payload["command_type"] == string(a.wantAction) &&
-		payload["health_version"] == float64(a.wantHealthVersion)
+		payload["health_version"] == float64(a.wantHealthVersion) &&
+		(a.wantQueuedMessage == 0 || payload["queued_message_id"] == strconv.FormatInt(a.wantQueuedMessage, 10))
 }
 
 func TestPRServiceBuildPullRequestHealthResponseUsesCurrentSummaryForRepairActions(t *testing.T) {
@@ -1491,6 +1494,101 @@ func TestPRServiceCompletePullRequestRepairRunPublishesUpdate(t *testing.T) {
 	require.NoError(t, mock.ExpectationsWereMet(), "all repair completion expectations should be met")
 }
 
+func TestPRServiceCompletePullRequestRepairRunClearsRevisionContextWhenNoActiveRepair(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "should create pgx mock pool")
+	defer mock.Close()
+
+	orgID := uuid.New()
+	pullRequestID := uuid.New()
+	sessionID := uuid.New()
+	repairRunID := uuid.New()
+	now := time.Now().UTC()
+	summaryJSON := json.RawMessage(`{"merge_state":"clean","has_conflicts":false,"failing_test_count":0,"needs_agent_action":false}`)
+
+	mock.ExpectExec("UPDATE pull_request_repair_runs").
+		WithArgs(pgx.NamedArgs{"org_id": orgID, "id": repairRunID}).
+		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
+	mock.ExpectQuery("SELECT .+ FROM pull_requests WHERE id").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(pgxmock.NewRows(prTestPullRequestColumns).AddRow(
+			pullRequestID, &sessionID, orgID, 42, "https://github.com/assembledhq/143/pull/42", "assembledhq/143",
+			"Fix bug", (*string)(nil), "open", "pending", "app", "", nil, nil, nil,
+			models.PullRequestMergeStateUnknown, false, 0, false, &now, int64(6), models.PullRequestMergeWhenReadyStateOff, (*uuid.UUID)(nil), (*time.Time)(nil), "", (*int64)(nil), "", (*time.Time)(nil), (*time.Time)(nil), now, now,
+		))
+	mock.ExpectQuery("SELECT .+ FROM pull_request_health_current WHERE org_id = .+ AND pull_request_id = .+").
+		WithArgs(pgx.NamedArgs{"org_id": orgID, "pull_request_id": pullRequestID}).
+		WillReturnRows(pgxmock.NewRows(prHealthCurrentTestColumns).AddRow(
+			pullRequestID, orgID, int64(6), "head-clean", "base-clean", summaryJSON, summaryJSON, models.PullRequestHealthEnrichmentStatusReady, nil, now, now,
+		))
+	mock.ExpectQuery("SELECT .+ FROM pull_request_repair_runs").
+		WithArgs(pgx.NamedArgs{"org_id": orgID, "pull_request_id": pullRequestID, "head_sha": "head-clean"}).
+		WillReturnRows(pgxmock.NewRows(prRepairRunTestColumns))
+	mock.ExpectExec("UPDATE sessions.+SET revision_context").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
+
+	service := &PRService{
+		pullRequests: db.NewPullRequestStore(mock),
+		sessions:     db.NewSessionStore(mock),
+		logger:       zerolog.New(io.Discard),
+	}
+
+	err = service.CompletePullRequestRepairRun(context.Background(), orgID, pullRequestID, repairRunID)
+	require.NoError(t, err, "CompletePullRequestRepairRun should clear stale repair revision context when no repair remains active for the head")
+	require.NoError(t, mock.ExpectationsWereMet(), "all revision-context cleanup expectations should be met")
+}
+
+func TestPRServiceCompletePullRequestRepairRunKeepsRevisionContextForActiveRepair(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "should create pgx mock pool")
+	defer mock.Close()
+
+	orgID := uuid.New()
+	pullRequestID := uuid.New()
+	sessionID := uuid.New()
+	repairRunID := uuid.New()
+	activeRunID := uuid.New()
+	now := time.Now().UTC()
+	summaryJSON := json.RawMessage(`{"merge_state":"blocked","has_conflicts":false,"failing_test_count":1,"needs_agent_action":true}`)
+
+	mock.ExpectExec("UPDATE pull_request_repair_runs").
+		WithArgs(pgx.NamedArgs{"org_id": orgID, "id": repairRunID}).
+		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
+	mock.ExpectQuery("SELECT .+ FROM pull_requests WHERE id").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(pgxmock.NewRows(prTestPullRequestColumns).AddRow(
+			pullRequestID, &sessionID, orgID, 42, "https://github.com/assembledhq/143/pull/42", "assembledhq/143",
+			"Fix bug", (*string)(nil), "open", "pending", "app", "", nil, nil, nil,
+			models.PullRequestMergeStateUnknown, false, 1, true, &now, int64(6), models.PullRequestMergeWhenReadyStateOff, (*uuid.UUID)(nil), (*time.Time)(nil), "", (*int64)(nil), "", (*time.Time)(nil), (*time.Time)(nil), now, now,
+		))
+	mock.ExpectQuery("SELECT .+ FROM pull_request_health_current WHERE org_id = .+ AND pull_request_id = .+").
+		WithArgs(pgx.NamedArgs{"org_id": orgID, "pull_request_id": pullRequestID}).
+		WillReturnRows(pgxmock.NewRows(prHealthCurrentTestColumns).AddRow(
+			pullRequestID, orgID, int64(6), "head-blocked", "base-blocked", summaryJSON, summaryJSON, models.PullRequestHealthEnrichmentStatusReady, nil, now, now,
+		))
+	mock.ExpectQuery("SELECT .+ FROM pull_request_repair_runs").
+		WithArgs(pgx.NamedArgs{"org_id": orgID, "pull_request_id": pullRequestID, "head_sha": "head-blocked"}).
+		WillReturnRows(pgxmock.NewRows(prRepairRunTestColumns).AddRow(
+			activeRunID, orgID, pullRequestID, sessionID, (*uuid.UUID)(nil), models.PullRequestRepairActionTypeFixTests,
+			int64(6), models.PullRequestRepairWorkspaceModeSnapshotContinuation, true, (*int64)(nil), now, now, "head-blocked", "base-blocked",
+		))
+
+	service := &PRService{
+		pullRequests: db.NewPullRequestStore(mock),
+		sessions:     db.NewSessionStore(mock),
+		logger:       zerolog.New(io.Discard),
+	}
+
+	err = service.CompletePullRequestRepairRun(context.Background(), orgID, pullRequestID, repairRunID)
+	require.NoError(t, err, "CompletePullRequestRepairRun should keep revision context while another repair remains active")
+	require.NoError(t, mock.ExpectationsWereMet(), "active repair should suppress revision-context cleanup")
+}
+
 func TestPRHealthServiceHelpers(t *testing.T) {
 	t.Parallel()
 
@@ -1552,6 +1650,10 @@ func TestPRServiceResumeRepairSession(t *testing.T) {
 			name: "resume repair session",
 			run: func(t *testing.T, mock pgxmock.PgxPoolIface, service *PRService, pr models.PullRequest, parentSession models.Session, userID uuid.UUID, now time.Time) {
 				threadID := uuid.New()
+				claimedSessionRow := newPRHealthSessionRow(parentSession.ID, pr.OrgID, now, models.SessionStatusRunning)
+				setPRHealthSessionRowValue(claimedSessionRow, "current_turn", 27)
+				threadRow := newPRHealthSessionThreadRow(threadID, parentSession.ID, pr.OrgID, now)
+				setPRHealthSessionThreadRowValue(threadRow, "current_turn", 4)
 				mock.ExpectBegin()
 				mock.ExpectQuery("UPDATE sessions").
 					WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
@@ -1561,7 +1663,7 @@ func TestPRServiceResumeRepairSession(t *testing.T) {
 				// arg compared to the legacy hardcoded IN (...) shape.
 				mock.ExpectQuery("UPDATE sessions").
 					WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
-					WillReturnRows(pgxmock.NewRows(prHealthSessionColumns).AddRow(newPRHealthSessionRow(parentSession.ID, pr.OrgID, now, models.SessionStatusRunning)...))
+					WillReturnRows(pgxmock.NewRows(prHealthSessionColumns).AddRow(claimedSessionRow...))
 				mock.ExpectExec("UPDATE sessions.+SET revision_context").
 					WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
 					WillReturnResult(pgxmock.NewResult("UPDATE", 1))
@@ -1569,7 +1671,7 @@ func TestPRServiceResumeRepairSession(t *testing.T) {
 					WithArgs(pr.OrgID, parentSession.ID).
 					WillReturnRows(
 						pgxmock.NewRows(prHealthSessionThreadColumns).
-							AddRow(newPRHealthSessionThreadRow(threadID, parentSession.ID, pr.OrgID, now)...),
+							AddRow(threadRow...),
 					)
 				mock.ExpectQuery("INSERT INTO session_messages").
 					WithArgs(
@@ -1577,7 +1679,7 @@ func TestPRServiceResumeRepairSession(t *testing.T) {
 						pr.OrgID,
 						uuidPtrArg{want: threadID},
 						pgxmock.AnyArg(),
-						1,
+						5,
 						models.MessageRoleUser,
 						"Please resolve the conflicts.",
 						pgxmock.AnyArg(),
@@ -1585,7 +1687,7 @@ func TestPRServiceResumeRepairSession(t *testing.T) {
 						pgxmock.AnyArg(),
 						pgxmock.AnyArg(),
 					).
-					WillReturnRows(pgxmock.NewRows([]string{"id", "created_at"}).AddRow(int64(1), now))
+					WillReturnRows(pgxmock.NewRows([]string{"id", "created_at"}).AddRow(int64(5127), now))
 				mock.ExpectQuery("INSERT INTO pull_request_repair_runs").
 					WithArgs(pgx.NamedArgs{
 						"org_id":               pr.OrgID,
@@ -1611,6 +1713,7 @@ func TestPRServiceResumeRepairSession(t *testing.T) {
 							wantPullRequestID: pr.ID,
 							wantAction:        models.PullRequestRepairActionTypeResolveConflicts,
 							wantHealthVersion: 9,
+							wantQueuedMessage: 5127,
 						},
 						"priority":   5,
 						"dedupe_key": pgxmock.AnyArg(),
@@ -2585,6 +2688,16 @@ func setPRHealthSessionRowValue(row []any, column string, value any) {
 		}
 	}
 	panic("unknown PR health session column: " + column)
+}
+
+func setPRHealthSessionThreadRowValue(row []any, column string, value any) {
+	for i, col := range prHealthSessionThreadColumns {
+		if col == column {
+			row[i] = value
+			return
+		}
+	}
+	panic("unknown PR health session thread column: " + column)
 }
 
 func strPtr(value string) *string {

--- a/internal/worker/handlers.go
+++ b/internal/worker/handlers.go
@@ -7102,24 +7102,20 @@ func newDeliverThreadInboxHandler(services *Services, logger zerolog.Logger) Job
 	}
 }
 
-func answerQueuedHumanInputForContinue(ctx context.Context, stores *Stores, orgID, sessionID, threadID uuid.UUID, hasThread bool, queuedMessageID string, logger zerolog.Logger) (*uuid.UUID, error) {
+func answerQueuedHumanInputForContinue(ctx context.Context, stores *Stores, orgID, sessionID, threadID uuid.UUID, hasThread bool, queuedMessageID int64, logger zerolog.Logger) (*uuid.UUID, error) {
 	if stores == nil || stores.HumanInputRequests == nil || stores.SessionMessages == nil {
 		return nil, nil
 	}
-	messageID, err := strconv.ParseInt(queuedMessageID, 10, 64)
-	if err != nil {
-		return nil, fmt.Errorf("parse queued message ID: %w", err)
-	}
-	queued, err := stores.SessionMessages.GetByID(ctx, orgID, messageID)
+	queued, err := stores.SessionMessages.GetByID(ctx, orgID, queuedMessageID)
 	if err != nil {
 		return nil, fmt.Errorf("fetch queued message for human input answer: %w", err)
 	}
 	if queued.SessionID != sessionID {
-		return nil, fmt.Errorf("queued message %d belongs to session %s, not %s", messageID, queued.SessionID, sessionID)
+		return nil, fmt.Errorf("queued message %d belongs to session %s, not %s", queuedMessageID, queued.SessionID, sessionID)
 	}
 	if hasThread {
 		if queued.ThreadID == nil || *queued.ThreadID != threadID {
-			return nil, fmt.Errorf("queued message %d does not belong to thread %s", messageID, threadID)
+			return nil, fmt.Errorf("queued message %d does not belong to thread %s", queuedMessageID, threadID)
 		}
 	}
 	if queued.UserID == nil {
@@ -7139,7 +7135,7 @@ func answerQueuedHumanInputForContinue(ctx context.Context, stores *Stores, orgI
 		logger.Warn().Err(err).
 			Str("session_id", sessionID.String()).
 			Str("thread_id", threadID.String()).
-			Int64("queued_message_id", messageID).
+			Int64("queued_message_id", queuedMessageID).
 			Msg("failed to answer pending human-input request from queued message")
 		return nil, nil
 	}
@@ -7205,12 +7201,20 @@ func newContinueSessionHandler(stores *Stores, services *Services, logger zerolo
 		var continueOpts *agent.ContinueSessionOptions
 		var resultAgentSessionID string
 		var humanInputRequestID *uuid.UUID
+		var queuedMessageID *int64
 		if input.HumanInputRequestID != "" {
 			parsedHumanInputRequestID, parseErr := uuid.Parse(input.HumanInputRequestID)
 			if parseErr != nil {
 				return fmt.Errorf("parse human input request ID: %w", parseErr)
 			}
 			humanInputRequestID = &parsedHumanInputRequestID
+		}
+		if input.QueuedMessageID != "" {
+			parsedQueuedMessageID, parseErr := strconv.ParseInt(input.QueuedMessageID, 10, 64)
+			if parseErr != nil {
+				return fmt.Errorf("parse queued message ID: %w", parseErr)
+			}
+			queuedMessageID = &parsedQueuedMessageID
 		}
 		// Captured by the OnTurnComplete callback so the post-success block
 		// below can persist per-thread result metadata (diff, summary,
@@ -7290,6 +7294,7 @@ func newContinueSessionHandler(stores *Stores, services *Services, logger zerolo
 					ThreadAgentSessionID: thread.AgentSessionID,
 					ResultAgentSessionID: &resultAgentSessionID,
 					HumanInputRequestID:  humanInputRequestID,
+					QueuedMessageID:      queuedMessageID,
 					ThreadID:             &threadIDLocal,
 					OnTurnComplete: func(result *agent.AgentResult) {
 						lastTurnResult = result
@@ -7305,17 +7310,24 @@ func newContinueSessionHandler(stores *Stores, services *Services, logger zerolo
 				continueOpts = threadOpts
 			}
 		}
-		if humanInputRequestID == nil && input.QueuedMessageID != "" {
-			answeredID, answerErr := answerQueuedHumanInputForContinue(ctx, stores, orgID, sessionID, threadID, hasThread, input.QueuedMessageID, logger)
+		isPRRepairContinuation := continueOpts != nil && continueOpts.PRRepair != nil
+		if humanInputRequestID == nil && queuedMessageID != nil && !isPRRepairContinuation {
+			answeredID, answerErr := answerQueuedHumanInputForContinue(ctx, stores, orgID, sessionID, threadID, hasThread, *queuedMessageID, logger)
 			if answerErr != nil {
 				return answerErr
 			}
 			humanInputRequestID = answeredID
 		}
-		if continueOpts == nil && humanInputRequestID != nil {
-			continueOpts = &agent.ContinueSessionOptions{HumanInputRequestID: humanInputRequestID}
-		} else if continueOpts != nil && humanInputRequestID != nil {
-			continueOpts.HumanInputRequestID = humanInputRequestID
+		if continueOpts == nil && (humanInputRequestID != nil || queuedMessageID != nil) {
+			continueOpts = &agent.ContinueSessionOptions{
+				HumanInputRequestID: humanInputRequestID,
+				QueuedMessageID:     queuedMessageID,
+			}
+		} else if continueOpts != nil {
+			if humanInputRequestID != nil {
+				continueOpts.HumanInputRequestID = humanInputRequestID
+			}
+			continueOpts.QueuedMessageID = queuedMessageID
 		}
 
 		var dispatchThreadID *uuid.UUID

--- a/internal/worker/handlers_test.go
+++ b/internal/worker/handlers_test.go
@@ -7454,6 +7454,106 @@ func TestContinueSessionHandler_PassesPRRepairCommandOptions(t *testing.T) {
 	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
 }
 
+func TestContinueSessionHandler_PassesQueuedMessageID(t *testing.T) {
+	t.Parallel()
+
+	stores, mock := newTestStores(t)
+	defer mock.Close()
+	stores.HumanInputRequests = nil
+
+	orgID := uuid.New()
+	sessionID := uuid.New()
+	issueID := uuid.New()
+	queuedMessageID := int64(5127)
+
+	mock.ExpectQuery("SELECT .* FROM sessions").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(
+			pgxmock.NewRows(workerSessionColumns).AddRow(
+				workerSessionRow(sessionID, issueID, orgID, models.SessionStatusIdle, 2, nil, nil)...,
+			),
+		)
+
+	orch := &orchestratorServiceStub{
+		continueSessionFn: func(ctx context.Context, session *models.Session, opts *agent.ContinueSessionOptions) error {
+			require.NotNil(t, opts, "queued_message_id should force continue_session options even without human input")
+			require.NotNil(t, opts.QueuedMessageID, "continue_session should pass the queued message id to the orchestrator")
+			require.Equal(t, queuedMessageID, *opts.QueuedMessageID, "continue_session should preserve the queued message id from the job payload")
+			return nil
+		},
+	}
+
+	handler := newContinueSessionHandler(stores, &Services{Orchestrator: orch}, zerolog.Nop())
+	payload := map[string]any{
+		"session_id":        sessionID.String(),
+		"org_id":            orgID.String(),
+		"queued_message_id": "5127",
+	}
+	payloadJSON, err := json.Marshal(payload)
+	require.NoError(t, err, "test payload should marshal")
+
+	err = handler(context.Background(), "continue_session", payloadJSON)
+	require.NoError(t, err, "continue_session should accept queued_message_id")
+	require.Equal(t, 1, orch.continueSessionCalls, "continue_session should invoke the orchestrator once")
+	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
+}
+
+func TestContinueSessionHandler_DoesNotAnswerHumanInputFromPRRepairQueuedMessage(t *testing.T) {
+	t.Parallel()
+
+	stores, mock := newTestStores(t)
+	defer mock.Close()
+	stores.SessionMessages = db.NewSessionMessageStore(mock)
+	stores.HumanInputRequests = db.NewSessionHumanInputRequestStore(mock)
+
+	orgID := uuid.New()
+	sessionID := uuid.New()
+	issueID := uuid.New()
+	prID := uuid.New()
+	repairRunID := uuid.New()
+	queuedMessageID := int64(5127)
+
+	mock.ExpectQuery("SELECT .* FROM sessions").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(
+			pgxmock.NewRows(workerSessionColumns).AddRow(
+				workerSessionRow(sessionID, issueID, orgID, models.SessionStatusIdle, 2, nil, nil)...,
+			),
+		)
+
+	orch := &orchestratorServiceStub{
+		continueSessionFn: func(ctx context.Context, session *models.Session, opts *agent.ContinueSessionOptions) error {
+			require.NotNil(t, opts, "PR repair continue_session should pass options")
+			require.NotNil(t, opts.PRRepair, "PR repair metadata should still reach the orchestrator")
+			require.Nil(t, opts.HumanInputRequestID, "PR repair queued_message_id should not be converted into a human-input answer")
+			require.NotNil(t, opts.QueuedMessageID, "PR repair should preserve queued_message_id as the exact carrier")
+			require.Equal(t, queuedMessageID, *opts.QueuedMessageID, "PR repair should pass the queued repair prompt id to the orchestrator")
+			return nil
+		},
+	}
+
+	handler := newContinueSessionHandler(stores, &Services{Orchestrator: orch}, zerolog.Nop())
+	payload := map[string]any{
+		"session_id":          sessionID.String(),
+		"org_id":              orgID.String(),
+		"pull_request_id":     prID.String(),
+		"repair_run_id":       repairRunID.String(),
+		"command_type":        "resolve_conflicts",
+		"health_version":      12,
+		"head_sha":            "head-sha",
+		"workspace_mode":      "pr_head_reconstruction",
+		"pull_request_number": 42,
+		"queued_message_id":   "5127",
+	}
+	payloadJSON, err := json.Marshal(payload)
+	require.NoError(t, err, "test payload should marshal")
+
+	err = handler(context.Background(), "continue_session", payloadJSON)
+	require.NoError(t, err, "PR repair queued_message_id should not be treated as a human-input answer")
+	require.Equal(t, 1, orch.continueSessionCalls, "continue_session should invoke the orchestrator once")
+	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
+}
+
 func TestContinueSessionHandler_CompletesPRRepairAfterSuccess(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- Add queued message IDs to continue-session options so the orchestrator can resume from the exact queued user message instead of inferring the latest row.
- Tighten message selection logic to prefer the newest message within a thread by row identity, and make scope checks consistent across thread-aware helpers.
- Propagate queued message IDs through repair-session job payloads and worker handling, and clear repair revision context once no active repairs remain.
- Expand tests around thread-scoped message selection, queued-message resumption, and repair-context cleanup.

## Testing
- Added and updated unit tests covering queued-message selection, thread-scoped ordering, repair run payloads, and revision-context cleanup behavior.
- Existing targeted service and orchestrator test coverage was updated to validate the new control flow.