### PR TITLE
Document how preview caching and startup work to keep branch previews in sync

### DIFF
--- a/docs/public/guides/previews.mdx
+++ b/docs/public/guides/previews.mdx
@@ -16,6 +16,22 @@ A preview turns a session from "read the diff" into "try the changed app." It is
 
 Previews are configured in `.143/config.json` under the top-level `preview` key. Commit that file to the repository so sessions, branch previews, and API-triggered previews all read the same contract.
 
+## How previews run
+
+143 starts your app inside the session sandbox, then exposes the primary service on an isolated preview URL. Services share the sandbox filesystem and can call each other on `localhost`; browser traffic only reaches the configured primary service.
+
+On startup, 143:
+
+<Steps>
+  <Step>Reads the selected preview config.</Step>
+  <Step>Starts managed infrastructure when the config declares it.</Step>
+  <Step>Restores safe caches and runs `preview.install` when needed.</Step>
+  <Step>Starts preview services.</Step>
+  <Step>Waits for readiness before showing the preview as openable.</Step>
+</Steps>
+
+Session previews always use the session workspace as the source of truth. Caches can restore dependencies and build tool artifacts, but they never replace the agent's current source files.
+
 ## Set up the config
 
 Start with the smallest shape that can boot your app:
@@ -83,6 +99,18 @@ Use services when the app needs a frontend and backend:
 
 Services share the same sandbox filesystem and `localhost` network namespace, so the frontend can call the backend at `http://localhost:8080`.
 
+## Keep previews current
+
+When an agent changes code, a running dev server usually applies the update through its normal hot-reload path. 143 records that live update so the preview can stay current without a full restart.
+
+Some changes need a restart because the process, dependency tree, or runtime contract changed. 143 marks the preview as needing refresh when changes touch files such as:
+
+- dependency manifests or lockfiles
+- `.143/config.json` or `.143/preview-start.sh`
+- build config, environment config, or database migrations
+
+Refreshing a preview restarts the preview runtime with the latest workspace. Dependency, package-manager, and build caches are reused when their keys still match, so refreshes do not have to reinstall or rebuild everything from scratch.
+
 ## Multiple preview configs
 
 If a repository has more than one previewable app, use named configs:
@@ -119,7 +147,7 @@ The Previews page can auto-select the default config or let you choose a named c
 
 ## Add dependencies
 
-Use `preview.install` when preview services need dependencies installed before they boot. This keeps package-manager work out of long service commands and lets 143 cache successful installs.
+Use `preview.install` when services need dependencies before they boot. Keep source-dependent builds out of `install`; put them in the service command so they run against the latest code.
 
 ```json
 {
@@ -141,13 +169,21 @@ Use `preview.install` when preview services need dependencies installed before t
 }
 ```
 
-143 reruns the install when the config or declared lockfiles change, or when a declared verify path is missing.
+143 reruns `install.command` when declared lockfiles or config change, or when a declared `verify_paths` entry is missing. With `verify_paths`, a fresh workspace can skip install after restoring a matching dependency cache.
 
-Declaring `verify_paths` also lets fresh workspaces skip the install entirely: when a dependency artifact cache hit matches the exact install command, lockfile contents, and sandbox image, 143 restores the cached artifacts and skips `command` once every verify path exists. Without `verify_paths`, fresh workspaces always run `command`.
+For cache tuning, see [Optimize preview startup](#optimize-preview-startup).
 
-Because the cache key contains no commit, install output is reused across commits whenever the install config and lockfiles are unchanged. `preview.install.command` must therefore produce output that depends only on those inputs — dependency installation, not application builds. A build step inside install that reads source files would be skipped at a newer commit and serve stale artifacts; keep source-dependent builds in the service `command`, where they run on every start.
+## Optimize preview startup
 
-Dependency artifact caching is enabled by default for session previews when `preview.install.lockfiles` and effective cache paths exist. Effective paths are:
+Use this section when previews boot correctly but cold starts are too slow.
+
+### Reuse dependency artifacts
+
+Declaring `verify_paths` lets fresh workspaces skip install entirely. When a cache hit matches the exact install command, lockfile contents, and sandbox image, 143 restores the cached artifacts and skips `install.command` once every verify path exists. Without `verify_paths`, fresh workspaces run `install.command`.
+
+Because the dependency cache key does not include the commit SHA, `install.command` must produce output that depends only on the install config and lockfiles. Do dependency installation here, not application builds. Source-dependent builds belong in the service `command`, where they run on every preview start.
+
+Effective dependency cache paths are:
 
 ```text
 clean_paths + cache.paths + inferred paths from known dependency files
@@ -161,7 +197,7 @@ clean_paths + cache.paths + inferred paths from known dependency files
 
 Inference is relative to the lockfile directory: `package-lock.json` infers `node_modules`, `services/api/poetry.lock` infers `services/api/.venv`, and `go.mod` infers `vendor`.
 
-For Python projects, no `cache` object is needed when a listed lockfile has a conventional local virtualenv:
+For Python projects, no `cache` object is needed when a listed lockfile uses a conventional local virtualenv:
 
 ```json
 {
@@ -189,7 +225,9 @@ For Go projects that use vendoring, `go.mod` infers `vendor`:
 }
 ```
 
-Add framework artifact caches with WorkDir-relative `cache.paths`, and add extra package-manager global caches with HomeDir-relative `cache.package_manager.paths`:
+### Add framework and package-manager caches
+
+Add framework artifact caches with WorkDir-relative `cache.paths`, and add extra package-manager global caches with HomeDir-relative `cache.package_manager.paths`.
 
 ```json
 {
@@ -225,9 +263,11 @@ Opt out when dependency artifacts are not safe to reuse:
 }
 ```
 
-Do not cache source directories, secret files, `.git`, or `.143/cache/preview-install`. Package-manager paths are relative to the sandbox home directory; broad or sensitive paths such as `.`, `.ssh`, `.gnupg`, `.codex`, `.claude`, `.config/gh`, and `.143` are rejected. `requirements.txt` can be unsafe if dependencies are not pinned; use a lockfile or opt out. Mutable image tags such as `latest` can also leave stale dependency artifacts, so prefer immutable digests or versioned tags.
+Do not cache source directories, secret files, `.git`, or `.143/cache/preview-install`. If dependencies look stale, change the lockfile so the key changes or temporarily set `cache.enabled: false`.
 
-If dependencies look stale, change the lockfile so the cache key changes, clear the preview cache when an admin cache API is available, or temporarily set `cache.enabled: false`.
+Package-manager paths are relative to the sandbox home directory. Broad or sensitive paths such as `.`, `.ssh`, `.gnupg`, `.codex`, `.claude`, `.config/gh`, and `.143` are rejected.
+
+`requirements.txt` can be unsafe if dependencies are not pinned; use a lockfile or opt out. Mutable image tags such as `latest` can also leave stale dependency artifacts, so prefer immutable digests or versioned tags.
 
 ## Add local infrastructure
 
@@ -344,13 +384,13 @@ Scope env secrets to the smallest service list with `services` or legacy `inject
 Any preview with `preview.secrets`, `preview.credentials.mode` other than `none`, or `preview.network.destinations` is treated as connected. Connected previews pin launch behavior to the base branch so a session diff cannot change commands, ports, env handling, secret bundle names, or generated secret file paths while secrets are in scope.
 </Callout>
 
-## How readiness works
+## Readiness
 
 143 starts declared services and waits for their readiness probes. A preview becomes available only after the primary service is reachable.
 
 <Steps>
   <Step>143 reads `.143/config.json` from the repo.</Step>
-  <Step>It starts infrastructure and services in dependency order.</Step>
+  <Step>It starts infrastructure, install steps, and services in dependency order.</Step>
   <Step>Each service must pass its readiness probe.</Step>
   <Step>The session page exposes the preview on an isolated preview origin.</Step>
 </Steps>

--- a/docs/public/reference/preview-config.mdx
+++ b/docs/public/reference/preview-config.mdx
@@ -71,7 +71,9 @@ Use `preview.default` to auto-select one config. If there are multiple configs a
 <ConfigField name="preview.install.cache.build.paths" type="string[]" description="Additive repo-relative build cache paths (globs allowed). Effective paths are build.paths + inferred Turborepo cache dirs next to each JS lockfile." />
 <ConfigField name="preview.install.timeout_seconds" type="integer" defaultValue="420" description="Maximum install duration. Max 1800." />
 
-Do not cache source directories, secret files, `.git`, `.143/cache`, `.143/cache/preview-install`, or any parent/glob path that can include preview install markers. For large repos, prefer narrow `cache.paths` or `cache.enabled: false`; use `preview.resources.limits.ephemeral-storage` for the final extracted dependency footprint, not as the primary cache correctness mechanism.
+Install caches are keyed from the install command, declared lockfiles, sandbox image, and effective cache paths. They speed up preview startup without replacing source files from the session workspace.
+
+Use `preview.install` for dependency installation only. Source-dependent builds belong in service commands, where they run against the current workspace on every start.
 
 Inferred dependency cache paths:
 
@@ -81,11 +83,15 @@ Inferred dependency cache paths:
 | `poetry.lock`, `uv.lock`, `Pipfile.lock`, `pdm.lock`, `requirements.txt`, `requirements-dev.txt` | `.venv` |
 | `go.mod`, `go.sum` | `vendor` |
 
-Inference is relative to the dependency file directory. For example, `services/api/poetry.lock` infers `services/api/.venv`, and `go.mod` infers `vendor`. Do not cache source directories, secret files, `.git`, or `.143/cache/preview-install`. For stale dependencies, change lockfiles, clear the preview cache when an admin cache API is available, or temporarily set `cache.enabled: false`.
+Inference is relative to the dependency file directory. For example, `services/api/poetry.lock` infers `services/api/.venv`, and `go.mod` infers `vendor`.
+
+Do not cache source directories, secret files, `.git`, `.143/cache`, `.143/cache/preview-install`, or any parent/glob path that can include preview install markers. `requirements.txt` is safe only when dependencies are pinned. For stale dependencies, change lockfiles or temporarily set `cache.enabled: false`.
 
 ### Build-artifact cache
 
-Separately from install artifacts, 143 caches incremental build output that services produce while booting (for example Turborepo's local task cache). JS lockfiles infer `node_modules/.cache/turbo` and `.turbo/cache` next to each lockfile; add other tool caches (such as `.next/cache`) via `preview.install.cache.build.paths`. The build cache is restored after the install phase and saved asynchronously once services report ready, using a latest-wins slot per preview config: the build tool's own content hashing makes a stale blob degrade to partial cache hits, never wrong output. Only cache directories whose build tool verifies entries by content hash.
+Build-artifact caches are separate from install artifacts. They are restored after install and saved asynchronously after services report ready. JS lockfiles infer Turborepo cache directories; add other content-addressed caches, such as `.next/cache`, with `preview.install.cache.build.paths`.
+
+Only cache build directories whose tool validates entries by content hash. A stale build cache should degrade to a partial miss, not serve wrong output.
 
 ## Service fields
 
@@ -191,4 +197,8 @@ Preview config is repository content. For fields that can expose secrets or netw
 
 For non-connected previews, service runtime fields can come from the session diff. For connected previews, launch behavior is pinned to the base branch. A preview is connected when `preview.secrets` is present, `preview.credentials.mode` is not `none`, or `preview.network.destinations` is non-empty.
 
-For task-based examples, see [Preview environments](/docs/guides/previews). For repo-wide setup, see [Repo config](/docs/guides/repo-config).
+## Runtime freshness
+
+143 can live-update ordinary source changes through the preview's dev server. Dependency, preview config, build config, environment config, and schema changes require a preview refresh. Refreshes reuse install, package-manager, and build caches when their keys still match.
+
+For task-based examples and behavior details, see [Preview environments](/docs/guides/previews). For repo-wide setup, see [Repo config](/docs/guides/repo-config).


### PR DESCRIPTION
## Summary

Previews can drift from the agent’s current code or start slowly due to unclear cache/install behavior. This change expands the previews docs to explain the end-to-end preview startup flow, when 143 refreshes a running preview, and how `preview.install` + `verify_paths` interact with dependency/build caches.

## Changes

- Added a “How previews run” section describing sandbox isolation, localhost service wiring, and the startup steps (config read → infra → cache restore/install → service start → readiness gate).
- Documented “Keep previews current” behavior: 143 tracks live updates and marks previews for refresh when changes affect runtime/process/deps (e.g., lockfiles, config scripts, env/build/db migrations).
- Updated guidance for `preview.install` to keep it focused on dependency bootstrapping (not code-dependent builds) and clarified when installs/commands rerun.
- Introduced “Optimize preview startup” and moved detailed cache tuning topics there (e.g., `verify_paths`, dependency cache keys, inferred cache paths, framework/package-manager examples, opt-out and stale-cache cautions).

## Validation

- `npm run test:ci -- src/lib/docs/public-docs.test.ts src/lib/source.test.ts`
- `npm run typecheck`
- `npm run lint`
- `npm run build`

[143.dev](https://143.dev) | [session 894aee18](https://143.dev/sessions/894aee18-c57c-4112-9664-81300dc1b1ea)

Preview: https://143.dev/previews/github/assembledhq/143/pull/1469?launch=1