### PR TITLE
Stop NoReposWarning flashing during query load

### DIFF
--- a/frontend/src/components/no-repos-warning.test.tsx
+++ b/frontend/src/components/no-repos-warning.test.tsx
@@ -28,6 +28,39 @@ describe("NoReposWarning", () => {
     });
   });
 
+  it("renders nothing while the integrations query is still pending", async () => {
+    let releaseIntegrations: () => void = () => {};
+    const integrationsGate = new Promise<void>((resolve) => {
+      releaseIntegrations = resolve;
+    });
+
+    server.use(
+      http.get("/api/v1/integrations", async () => {
+        await integrationsGate;
+        // No GitHub connected: once resolved this renders the warning, so the
+        // absence of the warning before release proves the loading guard.
+        return HttpResponse.json({ data: [], meta: {} });
+      }),
+      http.get("/api/v1/repositories", () => {
+        return HttpResponse.json({ data: [], meta: {} });
+      })
+    );
+
+    const { container } = renderWithProviders(
+      <NoReposWarning showDisconnectedState />
+    );
+
+    // While integrations is pending the guard returns null — nothing renders.
+    expect(container).toBeEmptyDOMElement();
+    expect(screen.queryByText(/github setup required/i)).not.toBeInTheDocument();
+
+    // Once the query resolves, the warning appears.
+    releaseIntegrations();
+    await waitFor(() => {
+      expect(screen.getByText(/github setup required/i)).toBeInTheDocument();
+    });
+  });
+
   it("renders nothing when GitHub is connected and repos exist", async () => {
     server.use(
       http.get("/api/v1/integrations", () => {

--- a/frontend/src/components/no-repos-warning.tsx
+++ b/frontend/src/components/no-repos-warning.tsx
@@ -43,12 +43,12 @@ export function NoReposWarning({
   compact = false,
   asRow = false,
 }: NoReposWarningProps) {
-  const { data: integrationsResp } = useQuery({
+  const { data: integrationsResp, isPending: integrationsPending } = useQuery({
     queryKey: ["integrations"],
     queryFn: () => api.integrations.list(),
   });
 
-  const { data: reposResp } = useQuery({
+  const { data: reposResp, isPending: reposPending } = useQuery({
     queryKey: queryKeys.repositories.all,
     queryFn: () => api.repositories.list(),
   });
@@ -78,6 +78,11 @@ export function NoReposWarning({
   useEffect(() => {
     autoSyncIfNeeded(hasGitHub && !githubAppInstalled, hasRepos);
   }, [hasGitHub, githubAppInstalled, hasRepos, autoSyncIfNeeded]);
+
+  // Don't render anything until both queries have resolved. Otherwise hasGitHub
+  // defaults to false during loading and we briefly flash the "GitHub setup
+  // required" warning before the data reveals GitHub is actually connected.
+  if (integrationsPending || reposPending) return null;
 
   if (!hasGitHub) {
     if (!showDisconnectedState) return null;


### PR DESCRIPTION
## What

Adds a loading guard to `NoReposWarning` so it renders nothing until its `integrations` and `repositories` queries resolve.

## Why

On the sessions sidebar, a new org with no sessions briefly flashes an orange **"GitHub setup required"** card on page load. The cause is a loading-state race inside `NoReposWarning`:

1. The component fires its `integrations`/`repositories` queries on mount; both start `undefined`.
2. While pending, `hasGitHub` computes to `false`, so it immediately renders the orange disconnected-GitHub card.
3. The integrations query resolves, `hasGitHub` flips to `true`, and (with repos present) `if (hasRepos) return null` hides the card.

That render-then-unmount is the flash — the component treated "data hasn't loaded yet" the same as "GitHub is disconnected."

## Change

Pull `isPending` from both queries and `return null` while either is pending, so the warning only renders once the real GitHub/repo state is known. Orgs that genuinely need the warning still see it — once, after the data settles, instead of flickering.

## Testing

- All 6 `no-repos-warning.test.tsx` tests pass (they assert post-settle state, unchanged).
- `tsc` clean for this change (one pre-existing unrelated error in `src/lib/source.ts`).

Not browser-verified: this is a sub-second loading-race that requires a freshly-loaded org with GitHub connected + repos to reproduce, which the preview can't reliably exercise. Unit tests + type check cover the behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
