### PR TITLE
Prefer failed preview diagnostics for blocked previews

### DIFF
--- a/frontend/src/app/(dashboard)/previews/github/[owner]/[repo]/pull/[number]/page.test.tsx
+++ b/frontend/src/app/(dashboard)/previews/github/[owner]/[repo]/pull/[number]/page.test.tsx
@@ -574,6 +574,43 @@ describe("PullRequestPreviewPage", () => {
     expect(screen.queryByRole("button", { name: /Restart|Start preview|Resume preview/ })).not.toBeInTheDocument();
   });
 
+  it("prefers failed preview diagnostics over blocked launch copy", async () => {
+    server.use(
+      http.get("*/api/v1/previews/github/acme/web/pull/42", () =>
+        HttpResponse.json({
+          data: {
+            target_id: "target-1",
+            preview_id: "prev-1",
+            repository_id: "repo-1",
+            repository_full_name: "acme/web",
+            branch: "feature/preview",
+            commit_sha: "def456",
+            latest_commit_sha: "def456",
+            source_type: "pull_request",
+            status: "failed",
+            error: "the preview ran out of memory (OOM, exit 137); capped at 4096 MiB.",
+            stable_url: "https://143.dev/previews/github/acme/web/pull/42",
+            pull_request_url: "https://github.com/acme/web/pull/42",
+            launch: {
+              action: "blocked",
+              reason: "preview_unavailable",
+              auto_open: false,
+              represents_latest: true,
+              message: "restart preview to apply network setting",
+            },
+          },
+        }),
+      ),
+    );
+
+    renderWithProviders(<PullRequestPreviewContent owner="acme" repo="web" number="42" />);
+
+    expect(await screen.findByText("Preview failed")).toBeInTheDocument();
+    expect(screen.getAllByText("the preview ran out of memory (OOM, exit 137); capped at 4096 MiB.").length).toBeGreaterThan(0);
+    expect(screen.queryByText("Preview blocked")).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Retry preview|Retry/ })).toBeEnabled();
+  });
+
   it("does not show Open preview button while preview is starting", async () => {
     server.use(
       http.get("*/api/v1/previews/github/acme/web/pull/42", () =>

--- a/frontend/src/app/(dashboard)/previews/github/[owner]/[repo]/pull/[number]/page.tsx
+++ b/frontend/src/app/(dashboard)/previews/github/[owner]/[repo]/pull/[number]/page.tsx
@@ -87,6 +87,10 @@ export function PullRequestPreviewContent({
   const launch = preview?.launch;
   const launchState = launchStateCopy(preview);
   const launchSessionShouldOpen = launchRequested || launchSessionActive;
+  const retryAllowed =
+    Boolean(preview?.preview_id) &&
+    launch?.action !== "closed" &&
+    (launch?.action !== "blocked" || preview?.status === "failed");
   const showStartAction =
     launch?.action === "start" ||
     (Boolean(targetId) && (launch?.action === "start_latest" || launch?.action === "resume"));
@@ -341,7 +345,7 @@ export function PullRequestPreviewContent({
                       </Tooltip>
                     </TooltipProvider>
                   ) : null}
-                  {preview.preview_id && launch?.action !== "blocked" && launch?.action !== "closed" ? (
+                  {retryAllowed ? (
                     <Button
                       type="button"
                       variant={launch?.action === "retry" ? "default" : "outline"}
@@ -390,6 +394,13 @@ function launchStateCopy(preview: BranchPreviewResponse | undefined): {
 } | null {
   const launch = preview?.launch;
   if (!launch) return null;
+  if (preview?.status === "failed") {
+    return {
+      title: "Preview failed",
+      description: preview.error || launch.message || "Retry the preview to rebuild this pull request.",
+      className: "border-destructive/20 bg-destructive/5 text-destructive",
+    };
+  }
   switch (launch.action) {
     case "wait":
       return {


### PR DESCRIPTION
## Summary
- Show failed preview diagnostics ahead of blocked launch messaging when a preview has failed
- Keep the retry action available for failed previews even if the launch state is blocked
- Add a UI test covering the failed-preview priority path

## Testing
- Added a unit/UI test for the failed-preview case with blocked launch metadata