### PR TITLE
Serve our own robots.txt allowing crawlers on marketing pages

### DIFF
--- a/frontend/src/app/robots.ts
+++ b/frontend/src/app/robots.ts
@@ -1,0 +1,40 @@
+import type { MetadataRoute } from "next";
+
+// Crawl policy for 143.dev. The public marketing + docs pages are crawlable by
+// any bot; the authenticated app and backend API are disallowed.
+//
+// This is the *advisory* layer — compliant crawlers read it and self-restrict.
+// The hard boundary (a 403 for un-allowlisted bots) is enforced separately at
+// the Cloudflare edge. Keep the two in sync: a path that is Disallow-ed here
+// should also stay blocked at the edge, and a marketing path opened at the edge
+// should remain crawlable here.
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: [
+      {
+        userAgent: "*",
+        allow: "/",
+        disallow: [
+          // Backend API + auth surfaces.
+          "/api/",
+          "/login",
+          "/invite/",
+          "/verify-email",
+          // Authenticated dashboard.
+          "/sessions",
+          "/projects",
+          "/settings",
+          "/team",
+          "/agent",
+          "/automations",
+          "/autopilot",
+          "/integrations",
+          "/llm",
+          "/repositories",
+          "/previews",
+          "/onboarding",
+        ],
+      },
+    ],
+  };
+}


### PR DESCRIPTION
## Summary

Coding agents and AI crawlers were getting a hard **403** on `https://143.dev/docs` (Cloudflare's AI-bot block), and the Cloudflare-managed `/robots.txt` separately told those bots `Disallow: /`. We want the public marketing + docs site to be crawlable while keeping the authenticated app off-limits. This PR takes ownership of `/robots.txt` in code (Next.js `app/robots.ts`) so crawl policy is per-path and version-controlled, instead of relying on Cloudflare's all-or-nothing managed file.

## Changes

- Add `frontend/src/app/robots.ts` serving a single policy: `User-agent: *` → `Allow: /`, with `Disallow` for the backend API (`/api/`) and authenticated app routes (`/login`, `/sessions`, `/settings`, `/projects`, `/team`, `/agent`, `/automations`, `/autopilot`, `/integrations`, `/llm`, `/repositories`, `/previews`, `/onboarding`, `/invite/`, `/verify-email`).
- No per-bot carve-outs or `Content-Signal` directives — we're fine with AI training on the public marketing/docs content.

## Validation

- `tsc --noEmit` passes for the new file (validated the `MetadataRoute.Robots` shape against the project's `next` types).

## Reviewer notes — required Cloudflare changes (out of band, not in this repo)

robots.txt is only the *advisory* layer. Two dashboard steps are needed for this to actually take effect:

1. **Disable Cloudflare's managed robots.txt** (Security → Bots → "Manage robots.txt" / "AI Crawl Control"). Otherwise Cloudflare keeps injecting/overriding the response and its `Disallow: /` for AI bots will override this file.
2. **Add a WAF custom rule** (Security → WAF → Custom rules) with action **Skip → Super Bot Fight Mode** for marketing paths (`/`, `/docs`, `/about`, `/why-143`, `/privacy`, `/security`, `/terms`, `/llms.txt`), so AI bots stop getting a hard 403 before they can even read robots.txt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
