### PR TITLE
Fix session transcript scroll by adding stable anchor IDs for reopen/thread restore

### DIFF
--- a/frontend/src/app/(dashboard)/sessions/[id]/page-transcript.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/page-transcript.test.tsx
@@ -1,11 +1,13 @@
 import { describe, it, expect, vi } from 'vitest';
 import { http, HttpResponse } from 'msw';
-import { fireEvent, renderWithProviders, screen, userEvent, waitFor, within } from '@/test/test-utils';
+import { createTestQueryClient, fireEvent, renderWithProviders, screen, userEvent, waitFor, within } from '@/test/test-utils';
 import { server } from '@/test/mocks/server';
 import { mockSessions, mockMembers, mockIssues } from '@/test/mocks/handlers';
 import { SessionDetailContent } from './session-detail-content';
+import { queryKeys } from '@/lib/query-keys';
 import type {
   Session,
+  SessionLog,
   SessionMessage,
   SessionThread,
   SessionTimelineEntry,
@@ -13,7 +15,7 @@ import type {
   SingleResponse,
   ListResponse,
 } from '@/lib/types';
-import { installSessionDetailPageTestHooks, getChatScroller, makeTranscriptWindow } from './session-detail-test-kit';
+import { installSessionDetailPageTestHooks, getChatScroller, makeTranscriptWindow, renderSessionDetailWithQueryClient } from './session-detail-test-kit';
 
 const { toast } = vi.hoisted(() => ({
   toast: {
@@ -1169,6 +1171,286 @@ describe('SessionDetailPage transcript and scroll', () => {
 
     expect(await screen.findByText('Newer anchored reply')).toBeInTheDocument();
     expect(requestedUrls.some((rawUrl) => new URL(rawUrl).searchParams.get('after') === '23')).toBe(true);
+  });
+
+  it('opens a thread around a saved non-message transcript entry anchor', async () => {
+    const threadSession: Session = {
+      ...mockSessions[0],
+      id: 'session-thread-entry-anchor-restore',
+      status: 'idle',
+      completed_at: undefined,
+      sandbox_state: 'snapshotted',
+      threads: [
+        {
+          id: 'thread-entry-anchor',
+          session_id: 'session-thread-entry-anchor-restore',
+          org_id: 'org-1',
+          agent_type: 'codex',
+          label: 'Main',
+          status: 'idle',
+          current_turn: 2,
+          created_at: '2026-02-17T07:00:00Z',
+          cost_cents: 0,
+          pending_message_count: 0,
+        },
+      ],
+    };
+    const requestedUrls: string[] = [];
+
+    vi.spyOn(HTMLElement.prototype, 'scrollHeight', 'get').mockReturnValue(1200);
+    vi.spyOn(HTMLElement.prototype, 'clientHeight', 'get').mockReturnValue(300);
+    window.localStorage.setItem(
+      `session-scroll-position:org-1:user-1:${threadSession.id}:thread-entry-anchor`,
+      JSON.stringify({
+        version: 3,
+        anchor_entry_id: 'tuse_31',
+        offset_px: 14,
+        scroll_top_fallback: 640,
+      }),
+    );
+
+    server.use(
+      http.get('/api/v1/sessions/:id', () => {
+        return HttpResponse.json({ data: threadSession } satisfies SingleResponse<Session>);
+      }),
+      http.get('/api/v1/sessions/:id/threads/:threadId/transcript', ({ request, params }) => {
+        requestedUrls.push(request.url);
+        const toolUse: SessionLog = {
+          id: 31,
+          session_id: threadSession.id,
+          thread_id: params.threadId as string,
+          level: 'tool_use',
+          message: 'using tool: Bash',
+          metadata: { tool: 'Bash', call_id: 'call-31' },
+          turn_number: 2,
+          created_at: '2026-02-17T07:02:00Z',
+          message_bytes: 16,
+          message_chars: 16,
+          message_truncated: false,
+        };
+        const toolResult: SessionLog = {
+          id: 32,
+          session_id: threadSession.id,
+          thread_id: params.threadId as string,
+          level: 'output',
+          message: 'tool output',
+          metadata: { type: 'tool_result', call_id: 'call-31' },
+          turn_number: 2,
+          created_at: '2026-02-17T07:02:01Z',
+          message_bytes: 11,
+          message_chars: 11,
+          message_truncated: false,
+        };
+        return HttpResponse.json(
+          makeTranscriptWindow(
+            [],
+            [toolUse, toolResult],
+            {
+              position: 'around',
+              has_older: true,
+              has_newer: false,
+              anchor_entry_id: 'tuse_31',
+              anchor_found: true,
+              latest_assistant_entry_id: 'tuse_31',
+              live_edge_entry_id: 'tres_32',
+              thread_status: 'idle',
+            },
+          ),
+        );
+      }),
+    );
+
+    const { container } = renderWithProviders(<SessionDetailContent id={threadSession.id} />);
+
+    await waitFor(() => {
+      const aroundUrl = requestedUrls.find((rawUrl) => new URL(rawUrl).searchParams.get('position') === 'around');
+      expect(aroundUrl).toBeDefined();
+      expect(new URL(aroundUrl!).searchParams.get('anchor_entry_id')).toBe('tuse_31');
+      expect(new URL(aroundUrl!).searchParams.get('anchor_message_id')).toBeNull();
+      expect(getChatScroller(container).scrollTop).toBe(14);
+    });
+  });
+
+  it('fetches an around window for a saved entry anchor even when latest is cached', async () => {
+    const threadSession: Session = {
+      ...mockSessions[0],
+      id: 'session-thread-anchor-cache-split',
+      status: 'idle',
+      completed_at: undefined,
+      sandbox_state: 'snapshotted',
+      threads: [
+        {
+          id: 'thread-cache-split',
+          session_id: 'session-thread-anchor-cache-split',
+          org_id: 'org-1',
+          agent_type: 'codex',
+          label: 'Main',
+          status: 'idle',
+          current_turn: 2,
+          created_at: '2026-02-17T07:00:00Z',
+          cost_cents: 0,
+          pending_message_count: 0,
+        },
+      ],
+    };
+    const queryClient = createTestQueryClient();
+    queryClient.setQueryData(
+      queryKeys.sessions.threadTranscript(threadSession.id, 'thread-cache-split'),
+      {
+        pages: [
+          makeTranscriptWindow(
+            [
+              {
+                id: 90,
+                session_id: threadSession.id,
+                org_id: 'org-1',
+                thread_id: 'thread-cache-split',
+                turn_number: 9,
+                role: 'assistant',
+                content: 'Cached latest reply',
+                created_at: '2026-02-17T09:00:00Z',
+              },
+            ] as SessionMessage[],
+            [],
+          ),
+        ],
+        pageParams: [{ position: 'latest' }],
+      },
+    );
+    const requestedUrls: string[] = [];
+    window.localStorage.setItem(
+      `session-scroll-position:org-1:user-1:${threadSession.id}:thread-cache-split`,
+      JSON.stringify({
+        version: 3,
+        anchor_entry_id: 'msg_22',
+        offset_px: 0,
+        scroll_top_fallback: 100,
+      }),
+    );
+
+    server.use(
+      http.get('/api/v1/sessions/:id', () => {
+        return HttpResponse.json({ data: threadSession } satisfies SingleResponse<Session>);
+      }),
+      http.get('/api/v1/sessions/:id/threads/:threadId/transcript', ({ request, params }) => {
+        requestedUrls.push(request.url);
+        return HttpResponse.json(
+          makeTranscriptWindow(
+            [
+              {
+                id: 22,
+                session_id: threadSession.id,
+                org_id: 'org-1',
+                thread_id: params.threadId as string,
+                turn_number: 2,
+                role: 'assistant',
+                content: 'Fetched anchored reply',
+                created_at: '2026-02-17T07:02:00Z',
+              },
+            ] as SessionMessage[],
+            [],
+            {
+              position: 'around',
+              anchor_entry_id: 'msg_22',
+              anchor_found: true,
+              thread_status: 'idle',
+            },
+          ),
+        );
+      }),
+    );
+
+    renderSessionDetailWithQueryClient(threadSession.id, queryClient);
+
+    expect(await screen.findByText('Fetched anchored reply')).toBeInTheDocument();
+    expect(screen.queryByText('Cached latest reply')).toBeNull();
+    expect(requestedUrls.some((rawUrl) => new URL(rawUrl).searchParams.get('anchor_entry_id') === 'msg_22')).toBe(true);
+  });
+
+  it('uses latest assistant entry metadata as the default inactive-thread anchor', async () => {
+    const threadSession: Session = {
+      ...mockSessions[0],
+      id: 'session-thread-default-entry-anchor',
+      status: 'idle',
+      completed_at: undefined,
+      sandbox_state: 'snapshotted',
+      threads: [
+        {
+          id: 'thread-default-entry-anchor',
+          session_id: 'session-thread-default-entry-anchor',
+          org_id: 'org-1',
+          agent_type: 'codex',
+          label: 'Main',
+          status: 'idle',
+          current_turn: 2,
+          created_at: '2026-02-17T07:00:00Z',
+          cost_cents: 0,
+          pending_message_count: 0,
+        },
+      ],
+    };
+    vi.spyOn(HTMLElement.prototype, 'scrollHeight', 'get').mockReturnValue(1200);
+    vi.spyOn(HTMLElement.prototype, 'clientHeight', 'get').mockReturnValue(300);
+    Object.defineProperty(HTMLElement.prototype, 'offsetTop', {
+      configurable: true,
+      get() {
+        return (this as HTMLElement).getAttribute('data-session-entry-id') === 'tuse_31' ? 250 : 0;
+      },
+    });
+    const toolUse: SessionLog = {
+      id: 31,
+      session_id: threadSession.id,
+      thread_id: 'thread-default-entry-anchor',
+      level: 'tool_use',
+      message: 'using tool: Bash',
+      metadata: { tool: 'Bash', call_id: 'call-31' },
+      turn_number: 2,
+      created_at: '2026-02-17T07:02:00Z',
+      message_bytes: 16,
+      message_chars: 16,
+      message_truncated: false,
+    };
+
+    server.use(
+      http.get('/api/v1/sessions/:id', () => {
+        return HttpResponse.json({ data: threadSession } satisfies SingleResponse<Session>);
+      }),
+      http.get('/api/v1/sessions/:id/threads/:threadId/transcript', () => {
+        return HttpResponse.json(
+          makeTranscriptWindow(
+            [
+              {
+                id: 21,
+                session_id: threadSession.id,
+                org_id: 'org-1',
+                thread_id: 'thread-default-entry-anchor',
+                turn_number: 2,
+                role: 'assistant',
+                content: 'Assistant message before tool entry',
+                created_at: '2026-02-17T07:01:00Z',
+              },
+            ] as SessionMessage[],
+            [toolUse],
+            {
+              position: 'latest',
+              latest_assistant_entry_id: 'tuse_31',
+              live_edge_entry_id: 'tuse_31',
+              thread_status: 'idle',
+            },
+          ),
+        );
+      }),
+    );
+
+    const { container } = renderWithProviders(<SessionDetailContent id={threadSession.id} />);
+
+    await screen.findByText('Assistant message before tool entry');
+    await waitFor(() => {
+      const target = container.querySelector<HTMLElement>('[data-session-entry-id="tuse_31"]');
+      expect(target).toBeInTheDocument();
+      expect(target?.offsetTop).toBe(250);
+      expect(getChatScroller(container).scrollTop).toBe(250);
+    });
   });
 
   it('does not apply a delayed saved scroll restore after jumping to the latest message', async () => {

--- a/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
@@ -2133,6 +2133,132 @@ function appendMessageToTranscriptCache(
   };
 }
 
+interface DefaultEntryAnchorOptions {
+  activeThreadId: string | null | undefined;
+  sessionId: string;
+  /** True only when there is no stored anchor, an active thread, and the session is not running. */
+  isEligible: boolean;
+  firstThreadWindow: SessionTranscriptWindowResponse | undefined;
+  timelineEntries: TimelineEntry[];
+  scrollRef: React.RefObject<HTMLDivElement | null>;
+  syncScrollState: (el: HTMLDivElement) => void;
+  activeThreadTranscriptQueryKey: readonly unknown[] | null;
+  queryClient: ReturnType<typeof useQueryClient>;
+  scrollToLiveEdgePosition: () => void;
+  initialAnchorAppliedRef: React.MutableRefObject<boolean>;
+  initialAnchorCancelledRef: React.MutableRefObject<boolean>;
+}
+
+/**
+ * Handles scrolling to the latest assistant transcript entry when reopening an
+ * inactive thread that has no stored scroll anchor. Owns the synchronous
+ * layout-effect fast path (when the target element is already in the DOM) and
+ * the three progressive fallbacks: a requestAnimationFrame retry, a remote
+ * "around" fetch, and a live-edge fallback on error.
+ *
+ * Returns `tryApply(el)` to be called from the parent's initial-anchor effect;
+ * it returns `true` when it has handled (or scheduled) the scroll so the
+ * caller can return early.
+ */
+function useDefaultEntryAnchor({
+  activeThreadId,
+  sessionId,
+  isEligible,
+  firstThreadWindow,
+  timelineEntries,
+  scrollRef,
+  syncScrollState,
+  activeThreadTranscriptQueryKey,
+  queryClient,
+  scrollToLiveEdgePosition,
+  initialAnchorAppliedRef,
+  initialAnchorCancelledRef,
+}: DefaultEntryAnchorOptions): (el: HTMLDivElement) => boolean {
+  const fetchRef = useRef<string | null>(null);
+  const appliedRef = useRef(false);
+
+  const latestAssistantEntryID = firstThreadWindow?.meta.latest_assistant_entry_id;
+
+  useEffect(() => {
+    fetchRef.current = null;
+    appliedRef.current = false;
+  }, [activeThreadId, sessionId]);
+
+  // Synchronous fast path: scroll as soon as the target node is in the DOM.
+  useLayoutEffect(() => {
+    if (!isEligible || appliedRef.current || !latestAssistantEntryID) return;
+    const el = scrollRef.current;
+    if (!el) return;
+    const target = el.querySelector<HTMLElement>(transcriptEntryIDSelector(latestAssistantEntryID));
+    if (!target) return;
+    el.scrollTop = target.offsetTop;
+    syncScrollState(el);
+    initialAnchorAppliedRef.current = true;
+    appliedRef.current = true;
+  }, [isEligible, latestAssistantEntryID, syncScrollState, timelineEntries]);
+
+  return useCallback((el: HTMLDivElement): boolean => {
+    if (!isEligible || !latestAssistantEntryID) return false;
+
+    // DOM target is already present.
+    const target = el.querySelector<HTMLElement>(transcriptEntryIDSelector(latestAssistantEntryID));
+    if (target) {
+      el.scrollTop = target.offsetTop;
+      syncScrollState(el);
+      initialAnchorAppliedRef.current = true;
+      return true;
+    }
+
+    // Target is in the entry list but the DOM hasn't updated yet — retry after paint.
+    if (timelineEntries.some((entry) => entry.transcriptEntryId === latestAssistantEntryID)) {
+      requestAnimationFrame(() => {
+        if (initialAnchorAppliedRef.current || initialAnchorCancelledRef.current) return;
+        const currentEl = scrollRef.current;
+        if (!currentEl) return;
+        const delayedTarget = currentEl.querySelector<HTMLElement>(transcriptEntryIDSelector(latestAssistantEntryID));
+        if (!delayedTarget) return;
+        currentEl.scrollTop = delayedTarget.offsetTop;
+        syncScrollState(currentEl);
+        initialAnchorAppliedRef.current = true;
+        appliedRef.current = true;
+      });
+      return true;
+    }
+
+    // Entry isn't in the current page — fetch an "around" window.
+    const fetchKey = `${activeThreadId}:${latestAssistantEntryID}`;
+    if (activeThreadTranscriptQueryKey && fetchRef.current !== fetchKey) {
+      fetchRef.current = fetchKey;
+      void api.sessions.getThreadTranscriptWindow(sessionId, activeThreadId!, {
+        position: "around",
+        anchorEntryId: latestAssistantEntryID,
+      }).then((window) => {
+        queryClient.setQueryData<TranscriptWindowInfiniteData>(
+          activeThreadTranscriptQueryKey,
+          { pages: [window], pageParams: [{ position: "around", anchorEntryId: latestAssistantEntryID }] },
+        );
+      }).catch((error) => {
+        toast.error(error instanceof ApiError ? error.message : "Failed to load latest assistant message");
+        scrollToLiveEdgePosition();
+        initialAnchorAppliedRef.current = true;
+      });
+      return true;
+    }
+
+    return false;
+  }, [
+    activeThreadId,
+    activeThreadTranscriptQueryKey,
+    isEligible,
+    latestAssistantEntryID,
+    queryClient,
+    scrollToLiveEdgePosition,
+    sessionId,
+    syncScrollState,
+    timelineEntries,
+  ]);
+}
+
 type ChatPanelProps = {
   session: Session;
   sessionId: string;
@@ -2175,8 +2301,6 @@ function ChatPanel({
   const initialAnchorAppliedRef = useRef(false);
   const initialAnchorCancelledRef = useRef(false);
   const olderMessagesPrependSnapshotRef = useRef<{ scrollHeight: number; scrollTop: number } | null>(null);
-  const defaultEntryAnchorFetchRef = useRef<string | null>(null);
-  const defaultEntryAnchorAppliedRef = useRef(false);
   const saveScrollTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const reconnectAttempts = useRef(0);
   const reconnectTimer = useRef<ReturnType<typeof setTimeout>>(null);
@@ -2514,6 +2638,21 @@ function ChatPanel({
     el.scrollTop = el.scrollHeight;
     isNearBottomRef.current = true;
   }, []);
+
+  const tryApplyDefaultEntryAnchor = useDefaultEntryAnchor({
+    activeThreadId,
+    sessionId,
+    isEligible: !!activeThreadId && !initialThreadAnchorPosition && !isRunning,
+    firstThreadWindow: threadTranscriptQuery.data?.pages[0],
+    timelineEntries,
+    scrollRef,
+    syncScrollState,
+    activeThreadTranscriptQueryKey,
+    queryClient,
+    scrollToLiveEdgePosition,
+    initialAnchorAppliedRef,
+    initialAnchorCancelledRef,
+  });
 
   // Jump to the true bottom and keep it pinned across late layout growth. Lazy
   // markdown/code/images expand a few frames after the first scroll, so a single
@@ -2908,8 +3047,6 @@ function ChatPanel({
   useEffect(() => {
     initialAnchorAppliedRef.current = false;
     initialAnchorCancelledRef.current = false;
-    defaultEntryAnchorFetchRef.current = null;
-    defaultEntryAnchorAppliedRef.current = false;
   }, [activeThreadId, sessionId]);
 
   useEffect(() => {
@@ -2923,31 +3060,6 @@ function ChatPanel({
       }
     };
   }, [persistScrollPosition]);
-
-  useLayoutEffect(() => {
-    if (
-      defaultEntryAnchorAppliedRef.current ||
-      !activeThreadId ||
-      initialThreadAnchorPosition ||
-      isRunning
-    ) {
-      return;
-    }
-
-    const latestAssistantEntryID = threadTranscriptQuery.data?.pages[0]?.meta.latest_assistant_entry_id;
-    if (!latestAssistantEntryID) return;
-
-    const el = scrollRef.current;
-    if (!el) return;
-
-    const target = el.querySelector<HTMLElement>(transcriptEntryIDSelector(latestAssistantEntryID));
-    if (!target) return;
-
-    el.scrollTop = target.offsetTop;
-    syncScrollState(el);
-    initialAnchorAppliedRef.current = true;
-    defaultEntryAnchorAppliedRef.current = true;
-  }, [activeThreadId, initialThreadAnchorPosition, isRunning, syncScrollState, threadTranscriptQuery.data?.pages, timelineEntries]);
 
   useEffect(() => {
     if (
@@ -2978,58 +3090,7 @@ function ChatPanel({
       }
     }
 
-    if (
-      activeThreadId &&
-      !initialThreadAnchorPosition &&
-      !isRunning &&
-      firstThreadWindow?.meta.latest_assistant_entry_id
-    ) {
-      const latestAssistantEntryID = firstThreadWindow.meta.latest_assistant_entry_id;
-      const target = el.querySelector<HTMLElement>(transcriptEntryIDSelector(latestAssistantEntryID));
-      if (target) {
-        el.scrollTop = target.offsetTop;
-        syncScrollState(el);
-        initialAnchorAppliedRef.current = true;
-        return;
-      }
-
-      if (timelineEntries.some((entry) => entry.transcriptEntryId === latestAssistantEntryID)) {
-        requestAnimationFrame(() => {
-          if (initialAnchorAppliedRef.current || initialAnchorCancelledRef.current) return;
-          const currentEl = scrollRef.current;
-          if (!currentEl) return;
-          const delayedTarget = currentEl.querySelector<HTMLElement>(transcriptEntryIDSelector(latestAssistantEntryID));
-          if (!delayedTarget) return;
-          currentEl.scrollTop = delayedTarget.offsetTop;
-          syncScrollState(currentEl);
-          initialAnchorAppliedRef.current = true;
-          defaultEntryAnchorAppliedRef.current = true;
-        });
-        return;
-      }
-
-      const fetchKey = `${activeThreadId}:${latestAssistantEntryID}`;
-      if (
-        activeThreadTranscriptQueryKey &&
-        defaultEntryAnchorFetchRef.current !== fetchKey
-      ) {
-        defaultEntryAnchorFetchRef.current = fetchKey;
-        void api.sessions.getThreadTranscriptWindow(sessionId, activeThreadId, {
-          position: "around",
-          anchorEntryId: latestAssistantEntryID,
-        }).then((window) => {
-          queryClient.setQueryData<TranscriptWindowInfiniteData>(
-            activeThreadTranscriptQueryKey,
-            { pages: [window], pageParams: [{ position: "around", anchorEntryId: latestAssistantEntryID }] },
-          );
-        }).catch((error) => {
-          toast.error(error instanceof ApiError ? error.message : "Failed to load latest assistant message");
-          scrollToLiveEdgePosition();
-          initialAnchorAppliedRef.current = true;
-        });
-        return;
-      }
-    }
+    if (tryApplyDefaultEntryAnchor(el)) return;
 
     const ignoreStoredScrollTop =
       activeThreadId &&
@@ -3074,7 +3135,7 @@ function ChatPanel({
 
     scrollToLiveEdgePosition();
     initialAnchorAppliedRef.current = true;
-  }, [activeThreadId, activeThreadTranscriptQueryKey, hasLoadedTimelineInputs, initialThreadAnchorPosition, isRunning, queryClient, scrollToLiveEdgePosition, sessionId, syncScrollState, threadTranscriptQuery, timelineEntries, viewerScope]);
+  }, [activeThreadId, hasLoadedTimelineInputs, initialThreadAnchorPosition, isRunning, scrollToLiveEdgePosition, sessionId, syncScrollState, threadTranscriptQuery, timelineEntries, tryApplyDefaultEntryAnchor, viewerScope]);
 
   // Only auto-scroll to bottom when new entries arrive if the user is already near the bottom.
   useEffect(() => {

--- a/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
@@ -2034,6 +2034,7 @@ function threadLiveLogsQueryKey(sessionId: string, threadId: string): readonly u
 // through newerThreadMessagePages, mirroring the legacy message-window flow.
 type TranscriptWindowPageParam =
   | { position: "latest" }
+  | { position: "around"; anchorEntryId: string }
   | { position: "around"; anchorMessageId: number }
   | { before: string };
 
@@ -2042,14 +2043,29 @@ type TranscriptWindowInfiniteData = {
   pageParams: unknown[];
 };
 
-function transcriptWindowQueryKey(sessionId: string, threadId: string): readonly unknown[] {
-  return queryKeys.sessions.threadTranscript(sessionId, threadId);
+function transcriptAnchorKey(anchor?: SessionAnchorPosition | null): string | null {
+  if (!anchor) return null;
+  return anchor.anchor.kind === "entry"
+    ? `entry:${anchor.anchor.id}`
+    : `message:${anchor.anchor.id}`;
 }
 
-function transcriptInitialPageParam(anchorMessageId?: number | null): TranscriptWindowPageParam {
-  return anchorMessageId != null
-    ? { position: "around", anchorMessageId }
-    : { position: "latest" };
+function transcriptWindowQueryKey(sessionId: string, threadId: string, anchorKey?: string | null): readonly unknown[] {
+  return queryKeys.sessions.threadTranscript(sessionId, threadId, anchorKey);
+}
+
+function transcriptInitialPageParam(anchor?: SessionAnchorPosition | null): TranscriptWindowPageParam {
+  if (!anchor) return { position: "latest" };
+  return anchor.anchor.kind === "entry"
+    ? { position: "around", anchorEntryId: anchor.anchor.id }
+    : { position: "around", anchorMessageId: anchor.anchor.id };
+}
+
+function transcriptEntryIDSelector(entryID: string): string {
+  const escaped = typeof CSS !== "undefined" && typeof CSS.escape === "function"
+    ? CSS.escape(entryID)
+    : entryID.replace(/["\\]/g, "\\$&");
+  return `[data-session-entry-id="${escaped}"]`;
 }
 
 // flattenTranscriptPages returns the turns of the infinite query (newest page
@@ -2159,6 +2175,8 @@ function ChatPanel({
   const initialAnchorAppliedRef = useRef(false);
   const initialAnchorCancelledRef = useRef(false);
   const olderMessagesPrependSnapshotRef = useRef<{ scrollHeight: number; scrollTop: number } | null>(null);
+  const defaultEntryAnchorFetchRef = useRef<string | null>(null);
+  const defaultEntryAnchorAppliedRef = useRef(false);
   const saveScrollTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const reconnectAttempts = useRef(0);
   const reconnectTimer = useRef<ReturnType<typeof setTimeout>>(null);
@@ -2174,6 +2192,14 @@ function ChatPanel({
     if (!activeThreadId || !viewerScope || typeof window === "undefined") return null;
     return readStoredSessionAnchorPosition(window.localStorage, sessionId, viewerScope, activeThreadId);
   }, [activeThreadId, sessionId, viewerScope]);
+  const initialThreadAnchorKey = useMemo(
+    () => transcriptAnchorKey(initialThreadAnchorPosition),
+    [initialThreadAnchorPosition],
+  );
+  const activeThreadTranscriptQueryKey = useMemo(
+    () => activeThreadId ? transcriptWindowQueryKey(sessionId, activeThreadId, initialThreadAnchorKey) : null,
+    [activeThreadId, initialThreadAnchorKey, sessionId],
+  );
 
   const timelineQuery = useQuery({
     queryKey: ["session", sessionId, "timeline"],
@@ -2195,10 +2221,10 @@ function ChatPanel({
     readonly unknown[],
     TranscriptWindowPageParam
   >({
-    queryKey: activeThreadId ? transcriptWindowQueryKey(sessionId, activeThreadId) : ["session", sessionId, "thread", "none", "transcript"],
+    queryKey: activeThreadTranscriptQueryKey ?? ["session", sessionId, "thread", "none", "transcript"],
     queryFn: ({ pageParam }) =>
       api.sessions.getThreadTranscriptWindow(sessionId, activeThreadId!, pageParam),
-    initialPageParam: transcriptInitialPageParam(initialThreadAnchorPosition?.anchor.id ?? null),
+    initialPageParam: transcriptInitialPageParam(initialThreadAnchorPosition),
     getNextPageParam: (lastPage) =>
       lastPage.meta.has_older && lastPage.meta.next_older_cursor
         ? { before: lastPage.meta.next_older_cursor }
@@ -2211,7 +2237,13 @@ function ChatPanel({
     () => flattenTranscriptPages(threadTranscriptQuery.data?.pages, newerThreadMessagePages),
     [newerThreadMessagePages, threadTranscriptQuery.data?.pages],
   );
-  const { messages: threadMessages, logs: threadTranscriptLogs } = useMemo(
+  const {
+    messages: threadMessages,
+    logs: threadTranscriptLogs,
+    messageEntryIds: threadMessageEntryIds,
+    logEntryIds: threadLogEntryIds,
+    humanInputEntryIds: threadHumanInputEntryIds,
+  } = useMemo(
     () => flattenTranscriptWindows(threadTranscriptTurns),
     [threadTranscriptTurns],
   );
@@ -2337,11 +2369,16 @@ function ChatPanel({
       ).data;
       const threadHumanInputEntries: TimelineEntry[] = (humanInputQuery.data?.data ?? [])
         .filter((request) => request.thread_id === activeThreadId)
-        .map((request) => ({ kind: "human_input" as const, data: request }));
+        .map((request) => ({
+          kind: "human_input" as const,
+          data: request,
+          transcriptEntryId: threadHumanInputEntryIds.get(request.id),
+        }));
       return sortTimelineEntries([
         ...buildTimeline(
           mergePendingMessages(threadMessages, optimisticForCurrentView),
           loadedThreadLogs,
+          { messageEntryIds: threadMessageEntryIds, logEntryIds: threadLogEntryIds },
         ),
         ...threadHumanInputEntries,
       ]);
@@ -2369,7 +2406,7 @@ function ChatPanel({
       created_at: session.created_at,
     };
     return [{ kind: "message" as const, data: syntheticMsg }, ...entries];
-  }, [activeThread, activeThreadId, optimisticMessages, threadMessages, threadTranscriptLogs, liveLogsQuery.data?.data, timelineQuery.data?.data, issueQuery.data?.data?.description, sessionId, session.org_id, session.created_at, session.status, humanInputQuery.data?.data]);
+  }, [activeThread, activeThreadId, optimisticMessages, threadMessages, threadTranscriptLogs, threadMessageEntryIds, threadLogEntryIds, threadHumanInputEntryIds, liveLogsQuery.data?.data, timelineQuery.data?.data, issueQuery.data?.data?.description, sessionId, session.org_id, session.created_at, session.status, humanInputQuery.data?.data]);
 
   const baseTimelineHumanInputIds = useMemo(() => {
     const humanInputIds = new Set<string>();
@@ -2418,17 +2455,16 @@ function ChatPanel({
     writeStoredSessionScrollPosition(window.localStorage, sessionId, viewerScope, scrollTop, activeThreadId);
   }, [activeThreadId, sessionId, viewerScope]);
 
-  const findFirstVisibleMessageAnchor = useCallback((el: HTMLDivElement) => {
+  const findFirstVisibleTranscriptAnchor = useCallback((el: HTMLDivElement) => {
     const containerTop = el.getBoundingClientRect().top;
-    const nodes = Array.from(el.querySelectorAll<HTMLElement>("[data-session-message-id]"));
+    const nodes = Array.from(el.querySelectorAll<HTMLElement>("[data-session-entry-id]"));
     for (const node of nodes) {
       const rect = node.getBoundingClientRect();
       if (rect.bottom < containerTop) continue;
-      const rawID = node.dataset.sessionMessageId;
-      const id = rawID ? Number(rawID) : NaN;
-      if (!Number.isInteger(id) || id <= 0) continue;
+      const id = node.dataset.sessionEntryId;
+      if (!id) continue;
       return {
-        anchor: { kind: "message" as const, id },
+        anchor: { kind: "entry" as const, id },
         offsetPx: Math.max(0, containerTop - rect.top),
         scrollTopFallback: el.scrollTop,
       };
@@ -2438,13 +2474,13 @@ function ChatPanel({
 
   const persistCurrentScrollPosition = useCallback((el: HTMLDivElement) => {
     if (typeof window === "undefined" || !viewerScope) return;
-    const anchorPosition = activeThreadId ? findFirstVisibleMessageAnchor(el) : null;
+    const anchorPosition = activeThreadId ? findFirstVisibleTranscriptAnchor(el) : null;
     if (anchorPosition) {
       writeStoredSessionAnchorPosition(window.localStorage, sessionId, viewerScope, anchorPosition, activeThreadId);
       return;
     }
     writeStoredSessionScrollPosition(window.localStorage, sessionId, viewerScope, el.scrollTop, activeThreadId);
-  }, [activeThreadId, findFirstVisibleMessageAnchor, sessionId, viewerScope]);
+  }, [activeThreadId, findFirstVisibleTranscriptAnchor, sessionId, viewerScope]);
 
   const schedulePersistScrollPosition = useCallback((scrollTop: number) => {
     if (saveScrollTimerRef.current) {
@@ -2530,9 +2566,16 @@ function ChatPanel({
       void api.sessions.getThreadTranscriptWindow(sessionId, activeThreadId, {
         position: "latest",
       }).then((window) => {
+        const latestData = { pages: [window], pageParams: [{ position: "latest" }] } satisfies TranscriptWindowInfiniteData;
+        if (activeThreadTranscriptQueryKey) {
+          queryClient.setQueryData<TranscriptWindowInfiniteData>(
+            activeThreadTranscriptQueryKey,
+            latestData,
+          );
+        }
         queryClient.setQueryData<TranscriptWindowInfiniteData>(
           transcriptWindowQueryKey(sessionId, activeThreadId),
-          { pages: [window], pageParams: [{ position: "latest" }] },
+          latestData,
         );
         setNewerThreadMessagePages([]);
         settleScrollToBottom();
@@ -2554,7 +2597,7 @@ function ChatPanel({
       persistScrollPosition(el.scrollTop);
     }
     setShowJumpToLatest(false);
-  }, [activeThreadId, cancelPendingInitialAnchorRestore, hasNewerThreadMessages, persistScrollPosition, queryClient, settleScrollToBottom, sessionId]);
+  }, [activeThreadId, activeThreadTranscriptQueryKey, cancelPendingInitialAnchorRestore, hasNewerThreadMessages, persistScrollPosition, queryClient, settleScrollToBottom, sessionId]);
 
   const focusTranscript = useCallback(() => {
     scrollRef.current?.focus({ preventScroll: true });
@@ -2630,6 +2673,7 @@ function ChatPanel({
     (_entry: TimelineEntry, index: number) =>
       ({
         "data-session-entry-index": index,
+        ...(_entry.transcriptEntryId ? { "data-session-entry-id": _entry.transcriptEntryId } : {}),
         ...(_entry.kind === "message" ? { "data-session-message-id": _entry.data.id } : {}),
       }) as React.HTMLAttributes<HTMLDivElement> & Record<`data-${string}`, string | number | undefined>,
     [],
@@ -2864,6 +2908,8 @@ function ChatPanel({
   useEffect(() => {
     initialAnchorAppliedRef.current = false;
     initialAnchorCancelledRef.current = false;
+    defaultEntryAnchorFetchRef.current = null;
+    defaultEntryAnchorAppliedRef.current = false;
   }, [activeThreadId, sessionId]);
 
   useEffect(() => {
@@ -2877,6 +2923,31 @@ function ChatPanel({
       }
     };
   }, [persistScrollPosition]);
+
+  useLayoutEffect(() => {
+    if (
+      defaultEntryAnchorAppliedRef.current ||
+      !activeThreadId ||
+      initialThreadAnchorPosition ||
+      isRunning
+    ) {
+      return;
+    }
+
+    const latestAssistantEntryID = threadTranscriptQuery.data?.pages[0]?.meta.latest_assistant_entry_id;
+    if (!latestAssistantEntryID) return;
+
+    const el = scrollRef.current;
+    if (!el) return;
+
+    const target = el.querySelector<HTMLElement>(transcriptEntryIDSelector(latestAssistantEntryID));
+    if (!target) return;
+
+    el.scrollTop = target.offsetTop;
+    syncScrollState(el);
+    initialAnchorAppliedRef.current = true;
+    defaultEntryAnchorAppliedRef.current = true;
+  }, [activeThreadId, initialThreadAnchorPosition, isRunning, syncScrollState, threadTranscriptQuery.data?.pages, timelineEntries]);
 
   useEffect(() => {
     if (
@@ -2895,11 +2966,67 @@ function ChatPanel({
       initialThreadAnchorPosition &&
       firstThreadWindow?.meta.anchor_found
     ) {
-      const target = el.querySelector<HTMLElement>(`[data-session-message-id="${initialThreadAnchorPosition.anchor.id}"]`);
+      const targetSelector = initialThreadAnchorPosition.anchor.kind === "entry"
+        ? transcriptEntryIDSelector(initialThreadAnchorPosition.anchor.id)
+        : `[data-session-message-id="${initialThreadAnchorPosition.anchor.id}"]`;
+      const target = el.querySelector<HTMLElement>(targetSelector);
       if (target) {
         el.scrollTop = target.offsetTop + initialThreadAnchorPosition.offsetPx;
         syncScrollState(el);
         initialAnchorAppliedRef.current = true;
+        return;
+      }
+    }
+
+    if (
+      activeThreadId &&
+      !initialThreadAnchorPosition &&
+      !isRunning &&
+      firstThreadWindow?.meta.latest_assistant_entry_id
+    ) {
+      const latestAssistantEntryID = firstThreadWindow.meta.latest_assistant_entry_id;
+      const target = el.querySelector<HTMLElement>(transcriptEntryIDSelector(latestAssistantEntryID));
+      if (target) {
+        el.scrollTop = target.offsetTop;
+        syncScrollState(el);
+        initialAnchorAppliedRef.current = true;
+        return;
+      }
+
+      if (timelineEntries.some((entry) => entry.transcriptEntryId === latestAssistantEntryID)) {
+        requestAnimationFrame(() => {
+          if (initialAnchorAppliedRef.current || initialAnchorCancelledRef.current) return;
+          const currentEl = scrollRef.current;
+          if (!currentEl) return;
+          const delayedTarget = currentEl.querySelector<HTMLElement>(transcriptEntryIDSelector(latestAssistantEntryID));
+          if (!delayedTarget) return;
+          currentEl.scrollTop = delayedTarget.offsetTop;
+          syncScrollState(currentEl);
+          initialAnchorAppliedRef.current = true;
+          defaultEntryAnchorAppliedRef.current = true;
+        });
+        return;
+      }
+
+      const fetchKey = `${activeThreadId}:${latestAssistantEntryID}`;
+      if (
+        activeThreadTranscriptQueryKey &&
+        defaultEntryAnchorFetchRef.current !== fetchKey
+      ) {
+        defaultEntryAnchorFetchRef.current = fetchKey;
+        void api.sessions.getThreadTranscriptWindow(sessionId, activeThreadId, {
+          position: "around",
+          anchorEntryId: latestAssistantEntryID,
+        }).then((window) => {
+          queryClient.setQueryData<TranscriptWindowInfiniteData>(
+            activeThreadTranscriptQueryKey,
+            { pages: [window], pageParams: [{ position: "around", anchorEntryId: latestAssistantEntryID }] },
+          );
+        }).catch((error) => {
+          toast.error(error instanceof ApiError ? error.message : "Failed to load latest assistant message");
+          scrollToLiveEdgePosition();
+          initialAnchorAppliedRef.current = true;
+        });
         return;
       }
     }
@@ -2947,7 +3074,7 @@ function ChatPanel({
 
     scrollToLiveEdgePosition();
     initialAnchorAppliedRef.current = true;
-  }, [activeThreadId, hasLoadedTimelineInputs, initialThreadAnchorPosition, isRunning, scrollToLiveEdgePosition, sessionId, syncScrollState, threadTranscriptQuery, timelineEntries, viewerScope]);
+  }, [activeThreadId, activeThreadTranscriptQueryKey, hasLoadedTimelineInputs, initialThreadAnchorPosition, isRunning, queryClient, scrollToLiveEdgePosition, sessionId, syncScrollState, threadTranscriptQuery, timelineEntries, viewerScope]);
 
   // Only auto-scroll to bottom when new entries arrive if the user is already near the bottom.
   useEffect(() => {
@@ -3490,16 +3617,14 @@ export function SessionDetailContent({ id }: { id: string }) {
     // ChatPanel's transcript infinite query shares this exact key, so React
     // Query dedupes against the in-flight prefetch.
     void queryClient.prefetchInfiniteQuery({
-      queryKey: transcriptWindowQueryKey(id, storedThreadId),
+      queryKey: transcriptWindowQueryKey(id, storedThreadId, transcriptAnchorKey(anchor)),
       queryFn: () =>
         api.sessions.getThreadTranscriptWindow(
           id,
           storedThreadId,
-          anchor
-            ? { position: "around", anchorMessageId: anchor.anchor.id }
-            : { position: "latest" },
+          transcriptInitialPageParam(anchor),
         ),
-      initialPageParam: transcriptInitialPageParam(anchor?.anchor.id ?? null),
+      initialPageParam: transcriptInitialPageParam(anchor),
     });
   }, [id, queryClient, user]);
 
@@ -4751,8 +4876,8 @@ export function SessionDetailContent({ id }: { id: string }) {
         // Inject the confirmed message into the newest transcript page so the
         // optimistic copy can be dropped without a gap; the next /transcript
         // refetch (triggered by SSE/invalidations) supersedes this patch.
-        queryClient.setQueryData<TranscriptWindowInfiniteData>(
-          transcriptWindowQueryKey(id, vars.activeThreadId),
+        queryClient.setQueriesData<TranscriptWindowInfiniteData>(
+          { queryKey: queryKeys.sessions.threadTranscript(id, vars.activeThreadId) },
           (previous) => appendMessageToTranscriptCache(previous, response.data, activeThread?.status ?? "idle"),
         );
       } else {

--- a/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
@@ -2195,7 +2195,7 @@ function useDefaultEntryAnchor({
     syncScrollState(el);
     initialAnchorAppliedRef.current = true;
     appliedRef.current = true;
-  }, [isEligible, latestAssistantEntryID, syncScrollState, timelineEntries]);
+  }, [initialAnchorAppliedRef, isEligible, latestAssistantEntryID, scrollRef, syncScrollState, timelineEntries]);
 
   return useCallback((el: HTMLDivElement): boolean => {
     if (!isEligible || !latestAssistantEntryID) return false;
@@ -2249,9 +2249,12 @@ function useDefaultEntryAnchor({
   }, [
     activeThreadId,
     activeThreadTranscriptQueryKey,
+    initialAnchorAppliedRef,
+    initialAnchorCancelledRef,
     isEligible,
     latestAssistantEntryID,
     queryClient,
+    scrollRef,
     scrollToLiveEdgePosition,
     sessionId,
     syncScrollState,

--- a/frontend/src/components/chat-timeline.test.tsx
+++ b/frontend/src/components/chat-timeline.test.tsx
@@ -100,6 +100,35 @@ describe("ChatTimeline", () => {
     expect(screen.getByText("Assistant replied")).toBeInTheDocument();
   });
 
+  it("anchors grouped hidden logs by the first hidden transcript entry", () => {
+    const entries: TimelineEntry[] = [
+      {
+        kind: "log",
+        data: makeLog({ id: 1, level: "info", message: "hidden diagnostic" }),
+        transcriptEntryId: "log_1",
+      },
+      {
+        kind: "log",
+        data: makeLog({ id: 2, level: "info", message: "second hidden diagnostic" }),
+        transcriptEntryId: "log_2",
+      },
+    ];
+
+    const { container } = render(
+      <ChatTimeline
+        entries={entries}
+        isRunning={false}
+        getEntryContainerProps={(entry) => ({
+          "data-session-entry-id": entry.transcriptEntryId,
+        })}
+      />,
+    );
+
+    expect(container.querySelector('[data-session-entry-id="log_1"]')).toBeInTheDocument();
+    expect(container.querySelector('[data-session-entry-id="log_2"]')).toBeNull();
+    expect(screen.getByText("2 log entries")).toBeInTheDocument();
+  });
+
   it("scopes user message bubbles for readable text selection", () => {
     const entries: TimelineEntry[] = [
       { kind: "message", data: makeMessage({ id: 1, content: "Selectable user prompt", role: "user" }) },

--- a/frontend/src/components/chat-timeline.tsx
+++ b/frontend/src/components/chat-timeline.tsx
@@ -646,7 +646,7 @@ function ChatTimelineImpl({ entries, isRunning, stoppingLabel, stoppedLabel, dif
   // Separate visible entries (messages, tool groups, errors) from hidden logs.
   // Group consecutive hidden logs together so they share a single "Show more" toggle.
   const rendered: React.ReactNode[] = [];
-  let hiddenBatch: SessionLog[] = [];
+  let hiddenBatch: Array<{ entry: Extract<TimelineEntry, { kind: "log" }>; index: number }> = [];
   let lastDay: string | null = null;
 
   function wrapEntry(node: React.ReactNode, entry: TimelineEntry, index: number, key: string) {
@@ -664,8 +664,17 @@ function ChatTimelineImpl({ entries, isRunning, stoppingLabel, stoppedLabel, dif
 
   function flushHidden() {
     if (hiddenBatch.length > 0) {
+      const first = hiddenBatch[0];
       rendered.push(
-        <HiddenLogsGroup key={`hidden-${hiddenBatch[0].id}`} logs={[...hiddenBatch]} />
+        wrapEntry(
+          <HiddenLogsGroup
+            key={`hidden-${first.entry.data.id}`}
+            logs={hiddenBatch.map((item) => item.entry.data)}
+          />,
+          first.entry,
+          first.index,
+          `hidden-${first.entry.data.id}`,
+        )
       );
       hiddenBatch = [];
     }
@@ -682,7 +691,7 @@ function ChatTimelineImpl({ entries, isRunning, stoppingLabel, stoppedLabel, dif
 
   for (const [index, entry] of entries.entries()) {
     if (entry.kind === "log") {
-      hiddenBatch.push(entry.data);
+      hiddenBatch.push({ entry, index });
       continue;
     }
 

--- a/frontend/src/lib/session-open-position.test.ts
+++ b/frontend/src/lib/session-open-position.test.ts
@@ -121,23 +121,57 @@ describe("session-open-position", () => {
     const storage = new Map<string, string>();
 
     writeStoredSessionAnchorPosition(storage, "sess-123", viewerScope, {
-      anchor: { kind: "message", id: 456 },
+      anchor: { kind: "entry", id: "msg_456" },
       offsetPx: 12.4,
       scrollTopFallback: 980.7,
     }, "thread-a");
 
     expect(storage.get("session-scroll-position:org-1:user-1:sess-123:thread-a")).toBe(JSON.stringify({
-      version: 2,
-      anchor: { kind: "message", id: 456 },
+      version: 3,
+      anchor_entry_id: "msg_456",
       offset_px: 12,
       scroll_top_fallback: 981,
     }));
+    expect(readStoredSessionAnchorPosition(storage, "sess-123", viewerScope, "thread-a")).toEqual({
+      anchor: { kind: "entry", id: "msg_456" },
+      offsetPx: 12,
+      scrollTopFallback: 981,
+    });
+    expect(readStoredSessionScrollPosition(storage, "sess-123", viewerScope, "thread-a")).toBe(981);
+  });
+
+  it("reads legacy message anchors for backward-compatible restores", () => {
+    const storage = new Map<string, string>([[
+      "session-scroll-position:org-1:user-1:sess-123:thread-a",
+      JSON.stringify({
+        version: 2,
+        anchor: { kind: "message", id: 456 },
+        offset_px: 12,
+        scroll_top_fallback: 981,
+      }),
+    ]]);
+
     expect(readStoredSessionAnchorPosition(storage, "sess-123", viewerScope, "thread-a")).toEqual({
       anchor: { kind: "message", id: 456 },
       offsetPx: 12,
       scrollTopFallback: 981,
     });
-    expect(readStoredSessionScrollPosition(storage, "sess-123", viewerScope, "thread-a")).toBe(981);
+  });
+
+  it("reads and writes non-message transcript entry anchors", () => {
+    const storage = new Map<string, string>();
+
+    writeStoredSessionAnchorPosition(storage, "sess-123", viewerScope, {
+      anchor: { kind: "entry", id: "tres_991" },
+      offsetPx: 4,
+      scrollTopFallback: 1200,
+    }, "thread-a");
+
+    expect(readStoredSessionAnchorPosition(storage, "sess-123", viewerScope, "thread-a")).toEqual({
+      anchor: { kind: "entry", id: "tres_991" },
+      offsetPx: 4,
+      scrollTopFallback: 1200,
+    });
   });
 
   it("ignores invalid structured anchor positions", () => {

--- a/frontend/src/lib/session-open-position.ts
+++ b/frontend/src/lib/session-open-position.ts
@@ -32,11 +32,23 @@ interface StoredSessionAnchorPosition {
   scroll_top_fallback: number;
 }
 
+interface StoredSessionEntryAnchorPosition {
+  version: 3;
+  anchor_entry_id: string;
+  offset_px: number;
+  scroll_top_fallback: number;
+}
+
 export interface SessionAnchorPosition {
-  anchor: {
-    kind: "message";
-    id: number;
-  };
+  anchor:
+    | {
+        kind: "message";
+        id: number;
+      }
+    | {
+        kind: "entry";
+        id: string;
+      };
   offsetPx: number;
   scrollTopFallback: number;
 }
@@ -88,8 +100,8 @@ export function readStoredSessionScrollPosition(
 
   if (rawValue.startsWith("{")) {
     try {
-      const parsed = JSON.parse(rawValue) as Partial<StoredSessionScrollPosition | StoredSessionAnchorPosition>;
-      if (parsed.version === 2) {
+      const parsed = JSON.parse(rawValue) as Partial<StoredSessionScrollPosition | StoredSessionAnchorPosition | StoredSessionEntryAnchorPosition>;
+      if (parsed.version === 2 || parsed.version === 3) {
         if (!Number.isFinite(parsed.scroll_top_fallback) || parsed.scroll_top_fallback! < 0) {
           return null;
         }
@@ -125,19 +137,37 @@ export function readStoredSessionAnchorPosition(
   if (!rawValue || !rawValue.startsWith("{")) return null;
 
   try {
-    const parsed = JSON.parse(rawValue) as Partial<StoredSessionAnchorPosition>;
+    const parsed = JSON.parse(rawValue) as Partial<StoredSessionAnchorPosition | StoredSessionEntryAnchorPosition>;
+    if (!Number.isFinite(parsed.offset_px) || parsed.offset_px! < 0) {
+      return null;
+    }
+    if (!Number.isFinite(parsed.scroll_top_fallback) || parsed.scroll_top_fallback! < 0) {
+      return null;
+    }
+
+    if (parsed.version === 3) {
+      if (
+        typeof parsed.anchor_entry_id !== "string" ||
+        parsed.anchor_entry_id.trim().length === 0
+      ) {
+        return null;
+      }
+      return {
+        anchor: { kind: "entry", id: parsed.anchor_entry_id.trim() },
+        offsetPx: parsed.offset_px!,
+        scrollTopFallback: parsed.scroll_top_fallback!,
+      };
+    }
+
     if (
       parsed.version !== 2 ||
       parsed.anchor?.kind !== "message" ||
       !Number.isInteger(parsed.anchor.id) ||
-      parsed.anchor.id <= 0 ||
-      !Number.isFinite(parsed.offset_px) ||
-      parsed.offset_px! < 0 ||
-      !Number.isFinite(parsed.scroll_top_fallback) ||
-      parsed.scroll_top_fallback! < 0
+      parsed.anchor.id <= 0
     ) {
       return null;
     }
+
     return {
       anchor: { kind: "message", id: parsed.anchor.id },
       offsetPx: parsed.offset_px!,
@@ -181,9 +211,6 @@ export function writeStoredSessionAnchorPosition(
   threadId?: string | null,
 ): void {
   if (
-    position.anchor.kind !== "message" ||
-    !Number.isInteger(position.anchor.id) ||
-    position.anchor.id <= 0 ||
     !Number.isFinite(position.offsetPx) ||
     position.offsetPx < 0 ||
     !Number.isFinite(position.scrollTopFallback) ||
@@ -191,17 +218,36 @@ export function writeStoredSessionAnchorPosition(
   ) {
     return;
   }
+  if (
+    position.anchor.kind === "message" &&
+    (!Number.isInteger(position.anchor.id) || position.anchor.id <= 0)
+  ) {
+    return;
+  }
+  if (
+    position.anchor.kind === "entry" &&
+    position.anchor.id.trim().length === 0
+  ) {
+    return;
+  }
 
   const key = getSessionScrollStorageKey(sessionId, viewerScope, threadId);
-  const normalizedValue = JSON.stringify({
-    version: 2,
-    anchor: {
-      kind: "message",
-      id: position.anchor.id,
-    },
-    offset_px: Math.round(position.offsetPx),
-    scroll_top_fallback: Math.round(position.scrollTopFallback),
-  } satisfies StoredSessionAnchorPosition);
+  const normalizedValue = position.anchor.kind === "entry"
+    ? JSON.stringify({
+      version: 3,
+      anchor_entry_id: position.anchor.id.trim(),
+      offset_px: Math.round(position.offsetPx),
+      scroll_top_fallback: Math.round(position.scrollTopFallback),
+    } satisfies StoredSessionEntryAnchorPosition)
+    : JSON.stringify({
+      version: 2,
+      anchor: {
+        kind: "message",
+        id: position.anchor.id,
+      },
+      offset_px: Math.round(position.offsetPx),
+      scroll_top_fallback: Math.round(position.scrollTopFallback),
+    } satisfies StoredSessionAnchorPosition);
 
   if ("setItem" in storage) {
     storage.setItem(key, normalizedValue);

--- a/frontend/src/lib/timeline.test.ts
+++ b/frontend/src/lib/timeline.test.ts
@@ -335,11 +335,41 @@ describe("flattenTranscriptWindows", () => {
       },
     ];
 
-    const { messages, logs, humanInputs } = flattenTranscriptWindows(turns);
+    const { messages, logs, humanInputs, messageEntryIds, logEntryIds, humanInputEntryIds } = flattenTranscriptWindows(turns);
 
     expect(messages).toEqual([message]);
     expect(logs).toEqual([toolUse]);
     expect(humanInputs).toEqual([humanInput]);
+    expect(messageEntryIds.get(1)).toBe("msg_1");
+    expect(logEntryIds.get(10)).toBe("tuse_10");
+    expect(humanInputEntryIds.get("hir-1")).toBe("hiq_hir-1");
+  });
+
+  it("attaches transcript entry ids to rendered timeline entries", () => {
+    const message = makeMessage({ id: 1, created_at: "2026-01-01T00:00:00Z", role: "user", content: "hi" });
+    const toolUse = makeLog({ id: 10, created_at: "2026-01-01T00:00:10Z", level: "tool_use" });
+    const toolResult = makeLog({
+      id: 11,
+      created_at: "2026-01-01T00:00:11Z",
+      level: "output",
+      metadata: { type: "tool_result" },
+    });
+    const turns: SessionTranscriptTurn[] = [
+      {
+        turn_number: 1,
+        started_at: message.created_at,
+        entries: [
+          { id: "msg_1", kind: "message", created_at: message.created_at, message_id: 1, message },
+          { id: "tuse_10", kind: "tool_use", created_at: toolUse.created_at, log_id: 10, log: toolUse },
+          { id: "tres_11", kind: "tool_result", created_at: toolResult.created_at, log_id: 11, log: toolResult },
+        ],
+      },
+    ];
+
+    const { messages, logs, messageEntryIds, logEntryIds } = flattenTranscriptWindows(turns);
+    const entries = buildTimeline(messages, logs, { messageEntryIds, logEntryIds });
+
+    expect(entries.map((entry) => entry.transcriptEntryId)).toEqual(["msg_1", "tuse_10"]);
   });
 
   it("de-duplicates records that repeat across overlapping turns/pages", () => {
@@ -370,7 +400,7 @@ describe("flattenTranscriptWindows", () => {
       },
     ];
 
-    expect(flattenTranscriptWindows(turns)).toEqual({ messages: [], logs: [], humanInputs: [] });
-    expect(flattenTranscriptWindows(undefined)).toEqual({ messages: [], logs: [], humanInputs: [] });
+    expect(flattenTranscriptWindows(turns)).toMatchObject({ messages: [], logs: [], humanInputs: [] });
+    expect(flattenTranscriptWindows(undefined)).toMatchObject({ messages: [], logs: [], humanInputs: [] });
   });
 });

--- a/frontend/src/lib/timeline.ts
+++ b/frontend/src/lib/timeline.ts
@@ -11,14 +11,23 @@ export function applyPlanModePrefix(content: string, planMode: boolean): string 
 }
 
 export type TimelineEntry =
-  | { kind: "message"; data: SessionMessage }
-  | { kind: "assistant_output"; data: SessionLog }
-  | { kind: "tool_group"; toolUse: SessionLog; toolResult?: SessionLog }
-  | { kind: "error"; data: SessionLog }
-  | { kind: "log"; data: SessionLog }
-  | { kind: "plan_output"; data: SessionLog; turnNumber: number }
-  | { kind: "plan_message"; data: SessionMessage; turnNumber: number }
-  | { kind: "human_input"; data: HumanInputRequest };
+  | ({ kind: "message"; data: SessionMessage } & TimelineEntryAnchor)
+  | ({ kind: "assistant_output"; data: SessionLog } & TimelineEntryAnchor)
+  | ({ kind: "tool_group"; toolUse: SessionLog; toolResult?: SessionLog } & TimelineEntryAnchor)
+  | ({ kind: "error"; data: SessionLog } & TimelineEntryAnchor)
+  | ({ kind: "log"; data: SessionLog } & TimelineEntryAnchor)
+  | ({ kind: "plan_output"; data: SessionLog; turnNumber: number } & TimelineEntryAnchor)
+  | ({ kind: "plan_message"; data: SessionMessage; turnNumber: number } & TimelineEntryAnchor)
+  | ({ kind: "human_input"; data: HumanInputRequest } & TimelineEntryAnchor);
+
+interface TimelineEntryAnchor {
+  transcriptEntryId?: string;
+}
+
+export interface TimelineTranscriptEntryIds {
+  messageEntryIds?: ReadonlyMap<number, string>;
+  logEntryIds?: ReadonlyMap<number, string>;
+}
 
 type TaggedTimelineItem =
   | { source: "message"; ts: string; data: SessionMessage }
@@ -88,7 +97,8 @@ function duplicateOutputLogIds(messages: SessionMessage[], logs: SessionLog[]): 
  */
 export function buildTimeline(
   messages: SessionMessage[],
-  logs: SessionLog[]
+  logs: SessionLog[],
+  transcriptEntryIds: TimelineTranscriptEntryIds = {},
 ): TimelineEntry[] {
   const suppressedLogIds = duplicateOutputLogIds(messages, logs);
 
@@ -130,10 +140,11 @@ export function buildTimeline(
       const msg = item.data;
       // If this is an assistant message responding to a plan mode turn,
       // mark it as a plan_message so the UI can show approve/adjust buttons.
+      const transcriptEntryId = transcriptEntryIds.messageEntryIds?.get(msg.id);
       if (msg.role === "assistant" && planModeTurns.has(msg.turn_number)) {
-        entries.push({ kind: "plan_message", data: msg, turnNumber: msg.turn_number });
+        entries.push({ kind: "plan_message", data: msg, turnNumber: msg.turn_number, transcriptEntryId });
       } else {
-        entries.push({ kind: "message", data: msg });
+        entries.push({ kind: "message", data: msg, transcriptEntryId });
       }
       i++;
       continue;
@@ -168,22 +179,23 @@ export function buildTimeline(
           kind: "tool_group",
           toolUse: log,
           toolResult,
+          transcriptEntryId: transcriptEntryIds.logEntryIds?.get(log.id),
         });
       } else {
-        entries.push({ kind: "tool_group", toolUse: log });
+        entries.push({ kind: "tool_group", toolUse: log, transcriptEntryId: transcriptEntryIds.logEntryIds?.get(log.id) });
       }
       i++;
       continue;
     }
 
     if (isHiddenLog(log)) {
-      entries.push({ kind: "log", data: log });
+      entries.push({ kind: "log", data: log, transcriptEntryId: transcriptEntryIds.logEntryIds?.get(log.id) });
       i++;
       continue;
     }
 
     if (log.level === "error") {
-      entries.push({ kind: "error", data: log });
+      entries.push({ kind: "error", data: log, transcriptEntryId: transcriptEntryIds.logEntryIds?.get(log.id) });
       i++;
       continue;
     }
@@ -193,16 +205,16 @@ export function buildTimeline(
     if (isVisibleAssistantOutput(log)) {
       // If this output belongs to a plan mode turn, mark it as plan output.
       if (planModeTurns.has(log.turn_number)) {
-        entries.push({ kind: "plan_output", data: log, turnNumber: log.turn_number });
+        entries.push({ kind: "plan_output", data: log, turnNumber: log.turn_number, transcriptEntryId: transcriptEntryIds.logEntryIds?.get(log.id) });
       } else {
-        entries.push({ kind: "assistant_output", data: log });
+        entries.push({ kind: "assistant_output", data: log, transcriptEntryId: transcriptEntryIds.logEntryIds?.get(log.id) });
       }
       i++;
       continue;
     }
 
     // debug, info, remaining output with metadata — hidden by default.
-    entries.push({ kind: "log", data: log });
+    entries.push({ kind: "log", data: log, transcriptEntryId: transcriptEntryIds.logEntryIds?.get(log.id) });
     i++;
   }
 
@@ -310,10 +322,16 @@ export function flattenTranscriptWindows(turns: SessionTranscriptTurn[] | undefi
   messages: SessionMessage[];
   logs: SessionLog[];
   humanInputs: HumanInputRequest[];
+  messageEntryIds: Map<number, string>;
+  logEntryIds: Map<number, string>;
+  humanInputEntryIds: Map<string, string>;
 } {
   const messages: SessionMessage[] = [];
   const logs: SessionLog[] = [];
   const humanInputs: HumanInputRequest[] = [];
+  const messageEntryIds = new Map<number, string>();
+  const logEntryIds = new Map<number, string>();
+  const humanInputEntryIds = new Map<string, string>();
   const seenMessageIds = new Set<number>();
   const seenLogIds = new Set<number>();
   const seenHumanInputIds = new Set<string>();
@@ -323,17 +341,20 @@ export function flattenTranscriptWindows(turns: SessionTranscriptTurn[] | undefi
       if (entry.message && !seenMessageIds.has(entry.message.id)) {
         seenMessageIds.add(entry.message.id);
         messages.push(entry.message);
+        messageEntryIds.set(entry.message.id, entry.id);
       }
       if (entry.log && !seenLogIds.has(entry.log.id)) {
         seenLogIds.add(entry.log.id);
         logs.push(entry.log);
+        logEntryIds.set(entry.log.id, entry.id);
       }
       if (entry.human_input && !seenHumanInputIds.has(entry.human_input.id)) {
         seenHumanInputIds.add(entry.human_input.id);
         humanInputs.push(entry.human_input);
+        humanInputEntryIds.set(entry.human_input.id, entry.id);
       }
     }
   }
 
-  return { messages, logs, humanInputs };
+  return { messages, logs, humanInputs, messageEntryIds, logEntryIds, humanInputEntryIds };
 }


### PR DESCRIPTION
## Summary

Reopening a session transcript could land the user at the wrong spot because the app relied on unstable position mapping when restoring scroll. This change implements stable transcript anchors so we can reliably compute the correct “open around” transcript entry for both message and non-message (e.g., tool log) anchors.

## Changes

- Added support for stable transcript entry anchors and restore logic when reopening a session, ensuring scroll position and “open thread around anchor” behavior stay consistent.
- Updated the transcript/timeline components to use deterministic anchor identifiers when rendering and when calculating the next `after`/window to fetch.
- Extended test coverage to include restoring around a saved non-message transcript entry anchor and verifying the correct transcript fetch behavior/scroll restoration path.

## Validation

- Updated/added frontend tests covering transcript anchor restore and timeline fetching:
  - `frontend/src/app/(dashboard)/sessions/[id]/page-transcript.test.tsx`
  - `frontend/src/components/chat-timeline.test.tsx`
  - `frontend/src/lib/session-open-position.test.ts`
  - `frontend/src/lib/timeline.test.ts`
- Ran the unit test suite for the above modules (via the repo’s standard vitest/test runner for frontend).

[143.dev](https://143.dev) | [session 52f2e259](https://143.dev/sessions/52f2e259-0720-4811-a22c-3f64c8c8e1d3)

Preview: https://143.dev/previews/github/assembledhq/143/pull/1478?launch=1