### PR TITLE
Hide revoked CLI install links from the admin list

### DIFF
--- a/internal/api/handlers/join_tokens.go
+++ b/internal/api/handlers/join_tokens.go
@@ -145,7 +145,9 @@ func (h *JoinTokenHandler) Create(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
-// List returns the org's join tokens with derived lifecycle status.
+// List returns the org's non-revoked join tokens with derived lifecycle
+// status. Revoked links are filtered out at the store so they don't clutter
+// the settings list.
 func (h *JoinTokenHandler) List(w http.ResponseWriter, r *http.Request) {
 	orgID := middleware.OrgIDFromContext(r.Context())
 	if orgID == uuid.Nil {

--- a/internal/api/handlers/join_tokens_test.go
+++ b/internal/api/handlers/join_tokens_test.go
@@ -127,6 +127,43 @@ func TestJoinTokenHandler_CreateStoresRecoverableRawToken(t *testing.T) {
 	require.Equal(t, http.StatusCreated, w.Code, "Create should return created for a recoverable join token, body: %s", w.Body.String())
 }
 
+func TestJoinTokenHandler_ListExcludesRevokedTokens(t *testing.T) {
+	t.Parallel()
+
+	orgID := uuid.New()
+	userID := uuid.New()
+	tokenID := uuid.New()
+	creatorID := uuid.New()
+	now := time.Now()
+	mock := newPgxMock(t)
+	handler := NewJoinTokenHandler(db.NewOrgJoinTokenStore(mock), "https://143.example")
+
+	// The list query must filter revoked links at the database so they don't
+	// clutter the settings list. Pin the WHERE clause here.
+	mock.ExpectQuery(`(?s)SELECT .*FROM org_join_tokens.*revoked_at IS NULL`).
+		WithArgs(pgx.NamedArgs{"org_id": orgID}).
+		WillReturnRows(pgxmock.NewRows(orgJoinTokenTestColumns()).AddRow(
+			tokenID, orgID, "sha256:test", "143j_ActiveTk", models.RoleMember, "Active link",
+			[]byte("v0:143j_TestToken123456789012"), creatorID, nil, 0, nil, nil, nil, now,
+		))
+
+	req := newJoinTokenRequest(http.MethodGet, "/api/v1/org/join-tokens", orgID, userID, nil)
+	w := httptest.NewRecorder()
+	handler.List(w, req)
+
+	require.NoError(t, mock.ExpectationsWereMet(), "List should filter revoked tokens in its query")
+	require.Equal(t, http.StatusOK, w.Code, "List should return OK, body: %s", w.Body.String())
+	var body struct {
+		Data []struct {
+			ID     string `json:"id"`
+			Status string `json:"status"`
+		} `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &body), "List response should be valid JSON")
+	require.Len(t, body.Data, 1, "List should return the active token")
+	require.Equal(t, "active", body.Data[0].Status, "listed tokens should never be revoked")
+}
+
 func newJoinTokenRequest(method, path string, orgID, userID uuid.UUID, params map[string]string) *http.Request {
 	req := httptest.NewRequest(method, path, nil)
 	ctx := middleware.WithOrgID(req.Context(), orgID)

--- a/internal/db/org_join_tokens.go
+++ b/internal/db/org_join_tokens.go
@@ -129,9 +129,14 @@ func (s *OrgJoinTokenStore) GetActiveRecoverableToken(ctx context.Context, orgID
 	return token, rawToken, nil
 }
 
+// List returns the org's join tokens for the admin UI, excluding revoked
+// ones. Revoked links are kept in the table for the audit trail but are
+// filtered out here so the settings list only shows links an admin can still
+// act on (expired/exhausted ones stay visible until revoked).
 func (s *OrgJoinTokenStore) List(ctx context.Context, orgID uuid.UUID) ([]models.OrgJoinToken, error) {
 	query := fmt.Sprintf(`SELECT %s FROM org_join_tokens
-		WHERE org_id = @org_id ORDER BY created_at DESC, id DESC`, orgJoinTokenColumns)
+		WHERE org_id = @org_id AND revoked_at IS NULL
+		ORDER BY created_at DESC, id DESC`, orgJoinTokenColumns)
 	rows, err := s.db.Query(ctx, query, pgx.NamedArgs{"org_id": orgID})
 	if err != nil {
 		return nil, fmt.Errorf("list org join tokens: %w", err)


### PR DESCRIPTION
## Summary

Admins reported that the settings "CLI install links" table kept showing every link they had ever revoked, each with a "revoked" badge — so the list grew cluttered with dead entries and made the still-usable links harder to find. This filters revoked links out of the admin list at the query level, so revoking a link removes it from the table. Revoked rows are retained in the database for the audit trail; they're just no longer surfaced in the UI.

## Changes

- `OrgJoinTokenStore.List` now includes `revoked_at IS NULL`, matching the predicate already used by every other read/consume query in the file (`GetActiveRecoverableToken`, `ConsumeByToken`, `GetActiveByToken`).
- Scope is intentionally narrow: only revoked links are hidden. Expired/exhausted links stay visible until revoked, and the revoke audit trail (`revoked_at` / `revoked_by_user_id`) is untouched.
- No frontend change needed — the revoke mutation already invalidates the React Query cache, so the link disappears immediately on revoke.
- Added `TestJoinTokenHandler_ListExcludesRevokedTokens`, which pins the `revoked_at IS NULL` clause into the list query as a regression guard.

## Validation

- `make lint` → 0 issues
- `go test ./internal/api/handlers/ -run TestJoinTokenHandler` → all pass (incl. new test)
- Pre-commit store-lint + gofmt passed

Note: the handler test uses pgxmock, which validates the query string rather than executing real SQL — so the test guards against the clause being removed but does not prove Postgres filtering end-to-end. The clause is trivial and mirrors four existing sibling queries; `make test-integration` would exercise the real predicate if deeper coverage is wanted.
