### PR TITLE
Constrain attached review comment chip text to prevent mobile composer overflow

### DIFF
--- a/frontend/src/app/(dashboard)/sessions/[id]/page-composer.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/page-composer.test.tsx
@@ -4,7 +4,7 @@ import { fireEvent, renderWithProviders, screen, userEvent, waitFor, within } fr
 import { server } from '@/test/mocks/server';
 import { mockSessions, mockMembers } from '@/test/mocks/handlers';
 import { SessionDetailContent } from './session-detail-content';
-import type { Session, SessionMessage, SessionThread, User, SingleResponse, ListResponse } from '@/lib/types';
+import type { Session, SessionMessage, SessionReviewComment, SessionThread, User, SingleResponse, ListResponse } from '@/lib/types';
 import { installSessionDetailPageTestHooks, setMobileViewport, changeFieldValue } from './session-detail-test-kit';
 
 const { toast } = vi.hoisted(() => ({
@@ -165,6 +165,53 @@ describe('SessionDetailPage composer and session metadata', () => {
     await waitFor(() => {
       expect(textarea).toHaveAttribute('data-mobile-composer-state', 'collapsed');
     });
+  });
+
+  it('constrains attached review comment chips inside the mobile composer', async () => {
+    const idleSession: Session = {
+      ...mockSessions[0],
+      status: 'idle',
+      completed_at: undefined,
+      current_turn: 1,
+      sandbox_state: 'snapshotted',
+    };
+    const comment: SessionReviewComment = {
+      id: 'comment-long-file',
+      session_id: idleSession.id,
+      org_id: 'org-1',
+      user_id: mockMembers[0].id,
+      file_path: 'docs/design/implemented/107-pagerduty-integration-with-a-very-long-file-name-that-used-to-overflow.md',
+      line_number: 776,
+      diff_side: 'new',
+      body: 'Let\'s make an oauth integration with enough text to require truncation in the attached comment chip.',
+      resolved: false,
+      pass_number: 1,
+      created_at: '2026-02-17T07:10:00Z',
+      updated_at: '2026-02-17T07:10:00Z',
+    };
+
+    setMobileViewport(true);
+    server.use(
+      http.get('/api/v1/sessions/:id', () => {
+        return HttpResponse.json({ data: idleSession } satisfies SingleResponse<Session>);
+      }),
+      http.get('/api/v1/sessions/:id/review-comments', () => {
+        return HttpResponse.json({ data: [comment], meta: {} } satisfies ListResponse<SessionReviewComment>);
+      }),
+    );
+
+    renderWithProviders(<SessionDetailContent id="session-mobile-attached-comment-chip" />);
+
+    const filename = await screen.findByText('107-pagerduty-integration-with-a-very-long-file-name-that-used-to-overflow.md:776');
+    const chip = filename.closest('div');
+    expect(chip).not.toBeNull();
+    const commentPreview = within(chip as HTMLElement).getByText((content) => (
+      content.startsWith('Let\'s make an oauth integration') && content.endsWith('...')
+    ));
+
+    expect(chip).toHaveClass('max-w-full', 'min-w-0');
+    expect(filename).toHaveClass('min-w-0', 'truncate');
+    expect(commentPreview).toHaveClass('min-w-0', 'truncate');
   });
 
   it('autofocuses the follow-up textarea on desktop session detail pages', async () => {

--- a/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
@@ -1555,20 +1555,20 @@ function SessionComposer({
           )}
         >
           {openComments.length > 0 && (
-            <div className="flex flex-wrap gap-1.5 px-3 pt-2.5 pb-1">
+            <div className="flex min-w-0 flex-wrap gap-1.5 px-3 pt-2.5 pb-1">
               {openComments.map((c) => {
                 const fileName = c.file_path.split("/").pop() ?? c.file_path;
                 return (
                   <div
                     key={c.id}
-                    className="inline-flex items-center gap-1.5 rounded-md border border-border bg-background px-2 py-1 text-xs"
+                    className="inline-flex max-w-full min-w-0 items-center gap-1.5 rounded-md border border-border bg-background px-2 py-1 text-xs"
                   >
                     <MessageSquare className="h-3 w-3 text-muted-foreground shrink-0" />
-                    <span className="font-mono text-muted-foreground">
+                    <span className="min-w-0 truncate font-mono text-muted-foreground">
                       {fileName}:{c.line_number}
                     </span>
                     <span className="text-muted-foreground/40">-</span>
-                    <span className="truncate max-w-[200px]">
+                    <span className="min-w-0 max-w-[200px] truncate">
                       {c.body.length > 60 ? `${c.body.slice(0, 60)}...` : c.body}
                     </span>
                   </div>


### PR DESCRIPTION
## Summary

Mobile users could see attached review comment chips overflow the composer due to flex intrinsic sizing with long monospace filename/comment text. This patch adds the missing width/min-width and truncation constraints so the chip content shrinks within the composer boundary.

## Changes

- Updated the attached review comment chip container to use `min-w-0` so flex layout can correctly shrink on small screens.
- Added truncation constraints on the filename/comment preview spans (and ensured the chip container has `max-w-full min-w-0`) to prevent horizontal overflow.
- Extended `page-composer.test.tsx` with a mobile regression test asserting the presence of the truncation/shrink classes for long filename + comment text.

## Validation

- `npm run test:ci -- page-composer.test.tsx`
- `npm run typecheck`
- `npm run lint`
- `npm run build`

[143.dev](https://143.dev) | [session 68bbb0f5](https://143.dev/sessions/68bbb0f5-cdea-47d5-86f8-522b457e4311)

Preview: https://143.dev/previews/github/assembledhq/143/pull/1489?launch=1