### PR TITLE
Set OpenCode default to OpenRouter provider when creating coding auth

### DIFF
--- a/frontend/src/app/(dashboard)/settings/account/page.test.tsx
+++ b/frontend/src/app/(dashboard)/settings/account/page.test.tsx
@@ -290,7 +290,7 @@ describe("Account settings page", () => {
 	    const dialog = await screen.findByRole("dialog");
 	    fireEvent.click(await within(dialog).findByLabelText("OpenCode"));
 	    expect(within(dialog).getByText("Note: we recommend using OpenRouter routes, which are pinned to US based inference providers. Native OpenCode routes are not provider-pinned.")).toBeInTheDocument();
-	    expect(within(dialog).getByRole("combobox", { name: "Default model" })).toHaveTextContent("opencode/glm-5.2");
+	    expect(within(dialog).getByRole("combobox", { name: "Default model" })).toHaveTextContent("openrouter/z-ai/glm-5.2");
 	    fireEvent.change(within(dialog).getByPlaceholderText("OpenCode or provider key"), {
 	      target: { value: "sk-or-opencode" },
 	    });

--- a/frontend/src/app/(dashboard)/settings/account/page.tsx
+++ b/frontend/src/app/(dashboard)/settings/account/page.tsx
@@ -7,6 +7,7 @@ import { notify as toast } from "@/lib/notify";
 import { api } from "@/lib/api";
 import {
   apiKeyHelp,
+  DEFAULT_OPENCODE_BACKING_PROVIDER,
   detectOpenCodeKeyPreset,
   OPENCODE_BACKING_PROVIDER_OPTIONS,
   OPENCODE_US_INFERENCE_HELP_TEXT,
@@ -234,9 +235,9 @@ export default function AccountPage() {
   const [authType, setAuthType] = useState<PersonalAuthType>("subscription");
   const [apiKey, setApiKey] = useState("");
   const [authLabel, setAuthLabel] = useState("");
-  const [openCodeBackingProvider, setOpenCodeBackingProvider] = useState<OpenCodeBackingProvider>("opencode");
+  const [openCodeBackingProvider, setOpenCodeBackingProvider] = useState<OpenCodeBackingProvider>(DEFAULT_OPENCODE_BACKING_PROVIDER);
   const [openCodeBackingProviderTouched, setOpenCodeBackingProviderTouched] = useState(false);
-  const [openCodeModel, setOpenCodeModel] = useState<string>(openCodeDefaultModelForBackingProvider("opencode"));
+  const [openCodeModel, setOpenCodeModel] = useState<string>(openCodeDefaultModelForBackingProvider(DEFAULT_OPENCODE_BACKING_PROVIDER));
   const [openCodeModelTouched, setOpenCodeModelTouched] = useState(false);
   const [openCodeCustomModel, setOpenCodeCustomModel] = useState("");
   const openCodeKeyDetection = useMemo(
@@ -295,8 +296,7 @@ export default function AccountPage() {
       }),
     onSuccess: () => {
       void queryClient.invalidateQueries({ queryKey: ["coding-credentials"] });
-      setApiKey("");
-      setAuthLabel("");
+      resetModalState();
       setAddOpen(false);
       toast.success("Personal auth saved");
     },
@@ -424,9 +424,9 @@ export default function AccountPage() {
     setAuthLabel("");
     setProvider("openai");
     setAuthType("subscription");
-    setOpenCodeBackingProvider("opencode");
+    setOpenCodeBackingProvider(DEFAULT_OPENCODE_BACKING_PROVIDER);
     setOpenCodeBackingProviderTouched(false);
-    setOpenCodeModel(openCodeDefaultModelForBackingProvider("opencode"));
+    setOpenCodeModel(openCodeDefaultModelForBackingProvider(DEFAULT_OPENCODE_BACKING_PROVIDER));
     setOpenCodeModelTouched(false);
     setOpenCodeCustomModel("");
   }

--- a/frontend/src/app/(dashboard)/settings/agent/page.test.tsx
+++ b/frontend/src/app/(dashboard)/settings/agent/page.test.tsx
@@ -247,7 +247,7 @@ describe("Agent settings page", () => {
 	    await user.click(screen.getByRole("button", { name: "Add auth" }));
 	    const dialog = await screen.findByRole("dialog");
 	    await user.click(screen.getByLabelText("OpenCode"));
-	    expect(within(dialog).getByRole("combobox", { name: "Default model" })).toHaveTextContent("opencode/glm-5.2");
+	    expect(within(dialog).getByRole("combobox", { name: "Default model" })).toHaveTextContent("openrouter/z-ai/glm-5.2");
 	    fireEvent.change(within(dialog).getByPlaceholderText("OpenCode or provider key"), {
 	      target: { value: "sk-or-opencode" },
 	    });

--- a/frontend/src/app/(dashboard)/settings/agent/page.tsx
+++ b/frontend/src/app/(dashboard)/settings/agent/page.tsx
@@ -8,6 +8,7 @@ import { notify as toast } from "@/lib/notify";
 import { api } from "@/lib/api";
 import {
   apiKeyHelp,
+  DEFAULT_OPENCODE_BACKING_PROVIDER,
   detectOpenCodeKeyPreset,
   OPENCODE_BACKING_PROVIDER_OPTIONS,
   OPENCODE_US_INFERENCE_HELP_TEXT,
@@ -166,9 +167,9 @@ export default function AgentPage() {
   const [renameValue, setRenameValue] = useState("");
   const [ampMode, setAmpMode] = useState<string>(AVAILABLE_AMP_MODES[0] ?? "smart");
   const [piModel, setPiModel] = useState<string>(PI_MODEL_CLAUDE_OPUS_48);
-  const [openCodeBackingProvider, setOpenCodeBackingProvider] = useState<OpenCodeBackingProvider>("opencode");
+  const [openCodeBackingProvider, setOpenCodeBackingProvider] = useState<OpenCodeBackingProvider>(DEFAULT_OPENCODE_BACKING_PROVIDER);
   const [openCodeBackingProviderTouched, setOpenCodeBackingProviderTouched] = useState(false);
-  const [openCodeModel, setOpenCodeModel] = useState<string>(openCodeDefaultModelForBackingProvider("opencode"));
+  const [openCodeModel, setOpenCodeModel] = useState<string>(openCodeDefaultModelForBackingProvider(DEFAULT_OPENCODE_BACKING_PROVIDER));
   const [openCodeModelTouched, setOpenCodeModelTouched] = useState(false);
   const [openCodeCustomModel, setOpenCodeCustomModel] = useState("");
   const openCodeKeyDetection = useMemo(
@@ -352,9 +353,9 @@ export default function AgentPage() {
     setInsertionMode("next_fallback");
     setAmpMode(AVAILABLE_AMP_MODES[0] ?? "smart");
     setPiModel(PI_MODEL_CLAUDE_OPUS_48);
-    setOpenCodeBackingProvider("opencode");
+    setOpenCodeBackingProvider(DEFAULT_OPENCODE_BACKING_PROVIDER);
     setOpenCodeBackingProviderTouched(false);
-    setOpenCodeModel(openCodeDefaultModelForBackingProvider("opencode"));
+    setOpenCodeModel(openCodeDefaultModelForBackingProvider(DEFAULT_OPENCODE_BACKING_PROVIDER));
     setOpenCodeModelTouched(false);
     setOpenCodeCustomModel("");
   }

--- a/frontend/src/lib/coding-auth-metadata.test.ts
+++ b/frontend/src/lib/coding-auth-metadata.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  DEFAULT_OPENCODE_BACKING_PROVIDER,
   detectOpenCodeKeyPreset,
   openCodeModelsForBackingProvider,
   openCodeDefaultModelForBackingProvider,
@@ -12,6 +13,11 @@ import {
 } from "./model-constants";
 
 describe("OpenCode backing provider model helpers", () => {
+  it("defaults new OpenCode auths to OpenRouter", () => {
+    expect(DEFAULT_OPENCODE_BACKING_PROVIDER).toBe("openrouter");
+    expect(openCodeDefaultModelForBackingProvider(DEFAULT_OPENCODE_BACKING_PROVIDER)).toBe(OPENCODE_MODEL_OPENROUTER_GLM_5_2);
+  });
+
   it("defaults native OpenCode auth to GLM 5.2", () => {
     expect(openCodeDefaultModelForBackingProvider("opencode")).toBe(OPENCODE_MODEL_GLM_5_2);
   });
@@ -60,7 +66,7 @@ describe("OpenCode backing provider model helpers", () => {
       confidence: "medium",
     });
     expect(detectOpenCodeKeyPreset("oc_unknown_shape")).toMatchObject({
-      provider: "opencode",
+      provider: "openrouter",
       confidence: "low",
     });
   });

--- a/frontend/src/lib/coding-auth-metadata.ts
+++ b/frontend/src/lib/coding-auth-metadata.ts
@@ -136,6 +136,8 @@ export function apiKeyHelp(provider: ApiKeyProvider | PersonalProvider) {
 export type OpenCodeBackingProvider = "opencode" | "anthropic" | "openai" | "gemini" | "openrouter";
 export type OpenCodePresetConfidence = "high" | "medium" | "low";
 
+export const DEFAULT_OPENCODE_BACKING_PROVIDER: OpenCodeBackingProvider = "openrouter";
+
 export interface OpenCodeKeyPresetDetection {
   provider: OpenCodeBackingProvider;
   confidence: OpenCodePresetConfidence;
@@ -191,10 +193,10 @@ export function detectOpenCodeKeyPreset(apiKey: string): OpenCodeKeyPresetDetect
     };
   }
   return {
-    provider: "opencode",
+    provider: DEFAULT_OPENCODE_BACKING_PROVIDER,
     confidence: "low",
     message: trimmed
-      ? "This key shape is ambiguous. Defaulting to OpenCode native; you can change the provider."
+      ? "This key shape is ambiguous. Defaulting to OpenCode via OpenRouter; you can change the provider."
       : "Paste a key to detect the provider preset.",
   };
 }

--- a/internal/api/handlers/coding_credentials.go
+++ b/internal/api/handlers/coding_credentials.go
@@ -687,10 +687,10 @@ func openCodeModelFromDefaults(defaults map[string]string) string {
 
 func openCodeBackingProviderFromInput(input string) models.ProviderName {
 	switch models.ProviderName(input) {
-	case models.ProviderAnthropic, models.ProviderOpenAI, models.ProviderGemini, models.ProviderOpenRouter:
+	case models.ProviderOpenCode, models.ProviderAnthropic, models.ProviderOpenAI, models.ProviderGemini, models.ProviderOpenRouter:
 		return models.ProviderName(input)
 	default:
-		return models.ProviderOpenCode
+		return models.ProviderOpenRouter
 	}
 }
 

--- a/internal/api/handlers/coding_credentials_test.go
+++ b/internal/api/handlers/coding_credentials_test.go
@@ -1241,3 +1241,43 @@ func TestAuthTypeForProvider(t *testing.T) {
 		})
 	}
 }
+
+func TestOpenCodeBackingProviderFromInput(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		input string
+		want  models.ProviderName
+	}{
+		{
+			name:  "omitted defaults to openrouter",
+			input: "",
+			want:  models.ProviderOpenRouter,
+		},
+		{
+			name:  "explicit native opencode is preserved",
+			input: string(models.ProviderOpenCode),
+			want:  models.ProviderOpenCode,
+		},
+		{
+			name:  "explicit openrouter is preserved",
+			input: string(models.ProviderOpenRouter),
+			want:  models.ProviderOpenRouter,
+		},
+		{
+			name:  "unknown defaults to openrouter",
+			input: "unknown",
+			want:  models.ProviderOpenRouter,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			require.Equal(t, tt.want, openCodeBackingProviderFromInput(tt.input), "OpenCode backing provider should normalize input")
+		})
+	}
+}


### PR DESCRIPTION
## Summary

OpenCode auth creation was defaulting to native OpenCode routes, even though the UI recommends OpenRouter (provider-pinned, US-based inference). This PR changes the default OpenCode backing provider and model to OpenRouter so new org/personal auth flows behave consistently and avoid provider-routing surprises. It also updates backend mapping defaults to align when `api_type` is omitted.

## Changes

- Default the frontend OpenCode backing provider from `opencode` to `openrouter` and set the default model to `openrouter/z-ai/glm-5.2`.
- Reset modal state on successful auth save (instead of manually clearing only some fields), reducing inconsistent UI state after creation.
- Update backend create-mapper defaults so omitted OpenCode `api_type` defaults to `openrouter` while preserving explicit `opencode`.
- Adjust affected frontend and backend tests to match new defaults and expectations.

## Validation

- `go test ./internal/api/handlers`
- `go vet ./internal/api/handlers`
- `npm --prefix frontend test -- --run src/lib/coding-auth-metadata.test.ts src/app/\(dashboard\)/settings/agent/page.test.tsx src/app/\(dashboard\)/settings/account/page.test.tsx`

Note: `npm ci` was required to install missing frontend dependencies; it completed but reported existing npm audit vulnerabilities.

[143.dev](https://143.dev) | [session 0e9de434](https://143.dev/sessions/0e9de434-9b77-477c-9616-bc741d18b858)

<!-- 143 readiness -->
**143 readiness:** not available for this revision.

Preview: https://143.dev/previews/github/assembledhq/143/pull/1658?launch=1