### PR TITLE
Handle PR preview starts when no target exists

### DIFF
--- a/frontend/src/app/(dashboard)/previews/github/[owner]/[repo]/pull/[number]/page.test.tsx
+++ b/frontend/src/app/(dashboard)/previews/github/[owner]/[repo]/pull/[number]/page.test.tsx
@@ -424,6 +424,79 @@ describe("PullRequestPreviewPage", () => {
     });
   });
 
+  it("starts a PR preview without an existing target by resolving with open intent", async () => {
+    const requestedIntents: Array<string | null> = [];
+    let zeroStartCalled = false;
+    server.use(
+      http.get("*/api/v1/previews/github/acme/web/pull/42", ({ request }) => {
+        const intent = new URL(request.url).searchParams.get("intent");
+        requestedIntents.push(intent);
+        if (intent === "open") {
+          return HttpResponse.json({
+            data: {
+              target_id: "target-new",
+              preview_id: "prev-new",
+              repository_id: "repo-1",
+              repository_full_name: "acme/web",
+              branch: "feature/preview",
+              commit_sha: "def456",
+              latest_commit_sha: "def456",
+              source_type: "pull_request",
+              status: "starting",
+              stable_url: "https://143.dev/previews/github/acme/web/pull/42",
+              pull_request_url: "https://github.com/acme/web/pull/42",
+              launch: {
+                action: "wait",
+                reason: "starting",
+                auto_open: true,
+                represents_latest: true,
+                primary_label: "Opening when ready",
+              },
+            },
+          });
+        }
+        return HttpResponse.json({
+          data: {
+            target_id: "00000000-0000-0000-0000-000000000000",
+            repository_id: "repo-1",
+            repository_full_name: "acme/web",
+            branch: "feature/preview",
+            commit_sha: "def456",
+            latest_commit_sha: "def456",
+            source_type: "pull_request",
+            status: "target_created",
+            stable_url: "https://143.dev/previews/github/acme/web/pull/42",
+            pull_request_url: "https://github.com/acme/web/pull/42",
+            launch: {
+              action: "start",
+              reason: "no_runtime",
+              auto_open: false,
+              represents_latest: true,
+              primary_label: "Start preview",
+            },
+          },
+        });
+      }),
+      http.post("*/api/v1/previews/00000000-0000-0000-0000-000000000000/start-latest", () => {
+        zeroStartCalled = true;
+        return HttpResponse.json(
+          { error: { code: "PREVIEW_NOT_FOUND", message: "preview not found" } },
+          { status: 404 },
+        );
+      }),
+    );
+
+    renderWithProviders(<PullRequestPreviewContent owner="acme" repo="web" number="42" />);
+
+    await userEvent.click(await screen.findByRole("button", { name: /Start preview/ }));
+
+    await waitFor(() => {
+      expect(requestedIntents).toContain("open");
+    });
+    expect(zeroStartCalled).toBe(false);
+    expect(await screen.findByText("Starting preview")).toBeInTheDocument();
+  });
+
   it("renders blocked launch guidance without start actions", async () => {
     server.use(
       http.get("*/api/v1/previews/github/acme/web/pull/42", () =>

--- a/frontend/src/app/(dashboard)/previews/github/[owner]/[repo]/pull/[number]/page.tsx
+++ b/frontend/src/app/(dashboard)/previews/github/[owner]/[repo]/pull/[number]/page.tsx
@@ -18,6 +18,8 @@ import type { BranchPreviewResponse, SingleResponse } from "@/lib/types";
 import { safeExternalUrl } from "@/lib/utils";
 import { pollMs } from "@/lib/poll-intervals";
 
+const ZERO_UUID = "00000000-0000-0000-0000-000000000000";
+
 export default function PullRequestPreviewPage({
   params,
 }: {
@@ -61,6 +63,12 @@ export function PullRequestPreviewContent({
       queryClient.setQueryData(queryKey, response);
     },
   });
+  const startPullRequest = useMutation({
+    mutationFn: () => api.previews.getPullRequest(owner, repo, number, { intent: "open" }),
+    onSuccess: (response) => {
+      queryClient.setQueryData(queryKey, response);
+    },
+  });
   const restart = useMutation({
     mutationFn: (id: string) => api.previews.restart(id),
     onSuccess: (response) => {
@@ -71,25 +79,30 @@ export function PullRequestPreviewContent({
   const preview = previewQuery.data?.data;
   const title = `${owner}/${repo}#${number}`;
   const status = preview?.status ? formatPreviewStatus(preview.status) : "Loading";
-  const canStartLatest = preview?.target_id;
+  const targetId = previewTargetId(preview?.target_id);
   const isExpired = preview?.status === "expired";
   const launch = preview?.launch;
   const launchState = launchStateCopy(preview);
   const launchSessionShouldOpen = launchRequested || launchSessionActive;
   const showStartAction =
-    canStartLatest &&
-    (!launch || launch.action === "start" || launch.action === "start_latest" || launch.action === "resume");
+    launch?.action === "start" ||
+    (Boolean(targetId) && (launch?.action === "start_latest" || launch?.action === "resume"));
   const safePreviewURL = safeExternalUrl(preview?.preview_url);
 
   useEffect(() => {
     if (!preview || !launchSessionShouldOpen || !launch?.auto_open) return;
-    if (startLatest.isPending || restart.isPending) return;
+    if (startLatest.isPending || startPullRequest.isPending || restart.isPending) return;
 
-    if ((launch.action === "start" || launch.action === "start_latest" || launch.action === "resume") && preview.target_id) {
-      const key = `${launch.action}:${preview.target_id}:${preview.latest_commit_sha ?? preview.commit_sha ?? ""}`;
+    if (launch.action === "start" || launch.action === "start_latest" || launch.action === "resume") {
+      const startTargetId = previewTargetId(preview.target_id);
+      const key = `${launch.action}:${startTargetId ?? "pull-request"}:${preview.latest_commit_sha ?? preview.commit_sha ?? ""}`;
       if (autoActionKeyRef.current === key) return;
       autoActionKeyRef.current = key;
-      startLatest.mutate(preview.target_id);
+      if (startTargetId) {
+        startLatest.mutate(startTargetId);
+      } else if (launch.action === "start") {
+        startPullRequest.mutate();
+      }
       return;
     }
 
@@ -106,6 +119,7 @@ export function PullRequestPreviewContent({
     preview,
     restart,
     startLatest,
+    startPullRequest,
   ]);
 
   useEffect(() => {
@@ -132,9 +146,15 @@ export function PullRequestPreviewContent({
   ]);
 
   const handleStartLatest = () => {
-    if (!preview?.target_id) return;
     setLaunchSessionActive(true);
-    startLatest.mutate(preview.target_id);
+    const startTargetId = previewTargetId(preview?.target_id);
+    if (startTargetId) {
+      startLatest.mutate(startTargetId);
+      return;
+    }
+    if (launch?.action === "start") {
+      startPullRequest.mutate();
+    }
   };
 
   const handleRetry = () => {
@@ -298,10 +318,10 @@ export function PullRequestPreviewContent({
                       type="button"
                       variant={launch?.action === "start_latest" || launch?.action === "start" || launch?.action === "resume" ? "default" : "outline"}
                       onClick={handleStartLatest}
-                      disabled={startLatest.isPending}
+                      disabled={startLatest.isPending || startPullRequest.isPending}
                     >
                       <GitBranch className="h-4 w-4" />
-                      {startLatest.isPending ? "Starting..." : launchStartLabel(launch?.action, launch?.primary_label)}
+                      {startLatest.isPending || startPullRequest.isPending ? "Starting..." : launchStartLabel(launch?.action, launch?.primary_label)}
                     </Button>
                   ) : null}
                   {preview.preview_id && launch?.action !== "blocked" && launch?.action !== "closed" ? (
@@ -324,6 +344,11 @@ export function PullRequestPreviewContent({
       </div>
     </PageContainer>
   );
+}
+
+function previewTargetId(id: string | undefined): string | null {
+  if (!id || id === ZERO_UUID) return null;
+  return id;
 }
 
 function launchStartLabel(action: NonNullable<BranchPreviewResponse["launch"]>["action"] | undefined, label?: string): string {


### PR DESCRIPTION
## Summary
- start pull request previews directly with `intent=open` when the preview has no existing target
- treat the zero UUID as missing so launch actions and auto-open flow choose the right start path
- cover the no-target start flow with a UI test

## Testing
- Added UI test coverage for starting a PR preview without an existing target