### PR TITLE
Add postgres-14 and postgres-15 preview infra templates

### DIFF
--- a/internal/services/preview/config.go
+++ b/internal/services/preview/config.go
@@ -33,6 +33,8 @@ type InfraTemplate struct {
 var supportedTemplates = map[string]InfraTemplate{
 	"postgres-17": {Image: "postgres:17-alpine", DefaultPort: 5432, HealthCmd: []string{"pg_isready"}, DefaultMemMB: 256, DefaultCPU: 0.25, MaxMemMB: 512},
 	"postgres-16": {Image: "postgres:16-alpine", DefaultPort: 5432, HealthCmd: []string{"pg_isready"}, DefaultMemMB: 256, DefaultCPU: 0.25, MaxMemMB: 512},
+	"postgres-15": {Image: "postgres:15-alpine", DefaultPort: 5432, HealthCmd: []string{"pg_isready"}, DefaultMemMB: 256, DefaultCPU: 0.25, MaxMemMB: 512},
+	"postgres-14": {Image: "postgres:14-alpine", DefaultPort: 5432, HealthCmd: []string{"pg_isready"}, DefaultMemMB: 256, DefaultCPU: 0.25, MaxMemMB: 512},
 	"redis-7":     {Image: "redis:7-alpine", DefaultPort: 6379, HealthCmd: []string{"redis-cli", "ping"}, DefaultMemMB: 128, DefaultCPU: 0.1, MaxMemMB: 256},
 	"mysql-8":     {Image: "mysql:8.4", DefaultPort: 3306, HealthCmd: []string{"mysqladmin", "ping"}, DefaultMemMB: 384, DefaultCPU: 0.25, MaxMemMB: 768},
 }

--- a/internal/services/preview/config_test.go
+++ b/internal/services/preview/config_test.go
@@ -1923,6 +1923,8 @@ func TestLookupInfraTemplate(t *testing.T) {
 	}{
 		{"postgres-17", true},
 		{"postgres-16", true},
+		{"postgres-15", true},
+		{"postgres-14", true},
 		{"redis-7", true},
 		{"mysql-8", true},
 		{"elasticsearch-8", false},


### PR DESCRIPTION
## Summary

Preview profiles can declare a managed database sidecar via `infrastructure`, but the supported-template allowlist only covered `postgres-16`/`postgres-17`. Apps pinned to an older Postgres major (e.g. Assembled runs Postgres 14) couldn't stand up a per-preview database that matches production. This adds `postgres-14` and `postgres-15` so a profile can run a version-matched sidecar.

## Changes

- Add `postgres-14` (`postgres:14-alpine`) and `postgres-15` (`postgres:15-alpine`) to `supportedTemplates` in `internal/services/preview/config.go`.
- Templates stay at **major-version granularity** — the rolling `:NN-alpine` tag floats minors, so one entry covers every 14.x/15.x without a template-per-minor explosion. The map continues to double as the vetted sidecar-image allowlist.
- Extend `TestLookupInfraTemplate` to cover the new templates.

## Validation

- `go test ./internal/services/preview/ -run TestLookupInfraTemplate` — pass
- `gofmt` clean

> Note: This is the platform half of enabling seeded per-preview Postgres for the Assembled app. The app-side changes (a `postgres-14` sidecar in its `.143` profile, a `cmd/preview-seed` that applies the branch schema + seeds synthetic data, and DB env wiring) live in the `assembledhq/assembled` repo and will ship as a separate PR. Deploy this template change first so the app config's `postgres-14` reference validates.