### PR TITLE
Capitalize and label-format user-visible preview status details

### DIFF
--- a/frontend/AGENTS.md
+++ b/frontend/AGENTS.md
@@ -118,6 +118,10 @@ The base font size is `text-[13px]` (set globally on `body`). The project uses a
 | Labels | `text-[13px]` (via `<Label>` component) |
 | Code/mono text | `font-mono text-xs` |
 
+#### Copy casing
+
+Helper text, status details, empty-state copy, and inline explanatory messages should read like polished product copy. Prefer sentence-case strings that start with a capital letter whenever the text is user-facing and prose-like. Do not surface raw API enum values (`running`, `expired`, `pending_auth`) directly; format them first with the appropriate label helper, such as `formatPreviewStatus`, or a local formatter that handles casing consistently.
+
 #### Quantitative columns
 
 Numbers that users compare or scan (counts, costs, durations, dates in tables/metric rows) always get `tabular-nums`, and quantitative table columns are **right-aligned — header cell included**. Don't right-align the data cells while leaving the header left-aligned.

--- a/frontend/src/app/(dashboard)/previews/page.test.tsx
+++ b/frontend/src/app/(dashboard)/previews/page.test.tsx
@@ -203,8 +203,8 @@ describe("PreviewsPage", () => {
     expect(screen.getAllByText("Ready")[0]).toBeInTheDocument();
     expect(screen.getAllByText("Stopped")[0]).toBeInTheDocument();
     expect(screen.getAllByText("Failed")[0]).toBeInTheDocument();
-    expect(screen.getByText("resumes in ~30s")).toBeInTheDocument();
-    expect(screen.getByText("stopped after error")).toBeInTheDocument();
+    expect(screen.getByText("Resumes in ~30s")).toBeInTheDocument();
+    expect(screen.getByText("Stopped after error")).toBeInTheDocument();
     expect(screen.getAllByText("PR #17")[0]).toBeInTheDocument();
   });
 
@@ -498,7 +498,7 @@ describe("PreviewsPage", () => {
     ).not.toBeInTheDocument();
     expect(within(runningSection).getAllByText("Out of date")[0]).toBeInTheDocument();
     expect(
-      within(runningSection).getAllByText(/running aabb1122, branch is ccdd3344/)[0],
+      within(runningSection).getAllByText(/Running aabb1122, branch is ccdd3344/)[0],
     ).toBeInTheDocument();
     expect(
       within(runningSection).getAllByRole("button", { name: /restart/i })[0],

--- a/frontend/src/app/(dashboard)/previews/page.tsx
+++ b/frontend/src/app/(dashboard)/previews/page.tsx
@@ -180,6 +180,25 @@ function statusLabel(preview: PreviewCurrentResponse): string {
   return formatPreviewStatus(preview.status);
 }
 
+function capitalizeStatusDetail(detail: string): string {
+  if (!detail) return "";
+  return detail.charAt(0).toUpperCase() + detail.slice(1);
+}
+
+function statusDetail(preview: PreviewCurrentResponse, scope: PreviewScope): string {
+  if (preview.freshness === "outdated") {
+    return capitalizeStatusDetail(
+      `running ${preview.running_commit_sha?.slice(0, 8) || "unknown"}, branch is ${preview.latest_commit_sha?.slice(0, 8) || "unknown"}`,
+    );
+  }
+  if (scope === "resumable" && preview.resume_estimate_seconds) {
+    return capitalizeStatusDetail(`resumes in ~${preview.resume_estimate_seconds}s`);
+  }
+  if (scope === "recent") return capitalizeStatusDetail(stoppedReasonLabel(preview.stopped_reason));
+  if (preview.expires_at) return capitalizeStatusDetail(`expires ${expiresIn(preview.expires_at)}`);
+  return preview.current_phase ? formatPreviewStatus(preview.current_phase) : "";
+}
+
 function previewDisplayName(preview: PreviewCurrentResponse): string {
   if (preview.group_kind === "pull_request" || preview.source_type === "pull_request") {
     const sourcePRNumber = preview.source_id?.match(/#(\d+)/)?.[1];
@@ -336,15 +355,7 @@ function SectionRows({
                       {statusLabel(preview)}
                     </Badge>
                     <p className="mt-1 text-xs text-muted-foreground">
-                      {preview.freshness === "outdated"
-                        ? `running ${preview.running_commit_sha?.slice(0, 8) || "unknown"}, branch is ${preview.latest_commit_sha?.slice(0, 8) || "unknown"}`
-                        : scope === "resumable" && preview.resume_estimate_seconds
-                        ? `resumes in ~${preview.resume_estimate_seconds}s`
-                        : scope === "recent"
-                          ? stoppedReasonLabel(preview.stopped_reason)
-                          : preview.expires_at
-                            ? `expires ${expiresIn(preview.expires_at)}`
-                            : preview.current_phase || ""}
+                      {statusDetail(preview, scope)}
                     </p>
                   </TableCell>
                   <TableCell>


### PR DESCRIPTION
## Summary

Preview cards show raw, inconsistent status/copy strings (e.g., lowercased phrases and raw enum-like values), which hurts readability and makes the UI feel unpolished. This change updates the preview page to format status details with consistent sentence-case/capitalization, and adjusts tests to assert the corrected, user-facing copy.  

## Changes

- Added helper utilities to normalize status detail text into polished sentence-case for user-facing helper/status/empty-state prose.
- Centralized status detail rendering for preview phases (resumable, outdated, recent/stopped, and expiry) so we don’t surface raw API values directly.
- Updated `previews/page.test.tsx` expectations to match the corrected capitalization/formatting (e.g., “Resumes in ~30s”, “Stopped after error”, and “Running …”).

## Validation

- Updated unit tests in `frontend/src/app/(dashboard)/previews/page.test.tsx` to reflect the new copy casing behavior.
- No new verification required for docs-only change in `frontend/AGENTS.md`; existing preview page checks (typecheck/build/targeted preview test) remain the validation baseline.

[143.dev](https://143.dev) | [session a2755019](https://143.dev/sessions/a2755019-1142-445b-aa7d-61edd0c402ad)

<!-- 143 readiness -->
**143 readiness:** not available for this revision.

Preview: https://143.dev/previews/github/assembledhq/143/pull/1554?launch=1