### PR TITLE
Make GitHub auth legible: first-class account row, gated by authorship

### DIFF
--- a/frontend/src/app/(dashboard)/sessions/[id]/page-pr-creation.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/page-pr-creation.test.tsx
@@ -1091,7 +1091,7 @@ describe('SessionDetailPage PR creation', () => {
     await userEvent.keyboard('pc');
 
     expect(await screen.findByText('Open this pull request as yourself?')).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Continue with GitHub' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Connect your GitHub account' })).toBeInTheDocument();
   });
 
   it('auto-resumes PR creation after GitHub auth callback', async () => {

--- a/frontend/src/app/(dashboard)/sessions/[id]/page-pr-health.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/page-pr-health.test.tsx
@@ -783,7 +783,7 @@ describe('SessionDetailPage PR health and merge', () => {
 
     expect(await screen.findByText('Merge this pull request as yourself?')).toBeInTheDocument();
     expect(screen.getByText('Connect your GitHub account to merge this pull request as yourself.')).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Continue with GitHub' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Connect your GitHub account' })).toBeInTheDocument();
   });
 
   it('toasts the API error message when the merge call fails', async () => {

--- a/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
@@ -6946,7 +6946,7 @@ export function SessionDetailContent({ id }: { id: string }) {
                 api.githubStatus.connect(resumeToken || undefined);
               }}
             >
-              Continue with GitHub
+              Connect your GitHub account
             </AlertDialogAction>
           </AlertDialogFooter>
         </AlertDialogContent>

--- a/frontend/src/app/(dashboard)/settings/integrations/page.test.tsx
+++ b/frontend/src/app/(dashboard)/settings/integrations/page.test.tsx
@@ -247,6 +247,7 @@ describe("IntegrationsPage", () => {
       pr_authorship_mode: "user_preferred",
       pr_draft_default: false,
       account_requirement: "recommended",
+      needs_reconnect: false,
     });
     githubDisconnectMock.mockResolvedValue(undefined);
     currentUserMock.role = "admin";
@@ -314,7 +315,11 @@ describe("IntegrationsPage", () => {
     renderWithProviders(<IntegrationsPage />);
 
     expect(await screen.findByText("Connected as @octocat")).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Disconnect GitHub account" })).toBeInTheDocument();
+    const user = userEvent.setup();
+    await user.click(screen.getByRole("button", { name: "Disconnect GitHub account" }));
+    // Confirm the destructive action in the dialog.
+    await user.click(await screen.findByRole("button", { name: "Disconnect" }));
+    expect(githubDisconnectMock).toHaveBeenCalledTimes(1);
   });
 
   it("marks the account optional and explains app authorship under app_only", async () => {
@@ -336,12 +341,13 @@ describe("IntegrationsPage", () => {
 
   it("prompts a reconnect when the account credential is no longer usable", async () => {
     githubStatusGetMock.mockResolvedValue({
-      connected: true,
+      connected: false,
       has_repo_scope: false,
       github_login: "octocat",
       pr_authorship_mode: "user_required",
       pr_draft_default: false,
       account_requirement: "required",
+      needs_reconnect: true,
     });
     renderWithProviders(<IntegrationsPage />);
 

--- a/frontend/src/app/(dashboard)/settings/integrations/page.test.tsx
+++ b/frontend/src/app/(dashboard)/settings/integrations/page.test.tsx
@@ -22,6 +22,8 @@ const {
   updateSlackChannelSettingsMock,
   teamListMembersMock,
   githubConnectMock,
+  githubStatusGetMock,
+  githubDisconnectMock,
   currentUserMock,
   ApiErrorMock,
   routerReplaceMock,
@@ -55,6 +57,8 @@ const {
     updateSlackChannelSettingsMock: vi.fn(),
     teamListMembersMock: vi.fn(),
     githubConnectMock: vi.fn(),
+    githubStatusGetMock: vi.fn(),
+    githubDisconnectMock: vi.fn(),
     currentUserMock: {
       id: "user-1",
       email: "admin@example.com",
@@ -119,6 +123,8 @@ vi.mock("@/lib/api", () => ({
     },
     githubStatus: {
       connect: githubConnectMock,
+      get: githubStatusGetMock,
+      disconnect: githubDisconnectMock,
     },
     team: {
       listMembers: teamListMembersMock,
@@ -235,6 +241,14 @@ describe("IntegrationsPage", () => {
       new ApiErrorMock("GITHUB_USER_AUTH_REQUIRED", "Connect your GitHub account before claiming repositories"),
     );
     githubConnectMock.mockClear();
+    githubStatusGetMock.mockResolvedValue({
+      connected: false,
+      has_repo_scope: false,
+      pr_authorship_mode: "user_preferred",
+      pr_draft_default: false,
+      account_requirement: "recommended",
+    });
+    githubDisconnectMock.mockResolvedValue(undefined);
     currentUserMock.role = "admin";
     routerReplaceMock.mockReset();
     notifySuccessMock.mockReset();
@@ -278,6 +292,88 @@ describe("IntegrationsPage", () => {
     expect(routerReplaceMock).not.toHaveBeenCalled();
   });
 
+  it("renders a first-class 'Your GitHub account' row with a connect action when not connected", async () => {
+    renderWithProviders(<IntegrationsPage />);
+
+    expect(await screen.findByText("Your GitHub account")).toBeInTheDocument();
+    const connect = await screen.findByRole("button", { name: "Connect GitHub account" });
+    const user = userEvent.setup();
+    await user.click(connect);
+    expect(githubConnectMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows the connected GitHub login and a disconnect action when connected", async () => {
+    githubStatusGetMock.mockResolvedValue({
+      connected: true,
+      has_repo_scope: true,
+      github_login: "octocat",
+      pr_authorship_mode: "user_preferred",
+      pr_draft_default: false,
+      account_requirement: "recommended",
+    });
+    renderWithProviders(<IntegrationsPage />);
+
+    expect(await screen.findByText("Connected as @octocat")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Disconnect GitHub account" })).toBeInTheDocument();
+  });
+
+  it("marks the account optional and explains app authorship under app_only", async () => {
+    githubStatusGetMock.mockResolvedValue({
+      connected: false,
+      has_repo_scope: false,
+      pr_authorship_mode: "app_only",
+      pr_draft_default: false,
+      account_requirement: "optional",
+    });
+    renderWithProviders(<IntegrationsPage />);
+
+    // Wait for the github-status query to resolve so the requirement-specific
+    // copy (not the default "recommended" copy) has rendered.
+    expect(await screen.findByText(/PRs are authored by the 143 app/)).toBeInTheDocument();
+    // "Optional" also appears on other integration cards, so just assert presence.
+    expect(screen.getAllByText("Optional").length).toBeGreaterThan(0);
+  });
+
+  it("prompts a reconnect when the account credential is no longer usable", async () => {
+    githubStatusGetMock.mockResolvedValue({
+      connected: true,
+      has_repo_scope: false,
+      github_login: "octocat",
+      pr_authorship_mode: "user_required",
+      pr_draft_default: false,
+      account_requirement: "required",
+    });
+    renderWithProviders(<IntegrationsPage />);
+
+    expect(await screen.findByRole("button", { name: "Reconnect GitHub account" })).toBeInTheDocument();
+  });
+
+  it("proactively prompts to connect the account before a repo transfer", async () => {
+    listGitHubRepositoriesMock.mockResolvedValue({
+      data: [
+        {
+          github_id: 222,
+          full_name: "other/api",
+          default_branch: "main",
+          private: true,
+          clone_url: "https://github.com/other/api.git",
+          installation_id: 12345,
+          status: "owned_by_other_org",
+          can_transfer: true,
+        },
+      ],
+      meta: {},
+    });
+    renderWithProviders(<IntegrationsPage />);
+
+    const user = userEvent.setup();
+    await user.click(await screen.findByRole("button", { name: "Manage GitHub" }));
+    await screen.findByText("other/api");
+    expect(
+      screen.getByText(/Transferring a repo owned by another organization needs your GitHub account/),
+    ).toBeInTheDocument();
+  });
+
   it("keeps GitHub repository claiming controls inside the manage sidesheet", async () => {
     renderWithProviders(<IntegrationsPage />);
 
@@ -285,7 +381,7 @@ describe("IntegrationsPage", () => {
     expect(screen.queryByText("Available")).not.toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "Claim" })).not.toBeInTheDocument();
 
-    const githubCard = screen.getByText("GitHub").closest("[data-testid='integration-card']");
+    const githubCard = screen.getByText("GitHub App").closest("[data-testid='integration-card']");
     expect(githubCard).not.toBeNull();
 
     const user = userEvent.setup();

--- a/frontend/src/app/(dashboard)/settings/integrations/page.tsx
+++ b/frontend/src/app/(dashboard)/settings/integrations/page.tsx
@@ -363,7 +363,7 @@ function GitHubRepositoryClaims({
                   Transferring a repo owned by another organization needs your GitHub account. Connect it first to avoid an interrupted transfer.
                 </p>
                 <Button variant="link" size="sm" className="mt-1 h-auto p-0 text-xs" onClick={onConnectAccount}>
-                  Connect GitHub account
+                  Connect account to transfer
                 </Button>
               </div>
             )}
@@ -1601,13 +1601,19 @@ export default function IntegrationsPage() {
     queryFn: () => api.githubStatus.get(),
   });
   const githubAccountConnected = githubAccountStatus?.connected ?? false;
-  // connected but not usable (e.g. token expired) → prompt a reconnect.
-  const githubAccountNeedsReconnect = githubAccountConnected && !(githubAccountStatus?.has_repo_scope ?? false);
+  // A credential row exists but is no longer usable (expired / refresh failed).
+  // The backend reports this directly so the UI can prompt a reconnect.
+  const githubAccountNeedsReconnect = githubAccountStatus?.needs_reconnect ?? false;
   const githubAccountDisconnectMutation = useMutation({
     mutationFn: () => api.githubStatus.disconnect(),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["github-status"] });
       queryClient.invalidateQueries({ queryKey: ["team-github-status"] });
+    },
+    onError: (err: Error) => {
+      notify.error("Couldn't disconnect your GitHub account", {
+        description: err.message || "Please try again.",
+      });
     },
   });
 

--- a/frontend/src/app/(dashboard)/settings/integrations/page.tsx
+++ b/frontend/src/app/(dashboard)/settings/integrations/page.tsx
@@ -267,6 +267,8 @@ function GitHubRepositoryClaims({
   pendingRepoID,
   onSyncRepos,
   isSyncing,
+  accountConnected,
+  onConnectAccount,
 }: {
   installationId?: number;
   enabled: boolean;
@@ -276,6 +278,11 @@ function GitHubRepositoryClaims({
   pendingRepoID?: string | null;
   onSyncRepos: () => void;
   isSyncing: boolean;
+  // Whether the current user has connected their personal GitHub account.
+  // Transferring a repo owned by another org needs that user token, so we
+  // surface a proactive prompt instead of letting the Transfer click fail.
+  accountConnected: boolean;
+  onConnectAccount: () => void;
 }) {
   const queryClient = useQueryClient();
   const [transferRepo, setTransferRepo] = useState<GitHubRepositoryClaimCandidate | null>(null);
@@ -303,6 +310,10 @@ function GitHubRepositoryClaims({
     repo.status === "unclaimed" || repo.status === "disconnected_in_current_org" || (repo.status === "owned_by_other_org" && repo.can_transfer)
   );
   const connectedCount = repos.filter((repo) => repo.status === "owned_by_current_org").length;
+  // Transfers (claiming a repo owned by another org) require the user's GitHub
+  // account token. Detect that case up front so we can prompt before the click.
+  const transferCandidates = repos.filter((repo) => repo.status === "owned_by_other_org" && repo.can_transfer);
+  const needsAccountForTransfer = !accountConnected && transferCandidates.length > 0;
   const claimError = claimMutation.error;
   const needsGitHubUserAuth = claimError instanceof ApiError && claimError.code === "GITHUB_USER_AUTH_REQUIRED";
 
@@ -346,6 +357,16 @@ function GitHubRepositoryClaims({
             <p className="text-xs text-muted-foreground">
               {repos.length} repositor{repos.length === 1 ? "y" : "ies"} · {connectedCount} connected · {actionable.length} available
             </p>
+            {needsAccountForTransfer && (
+              <div className="rounded-md border border-border bg-muted/40 px-3 py-2">
+                <p className="text-xs text-muted-foreground">
+                  Transferring a repo owned by another organization needs your GitHub account. Connect it first to avoid an interrupted transfer.
+                </p>
+                <Button variant="link" size="sm" className="mt-1 h-auto p-0 text-xs" onClick={onConnectAccount}>
+                  Connect GitHub account
+                </Button>
+              </div>
+            )}
             <div
               data-testid="github-repository-grid"
               className="grid grid-cols-[repeat(auto-fit,minmax(12rem,1fr))] gap-2"
@@ -1260,6 +1281,8 @@ function IntegrationDetailSheet({
   repositories,
   githubInstallationId,
   githubAccountLogin,
+  githubAccountConnected,
+  onConnectGitHubAccount,
   onDisconnect,
   disconnectingProvider,
   onDisconnectRepo,
@@ -1279,6 +1302,8 @@ function IntegrationDetailSheet({
   repositories: Repository[];
   githubInstallationId?: number;
   githubAccountLogin?: string;
+  githubAccountConnected: boolean;
+  onConnectGitHubAccount: () => void;
   onDisconnect: (provider: IntegrationKey) => void;
   disconnectingProvider?: IntegrationKey | null;
   onDisconnectRepo: (repoID: string) => void;
@@ -1334,6 +1359,8 @@ function IntegrationDetailSheet({
                 pendingRepoID={pendingRepoID}
                 onSyncRepos={onSyncRepos}
                 isSyncing={isSyncingRepos}
+                accountConnected={githubAccountConnected}
+                onConnectAccount={onConnectGitHubAccount}
               />
             </>
           ) : null}
@@ -1567,6 +1594,23 @@ export default function IntegrationsPage() {
     },
   });
 
+  // Per-user GitHub account status (distinct from the org-wide GitHub App).
+  // Drives the "Your GitHub account" row and the proactive transfer prompt.
+  const { data: githubAccountStatus } = useQuery({
+    queryKey: ["github-status"],
+    queryFn: () => api.githubStatus.get(),
+  });
+  const githubAccountConnected = githubAccountStatus?.connected ?? false;
+  // connected but not usable (e.g. token expired) → prompt a reconnect.
+  const githubAccountNeedsReconnect = githubAccountConnected && !(githubAccountStatus?.has_repo_scope ?? false);
+  const githubAccountDisconnectMutation = useMutation({
+    mutationFn: () => api.githubStatus.disconnect(),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["github-status"] });
+      queryClient.invalidateQueries({ queryKey: ["team-github-status"] });
+    },
+  });
+
   const [notionDialogOpen, setNotionDialogOpen] = useState(false);
   const [notionError, setNotionError] = useState<string | null>(null);
   const notionConnectMutation = useMutation({
@@ -1696,6 +1740,13 @@ export default function IntegrationsPage() {
           setMezmoError(null);
           setMezmoDialogOpen(true);
         }}
+        githubAccountConnected={githubAccountConnected}
+        githubAccountLogin={githubAccountStatus?.github_login}
+        githubAccountNeedsReconnect={githubAccountNeedsReconnect}
+        githubAccountRequirement={githubAccountStatus?.account_requirement ?? "recommended"}
+        onConnectGitHubAccount={() => api.githubStatus.connect()}
+        onDisconnectGitHubAccount={() => githubAccountDisconnectMutation.mutate()}
+        githubAccountDisconnecting={githubAccountDisconnectMutation.isPending}
         onManageGitHub={isAdmin ? () => setSelectedIntegration("github") : undefined}
         onManageIntegration={isAdmin ? (provider) => setSelectedIntegration(provider) : undefined}
         summaries={{
@@ -1735,6 +1786,8 @@ export default function IntegrationsPage() {
         repositories={repositories}
         githubInstallationId={githubIntegration?.github_installation_id}
         githubAccountLogin={githubIntegration?.github_account_login}
+        githubAccountConnected={githubAccountConnected && !githubAccountNeedsReconnect}
+        onConnectGitHubAccount={() => api.githubStatus.connect()}
         onDisconnect={(provider) => disconnectMutation.mutate(provider, { onSuccess: () => setSelectedIntegration(null) })}
         disconnectingProvider={disconnectMutation.isPending ? disconnectMutation.variables : null}
         onDisconnectRepo={(repoID) => repositoryStatusMutation.mutate({ repoID, action: "disconnect" })}

--- a/frontend/src/app/(dashboard)/settings/page.tsx
+++ b/frontend/src/app/(dashboard)/settings/page.tsx
@@ -40,16 +40,19 @@ function PRAuthorshipSettings() {
   const requireBuilderReview = settings.builder_permissions?.require_review_before_pr ?? true;
 
   const accountConnected = githubAccountStatus?.connected ?? false;
+  const accountNeedsReconnect = githubAccountStatus?.needs_reconnect ?? false;
   // Contextual hint tying this org-level setting to the per-user account
   // connection it implies, so the relationship is visible from both pages.
   const authorshipAccountHint =
     currentAuthorship === "app_only"
       ? "PRs are authored by the 143 app — connecting your GitHub account is optional."
-      : accountConnected
-        ? "Your GitHub account is connected, so PRs can be authored as you."
-        : currentAuthorship === "user_required"
-          ? "You haven't connected your GitHub account — it's required for this mode."
-          : "You haven't connected your GitHub account — connect it so PRs are authored as you.";
+      : accountNeedsReconnect
+        ? "Your GitHub authorization expired — reconnect it so PRs are authored as you."
+        : accountConnected
+          ? "Your GitHub account is connected, so PRs can be authored as you."
+          : currentAuthorship === "user_required"
+            ? "You haven't connected your GitHub account — it's required for this mode."
+            : "You haven't connected your GitHub account — connect it so PRs are authored as you.";
 
   const { save, status } = useOrgSettingsAutosave();
 

--- a/frontend/src/app/(dashboard)/settings/page.tsx
+++ b/frontend/src/app/(dashboard)/settings/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import Link from "next/link";
 import { useQuery } from "@tanstack/react-query";
 import { api } from "@/lib/api";
 import { queryKeys } from "@/lib/query-keys";
@@ -27,11 +28,28 @@ function PRAuthorshipSettings() {
     queryFn: () => api.settings.get(),
   });
 
+  const { data: githubAccountStatus } = useQuery({
+    queryKey: ["github-status"],
+    queryFn: () => api.githubStatus.get(),
+  });
+
   const settings = (settingsResponse?.data?.settings ?? {}) as OrgSettings;
   const currentAuthorship = settings.pr_authorship ?? "user_preferred";
   const currentDraftDefault = settings.pr_draft_default ?? false;
   const currentAutoArchive = settings.auto_archive_on_pr_close ?? false;
   const requireBuilderReview = settings.builder_permissions?.require_review_before_pr ?? true;
+
+  const accountConnected = githubAccountStatus?.connected ?? false;
+  // Contextual hint tying this org-level setting to the per-user account
+  // connection it implies, so the relationship is visible from both pages.
+  const authorshipAccountHint =
+    currentAuthorship === "app_only"
+      ? "PRs are authored by the 143 app — connecting your GitHub account is optional."
+      : accountConnected
+        ? "Your GitHub account is connected, so PRs can be authored as you."
+        : currentAuthorship === "user_required"
+          ? "You haven't connected your GitHub account — it's required for this mode."
+          : "You haven't connected your GitHub account — connect it so PRs are authored as you.";
 
   const { save, status } = useOrgSettingsAutosave();
 
@@ -71,6 +89,12 @@ function PRAuthorshipSettings() {
                 </label>
               ))}
             </div>
+            <p className="text-xs text-muted-foreground">
+              {authorshipAccountHint}{" "}
+              <Link href="/settings/integrations" className="underline">
+                Manage on Integrations
+              </Link>
+            </p>
           </div>
           <div className="flex items-center gap-2">
             <input

--- a/frontend/src/components/integration-connection-cards.test.tsx
+++ b/frontend/src/components/integration-connection-cards.test.tsx
@@ -201,6 +201,9 @@ describe("integration connection cards", () => {
         onConnectCircleCI={vi.fn()}
         mezmoConnected={false}
         onConnectMezmo={vi.fn()}
+        githubAccountConnected={false}
+        githubAccountRequirement="recommended"
+        onConnectGitHubAccount={vi.fn()}
       />
     );
 
@@ -468,13 +471,20 @@ describe("integration connection cards", () => {
         mezmoConnected={false}
         onConnectMezmo={vi.fn()}
         onDisconnect={vi.fn()}
+        githubAccountConnected={false}
+        githubAccountRequirement="recommended"
+        onConnectGitHubAccount={vi.fn()}
         readOnly
       />
     );
 
-    expect(screen.queryByRole("button", { name: /Connect/ })).not.toBeInTheDocument();
+    // Org-wide integration connect/disconnect controls are hidden for non-admins.
+    expect(screen.queryByRole("button", { name: "Connect Sentry" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Connect Slack" })).not.toBeInTheDocument();
     expect(screen.queryByRole("button", { name: /Disconnect/ })).not.toBeInTheDocument();
     expect(screen.queryByRole("button", { name: /Disconnect acme\/api/ })).not.toBeInTheDocument();
+    // The per-user GitHub account action stays available to everyone.
+    expect(screen.getByRole("button", { name: "Connect GitHub account" })).toBeInTheDocument();
     expect(screen.getAllByText("Connected").length).toBeGreaterThan(0);
     expect(screen.getAllByText("Not connected").length).toBeGreaterThan(0);
   });

--- a/frontend/src/components/integration-connection-cards.tsx
+++ b/frontend/src/components/integration-connection-cards.tsx
@@ -77,7 +77,7 @@ type AdditionalIntegrationCardsProps = IntegrationCallbacks & {
 type ReadOnlyProps = { readOnly?: boolean };
 
 type AllIntegrationCardsProps =
-  SourceControlIntegrationCardProps & AdditionalIntegrationCardsPropsWithReadOnly;
+  SourceControlIntegrationCardProps & AdditionalIntegrationCardsPropsWithReadOnly & GitHubAccountProps;
 
 type AdditionalIntegrationCardsPropsWithReadOnly =
   AdditionalIntegrationCardsProps & ReadOnlyProps;
@@ -455,11 +455,180 @@ export function AdditionalIntegrationCards(props: AdditionalIntegrationCardsProp
   );
 }
 
+// GitHubAccountProps describes the per-user "connect your GitHub account" row
+// that sits directly beneath the org-wide GitHub App row. This is a distinct
+// auth from the App install: the App grants 143 access to the org's repos, while
+// the account lets 143 act *as the signed-in user* (author PRs under their name,
+// transfer repos they personally own). It is per-user, so it stays actionable
+// even for non-admins (readOnly only gates the org-wide integrations).
+export type GitHubAccountRequirement = "required" | "recommended" | "optional";
+
+export type GitHubAccountProps = {
+  githubAccountConnected: boolean;
+  githubAccountLogin?: string;
+  // True when a credential exists but is no longer usable (e.g. token expired):
+  // connected === true but has_repo_scope === false on the status endpoint.
+  githubAccountNeedsReconnect?: boolean;
+  githubAccountRequirement: GitHubAccountRequirement;
+  onConnectGitHubAccount: () => void;
+  onDisconnectGitHubAccount?: () => void;
+  githubAccountDisconnecting?: boolean;
+};
+
+const ACCOUNT_REQUIREMENT_BADGE: Record<
+  GitHubAccountRequirement,
+  { label: string; variant: "outline" | "secondary" }
+> = {
+  required: { label: "Required", variant: "outline" },
+  recommended: { label: "Recommended", variant: "secondary" },
+  optional: { label: "Optional", variant: "secondary" },
+};
+
+function GitHubAccountAction({
+  connected,
+  needsReconnect,
+  login,
+  disconnecting,
+  onConnect,
+  onDisconnect,
+}: {
+  connected: boolean;
+  needsReconnect: boolean;
+  login?: string;
+  disconnecting?: boolean;
+  onConnect: () => void;
+  onDisconnect?: () => void;
+}) {
+  const [confirmOpen, setConfirmOpen] = useState(false);
+
+  if (needsReconnect) {
+    return (
+      <Button size="sm" variant="default" onClick={onConnect} aria-label="Reconnect GitHub account">
+        Reconnect account
+      </Button>
+    );
+  }
+
+  if (connected) {
+    return (
+      <>
+        <div className="flex items-center gap-2">
+          <span className="text-xs text-muted-foreground">{login ? `@${login}` : "Connected"}</span>
+          {onDisconnect ? (
+            <Button
+              size="sm"
+              variant="outline"
+              loading={disconnecting}
+              disabled={disconnecting}
+              onClick={() => setConfirmOpen(true)}
+              aria-label="Disconnect GitHub account"
+            >
+              {disconnecting ? "Disconnecting..." : "Disconnect"}
+            </Button>
+          ) : null}
+        </div>
+        <AlertDialog open={confirmOpen} onOpenChange={setConfirmOpen}>
+          <AlertDialogContent>
+            <AlertDialogHeader>
+              <AlertDialogTitle>Disconnect your GitHub account</AlertDialogTitle>
+              <AlertDialogDescription>
+                143 will stop acting as you on GitHub: PRs will be authored by the 143 app instead,
+                and you&rsquo;ll need to reconnect to transfer repos you personally own. This only
+                affects your account &mdash; the org&rsquo;s GitHub App stays connected.
+              </AlertDialogDescription>
+            </AlertDialogHeader>
+            <AlertDialogFooter>
+              <AlertDialogCancel>Cancel</AlertDialogCancel>
+              <AlertDialogAction
+                onClick={() => {
+                  setConfirmOpen(false);
+                  onDisconnect?.();
+                }}
+                className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+              >
+                Disconnect
+              </AlertDialogAction>
+            </AlertDialogFooter>
+          </AlertDialogContent>
+        </AlertDialog>
+      </>
+    );
+  }
+
+  return (
+    <Button size="sm" onClick={onConnect} aria-label="Connect GitHub account">
+      Connect account
+    </Button>
+  );
+}
+
+function buildGitHubAccountItem(p: GitHubAccountProps) {
+  const github = getIntegrationByKey("github");
+  const requirement = ACCOUNT_REQUIREMENT_BADGE[p.githubAccountRequirement];
+  const connected = p.githubAccountConnected && !p.githubAccountNeedsReconnect;
+
+  let summary: ReactNode;
+  if (p.githubAccountNeedsReconnect) {
+    summary = (
+      <p className="mt-1.5 text-xs text-warning">
+        Your GitHub authorization expired &mdash; reconnect to keep authoring PRs as yourself.
+      </p>
+    );
+  } else if (connected) {
+    summary = (
+      <p className="mt-1.5 text-xs text-muted-foreground">
+        {p.githubAccountLogin ? `Connected as @${p.githubAccountLogin}` : "Connected"}
+      </p>
+    );
+  } else if (p.githubAccountRequirement === "optional") {
+    summary = (
+      <p className="mt-1.5 text-xs text-muted-foreground">
+        PRs are authored by the 143 app. Connect only to author PRs as yourself or transfer repos you personally own.
+      </p>
+    );
+  } else if (p.githubAccountRequirement === "required") {
+    summary = (
+      <p className="mt-1.5 text-xs text-muted-foreground">
+        Required by your org&rsquo;s PR authorship setting &mdash; PRs must be created as you.
+      </p>
+    );
+  } else {
+    summary = (
+      <p className="mt-1.5 text-xs text-muted-foreground">
+        Recommended so PRs are authored under your name instead of the 143 app.
+      </p>
+    );
+  }
+
+  return {
+    id: "github-account",
+    title: "Your GitHub account",
+    description: "Lets 143 act as you — author PRs under your name and transfer repos you own.",
+    logo: <IntegrationLogo name={github.name} src={github.logoSrc} />,
+    badge: (
+      <Badge variant={requirement.variant} className="text-xs">
+        {requirement.label}
+      </Badge>
+    ),
+    summary,
+    action: (
+      <GitHubAccountAction
+        connected={connected}
+        needsReconnect={Boolean(p.githubAccountNeedsReconnect)}
+        login={p.githubAccountLogin}
+        disconnecting={p.githubAccountDisconnecting}
+        onConnect={p.onConnectGitHubAccount}
+        onDisconnect={p.onDisconnectGitHubAccount}
+      />
+    ),
+  };
+}
+
 export function AllIntegrationCards(props: AllIntegrationCardsProps) {
   const github = getIntegrationByKey("github");
   const githubItem = {
     id: github.key,
-    title: github.name,
+    title: "GitHub App",
     description: github.description,
     logo: <IntegrationLogo name={github.name} src={github.logoSrc} />,
     badge: <Badge variant="outline" className="text-xs">Required</Badge>,
@@ -485,6 +654,12 @@ export function AllIntegrationCards(props: AllIntegrationCardsProps) {
     ),
   };
   return (
-    <IntegrationsCard items={[githubItem, ...buildOptionalIntegrationItems(optionalDescriptorsFromProps(props), props)]} />
+    <IntegrationsCard
+      items={[
+        githubItem,
+        buildGitHubAccountItem(props),
+        ...buildOptionalIntegrationItems(optionalDescriptorsFromProps(props), props),
+      ]}
+    />
   );
 }

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -883,7 +883,7 @@ export const api = {
     disconnectAll: () => post<import('./types').SingleResponse<{ disconnected: boolean }>>('/api/v1/settings/claude-code-auth/disconnect'),
   },
   githubStatus: {
-    get: () => get<{ connected: boolean; has_repo_scope: boolean; github_login?: string; pr_authorship_mode: string; pr_draft_default: boolean }>('/api/v1/users/me/github-status'),
+    get: () => get<{ connected: boolean; has_repo_scope: boolean; github_login?: string; pr_authorship_mode: string; pr_draft_default: boolean; account_requirement: 'required' | 'recommended' | 'optional' }>('/api/v1/users/me/github-status'),
     connect: (resumeToken?: string) => {
       const searchParams = new URLSearchParams();
       if (resumeToken) searchParams.set('resume_token', resumeToken);

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -883,7 +883,7 @@ export const api = {
     disconnectAll: () => post<import('./types').SingleResponse<{ disconnected: boolean }>>('/api/v1/settings/claude-code-auth/disconnect'),
   },
   githubStatus: {
-    get: () => get<{ connected: boolean; has_repo_scope: boolean; github_login?: string; pr_authorship_mode: string; pr_draft_default: boolean; account_requirement: 'required' | 'recommended' | 'optional' }>('/api/v1/users/me/github-status'),
+    get: () => get<{ connected: boolean; has_repo_scope: boolean; github_login?: string; pr_authorship_mode: string; pr_draft_default: boolean; account_requirement: 'required' | 'recommended' | 'optional'; needs_reconnect: boolean }>('/api/v1/users/me/github-status'),
     connect: (resumeToken?: string) => {
       const searchParams = new URLSearchParams();
       if (resumeToken) searchParams.set('resume_token', resumeToken);

--- a/frontend/src/lib/integrations.ts
+++ b/frontend/src/lib/integrations.ts
@@ -11,7 +11,7 @@ export const INTEGRATIONS: IntegrationDefinition[] = [
   {
     key: "github",
     name: "GitHub",
-    description: "Sync repositories and open PRs.",
+    description: "Install the 143 app so it can access your repositories and open PRs.",
     logoSrc: "/integrations/github.svg",
   },
   {

--- a/internal/api/handlers/github_status.go
+++ b/internal/api/handlers/github_status.go
@@ -76,11 +76,32 @@ func (h *GitHubStatusHandler) SetAppUserAuth(auth githubAppUserAuth) {
 
 // GitHubStatusResponse is the response for GET /api/v1/users/me/github-status.
 type GitHubStatusResponse struct {
-	Connected        bool   `json:"connected"`
-	HasRepoScope     bool   `json:"has_repo_scope"`
-	GitHubLogin      string `json:"github_login,omitempty"`
+	Connected    bool   `json:"connected"`
+	HasRepoScope bool   `json:"has_repo_scope"`
+	GitHubLogin  string `json:"github_login,omitempty"`
+	// PRAuthorshipMode echoes the org's pr_authorship setting.
 	PRAuthorshipMode string `json:"pr_authorship_mode"`
 	PRDraftDefault   bool   `json:"pr_draft_default"`
+	// AccountRequirement tells the UI how to present the per-user "connect
+	// your GitHub account" step, derived from PRAuthorshipMode so the rule
+	// lives server-side: "required" (user_required), "recommended"
+	// (user_preferred), or "optional" (app_only). Note "optional" still
+	// matters — claiming/transferring a repo you personally own needs the
+	// user token regardless of authorship mode — so it is never "not needed".
+	AccountRequirement string `json:"account_requirement"`
+}
+
+// accountRequirement maps the org's PR authorship mode onto how prominently the
+// per-user GitHub account connection should be presented.
+func accountRequirement(mode models.PRAuthorship) string {
+	switch mode {
+	case models.PRAuthorshipUserRequired:
+		return "required"
+	case models.PRAuthorshipAppOnly:
+		return "optional"
+	default: // user_preferred and any unknown/empty value
+		return "recommended"
+	}
 }
 
 // GetStatus returns the user's GitHub connection status and the org's PR authorship mode.
@@ -93,7 +114,8 @@ func (h *GitHubStatusHandler) GetStatus(w http.ResponseWriter, r *http.Request) 
 	orgID := middleware.OrgIDFromContext(r.Context())
 
 	resp := GitHubStatusResponse{
-		PRAuthorshipMode: string(models.PRAuthorshipUserPreferred),
+		PRAuthorshipMode:   string(models.PRAuthorshipUserPreferred),
+		AccountRequirement: accountRequirement(models.PRAuthorshipUserPreferred),
 	}
 
 	// Check org settings for PR authorship mode.
@@ -103,6 +125,7 @@ func (h *GitHubStatusHandler) GetStatus(w http.ResponseWriter, r *http.Request) 
 		if parseErr == nil {
 			resp.PRAuthorshipMode = string(settings.PRAuthorship)
 			resp.PRDraftDefault = settings.PRDraftDefault
+			resp.AccountRequirement = accountRequirement(settings.PRAuthorship)
 		}
 	}
 

--- a/internal/api/handlers/github_status.go
+++ b/internal/api/handlers/github_status.go
@@ -89,6 +89,22 @@ type GitHubStatusResponse struct {
 	// matters — claiming/transferring a repo you personally own needs the
 	// user token regardless of authorship mode — so it is never "not needed".
 	AccountRequirement string `json:"account_requirement"`
+	// NeedsReconnect is true when a credential row exists but is no longer
+	// usable (expired, or a refresh that failed). Distinct from Connected so
+	// the UI can show a "reconnect" prompt instead of a plain "connect" — the
+	// user already authorized once, they just need to re-authorize.
+	NeedsReconnect bool `json:"needs_reconnect"`
+}
+
+// credentialExists reports whether a GitHub App user credential row exists for
+// the user, regardless of whether it is still valid. Used to distinguish
+// "never connected" from "connected but the token is no longer usable".
+func (h *GitHubStatusHandler) credentialExists(ctx context.Context, orgID, userID uuid.UUID) bool {
+	if h.credentials == nil {
+		return false
+	}
+	cred, err := h.credentials.GetForUser(ctx, orgID, userID, models.ProviderGitHubAppUser)
+	return err == nil && cred != nil
 }
 
 // accountRequirement maps the org's PR authorship mode onto how prominently the
@@ -141,17 +157,25 @@ func (h *GitHubStatusHandler) GetStatus(w http.ResponseWriter, r *http.Request) 
 			if user.GitHubLogin != nil {
 				resp.GitHubLogin = *user.GitHubLogin
 			}
+		} else if h.credentialExists(r.Context(), orgID, user.ID) {
+			// The credential is no longer valid (expired or refresh failed) but
+			// the user did authorize before — prompt a reconnect, not a connect.
+			resp.NeedsReconnect = true
 		}
 	} else {
 		// Fallback for tests/wiring without the refresh-aware auth service.
 		cred, err := h.credentials.GetForUser(r.Context(), orgID, user.ID, models.ProviderGitHubAppUser)
 		if err == nil && cred != nil {
 			cfg, ok := cred.Config.(models.GitHubAppUserConfig)
-			if ok && cfg.AccessToken != "" && !cfg.IsExpired() {
-				resp.Connected = true
-				resp.HasRepoScope = true
-				if user.GitHubLogin != nil {
-					resp.GitHubLogin = *user.GitHubLogin
+			if ok && cfg.AccessToken != "" {
+				if cfg.IsExpired() {
+					resp.NeedsReconnect = true
+				} else {
+					resp.Connected = true
+					resp.HasRepoScope = true
+					if user.GitHubLogin != nil {
+						resp.GitHubLogin = *user.GitHubLogin
+					}
 				}
 			}
 		}

--- a/internal/api/handlers/github_status_test.go
+++ b/internal/api/handlers/github_status_test.go
@@ -231,6 +231,69 @@ func TestGitHubStatusHandler_GetStatus_IgnoresExpiredCredential(t *testing.T) {
 	require.False(t, resp.Connected, "expired app-user credential should not be treated as connected")
 	require.False(t, resp.HasRepoScope, "expired app-user credential should not be treated as PR-capable")
 	require.Empty(t, resp.GitHubLogin, "disconnected response should not promise authorship as the user")
+	require.True(t, resp.NeedsReconnect, "an expired-but-present credential should prompt a reconnect, not a fresh connect")
+}
+
+func TestGitHubStatusHandler_GetStatus_NeedsReconnectWhenAppAuthInvalid(t *testing.T) {
+	t.Parallel()
+
+	orgID := uuid.New()
+	userID := uuid.New()
+
+	// A credential row exists, but the refresh-aware service reports it as no
+	// longer valid (e.g. the refresh token was revoked). The user authorized
+	// before, so the UI should prompt a reconnect rather than a first connect.
+	credStore := &stubGHCredentialStore{
+		cred: &models.DecryptedUserCredential{Config: models.GitHubAppUserConfig{AccessToken: "ghu_test"}},
+	}
+	handler := NewGitHubStatusHandler(credStore, &stubGHOrgReader{}, "", "", "", "")
+	handler.appUserAuth = &stubGitHubAppUserAuthService{
+		hasValidCredentialFunc: func(context.Context, uuid.UUID, uuid.UUID) (bool, error) {
+			return false, nil
+		},
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/users/me/github-status", nil)
+	ctx := middleware.WithUser(req.Context(), &models.User{ID: userID, OrgID: orgID})
+	ctx = middleware.WithOrgID(ctx, orgID)
+	req = req.WithContext(ctx)
+	rr := httptest.NewRecorder()
+	handler.GetStatus(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code)
+	var resp GitHubStatusResponse
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &resp))
+	require.False(t, resp.Connected, "invalid credential should not report connected")
+	require.True(t, resp.NeedsReconnect, "invalid-but-present credential should prompt a reconnect")
+}
+
+func TestGitHubStatusHandler_GetStatus_NoReconnectWhenNeverConnected(t *testing.T) {
+	t.Parallel()
+
+	orgID := uuid.New()
+	userID := uuid.New()
+
+	// No credential row at all → not connected and no reconnect prompt.
+	credStore := &stubGHCredentialStore{err: context.DeadlineExceeded}
+	handler := NewGitHubStatusHandler(credStore, &stubGHOrgReader{}, "", "", "", "")
+	handler.appUserAuth = &stubGitHubAppUserAuthService{
+		hasValidCredentialFunc: func(context.Context, uuid.UUID, uuid.UUID) (bool, error) {
+			return false, nil
+		},
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/users/me/github-status", nil)
+	ctx := middleware.WithUser(req.Context(), &models.User{ID: userID, OrgID: orgID})
+	ctx = middleware.WithOrgID(ctx, orgID)
+	req = req.WithContext(ctx)
+	rr := httptest.NewRecorder()
+	handler.GetStatus(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code)
+	var resp GitHubStatusResponse
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &resp))
+	require.False(t, resp.Connected, "no credential should report not connected")
+	require.False(t, resp.NeedsReconnect, "never-connected user should see connect, not reconnect")
 }
 
 func TestGitHubStatusHandler_StartConnect_NotConfigured(t *testing.T) {

--- a/internal/api/handlers/github_status_test.go
+++ b/internal/api/handlers/github_status_test.go
@@ -113,6 +113,47 @@ func TestGitHubStatusHandler_GetStatus_Connected(t *testing.T) {
 	require.True(t, resp.HasRepoScope, "app-user credential should be treated as PR-capable")
 	require.Equal(t, "testuser", resp.GitHubLogin, "response should include the user's GitHub login")
 	require.Equal(t, "user_preferred", resp.PRAuthorshipMode, "response should echo org PR authorship mode")
+	require.Equal(t, "recommended", resp.AccountRequirement, "user_preferred should make the account connection recommended")
+}
+
+func TestGitHubStatusHandler_GetStatus_AccountRequirementByMode(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		mode string
+		want string
+	}{
+		{"user_required", "required"},
+		{"user_preferred", "recommended"},
+		{"app_only", "optional"},
+		{"", "recommended"},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.mode, func(t *testing.T) {
+			t.Parallel()
+			orgID := uuid.New()
+			userID := uuid.New()
+			orgReader := &stubGHOrgReader{
+				org: models.Organization{
+					Settings: json.RawMessage(`{"pr_authorship":"` + tc.mode + `"}`),
+				},
+			}
+			handler := NewGitHubStatusHandler(&stubGHCredentialStore{err: context.DeadlineExceeded}, orgReader, "", "", "", "")
+
+			req := httptest.NewRequest(http.MethodGet, "/api/v1/users/me/github-status", nil)
+			ctx := middleware.WithUser(req.Context(), &models.User{ID: userID, OrgID: orgID})
+			ctx = middleware.WithOrgID(ctx, orgID)
+			req = req.WithContext(ctx)
+			rr := httptest.NewRecorder()
+			handler.GetStatus(rr, req)
+
+			require.Equal(t, http.StatusOK, rr.Code)
+			var resp GitHubStatusResponse
+			require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &resp))
+			require.Equal(t, tc.want, resp.AccountRequirement, "account requirement should follow authorship mode")
+		})
+	}
 }
 
 func TestGitHubStatusHandler_GetStatus_NotConnected(t *testing.T) {


### PR DESCRIPTION
## Why

Two distinct GitHub auths confused users: the org-wide **GitHub App** (lets 143 access repos and open PRs) and the per-user **GitHub account** (lets 143 act *as you* — author PRs under your name, transfer repos you personally own). The account auth had no standing UI — it only appeared as an error-triggered button — and the setting that decides whether it is needed lived on a different page. This makes both legible in one place.

## Changes (all 5 planned phases)

- **Phase 0 — vocabulary:** card renamed to **"GitHub App"** with clearer copy; per-user row titled **"Your GitHub account"** with an "acts as you" framing. Stops the inaccurate "org/repo level" labeling.
- **Phase 1 — first-class account row:** Integrations now queries `github-status` and renders a standing row with connected-as-`@login` / **Reconnect** (token expired) / **Connect account** states + Disconnect (with confirm). Per-user, so it stays actionable for non-admins.
- **Phase 2 — gated requirement:** backend `github-status` returns `account_requirement` (`required`/`recommended`/`optional`) derived from `pr_authorship`; the row shows the matching badge + copy.
- **Phase 3 — co-located setting:** the PR authorship control on Organization settings now reflects whether your account is connected and links to Integrations.
- **Phase 4 — proactive prompts:** repo transfers prompt to connect the account *before* the click fails when transfer candidates exist; in-session PR prompt button aligned to "Connect your GitHub account".
- **Phase 5 — honest `app_only`:** under app-only authorship the account is marked **Optional** with copy explaining PRs are authored by the app — but still connectable, since transfers need the user token regardless.

## Tests

- Go: `account_requirement` table test across all authorship modes; existing handler tests green; `make lint` 0 issues.
- Frontend: new tests for the account row (connect / connected+disconnect / app_only-optional / reconnect) and the proactive transfer prompt; updated existing tests for the rename and button label. `tsc` + `eslint` clean on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
