### PR TITLE
Lead landing with team-first headline and tighten nav buttons

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # 143
 
-Open-source autopilot for coding agents.
+The open-source platform where your whole team builds software together.
 
-143 gives engineering teams one shared place to run coding agents in the cloud, connect them to the tools that hold product context, and turn the result into reviewable GitHub PRs.
+143 gives your whole team one shared place to run coding agents in the cloud, connect them to the tools that hold product context, and turn the result into reviewable GitHub PRs.
 
 [143.dev](https://www.143.dev) · [Getting started](#getting-started) · [Development setup](docs/contributing/development-setup.md) · [Architecture](docs/design/overall.md) · [Self-hosting](docs/self-hosting/README.md)
 

--- a/docs/public/index.mdx
+++ b/docs/public/index.mdx
@@ -11,7 +11,7 @@ tags:
 llm_summary: Start here for public 143.dev documentation, including setup guides, repo configuration, previews, Linear, self-hosting, and reference material.
 ---
 
-143 is built for engineering teams that want coding agents to feel like shared execution infrastructure, not a set of solo terminal sessions. It defaults to team-level workflows: shared context, sandboxed runs, visible diffs, live previews, pull requests, and a clear link back to the issue, error, or automation that started the work.
+143 is where your whole team builds software together — engineers and non-engineers running coding agents as shared execution infrastructure. It defaults to team-level workflows: shared context, sandboxed runs, visible diffs, live previews, pull requests, and a clear link back to the issue, error, or automation that started the work.
 
 The core idea is simple: keep agent work close to the systems engineers already trust. GitHub stays the source of truth for branches, PRs, review, CI, and merge rules. 143 owns the workflow around the agent: setup, context, credentials, sandbox execution, previews, follow-ups, auditability, and automation.
 

--- a/frontend/src/app/manifest.ts
+++ b/frontend/src/app/manifest.ts
@@ -4,7 +4,7 @@ export default function manifest(): MetadataRoute.Manifest {
   return {
     name: "143",
     short_name: "143",
-    description: "Shared coding-agent infrastructure for engineering teams.",
+    description: "Where your whole team builds software together with coding agents.",
     start_url: "/",
     scope: "/",
     display: "standalone",

--- a/frontend/src/components/landing/hero-section.tsx
+++ b/frontend/src/components/landing/hero-section.tsx
@@ -41,7 +41,7 @@ export default function HeroSection({ isDark }: HeroSectionProps) {
           <Button
             asChild
             variant="ghost"
-            className={`${type.button} ${
+            className={`${type.button} px-3 ${
               isDark
                 ? "text-white/60 hover:bg-white/5 hover:text-white"
                 : "text-slate-600 hover:bg-slate-900/5 hover:text-slate-900"
@@ -52,7 +52,7 @@ export default function HeroSection({ isDark }: HeroSectionProps) {
           <Button
             asChild
             variant="ghost"
-            className={`hidden ${type.button} sm:inline-flex ${
+            className={`hidden ${type.button} px-3 sm:inline-flex ${
               isDark
                 ? "text-white/60 hover:bg-white/5 hover:text-white"
                 : "text-slate-600 hover:bg-slate-900/5 hover:text-slate-900"
@@ -84,7 +84,7 @@ export default function HeroSection({ isDark }: HeroSectionProps) {
               isDark ? "text-white" : "text-slate-900"
             }`}
           >
-            Shared coding agent automations, not private prompts
+            Where your whole team builds software together
           </h1>
 
           <p

--- a/frontend/src/components/landing/how-it-works-section.tsx
+++ b/frontend/src/components/landing/how-it-works-section.tsx
@@ -129,9 +129,9 @@ export default function HowItWorksSection({ isDark }: HowItWorksSectionProps) {
               place to run, review, and schedule it.
             </h2>
             <p className={`max-w-2xl ${type.body} ${body}`}>
-              143 turns private prompts, local runs, and one-off fixes into a
-              shared system with context, previews, review loops, and history
-              the whole team can trust.
+              143 turns scattered local runs and one-off fixes into a shared
+              system with context, previews, review loops, and history the
+              whole team can trust.
             </p>
           </div>
         </div>


### PR DESCRIPTION
## Summary

The landing hero led with "Shared coding agent automations, not private prompts" — an insider feature contrast that put no people in the message and undersold the platform with its narrowest slice. This leads instead with the team angle (engineers and non-engineers building in one place) via "Where your whole team builds software together," and carries that positioning across the other public-facing surfaces.

## Changes

- **Hero headline** → "Where your whole team builds software together" (`hero-section.tsx`).
- **Public copy aligned** to the team-first message: README tagline, Fumadocs docs landing (`docs/public/index.mdx`), and the PWA/meta manifest description; retired the matching "private prompts" / "solo terminal sessions" foil language in the landing "why this matters" section.
- **Nav button padding** tightened on Docs and Sign in (`px-7` → `px-3`) so they read as text links rather than wide, spread-apart ghost buttons; the Start CTA keeps its roomier padding.

## Validation

- Verified the new headline and tighter nav buttons render correctly in the local dev preview (light mode).
- Repo-wide grep confirms no leftover "private prompts" / "coding agent automations" / "solo terminal" / "infrastructure for engineering teams" strings in public-facing files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
