### PR TITLE
Add sandbox bootstrap command handling

### DIFF
--- a/docs/design/implemented/06-agent-orchestrator.md
+++ b/docs/design/implemented/06-agent-orchestrator.md
@@ -1,6 +1,6 @@
 # Design: Agent Orchestrator
 
-> **Status:** Implemented | **Last reviewed:** 2026-03-25
+> **Status:** Implemented | **Last reviewed:** 2026-06-18
 
 This document describes how 143.dev launches, manages, and monitors coding agent runs inside isolated sandboxes.
 
@@ -10,10 +10,11 @@ When an issue is selected for an agent run (either manually or auto-triggered), 
 
 1. Prepares the execution context (issue details, codebase, instructions)
 2. Launches a sandboxed container
-3. Runs the coding agent inside the container
-4. Streams logs back to the UI in real time
-5. Collects the result (code diff) when the agent completes
-6. Hands off to the validation pipeline
+3. Clones the repository, wires sandbox GitHub auth, installs supported repo-declared tools, and runs `.143/config.json` bootstrap commands
+4. Runs the coding agent inside the container
+5. Streams logs back to the UI in real time
+6. Collects the result (code diff) when the agent completes
+7. Hands off to the validation pipeline
 
 ## Agent Adapter Interface
 
@@ -328,13 +329,19 @@ func (o *Orchestrator) RunAgent(ctx context.Context, run *models.AgentRun) error
     // 7. Clone repo
     o.provider.CloneRepo(ctx, sandbox, run.RepoURL, run.RepoBranch, token)
 
-    // 8. Execute agent with log streaming
+    // 8. Prepare repo-specific sandbox setup
+    o.runSandboxGitBootstrap(ctx, sandbox, sandbox.WorkDir, log)
+    if err := o.prepareSandboxRepository(ctx, sandbox, sandbox.WorkDir, log); err != nil {
+        return err
+    }
+
+    // 9. Execute agent with log streaming
     logCh := make(chan LogEntry, 100)
     go o.streamLogs(ctx, run.ID, logCh)
 
     result, err := adapter.Execute(ctx, sandbox, prompt, logCh)
 
-    // 9. Store result
+    // 10. Store result
     if err != nil {
         o.db.UpdateAgentRun(ctx, run.ID, "failed", err.Error(), nil)
         // Enqueue failure analysis job — see 18-fix-quality-feedback.md

--- a/docs/design/overall.md
+++ b/docs/design/overall.md
@@ -73,6 +73,7 @@ Vector -> VictoriaLogs / Grafana for centralized logs, dashboards, and alerts
 
 - Workers run coding-agent jobs, continuation turns, preview starts, ingestion syncs, PM planning, automations, and repair work.
 - Sandboxes are the permission boundary for agent execution. They run with resource limits, gVisor isolation in production, controlled network policy, and per-session GitHub credential access through a worker-owned auth broker rather than long-lived tokens in the container environment.
+- Repository-owned `.143/config.json` can declare sandbox setup for agent work, including supported platform-managed tool dependencies and bootstrap commands that run after clone and auth setup before the coding agent starts.
 - The sandbox image installs the supported coding-agent CLIs, including Codex, Claude Code, OpenCode, Amp, and Pi. Runtime credentials are resolved from ordered personal/team auth stacks with health and rate-limit state tracked separately from credential config.
 - Long-running sessions survive routine deploys through durable session executors, leases, checkpointed recovery, snapshots, and worker drain/spin-down controls. See [implemented/82-durable-session-executors.md](implemented/82-durable-session-executors.md).
 - Routine worker deploys verify host support services without activating support-service changes. Mutating shared worker support services such as `sandbox-dns`, Chrome, gVisor checks, bridge config, or Docker daemon config is a maintenance-mode operation because it can affect active sandboxes and previews.

--- a/internal/services/agent/orchestrator.go
+++ b/internal/services/agent/orchestrator.go
@@ -1185,37 +1185,62 @@ func (o *Orchestrator) runSandboxGitBootstrap(ctx context.Context, sandbox *Sand
 	}
 }
 
-// installSandboxDependencies reads .143/config.json from the sandbox
-// workspace and installs the tools the repo declared (golangci-lint, etc.)
-// before bootstrap/validation commands run. Best-effort: a missing config,
-// malformed config, unknown dependency name, or install failure is logged
-// but never aborts the session — the agent can still run, just without the
-// linter. See sandboxdeps for the install/check contract.
-func (o *Orchestrator) installSandboxDependencies(ctx context.Context, sandbox *Sandbox, workDir string, log zerolog.Logger) {
+// prepareSandboxRepository reads .143/config.json from the sandbox workspace,
+// installs supported platform-managed tools, then runs repo-declared bootstrap
+// commands before the agent starts. Missing or malformed config stays
+// best-effort for compatibility. Explicit bootstrap command failures are
+// returned because the workspace is not ready for normal agent work.
+func (o *Orchestrator) prepareSandboxRepository(ctx context.Context, sandbox *Sandbox, workDir string, log zerolog.Logger) error {
 	if sandbox == nil || workDir == "" {
-		return
+		return nil
 	}
 	cfgPath := path.Join(workDir, repoconfig.ConfigPath)
 	raw, err := o.provider.ReadFile(ctx, sandbox, cfgPath)
 	if err != nil {
 		if isSandboxFileMissing(err) {
-			return
+			return nil
 		}
 		log.Warn().Err(err).Str("path", cfgPath).Msg("could not read repo config; skipping sandbox dependency install")
-		return
+		return nil
+	}
+	if len(raw) == 0 {
+		return nil
 	}
 	cfg, err := repoconfig.Parse(raw)
 	if err != nil {
 		log.Warn().Err(err).Str("path", cfgPath).Msg("repo config failed to parse; skipping sandbox dependency install")
-		return
+		return nil
 	}
-	if len(cfg.Dependencies) == 0 {
-		return
+	if len(cfg.Dependencies) > 0 {
+		exec := func(execCtx context.Context, cmd string, stdout, stderr io.Writer) (int, error) {
+			return o.provider.Exec(execCtx, sandbox, cmd, stdout, stderr)
+		}
+		sandboxdeps.Apply(ctx, log, exec, cfg.Dependencies)
 	}
-	exec := func(execCtx context.Context, cmd string, stdout, stderr io.Writer) (int, error) {
-		return o.provider.Exec(execCtx, sandbox, cmd, stdout, stderr)
+	return o.runSandboxBootstrapCommands(ctx, sandbox, workDir, cfg.Bootstrap.Commands, log)
+}
+
+func (o *Orchestrator) runSandboxBootstrapCommands(ctx context.Context, sandbox *Sandbox, workDir string, commands []string, log zerolog.Logger) error {
+	for _, command := range commands {
+		shellCmd := fmt.Sprintf("cd '%s' && %s", shellEscapeSingleQuote(workDir), command)
+		var stderr bytes.Buffer
+		exitCode, execErr := o.provider.Exec(ctx, sandbox, shellCmd, io.Discard, &stderr)
+		stderrText := strings.TrimSpace(stderr.String())
+		if execErr != nil || exitCode != 0 {
+			log.Warn().
+				Err(execErr).
+				Int("exit_code", exitCode).
+				Str("command", command).
+				Str("stderr", stderrText).
+				Msg("repo bootstrap command failed")
+			if execErr != nil {
+				return fmt.Errorf("repo bootstrap command %q failed: exit=%d err=%w stderr=%s", command, exitCode, execErr, stderrText)
+			}
+			return fmt.Errorf("repo bootstrap command %q exited with code %d: %s", command, exitCode, stderrText)
+		}
+		log.Info().Str("command", command).Msg("repo bootstrap command completed")
 	}
-	sandboxdeps.Apply(ctx, log, exec, cfg.Dependencies)
+	return nil
 }
 
 // RecoverSession resumes an interrupted session from its latest committed
@@ -2639,7 +2664,10 @@ func (o *Orchestrator) RunAgent(ctx context.Context, run *models.Session) error 
 		// session resume. Skipped when the auth socket isn't bound (legacy
 		// or non-integration path).
 		o.runSandboxGitBootstrap(ctx, sandbox, sandboxCfg.WorkDir, log)
-		o.installSandboxDependencies(ctx, sandbox, sandboxCfg.WorkDir, log)
+		if err := o.prepareSandboxRepository(ctx, sandbox, sandboxCfg.WorkDir, log); err != nil {
+			o.failRun(ctx, run, fmt.Sprintf("prepare repository: %s", err))
+			return fmt.Errorf("prepare repository: %w", err)
+		}
 		// 8d. Stamp git identity on the session row for audit. Best-effort —
 		// a failure here only affects post-hoc reporting, not the run.
 		if authState != nil && authState.source != "" {
@@ -3898,7 +3926,10 @@ func (o *Orchestrator) ContinueSession(ctx context.Context, session *models.Sess
 		}
 		if !reusedExisting {
 			o.runSandboxGitBootstrap(ctx, sandbox, sandboxCfg.WorkDir, log)
-			o.installSandboxDependencies(ctx, sandbox, sandboxCfg.WorkDir, log)
+			if err := o.prepareSandboxRepository(ctx, sandbox, sandboxCfg.WorkDir, log); err != nil {
+				o.failRun(ctx, session, fmt.Sprintf("prepare repository: %s", err))
+				return fmt.Errorf("prepare repository: %w", err)
+			}
 		}
 
 		commands := canonicalCommands(latestMsg, session.AgentType)
@@ -4034,7 +4065,10 @@ func (o *Orchestrator) ContinueSession(ctx context.Context, session *models.Sess
 		}
 		authBillingMode = authMode
 		o.runSandboxGitBootstrap(ctx, sandbox, sandboxCfg.WorkDir, log)
-		o.installSandboxDependencies(ctx, sandbox, sandboxCfg.WorkDir, log)
+		if err := o.prepareSandboxRepository(ctx, sandbox, sandboxCfg.WorkDir, log); err != nil {
+			o.failRun(ctx, session, fmt.Sprintf("prepare repository: %s", err))
+			return fmt.Errorf("prepare repository: %w", err)
+		}
 
 		// Build a full prompt via PreparePrompt so the agent gets the system
 		// prompt with integration skills, memory, and repo conventions.

--- a/internal/services/agent/orchestrator_internal_test.go
+++ b/internal/services/agent/orchestrator_internal_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"io"
 	"os"
+	"path"
 	"strings"
 	"testing"
 	"time"
@@ -15,6 +16,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/assembledhq/143/internal/models"
+	"github.com/assembledhq/143/internal/repoconfig"
 	"github.com/assembledhq/143/internal/services/sandbox"
 	"github.com/assembledhq/143/internal/services/sandboxauth"
 	"github.com/assembledhq/143/internal/services/workspace"
@@ -109,6 +111,56 @@ func TestWarmMentionIndexFromSandboxAsyncDoesNotBlockCaller(t *testing.T) {
 		return
 	}
 	close(release)
+}
+
+func TestPrepareSandboxRepositoryRunsBootstrapCommandsFromWorkDir(t *testing.T) {
+	t.Parallel()
+
+	workDir := "/home/sandbox/backend"
+	provider := &testInternalSandboxProvider{
+		readFiles: map[string][]byte{
+			path.Join(workDir, repoconfig.ConfigPath): []byte(`{
+				"bootstrap": {
+					"commands": ["npm install", "npm run lint:js -w assets"]
+				}
+			}`),
+		},
+	}
+	o := &Orchestrator{provider: provider}
+	sandbox := &Sandbox{ID: "sandbox-1", WorkDir: workDir}
+
+	err := o.prepareSandboxRepository(context.Background(), sandbox, workDir, zerolog.Nop())
+
+	require.NoError(t, err, "prepareSandboxRepository should run configured bootstrap commands successfully")
+	require.Equal(t, []string{
+		"cd '/home/sandbox/backend' && npm install",
+		"cd '/home/sandbox/backend' && npm run lint:js -w assets",
+	}, provider.execCalls, "bootstrap commands should run in order from the repository workdir")
+}
+
+func TestPrepareSandboxRepositoryReturnsBootstrapCommandFailure(t *testing.T) {
+	t.Parallel()
+
+	workDir := "/home/sandbox/backend"
+	provider := &testInternalSandboxProvider{
+		execExit:   127,
+		execStderr: "sh: eslint: not found",
+		readFiles: map[string][]byte{
+			path.Join(workDir, repoconfig.ConfigPath): []byte(`{
+				"bootstrap": {
+					"commands": ["npm run lint:js -w assets"]
+				}
+			}`),
+		},
+	}
+	o := &Orchestrator{provider: provider}
+	sandbox := &Sandbox{ID: "sandbox-1", WorkDir: workDir}
+
+	err := o.prepareSandboxRepository(context.Background(), sandbox, workDir, zerolog.Nop())
+
+	require.Error(t, err, "prepareSandboxRepository should fail when a configured bootstrap command exits non-zero")
+	require.Contains(t, err.Error(), "npm run lint:js -w assets", "bootstrap setup error should identify the command that failed")
+	require.Contains(t, err.Error(), "sh: eslint: not found", "bootstrap setup error should include stderr so missing tool failures are actionable")
 }
 
 type blockingMentionIndexFileReader struct {


### PR DESCRIPTION
## Summary
- Document repo-owned sandbox setup in the design docs
- Run supported repo-declared bootstrap commands after cloning and auth setup
- Fail agent setup when a bootstrap command exits non-zero, while keeping config parsing best-effort
- Add unit tests for successful bootstrap execution and failure propagation

## Testing
- Unit tests added for `prepareSandboxRepository` command execution and error handling
- Not run (not requested)