### PR TITLE
Preserve worker deploy mode across sudo filtering

### DIFF
--- a/deploy/deploy_config_test.go
+++ b/deploy/deploy_config_test.go
@@ -677,6 +677,27 @@ func TestRoutineWorkerDeployDoesNotRecreateHealthySandboxDNS(t *testing.T) {
 	require.Less(t, noRecreateIndex, recreateRetryIndex, "routine reconciliation should fail before the maintenance-only recreate cleanup path")
 }
 
+func TestWorkerReconcileModeSurvivesSudoEnvironmentFiltering(t *testing.T) {
+	t.Parallel()
+
+	deployScript, err := os.ReadFile("../deploy/scripts/deploy.sh")
+	require.NoError(t, err, "test should read deploy.sh")
+	deployText := string(deployScript)
+	runReconcile := extractTopLevelShellFunction(t, deployText, "run_worker_host_reconcile", "remote_shell_quote")
+	require.Contains(t, runReconcile, `DEPLOY_MODE_FILE="/opt/143/.deploy-mode"`, "worker deploy should use a host-side handoff file for reconcile mode")
+	require.Contains(t, runReconcile, `printf '%s %s\n' "$DEPLOY_MODE" "$(date +%s)" > "$DEPLOY_MODE_FILE"`, "worker deploy should write the requested deploy mode before sudo strips the environment")
+	require.Contains(t, runReconcile, `trap 'rm -f "$DEPLOY_MODE_FILE"' EXIT`, "worker deploy should remove the reconcile mode handoff file after the sudo call returns")
+	require.Contains(t, runReconcile, `sudo -n /opt/143/deploy/scripts/reconcile-worker-host.sh 143-sandbox`, "worker deploy should keep using the narrow sudoers command for host reconciliation")
+
+	reconcileScript, err := os.ReadFile("../deploy/scripts/reconcile-worker-host.sh")
+	require.NoError(t, err, "test should read reconcile-worker-host.sh")
+	reconcileText := string(reconcileScript)
+	require.Contains(t, reconcileText, `DEPLOY_MODE_FILE="${DEPLOY_MODE_FILE:-/opt/143/.deploy-mode}"`, "worker reconcile should know where deploy.sh writes the mode handoff")
+	require.Contains(t, reconcileText, "resolve_deploy_mode()", "worker reconcile should centralize deploy mode resolution")
+	require.Contains(t, reconcileText, `DEPLOY_MODE="$(resolve_deploy_mode)"`, "worker reconcile should populate DEPLOY_MODE before routine-vs-maintenance branches run")
+	require.Contains(t, reconcileText, "DEPLOY_MODE_FILE_MAX_AGE_SECONDS", "worker reconcile should ignore stale deploy mode handoff files")
+}
+
 func TestRoutineWorkerDeployBuildsSandboxDNSOnlyWhenMissing(t *testing.T) {
 	t.Parallel()
 

--- a/deploy/scripts/deploy.sh
+++ b/deploy/scripts/deploy.sh
@@ -101,8 +101,23 @@ DOCKER_DNS_RESOLVERS=(1.1.1.1 8.8.8.8 9.9.9.9)
 ALLOW_DEPLOY_DOCKER_DAEMON_RESTART="${ALLOW_DEPLOY_DOCKER_DAEMON_RESTART:-0}"
 
 run_worker_host_reconcile() {
+  local DEPLOY_MODE_FILE="/opt/143/.deploy-mode"
+
   ssh "${SSH_OPTS[@]}" deploy@"$HOST" \
-    "sudo -n /opt/143/deploy/scripts/reconcile-worker-host.sh 143-sandbox"
+    "$(remote_env_assignment DEPLOY_MODE "${DEPLOY_MODE:-routine}")" \
+    "$(remote_env_assignment DEPLOY_MODE_FILE "$DEPLOY_MODE_FILE")" \
+    'bash -s' <<'REMOTE'
+set -euo pipefail
+
+case "${DEPLOY_MODE:-routine}" in
+  routine|maintenance) ;;
+  *) echo "ERROR: invalid DEPLOY_MODE for worker reconciliation: ${DEPLOY_MODE}" >&2; exit 1 ;;
+esac
+
+printf '%s %s\n' "$DEPLOY_MODE" "$(date +%s)" > "$DEPLOY_MODE_FILE"
+trap 'rm -f "$DEPLOY_MODE_FILE"' EXIT
+sudo -n /opt/143/deploy/scripts/reconcile-worker-host.sh 143-sandbox
+REMOTE
 }
 
 remote_shell_quote() {

--- a/deploy/scripts/reconcile-worker-host.sh
+++ b/deploy/scripts/reconcile-worker-host.sh
@@ -16,6 +16,43 @@ STATIC_EGRESS_ENV_FILE="${STATIC_EGRESS_ENV_FILE:-/opt/143/.env}"
 STATIC_EGRESS_SECRETS_FILE="${STATIC_EGRESS_SECRETS_FILE:-/opt/143/static-egress-worker.env}"
 WORKER_COMPOSE_FILE="${WORKER_COMPOSE_FILE:-/opt/143/docker-compose.worker.yml}"
 DEFAULT_NETWORK="${2:-143_default}"
+DEPLOY_MODE_FILE="${DEPLOY_MODE_FILE:-/opt/143/.deploy-mode}"
+DEPLOY_MODE_FILE_MAX_AGE_SECONDS="${DEPLOY_MODE_FILE_MAX_AGE_SECONDS:-600}"
+
+resolve_deploy_mode() {
+  local mode="${DEPLOY_MODE:-}"
+  local file_mode file_ts now max_age age
+
+  if [ -z "$mode" ] && [ -r "$DEPLOY_MODE_FILE" ]; then
+    read -r file_mode file_ts < "$DEPLOY_MODE_FILE" || true
+    if [ -n "${file_mode:-}" ]; then
+      case "${file_ts:-}" in
+        ""|*[!0-9]*)
+          ;;
+        *)
+          now="$(date +%s)"
+          max_age="$DEPLOY_MODE_FILE_MAX_AGE_SECONDS"
+          case "$max_age" in
+            ""|*[!0-9]*) max_age=600 ;;
+          esac
+          age=$((now - file_ts))
+          if [ "$age" -ge 0 ] && [ "$age" -le "$max_age" ]; then
+            mode="$file_mode"
+          fi
+          ;;
+      esac
+    fi
+  fi
+
+  case "$mode" in
+    ""|routine) printf '%s\n' routine ;;
+    maintenance) printf '%s\n' maintenance ;;
+    *)
+      echo "ERROR: invalid DEPLOY_MODE for worker reconciliation: $mode" >&2
+      return 1
+      ;;
+  esac
+}
 
 load_static_egress_env_key() {
   local key="$1"
@@ -57,6 +94,9 @@ if ! command -v docker >/dev/null 2>&1; then
   echo "ERROR: docker is required before reconciling worker host invariants." >&2
   exit 1
 fi
+
+DEPLOY_MODE="$(resolve_deploy_mode)"
+export DEPLOY_MODE
 
 ensure_bridge() {
   local network="$1"


### PR DESCRIPTION
## Summary
- Pass worker deploy mode through a host-side handoff file before the sudo boundary
- Teach worker reconciliation to resolve deploy mode from the environment or a fresh handoff file
- Add a regression test covering the deploy and reconcile scripts

## Testing
- Added unit coverage for the deploy script and reconcile script behavior