### PR TITLE
Skip terminal previews during runtime heartbeat

### DIFF
--- a/internal/db/preview_store.go
+++ b/internal/db/preview_store.go
@@ -2604,13 +2604,19 @@ func (s *PreviewStore) MarkPreviewRuntimesDrainingByWorker(ctx context.Context, 
 	return tag.RowsAffected(), nil
 }
 
-// HeartbeatPreviewRuntimesByWorker extends leases for live runtimes owned by a worker.
+// HeartbeatPreviewRuntimesByWorker extends leases for live runtimes owned by
+// active previews on a worker.
 // lint:allow-no-orgid reason="cross-org worker heartbeat extends runtimes owned by this node"
 func (s *PreviewStore) HeartbeatPreviewRuntimesByWorker(ctx context.Context, workerNodeID string, leaseExpiresAt time.Time) (int64, error) {
 	tag, err := s.db.Exec(ctx,
-		fmt.Sprintf(`UPDATE preview_runtimes
+		fmt.Sprintf(`UPDATE preview_runtimes pr
 		 SET last_heartbeat_at = now(), lease_expires_at = @lease_expires_at, updated_at = now()
-		 WHERE worker_node_id = @worker AND status IN %s`, activeRuntimeStatusFilter),
+		 FROM preview_instances pi
+		 WHERE pr.preview_instance_id = pi.id
+		   AND pr.org_id = pi.org_id
+		   AND pr.worker_node_id = @worker
+		   AND pr.status IN %s
+		   AND pi.status IN %s`, activeRuntimeStatusFilter, activeStatusFilter),
 		pgx.NamedArgs{"worker": workerNodeID, "lease_expires_at": leaseExpiresAt},
 	)
 	if err != nil {

--- a/internal/db/preview_store_test.go
+++ b/internal/db/preview_store_test.go
@@ -3894,6 +3894,26 @@ func TestPreviewStore_ListActivePreviewRuntimesForReachability(t *testing.T) {
 	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
 }
 
+func TestPreviewStore_HeartbeatPreviewRuntimesByWorkerSkipsTerminalPreviews(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "pgx mock should initialize")
+	defer mock.Close()
+
+	store := NewPreviewStore(mock)
+	leaseExpiresAt := time.Now().UTC().Add(90 * time.Second)
+
+	mock.ExpectExec("UPDATE preview_runtimes pr[\\s\\S]+FROM preview_instances pi[\\s\\S]+pi.status IN \\('starting', 'ready', 'partially_ready', 'unhealthy'\\)").
+		WithArgs(previewAnyArgs(2)...).
+		WillReturnResult(pgxmock.NewResult("UPDATE", 3))
+
+	updated, err := store.HeartbeatPreviewRuntimesByWorker(context.Background(), "worker-1", leaseExpiresAt)
+	require.NoError(t, err, "HeartbeatPreviewRuntimesByWorker should extend active preview runtime leases")
+	require.Equal(t, int64(3), updated, "HeartbeatPreviewRuntimesByWorker should report updated runtime rows")
+	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
+}
+
 func TestPreviewStore_MarkActivePreviewRuntimesLostByWorkerMarksPreviewUnavailable(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- Restrict worker heartbeat updates to runtimes whose parent previews are still active
- Keep runtime lease extension limited to matching preview/runtime org and status pairs
- Add a regression test covering skipped terminal previews

## Testing
- Added unit coverage for `HeartbeatPreviewRuntimesByWorker` to verify terminal previews are not heartbeated