### PR TITLE
Fix session overview readiness card layout and running review actions

### DIFF
--- a/frontend/src/app/(dashboard)/sessions/[id]/page-overview.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/page-overview.test.tsx
@@ -239,6 +239,52 @@ describe('SessionDetailPage overview and review loop', () => {
     expect(within(screen.getByLabelText('Session detail actions')).queryByRole('button', { name: 'Review' })).not.toBeInTheDocument();
   });
 
+  it('keeps the Overview readiness card header stacked inside the constrained detail panel', async () => {
+    server.use(
+      http.get('/api/v1/sessions/:id', () => {
+        return HttpResponse.json({
+          data: {
+            ...mockSessions[1],
+            status: 'completed',
+            snapshot_key: 'snapshot-running-review',
+            sandbox_state: 'snapshotted',
+            diff: '--- a/file.ts\n+++ b/file.ts\n@@ -1 +1 @@\n-old\n+new',
+            diff_stats: { added: 1, removed: 1, files_changed: 1 },
+          },
+        } satisfies SingleResponse<Session>);
+      }),
+      http.get('/api/v1/sessions/:id/review-loops', () => {
+        return HttpResponse.json({
+          data: [{
+            id: 'review-loop-running',
+            org_id: 'org-1',
+            session_id: 'session-98765432-abcd-ef01',
+            status: 'running',
+            source: 'manual',
+            agent_type: 'claude_code',
+            max_passes: 2,
+            fix_mode: 'minimal',
+            completed_passes: 0,
+            review_required: false,
+            started_at: '2026-02-17T07:12:00Z',
+          }] as SessionReviewLoop[],
+          meta: {},
+        } satisfies ListResponse<SessionReviewLoop>);
+      }),
+    );
+
+    renderWithProviders(<SessionDetailContent id="session-98765432-abcd-ef01" />);
+
+    const reviewStatus = await screen.findByText('Fixing with Claude Code');
+    const header = reviewStatus.closest('.flex.flex-col.gap-3');
+
+    expect(header).not.toBeNull();
+    expect(header?.className).not.toContain('lg:flex-row');
+    expect(header?.className).not.toContain('lg:justify-between');
+    expect(screen.queryByRole('button', { name: 'Check readiness' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Review & fix' })).not.toBeInTheDocument();
+  });
+
   it('moves the review action into PR health after a PR exists when a snapshot is available', async () => {
     server.use(
       http.get('/api/v1/sessions/:id', () => {

--- a/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
@@ -6332,7 +6332,7 @@ export function SessionDetailContent({ id }: { id: string }) {
           {canManageSession && !hasPR && hasSessionChanges ? (
             <Card className="border-border/60">
               <CardContent className="space-y-3 p-4">
-                <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
+                <div className="flex flex-col gap-3">
                   <div className="flex min-w-0 flex-1 items-center gap-2">
                     <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-muted text-muted-foreground">
                       {reviewLoopRunning || readinessRunning ? (
@@ -6354,42 +6354,44 @@ export function SessionDetailContent({ id }: { id: string }) {
                       </p>
                     </div>
                   </div>
-                  <div className="flex shrink-0 flex-col gap-2 sm:flex-row sm:items-center">
-                    <Button
-                      type="button"
-                      variant="outline"
-                      size="sm"
-                      className="w-full gap-1.5 sm:w-auto"
-                      disabled={readinessCheckDisabled}
-                      onClick={() => runReadinessMutation.mutate()}
-                    >
-                      {readinessRunning ? (
-                        <Loader2 className="h-3.5 w-3.5 animate-spin" />
-                      ) : (
-                        <RefreshCw className="h-3.5 w-3.5" />
-                      )}
-                      {latestReadiness ? "Re-check" : "Check readiness"}
-                    </Button>
-                    {canUseNativeReviewLoop ? (
-                      <DisabledTooltip disabled={reviewActionDisabled} content={reviewActionDisabledReason}>
-                        <Button
-                          type="button"
-                          size="sm"
-                          className="w-full gap-1.5 sm:w-auto"
-                          disabled={reviewActionDisabled}
-                          title={reviewActionDisabledReason}
-                          onClick={() => setReviewConfigOpen(true)}
-                        >
-                          {startReviewLoopMutation.isPending || reviewLoopRunning ? (
-                            <Loader2 className="h-3.5 w-3.5 animate-spin" />
-                          ) : (
-                            <Settings2 className="h-3.5 w-3.5" />
-                          )}
-                          Review &amp; fix
-                        </Button>
-                      </DisabledTooltip>
-                    ) : null}
-                  </div>
+                  {!reviewLoopRunning ? (
+                    <div className="flex shrink-0 flex-col gap-2 sm:flex-row sm:items-center">
+                      <Button
+                        type="button"
+                        variant="outline"
+                        size="sm"
+                        className="w-full gap-1.5 sm:w-auto"
+                        disabled={readinessCheckDisabled}
+                        onClick={() => runReadinessMutation.mutate()}
+                      >
+                        {readinessRunning ? (
+                          <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                        ) : (
+                          <RefreshCw className="h-3.5 w-3.5" />
+                        )}
+                        {latestReadiness ? "Re-check" : "Check readiness"}
+                      </Button>
+                      {canUseNativeReviewLoop ? (
+                        <DisabledTooltip disabled={reviewActionDisabled} content={reviewActionDisabledReason}>
+                          <Button
+                            type="button"
+                            size="sm"
+                            className="w-full gap-1.5 sm:w-auto"
+                            disabled={reviewActionDisabled}
+                            title={reviewActionDisabledReason}
+                            onClick={() => setReviewConfigOpen(true)}
+                          >
+                            {startReviewLoopMutation.isPending ? (
+                              <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                            ) : (
+                              <Settings2 className="h-3.5 w-3.5" />
+                            )}
+                            Review &amp; fix
+                          </Button>
+                        </DisabledTooltip>
+                      ) : null}
+                    </div>
+                  ) : null}
                 </div>
                 {readinessRunning ? (
                   <div className="space-y-1 text-xs text-muted-foreground">


### PR DESCRIPTION
## Summary

Fixes a session-detail “Overview readiness” card that was rendered with a wide, horizontal layout even inside the constrained session detail panel, causing a squeezed/odd appearance. Also removes readiness/“Review & fix” actions while the review loop is already running so the UI shows a single, scannable progress state instead of competing controls.

This change adjusts the card’s layout classes to keep the header vertically stacked in the panel and updates the conditional rendering so that, during an active review loop, we only show the progress subtitle (e.g., “Fixing with Claude Code” / pass status) and no readiness/review action buttons.

## Changes

- Restack the overview readiness card header to remain vertically composed by removing the `lg:flex-row`/`lg:justify-between` behavior in `session-detail-content.tsx`.
- When a review loop is running, suppress “Check readiness” and the “Review & fix” button to reduce visual noise and state ambiguity.
- Add/extend a regression test to assert the header layout constraints and the absence of readiness/review buttons during the running state.

## Validation

- `frontend/src/app/(dashboard)/sessions/[id]/page-overview.test.tsx` regression test added/updated and verified
- `npm run typecheck`
- `npm run lint`
- `npm run build`

[143.dev](https://143.dev) | [session 367a5cea](https://143.dev/sessions/367a5cea-77ac-4750-a9c0-8e862bc43ee0)

<!-- 143 readiness -->
**143 readiness:** not available for this revision.

Preview: https://143.dev/previews/github/assembledhq/143/pull/1541?launch=1