### PR TITLE
Default the bare /sessions index to the "Let's build" composer

### DIFF
--- a/frontend/src/app/(dashboard)/sessions/layout.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/layout.test.tsx
@@ -143,14 +143,15 @@ describe("SessionsLayout", () => {
     expect(preloadSessionDetailContent).toHaveBeenCalled();
   });
 
-  it("owns the empty sessions workspace content on the bare /sessions route", () => {
+  it("defaults the bare /sessions route to the create-session content", () => {
     renderWithProviders(
       <SessionsLayout>
         <div>Legacy child content</div>
       </SessionsLayout>,
     );
 
-    expect(screen.getByText("Select a session")).toBeInTheDocument();
+    expect(screen.getByTestId("manual-session-create-page")).toBeInTheDocument();
+    expect(screen.queryByText("Select a session")).not.toBeInTheDocument();
     expect(screen.queryByText("Legacy child content")).not.toBeInTheDocument();
   });
 

--- a/frontend/src/app/(dashboard)/sessions/sessions-shell-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/sessions-shell-content.tsx
@@ -6,6 +6,10 @@ import { ManualSessionCreatePageContent } from "./new/manual-session-create-page
 import { SessionDetailPageClient } from "./[id]/session-detail-page-client";
 import type { SessionsRouteState } from "./sessions-route-state";
 
+// When nothing is selected we don't show a "Select a session" placeholder; we
+// default to the "Let's build" create-session experience so the main panel is
+// always actionable.
+
 export function SessionsShellContent({ routeState }: { routeState: SessionsRouteState }) {
   if (routeState.isUnsupportedRoute) {
     return (
@@ -21,10 +25,6 @@ export function SessionsShellContent({ routeState }: { routeState: SessionsRoute
     );
   }
 
-  if (routeState.isCreatingSession) {
-    return <ManualSessionCreatePageContent />;
-  }
-
   if (routeState.selectedSessionId) {
     return (
       <SessionDetailPageClient
@@ -34,15 +34,7 @@ export function SessionsShellContent({ routeState }: { routeState: SessionsRoute
     );
   }
 
-  return (
-    <div className="flex min-h-[calc(100vh-8rem)] items-center justify-center px-4 py-10">
-      <EmptyState
-        variant="inline"
-        icon={MessageSquareText}
-        title="Select a session"
-        description="Choose a session from the sidebar to review its transcript, changes, preview, and publish state."
-        action={{ label: "New session", href: "/sessions/new" }}
-      />
-    </div>
-  );
+  // Both the explicit create route (/sessions/new) and the bare index
+  // (/sessions, nothing selected) fall through to the "Let's build" composer.
+  return <ManualSessionCreatePageContent />;
 }


### PR DESCRIPTION
## Summary

Landing on `/sessions` with nothing selected showed a dead-end "Select a session" placeholder, even though the obvious next action is almost always to start a new session. This makes the bare `/sessions` index render the same "Let's build" composer as `/sessions/new`, so the main panel is always actionable rather than a do-nothing empty state.

## Changes

- `SessionsShellContent` now renders `ManualSessionCreatePageContent` for the bare index; both the explicit create route and the index fall through to the same composer.
- Removed the "Select a session" `EmptyState` and the now-redundant `isCreatingSession` branch (the unsupported-route and selected-session branches are unchanged).

## Validation

- Updated `layout.test.tsx`: the bare `/sessions` route now asserts the create-session content renders and "Select a session" is gone; the existing `/sessions/new` and session-detail tests are unchanged.
- Note: this worktree has no `node_modules`, so the FE test suite was not executed locally — please run it in CI. The change is a pure dispatch swap with no new dependencies.

## Reviewer notes

- On mobile the index keeps `mobileShow: "sidebar"`, so `/sessions` still shows the session list there; the composer is the default in the desktop content pane (and on `/sessions/new` everywhere). Flagging in case mobile should also default straight to the composer.
- `isCreatingSession` is still `false` for the bare index (it's `true` only for `/sessions/new`), so the sidebar's new-session highlight/focus behavior differs slightly between the two routes even though the content pane is identical. Intentional for now; happy to unify if preferred.
