### PR TITLE
Reconcile Caddy on app compose service changes and polish CLI install link UI

### DIFF
--- a/deploy/deploy_config_test.go
+++ b/deploy/deploy_config_test.go
@@ -233,6 +233,23 @@ func TestRoutineAppDeployLeavesUnchangedCaddyRunning(t *testing.T) {
     docker compose -f "$COMPOSE_FILE" build caddy`, "app deploys should not unconditionally rebuild Caddy because compose may recreate the Cloudflare-facing origin")
 }
 
+func TestAppDeployReconcilesCaddyWhenServiceConfigChanges(t *testing.T) {
+	t.Parallel()
+
+	deployScript, err := os.ReadFile("../deploy/scripts/deploy.sh")
+	require.NoError(t, err, "test should read deploy.sh")
+	deployText := string(deployScript)
+
+	require.Contains(t, deployText, "caddy_service_config_fingerprint", "app deploy should fingerprint the caddy compose service block")
+	require.Contains(t, deployText, "compose_service_fingerprint /opt/143/docker-compose.app.yml caddy", "caddy service fingerprint should use the app compose caddy service block")
+	require.Contains(t, deployText, "caddy_service_config_changed", "caddy reconcile should track compose service config drift separately")
+	require.Contains(t, deployText, `|| [ "$caddy_service_config_changed" -eq 1 ]`, "caddy reconcile should recreate the service when compose wiring changes")
+
+	changedFn := extractShellFunction(t, deployText, "caddy_service_config_changed", "commit_caddy_service_config_fingerprint")
+	require.Contains(t, changedFn, `[ ! -f "$fp_file" ]`, "first deploy with service fingerprinting should reconcile Caddy once")
+	require.Contains(t, changedFn, `printf '%s\n' "$next" > "$fp_file.new"`, "service fingerprint should only be staged until Caddy reconciliation succeeds")
+}
+
 func TestWorkerProvisioningIncludesGitHubAppUserAuthSecrets(t *testing.T) {
 	t.Parallel()
 

--- a/deploy/scripts/deploy.sh
+++ b/deploy/scripts/deploy.sh
@@ -508,7 +508,7 @@ fi
 # Sync compose file so the remote always runs the latest version. Worker
 # compose can include support-service changes, so stage it until the routine
 # worker fingerprint gate allows promotion.
-if [ "$ROLE" = "worker" ]; then
+if [ "$ROLE" = "app" ] || [ "$ROLE" = "worker" ]; then
   scp "${SCP_OPTS[@]}" "$PROJECT_DIR/$COMPOSE_FILE" deploy@"$HOST":/opt/143/"$COMPOSE_FILE".new
 else
   scp "${SCP_OPTS[@]}" "$PROJECT_DIR/$COMPOSE_FILE" deploy@"$HOST":/opt/143/
@@ -860,7 +860,7 @@ ssh "${SSH_OPTS[@]}" deploy@"$HOST" \
   # Clean up staged Caddy inputs on any exit path.
   # stage_caddy_*_if_changed normally consumes them (mv or rm), but this
   # guards against a failure between the scp and that call leaving it on disk.
-  trap 'rm -f /opt/143/deploy/Caddyfile.new /opt/143/Dockerfile.caddy.new /opt/143/.caddy-env.fingerprint.new' EXIT
+  trap 'rm -f /opt/143/deploy/Caddyfile.new /opt/143/Dockerfile.caddy.new /opt/143/.caddy-env.fingerprint.new /opt/143/.caddy-service.fingerprint.new' EXIT
 
   # recreate_other_services SKIP_SVCS — force-recreate every compose service
   # except the space-separated list in SKIP_SVCS. Used to update out-of-band
@@ -921,6 +921,13 @@ ssh "${SSH_OPTS[@]}" deploy@"$HOST" \
     fi
     rm -f "$new_file"
     return 1
+  }
+
+  promote_staged_app_compose() {
+    local new_file="/opt/143/$COMPOSE_FILE.new"
+    local cur_file="/opt/143/$COMPOSE_FILE"
+    [ -f "$new_file" ] || return 0
+    mv "$new_file" "$cur_file"
   }
 
   caddy_env_from_env_file() {
@@ -991,6 +998,40 @@ ssh "${SSH_OPTS[@]}" deploy@"$HOST" \
     fi
   }
 
+  caddy_service_config_fingerprint() {
+    compose_service_fingerprint /opt/143/docker-compose.app.yml caddy
+  }
+
+  caddy_active_service_config_fingerprint() {
+    compose_service_active_fingerprint /opt/143/docker-compose.app.yml caddy
+  }
+
+  caddy_service_config_changed() {
+    local fp_file="/opt/143/.caddy-service.fingerprint"
+    local next current
+    next="$(caddy_service_config_fingerprint)"
+
+    if [ ! -f "$fp_file" ]; then
+      printf '%s\n' "$next" > "$fp_file.new"
+      return 0
+    fi
+    current="$(cat "$fp_file")"
+
+    if [ "$current" != "$next" ]; then
+      printf '%s\n' "$next" > "$fp_file.new"
+      return 0
+    fi
+    rm -f "$fp_file.new"
+    return 1
+  }
+
+  commit_caddy_service_config_fingerprint() {
+    local fp_file="/opt/143/.caddy-service.fingerprint"
+    if [ -f "$fp_file.new" ]; then
+      mv "$fp_file.new" "$fp_file"
+    fi
+  }
+
   # reconcile_caddy_service — applies app-edge Caddy changes with the least
   # disruptive path available:
   #   1. Leave Caddy untouched for routine code-only deploys.
@@ -1004,14 +1045,14 @@ ssh "${SSH_OPTS[@]}" deploy@"$HOST" \
       caddy_config_changed=1
     fi
 
-    local old_caddy_id new_caddy_id caddy_env_changed=0 caddy_dockerfile_changed="${CADDY_DOCKERFILE_CHANGED:-0}"
+    local old_caddy_id new_caddy_id caddy_env_changed=0 caddy_dockerfile_changed="${CADDY_DOCKERFILE_CHANGED:-0}" caddy_service_config_changed="${CADDY_SERVICE_CONFIG_CHANGED:-0}"
     old_caddy_id="$(docker compose -f "$COMPOSE_FILE" ps -q caddy | head -1 || true)"
 
     if caddy_env_fingerprint_changed "$old_caddy_id"; then
       caddy_env_changed=1
     fi
 
-    if [ -z "$old_caddy_id" ] || [ "$caddy_dockerfile_changed" -eq 1 ] || [ "$caddy_env_changed" -eq 1 ]; then
+    if [ -z "$old_caddy_id" ] || [ "$caddy_dockerfile_changed" -eq 1 ] || [ "$caddy_env_changed" -eq 1 ] || [ "$caddy_service_config_changed" -eq 1 ]; then
       echo "Reconciling Caddy service..."
       docker compose -f "$COMPOSE_FILE" up -d --no-deps caddy
 
@@ -1022,6 +1063,7 @@ ssh "${SSH_OPTS[@]}" deploy@"$HOST" \
       fi
 
       commit_caddy_env_fingerprint
+      commit_caddy_service_config_fingerprint
 
       if [ -z "$old_caddy_id" ]; then
         echo "Caddy started successfully."
@@ -1512,6 +1554,33 @@ ssh "${SSH_OPTS[@]}" deploy@"$HOST" \
   }
 
   compose_service_fingerprint() {
+    local compose_file="$1"
+    shift
+    local read_file="$compose_file"
+    if [ -e "${compose_file}.new" ]; then
+      read_file="${compose_file}.new"
+    fi
+    if [ ! -e "$read_file" ]; then
+      printf 'missing:%s\n' "$compose_file" | sha256sum | awk '{print $1}'
+      return 0
+    fi
+    {
+      local svc
+      for svc in "$@"; do
+        printf -- '--- %s:%s ---\n' "$compose_file" "$svc"
+        awk -v svc="$svc" '
+          /^  [A-Za-z0-9_.-]+:/ {
+            current=$1
+            sub(/:$/, "", current)
+            in_service=(current == svc)
+          }
+          in_service { print }
+        ' "$read_file"
+      done
+    } | sha256sum | awk '{print $1}'
+  }
+
+  compose_service_active_fingerprint() {
     local compose_file="$1"
     shift
     if [ ! -e "$compose_file" ]; then
@@ -2040,6 +2109,14 @@ ssh "${SSH_OPTS[@]}" deploy@"$HOST" \
   # --ignore-buildable: skip services whose image is built locally (sandbox-dns
   # has both build: and image: 143-sandbox-dns:local in docker-compose.worker.yml,
   # which pull would otherwise treat as a registry reference and fail on).
+  if [ "$ROLE" = "app" ]; then
+    CADDY_SERVICE_CONFIG_CHANGED=0
+    if caddy_service_config_changed; then
+      CADDY_SERVICE_CONFIG_CHANGED=1
+    fi
+    promote_staged_app_compose
+  fi
+
   docker compose -f "$COMPOSE_FILE" pull --ignore-buildable
 
   # The sandbox image is referenced via SANDBOX_IMAGE env var, not as a compose

--- a/frontend/src/components/cli-join-tokens-card.test.tsx
+++ b/frontend/src/components/cli-join-tokens-card.test.tsx
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { http, HttpResponse } from "msw";
-import { renderWithProviders, screen } from "@/test/test-utils";
+import { renderWithProviders, screen, userEvent, waitFor } from "@/test/test-utils";
 import { server } from "@/test/mocks/server";
 import { CLIJoinTokensCard } from "./cli-join-tokens-card";
 
@@ -26,5 +26,53 @@ describe("CLIJoinTokensCard", () => {
     expect(await screen.findByLabelText("Link name")).toHaveClass("h-9");
     expect(screen.getByRole("combobox", { name: "Role granted" })).toHaveClass("h-9");
     expect(screen.getByRole("button", { name: "Create link" })).toHaveClass("h-9");
+  });
+
+  it("labels the member role as Engineer in the create-link role picker", async () => {
+    server.use(
+      http.get("/api/v1/org/join-tokens", () => HttpResponse.json({ data: [], meta: {} })),
+    );
+
+    renderWithProviders(<CLIJoinTokensCard />);
+
+    await userEvent.click(await screen.findByRole("combobox", { name: "Role granted" }));
+
+    expect(await screen.findByRole("option", { name: "Engineer" })).toBeInTheDocument();
+    expect(screen.queryByRole("option", { name: "Member" })).not.toBeInTheDocument();
+  });
+
+  it("keeps the created install command inside the dialog bounds", async () => {
+    const longInstallCommand =
+      "curl -fsSL https://143.dev/install/143j_Ab3x9kQ2mP4rY7tN2qV6w | sh";
+    server.use(
+      http.get("/api/v1/org/join-tokens", () => HttpResponse.json({ data: [], meta: {} })),
+      http.post("/api/v1/org/join-tokens", () =>
+        HttpResponse.json(
+          {
+            data: {
+              id: "join-token-1",
+              token: "143j_Ab3x9kQ2mP4rY7tN2qV6w",
+              token_prefix: "143j_jD74XFT",
+              role: "member",
+              name: "",
+              install_command: longInstallCommand,
+            },
+          },
+          { status: 201 },
+        ),
+      ),
+    );
+
+    renderWithProviders(<CLIJoinTokensCard />);
+    await userEvent.click(await screen.findByRole("button", { name: "Create link" }));
+
+    const dialog = await screen.findByRole("alertdialog", { name: "Install link created" });
+    const command = await screen.findByText(longInstallCommand);
+
+    await waitFor(() => {
+      expect(dialog).toHaveClass("max-w-[calc(100vw-2rem)]");
+      expect(command.parentElement).toHaveClass("min-w-0");
+      expect(command).toHaveClass("break-all");
+    });
   });
 });

--- a/frontend/src/components/cli-join-tokens-card.tsx
+++ b/frontend/src/components/cli-join-tokens-card.tsx
@@ -127,9 +127,9 @@ export function CLIJoinTokensCard() {
                   <SelectValue />
                 </SelectTrigger>
                 <SelectContent>
-                  <SelectItem value="member">Member</SelectItem>
-                  <SelectItem value="builder">Builder</SelectItem>
-                  <SelectItem value="viewer">Viewer</SelectItem>
+                  <SelectItem value="member">{roleLabel("member")}</SelectItem>
+                  <SelectItem value="builder">{roleLabel("builder")}</SelectItem>
+                  <SelectItem value="viewer">{roleLabel("viewer")}</SelectItem>
                 </SelectContent>
               </Select>
             </div>
@@ -182,7 +182,7 @@ export function CLIJoinTokensCard() {
       </Card>
 
       <AlertDialog open={created !== null} onOpenChange={(open) => !open && setCreated(null)}>
-        <AlertDialogContent>
+        <AlertDialogContent className="max-w-[calc(100vw-2rem)] sm:max-w-xl">
           <AlertDialogHeader>
             <AlertDialogTitle>Install link created</AlertDialogTitle>
             <AlertDialogDescription>
@@ -191,11 +191,19 @@ export function CLIJoinTokensCard() {
               prefix remains visible.
             </AlertDialogDescription>
           </AlertDialogHeader>
-          <div className="flex items-center gap-2">
-            <code className="block flex-1 overflow-x-auto whitespace-nowrap rounded-md bg-muted px-3 py-2 text-xs">
-              {created?.install_command}
-            </code>
-            <Button variant="outline" size="sm" onClick={copyInstallCommand}>
+          <div className="flex min-w-0 items-start gap-2">
+            <div className="min-w-0 flex-1 rounded-md bg-muted px-3 py-2">
+              <code className="block break-all font-mono text-xs leading-relaxed">
+                {created?.install_command}
+              </code>
+            </div>
+            <Button
+              aria-label="Copy install command"
+              variant="outline"
+              size="icon"
+              className="size-9 shrink-0"
+              onClick={copyInstallCommand}
+            >
               {copied ? <Check className="size-3.5" /> : <Copy className="size-3.5" />}
             </Button>
           </div>


### PR DESCRIPTION
## Summary
- Reconcile Caddy when the app compose service block changes by tracking a dedicated service fingerprint and promoting the staged app compose file before pull.
- Expand deploy script cleanup and reconciliation flow so Caddy restarts when its compose wiring drifts, not just when image/env inputs change.
- Improve the CLI join token dialog by localizing the role label text, tightening the dialog width, and wrapping long install commands without horizontal overflow.

## Testing
- Added deploy script coverage for app compose service fingerprinting and Caddy reconciliation behavior.
- Added frontend component coverage for the updated role label and dialog layout constraints.
- Frontend validation not run (not requested).