### PR TITLE
Return GitHub account connect to Integrations with a success toast

### DIFF
--- a/frontend/src/app/(dashboard)/settings/integrations/page.test.tsx
+++ b/frontend/src/app/(dashboard)/settings/integrations/page.test.tsx
@@ -24,6 +24,9 @@ const {
   githubConnectMock,
   currentUserMock,
   ApiErrorMock,
+  routerReplaceMock,
+  notifySuccessMock,
+  navState,
 } = vi.hoisted(() => {
   class MockApiError extends Error {
     constructor(public code: string, message: string, public details?: unknown) {
@@ -59,8 +62,26 @@ const {
       role: "admin",
     },
     ApiErrorMock: MockApiError,
+    routerReplaceMock: vi.fn(),
+    notifySuccessMock: vi.fn(),
+    navState: { params: {} as Record<string, string> },
   };
 });
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ replace: routerReplaceMock, push: vi.fn() }),
+  useSearchParams: () => ({ get: (key: string) => navState.params[key] ?? null }),
+}));
+
+vi.mock("@/lib/notify", () => ({
+  notify: {
+    success: notifySuccessMock,
+    info: vi.fn(),
+    warning: vi.fn(),
+    error: vi.fn(),
+    dismiss: vi.fn(),
+  },
+}));
 
 vi.mock("@/lib/api", () => ({
   ApiError: ApiErrorMock,
@@ -215,6 +236,9 @@ describe("IntegrationsPage", () => {
     );
     githubConnectMock.mockClear();
     currentUserMock.role = "admin";
+    routerReplaceMock.mockReset();
+    notifySuccessMock.mockReset();
+    navState.params = {};
   });
 
   it("offers a GitHub user-auth connect action when repo claiming requires it", async () => {
@@ -231,6 +255,27 @@ describe("IntegrationsPage", () => {
 
     await user.click(screen.getByRole("button", { name: "Connect GitHub account" }));
     expect(githubConnectMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("confirms a returning GitHub account connection and clears the one-shot param", async () => {
+    navState.params = { github_pr: "connected" };
+    renderWithProviders(<IntegrationsPage />);
+
+    await waitFor(() => {
+      expect(notifySuccessMock).toHaveBeenCalledWith(
+        "GitHub account connected",
+        expect.objectContaining({ description: expect.stringContaining("linked") }),
+      );
+    });
+    expect(routerReplaceMock).toHaveBeenCalledWith("/settings/integrations");
+  });
+
+  it("does not fire a connection toast on a normal visit", async () => {
+    renderWithProviders(<IntegrationsPage />);
+
+    await screen.findByText("Integrations");
+    expect(notifySuccessMock).not.toHaveBeenCalled();
+    expect(routerReplaceMock).not.toHaveBeenCalled();
   });
 
   it("keeps GitHub repository claiming controls inside the manage sidesheet", async () => {

--- a/frontend/src/app/(dashboard)/settings/integrations/page.tsx
+++ b/frontend/src/app/(dashboard)/settings/integrations/page.tsx
@@ -1,7 +1,9 @@
 "use client";
 
-import { useState, type ReactNode } from "react";
+import { useState, useEffect, type ReactNode } from "react";
 import Link from "next/link";
+import { useRouter, useSearchParams } from "next/navigation";
+import { notify } from "@/lib/notify";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { CircleHelp, ExternalLink, RefreshCw, Trash2 } from "lucide-react";
 import { ApiError, api } from "@/lib/api";
@@ -1502,8 +1504,41 @@ function TokenDialog({ open, onOpenChange, title, description, fields, submittin
 
 export default function IntegrationsPage() {
   const queryClient = useQueryClient();
+  const router = useRouter();
+  const searchParams = useSearchParams();
   const { user } = useAuth();
   const isAdmin = user?.role === "admin";
+
+  // The GitHub OAuth callbacks redirect back here with a one-shot query param
+  // on success: `github_pr=connected` after linking a personal GitHub account
+  // (the flow started by the "Connect GitHub account" button on a repo claim),
+  // and `github=connected` after installing the org GitHub App. The backend
+  // only adds these on success — failures render an error page instead — so
+  // their presence is the success signal. Confirm it with a toast, refresh the
+  // integration/repository caches so a retried claim sees the new auth, then
+  // strip the param so a refresh doesn't replay the toast.
+  useEffect(() => {
+    const githubPRConnected = searchParams.get("github_pr") === "connected";
+    const githubAppConnected = searchParams.get("github") === "connected";
+    if (!githubPRConnected && !githubAppConnected) {
+      return;
+    }
+    if (githubPRConnected) {
+      notify.success("GitHub account connected", {
+        description: "Your GitHub account is linked. You can now claim or transfer repositories.",
+      });
+      queryClient.invalidateQueries({ queryKey: ["github-status"] });
+      queryClient.invalidateQueries({ queryKey: ["team-github-status"] });
+    } else {
+      notify.success("GitHub connected", {
+        description: "The 143 GitHub App is installed for your organization.",
+      });
+    }
+    queryClient.invalidateQueries({ queryKey: queryKeys.integrations.all });
+    queryClient.invalidateQueries({ queryKey: queryKeys.repositories.all });
+    queryClient.invalidateQueries({ queryKey: ["repositories", "integrations", "include-disconnected"] });
+    router.replace("/settings/integrations");
+  }, [searchParams, router, queryClient]);
   const [selectedIntegration, setSelectedIntegration] = useState<IntegrationKey | null>(null);
   const { data: integrationsResp } = useQuery({
     queryKey: ["integrations"],

--- a/internal/api/handlers/github_status.go
+++ b/internal/api/handlers/github_status.go
@@ -226,7 +226,11 @@ func (h *GitHubStatusHandler) HandleConnectCallback(w http.ResponseWriter, r *ht
 		return
 	}
 
-	redirectURL := h.frontendURL + "/settings?github_pr=connected"
+	// Default back to the Integrations page, where the "Connect GitHub
+	// account" button that starts this flow lives, so the user lands where
+	// they began. The resume path below overrides this to return to the
+	// originating session instead.
+	redirectURL := h.frontendURL + "/settings/integrations?github_pr=connected"
 	resumeCookieName := githubPRResumeCookiePrefix + r.URL.Query().Get("state")
 	if resumeCookie, err := r.Cookie(resumeCookieName); err == nil && resumeCookie.Value != "" && len(h.signingKey) > 0 {
 		if claims, tokenErr := parsePRAuthResumeToken(h.signingKey, resumeCookie.Value, time.Now()); tokenErr == nil {

--- a/internal/api/handlers/github_status_test.go
+++ b/internal/api/handlers/github_status_test.go
@@ -433,6 +433,44 @@ func TestGitHubStatusHandler_HandleConnectCallback_UsesStateScopedResumeCookie(t
 	require.Equal(t, secondResumeToken, parsed.Query().Get("resume_pr"), "callback should return the state-scoped resume token")
 }
 
+func TestGitHubStatusHandler_HandleConnectCallback_RedirectsToIntegrations(t *testing.T) {
+	t.Parallel()
+
+	orgID := uuid.New()
+	userID := uuid.New()
+	handler := NewGitHubStatusHandler(
+		&stubGHCredentialStore{}, &stubGHOrgReader{},
+		"test-client-id", "test-secret", "https://app.143.dev", "https://app.143.dev",
+	)
+	handler.appUserAuth = &stubGitHubAppUserAuthService{
+		exchangeCodeFunc: func(context.Context, string) (*models.GitHubAppUserConfig, error) {
+			return &models.GitHubAppUserConfig{
+				AccessToken:           "ghu_test",
+				TokenType:             "bearer",
+				ExpiresAt:             time.Now().Add(time.Hour),
+				RefreshToken:          "ghr_test",
+				RefreshTokenExpiresAt: time.Now().Add(30 * 24 * time.Hour),
+			}, nil
+		},
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/users/me/github/callback?state=ok&code=abc", nil)
+	req.AddCookie(&http.Cookie{Name: githubPRConnectStateCookie, Value: "ok"})
+	ctx := middleware.WithUser(req.Context(), &models.User{ID: userID, OrgID: orgID})
+	ctx = middleware.WithOrgID(ctx, orgID)
+	req = req.WithContext(ctx)
+	rr := httptest.NewRecorder()
+
+	handler.HandleConnectCallback(rr, req)
+
+	require.Equal(t, http.StatusTemporaryRedirect, rr.Code, "callback should redirect after successful auth")
+	loc := rr.Header().Get("Location")
+	parsed, parseErr := url.Parse(loc)
+	require.NoError(t, parseErr, "redirect location should parse")
+	require.Equal(t, "/settings/integrations", parsed.Path, "non-resume callback should return to the integrations page where the connect button lives")
+	require.Equal(t, "connected", parsed.Query().Get("github_pr"), "redirect should note successful GitHub PR auth")
+}
+
 func TestGitHubStatusHandler_GetStatus_Unauthorized(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## What & why

After connecting a personal GitHub account (the flow started by the **Connect GitHub account** button on a repo claim/transfer, or during in-session PR creation), the OAuth callback redirected to `/settings` — the **Organization** page — with no visible confirmation. From a user's perspective the connection looked like it did nothing, and they landed on the wrong page (the button lives on **Integrations**).

## Changes

- **Backend** ([`github_status.go`](internal/api/handlers/github_status.go)): default the non-resume connect callback redirect to `/settings/integrations` (where the connect button lives) instead of `/settings`. The session-resume path (in-session PR creation) is unchanged.
- **Frontend** ([`integrations/page.tsx`](frontend/src/app/(dashboard)/settings/integrations/page.tsx)): read the one-shot `github_pr=connected` param (and `github=connected` for the org App-install flow), show a success toast via `notify`, refresh the GitHub/repository caches so a retried claim immediately sees the new auth, then strip the param so a refresh doesn't replay the toast.

## Tests

- Go: new `TestGitHubStatusHandler_HandleConnectCallback_RedirectsToIntegrations`; existing resume-path tests still pass.
- Frontend: 2 new tests (toast fires + param cleared on `github_pr=connected`; no toast on a normal visit). All 21 integrations-page tests pass; `tsc --noEmit` clean.

Note: this is a scoped fix split out from a worktree that also contained unrelated in-progress work; only the four GitHub-connect files are included here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)