### PR TITLE
Disable push retry while a session is still running

### DIFF
--- a/frontend/src/lib/session-pr-action-state.test.ts
+++ b/frontend/src/lib/session-pr-action-state.test.ts
@@ -143,6 +143,29 @@ describe("session PR action state", () => {
     expect(state.disabledReason, "Push changes should explain the running-session blocker").toBe("Wait for the session to finish before pushing changes");
   });
 
+  it("disables push retry while the session is still running", () => {
+    const state = derivePushChangesActionState({
+      canShipPR: true,
+      hasOpenPR: true,
+      hasUnpushedChanges: true,
+      hasSnapshot: true,
+      isRunning: true,
+      builderReviewAllowsPR: true,
+      snapshotUnavailable: false,
+      ghBlocked: false,
+      queueingPush: false,
+      pushingChanges: false,
+      pushState: "failed",
+      pushError: "The PR branch has changes that are not in this session checkpoint.",
+    });
+
+    expect(state.visible, "Failed Push changes should remain visible while the session is running").toBe(true);
+    expect(state.disabled, "Failed Push changes should not allow retry while the session is running").toBe(true);
+    expect(state.label, "Failed Push changes should keep the retry affordance visible").toBe("Retry");
+    expect(state.disabledReason, "Disabled retry should explain that the session must finish first").toBe("Wait for the session to finish before pushing changes");
+    expect(state.showError, "Disabled retry should retain the error styling").toBe(true);
+  });
+
   it("hides push changes when PR health is blocked", () => {
     const state = derivePushChangesActionState({
       canShipPR: true,

--- a/frontend/src/lib/session-pr-action-state.ts
+++ b/frontend/src/lib/session-pr-action-state.ts
@@ -213,6 +213,18 @@ export function derivePushChangesActionState(input: PushChangesActionInput): Lab
     };
   }
 
+  const hasRetryablePushError = Boolean(input.localError) || input.pushState === "failed";
+  if (input.isRunning) {
+    return {
+      visible: true,
+      disabled: true,
+      disabledReason: "Wait for the session to finish before pushing changes",
+      label: hasRetryablePushError ? "Retry" : "Push changes",
+      spinning: false,
+      showError: hasRetryablePushError,
+    };
+  }
+
   if (input.localError) {
     return {
       visible: true,
@@ -232,16 +244,6 @@ export function derivePushChangesActionState(input: PushChangesActionInput): Lab
       label: "Retry",
       spinning: false,
       showError: true,
-    };
-  }
-
-  if (input.isRunning) {
-    return {
-      visible: true,
-      disabled: true,
-      disabledReason: "Wait for the session to finish before pushing changes",
-      label: "Push changes",
-      spinning: false,
     };
   }
 


### PR DESCRIPTION
## Summary
- Keep the Push changes action visible and disabled when a session is still running
- Preserve the Retry label and error styling for failed push states until the session finishes
- Add a unit test covering the running-session retry case

## Testing
- Unit tests added for `derivePushChangesActionState` behavior