### PR TITLE
Polish preview OOM messaging: consistent cap + bounded text

### DIFF
--- a/internal/api/handlers/preview.go
+++ b/internal/api/handlers/preview.go
@@ -581,11 +581,11 @@ func (h *PreviewHandler) requireInspector(w http.ResponseWriter, r *http.Request
 // and map each to a stable, debuggable error code. The user-visible message
 // always includes the underlying cause so an operator can act on it without
 // digging through Grafana.
-func classifyLaunchError(err error) *previewHTTPError {
+func classifyLaunchError(err error, memoryLimitMB int) *previewHTTPError {
 	if err == nil {
 		return nil
 	}
-	classified := preview.ClassifyLaunchFailure(err)
+	classified := preview.ClassifyLaunchFailure(err, memoryLimitMB)
 	return newPreviewHTTPError(http.StatusUnprocessableEntity, classified.Code, classified.Message, err)
 }
 
@@ -866,7 +866,7 @@ func (h *PreviewHandler) startPreviewLocal(ctx context.Context, orgID, userID, s
 	if err != nil {
 		h.manager.AbortReservation(ctx, reservation, hydratedID, fmt.Sprintf("launch: %v", err))
 		h.logger.Warn().Err(err).Str("session_id", sessionID.String()).Msg("preview launch failed")
-		return nil, classifyLaunchError(err)
+		return nil, classifyLaunchError(err, reservation.MemoryLimitMB)
 	}
 
 	if h.localNodeID != "" && (acq.Hydrated || (session.ContainerID != nil && *session.ContainerID != "")) {

--- a/internal/api/handlers/preview_test.go
+++ b/internal/api/handlers/preview_test.go
@@ -3089,12 +3089,13 @@ func TestClassifyLaunchError(t *testing.T) {
 	t.Parallel()
 
 	cases := []struct {
-		name         string
-		err          error
-		wantCode     string
-		wantStatus   int
-		mustContain  string
-		mustContain2 string
+		name          string
+		err           error
+		memoryLimitMB int
+		wantCode      string
+		wantStatus    int
+		mustContain   string
+		mustContain2  string
 	}{
 		{
 			name:        "image unavailable",
@@ -3132,6 +3133,15 @@ func TestClassifyLaunchError(t *testing.T) {
 			mustContain: "port 3000",
 		},
 		{
+			name:          "oom at boot names the cause and the memory cap",
+			err:           fmt.Errorf("%w: primary service %q exited with code 137", preview.ErrServiceNotReady, "app"),
+			memoryLimitMB: 8192,
+			wantCode:      "PREVIEW_SERVICE_NOT_READY",
+			wantStatus:    http.StatusUnprocessableEntity,
+			mustContain:   "ran out of memory",
+			mustContain2:  "8192 MiB",
+		},
+		{
 			name:        "unclassified surfaces underlying cause",
 			err:         errors.New("provider start preview: something weird happened"),
 			wantCode:    "PREVIEW_START_FAILED",
@@ -3143,16 +3153,19 @@ func TestClassifyLaunchError(t *testing.T) {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			got := classifyLaunchError(tc.err)
+			got := classifyLaunchError(tc.err, tc.memoryLimitMB)
 			require.NotNil(t, got)
 			require.Equal(t, tc.wantStatus, got.status)
 			require.Equal(t, tc.wantCode, got.code)
 			require.Contains(t, got.message, tc.mustContain, "user-visible message must surface the underlying cause")
+			if tc.mustContain2 != "" {
+				require.Contains(t, got.message, tc.mustContain2)
+			}
 			require.NotEqual(t, "failed to start preview", got.message, "must not regress to the opaque generic message")
 		})
 	}
 
-	require.Nil(t, classifyLaunchError(nil), "nil error must not produce a response")
+	require.Nil(t, classifyLaunchError(nil, 0), "nil error must not produce a response")
 }
 
 func TestPreviewHandler_SetAuditEmitter(t *testing.T) {

--- a/internal/services/preview/manager.go
+++ b/internal/services/preview/manager.go
@@ -1203,12 +1203,11 @@ const maxOriginalFailureRunes = 500
 func oomFailureExplanation(memoryLimitMB int) string {
 	capText := ""
 	if memoryLimitMB > 0 {
-		capText = fmt.Sprintf(" The preview is capped at %d MiB of memory.", memoryLimitMB)
+		capText = fmt.Sprintf("; capped at %d MiB", memoryLimitMB)
 	}
 	return fmt.Sprintf(
-		"ran out of memory and was killed (OOM, exit code 137 / SIGKILL).%s "+
-			"Reduce the workload's memory use — e.g. run fewer concurrent build "+
-			"steps, or serve a production build instead of a dev server.",
+		"ran out of memory (OOM, exit 137)%s. Reduce memory use — "+
+			"e.g. serve a production build instead of a dev server.",
 		capText,
 	)
 }

--- a/internal/services/preview/manager.go
+++ b/internal/services/preview/manager.go
@@ -1191,6 +1191,28 @@ func looksLikeOOMFailure(errMsg string) bool {
 		strings.Contains(m, "cannot allocate memory")
 }
 
+// maxOriginalFailureRunes bounds the raw provider failure text appended to an
+// OOM explanation. The raw text can carry a long captured stdout/stderr tail,
+// which would otherwise bloat the instance error rendered on the launch page.
+const maxOriginalFailureRunes = 500
+
+// oomFailureExplanation returns the plain-English OOM explanation used across
+// the preview failure surfaces, including the memory cap when known
+// (memoryLimitMB > 0). It is a sentence fragment beginning "ran out of
+// memory…" so callers can prepend their own subject.
+func oomFailureExplanation(memoryLimitMB int) string {
+	capText := ""
+	if memoryLimitMB > 0 {
+		capText = fmt.Sprintf(" The preview is capped at %d MiB of memory.", memoryLimitMB)
+	}
+	return fmt.Sprintf(
+		"ran out of memory and was killed (OOM, exit code 137 / SIGKILL).%s "+
+			"Reduce the workload's memory use — e.g. run fewer concurrent build "+
+			"steps, or serve a production build instead of a dev server.",
+		capText,
+	)
+}
+
 // annotatePreviewFailure prefixes OOM failures with a plain-English
 // explanation (and the memory cap, when known) so preview errors are
 // debuggable without decoding exit codes. Non-OOM messages pass through
@@ -1199,17 +1221,11 @@ func annotatePreviewFailure(errMsg string, memoryLimitMB int) string {
 	if !looksLikeOOMFailure(errMsg) {
 		return errMsg
 	}
-	capText := ""
-	if memoryLimitMB > 0 {
-		capText = fmt.Sprintf(" The preview is capped at %d MiB of memory.", memoryLimitMB)
-	}
-	return fmt.Sprintf(
-		"ran out of memory and was killed (OOM, exit code 137 / SIGKILL).%s "+
-			"Reduce the workload's memory use — e.g. run fewer concurrent build "+
-			"steps, or serve a production build instead of a dev server. "+
-			"Original failure: %s",
-		capText, errMsg,
-	)
+	// truncateRunes (defined in session_prewarm_classifier.go) trims and bounds
+	// the raw provider text so a long captured stdout/stderr tail can't bloat
+	// the instance error rendered on the launch page.
+	return oomFailureExplanation(memoryLimitMB) +
+		" Original failure: " + truncateRunes(errMsg, maxOriginalFailureRunes)
 }
 
 func (o *managerServiceObserver) OnInstallFailed(errMsg string, tail []string) {

--- a/internal/services/preview/manager_test.go
+++ b/internal/services/preview/manager_test.go
@@ -3449,7 +3449,7 @@ func TestAnnotatePreviewFailure(t *testing.T) {
 		got := annotatePreviewFailure("exited with code 137; last output: app compiled", 8192)
 		require.Contains(t, got, "ran out of memory")
 		require.Contains(t, got, "8192 MiB")
-		require.Contains(t, got, "exit code 137")
+		require.Contains(t, got, "exit 137")
 		// The original failure is preserved for debugging.
 		require.Contains(t, got, "exited with code 137; last output: app compiled")
 	})
@@ -3467,8 +3467,10 @@ func TestAnnotatePreviewFailure(t *testing.T) {
 		raw := "exited with code 137; last output: " + strings.Repeat("x", 5000)
 		got := annotatePreviewFailure(raw, 8192)
 		require.Contains(t, got, "ran out of memory")
-		require.Less(t, len([]rune(got)), len([]rune(raw)), "the raw tail should be truncated")
 		require.Contains(t, got, "8192 MiB")
+		// The whole message is the short explanation + the bounded tail, so it
+		// stays close to the cap rather than echoing the full 5k-rune raw output.
+		require.LessOrEqual(t, len([]rune(got)), maxOriginalFailureRunes+256, "the raw tail should be truncated to the cap")
 	})
 
 	t.Run("non-oom failures pass through unchanged", func(t *testing.T) {

--- a/internal/services/preview/manager_test.go
+++ b/internal/services/preview/manager_test.go
@@ -3428,6 +3428,11 @@ func TestManagerServiceObserver_OnServiceFailed_PrimaryServiceDemotesInstance(t 
 			"id", "preview_instance_id", "org_id", "level", "step", "message", "metadata", "created_at",
 		}).AddRow(logID, previewID, orgID, "error", "start", "msg", json.RawMessage(`null`), time.Now()))
 	// Instance is demoted via UpdatePreviewStatusIfActive (non-terminal path).
+	// On a non-terminal transition with rows affected, the store then calls
+	// syncPreviewGroupStatusForPreview, which issues a follow-up query we don't
+	// mock here. That unmatched query errors and is swallowed as a warn inside
+	// the store (the demotion itself still succeeds), so the test only asserts
+	// the demotion UPDATE and intentionally leaves the group-sync unexpected.
 	mock.ExpectExec("UPDATE preview_instances SET status = @status.+NOT IN").
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
 		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
@@ -3454,6 +3459,16 @@ func TestAnnotatePreviewFailure(t *testing.T) {
 		got := annotatePreviewFailure("signal: killed", 0)
 		require.Contains(t, got, "ran out of memory")
 		require.NotContains(t, got, "capped at")
+	})
+
+	t.Run("a long original failure tail is truncated", func(t *testing.T) {
+		t.Parallel()
+		// A huge captured stdout/stderr tail must not bloat the message.
+		raw := "exited with code 137; last output: " + strings.Repeat("x", 5000)
+		got := annotatePreviewFailure(raw, 8192)
+		require.Contains(t, got, "ran out of memory")
+		require.Less(t, len([]rune(got)), len([]rune(raw)), "the raw tail should be truncated")
+		require.Contains(t, got, "8192 MiB")
 	})
 
 	t.Run("non-oom failures pass through unchanged", func(t *testing.T) {

--- a/internal/services/preview/start_runner.go
+++ b/internal/services/preview/start_runner.go
@@ -348,7 +348,7 @@ func (r *StartRunner) StartReservedBranchPreview(ctx context.Context, payload St
 	})
 	_, err = r.manager.LaunchPreview(ctx, reservation, input)
 	if err != nil {
-		classified := ClassifyLaunchFailure(err)
+		classified := ClassifyLaunchFailure(err, reservation.MemoryLimitMB)
 		r.abort(ctx, reservation, sb.ID, classified.Message)
 		r.logger.Warn().Err(err).Str("preview_id", payload.PreviewID.String()).Msg("branch preview launch failed")
 		return fmt.Errorf("%s: %s: %w", classified.Code, classified.Message, err)
@@ -1041,7 +1041,7 @@ func (r *StartRunner) StartReservedPreview(ctx context.Context, payload StartPre
 	})
 	_, err = r.manager.LaunchPreview(ctx, reservation, input)
 	if err != nil {
-		classified := ClassifyLaunchFailure(err)
+		classified := ClassifyLaunchFailure(err, reservation.MemoryLimitMB)
 		r.abort(ctx, reservation, hydratedID, classified.Message)
 		r.logger.Warn().Err(err).Str("session_id", payload.SessionID.String()).Msg("preview launch failed")
 		return fmt.Errorf("%s: %s: %w", classified.Code, classified.Message, err)
@@ -1161,7 +1161,7 @@ func (r *StartRunner) WarmSessionPreview(ctx context.Context, payload SessionPre
 	liveStarted := time.Now()
 	launched, err := r.manager.LaunchPreview(ctx, reservation, input)
 	if err != nil {
-		classified := ClassifyLaunchFailure(err)
+		classified := ClassifyLaunchFailure(err, reservation.MemoryLimitMB)
 		r.manager.AbortReservation(ctx, reservation, hydratedID, classified.Message)
 		failRun(classified.Message)
 		return fmt.Errorf("%s: %s: %w", classified.Code, classified.Message, err)
@@ -1300,7 +1300,10 @@ type StartFailure struct {
 	Message string
 }
 
-func ClassifyLaunchFailure(err error) StartFailure {
+// ClassifyLaunchFailure maps a launch error to a stable code + user-facing
+// message. memoryLimitMB is the preview's memory cap (0 when unknown), surfaced
+// in the message when the failure looks like an OOM.
+func ClassifyLaunchFailure(err error, memoryLimitMB int) StartFailure {
 	if err == nil {
 		return StartFailure{}
 	}
@@ -1308,12 +1311,11 @@ func ClassifyLaunchFailure(err error) StartFailure {
 	out := classifyLaunchFailureCode(err, cause)
 	// A service that OOM-kills at boot surfaces here (typically as
 	// ErrServiceNotReady) with a bare "exited with code 137" cause. Prepend a
-	// plain-English OOM explanation so the launch page and instance error make
-	// the cause obvious instead of leaving the exit code to be decoded.
+	// plain-English OOM explanation (with the cap, matching the runtime path in
+	// manager.go) so the launch page and instance error make the cause obvious
+	// instead of leaving the exit code to be decoded.
 	if looksLikeOOMFailure(cause) {
-		out.Message = "the preview ran out of memory and was killed (OOM, exit code 137 / SIGKILL). " +
-			"Reduce the workload's memory use — e.g. run fewer concurrent build steps, or serve a " +
-			"production build instead of a dev server. " + out.Message
+		out.Message = "the preview " + oomFailureExplanation(memoryLimitMB) + " " + out.Message
 	}
 	return out
 }

--- a/internal/services/preview/start_runner_test.go
+++ b/internal/services/preview/start_runner_test.go
@@ -40,7 +40,7 @@ func TestClassifyLaunchFailure_OutOfMemory(t *testing.T) {
 	failure := ClassifyLaunchFailure(fmt.Errorf("%w: webserver exited with code 137", ErrServiceNotReady), 8192)
 
 	require.Contains(t, failure.Message, "ran out of memory", "OOM failures should be explained in plain English")
-	require.Contains(t, failure.Message, "exit code 137", "OOM message should name the exit code")
+	require.Contains(t, failure.Message, "exit 137", "OOM message should name the exit code")
 	require.Contains(t, failure.Message, "8192 MiB", "OOM message should include the memory cap")
 	require.Contains(t, failure.Message, "webserver exited with code 137", "underlying detail should be preserved")
 }

--- a/internal/services/preview/start_runner_test.go
+++ b/internal/services/preview/start_runner_test.go
@@ -24,7 +24,7 @@ import (
 func TestClassifyLaunchFailure_InstallFailed(t *testing.T) {
 	t.Parallel()
 
-	failure := ClassifyLaunchFailure(fmt.Errorf("%w: npm ci exited with code 1", ErrInstallFailed))
+	failure := ClassifyLaunchFailure(fmt.Errorf("%w: npm ci exited with code 1", ErrInstallFailed), 0)
 
 	require.Equal(t, "PREVIEW_INSTALL_FAILED", failure.Code, "install failures should get a dedicated preview start error code")
 	require.Contains(t, failure.Message, "preview.install", "install failure message should point users at the install config")
@@ -35,12 +35,13 @@ func TestClassifyLaunchFailure_OutOfMemory(t *testing.T) {
 	t.Parallel()
 
 	// A service OOM-killed at boot arrives wrapped as ErrServiceNotReady with a
-	// "code 137" cause. The classified message should call out the OOM and
-	// still preserve the underlying detail for debugging.
-	failure := ClassifyLaunchFailure(fmt.Errorf("%w: webserver exited with code 137", ErrServiceNotReady))
+	// "code 137" cause. The classified message should call out the OOM, include
+	// the memory cap, and still preserve the underlying detail for debugging.
+	failure := ClassifyLaunchFailure(fmt.Errorf("%w: webserver exited with code 137", ErrServiceNotReady), 8192)
 
 	require.Contains(t, failure.Message, "ran out of memory", "OOM failures should be explained in plain English")
 	require.Contains(t, failure.Message, "exit code 137", "OOM message should name the exit code")
+	require.Contains(t, failure.Message, "8192 MiB", "OOM message should include the memory cap")
 	require.Contains(t, failure.Message, "webserver exited with code 137", "underlying detail should be preserved")
 }
 


### PR DESCRIPTION
Follow-up to #1553, addressing the review nits I flagged on that PR.

### 1. Consistent memory cap across both failure surfaces
Previously the runtime path (`OnServiceFailed`) named the memory cap ("capped at 8192 MiB") but the build/boot path (`ClassifyLaunchFailure`) did not. Now both do.

- Extracted a shared `oomFailureExplanation(memoryLimitMB)` helper used by both `annotatePreviewFailure` (runtime) and `ClassifyLaunchFailure` (startup), so the wording cannot drift.
- Threaded `MemoryLimitMB` through `ClassifyLaunchFailure` and its callers: the three `start_runner.go` launch sites and the synchronous handler's `classifyLaunchError` (all already had `reservation` in scope).

### 2. Bound the appended raw failure text
The OOM message appends `Original failure: <raw>` for debuggability, but the raw provider text can carry a long captured stdout/stderr tail that would bloat the instance error rendered on the launch page. It is now truncated (reusing the existing `truncateRunes`, 500 runes).

### 3. Test clarity
Added a comment explaining that the demotion test intentionally leaves the store's follow-up group-status-sync query unmocked (it is swallowed as a warn; the demotion itself still succeeds).

### Tests
- `start_runner` + handler OOM cases now assert the cap ("8192 MiB") appears.
- New `annotatePreviewFailure` case asserts a long tail is truncated.
- Full `internal/services/preview` and `internal/api/handlers` suites pass; vet/gofmt clean.

No behavior change beyond message wording + bounding; no new status transitions.
