### PR TITLE
Trim excess padding above auth success message

### DIFF
--- a/frontend/src/components/claude-code-auth-modal.tsx
+++ b/frontend/src/components/claude-code-auth-modal.tsx
@@ -169,9 +169,7 @@ export function ClaudeCodeAuthModal({
         )}
 
         {status === "completed" && (
-          <div className="mt-4">
-            <p className="text-sm font-medium text-success">Connected successfully!</p>
-          </div>
+          <p className="text-sm font-medium text-success">Connected successfully!</p>
         )}
 
         {status === "error" && (

--- a/frontend/src/components/codex-device-code-modal.tsx
+++ b/frontend/src/components/codex-device-code-modal.tsx
@@ -179,7 +179,7 @@ export function CodexDeviceCodeModal({
             </div>
           </div>
         )}
-        {status === "completed" && <div className="mt-4"><p className="text-sm font-medium text-success">Connected successfully!</p></div>}
+        {status === "completed" && <p className="text-sm font-medium text-success">Connected successfully!</p>}
         {(status === "error" || status === "expired") && (
           <div className="mt-4">
             <ErrorText className="text-sm">{error}</ErrorText>


### PR DESCRIPTION
## Summary

When Claude Code or Codex completes authentication, the success message in the auth modals sat with excessive space above it.

`ResponsiveModalBody` already applies `py-5` (20px top padding). The completed-state success message additionally wrapped itself in `<div className="mt-4">`, stacking another 16px on top — so ~36px of padding appeared above "Connected successfully!" when it's the only content in the body. The `mt-4` is only meaningful in the multi-step flows where the message stacks below other content.

This drops the wrapper div so the success message relies solely on the body's own padding.

- `frontend/src/components/claude-code-auth-modal.tsx`
- `frontend/src/components/codex-device-code-modal.tsx`

## Notes

The `completed` state is gated behind a real OAuth exchange, so it isn't reachable in a browser preview without live credentials. The change is a self-contained spacing fix (removing a redundant margin wrapper).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
