### PR TITLE
Update CapabilityInfoTooltip footer to remove category and all-caps styling

### DIFF
--- a/frontend/src/components/capability-info-tooltip.test.tsx
+++ b/frontend/src/components/capability-info-tooltip.test.tsx
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+
+import { CapabilityInfoTooltip } from "@/components/capability-info-tooltip";
+import { renderWithProviders, screen, userEvent } from "@/test/test-utils";
+import type { AgentCapabilityDefinition } from "@/lib/types";
+
+describe("CapabilityInfoTooltip", () => {
+  it("shows risk and access without category or all-caps styling", async () => {
+    const user = userEvent.setup();
+    const definition: AgentCapabilityDefinition = {
+      id: "repo_context",
+      display_name: "Repository context",
+      description: "Code, docs, and repository-local facts.",
+      category: "context",
+      max_access_level: "read",
+      risk: "low",
+      scope: "repository",
+    };
+
+    renderWithProviders(<CapabilityInfoTooltip definition={definition} />);
+
+    await user.hover(screen.getByRole("button", { name: "About Repository context" }));
+
+    const tooltip = await screen.findByRole("tooltip");
+    expect(tooltip).toHaveTextContent("Low risk · Read-only");
+    expect(tooltip).not.toHaveTextContent("context");
+    for (const footer of screen.getAllByText("Low risk · Read-only")) {
+      expect(footer).not.toHaveClass("uppercase");
+    }
+  });
+});

--- a/frontend/src/components/capability-info-tooltip.tsx
+++ b/frontend/src/components/capability-info-tooltip.tsx
@@ -65,8 +65,8 @@ export function CapabilityInfoTooltip({ definition }: { definition: AgentCapabil
         </TooltipTrigger>
         <TooltipContent side="top" sideOffset={6} className="max-w-72 space-y-1.5">
           <p>{detail}</p>
-          <p className="text-xs uppercase tracking-wide text-background/70">
-            {definition.category} · {RISK_LABEL[definition.risk]} · {ACCESS_LABEL[definition.max_access_level]}
+          <p className="text-xs text-background/70">
+            {RISK_LABEL[definition.risk]} · {ACCESS_LABEL[definition.max_access_level]}
           </p>
         </TooltipContent>
       </Tooltip>


### PR DESCRIPTION
## Summary

The tooltip footer in `CapabilityInfoTooltip` shows extra “category” context and all-caps styling, making it harder to scan and potentially inconsistent with the intended “low risk · read-only” presentation. This change updates the tooltip footer to display only the risk and access labels with normal (non-uppercase) styling, and adds a focused test to lock the behavior in (per #N/A).

## Changes

- Updated `frontend/src/components/capability-info-tooltip.tsx` to render only: `RISK_LABEL[risk] · ACCESS_LABEL[max_access_level]` (no `definition.category`).
- Removed `uppercase` (and related tracking) class so the footer matches the desired visual style.
- Added `frontend/src/components/capability-info-tooltip.test.tsx` to verify the tooltip text and absence of category/all-caps styling.

## Validation

- `npm test -- run capability-info-tooltip.test.tsx`
- `npm run typecheck`
- `npm run lint`
- `npm run build`

[143.dev](https://143.dev) | [session 4640aa83](https://143.dev/sessions/4640aa83-035b-41b9-9757-dc0d3a8687a8)

<!-- 143 readiness -->
**143 readiness:** not available for this revision.

Preview: https://143.dev/previews/github/assembledhq/143/pull/1607?launch=1