### PR TITLE
Recreate-safe preview recycle: fail fast when the sandbox is gone

### DIFF
--- a/internal/services/preview/manager.go
+++ b/internal/services/preview/manager.go
@@ -2143,6 +2143,45 @@ func (m *Manager) recyclePreview(ctx context.Context, orgID, previewID uuid.UUID
 		}
 	}
 
+	// Guard against recycling onto a sandbox container that no longer exists.
+	// Recycle reuses the sandbox recorded at first launch (input.Sandbox); if
+	// that container was removed out-of-band (OOM, crash, prune) after the
+	// preview went ready, reusing it fails deep inside provisionInfra with a
+	// confusing "No such container" error and hard-fails the preview. Probe
+	// liveness first — the same guard the launch-time reuse path applies — and
+	// only recycle in place when the container is definitively alive.
+	if m.sandboxProvider != nil && input.Sandbox != nil && input.Sandbox.ID != "" {
+		alive, aliveErr := m.sandboxProvider.IsAlive(ctx, input.Sandbox)
+		switch {
+		case aliveErr != nil:
+			// Indeterminate — the container may well be healthy. Don't disturb
+			// a possibly-running preview; the scheduled-recycle marker persists
+			// so the next recycler sweep retries the probe.
+			m.logger.Warn().Err(aliveErr).
+				Str("preview_id", previewID.String()).
+				Str("container_id", input.Sandbox.ID).
+				Msg("recycle: sandbox liveness probe failed; skipping this sweep")
+			return nil
+		case !alive:
+			// Definitively gone. The preview's workspace died with the
+			// container, so there is nothing to recycle in place. Fail with an
+			// actionable message; relaunching cold-starts a fresh sandbox.
+			const deadSandboxReason = "preview sandbox was removed; relaunch to recreate it"
+			m.logger.Warn().
+				Str("preview_id", previewID.String()).
+				Str("container_id", input.Sandbox.ID).
+				Msg("recycle: sandbox container no longer exists; failing preview so it can be relaunched")
+			if statusErr := m.store.UpdatePreviewStatus(ctx, orgID, previewID, models.PreviewStatusFailed, deadSandboxReason); statusErr != nil {
+				m.logger.Warn().Err(statusErr).Str("preview_id", previewID.String()).Msg("recycle: failed to set failed status after dead sandbox")
+			}
+			if schedErr := m.store.ClearRecycleSchedule(ctx, orgID, previewID); schedErr != nil {
+				m.logger.Warn().Err(schedErr).Str("preview_id", previewID.String()).Msg("recycle: failed to clear recycle schedule after dead sandbox")
+			}
+			m.releasePreviewHoldAfterRecycleFailure(ctx, instance)
+			return fmt.Errorf("recycle: sandbox container %s no longer exists", input.Sandbox.ID)
+		}
+	}
+
 	m.logger.Info().Str("preview_id", previewID.String()).Msg("recycling preview")
 
 	// Stop any running poll goroutine before recycling, so it cannot race

--- a/internal/services/preview/manager.go
+++ b/internal/services/preview/manager.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/google/uuid"
@@ -2096,6 +2097,54 @@ type workspaceRevisionStamp struct {
 	updatedAt time.Time
 }
 
+// errRecycleSkipped signals that a recycle attempt was intentionally skipped
+// (e.g. an indeterminate sandbox liveness probe) rather than failed. The
+// recycler treats it as a no-op so the attempt is not counted or logged as a
+// failed recycle.
+var errRecycleSkipped = errors.New("recycle skipped")
+
+// recycleIsAliveAttempts bounds how many times recyclePreview probes sandbox
+// liveness before treating a persistently-erroring probe as indeterminate.
+const recycleIsAliveAttempts = 3
+
+// recycleIsAliveBackoff is the delay between liveness-probe retries, stored as
+// nanoseconds in an atomic so tests can drop it to zero without racing the
+// recycler goroutine.
+var recycleIsAliveBackoff atomic.Int64
+
+func init() { recycleIsAliveBackoff.Store(int64(500 * time.Millisecond)) }
+
+// SetRecycleIsAliveBackoffForTesting overrides the liveness-probe retry backoff.
+func SetRecycleIsAliveBackoffForTesting(d time.Duration) {
+	recycleIsAliveBackoff.Store(int64(d))
+}
+
+// probeSandboxAlive calls IsAlive with bounded retries so a momentary
+// docker-daemon hiccup within a single recycle sweep does not skip an otherwise
+// healthy preview. A definitive result (err == nil) — including "container is
+// gone" — returns immediately without retrying.
+func (m *Manager) probeSandboxAlive(ctx context.Context, sb *agent.Sandbox) (bool, error) {
+	var lastErr error
+	for attempt := 1; attempt <= recycleIsAliveAttempts; attempt++ {
+		alive, err := m.sandboxProvider.IsAlive(ctx, sb)
+		if err == nil {
+			return alive, nil
+		}
+		lastErr = err
+		if ctx.Err() != nil {
+			break
+		}
+		if backoff := time.Duration(recycleIsAliveBackoff.Load()); attempt < recycleIsAliveAttempts && backoff > 0 {
+			select {
+			case <-ctx.Done():
+				return false, ctx.Err()
+			case <-time.After(backoff):
+			}
+		}
+	}
+	return false, lastErr
+}
+
 func (m *Manager) recyclePreview(ctx context.Context, orgID, previewID uuid.UUID, refreshedConfig *models.PreviewConfig, revisionStamp *workspaceRevisionStamp) error {
 	instance, err := m.store.GetPreviewInstance(ctx, orgID, previewID)
 	if err != nil {
@@ -2113,6 +2162,53 @@ func (m *Manager) recyclePreview(ctx context.Context, orgID, previewID uuid.UUID
 	if err != nil {
 		return fmt.Errorf("load recycle input: %w", err)
 	}
+
+	// Guard against recycling onto a sandbox container that no longer exists.
+	// Recycle reuses the sandbox recorded at first launch (input.Sandbox); if
+	// that container was removed out-of-band (OOM, crash, prune) after the
+	// preview went ready, reusing it fails deep inside provisionInfra with a
+	// confusing "No such container" error and hard-fails the preview. Probe
+	// liveness first — the same guard the launch-time reuse path applies — and
+	// only recycle in place when the container is definitively alive. Checked
+	// before the config refresh below so a dead preview is not left with a
+	// freshly-persisted recycle config it will never use.
+	if m.sandboxProvider != nil && input.Sandbox != nil && input.Sandbox.ID != "" {
+		alive, aliveErr := m.probeSandboxAlive(ctx, input.Sandbox)
+		switch {
+		case aliveErr != nil:
+			// Indeterminate even after retries — the container may well be
+			// healthy. Don't disturb a possibly-running preview; the
+			// scheduled-recycle marker persists so a later sweep retries.
+			// Wrap errRecycleSkipped so the recycler counts this as a skip,
+			// not a failed recycle, and logs it quietly.
+			m.logger.Debug().Err(aliveErr).
+				Str("preview_id", previewID.String()).
+				Str("container_id", input.Sandbox.ID).
+				Msg("recycle: sandbox liveness probe failed; skipping this sweep")
+			return fmt.Errorf("recycle: sandbox liveness probe failed: %w", errRecycleSkipped)
+		case !alive:
+			// Definitively gone. The preview's workspace died with the
+			// container, so there is nothing to recycle in place. Fail with an
+			// actionable message; relaunching cold-starts a fresh sandbox. Use
+			// the active-guarded status update so a preview that was stopped or
+			// expired concurrently (between the lookup above and here) is not
+			// clobbered back to "failed".
+			const deadSandboxReason = "preview sandbox was removed; relaunch to recreate it"
+			m.logger.Warn().
+				Str("preview_id", previewID.String()).
+				Str("container_id", input.Sandbox.ID).
+				Msg("recycle: sandbox container no longer exists; failing preview so it can be relaunched")
+			if _, statusErr := m.store.UpdatePreviewStatusIfActive(ctx, orgID, previewID, models.PreviewStatusFailed, deadSandboxReason); statusErr != nil {
+				m.logger.Warn().Err(statusErr).Str("preview_id", previewID.String()).Msg("recycle: failed to set failed status after dead sandbox")
+			}
+			if schedErr := m.store.ClearRecycleSchedule(ctx, orgID, previewID); schedErr != nil {
+				m.logger.Warn().Err(schedErr).Str("preview_id", previewID.String()).Msg("recycle: failed to clear recycle schedule after dead sandbox")
+			}
+			m.releasePreviewHoldAfterRecycleFailure(ctx, instance)
+			return fmt.Errorf("recycle: sandbox container %s no longer exists", input.Sandbox.ID)
+		}
+	}
+
 	if refreshedConfig != nil {
 		resourcePolicy, policyErr := m.resourcePolicy(ctx, orgID)
 		if policyErr != nil {
@@ -2140,45 +2236,6 @@ func (m *Manager) recyclePreview(ctx context.Context, orgID, previewID uuid.UUID
 			configJSON,
 		); err != nil {
 			return err
-		}
-	}
-
-	// Guard against recycling onto a sandbox container that no longer exists.
-	// Recycle reuses the sandbox recorded at first launch (input.Sandbox); if
-	// that container was removed out-of-band (OOM, crash, prune) after the
-	// preview went ready, reusing it fails deep inside provisionInfra with a
-	// confusing "No such container" error and hard-fails the preview. Probe
-	// liveness first — the same guard the launch-time reuse path applies — and
-	// only recycle in place when the container is definitively alive.
-	if m.sandboxProvider != nil && input.Sandbox != nil && input.Sandbox.ID != "" {
-		alive, aliveErr := m.sandboxProvider.IsAlive(ctx, input.Sandbox)
-		switch {
-		case aliveErr != nil:
-			// Indeterminate — the container may well be healthy. Don't disturb
-			// a possibly-running preview; the scheduled-recycle marker persists
-			// so the next recycler sweep retries the probe.
-			m.logger.Warn().Err(aliveErr).
-				Str("preview_id", previewID.String()).
-				Str("container_id", input.Sandbox.ID).
-				Msg("recycle: sandbox liveness probe failed; skipping this sweep")
-			return nil
-		case !alive:
-			// Definitively gone. The preview's workspace died with the
-			// container, so there is nothing to recycle in place. Fail with an
-			// actionable message; relaunching cold-starts a fresh sandbox.
-			const deadSandboxReason = "preview sandbox was removed; relaunch to recreate it"
-			m.logger.Warn().
-				Str("preview_id", previewID.String()).
-				Str("container_id", input.Sandbox.ID).
-				Msg("recycle: sandbox container no longer exists; failing preview so it can be relaunched")
-			if statusErr := m.store.UpdatePreviewStatus(ctx, orgID, previewID, models.PreviewStatusFailed, deadSandboxReason); statusErr != nil {
-				m.logger.Warn().Err(statusErr).Str("preview_id", previewID.String()).Msg("recycle: failed to set failed status after dead sandbox")
-			}
-			if schedErr := m.store.ClearRecycleSchedule(ctx, orgID, previewID); schedErr != nil {
-				m.logger.Warn().Err(schedErr).Str("preview_id", previewID.String()).Msg("recycle: failed to clear recycle schedule after dead sandbox")
-			}
-			m.releasePreviewHoldAfterRecycleFailure(ctx, instance)
-			return fmt.Errorf("recycle: sandbox container %s no longer exists", input.Sandbox.ID)
 		}
 	}
 

--- a/internal/services/preview/manager_test.go
+++ b/internal/services/preview/manager_test.go
@@ -1641,10 +1641,12 @@ func TestRecyclePreview_DeadSandboxFailsInsteadOfReprovisioning(t *testing.T) {
 
 // TestRecyclePreview_TransientLivenessProbeSkipsSweep verifies that an
 // indeterminate liveness probe (e.g. a transient Docker error) does not disturb
-// a possibly-healthy preview: the sweep is skipped and the scheduled-recycle
-// marker is left in place so a later sweep retries.
+// a possibly-healthy preview: the probe is retried, then the sweep is skipped
+// with errRecycleSkipped (so the recycler does not count it as a recycle) and
+// the preview is left untouched for a later sweep to retry.
 func TestRecyclePreview_TransientLivenessProbeSkipsSweep(t *testing.T) {
 	t.Parallel()
+	SetRecycleIsAliveBackoffForTesting(0) // keep probe retries instant
 
 	mock, err := pgxmock.NewPool()
 	require.NoError(t, err, "pgxmock pool should be created")
@@ -1663,8 +1665,10 @@ func TestRecyclePreview_TransientLivenessProbeSkipsSweep(t *testing.T) {
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
 		WillReturnRows(pgxmock.NewRows(previewInstanceTestCols).AddRow(row...))
 
+	var probes int
 	sandboxProvider := testutil.NewMockSandboxProvider()
 	sandboxProvider.IsAliveFn = func(context.Context, *agent.Sandbox) (bool, error) {
+		probes++
 		return false, errors.New("docker daemon unreachable")
 	}
 	mgr := NewManager(ManagerConfig{
@@ -1676,8 +1680,66 @@ func TestRecyclePreview_TransientLivenessProbeSkipsSweep(t *testing.T) {
 	})
 
 	err = mgr.RecyclePreview(context.Background(), orgID, previewID)
-	require.NoError(t, err, "a transient liveness probe failure should skip the sweep, not fail the preview")
+	require.Error(t, err, "a transient liveness probe failure should return an error")
+	require.ErrorIs(t, err, errRecycleSkipped, "transient probe failure should be reported as a skip, not a recycle failure")
+	require.Equal(t, recycleIsAliveAttempts, probes, "the liveness probe should be retried before giving up")
 	require.NoError(t, mock.ExpectationsWereMet(), "transient probe failure should not mutate the preview")
+}
+
+// TestRecyclePreview_LiveSandboxProceeds confirms the liveness guard does not
+// block the happy path: when the sandbox container is alive, recycle proceeds
+// through StartPreview and back to a ready status as before.
+func TestRecyclePreview_LiveSandboxProceeds(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "pgxmock pool should be created")
+	defer mock.Close()
+
+	orgID := uuid.New()
+	previewID := uuid.New()
+	sessionID := uuid.New()
+	userID := uuid.New()
+	now := time.Now()
+
+	mock.ExpectQuery("SELECT .+ FROM preview_instances WHERE id").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(
+			pgxmock.NewRows(previewInstanceTestCols).
+				AddRow(newPreviewInstanceRow(previewID, sessionID, orgID, userID, models.PreviewStatusReady, "handle-old", now)...),
+		)
+	// Full recycle path runs once the live-sandbox guard passes.
+	mock.ExpectExec("UPDATE preview_instances SET status = @status.+NOT IN").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
+	mock.ExpectExec("UPDATE preview_access_sessions SET revoked_at").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnResult(pgxmock.NewResult("UPDATE", 0))
+	mock.ExpectExec("UPDATE preview_instances SET preview_handle = @handle, port = @port").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
+	mock.ExpectExec("UPDATE preview_instances SET status = @status").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
+	mock.ExpectExec("UPDATE preview_instances SET expires_at = @expires_at").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
+
+	sandboxProvider := testutil.NewMockSandboxProvider()
+	sandboxProvider.IsAliveFn = func(context.Context, *agent.Sandbox) (bool, error) {
+		return true, nil
+	}
+	mgr := NewManager(ManagerConfig{
+		Store:           db.NewPreviewStore(mock),
+		Provider:        &mockProvider{startHandle: &PreviewHandle{Handle: "handle-new", PrimaryPort: 3001}},
+		SandboxProvider: sandboxProvider,
+		Logger:          zerolog.Nop(),
+		WorkerNodeID:    "worker-1",
+	})
+
+	err = mgr.RecyclePreview(context.Background(), orgID, previewID)
+	require.NoError(t, err, "recycle should proceed normally when the sandbox is alive")
+	require.NoError(t, mock.ExpectationsWereMet(), "live-sandbox recycle should run the full restart path")
 }
 
 func TestRecyclePreview_FallsBackForLegacyPreviewsWithoutStoredRecycleState(t *testing.T) {

--- a/internal/services/preview/manager_test.go
+++ b/internal/services/preview/manager_test.go
@@ -1588,6 +1588,98 @@ func TestRecyclePreview_StartFailureReleasesPreviewHold(t *testing.T) {
 	require.NoError(t, mock.ExpectationsWereMet(), "failed recycle should release the preview sandbox hold")
 }
 
+// TestRecyclePreview_DeadSandboxFailsInsteadOfReprovisioning guards the fix for
+// the recycle path reusing a sandbox container that was removed out-of-band
+// (OOM/crash/prune) after the preview went ready. Without the liveness probe,
+// re-provisioning infrastructure against the dead container fails deep with a
+// confusing "No such container" error; with it, the preview fails fast with an
+// actionable message and never transitions to "starting" or calls StartPreview.
+func TestRecyclePreview_DeadSandboxFailsInsteadOfReprovisioning(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "pgxmock pool should be created")
+	defer mock.Close()
+
+	orgID := uuid.New()
+	previewID := uuid.New()
+	userID := uuid.New()
+	now := time.Now()
+
+	// Branch preview (no session) whose recorded sandbox is gone.
+	row := newPreviewInstanceRow(previewID, uuid.Nil, orgID, userID, models.PreviewStatusReady, "handle-old", now)
+	setPreviewInstanceRowColumn(row, "recycle_sandbox", []byte(`{"id":"sandbox-dead","provider":"docker","work_dir":"/workspace"}`))
+
+	mock.ExpectQuery("SELECT .+ FROM preview_instances WHERE id").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(pgxmock.NewRows(previewInstanceTestCols).AddRow(row...))
+	// The guard marks the preview failed and clears the recycle schedule. No
+	// "starting" transition, RevokeAllForPreview, or handle update — those only
+	// happen once we commit to recycling onto a live sandbox.
+	expectUpdatePreviewStatusFailed(mock)
+	mock.ExpectExec("UPDATE preview_instances SET recycle_scheduled_at = NULL").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
+
+	sandboxProvider := testutil.NewMockSandboxProvider()
+	sandboxProvider.IsAliveFn = func(context.Context, *agent.Sandbox) (bool, error) {
+		return false, nil // definitively gone
+	}
+	mgr := NewManager(ManagerConfig{
+		Store:           db.NewPreviewStore(mock),
+		Provider:        &mockProvider{startHandle: &PreviewHandle{Handle: "handle-new", PrimaryPort: 3001}},
+		SandboxProvider: sandboxProvider,
+		Logger:          zerolog.Nop(),
+		WorkerNodeID:    "worker-1",
+	})
+
+	err = mgr.RecyclePreview(context.Background(), orgID, previewID)
+	require.Error(t, err, "recycle should fail when the sandbox container no longer exists")
+	require.Contains(t, err.Error(), "no longer exists", "error should explain the sandbox is gone")
+	require.NoError(t, mock.ExpectationsWereMet(), "dead-sandbox recycle should mark failed and clear the schedule without reprovisioning")
+}
+
+// TestRecyclePreview_TransientLivenessProbeSkipsSweep verifies that an
+// indeterminate liveness probe (e.g. a transient Docker error) does not disturb
+// a possibly-healthy preview: the sweep is skipped and the scheduled-recycle
+// marker is left in place so a later sweep retries.
+func TestRecyclePreview_TransientLivenessProbeSkipsSweep(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "pgxmock pool should be created")
+	defer mock.Close()
+
+	orgID := uuid.New()
+	previewID := uuid.New()
+	userID := uuid.New()
+	now := time.Now()
+
+	row := newPreviewInstanceRow(previewID, uuid.Nil, orgID, userID, models.PreviewStatusReady, "handle-old", now)
+	setPreviewInstanceRowColumn(row, "recycle_sandbox", []byte(`{"id":"sandbox-maybe","provider":"docker","work_dir":"/workspace"}`))
+
+	// Only the instance lookup runs — the preview is left untouched.
+	mock.ExpectQuery("SELECT .+ FROM preview_instances WHERE id").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(pgxmock.NewRows(previewInstanceTestCols).AddRow(row...))
+
+	sandboxProvider := testutil.NewMockSandboxProvider()
+	sandboxProvider.IsAliveFn = func(context.Context, *agent.Sandbox) (bool, error) {
+		return false, errors.New("docker daemon unreachable")
+	}
+	mgr := NewManager(ManagerConfig{
+		Store:           db.NewPreviewStore(mock),
+		Provider:        &mockProvider{startHandle: &PreviewHandle{Handle: "handle-new", PrimaryPort: 3001}},
+		SandboxProvider: sandboxProvider,
+		Logger:          zerolog.Nop(),
+		WorkerNodeID:    "worker-1",
+	})
+
+	err = mgr.RecyclePreview(context.Background(), orgID, previewID)
+	require.NoError(t, err, "a transient liveness probe failure should skip the sweep, not fail the preview")
+	require.NoError(t, mock.ExpectationsWereMet(), "transient probe failure should not mutate the preview")
+}
+
 func TestRecyclePreview_FallsBackForLegacyPreviewsWithoutStoredRecycleState(t *testing.T) {
 	t.Parallel()
 

--- a/internal/services/preview/recycler.go
+++ b/internal/services/preview/recycler.go
@@ -2,6 +2,7 @@ package preview
 
 import (
 	"context"
+	"errors"
 	"sync"
 	"time"
 
@@ -157,6 +158,15 @@ func (w *RecycleWorker) recycle() {
 		rErr := w.manager.RecyclePreview(previewCtx, p.OrgID, p.ID)
 		previewCancel()
 		if rErr != nil {
+			if errors.Is(rErr, errRecycleSkipped) {
+				// Intentional skip (e.g. indeterminate liveness probe) — not a
+				// failure and not a completed recycle. The scheduled marker
+				// persists so a later sweep retries.
+				w.logger.Debug().Err(rErr).
+					Str("preview_id", p.ID.String()).
+					Msg("recycle: skipped this sweep; will retry")
+				continue
+			}
 			w.logger.Warn().Err(rErr).
 				Str("preview_id", p.ID.String()).
 				Msg("recycle: failed to recycle preview")


### PR DESCRIPTION
## Problem

A branch preview launch surfaced this user-facing error:

> Preview could not open — provision infrastructure "db": resolve sandbox network: Error response from daemon: No such container: `1381375c9895…`

Tracing it in prod: the preview wasn't failing on first launch. It reached **ready**, ran for ~an hour, then the **60-minute auto-recycle** (`RecycleWorker`, `DefaultMaxUptime = 60min`) fired and failed.

`recyclePreview` reuses the sandbox recorded at first launch (`input.Sandbox`, loaded from the persisted `recycle_sandbox` snapshot) and calls `StartPreview` with the **old container ID**. That container had been removed out-of-band in the interim (OOM / crash / prune — this target also has a same-day history of OOM-kills and disk-full build failures). So `StartPreview → provisionInfra → resolveSandboxNetwork(sb.ID) → ContainerInspect(...)` returned "No such container", hard-failing the preview with a cryptic message — even though a fresh launch recovers cleanly.

`StopPreview` only tears down infra + service processes, so the recycle's own stop step isn't the culprit; the sandbox died independently and recycle blindly reused the corpse. The **launch-time** sandbox-reuse path already guards against exactly this with an `IsAlive` probe (`internal/api/handlers/preview.go`) — the **recycle** path had no equivalent.

## Fix

Add a liveness guard at the top of `recyclePreview`, before any destructive step (status→`starting`, `StopPreview`, session revocation, re-provision):

- **Container definitively gone** (`alive=false, err=nil`) → mark the preview `failed` with an actionable message (*"preview sandbox was removed; relaunch to recreate it"*), clear the recycle schedule, release any hold. No more cryptic infra error.
- **Indeterminate probe** (`alive=false, err≠nil`, e.g. transient Docker blip) → skip this sweep and leave the running preview untouched; `recycle_scheduled_at` persists so the next sweep retries. Avoids killing a healthy preview on a flaky inspect.
- **Alive** → recycle proceeds unchanged.

## Tests

- `TestRecyclePreview_DeadSandboxFailsInsteadOfReprovisioning` — dead container → fails fast, clears schedule, never transitions to `starting` or calls `StartPreview`.
- `TestRecyclePreview_TransientLivenessProbeSkipsSweep` — transient probe error → no mutation, preview left running.

Existing recycle tests are unaffected (they don't wire a `SandboxProvider`; the mock's default `IsAlive` returns alive). `make lint` clean, full `internal/services/preview` suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
