### PR TITLE
Align default Codex/PM and Claude Code models to GPT-5.5 Opus 4.8

### DIFF
--- a/frontend/src/lib/model-constants.test.ts
+++ b/frontend/src/lib/model-constants.test.ts
@@ -5,17 +5,25 @@ import {
   AVAILABLE_CLAUDE_CODE_MODELS,
   AVAILABLE_OPENCODE_MODELS,
   AVAILABLE_PI_MODELS,
+  DEFAULT_CLAUDE_CODE_MODEL,
+  DEFAULT_CODEX_MODEL,
   DEFAULT_PM_MODEL,
   DEFAULT_LLM_MODEL,
-  CODEX_MODEL_GPT_5_4,
+  CLAUDE_CODE_MODEL_OPUS_48,
+  CODEX_MODEL_GPT_5_5,
   LLM_PROVIDER_INFO,
   LLM_MODELS_BY_PROVIDER,
   ownerProviderForModel,
 } from "./model-constants";
 
 describe("model constants", () => {
-  it("uses gpt-5.4 as the PM default", () => {
-    expect(DEFAULT_PM_MODEL).toBe(CODEX_MODEL_GPT_5_4);
+  it("uses GPT 5.5 as the Codex and PM default", () => {
+    expect(DEFAULT_CODEX_MODEL).toBe(CODEX_MODEL_GPT_5_5);
+    expect(DEFAULT_PM_MODEL).toBe(DEFAULT_CODEX_MODEL);
+  });
+
+  it("uses Opus 4.8 as the Claude Code default", () => {
+    expect(DEFAULT_CLAUDE_CODE_MODEL).toBe(CLAUDE_CODE_MODEL_OPUS_48);
   });
 
   it("includes latest Claude Code models", () => {

--- a/frontend/src/lib/model-constants.ts
+++ b/frontend/src/lib/model-constants.ts
@@ -16,6 +16,8 @@ export const AVAILABLE_CLAUDE_CODE_MODELS = [
   CLAUDE_CODE_MODEL_HAIKU_45,
 ] as const;
 
+export const DEFAULT_CLAUDE_CODE_MODEL = CLAUDE_CODE_MODEL_OPUS_48;
+
 export const CODEX_MODEL_GPT_5_5 = "gpt-5.5";
 export const CODEX_MODEL_GPT_5_5_FAST = "gpt-5.5-fast";
 export const CODEX_MODEL_GPT_5_4 = "gpt-5.4";
@@ -37,6 +39,8 @@ export const AVAILABLE_CODEX_MODELS = [
   CODEX_MODEL_GPT_5_CODEX,
   CODEX_MODEL_GPT_5_3_CODEX_SPARK,
 ] as const;
+
+export const DEFAULT_CODEX_MODEL = CODEX_MODEL_GPT_5_5;
 
 // Amp uses agent "modes" instead of model names; each mode bundles a model,
 // system prompt, and tool set on Sourcegraph's side.
@@ -111,7 +115,7 @@ export const AVAILABLE_OPENCODE_MODELS = [
   OPENCODE_MODEL_GPT_5_5,
 ] as const;
 
-export const DEFAULT_PM_MODEL = CODEX_MODEL_GPT_5_4;
+export const DEFAULT_PM_MODEL = DEFAULT_CODEX_MODEL;
 
 // PM and session model dropdowns are both built from the AGENTS registry in
 // @/lib/agents (see availableAgentModelGroups). Keeping a second PM-only list

--- a/internal/models/agent_model_constants.go
+++ b/internal/models/agent_model_constants.go
@@ -64,6 +64,8 @@ const (
 	ClaudeCodeModelHaiku45  = "claude-haiku-4-5"
 )
 
+const DefaultClaudeCodeModel = ClaudeCodeModelOpus48
+
 var AvailableClaudeCodeModels = []string{ClaudeCodeModelFable5, ClaudeCodeModelOpus48, ClaudeCodeModelOpus47, ClaudeCodeModelOpus46, ClaudeCodeModelSonnet46, ClaudeCodeModelSonnet45, ClaudeCodeModelHaiku45}
 
 const (
@@ -77,6 +79,8 @@ const (
 	CodexModelGPT5Codex       = "gpt-5-codex"
 	CodexModelGPT53CodexSpark = "gpt-5.3-codex-spark"
 )
+
+const DefaultCodexModel = CodexModelGPT55
 
 var AvailableCodexModels = []string{
 	CodexModelGPT55,

--- a/internal/models/agent_model_constants_test.go
+++ b/internal/models/agent_model_constants_test.go
@@ -9,7 +9,7 @@ import (
 func TestPMModelConstants(t *testing.T) {
 	t.Parallel()
 
-	require.Equal(t, CodexModelGPT54, DefaultPMModel, "DefaultPMModel should use CodexModelGPT54")
+	require.Equal(t, DefaultCodexModel, DefaultPMModel, "DefaultPMModel should use the Codex default model")
 
 	// AvailablePMModels mirrors the union of every coding agent's model list,
 	// matching the session picker (frontend availableAgentModelGroups).
@@ -25,6 +25,7 @@ func TestPMModelConstants(t *testing.T) {
 func TestClaudeCodeModelConstants(t *testing.T) {
 	t.Parallel()
 
+	require.Equal(t, ClaudeCodeModelOpus48, DefaultClaudeCodeModel, "DefaultClaudeCodeModel should use Opus 4.8")
 	require.Equal(t,
 		[]string{ClaudeCodeModelFable5, ClaudeCodeModelOpus48, ClaudeCodeModelOpus47, ClaudeCodeModelOpus46, ClaudeCodeModelSonnet46, ClaudeCodeModelSonnet45, ClaudeCodeModelHaiku45},
 		AvailableClaudeCodeModels,
@@ -35,6 +36,7 @@ func TestClaudeCodeModelConstants(t *testing.T) {
 func TestCodexModelConstants(t *testing.T) {
 	t.Parallel()
 
+	require.Equal(t, CodexModelGPT55, DefaultCodexModel, "DefaultCodexModel should use GPT 5.5")
 	require.Equal(t,
 		[]string{CodexModelGPT55, CodexModelGPT55Fast, CodexModelGPT54, CodexModelGPT54Fast, CodexModelGPT54Mini, CodexModelGPT53Codex, CodexModelGPT52Codex, CodexModelGPT5Codex, CodexModelGPT53CodexSpark},
 		AvailableCodexModels,

--- a/internal/models/org_settings.go
+++ b/internal/models/org_settings.go
@@ -589,7 +589,7 @@ const (
 	DefaultMinPriorityThreshold                     = 30.0
 	DefaultDefaultAgentType           AgentType     = AgentTypeCodex
 	DefaultPMScheduleHours                          = 24
-	DefaultPMModel                                  = CodexModelGPT54
+	DefaultPMModel                                  = DefaultCodexModel
 	DefaultAuditRetentionDays                       = 90
 	DefaultContextRefreshIntervalDays               = 14
 	DefaultOrgSize                    OrgSize       = OrgSizeMedium

--- a/internal/services/agent/adapters/codex.go
+++ b/internal/services/agent/adapters/codex.go
@@ -292,7 +292,7 @@ func codexModelArgs(env map[string]string, effectiveModel string) string {
 		model = env["OPENAI_MODEL"]
 	}
 	if model == "" {
-		return ""
+		model = models.DefaultCodexModel
 	}
 	spec := models.CodexRuntimeModel(model)
 	if spec.PriorityTier {

--- a/internal/services/agent/adapters/codex_test.go
+++ b/internal/services/agent/adapters/codex_test.go
@@ -127,9 +127,9 @@ func TestCodexModelArgs(t *testing.T) {
 			expected: ` -m 'gpt-5.5'`,
 		},
 		{
-			name:     "does not add args when no env model is set",
+			name:     "uses the Codex default when no env model is set",
 			env:      map[string]string{},
-			expected: "",
+			expected: ` -m 'gpt-5.5'`,
 		},
 		{
 			name:           "uses resolved effective model when env model is absent",

--- a/internal/services/agent/env.go
+++ b/internal/services/agent/env.go
@@ -928,14 +928,13 @@ func (e *AgentEnv) ResolveForModel(ctx context.Context, orgID uuid.UUID, agentTy
 		}
 	}
 
+	e.applyAgentModelDefault(ctx, orgID, agentType, modelOverride, merged)
+
 	// Apply per-agent env overrides from org settings (agent_config.<type>.*).
 	// Scoped to Amp and Pi only — these are non-secret runtime defaults
 	// (AMP_MODE, PI_MODEL, PI_MODEL_CUSTOM), while auth itself comes from the
-	// credential stores. For claude_code/codex we keep the legacy
-	// behavior: provider creds come exclusively from resolveProviderConfig,
-	// and agent_config is treated as model-default metadata (validated,
-	// stored, but not injected here) — changing that would silently flip
-	// existing orgs' active keys.
+	// credential stores. Codex and Claude Code model defaults are applied
+	// above without changing which credential key is active.
 	if agentType == models.AgentTypeAmp || agentType == models.AgentTypePi {
 		e.applyAgentConfigOverrides(ctx, orgID, agentType, merged)
 	}
@@ -945,6 +944,34 @@ func (e *AgentEnv) ResolveForModel(ctx context.Context, orgID uuid.UUID, agentTy
 	}
 
 	return merged
+}
+
+func (e *AgentEnv) applyAgentModelDefault(ctx context.Context, orgID uuid.UUID, agentType models.AgentType, modelOverride string, merged map[string]string) {
+	envVar := models.ModelEnvVarForAgentType(agentType)
+	if envVar == "" || merged[envVar] != "" {
+		return
+	}
+
+	if model := strings.TrimSpace(modelOverride); model != "" {
+		merged[envVar] = model
+		return
+	}
+	if agentType == models.AgentTypeCodex || agentType == models.AgentTypeClaudeCode {
+		if agentConfig, ok := e.loadAgentConfig(ctx, orgID, agentType); ok {
+			if cfg := agentConfig[string(agentType)]; cfg != nil {
+				if model := strings.TrimSpace(cfg[envVar]); model != "" {
+					merged[envVar] = model
+					return
+				}
+			}
+		}
+	}
+	switch agentType {
+	case models.AgentTypeCodex:
+		merged[envVar] = models.DefaultCodexModel
+	case models.AgentTypeClaudeCode:
+		merged[envVar] = models.DefaultClaudeCodeModel
+	}
 }
 
 // CheckAuth returns a user-facing error when an agent type has no chance of

--- a/internal/services/agent/env_test.go
+++ b/internal/services/agent/env_test.go
@@ -785,6 +785,50 @@ func TestAgentEnvResolveLinearTokenInjection(t *testing.T) {
 	})
 }
 
+func TestAgentEnvResolveAppliesAgentModelDefaults(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	orgID := uuid.New()
+	userID := uuid.New()
+
+	tests := []struct {
+		name      string
+		agentType models.AgentType
+		expected  map[string]string
+	}{
+		{
+			name:      "codex",
+			agentType: models.AgentTypeCodex,
+			expected: map[string]string{
+				"OPENAI_MODEL":                  models.DefaultCodexModel,
+				"CODEX_UNSAFE_ALLOW_NO_SANDBOX": "1",
+			},
+		},
+		{
+			name:      "claude code",
+			agentType: models.AgentTypeClaudeCode,
+			expected: map[string]string{
+				"ANTHROPIC_MODEL": models.DefaultClaudeCodeModel,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			env := NewAgentEnv(AgentEnvDeps{
+				Provider: &envSandboxProvider{},
+				Logger:   zerolog.Nop(),
+			})
+
+			got := env.Resolve(ctx, orgID, tt.agentType, &userID)
+			require.Equal(t, tt.expected, got, "Resolve should apply the hardcoded agent model default")
+		})
+	}
+}
+
 func TestAgentEnvResolveAppliesCachedAgentConfigOverrides(t *testing.T) {
 	t.Parallel()
 

--- a/internal/services/pm/project_analyze_test.go
+++ b/internal/services/pm/project_analyze_test.go
@@ -300,7 +300,7 @@ func TestAnalyzeProject_EnrichesTokenUsageHintOnPrompt(t *testing.T) {
 	require.NoError(t, err, "AnalyzeProject should succeed")
 	require.NotNil(t, inner.calledPrompt, "AnalyzeProject should pass a prompt to the inner agent")
 	require.Equal(t, models.AgentTypeCodex, inner.calledPrompt.UsageHint.AgentType, "AnalyzeProject should preserve the selected agent type in UsageHint")
-	require.Equal(t, models.CodexModelGPT54, inner.calledPrompt.UsageHint.EffectiveModel, "AnalyzeProject should propagate the effective model into UsageHint")
+	require.Equal(t, models.DefaultCodexModel, inner.calledPrompt.UsageHint.EffectiveModel, "AnalyzeProject should propagate the effective model into UsageHint")
 	require.Equal(t, agent.TokenBillingModeSubscription, inner.calledPrompt.UsageHint.BillingMode, "AnalyzeProject should record subscription billing when Codex runs via ChatGPT auth")
 }
 

--- a/internal/services/pm/service_test.go
+++ b/internal/services/pm/service_test.go
@@ -372,6 +372,6 @@ func TestAnalyze_EnrichesTokenUsageHintOnPrompt(t *testing.T) {
 	require.NoError(t, err, "Analyze should succeed")
 	require.NotNil(t, inner.calledPrompt, "Analyze should pass a prompt to the inner agent")
 	require.Equal(t, models.AgentTypeCodex, inner.calledPrompt.UsageHint.AgentType, "Analyze should preserve the selected agent type in UsageHint")
-	require.Equal(t, models.CodexModelGPT54, inner.calledPrompt.UsageHint.EffectiveModel, "Analyze should propagate the effective model into UsageHint")
+	require.Equal(t, models.DefaultCodexModel, inner.calledPrompt.UsageHint.EffectiveModel, "Analyze should propagate the effective model into UsageHint")
 	require.Equal(t, agent.TokenBillingModeSubscription, inner.calledPrompt.UsageHint.BillingMode, "Analyze should record subscription billing when Codex runs via ChatGPT auth")
 }


### PR DESCRIPTION
## Summary

We were using the wrong backend defaults for coding agents, creating a reliability risk where sessions/PM jobs and automations could run with outdated models. This change makes the backend own enforcement by setting PM/Codex default to **GPT 5.5** and Claude Code default to **Opus 4.8**, while keeping frontend constants in sync for UI fallback and drift detection.

## Changes

- Set backend defaults: **DefaultCodexModel = gpt-5.5** and **DefaultClaudeCodeModel = claude-opus-4.8**, and updated tests to assert these defaults.
- Updated frontend model constants so **DEFAULT_PM_MODEL follows DEFAULT_CODEX_MODEL** and **DEFAULT_CLAUDE_CODE_MODEL** points to **Opus 4.8** (mirrored for display/testing only).
- Adjusted/extended test coverage in both frontend and backend to verify the “latest intended defaults” match the declared constants (including PM default behavior).

## Validation

- Frontend: `pnpm test frontend/src/lib/model-constants.test.ts`
- Backend: `go test ./internal/models ./internal/services/...`
- Verified affected unit tests covering env/settings interactions for model defaulting paths (`env_test.go`, PM/service tests).

[143.dev](https://143.dev) | [session 11c74d78](https://143.dev/sessions/11c74d78-c731-4feb-91e9-667695927080)

<!-- 143 readiness -->
**143 readiness:** not available for this revision.

Preview: https://143.dev/previews/github/assembledhq/143/pull/1577?launch=1