### PR TITLE
Align “Review & fix” button styling with “Review” button outline variant

### DIFF
--- a/frontend/src/app/(dashboard)/sessions/[id]/page-pr-creation.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/page-pr-creation.test.tsx
@@ -489,6 +489,10 @@ describe('SessionDetailPage PR creation', () => {
     renderWithProviders(<SessionDetailContent id="session-abcdef12-3456-7890" />);
 
     expect(await screen.findByText('Review before PR')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Review & fix' })).toHaveAttribute(
+      'data-variant',
+      'outline',
+    );
     expect(screen.queryByText('Issue-less context')).not.toBeInTheDocument();
     expect(screen.queryByDisplayValue('Maintenance follow-up requested in Slack')).not.toBeInTheDocument();
     expect(screen.queryByRole('button', { name: 'Save context' })).not.toBeInTheDocument();

--- a/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
@@ -6163,6 +6163,7 @@ export function SessionDetailContent({ id }: { id: string }) {
                         <DisabledTooltip disabled={reviewActionDisabled} content={reviewActionDisabledReason}>
                           <Button
                             type="button"
+                            variant="outline"
                             size="sm"
                             className="w-full gap-1.5 sm:w-auto"
                             disabled={reviewActionDisabled}


### PR DESCRIPTION
## Summary

The PR creation flow had inconsistent button styling: the session detail card’s **Review** action used an `outline` variant, but **Review & fix** defaulted to the primary gradient. This could mislead users into treating “Review & fix” as a final/commit action. This change updates **Review & fix** to use `variant="outline"` for consistent visual hierarchy, and adds a regression test to prevent the mismatch from returning.

## Changes

- Set `variant="outline"` on the **Review & fix** `<Button>` in `session-detail-content.tsx`
- Added a Vitest assertion in `page-pr-creation.test.tsx` to verify the **Review & fix** button uses the `outline` variant

## Validation

- Focused Vitest regression
- `npm run typecheck`
- `npm run lint`
- `npm run build`

[143.dev](https://143.dev) | [session c62b295f](https://143.dev/sessions/c62b295f-fa7a-44f7-b002-6275a6beaa1f)

<!-- 143 readiness -->
**143 readiness:** not available for this revision.

Preview: https://143.dev/previews/github/assembledhq/143/pull/1600?launch=1