### PR TITLE
Improve preview settings guidance and controls

### DIFF
--- a/frontend/src/app/(dashboard)/settings/previews/page.test.tsx
+++ b/frontend/src/app/(dashboard)/settings/previews/page.test.tsx
@@ -169,6 +169,61 @@ describe("PreviewSettingsPage", () => {
     ).toBeInTheDocument();
   });
 
+  it("shows contextual reasons when publish and surface controls are disabled", async () => {
+    server.use(
+      http.get("*/api/v1/repositories", () => HttpResponse.json({ data: repos, meta: {} })),
+      http.get("*/api/v1/repositories/:id/preview-secret-bundles", () => HttpResponse.json({ data: [], meta: {} })),
+      http.get("*/api/v1/previews/policies", () => HttpResponse.json({
+        data: [
+          {
+            repository_id: "repo-1",
+            repository_full_name: "assembledhq/143",
+            auto_mode: "warm",
+            session_prewarm_mode: "off",
+            session_prewarm_untrusted_fork: false,
+            pr_preview_surfaces_enabled: false,
+            github_pr_comment_enabled: true,
+            github_commit_status_enabled: true,
+            preview_configured: true,
+            preview_success_recorded: false,
+            preview_ready: false,
+            preview_readiness_missing_reason:
+              "Run a successful test preview before enabling GitHub PR links",
+            github_pr_comment_permission_ok: true,
+            github_commit_status_permission_ok: true,
+            open_pr_count: 1,
+            updated_at: null,
+          },
+        ],
+        meta: {},
+      })),
+    );
+
+    renderWithProviders(<PreviewSettingsPage />);
+
+    expect(
+      await screen.findByRole("switch", {
+        name: /publish preview links to GitHub PRs for assembledhq\/143/i,
+      }),
+    ).toBeDisabled();
+    expect(
+      screen.getByText("Run a successful test preview before enabling GitHub PR links"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("switch", {
+        name: /enable pr comment preview link for assembledhq\/143/i,
+      }),
+    ).toBeDisabled();
+    expect(
+      screen.getByRole("switch", {
+        name: /enable commit status preview link for assembledhq\/143/i,
+      }),
+    ).toBeDisabled();
+    expect(
+      screen.getAllByText(/Publishing is disabled: Run a successful test preview/i),
+    ).toHaveLength(2);
+  });
+
   it("falls back to connected repositories when preview policies are empty", async () => {
     server.use(
       http.get("*/api/v1/repositories", () => HttpResponse.json({ data: repos, meta: {} })),

--- a/frontend/src/app/(dashboard)/settings/previews/page.tsx
+++ b/frontend/src/app/(dashboard)/settings/previews/page.tsx
@@ -704,7 +704,7 @@ function RepoPreviewCard({
             {!sessionPrewarmEnabled ? (
               <p
                 id={`preview-prewarm-disabled-${policy.repository_id}`}
-                className="text-[11px] leading-4 text-muted-foreground"
+                className="text-xs leading-4 text-muted-foreground"
               >
                 Set speculative preview slots above 0 to enable session prewarm.
               </p>
@@ -742,7 +742,7 @@ function RepoPreviewCard({
                   ? "Publishing preview links to GitHub PRs"
                   : "Not publishing preview links to GitHub PRs"}
               </span>
-              <p className="text-[11px] leading-4 text-muted-foreground">
+              <p className="text-xs leading-4 text-muted-foreground">
                 When enabled, 143 publishes preview URLs to GitHub PR comments
                 or commit statuses. Auto-build can still create previews
                 internally when publishing is off.
@@ -750,7 +750,7 @@ function RepoPreviewCard({
               {publishDisabledReason ? (
                 <p
                   id={`preview-publish-disabled-${policy.repository_id}`}
-                  className="flex items-start gap-1.5 text-[11px] leading-4 text-muted-foreground"
+                  className="flex items-start gap-1.5 text-xs leading-4 text-muted-foreground"
                 >
                   <HelpCircle className="mt-0.5 h-3 w-3 shrink-0" />
                   <span>{publishDisabledReason}</span>
@@ -807,7 +807,7 @@ function RepoPreviewCard({
               {testPreviewDisabledReason ? (
                 <p
                   id={`preview-test-disabled-${policy.repository_id}`}
-                  className="text-[11px] leading-4 text-muted-foreground"
+                  className="text-xs leading-4 text-muted-foreground"
                 >
                   {testPreviewDisabledReason}
                 </p>
@@ -892,7 +892,7 @@ function PreviewModeOption({
         <span className="block text-xs font-medium text-foreground">
           {label}
         </span>
-        <span className="block text-[11px] leading-4 text-muted-foreground">
+        <span className="block text-xs leading-4 text-muted-foreground">
           {description}
         </span>
       </span>
@@ -932,7 +932,7 @@ function PreviewSurfaceSwitch({
       {disabledReason ? (
         <p
           id={`${id}-reason`}
-          className="mt-1 pl-11 text-[11px] leading-4 text-muted-foreground"
+          className="mt-1 pl-11 text-xs leading-4 text-muted-foreground"
         >
           {disabledReason}
         </p>

--- a/frontend/src/app/(dashboard)/settings/previews/page.tsx
+++ b/frontend/src/app/(dashboard)/settings/previews/page.tsx
@@ -49,6 +49,7 @@ import {
 } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
 import {
   Select,
   SelectContent,
@@ -67,7 +68,6 @@ import {
 import { Switch } from "@/components/ui/switch";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Textarea } from "@/components/ui/textarea";
-import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
 import {
   Tooltip,
   TooltipContent,
@@ -80,6 +80,7 @@ import { api, ApiError } from "@/lib/api";
 import { notify as toast } from "@/lib/notify";
 import { pollMs } from "@/lib/poll-intervals";
 import { queryKeys } from "@/lib/query-keys";
+import { cn } from "@/lib/utils";
 import {
   DEFAULT_PREVIEW_AUTO_POOL_MAX_ACTIVE,
   DEFAULT_PREVIEW_SESSION_PREWARM_MAX_ACTIVE,
@@ -323,11 +324,6 @@ function AutoPreviewSection() {
           publish their links to GitHub. Warm mode hibernates after a successful
           build so the PR link resumes quickly.
         </p>
-        <p className="text-xs text-muted-foreground">
-          Warm builds each PR preview, saves a resumable snapshot, then stops it.
-          On builds each PR preview and keeps it running until normal idle limits
-          reclaim it.
-        </p>
       </div>
 
       {policiesLoading ? (
@@ -546,6 +542,12 @@ function RepoPreviewCard({
   const testPreviewDisabled =
     testPreviewPending ||
     Boolean(policy.preview_config_requires_selection && !selectedPreviewConfig);
+  const testPreviewDisabledReason =
+    !testPreviewPending &&
+    policy.preview_config_requires_selection &&
+    !selectedPreviewConfig
+      ? "Select a build profile before starting a test preview."
+      : "";
   const disabledReason = !policy.preview_ready
     ? policy.preview_readiness_missing_reason ||
       "Run a successful test preview before enabling GitHub PR links"
@@ -553,6 +555,21 @@ function RepoPreviewCard({
       ? "GitHub App permissions are missing for one or more selected surfaces"
       : "";
   const canEnable = policy.preview_ready && !missingPermissions;
+  const publishDisabled = !canEnable && !policy.pr_preview_surfaces_enabled;
+  const publishDisabledReason = publishDisabled ? disabledReason : "";
+  const commentSurfaceDisabledReason = getSurfaceDisabledReason({
+    publishingEnabled: policy.pr_preview_surfaces_enabled,
+    publishDisabledReason,
+    permissionOK: policy.github_pr_comment_permission_ok,
+    missingPermissionReason:
+      "GitHub App needs Issues or Pull requests write permission.",
+  });
+  const statusSurfaceDisabledReason = getSurfaceDisabledReason({
+    publishingEnabled: policy.pr_preview_surfaces_enabled,
+    publishDisabledReason,
+    permissionOK: policy.github_commit_status_permission_ok,
+    missingPermissionReason: "GitHub App needs Statuses write permission.",
+  });
   const configNames = policy.preview_config_names ?? [];
   const defaultConfigName = policy.preview_config_default_name ?? "";
 
@@ -589,10 +606,11 @@ function RepoPreviewCard({
           <div className="text-xs font-medium text-muted-foreground">
             1 · Auto-build
           </div>
-          <div className="space-y-1.5">
-            <span className="block text-xs text-muted-foreground">Mode</span>
-            <ToggleGroup
-              type="single"
+          <div className="space-y-2">
+            <span className="block text-xs font-medium text-foreground">
+              Mode
+            </span>
+            <RadioGroup
               value={policy.auto_mode}
               onValueChange={(value) => {
                 if (!value || value === policy.auto_mode) return;
@@ -600,39 +618,39 @@ function RepoPreviewCard({
                   auto_mode: value as PreviewPolicySummary["auto_mode"],
                 });
               }}
-              className="justify-start"
+              className="gap-2"
             >
-              <ToggleGroupItem
+              <PreviewModeOption
+                id={`preview-auto-${policy.repository_id}-off`}
                 value="off"
-                aria-label={`Turn off auto-preview for ${policy.repository_full_name}`}
-              >
-                Off
-              </ToggleGroupItem>
-              <ToggleGroupItem
+                label="Off"
+                description="Do not build PR previews automatically."
+                selected={policy.auto_mode === "off"}
+                ariaLabel={`Turn off auto-preview for ${policy.repository_full_name}`}
+              />
+              <PreviewModeOption
+                id={`preview-auto-${policy.repository_id}-warm`}
                 value="warm"
-                aria-label={`Use warm auto-preview for ${policy.repository_full_name}`}
-              >
-                Warm
-              </ToggleGroupItem>
-              <ToggleGroupItem
+                label="Warm"
+                description="Warm builds each PR preview, saves a resumable snapshot, then stops it."
+                selected={policy.auto_mode === "warm"}
+                ariaLabel={`Use warm auto-preview for ${policy.repository_full_name}`}
+              />
+              <PreviewModeOption
+                id={`preview-auto-${policy.repository_id}-on`}
                 value="on"
-                aria-label={`Keep auto-preview on for ${policy.repository_full_name}`}
-              >
-                On
-              </ToggleGroupItem>
-            </ToggleGroup>
+                label="On"
+                description="On builds each PR preview and keeps it running until normal idle limits reclaim it."
+                selected={policy.auto_mode === "on"}
+                ariaLabel={`Keep auto-preview on for ${policy.repository_full_name}`}
+              />
+            </RadioGroup>
           </div>
-          <div className="space-y-1.5">
-            <span className="block text-xs text-muted-foreground">
+          <div className="space-y-2">
+            <span className="block text-xs font-medium text-foreground">
               Session prewarm
             </span>
-            <p className="text-xs text-muted-foreground">
-              Cache only installs dependencies ahead of time without starting
-              the app. Smart starts with cache warming and may prepare a full
-              preview when a session looks likely to need one.
-            </p>
-            <ToggleGroup
-              type="single"
+            <RadioGroup
               value={policy.session_prewarm_mode}
               onValueChange={(value) => {
                 if (
@@ -647,30 +665,47 @@ function RepoPreviewCard({
                     value as PreviewPolicySummary["session_prewarm_mode"],
                 });
               }}
-              className="justify-start"
+              className="gap-2"
               disabled={!sessionPrewarmEnabled}
+              aria-describedby={
+                !sessionPrewarmEnabled
+                  ? `preview-prewarm-disabled-${policy.repository_id}`
+                  : undefined
+              }
             >
-              <ToggleGroupItem
+              <PreviewModeOption
+                id={`preview-prewarm-${policy.repository_id}-off`}
                 value="off"
-                aria-label={`Turn off session prewarm for ${policy.repository_full_name}`}
-              >
-                Off
-              </ToggleGroupItem>
-              <ToggleGroupItem
+                label="Off"
+                description="Start only when a user opens Preview."
+                selected={policy.session_prewarm_mode === "off"}
+                disabled={!sessionPrewarmEnabled}
+                ariaLabel={`Turn off session prewarm for ${policy.repository_full_name}`}
+              />
+              <PreviewModeOption
+                id={`preview-prewarm-${policy.repository_id}-cache`}
                 value="cache"
-                aria-label={`Use cache-only session prewarm for ${policy.repository_full_name}`}
-              >
-                Cache only
-              </ToggleGroupItem>
-              <ToggleGroupItem
+                label="Cache only"
+                description="Cache only installs dependencies ahead of time without starting the app."
+                selected={policy.session_prewarm_mode === "cache"}
+                disabled={!sessionPrewarmEnabled}
+                ariaLabel={`Use cache-only session prewarm for ${policy.repository_full_name}`}
+              />
+              <PreviewModeOption
+                id={`preview-prewarm-${policy.repository_id}-smart`}
                 value="smart"
-                aria-label={`Use smart session prewarm for ${policy.repository_full_name}`}
-              >
-                Smart
-              </ToggleGroupItem>
-            </ToggleGroup>
+                label="Smart"
+                description="Smart starts with cache warming and may prepare a full preview when a session looks likely to need one."
+                selected={policy.session_prewarm_mode === "smart"}
+                disabled={!sessionPrewarmEnabled}
+                ariaLabel={`Use smart session prewarm for ${policy.repository_full_name}`}
+              />
+            </RadioGroup>
             {!sessionPrewarmEnabled ? (
-              <p className="text-xs text-muted-foreground">
+              <p
+                id={`preview-prewarm-disabled-${policy.repository_id}`}
+                className="text-[11px] leading-4 text-muted-foreground"
+              >
                 Set speculative preview slots above 0 to enable session prewarm.
               </p>
             ) : null}
@@ -681,81 +716,103 @@ function RepoPreviewCard({
           <div className="text-xs font-medium text-muted-foreground">
             2 · Publish to PRs
           </div>
-          {disabledReason ? (
-            <div className="flex items-start gap-2 rounded-md bg-muted px-2.5 py-2 text-xs text-muted-foreground">
-              <HelpCircle className="mt-0.5 h-3.5 w-3.5 shrink-0" />
-              <span>{disabledReason}</span>
-            </div>
-          ) : null}
           {policy.last_surface_sync_error ? (
             <p className="text-xs text-destructive">
               {policy.last_surface_sync_error}
             </p>
           ) : null}
-          <div className="flex items-center gap-2">
+          <div className="flex items-start gap-2 rounded-md border border-border p-2.5">
             <Switch
               aria-label={`Publish preview links to GitHub PRs for ${policy.repository_full_name}`}
               checked={policy.pr_preview_surfaces_enabled}
-              disabled={!canEnable && !policy.pr_preview_surfaces_enabled}
+              disabled={publishDisabled}
+              aria-describedby={
+                publishDisabledReason
+                  ? `preview-publish-disabled-${policy.repository_id}`
+                  : undefined
+              }
               onCheckedChange={(checked) =>
                 onUpdatePolicy({ pr_preview_surfaces_enabled: checked })
               }
+              className="mt-0.5"
             />
-            <span className="text-xs text-muted-foreground">
-              {policy.pr_preview_surfaces_enabled
-                ? "Publishing preview links to GitHub PRs"
-                : "Not publishing preview links to GitHub PRs"}
-            </span>
+            <div className="min-w-0 space-y-1">
+              <span className="block text-xs font-medium text-foreground">
+                {policy.pr_preview_surfaces_enabled
+                  ? "Publishing preview links to GitHub PRs"
+                  : "Not publishing preview links to GitHub PRs"}
+              </span>
+              <p className="text-[11px] leading-4 text-muted-foreground">
+                When enabled, 143 publishes preview URLs to GitHub PR comments
+                or commit statuses. Auto-build can still create previews
+                internally when publishing is off.
+              </p>
+              {publishDisabledReason ? (
+                <p
+                  id={`preview-publish-disabled-${policy.repository_id}`}
+                  className="flex items-start gap-1.5 text-[11px] leading-4 text-muted-foreground"
+                >
+                  <HelpCircle className="mt-0.5 h-3 w-3 shrink-0" />
+                  <span>{publishDisabledReason}</span>
+                </p>
+              ) : null}
+            </div>
           </div>
-          <p className="text-xs text-muted-foreground">
-            When enabled, 143 publishes preview URLs to GitHub PR comments or
-            commit statuses. Auto-build can still create previews internally
-            when publishing is off.
-          </p>
           <div className="space-y-1.5">
-            <span className="block text-xs text-muted-foreground">Surfaces</span>
-            <div className="flex flex-wrap gap-3">
-              <div className="flex items-center gap-2 text-xs">
-                <Switch
-                  aria-label={`Enable PR comment preview link for ${policy.repository_full_name}`}
-                  checked={policy.github_pr_comment_enabled}
-                  disabled={
-                    !policy.pr_preview_surfaces_enabled ||
-                    !policy.github_pr_comment_permission_ok
-                  }
-                  onCheckedChange={(checked) =>
-                    onUpdatePolicy({ github_pr_comment_enabled: checked })
-                  }
-                />
-                Comment
-              </div>
-              <div className="flex items-center gap-2 text-xs">
-                <Switch
-                  aria-label={`Enable commit status preview link for ${policy.repository_full_name}`}
-                  checked={policy.github_commit_status_enabled}
-                  disabled={
-                    !policy.pr_preview_surfaces_enabled ||
-                    !policy.github_commit_status_permission_ok
-                  }
-                  onCheckedChange={(checked) =>
-                    onUpdatePolicy({ github_commit_status_enabled: checked })
-                  }
-                />
-                Status
-              </div>
+            <span className="block text-xs font-medium text-foreground">
+              Surfaces
+            </span>
+            <div className="grid gap-2 sm:grid-cols-2">
+              <PreviewSurfaceSwitch
+                id={`preview-comment-${policy.repository_id}`}
+                label="Comment"
+                ariaLabel={`Enable PR comment preview link for ${policy.repository_full_name}`}
+                checked={policy.github_pr_comment_enabled}
+                disabled={Boolean(commentSurfaceDisabledReason)}
+                disabledReason={commentSurfaceDisabledReason}
+                onCheckedChange={(checked) =>
+                  onUpdatePolicy({ github_pr_comment_enabled: checked })
+                }
+              />
+              <PreviewSurfaceSwitch
+                id={`preview-status-${policy.repository_id}`}
+                label="Status"
+                ariaLabel={`Enable commit status preview link for ${policy.repository_full_name}`}
+                checked={policy.github_commit_status_enabled}
+                disabled={Boolean(statusSurfaceDisabledReason)}
+                disabledReason={statusSurfaceDisabledReason}
+                onCheckedChange={(checked) =>
+                  onUpdatePolicy({ github_commit_status_enabled: checked })
+                }
+              />
             </div>
           </div>
           {showTestPreview ? (
-            <Button
-              type="button"
-              size="sm"
-              variant="outline"
-              disabled={testPreviewDisabled}
-              onClick={() => onTestPreview(selectedPreviewConfig || undefined)}
-            >
-              <MonitorPlay className="mr-2 h-4 w-4" />
-              Test preview
-            </Button>
+            <div className="space-y-1.5">
+              <Button
+                type="button"
+                size="sm"
+                variant="outline"
+                disabled={testPreviewDisabled}
+                aria-describedby={
+                  testPreviewDisabledReason
+                    ? `preview-test-disabled-${policy.repository_id}`
+                    : undefined
+                }
+                onClick={() => onTestPreview(selectedPreviewConfig || undefined)}
+              >
+                <MonitorPlay className="mr-2 h-4 w-4" />
+                Test preview
+              </Button>
+              {testPreviewDisabledReason ? (
+                <p
+                  id={`preview-test-disabled-${policy.repository_id}`}
+                  className="text-[11px] leading-4 text-muted-foreground"
+                >
+                  {testPreviewDisabledReason}
+                </p>
+              ) : null}
+            </div>
           ) : null}
         </div>
       </div>
@@ -796,6 +853,114 @@ function RepoPreviewCard({
       ) : null}
     </div>
   );
+}
+
+function PreviewModeOption({
+  id,
+  value,
+  label,
+  description,
+  selected,
+  disabled = false,
+  ariaLabel,
+}: {
+  id: string;
+  value: string;
+  label: string;
+  description: string;
+  selected: boolean;
+  disabled?: boolean;
+  ariaLabel: string;
+}) {
+  return (
+    <Label
+      htmlFor={id}
+      className={cn(
+        "flex cursor-pointer items-start gap-2 rounded-md border border-border bg-background p-2.5 transition-colors",
+        selected && "border-primary bg-primary/5",
+        disabled && "cursor-not-allowed opacity-60",
+      )}
+    >
+      <RadioGroupItem
+        id={id}
+        value={value}
+        aria-label={ariaLabel}
+        disabled={disabled}
+        className="mt-0.5"
+      />
+      <span className="min-w-0 space-y-0.5">
+        <span className="block text-xs font-medium text-foreground">
+          {label}
+        </span>
+        <span className="block text-[11px] leading-4 text-muted-foreground">
+          {description}
+        </span>
+      </span>
+    </Label>
+  );
+}
+
+function PreviewSurfaceSwitch({
+  id,
+  label,
+  ariaLabel,
+  checked,
+  disabled,
+  disabledReason,
+  onCheckedChange,
+}: {
+  id: string;
+  label: string;
+  ariaLabel: string;
+  checked: boolean;
+  disabled: boolean;
+  disabledReason: string;
+  onCheckedChange: (checked: boolean) => void;
+}) {
+  return (
+    <div className="rounded-md border border-border p-2.5">
+      <div className="flex items-center gap-2 text-xs">
+        <Switch
+          aria-label={ariaLabel}
+          checked={checked}
+          disabled={disabled}
+          aria-describedby={disabledReason ? `${id}-reason` : undefined}
+          onCheckedChange={onCheckedChange}
+        />
+        <span className="font-medium text-foreground">{label}</span>
+      </div>
+      {disabledReason ? (
+        <p
+          id={`${id}-reason`}
+          className="mt-1 pl-11 text-[11px] leading-4 text-muted-foreground"
+        >
+          {disabledReason}
+        </p>
+      ) : null}
+    </div>
+  );
+}
+
+function getSurfaceDisabledReason({
+  publishingEnabled,
+  publishDisabledReason,
+  permissionOK,
+  missingPermissionReason,
+}: {
+  publishingEnabled: boolean;
+  publishDisabledReason: string;
+  permissionOK: boolean;
+  missingPermissionReason: string;
+}) {
+  if (!publishingEnabled) {
+    return publishDisabledReason
+      ? `Publishing is disabled: ${publishDisabledReason}`
+      : "Turn on publishing to choose this surface.";
+  }
+  if (!permissionOK) {
+    return missingPermissionReason;
+  }
+  return "";
 }
 
 function PreviewSecretsSection() {

--- a/frontend/src/app/(landing)/about/page.tsx
+++ b/frontend/src/app/(landing)/about/page.tsx
@@ -63,7 +63,7 @@ export default function AboutPage() {
             <p>
               I hate when people say &ldquo;X% of our code is written by AI.&rdquo; 
               Code volume, especially these days, is a bad
-              metric. What I care about when I'm on a team is whether we&apos;re building a better
+              metric. What I care about when I&apos;m on a team is whether we&apos;re building a better
               product that is genuinely useful to our customers. That is a much
               harder thing to measure, but I think it is the right one.
             </p>
@@ -110,7 +110,7 @@ export default function AboutPage() {
               the agent environment less fragile. All of that helped, but
               it also made the bigger issue obvious: we needed a system that made
               this work shared across the team as opposed to being trapped inside one
-              engineer's terminal.
+              engineer&apos;s terminal.
             </p>
 
             <p>


### PR DESCRIPTION
## Summary
- Reworked the preview settings card to use clearer radio-style mode choices with inline descriptions.
- Added contextual disabled reasons for publishing, PR surfaces, and test preview actions so users can see why controls are unavailable.
- Simplified the auto-build section copy and improved the visual hierarchy across the preview settings panel.
- Added coverage for the new disabled-state messaging and control behavior.

## Testing
- Added/updated UI tests for the preview settings page to verify disabled controls and contextual helper text.
- Not run (not requested).