### PR TITLE
Fix merge-when-ready false "not in a mergeable state" failures

### DIFF
--- a/internal/api/handlers/pull_requests.go
+++ b/internal/api/handlers/pull_requests.go
@@ -269,6 +269,8 @@ func (h *PullRequestHandler) Merge(w http.ResponseWriter, r *http.Request) {
 	resp, err := h.service.MergePullRequest(r.Context(), orgID, pullRequestID, user.ID)
 	if err != nil {
 		switch {
+		case errors.Is(err, ghservice.ErrPullRequestNotYetMergeable):
+			writeError(w, r, http.StatusConflict, "PR_NOT_MERGEABLE", "Pull request checks are still running", err)
 		case errors.Is(err, ghservice.ErrPullRequestNotMergeable):
 			writeError(w, r, http.StatusConflict, "PR_NOT_MERGEABLE", "Pull request is not in a mergeable state", err)
 		case errors.Is(err, ghservice.ErrNoMergeMethodAllowed):

--- a/internal/db/pull_requests.go
+++ b/internal/db/pull_requests.go
@@ -385,6 +385,31 @@ func (s *PullRequestStore) ClaimMergeWhenReadyForProcessing(ctx context.Context,
 	return res.RowsAffected() > 0, nil
 }
 
+// ReleaseMergeWhenReadyClaim returns a claimed (merging) merge-when-ready
+// request to the queued state so it is retried later. Used when a transient
+// block — checks still running, mergeability still being computed by GitHub —
+// is observed after the claim. It preserves the requesting user, head SHA, and
+// health version and clears any prior error. No-op if the row is not currently
+// in the merging state (e.g. it was cancelled or superseded meanwhile).
+func (s *PullRequestStore) ReleaseMergeWhenReadyClaim(ctx context.Context, orgID, id uuid.UUID) error {
+	query := `
+		UPDATE pull_requests
+		SET merge_when_ready_state = @state,
+			merge_when_ready_error = '',
+			merge_when_ready_updated_at = now(),
+			updated_at = now()
+		WHERE id = @id
+		  AND org_id = @org_id
+		  AND merge_when_ready_state = 'merging'`
+
+	_, err := s.db.Exec(ctx, query, pgx.NamedArgs{
+		"id":     id,
+		"org_id": orgID,
+		"state":  models.PullRequestMergeWhenReadyStateQueued,
+	})
+	return err
+}
+
 func (s *PullRequestStore) MarkMergeWhenReadySucceeded(ctx context.Context, orgID, id uuid.UUID) error {
 	return s.markMergeWhenReadyTerminal(ctx, orgID, id, models.PullRequestMergeWhenReadyStateSucceeded, "")
 }

--- a/internal/db/pull_requests_test.go
+++ b/internal/db/pull_requests_test.go
@@ -455,3 +455,27 @@ func TestPullRequestStore_ClaimMergeWhenReadyForProcessing(t *testing.T) {
 		})
 	}
 }
+
+func TestPullRequestStore_ReleaseMergeWhenReadyClaim(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "pgxmock pool should initialize")
+	defer mock.Close()
+
+	store := NewPullRequestStore(mock)
+	orgID := uuid.New()
+	prID := uuid.New()
+
+	mock.ExpectExec("UPDATE pull_requests[\\s\\S]*merge_when_ready_state = @state[\\s\\S]*merge_when_ready_error = ''[\\s\\S]*merge_when_ready_state = 'merging'").
+		WithArgs(pgx.NamedArgs{
+			"id":     prID,
+			"org_id": orgID,
+			"state":  models.PullRequestMergeWhenReadyStateQueued,
+		}).
+		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
+
+	err = store.ReleaseMergeWhenReadyClaim(context.Background(), orgID, prID)
+	require.NoError(t, err, "ReleaseMergeWhenReadyClaim should return a claimed intent to queued without error")
+	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
+}

--- a/internal/services/github/pr_merge.go
+++ b/internal/services/github/pr_merge.go
@@ -13,9 +13,19 @@ import (
 )
 
 // ErrPullRequestNotMergeable is returned when a caller invokes MergePullRequest
-// on a PR that is not currently in a clean, mergeable state. The handler maps
-// this to HTTP 409 so the UI can refresh its view of PR health.
+// on a PR that is not currently in a clean, mergeable state for a terminal
+// reason a human must resolve (merge conflicts or failed checks). The handler
+// maps this to HTTP 409 so the UI can refresh its view of PR health.
 var ErrPullRequestNotMergeable = errors.New("pull request is not in a mergeable state")
+
+// ErrPullRequestNotYetMergeable is returned when a PR is not mergeable for a
+// transient reason that is expected to clear on its own — GitHub still
+// computing mergeability, required checks still running, or branch protection
+// temporarily blocking. It is distinct from ErrPullRequestNotMergeable so the
+// merge-when-ready loop can keep waiting (rather than failing the request)
+// when the pre-merge re-sync catches checks mid-registration. The manual merge
+// handler still maps it to HTTP 409 — the PR is simply not mergeable yet.
+var ErrPullRequestNotYetMergeable = errors.New("pull request is not yet in a mergeable state")
 
 // ErrPullRequestHeadChanged is returned when an automated merge was scoped to
 // an earlier PR head SHA and the final pre-merge sync observes a different SHA.
@@ -96,6 +106,17 @@ func (s *PRService) mergePullRequest(ctx context.Context, orgID, pullRequestID, 
 		return nil, fmt.Errorf("build pull request health: %w", err)
 	}
 	if !health.CanMerge {
+		// Distinguish transient blocks (checks still running, mergeability still
+		// being computed by GitHub) from terminal ones (conflicts, failed
+		// checks). The re-sync above can legitimately observe checks that
+		// registered between the caller's CanMerge gate and this one — most
+		// commonly right after PR creation, when GitHub reports the PR clean
+		// before CI registers its pending check runs. Surfacing those as
+		// terminal would fail an otherwise-healthy merge-when-ready request.
+		if mergeBlockIsTransient(health) {
+			return nil, fmt.Errorf("%w: merge_state=%s, checks=%d",
+				ErrPullRequestNotYetMergeable, health.MergeState, len(health.Checks))
+		}
 		return nil, fmt.Errorf("%w: merge_state=%s, has_conflicts=%t, failing_tests=%d, checks=%d",
 			ErrPullRequestNotMergeable, health.MergeState, health.HasConflicts, health.FailingTestCount, len(health.Checks))
 	}

--- a/internal/services/github/pr_merge_when_ready.go
+++ b/internal/services/github/pr_merge_when_ready.go
@@ -14,9 +14,26 @@ import (
 var (
 	ErrPullRequestMergeWhenReadyNotQueueable = errors.New("pull request cannot be queued for merge when ready")
 	ErrPullRequestMergeWhenReadyInProgress   = errors.New("pull request merge when ready is already in progress")
+	// ErrPullRequestMergeWhenReadyChecksPending signals that a merge-when-ready
+	// request looks mergeable only because GitHub has not registered any check
+	// runs yet for a freshly requested head. The worker handler translates this
+	// into a short retryable delay so we re-evaluate once checks appear (or
+	// conclude the repo genuinely has no CI after the grace window) instead of
+	// merging in the eventual-consistency gap right after PR creation.
+	ErrPullRequestMergeWhenReadyChecksPending = errors.New("pull request merge when ready: checks have not registered yet")
 )
 
 const mergeWhenReadyMergingStaleAfter = 15 * time.Minute
+
+// mergeWhenReadyChecksRegisterGrace is how long we wait for GitHub to register
+// check runs on a freshly requested head before concluding the repository has
+// no CI and proceeding to merge. GitHub creates check runs (status queued)
+// within a few seconds of a push and the list-check-runs API reflects them
+// immediately, so this is a several-fold margin over the eventual-consistency
+// window where the PR reports clean with an empty check-runs list. The grace
+// only ever delays repos with no CI — once any check registers, CanMerge gates
+// on it directly and this window no longer applies.
+const mergeWhenReadyChecksRegisterGrace = 30 * time.Second
 
 func (s *PRService) QueueMergeWhenReady(ctx context.Context, orgID, pullRequestID, userID uuid.UUID) (*models.PullRequestMergeWhenReadyStatus, error) {
 	pr, err := s.pullRequests.GetByID(ctx, orgID, pullRequestID)
@@ -108,6 +125,16 @@ func (s *PRService) ProcessMergeWhenReady(ctx context.Context, orgID, pullReques
 	}
 
 	if health.CanMerge {
+		if mergeWhenReadyShouldWaitForChecks(pr, health, time.Now()) {
+			// Mergeable only because no check runs have registered yet for a
+			// freshly requested head. Defer rather than merge: right after PR
+			// creation GitHub reports the PR clean with an empty check-runs list
+			// before CI registers, so merging here would land the PR before its
+			// checks even start. The retryable error re-evaluates once checks
+			// appear (flipping CanMerge to false until they pass) or, after the
+			// grace window, treats the repo as genuinely having no CI.
+			return ErrPullRequestMergeWhenReadyChecksPending
+		}
 		if pr.MergeWhenReadyRequestedBy == nil {
 			return s.pullRequests.MarkMergeWhenReadyFailed(ctx, orgID, pullRequestID, "Merge when ready is missing the requesting user.")
 		}
@@ -119,6 +146,17 @@ func (s *PRService) ProcessMergeWhenReady(ctx context.Context, orgID, pullReques
 			return nil
 		}
 		if _, err := s.mergePullRequest(ctx, orgID, pullRequestID, *pr.MergeWhenReadyRequestedBy, &pr.MergeWhenReadyHeadSHA); err != nil {
+			if errors.Is(err, ErrPullRequestNotYetMergeable) {
+				// The pre-merge re-sync caught a transient block (checks still
+				// running, mergeability still computing) after we had already
+				// claimed the merge. Release the claim back to queued so the
+				// next sync/reconcile retries instead of failing the user's
+				// merge-when-ready request with a misleading error.
+				if releaseErr := s.pullRequests.ReleaseMergeWhenReadyClaim(ctx, orgID, pullRequestID); releaseErr != nil {
+					return fmt.Errorf("merge when ready hit a transient block, then releasing the claim failed: %w", releaseErr)
+				}
+				return ErrPullRequestMergeWhenReadyChecksPending
+			}
 			reason := mergeWhenReadyFailureMessage(err)
 			if markErr := s.pullRequests.MarkMergeWhenReadyFailed(ctx, orgID, pullRequestID, reason); markErr != nil {
 				return fmt.Errorf("merge when ready failed (%s), then marking failed failed: %w", reason, markErr)
@@ -219,6 +257,44 @@ func mergeWhenReadyQueueability(health *models.PullRequestHealthResponse) (strin
 		}
 	}
 	return "", true
+}
+
+// mergeWhenReadyShouldWaitForChecks reports whether a CanMerge=true snapshot is
+// trustworthy only because GitHub has not yet registered any check runs for the
+// requested head. Within the grace window after the merge-when-ready request we
+// hold off so CI has a chance to register; once any check appears the checks
+// list is non-empty and CanMerge already gates on it, and after the window we
+// treat an empty list as "no CI configured" and let the merge proceed.
+func mergeWhenReadyShouldWaitForChecks(pr models.PullRequest, health *models.PullRequestHealthResponse, now time.Time) bool {
+	if len(health.Checks) > 0 {
+		return false
+	}
+	if pr.MergeWhenReadyRequestedAt == nil {
+		return false
+	}
+	return now.Sub(*pr.MergeWhenReadyRequestedAt) < mergeWhenReadyChecksRegisterGrace
+}
+
+// mergeBlockIsTransient reports whether a CanMerge=false health snapshot is
+// blocked by a condition expected to clear on its own — GitHub still computing
+// mergeability, required checks still running, or branch protection temporarily
+// blocking — rather than a terminal condition a human must fix (merge conflicts
+// or failed checks). It mirrors mergeWhenReadyQueueability's wait-vs-fail split
+// so the pre-merge re-sync inside mergePullRequest classifies blocks the same
+// way the queueing gate does.
+func mergeBlockIsTransient(health *models.PullRequestHealthResponse) bool {
+	if health.HasConflicts || health.CanResolveConflicts || health.MergeState == models.PullRequestMergeStateConflicted {
+		return false
+	}
+	if health.FailingTestCount > 0 || health.CanFixTests {
+		return false
+	}
+	for _, check := range health.Checks {
+		if check.Status == models.PullRequestCheckStatusFailed {
+			return false
+		}
+	}
+	return true
 }
 
 func mergeWhenReadyFailureMessage(err error) string {

--- a/internal/services/github/pr_merge_when_ready_test.go
+++ b/internal/services/github/pr_merge_when_ready_test.go
@@ -199,6 +199,96 @@ func TestPRServiceEnqueueMergeWhenReadyProcessingIncludesStaleMerging(t *testing
 	}
 }
 
+func TestMergeWhenReadyShouldWaitForChecks(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now().UTC()
+	withinGrace := now.Add(-mergeWhenReadyChecksRegisterGrace / 2)
+	pastGrace := now.Add(-mergeWhenReadyChecksRegisterGrace - time.Second)
+
+	tests := []struct {
+		name        string
+		requestedAt *time.Time
+		checks      []models.PullRequestCheckSummary
+		want        bool
+	}{
+		{
+			name:        "empty checks within grace waits",
+			requestedAt: &withinGrace,
+			want:        true,
+		},
+		{
+			name:        "empty checks past grace proceeds (no CI configured)",
+			requestedAt: &pastGrace,
+			want:        false,
+		},
+		{
+			name:        "registered checks never wait on the empty-checks gate",
+			requestedAt: &withinGrace,
+			checks:      []models.PullRequestCheckSummary{{Name: "build", Status: models.PullRequestCheckStatusPending}},
+			want:        false,
+		},
+		{
+			name:        "missing requested-at proceeds",
+			requestedAt: nil,
+			want:        false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			pr := models.PullRequest{MergeWhenReadyRequestedAt: tt.requestedAt}
+			health := &models.PullRequestHealthResponse{Checks: tt.checks}
+			require.Equal(t, tt.want, mergeWhenReadyShouldWaitForChecks(pr, health, now))
+		})
+	}
+}
+
+func TestMergeBlockIsTransient(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		health *models.PullRequestHealthResponse
+		want   bool
+	}{
+		{
+			name:   "pending checks are transient",
+			health: &models.PullRequestHealthResponse{MergeState: models.PullRequestMergeStateBlocked, Checks: []models.PullRequestCheckSummary{{Name: "test", Status: models.PullRequestCheckStatusPending}}},
+			want:   true,
+		},
+		{
+			name:   "mergeability still computing is transient",
+			health: &models.PullRequestHealthResponse{MergeState: models.PullRequestMergeStateMergeabilityPending},
+			want:   true,
+		},
+		{
+			name:   "conflicts are terminal",
+			health: &models.PullRequestHealthResponse{MergeState: models.PullRequestMergeStateConflicted, HasConflicts: true},
+			want:   false,
+		},
+		{
+			name:   "failed checks are terminal",
+			health: &models.PullRequestHealthResponse{MergeState: models.PullRequestMergeStateClean, Checks: []models.PullRequestCheckSummary{{Name: "test", Status: models.PullRequestCheckStatusFailed}}},
+			want:   false,
+		},
+		{
+			name:   "failing test count is terminal",
+			health: &models.PullRequestHealthResponse{MergeState: models.PullRequestMergeStateClean, FailingTestCount: 1},
+			want:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			derivePullRequestRepairActions(tt.health)
+			require.Equal(t, tt.want, mergeBlockIsTransient(tt.health))
+		})
+	}
+}
+
 func ptrString(v string) *string {
 	return &v
 }

--- a/internal/worker/handlers.go
+++ b/internal/worker/handlers.go
@@ -9584,7 +9584,19 @@ func newMergePullRequestWhenReadyHandler(services *Services, logger zerolog.Logg
 			Str("org_id", orgID.String()).
 			Str("pull_request_id", pullRequestID.String()).
 			Msg("starting merge_pull_request_when_ready job")
-		return services.PR.ProcessMergeWhenReady(ctx, orgID, pullRequestID)
+		if err := services.PR.ProcessMergeWhenReady(ctx, orgID, pullRequestID); err != nil {
+			if errors.Is(err, ghservice.ErrPullRequestMergeWhenReadyChecksPending) {
+				// The PR looks mergeable only because GitHub has not registered
+				// its check runs yet. Retry on a short fixed delay (without
+				// consuming the attempt budget) so we re-evaluate once checks
+				// appear or the grace window elapses, rather than thrashing the
+				// queue with exponential backoff or dead-lettering.
+				retryAfter := 20 * time.Second
+				return &RetryableError{Err: err, RetryAfter: &retryAfter}
+			}
+			return err
+		}
+		return nil
 	}
 }
 


### PR DESCRIPTION
## Summary

The "create PR and merge when ready" button frequently failed with **"Merge when ready stopped: Pull request is not in a mergeable state"** while CI checks were still running — a straight-down-the-line use case. The cause is the eventual-consistency window right after PR creation, where GitHub briefly reports the PR `clean` with an empty check-runs list before CI registers. This PR teaches the merge-when-ready flow to treat "checks haven't registered/finished yet" as a transient wait condition instead of a terminal failure.

## Changes

- **Transient vs. terminal not-mergeable** (`pr_merge.go`, `pr_merge_when_ready.go`): the loop evaluates `CanMerge` twice (in `ProcessMergeWhenReady`, then again after a fresh re-sync inside `mergePullRequest`); a flip to `CanMerge=false` caused by checks registering between the two builds now raises the new `ErrPullRequestNotYetMergeable` (transient) rather than the terminal `ErrPullRequestNotMergeable`. A transient block **releases the claim back to `queued`** (new `ReleaseMergeWhenReadyClaim` store method) so the next sync/reconcile retries instead of failing the request.
- **Empty-checks grace window** (`pr_merge_when_ready.go`): `checksAllowMerge` treats an empty check list as "no CI → mergeable". Merge-when-ready now defers for a 30s grace window after the request when the check list is empty, giving CI time to register. Deferral uses a short `RetryableError` (`handlers.go`) so genuinely-no-CI repos still merge within ~40s. Scoped to merge-when-ready only — the manual merge button and health UI are unchanged (manual merge just gets a clearer "checks are still running" 409 message).

## Validation

- `go build ./...` — clean
- `go test ./internal/services/github/ ./internal/db/ ./internal/api/handlers/` — pass
- `make lint` — 0 issues
- New tests: `TestMergeWhenReadyShouldWaitForChecks`, `TestMergeBlockIsTransient`, `TestPullRequestStore_ReleaseMergeWhenReadyClaim`

🤖 Generated with [Claude Code](https://claude.com/claude-code)