### PR TITLE
Refine session diff truncation messaging

### DIFF
--- a/frontend/src/app/(dashboard)/sessions/[id]/session-changes-tab.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/session-changes-tab.tsx
@@ -21,7 +21,7 @@ export const ChangesTab = memo(function ChangesTab({
   emptyStatusText,
   isMobile,
   diffLoadErrorText,
-  diffTruncationText,
+  diffTruncationNotice,
   onRetryDiffLoad,
 }: {
   filteredFiles: DiffFile[];
@@ -36,7 +36,7 @@ export const ChangesTab = memo(function ChangesTab({
   emptyStatusText: string;
   isMobile: boolean;
   diffLoadErrorText?: string;
-  diffTruncationText?: string;
+  diffTruncationNotice?: { title: string; text: string };
   onRetryDiffLoad?: () => void;
 }) {
   const hasDiff = filteredFiles.length > 0;
@@ -71,10 +71,10 @@ export const ChangesTab = memo(function ChangesTab({
 
       {hasDiff ? (
         <div className="flex min-h-0 flex-1 flex-col">
-          {diffTruncationText ? (
+          {diffTruncationNotice ? (
             <div className="mx-4 mt-3 rounded-md border border-warning/30 bg-warning/10 px-3 py-2 text-xs text-warning">
-              <p className="font-medium">Large diff truncated</p>
-              <p className="mt-1 text-warning/80">{diffTruncationText}</p>
+              <p className="font-medium">{diffTruncationNotice.title}</p>
+              <p className="mt-1 text-warning/80">{diffTruncationNotice.text}</p>
             </div>
           ) : null}
           <div className="flex-1 overflow-hidden">

--- a/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.performance.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.performance.test.tsx
@@ -546,4 +546,51 @@ describe("SessionDetailContent performance", () => {
     expect(await screen.findByText("Large diff truncated")).toBeInTheDocument();
     expect(screen.getByText(/showing the first/)).toBeInTheDocument();
   });
+
+  it("does not describe raw diff truncation when only diff pass history is capped", async () => {
+    const { SessionDetailContent } = await import("./session-detail-content");
+    const user = userEvent.setup();
+
+    server.use(
+      http.get("/api/v1/sessions/:id", () => {
+        return HttpResponse.json({
+          data: {
+            ...mockSessions[0],
+            primary_issue_id: undefined,
+            sandbox_state: "ready",
+            diff: undefined,
+            diff_stats: { added: 4607, removed: 314, files_changed: 51 },
+          },
+        } satisfies SingleResponse<Session>);
+      }),
+      http.get("/api/v1/sessions/:id/timeline", () => {
+        return HttpResponse.json({ data: [], meta: {} } satisfies ListResponse<SessionTimelineEntry>);
+      }),
+      http.get("/api/v1/sessions/:id/diff", () => {
+        return HttpResponse.json({
+          data: {
+            session_id: "session-abcdef12-3456-7890",
+            diff: "diff --git a/main.go b/main.go\n--- a/main.go\n+++ b/main.go\n@@ -1 +1 @@\n-old\n+new\n",
+            diff_stats: { added: 4607, removed: 314, files_changed: 51 },
+            diff_history: [],
+            diff_truncated: false,
+            diff_history_truncated: true,
+            diff_chars: 259664,
+            diff_history_bytes: 4194304,
+            diff_max_chars: 2097152,
+            diff_history_max_bytes: 2097152,
+          },
+        } satisfies SingleResponse<import("@/lib/types").SessionDiff>);
+      }),
+    );
+
+    renderWithProviders(<SessionDetailContent id="session-abcdef12-3456-7890" />);
+
+    await screen.findByPlaceholderText("Send a follow-up message...");
+    await user.click(screen.getByRole("tab", { name: /Changes/i }));
+
+    expect(await screen.findByText("Large diff truncated")).toBeInTheDocument();
+    expect(screen.getByText("Diff pass history is too large to load for this view, so only the current diff is shown.")).toBeInTheDocument();
+    expect(screen.queryByText(/showing the first 2,097,152 of 259,664 characters/)).not.toBeInTheDocument();
+  });
 });

--- a/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.performance.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.performance.test.tsx
@@ -589,8 +589,9 @@ describe("SessionDetailContent performance", () => {
     await screen.findByPlaceholderText("Send a follow-up message...");
     await user.click(screen.getByRole("tab", { name: /Changes/i }));
 
-    expect(await screen.findByText("Large diff truncated")).toBeInTheDocument();
+    expect(await screen.findByText("Diff pass history truncated")).toBeInTheDocument();
     expect(screen.getByText("Diff pass history is too large to load for this view, so only the current diff is shown.")).toBeInTheDocument();
+    expect(screen.queryByText("Large diff truncated")).not.toBeInTheDocument();
     expect(screen.queryByText(/showing the first 2,097,152 of 259,664 characters/)).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
@@ -4445,12 +4445,23 @@ export function SessionDetailContent({ id }: { id: string }) {
     : undefined;
   const diffTruncationText = useMemo(() => {
     if (!sessionDiffPayload?.diff_truncated && !sessionDiffPayload?.diff_history_truncated) return undefined;
-    const originalChars = sessionDiffPayload.diff_chars?.toLocaleString();
-    const maxChars = sessionDiffPayload.diff_max_chars?.toLocaleString();
-    if (originalChars && maxChars) {
-      return `This diff is very large, so the viewer is showing the first ${maxChars} of ${originalChars} characters. Diff pass history may be omitted.`;
+    if (sessionDiffPayload.diff_truncated) {
+      const originalCharCount = sessionDiffPayload.diff_chars;
+      const maxCharCount = sessionDiffPayload.diff_max_chars;
+      const historyText = sessionDiffPayload.diff_history_truncated ? " Diff pass history may be omitted." : "";
+      if (
+        typeof originalCharCount === "number"
+        && typeof maxCharCount === "number"
+        && originalCharCount > maxCharCount
+      ) {
+        return `This diff is very large, so the viewer is showing the first ${maxCharCount.toLocaleString()} of ${originalCharCount.toLocaleString()} characters.${historyText}`;
+      }
+      return `This diff is very large, so the viewer is showing a bounded preview.${historyText}`;
     }
-    return "This diff is very large, so the viewer is showing a bounded preview. Diff pass history may be omitted.";
+    if (sessionDiffPayload.diff_history_truncated) {
+      return "Diff pass history is too large to load for this view, so only the current diff is shown.";
+    }
+    return undefined;
   }, [sessionDiffPayload?.diff_chars, sessionDiffPayload?.diff_history_truncated, sessionDiffPayload?.diff_max_chars, sessionDiffPayload?.diff_truncated]);
 
   // --- Shared review state (lifted from old ChangesTab) ---

--- a/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
@@ -4443,7 +4443,7 @@ export function SessionDetailContent({ id }: { id: string }) {
       ? diffError.message
       : "Changes could not be loaded. Retry to fetch the diff again."
     : undefined;
-  const diffTruncationText = useMemo(() => {
+  const diffTruncationNotice = useMemo(() => {
     if (!sessionDiffPayload?.diff_truncated && !sessionDiffPayload?.diff_history_truncated) return undefined;
     if (sessionDiffPayload.diff_truncated) {
       const originalCharCount = sessionDiffPayload.diff_chars;
@@ -4454,12 +4454,21 @@ export function SessionDetailContent({ id }: { id: string }) {
         && typeof maxCharCount === "number"
         && originalCharCount > maxCharCount
       ) {
-        return `This diff is very large, so the viewer is showing the first ${maxCharCount.toLocaleString()} of ${originalCharCount.toLocaleString()} characters.${historyText}`;
+        return {
+          title: "Large diff truncated",
+          text: `This diff is very large, so the viewer is showing the first ${maxCharCount.toLocaleString()} of ${originalCharCount.toLocaleString()} characters.${historyText}`,
+        };
       }
-      return `This diff is very large, so the viewer is showing a bounded preview.${historyText}`;
+      return {
+        title: "Large diff truncated",
+        text: `This diff is very large, so the viewer is showing a bounded preview.${historyText}`,
+      };
     }
     if (sessionDiffPayload.diff_history_truncated) {
-      return "Diff pass history is too large to load for this view, so only the current diff is shown.";
+      return {
+        title: "Diff pass history truncated",
+        text: "Diff pass history is too large to load for this view, so only the current diff is shown.",
+      };
     }
     return undefined;
   }, [sessionDiffPayload?.diff_chars, sessionDiffPayload?.diff_history_truncated, sessionDiffPayload?.diff_max_chars, sessionDiffPayload?.diff_truncated]);
@@ -5718,7 +5727,7 @@ export function SessionDetailContent({ id }: { id: string }) {
           }
           isMobile={isMobileReviewViewport}
           diffLoadErrorText={diffLoadErrorText}
-          diffTruncationText={diffTruncationText}
+          diffTruncationNotice={diffTruncationNotice}
           onRetryDiffLoad={retryDiffLoad}
         />
       </TabsContent>


### PR DESCRIPTION
## Summary
- Distinguish between raw diff truncation and capped diff pass history in session detail messaging
- Keep the detailed character-count message for genuinely truncated diffs
- Add UI coverage for the history-only capped case

## Testing
- Added a React performance test covering the diff-history-capped scenario
- Verified the existing truncation message still appears for large diffs