### PR TITLE
Remove unused RepoSettings import from autopilot settings page to fix frontend lint

### DIFF
--- a/frontend/src/app/(dashboard)/settings/autopilot/page.tsx
+++ b/frontend/src/app/(dashboard)/settings/autopilot/page.tsx
@@ -39,7 +39,7 @@ import {
   PM_SCHEDULE_MAX_HOURS,
   clampNumber,
 } from "@/lib/settings-constants";
-import type { CodingCredentialSummary, ListResponse, Organization, OrgSettings, RepoSettings, Repository, SingleResponse } from "@/lib/types";
+import type { CodingCredentialSummary, ListResponse, Organization, OrgSettings, Repository, SingleResponse } from "@/lib/types";
 
 export default function AutopilotSettingsPage() {
   const { user } = useAuth();


### PR DESCRIPTION
## Summary

Fixes an ESLint/TypeScript warning that breaks the frontend lint workflow in the Autopilot settings page. Removed the unused `RepoSettings` type import from `page.tsx` so the build pipeline is clean and doesn’t fail on unused symbols.

## Changes

- Dropped unused `RepoSettings` type from `frontend/src/app/(dashboard)/settings/autopilot/page.tsx`
- Kept the rest of the imports and page behavior unchanged

## Validation

From `frontend/`:
- `npm ci`
- `npm run typecheck`
- `npm run lint`
- `npm run build`

[143.dev](https://143.dev) | [session cdb416db](https://143.dev/sessions/cdb416db-e2ec-4f42-a2fd-59cf0777120b)

<!-- 143 readiness -->
**143 readiness:** not available for this revision.

Preview: https://143.dev/previews/github/assembledhq/143/pull/1556?launch=1