### PR TITLE
Surface preview failures instead of an infinite launch spinner

### DIFF
--- a/frontend/src/app/(dashboard)/previews/[id]/page.test.tsx
+++ b/frontend/src/app/(dashboard)/previews/[id]/page.test.tsx
@@ -216,6 +216,39 @@ describe("PreviewLandingPage launch mode", () => {
     expect(restartCalls).toBe(1);
   }, 10_000);
 
+  it("surfaces an error instead of an iframe when the preview is unhealthy", async () => {
+    server.use(
+      http.get("*/api/v1/previews/target-1", () =>
+        HttpResponse.json({
+          data: {
+            target_id: "target-1",
+            preview_id: "prev-1",
+            repository_id: "repo-1",
+            repository_full_name: "acme/web",
+            branch: "feature/preview",
+            commit_sha: "529975ce1faa2961ef3f23abde2418bf561116d9",
+            source_type: "pull_request",
+            status: "unhealthy",
+            error: 'primary service "frontend" stopped: exited with code 137',
+            current_phase: "ready",
+            stable_url: "https://143.dev/previews/target-1",
+            preview_url: "https://target-1.preview.143.dev",
+          },
+        }),
+      ),
+    );
+
+    renderLaunchPage();
+
+    expect(await screen.findByRole("heading", { name: "Preview could not open" })).toBeInTheDocument();
+    expect(
+      screen.getByText('primary service "frontend" stopped: exited with code 137'),
+    ).toBeInTheDocument();
+    // No bootstrap handshake against the dead process.
+    expect(screen.queryByTitle("Preview bootstrap")).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Retry preview" })).toBeEnabled();
+  });
+
   it("notifies the opener and closes in popup mode instead of navigating", async () => {
     searchParams = new URLSearchParams("launch=1&popup=1");
 

--- a/frontend/src/app/(dashboard)/previews/[id]/page.tsx
+++ b/frontend/src/app/(dashboard)/previews/[id]/page.tsx
@@ -39,7 +39,7 @@ import {
 import { Separator } from "@/components/ui/separator";
 import { api } from "@/lib/api";
 import type { BranchPreviewResponse, SingleResponse } from "@/lib/types";
-import { ACTIVE_PREVIEW_STATUSES, CONTROLLABLE_PREVIEW_STATUSES, formatPreviewStatus, type PreviewStatus } from "@/lib/preview-types";
+import { ACTIVE_PREVIEW_STATUSES, formatPreviewStatus, type PreviewStatus } from "@/lib/preview-types";
 import {
   PREVIEW_BOOTSTRAP_COMPLETE_EVENT,
   PREVIEW_BOOTSTRAP_READY_EVENT,
@@ -91,7 +91,15 @@ export function PreviewLandingContent({ id }: { id: string }) {
     queryFn: () => api.previews.get(id),
     refetchInterval: (query) => {
       const status = query.state.data?.data.status;
-      return status === "starting" ? pollMs(3000) : false;
+      if (status === "starting") return pollMs(3000);
+      // Keep a slow poll while the preview is nominally up so a runtime
+      // crash that demotes it to "unhealthy"/"failed" (e.g. an OOM kill at
+      // serve time) is observed, instead of leaving the launch iframe
+      // spinning forever against a dead process.
+      if (status === "ready" || status === "partially_ready" || status === "unhealthy") {
+        return pollMs(15000);
+      }
+      return false;
     },
   });
 
@@ -118,7 +126,12 @@ export function PreviewLandingContent({ id }: { id: string }) {
   const isFailed = preview?.status === "failed";
   const isStarting = preview?.status === "starting" || restartPreview.isPending;
   const isActive = Boolean(previewStatus && ACTIVE_PREVIEW_STATUSES.includes(previewStatus));
-  const isReady = Boolean(previewStatus && CONTROLLABLE_PREVIEW_STATUSES.includes(previewStatus));
+  // "unhealthy" is intentionally excluded: the primary service has crashed, so
+  // the preview can't actually serve and we must not try to bootstrap/iframe
+  // into it. It's surfaced as an error (see isUnhealthy / launchError) while
+  // lifecycle controls stay available via isActive.
+  const isReady = previewStatus === "ready" || previewStatus === "partially_ready";
+  const isUnhealthy = previewStatus === "unhealthy";
   const previewUrl = safeExternalUrl(preview?.preview_url);
   const previewOrigin = useMemo(() => {
     if (!previewUrl) return "";
@@ -145,8 +158,11 @@ export function PreviewLandingContent({ id }: { id: string }) {
   const launchTargetId = preview?.preview_id ?? preview?.target_id;
   const launchError =
     bootstrapError ??
-    (preview?.status === "failed" ? preview.error || "Preview failed to start." : null);
-  const commandIsFailed = isFailed || Boolean(bootstrapError);
+    (preview?.status === "failed" ? preview.error || "Preview failed to start." : null) ??
+    (isUnhealthy
+      ? preview?.error || "The preview stopped responding — a service crashed (often out of memory). Restart to try again."
+      : null);
+  const commandIsFailed = isFailed || isUnhealthy || Boolean(bootstrapError);
 
   const shouldStartForLaunch =
     launchMode &&

--- a/frontend/src/app/(dashboard)/settings/autopilot/page.tsx
+++ b/frontend/src/app/(dashboard)/settings/autopilot/page.tsx
@@ -39,7 +39,7 @@ import {
   PM_SCHEDULE_MAX_HOURS,
   clampNumber,
 } from "@/lib/settings-constants";
-import type { CodingCredentialSummary, ListResponse, Organization, OrgSettings, RepoSettings, Repository, SingleResponse } from "@/lib/types";
+import type { CodingCredentialSummary, ListResponse, Organization, OrgSettings, Repository, SingleResponse } from "@/lib/types";
 
 export default function AutopilotSettingsPage() {
   const { user } = useAuth();

--- a/internal/services/preview/manager.go
+++ b/internal/services/preview/manager.go
@@ -658,7 +658,7 @@ func (m *Manager) LaunchPreview(ctx context.Context, instance *models.PreviewIns
 	if metricsSource == "" {
 		metricsSource = input.Initiator
 	}
-	observer := m.newServiceObserver(input.OrgID, instance.ID, metricsSource, input.MetricsRepositoryFullName)
+	observer := m.newServiceObserver(input.OrgID, instance.ID, metricsSource, input.MetricsRepositoryFullName, input.Config.Primary)
 	defer observer.Close()
 	handle, err := m.provider.StartPreview(ctx, input.Sandbox, input.Config, StartPreviewOptions{
 		OrgID:        input.OrgID,
@@ -860,18 +860,19 @@ func (m *Manager) AbortReservation(parentCtx context.Context, instance *models.P
 // callbacks fired after StartPreview returns (progressive support services,
 // the startService goroutine catching a non-zero exit) still land in the DB
 // even if the request context has already been canceled.
-func (m *Manager) newServiceObserver(orgID, previewID uuid.UUID, metricsSource, metricsRepo string) *managerServiceObserver {
+func (m *Manager) newServiceObserver(orgID, previewID uuid.UUID, metricsSource, metricsRepo, primaryService string) *managerServiceObserver {
 	observer := &managerServiceObserver{
-		manager:       m,
-		orgID:         orgID,
-		previewID:     previewID,
-		source:        strings.TrimSpace(metricsSource),
-		repository:    strings.TrimSpace(metricsRepo),
-		phaseStarts:   make(map[string]time.Time),
-		outputCh:      make(chan previewServiceOutput, serviceOutputBufferSize),
-		outputDone:    make(chan struct{}),
-		lifecycleCh:   make(chan previewLifecycleLog, lifecycleLogBufferSize),
-		lifecycleDone: make(chan struct{}),
+		manager:        m,
+		orgID:          orgID,
+		previewID:      previewID,
+		source:         strings.TrimSpace(metricsSource),
+		repository:     strings.TrimSpace(metricsRepo),
+		primaryService: strings.TrimSpace(primaryService),
+		phaseStarts:    make(map[string]time.Time),
+		outputCh:       make(chan previewServiceOutput, serviceOutputBufferSize),
+		outputDone:     make(chan struct{}),
+		lifecycleCh:    make(chan previewLifecycleLog, lifecycleLogBufferSize),
+		lifecycleDone:  make(chan struct{}),
 	}
 	go observer.runServiceOutputWriter()
 	go observer.runLifecycleLogWriter()
@@ -879,20 +880,25 @@ func (m *Manager) newServiceObserver(orgID, previewID uuid.UUID, metricsSource, 
 }
 
 type managerServiceObserver struct {
-	manager       *Manager
-	orgID         uuid.UUID
-	previewID     uuid.UUID
-	source        string
-	repository    string
-	phaseMu       sync.Mutex
-	phaseStarts   map[string]time.Time
-	outputCh      chan previewServiceOutput
-	outputDone    chan struct{}
-	lifecycleCh   chan previewLifecycleLog
-	lifecycleDone chan struct{}
-	outputMu      sync.Mutex
-	outputClosed  bool
-	closeOnce     sync.Once
+	manager    *Manager
+	orgID      uuid.UUID
+	previewID  uuid.UUID
+	source     string
+	repository string
+	// primaryService is the name of the config's primary service. When that
+	// service dies, the whole preview can no longer serve, so OnServiceFailed
+	// demotes the instance to "unhealthy" (see below). Empty for flows that
+	// don't supply it (the demotion is then skipped).
+	primaryService string
+	phaseMu        sync.Mutex
+	phaseStarts    map[string]time.Time
+	outputCh       chan previewServiceOutput
+	outputDone     chan struct{}
+	lifecycleCh    chan previewLifecycleLog
+	lifecycleDone  chan struct{}
+	outputMu       sync.Mutex
+	outputClosed   bool
+	closeOnce      sync.Once
 }
 
 const observerWriteTimeout = 5 * time.Second
@@ -1134,6 +1140,28 @@ func (o *managerServiceObserver) OnServiceFailed(name, errMsg string, tail []str
 			Str("preview_id", o.previewID.String()).
 			Str("service", name).
 			Msg("observer: failed to write preview log")
+	}
+
+	// When the primary service dies the preview can no longer serve, but the
+	// instance row is left at whatever status it last reached (typically
+	// "ready"). A crash *after* readiness — e.g. an OOM kill at serve time —
+	// otherwise leaves the instance stuck at "ready" forever, so the launch
+	// page renders the iframe against a dead process and spins indefinitely.
+	// Demote the instance to "unhealthy" so consumers (the launch page, the
+	// gateway, listings) can surface the failure and offer a restart.
+	// UpdatePreviewStatusIfActive only transitions non-terminal rows, so this
+	// never clobbers a concurrent stop/expire and stays reversible: a later
+	// readiness write can promote it back to ready/partially_ready.
+	if o.primaryService != "" && name == o.primaryService {
+		demoteErr := fmt.Sprintf("primary service %q stopped: %s", name, errMsg)
+		if _, err := o.manager.store.UpdatePreviewStatusIfActive(
+			ctx, o.orgID, o.previewID, models.PreviewStatusUnhealthy, demoteErr,
+		); err != nil {
+			o.manager.logger.Warn().Err(err).
+				Str("preview_id", o.previewID.String()).
+				Str("service", name).
+				Msg("observer: failed to demote preview to unhealthy after primary service failure")
+		}
 	}
 }
 
@@ -1903,7 +1931,7 @@ func (m *Manager) ResumeStoppedWarmPreview(ctx context.Context, orgID, previewID
 		m.logger.Warn().Err(err).Str("preview_id", previewID.String()).Msg("warm resume: failed to revoke access sessions")
 	}
 
-	observer := m.newServiceObserver(orgID, previewID, "", "")
+	observer := m.newServiceObserver(orgID, previewID, "", "", instance.PrimaryService)
 	defer observer.Close()
 	if err := m.resolvePreviewSecrets(ctx, input); err != nil {
 		if statusErr := m.store.UpdatePreviewStatus(ctx, orgID, previewID, models.PreviewStatusFailed, err.Error()); statusErr != nil {
@@ -2098,7 +2126,7 @@ func (m *Manager) recyclePreview(ctx context.Context, orgID, previewID uuid.UUID
 
 	// Restart via provider with same sandbox and config. Use the existing
 	// instance ID so PREVIEW_ORIGIN stays stable across recycles.
-	observer := m.newServiceObserver(orgID, previewID, "", "")
+	observer := m.newServiceObserver(orgID, previewID, "", "", instance.PrimaryService)
 	defer observer.Close()
 	if err := m.resolvePreviewSecrets(ctx, input); err != nil {
 		if statusErr := m.store.UpdatePreviewStatus(ctx, orgID, previewID, models.PreviewStatusFailed, err.Error()); statusErr != nil {

--- a/internal/services/preview/manager.go
+++ b/internal/services/preview/manager.go
@@ -658,7 +658,7 @@ func (m *Manager) LaunchPreview(ctx context.Context, instance *models.PreviewIns
 	if metricsSource == "" {
 		metricsSource = input.Initiator
 	}
-	observer := m.newServiceObserver(input.OrgID, instance.ID, metricsSource, input.MetricsRepositoryFullName, input.Config.Primary)
+	observer := m.newServiceObserver(input.OrgID, instance.ID, metricsSource, input.MetricsRepositoryFullName, input.Config.Primary, instance.MemoryLimitMB)
 	defer observer.Close()
 	handle, err := m.provider.StartPreview(ctx, input.Sandbox, input.Config, StartPreviewOptions{
 		OrgID:        input.OrgID,
@@ -860,7 +860,7 @@ func (m *Manager) AbortReservation(parentCtx context.Context, instance *models.P
 // callbacks fired after StartPreview returns (progressive support services,
 // the startService goroutine catching a non-zero exit) still land in the DB
 // even if the request context has already been canceled.
-func (m *Manager) newServiceObserver(orgID, previewID uuid.UUID, metricsSource, metricsRepo, primaryService string) *managerServiceObserver {
+func (m *Manager) newServiceObserver(orgID, previewID uuid.UUID, metricsSource, metricsRepo, primaryService string, memoryLimitMB int) *managerServiceObserver {
 	observer := &managerServiceObserver{
 		manager:        m,
 		orgID:          orgID,
@@ -868,6 +868,7 @@ func (m *Manager) newServiceObserver(orgID, previewID uuid.UUID, metricsSource, 
 		source:         strings.TrimSpace(metricsSource),
 		repository:     strings.TrimSpace(metricsRepo),
 		primaryService: strings.TrimSpace(primaryService),
+		memoryLimitMB:  memoryLimitMB,
 		phaseStarts:    make(map[string]time.Time),
 		outputCh:       make(chan previewServiceOutput, serviceOutputBufferSize),
 		outputDone:     make(chan struct{}),
@@ -890,15 +891,19 @@ type managerServiceObserver struct {
 	// demotes the instance to "unhealthy" (see below). Empty for flows that
 	// don't supply it (the demotion is then skipped).
 	primaryService string
-	phaseMu        sync.Mutex
-	phaseStarts    map[string]time.Time
-	outputCh       chan previewServiceOutput
-	outputDone     chan struct{}
-	lifecycleCh    chan previewLifecycleLog
-	lifecycleDone  chan struct{}
-	outputMu       sync.Mutex
-	outputClosed   bool
-	closeOnce      sync.Once
+	// memoryLimitMB is the preview's cgroup memory cap, surfaced in OOM
+	// failure messages so the cause is obvious without decoding exit codes.
+	// 0 when unknown (the cap is then omitted from the message).
+	memoryLimitMB int
+	phaseMu       sync.Mutex
+	phaseStarts   map[string]time.Time
+	outputCh      chan previewServiceOutput
+	outputDone    chan struct{}
+	lifecycleCh   chan previewLifecycleLog
+	lifecycleDone chan struct{}
+	outputMu      sync.Mutex
+	outputClosed  bool
+	closeOnce     sync.Once
 }
 
 const observerWriteTimeout = 5 * time.Second
@@ -1118,13 +1123,20 @@ func (o *managerServiceObserver) OnServiceReady(name string, port, pid int) {
 func (o *managerServiceObserver) OnServiceFailed(name, errMsg string, tail []string) {
 	ctx, cancel := context.WithTimeout(context.Background(), observerWriteTimeout)
 	defer cancel()
-	if err := o.manager.store.UpdateServiceStatus(ctx, o.orgID, o.previewID, name, models.PreviewServiceStatusFailed, errMsg); err != nil {
+
+	// Annotate OOM kills (exit 137 etc.) with a plain-English explanation and
+	// the memory cap, so the per-service error, the preview log, and the
+	// instance error all make the cause obvious instead of leaving a bare
+	// "exited with code 137" for the user to decode.
+	detail := annotatePreviewFailure(errMsg, o.memoryLimitMB)
+
+	if err := o.manager.store.UpdateServiceStatus(ctx, o.orgID, o.previewID, name, models.PreviewServiceStatusFailed, detail); err != nil {
 		o.manager.logger.Warn().Err(err).
 			Str("preview_id", o.previewID.String()).
 			Str("service", name).
 			Msg("observer: failed to mark service failed")
 	}
-	msg := fmt.Sprintf("service %q failed: %s", name, errMsg)
+	msg := fmt.Sprintf("service %q failed: %s", name, detail)
 	if len(tail) > 0 {
 		msg += "\n--- last output ---\n" + strings.Join(tail, "\n")
 	}
@@ -1153,7 +1165,7 @@ func (o *managerServiceObserver) OnServiceFailed(name, errMsg string, tail []str
 	// never clobbers a concurrent stop/expire and stays reversible: a later
 	// readiness write can promote it back to ready/partially_ready.
 	if o.primaryService != "" && name == o.primaryService {
-		demoteErr := fmt.Sprintf("primary service %q stopped: %s", name, errMsg)
+		demoteErr := fmt.Sprintf("primary service %q failed and the preview can no longer serve: %s", name, detail)
 		if _, err := o.manager.store.UpdatePreviewStatusIfActive(
 			ctx, o.orgID, o.previewID, models.PreviewStatusUnhealthy, demoteErr,
 		); err != nil {
@@ -1163,6 +1175,41 @@ func (o *managerServiceObserver) OnServiceFailed(name, errMsg string, tail []str
 				Msg("observer: failed to demote preview to unhealthy after primary service failure")
 		}
 	}
+}
+
+// looksLikeOOMFailure reports whether a service/exit failure message carries
+// the signature of an out-of-memory kill. Exit code 137 is 128+SIGKILL(9),
+// which inside a memory-capped preview container is almost always the kernel
+// OOM killer; Docker also reports "OOMKilled" in container state, and runtimes
+// print "out of memory" / "cannot allocate memory" on heap exhaustion.
+func looksLikeOOMFailure(errMsg string) bool {
+	m := strings.ToLower(errMsg)
+	return strings.Contains(m, "code 137") ||
+		strings.Contains(m, "signal: killed") ||
+		strings.Contains(m, "oomkilled") ||
+		strings.Contains(m, "out of memory") ||
+		strings.Contains(m, "cannot allocate memory")
+}
+
+// annotatePreviewFailure prefixes OOM failures with a plain-English
+// explanation (and the memory cap, when known) so preview errors are
+// debuggable without decoding exit codes. Non-OOM messages pass through
+// unchanged. memoryLimitMB <= 0 omits the cap.
+func annotatePreviewFailure(errMsg string, memoryLimitMB int) string {
+	if !looksLikeOOMFailure(errMsg) {
+		return errMsg
+	}
+	capText := ""
+	if memoryLimitMB > 0 {
+		capText = fmt.Sprintf(" The preview is capped at %d MiB of memory.", memoryLimitMB)
+	}
+	return fmt.Sprintf(
+		"ran out of memory and was killed (OOM, exit code 137 / SIGKILL).%s "+
+			"Reduce the workload's memory use — e.g. run fewer concurrent build "+
+			"steps, or serve a production build instead of a dev server. "+
+			"Original failure: %s",
+		capText, errMsg,
+	)
 }
 
 func (o *managerServiceObserver) OnInstallFailed(errMsg string, tail []string) {
@@ -1931,7 +1978,7 @@ func (m *Manager) ResumeStoppedWarmPreview(ctx context.Context, orgID, previewID
 		m.logger.Warn().Err(err).Str("preview_id", previewID.String()).Msg("warm resume: failed to revoke access sessions")
 	}
 
-	observer := m.newServiceObserver(orgID, previewID, "", "", instance.PrimaryService)
+	observer := m.newServiceObserver(orgID, previewID, "", "", instance.PrimaryService, instance.MemoryLimitMB)
 	defer observer.Close()
 	if err := m.resolvePreviewSecrets(ctx, input); err != nil {
 		if statusErr := m.store.UpdatePreviewStatus(ctx, orgID, previewID, models.PreviewStatusFailed, err.Error()); statusErr != nil {
@@ -2126,7 +2173,7 @@ func (m *Manager) recyclePreview(ctx context.Context, orgID, previewID uuid.UUID
 
 	// Restart via provider with same sandbox and config. Use the existing
 	// instance ID so PREVIEW_ORIGIN stays stable across recycles.
-	observer := m.newServiceObserver(orgID, previewID, "", "", instance.PrimaryService)
+	observer := m.newServiceObserver(orgID, previewID, "", "", instance.PrimaryService, instance.MemoryLimitMB)
 	defer observer.Close()
 	if err := m.resolvePreviewSecrets(ctx, input); err != nil {
 		if statusErr := m.store.UpdatePreviewStatus(ctx, orgID, previewID, models.PreviewStatusFailed, err.Error()); statusErr != nil {

--- a/internal/services/preview/manager_test.go
+++ b/internal/services/preview/manager_test.go
@@ -3318,7 +3318,7 @@ func TestManagerServiceObserver_OnServiceReady_WithPID(t *testing.T) {
 	mgr := newTestManager(mock, &mockProvider{})
 	orgID := uuid.New()
 	previewID := uuid.New()
-	obs := mgr.newServiceObserver(orgID, previewID, "", "", "")
+	obs := mgr.newServiceObserver(orgID, previewID, "", "", "", 0)
 
 	mock.ExpectExec("UPDATE preview_services SET status").
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
@@ -3339,7 +3339,7 @@ func TestManagerServiceObserver_OnServiceReady_NoPID(t *testing.T) {
 	defer mock.Close()
 
 	mgr := newTestManager(mock, &mockProvider{})
-	obs := mgr.newServiceObserver(uuid.New(), uuid.New(), "", "", "")
+	obs := mgr.newServiceObserver(uuid.New(), uuid.New(), "", "", "", 0)
 
 	// pid=0 must skip the second exec — the readiness probe runs before the
 	// PID-detection goroutine has had a chance to populate ss.pid for some
@@ -3360,7 +3360,7 @@ func TestManagerServiceObserver_OnServiceReady_DBErrorsLogged(t *testing.T) {
 	defer mock.Close()
 
 	mgr := newTestManager(mock, &mockProvider{})
-	obs := mgr.newServiceObserver(uuid.New(), uuid.New(), "", "", "")
+	obs := mgr.newServiceObserver(uuid.New(), uuid.New(), "", "", "", 0)
 
 	mock.ExpectExec("UPDATE preview_services SET status").
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
@@ -3383,7 +3383,7 @@ func TestManagerServiceObserver_OnServiceFailed_WithTail(t *testing.T) {
 	mgr := newTestManager(mock, &mockProvider{})
 	orgID := uuid.New()
 	previewID := uuid.New()
-	obs := mgr.newServiceObserver(orgID, previewID, "", "", "")
+	obs := mgr.newServiceObserver(orgID, previewID, "", "", "", 0)
 
 	mock.ExpectExec("UPDATE preview_services SET status").
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
@@ -3415,7 +3415,7 @@ func TestManagerServiceObserver_OnServiceFailed_PrimaryServiceDemotesInstance(t 
 	mgr := newTestManager(mock, &mockProvider{})
 	orgID := uuid.New()
 	previewID := uuid.New()
-	obs := mgr.newServiceObserver(orgID, previewID, "", "", "frontend")
+	obs := mgr.newServiceObserver(orgID, previewID, "", "", "frontend", 8192)
 
 	// Service row flips to failed.
 	mock.ExpectExec("UPDATE preview_services SET status").
@@ -3436,6 +3436,47 @@ func TestManagerServiceObserver_OnServiceFailed_PrimaryServiceDemotesInstance(t 
 	require.NoError(t, mock.ExpectationsWereMet())
 }
 
+func TestAnnotatePreviewFailure(t *testing.T) {
+	t.Parallel()
+
+	t.Run("oom exit 137 is explained with the memory cap", func(t *testing.T) {
+		t.Parallel()
+		got := annotatePreviewFailure("exited with code 137; last output: app compiled", 8192)
+		require.Contains(t, got, "ran out of memory")
+		require.Contains(t, got, "8192 MiB")
+		require.Contains(t, got, "exit code 137")
+		// The original failure is preserved for debugging.
+		require.Contains(t, got, "exited with code 137; last output: app compiled")
+	})
+
+	t.Run("oom without a known cap omits the cap text", func(t *testing.T) {
+		t.Parallel()
+		got := annotatePreviewFailure("signal: killed", 0)
+		require.Contains(t, got, "ran out of memory")
+		require.NotContains(t, got, "capped at")
+	})
+
+	t.Run("non-oom failures pass through unchanged", func(t *testing.T) {
+		t.Parallel()
+		// Exit 126 (permission) and disk exhaustion must not be mislabeled as OOM.
+		require.Equal(t, "exited with code 126", annotatePreviewFailure("exited with code 126", 8192))
+		require.Equal(t,
+			"build failed: no space left on device",
+			annotatePreviewFailure("build failed: no space left on device", 8192),
+		)
+	})
+
+	t.Run("looksLikeOOMFailure matches known signatures", func(t *testing.T) {
+		t.Parallel()
+		for _, msg := range []string{"exited with code 137", "signal: killed", "OOMKilled", "runtime: out of memory", "cannot allocate memory"} {
+			require.True(t, looksLikeOOMFailure(msg), msg)
+		}
+		for _, msg := range []string{"exited with code 1", "exited with code 126", "no space left on device", ""} {
+			require.False(t, looksLikeOOMFailure(msg), msg)
+		}
+	})
+}
+
 func TestManagerServiceObserver_OnInstallFailed_WithTail(t *testing.T) {
 	t.Parallel()
 
@@ -3446,7 +3487,7 @@ func TestManagerServiceObserver_OnInstallFailed_WithTail(t *testing.T) {
 	mgr := newTestManager(mock, &mockProvider{})
 	orgID := uuid.New()
 	previewID := uuid.New()
-	obs := mgr.newServiceObserver(orgID, previewID, "", "", "")
+	obs := mgr.newServiceObserver(orgID, previewID, "", "", "", 0)
 
 	logID := uuid.New()
 	mock.ExpectQuery("INSERT INTO preview_logs").
@@ -3470,7 +3511,7 @@ func TestManagerServiceObserver_OnInstallOutput_PersistsInstallLog(t *testing.T)
 	mgr := newTestManager(mock, &mockProvider{})
 	orgID := uuid.New()
 	previewID := uuid.New()
-	obs := mgr.newServiceObserver(orgID, previewID, "", "", "")
+	obs := mgr.newServiceObserver(orgID, previewID, "", "", "", 0)
 
 	logID := uuid.New()
 	mock.ExpectQuery("INSERT INTO preview_logs").
@@ -3494,7 +3535,7 @@ func TestManagerServiceObserver_OnPhaseStart_PersistsPreviewLog(t *testing.T) {
 	mgr := newTestManager(mock, &mockProvider{})
 	orgID := uuid.New()
 	previewID := uuid.New()
-	obs := mgr.newServiceObserver(orgID, previewID, "", "", "")
+	obs := mgr.newServiceObserver(orgID, previewID, "", "", "", 0)
 
 	mock.ExpectExec("UPDATE preview_instances SET current_phase").
 		WithArgs(pgx.NamedArgs{"id": previewID, "org_id": orgID, "phase": "dependency_cache_restore"}).
@@ -3547,7 +3588,7 @@ func TestManagerServiceObserver_OnDependencyCacheRestore_PersistsNonFailureStatu
 			mgr := newTestManager(mock, &mockProvider{})
 			orgID := uuid.New()
 			previewID := uuid.New()
-			obs := mgr.newServiceObserver(orgID, previewID, "", "", "")
+			obs := mgr.newServiceObserver(orgID, previewID, "", "", "", 0)
 
 			logID := uuid.New()
 			mock.ExpectQuery("INSERT INTO preview_logs").
@@ -3577,7 +3618,7 @@ func TestManagerServiceObserver_OnCacheRestore_EmitsPreviewHealthCacheEvent(t *t
 	})
 	orgID := uuid.New()
 	previewID := uuid.New()
-	obs := mgr.newServiceObserver(orgID, previewID, "", "", "")
+	obs := mgr.newServiceObserver(orgID, previewID, "", "", "", 0)
 	cacheKey := strings.Repeat("d", 64)
 
 	logID := uuid.New()
@@ -3614,7 +3655,7 @@ func TestManagerServiceObserver_OnPhaseStartAndEnd_PersistsLifecycleLogs(t *test
 	mgr := newTestManager(mock, &mockProvider{})
 	orgID := uuid.New()
 	previewID := uuid.New()
-	obs := mgr.newServiceObserver(orgID, previewID, "", "", "")
+	obs := mgr.newServiceObserver(orgID, previewID, "", "", "", 0)
 
 	mock.ExpectExec("UPDATE preview_instances SET current_phase").
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
@@ -3647,7 +3688,7 @@ func TestManagerServiceObserver_OnPhaseStart_DoesNotBlockOnLifecycleLogWrite(t *
 		Logger:       zerolog.Nop(),
 		WorkerNodeID: "worker-1",
 	})
-	obs := mgr.newServiceObserver(uuid.New(), uuid.New(), "", "", "")
+	obs := mgr.newServiceObserver(uuid.New(), uuid.New(), "", "", "", 0)
 
 	done := make(chan struct{})
 	go func() {
@@ -3708,7 +3749,7 @@ func TestManagerServiceObserver_OnCacheSave_PersistsSuccessfulStatuses(t *testin
 			mgr := newTestManager(mock, &mockProvider{})
 			orgID := uuid.New()
 			previewID := uuid.New()
-			obs := mgr.newServiceObserver(orgID, previewID, "", "", "")
+			obs := mgr.newServiceObserver(orgID, previewID, "", "", "", 0)
 			cacheKey := strings.Repeat("c", 64)
 
 			logID := uuid.New()
@@ -3734,7 +3775,7 @@ func TestManagerServiceObserver_OnServiceOutput_PersistsStartupLog(t *testing.T)
 	mgr := newTestManager(mock, &mockProvider{})
 	orgID := uuid.New()
 	previewID := uuid.New()
-	obs := mgr.newServiceObserver(orgID, previewID, "", "", "")
+	obs := mgr.newServiceObserver(orgID, previewID, "", "", "", 0)
 
 	logID := uuid.New()
 	mock.ExpectQuery("INSERT INTO preview_logs").
@@ -3791,7 +3832,7 @@ func TestManagerServiceObserver_OnServiceOutput_DoesNotBlockOnDatabaseWrites(t *
 		Logger:       zerolog.Nop(),
 		WorkerNodeID: "worker-1",
 	})
-	obs := mgr.newServiceObserver(uuid.New(), uuid.New(), "", "", "")
+	obs := mgr.newServiceObserver(uuid.New(), uuid.New(), "", "", "", 0)
 
 	done := make(chan struct{})
 	go func() {
@@ -3824,7 +3865,7 @@ func TestManagerServiceObserver_OnServiceFailed_NoTail(t *testing.T) {
 	mgr := newTestManager(mock, &mockProvider{})
 	orgID := uuid.New()
 	previewID := uuid.New()
-	obs := mgr.newServiceObserver(orgID, previewID, "", "", "")
+	obs := mgr.newServiceObserver(orgID, previewID, "", "", "", 0)
 
 	mock.ExpectExec("UPDATE preview_services SET status").
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
@@ -3848,7 +3889,7 @@ func TestManagerServiceObserver_OnServiceFailed_DBErrorsLogged(t *testing.T) {
 	defer mock.Close()
 
 	mgr := newTestManager(mock, &mockProvider{})
-	obs := mgr.newServiceObserver(uuid.New(), uuid.New(), "", "", "")
+	obs := mgr.newServiceObserver(uuid.New(), uuid.New(), "", "", "", 0)
 
 	// Both DB writes fail; the observer must log and return without panicking
 	// so a flaky DB doesn't crash the worker mid-launch.

--- a/internal/services/preview/manager_test.go
+++ b/internal/services/preview/manager_test.go
@@ -3318,7 +3318,7 @@ func TestManagerServiceObserver_OnServiceReady_WithPID(t *testing.T) {
 	mgr := newTestManager(mock, &mockProvider{})
 	orgID := uuid.New()
 	previewID := uuid.New()
-	obs := mgr.newServiceObserver(orgID, previewID, "", "")
+	obs := mgr.newServiceObserver(orgID, previewID, "", "", "")
 
 	mock.ExpectExec("UPDATE preview_services SET status").
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
@@ -3339,7 +3339,7 @@ func TestManagerServiceObserver_OnServiceReady_NoPID(t *testing.T) {
 	defer mock.Close()
 
 	mgr := newTestManager(mock, &mockProvider{})
-	obs := mgr.newServiceObserver(uuid.New(), uuid.New(), "", "")
+	obs := mgr.newServiceObserver(uuid.New(), uuid.New(), "", "", "")
 
 	// pid=0 must skip the second exec — the readiness probe runs before the
 	// PID-detection goroutine has had a chance to populate ss.pid for some
@@ -3360,7 +3360,7 @@ func TestManagerServiceObserver_OnServiceReady_DBErrorsLogged(t *testing.T) {
 	defer mock.Close()
 
 	mgr := newTestManager(mock, &mockProvider{})
-	obs := mgr.newServiceObserver(uuid.New(), uuid.New(), "", "")
+	obs := mgr.newServiceObserver(uuid.New(), uuid.New(), "", "", "")
 
 	mock.ExpectExec("UPDATE preview_services SET status").
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
@@ -3383,7 +3383,7 @@ func TestManagerServiceObserver_OnServiceFailed_WithTail(t *testing.T) {
 	mgr := newTestManager(mock, &mockProvider{})
 	orgID := uuid.New()
 	previewID := uuid.New()
-	obs := mgr.newServiceObserver(orgID, previewID, "", "")
+	obs := mgr.newServiceObserver(orgID, previewID, "", "", "")
 
 	mock.ExpectExec("UPDATE preview_services SET status").
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
@@ -3400,6 +3400,42 @@ func TestManagerServiceObserver_OnServiceFailed_WithTail(t *testing.T) {
 	require.NoError(t, mock.ExpectationsWereMet())
 }
 
+// When the failing service is the config's primary service, OnServiceFailed
+// must additionally demote the instance to "unhealthy" so a crash after
+// readiness (e.g. an OOM kill at serve time) doesn't leave the row stuck at
+// "ready" forever — which is what makes the launch page spin indefinitely
+// against a dead process.
+func TestManagerServiceObserver_OnServiceFailed_PrimaryServiceDemotesInstance(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err)
+	defer mock.Close()
+
+	mgr := newTestManager(mock, &mockProvider{})
+	orgID := uuid.New()
+	previewID := uuid.New()
+	obs := mgr.newServiceObserver(orgID, previewID, "", "", "frontend")
+
+	// Service row flips to failed.
+	mock.ExpectExec("UPDATE preview_services SET status").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
+	logID := uuid.New()
+	mock.ExpectQuery("INSERT INTO preview_logs").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(pgxmock.NewRows([]string{
+			"id", "preview_instance_id", "org_id", "level", "step", "message", "metadata", "created_at",
+		}).AddRow(logID, previewID, orgID, "error", "start", "msg", json.RawMessage(`null`), time.Now()))
+	// Instance is demoted via UpdatePreviewStatusIfActive (non-terminal path).
+	mock.ExpectExec("UPDATE preview_instances SET status = @status.+NOT IN").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
+
+	obs.OnServiceFailed("frontend", "exited with code 137", []string{"out of memory"})
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
 func TestManagerServiceObserver_OnInstallFailed_WithTail(t *testing.T) {
 	t.Parallel()
 
@@ -3410,7 +3446,7 @@ func TestManagerServiceObserver_OnInstallFailed_WithTail(t *testing.T) {
 	mgr := newTestManager(mock, &mockProvider{})
 	orgID := uuid.New()
 	previewID := uuid.New()
-	obs := mgr.newServiceObserver(orgID, previewID, "", "")
+	obs := mgr.newServiceObserver(orgID, previewID, "", "", "")
 
 	logID := uuid.New()
 	mock.ExpectQuery("INSERT INTO preview_logs").
@@ -3434,7 +3470,7 @@ func TestManagerServiceObserver_OnInstallOutput_PersistsInstallLog(t *testing.T)
 	mgr := newTestManager(mock, &mockProvider{})
 	orgID := uuid.New()
 	previewID := uuid.New()
-	obs := mgr.newServiceObserver(orgID, previewID, "", "")
+	obs := mgr.newServiceObserver(orgID, previewID, "", "", "")
 
 	logID := uuid.New()
 	mock.ExpectQuery("INSERT INTO preview_logs").
@@ -3458,7 +3494,7 @@ func TestManagerServiceObserver_OnPhaseStart_PersistsPreviewLog(t *testing.T) {
 	mgr := newTestManager(mock, &mockProvider{})
 	orgID := uuid.New()
 	previewID := uuid.New()
-	obs := mgr.newServiceObserver(orgID, previewID, "", "")
+	obs := mgr.newServiceObserver(orgID, previewID, "", "", "")
 
 	mock.ExpectExec("UPDATE preview_instances SET current_phase").
 		WithArgs(pgx.NamedArgs{"id": previewID, "org_id": orgID, "phase": "dependency_cache_restore"}).
@@ -3511,7 +3547,7 @@ func TestManagerServiceObserver_OnDependencyCacheRestore_PersistsNonFailureStatu
 			mgr := newTestManager(mock, &mockProvider{})
 			orgID := uuid.New()
 			previewID := uuid.New()
-			obs := mgr.newServiceObserver(orgID, previewID, "", "")
+			obs := mgr.newServiceObserver(orgID, previewID, "", "", "")
 
 			logID := uuid.New()
 			mock.ExpectQuery("INSERT INTO preview_logs").
@@ -3541,7 +3577,7 @@ func TestManagerServiceObserver_OnCacheRestore_EmitsPreviewHealthCacheEvent(t *t
 	})
 	orgID := uuid.New()
 	previewID := uuid.New()
-	obs := mgr.newServiceObserver(orgID, previewID, "", "")
+	obs := mgr.newServiceObserver(orgID, previewID, "", "", "")
 	cacheKey := strings.Repeat("d", 64)
 
 	logID := uuid.New()
@@ -3578,7 +3614,7 @@ func TestManagerServiceObserver_OnPhaseStartAndEnd_PersistsLifecycleLogs(t *test
 	mgr := newTestManager(mock, &mockProvider{})
 	orgID := uuid.New()
 	previewID := uuid.New()
-	obs := mgr.newServiceObserver(orgID, previewID, "", "")
+	obs := mgr.newServiceObserver(orgID, previewID, "", "", "")
 
 	mock.ExpectExec("UPDATE preview_instances SET current_phase").
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
@@ -3611,7 +3647,7 @@ func TestManagerServiceObserver_OnPhaseStart_DoesNotBlockOnLifecycleLogWrite(t *
 		Logger:       zerolog.Nop(),
 		WorkerNodeID: "worker-1",
 	})
-	obs := mgr.newServiceObserver(uuid.New(), uuid.New(), "", "")
+	obs := mgr.newServiceObserver(uuid.New(), uuid.New(), "", "", "")
 
 	done := make(chan struct{})
 	go func() {
@@ -3672,7 +3708,7 @@ func TestManagerServiceObserver_OnCacheSave_PersistsSuccessfulStatuses(t *testin
 			mgr := newTestManager(mock, &mockProvider{})
 			orgID := uuid.New()
 			previewID := uuid.New()
-			obs := mgr.newServiceObserver(orgID, previewID, "", "")
+			obs := mgr.newServiceObserver(orgID, previewID, "", "", "")
 			cacheKey := strings.Repeat("c", 64)
 
 			logID := uuid.New()
@@ -3698,7 +3734,7 @@ func TestManagerServiceObserver_OnServiceOutput_PersistsStartupLog(t *testing.T)
 	mgr := newTestManager(mock, &mockProvider{})
 	orgID := uuid.New()
 	previewID := uuid.New()
-	obs := mgr.newServiceObserver(orgID, previewID, "", "")
+	obs := mgr.newServiceObserver(orgID, previewID, "", "", "")
 
 	logID := uuid.New()
 	mock.ExpectQuery("INSERT INTO preview_logs").
@@ -3755,7 +3791,7 @@ func TestManagerServiceObserver_OnServiceOutput_DoesNotBlockOnDatabaseWrites(t *
 		Logger:       zerolog.Nop(),
 		WorkerNodeID: "worker-1",
 	})
-	obs := mgr.newServiceObserver(uuid.New(), uuid.New(), "", "")
+	obs := mgr.newServiceObserver(uuid.New(), uuid.New(), "", "", "")
 
 	done := make(chan struct{})
 	go func() {
@@ -3788,7 +3824,7 @@ func TestManagerServiceObserver_OnServiceFailed_NoTail(t *testing.T) {
 	mgr := newTestManager(mock, &mockProvider{})
 	orgID := uuid.New()
 	previewID := uuid.New()
-	obs := mgr.newServiceObserver(orgID, previewID, "", "")
+	obs := mgr.newServiceObserver(orgID, previewID, "", "", "")
 
 	mock.ExpectExec("UPDATE preview_services SET status").
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
@@ -3812,7 +3848,7 @@ func TestManagerServiceObserver_OnServiceFailed_DBErrorsLogged(t *testing.T) {
 	defer mock.Close()
 
 	mgr := newTestManager(mock, &mockProvider{})
-	obs := mgr.newServiceObserver(uuid.New(), uuid.New(), "", "")
+	obs := mgr.newServiceObserver(uuid.New(), uuid.New(), "", "", "")
 
 	// Both DB writes fail; the observer must log and return without panicking
 	// so a flaky DB doesn't crash the worker mid-launch.

--- a/internal/services/preview/start_runner.go
+++ b/internal/services/preview/start_runner.go
@@ -1305,6 +1305,20 @@ func ClassifyLaunchFailure(err error) StartFailure {
 		return StartFailure{}
 	}
 	cause := err.Error()
+	out := classifyLaunchFailureCode(err, cause)
+	// A service that OOM-kills at boot surfaces here (typically as
+	// ErrServiceNotReady) with a bare "exited with code 137" cause. Prepend a
+	// plain-English OOM explanation so the launch page and instance error make
+	// the cause obvious instead of leaving the exit code to be decoded.
+	if looksLikeOOMFailure(cause) {
+		out.Message = "the preview ran out of memory and was killed (OOM, exit code 137 / SIGKILL). " +
+			"Reduce the workload's memory use — e.g. run fewer concurrent build steps, or serve a " +
+			"production build instead of a dev server. " + out.Message
+	}
+	return out
+}
+
+func classifyLaunchFailureCode(err error, cause string) StartFailure {
 	switch {
 	case errors.Is(err, ErrInfraImageUnavailable):
 		return StartFailure{Code: "PREVIEW_INFRA_IMAGE_UNAVAILABLE", Message: "preview infrastructure image is not available on this worker. The image could not be pulled from its registry — check the worker's network egress and registry credentials. Details: " + cause}

--- a/internal/services/preview/start_runner_test.go
+++ b/internal/services/preview/start_runner_test.go
@@ -31,6 +31,19 @@ func TestClassifyLaunchFailure_InstallFailed(t *testing.T) {
 	require.Contains(t, failure.Message, "npm ci exited with code 1", "install failure message should include provider details")
 }
 
+func TestClassifyLaunchFailure_OutOfMemory(t *testing.T) {
+	t.Parallel()
+
+	// A service OOM-killed at boot arrives wrapped as ErrServiceNotReady with a
+	// "code 137" cause. The classified message should call out the OOM and
+	// still preserve the underlying detail for debugging.
+	failure := ClassifyLaunchFailure(fmt.Errorf("%w: webserver exited with code 137", ErrServiceNotReady))
+
+	require.Contains(t, failure.Message, "ran out of memory", "OOM failures should be explained in plain English")
+	require.Contains(t, failure.Message, "exit code 137", "OOM message should name the exit code")
+	require.Contains(t, failure.Message, "webserver exited with code 137", "underlying detail should be preserved")
+}
+
 func TestShouldReassignPreviewWorker(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Problem

A preview I launched (`wangjohn/preview-seeded-postgres`, config "Assembled") got stuck on a loading spinner. Root cause, traced from the DB + logs:

- The preview's two services (`frontend` rspack dev-server + `webserver`) were **OOM-killed at serve time** (`exited with code 137`) ~25 min after reaching `ready`. The full Assembled monorepo dev stack exceeds the **8 GiB hard ceiling** (`DefaultPreviewMaxMemoryMiB == MaxPreviewMaxMemoryMiB == 8*1024`), so there's no knob to raise it.
- But `OnServiceFailed` only flipped the per-**service** row to `failed`; it never demoted the **instance**. So `preview_instances.status` stayed `ready` indefinitely.
- The launch page (`previews/[id]/page.tsx`) only polled while `starting` and treated `ready`/`unhealthy` identically — so it kept rendering the bootstrap iframe against a dead process and spun forever, with no error surfaced.

This PR makes the instance status truthful and the UI react to it. (It does **not** make the Assembled preview fit under 8 GiB — that needs a config trim: don't run the whole `turbo` graph, serve a prod build instead of the HMR dev-server, cap concurrency.)

## Changes

**Backend** (`internal/services/preview/manager.go`)
- Thread the config's primary-service name into `managerServiceObserver` (wired through start, warm-resume, and recycle call sites).
- `OnServiceFailed` now demotes the instance to `unhealthy` via `UpdatePreviewStatusIfActive` when the **primary** service dies. That only transitions non-terminal rows, so it never clobbers a concurrent stop/expire and stays reversible (a later readiness write can promote it back).

**Frontend** (`previews/[id]/page.tsx`)
- Keep a 15s poll while the preview is `ready`/`partially_ready`/`unhealthy`, so a later crash is observed instead of leaving the iframe spinning.
- Exclude `unhealthy` from `isReady` so we don't bootstrap/iframe into a dead process.
- Route `unhealthy` into the existing error + retry path with the backend's crash message.

## Net effect

When a preview's primary process dies, the instance flips to `unhealthy`, the open launch page picks it up within ~15s, and the user sees **"Preview could not open" + the crash reason + a Retry button** instead of an infinite spinner.

## Tests
- `TestManagerServiceObserver_OnServiceFailed_PrimaryServiceDemotesInstance` (and the existing non-primary case still doesn't demote).
- Frontend: new test that an `unhealthy` status renders the error + retry and **no** bootstrap iframe.
- Full preview Go package suite + launch-page vitest suite pass; gofmt/vet/eslint clean.