### PR TITLE
Update Slack final responses in place

### DIFF
--- a/internal/worker/handlers.go
+++ b/internal/worker/handlers.go
@@ -3086,6 +3086,11 @@ type slackMessagePoster interface {
 	PostMessageWithBlocks(ctx context.Context, accessToken, channelID, threadTS, text string, blocks []ingestion.SlackBlock) (ingestion.SlackPostedMessage, error)
 }
 
+type slackMessageUpdater interface {
+	UpdateMessage(ctx context.Context, accessToken, channelID, messageTS, text string) error
+	UpdateMessageWithBlocks(ctx context.Context, accessToken, channelID, messageTS, text string, blocks []ingestion.SlackBlock) error
+}
+
 type slackReactionAdder interface {
 	AddReaction(ctx context.Context, accessToken, channelID, messageTS, name string) error
 }
@@ -3151,6 +3156,37 @@ func postSlackMessageWithFallback(ctx context.Context, poster slackMessagePoster
 	}
 	recordSlackOutboundInChannel(ctx, stores, services, logger, link, channelID, fallbackPosted.Timestamp, kind, "sent_fallback", text)
 	return fallbackPosted, nil
+}
+
+func updateSlackMessageWithPostFallback(ctx context.Context, poster slackMessagePoster, updater slackMessageUpdater, stores *Stores, services *Services, logger zerolog.Logger, link models.SlackSessionLink, accessToken, channelID, threadTS, messageTS, text string, blocks []ingestion.SlackBlock, kind models.SlackOutboundMessageKind) (ingestion.SlackPostedMessage, error) {
+	if updater == nil || strings.TrimSpace(messageTS) == "" {
+		return postSlackMessageWithFallback(ctx, poster, stores, services, logger, link, accessToken, channelID, threadTS, text, blocks, kind)
+	}
+	if len(blocks) == 0 {
+		if err := updater.UpdateMessage(ctx, accessToken, channelID, messageTS, text); err != nil {
+			recordSlackOutboundInChannel(ctx, stores, services, logger, link, channelID, slackSyntheticMessageTS(kind, "failed_update"), kind, "failed_update", text)
+			logger.Warn().Err(err).Str("session_id", link.SessionID.String()).Msg("failed to update Slack message; posting a new message")
+			return postSlackMessageWithFallback(ctx, poster, stores, services, logger, link, accessToken, channelID, threadTS, text, blocks, kind)
+		}
+		recordSlackOutboundInChannel(ctx, stores, services, logger, link, channelID, messageTS, kind, "sent", text)
+		return ingestion.SlackPostedMessage{Channel: channelID, Timestamp: messageTS}, nil
+	}
+	if err := updater.UpdateMessageWithBlocks(ctx, accessToken, channelID, messageTS, text, blocks); err == nil {
+		recordSlackOutboundInChannel(ctx, stores, services, logger, link, channelID, messageTS, kind, "sent", text)
+		return ingestion.SlackPostedMessage{Channel: channelID, Timestamp: messageTS}, nil
+	} else if !slackIsInvalidBlocksError(err) {
+		recordSlackOutboundInChannel(ctx, stores, services, logger, link, channelID, slackSyntheticMessageTS(kind, "failed_update"), kind, "failed_update", text)
+		logger.Warn().Err(err).Str("session_id", link.SessionID.String()).Msg("failed to update Slack message; posting a new message")
+		return postSlackMessageWithFallback(ctx, poster, stores, services, logger, link, accessToken, channelID, threadTS, text, blocks, kind)
+	}
+	recordSlackOutboundInChannel(ctx, stores, services, logger, link, channelID, slackSyntheticMessageTS(kind, "failed_update_invalid_blocks"), kind, "failed_update_invalid_blocks", text)
+	if err := updater.UpdateMessage(ctx, accessToken, channelID, messageTS, text); err != nil {
+		recordSlackOutboundInChannel(ctx, stores, services, logger, link, channelID, slackSyntheticMessageTS(kind, "failed_update_fallback"), kind, "failed_update_fallback", text)
+		logger.Warn().Err(err).Str("session_id", link.SessionID.String()).Msg("failed to update Slack message without blocks; posting a new message")
+		return postSlackMessageWithFallback(ctx, poster, stores, services, logger, link, accessToken, channelID, threadTS, text, nil, kind)
+	}
+	recordSlackOutboundInChannel(ctx, stores, services, logger, link, channelID, messageTS, kind, "sent_update_fallback", text)
+	return ingestion.SlackPostedMessage{Channel: channelID, Timestamp: messageTS}, nil
 }
 
 func slackIsInvalidBlocksError(err error) bool {
@@ -3312,26 +3348,18 @@ func newSlackPostFinalResponseHandler(stores *Stores, services *Services, logger
 		}
 		text, blocks := renderSlackFinalBlocks(services, msg.Content, orgID, sessionID, link, details)
 		channelID, threadTS := slackDeliveryTarget(ctx, stores, slackClient, slackCfg.AccessToken, logger, link, slackReplyThreadTS(link.SlackThreadTS))
+		messageTS := ""
 		if link.LatestStatusMessageTS != nil && *link.LatestStatusMessageTS != "" {
-			terminal := slackbotsvc.RenderSessionStatus(slackbotsvc.SlackSessionRenderInput{
-				Session:    models.Session{ID: sessionID},
-				Link:       link,
-				State:      slackbotsvc.SessionLifecycleComplete,
-				SessionURL: slackSessionURL(services, sessionID),
-			})
-			updateStarted := time.Now()
-			if err := slackClient.UpdateMessageWithBlocks(ctx, slackCfg.AccessToken, channelID, *link.LatestStatusMessageTS, terminal.Text, terminal.Blocks); err != nil {
-				recordSlackMessageUpdateLatency(ctx, services, "chat.update", "failed", time.Since(updateStarted))
-				logger.Warn().Err(err).Str("session_id", sessionID.String()).Msg("failed to update Slack progress message to terminal state")
-			} else {
-				recordSlackMessageUpdateLatency(ctx, services, "chat.update", "sent", time.Since(updateStarted))
-				recordSlackOutboundInChannel(ctx, stores, services, logger, link, channelID, *link.LatestStatusMessageTS, models.SlackOutboundMessageKindProgress, "sent", terminal.Text)
-			}
+			messageTS = *link.LatestStatusMessageTS
 		}
-		posted, err := postSlackMessageWithFallback(ctx, slackClient, stores, services, logger, link, slackCfg.AccessToken, channelID, threadTS, text, blocks, models.SlackOutboundMessageKindFinal)
+		updateStarted := time.Now()
+		posted, err := updateSlackMessageWithPostFallback(ctx, slackClient, slackClient, stores, services, logger, link, slackCfg.AccessToken, channelID, threadTS, messageTS, text, blocks, models.SlackOutboundMessageKindFinal)
 		if err != nil {
 			recordSlackAPIFailure(ctx, services, "chat.postMessage")
 			return err
+		}
+		if messageTS != "" && posted.Timestamp == messageTS {
+			recordSlackMessageUpdateLatency(ctx, services, "chat.update", "sent", time.Since(updateStarted))
 		}
 		if stores.SlackSessionLinks != nil {
 			if updateErr := stores.SlackSessionLinks.SetFinalMessageTS(ctx, orgID, sessionID, posted.Timestamp); updateErr != nil {

--- a/internal/worker/handlers_test.go
+++ b/internal/worker/handlers_test.go
@@ -1226,6 +1226,111 @@ func TestPostSlackMessageWithFallback_InvalidBlocksRetriesPlainTextAndRecordsFal
 	require.NoError(t, mock.ExpectationsWereMet(), "helper should record failed block and fallback delivery attempts")
 }
 
+func TestUpdateSlackMessageWithPostFallback(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name                string
+		messageTS           string
+		blocksErr           error
+		updateTextErr       error
+		expectedTS          string
+		expectedBlockCalls  int
+		expectedUpdateCalls int
+		expectedBlockPosts  int
+		expectedTextPosts   int
+	}{
+		{
+			name:                "updates existing status message with final blocks",
+			messageTS:           "1700000000.000100",
+			expectedTS:          "1700000000.000100",
+			expectedBlockCalls:  1,
+			expectedUpdateCalls: 0,
+			expectedBlockPosts:  0,
+			expectedTextPosts:   0,
+		},
+		{
+			name:                "falls back to posting when no status message timestamp exists",
+			messageTS:           "",
+			expectedTS:          "1700000000.000200",
+			expectedBlockCalls:  0,
+			expectedUpdateCalls: 0,
+			expectedBlockPosts:  1,
+			expectedTextPosts:   0,
+		},
+		{
+			name:                "retries update as plain text when Slack rejects blocks",
+			messageTS:           "1700000000.000100",
+			blocksErr:           errors.New("slack chat.update: invalid_blocks"),
+			expectedTS:          "1700000000.000100",
+			expectedBlockCalls:  1,
+			expectedUpdateCalls: 1,
+			expectedBlockPosts:  0,
+			expectedTextPosts:   0,
+		},
+		{
+			name:                "posts a new message when both block and plain text updates fail",
+			messageTS:           "1700000000.000100",
+			blocksErr:           errors.New("slack chat.update: invalid_blocks"),
+			updateTextErr:       errors.New("slack chat.update: message_not_found"),
+			expectedTS:          "1700000000.000200",
+			expectedBlockCalls:  1,
+			expectedUpdateCalls: 1,
+			expectedBlockPosts:  0,
+			expectedTextPosts:   1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			link := models.SlackSessionLink{
+				ID:             uuid.New(),
+				OrgID:          uuid.New(),
+				SessionID:      uuid.New(),
+				SlackTeamID:    "T123",
+				SlackChannelID: "C123",
+				SlackThreadTS:  "1700000000.000050",
+				SlackRootTS:    "1700000000.000050",
+				SlackUserID:    "U123",
+				CreatedAt:      time.Now(),
+				UpdatedAt:      time.Now(),
+			}
+			client := &fakeSlackMessagePoster{
+				updateBlocksErr: tt.blocksErr,
+				updateTextErr:   tt.updateTextErr,
+				blocksPosted:    ingestion.SlackPostedMessage{Channel: "C123", Timestamp: "1700000000.000200"},
+				textPosted:      ingestion.SlackPostedMessage{Channel: "C123", Timestamp: "1700000000.000200"},
+			}
+
+			posted, err := updateSlackMessageWithPostFallback(
+				context.Background(),
+				client,
+				client,
+				nil,
+				&Services{},
+				zerolog.Nop(),
+				link,
+				"xoxb-token",
+				"C123",
+				"1700000000.000050",
+				tt.messageTS,
+				"Final response",
+				[]ingestion.SlackBlock{{Type: "section", Text: &ingestion.SlackTextObject{Type: "mrkdwn", Text: "*Final response*"}}},
+				models.SlackOutboundMessageKindFinal,
+			)
+
+			require.NoError(t, err, "update helper should deliver the final Slack message")
+			require.Equal(t, tt.expectedTS, posted.Timestamp, "update helper should return the delivered Slack timestamp")
+			require.Equal(t, tt.expectedBlockCalls, client.updateBlockCalls, "update helper should call block update the expected number of times")
+			require.Equal(t, tt.expectedUpdateCalls, client.updateTextCalls, "update helper should call plain-text update the expected number of times")
+			require.Equal(t, tt.expectedBlockPosts, client.blockCalls, "update helper should post with blocks only when update cannot be used")
+			require.Equal(t, tt.expectedTextPosts, client.textCalls, "update helper should post plain text only when update fallback cannot be used")
+		})
+	}
+}
+
 func TestEnqueueSlackFinalIfLinkedEnqueuesFinalResponseForAssistantMessage(t *testing.T) {
 	t.Parallel()
 
@@ -2640,12 +2745,16 @@ func workerAnyArgs(n int) []interface{} {
 }
 
 type fakeSlackMessagePoster struct {
-	blocksErr    error
-	textErr      error
-	blocksPosted ingestion.SlackPostedMessage
-	textPosted   ingestion.SlackPostedMessage
-	blockCalls   int
-	textCalls    int
+	blocksErr        error
+	textErr          error
+	updateBlocksErr  error
+	updateTextErr    error
+	blocksPosted     ingestion.SlackPostedMessage
+	textPosted       ingestion.SlackPostedMessage
+	blockCalls       int
+	textCalls        int
+	updateBlockCalls int
+	updateTextCalls  int
 }
 
 type fakeSlackReactionAdder struct {
@@ -2680,6 +2789,16 @@ func (f *fakeSlackMessagePoster) PostMessageWithBlocks(_ context.Context, _, _, 
 		return ingestion.SlackPostedMessage{}, f.blocksErr
 	}
 	return f.blocksPosted, nil
+}
+
+func (f *fakeSlackMessagePoster) UpdateMessage(_ context.Context, _, _, _, _ string) error {
+	f.updateTextCalls++
+	return f.updateTextErr
+}
+
+func (f *fakeSlackMessagePoster) UpdateMessageWithBlocks(_ context.Context, _, _, _, _ string, _ []ingestion.SlackBlock) error {
+	f.updateBlockCalls++
+	return f.updateBlocksErr
 }
 
 func expectSlackOutboundUpsert(t *testing.T, mock pgxmock.PgxPoolIface, orgID, linkID uuid.UUID, teamID, channelID string, kind models.SlackOutboundMessageKind, status string) {


### PR DESCRIPTION
## Summary
- Add a Slack message update helper that prefers `chat.update` and falls back to posting when updates fail
- Use the existing status message timestamp when finishing a session so the final response replaces the progress message when possible
- Record update outcomes and add unit coverage for update, fallback, and invalid-block paths

## Testing
- Added unit tests for the new Slack update fallback helper
- Verified the worker handler behavior with updated fake Slack client coverage