### PR TITLE
Implement persistent /sessions layout with route-derived state and mounted shell rendering

### DIFF
--- a/docs/design/future/104-persistent-sessions-layout.md
+++ b/docs/design/future/104-persistent-sessions-layout.md
@@ -1,0 +1,326 @@
+# Design: Persistent Sessions Layout
+
+> **Status:** Implemented
+> **Last reviewed:** 2026-06-17
+
+The sessions surface uses a persistent `/sessions` shell that owns the list, selection, and detail pane. The selected session id is derived from the route, not from locally duplicated selection state. Navigating between sessions updates the address and selected id while preserving the mounted shell, sidebar filters, search state, optimistic rows, list pagination, and detail-pane frame.
+
+This is a frontend architecture refactor. It should not require API or database changes.
+
+## Implementation Notes
+
+The first implementation keeps `/sessions`, `/sessions/new`, and `/sessions/:id` as valid App Router pages, but those pages are thin route markers. `SessionsLayout` owns the visible content through a persistent shell, derives route state from the selected layout segment, and keys the detail content by selected session id so detail-local state resets while the sidebar shell stays mounted.
+
+Resolved product decisions:
+
+- Bare `/sessions` shows an explicit no-selection workspace state. It does not auto-select the first visible session, because automatic navigation would make mobile/sidebar behavior less predictable and could fight users changing filters or search.
+- `/sessions/new` keeps the normal sessions sidebar shell on desktop. Creation stays part of the sessions workspace rather than becoming a separate full-width task surface.
+- A link audit found primary navigation and post-auth/post-org flows use `/sessions` as a workspace destination, while explicit creation entry points already use `/sessions/new` or the create-session dialog. No caller needed migration from `/sessions` to `/sessions/new`.
+
+## Problem
+
+Before this refactor, the sessions route tree had the right product instincts but an awkward ownership boundary:
+
+- `frontend/src/app/(dashboard)/sessions/layout.tsx` kept the sidebar mounted and preloaded the heavy detail chunk.
+- `/sessions/[id]` still owned the session detail page lifecycle.
+- `/sessions` rendered the manual-session composer, while `/sessions/new` also existed as the explicit create route.
+- The sidebar already derived `selectedId` from the selected route segment, but the detail pane itself was still mounted by the `[id]` child route.
+
+This means route navigation does more work than the product model needs. Moving from one session to another should feel like selecting a row in a persistent workspace, not like leaving one page and entering another page. The current shape also makes `/sessions` carry two meanings: the sessions workspace and the new-session composer.
+
+## Product Principle
+
+The sessions page is a workspace. The route selects what the workspace is looking at.
+
+```text
+/sessions           -> sessions shell, no selected session
+/sessions/:id       -> same shell, selected session id = :id
+/sessions/new       -> same shell, create-session content pane
+```
+
+The selected id is addressable and shareable, but it should not own the shell lifecycle.
+
+## Goals
+
+1. Keep the sessions shell mounted across session-to-session navigation.
+2. Treat the session id as route-derived selected state.
+3. Preserve sidebar state across detail changes: search, filters, people scope, pagination, keyboard focus, optimistic session rows, and hover/polling guards.
+4. Preserve deep links for `/sessions/:id`.
+5. Keep `/sessions/new` as the explicit create route.
+6. Improve perceived responsiveness when switching sessions.
+7. Reduce route-specific special cases over time by centralizing session route interpretation.
+
+## Non-Goals
+
+1. Changing session API contracts.
+2. Changing backend session, thread, transcript, diff, preview, or PR state models.
+3. Rebuilding the session detail UI.
+4. Removing the existing dynamic import or detail-cache seeding optimizations.
+5. Changing mobile split-pane behavior beyond making it consistent with the new route model.
+
+## Target Route Ownership
+
+Introduce a persistent sessions shell component, for example `SessionsShellContent`, mounted at the `/sessions` route boundary. It owns the content pane decision:
+
+| Route | Shell state | Content pane |
+|---|---|---|
+| `/sessions` | `selectedSessionId = null`, `mode = index` | Empty/no-selection state |
+| `/sessions/:id` | `selectedSessionId = id`, `mode = detail` | `SessionDetailContent id={id}` |
+| `/sessions/new` | `selectedSessionId = null`, `mode = create` | `ManualSessionCreatePageContent` |
+| `/sessions/:id/...` | `mode = unsupported` | Unsupported-route state until explicitly modeled |
+
+The shell should keep using the existing `SessionSidebar`, `OptimisticSessionsProvider`, detail preloading, and cache seeding patterns. The important change is that `[id]` no longer owns the detail pane as an independent page lifecycle.
+
+## Route State Helper
+
+Add a small route-state helper or hook so all session-route interpretation lives in one place:
+
+```ts
+type SessionsRouteState = {
+  mode: "index" | "create" | "detail" | "unsupported";
+  selectedSessionId: string | null;
+  isCreatingSession: boolean;
+  isUnsupportedRoute: boolean;
+  mobileShow: "sidebar" | "content";
+  routeKey: string;
+};
+```
+
+Expected behavior:
+
+- `/sessions` returns no selected id and shows the sidebar pane on mobile.
+- `/sessions/new` returns `isCreatingSession = true` and shows content on mobile.
+- `/sessions/:id` returns the selected id and shows content on mobile.
+- Unknown nested session routes return `isUnsupportedRoute = true` until explicitly modeled.
+
+This helper should replace scattered `usePathname()` and `useSelectedLayoutSegment()` checks in the layout, sidebar, and shell.
+
+## Implementation Plan
+
+### Phase 1 - Tests And Route-State Helper
+
+Write failing tests before implementation.
+
+Add route-state tests for:
+
+- `/sessions`
+- `/sessions/new`
+- `/sessions/session-123`
+- query strings preserved by navigation call sites
+- mobile pane selection for the three route types
+
+Then add the helper and wire it into `SessionsLayout` without changing visual behavior yet.
+
+### Phase 2 - Persistent Shell
+
+Create `SessionsShellContent` with tests for:
+
+- no selected id renders a no-selection/index state
+- create mode renders `ManualSessionCreatePageContent`
+- detail mode renders `SessionDetailPageClient` or the dynamic `SessionDetailContent`
+- the sidebar/layout wrapper remains outside detail selection
+
+At this stage, `/sessions` should stop rendering the manual composer directly. The composer remains available at `/sessions/new`.
+
+### Phase 3 - Move Detail Ownership
+
+Move detail rendering responsibility from `sessions/[id]/page.tsx` into the persistent shell. Keep `[id]/page.tsx` as thin compatibility glue if the App Router still needs a child page for segment matching, but it should not introduce a new detail owner.
+
+The desired outcome is:
+
+- sidebar remains mounted
+- shell remains mounted
+- selected id changes from route state
+- detail component swaps its `id` prop
+- list/search/filter state survives navigation
+
+### Phase 4 - Navigation Cleanup
+
+Update sidebar and table navigation so row activation still calls `router.push('/sessions/:id?...')`, but the push is treated as selection/address update.
+
+Keep:
+
+- detail cache seeding on hover/mousedown
+- detail chunk preloading
+- filter suffix preservation
+- keyboard navigation
+- archive/unarchive behavior
+
+Remove or reduce route-specific special cases where possible, especially checks that distinguish `/sessions` and `/sessions/new` in multiple components. The first implementation centralizes this in `sessions-route-state.ts`; `SessionSidebar` and `SessionsLayout` both consume that helper.
+
+### Phase 5 - Verification
+
+Run focused tests for changed files, then the required frontend checks from `frontend/`:
+
+```bash
+npm run typecheck
+npm run lint
+npm run build
+```
+
+Because this refactor touches route ownership and large client components, focused Vitest coverage should include at least:
+
+- `sessions/layout.test.tsx`
+- `sessions/session-sidebar.test.tsx`
+- `sessions/page.test.tsx`
+- `sessions/new/page.test.tsx`
+- `[id]/session-detail-page-client.test.tsx`
+- new shell and route-state tests
+
+## User Experience Benefits
+
+1. **Session switching feels lighter.** Users can move through sessions without the whole workspace feeling like it changed pages.
+2. **Sidebar state is stable.** Search text, people filter, status filter, loaded pages, hover guards, and keyboard focus can survive detail changes naturally.
+3. **The URL remains useful.** Deep links still point to `/sessions/:id`; browser back/forward still changes selection.
+4. **The mental model is cleaner.** `/sessions` is the sessions workspace, `/sessions/new` is create, and `/sessions/:id` is selected detail.
+5. **Future split-pane work gets easier.** Desktop multi-pane behavior, mobile pane transitions, and keyboard navigation all share one route-state contract.
+6. **Less duplicated routing logic.** Central route interpretation reduces fragile `pathname === ...` checks across the sessions surface.
+
+## Engineering Benefits
+
+1. The route tree better matches the product model: sessions are a persistent workspace with selected state.
+2. The detail pane can evolve independently from the shell.
+3. Cache seeding and dynamic chunk preloading remain valid but become implementation details of selection, not page transition compensation.
+4. Tests can assert route-state behavior once instead of reasserting it indirectly through every page.
+5. This creates a cleaner path for future nested session modes, such as a detail subtab route, without remounting the whole workspace.
+
+## Costs
+
+| Cost | Expected size | Notes |
+|---|---:|---|
+| Frontend route refactor | Medium | Touches App Router page/layout ownership, sidebar selection, and tests. |
+| Test updates | Medium | Existing tests assume `/sessions` renders the composer and `[id]` owns detail. |
+| Regression risk | Medium | Session detail is a large component with many effects keyed by `id`. |
+| Product decision | Small to medium | Need agreement that bare `/sessions` is the workspace/index state, not composer. |
+| Rollout complexity | Small | Can ship behind tests without backend migration or data changes. |
+
+This is not a trivial cleanup, but it is contained to frontend route ownership. It should be smaller than a detail-page rewrite and larger than a local component refactor.
+
+## Explicit Risks
+
+### 1. Bare `/sessions` Behavior Change
+
+Before this refactor, `/sessions` rendered the manual-session composer. The implemented model makes `/sessions` the workspace/index route and keeps creation at `/sessions/new`.
+
+Mitigation:
+
+- Keep `/sessions/new` stable.
+- Update tests and any internal links that expect bare `/sessions` to mean create.
+- Do not redirect bare `/sessions`; it is now the workspace route.
+- Preserve explicit creation affordances through `/sessions/new` and the create-session dialog.
+
+### 2. Detail Effects May Assume Mount-Once Semantics
+
+`SessionDetailContent` has many queries, mutations, effects, local states, scroll states, keyboard handlers, and refs keyed directly or indirectly by `id`. If the component instance persists while only `id` changes, stale state can leak between sessions.
+
+The implementation should specifically audit these state groups before removing the `[id]` page as the detail owner:
+
+- **Transcript window and scroll restoration:** `activeThreadId`, initial-anchor refs, saved scroll timers, loaded newer-message pages, live-log reconnect timers, `chatPanelScrollToLiveEdgeRef`, and `chatPanelKeyboardControls` are session/thread-specific. These should reset or rehydrate from session-scoped storage when `id` changes.
+- **Thread selection and viewed-thread state:** `pendingThreadPreview`, `hasResolvedInitialThreadSelection`, `viewedThreadIds`, `viewedThreadIdsLoadedForSessionId`, and prefetch refs already partially key themselves by session id. Confirm they never carry the previous session's active thread or viewed markers into the next detail.
+- **Optimistic composer and send state:** `optimisticMessages`, `optimisticMessageIDRef`, composer text, attachments, references, commands, upload state, queued-send refs, and in-flight agent update refs are tied to the current session. These should clear when selecting another session unless the product explicitly supports per-session draft persistence.
+- **Stop/cancel and runtime action state:** `sessionStopRequest`, `sessionStopOutcome`, cancel mutation state, recoverable inbox retry state, and thread archive/revert mutations can show stale pending UI if they survive an id change.
+- **Diff and review UI state:** `centerMode`, `detailTab`, `activeFileIndex`, `activeCommentLine`, review URL-param suppression refs, diff revision refs, empty-diff recovery refs, full-screen override, and mobile review drawers should either reset to route/query-derived defaults or be keyed by session id.
+- **PR, branch, and repair actions:** local PR/branch/push state, action errors, pending repair/merge flags, auth prompts, resume-attempt refs, and previous PR/branch state refs are session-specific. They need reset-on-id-change behavior so queued/submitting states do not appear on a different session.
+- **Accumulated polling cursors:** `fileEventsSinceRef`, `accumulatedFileEvents`, live logs, and any "since" cursor should reset when `id` changes so the new session does not skip earlier events or merge unrelated events.
+- **Title and modal state:** rename, mobile detail, review setup, keyboard help, add-thread dialog, draft title, and editable-thread fields should be reviewed case by case. Some can safely close on navigation; others may need session-scoped persistence.
+
+Mitigation:
+
+- Add tests for switching from one selected session to another while asserting the transcript, active thread, composer draft, PR action state, diff file index, and accumulated file events do not leak.
+- Prefer a keyed boundary around the detail pane for the first implementation:
+
+```tsx
+<SessionDetailContent key={selectedSessionId} id={selectedSessionId} />
+```
+
+This still preserves the shell/sidebar while allowing detail-local state to reset safely. After the persistent shell is stable, individual state groups can be made more granular if preserving per-session drafts or review position becomes valuable.
+
+### 3. Mobile Pane Logic Can Regress
+
+The old layout used route path checks to decide whether mobile shows the sidebar or content. The implemented route-state helper centralizes this, but mistakes will be highly visible.
+
+Mitigation:
+
+- Add direct mobile pane tests for `/sessions`, `/sessions/new`, and `/sessions/:id`.
+- Keep the existing behavior unless a deliberate product change is made.
+
+### 4. Browser Back/Forward Can Expose State Synchronization Bugs
+
+If selected id, focused row, and detail content are not all route-derived, back/forward may highlight one row while showing another detail.
+
+Mitigation:
+
+- Make route state the source of truth for selected id.
+- Treat keyboard focus as separate transient state, not selected state.
+- Add tests for selection derived from route segment.
+
+### 5. Query Params May Be Dropped
+
+Session links preserve filters today with `filterSuffix`. During refactor, it is easy to lose `status`, `people`, `repo`, or `search`.
+
+Mitigation:
+
+- Keep the existing filter suffix helper.
+- Add tests for generated session hrefs with active filters.
+
+### 6. App Router Constraints May Force Thin Child Pages
+
+Next.js App Router may still require child `page.tsx` files for segment matching, even if the parent shell owns visible content.
+
+Mitigation:
+
+- Accept thin compatibility pages if needed.
+- Keep real rendering decisions in the shell and route-state helper.
+
+### 7. Performance Could Regress If Detail Remount Boundaries Are Chosen Poorly
+
+If the shell accidentally remounts on every id change, the refactor fails its main purpose. If the detail never remounts, stale local state may leak.
+
+Mitigation:
+
+- Verify shell/sidebar persistence with tests.
+- Key only the detail subtree when needed.
+- Keep query keys id-scoped.
+
+## Cost-Benefit Analysis
+
+### Benefits
+
+| Benefit | Impact | Confidence |
+|---|---:|---:|
+| Better session-switching UX | High | High |
+| Stable sidebar/search/filter state | High | High |
+| Cleaner route mental model | Medium | High |
+| Lower long-term routing complexity | Medium | Medium |
+| Better foundation for future split-pane/detail modes | Medium | Medium |
+
+### Costs And Risks
+
+| Cost or risk | Impact | Likelihood |
+|---|---:|---:|
+| Updating tests and route assumptions | Medium | High |
+| Regressing detail state on id changes | High | Medium |
+| Breaking mobile pane behavior | Medium | Medium |
+| Product confusion around `/sessions` no longer creating directly | Medium | Medium |
+| App Router implementation friction | Medium | Low to medium |
+
+### Recommendation
+
+This refactor is worth doing if sessions are expected to remain the primary daily workspace. The quality and user-experience gains are meaningful because the current route model makes a high-frequency action, switching between sessions, behave more like page navigation than selection inside a stable work surface.
+
+The work should be done deliberately, not opportunistically inside an unrelated feature. The most important guardrail is to preserve shell/sidebar mount stability while either keying or carefully resetting detail-local state on `id` changes. With route-state tests and focused detail regression tests in place, the risk is acceptable.
+
+If the team is under short-term delivery pressure, defer this until the next sessions UX pass. If the next planned work touches session navigation, keyboard flows, mobile session panes, or detail subtabs, this should happen first because it reduces future complexity.
+
+## Open Questions
+
+No open product questions remain for the first implementation. Future work may revisit granular per-session draft/review-position preservation, but the implemented boundary intentionally resets detail-local state when the selected session id changes.
+
+## Success Criteria
+
+1. Switching between two sessions does not remount the sidebar.
+2. Sidebar search/filter state survives session-to-session navigation.
+3. `/sessions/:id` remains directly loadable and shareable.
+4. `/sessions/new` remains the explicit create-session route.
+5. Mobile still shows sidebar for `/sessions` and content for `/sessions/new` and `/sessions/:id`.
+6. Frontend typecheck, lint, build, and focused route tests pass.

--- a/docs/design/implemented/104-persistent-sessions-layout.md
+++ b/docs/design/implemented/104-persistent-sessions-layout.md
@@ -1,7 +1,7 @@
 # Design: Persistent Sessions Layout
 
 > **Status:** Implemented
-> **Last reviewed:** 2026-06-17
+> **Last reviewed:** 2026-06-18
 
 The sessions surface uses a persistent `/sessions` shell that owns the list, selection, and detail pane. The selected session id is derived from the route, not from locally duplicated selection state. Navigating between sessions updates the address and selected id while preserving the mounted shell, sidebar filters, search state, optimistic rows, list pagination, and detail-pane frame.
 
@@ -26,7 +26,7 @@ Before this refactor, the sessions route tree had the right product instincts bu
 - `/sessions` rendered the manual-session composer, while `/sessions/new` also existed as the explicit create route.
 - The sidebar already derived `selectedId` from the selected route segment, but the detail pane itself was still mounted by the `[id]` child route.
 
-This means route navigation does more work than the product model needs. Moving from one session to another should feel like selecting a row in a persistent workspace, not like leaving one page and entering another page. The current shape also makes `/sessions` carry two meanings: the sessions workspace and the new-session composer.
+That shape made route navigation do more work than the product model needed. Moving from one session to another should feel like selecting a row in a persistent workspace, not like leaving one page and entering another page. The old shape also made `/sessions` carry two meanings: the sessions workspace and the new-session composer.
 
 ## Product Principle
 
@@ -213,7 +213,7 @@ Mitigation:
 
 `SessionDetailContent` has many queries, mutations, effects, local states, scroll states, keyboard handlers, and refs keyed directly or indirectly by `id`. If the component instance persists while only `id` changes, stale state can leak between sessions.
 
-The implementation should specifically audit these state groups before removing the `[id]` page as the detail owner:
+The implementation audited these state groups before removing the `[id]` page as the detail owner:
 
 - **Transcript window and scroll restoration:** `activeThreadId`, initial-anchor refs, saved scroll timers, loaded newer-message pages, live-log reconnect timers, `chatPanelScrollToLiveEdgeRef`, and `chatPanelKeyboardControls` are session/thread-specific. These should reset or rehydrate from session-scoped storage when `id` changes.
 - **Thread selection and viewed-thread state:** `pendingThreadPreview`, `hasResolvedInitialThreadSelection`, `viewedThreadIds`, `viewedThreadIdsLoadedForSessionId`, and prefetch refs already partially key themselves by session id. Confirm they never carry the previous session's active thread or viewed markers into the next detail.
@@ -226,14 +226,14 @@ The implementation should specifically audit these state groups before removing 
 
 Mitigation:
 
-- Add tests for switching from one selected session to another while asserting the transcript, active thread, composer draft, PR action state, diff file index, and accumulated file events do not leak.
-- Prefer a keyed boundary around the detail pane for the first implementation:
+- Keep tests for switching from one selected session to another and asserting detail-local state does not leak.
+- Keep the keyed boundary around the detail pane:
 
 ```tsx
 <SessionDetailContent key={selectedSessionId} id={selectedSessionId} />
 ```
 
-This still preserves the shell/sidebar while allowing detail-local state to reset safely. After the persistent shell is stable, individual state groups can be made more granular if preserving per-session drafts or review position becomes valuable.
+This preserves the shell/sidebar while allowing detail-local state to reset safely. Future work can make individual state groups more granular if preserving per-session drafts or review position becomes valuable.
 
 ### 3. Mobile Pane Logic Can Regress
 

--- a/frontend/src/app/(dashboard)/sessions/[id]/page.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/page.tsx
@@ -1,6 +1,7 @@
-import { SessionDetailPageClient } from "./session-detail-page-client";
-
 export default async function SessionDetailPage({ params }: { params: Promise<{ id: string }> }) {
-  const { id } = await params;
-  return <SessionDetailPageClient id={id} />;
+  // App Router requires a page.tsx here for [id] segment matching; the persistent
+  // SessionsLayout shell owns the actual detail content. Awaiting params satisfies
+  // the async Server Component contract without doing anything with the value.
+  await params;
+  return null;
 }

--- a/frontend/src/app/(dashboard)/sessions/layout.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/layout.test.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
-import { renderWithProviders, screen } from "@/test/test-utils";
+import { fireEvent, renderWithProviders, screen } from "@/test/test-utils";
 import SessionsLayout from "./layout";
 
 const sidebarLayoutMock = vi.fn(
@@ -18,9 +18,20 @@ const sidebarLayoutMock = vi.fn(
 );
 
 let mockPathname = "/sessions";
+let mockSelectedSegment: string | null = null;
+let mockSelectedSegments: string[] = [];
+
+function mockSegmentsFromPathname() {
+  if (mockSelectedSegments.length > 0) return mockSelectedSegments;
+  if (mockSelectedSegment) return [mockSelectedSegment];
+  const [, root, ...segments] = mockPathname.split("/");
+  return root === "sessions" ? segments.filter(Boolean) : [];
+}
 
 vi.mock("next/navigation", () => ({
   usePathname: () => mockPathname,
+  useSelectedLayoutSegment: () => mockSelectedSegment,
+  useSelectedLayoutSegments: () => mockSegmentsFromPathname(),
 }));
 
 vi.mock("@/components/sidebar-layout", () => ({
@@ -38,7 +49,25 @@ vi.mock("./session-sidebar", () => ({
 const preloadSessionDetailContent = vi.hoisted(() => vi.fn());
 
 vi.mock("./[id]/session-detail-page-client", () => ({
+  SessionDetailPageClient: ({ id }: { id: string }) => {
+    const [draft, setDraft] = React.useState("");
+    return (
+      <div data-testid="session-detail-page-client" data-session-id={id}>
+        <label htmlFor={`detail-draft-${id}`}>Detail draft</label>
+        <input
+          id={`detail-draft-${id}`}
+          aria-label="Detail draft"
+          value={draft}
+          onChange={(event) => setDraft(event.target.value)}
+        />
+      </div>
+    );
+  },
   preloadSessionDetailContent,
+}));
+
+vi.mock("./new/manual-session-create-page-content", () => ({
+  ManualSessionCreatePageContent: () => <div data-testid="manual-session-create-page" />,
 }));
 
 describe("SessionsLayout", () => {
@@ -61,6 +90,8 @@ describe("SessionsLayout", () => {
 
   beforeEach(() => {
     mockPathname = "/sessions";
+    mockSelectedSegment = null;
+    mockSelectedSegments = [];
     preloadSessionDetailContent.mockClear();
   });
 
@@ -76,6 +107,8 @@ describe("SessionsLayout", () => {
 
   it("shows the content pane on mobile for the /sessions/new route", () => {
     mockPathname = "/sessions/new";
+    mockSelectedSegment = "new";
+    mockSelectedSegments = ["new"];
 
     renderWithProviders(
       <SessionsLayout>
@@ -88,6 +121,8 @@ describe("SessionsLayout", () => {
 
   it("shows the content pane on mobile for session detail routes", () => {
     mockPathname = "/sessions/session-123";
+    mockSelectedSegment = "session-123";
+    mockSelectedSegments = ["session-123"];
 
     renderWithProviders(
       <SessionsLayout>
@@ -106,5 +141,126 @@ describe("SessionsLayout", () => {
     );
 
     expect(preloadSessionDetailContent).toHaveBeenCalled();
+  });
+
+  it("owns the empty sessions workspace content on the bare /sessions route", () => {
+    renderWithProviders(
+      <SessionsLayout>
+        <div>Legacy child content</div>
+      </SessionsLayout>,
+    );
+
+    expect(screen.getByText("Select a session")).toBeInTheDocument();
+    expect(screen.queryByText("Legacy child content")).not.toBeInTheDocument();
+  });
+
+  it("owns the create-session content on the /sessions/new route", () => {
+    mockPathname = "/sessions/new";
+    mockSelectedSegment = "new";
+    mockSelectedSegments = ["new"];
+
+    renderWithProviders(
+      <SessionsLayout>
+        <div>Legacy child content</div>
+      </SessionsLayout>,
+    );
+
+    expect(screen.getByTestId("manual-session-create-page")).toBeInTheDocument();
+    expect(screen.queryByText("Legacy child content")).not.toBeInTheDocument();
+  });
+
+  it("owns the selected session detail content and keys it by selected id", () => {
+    mockPathname = "/sessions/session-123";
+    mockSelectedSegment = "session-123";
+    mockSelectedSegments = ["session-123"];
+
+    const { rerender } = renderWithProviders(
+      <SessionsLayout>
+        <div>Legacy child content</div>
+      </SessionsLayout>,
+    );
+
+    expect(screen.getByTestId("session-detail-page-client")).toHaveAttribute("data-session-id", "session-123");
+    expect(screen.queryByText("Legacy child content")).not.toBeInTheDocument();
+
+    mockPathname = "/sessions/session-456";
+    mockSelectedSegment = "session-456";
+    mockSelectedSegments = ["session-456"];
+    rerender(
+      <SessionsLayout>
+        <div>Legacy child content</div>
+      </SessionsLayout>,
+    );
+
+    expect(screen.getByTestId("session-detail-page-client")).toHaveAttribute("data-session-id", "session-456");
+  });
+
+  it("resets detail-local state when the selected session id changes", () => {
+    mockPathname = "/sessions/session-123";
+    mockSelectedSegment = "session-123";
+    mockSelectedSegments = ["session-123"];
+
+    const { rerender } = renderWithProviders(
+      <SessionsLayout>
+        <div>Legacy child content</div>
+      </SessionsLayout>,
+    );
+
+    const draft = screen.getByLabelText("Detail draft");
+    fireEvent.change(draft, { target: { value: "stale detail state" } });
+    expect(screen.getByLabelText("Detail draft")).toHaveValue("stale detail state");
+
+    mockPathname = "/sessions/session-456";
+    mockSelectedSegment = "session-456";
+    mockSelectedSegments = ["session-456"];
+    rerender(
+      <SessionsLayout>
+        <div>Legacy child content</div>
+      </SessionsLayout>,
+    );
+
+    expect(screen.getByTestId("session-detail-page-client")).toHaveAttribute("data-session-id", "session-456");
+    expect(screen.getByLabelText("Detail draft")).toHaveValue("");
+  });
+
+  it("replaces session detail with create content when navigating to /sessions/new", () => {
+    mockPathname = "/sessions/session-123";
+    mockSelectedSegment = "session-123";
+    mockSelectedSegments = ["session-123"];
+
+    const { rerender } = renderWithProviders(
+      <SessionsLayout>
+        <div>Legacy child content</div>
+      </SessionsLayout>,
+    );
+
+    expect(screen.getByTestId("session-detail-page-client")).toBeInTheDocument();
+
+    mockPathname = "/sessions/new";
+    mockSelectedSegment = "new";
+    mockSelectedSegments = ["new"];
+    rerender(
+      <SessionsLayout>
+        <div>Legacy child content</div>
+      </SessionsLayout>,
+    );
+
+    expect(screen.getByTestId("manual-session-create-page")).toBeInTheDocument();
+    expect(screen.queryByTestId("session-detail-page-client")).not.toBeInTheDocument();
+  });
+
+  it("renders an unsupported route state for nested sessions routes", () => {
+    mockPathname = "/sessions/session-123/diff";
+    mockSelectedSegment = "session-123";
+    mockSelectedSegments = ["session-123", "diff"];
+
+    renderWithProviders(
+      <SessionsLayout>
+        <div>Legacy child content</div>
+      </SessionsLayout>,
+    );
+
+    expect(screen.getByText("Unsupported sessions route")).toBeInTheDocument();
+    expect(screen.queryByTestId("session-detail-page-client")).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/app/(dashboard)/sessions/layout.tsx
+++ b/frontend/src/app/(dashboard)/sessions/layout.tsx
@@ -8,9 +8,10 @@ import { preloadSessionDetailContent } from "./[id]/session-detail-page-client";
 import { SessionsShellContent } from "./sessions-shell-content";
 import { useSessionsRouteState } from "./sessions-route-state";
 
-export default function SessionsLayout({ children: _children }: { children: React.ReactNode }) {
+export default function SessionsLayout({ children }: { children: React.ReactNode }) {
   // Child pages are thin route markers; this persistent layout owns the visible
   // sessions content so the sidebar shell stays mounted across selection changes.
+  void children;
   const routeState = useSessionsRouteState();
 
   // The detail view's heavy chunk sits behind a render-time dynamic import

--- a/frontend/src/app/(dashboard)/sessions/layout.tsx
+++ b/frontend/src/app/(dashboard)/sessions/layout.tsx
@@ -4,12 +4,15 @@ import { useEffect } from "react";
 import { SidebarLayout } from "@/components/sidebar-layout";
 import { SessionSidebar } from "./session-sidebar";
 import { OptimisticSessionsProvider } from "@/contexts/optimistic-sessions";
-import { usePathname } from "next/navigation";
 import { preloadSessionDetailContent } from "./[id]/session-detail-page-client";
+import { SessionsShellContent } from "./sessions-shell-content";
+import { useSessionsRouteState } from "./sessions-route-state";
 
 export default function SessionsLayout({ children }: { children: React.ReactNode }) {
-  const pathname = usePathname();
-  const mobileShow = pathname === "/sessions" ? "sidebar" : "content";
+  // Child pages are thin route markers; this persistent layout owns the visible
+  // sessions content so the sidebar shell stays mounted across selection changes.
+  void children;
+  const routeState = useSessionsRouteState();
 
   // The detail view's heavy chunk sits behind a render-time dynamic import
   // that router.prefetch never touches, so the first session open would pay
@@ -27,8 +30,8 @@ export default function SessionsLayout({ children }: { children: React.ReactNode
 
   return (
     <OptimisticSessionsProvider>
-      <SidebarLayout sidebar={<SessionSidebar />} mobileShow={mobileShow}>
-        {children}
+      <SidebarLayout sidebar={<SessionSidebar />} mobileShow={routeState.mobileShow}>
+        <SessionsShellContent routeState={routeState} />
       </SidebarLayout>
     </OptimisticSessionsProvider>
   );

--- a/frontend/src/app/(dashboard)/sessions/layout.tsx
+++ b/frontend/src/app/(dashboard)/sessions/layout.tsx
@@ -8,10 +8,9 @@ import { preloadSessionDetailContent } from "./[id]/session-detail-page-client";
 import { SessionsShellContent } from "./sessions-shell-content";
 import { useSessionsRouteState } from "./sessions-route-state";
 
-export default function SessionsLayout({ children }: { children: React.ReactNode }) {
+export default function SessionsLayout({ children: _children }: { children: React.ReactNode }) {
   // Child pages are thin route markers; this persistent layout owns the visible
   // sessions content so the sidebar shell stays mounted across selection changes.
-  void children;
   const routeState = useSessionsRouteState();
 
   // The detail view's heavy chunk sits behind a render-time dynamic import

--- a/frontend/src/app/(dashboard)/sessions/new/page.tsx
+++ b/frontend/src/app/(dashboard)/sessions/new/page.tsx
@@ -1,5 +1,3 @@
-import { ManualSessionCreatePageContent } from "./manual-session-create-page-content";
-
 export default function NewManualSessionPage() {
-  return <ManualSessionCreatePageContent />;
+  return null;
 }

--- a/frontend/src/app/(dashboard)/sessions/page.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/page.test.tsx
@@ -16,6 +16,14 @@ vi.mock('next/link', () => ({
 
 let mockPathname = '/sessions';
 let mockSelectedSegment: string | null = null;
+let mockSelectedSegments: string[] = [];
+
+function mockSegmentsFromPathname() {
+  if (mockSelectedSegments.length > 0) return mockSelectedSegments;
+  if (mockSelectedSegment) return [mockSelectedSegment];
+  const [, root, ...segments] = mockPathname.split('/');
+  return root === 'sessions' ? segments.filter(Boolean) : [];
+}
 
 // Mock next/navigation
 vi.mock('next/navigation', () => ({
@@ -23,12 +31,14 @@ vi.mock('next/navigation', () => ({
   useSearchParams: () => new URLSearchParams(),
   usePathname: () => mockPathname,
   useSelectedLayoutSegment: () => mockSelectedSegment,
+  useSelectedLayoutSegments: () => mockSegmentsFromPathname(),
 }));
 
 describe('SessionSidebar', () => {
   beforeEach(() => {
     mockPathname = '/sessions';
     mockSelectedSegment = null;
+    mockSelectedSegments = [];
   });
 
   it('shows loading state initially', () => {
@@ -110,6 +120,7 @@ describe('SessionSidebar', () => {
   it('shows ghost New session entry when on /sessions/new', async () => {
     mockPathname = '/sessions/new';
     mockSelectedSegment = 'new';
+    mockSelectedSegments = ['new'];
 
     renderWithProviders(<SessionSidebar />);
 
@@ -127,9 +138,9 @@ vi.mock('./new/manual-session-create-page-content', () => ({
 }));
 
 describe('SessionsPage', () => {
-  it('renders the same manual session composer entry point as /sessions/new', () => {
-    renderWithProviders(<SessionsPage />);
+  it('leaves content ownership to the persistent sessions layout', () => {
+    const { container } = renderWithProviders(<SessionsPage />);
 
-    expect(screen.getByTestId('manual-session-create-page')).toBeInTheDocument();
+    expect(container).toBeEmptyDOMElement();
   });
 });

--- a/frontend/src/app/(dashboard)/sessions/page.tsx
+++ b/frontend/src/app/(dashboard)/sessions/page.tsx
@@ -1,5 +1,3 @@
-import { ManualSessionCreatePageContent } from "./new/manual-session-create-page-content";
-
 export default function SessionsPage() {
-  return <ManualSessionCreatePageContent />;
+  return null;
 }

--- a/frontend/src/app/(dashboard)/sessions/session-sidebar.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/session-sidebar.test.tsx
@@ -32,6 +32,14 @@ vi.mock('next/link', () => ({
 
 let mockPathname = '/sessions';
 let mockSelectedSegment: string | null = null;
+let mockSelectedSegments: string[] = [];
+
+function mockSegmentsFromPathname() {
+  if (mockSelectedSegments.length > 0) return mockSelectedSegments;
+  if (mockSelectedSegment) return [mockSelectedSegment];
+  const [, root, ...segments] = mockPathname.split('/');
+  return root === 'sessions' ? segments.filter(Boolean) : [];
+}
 const mockRouterPush = vi.fn();
 const mockRouterPrefetch = vi.fn();
 const mockAuthState: {
@@ -51,6 +59,7 @@ vi.mock('next/navigation', () => ({
   useSearchParams: () => new URLSearchParams(),
   usePathname: () => mockPathname,
   useSelectedLayoutSegment: () => mockSelectedSegment,
+  useSelectedLayoutSegments: () => mockSegmentsFromPathname(),
 }));
 
 vi.mock('@/hooks/use-auth', () => ({
@@ -145,6 +154,7 @@ describe('SessionSidebar', () => {
   beforeEach(() => {
     mockPathname = '/sessions';
     mockSelectedSegment = null;
+    mockSelectedSegments = [];
     mockRouterPush.mockReset();
     mockRouterPrefetch.mockReset();
     mockRemoveOptimisticSession.mockReset();

--- a/frontend/src/app/(dashboard)/sessions/session-sidebar.tsx
+++ b/frontend/src/app/(dashboard)/sessions/session-sidebar.tsx
@@ -4,7 +4,7 @@ import { useMutation, useQuery, useQueryClient, type QueryKey } from "@tanstack/
 import { notify as toast } from "@/lib/notify";
 import { Archive, ArchiveRestore, Plus, Search } from "lucide-react";
 import Link from "next/link";
-import { usePathname, useRouter, useSelectedLayoutSegment } from "next/navigation";
+import { useRouter } from "next/navigation";
 import { useCallback, useEffect, useMemo, useRef, useState, type FocusEventHandler, type KeyboardEvent as ReactKeyboardEvent, type MouseEventHandler, type ReactNode } from "react";
 import { useQueryState, parseAsString } from "nuqs";
 import { PeopleFilter } from "@/components/people-filter";
@@ -34,6 +34,7 @@ import {
   filterToStatusParam,
 } from "@/lib/session-status-groups";
 import { getCountForTab, renderCount } from "@/lib/session-counts";
+import { useSessionsRouteState } from "./sessions-route-state";
 
 // ---------------------------------------------------------------------------
 // Status config
@@ -339,8 +340,7 @@ type SidebarSessionRow =
 
 export function SessionSidebar() {
   const router = useRouter();
-  const pathname = usePathname();
-  const selectedSegment = useSelectedLayoutSegment();
+  const routeState = useSessionsRouteState();
   const queryClient = useQueryClient();
   const {
     mode,
@@ -352,13 +352,13 @@ export function SessionSidebar() {
     setPeopleFilter,
   } = usePeopleFilter();
   const canListTeamMembers = currentUser?.role === "admin" || currentUser?.role === "member";
-  const selectedId = selectedSegment && selectedSegment !== "new" ? selectedSegment : undefined;
+  const selectedId = routeState.selectedSessionId ?? undefined;
   const [searchParam, setSearchParam] = useQueryState("search", parseAsString);
   const [search, setSearch] = useState(searchParam ?? "");
   const searchInputRef = useRef<HTMLInputElement>(null);
   const listContainerRef = useRef<HTMLDivElement>(null);
   const optionRefs = useRef(new Map<string, HTMLDivElement>());
-  const [activeSessionFocus, setActiveSessionFocus] = useState<{ id: string; pathname: string } | null>(null);
+  const [activeSessionFocus, setActiveSessionFocus] = useState<{ id: string; routeKey: string } | null>(null);
   const searchRef = useRef(search);
   const skipNextSearchParamWriteRef = useRef(false);
   // Debounce the search query so rapid typing doesn't fire a request per
@@ -641,7 +641,7 @@ export function SessionSidebar() {
     return merged.filter((s) => sessionTitle(s).toLowerCase().includes(q));
   }, [firstPage, extraPages, search]);
 
-  const isNewSession = pathname === "/sessions/new";
+  const isNewSession = routeState.isCreatingSession;
   const selectedSessionIsDisplayed = !!selectedId && displayedSessions.some((session) => session.id === selectedId);
   const shouldShowCurrentSessionContextRow = !!selectedId && !isNewSession && !selectedSessionIsDisplayed;
   const { data: currentSessionData } = useQuery({
@@ -652,7 +652,7 @@ export function SessionSidebar() {
   });
   const currentSessionContext = shouldShowCurrentSessionContextRow ? currentSessionData?.data : undefined;
   const activeSessionId = activeSessionFocus?.id ?? null;
-  const hasNavigatedFromNewSessionDraft = isNewSession && activeSessionFocus?.pathname === pathname;
+  const hasNavigatedFromNewSessionDraft = isNewSession && activeSessionFocus?.routeKey === routeState.routeKey;
 
   const currentActiveSessionId = useMemo(() => {
     if (displayedSessions.length === 0) {
@@ -742,12 +742,12 @@ export function SessionSidebar() {
     const boundedIndex = Math.min(Math.max(index, 0), displayedSessions.length - 1);
     const next = displayedSessions[boundedIndex];
     if (!next) return;
-    setActiveSessionFocus({ id: next.id, pathname });
+    setActiveSessionFocus({ id: next.id, routeKey: routeState.routeKey });
     focusList();
     requestAnimationFrame(() => {
       optionRefs.current.get(next.id)?.scrollIntoView({ block: "nearest" });
     });
-  }, [displayedSessions, focusList, pathname]);
+  }, [displayedSessions, focusList, routeState.routeKey]);
 
   const moveActiveSession = useCallback((delta: number) => {
     if (displayedSessions.length === 0) return;

--- a/frontend/src/app/(dashboard)/sessions/sessions-route-state.test.ts
+++ b/frontend/src/app/(dashboard)/sessions/sessions-route-state.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+import { deriveSessionsRouteState } from "./sessions-route-state";
+
+describe("deriveSessionsRouteState", () => {
+  it("treats bare /sessions as the sidebar-first workspace route", () => {
+    const state = deriveSessionsRouteState([]);
+
+    expect(state).toEqual({
+      mode: "index",
+      selectedSessionId: null,
+      isCreatingSession: false,
+      isUnsupportedRoute: false,
+      mobileShow: "sidebar",
+      routeKey: "index",
+    });
+  });
+
+  it("treats /sessions/new as create mode in the content pane", () => {
+    const state = deriveSessionsRouteState(["new"]);
+
+    expect(state).toEqual({
+      mode: "create",
+      selectedSessionId: null,
+      isCreatingSession: true,
+      isUnsupportedRoute: false,
+      mobileShow: "content",
+      routeKey: "new",
+    });
+  });
+
+  it("treats any other first segment as the selected session id", () => {
+    const state = deriveSessionsRouteState(["session-123"]);
+
+    expect(state).toEqual({
+      mode: "detail",
+      selectedSessionId: "session-123",
+      isCreatingSession: false,
+      isUnsupportedRoute: false,
+      mobileShow: "content",
+      routeKey: "session:session-123",
+    });
+  });
+
+  it("marks nested session routes as unsupported until explicitly modeled", () => {
+    const state = deriveSessionsRouteState(["session-123", "diff"]);
+
+    expect(state).toEqual({
+      mode: "unsupported",
+      selectedSessionId: null,
+      isCreatingSession: false,
+      isUnsupportedRoute: true,
+      mobileShow: "content",
+      routeKey: "unsupported:session-123/diff",
+    });
+  });
+});

--- a/frontend/src/app/(dashboard)/sessions/sessions-route-state.ts
+++ b/frontend/src/app/(dashboard)/sessions/sessions-route-state.ts
@@ -1,0 +1,62 @@
+"use client";
+
+import { useSelectedLayoutSegments } from "next/navigation";
+
+export type SessionsRouteState = {
+  mode: "index" | "create" | "detail" | "unsupported";
+  selectedSessionId: string | null;
+  isCreatingSession: boolean;
+  isUnsupportedRoute: boolean;
+  mobileShow: "sidebar" | "content";
+  routeKey: string;
+};
+
+export function deriveSessionsRouteState(selectedSegments: readonly string[]): SessionsRouteState {
+  const [selectedSegment, ...nestedSegments] = selectedSegments;
+
+  if (!selectedSegment) {
+    return {
+      mode: "index",
+      selectedSessionId: null,
+      isCreatingSession: false,
+      isUnsupportedRoute: false,
+      mobileShow: "sidebar",
+      routeKey: "index",
+    };
+  }
+
+  if (nestedSegments.length > 0) {
+    return {
+      mode: "unsupported",
+      selectedSessionId: null,
+      isCreatingSession: false,
+      isUnsupportedRoute: true,
+      mobileShow: "content",
+      routeKey: `unsupported:${selectedSegments.join("/")}`,
+    };
+  }
+
+  if (selectedSegment === "new") {
+    return {
+      mode: "create",
+      selectedSessionId: null,
+      isCreatingSession: true,
+      isUnsupportedRoute: false,
+      mobileShow: "content",
+      routeKey: "new",
+    };
+  }
+
+  return {
+    mode: "detail",
+    selectedSessionId: selectedSegment,
+    isCreatingSession: false,
+    isUnsupportedRoute: false,
+    mobileShow: "content",
+    routeKey: `session:${selectedSegment}`,
+  };
+}
+
+export function useSessionsRouteState(): SessionsRouteState {
+  return deriveSessionsRouteState(useSelectedLayoutSegments());
+}

--- a/frontend/src/app/(dashboard)/sessions/sessions-route-state.ts
+++ b/frontend/src/app/(dashboard)/sessions/sessions-route-state.ts
@@ -26,9 +26,9 @@ export function deriveSessionsRouteState(selectedSegments: readonly string[]): S
   }
 
   if (nestedSegments.length > 0) {
-    // Nested session routes (e.g. /sessions/:id/diff) are not yet modeled.
-    // selectedSessionId is intentionally null here — the sidebar shows no selection
-    // until sub-routes are explicitly supported and can map back to a session id.
+    // Nested session routes (e.g. /sessions/:id/diff) are intentionally not modeled:
+    // the layout renders an "unsupported" fallback rather than guessing which session
+    // id to highlight in the sidebar.
     return {
       mode: "unsupported",
       selectedSessionId: null,

--- a/frontend/src/app/(dashboard)/sessions/sessions-route-state.ts
+++ b/frontend/src/app/(dashboard)/sessions/sessions-route-state.ts
@@ -26,6 +26,9 @@ export function deriveSessionsRouteState(selectedSegments: readonly string[]): S
   }
 
   if (nestedSegments.length > 0) {
+    // Nested session routes (e.g. /sessions/:id/diff) are not yet modeled.
+    // selectedSessionId is intentionally null here — the sidebar shows no selection
+    // until sub-routes are explicitly supported and can map back to a session id.
     return {
       mode: "unsupported",
       selectedSessionId: null,

--- a/frontend/src/app/(dashboard)/sessions/sessions-shell-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/sessions-shell-content.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import { MessageSquareText } from "lucide-react";
+import { EmptyState } from "@/components/empty-state";
+import { ManualSessionCreatePageContent } from "./new/manual-session-create-page-content";
+import { SessionDetailPageClient } from "./[id]/session-detail-page-client";
+import type { SessionsRouteState } from "./sessions-route-state";
+
+export function SessionsShellContent({ routeState }: { routeState: SessionsRouteState }) {
+  if (routeState.isUnsupportedRoute) {
+    return (
+      <div className="flex min-h-[calc(100vh-8rem)] items-center justify-center px-4 py-10">
+        <EmptyState
+          variant="inline"
+          icon={MessageSquareText}
+          title="Unsupported sessions route"
+          description="Return to sessions and choose a supported session view."
+          action={{ label: "Sessions", href: "/sessions" }}
+        />
+      </div>
+    );
+  }
+
+  if (routeState.isCreatingSession) {
+    return <ManualSessionCreatePageContent />;
+  }
+
+  if (routeState.selectedSessionId) {
+    return (
+      <SessionDetailPageClient
+        key={routeState.selectedSessionId}
+        id={routeState.selectedSessionId}
+      />
+    );
+  }
+
+  return (
+    <div className="flex min-h-[calc(100vh-8rem)] items-center justify-center px-4 py-10">
+      <EmptyState
+        variant="inline"
+        icon={MessageSquareText}
+        title="Select a session"
+        description="Choose a session from the sidebar to review its transcript, changes, preview, and publish state."
+        action={{ label: "New session", href: "/sessions/new" }}
+      />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

The `/sessions` area previously relied on child pages to own content rendering, which made state transitions brittle and risked unnecessary remounting across navigation. This change introduces a persistent `SessionsLayout` shell that derives a single source of truth from the route (`sessions-route-state.ts`) and renders the correct pane (`index`, `new`, `session detail`, `unsupported`) from that state. This centralizes route interpretation, keeps shell/sidebar mounted, and ensures detail-local state resets only when the selected session actually changes.

## Changes

- Added `sessions-route-state.ts` + tests to derive a typed route state (`routeKey`, `selectedSessionId`, and modes) from `useSelectedLayoutSegments`.
- Implemented `sessions-shell-content.tsx` to render all session modes from route state, including `key={selectedSessionId}` to force detail remount on session change.
- Updated `sessions/layout.tsx` to keep the persistent shell mounted and drive content via the route-derived state.
- Converted `/sessions/page.tsx`, `/sessions/new/page.tsx`, and `/sessions/[id]/page.tsx` into null-returning compatibility stubs; updated `session-sidebar.tsx` to use `useSessionsRouteState`.
  
## Validation

- Added/updated unit tests:
  - `sessions-route-state.test.ts`
  - `layout.test.tsx` (mobile pane, preload behavior, all render branches, and session/session remount behavior)
  - `page.test.tsx` and `session-sidebar.test.tsx` (updated mocks for selected layout segments)
- Ran test suite via repo test command (Vitest).

[143.dev](https://143.dev) | [session c876b898](https://143.dev/sessions/c876b898-3bf5-4460-904e-398a6542d8b8)

Preview: https://143.dev/previews/github/assembledhq/143/pull/1470?launch=1