### PR TITLE
Fix mobile diff layout shift by containing horizontal overflow within the diff pane

### DIFF
--- a/frontend/src/components/code-review/diff-pane.test.tsx
+++ b/frontend/src/components/code-review/diff-pane.test.tsx
@@ -69,6 +69,13 @@ describe("DiffPane", () => {
     expect(scrollContainer).not.toHaveClass("p-3");
   });
 
+  it("prevents horizontal diff overflow from propagating outside the pane", () => {
+    const { container } = render(<DiffPane files={[makeDiffFile("src/a.ts")]} viewMode="unified" />);
+    const scrollContainer = container.firstElementChild;
+
+    expect(scrollContainer).toHaveClass("min-w-0", "max-w-full", "overflow-x-hidden");
+  });
+
   it("renders a single file", () => {
     render(<DiffPane files={[makeDiffFile("index.ts")]} viewMode="split" />);
     expect(screen.getByTestId("file-index.ts")).toBeInTheDocument();

--- a/frontend/src/components/code-review/diff-pane.tsx
+++ b/frontend/src/components/code-review/diff-pane.tsx
@@ -221,7 +221,7 @@ export const DiffPane = forwardRef<DiffPaneHandle, DiffPaneProps>(
         key={resetScrollKey ?? "all-files"}
         ref={containerRef}
         onScroll={handleScroll}
-        className="flex-1 overflow-y-auto px-3 pb-3 pt-0 space-y-3 md:px-4 md:pb-4 md:pt-0 md:space-y-4"
+        className="flex-1 min-w-0 max-w-full overflow-y-auto overflow-x-hidden px-3 pb-3 pt-0 space-y-3 md:px-4 md:pb-4 md:pt-0 md:space-y-4"
       >
         {files.map((file, i) => (
           <FileDiffSection

--- a/frontend/src/components/code-review/file-diff-section.test.tsx
+++ b/frontend/src/components/code-review/file-diff-section.test.tsx
@@ -178,6 +178,16 @@ describe("FileDiffSection", () => {
     expect(container.querySelector(".overflow-x-auto")).toHaveClass("[container-type:inline-size]");
   });
 
+  it("contains wide diff content inside the file section instead of widening the page", () => {
+    const { container } = render(<FileDiffSection file={makeDiffFile()} viewMode="unified" />);
+    const section = container.firstElementChild;
+    const horizontalViewport = container.querySelector(".overflow-x-auto");
+
+    expect(section).toHaveClass("min-w-0", "max-w-full");
+    expect(section).not.toHaveClass("overflow-hidden");
+    expect(horizontalViewport).toHaveClass("min-w-0", "max-w-full", "overscroll-x-contain");
+  });
+
   it("renders line content in unified mode", () => {
     render(<FileDiffSection file={makeDiffFile()} viewMode="unified" />);
     expect(screen.getByText(/line 1\|old:1\|new:1/)).toBeInTheDocument();

--- a/frontend/src/components/code-review/file-diff-section.tsx
+++ b/frontend/src/components/code-review/file-diff-section.tsx
@@ -467,58 +467,58 @@ export const FileDiffSection = forwardRef<HTMLDivElement, FileDiffSectionProps>(
     }, [highlighted, visibleHunkSections]);
 
     return (
-      <div ref={ref} className="border border-border rounded-lg">
+      <div ref={ref} className="min-w-0 max-w-full rounded-lg border border-border">
         <FileDiffHeader
           filePath={file.newPath}
           added={file.stats.added}
           removed={file.stats.removed}
           onBrowseFile={onBrowseFile}
         />
-        <div className="overflow-x-auto [container-type:inline-size]">
-        <div className="min-w-fit">
-        {visibleSections.map((section) => {
-          if (section.type === "gap") {
-            return renderGap(section.gap);
-          }
+        <div className="min-w-0 max-w-full overflow-x-auto overscroll-x-contain [container-type:inline-size]">
+          <div className="min-w-fit">
+            {visibleSections.map((section) => {
+              if (section.type === "gap") {
+                return renderGap(section.gap);
+              }
 
-          const hunkEl =
-            viewMode === "split" ? (
-              <SplitDiffHunk
-                key={section.index}
-                hunk={section.hunk}
-                highlightedLines={hunkHighlightMaps?.get(section.index)}
-                {...commonHunkProps}
-              />
-            ) : (
-              <DiffHunk
-                key={section.index}
-                hunk={section.hunk}
-                highlightedLines={hunkHighlightMaps?.get(section.index)}
-                {...commonHunkProps}
-              />
-            );
-          return <div key={section.index}>{hunkEl}</div>;
-        })}
-        {hasMoreDiffLines ? (
-          <div className="sticky bottom-0 border-t border-border bg-background/95 px-3 py-3 text-center backdrop-blur">
-            <p className="mb-2 text-xs text-muted-foreground">
-              Showing first {renderedLineCount} of {totalRenderableLines} diff lines in this file
-            </p>
-            <Button
-              type="button"
-              variant="outline"
-              size="sm"
-              className="text-xs"
-              onClick={() => setVisibleLineState((state) => ({
-                file,
-                count: state.count + RENDERED_DIFF_LINE_INCREMENT,
-              }))}
-            >
-              Show more diff lines
-            </Button>
+              const hunkEl =
+                viewMode === "split" ? (
+                  <SplitDiffHunk
+                    key={section.index}
+                    hunk={section.hunk}
+                    highlightedLines={hunkHighlightMaps?.get(section.index)}
+                    {...commonHunkProps}
+                  />
+                ) : (
+                  <DiffHunk
+                    key={section.index}
+                    hunk={section.hunk}
+                    highlightedLines={hunkHighlightMaps?.get(section.index)}
+                    {...commonHunkProps}
+                  />
+                );
+              return <div key={section.index}>{hunkEl}</div>;
+            })}
+            {hasMoreDiffLines ? (
+              <div className="sticky bottom-0 border-t border-border bg-background/95 px-3 py-3 text-center backdrop-blur">
+                <p className="mb-2 text-xs text-muted-foreground">
+                  Showing first {renderedLineCount} of {totalRenderableLines} diff lines in this file
+                </p>
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  className="text-xs"
+                  onClick={() => setVisibleLineState((state) => ({
+                    file,
+                    count: state.count + RENDERED_DIFF_LINE_INCREMENT,
+                  }))}
+                >
+                  Show more diff lines
+                </Button>
+              </div>
+            ) : null}
           </div>
-        ) : null}
-        </div>
         </div>
       </div>
     );

--- a/frontend/src/components/code-review/review-diff-view.test.tsx
+++ b/frontend/src/components/code-review/review-diff-view.test.tsx
@@ -140,7 +140,8 @@ describe("ReviewDiffView", () => {
   });
 
   it("renders DiffToolbar, DiffPane, and KeyboardHelpOverlay when files exist", () => {
-    render(<ReviewDiffView {...defaultProps()} />);
+    const { container } = render(<ReviewDiffView {...defaultProps()} />);
+    expect(container.firstElementChild).toHaveClass("min-w-0", "max-w-full", "overflow-hidden");
     expect(screen.getByTestId("diff-toolbar")).toBeInTheDocument();
     expect(screen.getByTestId("diff-pane")).toBeInTheDocument();
     expect(screen.getByTestId("keyboard-help")).toBeInTheDocument();

--- a/frontend/src/components/code-review/review-diff-view.tsx
+++ b/frontend/src/components/code-review/review-diff-view.tsx
@@ -299,7 +299,7 @@ export const ReviewDiffView = memo(function ReviewDiffView({
   // Explorer mode takes over
   if (explorerMode) {
     return (
-      <div className="flex flex-col h-full">
+      <div className="flex h-full min-w-0 max-w-full flex-col overflow-hidden">
         <RepoExplorer
           sessionId={sessionId}
           diffFiles={allFiles}
@@ -312,7 +312,7 @@ export const ReviewDiffView = memo(function ReviewDiffView({
 
   if (files.length === 0) {
     return (
-      <div className="flex flex-col h-full">
+      <div className="flex h-full min-w-0 max-w-full flex-col overflow-hidden">
         <DiffToolbar
           onBack={onBack}
           viewMode={effectiveViewMode}
@@ -338,7 +338,7 @@ export const ReviewDiffView = memo(function ReviewDiffView({
   }
 
   return (
-      <div className="flex flex-col h-full">
+    <div className="flex h-full min-w-0 max-w-full flex-col overflow-hidden">
       <DiffToolbar
         onBack={onBack}
         viewMode={effectiveViewMode}


### PR DESCRIPTION
## Summary

Mobile code review diff pages were prone to layout shift/jitter when horizontally scrollable diff content overflowed and affected the overall page width. This change tightens CSS containment so wide diff lines stay within the diff pane/file section boundaries, preventing overflow from propagating outward.

## Changes

- Updated `DiffPane` to add `min-w-0`, `max-w-full`, and `overflow-x-hidden` on the scroll container so horizontal overflow can’t affect the page layout.
- Updated `FileDiffSection` root to include `min-w-0 max-w-full` and removed `overflow-hidden` from the file section root so `FileDiffHeader` can remain sticky within the correct scroll container.
- Adjusted horizontal diff viewport containment via class additions (e.g., `overflow-x-auto` with sizing/containment) to keep wide content constrained.

## Validation

- Added component class-contract tests:
  - `diff-pane.test.tsx`: asserts the pane scroll container prevents horizontal overflow propagation.
  - `file-diff-section.test.tsx`: asserts wide diff content stays inside the file section and avoids widening the page.
- Existing test suite coverage for render modes and scroll behavior remains in place.

[143.dev](https://143.dev) | [session 0b59808e](https://143.dev/sessions/0b59808e-ae6e-4527-838f-9a45a84e18ca)

Preview: https://143.dev/previews/github/assembledhq/143/pull/1490?launch=1