### PR TITLE
Add Vitest coverage for landing drawP80 renderer branches

### DIFF
--- a/frontend/src/components/landing/draw-p80.test.ts
+++ b/frontend/src/components/landing/draw-p80.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from 'vitest';
+
+import { DARK, LIGHT, drawP80, drawP80Side } from './draw-p80';
+
+type RecordedCall = {
+  method: string;
+  args: unknown[];
+};
+
+type GradientStop = {
+  offset: number;
+  color: string;
+};
+
+function createRecordingCanvasContext() {
+  const calls: RecordedCall[] = [];
+  const gradientStops: GradientStop[] = [];
+
+  const record = (method: string) =>
+    (...args: unknown[]) => {
+      calls.push({ method, args });
+    };
+
+  const createGradient = (method: string) => (...args: unknown[]) => {
+    calls.push({ method, args });
+    return {
+      addColorStop(offset: number, color: string) {
+        gradientStops.push({ offset, color });
+        calls.push({ method: 'addColorStop', args: [offset, color] });
+      },
+    };
+  };
+
+  const context = new Proxy(
+    {},
+    {
+      get(_target, property) {
+        if (property === 'createLinearGradient' || property === 'createRadialGradient') {
+          return createGradient(String(property));
+        }
+        return record(String(property));
+      },
+      set(_target, property, value) {
+        calls.push({ method: `set:${String(property)}`, args: [value] });
+        return true;
+      },
+    },
+  ) as CanvasRenderingContext2D;
+
+  return { context, calls, gradientStops };
+}
+
+describe('drawP80', () => {
+  it('draws top-down and side-profile P-80 variants across option branches', () => {
+    const { context, calls, gradientStops } = createRecordingCanvasContext();
+
+    drawP80(context, 120, 80, 48, Math.PI / 5, 0.6, 0.85, DARK);
+    drawP80(context, 24, 32, 14, -Math.PI / 8, 0.9, 0.45, LIGHT);
+    drawP80Side(context, 180, 110, 72, Math.PI, 0.9, 0.08, {
+      gearDown: true,
+      perspective: 0.7,
+    });
+    drawP80Side(context, 80, 55, 42, 0, 0.55, -0.04, {
+      noShadow: true,
+      perspective: 0,
+    });
+
+    const methodNames = calls.map((call) => call.method);
+
+    expect(methodNames.filter((name) => name === 'save').length).toBeGreaterThanOrEqual(6);
+    expect(methodNames).toContain('scale');
+    expect(methodNames).toContain('roundRect');
+    expect(methodNames).toContain('createLinearGradient');
+    expect(methodNames).toContain('createRadialGradient');
+    expect(methodNames).toContain('fillText');
+    expect(
+      calls.some((call) => call.method === 'set:fillStyle' && call.args[0] === 'rgba(30, 32, 40, 0.8)'),
+    ).toBe(true);
+    expect(gradientStops.length).toBeGreaterThan(20);
+  });
+});


### PR DESCRIPTION
## Summary

Landing P-80 canvas rendering had a large untested surface area, risking regressions that would only show up visually in the browser. This change adds a focused Vitest that exercises the `drawP80`/`drawP80Side` rendering paths (including perspective, facing, no-shadow, and gear-down branches) using a recording canvas context, so we validate the drawing contract and key calls.

## Changes

- Added `frontend/src/components/landing/draw-p80.test.ts` with a recording `CanvasRenderingContext2D` proxy to capture drawing method calls.
- Covered top-down and side-profile P-80 branches by invoking `drawP80` and `drawP80Side` with multiple option combinations (DARK/LIGHT, perspective variations, facing-left, `noShadow`, `gearDown`).
- Asserted expected renderer behavior: save/transform usage (`scale`, `roundRect`), gradient creation (`createLinearGradient`/`createRadialGradient`), text rendering (`fillText`), and non-trivial gradient stop counts.

## Validation

- `npm run test:ci -- --coverage --coverage.reporter=json-summary --coverage.reporter=text`
- `npm run typecheck`
- `npm run lint`
- `npm run build`
- `npx vitest run src/components/landing/draw-p80.test.ts --reporter=dot`

Coverage after change cleared the minimum:
- `lines: 82.71%`
- `statements: 81.11%`

[143.dev](https://143.dev) | [session 29bd58df](https://143.dev/sessions/29bd58df-a86a-4de6-870d-5f181c76106e)

<!-- 143 readiness -->
**143 readiness:** not available for this revision.

Preview: https://143.dev/previews/github/assembledhq/143/pull/1630?launch=1