### PR TITLE
Handle preview startup interruptions with retry-safe recovery

### DIFF
--- a/deploy/deploy_config_test.go
+++ b/deploy/deploy_config_test.go
@@ -1330,10 +1330,27 @@ func TestWorkerBlockingDrainAllowsDefaultEndpointReuse(t *testing.T) {
 	require.Contains(t, deploy, `[ "$endpoint_reuse_mode" = "after-blocking-drain" ]`, "worker port selection should retain explicit maintenance-only reuse after the old worker generation has fully drained")
 	require.Contains(t, functionBody, `deploy_mode="${DEPLOY_MODE:-routine}"`, "worker deploy should resolve deploy mode once before selecting a rollout path")
 	require.Contains(t, functionBody, `if [ "$deploy_mode" = "maintenance" ]; then`, "maintenance worker deploy should take an explicit blocking drain path")
-	require.Contains(t, functionBody, `drain_worker_containers_blocking "$old_containers"`, "maintenance worker deploy should stop old containers before reusing their endpoint")
+	require.Contains(t, functionBody, `drain_worker_containers_blocking "$old_containers" "$deploy_id" "${IMAGE_TAG:-}"`, "maintenance worker deploy should drain old containers with a durable deploy identity before endpoint reuse")
 	require.Contains(t, functionBody, `host_port="$(find_free_worker_port "$worker_private_ip" "after-blocking-drain")"`, "maintenance worker deploy should allow default endpoint reuse after the blocking drain")
 	require.Contains(t, functionBody, `host_port="$(find_free_worker_port "$worker_private_ip")"`, "routine worker deploy should keep strict endpoint selection")
 	require.Contains(t, functionBody, `routine blue/green deploy refuses blocking drain fallback`, "routine worker deploy should still explain why it refuses endpoint reuse")
+}
+
+func TestWorkerMaintenanceBlockingDrainUsesDeployControl(t *testing.T) {
+	t.Parallel()
+
+	deployScript, err := os.ReadFile("../deploy/scripts/deploy.sh")
+	require.NoError(t, err, "test should read deploy.sh")
+	deploy := string(deployScript)
+	functionBody := extractShellFunction(t, deploy, "drain_worker_containers_blocking", "read_worker_env_value")
+
+	require.Contains(t, functionBody, `run_worker_deployctl mark-draining`, "maintenance drain should record DB drain state before stopping workers")
+	require.Contains(t, functionBody, `--intent host_maintenance`, "maintenance drain should use the host maintenance drain intent")
+	require.Contains(t, functionBody, `FORCE_INTERRUPT_ACTIVE_RUNTIMES`, "maintenance drain should require explicit force before interrupting active work")
+	require.Contains(t, functionBody, `run_worker_deployctl expire-budget`, "maintenance drain should reuse deploy budget expiry handling")
+	require.Contains(t, functionBody, `run_worker_deployctl retire-ready`, "maintenance drain should wait for retire readiness")
+	require.Contains(t, functionBody, `docker stop -t 60 "$cid"`, "maintenance drain should stop containers only after retire-ready or explicit forced timeout")
+	require.NotContains(t, functionBody, `docker kill --signal=TERM "$cid"`, "maintenance drain must not bypass DB-backed drain state with a direct TERM")
 }
 
 func extractShellFunction(t *testing.T, script, startFunc, nextFunc string) string {

--- a/deploy/scripts/deploy.sh
+++ b/deploy/scripts/deploy.sh
@@ -1465,8 +1465,8 @@ ssh "${SSH_OPTS[@]}" deploy@"$HOST" \
   }
 
   drain_worker_containers_blocking() {
-    local containers="${1:-}"
-    local timeout waited cid running_count
+    local containers="${1:-}" deploy_id="${2:-worker-maintenance-$(date -u +%Y%m%d%H%M%S)}" build_sha="${3:-${IMAGE_TAG:-}}"
+    local timeout waited cid running_count node_id force_arg
     timeout="$(resolve_worker_drain_timeout_seconds)"
     waited=0
 
@@ -1478,7 +1478,24 @@ ssh "${SSH_OPTS[@]}" deploy@"$HOST" \
     echo "Requesting blocking drain for existing worker containers (timeout ${timeout}s)..."
     for cid in $containers; do
       if docker inspect --format '{{.State.Running}}' "$cid" 2>/dev/null | grep -q true; then
-        docker kill --signal=TERM "$cid" >/dev/null
+        node_id="$(worker_container_node_id "$cid")"
+        if [ -z "$node_id" ]; then
+          echo "ERROR: worker container ${cid:0:12} has no NODE_ID; refusing maintenance drain without DB ownership." >&2
+          return 1
+        fi
+        force_arg=()
+        if [ "${FORCE_INTERRUPT_ACTIVE_RUNTIMES:-}" = "1" ]; then
+          force_arg=(--force)
+        fi
+        run_worker_deployctl mark-draining \
+          --node-id "$node_id" \
+          --intent host_maintenance \
+          --deploy-id "$deploy_id" \
+          --reason "${DEPLOY_REASON:-maintenance worker deploy}" \
+          --requested-by "${DEPLOY_REQUESTED_BY:-deploy-script}" \
+          --build-sha "$build_sha" \
+          "${force_arg[@]}" \
+          --json
       fi
     done
 
@@ -1487,6 +1504,22 @@ ssh "${SSH_OPTS[@]}" deploy@"$HOST" \
       for cid in $containers; do
         if docker inspect --format '{{.State.Running}}' "$cid" 2>/dev/null | grep -q true; then
           running_count=$((running_count + 1))
+          node_id="$(worker_container_node_id "$cid")"
+          if [ -z "$node_id" ]; then
+            echo "ERROR: worker container ${cid:0:12} lost NODE_ID while draining." >&2
+            return 1
+          fi
+          run_worker_deployctl expire-budget \
+            --node-id "$node_id" \
+            --deploy-id "$deploy_id" \
+            --reason "${DEPLOY_REASON:-maintenance worker deploy}" \
+            --requested-by "${DEPLOY_REQUESTED_BY:-deploy-script}" \
+            --build-sha "$build_sha" \
+            --json || true
+          if run_worker_deployctl retire-ready --node-id "$node_id" --json; then
+            echo "Worker node $node_id is retire-ready; stopping container ${cid:0:12}."
+            docker stop -t 60 "$cid"
+          fi
         fi
       done
       if [ "$running_count" -eq 0 ]; then
@@ -1494,6 +1527,15 @@ ssh "${SSH_OPTS[@]}" deploy@"$HOST" \
         return 0
       fi
       if [ "$waited" -ge "$timeout" ]; then
+        if [ "${FORCE_INTERRUPT_ACTIVE_RUNTIMES:-}" = "1" ]; then
+          echo "WARNING: worker container drain timed out after ${timeout}s; force-stopping ${running_count} remaining worker container(s)." >&2
+          for cid in $containers; do
+            if docker inspect --format '{{.State.Running}}' "$cid" 2>/dev/null | grep -q true; then
+              docker stop -t 60 "$cid"
+            fi
+          done
+          return 0
+        fi
         echo "ERROR: worker container drain timed out after ${timeout}s (${running_count} still running)" >&2
         return 1
       fi
@@ -2044,10 +2086,13 @@ SELECT COUNT(*) FROM endpoint_blockers;"
       return 1
     fi
     ensure_routine_worker_fingerprints_compatible
+    generation="$(date -u +%Y%m%d%H%M%S)-${IMAGE_TAG:0:12}"
+    node_id="${base_node_id}-g${generation}"
+    deploy_id="worker-${generation}"
 
     if [ "$deploy_mode" = "maintenance" ]; then
       if [ -n "$old_containers" ]; then
-        drain_worker_containers_blocking "$old_containers"
+        drain_worker_containers_blocking "$old_containers" "$deploy_id" "${IMAGE_TAG:-}"
       else
         echo "No existing worker containers found; maintenance deploy will start a fresh generation."
       fi
@@ -2056,9 +2101,6 @@ SELECT COUNT(*) FROM endpoint_blockers;"
       worker_host_capacity_preflight
     fi
 
-    generation="$(date -u +%Y%m%d%H%M%S)-${IMAGE_TAG:0:12}"
-    node_id="${base_node_id}-g${generation}"
-    deploy_id="worker-${generation}"
     if [ "$deploy_mode" = "maintenance" ]; then
       if ! host_port="$(find_free_worker_port "$worker_private_ip" "after-blocking-drain")"; then
         echo "ERROR: no reusable worker host port after maintenance drain." >&2

--- a/internal/db/preview_store.go
+++ b/internal/db/preview_store.go
@@ -1244,6 +1244,88 @@ func (s *PreviewStore) CreateNextPreviewRuntime(ctx context.Context, orgID, prev
 	return runtime, nil
 }
 
+// ResetStartingBranchPreviewForRetry clears transient startup state for a
+// standalone branch preview without terminally failing the reservation. It is
+// used when the worker loses the sandbox mid-start and the durable job will be
+// requeued to launch a fresh sandbox.
+func (s *PreviewStore) ResetStartingBranchPreviewForRetry(ctx context.Context, orgID, previewID uuid.UUID, reason string, unavailableReason models.PreviewUnavailableReason) error {
+	if err := unavailableReason.Validate(); err != nil {
+		return err
+	}
+	tx, err := s.db.Begin(ctx)
+	if err != nil {
+		return fmt.Errorf("begin branch preview retry reset: %w", err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	tag, err := tx.Exec(ctx, `
+		UPDATE preview_instances
+			SET preview_handle = '',
+				port = 0,
+				error = '',
+				current_phase = 'reserved',
+				unavailable_reason = '',
+				recycle_config = NULL,
+				recycle_sandbox = NULL,
+				updated_at = now()
+		WHERE id = @preview_id
+		  AND org_id = @org_id
+		  AND preview_target_id IS NOT NULL
+		  AND status = 'starting'`,
+		pgx.NamedArgs{"org_id": orgID, "preview_id": previewID},
+	)
+	if err != nil {
+		return fmt.Errorf("reset branch preview reservation: %w", err)
+	}
+	if tag.RowsAffected() == 0 {
+		return fmt.Errorf("branch preview reservation not found or no longer starting")
+	}
+
+	if _, err := tx.Exec(ctx,
+		fmt.Sprintf(`UPDATE preview_runtimes
+		 SET status = 'lost',
+			error = @reason,
+			unavailable_reason = @unavailable_reason,
+			stopped_at = COALESCE(stopped_at, now()),
+			updated_at = now()
+		 WHERE preview_instance_id = @preview_id
+		   AND org_id = @org_id
+		   AND status IN %s`, activeRuntimeStatusFilter),
+		pgx.NamedArgs{
+			"org_id":             orgID,
+			"preview_id":         previewID,
+			"reason":             reason,
+			"unavailable_reason": unavailableReason,
+		},
+	); err != nil {
+		return fmt.Errorf("mark branch preview runtime lost for retry: %w", err)
+	}
+	if _, err := tx.Exec(ctx, `
+		DELETE FROM preview_services
+		WHERE preview_instance_id = @preview_id
+		  AND preview_instance_id IN (
+			SELECT id FROM preview_instances WHERE id = @preview_id AND org_id = @org_id
+		  )`,
+		pgx.NamedArgs{"org_id": orgID, "preview_id": previewID},
+	); err != nil {
+		return fmt.Errorf("clear branch preview services for retry: %w", err)
+	}
+	if _, err := tx.Exec(ctx, `
+		DELETE FROM preview_infrastructure
+		WHERE preview_instance_id = @preview_id
+		  AND preview_instance_id IN (
+			SELECT id FROM preview_instances WHERE id = @preview_id AND org_id = @org_id
+		  )`,
+		pgx.NamedArgs{"org_id": orgID, "preview_id": previewID},
+	); err != nil {
+		return fmt.Errorf("clear branch preview infrastructure for retry: %w", err)
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return fmt.Errorf("commit branch preview retry reset: %w", err)
+	}
+	return nil
+}
+
 func newStartingPreviewRuntime(orgID, previewID uuid.UUID, epoch int, workerNodeID, endpointURL string) *models.PreviewRuntime {
 	now := time.Now().UTC()
 	return &models.PreviewRuntime{

--- a/internal/db/preview_store_test.go
+++ b/internal/db/preview_store_test.go
@@ -4422,6 +4422,44 @@ func TestPreviewStore_UpdatePreviewReservationConfig_ExecError(t *testing.T) {
 	require.Contains(t, err.Error(), "update preview reservation config")
 }
 
+func TestPreviewStore_ResetStartingBranchPreviewForRetryClearsRecycleInput(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "pgx mock should initialize")
+	defer mock.Close()
+
+	orgID := uuid.New()
+	previewID := uuid.New()
+	store := NewPreviewStore(mock)
+
+	mock.ExpectBegin()
+	mock.ExpectExec(`(?s)UPDATE preview_instances.*recycle_config = NULL.*recycle_sandbox = NULL`).
+		WithArgs(previewAnyArgs(2)...).
+		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
+	mock.ExpectExec("UPDATE preview_runtimes").
+		WithArgs(previewAnyArgs(4)...).
+		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
+	mock.ExpectExec("DELETE FROM preview_services").
+		WithArgs(previewAnyArgs(2)...).
+		WillReturnResult(pgxmock.NewResult("DELETE", 2))
+	mock.ExpectExec("DELETE FROM preview_infrastructure").
+		WithArgs(previewAnyArgs(2)...).
+		WillReturnResult(pgxmock.NewResult("DELETE", 1))
+	mock.ExpectCommit()
+
+	err = store.ResetStartingBranchPreviewForRetry(
+		context.Background(),
+		orgID,
+		previewID,
+		"lost sandbox during launch",
+		models.PreviewUnavailableReasonOwnerLost,
+	)
+
+	require.NoError(t, err, "retry reset should clear stale recycle input and transient startup rows")
+	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
+}
+
 func TestPreviewStore_DeleteExpiredDependencyCacheLocations(t *testing.T) {
 	t.Parallel()
 

--- a/internal/services/preview/errors.go
+++ b/internal/services/preview/errors.go
@@ -3,6 +3,7 @@ package preview
 import (
 	"errors"
 	"strconv"
+	"strings"
 )
 
 // Provider-side failure sentinels. The HTTP handler classifies preview-launch
@@ -47,7 +48,31 @@ var (
 	// ErrServiceBuildFailed means a service's build command (preview build
 	// phase) exited non-zero or timed out before any service was started.
 	ErrServiceBuildFailed = errors.New("preview service build failed")
+
+	// ErrPreviewStartupInterrupted means the preview worker lost the sandbox
+	// while startup was still in progress. This is an infrastructure interruption,
+	// not a user install/build/config failure.
+	ErrPreviewStartupInterrupted = errors.New("preview startup interrupted")
 )
+
+// IsPreviewStartupInterrupted classifies sandbox-lifecycle failures that are
+// safe to retry from a fresh branch-preview sandbox. Call this only from code
+// already known to be executing against a preview sandbox; user command output
+// can otherwise contain similar text.
+func IsPreviewStartupInterrupted(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, ErrPreviewStartupInterrupted) {
+		return true
+	}
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "no such container") ||
+		strings.Contains(msg, "broken pipe") ||
+		strings.Contains(msg, "connection reset by peer") ||
+		strings.Contains(msg, "use of closed network connection") ||
+		strings.Contains(msg, "client connection lost")
+}
 
 type CapacityScope string
 

--- a/internal/services/preview/start_runner.go
+++ b/internal/services/preview/start_runner.go
@@ -1322,6 +1322,7 @@ func (r *StartRunner) retryBranchPreviewStartupInterruption(ctx context.Context,
 		r.abort(ctx, reservation, sandboxID(sb), fmt.Sprintf("reset preview startup after interruption: %v", err))
 		return fmt.Errorf("reset branch preview after startup interruption: %w", err)
 	}
+	r.registerStartupInterruptionDeadLetter(ctx, reservation)
 	r.destroyBranchPreviewSandboxAfterInterruption(ctx, payload.PreviewID, sb)
 	return fmt.Errorf("%w: %s", ErrPreviewStartupInterrupted, reason)
 }
@@ -1346,6 +1347,28 @@ func sandboxID(sb *agent.Sandbox) string {
 		return ""
 	}
 	return sb.ID
+}
+
+func uuidValueString(id *uuid.UUID) string {
+	if id == nil {
+		return ""
+	}
+	return id.String()
+}
+
+func (r *StartRunner) registerStartupInterruptionDeadLetter(ctx context.Context, reservation *models.PreviewInstance) {
+	if r == nil || r.manager == nil || reservation == nil {
+		return
+	}
+	jobctx.RegisterDeadLetterHook(ctx, func(hookCtx context.Context, deadLetterErr error) {
+		if deadLetterErr != nil {
+			r.logger.Warn().Err(deadLetterErr).
+				Str("preview_id", reservation.ID.String()).
+				Str("preview_target_id", uuidValueString(reservation.PreviewTargetID)).
+				Msg("branch preview start dead-lettered after startup interruption retries")
+		}
+		r.manager.AbortReservation(hookCtx, reservation, "", "Preview could not start because the sandbox was interrupted repeatedly. Try starting the preview again.")
+	})
 }
 
 func (r *StartRunner) registerCapacityDeadLetter(ctx context.Context, reservation *models.PreviewInstance) {

--- a/internal/services/preview/start_runner.go
+++ b/internal/services/preview/start_runner.go
@@ -169,8 +169,8 @@ func (r *StartRunner) StartReservedBranchPreview(ctx context.Context, payload St
 		r.abort(ctx, reservation, "", "preview reservation no longer matches target")
 		return fmt.Errorf("reserved branch preview target mismatch")
 	}
-	if err := r.reassignReservationWorkerIfNeeded(ctx, payload.OrgID, payload.PreviewID, reservation); err != nil {
-		return fmt.Errorf("reassign branch preview worker: %w", err)
+	if err := r.ensureReservationRuntimeForClaimingWorker(ctx, payload.OrgID, payload.PreviewID, reservation); err != nil {
+		return fmt.Errorf("ensure branch preview worker runtime: %w", err)
 	}
 
 	target, err := r.previews.GetPreviewTarget(ctx, payload.OrgID, payload.PreviewTargetID)
@@ -239,6 +239,9 @@ func (r *StartRunner) StartReservedBranchPreview(ctx context.Context, payload St
 	})
 	token, err := r.github.GetInstallationToken(ctx, repo.InstallationID)
 	if err != nil {
+		if IsPreviewStartupInterrupted(err) {
+			return r.retryBranchPreviewStartupInterruption(ctx, payload, reservation, sb, "get_github_token", err)
+		}
 		r.abort(ctx, reservation, sb.ID, fmt.Sprintf("get GitHub token: %v", err))
 		return fmt.Errorf("get github token: %w", err)
 	}
@@ -252,6 +255,9 @@ func (r *StartRunner) StartReservedBranchPreview(ctx context.Context, payload St
 	})
 	if err := r.sandboxProvider.CloneRepo(ctx, sb, repo.CloneURL, target.Branch, token); err != nil {
 		metrics.RecordBranchPreviewStartupFailure(ctx, payload.OrgID.String(), string(target.SourceType), repo.FullName, "clone")
+		if IsPreviewStartupInterrupted(err) {
+			return r.retryBranchPreviewStartupInterruption(ctx, payload, reservation, sb, "clone", err)
+		}
 		r.abort(ctx, reservation, sb.ID, fmt.Sprintf("clone repository: %v", err))
 		return fmt.Errorf("clone repository: %w", err)
 	}
@@ -267,6 +273,9 @@ func (r *StartRunner) StartReservedBranchPreview(ctx context.Context, payload St
 	exitCode, err := r.sandboxProvider.Exec(ctx, sb, "git checkout --detach "+target.CommitSHA, io.Discard, &checkoutErr)
 	if err != nil {
 		metrics.RecordBranchPreviewStartupFailure(ctx, payload.OrgID.String(), string(target.SourceType), repo.FullName, "checkout")
+		if IsPreviewStartupInterrupted(err) {
+			return r.retryBranchPreviewStartupInterruption(ctx, payload, reservation, sb, "checkout", err)
+		}
 		r.abort(ctx, reservation, sb.ID, fmt.Sprintf("checkout commit: %v", err))
 		return fmt.Errorf("checkout commit: %w", err)
 	}
@@ -296,6 +305,9 @@ func (r *StartRunner) StartReservedBranchPreview(ctx context.Context, payload St
 		cfg, err = r.readWorkspacePreviewConfig(ctx, sb, uuid.Nil, target.PreviewConfigName)
 		if err != nil {
 			metrics.RecordBranchPreviewStartupFailure(ctx, payload.OrgID.String(), string(target.SourceType), repo.FullName, "config")
+			if IsPreviewStartupInterrupted(err) {
+				return r.retryBranchPreviewStartupInterruption(ctx, payload, reservation, sb, "config", err)
+			}
 			r.abort(ctx, reservation, sb.ID, fmt.Sprintf("read workspace config: %v", err))
 			return fmt.Errorf("PREVIEW_CONFIG_READ_FAILED: %w", err)
 		}
@@ -338,6 +350,9 @@ func (r *StartRunner) StartReservedBranchPreview(ctx context.Context, payload St
 		// restore that could not be re-checked-out from git). Launching from
 		// an inconsistent tree would serve wrong code — fail the start.
 		metrics.RecordBranchPreviewStartupFailure(ctx, payload.OrgID.String(), string(target.SourceType), repo.FullName, "startup_cache_recovery")
+		if IsPreviewStartupInterrupted(cacheErr) {
+			return r.retryBranchPreviewStartupInterruption(ctx, payload, reservation, sb, "startup_cache_recovery", cacheErr)
+		}
 		r.abort(ctx, reservation, sb.ID, fmt.Sprintf("restore startup cache: %v", cacheErr))
 		return fmt.Errorf("restore startup cache: %w", cacheErr)
 	}
@@ -348,6 +363,9 @@ func (r *StartRunner) StartReservedBranchPreview(ctx context.Context, payload St
 	})
 	_, err = r.manager.LaunchPreview(ctx, reservation, input)
 	if err != nil {
+		if IsPreviewStartupInterrupted(err) {
+			return r.retryBranchPreviewStartupInterruption(ctx, payload, reservation, sb, "launch_preview", err)
+		}
 		classified := ClassifyLaunchFailure(err, reservation.MemoryLimitMB)
 		r.abort(ctx, reservation, sb.ID, classified.Message)
 		r.logger.Warn().Err(err).Str("preview_id", payload.PreviewID.String()).Msg("branch preview launch failed")
@@ -1239,6 +1257,36 @@ func (r *StartRunner) createStartupLog(ctx context.Context, orgID, previewID uui
 	}
 }
 
+func (r *StartRunner) ensureReservationRuntimeForClaimingWorker(ctx context.Context, orgID, previewID uuid.UUID, reservation *models.PreviewInstance) error {
+	if reservation == nil || r.nodeID == "" {
+		return nil
+	}
+	endpointURL := ""
+	if r.manager != nil {
+		endpointURL = r.manager.previewInternalBaseURL
+	}
+	if shouldReassignPreviewWorker("", reservation.WorkerNodeID, r.nodeID) {
+		if err := r.previews.ReassignPreviewWorker(ctx, orgID, previewID, r.nodeID, endpointURL); err != nil {
+			return err
+		}
+		reservation.WorkerNodeID = r.nodeID
+		return nil
+	}
+	if endpointURL == "" {
+		return nil
+	}
+	if _, err := r.previews.GetActivePreviewRuntime(ctx, orgID, previewID); err == nil {
+		return nil
+	} else if !errors.Is(err, pgx.ErrNoRows) {
+		return err
+	}
+	if _, err := r.previews.CreateNextPreviewRuntime(ctx, orgID, previewID, r.nodeID, endpointURL); err != nil {
+		return err
+	}
+	reservation.WorkerNodeID = r.nodeID
+	return nil
+}
+
 func (r *StartRunner) reassignReservationWorkerIfNeeded(ctx context.Context, orgID, previewID uuid.UUID, reservation *models.PreviewInstance) error {
 	if reservation == nil || !shouldReassignPreviewWorker("", reservation.WorkerNodeID, r.nodeID) {
 		return nil
@@ -1256,6 +1304,48 @@ func (r *StartRunner) reassignReservationWorkerIfNeeded(ctx context.Context, org
 
 func shouldReassignPreviewWorker(_ string, reservationWorkerNode, claimingWorkerNode string) bool {
 	return claimingWorkerNode != "" && claimingWorkerNode != reservationWorkerNode
+}
+
+func (r *StartRunner) retryBranchPreviewStartupInterruption(ctx context.Context, payload StartBranchPreviewJobPayload, reservation *models.PreviewInstance, sb *agent.Sandbox, phase string, cause error) error {
+	reason := fmt.Sprintf("preview startup interrupted during %s: %v", phase, cause)
+	r.logger.Warn().
+		Err(cause).
+		Str("preview_id", payload.PreviewID.String()).
+		Str("preview_target_id", payload.PreviewTargetID.String()).
+		Str("phase", phase).
+		Msg("branch preview startup interrupted; requeueing with fresh sandbox")
+	r.createStartupLog(ctx, payload.OrgID, payload.PreviewID, "warn", models.PreviewLogStepStart, reason, map[string]any{
+		"phase": "startup_interrupted",
+		"stage": phase,
+	})
+	if err := r.previews.ResetStartingBranchPreviewForRetry(ctx, payload.OrgID, payload.PreviewID, reason, models.PreviewUnavailableReasonOwnerLost); err != nil {
+		r.abort(ctx, reservation, sandboxID(sb), fmt.Sprintf("reset preview startup after interruption: %v", err))
+		return fmt.Errorf("reset branch preview after startup interruption: %w", err)
+	}
+	r.destroyBranchPreviewSandboxAfterInterruption(ctx, payload.PreviewID, sb)
+	return fmt.Errorf("%w: %s", ErrPreviewStartupInterrupted, reason)
+}
+
+func (r *StartRunner) destroyBranchPreviewSandboxAfterInterruption(ctx context.Context, previewID uuid.UUID, sb *agent.Sandbox) {
+	if r == nil || r.sandboxProvider == nil || sb == nil || sb.ID == "" {
+		return
+	}
+	destroyCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 30*time.Second)
+	defer cancel()
+	if err := r.sandboxProvider.Destroy(destroyCtx, sb); err != nil {
+		r.logger.Warn().
+			Err(err).
+			Str("preview_id", previewID.String()).
+			Str("sandbox_id", sb.ID).
+			Msg("failed to destroy interrupted branch preview sandbox")
+	}
+}
+
+func sandboxID(sb *agent.Sandbox) string {
+	if sb == nil {
+		return ""
+	}
+	return sb.ID
 }
 
 func (r *StartRunner) registerCapacityDeadLetter(ctx context.Context, reservation *models.PreviewInstance) {

--- a/internal/services/preview/start_runner_test.go
+++ b/internal/services/preview/start_runner_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/assembledhq/143/internal/db"
+	"github.com/assembledhq/143/internal/jobctx"
 	"github.com/assembledhq/143/internal/models"
 	"github.com/assembledhq/143/internal/repoconfig"
 	"github.com/assembledhq/143/internal/services/agent"
@@ -193,20 +194,25 @@ func TestStartRunnerRetryBranchPreviewStartupInterruptionResetsAndDestroysSandbo
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
 		WillReturnResult(pgxmock.NewResult("DELETE", 1))
 	mock.ExpectCommit()
+	expectUpdatePreviewStatusFailed(mock)
 
+	store := db.NewPreviewStore(mock)
 	runner := &StartRunner{
-		previews:        db.NewPreviewStore(mock),
+		manager:         &Manager{store: store, logger: zerolog.Nop()},
+		previews:        store,
 		sandboxProvider: provider,
 		logger:          zerolog.Nop(),
 	}
 	reservation := &models.PreviewInstance{ID: previewID, OrgID: orgID, PreviewTargetID: &targetID, Status: models.PreviewStatusStarting}
 	payload := StartBranchPreviewJobPayload{OrgID: orgID, PreviewID: previewID, PreviewTargetID: targetID}
 	sb := &agent.Sandbox{ID: "sandbox-1", Provider: ProviderDocker}
+	ctx := jobctx.WithDeadLetterHooks(context.Background())
 
-	err = runner.retryBranchPreviewStartupInterruption(context.Background(), payload, reservation, sb, "launch_preview", errors.New("Error response from daemon: No such container: sandbox-1"))
+	err = runner.retryBranchPreviewStartupInterruption(ctx, payload, reservation, sb, "launch_preview", errors.New("Error response from daemon: No such container: sandbox-1"))
 
 	require.ErrorIs(t, err, ErrPreviewStartupInterrupted, "interrupted branch preview startup should return the retryable sentinel")
 	require.Equal(t, []string{"sandbox-1"}, provider.destroyed, "interrupted branch preview startup should destroy the transient sandbox")
+	jobctx.RunDeadLetterHooks(ctx, err)
 	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
 }
 

--- a/internal/services/preview/start_runner_test.go
+++ b/internal/services/preview/start_runner_test.go
@@ -3,6 +3,7 @@ package preview
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"strings"
@@ -10,6 +11,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
 	"github.com/pashagolub/pgxmock/v4"
 	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/require"
@@ -29,6 +31,50 @@ func TestClassifyLaunchFailure_InstallFailed(t *testing.T) {
 	require.Equal(t, "PREVIEW_INSTALL_FAILED", failure.Code, "install failures should get a dedicated preview start error code")
 	require.Contains(t, failure.Message, "preview.install", "install failure message should point users at the install config")
 	require.Contains(t, failure.Message, "npm ci exited with code 1", "install failure message should include provider details")
+}
+
+func TestIsPreviewStartupInterrupted(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		err      error
+		expected bool
+	}{
+		{
+			name:     "sentinel",
+			err:      fmt.Errorf("launch preview: %w", ErrPreviewStartupInterrupted),
+			expected: true,
+		},
+		{
+			name:     "docker missing container",
+			err:      fmt.Errorf("create exec: Error response from daemon: No such container: abc123"),
+			expected: true,
+		},
+		{
+			name:     "sandbox exec broken pipe",
+			err:      fmt.Errorf("write exec stdin: broken pipe"),
+			expected: true,
+		},
+		{
+			name:     "normal install failure",
+			err:      fmt.Errorf("%w: npm ci exited with code 1", ErrInstallFailed),
+			expected: false,
+		},
+		{
+			name:     "invalid config",
+			err:      fmt.Errorf("%w: missing primary service", ErrInvalidConfig),
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			require.Equal(t, tt.expected, IsPreviewStartupInterrupted(tt.err), "startup interruption classification should match expected retryability")
+		})
+	}
 }
 
 func TestClassifyLaunchFailure_OutOfMemory(t *testing.T) {
@@ -114,6 +160,103 @@ func TestShouldReassignPreviewWorker(t *testing.T) {
 			require.Equal(t, tt.expected, actual, "shouldReassignPreviewWorker should match the expected fallback ownership behavior")
 		})
 	}
+}
+
+func TestStartRunnerRetryBranchPreviewStartupInterruptionResetsAndDestroysSandbox(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "pgx mock should initialize")
+	defer mock.Close()
+
+	orgID := uuid.New()
+	previewID := uuid.New()
+	targetID := uuid.New()
+	now := time.Now()
+	provider := &destroyRecordingSandboxProvider{}
+	mock.ExpectQuery("INSERT INTO preview_logs").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(pgxmock.NewRows([]string{
+			"id", "preview_instance_id", "org_id", "level", "step", "message", "metadata", "created_at",
+		}).AddRow(uuid.New(), previewID, orgID, "warn", "start", "interrupted", json.RawMessage(`{}`), now))
+	mock.ExpectBegin()
+	mock.ExpectExec("UPDATE preview_instances").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
+	mock.ExpectExec("UPDATE preview_runtimes").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
+	mock.ExpectExec("DELETE FROM preview_services").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnResult(pgxmock.NewResult("DELETE", 2))
+	mock.ExpectExec("DELETE FROM preview_infrastructure").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnResult(pgxmock.NewResult("DELETE", 1))
+	mock.ExpectCommit()
+
+	runner := &StartRunner{
+		previews:        db.NewPreviewStore(mock),
+		sandboxProvider: provider,
+		logger:          zerolog.Nop(),
+	}
+	reservation := &models.PreviewInstance{ID: previewID, OrgID: orgID, PreviewTargetID: &targetID, Status: models.PreviewStatusStarting}
+	payload := StartBranchPreviewJobPayload{OrgID: orgID, PreviewID: previewID, PreviewTargetID: targetID}
+	sb := &agent.Sandbox{ID: "sandbox-1", Provider: ProviderDocker}
+
+	err = runner.retryBranchPreviewStartupInterruption(context.Background(), payload, reservation, sb, "launch_preview", errors.New("Error response from daemon: No such container: sandbox-1"))
+
+	require.ErrorIs(t, err, ErrPreviewStartupInterrupted, "interrupted branch preview startup should return the retryable sentinel")
+	require.Equal(t, []string{"sandbox-1"}, provider.destroyed, "interrupted branch preview startup should destroy the transient sandbox")
+	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
+}
+
+func TestStartRunnerEnsureReservationRuntimeForClaimingWorkerCreatesRuntimeForSameWorkerRetry(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "pgx mock should initialize")
+	defer mock.Close()
+
+	orgID := uuid.New()
+	previewID := uuid.New()
+	runtimeID := uuid.New()
+	now := time.Now()
+	mock.ExpectQuery("SELECT[\\s\\S]+FROM preview_runtimes").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnError(pgx.ErrNoRows)
+	mock.ExpectBegin()
+	mock.ExpectExec("UPDATE preview_runtimes").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
+	mock.ExpectQuery("SELECT COALESCE").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(pgxmock.NewRows([]string{"next_epoch"}).AddRow(2))
+	mock.ExpectQuery("INSERT INTO preview_runtimes").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(pgxmock.NewRows([]string{
+			"id", "org_id", "preview_instance_id", "runtime_epoch", "worker_node_id",
+			"endpoint_url", "preview_handle", "primary_port", "status", "lease_expires_at",
+			"last_heartbeat_at", "drain_requested_at", "stopped_at", "error", "unavailable_reason", "created_at", "updated_at",
+		}).AddRow(
+			runtimeID, orgID, previewID, 2, "worker-1",
+			"http://worker:8080", "", 0, string(models.PreviewRuntimeStatusStarting), now.Add(90*time.Second),
+			now, nil, nil, "", "", now, now,
+		))
+	mock.ExpectCommit()
+
+	runner := &StartRunner{
+		manager:  &Manager{previewInternalBaseURL: "http://worker:8080"},
+		previews: db.NewPreviewStore(mock),
+		nodeID:   "worker-1",
+		logger:   zerolog.Nop(),
+	}
+	reservation := &models.PreviewInstance{ID: previewID, OrgID: orgID, WorkerNodeID: "worker-1", Status: models.PreviewStatusStarting}
+
+	err = runner.ensureReservationRuntimeForClaimingWorker(context.Background(), orgID, previewID, reservation)
+
+	require.NoError(t, err, "same-worker retry should create a fresh runtime epoch when none is active")
+	require.Equal(t, "worker-1", reservation.WorkerNodeID, "reservation should remain owned by the claiming worker")
+	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
 }
 
 type startRunnerFileReader struct {
@@ -569,6 +712,16 @@ func (f fakeStartRunnerSandboxProvider) Restore(context.Context, *agent.Sandbox,
 }
 func (f fakeStartRunnerSandboxProvider) ExecStream(context.Context, *agent.Sandbox, string, func([]byte), io.Writer) (int, error) {
 	panic("not used")
+}
+
+type destroyRecordingSandboxProvider struct {
+	fakeStartRunnerSandboxProvider
+	destroyed []string
+}
+
+func (p *destroyRecordingSandboxProvider) Destroy(_ context.Context, sb *agent.Sandbox) error {
+	p.destroyed = append(p.destroyed, sb.ID)
+	return nil
 }
 
 func TestStartRunnerMaybeRestoreBranchPreviewStartupCache_RestoresMatchingSnapshot(t *testing.T) {

--- a/internal/worker/handlers.go
+++ b/internal/worker/handlers.go
@@ -46,6 +46,7 @@ import (
 
 const sandboxCapacityRetryDelay = 10 * time.Second
 const previewCapacityRetryDelay = 5 * time.Second
+const previewStartupInterruptedRetryDelay = 2 * time.Second
 const prePRReviewRetryDelay = 5 * time.Second
 
 // prePRReviewMaxWait bounds how long a readiness run will requeue itself waiting
@@ -875,6 +876,22 @@ func newStartBranchPreviewHandler(stores *Stores, services *Services, logger zer
 					Dur("retry_after", retryAfter).
 					Msg("preview capacity reached; retrying start_branch_preview")
 				return &RetryableError{Err: err, RetryAfter: &retryAfter, TargetNodeID: targetNodeID, ClearTargetNodeID: clearTarget}
+			}
+			if errors.Is(err, previewsvc.ErrPreviewStartupInterrupted) {
+				retryAfter := previewStartupInterruptedRetryDelay
+				logger.Info().
+					Err(err).
+					Str("preview_id", input.PreviewID.String()).
+					Str("preview_target_id", input.PreviewTargetID.String()).
+					Dur("retry_after", retryAfter).
+					Msg("preview startup interrupted; retrying start_branch_preview on a fresh worker selection")
+				return &RetryableError{
+					Err:                    err,
+					ConsumeAttempt:         true,
+					BypassMaxRetryDuration: true,
+					RetryAfter:             &retryAfter,
+					ClearTargetNodeID:      true,
+				}
 			}
 			enqueueSlackNotificationSubscribers(ctx, stores, logger, input.OrgID, slackNotificationFanoutInput{
 				EventKind: string(models.SlackNotificationPreviewFailed),

--- a/internal/worker/handlers_test.go
+++ b/internal/worker/handlers_test.go
@@ -6489,6 +6489,36 @@ func TestStartBranchPreviewHandler_PreviewCapacityRetriesTargetsAvailableWorker(
 	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
 }
 
+func TestStartBranchPreviewHandler_StartupInterruptedRetriesWithFreshWorkerSelection(t *testing.T) {
+	t.Parallel()
+
+	logger := zerolog.Nop()
+	starter := &mockPreviewStarter{err: fmt.Errorf("launch preview: %w", previewsvc.ErrPreviewStartupInterrupted)}
+	handler := newStartBranchPreviewHandler(nil, &Services{PreviewStarter: starter}, logger)
+
+	payload := previewsvc.StartBranchPreviewJobPayload{
+		OrgID:           uuid.New(),
+		UserID:          uuid.New(),
+		PreviewID:       uuid.New(),
+		PreviewTargetID: uuid.New(),
+		RepositoryID:    uuid.New(),
+		Branch:          "feature/previews",
+		CommitSHA:       "0123456789abcdef0123456789abcdef01234567",
+	}
+	raw, err := json.Marshal(payload)
+	require.NoError(t, err, "start_branch_preview payload should marshal")
+
+	err = handler(context.Background(), models.JobTypeStartBranchPreview, raw)
+
+	var retryable *RetryableError
+	require.ErrorAs(t, err, &retryable, "branch preview startup interruptions should retry instead of dead-lettering")
+	require.True(t, retryable.ConsumeAttempt, "startup interruption retries should consume attempts so they remain bounded")
+	require.True(t, retryable.BypassMaxRetryDuration, "startup interruption retries should bypass the generic retry window")
+	require.True(t, retryable.ClearTargetNodeID, "startup interruption retries should clear stale worker affinity")
+	require.NotNil(t, retryable.RetryAfter, "startup interruption retry should use a short fixed delay")
+	require.Equal(t, previewStartupInterruptedRetryDelay, *retryable.RetryAfter, "startup interruption retry should use the configured delay")
+}
+
 func TestStartPreviewHandler_PreviewCapacityRetries(t *testing.T) {
 	t.Parallel()
 

--- a/internal/worker/session_executor_runtime.go
+++ b/internal/worker/session_executor_runtime.go
@@ -396,6 +396,11 @@ func (r *SessionExecutorRuntime) finishAttempt(ctx context.Context, handlerCtx c
 
 	var retryable *RetryableError
 	if errors.As(err, &retryable) {
+		if retryable.ConsumeAttempt && job.Attempts >= job.MaxAttempts {
+			r.markJobDeadLetter(writeCtx, handlerCtx, executor, job, err)
+			r.markExecutorTerminal(writeCtx, executor, models.SessionExecutorStatusFailed, 1, err.Error())
+			return nil
+		}
 		if !retryable.BypassMaxRetryDuration && time.Since(job.CreatedAt) > maxRetryableDuration {
 			timeoutErr := fmt.Errorf("retryable job timed out after %s: %w", maxRetryableDuration, err)
 			r.markJobDeadLetter(writeCtx, handlerCtx, executor, job, timeoutErr)

--- a/internal/worker/session_executor_runtime_test.go
+++ b/internal/worker/session_executor_runtime_test.go
@@ -458,6 +458,58 @@ func TestSessionExecutorRuntime_RetryableErrorRequeuesJob(t *testing.T) {
 	require.Equal(t, 0, jobs.succeededCalls, "runtime should not mark retryable jobs succeeded")
 }
 
+func TestSessionExecutorRuntime_AttemptConsumingRetryableErrorDeadLettersAtMaxAttempts(t *testing.T) {
+	t.Parallel()
+
+	executorID := uuid.New()
+	orgID := uuid.New()
+	sessionID := uuid.New()
+	jobID := uuid.New()
+	lockToken := uuid.New()
+	jobs := &executorRuntimeJobStoreStub{
+		active: true,
+		job: &models.Job{
+			ID:          jobID,
+			OrgID:       orgID,
+			JobType:     "continue_session",
+			Payload:     json.RawMessage(`{}`),
+			Status:      "running",
+			Attempts:    3,
+			MaxAttempts: 3,
+			LockToken:   &lockToken,
+			CreatedAt:   time.Now(),
+		},
+	}
+	executors := &executorRuntimeExecutorStoreStub{
+		executor: models.SessionExecutor{
+			ID:        executorID,
+			OrgID:     orgID,
+			SessionID: sessionID,
+			JobID:     jobID,
+			JobType:   "continue_session",
+			LockToken: lockToken,
+			Status:    models.SessionExecutorStatusStarting,
+		},
+		markRunningOK: true,
+	}
+	runtime := &SessionExecutorRuntime{
+		Executors: executors,
+		Jobs:      jobs,
+		Handlers: map[string]JobHandler{
+			"continue_session": func(context.Context, string, json.RawMessage) error {
+				return &RetryableError{Err: errors.New("preview startup interrupted"), ConsumeAttempt: true}
+			},
+		},
+		Logger: zerolog.Nop(),
+	}
+
+	err := runtime.Run(context.Background(), executorID)
+	require.NoError(t, err, "runtime should treat terminal retry exhaustion as handled")
+	require.Equal(t, 1, jobs.deadLetterCalls, "attempt-consuming retryable errors should dead-letter at max attempts")
+	require.Equal(t, 0, jobs.retryCalls, "attempt-consuming retryable errors should not requeue past max attempts")
+	require.Equal(t, models.SessionExecutorStatusFailed, executors.terminalStatus, "executor should be marked failed when retry attempts are exhausted")
+}
+
 func TestSessionExecutorRuntime_RetryableErrorClearsTargetNode(t *testing.T) {
 	t.Parallel()
 

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -269,6 +269,12 @@ func (w *Worker) poll(ctx context.Context) {
 
 	var retryable *RetryableError
 	if errors.As(err, &retryable) {
+		if retryable.ConsumeAttempt && job.Attempts >= job.MaxAttempts {
+			w.logger.Error().Err(err).Str("job_id", job.ID.String()).Msg("retryable job exhausted attempts, dead-lettering")
+			w.deadLetterJob(ctx, job.ID, *job.LockToken, err.Error())
+			w.runDeadLetterHooks(handlerCtx, err)
+			return
+		}
 		if !retryable.BypassMaxRetryDuration && time.Since(job.CreatedAt) > maxRetryableDuration {
 			w.logger.Error().Err(err).
 				Str("job_id", job.ID.String()).

--- a/internal/worker/worker_test.go
+++ b/internal/worker/worker_test.go
@@ -257,6 +257,27 @@ func TestWorker_Poll(t *testing.T) {
 			},
 		},
 		{
+			name: "attempt-consuming retryable failure dead-letters at max attempts",
+			setupMock: func(t *testing.T, w *Worker, mock pgxmock.PgxPoolIface) {
+				t.Helper()
+
+				jobID := uuid.New()
+				lockToken := uuid.New()
+				orgID := uuid.New()
+				now := time.Now()
+				handlerErr := &RetryableError{Err: errors.New("preview startup interrupted"), ConsumeAttempt: true}
+
+				w.Register("attempt_consuming_exhausted_job", func(ctx context.Context, jobType string, got json.RawMessage) error {
+					return handlerErr
+				})
+
+				expectClaimWithAttempts(mock, jobID, orgID, "attempt_consuming_exhausted_job", json.RawMessage(`{}`), now, lockToken, 3, 3)
+				mock.ExpectExec("UPDATE jobs\\s+SET status = 'dead_letter'").
+					WithArgs(handlerErr.Error(), jobID, lockToken).
+					WillReturnResult(pgxmock.NewResult("UPDATE", 1))
+			},
+		},
+		{
 			name: "retryable max duration bypass retries old job",
 			setupMock: func(t *testing.T, w *Worker, mock pgxmock.PgxPoolIface) {
 				t.Helper()


### PR DESCRIPTION
## Summary
- classify sandbox-lifecycle failures during branch preview startup as retryable interruptions
- reset starting previews for retry, destroy the interrupted sandbox, and requeue with fresh worker selection
- teach worker/session execution to dead-letter attempt-consuming retries at max attempts and improve maintenance drain handling for workers

## Testing
- Added unit tests for preview interruption classification, retry reset behavior, worker retry handling, and maintenance drain control flow
- Added coverage for session executor and worker dead-letter behavior when attempt-consuming retries exhaust their limits