### PR TITLE
Wire Slack stores into session executor and hide Start work for auto routing

### DIFF
--- a/cmd/server/session_executor_main.go
+++ b/cmd/server/session_executor_main.go
@@ -290,6 +290,7 @@ func buildSessionExecutorRuntime(ctx context.Context, cfg *config.Config, pool *
 		Repositories:        repoStore,
 		SessionMessages:     sessionMessageStore,
 		SessionThreads:      sessionThreadStore,
+		HumanInputRequests:  db.NewSessionHumanInputRequestStore(pool),
 		ThreadFileEvents:    db.NewSessionThreadFileEventStore(pool),
 		Automations:         db.NewAutomationStore(pool),
 		AutomationRuns:      automationRunStore,
@@ -297,8 +298,15 @@ func buildSessionExecutorRuntime(ctx context.Context, cfg *config.Config, pool *
 		SessionIssueLinks:   db.NewSessionIssueLinkStore(pool),
 		Previews:            db.NewPreviewStore(pool),
 		PullRequests:        pullRequestStore,
+		SlackInstallations:  db.NewSlackInstallationStore(pool),
+		SlackOrgSelections:  db.NewSlackOrgSelectionStore(pool),
+		SlackBotSettings:    db.NewSlackBotSettingsStore(pool),
+		SlackUserLinks:      db.NewSlackUserLinkStore(pool),
+		SlackChannels:       db.NewSlackChannelSettingsStore(pool),
+		SlackSessionLinks:   db.NewSlackSessionLinkStore(pool),
+		SlackInboundEvents:  db.NewSlackInboundEventStore(pool),
+		SlackOutbound:       db.NewSlackOutboundMessageStore(pool),
 	}
-	wireSessionExecutorSlackStores(stores, pool)
 	if services.LinearAgentDeps != nil {
 		services.LinearAgentDeps.Stores = stores
 	}
@@ -321,19 +329,4 @@ func buildSessionExecutorRuntime(ctx context.Context, cfg *config.Config, pool *
 		HeartbeatInterval: 10 * time.Second,
 		RenewInterval:     20 * time.Second,
 	}, shutdown, nil
-}
-
-func wireSessionExecutorSlackStores(stores *worker.Stores, database db.DBTX) {
-	if stores == nil || database == nil {
-		return
-	}
-	stores.SlackInstallations = db.NewSlackInstallationStore(database)
-	stores.SlackOrgSelections = db.NewSlackOrgSelectionStore(database)
-	stores.SlackBotSettings = db.NewSlackBotSettingsStore(database)
-	stores.SlackUserLinks = db.NewSlackUserLinkStore(database)
-	stores.SlackChannels = db.NewSlackChannelSettingsStore(database)
-	stores.SlackSessionLinks = db.NewSlackSessionLinkStore(database)
-	stores.SlackInboundEvents = db.NewSlackInboundEventStore(database)
-	stores.SlackOutbound = db.NewSlackOutboundMessageStore(database)
-	stores.HumanInputRequests = db.NewSessionHumanInputRequestStore(database)
 }

--- a/cmd/server/session_executor_main.go
+++ b/cmd/server/session_executor_main.go
@@ -298,6 +298,7 @@ func buildSessionExecutorRuntime(ctx context.Context, cfg *config.Config, pool *
 		Previews:            db.NewPreviewStore(pool),
 		PullRequests:        pullRequestStore,
 	}
+	wireSessionExecutorSlackStores(stores, pool)
 	if services.LinearAgentDeps != nil {
 		services.LinearAgentDeps.Stores = stores
 	}
@@ -320,4 +321,19 @@ func buildSessionExecutorRuntime(ctx context.Context, cfg *config.Config, pool *
 		HeartbeatInterval: 10 * time.Second,
 		RenewInterval:     20 * time.Second,
 	}, shutdown, nil
+}
+
+func wireSessionExecutorSlackStores(stores *worker.Stores, database db.DBTX) {
+	if stores == nil || database == nil {
+		return
+	}
+	stores.SlackInstallations = db.NewSlackInstallationStore(database)
+	stores.SlackOrgSelections = db.NewSlackOrgSelectionStore(database)
+	stores.SlackBotSettings = db.NewSlackBotSettingsStore(database)
+	stores.SlackUserLinks = db.NewSlackUserLinkStore(database)
+	stores.SlackChannels = db.NewSlackChannelSettingsStore(database)
+	stores.SlackSessionLinks = db.NewSlackSessionLinkStore(database)
+	stores.SlackInboundEvents = db.NewSlackInboundEventStore(database)
+	stores.SlackOutbound = db.NewSlackOutboundMessageStore(database)
+	stores.HumanInputRequests = db.NewSessionHumanInputRequestStore(database)
 }

--- a/cmd/server/session_executor_main_test.go
+++ b/cmd/server/session_executor_main_test.go
@@ -1,32 +1,63 @@
 package main
 
 import (
+	"go/ast"
+	"go/parser"
+	"go/token"
 	"testing"
 
-	"github.com/pashagolub/pgxmock/v4"
 	"github.com/stretchr/testify/require"
-
-	"github.com/assembledhq/143/internal/worker"
 )
 
-func TestWireSessionExecutorSlackStores(t *testing.T) {
+func TestSessionExecutorStoresWireSlackLifecycleDependencies(t *testing.T) {
 	t.Parallel()
 
-	mock, err := pgxmock.NewPool()
-	require.NoError(t, err, "pgxmock should initialize")
-	defer mock.Close()
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, "session_executor_main.go", nil, 0)
+	require.NoError(t, err, "session_executor_main.go should parse")
 
-	stores := &worker.Stores{}
+	var storesLiteral *ast.CompositeLit
+	ast.Inspect(file, func(node ast.Node) bool {
+		if storesLiteral != nil {
+			return false
+		}
+		lit, ok := node.(*ast.CompositeLit)
+		if !ok {
+			return true
+		}
+		typ, ok := lit.Type.(*ast.SelectorExpr)
+		if !ok || typ.Sel.Name != "Stores" {
+			return true
+		}
+		pkg, ok := typ.X.(*ast.Ident)
+		if !ok || pkg.Name != "worker" {
+			return true
+		}
+		storesLiteral = lit
+		return false
+	})
+	require.NotNil(t, storesLiteral, "session executor should construct worker.Stores explicitly")
 
-	wireSessionExecutorSlackStores(stores, mock)
+	fields := map[string]bool{}
+	for _, element := range storesLiteral.Elts {
+		kv, ok := element.(*ast.KeyValueExpr)
+		if !ok {
+			continue
+		}
+		key, ok := kv.Key.(*ast.Ident)
+		if !ok {
+			continue
+		}
+		fields[key.Name] = true
+	}
 
-	require.NotNil(t, stores.SlackInstallations, "session executor stores should include Slack installations")
-	require.NotNil(t, stores.SlackOrgSelections, "session executor stores should include Slack org selections")
-	require.NotNil(t, stores.SlackBotSettings, "session executor stores should include Slack bot settings")
-	require.NotNil(t, stores.SlackUserLinks, "session executor stores should include Slack user links")
-	require.NotNil(t, stores.SlackChannels, "session executor stores should include Slack channel settings")
-	require.NotNil(t, stores.SlackSessionLinks, "session executor stores should include Slack session links for lifecycle enqueue hooks")
-	require.NotNil(t, stores.SlackInboundEvents, "session executor stores should include Slack inbound events")
-	require.NotNil(t, stores.SlackOutbound, "session executor stores should include Slack outbound messages")
-	require.NotNil(t, stores.HumanInputRequests, "session executor stores should include human-input requests for Slack delivery")
+	require.True(t, fields["SlackInstallations"], "session executor stores should include Slack installations")
+	require.True(t, fields["SlackOrgSelections"], "session executor stores should include Slack org selections")
+	require.True(t, fields["SlackBotSettings"], "session executor stores should include Slack bot settings")
+	require.True(t, fields["SlackUserLinks"], "session executor stores should include Slack user links")
+	require.True(t, fields["SlackChannels"], "session executor stores should include Slack channel settings")
+	require.True(t, fields["SlackSessionLinks"], "session executor stores should include Slack session links for lifecycle enqueue hooks")
+	require.True(t, fields["SlackInboundEvents"], "session executor stores should include Slack inbound events")
+	require.True(t, fields["SlackOutbound"], "session executor stores should include Slack outbound messages")
+	require.True(t, fields["HumanInputRequests"], "session executor stores should include human-input requests for Slack delivery")
 }

--- a/cmd/server/session_executor_main_test.go
+++ b/cmd/server/session_executor_main_test.go
@@ -1,0 +1,32 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/pashagolub/pgxmock/v4"
+	"github.com/stretchr/testify/require"
+
+	"github.com/assembledhq/143/internal/worker"
+)
+
+func TestWireSessionExecutorSlackStores(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "pgxmock should initialize")
+	defer mock.Close()
+
+	stores := &worker.Stores{}
+
+	wireSessionExecutorSlackStores(stores, mock)
+
+	require.NotNil(t, stores.SlackInstallations, "session executor stores should include Slack installations")
+	require.NotNil(t, stores.SlackOrgSelections, "session executor stores should include Slack org selections")
+	require.NotNil(t, stores.SlackBotSettings, "session executor stores should include Slack bot settings")
+	require.NotNil(t, stores.SlackUserLinks, "session executor stores should include Slack user links")
+	require.NotNil(t, stores.SlackChannels, "session executor stores should include Slack channel settings")
+	require.NotNil(t, stores.SlackSessionLinks, "session executor stores should include Slack session links for lifecycle enqueue hooks")
+	require.NotNil(t, stores.SlackInboundEvents, "session executor stores should include Slack inbound events")
+	require.NotNil(t, stores.SlackOutbound, "session executor stores should include Slack outbound messages")
+	require.NotNil(t, stores.HumanInputRequests, "session executor stores should include human-input requests for Slack delivery")
+}

--- a/internal/worker/handlers.go
+++ b/internal/worker/handlers.go
@@ -5885,7 +5885,7 @@ func slackSessionAckBlocks(ctx context.Context, stores *Stores, services *Servic
 				"channel_id": channelID,
 			}),
 		})
-		if routingMode != slackbotsvc.SlackRoutingModeStartWork {
+		if routingMode == slackbotsvc.SlackRoutingModeAnswerOnly {
 			actions = append(actions, slackbotsvc.SlackAction{
 				Text:     "Start work",
 				ActionID: "slack_start_work",

--- a/internal/worker/handlers_test.go
+++ b/internal/worker/handlers_test.go
@@ -646,6 +646,35 @@ func TestSlackSessionAckBlocksIncludeCorrectionActions(t *testing.T) {
 	require.Contains(t, slackBlocksActionValue(blocks, "slack_start_work"), orgID.String(), "start-work action should carry org scope")
 }
 
+func TestSlackSessionAckBlocksSuppressStartWorkForAutoRouting(t *testing.T) {
+	t.Parallel()
+
+	orgID := uuid.New()
+	sessionID := uuid.New()
+	session := &models.Session{ID: sessionID, OrgID: orgID}
+
+	blocks := slackSessionAckBlocks(
+		context.Background(),
+		nil,
+		&Services{FrontendURL: "https://143.test"},
+		zerolog.Nop(),
+		orgID,
+		uuid.New(),
+		"T123",
+		"C123",
+		session,
+		"Starting a 143 session",
+		slackbotsvc.SlackSessionContextSummary{
+			RepositoryName: "acme/api",
+			Branch:         "main",
+		},
+		slackbotsvc.SlackRoutingModeAuto,
+	)
+
+	require.False(t, slackBlocksContainAction(blocks, "slack_start_work"), "auto-routed Slack acks should not show a Start work escalation while the session is already running")
+	require.True(t, slackBlocksContainAction(blocks, "slack_configure_channel"), "auto-routed Slack acks should still let users correct repository defaults")
+}
+
 func TestSlackMissingContextHelpers(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- wire Slack-related stores into the session executor runtime so Slack follow-up flows can enqueue and persist state
- adjust Slack session ack actions so auto-routed sessions do not show a Start work escalation
- add unit coverage for the runtime wiring and auto-routing Slack ack behavior

## Testing
- Added unit tests for session executor Slack store wiring
- Added unit tests covering Slack ack action rendering for auto-routed sessions