### PR TITLE
Unify first-run setup into one calm setup card

### DIFF
--- a/frontend/src/app/(dashboard)/sessions/new/manual-session-create-page-content.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/new/manual-session-create-page-content.test.tsx
@@ -287,7 +287,7 @@ describe("ManualSessionCreatePageContent", () => {
     renderWithProviders(<ManualSessionCreatePageContent />);
 
     expect(await screen.findByRole("textbox", { name: "Manual session prompt" })).toBeInTheDocument();
-    expect(screen.queryByText(/No API key configured/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/isn't connected yet/)).not.toBeInTheDocument();
 
     settings.resolve({
       data: {
@@ -299,7 +299,7 @@ describe("ManualSessionCreatePageContent", () => {
       },
     });
 
-    expect(await screen.findByText(/No API key configured for Codex/)).toBeInTheDocument();
+    expect(await screen.findByText(/Codex isn't connected yet/)).toBeInTheDocument();
   });
 
   it("uses a mobile settings sheet instead of inline repo and model controls on small screens", async () => {

--- a/frontend/src/components/agent-key-required-banner.test.tsx
+++ b/frontend/src/components/agent-key-required-banner.test.tsx
@@ -3,12 +3,12 @@ import { renderWithProviders, screen } from "@/test/test-utils";
 import { AgentKeyRequiredBanner } from "./agent-key-required-banner";
 
 describe("AgentKeyRequiredBanner", () => {
-  it("links to /settings/agent for provider-backed agents", () => {
+  it("links to /settings/account for provider-backed agents", () => {
     renderWithProviders(<AgentKeyRequiredBanner agentType="claude_code" />);
 
     const link = screen.getByRole("link", { name: "Configure keys" });
     expect(link).toHaveAttribute("href", "/settings/account");
-    expect(screen.getByText(/No API key configured for Claude Code/)).toBeInTheDocument();
+    expect(screen.getByText(/Claude Code isn't connected yet/)).toBeInTheDocument();
   });
 
   it("links to /settings/account for Pi", () => {
@@ -16,13 +16,24 @@ describe("AgentKeyRequiredBanner", () => {
 
     const link = screen.getByRole("link", { name: "Configure keys" });
     expect(link).toHaveAttribute("href", "/settings/account");
-    expect(screen.getByText(/No API key configured for Pi/)).toBeInTheDocument();
+    expect(screen.getByText(/Pi isn't connected yet/)).toBeInTheDocument();
   });
 
   it("falls back to the raw agent type for unknown keys", () => {
     renderWithProviders(<AgentKeyRequiredBanner agentType="mystery" />);
 
-    expect(screen.getByText(/No API key configured for mystery/)).toBeInTheDocument();
+    expect(screen.getByText(/mystery isn't connected yet/)).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Configure keys" })).toHaveAttribute(
+      "href",
+      "/settings/agent",
+    );
+  });
+
+  it("renders as a labeled setup row with asRow", () => {
+    renderWithProviders(<AgentKeyRequiredBanner agentType="codex" asRow />);
+
+    expect(screen.getByText("Coding agent")).toBeInTheDocument();
+    expect(screen.getByText(/Codex isn't connected yet/)).toBeInTheDocument();
     expect(screen.getByRole("link", { name: "Configure keys" })).toHaveAttribute(
       "href",
       "/settings/agent",

--- a/frontend/src/components/agent-key-required-banner.tsx
+++ b/frontend/src/components/agent-key-required-banner.tsx
@@ -1,23 +1,48 @@
 "use client";
 
-import { AlertTriangle } from "lucide-react";
+import { AlertTriangle, Bot } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import Link from "next/link";
 import { AGENTS_BY_KEY } from "@/lib/agents";
+import { SetupItemRow } from "@/components/setup-item-row";
 
-export function AgentKeyRequiredBanner({ agentType }: { agentType: string }) {
+export function AgentKeyRequiredBanner({
+  agentType,
+  // asRow renders the warning as a SetupItemRow inside SetupRequirementsCard so
+  // it shares the onboarding cards' visual language. The default standalone
+  // rendering is the inline warning banner.
+  asRow = false,
+}: {
+  agentType: string;
+  asRow?: boolean;
+}) {
   const agent = AGENTS_BY_KEY[agentType];
   const label = agent?.label ?? agentType;
   const href = !agent ? "/settings/agent" : agentType === "codex" ? "/settings/agent" : "/settings/account";
+
+  if (asRow) {
+    return (
+      <SetupItemRow
+        icon={<Bot className="h-5 w-5" />}
+        title="Coding agent"
+        description={`${label} isn't connected yet — add a key or sign in so your sessions can run.`}
+        action={
+          <Button size="sm" variant="outline" asChild>
+            <Link href={href}>Configure keys</Link>
+          </Button>
+        }
+      />
+    );
+  }
 
   return (
     <div className="flex items-center gap-3 rounded-lg border border-warning/20 bg-warning/5 px-4 py-3">
       <AlertTriangle className="h-4 w-4 shrink-0 text-warning" />
       <div className="flex-1 min-w-0">
         <p className="text-xs text-warning">
-          No API key configured for {label}.{" "}
-          <Link href={href} className="underline font-medium">Add one in Settings</Link>
-          {" "}to use your own subscription. Org-wide credentials are used as a fallback.
+          {label} isn&apos;t connected yet.{" "}
+          <Link href={href} className="underline font-medium">Add a key or sign in</Link>
+          {" "}so your sessions can run.
         </p>
       </div>
       <Button size="sm" variant="outline" asChild className="shrink-0">

--- a/frontend/src/components/manual-session-composer.tsx
+++ b/frontend/src/components/manual-session-composer.tsx
@@ -76,8 +76,7 @@ import {
   availableAgentModelGroups,
   isAgentAvailable,
 } from "@/lib/agents";
-import { NoReposWarning } from "@/components/no-repos-warning";
-import { AgentKeyRequiredBanner } from "@/components/agent-key-required-banner";
+import { SetupRequirementsCard } from "@/components/setup-requirements-card";
 import { useOptimisticSessionsSafe } from "@/contexts/optimistic-sessions";
 import { useAuth } from "@/hooks/use-auth";
 import { useMediaQuery } from "@/hooks/use-media-query";
@@ -1180,18 +1179,14 @@ export function ManualSessionComposer({
 
       {heroSlot}
 
-      {reposLoaded && repositories.length === 0 && (
+      {(shouldShowAgentKeyRequiredBanner || (reposLoaded && repositories.length === 0)) && (
         <div className="shrink-0 px-0">
           <div className={cn("w-full mx-auto", innerClassName)}>
-            <NoReposWarning />
-          </div>
-        </div>
-      )}
-
-      {shouldShowAgentKeyRequiredBanner && (
-        <div className="shrink-0 px-0">
-          <div className={cn("w-full mx-auto", innerClassName)}>
-            <AgentKeyRequiredBanner agentType={effectiveAgentType} />
+            <SetupRequirementsCard
+              showAgentRow={shouldShowAgentKeyRequiredBanner}
+              agentType={effectiveAgentType}
+              showRepoRow={reposLoaded && repositories.length === 0}
+            />
           </div>
         </div>
       )}

--- a/frontend/src/components/no-repos-warning.test.tsx
+++ b/frontend/src/components/no-repos-warning.test.tsx
@@ -141,4 +141,38 @@ describe("NoReposWarning", () => {
       ).toBeInTheDocument();
     });
   });
+
+  it("renders as a labeled setup row with asRow", async () => {
+    server.use(
+      http.get("/api/v1/integrations", () => {
+        return HttpResponse.json({
+          data: [{
+            id: "int-1",
+            provider: "github",
+            status: "active",
+            github_app_installed: true,
+            github_repo_selection_required: true,
+          }],
+          meta: {},
+        });
+      }),
+      http.get("/api/v1/repositories", () => {
+        return HttpResponse.json({ data: [], meta: {} });
+      }),
+      http.post("/api/v1/integrations/github/sync", () => {
+        return HttpResponse.json({ data: { repos_synced: 0, repos_seen: 2, errors: 0 } });
+      })
+    );
+
+    renderWithProviders(<NoReposWarning asRow />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Repository")).toBeInTheDocument();
+    });
+    expect(screen.getByText(/choose repositories in integrations/i)).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /choose repositories/i })).toHaveAttribute(
+      "href",
+      "/settings/integrations?select_repos=1",
+    );
+  });
 });

--- a/frontend/src/components/no-repos-warning.tsx
+++ b/frontend/src/components/no-repos-warning.tsx
@@ -3,12 +3,13 @@
 import { useEffect } from "react";
 import Link from "next/link";
 import { useQuery } from "@tanstack/react-query";
-import { AlertTriangle, RefreshCw, Check } from "lucide-react";
+import { AlertTriangle, RefreshCw, Check, Github } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { api } from "@/lib/api";
 import { queryKeys } from "@/lib/query-keys";
 import { useGitHubRepoSync } from "@/hooks/use-github-repo-sync";
+import { SetupItemRow } from "@/components/setup-item-row";
 import { cn } from "@/lib/utils";
 
 /** Error codes that mean the user needs to reinstall the GitHub App. */
@@ -31,11 +32,16 @@ function isReinstallError(err: unknown): boolean {
 interface NoReposWarningProps {
   showDisconnectedState?: boolean;
   compact?: boolean;
+  // asRow renders the warning as an inline SetupItemRow (no outer banner
+  // chrome) for use inside SetupRequirementsCard, which supplies its own
+  // container. All behavior (sync, reinstall, choose-vs-sync) is unchanged.
+  asRow?: boolean;
 }
 
 export function NoReposWarning({
   showDisconnectedState = false,
   compact = false,
+  asRow = false,
 }: NoReposWarningProps) {
   const { data: integrationsResp } = useQuery({
     queryKey: ["integrations"],
@@ -106,18 +112,85 @@ export function NoReposWarning({
 
   // After a successful sync that found repos, show success briefly then hide
   if (syncResult && syncResult.repos_synced > 0 && hasRepos) {
+    const syncedCount = syncResult.repos_synced;
+    const syncedMessage = `${syncedCount} repositor${syncedCount === 1 ? "y" : "ies"} synced.`;
+    if (asRow) {
+      return (
+        <SetupItemRow
+          icon={<Check className="h-5 w-5 text-success" />}
+          title="Repository"
+          description={syncedMessage}
+          done
+        />
+      );
+    }
     return (
       <div className="flex items-center gap-3 rounded-lg border border-success/20 bg-success/5 px-4 py-3">
         <Check className="h-4 w-4 shrink-0 text-success" />
-        <p className="text-xs text-success">
-          {syncResult.repos_synced} repositor{syncResult.repos_synced === 1 ? "y" : "ies"} synced.
-        </p>
+        <p className="text-xs text-success">{syncedMessage}</p>
       </div>
     );
   }
 
   // If repos now exist (from query refetch), hide the warning
   if (hasRepos) return null;
+
+  // asRow renders the warning as a SetupItemRow inside SetupRequirementsCard so
+  // it shares the onboarding cards' visual language. Computed independently from
+  // the standalone banner below so that existing rendering stays untouched.
+  if (asRow) {
+    const message = shouldChooseRepos
+      ? "GitHub is connected, but no repositories are claimed for this organization. Choose repositories in integrations before creating sessions or projects."
+      : "GitHub is connected but no repositories are synced. Sessions won't have access to your code.";
+    const syncErrorMessage = syncError
+      ? needsReinstall
+        ? "The GitHub App installation ID is missing. Please reconnect GitHub to fix this."
+        : syncError instanceof Error
+          ? syncError.message
+          : "Sync failed. Please try again."
+      : null;
+    const rowAction = needsReinstall ? (
+      <Button
+        size="sm"
+        variant="outline"
+        onClick={async () => {
+          try {
+            await api.integrations.disconnect("github");
+          } catch (err) {
+            console.error("Failed to disconnect GitHub before reconnect:", err);
+          }
+          api.integrations.loginGitHub();
+        }}
+        className="shrink-0 gap-1.5"
+      >
+        Reconnect GitHub
+      </Button>
+    ) : shouldChooseRepos ? (
+      <Button size="sm" variant="outline" asChild className="shrink-0 gap-1.5">
+        <Link href="/settings/integrations?select_repos=1">Choose repositories</Link>
+      </Button>
+    ) : (
+      <Button
+        size="sm"
+        variant="outline"
+        onClick={sync}
+        disabled={isSyncing}
+        className="shrink-0 gap-1.5"
+      >
+        <RefreshCw className={`h-3.5 w-3.5 ${isSyncing ? "animate-spin" : ""}`} />
+        {isSyncing ? "Syncing..." : "Sync repositories"}
+      </Button>
+    );
+    return (
+      <SetupItemRow
+        icon={<Github className="h-5 w-5" />}
+        title="Repository"
+        description={syncErrorMessage ?? message}
+        descriptionTone={syncErrorMessage && !needsReinstall ? "destructive" : "muted"}
+        action={rowAction}
+      />
+    );
+  }
 
   return (
     <div className="space-y-3 rounded-lg border border-warning/20 bg-warning/5 px-4 py-3">

--- a/frontend/src/components/setup-item-row.test.tsx
+++ b/frontend/src/components/setup-item-row.test.tsx
@@ -1,0 +1,35 @@
+import { describe, it, expect } from "vitest";
+import { renderWithProviders, screen } from "@/test/test-utils";
+import { SetupItemRow } from "./setup-item-row";
+
+describe("SetupItemRow", () => {
+  it("renders title, description, and action", () => {
+    renderWithProviders(
+      <SetupItemRow
+        icon={<span data-testid="icon" />}
+        title="Coding agent"
+        description="Codex isn't connected yet."
+        action={<button>Configure keys</button>}
+      />,
+    );
+    expect(screen.getByText("Coding agent")).toBeInTheDocument();
+    expect(screen.getByText("Codex isn't connected yet.")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Configure keys" })).toBeInTheDocument();
+    expect(screen.getByTestId("icon")).toBeInTheDocument();
+  });
+
+  it("shows a Connected badge when done and no action is provided", () => {
+    renderWithProviders(
+      <SetupItemRow icon={<span />} title="Repository" done />,
+    );
+    expect(screen.getByText("Connected")).toBeInTheDocument();
+  });
+
+  it("prefers the action over the done badge", () => {
+    renderWithProviders(
+      <SetupItemRow icon={<span />} title="Repository" done action={<button>Sync</button>} />,
+    );
+    expect(screen.getByRole("button", { name: "Sync" })).toBeInTheDocument();
+    expect(screen.queryByText("Connected")).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/setup-item-row.tsx
+++ b/frontend/src/components/setup-item-row.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import type { ReactNode } from "react";
+import { Badge } from "@/components/ui/badge";
+import { cn } from "@/lib/utils";
+
+interface SetupItemRowProps {
+  // A lucide icon element shown in the leading tile. Sized by the tile.
+  icon: ReactNode;
+  title: string;
+  description?: ReactNode;
+  // descriptionTone keeps status copy calm by default; use "destructive" for
+  // genuine errors (e.g. a failed sync).
+  descriptionTone?: "muted" | "destructive";
+  // action is the right-aligned control (a button or link). When omitted and
+  // done is true, a "Connected" badge is shown instead.
+  action?: ReactNode;
+  done?: boolean;
+}
+
+// SetupItemRow is the shared presentation for a single setup step. It mirrors
+// the onboarding integration/agent cards (leading rounded icon tile, title,
+// muted description, trailing action) so the build-page SetupRequirementsCard
+// and the /onboarding checklist read as one system rather than two.
+export function SetupItemRow({
+  icon,
+  title,
+  description,
+  descriptionTone = "muted",
+  action,
+  done = false,
+}: SetupItemRowProps) {
+  return (
+    <div className="flex items-center gap-3">
+      <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-muted/50 text-muted-foreground ring-1 ring-border/50 dark:bg-white/5">
+        {icon}
+      </div>
+      <div className="min-w-0 flex-1">
+        <p className="text-sm font-medium text-foreground">{title}</p>
+        {description && (
+          <p
+            className={cn(
+              "text-xs",
+              descriptionTone === "destructive" ? "text-destructive" : "text-muted-foreground",
+            )}
+          >
+            {description}
+          </p>
+        )}
+      </div>
+      {action ? (
+        <div className="shrink-0">{action}</div>
+      ) : done ? (
+        <Badge variant="secondary" className="shrink-0">Connected</Badge>
+      ) : null}
+    </div>
+  );
+}

--- a/frontend/src/components/setup-requirements-card.test.tsx
+++ b/frontend/src/components/setup-requirements-card.test.tsx
@@ -1,0 +1,49 @@
+import { describe, it, expect, vi } from "vitest";
+import { renderWithProviders, screen } from "@/test/test-utils";
+import { SetupRequirementsCard } from "./setup-requirements-card";
+
+// The card is purely presentational; stub the rows so the test doesn't depend
+// on NoReposWarning's network queries.
+vi.mock("./no-repos-warning", () => ({
+  NoReposWarning: () => <div data-testid="repo-row" />,
+}));
+vi.mock("./agent-key-required-banner", () => ({
+  AgentKeyRequiredBanner: ({ agentType }: { agentType: string }) => (
+    <div data-testid="agent-row">{agentType}</div>
+  ),
+}));
+
+describe("SetupRequirementsCard", () => {
+  it("renders nothing when no rows are needed", () => {
+    const { container } = renderWithProviders(
+      <SetupRequirementsCard showAgentRow={false} agentType="codex" showRepoRow={false} />,
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("renders only the agent row when flagged", () => {
+    renderWithProviders(
+      <SetupRequirementsCard showAgentRow agentType="codex" showRepoRow={false} />,
+    );
+    expect(screen.getByTestId("setup-requirements-card")).toBeInTheDocument();
+    expect(screen.getByTestId("agent-row")).toHaveTextContent("codex");
+    expect(screen.queryByTestId("repo-row")).not.toBeInTheDocument();
+  });
+
+  it("renders only the repo row when flagged", () => {
+    renderWithProviders(
+      <SetupRequirementsCard showAgentRow={false} agentType="codex" showRepoRow />,
+    );
+    expect(screen.getByTestId("repo-row")).toBeInTheDocument();
+    expect(screen.queryByTestId("agent-row")).not.toBeInTheDocument();
+  });
+
+  it("renders both rows in one card when both are flagged", () => {
+    renderWithProviders(
+      <SetupRequirementsCard showAgentRow agentType="claude_code" showRepoRow />,
+    );
+    expect(screen.getAllByTestId("setup-requirements-card")).toHaveLength(1);
+    expect(screen.getByTestId("agent-row")).toHaveTextContent("claude_code");
+    expect(screen.getByTestId("repo-row")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/setup-requirements-card.tsx
+++ b/frontend/src/components/setup-requirements-card.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import { Rocket } from "lucide-react";
+import { NoReposWarning } from "@/components/no-repos-warning";
+import { AgentKeyRequiredBanner } from "@/components/agent-key-required-banner";
+
+interface SetupRequirementsCardProps {
+  // The composer already computes both conditions from the resolved-credential
+  // and repository queries, so this card stays purely presentational.
+  showAgentRow: boolean;
+  agentType: string;
+  showRepoRow: boolean;
+}
+
+// SetupRequirementsCard collapses the previously separate "no API key" and
+// "no repositories" warnings into a single calm card. Both items are advisory
+// (a manual session can still be submitted without a repo, and the agent row
+// only appears when no credential resolves), so the container uses neutral
+// styling rather than stacking two alarm-colored banners on the build page.
+export function SetupRequirementsCard({
+  showAgentRow,
+  agentType,
+  showRepoRow,
+}: SetupRequirementsCardProps) {
+  if (!showAgentRow && !showRepoRow) return null;
+
+  return (
+    <div
+      className="rounded-lg border border-border bg-muted/40 px-4 py-3"
+      data-testid="setup-requirements-card"
+    >
+      <div className="flex items-center gap-2 text-xs font-medium text-muted-foreground">
+        <Rocket className="h-3.5 w-3.5 shrink-0" />
+        <span>Finish setting up</span>
+      </div>
+      <div className="mt-2 divide-y divide-border/60">
+        {showAgentRow && (
+          <div className="py-2 first:pt-0 last:pb-0">
+            <AgentKeyRequiredBanner agentType={agentType} asRow />
+          </div>
+        )}
+        {showRepoRow && (
+          <div className="py-2 first:pt-0 last:pb-0">
+            <NoReposWarning asRow />
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## What & why

A first-time user landing on the build page (`/sessions/new`) was greeted by **two stacked orange warning banners** — one for unclaimed GitHub repos, one for a missing agent key. This read as "something is broken" even when nothing was, and it duplicated the dedicated `/onboarding` checklist with slightly different logic.

This collapses the two advisory banners into a **single neutral `SetupRequirementsCard`**, and gives it the **same visual language as the onboarding checklist** via a new shared `SetupItemRow` primitive (rounded icon tile + title + muted description + trailing action).

## Changes

- **New `SetupItemRow`** (`frontend/src/components/setup-item-row.tsx`) — shared row presentation mirroring the onboarding agent/integration cards.
- **New `SetupRequirementsCard`** (`frontend/src/components/setup-requirements-card.tsx`) — one calm container; renders the agent row, the repo row, or both; renders nothing when setup is complete.
- **Fixed misleading agent-key copy** — the banner only renders when *no* credential resolves at all, so the old _"Org-wide credentials are used as a fallback"_ line claimed a fallback that didn't exist. New copy: _"{agent} isn't connected yet — add a key or sign in so your sessions can run."_
- **Additive `asRow` variant** on `NoReposWarning` and `AgentKeyRequiredBanner` that renders through `SetupItemRow`. The standalone banner rendering is left **untouched**, so existing behavior and tests are preserved.
- **Composer** swaps the two banner blocks for the single card.

## Design decisions

- **Advisory, not blocking.** Manual sessions can be created without a repo (`repository_id` is optional in the submit payload) and without resolved creds, so the card guides rather than gates — no submit-behavior change.
- **Additive on `no-repos-warning.tsx`.** A separate, unmerged local effort also reworks that file's banner; keeping this change additive (new `asRow` path only) avoids absorbing or conflicting with that work.

## Tests

- Added `setup-item-row.test.tsx`, `setup-requirements-card.test.tsx`, plus `asRow` cases on the agent-banner and no-repos tests.
- Full affected suite: **64 passing**. Typecheck and lint clean on all touched files.

## Verification note

Not previewed live — this empty state sits behind auth and needs the full stack seeded with no-repos/no-creds; covered by unit tests instead. Happy to seed + screenshot if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
