### PR TITLE
Block no-checkpoint recovery while thread runtime is active

### DIFF
--- a/internal/db/session_executor_store.go
+++ b/internal/db/session_executor_store.go
@@ -37,7 +37,7 @@ func (s *SessionExecutorStore) ClearPreHandoffReservation(ctx context.Context, o
 		WHERE se.org_id = $1
 		  AND se.session_id = $2
 		  AND se.job_id = $3
-		  AND se.status IN ('starting', 'running', 'draining')
+		  AND se.status = 'starting'
 		  AND j.org_id = se.org_id
 		  AND j.id = se.job_id
 		  AND j.status = 'running'
@@ -272,9 +272,6 @@ func (s *SessionExecutorStore) MarkHumanInputCheckpointByJob(ctx context.Context
 			drain_requested_at = COALESCE(drain_requested_at, now()),
 			updated_at = now()
 		FROM sessions sess
-		LEFT JOIN session_threads th
-		  ON th.org_id = se.org_id
-		 AND th.id = se.thread_id
 		WHERE se.org_id = $1
 		  AND se.job_id = $2
 		  AND se.lock_token = $3
@@ -284,7 +281,13 @@ func (s *SessionExecutorStore) MarkHumanInputCheckpointByJob(ctx context.Context
 		  AND se.drain_intent IN ('none', 'planned_rollout')
 		  AND (
 			sess.status = 'awaiting_input'
-			OR th.status = 'awaiting_input'
+			OR EXISTS (
+				SELECT 1
+				FROM session_threads th
+				WHERE th.org_id = se.org_id
+				  AND th.id = se.thread_id
+				  AND th.status = 'awaiting_input'
+			)
 		  )`, orgID, jobID, lockToken)
 	if err != nil {
 		return false, fmt.Errorf("mark human input checkpoint executor: %w", err)

--- a/internal/db/session_executor_store_test.go
+++ b/internal/db/session_executor_store_test.go
@@ -71,6 +71,28 @@ func TestSessionExecutorStore_ClearPreHandoffReservation(t *testing.T) {
 	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
 }
 
+func TestSessionExecutorStore_ClearPreHandoffReservationOnlyTargetsStartingRows(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "should create mock pool")
+	defer mock.Close()
+
+	store := NewSessionExecutorStore(mock)
+	orgID := uuid.New()
+	sessionID := uuid.New()
+	jobID := uuid.New()
+
+	mock.ExpectExec("UPDATE session_executors se[\\s\\S]+AND se.status = 'starting'[\\s\\S]+AND j.owner_kind = 'worker'").
+		WithArgs(orgID, sessionID, jobID).
+		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
+
+	cleared, err := store.ClearPreHandoffReservation(context.Background(), orgID, sessionID, jobID)
+	require.NoError(t, err, "ClearPreHandoffReservation should clear only pre-handoff starting rows")
+	require.Equal(t, int64(1), cleared, "ClearPreHandoffReservation should report cleared starting rows")
+	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
+}
+
 func TestJobStore_HandoffToSessionExecutorWithLease(t *testing.T) {
 	t.Parallel()
 
@@ -343,6 +365,28 @@ func TestSessionExecutorStore_MarkDeployBudgetExpiredByNodeSkipsAlreadyMarkedExe
 	updated, err := store.MarkDeployBudgetExpiredByNode(context.Background(), "worker-1", now, 45*time.Second)
 	require.NoError(t, err, "MarkDeployBudgetExpiredByNode should not error when every expired executor was already marked")
 	require.Equal(t, int64(0), updated, "MarkDeployBudgetExpiredByNode should return zero once budget expiry has already been recorded")
+	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
+}
+
+func TestSessionExecutorStore_MarkHumanInputCheckpointByJobUsesValidThreadLookup(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "should create mock pool")
+	defer mock.Close()
+
+	store := NewSessionExecutorStore(mock)
+	orgID := uuid.New()
+	jobID := uuid.New()
+	lockToken := uuid.New()
+
+	mock.ExpectExec("UPDATE session_executors se[\\s\\S]+EXISTS \\([\\s\\S]+FROM session_threads th[\\s\\S]+th.org_id = se.org_id[\\s\\S]+th.id = se.thread_id[\\s\\S]+th.status = 'awaiting_input'[\\s\\S]+\\)").
+		WithArgs(orgID, jobID, lockToken).
+		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
+
+	marked, err := store.MarkHumanInputCheckpointByJob(context.Background(), orgID, jobID, lockToken)
+	require.NoError(t, err, "MarkHumanInputCheckpointByJob should use SQL that PostgreSQL can parse")
+	require.True(t, marked, "MarkHumanInputCheckpointByJob should report marked executors")
 	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
 }
 

--- a/internal/db/session_store.go
+++ b/internal/db/session_store.go
@@ -2058,13 +2058,22 @@ func (s *SessionStore) UpdateWorkspaceSnapshot(ctx context.Context, orgID, sessi
 		    diff_collected_at = COALESCE(@diff_collected_at, diff_collected_at)
 		WHERE id = @id AND org_id = @org_id`
 
+	var diff any
+	var baseCommitSHA any
+	var diffCollectedAt any
+	if result != nil {
+		diff = result.Diff
+		baseCommitSHA = result.DiffBaseCommitSHA
+		diffCollectedAt = result.DiffCollectedAt
+	}
+
 	_, err := s.db.Exec(ctx, query, pgx.NamedArgs{
 		"id":                sessionID,
 		"org_id":            orgID,
 		"snapshot_key":      snapshotKey,
-		"diff":              result.Diff,
-		"base_commit_sha":   result.DiffBaseCommitSHA,
-		"diff_collected_at": result.DiffCollectedAt,
+		"diff":              diff,
+		"base_commit_sha":   baseCommitSHA,
+		"diff_collected_at": diffCollectedAt,
 	})
 	return err
 }

--- a/internal/db/session_store_test.go
+++ b/internal/db/session_store_test.go
@@ -753,6 +753,36 @@ func TestSessionStore_PublishCheckpoint_BumpsWorkspaceRevisionForSnapshot(t *tes
 	require.NoError(t, mock.ExpectationsWereMet(), "expectations should be met")
 }
 
+func TestSessionStore_UpdateWorkspaceSnapshotAllowsNilResult(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "should create mock pool")
+	defer mock.Close()
+
+	store := NewSessionStore(mock)
+	orgID := uuid.New()
+	sessionID := uuid.New()
+	snapshotKey := "snapshots/org/session/interrupted.tar.zst"
+
+	mock.ExpectExec("UPDATE sessions[\\s\\S]+snapshot_key = @snapshot_key[\\s\\S]+diff = COALESCE\\(@diff, diff\\)").
+		WithArgs(pgx.NamedArgs{
+			"id":                sessionID,
+			"org_id":            orgID,
+			"snapshot_key":      snapshotKey,
+			"diff":              nil,
+			"base_commit_sha":   nil,
+			"diff_collected_at": nil,
+		}).
+		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
+
+	require.NotPanics(t, func() {
+		err = store.UpdateWorkspaceSnapshot(context.Background(), orgID, sessionID, snapshotKey, nil)
+	}, "UpdateWorkspaceSnapshot should allow interrupted-session snapshot updates without diff metadata")
+	require.NoError(t, err, "UpdateWorkspaceSnapshot should persist the snapshot when result metadata is nil")
+	require.NoError(t, mock.ExpectationsWereMet(), "expectations should be met")
+}
+
 func TestSessionStore_BumpWorkspaceRevision(t *testing.T) {
 	t.Parallel()
 

--- a/internal/services/agent/orchestrator.go
+++ b/internal/services/agent/orchestrator.go
@@ -1398,6 +1398,11 @@ func (o *Orchestrator) RecoverSession(ctx context.Context, session *models.Sessi
 		Str("org_id", session.OrgID.String()).
 		Logger()
 	checkpoint, ok := latestDurableCheckpoint(session)
+	if !ok {
+		if err := o.blockNoCheckpointRecoveryWhenThreadRuntimeActive(ctx, session, log); err != nil {
+			return err
+		}
+	}
 	if !ok && session.RecoveryAttemptCount >= maxNoCheckpointRecoveryAttempts {
 		errMsg := "Session recovery stopped after repeated worker interruptions before any durable checkpoint was available."
 		explanation := "The platform tried to recover this session multiple times, but each recovery would have restarted the first turn from scratch because no checkpoint had been saved yet. The session was stopped to avoid repeating the same work indefinitely."
@@ -1462,6 +1467,28 @@ func (o *Orchestrator) RecoverSession(ctx context.Context, session *models.Sessi
 	event.Msg("recovering session from latest durable checkpoint")
 
 	return o.ContinueSession(ctx, session, nil)
+}
+
+func (o *Orchestrator) blockNoCheckpointRecoveryWhenThreadRuntimeActive(ctx context.Context, session *models.Session, log zerolog.Logger) error {
+	if o.threadRuntimes == nil || session == nil || session.PrimaryThreadID == nil || *session.PrimaryThreadID == uuid.Nil {
+		return nil
+	}
+	runtime, err := o.threadRuntimes.GetActiveByThread(ctx, session.OrgID, *session.PrimaryThreadID)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil
+		}
+		return fmt.Errorf("check active thread runtime before no-checkpoint recovery: %w", err)
+	}
+	if runtime.SessionID != session.ID {
+		return fmt.Errorf("active thread runtime session mismatch before no-checkpoint recovery: runtime session %s != session %s", runtime.SessionID, session.ID)
+	}
+	log.Info().
+		Str("thread_id", session.PrimaryThreadID.String()).
+		Str("runtime_id", runtime.ID.String()).
+		Str("owner_node_id", runtime.OwnerNodeID).
+		Msg("no-checkpoint recovery deferred because thread runtime is still active")
+	return fmt.Errorf("%w: active thread runtime %s still owns thread %s", ErrThreadRuntimeAlreadyActive, runtime.ID, *session.PrimaryThreadID)
 }
 
 func (o *Orchestrator) beginRuntimeControl(ctx context.Context, controller *runtimeController, orgID, sessionID uuid.UUID, fallbackStatus models.SessionStatus, capability models.CheckpointCapability, startedAt time.Time, log zerolog.Logger) error {

--- a/internal/services/agent/orchestrator_test.go
+++ b/internal/services/agent/orchestrator_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/require"
 
+	"github.com/assembledhq/143/internal/db"
 	"github.com/assembledhq/143/internal/jobctx"
 	"github.com/assembledhq/143/internal/models"
 	"github.com/assembledhq/143/internal/services/agent"
@@ -1322,6 +1323,7 @@ type testDeps struct {
 	identityResolver *identity.Resolver
 	sandboxAuth      agent.SandboxAuthServer
 	sandboxCapacity  *agent.SandboxCapacityGate
+	threadRuntimes   agent.ThreadRuntimeStore
 	staticEgress     agent.StaticEgressRuntimeConfig
 	users            agent.UserLookup
 	logger           *zerolog.Logger
@@ -1403,6 +1405,40 @@ func (m *mockSessionThreadStore) completedTurns() []struct {
 	}, len(m.completeTurnCalls))
 	copy(out, m.completeTurnCalls)
 	return out
+}
+
+type activeRuntimeConflictStore struct {
+	active      models.ThreadRuntime
+	createCalls []db.CreateThreadRuntimeParams
+}
+
+func (s *activeRuntimeConflictStore) CreateStarting(_ context.Context, _ uuid.UUID, params db.CreateThreadRuntimeParams) (models.ThreadRuntime, error) {
+	s.createCalls = append(s.createCalls, params)
+	return models.ThreadRuntime{}, db.ErrActiveThreadRuntimeExists
+}
+
+func (s *activeRuntimeConflictStore) GetActiveByThread(context.Context, uuid.UUID, uuid.UUID) (models.ThreadRuntime, error) {
+	return s.active, nil
+}
+
+func (s *activeRuntimeConflictStore) MarkLiveWithLease(context.Context, uuid.UUID, uuid.UUID, uuid.UUID, string, time.Duration) (bool, error) {
+	return true, nil
+}
+
+func (s *activeRuntimeConflictStore) HeartbeatWithLease(context.Context, uuid.UUID, uuid.UUID, uuid.UUID, time.Duration) (bool, error) {
+	return true, nil
+}
+
+func (s *activeRuntimeConflictStore) AdvanceDeliveryWithLease(context.Context, uuid.UUID, uuid.UUID, uuid.UUID, int64, int64) (bool, error) {
+	return true, nil
+}
+
+func (s *activeRuntimeConflictStore) CommitInboxDeliveryWithLease(context.Context, uuid.UUID, uuid.UUID, uuid.UUID, uuid.UUID, string, int64, int64) (bool, error) {
+	return true, nil
+}
+
+func (s *activeRuntimeConflictStore) MarkTerminalWithLease(context.Context, uuid.UUID, uuid.UUID, uuid.UUID, models.ThreadRuntimeStatus, string, string) (bool, error) {
+	return true, nil
 }
 
 func defaultDeps() testDeps {
@@ -1530,6 +1566,7 @@ func buildOrchestrator(d testDeps) *agent.Orchestrator {
 		IdentityResolver:   d.identityResolver,
 		SandboxAuth:        d.sandboxAuth,
 		SandboxCapacity:    d.sandboxCapacity,
+		ThreadRuntimes:     d.threadRuntimes,
 		StaticEgress:       d.staticEgress,
 		Users:              d.users,
 		NodeID:             d.nodeID,
@@ -2159,6 +2196,48 @@ func TestRecoverSession_FailsAfterRepeatedNoCheckpointRecovery(t *testing.T) {
 	require.Empty(t, d.sessions.getTurnUpdates(), "exhausted recovery should not advance the turn")
 	require.Empty(t, d.sessions.getCheckpointUpdates(), "exhausted recovery should not publish checkpoint metadata")
 	require.Equal(t, []models.ThreadStatus{models.ThreadStatusFailed}, d.sessionThreads.statuses(), "exhausted recovery should fail the active thread so the UI does not stay stuck")
+}
+
+func TestRecoverSession_DoesNotConsumeNoCheckpointAttemptWhenThreadRuntimeIsStillActive(t *testing.T) {
+	t.Parallel()
+
+	orgID := testOrg()
+	issue := testIssue(orgID)
+	run := testRun(orgID, issue.ID)
+	threadID := uuid.New()
+	run.Status = models.SessionStatusRunning
+	run.PrimaryThreadID = &threadID
+	run.RecoveryAttemptCount = 2
+
+	runtimes := &activeRuntimeConflictStore{
+		active: models.ThreadRuntime{
+			ID:          uuid.New(),
+			OrgID:       orgID,
+			SessionID:   run.ID,
+			ThreadID:    threadID,
+			Status:      models.ThreadRuntimeStatusLive,
+			OwnerNodeID: "worker-live",
+			LeaseToken:  uuid.New(),
+		},
+	}
+	d := defaultDeps()
+	d.threadRuntimes = runtimes
+	d.adapter.executeFn = func(context.Context, *agent.Sandbox, *agent.AgentPrompt, chan<- agent.LogEntry) (*agent.AgentResult, error) {
+		t.Fatal("RecoverSession should not restart from scratch while the thread runtime is still active")
+		return nil, nil
+	}
+
+	err := buildOrchestrator(d).RecoverSession(context.Background(), run)
+	require.Error(t, err, "RecoverSession should surface active runtime conflicts as retryable errors")
+	require.ErrorIs(t, err, agent.ErrThreadRuntimeAlreadyActive, "active runtime conflicts should not be classified as recovery exhaustion")
+	require.Empty(t, runtimes.createCalls, "RecoverSession should not create another runtime when a live one already exists")
+
+	d.sessions.mu.Lock()
+	recoveryStates := append([]recoveryStateUpdate(nil), d.sessions.recoveryStates...)
+	d.sessions.mu.Unlock()
+	for _, update := range recoveryStates {
+		require.False(t, update.incrementAttempt, "active runtime conflict should not consume no-checkpoint recovery attempts")
+	}
 }
 
 func TestRecoverSession_RestartsWithoutCountingOwnRunningSlot(t *testing.T) {


### PR DESCRIPTION
## Summary
- Tighten session executor cleanup and human-input checkpoint SQL to match the intended row set and valid thread lookup semantics.
- Allow workspace snapshot updates when diff metadata is unavailable.
- Defer no-checkpoint session recovery when the primary thread still has an active runtime, and avoid counting that as a failed recovery attempt.
- Add unit coverage for the SQL changes, nil snapshot metadata, and active-runtime recovery behavior.

## Testing
- Added unit tests for session executor and session store behavior.
- Added orchestrator unit coverage for the active thread runtime recovery guard.