### PR TITLE
preview: redirect Go build GOTMPDIR off the 512 MiB /var/tmp tmpfs

### DIFF
--- a/internal/services/preview/providers/docker_preview.go
+++ b/internal/services/preview/providers/docker_preview.go
@@ -2305,11 +2305,27 @@ func (d *DockerPreviewProvider) runServiceBuilds(ctx context.Context, state *pre
 		if pinGoCacheEnv {
 			// Raw (unescaped) so $HOME expands in the shell. Only set when the
 			// service hasn't already chosen a location.
+			//
+			// GOTMPDIR is redirected off the container's default scratch dir.
+			// That default is the small exec tmpfs at /var/tmp (512 MiB,
+			// RAM-backed; see defaultScratchDir): a large module graph's compile
+			// scratch overflows it ("no space left on device" writing the build
+			// work dir) and, being RAM-backed, also draws down the memory cgroup.
+			// Point the build's work dir at the disk-quota'd $HOME instead (go
+			// build needs room, not exec). The dir must exist before the
+			// toolchain will use it, and it lives outside the archived cache set
+			// (.cache/go-build + go/pkg/mod) so scratch never bloats the cache.
+			if _, ok := svcCfg.Env["GOTMPDIR"]; !ok {
+				cmdParts = append(cmdParts, `mkdir -p "$HOME/.cache/go-build-tmp" &&`)
+			}
 			if _, ok := svcCfg.Env["GOCACHE"]; !ok {
 				cmdParts = append(cmdParts, `GOCACHE="$HOME/.cache/go-build"`)
 			}
 			if _, ok := svcCfg.Env["GOMODCACHE"]; !ok {
 				cmdParts = append(cmdParts, `GOMODCACHE="$HOME/go/pkg/mod"`)
+			}
+			if _, ok := svcCfg.Env["GOTMPDIR"]; !ok {
+				cmdParts = append(cmdParts, `GOTMPDIR="$HOME/.cache/go-build-tmp"`)
 			}
 		}
 		envKeys := make([]string, 0, len(svcCfg.Env))

--- a/internal/services/preview/providers/docker_preview_test.go
+++ b/internal/services/preview/providers/docker_preview_test.go
@@ -3239,6 +3239,11 @@ func TestStartPreview_BuildPhaseRunsBeforeStartAndSavesHomeCache(t *testing.T) {
 	require.Contains(t, buildCmd, "cmd/web", "the build command should be the service Build")
 	require.Contains(t, buildCmd, `GOCACHE="$HOME/.cache/go-build"`, "build env should pin GOCACHE to the archived default")
 	require.Contains(t, buildCmd, `GOMODCACHE="$HOME/go/pkg/mod"`, "build env should pin GOMODCACHE to the archived default")
+	// GOTMPDIR is steered off the small /var/tmp scratch tmpfs onto the
+	// disk-quota'd $HOME so a large compile's work dir cannot exhaust it; the
+	// dir is created first since the toolchain requires GOTMPDIR to exist.
+	require.Contains(t, buildCmd, `GOTMPDIR="$HOME/.cache/go-build-tmp"`, "build env should redirect GOTMPDIR off the /var/tmp scratch tmpfs")
+	require.Contains(t, buildCmd, `mkdir -p "$HOME/.cache/go-build-tmp" &&`, "the build should create GOTMPDIR before compiling")
 	mu.Unlock()
 
 	// The home build cache (Root=HomeDir) is saved asynchronously after readiness.


### PR DESCRIPTION
## Problem

Every launch of the Assembled-config preview (branch `wangjohn/preview-seeded-postgres`, target `eaf2704c…`) has been failing with:

```
service "webserver" build: exited with code 1;
... write /var/tmp/go-build.../importcfg: no space left on device
```

The Go-aware build phase (#1540 / #1544) pins `GOCACHE`/`GOMODCACHE` to disk-backed `$HOME` paths but leaves the compile **work dir** on the container's default `GOTMPDIR`/`TMPDIR` = `/var/tmp`, which is a **512 MiB exec tmpfs** (RAM-backed; `defaultScratchDir` in `internal/services/agent/providers/docker.go`). Compiling a large module graph writes well over 512 MiB of intermediate artifacts there, so the build dies with ENOSPC.

This is the tmpfs `size=` cap — **not** host disk and **not** the instance limits (the failing instances had 8 GiB memory and a disk quota). Because the launch page (`?launch=1`) only renders the error once the instance flips to `failed`, the UI just shows a perpetual "starting" loop with no visible error.

## Fix

In `runServiceBuilds`, alongside the existing GOCACHE/GOMODCACHE pinning, redirect `GOTMPDIR` to a disk-quota'd `$HOME/.cache/go-build-tmp` (created first, since the toolchain requires GOTMPDIR to exist). `go build` needs room, not the exec semantics `/var/tmp` exists for, so the disk-backed rootfs is the right home for compile scratch. The path sits outside the archived cache set (`.cache/go-build` + `go/pkg/mod`) so scratch never bloats the saved cache, and a service that sets `GOTMPDIR` itself still wins.

## Notes / trade-off

Compile scratch is now bounded by `SANDBOX_DISK_LIMIT_GB` rather than the 512 MiB tmpfs — i.e. a runaway compile fails on the disk quota instead of fast on the tmpfs. That's the intended trade-off here; flagging in case an explicit ceiling is preferred.

## Test plan

- Extended `TestStartPreview_BuildPhaseRunsBeforeStartAndSavesHomeCache` to assert the `GOTMPDIR` pin and the `mkdir`.
- `go test ./internal/services/preview/...` — pass
- `make lint` — 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)
