### PR TITLE
Remove Evals link from Settings sidebar navigation

### DIFF
--- a/frontend/src/components/sidebar-settings-section.test.tsx
+++ b/frontend/src/components/sidebar-settings-section.test.tsx
@@ -64,11 +64,11 @@ describe("SidebarSettingsSection", () => {
       "API keys",
       "Usage",
       "Audit log",
-      "Evals",
     ]) {
       expect(screen.getByText(label)).toBeInTheDocument();
     }
 
+    expect(screen.queryByText("Evals")).not.toBeInTheDocument();
     expect(screen.queryByText("PLATFORM")).not.toBeInTheDocument();
     expect(screen.queryByText("LLM")).not.toBeInTheDocument();
     expect(screen.queryByText("Runtime")).not.toBeInTheDocument();
@@ -82,7 +82,6 @@ describe("SidebarSettingsSection", () => {
 
     for (const visible of [
       "Account",
-      "Evals",
       "Team",
       "Integrations",
       "Coding agents",
@@ -91,6 +90,7 @@ describe("SidebarSettingsSection", () => {
     }
 
     for (const hidden of [
+      "Evals",
       "App LLM",
       "Autopilot",
       "Sandboxes",

--- a/frontend/src/components/sidebar-settings-section.tsx
+++ b/frontend/src/components/sidebar-settings-section.tsx
@@ -10,7 +10,6 @@ import {
   Sparkles,
   Target,
   Activity,
-  FlaskConical,
   Users,
   ScrollText,
   BarChart3,
@@ -83,7 +82,6 @@ const settingsGroups: SettingsGroup[] = [
     items: [
       { label: "Usage", icon: BarChart3, href: "/settings/usage", adminOnly: true },
       { label: "Audit log", icon: ScrollText, href: "/settings/audit-log", adminOnly: true },
-      { label: "Evals", icon: FlaskConical, href: "/settings/evals", hideForRoles: ["viewer", "builder"] },
     ],
   },
 ];


### PR DESCRIPTION
## Summary

The Settings sidebar currently shows an “Evals” navigation entry even though the page isn’t ready for general use, creating a broken/unclear user workflow for non-admin roles. This change removes the Evals link from the public Settings navigation while keeping the underlying `/settings/evals` route available by direct URL. Updated the sidebar tests to ensure the link is no longer rendered for admins or members.

## Changes

- Removed the “Evals” item from the Settings navigation group in `sidebar-settings-section.tsx`.
- Updated `sidebar-settings-section.test.tsx` to assert “Evals” is not present in the rendered sidebar for admin/member scenarios.

## Validation

- `npm test -- --run src/components/sidebar-settings-section.test.tsx`
- `npm run typecheck`
- `npm run lint`
- `npm run build`

[143.dev](https://143.dev) | [session 29a83859](https://143.dev/sessions/29a83859-c6c2-4ff9-bf2b-da602f47471f)

<!-- 143 readiness -->
**143 readiness:** not available for this revision.

Preview: https://143.dev/previews/github/assembledhq/143/pull/1543?launch=1