### PR TITLE
Format Slack kickoff repo/branch as code spans in session status

### DIFF
--- a/internal/services/slackbot/lifecycle.go
+++ b/internal/services/slackbot/lifecycle.go
@@ -157,10 +157,10 @@ func statusTitle(input SlackSessionRenderInput) string {
 func renderContextLines(input SlackSessionRenderInput) []string {
 	lines := []string{}
 	if input.Context.RepositoryName != "" {
-		lines = append(lines, "Repo: "+input.Context.RepositoryName)
+		lines = append(lines, "Repo: "+slackCodeSpan(input.Context.RepositoryName))
 	}
 	if input.Context.Branch != "" {
-		lines = append(lines, "Branch: "+input.Context.Branch)
+		lines = append(lines, "Branch: "+slackCodeSpan(input.Context.Branch))
 	}
 	if input.Context.PullRequestURL != "" {
 		lines = append(lines, "PR: "+input.Context.PullRequestURL)
@@ -172,6 +172,10 @@ func renderContextLines(input SlackSessionRenderInput) []string {
 		lines = append(lines, "Mode: "+label)
 	}
 	return lines
+}
+
+func slackCodeSpan(value string) string {
+	return "`" + strings.ReplaceAll(strings.TrimSpace(value), "`", "'") + "`"
 }
 
 func routingModeLabel(mode SlackRoutingMode) string {

--- a/internal/services/slackbot/lifecycle_test.go
+++ b/internal/services/slackbot/lifecycle_test.go
@@ -34,7 +34,7 @@ func TestRenderSessionStatus(t *testing.T) {
 				},
 				RoutingMode: SlackRoutingModeStartWork,
 			},
-			expected: "Starting a 143 session\n\nRepo: assembledhq/143\nBranch: main\nMode: Start work\n\nSession: https://143.test/sessions/" + sessionID.String(),
+			expected: "Starting a 143 session\n\nRepo: `assembledhq/143`\nBranch: `main`\nMode: Start work\n\nSession: https://143.test/sessions/" + sessionID.String(),
 		},
 		{
 			name: "failed status includes summary and session link",


### PR DESCRIPTION
## Summary

Slack kickoff messages for in-progress sessions were rendering repo and branch as plain text, which makes paths and branch names harder to scan and can introduce Slack formatting ambiguity. This change wraps the repository name and branch in Slack code spans (`` `...` ``) and updates the lifecycle status test to lock in the new format.

## Changes

- Render `Repo:` and `Branch:` values as Slack code spans for `renderContextLines` output.
- Add `slackCodeSpan()` helper to safely trim whitespace and avoid embedded backticks.
- Update `TestRenderSessionStatus` expected string for the “Start work” case.

## Validation

- `go test ./internal/services/slackbot -run TestRenderSessionStatus -count=1`
- `go test ./internal/services/slackbot`
- `go vet ./...`
- `go build ./...`
- `go test -p 1 ./...`

[143.dev](https://143.dev) | [session fcfb8729](https://143.dev/sessions/fcfb8729-4902-4525-938a-0b285cce51c1)

<!-- 143 readiness -->
**143 readiness:** not available for this revision.

Preview: https://143.dev/previews/github/assembledhq/143/pull/1582?launch=1