### PR TITLE
Guard session title regeneration to primary thread only to prevent odd cross-tab titles

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -1593,7 +1593,7 @@ func buildServices(
 	// Session title service (optional — only if LLM client is available).
 	var titleService *services.SessionTitleService
 	if llmClient != nil {
-		titleService = services.NewSessionTitleService(llmClient, sessionStore, sessionMessageStore)
+		titleService = services.NewSessionTitleService(llmClient, sessionStore, sessionMessageStore, sessionThreadStore)
 	}
 
 	// Linear session-linking service. Drives prepare_linear_primary,

--- a/internal/services/session_title.go
+++ b/internal/services/session_title.go
@@ -32,25 +32,31 @@ type titleMessageStore interface {
 	ListBySession(ctx context.Context, orgID, sessionID uuid.UUID) ([]models.SessionMessage, error)
 }
 
+type titleThreadStore interface {
+	ListBySession(ctx context.Context, orgID, sessionID uuid.UUID) ([]models.SessionThread, error)
+}
+
 // SessionTitleService generates and updates session titles using an LLM.
 type SessionTitleService struct {
 	llm      llmClient
 	sessions titleSessionStore
 	messages titleMessageStore
+	threads  titleThreadStore
 }
 
-func NewSessionTitleService(llm llmClient, sessions titleSessionStore, messages titleMessageStore) *SessionTitleService {
+func NewSessionTitleService(llm llmClient, sessions titleSessionStore, messages titleMessageStore, threads titleThreadStore) *SessionTitleService {
 	return &SessionTitleService{
 		llm:      llm,
 		sessions: sessions,
 		messages: messages,
+		threads:  threads,
 	}
 }
 
 // MaybeRegenerateTitle regenerates the session title if the current turn is
 // a multiple of regenerateEveryN (3, 6, 9, ...). It is safe to call on every
 // turn — it will no-op when regeneration is not due.
-func (s *SessionTitleService) MaybeRegenerateTitle(ctx context.Context, orgID, sessionID uuid.UUID) error {
+func (s *SessionTitleService) MaybeRegenerateTitle(ctx context.Context, orgID, sessionID uuid.UUID, completedThreadID *uuid.UUID) error {
 	session, err := s.sessions.GetByID(ctx, orgID, sessionID)
 	if err != nil {
 		return fmt.Errorf("fetch session: %w", err)
@@ -58,6 +64,16 @@ func (s *SessionTitleService) MaybeRegenerateTitle(ctx context.Context, orgID, s
 
 	if session.CurrentTurn < regenerateEveryN || session.CurrentTurn%regenerateEveryN != 0 {
 		return nil
+	}
+
+	if completedThreadID != nil {
+		isPrimary, err := completedThreadIDIsPrimary(ctx, s.threads, orgID, sessionID, *completedThreadID)
+		if err != nil {
+			return err
+		}
+		if !isPrimary {
+			return nil
+		}
 	}
 
 	msgs, err := s.messages.ListBySession(ctx, orgID, sessionID)
@@ -95,6 +111,20 @@ func (s *SessionTitleService) MaybeRegenerateTitle(ctx context.Context, orgID, s
 		return fmt.Errorf("update title: %w", err)
 	}
 	return nil
+}
+
+func completedThreadIDIsPrimary(ctx context.Context, threads titleThreadStore, orgID, sessionID, completedThreadID uuid.UUID) (bool, error) {
+	if completedThreadID == uuid.Nil || threads == nil {
+		return true, nil
+	}
+	sessionThreads, err := threads.ListBySession(ctx, orgID, sessionID)
+	if err != nil {
+		return false, fmt.Errorf("fetch session threads: %w", err)
+	}
+	if len(sessionThreads) == 0 {
+		return false, nil
+	}
+	return sessionThreads[0].ID == completedThreadID, nil
 }
 
 // CleanTitle trims whitespace and surrounding quotes from a generated title,

--- a/internal/services/session_title_test.go
+++ b/internal/services/session_title_test.go
@@ -50,6 +50,24 @@ func (m *mockTitleMessageStore) ListBySession(_ context.Context, _, _ uuid.UUID)
 	return m.messages, m.err
 }
 
+type mockTitleThreadStore struct {
+	threads []models.SessionThread
+	err     error
+}
+
+func (m *mockTitleThreadStore) ListBySession(_ context.Context, _, _ uuid.UUID) ([]models.SessionThread, error) {
+	return m.threads, m.err
+}
+
+func titleThreadStoreWithPrimary(primaryThreadID uuid.UUID) *mockTitleThreadStore {
+	return &mockTitleThreadStore{
+		threads: []models.SessionThread{
+			{ID: primaryThreadID},
+			{ID: uuid.New()},
+		},
+	}
+}
+
 // --- tests ---
 
 func TestMaybeRegenerateTitle_SkipsWhenNotDue(t *testing.T) {
@@ -59,9 +77,10 @@ func TestMaybeRegenerateTitle_SkipsWhenNotDue(t *testing.T) {
 		sessions := &mockTitleSessionStore{
 			session: models.Session{CurrentTurn: turn},
 		}
-		svc := NewSessionTitleService(llm, sessions, &mockTitleMessageStore{})
+		primaryThreadID := uuid.New()
+		svc := NewSessionTitleService(llm, sessions, &mockTitleMessageStore{}, titleThreadStoreWithPrimary(primaryThreadID))
 
-		err := svc.MaybeRegenerateTitle(context.Background(), uuid.New(), uuid.New())
+		err := svc.MaybeRegenerateTitle(context.Background(), uuid.New(), uuid.New(), &primaryThreadID)
 		require.NoError(t, err)
 		assert.Equal(t, 0, llm.calls, "should not call LLM on turn %d", turn)
 	}
@@ -84,9 +103,10 @@ func TestMaybeRegenerateTitle_RunsOnThirdTurn(t *testing.T) {
 			{TurnNumber: 2, Role: models.MessageRoleAssistant, Content: "Refactored"},
 		},
 	}
-	svc := NewSessionTitleService(llm, sessions, messages)
+	primaryThreadID := uuid.New()
+	svc := NewSessionTitleService(llm, sessions, messages, titleThreadStoreWithPrimary(primaryThreadID))
 
-	err := svc.MaybeRegenerateTitle(context.Background(), uuid.New(), uuid.New())
+	err := svc.MaybeRegenerateTitle(context.Background(), uuid.New(), uuid.New(), &primaryThreadID)
 	require.NoError(t, err)
 	require.Equal(t, 1, llm.calls, "should still consult the LLM on due turns for potential topic shifts")
 	require.Equal(t, "New title from LLM", sessions.updatedTitle, "should update the title when the model returns a new dominant topic")
@@ -108,12 +128,43 @@ func TestMaybeRegenerateTitle_FillsMissingTitleWhenDue(t *testing.T) {
 			{TurnNumber: 2, Role: models.MessageRoleAssistant, Content: "Refactored"},
 		},
 	}
-	svc := NewSessionTitleService(llm, sessions, messages)
+	primaryThreadID := uuid.New()
+	svc := NewSessionTitleService(llm, sessions, messages, titleThreadStoreWithPrimary(primaryThreadID))
 
-	err := svc.MaybeRegenerateTitle(context.Background(), uuid.New(), uuid.New())
+	err := svc.MaybeRegenerateTitle(context.Background(), uuid.New(), uuid.New(), &primaryThreadID)
 	require.NoError(t, err, "missing titles should still be generated on regeneration turns")
 	require.Equal(t, 1, llm.calls, "should call LLM when session title is missing")
 	require.Equal(t, "New title from LLM", sessions.updatedTitle, "should persist the generated title when session title is missing")
+}
+
+func TestMaybeRegenerateTitle_SkipsSecondaryThread(t *testing.T) {
+	t.Parallel()
+
+	title := "Fix auth redirect loop"
+	llm := &mockLLM{response: "Review flaky checkout tests"}
+	sessions := &mockTitleSessionStore{
+		session: models.Session{Title: &title, CurrentTurn: 3},
+	}
+	messages := &mockTitleMessageStore{
+		messages: []models.SessionMessage{
+			{TurnNumber: 0, Role: models.MessageRoleUser, Content: "Fix the auth redirect loop"},
+			{TurnNumber: 2, Role: models.MessageRoleUser, Content: "Review flaky checkout tests in a side tab"},
+		},
+	}
+	primaryThreadID := uuid.New()
+	secondaryThreadID := uuid.New()
+	threads := &mockTitleThreadStore{
+		threads: []models.SessionThread{
+			{ID: primaryThreadID},
+			{ID: secondaryThreadID},
+		},
+	}
+	svc := NewSessionTitleService(llm, sessions, messages, threads)
+
+	err := svc.MaybeRegenerateTitle(context.Background(), uuid.New(), uuid.New(), &secondaryThreadID)
+	require.NoError(t, err, "secondary thread completion should not fail title regeneration")
+	require.Equal(t, 0, llm.calls, "secondary thread completion should not call the title LLM")
+	require.Empty(t, sessions.updatedTitle, "secondary thread completion should not update the session title")
 }
 
 func TestMaybeRegenerateTitle_SkipsUpdateWhenTitleUnchanged(t *testing.T) {
@@ -128,9 +179,10 @@ func TestMaybeRegenerateTitle_SkipsUpdateWhenTitleUnchanged(t *testing.T) {
 			{TurnNumber: 0, Role: models.MessageRoleUser, Content: "Do something"},
 		},
 	}
-	svc := NewSessionTitleService(llm, sessions, messages)
+	primaryThreadID := uuid.New()
+	svc := NewSessionTitleService(llm, sessions, messages, titleThreadStoreWithPrimary(primaryThreadID))
 
-	err := svc.MaybeRegenerateTitle(context.Background(), uuid.New(), uuid.New())
+	err := svc.MaybeRegenerateTitle(context.Background(), uuid.New(), uuid.New(), &primaryThreadID)
 	require.NoError(t, err, "unchanged titles should be accepted without updating")
 	require.Equal(t, 1, llm.calls, "should ask the LLM whether the title still fits")
 	require.Empty(t, sessions.updatedTitle, "should not update when the LLM keeps the existing title")
@@ -146,18 +198,19 @@ func TestMaybeRegenerateTitle_SkipsEmptyOrTooLong(t *testing.T) {
 			{TurnNumber: 0, Role: models.MessageRoleUser, Content: "task"},
 		},
 	}
-	svc := NewSessionTitleService(llm, sessions, messages)
+	primaryThreadID := uuid.New()
+	svc := NewSessionTitleService(llm, sessions, messages, titleThreadStoreWithPrimary(primaryThreadID))
 
 	// Empty response
 	llm.response = "   "
-	err := svc.MaybeRegenerateTitle(context.Background(), uuid.New(), uuid.New())
+	err := svc.MaybeRegenerateTitle(context.Background(), uuid.New(), uuid.New(), &primaryThreadID)
 	require.NoError(t, err)
 	assert.Empty(t, sessions.updatedTitle)
 
 	// Too long response — reset for next call
 	sessions.session.CurrentTurn = 6
 	llm.response = string(make([]byte, 121))
-	err = svc.MaybeRegenerateTitle(context.Background(), uuid.New(), uuid.New())
+	err = svc.MaybeRegenerateTitle(context.Background(), uuid.New(), uuid.New(), &primaryThreadID)
 	require.NoError(t, err)
 	assert.Empty(t, sessions.updatedTitle)
 }
@@ -172,9 +225,10 @@ func TestMaybeRegenerateTitle_LLMError(t *testing.T) {
 			{TurnNumber: 0, Role: models.MessageRoleUser, Content: "task"},
 		},
 	}
-	svc := NewSessionTitleService(llm, sessions, messages)
+	primaryThreadID := uuid.New()
+	svc := NewSessionTitleService(llm, sessions, messages, titleThreadStoreWithPrimary(primaryThreadID))
 
-	err := svc.MaybeRegenerateTitle(context.Background(), uuid.New(), uuid.New())
+	err := svc.MaybeRegenerateTitle(context.Background(), uuid.New(), uuid.New(), &primaryThreadID)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "llm completion")
 }
@@ -185,9 +239,10 @@ func TestMaybeRegenerateTitle_NoMessages(t *testing.T) {
 	llm := &mockLLM{response: "New"}
 	sessions := &mockTitleSessionStore{session: models.Session{Title: &title, CurrentTurn: 3}}
 	messages := &mockTitleMessageStore{messages: nil}
-	svc := NewSessionTitleService(llm, sessions, messages)
+	primaryThreadID := uuid.New()
+	svc := NewSessionTitleService(llm, sessions, messages, titleThreadStoreWithPrimary(primaryThreadID))
 
-	err := svc.MaybeRegenerateTitle(context.Background(), uuid.New(), uuid.New())
+	err := svc.MaybeRegenerateTitle(context.Background(), uuid.New(), uuid.New(), &primaryThreadID)
 	require.NoError(t, err)
 	assert.Equal(t, 0, llm.calls, "should not call LLM with no messages")
 }

--- a/internal/worker/handlers.go
+++ b/internal/worker/handlers.go
@@ -8850,7 +8850,12 @@ func newContinueSessionHandler(stores *Stores, services *Services, logger zerolo
 
 		// Regenerate title if due (every 3 turns). Non-fatal — log and continue.
 		if services.TitleService != nil {
-			if titleErr := services.TitleService.MaybeRegenerateTitle(ctx, orgID, sessionID); titleErr != nil {
+			var completedThreadID *uuid.UUID
+			if hasThread {
+				threadIDLocal := threadID
+				completedThreadID = &threadIDLocal
+			}
+			if titleErr := services.TitleService.MaybeRegenerateTitle(ctx, orgID, sessionID, completedThreadID); titleErr != nil {
 				logger.Warn().Err(titleErr).Str("session_id", sessionID.String()).Msg("failed to regenerate session title")
 			}
 		}


### PR DESCRIPTION
## Summary

Fix session title regeneration across tabs so secondary tab completions don’t trigger LLM-based title updates and produce inconsistent/odd titles. This change threads the completed thread ID into title regeneration, verifies it belongs to the session’s primary thread, and no-ops otherwise.

## Changes

- Updated `SessionTitleService.MaybeRegenerateTitle` to accept an optional `completedThreadID` and skip regeneration when that thread isn’t the session’s primary thread.
- Added `completedThreadIDIsPrimary` using the session thread store to determine whether the completed thread should be allowed to update the title.
- Wired dependencies and call sites:
  - `cmd/server/main.go` now passes `sessionThreadStore` into `NewSessionTitleService`.
  - `internal/worker/handlers.go` now passes the completed thread ID to title regeneration.

## Validation

- `go test ./internal/services -run 'TestMaybeRegenerateTitle|TestCleanTitle|TestBuildTitleUserPrompt'`
- `go vet ./...`
- `go build ./...`
- `go test ./...` (resolved by rerunning the single unrelated transient Redis timing failure in `TestSessionHandler_StreamLogsViaRedis_SubscriptionClosureWritesRetryEvent` with `-count=1`)

[143.dev](https://143.dev) | [session 733dfadc](https://143.dev/sessions/733dfadc-04f5-41aa-9fe6-f2856de193c4)

<!-- 143 readiness -->
**143 readiness:** not available for this revision.

Preview: https://143.dev/previews/github/assembledhq/143/pull/1557?launch=1