### PR TITLE
Clean up after #1563: fix stale startup test, move design doc to implemented

### DIFF
--- a/cmd/server/main_test.go
+++ b/cmd/server/main_test.go
@@ -439,10 +439,12 @@ func TestBuildWorkerMetadataProvider_IncludesSandboxCapacity(t *testing.T) {
 	require.Equal(t, 4, metadata["max_active_sandboxes"], "worker metadata should expose the per-machine sandbox cap")
 }
 
-// TestMainStartupRunsRehydrateBeforeWorkers guards the sandbox-auth socket
-// invariant: process workers must not be able to call Listen for a new job
-// while the boot-time rehydrate pass is still restoring live listeners.
-func TestMainStartupRunsRehydrateBeforeWorkers(t *testing.T) {
+// TestMainStartupReconcilesSocketsBeforeWorkers guards the sandbox-auth socket
+// invariant: the worker must re-pin credential sockets for containers that
+// survived a restart before process workers can claim jobs, so an in-flight
+// agent's git push never races an empty socket. The boot-time reconciler pass
+// (socketReconciler.ReconcileOnce) supersedes the old node-scoped rehydrate.
+func TestMainStartupReconcilesSocketsBeforeWorkers(t *testing.T) {
 	t.Parallel()
 
 	src, err := os.ReadFile("main.go")
@@ -450,10 +452,10 @@ func TestMainStartupRunsRehydrateBeforeWorkers(t *testing.T) {
 
 	body := string(src)
 	startWorkers := strings.Index(body, "processWorkers = startProcessWorkers(")
-	rehydrate := strings.Index(body, "orch.RehydrateSandboxAuthListeners(")
+	reconcile := strings.Index(body, "socketReconciler.ReconcileOnce(")
 	require.NotEqual(t, -1, startWorkers, "startup should still start process workers")
-	require.NotEqual(t, -1, rehydrate, "startup should still run sandbox auth rehydrate")
-	require.Less(t, rehydrate, startWorkers, "sandbox auth rehydrate must run before process workers can claim jobs")
+	require.NotEqual(t, -1, reconcile, "startup should run the sandbox auth socket reconciler")
+	require.Less(t, reconcile, startWorkers, "sandbox auth socket reconcile must run before process workers can claim jobs")
 }
 
 func TestMainStartupDoesNotSweepSandboxAuthSocketDirs(t *testing.T) {

--- a/docs/design/implemented/109-sandbox-auth-socket-ownership.md
+++ b/docs/design/implemented/109-sandbox-auth-socket-ownership.md
@@ -46,7 +46,7 @@ Sandboxed coding agents push to GitHub through a per-session Unix-domain socket.
 The host listens on `<socket-dir>/<session-id>/sock`; the sandbox dials it at
 `/run/143-auth/sock` via a directory bind-mount, and the host replies with a
 fresh GitHub token resolved per request (see
-[implemented/65-unified-coding-credentials.md](../implemented/65-unified-coding-credentials.md)
+[65-unified-coding-credentials.md](65-unified-coding-credentials.md)
 and `internal/services/sandboxauth/`). The per-request resolve is deliberate:
 it lets each push pick up token refreshes and org-policy changes without
 restarting the session.

--- a/internal/services/agent/sandbox_auth_socket_reconciler.go
+++ b/internal/services/agent/sandbox_auth_socket_reconciler.go
@@ -56,7 +56,7 @@ type SandboxAuthSessionLoader interface {
 // credential sockets in lockstep with the sandbox containers alive on this
 // host. It is the worker-side owner of socket lifetime under the
 // worker-owns-the-socket model (see
-// docs/design/future/109-sandbox-auth-socket-ownership.md):
+// docs/design/implemented/109-sandbox-auth-socket-ownership.md):
 //
 //   - The per-turn session executor still acquires/releases a short-lived
 //     holder lease over the remote broker (which keeps the socket open during a


### PR DESCRIPTION
Cleanups after #1563 (worker-owned sandbox auth socket) merged.

## Fixes a broken test on `main`
`TestMainStartupRunsRehydrateBeforeWorkers` asserted that `cmd/server/main.go` still calls `orch.RehydrateSandboxAuthListeners(...)`, which #1563 removed. The test is **currently failing on `main`** (it was merged while CI was still pending). I verified the failure and the fix locally (`go test ./cmd/server/`).

It's renamed to `TestMainStartupReconcilesSocketsBeforeWorkers` and re-pointed at `socketReconciler.ReconcileOnce(...)` — the boot-time pass that now guards the same invariant ("re-pin credential sockets before process workers can claim jobs"), so the regression guard is preserved rather than dropped.

## Doc housekeeping
- Move the design doc `docs/design/future/` → `docs/design/implemented/` (it's marked `Status: Implemented`).
- Fix its now-same-directory relative link to `65-unified-coding-credentials.md`.
- Re-point the reconciler's source comment reference to the `implemented/` path.

## Testing
`go test ./cmd/server/` sandbox-auth startup/ordering tests pass; gofmt + lint-stores pre-commit hooks pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
