### PR TITLE
Route preview recovery through the stable launch flow

### DIFF
--- a/docs/design/implemented/100-pr-preview-launch-controller.md
+++ b/docs/design/implemented/100-pr-preview-launch-controller.md
@@ -23,6 +23,7 @@ The answer may be immediate, resumable, starting, failed, stale, or blocked, but
 - `/previews/github/{owner}/{repo}/pull/{number}` is the stable app route for a GitHub PR.
 - `GET /api/v1/previews/github/{owner}/{repo}/pull/{number}` resolves the PR head through GitHub, finds or creates a preview target, starts a runtime when allowed, and reports stale active previews with `new_commits_available`.
 - `OpenPreviewButton` bootstraps access before opening the preview origin. It opens `about:blank` for manual button clicks, loads `<preview-origin>/bootstrap` in a hidden iframe, mints a short-lived token from the app API, posts it to the preview origin, waits for completion, and navigates the popup. Stable PR launch sessions use the same bootstrap flow and then replace the current PR-launch tab with the preview origin.
+- Preview-origin recovery pages for stopped, expired, or disconnected previews hand off through the current tab to the stable app launch route. The app route owns start/restart, progress, diagnostics, bootstrap, and final navigation back to the preview origin.
 - Preview-origin traffic remains isolated from the app origin and is gateway-routed to the worker that owns the runtime.
 
 This is close, but product behavior is still page/button oriented instead of intent oriented. The response does not expose a single launch decision, and the frontend does not have a reusable auto-launch state machine.
@@ -49,6 +50,8 @@ Use the app stable route as the default PR footer link. It is the most reliable 
 
 A preview-origin target URL may remain supported for advanced/direct flows, but it must degrade into the same stable launch controller when the user lacks preview-domain access or no active runtime exists.
 
+When a user lands directly on a stopped, expired, or disconnected preview-origin URL, the gateway should render a lightweight recovery page whose primary action navigates the current tab to the stable app route with `launch=1`. It should not open a secondary app popup; the stable route is responsible for showing startup state and returning the tab to the preview when ready.
+
 ### PR Page Button
 
 In 143 PR surfaces, the primary PR action should be `Preview`.
@@ -73,7 +76,7 @@ Auto-open is allowed only when all are true:
 - The action was initiated by a user gesture on the stable app page or a 143 PR surface.
 - The returned launch decision says the preview represents the latest PR head.
 - The runtime is `ready` or transitions to `ready` during the page's launch session.
-- The launch session came from a stable app route with `launch=1` or from an explicit in-page start/retry action; the PR-launch tab bootstraps access and navigates itself to the preview origin. Manual `Open preview` buttons may still use a popup opened synchronously from the click.
+- The launch session came from a stable app route with `launch=1` or from an explicit in-page start/retry action; the PR-launch tab bootstraps access and navigates itself to the preview origin. Manual in-app `Open preview` buttons may still use a popup opened synchronously from the click so engineers can keep 143 open beside the preview.
 
 Auto-open is not allowed for stale previews, failed previews, permission-blocked previews, or closed PRs.
 
@@ -540,6 +543,7 @@ Behavior:
 
 - On first render from a direct navigation, call `getPullRequest(..., { intent: "open" })`.
 - If user arrived from clicking a 143 `Preview` button, open the stable PR route in a new tab with `launch=1`; that stable page owns bootstrap and replaces its own tab with the preview origin when ready.
+- If user arrived from a preview-origin recovery page, the current tab is already on the stable route with `launch=1`; keep showing launch progress in that tab and replace it with the preview origin when ready.
 - If `launch.action === "open"`, call `launchPreview`.
 - If `launch.action === "wait"` and `launch.auto_open`, poll until `open` or terminal.
 - If `resume/start/start_latest/retry`, show the primary action and optionally execute it immediately only when the original click explicitly requested open.

--- a/docs/design/implemented/44-sandbox-preview-server.md
+++ b/docs/design/implemented/44-sandbox-preview-server.md
@@ -99,6 +99,8 @@ Instead:
 9. The preview gateway proxies HTTP and WebSocket traffic to the owning worker/provider stream.
 10. Idle previews are stopped automatically based on activity-aware timeouts; the browser must request a fresh bootstrap token to resume.
 
+For branch/PR preview links, stopped, expired, or disconnected preview-origin visits render a lightweight recovery page. Its primary action navigates the current tab to the stable app launch route with `launch=1`; the app route starts or reconnects the preview, shows progress or diagnostics, bootstraps preview-domain access, and then returns the current tab to the preview origin. This keeps preview recovery as a one-window flow while preserving origin isolation.
+
 ## Implementation Status (2026-04-22)
 
 The production contract now differs from the original single-node MVP in a few important ways:
@@ -1670,6 +1672,8 @@ The recommended approach uses `postMessage` to keep the token out of URLs entire
 This keeps the token out of browser history, referrer headers, and server access logs. The `postMessage` origin check on both sides prevents cross-origin token interception.
 
 The gateway should reject token exchange requests that do not arrive as same-origin POST requests from the bootstrap page.
+
+Preview-origin recovery pages must not restart or authenticate previews directly. They should link the current tab to the stable app launch route, where the authenticated control plane can perform the start/restart and bootstrap flow.
 
 ### 6. Access Control
 

--- a/internal/api/gateway/preview_gateway.go
+++ b/internal/api/gateway/preview_gateway.go
@@ -932,16 +932,6 @@ a { display: inline-flex; align-items: center; justify-content: center; min-heig
   var descEl = document.getElementById("pv-desc");
   var statusEl = document.getElementById("pv-status");
   var actionEl = document.getElementById("pv-action");
-  var original = {
-    title: titleEl.textContent,
-    desc: descEl.textContent,
-    status: statusEl.textContent,
-    action: actionEl.textContent
-  };
-  var restarting = false;
-  var popup = null;
-  var pollTimer = null;
-  var activeSince = 0;
 
   function setPanel(title, desc, status) {
     titleEl.textContent = title;
@@ -950,98 +940,12 @@ a { display: inline-flex; align-items: center; justify-content: center; min-heig
     document.title = title;
   }
 
-  function stopPolling() {
-    if (pollTimer) {
-      clearInterval(pollTimer);
-      pollTimer = null;
-    }
-  }
-
-  function enableAction() {
-    restarting = false;
-    actionEl.textContent = original.action;
-    actionEl.removeAttribute("aria-disabled");
-  }
-
-  function resetPanel() {
-    stopPolling();
-    enableAction();
-    setPanel(original.title, original.desc, original.status);
-  }
-
-  function fallbackLaunch() {
-    stopPolling();
-    window.location.href = cfg.controlUrl;
-  }
-
-  // The popup posts this once it has connected the browser to the restarted
-  // preview (the session cookie is set at that point). The cookie is scoped
-  // to the host in data.url; when this overlay is on an alias host (runtime
-  // instance ID vs stable target ID) we must navigate there instead of
-  // reloading in place.
-  window.addEventListener("message", function(event) {
-    if (event.origin !== cfg.appOrigin) return;
-    var data = event.data;
-    if (!data || data.type !== "preview_launch_complete") return;
-    stopPolling();
-    statusEl.textContent = "Connected";
-    var dest = null;
-    try { dest = new URL(data.url); } catch (e) {}
-    if (dest && (dest.protocol === "https:" || dest.protocol === "http:") && dest.origin !== window.location.origin) {
-      window.location.href = dest.href;
-      return;
-    }
-    window.location.reload();
-  });
-
-  function poll() {
-    fetch(cfg.statusPath, {cache: "no-store"}).then(function(resp) {
-      return resp.ok ? resp.json() : null;
-    }).then(function(state) {
-      if (!state || !restarting) return;
-      if (state.status === cfg.initialStatus) {
-        // The restart has not been picked up yet. If the popup was closed
-        // without starting anything, put the panel back.
-        if (popup && popup.closed) resetPanel();
-        return;
-      }
-      if (state.status === "failed") {
-        stopPolling();
-        enableAction();
-        setPanel("Preview failed to start", "Check status and logs for details, then try restarting again.", state.label);
-        return;
-      }
-      if (state.active && state.status !== "starting") {
-        // Ready. The popup finishes the browser handshake and notifies us;
-        // if it is gone or stuck, fall back to the full launch flow.
-        if (!activeSince) activeSince = Date.now();
-        if (!popup || popup.closed || Date.now() - activeSince > 15000) {
-          fallbackLaunch();
-          return;
-        }
-        statusEl.textContent = "Connecting this browser…";
-        return;
-      }
-      statusEl.textContent = state.label + "…";
-    }).catch(function() {});
-  }
-
   actionEl.addEventListener("click", function(event) {
     event.preventDefault();
-    if (restarting) return;
-    popup = window.open(cfg.controlUrl + "&popup=1", "143-preview-launch", "popup=yes,width=440,height=400");
-    if (!popup) {
-      // Popup blocked: fall back to the full-page launch flow.
-      window.location.href = cfg.controlUrl;
-      return;
-    }
-    restarting = true;
-    activeSince = 0;
-    setPanel("Restarting preview", "Keep this tab open — the preview opens here when it is ready.", "Restart requested…");
-    actionEl.textContent = "Restarting…";
+    setPanel("Opening preview in 143", "143 will start or reconnect this preview, then return you here when it is ready.", "Opening launch flow…");
+    actionEl.textContent = "Opening…";
     actionEl.setAttribute("aria-disabled", "true");
-    pollTimer = setInterval(poll, 2500);
-    poll();
+    window.location.href = cfg.controlUrl;
   });
 })();
 </script>

--- a/internal/api/gateway/preview_gateway_test.go
+++ b/internal/api/gateway/preview_gateway_test.go
@@ -65,6 +65,16 @@ func previewGatewayLinkRow(id, orgID, targetID, repoID uuid.UUID, slug string, p
 	}
 }
 
+func requireCurrentTabPreviewLaunchOverlay(t *testing.T, body, launchURL, reason string) {
+	t.Helper()
+
+	require.Contains(t, body, launchURL, reason+" should link to the stable app launch flow")
+	require.Contains(t, body, "Opening preview in 143", reason+" should explain the current-tab app handoff")
+	require.Contains(t, body, "window.location.href = cfg.controlUrl", reason+" should navigate the current tab to the launch flow")
+	require.NotContains(t, body, "143-preview-launch", reason+" should not open a restart popup")
+	require.NotContains(t, body, "popup=1", reason+" should not request popup launch mode")
+}
+
 func TestExtractPreviewID(t *testing.T) {
 	t.Parallel()
 	id := uuid.New()
@@ -831,6 +841,7 @@ func TestGateway_ServeHTTP_Proxy_NoCookieStoppedTarget(t *testing.T) {
 	require.Contains(t, w.Body.String(), "Restart preview", "stopped target overlay should expose the restart action")
 	require.Contains(t, w.Body.String(), "Stopped · May 26, 2026 20:05 UTC", "stopped target overlay should show when the preview stopped")
 	require.Contains(t, w.Body.String(), `"restartable":true`, "stopped target overlay should enable the in-place restart script")
+	requireCurrentTabPreviewLaunchOverlay(t, w.Body.String(), "https://app.143.dev/previews/"+targetID.String()+"?launch=1", "stopped target overlay")
 	require.NotContains(t, w.Body.String(), "%!", "overlay template verbs should match the formatted arguments")
 	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
 }
@@ -880,7 +891,7 @@ func TestGateway_ServeHTTP_Proxy_NoCookieStoppedPRTargetLinksToPRLaunchRoute(t *
 	gw.ServeHTTP(w, req)
 
 	require.Equal(t, http.StatusOK, w.Code, "stopped PR target visits should render the recovery overlay")
-	require.Contains(t, w.Body.String(), "https://app.143.dev/previews/github/acme/web/pull/42?launch=1", "PR target overlay should link back to the stable PR launch controller")
+	requireCurrentTabPreviewLaunchOverlay(t, w.Body.String(), "https://app.143.dev/previews/github/acme/web/pull/42?launch=1", "stopped PR target overlay")
 	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
 }
 
@@ -1061,6 +1072,7 @@ func TestGateway_ServeHTTP_Proxy_StaleStoppedTargetCookieShowsRestart(t *testing
 	require.Contains(t, w.Header().Values("Set-Cookie")[0], "Max-Age=0", "cleared preview cookie should expire immediately")
 	require.Contains(t, w.Body.String(), "Restart preview", "stopped target overlay should expose the restart action")
 	require.Contains(t, w.Body.String(), "Preview stopped", "stopped target overlay should show terminal status")
+	requireCurrentTabPreviewLaunchOverlay(t, w.Body.String(), "https://app.143.dev/previews/"+targetID.String()+"?launch=1", "stale stopped target overlay")
 	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
 }
 
@@ -1357,6 +1369,7 @@ func TestGateway_ServeHTTP_Proxy_ExpiredSameInstanceCookieShowsRestart(t *testin
 	require.Contains(t, w.Header().Values("Set-Cookie")[0], "Max-Age=0", "cleared preview cookie should expire immediately")
 	require.Contains(t, w.Body.String(), "Restart preview", "stopped preview overlay should expose the restart action")
 	require.Contains(t, w.Body.String(), "Stopped · "+stoppedAt.Format("Jan 2, 2006 15:04 MST"), "stopped preview overlay should show terminal status")
+	requireCurrentTabPreviewLaunchOverlay(t, w.Body.String(), "https://app.143.dev/previews/"+previewID.String()+"?launch=1", "expired stopped overlay")
 	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
 }
 


### PR DESCRIPTION
## Summary
- Update preview-origin recovery pages to hand off in the current tab to the stable app launch route with `launch=1`
- Remove the popup-based restart path from the preview gateway overlay
- Document the one-window recovery flow in the implemented design docs
- Add gateway tests that verify recovery pages link to the stable launch flow and do not request popup mode

## Testing
- Unit tests updated for preview gateway recovery overlays