### PR TITLE
Clarify GitHub org auto-join empty state with an actionable install button

### DIFF
--- a/frontend/src/components/settings/verified-domains-section.tsx
+++ b/frontend/src/components/settings/verified-domains-section.tsx
@@ -192,13 +192,26 @@ export function VerifiedDomainsSection() {
             {githubOrgsLoading ? (
               <div className="p-4 text-xs text-muted-foreground">Loading GitHub organizations...</div>
             ) : githubOrgs.length === 0 ? (
-              <div className="flex items-center gap-2 px-4 py-3 text-xs text-muted-foreground">
-                <Github className="h-3.5 w-3.5" />
-                <span>
-                  {githubConnected
-                    ? "Install the GitHub App on a GitHub organization to enable organization-based auto-join."
-                    : "Connect GitHub to enable organization-based auto-join."}
-                </span>
+              <div className="flex flex-col gap-2 px-4 py-3 text-xs text-muted-foreground">
+                <div className="flex items-start gap-2">
+                  <Github className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+                  <span>
+                    {githubConnected
+                      ? "GitHub is connected, but the app isn't installed on a GitHub organization yet. Auto-join only works when the app is installed on the organization account itself — not a personal account, and not just on individual repos — and is granted permission to read organization members. Re-run the install below and pick your organization as the target."
+                      : "Connect GitHub and install the app on your organization so members can auto-join. Choose your organization (not a personal account) as the install target and grant access to read members."}
+                  </span>
+                </div>
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  className="h-7 self-start text-xs"
+                  onClick={() => api.integrations.loginGitHub()}
+                >
+                  <Github className="mr-1.5 h-3 w-3" />
+                  {githubConnected ? "Install on a GitHub organization" : "Connect GitHub"}
+                  <ExternalLink className="ml-1.5 h-3 w-3" />
+                </Button>
               </div>
             ) : (
               githubOrgs.map((org) => {


### PR DESCRIPTION
## Problem

On the **Auto-join** settings panel, when an org has no linked GitHub-organization installation, the empty state showed a dead-end string with no action and no explanation:

> Install the GitHub App on a GitHub organization to enable organization-based auto-join.

This left users stuck. The most common cause is that the app was installed on a **personal account**, on **specific repos only**, or **directly from GitHub** (rather than through the in-app flow that binds the installation to the workspace and creates the `github_installation_org_links` row). None of that was explained, and there was no button to re-run the install.

Note: repository scope ("all" vs "selected repos") does *not* affect auto-join — `repository_selection` isn't read anywhere; auto-join keys off **organization membership** (`account_type = "Organization"` + `members:read`).

## Change

In `verified-domains-section.tsx`, the empty state now:

- **Explains why an existing install may not count** — the app must be installed on the **organization account itself** (not a personal account, not just repos) and granted permission to read members.
- **Adds an actionable button** that launches the install flow via `api.integrations.loginGitHub()` → `github.com/apps/<slug>/installations/new` (the only path that creates the org-link row). Label adapts: "Install on a GitHub organization" when already connected, "Connect GitHub" otherwise.
- Uses only symbols already imported in the file (`Button`, `Github`, `ExternalLink`, `api`) — no new imports.

## Testing

Not verified in a live preview: reaching this branch requires `githubConnected === true` **and** `githubOrgs === []` for a logged-in org admin, which needs seeded GitHub installation DB state not reproducible from a cold dev server. The change is plain JSX over already-imported symbols.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
