### PR TITLE
Show coding agents as name + logo only on the landing page

### DIFF
--- a/frontend/public/agents/opencode.svg
+++ b/frontend/public/agents/opencode.svg
@@ -1,4 +1,4 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" fill="none">
-  <path d="M320 224V352H192V224H320Z" fill="white"/>
-  <path fill-rule="evenodd" clip-rule="evenodd" d="M384 416H128V96H384V416ZM320 160H192V352H320V160Z" fill="white"/>
+  <path d="M320 224V352H192V224H320Z" fill="currentColor"/>
+  <path fill-rule="evenodd" clip-rule="evenodd" d="M384 416H128V96H384V416ZM320 160H192V352H320V160Z" fill="currentColor"/>
 </svg>

--- a/frontend/src/components/landing/integrations-section.tsx
+++ b/frontend/src/components/landing/integrations-section.tsx
@@ -23,11 +23,11 @@ export default function IntegrationsSection({
   const body = isDark ? "text-white/50" : "text-slate-600";
 
   const renderGrid = (items: ToolItem[]) => (
-    <div className="grid gap-px overflow-hidden rounded-lg border border-border/60 bg-border/60 sm:grid-cols-2 lg:grid-cols-3">
+    <div className="flex flex-wrap justify-center gap-3">
       {items.map((item) => (
         <Card
           key={item.name}
-          className={`rounded-none border-0 ${
+          className={`w-full flex-none sm:w-[calc(50%_-_0.375rem)] lg:w-[calc(33.333%_-_0.5rem)] ${
             item.description ? "min-h-44" : ""
           } ${isDark ? "bg-[#0d0d15]" : "bg-white/80"}`}
         >

--- a/frontend/src/components/landing/integrations-section.tsx
+++ b/frontend/src/components/landing/integrations-section.tsx
@@ -12,7 +12,7 @@ interface IntegrationsSectionProps {
 interface ToolItem {
   name: string;
   logo: string;
-  description: string;
+  description?: string;
 }
 
 export default function IntegrationsSection({
@@ -27,9 +27,9 @@ export default function IntegrationsSection({
       {items.map((item) => (
         <Card
           key={item.name}
-          className={`min-h-44 rounded-none border-0 ${
-            isDark ? "bg-[#0d0d15]" : "bg-white/80"
-          }`}
+          className={`rounded-none border-0 ${
+            item.description ? "min-h-44" : ""
+          } ${isDark ? "bg-[#0d0d15]" : "bg-white/80"}`}
         >
           <CardContent className="p-5">
             <div className="flex items-center gap-3">
@@ -55,7 +55,9 @@ export default function IntegrationsSection({
                 {item.name}
               </h3>
             </div>
-            <p className={`mt-5 ${type.body} ${body}`}>{item.description}</p>
+            {item.description && (
+              <p className={`mt-5 ${type.body} ${body}`}>{item.description}</p>
+            )}
           </CardContent>
         </Card>
       ))}

--- a/frontend/src/components/landing/landing-copy.ts
+++ b/frontend/src/components/landing/landing-copy.ts
@@ -57,27 +57,22 @@ export const codingAgents = [
   {
     name: "Codex",
     logo: "/agents/codex.svg",
-    description: "OpenAI Codex on the GPT-5 models.",
   },
   {
     name: "Claude Code",
     logo: "/agents/claude_code.svg",
-    description: "Anthropic Claude — Fable, Opus, Sonnet, and Haiku.",
   },
   {
     name: "Amp",
     logo: "/agents/amp.svg",
-    description: "Sourcegraph Amp, run by mode.",
   },
   {
     name: "Pi",
     logo: "/agents/pi.svg",
-    description: "Pi coding agent with its own provider auth.",
   },
   {
     name: "OpenCode",
     logo: "/agents/opencode.svg",
-    description: "Multi-provider agent across OpenAI, Anthropic, Gemini, and more.",
   },
 ];
 


### PR DESCRIPTION
## Summary

The landing page's "Run any coding agent" block listed each supported agent (Codex, Claude Code, Amp, Pi, OpenCode) with a one-line description, which read as noise next to the engineering-tools grid that genuinely benefits from descriptions. This trims the agent block down to just a name and logo, and fixes the OpenCode mark, which was rendering invisibly.

## Changes

- Drop the per-agent `description` fields and render the agents grid as name + logo only; the shared `renderGrid` helper now renders the description paragraph (and the `min-h-44` filler height) only when an item has a description, so the Integrations grid keeps its tool descriptions unchanged.
- Fix the OpenCode logo: its SVG paths were filled `white`, making the mark invisible on the white logo box in light mode. Switch the fills to `currentColor` so it renders like the other monochrome brand logos.

## Validation

- `npx vitest run src/components/landing/landing-copy.test.ts` — 5/5 pass (asserts the `name:logo` pairs, which are unchanged).
- Verified against the running dev server: all 5 agent cards render with no description and correct logo `src`s; the integration cards still show descriptions; `/agents/opencode.svg` now serves with `fill="currentColor"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
