### PR TITLE
Fix previews showing "expires 1m ago" for running previews

### DIFF
--- a/frontend/src/app/(dashboard)/previews/page.tsx
+++ b/frontend/src/app/(dashboard)/previews/page.tsx
@@ -205,6 +205,22 @@ function relativeTime(value?: string): string {
   return `${Math.round(hours / 24)}d ago`;
 }
 
+// Formats a timestamp that may be in the past or future as "in 29m" / "5m ago".
+function expiresIn(value?: string): string {
+  if (!value) return "";
+  const ms = Date.parse(value) - Date.now();
+  if (Number.isNaN(ms)) return "";
+  const future = ms > 0;
+  const minutes = Math.max(1, Math.round(Math.abs(ms) / 60000));
+  let amount: string;
+  if (minutes < 60) amount = `${minutes}m`;
+  else {
+    const hours = Math.round(minutes / 60);
+    amount = hours < 48 ? `${hours}h` : `${Math.round(hours / 24)}d`;
+  }
+  return future ? `in ${amount}` : `${amount} ago`;
+}
+
 function SectionRows({
   scope,
   previews,
@@ -327,7 +343,7 @@ function SectionRows({
                         : scope === "recent"
                           ? stoppedReasonLabel(preview.stopped_reason)
                           : preview.expires_at
-                            ? `expires ${relativeTime(preview.expires_at)}`
+                            ? `expires ${expiresIn(preview.expires_at)}`
                             : preview.current_phase || ""}
                     </p>
                   </TableCell>


### PR DESCRIPTION
## Summary

The Previews page showed "expires 1m ago" for every running preview, making it look like running previews had already expired. The expiry was rendered with `relativeTime()`, a "time-ago" formatter that assumes a *past* timestamp — but `expires_at` is in the future (`created_at + 30m` hard TTL). The formatter always appends "ago" and clamps non-positive durations up to 1 via `Math.max(1, ...)`, so any future expiry collapsed to "1m ago" regardless of actual time remaining. This is purely a display bug; the backend TTL is correct.

## Changes

- Add an `expiresIn()` helper in `previews/page.tsx` that formats future timestamps as "in 30m" and past ones as "5m ago".
- Use `expiresIn()` for the running-preview expiry text instead of `relativeTime()`.
- Leave `relativeTime()` unchanged so the `created_at` "ago" display elsewhere on the page keeps its behavior.

## Validation

- Verified `expiresIn()` output across fresh (+30m → "in 30m"), near-now (+5s → "in 1m"), hours (+2h → "in 2h"), days (+3d → "in 3d"), genuinely-expired (−5m → "5m ago"), and empty/invalid inputs.
- Full `tsc`/preview not run locally: this worktree has no `node_modules` and the change is an isolated pure function with no new imports. CI typecheck/lint will cover it.
