### PR TITLE
Isolate org state per tab and scope the query cache by org

### DIFF
--- a/frontend/AGENTS.md
+++ b/frontend/AGENTS.md
@@ -526,6 +526,23 @@ Settings-style endpoints (user settings, org settings, per-resource preference d
 - **When adding a new settings-style endpoint, give it merge-patch semantics on the backend** rather than full-document replace, so callers are never forced into the cache-merge pattern. See `UserStore.MergeSettings` + `models.ApplyUserSettingsMergePatch` for the server-side reference implementation, and the backend rule in `internal/AGENTS.md`.
 - If multiple rapid edits to the same patch field are coalesced client-side (in-flight + queued refs), **merge queued patches per key** instead of replacing the queue, so edits to different keys all land.
 
+## Active organization (multi-tenancy)
+
+A user can belong to many orgs and have **a different org open in each browser tab**. Getting this right is a correctness requirement, not a nicety — mixing two orgs' data on one screen is a data-leak-shaped bug. There is exactly one client-side source of truth for "which org is this tab acting as":
+
+> **`src/lib/active-org.ts` — the per-tab `active_org_id` in `sessionStorage`. Read it with `getActiveOrgId()`; change it only with `setActiveOrgId()`.**
+
+Everything else is downstream of that value. Do not introduce a second store (React context, a Zustand slice, a second storage key, a prop drilled from the server) for "current org" — funnel through `active-org.ts`.
+
+How the value flows and why:
+
+- **Every org-scoped request carries it as the `X-Active-Org-ID` header** (`src/lib/api.ts`). EventSource streams can't send headers, so they pass it as the `?org_id=` query param (`src/lib/sse.ts`). If you add a new request path, it must carry the active org one of these two ways.
+- **Never rely on the server's `last_org_id` fallback for correctness.** The backend falls back to the session's `last_org_id` only when no header/param is present — and that hint is **shared across all of the user's tabs**, so any sibling tab can change it. A request that omits the header resolves against whatever org another tab last touched. That is the original cause of the "two workspaces blended into one screen" bug.
+- **A fresh tab adopts, but never mutates, the shared hint.** `OrgSwitcher` pins the server-resolved active org into this tab's `sessionStorage` on first load (local `setActiveOrgId`, **not** `api.auth.setActiveOrg`) so the tab immediately starts sending an explicit header. Adopting is read-only; only an explicit user switch (`activateOrgAndNavigate`) writes the server-side hint and drags future cold loads along.
+- **The React Query cache is scoped to the active org structurally** (`src/components/providers.tsx`): the `QueryClient` is recreated whenever `active_org_id` changes. **Do not encode the org id into individual `queryKey`s** — the boundary lives in the provider, in one place, so no current or future query (or invalidation prefix) has to remember to include it. Org-scoped query keys (`["sessions", …]`, `["integrations"]`, `["repositories"]`, etc.) stay org-free on purpose; the surrounding client is what makes them org-correct.
+
+When you touch anything org-aware, the test is: *could a request resolve to the wrong org because the header was missing, or could org A's cached data survive into an org-B client?* If either is possible, route the org through `active-org.ts` and let the provider own cache isolation.
+
 ## Error Reporting (Sentry)
 
 Errors are reported to Sentry via `@sentry/nextjs`. Three layers handle this automatically:

--- a/frontend/src/components/org-switcher.test.tsx
+++ b/frontend/src/components/org-switcher.test.tsx
@@ -84,6 +84,30 @@ describe("OrgSwitcher", () => {
     });
   });
 
+  it("adopts the server-resolved active org into sessionStorage on first load, without writing it server-side", async () => {
+    let setActiveOrgCalls = 0;
+    // Fresh tab: beforeEach cleared sessionStorage, so nothing is pinned yet.
+    mockMemberships([{ org_id: "org-1", org_name: "Acme", role: "admin" }], "org-1");
+    server.use(
+      http.post("/api/v1/auth/active-org", () => {
+        setActiveOrgCalls += 1;
+        return new HttpResponse(null, { status: 204 });
+      }),
+    );
+
+    renderWithProviders(<OrgSwitcher userEmail="alex@example.com" />);
+
+    // Once memberships resolve, the tab pins the server-resolved org so every
+    // subsequent request carries an explicit X-Active-Org-ID header instead of
+    // relying on the shared, sibling-tab-mutable last_org_id fallback.
+    await waitFor(() => {
+      expect(getActiveOrgId()).toBe("org-1");
+    });
+    // Adoption is strictly local: it must NOT POST /auth/active-org, which
+    // would mutate the cross-tab hint and drag sibling tabs to this org.
+    expect(setActiveOrgCalls).toBe(0);
+  });
+
   it("shows all memberships in the dropdown with a check on the active one", async () => {
     mockMemberships(
       [
@@ -626,7 +650,11 @@ describe("OrgSwitcher", () => {
       await userEvent.click(await screen.findByTestId("joinable-org-join-org-2"));
 
       expect(await screen.findByText("Joined Assembled")).toBeInTheDocument();
-      expect(getActiveOrgId()).toBeNull();
+      // Joining must not switch the active org to the joined org. The tab still
+      // adopts the server-resolved active org (org-1) on bootstrap, so the
+      // assertion is "not the joined org", not "nothing pinned".
+      expect(getActiveOrgId()).not.toBe("org-2");
+      expect(getActiveOrgId()).toBe("org-1");
     });
 
     it("a join rejected as NOT_ELIGIBLE surfaces an error toast", async () => {

--- a/frontend/src/components/org-switcher.tsx
+++ b/frontend/src/components/org-switcher.tsx
@@ -126,6 +126,26 @@ export function OrgSwitcher({ userEmail }: OrgSwitcherProps) {
     return () => window.removeEventListener(ACTIVE_ORG_CHANGED_EVENT, handler);
   }, []);
 
+  // Bootstrap: pin the server-resolved active org into this tab's
+  // sessionStorage the first time it resolves, so every subsequent request
+  // carries an explicit X-Active-Org-ID header. A fresh tab starts with empty
+  // sessionStorage and therefore sends NO header, leaving the backend to fall
+  // back to the *shared* session last_org_id — which any sibling tab can
+  // overwrite at any moment (see internal/api/middleware/auth.go). That
+  // fallback is exactly how one tab's data used to bleed into another. Writing
+  // the resolved id here closes the hole: the backend's "skip last_org_id
+  // write when a header is present" guard only protects tabs that actually
+  // send the header.
+  //
+  // Adoption is deliberately local-only — it does NOT call api.auth.setActiveOrg,
+  // so it never mutates the shared hint or drags sibling tabs to this org. Only
+  // an explicit switch (activateOrgAndNavigate) writes the server-side hint.
+  useEffect(() => {
+    if (!tabOrgId && serverActiveOrgId) {
+      setActiveOrgId(serverActiveOrgId);
+    }
+  }, [tabOrgId, serverActiveOrgId]);
+
   // Name the currently-active org in the revocation toast. Capturing via ref
   // lets us read the label the user *had* right before the server signaled
   // revocation without making invalidateQueries race our own read of it.

--- a/frontend/src/components/providers.test.tsx
+++ b/frontend/src/components/providers.test.tsx
@@ -1,6 +1,8 @@
-import { renderWithProviders, screen } from "@/test/test-utils";
-import { useQueryClient } from "@tanstack/react-query";
+import { renderWithProviders, screen, waitFor } from "@/test/test-utils";
+import { act, render } from "@testing-library/react";
+import { QueryClient, useQueryClient } from "@tanstack/react-query";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ACTIVE_ORG_CHANGED_EVENT } from "@/lib/active-org";
 import { Providers, shouldRetryQuery } from "./providers";
 
 function QueryDefaultsProbe() {
@@ -17,8 +19,16 @@ function QueryDefaultsProbe() {
   );
 }
 
+// Records the QueryClient instance the provider hands down on every render so a
+// test can detect when the provider swaps it.
+function ClientProbe({ onClient }: { onClient: (client: QueryClient) => void }) {
+  onClient(useQueryClient());
+  return null;
+}
+
 describe("Providers", () => {
   beforeEach(() => {
+    window.sessionStorage.clear();
     Object.defineProperty(window, "matchMedia", {
       configurable: true,
       writable: true,
@@ -60,5 +70,52 @@ describe("Providers", () => {
     expect(shouldRetryQuery(0, { status: 500 })).toBe(true);
     expect(shouldRetryQuery(1, new Error("network reset"))).toBe(true);
     expect(shouldRetryQuery(2, new Error("network reset"))).toBe(false);
+  });
+
+  it("swaps in a fresh query client when the active org switches, clearing the old one", async () => {
+    window.sessionStorage.setItem("active_org_id", "org-a");
+    const clients: QueryClient[] = [];
+    render(
+      <Providers>
+        <ClientProbe onClient={(c) => clients.push(c)} />
+      </Providers>,
+    );
+    const first = clients[clients.length - 1];
+    first.setQueryData(["sessions"], ["cached-for-org-a"]);
+
+    act(() => {
+      window.sessionStorage.setItem("active_org_id", "org-b");
+      window.dispatchEvent(new CustomEvent(ACTIVE_ORG_CHANGED_EVENT));
+    });
+
+    await waitFor(() => {
+      expect(clients[clients.length - 1]).not.toBe(first);
+    });
+    // The discarded client is cleared immediately rather than left pinned alive
+    // by its gcTime timers, so org-A data can't linger after the switch.
+    expect(first.getQueryData(["sessions"])).toBeUndefined();
+  });
+
+  it("keeps the warm cache on first-load adoption (null → org) instead of refetching", () => {
+    // Fresh tab: nothing pinned at mount, so the provider's baseline is null.
+    const clients: QueryClient[] = [];
+    render(
+      <Providers>
+        <ClientProbe onClient={(c) => clients.push(c)} />
+      </Providers>,
+    );
+    const first = clients[clients.length - 1];
+    first.setQueryData(["sessions"], ["warm"]);
+
+    act(() => {
+      window.sessionStorage.setItem("active_org_id", "org-a");
+      window.dispatchEvent(new CustomEvent(ACTIVE_ORG_CHANGED_EVENT));
+    });
+
+    // No swap: the adopted org is the one header-less queries already resolved
+    // against via last_org_id, so the cache is correct — recreating it would
+    // only discard good data and force a needless refetch.
+    expect(clients[clients.length - 1]).toBe(first);
+    expect(first.getQueryData(["sessions"])).toEqual(["warm"]);
   });
 });

--- a/frontend/src/components/providers.tsx
+++ b/frontend/src/components/providers.tsx
@@ -2,10 +2,11 @@
 
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { NuqsAdapter } from "nuqs/adapters/next/app";
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 import { ErrorBoundary } from "@/components/error-boundary";
 import { ThemeProvider } from "@/components/theme-provider";
 import { DocumentTitle } from "@/components/document-title";
+import { ACTIVE_ORG_CHANGED_EVENT, getActiveOrgId } from "@/lib/active-org";
 
 export const DEFAULT_QUERY_STALE_TIME_MS = 30_000;
 export const DEFAULT_QUERY_GC_TIME_MS = 10 * 60_000;
@@ -25,23 +26,65 @@ export function shouldRetryQuery(failureCount: number, error: unknown): boolean 
   return failureCount < DEFAULT_QUERY_RETRY_LIMIT;
 }
 
+function createQueryClient(): QueryClient {
+  return new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: shouldRetryQuery,
+        staleTime: DEFAULT_QUERY_STALE_TIME_MS,
+        gcTime: DEFAULT_QUERY_GC_TIME_MS,
+        refetchOnWindowFocus: false,
+      },
+      mutations: {
+        retry: 0,
+      },
+    },
+  });
+}
+
 export function Providers({ children }: { children: React.ReactNode }) {
-  const [queryClient] = useState(
-    () =>
-      new QueryClient({
-        defaultOptions: {
-          queries: {
-            retry: shouldRetryQuery,
-            staleTime: DEFAULT_QUERY_STALE_TIME_MS,
-            gcTime: DEFAULT_QUERY_GC_TIME_MS,
-            refetchOnWindowFocus: false,
-          },
-          mutations: {
-            retry: 0,
-          },
-        },
-      })
-  );
+  // The QueryClient is scoped to the active org: when the tab switches between
+  // orgs we swap in a brand-new client, structurally guaranteeing that two
+  // orgs' data can never coexist in one cache. We deliberately do NOT encode
+  // the org id into individual query keys — that would mean every current and
+  // future org-scoped query (and every invalidation prefix) has to remember to
+  // include it, and missing one silently reintroduces cross-org bleed. The org
+  // boundary lives here, in one place, instead. See frontend/AGENTS.md →
+  // "Active organization (multi-tenancy)".
+  const [queryClient, setQueryClient] = useState(createQueryClient);
+
+  // Swap in a fresh client when the active org changes between two concrete
+  // ids (a real switch), or drops to none (revocation). This supersedes the
+  // explicit queryClient.clear() that org switching also does — that clear is
+  // now belt-and-suspenders.
+  //
+  // We deliberately do NOT swap on the first-load `null → org` adoption that
+  // OrgSwitcher performs. That isn't a switch: the org being adopted is the
+  // one the server already resolved this tab to, so any queries that raced
+  // ahead and fetched header-less (falling back to the same last_org_id) hold
+  // correctly-scoped data. Recreating the client there would throw away a warm
+  // cache and force a full refetch on every cold load for no correctness gain.
+  const activeOrgRef = useRef<string | null>(null);
+  useEffect(() => {
+    activeOrgRef.current = getActiveOrgId();
+    const handler = () => {
+      const next = getActiveOrgId();
+      const prev = activeOrgRef.current;
+      if (next === prev) return;
+      activeOrgRef.current = next;
+      // First-load adoption (null → org): keep the warm cache (see above).
+      if (prev === null) return;
+      // Real org → org (or org → null) change: replace the client so org-A
+      // data can't survive into org B, and clear the discarded one now rather
+      // than leaving its cache pinned alive by gcTime timers.
+      setQueryClient((old) => {
+        old.clear();
+        return createQueryClient();
+      });
+    };
+    window.addEventListener(ACTIVE_ORG_CHANGED_EVENT, handler);
+    return () => window.removeEventListener(ACTIVE_ORG_CHANGED_EVENT, handler);
+  }, []);
 
   useEffect(() => {
     // ── P-80 Shooting Star easter egg ──────────────────────────────────────────


### PR DESCRIPTION
## Problem

A user who belongs to multiple orgs could see **two workspaces blended onto one screen** — e.g. one org's session detail in the right pane beside another org's "GitHub connected, but no repositories claimed" card and empty session list. It looked like the two orgs were combined.

### Root cause

There were three unsynchronized sources of truth for "which org is this tab acting as":

1. **Per-tab `sessionStorage` `active_org_id`** → sent as the `X-Active-Org-ID` header.
2. **Server session `last_org_id`** → used only when no header is sent, and **shared across all of the user's tabs**.
3. **React Query cache** → keyed org-scoped data *without* the org id.

A fresh tab (opened by URL, never explicitly switched) has empty `sessionStorage`, so it sends **no header** and the backend falls back to the shared `last_org_id` — which any *other* tab can overwrite at any moment ([`internal/api/middleware/auth.go`](https://github.com/assembledhq/143/blob/main/internal/api/middleware/auth.go)). Combined with an org-blind cache, different queries in one tab could resolve to different orgs and their data could coexist.

## Fixes

**1. Every tab pins and sends its own org** (`org-switcher.tsx`)
`OrgSwitcher` now writes the server-resolved active org into this tab's `sessionStorage` on first load, so every subsequent request carries an explicit `X-Active-Org-ID`. Adoption is **local-only** (no `api.auth.setActiveOrg` call), so it never mutates the shared hint or drags sibling tabs to this org. The backend's existing "skip the `last_org_id` write when a header is present" guard now actually protects every tab.

**2. Cache is scoped to the active org structurally** (`providers.tsx`)
The `QueryClient` is recreated on a real `org → org` switch (and `org → null` revocation), so two orgs' data can never share a cache, and the discarded client is `clear()`-ed immediately rather than lingering until `gcTime`. The first-load `null → org` adoption deliberately **keeps the warm cache** — that data already resolved against the same org via `last_org_id`, so recreating would only force a needless refetch on every cold load.

**3. Documentation** (`frontend/AGENTS.md`)
New "Active organization (multi-tenancy)" section naming `src/lib/active-org.ts` as the single source of truth, and the rule: don't encode org id into query keys — the provider owns cache isolation.

## Resulting behavior

- Open a new tab on a different org → **old tabs stay put** (each sends its own pinned header; the backend skips the shared-hint write).
- A brand-new tab adopts your most recent explicit choice as its starting org but never pulls existing tabs to follow it.
- Within a tab the org is constant for its lifetime; the only transition (explicit switch) swaps the entire cache — so the blended-workspace screen can't happen.

## Testing

- `org-switcher.test.tsx`: a fresh tab pins the server-resolved org **and** does not POST `/auth/active-org` (adoption is local-only).
- `providers.test.tsx`: org→org switch swaps in a fresh client and clears the old cache; `null→org` adoption keeps the same client and its warm cache.
- `tsc --noEmit`, `eslint`, and `vitest` (28 tests) all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)