### PR TITLE
Search branches server-side so large repos are usable in the picker

### DIFF
--- a/frontend/src/components/branch-picker.test.tsx
+++ b/frontend/src/components/branch-picker.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { renderWithProviders, screen, userEvent } from "@/test/test-utils";
+import { renderWithProviders, screen, userEvent, waitFor } from "@/test/test-utils";
 import { BranchPicker } from "./branch-picker";
 
 const mocks = vi.hoisted(() => ({
@@ -19,17 +19,24 @@ describe("BranchPicker", () => {
     mocks.branchesMock.mockReset();
   });
 
-  it("filters existing branches and applies the selected branch", async () => {
+  it("searches branches server-side and applies the selected branch", async () => {
     const user = userEvent.setup();
     const onValueChange = vi.fn();
 
-    mocks.branchesMock.mockResolvedValue({
-      data: [
-        { name: "main", protected: true },
-        { name: "release/2026.04", protected: true },
-        { name: "feature/smart-picker", protected: false },
-      ],
-    });
+    const allBranches = [
+      { name: "main", protected: true },
+      { name: "release/2026.04", protected: true },
+      { name: "feature/smart-picker", protected: false },
+    ];
+    // Mirror the backend: the search query filters server-side, so the picker
+    // only ever renders what the request returned for the current query.
+    mocks.branchesMock.mockImplementation((_id: string, query?: string) =>
+      Promise.resolve({
+        data: query
+          ? allBranches.filter((b) => b.name.includes(query))
+          : allBranches,
+      }),
+    );
 
     renderWithProviders(
       <BranchPicker
@@ -44,10 +51,16 @@ describe("BranchPicker", () => {
     await user.click(screen.getByRole("button", { name: "Base branch" }));
 
     expect(await screen.findByPlaceholderText("Search branches...")).toBeInTheDocument();
+    expect(await screen.findByText("feature/smart-picker")).toBeInTheDocument();
+
     await user.type(screen.getByPlaceholderText("Search branches..."), "release");
 
-    expect(await screen.findByText("release/2026.04")).toBeInTheDocument();
-    expect(screen.queryByText("feature/smart-picker")).not.toBeInTheDocument();
+    // Once the debounced query resolves, the non-matching branch is gone.
+    await waitFor(() =>
+      expect(screen.queryByText("feature/smart-picker")).not.toBeInTheDocument(),
+    );
+    expect(screen.getByText("release/2026.04")).toBeInTheDocument();
+    expect(mocks.branchesMock).toHaveBeenCalledWith("repo-1", "release");
 
     await user.click(screen.getByText("release/2026.04"));
 

--- a/frontend/src/components/branch-picker.tsx
+++ b/frontend/src/components/branch-picker.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { ChevronsUpDown, GitBranch } from "lucide-react";
 
@@ -50,19 +50,48 @@ export function BranchPicker({
   disabled = false,
 }: BranchPickerProps) {
   const [open, setOpen] = useState(false);
+  const [search, setSearch] = useState("");
+
+  // Debounce the search box so each keystroke doesn't fire its own GitHub
+  // request. The query itself runs server-side (GitHub GraphQL refs search),
+  // which is what lets repos with thousands of branches find an arbitrary
+  // branch — client-side filtering can only narrow what was already fetched.
+  const [debouncedSearch, setDebouncedSearch] = useState("");
+  useEffect(() => {
+    const handle = setTimeout(() => setDebouncedSearch(search), 250);
+    return () => clearTimeout(handle);
+  }, [search]);
 
   const { data, isLoading, isError, refetch } = useQuery<ListResponse<BranchInfo>>({
-    queryKey: queryKeys.repositories.branches(repositoryId),
-    queryFn: () => api.repositories.branches(repositoryId),
+    queryKey: queryKeys.repositories.branches(repositoryId, debouncedSearch),
+    queryFn: () => api.repositories.branches(repositoryId, debouncedSearch),
     enabled: !!repositoryId && open,
     staleTime: 0,
+    // Keep the previous results visible while the next *search* request is in
+    // flight so the list doesn't flicker to a loading state on every keystroke.
+    // Scope this to the same repository: keepPreviousData would otherwise show
+    // the prior repo's branches when repositoryId changes (the query key's repo
+    // segment is at index 1), so only reuse the placeholder when it matches.
+    placeholderData: (previousData, previousQuery) =>
+      previousQuery?.queryKey[1] === repositoryId ? previousData : undefined,
   });
 
   const branches = useMemo(() => data?.data ?? [], [data]);
   const selectedBranch = value || defaultBranch || "";
 
   return (
-    <Popover open={open} onOpenChange={setOpen}>
+    <Popover
+      open={open}
+      onOpenChange={(next) => {
+        setOpen(next);
+        // Reset the search when the picker closes so reopening starts from the
+        // default (recently-committed) branch list rather than a stale query.
+        if (!next) {
+          setSearch("");
+          setDebouncedSearch("");
+        }
+      }}
+    >
       <PopoverTrigger asChild>
         <Button
           type="button"
@@ -81,8 +110,12 @@ export function BranchPicker({
         </Button>
       </PopoverTrigger>
       <PopoverContent className={cn("w-[var(--radix-popover-trigger-width)] p-0", contentClassName)}>
-        <Command>
-          <CommandInput placeholder="Search branches..." />
+        {/* shouldFilter={false}: branches are filtered server-side, so cmdk
+            must render exactly what the query returned without re-filtering it
+            against the input text (which would re-hide matches whose names
+            don't fuzzy-match the raw query string). */}
+        <Command shouldFilter={false}>
+          <CommandInput placeholder="Search branches..." value={search} onValueChange={setSearch} />
           <CommandList>
             {isLoading && (
               <div className="px-3 py-4 text-sm text-muted-foreground">Loading branches...</div>

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -243,7 +243,10 @@ export const api = {
     reconnect: (id: string) =>
       post<import('./types').SingleResponse<import('./types').Repository>>(`/api/v1/repositories/${id}/reconnect`),
     summary: () => get<import('./types').ListResponse<import('./types').RepoSummary>>('/api/v1/repositories/summary'),
-    branches: (id: string) => get<import('./types').ListResponse<{ name: string; protected: boolean }>>(`/api/v1/repositories/${id}/branches`),
+    branches: (id: string, query?: string) =>
+      get<import('./types').ListResponse<{ name: string; protected: boolean }>>(
+        `/api/v1/repositories/${id}/branches${query ? `?query=${encodeURIComponent(query)}` : ''}`,
+      ),
     detectPreview: (owner: string, repo: string) => get<import('./preview-types').PreviewDetectionResult>(`/api/v1/repos/${owner}/${repo}/preview/detect`),
     previewSecretBundles: {
       list: (id: string) =>

--- a/frontend/src/lib/query-keys.test.ts
+++ b/frontend/src/lib/query-keys.test.ts
@@ -65,8 +65,17 @@ describe("queryKeys", () => {
       expect(queryKeys.repositories.all).toEqual(["repositories"]);
     });
 
-    it("branches includes repository id", () => {
-      expect(queryKeys.repositories.branches("repo-1")).toEqual(["repositories", "repo-1", "branches"]);
+    it("branches includes repository id and an empty query by default", () => {
+      expect(queryKeys.repositories.branches("repo-1")).toEqual(["repositories", "repo-1", "branches", ""]);
+    });
+
+    it("branches includes the search query so distinct searches cache separately", () => {
+      expect(queryKeys.repositories.branches("repo-1", "release")).toEqual([
+        "repositories",
+        "repo-1",
+        "branches",
+        "release",
+      ]);
     });
   });
 

--- a/frontend/src/lib/query-keys.ts
+++ b/frontend/src/lib/query-keys.ts
@@ -38,7 +38,7 @@ export const queryKeys = {
   repositories: {
     all: ["repositories"] as const,
     summary: ["repositories", "summary"] as const,
-    branches: (id: string) => ["repositories", id, "branches"] as const,
+    branches: (id: string, query = "") => ["repositories", id, "branches", query] as const,
     previewSecretBundles: (id: string) => ["repositories", id, "preview-secret-bundles"] as const,
   },
   sessionComposer: {

--- a/internal/api/handlers/repositories.go
+++ b/internal/api/handlers/repositories.go
@@ -228,12 +228,17 @@ func (h *RepositoryHandler) ListBranches(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	ghBranches, err := h.prService.ListBranches(r.Context(), token, parts[0], parts[1])
+	query := strings.TrimSpace(r.URL.Query().Get("query"))
+	ghBranches, err := h.prService.SearchBranches(r.Context(), token, parts[0], parts[1], query)
 	if err != nil {
 		writeError(w, r, http.StatusBadGateway, "GITHUB_API_FAILED", "failed to list branches from GitHub")
 		return
 	}
 
+	// Protected is always false here: the GraphQL refs search doesn't return
+	// branch-protection state cheaply (it needs admin:read, which the App lacks),
+	// so the field is retained for response-shape stability but no longer
+	// populated. The branch picker only used it as a search keyword.
 	branches := make([]branchResponse, len(ghBranches))
 	for i, b := range ghBranches {
 		branches[i] = branchResponse{Name: b.Name, Protected: b.Protected}

--- a/internal/services/github/pr.go
+++ b/internal/services/github/pr.go
@@ -2460,6 +2460,52 @@ func (s *PRService) doGitHubRequest(ctx context.Context, token, method, path str
 	return respBody, nil
 }
 
+// doGitHubGraphQL POSTs a GraphQL query to the GitHub GraphQL endpoint and
+// returns the raw response body. GraphQL returns HTTP 200 even for query-level
+// errors (surfaced in the response's `errors` array), so callers must inspect
+// the decoded body — a nil error here only means the transport succeeded.
+//
+// The endpoint is derived as baseURL+"/graphql", which is correct for
+// github.com (REST base https://api.github.com → https://api.github.com/graphql).
+// GitHub Enterprise Server splits these differently (REST at /api/v3, GraphQL at
+// /api/graphql); revisit this if 143 ever targets a GHES base URL.
+func (s *PRService) doGitHubGraphQL(ctx context.Context, token, query string, variables map[string]any) ([]byte, error) {
+	payload, err := json.Marshal(map[string]any{"query": query, "variables": variables})
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, s.baseURL+"/graphql", bytes.NewReader(payload))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Authorization", "bearer "+token)
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := s.httpClient.Do(req) // #nosec G704 -- URL is GitHub GraphQL endpoint from config
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.StatusCode >= 400 {
+		return nil, &GitHubAPIError{
+			Method:     http.MethodPost,
+			Path:       "/graphql",
+			StatusCode: resp.StatusCode,
+			Body:       respBody,
+		}
+	}
+
+	return respBody, nil
+}
+
 // GitHubAPIError wraps a non-2xx response from the GitHub REST API so callers
 // can inspect the status and parsed error details with errors.As rather than
 // matching on prose.
@@ -2580,27 +2626,75 @@ type GitHubTreeEntry struct {
 	Type string `json:"type"`
 }
 
-// ListBranches returns the branches for a repository from the GitHub API.
-func (s *PRService) ListBranches(ctx context.Context, token, owner, repo string) ([]GitHubBranch, error) {
-	var all []GitHubBranch
-	page := 1
-	for {
-		path := fmt.Sprintf("/repos/%s/%s/branches?per_page=100&page=%d", owner, repo, page)
-		body, err := s.doGitHubRequest(ctx, token, http.MethodGet, path, nil)
-		if err != nil {
-			return nil, fmt.Errorf("list branches: %w", err)
-		}
-		var branches []GitHubBranch
-		if err := json.Unmarshal(body, &branches); err != nil {
-			return nil, fmt.Errorf("decode branches: %w", err)
-		}
-		all = append(all, branches...)
-		if len(branches) < 100 || page >= 10 {
-			break
-		}
-		page++
+// maxBranchResults caps how many branches the branch picker fetches in one
+// request. GitHub's GraphQL refs connection allows up to 100 per page; we never
+// page past the first because the picker relies on server-side search (an empty
+// query shows the most-recently-committed branches, a typed query narrows the
+// set), so a single page of matches is always enough to surface the target.
+const maxBranchResults = 100
+
+// branchSearchQuery searches a repository's branches by name. The refs `query`
+// argument does a server-side contains-match against branch names, so repos
+// with thousands of branches can still find an arbitrary branch without
+// downloading the entire list. Ordering by commit date keeps the unfiltered
+// (empty-query) view focused on recently-active branches.
+const branchSearchQuery = `query($owner:String!,$name:String!,$query:String,$limit:Int!){
+  repository(owner:$owner,name:$name){
+    refs(refPrefix:"refs/heads/",query:$query,first:$limit,orderBy:{field:TAG_COMMIT_DATE,direction:DESC}){
+      nodes{ name }
+    }
+  }
+}`
+
+// SearchBranches returns up to maxBranchResults branches for a repository,
+// filtered by a server-side name search via the GitHub GraphQL API. An empty
+// query returns the most-recently-committed branches. This replaces the old
+// REST pagination over /branches, which could not search and silently truncated
+// repos with more than ~1000 branches.
+func (s *PRService) SearchBranches(ctx context.Context, token, owner, repo, query string) ([]GitHubBranch, error) {
+	variables := map[string]any{
+		"owner": owner,
+		"name":  repo,
+		"limit": maxBranchResults,
+		// A nil query tells GitHub to return all refs (ordered); a non-empty
+		// string filters by contains-match.
+		"query": nil,
 	}
-	return all, nil
+	if query != "" {
+		variables["query"] = query
+	}
+
+	body, err := s.doGitHubGraphQL(ctx, token, branchSearchQuery, variables)
+	if err != nil {
+		return nil, fmt.Errorf("search branches: %w", err)
+	}
+
+	var result struct {
+		Data struct {
+			Repository struct {
+				Refs struct {
+					Nodes []struct {
+						Name string `json:"name"`
+					} `json:"nodes"`
+				} `json:"refs"`
+			} `json:"repository"`
+		} `json:"data"`
+		Errors []struct {
+			Message string `json:"message"`
+		} `json:"errors"`
+	}
+	if err := json.Unmarshal(body, &result); err != nil {
+		return nil, fmt.Errorf("decode branches: %w", err)
+	}
+	if len(result.Errors) > 0 {
+		return nil, fmt.Errorf("search branches: %s", result.Errors[0].Message)
+	}
+
+	branches := make([]GitHubBranch, 0, len(result.Data.Repository.Refs.Nodes))
+	for _, n := range result.Data.Repository.Refs.Nodes {
+		branches = append(branches, GitHubBranch{Name: n.Name})
+	}
+	return branches, nil
 }
 
 // ResolveBranchHead returns the current commit SHA for a branch.

--- a/internal/services/github/pr_handlers_test.go
+++ b/internal/services/github/pr_handlers_test.go
@@ -2158,22 +2158,24 @@ func TestHandlePullRequestEvent_MergedWithUpdateStatusError(t *testing.T) {
 	require.Contains(t, err.Error(), "update PR status to merged", "error should describe the failed operation")
 }
 
-func TestListBranches_Success(t *testing.T) {
+func TestSearchBranches_Success(t *testing.T) {
 	t.Parallel()
 
-	branches := []GitHubBranch{
-		{Name: "main", Protected: true},
-		{Name: "develop", Protected: false},
-		{Name: "feature/foo", Protected: false},
-	}
-
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		require.Equal(t, http.MethodGet, r.Method, "ListBranches should use GET")
-		require.Contains(t, r.URL.Path, "/repos/owner/repo/branches", "request path should target branches endpoint")
-		require.Equal(t, "token test-token", r.Header.Get("Authorization"), "should send authorization header")
+		require.Equal(t, http.MethodPost, r.Method, "SearchBranches should use POST")
+		require.Equal(t, "/graphql", r.URL.Path, "request should target the GraphQL endpoint")
+		require.Equal(t, "bearer test-token", r.Header.Get("Authorization"), "should send bearer authorization header")
+
+		var req struct {
+			Variables map[string]any `json:"variables"`
+		}
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&req), "request body should be valid JSON")
+		require.Equal(t, "owner", req.Variables["owner"], "owner variable should be forwarded")
+		require.Equal(t, "repo", req.Variables["name"], "repo variable should be forwarded")
+		require.Nil(t, req.Variables["query"], "empty query should be sent as null")
 
 		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(branches)
+		w.Write([]byte(`{"data":{"repository":{"refs":{"nodes":[{"name":"main"},{"name":"develop"},{"name":"feature/foo"}]}}}}`))
 	}))
 	defer server.Close()
 
@@ -2183,34 +2185,27 @@ func TestListBranches_Success(t *testing.T) {
 		logger:     zerolog.Nop(),
 	}
 
-	result, err := svc.ListBranches(context.Background(), "test-token", "owner", "repo")
-	require.NoError(t, err, "ListBranches should not return an error")
-	require.Len(t, result, 3, "should return all branches")
+	result, err := svc.SearchBranches(context.Background(), "test-token", "owner", "repo", "")
+	require.NoError(t, err, "SearchBranches should not return an error")
+	require.Len(t, result, 3, "should return all branches in the response")
 	require.Equal(t, "main", result[0].Name, "first branch should be main")
-	require.True(t, result[0].Protected, "main branch should be protected")
 	require.Equal(t, "feature/foo", result[2].Name, "third branch should be feature/foo")
 }
 
-func TestListBranches_Pagination(t *testing.T) {
+func TestSearchBranches_ForwardsQueryAndLimit(t *testing.T) {
 	t.Parallel()
 
-	callCount := 0
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		callCount++
-		w.Header().Set("Content-Type", "application/json")
-
-		if callCount == 1 {
-			// Return exactly 100 branches to trigger pagination.
-			branches := make([]GitHubBranch, 100)
-			for i := range branches {
-				branches[i] = GitHubBranch{Name: fmt.Sprintf("branch-%d", i)}
-			}
-			json.NewEncoder(w).Encode(branches)
-		} else {
-			// Second page returns fewer than 100.
-			branches := []GitHubBranch{{Name: "last-branch"}}
-			json.NewEncoder(w).Encode(branches)
+		var req struct {
+			Variables map[string]any `json:"variables"`
 		}
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&req), "request body should be valid JSON")
+		require.Equal(t, "preview-seeded", req.Variables["query"], "typed query should be forwarded")
+		// JSON numbers decode as float64; the limit is always the maxBranchResults cap.
+		require.Equal(t, float64(maxBranchResults), req.Variables["limit"], "limit should be the result cap")
+
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"data":{"repository":{"refs":{"nodes":[{"name":"wangjohn/preview-seeded-postgres"}]}}}}`))
 	}))
 	defer server.Close()
 
@@ -2220,14 +2215,35 @@ func TestListBranches_Pagination(t *testing.T) {
 		logger:     zerolog.Nop(),
 	}
 
-	result, err := svc.ListBranches(context.Background(), "test-token", "owner", "repo")
-	require.NoError(t, err, "ListBranches should not return an error")
-	require.Len(t, result, 101, "should return all branches across pages")
-	require.Equal(t, 2, callCount, "should make exactly 2 API calls")
-	require.Equal(t, "last-branch", result[100].Name, "last branch should be from second page")
+	result, err := svc.SearchBranches(context.Background(), "test-token", "owner", "repo", "preview-seeded")
+	require.NoError(t, err, "SearchBranches should not return an error")
+	require.Len(t, result, 1, "should return the single matching branch")
+	require.Equal(t, "wangjohn/preview-seeded-postgres", result[0].Name, "should return the searched branch")
 }
 
-func TestListBranches_APIError(t *testing.T) {
+func TestSearchBranches_GraphQLErrors(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// GraphQL surfaces query-level failures as HTTP 200 with an errors array.
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"errors":[{"message":"Could not resolve to a Repository"}]}`))
+	}))
+	defer server.Close()
+
+	svc := &PRService{
+		baseURL:    server.URL,
+		httpClient: server.Client(),
+		logger:     zerolog.Nop(),
+	}
+
+	result, err := svc.SearchBranches(context.Background(), "test-token", "owner", "repo", "")
+	require.Error(t, err, "SearchBranches should return an error when GraphQL reports errors")
+	require.Nil(t, result, "result should be nil on error")
+	require.Contains(t, err.Error(), "Could not resolve to a Repository", "error should include the GraphQL message")
+}
+
+func TestSearchBranches_APIError(t *testing.T) {
 	t.Parallel()
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -2242,10 +2258,10 @@ func TestListBranches_APIError(t *testing.T) {
 		logger:     zerolog.Nop(),
 	}
 
-	result, err := svc.ListBranches(context.Background(), "test-token", "owner", "repo")
-	require.Error(t, err, "ListBranches should return an error on API failure")
+	result, err := svc.SearchBranches(context.Background(), "test-token", "owner", "repo", "")
+	require.Error(t, err, "SearchBranches should return an error on API failure")
 	require.Nil(t, result, "result should be nil on error")
-	require.Contains(t, err.Error(), "list branches", "error should include context")
+	require.Contains(t, err.Error(), "search branches", "error should include context")
 }
 
 func TestGetInstallationToken_DelegatesToTokenProvider(t *testing.T) {


### PR DESCRIPTION
## Summary

The Create-preview branch picker was unusable for repos with many branches: you couldn't find a target branch, and loading was slow. The backend fetched branches via the REST `/branches` endpoint capped at 10 pages (~1000 branches, alphabetical, no search), so anything past the first 1000 never reached the client and the search box only filtered what was already downloaded. This switches to GitHub's GraphQL `refs(query:)` API, which does a server-side contains-match across *all* branches and returns only matches.

## Changes

- **Backend:** replace `PRService.ListBranches` (serial REST pagination) with `SearchBranches(ctx, token, owner, repo, query)` using a new `doGitHubGraphQL` helper; `GET /api/v1/repositories/{id}/branches` now accepts `?query=`. Empty query returns the 100 most-recently-committed branches (orderBy TAG_COMMIT_DATE DESC).
- **Frontend:** the picker debounces the search box (250ms) and drives the server query; `shouldFilter={false}` so cmdk renders exactly what the server returned; `placeholderData` is scoped to the same repository to avoid flicker without bleeding the prior repo's branches across a repo switch.
- `protected` is no longer populated (GraphQL doesn't expose it without admin:read) — the field is retained for response-shape stability; it was only ever a search keyword.
- One GraphQL request per search instead of up to 10 heavy REST round-trips.

## Validation

- **Live API:** verified `refs(query:)` is contains-matching against assembledhq/143 (382 branches) — e.g. searching `add-about` matched `claude/add-about-page-footer-GZQBB`, `preview` matched `wangjohn/preview-server-design`; null query returns all 382 ordered most-recent-first.
- **Go:** internal/services/github + internal/api/handlers package tests pass; `make lint` reports 0 issues.
- **Frontend:** branch-picker + query-keys vitest suites (29 tests) pass; eslint and `tsc --noEmit` clean.
- Not browser-verified: a local preview can't reach a real GitHub App with thousands of branches, so the live GraphQL call above is the stronger proof; UI wiring is covered by unit tests.
