### PR TITLE
Treat Slack formatting requests as start work

### DIFF
--- a/internal/prompts/templates/slack_routing_classifier_prompt.template
+++ b/internal/prompts/templates/slack_routing_classifier_prompt.template
@@ -7,4 +7,6 @@ Use "answer_only" when the user is asking for information, explanation, status, 
 
 Use "start_work" when the user asks 143 to implement, fix, change, create, remove, update, build, wire, refactor, or otherwise modify code or product behavior.
 
+Formatting, wording, presentation, or display changes to 143 product output are product behavior changes. For example, "please use backticks to display the repo and branch" is start_work, not answer_only.
+
 Explicit command words are authoritative: "ask" means answer_only, and "start" means start_work.

--- a/internal/worker/handlers.go
+++ b/internal/worker/handlers.go
@@ -6938,6 +6938,9 @@ func resolveSlackAutoRouting(ctx context.Context, llm llmClient, logger zerolog.
 	if resolved.RoutingMode != "" && resolved.RoutingMode != slackbotsvc.SlackRoutingModeAuto {
 		return resolved
 	}
+	if slackTextDeterministicallyRequestsWork(text) {
+		return applySlackRoutingMode(resolved, slackbotsvc.SlackRoutingModeStartWork, "imperative Slack request to modify product behavior")
+	}
 	classification := classifySlackRouting(ctx, llm, logger, text)
 	return applySlackRoutingMode(resolved, classification.RoutingMode, classification.Reason)
 }
@@ -7014,6 +7017,79 @@ func fallbackSlackRoutingClassification(text, reason string) slackRoutingClassif
 		Confidence:  0,
 		Reason:      reason,
 	}
+}
+
+func slackTextDeterministicallyRequestsWork(text string) bool {
+	cleaned := normalizeSlackRoutingText(text)
+	if cleaned == "" {
+		return false
+	}
+	startWorkPhrases := []string{
+		"start this work",
+		"start the work",
+		"start this task",
+		"start the task",
+		"kick off this work",
+		"kick off the work",
+	}
+	for _, phrase := range startWorkPhrases {
+		if strings.Contains(cleaned, phrase) {
+			return true
+		}
+	}
+	requestPrefixes := []string{
+		"please ",
+		"can you ",
+		"could you ",
+		"would you ",
+		"will you ",
+		"can we ",
+		"could we ",
+		"let's ",
+		"lets ",
+	}
+	for _, prefix := range requestPrefixes {
+		if strings.HasPrefix(cleaned, prefix) && slackDirectiveRestRequestsWork(strings.TrimSpace(strings.TrimPrefix(cleaned, prefix))) {
+			return true
+		}
+	}
+	if idx := strings.Index(cleaned, " please "); idx >= 0 {
+		return slackDirectiveRestRequestsWork(strings.TrimSpace(cleaned[idx+len(" please "):]))
+	}
+	return false
+}
+
+func slackDirectiveRestRequestsWork(rest string) bool {
+	if rest == "" {
+		return false
+	}
+	answerOnlyPrefixes := []string{
+		"show me ",
+		"show us ",
+		"tell me ",
+		"explain ",
+		"describe ",
+		"list ",
+		"don't ",
+		"do not ",
+		"not ",
+	}
+	for _, prefix := range answerOnlyPrefixes {
+		if strings.HasPrefix(rest, prefix) {
+			return false
+		}
+	}
+	workTerms := []string{
+		"fix", "implement", "change", "update", "add", "remove", "create", "build",
+		"wire", "refactor", "migrate", "hide", "make", "repair", "use", "display",
+		"format", "wrap", "render", "style", "rename", "reword", "label",
+	}
+	for _, term := range workTerms {
+		if rest == term || strings.HasPrefix(rest, term+" ") {
+			return true
+		}
+	}
+	return false
 }
 
 func normalizeSlackRoutingText(text string) string {

--- a/internal/worker/handlers_test.go
+++ b/internal/worker/handlers_test.go
@@ -977,6 +977,13 @@ func TestResolveSlackAutoRoutingWithClassifier(t *testing.T) {
 			expectedLLMCalls: 1,
 		},
 		{
+			name:             "formatting change request overrides classifier answer only",
+			text:             "<@U143> when the slack session is kicked off and shows an in progress changes, please use backticks to display the repo and branch. Right now they look like:\n\nRepo: assembledhq/143\nBranch: main\n\nBut Ideally I'd like them to be:\n\nRepo: `assembledhq/143`\nBranch: `main`",
+			llmResponse:      `{"routing_mode":"answer_only","confidence":0.97,"reason":"formatting guidance"}`,
+			expectedRouting:  slackbotsvc.SlackRoutingModeStartWork,
+			expectedLLMCalls: 0,
+		},
+		{
 			name:             "invalid classifier response falls back conservatively",
 			text:             "<@U143> does our slack bot post notifications when a job finishes?",
 			llmResponse:      `not json`,


### PR DESCRIPTION
## Summary
- Expand the Slack routing prompt so formatting, wording, presentation, and display changes are classified as product behavior changes.
- Add a deterministic routing shortcut for imperative Slack requests that ask to modify output formatting, so they bypass the LLM classifier when the intent is clear.
- Cover the new behavior with a regression test for a formatting-change request that should route to `start_work`.

## Testing
- Added/updated unit coverage for Slack auto-routing classification.
- Not run (not requested).