### PR TITLE
Handle slow session context expansion failures

### DIFF
--- a/frontend/src/components/code-review/context-expander.test.tsx
+++ b/frontend/src/components/code-review/context-expander.test.tsx
@@ -382,7 +382,54 @@ describe("ContextExpander", () => {
     expect(onContextUnavailable).toHaveBeenCalledTimes(1);
   });
 
-  it("does not call onContextUnavailable on non-NO_SANDBOX errors", async () => {
+  it("calls onContextUnavailable on SNAPSHOT_UNREADABLE response", async () => {
+    const onContextUnavailable = vi.fn();
+    vi.mocked(api.sessions.getFileContext).mockRejectedValue(
+      new ApiError("SNAPSHOT_UNREADABLE", "session snapshot exists but cannot be read")
+    );
+
+    const user = userEvent.setup();
+    render(
+      <ContextExpander
+        kind="middle"
+        hiddenLineCount={4}
+        sessionId="s1"
+        filePath="f.ts"
+        hiddenStart={1}
+        hiddenEnd={4}
+        onExpand={vi.fn()}
+        onContextUnavailable={onContextUnavailable}
+      />
+    );
+
+    await user.click(screen.getByRole("button", { name: "Reveal context above" }));
+    expect(onContextUnavailable).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls onContextUnavailable when context loading times out", async () => {
+    const onContextUnavailable = vi.fn();
+    const abortError = new DOMException("The operation was aborted.", "AbortError");
+    vi.mocked(api.sessions.getFileContext).mockRejectedValue(abortError);
+
+    const user = userEvent.setup();
+    render(
+      <ContextExpander
+        kind="middle"
+        hiddenLineCount={4}
+        sessionId="s1"
+        filePath="f.ts"
+        hiddenStart={1}
+        hiddenEnd={4}
+        onExpand={vi.fn()}
+        onContextUnavailable={onContextUnavailable}
+      />
+    );
+
+    await user.click(screen.getByRole("button", { name: "Reveal context above" }));
+    expect(onContextUnavailable).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not call onContextUnavailable on unrelated API errors", async () => {
     const onContextUnavailable = vi.fn();
     vi.mocked(api.sessions.getFileContext).mockRejectedValue(
       new ApiError("INTERNAL", "boom")

--- a/frontend/src/components/code-review/context-expander.tsx
+++ b/frontend/src/components/code-review/context-expander.tsx
@@ -44,6 +44,15 @@ interface ContextExpanderProps {
   onContextUnavailable?: () => void;
 }
 
+const UNAVAILABLE_CONTEXT_ERROR_CODES = new Set(["NO_SANDBOX", "SNAPSHOT_UNREADABLE"]);
+
+function isContextUnavailableError(err: unknown): boolean {
+  if (err instanceof ApiError && UNAVAILABLE_CONTEXT_ERROR_CODES.has(err.code)) {
+    return true;
+  }
+  return err instanceof DOMException && err.name === "AbortError";
+}
+
 /**
  * Clickable expander shown between diff hunks to indicate hidden context lines.
  * Fetches additional context from the file content API when clicked.
@@ -144,10 +153,11 @@ export function ContextExpander({
         });
       }
     } catch (err) {
-      // The session container is gone (completed sessions tear down their
-      // sandbox). Lift this signal so all expanders flip to the disabled
-      // state instead of silently swallowing repeated clicks.
-      if (err instanceof ApiError && err.code === "NO_SANDBOX") {
+      // Additional context is an optional affordance. If the backing
+      // workspace is unavailable, unreadable, or too slow to answer, flip
+      // every expander into the disabled state instead of letting repeated
+      // clicks wait on the same failing path.
+      if (isContextUnavailableError(err)) {
         onContextUnavailable?.();
       }
     } finally {

--- a/frontend/src/lib/api.test.ts
+++ b/frontend/src/lib/api.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, afterEach } from 'vitest';
+import { describe, it, expect, afterEach, vi } from 'vitest';
 import { server } from '@/test/mocks/server';
 import { http, HttpResponse } from 'msw';
 import { api } from './api';
@@ -374,6 +374,49 @@ describe('api client', () => {
       const result = await api.sessions.get('session-abc');
       expect(result.data.id).toBe('session-abc');
       expect(result.data.status).toBe('running');
+    });
+
+    it('bounds session file context requests with a short abort timeout', async () => {
+      vi.useFakeTimers();
+      const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation((_input, init) => {
+        const signal = init?.signal as AbortSignal | undefined;
+        if (!signal) {
+          return Promise.resolve(new Response(JSON.stringify({
+            data: {
+              lines: [],
+              start_line: 0,
+              end_line: 0,
+              has_more_above: false,
+              has_more_below: false,
+              total_lines: 0,
+            },
+          }), { status: 200 }));
+        }
+        return new Promise<Response>((_resolve, reject) => {
+          signal.addEventListener('abort', () => {
+            reject(new DOMException('The operation was aborted.', 'AbortError'));
+          });
+        });
+      });
+
+      try {
+        const request = api.sessions.getFileContext('session-abc', 'src/app.ts', 10, 0, 19);
+        const caughtRequest = request.catch((err: unknown) => err);
+        const signal = fetchSpy.mock.calls[0]?.[1]?.signal as AbortSignal | undefined;
+
+        expect(signal).toBeInstanceOf(AbortSignal);
+        expect(signal?.aborted).toBe(false);
+
+        await vi.advanceTimersByTimeAsync(1_999);
+        expect(signal?.aborted).toBe(false);
+
+        await vi.advanceTimersByTimeAsync(1);
+        expect(signal?.aborted).toBe(true);
+        await expect(caughtRequest).resolves.toMatchObject({ name: 'AbortError' });
+      } finally {
+        fetchSpy.mockRestore();
+        vi.useRealTimers();
+      }
     });
 
     it('fetches session log detail by log id', async () => {

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -661,11 +661,14 @@ export const api = {
     },
     getFileContent: (sessionId: string, path: string) =>
       get<import('./types').SingleResponse<import('./types').FileContent>>(`/api/v1/sessions/${sessionId}/files/content?path=${encodeURIComponent(path)}`),
-    getFileContext: (sessionId: string, path: string, line: number, above?: number, below?: number) => {
+    getFileContext: (sessionId: string, path: string, line: number, above?: number, below?: number, opts?: { signal?: AbortSignal; timeoutMs?: number }) => {
       const params = new URLSearchParams({ path, line: String(line) });
       if (above != null) params.set('above', String(above));
       if (below != null) params.set('below', String(below));
-      return get<import('./types').SingleResponse<import('./types').FileContextResponse>>(`/api/v1/sessions/${sessionId}/files/context?${params.toString()}`);
+      return get<import('./types').SingleResponse<import('./types').FileContextResponse>>(
+        `/api/v1/sessions/${sessionId}/files/context?${params.toString()}`,
+        { signal: timeoutSignal(opts?.timeoutMs ?? 2000, opts?.signal) },
+      );
     },
     preview: {
       get: (sessionId: string) =>


### PR DESCRIPTION
## Summary
- Treat unreadable snapshots and abort timeouts as unavailable context in code review expanders
- Add a short abort timeout to session file context requests
- Cover the new unavailable-context cases with unit tests

## Testing
- Added unit tests for `ContextExpander` error handling
- Added unit tests for session file context request timeout behavior