### PR TITLE
Fix pending session capacity gating to use agent-run limits (add regression tests)

### DIFF
--- a/docs/design/implemented/101-session-transcript-refactor.md
+++ b/docs/design/implemented/101-session-transcript-refactor.md
@@ -71,6 +71,16 @@ loaded history. The frontend still keeps the established transcript UI:
   active sessions.
 - Older and newer history use transcript cursors, with the existing scroll
   compensation path preserving the visible area when older content is prepended.
+- Pending sessions or tabs render one of two transcript notices. Because the
+  `pending` status covers both normal container/environment setup and a session
+  queued behind the org's concurrency limit, the frontend consults the runtime
+  capacity signal (`GET /settings/runtime/status`) to disambiguate. It compares
+  the agent-run counts (`active_agent_runs >= max_concurrent_agent_runs`) rather
+  than the response's conflated `state`, which also flips to `limited` for the
+  unrelated preview quota. When agent-run concurrency is exhausted it shows an
+  explicit "waiting for capacity" notice (with the configured limit and that the
+  session starts automatically once capacity frees up or the limit is raised);
+  otherwise it shows the standard "setting up environment" message.
 
 The older thread message and log APIs remain available for compatibility,
 internal tools, and direct log inspection.

--- a/frontend/src/app/(dashboard)/sessions/[id]/page-session-states.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/page-session-states.test.tsx
@@ -239,6 +239,118 @@ describe('SessionDetailPage session states', () => {
     expect(screen.getByTitle('Send message')).toBeInTheDocument();
   });
 
+  it('explains that a pending session is waiting on the org concurrency limit', async () => {
+    const pendingSession: Session = {
+      ...mockSessions[0],
+      status: 'pending',
+      completed_at: undefined,
+      current_turn: 0,
+      sandbox_state: 'none',
+    };
+
+    server.use(
+      http.get('/api/v1/sessions/:id', () => {
+        return HttpResponse.json({ data: pendingSession } satisfies SingleResponse<Session>);
+      }),
+      http.get('/api/v1/settings/runtime/status', () => {
+        return HttpResponse.json({
+          data: {
+            static_egress: { available: true, enabled: false },
+            capacity: {
+              state: 'limited',
+              active_agent_runs: 2,
+              max_concurrent_agent_runs: 2,
+              active_previews: 0,
+              max_previews_per_user: 5,
+            },
+          },
+        });
+      }),
+    );
+
+    renderWithProviders(<SessionDetailContent id={pendingSession.id} />);
+
+    expect(await screen.findByText('Waiting for capacity')).toBeInTheDocument();
+    expect(await screen.findByText('Your organization is already at its max concurrency limit of 2 running sessions.')).toBeInTheDocument();
+    expect(screen.getByText('This session will start automatically when another session finishes or the limit is raised.')).toBeInTheDocument();
+    expect(screen.queryByText('Setting up environment')).not.toBeInTheDocument();
+  });
+
+  it('shows the environment setup message for a pending session when the org is below its concurrency limit', async () => {
+    const pendingSession: Session = {
+      ...mockSessions[0],
+      status: 'pending',
+      completed_at: undefined,
+      current_turn: 0,
+      sandbox_state: 'none',
+    };
+
+    server.use(
+      http.get('/api/v1/sessions/:id', () => {
+        return HttpResponse.json({ data: pendingSession } satisfies SingleResponse<Session>);
+      }),
+      http.get('/api/v1/settings/runtime/status', () => {
+        return HttpResponse.json({
+          data: {
+            static_egress: { available: true, enabled: false },
+            capacity: {
+              state: 'normal',
+              active_agent_runs: 0,
+              max_concurrent_agent_runs: 2,
+              active_previews: 0,
+              max_previews_per_user: 5,
+            },
+          },
+        });
+      }),
+    );
+
+    renderWithProviders(<SessionDetailContent id={pendingSession.id} />);
+
+    expect(await screen.findByText('Setting up environment')).toBeInTheDocument();
+    expect(screen.queryByText('Waiting for capacity')).not.toBeInTheDocument();
+    expect(screen.queryByText('Max concurrency reached')).not.toBeInTheDocument();
+  });
+
+  it('shows the environment setup message for a pending session when capacity is limited only by the preview quota', async () => {
+    const pendingSession: Session = {
+      ...mockSessions[0],
+      status: 'pending',
+      completed_at: undefined,
+      current_turn: 0,
+      sandbox_state: 'none',
+    };
+
+    server.use(
+      http.get('/api/v1/sessions/:id', () => {
+        return HttpResponse.json({ data: pendingSession } satisfies SingleResponse<Session>);
+      }),
+      http.get('/api/v1/settings/runtime/status', () => {
+        return HttpResponse.json({
+          data: {
+            static_egress: { available: true, enabled: false },
+            capacity: {
+              // `state` is "limited" because previews are maxed, but agent-run
+              // concurrency still has headroom, so this pending session is just
+              // setting up — not queued behind the concurrency limit.
+              state: 'limited',
+              active_agent_runs: 0,
+              max_concurrent_agent_runs: 2,
+              active_previews: 5,
+              max_previews_per_user: 5,
+            },
+          },
+        });
+      }),
+    );
+
+    renderWithProviders(<SessionDetailContent id={pendingSession.id} />);
+
+    expect(await screen.findByText('Setting up environment')).toBeInTheDocument();
+    expect(screen.queryByText('Waiting for capacity')).not.toBeInTheDocument();
+    expect(screen.queryByText('Max concurrency reached')).not.toBeInTheDocument();
+  });
+
   it('keeps the composer enabled and sends follow-up messages while the session is running', async () => {
     let postedMessage = '';
     const runningSession: Session = {

--- a/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
@@ -2229,8 +2229,26 @@ function ChatPanel({
 
   const activeThreadId = activeThread?.id;
   const isRunning = activeThread ? activeThread.status === "running" : session.status === "running";
+  const isPending = activeThread ? activeThread.status === "pending" : session.status === "pending";
   const isSnapshotExpired = session.sandbox_state === "destroyed";
   const canSendMessage = session.status !== "skipped" && session.status !== "pending" && !isSnapshotExpired;
+  // `pending` covers both the normal environment-setup window and a session
+  // that is queued because the org is at its concurrency limit. The two look
+  // identical on the session row, so consult the runtime capacity signal to
+  // decide which message to show instead of assuming every pending session is
+  // capacity-blocked. Gate on the agent-run dimension specifically rather than
+  // the conflated `state`, which also flips to "limited" when only the
+  // unrelated preview limit is reached.
+  const runtimeStatusQuery = useQuery({
+    queryKey: queryKeys.settings.runtimeStatus,
+    queryFn: () => api.settings.getRuntimeStatus(),
+    enabled: isPending,
+    staleTime: 15_000,
+    refetchInterval: 15_000,
+  });
+  const capacity = runtimeStatusQuery.data?.data.capacity;
+  const isCapacityLimited = capacity != null && capacity.active_agent_runs >= capacity.max_concurrent_agent_runs;
+  const maxConcurrentRuns = capacity?.max_concurrent_agent_runs;
   const initialThreadAnchorPosition = useMemo<SessionAnchorPosition | null>(() => {
     if (!activeThreadId || !viewerScope || typeof window === "undefined") return null;
     return readStoredSessionAnchorPosition(window.localStorage, sessionId, viewerScope, activeThreadId);
@@ -3159,16 +3177,50 @@ function ChatPanel({
             ) : null}
           </>
         )}
-        {(activeThread?.status === "pending" || (!activeThread && session.status === "pending")) && (
-          <div className="flex items-center justify-center py-12">
-            <div className="text-center space-y-2 max-w-[280px]">
-              <Loader2 className="h-8 w-8 text-muted-foreground/40 mx-auto animate-spin" />
-              <p className="text-xs font-medium text-muted-foreground">Setting up environment</p>
-              <p className="text-xs text-muted-foreground/60">Preparing the container and getting the agent ready to run.</p>
+        {isPending && (
+          isCapacityLimited ? (
+            <PendingCapacityNotice maxConcurrentRuns={maxConcurrentRuns} />
+          ) : (
+            <div className="flex items-center justify-center py-12">
+              <div className="text-center space-y-2 max-w-[280px]">
+                <Loader2 className="h-8 w-8 text-muted-foreground/40 mx-auto animate-spin" />
+                <p className="text-xs font-medium text-muted-foreground">Setting up environment</p>
+                <p className="text-xs text-muted-foreground/60">Preparing the container and getting the agent ready to run.</p>
+              </div>
             </div>
-          </div>
+          )
         )}
       </div>
+    </div>
+  );
+}
+
+function PendingCapacityNotice({ maxConcurrentRuns }: { maxConcurrentRuns?: number }) {
+  const limitText = maxConcurrentRuns && maxConcurrentRuns > 0
+    ? `Your organization is already at its max concurrency limit of ${maxConcurrentRuns} running ${maxConcurrentRuns === 1 ? "session" : "sessions"}.`
+    : "Your organization is already at its max concurrency limit for running sessions.";
+
+  return (
+    <div className="flex justify-center py-8">
+      <Card className="w-full max-w-[34rem] border-amber-200/70 bg-amber-50/70 shadow-none dark:border-amber-900/60 dark:bg-amber-950/20">
+        <CardContent className="flex gap-3 p-4">
+          <div className="mt-0.5 flex h-9 w-9 shrink-0 items-center justify-center rounded-md border border-amber-200 bg-background text-amber-700 dark:border-amber-900/70 dark:text-amber-300">
+            <Clock className="h-4 w-4" aria-hidden />
+          </div>
+          <div className="min-w-0 space-y-1.5">
+            <div className="flex flex-wrap items-center gap-2">
+              <p className="text-sm font-semibold text-foreground">Waiting for capacity</p>
+              <Badge variant="outline" className="border-amber-300/80 bg-background/70 text-amber-800 dark:border-amber-800 dark:text-amber-300">
+                Max concurrency reached
+              </Badge>
+            </div>
+            <p className="text-sm text-muted-foreground">{limitText}</p>
+            <p className="text-sm text-muted-foreground">
+              This session will start automatically when another session finishes or the limit is raised.
+            </p>
+          </div>
+        </CardContent>
+      </Card>
     </div>
   );
 }


### PR DESCRIPTION
## Summary

Pending sessions can incorrectly show “max concurrency reached” because the UI previously relied on a conflated `capacity.state` value that is also used for an unrelated preview quota. This blocks the wrong user workflow and creates a reliability risk of misleading status messaging. This change disambiguates using the runtime agent-run counts so the UI shows “waiting for capacity” only when concurrency is truly exhausted.

## Changes

- `frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx`: Updated the capacity gate to compare `capacity.active_agent_runs >= capacity.max_concurrent_agent_runs` instead of `capacity.state === "limited"`; also simplified a redundant polling interval since the query is already `enabled: isPending`.
- `frontend/src/app/(dashboard)/sessions/[id]/page-session-states.test.tsx`: Added regression coverage for pending sessions:
  - When `capacity.state` is `"limited"` due to preview quota but agent-run counts are below max, the UI shows “Setting up environment”.
  - When agent-run concurrency is exhausted, the UI shows “Waiting for capacity” with the configured limit guidance.
- `docs/design/implemented/101-session-transcript-refactor.md`: Documented that the transcript notice selection uses agent-run counts (not the conflated `state`).

## Validation

- `tsc --noEmit`
- ESLint (clean)
- Capacity-related test suite: all added/regression tests pass

[143.dev](https://143.dev) | [session b71a1bdc](https://143.dev/sessions/b71a1bdc-6f84-4a5f-a3df-4930650f480c)

<!-- 143 readiness -->
**143 readiness:** not available for this revision.

Preview: https://143.dev/previews/github/assembledhq/143/pull/1603?launch=1