### PR TITLE
Align New Automation page header container with standard dashboard layout

### DIFF
--- a/frontend/src/app/(dashboard)/automations/new/page.test.tsx
+++ b/frontend/src/app/(dashboard)/automations/new/page.test.tsx
@@ -522,6 +522,49 @@ describe("NewAutomationPage", () => {
     expect(screen.getByLabelText("Name")).toBeInTheDocument();
   });
 
+  it("aligns the new automation header with the standard page container", async () => {
+    server.use(
+      http.get("/api/v1/repositories", () =>
+        HttpResponse.json({
+          data: [
+            {
+              id: "repo-1",
+              org_id: "org-1",
+              integration_id: "int-1",
+              github_id: 1,
+              full_name: "acme/repo",
+              default_branch: "main",
+              private: false,
+              clone_url: "https://github.com/acme/repo.git",
+              installation_id: 10,
+              status: "active",
+              settings: {},
+              created_at: "2026-03-05T12:00:00Z",
+              updated_at: "2026-03-05T12:00:00Z",
+            },
+          ],
+          meta: {},
+        }),
+      ),
+    );
+
+    renderWithProviders(<NewAutomationPage />);
+
+    await screen.findByDisplayValue("Security sweep");
+
+    const heading = screen.getByRole("heading", { name: "New automation" });
+    const pageContainer = heading.closest('[data-slot="page-container"]');
+    const composerWrapper = screen.getByTestId("automation-composer").parentElement;
+
+    expect(pageContainer).toHaveAttribute(
+      "data-size",
+      "default",
+    );
+    expect(composerWrapper).not.toHaveClass(
+      "mx-auto",
+    );
+  });
+
   it("inserts selected @ mentions into the automation goal", async () => {
     const user = userEvent.setup();
 

--- a/frontend/src/app/(dashboard)/automations/new/page.tsx
+++ b/frontend/src/app/(dashboard)/automations/new/page.tsx
@@ -396,53 +396,52 @@ export default function NewAutomationPage() {
     (scheduleEnabled || hasEventTriggers);
 
   return (
-    <PageContainer size="wide">
+    <PageContainer size="default">
       <div className="space-y-6">
         <PageHeader
           title="New automation"
           description="Create a recurring agent for this team."
         />
 
-        <div className="mx-auto max-w-4xl">
-          <AutomationComposer
-            name={name}
-            onNameChange={setName}
-            iconValue={iconValue}
-            onIconChange={setIconValue}
-            goal={goal}
-            onGoalChange={setGoal}
-            repositoryId={repoId || undefined}
-            branch={
-              selectedBaseBranch || selectedRepo?.default_branch || undefined
-            }
-            agentType={effectiveAgentType}
-            goalEditorContainerRef={goalEditorRef}
-            goalImprovementControls={
-              <AutomationGoalImprovementControl
-                name={name}
-                goal={goal}
-                repositoryId={repoId || undefined}
-                scope={scope.trim() || undefined}
-                config={{
-                  schedule_type: scheduleEnabled ? "interval" : "none",
-                  triggers: productTriggers,
-                  github_event_filters: githubEventFilters,
-                  event_triggers: pagerDutyEventTriggers,
-                  base_branch: selectedBaseBranch.trim() || undefined,
-                  agent_type: effectiveAgentType,
-                  model,
-                  reasoning_effort:
-                    showReasoningSelector && reasoningEffort
-                      ? reasoningEffort
-                      : undefined,
-                  pre_pr_review_loops: effectivePrePRReviewLoops,
-                }}
-                disabled={createMutation.isPending || redirecting}
-                onDraftApply={setGoal}
-              />
-            }
-            footerControls={
-              <>
+        <AutomationComposer
+          name={name}
+          onNameChange={setName}
+          iconValue={iconValue}
+          onIconChange={setIconValue}
+          goal={goal}
+          onGoalChange={setGoal}
+          repositoryId={repoId || undefined}
+          branch={
+            selectedBaseBranch || selectedRepo?.default_branch || undefined
+          }
+          agentType={effectiveAgentType}
+          goalEditorContainerRef={goalEditorRef}
+          goalImprovementControls={
+            <AutomationGoalImprovementControl
+              name={name}
+              goal={goal}
+              repositoryId={repoId || undefined}
+              scope={scope.trim() || undefined}
+              config={{
+                schedule_type: scheduleEnabled ? "interval" : "none",
+                triggers: productTriggers,
+                github_event_filters: githubEventFilters,
+                event_triggers: pagerDutyEventTriggers,
+                base_branch: selectedBaseBranch.trim() || undefined,
+                agent_type: effectiveAgentType,
+                model,
+                reasoning_effort:
+                  showReasoningSelector && reasoningEffort
+                    ? reasoningEffort
+                    : undefined,
+                pre_pr_review_loops: effectivePrePRReviewLoops,
+              }}
+              disabled={createMutation.isPending || redirecting}
+              onDraftApply={setGoal}
+            />
+          }
+          footerControls={
+            <>
                 <Select value={repoId} onValueChange={setSelectedRepoId}>
                   <SelectTrigger
                     className="h-8 w-full border-transparent bg-muted/25 shadow-none hover:bg-muted/50 sm:w-[210px]"
@@ -1051,34 +1050,33 @@ export default function NewAutomationPage() {
                     </div>
                   </SheetContent>
                 </Sheet>
-              </>
-            }
-            submitArea={
-              <div className="flex items-center gap-3">
-                {createMutation.isError && (
-                  <p className="text-xs text-destructive">
-                    Failed to create automation. Please try again.
-                  </p>
+            </>
+          }
+          submitArea={
+            <div className="flex items-center gap-3">
+              {createMutation.isError && (
+                <p className="text-xs text-destructive">
+                  Failed to create automation. Please try again.
+                </p>
+              )}
+              <Button
+                onClick={() => createMutation.mutate()}
+                disabled={
+                  !canSubmit || createMutation.isPending || redirecting
+                }
+              >
+                {createMutation.isPending || redirecting ? (
+                  <>
+                    <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                    Creating...
+                  </>
+                ) : (
+                  "Create automation"
                 )}
-                <Button
-                  onClick={() => createMutation.mutate()}
-                  disabled={
-                    !canSubmit || createMutation.isPending || redirecting
-                  }
-                >
-                  {createMutation.isPending || redirecting ? (
-                    <>
-                      <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                      Creating...
-                    </>
-                  ) : (
-                    "Create automation"
-                  )}
-                </Button>
-              </div>
-            }
-          />
-        </div>
+              </Button>
+            </div>
+          }
+        />
       </div>
     </PageContainer>
   );


### PR DESCRIPTION
## Summary

The new automation form page was using a different layout container than the rest of the automations dashboard, causing the header/content alignment to drift from the expected UI. This change updates `/automations/new` to use the same standard `PageContainer size="default"` wrapper and removes the extra centered `mx-auto max-w-4xl` wrapper so the header and composer align consistently.

## Changes

- Switch `NewAutomationPage` from `PageContainer size="wide"` to `PageContainer size="default"`.
- Remove the inner `div` wrapper that added `mx-auto max-w-4xl`, letting the composer naturally follow the standard page container sizing.
- Add a regression test asserting the heading aligns to the standard `data-slot="page-container"` and that the composer wrapper no longer includes `mx-auto`.

## Validation

- Frontend test update: `frontend/src/app/(dashboard)/automations/new/page.test.tsx`
  - Added: `aligns the new automation header with the standard page container`
- Ran the relevant test suite/CI for the frontend (per existing repo test workflow).

[143.dev](https://143.dev) | [session 81e8c048](https://143.dev/sessions/81e8c048-7be3-4b2c-8c51-79d88c750f3b)

<!-- 143 readiness -->
**143 readiness:** not available for this revision.

Preview: https://143.dev/previews/github/assembledhq/143/pull/1566?launch=1