### PR TITLE
Cache Go builds and compile off the readiness hot path for previews

### DIFF
--- a/internal/models/preview.go
+++ b/internal/models/preview.go
@@ -634,6 +634,14 @@ type SessionPreviewPrewarmRun struct {
 
 // ServiceConfig defines a single service within a preview.
 type ServiceConfig struct {
+	// Build, when set, runs once during a dedicated build phase after the
+	// install phase and after build caches are restored, but before any
+	// service starts. It is the place to compile artifacts (e.g. `go build`)
+	// so the start Command can exec a prebuilt binary instead of compiling on
+	// the readiness-probe hot path. Build commands run in dependency order
+	// (support services first, primary last), share the service Env, and
+	// populate build caches that the post-build checkpoint persists.
+	Build   []string          `json:"build,omitempty"`
 	Command []string          `json:"command"`
 	Cwd     string            `json:"cwd,omitempty"`
 	Port    int               `json:"port"`

--- a/internal/services/preview/config.go
+++ b/internal/services/preview/config.go
@@ -230,7 +230,7 @@ func ParseNamedConfig(data []byte, name string) (*models.PreviewConfig, error) {
 		if svcName == "" {
 			svcName = "app"
 		}
-		ready := models.ReadinessProbe{HTTPPath: "/", TimeoutSeconds: 90}
+		ready := models.ReadinessProbe{HTTPPath: "/", TimeoutSeconds: 300}
 		if raw.Ready != nil {
 			ready = *raw.Ready
 		}
@@ -575,6 +575,11 @@ func ValidateConfigWithResourcePolicy(cfg *models.PreviewConfig, resourcePolicy 
 				if strings.TrimSpace(part) == "" {
 					errs = append(errs, fmt.Sprintf("service %q: command[%d] must not be blank", name, i))
 				}
+			}
+		}
+		for i, part := range svc.Build {
+			if strings.TrimSpace(part) == "" {
+				errs = append(errs, fmt.Sprintf("service %q: build[%d] must not be blank", name, i))
 			}
 		}
 		if svc.Port < MinPort || svc.Port > MaxPort {
@@ -984,6 +989,47 @@ func ResolvePreviewBuildCachePaths(install *models.PreviewInstallConfig) ([]stri
 	}
 	sort.Strings(paths)
 	return paths, len(paths) > 0
+}
+
+// ResolvePreviewBuildCacheHomePaths returns the effective HOME-rooted build
+// cache paths and whether home-rooted build caching is enabled. Unlike the
+// workdir build cache (which captures workspace-relative build-tool caches such
+// as Turborepo's), this captures compiled-artifact caches that live under $HOME
+// and are populated by a service's build step — most importantly Go's build
+// cache (.cache/go-build) and module cache (go/pkg/mod). These are home-rooted
+// because that is where Go places GOCACHE/GOMODCACHE by default in the sandbox,
+// matching the package-manager cache's "go" defaults. Both Go caches are
+// content/version-addressed, so a latest-wins blob shared across commits is
+// safe and degrades to a partial (incremental) build rather than wrong output.
+//
+// Inference is gated on a Go lockfile (go.mod/go.sum) being declared in
+// preview.install.lockfiles, the same signal the package-manager cache uses to
+// enable Go caching. Build caching must also not be explicitly disabled.
+func ResolvePreviewBuildCacheHomePaths(install *models.PreviewInstallConfig) ([]string, bool) {
+	if install == nil || len(install.Lockfiles) == 0 {
+		return nil, false
+	}
+	if install.Cache != nil && install.Cache.Enabled != nil && !*install.Cache.Enabled {
+		return nil, false
+	}
+	if install.Cache != nil && install.Cache.Build != nil && install.Cache.Build.Enabled != nil && !*install.Cache.Build.Enabled {
+		return nil, false
+	}
+	hasGoLockfile := false
+	for _, lockfile := range install.Lockfiles {
+		if manager, ok := inferPreviewPackageManagerFromLockfile(lockfile); ok && manager == "go" {
+			hasGoLockfile = true
+			break
+		}
+	}
+	if !hasGoLockfile {
+		return nil, false
+	}
+	// Both are home-rooted: GOCACHE defaults to ~/.cache/go-build (compiled
+	// objects — the dominant cold-compile cost) and GOMODCACHE to ~/go/pkg/mod
+	// (downloaded modules). Capturing both after the build phase means a launch
+	// that compiled cold still warms every subsequent launch.
+	return []string{".cache/go-build", "go/pkg/mod"}, true
 }
 
 // CacheRestorablePreviewInstallVerifyPaths returns the verify paths that can

--- a/internal/services/preview/config_test.go
+++ b/internal/services/preview/config_test.go
@@ -2152,6 +2152,78 @@ func TestResolvePreviewBuildCachePaths(t *testing.T) {
 	}
 }
 
+func TestResolvePreviewBuildCacheHomePaths(t *testing.T) {
+	t.Parallel()
+
+	disabled := false
+	tests := []struct {
+		name    string
+		install *models.PreviewInstallConfig
+		want    []string
+		enabled bool
+	}{
+		{
+			name:    "nil install disables home build caching",
+			install: nil,
+			enabled: false,
+		},
+		{
+			name: "no go lockfile infers no home paths",
+			install: &models.PreviewInstallConfig{
+				Lockfiles: []string{"package-lock.json"},
+			},
+			enabled: false,
+		},
+		{
+			name: "go.mod lockfile enables go build/module caches",
+			install: &models.PreviewInstallConfig{
+				Lockfiles: []string{"go.mod"},
+			},
+			want:    []string{".cache/go-build", "go/pkg/mod"},
+			enabled: true,
+		},
+		{
+			name: "go.sum alongside javascript lockfile still enables go caches",
+			install: &models.PreviewInstallConfig{
+				Lockfiles: []string{"package-lock.json", "go.sum"},
+			},
+			want:    []string{".cache/go-build", "go/pkg/mod"},
+			enabled: true,
+		},
+		{
+			name: "cache disabled flag disables home build caching",
+			install: &models.PreviewInstallConfig{
+				Lockfiles: []string{"go.mod"},
+				Cache:     &models.PreviewInstallCacheConfig{Enabled: &disabled},
+			},
+			enabled: false,
+		},
+		{
+			name: "build disabled flag disables home build caching",
+			install: &models.PreviewInstallConfig{
+				Lockfiles: []string{"go.mod"},
+				Cache: &models.PreviewInstallCacheConfig{
+					Build: &models.PreviewBuildCacheConfig{Enabled: &disabled},
+				},
+			},
+			enabled: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, enabled := ResolvePreviewBuildCacheHomePaths(tt.install)
+			require.Equal(t, tt.enabled, enabled, "enabled flag should match")
+			if tt.enabled {
+				require.Equal(t, tt.want, got, "effective home build cache paths should match")
+			} else {
+				require.Empty(t, got, "disabled home build caching should resolve no paths")
+			}
+		})
+	}
+}
+
 func TestCacheRestorablePreviewInstallVerifyPaths(t *testing.T) {
 	t.Parallel()
 

--- a/internal/services/preview/dependency_cache_keys.go
+++ b/internal/services/preview/dependency_cache_keys.go
@@ -20,6 +20,12 @@ const PreviewDependencyCacheRuntimeVersion = "preview-dependency-cache-v1"
 const PreviewPackageManagerCacheRuntimeVersion = "preview-package-manager-cache-v1"
 const PreviewBuildCacheRuntimeVersion = "preview-build-cache-v1"
 
+// PreviewBuildCacheHomeRuntimeVersion keys the HOME-rooted build cache (Go's
+// GOCACHE/GOMODCACHE). It is distinct from the workdir build cache version so
+// the two blobs occupy separate slots under the same build_artifact kind and
+// never overwrite each other.
+const PreviewBuildCacheHomeRuntimeVersion = "preview-build-cache-home-v1"
+
 type PreviewInstallLockfileKey struct {
 	Path   string `json:"path"`
 	SHA256 string `json:"sha256"`
@@ -164,6 +170,35 @@ func ComputePreviewBuildCacheKey(orgID, repoID uuid.UUID, configName, configDige
 	key, err := stableJSONSHA256(payload)
 	if err != nil {
 		return "", fmt.Errorf("marshal build cache key: %w", err)
+	}
+	return key, nil
+}
+
+// ComputePreviewBuildCacheHomeKey returns the latest-wins key for the
+// HOME-rooted build-artifact cache (Go's GOCACHE/GOMODCACHE). It mirrors
+// ComputePreviewBuildCacheKey but uses a distinct runtime version so the
+// home-rooted blob occupies its own slot, separate from the workdir build
+// blob, within the build_artifact cache kind.
+func ComputePreviewBuildCacheHomeKey(orgID, repoID uuid.UUID, configName, configDigest string, install *models.PreviewInstallConfig, effectivePaths []string) (string, error) {
+	payload := previewDependencyCachePlacementKey{
+		RuntimeVersion: PreviewBuildCacheHomeRuntimeVersion,
+		OrgID:          orgID,
+		RepoID:         repoID,
+		ConfigName:     strings.TrimSpace(configName),
+		ConfigDigest:   strings.TrimSpace(configDigest),
+		EffectivePaths: sortedNormalizedDependencyPaths(effectivePaths),
+	}
+	if install != nil {
+		payload.InstallCommand = append([]string(nil), install.Command...)
+		payload.InstallCwd = install.Cwd
+		if payload.InstallCwd == "" {
+			payload.InstallCwd = "."
+		}
+		payload.LockfilePaths = sortedNormalizedDependencyPaths(install.Lockfiles)
+	}
+	key, err := stableJSONSHA256(payload)
+	if err != nil {
+		return "", fmt.Errorf("marshal build cache home key: %w", err)
 	}
 	return key, nil
 }

--- a/internal/services/preview/dependency_cache_keys_test.go
+++ b/internal/services/preview/dependency_cache_keys_test.go
@@ -213,3 +213,40 @@ func TestComputePreviewBuildCacheKey_LatestWinsAcrossLockfileContents(t *testing
 	require.NoError(t, err, "dependency placement key should compute")
 	require.NotEqual(t, key1, placementKey, "build cache keys must not collide with dependency placement keys")
 }
+
+func TestComputePreviewBuildCacheHomeKey_DistinctSlot(t *testing.T) {
+	t.Parallel()
+
+	orgID := uuid.New()
+	repoID := uuid.New()
+	install := &models.PreviewInstallConfig{
+		Command:   []string{"npm", "ci"},
+		Lockfiles: []string{"package-lock.json", "go.mod"},
+	}
+	homePaths := []string{".cache/go-build", "go/pkg/mod"}
+	workdirPaths := []string{"node_modules/.cache/turbo", ".turbo/cache"}
+
+	homeKey, err := ComputePreviewBuildCacheHomeKey(orgID, repoID, "app", "digest-a", install, homePaths)
+	require.NoError(t, err, "home build cache key should compute")
+	require.NotEmpty(t, homeKey, "home build cache key should not be empty")
+
+	// Stable across recomputation: latest-wins like the workdir variant.
+	homeKey2, err := ComputePreviewBuildCacheHomeKey(orgID, repoID, "app", "digest-a", install, homePaths)
+	require.NoError(t, err, "home build cache key should recompute")
+	require.Equal(t, homeKey, homeKey2, "identical inputs should map to the same home slot")
+
+	// Must not collide with the workdir build cache slot even when all other
+	// inputs match: the distinct runtime version keeps the two blobs separate.
+	workdirKey, err := ComputePreviewBuildCacheKey(orgID, repoID, "app", "digest-a", install, workdirPaths)
+	require.NoError(t, err, "workdir build cache key should compute")
+	require.NotEqual(t, homeKey, workdirKey, "home and workdir build caches must occupy distinct slots")
+
+	// Even with identical effective paths, the runtime version differs.
+	workdirSamePaths, err := ComputePreviewBuildCacheKey(orgID, repoID, "app", "digest-a", install, homePaths)
+	require.NoError(t, err, "workdir build cache key should compute with home paths")
+	require.NotEqual(t, homeKey, workdirSamePaths, "distinct runtime version must separate the slots regardless of paths")
+
+	differentDigest, err := ComputePreviewBuildCacheHomeKey(orgID, repoID, "app", "digest-b", install, homePaths)
+	require.NoError(t, err, "home build cache key should compute for different config digest")
+	require.NotEqual(t, homeKey, differentDigest, "config changes should map to a different home slot")
+}

--- a/internal/services/preview/errors.go
+++ b/internal/services/preview/errors.go
@@ -43,6 +43,10 @@ var (
 	// preview command likely crashed at boot or never bound to its declared
 	// port.
 	ErrServiceNotReady = errors.New("preview service readiness probe failed")
+
+	// ErrServiceBuildFailed means a service's build command (preview build
+	// phase) exited non-zero or timed out before any service was started.
+	ErrServiceBuildFailed = errors.New("preview service build failed")
 )
 
 type CapacityScope string

--- a/internal/services/preview/providers/docker_preview.go
+++ b/internal/services/preview/providers/docker_preview.go
@@ -136,14 +136,27 @@ type previewState struct {
 
 	deferredCacheSaves []func()
 
-	// Build-artifact cache slot for this launch. The fields are written once
+	// Build-artifact cache slots for this launch. The fields are written once
 	// during the install phase (before service goroutines start) and read by
-	// the post-ready save, so they need no locking. buildCacheSaveOnce
-	// guarantees a single save regardless of which readiness path triggers it.
+	// the save paths, so they need no locking. The *SaveOnce guards guarantee a
+	// single save per set regardless of which path (checkpoint, post-ready, or
+	// failure flush) triggers it.
+	//
+	// The workdir set holds workspace-relative build-tool caches (e.g. turbo),
+	// populated while services boot, saved after readiness. The home set holds
+	// $HOME-rooted compiled-artifact caches (Go's GOCACHE/GOMODCACHE), populated
+	// by the build phase, saved synchronously at the build checkpoint so an
+	// expensive cold compile warms subsequent launches even if this one later
+	// fails its readiness probe.
 	buildCacheKey              string
 	buildCachePaths            []string
 	buildCacheRestoredChecksum string
 	buildCacheSaveOnce         sync.Once
+
+	buildCacheHomeKey              string
+	buildCacheHomePaths            []string
+	buildCacheHomeRestoredChecksum string
+	buildCacheHomeSaveOnce         sync.Once
 }
 
 // serviceState tracks a running application service process.
@@ -183,6 +196,19 @@ func (s *previewState) runDeferredCacheSaves() {
 // that the provider keeps so it can replay the tail to the observer when a
 // service exits non-zero.
 const serviceTailLines = 200
+
+// defaultServiceBuildTimeout bounds a single service's build command. Cold
+// monorepo compiles (e.g. a from-scratch `go build`) can run for several
+// minutes, so the default is generous; the build cache makes warm builds far
+// faster.
+const defaultServiceBuildTimeout = 30 * time.Minute
+
+// defaultServiceReadinessTimeout is how long a service has to pass its
+// readiness probe when the config does not set ready.timeout_seconds. With the
+// build phase compiling artifacts ahead of start, services should bind quickly;
+// the default still leaves generous headroom for first-request warmup. Configs
+// with unusually slow boots should set ready.timeout_seconds explicitly.
+const defaultServiceReadinessTimeout = 300 * time.Second
 
 // serviceExitTailLines is the number of trailing non-blank stdout/stderr
 // lines folded into the user-visible exit error from formatServiceExitError.
@@ -366,7 +392,23 @@ func (d *DockerPreviewProvider) StartPreview(ctx context.Context, sb *agent.Sand
 		// after install — install commands like `npm ci` wipe node_modules and
 		// would delete a tree restored earlier — and before services start so
 		// boot-time builds get cache hits. Failures degrade to a cold build.
+		// The home-rooted set (Go's GOCACHE/GOMODCACHE) is restored alongside so
+		// the build phase's `go build` is incremental.
 		d.restorePreviewBuildCache(ctx, state, cfg.Install, opts, observer)
+		d.restorePreviewBuildCacheHome(ctx, state, cfg.Install, opts, observer)
+
+		// Phase 4.6: Run per-service build commands. This is deliberately before
+		// runtime secret files (so build steps cannot read app secrets) and
+		// before services start (so compilation happens off the readiness-probe
+		// hot path). The home build cache is checkpointed synchronously here so
+		// an expensive cold compile warms subsequent launches even if this one
+		// later fails to become ready.
+		if err := d.runServiceBuilds(ctx, state, cfg, opts, observer); err != nil {
+			d.savePreviewBuildCacheHome(ctx, state, cfg.Install, opts, observer)
+			phaseErr = fmt.Errorf("%w: %v", preview.ErrServiceBuildFailed, err)
+			return phaseErr
+		}
+		d.savePreviewBuildCacheHome(ctx, state, cfg.Install, opts, observer)
 
 		// Phase 5: Write generated runtime secret files after install so install
 		// hooks cannot read preview-runtime app secrets.
@@ -420,6 +462,7 @@ func (d *DockerPreviewProvider) StartPreview(ctx context.Context, sb *agent.Sand
 		}
 		return nil
 	}(); err != nil {
+		d.flushBuildCachesBeforeCleanup(svcCtx, state, cfg.Install, opts, observer)
 		d.cleanupState(handle)
 		return nil, err
 	}
@@ -444,7 +487,7 @@ func (d *DockerPreviewProvider) StartPreview(ctx context.Context, sb *agent.Sand
 		if cfg.Progressive && len(cfg.Services) > 1 {
 			// Wait for primary first.
 			if primaryCfg, ok := cfg.Services[cfg.Primary]; ok {
-				timeout := 90 * time.Second
+				timeout := defaultServiceReadinessTimeout
 				if primaryCfg.Ready.TimeoutSeconds > 0 {
 					timeout = time.Duration(primaryCfg.Ready.TimeoutSeconds) * time.Second
 				}
@@ -478,7 +521,7 @@ func (d *DockerPreviewProvider) StartPreview(ctx context.Context, sb *agent.Sand
 					if name == cfg.Primary {
 						continue
 					}
-					timeout := 90 * time.Second
+					timeout := defaultServiceReadinessTimeout
 					if svcCfg.Ready.TimeoutSeconds > 0 {
 						timeout = time.Duration(svcCfg.Ready.TimeoutSeconds) * time.Second
 					}
@@ -509,7 +552,7 @@ func (d *DockerPreviewProvider) StartPreview(ctx context.Context, sb *agent.Sand
 
 		// Standard: wait for all services before reporting ready.
 		for name, svcCfg := range cfg.Services {
-			timeout := 90 * time.Second
+			timeout := defaultServiceReadinessTimeout
 			if svcCfg.Ready.TimeoutSeconds > 0 {
 				timeout = time.Duration(svcCfg.Ready.TimeoutSeconds) * time.Second
 			}
@@ -542,6 +585,11 @@ func (d *DockerPreviewProvider) StartPreview(ctx context.Context, sb *agent.Sand
 		d.savePreviewBuildCache(svcCtx, state, cfg.Install, opts, observer)
 		return nil
 	}(); err != nil {
+		// Readiness failed, but boot-time builds may have populated their
+		// caches (and a cold compile in the build phase certainly did). Persist
+		// them synchronously before the sandbox is torn down so the next launch
+		// is warm instead of repeating the work that just timed out.
+		d.flushBuildCachesBeforeCleanup(svcCtx, state, cfg.Install, opts, observer)
 		d.cleanupState(handle)
 		return nil, err
 	}
@@ -1635,61 +1683,167 @@ func (d *DockerPreviewProvider) restorePreviewBuildCache(ctx context.Context, st
 	d.logger.Info().Str("cache_key", cacheKey).Int64("size_bytes", hit.Entry.SizeBytes).Msg("preview build cache restored")
 }
 
-// savePreviewBuildCache archives the build-artifact paths once services have
-// reported ready — the only point in a launch where boot-time builds (turbo
-// and friends) have populated their caches. The key is latest-wins: each save
-// overwrites the same slot, and the build tool's own content hashing makes a
-// stale blob degrade to partial hits rather than wrong output. SkipIfChecksum
-// avoids re-uploading when the tree is byte-identical to what was restored.
+// restorePreviewBuildCacheHome restores the home-rooted build-artifact blob
+// (Go's GOCACHE/GOMODCACHE) into $HOME after install and before the build
+// phase, so `go build` gets incremental cache hits instead of recompiling the
+// world. It mirrors restorePreviewBuildCache but targets the home root and a
+// distinct cache slot. The key/paths are recorded on state even on a miss so
+// the build checkpoint can save the freshly-populated cache. Failures degrade
+// to a cold build.
+func (d *DockerPreviewProvider) restorePreviewBuildCacheHome(ctx context.Context, state *previewState, install *models.PreviewInstallConfig, opts preview.StartPreviewOptions, observer preview.ServiceObserver) {
+	pathCache, hasPathCache := d.dependencyCache.(preview.PreviewPathCache)
+	if d.dependencyCache == nil || !hasPathCache || opts.OrgID == uuid.Nil || opts.RepositoryID == uuid.Nil {
+		return
+	}
+	paths, enabled := preview.ResolvePreviewBuildCacheHomePaths(install)
+	if !enabled {
+		return
+	}
+	configDigest := opts.ConfigDigest
+	if configDigest == "" {
+		if digest, digestErr := preview.ComputePreviewConfigDigest(state.config); digestErr == nil {
+			configDigest = digest
+		}
+	}
+	cacheKey, err := preview.ComputePreviewBuildCacheHomeKey(opts.OrgID, opts.RepositoryID, state.config.Name, configDigest, install, paths)
+	if err != nil {
+		d.logger.Warn().Err(err).Msg("preview home build cache key unavailable; continuing cold")
+		return
+	}
+	state.buildCacheHomeKey = cacheKey
+	state.buildCacheHomePaths = paths
+
+	lookupStarted := time.Now()
+	notifyPhaseStart(observer, "build_cache_home_lookup")
+	hit, findErr := pathCache.FindPathCache(ctx, opts.OrgID, opts.RepositoryID, models.PreviewCacheKindBuildArtifact, cacheKey)
+	notifyPhaseEnd(observer, "build_cache_home_lookup", findErr)
+	metrics.RecordSessionPreviewPhaseDuration(ctx, opts.OrgID.String(), "build_cache_home_lookup", time.Since(lookupStarted))
+	if findErr != nil {
+		d.logger.Warn().Err(findErr).Str("cache_key", cacheKey).Msg("preview home build cache lookup failed; continuing cold")
+		return
+	}
+	if hit == nil {
+		notifyBuildCacheRestore(observer, "miss", cacheKey, 0, nil)
+		metrics.RecordSessionBuildCacheRestore(ctx, opts.OrgID.String(), "miss", time.Since(lookupStarted))
+		d.logger.Info().Str("cache_key", cacheKey).Msg("preview home build cache miss")
+		return
+	}
+	restoreStarted := time.Now()
+	notifyPhaseStart(observer, "build_cache_home_restore")
+	restoreErr := pathCache.RestorePathCache(ctx, state.sandbox, hit, models.PreviewCacheRootHomeDir)
+	notifyPhaseEnd(observer, "build_cache_home_restore", restoreErr)
+	metrics.RecordSessionPreviewPhaseDuration(ctx, opts.OrgID.String(), "build_cache_home_restore", time.Since(restoreStarted))
+	if restoreErr != nil {
+		d.logger.Warn().Err(restoreErr).Str("cache_key", cacheKey).Msg("preview home build cache restore failed; continuing cold")
+		return
+	}
+	var restoredMeta preview.DependencyCacheMetadata
+	if err := json.Unmarshal(hit.Entry.Metadata, &restoredMeta); err == nil {
+		state.buildCacheHomeRestoredChecksum = restoredMeta.ChecksumSHA256
+	}
+	notifyBuildCacheRestore(observer, "restored", cacheKey, hit.Entry.SizeBytes, nil)
+	metrics.RecordSessionBuildCacheRestore(ctx, opts.OrgID.String(), "restored", time.Since(restoreStarted))
+	d.logger.Info().Str("cache_key", cacheKey).Int64("size_bytes", hit.Entry.SizeBytes).Msg("preview home build cache restored")
+}
+
+// saveBuildCacheSet synchronously archives one build-artifact cache set (either
+// the workdir or home root) under a latest-wins key: each save overwrites the
+// same slot, and the build tool's own content hashing makes a stale blob
+// degrade to partial hits rather than wrong output. SkipIfChecksum avoids
+// re-uploading when the tree is byte-identical to what was restored. It is safe
+// to call from a goroutine; idempotency across call sites is the caller's job
+// (via the per-set sync.Once).
+func (d *DockerPreviewProvider) saveBuildCacheSet(ctx context.Context, state *previewState, opts preview.StartPreviewOptions, observer preview.ServiceObserver, install *models.PreviewInstallConfig, root models.PreviewCacheRoot, cacheKey string, paths []string, skipIfChecksum string) {
+	pathCache, hasPathCache := d.dependencyCache.(preview.PreviewPathCache)
+	if d.dependencyCache == nil || !hasPathCache || install == nil || cacheKey == "" || len(paths) == 0 {
+		notifyBuildCacheSave(observer, "skipped", cacheKey, 0, nil)
+		if opts.OrgID != uuid.Nil {
+			metrics.RecordSessionBuildCacheSave(context.Background(), opts.OrgID.String(), "skipped", 0)
+		}
+		return
+	}
+	metadata := preview.DependencyCacheMetadata{
+		Kind:           models.PreviewCacheKindBuildArtifact,
+		Root:           root,
+		OrgID:          opts.OrgID,
+		RepoID:         opts.RepositoryID,
+		SessionID:      opts.SessionID,
+		PlacementKey:   cacheKey,
+		InstallCommand: append([]string(nil), install.Command...),
+		EffectivePaths: append([]string(nil), paths...),
+	}
+	saveCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 10*time.Minute)
+	defer cancel()
+	started := time.Now()
+	result, err := pathCache.SavePathCache(saveCtx, state.sandbox, preview.PreviewPathCacheSaveSpec{
+		Kind:           models.PreviewCacheKindBuildArtifact,
+		Root:           root,
+		CacheKey:       cacheKey,
+		Paths:          paths,
+		Metadata:       metadata,
+		SkipIfChecksum: skipIfChecksum,
+	})
+	switch {
+	case err != nil:
+		notifyBuildCacheSave(observer, "save_failed", cacheKey, 0, err)
+		metrics.RecordSessionBuildCacheSave(saveCtx, opts.OrgID.String(), "save_failed", time.Since(started))
+		d.logger.Warn().Err(err).Str("cache_key", cacheKey).Msg("preview build cache save failed")
+	case result.Unchanged:
+		notifyBuildCacheSave(observer, "unchanged", cacheKey, result.SizeBytes, nil)
+		metrics.RecordSessionBuildCacheSave(saveCtx, opts.OrgID.String(), "unchanged", time.Since(started))
+	case result.SizeBytes == 0:
+		notifyBuildCacheSave(observer, "skipped_no_paths", cacheKey, 0, nil)
+		metrics.RecordSessionBuildCacheSave(saveCtx, opts.OrgID.String(), "skipped_no_paths", time.Since(started))
+	default:
+		notifyBuildCacheSave(observer, "saved", cacheKey, result.SizeBytes, nil)
+		metrics.RecordSessionBuildCacheSave(saveCtx, opts.OrgID.String(), "saved", time.Since(started))
+		d.logger.Info().Str("cache_key", cacheKey).Int64("size_bytes", result.SizeBytes).Msg("preview build cache saved")
+	}
+}
+
+// savePreviewBuildCache archives the workdir build-artifact paths (turbo and
+// friends) once services have reported ready — the point in a launch where
+// boot-time builds have populated their workspace-relative caches. The save
+// runs asynchronously so it does not delay reporting the ready preview.
 func (d *DockerPreviewProvider) savePreviewBuildCache(ctx context.Context, state *previewState, install *models.PreviewInstallConfig, opts preview.StartPreviewOptions, observer preview.ServiceObserver) {
 	state.buildCacheSaveOnce.Do(func() {
-		pathCache, hasPathCache := d.dependencyCache.(preview.PreviewPathCache)
-		if d.dependencyCache == nil || !hasPathCache || install == nil || state.buildCacheKey == "" || len(state.buildCachePaths) == 0 {
-			notifyBuildCacheSave(observer, "skipped", state.buildCacheKey, 0, nil)
-			if opts.OrgID != uuid.Nil {
-				metrics.RecordSessionBuildCacheSave(context.Background(), opts.OrgID.String(), "skipped", 0)
-			}
+		go d.saveBuildCacheSet(ctx, state, opts, observer, install, models.PreviewCacheRootWorkDir, state.buildCacheKey, state.buildCachePaths, state.buildCacheRestoredChecksum)
+	})
+}
+
+// savePreviewBuildCacheHome archives the home-rooted build-artifact paths (Go's
+// GOCACHE/GOMODCACHE) at the build checkpoint. Unlike the workdir save this is
+// synchronous: it is the only point at which a (potentially multi-minute) cold
+// compile is durably captured, and running it before the build phase returns
+// guarantees the cache survives even if the launch later fails its readiness
+// probe or the sandbox is torn down. SkipIfChecksum keeps a warm, incremental
+// build's save to a near no-op.
+func (d *DockerPreviewProvider) savePreviewBuildCacheHome(ctx context.Context, state *previewState, install *models.PreviewInstallConfig, opts preview.StartPreviewOptions, observer preview.ServiceObserver) {
+	state.buildCacheHomeSaveOnce.Do(func() {
+		// No home build cache configured for this launch (no Go lockfile): stay
+		// silent rather than emitting a misleading "skipped" save event.
+		if state.buildCacheHomeKey == "" {
 			return
 		}
-		metadata := preview.DependencyCacheMetadata{
-			Kind:           models.PreviewCacheKindBuildArtifact,
-			Root:           models.PreviewCacheRootWorkDir,
-			OrgID:          opts.OrgID,
-			RepoID:         opts.RepositoryID,
-			SessionID:      opts.SessionID,
-			PlacementKey:   state.buildCacheKey,
-			InstallCommand: append([]string(nil), install.Command...),
-			EffectivePaths: append([]string(nil), state.buildCachePaths...),
+		d.saveBuildCacheSet(ctx, state, opts, observer, install, models.PreviewCacheRootHomeDir, state.buildCacheHomeKey, state.buildCacheHomePaths, state.buildCacheHomeRestoredChecksum)
+	})
+}
+
+// flushBuildCachesBeforeCleanup synchronously persists any not-yet-saved build
+// caches on a failure path, before the sandbox is torn down. The home set is
+// usually already saved at the build checkpoint (its sync.Once short-circuits
+// here); the workdir set, which would otherwise only save after readiness, is
+// captured here so a launch that compiled and booted but missed its readiness
+// deadline still warms the next launch instead of repeating cold work.
+func (d *DockerPreviewProvider) flushBuildCachesBeforeCleanup(ctx context.Context, state *previewState, install *models.PreviewInstallConfig, opts preview.StartPreviewOptions, observer preview.ServiceObserver) {
+	state.buildCacheHomeSaveOnce.Do(func() {
+		if state.buildCacheHomeKey == "" {
+			return
 		}
-		go func() {
-			saveCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 10*time.Minute)
-			defer cancel()
-			started := time.Now()
-			result, err := pathCache.SavePathCache(saveCtx, state.sandbox, preview.PreviewPathCacheSaveSpec{
-				Kind:           models.PreviewCacheKindBuildArtifact,
-				Root:           models.PreviewCacheRootWorkDir,
-				CacheKey:       state.buildCacheKey,
-				Paths:          state.buildCachePaths,
-				Metadata:       metadata,
-				SkipIfChecksum: state.buildCacheRestoredChecksum,
-			})
-			switch {
-			case err != nil:
-				notifyBuildCacheSave(observer, "save_failed", state.buildCacheKey, 0, err)
-				metrics.RecordSessionBuildCacheSave(saveCtx, opts.OrgID.String(), "save_failed", time.Since(started))
-				d.logger.Warn().Err(err).Str("cache_key", state.buildCacheKey).Msg("preview build cache save failed")
-			case result.Unchanged:
-				notifyBuildCacheSave(observer, "unchanged", state.buildCacheKey, result.SizeBytes, nil)
-				metrics.RecordSessionBuildCacheSave(saveCtx, opts.OrgID.String(), "unchanged", time.Since(started))
-			case result.SizeBytes == 0:
-				notifyBuildCacheSave(observer, "skipped_no_paths", state.buildCacheKey, 0, nil)
-				metrics.RecordSessionBuildCacheSave(saveCtx, opts.OrgID.String(), "skipped_no_paths", time.Since(started))
-			default:
-				notifyBuildCacheSave(observer, "saved", state.buildCacheKey, result.SizeBytes, nil)
-				metrics.RecordSessionBuildCacheSave(saveCtx, opts.OrgID.String(), "saved", time.Since(started))
-				d.logger.Info().Str("cache_key", state.buildCacheKey).Int64("size_bytes", result.SizeBytes).Msg("preview build cache saved")
-			}
-		}()
+		d.saveBuildCacheSet(ctx, state, opts, observer, install, models.PreviewCacheRootHomeDir, state.buildCacheHomeKey, state.buildCacheHomePaths, state.buildCacheHomeRestoredChecksum)
+	})
+	state.buildCacheSaveOnce.Do(func() {
+		d.saveBuildCacheSet(ctx, state, opts, observer, install, models.PreviewCacheRootWorkDir, state.buildCacheKey, state.buildCachePaths, state.buildCacheRestoredChecksum)
 	})
 }
 
@@ -2083,6 +2237,104 @@ func truncatedTail(outputTail []string, maxLines, maxRunes int) string {
 		}
 	}
 	return joined
+}
+
+// previewServiceBuildOrder returns service names with the primary last, so
+// support services build before the primary (which may depend on their
+// artifacts), matching the start ordering. Support services are sorted for
+// deterministic, reproducible build order.
+func previewServiceBuildOrder(cfg *models.PreviewConfig) []string {
+	names := make([]string, 0, len(cfg.Services))
+	for name := range cfg.Services {
+		if name == cfg.Primary {
+			continue
+		}
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	if _, ok := cfg.Services[cfg.Primary]; ok {
+		names = append(names, cfg.Primary)
+	}
+	return names
+}
+
+// runServiceBuilds runs each service's optional Build command to completion,
+// in dependency order, before any service starts. It is the place to compile
+// artifacts (e.g. `go build`) so the start command can exec a prebuilt binary
+// off the readiness-probe hot path. Build commands run with the service's own
+// Env (no injected platform credentials or runtime secrets) so build steps
+// cannot read app secrets. A non-zero exit or timeout fails the launch.
+func (d *DockerPreviewProvider) runServiceBuilds(ctx context.Context, state *previewState, cfg *models.PreviewConfig, opts preview.StartPreviewOptions, observer preview.ServiceObserver) error {
+	hasBuild := false
+	for _, svcCfg := range cfg.Services {
+		if len(svcCfg.Build) > 0 {
+			hasBuild = true
+			break
+		}
+	}
+	if !hasBuild {
+		return nil
+	}
+
+	notifyPhaseStart(observer, "service_build")
+	phaseStarted := time.Now()
+	for _, name := range previewServiceBuildOrder(cfg) {
+		svcCfg := cfg.Services[name]
+		if len(svcCfg.Build) == 0 {
+			continue
+		}
+
+		var cmdParts []string
+		if svcCfg.Cwd != "" {
+			cmdParts = append(cmdParts, "cd", shellEscape(svcCfg.Cwd), "&&")
+		}
+		envKeys := make([]string, 0, len(svcCfg.Env))
+		for k := range svcCfg.Env {
+			envKeys = append(envKeys, k)
+		}
+		sort.Strings(envKeys)
+		for _, k := range envKeys {
+			cmdParts = append(cmdParts, fmt.Sprintf("%s=%s", k, shellEscape(svcCfg.Env[k])))
+		}
+		escapedCmd := make([]string, len(svcCfg.Build))
+		for i, c := range svcCfg.Build {
+			escapedCmd[i] = shellEscape(c)
+		}
+		cmdParts = append(cmdParts, strings.Join(escapedCmd, " "))
+		cmd := strings.Join(cmdParts, " ")
+
+		outputTail := make([]string, 0, serviceTailLines)
+		appendTail := func(line []byte) {
+			text := string(line)
+			if len(outputTail) >= serviceTailLines {
+				outputTail = outputTail[1:]
+			}
+			outputTail = append(outputTail, text)
+			notifyServiceOutput(observer, name, text)
+			d.logger.Debug().Str("service", name).Str("output", text).Msg("service build output")
+		}
+		stderrSplitter := &previewLineSplitter{onLine: appendTail}
+		buildCtx, cancel := context.WithTimeout(ctx, defaultServiceBuildTimeout)
+		exitCode, err := d.executor.ExecStream(buildCtx, state.sandbox, cmd, appendTail, stderrSplitter)
+		stderrSplitter.flush()
+		cancel()
+		if err != nil || exitCode != 0 {
+			var errMsg string
+			if err != nil {
+				errMsg = fmt.Sprintf("service %q build: %v", name, err)
+			} else {
+				errMsg = fmt.Sprintf("service %q build: %s", name, formatServiceExitError(exitCode, outputTail))
+			}
+			notifyServiceFailed(observer, name, errMsg, append([]string(nil), outputTail...))
+			notifyPhaseEnd(observer, "service_build", fmt.Errorf("%s", errMsg))
+			metrics.RecordSessionPreviewPhaseDuration(ctx, opts.OrgID.String(), "service_build", time.Since(phaseStarted))
+			return fmt.Errorf("%s", errMsg)
+		}
+		d.logger.Info().Str("service", name).Msg("service build completed")
+	}
+	notifyPhaseEnd(observer, "service_build", nil)
+	metrics.RecordSessionPreviewPhaseDuration(ctx, opts.OrgID.String(), "service_build", time.Since(phaseStarted))
+	return nil
 }
 
 func (d *DockerPreviewProvider) startService(

--- a/internal/services/preview/providers/docker_preview_test.go
+++ b/internal/services/preview/providers/docker_preview_test.go
@@ -3132,3 +3132,25 @@ func TestStartPreview_DependencyCacheSaveExcludesBuildCachePaths(t *testing.T) {
 	close(release)
 	require.NoError(t, d.StopPreview(context.Background(), handle.Handle), "StopPreview should clean up the started preview")
 }
+
+func TestPreviewServiceBuildOrder(t *testing.T) {
+	t.Parallel()
+
+	cfg := &models.PreviewConfig{
+		Primary: "webserver",
+		Services: map[string]models.ServiceConfig{
+			"webserver": {Command: []string{"./webserver"}},
+			"worker":    {Command: []string{"./worker"}},
+			"frontend":  {Command: []string{"npm", "start"}},
+		},
+	}
+
+	order := previewServiceBuildOrder(cfg)
+	require.Equal(t, []string{"frontend", "worker", "webserver"}, order,
+		"support services build first in sorted order, primary last")
+
+	// Missing primary entry: only support services, still sorted.
+	cfg.Primary = "absent"
+	require.Equal(t, []string{"frontend", "webserver", "worker"}, previewServiceBuildOrder(cfg),
+		"absent primary should not be appended")
+}


### PR DESCRIPTION
## Problem

Branch previews of large Go apps (e.g. Assembled) recompiled the entire module graph at **service start**, on every launch. Traced from a real launch (target `bbab2aad`, branch `wangjohn/preview-seeded-postgres`):

- The build cache only knew about **workdir build-tool caches** (turbo) — it had no concept of Go. `GOCACHE`/`GOMODCACHE` were never persisted, so the webserver re-downloaded modules (~46s) and recompiled the monorepo (~5.5 min) at boot.
- The build cache was saved **only after readiness passed**. A cold compile blew the 7-minute readiness budget (bound `:3000` ~1s after the deadline), so the launch failed and the cache **never warmed** — every retry was cold. A chicken-and-egg loop.

## Changes

- **`ServiceConfig.Build []string`** — a per-service build phase (4.6) runs after build caches restore and before services start, with the service's own `Env` (no injected platform secrets), support services first then primary. The start command can now exec a **prebuilt binary** instead of compiling on the readiness hot path. New `ErrServiceBuildFailed`.
- **Go-aware home-rooted build cache** — when a `go.mod`/`go.sum` lockfile is declared, `ResolvePreviewBuildCacheHomePaths` captures Go's `GOCACHE` (`.cache/go-build`) and `GOMODCACHE` (`go/pkg/mod`) under `$HOME` as a **distinct `build_artifact` slot** (`ComputePreviewBuildCacheHomeKey`, separate runtime version), so `go build` is incremental across launches. Symmetric with the existing package-manager `go` cache.
- **Save-on-checkpoint** — the home cache is saved **synchronously at the build checkpoint** (and on build failure); `flushBuildCachesBeforeCleanup` persists both sets on start/readiness failure **before the sandbox is torn down**. A launch that compiled but missed its readiness deadline now warms the next launch instead of repeating cold work. This breaks the chicken-and-egg loop.
- **Readiness default** raised 90s → 300s.

## Tests

- Unit coverage: `ResolvePreviewBuildCacheHomePaths` (go-lockfile gating, disable flags), `ComputePreviewBuildCacheHomeKey` (distinct slot vs workdir), `previewServiceBuildOrder`.
- `go test ./internal/services/preview/...` ✅ · `make lint` → 0 issues ✅

## Follow-up (separate, app repo)

The matching `.143/config.json` wiring for the Assembled app — declare `go.mod` as an install lockfile and split the webserver into a cached `build` step + prebuilt-binary `command` — lives in the app repo and is applied separately. Without it, this PR is a no-op for that config (the home cache only activates when a Go lockfile is declared).

🤖 Generated with [Claude Code](https://claude.com/claude-code)