### PR TITLE
Fix invite modal state and default GitHub username handling

### DIFF
--- a/frontend/src/app/(dashboard)/settings/team/page.test.tsx
+++ b/frontend/src/app/(dashboard)/settings/team/page.test.tsx
@@ -183,9 +183,10 @@ describe('TeamSettingsPage', () => {
     await userEvent.click(screen.getByRole('button', { name: 'Invite' }));
 
     expect(screen.getByText('Invite a member')).toBeInTheDocument();
-    expect(screen.getByRole('textbox', { name: 'Email' })).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: 'GitHub username' })).toHaveAttribute('data-state', 'active');
+    expect(screen.getByPlaceholderText('octocat')).toBeInTheDocument();
+    expect(screen.getByLabelText('Notification email')).toBeInTheDocument();
     expect(screen.getByText('Invite setup')).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Add email' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Send invite' })).toBeDisabled();
   });
 
@@ -194,6 +195,7 @@ describe('TeamSettingsPage', () => {
 
     await userEvent.click(await screen.findByRole('button', { name: 'Invite' }));
 
+    await userEvent.click(screen.getByRole('tab', { name: 'Email' }));
     const emailInput = await screen.findByRole('textbox', { name: 'Email' });
     expect(emailInput).toHaveClass('h-9');
   });
@@ -261,23 +263,18 @@ describe('TeamSettingsPage', () => {
     expect(screen.getAllByText('Actions').length).toBeGreaterThan(0);
   });
 
-  it('adds an email invite draft before submission', async () => {
+  it('submits a live email invite without a separate draft step', async () => {
     const user = userEvent.setup();
     renderWithProviders(<TeamSettingsPage />);
 
     await user.click(await screen.findByRole('button', { name: 'Invite' }));
+    await user.click(screen.getByRole('tab', { name: 'Email' }));
 
     await waitFor(() => {
       expect(screen.getByRole('textbox', { name: 'Email' })).toBeInTheDocument();
     });
 
     await user.type(screen.getByRole('textbox', { name: 'Email' }), 'newuser@test.com');
-    await user.click(screen.getByRole('button', { name: 'Add email' }));
-
-    expect(await screen.findByText('newuser@test.com')).toBeInTheDocument();
-    expect(screen.getByRole('textbox', { name: 'Email' })).toBeDisabled();
-    expect(screen.getByRole('button', { name: 'Add email' })).toBeDisabled();
-    expect(screen.getByRole('button', { name: 'Change' })).toBeInTheDocument();
 
     await user.click(
       screen.getByRole('button', { name: 'Send invite to newuser@test.com' }),
@@ -286,6 +283,32 @@ describe('TeamSettingsPage', () => {
     await waitFor(() => {
       expect(createInvitationMock).toHaveBeenCalledWith({ email: 'newuser@test.com', role: 'member' });
     });
+  });
+
+  it('does not leak the email field across invite tabs', async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<TeamSettingsPage />);
+
+    await user.click(await screen.findByRole('button', { name: 'Invite' }));
+    await user.click(screen.getByRole('tab', { name: 'Email' }));
+    await user.type(screen.getByRole('textbox', { name: 'Email' }), 'newuser@test.com');
+
+    await user.click(screen.getByRole('tab', { name: 'GitHub username' }));
+    expect(screen.getByLabelText('Notification email')).toHaveValue('');
+
+    await user.type(screen.getByPlaceholderText('octocat'), 'octocat');
+    await user.click(screen.getByRole('button', { name: 'Send invite to @octocat' }));
+
+    await waitFor(() => {
+      expect(createInvitationMock).toHaveBeenCalledWith({
+        github_username: 'octocat',
+        acceptance_method: 'github',
+        role: 'member',
+      });
+    });
+    expect(createInvitationMock).not.toHaveBeenCalledWith(
+      expect.objectContaining({ email: 'newuser@test.com' }),
+    );
   });
 
   it('offers builder as an invite role option', async () => {
@@ -310,8 +333,8 @@ describe('TeamSettingsPage', () => {
     expect(screen.getByLabelText('Role')).toHaveTextContent('Engineer');
 
     await user.click(screen.getByRole('option', { name: 'Engineer' }));
+    await user.click(screen.getByRole('tab', { name: 'Email' }));
     await user.type(screen.getByRole('textbox', { name: 'Email' }), 'engineer@test.com');
-    await user.click(screen.getByRole('button', { name: 'Add email' }));
     await user.click(screen.getByRole('button', { name: 'Send invite to engineer@test.com' }));
 
     await waitFor(() => {
@@ -559,12 +582,11 @@ describe('TeamSettingsPage', () => {
     expect(avatarFallbacks.length).toBeGreaterThanOrEqual(1);
   });
 
-  it('adds a github invite draft via the fallback input when GitHub is not connected', async () => {
+  it('submits a GitHub invite from the fallback input when GitHub is not connected', async () => {
     const user = userEvent.setup();
     renderWithProviders(<TeamSettingsPage />);
 
     await user.click(await screen.findByRole('button', { name: 'Invite' }));
-    await user.click(screen.getByRole('tab', { name: 'GitHub username' }));
 
     expect(
       await screen.findByText('Connect a GitHub App to search for users.'),
@@ -572,10 +594,8 @@ describe('TeamSettingsPage', () => {
 
     const input = screen.getByPlaceholderText('octocat');
     await user.type(input, '@octocat');
-    await user.click(screen.getByRole('button', { name: 'Add GitHub username' }));
 
     expect(await screen.findByText('@octocat')).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Change' })).toBeInTheDocument();
 
     await user.click(screen.getByRole('button', { name: 'Send invite to @octocat' }));
 
@@ -593,11 +613,9 @@ describe('TeamSettingsPage', () => {
     renderWithProviders(<TeamSettingsPage />);
 
     await user.click(await screen.findByRole('button', { name: 'Invite' }));
-    await user.click(screen.getByRole('tab', { name: 'GitHub username' }));
 
     await user.type(screen.getByPlaceholderText('octocat'), 'octocat');
     await user.type(screen.getByLabelText('Notification email'), 'octo@example.com');
-    await user.click(screen.getByRole('button', { name: 'Add GitHub username' }));
 
     expect(await screen.findByText('@octocat')).toBeInTheDocument();
     expect(screen.getByText(/octo@example\.com/)).toBeInTheDocument();
@@ -614,17 +632,16 @@ describe('TeamSettingsPage', () => {
     });
   });
 
-  it('keeps GitHub submit disabled until an invite draft exists', async () => {
+  it('keeps GitHub submit disabled until a username is present', async () => {
     const user = userEvent.setup();
     renderWithProviders(<TeamSettingsPage />);
 
     await user.click(await screen.findByRole('button', { name: 'Invite' }));
-    await user.click(screen.getByRole('tab', { name: 'GitHub username' }));
     expect(screen.getByRole('button', { name: 'Send invite' })).toBeDisabled();
     expect(createInvitationMock).not.toHaveBeenCalled();
   });
 
-  it('moves a selected GitHub user into the invite setup when connected', async () => {
+  it('keeps the notification email editable after selecting a GitHub user when connected', async () => {
     githubInviteStatusMock.mockResolvedValue({ data: { connected: true } });
     searchGitHubUsersMock.mockResolvedValue({
       data: [{ login: 'octocat', avatar_url: 'https://example.com/a.png' }],
@@ -635,7 +652,6 @@ describe('TeamSettingsPage', () => {
     renderWithProviders(<TeamSettingsPage />);
 
     await user.click(await screen.findByRole('button', { name: 'Invite' }));
-    await user.click(screen.getByRole('tab', { name: 'GitHub username' }));
 
     const commandInput = await screen.findByPlaceholderText(
       'Search GitHub users...',
@@ -646,14 +662,16 @@ describe('TeamSettingsPage', () => {
     await user.click(suggestion);
 
     expect(await screen.findByText('Invite setup')).toBeInTheDocument();
-    expect(await screen.findByText('GitHub invitee added to this invite.')).toBeInTheDocument();
-    expect(screen.getByText('@octocat')).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Change' })).toBeInTheDocument();
+    expect(screen.getAllByText('@octocat').length).toBeGreaterThan(0);
+    const emailInput = screen.getByLabelText('Notification email');
+    expect(emailInput).toBeEnabled();
+    await user.type(emailInput, 'updated@example.com');
 
     await user.click(screen.getByRole('button', { name: 'Send invite to @octocat' }));
 
     await waitFor(() => {
       expect(createInvitationMock).toHaveBeenCalledWith({
+        email: 'updated@example.com',
         github_username: 'octocat',
         acceptance_method: 'github',
         role: 'member',

--- a/frontend/src/app/(dashboard)/settings/team/page.tsx
+++ b/frontend/src/app/(dashboard)/settings/team/page.tsx
@@ -54,19 +54,13 @@ import type {
   GitHubUserSuggestion,
 } from "@/lib/types";
 
-type InviteDraft =
-  | { mode: "email"; value: string }
-  | { mode: "github"; value: string; avatarUrl?: string; notificationEmail?: string };
-
 export default function TeamSettingsPage() {
   const queryClient = useQueryClient();
   const { user: currentUser } = useAuth();
   const canManageTeam = currentUser?.role === "admin";
   const [inviteEmail, setInviteEmail] = useState("");
   const [inviteRole, setInviteRole] = useState("member");
-  const [inviteMode, setInviteMode] = useState<"email" | "github">("email");
-  const [inviteDraft, setInviteDraft] = useState<InviteDraft | null>(null);
-  const [githubNotificationEmail, setGithubNotificationEmail] = useState("");
+  const [inviteMode, setInviteMode] = useState<"email" | "github">("github");
   const [inviteError, setInviteError] = useState("");
   const [actionError, setActionError] = useState("");
   const [isInviteDialogOpen, setIsInviteDialogOpen] = useState(false);
@@ -77,6 +71,8 @@ export default function TeamSettingsPage() {
   } | null>(null);
   const [ghSearchQuery, setGhSearchQuery] = useState("");
   const [debouncedGhQuery, setDebouncedGhQuery] = useState("");
+  const [selectedGitHubAvatarUrl, setSelectedGitHubAvatarUrl] = useState<string | undefined>();
+  const [ghUserSelected, setGhUserSelected] = useState(false);
 
   const { data: membersData, isLoading: membersLoading } = useQuery<ListResponse<User>>({
     queryKey: ["team", "members"],
@@ -106,7 +102,8 @@ export default function TeamSettingsPage() {
     githubConnected &&
     inviteMode === "github" &&
     isInviteDialogOpen &&
-    debouncedGhQuery.length > 0;
+    debouncedGhQuery.length > 0 &&
+    !ghUserSelected;
 
   const { data: ghSearchData, isFetching: ghSearchLoading } = useQuery<
     ListResponse<GitHubUserSuggestion>
@@ -179,82 +176,56 @@ export default function TeamSettingsPage() {
   const resetInviteForm = () => {
     setInviteEmail("");
     setInviteRole("member");
-    setInviteMode("email");
-    setInviteDraft(null);
-    setGithubNotificationEmail("");
+    setInviteMode("github");
     setInviteError("");
     setGhSearchQuery("");
     setDebouncedGhQuery("");
-  };
-
-  const clearInviteDraft = () => {
-    setInviteDraft(null);
-    setInviteError("");
-  };
-
-  const addEmailDraft = () => {
-    const email = inviteEmail.trim();
-    if (!email) {
-      setInviteError("Add an email address to the invite.");
-      return;
-    }
-
-    setInviteDraft({ mode: "email", value: email });
-    setInviteError("");
-  };
-
-  const addGitHubDraft = (username: string, avatarUrl?: string) => {
-    const normalizedUsername = username.trim().replace(/^@/, "");
-    const notificationEmail = githubNotificationEmail.trim();
-    if (!normalizedUsername) {
-      setInviteError("Add a GitHub username to the invite.");
-      return;
-    }
-
-    setInviteDraft({
-      mode: "github",
-      value: normalizedUsername,
-      avatarUrl,
-      notificationEmail: notificationEmail || undefined,
-    });
-    setInviteError("");
-    setGhSearchQuery("");
-    setDebouncedGhQuery("");
+    setSelectedGitHubAvatarUrl(undefined);
+    setGhUserSelected(false);
   };
 
   function handleInvite(e: React.FormEvent) {
     e.preventDefault();
     setInviteError("");
-    if (!inviteDraft || inviteDraft.mode !== inviteMode) {
-      setInviteError(
-        inviteMode === "email"
-          ? "Add an email address to the invite."
-          : "Add a GitHub username to the invite.",
-      );
+    const email = inviteEmail.trim();
+    const githubUsername = ghSearchQuery.trim().replace(/^@/, "");
+
+    if (inviteMode === "email") {
+      if (!email) {
+        setInviteError("Add an email address to the invite.");
+        return;
+      }
+
+      inviteMutation.mutate({ email, role: inviteRole });
       return;
     }
 
-    if (inviteDraft.mode === "email") {
-      inviteMutation.mutate({ email: inviteDraft.value, role: inviteRole });
+    if (!githubUsername) {
+      setInviteError("Add a GitHub username to the invite.");
       return;
     }
 
     inviteMutation.mutate({
-      ...(inviteDraft.notificationEmail ? { email: inviteDraft.notificationEmail } : {}),
-      github_username: inviteDraft.value,
+      ...(email ? { email } : {}),
+      github_username: githubUsername,
       acceptance_method: "github",
       role: inviteRole,
     });
   }
 
-  const inviteDraftLabel = inviteDraft
-    ? inviteDraft.mode === "github"
-      ? `@${inviteDraft.value}`
-      : inviteDraft.value
-    : "";
-  const submitInviteLabel = inviteDraft
-    ? `Send invite to ${inviteDraftLabel}`
+  const normalizedGitHubUsername = ghSearchQuery.trim().replace(/^@/, "");
+  const trimmedInviteEmail = inviteEmail.trim();
+  const inviteeLabel = inviteMode === "github"
+    ? normalizedGitHubUsername
+      ? `@${normalizedGitHubUsername}`
+      : ""
+    : trimmedInviteEmail;
+  const submitInviteLabel = inviteeLabel
+    ? `Send invite to ${inviteeLabel}`
     : "Send invite";
+  const canSubmitInvite = inviteMode === "github"
+    ? normalizedGitHubUsername.length > 0
+    : trimmedInviteEmail.length > 0;
 
   const roleBadgeVariant = (role: string) => {
     switch (role) {
@@ -283,10 +254,6 @@ export default function TeamSettingsPage() {
       </Badge>
     );
   };
-
-  const inviteDraftMatchesMode = inviteDraft?.mode === inviteMode;
-  const emailDraftActive = inviteMode === "email" && inviteDraftMatchesMode;
-  const githubDraftActive = inviteMode === "github" && inviteDraftMatchesMode;
 
   return (
     <PageContainer size="default">
@@ -553,8 +520,11 @@ export default function TeamSettingsPage() {
                   const nextMode = v as "email" | "github";
                   setInviteMode(nextMode);
                   setInviteError("");
-                  setInviteDraft(null);
-                  setGithubNotificationEmail("");
+                  setInviteEmail("");
+                  setGhSearchQuery("");
+                  setDebouncedGhQuery("");
+                  setSelectedGitHubAvatarUrl(undefined);
+                  setGhUserSelected(false);
                 }}
               >
                 <TabsList className="w-full">
@@ -569,31 +539,19 @@ export default function TeamSettingsPage() {
                   <div className="space-y-3">
                     <div className="space-y-1.5">
                       <Label htmlFor="invite-email">Email</Label>
-                      <div className="flex gap-2">
-                        <Input
-                          id="invite-email"
-                          type="email"
-                          placeholder="colleague@company.com"
-                          value={inviteEmail}
-                          disabled={emailDraftActive}
-                          onChange={(e) => {
-                            setInviteEmail(e.target.value);
-                            setInviteError("");
-                          }}
-                          className="h-9"
-                        />
-                        <Button
-                          type="button"
-                          variant="secondary"
-                          className="h-9 shrink-0"
-                          disabled={emailDraftActive}
-                          onClick={addEmailDraft}
-                        >
-                          Add email
-                        </Button>
-                      </div>
+                      <Input
+                        id="invite-email"
+                        type="email"
+                        placeholder="colleague@company.com"
+                        value={inviteEmail}
+                        onChange={(e) => {
+                          setInviteEmail(e.target.value);
+                          setInviteError("");
+                        }}
+                        className="h-9"
+                      />
                       <p className="text-xs text-muted-foreground">
-                        Add the email to the invite setup below before sending.
+                        The invitee will accept with this email address.
                       </p>
                     </div>
                   </div>
@@ -610,13 +568,14 @@ export default function TeamSettingsPage() {
                                 id="invite-github"
                                 placeholder="Search GitHub users..."
                                 value={ghSearchQuery}
-                                disabled={githubDraftActive}
                                 onValueChange={(value) => {
                                   setGhSearchQuery(value);
+                                  setSelectedGitHubAvatarUrl(undefined);
+                                  setGhUserSelected(false);
                                   setInviteError("");
                                 }}
                               />
-                              {debouncedGhQuery.length > 0 && (
+                              {debouncedGhQuery.length > 0 && !ghUserSelected && (
                                 <CommandList className="max-h-48">
                                   {ghSearchLoading ? (
                                     <div className="py-3 text-center text-xs text-muted-foreground">
@@ -636,12 +595,12 @@ export default function TeamSettingsPage() {
                                         <CommandItem
                                           key={user.login}
                                           value={user.login}
-                                          onSelect={() =>
-                                            addGitHubDraft(
-                                              user.login,
-                                              user.avatar_url,
-                                            )
-                                          }
+                                          onSelect={() => {
+                                            setGhSearchQuery(user.login);
+                                            setSelectedGitHubAvatarUrl(user.avatar_url);
+                                            setGhUserSelected(true);
+                                            setInviteError("");
+                                          }}
                                         >
                                           {user.avatar_url && (
                                             /* eslint-disable-next-line @next/next/no-img-element */
@@ -662,46 +621,24 @@ export default function TeamSettingsPage() {
                               )}
                             </Command>
                           </div>
-                          <div className="flex items-center justify-between gap-3">
-                            <p className="text-xs text-muted-foreground">
-                              Search GitHub and choose a result, or add the typed
-                              username directly.
-                            </p>
-                            <Button
-                              type="button"
-                              variant="secondary"
-                              className="h-9 shrink-0"
-                              disabled={githubDraftActive}
-                              onClick={() => addGitHubDraft(ghSearchQuery)}
-                            >
-                              Add GitHub username
-                            </Button>
-                          </div>
+                          <p className="text-xs text-muted-foreground">
+                            Search GitHub and choose a result, or type a
+                            username directly.
+                          </p>
                         </>
                       ) : (
                         <>
-                          <div className="flex gap-2">
-                            <Input
-                              id="invite-github"
-                              placeholder="octocat"
-                              value={ghSearchQuery}
-                              disabled={githubDraftActive}
-                              onChange={(e) => {
-                                setGhSearchQuery(e.target.value);
-                                setInviteError("");
-                              }}
-                              className="h-9"
-                            />
-                            <Button
-                              type="button"
-                              variant="secondary"
-                              className="h-9 shrink-0"
-                              disabled={githubDraftActive}
-                              onClick={() => addGitHubDraft(ghSearchQuery)}
-                            >
-                              Add GitHub username
-                            </Button>
-                          </div>
+                          <Input
+                            id="invite-github"
+                            placeholder="octocat"
+                            value={ghSearchQuery}
+                            onChange={(e) => {
+                              setGhSearchQuery(e.target.value);
+                              setSelectedGitHubAvatarUrl(undefined);
+                              setInviteError("");
+                            }}
+                            className="h-9"
+                          />
                           <p className="text-xs text-muted-foreground">
                             Connect a GitHub App to search for users.
                           </p>
@@ -714,10 +651,9 @@ export default function TeamSettingsPage() {
                         id="invite-github-notification-email"
                         type="email"
                         placeholder="colleague@company.com"
-                        value={githubNotificationEmail}
-                        disabled={githubDraftActive}
+                        value={inviteEmail}
                         onChange={(e) => {
-                          setGithubNotificationEmail(e.target.value);
+                          setInviteEmail(e.target.value);
                           setInviteError("");
                         }}
                         className="h-9"
@@ -730,35 +666,22 @@ export default function TeamSettingsPage() {
                 </TabsContent>
               </Tabs>
               <div className="space-y-2 rounded-lg border border-dashed border-border bg-muted/20 p-4">
-                <div className="flex items-center justify-between gap-2">
-                  <div>
-                    <p className="text-sm font-medium text-foreground">
-                      Invite setup
-                    </p>
-                    <p className="text-xs text-muted-foreground">
-                      Review the invitee below before sending the invite.
-                    </p>
-                  </div>
-                  {inviteDraftMatchesMode && (
-                    <Button
-                      type="button"
-                      variant="ghost"
-                      size="sm"
-                      className="h-8"
-                      onClick={clearInviteDraft}
-                    >
-                      Change
-                    </Button>
-                  )}
+                <div>
+                  <p className="text-sm font-medium text-foreground">
+                    Invite setup
+                  </p>
+                  <p className="text-xs text-muted-foreground">
+                    This updates as you edit the fields above.
+                  </p>
                 </div>
-                {inviteDraftMatchesMode ? (
+                {inviteeLabel ? (
                   <div className="flex items-center gap-3 rounded-lg border border-border bg-background px-3 py-3">
                     <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-muted text-muted-foreground">
-                      {inviteDraft.mode === "github" ? (
-                        inviteDraft.avatarUrl ? (
+                      {inviteMode === "github" ? (
+                        selectedGitHubAvatarUrl ? (
                           /* eslint-disable-next-line @next/next/no-img-element */
                           <img
-                            src={inviteDraft.avatarUrl}
+                            src={selectedGitHubAvatarUrl}
                             alt=""
                             className="h-10 w-10 rounded-full"
                           />
@@ -771,14 +694,14 @@ export default function TeamSettingsPage() {
                     </div>
                     <div className="min-w-0">
                       <p className="text-sm font-medium text-foreground">
-                        {inviteDraftLabel}
+                        {inviteeLabel}
                       </p>
                       <p className="text-xs text-muted-foreground">
-                        {inviteDraft.mode === "github"
-                          ? inviteDraft.notificationEmail
-                            ? `Email notification will go to ${inviteDraft.notificationEmail}.`
-                            : "GitHub invitee added to this invite."
-                          : "Email invitee added to this invite."}
+                        {inviteMode === "github"
+                          ? trimmedInviteEmail
+                            ? `Email notification will go to ${trimmedInviteEmail}.`
+                            : "Acceptance will require this GitHub account."
+                          : "Acceptance will require this email address."}
                       </p>
                     </div>
                   </div>
@@ -793,8 +716,8 @@ export default function TeamSettingsPage() {
                       </p>
                       <p className="text-xs text-muted-foreground">
                         {inviteMode === "email"
-                          ? "Add an email above to create the invite draft."
-                          : "Choose a GitHub user above to create the invite draft."}
+                          ? "Enter an email above to send an invite."
+                          : "Choose or type a GitHub username above to send an invite."}
                       </p>
                     </div>
                   </div>
@@ -823,8 +746,7 @@ export default function TeamSettingsPage() {
                   type="submit"
                   disabled={
                     inviteMutation.isPending ||
-                    !inviteDraft ||
-                    inviteDraft.mode !== inviteMode
+                    !canSubmitInvite
                   }
                 >
                   {inviteMutation.isPending ? "Sending..." : submitInviteLabel}


### PR DESCRIPTION
## Summary

The Team Settings “Invite” modal could retain or mix form state across invite methods (Email vs GitHub), causing confusing UI and risking sending the wrong invitation payload. This change tightens the modal’s tab-driven state so the correct fields are active and cleared when switching, and updates tests to reflect the default GitHub username and live email submission flow.

## Changes

- Make the invite modal start on the GitHub username tab by default and ensure the GitHub username input shows the expected placeholder/initial value.
- Remove the extra “email draft” step in the invite flow: email invites are now submitted directly from the Email tab.
- Prevent cross-tab leakage: typing an email, switching tabs, and then inviting via GitHub must not trigger an email-based API call or leave stale email values around.

## Validation

- Updated and extended frontend tests in `frontend/src/app/(dashboard)/settings/team/page.test.tsx` to cover:
  - GitHub tab default state and placeholder rendering
  - Live email invite submission without a separate draft action
  - No email field leakage when switching invite tabs
- Ran the existing test suite for this page (`page.test.tsx`) via repo test commands/CI.

[143.dev](https://143.dev) | [session dbe3259b](https://143.dev/sessions/dbe3259b-e381-49d4-8841-cf287b19f524)

<!-- 143 readiness -->
**143 readiness:** not available for this revision.

Preview: https://143.dev/previews/github/assembledhq/143/pull/1587?launch=1