### PR TITLE
Add per-button loading spinners for restart/resume in Previews

### DIFF
--- a/frontend/src/app/(dashboard)/previews/page.test.tsx
+++ b/frontend/src/app/(dashboard)/previews/page.test.tsx
@@ -505,6 +505,152 @@ describe("PreviewsPage", () => {
     ).toBeInTheDocument();
   });
 
+  it("shows a spinner on the start-latest button in the recent section while request is in flight", async () => {
+    const restartReleased = deferred<void>();
+    const mutationPaths: string[] = [];
+    installPreviewHandlers({
+      running: [],
+      resumable: [],
+      recent: [
+        preview({
+          preview_group_id: "recent-group",
+          branch: "fix/startup-error",
+          status: "failed",
+          stopped_reason: "error",
+          preview_url: undefined,
+        }),
+      ],
+    });
+    server.use(
+      http.post("*/api/v1/previews/current/:id/start-latest", async ({ request }) => {
+        mutationPaths.push(new URL(request.url).pathname);
+        await restartReleased.promise;
+        return HttpResponse.json({ data: preview({}) });
+      }),
+    );
+
+    renderWithProviders(<PreviewsPage />);
+
+    const recentSection = await screen.findByRole("region", {
+      name: /recent/i,
+    });
+    const restartButton = within(recentSection).getAllByRole("button", {
+      name: /restart preview from the latest source state/i,
+    })[0];
+
+    await userEvent.click(restartButton);
+
+    await waitFor(() => {
+      expect(mutationPaths).toEqual([
+        "/api/v1/previews/current/recent-group/start-latest",
+      ]);
+    });
+    expect(restartButton).toHaveAttribute("data-loading", "true");
+    expect(
+      restartButton.querySelector('[data-slot="button-spinner"]'),
+    ).toBeInTheDocument();
+
+    restartReleased.resolve();
+  });
+
+  it("shows a spinner on the resume button in the resumable section while request is in flight", async () => {
+    const restartReleased = deferred<void>();
+    const mutationPaths: string[] = [];
+    installPreviewHandlers({
+      running: [],
+      resumable: [
+        preview({
+          preview_group_id: "resumable-group",
+          branch: "feature/paused",
+          status: "ready",
+          resumable: true,
+          preview_url: undefined,
+        }),
+      ],
+      recent: [],
+    });
+    server.use(
+      http.post("*/api/v1/previews/current/:id/restart", async ({ request }) => {
+        mutationPaths.push(new URL(request.url).pathname);
+        await restartReleased.promise;
+        return HttpResponse.json({ data: preview({}) });
+      }),
+    );
+
+    renderWithProviders(<PreviewsPage />);
+
+    const resumableSection = await screen.findByRole("region", {
+      name: /ready to resume/i,
+    });
+    const resumeButton = within(resumableSection).getAllByRole("button", {
+      name: /resume/i,
+    })[0];
+
+    await userEvent.click(resumeButton);
+
+    await waitFor(() => {
+      expect(mutationPaths).toEqual([
+        "/api/v1/previews/current/resumable-group/restart",
+      ]);
+    });
+    expect(resumeButton).toHaveAttribute("data-loading", "true");
+    expect(
+      resumeButton.querySelector('[data-slot="button-spinner"]'),
+    ).toBeInTheDocument();
+
+    restartReleased.resolve();
+  });
+
+  it("shows a spinner on the start-latest button in the running section while request is in flight", async () => {
+    const startLatestReleased = deferred<void>();
+    const mutationPaths: string[] = [];
+    installPreviewHandlers({
+      running: [
+        preview({
+          preview_group_id: "outdated-running-group",
+          branch: "feature/stale",
+          status: "ready",
+          freshness: "outdated",
+          running_commit_sha: "aabb1122",
+          latest_commit_sha: "ccdd3344",
+          preview_url: "https://preview.143.dev",
+        }),
+      ],
+      resumable: [],
+      recent: [],
+    });
+    server.use(
+      http.post("*/api/v1/previews/current/:id/start-latest", async ({ request }) => {
+        mutationPaths.push(new URL(request.url).pathname);
+        await startLatestReleased.promise;
+        return HttpResponse.json({ data: preview({}) });
+      }),
+    );
+
+    renderWithProviders(<PreviewsPage />);
+
+    const runningSection = await screen.findByRole("region", {
+      name: /running/i,
+    });
+    const restartLatestButton = within(runningSection).getAllByRole("button", {
+      name: /restart preview from the latest source state/i,
+    })[0];
+
+    await userEvent.click(restartLatestButton);
+
+    await waitFor(() => {
+      expect(mutationPaths).toEqual([
+        "/api/v1/previews/current/outdated-running-group/start-latest",
+      ]);
+    });
+    expect(restartLatestButton).toHaveAttribute("data-loading", "true");
+    expect(
+      restartLatestButton.querySelector('[data-slot="button-spinner"]'),
+    ).toBeInTheDocument();
+
+    startLatestReleased.resolve();
+  });
+
   it("does not render unsafe external preview or source URLs as links", async () => {
     installPreviewHandlers({
       running: [

--- a/frontend/src/app/(dashboard)/previews/page.tsx
+++ b/frontend/src/app/(dashboard)/previews/page.tsx
@@ -250,6 +250,8 @@ function SectionRows({
   onStop,
   onRestart,
   onStartLatest,
+  isRestartPending,
+  isStartLatestPending,
 }: {
   scope: PreviewScope;
   previews: PreviewCurrentResponse[];
@@ -260,6 +262,8 @@ function SectionRows({
   onStop: (preview: PreviewCurrentResponse) => void;
   onRestart: (preview: PreviewCurrentResponse) => void;
   onStartLatest: (preview: PreviewCurrentResponse) => void;
+  isRestartPending: (preview: PreviewCurrentResponse) => boolean;
+  isStartLatestPending: (preview: PreviewCurrentResponse) => boolean;
 }) {
   if (isError) {
     return (
@@ -383,12 +387,16 @@ function SectionRows({
                         </Button>
                       ) : null}
                       {canMutate && scope === "running" && previewNeedsAttention(preview) ? (
-                        <RestartLatestButton onClick={() => onStartLatest(preview)} />
+                        <RestartLatestButton
+                          loading={isStartLatestPending(preview)}
+                          onClick={() => onStartLatest(preview)}
+                        />
                       ) : null}
                       {canMutate && scope === "resumable" ? (
                         <Button
                           size="sm"
                           variant="outline"
+                          loading={isRestartPending(preview)}
                           onClick={() => onRestart(preview)}
                         >
                           <Play className="h-4 w-4" />
@@ -396,7 +404,10 @@ function SectionRows({
                         </Button>
                       ) : null}
                       {canMutate && scope !== "running" ? (
-                        <RestartLatestButton onClick={() => onStartLatest(preview)} />
+                        <RestartLatestButton
+                          loading={isStartLatestPending(preview)}
+                          onClick={() => onStartLatest(preview)}
+                        />
                       ) : null}
                     </div>
                   </TableCell>
@@ -465,12 +476,16 @@ function SectionRows({
                     </Button>
                   ) : null}
                   {canMutate && scope === "running" && previewNeedsAttention(preview) ? (
-                    <RestartLatestButton onClick={() => onStartLatest(preview)} />
+                    <RestartLatestButton
+                      loading={isStartLatestPending(preview)}
+                      onClick={() => onStartLatest(preview)}
+                    />
                   ) : null}
                   {canMutate && scope === "resumable" ? (
                     <Button
                       size="sm"
                       variant="outline"
+                      loading={isRestartPending(preview)}
                       onClick={() => onRestart(preview)}
                     >
                       <Play className="h-4 w-4" />
@@ -478,7 +493,10 @@ function SectionRows({
                     </Button>
                   ) : null}
                   {canMutate && scope !== "running" ? (
-                    <RestartLatestButton onClick={() => onStartLatest(preview)} />
+                    <RestartLatestButton
+                      loading={isStartLatestPending(preview)}
+                      onClick={() => onStartLatest(preview)}
+                    />
                   ) : null}
                 </div>
               </CardContent>
@@ -491,8 +509,10 @@ function SectionRows({
 }
 
 function RestartLatestButton({
+  loading,
   onClick,
 }: {
+  loading: boolean;
   onClick: () => void;
 }) {
   return (
@@ -503,6 +523,7 @@ function RestartLatestButton({
             size="sm"
             variant="ghost"
             aria-label={RESTART_LATEST_TOOLTIP}
+            loading={loading}
             onClick={onClick}
           >
             <RotateCw className="h-4 w-4" />
@@ -664,14 +685,37 @@ export default function PreviewsPage() {
       api.previews.current.stop(preview.preview_group_id),
     onSuccess: () => queryClient.invalidateQueries({ queryKey: ["previews"] }),
   });
+  const [pendingRestartIds, setPendingRestartIds] = useState<Set<string>>(new Set());
   const restartPreview = useMutation({
     mutationFn: (preview: PreviewCurrentResponse) =>
       api.previews.current.restart(preview.preview_group_id),
+    onMutate: (preview) => {
+      setPendingRestartIds((prev) => new Set([...prev, preview.preview_group_id]));
+    },
+    onSettled: (_data, _error, preview) => {
+      setPendingRestartIds((prev) => {
+        const next = new Set(prev);
+        next.delete(preview.preview_group_id);
+        return next;
+      });
+    },
     onSuccess: () => queryClient.invalidateQueries({ queryKey: ["previews"] }),
   });
+
+  const [pendingStartLatestIds, setPendingStartLatestIds] = useState<Set<string>>(new Set());
   const startLatest = useMutation({
     mutationFn: (preview: PreviewCurrentResponse) =>
       api.previews.current.startLatest(preview.preview_group_id),
+    onMutate: (preview) => {
+      setPendingStartLatestIds((prev) => new Set([...prev, preview.preview_group_id]));
+    },
+    onSettled: (_data, _error, preview) => {
+      setPendingStartLatestIds((prev) => {
+        const next = new Set(prev);
+        next.delete(preview.preview_group_id);
+        return next;
+      });
+    },
     onSuccess: () => queryClient.invalidateQueries({ queryKey: ["previews"] }),
   });
 
@@ -790,6 +834,12 @@ export default function PreviewsPage() {
                     onStop={(preview) => stopPreview.mutate(preview)}
                     onRestart={(preview) => restartPreview.mutate(preview)}
                     onStartLatest={(preview) => startLatest.mutate(preview)}
+                    isRestartPending={(preview) =>
+                      pendingRestartIds.has(preview.preview_group_id)
+                    }
+                    isStartLatestPending={(preview) =>
+                      pendingStartLatestIds.has(preview.preview_group_id)
+                    }
                   />
                 </section>
               );


### PR DESCRIPTION
## Summary

The Previews page didn’t give clear feedback when a user triggers “Restart from latest” or “Resume”, which can cause repeated clicks and confusing state while the request is in flight. This change adds per-button loading animations and disables the relevant button(s) during the mutation, including concurrent in-flight mutations across multiple previews. (Fixes issue referenced as “Add Restart Button Loading Animation Before Unmount”.)

## Changes

- Track loading state per preview group with a `Set` so multiple buttons can show independent spinners correctly during concurrent mutations.
- Wire “Restart from latest” (recent section) and “Resume” (resumable section) to set/clear loading state via React Query `onMutate`/`onSettled`.
- Ensure buttons render the spinner (`data-slot="button-spinner"`) and expose `data-loading="true"` while the network request is pending.
- Add test coverage for the three key paths: recent start-latest, resumable restart, and running start-latest.

## Validation

- Updated/added frontend tests in `frontend/src/app/(dashboard)/previews/page.test.tsx` covering:
  - spinner appears during in-flight “start-latest” (Recent)
  - spinner appears during in-flight “restart”/“resume” (Resumable)
  - spinner appears during in-flight “start-latest” (Running)
- Manual/CI run: repo test suite (implicitly via existing test workflow for the updated page tests).

[143.dev](https://143.dev) | [session 1a279c70](https://143.dev/sessions/1a279c70-e4ac-4bb4-821e-22f4656118b9)

<!-- 143 readiness -->
**143 readiness:** not available for this revision.

Preview: https://143.dev/previews/github/assembledhq/143/pull/1575?launch=1