### PR TITLE
Capitalize GitHub claim auth-required error message

### DIFF
--- a/internal/api/handlers/integrations.go
+++ b/internal/api/handlers/integrations.go
@@ -1735,7 +1735,7 @@ func (h *IntegrationHandler) ClaimGitHubInstallationRepositories(w http.Response
 		return
 	}
 	if h.githubAppUserAuth == nil {
-		writeError(w, r, http.StatusBadRequest, "GITHUB_USER_AUTH_REQUIRED", "connect your GitHub account before claiming repositories")
+		writeError(w, r, http.StatusBadRequest, "GITHUB_USER_AUTH_REQUIRED", "Connect your GitHub account before claiming repositories")
 		return
 	}
 
@@ -1776,7 +1776,7 @@ func (h *IntegrationHandler) ClaimGitHubInstallationRepositories(w http.Response
 
 	userCredential, err := h.githubAppUserAuth.GetValidCredential(ctx, orgID, user.ID)
 	if err != nil || userCredential == nil || userCredential.AccessToken == "" {
-		writeError(w, r, http.StatusBadRequest, "GITHUB_USER_AUTH_REQUIRED", "connect your GitHub account before claiming repositories")
+		writeError(w, r, http.StatusBadRequest, "GITHUB_USER_AUTH_REQUIRED", "Connect your GitHub account before claiming repositories")
 		return
 	}
 


### PR DESCRIPTION
## What

Capitalizes the "Connect your GitHub account before claiming repositories" error returned by the repository-claim handler.

The message is returned by `ClaimGitHubInstallationRepositories` (`internal/api/handlers/integrations.go`) with code `GITHUB_USER_AUTH_REQUIRED` and surfaces verbatim in the org settings → integrations UI, where the frontend renders it directly via `claimError.message`. It was lowercase (`connect ...`) in both code paths.

The frontend test (`frontend/src/app/(dashboard)/settings/integrations/page.test.tsx:214`) already asserts the capitalized form `"Connect your GitHub account before claiming repositories"`, so the backend copy was simply out of sync. This brings the two into alignment.

## Why

Sentence-case copy for a user-facing notice; matches the casing the frontend already expects.

## Note (not changed here)

This error fires when a user has installed the org-level GitHub App (which lets the org see repos) but has not completed the separate per-user GitHub OAuth connect for that org — the credential is scoped per `(org_id, user_id)`, so it does not carry over between orgs and can be auto-disabled if a token lapses. That is expected behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
