### PR TITLE
Refactor session detail state resets into reusable session-scoped hook

### DIFF
--- a/frontend/src/app/(dashboard)/sessions/[id]/page-composer.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/page-composer.test.tsx
@@ -57,6 +57,49 @@ vi.mock('next/image', () => ({
 installSessionDetailPageTestHooks({ toast, routerPush });
 
 describe('SessionDetailPage composer and session metadata', () => {
+  it('clears draft composer text when the session id changes without remounting the page shell', async () => {
+    const firstSession: Session = {
+      ...mockSessions[0],
+      id: 'session-first-draft-reset',
+      result_summary: 'First draft reset session',
+      status: 'idle',
+      completed_at: undefined,
+      current_turn: 1,
+      sandbox_state: 'snapshotted',
+      threads: [],
+    };
+    const secondSession: Session = {
+      ...mockSessions[0],
+      id: 'session-second-draft-reset',
+      result_summary: 'Second draft reset session',
+      status: 'idle',
+      completed_at: undefined,
+      current_turn: 1,
+      sandbox_state: 'snapshotted',
+      threads: [],
+    };
+
+    server.use(
+      http.get('/api/v1/sessions/:id', ({ params }) => {
+        const session = params.id === firstSession.id ? firstSession : secondSession;
+        return HttpResponse.json({ data: session } satisfies SingleResponse<Session>);
+      }),
+    );
+
+    const { rerender } = renderWithProviders(<SessionDetailContent id={firstSession.id} />);
+    await screen.findAllByText('First draft reset session');
+    const composer = await screen.findByPlaceholderText('Send a follow-up message...');
+    changeFieldValue(composer, 'This belongs to the first session');
+    expect(composer).toHaveValue('This belongs to the first session');
+
+    rerender(<SessionDetailContent id={secondSession.id} />);
+
+    await screen.findAllByText('Second draft reset session');
+    await waitFor(() => {
+      expect(screen.getByPlaceholderText('Send a follow-up message...')).toHaveValue('');
+    });
+  });
+
   it('shows model selector for agents with available models', async () => {
     const idleSession: Session = {
       ...mockSessions[0],

--- a/frontend/src/app/(dashboard)/sessions/[id]/page-review-mode.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/page-review-mode.test.tsx
@@ -11,6 +11,7 @@ import {
   changeFieldValue,
   submitFieldWithEnter,
   mockSessionDetailWithLazyDiff,
+  sessionWithoutRawDiff,
 } from './session-detail-test-kit';
 
 const { toast } = vi.hoisted(() => ({
@@ -535,6 +536,62 @@ describe('SessionDetailPage review mode and mobile diff', () => {
     expect(await screen.findByText('Edit review comment')).toBeInTheDocument();
     expect(screen.getByDisplayValue('Add a guard before using this import.')).toBeInTheDocument();
     expect(screen.queryByTestId('inline-comment-composer-anchor')).not.toBeInTheDocument();
+  });
+
+  it('resets review center mode to chat when the session id changes without remounting', async () => {
+    const diffFor = (path: string) =>
+      `diff --git a/${path} b/${path}\n--- a/${path}\n+++ b/${path}\n@@ -1,3 +1,4 @@\n const a = 1;\n+const b = 2;\n const c = 3;\n export {};`;
+    const firstSession: Session = {
+      ...mockSessions[0],
+      id: 'session-review-reset-first',
+      result_summary: 'First review reset session',
+      diff: diffFor('src/first.ts'),
+      diff_stats: { added: 1, removed: 0, files_changed: 1 },
+    };
+    const secondSession: Session = {
+      ...mockSessions[0],
+      id: 'session-review-reset-second',
+      result_summary: 'Second review reset session',
+      diff: diffFor('src/second.ts'),
+      diff_stats: { added: 1, removed: 0, files_changed: 1 },
+    };
+
+    server.use(
+      http.get('/api/v1/sessions/:id', ({ params }) => {
+        const session = params.id === firstSession.id ? firstSession : secondSession;
+        return HttpResponse.json({ data: sessionWithoutRawDiff(session) } satisfies SingleResponse<Session>);
+      }),
+      http.get('/api/v1/sessions/:id/diff', ({ params }) => {
+        const session = params.id === firstSession.id ? firstSession : secondSession;
+        return HttpResponse.json({
+          data: {
+            session_id: session.id,
+            diff: session.diff,
+            diff_stats: session.diff_stats,
+            diff_history: [],
+            diff_truncated: false,
+            diff_history_truncated: false,
+          },
+        });
+      }),
+    );
+
+    const { rerender } = renderWithProviders(<SessionDetailContent id={firstSession.id} />);
+    await screen.findAllByText('First review reset session');
+
+    const user = userEvent.setup();
+    await user.click(screen.getAllByTitle('View changes')[0]);
+    // In review mode the detail toggle is disabled and relabeled.
+    expect(await screen.findByTitle('File tree required during review')).toBeInTheDocument();
+
+    rerender(<SessionDetailContent id={secondSession.id} />);
+    await screen.findAllByText('Second review reset session');
+
+    // The new session must land in chat mode, not inherit review mode.
+    await waitFor(() => {
+      expect(screen.getByTitle('Hide details')).toBeInTheDocument();
+    });
+    expect(screen.queryByTitle('File tree required during review')).not.toBeInTheDocument();
   });
 
   it('exits review mode when clicking a non-changes tab', async () => {

--- a/frontend/src/app/(dashboard)/sessions/[id]/page-warm-start.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/page-warm-start.test.tsx
@@ -144,6 +144,40 @@ describe('SessionDetailPage warm-start message prefetch', () => {
     await screen.findAllByText('Fixed TypeError by adding null check');
   });
 
+  it('prefetches the next session stored thread window when the id changes without remounting', async () => {
+    const firstSessionId = 'session-prefetch-first';
+    const secondSessionId = 'session-prefetch-second';
+    const firstThreadId = 'thread-prefetch-first';
+    const secondThreadId = 'thread-prefetch-second';
+
+    writeCachedViewerScope(window.localStorage, viewerScope);
+    writeStoredSessionActiveThread(window.localStorage, firstSessionId, viewerScope, firstThreadId);
+    writeStoredSessionActiveThread(window.localStorage, secondSessionId, viewerScope, secondThreadId);
+
+    const transcriptRequests: string[] = [];
+    server.use(
+      http.get('/api/v1/sessions/:id', ({ params }) =>
+        HttpResponse.json({
+          data: { ...mockSessions[0], id: params.id as string, threads: [] },
+        } satisfies SingleResponse<Session>),
+      ),
+      http.get('/api/v1/sessions/:id/threads/:threadId/transcript', ({ params }) => {
+        transcriptRequests.push(params.threadId as string);
+        return HttpResponse.json(makeTranscriptWindow([], []));
+      }),
+    );
+
+    const { rerender } = renderWithProviders(<SessionDetailContent id={firstSessionId} />);
+    await waitFor(() => {
+      expect(transcriptRequests).toContain(firstThreadId);
+    });
+
+    rerender(<SessionDetailContent id={secondSessionId} />);
+    await waitFor(() => {
+      expect(transcriptRequests).toContain(secondThreadId);
+    });
+  });
+
   it('does not prefetch when no thread is stored for the session', async () => {
     writeCachedViewerScope(window.localStorage, viewerScope);
 

--- a/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
@@ -148,6 +148,7 @@ import { ResizeHandle } from "@/components/resize-handle";
 import { DiffStatsBadge } from "@/components/code-review/diff-stats-badge";
 import { LinkedIssueChips } from "./linked-issue-chips";
 import { useReviewComments } from "@/hooks/use-review-comments";
+import { useSessionScopedReset } from "@/hooks/use-session-scoped-reset";
 import { useDiffViewState } from "@/hooks/use-diff-view-state";
 import { CodexDeviceCodeModal } from "@/components/codex-device-code-modal";
 import { AgentBadge } from "@/components/agent-badge";
@@ -3614,6 +3615,7 @@ export function SessionDetailContent({ id }: { id: string }) {
   const [isMobileReviewViewport, setIsMobileReviewViewport] = useState(false);
   const previousReviewParamRef = useRef(reviewParam);
   const suppressNextReviewParamClearRef = useRef(false);
+  const lastReviewSyncIdRef = useRef<string | undefined>(undefined);
   useEffect(() => {
     if (reviewParam === "active") {
       setCenterMode("review");
@@ -3629,20 +3631,39 @@ export function SessionDetailContent({ id }: { id: string }) {
   }, [reviewParam]);
 
   useEffect(() => {
-    const urlReviewParam =
+    const urlParams =
       typeof window === "undefined"
         ? null
-        : new URLSearchParams(window.location.search).get("review");
-    const nextReviewParam =
-      typeof window === "undefined" || window.location.search === ""
+        : new URLSearchParams(window.location.search);
+    const urlReviewParam = urlParams?.get("review") ?? null;
+    const urlPreviewParam = urlParams?.get("preview") ?? null;
+    // On a session switch the new session's review state comes solely from its
+    // own URL; only the initial mount may fall back to the remembered param
+    // (e.g. an empty search string during hydration). Without this guard the
+    // stale ref carries the previous session's "active" param into the next
+    // session and leaves it stuck in review mode.
+    const isSessionSwitch =
+      lastReviewSyncIdRef.current !== undefined && lastReviewSyncIdRef.current !== id;
+    lastReviewSyncIdRef.current = id;
+    const nextReviewParam = isSessionSwitch
+      ? urlReviewParam
+      : typeof window === "undefined" || window.location.search === ""
         ? previousReviewParamRef.current
         : urlReviewParam;
     const isDirectReview = nextReviewParam === "active";
+    const isDirectPreview = urlPreviewParam === "1";
+    if (!isSessionSwitch && !isDirectReview && !isDirectPreview) {
+      return;
+    }
     setHasMountedChatPanel(!isDirectReview);
     previousReviewParamRef.current = nextReviewParam;
-    if (isDirectReview) {
-      setCenterMode("review");
-    }
+    setDetailTab(isDirectPreview ? "preview" : isDirectReview ? "changes" : "overview");
+    // Drive centerMode deterministically on session change. Without this, a
+    // session left in review mode bleeds "review" into the next session,
+    // because the reviewParam clear path is gated by
+    // suppressNextReviewParamClearRef (set by openReview) and gets skipped.
+    suppressNextReviewParamClearRef.current = false;
+    setCenterMode(isDirectReview ? "review" : "chat");
   }, [id]);
 
   useEffect(() => {
@@ -3739,6 +3760,33 @@ export function SessionDetailContent({ id }: { id: string }) {
   const apiBase = process.env.NEXT_PUBLIC_API_URL || "";
   const isDocumentVisible = useDocumentVisible();
 
+  const resetSessionChromeAndActionState = useCallback(() => {
+    setMobileDetailOpen(false);
+    setMobileReviewComposerOpen(false);
+    setMobileRenameOpen(false);
+    setKeyboardHelpOpen(false);
+    setReviewConfigOpen(false);
+    setReviewPasses(2);
+    setReviewFixMode("minimal");
+    setActiveFileIndex(0);
+    setIsEditingTitle(false);
+    setDraftTitle("");
+    setLocalPRState("idle");
+    setLocalPRActionError(null);
+    setLocalBranchState("idle");
+    setLocalBranchActionError(null);
+    setLocalPushState("idle");
+    setLocalPushActionError(null);
+    setPendingPRAction(null);
+    setPendingMergeWhenReady(false);
+    setRepairActionError(null);
+    setPRAuthPrompt(null);
+    resumeAttemptRef.current = null;
+  }, []);
+  useSessionScopedReset(id, [
+    { name: "session chrome and action state", reset: resetSessionChromeAndActionState },
+  ]);
+
   const { data, isLoading, error } = useQuery({
     queryKey: queryKeys.sessions.detail(id),
     queryFn: () => api.sessions.get(id),
@@ -3832,10 +3880,13 @@ export function SessionDetailContent({ id }: { id: string }) {
     refetchOnWindowFocus: false,
     retry: false,
   });
-  useEffect(() => {
+  const resetSessionDiffRevisionState = useCallback(() => {
     fetchedDiffBeforeRevisionRef.current = false;
     observedDiffRevisionKeyRef.current = null;
-  }, [id]);
+  }, []);
+  useSessionScopedReset(id, [
+    { name: "session diff revision state", reset: resetSessionDiffRevisionState },
+  ]);
   useEffect(() => {
     if (centerMode === "review") {
       void loadReviewDiffView();
@@ -3904,6 +3955,12 @@ export function SessionDetailContent({ id }: { id: string }) {
   // this prefetch is just unused cache. ChatPanel's useInfiniteQuery shares
   // the exact query key, so React Query dedupes against the in-flight fetch.
   const didPrefetchThreadMessagesRef = useRef(false);
+  const resetSessionPrefetchState = useCallback(() => {
+    didPrefetchThreadMessagesRef.current = false;
+  }, []);
+  useSessionScopedReset(id, [
+    { name: "session prefetch state", reset: resetSessionPrefetchState },
+  ]);
   useEffect(() => {
     if (didPrefetchThreadMessagesRef.current || typeof window === "undefined") return;
     didPrefetchThreadMessagesRef.current = true;
@@ -4073,13 +4130,18 @@ export function SessionDetailContent({ id }: { id: string }) {
     session?.workspace_revision,
   ]);
 
-  useEffect(() => {
+  const resetSessionRuntimeState = useCallback(() => {
     setHasResolvedInitialThreadSelection(false);
     setActiveThreadId(null);
     setPendingThreadPreview(null);
     setSessionStopRequest(null);
     setSessionStopOutcome(null);
-  }, [id]);
+    setOptimisticMessages([]);
+    optimisticMessageIDRef.current = -1_000_000;
+  }, []);
+  useSessionScopedReset(id, [
+    { name: "session runtime state", reset: resetSessionRuntimeState },
+  ]);
 
   useEffect(() => {
     if (!session) {
@@ -4155,10 +4217,6 @@ export function SessionDetailContent({ id }: { id: string }) {
 
     writeStoredSessionActiveThread(window.localStorage, id, viewerScope, activeThreadId);
   }, [activeThreadId, hasResolvedInitialThreadSelection, id, viewerScope]);
-
-  useEffect(() => {
-    setOptimisticMessages([]);
-  }, [id]);
 
   useEffect(() => {
     if (typeof window === "undefined") {
@@ -4297,6 +4355,18 @@ export function SessionDetailContent({ id }: { id: string }) {
   // previous value via ref so we fire once per transition rather than on
   // every render.
   const prevPRStateRef = useRef<string | undefined>(undefined);
+  const prevPRUrlRef = useRef<string | undefined>(undefined);
+  const prevPRPushStateRef = useRef<string | undefined>(undefined);
+  const prevBranchStateRef = useRef<string | undefined>(undefined);
+  const resetSessionTransitionRefs = useCallback(() => {
+    prevPRStateRef.current = undefined;
+    prevPRUrlRef.current = undefined;
+    prevPRPushStateRef.current = undefined;
+    prevBranchStateRef.current = undefined;
+  }, []);
+  useSessionScopedReset(id, [
+    { name: "session transition refs", reset: resetSessionTransitionRefs },
+  ]);
   const prUrl = prData?.data?.github_pr_url;
   const serverPRState = session?.pr_creation_state;
   const localPRWaitingForServer =
@@ -4324,7 +4394,6 @@ export function SessionDetailContent({ id }: { id: string }) {
     }
     prevPRStateRef.current = current;
   }, [session?.pr_creation_state, session?.pr_creation_error, prUrl, queryClient, id]);
-  const prevPRUrlRef = useRef<string | undefined>(undefined);
   useEffect(() => {
     if (localPRState !== "idle" && prUrl && prevPRUrlRef.current !== prUrl && !session?.pr_creation_state) {
       toast.success("PR opened", {
@@ -4340,7 +4409,6 @@ export function SessionDetailContent({ id }: { id: string }) {
   // Also clears localPushState when the server transitions out of in-flight
   // so the button returns to "Push changes" promptly without waiting for the
   // next polling tick.
-  const prevPRPushStateRef = useRef<string | undefined>(undefined);
   useEffect(() => {
     const prev = prevPRPushStateRef.current;
     const current = session?.pr_push_state;
@@ -4361,7 +4429,6 @@ export function SessionDetailContent({ id }: { id: string }) {
     }
     prevPRPushStateRef.current = current;
   }, [session?.pr_push_state, session?.pr_push_error, prUrl, queryClient, id, pullRequestId]);
-  const prevBranchStateRef = useRef<string | undefined>(undefined);
   useEffect(() => {
     const prev = prevBranchStateRef.current;
     const current = session?.branch_creation_state;
@@ -4562,6 +4629,12 @@ export function SessionDetailContent({ id }: { id: string }) {
     };
   }, [apiBase, prData?.data?.status, pullRequestId, queryClient, isDocumentVisible, id]);
   const previousSessionStatusRef = useRef<SessionStatus | undefined>(undefined);
+  const resetSessionNotificationRefs = useCallback(() => {
+    previousSessionStatusRef.current = undefined;
+  }, []);
+  useSessionScopedReset(id, [
+    { name: "session notification refs", reset: resetSessionNotificationRefs },
+  ]);
   useEffect(() => {
     const currentStatus = session?.status;
     if (!session?.id || !currentStatus) {
@@ -4849,6 +4922,13 @@ export function SessionDetailContent({ id }: { id: string }) {
   // Review card can surface blockers, bypasses, and the review packet inline.
   const [readinessBypassOpen, setReadinessBypassOpen] = useState(false);
   const [readinessBypassReason, setReadinessBypassReason] = useState("");
+  const resetSessionReadinessBypassState = useCallback(() => {
+    setReadinessBypassOpen(false);
+    setReadinessBypassReason("");
+  }, []);
+  useSessionScopedReset(id, [
+    { name: "session readiness bypass state", reset: resetSessionReadinessBypassState },
+  ]);
   const readinessPacketRef = useRef<HTMLDivElement | null>(null);
   const readinessBypassMutation = useMutation({
     mutationFn: () => api.sessions.createReadinessBypass(id, readinessBypassReason),
@@ -5083,6 +5163,12 @@ export function SessionDetailContent({ id }: { id: string }) {
     setDiffSearchQuery,
   } = diffViewState;
   const emptyDiffRecoveryKeyRef = useRef<string | null>(null);
+  const resetSessionDiffRecoveryState = useCallback(() => {
+    emptyDiffRecoveryKeyRef.current = null;
+  }, []);
+  useSessionScopedReset(id, [
+    { name: "session diff recovery state", reset: resetSessionDiffRecoveryState },
+  ]);
   useEffect(() => {
     if (
       !shouldLoadDiff ||
@@ -5190,6 +5276,28 @@ export function SessionDetailContent({ id }: { id: string }) {
   const inFlightAgentUpdateRef = useRef<Promise<unknown> | null>(null);
   const chatPanelScrollToLiveEdgeRef = useRef<(() => void) | null>(null);
   const [chatPanelKeyboardControls, setChatPanelKeyboardControls] = useState<SessionTranscriptKeyboardControls | null>(null);
+  const resetSessionComposerState = useCallback(() => {
+    setActiveCommentLine(null);
+    setComposerMessage("");
+    setComposerPlanMode(false);
+    setComposerSelectedModel("");
+    setComposerAttachments([]);
+    setComposerReferences([]);
+    setComposerCommands([]);
+    setComposerIsUploading(false);
+    setComposerUploadError(null);
+    setAddThreadOpen(false);
+    setNewThreadAgentType("codex");
+    setNewThreadModel("");
+    setNewThreadLabel("");
+    focusComposerAfterThreadCreateRef.current = false;
+    inFlightAgentUpdateRef.current = null;
+    chatPanelScrollToLiveEdgeRef.current = null;
+    setChatPanelKeyboardControls(null);
+  }, []);
+  useSessionScopedReset(id, [
+    { name: "session composer state", reset: resetSessionComposerState },
+  ]);
   // Open comments are the source of truth for what gets attached to the next
   // message — once a send succeeds, the backend marks them resolved in the
   // same transaction, the comments query is invalidated below, and the next
@@ -5586,6 +5694,13 @@ export function SessionDetailContent({ id }: { id: string }) {
   // recent response, which is now a delta.
   const fileEventsSinceRef = useRef<string | undefined>(undefined);
   const [accumulatedFileEvents, setAccumulatedFileEvents] = useState<SessionThreadFileEvent[]>([]);
+  const resetSessionFileEventState = useCallback(() => {
+    fileEventsSinceRef.current = undefined;
+    setAccumulatedFileEvents([]);
+  }, []);
+  useSessionScopedReset(id, [
+    { name: "session file event state", reset: resetSessionFileEventState },
+  ]);
   const fileEventsQuery = useQuery({
     queryKey: queryKeys.sessions.threadFileEvents(id),
     queryFn: () => api.sessions.listThreadFileEvents(id, fileEventsSinceRef.current),

--- a/frontend/src/app/(dashboard)/sessions/layout.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/layout.test.tsx
@@ -196,7 +196,7 @@ describe("SessionsLayout", () => {
     expect(screen.getByTestId("session-detail-page-client")).toHaveAttribute("data-session-id", "session-456");
   });
 
-  it("resets detail-local state when the selected session id changes", () => {
+  it("keeps the detail shell mounted when the selected session id changes", () => {
     mockPathname = "/sessions/session-123";
     mockSelectedSegment = "session-123";
     mockSelectedSegments = ["session-123"];
@@ -208,8 +208,8 @@ describe("SessionsLayout", () => {
     );
 
     const draft = screen.getByLabelText("Detail draft");
-    fireEvent.change(draft, { target: { value: "stale detail state" } });
-    expect(screen.getByLabelText("Detail draft")).toHaveValue("stale detail state");
+    fireEvent.change(draft, { target: { value: "shell state survives" } });
+    expect(screen.getByLabelText("Detail draft")).toHaveValue("shell state survives");
 
     mockPathname = "/sessions/session-456";
     mockSelectedSegment = "session-456";
@@ -221,7 +221,7 @@ describe("SessionsLayout", () => {
     );
 
     expect(screen.getByTestId("session-detail-page-client")).toHaveAttribute("data-session-id", "session-456");
-    expect(screen.getByLabelText("Detail draft")).toHaveValue("");
+    expect(screen.getByLabelText("Detail draft")).toHaveValue("shell state survives");
   });
 
   it("replaces session detail with create content when navigating to /sessions/new", () => {

--- a/frontend/src/app/(dashboard)/sessions/sessions-shell-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/sessions-shell-content.tsx
@@ -26,12 +26,7 @@ export function SessionsShellContent({ routeState }: { routeState: SessionsRoute
   }
 
   if (routeState.selectedSessionId) {
-    return (
-      <SessionDetailPageClient
-        key={routeState.selectedSessionId}
-        id={routeState.selectedSessionId}
-      />
-    );
+    return <SessionDetailPageClient id={routeState.selectedSessionId} />;
   }
 
   // Both the explicit create route (/sessions/new) and the bare index

--- a/frontend/src/hooks/use-session-scoped-reset.test.ts
+++ b/frontend/src/hooks/use-session-scoped-reset.test.ts
@@ -1,0 +1,53 @@
+import { renderHook } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { useSessionScopedReset } from "./use-session-scoped-reset";
+
+describe("useSessionScopedReset", () => {
+  it("runs named reset groups only when the session id changes", () => {
+    const resetChrome = vi.fn();
+    const resetComposer = vi.fn();
+
+    const { rerender } = renderHook(
+      ({ sessionId }) =>
+        useSessionScopedReset(sessionId, [
+          { name: "chrome", reset: resetChrome },
+          { name: "composer", reset: resetComposer },
+        ]),
+      { initialProps: { sessionId: "session-1" } },
+    );
+
+    expect(resetChrome).not.toHaveBeenCalled();
+    expect(resetComposer).not.toHaveBeenCalled();
+
+    rerender({ sessionId: "session-1" });
+
+    expect(resetChrome).not.toHaveBeenCalled();
+    expect(resetComposer).not.toHaveBeenCalled();
+
+    rerender({ sessionId: "session-2" });
+
+    expect(resetChrome).toHaveBeenCalledTimes(1);
+    expect(resetComposer).toHaveBeenCalledTimes(1);
+  });
+
+  it("uses the latest reset callback for a group after rerender", () => {
+    const staleReset = vi.fn();
+    const latestReset = vi.fn();
+    let reset = staleReset;
+
+    const { rerender } = renderHook(
+      ({ sessionId }) =>
+        useSessionScopedReset(sessionId, [
+          { name: "composer", reset },
+        ]),
+      { initialProps: { sessionId: "session-1" } },
+    );
+
+    reset = latestReset;
+    rerender({ sessionId: "session-1" });
+    rerender({ sessionId: "session-2" });
+
+    expect(staleReset).not.toHaveBeenCalled();
+    expect(latestReset).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/hooks/use-session-scoped-reset.ts
+++ b/frontend/src/hooks/use-session-scoped-reset.ts
@@ -1,0 +1,28 @@
+import { useEffect, useRef } from "react";
+
+export type SessionScopedResetGroup = {
+  name: string;
+  reset: () => void;
+};
+
+export function useSessionScopedReset(
+  sessionId: string,
+  groups: SessionScopedResetGroup[],
+) {
+  const groupsRef = useRef(groups);
+  const previousSessionIdRef = useRef(sessionId);
+
+  useEffect(() => {
+    groupsRef.current = groups;
+  }, [groups]);
+
+  useEffect(() => {
+    if (previousSessionIdRef.current === sessionId) {
+      return;
+    }
+    previousSessionIdRef.current = sessionId;
+    for (const group of groupsRef.current) {
+      group.reset();
+    }
+  }, [sessionId]);
+}


### PR DESCRIPTION
## Summary

Session detail pages could retain stale UI state (composer text, review mode, readiness/diff/composer internals) when navigating between sessions via the same shell, causing incorrect workflow behavior. This change refactors the reset logic into a single reusable, session-scoped hook and tightens URL mode sync so an initial no-param mount doesn’t overwrite a user’s quick “Changes” tab click—while still resetting review mode correctly on session id changes.

## Changes

- Added `useSessionScopedReset(sessionId, groups)` in `frontend/src/hooks/use-session-scoped-reset.ts` to centralize and standardize which state slices reset per session.
- Updated `SessionDetailContent` to replace scattered raw reset effects with explicit named reset groups:
  session chrome/action state, runtime state, transition/notification refs, readiness bypass, diff/recovery, composer, file event, and prefetch.
- Preserved “smooth transition” behavior by keeping the session detail shell mounted across session id changes, and added regression tests to ensure key state resets still happen on id change.
- Adjusted URL review/preview mode synchronization so the initial mount with no params doesn’t stomp user interactions, while session id changes still update review mode.

## Validation

- Frontend focused tests:
  - `use-session-scoped-reset.test.ts`
  - `sessions/layout.test.tsx`
  - `page-composer.test.tsx`
  - `page-review-mode.test.tsx`
  - `page-warm-start.test.tsx`
- Full frontend checks:
  - `npm run typecheck`
  - `npm run lint`
  - `npm run build`

[143.dev](https://143.dev) | [session 0fa4995a](https://143.dev/sessions/0fa4995a-17d1-4c69-8511-4b2f0938ae3e)

<!-- 143 readiness -->
**143 readiness:** not available for this revision.

Preview: https://143.dev/previews/github/assembledhq/143/pull/1596?launch=1