### PR TITLE
Hide untrusted fork prewarm and clarify preview warming/link publishing states

### DIFF
--- a/docs/design/implemented/103-session-preview-prewarm-policy.md
+++ b/docs/design/implemented/103-session-preview-prewarm-policy.md
@@ -330,9 +330,9 @@ State transitions (`warming → warm`, `warming → failed`) should emit through
 
 - Add a `Session prewarm` row under Preview settings for each repository.
 - Mode labels: `Off`, `Cache only`, `Smart`. (`Cache only` is clearer than `Cache` for admins scanning without helper copy.)
-- Fork policy: `Untrusted forks`, disabled unless speculative slots are configured. Default is off; enabling it is an explicit repo-level opt-in.
+- Fork prewarm remains off and is not exposed in the normal settings UI. Sessions derived from untrusted fork content should not be speculatively warmed unless a reviewed operator-only path explicitly allows it.
 - Pool setting: `Speculative preview slots`.
-- Helper copy: `Cache only warms dependencies before the user clicks Preview. Smart mode may also prepare a full preview when a session looks likely to need one. Speculative work yields to active sessions and user-started previews.`
+- Helper copy: `Cache only installs dependencies ahead of time without starting the app. Smart starts with cache warming and may prepare a full preview when a session looks likely to need one. Speculative work yields to active sessions and user-started previews.`
 - When `Speculative preview slots = 0`, disable the mode selector with inline text: `Set speculative preview slots above 0 to enable session prewarm.`
 - Repos already using `auto_mode = 'warm'` for PR auto-preview are natural candidates for `cache` mode. Consider surfacing an indicator in the settings list for these repos.
 

--- a/docs/design/implemented/99-previews-index-and-auto-preview-policy.md
+++ b/docs/design/implemented/99-previews-index-and-auto-preview-policy.md
@@ -180,6 +180,8 @@ Per-repository setting, admin-only, three modes:
 | `warm` | Build the preview, save the startup snapshot, then stop it ("hibernate") | Already stopped; resumes in ~30s from the PR link or index | Most repos: every PR link works fast, near-zero idle cost |
 | `on` | Build and leave running | Normal idle TTL applies; when reclaimed it degrades to warm (resumable), never to cold | Repos with active nontechnical reviewers who click PR links all day |
 
+Settings helper copy should make the distinction explicit: `Warm builds each PR preview, saves a resumable snapshot, then stops it. On builds each PR preview and keeps it running until normal idle limits reclaim it.`
+
 Key behaviors:
 
 - Triggered by GitHub PR `opened`, `reopened`, and `synchronize` (new head SHA) webhooks for PRs targeting the repository's default branch. Draft PRs are skipped in v1. Fork PRs are always skipped (secrets).
@@ -187,6 +189,7 @@ Key behaviors:
 - Auto-created previews draw from a **separate org-level pool** (`preview_auto_pool_max_active`), not the per-user quota, so a busy repo cannot exhaust a human's interactive previews — and vice versa. Warm builds queue at lower priority than user-initiated starts.
 - When the PR closes or merges, any active auto-preview is stopped and its target is excluded from the "Ready to resume" section (it still appears in Recent).
 - `on` mode is not staging: idle TTL and the 2h lifetime cap from [82-preview-lifetime-controls](../implemented/82-preview-lifetime-controls.md) still apply. The promise is "the PR link is always one fast click from a running app," not "a container is always burning."
+- When GitHub PR publishing is off, 143 may still create previews internally, but it will not publish preview URLs to GitHub PR comments or commit statuses.
 
 ### Settings Wireframe
 

--- a/frontend/src/app/(dashboard)/settings/previews/page.test.tsx
+++ b/frontend/src/app/(dashboard)/settings/previews/page.test.tsx
@@ -115,6 +115,60 @@ describe("PreviewSettingsPage", () => {
     });
   });
 
+  it("explains preview warming modes and GitHub PR publishing", async () => {
+    server.use(
+      http.get("*/api/v1/repositories", () => HttpResponse.json({ data: repos, meta: {} })),
+      http.get("*/api/v1/repositories/:id/preview-secret-bundles", () => HttpResponse.json({ data: [], meta: {} })),
+      http.get("*/api/v1/settings", () => HttpResponse.json({
+        data: {
+          id: "org-1",
+          name: "Assembled",
+          settings: { preview_auto_pool_max_active: 4, preview_session_prewarm_max_active: 2 },
+          created_at: "2026-01-01T00:00:00Z",
+          updated_at: "2026-01-01T00:00:00Z",
+        },
+      })),
+      http.get("*/api/v1/previews/policies", () => HttpResponse.json({
+        data: [
+          {
+            repository_id: "repo-1",
+            repository_full_name: "assembledhq/143",
+            auto_mode: "warm",
+            session_prewarm_mode: "smart",
+            session_prewarm_untrusted_fork: false,
+            open_pr_count: 5,
+            updated_at: "2026-06-08T12:00:00Z",
+          },
+        ],
+        meta: {},
+      })),
+    );
+
+    renderWithProviders(<PreviewSettingsPage />);
+
+    expect(
+      await screen.findByText(/Warm builds each PR preview, saves a resumable snapshot, then stops it/i),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/On builds each PR preview and keeps it running until normal idle limits reclaim it/i),
+    ).toBeInTheDocument();
+    expect(await screen.findByText("assembledhq/143")).toBeInTheDocument();
+    expect(
+      screen.getByText(/Cache only installs dependencies ahead of time without starting the app/i),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/Smart starts with cache warming and may prepare a full preview/i),
+    ).toBeInTheDocument();
+    expect(screen.queryByText("Forks")).not.toBeInTheDocument();
+    expect(screen.queryByText("Untrusted forks")).not.toBeInTheDocument();
+    expect(
+      screen.getByText("Not publishing preview links to GitHub PRs"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/When enabled, 143 publishes preview URLs to GitHub PR comments or commit statuses/i),
+    ).toBeInTheDocument();
+  });
+
   it("falls back to connected repositories when preview policies are empty", async () => {
     server.use(
       http.get("*/api/v1/repositories", () => HttpResponse.json({ data: repos, meta: {} })),
@@ -211,8 +265,7 @@ describe("PreviewSettingsPage", () => {
     });
   });
 
-  it("autosaves untrusted fork session prewarm policy when speculative slots are configured", async () => {
-    let savedPolicy: unknown;
+  it("does not expose untrusted fork session prewarm policy", async () => {
     server.use(
       http.get("*/api/v1/repositories", () => HttpResponse.json({ data: repos, meta: {} })),
       http.get("*/api/v1/repositories/:id/preview-secret-bundles", () => HttpResponse.json({ data: [], meta: {} })),
@@ -239,19 +292,14 @@ describe("PreviewSettingsPage", () => {
         ],
         meta: {},
       })),
-      http.put("*/api/v1/repositories/repo-1/preview-policy", async ({ request }) => {
-        savedPolicy = await request.json();
-        return HttpResponse.json({ data: { id: "policy-1", session_prewarm_untrusted_fork: true } });
-      }),
     );
 
     renderWithProviders(<PreviewSettingsPage />);
 
-    await userEvent.click(await screen.findByRole("switch", { name: /allow session prewarm for untrusted forks in assembledhq\/143/i }));
-
-    await waitFor(() => {
-      expect(savedPolicy).toEqual({ session_prewarm_untrusted_fork: true });
-    });
+    expect(await screen.findByText("assembledhq/143")).toBeInTheDocument();
+    expect(
+      screen.queryByRole("switch", { name: /allow session prewarm for untrusted forks/i }),
+    ).not.toBeInTheDocument();
   });
 
   it("groups each repository's build and publish controls in one stacked card", async () => {

--- a/frontend/src/app/(dashboard)/settings/previews/page.tsx
+++ b/frontend/src/app/(dashboard)/settings/previews/page.tsx
@@ -323,6 +323,11 @@ function AutoPreviewSection() {
           publish their links to GitHub. Warm mode hibernates after a successful
           build so the PR link resumes quickly.
         </p>
+        <p className="text-xs text-muted-foreground">
+          Warm builds each PR preview, saves a resumable snapshot, then stops it.
+          On builds each PR preview and keeps it running until normal idle limits
+          reclaim it.
+        </p>
       </div>
 
       {policiesLoading ? (
@@ -621,6 +626,11 @@ function RepoPreviewCard({
             <span className="block text-xs text-muted-foreground">
               Session prewarm
             </span>
+            <p className="text-xs text-muted-foreground">
+              Cache only installs dependencies ahead of time without starting
+              the app. Smart starts with cache warming and may prepare a full
+              preview when a session looks likely to need one.
+            </p>
             <ToggleGroup
               type="single"
               value={policy.session_prewarm_mode}
@@ -665,28 +675,6 @@ function RepoPreviewCard({
               </p>
             ) : null}
           </div>
-          <div className="space-y-1.5">
-            <span className="block text-xs text-muted-foreground">Forks</span>
-            <div className="flex items-center gap-2">
-              <Switch
-                checked={policy.session_prewarm_untrusted_fork}
-                disabled={!sessionPrewarmEnabled}
-                aria-label={`Allow session prewarm for untrusted forks in ${policy.repository_full_name}`}
-                onCheckedChange={(checked) => {
-                  if (
-                    checked === policy.session_prewarm_untrusted_fork ||
-                    !sessionPrewarmEnabled
-                  ) {
-                    return;
-                  }
-                  onUpdatePolicy({ session_prewarm_untrusted_fork: checked });
-                }}
-              />
-              <span className="text-xs text-muted-foreground">
-                Untrusted forks
-              </span>
-            </div>
-          </div>
         </div>
 
         <div className="space-y-3 md:border-l md:border-border md:pl-4">
@@ -706,7 +694,7 @@ function RepoPreviewCard({
           ) : null}
           <div className="flex items-center gap-2">
             <Switch
-              aria-label={`Enable PR preview links for ${policy.repository_full_name}`}
+              aria-label={`Publish preview links to GitHub PRs for ${policy.repository_full_name}`}
               checked={policy.pr_preview_surfaces_enabled}
               disabled={!canEnable && !policy.pr_preview_surfaces_enabled}
               onCheckedChange={(checked) =>
@@ -715,10 +703,15 @@ function RepoPreviewCard({
             />
             <span className="text-xs text-muted-foreground">
               {policy.pr_preview_surfaces_enabled
-                ? "Links enabled"
-                : "Links disabled"}
+                ? "Publishing preview links to GitHub PRs"
+                : "Not publishing preview links to GitHub PRs"}
             </span>
           </div>
+          <p className="text-xs text-muted-foreground">
+            When enabled, 143 publishes preview URLs to GitHub PR comments or
+            commit statuses. Auto-build can still create previews internally
+            when publishing is off.
+          </p>
           <div className="space-y-1.5">
             <span className="block text-xs text-muted-foreground">Surfaces</span>
             <div className="flex flex-wrap gap-3">


### PR DESCRIPTION
## Summary

Untrusted fork content should not be speculatively warmed via the normal admin workflow, but the UI/design previously left room for confusion. This change removes the untrusted fork prewarm control from Preview settings UI (policy remains backend-supported only via a reviewed operator-only path) and updates copy/state labels so admins understand whether the system is building previews vs publishing preview links to GitHub.

## Changes

- **Preview settings UI:** Removed the “untrusted forks” prewarm option from the normal settings surface; fork prewarm is now **off/not exposed** except for a controlled operator-only path.
- **Design docs/copy:** Clarified “Cache only” vs “Smart” semantics and updated helper copy to state clearly what is being warmed/started.
- **PR publishing states:** Renamed publishing state labels to be explicit about **publishing preview links to GitHub PRs** vs not publishing them (decoupling internal preview creation from GitHub link/status publishing).

## Validation

- Frontend focused tests for preview settings behavior passed
- `npm run typecheck`
- `npm run lint`
- `npm run build`

[143.dev](https://143.dev) | [session 71e8eab8](https://143.dev/sessions/71e8eab8-b286-4f83-aa44-c98b2e16a2ea)

<!-- 143 readiness -->
**143 readiness:** not available for this revision.

Preview: https://143.dev/previews/github/assembledhq/143/pull/1632?launch=1