### PR TITLE
Make mobile diff toolbar/header file paths horizontally scrollable

### DIFF
--- a/frontend/src/components/code-review/diff-toolbar.test.tsx
+++ b/frontend/src/components/code-review/diff-toolbar.test.tsx
@@ -104,6 +104,26 @@ describe("DiffToolbar", () => {
     expect(screen.queryByText("Split")).not.toBeInTheDocument();
   });
 
+  it("makes the mobile file path horizontally scrollable while keeping navigation controls fixed", () => {
+    const longPath = "frontend/src/app/(dashboard)/settings/runtime/components/very-long-file-name-that-overflows-mobile.tsx";
+    renderToolbar({
+      isMobile: true,
+      filePath: longPath,
+      filePositionLabel: "2 of 5",
+      onOpenFileList: vi.fn(),
+      onPrevFile: vi.fn(),
+      onNextFile: vi.fn(),
+      canGoPrev: true,
+      canGoNext: true,
+    });
+
+    const path = screen.getByText(longPath);
+    expect(path).toHaveClass("overflow-x-auto", "whitespace-nowrap", "scrollbar-hide");
+    expect(path).not.toHaveClass("truncate");
+    expect(screen.getByRole("button", { name: "Previous file" })).toHaveClass("shrink-0");
+    expect(screen.getByRole("button", { name: "Next file" })).toHaveClass("shrink-0");
+  });
+
   it("keeps mobile controls icon-first and does not render desktop-style text actions", () => {
     renderToolbar({
       isMobile: true,

--- a/frontend/src/components/code-review/diff-toolbar.tsx
+++ b/frontend/src/components/code-review/diff-toolbar.tsx
@@ -76,7 +76,7 @@ export function DiffToolbar({
             <ArrowLeft className="h-3.5 w-3.5" />
           </Button>
           <div className="min-w-0 flex-1">
-            <div className="truncate font-mono text-xs font-medium text-foreground">
+            <div className="min-w-0 overflow-x-auto overflow-y-hidden whitespace-nowrap overscroll-x-contain scrollbar-hide font-mono text-xs font-medium text-foreground">
               {filePath || "Changed file"}
             </div>
             {filePositionLabel ? (

--- a/frontend/src/components/code-review/file-diff-header.test.tsx
+++ b/frontend/src/components/code-review/file-diff-header.test.tsx
@@ -10,6 +10,17 @@ describe("FileDiffHeader", () => {
     expect(screen.getByText("src/app.ts")).toBeInTheDocument();
   });
 
+  it("keeps long file paths horizontally scrollable without moving header actions", () => {
+    const longPath = "frontend/src/app/(dashboard)/settings/runtime/components/very-long-file-name-that-overflows-mobile.tsx";
+    render(<FileDiffHeader filePath={longPath} added={3} removed={1} onBrowseFile={vi.fn()} />);
+
+    const path = screen.getByText(longPath);
+    expect(path).toHaveClass("overflow-x-auto", "whitespace-nowrap", "scrollbar-hide");
+    expect(path).not.toHaveClass("truncate");
+    expect(screen.getByTitle("Browse in repository explorer")).toHaveClass("shrink-0");
+    expect(screen.getByTitle("Copy file path")).toHaveClass("shrink-0");
+  });
+
   it("uses attached diff-surface styling without an independent sticky shadow", () => {
     const { container } = render(<FileDiffHeader filePath="src/app.ts" added={3} removed={1} />);
     const header = container.firstElementChild;

--- a/frontend/src/components/code-review/file-diff-header.tsx
+++ b/frontend/src/components/code-review/file-diff-header.tsx
@@ -36,11 +36,11 @@ export function FileDiffHeader({ filePath, added, removed, className, onBrowseFi
         className
       )}
     >
-      <div className="flex items-center gap-2 min-w-0">
-        <span className="text-xs font-medium font-mono text-foreground truncate">
+      <div className="flex min-w-0 flex-1 items-center gap-2">
+        <span className="min-w-0 flex-1 overflow-x-auto overflow-y-hidden whitespace-nowrap overscroll-x-contain scrollbar-hide font-mono text-xs font-medium text-foreground">
           {filePath}
         </span>
-        <DiffStatsBadge added={added} removed={removed} />
+        <DiffStatsBadge added={added} removed={removed} className="shrink-0" />
       </div>
       <div className="flex items-center gap-0.5 shrink-0">
         {onBrowseFile && (
@@ -49,7 +49,7 @@ export function FileDiffHeader({ filePath, added, removed, className, onBrowseFi
             variant="ghost"
             size="icon"
             onClick={() => onBrowseFile(filePath)}
-            className="h-7 w-7 text-muted-foreground hover:text-foreground"
+            className="h-7 w-7 shrink-0 text-muted-foreground hover:text-foreground"
             title="Browse in repository explorer"
           >
             <ExternalLink className="h-3.5 w-3.5" />
@@ -60,7 +60,7 @@ export function FileDiffHeader({ filePath, added, removed, className, onBrowseFi
           variant="ghost"
           size="icon"
           onClick={copyPath}
-          className="h-7 w-7 text-muted-foreground hover:text-foreground"
+          className="h-7 w-7 shrink-0 text-muted-foreground hover:text-foreground"
           title="Copy file path"
         >
           {copied ? (

--- a/frontend/src/components/code-review/file-diff-section.test.tsx
+++ b/frontend/src/components/code-review/file-diff-section.test.tsx
@@ -175,13 +175,13 @@ describe("FileDiffSection", () => {
 
   it("marks the horizontal diff viewport as a size container for inline comments", () => {
     const { container } = render(<FileDiffSection file={makeDiffFile()} viewMode="unified" />);
-    expect(container.querySelector(".overflow-x-auto")).toHaveClass("[container-type:inline-size]");
+    expect(container.querySelector(".overflow-x-auto.max-w-full")).toHaveClass("[container-type:inline-size]");
   });
 
   it("contains wide diff content inside the file section instead of widening the page", () => {
     const { container } = render(<FileDiffSection file={makeDiffFile()} viewMode="unified" />);
     const section = container.firstElementChild;
-    const horizontalViewport = container.querySelector(".overflow-x-auto");
+    const horizontalViewport = container.querySelector(".overflow-x-auto.max-w-full");
 
     expect(section).toHaveClass("min-w-0", "max-w-full");
     expect(section).not.toHaveClass("overflow-hidden");


### PR DESCRIPTION
## Summary

On mobile, long diff file paths were being visually truncated, forcing users to lose important context when navigating between files. This change updates the diff toolbar and file diff header to keep full paths available via horizontal scrolling, while ensuring the navigation/header actions remain fixed and don’t shift.  

## Changes

- Updated `DiffToolbar` to replace `truncate` with horizontal scrolling (`overflow-x-auto`, `whitespace-nowrap`, `scrollbar-hide`) for the displayed `filePath`.
- Updated `FileDiffHeader` to render long `filePath` values the same way (scrollable, non-truncated) without affecting adjacent header action buttons.
- Added/extended unit tests to verify the new mobile scroll behavior and that navigation/header controls keep their `shrink-0` styling.

## Validation

- Frontend unit tests:
  - `frontend/src/components/code-review/diff-toolbar.test.tsx`
  - `frontend/src/components/code-review/file-diff-header.test.tsx`

[143.dev](https://143.dev) | [session 971f5c24](https://143.dev/sessions/971f5c24-edb9-4765-b19f-dac38084a085)

<!-- 143 readiness -->
**143 readiness:** not available for this revision.

Preview: https://143.dev/previews/github/assembledhq/143/pull/1601?launch=1