### PR TITLE
Fix Caddyfile bind-mount drift by promoting config in place

### DIFF
--- a/deploy/deploy_config_test.go
+++ b/deploy/deploy_config_test.go
@@ -183,6 +183,15 @@ func TestCaddyfilePromotedInPlaceNotRenamed(t *testing.T) {
 		"stage_caddy_config_if_changed must overwrite the live Caddyfile in place to preserve the bind-mounted inode")
 	require.NotContains(t, fn, `mv "$new_file" "$cur_file"`,
 		"stage_caddy_config_if_changed must not mv the staged Caddyfile over the live one — mv swaps the inode and the single-file bind mount keeps serving the old config")
+
+	// The in-place overwrite is not atomic, so the function must guard against
+	// truncating the live config to an empty/partial file: refuse an empty
+	// staged file and abort (exit) on a failed write rather than silently
+	// reporting "unchanged".
+	require.Contains(t, fn, `[ ! -s "$new_file" ]`,
+		"stage_caddy_config_if_changed must refuse to promote an empty staged Caddyfile before truncating the live config")
+	require.Contains(t, fn, "exit 1",
+		"stage_caddy_config_if_changed must abort the deploy on an empty staged file or failed write instead of leaving a corrupt live Caddyfile")
 }
 
 func TestPreviewWildcardProxyDoesNotUseMainAppPassiveHealth(t *testing.T) {

--- a/deploy/deploy_config_test.go
+++ b/deploy/deploy_config_test.go
@@ -164,6 +164,27 @@ func TestCLIDistributionRoutesProxyToAPI(t *testing.T) {
 	require.Contains(t, cliDistBlock, "port 8080", "CLI distribution routes must target the main API port")
 }
 
+// TestCaddyfilePromotedInPlaceNotRenamed pins the fix for the June 2026 "Caddy
+// bind-mount drift" incident: docker-compose.app.yml bind-mounts the Caddyfile
+// as a single file, and Docker pins single-file mounts to the inode at container
+// start. Promoting a new Caddyfile with `mv` swaps the inode, so the running
+// container keeps reading the old file and `caddy reload` is a silent no-op
+// ("config is unchanged"). stage_caddy_config_if_changed must overwrite the
+// live Caddyfile in place (cat > preserves the inode) so reloads actually apply.
+func TestCaddyfilePromotedInPlaceNotRenamed(t *testing.T) {
+	t.Parallel()
+
+	deployScript, err := os.ReadFile("../deploy/scripts/deploy.sh")
+	require.NoError(t, err, "test should read deploy.sh")
+	deployText := string(deployScript)
+
+	fn := extractShellFunction(t, deployText, "stage_caddy_config_if_changed", "stage_caddy_dockerfile_if_changed")
+	require.Contains(t, fn, `cat "$new_file" > "$cur_file"`,
+		"stage_caddy_config_if_changed must overwrite the live Caddyfile in place to preserve the bind-mounted inode")
+	require.NotContains(t, fn, `mv "$new_file" "$cur_file"`,
+		"stage_caddy_config_if_changed must not mv the staged Caddyfile over the live one — mv swaps the inode and the single-file bind mount keeps serving the old config")
+}
+
 func TestPreviewWildcardProxyDoesNotUseMainAppPassiveHealth(t *testing.T) {
 	t.Parallel()
 

--- a/deploy/scripts/deploy.sh
+++ b/deploy/scripts/deploy.sh
@@ -884,24 +884,37 @@ ssh "${SSH_OPTS[@]}" deploy@"$HOST" \
 
   # stage_caddy_config_if_changed — returns 0 if deploy/Caddyfile.new differs
   # from the currently deployed deploy/Caddyfile, and when it does, promotes
-  # the staged file into place (mv). Returns 1 (and removes the staged file)
-  # when contents match. Used to avoid restarting Caddy on code-only deploys;
-  # Caddy restarts briefly unbind ports 80/443 and surface as 502s through
-  # any upstream proxy (Cloudflare, etc.).
+  # the staged file into place. Returns 1 (and removes the staged file) when
+  # contents match. Used to avoid restarting Caddy on code-only deploys; Caddy
+  # restarts briefly unbind ports 80/443 and surface as 502s through any
+  # upstream proxy (Cloudflare, etc.).
+  #
+  # The promotion MUST overwrite the existing file in place (truncate + rewrite)
+  # rather than `mv` it. docker-compose.app.yml bind-mounts the Caddyfile as a
+  # single file (./deploy/Caddyfile:/etc/caddy/Caddyfile), and Docker pins a
+  # single-file mount to the file's inode at container start. `mv` replaces the
+  # path with a NEW inode, so the running container stays bound to the OLD one
+  # and never sees the change — `caddy reload` reads the frozen inode and logs
+  # "config is unchanged", a silent no-op. Overwriting in place keeps the inode
+  # stable so the bind-mounted file (and reload) reflects the new content. See
+  # the "Caddy bind-mount drift" incident (June 2026, install routes 404'd for
+  # ~10 days). The `cat >` redirect creates cur_file on the first deploy and
+  # truncates+rewrites the same inode afterwards (never `mv`/`cp`, which unlink
+  # and recreate the path with a fresh inode).
   stage_caddy_config_if_changed() {
     local new_file="/opt/143/deploy/Caddyfile.new"
     local cur_file="/opt/143/deploy/Caddyfile"
     [ -f "$new_file" ] || return 1
-    if [ ! -f "$cur_file" ]; then
-      mv "$new_file" "$cur_file"
-      return 0
+    if [ -f "$cur_file" ] && cmp -s "$new_file" "$cur_file"; then
+      rm -f "$new_file"
+      return 1
     fi
-    if ! cmp -s "$new_file" "$cur_file"; then
-      mv "$new_file" "$cur_file"
-      return 0
+    if ! cat "$new_file" > "$cur_file"; then
+      rm -f "$new_file"
+      return 1
     fi
     rm -f "$new_file"
-    return 1
+    return 0
   }
 
   # stage_caddy_dockerfile_if_changed — returns 0 only when Dockerfile.caddy

--- a/deploy/scripts/deploy.sh
+++ b/deploy/scripts/deploy.sh
@@ -898,9 +898,12 @@ ssh "${SSH_OPTS[@]}" deploy@"$HOST" \
   # "config is unchanged", a silent no-op. Overwriting in place keeps the inode
   # stable so the bind-mounted file (and reload) reflects the new content. See
   # the "Caddy bind-mount drift" incident (June 2026, install routes 404'd for
-  # ~10 days). The `cat >` redirect creates cur_file on the first deploy and
-  # truncates+rewrites the same inode afterwards (never `mv`/`cp`, which unlink
-  # and recreate the path with a fresh inode).
+  # ~10 days). Use a shell redirect, not `mv`: a rename always allocates a new
+  # inode. `cat >` is also preferred over `cp`, whose in-place-truncate vs.
+  # unlink-and-recreate behavior varies across implementations and flags, while
+  # a redirect is unambiguously an in-place truncate+rewrite. That write is
+  # therefore NOT atomic, so the guards below refuse an empty staged file and
+  # treat a failed write as fatal rather than leaving a corrupt live config.
   stage_caddy_config_if_changed() {
     local new_file="/opt/143/deploy/Caddyfile.new"
     local cur_file="/opt/143/deploy/Caddyfile"
@@ -909,9 +912,21 @@ ssh "${SSH_OPTS[@]}" deploy@"$HOST" \
       rm -f "$new_file"
       return 1
     fi
-    if ! cat "$new_file" > "$cur_file"; then
+    # The overwrite below truncates cur_file before writing and is not atomic, so
+    # a bad write leaves the LIVE Caddyfile corrupt with no rollback. Refuse an
+    # empty staged file (checked before any truncation), and abort the deploy on
+    # a write failure instead of reporting a silent "unchanged" — shipping a
+    # truncated config would break the next caddy (re)load and can unbind
+    # :80/:443 on container recreate. A valid Caddyfile is never empty.
+    if [ ! -s "$new_file" ]; then
+      echo "ERROR: staged Caddyfile $new_file is empty; refusing to overwrite live config" >&2
       rm -f "$new_file"
-      return 1
+      exit 1
+    fi
+    if ! cat "$new_file" > "$cur_file"; then
+      echo "ERROR: failed writing $cur_file from staged Caddyfile (live config may be truncated)" >&2
+      rm -f "$new_file"
+      exit 1
     fi
     rm -f "$new_file"
     return 0


### PR DESCRIPTION
## Problem

`https://143.dev/install/<token>` (and all `/install*` / `/download/*` CLI routes added in #1305) returned a Next.js 404 in production for ~10 days, even though every deploy reported success.

Root cause is a **Docker single-file bind-mount + `mv` bug**:

- `docker-compose.app.yml` mounts the Caddyfile as a single file: `./deploy/Caddyfile:/etc/caddy/Caddyfile:ro`. Docker pins a single-file bind mount to the file's **inode** at container start.
- `stage_caddy_config_if_changed` promoted the new Caddyfile with **`mv`**, which atomically replaces the path with a **new inode**. The host path gets the new content, but the running container stays bound to the **old inode** — so it keeps serving the stale config.
- `caddy reload` inside the container reads that frozen inode and logs `"config is unchanged"` — a silent no-op. Every reconcile path (the diff-gated reload and #1494's service-drift detection) was therefore defeated. The config only refreshed on a full container **recreate**.

`/api/*` kept working only because that route existed in the config Caddy loaded weeks earlier.

Confirmed on the prod app host: host `Caddyfile` had the `@cli_dist` routes (sha matched `main`) while `docker exec caddy cat /etc/caddy/Caddyfile` did not, and the live admin config had zero install routes. Prod was unblocked with a one-time `docker compose up -d --force-recreate caddy`; this PR is the durable fix.

## Change

- `stage_caddy_config_if_changed` now overwrites the live Caddyfile **in place** with `cat "$new_file" > "$cur_file"` instead of `mv`, preserving the inode so the bind-mounted file (and `caddy reload`) reflect new content.
- New `TestCaddyfilePromotedInPlaceNotRenamed` pins the in-place write and fails if the function regresses to `mv "$new_file" "$cur_file"`.

## Testing

- `bash -n deploy/scripts/deploy.sh` — syntax OK
- `go test ./deploy/` — ok (full package)
- `make lint` — 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)
