### PR TITLE
Show failing commit-status checks in PR hover card when no failing_test_count is present

### DIFF
--- a/frontend/src/components/pr-health-banner.test.tsx
+++ b/frontend/src/components/pr-health-banner.test.tsx
@@ -584,6 +584,43 @@ describe("PRHealthBanner", () => {
     expect(screen.getAllByText("Passed").length).toBeGreaterThan(0);
   });
 
+  it("shows failed commit-status checks in the PR details card when no test-category counter is present", async () => {
+    renderWithProviders(
+      <PRHealthBanner
+        health={{
+          ...baseHealth,
+          failing_test_count: 0,
+          checks: [
+            {
+              name: "ci/circleci: frontend_lint_format_license",
+              category: "lint",
+              status: "failed",
+              provider: "circleci",
+              details_url: "https://circleci.com/gh/acme/widgets/123",
+              summary: "Your tests failed on CircleCI",
+            },
+            { name: "github-actions / unit", category: "test", status: "passed", details_url: "https://github.com/acme/widgets/actions/runs/456" },
+          ],
+        }}
+        pendingAction={null}
+        repairError={null}
+        mergeAuthRequired={false}
+        onFixTests={vi.fn()}
+        onResolveConflicts={vi.fn()}
+        onMerge={vi.fn()}
+      />,
+    );
+
+    const user = userEvent.setup();
+    await user.hover(screen.getByText("1/2 failed"));
+
+    expect(await screen.findByText("CI jobs")).toBeInTheDocument();
+    expect(screen.getByText("ci/circleci: frontend_lint_format_license")).toBeInTheDocument();
+    expect(screen.getByText("github-actions / unit")).toBeInTheDocument();
+    expect(screen.getAllByText("Failed").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Passed").length).toBeGreaterThan(0);
+  });
+
   it("renders each hover-card check as an external link when details URLs are available", async () => {
     renderWithProviders(
       <PRHealthBanner

--- a/frontend/src/components/pr-health-banner.tsx
+++ b/frontend/src/components/pr-health-banner.tsx
@@ -116,6 +116,7 @@ export function PRHealthBanner({
     canShowPushChanges ||
     (canShowSnapshotDetails && !!activeRepairState.openSessionID);
   const failedChecks = orderedChecks.filter((check) => check.status === "failed").length;
+  const hasFailedCheckDetails = failedChecks > 0 || health.failing_test_count > 0;
   const failedSummaryLabel = orderedChecks.length > 0
     ? `${failedChecks}/${orderedChecks.length} failed`
     : `${health.failing_test_count} failing test${health.failing_test_count === 1 ? "" : "s"}`;
@@ -153,7 +154,7 @@ export function PRHealthBanner({
                   Repository disconnected
                 </Badge>
               )}
-              {canShowSnapshotDetails && health.failing_test_count > 0 && (
+              {canShowSnapshotDetails && hasFailedCheckDetails && (
                 orderedChecks.length > 0 ? (
                   <HoverCard openDelay={100} closeDelay={100}>
                     <HoverCardTrigger asChild>


### PR DESCRIPTION
## Summary

Users can see “failed” on the PR banner, but the PR details hover card may not appear when failures come from GitHub classic commit statuses (instead of the `failing_test_count` counter). This can hide actionable CI information, so the UI now treats any failed normalized `checks` entry as sufficient to show the hover card details.  

## Changes

- Compute `hasFailedCheckDetails` from normalized `checks` (failed count) or `health.failing_test_count`, and use it to gate the PR details hover card.
- Add a test covering the “no test-category counter present” case: hovering the failed label renders commit-status checks in the card.

## Validation

- `npm test -- pr-health-banner.test.tsx --run`
- `npm run typecheck`
- `npm run lint`
- `npm run build`

[143.dev](https://143.dev) | [session e55f584e](https://143.dev/sessions/e55f584e-8860-41cf-a959-77b804176557)

<!-- 143 readiness -->
**143 readiness:** not available for this revision.

Preview: https://143.dev/previews/github/assembledhq/143/pull/1614?launch=1