### PR TITLE
Add sandbox runtime guidance to coding prompts

### DIFF
--- a/docs/design/implemented/76-sandbox-disk-guardrails.md
+++ b/docs/design/implemented/76-sandbox-disk-guardrails.md
@@ -1,6 +1,6 @@
 # Sandbox Disk Guardrails
 
-> **Status:** Implemented | **Last reviewed:** 2026-05-09
+> **Status:** Implemented | **Last reviewed:** 2026-06-24
 
 Production workers run untrusted, write-heavy coding sandboxes on the same Docker host as the worker service. Disk exhaustion is therefore a platform availability risk, not just a per-session failure. The long-term guardrail is layered: reclaim routine deploy churn, make sandbox ownership visible to the host, reconcile leaked containers continuously, tighten lifecycle accounting, and require real Docker storage quotas in production.
 
@@ -71,6 +71,12 @@ When the GC destroys a container, it closes any open `container_usage_events` ro
 Production worker env files set `SANDBOX_REQUIRE_DISK_QUOTA=true`. When enabled, Docker health checks create a tiny quota probe container with `StorageOpt{"size":"1G"}`. Sandbox creation also fails instead of retrying without `StorageOpt` if Docker rejects the configured per-container disk limit.
 
 This is intentionally fail-closed. Docker only enforces `StorageOpt.size` for compatible storage setups, typically `overlay2` over XFS with project quotas. Hosts using ext4 or XFS without project quotas must be reprovisioned before this flag is enabled. Local development defaults remain permissive with `SANDBOX_REQUIRE_DISK_QUOTA=false`.
+
+## Tmpfs Scratch Paths
+
+Sandbox containers mount `/tmp` as a 256 MiB noexec tmpfs and `/var/tmp` as a 512 MiB exec tmpfs. These mounts count against the container memory limit and are intentionally small; they are not expanded by raising `SANDBOX_DISK_LIMIT_GB`, which only controls root filesystem quota.
+
+Language toolchains and package managers can write large build scratch trees, compiler inputs, or dependency caches under `TMPDIR`, `/tmp`, `/var/tmp`, or ecosystem-specific cache locations. Shared sandbox runtime guidance therefore tells coding agents to run build, test, lint, and verification commands with large scratch/cache paths pointed at rootfs-backed storage under `/home/sandbox` or the repository. Examples include common `TMPDIR`/`TEMP`/`TMP`, Go `GOTMPDIR`/`GOCACHE`, Node package-manager cache dirs, Python `PIP_CACHE_DIR`, and Rust `CARGO_HOME`/`CARGO_TARGET_DIR`. This guidance prevents misleading `no space left on device` failures from tmpfs paths while keeping the tmpfs memory budget small.
 
 ## Operational Recipe
 

--- a/internal/prompts/prompts.go
+++ b/internal/prompts/prompts.go
@@ -146,6 +146,11 @@ func CodingTaskPreamble() string {
 	return render("coding_task_preamble.template", nil)
 }
 
+// CodingSandboxGuidance returns runtime guidance shared by coding-agent prompts.
+func CodingSandboxGuidance() string {
+	return render("coding_sandbox_guidance.template", nil)
+}
+
 // AnswerOnlyPreamble returns the preamble injected into Slack answer-only agent
 // prompts. These runs should answer questions without mutating the repository.
 func AnswerOnlyPreamble() string {

--- a/internal/prompts/prompts_test.go
+++ b/internal/prompts/prompts_test.go
@@ -163,6 +163,19 @@ func TestCodingTaskPreamble(t *testing.T) {
 	assert.Contains(t, result, "untrusted external content")
 }
 
+func TestCodingSandboxGuidance(t *testing.T) {
+	t.Parallel()
+
+	result := CodingSandboxGuidance()
+	require.NotEmpty(t, result, "sandbox guidance should render")
+	require.Contains(t, result, "build, test, lint, or verification commands", "sandbox guidance should apply to all language ecosystems")
+	require.Contains(t, result, "TMPDIR", "sandbox guidance should teach agents to redirect general temp files")
+	require.Contains(t, result, "language/tool-specific", "sandbox guidance should account for ecosystem-specific cache and temp settings")
+	require.Contains(t, result, "GOTMPDIR", "sandbox guidance should keep Go temp knobs as one example")
+	require.Contains(t, result, "/home/sandbox", "sandbox guidance should point Go temp/cache paths at rootfs-backed sandbox storage")
+	require.NotContains(t, result, "When running Go verification commands", "sandbox guidance should not be framed as Go-only")
+}
+
 func TestAnswerOnlyPreamble(t *testing.T) {
 	t.Parallel()
 

--- a/internal/prompts/templates/coding_sandbox_guidance.template
+++ b/internal/prompts/templates/coding_sandbox_guidance.template
@@ -1,0 +1,3 @@
+## Sandbox Runtime Guidance
+
+When running build, test, lint, or verification commands inside a 143 sandbox, avoid the small tmpfs-backed `/tmp` and `/var/tmp` paths for large scratch or cache data. Prefer rootfs-backed directories under `/home/sandbox` or the repository, and set the relevant language/tool-specific temp or cache settings when a tool may write a lot of data. Examples include common `TMPDIR`/`TEMP`/`TMP`, Go `GOTMPDIR`/`GOCACHE`, Node package-manager cache dirs, Python `PIP_CACHE_DIR`, and Rust `CARGO_HOME`/`CARGO_TARGET_DIR`. If a command fails with `no space left on device` under `/tmp` or `/var/tmp`, rerun it with those paths redirected rather than increasing sandbox disk.

--- a/internal/services/agent/adapters/prompt_builders.go
+++ b/internal/services/agent/adapters/prompt_builders.go
@@ -87,6 +87,13 @@ func buildSystemPrompt(input *agent.AgentInput) string {
 			b.WriteString("\n\n")
 		}
 	}
+	if input == nil || input.PromptStyle != agent.PromptStyleAnswerOnly {
+		guidance := prompts.CodingSandboxGuidance()
+		b.WriteString(guidance)
+		if !strings.HasSuffix(guidance, "\n\n") {
+			b.WriteString("\n\n")
+		}
+	}
 
 	// Repo conventions from context docs.
 	if len(input.ContextDocs) > 0 {

--- a/internal/services/agent/adapters/prompt_builders_test.go
+++ b/internal/services/agent/adapters/prompt_builders_test.go
@@ -260,6 +260,21 @@ func TestBuildSystemPrompt_ManualSessionLinkedIssuesCarryTrustFence(t *testing.T
 	require.Contains(t, prompt, "untrusted external content", "trust_warning must call out untrusted external content")
 }
 
+func TestBuildSystemPrompt_ManualSessionIncludesSandboxRuntimeGuidance(t *testing.T) {
+	t.Parallel()
+
+	input := &agent.AgentInput{
+		Issue:  &models.Issue{Title: "run focused verification", Source: models.IssueSourceManual},
+		Manual: true,
+	}
+
+	prompt := buildSystemPrompt(input)
+	require.Contains(t, prompt, "build, test, lint, or verification commands", "manual coding sessions should receive language-agnostic sandbox runtime guidance")
+	require.Contains(t, prompt, "TMPDIR", "manual coding sessions should still receive sandbox runtime guidance")
+	require.Contains(t, prompt, "language/tool-specific", "manual coding sessions should learn to redirect ecosystem-specific cache and temp paths")
+	require.Contains(t, prompt, "/home/sandbox", "manual coding sessions should point Go scratch/cache paths at rootfs-backed storage")
+}
+
 func TestBuildSystemPrompt_AutomationRunMatchesSessionStyle(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- Add a shared coding sandbox guidance template covering tmpfs scratch/cache path redirects
- Inject that guidance into non-answer-only system prompts
- Update sandbox disk guardrail docs to reflect the tmpfs behavior and operator guidance
- Add unit coverage for the new prompt template and prompt builder behavior

## Testing
- Unit tests added for `CodingSandboxGuidance`
- Unit tests added for `buildSystemPrompt` to verify manual sessions include the sandbox guidance