### PR TITLE
Merge preview settings into per-repo cards; persist build profile

### DIFF
--- a/frontend/src/app/(dashboard)/settings/previews/page.test.tsx
+++ b/frontend/src/app/(dashboard)/settings/previews/page.test.tsx
@@ -920,6 +920,93 @@ describe("PreviewSettingsPage", () => {
     });
   });
 
+  it("toggles a PR preview surface from the publish stage", async () => {
+    let savedPolicy: unknown;
+    server.use(
+      http.get("*/api/v1/repositories", () => HttpResponse.json({ data: repos, meta: {} })),
+      http.get("*/api/v1/repositories/:id/preview-secret-bundles", () => HttpResponse.json({ data: [], meta: {} })),
+      http.get("*/api/v1/previews/policies", () => HttpResponse.json({
+        data: [
+          {
+            repository_id: "repo-1",
+            repository_full_name: "assembledhq/143",
+            auto_mode: "warm",
+            session_prewarm_mode: "off",
+            pr_preview_surfaces_enabled: true,
+            github_pr_comment_enabled: true,
+            github_commit_status_enabled: true,
+            preview_configured: true,
+            preview_success_recorded: true,
+            preview_ready: true,
+            github_pr_comment_permission_ok: true,
+            github_commit_status_permission_ok: true,
+            open_pr_count: 2,
+            updated_at: "2026-06-08T12:00:00Z",
+          },
+        ],
+        meta: {},
+      })),
+      http.put("*/api/v1/repositories/repo-1/preview-policy", async ({ request }) => {
+        savedPolicy = await request.json();
+        return HttpResponse.json({ data: { id: "policy-1" } });
+      }),
+    );
+
+    renderWithProviders(<PreviewSettingsPage />);
+
+    await userEvent.click(
+      await screen.findByRole("switch", { name: /enable pr comment preview link for assembledhq\/143/i }),
+    );
+    await waitFor(() => {
+      expect(savedPolicy).toEqual({ github_pr_comment_enabled: false });
+    });
+  });
+
+  it("persists the selected build profile to the repository policy", async () => {
+    let savedPolicy: unknown;
+    server.use(
+      http.get("*/api/v1/repositories", () => HttpResponse.json({ data: repos, meta: {} })),
+      http.get("*/api/v1/repositories/:id/preview-secret-bundles", () => HttpResponse.json({ data: [], meta: {} })),
+      http.get("*/api/v1/previews/policies", () => HttpResponse.json({
+        data: [
+          {
+            repository_id: "repo-1",
+            repository_full_name: "assembledhq/143",
+            auto_mode: "warm",
+            session_prewarm_mode: "off",
+            pr_preview_surfaces_enabled: false,
+            github_pr_comment_enabled: true,
+            github_commit_status_enabled: true,
+            preview_configured: true,
+            preview_success_recorded: true,
+            preview_config_names: ["web", "admin"],
+            preview_config_default_name: "web",
+            preview_ready: true,
+            github_pr_comment_permission_ok: true,
+            github_commit_status_permission_ok: true,
+            open_pr_count: 1,
+            updated_at: null,
+          },
+        ],
+        meta: {},
+      })),
+      http.put("*/api/v1/repositories/repo-1/preview-policy", async ({ request }) => {
+        savedPolicy = await request.json();
+        return HttpResponse.json({ data: { id: "policy-1" } });
+      }),
+    );
+
+    renderWithProviders(<PreviewSettingsPage />);
+
+    await userEvent.click(
+      await screen.findByRole("combobox", { name: /select build profile for assembledhq\/143/i }),
+    );
+    await userEvent.click(await screen.findByRole("option", { name: "admin" }));
+    await waitFor(() => {
+      expect(savedPolicy).toEqual({ preview_config_name: "admin" });
+    });
+  });
+
 });
 
 function repo(id: string, fullName: string) {

--- a/frontend/src/app/(dashboard)/settings/previews/page.test.tsx
+++ b/frontend/src/app/(dashboard)/settings/previews/page.test.tsx
@@ -99,7 +99,7 @@ describe("PreviewSettingsPage", () => {
 
     expect(await screen.findByRole("tab", { name: "Auto-start policy" })).toHaveAttribute("aria-selected", "true");
     expect(await screen.findAllByText("assembledhq/143")).not.toHaveLength(0);
-    expect(screen.getByText("12")).toBeInTheDocument();
+    expect(screen.getByText(/12 open PRs/)).toBeInTheDocument();
 
     await userEvent.click(screen.getByRole("radio", { name: /use warm auto-preview for assembledhq\/143/i }));
     await waitFor(() => {
@@ -174,7 +174,7 @@ describe("PreviewSettingsPage", () => {
     });
   });
 
-  it("keeps auto-preview rows usable in the mobile stacked layout", async () => {
+  it("groups each repository's build and publish controls in one stacked card", async () => {
     server.use(
       http.get("*/api/v1/repositories", () => HttpResponse.json({ data: repos, meta: {} })),
       http.get("*/api/v1/repositories/:id/preview-secret-bundles", () => HttpResponse.json({ data: [], meta: {} })),
@@ -195,13 +195,16 @@ describe("PreviewSettingsPage", () => {
 
     renderWithProviders(<PreviewSettingsPage />);
 
-    const repoLabels = await screen.findAllByText("assembledhq/143");
-    const row = repoLabels
-      .map((repoLabel) => repoLabel.closest("tr"))
-      .find((candidate) => candidate && within(candidate as HTMLElement).queryByText("Open PRs"));
-    expect(row).not.toBeNull();
-    expect(within(row as HTMLElement).getByText("Open PRs")).toBeInTheDocument();
-    expect(within(row as HTMLElement).getByText("Updated")).toBeInTheDocument();
+    const repoLabel = (await screen.findAllByText("assembledhq/143"))[0];
+    // Each repository renders as a single self-contained card, not a table row.
+    const card = repoLabel.closest("div.rounded-md");
+    expect(card).not.toBeNull();
+    const cardEl = card as HTMLElement;
+    // The merged card carries both the auto-build mode and the open-PR count.
+    expect(within(cardEl).getByText(/5 open PRs/)).toBeInTheDocument();
+    expect(
+      within(cardEl).getByRole("radio", { name: /use warm auto-preview for assembledhq\/143/i }),
+    ).toBeInTheDocument();
   });
 
   it("renders the renamed Preview settings surface and loads bundles for the selected repository", async () => {

--- a/frontend/src/app/(dashboard)/settings/previews/page.tsx
+++ b/frontend/src/app/(dashboard)/settings/previews/page.tsx
@@ -11,7 +11,6 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useQueryState } from "nuqs";
 import {
   Eye,
-  GitPullRequest,
   HelpCircle,
   KeyRound,
   MonitorPlay,
@@ -255,357 +254,81 @@ function AutoPreviewSection() {
   const policies = policiesQuery.data?.data ?? [];
 
   return (
-    <section className="space-y-4" aria-labelledby="auto-preview-heading">
+    <section className="space-y-4" aria-labelledby="previews-heading">
       <div className="space-y-1">
         <h2
-          id="auto-preview-heading"
+          id="previews-heading"
           className="text-sm font-semibold text-foreground"
         >
-          Auto-preview
+          Previews
         </h2>
         <p className="text-xs text-muted-foreground">
-          Build previews for open pull requests. Warm mode hibernates after a
-          successful build so the PR link resumes quickly.
+          For each repository: build previews for open pull requests, then
+          publish their links to GitHub. Warm mode hibernates after a successful
+          build so the PR link resumes quickly.
         </p>
       </div>
 
-      <div className="overflow-hidden rounded-md border border-border">
-        <Table>
-          <TableHeader className="hidden md:table-header-group">
-            <TableRow>
-              <TableHead>Repository</TableHead>
-              <TableHead>Mode</TableHead>
-              <TableHead>Session Prewarm</TableHead>
-              <TableHead>Open PRs</TableHead>
-              <TableHead>Updated</TableHead>
-            </TableRow>
-          </TableHeader>
-          <TableBody>
-            {policiesQuery.isLoading ? (
-              <TableRow>
-                <TableCell
-                  colSpan={5}
-                  className="py-6 text-sm text-muted-foreground"
-                >
-                  Loading preview policies...
-                </TableCell>
-              </TableRow>
-            ) : policies.length ? (
-              policies.map((policy) => (
-                <TableRow
-                  key={policy.repository_id}
-                  className="block border-b p-3 md:table-row md:p-0"
-                >
-                  <TableCell className="block px-0 py-1 md:table-cell md:px-4 md:py-3">
-                    <div className="flex items-center gap-2 font-medium text-foreground">
-                      <MonitorPlay className="h-4 w-4 text-muted-foreground" />
-                      {policy.repository_full_name}
-                    </div>
-                  </TableCell>
-                  <TableCell className="block px-0 py-2 md:table-cell md:px-4 md:py-3">
-                    <ToggleGroup
-                      type="single"
-                      value={policy.auto_mode}
-                      onValueChange={(value) => {
-                        if (!value || value === policy.auto_mode) return;
-                        policyMutation.mutate({
-                          repositoryId: policy.repository_id,
-                          body: { auto_mode: value as PreviewPolicySummary["auto_mode"] },
-                        });
-                      }}
-                      className="justify-start"
-                    >
-                      <ToggleGroupItem
-                        value="off"
-                        aria-label={`Turn off auto-preview for ${policy.repository_full_name}`}
-                      >
-                        Off
-                      </ToggleGroupItem>
-                      <ToggleGroupItem
-                        value="warm"
-                        aria-label={`Use warm auto-preview for ${policy.repository_full_name}`}
-                      >
-                        Warm
-                      </ToggleGroupItem>
-                      <ToggleGroupItem
-                        value="on"
-                        aria-label={`Keep auto-preview on for ${policy.repository_full_name}`}
-                      >
-                        On
-                      </ToggleGroupItem>
-                    </ToggleGroup>
-                  </TableCell>
-                  <TableCell className="block px-0 py-2 md:table-cell md:px-4 md:py-3">
-                    <ToggleGroup
-                      type="single"
-                      value={policy.session_prewarm_mode}
-                      onValueChange={(value) => {
-                        if (
-                          !value ||
-                          value === policy.session_prewarm_mode ||
-                          !sessionPrewarmEnabled
-                        ) {
-                          return;
-                        }
-                        policyMutation.mutate({
-                          repositoryId: policy.repository_id,
-                          body: {
-                            session_prewarm_mode:
-                              value as PreviewPolicySummary["session_prewarm_mode"],
-                          },
-                        });
-                      }}
-                      className="justify-start"
-                      disabled={!sessionPrewarmEnabled}
-                    >
-                      <ToggleGroupItem
-                        value="off"
-                        aria-label={`Turn off session prewarm for ${policy.repository_full_name}`}
-                      >
-                        Off
-                      </ToggleGroupItem>
-                      <ToggleGroupItem
-                        value="cache"
-                        aria-label={`Use cache-only session prewarm for ${policy.repository_full_name}`}
-                      >
-                        Cache only
-                      </ToggleGroupItem>
-                      <ToggleGroupItem
-                        value="smart"
-                        aria-label={`Use smart session prewarm for ${policy.repository_full_name}`}
-                      >
-                        Smart
-                      </ToggleGroupItem>
-                    </ToggleGroup>
-                    {!sessionPrewarmEnabled ? (
-                      <p className="mt-1 text-xs text-muted-foreground">
-                        Set speculative preview slots above 0 to enable session
-                        prewarm.
-                      </p>
-                    ) : null}
-                  </TableCell>
-                  <TableCell className="block px-0 py-1 text-sm md:table-cell md:px-4 md:py-3">
-                    <span className="mr-2 font-medium md:hidden">Open PRs</span>
-                    {policy.open_pr_count}
-                  </TableCell>
-                  <TableCell className="block px-0 py-1 text-sm text-muted-foreground md:table-cell md:px-4 md:py-3">
-                    <span className="mr-2 font-medium text-foreground md:hidden">
-                      Updated
-                    </span>
-                    {policy.updated_at
-                      ? new Date(policy.updated_at).toLocaleDateString()
-                      : "-"}
-                  </TableCell>
-                </TableRow>
-              ))
-            ) : (
-              <TableRow>
-                <TableCell colSpan={5} className="py-6">
-                  <EmptyState
-                    icon={MonitorPlay}
-                    title="No connected repositories"
-                    description="Connect a repository before configuring auto-preview policy."
-                    variant="inline"
-                  />
-                </TableCell>
-              </TableRow>
-            )}
-          </TableBody>
-        </Table>
-      </div>
-
-      <div className="space-y-3">
-        <div className="space-y-1">
-          <h3 className="text-sm font-medium text-foreground">
-            PR preview links
-          </h3>
-          <p className="text-xs text-muted-foreground">
-            Publish stable 143 preview entry points to GitHub pull requests.
-          </p>
+      {policiesQuery.isLoading ? (
+        <div className="rounded-md border border-border p-4 text-sm text-muted-foreground">
+          Loading preview policies...
         </div>
-        <div className="overflow-hidden rounded-md border border-border">
-          <Table>
-            <TableHeader className="hidden md:table-header-group">
-              <TableRow>
-                <TableHead>Repository</TableHead>
-                <TableHead>Links</TableHead>
-                <TableHead>Surfaces</TableHead>
-                <TableHead>Status</TableHead>
-              </TableRow>
-            </TableHeader>
-            <TableBody>
-              {policiesQuery.isLoading ? (
-                <TableRow>
-                  <TableCell colSpan={4} className="py-6 text-sm text-muted-foreground">
-                    Loading preview link policies...
-                  </TableCell>
-                </TableRow>
-              ) : policies.length ? (
-                policies.map((policy) => {
-                  const missingPermissions =
-                    (policy.github_pr_comment_enabled &&
-                      !policy.github_pr_comment_permission_ok) ||
-                    (policy.github_commit_status_enabled &&
-                      !policy.github_commit_status_permission_ok);
-                  const showTestPreview =
-                    policy.preview_configured &&
-                    (!policy.preview_success_recorded ||
-                      policy.preview_config_requires_selection);
-                  const selectedPreviewConfig =
-                    selectedPreviewConfigs[policy.repository_id] ||
-                    policy.preview_config_default_name ||
-                    policy.preview_config_names?.[0] ||
-                    "";
-                  const testPreviewDisabled =
-                    (testPreviewMutation.isPending && testPreviewMutation.variables?.repositoryId === policy.repository_id) ||
-                    Boolean(policy.preview_config_requires_selection && !selectedPreviewConfig);
-                  const disabledReason = !policy.preview_ready
-                    ? policy.preview_readiness_missing_reason || "Run a successful test preview before enabling GitHub PR links"
-                    : missingPermissions
-                      ? "GitHub App permissions are missing for one or more selected surfaces"
-                      : "";
-                  const canEnable = policy.preview_ready && !missingPermissions;
-                  return (
-                    <TableRow key={`${policy.repository_id}-links`} className="block border-b p-3 md:table-row md:p-0">
-                      <TableCell className="block px-0 py-1 md:table-cell md:px-4 md:py-3">
-                        <div className="flex items-center gap-2 font-medium text-foreground">
-                          <GitPullRequest className="h-4 w-4 text-muted-foreground" />
-                          {policy.repository_full_name}
-                        </div>
-                        {disabledReason ? (
-                          <p className="mt-1 text-xs text-muted-foreground">{disabledReason}</p>
-                        ) : null}
-                        {policy.preview_config_names?.length ? (
-                          <div className="mt-2 max-w-56">
-                            <Select
-                              value={selectedPreviewConfig}
-                              onValueChange={(value) => {
-                                setSelectedPreviewConfigs((current) => ({
-                                  ...current,
-                                  [policy.repository_id]: value,
-                                }));
-                              }}
-                            >
-                              <SelectTrigger
-                                aria-label={`Select preview config for ${policy.repository_full_name}`}
-                              >
-                                <SelectValue placeholder="Preview config" />
-                              </SelectTrigger>
-                              <SelectContent>
-                                {policy.preview_config_names.map((name) => (
-                                  <SelectItem key={name} value={name}>
-                                    {name}
-                                  </SelectItem>
-                                ))}
-                              </SelectContent>
-                            </Select>
-                          </div>
-                        ) : null}
-                        {showTestPreview ? (
-                          <Button
-                            type="button"
-                            size="sm"
-                            variant="outline"
-                            className="mt-2"
-                            disabled={testPreviewDisabled}
-                            onClick={() => {
-                              testPreviewMutation.mutate({
-                                repositoryId: policy.repository_id,
-                                previewConfigName: selectedPreviewConfig || undefined,
-                              });
-                            }}
-                          >
-                            <MonitorPlay className="mr-2 h-4 w-4" />
-                            Test preview
-                          </Button>
-                        ) : null}
-                      </TableCell>
-                      <TableCell className="block px-0 py-2 md:table-cell md:px-4 md:py-3">
-                        <div className="flex items-center gap-2">
-                          <Switch
-                            aria-label={`Enable PR preview links for ${policy.repository_full_name}`}
-                            checked={policy.pr_preview_surfaces_enabled}
-                            disabled={!canEnable && !policy.pr_preview_surfaces_enabled}
-                            onCheckedChange={(checked) => {
-                              policyMutation.mutate({
-                                repositoryId: policy.repository_id,
-                                body: { pr_preview_surfaces_enabled: checked },
-                              });
-                            }}
-                          />
-                          <span className="text-sm text-muted-foreground">
-                            {policy.pr_preview_surfaces_enabled ? "Enabled" : "Disabled"}
-                          </span>
-                        </div>
-                      </TableCell>
-                      <TableCell className="block px-0 py-2 md:table-cell md:px-4 md:py-3">
-                        <div className="flex flex-wrap gap-3">
-                          <div className="flex items-center gap-2 text-sm">
-                            <Switch
-                              aria-label={`Enable PR comment preview link for ${policy.repository_full_name}`}
-                              checked={policy.github_pr_comment_enabled}
-                              disabled={
-                                !policy.pr_preview_surfaces_enabled ||
-                                !policy.github_pr_comment_permission_ok
-                              }
-                              onCheckedChange={(checked) => {
-                                policyMutation.mutate({
-                                  repositoryId: policy.repository_id,
-                                  body: { github_pr_comment_enabled: checked },
-                                });
-                              }}
-                            />
-                            Comment
-                          </div>
-                          <div className="flex items-center gap-2 text-sm">
-                            <Switch
-                              aria-label={`Enable commit status preview link for ${policy.repository_full_name}`}
-                              checked={policy.github_commit_status_enabled}
-                              disabled={
-                                !policy.pr_preview_surfaces_enabled ||
-                                !policy.github_commit_status_permission_ok
-                              }
-                              onCheckedChange={(checked) => {
-                                policyMutation.mutate({
-                                  repositoryId: policy.repository_id,
-                                  body: { github_commit_status_enabled: checked },
-                                });
-                              }}
-                            />
-                            Status
-                          </div>
-                        </div>
-                      </TableCell>
-                      <TableCell className="block px-0 py-1 text-sm text-muted-foreground md:table-cell md:px-4 md:py-3">
-                        {policy.last_surface_sync_error ? (
-                          <span className="text-destructive">{policy.last_surface_sync_error}</span>
-                        ) : policy.last_surface_sync_at ? (
-                          `Synced ${new Date(policy.last_surface_sync_at).toLocaleDateString()}`
-                        ) : policy.preview_ready ? (
-                          "Ready"
-                        ) : (
-                          "Not ready"
-                        )}
-                      </TableCell>
-                    </TableRow>
-                  );
+      ) : policies.length ? (
+        <div className="space-y-3">
+          {policies.map((policy) => (
+            <RepoPreviewCard
+              key={policy.repository_id}
+              policy={policy}
+              sessionPrewarmEnabled={sessionPrewarmEnabled}
+              selectedPreviewConfig={
+                selectedPreviewConfigs[policy.repository_id] ||
+                policy.preview_config_name ||
+                policy.preview_config_default_name ||
+                policy.preview_config_names?.[0] ||
+                ""
+              }
+              onSelectPreviewConfig={(value) => {
+                // Optimistically reflect the choice, then persist it so both
+                // auto-built PR previews and Test preview use this profile.
+                setSelectedPreviewConfigs((current) => ({
+                  ...current,
+                  [policy.repository_id]: value,
+                }));
+                policyMutation.mutate({
+                  repositoryId: policy.repository_id,
+                  body: { preview_config_name: value },
+                });
+              }}
+              onUpdatePolicy={(body) =>
+                policyMutation.mutate({
+                  repositoryId: policy.repository_id,
+                  body,
                 })
-              ) : (
-                <TableRow>
-                  <TableCell colSpan={4} className="py-6">
-                    <EmptyState
-                      icon={GitPullRequest}
-                      title="No connected repositories"
-                      description="Connect a repository before configuring PR preview links."
-                      variant="inline"
-                    />
-                  </TableCell>
-                </TableRow>
-              )}
-            </TableBody>
-          </Table>
+              }
+              onTestPreview={(previewConfigName) =>
+                testPreviewMutation.mutate({
+                  repositoryId: policy.repository_id,
+                  previewConfigName,
+                })
+              }
+              testPreviewPending={
+                testPreviewMutation.isPending &&
+                testPreviewMutation.variables?.repositoryId ===
+                  policy.repository_id
+              }
+            />
+          ))}
         </div>
-      </div>
+      ) : (
+        <div className="rounded-md border border-border p-4">
+          <EmptyState
+            icon={MonitorPlay}
+            title="No connected repositories"
+            description="Connect a repository before configuring previews."
+            variant="inline"
+          />
+        </div>
+      )}
 
       <div className="space-y-3 rounded-md border border-border p-4">
         <div className="flex items-center justify-between">
@@ -672,6 +395,279 @@ function AutoPreviewSection() {
         </div>
       </div>
     </section>
+  );
+}
+
+function RepoPreviewCard({
+  policy,
+  sessionPrewarmEnabled,
+  selectedPreviewConfig,
+  onSelectPreviewConfig,
+  onUpdatePolicy,
+  onTestPreview,
+  testPreviewPending,
+}: {
+  policy: PreviewPolicySummary;
+  sessionPrewarmEnabled: boolean;
+  selectedPreviewConfig: string;
+  onSelectPreviewConfig: (value: string) => void;
+  onUpdatePolicy: (
+    body: Parameters<typeof api.previews.policies.update>[1],
+  ) => void;
+  onTestPreview: (previewConfigName?: string) => void;
+  testPreviewPending: boolean;
+}) {
+  const missingPermissions =
+    (policy.github_pr_comment_enabled &&
+      !policy.github_pr_comment_permission_ok) ||
+    (policy.github_commit_status_enabled &&
+      !policy.github_commit_status_permission_ok);
+  const showTestPreview =
+    policy.preview_configured &&
+    (!policy.preview_success_recorded ||
+      policy.preview_config_requires_selection);
+  const testPreviewDisabled =
+    testPreviewPending ||
+    Boolean(policy.preview_config_requires_selection && !selectedPreviewConfig);
+  const disabledReason = !policy.preview_ready
+    ? policy.preview_readiness_missing_reason ||
+      "Run a successful test preview before enabling GitHub PR links"
+    : missingPermissions
+      ? "GitHub App permissions are missing for one or more selected surfaces"
+      : "";
+  const canEnable = policy.preview_ready && !missingPermissions;
+  const configNames = policy.preview_config_names ?? [];
+  const defaultConfigName = policy.preview_config_default_name ?? "";
+
+  const statusBadge = policy.last_surface_sync_error ? (
+    <Badge variant="destructive">Sync failed</Badge>
+  ) : policy.preview_ready ? (
+    <Badge variant="success">
+      {policy.last_surface_sync_at
+        ? `Synced ${new Date(policy.last_surface_sync_at).toLocaleDateString()}`
+        : "Ready"}
+    </Badge>
+  ) : (
+    <Badge variant="secondary">Not ready</Badge>
+  );
+
+  return (
+    <div className="space-y-4 rounded-md border border-border p-4">
+      <div className="flex items-start justify-between gap-2">
+        <div className="flex min-w-0 items-center gap-2">
+          <MonitorPlay className="h-4 w-4 shrink-0 text-muted-foreground" />
+          <span className="truncate font-medium text-foreground">
+            {policy.repository_full_name}
+          </span>
+          <span className="shrink-0 text-xs text-muted-foreground">
+            · {policy.open_pr_count}{" "}
+            {policy.open_pr_count === 1 ? "open PR" : "open PRs"}
+          </span>
+        </div>
+        {statusBadge}
+      </div>
+
+      <div className="grid gap-4 md:grid-cols-2">
+        <div className="space-y-3">
+          <div className="text-xs font-medium text-muted-foreground">
+            1 · Auto-build
+          </div>
+          <div className="space-y-1.5">
+            <span className="block text-xs text-muted-foreground">Mode</span>
+            <ToggleGroup
+              type="single"
+              value={policy.auto_mode}
+              onValueChange={(value) => {
+                if (!value || value === policy.auto_mode) return;
+                onUpdatePolicy({
+                  auto_mode: value as PreviewPolicySummary["auto_mode"],
+                });
+              }}
+              className="justify-start"
+            >
+              <ToggleGroupItem
+                value="off"
+                aria-label={`Turn off auto-preview for ${policy.repository_full_name}`}
+              >
+                Off
+              </ToggleGroupItem>
+              <ToggleGroupItem
+                value="warm"
+                aria-label={`Use warm auto-preview for ${policy.repository_full_name}`}
+              >
+                Warm
+              </ToggleGroupItem>
+              <ToggleGroupItem
+                value="on"
+                aria-label={`Keep auto-preview on for ${policy.repository_full_name}`}
+              >
+                On
+              </ToggleGroupItem>
+            </ToggleGroup>
+          </div>
+          <div className="space-y-1.5">
+            <span className="block text-xs text-muted-foreground">
+              Session prewarm
+            </span>
+            <ToggleGroup
+              type="single"
+              value={policy.session_prewarm_mode}
+              onValueChange={(value) => {
+                if (
+                  !value ||
+                  value === policy.session_prewarm_mode ||
+                  !sessionPrewarmEnabled
+                ) {
+                  return;
+                }
+                onUpdatePolicy({
+                  session_prewarm_mode:
+                    value as PreviewPolicySummary["session_prewarm_mode"],
+                });
+              }}
+              className="justify-start"
+              disabled={!sessionPrewarmEnabled}
+            >
+              <ToggleGroupItem
+                value="off"
+                aria-label={`Turn off session prewarm for ${policy.repository_full_name}`}
+              >
+                Off
+              </ToggleGroupItem>
+              <ToggleGroupItem
+                value="cache"
+                aria-label={`Use cache-only session prewarm for ${policy.repository_full_name}`}
+              >
+                Cache only
+              </ToggleGroupItem>
+              <ToggleGroupItem
+                value="smart"
+                aria-label={`Use smart session prewarm for ${policy.repository_full_name}`}
+              >
+                Smart
+              </ToggleGroupItem>
+            </ToggleGroup>
+            {!sessionPrewarmEnabled ? (
+              <p className="text-xs text-muted-foreground">
+                Set speculative preview slots above 0 to enable session prewarm.
+              </p>
+            ) : null}
+          </div>
+        </div>
+
+        <div className="space-y-3 md:border-l md:border-border md:pl-4">
+          <div className="text-xs font-medium text-muted-foreground">
+            2 · Publish to PRs
+          </div>
+          {disabledReason ? (
+            <div className="flex items-start gap-2 rounded-md bg-muted px-2.5 py-2 text-xs text-muted-foreground">
+              <HelpCircle className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+              <span>{disabledReason}</span>
+            </div>
+          ) : null}
+          {policy.last_surface_sync_error ? (
+            <p className="text-xs text-destructive">
+              {policy.last_surface_sync_error}
+            </p>
+          ) : null}
+          <div className="flex items-center gap-2">
+            <Switch
+              aria-label={`Enable PR preview links for ${policy.repository_full_name}`}
+              checked={policy.pr_preview_surfaces_enabled}
+              disabled={!canEnable && !policy.pr_preview_surfaces_enabled}
+              onCheckedChange={(checked) =>
+                onUpdatePolicy({ pr_preview_surfaces_enabled: checked })
+              }
+            />
+            <span className="text-xs text-muted-foreground">
+              {policy.pr_preview_surfaces_enabled
+                ? "Links enabled"
+                : "Links disabled"}
+            </span>
+          </div>
+          <div className="space-y-1.5">
+            <span className="block text-xs text-muted-foreground">Surfaces</span>
+            <div className="flex flex-wrap gap-3">
+              <div className="flex items-center gap-2 text-xs">
+                <Switch
+                  aria-label={`Enable PR comment preview link for ${policy.repository_full_name}`}
+                  checked={policy.github_pr_comment_enabled}
+                  disabled={
+                    !policy.pr_preview_surfaces_enabled ||
+                    !policy.github_pr_comment_permission_ok
+                  }
+                  onCheckedChange={(checked) =>
+                    onUpdatePolicy({ github_pr_comment_enabled: checked })
+                  }
+                />
+                Comment
+              </div>
+              <div className="flex items-center gap-2 text-xs">
+                <Switch
+                  aria-label={`Enable commit status preview link for ${policy.repository_full_name}`}
+                  checked={policy.github_commit_status_enabled}
+                  disabled={
+                    !policy.pr_preview_surfaces_enabled ||
+                    !policy.github_commit_status_permission_ok
+                  }
+                  onCheckedChange={(checked) =>
+                    onUpdatePolicy({ github_commit_status_enabled: checked })
+                  }
+                />
+                Status
+              </div>
+            </div>
+          </div>
+          {showTestPreview ? (
+            <Button
+              type="button"
+              size="sm"
+              variant="outline"
+              disabled={testPreviewDisabled}
+              onClick={() => onTestPreview(selectedPreviewConfig || undefined)}
+            >
+              <MonitorPlay className="mr-2 h-4 w-4" />
+              Test preview
+            </Button>
+          ) : null}
+        </div>
+      </div>
+
+      {configNames.length ? (
+        <div className="flex flex-wrap items-center gap-2 border-t border-border pt-3">
+          <span className="text-xs text-muted-foreground">Build profile</span>
+          {configNames.length > 1 ? (
+            <Select
+              value={selectedPreviewConfig}
+              onValueChange={onSelectPreviewConfig}
+            >
+              <SelectTrigger
+                size="sm"
+                className="w-auto min-w-40"
+                aria-label={`Select build profile for ${policy.repository_full_name}`}
+              >
+                <SelectValue placeholder="Build profile" />
+              </SelectTrigger>
+              <SelectContent>
+                {configNames.map((name) => (
+                  <SelectItem key={name} value={name}>
+                    {name}
+                    {name === defaultConfigName ? " (default)" : ""}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          ) : (
+            <span className="text-xs font-medium text-foreground">
+              {configNames[0]}
+            </span>
+          )}
+          <span className="text-xs text-muted-foreground">
+            from <code className="font-mono text-xs">.143/config.json</code>
+          </span>
+        </div>
+      ) : null}
+    </div>
   );
 }
 

--- a/frontend/src/app/(dashboard)/settings/previews/page.tsx
+++ b/frontend/src/app/(dashboard)/settings/previews/page.tsx
@@ -290,14 +290,31 @@ function AutoPreviewSection() {
               onSelectPreviewConfig={(value) => {
                 // Optimistically reflect the choice, then persist it so both
                 // auto-built PR previews and Test preview use this profile.
+                const previous = selectedPreviewConfigs[policy.repository_id];
                 setSelectedPreviewConfigs((current) => ({
                   ...current,
                   [policy.repository_id]: value,
                 }));
-                policyMutation.mutate({
-                  repositoryId: policy.repository_id,
-                  body: { preview_config_name: value },
-                });
+                policyMutation.mutate(
+                  {
+                    repositoryId: policy.repository_id,
+                    body: { preview_config_name: value },
+                  },
+                  {
+                    // Revert the optimistic selection if the save fails, so the
+                    // dropdown never shows an unpersisted profile.
+                    onError: () =>
+                      setSelectedPreviewConfigs((current) => {
+                        const next = { ...current };
+                        if (previous === undefined) {
+                          delete next[policy.repository_id];
+                        } else {
+                          next[policy.repository_id] = previous;
+                        }
+                        return next;
+                      }),
+                  },
+                );
               }}
               onUpdatePolicy={(body) =>
                 policyMutation.mutate({

--- a/frontend/src/components/settings/verified-domains-section.test.tsx
+++ b/frontend/src/components/settings/verified-domains-section.test.tsx
@@ -58,7 +58,7 @@ describe("VerifiedDomainsSection", () => {
 
     renderWithProviders(<VerifiedDomainsSection />);
 
-    expect(await screen.findByText(/Install the GitHub App on a GitHub organization/)).toBeInTheDocument();
+    expect(await screen.findByText(/GitHub is connected, but the app isn't installed on a GitHub organization/)).toBeInTheDocument();
     expect(screen.queryByText(/Connect GitHub to enable organization-based auto-join/)).not.toBeInTheDocument();
   });
 

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -344,6 +344,7 @@ export const api = {
         pr_preview_surfaces_enabled?: boolean;
         github_pr_comment_enabled?: boolean;
         github_commit_status_enabled?: boolean;
+        preview_config_name?: string;
       }) =>
         request<import('./types').SingleResponse<unknown>>(`/api/v1/repositories/${repositoryId}/preview-policy`, {
           method: 'PUT',

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -396,6 +396,7 @@ export interface PreviewPolicySummary {
   pr_preview_surfaces_enabled: boolean;
   github_pr_comment_enabled: boolean;
   github_commit_status_enabled: boolean;
+  preview_config_name?: string;
   preview_configured: boolean;
   preview_success_recorded: boolean;
   preview_config_names?: string[];

--- a/internal/api/handlers/branch_previews.go
+++ b/internal/api/handlers/branch_previews.go
@@ -284,6 +284,7 @@ type updatePreviewPolicyRequest struct {
 	PRPreviewSurfacesEnabled  *bool                             `json:"pr_preview_surfaces_enabled"`
 	GitHubPRCommentEnabled    *bool                             `json:"github_pr_comment_enabled"`
 	GitHubCommitStatusEnabled *bool                             `json:"github_commit_status_enabled"`
+	PreviewConfigName         *string                           `json:"preview_config_name"`
 }
 
 type testPreviewPolicyRequest struct {
@@ -1357,6 +1358,11 @@ func (h *BranchPreviewHandler) StartAutoPullRequestPreview(ctx context.Context, 
 			SourceURL:       htmlURL,
 			CreatedByUserID: userID,
 		}
+		// Honor the repository's saved build profile so auto-built PR previews
+		// use the same named config as the settings page selection.
+		if policy, policyErr := h.previews.GetRepositoryPreviewPolicy(ctx, orgID, repo.ID); policyErr == nil && policy != nil {
+			target.PreviewConfigName = policy.PreviewConfigName
+		}
 		if err := h.previews.CreatePreviewTarget(ctx, target); err != nil {
 			return fmt.Errorf("create auto preview target: %w", err)
 		}
@@ -2224,9 +2230,13 @@ func (h *BranchPreviewHandler) UpdatePolicy(w http.ResponseWriter, r *http.Reque
 		writeError(w, r, http.StatusBadRequest, "INVALID_JSON", "invalid request body")
 		return
 	}
-	if req.AutoMode == nil && req.SessionPrewarmMode == nil && req.PRPreviewSurfacesEnabled == nil && req.GitHubPRCommentEnabled == nil && req.GitHubCommitStatusEnabled == nil {
+	if req.AutoMode == nil && req.SessionPrewarmMode == nil && req.PRPreviewSurfacesEnabled == nil && req.GitHubPRCommentEnabled == nil && req.GitHubCommitStatusEnabled == nil && req.PreviewConfigName == nil {
 		writeError(w, r, http.StatusBadRequest, "INVALID_PREVIEW_POLICY", "at least one preview policy field is required")
 		return
+	}
+	if req.PreviewConfigName != nil {
+		trimmed := strings.TrimSpace(*req.PreviewConfigName)
+		req.PreviewConfigName = &trimmed
 	}
 	if req.AutoMode != nil {
 		if err := req.AutoMode.Validate(); err != nil {
@@ -2264,12 +2274,14 @@ func (h *BranchPreviewHandler) UpdatePolicy(w http.ResponseWriter, r *http.Reque
 	beforeSurfaces := false
 	beforeComment := true
 	beforeStatus := true
+	beforeConfigName := ""
 	if existing, existingErr := h.previews.GetRepositoryPreviewPolicy(r.Context(), orgID, repoID); existingErr == nil && existing != nil {
 		beforeMode = existing.AutoMode
 		beforeSessionPrewarmMode = existing.SessionPrewarmMode
 		beforeSurfaces = existing.PRPreviewSurfacesEnabled
 		beforeComment = existing.GitHubPRCommentEnabled
 		beforeStatus = existing.GitHubCommitStatusEnabled
+		beforeConfigName = existing.PreviewConfigName
 	} else if existingErr != nil && !errors.Is(existingErr, pgx.ErrNoRows) {
 		writeError(w, r, http.StatusInternalServerError, "PREVIEW_POLICY_LOOKUP_FAILED", "failed to load preview policy", existingErr)
 		return
@@ -2309,6 +2321,7 @@ func (h *BranchPreviewHandler) UpdatePolicy(w http.ResponseWriter, r *http.Reque
 		PRPreviewSurfacesEnabled:  req.PRPreviewSurfacesEnabled,
 		GitHubPRCommentEnabled:    req.GitHubPRCommentEnabled,
 		GitHubCommitStatusEnabled: req.GitHubCommitStatusEnabled,
+		PreviewConfigName:         req.PreviewConfigName,
 	})
 	if err != nil {
 		if errors.Is(err, db.ErrPreviewNotReady) {
@@ -2334,6 +2347,9 @@ func (h *BranchPreviewHandler) UpdatePolicy(w http.ResponseWriter, r *http.Reque
 		}
 		if req.GitHubCommitStatusEnabled != nil {
 			changes["github_commit_status_enabled"] = map[string]any{"before": beforeStatus, "after": policy.GitHubCommitStatusEnabled}
+		}
+		if req.PreviewConfigName != nil {
+			changes["preview_config_name"] = map[string]any{"before": beforeConfigName, "after": policy.PreviewConfigName}
 		}
 		details, marshalErr := json.Marshal(map[string]any{
 			"repository_id": repoID.String(),

--- a/internal/api/handlers/branch_previews.go
+++ b/internal/api/handlers/branch_previews.go
@@ -1307,7 +1307,7 @@ func (h *BranchPreviewHandler) selectBranchPreviewWorker(ctx context.Context, or
 	return branchPreviewWorkerSelection{worker: worker}, nil
 }
 
-func (h *BranchPreviewHandler) StartAutoPullRequestPreview(ctx context.Context, orgID, userID uuid.UUID, repo models.Repository, prNumber int, headRef, headSHA, htmlURL string, mode models.PreviewAutoMode) error {
+func (h *BranchPreviewHandler) StartAutoPullRequestPreview(ctx context.Context, orgID, userID uuid.UUID, repo models.Repository, prNumber int, headRef, headSHA, htmlURL string, mode models.PreviewAutoMode, previewConfigName string) error {
 	if h == nil || h.previews == nil {
 		return fmt.Errorf("preview handler is not configured")
 	}
@@ -1326,14 +1326,15 @@ func (h *BranchPreviewHandler) StartAutoPullRequestPreview(ctx context.Context, 
 		metrics.RecordPreviewAutoBuild(ctx, orgID.String(), string(mode), "pool_full")
 		if h.jobs != nil {
 			deferredPayload := preview.AutoPreviewDeferredPayload{
-				OrgID:        orgID,
-				UserID:       userID,
-				RepositoryID: repo.ID,
-				PRNumber:     prNumber,
-				HeadRef:      headRef,
-				HeadSHA:      headSHA,
-				HTMLURL:      htmlURL,
-				Mode:         mode,
+				OrgID:             orgID,
+				UserID:            userID,
+				RepositoryID:      repo.ID,
+				PRNumber:          prNumber,
+				HeadRef:           headRef,
+				HeadSHA:           headSHA,
+				HTMLURL:           htmlURL,
+				Mode:              mode,
+				PreviewConfigName: previewConfigName,
 			}
 			dedupeKey := fmt.Sprintf("auto_preview_deferred:%s:%s:%d:%s", orgID, repo.ID, prNumber, headSHA)
 			if _, err := h.jobs.Enqueue(ctx, orgID, "preview", models.JobTypeAutoPreviewDeferred, deferredPayload, 4, &dedupeKey); err != nil {
@@ -1357,11 +1358,9 @@ func (h *BranchPreviewHandler) StartAutoPullRequestPreview(ctx context.Context, 
 			SourceID:        sourceID,
 			SourceURL:       htmlURL,
 			CreatedByUserID: userID,
-		}
-		// Honor the repository's saved build profile so auto-built PR previews
-		// use the same named config as the settings page selection.
-		if policy, policyErr := h.previews.GetRepositoryPreviewPolicy(ctx, orgID, repo.ID); policyErr == nil && policy != nil {
-			target.PreviewConfigName = policy.PreviewConfigName
+			// Honor the repository's saved build profile so auto-built PR
+			// previews use the same named config as the settings page selection.
+			PreviewConfigName: previewConfigName,
 		}
 		if err := h.previews.CreatePreviewTarget(ctx, target); err != nil {
 			return fmt.Errorf("create auto preview target: %w", err)

--- a/internal/api/handlers/branch_previews_test.go
+++ b/internal/api/handlers/branch_previews_test.go
@@ -42,8 +42,8 @@ func (f fakeBranchPreviewGitHubWithDetails) GetInstallationDetails(context.Conte
 
 type fakeBranchPreviewGitHubWithErrors struct {
 	fakeBranchPreviewGitHub
-	tokenErr      error
-	configErr     error
+	tokenErr  error
+	configErr error
 }
 
 func (f fakeBranchPreviewGitHubWithErrors) GetInstallationToken(context.Context, int64) (string, error) {
@@ -1467,9 +1467,9 @@ func TestBranchPreviewHandler_UpdatePolicyEmitsAudit(t *testing.T) {
 		WithArgs(previewHandlerAnyArgs(2)...).
 		WillReturnRows(pgxmock.NewRows(repositoryPreviewPolicyTestCols()))
 	mock.ExpectQuery("INSERT INTO repository_preview_policies").
-		WithArgs(previewHandlerAnyArgs(8)...).
+		WithArgs(previewHandlerAnyArgs(9)...).
 		WillReturnRows(pgxmock.NewRows(repositoryPreviewPolicyTestCols()).
-			AddRow(policyID, orgID, repoID, string(models.PreviewAutoModeWarm), string(models.PreviewSessionPrewarmModeOff), false, true, true, userID, now, now))
+			AddRow(policyID, orgID, repoID, string(models.PreviewAutoModeWarm), string(models.PreviewSessionPrewarmModeOff), false, true, true, "", userID, now, now))
 	expectAuditInsert(mock)
 
 	req := httptest.NewRequest(http.MethodPut, "/api/v1/repositories/"+repoID.String()+"/preview-policy", bytes.NewBufferString(`{"auto_mode":"warm"}`))
@@ -1566,11 +1566,11 @@ func TestBranchPreviewHandler_UpdatePolicySessionPrewarmOnlyPreservesAutoMode(t 
 	mock.ExpectQuery("SELECT .+ FROM repository_preview_policies").
 		WithArgs(previewHandlerAnyArgs(2)...).
 		WillReturnRows(pgxmock.NewRows(repositoryPreviewPolicyTestCols()).
-			AddRow(policyID, orgID, repoID, string(models.PreviewAutoModeWarm), string(models.PreviewSessionPrewarmModeOff), false, true, true, userID, now, now))
+			AddRow(policyID, orgID, repoID, string(models.PreviewAutoModeWarm), string(models.PreviewSessionPrewarmModeOff), false, true, true, "", userID, now, now))
 	mock.ExpectQuery("INSERT INTO repository_preview_policies").
-		WithArgs(previewHandlerAnyArgs(8)...).
+		WithArgs(previewHandlerAnyArgs(9)...).
 		WillReturnRows(pgxmock.NewRows(repositoryPreviewPolicyTestCols()).
-			AddRow(policyID, orgID, repoID, string(models.PreviewAutoModeWarm), string(models.PreviewSessionPrewarmModeSmart), false, true, true, userID, now, now))
+			AddRow(policyID, orgID, repoID, string(models.PreviewAutoModeWarm), string(models.PreviewSessionPrewarmModeSmart), false, true, true, "", userID, now, now))
 	expectAuditInsert(mock)
 
 	req := httptest.NewRequest(http.MethodPut, "/api/v1/repositories/"+repoID.String()+"/preview-policy", bytes.NewBufferString(`{"session_prewarm_mode":"smart"}`))
@@ -1688,7 +1688,7 @@ func TestGitHubPreviewSurfacePermissionHelpers(t *testing.T) {
 }
 
 func repositoryPreviewPolicyTestCols() []string {
-	return []string{"id", "org_id", "repository_id", "auto_mode", "session_prewarm_mode", "pr_preview_surfaces_enabled", "github_pr_comment_enabled", "github_commit_status_enabled", "updated_by_user_id", "created_at", "updated_at"}
+	return []string{"id", "org_id", "repository_id", "auto_mode", "session_prewarm_mode", "pr_preview_surfaces_enabled", "github_pr_comment_enabled", "github_commit_status_enabled", "preview_config_name", "updated_by_user_id", "created_at", "updated_at"}
 }
 
 func repositoryTestCols() []string {
@@ -2986,9 +2986,9 @@ func TestEnrichPreviewPolicyConfigReadiness_PreservesReadinessOnTransientError(t
 		DefaultBranch: "main",
 	}
 	policy := &models.RepositoryPreviewPolicySummary{
-		PreviewConfigured:    true,
+		PreviewConfigured:      true,
 		PreviewSuccessRecorded: true,
-		PreviewReady:         true,
+		PreviewReady:           true,
 	}
 
 	handler.enrichPreviewPolicyConfigReadiness(context.Background(), repo, policy)
@@ -3025,9 +3025,9 @@ func TestEnrichPreviewPolicyConfigReadiness_SetsNotConfiguredOnMissingFile(t *te
 		DefaultBranch: "main",
 	}
 	policy := &models.RepositoryPreviewPolicySummary{
-		PreviewConfigured:    true,
+		PreviewConfigured:      true,
 		PreviewSuccessRecorded: true,
-		PreviewReady:         true,
+		PreviewReady:           true,
 	}
 
 	handler.enrichPreviewPolicyConfigReadiness(context.Background(), repo, policy)

--- a/internal/db/preview_store.go
+++ b/internal/db/preview_store.go
@@ -131,7 +131,7 @@ const previewStartupCacheColumns = `id, org_id, repo_id, snapshot_key, base_key,
 
 const repositoryPreviewPolicyColumns = `id, org_id, repository_id, auto_mode,
 	session_prewarm_mode, pr_preview_surfaces_enabled, github_pr_comment_enabled, github_commit_status_enabled,
-	updated_by_user_id, created_at, updated_at`
+	preview_config_name, updated_by_user_id, created_at, updated_at`
 
 const previewDependencyCacheColumns = `id, org_id, repo_id, cache_kind, cache_key, placement_key,
 	blob_key, size_bytes, metadata, last_used_at, created_at`
@@ -632,6 +632,7 @@ type RepositoryPreviewPolicyPatch struct {
 	PRPreviewSurfacesEnabled  *bool
 	GitHubPRCommentEnabled    *bool
 	GitHubCommitStatusEnabled *bool
+	PreviewConfigName         *string
 }
 
 // UpsertRepositoryPreviewPolicy stores preview policy for one repository.
@@ -659,7 +660,7 @@ func (s *PreviewStore) UpsertRepositoryPreviewPolicy(ctx context.Context, orgID,
 		INSERT INTO repository_preview_policies (
 			org_id, repository_id, auto_mode, session_prewarm_mode,
 			pr_preview_surfaces_enabled, github_pr_comment_enabled, github_commit_status_enabled,
-			updated_by_user_id
+			preview_config_name, updated_by_user_id
 		) VALUES (
 			@org_id, @repository_id,
 			COALESCE(@auto_mode, 'off'),
@@ -667,6 +668,7 @@ func (s *PreviewStore) UpsertRepositoryPreviewPolicy(ctx context.Context, orgID,
 			COALESCE(@pr_preview_surfaces_enabled, false),
 			COALESCE(@github_pr_comment_enabled, true),
 			COALESCE(@github_commit_status_enabled, true),
+			COALESCE(@preview_config_name, ''),
 			@updated_by_user_id
 		)
 		ON CONFLICT (org_id, repository_id)
@@ -676,6 +678,7 @@ func (s *PreviewStore) UpsertRepositoryPreviewPolicy(ctx context.Context, orgID,
 			pr_preview_surfaces_enabled = COALESCE(@pr_preview_surfaces_enabled, repository_preview_policies.pr_preview_surfaces_enabled),
 			github_pr_comment_enabled = COALESCE(@github_pr_comment_enabled, repository_preview_policies.github_pr_comment_enabled),
 			github_commit_status_enabled = COALESCE(@github_commit_status_enabled, repository_preview_policies.github_commit_status_enabled),
+			preview_config_name = COALESCE(@preview_config_name, repository_preview_policies.preview_config_name),
 			updated_by_user_id = EXCLUDED.updated_by_user_id,
 			updated_at = now()
 		RETURNING %s`, repositoryPreviewPolicyColumns)
@@ -687,6 +690,7 @@ func (s *PreviewStore) UpsertRepositoryPreviewPolicy(ctx context.Context, orgID,
 		"pr_preview_surfaces_enabled":  patch.PRPreviewSurfacesEnabled,
 		"github_pr_comment_enabled":    patch.GitHubPRCommentEnabled,
 		"github_commit_status_enabled": patch.GitHubCommitStatusEnabled,
+		"preview_config_name":          patch.PreviewConfigName,
 		"updated_by_user_id":           userID,
 	})
 	if err != nil {
@@ -736,6 +740,7 @@ func (s *PreviewStore) ListRepositoryPreviewPolicies(ctx context.Context, orgID 
 			COALESCE(policy.pr_preview_surfaces_enabled, false) AS pr_preview_surfaces_enabled,
 			COALESCE(policy.github_pr_comment_enabled, true) AS github_pr_comment_enabled,
 			COALESCE(policy.github_commit_status_enabled, true) AS github_commit_status_enabled,
+			COALESCE(policy.preview_config_name, '') AS preview_config_name,
 			COALESCE(readiness.has_config, false) AS preview_configured,
 			COALESCE(readiness.has_success, false) AS preview_success_recorded,
 			COALESCE(readiness.preview_ready, false) AS preview_ready,

--- a/internal/db/preview_store_test.go
+++ b/internal/db/preview_store_test.go
@@ -82,7 +82,7 @@ var previewStartupCacheTestCols = []string{
 var repositoryPreviewPolicyTestCols = []string{
 	"id", "org_id", "repository_id", "auto_mode", "session_prewarm_mode",
 	"pr_preview_surfaces_enabled", "github_pr_comment_enabled", "github_commit_status_enabled",
-	"updated_by_user_id", "created_at", "updated_at",
+	"preview_config_name", "updated_by_user_id", "created_at", "updated_at",
 }
 
 var sessionPreviewPrewarmRunTestCols = []string{
@@ -115,9 +115,9 @@ func TestPreviewStore_UpsertRepositoryPreviewPolicy_PreservesUnspecifiedModes(t 
 	sessionMode := models.PreviewSessionPrewarmModeSmart
 
 	mock.ExpectQuery("INSERT INTO repository_preview_policies").
-		WithArgs(previewAnyArgs(8)...).
+		WithArgs(previewAnyArgs(9)...).
 		WillReturnRows(pgxmock.NewRows(repositoryPreviewPolicyTestCols).
-			AddRow(policyID, orgID, repoID, string(models.PreviewAutoModeWarm), string(sessionMode), false, true, true, userID, now, now))
+			AddRow(policyID, orgID, repoID, string(models.PreviewAutoModeWarm), string(sessionMode), false, true, true, "", userID, now, now))
 
 	policy, err := store.UpsertRepositoryPreviewPolicy(context.Background(), orgID, repoID, userID, RepositoryPreviewPolicyPatch{SessionPrewarmMode: &sessionMode})
 	require.NoError(t, err, "UpsertRepositoryPreviewPolicy should accept a session-only update")

--- a/internal/models/preview.go
+++ b/internal/models/preview.go
@@ -208,28 +208,32 @@ type RepositoryPreviewPolicy struct {
 // RepositoryPreviewPolicySummary is the settings-page view of repository
 // policy with repository identity and PR volume.
 type RepositoryPreviewPolicySummary struct {
-	RepositoryID                   uuid.UUID                 `db:"repository_id" json:"repository_id"`
-	RepositoryFullName             string                    `db:"repository_full_name" json:"repository_full_name"`
-	AutoMode                       PreviewAutoMode           `db:"auto_mode" json:"auto_mode"`
-	SessionPrewarmMode             PreviewSessionPrewarmMode `db:"session_prewarm_mode" json:"session_prewarm_mode"`
-	PRPreviewSurfacesEnabled       bool                      `db:"pr_preview_surfaces_enabled" json:"pr_preview_surfaces_enabled"`
-	GitHubPRCommentEnabled         bool                      `db:"github_pr_comment_enabled" json:"github_pr_comment_enabled"`
-	GitHubCommitStatusEnabled      bool                      `db:"github_commit_status_enabled" json:"github_commit_status_enabled"`
-	PreviewConfigName              string                    `db:"preview_config_name" json:"preview_config_name,omitempty"`
-	PreviewConfigured              bool                      `db:"preview_configured" json:"preview_configured"`
-	PreviewSuccessRecorded         bool                      `db:"preview_success_recorded" json:"preview_success_recorded"`
-	PreviewConfigNames             []string                  `db:"-" json:"preview_config_names,omitempty"`
-	PreviewConfigDefaultName       string                    `db:"-" json:"preview_config_default_name,omitempty"`
-	PreviewConfigRequiresSelection bool                      `db:"-" json:"preview_config_requires_selection,omitempty"`
-	PreviewReady                   bool                      `db:"preview_ready" json:"preview_ready"`
-	PreviewReadinessMissingReason  string                    `db:"preview_readiness_missing_reason" json:"preview_readiness_missing_reason,omitempty"`
-	GitHubPRCommentPermissionOK    bool                      `db:"github_pr_comment_permission_ok" json:"github_pr_comment_permission_ok"`
-	GitHubCommitStatusPermissionOK bool                      `db:"github_commit_status_permission_ok" json:"github_commit_status_permission_ok"`
-	LastSurfaceSyncSHA             string                    `db:"last_surface_sync_sha" json:"last_surface_sync_sha,omitempty"`
-	LastSurfaceSyncAt              *time.Time                `db:"last_surface_sync_at" json:"last_surface_sync_at,omitempty"`
-	LastSurfaceSyncError           string                    `db:"last_surface_sync_error" json:"last_surface_sync_error,omitempty"`
-	OpenPRCount                    int                       `db:"open_pr_count" json:"open_pr_count"`
-	UpdatedAt                      *time.Time                `db:"updated_at" json:"updated_at,omitempty"`
+	RepositoryID              uuid.UUID                 `db:"repository_id" json:"repository_id"`
+	RepositoryFullName        string                    `db:"repository_full_name" json:"repository_full_name"`
+	AutoMode                  PreviewAutoMode           `db:"auto_mode" json:"auto_mode"`
+	SessionPrewarmMode        PreviewSessionPrewarmMode `db:"session_prewarm_mode" json:"session_prewarm_mode"`
+	PRPreviewSurfacesEnabled  bool                      `db:"pr_preview_surfaces_enabled" json:"pr_preview_surfaces_enabled"`
+	GitHubPRCommentEnabled    bool                      `db:"github_pr_comment_enabled" json:"github_pr_comment_enabled"`
+	GitHubCommitStatusEnabled bool                      `db:"github_commit_status_enabled" json:"github_commit_status_enabled"`
+	// PreviewConfigName is the saved build profile for this repository (the
+	// settings-page selection). Distinct from PreviewConfigNames (the profiles
+	// available in .143/config.json) and PreviewConfigDefaultName (that file's
+	// own default).
+	PreviewConfigName              string     `db:"preview_config_name" json:"preview_config_name,omitempty"`
+	PreviewConfigured              bool       `db:"preview_configured" json:"preview_configured"`
+	PreviewSuccessRecorded         bool       `db:"preview_success_recorded" json:"preview_success_recorded"`
+	PreviewConfigNames             []string   `db:"-" json:"preview_config_names,omitempty"`
+	PreviewConfigDefaultName       string     `db:"-" json:"preview_config_default_name,omitempty"`
+	PreviewConfigRequiresSelection bool       `db:"-" json:"preview_config_requires_selection,omitempty"`
+	PreviewReady                   bool       `db:"preview_ready" json:"preview_ready"`
+	PreviewReadinessMissingReason  string     `db:"preview_readiness_missing_reason" json:"preview_readiness_missing_reason,omitempty"`
+	GitHubPRCommentPermissionOK    bool       `db:"github_pr_comment_permission_ok" json:"github_pr_comment_permission_ok"`
+	GitHubCommitStatusPermissionOK bool       `db:"github_commit_status_permission_ok" json:"github_commit_status_permission_ok"`
+	LastSurfaceSyncSHA             string     `db:"last_surface_sync_sha" json:"last_surface_sync_sha,omitempty"`
+	LastSurfaceSyncAt              *time.Time `db:"last_surface_sync_at" json:"last_surface_sync_at,omitempty"`
+	LastSurfaceSyncError           string     `db:"last_surface_sync_error" json:"last_surface_sync_error,omitempty"`
+	OpenPRCount                    int        `db:"open_pr_count" json:"open_pr_count"`
+	UpdatedAt                      *time.Time `db:"updated_at" json:"updated_at,omitempty"`
 }
 
 // PreviewLink is a stable app-owned URL mapping to a branch preview target.

--- a/internal/models/preview.go
+++ b/internal/models/preview.go
@@ -199,6 +199,7 @@ type RepositoryPreviewPolicy struct {
 	PRPreviewSurfacesEnabled  bool                      `db:"pr_preview_surfaces_enabled" json:"pr_preview_surfaces_enabled"`
 	GitHubPRCommentEnabled    bool                      `db:"github_pr_comment_enabled" json:"github_pr_comment_enabled"`
 	GitHubCommitStatusEnabled bool                      `db:"github_commit_status_enabled" json:"github_commit_status_enabled"`
+	PreviewConfigName         string                    `db:"preview_config_name" json:"preview_config_name,omitempty"`
 	UpdatedByUserID           uuid.UUID                 `db:"updated_by_user_id" json:"updated_by_user_id"`
 	CreatedAt                 time.Time                 `db:"created_at" json:"created_at"`
 	UpdatedAt                 time.Time                 `db:"updated_at" json:"updated_at"`
@@ -214,6 +215,7 @@ type RepositoryPreviewPolicySummary struct {
 	PRPreviewSurfacesEnabled       bool                      `db:"pr_preview_surfaces_enabled" json:"pr_preview_surfaces_enabled"`
 	GitHubPRCommentEnabled         bool                      `db:"github_pr_comment_enabled" json:"github_pr_comment_enabled"`
 	GitHubCommitStatusEnabled      bool                      `db:"github_commit_status_enabled" json:"github_commit_status_enabled"`
+	PreviewConfigName              string                    `db:"preview_config_name" json:"preview_config_name,omitempty"`
 	PreviewConfigured              bool                      `db:"preview_configured" json:"preview_configured"`
 	PreviewSuccessRecorded         bool                      `db:"preview_success_recorded" json:"preview_success_recorded"`
 	PreviewConfigNames             []string                  `db:"-" json:"preview_config_names,omitempty"`

--- a/internal/services/github/pr.go
+++ b/internal/services/github/pr.go
@@ -59,7 +59,7 @@ type PreviewStopper interface {
 // concrete implementation lives in the API/preview layer so this package can
 // own webhook policy decisions without importing the preview package.
 type AutoPreviewStarter interface {
-	StartAutoPullRequestPreview(ctx context.Context, orgID, userID uuid.UUID, repo models.Repository, prNumber int, headRef, headSHA, htmlURL string, mode models.PreviewAutoMode) error
+	StartAutoPullRequestPreview(ctx context.Context, orgID, userID uuid.UUID, repo models.Repository, prNumber int, headRef, headSHA, htmlURL string, mode models.PreviewAutoMode, previewConfigName string) error
 }
 
 type SyncPRPreviewSurfacesPayload struct {
@@ -1750,7 +1750,7 @@ func (s *PRService) handleAutoPreviewEvent(ctx context.Context, event PullReques
 				Msg("failed to update preview group latest sha on pr event")
 		}
 	}
-	return s.autoPreviewStarter.StartAutoPullRequestPreview(ctx, repo.OrgID, policy.UpdatedByUserID, repo, event.Number, event.PR.Head.Ref, event.PR.Head.SHA, event.PR.HTMLURL, policy.AutoMode)
+	return s.autoPreviewStarter.StartAutoPullRequestPreview(ctx, repo.OrgID, policy.UpdatedByUserID, repo, event.Number, event.PR.Head.Ref, event.PR.Head.SHA, event.PR.HTMLURL, policy.AutoMode, policy.PreviewConfigName)
 }
 
 func (s *PRService) repositoryFromPullRequestEvent(ctx context.Context, event PullRequestEvent) (models.Repository, error) {

--- a/internal/services/github/pr_handlers_test.go
+++ b/internal/services/github/pr_handlers_test.go
@@ -428,7 +428,7 @@ type recordingAutoPreviewStarter struct {
 	headRef string
 }
 
-func (s *recordingAutoPreviewStarter) StartAutoPullRequestPreview(_ context.Context, _ uuid.UUID, _ uuid.UUID, _ models.Repository, _ int, headRef, _ string, _ string, mode models.PreviewAutoMode) error {
+func (s *recordingAutoPreviewStarter) StartAutoPullRequestPreview(_ context.Context, _ uuid.UUID, _ uuid.UUID, _ models.Repository, _ int, headRef, _ string, _ string, mode models.PreviewAutoMode, _ string) error {
 	s.called = true
 	s.mode = mode
 	s.headRef = headRef

--- a/internal/services/github/pr_handlers_test.go
+++ b/internal/services/github/pr_handlers_test.go
@@ -199,7 +199,7 @@ func TestHandleAutoPreviewEvent_StartsForPolicyEnabledPullRequest(t *testing.T) 
 	previewMock.ExpectQuery("SELECT .+ FROM repository_preview_policies").
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
 		WillReturnRows(pgxmock.NewRows(githubRepositoryPreviewPolicyTestCols()).
-			AddRow(uuid.New(), orgID, repoID, string(models.PreviewAutoModeWarm), string(models.PreviewSessionPrewarmModeOff), false, true, true, userID, now, now))
+			AddRow(uuid.New(), orgID, repoID, string(models.PreviewAutoModeWarm), string(models.PreviewSessionPrewarmModeOff), false, true, true, "", userID, now, now))
 
 	event := autoPreviewPullRequestEvent(orgID)
 	err := svc.handleAutoPreviewEvent(context.Background(), event)
@@ -249,7 +249,7 @@ func TestHandleAutoPreviewEvent_StartsForReopenedAndSynchronizePullRequests(t *t
 			previewMock.ExpectQuery("SELECT .+ FROM repository_preview_policies").
 				WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
 				WillReturnRows(pgxmock.NewRows(githubRepositoryPreviewPolicyTestCols()).
-					AddRow(uuid.New(), orgID, repoID, string(models.PreviewAutoModeOn), string(models.PreviewSessionPrewarmModeOff), false, true, true, userID, now, now))
+					AddRow(uuid.New(), orgID, repoID, string(models.PreviewAutoModeOn), string(models.PreviewSessionPrewarmModeOff), false, true, true, "", userID, now, now))
 
 			event := autoPreviewPullRequestEvent(orgID)
 			event.Action = tt.action
@@ -300,7 +300,7 @@ func TestHandleAutoPreviewEvent_SkipsDraftAndForkPullRequests(t *testing.T) {
 			previewMock.ExpectQuery("SELECT .+ FROM repository_preview_policies").
 				WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
 				WillReturnRows(pgxmock.NewRows(githubRepositoryPreviewPolicyTestCols()).
-					AddRow(uuid.New(), orgID, repoID, string(models.PreviewAutoModeOn), string(models.PreviewSessionPrewarmModeOff), false, true, true, uuid.New(), now, now))
+					AddRow(uuid.New(), orgID, repoID, string(models.PreviewAutoModeOn), string(models.PreviewSessionPrewarmModeOff), false, true, true, "", uuid.New(), now, now))
 
 			event := autoPreviewPullRequestEvent(orgID)
 			tt.mutate(&event)
@@ -342,7 +342,7 @@ func TestHandleAutoPreviewEvent_EnqueuesSurfaceSyncForForkPullRequestHeadRepo(t 
 	previewMock.ExpectQuery("SELECT .+ FROM repository_preview_policies").
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
 		WillReturnRows(pgxmock.NewRows(githubRepositoryPreviewPolicyTestCols()).
-			AddRow(uuid.New(), orgID, repoID, string(models.PreviewAutoModeOn), string(models.PreviewSessionPrewarmModeOff), true, true, true, uuid.New(), now, now))
+			AddRow(uuid.New(), orgID, repoID, string(models.PreviewAutoModeOn), string(models.PreviewSessionPrewarmModeOff), true, true, true, "", uuid.New(), now, now))
 	jobMock.ExpectQuery("INSERT INTO jobs").
 		WithArgs(pgxmock.AnyArg(), "preview", models.JobTypeSyncPRPreviewSurfaces, prPreviewSurfacePayloadArg{wantHeadOwner: "fork", wantHeadRepo: "app"}, 0, pgxmock.AnyArg()).
 		WillReturnRows(pgxmock.NewRows([]string{"id"}).AddRow(uuid.New()))
@@ -382,7 +382,7 @@ func TestHandleAutoPreviewEvent_SkipsDisabledPolicyAndNonDefaultBranch(t *testin
 				previewMock.ExpectQuery("SELECT .+ FROM repository_preview_policies").
 					WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
 					WillReturnRows(pgxmock.NewRows(githubRepositoryPreviewPolicyTestCols()).
-						AddRow(uuid.New(), orgID, repoID, string(models.PreviewAutoModeOff), string(models.PreviewSessionPrewarmModeOff), false, true, true, uuid.New(), now, now))
+						AddRow(uuid.New(), orgID, repoID, string(models.PreviewAutoModeOff), string(models.PreviewSessionPrewarmModeOff), false, true, true, "", uuid.New(), now, now))
 			},
 		},
 		{
@@ -453,7 +453,7 @@ func autoPreviewPullRequestEvent(orgID uuid.UUID) PullRequestEvent {
 }
 
 func githubRepositoryPreviewPolicyTestCols() []string {
-	return []string{"id", "org_id", "repository_id", "auto_mode", "session_prewarm_mode", "pr_preview_surfaces_enabled", "github_pr_comment_enabled", "github_commit_status_enabled", "updated_by_user_id", "created_at", "updated_at"}
+	return []string{"id", "org_id", "repository_id", "auto_mode", "session_prewarm_mode", "pr_preview_surfaces_enabled", "github_pr_comment_enabled", "github_commit_status_enabled", "preview_config_name", "updated_by_user_id", "created_at", "updated_at"}
 }
 
 type prPreviewSurfacePayloadArg struct {
@@ -3247,7 +3247,7 @@ func TestHandlePullRequestEvent_OpenedWith143GeneratedPRTriggersAutoPreview(t *t
 	previewMock.ExpectQuery("SELECT .+ FROM repository_preview_policies").
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
 		WillReturnRows(pgxmock.NewRows(githubRepositoryPreviewPolicyTestCols()).
-			AddRow(uuid.New(), orgID, repoID, string(models.PreviewAutoModeWarm), string(models.PreviewSessionPrewarmModeOff), false, true, true, userID, now, now))
+			AddRow(uuid.New(), orgID, repoID, string(models.PreviewAutoModeWarm), string(models.PreviewSessionPrewarmModeOff), false, true, true, "", userID, now, now))
 
 	event := autoPreviewPullRequestEvent(orgID)
 	err := svc.HandlePullRequestEvent(context.Background(), event)
@@ -3312,7 +3312,7 @@ func TestHandlePullRequestEvent_ReadyForReviewWith143GeneratedPRTriggersAutoPrev
 	previewMock.ExpectQuery("SELECT .+ FROM repository_preview_policies").
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
 		WillReturnRows(pgxmock.NewRows(githubRepositoryPreviewPolicyTestCols()).
-			AddRow(uuid.New(), orgID, repoID, string(models.PreviewAutoModeWarm), string(models.PreviewSessionPrewarmModeOff), false, true, true, userID, now, now))
+			AddRow(uuid.New(), orgID, repoID, string(models.PreviewAutoModeWarm), string(models.PreviewSessionPrewarmModeOff), false, true, true, "", userID, now, now))
 
 	event := autoPreviewPullRequestEvent(orgID)
 	event.Action = "ready_for_review"
@@ -3505,7 +3505,7 @@ func TestHandleAutoPreviewEvent_SynchronizeUpdatesPRPreviewGroupSHA(t *testing.T
 	previewMock.ExpectQuery("SELECT .+ FROM repository_preview_policies").
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
 		WillReturnRows(pgxmock.NewRows(githubRepositoryPreviewPolicyTestCols()).
-			AddRow(uuid.New(), orgID, repoID, string(models.PreviewAutoModeOn), string(models.PreviewSessionPrewarmModeOff), false, true, true, userID, now, now))
+			AddRow(uuid.New(), orgID, repoID, string(models.PreviewAutoModeOn), string(models.PreviewSessionPrewarmModeOff), false, true, true, "", userID, now, now))
 	previewMock.ExpectExec("UPDATE preview_groups").
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
 		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
@@ -3547,7 +3547,7 @@ func TestHandleAutoPreviewEvent_ReadyForReviewUpdatesPRPreviewGroupSHA(t *testin
 	previewMock.ExpectQuery("SELECT .+ FROM repository_preview_policies").
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
 		WillReturnRows(pgxmock.NewRows(githubRepositoryPreviewPolicyTestCols()).
-			AddRow(uuid.New(), orgID, repoID, string(models.PreviewAutoModeOn), string(models.PreviewSessionPrewarmModeOff), false, true, true, userID, now, now))
+			AddRow(uuid.New(), orgID, repoID, string(models.PreviewAutoModeOn), string(models.PreviewSessionPrewarmModeOff), false, true, true, "", userID, now, now))
 	previewMock.ExpectExec("UPDATE preview_groups").
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
 		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
@@ -3613,7 +3613,7 @@ func TestSyncPRPreviewSurfaces_SkipsWhenPolicySurfacesDisabled(t *testing.T) {
 	previewMock.ExpectQuery("SELECT .+ FROM repository_preview_policies").
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
 		WillReturnRows(pgxmock.NewRows(githubRepositoryPreviewPolicyTestCols()).
-			AddRow(uuid.New(), orgID, repoID, string(models.PreviewAutoModeOn), string(models.PreviewSessionPrewarmModeOff), false, true, true, uuid.New(), now, now))
+			AddRow(uuid.New(), orgID, repoID, string(models.PreviewAutoModeOn), string(models.PreviewSessionPrewarmModeOff), false, true, true, "", uuid.New(), now, now))
 
 	payload := SyncPRPreviewSurfacesPayload{
 		OrgID:        orgID,
@@ -3655,7 +3655,7 @@ func TestSyncPRPreviewSurfaces_SkipsDraftPullRequests(t *testing.T) {
 	previewMock.ExpectQuery("SELECT .+ FROM repository_preview_policies").
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
 		WillReturnRows(pgxmock.NewRows(githubRepositoryPreviewPolicyTestCols()).
-			AddRow(uuid.New(), orgID, repoID, string(models.PreviewAutoModeOn), string(models.PreviewSessionPrewarmModeOff), true, true, true, uuid.New(), now, now))
+			AddRow(uuid.New(), orgID, repoID, string(models.PreviewAutoModeOn), string(models.PreviewSessionPrewarmModeOff), true, true, true, "", uuid.New(), now, now))
 
 	payload := SyncPRPreviewSurfacesPayload{
 		OrgID:        orgID,

--- a/internal/services/preview/config.go
+++ b/internal/services/preview/config.go
@@ -75,6 +75,12 @@ const (
 
 var ErrInvalidConfig = errors.New("invalid preview config")
 
+// ErrPreviewConfigNotFound reports that a requested named preview config is
+// absent from .143/config.json. Callers that source the name from stored state
+// (e.g. a saved build profile that has since been renamed) can fall back to the
+// default config instead of failing the build.
+var ErrPreviewConfigNotFound = errors.New("preview config not found")
+
 func InvalidConfigMessage(err error) string {
 	detail := "unknown error"
 	if err != nil {
@@ -341,7 +347,7 @@ func selectNamedPreviewSection(previewData []byte, name string) ([]byte, bool, e
 	}
 	selected, ok := probe.Configs[selectedName]
 	if !ok {
-		return nil, false, fmt.Errorf("preview config %q not found; available configs: %s", selectedName, strings.Join(names, ", "))
+		return nil, false, fmt.Errorf("%w: %q; available configs: %s", ErrPreviewConfigNotFound, selectedName, strings.Join(names, ", "))
 	}
 	merged, err := mergeNamedPreviewSection(previewData, selected)
 	if err != nil {

--- a/internal/services/preview/config_test.go
+++ b/internal/services/preview/config_test.go
@@ -1589,6 +1589,31 @@ func TestParseNamedConfig_InstallCacheFieldMerge(t *testing.T) {
 	require.Equal(t, []string{".turbo/cache"}, turbo.Install.Cache.Paths, "named cache.paths should replace base cache paths")
 }
 
+func TestParseNamedConfig_MissingNameReturnsSentinel(t *testing.T) {
+	t.Parallel()
+
+	raw := []byte(`{
+		"preview": {
+			"default": "web",
+			"configs": {
+				"web": {"name": "web", "command": ["npm", "run", "dev"], "port": 3000},
+				"admin": {"name": "admin", "command": ["npm", "run", "admin"], "port": 4000}
+			}
+		}
+	}`)
+
+	_, err := ParseNamedConfig(raw, "ghost")
+	require.Error(t, err, "a missing named config should error")
+	require.ErrorIs(t, err, ErrPreviewConfigNotFound,
+		"missing config must report the sentinel so build callers can fall back to default")
+
+	// An empty name resolves the file's default config rather than failing,
+	// which is the fallback target when a saved profile no longer exists.
+	cfg, err := ParseNamedConfig(raw, "")
+	require.NoError(t, err, "empty name should resolve the default config")
+	require.Equal(t, "web", cfg.Name, "empty name should select the default profile")
+}
+
 func TestResolveConfig_DiffCannotAddServices(t *testing.T) {
 	t.Parallel()
 

--- a/internal/services/preview/start_runner.go
+++ b/internal/services/preview/start_runner.go
@@ -1559,6 +1559,16 @@ func (r *StartRunner) readWorkspacePreviewConfig(ctx context.Context, sb *agent.
 		return nil, fmt.Errorf("read %s: %w", repoconfig.ConfigPath, err)
 	}
 	cfg, err := ParseNamedConfig([]byte(content), previewConfigName)
+	if err != nil && previewConfigName != "" && errors.Is(err, ErrPreviewConfigNotFound) {
+		// The requested build profile no longer exists in .143/config.json
+		// (e.g. a saved policy profile was renamed). Fall back to the default
+		// config rather than failing the whole preview.
+		r.logger.Warn().Err(err).
+			Str("session_id", sessionID.String()).
+			Str("preview_config_name", previewConfigName).
+			Msg("saved preview config not found; falling back to default")
+		cfg, err = ParseNamedConfig([]byte(content), "")
+	}
 	if err != nil {
 		r.logger.Warn().Err(err).Str("session_id", sessionID.String()).Str("path", repoconfig.ConfigPath).Msg("committed preview config failed to parse")
 		return nil, fmt.Errorf("%w: parse %s: %w", ErrInvalidConfig, repoconfig.ConfigPath, err)

--- a/internal/services/preview/worker_client.go
+++ b/internal/services/preview/worker_client.go
@@ -85,14 +85,15 @@ type StartBranchPreviewJobPayload struct {
 // The job re-attempts the start once capacity is available, retrying with
 // backoff rather than silently dropping the webhook event.
 type AutoPreviewDeferredPayload struct {
-	OrgID        uuid.UUID              `json:"org_id"`
-	UserID       uuid.UUID              `json:"user_id"`
-	RepositoryID uuid.UUID              `json:"repository_id"`
-	PRNumber     int                    `json:"pr_number"`
-	HeadRef      string                 `json:"head_ref"`
-	HeadSHA      string                 `json:"head_sha"`
-	HTMLURL      string                 `json:"html_url"`
-	Mode         models.PreviewAutoMode `json:"mode"`
+	OrgID             uuid.UUID              `json:"org_id"`
+	UserID            uuid.UUID              `json:"user_id"`
+	RepositoryID      uuid.UUID              `json:"repository_id"`
+	PRNumber          int                    `json:"pr_number"`
+	HeadRef           string                 `json:"head_ref"`
+	HeadSHA           string                 `json:"head_sha"`
+	HTMLURL           string                 `json:"html_url"`
+	Mode              models.PreviewAutoMode `json:"mode"`
+	PreviewConfigName string                 `json:"preview_config_name,omitempty"`
 }
 
 type PreviewCachePrewarmSource string

--- a/internal/worker/handlers.go
+++ b/internal/worker/handlers.go
@@ -898,7 +898,7 @@ func newAutoPreviewDeferredHandler(stores *Stores, services *Services, logger ze
 			}
 		}
 
-		if err := services.AutoPreviewStarter.StartAutoPullRequestPreview(ctx, input.OrgID, input.UserID, repo, input.PRNumber, input.HeadRef, input.HeadSHA, input.HTMLURL, input.Mode); err != nil {
+		if err := services.AutoPreviewStarter.StartAutoPullRequestPreview(ctx, input.OrgID, input.UserID, repo, input.PRNumber, input.HeadRef, input.HeadSHA, input.HTMLURL, input.Mode, input.PreviewConfigName); err != nil {
 			return fmt.Errorf("auto_preview_deferred: start preview: %w", err)
 		}
 		return nil

--- a/internal/worker/handlers_test.go
+++ b/internal/worker/handlers_test.go
@@ -5614,7 +5614,7 @@ func TestEnqueueSessionPreviewPrewarmOnStart_CacheModeEnqueuesLowPriorityJob(t *
 	mock.ExpectQuery("SELECT id, org_id, repository_id, auto_mode").
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
 		WillReturnRows(pgxmock.NewRows(workerRepositoryPreviewPolicyColumns()).
-			AddRow(uuid.New(), orgID, repoID, string(models.PreviewAutoModeWarm), string(models.PreviewSessionPrewarmModeCache), false, true, true, userID, now, now))
+			AddRow(uuid.New(), orgID, repoID, string(models.PreviewAutoModeWarm), string(models.PreviewSessionPrewarmModeCache), false, true, true, "", userID, now, now))
 	mock.ExpectQuery("SELECT COUNT").
 		WithArgs(pgxmock.AnyArg()).
 		WillReturnRows(pgxmock.NewRows([]string{"count"}).AddRow(0))
@@ -5709,7 +5709,7 @@ func TestEnqueueSessionPreviewPrewarmOnStart_RecordsCapacitySkip(t *testing.T) {
 	mock.ExpectQuery("SELECT id, org_id, repository_id, auto_mode").
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
 		WillReturnRows(pgxmock.NewRows(workerRepositoryPreviewPolicyColumns()).
-			AddRow(uuid.New(), orgID, repoID, string(models.PreviewAutoModeWarm), string(models.PreviewSessionPrewarmModeCache), false, true, true, userID, now, now))
+			AddRow(uuid.New(), orgID, repoID, string(models.PreviewAutoModeWarm), string(models.PreviewSessionPrewarmModeCache), false, true, true, "", userID, now, now))
 	mock.ExpectQuery("SELECT COUNT").
 		WithArgs(pgxmock.AnyArg()).
 		WillReturnRows(pgxmock.NewRows([]string{"count"}).AddRow(1))
@@ -5758,7 +5758,7 @@ func TestEnqueueSessionPreviewPrewarmOnStart_SmartModeEnqueuesClassifier(t *test
 	mock.ExpectQuery("SELECT id, org_id, repository_id, auto_mode").
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
 		WillReturnRows(pgxmock.NewRows(workerRepositoryPreviewPolicyColumns()).
-			AddRow(uuid.New(), orgID, repoID, string(models.PreviewAutoModeWarm), string(models.PreviewSessionPrewarmModeSmart), false, true, true, userID, now, now))
+			AddRow(uuid.New(), orgID, repoID, string(models.PreviewAutoModeWarm), string(models.PreviewSessionPrewarmModeSmart), false, true, true, "", userID, now, now))
 	mock.ExpectQuery("SELECT COUNT").
 		WithArgs(pgxmock.AnyArg()).
 		WillReturnRows(pgxmock.NewRows([]string{"count"}).AddRow(0))
@@ -5956,7 +5956,7 @@ func workerOrganizationColumns() []string {
 }
 
 func workerRepositoryPreviewPolicyColumns() []string {
-	return []string{"id", "org_id", "repository_id", "auto_mode", "session_prewarm_mode", "pr_preview_surfaces_enabled", "github_pr_comment_enabled", "github_commit_status_enabled", "updated_by_user_id", "created_at", "updated_at"}
+	return []string{"id", "org_id", "repository_id", "auto_mode", "session_prewarm_mode", "pr_preview_surfaces_enabled", "github_pr_comment_enabled", "github_commit_status_enabled", "preview_config_name", "updated_by_user_id", "created_at", "updated_at"}
 }
 
 func workerRepositoryColumns() []string {

--- a/migrations/000212_repository_preview_policy_config_name.down.sql
+++ b/migrations/000212_repository_preview_policy_config_name.down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE repository_preview_policies
+    DROP COLUMN IF EXISTS preview_config_name;

--- a/migrations/000212_repository_preview_policy_config_name.up.sql
+++ b/migrations/000212_repository_preview_policy_config_name.up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE repository_preview_policies
+    ADD COLUMN preview_config_name TEXT NOT NULL DEFAULT '';


### PR DESCRIPTION
## Summary

Reworks the **Previews** settings page in response to three usability problems: a confusing unlabeled dropdown, two sections that were really one, and inconsistent input typography.

- **Merged the two tables** — `Auto-preview` and `PR preview links` iterated the *same* per-repo policy list twice. They're now **one card per repository** with a `1 · Auto-build` stage (mode + session prewarm), a `2 · Publish to PRs` stage (links + surfaces), a status pill, open-PR count, and the build profile on a footer row.
- **Typography consistency** — every control/label now renders at the `text-xs` scale used across the rest of settings; the build-profile `Select` is sized to match the toggle heights.
- **Build-profile selector** — was a bare dropdown (`manado` / `Assembled`) whose selection only fed the immediate Test preview and persisted nothing. Now it's labeled "Build profile", shows the `(default)` option, only renders as a dropdown when 2+ profiles exist, and has `from .143/config.json` helper text.
- **Persistence** — the selected profile is now saved to `repository_preview_policies.preview_config_name` (migration `000212`) and **honored when creating auto-preview targets**, so auto-built PR previews use the chosen config instead of always falling back to the config.json default.

## Implementation

- Frontend: `settings/previews/page.tsx` (new `RepoPreviewCard`), `lib/api.ts`, `lib/types.ts`.
- Backend: `models/preview.go`, `db/preview_store.go` (column, patch, upsert, summary query), `api/handlers/branch_previews.go` (request field, validation, audit, `StartAutoPullRequestPreview` stamps the target).
- Migration `000212_repository_preview_policy_config_name`.

## Behavior note

A saved profile takes effect on the **next** PR commit (new `PreviewTarget`); in-flight targets keep their original profile.

## Verification

`tsc`, `eslint`, `go build`, `go vet`, `go test` (handlers + db preview, with updated pgxmock expectations), and `make lint` (golangci-lint + schema + stores) all pass. Not rendered live — the page needs an authed dashboard with seeded multi-config preview policies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)