### PR TITLE
Move dogfood preview Go build off the readiness hot path

### DIFF
--- a/.143/config.json
+++ b/.143/config.json
@@ -7,7 +7,7 @@
     "primary": "frontend",
     "install": {
       "command": ["sh", ".143/preview-install-frontend.sh"],
-      "lockfiles": ["frontend/package-lock.json"],
+      "lockfiles": ["frontend/package-lock.json", "go.mod", "go.sum"],
       "verify_paths": ["frontend/node_modules/.bin/next"],
       "timeout_seconds": 600,
       "cache": {
@@ -29,6 +29,7 @@
         }
       },
       "server": {
+        "build": ["sh", ".143/preview-build.sh"],
         "command": ["sh", ".143/preview-start.sh"],
         "port": 8080,
         "env": {

--- a/.143/preview-build.sh
+++ b/.143/preview-build.sh
@@ -1,0 +1,51 @@
+#!/bin/sh
+# preview-build.sh — compile the dogfood preview binaries.
+#
+# Wired as the `build` command of the server service in .143/config.json, this
+# runs in the preview's dedicated build phase: after the Go build cache is
+# restored, before any service starts, and OFF the readiness-probe hot path.
+# That matters because a cold `go build` of ./cmd/server downloads ~70 modules
+# and compiles the world — several minutes — which blows past the server's
+# readiness timeout when it runs at start time. The build phase has its own
+# 30-minute budget (defaultServiceBuildTimeout) and its cache is flushed even on
+# failure (flushBuildCachesBeforeCleanup), so the first cold build still warms
+# every subsequent launch instead of failing the whole preview.
+#
+# The compiled binaries land under $SCRATCH_DIR on the container rootfs, which
+# persists into the start phase (same sandbox, same $HOME). preview-start.sh
+# execs them directly and falls back to invoking this script if they're missing.
+#
+# Go cache locations: in the build phase the platform pins GOCACHE
+# ($HOME/.cache/go-build), GOMODCACHE ($HOME/go/pkg/mod), and GOTMPDIR
+# ($HOME/.cache/go-build-tmp) — exactly the paths it archives as the home build
+# cache (see ResolvePreviewBuildCacheHomePaths). The `:=` defaults below only
+# apply when this script is invoked directly (e.g. the preview-start.sh
+# fallback), keeping that path pointed at the same restored caches. GOTMPDIR
+# must stay off the 512 MiB /var/tmp tmpfs (RAM-backed, counts against the
+# memory cgroup) or a large compile overflows it with "no space left on device".
+#
+# -u catches typos in required env vars instead of silently substituting empty
+# strings.
+set -eu
+
+HOME_DIR="${HOME:-/home/sandbox}"
+SCRATCH_DIR="${HOME_DIR}/.cache/143-preview"
+MIGRATE_BIN="${SCRATCH_DIR}/143-migrate"
+SERVER_BIN="${SCRATCH_DIR}/143-server"
+
+mkdir -p "$SCRATCH_DIR"
+chmod 700 "$SCRATCH_DIR"
+
+: "${GOCACHE:=${HOME_DIR}/.cache/go-build}"
+: "${GOMODCACHE:=${HOME_DIR}/go/pkg/mod}"
+: "${GOTMPDIR:=${HOME_DIR}/.cache/go-build-tmp}"
+export GOCACHE GOMODCACHE GOTMPDIR
+mkdir -p "$GOCACHE" "$GOMODCACHE" "$GOTMPDIR"
+
+echo '[143-preview] building binaries...'
+# Merge stderr into stdout so `go build` compile errors are captured by the
+# preview executor's output tail and surfaced in the launch error. Without this,
+# the executor discards stderr (see docker_preview.go) and the only visible line
+# is "building binaries..." followed by a bare non-zero exit.
+go build -o "$MIGRATE_BIN" ./cmd/migrate 2>&1
+go build -o "$SERVER_BIN" ./cmd/server 2>&1

--- a/.143/preview-start.sh
+++ b/.143/preview-start.sh
@@ -2,78 +2,66 @@
 # preview-start.sh — dogfood preview server entrypoint.
 #
 # Runs inside the 143 preview sandbox for this repo. Ordered as:
-#   1. build binaries once (go run would rebuild twice for migrate+server)
+#   1. ensure binaries exist (normally already built by the build phase —
+#      .143/preview-build.sh, wired as the server service's `build` command)
 #   2. run migrations
 #   3. seed the database
 #   4. generate + cache SESSION_SECRET at $SCRATCH_DIR/session_secret so
 #      a server restart inside the same sandbox keeps the reviewer signed in
 #   5. exec the server
 #
-# Scratch lives under $HOME on the container's writable rootfs, NOT in
-# $TMPDIR. The sandbox mounts /tmp (256 MiB) and /var/tmp (512 MiB) as
-# tmpfs (see internal/services/agent/providers/docker.go), and the Go
-# build's GOCACHE + $WORK + the migrate/server output binaries together
-# blow past 512 MiB while compiling deps like aws-sdk-go-v2/service/s3.
-# Moving them off tmpfs also frees that footprint from the container's
-# memory cgroup (tmpfs pages count against the memory limit per the
-# Tmpfs comment in providers/docker.go), giving the running server more
-# heap headroom.
+# Compilation deliberately happens in the dedicated build phase, not here: a
+# cold `go build` of ./cmd/server takes minutes, and at start time that runs
+# against the readiness probe's clock and times out the whole preview. The build
+# phase (see .143/preview-build.sh) has a 30-minute budget and persists the Go
+# cache even on failure, so it warms subsequent launches. The binaries it
+# produces live under $SCRATCH_DIR on the container rootfs, which persists into
+# this start phase (same sandbox, same $HOME).
 #
-# The rootfs is wiped automatically when the container is removed — both
-# on the happy path (Destroy) and the crash path (orphan reconciler), so
-# no explicit cleanup is needed here. Size is bounded by
-# SANDBOX_DISK_LIMIT_GB (default 10 GB) on hosts whose Docker storage
-# driver supports project quotas (overlay2 + XFS with pquota); on hosts
-# without that, providers/docker.go silently disables the quota and the
-# only ceiling is host disk. Prod is provisioned with the supported
-# driver; dev hosts without it should treat the cap as advisory.
+# Scratch lives under $HOME on the container's writable rootfs, NOT in $TMPDIR.
+# The sandbox mounts /tmp (256 MiB) and /var/tmp (512 MiB) as tmpfs (see
+# internal/services/agent/providers/docker.go); keeping artifacts off tmpfs also
+# frees that footprint from the container's memory cgroup (tmpfs pages count
+# against the memory limit), giving the running server more heap headroom.
 #
-# Cleanup invariant: this path must stay on a non-bind-mounted directory.
-# Today $HOME and the repo workdir are both rootfs-only (the only host
-# binds are /etc/resolv.conf and the auth-socket dir; see Mounts in
-# providers/docker.go). If a future change bind-mounts $HOME from the
-# host, move SCRATCH_DIR to a path that's still on the rootfs — otherwise
-# build artifacts will outlive the sandbox.
+# The rootfs is wiped automatically when the container is removed — both on the
+# happy path (Destroy) and the crash path (orphan reconciler), so no explicit
+# cleanup is needed here. Size is bounded by SANDBOX_DISK_LIMIT_GB (default
+# 10 GB) on hosts whose Docker storage driver supports project quotas (overlay2
+# + XFS with pquota); on hosts without that, providers/docker.go silently
+# disables the quota and the only ceiling is host disk. Prod is provisioned with
+# the supported driver; dev hosts without it should treat the cap as advisory.
 #
-# GOTMPDIR is set explicitly so `go build`'s intermediate $WORK files
-# don't fall back to the ambient GOTMPDIR=/var/tmp set by docker.go,
-# which would put the largest churn back on the small tmpfs.
+# Cleanup invariant: this path must stay on a non-bind-mounted directory. Today
+# $HOME and the repo workdir are both rootfs-only (the only host binds are
+# /etc/resolv.conf and the auth-socket dir; see Mounts in providers/docker.go).
+# If a future change bind-mounts $HOME from the host, move SCRATCH_DIR to a path
+# that's still on the rootfs — otherwise build artifacts will outlive the sandbox.
 #
-# -u catches typos in required env vars (DATABASE_URL, PREVIEW_ORIGIN)
-# instead of silently substituting empty strings and failing downstream.
+# -u catches typos in required env vars (DATABASE_URL, PREVIEW_ORIGIN) instead of
+# silently substituting empty strings and failing downstream.
 set -eu
 
-# Fall back to /home/sandbox if HOME is somehow unset; the sandbox image
-# bakes that as the user's home so it's the right default. The fallback
-# matches HomeDir in internal/services/agent/adapter.go.
+# Fall back to /home/sandbox if HOME is somehow unset; the sandbox image bakes
+# that as the user's home so it's the right default. The fallback matches HomeDir
+# in internal/services/agent/adapter.go.
 SCRATCH_DIR="${HOME:-/home/sandbox}/.cache/143-preview"
 SECRET_FILE="${SCRATCH_DIR}/session_secret"
 MIGRATE_BIN="${SCRATCH_DIR}/143-migrate"
 SERVER_BIN="${SCRATCH_DIR}/143-server"
 
 mkdir -p "$SCRATCH_DIR"
-# Lock down the scratch dir up-front so anything dropped here later
-# (notably SECRET_FILE) inherits a sandbox-only parent. SECRET_FILE
-# itself is also chmod 600 below; this is defense in depth, not the
-# primary control.
+# Lock down the scratch dir up-front so anything dropped here later (notably
+# SECRET_FILE) inherits a sandbox-only parent. SECRET_FILE itself is also
+# chmod 600 below; this is defense in depth, not the primary control.
 chmod 700 "$SCRATCH_DIR"
 
-# Persist the Go build cache and intermediate $WORK dir across in-sandbox
-# server restarts so rebuilds after a code edit reuse object files
-# instead of recompiling the world. A full sandbox recycle wipes the
-# rootfs and pays the cold-build cost once.
-GOCACHE="${SCRATCH_DIR}/gocache"
-GOTMPDIR="${SCRATCH_DIR}/gotmp"
-export GOCACHE GOTMPDIR
-mkdir -p "$GOCACHE" "$GOTMPDIR"
-
-echo '[143-preview] building binaries...'
-# Merge stderr into stdout so `go build` compile errors are captured by the
-# preview executor's output tail and surfaced in the launch error. Without
-# this, the executor discards stderr (see docker_preview.go) and the user
-# only sees the "building binaries..." line followed by "exited with code 1".
-go build -o "$MIGRATE_BIN" ./cmd/migrate 2>&1
-go build -o "$SERVER_BIN" ./cmd/server 2>&1
+# Normally the build phase already produced these. Fall back to building now if
+# they're missing — a platform without build-phase support, or a manual run.
+if [ ! -x "$MIGRATE_BIN" ] || [ ! -x "$SERVER_BIN" ]; then
+    echo '[143-preview] binaries missing; building inline...'
+    sh "$(dirname "$0")/preview-build.sh"
+fi
 
 echo '[143-preview] running migrations...'
 "$MIGRATE_BIN" up


### PR DESCRIPTION
## Summary

The 143 self-preview kept failing to launch: the server service compiled `./cmd/server` at start time, so on a cold sandbox the readiness probe spent its entire window on `go: downloading ...` and timed out at 240s before the build ever finished. This moves compilation into the dedicated build phase (off the readiness clock) and enables the platform's Go home build cache so cold launches stop re-downloading the whole module graph.

## Changes

- Add `.143/preview-build.sh` and wire it as the `server` service's `build` command, so the `go build` runs in the build phase (30-min budget, cache flushed even on failure) instead of against the readiness probe.
- Declare `go.mod`/`go.sum` in `install.lockfiles`, activating `ResolvePreviewBuildCacheHomePaths` so `.cache/go-build` + `go/pkg/mod` persist across cold launches.
- `preview-start.sh` now execs the prebuilt binaries, with an inline-build fallback for platforms without build-phase support or manual runs.

## Validation

- Parsed the real `.143/config.json` through `ParseConfig` then `ValidateConfig` (no errors), confirmed `server.build` parses, and `ResolvePreviewBuildCacheHomePaths` resolves both `.cache/go-build` and `go/pkg/mod`.
- `sh -n` syntax-checked both scripts; `python3 -m json.tool` validated the config.

## Reviewer notes

- Requires the build-phase platform code to be deployed to take full effect on 143.dev. If prod is older, the `build` field is ignored (`omitempty`) and `preview-start.sh`'s inline fallback keeps the preview working.
- The first launch after deploy is still a cold compile (within the 30-min build budget); it seeds the cache so subsequent cold launches are fast.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
