### PR TITLE
Refine “Merge when ready stopped” banner to keep Retry aligned and test grouped state

### DIFF
--- a/frontend/src/app/(dashboard)/sessions/[id]/page-pr-health.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/page-pr-health.test.tsx
@@ -846,6 +846,48 @@ describe('SessionDetailPage PR health and merge', () => {
     expect(mergeButton).toHaveAttribute('title', 'Waiting for GitHub to confirm required checks.');
   });
 
+  it('groups a stopped merge when ready state with its retry action', async () => {
+    let retryRequested = false;
+
+    server.use(
+      http.get('/api/v1/pull-requests/:id/health', () => {
+        return HttpResponse.json({
+          data: {
+            ...mockPRHealth,
+            merge_state: 'blocked' as const,
+            can_merge: false,
+            checks_confirmed: true,
+            summary: 'PR #42 is blocked by GitHub merge requirements.',
+            merge_when_ready: {
+              state: 'failed' as const,
+              last_error: 'Fix failing checks before enabling merge when ready.',
+              requested_head_sha: 'head-sha',
+              requested_health_version: 1,
+            },
+          },
+        } satisfies SingleResponse<typeof mockPRHealth>);
+      }),
+      http.post('/api/v1/pull-requests/:id/merge-when-ready', () => {
+        retryRequested = true;
+        return HttpResponse.json({
+          data: { state: 'queued', requested_head_sha: 'head-sha', requested_health_version: 1 },
+        });
+      }),
+    );
+
+    const user = userEvent.setup();
+    renderWithProviders(<SessionDetailContent id="session-abcdef12-3456-7890" />);
+
+    const stoppedNotice = await screen.findByRole('status', { name: 'Merge when ready stopped' });
+    expect(within(stoppedNotice).getByText(/Fix failing checks before enabling merge when ready\./)).toBeInTheDocument();
+
+    await user.click(within(stoppedNotice).getByRole('button', { name: 'Retry merge when ready' }));
+
+    await waitFor(() => {
+      expect(retryRequested).toBe(true);
+    });
+  });
+
   it('shows the Merge button when GitHub has confirmed that the repo has no CI checks configured', async () => {
     server.use(
       http.get('/api/v1/pull-requests/:id/health', () => {

--- a/frontend/src/app/(dashboard)/settings/autopilot/page.tsx
+++ b/frontend/src/app/(dashboard)/settings/autopilot/page.tsx
@@ -39,7 +39,7 @@ import {
   PM_SCHEDULE_MAX_HOURS,
   clampNumber,
 } from "@/lib/settings-constants";
-import type { CodingCredentialSummary, ListResponse, Organization, OrgSettings, RepoSettings, Repository, SingleResponse } from "@/lib/types";
+import type { CodingCredentialSummary, ListResponse, Organization, OrgSettings, Repository, SingleResponse } from "@/lib/types";
 
 export default function AutopilotSettingsPage() {
   const { user } = useAuth();
@@ -74,7 +74,7 @@ export default function AutopilotSettingsPage() {
   const settings = (settingsResponse?.data?.settings ?? {}) as OrgSettings;
   const repositories = repositoriesResponse?.data ?? [];
   const reposWithCustomPM = repositories.filter((repository) => {
-    const repoSettings = (repository.settings ?? {}) as RepoSettings;
+    const repoSettings = repository.settings as { pm?: unknown };
     return repoSettings.pm != null;
   });
   const resolvedCredentials = useMemo(

--- a/frontend/src/components/pr-health-banner.tsx
+++ b/frontend/src/components/pr-health-banner.tsx
@@ -417,12 +417,28 @@ export function PRHealthBanner({
                   </p>
                 )}
                 {health.merge_when_ready.state === "failed" && health.merge_when_ready.last_error && (
-                  <div className="flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
-                    <span>Merge when ready stopped: {health.merge_when_ready.last_error}</span>
+                  <div
+                    role="status"
+                    aria-label="Merge when ready stopped"
+                    className="flex flex-col gap-1.5 text-xs text-muted-foreground sm:flex-row sm:items-center sm:justify-between sm:gap-2"
+                  >
+                    <span className="min-w-0">
+                      Merge when ready stopped: {health.merge_when_ready.last_error}
+                    </span>
                     {onQueueMergeWhenReady && (
-                      <Button size="sm" variant="ghost" className="h-6 px-2 text-xs" onClick={onQueueMergeWhenReady} disabled={mergeWhenReadyAction.disabled || mergeWhenReadyPending}>
-                        Retry
-                      </Button>
+                      <DisabledTooltip disabled={mergeWhenReadyAction.disabled || mergeWhenReadyPending} content={mergeWhenReadyAction.disabledReason}>
+                        <Button
+                          size="sm"
+                          variant="ghost"
+                          className="h-6 w-fit shrink-0 px-2 text-xs"
+                          onClick={onQueueMergeWhenReady}
+                          disabled={mergeWhenReadyAction.disabled || mergeWhenReadyPending}
+                          title={mergeWhenReadyAction.disabledReason}
+                          aria-label="Retry merge when ready"
+                        >
+                          {mergeWhenReadyAction.spinning ? "Retrying…" : "Retry"}
+                        </Button>
+                      </DisabledTooltip>
                     )}
                   </div>
                 )}


### PR DESCRIPTION
## Summary

“Merge when ready stopped” currently uses a heavier/wider layout that can visually detach the **Retry merge when ready** action from the stopped message, making it easier to miss or misinterpret—especially on narrow screens. This change restores a lightweight inline row for the stopped state (muted text on the left, Retry on the right) while keeping the Retry affordance clearly grouped with the stopped notice. It also adds a regression test to ensure the stopped status and its Retry action remain associated.

## Changes

- Update `PRHealthBanner` stopped (`merge_when_ready.state === 'failed'`) UI to render as a compact, responsive row:
  - Left-aligned muted stopped text
  - Right-aligned `Retry` button when `onQueueMergeWhenReady` is available
  - Adds `role="status"` + `aria-label="Merge when ready stopped"` for stable querying/accessibility
- Replace the previous structure with a flex layout that stacks cleanly on small screens while preserving left/right grouping on larger screens
- Add a page test to verify the stopped state shows the correct error text and that clicking **Retry merge when ready** triggers the expected API call

## Validation

- `vitest` (focused session PR health test)
- `npm run typecheck`
- `npm run lint`
- `npm run build`

[143.dev](https://143.dev) | [session 7290ddb5](https://143.dev/sessions/7290ddb5-34ad-4196-839d-59bb70678654)

<!-- 143 readiness -->
**143 readiness:** not available for this revision.

Preview: https://143.dev/previews/github/assembledhq/143/pull/1552?launch=1