### PR TITLE
Preselect shared default repository in Create preview dialog

### DIFF
--- a/frontend/src/app/(dashboard)/previews/new/page.test.tsx
+++ b/frontend/src/app/(dashboard)/previews/new/page.test.tsx
@@ -119,6 +119,47 @@ describe("NewPreviewPage", () => {
     });
   });
 
+  it("preselects the shared default repository when no repo param exists", async () => {
+    server.use(
+      http.get("*/api/v1/repositories", () =>
+        HttpResponse.json({
+          data: repositories,
+          meta: { default_repository_id: "repo-2" },
+        }),
+      ),
+      http.get("*/api/v1/repositories/:id/branches", () =>
+        HttpResponse.json({
+          data: [
+            { name: "develop", protected: true },
+            { name: "main", protected: true },
+          ],
+          meta: {},
+        }),
+      ),
+      http.get("*/api/v1/previews/configs", () =>
+        HttpResponse.json({
+          data: {
+            names: [],
+            default_name: "",
+            selected_name: "",
+            requires_selection: false,
+          },
+        }),
+      ),
+    );
+
+    renderWithProviders(<NewPreviewPage />);
+
+    await waitFor(() => {
+      expect(screen.getByRole("combobox", { name: "Repository" })).toHaveTextContent(
+        "assembledhq/web",
+      );
+    });
+    expect(screen.getByRole("button", { name: "Target branch" })).toHaveTextContent(
+      "develop",
+    );
+  });
+
   it("navigates to /previews when the dialog is closed", async () => {
     installHandlers();
 

--- a/frontend/src/components/preview/create-preview-dialog.tsx
+++ b/frontend/src/components/preview/create-preview-dialog.tsx
@@ -96,6 +96,7 @@ function CreatePreviewForm({
   });
 
   const repositories = useMemo(() => repositoriesQuery.data?.data ?? [], [repositoriesQuery.data?.data]);
+  const defaultRepositoryId = repositoriesQuery.data?.meta.default_repository_id;
   const filteredRepositories = useMemo(
     () => repositories.filter((repo) => repo.full_name.toLowerCase().includes(repoSearch.trim().toLowerCase())),
     [repositories, repoSearch],
@@ -103,9 +104,11 @@ function CreatePreviewForm({
   const selectedRepo = useMemo(() => {
     const explicit = repositories.find((repo) => repo.id === repositoryId);
     if (explicit) return explicit;
+    const defaultRepo = repositories.find((repo) => repo.id === defaultRepositoryId);
+    if (!repositoryId && defaultRepo) return defaultRepo;
     if (!repositoryId && repositories.length === 1) return repositories[0];
     return undefined;
-  }, [repositories, repositoryId]);
+  }, [defaultRepositoryId, repositories, repositoryId]);
   const selectedRepositoryId = repositoryId || selectedRepo?.id || "";
   const selectedBranch = branch || selectedRepo?.default_branch || "";
 

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -2317,6 +2317,7 @@ export interface ListResponse<T> {
   data: T[];
   meta: {
     next_cursor?: string;
+    default_repository_id?: string;
   };
 }
 

--- a/internal/api/handlers/repositories.go
+++ b/internal/api/handlers/repositories.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"net/http"
@@ -17,11 +18,16 @@ import (
 
 type RepositoryHandler struct {
 	repoStore *db.RepositoryStore
+	orgStore  *db.OrganizationStore
 	prService *ghservice.PRService
 }
 
-func NewRepositoryHandler(repoStore *db.RepositoryStore) *RepositoryHandler {
-	return &RepositoryHandler{repoStore: repoStore}
+func NewRepositoryHandler(repoStore *db.RepositoryStore, orgStores ...*db.OrganizationStore) *RepositoryHandler {
+	h := &RepositoryHandler{repoStore: repoStore}
+	if len(orgStores) > 0 {
+		h.orgStore = orgStores[0]
+	}
+	return h
 }
 
 func (h *RepositoryHandler) SetPRService(svc *ghservice.PRService) {
@@ -44,7 +50,41 @@ func (h *RepositoryHandler) List(w http.ResponseWriter, r *http.Request) {
 	if repos == nil {
 		repos = []models.Repository{}
 	}
-	writeJSON(w, http.StatusOK, models.ListResponse[models.Repository]{Data: repos})
+	meta := models.PaginationMeta{}
+	if !filters.IncludeDisconnected {
+		defaultRepositoryID, err := h.defaultRepositoryID(r.Context(), orgID, repos)
+		if err != nil {
+			writeError(w, r, http.StatusInternalServerError, "DEFAULT_REPOSITORY_FAILED", "failed to resolve default repository", err)
+			return
+		}
+		meta.DefaultRepositoryID = defaultRepositoryID
+	}
+	writeJSON(w, http.StatusOK, models.ListResponse[models.Repository]{Data: repos, Meta: meta})
+}
+
+func (h *RepositoryHandler) defaultRepositoryID(ctx context.Context, orgID uuid.UUID, repos []models.Repository) (string, error) {
+	if len(repos) == 0 || h.orgStore == nil {
+		return "", nil
+	}
+	org, err := h.orgStore.GetByID(ctx, orgID)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return "", nil
+		}
+		return "", err
+	}
+	settings, err := models.ParseOrgSettings(org.Settings)
+	if err != nil {
+		return "", err
+	}
+	if settings.DefaultWorkRepositoryID != nil {
+		for _, repo := range repos {
+			if repo.ID == *settings.DefaultWorkRepositoryID {
+				return settings.DefaultWorkRepositoryID.String(), nil
+			}
+		}
+	}
+	return "", nil
 }
 
 func (h *RepositoryHandler) Get(w http.ResponseWriter, r *http.Request) {

--- a/internal/api/handlers/repositories_test.go
+++ b/internal/api/handlers/repositories_test.go
@@ -33,10 +33,12 @@ func TestRepositoryHandler_List(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name         string
-		setupMock    func(mock pgxmock.PgxPoolIface, orgID uuid.UUID)
-		expectedCode int
-		expectedLen  int
+		name          string
+		setupMock     func(mock pgxmock.PgxPoolIface, orgID uuid.UUID)
+		expectedCode  int
+		expectedLen   int
+		useOrgStore   bool
+		expectDefault bool
 	}{
 		{
 			name: "returns repositories for org successfully",
@@ -56,6 +58,88 @@ func TestRepositoryHandler_List(t *testing.T) {
 			},
 			expectedCode: http.StatusOK,
 			expectedLen:  1,
+		},
+		{
+			name: "returns configured shared default repository in meta",
+			setupMock: func(mock pgxmock.PgxPoolIface, orgID uuid.UUID) {
+				now := time.Now()
+				repoID := uuid.New()
+				integrationID := uuid.New()
+				mock.ExpectQuery("SELECT .+ FROM repositories WHERE org_id").
+					WithArgs(pgxmock.AnyArg()).
+					WillReturnRows(
+						pgxmock.NewRows(repoColumns()).AddRow(
+							repoID, orgID, integrationID, int64(1001), "test-org/repo1", "main",
+							false, nil, nil, "https://github.com/test-org/repo1.git", int64(12345), "active",
+							nil, nil, json.RawMessage(`{}`), now, now,
+						),
+					)
+				mock.ExpectQuery("SELECT id, name, settings, created_at, updated_at").
+					WithArgs(pgxmock.AnyArg()).
+					WillReturnRows(
+						pgxmock.NewRows([]string{"id", "name", "settings", "created_at", "updated_at"}).
+							AddRow(orgID, "test-org", json.RawMessage(`{"default_work_repository_id":"`+repoID.String()+`"}`), now, now),
+					)
+			},
+			expectedCode:  http.StatusOK,
+			expectedLen:   1,
+			useOrgStore:   true,
+			expectDefault: true,
+		},
+		{
+			name: "omits default_repository_id when org has no default configured",
+			setupMock: func(mock pgxmock.PgxPoolIface, orgID uuid.UUID) {
+				now := time.Now()
+				repoID := uuid.New()
+				integrationID := uuid.New()
+				mock.ExpectQuery("SELECT .+ FROM repositories WHERE org_id").
+					WithArgs(pgxmock.AnyArg()).
+					WillReturnRows(
+						pgxmock.NewRows(repoColumns()).AddRow(
+							repoID, orgID, integrationID, int64(1001), "test-org/repo1", "main",
+							false, nil, nil, "https://github.com/test-org/repo1.git", int64(12345), "active",
+							nil, nil, json.RawMessage(`{}`), now, now,
+						),
+					)
+				mock.ExpectQuery("SELECT id, name, settings, created_at, updated_at").
+					WithArgs(pgxmock.AnyArg()).
+					WillReturnRows(
+						pgxmock.NewRows([]string{"id", "name", "settings", "created_at", "updated_at"}).
+							AddRow(orgID, "test-org", json.RawMessage(`{}`), now, now),
+					)
+			},
+			expectedCode:  http.StatusOK,
+			expectedLen:   1,
+			useOrgStore:   true,
+			expectDefault: false,
+		},
+		{
+			name: "omits default_repository_id when configured default is not in active repos list",
+			setupMock: func(mock pgxmock.PgxPoolIface, orgID uuid.UUID) {
+				now := time.Now()
+				repoID := uuid.New()
+				deletedRepoID := uuid.New()
+				integrationID := uuid.New()
+				mock.ExpectQuery("SELECT .+ FROM repositories WHERE org_id").
+					WithArgs(pgxmock.AnyArg()).
+					WillReturnRows(
+						pgxmock.NewRows(repoColumns()).AddRow(
+							repoID, orgID, integrationID, int64(1001), "test-org/repo1", "main",
+							false, nil, nil, "https://github.com/test-org/repo1.git", int64(12345), "active",
+							nil, nil, json.RawMessage(`{}`), now, now,
+						),
+					)
+				mock.ExpectQuery("SELECT id, name, settings, created_at, updated_at").
+					WithArgs(pgxmock.AnyArg()).
+					WillReturnRows(
+						pgxmock.NewRows([]string{"id", "name", "settings", "created_at", "updated_at"}).
+							AddRow(orgID, "test-org", json.RawMessage(`{"default_work_repository_id":"`+deletedRepoID.String()+`"}`), now, now),
+					)
+			},
+			expectedCode:  http.StatusOK,
+			expectedLen:   1,
+			useOrgStore:   true,
+			expectDefault: false,
 		},
 		{
 			name: "returns empty list when no repositories exist",
@@ -80,6 +164,9 @@ func TestRepositoryHandler_List(t *testing.T) {
 			orgID := uuid.New()
 			store := db.NewRepositoryStore(mock)
 			handler := NewRepositoryHandler(store)
+			if tt.useOrgStore {
+				handler = NewRepositoryHandler(store, db.NewOrganizationStore(mock))
+			}
 
 			tt.setupMock(mock, orgID)
 
@@ -95,6 +182,12 @@ func TestRepositoryHandler_List(t *testing.T) {
 			err = json.Unmarshal(w.Body.Bytes(), &resp)
 			require.NoError(t, err, "response body should be valid JSON")
 			require.Equal(t, tt.expectedLen, len(resp.Data), "should return expected number of repositories")
+			if tt.expectDefault {
+				require.NotEmpty(t, resp.Meta.DefaultRepositoryID, "repository list meta should include the shared default repository id")
+				require.Equal(t, resp.Data[0].ID.String(), resp.Meta.DefaultRepositoryID, "repository list meta should use the configured shared default repository")
+			} else {
+				require.Empty(t, resp.Meta.DefaultRepositoryID, "repository list meta should not include a default repository id when none is configured")
+			}
 			require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
 		})
 	}

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -213,7 +213,7 @@ func NewRouter(cfg *config.Config, pool *pgxpool.Pool, logger zerolog.Logger, se
 	cliToolsHandler := handlers.NewCLIToolsHandler(credentialStore, logger)
 	cliToolsHandler.SetAuditEmitter(auditEmitter)
 	organizationsHandler := handlers.NewOrganizationsHandler(pool)
-	repoHandler := handlers.NewRepositoryHandler(repoStore)
+	repoHandler := handlers.NewRepositoryHandler(repoStore, orgStore)
 	if prService != nil {
 		repoHandler.SetPRService(prService)
 	}

--- a/internal/models/responses.go
+++ b/internal/models/responses.go
@@ -35,9 +35,10 @@ type ErrorDetail struct {
 
 // PaginationMeta contains cursor-based pagination info.
 type PaginationMeta struct {
-	NextCursor string `json:"next_cursor,omitempty"`
-	Counts     any    `json:"counts,omitempty"`
-	Pool       any    `json:"pool,omitempty"`
+	NextCursor          string `json:"next_cursor,omitempty"`
+	DefaultRepositoryID string `json:"default_repository_id,omitempty"`
+	Counts              any    `json:"counts,omitempty"`
+	Pool                any    `json:"pool,omitempty"`
 }
 
 // ThreadMessageWindowMeta contains cursor and anchor metadata for bottom-first


### PR DESCRIPTION
## Summary
Users creating a preview without a repository parameter may land on an empty/incorrect repository selection, forcing extra steps and risking inconsistent “default” behavior across UI/API. This change adds app-wide `default_repository_id` support to the repositories list response and uses it in the Create Preview dialog to preselect the shared default when no explicit repo is provided.

## Changes
- API: extend `GET /api/v1/repositories` to return `meta.default_repository_id` (and avoid returning an explicit fallback when no default is configured or it’s not active).
- Types: update `ListResponse` to include optional `default_repository_id`.
- Frontend: in `CreatePreviewForm`, choose the repository from `default_repository_id` when `repositoryId` is absent; otherwise keep existing behavior (explicit repo, single repo, etc.).
- Tests: add a UI test asserting the repository combobox and target branch are prefilled from the shared default repo.

## Validation
- Added/updated frontend test: `frontend/src/app/(dashboard)/previews/new/page.test.tsx` (new case for “no repo param exists” preselection).
- Added/updated backend tests for default meta behavior: `internal/api/handlers/repositories_test.go`.
- Ran existing unit/integration suites and ensured handler contracts still match expected list/meta shapes.

[143.dev](https://143.dev) | [session b64ae5a9](https://143.dev/sessions/b64ae5a9-c5b8-434f-856a-6c4048878b86)

<!-- 143 readiness -->
**143 readiness:** not available for this revision.

Preview: https://143.dev/previews/github/assembledhq/143/pull/1538?launch=1