### PR TITLE
Improve “Create” disabled tooltip stability and fix Automation page schedule/label UI

### DIFF
--- a/frontend/src/app/(dashboard)/automations/new/page.test.tsx
+++ b/frontend/src/app/(dashboard)/automations/new/page.test.tsx
@@ -37,6 +37,7 @@ describe("NewAutomationPage", () => {
     pushMock.mockReset();
     replaceMock.mockReset();
     currentUserRole.value = "member";
+    searchParams.set("template", "security-sweep");
   });
 
   it("allows the timezone selector to wrap cleanly on mobile layouts", async () => {
@@ -73,7 +74,7 @@ describe("NewAutomationPage", () => {
     const timezoneButton = await screen.findByTitle(expectedTimezone);
     const scheduleRow = timezoneButton.parentElement;
     const runEveryText = screen.getByText("Run every");
-    const atText = screen.getByText("At");
+    const atText = screen.getByText("at");
 
     expect(scheduleRow).toHaveClass("flex-wrap");
     expect(timezoneButton).toHaveClass("w-full", "sm:w-auto");
@@ -90,6 +91,49 @@ describe("NewAutomationPage", () => {
       "text-muted-foreground",
     );
     expect(screen.queryByText(/Run time is in/i)).not.toBeInTheDocument();
+  });
+
+  it("shows weekly schedule day context and keeps schedule controls consistently sized", async () => {
+    const user = userEvent.setup();
+
+    server.use(
+      http.get("/api/v1/repositories", () =>
+        HttpResponse.json({
+          data: [
+            {
+              id: "repo-1",
+              org_id: "org-1",
+              integration_id: "int-1",
+              github_id: 1,
+              full_name: "acme/repo",
+              default_branch: "main",
+              private: false,
+              clone_url: "https://github.com/acme/repo.git",
+              installation_id: 10,
+              status: "active",
+              settings: {},
+              created_at: "2026-03-05T12:00:00Z",
+              updated_at: "2026-03-05T12:00:00Z",
+            },
+          ],
+          meta: {},
+        }),
+      ),
+    );
+
+    renderWithProviders(<NewAutomationPage />);
+
+    await user.click(await screen.findByRole("combobox", { name: "Interval unit" }));
+    await user.click(screen.getByRole("option", { name: "weeks" }));
+
+    expect(screen.getByText("at")).toBeInTheDocument();
+    expect(screen.getByText(/first run anchors on/i)).toBeInTheDocument();
+    expect(screen.getByText(/then repeats every \d+ weeks?/i)).toBeInTheDocument();
+    expect(screen.queryByText("At")).not.toBeInTheDocument();
+    expect(screen.getByLabelText("Interval value")).toHaveClass("h-8");
+    expect(screen.getByRole("combobox", { name: "Interval unit" })).toHaveClass("h-8");
+    expect(screen.getByRole("combobox", { name: "Run at hour" })).toHaveClass("h-8");
+    expect(screen.getByRole("combobox", { name: "Run at minute" })).toHaveClass("h-8");
   });
 
   it("keeps timezone in the primary schedule controls and moves execution defaults into advanced settings", async () => {
@@ -226,6 +270,55 @@ describe("NewAutomationPage", () => {
     ).not.toBeChecked();
     expect(screen.queryByText("Also trigger on")).not.toBeInTheDocument();
     expect(screen.queryByText("Pull requests")).not.toBeInTheDocument();
+    expect(screen.getByText("Triggers").parentElement).toHaveClass("flex-wrap");
+    expect(screen.getByText("on a schedule")).toHaveClass("block");
+  });
+
+  it("explains why the create button is disabled even when schedule triggering is selected", async () => {
+    const user = userEvent.setup();
+    searchParams.delete("template");
+
+    server.use(
+      http.get("/api/v1/repositories", () =>
+        HttpResponse.json({
+          data: [
+            {
+              id: "repo-1",
+              org_id: "org-1",
+              integration_id: "int-1",
+              github_id: 1,
+              full_name: "acme/repo",
+              default_branch: "main",
+              private: false,
+              clone_url: "https://github.com/acme/repo.git",
+              installation_id: 10,
+              status: "active",
+              settings: {},
+              created_at: "2026-03-05T12:00:00Z",
+              updated_at: "2026-03-05T12:00:00Z",
+            },
+          ],
+          meta: {},
+        }),
+      ),
+    );
+
+    renderWithProviders(<NewAutomationPage />);
+
+    const createButton = await screen.findByRole("button", {
+      name: "Create automation",
+    });
+    expect(screen.getByLabelText("On a schedule")).toBeChecked();
+    expect(createButton).toBeDisabled();
+
+    const tooltipWrapper = createButton.parentElement;
+    expect(tooltipWrapper).not.toBeNull();
+    await user.hover(tooltipWrapper!);
+
+    const tooltip = await screen.findByRole("tooltip");
+    expect(tooltip).toHaveTextContent(
+      "Add an automation name and goal to create this automation.",
+    );
   });
 
   it("submits an event-only PR feedback automation without schedule fields", async () => {

--- a/frontend/src/app/(dashboard)/automations/new/page.tsx
+++ b/frontend/src/app/(dashboard)/automations/new/page.tsx
@@ -63,6 +63,7 @@ import {
 } from "@/components/automation-capabilities-editor";
 import { AutomationModelSelect } from "@/components/automation-model-select";
 import { NoReposWarning } from "@/components/no-repos-warning";
+import { DisabledTooltip } from "@/components/ui/disabled-tooltip";
 import { PageContainer } from "@/components/page-container";
 import { PageHeader } from "@/components/page-header";
 import {
@@ -121,6 +122,46 @@ const pagerDutyEventTypeOptions: Array<{
     ariaLabel: "PagerDuty resolved events",
   },
 ];
+
+function formatWeeklyRunHint(
+  intervalValue: number,
+  intervalRunHour: string,
+  intervalRunMinute: string,
+  timezone: string,
+  now = new Date(),
+): string {
+  const weeks = Math.max(1, intervalValue);
+  const localParts = new Intl.DateTimeFormat(undefined, {
+    timeZone: timezone || "UTC",
+    weekday: "long",
+    hour: "2-digit",
+    minute: "2-digit",
+    hourCycle: "h23",
+  }).formatToParts(now);
+  const weekday = localParts.find((part) => part.type === "weekday")?.value;
+  const localHour = Number(
+    localParts.find((part) => part.type === "hour")?.value ?? "0",
+  );
+  const localMinute = Number(
+    localParts.find((part) => part.type === "minute")?.value ?? "0",
+  );
+  const selectedHour = Number(intervalRunHour);
+  const selectedMinute = Number(intervalRunMinute);
+  const selectedBeforeNow =
+    selectedHour < localHour ||
+    (selectedHour === localHour && selectedMinute < localMinute);
+  const nextCalendarDay = new Date(now);
+  nextCalendarDay.setDate(nextCalendarDay.getDate() + 1);
+  const anchor = selectedBeforeNow
+    ? new Intl.DateTimeFormat(undefined, {
+        timeZone: timezone || "UTC",
+        weekday: "long",
+      }).format(nextCalendarDay)
+    : weekday;
+  const unitLabel = weeks === 1 ? "week" : "weeks";
+
+  return `First run anchors on ${anchor ?? "the selected weekday"}, then repeats every ${weeks} ${unitLabel}.`;
+}
 
 export default function NewAutomationPage() {
   const router = useRouter();
@@ -394,6 +435,17 @@ export default function NewAutomationPage() {
     repoId.length > 0 &&
     pagerDutyTriggerValid &&
     (scheduleEnabled || hasEventTriggers);
+  const submitDisabledReason = createMutation.isPending || redirecting
+    ? undefined
+    : getCreateDisabledReason({
+        name: name.trim(),
+        goal: goal.trim(),
+        goalTooLong: goalLength.isTooLong,
+        hasRepository: repoId.length > 0,
+        pagerDutyTriggerValid,
+        scheduleEnabled,
+        hasEventTriggers,
+      });
 
   return (
     <PageContainer size="wide">
@@ -476,7 +528,7 @@ export default function NewAutomationPage() {
                         }
                         aria-label="On a schedule"
                       />
-                      <span>On a schedule</span>
+                      <span className="block">on a schedule</span>
                     </Label>
                   </div>
                   {scheduleEnabled ? (
@@ -497,7 +549,7 @@ export default function NewAutomationPage() {
                             Number.isNaN(parsed) ? 1 : Math.max(1, parsed),
                           );
                         }}
-                        className="h-7 w-16 px-2 text-base sm:text-xs"
+                        className="h-8 w-20 px-2 text-base sm:text-xs"
                       />
                       <Select
                         value={intervalUnit}
@@ -508,7 +560,7 @@ export default function NewAutomationPage() {
                         }}
                       >
                         <SelectTrigger
-                          className="h-7 w-24 text-base sm:text-xs"
+                          className="h-8 w-24 text-base sm:text-xs"
                           aria-label="Interval unit"
                         >
                           <SelectValue />
@@ -520,14 +572,14 @@ export default function NewAutomationPage() {
                         </SelectContent>
                       </Select>
                       <span className="text-sm font-medium leading-none text-muted-foreground">
-                        At
+                        at
                       </span>
                       <Select
                         value={intervalRunHour}
                         onValueChange={setIntervalRunHour}
                       >
                         <SelectTrigger
-                          className="h-7 w-18 text-base sm:text-xs"
+                          className="h-8 w-20 text-base sm:text-xs"
                           aria-label="Run at hour"
                         >
                           <SelectValue />
@@ -546,7 +598,7 @@ export default function NewAutomationPage() {
                         onValueChange={setIntervalRunMinute}
                       >
                         <SelectTrigger
-                          className="h-7 w-18 text-base sm:text-xs"
+                          className="h-8 w-20 text-base sm:text-xs"
                           aria-label="Run at minute"
                         >
                           <SelectValue />
@@ -565,6 +617,16 @@ export default function NewAutomationPage() {
                         detected={detectedTimezone}
                         className="w-full sm:w-auto"
                       />
+                      {intervalUnit === "weeks" ? (
+                        <p className="basis-full text-xs text-muted-foreground">
+                          {formatWeeklyRunHint(
+                            intervalValue,
+                            intervalRunHour,
+                            intervalRunMinute,
+                            timezone,
+                          )}
+                        </p>
+                      ) : null}
                     </div>
                   ) : null}
                   <div className="space-y-1">
@@ -1060,21 +1122,26 @@ export default function NewAutomationPage() {
                     Failed to create automation. Please try again.
                   </p>
                 )}
-                <Button
-                  onClick={() => createMutation.mutate()}
-                  disabled={
-                    !canSubmit || createMutation.isPending || redirecting
-                  }
+                <DisabledTooltip
+                  disabled={!canSubmit && !!submitDisabledReason}
+                  content={submitDisabledReason}
                 >
-                  {createMutation.isPending || redirecting ? (
-                    <>
-                      <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                      Creating...
-                    </>
-                  ) : (
-                    "Create automation"
-                  )}
-                </Button>
+                  <Button
+                    onClick={() => createMutation.mutate()}
+                    disabled={
+                      !canSubmit || createMutation.isPending || redirecting
+                    }
+                  >
+                    {createMutation.isPending || redirecting ? (
+                      <>
+                        <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                        Creating...
+                      </>
+                    ) : (
+                      "Create automation"
+                    )}
+                  </Button>
+                </DisabledTooltip>
               </div>
             }
           />
@@ -1082,6 +1149,47 @@ export default function NewAutomationPage() {
       </div>
     </PageContainer>
   );
+}
+
+function getCreateDisabledReason({
+  name,
+  goal,
+  goalTooLong,
+  hasRepository,
+  pagerDutyTriggerValid,
+  scheduleEnabled,
+  hasEventTriggers,
+}: {
+  name: string;
+  goal: string;
+  goalTooLong: boolean;
+  hasRepository: boolean;
+  pagerDutyTriggerValid: boolean;
+  scheduleEnabled: boolean;
+  hasEventTriggers: boolean;
+}): string | undefined {
+  if (!name && !goal) {
+    return "Add an automation name and goal to create this automation.";
+  }
+  if (!name) {
+    return "Add an automation name before creating it.";
+  }
+  if (!goal) {
+    return "Describe what the automation should do before creating it.";
+  }
+  if (goalTooLong) {
+    return "Shorten the automation goal before creating it.";
+  }
+  if (!hasRepository) {
+    return "Select a repository before creating the automation.";
+  }
+  if (!scheduleEnabled && !hasEventTriggers) {
+    return "Select at least one trigger before creating the automation.";
+  }
+  if (!pagerDutyTriggerValid) {
+    return "Add at least one PagerDuty service ID before creating the automation.";
+  }
+  return undefined;
 }
 
 function TemplatePicker({

--- a/frontend/src/app/(dashboard)/settings/autopilot/page.tsx
+++ b/frontend/src/app/(dashboard)/settings/autopilot/page.tsx
@@ -39,7 +39,7 @@ import {
   PM_SCHEDULE_MAX_HOURS,
   clampNumber,
 } from "@/lib/settings-constants";
-import type { CodingCredentialSummary, ListResponse, Organization, OrgSettings, RepoSettings, Repository, SingleResponse } from "@/lib/types";
+import type { CodingCredentialSummary, ListResponse, Organization, OrgSettings, Repository, SingleResponse } from "@/lib/types";
 
 export default function AutopilotSettingsPage() {
   const { user } = useAuth();

--- a/frontend/src/components/ui/disabled-tooltip.tsx
+++ b/frontend/src/components/ui/disabled-tooltip.tsx
@@ -14,10 +14,12 @@ export function DisabledTooltip({ children, content, disabled = false }: Disable
   // Once the wrapper span has been rendered, keep it even if content later
   // becomes undefined. Removing the wrapper unmounts the child element, which
   // invalidates any external DOM reference held to it.
-  const everHadContent = React.useRef(false);
-  if (content) everHadContent.current = true;
+  const [everHadContent, setEverHadContent] = React.useState(() => !!content);
+  React.useEffect(() => {
+    if (content) setEverHadContent(true);
+  }, [content]);
 
-  if (!everHadContent.current) {
+  if (!everHadContent) {
     return children;
   }
 

--- a/frontend/src/components/ui/disabled-tooltip.tsx
+++ b/frontend/src/components/ui/disabled-tooltip.tsx
@@ -11,15 +11,24 @@ type DisabledTooltipProps = {
 };
 
 export function DisabledTooltip({ children, content, disabled = false }: DisabledTooltipProps) {
-  if (!disabled || !content) {
+  // Once the wrapper span has been rendered, keep it even if content later
+  // becomes undefined. Removing the wrapper unmounts the child element, which
+  // invalidates any external DOM reference held to it.
+  const everHadContent = React.useRef(false);
+  if (content) everHadContent.current = true;
+
+  if (!everHadContent.current) {
     return children;
   }
 
   return (
     <TooltipProvider delayDuration={150}>
-      <Tooltip>
+      <Tooltip open={disabled && !!content ? undefined : false}>
         <TooltipTrigger asChild>
-          <span className="inline-flex cursor-not-allowed" tabIndex={0}>
+          <span
+            className={disabled ? "inline-flex cursor-not-allowed" : "inline-flex"}
+            tabIndex={disabled ? 0 : undefined}
+          >
             {children}
           </span>
         </TooltipTrigger>


### PR DESCRIPTION
## Summary

The Automation “Create” button can show inconsistent/buggy disabled-tooltips because tooltip mounting/unmounting can invalidate DOM references as form state changes. This PR makes the disabled tooltip DOM-stable and improves the New Automation page workflow by fixing label casing, adding weekly schedule day context, and tightening disabled-reason messaging so users understand why they can’t submit.

## Changes

- **Stabilize disabled tooltips:** Update `DisabledTooltip` to keep its wrapper mounted once tooltip `content` has ever been present, preventing DOM reference invalidation; only force-close and apply `cursor-not-allowed/tabIndex` when disabled.
- **Improve New Automation page UX:** Add weekly run hint/context, resize schedule controls consistently on mobile, and normalize label text (e.g., “At” → “at”).
- **Clarify disabled “Create” reason:** Wrap the Create button in `DisabledTooltip` and centralize disabled-reason logic (`getCreateDisabledReason`) so messaging matches the actual `canSubmit`/submission state.
- **Housekeeping + tests:** Remove an unused import in Autopilot settings and add/adjust tests to cover weekly schedule context, flex-wrap/block behavior, and the disabled-create tooltip copy.

## Validation

- Updated and extended `frontend/src/app/(dashboard)/automations/new/page.test.tsx` covering:
  - weekly schedule day context + control sizing
  - trigger layout flex wrapping/block behavior
  - disabled Create button tooltip explanation
- CI: existing test suite should pass with the updated label assertion (`At` → `at`).

[143.dev](https://143.dev) | [session 29ef97a1](https://143.dev/sessions/29ef97a1-d79b-496c-ac8b-cda6f05f5b9d)

<!-- 143 readiness -->
**143 readiness:** not available for this revision.

Preview: https://143.dev/previews/github/assembledhq/143/pull/1562?launch=1