### PR TITLE
Fix frontend session creation tests for correct redirects and stable dropdown rendering

### DIFF
--- a/frontend/src/app/(dashboard)/sessions/new/manual-session-create-page-content.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/new/manual-session-create-page-content.test.tsx
@@ -173,6 +173,25 @@ vi.mock("next/navigation", () => ({
   }),
 }));
 
+vi.mock("@/components/ui/dropdown-menu", () => ({
+  DropdownMenu: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DropdownMenuTrigger: ({ children }: { children: React.ReactNode; asChild?: boolean }) => <>{children}</>,
+  DropdownMenuContent: ({ children }: { children: React.ReactNode }) => <div role="menu">{children}</div>,
+  DropdownMenuItem: ({
+    children,
+    className,
+    onClick,
+  }: {
+    children: React.ReactNode;
+    className?: string;
+    onClick?: () => void;
+  }) => (
+    <button type="button" role="menuitem" className={className} onClick={onClick}>
+      {children}
+    </button>
+  ),
+}));
+
 vi.mock("@/components/no-repos-warning", () => ({
   NoReposWarning: () => <div data-testid="no-repos-warning" />,
 }));
@@ -670,6 +689,9 @@ describe("ManualSessionCreatePageContent", () => {
     const linearInput = await screen.findByRole("textbox", { name: "Linear issue id or URL" });
     await user.type(linearInput, "ACS-1234");
     await user.click(screen.getByRole("button", { name: "Add" }));
+    await waitFor(() => {
+      expect(screen.queryByRole("textbox", { name: "Linear issue id or URL" })).not.toBeInTheDocument();
+    });
     await user.click((await screen.findAllByRole("button", { name: "Start session" }))[0]);
 
     await waitFor(() => {

--- a/frontend/src/app/(dashboard)/sessions/new/page.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/new/page.test.tsx
@@ -7,10 +7,10 @@ import { renderWithProviders, screen, userEvent, waitFor } from '@/test/test-uti
 import { server } from '@/test/mocks/server';
 import { ManualSessionCreatePageContent } from './manual-session-create-page-content';
 
-const pushMock = vi.fn();
+const replaceMock = vi.fn();
 
 vi.mock('next/navigation', () => ({
-  useRouter: () => ({ push: pushMock, back: vi.fn() }),
+  useRouter: () => ({ replace: replaceMock, push: vi.fn(), back: vi.fn() }),
   useSearchParams: () => new URLSearchParams(),
 }));
 
@@ -76,7 +76,7 @@ describe('ManualSessionCreatePage', () => {
       }),
     );
 
-    pushMock.mockReset();
+    replaceMock.mockReset();
     renderWithProviders(<ManualSessionCreatePageContent />);
 
     await user.click(screen.getByRole('button', { name: 'Add files or photos' }));
@@ -89,7 +89,7 @@ describe('ManualSessionCreatePage', () => {
     await user.click(screen.getByRole('button', { name: 'Start session' }));
 
     await waitFor(() => {
-      expect(pushMock).toHaveBeenCalledWith('/sessions/session-manual-chat-1');
+      expect(replaceMock).toHaveBeenCalledWith('/sessions/session-manual-chat-1');
     });
   }, 10000);
 
@@ -150,7 +150,7 @@ describe('ManualSessionCreatePage', () => {
       }),
     );
 
-    pushMock.mockReset();
+    replaceMock.mockReset();
     renderWithProviders(<ManualSessionCreatePageContent />);
 
     const textarea = screen.getByPlaceholderText('Tell the agent what to do...');
@@ -163,7 +163,7 @@ describe('ManualSessionCreatePage', () => {
     await user.click(screen.getByRole('button', { name: 'Start session' }));
 
     await waitFor(() => {
-      expect(pushMock).toHaveBeenCalledWith('/sessions/session-with-reference');
+      expect(replaceMock).toHaveBeenCalledWith('/sessions/session-with-reference');
     });
   });
 


### PR DESCRIPTION
## Summary

Frontend tests were failing due to mismatched navigation behavior (expecting `router.push` when the page now uses `router.replace`) and flaky async UI updates around Radix dropdown interactions. This PR updates the test contracts to match current routing/UX behavior and makes the dropdown rendering deterministic so assertions and `act(...)` timing are reliable.

## Changes

- Updated `page.test.tsx` to mock and assert `router.replace(...)` instead of `router.push(...)`, including resetting the correct mock between tests.
- Stabilized `manual-session-create-page-content.test.tsx` by mocking `@/components/ui/dropdown-menu` to avoid Radix async focus/presence noise.
- Added an explicit wait for the Linear issue input textbox to disappear before starting the session to ensure the UI is fully settled before redirect assertions.

## Validation

- `npm test -- --run 'src/app/(dashboard)/sessions/new/page.test.tsx' 'src/app/(dashboard)/sessions/new/manual-session-create-page-content.test.tsx'`
- `npm run typecheck`
- `npm run lint`
- `npm run build`

[143.dev](https://143.dev) | [session cc0113e4](https://143.dev/sessions/cc0113e4-0be7-40f0-a856-0c34cc4ff168)

<!-- 143 readiness -->
**143 readiness:** not available for this revision.

Preview: https://143.dev/previews/github/assembledhq/143/pull/1570?launch=1