### PR TITLE
Enable default Slack notifications and production diagnostics for org session defaults

### DIFF
--- a/frontend/src/components/automation-capabilities-editor.test.tsx
+++ b/frontend/src/components/automation-capabilities-editor.test.tsx
@@ -31,6 +31,12 @@ const CATALOG: AgentCapabilityDefinition[] = [
   def("publishing", { max_access_level: "publish", risk: "high", category: "Actions" }),
   def("issue_sources", { risk: "medium", scope: "integration" }),
   def("production_diagnostics", { risk: "high", category: "Diagnostics" }),
+  def("slack_notifications", {
+    max_access_level: "write",
+    risk: "medium",
+    category: "Actions",
+    scope: "integration",
+  }),
 ];
 
 describe("recommendedDefaultGrants", () => {
@@ -51,10 +57,9 @@ describe("recommendedDefaultGrants", () => {
     const byID = new Map(grants.map((grant) => [grant.capability_id, grant]));
     expect(byID.get("repo_context")?.enabled).toBe(true);
     expect(byID.get("publishing")?.enabled).toBe(true);
-    // issue_sources is intentionally scoped to triggered sessions, so it must
-    // not be on by default in the org-level policy.
-    expect(byID.get("issue_sources")?.enabled).toBe(false);
-    expect(byID.get("production_diagnostics")?.enabled).toBe(false);
+    expect(byID.get("issue_sources")?.enabled).toBe(true);
+    expect(byID.get("production_diagnostics")?.enabled).toBe(true);
+    expect(byID.get("slack_notifications")?.enabled).toBe(true);
   });
 
   it("uses each capability's max access level for its grant", () => {
@@ -63,6 +68,7 @@ describe("recommendedDefaultGrants", () => {
 
     expect(byID.get("repo_context")?.access_level).toBe("read");
     expect(byID.get("publishing")?.access_level).toBe("publish");
+    expect(byID.get("slack_notifications")?.access_level).toBe("write");
   });
 });
 

--- a/frontend/src/components/automation-capabilities-editor.tsx
+++ b/frontend/src/components/automation-capabilities-editor.tsx
@@ -13,9 +13,10 @@ export function capabilityAccessFor(definition: AgentCapabilityDefinition) {
 }
 
 // Capabilities that ship enabled by default for the org session-default policy
-// when an admin has not configured one yet. These are the broadly-useful,
-// commonly-needed capabilities (code/PR/test context plus branch & PR
-// publishing); higher-risk write and production-data capabilities stay opt-in.
+// when an admin has not configured one yet. These are the broadly-useful
+// capabilities (code/PR/test context, integration issue context, read-only
+// production diagnostics, Slack status notifications, plus branch & PR
+// publishing).
 // Keep in sync with recommendedDefaultGrants in
 // internal/services/agentcapabilities/service.go.
 export const RECOMMENDED_DEFAULT_CAPABILITY_IDS: readonly AgentCapabilityID[] = [
@@ -23,6 +24,9 @@ export const RECOMMENDED_DEFAULT_CAPABILITY_IDS: readonly AgentCapabilityID[] = 
   "pr_history",
   "review_feedback",
   "ci_history",
+  "issue_sources",
+  "production_diagnostics",
+  "slack_notifications",
   "publishing",
 ];
 

--- a/internal/services/agentcapabilities/service.go
+++ b/internal/services/agentcapabilities/service.go
@@ -295,18 +295,20 @@ func (s *Service) resolvePolicyGrants(ctx context.Context, in ResolveInput) ([]m
 
 // recommendedDefaultEnabledCapabilities is the set of capabilities that ship
 // enabled by default when an org has not configured a session-default policy.
-// These cover the broadly-useful, commonly-needed capabilities (code/PR/test
-// context plus branch & PR publishing); higher-risk write and production-data
-// capabilities stay opt-in. Keep in sync with RECOMMENDED_DEFAULT_CAPABILITY_IDS
-// in frontend/src/components/automation-capabilities-editor.tsx. Note that
-// issue_sources is intentionally excluded here and instead added only for
-// triggered sessions below.
+// These cover broadly-useful capabilities (code/PR/test context, integration
+// issue context, read-only production diagnostics, Slack status notifications,
+// plus branch & PR publishing). Keep in sync with
+// RECOMMENDED_DEFAULT_CAPABILITY_IDS in
+// frontend/src/components/automation-capabilities-editor.tsx.
 var recommendedDefaultEnabledCapabilities = map[models.AgentCapabilityID]bool{
-	models.AgentCapabilityRepoContext:    true,
-	models.AgentCapabilityPRHistory:      true,
-	models.AgentCapabilityReviewFeedback: true,
-	models.AgentCapabilityCIHistory:      true,
-	models.AgentCapabilityPublishing:     true,
+	models.AgentCapabilityRepoContext:           true,
+	models.AgentCapabilityPRHistory:             true,
+	models.AgentCapabilityReviewFeedback:        true,
+	models.AgentCapabilityCIHistory:             true,
+	models.AgentCapabilityIssueSources:          true,
+	models.AgentCapabilityProductionDiagnostics: true,
+	models.AgentCapabilitySlackNotifications:    true,
+	models.AgentCapabilityPublishing:            true,
 }
 
 func recommendedDefaultGrants(in ResolveInput) []models.AgentCapabilityGrant {
@@ -322,12 +324,6 @@ func recommendedDefaultGrants(in ResolveInput) []models.AgentCapabilityGrant {
 			Enabled:      true,
 			Config:       json.RawMessage(`{}`),
 		})
-	}
-	// Issue context (Linear/Sentry/support) is only relevant when a session was
-	// triggered by an external issue source, so scope it to those origins
-	// rather than enabling it for every manual session.
-	if in.SessionOrigin == models.SessionOriginIssueTrigger || in.SessionOrigin == models.SessionOriginSlack || in.SessionOrigin == models.SessionOriginExternalAPI {
-		grants = append(grants, models.AgentCapabilityGrant{CapabilityID: models.AgentCapabilityIssueSources, AccessLevel: models.AgentCapabilityAccessRead, Enabled: true, Config: json.RawMessage(`{}`)})
 	}
 	return grants
 }

--- a/internal/services/agentcapabilities/service_test.go
+++ b/internal/services/agentcapabilities/service_test.go
@@ -65,10 +65,11 @@ func TestServiceResolveForSessionUsesRecommendedDefaultsWhenNoPolicyExists(t *te
 		models.AgentCapabilityPRHistory,
 		models.AgentCapabilityReviewFeedback,
 		models.AgentCapabilityCIHistory,
+		models.AgentCapabilityIssueSources,
+		models.AgentCapabilityProductionDiagnostics,
+		models.AgentCapabilitySlackNotifications,
 		models.AgentCapabilityPublishing,
 	}, snapshotIDs(snapshot), "manual repository sessions should get recommended commonly-used defaults")
-	require.NotContains(t, snapshotIDs(snapshot), models.AgentCapabilityIssueSources,
-		"manual sessions should not get issue sources by default")
 }
 
 func TestServiceResolveForSessionAddsIssueSourcesForTriggeredSessions(t *testing.T) {

--- a/migrations/000224_agent_capability_defaults_on.down.sql
+++ b/migrations/000224_agent_capability_defaults_on.down.sql
@@ -1,0 +1,12 @@
+UPDATE agent_capability_policy_grants g
+SET enabled = false
+FROM agent_capability_policies p
+WHERE g.org_id = p.org_id
+  AND g.policy_id = p.id
+  AND p.policy_type = 'session_default'
+  AND p.active = true
+  AND g.capability_id IN (
+      'issue_sources',
+      'production_diagnostics',
+      'slack_notifications'
+  );

--- a/migrations/000224_agent_capability_defaults_on.up.sql
+++ b/migrations/000224_agent_capability_defaults_on.up.sql
@@ -1,0 +1,33 @@
+WITH default_capabilities(capability_id, access_level) AS (
+    VALUES
+        ('issue_sources', 'read'),
+        ('production_diagnostics', 'read'),
+        ('slack_notifications', 'write')
+),
+active_defaults AS (
+    SELECT id, org_id
+    FROM agent_capability_policies
+    WHERE policy_type = 'session_default'
+      AND active = true
+)
+INSERT INTO agent_capability_policy_grants (
+    org_id,
+    policy_id,
+    capability_id,
+    access_level,
+    enabled,
+    config
+)
+SELECT
+    p.org_id,
+    p.id,
+    c.capability_id,
+    c.access_level,
+    true,
+    '{}'::jsonb
+FROM active_defaults p
+CROSS JOIN default_capabilities c
+WHERE true
+ON CONFLICT (org_id, policy_id, capability_id) DO UPDATE
+SET enabled = true,
+    access_level = EXCLUDED.access_level;


### PR DESCRIPTION
## Summary

Org session-default policies currently ship with key capabilities turned off by default, creating a workflow gap where teams must manually enable issue sourcing, production diagnostics, and Slack notifications before the agent can be useful out of the box. This PR updates backend defaults and the frontend “recommended defaults” UI to enable `issue_sources`, `production_diagnostics`, and `slack_notifications` by default, and adds a migration to apply the expanded defaults to existing active org session-default policies.

## Changes

- Expanded recommended default capability grants in the backend (`issue_sources`, `production_diagnostics`, `slack_notifications`) and made them align with frontend defaults.
- Updated the automation capabilities editor UI and its tests to reflect the new default-on set (including Slack access level).
- Added migration `000223_agent_capability_defaults_on.up.sql` (and corresponding down migration) to expand existing active org session-default policies idempotently without affecting unrelated policies.
- Updated backend/frontend tests to cover the new default grant behavior and access levels.

## Validation

- `go test ./internal/services/agentcapabilities`
- `go test ./internal/db -run 'TestAgentCapabilitiesRepairMigrationIsIdempotentAndExpandOnly|TestMigrations'`
- Frontend tests: not run in this workspace (no `vitest` present in `frontend/node_modules`).

[143.dev](https://143.dev) | [session 1f9fb06c](https://143.dev/sessions/1f9fb06c-cba6-4cda-8336-4516c0313ac7)

<!-- 143 readiness -->
**143 readiness:** not available for this revision.

Preview: https://143.dev/previews/github/assembledhq/143/pull/1657?launch=1