### PR TITLE
Add focused frontend unit tests to raise coverage and unblock 80% gate

### DIFF
--- a/frontend/src/components/AutosaveIndicator.test.tsx
+++ b/frontend/src/components/AutosaveIndicator.test.tsx
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+
+import { renderWithProviders, screen } from "@/test/test-utils";
+import { AutosaveIndicator } from "./AutosaveIndicator";
+
+describe("AutosaveIndicator", () => {
+  it("reserves an empty live status region when idle", () => {
+    renderWithProviders(<AutosaveIndicator status="idle" className="custom" />);
+
+    const status = screen.getByRole("status");
+    expect(status).toHaveClass("custom");
+    expect(status).toHaveTextContent("");
+  });
+
+  it("renders the saving state", () => {
+    renderWithProviders(<AutosaveIndicator status="saving" />);
+
+    expect(screen.getByRole("status")).toHaveTextContent("Saving…");
+  });
+
+  it("renders the saved state", () => {
+    renderWithProviders(<AutosaveIndicator status="saved" />);
+
+    expect(screen.getByRole("status")).toHaveTextContent("Saved");
+  });
+
+  it("renders the error state", () => {
+    renderWithProviders(<AutosaveIndicator status="error" />);
+
+    expect(screen.getByRole("status")).toHaveTextContent("Couldn't save");
+  });
+});

--- a/frontend/src/components/agent-badge.test.tsx
+++ b/frontend/src/components/agent-badge.test.tsx
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+
+import { renderWithProviders, screen } from "@/test/test-utils";
+import { AgentBadge } from "./agent-badge";
+
+describe("AgentBadge", () => {
+  it("renders a known agent icon and label", () => {
+    const { container } = renderWithProviders(<AgentBadge agentType="codex" />);
+
+    expect(screen.getByText("Codex")).toBeInTheDocument();
+    const icon = container.querySelector('[aria-hidden="true"]');
+    expect(icon).toHaveStyle({
+      maskImage: "url(/agents/codex.svg)",
+    });
+  });
+
+  it("can hide the label for compact surfaces", () => {
+    renderWithProviders(<AgentBadge agentType="codex" hideLabel />);
+
+    expect(screen.queryByText("Codex")).not.toBeInTheDocument();
+  });
+
+  it("falls back to a monogram for known agents without a brand icon", () => {
+    renderWithProviders(<AgentBadge agentType="pi" />);
+
+    expect(screen.getByText("Pi")).toBeInTheDocument();
+    expect(screen.getByText("PI")).toBeInTheDocument();
+  });
+
+  it("falls back to display labels or raw agent type for unknown agents", () => {
+    const { rerender } = renderWithProviders(<AgentBadge agentType="pm_agent" />);
+
+    expect(screen.getByText("PM Agent")).toBeInTheDocument();
+
+    rerender(<AgentBadge agentType="custom_agent" />);
+    expect(screen.getByText("custom_agent")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/animated-ellipsis.test.tsx
+++ b/frontend/src/components/animated-ellipsis.test.tsx
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+
+import { renderWithProviders } from "@/test/test-utils";
+import { AnimatedEllipsis } from "./animated-ellipsis";
+
+describe("AnimatedEllipsis", () => {
+  it("renders three hidden animation dots with custom classes", () => {
+    const { container } = renderWithProviders(<AnimatedEllipsis className="text-muted" />);
+
+    const wrapper = container.firstElementChild;
+    expect(wrapper).toHaveAttribute("aria-hidden", "true");
+    expect(wrapper).toHaveClass("text-muted");
+    expect(container.querySelectorAll(".ellipsis-dot")).toHaveLength(3);
+    expect(container).toHaveTextContent("...");
+  });
+});

--- a/frontend/src/components/landing/canvas-utils.test.ts
+++ b/frontend/src/components/landing/canvas-utils.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  CLOUDS,
+  NOISE_BLIPS,
+  STARS,
+  cockpitFrame,
+  drawCRTGrain,
+  drawHudPitchLadder,
+  drawVignette,
+  hudText,
+  pseudoRandom,
+} from "./canvas-utils";
+
+function makeCanvasContext() {
+  const gradient = {
+    addColorStop: vi.fn(),
+  };
+  const ctx = {
+    fillStyle: "",
+    strokeStyle: "",
+    font: "",
+    textAlign: "left" as CanvasTextAlign,
+    textBaseline: "alphabetic" as CanvasTextBaseline,
+    lineWidth: 0,
+    beginPath: vi.fn(),
+    moveTo: vi.fn(),
+    lineTo: vi.fn(),
+    quadraticCurveTo: vi.fn(),
+    closePath: vi.fn(),
+    fill: vi.fn(),
+    stroke: vi.fn(),
+    arc: vi.fn(),
+    fillRect: vi.fn(),
+    strokeRect: vi.fn(),
+    fillText: vi.fn(),
+    createRadialGradient: vi.fn(() => gradient),
+  };
+  return {
+    ctx: ctx as unknown as CanvasRenderingContext2D,
+    spies: ctx,
+    gradient,
+  };
+}
+
+describe("canvas landing utilities", () => {
+  it("generates stable pseudo-random values in the expected range", () => {
+    const first = pseudoRandom(42);
+
+    expect(first).toBeGreaterThanOrEqual(0);
+    expect(first).toBeLessThan(1);
+    expect(pseudoRandom(42)).toBe(first);
+  });
+
+  it("draws HUD text with the requested alpha, size, and alignment", () => {
+    const { ctx, spies } = makeCanvasContext();
+
+    hudText(ctx, 10, 20, "ALT", 0.5, 18, "center");
+
+    expect(spies.fillStyle).toBe("rgba(0, 255, 100, 0.5)");
+    expect(spies.font).toBe("bold 18px monospace");
+    expect(spies.textAlign).toBe("center");
+    expect(spies.textBaseline).toBe("middle");
+    expect(spies.fillText).toHaveBeenCalledWith("ALT", 10, 20);
+  });
+
+  it("draws a vignette gradient over the canvas", () => {
+    const { ctx, spies, gradient } = makeCanvasContext();
+
+    drawVignette(ctx, 200, 100, 0.25);
+
+    expect(spies.createRadialGradient).toHaveBeenCalled();
+    expect(gradient.addColorStop).toHaveBeenCalledWith(0, "rgba(0,0,0,0)");
+    expect(gradient.addColorStop).toHaveBeenCalledWith(1, "rgba(0,0,0,0.25)");
+    expect(spies.fillRect).toHaveBeenCalledWith(0, 0, 200, 100);
+  });
+
+  it("draws CRT scanlines, noise, and tint", () => {
+    const { ctx, spies } = makeCanvasContext();
+
+    drawCRTGrain(ctx, 90, 9, 100, 0.05);
+
+    expect(spies.fillRect).toHaveBeenCalledWith(0, 0, 90, 1);
+    expect(spies.fillRect).toHaveBeenCalledWith(0, 3, 90, 1);
+    expect(spies.fillRect).toHaveBeenCalledWith(0, 6, 90, 1);
+    expect(spies.fillRect).toHaveBeenCalledWith(0, 0, 90, 9);
+    expect(spies.fillRect).toHaveBeenCalledTimes(44);
+  });
+
+  it("draws the pitch ladder without a center rung", () => {
+    const { ctx, spies } = makeCanvasContext();
+
+    drawHudPitchLadder(ctx, 300, 200, 0.8);
+
+    expect(spies.fillText).toHaveBeenCalledTimes(6);
+    expect(spies.fillText).toHaveBeenCalledWith("15", expect.any(Number), expect.any(Number));
+    expect(spies.fillText).not.toHaveBeenCalledWith("0", expect.any(Number), expect.any(Number));
+  });
+
+  it("draws the cockpit frame with panels, instruments, and struts", () => {
+    const { ctx, spies } = makeCanvasContext();
+
+    cockpitFrame(ctx, 400, 300);
+
+    expect(spies.quadraticCurveTo).toHaveBeenCalledWith(200, 226.5, 400, 234);
+    expect(spies.strokeRect).toHaveBeenCalledTimes(2);
+    expect(spies.arc).toHaveBeenCalled();
+    expect(spies.lineTo).toHaveBeenCalledWith(40, 0);
+    expect(spies.lineTo).toHaveBeenCalledWith(360, 0);
+  });
+
+  it("exports stable seeded decoration data", () => {
+    expect(STARS).toHaveLength(80);
+    expect(CLOUDS).toHaveLength(5);
+    expect(NOISE_BLIPS).toHaveLength(8);
+    expect(STARS[0]).toMatchObject({
+      x: expect.any(Number),
+      y: expect.any(Number),
+      s: expect.any(Number),
+    });
+  });
+});

--- a/frontend/src/components/status-dot.test.tsx
+++ b/frontend/src/components/status-dot.test.tsx
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+
+import { renderWithProviders } from "@/test/test-utils";
+import { StatusDot } from "./status-dot";
+
+describe("StatusDot", () => {
+  it("renders a static dot with the requested color and wrapper class", () => {
+    const { container } = renderWithProviders(
+      <StatusDot color="bg-success" className="custom-dot" />,
+    );
+
+    const dot = container.firstElementChild;
+    expect(dot).toHaveClass("bg-success");
+    expect(dot).toHaveClass("custom-dot");
+    expect(dot).not.toHaveClass("relative");
+  });
+
+  it("renders an animated dot with halo and shimmer layers", () => {
+    const { container } = renderWithProviders(
+      <StatusDot animate color="bg-primary" pingColor="bg-primary/40" />,
+    );
+
+    const wrapper = container.firstElementChild;
+    expect(wrapper).toHaveClass("relative");
+    expect(container.querySelector(".ai-pulse-halo")).toHaveClass("bg-primary/40");
+    expect(container.querySelector(".ai-shimmer")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/hooks/use-document-visible.test.ts
+++ b/frontend/src/hooks/use-document-visible.test.ts
@@ -1,0 +1,47 @@
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { useDocumentVisible } from "./use-document-visible";
+
+const originalVisibilityState = Object.getOwnPropertyDescriptor(
+  Document.prototype,
+  "visibilityState",
+);
+
+function setVisibilityState(value: DocumentVisibilityState): void {
+  Object.defineProperty(document, "visibilityState", {
+    configurable: true,
+    get: () => value,
+  });
+}
+
+describe("useDocumentVisible", () => {
+  afterEach(() => {
+    delete (document as unknown as Record<string, unknown>).visibilityState;
+    if (originalVisibilityState) {
+      Object.defineProperty(Document.prototype, "visibilityState", originalVisibilityState);
+    }
+  });
+
+  it("initializes from the current document visibility state", () => {
+    setVisibilityState("hidden");
+
+    const { result } = renderHook(() => useDocumentVisible());
+
+    expect(result.current).toBe(false);
+  });
+
+  it("updates when document visibility changes", () => {
+    setVisibilityState("visible");
+    const { result } = renderHook(() => useDocumentVisible());
+
+    expect(result.current).toBe(true);
+
+    setVisibilityState("hidden");
+    act(() => {
+      document.dispatchEvent(new Event("visibilitychange"));
+    });
+
+    expect(result.current).toBe(false);
+  });
+});

--- a/frontend/src/hooks/use-scroll-progress.test.tsx
+++ b/frontend/src/hooks/use-scroll-progress.test.tsx
@@ -1,0 +1,113 @@
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { useScrollProgress } from "./use-scroll-progress";
+
+const originalInnerHeight = window.innerHeight;
+const originalMatchMedia = window.matchMedia;
+
+function setReducedMotion(matches: boolean): void {
+  Object.defineProperty(window, "matchMedia", {
+    configurable: true,
+    value: vi.fn().mockReturnValue({
+      matches,
+      media: "(prefers-reduced-motion: reduce)",
+      onchange: null,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    }),
+  });
+}
+
+describe("useScrollProgress", () => {
+  afterEach(() => {
+    Object.defineProperty(window, "innerHeight", {
+      configurable: true,
+      value: originalInnerHeight,
+    });
+    Object.defineProperty(window, "matchMedia", {
+      configurable: true,
+      value: originalMatchMedia,
+    });
+  });
+
+  it("starts complete and skips listeners when reduced motion is enabled", () => {
+    setReducedMotion(true);
+    const addEventListener = vi.spyOn(window, "addEventListener");
+
+    const { result } = renderHook(() => useScrollProgress());
+
+    expect(result.current.progress).toBe(1);
+    expect(addEventListener).not.toHaveBeenCalledWith(
+      "scroll",
+      expect.any(Function),
+      expect.anything(),
+    );
+  });
+
+  it("clamps progress between the configured viewport thresholds", () => {
+    setReducedMotion(false);
+    Object.defineProperty(window, "innerHeight", {
+      configurable: true,
+      value: 1000,
+    });
+    const { result } = renderHook(() =>
+      useScrollProgress<HTMLDivElement>({ startViewport: 0.8, endViewport: 0.2 }),
+    );
+    const element = document.createElement("div");
+    result.current.ref.current = element;
+
+    vi.spyOn(element, "getBoundingClientRect").mockReturnValue({
+      top: 500,
+      bottom: 600,
+      left: 0,
+      right: 0,
+      width: 100,
+      height: 100,
+      x: 0,
+      y: 500,
+      toJSON: () => ({}),
+    });
+
+    act(() => {
+      window.dispatchEvent(new Event("scroll"));
+    });
+
+    expect(result.current.progress).toBeCloseTo(0.5);
+
+    vi.mocked(element.getBoundingClientRect).mockReturnValue({
+      top: -100,
+      bottom: 0,
+      left: 0,
+      right: 0,
+      width: 100,
+      height: 100,
+      x: 0,
+      y: -100,
+      toJSON: () => ({}),
+    });
+    act(() => {
+      window.dispatchEvent(new Event("resize"));
+    });
+    expect(result.current.progress).toBe(1);
+
+    vi.mocked(element.getBoundingClientRect).mockReturnValue({
+      top: 900,
+      bottom: 1000,
+      left: 0,
+      right: 0,
+      width: 100,
+      height: 100,
+      x: 0,
+      y: 900,
+      toJSON: () => ({}),
+    });
+    act(() => {
+      window.dispatchEvent(new Event("scroll"));
+    });
+    expect(result.current.progress).toBe(0);
+  });
+});

--- a/frontend/src/lib/active-org.test.ts
+++ b/frontend/src/lib/active-org.test.ts
@@ -1,0 +1,80 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  ACTIVE_ORG_CHANGED_EVENT,
+  getActiveOrgId,
+  setActiveOrgId,
+} from "./active-org";
+
+const originalSessionStorage = Object.getOwnPropertyDescriptor(window, "sessionStorage");
+
+function restoreSessionStorage(): void {
+  if (originalSessionStorage) {
+    Object.defineProperty(window, "sessionStorage", originalSessionStorage);
+  }
+}
+
+describe("active org storage", () => {
+  afterEach(() => {
+    restoreSessionStorage();
+    window.sessionStorage.clear();
+  });
+
+  it("stores and reads the active org from tab-local session storage", () => {
+    setActiveOrgId("org-1");
+
+    expect(getActiveOrgId()).toBe("org-1");
+  });
+
+  it("removes the active org when set to null", () => {
+    setActiveOrgId("org-1");
+    setActiveOrgId(null);
+
+    expect(getActiveOrgId()).toBeNull();
+  });
+
+  it("dispatches an active-org-changed event after storage updates", () => {
+    const listener = vi.fn();
+    window.addEventListener(ACTIVE_ORG_CHANGED_EVENT, listener);
+
+    setActiveOrgId("org-2");
+
+    expect(listener).toHaveBeenCalledTimes(1);
+    expect(listener.mock.calls[0]?.[0]).toMatchObject({
+      detail: { id: "org-2" },
+    });
+
+    window.removeEventListener(ACTIVE_ORG_CHANGED_EVENT, listener);
+  });
+
+  it("returns null when session storage cannot be read", () => {
+    Object.defineProperty(window, "sessionStorage", {
+      configurable: true,
+      value: {
+        getItem: vi.fn(() => {
+          throw new Error("blocked");
+        }),
+      },
+    });
+
+    expect(getActiveOrgId()).toBeNull();
+  });
+
+  it("does not dispatch when session storage cannot be written", () => {
+    const listener = vi.fn();
+    window.addEventListener(ACTIVE_ORG_CHANGED_EVENT, listener);
+    Object.defineProperty(window, "sessionStorage", {
+      configurable: true,
+      value: {
+        setItem: vi.fn(() => {
+          throw new Error("blocked");
+        }),
+      },
+    });
+
+    setActiveOrgId("org-3");
+
+    expect(listener).not.toHaveBeenCalled();
+    window.removeEventListener(ACTIVE_ORG_CHANGED_EVENT, listener);
+  });
+});

--- a/frontend/src/lib/audit-details.test.ts
+++ b/frontend/src/lib/audit-details.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+
+import { formatAuditDetailValue } from "./audit-details";
+
+describe("formatAuditDetailValue", () => {
+  it("formats membership role details with product labels", () => {
+    expect(formatAuditDetailValue("role", "member")).toBe("Engineer");
+    expect(formatAuditDetailValue("previous_role", "viewer")).toBe("Viewer");
+  });
+
+  it("leaves non-role strings unchanged", () => {
+    expect(formatAuditDetailValue("status", "member")).toBe("member");
+    expect(formatAuditDetailValue("role", "owner")).toBe("owner");
+  });
+
+  it("serializes object values for display", () => {
+    expect(formatAuditDetailValue("metadata", { repo: "app", count: 2 })).toBe(
+      JSON.stringify({ repo: "app", count: 2 }),
+    );
+  });
+
+  it("stringifies primitive values", () => {
+    expect(formatAuditDetailValue("enabled", true)).toBe("true");
+    expect(formatAuditDetailValue("attempts", 3)).toBe("3");
+    expect(formatAuditDetailValue("deleted_at", null)).toBe("null");
+  });
+});

--- a/frontend/src/lib/automation-validation.test.ts
+++ b/frontend/src/lib/automation-validation.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  AUTOMATION_GOAL_MAX_LENGTH,
+  automationGoalLengthState,
+} from "./automation-validation";
+
+describe("automationGoalLengthState", () => {
+  it("returns a valid state with a formatted count under the limit", () => {
+    expect(automationGoalLengthState("Ship it")).toEqual({
+      isTooLong: false,
+      countText: "7 / 64,000",
+      message: null,
+    });
+  });
+
+  it("treats the exact maximum as valid", () => {
+    const state = automationGoalLengthState("a".repeat(AUTOMATION_GOAL_MAX_LENGTH));
+
+    expect(state).toEqual({
+      isTooLong: false,
+      countText: "64,000 / 64,000",
+      message: null,
+    });
+  });
+
+  it("returns a validation message above the limit", () => {
+    const state = automationGoalLengthState("a".repeat(AUTOMATION_GOAL_MAX_LENGTH + 1));
+
+    expect(state).toEqual({
+      isTooLong: true,
+      countText: "64,001 / 64,000",
+      message: "Goal must be at most 64,000 characters.",
+    });
+  });
+});

--- a/frontend/src/lib/clipboard-files.test.ts
+++ b/frontend/src/lib/clipboard-files.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { getClipboardFiles } from "./clipboard-files";
+
+describe("getClipboardFiles", () => {
+  it("returns an empty array without transfer data", () => {
+    expect(getClipboardFiles(null)).toEqual([]);
+    expect(getClipboardFiles(undefined)).toEqual([]);
+  });
+
+  it("prefers file items from the transfer item list", () => {
+    const file = new File(["image"], "image.png", { type: "image/png" });
+    const fallback = new File(["fallback"], "fallback.png", { type: "image/png" });
+    const data = {
+      items: [
+        { kind: "string", getAsFile: vi.fn(() => null) },
+        { kind: "file", getAsFile: vi.fn(() => file) },
+      ],
+      files: [fallback],
+    } as unknown as DataTransfer;
+
+    expect(getClipboardFiles(data)).toEqual([file]);
+  });
+
+  it("falls back to the transfer file list when item files are unavailable", () => {
+    const fallback = new File(["fallback"], "fallback.png", { type: "image/png" });
+    const data = {
+      items: [{ kind: "file", getAsFile: vi.fn(() => null) }],
+      files: [fallback],
+    } as unknown as DataTransfer;
+
+    expect(getClipboardFiles(data)).toEqual([fallback]);
+  });
+});

--- a/frontend/src/lib/clipboard.test.ts
+++ b/frontend/src/lib/clipboard.test.ts
@@ -1,0 +1,50 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { canCopyToClipboard, copyTextToClipboard } from "./clipboard";
+
+const originalClipboard = Object.getOwnPropertyDescriptor(navigator, "clipboard");
+
+function setClipboard(value: Clipboard | undefined): void {
+  Object.defineProperty(navigator, "clipboard", {
+    configurable: true,
+    value,
+  });
+}
+
+describe("clipboard helpers", () => {
+  afterEach(() => {
+    if (originalClipboard) {
+      Object.defineProperty(navigator, "clipboard", originalClipboard);
+    } else {
+      delete (navigator as unknown as Record<string, unknown>).clipboard;
+    }
+  });
+
+  it("reports clipboard support when writeText exists", () => {
+    setClipboard({ writeText: vi.fn() } as unknown as Clipboard);
+
+    expect(canCopyToClipboard()).toBe(true);
+  });
+
+  it("reports clipboard support as unavailable without writeText", () => {
+    setClipboard({} as Clipboard);
+
+    expect(canCopyToClipboard()).toBe(false);
+  });
+
+  it("writes text through the Clipboard API", async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    setClipboard({ writeText } as unknown as Clipboard);
+
+    await expect(copyTextToClipboard("copy me")).resolves.toBeUndefined();
+    expect(writeText).toHaveBeenCalledWith("copy me");
+  });
+
+  it("rejects when the Clipboard API is unavailable", async () => {
+    setClipboard(undefined);
+
+    await expect(copyTextToClipboard("copy me")).rejects.toThrow(
+      "Clipboard API is unavailable",
+    );
+  });
+});

--- a/frontend/src/lib/docs/raw-docs-route.test.ts
+++ b/frontend/src/lib/docs/raw-docs-route.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+
+import { getRawDocsStaticParams } from "./raw-docs-route";
+
+describe("getRawDocsStaticParams", () => {
+  it("drops root docs pages and maps non-empty slugs", () => {
+    expect(
+      getRawDocsStaticParams([
+        { slugs: [] },
+        { slugs: ["guides"] },
+        { slugs: ["guides", "autopilot"] },
+      ]),
+    ).toEqual([
+      { slug: ["guides"] },
+      { slug: ["guides", "autopilot"] },
+    ]);
+  });
+});

--- a/frontend/src/lib/docs/sidebar-labels.test.ts
+++ b/frontend/src/lib/docs/sidebar-labels.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+
+import { sidebarLabelForPageTreeFile } from "./sidebar-labels";
+
+describe("sidebarLabelForPageTreeFile", () => {
+  it("keeps the current label without a file path", () => {
+    expect(sidebarLabelForPageTreeFile(undefined, "Docs")).toBe("Docs");
+  });
+
+  it("renames section index pages to Overview", () => {
+    expect(sidebarLabelForPageTreeFile("guides/index.mdx", "Guides")).toBe(
+      "Overview",
+    );
+  });
+
+  it("normalizes Windows path separators before matching", () => {
+    expect(sidebarLabelForPageTreeFile("reference\\index.mdx", "Reference")).toBe(
+      "Overview",
+    );
+  });
+
+  it("keeps normal document labels", () => {
+    expect(sidebarLabelForPageTreeFile("guides/autopilot.mdx", "Autopilot")).toBe(
+      "Autopilot",
+    );
+  });
+});

--- a/frontend/src/lib/linear-refs.test.ts
+++ b/frontend/src/lib/linear-refs.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+
+import { looksLikeLinearRef } from "./linear-refs";
+
+describe("looksLikeLinearRef", () => {
+  it("accepts bare Linear issue identifiers", () => {
+    expect(looksLikeLinearRef("ABC-123")).toBe(true);
+    expect(looksLikeLinearRef(" ABC_123-456 ")).toBe(true);
+  });
+
+  it("accepts Linear issue URLs with optional suffixes", () => {
+    expect(looksLikeLinearRef("https://linear.app/acme/issue/ABC-123")).toBe(true);
+    expect(looksLikeLinearRef("http://linear.app/acme/issue/ABC-123/comment/xyz")).toBe(true);
+    expect(looksLikeLinearRef("https://linear.app/acme/issue/ABC-123?focused=true")).toBe(true);
+    expect(looksLikeLinearRef("https://linear.app/acme/issue/ABC-123#activity")).toBe(true);
+  });
+
+  it("rejects empty, lowercase, malformed, and non-Linear references", () => {
+    expect(looksLikeLinearRef("")).toBe(false);
+    expect(looksLikeLinearRef("abc-123")).toBe(false);
+    expect(looksLikeLinearRef("ABC")).toBe(false);
+    expect(looksLikeLinearRef("https://example.com/acme/issue/ABC-123")).toBe(false);
+    expect(looksLikeLinearRef("https://linear.app/acme/project/ABC-123")).toBe(false);
+  });
+});

--- a/frontend/src/lib/preview-bootstrap.test.ts
+++ b/frontend/src/lib/preview-bootstrap.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  PREVIEW_BOOTSTRAP_TIMEOUT_ERROR,
+  buildPreviewBootstrapSrc,
+  previewBootstrapTimeoutDetails,
+  previewOriginFromURL,
+} from "./preview-bootstrap";
+
+describe("previewOriginFromURL", () => {
+  it("returns the origin for HTTPS preview URLs", () => {
+    expect(previewOriginFromURL("https://abc.preview.143.dev/path?x=1")).toBe(
+      "https://abc.preview.143.dev",
+    );
+  });
+
+  it("rejects non-HTTPS and malformed URLs", () => {
+    expect(previewOriginFromURL("http://abc.preview.localhost:9090")).toBeUndefined();
+    expect(previewOriginFromURL("not a url")).toBeUndefined();
+  });
+});
+
+describe("buildPreviewBootstrapSrc", () => {
+  it("appends the bootstrap path after trimming trailing slashes", () => {
+    expect(buildPreviewBootstrapSrc("https://abc.preview.143.dev///")).toBe(
+      "https://abc.preview.143.dev/bootstrap",
+    );
+  });
+});
+
+describe("previewBootstrapTimeoutDetails", () => {
+  it("uses the default timeout copy and error constant", () => {
+    expect(PREVIEW_BOOTSTRAP_TIMEOUT_ERROR).toContain("timed out");
+    expect(previewBootstrapTimeoutDetails()).toContain("within 5 seconds");
+  });
+
+  it("formats custom timeout durations in seconds", () => {
+    expect(previewBootstrapTimeoutDetails(2_400)).toContain("within 2 seconds");
+    expect(previewBootstrapTimeoutDetails(2_600)).toContain("within 3 seconds");
+  });
+});

--- a/frontend/src/lib/session-counts.test.ts
+++ b/frontend/src/lib/session-counts.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+
+import { getCountForTab, renderCount } from "./session-counts";
+import type { SessionCounts } from "./types";
+
+const counts: SessionCounts = {
+  all: 99,
+  active: 12,
+  archived: 4,
+  cap: 100,
+};
+
+describe("renderCount", () => {
+  it("returns undefined when the value or counts are missing", () => {
+    expect(renderCount(undefined, counts)).toBeUndefined();
+    expect(renderCount(5, undefined)).toBeUndefined();
+  });
+
+  it("renders exact counts below the server cap", () => {
+    expect(renderCount(12, counts)).toBe("12");
+    expect(renderCount(0, counts)).toBe("0");
+  });
+
+  it("renders capped counts with a plus suffix", () => {
+    expect(renderCount(100, counts)).toBe("99+");
+    expect(renderCount(125, counts)).toBe("99+");
+  });
+});
+
+describe("getCountForTab", () => {
+  it("returns undefined when counts are unavailable", () => {
+    expect(getCountForTab("all", undefined)).toBeUndefined();
+  });
+
+  it("maps known tab values to their count buckets", () => {
+    expect(getCountForTab("all", counts)).toBe(99);
+    expect(getCountForTab("active", counts)).toBe(12);
+    expect(getCountForTab("archived", counts)).toBe(4);
+  });
+
+  it("returns undefined for uncounted tabs", () => {
+    expect(getCountForTab("mine", counts)).toBeUndefined();
+  });
+});

--- a/frontend/src/lib/session-detail-cache.test.ts
+++ b/frontend/src/lib/session-detail-cache.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  isProvisionalSessionDetail,
+  markProvisionalSessionDetail,
+  provisionalSessionDetailFromListItem,
+} from "./session-detail-cache";
+import type { Session, SessionDetail } from "./types";
+
+describe("session detail cache helpers", () => {
+  it("marks a session detail as provisional without changing its fields", () => {
+    const session = { id: "session-1", title: "Fix bug" } as SessionDetail;
+
+    const marked = markProvisionalSessionDetail(session);
+
+    expect(marked).toMatchObject(session);
+    expect(isProvisionalSessionDetail(marked)).toBe(true);
+    expect(isProvisionalSessionDetail(session)).toBe(false);
+  });
+
+  it("treats nullish session details as non-provisional", () => {
+    expect(isProvisionalSessionDetail(undefined)).toBe(false);
+    expect(isProvisionalSessionDetail(null)).toBe(false);
+  });
+
+  it("creates a provisional detail response from a list item with existing threads", () => {
+    const session = {
+      id: "session-1",
+      title: "Fix bug",
+      threads: [{ id: "thread-1" }],
+    } as unknown as Session;
+
+    const response = provisionalSessionDetailFromListItem(session);
+
+    expect(response.data).toMatchObject({
+      id: "session-1",
+      title: "Fix bug",
+      threads: [{ id: "thread-1" }],
+    });
+    expect(isProvisionalSessionDetail(response.data)).toBe(true);
+  });
+
+  it("defaults missing threads to an empty array", () => {
+    const session = { id: "session-1", title: "Fix bug" } as Session;
+
+    expect(provisionalSessionDetailFromListItem(session).data.threads).toEqual([]);
+  });
+});

--- a/frontend/src/lib/session-status-groups.test.ts
+++ b/frontend/src/lib/session-status-groups.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  activeSet,
+  activeStatuses,
+  doneStatuses,
+  filterToStatusParam,
+  workingSet,
+  workingStatusesSet,
+} from "./session-status-groups";
+
+describe("session status groups", () => {
+  it("exposes active and done status sets used by filters", () => {
+    expect(activeSet.has("running")).toBe(true);
+    expect(activeSet.has("completed")).toBe(false);
+    expect(workingSet.has("running")).toBe(true);
+    expect(workingSet.has("awaiting_input")).toBe(false);
+    expect(workingStatusesSet.has("awaiting_input")).toBe(true);
+    expect(doneStatuses).toContain("pr_created");
+  });
+});
+
+describe("filterToStatusParam", () => {
+  it("omits the status parameter for empty, all, and passthrough filters", () => {
+    expect(filterToStatusParam(null)).toBeUndefined();
+    expect(filterToStatusParam("all")).toBeUndefined();
+    expect(filterToStatusParam("mine", ["mine"])).toBeUndefined();
+  });
+
+  it("maps active and done filters to comma-separated status groups", () => {
+    expect(filterToStatusParam("active")).toBe(activeStatuses.join(","));
+    expect(filterToStatusParam("done")).toBe(doneStatuses.join(","));
+  });
+
+  it("passes custom status filters through", () => {
+    expect(filterToStatusParam("failed")).toBe("failed");
+  });
+});

--- a/frontend/src/lib/settings-constants.test.ts
+++ b/frontend/src/lib/settings-constants.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  MAX_CONCURRENT_RUNS,
+  MIN_CONCURRENT_RUNS,
+  clampNumber,
+} from "./settings-constants";
+
+describe("clampNumber", () => {
+  it("keeps values inside the allowed range", () => {
+    expect(clampNumber(5, MIN_CONCURRENT_RUNS, MAX_CONCURRENT_RUNS)).toBe(5);
+  });
+
+  it("raises values below the minimum", () => {
+    expect(clampNumber(0, MIN_CONCURRENT_RUNS, MAX_CONCURRENT_RUNS)).toBe(1);
+  });
+
+  it("lowers values above the maximum", () => {
+    expect(clampNumber(30, MIN_CONCURRENT_RUNS, MAX_CONCURRENT_RUNS)).toBe(25);
+  });
+});


### PR DESCRIPTION
## Summary

Frontend coverage is failing the 80% check, creating a reliability risk where unrelated changes can’t safely ship. This PR adds a focused set of deterministic unit tests across previously under-tested utilities/components/hooks to increase coverage and make CI more stable.

## Changes

- Added new unit test suites for small, deterministic UI components (e.g., `AutosaveIndicator`, `AgentBadge`, `AnimatedEllipsis`, `StatusDot`), asserting key rendering states and accessibility roles.
- Added hook and utility tests for previously unverified behavior (e.g., document visibility, scroll progress, active org, clipboard helpers, landing canvas utilities).
- Added lib-level contract tests covering parsing/formatting and route/sidebar/doc helpers (e.g., raw docs routes, sidebar label resolution, linear refs, preview/bootstrap, session status/grouping, settings constants).

## Validation

- `npm run typecheck`
- `npm run lint`
- `npm run build`
- Focused new-test coverage run: **20 passed**, **71 tests passed** (885 lines added)
- Note: Full local `vitest --coverage` still fails due to 4 existing flaky/time-limited page tests not related to this change:
  - `page-pr-creation.test.tsx`
  - `page-transcript.test.tsx`
  - `settings/account/page.test.tsx`
  - `settings/agent/page.test.tsx`

[143.dev](https://143.dev) | [session a1881911](https://143.dev/sessions/a1881911-8a60-4cea-bd08-e9ad0712316d)

<!-- 143 readiness -->
**143 readiness:** not available for this revision.

Preview: https://143.dev/previews/github/assembledhq/143/pull/1593?launch=1