### PR TITLE
Make Homepage Plane Canvas Subtler on Manual “Let’s Build” Session Page

### DIFF
--- a/frontend/src/app/(dashboard)/sessions/new/manual-session-create-page-content.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/new/manual-session-create-page-content.test.tsx
@@ -252,6 +252,7 @@ describe("ManualSessionCreatePageContent", () => {
     expect(
       screen.getByText("Start a manual session with text, files, photos, or a screenshot anywhere here."),
     ).toBeInTheDocument();
+    expect(screen.getByTestId("manual-session-plane-canvas")).toHaveAttribute("aria-hidden", "true");
     expect(screen.queryByText("Drop a screenshot anywhere here, or use +")).not.toBeInTheDocument();
   });
 

--- a/frontend/src/app/(dashboard)/sessions/new/manual-session-create-page-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/new/manual-session-create-page-content.tsx
@@ -3,6 +3,7 @@
 import { useMemo } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { ManualSessionComposer } from "@/components/manual-session-composer";
+import { ManualSessionPlaneCanvas } from "@/components/manual-session-plane-canvas";
 import { MobileBackButton } from "@/components/mobile-back-button";
 import { buildFilterSuffix } from "@/hooks/use-people-filter";
 import { cn } from "@/lib/utils";
@@ -29,7 +30,8 @@ export function ManualSessionCreatePageContent() {
       <div className="md:hidden flex items-center px-2 pt-2">
         <MobileBackButton to="/sessions" label="Back to sessions" />
       </div>
-      <div className="flex flex-1 flex-col px-4 pb-4">
+      <div className="relative flex flex-1 flex-col overflow-hidden px-4 pb-4">
+        <ManualSessionPlaneCanvas />
         <ManualSessionComposer
           enableDrafts
           autoFocus
@@ -37,7 +39,7 @@ export function ManualSessionCreatePageContent() {
           showDropIndicator
           dataTestId="manual-session-dropzone"
           textareaAriaLabel="Manual session prompt"
-          className={cn("mx-auto flex w-full max-w-3xl flex-1")}
+          className={cn("relative z-10 mx-auto flex w-full max-w-3xl flex-1")}
           innerClassName="max-w-3xl"
           showOptimisticSidebarRow={false}
           onCreated={(id) => router.replace(`/sessions/${id}${filterSuffix}`)}

--- a/frontend/src/components/manual-session-plane-canvas.tsx
+++ b/frontend/src/components/manual-session-plane-canvas.tsx
@@ -1,0 +1,165 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { drawP80, DARK, LIGHT, type PlaneTheme } from "@/components/landing/draw-p80";
+import { usePrefersDark } from "@/hooks/use-prefers-dark";
+
+type Plane = {
+  x: number;
+  y: number;
+  size: number;
+  speed: number;
+  heading: number;
+  baseY: number;
+  phase: number;
+  opacity: number;
+  trail: Array<{ x: number; y: number }>;
+};
+
+const PLANE_COUNT = 2;
+
+function createPlane(width: number, height: number, index: number): Plane {
+  const leftToRight = index % 2 === 0;
+  const y = height * (index === 0 ? 0.26 : 0.58);
+
+  return {
+    x: leftToRight ? -width * 0.18 : width * 1.18,
+    y,
+    size: Math.max(14, Math.min(24, width * 0.024)) * (index === 0 ? 1 : 0.82),
+    speed: (leftToRight ? 0.24 : -0.18) * Math.max(0.85, Math.min(1.2, width / 900)),
+    heading: leftToRight ? -0.06 : Math.PI + 0.05,
+    baseY: y,
+    phase: index * Math.PI * 0.7,
+    opacity: index === 0 ? 0.36 : 0.24,
+    trail: [],
+  };
+}
+
+function subtleTheme(theme: PlaneTheme): PlaneTheme {
+  return {
+    ...theme,
+    planeFill: (a: number) => theme.planeFill(a * 0.72),
+    planeStroke: (a: number) => theme.planeStroke(a * 0.55),
+    planeHighlight: (a: number) => theme.planeHighlight(a * 0.45),
+    planeShadow: (a: number) => theme.planeShadow(a * 0.3),
+    canopy: (a: number) => theme.canopy(a * 0.5),
+    canopyEdge: (a: number) => theme.canopyEdge(a * 0.45),
+    panelLine: (a: number) => theme.panelLine(a * 0.35),
+    trail: (a: number) => theme.trail(a * 0.18),
+  };
+}
+
+export function ManualSessionPlaneCanvas() {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const planesRef = useRef<Plane[]>([]);
+  const isDark = usePrefersDark();
+  const isDarkRef = useRef(isDark);
+
+  useEffect(() => {
+    isDarkRef.current = isDark;
+  }, [isDark]);
+
+  useEffect(() => {
+    if (process.env.NODE_ENV === "test") {
+      return;
+    }
+
+    const canvas = canvasRef.current;
+    const parent = canvas?.parentElement;
+    const ctx = canvas?.getContext("2d");
+
+    if (!canvas || !parent || !ctx) {
+      return;
+    }
+
+    let frameId = 0;
+    let reducedMotion = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+    let width = 0;
+    let height = 0;
+
+    const resize = () => {
+      const rect = parent.getBoundingClientRect();
+      width = Math.max(1, rect.width);
+      height = Math.max(1, rect.height);
+
+      const dpr = window.devicePixelRatio || 1;
+      canvas.width = Math.round(width * dpr);
+      canvas.height = Math.round(height * dpr);
+      canvas.style.width = `${width}px`;
+      canvas.style.height = `${height}px`;
+      ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+
+      planesRef.current = Array.from({ length: PLANE_COUNT }, (_, index) =>
+        createPlane(width, height, index),
+      );
+    };
+
+    const draw = (time: number) => {
+      ctx.clearRect(0, 0, width, height);
+      const theme = subtleTheme(isDarkRef.current ? DARK : LIGHT);
+
+      for (const plane of planesRef.current) {
+        if (!reducedMotion) {
+          plane.x += plane.speed;
+          plane.y = plane.baseY + Math.sin(time * 0.00045 + plane.phase) * 8;
+
+          const exitingRight = plane.speed > 0 && plane.x > width * 1.16;
+          const exitingLeft = plane.speed < 0 && plane.x < -width * 0.16;
+          if (exitingRight || exitingLeft) {
+            plane.x = plane.speed > 0 ? -width * 0.14 : width * 1.14;
+            plane.trail = [];
+          }
+        }
+
+        plane.trail.push({ x: plane.x, y: plane.y });
+        while (plane.trail.length > 78) {
+          plane.trail.shift();
+        }
+
+        for (let i = 1; i < plane.trail.length; i += 1) {
+          const prev = plane.trail[i - 1];
+          const current = plane.trail[i];
+          const progress = i / plane.trail.length;
+
+          ctx.beginPath();
+          ctx.moveTo(prev.x, prev.y);
+          ctx.lineTo(current.x, current.y);
+          ctx.strokeStyle = theme.trail(progress * plane.opacity);
+          ctx.lineWidth = 0.45 + progress * 1.3;
+          ctx.lineCap = "round";
+          ctx.stroke();
+        }
+
+        drawP80(ctx, plane.x, plane.y, plane.size, plane.heading, 0.58, plane.opacity, theme);
+      }
+
+      frameId = window.requestAnimationFrame(draw);
+    };
+
+    const motionQuery = window.matchMedia("(prefers-reduced-motion: reduce)");
+    const onMotionChange = (event: MediaQueryListEvent) => {
+      reducedMotion = event.matches;
+    };
+    const observer = new ResizeObserver(resize);
+
+    resize();
+    observer.observe(parent);
+    motionQuery.addEventListener("change", onMotionChange);
+    frameId = window.requestAnimationFrame(draw);
+
+    return () => {
+      window.cancelAnimationFrame(frameId);
+      observer.disconnect();
+      motionQuery.removeEventListener("change", onMotionChange);
+    };
+  }, []);
+
+  return (
+    <canvas
+      ref={canvasRef}
+      aria-hidden="true"
+      data-testid="manual-session-plane-canvas"
+      className="pointer-events-none absolute inset-0 h-full w-full"
+    />
+  );
+}


### PR DESCRIPTION
## Summary

The “Let’s build” manual session page needs lightweight, decorative motion without drawing attention away from the composer. This change adds the homepage P-80 plane treatment as a subtle background canvas—slower, lower-opacity planes with reduced-motion support—and ensures it’s hidden from assistive tech.

## Changes

- Added `ManualSessionPlaneCanvas` and reused the existing `drawP80` rendering logic, tuned to be more subtle (2 planes, slower speeds, lower opacity, and reduced-motion handling).
- Layered the decorative canvas behind `ManualSessionComposer` on `manual-session-create-page-content.tsx`, so the composer remains the primary focus.
- Added a test assertion verifying the canvas is present and `aria-hidden="true"` to avoid noisy accessibility tree output.

## Validation

- `npm test -- manual-session-create-page-content.test.tsx --run`
- `npm run typecheck`
- `npm run lint`
- `npm run build`

[143.dev](https://143.dev) | [session 6c698999](https://143.dev/sessions/6c698999-8b44-4716-9391-1aaac7ab23af)

<!-- 143 readiness -->
**143 readiness:** not available for this revision.

Preview: https://143.dev/previews/github/assembledhq/143/pull/1583?launch=1