### PR TITLE
Fix stuck PR-action spinners: level-triggered reconciliation + server backstop

### DIFF
--- a/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
@@ -169,6 +169,7 @@ import { prMergedAccent } from "@/lib/pr-status-styles";
 import { deriveCreatePRActionState, derivePushChangesActionState, hasRepairableFailedChecks, prHealthBlocksPRActions } from "@/lib/session-pr-action-state";
 import { cn, sessionTitle, formatTimeAgo } from "@/lib/utils";
 import { isProvisionalSessionDetail } from "@/lib/session-detail-cache";
+import { useReconcileOptimisticAction } from "./use-optimistic-pr-action";
 import { pollMs } from "@/lib/poll-intervals";
 import { activeSet, workingStatusesSet } from "@/lib/session-status-groups";
 import { MobileSessionTopBar } from "./mobile-session-top-bar";
@@ -3484,11 +3485,22 @@ export function SessionDetailContent({ id }: { id: string }) {
   const [localBranchActionError, setLocalBranchActionError] = useState<PRActionErrorState | null>(null);
   const [localPushState, setLocalPushState] = useState<"idle" | "submitting" | "queued">("idle");
   const [localPushActionError, setLocalPushActionError] = useState<PRActionErrorState | null>(null);
+  // True while any PR-level action (create PR / push / create branch) is mid
+  // flight from this tab. Drives background reconciliation on the session
+  // detail query (see Fix below) so a backgrounded or refocused tab still
+  // converges to the action's terminal state instead of spinning forever.
+  // Mirrored from the optimistic phases via an effect because the detail query
+  // is declared before those phases are reconciled against the server.
+  const [anyActionInFlight, setAnyActionInFlight] = useState(false);
   const [pendingPRAction, setPendingPRAction] = useState<"fix_tests" | "resolve_conflicts" | "merge" | null>(null);
   const [pendingMergeWhenReady, setPendingMergeWhenReady] = useState(false);
   const [repairActionError, setRepairActionError] = useState<string | null>(null);
   const [prAuthPrompt, setPRAuthPrompt] = useState<PRAuthPromptState | null>(null);
   const resumeAttemptRef = useRef<string | null>(null);
+  useEffect(() => {
+    const inFlight = localPRState !== "idle" || localPushState !== "idle" || localBranchState !== "idle";
+    setAnyActionInFlight((prev) => (prev === inFlight ? prev : inFlight));
+  }, [localPRState, localPushState, localBranchState]);
   const apiBase = process.env.NEXT_PUBLIC_API_URL || "";
   const isDocumentVisible = useDocumentVisible();
 
@@ -3554,6 +3566,15 @@ export function SessionDetailContent({ id }: { id: string }) {
       }
       return sessionVolatile || threadVolatile ? SESSION_DETAIL_ACTIVE_REFETCH_INTERVAL_MS : false;
     },
+    // While a PR-level action is in flight, keep converging even if the tab is
+    // backgrounded or refocused. For a terminal (completed) session there is no
+    // live SSE channel — the only signal that the action settled is this poll,
+    // and the global defaults (refetchIntervalInBackground=false,
+    // refetchOnWindowFocus=false) would otherwise pause it and leave the button
+    // spinning until a manual reload. Scoped to the in-flight window so idle
+    // sessions keep the original no-background-work behavior.
+    refetchIntervalInBackground: anyActionInFlight,
+    refetchOnWindowFocus: anyActionInFlight,
   });
 
   const { data: membersData } = useQuery({
@@ -4096,6 +4117,34 @@ export function SessionDetailContent({ id }: { id: string }) {
   useSessionScopedReset(id, [
     { name: "session transition refs", reset: resetSessionTransitionRefs },
   ]);
+
+  // Optimistically mark a PR-level action's server column in flight in the
+  // detail cache the moment the request is accepted (202). This keeps the
+  // cached state consistent with reality (the server CAS'd the column to
+  // queued) so the optimistic-action reconcile arms deterministically and a
+  // stale prior terminal value (e.g. a previous failed push) doesn't briefly
+  // flash through the button before the next fetch lands.
+  const markSessionActionInFlight = useCallback(
+    (field: "pr_creation_state" | "pr_push_state" | "branch_creation_state") => {
+      queryClient.setQueryData<SingleResponse<SessionDetail>>(queryKeys.sessions.detail(id), (old) => {
+        if (!old?.data) return old;
+        if (old.data[field] === "queued" || old.data[field] === "pushing") return old;
+        return { ...old, data: { ...old.data, [field]: "queued" } };
+      });
+    },
+    [queryClient, id],
+  );
+  // Level-triggered reconciliation: clear each optimistic phase once the server
+  // settles, independent of whether the client witnessed the transition edge.
+  // This is what prevents a missed SSE event or a paused background poll from
+  // stranding an action button on a spinner.
+  const resolvePRAction = useCallback(() => setLocalPRState("idle"), []);
+  const resolvePushAction = useCallback(() => setLocalPushState("idle"), []);
+  const resolveBranchAction = useCallback(() => setLocalBranchState("idle"), []);
+  useReconcileOptimisticAction({ phase: localPRState, serverState: session?.pr_creation_state, onResolved: resolvePRAction });
+  useReconcileOptimisticAction({ phase: localPushState, serverState: session?.pr_push_state, onResolved: resolvePushAction });
+  useReconcileOptimisticAction({ phase: localBranchState, serverState: session?.branch_creation_state, onResolved: resolveBranchAction });
+
   const prUrl = prData?.data?.github_pr_url;
   const serverPRState = session?.pr_creation_state;
   const localPRWaitingForServer =
@@ -4135,9 +4184,9 @@ export function SessionDetailContent({ id }: { id: string }) {
   // React to pr_push_state transitions with toast feedback. Mirrors the
   // pr_creation_state effect above; kept separate so the two operations'
   // success/error messages don't collide when both fire on the same render.
-  // Also clears localPushState when the server transitions out of in-flight
-  // so the button returns to "Push changes" promptly without waiting for the
-  // next polling tick.
+  // Edge-triggered (one toast per transition); clearing the optimistic phase is
+  // owned by useReconcileOptimisticAction above, which is level-triggered and
+  // therefore robust to a missed transition.
   useEffect(() => {
     const prev = prevPRPushStateRef.current;
     const current = session?.pr_push_state;
@@ -4147,12 +4196,10 @@ export function SessionDetailContent({ id }: { id: string }) {
         if (pullRequestId) {
           queryClient.invalidateQueries({ queryKey: ["pull-request", pullRequestId, "health"] });
         }
-        setLocalPushState("idle");
         toast.success("Changes pushed to PR", prUrl ? {
           action: { label: "View \u2197", onClick: () => window.open(prUrl, "_blank", "noopener,noreferrer") },
         } : undefined);
       } else if (current === "failed") {
-        setLocalPushState("idle");
         toast.error(session?.pr_push_error || "Push to PR failed", { duration: PR_ERROR_TOAST_DURATION_MS });
       }
     }
@@ -4161,25 +4208,17 @@ export function SessionDetailContent({ id }: { id: string }) {
   useEffect(() => {
     const prev = prevBranchStateRef.current;
     const current = session?.branch_creation_state;
-    if (current === "succeeded") {
-      if (localBranchState !== "idle") {
-        setLocalBranchState("idle");
-      }
-      if (prev && prev !== current) {
+    if (prev && prev !== current) {
+      if (current === "succeeded") {
         toast.success("Branch created", session?.branch_url ? {
           action: { label: "View \u2197", onClick: () => window.open(session.branch_url, "_blank", "noopener,noreferrer") },
         } : undefined);
-      }
-    } else if (current === "failed") {
-      if (localBranchState !== "idle") {
-        setLocalBranchState("idle");
-      }
-      if (prev && prev !== current) {
+      } else if (current === "failed") {
         toast.error(session?.branch_creation_error || "Failed to create branch", { duration: PR_ERROR_TOAST_DURATION_MS });
       }
     }
     prevBranchStateRef.current = current;
-  }, [localBranchState, session?.branch_creation_state, session?.branch_creation_error, session?.branch_url]);
+  }, [session?.branch_creation_state, session?.branch_creation_error, session?.branch_url]);
   const startRepairMutation = useMutation({
     mutationFn: async ({ action, pushChanges }: { action: "fix_tests" | "resolve_conflicts"; pushChanges: boolean }) => {
       if (!pullRequestId) {
@@ -4520,6 +4559,7 @@ export function SessionDetailContent({ id }: { id: string }) {
       }
       setLocalPRActionError(null);
       setLocalPRState("queued");
+      markSessionActionInFlight("pr_creation_state");
       if (options?.resumeToken) {
         clearPRResumeParams();
       }
@@ -4559,6 +4599,7 @@ export function SessionDetailContent({ id }: { id: string }) {
     onSuccess: (_data, options) => {
       setLocalBranchActionError(null);
       setLocalBranchState("queued");
+      markSessionActionInFlight("branch_creation_state");
       if (options?.resumeToken) {
         clearPRResumeParams();
       }
@@ -4754,6 +4795,7 @@ export function SessionDetailContent({ id }: { id: string }) {
     onSuccess: (_data, options) => {
       setLocalPushActionError(null);
       setLocalPushState("queued");
+      markSessionActionInFlight("pr_push_state");
       if (options?.resumeToken) {
         clearPRResumeParams();
       }

--- a/frontend/src/app/(dashboard)/sessions/[id]/use-optimistic-pr-action.test.ts
+++ b/frontend/src/app/(dashboard)/sessions/[id]/use-optimistic-pr-action.test.ts
@@ -1,0 +1,78 @@
+import { renderHook } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { useReconcileOptimisticAction, type OptimisticActionPhase } from "./use-optimistic-pr-action";
+import type { SessionPublishState } from "@/lib/types";
+
+type ServerState = SessionPublishState | null | undefined;
+
+function setup(initial: { phase: OptimisticActionPhase; serverState: ServerState }) {
+  const onResolved = vi.fn();
+  const view = renderHook(
+    ({ phase, serverState }) => useReconcileOptimisticAction({ phase, serverState, onResolved }),
+    { initialProps: initial },
+  );
+  return { ...view, onResolved };
+}
+
+describe("useReconcileOptimisticAction", () => {
+  it("clears once the server settles after being observed in flight", () => {
+    const { rerender, onResolved } = setup({ phase: "submitting", serverState: "idle" });
+
+    rerender({ phase: "queued", serverState: "pushing" }); // arms the gate
+    expect(onResolved).not.toHaveBeenCalled();
+
+    rerender({ phase: "queued", serverState: "failed" }); // terminal -> resolve
+    expect(onResolved).toHaveBeenCalledTimes(1);
+  });
+
+  it("clears even if the in-flight edge was never observed, once armed (missed event)", () => {
+    const { rerender, onResolved } = setup({ phase: "submitting", serverState: "idle" });
+
+    // Caller optimistically marks the cached server state in flight on ack.
+    rerender({ phase: "queued", serverState: "queued" }); // arms
+    // Jump straight to terminal (SSE missed + single delayed poll).
+    rerender({ phase: "queued", serverState: "failed" });
+    expect(onResolved).toHaveBeenCalledTimes(1);
+  });
+
+  it("does NOT clear a fresh submission against a stale prior terminal state", () => {
+    // Retry of a previously-failed action: cached state still reads "failed".
+    const { rerender, onResolved } = setup({ phase: "idle", serverState: "failed" });
+
+    rerender({ phase: "submitting", serverState: "failed" });
+    expect(onResolved).not.toHaveBeenCalled();
+
+    rerender({ phase: "queued", serverState: "failed" }); // not yet observed in flight
+    expect(onResolved).not.toHaveBeenCalled();
+
+    rerender({ phase: "queued", serverState: "pushing" }); // now armed
+    rerender({ phase: "queued", serverState: "failed" });
+    expect(onResolved).toHaveBeenCalledTimes(1);
+  });
+
+  it("never resolves while idle (fresh load of a settled session)", () => {
+    const { rerender, onResolved } = setup({ phase: "idle", serverState: "failed" });
+    rerender({ phase: "idle", serverState: "failed" });
+    rerender({ phase: "idle", serverState: "succeeded" });
+    expect(onResolved).not.toHaveBeenCalled();
+  });
+
+  it("re-arms fresh for each submission after returning to idle", () => {
+    const { rerender, onResolved } = setup({ phase: "submitting", serverState: "idle" });
+    rerender({ phase: "queued", serverState: "pushing" });
+    rerender({ phase: "queued", serverState: "succeeded" });
+    expect(onResolved).toHaveBeenCalledTimes(1);
+
+    // Caller cleared to idle; the gate disarms. A new submission must observe
+    // in-flight again before a terminal state can resolve it.
+    rerender({ phase: "idle", serverState: "idle" });
+    rerender({ phase: "submitting", serverState: "idle" });
+    rerender({ phase: "queued", serverState: "failed" }); // stale-ish, not armed
+    expect(onResolved).toHaveBeenCalledTimes(1);
+
+    rerender({ phase: "queued", serverState: "pushing" });
+    rerender({ phase: "queued", serverState: "failed" });
+    expect(onResolved).toHaveBeenCalledTimes(2);
+  });
+});

--- a/frontend/src/app/(dashboard)/sessions/[id]/use-optimistic-pr-action.ts
+++ b/frontend/src/app/(dashboard)/sessions/[id]/use-optimistic-pr-action.ts
@@ -1,0 +1,83 @@
+import { useEffect, useRef } from "react";
+
+import type { SessionPublishState } from "@/lib/types";
+
+// Optimistic client phase for a PR-level lifecycle action (create PR, push
+// changes, create branch). It bridges the gap between the user's click and the
+// server reflecting the action as in flight:
+//   - "submitting": request sent, server hasn't acknowledged (202) yet
+//   - "queued":     server acknowledged; worker is (or will be) running it
+//   - "idle":       no action in flight, or the server has settled
+export type OptimisticActionPhase = "idle" | "submitting" | "queued";
+
+type LifecycleServerState = SessionPublishState | null | undefined;
+
+function isInFlight(state: LifecycleServerState): boolean {
+  return state === "queued" || state === "pushing";
+}
+
+function isTerminal(state: LifecycleServerState): boolean {
+  return state === "failed" || state === "succeeded";
+}
+
+export interface ReconcileOptimisticActionParams {
+  /** The current optimistic client phase. */
+  phase: OptimisticActionPhase;
+  /** Authoritative server lifecycle column for this action. */
+  serverState: LifecycleServerState;
+  /**
+   * Clears the optimistic phase (e.g. setLocalPushState("idle")). Should be a
+   * stable reference (useCallback) so the reconcile effect doesn't re-run every
+   * render.
+   */
+  onResolved: () => void;
+}
+
+/**
+ * Reconciles a client-side optimistic action phase against the authoritative
+ * server lifecycle column (pr_creation_state / pr_push_state /
+ * branch_creation_state), clearing the optimistic phase once the server
+ * settles.
+ *
+ * The reconciliation is *level-triggered*: it clears the optimistic phase
+ * whenever the server row reaches a terminal state (after the action was
+ * observed in flight), rather than requiring the client to witness the exact
+ * `queued -> terminal` transition edge. A missed SSE event or a paused
+ * background poll therefore cannot strand the button on a spinner — the next
+ * authoritative read of a terminal state resolves it.
+ *
+ * The `seenInFlight` gate prevents a stale *prior* terminal state from
+ * instantly clearing a fresh optimistic phase: when the user clicks Retry on a
+ * previously-failed action, the cached server state may still read "failed"
+ * until the next fetch. We only honor a terminal state once we've observed the
+ * server actually running our action (its state went in-flight). Callers should
+ * optimistically mark the cached server state in-flight on ack so this arms
+ * deterministically rather than depending on a poll landing.
+ */
+export function useReconcileOptimisticAction({
+  phase,
+  serverState,
+  onResolved,
+}: ReconcileOptimisticActionParams): void {
+  const seenInFlightRef = useRef(false);
+
+  // Disarm whenever the optimistic flow ends so the next submission starts
+  // fresh and a stale terminal state can't resolve it prematurely.
+  useEffect(() => {
+    if (phase === "idle") {
+      seenInFlightRef.current = false;
+    }
+  }, [phase]);
+
+  useEffect(() => {
+    if (phase === "idle") return;
+    if (isInFlight(serverState)) {
+      seenInFlightRef.current = true;
+      return;
+    }
+    if (isTerminal(serverState) && seenInFlightRef.current) {
+      seenInFlightRef.current = false;
+      onResolved();
+    }
+  }, [serverState, phase, onResolved]);
+}

--- a/internal/db/session_store.go
+++ b/internal/db/session_store.go
@@ -2366,6 +2366,140 @@ func (s *SessionStore) UpdateBranchCreationState(ctx context.Context, orgID, ses
 	return nil
 }
 
+// publishActionJobTypes are the worker job types that drive the three
+// PR-level publish columns (pr_creation_state / pr_push_state /
+// branch_creation_state) through queued -> pushing -> succeeded/failed.
+const publishActionJobTypes = `'open_pr', 'push_pr_changes', 'create_branch'`
+
+// ListStuckPublishActionSessions returns sessions whose PR-level action column
+// is wedged in an in-flight state ('queued' or 'pushing') with no backing job
+// that can still make progress.
+//
+// The handlers write a terminal state inline on every error, so a clean
+// failure already lands as 'failed'. The gap this closes is a job that dies
+// *without* its handler returning — a worker OOM/crash/lease-loss mid-push.
+// ReclaimLostRunningJobs requeues such a job and ClaimNextRunnable increments
+// `attempts` on every re-dispatch, but a job that kills its worker on each
+// attempt is never dead-lettered (the handler never reaches the dead-letter
+// path), so `attempts` climbs past `max_attempts` while the column stays
+// 'pushing' forever.
+//
+// A backing job counts as "still working" — and so blocks reconciliation — when
+// either it has retry budget left (pending/running AND attempts < max_attempts)
+// or a worker is provably on it right now (running with an unexpired lease). The
+// live-lease clause matters because `attempts` is incremented at claim time, so
+// the final attempt runs with attempts == max_attempts; without it a slow but
+// healthy last attempt (a push can take minutes) would be force-failed mid-run.
+// The OOM loop is still caught: it spends ~all its time either pending without
+// budget or running with an expired lease, so a sweep lands on a moment where
+// neither clause holds.
+//
+// The second EXISTS clause requires a backing job older than stuckBefore so we
+// never race a brand-new action whose job is mid-enqueue, and bounds the scan
+// to genuinely-aged rows.
+func (s *SessionStore) ListStuckPublishActionSessions(ctx context.Context, orgID uuid.UUID, stuckBefore time.Time, limit int) ([]uuid.UUID, error) {
+	if limit <= 0 {
+		limit = 50
+	}
+	query := `
+		SELECT s.id
+		FROM sessions s
+		WHERE s.org_id = @org_id
+		  AND s.deleted_at IS NULL
+		  AND (
+		    s.pr_creation_state IN ('queued', 'pushing')
+		    OR s.pr_push_state IN ('queued', 'pushing')
+		    OR s.branch_creation_state IN ('queued', 'pushing')
+		  )
+		  AND NOT EXISTS (
+		    SELECT 1 FROM jobs j
+		    WHERE j.org_id = s.org_id
+		      AND j.job_type IN (` + publishActionJobTypes + `)
+		      AND NULLIF(j.payload->>'session_id', '') = s.id::text
+		      AND (
+		        -- Still has retry budget: will run (or run again) and terminalize.
+		        (j.status IN ('pending', 'running') AND j.attempts < j.max_attempts)
+		        -- Or a worker is provably on it right now. attempts is bumped at
+		        -- claim time, so the final attempt runs with attempts ==
+		        -- max_attempts; the live lease keeps us from force-failing a slow
+		        -- but healthy last attempt mid-run.
+		        OR (j.status = 'running' AND j.lease_expires_at IS NOT NULL AND j.lease_expires_at > now())
+		      )
+		  )
+		  AND EXISTS (
+		    SELECT 1 FROM jobs j2
+		    WHERE j2.org_id = s.org_id
+		      AND j2.job_type IN (` + publishActionJobTypes + `)
+		      AND NULLIF(j2.payload->>'session_id', '') = s.id::text
+		      AND j2.created_at < @stuck_before
+		  )
+		ORDER BY s.id
+		LIMIT @limit`
+	rows, err := s.db.Query(ctx, query, pgx.NamedArgs{
+		"org_id":       orgID,
+		"stuck_before": stuckBefore,
+		"limit":        limit,
+	})
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var ids []uuid.UUID
+	for rows.Next() {
+		var id uuid.UUID
+		if err := rows.Scan(&id); err != nil {
+			return nil, err
+		}
+		ids = append(ids, id)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return ids, nil
+}
+
+// FailInFlightPublishActions force-transitions any of the three PR-level
+// publish columns that are still in flight ('queued'/'pushing') to 'failed'
+// with errMsg, leaving already-terminal columns untouched. It is the durable
+// backstop for ListStuckPublishActionSessions: a guarded CAS that cannot
+// clobber a state that legitimately advanced between the scan and this write,
+// and a no-op (returns false) when nothing is in flight. On a real transition
+// it publishes the session status SSE so connected clients converge.
+func (s *SessionStore) FailInFlightPublishActions(ctx context.Context, orgID, sessionID uuid.UUID, errMsg string) (bool, error) {
+	query := `UPDATE sessions
+		SET pr_creation_state = CASE WHEN pr_creation_state IN ('queued', 'pushing') THEN 'failed' ELSE pr_creation_state END,
+		    pr_creation_error = CASE WHEN pr_creation_state IN ('queued', 'pushing') THEN @err ELSE pr_creation_error END,
+		    pr_push_state = CASE WHEN pr_push_state IN ('queued', 'pushing') THEN 'failed' ELSE pr_push_state END,
+		    pr_push_error = CASE WHEN pr_push_state IN ('queued', 'pushing') THEN @err ELSE pr_push_error END,
+		    branch_creation_state = CASE WHEN branch_creation_state IN ('queued', 'pushing') THEN 'failed' ELSE branch_creation_state END,
+		    branch_creation_error = CASE WHEN branch_creation_state IN ('queued', 'pushing') THEN @err ELSE branch_creation_error END
+		WHERE id = @id AND org_id = @org_id AND deleted_at IS NULL
+		  AND (
+		    pr_creation_state IN ('queued', 'pushing')
+		    OR pr_push_state IN ('queued', 'pushing')
+		    OR branch_creation_state IN ('queued', 'pushing')
+		  )
+		RETURNING ` + sessionSelectColumns
+	rows, err := s.db.Query(ctx, query, pgx.NamedArgs{
+		"id":     sessionID,
+		"org_id": orgID,
+		"err":    errMsg,
+	})
+	if err != nil {
+		return false, err
+	}
+	session, err := pgx.CollectOneRow(rows, pgx.RowToStructByName[models.Session])
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return false, nil
+		}
+		return false, err
+	}
+	hydrateSessionPolicy(&session)
+	s.publishStatus(ctx, &session)
+	return true, nil
+}
+
 // ClearSnapshotKey NULLs the snapshot_key column and transitions sandbox_state
 // to 'destroyed'. Called after the snapshot file has been removed from storage
 // — on PR merge, session archive, or reaper expiry. Idempotent: calling it on

--- a/internal/integration/session_publish_reconcile_test.go
+++ b/internal/integration/session_publish_reconcile_test.go
@@ -1,0 +1,190 @@
+//go:build integration
+
+package integration
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/stretchr/testify/require"
+
+	"github.com/assembledhq/143/internal/db"
+	"github.com/assembledhq/143/internal/models"
+)
+
+// seedPublishActionJob inserts a backing publish-action job for a session via
+// the real JobStore, then forces its status / attempts / age so a test can
+// reproduce a specific worker-death scenario. Returns the job ID.
+func seedPublishActionJob(t *testing.T, pool *pgxpool.Pool, orgID, sessionID uuid.UUID, jobType, status string, attempts, maxAttempts int, ageBack time.Duration) uuid.UUID {
+	t.Helper()
+	return seedPublishActionJobWithLease(t, pool, orgID, sessionID, jobType, status, attempts, maxAttempts, ageBack, nil)
+}
+
+// seedPublishActionJobWithLease additionally sets lease_expires_at relative to
+// now (positive = unexpired/live lease, negative = expired), or leaves it NULL
+// when leaseFromNow is nil.
+func seedPublishActionJobWithLease(t *testing.T, pool *pgxpool.Pool, orgID, sessionID uuid.UUID, jobType, status string, attempts, maxAttempts int, ageBack time.Duration, leaseFromNow *time.Duration) uuid.UUID {
+	t.Helper()
+	jobs := db.NewJobStore(pool)
+	payload := map[string]string{"session_id": sessionID.String(), "org_id": orgID.String()}
+	jobID, err := jobs.Enqueue(context.Background(), orgID, "agent", jobType, payload, 5, nil)
+	require.NoError(t, err)
+	_, err = pool.Exec(context.Background(),
+		`UPDATE jobs SET status = $2, attempts = $3, max_attempts = $4, created_at = now() - $5::interval WHERE id = $1`,
+		jobID, status, attempts, maxAttempts, ageBack.String())
+	require.NoError(t, err)
+	if leaseFromNow != nil {
+		_, err = pool.Exec(context.Background(),
+			`UPDATE jobs SET lease_expires_at = now() + $2::interval WHERE id = $1`,
+			jobID, leaseFromNow.String())
+		require.NoError(t, err)
+	}
+	return jobID
+}
+
+func setPublishColumn(t *testing.T, pool *pgxpool.Pool, sessionID uuid.UUID, column, state string) {
+	t.Helper()
+	// #nosec G202 -- column is a test-controlled literal, not user input.
+	_, err := pool.Exec(context.Background(),
+		`UPDATE sessions SET `+column+` = $2 WHERE id = $1`, sessionID, state)
+	require.NoError(t, err)
+}
+
+func publishColumn(t *testing.T, pool *pgxpool.Pool, sessionID uuid.UUID, column string) (string, string) {
+	t.Helper()
+	var state, errMsg string
+	errCol := map[string]string{
+		"pr_push_state":         "pr_push_error",
+		"pr_creation_state":     "pr_creation_error",
+		"branch_creation_state": "branch_creation_error",
+	}[column]
+	err := pool.QueryRow(context.Background(),
+		`SELECT `+column+`, COALESCE(`+errCol+`, '') FROM sessions WHERE id = $1`, sessionID).
+		Scan(&state, &errMsg)
+	require.NoError(t, err)
+	return state, errMsg
+}
+
+// TestIntegration_ListStuckPublishActionSessions exercises the Fix 3 backstop
+// detection against a real Postgres, covering each worker-death and
+// still-healthy scenario the SQL must distinguish.
+func TestIntegration_ListStuckPublishActionSessions(t *testing.T) {
+	pool := setup(t)
+	orgID := seedOrg(t, pool)
+	ctx := context.Background()
+	store := db.NewSessionStore(pool)
+
+	newSession := func() uuid.UUID {
+		return seedSession(t, pool, orgID, sessionOpts{Status: models.SessionStatusIdle}).ID
+	}
+
+	// A: orphaned push — job kept dying so attempts climbed past max but it was
+	// never dead-lettered; column wedged at 'pushing'. STUCK.
+	orphanedPush := newSession()
+	setPublishColumn(t, pool, orphanedPush, "pr_push_state", "pushing")
+	seedPublishActionJob(t, pool, orgID, orphanedPush, "push_pr_changes", "running", 5, 3, 30*time.Minute)
+
+	// B: legitimately running push — job still has retry budget. NOT stuck.
+	runningPush := newSession()
+	setPublishColumn(t, pool, runningPush, "pr_push_state", "pushing")
+	seedPublishActionJob(t, pool, orgID, runningPush, "push_pr_changes", "running", 1, 3, 30*time.Minute)
+
+	// C: fresh queued push — pending job, attempts left, just enqueued. NOT stuck.
+	freshPush := newSession()
+	setPublishColumn(t, pool, freshPush, "pr_push_state", "queued")
+	seedPublishActionJob(t, pool, orgID, freshPush, "push_pr_changes", "pending", 0, 3, 30*time.Second)
+
+	// D: dead-lettered create-PR with a column still wedged at 'pushing'. STUCK.
+	orphanedPR := newSession()
+	setPublishColumn(t, pool, orphanedPR, "pr_creation_state", "pushing")
+	seedPublishActionJob(t, pool, orgID, orphanedPR, "open_pr", "dead_letter", 3, 3, 30*time.Minute)
+
+	// E: already-terminal column. NOT stuck.
+	failedPush := newSession()
+	setPublishColumn(t, pool, failedPush, "pr_push_state", "failed")
+	seedPublishActionJob(t, pool, orgID, failedPush, "push_pr_changes", "dead_letter", 3, 3, 30*time.Minute)
+
+	// F: in-flight column but its backing job is too new to act on yet. NOT stuck.
+	youngOrphan := newSession()
+	setPublishColumn(t, pool, youngOrphan, "branch_creation_state", "queued")
+	seedPublishActionJob(t, pool, orgID, youngOrphan, "create_branch", "dead_letter", 3, 3, time.Minute)
+
+	// G: slow but healthy *final* attempt — running with attempts == max but a
+	// live (unexpired) lease, so a worker is actively on it. NOT stuck.
+	liveLease := 5 * time.Minute
+	liveFinalAttempt := newSession()
+	setPublishColumn(t, pool, liveFinalAttempt, "pr_push_state", "pushing")
+	seedPublishActionJobWithLease(t, pool, orgID, liveFinalAttempt, "push_pr_changes", "running", 3, 3, 30*time.Minute, &liveLease)
+
+	got, err := store.ListStuckPublishActionSessions(ctx, orgID, time.Now().Add(-15*time.Minute), 50)
+	require.NoError(t, err)
+
+	gotSet := map[uuid.UUID]bool{}
+	for _, id := range got {
+		gotSet[id] = true
+	}
+	require.True(t, gotSet[orphanedPush], "orphaned push should be detected")
+	require.True(t, gotSet[orphanedPR], "dead-lettered create-PR should be detected")
+	require.False(t, gotSet[runningPush], "healthy running push must not be detected")
+	require.False(t, gotSet[freshPush], "freshly-queued push must not be detected")
+	require.False(t, gotSet[failedPush], "already-terminal column must not be detected")
+	require.False(t, gotSet[youngOrphan], "too-new backing job must not be detected yet")
+	require.False(t, gotSet[liveFinalAttempt], "a live-leased final attempt must not be force-failed mid-run")
+	require.Len(t, got, 2)
+}
+
+// TestIntegration_FailInFlightPublishActions verifies the guarded force-fail:
+// it flips only in-flight columns, is idempotent, and leaves terminal columns
+// untouched.
+func TestIntegration_FailInFlightPublishActions(t *testing.T) {
+	pool := setup(t)
+	orgID := seedOrg(t, pool)
+	ctx := context.Background()
+	store := db.NewSessionStore(pool)
+
+	session := seedSession(t, pool, orgID, sessionOpts{Status: models.SessionStatusIdle}).ID
+	setPublishColumn(t, pool, session, "pr_push_state", "pushing")
+
+	changed, err := store.FailInFlightPublishActions(ctx, orgID, session, "boom")
+	require.NoError(t, err)
+	require.True(t, changed, "first reconcile should transition the wedged column")
+
+	state, errMsg := publishColumn(t, pool, session, "pr_push_state")
+	require.Equal(t, "failed", state)
+	require.Equal(t, "boom", errMsg)
+
+	// Idempotent: nothing is in flight anymore, so a second call is a no-op.
+	changed, err = store.FailInFlightPublishActions(ctx, orgID, session, "boom again")
+	require.NoError(t, err)
+	require.False(t, changed, "second reconcile should be a no-op")
+	state, errMsg = publishColumn(t, pool, session, "pr_push_state")
+	require.Equal(t, "failed", state)
+	require.Equal(t, "boom", errMsg, "the existing error must not be overwritten")
+}
+
+// TestIntegration_FailInFlightPublishActions_PreservesTerminalColumns ensures a
+// column that legitimately advanced to a terminal state between the scan and
+// the write is never clobbered.
+func TestIntegration_FailInFlightPublishActions_PreservesTerminalColumns(t *testing.T) {
+	pool := setup(t)
+	orgID := seedOrg(t, pool)
+	ctx := context.Background()
+	store := db.NewSessionStore(pool)
+
+	session := seedSession(t, pool, orgID, sessionOpts{Status: models.SessionStatusIdle}).ID
+	// pr_push wedged, but pr_creation already succeeded — must be left alone.
+	setPublishColumn(t, pool, session, "pr_push_state", "pushing")
+	setPublishColumn(t, pool, session, "pr_creation_state", "succeeded")
+
+	changed, err := store.FailInFlightPublishActions(ctx, orgID, session, "boom")
+	require.NoError(t, err)
+	require.True(t, changed)
+
+	pushState, _ := publishColumn(t, pool, session, "pr_push_state")
+	require.Equal(t, "failed", pushState, "wedged push column should fail")
+	prState, _ := publishColumn(t, pool, session, "pr_creation_state")
+	require.Equal(t, "succeeded", prState, "terminal create-PR column must be preserved")
+}

--- a/internal/services/github/pr.go
+++ b/internal/services/github/pr.go
@@ -358,6 +358,12 @@ const (
 	// GitHub permissions fallback because these failures are often runtime or
 	// auth-broker setup issues rather than user/repo access problems.
 	SandboxAuthUnavailablePRMessage = "143 could not prepare GitHub credentials for this push."
+	// PublishActionAbandonedMessage is written by the reconciler backstop when a
+	// PR-level action (create PR / push / create branch) is left wedged in an
+	// in-flight state because the worker handling it stopped before writing a
+	// terminal state (OOM/crash/lease loss). It clears the spinner and invites a
+	// retry rather than leaving the button stuck forever.
+	PublishActionAbandonedMessage = "This action stopped unexpectedly before it finished. Please try again."
 )
 
 // WaitForPostPRSnapshotUploads blocks until every in-flight post-PR snapshot

--- a/internal/services/github/pr_health_service.go
+++ b/internal/services/github/pr_health_service.go
@@ -575,7 +575,41 @@ func (s *PRService) ReconcilePullRequestState(ctx context.Context, orgID uuid.UU
 	for _, pr := range queued {
 		s.enqueueMergeWhenReadyProcessing(ctx, pr)
 	}
+	s.reconcileStuckPublishActions(ctx, orgID, limit)
 	return nil
+}
+
+// stuckPublishActionAfter bounds how long a PR-level action column may sit in an
+// in-flight state before the reconciler force-fails it. Generous so it never
+// races a legitimately slow push (snapshot hydrate + build can take minutes) or
+// the worker-recovery loop that re-dispatches a lease-lost job.
+const stuckPublishActionAfter = 15 * time.Minute
+
+// reconcileStuckPublishActions is the server-side backstop for PR-level action
+// buttons (create PR / push / create branch). The handlers write a terminal
+// state inline on any error, so this only catches the gap where the worker died
+// mid-action without writing one, leaving the column wedged at 'queued'/
+// 'pushing' with no live backing job. It force-fails those columns so the
+// frontend spinner resolves to a retryable error instead of spinning forever.
+func (s *PRService) reconcileStuckPublishActions(ctx context.Context, orgID uuid.UUID, limit int) {
+	if s.sessions == nil {
+		return
+	}
+	stuck, err := s.sessions.ListStuckPublishActionSessions(ctx, orgID, time.Now().Add(-stuckPublishActionAfter), limit)
+	if err != nil {
+		s.logger.Warn().Err(err).Str("org_id", orgID.String()).Msg("failed to list stuck publish-action sessions")
+		return
+	}
+	for _, sessionID := range stuck {
+		changed, ferr := s.sessions.FailInFlightPublishActions(ctx, orgID, sessionID, PublishActionAbandonedMessage)
+		if ferr != nil {
+			s.logger.Warn().Err(ferr).Str("session_id", sessionID.String()).Msg("failed to reconcile stuck publish action")
+			continue
+		}
+		if changed {
+			s.logger.Info().Str("session_id", sessionID.String()).Msg("reconciled stuck PR-level action to failed: no live backing job")
+		}
+	}
 }
 
 func (s *PRService) EnrichPullRequestHealth(ctx context.Context, orgID, pullRequestID uuid.UUID, version int64) error {


### PR DESCRIPTION
## Summary

The session detail page's **Push changes / Create PR / Create branch** buttons could spin forever. For a terminal (completed) session there is no live SSE channel, so the only signal that an action settled is the detail query's in-flight poll — and the global React Query defaults (`refetchOnWindowFocus: false`, `refetchIntervalInBackground: false`) pause it on a hidden tab and skip the refocus refetch. A missed `queued → failed` transition left the cached column at `queued`/`pushing` with no path back to ground truth, so the button stayed on a spinner until a manual reload (the backend had already written `failed`). This makes client convergence robust and adds a server backstop so a terminal state always exists to converge to.

## Changes

- **Frontend convergence:** while any PR-level action is in flight, the session detail query gets `refetchIntervalInBackground` + `refetchOnWindowFocus` so a backgrounded/refocused tab keeps converging to the terminal state.
- **Frontend reconcile:** extract `useReconcileOptimisticAction` — clears the optimistic phase *level-triggered* (whenever the server settles) instead of requiring the client to witness the transition edge, gated by a `seenInFlight` ref so a stale prior terminal can't clear a fresh Retry. `onSuccess` optimistically marks the cached column in-flight on the 202 ack to arm the gate deterministically. Applied to all three action machines (create PR / push / branch).
- **Backend backstop:** `PRService.ReconcilePullRequestState` (the leader-scheduled per-org reconcile job) now force-fails orphaned in-flight columns via new `SessionStore.ListStuckPublishActionSessions` + `FailInFlightPublishActions`. This closes the genuinely unbounded hole: a job that kills its worker every attempt is never dead-lettered (`attempts` climbs past `max_attempts` while the handler never returns), so the column stays `pushing` forever. A live-lease clause avoids force-failing a slow-but-healthy *final* attempt mid-run.

## Validation

- Frontend: new `useReconcileOptimisticAction` unit tests (missed-edge, stale-terminal Retry, re-arm); `session-pr-action-state` + `page-pr-creation` + `page-pr-health` suites (96 tests) pass; `tsc` + `eslint` clean on changed files.
- Backend: new integration tests in `session_publish_reconcile_test.go` run against real Postgres covering each worker-death / still-healthy detection case (orphaned, healthy-running, fresh, dead-lettered, terminal, too-new, live-lease final attempt) + guarded/idempotent force-fail; `internal/db` + `internal/services/github` unit tests pass; `make lint` 0 issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
