### PR TITLE
Default auto-archive PRs on new orgs, with explicit opt-out preserved

### DIFF
--- a/docs/design/implemented/96-runtime-network-settings-placement.md
+++ b/docs/design/implemented/96-runtime-network-settings-placement.md
@@ -246,7 +246,7 @@ Keep these controls where they are:
 - Coding-agent auth stacks: Coding agents.
 - Default agent type and provider-specific auth setup: Coding agents.
 - Preview secrets and preview API tokens: Preview.
-- PR authorship, draft PR default, auto-archive, and builder PR review gate: General / Pull requests.
+- PR authorship, draft PR default, auto-archive, and builder PR review gate: General / Pull requests. Auto-archive defaults on for new organizations while explicit opt-out remains supported.
 - LLM model defaults: LLM or Coding agents, depending on the existing page contract.
 
 The implementation also:

--- a/frontend/src/app/(dashboard)/settings/page.tsx
+++ b/frontend/src/app/(dashboard)/settings/page.tsx
@@ -165,7 +165,7 @@ function PRAuthorshipSettings() {
   const settings = (settingsResponse?.data?.settings ?? {}) as OrgSettings;
   const currentAuthorship = settings.pr_authorship ?? "user_preferred";
   const currentDraftDefault = settings.pr_draft_default ?? false;
-  const currentAutoArchive = settings.auto_archive_on_pr_close ?? false;
+  const currentAutoArchive = settings.auto_archive_on_pr_close ?? true;
   const requireBuilderReview = settings.builder_permissions?.require_review_before_pr ?? true;
 
   const accountConnected = githubAccountStatus?.connected ?? false;

--- a/internal/models/org_settings.go
+++ b/internal/models/org_settings.go
@@ -249,7 +249,7 @@ type OrgSettings struct {
 	ContextLimits              ContextLimits          `json:"context_limits,omitempty"`
 	PRAuthorship               PRAuthorship           `json:"pr_authorship,omitempty"`
 	PRDraftDefault             bool                   `json:"pr_draft_default,omitempty"`
-	AutoArchiveOnPRClose       bool                   `json:"auto_archive_on_pr_close,omitempty"`
+	AutoArchiveOnPRClose       *bool                  `json:"auto_archive_on_pr_close,omitempty"`
 	DefaultWorkRepositoryID    *uuid.UUID             `json:"default_work_repository_id,omitempty"`
 	BuilderPermissions         BuilderPermissions     `json:"builder_permissions,omitempty"`
 	SandboxNetwork             SandboxNetworkSettings `json:"sandbox_network,omitempty"`
@@ -357,6 +357,14 @@ func (s OrgSettings) EffectiveCodingAgentTabToolsEnabled() bool {
 		return true
 	}
 	return *s.CodingAgentTabToolsEnabled
+}
+
+// EffectiveAutoArchiveOnPRClose applies the default PR cleanup policy.
+func (s OrgSettings) EffectiveAutoArchiveOnPRClose() bool {
+	if s.AutoArchiveOnPRClose == nil {
+		return true
+	}
+	return *s.AutoArchiveOnPRClose
 }
 
 // BuilderPermissions controls the narrower builder role's access to

--- a/internal/models/org_settings_test.go
+++ b/internal/models/org_settings_test.go
@@ -30,8 +30,32 @@ func TestParseOrgSettings_Defaults(t *testing.T) {
 	require.Nil(t, s.ProductContext, "should default product_context to nil")
 	require.True(t, s.BuilderPermissions.EffectiveRequireReviewBeforePR(), "builders should require review before PR by default")
 	require.True(t, s.EffectiveCodingAgentTabToolsEnabled(), "agent tab tools should default on")
+	require.True(t, s.EffectiveAutoArchiveOnPRClose(), "auto-archive on PR close should default on")
 	require.Equal(t, DefaultPreviewMaxPreviewsPerUser, s.PreviewMaxPreviewsPerUser, "should default per-user preview capacity")
 	require.False(t, s.SandboxNetwork.StaticEgressEnabled, "static egress should be disabled by default")
+}
+
+func TestOrgSettings_EffectiveAutoArchiveOnPRClose(t *testing.T) {
+	t.Parallel()
+
+	f := false
+	tVal := true
+	tests := []struct {
+		name     string
+		settings OrgSettings
+		expected bool
+	}{
+		{name: "missing defaults on", settings: OrgSettings{}, expected: true},
+		{name: "explicit false disables", settings: OrgSettings{AutoArchiveOnPRClose: &f}, expected: false},
+		{name: "explicit true enables", settings: OrgSettings{AutoArchiveOnPRClose: &tVal}, expected: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tt.expected, tt.settings.EffectiveAutoArchiveOnPRClose(), "effective auto-archive setting should match expected value")
+		})
+	}
 }
 
 func TestOrgSettings_EffectiveCodingAgentTabToolsEnabled(t *testing.T) {

--- a/internal/services/github/pr.go
+++ b/internal/services/github/pr.go
@@ -2004,7 +2004,7 @@ func (s *PRService) maybeAutoArchiveSessionOnPRClose(ctx context.Context, pr mod
 		s.logger.Warn().Err(err).Str("org_id", pr.OrgID.String()).Msg("failed to parse org settings for auto-archive")
 		return
 	}
-	if !settings.AutoArchiveOnPRClose {
+	if !settings.EffectiveAutoArchiveOnPRClose() {
 		return
 	}
 

--- a/internal/services/github/pr_handlers_test.go
+++ b/internal/services/github/pr_handlers_test.go
@@ -1260,7 +1260,7 @@ func TestHandlePullRequestEvent_AutoArchiveOnCloseWhenEnabled(t *testing.T) {
 		WithArgs(pgxmock.AnyArg()).
 		WillReturnRows(
 			pgxmock.NewRows(organizationColumns).
-				AddRow(orgID, "Test Org", json.RawMessage(`{"auto_archive_on_pr_close": true}`), now, now),
+				AddRow(orgID, "Test Org", json.RawMessage(`{}`), now, now),
 		)
 	sessionMock.ExpectExec("UPDATE sessions SET archived_at = now\\(\\), archived_by_user_id = NULL").
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
@@ -1313,7 +1313,7 @@ func TestHandlePullRequestEvent_AutoArchiveSkippedWhenDisabled(t *testing.T) {
 		WithArgs(pgxmock.AnyArg()).
 		WillReturnRows(
 			pgxmock.NewRows(organizationColumns).
-				AddRow(orgID, "Test Org", json.RawMessage(`{}`), now, now),
+				AddRow(orgID, "Test Org", json.RawMessage(`{"auto_archive_on_pr_close": false}`), now, now),
 		)
 	// No session archive expected — pgxmock.ExpectationsWereMet passes only if
 	// no unmocked calls were made, but it does not fail on un-called expectations


### PR DESCRIPTION
## Summary

New organizations currently default to **auto-archiving PRs off**, creating a workflow gap where PRs stay open after merge/close unless a user explicitly configures the setting. This PR changes the backend model to treat a missing `auto_archive_on_pr_close` value as **default-on**, while keeping **explicit `false`** as an intentional opt-out.

## Changes

- Updated `OrgSettings.AutoArchiveOnPRClose` to be pointer-backed (`*bool`) so “unset” can default to on, but an explicit `false` is preserved.
- Added `EffectiveAutoArchiveOnPRClose()` and updated PR close/merge auto-archive logic to use the effective default.
- Updated the settings UI to default the auto-archive checkbox to **checked** when the backend field is absent.
- Extended model and PR handler tests to cover default-on behavior and explicit opt-out.

## Validation

- `go vet ./...`
- `go build ./...`
- `go test ./...`
- `npm run typecheck`
- `npm run lint`
- `npm run build`

[143.dev](https://143.dev) | [session d1e022cf](https://143.dev/sessions/d1e022cf-1bbe-4ded-834d-b90db5977919)

<!-- 143 readiness -->
**143 readiness:** not available for this revision.

Preview: https://143.dev/previews/github/assembledhq/143/pull/1535?launch=1