### PR TITLE
Remove advisory PR readiness preflight modal for engineers/admins

### DIFF
--- a/docs/design/implemented/107-pr-readiness-checks.md
+++ b/docs/design/implemented/107-pr-readiness-checks.md
@@ -312,7 +312,7 @@ Safety and product constraints:
 
 ### Phase 2: PR preflight
 
-- Implemented for the web UI. Builders are blocked by backend enforcement; engineers/admins get a localStorage-keyed one-time advisory for the same session/revision/warning signature.
+- Implemented for the web UI. Builders are blocked by backend enforcement. Engineers/admins can create PRs directly; advisory readiness findings remain visible in the readiness card instead of opening a pre-creation modal.
 
 ### Phase 3: Automatic run options
 

--- a/frontend/src/app/(dashboard)/sessions/[id]/page-pr-creation.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/page-pr-creation.test.tsx
@@ -604,7 +604,7 @@ describe('SessionDetailPage PR creation', () => {
     expect(screen.getByText('Readiness is stale')).toBeInTheDocument();
   });
 
-  it('lists readiness warnings in the engineer preflight dialog', async () => {
+  it('creates a PR directly when readiness has advisory warnings', async () => {
     const sessionWithDiff: Session = {
       ...mockSessions[0],
       status: 'completed',
@@ -642,10 +642,16 @@ describe('SessionDetailPage PR creation', () => {
       bypasses: [],
     };
 
+    let createPRCalled = false;
+
     server.use(
       http.get('/api/v1/sessions/:id', () => HttpResponse.json({ data: sessionWithDiff } satisfies SingleResponse<Session>)),
       http.get('/api/v1/sessions/:id/pr', () => HttpResponse.json({ error: { code: 'NOT_FOUND', message: 'pull request not found' } }, { status: 404 })),
       http.get('/api/v1/sessions/:id/pr-readiness-runs/latest', () => HttpResponse.json({ data: { latest } })),
+      http.post('/api/v1/sessions/:id/pr', () => {
+        createPRCalled = true;
+        return HttpResponse.json({ status: 'queued' }, { status: 202 });
+      }),
     );
 
     const user = userEvent.setup();
@@ -653,8 +659,10 @@ describe('SessionDetailPage PR creation', () => {
 
     await user.click(await screen.findByRole('button', { name: /Create PR/ }));
 
-    const dialog = await screen.findByRole('alertdialog', { name: 'Review readiness before creating PR?' });
-    expect(within(dialog).getByText('No test evidence found')).toBeInTheDocument();
+    await waitFor(() => {
+      expect(createPRCalled).toBe(true);
+    });
+    expect(screen.queryByRole('alertdialog', { name: 'Review readiness before creating PR?' })).not.toBeInTheDocument();
   });
 
   it('shows exact readiness blockers in the bypass dialog', async () => {
@@ -1156,7 +1164,7 @@ describe('SessionDetailPage PR creation', () => {
     });
   });
 
-  it('shows a one-time advisory readiness preflight for missing readiness', async () => {
+  it('creates a PR directly when readiness is missing', async () => {
     const sessionWithSnapshot: Session = {
       ...mockSessions[0],
       status: 'completed',
@@ -1191,15 +1199,11 @@ describe('SessionDetailPage PR creation', () => {
     renderWithProviders(<SessionDetailContent id="session-abcdef12-3456-7890" />);
 
     await user.click(await screen.findByRole('button', { name: 'Create PR' }));
-    expect(await screen.findByRole('alertdialog', { name: 'Review readiness before creating PR?' })).toBeInTheDocument();
-    expect(screen.getByText(/PR readiness is missing/)).toBeInTheDocument();
-    expect(createPRCalled).toBe(false);
-
-    await user.click(screen.getByRole('button', { name: 'Create PR' }));
 
     await waitFor(() => {
       expect(createPRCalled).toBe(true);
     });
+    expect(screen.queryByRole('alertdialog', { name: 'Review readiness before creating PR?' })).not.toBeInTheDocument();
   });
 
   it('calls createPR API with merge_when_ready when Create PR and enable auto-merge is clicked', async () => {

--- a/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
@@ -3735,7 +3735,6 @@ export function SessionDetailContent({ id }: { id: string }) {
   const [pendingMergeWhenReady, setPendingMergeWhenReady] = useState(false);
   const [repairActionError, setRepairActionError] = useState<string | null>(null);
   const [prAuthPrompt, setPRAuthPrompt] = useState<PRAuthPromptState | null>(null);
-  const [readinessPreflightOptions, setReadinessPreflightOptions] = useState<{ draft?: boolean; authorMode?: PRAuthorMode; resumeToken?: string; mergeWhenReady?: boolean } | null>(null);
   const resumeAttemptRef = useRef<string | null>(null);
   const apiBase = process.env.NEXT_PUBLIC_API_URL || "";
   const isDocumentVisible = useDocumentVisible();
@@ -4628,7 +4627,6 @@ export function SessionDetailContent({ id }: { id: string }) {
   const runReadinessMutation = useMutation({
     mutationFn: () => api.sessions.runReadiness(id),
     onSuccess: () => {
-      setReadinessPreflightOptions(null);
       queryClient.invalidateQueries({ queryKey: queryKeys.sessions.readiness(id) });
       toast.success("Readiness checks queued");
     },
@@ -4683,28 +4681,6 @@ export function SessionDetailContent({ id }: { id: string }) {
   const canAttemptCreatePR = canShipPR && hasSnapshot && !hasPR && !isRunning;
   const canCreatePR = canAttemptCreatePR && createPRAllowsSubmission;
   const canCreateBranch = canAttemptCreatePR && builderReviewAllowsPR;
-  const readinessWarningSignature = !latestReadiness
-    ? "missing"
-    : latestReadinessStale
-      ? "stale"
-      : (latestReadiness.checks ?? [])
-        .filter((check) => check.status === "warning" || check.status === "failed" || check.status === "error")
-        .map((check) => `${check.check_key || check.check_type}:${check.status}`)
-        .sort()
-        .join("|") || "none";
-  const readinessPreflightKey = `pr-readiness-preflight:${user?.id ?? "anon"}:${id}:${session?.workspace_revision ?? 0}:${readinessWarningSignature}`;
-  const shouldShowReadinessPreflight = (user?.role === "admin" || user?.role === "member") &&
-    canAttemptCreatePR &&
-    readinessWarningSignature !== "none";
-  const readinessPreflightFindings = latestReadinessStale
-    ? [{ key: "stale", title: "Readiness is stale", summary: "Re-run checks before relying on this result." }]
-    : (latestReadiness?.checks ?? [])
-      .filter((check) => check.status === "warning" || check.status === "failed" || check.status === "error")
-      .map((check) => ({
-        key: check.check_key || check.check_type,
-        title: check.title,
-        summary: check.summary,
-      }));
   const needsGitHubStatus = canCreatePR || (hasPR && prData?.data?.status === "open");
   const reviewLoopRunning = latestReviewLoop?.status === "running";
   const canStartReviewLoop = !!session && canManageSession && canUseNativeReviewLoop && hasSnapshot && !isRunning && !reviewLoopRunning;
@@ -4816,12 +4792,8 @@ export function SessionDetailContent({ id }: { id: string }) {
   });
 
   const submitCreatePR = useCallback((options?: { draft?: boolean; authorMode?: PRAuthorMode; resumeToken?: string; mergeWhenReady?: boolean }) => {
-    if (shouldShowReadinessPreflight && typeof window !== "undefined" && window.localStorage.getItem(readinessPreflightKey) !== "ack") {
-      setReadinessPreflightOptions(options ?? {});
-      return;
-    }
     createPRMutation.mutate(options);
-  }, [createPRMutation, readinessPreflightKey, shouldShowReadinessPreflight]);
+  }, [createPRMutation]);
 
   const startReviewLoopMutation = useMutation({
     mutationFn: () =>
@@ -7244,55 +7216,6 @@ export function SessionDetailContent({ id }: { id: string }) {
         onOpenChange={setKeyboardHelpOpen}
         canShipPR={canShipPR}
       />
-      <AlertDialog
-        open={readinessPreflightOptions !== null}
-        onOpenChange={(open) => {
-          if (!open) setReadinessPreflightOptions(null);
-        }}
-      >
-        <AlertDialogContent>
-          <AlertDialogHeader>
-            <AlertDialogTitle>Review readiness before creating PR?</AlertDialogTitle>
-            <AlertDialogDescription>
-              PR readiness is {readinessWarningSignature === "missing" ? "missing" : readinessWarningSignature === "stale" ? "stale" : "showing warnings"} for this workspace revision.
-            </AlertDialogDescription>
-          </AlertDialogHeader>
-          {readinessPreflightFindings.length > 0 && (
-            <div className="space-y-2 rounded-md border border-border px-3 py-2 text-xs">
-              {readinessPreflightFindings.map((finding) => (
-                <div key={finding.key}>
-                  <div className="font-medium text-foreground">{finding.title}</div>
-                  {finding.summary ? <div className="text-muted-foreground">{finding.summary}</div> : null}
-                </div>
-              ))}
-            </div>
-          )}
-          <AlertDialogFooter>
-            <AlertDialogCancel>Cancel</AlertDialogCancel>
-            <Button
-              variant="outline"
-              disabled={runReadinessMutation.isPending}
-              onClick={() => runReadinessMutation.mutate()}
-            >
-              {runReadinessMutation.isPending ? <Loader2 className="mr-1.5 h-3 w-3 animate-spin" /> : <RefreshCw className="mr-1.5 h-3 w-3" />}
-              Run checks
-            </Button>
-            <AlertDialogAction
-              onClick={(event) => {
-                event.preventDefault();
-                if (typeof window !== "undefined") {
-                  window.localStorage.setItem(readinessPreflightKey, "ack");
-                }
-                const options = readinessPreflightOptions ?? undefined;
-                setReadinessPreflightOptions(null);
-                createPRMutation.mutate(options);
-              }}
-            >
-              Create PR
-            </AlertDialogAction>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
       <AlertDialog
         open={!!prAuthPrompt}
         onOpenChange={(open) => {


### PR DESCRIPTION
## Summary

Builders can be blocked by PR readiness enforcement, but engineers/admins previously hit a local, advisory “readiness preflight” modal before PR creation (see #107). This adds an unnecessary extra click and can make the PR workflow feel unreliable, since the advisory findings shouldn’t block creation.

This change removes the advisory pre-creation modal for engineers/admins and keeps the readiness findings visible in the readiness card instead. Updated tests ensure `POST /api/v1/sessions/:id/pr` is called immediately when readiness is missing or only advisory warnings exist.

## Changes

- Removed the advisory PR readiness preflight modal from `session-detail-content.tsx`; engineers/admins now proceed to PR creation directly.
- Adjusted PR creation tests in `page-pr-creation.test.tsx` to assert PR creation occurs immediately when readiness has advisory warnings or is missing.
- Updated the PR readiness design note to reflect the new behavior: advisory findings stay in the readiness card rather than opening a blocking dialog.

## Validation

- `npm test -- page-pr-creation.test.tsx`
- `npm run typecheck`
- `npm run lint`
- `npm run build`

[143.dev](https://143.dev) | [session 803e66f2](https://143.dev/sessions/803e66f2-652b-4eef-bbef-26c3e8f1788f)

<!-- 143 readiness -->
**143 readiness:** not available for this revision.

Preview: https://143.dev/previews/github/assembledhq/143/pull/1537?launch=1