### PR TITLE
Fix automation draft restore when template is chosen via URL param

### DIFF
--- a/frontend/src/app/(dashboard)/automations/new/page.test.tsx
+++ b/frontend/src/app/(dashboard)/automations/new/page.test.tsx
@@ -278,7 +278,7 @@ describe("NewAutomationPage", () => {
 
   it("explains why the create button is disabled even when schedule triggering is selected", async () => {
     const user = userEvent.setup();
-    searchParams.delete("template");
+    searchParamsState.value = "";
 
     server.use(
       http.get("/api/v1/repositories", () =>

--- a/frontend/src/app/(dashboard)/automations/new/page.test.tsx
+++ b/frontend/src/app/(dashboard)/automations/new/page.test.tsx
@@ -12,9 +12,10 @@ import { server } from "@/test/mocks/server";
 import NewAutomationPage from "./page";
 import { AUTOMATION_GOAL_MAX_LENGTH } from "@/lib/automation-validation";
 
+const DRAFT_STORAGE_KEY = "143:new-automation-draft";
 const pushMock = vi.fn();
 const replaceMock = vi.fn();
-const searchParams = new URLSearchParams("template=security-sweep");
+const searchParamsState = vi.hoisted(() => ({ value: "template=security-sweep" }));
 const currentUserRole = vi.hoisted(() => ({ value: "member" }));
 
 vi.mock("next/navigation", () => ({
@@ -22,7 +23,7 @@ vi.mock("next/navigation", () => ({
     push: pushMock,
     replace: replaceMock,
   }),
-  useSearchParams: () => searchParams,
+  useSearchParams: () => new URLSearchParams(searchParamsState.value),
 }));
 
 vi.mock("@/hooks/use-auth", () => ({
@@ -36,7 +37,9 @@ describe("NewAutomationPage", () => {
   beforeEach(() => {
     pushMock.mockReset();
     replaceMock.mockReset();
+    searchParamsState.value = "template=security-sweep";
     currentUserRole.value = "member";
+    window.sessionStorage.clear();
   });
 
   it("allows the timezone selector to wrap cleanly on mobile layouts", async () => {
@@ -475,6 +478,266 @@ describe("NewAutomationPage", () => {
     expect(
       (screen.getByLabelText("Goal") as HTMLTextAreaElement).value,
     ).toContain("Review the repository for concrete, actionable security risk");
+  });
+
+  it("restores the latest in-progress automation draft when no template is selected", async () => {
+    searchParamsState.value = "";
+    window.sessionStorage.setItem(
+      DRAFT_STORAGE_KEY,
+      JSON.stringify({
+        __v: 1,
+        name: "Saved automation",
+        goal: "Continue the automation I was writing.",
+        iconValue: "✨",
+        selectedRepoId: "repo-2",
+        intervalValue: 3,
+        intervalUnit: "weeks",
+        intervalRunHour: "14",
+        intervalRunMinute: "45",
+        timezone: "UTC",
+        scheduleEnabled: true,
+        productTriggers: ["github.pr.feedback"],
+        identityScope: "personal",
+        prePRReviewLoops: 2,
+        priority: 25,
+      }),
+    );
+    server.use(
+      http.get("/api/v1/repositories", () =>
+        HttpResponse.json({
+          data: [
+            {
+              id: "repo-1",
+              org_id: "org-1",
+              integration_id: "int-1",
+              github_id: 1,
+              full_name: "acme/repo",
+              default_branch: "main",
+              private: false,
+              clone_url: "https://github.com/acme/repo.git",
+              installation_id: 10,
+              status: "active",
+              settings: {},
+              created_at: "2026-03-05T12:00:00Z",
+              updated_at: "2026-03-05T12:00:00Z",
+            },
+            {
+              id: "repo-2",
+              org_id: "org-1",
+              integration_id: "int-1",
+              github_id: 2,
+              full_name: "acme/worker",
+              default_branch: "develop",
+              private: false,
+              clone_url: "https://github.com/acme/worker.git",
+              installation_id: 10,
+              status: "active",
+              settings: {},
+              created_at: "2026-03-05T12:00:00Z",
+              updated_at: "2026-03-05T12:00:00Z",
+            },
+          ],
+          meta: {},
+        }),
+      ),
+    );
+
+    renderWithProviders(<NewAutomationPage />);
+
+    expect(await screen.findByDisplayValue("Saved automation")).toBeInTheDocument();
+    expect(screen.getByLabelText("Goal")).toHaveValue("Continue the automation I was writing.");
+    await waitFor(() => {
+      expect(screen.getByRole("combobox", { name: "Repository" })).toHaveTextContent("acme/worker");
+    });
+    expect(screen.getByLabelText("Interval value")).toHaveValue(3);
+    expect(screen.getByRole("combobox", { name: "Interval unit" })).toHaveTextContent("weeks");
+    expect(screen.getByLabelText("When there is new PR feedback")).toBeChecked();
+  });
+
+  it("saves draft changes before navigating to the template library", async () => {
+    searchParamsState.value = "";
+    const user = userEvent.setup();
+    server.use(
+      http.get("/api/v1/repositories", () =>
+        HttpResponse.json({
+          data: [
+            {
+              id: "repo-1",
+              org_id: "org-1",
+              integration_id: "int-1",
+              github_id: 1,
+              full_name: "acme/repo",
+              default_branch: "main",
+              private: false,
+              clone_url: "https://github.com/acme/repo.git",
+              installation_id: 10,
+              status: "active",
+              settings: {},
+              created_at: "2026-03-05T12:00:00Z",
+              updated_at: "2026-03-05T12:00:00Z",
+            },
+          ],
+          meta: {},
+        }),
+      ),
+    );
+
+    renderWithProviders(<NewAutomationPage />);
+
+    await user.type(await screen.findByLabelText("Name"), "Draft before browsing");
+    await user.type(screen.getByLabelText("Goal"), "Do not lose this automation.");
+    await user.click(screen.getByRole("link", { name: /Browse all templates/i }));
+
+    const stored = window.sessionStorage.getItem(DRAFT_STORAGE_KEY);
+    expect(stored).not.toBeNull();
+    expect(JSON.parse(stored!)).toMatchObject({
+      __v: 1,
+      name: "Draft before browsing",
+      goal: "Do not lose this automation.",
+    });
+  });
+
+  it("debounces automation draft writes while typing", async () => {
+    searchParamsState.value = "";
+    server.use(
+      http.get("/api/v1/repositories", () =>
+        HttpResponse.json({
+          data: [
+            {
+              id: "repo-1",
+              org_id: "org-1",
+              integration_id: "int-1",
+              github_id: 1,
+              full_name: "acme/repo",
+              default_branch: "main",
+              private: false,
+              clone_url: "https://github.com/acme/repo.git",
+              installation_id: 10,
+              status: "active",
+              settings: {},
+              created_at: "2026-03-05T12:00:00Z",
+              updated_at: "2026-03-05T12:00:00Z",
+            },
+          ],
+          meta: {},
+        }),
+      ),
+    );
+
+    renderWithProviders(<NewAutomationPage />);
+
+    const nameInput = await screen.findByLabelText("Name");
+    vi.useFakeTimers();
+    try {
+      fireEvent.change(nameInput, { target: { value: "D" } });
+      fireEvent.change(nameInput, { target: { value: "Draft before browsing" } });
+
+      expect(window.sessionStorage.getItem(DRAFT_STORAGE_KEY)).toBeNull();
+
+      vi.advanceTimersByTime(399);
+      expect(window.sessionStorage.getItem(DRAFT_STORAGE_KEY)).toBeNull();
+
+      await vi.advanceTimersByTimeAsync(1);
+      const stored = window.sessionStorage.getItem(DRAFT_STORAGE_KEY);
+      expect(stored).not.toBeNull();
+      expect(JSON.parse(stored!)).toMatchObject({
+        __v: 1,
+        name: "Draft before browsing",
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("clears the stored automation draft after successful creation", async () => {
+    searchParamsState.value = "";
+    const user = userEvent.setup();
+    server.use(
+      http.get("/api/v1/repositories", () =>
+        HttpResponse.json({
+          data: [
+            {
+              id: "repo-1",
+              org_id: "org-1",
+              integration_id: "int-1",
+              github_id: 1,
+              full_name: "acme/repo",
+              default_branch: "main",
+              private: false,
+              clone_url: "https://github.com/acme/repo.git",
+              installation_id: 10,
+              status: "active",
+              settings: {},
+              created_at: "2026-03-05T12:00:00Z",
+              updated_at: "2026-03-05T12:00:00Z",
+            },
+          ],
+          meta: {},
+        }),
+      ),
+      http.post("/api/v1/automations", async ({ request }) => {
+        const requestBody = (await request.json()) as Record<string, unknown>;
+        return HttpResponse.json(
+          {
+            data: {
+              id: "automation-1",
+              org_id: "org-1",
+              repository_id: "repo-1",
+              name: requestBody.name,
+              goal: requestBody.goal,
+              icon_type: "emoji",
+              icon_value: "⚙️",
+              execution_mode: "sequential",
+              max_concurrent: 1,
+              base_branch: "main",
+              identity_scope: "org",
+              pre_pr_review_loops: 1,
+              schedule_type: "interval",
+              github_event_triggers: [],
+              timezone: "UTC",
+              enabled: true,
+              priority: 50,
+              created_at: "2026-03-05T12:00:00Z",
+              updated_at: "2026-03-05T12:00:00Z",
+            },
+          },
+          { status: 201 },
+        );
+      }),
+    );
+
+    renderWithProviders(<NewAutomationPage />);
+
+    await user.type(await screen.findByLabelText("Name"), "Draft to create");
+    await user.type(screen.getByLabelText("Goal"), "Create this automation.");
+    await waitFor(() => {
+      expect(window.sessionStorage.getItem(DRAFT_STORAGE_KEY)).not.toBeNull();
+    });
+
+    await user.click(screen.getByRole("button", { name: "Create automation" }));
+
+    await waitFor(() => {
+      expect(pushMock).toHaveBeenCalledWith("/automations/automation-1");
+    });
+    expect(window.sessionStorage.getItem(DRAFT_STORAGE_KEY)).toBeNull();
+  });
+
+  it("does not restore a stored draft when a template is selected via URL param", async () => {
+    // searchParamsState.value is already "template=security-sweep" (default from beforeEach)
+    window.sessionStorage.setItem(
+      DRAFT_STORAGE_KEY,
+      JSON.stringify({
+        __v: 1,
+        name: "My saved draft",
+        goal: "This should not appear.",
+      }),
+    );
+
+    renderWithProviders(<NewAutomationPage />);
+
+    // The template name should be pre-filled, not the draft name
+    expect(await screen.findByDisplayValue("Security sweep")).toBeInTheDocument();
+    expect(screen.queryByDisplayValue("My saved draft")).not.toBeInTheDocument();
   });
 
   it("renders the composer as a lightweight document-style form", async () => {

--- a/frontend/src/app/(dashboard)/automations/new/page.tsx
+++ b/frontend/src/app/(dashboard)/automations/new/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Link from "next/link";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useMutation, useQuery } from "@tanstack/react-query";
 import {
   ChevronDown,
@@ -75,11 +75,16 @@ import {
   getCodingAgentReasoningOptions,
   supportsReasoningEffort,
   toCodingAgentReasoningEffort,
-  type CodingAgentReasoningEffort,
 } from "@/lib/coding-agent-reasoning";
+import {
+  clearAutomationDraft,
+  defaultAutomationFormState,
+  loadAutomationDraft,
+  saveAutomationDraft,
+  type AutomationFormState,
+} from "@/lib/automation-draft";
 import type {
   AgentCapabilityDefinition,
-  AgentCapabilityGrant,
   AutomationEventTriggerInput,
   AutomationGitHubEventFilters,
   ListResponse,
@@ -131,6 +136,12 @@ export default function NewAutomationPage() {
     searchParams.get("template") ?? "",
   );
   const goalEditorRef = useRef<HTMLDivElement>(null);
+  const draftSaveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const draftPersistenceDisabledRef = useRef(false);
+  const latestFormRef = useRef<AutomationFormState | null>(null);
+  const draftHydratedRef = useRef(!!initialTemplate);
+  const initialTemplateRef = useRef(initialTemplate);
+  const detectedTimezoneRef = useRef<string | null>(null);
 
   useEffect(() => {
     if (!isLoading && !canManage) {
@@ -138,58 +149,70 @@ export default function NewAutomationPage() {
     }
   }, [canManage, isLoading, router]);
 
-  const [name, setName] = useState(initialTemplate?.name ?? "");
-  const [goal, setGoal] = useState(initialTemplate?.goal ?? "");
-  const [iconValue, setIconValue] = useState("⚙️");
-  const [scope, setScope] = useState("");
-  const [selectedRepoId, setSelectedRepoId] = useState("");
-  const [intervalValue, setIntervalValue] = useState(
-    initialTemplate?.defaultInterval ?? 1,
-  );
-  const [intervalUnit, setIntervalUnit] = useState<"hours" | "days" | "weeks">(
-    initialTemplate?.defaultUnit ?? "days",
-  );
-  const [intervalRunHour, setIntervalRunHour] = useState("09");
-  const [intervalRunMinute, setIntervalRunMinute] = useState("00");
   const [detectedTimezone] = useState<string>(() => browserTimezone());
-  const [timezone, setTimezone] = useState<string>(detectedTimezone);
-  const [scheduleEnabled, setScheduleEnabled] = useState(true);
-  const [productTriggers, setProductTriggers] = useState<
-    AutomationProductTrigger[]
-  >([]);
-  const [triggerBaseBranches, setTriggerBaseBranches] = useState("");
-  const [triggerAuthors, setTriggerAuthors] = useState("");
-  const [triggerPaths, setTriggerPaths] = useState("");
-  const [triggerFeedbackTypes, setTriggerFeedbackTypes] = useState("");
-  const [triggerReviewStates, setTriggerReviewStates] = useState("");
-  const [pagerDutyEnabled, setPagerDutyEnabled] = useState(false);
-  const [pagerDutyEventTypes, setPagerDutyEventTypes] = useState<
-    PagerDutyEventType[]
-  >(["incident.triggered"]);
-  const [pagerDutyServiceIDs, setPagerDutyServiceIDs] = useState("");
-  const [pagerDutyTeamIDs, setPagerDutyTeamIDs] = useState("");
-  const [pagerDutyStatuses, setPagerDutyStatuses] = useState("");
-  const [pagerDutyUrgency, setPagerDutyUrgency] = useState<"high" | "low">("high");
-  const [pagerDutyPriorityNames, setPagerDutyPriorityNames] = useState("");
-  const [pagerDutyIncidentTypes, setPagerDutyIncidentTypes] = useState("");
-  const [pagerDutyTitleContains, setPagerDutyTitleContains] = useState("");
-  const [pagerDutyCustomFields, setPagerDutyCustomFields] = useState("");
-  const [pagerDutyCooldownMinutes, setPagerDutyCooldownMinutes] = useState("0");
+  const [form, setForm] = useState<AutomationFormState>(() =>
+    defaultAutomationFormState({
+      name: initialTemplate?.name ?? "",
+      goal: initialTemplate?.goal ?? "",
+      intervalValue: initialTemplate?.defaultInterval ?? 1,
+      intervalUnit: initialTemplate?.defaultUnit ?? "days",
+      timezone: detectedTimezone,
+    }),
+  );
   const [advancedOpen, setAdvancedOpen] = useState(false);
   const [templateOpen, setTemplateOpen] = useState(false);
-  const [baseBranchByRepoId, setBaseBranchByRepoId] = useState<
-    Record<string, string>
-  >({});
-  const [model, setModel] = useState<string | undefined>(undefined);
-  const [identityScope, setIdentityScope] = useState<"org" | "personal">("org");
-  const [prePRReviewLoops, setPrePRReviewLoops] = useState(1);
-  const [reasoningEffort, setReasoningEffort] =
-    useState<CodingAgentReasoningEffort>("");
-  const [priority, setPriority] = useState(50);
-  const [capabilityOverride, setCapabilityOverride] = useState<
-    AgentCapabilityGrant[] | null
-  >(null);
   const [redirecting, setRedirecting] = useState(false);
+  const [draftHydrated, setDraftHydrated] = useState(!!initialTemplate);
+  const patchForm = useCallback(
+    (patch: Partial<AutomationFormState>) => {
+      setForm((current) => ({ ...current, ...patch }));
+    },
+    [],
+  );
+  const setFormField = useCallback(
+    <K extends keyof AutomationFormState>(key: K, value: AutomationFormState[K]) => {
+      setForm((current) => ({ ...current, [key]: value }));
+    },
+    [],
+  );
+
+  const {
+    name,
+    goal,
+    iconValue,
+    scope,
+    selectedRepoId,
+    intervalValue,
+    intervalUnit,
+    intervalRunHour,
+    intervalRunMinute,
+    timezone,
+    scheduleEnabled,
+    productTriggers,
+    triggerBaseBranches,
+    triggerAuthors,
+    triggerPaths,
+    triggerFeedbackTypes,
+    triggerReviewStates,
+    pagerDutyEnabled,
+    pagerDutyEventTypes,
+    pagerDutyServiceIDs,
+    pagerDutyTeamIDs,
+    pagerDutyStatuses,
+    pagerDutyUrgency,
+    pagerDutyPriorityNames,
+    pagerDutyIncidentTypes,
+    pagerDutyTitleContains,
+    pagerDutyCustomFields,
+    pagerDutyCooldownMinutes,
+    baseBranchByRepoId,
+    model,
+    identityScope,
+    prePRReviewLoops,
+    reasoningEffort,
+    priority,
+    capabilityOverride,
+  } = form;
 
   const { data: settingsResponse } = useQuery({
     queryKey: ["settings"],
@@ -256,11 +279,103 @@ export default function NewAutomationPage() {
   const showReasoningSelector = supportsReasoningEffort(effectiveAgentType);
   const reasoningOptions = getCodingAgentReasoningOptions(effectiveAgentType);
 
+  const flushDraft = useCallback(() => {
+    if (
+      !draftHydrated
+      || initialTemplate
+      || draftPersistenceDisabledRef.current
+    ) {
+      return;
+    }
+    if (draftSaveTimerRef.current) {
+      clearTimeout(draftSaveTimerRef.current);
+      draftSaveTimerRef.current = null;
+    }
+    saveAutomationDraft(form, { defaultTimezone: detectedTimezone });
+  }, [detectedTimezone, draftHydrated, form, initialTemplate]);
+
+  useEffect(() => {
+    latestFormRef.current = form;
+  }, [form]);
+
+  useEffect(() => {
+    draftHydratedRef.current = draftHydrated;
+  }, [draftHydrated]);
+
+  useEffect(() => {
+    initialTemplateRef.current = initialTemplate;
+  }, [initialTemplate]);
+
+  useEffect(() => {
+    detectedTimezoneRef.current = detectedTimezone;
+  }, [detectedTimezone]);
+
+  useEffect(() => {
+    if (initialTemplate) return;
+    const draft = loadAutomationDraft({ defaultTimezone: detectedTimezone });
+    let cancelled = false;
+
+    queueMicrotask(() => {
+      if (cancelled) return;
+      if (!draft) {
+        setDraftHydrated(true);
+        return;
+      }
+      setForm(draft);
+      setDraftHydrated(true);
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [detectedTimezone, initialTemplate]);
+
+  useEffect(() => {
+    if (!draftHydrated || initialTemplate || draftPersistenceDisabledRef.current) return undefined;
+    if (draftSaveTimerRef.current) {
+      clearTimeout(draftSaveTimerRef.current);
+    }
+    draftSaveTimerRef.current = setTimeout(() => {
+      saveAutomationDraft(form, { defaultTimezone: detectedTimezone });
+      draftSaveTimerRef.current = null;
+    }, 400);
+
+    return () => {
+      if (draftSaveTimerRef.current) {
+        clearTimeout(draftSaveTimerRef.current);
+        draftSaveTimerRef.current = null;
+      }
+    };
+  }, [detectedTimezone, draftHydrated, form, initialTemplate]);
+
+  useEffect(
+    () => () => {
+      const latestForm = latestFormRef.current;
+      const defaultTimezone = detectedTimezoneRef.current;
+      if (
+        !latestForm
+        || !draftHydratedRef.current
+        || initialTemplateRef.current
+        || draftPersistenceDisabledRef.current
+      ) {
+        return;
+      }
+      if (draftSaveTimerRef.current) {
+        clearTimeout(draftSaveTimerRef.current);
+        draftSaveTimerRef.current = null;
+      }
+      saveAutomationDraft(latestForm, { defaultTimezone: defaultTimezone ?? undefined });
+    },
+    [],
+  );
+
   const applyTemplate = (template: AutomationTemplate) => {
-    setName(template.name);
-    setGoal(template.goal);
-    setIntervalValue(template.defaultInterval);
-    setIntervalUnit(template.defaultUnit);
+    patchForm({
+      name: template.name,
+      goal: template.goal,
+      intervalValue: template.defaultInterval,
+      intervalUnit: template.defaultUnit,
+    });
     setTemplateOpen(false);
     requestAnimationFrame(() => {
       goalEditorRef.current?.querySelector("textarea")?.focus();
@@ -271,22 +386,26 @@ export default function NewAutomationPage() {
     trigger: AutomationProductTrigger,
     checked: boolean,
   ) => {
-    setProductTriggers((current) => {
-      if (checked) {
-        return current.includes(trigger) ? current : [...current, trigger];
-      }
-      return current.filter((item) => item !== trigger);
+    setForm((current) => {
+      const nextTriggers = checked
+        ? current.productTriggers.includes(trigger)
+          ? current.productTriggers
+          : [...current.productTriggers, trigger]
+        : current.productTriggers.filter((item) => item !== trigger);
+      return { ...current, productTriggers: nextTriggers };
     });
   };
   const togglePagerDutyEventType = (
     eventType: PagerDutyEventType,
     checked: boolean,
   ) => {
-    setPagerDutyEventTypes((current) => {
-      if (checked) {
-        return current.includes(eventType) ? current : [...current, eventType];
-      }
-      return current.filter((item) => item !== eventType);
+    setForm((current) => {
+      const nextEventTypes = checked
+        ? current.pagerDutyEventTypes.includes(eventType)
+          ? current.pagerDutyEventTypes
+          : [...current.pagerDutyEventTypes, eventType]
+        : current.pagerDutyEventTypes.filter((item) => item !== eventType);
+      return { ...current, pagerDutyEventTypes: nextEventTypes };
     });
   };
 
@@ -363,6 +482,12 @@ export default function NewAutomationPage() {
         ...(capabilityOverride ? { capabilities: capabilityOverride } : {}),
       }),
     onSuccess: (res) => {
+      draftPersistenceDisabledRef.current = true;
+      if (draftSaveTimerRef.current) {
+        clearTimeout(draftSaveTimerRef.current);
+        draftSaveTimerRef.current = null;
+      }
+      clearAutomationDraft();
       setRedirecting(true);
       router.push(`/automations/${res.data.id}`);
     },
@@ -406,11 +531,11 @@ export default function NewAutomationPage() {
         <div className="mx-auto max-w-4xl">
           <AutomationComposer
             name={name}
-            onNameChange={setName}
+            onNameChange={(value) => setFormField("name", value)}
             iconValue={iconValue}
-            onIconChange={setIconValue}
+            onIconChange={(value) => setFormField("iconValue", value)}
             goal={goal}
-            onGoalChange={setGoal}
+            onGoalChange={(value) => setFormField("goal", value)}
             repositoryId={repoId || undefined}
             branch={
               selectedBaseBranch || selectedRepo?.default_branch || undefined
@@ -438,12 +563,15 @@ export default function NewAutomationPage() {
                   pre_pr_review_loops: effectivePrePRReviewLoops,
                 }}
                 disabled={createMutation.isPending || redirecting}
-                onDraftApply={setGoal}
+                onDraftApply={(value) => setFormField("goal", value)}
               />
             }
             footerControls={
               <>
-                <Select value={repoId} onValueChange={setSelectedRepoId}>
+                <Select
+                  value={repoId}
+                  onValueChange={(value) => setFormField("selectedRepoId", value)}
+                >
                   <SelectTrigger
                     className="h-8 w-full border-transparent bg-muted/25 shadow-none hover:bg-muted/50 sm:w-[210px]"
                     aria-label="Repository"
@@ -472,7 +600,7 @@ export default function NewAutomationPage() {
                       <Checkbox
                         checked={scheduleEnabled}
                         onCheckedChange={(checked) =>
-                          setScheduleEnabled(checked === true)
+                          setFormField("scheduleEnabled", checked === true)
                         }
                         aria-label="On a schedule"
                       />
@@ -493,7 +621,8 @@ export default function NewAutomationPage() {
                         value={intervalValue}
                         onChange={(e) => {
                           const parsed = parseInt(e.target.value, 10);
-                          setIntervalValue(
+                          setFormField(
+                            "intervalValue",
                             Number.isNaN(parsed) ? 1 : Math.max(1, parsed),
                           );
                         }}
@@ -503,7 +632,7 @@ export default function NewAutomationPage() {
                         value={intervalUnit}
                         onValueChange={(v) => {
                           if (v === "hours" || v === "days" || v === "weeks") {
-                            setIntervalUnit(v);
+                            setFormField("intervalUnit", v);
                           }
                         }}
                       >
@@ -524,7 +653,7 @@ export default function NewAutomationPage() {
                       </span>
                       <Select
                         value={intervalRunHour}
-                        onValueChange={setIntervalRunHour}
+                        onValueChange={(value) => setFormField("intervalRunHour", value)}
                       >
                         <SelectTrigger
                           className="h-7 w-18 text-base sm:text-xs"
@@ -543,7 +672,7 @@ export default function NewAutomationPage() {
                       <span className="text-sm text-muted-foreground">:</span>
                       <Select
                         value={intervalRunMinute}
-                        onValueChange={setIntervalRunMinute}
+                        onValueChange={(value) => setFormField("intervalRunMinute", value)}
                       >
                         <SelectTrigger
                           className="h-7 w-18 text-base sm:text-xs"
@@ -561,7 +690,7 @@ export default function NewAutomationPage() {
                       </Select>
                       <TimezonePicker
                         value={timezone}
-                        onChange={setTimezone}
+                        onChange={(value) => setFormField("timezone", value)}
                         detected={detectedTimezone}
                         className="w-full sm:w-auto"
                       />
@@ -603,7 +732,7 @@ export default function NewAutomationPage() {
                         checked={pagerDutyEnabled}
                         disabled={!pagerDutyConnected}
                         onCheckedChange={(checked) =>
-                          setPagerDutyEnabled(checked === true)
+                          setFormField("pagerDutyEnabled", checked === true)
                         }
                         aria-label="PagerDuty incidents"
                       />
@@ -648,7 +777,7 @@ export default function NewAutomationPage() {
                             placeholder="Service IDs, comma-separated"
                             value={pagerDutyServiceIDs}
                             onChange={(event) =>
-                              setPagerDutyServiceIDs(event.target.value)
+                              setFormField("pagerDutyServiceIDs", event.target.value)
                             }
                             className="h-8"
                           />
@@ -656,7 +785,7 @@ export default function NewAutomationPage() {
                             value={pagerDutyUrgency}
                             onValueChange={(value) => {
                               if (value === "high" || value === "low") {
-                                setPagerDutyUrgency(value);
+                                setFormField("pagerDutyUrgency", value);
                               }
                             }}
                           >
@@ -678,7 +807,7 @@ export default function NewAutomationPage() {
                             placeholder="Team IDs, comma-separated"
                             value={pagerDutyTeamIDs}
                             onChange={(event) =>
-                              setPagerDutyTeamIDs(event.target.value)
+                              setFormField("pagerDutyTeamIDs", event.target.value)
                             }
                             className="h-8"
                           />
@@ -687,7 +816,7 @@ export default function NewAutomationPage() {
                             placeholder="Statuses: triggered, acknowledged"
                             value={pagerDutyStatuses}
                             onChange={(event) =>
-                              setPagerDutyStatuses(event.target.value)
+                              setFormField("pagerDutyStatuses", event.target.value)
                             }
                             className="h-8"
                           />
@@ -696,7 +825,7 @@ export default function NewAutomationPage() {
                             placeholder="Priority names, comma-separated"
                             value={pagerDutyPriorityNames}
                             onChange={(event) =>
-                              setPagerDutyPriorityNames(event.target.value)
+                              setFormField("pagerDutyPriorityNames", event.target.value)
                             }
                             className="h-8"
                           />
@@ -705,7 +834,7 @@ export default function NewAutomationPage() {
                             placeholder="Incident types, comma-separated"
                             value={pagerDutyIncidentTypes}
                             onChange={(event) =>
-                              setPagerDutyIncidentTypes(event.target.value)
+                              setFormField("pagerDutyIncidentTypes", event.target.value)
                             }
                             className="h-8"
                           />
@@ -714,7 +843,7 @@ export default function NewAutomationPage() {
                             placeholder="Title contains"
                             value={pagerDutyTitleContains}
                             onChange={(event) =>
-                              setPagerDutyTitleContains(event.target.value)
+                              setFormField("pagerDutyTitleContains", event.target.value)
                             }
                             className="h-8"
                           />
@@ -725,7 +854,7 @@ export default function NewAutomationPage() {
                             max={10080}
                             value={pagerDutyCooldownMinutes}
                             onChange={(event) =>
-                              setPagerDutyCooldownMinutes(event.target.value)
+                              setFormField("pagerDutyCooldownMinutes", event.target.value)
                             }
                             className="h-8"
                           />
@@ -734,7 +863,7 @@ export default function NewAutomationPage() {
                             placeholder="field=value, field=other"
                             value={pagerDutyCustomFields}
                             onChange={(event) =>
-                              setPagerDutyCustomFields(event.target.value)
+                              setFormField("pagerDutyCustomFields", event.target.value)
                             }
                             className="h-8 sm:col-span-2"
                           />
@@ -763,7 +892,7 @@ export default function NewAutomationPage() {
                   onSelect={applyTemplate}
                 />
                 <Button asChild variant="ghost" size="sm">
-                  <Link href="/automations/templates">
+                  <Link href="/automations/templates" onClick={flushDraft}>
                     Browse all templates
                   </Link>
                 </Button>
@@ -797,7 +926,7 @@ export default function NewAutomationPage() {
                         <Input
                           id="scope"
                           value={scope}
-                          onChange={(e) => setScope(e.target.value)}
+                          onChange={(e) => setFormField("scope", e.target.value)}
                           placeholder="e.g. src/payments/, tests/"
                         />
                       </div>
@@ -806,7 +935,7 @@ export default function NewAutomationPage() {
                         <Select
                           value={identityScope}
                           onValueChange={(value: "org" | "personal") =>
-                            setIdentityScope(value)
+                            setFormField("identityScope", value)
                           }
                         >
                           <SelectTrigger aria-label="Run as">
@@ -824,7 +953,7 @@ export default function NewAutomationPage() {
                           id="advanced-model"
                           ariaLabel="Model"
                           value={model}
-                          onValueChange={setModel}
+                          onValueChange={(value) => setFormField("model", value)}
                         />
                       </div>
                       {showReasoningSelector ? (
@@ -833,7 +962,8 @@ export default function NewAutomationPage() {
                           <Select
                             value={reasoningEffort || "__default__"}
                             onValueChange={(value) =>
-                              setReasoningEffort(
+                              setFormField(
+                                "reasoningEffort",
                                 value === "__default__"
                                   ? ""
                                   : toCodingAgentReasoningEffort(value),
@@ -866,9 +996,12 @@ export default function NewAutomationPage() {
                           value={selectedBaseBranch}
                           defaultBranch={selectedRepo?.default_branch}
                           onValueChange={(branch) =>
-                            setBaseBranchByRepoId((prev) => ({
-                              ...prev,
-                              [repoId]: branch,
+                            setForm((current) => ({
+                              ...current,
+                              baseBranchByRepoId: {
+                                ...current.baseBranchByRepoId,
+                                [repoId]: branch,
+                              },
                             }))
                           }
                           label="Base branch"
@@ -881,7 +1014,7 @@ export default function NewAutomationPage() {
                         <Label>Priority</Label>
                         <Select
                           value={String(priority)}
-                          onValueChange={(v) => setPriority(parseInt(v, 10))}
+                          onValueChange={(v) => setFormField("priority", parseInt(v, 10))}
                         >
                           <SelectTrigger aria-label="Priority">
                             <SelectValue />
@@ -909,7 +1042,7 @@ export default function NewAutomationPage() {
                         <AutomationCapabilitiesEditor
                           catalog={capabilityCatalog}
                           grants={capabilityGrants}
-                          onChange={setCapabilityOverride}
+                          onChange={(value) => setFormField("capabilityOverride", value)}
                         />
                       </div>
                       <div className="space-y-3 rounded-md border border-border p-3">
@@ -929,7 +1062,7 @@ export default function NewAutomationPage() {
                               id="trigger-base-branches"
                               value={triggerBaseBranches}
                               onChange={(e) =>
-                                setTriggerBaseBranches(e.target.value)
+                                setFormField("triggerBaseBranches", e.target.value)
                               }
                               placeholder="main, release"
                             />
@@ -940,7 +1073,7 @@ export default function NewAutomationPage() {
                               id="trigger-authors"
                               value={triggerAuthors}
                               onChange={(e) =>
-                                setTriggerAuthors(e.target.value)
+                                setFormField("triggerAuthors", e.target.value)
                               }
                               placeholder="octocat, dependabot[bot]"
                             />
@@ -950,7 +1083,7 @@ export default function NewAutomationPage() {
                             <Input
                               id="trigger-paths"
                               value={triggerPaths}
-                              onChange={(e) => setTriggerPaths(e.target.value)}
+                              onChange={(e) => setFormField("triggerPaths", e.target.value)}
                               placeholder="src/, package.json"
                             />
                           </div>
@@ -962,7 +1095,7 @@ export default function NewAutomationPage() {
                               id="trigger-feedback-types"
                               value={triggerFeedbackTypes}
                               onChange={(e) =>
-                                setTriggerFeedbackTypes(e.target.value)
+                                setFormField("triggerFeedbackTypes", e.target.value)
                               }
                               placeholder="Inline review comment"
                             />
@@ -975,7 +1108,7 @@ export default function NewAutomationPage() {
                               id="trigger-review-states"
                               value={triggerReviewStates}
                               onChange={(e) =>
-                                setTriggerReviewStates(e.target.value)
+                                setFormField("triggerReviewStates", e.target.value)
                               }
                               placeholder="approved, changes_requested, commented"
                             />
@@ -993,9 +1126,10 @@ export default function NewAutomationPage() {
                             size="icon"
                             aria-label="Decrease review passes"
                             onClick={() =>
-                              setPrePRReviewLoops((value) =>
-                                Math.max(0, value - 1),
-                              )
+                              setForm((current) => ({
+                                ...current,
+                                prePRReviewLoops: Math.max(0, current.prePRReviewLoops - 1),
+                              }))
                             }
                             disabled={!supportsNativeReviewLoop}
                           >
@@ -1010,7 +1144,8 @@ export default function NewAutomationPage() {
                             value={effectivePrePRReviewLoops}
                             onChange={(e) => {
                               const parsed = parseInt(e.target.value, 10);
-                              setPrePRReviewLoops(
+                              setFormField(
+                                "prePRReviewLoops",
                                 Number.isNaN(parsed)
                                   ? 0
                                   : Math.min(5, Math.max(0, parsed)),
@@ -1025,9 +1160,10 @@ export default function NewAutomationPage() {
                             size="icon"
                             aria-label="Increase review passes"
                             onClick={() =>
-                              setPrePRReviewLoops((value) =>
-                                Math.min(5, value + 1),
-                              )
+                              setForm((current) => ({
+                                ...current,
+                                prePRReviewLoops: Math.min(5, current.prePRReviewLoops + 1),
+                              }))
                             }
                             disabled={!supportsNativeReviewLoop}
                           >

--- a/frontend/src/app/(dashboard)/settings/autopilot/page.tsx
+++ b/frontend/src/app/(dashboard)/settings/autopilot/page.tsx
@@ -39,7 +39,7 @@ import {
   PM_SCHEDULE_MAX_HOURS,
   clampNumber,
 } from "@/lib/settings-constants";
-import type { CodingCredentialSummary, ListResponse, Organization, OrgSettings, RepoSettings, Repository, SingleResponse } from "@/lib/types";
+import type { CodingCredentialSummary, ListResponse, Organization, OrgSettings, Repository, SingleResponse } from "@/lib/types";
 
 export default function AutopilotSettingsPage() {
   const { user } = useAuth();

--- a/frontend/src/lib/automation-draft.test.ts
+++ b/frontend/src/lib/automation-draft.test.ts
@@ -1,0 +1,221 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  automationFormStateFromDraft,
+  automationFormStateToDraft,
+  clearAutomationDraft,
+  defaultAutomationFormState,
+  loadAutomationDraft,
+  saveAutomationDraft,
+  type AutomationFormState,
+} from "./automation-draft";
+
+const STORAGE_KEY = "143:new-automation-draft";
+
+const FORM_STATE_KEYS = [
+  "baseBranchByRepoId",
+  "capabilityOverride",
+  "goal",
+  "iconValue",
+  "identityScope",
+  "intervalRunHour",
+  "intervalRunMinute",
+  "intervalUnit",
+  "intervalValue",
+  "model",
+  "name",
+  "pagerDutyCooldownMinutes",
+  "pagerDutyCustomFields",
+  "pagerDutyEnabled",
+  "pagerDutyEventTypes",
+  "pagerDutyIncidentTypes",
+  "pagerDutyPriorityNames",
+  "pagerDutyServiceIDs",
+  "pagerDutyStatuses",
+  "pagerDutyTeamIDs",
+  "pagerDutyTitleContains",
+  "pagerDutyUrgency",
+  "prePRReviewLoops",
+  "priority",
+  "productTriggers",
+  "reasoningEffort",
+  "scheduleEnabled",
+  "scope",
+  "selectedRepoId",
+  "timezone",
+  "triggerAuthors",
+  "triggerBaseBranches",
+  "triggerFeedbackTypes",
+  "triggerPaths",
+  "triggerReviewStates",
+].sort();
+
+function populatedDraft(overrides: Partial<AutomationFormState> = {}): AutomationFormState {
+  return defaultAutomationFormState({
+    name: "Nightly triage",
+    goal: "Review new production errors and open focused fixes.",
+    iconValue: "✨",
+    scope: "src/",
+    selectedRepoId: "repo-1",
+    intervalValue: 2,
+    intervalUnit: "days",
+    intervalRunHour: "10",
+    intervalRunMinute: "30",
+    timezone: "UTC",
+    scheduleEnabled: true,
+    productTriggers: ["github.pr.opened"],
+    triggerBaseBranches: "main",
+    triggerAuthors: "dependabot[bot]",
+    triggerPaths: "src/",
+    triggerFeedbackTypes: "Inline review comment",
+    triggerReviewStates: "changes_requested",
+    pagerDutyEnabled: true,
+    pagerDutyEventTypes: ["incident.triggered"],
+    pagerDutyServiceIDs: "P123",
+    pagerDutyTeamIDs: "T123",
+    pagerDutyStatuses: "triggered",
+    pagerDutyUrgency: "high",
+    pagerDutyPriorityNames: "P1",
+    pagerDutyIncidentTypes: "incident",
+    pagerDutyTitleContains: "checkout",
+    pagerDutyCustomFields: "service=checkout",
+    pagerDutyCooldownMinutes: "30",
+    baseBranchByRepoId: { "repo-1": "main" },
+    model: "gpt-5.4",
+    identityScope: "org",
+    prePRReviewLoops: 2,
+    reasoningEffort: "high",
+    priority: 25,
+    capabilityOverride: [
+      {
+        capability_id: "publishing",
+        access_level: "write",
+        enabled: true,
+      },
+    ],
+    ...overrides,
+  });
+}
+
+describe("automation-draft storage", () => {
+  beforeEach(() => {
+    window.sessionStorage.clear();
+  });
+
+  it("keeps the canonical form state keys explicit", () => {
+    expect(Object.keys(defaultAutomationFormState()).sort()).toEqual(FORM_STATE_KEYS);
+  });
+
+  it("round-trips a populated draft", () => {
+    const draft = populatedDraft();
+
+    saveAutomationDraft(draft);
+
+    expect(loadAutomationDraft()).toEqual(draft);
+  });
+
+  it("does not persist an empty draft and clears existing storage", () => {
+    saveAutomationDraft(populatedDraft());
+
+    saveAutomationDraft(defaultAutomationFormState());
+
+    expect(window.sessionStorage.getItem(STORAGE_KEY)).toBeNull();
+  });
+
+  it("normalizes the detected timezone out of stored drafts", () => {
+    const state = defaultAutomationFormState({ timezone: "America/New_York" });
+
+    expect(automationFormStateToDraft(state, { defaultTimezone: "America/New_York" })).toEqual(
+      defaultAutomationFormState({ timezone: "" }),
+    );
+    expect(
+      automationFormStateFromDraft(
+        { __v: 1, timezone: "" },
+        { defaultTimezone: "America/New_York" },
+      ),
+    ).toEqual(defaultAutomationFormState({ timezone: "America/New_York" }));
+  });
+
+  it("discards drafts with a mismatched schema version", () => {
+    window.sessionStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({ __v: 999, name: "Old draft" }),
+    );
+
+    expect(loadAutomationDraft()).toBeNull();
+  });
+
+  it("sanitizes malformed field values", () => {
+    window.sessionStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({
+        __v: 1,
+        name: "Partly valid",
+        goal: "Keep the strings",
+        intervalValue: -10,
+        intervalUnit: "months",
+        pagerDutyUrgency: "medium",
+        productTriggers: ["github.pr.opened", 123],
+        pagerDutyEventTypes: ["incident.resolved", false],
+        baseBranchByRepoId: { "repo-1": "release", bad: 42 },
+        identityScope: "robot",
+        prePRReviewLoops: 10,
+        reasoningEffort: "impossible",
+        priority: 999,
+        capabilityOverride: [
+          { capability_id: "publishing", access_level: "write", enabled: true },
+          { capability_id: 42, access_level: "write", enabled: true },
+        ],
+      }),
+    );
+
+    expect(loadAutomationDraft()).toEqual(
+      populatedDraft({
+        name: "Partly valid",
+        goal: "Keep the strings",
+        iconValue: "⚙️",
+        scope: "",
+        selectedRepoId: "",
+        intervalValue: 1,
+        intervalUnit: "days",
+        intervalRunHour: "09",
+        intervalRunMinute: "00",
+        timezone: "",
+        scheduleEnabled: true,
+        productTriggers: ["github.pr.opened"],
+        triggerBaseBranches: "",
+        triggerAuthors: "",
+        triggerPaths: "",
+        triggerFeedbackTypes: "",
+        triggerReviewStates: "",
+        pagerDutyEnabled: false,
+        pagerDutyEventTypes: ["incident.resolved"],
+        pagerDutyServiceIDs: "",
+        pagerDutyTeamIDs: "",
+        pagerDutyStatuses: "",
+        pagerDutyUrgency: "high",
+        pagerDutyPriorityNames: "",
+        pagerDutyIncidentTypes: "",
+        pagerDutyTitleContains: "",
+        pagerDutyCustomFields: "",
+        pagerDutyCooldownMinutes: "0",
+        baseBranchByRepoId: {},
+        model: undefined,
+        identityScope: "org",
+        prePRReviewLoops: 5,
+        reasoningEffort: "",
+        priority: 50,
+        capabilityOverride: [
+          { capability_id: "publishing", access_level: "write", enabled: true },
+        ],
+      }),
+    );
+  });
+
+  it("clears the stored draft", () => {
+    saveAutomationDraft(populatedDraft());
+
+    clearAutomationDraft();
+
+    expect(window.sessionStorage.getItem(STORAGE_KEY)).toBeNull();
+  });
+});

--- a/frontend/src/lib/automation-draft.ts
+++ b/frontend/src/lib/automation-draft.ts
@@ -1,0 +1,320 @@
+import { toCodingAgentReasoningEffort, type CodingAgentReasoningEffort } from "@/lib/coding-agent-reasoning";
+import type { AutomationProductTrigger } from "@/lib/automation-triggers";
+import type { AgentCapabilityGrant, PagerDutyEventType } from "@/lib/types";
+
+const STORAGE_KEY = "143:new-automation-draft";
+const SCHEMA_VERSION = 1;
+
+export type AutomationFormState = {
+  name: string;
+  goal: string;
+  iconValue: string;
+  scope: string;
+  selectedRepoId: string;
+  intervalValue: number;
+  intervalUnit: "hours" | "days" | "weeks";
+  intervalRunHour: string;
+  intervalRunMinute: string;
+  timezone: string;
+  scheduleEnabled: boolean;
+  productTriggers: AutomationProductTrigger[];
+  triggerBaseBranches: string;
+  triggerAuthors: string;
+  triggerPaths: string;
+  triggerFeedbackTypes: string;
+  triggerReviewStates: string;
+  pagerDutyEnabled: boolean;
+  pagerDutyEventTypes: PagerDutyEventType[];
+  pagerDutyServiceIDs: string;
+  pagerDutyTeamIDs: string;
+  pagerDutyStatuses: string;
+  pagerDutyUrgency: "high" | "low";
+  pagerDutyPriorityNames: string;
+  pagerDutyIncidentTypes: string;
+  pagerDutyTitleContains: string;
+  pagerDutyCustomFields: string;
+  pagerDutyCooldownMinutes: string;
+  baseBranchByRepoId: Record<string, string>;
+  model: string | undefined;
+  identityScope: "org" | "personal";
+  prePRReviewLoops: number;
+  reasoningEffort: CodingAgentReasoningEffort;
+  priority: number;
+  capabilityOverride: AgentCapabilityGrant[] | null;
+};
+
+export type AutomationDraft = AutomationFormState;
+
+type StoredAutomationDraft = AutomationDraft & { __v: number };
+
+type DraftStorageOptions = {
+  defaultTimezone?: string;
+};
+
+const productTriggerValues = new Set<AutomationProductTrigger>([
+  "github.pr.opened",
+  "github.pr.updated",
+  "github.pr.feedback",
+  "github.checks.completed",
+  "github.pr.merged",
+]);
+
+const pagerDutyEventTypeValues = new Set<PagerDutyEventType>([
+  "incident.triggered",
+  "incident.annotated",
+  "incident.priority_updated",
+  "incident.acknowledged",
+  "incident.resolved",
+]);
+
+function getStorage(): Storage | null {
+  if (typeof window === "undefined") return null;
+  try {
+    return window.sessionStorage;
+  } catch {
+    return null;
+  }
+}
+
+export function defaultAutomationFormState(
+  overrides: Partial<AutomationFormState> = {},
+): AutomationFormState {
+  return {
+    name: "",
+    goal: "",
+    iconValue: "⚙️",
+    scope: "",
+    selectedRepoId: "",
+    intervalValue: 1,
+    intervalUnit: "days",
+    intervalRunHour: "09",
+    intervalRunMinute: "00",
+    timezone: "",
+    scheduleEnabled: true,
+    productTriggers: [],
+    triggerBaseBranches: "",
+    triggerAuthors: "",
+    triggerPaths: "",
+    triggerFeedbackTypes: "",
+    triggerReviewStates: "",
+    pagerDutyEnabled: false,
+    pagerDutyEventTypes: ["incident.triggered"],
+    pagerDutyServiceIDs: "",
+    pagerDutyTeamIDs: "",
+    pagerDutyStatuses: "",
+    pagerDutyUrgency: "high",
+    pagerDutyPriorityNames: "",
+    pagerDutyIncidentTypes: "",
+    pagerDutyTitleContains: "",
+    pagerDutyCustomFields: "",
+    pagerDutyCooldownMinutes: "0",
+    baseBranchByRepoId: {},
+    model: undefined,
+    identityScope: "org",
+    prePRReviewLoops: 1,
+    reasoningEffort: "",
+    priority: 50,
+    capabilityOverride: null,
+    ...overrides,
+  };
+}
+
+export function automationFormStateFromDraft(
+  parsed: Partial<StoredAutomationDraft>,
+  options: DraftStorageOptions = {},
+): AutomationFormState {
+  return defaultAutomationFormState({
+    name: stringOr(parsed.name, ""),
+    goal: stringOr(parsed.goal, ""),
+    iconValue: stringOr(parsed.iconValue, "⚙️"),
+    scope: stringOr(parsed.scope, ""),
+    selectedRepoId: stringOr(parsed.selectedRepoId, ""),
+    intervalValue: clampInteger(parsed.intervalValue, 1, 365, 1),
+    intervalUnit: isIntervalUnit(parsed.intervalUnit) ? parsed.intervalUnit : "days",
+    intervalRunHour: stringOr(parsed.intervalRunHour, "09"),
+    intervalRunMinute: stringOr(parsed.intervalRunMinute, "00"),
+    timezone:
+      typeof parsed.timezone === "string" && parsed.timezone.length > 0
+        ? parsed.timezone
+        : (options.defaultTimezone ?? ""),
+    scheduleEnabled: parsed.scheduleEnabled !== false,
+    productTriggers: validArray(parsed.productTriggers, productTriggerValues),
+    triggerBaseBranches: stringOr(parsed.triggerBaseBranches, ""),
+    triggerAuthors: stringOr(parsed.triggerAuthors, ""),
+    triggerPaths: stringOr(parsed.triggerPaths, ""),
+    triggerFeedbackTypes: stringOr(parsed.triggerFeedbackTypes, ""),
+    triggerReviewStates: stringOr(parsed.triggerReviewStates, ""),
+    pagerDutyEnabled: parsed.pagerDutyEnabled === true,
+    pagerDutyEventTypes:
+      parsed.pagerDutyEventTypes === undefined
+        ? ["incident.triggered"]
+        : validArray(parsed.pagerDutyEventTypes, pagerDutyEventTypeValues),
+    pagerDutyServiceIDs: stringOr(parsed.pagerDutyServiceIDs, ""),
+    pagerDutyTeamIDs: stringOr(parsed.pagerDutyTeamIDs, ""),
+    pagerDutyStatuses: stringOr(parsed.pagerDutyStatuses, ""),
+    pagerDutyUrgency: parsed.pagerDutyUrgency === "low" ? "low" : "high",
+    pagerDutyPriorityNames: stringOr(parsed.pagerDutyPriorityNames, ""),
+    pagerDutyIncidentTypes: stringOr(parsed.pagerDutyIncidentTypes, ""),
+    pagerDutyTitleContains: stringOr(parsed.pagerDutyTitleContains, ""),
+    pagerDutyCustomFields: stringOr(parsed.pagerDutyCustomFields, ""),
+    pagerDutyCooldownMinutes: stringOr(parsed.pagerDutyCooldownMinutes, "0"),
+    baseBranchByRepoId: isStringRecord(parsed.baseBranchByRepoId)
+      ? parsed.baseBranchByRepoId
+      : {},
+    model: typeof parsed.model === "string" ? parsed.model : undefined,
+    identityScope: parsed.identityScope === "personal" ? "personal" : "org",
+    prePRReviewLoops: clampInteger(parsed.prePRReviewLoops, 0, 5, 1),
+    reasoningEffort: toCodingAgentReasoningEffort(
+      typeof parsed.reasoningEffort === "string" ? parsed.reasoningEffort : "",
+    ),
+    priority: [0, 25, 50, 75].includes(Number(parsed.priority))
+      ? Number(parsed.priority)
+      : 50,
+    capabilityOverride: Array.isArray(parsed.capabilityOverride)
+      ? parsed.capabilityOverride.filter(isCapabilityGrant)
+      : null,
+  });
+}
+
+export function loadAutomationDraft(
+  options: DraftStorageOptions = {},
+): AutomationDraft | null {
+  const storage = getStorage();
+  if (!storage) return null;
+
+  let raw: string | null;
+  try {
+    raw = storage.getItem(STORAGE_KEY);
+  } catch {
+    return null;
+  }
+  if (!raw) return null;
+
+  let parsed: Partial<StoredAutomationDraft>;
+  try {
+    parsed = JSON.parse(raw) as Partial<StoredAutomationDraft>;
+  } catch {
+    return null;
+  }
+  if (parsed.__v !== SCHEMA_VERSION) return null;
+
+  return automationFormStateFromDraft(parsed, options);
+}
+
+export function automationFormStateToDraft(
+  state: AutomationFormState,
+  options: DraftStorageOptions = {},
+): AutomationDraft {
+  return {
+    ...state,
+    timezone: state.timezone === options.defaultTimezone ? "" : state.timezone,
+  };
+}
+
+export function saveAutomationDraft(
+  state: AutomationFormState,
+  options: DraftStorageOptions = {},
+): void {
+  const storage = getStorage();
+  if (!storage) return;
+
+  const draft = automationFormStateToDraft(state, options);
+  if (isEmptyDraft(draft)) {
+    try { storage.removeItem(STORAGE_KEY); } catch {}
+    return;
+  }
+
+  const stored: StoredAutomationDraft = { __v: SCHEMA_VERSION, ...draft };
+  try {
+    storage.setItem(STORAGE_KEY, JSON.stringify(stored));
+  } catch {
+    // Best-effort draft persistence should never block automation creation.
+  }
+}
+
+export function clearAutomationDraft(): void {
+  const storage = getStorage();
+  if (!storage) return;
+  try { storage.removeItem(STORAGE_KEY); } catch {}
+}
+
+function isEmptyDraft(draft: AutomationDraft): boolean {
+  return (
+    draft.name.length === 0
+    && draft.goal.length === 0
+    && draft.iconValue === "⚙️"
+    && draft.scope.length === 0
+    && draft.selectedRepoId.length === 0
+    && draft.intervalValue === 1
+    && draft.intervalUnit === "days"
+    && draft.intervalRunHour === "09"
+    && draft.intervalRunMinute === "00"
+    && draft.timezone.length === 0
+    && draft.scheduleEnabled
+    && draft.productTriggers.length === 0
+    && draft.triggerBaseBranches.length === 0
+    && draft.triggerAuthors.length === 0
+    && draft.triggerPaths.length === 0
+    && draft.triggerFeedbackTypes.length === 0
+    && draft.triggerReviewStates.length === 0
+    && !draft.pagerDutyEnabled
+    && draft.pagerDutyEventTypes.length === 1
+    && draft.pagerDutyEventTypes[0] === "incident.triggered"
+    && draft.pagerDutyServiceIDs.length === 0
+    && draft.pagerDutyTeamIDs.length === 0
+    && draft.pagerDutyStatuses.length === 0
+    && draft.pagerDutyUrgency === "high"
+    && draft.pagerDutyPriorityNames.length === 0
+    && draft.pagerDutyIncidentTypes.length === 0
+    && draft.pagerDutyTitleContains.length === 0
+    && draft.pagerDutyCustomFields.length === 0
+    && draft.pagerDutyCooldownMinutes === "0"
+    && Object.keys(draft.baseBranchByRepoId).length === 0
+    && draft.model === undefined
+    && draft.identityScope === "org"
+    && draft.prePRReviewLoops === 1
+    && draft.reasoningEffort === ""
+    && draft.priority === 50
+    && draft.capabilityOverride === null
+  );
+}
+
+function stringOr(value: unknown, fallback: string): string {
+  return typeof value === "string" ? value : fallback;
+}
+
+function clampInteger(
+  value: unknown,
+  min: number,
+  max: number,
+  fallback: number,
+): number {
+  if (typeof value !== "number" || !Number.isInteger(value)) return fallback;
+  return Math.min(max, Math.max(min, value));
+}
+
+function isIntervalUnit(value: unknown): value is AutomationDraft["intervalUnit"] {
+  return value === "hours" || value === "days" || value === "weeks";
+}
+
+function validArray<T extends string>(value: unknown, allowed: Set<T>): T[] {
+  if (!Array.isArray(value)) return [];
+  return value.filter((item): item is T => typeof item === "string" && allowed.has(item as T));
+}
+
+function isStringRecord(value: unknown): value is Record<string, string> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+  return Object.values(value as Record<string, unknown>).every((item) => typeof item === "string");
+}
+
+function isCapabilityGrant(value: unknown): value is AgentCapabilityGrant {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+  const grant = value as Record<string, unknown>;
+  return (
+    (grant.id === undefined || typeof grant.id === "string")
+    && typeof grant.capability_id === "string"
+    && typeof grant.access_level === "string"
+    && typeof grant.enabled === "boolean"
+    && (grant.config === undefined || (!!grant.config && typeof grant.config === "object" && !Array.isArray(grant.config)))
+  );
+}


### PR DESCRIPTION
## Summary

Restoring a previously saved automation draft on the “New Automation” page can override the user’s intended template selection (e.g., `?template=security-sweep`), leading to incorrect prefilled data and a confusing workflow. This change tightens the draft/session persistence logic so the URL-selected template always takes precedence, and adds a regression test covering the exact failure mode.

## Changes

- Updated the “New Automation” page logic to consistently persist/restore the draft from session storage while ensuring a template selected via URL param wins over any stored draft.
- Strengthened test coverage by adding a new scenario that pre-populates sessionStorage with a draft, renders with `?template=security-sweep`, and asserts the template’s name/data is used instead of the draft.
- Refined test setup/mocking for `useSearchParams` to avoid state leakage across cases and to accurately model the URL param behavior.
- Minor cleanup to keep automation draft handling coherent across the setup flow and related draft utilities/tests.

## Validation

- Added/ran frontend tests:
  - `frontend/src/app/(dashboard)/automations/new/page.test.tsx` (new test for URL template vs stored draft precedence)
  - `frontend/src/lib/automation-draft.test.ts`
- Verified the PR diff is clean and the added coverage specifically guards against the regression (“does not restore a stored draft when a template is selected via URL param”).

[143.dev](https://143.dev) | [session b18b5637](https://143.dev/sessions/b18b5637-1621-46f2-98b6-1d5889e75894)

<!-- 143 readiness -->
**143 readiness:** not available for this revision.

Preview: https://143.dev/previews/github/assembledhq/143/pull/1564?launch=1