### PR TITLE
Add user toggle to hide planes in session view and persist preference

### DIFF
--- a/frontend/src/app/(dashboard)/sessions/new/manual-session-create-page-content.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/new/manual-session-create-page-content.test.tsx
@@ -111,6 +111,17 @@ const mocks = vi.hoisted(() => ({
       created_at: "2026-01-01T00:00:00Z",
     },
   }),
+  authUpdateSettingsMock: vi.fn().mockResolvedValue({
+    data: {
+      id: "user-1",
+      org_id: "org-1",
+      email: "alice@example.com",
+      name: "Alice Smith",
+      role: "admin",
+      settings: { manual_session_planes_hidden: true },
+      created_at: "2026-01-01T00:00:00Z",
+    },
+  }),
   integrationsListMock: vi.fn().mockResolvedValue({
     data: [
       {
@@ -148,6 +159,7 @@ vi.mock("@/lib/api", () => ({
     },
     auth: {
       me: mocks.authMeMock,
+      updateSettings: mocks.authUpdateSettingsMock,
     },
     integrations: {
       list: mocks.integrationsListMock,
@@ -253,7 +265,39 @@ describe("ManualSessionCreatePageContent", () => {
       screen.getByText("Start a manual session with text, files, photos, or a screenshot anywhere here."),
     ).toBeInTheDocument();
     expect(screen.getByTestId("manual-session-plane-canvas")).toHaveAttribute("aria-hidden", "true");
+    expect(screen.getByRole("button", { name: "Hide planes" })).toBeInTheDocument();
     expect(screen.queryByText("Drop a screenshot anywhere here, or use +")).not.toBeInTheDocument();
+  });
+
+  it("hides planes when the user setting is enabled", async () => {
+    mocks.authMeMock.mockResolvedValueOnce({
+      data: {
+        id: "user-1",
+        org_id: "org-1",
+        email: "alice@example.com",
+        name: "Alice Smith",
+        role: "admin",
+        settings: { manual_session_planes_hidden: true },
+        created_at: "2026-01-01T00:00:00Z",
+      },
+    });
+
+    renderWithProviders(<ManualSessionCreatePageContent />);
+
+    expect(await screen.findByRole("button", { name: "Show planes" })).toBeInTheDocument();
+    expect(screen.queryByTestId("manual-session-plane-canvas")).not.toBeInTheDocument();
+  });
+
+  it("persists the planes visibility toggle as a user setting", async () => {
+    const user = userEvent.setup();
+
+    renderWithProviders(<ManualSessionCreatePageContent />);
+
+    await user.click(await screen.findByRole("button", { name: "Hide planes" }));
+
+    expect(mocks.authUpdateSettingsMock).toHaveBeenCalledWith({ manual_session_planes_hidden: true });
+    expect(screen.queryByTestId("manual-session-plane-canvas")).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Show planes" })).toBeInTheDocument();
   });
 
   it("does not render dictation controls on desktop or mobile", async () => {

--- a/frontend/src/app/(dashboard)/sessions/new/manual-session-create-page-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/new/manual-session-create-page-content.tsx
@@ -1,16 +1,40 @@
 "use client";
 
-import { useMemo } from "react";
+import { useCallback, useMemo, useState } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { Eye, EyeOff } from "lucide-react";
 import { ManualSessionComposer } from "@/components/manual-session-composer";
 import { ManualSessionPlaneCanvas } from "@/components/manual-session-plane-canvas";
 import { MobileBackButton } from "@/components/mobile-back-button";
+import { Button } from "@/components/ui/button";
 import { buildFilterSuffix } from "@/hooks/use-people-filter";
+import { useAuth } from "@/hooks/use-auth";
+import { api } from "@/lib/api";
+import { notify as toast } from "@/lib/notify";
 import { cn } from "@/lib/utils";
 
 export function ManualSessionCreatePageContent() {
   const router = useRouter();
   const searchParams = useSearchParams();
+  const queryClient = useQueryClient();
+  const { user } = useAuth();
+  const storedPlanesHidden = user?.settings?.manual_session_planes_hidden ?? false;
+  const [planesHiddenOverride, setPlanesHiddenOverride] = useState<boolean | null>(null);
+  const planesHidden = planesHiddenOverride ?? storedPlanesHidden;
+
+  const { mutate: persistPlanesHidden } = useMutation({
+    mutationFn: (hidden: boolean) =>
+      api.auth.updateSettings({ manual_session_planes_hidden: hidden }),
+    onSuccess: (response) => {
+      queryClient.setQueryData(["auth", "me"], { data: response.data });
+      setPlanesHiddenOverride(null);
+    },
+    onError: () => {
+      setPlanesHiddenOverride(null);
+      toast.error("Couldn't save planes preference");
+    },
+  });
 
   // Read the currently selected repository from the URL query params
   // (set by the RepoContextSwitcher) so we clone the codebase into the sandbox.
@@ -25,13 +49,30 @@ export function ManualSessionCreatePageContent() {
     [searchParams],
   );
 
+  const togglePlanes = useCallback(() => {
+    const next = !planesHidden;
+    setPlanesHiddenOverride(next);
+    persistPlanesHidden(next);
+  }, [persistPlanesHidden, planesHidden]);
+
   return (
     <div className="flex flex-col h-full">
       <div className="md:hidden flex items-center px-2 pt-2">
         <MobileBackButton to="/sessions" label="Back to sessions" />
       </div>
       <div className="relative flex flex-1 flex-col overflow-hidden px-4 pb-4">
-        <ManualSessionPlaneCanvas />
+        {!planesHidden ? <ManualSessionPlaneCanvas /> : null}
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon"
+          className="absolute right-4 top-4 z-20 h-8 w-8 text-muted-foreground hover:text-foreground"
+          aria-label={planesHidden ? "Show planes" : "Hide planes"}
+          title={planesHidden ? "Show planes" : "Hide planes"}
+          onClick={togglePlanes}
+        >
+          {planesHidden ? <Eye className="h-4 w-4" /> : <EyeOff className="h-4 w-4" />}
+        </Button>
         <ManualSessionComposer
           enableDrafts
           autoFocus

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -55,6 +55,7 @@ export interface UserSettings {
     Record<"codex" | "claude_code", "low" | "medium" | "high" | "xhigh" | "max">
   >;
   diff_viewer_full_screen?: boolean;
+  manual_session_planes_hidden?: boolean;
 }
 
 // PATCH /api/v1/auth/me/settings is an RFC 7386 JSON merge patch: omitted
@@ -71,6 +72,7 @@ export interface UserSettingsUpdateRequest {
     >
   > | null;
   diff_viewer_full_screen?: boolean | null;
+  manual_session_planes_hidden?: boolean | null;
 }
 
 export type AgentCapabilityID =

--- a/internal/models/user_settings.go
+++ b/internal/models/user_settings.go
@@ -14,6 +14,7 @@ type UserSettings struct {
 	CodingAgentModelDefault      string                        `json:"coding_agent_model_default,omitempty"`
 	CodingAgentReasoningDefaults map[AgentType]ReasoningEffort `json:"coding_agent_reasoning_defaults,omitempty"`
 	DiffViewerFullScreen         bool                          `json:"diff_viewer_full_screen,omitempty"`
+	ManualSessionPlanesHidden    bool                          `json:"manual_session_planes_hidden,omitempty"`
 }
 
 // ParseUserSettings deserializes the JSONB settings column into UserSettings.

--- a/internal/models/user_settings_test.go
+++ b/internal/models/user_settings_test.go
@@ -38,6 +38,11 @@ func TestParseUserSettings(t *testing.T) {
 			want: UserSettings{DiffViewerFullScreen: true},
 		},
 		{
+			name: "parses manual session planes hidden preference",
+			raw:  json.RawMessage(`{"manual_session_planes_hidden":true}`),
+			want: UserSettings{ManualSessionPlanesHidden: true},
+		},
+		{
 			name:    "rejects malformed json",
 			raw:     json.RawMessage(`{"coding_agent_reasoning_defaults":`),
 			wantErr: true,
@@ -92,13 +97,13 @@ func TestApplyUserSettingsMergePatch(t *testing.T) {
 		{
 			name:    "sets a field without touching the others",
 			current: json.RawMessage(`{"coding_agent_model_default":"claude-opus-4-7","coding_agent_reasoning_defaults":{"codex":"xhigh"}}`),
-			patch:   json.RawMessage(`{"diff_viewer_full_screen":true}`),
+			patch:   json.RawMessage(`{"manual_session_planes_hidden":true}`),
 			want: UserSettings{
 				CodingAgentModelDefault: "claude-opus-4-7",
 				CodingAgentReasoningDefaults: map[AgentType]ReasoningEffort{
 					AgentTypeCodex: ReasoningEffortXHigh,
 				},
-				DiffViewerFullScreen: true,
+				ManualSessionPlanesHidden: true,
 			},
 		},
 		{
@@ -205,6 +210,18 @@ func TestUserSettings_MarshalJSONB(t *testing.T) {
 		raw, err = (UserSettings{DiffViewerFullScreen: true}).MarshalJSONB()
 		require.NoError(t, err, "MarshalJSONB should accept full screen preference")
 		require.JSONEq(t, `{"diff_viewer_full_screen":true}`, string(raw), "MarshalJSONB should encode the full screen preference")
+	})
+
+	t.Run("omits manual session planes hidden when false", func(t *testing.T) {
+		t.Parallel()
+
+		raw, err := (UserSettings{ManualSessionPlanesHidden: false}).MarshalJSONB()
+		require.NoError(t, err, "MarshalJSONB should accept zero-value settings")
+		require.JSONEq(t, `{}`, string(raw), "MarshalJSONB should omit the default planes preference")
+
+		raw, err = (UserSettings{ManualSessionPlanesHidden: true}).MarshalJSONB()
+		require.NoError(t, err, "MarshalJSONB should accept planes preference")
+		require.JSONEq(t, `{"manual_session_planes_hidden":true}`, string(raw), "MarshalJSONB should encode the planes preference")
 	})
 
 	t.Run("rejects invalid settings", func(t *testing.T) {


### PR DESCRIPTION
## Summary

Manual session creators currently can’t control whether the plane canvas is shown, forcing all users to see (and potentially be distracted by) planes regardless of preference. This PR adds a “Hide planes / Show planes” toggle and persists it as a user setting, so the UI reliably reflects the saved preference across page loads.

## Changes

- Add a plane visibility toggle to `ManualSessionCreatePageContent`, defaulting to the user setting (`manual_session_planes_hidden`).
- When toggled, call `auth.updateSettings` to persist the new value and update the UI immediately.
- Update API/client types and backend user settings model to support `manual_session_planes_hidden`.
- Extend tests to cover: initial rendering based on the setting and persistence via the settings update call.

## Validation

- Frontend: updated/added React Testing Library tests in `manual-session-create-page-content.test.tsx` (rendering + toggle + persistence).
- Backend: updated/added Go tests in `internal/models/user_settings_test.go` for the new `manual_session_planes_hidden` setting.

[143.dev](https://143.dev) | [session 5a9a9f22](https://143.dev/sessions/5a9a9f22-da62-4f71-aeea-99d6f222b9f6)

<!-- 143 readiness -->
**143 readiness:** not available for this revision.

Preview: https://143.dev/previews/github/assembledhq/143/pull/1594?launch=1