### PR TITLE
Remove Needs attention section; promote attention rows inline in Previews index

### DIFF
--- a/docs/design/future/102-preview-index-current-targets.md
+++ b/docs/design/future/102-preview-index-current-targets.md
@@ -91,7 +91,7 @@ For a PR, the PR grouping wins over branch grouping because a PR is the review o
 | `current` | Running SHA matches `latest_commit_sha`. |
 | `outdated` | Running SHA differs from `latest_commit_sha`, or the running preview's config hash differs from the currently resolved config. Config staleness (`.143/config.json` changes) triggers `outdated` the same as a commit delta. |
 | `pinned` | Group has `pinned = true`; freshness comparisons are suppressed. |
-| `unknown` | `latest_commit_sha` could not be resolved — branch was deleted, repo access was revoked, or the GitHub token expired. Groups in `unknown` freshness are surfaced in the `Needs attention` section with an explanatory message. |
+| `unknown` | `latest_commit_sha` could not be resolved — branch was deleted, repo access was revoked, or the GitHub token expired. Groups in `unknown` freshness are surfaced inline as attention rows with an explanatory message. |
 
 `latest_commit_sha` is updated by:
 
@@ -109,10 +109,9 @@ Default sections remain useful, but they should operate on grouped current previ
 
 - `Running`
 - `Ready to resume`
-- `Needs attention`
 - `Recent`
 
-`Needs attention` should include failed, unavailable, blocked, out-of-date, and freshness-unknown previews. This is more actionable than hiding these previews under generic `Recent`.
+Attention is an inline priority state, not a separate top-level section. Failed, unavailable, blocked, out-of-date, and freshness-unknown previews should be promoted within the section that matches their runtime state: running stale previews remain in `Running`, resumable previews remain in `Ready to resume`, and stopped or failed previews appear at the top of `Recent`. This keeps the page simpler while still preventing actionable problems from being buried under ordinary stopped previews.
 
 Table columns:
 
@@ -191,7 +190,7 @@ Action semantics:
 
 Pinned rows appear in the index alongside normal rows. They are visually differentiated by a `Pinned` badge next to the branch/PR name and a secondary `Unpin` action. Pinned rows do not show freshness warnings — `outdated` is suppressed and the `Start` action label reads `Start pinned` to reinforce that the user is working with a fixed commit.
 
-Pinned rows appear in whichever scope section matches their current runtime state (`Running`, `Ready to resume`, `Needs attention`, or `Recent`). They are not given a dedicated section in v1. Engineers who want to find all pinned rows can filter by `pinned=true` in the query string.
+Pinned rows appear in whichever scope section matches their current runtime state (`Running`, `Ready to resume`, or `Recent`). They are not given a dedicated section in v1. Engineers who want to find all pinned rows can filter by `pinned=true` in the query string.
 
 ### Detail Page
 
@@ -867,7 +866,7 @@ Frontend:
 
 1. **Group IDs are opaque UUIDs in v1.** Stable human-readable paths (`/previews/current/pr/assembledhq-143/42`) are useful but require URL-encoding edge cases and add router complexity. Use opaque UUIDs now and add canonical slug paths in a follow-up once the group model is stable.
 
-2. **`attention` and `recent` are separate sections.** Merging them would bury failed/outdated previews below recent-but-healthy stopped rows. Keeping them separate lets the `Needs attention` section surface actionable problems without sorting noise.
+2. **Attention is an inline priority state.** A separate `Needs attention` section added visual weight even when empty and made the page feel like backend taxonomy instead of a user workflow. The UI still queries the `attention` scope, but it merges those rows into `Running`, `Ready to resume`, or `Recent`, sorts attention rows first, and gives them state-appropriate actions such as `Start latest`. This preserves the recovery path without adding another section.
 
 3. **API-created previews default to branch grouping.** A preview created via API with no `source_id` and no PR reference groups by branch. Callers who want source-scoped groups must supply a stable `source_id`. This is the least-surprising default and matches how manual starts behave.
 

--- a/frontend/src/app/(dashboard)/previews/page.test.tsx
+++ b/frontend/src/app/(dashboard)/previews/page.test.tsx
@@ -195,6 +195,9 @@ describe("PreviewsPage", () => {
     expect(
       screen.getByRole("heading", { level: 2, name: "Recent (1)" }),
     ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("region", { name: /needs attention/i }),
+    ).not.toBeInTheDocument();
     expect(screen.getByText("Pool: 3 of 10 previews")).toBeInTheDocument();
     expect(screen.getAllByText("PR #17 - feature/warm-link")[0]).toBeInTheDocument();
     expect(screen.getAllByText("Ready")[0]).toBeInTheDocument();
@@ -410,7 +413,7 @@ describe("PreviewsPage", () => {
     renderWithProviders(<PreviewsPage />);
 
     expect(await screen.findAllByText("Failed to load previews.")).toHaveLength(
-      4,
+      3,
     );
     expect(screen.queryByText("No previews yet")).not.toBeInTheDocument();
     expect(screen.queryByText("Loading previews...")).not.toBeInTheDocument();
@@ -470,9 +473,9 @@ describe("PreviewsPage", () => {
     ).not.toBeInTheDocument();
   });
 
-  it("renders Out of date badge and running-vs-head SHA detail for outdated rows", async () => {
+  it("surfaces out-of-date running previews inline with the latest-start action", async () => {
     installPreviewHandlers({
-      attention: [
+      running: [
         preview({
           preview_group_id: "outdated-group",
           branch: "feature/stale",
@@ -487,12 +490,18 @@ describe("PreviewsPage", () => {
 
     renderWithProviders(<PreviewsPage />);
 
-    const attentionSection = await screen.findByRole("region", {
-      name: /needs attention/i,
+    const runningSection = await screen.findByRole("region", {
+      name: /running/i,
     });
-    expect(within(attentionSection).getAllByText("Out of date")[0]).toBeInTheDocument();
     expect(
-      within(attentionSection).getAllByText(/running aabb1122, branch is ccdd3344/)[0],
+      screen.queryByRole("region", { name: /needs attention/i }),
+    ).not.toBeInTheDocument();
+    expect(within(runningSection).getAllByText("Out of date")[0]).toBeInTheDocument();
+    expect(
+      within(runningSection).getAllByText(/running aabb1122, branch is ccdd3344/)[0],
+    ).toBeInTheDocument();
+    expect(
+      within(runningSection).getAllByRole("button", { name: /start latest/i })[0],
     ).toBeInTheDocument();
   });
 
@@ -549,16 +558,9 @@ describe("PreviewsPage", () => {
     ).toBeInTheDocument();
   });
 
-  it("renders the attention section with failed previews sorted before stopped ones", async () => {
+  it("promotes attention previews inside Recent ahead of ordinary recent activity", async () => {
     installPreviewHandlers({
       attention: [
-        preview({
-          preview_group_id: "stopped-group",
-          branch: "feature/stopped",
-          status: "stopped",
-          freshness: "unknown",
-          preview_url: undefined,
-        }),
         preview({
           preview_group_id: "failed-group",
           branch: "feature/failed",
@@ -568,15 +570,31 @@ describe("PreviewsPage", () => {
           preview_url: undefined,
         }),
       ],
+      recent: [
+        preview({
+          preview_group_id: "stopped-group",
+          branch: "feature/stopped",
+          status: "stopped",
+          stopped_reason: "expired",
+          preview_url: undefined,
+        }),
+      ],
     });
 
     renderWithProviders(<PreviewsPage />);
 
-    const attentionSection = await screen.findByRole("region", {
-      name: /needs attention/i,
+    const recentSection = await screen.findByRole("region", {
+      name: /recent/i,
     });
-    expect(within(attentionSection).getAllByText("Failed")[0]).toBeInTheDocument();
-    expect(within(attentionSection).getAllByText("Needs attention")[0]).toBeInTheDocument();
+    expect(
+      screen.queryByRole("region", { name: /needs attention/i }),
+    ).not.toBeInTheDocument();
+    expect(within(recentSection).getAllByText("Failed")[0]).toBeInTheDocument();
+    expect(within(recentSection).getAllByText("Stopped")[0]).toBeInTheDocument();
+
+    const rows = within(recentSection).getAllByRole("row");
+    expect(rows[1]).toHaveTextContent("feature/failed");
+    expect(rows[2]).toHaveTextContent("feature/stopped");
   });
 
   it("keeps mobile stacked row metadata available alongside the desktop table", async () => {

--- a/frontend/src/app/(dashboard)/previews/page.tsx
+++ b/frontend/src/app/(dashboard)/previews/page.tsx
@@ -52,7 +52,7 @@ import type {
 } from "@/lib/types";
 import { safeExternalUrl } from "@/lib/utils";
 
-type PreviewScope = "running" | "resumable" | "attention" | "recent";
+type PreviewScope = "running" | "resumable" | "recent";
 
 const SECTIONS: {
   scope: PreviewScope;
@@ -73,12 +73,6 @@ const SECTIONS: {
     interval: 30000,
   },
   {
-    scope: "attention",
-    title: "Needs attention",
-    empty: "No previews need attention.",
-    interval: 30000,
-  },
-  {
     scope: "recent",
     title: "Recent",
     empty: "No recent preview activity.",
@@ -96,6 +90,57 @@ function sourceLabel(preview: PreviewCurrentResponse): string {
   if (preview.source_type === "api") return "API";
   if (preview.source_type === "automation") return "Automation";
   return "Manual";
+}
+
+function previewNeedsAttention(preview: PreviewCurrentResponse): boolean {
+  return (
+    preview.status === "failed" ||
+    preview.status === "unavailable" ||
+    preview.status === "blocked" ||
+    preview.status === "capacity_blocked" ||
+    preview.status === "config_invalid" ||
+    preview.status === "outdated" ||
+    preview.freshness === "outdated" ||
+    preview.freshness === "unknown" ||
+    preview.latest_commit_sha === ""
+  );
+}
+
+function previewIsRunning(preview: PreviewCurrentResponse): boolean {
+  return (
+    preview.status === "starting" ||
+    preview.status === "ready" ||
+    preview.status === "partially_ready" ||
+    preview.status === "unhealthy" ||
+    preview.status === "recycling"
+  );
+}
+
+function sortAttentionFirst(
+  previews: PreviewCurrentResponse[],
+): PreviewCurrentResponse[] {
+  return [...previews].sort((a, b) => {
+    const attentionDelta =
+      Number(previewNeedsAttention(b)) - Number(previewNeedsAttention(a));
+    if (attentionDelta !== 0) return attentionDelta;
+    if (a.status === "failed" && b.status !== "failed") return -1;
+    if (a.status !== "failed" && b.status === "failed") return 1;
+    return 0;
+  });
+}
+
+function mergePreviewRows(
+  primary: PreviewCurrentResponse[],
+  additions: PreviewCurrentResponse[],
+): PreviewCurrentResponse[] {
+  const seen = new Set(primary.map((preview) => preview.preview_group_id));
+  const merged = [...primary];
+  for (const preview of additions) {
+    if (seen.has(preview.preview_group_id)) continue;
+    seen.add(preview.preview_group_id);
+    merged.push(preview);
+  }
+  return merged;
 }
 
 function stoppedReasonLabel(
@@ -301,6 +346,16 @@ function SectionRows({
                           Stop
                         </Button>
                       ) : null}
+                      {canMutate && scope === "running" && previewNeedsAttention(preview) ? (
+                        <Button
+                          size="sm"
+                          variant="ghost"
+                          onClick={() => onStartLatest(preview)}
+                        >
+                          <RotateCw className="h-4 w-4" />
+                          Start latest
+                        </Button>
+                      ) : null}
                       {canMutate && scope === "resumable" ? (
                         <Button
                           size="sm"
@@ -385,6 +440,16 @@ function SectionRows({
                     >
                       <Square className="h-4 w-4" />
                       Stop
+                    </Button>
+                  ) : null}
+                  {canMutate && scope === "running" && previewNeedsAttention(preview) ? (
+                    <Button
+                      size="sm"
+                      variant="ghost"
+                      onClick={() => onStartLatest(preview)}
+                    >
+                      <RotateCw className="h-4 w-4" />
+                      Start latest
                     </Button>
                   ) : null}
                   {canMutate && scope === "resumable" ? (
@@ -490,9 +555,10 @@ export default function PreviewsPage() {
     refetchInterval: pollMs(30000),
     placeholderData: (previous) => previous,
   });
-  const sectionQueries = [runningQuery, resumableQuery, attentionQuery, recentQuery];
+  const allSectionQueries = [runningQuery, resumableQuery, attentionQuery, recentQuery];
+  const visibleSectionQueries = [runningQuery, resumableQuery, recentQuery];
 
-  const firstMeta = sectionQueries.find((item) => item.data?.meta)?.data?.meta;
+  const firstMeta = allSectionQueries.find((item) => item.data?.meta)?.data?.meta;
   // A query that has only ever errored holds no data, and React Query resets
   // no-data queries to pending (clearing the error) on every interval refetch.
   // isError alone would therefore blink off for the duration of each poll —
@@ -500,15 +566,15 @@ export default function PreviewsPage() {
   // Sections that already hold rows keep showing them through refetch
   // failures: stale-but-real previews beat an error card, and the poll loop
   // refreshes them as soon as the backend recovers.
-  const sectionFailed = (query: (typeof sectionQueries)[number]) =>
+  const sectionFailed = (query: (typeof allSectionQueries)[number]) =>
     query.data === undefined && (query.isError || query.errorUpdateCount > 0);
-  const previewSectionsSettled = sectionQueries.every(
+  const previewSectionsSettled = allSectionQueries.every(
     (item) => item.data !== undefined || sectionFailed(item),
   );
   // Only successfully settled, genuinely empty sections count toward the
   // page-level empty state; loading or failed sections must not flip the page
   // to "No previews yet".
-  const allEmpty = sectionQueries.every(
+  const allEmpty = allSectionQueries.every(
     (item) => item.data !== undefined && item.data.data.length === 0,
   );
   const repositories = useMemo(
@@ -516,14 +582,49 @@ export default function PreviewsPage() {
     [repositoriesQuery.data?.data],
   );
 
-  const recentPreviews = useMemo(() => {
-    const data = recentQuery.data?.data ?? [];
-    return [...data].sort((a, b) => {
-      if (a.status === "failed" && b.status !== "failed") return -1;
-      if (a.status !== "failed" && b.status === "failed") return 1;
-      return 0;
-    });
-  }, [recentQuery.data?.data]);
+  const attentionPreviews = useMemo(
+    () => attentionQuery.data?.data ?? [],
+    [attentionQuery.data?.data],
+  );
+  const runningPreviews = useMemo(
+    () =>
+      sortAttentionFirst(
+        mergePreviewRows(
+          runningQuery.data?.data ?? [],
+          attentionPreviews.filter(previewIsRunning),
+        ),
+      ),
+    [attentionPreviews, runningQuery.data?.data],
+  );
+  const resumablePreviews = useMemo(
+    () =>
+      sortAttentionFirst(
+        mergePreviewRows(
+          resumableQuery.data?.data ?? [],
+          attentionPreviews.filter(
+            (preview) => preview.resumable && !previewIsRunning(preview),
+          ),
+        ),
+      ),
+    [attentionPreviews, resumableQuery.data?.data],
+  );
+  const recentPreviews = useMemo(
+    () =>
+      sortAttentionFirst(
+        mergePreviewRows(
+          recentQuery.data?.data ?? [],
+          attentionPreviews.filter(
+            (preview) => !previewIsRunning(preview) && !preview.resumable,
+          ),
+        ),
+      ),
+    [attentionPreviews, recentQuery.data?.data],
+  );
+  const previewsByScope: Record<PreviewScope, PreviewCurrentResponse[]> = {
+    running: runningPreviews,
+    resumable: resumablePreviews,
+    recent: recentPreviews,
+  };
 
   const stopPreview = useMutation({
     mutationFn: (preview: PreviewCurrentResponse) =>
@@ -603,11 +704,9 @@ export default function PreviewsPage() {
         ) : (
           <div className="space-y-7">
             {SECTIONS.map((section, index) => {
-              const sectionQuery = sectionQueries[index];
-              const count =
-                firstMeta?.counts?.[section.scope] ??
-                sectionQuery.data?.data.length ??
-                0;
+              const sectionQuery = visibleSectionQueries[index];
+              const sectionPreviews = previewsByScope[section.scope];
+              const count = sectionPreviews.length;
               return (
                 <section
                   key={section.scope}
@@ -647,9 +746,7 @@ export default function PreviewsPage() {
                   <SectionRows
                     scope={section.scope}
                     previews={
-                      section.scope === "recent"
-                        ? recentPreviews
-                        : (sectionQuery.data?.data ?? [])
+                      sectionPreviews
                     }
                     isLoading={
                       sectionQuery.isLoading && !sectionFailed(sectionQuery)


### PR DESCRIPTION
## Summary

The Previews dashboard currently uses a dedicated “Needs attention” section, creating an awkward workflow when there are no such rows and adding visual weight even when attention items are better handled in-place. This change removes the standalone section and instead merges `attention` rows inline into `Running`, `Ready to resume`, and `Recent`, while deduping and sorting so the priority items remain visible.

## Changes

- Simplified the default Previews page layout to only show `Running`, `Ready to resume`, and `Recent`; there is no standalone “Needs attention” region.
- Kept querying the `attention` scope, but reclassified/mapped attention rows into the appropriate runtime section; rows are deduped and sorted ahead of normal rows.
- Updated “out-of-date running” behavior: stale running previews now expose an inline **Start latest** action.
- Updated the design contract to describe “attention” as an inline priority state (not a separate top-level section).

## Validation

- `npm test -- --run 'src/app/(dashboard)/previews/page.test.tsx'`
- `npm run typecheck`
- `npm run lint`
- `npm run build`

Notes: The focused test run still surfaces existing React `act(...)` warnings around the select interaction, but the suite exits successfully.

[143.dev](https://143.dev) | [session e628fabb](https://143.dev/sessions/e628fabb-9722-4e13-bb7d-125c909965a6)

<!-- 143 readiness -->
**143 readiness:** not available for this revision.

Preview: https://143.dev/previews/github/assembledhq/143/pull/1531?launch=1