### PR TITLE
Prefer the org default work repo when creating new sessions

### DIFF
--- a/frontend/src/app/(dashboard)/sessions/new/manual-session-create-page-content.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/new/manual-session-create-page-content.test.tsx
@@ -329,6 +329,154 @@ describe("ManualSessionCreatePageContent", () => {
     });
   });
 
+  it("uses the org default work repository before last-used or first alphabetical repo", async () => {
+    const user = userEvent.setup();
+    localStorage.setItem("143:lastUsedRepoId", "repo-docs");
+    mocks.settingsGetMock.mockResolvedValueOnce({
+      data: {
+        name: "Test Org",
+        settings: {
+          default_agent_type: "codex",
+          default_work_repository_id: "repo-app",
+        },
+      },
+    });
+    mocks.repositoriesListMock.mockResolvedValueOnce({
+      data: [
+        {
+          id: "repo-docs",
+          name: "apidocs",
+          full_name: "assembledhq/apidocs",
+          default_branch: "master",
+          integration_id: "int-1",
+        },
+        {
+          id: "repo-app",
+          name: "assembled",
+          full_name: "assembledhq/assembled",
+          default_branch: "master",
+          integration_id: "int-1",
+        },
+      ],
+    });
+
+    renderWithProviders(<ManualSessionCreatePageContent />);
+
+    const prompt = await screen.findByRole("textbox", { name: "Manual session prompt" });
+    await user.type(prompt, "Fix the forecast modal");
+    await user.click(screen.getByRole("button", { name: "Start session" }));
+
+    await waitFor(() => {
+      expect(mocks.createSessionMock).toHaveBeenCalledWith(expect.objectContaining({
+        repository_id: "repo-app",
+        branch: "master",
+      }));
+    });
+  });
+
+  it("does not start with a last-used repository before org settings resolve", async () => {
+    const user = userEvent.setup();
+    const settings = deferred<Awaited<ReturnType<typeof mocks.settingsGetMock>>>();
+    localStorage.setItem("143:lastUsedRepoId", "repo-docs");
+    mocks.settingsGetMock.mockImplementationOnce(() => settings.promise);
+    mocks.repositoriesListMock.mockResolvedValueOnce({
+      data: [
+        {
+          id: "repo-docs",
+          name: "apidocs",
+          full_name: "assembledhq/apidocs",
+          default_branch: "master",
+          integration_id: "int-1",
+        },
+        {
+          id: "repo-app",
+          name: "assembled",
+          full_name: "assembledhq/assembled",
+          default_branch: "master",
+          integration_id: "int-1",
+        },
+      ],
+    });
+
+    renderWithProviders(<ManualSessionCreatePageContent />);
+
+    const prompt = await screen.findByRole("textbox", { name: "Manual session prompt" });
+    await user.type(prompt, "Fix the forecast modal");
+    const startButton = screen.getByRole("button", { name: "Start session" });
+    expect(startButton).toBeDisabled();
+    await user.click(startButton);
+    expect(mocks.createSessionMock).not.toHaveBeenCalled();
+
+    await act(async () => {
+      settings.resolve({
+        data: {
+          name: "Test Org",
+          settings: {
+            default_agent_type: "codex",
+            default_work_repository_id: "repo-app",
+          },
+        },
+      });
+    });
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Start session" })).not.toBeDisabled();
+    });
+    await user.click(screen.getByRole("button", { name: "Start session" }));
+
+    await waitFor(() => {
+      expect(mocks.createSessionMock).toHaveBeenCalledWith(expect.objectContaining({
+        repository_id: "repo-app",
+        branch: "master",
+      }));
+    });
+  });
+
+  it("keeps an explicit URL repository selection ahead of the org default work repository", async () => {
+    const user = userEvent.setup();
+    mocks.searchParamGetMock.mockImplementation((key: string) => (key === "repo" ? "repo-docs" : null));
+    mocks.settingsGetMock.mockResolvedValueOnce({
+      data: {
+        name: "Test Org",
+        settings: {
+          default_agent_type: "codex",
+          default_work_repository_id: "repo-app",
+        },
+      },
+    });
+    mocks.repositoriesListMock.mockResolvedValueOnce({
+      data: [
+        {
+          id: "repo-docs",
+          name: "apidocs",
+          full_name: "assembledhq/apidocs",
+          default_branch: "master",
+          integration_id: "int-1",
+        },
+        {
+          id: "repo-app",
+          name: "assembled",
+          full_name: "assembledhq/assembled",
+          default_branch: "master",
+          integration_id: "int-1",
+        },
+      ],
+    });
+
+    renderWithProviders(<ManualSessionCreatePageContent />);
+
+    const prompt = await screen.findByRole("textbox", { name: "Manual session prompt" });
+    await user.type(prompt, "Update docs");
+    await user.click(screen.getByRole("button", { name: "Start session" }));
+
+    await waitFor(() => {
+      expect(mocks.createSessionMock).toHaveBeenCalledWith(expect.objectContaining({
+        repository_id: "repo-docs",
+        branch: "master",
+      }));
+    });
+  });
+
   it("keeps model controls visible on desktop when there are no repositories", async () => {
     mocks.repositoriesListMock.mockResolvedValueOnce({ data: [] });
 

--- a/frontend/src/app/(dashboard)/sessions/session-sidebar.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/session-sidebar.test.tsx
@@ -1382,7 +1382,7 @@ describe('SessionSidebar', () => {
     expect(link).toHaveAttribute('href', '/sessions/s1');
   });
 
-  it('preserves the current filters in the new session link', async () => {
+  it('preserves non-repo filters in the new session link', async () => {
     serveSessions([
       makeSession({ id: 's1', result_summary: 'Linked session' }),
     ]);
@@ -1395,7 +1395,7 @@ describe('SessionSidebar', () => {
 
     expect(screen.getByRole('link', { name: 'New session' })).toHaveAttribute(
       'href',
-      '/sessions/new?people=all&status=active&repo=repo-1&search=Linked',
+      '/sessions/new?people=all&status=active&search=Linked',
     );
   });
 
@@ -1666,7 +1666,7 @@ describe('SessionSidebar', () => {
 
     await user.keyboard('{Escape}');
     await user.keyboard('n');
-    expect(mockRouterPush).toHaveBeenCalledWith('/sessions/new?repo=repo-1');
+    expect(mockRouterPush).toHaveBeenCalledWith('/sessions/new');
 
     await user.keyboard('j');
     // Plain `a` is a no-op — archive requires Shift to avoid accidental fires.

--- a/frontend/src/app/(dashboard)/sessions/session-sidebar.tsx
+++ b/frontend/src/app/(dashboard)/sessions/session-sidebar.tsx
@@ -717,6 +717,7 @@ export function SessionSidebar() {
   // Carry the sidebar's filters into detail-page links so opening a session
   // doesn't reset the scope back to "Mine".
   const filterSuffix = useFilterSuffix(serializedPeopleParam, activeFilter, repo, search || null);
+  const newSessionFilterSuffix = useFilterSuffix(serializedPeopleParam, activeFilter, null, search || null);
 
   const showDefaultEmptyState =
     currentFilter === "all" && !trimmedSearch && (!counts || counts.all === 0);
@@ -909,13 +910,13 @@ export function SessionSidebar() {
         focusSearch();
       } else if (event.key === "n") {
         event.preventDefault();
-        router.push(`/sessions/new${filterSuffix}`);
+        router.push(`/sessions/new${newSessionFilterSuffix}`);
       }
     }
 
     document.addEventListener("keydown", handleDocumentKeyDown);
     return () => document.removeEventListener("keydown", handleDocumentKeyDown);
-  }, [filterSuffix, focusSearch, moveActiveSession, router]);
+  }, [focusSearch, moveActiveSession, newSessionFilterSuffix, router]);
 
   const renderSavedSessionRow = (session: SessionListItem, renderKey: string) => {
     const isSelected = selectedId === session.id;
@@ -1095,9 +1096,9 @@ export function SessionSidebar() {
 
         {/* New session button */}
         <Link
-          href={`/sessions/new${filterSuffix}`}
-          onMouseEnter={() => prefetchRoute(`/sessions/new${filterSuffix}`)}
-          onFocus={() => prefetchRoute(`/sessions/new${filterSuffix}`)}
+          href={`/sessions/new${newSessionFilterSuffix}`}
+          onMouseEnter={() => prefetchRoute(`/sessions/new${newSessionFilterSuffix}`)}
+          onFocus={() => prefetchRoute(`/sessions/new${newSessionFilterSuffix}`)}
           className="relative flex items-center justify-center gap-2 w-full h-9 rounded-md bg-primary bg-[image:var(--gradient-primary)] text-xs font-medium text-white shadow-sm hover:bg-[image:var(--gradient-primary-hover)] hover:shadow-[var(--glow-primary-sm)] transition-all"
         >
           <Plus className="h-4 w-4" />
@@ -1162,7 +1163,7 @@ export function SessionSidebar() {
               className={!currentActiveSessionId ? "border-primary/25 bg-card shadow-sm ring-1 ring-primary/10" : undefined}
             >
               <SessionSidebarRowSurface
-                href={`/sessions/new${filterSuffix}`}
+                href={`/sessions/new${newSessionFilterSuffix}`}
                 ariaCurrent="page"
                 className={
                   !currentActiveSessionId

--- a/frontend/src/components/command-palette/command-palette-actions.test.ts
+++ b/frontend/src/components/command-palette/command-palette-actions.test.ts
@@ -51,4 +51,9 @@ describe("command-palette-actions", () => {
     const projectsAction = staticActions.find((a) => a.id === "nav-projects");
     expect(projectsAction?.preserveRepo).toBe(true);
   });
+
+  it("global new session action does not preserve ambient repo context", () => {
+    const newSessionAction = staticActions.find((a) => a.id === "action-new-session");
+    expect(newSessionAction?.preserveRepo).toBeUndefined();
+  });
 });

--- a/frontend/src/components/command-palette/command-palette-actions.ts
+++ b/frontend/src/components/command-palette/command-palette-actions.ts
@@ -56,7 +56,7 @@ export const staticActions: PaletteAction[] = [
   { id: "settings-audit-log", label: "Audit log", icon: ScrollText, href: "/settings/audit-log", requiredRole: "admin", group: "settings" },
 
   // Quick actions
-  { id: "action-new-session", label: "New session", icon: Plus, href: "/sessions/new", preserveRepo: true, group: "quick-actions" },
+  { id: "action-new-session", label: "New session", icon: Plus, href: "/sessions/new", group: "quick-actions" },
   { id: "action-create-preview", label: "Create preview", icon: MonitorPlay, href: "/previews/new", preserveRepo: true, hiddenRoles: ["viewer"], group: "quick-actions" },
   { id: "action-new-project", label: "New project", icon: Plus, href: "/projects/new", preserveRepo: true, hiddenRoles: ["builder"], group: "quick-actions" },
   { id: "action-new-eval", label: "Create eval task", icon: Plus, href: "/settings/evals/new", hiddenRoles: ["viewer", "builder"], group: "quick-actions" },

--- a/frontend/src/components/command-palette/command-palette.test.tsx
+++ b/frontend/src/components/command-palette/command-palette.test.tsx
@@ -61,6 +61,16 @@ describe("CommandPalette", () => {
     expect(screen.getByText("Log out")).toBeInTheDocument();
   });
 
+  it("starts a global new session without preserving ambient repo context", async () => {
+    const user = userEvent.setup();
+    renderPalette({ searchParams: { repo: "repo-1" } });
+
+    const newSessionItem = await screen.findByText("New session");
+    await user.click(newSessionItem);
+
+    expect(pushMock).toHaveBeenCalledWith("/sessions/new");
+  });
+
   it("excludes admin-only items for non-admin users", async () => {
     renderPalette({ userRole: "member" });
     await screen.findByText("Account");
@@ -221,7 +231,7 @@ describe("CommandPalette", () => {
     await user.keyboard("[ArrowDown][Enter]");
 
     expect(pushMock).toHaveBeenCalledWith(
-      "/sessions/new?prompt=nonexistent-thing-xyz&repo=repo-1"
+      "/sessions/new?prompt=nonexistent-thing-xyz"
     );
   });
 

--- a/frontend/src/components/command-palette/command-palette.tsx
+++ b/frontend/src/components/command-palette/command-palette.tsx
@@ -148,7 +148,7 @@ function CommandPaletteContent({
       params.set("prompt", query);
     }
     const qs = params.toString();
-    navigate(`/sessions/new${qs ? `?${qs}` : ""}`, true);
+    navigate(`/sessions/new${qs ? `?${qs}` : ""}`);
   }, [navigate, query]);
 
   const normalizedQuery = query.trim().toLowerCase();

--- a/frontend/src/components/manual-session-composer.tsx
+++ b/frontend/src/components/manual-session-composer.tsx
@@ -497,13 +497,18 @@ export function ManualSessionComposer({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  const { data: settingsResponse, isSuccess: settingsLoaded } = useQuery<SingleResponse<Organization>>({
+  const {
+    data: settingsResponse,
+    isPending: settingsPending,
+    isSuccess: settingsLoaded,
+  } = useQuery<SingleResponse<Organization>>({
     queryKey: queryKeys.settings.all,
     queryFn: () => api.settings.get(),
   });
 
   const settings = settingsResponse?.data?.settings as OrgSettings | undefined;
   const defaultAgentType = settings?.default_agent_type ?? "codex";
+  const defaultWorkRepositoryId = settings?.default_work_repository_id ?? "";
 
   const { data: reposResponse, isSuccess: reposLoaded } = useQuery<ListResponse<Repository>>({
     queryKey: queryKeys.repositories.all,
@@ -543,11 +548,17 @@ export function ManualSessionComposer({
     queryFn: () => api.integrations.list(),
   });
 
-  // Auto-select: user's choice > last used repo > first repo.
+  const isAutoRepoSelectionPending = userSelectedRepoId === null && repositories.length > 1 && settingsPending;
+
+  // Auto-select: user's explicit choice > org default work repo > last used repo > first repo.
   const selectedRepoId = useMemo(() => {
     if (userSelectedRepoId !== null) return userSelectedRepoId;
     if (repositories.length === 1) return repositories[0].id;
     if (repositories.length > 0) {
+      if (isAutoRepoSelectionPending) return "";
+      if (defaultWorkRepositoryId && repositories.some((r) => r.id === defaultWorkRepositoryId)) {
+        return defaultWorkRepositoryId;
+      }
       try {
         const lastUsed = localStorage.getItem("143:lastUsedRepoId");
         if (lastUsed && repositories.some((r) => r.id === lastUsed)) return lastUsed;
@@ -555,7 +566,7 @@ export function ManualSessionComposer({
       return repositories[0].id;
     }
     return "";
-  }, [userSelectedRepoId, repositories]);
+  }, [defaultWorkRepositoryId, isAutoRepoSelectionPending, userSelectedRepoId, repositories]);
 
   const selectedRepo = repositories.find((r) => r.id === selectedRepoId);
   // Derive branch: use user override if set, otherwise the repo's default.
@@ -770,6 +781,7 @@ export function ManualSessionComposer({
     if (submittingRef.current) return;
     if (!hasSubmittableInput) return;
     if (hasInvalidCommands) return;
+    if (isAutoRepoSelectionPending) return;
     submittingRef.current = true;
     createManualSessionMutation.mutate();
   }
@@ -1437,7 +1449,7 @@ export function ManualSessionComposer({
                         type="button"
                         size="icon"
                         onClick={submitManualSession}
-                        disabled={!hasSubmittableInput || isCreatingSession}
+                        disabled={!hasSubmittableInput || isCreatingSession || isAutoRepoSelectionPending}
                         className="ml-auto h-8 w-8 rounded-full"
                         aria-label="Start session"
                       >
@@ -1490,7 +1502,7 @@ export function ManualSessionComposer({
                       type="button"
                       size="icon"
                       onClick={submitManualSession}
-                      disabled={!hasSubmittableInput || isCreatingSession}
+                      disabled={!hasSubmittableInput || isCreatingSession || isAutoRepoSelectionPending}
                       className="ml-auto h-8 w-8 rounded-full"
                       aria-label="Start session"
                     >

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -1826,6 +1826,7 @@ export interface OrgSettings {
   llm_reasoning_effort?: "low" | "medium" | "high" | "xhigh" | "max" | "";
   agent_config?: Record<string, Record<string, string>>;
   default_agent_type?: "codex" | "claude_code" | "amp" | "pi" | "opencode";
+  default_work_repository_id?: string | null;
   pr_authorship?: "user_preferred" | "app_only" | "user_required";
   pr_draft_default?: boolean;
   auto_archive_on_pr_close?: boolean;


### PR DESCRIPTION
## Summary
- Use the organization’s default work repository before falling back to last-used or first available repo in manual session creation
- Keep new session entry points from preserving ambient repo context in the sidebar and command palette
- Prevent submission while repository auto-selection is still resolving
- Add `default_work_repository_id` to the frontend org settings type

## Testing
- Added unit tests covering repo selection precedence, pending settings behavior, and new session navigation
- Added command palette and sidebar tests to verify new session links no longer carry repo context