### PR TITLE
Prevent inline code from overflowing markdown line boundaries

### DIFF
--- a/frontend/src/components/markdown.test.tsx
+++ b/frontend/src/components/markdown.test.tsx
@@ -22,6 +22,25 @@ describe("MarkdownContent", () => {
     expect(code.closest("pre")).toBeNull();
   });
 
+  it("wraps long inline code without overflowing its line box", () => {
+    render(
+      <MarkdownContent content="Use `luxonDateTimeToMomentInTimezone(adjust_start.toJSDate(), UserManager.timezone())` here" />
+    );
+
+    const code = screen.getByText(
+      "luxonDateTimeToMomentInTimezone(adjust_start.toJSDate(), UserManager.timezone())"
+    );
+    expect(code).toHaveClass("break-all", {
+      exact: false,
+    });
+    expect(code).toHaveClass("box-decoration-clone", {
+      exact: false,
+    });
+    expect(code).toHaveClass("leading-relaxed", {
+      exact: false,
+    });
+  });
+
   it("renders fenced code blocks with language", () => {
     const md = "```js\nconsole.log('hi');\n```";
     render(<MarkdownContent content={md} />);

--- a/frontend/src/components/markdown.tsx
+++ b/frontend/src/components/markdown.tsx
@@ -23,7 +23,10 @@ function Code({ className, children, ...props }: React.ComponentProps<"code">) {
 
   return (
     <code
-      className="rounded bg-background border border-border px-1 py-0.5 font-mono text-xs"
+      className={cn(
+        "box-decoration-clone break-all whitespace-normal rounded border border-border bg-background px-1 py-0.5 font-mono text-xs leading-relaxed",
+        className
+      )}
       {...props}
     >
       {children}


### PR DESCRIPTION
## Summary

Inline code rendered in Markdown can overflow its line box when tokens are long, breaking layout and making text harder to read. This change updates the inline `<code>` styling to wrap safely within the line (including decoration across wrapped lines) and adds a regression test to lock in the behavior.

## Changes

- Updated `frontend/src/components/markdown.tsx` inline `Code` component classes to:
  - break long tokens (`break-all`) so they wrap instead of overflowing
  - ensure background/border decoration clones across wrapped lines (`box-decoration-clone`)
  - use a safer line height (`leading-relaxed`) to keep border/padding aligned
- Added a test in `frontend/src/components/markdown.test.tsx` asserting the expected classes are applied for long inline code strings.

## Validation

- `npm test -- markdown.test.tsx`
- `npm run typecheck`
- `npm run lint`
- `npm run build`
- Build emitted only the existing Next.js middleware convention deprecation warning.

[143.dev](https://143.dev) | [session 001eab24](https://143.dev/sessions/001eab24-94ab-4476-a44b-76597f981013)

<!-- 143 readiness -->
**143 readiness:** not available for this revision.

Preview: https://143.dev/previews/github/assembledhq/143/pull/1572?launch=1