### PR TITLE
Simplify automation goal improvement modal with inline editable revised goal and safer Apply logic

### DIFF
--- a/frontend/src/app/(dashboard)/settings/autopilot/page.tsx
+++ b/frontend/src/app/(dashboard)/settings/autopilot/page.tsx
@@ -39,7 +39,7 @@ import {
   PM_SCHEDULE_MAX_HOURS,
   clampNumber,
 } from "@/lib/settings-constants";
-import type { CodingCredentialSummary, ListResponse, Organization, OrgSettings, RepoSettings, Repository, SingleResponse } from "@/lib/types";
+import type { CodingCredentialSummary, ListResponse, Organization, OrgSettings, Repository, SingleResponse } from "@/lib/types";
 
 export default function AutopilotSettingsPage() {
   const { user } = useAuth();

--- a/frontend/src/components/automation-goal-improvement.test.tsx
+++ b/frontend/src/components/automation-goal-improvement.test.tsx
@@ -114,15 +114,110 @@ describe("AutomationGoalImprovementControl", () => {
 
     await user.click(screen.getByRole("button", { name: /improve goal/i }));
     expect(await screen.findByText("Review improved goal")).toBeInTheDocument();
-    expect(screen.getByDisplayValue(/focused test suite/i)).toBeInTheDocument();
+    const revisedGoal = screen.getByLabelText("Revised goal");
+    expect(revisedGoal).toHaveValue(
+      "Run the focused test suite and report failures with evidence.",
+    );
+    await user.clear(revisedGoal);
+    await user.type(revisedGoal, "Run only changed tests and summarize failures.");
 
     await user.click(screen.getByRole("button", { name: "Apply" }));
 
     await waitFor(() => {
       expect(onDraftApply).toHaveBeenCalledWith(
-        "Run the focused test suite and report failures with evidence.",
+        "Run only changed tests and summarize failures.",
       );
     });
+  });
+
+  it("keeps review details collapsed by default", async () => {
+    const user = userEvent.setup();
+
+    server.use(
+      http.post("/api/v1/automations/goal-improvements", () =>
+        HttpResponse.json({
+          data: {
+            id: "imp-1",
+            org_id: "org-1",
+            mode: "fast",
+            status: "completed",
+            input_goal: "Run tests",
+            base_goal_hash: "sha256:abc",
+            proposed_goal: "Run tests with concise evidence.",
+            proposal: {
+              rationale: "The original goal was too terse.",
+              changes: ["Added evidence requirements."],
+            },
+            confidence: "medium",
+            warnings: ["No repository evidence was available."],
+            created_at: "2026-06-18T00:00:00Z",
+            updated_at: "2026-06-18T00:00:00Z",
+          },
+        }),
+      ),
+    );
+
+    renderWithProviders(
+      <AutomationGoalImprovementControl
+        name="Tests"
+        goal="Run tests"
+        repositoryId="repo-1"
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: /improve goal/i }));
+    expect(await screen.findByLabelText("Revised goal")).toBeInTheDocument();
+    expect(screen.queryByText("Current goal")).not.toBeInTheDocument();
+    expect(screen.queryByText("Proposed changes")).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Show review notes" }));
+
+    expect(await screen.findByText("Current goal")).toBeInTheDocument();
+    expect(screen.getByText("Proposed changes")).toBeInTheDocument();
+  });
+
+  it("disables Apply when the revised goal textarea is cleared", async () => {
+    const user = userEvent.setup();
+
+    server.use(
+      http.post("/api/v1/automations/goal-improvements", () =>
+        HttpResponse.json({
+          data: {
+            id: "imp-1",
+            org_id: "org-1",
+            mode: "fast",
+            status: "completed",
+            input_goal: "Run tests",
+            base_goal_hash: "sha256:abc",
+            proposed_goal: "Run tests with evidence.",
+            proposal: { changes: ["Added evidence."] },
+            confidence: "medium",
+            warnings: [],
+            created_at: "2026-06-18T00:00:00Z",
+            updated_at: "2026-06-18T00:00:00Z",
+          },
+        }),
+      ),
+    );
+
+    renderWithProviders(
+      <AutomationGoalImprovementControl
+        name="Tests"
+        goal="Run tests"
+        repositoryId="repo-1"
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: /improve goal/i }));
+    const revisedGoal = await screen.findByLabelText("Revised goal");
+    expect(screen.getByRole("button", { name: "Apply" })).not.toBeDisabled();
+
+    await user.clear(revisedGoal);
+
+    expect(screen.getByRole("button", { name: "Apply" })).toBeDisabled();
+
+    await user.type(revisedGoal, "Run only changed tests.");
+    expect(screen.getByRole("button", { name: "Apply" })).not.toBeDisabled();
   });
 
   it("shows stale-goal guidance when saved apply is rejected", async () => {

--- a/frontend/src/components/automation-goal-improvement.tsx
+++ b/frontend/src/components/automation-goal-improvement.tsx
@@ -28,6 +28,7 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
+import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
 
 interface AutomationGoalImprovementProps {
@@ -59,6 +60,9 @@ export function AutomationGoalImprovementControl({
   const [historyOpen, setHistoryOpen] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [lastMode, setLastMode] = useState<"fast" | "deep">("fast");
+  const [reviewNotesOpen, setReviewNotesOpen] = useState(false);
+  const [editedGoalIsEmpty, setEditedGoalIsEmpty] = useState(false);
+  const editedGoalRef = useRef<HTMLTextAreaElement>(null);
   const lastImproveAtRef = useRef(0);
   const shouldPoll =
     proposal?.id &&
@@ -105,17 +109,23 @@ export function AutomationGoalImprovementControl({
         config,
       });
     },
-    onSuccess: (response) => setProposal(response.data),
+    onSuccess: (response) => {
+      setProposal(response.data);
+      setReviewNotesOpen(false);
+      setEditedGoalIsEmpty(false);
+    },
     onError: (err) => setError(errorMessage(err)),
   });
 
   const applyMutation = useMutation({
     mutationFn: () => {
-      if (!displayedProposal?.proposed_goal) {
+      const proposedGoal =
+        editedGoalRef.current?.value ?? displayedProposal?.proposed_goal ?? "";
+      if (!displayedProposal?.id || !proposedGoal.trim()) {
         throw new Error("Improvement has no proposed goal.");
       }
       if (!automationId) {
-        onDraftApply?.(displayedProposal.proposed_goal);
+        onDraftApply?.(proposedGoal);
         return Promise.resolve(null);
       }
       return api.automations.applyGoalImprovement(
@@ -123,7 +133,7 @@ export function AutomationGoalImprovementControl({
         displayedProposal.id,
         {
           expected_base_goal_hash: displayedProposal.base_goal_hash,
-          proposed_goal: displayedProposal.proposed_goal,
+          proposed_goal: proposedGoal,
         },
       );
     },
@@ -191,6 +201,7 @@ export function AutomationGoalImprovementControl({
     refetchInterval: isRunningProposal ? 3000 : false,
   });
   const transcriptPreview = latestTranscriptPreview(transcriptQuery.data?.data);
+
   const requestImprove = (mode: "fast" | "deep") => {
     const now = Date.now();
     if (now - lastImproveAtRef.current < 750) {
@@ -261,7 +272,7 @@ export function AutomationGoalImprovementControl({
         open={proposal !== null}
         onOpenChange={(open) => !open && setProposal(null)}
       >
-        <DialogContent className="sm:max-w-3xl">
+        <DialogContent className="max-h-[90vh] overflow-y-auto sm:max-w-2xl">
           <DialogHeader>
             <DialogTitle>
               {isRunningProposal ? "Improving goal" : "Review improved goal"}
@@ -313,55 +324,84 @@ export function AutomationGoalImprovementControl({
             </div>
           )}
           {displayedProposal && displayedProposal.status === "completed" && (
-            <div className="space-y-4">
-              <div className="grid gap-3 md:grid-cols-2">
-                <div className="space-y-1.5">
-                  <p className="text-xs font-medium text-muted-foreground">
-                    Current
-                  </p>
-                  <Textarea
-                    value={goal}
-                    readOnly
-                    rows={10}
-                    className="resize-y text-sm"
-                  />
-                </div>
-                <div className="space-y-1.5">
-                  <p className="text-xs font-medium text-muted-foreground">
-                    Proposed
-                  </p>
-                  <Textarea
-                    value={displayedProposal.proposed_goal ?? ""}
-                    readOnly
-                    rows={10}
-                    className="resize-y text-sm"
-                  />
-                </div>
-              </div>
-              <GoalDiff
-                current={goal}
-                proposed={displayedProposal.proposed_goal ?? ""}
-              />
-              <div className="grid gap-3 md:grid-cols-2">
-                <ReviewList
-                  title="Changes"
-                  items={displayedProposal.proposal?.changes}
+            <div className="space-y-3">
+              <div className="space-y-1.5">
+                <Label
+                  htmlFor="revised-goal"
+                  className="text-xs font-medium text-muted-foreground"
+                >
+                  Revised goal
+                </Label>
+                <Textarea
+                  key={displayedProposal.id}
+                  id="revised-goal"
+                  ref={editedGoalRef}
+                  defaultValue={displayedProposal.proposed_goal ?? ""}
+                  rows={12}
+                  className="min-h-56 resize-y text-sm leading-6"
+                  onChange={(e) =>
+                    setEditedGoalIsEmpty(e.target.value.trim() === "")
+                  }
                 />
-                <ReviewList
-                  title="Warnings"
-                  items={displayedProposal.warnings}
-                  empty="No warnings."
-                />
-              </div>
-              {displayedProposal.proposal?.rationale && (
-                <p className="text-sm text-muted-foreground">
-                  {displayedProposal.proposal.rationale}
-                </p>
-              )}
-              {displayedProposal.confidence && (
                 <p className="text-xs text-muted-foreground">
-                  Confidence: {displayedProposal.confidence}
+                  Edit directly, then apply when it reads correctly.
                 </p>
+              </div>
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                className="px-0 text-muted-foreground"
+                onClick={() => setReviewNotesOpen((open) => !open)}
+              >
+                <ChevronDown
+                  className={
+                    reviewNotesOpen
+                      ? "h-4 w-4 rotate-180 transition-transform"
+                      : "h-4 w-4 transition-transform"
+                  }
+                />
+                {reviewNotesOpen ? "Hide review notes" : "Show review notes"}
+              </Button>
+              {reviewNotesOpen && (
+                <div className="space-y-4 rounded-md border border-border bg-muted/20 p-3">
+                  <div className="space-y-1.5">
+                    <p className="text-xs font-medium text-muted-foreground">
+                      Current goal
+                    </p>
+                    <Textarea
+                      value={goal}
+                      readOnly
+                      rows={5}
+                      className="resize-y bg-background text-sm"
+                    />
+                  </div>
+                  <GoalDiff
+                    current={goal}
+                    proposed={displayedProposal.proposed_goal ?? ""}
+                  />
+                  <div className="grid gap-3 md:grid-cols-2">
+                    <ReviewList
+                      title="Changes"
+                      items={displayedProposal.proposal?.changes}
+                    />
+                    <ReviewList
+                      title="Warnings"
+                      items={displayedProposal.warnings}
+                      empty="No warnings."
+                    />
+                  </div>
+                  {displayedProposal.proposal?.rationale && (
+                    <p className="text-sm text-muted-foreground">
+                      {displayedProposal.proposal.rationale}
+                    </p>
+                  )}
+                  {displayedProposal.confidence && (
+                    <p className="text-xs text-muted-foreground">
+                      Confidence: {displayedProposal.confidence}
+                    </p>
+                  )}
+                </div>
               )}
             </div>
           )}
@@ -411,7 +451,8 @@ export function AutomationGoalImprovementControl({
               disabled={
                 applyMutation.isPending ||
                 displayedProposal?.status !== "completed" ||
-                !displayedProposal?.proposed_goal
+                !displayedProposal?.proposed_goal ||
+                editedGoalIsEmpty
               }
               onClick={() => applyMutation.mutate()}
             >
@@ -450,6 +491,8 @@ export function AutomationGoalImprovementControl({
                 onClick={() => {
                   setProposal(item);
                   setHistoryOpen(false);
+                  setReviewNotesOpen(false);
+                  setEditedGoalIsEmpty(false);
                 }}
               >
                 <div className="min-w-0 space-y-1">
@@ -520,7 +563,9 @@ function GoalDiff({
 
   return (
     <div className="space-y-1.5">
-      <p className="text-xs font-medium text-muted-foreground">Diff</p>
+      <p className="text-xs font-medium text-muted-foreground">
+        Proposed changes
+      </p>
       <div className="max-h-48 overflow-auto rounded-md border border-border bg-muted/20 p-3 font-mono text-xs">
         {removed.slice(0, 8).map((line, index) => (
           <p key={`removed-${index}-${line}`} className="text-destructive">


### PR DESCRIPTION
## Summary

## Code Review: Simplify Review Improved Goal Modal (with fixes applied)

### Overview

The full diff covers the original PR changes plus follow-up fixes: replacing the side-by-side read-only textareas with a single editable revised-goal textarea, collapsing review details behind a toggle, removing an unused import, and three correctness fixes from the prior review round.

---

### Assessment

**`settings/autopilot/page.tsx`** — Unused `RepoSettings` import removed. Clean.

**`automation-goal-improvement.tsx`**
- `editedGoalIsEmpty` state is correctly initialized to `false`, updated via `onChange`, and reset in both `improveMutation.onSuccess` and the history-item click handler — all paths that produce a new `displayedProposal` are covered.
- The `??` fallback chain in `applyMutation.mutationFn` (`editedGoalRef.current?.value ?? displayedProposal?.proposed_goal ?? ""`) is correct: a ref read at click time is safe since the Apply button is only enabled when the textarea is mounted.
- `key={displayedProposal.id}` on the `Textarea` correctly remounts and resets the DOM value when switching proposals; the explicit `setEditedGoalIsEmpty(false)` alongside each reset ensures parent state stays in sync.
- Apply `disabled` check: `!displayedProposal?.proposed_goal || editedGoalIsEmpty` — correctly guards both the server-null case and the user-cleared case.
- `Label`/`htmlFor`/`id` linkage is correct and matches what tests query via `getByLabelText`.
- "Proposed changes" label on `GoalDiff` accurately describes the content (AI proposal vs. current goal) without implying it reflects user edits.

**`automation-goal-improvement.test.tsx`**
- "applies a draft fast improvement" — correctly tests that user edits are sent to `onDraftApply` instead of the original AI value.
- "keeps review details collapsed" — asserts correct initial hidden state and correct expansion.
- "disables Apply when revised goal textarea is cleared" — covers the full cycle: enabled → clear → disabled → retype → enabled. Directly exercises the new `editedGoalIsEmpty` path.
- Existing tests for polling, cancel, history selection, and stale-goal rejection are unaffected.

No issues found.

REVIEW_CLEAN

## Test plan

Validated by automated agent run.


[143.dev](https://143.dev) | [session 1899c486](https://143.dev/sessions/1899c486-b07b-4251-85cb-a6a529f9bc87)

<!-- 143 readiness -->
**143 readiness:** not available for this revision.

Preview: https://143.dev/previews/github/assembledhq/143/pull/1560?launch=1