### PR TITLE
Remove legacy builder review compatibility and always use default PR readiness when unset

### DIFF
--- a/docs/design/implemented/107-pr-readiness-checks.md
+++ b/docs/design/implemented/107-pr-readiness-checks.md
@@ -13,7 +13,7 @@ This is not a human approval system. Readiness must come from platform-observed 
 Implemented core behavior:
 
 - `pr_readiness_runs`, `pr_readiness_checks`, `pr_readiness_policies`, `pr_readiness_custom_checks`, `pr_readiness_bypasses`, and `pr_readiness_contexts` persist readiness state with `org_id` tenancy.
-- Policies resolve as repository override -> org policy -> default policy. The legacy `builder_permissions.require_review_before_pr=false` setting disables builder blocking only until an explicit readiness policy exists.
+- Policies resolve as repository override -> org policy -> default policy. Legacy builder review compatibility settings are no longer honored; absent explicit policy means the default PR readiness policy applies.
 - Checks store factual status separately from role-specific enforcement (`builder`, `engineer`, `admin`) and expose effective enforcement to the UI.
 - Builders are blocked only by current-revision, non-bypassed blocking `failed`/`error` checks. Queued/running, missing, and stale readiness cannot be bypassed.
 - The Overview card groups checks, shows per-check next actions and expandable evidence, and derives a visible stale blocker when the stored run no longer matches the session revision/snapshot.

--- a/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
@@ -141,7 +141,7 @@ import {
   writeStoredViewedThreadIds,
 } from "@/lib/session-thread-views";
 import { applySessionDetailToSessionListCaches } from "@/lib/session-list-cache";
-import type { HumanInputAnswerBody, HumanInputRequest, ListResponse, Organization, OrgSettings, PRReadinessBypass, PRReadinessCheck, PRReadinessEnforcement, PRReadinessPolicyConfig, PRReadinessRun, ReviewLoopFixMode, Session, SessionDetail, SessionInputCommand, SessionInputReference, SessionLog, SessionMessage, SessionReviewComment, SessionReviewLoop, SessionRetryMode, SessionStatus, SessionThread, SessionThreadFileEvent, SessionTimelineEntry, ThreadInboxEvent, ThreadRuntimeEvent, ThreadStatus, User, CodexAuthStatus, PullRequestHealthResponse, PullRequestStatus, SessionWorkspaceGenerationChangedEvent, SingleResponse, SessionTranscriptWindowResponse, SessionTranscriptTurn, SessionTranscriptEntry } from "@/lib/types";
+import type { HumanInputAnswerBody, HumanInputRequest, ListResponse, PRReadinessBypass, PRReadinessCheck, PRReadinessEnforcement, PRReadinessPolicyConfig, PRReadinessRun, ReviewLoopFixMode, Session, SessionDetail, SessionInputCommand, SessionInputReference, SessionLog, SessionMessage, SessionReviewComment, SessionReviewLoop, SessionRetryMode, SessionStatus, SessionThread, SessionThreadFileEvent, SessionTimelineEntry, ThreadInboxEvent, ThreadRuntimeEvent, ThreadStatus, User, CodexAuthStatus, PullRequestHealthResponse, PullRequestStatus, SessionWorkspaceGenerationChangedEvent, SingleResponse, SessionTranscriptWindowResponse, SessionTranscriptTurn, SessionTranscriptEntry } from "@/lib/types";
 import { AgentTabStrip, computeThreadOverlap } from "./agent-tab-strip";
 import { AuditLogTrigger } from "@/components/audit/audit-log-trigger";
 import { ResizeHandle } from "@/components/resize-handle";
@@ -4636,22 +4636,16 @@ export function SessionDetailContent({ id }: { id: string }) {
       toast.error(err instanceof Error ? err.message : "Readiness checks could not be queued");
     },
   });
-  const { data: orgSettingsResponse } = useQuery<SingleResponse<Organization>>({
-    queryKey: queryKeys.settings.all,
-    queryFn: () => api.settings.get(),
-    enabled: user?.role === "builder",
-  });
   const { data: readinessPolicyResponse } = useQuery({
     queryKey: queryKeys.settings.prReadinessPolicy(session?.repository_id ?? null),
     queryFn: () => api.settings.getPRReadinessPolicy(session?.repository_id ?? undefined),
     enabled: !!session && canManageSession,
   });
-  const orgSettings = (orgSettingsResponse?.data?.settings ?? {}) as OrgSettings;
   const latestReviewLoop = reviewLoopsData?.data?.[0] ?? null;
   const builderRequiresReviewBeforePR = user?.role === "builder" && (
     readinessPolicyResponse?.data.config
       ? policyRequiresRoleReadiness(readinessPolicyResponse.data.config, "builder")
-      : (orgSettings.builder_permissions?.require_review_before_pr ?? true)
+      : true
   );
   const latestReadiness = readinessData?.data.latest;
   const latestReadinessStale = !!latestReadiness && (

--- a/frontend/src/app/(dashboard)/settings/page.test.tsx
+++ b/frontend/src/app/(dashboard)/settings/page.test.tsx
@@ -313,7 +313,7 @@ describe('SettingsPage', () => {
       data: {
         id: 'org-1',
         name: 'Test Org',
-        settings: { builder_permissions: { require_review_before_pr: true, extra_flag: true } },
+        settings: { pr_draft_default: false },
         created_at: '2026-05-01T12:00:00Z',
         updated_at: '2026-05-01T12:00:00Z',
       },
@@ -322,16 +322,7 @@ describe('SettingsPage', () => {
       data: {
         id: 'org-1',
         name: 'Trimmed Org',
-        settings: { builder_permissions: { require_review_before_pr: true, extra_flag: true } },
-        created_at: '2026-05-01T12:00:00Z',
-        updated_at: '2026-05-06T15:30:00Z',
-      },
-    });
-    settingsUpdateMock.mockResolvedValueOnce({
-      data: {
-        id: 'org-1',
-        name: 'Trimmed Org',
-        settings: { builder_permissions: { require_review_before_pr: false, extra_flag: true } },
+        settings: { pr_draft_default: false },
         created_at: '2026-05-01T12:00:00Z',
         updated_at: '2026-05-06T15:30:00Z',
       },
@@ -351,17 +342,7 @@ describe('SettingsPage', () => {
     await waitFor(() => {
       expect(input).toHaveValue('Trimmed Org');
     });
-
-    await user.click(screen.getByLabelText('Require builder review before PR'));
-
-    await waitFor(() => {
-      expect(settingsUpdateMock).toHaveBeenCalledWith({
-        settings: { builder_permissions: { require_review_before_pr: false } },
-      });
-    });
-    expect(settingsUpdateMock).toHaveBeenLastCalledWith({
-      settings: { builder_permissions: { require_review_before_pr: false } },
-    });
+    expect(screen.queryByLabelText('Require builder review before PR')).not.toBeInTheDocument();
   });
 
   it('shows a saved indicator only on the pull requests section after PR changes', async () => {

--- a/frontend/src/app/(dashboard)/settings/page.tsx
+++ b/frontend/src/app/(dashboard)/settings/page.tsx
@@ -274,7 +274,6 @@ function PRAuthorshipSettings() {
   const currentAuthorship = settings.pr_authorship ?? "user_preferred";
   const currentDraftDefault = settings.pr_draft_default ?? false;
   const currentAutoArchive = settings.auto_archive_on_pr_close ?? true;
-  const requireBuilderReview = settings.builder_permissions?.require_review_before_pr ?? true;
 
   const accountConnected = githubAccountStatus?.connected ?? false;
   const accountNeedsReconnect = githubAccountStatus?.needs_reconnect ?? false;
@@ -443,22 +442,6 @@ function PRAuthorshipSettings() {
             <p className="text-xs text-muted-foreground pl-6">
               Automatically archive sessions when their associated pull request is merged or closed.
             </p>
-          </div>
-          <div className="flex items-start justify-between gap-4 border-t border-border pt-4">
-            <div className="space-y-1">
-              <Label htmlFor="builder-review-before-pr">Legacy builder review compatibility</Label>
-              <p className="text-xs text-muted-foreground">
-                Kept for older clients. Explicit readiness policy controls below take precedence.
-              </p>
-            </div>
-            <Switch
-              id="builder-review-before-pr"
-              checked={requireBuilderReview}
-              onCheckedChange={(checked) =>
-                save({ settings: { builder_permissions: { require_review_before_pr: checked } } })
-              }
-              aria-label="Require builder review before PR"
-            />
           </div>
           <div className="space-y-3 border-t border-border pt-4">
             <div className="flex items-start justify-between gap-4">

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -1828,9 +1828,6 @@ export interface OrgSettings {
   pr_draft_default?: boolean;
   auto_archive_on_pr_close?: boolean;
   coding_agent_tab_tools_enabled?: boolean;
-  builder_permissions?: {
-    require_review_before_pr?: boolean;
-  };
   sandbox_network?: {
     static_egress_enabled?: boolean;
   };

--- a/internal/api/handlers/sessions.go
+++ b/internal/api/handlers/sessions.go
@@ -2206,8 +2206,7 @@ func (h *SessionHandler) CreateReadinessBypass(w http.ResponseWriter, r *http.Re
 		writeError(w, r, http.StatusConflict, "READINESS_STALE", "Stale readiness cannot be bypassed; re-run checks first")
 		return
 	}
-	legacy := h.legacyRequireReviewBeforePR(r.Context(), orgID)
-	policy, err := h.readinessStore.ResolvePolicy(r.Context(), orgID, session.RepositoryID, legacy)
+	policy, err := h.readinessStore.ResolvePolicy(r.Context(), orgID, session.RepositoryID)
 	if err != nil {
 		writeError(w, r, http.StatusInternalServerError, "READINESS_POLICY_LOAD_FAILED", "failed to load PR readiness policy", err)
 		return
@@ -2249,8 +2248,7 @@ func (h *SessionHandler) GetReadinessPolicy(w http.ResponseWriter, r *http.Reque
 	if !h.validateReadinessRepositoryScope(w, r, orgID, repositoryID) {
 		return
 	}
-	legacy := h.legacyRequireReviewBeforePR(r.Context(), orgID)
-	policy, err := h.readinessStore.ResolvePolicy(r.Context(), orgID, repositoryID, legacy)
+	policy, err := h.readinessStore.ResolvePolicy(r.Context(), orgID, repositoryID)
 	if err != nil {
 		writeError(w, r, http.StatusInternalServerError, "READINESS_POLICY_LOAD_FAILED", "failed to load PR readiness policy", err)
 		return
@@ -2411,21 +2409,6 @@ func (h *SessionHandler) DeleteReadinessCustomCheck(w http.ResponseWriter, r *ht
 	w.WriteHeader(http.StatusNoContent)
 }
 
-func (h *SessionHandler) legacyRequireReviewBeforePR(ctx context.Context, orgID uuid.UUID) *bool {
-	if h.orgStore == nil {
-		return nil
-	}
-	org, err := h.orgStore.GetByID(ctx, orgID)
-	if err != nil {
-		return nil
-	}
-	settings, err := models.ParseOrgSettings(org.Settings)
-	if err != nil {
-		return nil
-	}
-	return settings.BuilderPermissions.RequireReviewBeforePR
-}
-
 func (h *SessionHandler) validateReadinessRepositoryScope(w http.ResponseWriter, r *http.Request, orgID uuid.UUID, repositoryID *uuid.UUID) bool {
 	if repositoryID == nil {
 		return true
@@ -2457,9 +2440,9 @@ func parseOptionalUUIDQuery(w http.ResponseWriter, r *http.Request, key string) 
 	return &id, true
 }
 
-func (h *SessionHandler) requireBuilderReviewForCurrentSnapshot(w http.ResponseWriter, r *http.Request, settings models.OrgSettings, orgID, sessionID uuid.UUID, snapshotKey string) bool {
+func (h *SessionHandler) requireBuilderReviewForCurrentSnapshot(w http.ResponseWriter, r *http.Request, orgID, sessionID uuid.UUID, snapshotKey string) bool {
 	role := middleware.ActiveRoleFromContext(r.Context())
-	if role != string(models.RoleBuilder) || !settings.BuilderPermissions.EffectiveRequireReviewBeforePR() {
+	if role != string(models.RoleBuilder) {
 		return true
 	}
 	if h.reviewLoopStore == nil {
@@ -2480,18 +2463,15 @@ func (h *SessionHandler) requireBuilderReviewForCurrentSnapshot(w http.ResponseW
 	return false
 }
 
-func (h *SessionHandler) requirePRReadinessForBuilder(w http.ResponseWriter, r *http.Request, settings models.OrgSettings, orgID uuid.UUID, session models.Session) bool {
+func (h *SessionHandler) requirePRReadinessForBuilder(w http.ResponseWriter, r *http.Request, orgID uuid.UUID, session models.Session) bool {
 	role := middleware.ActiveRoleFromContext(r.Context())
 	if role != string(models.RoleBuilder) {
 		return true
 	}
 	if h.readinessStore == nil {
-		if !settings.BuilderPermissions.EffectiveRequireReviewBeforePR() {
-			return true
-		}
-		return h.requireBuilderReviewForCurrentSnapshot(w, r, settings, orgID, session.ID, stringPtrValue(session.SnapshotKey))
+		return h.requireBuilderReviewForCurrentSnapshot(w, r, orgID, session.ID, stringPtrValue(session.SnapshotKey))
 	}
-	resolved, err := h.readinessStore.ResolvePolicy(r.Context(), orgID, session.RepositoryID, settings.BuilderPermissions.RequireReviewBeforePR)
+	resolved, err := h.readinessStore.ResolvePolicy(r.Context(), orgID, session.RepositoryID)
 	if err != nil {
 		writeError(w, r, http.StatusInternalServerError, "READINESS_POLICY_CHECK_FAILED", "failed to check PR readiness policy", err)
 		return false
@@ -2615,11 +2595,11 @@ func (h *SessionHandler) CreatePR(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	if h.maybeAutoRunPRReadinessOnCreatePR(w, r, orgSettings, orgID, session) {
+	if h.maybeAutoRunPRReadinessOnCreatePR(w, r, orgID, session) {
 		return
 	}
 
-	if !h.requirePRReadinessForBuilder(w, r, orgSettings, orgID, session) {
+	if !h.requirePRReadinessForBuilder(w, r, orgID, session) {
 		return
 	}
 
@@ -2700,11 +2680,11 @@ func (h *SessionHandler) CreatePR(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusAccepted, map[string]string{"status": "queued"})
 }
 
-func (h *SessionHandler) maybeAutoRunPRReadinessOnCreatePR(w http.ResponseWriter, r *http.Request, settings models.OrgSettings, orgID uuid.UUID, session models.Session) bool {
+func (h *SessionHandler) maybeAutoRunPRReadinessOnCreatePR(w http.ResponseWriter, r *http.Request, orgID uuid.UUID, session models.Session) bool {
 	if h.readinessStore == nil || h.jobStore == nil {
 		return false
 	}
-	resolved, err := h.readinessStore.ResolvePolicy(r.Context(), orgID, session.RepositoryID, settings.BuilderPermissions.RequireReviewBeforePR)
+	resolved, err := h.readinessStore.ResolvePolicy(r.Context(), orgID, session.RepositoryID)
 	if err != nil {
 		writeError(w, r, http.StatusInternalServerError, "READINESS_POLICY_CHECK_FAILED", "failed to check PR readiness policy", err)
 		return true
@@ -2933,7 +2913,7 @@ func (h *SessionHandler) PushChangesToPR(w http.ResponseWriter, r *http.Request)
 		}
 	}
 
-	if !h.requirePRReadinessForBuilder(w, r, orgSettings, orgID, session) {
+	if !h.requirePRReadinessForBuilder(w, r, orgID, session) {
 		return
 	}
 

--- a/internal/api/handlers/sessions_test.go
+++ b/internal/api/handlers/sessions_test.go
@@ -7410,11 +7410,11 @@ func TestSessionHandler_CreatePR_BuilderRequiresCleanReviewLoop(t *testing.T) {
 			expectedBody:   "REVIEW_REQUIRED_BEFORE_PR",
 		},
 		{
-			name:           "allows builder when org disables requirement",
+			name:           "ignores legacy disabled setting and still requires review",
 			settings:       json.RawMessage(`{"builder_permissions":{"require_review_before_pr":false}}`),
-			expectedStatus: http.StatusAccepted,
-			expectedBody:   `"status":"queued"`,
-			expectEnqueue:  true,
+			reviewRows:     pgxmock.NewRows(reviewLoopColumns),
+			expectedStatus: http.StatusConflict,
+			expectedBody:   "REVIEW_REQUIRED_BEFORE_PR",
 		},
 	}
 
@@ -9034,11 +9034,11 @@ func TestSessionHandler_PushChangesToPR_BuilderRequiresCleanReviewLoopForCurrent
 			expectedBody:   "REVIEW_REQUIRED_BEFORE_PR",
 		},
 		{
-			name:           "allows builder when org disables requirement",
+			name:           "ignores legacy disabled setting and still requires review",
 			settings:       json.RawMessage(`{"builder_permissions":{"require_review_before_pr":false}}`),
-			expectedStatus: http.StatusAccepted,
-			expectedBody:   `"status":"queued"`,
-			expectEnqueue:  true,
+			reviewRows:     pgxmock.NewRows(reviewLoopColumns),
+			expectedStatus: http.StatusConflict,
+			expectedBody:   "REVIEW_REQUIRED_BEFORE_PR",
 		},
 	}
 

--- a/internal/db/pr_readiness.go
+++ b/internal/db/pr_readiness.go
@@ -289,7 +289,7 @@ func (s *PRReadinessStore) ListChecksByRun(ctx context.Context, orgID, runID uui
 	return checks, nil
 }
 
-func (s *PRReadinessStore) ResolvePolicy(ctx context.Context, orgID uuid.UUID, repositoryID *uuid.UUID, legacyRequireReviewBeforePR *bool) (models.PRReadinessResolvedPolicy, error) {
+func (s *PRReadinessStore) ResolvePolicy(ctx context.Context, orgID uuid.UUID, repositoryID *uuid.UUID) (models.PRReadinessResolvedPolicy, error) {
 	rows, err := s.db.Query(ctx, `
 		SELECT id, org_id, repository_id, config, active, created_by_user_id, created_at
 		FROM pr_readiness_policies
@@ -305,7 +305,7 @@ func (s *PRReadinessStore) ResolvePolicy(ctx context.Context, orgID uuid.UUID, r
 	if err != nil {
 		if err == pgx.ErrNoRows {
 			return models.PRReadinessResolvedPolicy{
-				Config: models.ResolvePRReadinessPolicyConfig(nil, nil, legacyRequireReviewBeforePR),
+				Config: models.ResolvePRReadinessPolicyConfig(nil, nil),
 				Source: "default",
 			}, nil
 		}
@@ -323,7 +323,7 @@ func (s *PRReadinessStore) ResolvePolicy(ctx context.Context, orgID uuid.UUID, r
 }
 
 func (s *PRReadinessStore) SavePolicy(ctx context.Context, orgID uuid.UUID, repositoryID *uuid.UUID, config models.PRReadinessPolicyConfig, createdByUserID *uuid.UUID) (models.PRReadinessPolicyRecord, error) {
-	config = models.ResolvePRReadinessPolicyConfig(&config, nil, nil)
+	config = models.ResolvePRReadinessPolicyConfig(&config, nil)
 	if err := config.Validate(); err != nil {
 		return models.PRReadinessPolicyRecord{}, err
 	}
@@ -880,7 +880,7 @@ func collectOnePRReadinessPolicy(rows pgx.Rows) (models.PRReadinessPolicyRecord,
 	if err := json.Unmarshal(configBytes, &record.Config); err != nil {
 		return models.PRReadinessPolicyRecord{}, fmt.Errorf("decode PR readiness policy config: %w", err)
 	}
-	record.Config = models.ResolvePRReadinessPolicyConfig(&record.Config, nil, nil)
+	record.Config = models.ResolvePRReadinessPolicyConfig(&record.Config, nil)
 	return record, nil
 }
 

--- a/internal/db/pr_readiness_test.go
+++ b/internal/db/pr_readiness_test.go
@@ -166,7 +166,7 @@ func TestPRReadinessStore_ResolvePolicyPrefersRepositoryOverride(t *testing.T) {
 			"id", "org_id", "repository_id", "config", "active", "created_by_user_id", "created_at",
 		}).AddRow(uuid.New(), orgID, &repoID, configBytes, true, nil, now))
 
-	policy, err := NewPRReadinessStore(mock).ResolvePolicy(context.Background(), orgID, &repoID, nil)
+	policy, err := NewPRReadinessStore(mock).ResolvePolicy(context.Background(), orgID, &repoID)
 	require.NoError(t, err, "ResolvePolicy should load the active repository override")
 	require.Equal(t, models.PRReadinessEnforcementBlocking, policy.Config.EffectivePolicy().EnforcementFor(models.RoleBuilder, models.PRReadinessCheckTypeRiskFlags), "repository override should control effective builder enforcement")
 	require.Equal(t, "repository", policy.Source, "ResolvePolicy should expose repository override provenance")

--- a/internal/models/org_settings.go
+++ b/internal/models/org_settings.go
@@ -251,7 +251,6 @@ type OrgSettings struct {
 	PRDraftDefault             bool                   `json:"pr_draft_default,omitempty"`
 	AutoArchiveOnPRClose       *bool                  `json:"auto_archive_on_pr_close,omitempty"`
 	DefaultWorkRepositoryID    *uuid.UUID             `json:"default_work_repository_id,omitempty"`
-	BuilderPermissions         BuilderPermissions     `json:"builder_permissions,omitempty"`
 	SandboxNetwork             SandboxNetworkSettings `json:"sandbox_network,omitempty"`
 	// CodingAgentTabToolsEnabled controls whether sandbox agents may use
 	// 143-tools to view/create/message tabs in their current session. Pointer
@@ -365,20 +364,6 @@ func (s OrgSettings) EffectiveAutoArchiveOnPRClose() bool {
 		return true
 	}
 	return *s.AutoArchiveOnPRClose
-}
-
-// BuilderPermissions controls the narrower builder role's access to
-// publishing actions. Pointer fields preserve absent-vs-explicit-false.
-type BuilderPermissions struct {
-	RequireReviewBeforePR *bool `json:"require_review_before_pr,omitempty"`
-}
-
-// EffectiveRequireReviewBeforePR applies the default builder guardrail.
-func (p BuilderPermissions) EffectiveRequireReviewBeforePR() bool {
-	if p.RequireReviewBeforePR == nil {
-		return true
-	}
-	return *p.RequireReviewBeforePR
 }
 
 // LinearAutomationSettings captures org-level defaults plus per-team

--- a/internal/models/org_settings_test.go
+++ b/internal/models/org_settings_test.go
@@ -28,7 +28,6 @@ func TestParseOrgSettings_Defaults(t *testing.T) {
 	require.Equal(t, DefaultPMScheduleHours, s.PMScheduleHours, "should default pm_schedule_hours")
 	require.Equal(t, DefaultPMModel, s.PMModel, "should default pm_model")
 	require.Nil(t, s.ProductContext, "should default product_context to nil")
-	require.True(t, s.BuilderPermissions.EffectiveRequireReviewBeforePR(), "builders should require review before PR by default")
 	require.True(t, s.EffectiveCodingAgentTabToolsEnabled(), "agent tab tools should default on")
 	require.True(t, s.EffectiveAutoArchiveOnPRClose(), "auto-archive on PR close should default on")
 	require.Equal(t, DefaultPreviewMaxPreviewsPerUser, s.PreviewMaxPreviewsPerUser, "should default per-user preview capacity")
@@ -128,9 +127,6 @@ func TestParseOrgSettings_OverrideValues(t *testing.T) {
 			"recency": 0.15,
 			"revenue_risk": 0.15
 		},
-		"builder_permissions": {
-			"require_review_before_pr": false
-		},
 		"sandbox_network": {
 			"static_egress_enabled": true
 		}
@@ -157,7 +153,6 @@ func TestParseOrgSettings_OverrideValues(t *testing.T) {
 	require.Equal(t, 0.30, s.PriorityWeights.Severity, "should override severity")
 	require.Equal(t, 0.15, s.PriorityWeights.Recency, "should override recency")
 	require.Equal(t, 0.15, s.PriorityWeights.RevenueRisk, "should override revenue_risk")
-	require.False(t, s.BuilderPermissions.EffectiveRequireReviewBeforePR(), "should allow admins to disable builder review requirement")
 	require.True(t, s.SandboxNetwork.StaticEgressEnabled, "should parse sandbox_network.static_egress_enabled")
 }
 

--- a/internal/models/pr_readiness.go
+++ b/internal/models/pr_readiness.go
@@ -298,22 +298,14 @@ func (c *PRReadinessPolicyConfig) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-func ResolvePRReadinessPolicyConfig(orgPolicy, repoPolicy *PRReadinessPolicyConfig, legacyRequireReviewBeforePR *bool) PRReadinessPolicyConfig {
+func ResolvePRReadinessPolicyConfig(orgPolicy, repoPolicy *PRReadinessPolicyConfig) PRReadinessPolicyConfig {
 	switch {
 	case repoPolicy != nil:
 		return repoPolicy.normalized()
 	case orgPolicy != nil:
 		return orgPolicy.normalized()
 	default:
-		cfg := DefaultPRReadinessPolicyConfig()
-		if legacyRequireReviewBeforePR != nil && !*legacyRequireReviewBeforePR {
-			cfg.EnabledForBuilders = false
-			for checkType, check := range cfg.Checks {
-				check.Enforcement.Builder = PRReadinessEnforcementOff
-				cfg.Checks[checkType] = check
-			}
-		}
-		return cfg.normalized()
+		return DefaultPRReadinessPolicyConfig().normalized()
 	}
 }
 

--- a/internal/models/pr_readiness_core_gaps_test.go
+++ b/internal/models/pr_readiness_core_gaps_test.go
@@ -34,15 +34,14 @@ func TestPRReadinessPolicyConfigResolution(t *testing.T) {
 	}
 	repoPolicy.AutoRun.OnCreatePR = true
 
-	resolved := ResolvePRReadinessPolicyConfig(&orgPolicy, &repoPolicy, nil)
+	resolved := ResolvePRReadinessPolicyConfig(&orgPolicy, &repoPolicy)
 	require.Equal(t, PRReadinessEnforcementBlocking, resolved.EffectivePolicy().EnforcementFor(RoleBuilder, PRReadinessCheckTypeRiskFlags), "repository policy should override org policy for the same repository")
 	require.Equal(t, PRReadinessEnforcementAdvisory, resolved.EffectivePolicy().EnforcementFor(RoleBuilder, PRReadinessCheckTypeTestEvidencePresent), "repository policy should replace org check overrides rather than merge stale org settings")
 	require.True(t, resolved.AutoRun.OnCreatePR, "repository policy should carry repository auto-run settings")
 
-	legacyDisabled := false
-	resolved = ResolvePRReadinessPolicyConfig(nil, nil, &legacyDisabled)
-	require.False(t, resolved.EnabledForBuilders, "legacy builder review disable setting should keep builder blocking off until an explicit readiness policy exists")
-	require.Equal(t, PRReadinessEnforcementOff, resolved.EffectivePolicy().EnforcementFor(RoleBuilder, PRReadinessCheckTypeAgentReviewClean), "disabled legacy compatibility should make builder checks advisory/off for enforcement")
+	resolved = ResolvePRReadinessPolicyConfig(nil, nil)
+	require.True(t, resolved.EnabledForBuilders, "default readiness policy should enable builder checks")
+	require.Equal(t, PRReadinessEnforcementBlocking, resolved.EffectivePolicy().EnforcementFor(RoleBuilder, PRReadinessCheckTypeAgentReviewClean), "default readiness policy should block builders on failed agent review")
 }
 
 func TestPRReadinessCheckEffectiveEnforcement(t *testing.T) {
@@ -107,11 +106,6 @@ func TestPRReadinessPolicyConfigRequiresRoleReadiness(t *testing.T) {
 	require.True(t, cfg.RequiresRoleReadiness(RoleBuilder), "default builder policy should require readiness because at least one builder check blocks")
 	require.True(t, cfg.RequiresRoleReadiness(RoleMember), "engineers should still have advisory readiness by default")
 
-	legacyDisabled := false
-	cfg = ResolvePRReadinessPolicyConfig(nil, nil, &legacyDisabled)
-	require.False(t, cfg.RequiresRoleReadiness(RoleBuilder), "legacy-disabled builder policy should not require a readiness run")
-	require.True(t, cfg.RequiresRoleReadiness(RoleMember), "legacy builder compatibility should not disable engineer advisory readiness")
-
 	cfg = DefaultPRReadinessPolicyConfig()
 	for checkType, check := range cfg.Checks {
 		check.Enforcement.Builder = PRReadinessEnforcementOff
@@ -150,7 +144,7 @@ func TestPRReadinessPolicyConfigExplicitBypassDisableSurvivesDefaults(t *testing
 	var cfg PRReadinessPolicyConfig
 	require.NoError(t, json.Unmarshal([]byte(`{"enabled_for_builders":true,"bypass":{"enabled":false}}`), &cfg), "policy config should decode explicit bypass disable")
 
-	resolved := ResolvePRReadinessPolicyConfig(&cfg, nil, nil)
+	resolved := ResolvePRReadinessPolicyConfig(&cfg, nil)
 
 	require.False(t, resolved.Bypass.Enabled, "explicit bypass disable should not be replaced by default enabled bypass settings")
 	require.False(t, resolved.BypassAllowedFor(RoleAdmin), "explicit bypass disable should deny bypass even when no roles/scopes are supplied")

--- a/internal/services/agent/orchestrator.go
+++ b/internal/services/agent/orchestrator.go
@@ -337,7 +337,7 @@ type UserLookup interface {
 
 type PRReadinessStore interface {
 	MaterializeRepoConfigChecks(ctx context.Context, orgID, repositoryID uuid.UUID, checks []models.PRReadinessCustomCheck) error
-	ResolvePolicy(ctx context.Context, orgID uuid.UUID, repositoryID *uuid.UUID, legacyRequireReviewBeforePR *bool) (models.PRReadinessResolvedPolicy, error)
+	ResolvePolicy(ctx context.Context, orgID uuid.UUID, repositoryID *uuid.UUID) (models.PRReadinessResolvedPolicy, error)
 	GetLatestBySession(ctx context.Context, orgID, sessionID uuid.UUID) (*models.PRReadinessRun, error)
 	CreateRun(ctx context.Context, run *models.PRReadinessRun) error
 }
@@ -1323,7 +1323,7 @@ func (o *Orchestrator) enqueuePRReadinessAfterCompletion(ctx context.Context, ru
 	if run.RepositoryID == nil || strings.TrimSpace(snapshotKey) == "" || result.Diff == nil || strings.TrimSpace(*result.Diff) == "" {
 		return
 	}
-	resolved, err := o.prReadiness.ResolvePolicy(ctx, run.OrgID, run.RepositoryID, o.legacyPRReadinessBuilderSetting(ctx, run.OrgID))
+	resolved, err := o.prReadiness.ResolvePolicy(ctx, run.OrgID, run.RepositoryID)
 	if err != nil {
 		log.Warn().Err(err).Str("session_id", run.ID.String()).Msg("failed to resolve PR readiness policy for completion auto-run")
 		return
@@ -1364,21 +1364,6 @@ func (o *Orchestrator) enqueuePRReadinessAfterCompletion(ctx context.Context, ru
 	if _, err := o.jobs.Enqueue(ctx, run.OrgID, "agent", "run_pr_readiness", payload, 6, &dedupeKey); err != nil {
 		log.Warn().Err(err).Str("session_id", run.ID.String()).Str("readiness_id", readinessRun.ID.String()).Msg("failed to enqueue completion PR readiness run")
 	}
-}
-
-func (o *Orchestrator) legacyPRReadinessBuilderSetting(ctx context.Context, orgID uuid.UUID) *bool {
-	if o == nil || o.orgs == nil {
-		return nil
-	}
-	org, err := o.orgs.GetByID(ctx, orgID)
-	if err != nil {
-		return nil
-	}
-	settings, err := models.ParseOrgSettings(org.Settings)
-	if err != nil {
-		return nil
-	}
-	return settings.BuilderPermissions.RequireReviewBeforePR
 }
 
 func runSandboxBootstrapCommands(ctx context.Context, provider SandboxProvider, sandbox *Sandbox, workDir string, commands []string, log zerolog.Logger) error {

--- a/internal/services/agent/orchestrator_internal_test.go
+++ b/internal/services/agent/orchestrator_internal_test.go
@@ -343,7 +343,7 @@ func (s *testInternalPRReadinessStore) MaterializeRepoConfigChecks(_ context.Con
 	return nil
 }
 
-func (s *testInternalPRReadinessStore) ResolvePolicy(context.Context, uuid.UUID, *uuid.UUID, *bool) (models.PRReadinessResolvedPolicy, error) {
+func (s *testInternalPRReadinessStore) ResolvePolicy(context.Context, uuid.UUID, *uuid.UUID) (models.PRReadinessResolvedPolicy, error) {
 	return models.PRReadinessResolvedPolicy{Config: models.DefaultPRReadinessPolicyConfig(), Source: "default"}, nil
 }
 

--- a/internal/worker/handlers.go
+++ b/internal/worker/handlers.go
@@ -9795,7 +9795,7 @@ func ensureBuilderReadinessFresh(ctx context.Context, stores *Stores, run models
 	if stores == nil || stores.PRReadiness == nil {
 		return fmt.Errorf("PR readiness policy is not configured")
 	}
-	resolved, err := stores.PRReadiness.ResolvePolicy(ctx, run.OrgID, run.RepositoryID, legacyPRReadinessBuilderSetting(ctx, stores, run.OrgID))
+	resolved, err := stores.PRReadiness.ResolvePolicy(ctx, run.OrgID, run.RepositoryID)
 	if err != nil {
 		return fmt.Errorf("resolve PR readiness policy: %w", err)
 	}
@@ -9934,7 +9934,7 @@ func newRunPRReadinessHandler(stores *Stores, services *Services, logger zerolog
 		}
 		policyConfig := models.DefaultPRReadinessPolicyConfig()
 		if stores.PRReadiness != nil {
-			resolved, err := stores.PRReadiness.ResolvePolicy(ctx, orgID, session.RepositoryID, legacyPRReadinessBuilderSetting(ctx, stores, orgID))
+			resolved, err := stores.PRReadiness.ResolvePolicy(ctx, orgID, session.RepositoryID)
 			if err != nil {
 				return fmt.Errorf("resolve PR readiness policy: %w", err)
 			}
@@ -9989,21 +9989,6 @@ func newRunPRReadinessHandler(stores *Stores, services *Services, logger zerolog
 		}
 		return nil
 	}
-}
-
-func legacyPRReadinessBuilderSetting(ctx context.Context, stores *Stores, orgID uuid.UUID) *bool {
-	if stores == nil || stores.Organizations == nil {
-		return nil
-	}
-	org, err := stores.Organizations.GetByID(ctx, orgID)
-	if err != nil {
-		return nil
-	}
-	settings, err := models.ParseOrgSettings(org.Settings)
-	if err != nil {
-		return nil
-	}
-	return settings.BuilderPermissions.RequireReviewBeforePR
 }
 
 type customReadinessLLMResponse struct {


### PR DESCRIPTION
## Summary

Fixes a PR readiness reliability gap where legacy builder review compatibility settings could silently override readiness enforcement. The workflow now consistently resolves readiness via repository override → org policy → default policy, so absent explicit readiness policy no longer depends on an outdated boolean.  

## Changes

- Removed the settings-page toggle and the `builder_permissions.require_review_before_pr` frontend type.
- Dropped backend parsing/model support for `BuilderPermissions` so legacy stored values are no longer interpreted.
- Simplified PR readiness policy resolution to ignore legacy compatibility entirely; default policy applies when no explicit readiness policy exists.
- Updated API/worker/orchestrator callers and tests to assert old stored JSON is ignored.

## Validation

- `go vet ./...`
- `go build ./...`
- `go test ./...`
- `npm run typecheck`
- `npm run lint`
- `npm run build`
- `npm test -- --run src/app/'(dashboard)'/settings/page.test.tsx`

[143.dev](https://143.dev) | [session e48c9b63](https://143.dev/sessions/e48c9b63-02c8-4868-abce-acbad9eeda79)

<!-- 143 readiness -->
**143 readiness:** not available for this revision.

Preview: https://143.dev/previews/github/assembledhq/143/pull/1539?launch=1