### PR TITLE
Remove issue-less readiness context editor from “Review before PR” card and fix header layout overlap

### DIFF
--- a/frontend/src/app/(dashboard)/sessions/[id]/page-pr-creation.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/page-pr-creation.test.tsx
@@ -444,7 +444,7 @@ describe('SessionDetailPage PR creation', () => {
     expect(toast.success).toHaveBeenCalledWith('Readiness checks queued');
   });
 
-  it('preserves existing issue-less readiness context when saving without edits', async () => {
+  it('does not render the issue-less readiness context editor in the review before PR card', async () => {
     const sessionWithDiff: Session = {
       ...mockSessions[0],
       status: 'completed',
@@ -453,7 +453,7 @@ describe('SessionDetailPage PR creation', () => {
       snapshot_key: 'snap-abc',
       linked_issues: [],
     };
-    let submittedReason = '';
+    let contextSaveRequested = false;
 
     server.use(
       http.get('/api/v1/sessions/:id', () => {
@@ -474,14 +474,13 @@ describe('SessionDetailPage PR creation', () => {
           },
         });
       }),
-      http.post('/api/v1/sessions/:id/pr-readiness-context', async ({ params, request }) => {
-        const body = await request.json() as { issue_less_reason?: string };
-        submittedReason = body.issue_less_reason ?? '';
+      http.post('/api/v1/sessions/:id/pr-readiness-context', () => {
+        contextSaveRequested = true;
         return HttpResponse.json({
           data: {
             org_id: 'org-1',
-            session_id: params.id,
-            issue_less_reason: submittedReason,
+            session_id: sessionWithDiff.id,
+            issue_less_reason: 'Maintenance follow-up requested in Slack',
           },
         });
       }),
@@ -489,12 +488,12 @@ describe('SessionDetailPage PR creation', () => {
 
     renderWithProviders(<SessionDetailContent id="session-abcdef12-3456-7890" />);
 
-    await screen.findByDisplayValue('Maintenance follow-up requested in Slack');
-    await userEvent.setup().click(screen.getByRole('button', { name: 'Save context' }));
+    expect(await screen.findByText('Review before PR')).toBeInTheDocument();
+    expect(screen.queryByText('Issue-less context')).not.toBeInTheDocument();
+    expect(screen.queryByDisplayValue('Maintenance follow-up requested in Slack')).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Save context' })).not.toBeInTheDocument();
 
-    await waitFor(() => {
-      expect(submittedReason).toBe('Maintenance follow-up requested in Slack');
-    });
+    expect(contextSaveRequested).toBe(false);
   });
 
   it('renders readiness check actions and expandable evidence', async () => {

--- a/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
@@ -4880,18 +4880,10 @@ export function SessionDetailContent({ id }: { id: string }) {
   const readinessCheckDisabled = readinessRunning || isRunning;
 
   // Readiness findings, grouped with role-aware enforcement so the merged
-  // Review card can surface blockers, bypasses, the review packet, and the
-  // issue-less context editor inline (see folded-in PRReadinessCard features).
+  // Review card can surface blockers, bypasses, and the review packet inline.
   const [readinessBypassOpen, setReadinessBypassOpen] = useState(false);
   const [readinessBypassReason, setReadinessBypassReason] = useState("");
-  const [readinessIssueLessReason, setReadinessIssueLessReason] = useState<string | null>(null);
   const readinessPacketRef = useRef<HTMLDivElement | null>(null);
-  const readinessContextRef = useRef<HTMLTextAreaElement | null>(null);
-  const readinessContextQuery = useQuery({
-    queryKey: [...queryKeys.sessions.readiness(id), "context"],
-    queryFn: () => api.sessions.getReadinessContext(id),
-    enabled: !!session && canManageSession && (session?.linked_issues?.length ?? 0) === 0,
-  });
   const readinessBypassMutation = useMutation({
     mutationFn: () => api.sessions.createReadinessBypass(id, readinessBypassReason),
     onSuccess: () => {
@@ -4902,19 +4894,6 @@ export function SessionDetailContent({ id }: { id: string }) {
     },
     onError: (err) => {
       toast.error(err instanceof Error ? err.message : "Readiness blocker could not be bypassed");
-    },
-  });
-  const readinessContextMutation = useMutation({
-    mutationFn: (reason: string) => api.sessions.updateReadinessContext(id, reason),
-    onSuccess: () => {
-      // Drop the local override so the field re-syncs from the invalidated query
-      // (and reflects edits made elsewhere) instead of pinning the typed value.
-      setReadinessIssueLessReason(null);
-      queryClient.invalidateQueries({ queryKey: [...queryKeys.sessions.readiness(id), "context"] });
-      toast.success("Readiness context saved");
-    },
-    onError: (err) => {
-      toast.error(err instanceof Error ? err.message : "Readiness context could not be saved");
     },
   });
   const readinessChecks = latestReadiness?.checks ?? [];
@@ -4956,8 +4935,6 @@ export function SessionDetailContent({ id }: { id: string }) {
     !readinessNonBypassableChecks.has(check.check_type)
   );
   const readinessReviewPacket = readinessPacket(latestReadiness?.review_packet);
-  const readinessDisplayedIssueLessReason =
-    readinessIssueLessReason ?? readinessContextQuery.data?.data.issue_less_reason ?? "";
   const handleReadinessCheckAction = (check: PRReadinessCheck) => {
     const action = (check.action ?? "").toLowerCase();
     if (!action) return;
@@ -4975,11 +4952,6 @@ export function SessionDetailContent({ id }: { id: string }) {
     }
     if (action.includes("view packet")) {
       readinessPacketRef.current?.scrollIntoView({ block: "nearest" });
-      return;
-    }
-    if (action.includes("view context") || action.includes("add context")) {
-      readinessContextRef.current?.focus();
-      readinessContextRef.current?.scrollIntoView({ block: "nearest" });
       return;
     }
     if (action.includes("configuration")) {
@@ -6388,8 +6360,8 @@ export function SessionDetailContent({ id }: { id: string }) {
           {canManageSession && !hasPR && hasSessionChanges ? (
             <Card className="border-border/60">
               <CardContent className="space-y-3 p-4">
-                <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
-                  <div className="flex min-w-0 items-center gap-2">
+                <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
+                  <div className="flex min-w-0 flex-1 items-center gap-2">
                     <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-muted text-muted-foreground">
                       {reviewLoopRunning || readinessRunning ? (
                         <Loader2 className="h-4 w-4 animate-spin" />
@@ -6469,27 +6441,6 @@ export function SessionDetailContent({ id }: { id: string }) {
                     )}
                   </div>
                 ) : null}
-                {(session.linked_issues?.length ?? 0) === 0 && (
-                  <div className="space-y-2 border-t border-border pt-3 text-xs">
-                    <Label htmlFor="readiness-context" className="text-xs">Issue-less context</Label>
-                    <Textarea
-                      id="readiness-context"
-                      ref={readinessContextRef}
-                      value={readinessDisplayedIssueLessReason}
-                      onChange={(event) => setReadinessIssueLessReason(event.target.value)}
-                      rows={2}
-                      placeholder="Reason this PR has no linked issue"
-                    />
-                    <Button
-                      size="xs"
-                      variant="outline"
-                      disabled={readinessContextMutation.isPending || !readinessDisplayedIssueLessReason.trim()}
-                      onClick={() => readinessContextMutation.mutate(readinessDisplayedIssueLessReason)}
-                    >
-                      Save context
-                    </Button>
-                  </div>
-                )}
               </CardContent>
             </Card>
           ) : null}


### PR DESCRIPTION
## Summary

The “Review before PR” experience was exposing an issue-less readiness context editor and save controls that don’t apply to that workflow, causing UI clutter and leaving reliability to client-side state. This change removes the unused issue-less context textarea and related focus/save wiring, and updates the UI layout so card actions don’t overlap the title/status at larger breakpoints. We also replaced the old save-context test with a regression test that asserts the editor and save button are not rendered.

## Changes

- Removed the issue-less readiness context editor UI (and associated save button/focus handling) from `session-detail-content.tsx`, keeping the review card focused on the intended “Review before PR” flow.
- Adjusted the card header layout so action elements render below the title/status until `lg`, preventing the cramped/overlapping appearance.
- Updated `page-pr-creation.test.tsx` to assert the editor text, display value, and “Save context” button are absent, and that no `/pr-readiness-context` POST is triggered.

## Validation

- `npm test -- page-pr-creation.test.tsx`
- `npm run typecheck`
- `npm run lint`
- `npm run build`

[143.dev](https://143.dev) | [session 8b8739be](https://143.dev/sessions/8b8739be-d732-48a2-aca1-740b6fb489ef)

<!-- 143 readiness -->
**143 readiness:** not available for this revision.

Preview: https://143.dev/previews/github/assembledhq/143/pull/1533?launch=1