### PR TITLE
Fix duplicate session sidebar rows and replace navigation after manual session creation

### DIFF
--- a/frontend/src/app/(dashboard)/sessions/new/manual-session-create-page-content.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/new/manual-session-create-page-content.test.tsx
@@ -45,6 +45,7 @@ const mocks = vi.hoisted(() => ({
     data: { id: "new-sess" },
   }),
   routerPushMock: vi.fn(),
+  routerReplaceMock: vi.fn(),
   addOptimisticSessionMock: vi.fn().mockReturnValue("optimistic-1"),
   removeOptimisticSessionMock: vi.fn(),
   markOptimisticResolvedMock: vi.fn(),
@@ -164,7 +165,7 @@ vi.mock("@/lib/errors", () => ({
 vi.mock("next/navigation", () => ({
   useRouter: () => ({
     push: mocks.routerPushMock,
-    replace: vi.fn(),
+    replace: mocks.routerReplaceMock,
     prefetch: vi.fn(),
   }),
   useSearchParams: () => ({
@@ -552,10 +553,10 @@ describe("ManualSessionCreatePageContent", () => {
         }),
       );
     });
-    expect(mocks.addOptimisticSessionMock).toHaveBeenCalledWith("Manual Session");
+    expect(mocks.addOptimisticSessionMock).not.toHaveBeenCalled();
   });
 
-  it("keeps the start button loading after create succeeds while navigation is pending", async () => {
+  it("replaces the new-session route after create succeeds while navigation is pending", async () => {
     const user = userEvent.setup();
     const createSession = deferred<{ data: { id: string } }>();
     mocks.createSessionMock.mockImplementationOnce(() => createSession.promise);
@@ -576,8 +577,9 @@ describe("ManualSessionCreatePageContent", () => {
     });
 
     await waitFor(() => {
-      expect(mocks.routerPushMock).toHaveBeenCalledWith("/sessions/new-sess");
+      expect(mocks.routerReplaceMock).toHaveBeenCalledWith("/sessions/new-sess");
     });
+    expect(mocks.routerPushMock).not.toHaveBeenCalled();
     expect(startButton).toBeDisabled();
     expect(startButton.querySelector(".animate-spin")).not.toBeNull();
   });

--- a/frontend/src/app/(dashboard)/sessions/new/manual-session-create-page-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/new/manual-session-create-page-content.tsx
@@ -39,7 +39,8 @@ export function ManualSessionCreatePageContent() {
           textareaAriaLabel="Manual session prompt"
           className={cn("mx-auto flex w-full max-w-3xl flex-1")}
           innerClassName="max-w-3xl"
-          onCreated={(id) => router.push(`/sessions/${id}${filterSuffix}`)}
+          showOptimisticSidebarRow={false}
+          onCreated={(id) => router.replace(`/sessions/${id}${filterSuffix}`)}
           heroSlot={
             <div className="flex-1 flex flex-col items-center justify-center px-2 pt-16 pb-4">
               <div className="text-center mb-8">

--- a/frontend/src/components/manual-session-composer.tsx
+++ b/frontend/src/components/manual-session-composer.tsx
@@ -161,6 +161,8 @@ export interface ManualSessionComposerProps {
   textareaAriaLabel?: string;
   /** Show the live drop indicator pill inside the dropzone. Page only. */
   showDropIndicator?: boolean;
+  /** Add a temporary sidebar row while create is pending. Disable when the route already renders a draft row. */
+  showOptimisticSidebarRow?: boolean;
   /** Test id placed on the outer drop-target div. */
   dataTestId?: string;
 }
@@ -293,6 +295,7 @@ export function ManualSessionComposer({
   placeholder = "Tell the agent what to do...",
   textareaAriaLabel = "Session prompt",
   showDropIndicator = false,
+  showOptimisticSidebarRow = true,
   dataTestId,
 }: ManualSessionComposerProps) {
   const { user } = useAuth();
@@ -732,7 +735,7 @@ export function ManualSessionComposer({
       const title = optimisticTitle.length > 80
         ? optimisticTitle.slice(0, 80) + "..."
         : optimisticTitle;
-      return { optimisticId: addOptimisticSession(title) };
+      return { optimisticId: showOptimisticSidebarRow ? addOptimisticSession(title) : undefined };
     },
     onSuccess: (response, _variables, context) => {
       if (selectedRepoId) {
@@ -741,7 +744,9 @@ export function ManualSessionComposer({
       discardDraftSave();
       // Keep the optimistic row visible — the sidebar swaps it for the real
       // session once the refetch lands. See OptimisticSession.resolvedId.
-      markOptimisticResolved(context.optimisticId, response.data.id);
+      if (context.optimisticId) {
+        markOptimisticResolved(context.optimisticId, response.data.id);
+      }
       applyCreatedSessionToSessionListCaches(queryClient, response.data);
       queryClient.invalidateQueries({ queryKey: queryKeys.sessions.all });
       setIsNavigatingAfterCreate(true);


### PR DESCRIPTION
## Summary

Creating a manual session from `/sessions/new` briefly showed two sidebar entries for the same pending session (route-owned draft row plus the composer’s optimistic row), which is confusing and undermines trust in the UI state. This PR makes the composer’s optimistic sidebar row optional and disables it for the `/sessions/new` page, then improves the post-create transition by using `router.replace` instead of `router.push` to avoid an extra route step.

## Changes

- Added `showOptimisticSidebarRow?: boolean` to `ManualSessionComposer` (default `true`) so callers can opt out when the page already renders its own draft row.
- Updated `ManualSessionCreatePageContent` to pass `showOptimisticSidebarRow={false}` and to navigate to `/sessions/:id` via `router.replace` after creation.
- Adjusted/expanded unit tests to assert no optimistic sidebar row is added on `/sessions/new` and that `router.replace` is used (not `router.push`) after create succeeds.

## Validation

- Updated `manual-session-create-page-content.test.tsx` assertions for optimistic-row behavior and navigation semantics.
- Ran the relevant frontend test suite (per existing repo test workflow) to ensure the new expectations pass for create/pending navigation scenarios.

[143.dev](https://143.dev) | [session f02fa5ec](https://143.dev/sessions/f02fa5ec-b788-4fbc-8b49-cbf6b0c98552)

<!-- 143 readiness -->
**143 readiness:** not available for this revision.

Preview: https://143.dev/previews/github/assembledhq/143/pull/1565?launch=1