### PR TITLE
Expand mention index ignore rules for language-specific cache and binary files

### DIFF
--- a/internal/services/workspace/mention_index.go
+++ b/internal/services/workspace/mention_index.go
@@ -19,20 +19,65 @@ const (
 )
 
 var mentionIndexIgnoredDirNames = map[string]struct{}{
-	".git":         {},
-	".next":        {},
-	".nuxt":        {},
-	".pnpm-store":  {},
-	".turbo":       {},
-	".venv":        {},
-	"__pycache__":  {},
-	"build":        {},
-	"coverage":     {},
-	"dist":         {},
-	"node_modules": {},
-	"target":       {},
-	"vendor":       {},
-	"venv":         {},
+	".angular":      {},
+	".cache":        {},
+	".dart_tool":    {},
+	".git":          {},
+	".gradle":       {},
+	".idea":         {},
+	".mypy_cache":   {},
+	".next":         {},
+	".nox":          {},
+	".nuxt":         {},
+	".parcel-cache": {},
+	".pnpm-store":   {},
+	".pytest_cache": {},
+	".ruff_cache":   {},
+	".svelte-kit":   {},
+	".tox":          {},
+	".turbo":        {},
+	".venv":         {},
+	".yarn":         {},
+	"__pycache__":   {},
+	"build":         {},
+	"coverage":      {},
+	"dist":          {},
+	"htmlcov":       {},
+	"node_modules":  {},
+	"obj":           {},
+	"target":        {},
+	"vendor":        {},
+	"venv":          {},
+}
+
+var mentionIndexIgnoredFileNames = map[string]struct{}{
+	".coverage":       {},
+	".DS_Store":       {},
+	".ds_store":       {},
+	".eslintcache":    {},
+	".stylelintcache": {},
+	"desktop.ini":     {},
+	"Thumbs.db":       {},
+	"thumbs.db":       {},
+}
+
+var mentionIndexIgnoredFileSuffixes = []string{
+	".a",
+	".class",
+	".dll",
+	".dylib",
+	".ear",
+	".exe",
+	".jar",
+	".o",
+	".obj",
+	".prof",
+	".pyc",
+	".pyo",
+	".so",
+	".test",
+	".tsbuildinfo",
+	".war",
 }
 
 type MentionIndexEntry struct {
@@ -186,8 +231,22 @@ func mentionIndexIgnoredDirNameList() []string {
 }
 
 func mentionIndexShouldIgnorePath(cleanPath string) bool {
-	for _, part := range strings.Split(cleanPath, "/") {
+	parts := strings.Split(cleanPath, "/")
+	for _, part := range parts {
 		if _, ok := mentionIndexIgnoredDirNames[part]; ok {
+			return true
+		}
+	}
+	base := parts[len(parts)-1]
+	baseLower := strings.ToLower(base)
+	if _, ok := mentionIndexIgnoredFileNames[base]; ok {
+		return true
+	}
+	if _, ok := mentionIndexIgnoredFileNames[baseLower]; ok {
+		return true
+	}
+	for _, suffix := range mentionIndexIgnoredFileSuffixes {
+		if strings.HasSuffix(baseLower, suffix) {
 			return true
 		}
 	}

--- a/internal/services/workspace/mention_index_test.go
+++ b/internal/services/workspace/mention_index_test.go
@@ -105,11 +105,13 @@ type recursiveMentionReader struct {
 	entries        []sandbox.FileEntry
 	recursiveCalls int
 	maxEntries     int
+	ignoredDirs    []string
 }
 
-func (r *recursiveMentionReader) ListDirRecursive(_ context.Context, maxEntries int, _ []string) ([]sandbox.FileEntry, error) {
+func (r *recursiveMentionReader) ListDirRecursive(_ context.Context, maxEntries int, ignoredDirNames []string) ([]sandbox.FileEntry, error) {
 	r.recursiveCalls++
 	r.maxEntries = maxEntries
+	r.ignoredDirs = ignoredDirNames
 	return r.entries, nil
 }
 
@@ -129,11 +131,58 @@ func TestBuildMentionIndex_UsesRecursiveReaderFastPath(t *testing.T) {
 	require.NoError(t, err, "BuildMentionIndex should succeed through the recursive reader fast path")
 	require.Equal(t, 1, reader.recursiveCalls, "BuildMentionIndex should use one recursive list call when the reader supports it")
 	require.Equal(t, defaultMentionIndexMaxPaths, reader.maxEntries, "BuildMentionIndex should pass its traversal cap into the recursive reader")
+	require.Contains(t, reader.ignoredDirs, ".cache", "BuildMentionIndex should ask recursive readers to skip common cache directories")
+	require.Contains(t, reader.ignoredDirs, ".pytest_cache", "BuildMentionIndex should ask recursive readers to skip Python cache directories")
+	require.Contains(t, reader.ignoredDirs, ".svelte-kit", "BuildMentionIndex should ask recursive readers to skip JavaScript framework caches")
 	require.Equal(t, 0, reader.listDirCalls, "BuildMentionIndex should avoid per-directory ListDir calls when the recursive fast path is available")
 	require.Equal(t, []MentionIndexEntry{
 		{Kind: string(models.SessionInputReferenceKindDirectory), Path: "docs"},
 		{Kind: string(models.SessionInputReferenceKindFile), Path: "docs/guide.md"},
 	}, index.Entries, "BuildMentionIndex should still filter ignored paths returned by the recursive reader")
+}
+
+func TestBuildMentionIndex_FiltersLanguageCachesAndArtifacts(t *testing.T) {
+	t.Parallel()
+
+	reader := &recursiveMentionReader{
+		entries: []sandbox.FileEntry{
+			{Type: "dir", Path: ".cache"},
+			{Type: "file", Path: ".cache/go/11/113a087bb6df4fbe-d"},
+			{Type: "dir", Path: ".pytest_cache"},
+			{Type: "file", Path: ".pytest_cache/v/cache/nodeids"},
+			{Type: "dir", Path: ".mypy_cache"},
+			{Type: "file", Path: ".mypy_cache/3.12/module.meta.json"},
+			{Type: "dir", Path: ".ruff_cache"},
+			{Type: "file", Path: ".ruff_cache/content"},
+			{Type: "dir", Path: ".parcel-cache"},
+			{Type: "file", Path: ".parcel-cache/data.mdb"},
+			{Type: "dir", Path: ".svelte-kit"},
+			{Type: "file", Path: ".svelte-kit/generated/client/app.js"},
+			{Type: "dir", Path: ".gradle"},
+			{Type: "file", Path: ".gradle/8.8/checksums/checksums.lock"},
+			{Type: "dir", Path: "target"},
+			{Type: "file", Path: "target/debug/app"},
+			{Type: "dir", Path: "src"},
+			{Type: "file", Path: "src/main.rs"},
+			{Type: "file", Path: "src/app.pyc"},
+			{Type: "file", Path: "src/App.class"},
+			{Type: "file", Path: "src/module.o"},
+			{Type: "file", Path: "src/lib.so"},
+			{Type: "file", Path: "src/app.tsbuildinfo"},
+			{Type: "file", Path: ".DS_Store"},
+			{Type: "file", Path: "README.md"},
+			{Type: "file", Path: "migrations/000113_session_threads_backfill_primary.up.sql"},
+		},
+	}
+
+	index, err := BuildMentionIndex(context.Background(), reader)
+	require.NoError(t, err, "BuildMentionIndex should succeed while filtering cache and artifact paths")
+	require.Equal(t, []MentionIndexEntry{
+		{Kind: string(models.SessionInputReferenceKindFile), Path: "README.md"},
+		{Kind: string(models.SessionInputReferenceKindFile), Path: "migrations/000113_session_threads_backfill_primary.up.sql"},
+		{Kind: string(models.SessionInputReferenceKindDirectory), Path: "src"},
+		{Kind: string(models.SessionInputReferenceKindFile), Path: "src/main.rs"},
+	}, index.Entries, "BuildMentionIndex should keep searchable source files while excluding common cache and generated artifact paths")
 }
 
 func TestBuildMentionIndexWithConfig_PassesCustomCapToRecursiveReader(t *testing.T) {


### PR DESCRIPTION
## Summary

Workspace mention indexing was incorrectly scanning language-specific cache/config directories and compiled artifacts, which can bloat the index and add irrelevant “mentions” to search results. This change expands the ignore rules and ensures the recursive listing path receives the updated ignore directory list so caches are skipped consistently during traversal.

## Changes

- Broaden ignored directories to include common language/tooling caches (e.g. `.cache`, `.angular`, `.dart_tool`, `.pytest_cache`, `.ruff_cache`, `.tox`, `.yarn`, etc.).
- Add ignored files (e.g. `.DS_Store`, `desktop.ini`, eslint/stylelint caches) and ignored binary/compiled file suffixes (e.g. `.exe`, `.dll`, `.so`, `.pyc`, `.class`, `.o`, `.obj`).
- Update `mentionIndexShouldIgnorePath` to ignore both directory parts and the final path component based on exact names, case-insensitive names, and suffixes.
- Adjust the recursive reader contract in `mention_index_test.go` so tests verify the traversal skip list includes `.cache` (and other new entries).

## Validation

- Updated/extended unit tests in `internal/services/workspace/mention_index_test.go` to assert recursive traversal is instructed to skip cache directories.

[143.dev](https://143.dev) | [session 09c98b1b](https://143.dev/sessions/09c98b1b-5a43-4fd0-a55f-5b762c952024)

<!-- 143 readiness -->
**143 readiness:** not available for this revision.

Preview: https://143.dev/previews/github/assembledhq/143/pull/1661?launch=1