### PR TITLE
Inject platform context env into preview build commands

### DIFF
--- a/docs/guides/previews.md
+++ b/docs/guides/previews.md
@@ -455,6 +455,8 @@ Every service receives:
 | `ONEFORTYTHREE_ENV` | `preview` — always injected for preview runtimes. Apps should use this to skip work that is not needed to serve the preview, such as background consumers, schedulers, profilers, analytics/telemetry exporters, and expensive startup warmers. This name is reserved; preview configs and secret bundle env outputs that declare it fail validation. |
 | `PREVIEW_ORIGIN` | The public URL the gateway serves this preview on, e.g. `http://<id>.preview.localhost:9090`. Set this as your app's external base URL (e.g. `BASE_URL`, `FRONTEND_URL`) so redirects and absolute links point at the preview instead of `localhost`. Overrides any user-declared value. |
 
+The platform context vars (`ONEFORTYTHREE`, `ONEFORTYTHREE_ENV`, `PREVIEW_ORIGIN`) are injected into **service build commands as well as the runtime env**, so a build step can detect that it is building for a preview — for example, a statically built frontend can bake a preview-only flag into its bundle. They carry only non-secret platform context; injected infrastructure credentials and secret bundles stay runtime-only, so build steps still cannot read app secrets.
+
 ## Trust Split
 
 Preview config is untrusted repo content. Not every field is read from the same git revision.

--- a/internal/services/preview/manager.go
+++ b/internal/services/preview/manager.go
@@ -2487,12 +2487,16 @@ func (m *Manager) WorkerNodeID() string {
 }
 
 // platformEnv returns environment variables the platform injects into every
-// service of the given preview. It always exposes ONEFORTYTHREE=true and
-// ONEFORTYTHREE_ENV=preview so apps can detect 143 preview runtimes and disable
-// background workers, profilers, schedulers, and other non-serving work;
-// validation rejects user-declared values for those reserved names so collisions
-// fail before launch. When configured, it also exposes PREVIEW_ORIGIN (computed
-// from PreviewOriginTemplate with "{id}" replaced by the preview UUID).
+// service of the given preview, in both its build and runtime env. It always
+// exposes ONEFORTYTHREE=true and ONEFORTYTHREE_ENV=preview so apps can detect
+// 143 preview runtimes and disable background workers, profilers, schedulers,
+// and other non-serving work — including at build time, e.g. a static frontend
+// baking a preview flag into its bundle; validation rejects user-declared
+// values for those reserved names so collisions fail before launch. When
+// configured, it also exposes PREVIEW_ORIGIN (computed from
+// PreviewOriginTemplate with "{id}" replaced by the preview UUID). These values
+// are non-secret platform context, so injecting them at build time leaks
+// nothing.
 func (m *Manager) platformEnv(previewID uuid.UUID) map[string]string {
 	env := map[string]string{
 		previewPlatformNameEnv:    previewPlatformNameValue,

--- a/internal/services/preview/provider.go
+++ b/internal/services/preview/provider.go
@@ -28,7 +28,10 @@ type PreviewCapableProvider interface {
 	// is merged into every service's environment after the user's
 	// declared env and any infrastructure-injected credentials, so it can
 	// carry platform-level values (e.g. PREVIEW_ORIGIN) that must always be
-	// available and should win over user overrides.
+	// available and should win over user overrides. It is also injected into
+	// service build commands so build steps can detect the preview runtime;
+	// unlike credentials and secret bundles, ExtraEnv carries only non-secret
+	// platform context, so exposing it at build time leaks nothing.
 	//
 	// observer receives per-service Ready/Failed transitions as they happen,
 	// so callers (typically the manager) can persist per-service state to the

--- a/internal/services/preview/providers/docker_preview.go
+++ b/internal/services/preview/providers/docker_preview.go
@@ -2323,8 +2323,12 @@ func previewServiceBuildOrder(cfg *models.PreviewConfig) []string {
 // in dependency order, before any service starts. It is the place to compile
 // artifacts (e.g. `go build`) so the start command can exec a prebuilt binary
 // off the readiness-probe hot path. Build commands run with the service's own
-// Env (no injected platform credentials or runtime secrets) so build steps
-// cannot read app secrets. A non-zero exit or timeout fails the launch.
+// Env plus the platform context env (ONEFORTYTHREE, ONEFORTYTHREE_ENV,
+// PREVIEW_ORIGIN) so build steps can detect the preview runtime and gate
+// build-time behavior — e.g. a static frontend baking a preview flag into its
+// bundle. Injected infrastructure credentials and runtime secret bundles stay
+// runtime-only, so build steps still cannot read app secrets. A non-zero exit
+// or timeout fails the launch.
 func (d *DockerPreviewProvider) runServiceBuilds(ctx context.Context, state *previewState, cfg *models.PreviewConfig, opts preview.StartPreviewOptions, observer preview.ServiceObserver) error {
 	hasBuild := false
 	for _, svcCfg := range cfg.Services {
@@ -2389,6 +2393,19 @@ func (d *DockerPreviewProvider) runServiceBuilds(ctx context.Context, state *pre
 		sort.Strings(envKeys)
 		for _, k := range envKeys {
 			cmdParts = append(cmdParts, fmt.Sprintf("%s=%s", k, shellEscape(svcCfg.Env[k])))
+		}
+		// Inject the platform context env (ONEFORTYTHREE, ONEFORTYTHREE_ENV,
+		// PREVIEW_ORIGIN) after the service's own Env so the platform value wins,
+		// matching buildServiceEnvs. This is the same non-secret context exposed at
+		// runtime; infra credentials and secret bundles are deliberately not added
+		// here, so build steps still cannot read app secrets.
+		platformKeys := make([]string, 0, len(opts.ExtraEnv))
+		for k := range opts.ExtraEnv {
+			platformKeys = append(platformKeys, k)
+		}
+		sort.Strings(platformKeys)
+		for _, k := range platformKeys {
+			cmdParts = append(cmdParts, fmt.Sprintf("%s=%s", k, shellEscape(opts.ExtraEnv[k])))
 		}
 		escapedCmd := make([]string, len(svcCfg.Build))
 		for i, c := range svcCfg.Build {

--- a/internal/services/preview/providers/docker_preview_test.go
+++ b/internal/services/preview/providers/docker_preview_test.go
@@ -3336,6 +3336,64 @@ func goBuildPreviewConfig() *models.PreviewConfig {
 	}
 }
 
+// TestStartPreview_BuildPhaseInjectsPlatformEnv verifies the platform context
+// env (ONEFORTYTHREE, ONEFORTYTHREE_ENV, PREVIEW_ORIGIN) is exposed to service
+// build commands, so build steps can detect the preview runtime — e.g. a static
+// frontend baking a preview flag into its bundle.
+func TestStartPreview_BuildPhaseInjectsPlatformEnv(t *testing.T) {
+	t.Parallel()
+
+	release := make(chan struct{})
+	var mu sync.Mutex
+	var buildCmd string
+	exec := &fakeServiceExecutor{
+		execStreamFn: func(ctx context.Context, cmd string, _ func([]byte)) (int, error) {
+			if strings.Contains(cmd, "cmd/web") {
+				mu.Lock()
+				buildCmd = cmd
+				mu.Unlock()
+				return 0, nil
+			}
+			select {
+			case <-release:
+			case <-ctx.Done():
+			}
+			return 0, nil
+		},
+		execFn: func(_ context.Context, _ string) (int, error) { return 0, nil },
+		readFileFn: func(_ context.Context, path string) ([]byte, error) {
+			if path == "package-lock.json" {
+				return []byte(`{"lockfileVersion":3}`), nil
+			}
+			return []byte("ok"), nil
+		},
+	}
+	cache := &fakeDependencyCache{findHit: &preview.DependencyCacheHit{}}
+	d := NewDockerPreviewProvider(previewReachableClient(), exec, zerolog.Nop(), WithPreviewDialer(successfulPreviewDialer), WithDependencyCache(cache))
+
+	handle, err := d.StartPreview(context.Background(), &agent.Sandbox{ID: "sb", WorkDir: "/workspace/repo", HomeDir: "/home/codex"}, goBuildPreviewConfig(), preview.StartPreviewOptions{
+		OrgID:        uuid.New(),
+		RepositoryID: uuid.New(),
+		SessionID:    uuid.New(),
+		ExtraEnv: map[string]string{
+			"ONEFORTYTHREE":     "true",
+			"ONEFORTYTHREE_ENV": "preview",
+			"PREVIEW_ORIGIN":    "http://abc.preview.localhost:9090",
+		},
+	}, &recordingObserver{})
+	require.NoError(t, err, "StartPreview should succeed")
+	require.NotNil(t, handle, "StartPreview should return a handle")
+
+	mu.Lock()
+	require.Contains(t, buildCmd, "ONEFORTYTHREE_ENV='preview'", "build command should expose ONEFORTYTHREE_ENV so build steps can detect the preview runtime")
+	require.Contains(t, buildCmd, "ONEFORTYTHREE='true'", "build command should expose the ONEFORTYTHREE marker")
+	require.Contains(t, buildCmd, "PREVIEW_ORIGIN='http://abc.preview.localhost:9090'", "build command should expose PREVIEW_ORIGIN")
+	mu.Unlock()
+
+	close(release)
+	require.NoError(t, d.StopPreview(context.Background(), handle.Handle), "StopPreview should clean up the started preview")
+}
+
 // TestStartPreview_BuildPhaseRunsBeforeStartAndSavesHomeCache covers the happy
 // path: the build command compiles before the service starts, GOCACHE/GOMODCACHE
 // are pinned to the archived default locations, and the home build cache is


### PR DESCRIPTION
## Summary

A preview's frontend is often a statically built bundle, which bakes its configuration at build time. Today the platform context vars (`ONEFORTYTHREE`, `ONEFORTYTHREE_ENV`, `PREVIEW_ORIGIN`) are injected only into the runtime env, so a static build cannot detect that it is building for a preview — it can only learn this after it has already been compiled. This change injects that same non-secret platform context into service **build** commands too, so build steps can gate build-time behavior (e.g. a frontend baking a preview-only flag into its bundle).

## Changes

- `runServiceBuilds` now appends `opts.ExtraEnv` to each service's build command, after the service's own `Env` so the platform value wins (matching `buildServiceEnvs`' runtime precedence).
- Security boundary preserved: `ExtraEnv` is sourced solely from `platformEnv` (verified — all three call sites) and carries no secrets. Infrastructure credentials and runtime secret bundles are still merged only in `buildServiceEnvs` at runtime, so build steps remain unable to read app secrets.
- Updated the `runServiceBuilds`, `platformEnv`, and `StartPreviewOptions` doc comments and the Platform-Injected Env guide to document build-time availability.

## Validation

- New test `TestStartPreview_BuildPhaseInjectsPlatformEnv` asserts the build command exposes `ONEFORTYTHREE`, `ONEFORTYTHREE_ENV=preview`, and `PREVIEW_ORIGIN`.
- `go build ./internal/services/preview/...`, `go vet`, and the full `./internal/services/preview/...` suite pass. gofmt clean; pre-commit hook passed.

## Context

This unblocks the Assembled-side change (assembledhq/assembled#53159), which currently sets a separate `REACT_APP_143_PREVIEW` build flag because `ONEFORTYTHREE_ENV` wasn't reachable at build time. Once this ships, that app can read `ONEFORTYTHREE_ENV` directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
