### PR TITLE
Harden worker deploy helpers against sandbox network collisions

### DIFF
--- a/deploy/deploy_config_test.go
+++ b/deploy/deploy_config_test.go
@@ -765,7 +765,9 @@ func TestWorkerDeployControlHelpersAvoidSandboxNetworks(t *testing.T) {
 	require.Contains(t, deployText, `docker run --rm -i \
             --network 143_default`, "detached drain monitors should also keep deploy-control helpers off sandbox networks")
 	require.Contains(t, listWorkers, `Label "com.docker.compose.project"`, "worker generation discovery should inspect compose project labels")
-	require.Contains(t, listWorkers, `/^143-worker-/`, "worker generation discovery should exclude compose-run deploy-control helpers")
+	require.Contains(t, listWorkers, `{{.Names}}`, "worker discovery should inspect container names to distinguish compose-run helpers from real default-project workers")
+	require.Contains(t, listWorkers, `$3 ~ /^143-worker-/`, "worker generation discovery should include blue/green worker projects")
+	require.Contains(t, listWorkers, `$3 == "143" && $2 !~ /^143-worker-run-/`, "worker generation discovery should include fresh default-project workers while excluding compose-run deploy-control helpers")
 
 	reconcileScript, err := os.ReadFile("../deploy/scripts/reconcile-worker-host.sh")
 	require.NoError(t, err, "test should read reconcile-worker-host.sh")
@@ -1173,6 +1175,7 @@ func TestWorkerSpinDownScriptDrainsBeforeClearingHost(t *testing.T) {
 	text := string(script)
 
 	require.Contains(t, text, "docker kill --signal=TERM", "worker spin-down should request worker drain before stopping support services")
+	require.Contains(t, text, `$3 == "143" && $2 !~ /^143-worker-run-/`, "worker spin-down should drain fresh default-project workers while excluding compose-run deploy-control helpers")
 	require.Contains(t, text, "wait_for_stopped \"worker\" \"$WORKER_DRAIN_TIMEOUT_SECONDS\"", "worker spin-down should bound the worker drain with the drain timeout")
 	require.Contains(t, text, "docker stop -t \"$EXECUTOR_DRAIN_TIMEOUT_SECONDS\"", "worker spin-down should bound the executor drain with Docker's stop timeout")
 	require.Contains(t, text, "label=com.143.role=session-executor", "worker spin-down should include durable session executor containers in cleanup")

--- a/deploy/deploy_config_test.go
+++ b/deploy/deploy_config_test.go
@@ -742,10 +742,36 @@ func TestMaintenanceWorkerSupportServiceRecreateRetriesSandboxDNSAddressConflict
 	require.Contains(t, clearFn, "143-sandbox 172.30.0.2", "worker maintenance cleanup should clear the default sandbox DNS pinned IP")
 	require.Contains(t, clearFn, "143-sandbox-static-egress 172.31.0.2", "worker maintenance cleanup should clear the static-egress sandbox DNS pinned IP")
 	require.Contains(t, clearFn, "name=143-worker-run-", "worker maintenance cleanup should remove stale deploy-control run containers that can leave endpoints behind")
+	require.Contains(t, clearFn, `Label "com.docker.compose.project"`, "worker maintenance cleanup should distinguish compose deploy-control helpers from user sandbox containers")
+	require.Contains(t, clearFn, `docker rm -f`, "worker maintenance cleanup should force-remove deploy-control helpers that are racing the pinned DNS IP")
 	require.Contains(t, deployText, "recreate_worker_other_services", "maintenance worker deploy should use the retrying support-service recreate path")
 	require.Contains(t, deployText, `recreate_other_services "api frontend caddy"`, "generic recreate helper should remain available for non-worker paths")
 	require.NotContains(t, deployText, `echo "Updating supporting services for ${DEPLOY_MODE:-maintenance} worker deploy..."
       recreate_other_services "$HEALTH_SERVICE"`, "maintenance worker deploy should not use the generic no-retry recreate path")
+}
+
+func TestWorkerDeployControlHelpersAvoidSandboxNetworks(t *testing.T) {
+	t.Parallel()
+
+	deployScript, err := os.ReadFile("../deploy/scripts/deploy.sh")
+	require.NoError(t, err, "test should read deploy.sh")
+	deployText := string(deployScript)
+	runDeployctl := extractShellFunction(t, deployText, "run_worker_deployctl", "wait_worker_db_heartbeat")
+	listWorkers := extractShellFunction(t, deployText, "list_running_worker_containers", "worker_container_node_id")
+
+	require.Contains(t, runDeployctl, `docker run --rm -i`, "deploy-control helpers should run as plain containers instead of compose service runs")
+	require.Contains(t, runDeployctl, `--network 143_default`, "deploy-control helpers should attach only to the default network")
+	require.NotContains(t, runDeployctl, `docker compose -f "$COMPOSE_FILE" run`, "deploy-control helpers must not inherit the worker service sandbox networks")
+	require.Contains(t, deployText, `docker run --rm -i \
+            --network 143_default`, "detached drain monitors should also keep deploy-control helpers off sandbox networks")
+	require.Contains(t, listWorkers, `Label "com.docker.compose.project"`, "worker generation discovery should inspect compose project labels")
+	require.Contains(t, listWorkers, `/^143-worker-/`, "worker generation discovery should exclude compose-run deploy-control helpers")
+
+	reconcileScript, err := os.ReadFile("../deploy/scripts/reconcile-worker-host.sh")
+	require.NoError(t, err, "test should read reconcile-worker-host.sh")
+	reconcileText := string(reconcileScript)
+	require.Contains(t, reconcileText, `Label "com.docker.compose.project"`, "worker reconciliation should identify old compose-run deploy-control helpers")
+	require.Contains(t, reconcileText, `docker rm -f`, "worker reconciliation should remove old deploy-control helpers before starting sandbox-dns")
 }
 
 func TestWorkerDeployUsesBlueGreenGenerations(t *testing.T) {
@@ -2037,12 +2063,13 @@ func TestDeployPrunesDockerArtifactsAfterSuccessfulRollout(t *testing.T) {
 	deployScript, err := os.ReadFile("../deploy/scripts/deploy.sh")
 	require.NoError(t, err, "test should read deploy script")
 	deployText := string(deployScript)
+	pruneFn := extractShellFunction(t, deployText, "prune_docker_deploy_artifacts", "run_worker_session_deploy_guardrail")
 
 	require.Contains(t, deployText, "prune_docker_deploy_artifacts()", "deploy.sh should define one prune helper so app, worker, and detached worker paths stay aligned")
-	require.Contains(t, deployText, `docker container prune -f --filter "until=$prune_until"`, "deploy prune should remove stopped containers after a successful rollout")
-	require.NotContains(t, deployText, `docker rm -f`, "deploy prune must not force-remove running executor containers")
-	require.Contains(t, deployText, `docker image prune -af --filter "until=$prune_until"`, "deploy prune should remove old unused SHA-tagged images after a successful rollout")
-	require.Contains(t, deployText, `docker builder prune -af --filter "until=$prune_until"`, "deploy prune should remove unused build cache after a successful rollout")
+	require.Contains(t, pruneFn, `docker container prune -f --filter "until=$prune_until"`, "deploy prune should remove stopped containers after a successful rollout")
+	require.NotContains(t, pruneFn, `docker rm -f`, "deploy prune must not force-remove running executor containers")
+	require.Contains(t, pruneFn, `docker image prune -af --filter "until=$prune_until"`, "deploy prune should remove old unused SHA-tagged images after a successful rollout")
+	require.Contains(t, pruneFn, `docker builder prune -af --filter "until=$prune_until"`, "deploy prune should remove unused build cache after a successful rollout")
 	require.Contains(t, deployText, `$(remote_env_assignment DEPLOY_DOCKER_PRUNE "${DEPLOY_DOCKER_PRUNE:-1}")`, "deploy should pass the prune enable/disable knob through SSH to the remote host")
 	require.Contains(t, deployText, `$(remote_env_assignment DOCKER_PRUNE_UNTIL "${DOCKER_PRUNE_UNTIL:-24h}")`, "deploy should pass the prune age window through SSH to the remote host")
 	require.Contains(t, deployText, `$(remote_env_assignment SESSION_EXECUTOR_DOCKER_NETWORK "${SESSION_EXECUTOR_DOCKER_NETWORK:-}")`, "deploy should pass the executor network override through SSH to the remote host")

--- a/deploy/scripts/deploy.sh
+++ b/deploy/scripts/deploy.sh
@@ -943,13 +943,11 @@ ssh "${SSH_OPTS[@]}" deploy@"$HOST" \
 
     stale="$(docker ps -a \
       --filter 'name=143-worker-run-' \
-      --filter 'status=exited' \
-      --filter 'status=created' \
-      --filter 'status=dead' \
-      --format '{{.ID}}' 2>/dev/null || true)"
+      --format '{{.ID}} {{.Label "com.docker.compose.project"}} {{.Label "com.docker.compose.service"}}' 2>/dev/null \
+      | awk '$2 == "143" && $3 == "worker" {print $1}' || true)"
     if [ -n "$stale" ]; then
       echo "Removing stale worker deploy control containers..." >&2
-      printf '%s\n' "$stale" | xargs -r docker rm >/dev/null 2>&1 || true
+      printf '%s\n' "$stale" | xargs -r docker rm -f >/dev/null 2>&1 || true
     fi
   }
 
@@ -1531,13 +1529,32 @@ ssh "${SSH_OPTS[@]}" deploy@"$HOST" \
   }
 
   list_running_worker_containers() {
-    docker ps --filter "label=com.docker.compose.service=worker" --format '{{.ID}}'
+    docker ps \
+      --filter "label=com.docker.compose.service=worker" \
+      --format '{{.ID}} {{.Label "com.docker.compose.project"}}' \
+      | awk '$2 ~ /^143-worker-/ {print $1}'
   }
 
   worker_container_node_id() {
     local cid="$1"
     docker inspect --format '{{range .Config.Env}}{{println .}}{{end}}' "$cid" 2>/dev/null \
       | awk -F= '$1=="NODE_ID"{print $2; exit}'
+  }
+
+  worker_database_url() {
+    local db_host db_password pool_max_conns
+    db_host="$(read_worker_env_value DB_HOST)"
+    db_password="$(read_worker_env_value DB_PASSWORD)"
+    pool_max_conns="$(read_worker_env_value WORKER_DATABASE_POOL_MAX_CONNS)"
+    if [ -z "$pool_max_conns" ]; then
+      pool_max_conns=4
+    fi
+    if [ -z "$db_host" ] || [ -z "$db_password" ]; then
+      echo "ERROR: DB_HOST and DB_PASSWORD must be present in /opt/143/.env for deploy-control helpers." >&2
+      return 1
+    fi
+    printf 'postgres://onefortythree:%s@%s:5432/onefortythree?sslmode=disable&pool_max_conns=%s' \
+      "$db_password" "$db_host" "$pool_max_conns"
   }
 
   first_running_worker_node_id() {
@@ -1556,9 +1573,16 @@ ssh "${SSH_OPTS[@]}" deploy@"$HOST" \
   }
 
   run_worker_deployctl() {
-    docker compose -f "$COMPOSE_FILE" run --rm -T --no-deps \
+    local database_url
+    database_url="$(worker_database_url)"
+    docker run --rm -i \
+      --network 143_default \
+      --env-file /opt/143/.env \
+      -e "DATABASE_URL=$database_url" \
       -e "IMAGE_TAG=${IMAGE_TAG:-}" \
-      "$HEALTH_SERVICE" /bin/worker-deployctl "$@" < /dev/null
+      -v /opt/143/.env.production.enc:/app/.env.production.enc:ro \
+      "ghcr.io/assembledhq/143-server:${IMAGE_TAG:-latest}" \
+      /bin/worker-deployctl "$@" < /dev/null
   }
 
   wait_worker_db_heartbeat() {
@@ -1963,9 +1987,26 @@ SELECT COUNT(*) FROM endpoint_blockers;"
           exit 0
         fi
         run_ctl() {
-          docker compose -f "$compose_file" run --rm -T --no-deps \
+          local db_host db_password pool_max_conns database_url
+          db_host="$(awk -F= "\$1 == \"DB_HOST\" {sub(/^[^=]*=/, \"\"); print; exit}" /opt/143/.env)"
+          db_password="$(awk -F= "\$1 == \"DB_PASSWORD\" {sub(/^[^=]*=/, \"\"); print; exit}" /opt/143/.env)"
+          pool_max_conns="$(awk -F= "\$1 == \"WORKER_DATABASE_POOL_MAX_CONNS\" {sub(/^[^=]*=/, \"\"); print; exit}" /opt/143/.env)"
+          if [ -z "$pool_max_conns" ]; then
+            pool_max_conns=4
+          fi
+          if [ -z "$db_host" ] || [ -z "$db_password" ]; then
+            echo "ERROR: DB_HOST and DB_PASSWORD must be present in /opt/143/.env for deploy-control helpers." >&2
+            return 1
+          fi
+          database_url="postgres://onefortythree:${db_password}@${db_host}:5432/onefortythree?sslmode=disable&pool_max_conns=${pool_max_conns}"
+          docker run --rm -i \
+            --network 143_default \
+            --env-file /opt/143/.env \
+            -e "DATABASE_URL=$database_url" \
             -e "IMAGE_TAG=$build_sha" \
-            "$health_service" /bin/worker-deployctl "$@" < /dev/null
+            -v /opt/143/.env.production.enc:/app/.env.production.enc:ro \
+            "ghcr.io/assembledhq/143-server:${build_sha:-latest}" \
+            /bin/worker-deployctl "$@" < /dev/null
         }
         while true; do
           if ! docker inspect --format "{{.State.Running}}" "$cid" 2>/dev/null | grep -q true; then
@@ -2142,10 +2183,17 @@ SELECT COUNT(*) FROM endpoint_blockers;"
     if [ "$ROLE" != "worker" ]; then
       return 0
     fi
+    local database_url
+    database_url="$(worker_database_url)"
     echo "Checking active long-running sessions before worker deploy..."
-    docker compose -f "$COMPOSE_FILE" run --rm -T --no-deps \
+    docker run --rm -i \
+      --network 143_default \
+      --env-file /opt/143/.env \
+      -e "DATABASE_URL=$database_url" \
       -e "FORCE_DEPLOY_WITH_ACTIVE_SESSIONS=${FORCE_DEPLOY_WITH_ACTIVE_SESSIONS:-}" \
-      "$HEALTH_SERVICE" /bin/deploy-guardrail worker-sessions < /dev/null
+      -v /opt/143/.env.production.enc:/app/.env.production.enc:ro \
+      "ghcr.io/assembledhq/143-server:${IMAGE_TAG:-latest}" \
+      /bin/deploy-guardrail worker-sessions < /dev/null
   }
 
   # wait_container_healthy CONTAINER_ID TIMEOUT — poll until a specific container
@@ -2374,7 +2422,7 @@ SELECT COUNT(*) FROM endpoint_blockers;"
       cat > "$rollover_script" <<EOS
 #!/bin/bash
 set -euo pipefail
-$(declare -f resolve_worker_drain_timeout_seconds drain_worker_service drain_worker_containers_blocking read_worker_env_value load_worker_endpoint_check_env sanitize_compose_project list_running_worker_containers worker_container_node_id first_running_worker_node_id run_worker_deployctl wait_worker_db_heartbeat worker_port_in_use worker_runtime_endpoint_in_use worker_blue_green_extra_ports_configured worker_host_capacity_preflight fingerprint_files compose_service_fingerprint worker_process_config_fingerprint worker_support_service_fingerprint worker_host_runtime_fingerprint worker_docker_daemon_fingerprint ensure_routine_worker_fingerprints_compatible worker_expected_schema_version protect_active_executor_images find_free_worker_port start_worker_generation drain_old_worker_containers deploy_worker_blue_green wait_container_healthy dump_diagnostics prune_docker_deploy_artifacts)
+$(declare -f resolve_worker_drain_timeout_seconds drain_worker_service drain_worker_containers_blocking read_worker_env_value load_worker_endpoint_check_env sanitize_compose_project list_running_worker_containers worker_container_node_id worker_database_url first_running_worker_node_id run_worker_deployctl wait_worker_db_heartbeat worker_port_in_use worker_runtime_endpoint_in_use worker_blue_green_extra_ports_configured worker_host_capacity_preflight fingerprint_files compose_service_fingerprint worker_process_config_fingerprint worker_support_service_fingerprint worker_host_runtime_fingerprint worker_docker_daemon_fingerprint ensure_routine_worker_fingerprints_compatible worker_expected_schema_version protect_active_executor_images find_free_worker_port start_worker_generation drain_old_worker_containers deploy_worker_blue_green wait_container_healthy dump_diagnostics prune_docker_deploy_artifacts)
 COMPOSE_FILE='$COMPOSE_FILE'
 HEALTH_SERVICE='$HEALTH_SERVICE'
 STATUS_FILE='$status_file'

--- a/deploy/scripts/deploy.sh
+++ b/deploy/scripts/deploy.sh
@@ -1531,8 +1531,8 @@ ssh "${SSH_OPTS[@]}" deploy@"$HOST" \
   list_running_worker_containers() {
     docker ps \
       --filter "label=com.docker.compose.service=worker" \
-      --format '{{.ID}} {{.Label "com.docker.compose.project"}}' \
-      | awk '$2 ~ /^143-worker-/ {print $1}'
+      --format '{{.ID}} {{.Names}} {{.Label "com.docker.compose.project"}}' \
+      | awk '$3 ~ /^143-worker-/ || ($3 == "143" && $2 !~ /^143-worker-run-/) {print $1}'
   }
 
   worker_container_node_id() {

--- a/deploy/scripts/reconcile-worker-host.sh
+++ b/deploy/scripts/reconcile-worker-host.sh
@@ -217,20 +217,20 @@ clear_sandbox_dns_endpoints() {
   disconnect_endpoint_for_ip "$STATIC_EGRESS_NETWORK" "$STATIC_EGRESS_DNS_IP"
 }
 
-# Per-turn sandbox run containers (143-worker-run-*) should be removed when a
-# coding turn ends; leftovers accumulate stale libnetwork endpoints on the
-# sandbox bridge and feed the leaked-endpoint failure handled above. Sweep only
-# NON-running containers so in-flight coding turns are never touched.
+# docker compose run helper containers (143-worker-run-*) should be short-lived
+# deploy-control processes. Old drain monitors can keep creating them while this
+# sidecar is down; because they inherit the worker service networks, one can
+# take sandbox-dns's pinned IP before Docker starts the sidecar. Remove them
+# before reconciliation retries. User sandbox containers are created through the
+# Docker API and carry the 143 sandbox labels instead of the compose project.
 sweep_stopped_worker_run_containers() {
   local stale
   stale="$(docker ps -a \
     --filter 'name=143-worker-run-' \
-    --filter 'status=exited' \
-    --filter 'status=created' \
-    --filter 'status=dead' \
-    --format '{{.ID}}' 2>/dev/null || true)"
+    --format '{{.ID}} {{.Label "com.docker.compose.project"}} {{.Label "com.docker.compose.service"}}' 2>/dev/null \
+    | awk '$2 == "143" && $3 == "worker" {print $1}' || true)"
   if [ -n "$stale" ]; then
-    echo "Removing stale (non-running) worker-run sandbox containers..." >&2
+    echo "Removing worker deploy-control helper containers..." >&2
     printf '%s\n' "$stale" | xargs -r docker rm -f >/dev/null 2>&1 || true
   fi
 }
@@ -269,12 +269,18 @@ ensure_static_egress_dns() {
         docker compose -f "$compose_file" build sandbox-dns
       fi
 
-      if docker compose -f "$compose_file" up -d --no-deps --no-recreate sandbox-dns \
-        && wait_for_sandbox_dns_pinned_ips "${SANDBOX_DNS_ROUTINE_WAIT_SECONDS:-30}"; then
-        warn_if_sandbox_dns_image_drift
-        echo "sandbox-dns verified on pinned IPs without recreation."
-        exit 0
-      fi
+      for attempt in 1 2 3; do
+        sweep_stopped_worker_run_containers
+        if docker compose -f "$compose_file" up -d --no-deps --no-recreate sandbox-dns \
+          && wait_for_sandbox_dns_pinned_ips "${SANDBOX_DNS_ROUTINE_WAIT_SECONDS:-30}"; then
+          warn_if_sandbox_dns_image_drift
+          echo "sandbox-dns verified on pinned IPs without recreation."
+          exit 0
+        fi
+        if [ "$attempt" != "3" ]; then
+          sleep 1
+        fi
+      done
 
       echo "ERROR: routine worker reconciliation could not verify healthy sandbox-dns without recreating it." >&2
       echo "  Routine deploys do not recreate sandbox-dns because recreating the pinned-IP sidecar can race active sandboxes." >&2

--- a/deploy/scripts/spin-down-worker.sh
+++ b/deploy/scripts/spin-down-worker.sh
@@ -79,8 +79,8 @@ cd /opt/143
 list_worker_containers() {
   docker ps \
     --filter "label=com.docker.compose.service=worker" \
-    --format '{{.ID}} {{.Label "com.docker.compose.project"}}' \
-    | awk '$2 ~ /^143-worker-/ {print $1}'
+    --format '{{.ID}} {{.Names}} {{.Label "com.docker.compose.project"}}' \
+    | awk '$3 ~ /^143-worker-/ || ($3 == "143" && $2 !~ /^143-worker-run-/) {print $1}'
 }
 
 list_session_executor_containers() {

--- a/deploy/scripts/spin-down-worker.sh
+++ b/deploy/scripts/spin-down-worker.sh
@@ -77,7 +77,10 @@ set -euo pipefail
 cd /opt/143
 
 list_worker_containers() {
-  docker ps --filter "label=com.docker.compose.service=worker" --format '{{.ID}}'
+  docker ps \
+    --filter "label=com.docker.compose.service=worker" \
+    --format '{{.ID}} {{.Label "com.docker.compose.project"}}' \
+    | awk '$2 ~ /^143-worker-/ {print $1}'
 }
 
 list_session_executor_containers() {


### PR DESCRIPTION
## Summary
- Move worker deploy-control helpers off compose-run networking and onto the default network
- Filter worker container discovery and cleanup by compose project labels so helper containers are not mistaken for user sandboxes
- Retry sandbox-dns reconciliation after sweeping stale compose-run helpers, and keep deploy artifact pruning scoped to its helper function

## Testing
- Added deploy script coverage for helper networking, container filtering, and stale helper cleanup behavior
- Tightened existing prune coverage to validate the prune helper in isolation