### PR TITLE
Remove the Start work action from Slack session acknowledgements

### DIFF
--- a/internal/worker/handlers.go
+++ b/internal/worker/handlers.go
@@ -2345,7 +2345,7 @@ func newSlackStartOrContinueSessionHandler(stores *Stores, services *Services, l
 					ackText = strings.TrimSpace(ackText) + "\n\n" + teamLine
 				}
 				ackChannelID, ackThreadTS := slackDeliveryTarget(ctx, stores, slackClient, slackCfg.AccessToken, logger, existingLink, threadTS)
-				ackBlocks := slackSessionAckBlocks(ctx, stores, services, logger, orgID, installationID, payload.TeamID, payload.ChannelID, &session, ackText, slackbotsvc.SlackSessionContextSummary{}, routingMode, routingMode == slackbotsvc.SlackRoutingModeAnswerOnly)
+				ackBlocks := slackSessionAckBlocks(ctx, stores, services, logger, orgID, installationID, payload.TeamID, payload.ChannelID, &session, ackText, slackbotsvc.SlackSessionContextSummary{}, routingMode)
 				posted, postErr := postSlackMessageWithFallback(ctx, slackClient, stores, services, logger, existingLink, slackCfg.AccessToken, ackChannelID, ackThreadTS, ackText, ackBlocks, models.SlackOutboundMessageKindAck)
 				if postErr != nil {
 					logger.Warn().Err(postErr).Str("session_id", session.ID.String()).Msg("failed to post Slack continuation acknowledgement")
@@ -2475,7 +2475,7 @@ func newSlackStartOrContinueSessionHandler(stores *Stores, services *Services, l
 		if teamLine := slackTeamSessionLine(*link); teamLine != "" {
 			ackText = strings.TrimSpace(ackText) + "\n\n" + teamLine
 		}
-		ackBlocks := slackSessionAckBlocks(ctx, stores, services, logger, orgID, installationID, payload.TeamID, payload.ChannelID, session, ackText, resolvedContext.ContextSummary, resolvedContext.RoutingMode, resolvedContext.RoutingMode == slackbotsvc.SlackRoutingModeAnswerOnly)
+		ackBlocks := slackSessionAckBlocks(ctx, stores, services, logger, orgID, installationID, payload.TeamID, payload.ChannelID, session, ackText, resolvedContext.ContextSummary, resolvedContext.RoutingMode)
 		ackChannelID, ackThreadTS := slackDeliveryTarget(ctx, stores, slackClient, slackCfg.AccessToken, logger, *link, threadTS)
 		posted, postErr := postSlackMessageWithFallback(ctx, slackClient, stores, services, logger, *link, slackCfg.AccessToken, ackChannelID, ackThreadTS, ackText, ackBlocks, models.SlackOutboundMessageKindAck)
 		if postErr != nil {
@@ -6896,7 +6896,7 @@ func slackSessionAckText(services *Services, sessionID uuid.UUID, verb string) s
 	}).Text
 }
 
-func slackSessionAckBlocks(ctx context.Context, stores *Stores, services *Services, logger zerolog.Logger, orgID, installationID uuid.UUID, teamID, channelID string, session *models.Session, text string, contextSummary slackbotsvc.SlackSessionContextSummary, routingMode slackbotsvc.SlackRoutingMode, showStartWorkAction bool) []ingestion.SlackBlock {
+func slackSessionAckBlocks(ctx context.Context, stores *Stores, services *Services, logger zerolog.Logger, orgID, installationID uuid.UUID, teamID, channelID string, session *models.Session, text string, contextSummary slackbotsvc.SlackSessionContextSummary, routingMode slackbotsvc.SlackRoutingMode) []ingestion.SlackBlock {
 	var sessionID uuid.UUID
 	if session != nil {
 		sessionID = session.ID
@@ -6928,16 +6928,6 @@ func slackSessionAckBlocks(ctx context.Context, stores *Stores, services *Servic
 				"channel_id": channelID,
 			}),
 		})
-		if showStartWorkAction {
-			actions = append(actions, slackbotsvc.SlackAction{
-				Text:     "Start work",
-				ActionID: "slack_start_work",
-				Value: slackActionValue(map[string]string{
-					"session_id": session.ID.String(),
-					"org_id":     orgID.String(),
-				}),
-			})
-		}
 		for _, missing := range contextSummary.Missing {
 			switch missing.Kind {
 			case "preview_target":

--- a/internal/worker/handlers_test.go
+++ b/internal/worker/handlers_test.go
@@ -893,14 +893,12 @@ func TestSlackSessionAckBlocksIncludeCorrectionActions(t *testing.T) {
 			},
 		},
 		slackbotsvc.SlackRoutingModeAnswerOnly,
-		true,
 	)
 
 	require.True(t, slackBlocksContainAction(blocks, "slack_configure_channel"), "ack should let users correct channel repository defaults")
-	require.True(t, slackBlocksContainAction(blocks, "slack_start_work"), "answer-only ack should let users escalate into durable work")
+	require.False(t, slackBlocksContainAction(blocks, "slack_start_work"), "ack should not show start-work escalation while the session is already running")
 	require.True(t, slackBlocksContainAction(blocks, "slack_choose_preview_target"), "ack should offer a preview target selector when preview context is missing")
 	require.True(t, slackBlocksContainAction(blocks, "slack_choose_pull_request"), "ack should offer a PR selector when PR context is missing")
-	require.Contains(t, slackBlocksActionValue(blocks, "slack_start_work"), orgID.String(), "start-work action should carry org scope")
 }
 
 func TestSlackSessionAckBlocksHideStartWorkWhenWorkAlreadyQueued(t *testing.T) {
@@ -925,7 +923,6 @@ func TestSlackSessionAckBlocksHideStartWorkWhenWorkAlreadyQueued(t *testing.T) {
 			Branch:         "main",
 		},
 		slackbotsvc.SlackRoutingModeStartWork,
-		false,
 	)
 
 	require.True(t, slackBlocksContainAction(blocks, "slack_configure_channel"), "ack should still let users correct channel repository defaults")
@@ -955,7 +952,6 @@ func TestSlackSessionAckBlocksSuppressStartWorkForAutoRouting(t *testing.T) {
 			Branch:         "main",
 		},
 		slackbotsvc.SlackRoutingModeAuto,
-		false,
 	)
 
 	require.False(t, slackBlocksContainAction(blocks, "slack_start_work"), "auto-routed Slack acks should not show a Start work escalation while the session is already running")


### PR DESCRIPTION
## Summary
- Remove the `Start work` button from Slack session acknowledgement blocks
- Keep ack actions focused on correction and context-selection flows
- Update tests to reflect that running sessions no longer expose a start-work escalation

## Testing
- Updated unit tests for Slack ack block rendering to verify the action is omitted across routing modes