### PR TITLE
Stabilize frontend tests and default API key fields

### DIFF
--- a/frontend/src/app/(dashboard)/previews/github/[owner]/[repo]/pull/[number]/page.test.tsx
+++ b/frontend/src/app/(dashboard)/previews/github/[owner]/[repo]/pull/[number]/page.test.tsx
@@ -219,6 +219,7 @@ describe("PullRequestPreviewPage", () => {
   it("bootstraps preview access before opening the preview origin", async () => {
     let bootstrapCalls = 0;
     const openedWindow = {
+      addEventListener: vi.fn(),
       close: vi.fn(),
       document: {
         close: vi.fn(),
@@ -228,6 +229,7 @@ describe("PullRequestPreviewPage", () => {
         href: "about:blank",
       },
       opener: null,
+      removeEventListener: vi.fn(),
     } as unknown as Window;
     const openSpy = vi.spyOn(window, "open").mockReturnValue(openedWindow);
 

--- a/frontend/src/app/(dashboard)/settings/account/page.test.tsx
+++ b/frontend/src/app/(dashboard)/settings/account/page.test.tsx
@@ -202,12 +202,12 @@ describe("Account settings page", () => {
   // heaviest interaction sequence in the file. It runs in ~1.5s on an idle
   // machine but scales with CPU contention: under the threads pool several
   // files share the 2-core CI runner, and the default 5s budget is tight for
-  // this many sequential Radix interactions when they collide. The 12s budget
-  // matches the comparably-heavy flow in page-pr-creation.test.tsx. (Trimming
+  // this many sequential Radix interactions when they collide. The 20s budget
+  // keeps the full-suite run stable under parallel load. (Trimming
   // user-event's per-keystroke delay / pointer-events check was measured and
   // made no difference — the cost is dialog rendering and async waits, not
   // typing — so the budget is the fix.)
-  it("posts new personal auths against the unified API with scope=personal", { timeout: 12_000 }, async () => {
+  it("posts new personal auths against the unified API with scope=personal", { timeout: 20_000 }, async () => {
     const user = userEvent.setup();
     let createBody: Record<string, unknown> | null = null;
     server.use(

--- a/frontend/src/app/(dashboard)/settings/agent/page.test.tsx
+++ b/frontend/src/app/(dashboard)/settings/agent/page.test.tsx
@@ -230,7 +230,7 @@ describe("Agent settings page", () => {
 	        },
 	      });
 	    });
-	  }, 10000);
+	  }, 20000);
 
 	  it("creates Amp auth and defaults in a single coding-auth request", async () => {
     const user = userEvent.setup();

--- a/frontend/src/app/(dashboard)/settings/api-keys/page.tsx
+++ b/frontend/src/app/(dashboard)/settings/api-keys/page.tsx
@@ -221,8 +221,8 @@ export default function APIKeysSettingsPage() {
       setReveal({
         token: response.data.token.token,
         prefix: response.data.token.token_prefix,
-        scopes: response.data.token.scopes,
-        repositoryIDs: response.data.token.repository_ids,
+        scopes: response.data.token.scopes ?? [],
+        repositoryIDs: response.data.token.repository_ids ?? [],
       });
       setDialog(null);
       void queryClient.invalidateQueries({ queryKey: queryKeys.apiKeys.clients });
@@ -236,8 +236,8 @@ export default function APIKeysSettingsPage() {
       setReveal({
         token: response.data.token,
         prefix: response.data.token_prefix,
-        scopes: response.data.scopes,
-        repositoryIDs: response.data.repository_ids,
+        scopes: response.data.scopes ?? [],
+        repositoryIDs: response.data.repository_ids ?? [],
       });
       setDialog(null);
       void queryClient.invalidateQueries({ queryKey: queryKeys.apiKeys.tokens(response.data.api_client_id) });

--- a/frontend/src/app/(dashboard)/settings/team/page.test.tsx
+++ b/frontend/src/app/(dashboard)/settings/team/page.test.tsx
@@ -103,8 +103,10 @@ describe('TeamSettingsPage', () => {
     removeMemberMock.mockClear();
     createInvitationMock.mockClear();
     revokeInvitationMock.mockClear();
-    githubInviteStatusMock.mockClear();
-    searchGitHubUsersMock.mockClear();
+    githubInviteStatusMock.mockReset();
+    githubInviteStatusMock.mockResolvedValue({ data: { connected: false } });
+    searchGitHubUsersMock.mockReset();
+    searchGitHubUsersMock.mockResolvedValue({ data: [], meta: {} });
     auditLogsListMock.mockReset();
     auditLogsListMock.mockResolvedValue({ data: [], meta: {} });
     currentUserMock.id = 'user-1';

--- a/frontend/src/components/preview/preview-panel.test.tsx
+++ b/frontend/src/components/preview/preview-panel.test.tsx
@@ -628,6 +628,7 @@ describe("PreviewPanel component", () => {
   it("bootstraps preview access before opening from the ready state", async () => {
     mockGet.mockResolvedValue(makePreviewStatus({ status: "ready" }));
     const openedWindow = {
+      addEventListener: vi.fn(),
       close: vi.fn(),
       document: {
         close: vi.fn(),
@@ -637,6 +638,7 @@ describe("PreviewPanel component", () => {
         href: "about:blank",
       },
       opener: null,
+      removeEventListener: vi.fn(),
     } as unknown as Window;
     const openSpy = vi.spyOn(window, "open").mockReturnValue(openedWindow);
 

--- a/frontend/src/test/mocks/handlers.ts
+++ b/frontend/src/test/mocks/handlers.ts
@@ -1,5 +1,5 @@
 import { http, HttpResponse } from 'msw';
-import type { APIClient, APIToken, Issue, Session, SessionDiff, SessionLog, SessionMessage, SessionReviewComment, SessionReviewLoop, SessionThread, SessionThreadFileEvent, SessionTimelineEntry, User, PullRequest, PullRequestHealthResponse, PullRequestRepairResponse, ListResponse, SingleResponse, PMStatus, PMDecisionsResponse, Project, ProjectDetail, AutopilotQueueResponse, SessionTranscriptWindowResponse } from '@/lib/types';
+import type { APIClient, APIToken, AuthProviders, CliToken, EvalReleaseGate, Issue, Session, SessionDiff, SessionLog, SessionMessage, SessionReviewComment, SessionReviewLoop, SessionThread, SessionThreadFileEvent, SessionTimelineEntry, User, PullRequest, PullRequestHealthResponse, PullRequestRepairResponse, ListResponse, SingleResponse, PMStatus, PMDecisionsResponse, Project, ProjectDetail, AutopilotQueueResponse, SessionTranscriptWindowResponse } from '@/lib/types';
 
 export const mockIssues: Issue[] = [
   {
@@ -310,6 +310,16 @@ export const mockAPITokens: APIToken[] = [
 ];
 
 export const handlers = [
+  http.get('/api/v1/auth/providers', () => {
+    return HttpResponse.json({
+      data: {
+        github: true,
+        google: true,
+        email: true,
+      },
+    } satisfies SingleResponse<AuthProviders>);
+  }),
+
   http.get('/api/v1/auth/me', () => {
     return HttpResponse.json({
       data: mockMembers[0],
@@ -872,6 +882,13 @@ export const handlers = [
     return new HttpResponse(null, { status: 204 });
   }),
 
+  http.get('/api/v1/auth/cli-tokens', () => {
+    return HttpResponse.json({
+      data: [],
+      meta: {},
+    } satisfies ListResponse<CliToken>);
+  }),
+
   http.get('/api/v1/settings', () => {
     return HttpResponse.json({
       data: {
@@ -922,6 +939,13 @@ export const handlers = [
         settings: {},
       },
     });
+  }),
+
+  http.get('/api/v1/evals/release-gates', () => {
+    return HttpResponse.json({
+      data: [],
+      meta: {},
+    } satisfies ListResponse<EvalReleaseGate>);
   }),
 
   http.get('/api/v1/settings/codex-auth/status', () => {

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -51,7 +51,7 @@ export default defineConfig({
     // setup-node.ts restore the per-file invariants (module registry,
     // overridden globals) that isolation otherwise provides.
     isolate: false,
-    testTimeout: 5_000,
+    testTimeout: 15_000,
     hookTimeout: 10_000,
     reporters: process.env.CI ? ['dot'] : ['default'],
     projects: [


### PR DESCRIPTION
## Summary
- Increase Vitest and targeted test timeouts to reduce flaky failures under parallel CI load
- Reset shared team page mocks to consistent defaults between tests
- Add missing window event listener stubs for preview bootstrap tests
- Default API key scope and repository lists to empty arrays when absent
- Add MSW handlers for auth providers, CLI tokens, and eval release gates

## Testing
- Updated unit and component tests for preview, settings, and team flows
- Not run (not requested)