### PR TITLE
Simplify org auths header to a single "View personal auths" button

### DIFF
--- a/frontend/src/app/(dashboard)/settings/agent/page.test.tsx
+++ b/frontend/src/app/(dashboard)/settings/agent/page.test.tsx
@@ -70,8 +70,8 @@ describe("Agent settings page", () => {
     expect((await screen.findAllByText("Team seat A")).length).toBeGreaterThan(0);
     expect(screen.getByRole("heading", { name: "Organization-wide auths" })).toBeInTheDocument();
     expect(screen.getByText("Personal auths run first for each user. When none are available, sessions fall back to this stack, running top to bottom. Move the auth you want to prefer higher in the list.")).toBeInTheDocument();
-    expect(screen.getByRole("link", { name: "Personal auths" })).toHaveAttribute("href", "/settings/account");
-    expect(screen.getByRole("link", { name: "Sandboxes" })).toHaveAttribute("href", "/settings/runtime");
+    expect(screen.getByRole("link", { name: "View personal auths" })).toHaveAttribute("href", "/settings/account");
+    expect(screen.queryByRole("link", { name: "Sandboxes" })).not.toBeInTheDocument();
     expect(screen.queryByLabelText("Max concurrent sessions")).not.toBeInTheDocument();
     expect(screen.queryByLabelText("Session max time (minutes)")).not.toBeInTheDocument();
     expect(screen.queryByLabelText("Agent tab tools")).not.toBeInTheDocument();
@@ -87,7 +87,7 @@ describe("Agent settings page", () => {
 
     expect(await screen.findByText("Read-only view. Only admins can add, edit, or reorder coding auths.")).toBeInTheDocument();
     expect(screen.getByText("Personal auths run first for each user. When none are available, sessions fall back to this stack, running top to bottom.")).toBeInTheDocument();
-    expect(screen.getByRole("link", { name: "Personal auths" })).toHaveAttribute("href", "/settings/account");
+    expect(screen.getByRole("link", { name: "View personal auths" })).toHaveAttribute("href", "/settings/account");
     expect(screen.queryByRole("link", { name: "Sandboxes" })).not.toBeInTheDocument();
   });
 

--- a/frontend/src/app/(dashboard)/settings/agent/page.tsx
+++ b/frontend/src/app/(dashboard)/settings/agent/page.tsx
@@ -115,7 +115,7 @@ function defaultLabel(provider: ModalProvider, authType: AddFlowAuthType) {
   }
 }
 
-function OrgAuthsHeader({ isAdmin, showReorderHint }: { isAdmin: boolean; showReorderHint?: boolean }) {
+function OrgAuthsHeader({ showReorderHint }: { showReorderHint?: boolean }) {
   return (
     <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
       <div className="space-y-1.5">
@@ -127,13 +127,8 @@ function OrgAuthsHeader({ isAdmin, showReorderHint }: { isAdmin: boolean; showRe
       </div>
       <div className="flex flex-wrap gap-2">
         <Button asChild variant="outline" size="sm">
-          <Link href="/settings/account">Personal auths</Link>
+          <Link href="/settings/account">View personal auths</Link>
         </Button>
-        {isAdmin && (
-          <Button asChild variant="outline" size="sm">
-            <Link href="/settings/runtime">Sandboxes</Link>
-          </Button>
-        )}
       </div>
     </div>
   );
@@ -364,7 +359,7 @@ export default function AgentPage() {
             Read-only view. Only admins can add, edit, or reorder coding auths.
           </div>
           <section className="space-y-3">
-            <OrgAuthsHeader isAdmin={isAdmin} />
+            <OrgAuthsHeader />
             {rows.length === 0 ? (
               <Card>
                 <EmptyState
@@ -447,7 +442,7 @@ export default function AgentPage() {
           )}
         />
         <section className="space-y-4">
-          <OrgAuthsHeader isAdmin={isAdmin} showReorderHint />
+          <OrgAuthsHeader showReorderHint />
           <CodingAuthStack
             rows={rows}
             selectedId={selectedId}


### PR DESCRIPTION
## Summary

The org-wide coding auths header was cluttered with two buttons — a "Personal auths" link and an admin-only "Sandboxes" shortcut — where the Sandboxes link was tangential to the auths context. This trims the header to a single, clearly-labeled "View personal auths" button for a cleaner UI.

## Changes

- Remove the admin-only "Sandboxes" button (the `/settings/runtime` link) from `OrgAuthsHeader`.
- Relabel the remaining button from "Personal auths" to "View personal auths".
- Drop the now-unused `isAdmin` prop from `OrgAuthsHeader` and its call sites.

## Validation

- Updated `agent/page.test.tsx` to assert the new "View personal auths" label and that the Sandboxes link is no longer rendered.
- Note: this branch is a fresh git worktree without `node_modules`, so vitest/typecheck were not run locally; CI will exercise them.