### PR TITLE
Cache startup snapshots for previews that deliver secret files

### DIFF
--- a/internal/services/preview/snapshot_cache.go
+++ b/internal/services/preview/snapshot_cache.go
@@ -41,6 +41,39 @@ const (
 	tarExcludeFlags = `--exclude=.git --exclude='__pycache__' --exclude='.pytest_cache'`
 )
 
+// snapshotExtraExcludeFlags builds tar --exclude flags for additional
+// workspace-relative paths (e.g. runtime secret files) that must never enter
+// the snapshot blob. Each path is emitted in both the bare ("foo.json") and
+// workspace-root ("./foo.json") forms because GNU tar archives members from
+// "-C dir -- ." with a leading "./" while BusyBox tar (alpine images) does not,
+// and an exclude only fires on an exact member-name match. Paths are cleaned and
+// shell-quoted; entries that are empty, absolute, or escape the workspace are
+// dropped (they cannot name a real workspace member, so excluding them is a
+// no-op and including a malformed flag would corrupt the whole tar invocation).
+func snapshotExtraExcludeFlags(paths []string) string {
+	if len(paths) == 0 {
+		return ""
+	}
+	seen := make(map[string]struct{}, len(paths))
+	var flags []string
+	for _, raw := range paths {
+		clean := filepath.ToSlash(filepath.Clean(strings.TrimSpace(raw)))
+		if clean == "" || clean == "." || clean == ".." ||
+			strings.HasPrefix(clean, "/") || strings.HasPrefix(clean, "../") {
+			continue
+		}
+		if _, ok := seen[clean]; ok {
+			continue
+		}
+		seen[clean] = struct{}{}
+		flags = append(flags,
+			"--exclude="+shellQuote(clean),
+			"--exclude="+shellQuote("./"+clean),
+		)
+	}
+	return strings.Join(flags, " ")
+}
+
 // =============================================================================
 // Interfaces
 // =============================================================================
@@ -191,28 +224,38 @@ func ComputeSnapshotBaseKey(lockfileContents []byte, configDigest string) string
 //
 // The method is safe to call concurrently for different sandboxes. Each
 // snapshot is written to a unique file path derived from the snapshot key.
+// excludePaths are additional workspace-relative paths to keep OUT of the
+// snapshot blob — most importantly runtime secret files, which are re-injected
+// on every launch (see runtime_secret_files) and must never be persisted into a
+// worker-local cache blob in plaintext. Pass nil when there is nothing extra to
+// exclude.
 func (sc *SnapshotCache) CreateSnapshot(
 	ctx context.Context,
 	sb *agent.Sandbox,
 	snapshotKey string,
 	metadata SnapshotMetadata,
+	excludePaths []string,
 ) error {
 	log := sc.logger.With().
 		Str("snapshot_key", snapshotKey).
 		Str("sandbox_id", sb.ID).
 		Logger()
 
-	log.Info().Msg("creating filesystem snapshot")
+	log.Info().Int("extra_excludes", len(excludePaths)).Msg("creating filesystem snapshot")
 	start := time.Now()
 
 	// 1. Create the tar.gz inside the sandbox.
 	//    Using shell tar is significantly faster than Go's archive/tar for
 	//    large node_modules trees (parallel I/O, kernel-level buffering).
+	excludeFlags := tarExcludeFlags
+	if extra := snapshotExtraExcludeFlags(excludePaths); extra != "" {
+		excludeFlags += " " + extra
+	}
 	tarCmd := fmt.Sprintf(
 		"tar czf %s -C %s %s -- .",
 		snapshotTmpFile,
 		shellQuote(sb.WorkDir),
-		tarExcludeFlags,
+		excludeFlags,
 	)
 
 	var stderr bytes.Buffer

--- a/internal/services/preview/start_runner.go
+++ b/internal/services/preview/start_runner.go
@@ -129,7 +129,7 @@ type previewStartupCache interface {
 	FindBaseSnapshot(ctx context.Context, orgID, repoID uuid.UUID, baseKey, excludeCommitSHA string) (*CacheHit, error)
 	RestoreSnapshot(ctx context.Context, sb *agent.Sandbox, hit *CacheHit) error
 	ApplyPartialInvalidation(ctx context.Context, sb *agent.Sandbox, hit *CacheHit, gitDiff []byte) error
-	CreateSnapshot(ctx context.Context, sb *agent.Sandbox, snapshotKey string, metadata SnapshotMetadata) error
+	CreateSnapshot(ctx context.Context, sb *agent.Sandbox, snapshotKey string, metadata SnapshotMetadata, excludePaths []string) error
 }
 
 // branchPreviewStartupCacheKeys carries the cache keys computed for one branch
@@ -1598,16 +1598,11 @@ func (r *StartRunner) maybeRestoreBranchPreviewStartupCache(ctx context.Context,
 	if r == nil || r.snapshotCache == nil || r.sandboxProvider == nil || sb == nil || cfg == nil || commitSHA == "" {
 		return branchPreviewStartupCacheKeys{}, nil
 	}
-	if previewConfigHasRuntimeSecretFiles(cfg) {
-		// Runtime secret files are written into the shared workspace during
-		// LaunchPreview. The startup cache snapshots that workspace after
-		// launch, so do not read or write cache entries for these configs:
-		// otherwise worker-local cache blobs could retain plaintext secrets.
-		r.logger.Debug().
-			Str("repository_id", repoID.String()).
-			Msg("branch preview startup cache skipped because config delivers preview secrets as files")
-		return branchPreviewStartupCacheKeys{}, nil
-	}
+	// Configs that deliver runtime secret files are still cached: the secret
+	// destinations are excluded from the snapshot blob at create time (see
+	// createBranchPreviewStartupCache) and re-injected on every launch by the
+	// runtime_secret_files phase, so a restored workspace never carries stale
+	// or persisted plaintext secrets.
 	keys, err := r.computeBranchPreviewStartupCacheKeys(ctx, sb, cfg, commitSHA)
 	if err != nil {
 		r.logger.Warn().Err(err).
@@ -1753,20 +1748,10 @@ func (r *StartRunner) createBranchPreviewStartupCache(ctx context.Context, orgID
 		}
 		return result
 	}
-	if previewConfigHasRuntimeSecretFiles(cfg) {
-		// See maybeRestoreBranchPreviewStartupCache for why secret-file
-		// configs are excluded from the workspace snapshot cache.
-		r.logger.Debug().
-			Str("repository_id", repoID.String()).
-			Str("snapshot_key", keys.SnapshotKey).
-			Msg("branch preview startup cache creation skipped because config delivers preview secrets as files")
-		r.logBranchPreviewStartupSnapshotResult(repoID, keys.SnapshotKey, StartupSnapshotSkippedSecretFiles, 0, started, nil)
-		return StartupSnapshotSkippedSecretFiles
-	}
 	cacheCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 10*time.Minute)
 	defer cancel()
 	metadata := SnapshotMetadata{OrgID: orgID, RepoID: repoID, BaseKey: keys.BaseKey, CommitSHA: keys.CommitSHA}
-	if err := r.snapshotCache.CreateSnapshot(cacheCtx, sb, keys.SnapshotKey, metadata); err != nil {
+	if err := r.snapshotCache.CreateSnapshot(cacheCtx, sb, keys.SnapshotKey, metadata, previewSnapshotExcludePaths(cfg)); err != nil {
 		result := startupSnapshotResultForCreateError(err)
 		r.logger.Warn().Err(err).
 			Str("repository_id", repoID.String()).
@@ -1861,19 +1846,67 @@ func branchPreviewStartupCacheLockfiles(cfg *models.PreviewConfig) []string {
 	return lockfiles
 }
 
-func previewConfigHasRuntimeSecretFiles(cfg *models.PreviewConfig) bool {
+// previewSnapshotExcludePaths returns the workspace-relative paths to keep OUT
+// of the startup snapshot:
+//
+//   - Runtime secret-file destinations, so plaintext secrets never enter a
+//     worker-local blob (re-injected every launch by runtime_secret_files,
+//     after the snapshot is restored).
+//   - Workspace build-cache paths (preview.install.cache.build). These are
+//     already persisted and restored by the dedicated build-cache mechanism
+//     (restorePreviewBuildCache runs right before the build phase), so storing
+//     them in the snapshot too is pure duplication — and for a large monorepo's
+//     Go/turbo caches that bloat can push the blob past the size cap, which
+//     would silently defeat the whole snapshot.
+//
+// Dependency caches (node_modules, .venv, …) are deliberately NOT excluded: the
+// snapshot's value is bundling installed deps + build outputs into one restore
+// so the install phase fully skips, which requires those trees to be present.
+func previewSnapshotExcludePaths(cfg *models.PreviewConfig) []string {
 	if cfg == nil {
-		return false
+		return nil
 	}
-	if len(cfg.RuntimeSecretFiles) > 0 {
-		return true
+	paths := previewRuntimeSecretFilePaths(cfg)
+	if buildCachePaths, ok := ResolvePreviewBuildCachePaths(cfg.Install); ok {
+		paths = append(paths, buildCachePaths...)
+	}
+	return paths
+}
+
+// previewRuntimeSecretFilePaths returns every workspace-relative path the
+// runtime secret resolver writes into the workspace for this config. These are
+// excluded from the startup snapshot so plaintext secrets never enter a
+// worker-local cache blob; the runtime_secret_files phase re-injects them on
+// every launch after the snapshot is restored. The resolved RuntimeSecretFiles
+// (populated during launch) are the authoritative set; the declared bundle
+// Files are unioned in as a belt-and-suspenders guard in case resolution order
+// ever changes. Returns nil when the config delivers no secret files.
+func previewRuntimeSecretFilePaths(cfg *models.PreviewConfig) []string {
+	if cfg == nil {
+		return nil
+	}
+	seen := make(map[string]struct{})
+	var paths []string
+	add := func(raw string) {
+		clean := path.Clean(strings.TrimSpace(raw))
+		if clean == "" || clean == "." {
+			return
+		}
+		if _, ok := seen[clean]; ok {
+			return
+		}
+		seen[clean] = struct{}{}
+		paths = append(paths, clean)
+	}
+	for _, file := range cfg.RuntimeSecretFiles {
+		add(file.Path)
 	}
 	for _, ref := range SecretBundleRefs(cfg) {
-		if len(ref.Files) > 0 {
-			return true
+		for _, file := range ref.Files {
+			add(file)
 		}
 	}
-	return false
+	return paths
 }
 
 func cleanBranchPreviewStartupCachePath(raw string) (string, error) {

--- a/internal/services/preview/start_runner_test.go
+++ b/internal/services/preview/start_runner_test.go
@@ -470,14 +470,15 @@ func (acquireSandboxSnapshotStore) Delete(context.Context, string) error {
 }
 
 type fakePreviewStartupCache struct {
-	findKey       string
-	findRepoID    uuid.UUID
-	findOrgID     uuid.UUID
-	restoreCalled bool
-	createKey     string
-	createMeta    SnapshotMetadata
-	createErr     error
-	hit           *CacheHit
+	findKey        string
+	findRepoID     uuid.UUID
+	findOrgID      uuid.UUID
+	restoreCalled  bool
+	createKey      string
+	createMeta     SnapshotMetadata
+	createExcludes []string
+	createErr      error
+	hit            *CacheHit
 
 	baseFindKey   string
 	baseHit       *CacheHit
@@ -509,9 +510,10 @@ func (f *fakePreviewStartupCache) ApplyPartialInvalidation(_ context.Context, _ 
 	return f.partialErr
 }
 
-func (f *fakePreviewStartupCache) CreateSnapshot(_ context.Context, _ *agent.Sandbox, snapshotKey string, metadata SnapshotMetadata) error {
+func (f *fakePreviewStartupCache) CreateSnapshot(_ context.Context, _ *agent.Sandbox, snapshotKey string, metadata SnapshotMetadata, excludePaths []string) error {
 	f.createKey = snapshotKey
 	f.createMeta = metadata
+	f.createExcludes = append([]string(nil), excludePaths...)
 	return f.createErr
 }
 
@@ -870,12 +872,13 @@ func TestStartRunnerCreateBranchPreviewStartupCache_ReportsTooLarge(t *testing.T
 	require.Equal(t, "cache-key", cache.createKey, "startup snapshot creation should have been attempted before size classification")
 }
 
-func TestStartRunnerBranchPreviewStartupCache_SkipsFileDeliveredSecrets(t *testing.T) {
+func TestStartRunnerBranchPreviewStartupCache_ExcludesFileDeliveredSecrets(t *testing.T) {
 	t.Parallel()
 
-	// The current launch would overwrite restored secret files, but cache
-	// creation happens after launch and would otherwise persist plaintext
-	// generated secret files in worker-local cache blobs.
+	// Secret-file configs are still cached: the secret destinations are excluded
+	// from the snapshot blob at create time (so plaintext secrets never persist
+	// in a worker-local blob) and re-injected on every launch by the
+	// runtime_secret_files phase after the snapshot is restored.
 	orgID := uuid.New()
 	repoID := uuid.New()
 	cfg := &models.PreviewConfig{
@@ -888,6 +891,12 @@ func TestStartRunnerBranchPreviewStartupCache_SkipsFileDeliveredSecrets(t *testi
 		Secrets: []models.PreviewSecretBundleRef{
 			{Bundle: "app-secrets", Services: []string{"web"}, Files: []string{".env.local"}},
 		},
+		// Resolved at launch time; the create path reads these as the
+		// authoritative set of secret destinations to exclude.
+		RuntimeSecretFiles: []models.PreviewRuntimeSecretFile{
+			{Services: []string{"web"}, Path: ".env.local"},
+			{Services: []string{"web"}, Path: "config/api.json"},
+		},
 	}
 	cache := &fakePreviewStartupCache{hit: &CacheHit{}}
 	runner := &StartRunner{
@@ -898,14 +907,87 @@ func TestStartRunnerBranchPreviewStartupCache_SkipsFileDeliveredSecrets(t *testi
 	sb := &agent.Sandbox{ID: "sandbox-1", WorkDir: "/workspace/repo"}
 
 	keys, err := runner.maybeRestoreBranchPreviewStartupCache(context.Background(), orgID, repoID, "abc1234", sb, cfg)
-	require.NoError(t, err, "skipping secret-file configs should not surface an error")
+	require.NoError(t, err, "secret-file configs should not surface an error")
 	result := runner.createBranchPreviewStartupCache(context.Background(), orgID, repoID, branchPreviewStartupCacheKeys{SnapshotKey: "cache-key"}, sb, cfg)
 
-	require.Empty(t, keys.SnapshotKey, "branch preview startup cache should not restore snapshots for configs with generated secret files")
-	require.Empty(t, cache.findKey, "secret-file configs should not query startup cache entries")
-	require.Empty(t, cache.createKey, "secret-file configs should not write startup cache snapshots")
-	require.False(t, cache.restoreCalled, "secret-file configs should not restore cached workspace files")
-	require.Equal(t, StartupSnapshotSkippedSecretFiles, result, "secret-file configs should report the secret-file skip reason")
+	require.NotEmpty(t, keys.SnapshotKey, "secret-file configs should still compute a snapshot key")
+	require.Equal(t, keys.SnapshotKey, cache.findKey, "secret-file configs should query startup cache entries")
+	require.True(t, cache.restoreCalled, "secret-file configs should restore cached workspace files (secrets re-injected after)")
+	require.Equal(t, "cache-key", cache.createKey, "secret-file configs should write startup cache snapshots")
+	require.Equal(t, StartupSnapshotSaved, result, "secret-file configs should now save the startup snapshot")
+	require.ElementsMatch(t, []string{".env.local", "config/api.json"}, cache.createExcludes,
+		"every runtime secret-file destination must be excluded from the snapshot blob")
+}
+
+func TestPreviewRuntimeSecretFilePaths(t *testing.T) {
+	t.Parallel()
+
+	t.Run("unions resolved and declared paths and dedups", func(t *testing.T) {
+		t.Parallel()
+		cfg := &models.PreviewConfig{
+			Secrets: []models.PreviewSecretBundleRef{
+				{Bundle: "b", Services: []string{"web"}, Files: []string{"development.conf.json", "./nested/secret.json"}},
+			},
+			RuntimeSecretFiles: []models.PreviewRuntimeSecretFile{
+				{Path: "development.conf.json"}, // duplicate of a declared path
+				{Path: "extra.env"},
+			},
+		}
+		require.ElementsMatch(t,
+			[]string{"development.conf.json", "nested/secret.json", "extra.env"},
+			previewRuntimeSecretFilePaths(cfg))
+	})
+
+	t.Run("nil config and no secret files", func(t *testing.T) {
+		t.Parallel()
+		require.Nil(t, previewRuntimeSecretFilePaths(nil))
+		require.Nil(t, previewRuntimeSecretFilePaths(&models.PreviewConfig{}))
+	})
+}
+
+func TestPreviewSnapshotExcludePaths(t *testing.T) {
+	t.Parallel()
+
+	// Mirrors assembled's config: secret files + workspace Go build caches that
+	// are persisted separately via install.cache.build and so must not be
+	// duplicated into the snapshot blob.
+	cfg := &models.PreviewConfig{
+		Install: &models.PreviewInstallConfig{
+			Lockfiles: []string{"package-lock.json"},
+			Cache: &models.PreviewInstallCacheConfig{
+				Build: &models.PreviewBuildCacheConfig{
+					Paths: []string{".143/go-mod", ".143/go-build"},
+				},
+			},
+		},
+		Secrets: []models.PreviewSecretBundleRef{
+			{Bundle: "b", Services: []string{"web"}, Files: []string{"development.conf.json"}},
+		},
+	}
+	got := previewSnapshotExcludePaths(cfg)
+	// Secret file + explicit build caches + inferred turbo caches (from the JS
+	// lockfile) should all be excluded.
+	require.Subset(t, got, []string{"development.conf.json", ".143/go-mod", ".143/go-build"})
+	require.Contains(t, got, "node_modules/.cache/turbo")
+	require.Nil(t, previewSnapshotExcludePaths(nil))
+}
+
+func TestSnapshotExtraExcludeFlags(t *testing.T) {
+	t.Parallel()
+
+	t.Run("emits bare and rooted forms, dedups", func(t *testing.T) {
+		t.Parallel()
+		got := snapshotExtraExcludeFlags([]string{"development.conf.json", "development.conf.json"})
+		require.Equal(t,
+			`--exclude='development.conf.json' --exclude='./development.conf.json'`,
+			got)
+	})
+
+	t.Run("drops empty, absolute, and escaping paths", func(t *testing.T) {
+		t.Parallel()
+		require.Empty(t, snapshotExtraExcludeFlags(nil))
+		require.Empty(t, snapshotExtraExcludeFlags([]string{"", "  ", "/etc/passwd", "../escape", ".."}))
+	})
 }
 
 func TestSessionPreviewPrewarmStatusForCacheStatus(t *testing.T) {


### PR DESCRIPTION
## Problem

Previews whose `.143/config.json` delivers runtime secret files (via `secrets[].files`, e.g. assembled's `development.conf.json`) were **hard-excluded from the startup snapshot cache**. `previewConfigHasRuntimeSecretFiles` short-circuited *both* the restore and create paths so plaintext secrets could never be baked into a worker-local snapshot blob.

The cost: these previews could never reuse a snapshot and paid the **full cold install + build on every launch**. For a large monorepo (assembled) that's ~5–8 min each time, and `preview_startup_cache` stayed **empty for every such repo**.

## Fix

Instead of refusing to snapshot these configs, exclude only the paths that shouldn't live in the blob:

- **Runtime secret-file destinations** — so plaintext secrets never persist in a worker-local blob. They're re-injected on every launch by `runtime_secret_files`, which runs *after* the snapshot is restored, so a restored workspace never carries stale/persisted secrets.
- **Workspace build-cache paths** (`preview.install.cache.build`) — already persisted/restored by the dedicated build-cache mechanism (`restorePreviewBuildCache` runs right before the build phase). Duplicating them in the snapshot is wasteful, and for a large monorepo's Go/turbo caches that bloat can push the blob past the size cap and silently defeat the snapshot.

`CreateSnapshot` now takes `excludePaths []string`; `snapshotExtraExcludeFlags` emits each in both bare (`foo`) and `./`-rooted (`./foo`) forms so GNU tar (members stored with `./`) and BusyBox tar (alpine) both match. Dependency caches (node_modules, .venv, …) are **not** excluded — the snapshot's value is bundling installed deps + build outputs into one restore so the install phase fully skips, which needs those trees present.

## Tests

- `make lint` clean; full `internal/services/preview` package tests pass.
- New: `TestStartRunnerBranchPreviewStartupCache_ExcludesFileDeliveredSecrets`, `TestPreviewRuntimeSecretFilePaths`, `TestPreviewSnapshotExcludePaths`, `TestSnapshotExtraExcludeFlags`.

## Note

This is half the fix for fast assembled previews. The snapshot restores the workspace but `runServiceBuilds` still runs the repo's `build` command unconditionally, so the repo's `.143/preview-build.sh` must self-skip when this commit's artifacts are already present (handled on the assembled side in `wangjohn/preview-seeded-postgres`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
