### PR TITLE
Refresh session before admitting queued threads

### DIFF
--- a/internal/services/agent/orchestrator.go
+++ b/internal/services/agent/orchestrator.go
@@ -4625,30 +4625,40 @@ func (o *Orchestrator) drainQueuedMessagesAfterProcessedID(ctx context.Context, 
 }
 
 func (o *Orchestrator) admitNextQueuedThread(ctx context.Context, session *models.Session, log zerolog.Logger) {
-	if o == nil || session == nil || o.sessionThreads == nil || o.jobs == nil {
+	if o == nil || session == nil || o.sessions == nil || o.sessionThreads == nil || o.jobs == nil {
 		return
 	}
-	thread, err := o.sessionThreads.ClaimNextQueuedForSession(ctx, session.OrgID, session.ID, models.MaxRunningThreadsPerSession)
+	current, err := o.sessions.GetByID(ctx, session.OrgID, session.ID)
+	if err != nil {
+		log.Warn().Err(err).
+			Str("session_id", session.ID.String()).
+			Msg("failed to refresh session before admitting queued thread")
+		return
+	}
+	if current.Status != models.SessionStatusRunning {
+		return
+	}
+	thread, err := o.sessionThreads.ClaimNextQueuedForSession(ctx, current.OrgID, current.ID, models.MaxRunningThreadsPerSession)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return
 		}
 		log.Warn().Err(err).
-			Str("session_id", session.ID.String()).
+			Str("session_id", current.ID.String()).
 			Msg("failed to claim next queued sibling thread")
 		return
 	}
 	payload := map[string]string{
-		"session_id": session.ID.String(),
+		"session_id": current.ID.String(),
 		"thread_id":  thread.ID.String(),
-		"org_id":     session.OrgID.String(),
+		"org_id":     current.OrgID.String(),
 	}
 	dedupeKey := continueSessionDedupeKey(thread.ID)
-	if _, err := o.jobs.EnqueueWithTarget(ctx, session.OrgID, "agent", "continue_session", payload, 5, &dedupeKey, models.SessionWorkerTarget(session)); err != nil {
+	if _, err := o.jobs.EnqueueWithTarget(ctx, current.OrgID, "agent", "continue_session", payload, 5, &dedupeKey, models.SessionWorkerTarget(&current)); err != nil {
 		log.Warn().Err(err).
 			Str("thread_id", thread.ID.String()).
 			Msg("failed to enqueue queued sibling thread after slot opened")
-		if revertErr := o.sessionThreads.UpdateStatus(ctx, session.OrgID, thread.ID, models.ThreadStatusIdle); revertErr != nil {
+		if revertErr := o.sessionThreads.UpdateStatus(ctx, current.OrgID, thread.ID, models.ThreadStatusIdle); revertErr != nil {
 			log.Warn().Err(revertErr).
 				Str("thread_id", thread.ID.String()).
 				Msg("failed to revert queued sibling thread after enqueue failure")

--- a/internal/services/agent/orchestrator_drain_internal_test.go
+++ b/internal/services/agent/orchestrator_drain_internal_test.go
@@ -194,6 +194,9 @@ func (j *drainStubJobs) OldestPendingSessionJobAge(context.Context) (time.Durati
 type drainStubThreads struct {
 	clearedThreadIDs []uuid.UUID
 	clearErr         error
+	nextQueuedThread models.SessionThread
+	claimNextErr     error
+	claimNextCalls   int
 }
 
 func (t *drainStubThreads) UpdateStatus(context.Context, uuid.UUID, uuid.UUID, models.ThreadStatus) error {
@@ -213,7 +216,14 @@ func (t *drainStubThreads) ClearPendingMessages(_ context.Context, _, threadID u
 	return nil
 }
 func (t *drainStubThreads) ClaimNextQueuedForSession(context.Context, uuid.UUID, uuid.UUID, int) (models.SessionThread, error) {
-	return models.SessionThread{}, pgx.ErrNoRows
+	t.claimNextCalls++
+	if t.claimNextErr != nil {
+		return models.SessionThread{}, t.claimNextErr
+	}
+	if t.nextQueuedThread.ID == uuid.Nil {
+		return models.SessionThread{}, pgx.ErrNoRows
+	}
+	return t.nextQueuedThread, nil
 }
 
 type drainStubHumanInputs struct {
@@ -520,4 +530,63 @@ func TestDrainQueuedMessages_NilProcessedNoOp(t *testing.T) {
 	o.drainQueuedMessages(context.Background(), &models.Session{}, nil, nil, zerolog.Nop())
 
 	require.Empty(t, jobs.enqueues, "drain must no-op when no message was processed")
+}
+
+func TestAdmitNextQueuedThread_SkipsTerminalSessionStatus(t *testing.T) {
+	t.Parallel()
+
+	orgID := uuid.New()
+	sessionID := uuid.New()
+	threadID := uuid.New()
+	sessions := &drainStubSessions{session: models.Session{
+		ID:     sessionID,
+		OrgID:  orgID,
+		Status: models.SessionStatusFailed,
+	}}
+	jobs := &drainStubJobs{}
+	threads := &drainStubThreads{nextQueuedThread: models.SessionThread{
+		ID:        threadID,
+		OrgID:     orgID,
+		SessionID: sessionID,
+		Status:    models.ThreadStatusRunning,
+	}}
+	o := newDrainOrchestrator(nil, sessions, jobs, threads)
+
+	o.admitNextQueuedThread(context.Background(), &models.Session{ID: sessionID, OrgID: orgID}, zerolog.Nop())
+
+	require.Zero(t, threads.claimNextCalls, "terminal sessions must not claim queued threads after a runtime closes")
+	require.Empty(t, jobs.enqueues, "terminal sessions must not enqueue follow-up continue_session jobs")
+}
+
+func TestAdmitNextQueuedThread_EnqueuesForDrainableSession(t *testing.T) {
+	t.Parallel()
+
+	orgID := uuid.New()
+	sessionID := uuid.New()
+	threadID := uuid.New()
+	workerNodeID := "worker-a"
+	containerID := "container-a"
+	sessions := &drainStubSessions{session: models.Session{
+		ID:           sessionID,
+		OrgID:        orgID,
+		Status:       models.SessionStatusRunning,
+		WorkerNodeID: &workerNodeID,
+		ContainerID:  &containerID,
+	}}
+	jobs := &drainStubJobs{}
+	threads := &drainStubThreads{nextQueuedThread: models.SessionThread{
+		ID:        threadID,
+		OrgID:     orgID,
+		SessionID: sessionID,
+		Status:    models.ThreadStatusRunning,
+	}}
+	o := newDrainOrchestrator(nil, sessions, jobs, threads)
+
+	o.admitNextQueuedThread(context.Background(), &models.Session{ID: sessionID, OrgID: orgID}, zerolog.Nop())
+
+	require.Equal(t, 1, threads.claimNextCalls, "drainable sessions should claim one queued thread when a runtime slot opens")
+	require.Len(t, jobs.enqueues, 1, "drainable sessions should enqueue the claimed thread")
+	require.Equal(t, "continue_session", jobs.enqueues[0].jobType, "admitted queued threads should resume through continue_session")
+	require.Equal(t, continueSessionDedupeKey(threadID), jobs.enqueues[0].dedupeKey, "admitted queued threads should be deduped by thread")
+	require.Equal(t, workerNodeID, jobs.enqueues[0].targetNodeID, "admitted queued threads should stay pinned to the session worker")
 }


### PR DESCRIPTION
## Summary
- Refresh the session from storage before admitting queued threads
- Skip admission for terminal sessions so they do not reopen work after closure
- Add drain tests covering terminal-session no-op and successful enqueue behavior

## Testing
- Unit tests added for `admitNextQueuedThread` to verify terminal sessions are skipped and running sessions enqueue the claimed thread