### PR TITLE
Remove session route-level loading fallback to prevent flash during /sessions/:id switches

### DIFF
--- a/frontend/src/app/(dashboard)/sessions/[id]/loading.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/loading.test.tsx
@@ -1,11 +1,15 @@
-import { describe, expect, it } from 'vitest';
-import { render, screen } from '@testing-library/react';
-import Loading from './loading';
+import { existsSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
 
-describe('SessionDetail route loading shell', () => {
-  it('renders the session detail skeleton', () => {
-    render(<Loading />);
+describe("SessionDetail route loading shell", () => {
+  it("does not define a route-level loading fallback for session-to-session navigation", () => {
+    const routeDir = dirname(fileURLToPath(import.meta.url));
 
-    expect(screen.getByTestId('session-detail-loading-skeleton')).toBeInTheDocument();
+    expect(
+      existsSync(join(routeDir, "loading.tsx")),
+      "the [id]/loading.tsx fallback replaces the current session with a skeleton during /sessions/:id -> /sessions/:id navigation",
+    ).toBe(false);
   });
 });

--- a/frontend/src/app/(dashboard)/sessions/[id]/loading.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/loading.tsx
@@ -1,5 +1,0 @@
-import { SessionDetailLoadingSkeleton } from "./session-detail-loading-skeleton";
-
-export default function Loading() {
-  return <SessionDetailLoadingSkeleton />;
-}


### PR DESCRIPTION
## Summary

Switching between session details was causing a route-level UX flash: Next replaced the current session detail view with a skeleton during `/sessions/:id -> /sessions/:id` navigation. This is a reliability/UX risk because it breaks visual continuity and can look like content disappeared and reloaded.

This change removes the `frontend/src/app/(dashboard)/sessions/[id]/loading.tsx` fallback so the existing session detail client UI and React Query can handle in-place data transitions more gracefully while the URL still updates to `/sessions/:id` for deep links, refresh, and back/forward navigation.

## Changes

- Deleted `frontend/src/app/(dashboard)/sessions/[id]/loading.tsx` to stop Next from swapping the entire session detail surface to a loading skeleton on id changes.
- Updated `frontend/src/app/(dashboard)/sessions/[id]/loading.test.tsx` to add a regression check that `loading.tsx` must not exist for this route.

## Validation

- `vitest frontend/src/app/(dashboard)/sessions/[id]/loading.test.tsx`

[143.dev](https://143.dev) | [session bc8a0d24](https://143.dev/sessions/bc8a0d24-5f16-4b10-9b5a-a61680ce6a28)

Preview: https://143.dev/previews/github/assembledhq/143/pull/1467?launch=1