### PR TITLE
Make preview dependency-cache saves reliable and diagnosable

### DIFF
--- a/internal/services/preview/dependency_cache.go
+++ b/internal/services/preview/dependency_cache.go
@@ -17,6 +17,7 @@ import (
 	"sort"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
@@ -30,6 +31,79 @@ import (
 
 const dependencyCacheMaxBlobBytes int64 = 2 * 1024 * 1024 * 1024
 const dependencyCacheTouchInterval = 10 * time.Minute
+
+// Sandbox exec steps in the cache save/restore path (probe, archive, pre-extract
+// cleanup) share a preview sandbox with the running app and agent, so they are
+// subject to transient memory pressure: Docker reports 128+signal (>=129, e.g.
+// 137 = SIGKILL from the cgroup OOM killer) for a signal-killed process and 128
+// when an exec cannot start against a momentarily-unavailable container, while
+// our executor returns a negative code when the exec could not be run at all.
+// Each step is idempotent, so we retry once after a short backoff to ride out a
+// momentary spike before degrading to a cold launch.
+const dependencyCacheExecRetries = 1
+const dependencyCacheExecRetryBackoff = 500 * time.Millisecond
+
+// dependencyCacheExitTransient reports whether a sandbox exec exit code denotes
+// a transient failure worth a retry rather than a deterministic one.
+func dependencyCacheExitTransient(exitCode int) bool {
+	return exitCode < 0 || exitCode >= 128
+}
+
+// dependencyCacheStderrSuffix trims and tail-truncates captured stderr for
+// inclusion in an error. The fatal line of a tar/rm/shell failure is almost
+// always last, so we keep the tail; truncating bounds log volume on a runaway
+// stream. Returns "" when there is nothing useful to add.
+func dependencyCacheStderrSuffix(stderr string) string {
+	stderr = strings.TrimSpace(stderr)
+	if stderr == "" {
+		return ""
+	}
+	const maxStderr = 2048
+	if len(stderr) > maxStderr {
+		truncated := stderr[len(stderr)-maxStderr:]
+		// Drop a possibly-partial leading rune so the kept tail is valid UTF-8.
+		for len(truncated) > 0 && !utf8.RuneStart(truncated[0]) {
+			truncated = truncated[1:]
+		}
+		stderr = "..." + truncated
+	}
+	return ": " + stderr
+}
+
+// dependencyCacheExecError builds an exec failure error that surfaces the
+// captured stderr and avoids the "%!w(<nil>)" noise that `: %w` produces when a
+// non-zero exit code carries no wrapped error.
+func dependencyCacheExecError(stage string, exitCode int, err error, stderr string) error {
+	suffix := dependencyCacheStderrSuffix(stderr)
+	if err != nil {
+		return fmt.Errorf("%s exited %d: %w%s", stage, exitCode, err, suffix)
+	}
+	return fmt.Errorf("%s exited %d%s", stage, exitCode, suffix)
+}
+
+// execWithTransientRetry runs an idempotent sandbox exec, retrying once on a
+// transient failure (signal kill / unavailable container). fn owns resetting any
+// per-attempt buffers and returns the exec's (exitCode, err).
+func (c *SharedDependencyCache) execWithTransientRetry(ctx context.Context, op string, fn func() (int, error)) (int, error) {
+	var exitCode int
+	var err error
+	for attempt := 0; ; attempt++ {
+		exitCode, err = fn()
+		if err == nil && exitCode == 0 {
+			return exitCode, nil
+		}
+		if attempt >= dependencyCacheExecRetries || !dependencyCacheExitTransient(exitCode) {
+			return exitCode, err
+		}
+		c.logger.Warn().Str("op", op).Int("exit_code", exitCode).Int("attempt", attempt+1).
+			Msg("retrying transient preview cache sandbox exec")
+		select {
+		case <-ctx.Done():
+			return exitCode, ctx.Err()
+		case <-time.After(dependencyCacheExecRetryBackoff):
+		}
+	}
+}
 
 type DependencyCache interface {
 	Find(ctx context.Context, orgID, repoID uuid.UUID, cacheKey string) (*DependencyCacheHit, error)
@@ -343,14 +417,15 @@ func (c *SharedDependencyCache) SavePathCache(ctx context.Context, sb *agent.San
 		probes = append(probes, fmt.Sprintf("if %s; then printf '%%s\\n' %s; fi", existsCmd, dependencyCacheShellPathArg(clean)))
 	}
 	if len(probes) > 0 {
-		var probeOut bytes.Buffer
+		var probeOut, probeErr bytes.Buffer
 		probeCmd := fmt.Sprintf("cd %s && { %s; }", shellQuote(rootDir), strings.Join(probes, "; "))
-		exitCode, err := c.executor.Exec(ctx, sb, probeCmd, &probeOut, io.Discard)
-		if err != nil {
-			return DependencyCacheSaveResult{}, fmt.Errorf("dependency cache save: probe effective paths exited %d: %w", exitCode, err)
-		}
-		if exitCode != 0 {
-			return DependencyCacheSaveResult{}, fmt.Errorf("dependency cache save: probe effective paths exited %d", exitCode)
+		exitCode, err := c.execWithTransientRetry(ctx, "save_probe", func() (int, error) {
+			probeOut.Reset()
+			probeErr.Reset()
+			return c.executor.Exec(ctx, sb, probeCmd, &probeOut, &probeErr)
+		})
+		if err != nil || exitCode != 0 {
+			return DependencyCacheSaveResult{}, fmt.Errorf("dependency cache save: %w", dependencyCacheExecError("probe effective paths", exitCode, err, probeErr.String()))
 		}
 		for _, line := range strings.Split(probeOut.String(), "\n") {
 			clean := strings.TrimSpace(line)
@@ -382,9 +457,13 @@ func (c *SharedDependencyCache) SavePathCache(ctx context.Context, sb *agent.San
 	if len(excludeArgs) > 0 {
 		excludeExpr = strings.Join(excludeArgs, " ") + " "
 	}
-	archiveCmd := fmt.Sprintf("cd %s && tar czf - %s-- %s", shellQuote(rootDir), excludeExpr, strings.Join(args, " "))
-	var stderr bytes.Buffer
-	staged, err := c.stageSandboxArchive(ctx, sb, archiveCmd, &stderr)
+	// Stream an UNcompressed `tar cf -` and gzip on the worker (see
+	// stageSandboxArchiveAttempt) rather than `tar czf -`: keeping the gzip
+	// compressor off the memory-capped, shared session sandbox trims the
+	// sandbox-side work at save time. The stored blob is still gzip (.tar.gz), so
+	// restore (`tar xzf`) and validation are unchanged.
+	archiveCmd := fmt.Sprintf("cd %s && tar cf - %s-- %s", shellQuote(rootDir), excludeExpr, strings.Join(args, " "))
+	staged, err := c.stageSandboxArchive(ctx, sb, archiveCmd)
 	if err != nil {
 		return DependencyCacheSaveResult{}, err
 	}
@@ -579,37 +658,67 @@ func (c *SharedDependencyCache) stageLocalBlob(path string) (*dependencyCacheSta
 	}, nil
 }
 
-func (c *SharedDependencyCache) stageSandboxArchive(ctx context.Context, sb *agent.Sandbox, archiveCmd string, stderr io.Writer) (*dependencyCacheStagedBlob, error) {
+// stageSandboxArchive streams the sandbox `tar` archive to a gzip-compressed
+// staged blob on the worker, retrying once on a transient sandbox-exec failure
+// (OOM/SIGKILL or a momentarily-unavailable container) via the shared
+// execWithTransientRetry policy. Each attempt recreates its own temp file, so a
+// retry never reuses a partially-written archive.
+func (c *SharedDependencyCache) stageSandboxArchive(ctx context.Context, sb *agent.Sandbox, archiveCmd string) (*dependencyCacheStagedBlob, error) {
+	var blob *dependencyCacheStagedBlob
+	_, err := c.execWithTransientRetry(ctx, "save_archive", func() (int, error) {
+		b, exitCode, attemptErr := c.stageSandboxArchiveAttempt(ctx, sb, archiveCmd)
+		if attemptErr == nil {
+			blob = b
+		}
+		return exitCode, attemptErr
+	})
+	if err != nil {
+		return nil, err
+	}
+	return blob, nil
+}
+
+// stageSandboxArchiveAttempt performs a single archive stream, gzip-compressing
+// the sandbox's raw `tar` output on the worker. It returns the sandbox exec exit
+// code alongside any error so execWithTransientRetry can classify a transient
+// failure; setup/compress errors return exit code 0, which is never treated as
+// transient.
+func (c *SharedDependencyCache) stageSandboxArchiveAttempt(ctx context.Context, sb *agent.Sandbox, archiveCmd string) (*dependencyCacheStagedBlob, int, error) {
 	dir, err := c.makeStagingDir("preview-dependency-cache-save-*")
 	if err != nil {
-		return nil, fmt.Errorf("dependency cache save: temp dir: %w", err)
+		return nil, 0, fmt.Errorf("dependency cache save: temp dir: %w", err)
 	}
 	path := filepath.Join(dir, "blob.tar.gz")
 	file, err := os.OpenFile(path, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o600) // #nosec G304 -- path is under a private temp dir.
 	if err != nil {
 		_ = os.RemoveAll(dir)
-		return nil, fmt.Errorf("dependency cache save: temp blob: %w", err)
+		return nil, 0, fmt.Errorf("dependency cache save: temp blob: %w", err)
 	}
 	hasher := sha256.New()
 	counter := &cappedCountingWriter{limit: dependencyCacheMaxBlobBytes}
-	stream := io.MultiWriter(file, hasher, counter)
-	exitCode, execErr := c.executor.Exec(ctx, sb, archiveCmd, stream, stderr)
+	// Compress on the worker: the sandbox streams a raw `tar cf -` and gzip runs
+	// here. The hasher and size counter sit downstream of gzip so they observe
+	// the final compressed blob, matching the restore path's `tar xzf`.
+	gzw := gzip.NewWriter(io.MultiWriter(file, hasher, counter))
+	var stderr bytes.Buffer
+	exitCode, execErr := c.executor.Exec(ctx, sb, archiveCmd, gzw, &stderr)
+	gzErr := gzw.Close()
 	closeErr := file.Close()
-	if execErr != nil {
+	if execErr != nil || exitCode != 0 {
 		_ = os.RemoveAll(dir)
-		return nil, fmt.Errorf("dependency cache save: archive stream exited %d: %w", exitCode, execErr)
+		return nil, exitCode, fmt.Errorf("dependency cache save: %w", dependencyCacheExecError("archive stream", exitCode, execErr, stderr.String()))
 	}
-	if exitCode != 0 {
+	if gzErr != nil {
 		_ = os.RemoveAll(dir)
-		return nil, fmt.Errorf("dependency cache save: archive stream exited %d", exitCode)
+		return nil, 0, fmt.Errorf("dependency cache save: compress archive: %w", gzErr)
 	}
 	if closeErr != nil {
 		_ = os.RemoveAll(dir)
-		return nil, fmt.Errorf("dependency cache save: close temp blob: %w", closeErr)
+		return nil, 0, fmt.Errorf("dependency cache save: close temp blob: %w", closeErr)
 	}
 	if counter.exceeded {
 		_ = os.RemoveAll(dir)
-		return nil, fmt.Errorf("dependency cache save: archive too large (>%d bytes max)", dependencyCacheMaxBlobBytes)
+		return nil, 0, fmt.Errorf("dependency cache save: archive too large (>%d bytes max)", dependencyCacheMaxBlobBytes)
 	}
 	return &dependencyCacheStagedBlob{
 		path:      path,
@@ -617,7 +726,7 @@ func (c *SharedDependencyCache) stageSandboxArchive(ctx context.Context, sb *age
 		checksum:  hex.EncodeToString(hasher.Sum(nil)),
 		fromLocal: false,
 		cleanup:   func() { _ = os.RemoveAll(dir) },
-	}, nil
+	}, 0, nil
 }
 
 type dependencyCacheArchiveStats struct {

--- a/internal/services/preview/dependency_cache_reliability_test.go
+++ b/internal/services/preview/dependency_cache_reliability_test.go
@@ -1,0 +1,185 @@
+package preview
+
+import (
+	"context"
+	"errors"
+	"io"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/pashagolub/pgxmock/v4"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/require"
+
+	"github.com/assembledhq/143/internal/db"
+	"github.com/assembledhq/143/internal/services/agent"
+)
+
+// scriptedResponse is one canned reply for a sandbox exec matched by substring.
+type scriptedResponse struct {
+	exitCode int
+	err      error
+	stderr   string
+}
+
+// scriptedDependencyCacheExec wraps the happy-path mock executor and lets a test
+// inject a queue of failures for commands matching a substring. Unmatched calls
+// (and calls past the end of a queue) fall through to the real mock behavior, so
+// a retry that exhausts the failure queue exercises the success path.
+type scriptedDependencyCacheExec struct {
+	*dependencyCacheExec
+	mu    sync.Mutex
+	rules map[string][]scriptedResponse
+	hits  map[string]int
+}
+
+func newScriptedExec(base *dependencyCacheExec) *scriptedDependencyCacheExec {
+	return &scriptedDependencyCacheExec{
+		dependencyCacheExec: base,
+		rules:               map[string][]scriptedResponse{},
+		hits:                map[string]int{},
+	}
+}
+
+func (e *scriptedDependencyCacheExec) script(substr string, resp ...scriptedResponse) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	e.rules[substr] = resp
+}
+
+func (e *scriptedDependencyCacheExec) Exec(ctx context.Context, sb *agent.Sandbox, cmd string, stdout, stderr io.Writer) (int, error) {
+	e.mu.Lock()
+	for substr, resps := range e.rules {
+		if !strings.Contains(cmd, substr) {
+			continue
+		}
+		i := e.hits[substr]
+		if i >= len(resps) {
+			continue
+		}
+		e.hits[substr]++
+		r := resps[i]
+		e.mu.Unlock()
+		e.dependencyCacheExec.mu.Lock()
+		e.dependencyCacheExec.execCalls = append(e.dependencyCacheExec.execCalls, cmd)
+		e.dependencyCacheExec.mu.Unlock()
+		if r.stderr != "" && stderr != nil {
+			_, _ = stderr.Write([]byte(r.stderr))
+		}
+		return r.exitCode, r.err
+	}
+	e.mu.Unlock()
+	return e.dependencyCacheExec.Exec(ctx, sb, cmd, stdout, stderr)
+}
+
+func newReliabilityTestCache(t *testing.T, exec SnapshotExecutor) *SharedDependencyCache {
+	t.Helper()
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "pgx mock should initialize")
+	t.Cleanup(mock.Close)
+	cache, err := NewDependencyCache(DependencyCacheConfig{
+		Store:      db.NewPreviewStore(mock),
+		Executor:   exec,
+		BlobStore:  newMemorySnapshotStore(),
+		Logger:     zerolog.Nop(),
+		Prefix:     "deps",
+		StagingDir: t.TempDir(),
+	})
+	require.NoError(t, err, "dependency cache should initialize")
+	return cache
+}
+
+func countCalls(calls []string, substr string) int {
+	n := 0
+	for _, c := range calls {
+		if strings.Contains(c, substr) {
+			n++
+		}
+	}
+	return n
+}
+
+// A SIGKILL/OOM (exit 137) on the archive is transient, so the save retries once
+// and succeeds on the second attempt rather than degrading to a cold launch.
+func TestStageSandboxArchive_RetriesTransientArchiveFailure(t *testing.T) {
+	t.Parallel()
+	base := &dependencyCacheExec{payload: makeDependencyCacheTarGz(t, map[string]string{"node_modules/.bin/next": "next"})}
+	exec := newScriptedExec(base)
+	exec.script("tar cf -", scriptedResponse{exitCode: 137, stderr: "Killed"})
+	cache := newReliabilityTestCache(t, exec)
+
+	blob, err := cache.stageSandboxArchive(context.Background(), &agent.Sandbox{WorkDir: "/workspace/repo"}, "cd '/workspace/repo' && tar cf - -- 'node_modules'")
+	require.NoError(t, err, "transient OOM on the archive should be retried, not surfaced")
+	require.NotNil(t, blob, "a successful retry should return a staged blob")
+	defer blob.cleanup()
+	require.Equal(t, 2, countCalls(exec.calls(), "tar cf -"), "archive should run twice: one transient failure then a success")
+}
+
+// A deterministic archive failure (exit 2) is not retried and surfaces the
+// sandbox stderr instead of a bare "exited 2" with no diagnostic.
+func TestStageSandboxArchive_SurfacesStderrAndDoesNotRetryDeterministicFailure(t *testing.T) {
+	t.Parallel()
+	exec := newScriptedExec(&dependencyCacheExec{})
+	exec.script("tar cf -",
+		scriptedResponse{exitCode: 2, stderr: "tar: node_modules: Cannot stat: No such file or directory"},
+		scriptedResponse{exitCode: 2, stderr: "tar: node_modules: Cannot stat: No such file or directory"},
+	)
+	cache := newReliabilityTestCache(t, exec)
+
+	blob, err := cache.stageSandboxArchive(context.Background(), &agent.Sandbox{WorkDir: "/workspace/repo"}, "cd '/workspace/repo' && tar cf - -- 'node_modules'")
+	require.Error(t, err, "a deterministic tar failure should surface")
+	require.Nil(t, blob)
+	require.Contains(t, err.Error(), "archive stream exited 2")
+	require.Contains(t, err.Error(), "Cannot stat", "the captured tar stderr should be in the error")
+	require.NotContains(t, err.Error(), "%!w(<nil>)", "a nil wrapped error must not leak fmt noise")
+	require.Equal(t, 1, countCalls(exec.calls(), "tar cf -"), "exit 2 is deterministic and must not be retried")
+}
+
+// The save probe currently discards stderr and prints a bare "exited 128"; the
+// fix captures stderr (e.g. an OOM message) so the failure is diagnosable.
+func TestSavePathCache_ProbeFailureSurfacesStderr(t *testing.T) {
+	t.Parallel()
+	exec := newScriptedExec(&dependencyCacheExec{})
+	// 128 is transient, so both attempts must fail for the error to surface.
+	exec.script("test -e",
+		scriptedResponse{exitCode: 128, stderr: "bash: fork: Cannot allocate memory"},
+		scriptedResponse{exitCode: 128, stderr: "bash: fork: Cannot allocate memory"},
+	)
+	cache := newReliabilityTestCache(t, exec)
+
+	_, err := cache.Save(context.Background(), &agent.Sandbox{WorkDir: "/workspace/repo"}, strings.Repeat("a", 64), []string{"node_modules"}, DependencyCacheMetadata{
+		OrgID:  uuid.New(),
+		RepoID: uuid.New(),
+	})
+	require.Error(t, err, "a probe failure should abort the save")
+	require.Contains(t, err.Error(), "probe effective paths exited 128")
+	require.Contains(t, err.Error(), "Cannot allocate memory", "the captured probe stderr should be in the error")
+	require.NotContains(t, err.Error(), "%!w(<nil>)")
+}
+
+func TestDependencyCacheExitTransient(t *testing.T) {
+	t.Parallel()
+	transient := []int{-1, 128, 137, 143}
+	deterministic := []int{0, 1, 2, 127}
+	for _, code := range transient {
+		require.Truef(t, dependencyCacheExitTransient(code), "exit %d should be transient", code)
+	}
+	for _, code := range deterministic {
+		require.Falsef(t, dependencyCacheExitTransient(code), "exit %d should be deterministic", code)
+	}
+}
+
+func TestDependencyCacheExecError_NoNilWrapNoise(t *testing.T) {
+	t.Parallel()
+	withErr := dependencyCacheExecError("archive stream", 137, errors.New("attach exec"), "Killed")
+	require.Contains(t, withErr.Error(), "archive stream exited 137")
+	require.Contains(t, withErr.Error(), "attach exec")
+	require.Contains(t, withErr.Error(), "Killed")
+
+	noErr := dependencyCacheExecError("probe effective paths", 128, nil, "Cannot allocate memory")
+	require.Contains(t, noErr.Error(), "probe effective paths exited 128")
+	require.Contains(t, noErr.Error(), "Cannot allocate memory")
+	require.NotContains(t, noErr.Error(), "%!w(<nil>)", "nil wrapped error must not produce fmt noise")
+}

--- a/internal/services/preview/dependency_cache_test.go
+++ b/internal/services/preview/dependency_cache_test.go
@@ -75,8 +75,15 @@ func (e *dependencyCacheExec) Exec(_ context.Context, _ *agent.Sandbox, cmd stri
 		return 0, nil
 	case strings.HasPrefix(cmd, "test -e "), strings.Contains(cmd, " && test -e "):
 		return 0, nil
-	case strings.Contains(cmd, "tar czf -"):
-		_, err := stdout.Write(e.payload)
+	case strings.Contains(cmd, "tar cf -"):
+		// Production compresses on the worker now, so the sandbox emits raw tar.
+		// Stream the gunzipped payload; the worker re-gzips it (same gzip.Writer
+		// settings as makeDependencyCacheTarGz) back to the identical blob.
+		raw, err := gunzipBytes(e.payload)
+		if err != nil {
+			return -1, err
+		}
+		_, err = stdout.Write(raw)
 		return 0, err
 	case strings.Contains(cmd, "tar tzf"):
 		if stderr != nil {
@@ -181,6 +188,20 @@ func (s dependencyCacheFailingLoadStore) Delete(context.Context, string) error {
 	return nil
 }
 
+// gunzipBytes reverses makeDependencyCacheTarGz so the exec mock can hand the
+// archive command a raw tar stream (the worker re-compresses it).
+func gunzipBytes(b []byte) ([]byte, error) {
+	if len(b) == 0 {
+		return nil, nil
+	}
+	gzr, err := gzip.NewReader(bytes.NewReader(b))
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = gzr.Close() }()
+	return io.ReadAll(gzr)
+}
+
 func makeDependencyCacheTarGz(t *testing.T, files map[string]string) []byte {
 	t.Helper()
 
@@ -282,7 +303,7 @@ func TestSharedDependencyCache_SaveUploadsBlobChecksumAndReturnsSize(t *testing.
 	require.Equal(t, payload, blobStore.blobs[expectedBlobKey], "Save should upload archive bytes to a checksum-addressed object key")
 	require.NotEmpty(t, bytes.TrimSpace(blobStore.blobs[expectedBlobKey+".sha256"]), "Save should upload checksum sidecar next to the checksum-addressed blob")
 	require.Empty(t, blobStore.blobs["deps/"+orgID.String()+"/"+repoID.String()+"/install_artifact/"+cacheKey+".tar.gz"], "Save should not overwrite a shared mutable blob key")
-	require.Contains(t, strings.Join(cache.executor.(*dependencyCacheExec).calls(), "\n"), "tar czf -", "Save should stream tar output instead of creating a sandbox temp archive")
+	require.Contains(t, strings.Join(cache.executor.(*dependencyCacheExec).calls(), "\n"), "tar cf -", "Save should stream raw tar output (compression happens on the worker) instead of creating a sandbox temp archive")
 	require.NotContains(t, strings.Join(cache.executor.(*dependencyCacheExec).calls(), "\n"), "cat /tmp/preview-dependency-cache-", "Save should not read back a sandbox temp archive")
 	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
 }


### PR DESCRIPTION
## Problem
Preview dependency/build-cache **saves** have been failing fleet-wide, leaving caches unpopulated so every launch pays a full cold build. The failures were also undiagnosable:
- The save probe ran with `stderr` sent to `io.Discard`, so a failure surfaced as a bare `probe effective paths exited 128` with no cause.
- The archive failure surfaced as `archive stream exited 137` (SIGKILL — the cgroup OOM killer in the shared session sandbox) with the captured stderr never included.
- `fmt.Errorf("... exited %d: %w", code, err)` printed `%!w(<nil>)` noise whenever Docker reported the failure in the exit code with a nil Go error (the common case).

## Fix
- **Surface stderr** (trimmed, UTF-8-safe, tail-truncated) on the probe and archive via a shared `dependencyCacheExecError` helper that also drops the `%!w(<nil>)` noise.
- **Transient-aware retry:** classify exit codes `< 0` (exec couldn't run) and `>= 128` (signal-kill / momentarily-unavailable container) as transient and retry once after a short backoff, so a momentary memory spike degrades to a retry instead of a cold launch. Deterministic failures (`1`, `2`, `127`) are never retried.
- **Move compression to the worker:** the sandbox now streams an uncompressed `tar cf -` and the worker gzips it, keeping the gzip compressor off the memory-capped, shared session sandbox. The stored blob is still `.tar.gz`, so restore and validation are unchanged.

## Tests (`dependency_cache_reliability_test.go`)
- Probe failure surfaces its stderr; archive retries a transient `137` then succeeds, and does not retry a deterministic `2` (surfacing its stderr).
- Exit-code classification and the no-`%!w(<nil>)` error formatting.
- The existing save tests still pass byte-for-byte: the mock gunzips its payload to simulate the raw `tar` stream and the worker re-gzips to an identical blob.

`make lint` clean; full preview suite green (incl. the race detector).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
