### PR TITLE
Add idempotent repair migration for agent capabilities

### DIFF
--- a/internal/db/migrations_test.go
+++ b/internal/db/migrations_test.go
@@ -538,3 +538,30 @@ func TestGitHubInstallationClaimsDownMigrationDropsChildLinksFirst(t *testing.T)
 	require.Less(t, linkDrop, installationDrop,
 		"down migration should drop child org-link table before parent installations table")
 }
+
+func TestAgentCapabilitiesRepairMigrationIsIdempotentAndExpandOnly(t *testing.T) {
+	t.Parallel()
+
+	upBody, err := os.ReadFile("../../migrations/000204_agent_capabilities_repair.up.sql")
+	require.NoError(t, err, "test should read the agent capabilities repair up migration")
+	downBody, err := os.ReadFile("../../migrations/000204_agent_capabilities_repair.down.sql")
+	require.NoError(t, err, "test should read the agent capabilities repair down migration")
+
+	upSQL := string(upBody)
+	require.Contains(t, upSQL, "CREATE TABLE IF NOT EXISTS agent_capability_policies",
+		"repair migration should tolerate databases where 000199 already created policy tables")
+	require.Contains(t, upSQL, "CREATE TABLE IF NOT EXISTS agent_capability_policy_grants",
+		"repair migration should tolerate databases where 000199 already created grant tables")
+	require.Contains(t, upSQL, "ADD COLUMN IF NOT EXISTS capability_snapshot",
+		"repair migration should tolerate databases where 000199 already added snapshot columns")
+	require.Contains(t, upSQL, "chk_sessions_capability_snapshot_array",
+		"repair migration should add the sessions snapshot array check when the skipped migration left it missing")
+	require.Contains(t, upSQL, "chk_automation_runs_capability_snapshot_array",
+		"repair migration should add the automation_runs snapshot array check when the skipped migration left it missing")
+
+	downSQL := strings.ToUpper(string(downBody))
+	require.NotContains(t, downSQL, "DROP TABLE",
+		"repair down migration must not drop tables owned by 000199 on databases where 000199 did run")
+	require.NotContains(t, downSQL, "DROP COLUMN",
+		"repair down migration must not drop columns owned by 000199 on databases where 000199 did run")
+}

--- a/migrations/000204_agent_capabilities_repair.down.sql
+++ b/migrations/000204_agent_capabilities_repair.down.sql
@@ -1,0 +1,5 @@
+-- Intentionally no-op.
+--
+-- Migration 000204 repairs production databases that had already advanced past
+-- version 199 before 000199_agent_capabilities was merged. Fresh databases run
+-- 000199 first, so rolling back only 000204 must not drop schema owned by 000199.

--- a/migrations/000204_agent_capabilities_repair.up.sql
+++ b/migrations/000204_agent_capabilities_repair.up.sql
@@ -1,0 +1,103 @@
+CREATE TABLE IF NOT EXISTS agent_capability_policies (
+    id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    org_id uuid NOT NULL REFERENCES organizations(id),
+    policy_type text NOT NULL,
+    automation_id uuid REFERENCES automations(id) ON DELETE CASCADE,
+    name text NOT NULL DEFAULT '',
+    active boolean NOT NULL DEFAULT true,
+    created_by uuid REFERENCES users(id),
+    created_at timestamptz NOT NULL DEFAULT now(),
+    CONSTRAINT chk_agent_capability_policy_type
+        CHECK (policy_type IN ('session_default', 'automation')),
+    CONSTRAINT chk_agent_capability_policy_owner
+        CHECK (
+            (policy_type = 'session_default' AND automation_id IS NULL)
+            OR (policy_type = 'automation' AND automation_id IS NOT NULL)
+        ),
+    UNIQUE (org_id, id)
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_agent_capability_policies_session_default
+    ON agent_capability_policies (org_id)
+    WHERE policy_type = 'session_default' AND active = true;
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_agent_capability_policies_automation
+    ON agent_capability_policies (org_id, automation_id)
+    WHERE policy_type = 'automation' AND active = true;
+
+CREATE TABLE IF NOT EXISTS agent_capability_policy_grants (
+    id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    org_id uuid NOT NULL REFERENCES organizations(id),
+    policy_id uuid NOT NULL,
+    capability_id text NOT NULL,
+    access_level text NOT NULL DEFAULT 'read',
+    enabled boolean NOT NULL DEFAULT true,
+    config jsonb NOT NULL DEFAULT '{}'::jsonb,
+    created_by uuid REFERENCES users(id),
+    created_at timestamptz NOT NULL DEFAULT now(),
+    CONSTRAINT chk_agent_capability_grant_access_level
+        CHECK (access_level IN ('read', 'write', 'publish')),
+    CONSTRAINT chk_agent_capability_grant_config_object
+        CHECK (jsonb_typeof(config) = 'object'),
+    CONSTRAINT fk_agent_capability_grants_policy
+        FOREIGN KEY (org_id, policy_id)
+        REFERENCES agent_capability_policies (org_id, id)
+        ON DELETE CASCADE
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_agent_capability_policy_grants_unique
+    ON agent_capability_policy_grants (org_id, policy_id, capability_id);
+
+ALTER TABLE sessions
+    ADD COLUMN IF NOT EXISTS capability_snapshot jsonb NOT NULL DEFAULT '[]'::jsonb;
+
+UPDATE sessions
+SET capability_snapshot = '[]'::jsonb
+WHERE capability_snapshot IS NULL;
+
+ALTER TABLE sessions
+    ALTER COLUMN capability_snapshot SET DEFAULT '[]'::jsonb,
+    ALTER COLUMN capability_snapshot SET NOT NULL;
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1
+        FROM pg_constraint
+        WHERE conrelid = 'sessions'::regclass
+          AND conname = 'chk_sessions_capability_snapshot_array'
+    ) THEN
+        ALTER TABLE sessions
+            ADD CONSTRAINT chk_sessions_capability_snapshot_array
+            CHECK (jsonb_typeof(capability_snapshot) = 'array') NOT VALID;
+    END IF;
+END $$;
+
+ALTER TABLE sessions VALIDATE CONSTRAINT chk_sessions_capability_snapshot_array;
+
+ALTER TABLE automation_runs
+    ADD COLUMN IF NOT EXISTS capability_snapshot jsonb NOT NULL DEFAULT '[]'::jsonb;
+
+UPDATE automation_runs
+SET capability_snapshot = '[]'::jsonb
+WHERE capability_snapshot IS NULL;
+
+ALTER TABLE automation_runs
+    ALTER COLUMN capability_snapshot SET DEFAULT '[]'::jsonb,
+    ALTER COLUMN capability_snapshot SET NOT NULL;
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1
+        FROM pg_constraint
+        WHERE conrelid = 'automation_runs'::regclass
+          AND conname = 'chk_automation_runs_capability_snapshot_array'
+    ) THEN
+        ALTER TABLE automation_runs
+            ADD CONSTRAINT chk_automation_runs_capability_snapshot_array
+            CHECK (jsonb_typeof(capability_snapshot) = 'array') NOT VALID;
+    END IF;
+END $$;
+
+ALTER TABLE automation_runs VALIDATE CONSTRAINT chk_automation_runs_capability_snapshot_array;


### PR DESCRIPTION
## Summary
- Add a repair migration for agent capabilities that is safe to run on databases that already advanced past the original migration
- Make the migration expand-only by using `IF NOT EXISTS` guards and adding missing snapshot constraints
- Add regression tests that verify the up migration is idempotent and the down migration does not drop schema owned by the original migration

## Testing
- Added unit coverage in `internal/db/migrations_test.go` for the repair migration structure and rollback behavior
- Not run (not requested)