### PR TITLE
Guard against stale PR branch force pushes

### DIFF
--- a/docs/design/implemented/66-session-branch-guardrails.md
+++ b/docs/design/implemented/66-session-branch-guardrails.md
@@ -1,7 +1,7 @@
 # Session Branch Guardrails
 
 > Status: Implemented
-> Last reviewed: 2026-04-30
+> Last reviewed: 2026-06-19
 
 ## Summary
 
@@ -24,6 +24,7 @@ The worker creates one canonical branch name for the session, injects that branc
 - `git-bootstrap` now sets `push.autoSetupRemote=true` so a first plain `git push` from the designated branch naturally creates the matching upstream.
 - The push guard lives in the repo’s `pre-push` hook, so it applies to ordinary agent-driven Git pushes as well as resumed sessions after bootstrap reruns.
 - The guard is intentionally branch-specific rather than token-specific: it reduces accidental pushes to the wrong branch without changing GitHub auth behavior.
+- Snapshot-backed PR/branch publish paths also guard server-side force pushes: before `--force-with-lease`, the push sandbox fetches the current remote session branch and refuses to overwrite it when the remote tree is not represented in the checkpoint. Metadata-only retry rewrites remain allowed when the remote tree equals the local tree.
 
 ## Why this shape
 

--- a/internal/services/github/pr.go
+++ b/internal/services/github/pr.go
@@ -342,6 +342,11 @@ const (
 	// and this error fires when even the lease check fails (a true concurrent
 	// write between ls-remote and push).
 	PushRejectedPRMessage = "GitHub rejected the push because the remote branch changed during the attempt. Try again, or delete the branch on GitHub if it was created outside this session."
+	// PushBranchDivergedPRMessage is shown when the push sandbox's checkpoint
+	// does not contain the current PR branch head and also has a different
+	// tree. This blocks a stale or start-over checkpoint from wiping out
+	// someone else's commits through --force-with-lease.
+	PushBranchDivergedPRMessage = "The PR branch has changes that are not in this session checkpoint. Pull the latest PR branch into the session before pushing again."
 	// SandboxAuthUnavailablePRMessage is shown when 143 cannot prepare the
 	// sandbox credential socket needed for git push. Keep it distinct from the
 	// GitHub permissions fallback because these failures are often runtime or
@@ -399,6 +404,12 @@ var ErrNoChanges = errors.New("no changes to push")
 // failures so the worker can surface a targeted user-facing message instead
 // of the catch-all "Check GitHub access or repo permissions" fallback.
 var ErrPushRejected = errors.New("git push rejected by remote")
+
+// ErrPushBranchDiverged is returned when the current remote PR branch contains
+// commits that are not represented in the hydrated session checkpoint. It is
+// intentionally distinct from ErrPushRejected: the lease may be fresh, but the
+// local snapshot is still stale and must not overwrite the remote tree.
+var ErrPushBranchDiverged = errors.New("remote branch diverged from session snapshot")
 
 // ErrSandboxAuthUnavailable is returned when the host cannot prepare the
 // sandbox credential socket used by git-credential. This is a 143 runtime/auth
@@ -1298,6 +1309,12 @@ func (s *PRService) pushSessionBranch(
 		// Continue to HeadSHA parse + snapshot capture below.
 	case pushExitNoChanges:
 		return nil, ErrNoChanges
+	case pushExitBranchDiverged:
+		msg := strings.TrimSpace(stderr.String())
+		if msg == "" {
+			msg = pushBranchDivergedMessage
+		}
+		return nil, fmt.Errorf("%w: %s", ErrPushBranchDiverged, msg)
 	default:
 		msg := strings.TrimSpace(stderr.String())
 		if msg == "" {
@@ -1412,11 +1429,19 @@ func pushCommitMsgPath(homeDir string) string {
 // the remote tracking branch — i.e. there is nothing meaningful to push.
 const pushExitNoChanges = 77
 
+// pushExitBranchDiverged is the sentinel exit code the push script uses when
+// the current remote PR branch is neither an ancestor of HEAD nor tree-equal
+// to HEAD. That combination means --force-with-lease would overwrite remote
+// work with a stale or start-over checkpoint.
+const pushExitBranchDiverged = 78
+
 // pushHeadSHASentinel is a well-known prefix the push script writes to stdout
 // after a successful `git push`. The caller scans stdout for this line and
 // extracts the just-pushed commit SHA. Chosen to be unlikely to collide with
 // any line git itself prints.
 const pushHeadSHASentinel = "__143_HEAD_SHA="
+
+const pushBranchDivergedMessage = "remote branch has changes that are not present in this session checkpoint; refusing to force push"
 
 // pushScriptTemplate is the shell script executed inside the restored
 // sandbox. All variable interpolations are pre-quoted by the caller (see
@@ -1448,10 +1473,14 @@ const pushHeadSHASentinel = "__143_HEAD_SHA="
 const pushScriptTemplate = `set -eu
 cleanup() { rm -f %[1]s; }
 trap cleanup EXIT
+branch=%[7]s
+push_url=%[6]s
+remote_ref="refs/heads/$branch"
+remote_guard_ref="refs/remotes/__143_push_guard/$branch"
 cd %[2]s
 git config user.name %[3]s
 git config user.email %[4]s
-git checkout -B %[7]s
+git checkout -B "$branch"
 git add -A
 if ! git diff --cached --quiet; then
     git commit -F %[1]s
@@ -1461,8 +1490,17 @@ if git rev-parse --abbrev-ref --symbolic-full-name @{u} >/dev/null 2>&1; then
         exit %[5]d
     fi
 fi
-remote_sha=$(git ls-remote %[6]s refs/heads/%[7]s | awk 'NR==1 {print $1}')
-git push --force-with-lease=refs/heads/%[7]s:"${remote_sha}" %[6]s HEAD:refs/heads/%[7]s
+remote_sha=$(git ls-remote "$push_url" "$remote_ref" | awk 'NR==1 {print $1}')
+if [ -n "$remote_sha" ]; then
+    git fetch --no-tags --quiet "$push_url" "+${remote_ref}:${remote_guard_ref}"
+    if ! git merge-base --is-ancestor "$remote_guard_ref" HEAD; then
+        if ! git diff --quiet HEAD "$remote_guard_ref"; then
+            echo "%[9]s" >&2
+            exit %[10]d
+        fi
+    fi
+fi
+git push --force-with-lease="${remote_ref}:${remote_sha}" "$push_url" "HEAD:${remote_ref}"
 echo "%[8]s$(git rev-parse HEAD)"
 `
 
@@ -1485,6 +1523,8 @@ func buildPushScript(workDir, commitMsgPath, authorName, authorEmail, branchName
 		// interpolated raw — no shellQuote. Anyone who later changes the
 		// sentinel to include shell metacharacters MUST add quoting here.
 		pushHeadSHASentinel,
+		pushBranchDivergedMessage,
+		pushExitBranchDiverged,
 	)
 }
 
@@ -1592,7 +1632,6 @@ func (s *PRService) HandlePullRequestEvent(ctx context.Context, event PullReques
 	s.enqueuePullRequestStateSync(ctx, pr)
 	return s.handleAutoPreviewEvent(ctx, event)
 }
-
 
 func (s *PRService) enqueuePRPreviewSurfaceSyncForRepo(ctx context.Context, repo models.Repository, event PullRequestEvent) {
 	if s == nil || s.jobs == nil {

--- a/internal/services/github/pr_test.go
+++ b/internal/services/github/pr_test.go
@@ -3882,7 +3882,7 @@ func TestPushChangesToPR_EnqueuesHealthSyncAfterSuccessfulPush(t *testing.T) {
 	})
 	require.NoError(t, err, "PushChangesToPR should succeed for a snapshot-backed session with an open PR")
 	require.Equal(t, headSHA, *pr.HeadSHA, "PushChangesToPR should return the just-pushed head SHA")
-	require.Contains(t, provider.lastExecCmd, "HEAD:refs/heads/'"+headRef+"'", "PushChangesToPR should push to the persisted PR head ref")
+	require.Contains(t, provider.lastExecCmd, "branch='"+headRef+"'", "PushChangesToPR should push to the persisted PR head ref")
 	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
 }
 
@@ -4052,20 +4052,32 @@ func TestBuildPushScript_Structure(t *testing.T) {
 	// WorkDir is cd'd into.
 	require.Contains(t, script, "cd '/home/user/repo'")
 
+	// User-controlled shell values are assigned once through shellQuote, then
+	// referenced via variables so every later git command handles branch names
+	// and URLs consistently.
+	require.Contains(t, script, "branch='143/abc123/fix-typo'", "push script should assign the branch through shellQuote")
+	require.Contains(t, script, "push_url='https://github.com/owner/repo.git'", "push script should assign the push URL through shellQuote")
+
 	// Hydrated snapshots may have been captured while the repo was on a stale
 	// branch. The PR push path must normalize the current branch before the
 	// pre-push guard runs.
-	require.Contains(t, script, "git checkout -B '143/abc123/fix-typo'")
+	require.Contains(t, script, `git checkout -B "$branch"`, "push script should check out the persisted branch before staging")
 
 	// Commit message is read from file (not argv).
 	require.Contains(t, script, "git commit -F '/home/user/.143-pr-commit-msg'")
 
 	// Push uses --force-with-lease keyed on the remote SHA we just observed
-	// via ls-remote. Auth flows through credential.helper=!143-tools
-	// git-credential talking to the per-push host socket — no userinfo in
-	// the URL.
-	require.Contains(t, script, "git ls-remote 'https://github.com/owner/repo.git' refs/heads/'143/abc123/fix-typo'")
-	require.Contains(t, script, `git push --force-with-lease=refs/heads/'143/abc123/fix-typo':"${remote_sha}" 'https://github.com/owner/repo.git' HEAD:refs/heads/'143/abc123/fix-typo'`)
+	// via ls-remote. Before force-pushing, the script fetches the current PR
+	// branch and refuses to overwrite a different remote tree unless HEAD
+	// already contains it. That still allows metadata-only retry rewrites.
+	require.Contains(t, script, `remote_ref="refs/heads/$branch"`, "push script should derive the remote branch ref from the persisted branch")
+	require.Contains(t, script, `remote_guard_ref="refs/remotes/__143_push_guard/$branch"`, "push script should derive a local guard ref for the remote branch")
+	require.Contains(t, script, `git ls-remote "$push_url" "$remote_ref"`, "push script should read the current remote SHA before pushing")
+	require.Contains(t, script, `git fetch --no-tags --quiet "$push_url" "+${remote_ref}:${remote_guard_ref}"`, "push script should fetch the current PR branch before force pushing")
+	require.Contains(t, script, `git merge-base --is-ancestor "$remote_guard_ref" HEAD`, "push script should allow pushes that include the remote PR head")
+	require.Contains(t, script, `git diff --quiet HEAD "$remote_guard_ref"`, "push script should allow metadata-only retries with identical trees")
+	require.Contains(t, script, "exit 78", "push script should use the divergent-branch sentinel exit code")
+	require.Contains(t, script, `git push --force-with-lease="${remote_ref}:${remote_sha}" "$push_url" "HEAD:${remote_ref}"`, "push script should lease against the observed remote SHA")
 
 	// No-changes sentinel exit code is present in the upstream-ancestor branch.
 	require.Contains(t, script, "exit 77")
@@ -4090,13 +4102,11 @@ func TestBuildPushScript_QuotesHostileBranchName(t *testing.T) {
 		"143/abc/it's-fine",
 		"https://github.com/o/r.git",
 	)
-	require.Contains(t, script, `HEAD:refs/heads/'143/abc/it'\''s-fine'`)
-	// The branch is interpolated four times now (checkout, ls-remote, lease
-	// ref, push ref); each must round-trip through shellQuote so the embedded
-	// quote can't break out and corrupt the script.
-	require.Contains(t, script, `git checkout -B '143/abc/it'\''s-fine'`)
-	require.Contains(t, script, `git ls-remote 'https://github.com/o/r.git' refs/heads/'143/abc/it'\''s-fine'`)
-	require.Contains(t, script, `--force-with-lease=refs/heads/'143/abc/it'\''s-fine':"${remote_sha}"`)
+	// The branch is assigned through shellQuote once, so the embedded quote
+	// cannot break out and corrupt later variable-based git commands.
+	require.Contains(t, script, `branch='143/abc/it'\''s-fine'`, "push script should quote hostile branch names in the branch variable")
+	require.Contains(t, script, `git checkout -B "$branch"`, "push script should use the safely assigned branch variable")
+	require.Contains(t, script, `--force-with-lease="${remote_ref}:${remote_sha}"`, "push script should lease through the safely derived remote ref")
 }
 
 func TestIsPushRejection(t *testing.T) {
@@ -4334,6 +4344,13 @@ func TestPushSessionBranch(t *testing.T) {
 			snapshots:      &prTestSnapshotStore{payload: []byte("snapshot")},
 			provider:       &prTestSandboxProvider{execExit: 1, execStderr: "! [rejected]   HEAD -> b (stale info)"},
 			wantErrIs:      ErrPushRejected,
+			wantDestroyCnt: 1,
+		},
+		{
+			name:           "divergent remote branch guard maps to ErrPushBranchDiverged",
+			snapshots:      &prTestSnapshotStore{payload: []byte("snapshot")},
+			provider:       &prTestSandboxProvider{execExit: pushExitBranchDiverged, execStderr: pushBranchDivergedMessage},
+			wantErrIs:      ErrPushBranchDiverged,
 			wantDestroyCnt: 1,
 		},
 		{
@@ -5124,7 +5141,7 @@ func TestCreatePR_SuccessPushesSnapshotBranchAndStoresPR(t *testing.T) {
 	require.Equal(t, 1, labelCalls, "CreatePR should add labels to the created PR")
 	require.Equal(t, true, createPRPayload["draft"], "CreatePR should honor the org default draft setting")
 	require.Contains(t, string(provider.writes[pushCommitMsgPath(agent.DefaultSandboxConfig().HomeDir)]), "Co-authored-by: Alice <alice@example.com>", "CreatePR should include a co-author trailer when using the app token for a user-triggered run")
-	require.Contains(t, provider.lastExecCmd, "HEAD:refs/heads/", "CreatePR should push the restored branch before opening the PR")
+	require.Contains(t, provider.lastExecCmd, `git push --force-with-lease="${remote_ref}:${remote_sha}" "$push_url" "HEAD:${remote_ref}"`, "CreatePR should push the restored branch before opening the PR")
 	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
 	_ = body
 }

--- a/internal/worker/handlers.go
+++ b/internal/worker/handlers.go
@@ -9876,6 +9876,8 @@ func userFacingPRError(err error) string {
 		return "This PR predates branch tracking; create a new PR to push follow-up changes."
 	case errors.Is(err, ghservice.ErrPushRejected):
 		return ghservice.PushRejectedPRMessage
+	case errors.Is(err, ghservice.ErrPushBranchDiverged):
+		return ghservice.PushBranchDivergedPRMessage
 	case errors.Is(err, ghservice.ErrSandboxAuthUnavailable):
 		return ghservice.SandboxAuthUnavailablePRMessage
 	default:
@@ -10004,6 +10006,8 @@ func shouldDeadLetterPRError(err error) bool {
 	case errors.Is(err, ghservice.ErrPRClosed):
 		return true
 	case errors.Is(err, ghservice.ErrLegacyPRMissingHeadRef):
+		return true
+	case errors.Is(err, ghservice.ErrPushBranchDiverged):
 		return true
 	default:
 		return false

--- a/internal/worker/handlers_test.go
+++ b/internal/worker/handlers_test.go
@@ -5156,6 +5156,11 @@ func TestUserFacingPRError(t *testing.T) {
 			want: "GitHub rejected the push because the remote branch changed during the attempt. Try again, or delete the branch on GitHub if it was created outside this session.",
 		},
 		{
+			name: "branch diverged",
+			err:  ghservice.ErrPushBranchDiverged,
+			want: "The PR branch has changes that are not in this session checkpoint. Pull the latest PR branch into the session before pushing again.",
+		},
+		{
 			name: "sandbox auth unavailable",
 			err:  fmt.Errorf("open sandbox auth socket: %w", ghservice.ErrSandboxAuthUnavailable),
 			want: "143 could not prepare GitHub credentials for this push.",
@@ -5187,6 +5192,7 @@ func TestShouldDeadLetterPRError(t *testing.T) {
 		{name: "snapshot not captured is terminal", err: ghservice.ErrSnapshotNotCaptured, want: true},
 		{name: "snapshot unavailable is terminal", err: ghservice.ErrSnapshotUnavailable, want: true},
 		{name: "no changes is terminal", err: ghservice.ErrNoChanges, want: true},
+		{name: "branch diverged is terminal", err: ghservice.ErrPushBranchDiverged, want: true},
 		{name: "generic error retries", err: errors.New("boom"), want: false},
 	}
 


### PR DESCRIPTION
## Summary
- Add a server-side guard before `--force-with-lease` so snapshot-backed PR publishes refuse to overwrite a remote branch whose tree is not represented in the session checkpoint
- Introduce a dedicated diverged-branch error and user-facing message, and route it to terminal handling in the worker
- Update design docs and strengthen push-script coverage for branch quoting and divergence cases

## Testing
- Added and updated Go unit tests for push-script structure, divergent-branch handling, and worker error mapping