### PR TITLE
Add consistent “last activity” audit component to all settings pages

### DIFF
--- a/frontend/src/app/(dashboard)/settings/account/page.tsx
+++ b/frontend/src/app/(dashboard)/settings/account/page.tsx
@@ -15,6 +15,7 @@ import { CodingAuthDialog } from "@/components/coding-auth-dialog";
 import { EmptyState } from "@/components/empty-state";
 import { PageContainer } from "@/components/page-container";
 import { PageHeader } from "@/components/page-header";
+import { SettingsLastActivity } from "@/components/settings/settings-last-activity";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
@@ -570,6 +571,11 @@ export default function AccountPage() {
             <ThemeSelect />
           </CardContent>
         </Card>
+
+        <SettingsLastActivity
+          scopes={[{ resource_type: "credential" }, { resource_type: "user" }]}
+          title="Account settings activity"
+        />
       </div>
 
       <CodingAuthDialog

--- a/frontend/src/app/(dashboard)/settings/agent/page.tsx
+++ b/frontend/src/app/(dashboard)/settings/agent/page.tsx
@@ -21,6 +21,7 @@ import { EmptyState } from "@/components/empty-state";
 import { AGENTS_BY_KEY } from "@/lib/agents";
 import { PageContainer } from "@/components/page-container";
 import { PageHeader } from "@/components/page-header";
+import { SettingsLastActivity } from "@/components/settings/settings-last-activity";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { APIKeyHelpTooltip } from "@/components/api-key-help-tooltip";
@@ -426,6 +427,10 @@ export default function AgentPage() {
             </Card>
           </section>
 
+          <SettingsLastActivity
+            scopes={[{ resource_type: "credential" }, { resource_type: "settings" }]}
+            title="Coding agent settings activity"
+          />
         </div>
       </PageContainer>
     );
@@ -498,6 +503,11 @@ export default function AgentPage() {
             </CardContent>
           </Card>
         </section>
+
+        <SettingsLastActivity
+          scopes={[{ resource_type: "credential" }, { resource_type: "settings" }]}
+          title="Coding agent settings activity"
+        />
 
         <Sheet open={Boolean(selected)} onOpenChange={(open) => { if (!open) setSelectedId(null); }}>
           <SheetContent className="w-full sm:max-w-lg">

--- a/frontend/src/app/(dashboard)/settings/api-keys/page.tsx
+++ b/frontend/src/app/(dashboard)/settings/api-keys/page.tsx
@@ -8,6 +8,7 @@ import { Copy, KeyRound, Pencil, Plus, Shield, Trash2 } from "lucide-react";
 import { EmptyState } from "@/components/empty-state";
 import { PageContainer } from "@/components/page-container";
 import { PageHeader } from "@/components/page-header";
+import { SettingsLastActivity } from "@/components/settings/settings-last-activity";
 import { AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent, AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle } from "@/components/ui/alert-dialog";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -402,6 +403,11 @@ export default function APIKeysSettingsPage() {
             )}
           </div>
         )}
+
+        <SettingsLastActivity
+          scopes={[{ resource_type: "api_client" }, { resource_type: "api_token" }]}
+          title="API key activity"
+        />
       </div>
 
       <Dialog open={dialog != null} onOpenChange={(open) => !open && setDialog(null)}>

--- a/frontend/src/app/(dashboard)/settings/autopilot/page.tsx
+++ b/frontend/src/app/(dashboard)/settings/autopilot/page.tsx
@@ -21,6 +21,7 @@ import {
 } from "@/components/ui/select";
 import { PageContainer } from "@/components/page-container";
 import { PageHeader } from "@/components/page-header";
+import { SettingsLastActivity } from "@/components/settings/settings-last-activity";
 import { useAutosave } from "@/hooks/useAutosave";
 import { useAutosaveNumericField } from "@/hooks/useAutosaveNumericField";
 import { availableAgentModelGroups, pmUsableResolvedCredentials } from "@/lib/agents";
@@ -339,6 +340,11 @@ export default function AutopilotSettingsPage() {
             </div>
           )}
         </section>
+
+        <SettingsLastActivity
+          scopes={{ resource_type: "settings" }}
+          title="Autopilot settings activity"
+        />
       </div>
     </PageContainer>
   );

--- a/frontend/src/app/(dashboard)/settings/integrations/page.test.tsx
+++ b/frontend/src/app/(dashboard)/settings/integrations/page.test.tsx
@@ -29,6 +29,7 @@ const {
   startPagerDutyIncidentSessionMock,
   loginPagerDutyMock,
   teamListMembersMock,
+  auditLogsListMock,
   githubConnectMock,
   githubStatusGetMock,
   githubDisconnectMock,
@@ -72,6 +73,7 @@ const {
     startPagerDutyIncidentSessionMock: vi.fn(),
     loginPagerDutyMock: vi.fn(),
     teamListMembersMock: vi.fn(),
+    auditLogsListMock: vi.fn(),
     githubConnectMock: vi.fn(),
     githubStatusGetMock: vi.fn(),
     githubDisconnectMock: vi.fn(),
@@ -153,6 +155,9 @@ vi.mock("@/lib/api", () => ({
     team: {
       listMembers: teamListMembersMock,
     },
+    auditLogs: {
+      list: auditLogsListMock,
+    },
   },
 }));
 
@@ -165,6 +170,7 @@ vi.mock("@/hooks/use-auth", () => ({
 
 describe("IntegrationsPage", () => {
   beforeEach(() => {
+    auditLogsListMock.mockResolvedValue({ data: [], meta: {} });
     integrationsListMock.mockResolvedValue({
       data: [
         {

--- a/frontend/src/app/(dashboard)/settings/integrations/page.tsx
+++ b/frontend/src/app/(dashboard)/settings/integrations/page.tsx
@@ -11,6 +11,7 @@ import { AllIntegrationCards } from "@/components/integration-connection-cards";
 import { AutosaveIndicator } from "@/components/AutosaveIndicator";
 import { PageHeader } from "@/components/page-header";
 import { PageContainer } from "@/components/page-container";
+import { SettingsLastActivity } from "@/components/settings/settings-last-activity";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Checkbox } from "@/components/ui/checkbox";
@@ -2321,6 +2322,10 @@ export default function IntegrationsPage() {
         disconnectErrorProvider={disconnectMutation.isError ? disconnectMutation.variables ?? null : null}
         disconnectError={disconnectMutation.isError ? "Failed to disconnect." : null}
         readOnly={!isAdmin}
+      />
+      <SettingsLastActivity
+        scopes={[{ resource_type: "integration" }, { resource_type: "credential" }]}
+        title="Integration settings activity"
       />
       </div>
 

--- a/frontend/src/app/(dashboard)/settings/llm/page.test.tsx
+++ b/frontend/src/app/(dashboard)/settings/llm/page.test.tsx
@@ -10,6 +10,8 @@ const {
   settingsUpdateMock,
   llmModelsMock,
   llmDefaultsMock,
+  auditLogsListMock,
+  teamListMembersMock,
 } = vi.hoisted(() => ({
   settingsGetMock: vi.fn().mockResolvedValue({
     data: {
@@ -35,6 +37,8 @@ const {
   llmDefaultsMock: vi.fn().mockResolvedValue({
     data: { openai: "sk-...plat" },
   }),
+  auditLogsListMock: vi.fn().mockResolvedValue({ data: [], meta: {} }),
+  teamListMembersMock: vi.fn().mockResolvedValue({ data: [], meta: {} }),
 }));
 
 vi.mock("@/lib/api", () => ({
@@ -49,6 +53,12 @@ vi.mock("@/lib/api", () => ({
       list: credentialsListMock,
       update: credentialsUpdateMock,
       delete: credentialsDeleteMock,
+    },
+    auditLogs: {
+      list: auditLogsListMock,
+    },
+    team: {
+      listMembers: teamListMembersMock,
     },
   },
 }));
@@ -79,6 +89,10 @@ describe("LLMPage", () => {
     llmModelsMock.mockClear();
     llmDefaultsMock.mockClear();
     llmDefaultsMock.mockResolvedValue({ data: { openai: "sk-...plat" } });
+    auditLogsListMock.mockClear();
+    auditLogsListMock.mockResolvedValue({ data: [], meta: {} });
+    teamListMembersMock.mockClear();
+    teamListMembersMock.mockResolvedValue({ data: [], meta: {} });
   });
 
   it("renders the page header", async () => {

--- a/frontend/src/app/(dashboard)/settings/llm/page.tsx
+++ b/frontend/src/app/(dashboard)/settings/llm/page.tsx
@@ -26,6 +26,7 @@ import {
 } from "@/components/ui/alert-dialog";
 import { PageHeader } from "@/components/page-header";
 import { PageContainer } from "@/components/page-container";
+import { SettingsLastActivity } from "@/components/settings/settings-last-activity";
 import { AlertTriangle } from "lucide-react";
 import Link from "next/link";
 import {
@@ -323,6 +324,11 @@ export default function LLMPage() {
             ))}
           </div>
         </section>
+
+        <SettingsLastActivity
+          scopes={[{ resource_type: "settings" }, { resource_type: "credential" }]}
+          title="App LLM settings activity"
+        />
       </div>
 
       {editingProvider && editingInfo && (

--- a/frontend/src/app/(dashboard)/settings/page.tsx
+++ b/frontend/src/app/(dashboard)/settings/page.tsx
@@ -29,7 +29,7 @@ import { Switch } from "@/components/ui/switch";
 import { Textarea } from "@/components/ui/textarea";
 import { PageHeader } from "@/components/page-header";
 import { PageContainer } from "@/components/page-container";
-import { AuditLogTrigger } from "@/components/audit/audit-log-trigger";
+import { SettingsLastActivity } from "@/components/settings/settings-last-activity";
 import { AutosaveIndicator } from "@/components/AutosaveIndicator";
 import { DebouncedInput } from "@/components/debounced-fields";
 import { useAuth } from "@/hooks/use-auth";
@@ -858,10 +858,9 @@ export default function SettingsPage() {
 
         {user?.role === "admin" && <PRAuthorshipSettings />}
 
-        <AuditLogTrigger
-          filters={{ resource_type: "settings" }}
+        <SettingsLastActivity
+          scopes={{ resource_type: "settings" }}
           title="Settings activity"
-          variant="footer"
         />
       </div>
     </PageContainer>

--- a/frontend/src/app/(dashboard)/settings/previews/page.tsx
+++ b/frontend/src/app/(dashboard)/settings/previews/page.tsx
@@ -23,6 +23,7 @@ import { AutosaveIndicator } from "@/components/AutosaveIndicator";
 import { EmptyState } from "@/components/empty-state";
 import { PageContainer } from "@/components/page-container";
 import { PageHeader } from "@/components/page-header";
+import { SettingsLastActivity } from "@/components/settings/settings-last-activity";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -179,6 +180,14 @@ export default function PreviewSettingsPage() {
             <PreviewSecretsSection />
           </TabsContent>
         </Tabs>
+        <SettingsLastActivity
+          scopes={[
+            { resource_type: "settings" },
+            { resource_type: "preview_policy" },
+            { resource_type: "preview_secret_bundle" },
+          ]}
+          title="Preview settings activity"
+        />
       </div>
     </PageContainer>
   );

--- a/frontend/src/app/(dashboard)/settings/runtime/page.test.tsx
+++ b/frontend/src/app/(dashboard)/settings/runtime/page.test.tsx
@@ -12,11 +12,15 @@ const {
   settingsUpdateMock,
   settingsNetworkStatusMock,
   settingsRuntimeStatusMock,
+  auditLogsListMock,
+  teamListMembersMock,
 } = vi.hoisted(() => ({
   settingsGetMock: vi.fn(),
   settingsUpdateMock: vi.fn(),
   settingsNetworkStatusMock: vi.fn(),
   settingsRuntimeStatusMock: vi.fn(),
+  auditLogsListMock: vi.fn().mockResolvedValue({ data: [], meta: {} }),
+  teamListMembersMock: vi.fn().mockResolvedValue({ data: [], meta: {} }),
 }));
 
 vi.mock("@/lib/api", () => ({
@@ -26,6 +30,12 @@ vi.mock("@/lib/api", () => ({
       update: settingsUpdateMock,
       getNetworkStatus: settingsNetworkStatusMock,
       getRuntimeStatus: settingsRuntimeStatusMock,
+    },
+    auditLogs: {
+      list: auditLogsListMock,
+    },
+    team: {
+      listMembers: teamListMembersMock,
     },
   },
 }));
@@ -45,6 +55,10 @@ describe("RuntimeSettingsPage", () => {
     settingsUpdateMock.mockReset();
     settingsNetworkStatusMock.mockReset();
     settingsRuntimeStatusMock.mockReset();
+    auditLogsListMock.mockReset();
+    auditLogsListMock.mockResolvedValue({ data: [], meta: {} });
+    teamListMembersMock.mockReset();
+    teamListMembersMock.mockResolvedValue({ data: [], meta: {} });
     settingsGetMock.mockResolvedValue({
       data: {
         id: "org-1",

--- a/frontend/src/app/(dashboard)/settings/runtime/page.tsx
+++ b/frontend/src/app/(dashboard)/settings/runtime/page.tsx
@@ -13,6 +13,7 @@ import { AutosaveIndicator } from "@/components/AutosaveIndicator";
 import { CopyButton } from "@/components/copy-button";
 import { PageContainer } from "@/components/page-container";
 import { PageHeader } from "@/components/page-header";
+import { SettingsLastActivity } from "@/components/settings/settings-last-activity";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import {
@@ -1192,6 +1193,10 @@ export default function RuntimeSettingsPage() {
           <CapacityLimitsSection />
           <SessionsAndCleanupSection />
           <ResourceDefaultsSection />
+          <SettingsLastActivity
+            scopes={{ resource_type: "settings" }}
+            title="Sandbox settings activity"
+          />
         </div>
       </TooltipProvider>
     </PageContainer>

--- a/frontend/src/app/(dashboard)/settings/team/page.tsx
+++ b/frontend/src/app/(dashboard)/settings/team/page.tsx
@@ -43,7 +43,7 @@ import { PageContainer } from "@/components/page-container";
 import { VerifiedDomainsSection } from "@/components/settings/verified-domains-section";
 import { CLIJoinTokensCard } from "@/components/cli-join-tokens-card";
 import { useAuth } from "@/hooks/use-auth";
-import { AuditLogTrigger } from "@/components/audit/audit-log-trigger";
+import { SettingsLastActivity } from "@/components/settings/settings-last-activity";
 import { roleLabel } from "@/lib/roles";
 import type {
   User,
@@ -517,11 +517,15 @@ export default function TeamSettingsPage() {
       {/* CLI install links (admin-only: creating one hands out membership) */}
       {canManageTeam && <CLIJoinTokensCard />}
 
-      <AuditLogTrigger
-        filters={{ resource_type: "team_member" }}
+      <SettingsLastActivity
+        scopes={[
+          { resource_type: "team_member" },
+          { resource_type: "invitation" },
+          { resource_type: "organization_domain" },
+          { resource_type: "org_join_token" },
+        ]}
         members={members}
         title="Team activity"
-        variant="footer"
       />
 
       {/* Invite Member Dialog */}

--- a/frontend/src/components/audit/audit-log-trigger.test.tsx
+++ b/frontend/src/components/audit/audit-log-trigger.test.tsx
@@ -122,6 +122,48 @@ describe('AuditLogTrigger', () => {
     expect(container.querySelector('svg')).not.toBeNull();
   });
 
+  it('footer variant: chooses the newest entry across multiple resource scopes', async () => {
+    auditLogListMock.mockImplementation((params: { resource_type?: string }) => {
+      if (params.resource_type === 'settings') {
+        return Promise.resolve({
+          data: [{
+            id: 'audit-settings',
+            actor_type: 'user',
+            user_id: 'user-1',
+            action: 'settings.updated',
+            created_at: new Date(Date.now() - 10 * 60000).toISOString(),
+          }],
+          meta: {},
+        });
+      }
+      return Promise.resolve({
+        data: [{
+          id: 'audit-credential',
+          actor_type: 'system',
+          actor_id: 'system',
+          action: 'credential.updated',
+          created_at: new Date(Date.now() - 2 * 60000).toISOString(),
+        }],
+        meta: {},
+      });
+    });
+
+    renderWithProviders(
+      <AuditLogTrigger
+        filters={[{ resource_type: 'settings' }, { resource_type: 'credential' }]}
+        members={mockMembers}
+        variant="footer"
+      />
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText(/Last activity:/)).toBeInTheDocument();
+      expect(screen.getByText(/Updated.*ago by System/)).toBeInTheDocument();
+    });
+    expect(auditLogListMock).toHaveBeenCalledWith({ resource_type: 'settings', limit: 1 });
+    expect(auditLogListMock).toHaveBeenCalledWith({ resource_type: 'credential', limit: 1 });
+  });
+
   it('default variant: renders the Clock icon and no separator', async () => {
     auditLogListMock.mockResolvedValue({
       data: [{

--- a/frontend/src/components/audit/audit-log-trigger.tsx
+++ b/frontend/src/components/audit/audit-log-trigger.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { useState } from "react";
-import { useQuery } from "@tanstack/react-query";
+import { useEffect, useState } from "react";
+import { useQueries, useQuery } from "@tanstack/react-query";
 import { Clock } from "lucide-react";
 import { api } from "@/lib/api";
 import { captureError } from "@/lib/errors";
@@ -13,7 +13,7 @@ import { AuditLogSidesheet } from "./audit-log-sidesheet";
 
 interface AuditLogTriggerProps {
   /** Filters to scope the audit log query (e.g., { session_id: "..." }). */
-  filters: Record<string, string>;
+  filters: Record<string, string> | Record<string, string>[];
   /** Team members for resolving actor names. If omitted, fetched internally. */
   members?: User[];
   /** Sidesheet title. */
@@ -32,6 +32,7 @@ export function AuditLogTrigger({ filters, members: membersProp, title, variant 
   const [open, setOpen] = useState(false);
   const { user } = useAuth();
   const isAdmin = user?.role === "admin";
+  const filterList = Array.isArray(filters) ? filters : [filters];
 
   // Fetch members internally when not provided by parent
   const { data: membersData } = useQuery({
@@ -41,18 +42,33 @@ export function AuditLogTrigger({ filters, members: membersProp, title, variant 
   });
   const members = membersProp ?? membersData?.data ?? [];
 
-  // Fetch just the latest entry to show "Updated X ago by Y"
-  const { data, error } = useQuery({
-    queryKey: ["audit-logs", "latest", filters],
-    queryFn: () => api.auditLogs.list({ ...filters, limit: 1 }),
-    enabled: isAdmin,
+  // Fetch just the latest entry from each scope to show the newest activity.
+  const latestQueries = useQueries({
+    queries: filterList.map((filter) => ({
+      queryKey: ["audit-logs", "latest", filter],
+      queryFn: () => api.auditLogs.list({ ...filter, limit: 1 }),
+      enabled: isAdmin,
+    })),
   });
 
-  if (error) {
-    captureError(error, { feature: "audit-log" });
-  }
+  useEffect(() => {
+    for (const query of latestQueries) {
+      if (query.error) {
+        captureError(query.error, { feature: "audit-log" });
+      }
+    }
+  // Depend on individual error objects so the effect fires once per new error identity.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, latestQueries.map((q) => q.error));
 
-  const latestEntry = data?.data?.[0];
+  const latestResult = latestQueries
+    .map((query, index) => ({ entry: query.data?.data?.[0], filters: filterList[index] }))
+    .filter((result): result is { entry: NonNullable<(typeof result)["entry"]>; filters: Record<string, string> } =>
+      Boolean(result.entry),
+    )
+    .sort((a, b) => new Date(b.entry.created_at).getTime() - new Date(a.entry.created_at).getTime())[0];
+  const latestEntry = latestResult?.entry;
+  const sidesheetFilters = latestResult?.filters ?? filterList[0] ?? {};
 
   // Don't render anything if there's no audit history
   if (!latestEntry) return null;
@@ -90,7 +106,7 @@ export function AuditLogTrigger({ filters, members: membersProp, title, variant 
         <AuditLogSidesheet
           open={open}
           onOpenChange={setOpen}
-          filters={filters}
+          filters={sidesheetFilters}
           title={title}
           members={members}
         />
@@ -120,7 +136,7 @@ export function AuditLogTrigger({ filters, members: membersProp, title, variant 
       <AuditLogSidesheet
         open={open}
         onOpenChange={setOpen}
-        filters={filters}
+        filters={sidesheetFilters}
         title={title}
         members={members}
       />

--- a/frontend/src/components/settings/settings-last-activity.tsx
+++ b/frontend/src/components/settings/settings-last-activity.tsx
@@ -1,0 +1,16 @@
+"use client";
+
+import { AuditLogTrigger } from "@/components/audit/audit-log-trigger";
+import type { AuditResourceType, User } from "@/lib/types";
+
+type ActivityScope = { resource_type: AuditResourceType };
+
+interface SettingsLastActivityProps {
+  scopes: ActivityScope | ActivityScope[];
+  members?: User[];
+  title: string;
+}
+
+export function SettingsLastActivity({ scopes, members, title }: SettingsLastActivityProps) {
+  return <AuditLogTrigger filters={scopes} members={members} title={title} variant="footer" />;
+}

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -2607,7 +2607,23 @@ export type AuditResourceType =
   | "credential"
   | "user"
   | "api_client"
-  | "api_token";
+  | "api_token"
+  | "session_review_comment"
+  | "pm_document"
+  | "pm_document_set"
+  | "eval_task"
+  | "eval_run"
+  | "eval_batch"
+  | "organization"
+  | "preview_secret_bundle"
+  | "preview_policy"
+  | "pr_readiness_policy"
+  | "pr_readiness_custom_check"
+  | "pr_readiness_bypass"
+  | "cli_token"
+  | "org_join_token"
+  | "cli_tool"
+  | "organization_domain";
 
 export interface AuditLog {
   id: number;


### PR DESCRIPTION
## Summary

Settings users currently get inconsistent “last activity” visibility across different settings sections, making it harder to audit recent changes. This change adds a shared `SettingsLastActivity` component to each settings page with the correct audit scopes, so the UI workflow is uniform and driven by explicit backend filter parameters.

## Changes

- Introduce `SettingsLastActivity` usage across settings pages (account, agent, api keys, autopilot, integrations, llm, previews, runtime, team, and general settings).
- Pass explicit `scopes` and page-specific `title` so the audit query targets the right resources per page.
- Update settings audit types used by the component (`frontend/src/lib/types.ts`) and adjust audit trigger logic/tests to match the new contract.

## Validation

- Updated/added React page/component tests for settings + audit trigger behavior:
  - `frontend/src/app/(dashboard)/settings/integrations/page.test.tsx`
  - `frontend/src/app/(dashboard)/settings/llm/page.test.tsx`
  - `frontend/src/app/(dashboard)/settings/runtime/page.test.tsx`
  - `frontend/src/components/audit/audit-log-trigger.test.tsx`
- Run the frontend test suite/CI to confirm rendering and audit-trigger behavior for each settings page.

[143.dev](https://143.dev) | [session cbc6563d](https://143.dev/sessions/cbc6563d-8895-4f09-8a69-02b50e34faf9)

<!-- 143 readiness -->
**143 readiness:** not available for this revision.

Preview: https://143.dev/previews/github/assembledhq/143/pull/1549?launch=1