### PR TITLE
Add public docs for `143-tools slack send` command

### DIFF
--- a/docs/public/reference/agent-tools.mdx
+++ b/docs/public/reference/agent-tools.mdx
@@ -47,7 +47,7 @@ Only configured namespaces appear in `143-tools --help`.
 | `github` | `list_recent_prs`, `get_pr_reviews` |
 | `circleci` | `list_flaky_tests`, `get_job_test_results`, `get_recent_test_failures` |
 | `logs` | `query`, `context`, `fields`, `stats` |
-| `slack` | `search_messages`, `get_thread` |
+| `slack` | `search_messages`, `get_thread`, `send` |
 | `issue` | `create` |
 | `pr` | `create` |
 | `project` | `propose` |
@@ -439,6 +439,27 @@ Common use: read the full discussion around a bug report before coding.
 
 ```bash
 143-tools slack get_thread --message_id msg-456
+```
+
+### `slack send`
+
+Send a plain-text Slack message through 143's platform-managed Slack connection. This command appears only when the session or automation has the Slack notification capability.
+
+| Flag | Type | Required | Description |
+|---|---|---:|---|
+| `--channel-id` | string | Yes | Slack channel ID to send to, such as `C123`. |
+| `--text` | string | Yes | Plain-text message body. |
+
+Common use: post automation completion or status updates to a channel chosen by the automation owner.
+
+```bash
+143-tools slack send --channel-id C123 --text "Automation completed successfully."
+```
+
+The command returns delivery state and Slack message coordinates:
+
+```json
+{"status":"sent","channel_id":"C123","message_ts":"1700000000.000100"}
 ```
 
 ## 143 workflow tools


### PR DESCRIPTION
## Summary

The preview environment changes introduced Slack notification tooling (`143-tools slack send`), but the public agent tools reference was missing the command, leaving developers without a documented workflow or expected flags/response shape. This updates `docs/public/reference/agent-tools.mdx` to include `slack send` so users can discover and use it safely.

## Changes

- Documented `143-tools slack send` in the public agent tools reference.
- Added required flags (`--channel-id`, `--text`) and clarified capability gating (command only appears when the Slack notification capability is present).
- Documented the response payload shape including delivery status and Slack message coordinates.

## Validation

- Checked the rendered doc content by reviewing the updated section in `docs/public/reference/agent-tools.mdx`.
- Attempted to run `npm run test -- public-docs.test.ts` from `frontend/`, but tests could not execute in this environment because `frontend/node_modules` is missing and `vitest` is not installed.

[143.dev](https://143.dev) | [session f680f1c4](https://143.dev/sessions/f680f1c4-0944-48a0-b79f-c8dee9e6b53a)

<!-- 143 readiness -->
**143 readiness:** not available for this revision.

Preview: https://143.dev/previews/github/assembledhq/143/pull/1608?launch=1