### PR TITLE
Fix org auths header layout so “View personal auths” aligns with description

### DIFF
--- a/frontend/src/app/(dashboard)/settings/agent/page.test.tsx
+++ b/frontend/src/app/(dashboard)/settings/agent/page.test.tsx
@@ -77,6 +77,23 @@ describe("Agent settings page", () => {
     expect(screen.queryByLabelText("Agent tab tools")).not.toBeInTheDocument();
   });
 
+  it("aligns the personal auths link with the organization auths description", async () => {
+    installHandlers();
+
+    renderWithProviders(<AgentPage />);
+
+    const description = screen.getByText(
+      "Personal auths run first for each user. When none are available, sessions fall back to this stack, running top to bottom. Move the auth you want to prefer higher in the list.",
+    );
+    const descriptionRow = description.closest("[data-testid='org-auths-description-row']");
+
+    expect(descriptionRow, "description should be wrapped in an action row").not.toBeNull();
+    expect(within(descriptionRow as HTMLElement).getByRole("link", { name: "View personal auths" })).toHaveAttribute(
+      "href",
+      "/settings/account",
+    );
+  });
+
   it("shows auth resolution notice in read-only view for non-admin users", async () => {
     mockUseAuth.mockReturnValueOnce({
       user: { id: "user-2", org_id: "org-1", role: "member", email: "member@example.com", name: "Member", created_at: "", role_display: "member" },

--- a/frontend/src/app/(dashboard)/settings/agent/page.tsx
+++ b/frontend/src/app/(dashboard)/settings/agent/page.tsx
@@ -117,18 +117,21 @@ function defaultLabel(provider: ModalProvider, authType: AddFlowAuthType) {
 
 function OrgAuthsHeader({ showReorderHint }: { showReorderHint?: boolean }) {
   return (
-    <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
-      <div className="space-y-1.5">
-        <h2 className="text-xs font-medium text-foreground">Organization-wide auths</h2>
+    <div className="space-y-1.5">
+      <h2 className="text-xs font-medium text-foreground">Organization-wide auths</h2>
+      <div
+        className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between"
+        data-testid="org-auths-description-row"
+      >
         <p className="text-xs text-muted-foreground">
           Personal auths run first for each user. When none are available, sessions fall back to this stack, running top to bottom.
           {showReorderHint && " Move the auth you want to prefer higher in the list."}
         </p>
-      </div>
-      <div className="flex flex-wrap gap-2">
-        <Button asChild variant="outline" size="sm">
-          <Link href="/settings/account">View personal auths</Link>
-        </Button>
+        <div className="flex flex-wrap gap-2">
+          <Button asChild variant="outline" size="sm">
+            <Link href="/settings/account">View personal auths</Link>
+          </Button>
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary

The Agent settings page had a layout inconsistency where the **“View personal auths”** button wasn’t aligned with the **organization-wide auths description** row, causing awkward responsive wrapping. This change restructures `OrgAuthsHeader` so the heading is separated and the description + link share the same responsive flex row.  

## Changes

- Updated `OrgAuthsHeader` layout in `frontend/src/app/(dashboard)/settings/agent/page.tsx` to:
  - Render the heading as its own block
  - Wrap the description and **“View personal auths”** button together in a single flex row
- Added a `data-testid="org-auths-description-row"` marker to make the intended layout contract testable.
- Added a regression test in `frontend/src/app/(dashboard)/settings/agent/page.test.tsx` to verify the button lives inside the description row.

## Validation

- `npm test -- --run 'src/app/(dashboard)/settings/agent/page.test.tsx'`
- `npm run typecheck`
- `npm run lint`
- `npm run build`

Notes: `npm ci` reported pre-existing audit findings; the focused test still emits existing MSW warnings for `/api/v1/settings/agent/capabilities`, but the checks passed.

[143.dev](https://143.dev) | [session 6d4d527a](https://143.dev/sessions/6d4d527a-b01b-422a-8592-2b97c2196763)

<!-- 143 readiness -->
**143 readiness:** not available for this revision.

Preview: https://143.dev/previews/github/assembledhq/143/pull/1532?launch=1