### PR TITLE
Add sitemap.xml for public marketing + docs pages

### DIFF
--- a/frontend/src/app/robots.ts
+++ b/frontend/src/app/robots.ts
@@ -36,5 +36,6 @@ export default function robots(): MetadataRoute.Robots {
         ],
       },
     ],
+    sitemap: "https://143.dev/sitemap.xml",
   };
 }

--- a/frontend/src/app/robots.ts
+++ b/frontend/src/app/robots.ts
@@ -1,4 +1,5 @@
 import type { MetadataRoute } from "next";
+import { getSiteOrigin } from "@/lib/site-url";
 
 // Crawl policy for 143.dev. The public marketing + docs pages are crawlable by
 // any bot; the authenticated app and backend API are disallowed.
@@ -8,7 +9,8 @@ import type { MetadataRoute } from "next";
 // the Cloudflare edge. Keep the two in sync: a path that is Disallow-ed here
 // should also stay blocked at the edge, and a marketing path opened at the edge
 // should remain crawlable here.
-export default function robots(): MetadataRoute.Robots {
+export default async function robots(): Promise<MetadataRoute.Robots> {
+  const origin = await getSiteOrigin();
   return {
     rules: [
       {
@@ -36,6 +38,6 @@ export default function robots(): MetadataRoute.Robots {
         ],
       },
     ],
-    sitemap: "https://143.dev/sitemap.xml",
+    sitemap: `${origin}/sitemap.xml`,
   };
 }

--- a/frontend/src/app/sitemap.ts
+++ b/frontend/src/app/sitemap.ts
@@ -1,9 +1,6 @@
 import type { MetadataRoute } from "next";
 import { source } from "@/lib/source";
-
-// Absolute origin for sitemap URLs. The hosted service runs on 143.dev; this is
-// the same canonical domain hardcoded elsewhere in the app.
-const SITE_URL = "https://143.dev";
+import { getSiteOrigin } from "@/lib/site-url";
 
 // Public, linked marketing pages. Intentionally excludes:
 //   - auth-gated app + API routes (kept out of crawl scope; see robots.ts)
@@ -13,9 +10,11 @@ const SITE_URL = "https://143.dev";
 // whose pages already include the /docs index.
 const MARKETING_PATHS = ["/", "/about", "/privacy", "/security", "/terms"];
 
-export default function sitemap(): MetadataRoute.Sitemap {
+export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
+  const origin = await getSiteOrigin();
+
   const marketing: MetadataRoute.Sitemap = MARKETING_PATHS.map((path) => ({
-    url: `${SITE_URL}${path}`,
+    url: `${origin}${path}`,
     changeFrequency: "monthly",
     priority: path === "/" ? 1 : 0.7,
   }));
@@ -24,7 +23,7 @@ export default function sitemap(): MetadataRoute.Sitemap {
   // sitemap stays in sync as docs are added or removed. page.url already
   // includes the /docs base path (e.g. "/docs", "/docs/getting-started/...").
   const docs: MetadataRoute.Sitemap = source.getPages().map((page) => ({
-    url: `${SITE_URL}${page.url}`,
+    url: `${origin}${page.url}`,
     changeFrequency: "weekly",
     priority: page.url === "/docs" ? 0.8 : 0.6,
   }));

--- a/frontend/src/app/sitemap.ts
+++ b/frontend/src/app/sitemap.ts
@@ -1,0 +1,33 @@
+import type { MetadataRoute } from "next";
+import { source } from "@/lib/source";
+
+// Absolute origin for sitemap URLs. The hosted service runs on 143.dev; this is
+// the same canonical domain hardcoded elsewhere in the app.
+const SITE_URL = "https://143.dev";
+
+// Public, linked marketing pages. Intentionally excludes:
+//   - auth-gated app + API routes (kept out of crawl scope; see robots.ts)
+//   - unlinked / in-progress landing pages (e.g. /why-143) that are not yet
+//     meant to be discoverable.
+// The /docs surface is not listed here — it comes from the docs source below,
+// whose pages already include the /docs index.
+const MARKETING_PATHS = ["/", "/about", "/privacy", "/security", "/terms"];
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  const marketing: MetadataRoute.Sitemap = MARKETING_PATHS.map((path) => ({
+    url: `${SITE_URL}${path}`,
+    changeFrequency: "monthly",
+    priority: path === "/" ? 1 : 0.7,
+  }));
+
+  // Docs pages are generated from the same fumadocs source as /llms.txt, so the
+  // sitemap stays in sync as docs are added or removed. page.url already
+  // includes the /docs base path (e.g. "/docs", "/docs/getting-started/...").
+  const docs: MetadataRoute.Sitemap = source.getPages().map((page) => ({
+    url: `${SITE_URL}${page.url}`,
+    changeFrequency: "weekly",
+    priority: page.url === "/docs" ? 0.8 : 0.6,
+  }));
+
+  return [...marketing, ...docs];
+}

--- a/frontend/src/lib/site-url.ts
+++ b/frontend/src/lib/site-url.ts
@@ -1,0 +1,31 @@
+import { headers } from "next/headers";
+
+const FALLBACK_ORIGIN = "https://143.dev";
+
+/**
+ * Absolute origin (scheme + host) used to build canonical URLs in robots.txt
+ * and sitemap.xml.
+ *
+ * Self-hosting friendly, in priority order:
+ *   1. An explicit `SITE_URL` env var (set this when serving behind a CDN or on
+ *      multiple hostnames and you want one canonical origin). Read at runtime,
+ *      so it works with the prebuilt standalone image.
+ *   2. The incoming request's host. Behind our Caddy reverse proxy the original
+ *      `Host` is preserved and `X-Forwarded-*` are set, so the app emits URLs
+ *      for whatever domain it is actually served on — no config required.
+ *   3. The hosted domain, only if there is no request context.
+ */
+export async function getSiteOrigin(): Promise<string> {
+  const explicit = process.env.SITE_URL?.trim();
+  if (explicit) return explicit.replace(/\/+$/, "");
+
+  const headerList = await headers();
+  const host =
+    headerList.get("x-forwarded-host") ?? headerList.get("host");
+  if (host) {
+    const proto = headerList.get("x-forwarded-proto") ?? "https";
+    return `${proto}://${host}`;
+  }
+
+  return FALLBACK_ORIGIN;
+}


### PR DESCRIPTION
## Summary

We never had a `sitemap.xml`, yet `/sitemap.xml` was the single most-requested path in Cloudflare AI Crawl Control (19 hits) — every one landing on a Next.js 404. This adds an app-generated sitemap covering our public marketing and docs pages, and references it from `robots.txt` so crawlers can discover it.

## Changes

- **`frontend/src/app/sitemap.ts`** (new): lists the public, linked marketing pages (`/`, `/about`, `/privacy`, `/security`, `/terms`) plus every docs page. Docs entries are generated from the same fumadocs `source.getPages()` the `/llms.txt` route uses, so the sitemap stays in sync automatically as docs are added or removed.
- **`frontend/src/app/robots.ts`**: add the `sitemap: https://143.dev/sitemap.xml` reference.

## What's intentionally excluded

- Auth-gated app + API routes (`/sessions`, `/settings`, `/projects`, `/api/*`, etc.) — already `Disallow`-ed in `robots.ts`; sitemaps should only list public, indexable URLs.
- `/why-143` — it exists on `main` but is **not linked from anywhere** in the frontend (verified: zero references), i.e. an unlinked/in-progress landing page. Excluded so we don't advertise a route that's still being worked on. Easy to add later by appending it to `MARKETING_PATHS`.

## Validation

- `tsc --noEmit` clean for the new file (validated `MetadataRoute.Sitemap` shape and the `source.getPages()` usage against the project's types).
- Reachable marketing/docs paths were confirmed serving `200` on the live site during investigation.

After deploy, `/sitemap.xml` will return the generated XML (currently 404) and `/robots.txt` will point at it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
