### PR TITLE
Hide OpenCode custom model override behind advanced collapsible in account/agent settings

### DIFF
--- a/frontend/src/app/(dashboard)/settings/account/page.test.tsx
+++ b/frontend/src/app/(dashboard)/settings/account/page.test.tsx
@@ -193,7 +193,8 @@ describe("Account settings page", () => {
 	    const dialog = screen.getByRole("dialog");
 	    expect(within(dialog).getByLabelText("OpenCode provider")).toBeInTheDocument();
 	    expect(within(dialog).getByLabelText("Default model")).toBeInTheDocument();
-	    expect(within(dialog).getByLabelText("Custom model override")).toBeInTheDocument();
+	    expect(within(dialog).queryByLabelText("Custom model override")).not.toBeInTheDocument();
+	    expect(within(dialog).getByRole("button", { name: "Advanced OpenCode model" })).toBeInTheDocument();
 	    expect(within(dialog).getByPlaceholderText("OpenCode or provider key")).toBeInTheDocument();
 	  });
 
@@ -295,6 +296,9 @@ describe("Account settings page", () => {
 	      target: { value: "sk-or-opencode" },
 	    });
 	    await within(dialog).findByText("Detected OpenRouter key from the sk-or prefix.");
+	    expect(within(dialog).queryByLabelText("Custom model override")).not.toBeInTheDocument();
+	    await user.click(within(dialog).getByRole("button", { name: "Advanced OpenCode model" }));
+	    expect(within(dialog).getByRole("button", { name: "What custom OpenCode model override does" })).toBeInTheDocument();
 	    fireEvent.change(within(dialog).getByLabelText("Custom model override"), {
 	      target: { value: "xai/grok-code-fast" },
 	    });

--- a/frontend/src/app/(dashboard)/settings/account/page.tsx
+++ b/frontend/src/app/(dashboard)/settings/account/page.tsx
@@ -26,6 +26,7 @@ import { CLISessionsCard } from "@/components/cli-sessions-card";
 import { CodexDeviceCodeModal } from "@/components/codex-device-code-modal";
 import { CodingAuthDialog } from "@/components/coding-auth-dialog";
 import { EmptyState } from "@/components/empty-state";
+import { OpenCodeCustomModelField } from "@/components/opencode-custom-model-field";
 import { PageContainer } from "@/components/page-container";
 import { PageHeader } from "@/components/page-header";
 import { SettingsLastActivity } from "@/components/settings/settings-last-activity";
@@ -727,15 +728,11 @@ export default function AccountPage() {
                     </SelectContent>
                   </Select>
                 </div>
-                <div className="space-y-2">
-                  <Label htmlFor="personal-opencode-model-custom">Custom model override</Label>
-                  <Input
-                    id="personal-opencode-model-custom"
-                    value={openCodeCustomModel}
-                    onChange={(event) => setOpenCodeCustomModel(event.target.value)}
-                    placeholder="provider/model (e.g. xai/grok-code-fast)"
-                  />
-                </div>
+                <OpenCodeCustomModelField
+                  id="personal-opencode-model-custom"
+                  value={openCodeCustomModel}
+                  onChange={setOpenCodeCustomModel}
+                />
               </>
             ) : null}
             <div className="space-y-2">

--- a/frontend/src/app/(dashboard)/settings/agent/page.test.tsx
+++ b/frontend/src/app/(dashboard)/settings/agent/page.test.tsx
@@ -213,7 +213,8 @@ describe("Agent settings page", () => {
 	    expect(within(dialog).getByLabelText("OpenCode provider")).toBeInTheDocument();
 	    expect(within(dialog).getByLabelText("Default model")).toBeInTheDocument();
 	    expect(within(dialog).getByText("Note: we recommend using OpenRouter routes, which are pinned to US based inference providers. Native OpenCode routes are not provider-pinned.")).toBeInTheDocument();
-	    expect(within(dialog).getByLabelText("Custom model override")).toBeInTheDocument();
+	    expect(within(dialog).queryByLabelText("Custom model override")).not.toBeInTheDocument();
+	    expect(within(dialog).getByRole("button", { name: "Advanced OpenCode model" })).toBeInTheDocument();
 	    expect(within(dialog).getByPlaceholderText("OpenCode or provider key")).toBeInTheDocument();
 	  });
 
@@ -252,6 +253,9 @@ describe("Agent settings page", () => {
 	      target: { value: "sk-or-opencode" },
 	    });
 	    expect(await within(dialog).findByText("Detected OpenRouter key from the sk-or prefix.")).toBeInTheDocument();
+	    expect(within(dialog).queryByLabelText("Custom model override")).not.toBeInTheDocument();
+	    await user.click(within(dialog).getByRole("button", { name: "Advanced OpenCode model" }));
+	    expect(within(dialog).getByRole("button", { name: "What custom OpenCode model override does" })).toBeInTheDocument();
 	    fireEvent.change(within(dialog).getByLabelText("Custom model override"), {
 	      target: { value: "xai/grok-code-fast" },
 	    });

--- a/frontend/src/app/(dashboard)/settings/agent/page.tsx
+++ b/frontend/src/app/(dashboard)/settings/agent/page.tsx
@@ -30,6 +30,7 @@ import type { AgentCapabilityDefinition, AgentCapabilityGrant, CodingCredentialS
 import { CodingAuthStack } from "@/components/coding-auth-stack";
 import { EmptyState } from "@/components/empty-state";
 import { AGENTS_BY_KEY } from "@/lib/agents";
+import { OpenCodeCustomModelField } from "@/components/opencode-custom-model-field";
 import { PageContainer } from "@/components/page-container";
 import { PageHeader } from "@/components/page-header";
 import { SettingsLastActivity } from "@/components/settings/settings-last-activity";
@@ -770,15 +771,11 @@ export default function AgentPage() {
                         </SelectContent>
                       </Select>
                     </div>
-                    <div className="space-y-2">
-                      <Label htmlFor="opencode-model-custom">Custom model override</Label>
-                      <Input
-                        id="opencode-model-custom"
-                        value={openCodeCustomModel}
-                        onChange={(event) => setOpenCodeCustomModel(event.target.value)}
-                        placeholder="provider/model (e.g. xai/grok-code-fast)"
-                      />
-                    </div>
+                    <OpenCodeCustomModelField
+                      id="opencode-model-custom"
+                      value={openCodeCustomModel}
+                      onChange={setOpenCodeCustomModel}
+                    />
                   </>
                 ) : null}
                 <div className="space-y-2">

--- a/frontend/src/components/opencode-custom-model-field.tsx
+++ b/frontend/src/components/opencode-custom-model-field.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+import { useState } from "react";
+import { ChevronDown, CircleHelp } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
+
+type OpenCodeCustomModelFieldProps = {
+  id: string;
+  value: string;
+  onChange: (value: string) => void;
+};
+
+export function OpenCodeCustomModelField({ id, value, onChange }: OpenCodeCustomModelFieldProps) {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <Collapsible open={open} onOpenChange={setOpen}>
+      <CollapsibleTrigger asChild>
+        <Button type="button" variant="outline" size="sm" className="w-fit">
+          <ChevronDown className={`h-4 w-4 transition-transform ${open ? "rotate-180" : ""}`} />
+          Advanced OpenCode model
+        </Button>
+      </CollapsibleTrigger>
+      <CollapsibleContent className="mt-4">
+        <div className="space-y-2 rounded-md border border-border bg-muted/20 p-3">
+          <div className="flex items-center gap-2">
+            <Label htmlFor={id}>Custom model override</Label>
+            <TooltipProvider delayDuration={150}>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="icon"
+                    className="h-5 w-5 rounded-full text-muted-foreground hover:text-foreground"
+                    aria-label="What custom OpenCode model override does"
+                  >
+                    <CircleHelp className="h-3.5 w-3.5" />
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent side="top" sideOffset={6} className="max-w-80 space-y-1.5">
+                  <p>Use this only when the model you need is not in the default list.</p>
+                  <p>When set, this provider/model id wins over the selected default model for this OpenCode auth.</p>
+                </TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
+          </div>
+          <Input
+            id={id}
+            value={value}
+            onChange={(event) => onChange(event.target.value)}
+            placeholder="provider/model (e.g. xai/grok-code-fast)"
+          />
+          <p className="text-xs text-muted-foreground">
+            The provider prefix must match how this key can run the model, such as openrouter, openai, anthropic, google, or opencode.
+          </p>
+        </div>
+      </CollapsibleContent>
+    </Collapsible>
+  );
+}


### PR DESCRIPTION
## Summary

Implemented.

Changed OpenCode auth setup in both org and personal settings so `Custom model override` is now hidden behind an `Advanced OpenCode model` collapsible. When expanded, it includes an info tooltip explaining that the field is only for non-default OpenCode `provider/model` IDs and that it overrides the selected default model for that auth.

Updated tests to cover the new collapsed-by-default behavior and the existing custom model save path.

Verification:
- `npm test -- --run 'src/app/(dashboard)/settings/agent/page.test.tsx'` passed
- `npm test -- --run 'src/app/(dashboard)/settings/account/page.test.tsx'` passed
- `npx eslint ...changed files...` passed

Note: I had to run `npm ci` because `node_modules` was not present; npm reported existing audit findings during install.

## Test plan

Validated by automated agent run.


[143.dev](https://143.dev) | [session 8127a8b8](https://143.dev/sessions/8127a8b8-298f-4201-b846-aab3e935faad)

<!-- 143 readiness -->
**143 readiness:** not available for this revision.

Preview: https://143.dev/previews/github/assembledhq/143/pull/1659?launch=1