### PR TITLE
Rewrite About page as an editorial founder note

### DIFF
--- a/frontend/src/app/(landing)/about/page.test.tsx
+++ b/frontend/src/app/(landing)/about/page.test.tsx
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+import { renderWithProviders, screen } from "@/test/test-utils";
+import AboutPage from "./page";
+
+describe("AboutPage", () => {
+  it("renders as a plain editorial note from John", () => {
+    renderWithProviders(<AboutPage />);
+
+    expect(screen.getByRole("heading", { name: "Why we built 143" })).toBeInTheDocument();
+    expect(screen.getByRole("article", { name: "Why we built 143" })).toBeInTheDocument();
+    expect(screen.queryByText("Founder note")).not.toBeInTheDocument();
+    expect(screen.getByText(/I really hope you like it/i)).toBeInTheDocument();
+    expect(screen.getByText("John")).toBeInTheDocument();
+  });
+
+  it("explains why 143 was built for production teams", () => {
+    renderWithProviders(<AboutPage />);
+
+    expect(screen.getByText(/very impressive in fresh repos/i)).toBeInTheDocument();
+    expect(screen.getByText(/we needed more in order to actually get them working well/i)).toBeInTheDocument();
+    expect(screen.getByText(/across teams of engineers and non-engineers/i)).toBeInTheDocument();
+    expect(screen.getByText(/That.s why we built 143 and open sourced it/i)).toBeInTheDocument();
+    expect(screen.getByText(/real product work, not just demos and internal tools/i)).toBeInTheDocument();
+    expect(screen.getByText(/production systems across teams/i)).toBeInTheDocument();
+    expect(screen.getByText(/shared infrastructure problem/i)).toBeInTheDocument();
+    expect(screen.getByText(/vibe coding is not the right word/i)).toBeInTheDocument();
+    expect(screen.queryByText(/We had real FOMO/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Also, vibe coding/i)).not.toBeInTheDocument();
+  });
+
+  it("describes how 143 helps non-engineers write code safely", () => {
+    renderWithProviders(<AboutPage />);
+
+    expect(screen.getAllByText(/domain experts/i).length).toBeGreaterThan(0);
+    expect(screen.getByText(/write real code/i)).toBeInTheDocument();
+    expect(screen.getAllByText(/review gates/i).length).toBeGreaterThan(0);
+  });
+
+  it("covers the team-level product choices behind 143", () => {
+    renderWithProviders(<AboutPage />);
+
+    expect(screen.getByText(/automations should be visible to the team/i)).toBeInTheDocument();
+    expect(screen.getByText(/swap out intelligence/i)).toBeInTheDocument();
+    expect(screen.getByText(/set up a great environment once/i)).toBeInTheDocument();
+  });
+
+  it("uses inline callouts to annotate the note", () => {
+    renderWithProviders(<AboutPage />);
+
+    expect(screen.getByRole("note", { name: "What was missing" })).toBeInTheDocument();
+    expect(screen.getByRole("note", { name: "For non-engineers" })).toBeInTheDocument();
+    expect(screen.getByRole("note", { name: "Why open source" })).toBeInTheDocument();
+  });
+
+  it("states the open-source and pricing principles", () => {
+    renderWithProviders(<AboutPage />);
+
+    expect(screen.getByRole("heading", { name: /open source/i })).toBeInTheDocument();
+    expect(screen.getByText(/Ruby on Rails/i)).toBeInTheDocument();
+    expect(screen.getByText(/Aaron Patterson/i)).toBeInTheDocument();
+    expect(screen.queryByText(/tenderlove/i)).not.toBeInTheDocument();
+    expect(screen.getByText(/charging just for the containers you run/i)).toBeInTheDocument();
+  });
+
+  it("avoids heavy product-page visual sections", () => {
+    renderWithProviders(<AboutPage />);
+
+    expect(screen.queryByLabelText("143 origin visual")).not.toBeInTheDocument();
+    expect(screen.queryByRole("heading", { name: "From individual tools to shared infrastructure" })).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/app/(landing)/about/page.tsx
+++ b/frontend/src/app/(landing)/about/page.tsx
@@ -3,152 +3,228 @@
 import { usePrefersDark } from "@/hooks/use-prefers-dark";
 import Link from "next/link";
 import Footer from "@/components/landing/footer";
+import type { ReactNode } from "react";
 
 export default function AboutPage() {
   const isDark = usePrefersDark();
+  const navLinkClass = `text-sm font-medium ${
+    isDark ? "text-white/60 hover:text-white" : "text-slate-600 hover:text-slate-900"
+  } transition-colors`;
+  const pageTitleClass = `text-2xl sm:text-3xl font-light tracking-tight ${
+    isDark ? "text-white" : "text-slate-900"
+  }`;
+  const ledeClass = `max-w-2xl text-base leading-7 ${
+    isDark ? "text-white/58" : "text-slate-600"
+  }`;
+  const bodyClass = `space-y-6 text-sm leading-7 ${
+    isDark ? "text-white/58" : "text-slate-600"
+  }`;
+  const headingClass = `text-base font-medium ${
+    isDark ? "text-white/78" : "text-slate-800"
+  }`;
+  const metaClass = `text-xs font-medium uppercase tracking-wider ${
+    isDark ? "text-white/35" : "text-slate-500"
+  }`;
+  const linkClass = `underline underline-offset-2 ${
+    isDark ? "hover:text-white/78" : "hover:text-slate-800"
+  } transition-colors`;
+  const ruleClass = `my-8 h-px w-full ${
+    isDark ? "bg-white/10" : "bg-slate-900/12"
+  }`;
 
   return (
     <div
       className="min-h-screen flex flex-col"
       style={{ background: isDark ? "#08080f" : "#d4e6f5" }}
     >
-      {/* Nav */}
       <div className="flex items-center justify-between px-6 sm:px-10 pt-6 sm:pt-8">
-        <Link
-          href="/"
-          className={`text-sm font-medium ${isDark ? "text-white/60 hover:text-white" : "text-slate-600 hover:text-slate-900"} transition-colors`}
-        >
+        <Link href="/" className={navLinkClass}>
           &larr; 143
         </Link>
       </div>
 
-      {/* Content */}
-      <main className="flex-1 px-6 sm:px-10 py-16 sm:py-24">
-        <div className="max-w-2xl mx-auto">
-          <h1
-            className={`text-2xl sm:text-3xl font-light tracking-tight mb-12 ${isDark ? "text-white" : "text-slate-900"}`}
-          >
-            About 143
-          </h1>
+      <main className="flex-1 px-6 sm:px-10 py-14 sm:py-20">
+        <article aria-label="Why we built 143" className="mx-auto max-w-[720px]">
+          <header className="space-y-5">
+            <p className={metaClass}>143.dev</p>
+            <h1 className={pageTitleClass}>Why we built 143</h1>
+            <p className={ledeClass}>
+              Coding agents are very impressive in fresh repos, but we needed
+              more in order to actually get them working well in our production
+              systems across teams of engineers and non-engineers. That&apos;s why
+              we built 143 and open sourced it.
+            </p>
+            <p className={isDark ? "text-xs text-white/35" : "text-xs text-slate-500"}>
+              By John, from Assembled
+            </p>
+          </header>
 
-          <div
-            className={`space-y-8 text-sm leading-relaxed ${isDark ? "text-white/50" : "text-slate-600"}`}
-          >
-            <section className="space-y-3">
-              <h2
-                className={`text-base font-medium ${isDark ? "text-white/70" : "text-slate-800"}`}
+          <div className={ruleClass} aria-hidden="true" />
+
+          <div className={bodyClass}>
+            <p>
+              At{" "}
+              <a
+                href="https://www.assembled.com"
+                target="_blank"
+                rel="noopener noreferrer"
+                className={linkClass}
               >
-                How it started
-              </h2>
+                Assembled
+              </a>
+              , we wanted coding agents to help with real product work, not
+              just demos and internal tools. Even heading into 2026, we were not
+              seeing the velocity increase we expected. Other people seemed to
+              be getting huge leverage from new repos. We were still losing time
+              to setup, context, CI, review, and handoff.
+            </p>
+
+            <p>
+              We kept asking what we were doing wrong. After talking to a lot of
+              other teams, the answer felt much clearer: this was a shared
+              infrastructure problem, not just an individual prompting problem.
+            </p>
+
+            <InlineCallout isDark={isDark} label="What was missing">
+              The useful unit was not one better prompt. It was everything
+              around the agent: setup, context, CI, credentials, logs, review,
+              handoff, and the product knowledge needed to make good changes.
+            </InlineCallout>
+
+            <p>
+              We started with a small tiger team. We cleaned up our
+              instructions, invested more in CI/CD, built agent hooks, and made
+              the agent environment less fragile. All of that helped, but it
+              also made the bigger issue obvious: we needed a system that made
+              this work shared by the team, not trapped inside one
+              engineer&apos;s terminal.
+            </p>
+
+            <p>
+              That is why we built 143.dev. We were inspired by internal systems
+              like Stripe Minions and Ramp Inspect, but those were not available
+              to the public. We wanted to build something open source that other
+              teams could use, adapt, and improve.
+            </p>
+
+            <p>
+              Vibe coding is not the right word for what we want. I care much
+              more about productionalized coding. The point is not one-off apps.
+              It is helping professional engineers move faster on important
+              work, and giving domain experts and non-engineers a real path to
+              write real code in production systems.
+            </p>
+
+            <p>
+              That last part matters a lot to me. 143 should not pretend a PM,
+              designer, support leader, or operator suddenly becomes a senior
+              engineer. But they should be able to turn product knowledge into a
+              scoped code change, with shared context, previews, pull requests,
+              CI, and review gates before anything ships.
+            </p>
+
+            <InlineCallout isDark={isDark} label="For non-engineers">
+              The goal is not to route around engineers. It is to make product
+              knowledge useful in code, with previews, tests, pull requests, and
+              review gates before anything gets merged.
+            </InlineCallout>
+
+            <p>
+              A lot of today&apos;s tools make individual engineers faster, but
+              they can make the team part harder. That makes sense; many were
+              built by engineers for their own workflows. Running engineering
+              teams made us notice that a lot of primitives were sitting at the
+              wrong level.
+            </p>
+
+            <p>
+              Automations should be visible to the team, not hidden on one
+              person&apos;s laptop. Teams should be able to swap out intelligence
+              as coding agents and models improve. Usage should be legible by
+              person, PR, issue, automation, and outcome, not just token count.
+              Hooks should make it natural to start work from Sentry issues,
+              Linear assignments, PR comments, or scheduled checks. And you
+              should be able to set up a great environment once for everyone,
+              with the same repos, credentials, tools, logs, docs, and product
+              context available to the whole team.
+            </p>
+
+            <section className="space-y-3 pt-2">
+              <h2 className={headingClass}>Open source from day one</h2>
               <p>
-                143 started as an internal project at{" "}
-                <a
-                  href="https://www.assembled.com"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className={`underline underline-offset-2 ${isDark ? "hover:text-white/70" : "hover:text-slate-800"} transition-colors`}
-                >
-                  Assembled
-                </a>
-                . We wanted to speed up our engineering team and looked at
-                everything out there. None of the existing tools had what we
-                needed: agentic thinking, cloud-based coding, and a way for
-                non-technical people to build product too.
+                I owe a lot of my career to early open-source work on Ruby on
+                Rails. That is where I learned software fundamentals from people
+                like Aaron Patterson, Santiago Pastorino, Jose Valim, and
+                Jeremy Doerr. Their PR reviews, their patience, and their
+                willingness to design-pair with strangers on the internet shaped
+                how I think about software.
+              </p>
+              <p>
+                I was just a college student, but the Rails core team did not
+                care who I was. If a PR was good and well-intentioned, it was
+                welcome. I started with tests and tiny refactors, learned more
+                of the codebase, and eventually fixed Active Record bugs. That
+                work helped me get my job at Stripe and became the launching pad
+                for the rest of my career.
+              </p>
+              <p>
+                I want 143 to be available in that same spirit. I hope it helps
+                other people and teams the way open source helped me.
               </p>
             </section>
 
-            <section className="space-y-3">
-              <h2
-                className={`text-base font-medium ${isDark ? "text-white/70" : "text-slate-800"}`}
-              >
-                Built for ourselves first
-              </h2>
-              <p>
-                So we built it ourselves. 143 is an autopilot for coding agents
-                that lets anyone on the team spin up a cloud session, describe
-                what they need, and watch it get built. Engineers use it to move
-                faster day to day. PMs and designers use it to prototype features
-                and ship fixes without waiting on a sprint.
-              </p>
-              <p>
-                The name comes from the 143 days it took a small team of
-                Lockheed engineers to build the XP-80 Shooting Star, America&apos;s
-                first jet fighter, in 1943. A small focused team with the right
-                tools doing the impossible. That&apos;s the spirit we wanted to
-                capture.
-              </p>
-            </section>
+            <InlineCallout isDark={isDark} label="Why open source">
+              A lot of us learned by reading public code and sending small
+              patches. 143 should be useful out of the box, but also easy for
+              teams to inspect, adapt, and improve in the open.
+            </InlineCallout>
 
-            <section className="space-y-3">
-              <h2
-                className={`text-base font-medium ${isDark ? "text-white/70" : "text-slate-800"}`}
-              >
-                Open source from day one
-              </h2>
-              <p>
-                We built 143 as open source from the start. Our founders have
-                been in open source for a long time and always wanted to
-                contribute back to the community. 143 was that chance. We think
-                the best developer tools are built in the open and shaped by the
-                people who use them. We hope it helps other teams move faster and
-                bring more people into the building process.
-              </p>
-            </section>
+            <p>
+              I also wanted the hosted version to feel like the old days of
+              developer tools, when pricing was simpler. For hosted 143, we are
+              charging just for the containers you run. Bring whatever LLM
+              provider or coding agent you prefer. We want you to help pay for
+              the servers, not make your team pay our model markup.
+            </p>
 
-            <section className="space-y-3">
-              <h2
-                className={`text-base font-medium ${isDark ? "text-white/70" : "text-slate-800"}`}
-              >
-                One platform, every model, every agent
-              </h2>
-              <p>
-                Every model provider only supports their own models. That
-                frustrated us. We wanted one place where different people on the
-                team could use whatever coding agent they preferred, whether
-                that&apos;s Claude, GPT, Gemini, or something else, without getting
-                locked into a single vendor.
-              </p>
-              <p>
-                It&apos;s not just about model choice though. We wanted a single
-                experience for the whole team where you can see all coding agent
-                usage in one place, collaborate on projects that span multiple
-                PRs and commits, and keep context alive across sessions instead
-                of starting from scratch every time.
-              </p>
-              <p>
-                We also wanted to build a PM agent that actually knows your
-                company&apos;s context. Your codebase, your product, your priorities.
-                One that keeps building on that knowledge over time and gets
-                smarter the more your team uses it.
-              </p>
-            </section>
+            <p>
+              The name comes from 1943, when the Lockheed Skunk Works team built
+              the XP-80 Shooting Star in 143 days. It is a nod to small teams
+              with enough ownership and infrastructure to move quickly.
+            </p>
 
-            <section className="space-y-3">
-              <h2
-                className={`text-base font-medium ${isDark ? "text-white/70" : "text-slate-800"}`}
-              >
-                About Assembled
-              </h2>
-              <p>
-                <a
-                  href="https://www.assembled.com"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className={`underline underline-offset-2 ${isDark ? "hover:text-white/70" : "hover:text-slate-800"} transition-colors`}
-                >
-                  Assembled
-                </a>{" "}
-                is a workforce management platform that helps support teams
-                deliver better customer experiences. 143 is a piece of the
-                engineering culture behind Assembled that we wanted to share with
-                everyone.
-              </p>
-            </section>
+            <p>I really hope you like it.</p>
+
+            <p className={isDark ? "text-white/78" : "text-slate-800"}>John</p>
           </div>
-        </div>
+        </article>
       </main>
 
       <Footer isDark={isDark} />
     </div>
+  );
+}
+
+function InlineCallout({
+  isDark,
+  label,
+  children,
+}: {
+  isDark: boolean;
+  label: string;
+  children: ReactNode;
+}) {
+  const calloutClass = `my-7 border-l py-1 pl-5 ${
+    isDark ? "border-white/16 text-white/64" : "border-slate-900/18 text-slate-600"
+  }`;
+  const labelClass = `mb-2 text-xs font-medium uppercase tracking-wider ${
+    isDark ? "text-white/42" : "text-slate-500"
+  }`;
+
+  return (
+    <aside role="note" aria-label={label} className={calloutClass}>
+      <p className={labelClass}>{label}</p>
+      <p className="text-sm leading-7">{children}</p>
+    </aside>
   );
 }


### PR DESCRIPTION
## Summary
- Reworked the About page into a plain editorial note from John with clearer narrative flow and lighter visual treatment.
- Added inline callouts to explain what was missing, how 143 helps non-engineers, and why the project is open source.
- Updated the page tests to cover the new content, accessibility landmarks, and the removal of heavier product-page sections.

## Testing
- Added/updated frontend tests for the About page content and structure.
- Not run (not requested).