### PR TITLE
Fix preview open button stuck/disappearing when popup closes before load

### DIFF
--- a/frontend/src/components/preview/open-preview-button.test.tsx
+++ b/frontend/src/components/preview/open-preview-button.test.tsx
@@ -3,7 +3,7 @@ import { describe, expect, it, vi, afterEach } from "vitest";
 import userEvent from "@testing-library/user-event";
 import { toast } from "sonner";
 
-import { renderWithProviders, screen } from "@/test/test-utils";
+import { renderWithProviders, screen, waitFor } from "@/test/test-utils";
 import { OpenPreviewButton } from "./open-preview-button";
 
 vi.mock("sonner", () => ({
@@ -58,4 +58,131 @@ describe("OpenPreviewButton", () => {
     expect(toast.error).toHaveBeenCalledWith("Preview bootstrap timed out. Try opening it again.");
     expect(screen.getByRole("button", { name: "Open preview" })).toBeEnabled();
   }, 10_000);
+
+  it("keeps the button in its opening state until the popup preview load completes", async () => {
+    const user = userEvent.setup();
+    const popupListeners = new Map<string, EventListener>();
+    const popup = {
+      opener: window,
+      close: vi.fn(),
+      document: {
+        write: vi.fn(),
+        close: vi.fn(),
+      },
+      location: {
+        href: "",
+      },
+      addEventListener: vi.fn((type: string, listener: EventListener) => {
+        popupListeners.set(type, listener);
+      }),
+      removeEventListener: vi.fn((type: string) => {
+        popupListeners.delete(type);
+      }),
+    } as unknown as Window;
+    vi.spyOn(window, "open").mockReturnValue(popup);
+
+    renderWithProviders(
+      <OpenPreviewButton
+        previewId="prev-1"
+        previewUrl="https://prev-1.preview.143.dev"
+        bootstrapPreview={() => Promise.resolve({ token: "tok-1" })}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Open preview" }));
+    expect(screen.getByRole("button", { name: "Opening..." })).toBeDisabled();
+
+    await act(async () => {
+      window.dispatchEvent(
+        new MessageEvent("message", {
+          origin: "https://prev-1.preview.143.dev",
+          data: { type: "preview_bootstrap_ready" },
+        }),
+      );
+    });
+
+    await act(async () => {
+      window.dispatchEvent(
+        new MessageEvent("message", {
+          origin: "https://prev-1.preview.143.dev",
+          data: { type: "preview_bootstrap_complete" },
+        }),
+      );
+    });
+
+    await waitFor(() => {
+      expect(popup.location.href).toBe("https://prev-1.preview.143.dev");
+    });
+
+    expect(screen.getByRole("button", { name: "Opening..." })).toBeDisabled();
+    expect(popupListeners.has("load")).toBe(true);
+
+    await act(async () => {
+      popupListeners.get("load")?.(new Event("load"));
+    });
+
+    expect(screen.getByRole("button", { name: "Open preview" })).toBeEnabled();
+    expect(popup.removeEventListener).toHaveBeenCalledWith(
+      "load",
+      expect.any(Function),
+    );
+  });
+
+  it("recovers if the popup closes before the preview load event", async () => {
+    const user = userEvent.setup();
+    const popup = {
+      opener: window,
+      closed: false,
+      close: vi.fn(),
+      document: {
+        write: vi.fn(),
+        close: vi.fn(),
+      },
+      location: {
+        href: "",
+      },
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    } as unknown as Window;
+    vi.spyOn(window, "open").mockReturnValue(popup);
+
+    renderWithProviders(
+      <OpenPreviewButton
+        previewId="prev-1"
+        previewUrl="https://prev-1.preview.143.dev"
+        bootstrapPreview={() => Promise.resolve({ token: "tok-1" })}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Open preview" }));
+
+    await act(async () => {
+      window.dispatchEvent(
+        new MessageEvent("message", {
+          origin: "https://prev-1.preview.143.dev",
+          data: { type: "preview_bootstrap_ready" },
+        }),
+      );
+    });
+
+    await act(async () => {
+      window.dispatchEvent(
+        new MessageEvent("message", {
+          origin: "https://prev-1.preview.143.dev",
+          data: { type: "preview_bootstrap_complete" },
+        }),
+      );
+    });
+
+    expect(screen.getByRole("button", { name: "Opening..." })).toBeDisabled();
+
+    Object.defineProperty(popup, "closed", {
+      configurable: true,
+      value: true,
+    });
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Open preview" })).toBeEnabled();
+    });
+  });
 });

--- a/frontend/src/components/preview/open-preview-button.tsx
+++ b/frontend/src/components/preview/open-preview-button.tsx
@@ -15,6 +15,8 @@ import {
 } from "@/lib/preview-bootstrap";
 
 const BOOTSTRAP_TIMEOUT_MS = 5_000;
+const POPUP_NAVIGATION_POLL_MS = 250;
+const POPUP_NAVIGATION_TIMEOUT_MS = 30_000;
 
 // Document shown in the popup while the preview connects. Once the bootstrap
 // handshake completes we navigate the popup to the preview origin; because that
@@ -65,6 +67,9 @@ export function usePreviewLauncher(bootstrapPreview?: (previewId: string) => Pro
   const iframeRef = useRef<HTMLIFrameElement | null>(null);
   const pendingRef = useRef<PendingOpen | null>(null);
   const timeoutRef = useRef<number | null>(null);
+  const popupLoadCleanupRef = useRef<(() => void) | null>(null);
+  const popupNavigationPollRef = useRef<number | null>(null);
+  const popupNavigationTimeoutRef = useRef<number | null>(null);
   const [iframeSrc, setIframeSrc] = useState<string | undefined>();
   const [isOpening, setIsOpening] = useState(false);
   const [error, setError] = useState<Error | null>(null);
@@ -78,10 +83,53 @@ export function usePreviewLauncher(bootstrapPreview?: (previewId: string) => Pro
 
   const resetPendingOpen = useCallback(() => {
     clearTimeoutRef();
+    popupLoadCleanupRef.current?.();
+    popupLoadCleanupRef.current = null;
+    if (popupNavigationPollRef.current !== null) {
+      window.clearInterval(popupNavigationPollRef.current);
+      popupNavigationPollRef.current = null;
+    }
+    if (popupNavigationTimeoutRef.current !== null) {
+      window.clearTimeout(popupNavigationTimeoutRef.current);
+      popupNavigationTimeoutRef.current = null;
+    }
     pendingRef.current = null;
     setIframeSrc(undefined);
     setIsOpening(false);
   }, [clearTimeoutRef]);
+
+  const completeOpenWhenPopupLoads = useCallback(
+    (popup: Window) => {
+      popupLoadCleanupRef.current?.();
+
+      const onLoad = () => {
+        resetPendingOpen();
+      };
+
+      popup.addEventListener("load", onLoad, { once: true });
+      popupLoadCleanupRef.current = () => {
+        popup.removeEventListener("load", onLoad);
+      };
+
+      popupNavigationPollRef.current = window.setInterval(() => {
+        if (popup.closed) {
+          resetPendingOpen();
+          return;
+        }
+
+        try {
+          void popup.document;
+        } catch {
+          resetPendingOpen();
+        }
+      }, POPUP_NAVIGATION_POLL_MS);
+
+      popupNavigationTimeoutRef.current = window.setTimeout(() => {
+        resetPendingOpen();
+      }, POPUP_NAVIGATION_TIMEOUT_MS);
+    },
+    [resetPendingOpen],
+  );
 
   const failOpen = useCallback(
     (message: string) => {
@@ -180,22 +228,34 @@ export function usePreviewLauncher(bootstrapPreview?: (previewId: string) => Pro
       }
 
       if (event.data?.type === PREVIEW_BOOTSTRAP_COMPLETE_EVENT) {
+        clearTimeoutRef();
+        setIframeSrc(undefined);
         if (pending.currentTab) {
           window.open(pending.previewURL, "_self");
         } else if (pending.popup) {
+          completeOpenWhenPopupLoads(pending.popup);
           pending.popup.location.href = pending.previewURL;
         }
-        resetPendingOpen();
       }
     };
 
     window.addEventListener("message", handleMessage);
     return () => window.removeEventListener("message", handleMessage);
-  }, [bootstrapMutation, resetPendingOpen]);
+  }, [bootstrapMutation, clearTimeoutRef, completeOpenWhenPopupLoads]);
 
   useEffect(() => {
     return () => {
       clearTimeoutRef();
+      popupLoadCleanupRef.current?.();
+      popupLoadCleanupRef.current = null;
+      if (popupNavigationPollRef.current !== null) {
+        window.clearInterval(popupNavigationPollRef.current);
+        popupNavigationPollRef.current = null;
+      }
+      if (popupNavigationTimeoutRef.current !== null) {
+        window.clearTimeout(popupNavigationTimeoutRef.current);
+        popupNavigationTimeoutRef.current = null;
+      }
       if (pendingRef.current && !pendingRef.current.currentTab) {
         pendingRef.current.popup?.close();
       }


### PR DESCRIPTION
## Summary

The preview open workflow can leave the “Opening…” state incorrectly cleared (or never recovered) if the popup closes early or the expected load/navigation signals don’t arrive. This change makes the OpenPreviewButton keep its opening/loading state through normal preview navigation, and reliably reset/cleanup watcher/listener/timeout paths when the popup closes or unmounts.

## Changes

- Updated `OpenPreviewButton` to retain the “Opening…” disabled state until the preview finishes loading, and to recover if the popup closes before the load event fires.
- Fixed cleanup behavior on reset/unmount: listener/watchers/timeouts are correctly cleared and not double-removed across transitions.
- Added a regression test covering the “popup closed before preview load” case to prevent future spinner/state regressions.

## Validation

- `npm test -- --run src/components/preview/open-preview-button.test.tsx`
- `npm run typecheck`
- `npm run lint`
- `npm run build`

[143.dev](https://143.dev) | [session ea984fa3](https://143.dev/sessions/ea984fa3-8661-410a-a59d-281a0c455f61)

Preview: https://143.dev/previews/github/assembledhq/143/pull/1468?launch=1