### PR TITLE
Fix sandbox git-push ECONNREFUSED when worker restarts mid-session

### DIFF
--- a/docs/design/future/109-sandbox-auth-socket-ownership.md
+++ b/docs/design/future/109-sandbox-auth-socket-ownership.md
@@ -1,0 +1,187 @@
+# Design: Sandbox GitHub-Auth Socket Ownership
+
+> **Status:** Future
+> **Last reviewed:** 2026-06-22
+
+## Problem
+
+Sandboxed coding agents push to GitHub through a per-session Unix-domain socket.
+The host listens on `<socket-dir>/<session-id>/sock`; the sandbox dials it at
+`/run/143-auth/sock` via a directory bind-mount, and the host replies with a
+fresh GitHub token resolved per request (see
+[implemented/65-unified-coding-credentials.md](../implemented/65-unified-coding-credentials.md)
+and `internal/services/sandboxauth/`). The per-request resolve is deliberate:
+it lets each push pick up token refreshes and org-policy changes without
+restarting the session.
+
+The socket has a **lifetime-ownership bug**: it is bound by the **per-turn
+`session-executor` process**, but the sandbox container **outlives every
+executor**.
+
+Concretely:
+
+- A turn is run by a one-off `session-executor` process (the
+  `143-worker-run-*` containers, dispatched by `DurableSessionExecutorDispatcher`).
+- That process builds the `sandboxauth.Broker` and binds the socket inside
+  `prepareSandboxGitHubAuth` → `Listen` (`orchestrator.go`).
+- On exit it runs `SandboxAuthShutdown` → `Broker.Shutdown`, which closes **all**
+  its session sockets and unlinks the files (`session_executor_main.go`,
+  `broker.go`).
+- The container is kept alive across turns by a **turn hold**
+  (`turn_holding_container`) or a **preview hold** (`preview_holding_container`).
+
+So between turns — and during any executor restart (rolling deploy drain,
+crash, OOM) — there is no process listening on the socket. The agent's next
+`git push` dials a live bind-mounted path with nothing behind it and gets:
+
+```
+143-tools git-credential: sandboxauth: dial /run/143-auth/sock: connect: connection refused
+fatal: could not read Username for 'https://github.com'
+```
+
+This is what the `Broker` doc comment already *claims* is impossible — it says
+ownership lives "in the long-lived worker process." Reality drifted when turn
+execution was split into one-off executors. This doc is the plan to realign
+code with that intent.
+
+### Observed incident (2026-06-22)
+
+Session `7290ddb5-…` (turn-held, **no** preview hold) failed a push at 21:09
+UTC. Its executor node `g20260622201202` was `node_marked_draining` at 21:04
+(mid-turn) during a rolling deploy; the socket died with the drained executor.
+The push only succeeded on the user's *next* turn (21:30), which re-ran
+`prepareSandboxGitHubAuth`. There were **zero** `rehydrate:` log lines all day
+across many restarts because the rehydrate safety net (a) covered only
+preview-held containers and (b) was scoped to a deploy-stamped `worker_node_id`
+that no longer matched the surviving row.
+
+## Stopgaps already shipped (Option 1)
+
+These reduce the failure rate but do **not** remove the root cause:
+
+1. **In-sandbox connect-retry.** `sandboxauth.Client.dial` retries a refused /
+   missing socket for ~30s (`protocol.go`). Turns the common brief re-bind gap
+   into a short pause for `git push` instead of a hard failure. Bounded so a
+   socket that is never coming back still fails in bounded time. This stays
+   useful permanently, regardless of who owns the socket.
+2. **Rehydrate covers turn holds.** `ListContainerHoldingSessions`
+   (`session_store.go`) now returns running/recovering **turn-held** containers
+   in addition to preview-held ones — exactly the set the orphan reconciler
+   preserves — so a same-generation process restart re-opens their sockets at
+   boot. Still scoped to `worker_node_id`, so it does **not** cover a rolling
+   deploy that changes the node id.
+
+The residual gap after Option 1: a **rolling deploy** (new node id) where the
+re-bind has to wait for the next turn, and that turn is delayed longer than the
+client retry budget.
+
+## Goal
+
+Bind the per-session socket in a process whose lifetime matches the
+**container's** lifetime, so the socket is continuously available from container
+create/adopt until container reap — independent of how many turn executors come
+and go, and transparent across rolling deploys on the same host.
+
+## Proposed design
+
+### 1. The long-lived worker owns the socket
+
+Move socket binding out of the per-turn executor and into the **long-lived
+worker** process on the host (the process that already runs the orphan
+reconciler and the rehydrate pass at startup).
+
+- The worker opens the listener when a container is **created or adopted** for a
+  session on this host, and closes it only when the container is **reaped**
+  (the same lifecycle the orphan reconciler already tracks).
+- The executor **stops hosting** the socket. It keeps the `Resolve()` call that
+  stamps commit-identity env (`user.name` / `user.email` / co-author), but drops
+  `Listen` and the `SandboxAuthShutdown`-on-exit. Exiting an executor must never
+  unlink a live container's socket.
+- The resolver must be wired on the worker side (it already is — rehydrate uses
+  `o.identityResolver` via the worker's orchestrator).
+
+Because the credential is resolved fresh per request by whichever process holds
+the listener, moving the host end does not change the token semantics.
+
+### 2. Deploy-proof, host-grounded scoping
+
+Stop keying "which containers are mine" on the deploy-stamped `worker_node_id`.
+Follow the orphan reconciler's proven pattern: enumerate candidates and gate the
+actual bind on a **local `IsAlive` probe** (docker inspect only sees containers
+physically on this host). A container on another host fails the probe and is
+skipped, so a node never binds a socket it shouldn't — without depending on the
+DB's node-id bookkeeping surviving a deploy.
+
+Either: scan all container-holding sessions and `IsAlive`-gate each (simplest,
+matches the reconciler; acceptable at current scale), or introduce a
+**host-stable identifier** (the host portion of the node id, before the
+`-g<deploy-ts>-<sha>` suffix) and scope by that. The host-stable id is the
+better long-term choice if global scans become expensive.
+
+### 3. Cross-generation handoff during rolling deploys
+
+The hard case: during a rolling deploy two worker generations run on the **same
+host** for a window — the old generation draining in-flight turns, the new
+generation booting. Both can see the same container as alive. Binding rules must
+prevent them from fighting over one socket file:
+
+- **Do not blindly `os.Remove` + re-bind** a socket another live generation may
+  be serving. Before re-binding, probe whether the existing socket already has a
+  working listener (dial it); if it answers, adopt it / leave it alone rather
+  than stealing the path.
+- **A draining generation must not unlink sockets for containers it is handing
+  off.** `Broker.Shutdown` on drain should release leases without removing the
+  socket file when the container survives — only the reaper (container gone)
+  unlinks.
+- Make socket ownership a function of **container liveness**, not process
+  lifetime, so "who should be serving this path right now" has a single
+  unambiguous answer (the newest live worker generation on the host that owns
+  the container).
+
+### 4. Keep the bind-mount contract
+
+No change to the directory bind-mount (`SandboxSocketDir`) — that already lets a
+freshly bound socket file be picked up by the running container at lookup time.
+The whole point is that re-binding at the same path is transparent to the
+sandbox; this design just makes the re-binds rarer and never racy.
+
+## Migration / rollout
+
+1. Land Option 1 (done) — buys headroom and de-risks the window.
+2. Add worker-owned `Listen` on container create/adopt **alongside** the
+   executor's existing `Listen`, behind a flag, with the dial-before-rebind
+   guard so the two can coexist during rollout.
+3. Flip executors to skip `Listen` (keep `Resolve` for env). Verify via
+   `make logs-query` that `listener started/closed` now tracks container
+   lifecycle, not turn boundaries.
+4. Remove `SandboxAuthShutdown` from the executor shutdown path.
+5. Make rehydrate host-grounded (`IsAlive`-gated, deploy-proof) and drop the
+   `worker_node_id` scoping once worker-owned binding is the only path.
+
+## Verification
+
+- Drain a worker node mid-turn (simulate a rolling deploy) and confirm an
+  in-sandbox `git push` succeeds throughout, with no ECONNREFUSED.
+- Confirm `sandboxauth: listener started/closed` events correlate with
+  container create/reap, not with turn start/end.
+- Confirm two overlapping worker generations on one host never trade ENOENT /
+  "address already in use" on the same session socket.
+
+## Open questions
+
+- Global `IsAlive` scan vs. host-stable node id — pick based on expected
+  concurrent-session count per host.
+- Should the socket survive a *full* host reboot (container gone) — no; reaped
+  container ⇒ unlink. Confirm tmpfiles.d still recreates the parent dir
+  (`reconcile-worker-host.sh`).
+- Interaction with `remote_broker_client` / multi-host preview routing — does any
+  cross-host caller depend on the current per-executor broker?
+
+## Related
+
+- `internal/services/sandboxauth/` — protocol, broker, server, client.
+- `internal/services/agent/sandbox_auth_rehydrate.go` — startup rehydrate pass.
+- `internal/services/agent/reconciler.go` — the host-grounded, `IsAlive`-gated
+  pattern to mirror.
+- `internal/db/session_store.go` — `ListContainerHoldingSessions`,
+  `ListOrphanedContainers`.

--- a/internal/db/session_store.go
+++ b/internal/db/session_store.go
@@ -2924,25 +2924,38 @@ func (s *SessionStore) ListReferencedContainerIDs(ctx context.Context) ([]string
 	return ids, nil
 }
 
-// ListContainerHoldingSessions returns sessions with a preview hold owned by
-// workerNodeID whose container_id is set. Called on startup to rehydrate
-// per-session GitHub credential socket listeners for containers that survive
-// a worker restart (preview holds keep them alive across the gap).
+// ListContainerHoldingSessions returns sessions owned by workerNodeID whose
+// container_id is set and whose container is expected to outlive a worker
+// restart — both preview-held and turn-held (running / recovering) sessions.
+// Called on startup to rehydrate per-session GitHub credential socket
+// listeners for those surviving containers.
 //
 // Without rehydration, a push from inside a held-alive sandbox dials a dead
 // socket and gets ECONNREFUSED until the next turn boundary calls Listen
 // again. The fresh listener uses the same on-disk path so the container's
 // directory bind-mount picks it up transparently.
 //
-// Why preview-only and not turn-or-preview: a turn_holding_container=TRUE
-// row at startup means a worker crashed mid-turn. Those rows go through
-// the orphan reconciler (ListOrphanedContainers), which IsAlive-probes
-// them and either CAS-clears the row (container gone) or leaves it for
-// the next turn boundary to re-Listen as part of normal flow. Adding
-// turn-held rows here would either double-process them with the reconciler
-// or race it. Preview-held rows, by contrast, are the only ones whose
-// containers are *expected* to outlive the worker and need a proactive
-// re-Listen before any user action.
+// Why both hold kinds (was preview-only): the orphan reconciler
+// (ListOrphanedContainers / startupContainerDestroyProtected) *preserves*
+// turn-held containers for running and recovering sessions rather than
+// destroying them — but it never re-opens their auth socket. That left a gap:
+// a worker process restart (crash, OOM, drain) while a turn-held sandbox is
+// alive leaves the socket dead with nothing proactively re-binding it, so the
+// agent's next push fails until a brand-new turn happens to call Listen. We
+// now rehydrate exactly the set the reconciler preserves, so the two passes
+// are complementary (reconciler keeps the container; rehydrate re-sockets it)
+// rather than leaving turn-held rows uncovered. The caller's IsAlive probe
+// still gates the actual re-Listen, so a dead container the reconciler is
+// about to clear is never re-socketed.
+//
+// Scoping note: both branches are scoped to @worker_node_id (the preview row's
+// owner for preview holds; the session's owner for turn holds), so a node
+// never re-binds sockets for containers another generation owns. This does NOT
+// cover a rolling deploy that gives the surviving container's new owner a
+// different node id than the row still records — that gap is bridged by the
+// in-sandbox client's connect-retry plus the next turn's re-Listen, and closed
+// structurally by moving socket ownership to the long-lived worker (see
+// docs/design/future/109-sandbox-auth-socket-ownership.md).
 //
 // Returns at most limit rows per call, keyset-paginated by session id >
 // afterID and ordered by id ASC. Mirrors ListOrphanedContainers' pagination
@@ -2958,12 +2971,22 @@ func (s *SessionStore) ListContainerHoldingSessions(ctx context.Context, workerN
 		FROM sessions
 		WHERE container_id IS NOT NULL
 		  AND id > @after_id
-		  AND EXISTS (
-		    SELECT 1 FROM preview_instances p
-		    WHERE p.session_id = sessions.id
-		      AND p.org_id = sessions.org_id
-		      AND p.worker_node_id = @worker_node_id
-		      AND p.preview_holding_container = TRUE
+		  AND (
+		    EXISTS (
+		      SELECT 1 FROM preview_instances p
+		      WHERE p.session_id = sessions.id
+		        AND p.org_id = sessions.org_id
+		        AND p.worker_node_id = @worker_node_id
+		        AND p.preview_holding_container = TRUE
+		    )
+		    OR (
+		      sessions.turn_holding_container = TRUE
+		      AND sessions.worker_node_id = @worker_node_id
+		      AND (
+		        sessions.status = 'running'
+		        OR sessions.recovery_state IN ('queued', 'recovering')
+		      )
+		    )
 		  )
 		ORDER BY id ASC
 		LIMIT @limit`

--- a/internal/db/session_store_test.go
+++ b/internal/db/session_store_test.go
@@ -2764,9 +2764,12 @@ func TestSessionStore_ListReferencedContainerIDs_QueryError(t *testing.T) {
 
 // TestSessionStore_ListContainerHoldingSessions is the rehydrate-side
 // counterpart to ListOrphanedContainers: same paging, opposite predicate
-// (EXISTS preview hold instead of NOT EXISTS). The query must filter by
-// preview_holding_container so we don't try to rehydrate listeners for
-// containers that aren't actually being kept alive across a worker restart.
+// (a container that's being kept alive across a worker restart). The query
+// must match BOTH a preview hold (preview_holding_container) and a running /
+// recovering turn hold (turn_holding_container), so we re-open the credential
+// socket for every container the orphan reconciler preserves — not just the
+// preview-held ones. (pgxmock only asserts the SQL text shape;
+// TestIntegration_ListContainerHoldingSessions exercises the real predicate.)
 func TestSessionStore_ListContainerHoldingSessions(t *testing.T) {
 	t.Parallel()
 
@@ -2776,7 +2779,7 @@ func TestSessionStore_ListContainerHoldingSessions(t *testing.T) {
 
 	store := NewSessionStore(mock)
 	now := time.Now()
-	mock.ExpectQuery(`FROM sessions\s+WHERE container_id IS NOT NULL\s+AND id > @after_id\s+AND EXISTS[\s\S]+p\.worker_node_id = @worker_node_id[\s\S]+LIMIT @limit`).
+	mock.ExpectQuery(`FROM sessions\s+WHERE container_id IS NOT NULL\s+AND id > @after_id\s+AND \([\s\S]+preview_holding_container = TRUE[\s\S]+OR \([\s\S]+turn_holding_container = TRUE[\s\S]+worker_node_id = @worker_node_id[\s\S]+LIMIT @limit`).
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
 		WillReturnRows(
 			pgxmock.NewRows(sessionTestColumns).
@@ -2820,7 +2823,7 @@ func TestSessionStore_ListContainerHoldingSessions_ScanError(t *testing.T) {
 	store := NewSessionStore(mock)
 	now := time.Now()
 	scanErr := errors.New("simulated mid-row scan failure")
-	mock.ExpectQuery(`FROM sessions\s+WHERE container_id IS NOT NULL\s+AND id > @after_id\s+AND EXISTS[\s\S]+p\.worker_node_id = @worker_node_id[\s\S]+LIMIT @limit`).
+	mock.ExpectQuery(`FROM sessions\s+WHERE container_id IS NOT NULL\s+AND id > @after_id\s+AND \([\s\S]+preview_holding_container = TRUE[\s\S]+OR \([\s\S]+turn_holding_container = TRUE[\s\S]+LIMIT @limit`).
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
 		WillReturnRows(
 			pgxmock.NewRows(sessionTestColumns).

--- a/internal/services/agent/sandbox_auth_rehydrate.go
+++ b/internal/services/agent/sandbox_auth_rehydrate.go
@@ -30,9 +30,10 @@ const (
 // needed by the rehydrate pass. ListContainerHoldingSessions is scoped to the
 // local worker node, keyset-paginated by session id (pass uuid.Nil as the
 // cursor for the first page) with the caller-provided limit, and returns
-// sessions where container_id is set and a preview hold is in place — i.e.
-// the ones whose containers survive worker restarts and whose in-sandbox
-// tooling will dial a dead socket until we Listen again.
+// sessions where container_id is set and a hold (preview, or a running /
+// recovering turn) keeps the container alive — i.e. the ones whose containers
+// survive worker restarts and whose in-sandbox tooling will dial a dead socket
+// until we Listen again.
 type ContainerHoldingSessionLister interface {
 	ListContainerHoldingSessions(ctx context.Context, workerNodeID string, afterID uuid.UUID, limit int) ([]models.Session, error)
 }
@@ -52,7 +53,8 @@ type SandboxAuthRehydrater interface {
 
 // RehydrateSandboxAuthListeners is a one-shot startup pass that re-opens the
 // per-session GitHub credential socket listener for sessions whose containers
-// are still alive across a worker restart (preview holds keep them running).
+// are still alive across a worker restart (a preview hold, or a running /
+// recovering turn hold, keeps them running).
 //
 // Why this exists: the host-side sandboxauth.Server holds its listeners in
 // process memory, so a worker restart leaves their sockets on disk with no
@@ -66,7 +68,9 @@ type SandboxAuthRehydrater interface {
 //
 // Per session we:
 //  1. Probe IsAlive (cheap docker inspect). Containers that report dead are
-//     skipped — the orphan reconciler clears those rows separately.
+//     skipped — there is no socket worth opening for a gone container. The
+//     orphan reconciler clears (preview-held) or recovery handles (turn-held)
+//     those rows separately.
 //  2. Load the repo + org settings the resolver needs.
 //  3. Call sandboxAuth.Listen, which removes any stale socket file at the
 //     deterministic path and binds a fresh one. The bind-mount inside the

--- a/internal/services/sandboxauth/protocol.go
+++ b/internal/services/sandboxauth/protocol.go
@@ -27,6 +27,7 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"syscall"
 	"time"
 )
 
@@ -124,12 +125,37 @@ const DialTimeout = 5 * time.Second
 // allow more headroom than DialTimeout.
 const CallTimeout = 30 * time.Second
 
+// defaultConnectRetryBudget bounds how long Get keeps retrying a connection
+// that is refused or whose socket file is missing. The per-session socket is
+// bound by a worker/executor process that can briefly vanish across a rolling
+// deploy or restart while the sandbox container (and this client) keep
+// running. The socket directory bind-mount is stable, so a fresh listener
+// reappears at the same path within the host's restart/rehydrate window.
+// Retrying here turns that gap into a short pause for `git push` instead of a
+// hard "connection refused" failure. Bounded so a socket that is genuinely
+// never coming back still fails the push in bounded time rather than hanging
+// git indefinitely.
+const defaultConnectRetryBudget = 30 * time.Second
+
+// defaultConnectRetryInterval is the delay between connection attempts while
+// within the retry budget. Small enough that a listener returning mid-deploy
+// is picked up promptly, large enough not to busy-spin on a refused socket
+// (which fails its dial immediately rather than after DialTimeout).
+const defaultConnectRetryInterval = 1 * time.Second
+
 // Client dials the per-session socket and runs one request/response. It
 // opens a fresh connection per call — git's credential helper invokes us
 // once per push, so connection reuse buys nothing and complicates the
 // host-side handler (which today does one Resolve per Accept).
 type Client struct {
 	SocketPath string
+
+	// retryBudget and retryInterval bound dial retries when the listener is
+	// transiently absent (connection refused / socket file missing). Zero
+	// values fall back to the package defaults; they are fields rather than
+	// consts so tests can tighten them without real-time sleeps.
+	retryBudget   time.Duration
+	retryInterval time.Duration
 }
 
 // NewClient constructs a Client that talks to socketPath. socketPath is
@@ -154,6 +180,53 @@ func (c *Client) GetAPIToken(ctx context.Context) (string, error) {
 	return resp.Token, nil
 }
 
+// dial opens the per-session socket, retrying while the listener is
+// transiently absent. A worker/executor restart (rolling deploy, crash, or
+// drain) tears down the in-process listener while the bind-mounted socket
+// directory — and this sandbox client — keep living, so a connect can be
+// refused (no listener) or hit a not-yet-recreated socket file (ENOENT) for
+// the few seconds until the host re-binds at the same path. Both are treated
+// as "retry"; any other dial error (permission, malformed path, context
+// cancellation) is returned immediately. The last attempt's error is returned
+// verbatim so the caller's "dial %s" wrapper preserves the familiar message.
+func (c *Client) dial(ctx context.Context) (net.Conn, error) {
+	budget := c.retryBudget
+	if budget <= 0 {
+		budget = defaultConnectRetryBudget
+	}
+	interval := c.retryInterval
+	if interval <= 0 {
+		interval = defaultConnectRetryInterval
+	}
+
+	dialer := net.Dialer{Timeout: DialTimeout}
+	start := time.Now()
+	for {
+		conn, err := dialer.DialContext(ctx, "unix", c.SocketPath)
+		if err == nil {
+			return conn, nil
+		}
+		if !isListenerTransientlyAbsent(err) || ctx.Err() != nil || time.Since(start) >= budget {
+			return nil, err
+		}
+		select {
+		case <-ctx.Done():
+			return nil, err
+		case <-time.After(interval):
+		}
+	}
+}
+
+// isListenerTransientlyAbsent reports whether a dial error means "no one is
+// listening on the socket right now" — a refused connection or a socket file
+// that does not exist yet. These are the states a host restart passes through
+// before it re-binds the per-session socket, so they are safe to retry. Other
+// errors (EACCES, ENOTSOCK, name-too-long) are not transient and must not be
+// retried.
+func isListenerTransientlyAbsent(err error) bool {
+	return errors.Is(err, syscall.ECONNREFUSED) || errors.Is(err, syscall.ENOENT)
+}
+
 // Get asks the host to resolve a fresh GitHub credential for the given
 // action. Returns the response payload (which may carry a non-empty Error
 // field) and any transport error.
@@ -161,8 +234,7 @@ func (c *Client) Get(ctx context.Context, action Action) (*Response, error) {
 	if c.SocketPath == "" {
 		return nil, errors.New("sandboxauth: socket path is empty (set " + SocketEnvVar + ")")
 	}
-	dialer := net.Dialer{Timeout: DialTimeout}
-	conn, err := dialer.DialContext(ctx, "unix", c.SocketPath)
+	conn, err := c.dial(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("sandboxauth: dial %s: %w", c.SocketPath, err)
 	}

--- a/internal/services/sandboxauth/protocol_test.go
+++ b/internal/services/sandboxauth/protocol_test.go
@@ -4,11 +4,95 @@ import (
 	"context"
 	"encoding/json"
 	"net"
+	"os"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
 )
+
+// shortSockPath returns a test-unique AF_UNIX path that does not yet exist,
+// short enough to fit the ~104-byte macOS sun_path limit (t.TempDir() is too
+// long). The caller is responsible for listening on / cleaning up the path.
+func shortSockPath(t *testing.T) string {
+	t.Helper()
+	f, err := os.CreateTemp("", "143auth-*.sock")
+	require.NoError(t, err)
+	sock := f.Name()
+	require.NoError(t, f.Close())
+	require.NoError(t, os.Remove(sock)) // listen wants the path to not exist
+	t.Cleanup(func() { _ = os.Remove(sock) })
+	return sock
+}
+
+func TestClient_Get_RetriesUntilListenerAppears(t *testing.T) {
+	t.Parallel()
+
+	// Socket file is absent at first (ENOENT), then a listener binds it mid-
+	// flight — the exact shape of a worker re-binding the per-session socket
+	// after a restart while the sandbox client keeps dialing.
+	sock := shortSockPath(t)
+
+	go func() {
+		time.Sleep(150 * time.Millisecond)
+		ln, err := net.Listen("unix", sock)
+		if err != nil {
+			return
+		}
+		defer ln.Close()
+		conn, err := ln.Accept()
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+		var req Request
+		_ = json.NewDecoder(conn).Decode(&req)
+		_ = json.NewEncoder(conn).Encode(&Response{Token: "tok-after-retry"})
+	}()
+
+	client := &Client{SocketPath: sock, retryBudget: 5 * time.Second, retryInterval: 25 * time.Millisecond}
+	resp, err := client.Get(context.Background(), ActionPush)
+	require.NoError(t, err, "Get should retry past the initial ENOENT and connect once the listener binds")
+	require.Equal(t, "tok-after-retry", resp.Token)
+}
+
+func TestClient_Get_RetryGivesUpAfterBudget(t *testing.T) {
+	t.Parallel()
+
+	// No listener ever appears: Get should exhaust its (tiny) budget and
+	// surface the dial error rather than hanging git indefinitely.
+	sock := shortSockPath(t)
+
+	client := &Client{SocketPath: sock, retryBudget: 80 * time.Millisecond, retryInterval: 20 * time.Millisecond}
+	start := time.Now()
+	_, err := client.Get(context.Background(), ActionPush)
+	elapsed := time.Since(start)
+
+	require.Error(t, err, "a socket that never gets a listener must fail")
+	require.Contains(t, err.Error(), "dial "+sock, "error should preserve the familiar dial message")
+	require.GreaterOrEqual(t, elapsed, 60*time.Millisecond, "Get should have retried for roughly the budget before giving up")
+	require.Less(t, elapsed, 3*time.Second, "Get must not block far beyond its retry budget")
+}
+
+func TestClient_Get_StopsRetryingOnContextCancel(t *testing.T) {
+	t.Parallel()
+
+	// No listener exists, but the caller's context is cancelled well before
+	// the retry budget. Get must abandon retries promptly on cancellation
+	// rather than sleeping out the whole budget.
+	sock := shortSockPath(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Millisecond)
+	defer cancel()
+
+	client := &Client{SocketPath: sock, retryBudget: 10 * time.Second, retryInterval: 20 * time.Millisecond}
+	start := time.Now()
+	_, err := client.Get(ctx, ActionPush)
+	elapsed := time.Since(start)
+
+	require.Error(t, err, "a cancelled context with no listener must fail")
+	require.Less(t, elapsed, 2*time.Second, "Get must stop retrying once the context is done")
+}
 
 func TestClient_Get_UsesEarlierContextDeadline(t *testing.T) {
 	t.Parallel()
@@ -48,7 +132,12 @@ func TestClient_GetAPIToken(t *testing.T) {
 	t.Run("transport error propagates", func(t *testing.T) {
 		t.Parallel()
 
-		_, err := NewClient("/does/not/exist.sock").GetAPIToken(context.Background())
+		// Tiny retry budget: a permanently-missing socket is ENOENT, which Get
+		// now retries (a real session's socket reappears after a worker
+		// re-bind). We only care that the error still surfaces, not that we
+		// wait out the production-default budget.
+		client := &Client{SocketPath: "/does/not/exist.sock", retryBudget: 20 * time.Millisecond, retryInterval: 5 * time.Millisecond}
+		_, err := client.GetAPIToken(context.Background())
 		require.Error(t, err, "missing socket should surface as a transport error")
 	})
 

--- a/internal/services/sandboxauth/sandboxcli_test.go
+++ b/internal/services/sandboxauth/sandboxcli_test.go
@@ -119,7 +119,11 @@ func TestClient_GetMissingSocket(t *testing.T) {
 
 func TestClient_GetDialFailure(t *testing.T) {
 	t.Parallel()
-	_, err := NewClient("/tmp/no-such-socket-143-test").Get(context.Background(), ActionPush)
+	// Small retry budget: a missing socket is ENOENT, which Get now retries
+	// (it reappears when the host re-binds). We only assert the dial error
+	// surfaces, not that we wait out the production-default budget.
+	client := &Client{SocketPath: "/tmp/no-such-socket-143-test", retryBudget: 20 * time.Millisecond, retryInterval: 5 * time.Millisecond}
+	_, err := client.Get(context.Background(), ActionPush)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "dial")
 }


### PR DESCRIPTION
## Problem

In-sandbox `git push` resolves a GitHub token over a per-session unix socket (`/run/143-auth/sock`) that is bound by the **per-turn `session-executor` process**. The sandbox container outlives every executor (turn/preview hold), so an executor restart — rolling deploy drain, crash, OOM — leaves the socket dead while the container keeps running. The agent's next push fails with:

```
143-tools git-credential: sandboxauth: dial /run/143-auth/sock: connect: connection refused
fatal: could not read Username for 'https://github.com'
```

…until a brand-new turn happens to call `Listen` again.

**Why the safety net missed it:** `RehydrateSandboxAuthListeners` covered only **preview-held** containers, scoped to a deploy-stamped `worker_node_id`. But the orphan reconciler *preserves* running/recovering **turn-held** containers without ever re-opening their socket — so a turn-held sandbox (no preview hold) was never rehydrated. Confirmed in production: a session with `turn_holding_container=TRUE` and zero `preview_instances` rows failed a push right after its executor node was `node_marked_draining` mid-turn during a rolling deploy.

## Changes (Option 1 — targeted mitigation)

- **Client connect-retry** — `sandboxauth.Client.dial` retries `ECONNREFUSED`/`ENOENT` for ~30s (bounded, context-aware). Turns a brief re-bind gap into a short pause for `git push` instead of a hard failure. Benefits the credential helper and the MCP GitHub source alike.
- **Rehydrate coverage** — `ListContainerHoldingSessions` now also returns running/recovering **turn-held** containers — exactly the set the reconciler preserves — so a same-generation process restart re-sockets them at boot. Still `worker_node_id`-scoped (cross-generation safe). Deploys that change the node id are bridged by the retry above and closed structurally by the design doc.
- **Design doc** — `docs/design/future/109-sandbox-auth-socket-ownership.md`: move socket ownership to the long-lived worker (lifetime matches the container), host-grounded `IsAlive` scoping (deploy-proof, mirrors the reconciler), cross-generation handoff rules, and a staged rollout.

## Testing

- New `Client.Get` tests: retries until a listener appears, gives up after budget, stops on context cancel.
- `ListContainerHoldingSessions` query shape asserted (pgxmock); **new SQL validated with `EXPLAIN` against the real prod schema** (valid, uses existing indexes).
- `make lint` → 0 issues; `go build` of touched packages clean; `sandboxauth` + `db` tests pass against latest `main`.

## Notes

- The triggering session is already unblocked (it pushed on a follow-up turn). This PR fixes the recurrence.
- Scoped to only the 6 Go files + design doc; no unrelated changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
