### PR TITLE
Remove “Updating preview…” copy and standardize “Starting services” typography

### DIFF
--- a/docs/design/implemented/89-session-preview-freshness.md
+++ b/docs/design/implemented/89-session-preview-freshness.md
@@ -21,7 +21,7 @@ Suggested copy:
 - Out of date marker: `New changes available`
 - Out of date action: `Refresh preview`
 - Out of date helper text: `Restart the preview to see the latest session changes.`
-- Updating: `Updating preview...`
+- Updating: no extra startup copy; the startup checklist already indicates that the preview is being prepared.
 - Unknown: `Preview freshness could not be verified.`
 
 The stale state should be visible inside the Preview tab even before the user opens the secondary preview actions menu. The marker should look like a small inline status callout or amber-tinted badge row near the Preview command header, not a blocking modal and not a global toast. The user should understand two things at a glance: the preview still exists, and there is newer session code available.
@@ -350,7 +350,7 @@ Preview tab behavior in `frontend/src/components/preview/preview-panel.tsx`:
 - Show a visible `Refresh preview` button in the command header when stale, wired to the existing `startMutation` / `api.sessions.preview.ensure(sessionId)`.
 - Keep `Open Preview` available for ready stale previews, but do not let it visually suppress the freshness marker.
 - Keep the existing secondary `Restart preview` menu item. `Refresh preview` is the promoted stale-state action; `Restart preview` remains the generic lifecycle command.
-- While the mutation is pending or status is `starting` with current revision, render `Updating preview...`.
+- While the mutation is pending or status is `starting` with current revision, keep the startup copy focused on the current startup step instead of rendering an additional updating label.
 - For `unknown`, avoid a loud warning; show quiet metadata only if useful for support.
 
 The preview status query already polls/refetches around active states. The session detail SSE/polling path should invalidate `["preview-status", sessionId]` when session detail receives a new `latest_diff_snapshot_id`, `diff_collected_at`, or future explicit `workspace_revision` change. This keeps the Preview tab aware soon after the agent completes a change even if the tab was already open.

--- a/frontend/src/components/preview/preview-panel.test.tsx
+++ b/frontend/src/components/preview/preview-panel.test.tsx
@@ -387,7 +387,10 @@ describe("PreviewPanel component", () => {
     renderWithProviders(<PreviewPanel {...DEFAULT_PROPS} />);
 
     await waitFor(() => {
-      expect(screen.getByText("Preparing preview")).toBeInTheDocument();
+      expect(screen.getByText("Preparing preview")).toHaveClass(
+        "text-sm",
+        "font-medium",
+      );
     });
 
     expect(screen.getByText("Provisioning postgres")).toBeInTheDocument();
@@ -395,7 +398,7 @@ describe("PreviewPanel component", () => {
     expect(screen.getByText("postgres is provisioning")).toBeInTheDocument();
     expect(screen.getByText("Services")).toBeInTheDocument();
     expect(screen.getByText("Waiting for services to boot.")).toBeInTheDocument();
-    expect(screen.getByText("Updating preview...")).toBeInTheDocument();
+    expect(screen.queryByText("Updating preview...")).not.toBeInTheDocument();
     expect(screen.getByText("Preview")).toBeInTheDocument();
     expect(screen.getByText("Waiting for the preview URL to become reachable.")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Stop preview" })).toBeInTheDocument();

--- a/frontend/src/components/preview/preview-panel.tsx
+++ b/frontend/src/components/preview/preview-panel.tsx
@@ -434,7 +434,7 @@ function freshnessLabel(
   mutationPending: boolean,
 ): string | undefined {
   if (mutationPending || freshness === "updating") {
-    return "Updating preview...";
+    return undefined;
   }
   if (freshness === "live_updated") {
     return "Updated live";
@@ -932,8 +932,6 @@ export function PreviewPanel({
         : previewRecoveryAction === "retry"
           ? "Retry the preview to use the latest session changes."
           : undefined;
-  const startupFreshnessText =
-    showStartupCanvas && freshnessState === "updating" ? freshnessText : undefined;
   const startupEstimate = previewStatus?.startup_estimate;
   const startupEstimateLabel =
     startupEstimate && startupEstimate.sample_count >= 5
@@ -1205,17 +1203,12 @@ export function PreviewPanel({
                 <Loader2 className="size-5 animate-spin text-primary" />
               </div>
               <div className="space-y-1">
-                <p className="text-lg font-semibold text-foreground">
+                <p className="text-sm font-medium text-foreground">
                   Preparing preview
                 </p>
-                <p className="text-sm text-muted-foreground">
+                <p className="text-sm font-medium text-muted-foreground">
                   {startupSubtitle}
                 </p>
-                {startupFreshnessText && (
-                  <p className="text-xs font-medium text-muted-foreground">
-                    {startupFreshnessText}
-                  </p>
-                )}
                 {startupEstimateLabel && (
                   <p className="text-xs font-medium text-muted-foreground">
                     {startupEstimateLabel}


### PR DESCRIPTION
## Summary

Fixes a preview freshness UI reliability issue where users see conflicting/stale status copy (“Updating preview...”) alongside the startup step checklist. This reduces confusion during refresh/prepare flows by removing the redundant updating label and standardizing the typography used for the startup step text.

## Changes

- Updated preview freshness copy to remove the standalone **“Updating preview...”** label while refresh/start is pending/`starting`.
- Adjusted the startup canvas to remove extra startup freshness line, relying on the existing startup checklist to indicate progress.
- Normalized **“Preparing preview”** and startup subtitle styling to the same `text-sm font-medium` so **“Starting services”** no longer appears in a different size/weight family.
- Updated `preview-panel.test.tsx` to assert the new expected DOM (no “Updating preview...” and consistent class styling).

## Validation

- `npm run test -- src/components/preview/preview-panel.test.tsx --run`
- `npm run typecheck`
- `npm run lint`
- `npm run build`

[143.dev](https://143.dev) | [session 841fcc22](https://143.dev/sessions/841fcc22-be3b-4f91-bc76-557d4f364d54)

<!-- 143 readiness -->
**143 readiness:** not available for this revision.

Preview: https://143.dev/previews/github/assembledhq/143/pull/1623?launch=1