### PR TITLE
Persist preview build cache on prewarm by awaiting saves in StopPreview

### DIFF
--- a/internal/services/preview/providers/docker_preview.go
+++ b/internal/services/preview/providers/docker_preview.go
@@ -639,6 +639,36 @@ func previewConfigHasInitScripts(cfg *models.PreviewConfig) bool {
 // StopPreview
 // =============================================================================
 
+// previewStopBackgroundWaitCap bounds how long StopPreview blocks on background
+// work — chiefly the post-ready build-cache uploads it deliberately awaits so a
+// prewarm persists its cache. It sits below the saves' own 10-minute timeout so
+// an interactive stop can't hang on a wedged blob store, yet is generous enough
+// that a normal prewarm save (seconds) completes.
+const previewStopBackgroundWaitCap = 3 * time.Minute
+
+// waitForGroupBounded blocks until wg is done, ctx is cancelled, or maxWait
+// elapses — whichever first — returning a non-nil error only when it gives up
+// before wg completed. The detached goroutine finishes wg and exits; closing
+// done after the receiver moved on is harmless, and the saves run under
+// context.WithoutCancel so they keep going regardless of which branch wins.
+func waitForGroupBounded(ctx context.Context, wg *sync.WaitGroup, maxWait time.Duration) error {
+	done := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(done)
+	}()
+	timer := time.NewTimer(maxWait)
+	defer timer.Stop()
+	select {
+	case <-done:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return fmt.Errorf("timed out after %s waiting for preview background work", maxWait)
+	}
+}
+
 func (d *DockerPreviewProvider) StopPreview(ctx context.Context, handle string) error {
 	d.mu.RLock()
 	state, ok := d.previews[handle]
@@ -648,10 +678,18 @@ func (d *DockerPreviewProvider) StopPreview(ctx context.Context, handle string) 
 		return nil // already stopped — idempotent
 	}
 
-	// Cancel all service goroutines and wait for background work to finish.
+	// Cancel all service goroutines and wait for background work to finish. The
+	// wait is bounded: it intentionally blocks on the post-ready build-cache
+	// uploads (so a prewarm, which stops the moment the preview is ready,
+	// persists its cache), but an interactive stop must not hang on a slow blob
+	// store. The cap sits well under the saves' own 10-minute self-timeout, and a
+	// caller (e.g. a prewarm job) with a longer-lived ctx still gets the full cap.
 	state.cancelFn()
 	d.terminateServiceProcesses(state)
-	state.wg.Wait()
+	if err := waitForGroupBounded(ctx, &state.wg, previewStopBackgroundWaitCap); err != nil {
+		d.logger.Warn().Err(err).Str("handle", handle).
+			Msg("stop preview: proceeding before background work finished; an in-flight build cache save may be aborted by teardown")
+	}
 
 	// Tear down infrastructure containers.
 	for name, ih := range state.infra {
@@ -1814,7 +1852,17 @@ func (d *DockerPreviewProvider) saveBuildCacheSet(ctx context.Context, state *pr
 // runs asynchronously so it does not delay reporting the ready preview.
 func (d *DockerPreviewProvider) savePreviewBuildCache(ctx context.Context, state *previewState, install *models.PreviewInstallConfig, opts preview.StartPreviewOptions, observer preview.ServiceObserver) {
 	state.buildCacheSaveOnce.Do(func() {
-		go d.saveBuildCacheSet(ctx, state, opts, observer, install, models.PreviewCacheRootWorkDir, state.buildCacheKey, state.buildCachePaths, state.buildCacheRestoredChecksum)
+		// Register on the wait group so StopPreview's wg.Wait() blocks until the
+		// upload finishes. saveBuildCacheSet detaches from ctx (WithoutCancel +
+		// its own timeout), so this never delays a normal serving launch — the
+		// save almost always completes long before a user stop — but it does
+		// guarantee a prewarm, which stops the preview the instant it is ready,
+		// leaves a durably-saved build cache behind instead of racing teardown.
+		state.wg.Add(1)
+		go func() {
+			defer state.wg.Done()
+			d.saveBuildCacheSet(ctx, state, opts, observer, install, models.PreviewCacheRootWorkDir, state.buildCacheKey, state.buildCachePaths, state.buildCacheRestoredChecksum)
+		}()
 	})
 }
 
@@ -1832,7 +1880,13 @@ func (d *DockerPreviewProvider) savePreviewBuildCacheHome(ctx context.Context, s
 		if state.buildCacheHomeKey == "" {
 			return
 		}
-		go d.saveBuildCacheSet(ctx, state, opts, observer, install, models.PreviewCacheRootHomeDir, state.buildCacheHomeKey, state.buildCacheHomePaths, state.buildCacheHomeRestoredChecksum)
+		// Registered on the wait group (see savePreviewBuildCache) so a prewarm's
+		// StopPreview awaits the GOCACHE/GOMODCACHE upload before completing.
+		state.wg.Add(1)
+		go func() {
+			defer state.wg.Done()
+			d.saveBuildCacheSet(ctx, state, opts, observer, install, models.PreviewCacheRootHomeDir, state.buildCacheHomeKey, state.buildCacheHomePaths, state.buildCacheHomeRestoredChecksum)
+		}()
 	})
 }
 

--- a/internal/services/preview/providers/docker_preview_test.go
+++ b/internal/services/preview/providers/docker_preview_test.go
@@ -869,6 +869,9 @@ type fakeDependencyCache struct {
 	restoreRoots    []models.PreviewCacheRoot
 	saveSpecs       []preview.PreviewPathCacheSaveSpec
 	saveStarted     chan models.PreviewCacheKind
+	// buildSaveBlock, when set, makes the workdir build-artifact save block until
+	// the channel is closed — used to prove StopPreview awaits the save.
+	buildSaveBlock chan struct{}
 }
 
 func (f *fakeDependencyCache) Find(context.Context, uuid.UUID, uuid.UUID, string) (*preview.DependencyCacheHit, error) {
@@ -939,6 +942,9 @@ func (f *fakeDependencyCache) SavePathCache(_ context.Context, _ *agent.Sandbox,
 		case f.saveStarted <- spec.Kind:
 		default:
 		}
+	}
+	if f.buildSaveBlock != nil && spec.Kind == models.PreviewCacheKindBuildArtifact && spec.Root == models.PreviewCacheRootWorkDir {
+		<-f.buildSaveBlock
 	}
 	f.mu.Lock()
 	defer f.mu.Unlock()
@@ -3063,6 +3069,157 @@ func TestStartPreview_BuildCacheRestoresAfterInstallAndSavesPostReady(t *testing
 
 	close(release)
 	require.NoError(t, d.StopPreview(context.Background(), handle.Handle), "StopPreview should clean up the started preview")
+}
+
+// TestStopPreview_AwaitsBuildCacheSave proves the prewarm coordination
+// guarantee: StopPreview blocks until the post-ready build-cache save finishes,
+// so a session prewarm (which stops the preview the instant it is ready) leaves
+// a durably-saved build cache behind instead of racing teardown.
+func TestStopPreview_AwaitsBuildCacheSave(t *testing.T) {
+	t.Parallel()
+
+	// The service "process" must stay running until cancelled so readiness
+	// succeeds via the dialer; an immediate return would look like a crashed
+	// service and divert to the synchronous failure-path cache flush.
+	release := make(chan struct{})
+	defer close(release)
+	exec := &fakeServiceExecutor{
+		execStreamFn: func(ctx context.Context, _ string, _ func([]byte)) (int, error) {
+			select {
+			case <-release:
+			case <-ctx.Done():
+			}
+			return 0, nil
+		},
+		execFn:     func(_ context.Context, _ string) (int, error) { return 0, nil },
+		readFileFn: func(_ context.Context, _ string) ([]byte, error) { return []byte(`{"lockfileVersion":3}`), nil },
+	}
+	saveStarted := make(chan models.PreviewCacheKind, 8)
+	buildSaveBlock := make(chan struct{})
+	cache := &fakeDependencyCache{
+		findHit: &preview.DependencyCacheHit{},
+		buildFindHit: &preview.DependencyCacheHit{
+			Entry: models.PreviewDependencyCache{
+				CacheKind: models.PreviewCacheKindBuildArtifact,
+				SizeBytes: 999,
+				Metadata:  []byte(`{"checksum_sha256":"prior-checksum"}`),
+			},
+		},
+		saveStarted:    saveStarted,
+		buildSaveBlock: buildSaveBlock,
+	}
+	d := NewDockerPreviewProvider(previewReachableClient(), exec, zerolog.Nop(), WithPreviewDialer(successfulPreviewDialer), WithDependencyCache(cache))
+
+	handle, err := d.StartPreview(context.Background(), &agent.Sandbox{ID: "sb", WorkDir: "/workspace/repo"}, previewInstallTestConfig(), preview.StartPreviewOptions{
+		OrgID:        uuid.New(),
+		RepositoryID: uuid.New(),
+		SessionID:    uuid.New(),
+	}, nil)
+	require.NoError(t, err, "StartPreview should succeed with a build cache hit")
+	require.NotNil(t, handle)
+
+	// Wait until the workdir build-cache save goroutine has started and is
+	// blocked inside SavePathCache on buildSaveBlock.
+	waitForBuildArtifactSave := func() {
+		deadline := time.After(5 * time.Second)
+		for {
+			select {
+			case kind := <-saveStarted:
+				if kind == models.PreviewCacheKindBuildArtifact {
+					return
+				}
+			case <-deadline:
+				t.Fatal("build cache save never started")
+			}
+		}
+	}
+	waitForBuildArtifactSave()
+
+	// StopPreview must not return while the save is still in flight.
+	stopErr := make(chan error, 1)
+	go func() { stopErr <- d.StopPreview(context.Background(), handle.Handle) }()
+	select {
+	case <-stopErr:
+		t.Fatal("StopPreview returned before the build cache save completed")
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	// Release the save; StopPreview should now complete and the save be recorded.
+	close(buildSaveBlock)
+	select {
+	case err := <-stopErr:
+		require.NoError(t, err, "StopPreview should clean up the started preview")
+	case <-time.After(5 * time.Second):
+		t.Fatal("StopPreview did not return after the build cache save was released")
+	}
+	_, _, saves, _, _ := cache.pathCounts()
+	require.Equal(t, 1, saves[models.PreviewCacheKindBuildArtifact], "the awaited build cache save should have completed before StopPreview returned")
+}
+
+// TestStopPreview_BoundedByContextWhenSaveStalls proves the other half of the
+// trade-off: an interactive stop must not hang on a slow/stuck build-cache
+// upload. With a stalled save, StopPreview returns when the caller's context
+// expires instead of blocking on the save's full timeout.
+func TestStopPreview_BoundedByContextWhenSaveStalls(t *testing.T) {
+	t.Parallel()
+
+	// Keep the service "process" running until cancelled so readiness succeeds
+	// (see TestStopPreview_AwaitsBuildCacheSave).
+	release := make(chan struct{})
+	defer close(release)
+	exec := &fakeServiceExecutor{
+		execStreamFn: func(ctx context.Context, _ string, _ func([]byte)) (int, error) {
+			select {
+			case <-release:
+			case <-ctx.Done():
+			}
+			return 0, nil
+		},
+		execFn:     func(_ context.Context, _ string) (int, error) { return 0, nil },
+		readFileFn: func(_ context.Context, _ string) ([]byte, error) { return []byte(`{"lockfileVersion":3}`), nil },
+	}
+	saveStarted := make(chan models.PreviewCacheKind, 8)
+	buildSaveBlock := make(chan struct{})
+	// Release the stalled save at the end so the detached save goroutine exits.
+	defer close(buildSaveBlock)
+	cache := &fakeDependencyCache{
+		findHit: &preview.DependencyCacheHit{},
+		buildFindHit: &preview.DependencyCacheHit{
+			Entry: models.PreviewDependencyCache{
+				CacheKind: models.PreviewCacheKindBuildArtifact,
+				SizeBytes: 999,
+				Metadata:  []byte(`{"checksum_sha256":"prior-checksum"}`),
+			},
+		},
+		saveStarted:    saveStarted,
+		buildSaveBlock: buildSaveBlock,
+	}
+	d := NewDockerPreviewProvider(previewReachableClient(), exec, zerolog.Nop(), WithPreviewDialer(successfulPreviewDialer), WithDependencyCache(cache))
+
+	handle, err := d.StartPreview(context.Background(), &agent.Sandbox{ID: "sb", WorkDir: "/workspace/repo"}, previewInstallTestConfig(), preview.StartPreviewOptions{
+		OrgID:        uuid.New(),
+		RepositoryID: uuid.New(),
+		SessionID:    uuid.New(),
+	}, nil)
+	require.NoError(t, err)
+	require.NotNil(t, handle)
+
+	deadline := time.After(5 * time.Second)
+	for sawBuild := false; !sawBuild; {
+		select {
+		case kind := <-saveStarted:
+			sawBuild = kind == models.PreviewCacheKindBuildArtifact
+		case <-deadline:
+			t.Fatal("build cache save never started")
+		}
+	}
+
+	// The save is stalled; a stop with a short-lived ctx must still return.
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+	start := time.Now()
+	require.NoError(t, d.StopPreview(ctx, handle.Handle), "StopPreview should proceed (best-effort) when the save stalls")
+	require.Less(t, time.Since(start), 3*time.Second, "StopPreview must not block on a stalled save once the caller ctx expires")
 }
 
 func TestStartPreview_DependencyCacheSaveExcludesBuildCachePaths(t *testing.T) {


### PR DESCRIPTION
## Problem
Session prewarm runs the full preview launch (so `service_build` populates the Go/turbo build caches) and then immediately stops the preview, expecting the build cache to be saved for the next user click. But the post-ready build-cache saves were detached goroutines (`go saveBuildCacheSet(...)`) **not** registered on the preview's wait group, so `StopPreview`'s `wg.Wait()` returned without awaiting them. The warm-build job completed — and the sandbox could be torn down — before the GOCACHE/turbo blob finished uploading. The cache prewarm exists to populate was lost, and the next user launch paid the full cold build.

## Fix
- Register both `savePreviewBuildCache` and `savePreviewBuildCacheHome` on `state.wg` so `StopPreview` awaits the uploads. The saves already detach from the launch ctx (`context.WithoutCancel` + their own 10-min timeout), so `cancelFn()` does not abort the very upload we now wait on.
- **Bound the wait** so an interactive stop can't hang on a slow/wedged blob store: `StopPreview` waits on the wait group, the caller's `ctx`, or a 3-minute hard cap (well under the saves' self-timeout), whichever first, then proceeds best-effort. A prewarm passes a long-lived job ctx and still gets the full save; a normal user stop happens long after ready, by which point the save is already done.

## Tests
- `TestStopPreview_AwaitsBuildCacheSave` — deterministically proves the save completes before `StopPreview` returns.
- `TestStopPreview_BoundedByContextWhenSaveStalls` — a stalled save does not hang the stop once the caller ctx expires.

Full preview + providers suite green (incl. the race detector); `make lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
