### PR TITLE
Update stale preview launch action text to Restart with clearer tooltip

### DIFF
--- a/docs/design/implemented/100-pr-preview-launch-controller.md
+++ b/docs/design/implemented/100-pr-preview-launch-controller.md
@@ -64,7 +64,7 @@ Click behavior:
 | Latest PR head has an active preview still starting | Show stable page with startup progress and auto-open when ready if the click initiated launch. |
 | Latest PR head has a warm/resumable preview | Start/resume the preview, show `Resuming preview...`, then auto-open when ready. |
 | No target/runtime exists and caller may create | Create target for latest PR head, start runtime, show progress, then auto-open. |
-| Active preview exists for an older SHA | Do not auto-open stale code. Show `New commits available` with `Open stale preview` secondary and `Start latest` primary. |
+| Active preview exists for an older SHA | Do not auto-open stale code. Show `New commits available` with `Open stale preview` secondary and `Restart` primary. |
 | Latest target failed | Show failure summary, phase/log diagnostics, and `Retry`. |
 | Preview is blocked by role/token/capacity/config | Show a specific recovery state; do not fall through to generic failure. |
 | PR is closed or merged | Show terminal state and do not start new runtimes by default. |
@@ -245,7 +245,7 @@ Example stale response:
       "reason": "stale",
       "auto_open": false,
       "represents_latest": false,
-      "primary_label": "Start latest",
+      "primary_label": "Restart",
       "secondary_label": "Open stale preview",
       "message": "This preview is for abc123; the pull request is now at def456."
     }
@@ -289,7 +289,7 @@ Supported intent values:
 
 Default `intent=open` preserves current PR-link behavior.
 
-### Start Latest
+### Restart Latest Source
 
 `POST /api/v1/previews/{target_id}/start-latest`
 
@@ -621,7 +621,7 @@ Required cases:
 
 - ready launch bootstraps and opens preview origin.
 - starting launch shows progress and polls until ready, then opens.
-- stale launch does not auto-open and shows `Start latest`.
+- stale launch does not auto-open and shows `Restart`.
 - resumable launch shows resume estimate and calls `start-latest` or restart path.
 - failed launch shows retry and logs/phase summary.
 - blocked role/token/capacity launch renders specific copy.

--- a/docs/design/implemented/83-branch-and-pr-previews.md
+++ b/docs/design/implemented/83-branch-and-pr-previews.md
@@ -286,7 +286,7 @@ For 143-generated PRs:
 
 - Append one durable preview link in the existing 143 footer.
 - The link resolves by PR number and current head branch.
-- If the PR head SHA changes, the page should detect that the latest target is stale and offer `Start latest`.
+- If the PR head SHA changes, the page should detect that the latest target is stale and offer `Restart` with tooltip/accessibility copy clarifying that it restarts from the latest source state.
 
 For non-143 PRs:
 

--- a/docs/design/implemented/99-previews-index-and-auto-preview-policy.md
+++ b/docs/design/implemented/99-previews-index-and-auto-preview-policy.md
@@ -103,10 +103,10 @@ Ready to resume (3)                            warm — resumes in ~30s
 ┌──────────────────────────────────────────────────────────────────────┐
 │ ◌  feature/pricing-table  acme/shop      PR #479   hibernated 2h ago │
 │    auto-preview (warm) · commit 3f2a91c                              │
-│                                              [Resume] [Start latest] │
+│                                              [Resume] [Restart]      │
 ├──────────────────────────────────────────────────────────────────────┤
 │ ◌  docs/api-reference     acme/docs      Manual    stopped 5h ago    │
-│                                              [Resume] [Start latest] │
+│                                              [Resume] [Restart]      │
 └──────────────────────────────────────────────────────────────────────┘
 
 Recent (last 7 days)                                        [Show all]
@@ -115,7 +115,7 @@ Recent (last 7 days)                                        [Show all]
 │    2 days ago                                  [View logs] [Retry]   │
 ├──────────────────────────────────────────────────────────────────────┤
 │ ○  chore/deps             acme/shop      API       expired 3d ago    │
-│                                                       [Start latest] │
+│                                                       [Restart]      │
 └──────────────────────────────────────────────────────────────────────┘
 ```
 
@@ -372,7 +372,7 @@ Rules:
 
 ### 2. Resume (reuse existing restart)
 
-`POST /api/v1/previews/{preview_id}/restart` gains scheduler behavior, not a new contract: when the target has a live snapshot row, worker selection pins to that `worker_node_id` first (capacity permitting), then falls back to normal selection. Response unchanged. No new endpoint — `Resume` in the UI is `restart`; `Start latest` is the existing `start-latest`.
+`POST /api/v1/previews/{preview_id}/restart` gains scheduler behavior, not a new contract: when the target has a live snapshot row, worker selection pins to that `worker_node_id` first (capacity permitting), then falls back to normal selection. Response unchanged. No new endpoint — `Resume` in the UI is `restart`; `Restart` is the existing `start-latest` action with the tooltip/accessibility label `Restart preview from the latest source state`.
 
 ### 3. Preview Policies
 
@@ -521,7 +521,7 @@ No schema dependency except the terminal-instances index (safe to include here e
 Starts immediately against MSW mocks of the A contract.
 
 - [x] B1. Build `/previews` page at `frontend/src/app/(dashboard)/previews/page.tsx`: three sections (Running / Ready to resume / Recent), `PageContainer`/`PageHeader`, browser title, search input, repository filter, desktop `Table` rows + stacked mobile rows, empty state with create CTA (settings deep-link shown to admins only). One query per scope, keys `["previews", scope, repositoryId, q]`, polling through `pollMs()` (5s running, 30s others).
-- [x] B2. Wire row actions to existing client methods: `Open preview` (stable URL), `Stop`, `Resume` → `restart`, `Start latest` → `start-latest`, `Retry`, `View logs` (detail page deep link). Mutations invalidate all `["previews", ...]` keys. Hide mutation affordances from viewers (server still enforces).
+- [x] B2. Wire row actions to existing client methods: `Open preview` (stable URL), `Stop`, `Resume` → `restart`, `Restart` → `start-latest`, `Retry`, `View logs` (detail page deep link). Mutations invalidate all `["previews", ...]` keys. Hide mutation affordances from viewers (server still enforces).
 - [x] B3. Replace MSW-only types with the real client from A6; verify against a local backend.
 - [x] B4. Add `Previews` to `authenticated-layout.tsx` after Autopilot with running-count badge fed by the list query's `meta.counts` (lazy 60s poll via `pollMs()` when the page is closed). Add a command-palette entry (`Go to Previews`).
 - [x] B5. Add a breadcrumb/back link from `/previews/new` and `/previews/[id]` to the index.

--- a/frontend/src/app/(dashboard)/previews/[id]/page.tsx
+++ b/frontend/src/app/(dashboard)/previews/[id]/page.tsx
@@ -557,7 +557,7 @@ function PreviewActions({
         </DropdownMenuItem>
         <DropdownMenuItem onSelect={onStartLatest} disabled={restartPending || isStarting}>
           <GitBranch className="h-4 w-4" />
-          Start latest
+          Restart
         </DropdownMenuItem>
         {canRestart ? (
           <DropdownMenuItem onSelect={onRestart} disabled={restartPending}>

--- a/frontend/src/app/(dashboard)/previews/github/[owner]/[repo]/pull/[number]/page.test.tsx
+++ b/frontend/src/app/(dashboard)/previews/github/[owner]/[repo]/pull/[number]/page.test.tsx
@@ -135,7 +135,7 @@ describe("PullRequestPreviewPage", () => {
               reason: "stale",
               auto_open: true,
               represents_latest: false,
-              primary_label: "Start latest",
+              primary_label: "Restart",
               secondary_label: "Open stale preview",
               stale_preview_url: "https://prev-old.preview.143.dev",
             },
@@ -359,7 +359,7 @@ describe("PullRequestPreviewPage", () => {
     expect(screen.getByText("Unhealthy")).toBeInTheDocument();
   });
 
-  it("does not auto-open stale previews and makes Start latest primary", async () => {
+  it("does not auto-open stale previews and makes Restart primary", async () => {
     let startLatestCalled = false;
     server.use(
       http.get("*/api/v1/previews/github/acme/web/pull/42", () =>
@@ -384,7 +384,7 @@ describe("PullRequestPreviewPage", () => {
               reason: "stale",
               auto_open: false,
               represents_latest: false,
-              primary_label: "Start latest",
+              primary_label: "Restart",
               secondary_label: "Open stale preview",
               stale_preview_url: "https://prev-old.preview.143.dev",
               message: "This preview is for abc123; the pull request is now at def456.",
@@ -417,7 +417,7 @@ describe("PullRequestPreviewPage", () => {
     expect(screen.getByText("This preview is for abc123; the pull request is now at def456.")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /Open stale preview/ })).toBeInTheDocument();
 
-    await userEvent.click(screen.getByRole("button", { name: /Start latest/ }));
+    await userEvent.click(screen.getByRole("button", { name: /Restart/ }));
 
     await waitFor(() => {
       expect(startLatestCalled).toBe(true);
@@ -528,7 +528,7 @@ describe("PullRequestPreviewPage", () => {
 
     expect(await screen.findByText("Preview blocked")).toBeInTheDocument();
     expect(screen.getByText("You can open existing previews, but you do not have permission to start a new preview for this pull request.")).toBeInTheDocument();
-    expect(screen.queryByRole("button", { name: /Start latest|Start preview|Resume preview/ })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /Restart|Start preview|Resume preview/ })).not.toBeInTheDocument();
   });
 
   it("does not show Open preview button while preview is starting", async () => {

--- a/frontend/src/app/(dashboard)/previews/github/[owner]/[repo]/pull/[number]/page.tsx
+++ b/frontend/src/app/(dashboard)/previews/github/[owner]/[repo]/pull/[number]/page.tsx
@@ -12,6 +12,7 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import { ErrorText } from "@/components/ui/error-notice";
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { api } from "@/lib/api";
 import { formatPreviewStatus } from "@/lib/preview-types";
 import type { BranchPreviewResponse, SingleResponse } from "@/lib/types";
@@ -19,6 +20,8 @@ import { safeExternalUrl } from "@/lib/utils";
 import { pollMs } from "@/lib/poll-intervals";
 
 const ZERO_UUID = "00000000-0000-0000-0000-000000000000";
+const RESTART_LATEST_LABEL = "Restart";
+const RESTART_LATEST_TOOLTIP = "Restart preview from the latest source state";
 
 export default function PullRequestPreviewPage({
   params,
@@ -213,7 +216,7 @@ export function PullRequestPreviewContent({
                     <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-muted-foreground" />
                     <div>
                       <p className="font-medium text-foreground">Preview expired</p>
-                      <p className="text-muted-foreground">Start latest to launch a fresh runtime for this pull request.</p>
+                      <p className="text-muted-foreground">Restart to launch a fresh runtime for this pull request.</p>
                     </div>
                   </div>
                 ) : null}
@@ -314,15 +317,23 @@ export function PullRequestPreviewContent({
                     </Button>
                   ) : null}
                   {showStartAction ? (
-                    <Button
-                      type="button"
-                      variant={launch?.action === "start_latest" || launch?.action === "start" || launch?.action === "resume" ? "default" : "outline"}
-                      onClick={handleStartLatest}
-                      disabled={startLatest.isPending || startPullRequest.isPending}
-                    >
-                      <GitBranch className="h-4 w-4" />
-                      {startLatest.isPending || startPullRequest.isPending ? "Starting..." : launchStartLabel(launch?.action, launch?.primary_label)}
-                    </Button>
+                    <TooltipProvider delayDuration={150}>
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <Button
+                            type="button"
+                            variant={launch?.action === "start_latest" || launch?.action === "start" || launch?.action === "resume" ? "default" : "outline"}
+                            aria-label={launch?.action === "start_latest" ? RESTART_LATEST_TOOLTIP : undefined}
+                            onClick={handleStartLatest}
+                            disabled={startLatest.isPending || startPullRequest.isPending}
+                          >
+                            <GitBranch className="h-4 w-4" />
+                            {startLatest.isPending || startPullRequest.isPending ? "Starting..." : launchStartLabel(launch?.action, launch?.primary_label)}
+                          </Button>
+                        </TooltipTrigger>
+                        {launch?.action === "start_latest" ? <TooltipContent>{RESTART_LATEST_TOOLTIP}</TooltipContent> : null}
+                      </Tooltip>
+                    </TooltipProvider>
                   ) : null}
                   {preview.preview_id && launch?.action !== "blocked" && launch?.action !== "closed" ? (
                     <Button
@@ -359,9 +370,9 @@ function launchStartLabel(action: NonNullable<BranchPreviewResponse["launch"]>["
     case "start":
       return "Start preview";
     case "start_latest":
-      return "Start latest";
+      return RESTART_LATEST_LABEL;
     default:
-      return "Start latest";
+      return RESTART_LATEST_LABEL;
   }
 }
 
@@ -391,7 +402,7 @@ function launchStateCopy(preview: BranchPreviewResponse | undefined): {
       return {
         title: preview?.status === "expired" ? "Preview expired" : "Preview not started",
         description: launch.message ?? (preview?.status === "expired"
-          ? "Start latest to launch a fresh runtime for this pull request."
+          ? "Restart to launch a fresh runtime for this pull request."
           : "Start a preview for the latest pull request head."),
         className: "border-border bg-muted/40 text-foreground",
       };

--- a/frontend/src/app/(dashboard)/previews/page.test.tsx
+++ b/frontend/src/app/(dashboard)/previews/page.test.tsx
@@ -277,7 +277,7 @@ describe("PreviewsPage", () => {
     await userEvent.click(screen.getAllByRole("button", { name: /stop/i })[0]);
     await userEvent.click(screen.getAllByRole("button", { name: /resume/i })[0]);
     await userEvent.click(
-      screen.getAllByRole("button", { name: /start latest/i })[0],
+      screen.getAllByRole("button", { name: /restart/i })[0],
     );
 
     await waitFor(() => {
@@ -305,7 +305,7 @@ describe("PreviewsPage", () => {
     expect(screen.queryByRole("link", { name: /new preview/i })).not.toBeInTheDocument();
     expect(screen.queryByRole("button", { name: /stop/i })).not.toBeInTheDocument();
     expect(screen.queryByRole("button", { name: /resume/i })).not.toBeInTheDocument();
-    expect(screen.queryByRole("button", { name: /start latest/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /restart/i })).not.toBeInTheDocument();
   });
 
   it("opens the create preview dialog from the empty state action", async () => {
@@ -501,7 +501,7 @@ describe("PreviewsPage", () => {
       within(runningSection).getAllByText(/running aabb1122, branch is ccdd3344/)[0],
     ).toBeInTheDocument();
     expect(
-      within(runningSection).getAllByRole("button", { name: /start latest/i })[0],
+      within(runningSection).getAllByRole("button", { name: /restart/i })[0],
     ).toBeInTheDocument();
   });
 

--- a/frontend/src/app/(dashboard)/previews/page.tsx
+++ b/frontend/src/app/(dashboard)/previews/page.tsx
@@ -38,6 +38,12 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 import { useAuth } from "@/hooks/use-auth";
 import { usePageTitle } from "@/hooks/use-page-title";
 import { api } from "@/lib/api";
@@ -53,6 +59,9 @@ import type {
 import { safeExternalUrl } from "@/lib/utils";
 
 type PreviewScope = "running" | "resumable" | "recent";
+
+const RESTART_LATEST_LABEL = "Restart";
+const RESTART_LATEST_TOOLTIP = "Restart preview from the latest source state";
 
 const SECTIONS: {
   scope: PreviewScope;
@@ -347,14 +356,7 @@ function SectionRows({
                         </Button>
                       ) : null}
                       {canMutate && scope === "running" && previewNeedsAttention(preview) ? (
-                        <Button
-                          size="sm"
-                          variant="ghost"
-                          onClick={() => onStartLatest(preview)}
-                        >
-                          <RotateCw className="h-4 w-4" />
-                          Start latest
-                        </Button>
+                        <RestartLatestButton onClick={() => onStartLatest(preview)} />
                       ) : null}
                       {canMutate && scope === "resumable" ? (
                         <Button
@@ -367,14 +369,7 @@ function SectionRows({
                         </Button>
                       ) : null}
                       {canMutate && scope !== "running" ? (
-                        <Button
-                          size="sm"
-                          variant="ghost"
-                          onClick={() => onStartLatest(preview)}
-                        >
-                          <RotateCw className="h-4 w-4" />
-                          Start latest
-                        </Button>
+                        <RestartLatestButton onClick={() => onStartLatest(preview)} />
                       ) : null}
                     </div>
                   </TableCell>
@@ -443,14 +438,7 @@ function SectionRows({
                     </Button>
                   ) : null}
                   {canMutate && scope === "running" && previewNeedsAttention(preview) ? (
-                    <Button
-                      size="sm"
-                      variant="ghost"
-                      onClick={() => onStartLatest(preview)}
-                    >
-                      <RotateCw className="h-4 w-4" />
-                      Start latest
-                    </Button>
+                    <RestartLatestButton onClick={() => onStartLatest(preview)} />
                   ) : null}
                   {canMutate && scope === "resumable" ? (
                     <Button
@@ -463,14 +451,7 @@ function SectionRows({
                     </Button>
                   ) : null}
                   {canMutate && scope !== "running" ? (
-                    <Button
-                      size="sm"
-                      variant="ghost"
-                      onClick={() => onStartLatest(preview)}
-                    >
-                      <RotateCw className="h-4 w-4" />
-                      Start latest
-                    </Button>
+                    <RestartLatestButton onClick={() => onStartLatest(preview)} />
                   ) : null}
                 </div>
               </CardContent>
@@ -479,6 +460,31 @@ function SectionRows({
         })}
       </div>
     </>
+  );
+}
+
+function RestartLatestButton({
+  onClick,
+}: {
+  onClick: () => void;
+}) {
+  return (
+    <TooltipProvider delayDuration={150}>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Button
+            size="sm"
+            variant="ghost"
+            aria-label={RESTART_LATEST_TOOLTIP}
+            onClick={onClick}
+          >
+            <RotateCw className="h-4 w-4" />
+            {RESTART_LATEST_LABEL}
+          </Button>
+        </TooltipTrigger>
+        <TooltipContent>{RESTART_LATEST_TOOLTIP}</TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
   );
 }
 

--- a/internal/api/handlers/branch_previews.go
+++ b/internal/api/handlers/branch_previews.go
@@ -3077,7 +3077,7 @@ func derivePRPreviewLaunch(resp branchPreviewResponse, opts prPreviewLaunchOptio
 			Reason:           models.PreviewLaunchReasonStale,
 			AutoOpen:         false,
 			RepresentsLatest: false,
-			PrimaryLabel:     "Start latest",
+			PrimaryLabel:     "Restart",
 			SecondaryLabel:   "Open stale preview",
 			StalePreviewURL:  resp.PreviewURL,
 			Message:          stalePreviewMessage(resp.CommitSHA, latest),

--- a/internal/api/handlers/branch_previews_test.go
+++ b/internal/api/handlers/branch_previews_test.go
@@ -399,7 +399,7 @@ func TestDerivePRPreviewLaunch(t *testing.T) {
 				Reason:           models.PreviewLaunchReasonStale,
 				AutoOpen:         false,
 				RepresentsLatest: false,
-				PrimaryLabel:     "Start latest",
+				PrimaryLabel:     "Restart",
 				SecondaryLabel:   "Open stale preview",
 				StalePreviewURL:  &staleURL,
 				Message:          "This preview is for abc123; the pull request is now at def456.",


### PR DESCRIPTION
## Summary

Users clicking the “latest” action on a stale PR preview can get confusing/incorrect expectations—“Start latest” doesn’t communicate that the action restarts from the most recent PR source state. This PR renames the user-facing action to **Restart** and aligns backend labels so the UI and API agree on the intended behavior.

## Changes

- Updated stale PR preview UI copy: **Start latest** → **Restart** (with tooltip/accessibility label: `Restart preview from the latest source state`).
- Ensured PR preview pages consistently use **Restart** for stale/latest preview launch actions.
- Renamed the backend stale PR launch metadata to return `primary_label: "Restart"` so the frontend can render the correct primary action.
- Updated related design docs and tests to match the new copy/labels.

## Validation

- `npm run typecheck`
- `npm run lint`
- `npm run build`
- `go vet ./...`
- `go build ./...`
- `go test ./...`

[143.dev](https://143.dev) | [session d9452333](https://143.dev/sessions/d9452333-9239-409e-9c6e-da1298b36440)

<!-- 143 readiness -->
**143 readiness:** not available for this revision.

Preview: https://143.dev/previews/github/assembledhq/143/pull/1536?launch=1