### PR TITLE
Fix home-rooted cache restore for Go's read-only module cache

### DIFF
--- a/internal/services/preview/dependency_cache.go
+++ b/internal/services/preview/dependency_cache.go
@@ -275,7 +275,14 @@ func (c *SharedDependencyCache) RestorePathCache(ctx context.Context, sb *agent.
 	if err != nil {
 		return fmt.Errorf("dependency cache restore: %w", err)
 	}
-	cleanCmd := fmt.Sprintf("cd %s && rm -rf -- %s", shellQuote(rootDir), strings.Join(cleanArgs, " "))
+	// chmod -R u+w before removing: Go marks its module cache
+	// ($HOME/go/pkg/mod) read-only — both the files (0444) and the containing
+	// directories (0555) — so a plain `rm -rf` can't unlink them and exits 1,
+	// which previously failed the home-rooted Go cache restore and forced a
+	// cold rebuild every launch. Errors are suppressed because the paths may
+	// not exist yet on a first restore.
+	pathArgs := strings.Join(cleanArgs, " ")
+	cleanCmd := fmt.Sprintf("cd %s && chmod -R u+w -- %s 2>/dev/null; rm -rf -- %s", shellQuote(rootDir), pathArgs, pathArgs)
 	if exitCode, err := c.executor.Exec(ctx, sb, cleanCmd, io.Discard, io.Discard); err != nil || exitCode != 0 {
 		return fmt.Errorf("dependency cache restore: remove existing paths exited %d: %w", exitCode, err)
 	}

--- a/internal/services/preview/dependency_cache_test.go
+++ b/internal/services/preview/dependency_cache_test.go
@@ -676,6 +676,7 @@ func TestSharedDependencyCache_RestoreStreamsExtractWithoutSandboxTempBlob(t *te
 	require.NoError(t, err, "Restore should stream and extract a valid cache blob")
 	calls := strings.Join(exec.calls(), "\n")
 	require.Contains(t, calls, "tar xzf -", "Restore should extract the archive from stdin")
+	require.Contains(t, calls, "chmod -R u+w", "Restore should make read-only paths (e.g. Go's module cache) writable before rm -rf")
 	require.NotContains(t, calls, "/tmp/preview-dependency-cache-", "Restore should not stage a compressed blob in sandbox /tmp")
 	require.NotContains(t, strings.Join(exec.writtenFilePaths(), "\n"), "/tmp/preview-dependency-cache-", "Restore should not write the compressed blob as a sandbox file")
 }


### PR DESCRIPTION
## Summary

The home-rooted dependency cache (`build_cache_home_restore`, used for Go's `$HOME/.cache/go-build` and `$HOME/go/pkg/mod`) clears the target paths with `rm -rf` before extracting the cached archive. Go marks its **module cache read-only** — files `0444` and the containing directories `0555` — so `rm` cannot unlink them and the command exits `1`. The restore phase then fails, and any preview with a large Go module cache (e.g. the Assembled monolith) re-downloads and recompiles **everything cold on every launch** — which OOM-kills the sandbox at the 8 GiB cap.

Observed in a real preview: `build_cache_home_restore: dependency cache restore: remove existing paths exited 1`, immediately followed by hundreds of `go: downloading …` lines and an exit-137 OOM in the service build.

## Changes

- `internal/services/preview/dependency_cache.go`: `chmod -R u+w` the target paths before `rm -rf` (errors suppressed since the paths may not exist on a first restore). This lets the restore clear the read-only Go module cache and proceed, so the cache actually persists and builds become incremental.
- Add a restore-test assertion that the clean step includes `chmod -R u+w`.

## Validation

- `go build ./internal/services/preview/` — pass
- `go test ./internal/services/preview/ -run DependencyCache` — pass (existing + new assertion)
