### PR TITLE
Preview build cache: keep the Go cache off the hot path + dedup/pin fixes

### DIFF
--- a/internal/services/preview/config.go
+++ b/internal/services/preview/config.go
@@ -230,7 +230,7 @@ func ParseNamedConfig(data []byte, name string) (*models.PreviewConfig, error) {
 		if svcName == "" {
 			svcName = "app"
 		}
-		ready := models.ReadinessProbe{HTTPPath: "/", TimeoutSeconds: 300}
+		ready := models.ReadinessProbe{HTTPPath: "/", TimeoutSeconds: 180}
 		if raw.Ready != nil {
 			ready = *raw.Ready
 		}
@@ -1005,6 +1005,14 @@ func ResolvePreviewBuildCachePaths(install *models.PreviewInstallConfig) ([]stri
 // Inference is gated on a Go lockfile (go.mod/go.sum) being declared in
 // preview.install.lockfiles, the same signal the package-manager cache uses to
 // enable Go caching. Build caching must also not be explicitly disabled.
+//
+// To avoid double-caching the module cache, go/pkg/mod is dropped from the home
+// set when the install *command* already runs go (e.g. `go mod download`): in
+// that case the package-manager cache captures the modules post-install, so the
+// home set only needs the compiled-object cache (.cache/go-build) that the build
+// phase uniquely warms. When install does not run go (the common case: a JS
+// install that happens to sit beside a go.mod), the build phase is the only
+// thing that downloads modules, so the home set owns go/pkg/mod too.
 func ResolvePreviewBuildCacheHomePaths(install *models.PreviewInstallConfig) ([]string, bool) {
 	if install == nil || len(install.Lockfiles) == 0 {
 		return nil, false
@@ -1025,11 +1033,23 @@ func ResolvePreviewBuildCacheHomePaths(install *models.PreviewInstallConfig) ([]
 	if !hasGoLockfile {
 		return nil, false
 	}
-	// Both are home-rooted: GOCACHE defaults to ~/.cache/go-build (compiled
-	// objects — the dominant cold-compile cost) and GOMODCACHE to ~/go/pkg/mod
-	// (downloaded modules). Capturing both after the build phase means a launch
-	// that compiled cold still warms every subsequent launch.
-	return []string{".cache/go-build", "go/pkg/mod"}, true
+	// .cache/go-build (GOCACHE) is the compiled-object cache — the dominant
+	// cold-compile cost — and is only populated by an actual build, so the home
+	// build cache always owns it.
+	paths := []string{".cache/go-build"}
+	installRunsGo := false
+	for _, part := range install.Command {
+		if manager, ok := inferPreviewPackageManagerFromCommandPart(part); ok && manager == "go" {
+			installRunsGo = true
+			break
+		}
+	}
+	if !installRunsGo {
+		// Nothing else populates the module cache, so capture it here too.
+		paths = append(paths, "go/pkg/mod")
+	}
+	sort.Strings(paths)
+	return paths, true
 }
 
 // CacheRestorablePreviewInstallVerifyPaths returns the verify paths that can

--- a/internal/services/preview/config_test.go
+++ b/internal/services/preview/config_test.go
@@ -2191,6 +2191,15 @@ func TestResolvePreviewBuildCacheHomePaths(t *testing.T) {
 			enabled: true,
 		},
 		{
+			name: "install command running go leaves modules to the package-manager cache",
+			install: &models.PreviewInstallConfig{
+				Command:   []string{"go", "mod", "download"},
+				Lockfiles: []string{"go.mod"},
+			},
+			want:    []string{".cache/go-build"},
+			enabled: true,
+		},
+		{
 			name: "cache disabled flag disables home build caching",
 			install: &models.PreviewInstallConfig{
 				Lockfiles: []string{"go.mod"},

--- a/internal/services/preview/providers/docker_preview.go
+++ b/internal/services/preview/providers/docker_preview.go
@@ -206,9 +206,10 @@ const defaultServiceBuildTimeout = 30 * time.Minute
 // defaultServiceReadinessTimeout is how long a service has to pass its
 // readiness probe when the config does not set ready.timeout_seconds. With the
 // build phase compiling artifacts ahead of start, services should bind quickly;
-// the default still leaves generous headroom for first-request warmup. Configs
-// with unusually slow boots should set ready.timeout_seconds explicitly.
-const defaultServiceReadinessTimeout = 300 * time.Second
+// the default still leaves generous headroom for first-request warmup while
+// failing a genuinely broken service reasonably fast. Configs with unusually
+// slow boots should set ready.timeout_seconds explicitly.
+const defaultServiceReadinessTimeout = 180 * time.Second
 
 // serviceExitTailLines is the number of trailing non-blank stdout/stderr
 // lines folded into the user-visible exit error from formatServiceExitError.
@@ -400,15 +401,14 @@ func (d *DockerPreviewProvider) StartPreview(ctx context.Context, sb *agent.Sand
 		// Phase 4.6: Run per-service build commands. This is deliberately before
 		// runtime secret files (so build steps cannot read app secrets) and
 		// before services start (so compilation happens off the readiness-probe
-		// hot path). The home build cache is checkpointed synchronously here so
-		// an expensive cold compile warms subsequent launches even if this one
-		// later fails to become ready.
+		// hot path). On success the home build cache is saved asynchronously
+		// after readiness (see below); on any failure from here on it is flushed
+		// synchronously before cleanup, so an expensive cold compile warms
+		// subsequent launches even when this launch fails.
 		if err := d.runServiceBuilds(ctx, state, cfg, opts, observer); err != nil {
-			d.savePreviewBuildCacheHome(ctx, state, cfg.Install, opts, observer)
 			phaseErr = fmt.Errorf("%w: %v", preview.ErrServiceBuildFailed, err)
 			return phaseErr
 		}
-		d.savePreviewBuildCacheHome(ctx, state, cfg.Install, opts, observer)
 
 		// Phase 5: Write generated runtime secret files after install so install
 		// hooks cannot read preview-runtime app secrets.
@@ -429,6 +429,9 @@ func (d *DockerPreviewProvider) StartPreview(ctx context.Context, sb *agent.Sand
 		svcEnvs = d.buildServiceEnvs(cfg, infraCreds, opts.ExtraEnv)
 		return nil
 	}(); err != nil {
+		// A build-phase failure reaches here after `go build` may have populated
+		// GOCACHE; flush so even a failed compile warms the next launch.
+		d.flushBuildCachesBeforeCleanup(svcCtx, state, cfg.Install, opts, observer)
 		d.cleanupState(handle)
 		return nil, err
 	}
@@ -544,8 +547,10 @@ func (d *DockerPreviewProvider) StartPreview(ctx context.Context, sb *agent.Sand
 					cancel()
 				}
 				// All services finished their readiness window: boot-time
-				// builds are done, so capture the build cache now.
+				// builds are done, so capture the build caches now. Both saves
+				// are async; the launch is already reported ready.
 				d.savePreviewBuildCache(svcCtx, state, cfg.Install, opts, observer)
+				d.savePreviewBuildCacheHome(svcCtx, state, cfg.Install, opts, observer)
 			}()
 			return nil
 		}
@@ -581,8 +586,10 @@ func (d *DockerPreviewProvider) StartPreview(ctx context.Context, sb *agent.Sand
 			}
 		}
 		// All services are ready: boot-time builds are done, so capture the
-		// build cache now.
+		// build caches now. Both saves are async so a large GOCACHE upload does
+		// not delay returning the ready preview.
 		d.savePreviewBuildCache(svcCtx, state, cfg.Install, opts, observer)
+		d.savePreviewBuildCacheHome(svcCtx, state, cfg.Install, opts, observer)
 		return nil
 	}(); err != nil {
 		// Readiness failed, but boot-time builds may have populated their
@@ -1812,12 +1819,12 @@ func (d *DockerPreviewProvider) savePreviewBuildCache(ctx context.Context, state
 }
 
 // savePreviewBuildCacheHome archives the home-rooted build-artifact paths (Go's
-// GOCACHE/GOMODCACHE) at the build checkpoint. Unlike the workdir save this is
-// synchronous: it is the only point at which a (potentially multi-minute) cold
-// compile is durably captured, and running it before the build phase returns
-// guarantees the cache survives even if the launch later fails its readiness
-// probe or the sandbox is torn down. SkipIfChecksum keeps a warm, incremental
-// build's save to a near no-op.
+// GOCACHE/GOMODCACHE) populated by the build phase, on the SUCCESS path once
+// services are ready. It runs asynchronously so a large GOCACHE upload never
+// blocks the launch hot path — the prebuilt binary has already started. Failure
+// paths persist the same set synchronously via flushBuildCachesBeforeCleanup
+// (the sync.Once makes the two mutually exclusive). SkipIfChecksum keeps a warm,
+// incremental build's save to a near no-op.
 func (d *DockerPreviewProvider) savePreviewBuildCacheHome(ctx context.Context, state *previewState, install *models.PreviewInstallConfig, opts preview.StartPreviewOptions, observer preview.ServiceObserver) {
 	state.buildCacheHomeSaveOnce.Do(func() {
 		// No home build cache configured for this launch (no Go lockfile): stay
@@ -1825,16 +1832,16 @@ func (d *DockerPreviewProvider) savePreviewBuildCacheHome(ctx context.Context, s
 		if state.buildCacheHomeKey == "" {
 			return
 		}
-		d.saveBuildCacheSet(ctx, state, opts, observer, install, models.PreviewCacheRootHomeDir, state.buildCacheHomeKey, state.buildCacheHomePaths, state.buildCacheHomeRestoredChecksum)
+		go d.saveBuildCacheSet(ctx, state, opts, observer, install, models.PreviewCacheRootHomeDir, state.buildCacheHomeKey, state.buildCacheHomePaths, state.buildCacheHomeRestoredChecksum)
 	})
 }
 
 // flushBuildCachesBeforeCleanup synchronously persists any not-yet-saved build
-// caches on a failure path, before the sandbox is torn down. The home set is
-// usually already saved at the build checkpoint (its sync.Once short-circuits
-// here); the workdir set, which would otherwise only save after readiness, is
-// captured here so a launch that compiled and booted but missed its readiness
-// deadline still warms the next launch instead of repeating cold work.
+// caches on a failure path, before the sandbox is torn down. Both sets are saved
+// synchronously here (not via a goroutine that would race teardown): a launch
+// that compiled in the build phase and/or populated boot-time caches but then
+// failed still warms the next launch instead of repeating cold work. The home
+// set's sync.Once short-circuits if a success-path save already ran.
 func (d *DockerPreviewProvider) flushBuildCachesBeforeCleanup(ctx context.Context, state *previewState, install *models.PreviewInstallConfig, opts preview.StartPreviewOptions, observer preview.ServiceObserver) {
 	state.buildCacheHomeSaveOnce.Do(func() {
 		if state.buildCacheHomeKey == "" {
@@ -2276,6 +2283,13 @@ func (d *DockerPreviewProvider) runServiceBuilds(ctx context.Context, state *pre
 		return nil
 	}
 
+	// When home build caching is active (a Go project), pin GOCACHE/GOMODCACHE
+	// to the default $HOME locations the platform archives, so a base image that
+	// overrides them can't silently send the build's output somewhere the cache
+	// never captures. These are defaults: a service that sets them explicitly in
+	// its own Env still wins.
+	_, pinGoCacheEnv := preview.ResolvePreviewBuildCacheHomePaths(cfg.Install)
+
 	notifyPhaseStart(observer, "service_build")
 	phaseStarted := time.Now()
 	for _, name := range previewServiceBuildOrder(cfg) {
@@ -2287,6 +2301,16 @@ func (d *DockerPreviewProvider) runServiceBuilds(ctx context.Context, state *pre
 		var cmdParts []string
 		if svcCfg.Cwd != "" {
 			cmdParts = append(cmdParts, "cd", shellEscape(svcCfg.Cwd), "&&")
+		}
+		if pinGoCacheEnv {
+			// Raw (unescaped) so $HOME expands in the shell. Only set when the
+			// service hasn't already chosen a location.
+			if _, ok := svcCfg.Env["GOCACHE"]; !ok {
+				cmdParts = append(cmdParts, `GOCACHE="$HOME/.cache/go-build"`)
+			}
+			if _, ok := svcCfg.Env["GOMODCACHE"]; !ok {
+				cmdParts = append(cmdParts, `GOMODCACHE="$HOME/go/pkg/mod"`)
+			}
 		}
 		envKeys := make([]string, 0, len(svcCfg.Env))
 		for k := range svcCfg.Env {

--- a/internal/services/preview/providers/docker_preview_test.go
+++ b/internal/services/preview/providers/docker_preview_test.go
@@ -3154,3 +3154,151 @@ func TestPreviewServiceBuildOrder(t *testing.T) {
 	require.Equal(t, []string{"frontend", "webserver", "worker"}, previewServiceBuildOrder(cfg),
 		"absent primary should not be appended")
 }
+
+// goBuildPreviewConfig is a Go service with a build step and a go.mod lockfile,
+// so the build phase runs and the home build cache (GOCACHE/GOMODCACHE) is
+// active. The install command is JS-only, so the home set owns go/pkg/mod and
+// install is a no-op cache hit in these tests.
+func goBuildPreviewConfig() *models.PreviewConfig {
+	return &models.PreviewConfig{
+		Name:    "test-app",
+		Primary: "web",
+		Install: &models.PreviewInstallConfig{
+			Command:     []string{"npm", "ci"},
+			Lockfiles:   []string{"package-lock.json", "go.mod"},
+			VerifyPaths: []string{"node_modules/.bin/next"},
+		},
+		Services: map[string]models.ServiceConfig{
+			"web": {
+				Build:   []string{"go", "build", "-o", "bin/web", "./cmd/web"},
+				Command: []string{"./bin/web"},
+				Port:    3000,
+				Ready:   models.ReadinessProbe{HTTPPath: "/"},
+			},
+		},
+	}
+}
+
+// TestStartPreview_BuildPhaseRunsBeforeStartAndSavesHomeCache covers the happy
+// path: the build command compiles before the service starts, GOCACHE/GOMODCACHE
+// are pinned to the archived default locations, and the home build cache is
+// saved (asynchronously) after a successful launch.
+func TestStartPreview_BuildPhaseRunsBeforeStartAndSavesHomeCache(t *testing.T) {
+	t.Parallel()
+
+	release := make(chan struct{})
+	var mu sync.Mutex
+	var order []string
+	var buildCmd string
+	exec := &fakeServiceExecutor{
+		execStreamFn: func(ctx context.Context, cmd string, _ func([]byte)) (int, error) {
+			// The build command is shell-escaped per-arg, so match on the build
+			// target path rather than a "go build" substring.
+			if strings.Contains(cmd, "cmd/web") {
+				mu.Lock()
+				order = append(order, "build")
+				buildCmd = cmd
+				mu.Unlock()
+				return 0, nil
+			}
+			// Service run: block so the preview stays "running" until released.
+			mu.Lock()
+			order = append(order, "run")
+			mu.Unlock()
+			select {
+			case <-release:
+			case <-ctx.Done():
+			}
+			return 0, nil
+		},
+		execFn: func(_ context.Context, _ string) (int, error) { return 0, nil },
+		readFileFn: func(_ context.Context, path string) ([]byte, error) {
+			if path == "package-lock.json" {
+				return []byte(`{"lockfileVersion":3}`), nil
+			}
+			return []byte("ok"), nil
+		},
+	}
+	// findHit makes install a no-op cache hit so ExecStream only sees the build
+	// and the service run; buildFindHit nil so the build cache misses and saves.
+	cache := &fakeDependencyCache{findHit: &preview.DependencyCacheHit{}}
+	d := NewDockerPreviewProvider(previewReachableClient(), exec, zerolog.Nop(), WithPreviewDialer(successfulPreviewDialer), WithDependencyCache(cache))
+	obs := &recordingObserver{}
+
+	handle, err := d.StartPreview(context.Background(), &agent.Sandbox{ID: "sb", WorkDir: "/workspace/repo", HomeDir: "/home/codex"}, goBuildPreviewConfig(), preview.StartPreviewOptions{
+		OrgID:        uuid.New(),
+		RepositoryID: uuid.New(),
+		SessionID:    uuid.New(),
+	}, obs)
+	require.NoError(t, err, "StartPreview should succeed")
+	require.NotNil(t, handle, "StartPreview should return a handle")
+
+	mu.Lock()
+	require.NotEmpty(t, order, "an exec should have run")
+	require.Equal(t, "build", order[0], "the build phase must run before any service starts")
+	require.Contains(t, buildCmd, "cmd/web", "the build command should be the service Build")
+	require.Contains(t, buildCmd, `GOCACHE="$HOME/.cache/go-build"`, "build env should pin GOCACHE to the archived default")
+	require.Contains(t, buildCmd, `GOMODCACHE="$HOME/go/pkg/mod"`, "build env should pin GOMODCACHE to the archived default")
+	mu.Unlock()
+
+	// The home build cache (Root=HomeDir) is saved asynchronously after readiness.
+	require.Eventually(t, func() bool {
+		_, _, _, _, specs := cache.pathCounts()
+		for _, spec := range specs {
+			if spec.Kind == models.PreviewCacheKindBuildArtifact && spec.Root == models.PreviewCacheRootHomeDir {
+				return true
+			}
+		}
+		return false
+	}, 5*time.Second, 10*time.Millisecond, "home build cache should be saved after a successful launch")
+
+	close(release)
+	require.NoError(t, d.StopPreview(context.Background(), handle.Handle), "StopPreview should clean up the started preview")
+}
+
+// TestStartPreview_BuildFailureFlushesHomeCache covers the save-on-checkpoint
+// guarantee: when the build command fails, the launch fails with
+// ErrServiceBuildFailed but the home build cache is still flushed synchronously,
+// so even a failed compile warms the next launch.
+func TestStartPreview_BuildFailureFlushesHomeCache(t *testing.T) {
+	t.Parallel()
+
+	exec := &fakeServiceExecutor{
+		execStreamFn: func(_ context.Context, cmd string, _ func([]byte)) (int, error) {
+			if strings.Contains(cmd, "cmd/web") {
+				return 1, nil // build fails
+			}
+			return 0, nil
+		},
+		execFn: func(_ context.Context, _ string) (int, error) { return 0, nil },
+		readFileFn: func(_ context.Context, path string) ([]byte, error) {
+			if path == "package-lock.json" {
+				return []byte(`{"lockfileVersion":3}`), nil
+			}
+			return []byte("ok"), nil
+		},
+	}
+	cache := &fakeDependencyCache{findHit: &preview.DependencyCacheHit{}}
+	d := NewDockerPreviewProvider(previewReachableClient(), exec, zerolog.Nop(), WithPreviewDialer(successfulPreviewDialer), WithDependencyCache(cache))
+	obs := &recordingObserver{}
+
+	handle, err := d.StartPreview(context.Background(), &agent.Sandbox{ID: "sb", WorkDir: "/workspace/repo", HomeDir: "/home/codex"}, goBuildPreviewConfig(), preview.StartPreviewOptions{
+		OrgID:        uuid.New(),
+		RepositoryID: uuid.New(),
+		SessionID:    uuid.New(),
+	}, obs)
+	require.Error(t, err, "StartPreview should fail when the build fails")
+	require.ErrorIs(t, err, preview.ErrServiceBuildFailed, "failure should be classified as a build failure")
+	require.Nil(t, handle, "no handle on a failed launch")
+
+	// The flush is synchronous on the failure path, so the home save is already
+	// recorded by the time StartPreview returns.
+	_, _, _, _, specs := cache.pathCounts()
+	foundHomeSave := false
+	for _, spec := range specs {
+		if spec.Kind == models.PreviewCacheKindBuildArtifact && spec.Root == models.PreviewCacheRootHomeDir {
+			foundHomeSave = true
+		}
+	}
+	require.True(t, foundHomeSave, "a failed build should still flush the home build cache before cleanup")
+}


### PR DESCRIPTION
Follow-up to [#1540](https://github.com/assembledhq/143/pull/1540) (merged), addressing the code-review findings on that PR. Touches only `internal/services/preview`.

## What changed

**🔴 Keep the home (Go) build cache off the launch hot path.** #1540 saved the home cache *synchronously* at the build checkpoint — after an incremental compile, `.cache/go-build` changes, so it re-uploaded the full (multi-GB) GOCACHE *before services started* on every new-commit launch, partly undoing the latency win. Now:
- On success the home cache saves **asynchronously** after readiness (alongside the workdir save) — the prebuilt binary starts immediately.
- All failure paths (build / start / readiness) still **flush both cache sets synchronously** before sandbox teardown, so a launch that compiled but failed still warms the next one. `flushBuildCachesBeforeCleanup` now also runs on the build/secret/env cleanup path.

**🟡 Dedup the module cache.** `ResolvePreviewBuildCacheHomePaths` drops `go/pkg/mod` from the home set when the install *command* itself runs go (e.g. `go mod download`) — there the package-manager cache already captures modules post-install, so the home set only needs the compiled-object cache (`.cache/go-build`). When install is JS-only (the common case beside a `go.mod`), the home set still owns `go/pkg/mod` since nothing else captures it. Avoids double-archiving/double-restoring the module cache.

**🟡 Pin GOCACHE/GOMODCACHE in the build env.** The build phase now exports `GOCACHE`/`GOMODCACHE` to the archived `$HOME` default locations (unless the service already sets them), so a base image that overrides them can't silently send build output where the cache never looks.

**🟢 Readiness default 300s → 180s.** Generous boot headroom without slow failure feedback for genuinely broken services.

**🟢 Integration tests.** Added coverage for (a) the build phase running before service start with GOCACHE pinned and the home cache saved on success, and (b) a failed build still flushing the home cache before cleanup.

## Verification
`go build ./internal/...` ✅ · full `internal/services/preview/...` suite ✅ · `make lint` → 0 issues ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)
