### PR TITLE
Refactor preview link UI to match main preview behavior and remove dead overrides

### DIFF
--- a/frontend/src/app/(dashboard)/previews/[id]/page.test.tsx
+++ b/frontend/src/app/(dashboard)/previews/[id]/page.test.tsx
@@ -64,7 +64,7 @@ describe("PreviewLandingPage launch mode", () => {
     expect(screen.getByText("529975ce1faa")).toBeInTheDocument();
     expect(screen.getByText("Opening when ready")).toBeInTheDocument();
     expect(screen.getByText("This preview will open automatically when it is ready.")).toBeInTheDocument();
-    expect(screen.getByText("Start services")).toBeInTheDocument();
+    expect(screen.getAllByText("Start Services").length).toBeGreaterThan(0);
   });
 
   it("waits for bootstrap completion before navigating to the preview origin", async () => {
@@ -559,5 +559,36 @@ describe("PreviewLandingPage status mode", () => {
     ).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Start preview" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Preview actions" })).toBeInTheDocument();
+  });
+
+  it("warns when new commits are available on the branch preview", async () => {
+    searchParams = new URLSearchParams("");
+
+    server.use(
+      http.get("*/api/v1/previews/target-1", () =>
+        HttpResponse.json({
+          data: {
+            target_id: "target-1",
+            preview_id: "prev-1",
+            repository_id: "repo-1",
+            repository_full_name: "acme/web",
+            branch: "feature/preview",
+            commit_sha: "529975ce1faa2961ef3f23abde2418bf561116d9",
+            latest_commit_sha: "def456abc7890000000000000000000000000000",
+            new_commits_available: true,
+            source_type: "pull_request",
+            status: "ready",
+            current_phase: "ready",
+            stable_url: "https://143.dev/previews/target-1",
+            preview_url: "https://target-1.preview.143.dev",
+          },
+        }),
+      ),
+    );
+
+    renderLaunchPage();
+
+    expect(await screen.findByText("New commits available")).toBeInTheDocument();
+    expect(screen.getByText("Latest: def456abc789")).toBeInTheDocument();
   });
 });

--- a/frontend/src/app/(dashboard)/previews/[id]/page.tsx
+++ b/frontend/src/app/(dashboard)/previews/[id]/page.tsx
@@ -1,45 +1,15 @@
 "use client";
 
 import { use, useEffect, useMemo, useRef, useState } from "react";
-import Link from "next/link";
 import { useSearchParams } from "next/navigation";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import {
-  AlertTriangle,
-  ArrowLeft,
-  CheckCircle2,
-  Circle,
-  Clock3,
-  ExternalLink,
-  GitBranch,
-  GitPullRequest,
-  Loader2,
-  MoreHorizontal,
-  RotateCw,
-  Square,
-  XCircle,
-} from "lucide-react";
+import { AlertTriangle } from "lucide-react";
 
-import { PageContainer } from "@/components/page-container";
-import { PageHeader } from "@/components/page-header";
-import { OpenPreviewButton } from "@/components/preview/open-preview-button";
-import { PreviewStatusBadge } from "@/components/preview/preview-status-badge";
-import { Button } from "@/components/ui/button";
-import { Card, CardContent } from "@/components/ui/card";
-import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
+import { PreviewDetailSurface } from "@/components/preview/preview-detail-surface";
 import { ErrorNotice } from "@/components/ui/error-notice";
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuLabel,
-  DropdownMenuSeparator,
-  DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu";
-import { Separator } from "@/components/ui/separator";
 import { api } from "@/lib/api";
-import type { BranchPreviewResponse, SingleResponse } from "@/lib/types";
-import { ACTIVE_PREVIEW_STATUSES, formatPreviewStatus, type PreviewStatus } from "@/lib/preview-types";
+import { pollMs } from "@/lib/poll-intervals";
+import { ACTIVE_PREVIEW_STATUSES, type PreviewStatus } from "@/lib/preview-types";
 import {
   PREVIEW_BOOTSTRAP_COMPLETE_EVENT,
   PREVIEW_BOOTSTRAP_READY_EVENT,
@@ -49,22 +19,8 @@ import {
   PREVIEW_LAUNCH_COMPLETE_EVENT,
   previewBootstrapTimeoutDetails,
 } from "@/lib/preview-bootstrap";
-import { cn, safeExternalUrl } from "@/lib/utils";
-import { pollMs } from "@/lib/poll-intervals";
-
-type PreviewStepTone = "complete" | "active" | "failed" | "pending";
-
-function previewUnavailableRecoveryCopy(unavailableReason?: string) {
-  if (unavailableReason === "endpoint_unreachable") {
-    return {
-      title: "Preview connection lost",
-      description:
-        "The worker that was serving this preview stopped responding. Start the preview again to create a fresh runtime.",
-    };
-  }
-
-  return null;
-}
+import type { BranchPreviewResponse, SingleResponse } from "@/lib/types";
+import { safeExternalUrl } from "@/lib/utils";
 
 export default function PreviewLandingPage({
   params,
@@ -84,7 +40,6 @@ export function PreviewLandingContent({ id }: { id: string }) {
   const bootstrappedPreviewIdRef = useRef<string | null>(null);
   const launchStartAttemptedRef = useRef<string | null>(null);
   const [bootstrapError, setBootstrapError] = useState<string | null>(null);
-  const [detailsOpen, setDetailsOpen] = useState(false);
 
   const previewQuery = useQuery<SingleResponse<BranchPreviewResponse>>({
     queryKey: ["branch-preview", id],
@@ -92,10 +47,6 @@ export function PreviewLandingContent({ id }: { id: string }) {
     refetchInterval: (query) => {
       const status = query.state.data?.data.status;
       if (status === "starting") return pollMs(3000);
-      // Keep a slow poll while the preview is nominally up so a runtime
-      // crash that demotes it to "unhealthy"/"failed" (e.g. an OOM kill at
-      // serve time) is observed, instead of leaving the launch iframe
-      // spinning forever against a dead process.
       if (status === "ready" || status === "partially_ready" || status === "unhealthy") {
         return pollMs(15000);
       }
@@ -122,16 +73,8 @@ export function PreviewLandingContent({ id }: { id: string }) {
 
   const preview = previewQuery.data?.data;
   const previewStatus = preview?.status as PreviewStatus | undefined;
-  const isExpired = preview?.status === "expired";
-  const isFailed = preview?.status === "failed";
-  const isStarting = preview?.status === "starting" || restartPreview.isPending;
   const isActive = Boolean(previewStatus && ACTIVE_PREVIEW_STATUSES.includes(previewStatus));
-  // "unhealthy" is intentionally excluded: the primary service has crashed, so
-  // the preview can't actually serve and we must not try to bootstrap/iframe
-  // into it. It's surfaced as an error (see isUnhealthy / launchError) while
-  // lifecycle controls stay available via isActive.
   const isReady = previewStatus === "ready" || previewStatus === "partially_ready";
-  const isUnhealthy = previewStatus === "unhealthy";
   const previewUrl = safeExternalUrl(preview?.preview_url);
   const previewOrigin = useMemo(() => {
     if (!previewUrl) return "";
@@ -141,29 +84,7 @@ export function PreviewLandingContent({ id }: { id: string }) {
       return "";
     }
   }, [previewUrl]);
-
-  const title = preview?.repository_full_name
-    ? preview.repository_full_name
-    : preview
-      ? `Preview ${(preview.target_id ?? preview.preview_id ?? "").slice(0, 8)}`
-      : "Preview";
-  const subtitleParts = [
-    preview?.branch,
-    preview?.commit_sha ? preview.commit_sha.slice(0, 12) : null,
-    preview?.preview_config_name ? `Config ${preview.preview_config_name}` : null,
-  ].filter(Boolean);
-  const status = preview?.status ? formatPreviewStatus(preview.status) : "Loading";
-  const unavailableRecovery = previewUnavailableRecoveryCopy(preview?.unavailable_reason);
-  const stoppedAtText = preview?.stopped_at ? formatDateTime(preview.stopped_at) : null;
   const launchTargetId = preview?.preview_id ?? preview?.target_id;
-  const launchError =
-    bootstrapError ??
-    (preview?.status === "failed" ? preview.error || "Preview failed to start." : null) ??
-    (isUnhealthy
-      ? preview?.error || "The preview stopped responding — a service crashed (often out of memory). Restart to try again."
-      : null);
-  const commandIsFailed = isFailed || isUnhealthy || Boolean(bootstrapError);
-
   const shouldStartForLaunch =
     launchMode &&
     preview &&
@@ -171,13 +92,15 @@ export function PreviewLandingContent({ id }: { id: string }) {
     !isActive &&
     !restartPreview.isPending &&
     !previewQuery.isFetching;
+  const launchError =
+    bootstrapError ??
+    (preview?.status === "failed" ? preview.error || "Preview failed to start." : null) ??
+    (preview?.status === "unhealthy"
+      ? preview.error || "The preview stopped responding - a service crashed. Restart to try again."
+      : null);
 
   useEffect(() => {
     if (!shouldStartForLaunch || !launchTargetId) return;
-    // Dedupe on the stable route id, not launchTargetId: start-latest mints a
-    // fresh preview_id, so keying on launchTargetId lets a failed preview slip
-    // past the guard and auto-restart forever, hiding the error behind
-    // "Opening when ready". One auto-start per page load; failures stick.
     if (launchStartAttemptedRef.current === id) return;
     launchStartAttemptedRef.current = id;
     restartPreview.mutate({ previewId: launchTargetId, latest: true });
@@ -242,540 +165,69 @@ export function PreviewLandingContent({ id }: { id: string }) {
 
   const startLatest = () => {
     if (!launchTargetId) return;
-    // Manual retry starts the preview directly, so mark auto-start as done for
-    // this page rather than re-arming it — otherwise a second failure would
-    // trip the auto-restart loop again.
     launchStartAttemptedRef.current = id;
     restartPreview.mutate({ previewId: launchTargetId, latest: true });
   };
 
+  const title = preview?.repository_full_name
+    ? preview.repository_full_name
+    : preview
+      ? `Preview ${(preview.target_id ?? preview.preview_id ?? "").slice(0, 8)}`
+      : "Preview";
+  const subtitleParts = [
+    preview?.branch,
+    preview?.commit_sha ? preview.commit_sha.slice(0, 12) : null,
+    preview?.preview_config_name ? `Config ${preview.preview_config_name}` : null,
+  ].filter(Boolean);
+  const mutationError = stopPreview.error ?? restartPreview.error;
+
   return (
-    <PageContainer size="default">
-      <div className="space-y-4">
-        <Button asChild variant="ghost" size="sm" className="w-fit">
-          <Link href="/previews">
-            <ArrowLeft className="h-4 w-4" />
-            Previews
-          </Link>
-        </Button>
-
-        <PageHeader
-          title={title}
-          description={subtitleParts.length ? subtitleParts.join(" · ") : "Branch preview"}
-          action={
-            <div className="flex items-center gap-2">
-              <span className="hidden text-xs text-muted-foreground sm:inline">{status}</span>
-              {preview ? (
-                <PreviewActions
-                  preview={preview}
-                  isActive={isActive}
-                  isStarting={isStarting}
-                  canRestart={Boolean(preview.preview_id)}
-                  stopPending={stopPreview.isPending}
-                  restartPending={restartPreview.isPending}
-                  onStop={() => preview.preview_id && stopPreview.mutate(preview.preview_id)}
-                  onRestart={() => preview.preview_id && restartPreview.mutate({ previewId: preview.preview_id, latest: false })}
-                  onStartLatest={startLatest}
-                  onRefresh={() => previewQuery.refetch()}
-                />
-              ) : null}
-            </div>
-          }
-        />
-
-        <Card className="shadow-sm">
-          <CardContent className="space-y-5 p-5">
-            {previewQuery.isLoading ? (
-              <div className="flex items-center gap-3 text-sm text-muted-foreground">
-                <Loader2 className="h-4 w-4 animate-spin" />
-                Loading preview...
+    <PreviewDetailSurface
+      preview={preview}
+      isLoading={previewQuery.isLoading}
+      error={previewQuery.isError ? previewQuery.error : undefined}
+      title={title}
+      description={subtitleParts.length ? subtitleParts.join(" · ") : "Branch preview"}
+      launchMode={launchMode}
+      launchError={launchError}
+      startPending={restartPreview.isPending}
+      stopPending={stopPreview.isPending}
+      restartPending={restartPreview.isPending}
+      onStartLatest={startLatest}
+      onStop={() => preview?.preview_id && stopPreview.mutate(preview.preview_id)}
+      onRestart={() => preview?.preview_id && restartPreview.mutate({ previewId: preview.preview_id, latest: false })}
+      onRefresh={() => previewQuery.refetch()}
+      topContent={
+        <>
+          {preview?.new_commits_available ? (
+            <div className="flex items-start gap-3 rounded-md border border-warning/30 bg-warning/10 p-3 text-sm text-warning">
+              <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" />
+              <div className="min-w-0">
+                <p className="font-medium">New commits available</p>
+                <p className="break-all text-warning/80">
+                  Latest: {preview.latest_commit_sha?.slice(0, 12) ?? "unknown"}
+                </p>
               </div>
-            ) : previewQuery.isError ? (
-              <PreviewError
-                title="Preview could not be loaded"
-                message={previewQuery.error instanceof Error ? previewQuery.error.message : "Try refreshing the page."}
-              />
-            ) : preview ? (
-              <>
-                <PreviewCommandState
-                  preview={preview}
-                  launchMode={launchMode}
-                  isReady={isReady}
-                  isStarting={isStarting}
-                  isFailed={commandIsFailed}
-                  isExpired={isExpired}
-                  launchError={launchError}
-                  stoppedAtText={stoppedAtText}
-                  startLatest={startLatest}
-                />
-
-                <PreviewMetadata preview={preview} stoppedAtText={stoppedAtText} />
-
-                {preview.new_commits_available ? (
-                  <div className="flex items-start gap-3 rounded-md border border-warning/30 bg-warning/10 p-3 text-sm text-warning">
-                    <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" />
-                    <div className="min-w-0">
-                      <p className="font-medium">New commits available</p>
-                      <p className="break-all text-warning/80">
-                        Latest: {preview.latest_commit_sha?.slice(0, 12) ?? "unknown"}
-                      </p>
-                    </div>
-                  </div>
-                ) : null}
-
-                <PreviewProgress preview={preview} prominent={isStarting || commandIsFailed} />
-
-
-                {unavailableRecovery ? (
-                  <div className="flex items-start gap-3 rounded-md border border-border bg-muted/40 p-3 text-sm">
-                    <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-muted-foreground" />
-                    <div>
-                      <p className="font-medium text-foreground">{unavailableRecovery.title}</p>
-                      <p className="text-muted-foreground">{unavailableRecovery.description}</p>
-                    </div>
-                  </div>
-                ) : null}
-                {stopPreview.isError ? (
-                  <PreviewError
-                    title="Preview could not be stopped"
-                    message={stopPreview.error instanceof Error ? stopPreview.error.message : "Try again."}
-                  />
-                ) : null}
-
-                {restartPreview.isError ? (
-                  <PreviewError
-                    title="Preview could not be restarted"
-                    message={restartPreview.error instanceof Error ? restartPreview.error.message : "Try again."}
-                  />
-                ) : null}
-
-                <Collapsible open={detailsOpen} onOpenChange={setDetailsOpen}>
-                  <div className="flex items-center justify-between border-t border-border pt-4">
-                    <div>
-                      <p className="text-sm font-medium text-foreground">Details</p>
-                      <p className="text-xs text-muted-foreground">Services, infrastructure, and stable links.</p>
-                    </div>
-                    <CollapsibleTrigger asChild>
-                      <Button type="button" variant="outline" size="sm">
-                        {detailsOpen ? "Hide details" : "Show details"}
-                      </Button>
-                    </CollapsibleTrigger>
-                  </div>
-                  <CollapsibleContent className="mt-4 space-y-4">
-                    <PreviewAdvancedDetails preview={preview} />
-                  </CollapsibleContent>
-                </Collapsible>
-
-                {isReady && launchMode && previewUrl ? (
-                  <iframe
-                    ref={iframeRef}
-                    src={`${previewUrl.replace(/\/$/, "")}/bootstrap`}
-                    title="Preview bootstrap"
-                    className="hidden"
-                  />
-                ) : null}
-              </>
-            ) : null}
-          </CardContent>
-        </Card>
-      </div>
-    </PageContainer>
-  );
-}
-
-function PreviewCommandState({
-  preview,
-  launchMode,
-  isReady,
-  isStarting,
-  isFailed,
-  isExpired,
-  launchError,
-  stoppedAtText,
-  startLatest,
-}: {
-  preview: BranchPreviewResponse;
-  launchMode: boolean;
-  isReady: boolean;
-  isStarting: boolean;
-  isFailed: boolean;
-  isExpired: boolean;
-  launchError: string | null;
-  stoppedAtText: string | null;
-  startLatest: () => void;
-}) {
-  const previewUrl = safeExternalUrl(preview.preview_url);
-  const title = getCommandTitle({ launchMode, isReady, isStarting, isFailed, isExpired });
-  const description = getCommandDescription({ launchMode, isReady, isStarting, isFailed, isExpired, stoppedAtText });
-
-  return (
-    <div className="grid gap-4 md:grid-cols-[1fr_auto] md:items-start">
-      <div className="min-w-0 space-y-3">
-        <div className="flex items-start gap-3">
-          <StatusIcon status={preview.status} launchMode={launchMode} />
-          <div className="min-w-0 space-y-1">
-            <div className="flex flex-wrap items-center gap-2">
-              <h2 className="text-lg font-semibold tracking-tight text-foreground">{title}</h2>
-              <PreviewStatusBadge
-                status={preview.status}
-                variant={isReady ? "default" : "secondary"}
-                className="h-5 rounded-full px-2 text-xs"
-              />
-            </div>
-            <p className="max-w-2xl text-sm text-muted-foreground">{description}</p>
-          </div>
-        </div>
-
-        {launchError ? (
-          <PreviewError title={launchMode ? "Preview could not open" : "Preview could not start"} message={launchError} />
-        ) : null}
-
-        {preview.error && !launchError ? (
-          <PreviewError title="Preview failed" message={preview.error} />
-        ) : null}
-
-        {previewUrl ? (
-          <p className="truncate rounded-md border border-border bg-muted/30 px-3 py-2 font-mono text-xs text-muted-foreground">
-            {previewUrl}
-          </p>
-        ) : preview.stable_url ? (
-          <p className="break-all rounded-md border border-border bg-muted/30 px-3 py-2 font-mono text-xs text-muted-foreground">
-            {preview.stable_url}
-          </p>
-        ) : null}
-      </div>
-
-      <div className="flex gap-2 md:justify-end">
-        {isReady && previewUrl && !isFailed ? (
-          launchMode ? (
-            <Button type="button" disabled className="w-full sm:w-auto">
-              <Loader2 className="h-4 w-4 animate-spin" />
-              Connecting
-            </Button>
-          ) : (
-            <OpenPreviewButton previewId={preview.preview_id} previewUrl={preview.preview_url} className="w-full sm:w-auto" />
-          )
-        ) : (
-          <Button type="button" onClick={startLatest} disabled={isStarting} className="w-full sm:w-auto">
-            {isStarting ? <Loader2 className="h-4 w-4 animate-spin" /> : <RotateCw className="h-4 w-4" />}
-            {isStarting ? (launchMode ? "Waiting" : "Starting") : isFailed ? "Retry preview" : "Start preview"}
-          </Button>
-        )}
-      </div>
-    </div>
-  );
-}
-
-function PreviewMetadata({ preview, stoppedAtText }: { preview: BranchPreviewResponse; stoppedAtText: string | null }) {
-  const items = [
-    { label: "Repository", value: preview.repository_full_name ?? preview.repository_id ?? "Unknown" },
-    { label: "Branch", value: preview.branch ?? "Unknown" },
-    { label: "Commit", value: preview.commit_sha ? preview.commit_sha.slice(0, 12) : "Unknown" },
-    { label: "Source", value: preview.source_type ? formatPreviewStatus(preview.source_type) : "Manual" },
-    { label: "Expires", value: preview.expires_at ? formatDateTime(preview.expires_at) : "No runtime" },
-    { label: "Stopped", value: stoppedAtText ?? "Not stopped" },
-  ];
-
-  return (
-    <div className="grid gap-3 rounded-lg border border-border/70 bg-muted/20 p-3 text-sm sm:grid-cols-2 lg:grid-cols-3">
-      {items.map((item) => (
-        <div key={item.label} className="min-w-0">
-          <p className="text-xs text-muted-foreground">{item.label}</p>
-          <p className="break-words font-medium text-foreground">{item.value}</p>
-        </div>
-      ))}
-    </div>
-  );
-}
-
-function PreviewProgress({ preview, prominent }: { preview: BranchPreviewResponse; prominent: boolean }) {
-  if (!preview.phase_steps?.length && !prominent) {
-    return null;
-  }
-
-  const steps = preview.phase_steps?.length
-    ? preview.phase_steps
-    : [
-        { name: "checkout", status: preview.status === "failed" ? "failed" : "pending" },
-        { name: "install_build", status: "pending" },
-        { name: "start_services", status: "pending" },
-        { name: "readiness", status: "pending" },
-      ];
-
-  return (
-    <div className="space-y-3">
-      <div>
-        <p className="text-sm font-medium text-foreground">Startup progress</p>
-        <p className="text-xs text-muted-foreground">The preview opens after code, services, and readiness checks complete.</p>
-      </div>
-      <div className="grid gap-2 sm:grid-cols-4">
-        {steps.map((step) => (
-          <PreviewStep key={step.name} name={step.name} status={step.status} />
-        ))}
-      </div>
-    </div>
-  );
-}
-
-function PreviewStep({ name, status }: { name: string; status: string }) {
-  const tone = getStepTone(status);
-  const Icon = tone === "complete" ? CheckCircle2 : tone === "active" ? Loader2 : tone === "failed" ? XCircle : Circle;
-
-  return (
-    <div className="flex min-h-16 items-start gap-2 rounded-md border border-border px-3 py-2">
-      <Icon
-        className={cn(
-          "mt-0.5 h-4 w-4 shrink-0",
-          tone === "complete" && "text-primary",
-          tone === "active" && "animate-spin text-muted-foreground",
-          tone === "failed" && "text-destructive",
-          tone === "pending" && "text-muted-foreground/60",
-        )}
-      />
-      <div className="min-w-0">
-        <p className="text-sm font-medium text-foreground">{formatStepName(name)}</p>
-        <p className="text-xs capitalize text-muted-foreground">{status.replaceAll("_", " ")}</p>
-      </div>
-    </div>
-  );
-}
-
-function PreviewActions({
-  preview,
-  isActive,
-  isStarting,
-  canRestart,
-  stopPending,
-  restartPending,
-  onStop,
-  onRestart,
-  onStartLatest,
-  onRefresh,
-}: {
-  preview: BranchPreviewResponse;
-  isActive: boolean;
-  isStarting: boolean;
-  canRestart: boolean;
-  stopPending: boolean;
-  restartPending: boolean;
-  onStop: () => void;
-  onRestart: () => void;
-  onStartLatest: () => void;
-  onRefresh: () => void;
-}) {
-  const branchUrl = safeExternalUrl(preview.github_branch_url);
-  const pullRequestUrl = safeExternalUrl(preview.pull_request_url);
-
-  return (
-    <DropdownMenu>
-      <DropdownMenuTrigger asChild>
-        <Button type="button" variant="outline" size="sm">
-          <MoreHorizontal className="h-4 w-4" />
-          Preview actions
-        </Button>
-      </DropdownMenuTrigger>
-      <DropdownMenuContent align="end" className="w-56">
-        <DropdownMenuLabel>Preview actions</DropdownMenuLabel>
-        <DropdownMenuItem onSelect={onRefresh}>
-          <RotateCw className="h-4 w-4" />
-          Refresh status
-        </DropdownMenuItem>
-        <DropdownMenuItem onSelect={onStartLatest} disabled={restartPending || isStarting}>
-          <GitBranch className="h-4 w-4" />
-          Restart
-        </DropdownMenuItem>
-        {canRestart ? (
-          <DropdownMenuItem onSelect={onRestart} disabled={restartPending}>
-            <RotateCw className="h-4 w-4" />
-            Restart runtime
-          </DropdownMenuItem>
-        ) : null}
-        {isActive ? (
-          <DropdownMenuItem variant="destructive" onSelect={onStop} disabled={stopPending}>
-            <Square className="h-4 w-4" />
-            Stop runtime
-          </DropdownMenuItem>
-        ) : null}
-        {branchUrl || pullRequestUrl ? <DropdownMenuSeparator /> : null}
-        {pullRequestUrl ? (
-          <DropdownMenuItem asChild>
-            <a href={pullRequestUrl} target="_blank" rel="noopener noreferrer">
-              <GitPullRequest className="h-4 w-4" />
-              Pull request
-            </a>
-          </DropdownMenuItem>
-        ) : null}
-        {branchUrl ? (
-          <DropdownMenuItem asChild>
-            <a href={branchUrl} target="_blank" rel="noopener noreferrer">
-              <ExternalLink className="h-4 w-4" />
-              GitHub branch
-            </a>
-          </DropdownMenuItem>
-        ) : null}
-      </DropdownMenuContent>
-    </DropdownMenu>
-  );
-}
-
-function PreviewAdvancedDetails({ preview }: { preview: BranchPreviewResponse }) {
-  const hasServices = Boolean(preview.services?.length);
-  const hasInfrastructure = Boolean(preview.infrastructure?.length);
-
-  return (
-    <div className="space-y-4">
-      {(hasServices || hasInfrastructure) ? (
-        <div className="grid gap-4 md:grid-cols-2">
-          {hasServices ? (
-            <div className="space-y-2">
-              <p className="text-sm font-medium text-foreground">Services</p>
-              {preview.services?.map((service) => (
-                <div key={service.id} className="flex min-h-10 items-center justify-between gap-3 rounded-md border border-border px-3 py-2 text-sm">
-                  <span className="truncate text-foreground">{service.service_name}</span>
-                  <PreviewStatusBadge status={service.status} variant={service.status === "ready" ? "default" : "secondary"} />
-                </div>
-              ))}
             </div>
           ) : null}
-          {hasInfrastructure ? (
-            <div className="space-y-2">
-              <p className="text-sm font-medium text-foreground">Infrastructure</p>
-              {preview.infrastructure?.map((infra) => (
-                <div key={infra.id} className="flex min-h-10 items-center justify-between gap-3 rounded-md border border-border px-3 py-2 text-sm">
-                  <span className="truncate text-foreground">{infra.infra_name}</span>
-                  <PreviewStatusBadge status={infra.status} variant={infra.status === "healthy" ? "default" : "secondary"} />
-                </div>
-              ))}
-            </div>
+          {mutationError ? (
+            <ErrorNotice
+              title="Preview action failed"
+              description={mutationError instanceof Error ? mutationError.message : "Try again."}
+            />
           ) : null}
-        </div>
-      ) : (
-        <p className="rounded-md border border-border bg-muted/20 px-3 py-2 text-sm text-muted-foreground">
-          No service details are available for this preview yet.
-        </p>
-      )}
-
-      <Separator />
-
-      <div className="grid gap-3 text-xs sm:grid-cols-2">
-        <DetailValue label="Stable link" value={preview.stable_url} />
-        <DetailValue label="Created" value={preview.created_at ? formatDateTime(preview.created_at) : "Unknown"} />
-        {preview.source_url ? <DetailValue label="Source link" value={preview.source_url} /> : null}
-        {preview.request_id ? <DetailValue label="Request" value={preview.request_id} /> : null}
-      </div>
-    </div>
+        </>
+      }
+      footerContent={
+        isReady && launchMode && previewUrl ? (
+          <iframe
+            ref={iframeRef}
+            src={`${previewUrl.replace(/\/$/, "")}/bootstrap`}
+            title="Preview bootstrap"
+            className="hidden"
+          />
+        ) : null
+      }
+    />
   );
-}
-
-function DetailValue({ label, value }: { label: string; value: string }) {
-  return (
-    <div className="min-w-0">
-      <p className="text-muted-foreground">{label}</p>
-      <p className="break-all font-medium text-foreground">{value}</p>
-    </div>
-  );
-}
-
-function PreviewError({ title, message }: { title: string; message: string }) {
-  return <ErrorNotice title={title} description={message} />;
-}
-
-function StatusIcon({ status, launchMode }: { status: string; launchMode: boolean }) {
-  if (status === "ready" || status === "partially_ready" || status === "unhealthy") {
-    return (
-      <div className="rounded-full border border-primary/20 bg-primary/10 p-2 text-primary">
-        {launchMode ? <Loader2 className="h-4 w-4 animate-spin" /> : <CheckCircle2 className="h-4 w-4" />}
-      </div>
-    );
-  }
-  if (status === "starting") {
-    return (
-      <div className="rounded-full border border-border bg-muted/50 p-2 text-muted-foreground">
-        <Loader2 className="h-4 w-4 animate-spin" />
-      </div>
-    );
-  }
-  if (status === "failed") {
-    return (
-      <div className="rounded-full border border-destructive/20 bg-destructive/5 p-2 text-destructive">
-        <XCircle className="h-4 w-4" />
-      </div>
-    );
-  }
-  return (
-    <div className="rounded-full border border-border bg-muted/40 p-2 text-muted-foreground">
-      <Clock3 className="h-4 w-4" />
-    </div>
-  );
-}
-
-function getCommandTitle({
-  launchMode,
-  isReady,
-  isStarting,
-  isFailed,
-  isExpired,
-}: {
-  launchMode: boolean;
-  isReady: boolean;
-  isStarting: boolean;
-  isFailed: boolean;
-  isExpired: boolean;
-}) {
-  if (launchMode && isFailed) return "Preview could not open";
-  if (launchMode && isReady) return "Opening preview";
-  if (launchMode && isStarting) return "Opening when ready";
-  if (isReady) return "Preview is ready";
-  if (isStarting) return "Starting preview";
-  if (isFailed) return "Preview failed";
-  if (isExpired) return "Preview expired";
-  return "Preview is stopped";
-}
-
-function getCommandDescription({
-  launchMode,
-  isReady,
-  isStarting,
-  isFailed,
-  isExpired,
-  stoppedAtText,
-}: {
-  launchMode: boolean;
-  isReady: boolean;
-  isStarting: boolean;
-  isFailed: boolean;
-  isExpired: boolean;
-  stoppedAtText: string | null;
-}) {
-  if (launchMode && isFailed) return "This preview failed to start. Retry to try opening it again.";
-  if (launchMode && isReady) return "Connecting this browser to the running preview.";
-  if (launchMode && isStarting) return "This preview will open automatically when it is ready.";
-  if (isReady) return "Open the running branch preview, or use preview actions for lifecycle controls.";
-  if (isStarting) return "Preparing the branch runtime. The preview will be available after readiness checks pass.";
-  if (isFailed) return "Retry the preview from this page, then use details only if the failure needs investigation.";
-  if (isExpired) return stoppedAtText ? `Last stopped at ${stoppedAtText}. Start it again when you need it.` : "Start a fresh runtime for this branch.";
-  return stoppedAtText ? `Last stopped at ${stoppedAtText}.` : "Start this preview when you need to see the branch running.";
-}
-
-function getStepTone(status: string): PreviewStepTone {
-  const normalized = status.toLowerCase();
-  if (["complete", "completed", "ready", "healthy", "success"].includes(normalized)) return "complete";
-  if (["active", "running", "starting", "provisioning"].includes(normalized)) return "active";
-  if (["failed", "unhealthy", "error"].includes(normalized)) return "failed";
-  return "pending";
-}
-
-function formatStepName(name: string) {
-  const normalized = name.replaceAll("_", " ").toLowerCase();
-  return normalized.charAt(0).toUpperCase() + normalized.slice(1);
-}
-
-function formatDateTime(value: string) {
-  return new Date(value).toLocaleString(undefined, {
-    month: "short",
-    day: "numeric",
-    year: "numeric",
-    hour: "numeric",
-    minute: "2-digit",
-  });
 }

--- a/frontend/src/app/(dashboard)/previews/github/[owner]/[repo]/pull/[number]/page.test.tsx
+++ b/frontend/src/app/(dashboard)/previews/github/[owner]/[repo]/pull/[number]/page.test.tsx
@@ -353,9 +353,10 @@ describe("PullRequestPreviewPage", () => {
 
     renderWithProviders(<PullRequestPreviewContent owner="acme" repo="web" number="42" />);
 
-    expect(await screen.findByText("Partially Ready")).toBeInTheDocument();
+    expect((await screen.findAllByText("Partially Ready")).length).toBeGreaterThan(0);
     expect(screen.getByText("Start Services")).toBeInTheDocument();
-    expect(screen.getByText("Starting")).toBeInTheDocument();
+    await userEvent.click(screen.getByRole("button", { name: "Show details" }));
+    expect(screen.getAllByText("Starting").length).toBeGreaterThan(0);
     expect(screen.getByText("Unhealthy")).toBeInTheDocument();
   });
 
@@ -396,8 +397,9 @@ describe("PullRequestPreviewPage", () => {
     renderWithProviders(<PullRequestPreviewContent owner="acme" repo="web" number="42" />);
 
     const startingLabels = await screen.findAllByText("Starting");
-    expect(startingLabels).toHaveLength(2);
-    for (const label of startingLabels) {
+    const startingBadges = startingLabels.filter((label) => label.closest('[data-slot="badge"]'));
+    expect(startingBadges.length).toBeGreaterThan(0);
+    for (const label of startingBadges) {
       expect(label.closest('[data-slot="badge"]')?.querySelector('[data-slot="preview-status-spinner"]')).toBeInTheDocument();
     }
   });

--- a/frontend/src/app/(dashboard)/previews/github/[owner]/[repo]/pull/[number]/page.tsx
+++ b/frontend/src/app/(dashboard)/previews/github/[owner]/[repo]/pull/[number]/page.tsx
@@ -2,26 +2,18 @@
 
 import { use, useEffect, useMemo, useRef, useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { AlertTriangle, GitBranch, GitPullRequest, Loader2, RotateCw } from "lucide-react";
+import { AlertTriangle } from "lucide-react";
 import { useSearchParams } from "next/navigation";
 
-import { PageContainer } from "@/components/page-container";
-import { PageHeader } from "@/components/page-header";
 import { OpenPreviewButton, usePreviewLauncher } from "@/components/preview/open-preview-button";
-import { PreviewStatusBadge } from "@/components/preview/preview-status-badge";
-import { Button } from "@/components/ui/button";
-import { Card, CardContent } from "@/components/ui/card";
-import { ErrorText } from "@/components/ui/error-notice";
-import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
+import { PreviewDetailSurface, type PreviewCommandOverride } from "@/components/preview/preview-detail-surface";
 import { api } from "@/lib/api";
-import { formatPreviewStatus } from "@/lib/preview-types";
 import type { BranchPreviewResponse, SingleResponse } from "@/lib/types";
 import { safeExternalUrl } from "@/lib/utils";
 import { pollMs } from "@/lib/poll-intervals";
 
 const ZERO_UUID = "00000000-0000-0000-0000-000000000000";
 const RESTART_LATEST_LABEL = "Restart";
-const RESTART_LATEST_TOOLTIP = "Restart preview from the latest source state";
 
 export default function PullRequestPreviewPage({
   params,
@@ -81,9 +73,7 @@ export function PullRequestPreviewContent({
 
   const preview = previewQuery.data?.data;
   const title = `${owner}/${repo}#${number}`;
-  const status = preview?.status ? formatPreviewStatus(preview.status) : "Loading";
   const targetId = previewTargetId(preview?.target_id);
-  const isExpired = preview?.status === "expired";
   const launch = preview?.launch;
   const launchState = launchStateCopy(preview);
   const launchSessionShouldOpen = launchRequested || launchSessionActive;
@@ -95,6 +85,29 @@ export function PullRequestPreviewContent({
     launch?.action === "start" ||
     (Boolean(targetId) && (launch?.action === "start_latest" || launch?.action === "resume"));
   const safePreviewURL = safeExternalUrl(preview?.preview_url);
+  const topContent = preview?.new_commits_available ? (
+    <div className="flex items-start gap-3 rounded-md border border-warning/30 bg-warning/10 p-3 text-sm text-warning">
+      <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" />
+      <div className="min-w-0">
+        <p className="font-medium">New commits available</p>
+        <p className="break-all text-warning/80">
+          {launch?.message ?? `Latest head: ${preview.latest_commit_sha?.slice(0, 12) ?? "unknown"}`}
+        </p>
+      </div>
+    </div>
+  ) : null;
+  const stalePreviewAction =
+    preview?.new_commits_available &&
+    safeExternalUrl(launch?.stale_preview_url ?? preview.preview_url) &&
+    preview.preview_id ? (
+      <OpenPreviewButton
+        previewId={preview.preview_id}
+        previewUrl={launch?.stale_preview_url ?? preview.preview_url}
+        label={launch?.secondary_label ?? "Open stale preview"}
+        variant="outline"
+        className="w-full sm:w-auto"
+      />
+    ) : null;
 
   useEffect(() => {
     if (!preview || !launchSessionShouldOpen || !launch?.auto_open) return;
@@ -171,199 +184,30 @@ export function PullRequestPreviewContent({
   };
 
   return (
-    <PageContainer size="default">
-      <div className="space-y-6">
-        <PageHeader
-          title={title}
-          description="Pull request preview"
-          action={
-            <PreviewStatusBadge
-              status={preview?.status ?? "loading"}
-              label={status}
-              variant={preview?.status === "ready" ? "default" : "secondary"}
-            />
-          }
-        />
-
-        <Card>
-          <CardContent className="space-y-5 pt-6">
-            {previewQuery.isLoading ? (
-              <p className="text-sm text-muted-foreground">Loading PR preview...</p>
-            ) : previewQuery.isError ? (
-              <ErrorText className="text-sm">
-                {previewQuery.error instanceof Error ? previewQuery.error.message : "Preview could not be loaded."}
-              </ErrorText>
-            ) : preview ? (
-              <>
-                {preview.new_commits_available ? (
-                  <div className="flex items-start gap-3 rounded-md border border-warning/30 bg-warning/10 p-3 text-sm text-warning">
-                    <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" />
-                    <div className="min-w-0">
-                      <p className="font-medium">New commits available</p>
-                      <p className="break-all text-warning/80">
-                        {launch?.message ?? `Latest head: ${preview.latest_commit_sha?.slice(0, 12) ?? "unknown"}`}
-                      </p>
-                    </div>
-                  </div>
-                ) : null}
-
-                {launchState ? (
-                  <div className={`flex items-start gap-3 rounded-md border p-3 text-sm ${launchState.className}`}>
-                    {launchState.loading ? (
-                      <Loader2 className="mt-0.5 h-4 w-4 shrink-0 animate-spin" />
-                    ) : (
-                      <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" />
-                    )}
-                    <div className="min-w-0">
-                      <p className="font-medium">{launchState.title}</p>
-                      <p>{launchState.description}</p>
-                    </div>
-                  </div>
-                ) : null}
-
-                {isExpired && !launchState ? (
-                  <div className="flex items-start gap-3 rounded-md border border-border bg-muted/40 p-3 text-sm">
-                    <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-muted-foreground" />
-                    <div>
-                      <p className="font-medium text-foreground">Preview expired</p>
-                      <p className="text-muted-foreground">Restart to launch a fresh runtime for this pull request.</p>
-                    </div>
-                  </div>
-                ) : null}
-
-                <div className="grid gap-3 text-sm md:grid-cols-2">
-                  <div>
-                    <p className="text-muted-foreground">Repository</p>
-                    <p className="font-medium text-foreground">{preview.repository_full_name ?? `${owner}/${repo}`}</p>
-                  </div>
-                  <div>
-                    <p className="text-muted-foreground">Branch</p>
-                    <p className="break-all font-medium text-foreground">{preview.branch ?? "Unknown"}</p>
-                  </div>
-                  <div>
-                    <p className="text-muted-foreground">Commit</p>
-                    <p className="break-all font-medium text-foreground">{preview.commit_sha?.slice(0, 12) ?? "Unknown"}</p>
-                  </div>
-                  <div>
-                    <p className="text-muted-foreground">Phase</p>
-                    <p className="font-medium text-foreground">{preview.current_phase ? formatPreviewStatus(preview.current_phase) : status}</p>
-                  </div>
-                </div>
-
-                {preview.error ? (
-                  <ErrorText className="rounded-md border border-destructive/20 bg-destructive/5 p-3 text-sm">
-                    {preview.error}
-                  </ErrorText>
-                ) : null}
-                {launchError ? (
-                  <ErrorText className="rounded-md border border-destructive/20 bg-destructive/5 p-3 text-sm">
-                    {launchError.message}
-                  </ErrorText>
-                ) : null}
-
-                {preview.phase_steps?.length ? (
-                  <div className="space-y-2">
-                    <p className="text-sm font-medium text-foreground">Startup progress</p>
-                    <div className="grid gap-2 md:grid-cols-4">
-                      {preview.phase_steps.map((step) => (
-                        <div key={step.name} className="rounded-md border border-border px-3 py-2">
-                          <p className="text-sm font-medium capitalize text-foreground">{step.name.replaceAll("_", " ")}</p>
-                          <p className="text-xs capitalize text-muted-foreground">{step.status}</p>
-                        </div>
-                      ))}
-                    </div>
-                  </div>
-                ) : null}
-
-                {(preview.services?.length || preview.infrastructure?.length) ? (
-                  <div className="grid gap-3 md:grid-cols-2">
-                    <div className="space-y-2">
-                      <p className="text-sm font-medium text-foreground">Services</p>
-                      {(preview.services ?? []).map((service) => (
-                        <div key={service.id} className="flex items-center justify-between rounded-md border border-border px-3 py-2 text-sm">
-                          <span className="truncate">{service.service_name}</span>
-                          <PreviewStatusBadge status={service.status} variant={service.status === "ready" ? "default" : "secondary"} />
-                        </div>
-                      ))}
-                    </div>
-                    <div className="space-y-2">
-                      <p className="text-sm font-medium text-foreground">Infrastructure</p>
-                      {(preview.infrastructure ?? []).map((infra) => (
-                        <div key={infra.id} className="flex items-center justify-between rounded-md border border-border px-3 py-2 text-sm">
-                          <span className="truncate">{infra.infra_name}</span>
-                          <PreviewStatusBadge status={infra.status} variant={infra.status === "healthy" ? "default" : "secondary"} />
-                        </div>
-                      ))}
-                    </div>
-                  </div>
-                ) : null}
-
-                <div className="flex flex-col gap-2 sm:flex-row">
-                  {safePreviewURL && preview.preview_id && launch?.action !== "blocked" && launch?.action !== "closed" && launch?.action !== "wait" && !preview.new_commits_available ? (
-                    <OpenPreviewButton previewId={preview.preview_id} previewUrl={safePreviewURL} label={launch?.primary_label ?? "Open preview"} />
-                  ) : null}
-                  {preview.new_commits_available && safeExternalUrl(launch?.stale_preview_url ?? preview.preview_url) && preview.preview_id ? (
-                    <OpenPreviewButton
-                      previewId={preview.preview_id}
-                      previewUrl={launch?.stale_preview_url ?? preview.preview_url}
-                      label={launch?.secondary_label ?? "Open stale preview"}
-                      variant="outline"
-                    />
-                  ) : null}
-                  {safeExternalUrl(preview.pull_request_url) ? (
-                    <Button asChild variant="outline">
-                      <a href={safeExternalUrl(preview.pull_request_url)} target="_blank" rel="noopener noreferrer">
-                        <GitPullRequest className="h-4 w-4" />
-                        Open PR
-                      </a>
-                    </Button>
-                  ) : null}
-                  {safeExternalUrl(preview.github_branch_url) ? (
-                    <Button asChild variant="outline">
-                      <a href={safeExternalUrl(preview.github_branch_url)} target="_blank" rel="noopener noreferrer">
-                        <GitBranch className="h-4 w-4" />
-                        Branch
-                      </a>
-                    </Button>
-                  ) : null}
-                  {showStartAction ? (
-                    <TooltipProvider delayDuration={150}>
-                      <Tooltip>
-                        <TooltipTrigger asChild>
-                          <Button
-                            type="button"
-                            variant={launch?.action === "start_latest" || launch?.action === "start" || launch?.action === "resume" ? "default" : "outline"}
-                            aria-label={launch?.action === "start_latest" ? RESTART_LATEST_TOOLTIP : undefined}
-                            onClick={handleStartLatest}
-                            disabled={startLatest.isPending || startPullRequest.isPending}
-                          >
-                            <GitBranch className="h-4 w-4" />
-                            {startLatest.isPending || startPullRequest.isPending ? "Starting..." : launchStartLabel(launch?.action, launch?.primary_label)}
-                          </Button>
-                        </TooltipTrigger>
-                        {launch?.action === "start_latest" ? <TooltipContent>{RESTART_LATEST_TOOLTIP}</TooltipContent> : null}
-                      </Tooltip>
-                    </TooltipProvider>
-                  ) : null}
-                  {retryAllowed ? (
-                    <Button
-                      type="button"
-                      variant={launch?.action === "retry" ? "default" : "outline"}
-                      onClick={handleRetry}
-                      disabled={restart.isPending}
-                    >
-                      <RotateCw className="h-4 w-4" />
-                      {restart.isPending ? "Retrying..." : launch?.action === "retry" ? (launch.primary_label ?? "Retry preview") : "Retry"}
-                    </Button>
-                  ) : null}
-                </div>
-                {bootstrapFrame}
-              </>
-            ) : null}
-          </CardContent>
-        </Card>
-      </div>
-    </PageContainer>
+    <PreviewDetailSurface
+      preview={preview}
+      isLoading={previewQuery.isLoading}
+      error={previewQuery.isError ? previewQuery.error : undefined}
+      title={title}
+      description="Pull request preview"
+      launchMode={launchSessionShouldOpen}
+      launchError={launchError?.message ?? null}
+      startPending={startLatest.isPending || startPullRequest.isPending || restart.isPending}
+      hidePrimaryStart={Boolean(
+        (launch?.action === "blocked" && preview?.status !== "failed") ||
+          launch?.action === "closed" ||
+          (!showStartAction && !retryAllowed),
+      )}
+      primaryStartLabel={retryAllowed && !showStartAction ? "Retry preview" : launchStartLabel(launch?.action, launch?.primary_label)}
+      commandOverride={launchState}
+      topContent={topContent}
+      primaryExtraAction={stalePreviewAction}
+      footerContent={bootstrapFrame}
+      onStartLatest={retryAllowed && !showStartAction ? handleRetry : handleStartLatest}
+      onRestart={preview?.preview_id ? handleRetry : undefined}
+      onRefresh={() => previewQuery.refetch()}
+      canRestart={Boolean(preview?.preview_id) && launch?.action !== "closed"}
+    />
   );
 }
 
@@ -389,7 +233,7 @@ function launchStartLabel(action: NonNullable<BranchPreviewResponse["launch"]>["
 function launchStateCopy(preview: BranchPreviewResponse | undefined): {
   title: string;
   description: string;
-  className: string;
+  tone?: PreviewCommandOverride["tone"];
   loading?: boolean;
 } | null {
   const launch = preview?.launch;
@@ -398,7 +242,7 @@ function launchStateCopy(preview: BranchPreviewResponse | undefined): {
     return {
       title: "Preview failed",
       description: preview.error || launch.message || "Retry the preview to rebuild this pull request.",
-      className: "border-destructive/20 bg-destructive/5 text-destructive",
+      tone: "destructive",
     };
   }
   switch (launch.action) {
@@ -406,14 +250,12 @@ function launchStateCopy(preview: BranchPreviewResponse | undefined): {
       return {
         title: "Starting preview",
         description: launch.message ?? "The preview is starting and will be ready shortly.",
-        className: "border-border bg-muted/40 text-foreground",
         loading: true,
       };
     case "resume":
       return {
         title: "Preview ready to resume",
         description: launch.message ?? "Resume this preview to open the running app.",
-        className: "border-border bg-muted/40 text-foreground",
       };
     case "start":
       return {
@@ -421,25 +263,24 @@ function launchStateCopy(preview: BranchPreviewResponse | undefined): {
         description: launch.message ?? (preview?.status === "expired"
           ? "Restart to launch a fresh runtime for this pull request."
           : "Start a preview for the latest pull request head."),
-        className: "border-border bg-muted/40 text-foreground",
       };
     case "retry":
       return {
         title: "Preview failed",
         description: launch.message ?? preview?.error ?? "Retry the preview to rebuild this pull request.",
-        className: "border-destructive/20 bg-destructive/5 text-destructive",
+        tone: "destructive",
       };
     case "blocked":
       return {
         title: "Preview blocked",
         description: launch.message ?? blockedLaunchMessage(launch.reason),
-        className: "border-destructive/20 bg-destructive/5 text-destructive",
+        tone: "destructive",
       };
     case "closed":
       return {
         title: "Pull request closed",
         description: launch.message ?? "This pull request is closed, so 143 will not start a new preview by default.",
-        className: "border-border bg-muted/40 text-foreground",
+        tone: "muted",
       };
     default:
       return null;

--- a/frontend/src/components/preview/preview-detail-surface.tsx
+++ b/frontend/src/components/preview/preview-detail-surface.tsx
@@ -1,0 +1,684 @@
+"use client";
+
+import { useState, type ReactNode } from "react";
+import Link from "next/link";
+import {
+  AlertTriangle,
+  ArrowLeft,
+  CheckCircle2,
+  Circle,
+  Clock3,
+  ExternalLink,
+  GitBranch,
+  GitPullRequest,
+  Loader2,
+  MoreHorizontal,
+  RotateCw,
+  Square,
+  XCircle,
+} from "lucide-react";
+
+import { PageContainer } from "@/components/page-container";
+import { PageHeader } from "@/components/page-header";
+import { OpenPreviewButton } from "@/components/preview/open-preview-button";
+import { PreviewStatusBadge } from "@/components/preview/preview-status-badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
+import { ErrorNotice } from "@/components/ui/error-notice";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { Separator } from "@/components/ui/separator";
+import { ACTIVE_PREVIEW_STATUSES, formatPreviewStatus, type PreviewStatus } from "@/lib/preview-types";
+import type { BranchPreviewResponse } from "@/lib/types";
+import { cn, safeExternalUrl } from "@/lib/utils";
+
+type PreviewStepTone = "complete" | "active" | "failed" | "pending";
+
+export interface PreviewCommandOverride {
+  title: string;
+  description: string;
+  tone?: "default" | "muted" | "warning" | "destructive";
+  loading?: boolean;
+}
+
+export interface PreviewDetailSurfaceProps {
+  preview?: BranchPreviewResponse;
+  isLoading: boolean;
+  error?: unknown;
+  title: string;
+  description: string;
+  backHref?: string;
+  backLabel?: string;
+  launchMode?: boolean;
+  launchError?: string | null;
+  startPending?: boolean;
+  stopPending?: boolean;
+  restartPending?: boolean;
+  canRestart?: boolean;
+  hidePrimaryStart?: boolean;
+  primaryStartLabel?: string;
+  commandOverride?: PreviewCommandOverride | null;
+  topContent?: ReactNode;
+  primaryExtraAction?: ReactNode;
+  footerContent?: ReactNode;
+  onStartLatest: () => void;
+  onStop?: () => void;
+  onRestart?: () => void;
+  onRefresh?: () => void;
+}
+
+export function PreviewDetailSurface({
+  preview,
+  isLoading,
+  error,
+  title,
+  description,
+  backHref = "/previews",
+  backLabel = "Previews",
+  launchMode = false,
+  launchError = null,
+  startPending = false,
+  stopPending = false,
+  restartPending = false,
+  canRestart,
+  hidePrimaryStart = false,
+  primaryStartLabel,
+  commandOverride,
+  topContent,
+  primaryExtraAction,
+  footerContent,
+  onStartLatest,
+  onStop,
+  onRestart,
+  onRefresh,
+}: PreviewDetailSurfaceProps) {
+  const [detailsOpen, setDetailsOpen] = useState(false);
+  const previewStatus = preview?.status as PreviewStatus | undefined;
+  const isExpired = preview?.status === "expired";
+  const isFailed = preview?.status === "failed" || Boolean(launchError);
+  const isStarting = preview?.status === "starting" || startPending || restartPending;
+  const isActive = Boolean(previewStatus && ACTIVE_PREVIEW_STATUSES.includes(previewStatus));
+  const isReady = previewStatus === "ready" || previewStatus === "partially_ready";
+  const isUnhealthy = previewStatus === "unhealthy";
+  const status = preview?.status ? formatPreviewStatus(preview.status) : "Loading";
+  const stoppedAtText = preview?.stopped_at ? formatDateTime(preview.stopped_at) : null;
+  const unavailableRecovery = previewUnavailableRecoveryCopy(preview?.unavailable_reason);
+  const commandError =
+    launchError ??
+    (preview?.status === "failed" ? preview.error || "Preview failed to start." : null) ??
+    (isUnhealthy
+      ? preview?.error || "The preview stopped responding - a service crashed. Restart to try again."
+      : null);
+
+  return (
+    <PageContainer size="default">
+      <div className="space-y-4">
+        <Button asChild variant="ghost" size="sm" className="w-fit">
+          <Link href={backHref}>
+            <ArrowLeft className="h-4 w-4" />
+            {backLabel}
+          </Link>
+        </Button>
+
+        <PageHeader
+          title={title}
+          description={description}
+          action={
+            <div className="flex items-center gap-2">
+              <span className="hidden text-xs text-muted-foreground sm:inline">{status}</span>
+              {preview ? (
+                <PreviewActions
+                  preview={preview}
+                  isActive={isActive}
+                  isStarting={isStarting}
+                  canRestart={canRestart ?? Boolean(preview.preview_id)}
+                  stopPending={stopPending}
+                  restartPending={restartPending}
+                  onStop={onStop}
+                  onRestart={onRestart}
+                  onStartLatest={onStartLatest}
+                  onRefresh={onRefresh}
+                />
+              ) : null}
+            </div>
+          }
+        />
+
+        <Card className="shadow-sm">
+          <CardContent className="space-y-5 p-5">
+            {isLoading ? (
+              <div className="flex items-center gap-3 text-sm text-muted-foreground">
+                <Loader2 className="h-4 w-4 animate-spin" />
+                Loading preview...
+              </div>
+            ) : error ? (
+              <PreviewError
+                title="Preview could not be loaded"
+                message={error instanceof Error ? error.message : "Try refreshing the page."}
+              />
+            ) : preview ? (
+              <>
+                {topContent}
+
+                <PreviewCommandState
+                  preview={preview}
+                  launchMode={launchMode}
+                  isReady={isReady}
+                  isStarting={isStarting}
+                  isFailed={isFailed || isUnhealthy}
+                  isExpired={isExpired}
+                  launchError={commandError}
+                  stoppedAtText={stoppedAtText}
+                  startLatest={onStartLatest}
+                  startPending={isStarting}
+                  hidePrimaryStart={hidePrimaryStart}
+                  primaryStartLabel={primaryStartLabel}
+                  override={commandOverride}
+                  extraAction={primaryExtraAction}
+                />
+
+                <PreviewMetadata preview={preview} stoppedAtText={stoppedAtText} />
+
+                <PreviewProgress preview={preview} prominent={isStarting || isFailed || isUnhealthy} />
+
+                {unavailableRecovery ? (
+                  <div className="flex items-start gap-3 rounded-md border border-border bg-muted/40 p-3 text-sm">
+                    <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-muted-foreground" />
+                    <div>
+                      <p className="font-medium text-foreground">{unavailableRecovery.title}</p>
+                      <p className="text-muted-foreground">{unavailableRecovery.description}</p>
+                    </div>
+                  </div>
+                ) : null}
+
+                <Collapsible open={detailsOpen} onOpenChange={setDetailsOpen}>
+                  <div className="flex items-center justify-between border-t border-border pt-4">
+                    <div>
+                      <p className="text-sm font-medium text-foreground">Details</p>
+                      <p className="text-xs text-muted-foreground">Services, infrastructure, and stable links.</p>
+                    </div>
+                    <CollapsibleTrigger asChild>
+                      <Button type="button" variant="outline" size="sm">
+                        {detailsOpen ? "Hide details" : "Show details"}
+                      </Button>
+                    </CollapsibleTrigger>
+                  </div>
+                  <CollapsibleContent className="mt-4 space-y-4">
+                    <PreviewAdvancedDetails preview={preview} />
+                  </CollapsibleContent>
+                </Collapsible>
+
+                {footerContent}
+              </>
+            ) : null}
+          </CardContent>
+        </Card>
+      </div>
+    </PageContainer>
+  );
+}
+
+function PreviewCommandState({
+  preview,
+  launchMode,
+  isReady,
+  isStarting,
+  isFailed,
+  isExpired,
+  launchError,
+  stoppedAtText,
+  startLatest,
+  startPending,
+  hidePrimaryStart,
+  primaryStartLabel,
+  override,
+  extraAction,
+}: {
+  preview: BranchPreviewResponse;
+  launchMode: boolean;
+  isReady: boolean;
+  isStarting: boolean;
+  isFailed: boolean;
+  isExpired: boolean;
+  launchError: string | null;
+  stoppedAtText: string | null;
+  startLatest: () => void;
+  startPending: boolean;
+  hidePrimaryStart: boolean;
+  primaryStartLabel?: string;
+  override?: PreviewCommandOverride | null;
+  extraAction?: ReactNode;
+}) {
+  const previewUrl = safeExternalUrl(preview.preview_url);
+  const title = override?.title ?? getCommandTitle({ launchMode, isReady, isStarting, isFailed, isExpired });
+  const description =
+    override?.description ?? getCommandDescription({ launchMode, isReady, isStarting, isFailed, isExpired, stoppedAtText });
+  const showOpen = isReady && previewUrl && !isFailed && !preview.new_commits_available;
+  const showStart = !showOpen && !hidePrimaryStart;
+
+  return (
+    <div className="grid gap-4 md:grid-cols-[1fr_auto] md:items-start">
+      <div className="min-w-0 space-y-3">
+        <div className="flex items-start gap-3">
+          <StatusIcon status={preview.status} launchMode={launchMode || Boolean(override?.loading)} tone={override?.tone} />
+          <div className="min-w-0 space-y-1">
+            <div className="flex flex-wrap items-center gap-2">
+              <h2 className="text-lg font-semibold tracking-tight text-foreground">{title}</h2>
+              <PreviewStatusBadge
+                status={preview.status}
+                variant={isReady ? "default" : "secondary"}
+                className="h-5 rounded-full px-2 text-xs"
+              />
+            </div>
+            <p className="max-w-2xl text-sm text-muted-foreground">{description}</p>
+          </div>
+        </div>
+
+        {launchError ? (
+          <PreviewError title={launchMode ? "Preview could not open" : "Preview could not start"} message={launchError} />
+        ) : null}
+
+        {preview.error && !launchError ? <PreviewError title="Preview failed" message={preview.error} /> : null}
+
+        {previewUrl ? (
+          <p className="truncate rounded-md border border-border bg-muted/30 px-3 py-2 font-mono text-xs text-muted-foreground">
+            {previewUrl}
+          </p>
+        ) : preview.stable_url ? (
+          <p className="break-all rounded-md border border-border bg-muted/30 px-3 py-2 font-mono text-xs text-muted-foreground">
+            {preview.stable_url}
+          </p>
+        ) : null}
+      </div>
+
+      <div className="flex flex-col gap-2 sm:flex-row md:justify-end">
+        {extraAction}
+        {showOpen ? (
+          launchMode ? (
+            <Button type="button" disabled className="w-full sm:w-auto">
+              <Loader2 className="h-4 w-4 animate-spin" />
+              Connecting
+            </Button>
+          ) : (
+            <OpenPreviewButton previewId={preview.preview_id} previewUrl={preview.preview_url} className="w-full sm:w-auto" />
+          )
+        ) : null}
+        {showStart ? (
+          <Button type="button" onClick={startLatest} disabled={startPending} className="w-full sm:w-auto">
+            {startPending ? <Loader2 className="h-4 w-4 animate-spin" /> : <RotateCw className="h-4 w-4" />}
+            {startPending ? (launchMode ? "Waiting" : "Starting") : (primaryStartLabel ?? (isFailed ? "Retry preview" : "Start preview"))}
+          </Button>
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
+function PreviewMetadata({ preview, stoppedAtText }: { preview: BranchPreviewResponse; stoppedAtText: string | null }) {
+  const items = [
+    { label: "Repository", value: preview.repository_full_name ?? preview.repository_id ?? "Unknown" },
+    { label: "Branch", value: preview.branch ?? "Unknown" },
+    { label: "Commit", value: preview.commit_sha ? preview.commit_sha.slice(0, 12) : "Unknown" },
+    { label: "Phase", value: preview.current_phase ? formatPreviewStatus(preview.current_phase) : formatPreviewStatus(preview.status) },
+    { label: "Source", value: preview.source_type ? formatPreviewStatus(preview.source_type) : "Manual" },
+    { label: "Expires", value: preview.expires_at ? formatDateTime(preview.expires_at) : "No runtime" },
+    { label: "Stopped", value: stoppedAtText ?? "Not stopped" },
+  ];
+
+  return (
+    <div className="grid gap-3 rounded-lg border border-border/70 bg-muted/20 p-3 text-sm sm:grid-cols-2 lg:grid-cols-3">
+      {items.map((item) => (
+        <div key={item.label} className="min-w-0">
+          <p className="text-xs text-muted-foreground">{item.label}</p>
+          <p className="break-words font-medium text-foreground">{item.value}</p>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function PreviewProgress({ preview, prominent }: { preview: BranchPreviewResponse; prominent: boolean }) {
+  if (!preview.phase_steps?.length && !prominent) {
+    return null;
+  }
+
+  const steps = preview.phase_steps?.length
+    ? preview.phase_steps
+    : [
+        { name: "checkout", status: preview.status === "failed" ? "failed" : "pending" },
+        { name: "install_build", status: "pending" },
+        { name: "start_services", status: "pending" },
+        { name: "readiness", status: "pending" },
+      ];
+
+  return (
+    <div className="space-y-3">
+      <div>
+        <p className="text-sm font-medium text-foreground">Startup progress</p>
+        <p className="text-xs text-muted-foreground">The preview opens after code, services, and readiness checks complete.</p>
+      </div>
+      <div className="grid gap-2 sm:grid-cols-4">
+        {steps.map((step) => (
+          <PreviewStep key={step.name} name={step.name} status={step.status} />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function PreviewStep({ name, status }: { name: string; status: string }) {
+  const tone = getStepTone(status);
+  const Icon = tone === "complete" ? CheckCircle2 : tone === "active" ? Loader2 : tone === "failed" ? XCircle : Circle;
+
+  return (
+    <div className="flex min-h-16 items-start gap-2 rounded-md border border-border px-3 py-2">
+      <Icon
+        className={cn(
+          "mt-0.5 h-4 w-4 shrink-0",
+          tone === "complete" && "text-primary",
+          tone === "active" && "animate-spin text-muted-foreground",
+          tone === "failed" && "text-destructive",
+          tone === "pending" && "text-muted-foreground/60",
+        )}
+      />
+      <div className="min-w-0">
+        <p className="text-sm font-medium text-foreground">{formatStepName(name)}</p>
+        <p className="text-xs capitalize text-muted-foreground">{status.replaceAll("_", " ")}</p>
+      </div>
+    </div>
+  );
+}
+
+function PreviewActions({
+  preview,
+  isActive,
+  isStarting,
+  canRestart,
+  stopPending,
+  restartPending,
+  onStop,
+  onRestart,
+  onStartLatest,
+  onRefresh,
+}: {
+  preview: BranchPreviewResponse;
+  isActive: boolean;
+  isStarting: boolean;
+  canRestart: boolean;
+  stopPending: boolean;
+  restartPending: boolean;
+  onStop?: () => void;
+  onRestart?: () => void;
+  onStartLatest: () => void;
+  onRefresh?: () => void;
+}) {
+  const branchUrl = safeExternalUrl(preview.github_branch_url);
+  const pullRequestUrl = safeExternalUrl(preview.pull_request_url);
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button type="button" variant="outline" size="sm">
+          <MoreHorizontal className="h-4 w-4" />
+          Preview actions
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" className="w-56">
+        <DropdownMenuLabel>Preview actions</DropdownMenuLabel>
+        {onRefresh ? (
+          <DropdownMenuItem onSelect={onRefresh}>
+            <RotateCw className="h-4 w-4" />
+            Refresh status
+          </DropdownMenuItem>
+        ) : null}
+        <DropdownMenuItem onSelect={onStartLatest} disabled={restartPending || isStarting}>
+          <GitBranch className="h-4 w-4" />
+          Restart
+        </DropdownMenuItem>
+        {canRestart && onRestart ? (
+          <DropdownMenuItem onSelect={onRestart} disabled={restartPending}>
+            <RotateCw className="h-4 w-4" />
+            Restart runtime
+          </DropdownMenuItem>
+        ) : null}
+        {isActive && onStop ? (
+          <DropdownMenuItem variant="destructive" onSelect={onStop} disabled={stopPending}>
+            <Square className="h-4 w-4" />
+            Stop runtime
+          </DropdownMenuItem>
+        ) : null}
+        {branchUrl || pullRequestUrl ? <DropdownMenuSeparator /> : null}
+        {pullRequestUrl ? (
+          <DropdownMenuItem asChild>
+            <a href={pullRequestUrl} target="_blank" rel="noopener noreferrer">
+              <GitPullRequest className="h-4 w-4" />
+              Pull request
+            </a>
+          </DropdownMenuItem>
+        ) : null}
+        {branchUrl ? (
+          <DropdownMenuItem asChild>
+            <a href={branchUrl} target="_blank" rel="noopener noreferrer">
+              <ExternalLink className="h-4 w-4" />
+              GitHub branch
+            </a>
+          </DropdownMenuItem>
+        ) : null}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}
+
+function PreviewAdvancedDetails({ preview }: { preview: BranchPreviewResponse }) {
+  const hasServices = Boolean(preview.services?.length);
+  const hasInfrastructure = Boolean(preview.infrastructure?.length);
+
+  return (
+    <div className="space-y-4">
+      {hasServices || hasInfrastructure ? (
+        <div className="grid gap-4 md:grid-cols-2">
+          {hasServices ? (
+            <div className="space-y-2">
+              <p className="text-sm font-medium text-foreground">Services</p>
+              {preview.services?.map((service) => (
+                <div
+                  key={service.id}
+                  className="flex min-h-10 items-center justify-between gap-3 rounded-md border border-border px-3 py-2 text-sm"
+                >
+                  <span className="truncate text-foreground">{service.service_name}</span>
+                  <PreviewStatusBadge status={service.status} variant={service.status === "ready" ? "default" : "secondary"} />
+                </div>
+              ))}
+            </div>
+          ) : null}
+          {hasInfrastructure ? (
+            <div className="space-y-2">
+              <p className="text-sm font-medium text-foreground">Infrastructure</p>
+              {preview.infrastructure?.map((infra) => (
+                <div
+                  key={infra.id}
+                  className="flex min-h-10 items-center justify-between gap-3 rounded-md border border-border px-3 py-2 text-sm"
+                >
+                  <span className="truncate text-foreground">{infra.infra_name}</span>
+                  <PreviewStatusBadge status={infra.status} variant={infra.status === "healthy" ? "default" : "secondary"} />
+                </div>
+              ))}
+            </div>
+          ) : null}
+        </div>
+      ) : (
+        <p className="rounded-md border border-border bg-muted/20 px-3 py-2 text-sm text-muted-foreground">
+          No service details are available for this preview yet.
+        </p>
+      )}
+
+      <Separator />
+
+      <div className="grid gap-3 text-xs sm:grid-cols-2">
+        <DetailValue label="Stable link" value={preview.stable_url} />
+        <DetailValue label="Created" value={preview.created_at ? formatDateTime(preview.created_at) : "Unknown"} />
+        {preview.source_url ? <DetailValue label="Source link" value={preview.source_url} /> : null}
+        {preview.request_id ? <DetailValue label="Request" value={preview.request_id} /> : null}
+      </div>
+    </div>
+  );
+}
+
+function DetailValue({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="min-w-0">
+      <p className="text-muted-foreground">{label}</p>
+      <p className="break-all font-medium text-foreground">{value}</p>
+    </div>
+  );
+}
+
+function PreviewError({ title, message }: { title: string; message: string }) {
+  return <ErrorNotice title={title} description={message} />;
+}
+
+function StatusIcon({
+  status,
+  launchMode,
+  tone,
+}: {
+  status: string;
+  launchMode: boolean;
+  tone?: PreviewCommandOverride["tone"];
+}) {
+  if (tone === "destructive") {
+    return (
+      <div className="rounded-full border border-destructive/20 bg-destructive/5 p-2 text-destructive">
+        <XCircle className="h-4 w-4" />
+      </div>
+    );
+  }
+  if (tone === "warning") {
+    return (
+      <div className="rounded-full border border-warning/30 bg-warning/10 p-2 text-warning">
+        <AlertTriangle className="h-4 w-4" />
+      </div>
+    );
+  }
+  if (status === "ready" || status === "partially_ready" || status === "unhealthy") {
+    return (
+      <div className="rounded-full border border-primary/20 bg-primary/10 p-2 text-primary">
+        {launchMode ? <Loader2 className="h-4 w-4 animate-spin" /> : <CheckCircle2 className="h-4 w-4" />}
+      </div>
+    );
+  }
+  if (status === "starting") {
+    return (
+      <div className="rounded-full border border-border bg-muted/50 p-2 text-muted-foreground">
+        <Loader2 className="h-4 w-4 animate-spin" />
+      </div>
+    );
+  }
+  if (status === "failed") {
+    return (
+      <div className="rounded-full border border-destructive/20 bg-destructive/5 p-2 text-destructive">
+        <XCircle className="h-4 w-4" />
+      </div>
+    );
+  }
+  return (
+    <div className="rounded-full border border-border bg-muted/40 p-2 text-muted-foreground">
+      <Clock3 className="h-4 w-4" />
+    </div>
+  );
+}
+
+function previewUnavailableRecoveryCopy(unavailableReason?: string) {
+  if (unavailableReason === "endpoint_unreachable") {
+    return {
+      title: "Preview connection lost",
+      description:
+        "The worker that was serving this preview stopped responding. Start the preview again to create a fresh runtime.",
+    };
+  }
+
+  return null;
+}
+
+function getCommandTitle({
+  launchMode,
+  isReady,
+  isStarting,
+  isFailed,
+  isExpired,
+}: {
+  launchMode: boolean;
+  isReady: boolean;
+  isStarting: boolean;
+  isFailed: boolean;
+  isExpired: boolean;
+}) {
+  if (launchMode && isFailed) return "Preview could not open";
+  if (launchMode && isReady) return "Opening preview";
+  if (launchMode && isStarting) return "Opening when ready";
+  if (isReady) return "Preview is ready";
+  if (isStarting) return "Starting preview";
+  if (isFailed) return "Preview failed";
+  if (isExpired) return "Preview expired";
+  return "Preview is stopped";
+}
+
+function getCommandDescription({
+  launchMode,
+  isReady,
+  isStarting,
+  isFailed,
+  isExpired,
+  stoppedAtText,
+}: {
+  launchMode: boolean;
+  isReady: boolean;
+  isStarting: boolean;
+  isFailed: boolean;
+  isExpired: boolean;
+  stoppedAtText: string | null;
+}) {
+  if (launchMode && isFailed) return "This preview failed to start. Retry to try opening it again.";
+  if (launchMode && isReady) return "Connecting this browser to the running preview.";
+  if (launchMode && isStarting) return "This preview will open automatically when it is ready.";
+  if (isReady) return "Open the running branch preview, or use preview actions for lifecycle controls.";
+  if (isStarting) return "Preparing the branch runtime. The preview will be available after readiness checks pass.";
+  if (isFailed) return "Retry the preview from this page, then use details only if the failure needs investigation.";
+  if (isExpired) {
+    return stoppedAtText ? `Last stopped at ${stoppedAtText}. Start it again when you need it.` : "Start a fresh runtime for this branch.";
+  }
+  return stoppedAtText ? `Last stopped at ${stoppedAtText}.` : "Start this preview when you need to see the branch running.";
+}
+
+function getStepTone(status: string): PreviewStepTone {
+  const normalized = status.toLowerCase();
+  if (["complete", "completed", "ready", "healthy", "success"].includes(normalized)) return "complete";
+  if (["active", "running", "starting", "provisioning"].includes(normalized)) return "active";
+  if (["failed", "unhealthy", "error"].includes(normalized)) return "failed";
+  return "pending";
+}
+
+function formatStepName(name: string) {
+  const normalized = name.replaceAll("_", " ").toLowerCase();
+  return normalized
+    .split(" ")
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(" ");
+}
+
+function formatDateTime(value: string) {
+  return new Date(value).toLocaleString(undefined, {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  });
+}


### PR DESCRIPTION
## Summary

Preview pages had inconsistent/duplicated UI logic around preview actions (and the warning state when new commits are available), creating a reliability risk where users see mismatched labels and stale actions. This change consolidates the preview detail rendering to use the shared `PreviewDetailSurface` and removes dead/unused props and helpers so the fallback behavior is consistent.

## Changes

- Refactored dashboard preview routes (`/previews/[id]` and GitHub PR preview) to render through `PreviewDetailSurface`, aligning the UI/labels with the main preview experience.
- Updated tests to assert the correct user-facing strings (including case/label consistency) and added coverage for the “New commits available” warning + latest commit display.
- Removed dead exported helper `formatPreviewDateTime` from `preview-detail-surface.tsx`.
- Removed `primaryOpeningLabel` prop entirely (interface/destructure/pass-through) since it was never supplied by callers and the `"Connecting"` fallback always applied.

## Validation

- `tsc --noEmit`
- `eslint` (no lint errors)
- All preview tests passing: `43` tests (including the newly added “warns when new commits are available” case)

[143.dev](https://143.dev) | [session a33c7794](https://143.dev/sessions/a33c7794-48d8-4709-b560-30b7b546c0f5)

<!-- 143 readiness -->
**143 readiness:** not available for this revision.

Preview: https://143.dev/previews/github/assembledhq/143/pull/1660?launch=1