### PR TITLE
Merge auth-resolution notice into the org auths section header

### DIFF
--- a/frontend/src/app/(dashboard)/settings/agent/page.test.tsx
+++ b/frontend/src/app/(dashboard)/settings/agent/page.test.tsx
@@ -68,9 +68,9 @@ describe("Agent settings page", () => {
 
     expect(screen.getByText("Coding agents")).toBeInTheDocument();
     expect((await screen.findAllByText("Team seat A")).length).toBeGreaterThan(0);
-    expect(screen.getByText("Personal auths run first for each user. If none are available, sessions fall back to this org Coding agents list.")).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Organization-wide auths" })).toBeInTheDocument();
+    expect(screen.getByText("Personal auths run first for each user. When none are available, sessions fall back to this stack, running top to bottom. Move the auth you want to prefer higher in the list.")).toBeInTheDocument();
     expect(screen.getByRole("link", { name: "Personal auths" })).toHaveAttribute("href", "/settings/account");
-    expect(screen.getByText("The stack runs from top to bottom. Move the auth you want to prefer higher in the list.")).toBeInTheDocument();
     expect(screen.getByRole("link", { name: "Sandboxes" })).toHaveAttribute("href", "/settings/runtime");
     expect(screen.queryByLabelText("Max concurrent sessions")).not.toBeInTheDocument();
     expect(screen.queryByLabelText("Session max time (minutes)")).not.toBeInTheDocument();
@@ -86,7 +86,7 @@ describe("Agent settings page", () => {
     renderWithProviders(<AgentPage />);
 
     expect(await screen.findByText("Read-only view. Only admins can add, edit, or reorder coding auths.")).toBeInTheDocument();
-    expect(screen.getByText("Personal auths run first for each user. If none are available, sessions fall back to this org Coding agents list.")).toBeInTheDocument();
+    expect(screen.getByText("Personal auths run first for each user. When none are available, sessions fall back to this stack, running top to bottom.")).toBeInTheDocument();
     expect(screen.getByRole("link", { name: "Personal auths" })).toHaveAttribute("href", "/settings/account");
     expect(screen.queryByRole("link", { name: "Sandboxes" })).not.toBeInTheDocument();
   });

--- a/frontend/src/app/(dashboard)/settings/agent/page.tsx
+++ b/frontend/src/app/(dashboard)/settings/agent/page.tsx
@@ -115,15 +115,14 @@ function defaultLabel(provider: ModalProvider, authType: AddFlowAuthType) {
   }
 }
 
-function AuthResolutionNotice({ isAdmin }: { isAdmin: boolean }) {
+function OrgAuthsHeader({ isAdmin, showReorderHint }: { isAdmin: boolean; showReorderHint?: boolean }) {
   return (
-    <div className="flex flex-col gap-3 rounded-md border border-border bg-muted/30 px-3 py-3 sm:flex-row sm:items-center sm:justify-between">
-      <div className="space-y-1">
-        <p className="text-xs font-medium text-foreground">
-          Personal auths run first for each user. If none are available, sessions fall back to this org Coding agents list.
-        </p>
+    <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+      <div className="space-y-1.5">
+        <h2 className="text-xs font-medium text-foreground">Organization-wide auths</h2>
         <p className="text-xs text-muted-foreground">
-          Shared sandbox networking, lifecycle, and capacity controls live in Sandboxes.
+          Personal auths run first for each user. When none are available, sessions fall back to this stack, running top to bottom.
+          {showReorderHint && " Move the auth you want to prefer higher in the list."}
         </p>
       </div>
       <div className="flex flex-wrap gap-2">
@@ -364,10 +363,8 @@ export default function AgentPage() {
             <ShieldAlert className="mr-1.5 inline h-3.5 w-3.5 align-text-bottom" />
             Read-only view. Only admins can add, edit, or reorder coding auths.
           </div>
-          <AuthResolutionNotice isAdmin={isAdmin} />
-
           <section className="space-y-3">
-            <h2 className="text-xs font-medium text-foreground">Fallback stack</h2>
+            <OrgAuthsHeader isAdmin={isAdmin} />
             {rows.length === 0 ? (
               <Card>
                 <EmptyState
@@ -449,15 +446,8 @@ export default function AgentPage() {
             </Button>
           )}
         />
-        <AuthResolutionNotice isAdmin={isAdmin} />
-
         <section className="space-y-4">
-          <div className="space-y-1.5">
-            <h2 className="text-xs font-medium text-foreground">Fallback stack</h2>
-            <p className="text-xs text-muted-foreground">
-              The stack runs from top to bottom. Move the auth you want to prefer higher in the list.
-            </p>
-          </div>
+          <OrgAuthsHeader isAdmin={isAdmin} showReorderHint />
           <CodingAuthStack
             rows={rows}
             selectedId={selectedId}


### PR DESCRIPTION
## Summary

The org Coding agents settings page showed a standalone bordered "Personal auths run first…" notice card stacked directly above a separate "Fallback stack" heading. The two restated the same org-vs-personal fallback framing and made one logical section read as two, adding visual clutter. This folds the notice into the section header and clarifies the naming.

## Changes

- Replace the `AuthResolutionNotice` card + separate "Fallback stack" heading with a single `OrgAuthsHeader` (title, one-line description, and the Personal auths / Sandboxes links).
- Rename the section "Fallback stack" → "Organization-wide auths".
- Trim redundant copy and gate the "move the auth higher" reorder hint behind a `showReorderHint` prop so it only appears in the admin view (the read-only view can't reorder).

## Validation

- `npx tsc --noEmit` — passes.
- Route compiles cleanly in `next dev` (no error overlay / console errors). Full in-browser render is auth-gated (needs the backend stack + login), so it wasn't exercised live; change is presentation-only with no logic touched.
