### PR TITLE
Fix mobile eye toggle placement to align with back button

### DIFF
--- a/frontend/src/app/(dashboard)/sessions/new/manual-session-create-page-content.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/new/manual-session-create-page-content.test.tsx
@@ -300,6 +300,15 @@ describe("ManualSessionCreatePageContent", () => {
     expect(screen.getByRole("button", { name: "Show planes" })).toBeInTheDocument();
   });
 
+  it("aligns the mobile planes toggle with the back button", async () => {
+    setMobileViewport(true);
+
+    renderWithProviders(<ManualSessionCreatePageContent />);
+
+    const toggle = await screen.findByRole("button", { name: "Hide planes" });
+    expect(toggle).toHaveClass("right-2", "top-2", "md:right-4", "md:top-4");
+  });
+
   it("does not render dictation controls on desktop or mobile", async () => {
     const { unmount } = renderWithProviders(<ManualSessionCreatePageContent />);
 

--- a/frontend/src/app/(dashboard)/sessions/new/manual-session-create-page-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/new/manual-session-create-page-content.tsx
@@ -56,23 +56,23 @@ export function ManualSessionCreatePageContent() {
   }, [persistPlanesHidden, planesHidden]);
 
   return (
-    <div className="flex flex-col h-full">
+    <div className="relative flex h-full flex-col">
       <div className="md:hidden flex items-center px-2 pt-2">
         <MobileBackButton to="/sessions" label="Back to sessions" />
       </div>
+      <Button
+        type="button"
+        variant="ghost"
+        size="icon"
+        className="absolute right-2 top-2 z-20 h-8 w-8 text-muted-foreground hover:text-foreground md:right-4 md:top-4"
+        aria-label={planesHidden ? "Show planes" : "Hide planes"}
+        title={planesHidden ? "Show planes" : "Hide planes"}
+        onClick={togglePlanes}
+      >
+        {planesHidden ? <Eye className="h-4 w-4" /> : <EyeOff className="h-4 w-4" />}
+      </Button>
       <div className="relative flex flex-1 flex-col overflow-hidden px-4 pb-4">
         {!planesHidden ? <ManualSessionPlaneCanvas /> : null}
-        <Button
-          type="button"
-          variant="ghost"
-          size="icon"
-          className="absolute right-4 top-4 z-20 h-8 w-8 text-muted-foreground hover:text-foreground"
-          aria-label={planesHidden ? "Show planes" : "Hide planes"}
-          title={planesHidden ? "Show planes" : "Hide planes"}
-          onClick={togglePlanes}
-        >
-          {planesHidden ? <Eye className="h-4 w-4" /> : <EyeOff className="h-4 w-4" />}
-        </Button>
         <ManualSessionComposer
           enableDrafts
           autoFocus


### PR DESCRIPTION
## Summary

On the “new manual session” page, the mobile planes eye toggle is offset differently than the back button, making the top-right controls feel misaligned. This change moves the eye toggle to the page container with `absolute top-2 right-2` on mobile (and preserves the existing `md:top-4 md:right-4` desktop positioning), ensuring consistent placement regardless of inner layout.

## Changes

- Updated `ManualSessionCreatePageContent` layout to make the root container `relative` and place the planes eye toggle in the top-right corner (`right-2 top-2` on mobile, `md:right-4 md:top-4` on desktop).
- Kept the same button behavior/labels (`aria-label`/`title`, `togglePlanes` on click) while removing the previous placement inside the inner content wrapper.
- Added a regression test asserting the mobile toggle contains the expected positioning classes (`right-2`, `top-2`, plus the `md:*` desktop overrides).

## Validation

- `npm test -- manual-session-create-page-content.test.tsx --run`
- `npm run typecheck`
- `npm run lint`
- `npm run build`

[143.dev](https://143.dev) | [session e5306e93](https://143.dev/sessions/e5306e93-c06b-48da-800d-1cee12e6abe8)

<!-- 143 readiness -->
**143 readiness:** not available for this revision.

Preview: https://143.dev/previews/github/assembledhq/143/pull/1597?launch=1