### PR TITLE
Fix launch-mode previews hiding errors behind "Opening when ready"

### DIFF
--- a/frontend/src/app/(dashboard)/previews/[id]/page.test.tsx
+++ b/frontend/src/app/(dashboard)/previews/[id]/page.test.tsx
@@ -349,6 +349,77 @@ describe("PreviewLandingPage launch mode", () => {
     await new Promise((resolve) => window.setTimeout(resolve, 50));
     expect(startCalls).toBe(1);
   });
+
+  it("keeps the failure visible when a launched preview fails after start-latest mints a new id", async () => {
+    let phase: "stopped" | "failed" = "stopped";
+    let prev1StartCalls = 0;
+    let prev2StartCalls = 0;
+
+    server.use(
+      http.get("*/api/v1/previews/target-1", () => {
+        if (phase === "stopped") {
+          return HttpResponse.json({
+            data: {
+              target_id: "target-1",
+              preview_id: "prev-1",
+              repository_full_name: "acme/web",
+              branch: "feature/preview",
+              status: "stopped",
+              current_phase: "stopped",
+              stable_url: "https://143.dev/previews/target-1",
+              preview_url: "https://target-1.preview.143.dev",
+            },
+          });
+        }
+        // start-latest minted a fresh instance (prev-2) that then fails readiness.
+        return HttpResponse.json({
+          data: {
+            target_id: "target-1",
+            preview_id: "prev-2",
+            repository_full_name: "acme/web",
+            branch: "feature/preview",
+            status: "failed",
+            error: "Service failed readiness checks.",
+            current_phase: "readiness",
+            stable_url: "https://143.dev/previews/target-1",
+            preview_url: "https://target-1.preview.143.dev",
+          },
+        });
+      }),
+      http.post("*/api/v1/previews/prev-1/start-latest", () => {
+        prev1StartCalls += 1;
+        phase = "failed";
+        return HttpResponse.json({
+          data: {
+            target_id: "target-1",
+            preview_id: "prev-2",
+            repository_full_name: "acme/web",
+            branch: "feature/preview",
+            status: "starting",
+            current_phase: "start_services",
+            stable_url: "https://143.dev/previews/target-1",
+            preview_url: "https://target-1.preview.143.dev",
+          },
+        });
+      }),
+      http.post("*/api/v1/previews/prev-2/start-latest", () => {
+        prev2StartCalls += 1;
+        return HttpResponse.json({ data: { target_id: "target-1", preview_id: "prev-2", status: "starting" } });
+      }),
+    );
+
+    renderLaunchPage();
+
+    expect(await screen.findByText("Service failed readiness checks.")).toBeInTheDocument();
+
+    // The error must stick — not get clobbered by an auto-restart loop that
+    // flips the UI back to "Opening when ready" and spins up new instances.
+    await new Promise((resolve) => window.setTimeout(resolve, 250));
+    expect(screen.getByText("Service failed readiness checks.")).toBeInTheDocument();
+    expect(screen.queryByText("Opening when ready")).not.toBeInTheDocument();
+    expect(prev1StartCalls).toBe(1);
+    expect(prev2StartCalls).toBe(0);
+  });
 });
 
 describe("PreviewLandingPage detail mode", () => {

--- a/frontend/src/app/(dashboard)/previews/[id]/page.tsx
+++ b/frontend/src/app/(dashboard)/previews/[id]/page.tsx
@@ -158,10 +158,14 @@ export function PreviewLandingContent({ id }: { id: string }) {
 
   useEffect(() => {
     if (!shouldStartForLaunch || !launchTargetId) return;
-    if (launchStartAttemptedRef.current === launchTargetId) return;
-    launchStartAttemptedRef.current = launchTargetId;
+    // Dedupe on the stable route id, not launchTargetId: start-latest mints a
+    // fresh preview_id, so keying on launchTargetId lets a failed preview slip
+    // past the guard and auto-restart forever, hiding the error behind
+    // "Opening when ready". One auto-start per page load; failures stick.
+    if (launchStartAttemptedRef.current === id) return;
+    launchStartAttemptedRef.current = id;
     restartPreview.mutate({ previewId: launchTargetId, latest: true });
-  }, [launchTargetId, restartPreview, shouldStartForLaunch]);
+  }, [id, launchTargetId, restartPreview, shouldStartForLaunch]);
 
   useEffect(() => {
     if (!launchMode || !previewOrigin || !previewUrl || !preview?.preview_id || !isReady) return;
@@ -222,7 +226,10 @@ export function PreviewLandingContent({ id }: { id: string }) {
 
   const startLatest = () => {
     if (!launchTargetId) return;
-    launchStartAttemptedRef.current = null;
+    // Manual retry starts the preview directly, so mark auto-start as done for
+    // this page rather than re-arming it — otherwise a second failure would
+    // trip the auto-restart loop again.
+    launchStartAttemptedRef.current = id;
     restartPreview.mutate({ previewId: launchTargetId, latest: true });
   };
 


### PR DESCRIPTION
## Problem

On the preview launch page (`/previews/<id>?launch=1`), hitting an error never shows the error — the UI flashes it for a frame then reverts to **"Opening when ready"**, looping indefinitely (and spinning up a new preview instance each cycle).

Reported on a real preview: https://143.dev/previews/eaf2704c-5df5-4d0c-b0ed-ae96ec4ab132?launch=1

## Root cause

Launch mode auto-starts the preview once, deduped by `launchStartAttemptedRef` keyed on `launchTargetId`:

```js
const launchTargetId = preview?.preview_id ?? preview?.target_id;
...
if (launchStartAttemptedRef.current === launchTargetId) return;
launchStartAttemptedRef.current = launchTargetId;
restartPreview.mutate({ previewId: launchTargetId, latest: true });
```

`launchTargetId` is **mutable** — `start-latest` (`startTargetRuntime` → `resolveLatestTarget`) mints a fresh `preview_id` on every call. After the start succeeds, the guard's recorded id no longer matches the new `launchTargetId`. When the preview then transitions to `failed` (not in `ACTIVE_PREVIEW_STATUSES`), `shouldStartForLaunch` flips true again, the guard **misses**, and the effect **restarts the preview** — overwriting the `failed` state with `starting` before the error can be read.

The title logic itself was correct (`isFailed` is checked before `isStarting`); the error simply never survived a render.

## Fix

- Key the auto-start guard on the **stable route `id`** instead of the mutable `launchTargetId`, so auto-start fires at most once per page load and a failure sticks.
- The manual **Retry** button now marks the guard as attempted (`= id`) rather than re-arming it (`= null`), so a second failure can't re-trip the loop. Retry still works — it calls `mutate` directly.

## Test

Added a regression test reproducing the actual path: `start-latest` succeeds with a **new** `preview_id`, then polling returns `failed`. It asserts the error stays visible, "Opening when ready" is gone, and `start-latest` is called exactly once. **Verified it fails on the old code and passes on the fix.**

The pre-existing "does not repeatedly auto-start..." test only covered an HTTP-error start (where `preview_id` never changed), which is why this slipped through.

🤖 Generated with [Claude Code](https://claude.com/claude-code)