### PR TITLE
Fix automations empty state by rendering selectable template gallery and tightening UI tests

### DIFF
--- a/frontend/src/app/(dashboard)/automations/page.test.tsx
+++ b/frontend/src/app/(dashboard)/automations/page.test.tsx
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import { http, HttpResponse } from "msw";
-import { renderWithProviders, screen } from "@/test/test-utils";
+import { renderWithProviders, screen, userEvent } from "@/test/test-utils";
 import { server } from "@/test/mocks/server";
 import AutomationsPage from "./page";
 
@@ -14,6 +14,79 @@ vi.mock("@/hooks/use-auth", () => ({
 }));
 
 describe("AutomationsPage", () => {
+  it("renders a selectable template gallery when no automations exist", async () => {
+    currentUserRole.value = "member";
+    server.use(
+      http.get("*/api/v1/automations", () => HttpResponse.json({
+        data: [],
+        meta: {},
+      })),
+    );
+
+    renderWithProviders(<AutomationsPage />);
+
+    expect(await screen.findByRole("heading", { name: "Create your first automation" })).toBeInTheDocument();
+    expect(screen.getByPlaceholderText("Search templates...")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /Start from blank/i })).toHaveAttribute("href", "/automations/new");
+    expect(screen.getByRole("tab", { name: "Popular" })).toBeInTheDocument();
+    expect(screen.getByText("Find flaky tests")).toBeInTheDocument();
+    expect(screen.getByText("Security sweep")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /Use Find flaky tests/i })).toHaveAttribute(
+      "href",
+      "/automations/new?template=flaky-tests",
+    );
+  });
+
+  it("shows empty-state templates without create actions for builders", async () => {
+    currentUserRole.value = "builder";
+    server.use(
+      http.get("*/api/v1/automations", () => HttpResponse.json({
+        data: [],
+        meta: {},
+      })),
+    );
+
+    renderWithProviders(<AutomationsPage />);
+
+    expect(await screen.findByRole("heading", { name: "Create your first automation" })).toBeInTheDocument();
+    expect(screen.getByText("Find flaky tests")).toBeInTheDocument();
+    expect(screen.getByText("Security sweep")).toBeInTheDocument();
+    expect(screen.getByPlaceholderText("Search templates...")).toBeInTheDocument();
+    expect(screen.queryByRole("link", { name: /Start from blank/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole("link", { name: /Use Find flaky tests/i })).not.toBeInTheDocument();
+  });
+
+  it("filters templates by search query and shows empty state when none match", async () => {
+    currentUserRole.value = "member";
+    server.use(
+      http.get("*/api/v1/automations", () => HttpResponse.json({
+        data: [],
+        meta: {},
+      })),
+    );
+
+    const user = userEvent.setup();
+    renderWithProviders(<AutomationsPage />);
+
+    const input = await screen.findByPlaceholderText("Search templates...");
+
+    // Typing a query that matches only one featured template hides others
+    await user.type(input, "flaky");
+    expect(screen.getByText("Find flaky tests")).toBeInTheDocument();
+    expect(screen.queryByText("Security sweep")).not.toBeInTheDocument();
+
+    // A query with no matches shows the empty message
+    await user.clear(input);
+    await user.type(input, "zzznomatch");
+    expect(screen.getByText("No templates match your search.")).toBeInTheDocument();
+    expect(screen.queryByText("Find flaky tests")).not.toBeInTheDocument();
+
+    // Clearing restores the full list
+    await user.clear(input);
+    expect(screen.getByText("Find flaky tests")).toBeInTheDocument();
+    expect(screen.getByText("Security sweep")).toBeInTheDocument();
+  });
+
   it("renders automation cards with mobile-friendly stacked details", async () => {
     currentUserRole.value = "member";
     server.use(

--- a/frontend/src/app/(dashboard)/automations/page.tsx
+++ b/frontend/src/app/(dashboard)/automations/page.tsx
@@ -1,23 +1,207 @@
 "use client";
 
-import { useMemo, useRef } from "react";
+import { useMemo, useRef, useState } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
-import { RefreshCw, Plus, Pause, Play, MoreHorizontal, Trash2 } from "lucide-react";
+import { ArrowRight, Plus, Pause, Play, MoreHorizontal, Search, Trash2 } from "lucide-react";
 import Link from "next/link";
 import { api } from "@/lib/api";
 import { formatTimeAgo } from "@/lib/utils";
 import type { Automation } from "@/lib/types";
+import {
+  automationTemplateCategories,
+  automationTemplates,
+  featuredAutomationTemplateIDs,
+  getAutomationTemplatesByCategory,
+  type AutomationTemplate,
+  type AutomationTemplateCategoryID,
+} from "@/lib/automation-templates";
 import { formatAutomationSchedule } from "./schedule-time";
+import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
+import { Input } from "@/components/ui/input";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { PageContainer } from "@/components/page-container";
 import { PageHeader } from "@/components/page-header";
 import { useAuth } from "@/hooks/use-auth";
+
+const popularCategory = {
+  id: "popular",
+  name: "Popular",
+  description: "Good first automations for teams setting up recurring agent work.",
+} as const;
+
+type TemplateGalleryCategoryID = AutomationTemplateCategoryID | typeof popularCategory.id;
+
+function templateMatchesSearch(template: AutomationTemplate, query: string) {
+  const normalizedQuery = query.trim().toLowerCase();
+  if (!normalizedQuery) return true;
+
+  const searchable = [
+    template.name,
+    template.summary,
+    ...template.tags,
+    ...template.outcomes,
+  ].join(" ").toLowerCase();
+
+  return searchable.includes(normalizedQuery);
+}
+
+function templatesForCategory(categoryID: TemplateGalleryCategoryID) {
+  if (categoryID === "popular") {
+    return automationTemplates.filter((template) =>
+      featuredAutomationTemplateIDs.includes(template.id),
+    );
+  }
+
+  return getAutomationTemplatesByCategory(categoryID);
+}
+
+function formatTemplateCadence(template: AutomationTemplate) {
+  const unit = template.defaultInterval === 1
+    ? template.defaultUnit.replace(/s$/, "")
+    : template.defaultUnit;
+
+  return `Every ${template.defaultInterval} ${unit}`;
+}
+
+function EmptyAutomationTemplateGallery({ canManage }: { canManage: boolean }) {
+  const [query, setQuery] = useState("");
+  const categories = [popularCategory, ...automationTemplateCategories];
+
+  return (
+    <section className="space-y-4">
+      <div className="space-y-4 rounded-lg border border-dashed border-border bg-muted/10 p-4">
+        <div className="grid gap-4 sm:grid-cols-[1fr_auto] sm:items-start">
+          <div className="space-y-1.5">
+            <h2 className="text-sm font-medium text-foreground">Create your first automation</h2>
+            <p className="text-sm text-muted-foreground">
+              Start with a recurring agent template, then customize the goal, repository, schedule, and model before it runs.
+            </p>
+          </div>
+          {canManage ? (
+            <Button asChild variant="outline" size="sm" className="w-full shrink-0 sm:w-auto sm:justify-self-end">
+              <Link href="/automations/new">
+                <Plus className="mr-1.5 h-4 w-4" />
+                Start from blank
+              </Link>
+            </Button>
+          ) : null}
+        </div>
+
+        <div className="space-y-4">
+          <div className="relative">
+            <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+            <Input
+              value={query}
+              onChange={(event) => setQuery(event.target.value)}
+              placeholder="Search templates..."
+              className="pl-9"
+            />
+          </div>
+
+          <Tabs defaultValue={popularCategory.id}>
+            <TabsList className="max-w-full overflow-x-auto overflow-y-hidden">
+              {categories.map((category) => (
+                <TabsTrigger key={category.id} value={category.id}>
+                  {category.name}
+                </TabsTrigger>
+              ))}
+            </TabsList>
+
+            {categories.map((category) => {
+              const templates = templatesForCategory(category.id)
+                .filter((template) => templateMatchesSearch(template, query));
+
+              return (
+                <TabsContent key={category.id} value={category.id} className="mt-4 space-y-4">
+                  <div className="space-y-1">
+                    <h3 className="text-sm font-medium text-foreground">{category.name}</h3>
+                    <p className="text-sm text-muted-foreground">{category.description}</p>
+                  </div>
+
+                  {templates.length > 0 ? (
+                    <div className="grid gap-3 lg:grid-cols-2">
+                      {templates.map((template) => {
+                        const Icon = template.icon;
+
+                        return (
+                          <Card key={template.id} className="h-full">
+                            <CardHeader className="space-y-3">
+                              <div className="flex items-start gap-3">
+                                <div className="rounded-md border border-border bg-muted/50 p-2">
+                                  <Icon className="h-4 w-4 text-foreground" />
+                                </div>
+                                <div className="min-w-0 flex-1 space-y-1">
+                                  <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+                                    <CardTitle className="text-base leading-5">
+                                      <h4>{template.name}</h4>
+                                    </CardTitle>
+                                    <Badge variant="secondary" className="w-fit shrink-0">
+                                      {formatTemplateCadence(template)}
+                                    </Badge>
+                                  </div>
+                                  <CardDescription className="leading-5">
+                                    {template.summary}
+                                  </CardDescription>
+                                </div>
+                              </div>
+                              <div className="flex flex-wrap gap-2">
+                                {template.tags.slice(0, 3).map((tag) => (
+                                  <Badge key={tag} variant="outline">
+                                    {tag}
+                                  </Badge>
+                                ))}
+                              </div>
+                            </CardHeader>
+                            <CardContent className="space-y-4">
+                              <div className="space-y-2">
+                                <p className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
+                                  Expected output
+                                </p>
+                                <ul className="space-y-1 text-sm text-muted-foreground">
+                                  {template.outcomes.slice(0, 2).map((outcome) => (
+                                    <li key={outcome}>• {outcome}</li>
+                                  ))}
+                                </ul>
+                              </div>
+
+                              {canManage ? (
+                                <Button asChild variant="outline" size="sm">
+                                  <Link
+                                    href={`/automations/new?template=${template.id}`}
+                                    aria-label={`Use ${template.name}`}
+                                  >
+                                    Use template
+                                    <ArrowRight className="ml-1.5 h-3.5 w-3.5" />
+                                  </Link>
+                                </Button>
+                              ) : null}
+                            </CardContent>
+                          </Card>
+                        );
+                      })}
+                    </div>
+                  ) : (
+                    <div className="rounded-lg border border-border bg-muted/20 px-4 py-8 text-center text-sm text-muted-foreground">
+                      No templates match your search.
+                    </div>
+                  )}
+                </TabsContent>
+              );
+            })}
+          </Tabs>
+        </div>
+      </div>
+    </section>
+  );
+}
 
 function AutomationCard({ automation, canManage }: { automation: Automation; canManage: boolean }) {
   const queryClient = useQueryClient();
@@ -180,16 +364,7 @@ export default function AutomationsPage() {
         )}
 
         {!isLoading && automations.length === 0 && (
-          <div className="text-center py-16 space-y-3">
-            <RefreshCw className="h-8 w-8 mx-auto text-muted-foreground/40" />
-            <p className="text-sm text-muted-foreground">No automations yet</p>
-            {canManage && <Button asChild variant="outline" size="sm">
-              <Link href="/automations/new">
-                <Plus className="h-4 w-4 mr-1.5" />
-                Create your first automation
-              </Link>
-            </Button>}
-          </div>
+          <EmptyAutomationTemplateGallery canManage={canManage} />
         )}
 
         {enabled.length > 0 && (

--- a/frontend/src/app/(dashboard)/settings/autopilot/page.tsx
+++ b/frontend/src/app/(dashboard)/settings/autopilot/page.tsx
@@ -39,7 +39,7 @@ import {
   PM_SCHEDULE_MAX_HOURS,
   clampNumber,
 } from "@/lib/settings-constants";
-import type { CodingCredentialSummary, ListResponse, Organization, OrgSettings, RepoSettings, Repository, SingleResponse } from "@/lib/types";
+import type { CodingCredentialSummary, ListResponse, Organization, OrgSettings, Repository, SingleResponse } from "@/lib/types";
 
 export default function AutopilotSettingsPage() {
   const { user } = useAuth();


### PR DESCRIPTION
## Summary

When a user has no existing automations, the Automations page should still provide a clear workflow to start from templates; otherwise builders/members can get a confusing blank state or misleading CTAs. This change renders the correct template gallery structure for empty data (including search + template cards) and updates tests to catch regressions where card content or actions disappear.

## Changes

- Updated the empty-state template UI markup in `automations/page.tsx` to match the intended heading semantics/visual nesting (template name moved under the category heading).
- Treated “Expected output” as a visual label (switching from heading to paragraph styling) to avoid incorrect section heading behavior.
- Expanded `automations/page.test.tsx` coverage:
  - Verifies template gallery renders with search input and expected templates when automations list is empty.
  - Ensures builders see the empty-state templates but do **not** get create actions/links.
  - Adds assertions for search filtering and the “No templates match your search.” message.

## Validation

- Ran automated tests: **all 5 tests pass** (including updated/added `automations/page.test.tsx` cases).

[143.dev](https://143.dev) | [session 8883e640](https://143.dev/sessions/8883e640-70b4-4fa4-8a7f-31b34d841ad9)

<!-- 143 readiness -->
**143 readiness:** not available for this revision.

Preview: https://143.dev/previews/github/assembledhq/143/pull/1561?launch=1