### PR TITLE
Fix mobile overflow in Sessions disclosure and cleanup card action layout

### DIFF
--- a/frontend/src/app/(dashboard)/settings/runtime/page.test.tsx
+++ b/frontend/src/app/(dashboard)/settings/runtime/page.test.tsx
@@ -3,6 +3,7 @@ import {
   renderWithProviders,
   screen,
   waitFor,
+  within,
   userEvent,
 } from "@/test/test-utils";
 import RuntimeSettingsPage from "./page";
@@ -251,6 +252,20 @@ describe("RuntimeSettingsPage", () => {
     expect(
       screen.getByLabelText("Keep sandbox while preview is active"),
     ).not.toBeChecked();
+  });
+
+  it("allows the session lifecycle disclosure summary to wrap on narrow screens", async () => {
+    renderWithProviders(<RuntimeSettingsPage />);
+
+    const disclosure = await screen.findByRole("button", {
+      name: "Show session lifecycle controls",
+    });
+    const summary = await within(disclosure).findByText(/Session max 25 minutes/);
+    const action = screen.getByTestId("session-lifecycle-disclosure-action");
+
+    expect(disclosure).toHaveClass("items-start");
+    expect(summary).toHaveClass("whitespace-normal");
+    expect(action).toHaveClass("shrink-0");
   });
 
   it("keeps repository resource requests visible while exact resource caps stay advanced", async () => {

--- a/frontend/src/app/(dashboard)/settings/runtime/page.tsx
+++ b/frontend/src/app/(dashboard)/settings/runtime/page.tsx
@@ -799,15 +799,15 @@ function SessionsAndCleanupSection() {
                     ? "Hide session lifecycle controls"
                     : "Show session lifecycle controls"
                 }
-                className="flex h-auto w-full items-center justify-between gap-4 rounded-none px-0 py-4 text-left hover:bg-transparent"
+                className="flex h-auto w-full items-start justify-between gap-3 rounded-none px-0 py-4 text-left hover:bg-transparent sm:items-center sm:gap-4"
               >
-                <span className="block min-w-0 space-y-1">
-                  <span className="flex items-center gap-2 text-xs font-medium text-foreground">
+                <span className="block min-w-0 flex-1 space-y-1">
+                  <span className="flex flex-wrap items-center gap-2 text-xs font-medium whitespace-normal text-foreground">
                     Sessions and cleanup
                     <AutosaveIndicator status={autosave.status} />
                   </span>
                   {summary && (
-                    <span className="block text-sm font-medium text-foreground">
+                    <span className="block text-sm font-medium whitespace-normal text-foreground">
                       {summary}
                     </span>
                   )}
@@ -815,7 +815,10 @@ function SessionsAndCleanupSection() {
                     Lifecycle, retention, preview idle behavior, and advanced agent tab coordination.
                   </span>
                 </span>
-                <span className="flex shrink-0 items-center gap-2 text-xs text-muted-foreground">
+                <span
+                  data-testid="session-lifecycle-disclosure-action"
+                  className="flex shrink-0 items-center gap-2 pt-0.5 text-xs text-muted-foreground sm:pt-0"
+                >
                   {open ? "Hide" : "Show"}
                   <ChevronDown
                     className={cn(
@@ -1067,13 +1070,13 @@ function ResourceDefaultsSection() {
                       ? "Hide advanced resource limits"
                       : "Show advanced resource limits"
                   }
-                  className="flex h-auto w-full items-center justify-between gap-4 rounded-none px-0 py-4 text-left hover:bg-transparent"
+                  className="flex h-auto w-full items-start justify-between gap-3 rounded-none px-0 py-4 text-left hover:bg-transparent sm:items-center sm:gap-4"
                 >
-                  <span className="block min-w-0 space-y-1">
-                    <span className="block text-xs font-medium text-foreground">
+                  <span className="block min-w-0 flex-1 space-y-1">
+                    <span className="block text-xs font-medium whitespace-normal text-foreground">
                       Advanced resource limits
                     </span>
-                    <span className="block text-sm font-medium text-foreground">
+                    <span className="block text-sm font-medium whitespace-normal text-foreground">
                       {advancedSummary}
                     </span>
                     <span className="block text-xs leading-5 whitespace-normal text-muted-foreground">


### PR DESCRIPTION
## Summary

On narrow screens, the Sessions “Show/Hide session lifecycle controls” disclosure header was causing layout overflow: the summary/title text couldn’t wrap and the action area could shrink or misalign. This change adjusts the disclosure layout so the header top-aligns on mobile, allows the summary text to wrap, and keeps the action control fixed—while applying the same pattern to the adjacent advanced resource limits disclosure for consistency.

## Changes

- Updated the Sessions disclosure button layout:
  - Switch to `items-start` on mobile and restore `items-center` on `sm+`
  - Allow the header/summary text to wrap (`flex-wrap` + `whitespace-normal`)
  - Make the action area non-shrinking (`shrink-0`) and add a `data-testid` for regression coverage
- Applied the same mobile overflow/layout treatment to the Advanced resource limits disclosure since it used the same structural pattern.

## Validation

- `npm test -- --run 'src/app/(dashboard)/settings/runtime/page.test.tsx'`
- `npm run typecheck`
- `npm run lint`
- `npm run build`

[143.dev](https://143.dev) | [session 0b28c0a5](https://143.dev/sessions/0b28c0a5-fd1c-4770-a43a-8f84340617ac)

<!-- 143 readiness -->
**143 readiness:** not available for this revision.

Preview: https://143.dev/previews/github/assembledhq/143/pull/1598?launch=1