### PR TITLE
Add Docs link to bottom-left user dropdown

### DIFF
--- a/frontend/src/components/authenticated-layout.test.tsx
+++ b/frontend/src/components/authenticated-layout.test.tsx
@@ -272,7 +272,7 @@ describe("AuthenticatedLayout", () => {
     expect(screen.getByRole("link", { name: "Audit log" })).toHaveAttribute("href", "/settings/audit-log");
   });
 
-  it("shows only log out in the user menu", async () => {
+  it("shows docs in the user menu", async () => {
     const user = userEvent.setup();
 
     renderWithProviders(
@@ -283,6 +283,7 @@ describe("AuthenticatedLayout", () => {
 
     await user.click(screen.getByRole("button", { name: /Alex Doe/ }));
 
+    expect(await screen.findByRole("menuitem", { name: "Docs" })).toHaveAttribute("href", "/docs");
     expect(await screen.findByRole("menuitem", { name: "Log out" })).toBeInTheDocument();
   });
 

--- a/frontend/src/components/authenticated-layout.tsx
+++ b/frontend/src/components/authenticated-layout.tsx
@@ -15,6 +15,7 @@ import {
   X,
   Settings,
   MonitorPlay,
+  BookOpen,
   type LucideIcon,
 } from "lucide-react";
 import Link from "next/link";
@@ -304,6 +305,12 @@ function SidebarBody({
               </Button>
             </DropdownMenuTrigger>
             <DropdownMenuContent align="start" side="top" className="w-48">
+              <DropdownMenuItem asChild>
+                <Link href="/docs">
+                  <BookOpen className="h-4 w-4" />
+                  Docs
+                </Link>
+              </DropdownMenuItem>
               <DropdownMenuItem onClick={onLogout}>
                 <LogOut className="h-4 w-4" />
                 Log out


### PR DESCRIPTION
## Summary

Users currently only see “Log out” in the bottom-left user menu, leaving no obvious path to product documentation. This change adds a “Docs” menu item (with a BookOpen icon) that links to `/docs`, and updates the existing test to assert the new navigation option.

## Changes

- Add a `Docs` item to the authenticated user dropdown linking to `/docs`
- Include a `BookOpen` icon for clearer menu affordance
- Update `authenticated-layout` test to verify the new `Docs` menu item appears alongside “Log out”

## Validation

- `npm test -- authenticated-layout.test.tsx`
- `npm run typecheck`
- `npm run lint`
- `npm run build`

[143.dev](https://143.dev) | [session 024f0488](https://143.dev/sessions/024f0488-2b99-4484-8ac2-7064875a0f3d)

<!-- 143 readiness -->
**143 readiness:** not available for this revision.

Preview: https://143.dev/previews/github/assembledhq/143/pull/1606?launch=1