### PR TITLE
Stack no-repos warning card vertically and trim copy

### DIFF
--- a/frontend/src/components/no-repos-warning.test.tsx
+++ b/frontend/src/components/no-repos-warning.test.tsx
@@ -85,7 +85,7 @@ describe("NoReposWarning", () => {
 
     await waitFor(() => {
       expect(
-        screen.getByText(/choose repositories in integrations/i)
+        screen.getByText(/no repositories are claimed yet/i)
       ).toBeInTheDocument();
     });
     expect(screen.getByRole("link", { name: /choose repositories/i })).toHaveAttribute("href", "/settings/integrations?select_repos=1");

--- a/frontend/src/components/no-repos-warning.tsx
+++ b/frontend/src/components/no-repos-warning.tsx
@@ -120,62 +120,66 @@ export function NoReposWarning({
   if (hasRepos) return null;
 
   return (
-    <div className="flex items-center gap-3 rounded-lg border border-warning/20 bg-warning/5 px-4 py-3">
-      <AlertTriangle className="h-4 w-4 shrink-0 text-warning" />
-      <div className="flex-1 min-w-0">
-        <p className="text-xs text-warning">
-          {shouldChooseRepos
-            ? "GitHub is connected, but no repositories are claimed for this organization. Choose repositories in integrations before creating sessions or projects."
-            : "GitHub is connected but no repositories are synced. Sessions won't have access to your code."}
-        </p>
-        {syncError && needsReinstall && (
-          <p className="mt-1 text-xs text-warning">
-            The GitHub App installation ID is missing. Please reconnect GitHub to fix this.
+    <div className="space-y-3 rounded-lg border border-warning/20 bg-warning/5 px-4 py-3">
+      <div className="flex items-start gap-3">
+        <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-warning" />
+        <div className="min-w-0 flex-1">
+          <p className="text-xs text-warning">
+            {shouldChooseRepos
+              ? "GitHub is connected, but no repositories are claimed yet."
+              : "GitHub is connected but no repositories are synced. Sessions won't have access to your code."}
           </p>
-        )}
-        {syncError && !needsReinstall && (
-          <p className="mt-1 text-xs text-destructive">
-            {syncError instanceof Error ? syncError.message : "Sync failed. Please try again."}
-          </p>
-        )}
-        {syncResult && syncResult.repos_synced === 0 && !shouldChooseRepos && (
-          <p className="mt-1 text-xs text-warning">
-            No repositories found. Make sure the GitHub App has access to at least one repository.
-          </p>
+          {syncError && needsReinstall && (
+            <p className="mt-1 text-xs text-warning">
+              The GitHub App installation ID is missing. Please reconnect GitHub to fix this.
+            </p>
+          )}
+          {syncError && !needsReinstall && (
+            <p className="mt-1 text-xs text-destructive">
+              {syncError instanceof Error ? syncError.message : "Sync failed. Please try again."}
+            </p>
+          )}
+          {syncResult && syncResult.repos_synced === 0 && !shouldChooseRepos && (
+            <p className="mt-1 text-xs text-warning">
+              No repositories found. Make sure the GitHub App has access to at least one repository.
+            </p>
+          )}
+        </div>
+      </div>
+      <div className="flex justify-end">
+        {needsReinstall ? (
+          <Button
+            size="sm"
+            variant="outline"
+            onClick={async () => {
+              try {
+                await api.integrations.disconnect("github");
+              } catch (err) {
+                console.error("Failed to disconnect GitHub before reconnect:", err);
+              }
+              api.integrations.loginGitHub();
+            }}
+            className="gap-1.5"
+          >
+            Reconnect GitHub
+          </Button>
+        ) : shouldChooseRepos ? (
+          <Button size="sm" variant="outline" asChild className="gap-1.5">
+            <Link href="/settings/integrations?select_repos=1">Choose repositories</Link>
+          </Button>
+        ) : (
+          <Button
+            size="sm"
+            variant="outline"
+            onClick={sync}
+            disabled={isSyncing}
+            className="gap-1.5"
+          >
+            <RefreshCw className={`h-3.5 w-3.5 ${isSyncing ? "animate-spin" : ""}`} />
+            {isSyncing ? "Syncing..." : "Sync repositories"}
+          </Button>
         )}
       </div>
-      {needsReinstall ? (
-        <Button
-          size="sm"
-          variant="outline"
-          onClick={async () => {
-            try {
-              await api.integrations.disconnect("github");
-            } catch (err) {
-              console.error("Failed to disconnect GitHub before reconnect:", err);
-            }
-            api.integrations.loginGitHub();
-          }}
-          className="shrink-0 gap-1.5"
-        >
-          Reconnect GitHub
-        </Button>
-      ) : shouldChooseRepos ? (
-        <Button size="sm" variant="outline" asChild className="shrink-0 gap-1.5">
-          <Link href="/settings/integrations?select_repos=1">Choose repositories</Link>
-        </Button>
-      ) : (
-        <Button
-          size="sm"
-          variant="outline"
-          onClick={sync}
-          disabled={isSyncing}
-          className="shrink-0 gap-1.5"
-        >
-          <RefreshCw className={`h-3.5 w-3.5 ${isSyncing ? "animate-spin" : ""}`} />
-          {isSyncing ? "Syncing..." : "Sync repositories"}
-        </Button>
-      )}
     </div>
   );
 }


### PR DESCRIPTION
## What

Tightens the layout and copy of the "no repositories claimed" warning card that shows on the sessions / new-session flow when GitHub is connected but no repos are claimed.

## Why

In the narrow sessions column the card rendered the icon, message, and action button all in a single horizontal row. Because the button was `shrink-0`, it reserved its full width on the right and squeezed the long message into a thin, tall sliver of wrapped text — cramped and awkward.

## Changes

- **Vertical layout**: outer container switched from `flex items-center` to a `space-y-3` stack. Row 1 is the icon + message (full width); row 2 is the button in a `flex justify-end` wrapper below. Icon nudged to `mt-0.5` to align with the first line of wrapped text. Dropped the now-unneeded `shrink-0` on the buttons. Applies to all three button states (Choose repositories / Reconnect GitHub / Sync repositories).
- **Shorter copy**: trimmed "GitHub is connected, but no repositories are claimed for this organization. Choose repositories in integrations before creating sessions or projects." to "GitHub is connected, but no repositories are claimed yet." The dropped sentence was redundant with the "Choose repositories" button.

## Verification

Type-checks clean. This auth-gated empty state (GitHub connected, zero repos) isn't reachable in a standalone frontend preview, and the change is layout/copy only with no logic touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
