### PR TITLE
Update sandbox runtime session timeout default to 60 minutes

### DIFF
--- a/docs/design/future/60-agent-runtime-timeouts-and-checkpointed-shutdown.md
+++ b/docs/design/future/60-agent-runtime-timeouts-and-checkpointed-shutdown.md
@@ -6,13 +6,13 @@
 
 ## Summary
 
-143 should keep the current `25 minute` default as a **shared-infrastructure soft
+143 should keep the current `60 minute` default as a **shared-infrastructure soft
 budget**, but it should stop treating that number as the only kill switch for a
 coding session.
 
 The product contract should become:
 
-1. A coding session gets a default runtime budget of 25 minutes.
+1. A coding session gets a default runtime budget of 60 minutes.
 2. If the agent is still making meaningful progress near that budget, the
    system may extend the run within policy rather than killing it immediately.
 3. When the platform does need to stop a run, it first attempts a **graceful,
@@ -36,7 +36,7 @@ The current system has a useful but incomplete timeout model.
 
 What exists today:
 
-- org settings default `max_session_duration_seconds` to 25 minutes
+- org settings default `max_session_duration_seconds` to 60 minutes
 - worker handlers wrap `run_agent` and `continue_session` in
   `session timeout + cleanup buffer`
 - completed turns are snapshotted and persisted
@@ -54,7 +54,7 @@ What is still wrong:
 - resume fidelity is uneven across agents
 - the user-facing contract is not explicit about what survives interruption
 
-That means `25 minutes` is currently serving two jobs badly:
+That means `60 minutes` is currently serving two jobs badly:
 
 1. protecting shared capacity
 2. deciding when a run should die
@@ -65,7 +65,7 @@ These should be separate concerns.
 
 ### Current defaults
 
-- Default per-session timeout: `25 minutes`
+- Default per-session timeout: `60 minutes`
 - Current org-level minimum: `2 minutes`
 - Current org-level maximum: `2 hours`
 - Worker handler cleanup buffer: `2 minutes`
@@ -97,7 +97,7 @@ That is operationally safe, but it is not a good coding-agent experience.
 
 This design should satisfy seven guarantees:
 
-1. **Soft default, not arbitrary kill.** `25 minutes` remains the default
+1. **Soft default, not arbitrary kill.** `60 minutes` remains the default
    budget, not the only control.
 2. **Progress-aware execution.** A healthy long-running session should be
    extendable within policy.
@@ -173,7 +173,7 @@ The correct escalation order is:
 
 Recommended defaults:
 
-- **Soft runtime budget:** 25 minutes
+- **Soft runtime budget:** 60 minutes
 - **No-progress timeout:** 15 minutes without meaningful progress
 - **Graceful shutdown window:** 30 seconds
 - **Checkpoint finalization window:** 30 seconds
@@ -181,7 +181,7 @@ Recommended defaults:
 
 Rationale:
 
-- 25 minutes is still a good default threshold for "this run is getting long"
+- 60 minutes is the default threshold for "this run is getting long"
 - 15 minutes of no output/tool activity is a better stuckness signal than raw
   wall clock
 - 90 minutes is long enough for legitimately heavy repo work, but still bounded
@@ -772,7 +772,7 @@ Recommended derived metrics:
 
 The recommended product decision is:
 
-- keep `25 minutes` as the default soft runtime budget
+- keep `60 minutes` as the default soft runtime budget
 - do not use that number as the only kill condition
 - stop long-running sessions with a graceful, checkpoint-first path
 - extend healthy runs within policy

--- a/frontend/src/app/(dashboard)/settings/runtime/page.test.tsx
+++ b/frontend/src/app/(dashboard)/settings/runtime/page.test.tsx
@@ -191,6 +191,29 @@ describe("RuntimeSettingsPage", () => {
     ).toBeInTheDocument();
   });
 
+  it("defaults the maximum session length to one hour when unset", async () => {
+    settingsGetMock.mockResolvedValueOnce({
+      data: {
+        id: "org-1",
+        name: "Test Org",
+        settings: {
+          max_concurrent_runs: 5,
+          preview_max_previews_per_user: 7,
+        },
+        created_at: "2026-05-01T12:00:00Z",
+        updated_at: "2026-05-01T12:00:00Z",
+      },
+    });
+
+    renderWithProviders(<RuntimeSettingsPage />);
+
+    expect(await screen.findByText("1 hour")).toBeInTheDocument();
+
+    await openSessionLifecycleControls();
+
+    expect(screen.getByLabelText("Maximum session length")).toHaveValue(60);
+  });
+
   it("uses concise visible helper copy with question mark tooltips for caveats", async () => {
     renderWithProviders(<RuntimeSettingsPage />);
 

--- a/frontend/src/app/(dashboard)/settings/runtime/page.tsx
+++ b/frontend/src/app/(dashboard)/settings/runtime/page.tsx
@@ -77,7 +77,7 @@ import type {
 
 const DEFAULT_EXECUTION_SETTINGS = {
   max_concurrent_runs: 5,
-  max_session_duration_seconds: 25 * 60,
+  max_session_duration_seconds: 60 * 60,
 };
 
 const CPU_MILLIS_PER_CORE = 1000;

--- a/internal/models/org_settings.go
+++ b/internal/models/org_settings.go
@@ -600,9 +600,9 @@ const (
 	DefaultWeightRevenueRisk    = 0.20
 
 	// DefaultMaxSessionDurationSeconds is the default per-session wall-clock
-	// timeout (25 minutes). Long enough for non-trivial agent runs, short
+	// timeout (60 minutes). Long enough for non-trivial agent runs, short
 	// enough that stuck sessions don't silently eat capacity.
-	DefaultMaxSessionDurationSeconds = 25 * 60
+	DefaultMaxSessionDurationSeconds = 60 * 60
 
 	// MinMaxSessionDurationSeconds is the smallest sensible per-org timeout.
 	// Values below this produce very short runs that are unlikely to complete

--- a/internal/models/org_settings_test.go
+++ b/internal/models/org_settings_test.go
@@ -462,6 +462,7 @@ func TestParseOrgSettings_MaxSessionDuration_Default(t *testing.T) {
 	s, err := ParseOrgSettings(nil)
 	require.NoError(t, err)
 	require.Equal(t, DefaultMaxSessionDurationSeconds, s.MaxSessionDurationSeconds, "unset should default")
+	require.Equal(t, 60*60, s.MaxSessionDurationSeconds, "unset max session duration should default to one hour")
 }
 
 func TestParseOrgSettings_MaxSessionDuration_Zero(t *testing.T) {
@@ -470,6 +471,7 @@ func TestParseOrgSettings_MaxSessionDuration_Zero(t *testing.T) {
 	s, err := ParseOrgSettings(json.RawMessage(`{"max_session_duration_seconds":0}`))
 	require.NoError(t, err)
 	require.Equal(t, DefaultMaxSessionDurationSeconds, s.MaxSessionDurationSeconds, "zero should default")
+	require.Equal(t, 60*60, s.MaxSessionDurationSeconds, "zero max session duration should default to one hour")
 }
 
 func TestParseOrgSettings_MaxSessionDuration_ClampsBelowMin(t *testing.T) {

--- a/internal/services/agent/adapter.go
+++ b/internal/services/agent/adapter.go
@@ -451,7 +451,7 @@ type ExecStreamOptions struct {
 // DefaultSandboxTimeout is the default maximum wall-clock duration for an
 // agent execution inside a sandbox. Org admins can override this per-org via
 // OrgSettings.MaxSessionDurationSeconds.
-const DefaultSandboxTimeout = 25 * time.Minute
+const DefaultSandboxTimeout = time.Hour
 
 // HandlerCleanupBuffer is the slack added on top of the resolved session
 // timeout at the worker handler boundary, giving the orchestrator time to

--- a/internal/services/agent/runtime_test.go
+++ b/internal/services/agent/runtime_test.go
@@ -311,6 +311,7 @@ func TestResolveRuntimeConfig_UsesDefaultsAndOrgOverrides(t *testing.T) {
 
 		cfg := (&Orchestrator{}).resolveRuntimeConfig(context.Background(), orgID)
 		require.Equal(t, defaultCfg, cfg, "resolveRuntimeConfig should return defaults when no org store is configured")
+		require.Equal(t, time.Hour, cfg.SoftBudget, "default runtime soft budget should be one hour")
 	})
 
 	t.Run("defaults on org lookup error", func(t *testing.T) {


### PR DESCRIPTION
## Summary

Sandbox coding sessions were using a 25-minute default runtime budget, which created an unnecessary user workflow friction for longer legitimate work. This change updates the product/runtime contract to use a 60-minute default soft budget (and aligns UI fallback and tests) so sessions have a more reasonable out-of-the-box window without removing progress-aware/soft shutdown behavior.

## Changes

- Updated backend org settings default `DefaultMaxSessionDurationSeconds` from 25 min to 60 min.
- Updated sandbox fallback timeout to `time.Hour`, and aligned runtime settings UI fallback default to `60 * 60`.
- Updated tests to assert the one-hour defaults and reflect the new runtime timeout behavior.
- Refreshed the runtime/timeout design doc to document the 60-minute default contract.

## Validation

- `go vet ./...`
- `go build ./...`
- `go test ./internal/models ./internal/services/agent`
- `npm run typecheck`
- `npm run lint`
- `npm run build`
- `npm run test:ci -- src/app/(dashboard)/settings/runtime/page.test.tsx` (focused frontend test)

[143.dev](https://143.dev) | [session 1785157b](https://143.dev/sessions/1785157b-4983-4e44-9c88-494c3857bea5)

<!-- 143 readiness -->
**143 readiness:** not available for this revision.

Preview: https://143.dev/previews/github/assembledhq/143/pull/1641?launch=1