### PR TITLE
Handle stuck PR readiness review loops

### DIFF
--- a/internal/db/pr_readiness.go
+++ b/internal/db/pr_readiness.go
@@ -71,6 +71,29 @@ func (s *PRReadinessStore) MarkRunning(ctx context.Context, orgID, runID uuid.UU
 	return nil
 }
 
+func (s *PRReadinessStore) MarkFailed(ctx context.Context, orgID, runID uuid.UUID, summary string) error {
+	tag, err := s.db.Exec(ctx, `
+		UPDATE pr_readiness_runs
+		SET status = 'failed',
+		    summary = @summary,
+		    completed_at = COALESCE(completed_at, now()),
+		    updated_at = now()
+		WHERE org_id = @org_id
+		  AND id = @id
+		  AND status IN ('queued', 'running')`, pgx.NamedArgs{
+		"org_id":  orgID,
+		"id":      runID,
+		"summary": summary,
+	})
+	if err != nil {
+		return fmt.Errorf("mark PR readiness failed: %w", err)
+	}
+	if tag.RowsAffected() == 0 {
+		return pgx.ErrNoRows
+	}
+	return nil
+}
+
 func (s *PRReadinessStore) CompleteRunWithChecks(ctx context.Context, orgID uuid.UUID, runID uuid.UUID, result models.PRReadinessRun, checks []models.PRReadinessCheck) error {
 	txStarter, ok := s.db.(TxStarter)
 	if !ok {

--- a/internal/db/pr_readiness_test.go
+++ b/internal/db/pr_readiness_test.go
@@ -53,6 +53,27 @@ func TestPRReadinessStore_CreateRun(t *testing.T) {
 	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
 }
 
+func TestPRReadinessStore_MarkFailed(t *testing.T) {
+	t.Parallel()
+
+	orgID := uuid.New()
+	runID := uuid.New()
+	summary := "Worker job failed before readiness completed."
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "pgxmock should initialize")
+	defer mock.Close()
+
+	mock.ExpectExec("UPDATE pr_readiness_runs").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
+
+	err = NewPRReadinessStore(mock).MarkFailed(context.Background(), orgID, runID, summary)
+
+	require.NoError(t, err, "MarkFailed should mark the readiness run failed")
+	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
+}
+
 func TestPRReadinessStore_GetLatestBySession(t *testing.T) {
 	t.Parallel()
 

--- a/internal/worker/handlers.go
+++ b/internal/worker/handlers.go
@@ -9546,6 +9546,7 @@ func newRunPRReadinessHandler(stores *Stores, services *Services, logger zerolog
 		if stores == nil || stores.PRReadiness == nil || stores.Sessions == nil {
 			return fmt.Errorf("PR readiness stores are not configured")
 		}
+		registerPRReadinessDeadLetter(ctx, stores, logger, orgID, readinessID)
 
 		run, err := stores.PRReadiness.GetRunByID(ctx, orgID, readinessID)
 		if err != nil {
@@ -9560,6 +9561,11 @@ func newRunPRReadinessHandler(stores *Stores, services *Services, logger zerolog
 		if err != nil {
 			return fmt.Errorf("load readiness session: %w", err)
 		}
+		if loop, err := runningReadinessReviewLoop(ctx, stores, session); err != nil {
+			return err
+		} else if loop != nil {
+			return retryPRReadinessReviewLoop(logger, sessionID, readinessID)
+		}
 		if err := ensureSessionSnapshotQuiescent(ctx, stores, session); err != nil {
 			return err
 		}
@@ -9569,12 +9575,7 @@ func newRunPRReadinessHandler(stores *Stores, services *Services, logger zerolog
 			return err
 		}
 		if !reviewReady {
-			logger.Info().
-				Str("session_id", sessionID.String()).
-				Str("readiness_id", readinessID.String()).
-				Msg("PR readiness waiting for review loop")
-			delay := prePRReviewRetryDelay
-			return &RetryableError{Err: fmt.Errorf("PR readiness review loop is still running"), RetryAfter: &delay}
+			return retryPRReadinessReviewLoop(logger, sessionID, readinessID)
 		}
 
 		logs := []models.SessionLog{}
@@ -9638,6 +9639,53 @@ func newRunPRReadinessHandler(stores *Stores, services *Services, logger zerolog
 	}
 }
 
+func registerPRReadinessDeadLetter(ctx context.Context, stores *Stores, logger zerolog.Logger, orgID, readinessID uuid.UUID) {
+	if stores == nil || stores.PRReadiness == nil {
+		return
+	}
+	jobctx.RegisterDeadLetterHook(ctx, func(hookCtx context.Context, deadLetterErr error) {
+		writeCtx, cancel := context.WithTimeout(context.WithoutCancel(hookCtx), 10*time.Second)
+		defer cancel()
+		summary := "Readiness job failed before checks completed."
+		if deadLetterErr != nil {
+			summary = "Readiness job failed before checks completed: " + deadLetterErr.Error()
+		}
+		if err := stores.PRReadiness.MarkFailed(writeCtx, orgID, readinessID, summary); err != nil && !errors.Is(err, pgx.ErrNoRows) {
+			logger.Error().
+				Err(err).
+				Str("readiness_id", readinessID.String()).
+				Msg("failed to mark PR readiness run failed after job dead-letter")
+		}
+	})
+}
+
+func runningReadinessReviewLoop(ctx context.Context, stores *Stores, session models.Session) (*models.SessionReviewLoop, error) {
+	if stores == nil || stores.ReviewLoops == nil {
+		return nil, nil
+	}
+	loop, err := stores.ReviewLoops.GetRunningLoopBySession(ctx, session.OrgID, session.ID)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("load running readiness review loop: %w", err)
+	}
+	return &loop, nil
+}
+
+func retryPRReadinessReviewLoop(logger zerolog.Logger, sessionID, readinessID uuid.UUID) error {
+	logger.Info().
+		Str("session_id", sessionID.String()).
+		Str("readiness_id", readinessID.String()).
+		Msg("PR readiness waiting for review loop")
+	delay := prePRReviewRetryDelay
+	return &RetryableError{
+		Err:                    fmt.Errorf("PR readiness review loop is still running"),
+		RetryAfter:             &delay,
+		BypassMaxRetryDuration: true,
+	}
+}
+
 func ensureReadinessReviewLoop(ctx context.Context, stores *Stores, services *Services, session models.Session, snapshotKey string) (*models.SessionReviewLoop, bool, error) {
 	if stores == nil || stores.ReviewLoops == nil {
 		return nil, true, nil
@@ -9657,6 +9705,9 @@ func ensureReadinessReviewLoop(ctx context.Context, stores *Stores, services *Se
 		}
 		if loop.Status == models.ReviewLoopStatusRunning {
 			return &loop, false, nil
+		}
+		if stringValue(loop.LatestCheckpointKey) == snapshotKey || stringValue(loop.LoopStartCheckpointKey) == snapshotKey {
+			return &loop, true, nil
 		}
 	}
 	if services == nil || services.ReviewLoops == nil || snapshotKey == "" {

--- a/internal/worker/handlers_test.go
+++ b/internal/worker/handlers_test.go
@@ -9324,6 +9324,121 @@ func TestContinueSessionHandler_WrapsSiblingSandboxRaceAsRetryable(t *testing.T)
 	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
 }
 
+func TestRunPRReadinessHandler_DeadLetterMarksReadinessFailed(t *testing.T) {
+	t.Parallel()
+
+	stores, mock := newTestStores(t)
+	defer mock.Close()
+	stores.PRReadiness = db.NewPRReadinessStore(mock)
+
+	orgID := uuid.New()
+	sessionID := uuid.New()
+	readinessID := uuid.New()
+
+	mock.ExpectQuery("FROM pr_readiness_runs").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnError(errors.New("database unavailable"))
+	mock.ExpectExec("UPDATE pr_readiness_runs").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
+
+	ctx := jobctx.WithDeadLetterHooks(context.Background())
+	handler := newRunPRReadinessHandler(stores, &Services{}, zerolog.Nop())
+	payload := json.RawMessage(`{"org_id":"` + orgID.String() + `","session_id":"` + sessionID.String() + `","readiness_id":"` + readinessID.String() + `"}`)
+
+	err := handler(ctx, "run_pr_readiness", payload)
+	require.Error(t, err, "handler should surface the readiness load failure")
+
+	jobctx.RunDeadLetterHooks(ctx, errors.New("retryable job timed out after 8m0s"))
+
+	require.NoError(t, mock.ExpectationsWereMet(), "dead-letter hook should mark the readiness run failed")
+}
+
+func TestRunPRReadinessHandler_RunningReviewLoopBypassesRetryWindow(t *testing.T) {
+	t.Parallel()
+
+	stores, mock := newTestStores(t)
+	defer mock.Close()
+	stores.PRReadiness = db.NewPRReadinessStore(mock)
+	stores.ReviewLoops = db.NewSessionReviewLoopStore(mock)
+
+	orgID := uuid.New()
+	sessionID := uuid.New()
+	readinessID := uuid.New()
+	loopID := uuid.New()
+	threadID := uuid.New()
+	now := time.Now().UTC()
+	snapshotKey := "snapshots/org/session/workspace.tar.zst"
+
+	mock.ExpectQuery("FROM pr_readiness_runs").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(pgxmock.NewRows([]string{
+			"id", "org_id", "session_id", "repository_id", "status",
+			"evaluated_workspace_revision", "evaluated_snapshot_key", "summary", "review_packet",
+			"triggered_by_user_id", "started_at", "completed_at", "created_at", "updated_at",
+		}).AddRow(readinessID, orgID, sessionID, nil, models.PRReadinessRunStatusRunning, int64(2), &snapshotKey, "Queued", nil, nil, now, nil, now, now))
+	mock.ExpectQuery("SELECT .* FROM sessions").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(pgxmock.NewRows(workerSessionColumns).AddRow(
+			workerSessionRow(sessionID, uuid.Nil, orgID, models.SessionStatusRunning, 2, nil, &snapshotKey)...,
+		))
+	mock.ExpectQuery("FROM session_review_loops").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(pgxmock.NewRows(workerReviewLoopColumns()).AddRow(
+			loopID, orgID, sessionID, nil, &threadID, models.ReviewLoopStatusRunning,
+			models.ReviewLoopSourceManual, models.AgentTypeCodex, 1, models.ReviewLoopFixModeMinimal, 0,
+			true, nil, nil, &snapshotKey, &snapshotKey, nil, nil, now, nil,
+		))
+
+	handler := newRunPRReadinessHandler(stores, &Services{}, zerolog.Nop())
+	payload := json.RawMessage(`{"org_id":"` + orgID.String() + `","session_id":"` + sessionID.String() + `","readiness_id":"` + readinessID.String() + `"}`)
+
+	err := handler(context.Background(), "run_pr_readiness", payload)
+
+	var retryable *RetryableError
+	require.ErrorAs(t, err, &retryable, "running review loop should defer readiness with a retryable error")
+	require.True(t, retryable.BypassMaxRetryDuration, "review-loop waits must not spend the generic retryable job window")
+	require.NotNil(t, retryable.RetryAfter, "review-loop waits should use a short fixed retry delay")
+	require.Equal(t, prePRReviewRetryDelay, *retryable.RetryAfter, "review-loop waits should use the PR review retry delay")
+	require.ErrorContains(t, retryable.Err, "PR readiness review loop is still running", "retryable reason should explain the review-loop wait")
+	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
+}
+
+func TestEnsureReadinessReviewLoop_UsesTerminalLoopForSnapshot(t *testing.T) {
+	t.Parallel()
+
+	stores, mock := newTestStores(t)
+	defer mock.Close()
+	stores.ReviewLoops = db.NewSessionReviewLoopStore(mock)
+
+	orgID := uuid.New()
+	sessionID := uuid.New()
+	loopID := uuid.New()
+	threadID := uuid.New()
+	now := time.Now().UTC()
+	snapshotKey := "snapshots/org/session/workspace.tar.zst"
+	latestSummary := "Review still needs a decision."
+	session := models.Session{ID: sessionID, OrgID: orgID, AgentType: models.AgentTypeCodex}
+
+	mock.ExpectQuery("FROM session_review_loops").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(pgxmock.NewRows(workerReviewLoopColumns()).AddRow(
+			loopID, orgID, sessionID, nil, &threadID, models.ReviewLoopStatusNeedsHumanDecision,
+			models.ReviewLoopSourceManual, models.AgentTypeCodex, 1, models.ReviewLoopFixModeMinimal, 1,
+			true, nil, nil, &snapshotKey, &snapshotKey, &latestSummary, nil, now, &now,
+		))
+
+	reviews := &stubWorkerReviewLoops{}
+	latest, reviewReady, err := ensureReadinessReviewLoop(context.Background(), stores, &Services{ReviewLoops: reviews}, session, snapshotKey)
+
+	require.NoError(t, err, "terminal review loop lookup should not fail")
+	require.True(t, reviewReady, "terminal review loops for the target snapshot should be ready for readiness evaluation")
+	require.NotNil(t, latest, "the terminal review loop should be returned as readiness evidence")
+	require.Equal(t, models.ReviewLoopStatusNeedsHumanDecision, latest.Status, "readiness should evaluate the existing non-clean review result")
+	require.Empty(t, reviews.starts, "readiness must not start another review loop after a terminal loop exists for the snapshot")
+	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
+}
+
 func TestContinueSessionHandler_ReleasesThreadOnContinuationFailure(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- mark PR readiness runs as failed when the worker dead-letters before checks complete
- detect already-running or terminal review loops for the same snapshot and retry readiness with a bypassed retry window
- add unit coverage for the new failure path and review-loop handling

## Testing
- Added unit tests for `PRReadinessStore.MarkFailed`
- Added unit tests for PR readiness dead-letter handling and review-loop retry behavior
- Added a unit test covering terminal review-loop reuse for a snapshot