### PR TITLE
Fix Slack continuation threading and final response handling

### DIFF
--- a/internal/worker/handlers.go
+++ b/internal/worker/handlers.go
@@ -2322,33 +2322,16 @@ func newSlackStartOrContinueSessionHandler(stores *Stores, services *Services, l
 					return fmt.Errorf("refresh linked Slack session routing: %w", routeErr)
 				}
 				session = refreshedSession
-				msg := &models.SessionMessage{
-					SessionID:  session.ID,
-					OrgID:      orgID,
-					ThreadID:   session.PrimaryThreadID,
-					UserID:     mappedUserID,
-					TurnNumber: session.CurrentTurn,
-					Role:       models.MessageRoleUser,
-					Content:    renderSlackPromptWithUserResolver(ctx, payload.Text, permalink, threadMessages, contextRefs, contextFiles, userResolver),
-					References: slackContextReferencesForSessionInput(contextRefs),
-				}
-				if err := stores.SessionMessages.Create(ctx, msg); err != nil {
-					return fmt.Errorf("create slack follow-up message: %w", err)
-				}
-				scopeID := session.ID
-				if session.PrimaryThreadID != nil {
-					scopeID = *session.PrimaryThreadID
-				}
-				dedupeKey := db.ContinueSessionDedupeKey(scopeID)
-				continuePayload := map[string]string{
-					"org_id":     orgID.String(),
-					"session_id": session.ID.String(),
-				}
-				if session.PrimaryThreadID != nil {
-					continuePayload["thread_id"] = session.PrimaryThreadID.String()
-				}
-				if _, err := stores.Jobs.Enqueue(ctx, orgID, "agent", "continue_session", continuePayload, 5, &dedupeKey); err != nil {
-					return fmt.Errorf("enqueue slack session continuation: %w", err)
+				if err := enqueueSlackSessionContinuationMessage(
+					ctx,
+					stores,
+					orgID,
+					session,
+					mappedUserID,
+					renderSlackPromptWithUserResolver(ctx, payload.Text, permalink, threadMessages, contextRefs, contextFiles, userResolver),
+					contextRefs,
+				); err != nil {
+					return err
 				}
 				ackText := slackSessionAckText(services, session.ID, "Continuing")
 				if teamLine := slackTeamSessionLine(existingLink); teamLine != "" {
@@ -5491,12 +5474,24 @@ func enqueueSlackSessionContinuationPromptWithReferences(ctx context.Context, st
 	if err != nil {
 		return fmt.Errorf("get session for Slack continuation: %w", err)
 	}
+	return enqueueSlackSessionContinuationMessage(ctx, stores, orgID, session, session.TriggeredByUserID, prompt, refs)
+}
+
+func enqueueSlackSessionContinuationMessage(ctx context.Context, stores *Stores, orgID uuid.UUID, session models.Session, userID *uuid.UUID, prompt string, refs []slackContextReference) error {
+	if stores == nil || stores.SessionMessages == nil || stores.SessionThreads == nil || stores.Jobs == nil {
+		return fmt.Errorf("slack session continuation dependencies are not configured")
+	}
+	thread, err := primaryThreadForSlackContinuation(ctx, stores, session)
+	if err != nil {
+		return fmt.Errorf("resolve primary thread for Slack continuation: %w", err)
+	}
+	threadIDLocal := thread.ID
 	msg := &models.SessionMessage{
 		SessionID:  session.ID,
 		OrgID:      orgID,
-		ThreadID:   session.PrimaryThreadID,
-		UserID:     session.TriggeredByUserID,
-		TurnNumber: session.CurrentTurn,
+		ThreadID:   &threadIDLocal,
+		UserID:     userID,
+		TurnNumber: thread.CurrentTurn + 1,
 		Role:       models.MessageRoleUser,
 		Content:    prompt,
 		References: slackContextReferencesForSessionInput(refs),
@@ -5504,17 +5499,31 @@ func enqueueSlackSessionContinuationPromptWithReferences(ctx context.Context, st
 	if err := stores.SessionMessages.Create(ctx, msg); err != nil {
 		return fmt.Errorf("create Slack continuation message: %w", err)
 	}
-	scopeID := session.ID
-	if session.PrimaryThreadID != nil {
-		scopeID = *session.PrimaryThreadID
-	}
-	dedupeKey := db.ContinueSessionDedupeKey(scopeID)
-	payload := map[string]string{"org_id": orgID.String(), "session_id": session.ID.String()}
-	if session.PrimaryThreadID != nil {
-		payload["thread_id"] = session.PrimaryThreadID.String()
+	dedupeKey := db.ContinueSessionDedupeKey(thread.ID)
+	payload := map[string]string{
+		"org_id":     orgID.String(),
+		"session_id": session.ID.String(),
+		"thread_id":  thread.ID.String(),
 	}
 	_, err = stores.Jobs.Enqueue(ctx, orgID, "agent", "continue_session", payload, 5, &dedupeKey)
 	return err
+}
+
+func primaryThreadForSlackContinuation(ctx context.Context, stores *Stores, session models.Session) (models.SessionThread, error) {
+	if stores == nil || stores.SessionThreads == nil {
+		return models.SessionThread{}, fmt.Errorf("session thread store not configured")
+	}
+	if session.PrimaryThreadID != nil && *session.PrimaryThreadID != uuid.Nil {
+		return stores.SessionThreads.GetByID(ctx, session.OrgID, *session.PrimaryThreadID)
+	}
+	threads, err := stores.SessionThreads.ListBySession(ctx, session.OrgID, session.ID)
+	if err != nil {
+		return models.SessionThread{}, fmt.Errorf("list session threads: %w", err)
+	}
+	if len(threads) == 0 {
+		return models.SessionThread{}, fmt.Errorf("session has no threads")
+	}
+	return threads[0], nil
 }
 
 func postSlackEphemeralIfPossible(ctx context.Context, stores *Stores, slackClient *ingestion.SlackAPIClient, orgID uuid.UUID, input models.SlackInteractionJobPayload, text string) error {
@@ -8519,6 +8528,10 @@ func enqueueSlackRunUpdateIfLinked(ctx context.Context, stores *Stores, logger z
 }
 
 func enqueueSlackFinalIfLinked(ctx context.Context, stores *Stores, logger zerolog.Logger, orgID, sessionID uuid.UUID) {
+	enqueueSlackFinalIfLinkedForThread(ctx, stores, logger, orgID, sessionID, nil, 0)
+}
+
+func enqueueSlackFinalIfLinkedForThread(ctx context.Context, stores *Stores, logger zerolog.Logger, orgID, sessionID uuid.UUID, threadID *uuid.UUID, turnNumber int) {
 	if stores == nil || stores.SlackSessionLinks == nil || stores.SessionMessages == nil || stores.Jobs == nil {
 		return
 	}
@@ -8529,14 +8542,19 @@ func enqueueSlackFinalIfLinked(ctx context.Context, stores *Stores, logger zerol
 		}
 		return
 	}
-	messages, err := stores.SessionMessages.ListBySession(ctx, orgID, sessionID)
+	var messages []models.SessionMessage
+	if threadID != nil && *threadID != uuid.Nil {
+		messages, err = stores.SessionMessages.ListByThread(ctx, orgID, *threadID)
+	} else {
+		messages, err = stores.SessionMessages.ListBySession(ctx, orgID, sessionID)
+	}
 	if err != nil {
 		logger.Warn().Err(err).Str("session_id", sessionID.String()).Msg("failed to load messages for Slack final response")
 		return
 	}
 	var finalMessageID int64
 	for i := len(messages) - 1; i >= 0; i-- {
-		if messages[i].Role == models.MessageRoleAssistant {
+		if messages[i].Role == models.MessageRoleAssistant && (turnNumber <= 0 || messages[i].TurnNumber == turnNumber) {
 			finalMessageID = messages[i].ID
 			break
 		}
@@ -9144,6 +9162,15 @@ func newContinueSessionHandler(stores *Stores, services *Services, logger zerolo
 					Msg("failed to complete pull request repair run after continue_session")
 			}
 		}
+		enqueueSlackHumanInputsIfPending(ctx, stores, logger, orgID, sessionID)
+		var completedThreadID *uuid.UUID
+		completedThreadTurn := 0
+		if hasThread {
+			threadIDLocal := threadID
+			completedThreadID = &threadIDLocal
+			completedThreadTurn = threadTurnBefore + 1
+		}
+		enqueueSlackFinalIfLinkedForThread(ctx, stores, logger, orgID, sessionID, completedThreadID, completedThreadTurn)
 		supersedeStaleSessionPreviewWarmRuns(ctx, stores, logger, orgID, sessionID)
 		enqueueSessionPreviewCachePrewarm(ctx, stores, services, logger, orgID, sessionID, "continue_session_completed")
 		enqueueSessionPreviewPostTurnClassifier(ctx, stores, services, logger, orgID, sessionID)

--- a/internal/worker/handlers_test.go
+++ b/internal/worker/handlers_test.go
@@ -1378,6 +1378,72 @@ func TestEnqueueSlackFinalIfLinkedEnqueuesFinalResponseForAssistantMessage(t *te
 	require.NoError(t, mock.ExpectationsWereMet(), "Slack-linked successful run should enqueue one final response job")
 }
 
+func TestEnqueueSlackSessionContinuationMessageUsesPrimaryThread(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "pgxmock should initialize")
+	defer mock.Close()
+
+	orgID := uuid.New()
+	sessionID := uuid.New()
+	threadID := uuid.New()
+	userID := uuid.New()
+	now := time.Now()
+	session := models.Session{
+		ID:          sessionID,
+		OrgID:       orgID,
+		CurrentTurn: 3,
+	}
+	expectedDedupeKey := db.ContinueSessionDedupeKey(threadID)
+
+	mock.ExpectQuery("SELECT .* FROM session_threads").
+		WithArgs(workerAnyArgs(2)...).
+		WillReturnRows(pgxmock.NewRows(workerSessionThreadColumns).AddRow(
+			workerSessionThreadRow(threadID, sessionID, orgID, models.AgentTypeCodex, nil, models.ThreadStatusIdle)...,
+		))
+	mock.ExpectQuery("INSERT INTO session_messages").
+		WithArgs(
+			sessionID,
+			orgID,
+			uuidPtrEqualsArg{expected: threadID},
+			uuidPtrEqualsArg{expected: userID},
+			2,
+			models.MessageRoleUser,
+			"follow up from Slack",
+			pgxmock.AnyArg(),
+			pgxmock.AnyArg(),
+			pgxmock.AnyArg(),
+			pgxmock.AnyArg(),
+		).
+		WillReturnRows(pgxmock.NewRows([]string{"id", "created_at"}).AddRow(int64(101), now))
+	mock.ExpectQuery("INSERT INTO jobs").
+		WithArgs(
+			orgID,
+			"agent",
+			"continue_session",
+			jsonStringFieldsArg{expected: map[string]string{
+				"org_id":     orgID.String(),
+				"session_id": sessionID.String(),
+				"thread_id":  threadID.String(),
+			}},
+			5,
+			stringPtrEqualsArg{expected: expectedDedupeKey},
+		).
+		WillReturnRows(pgxmock.NewRows([]string{"id"}).AddRow(uuid.New()))
+
+	stores := &Stores{
+		SessionThreads:  db.NewSessionThreadStore(mock),
+		SessionMessages: db.NewSessionMessageStore(mock),
+		Jobs:            db.NewJobStore(mock),
+	}
+
+	err = enqueueSlackSessionContinuationMessage(context.Background(), stores, orgID, session, &userID, "follow up from Slack", nil)
+
+	require.NoError(t, err, "Slack continuation should append and enqueue against the primary thread")
+	require.NoError(t, mock.ExpectationsWereMet(), "Slack continuation should persist the thread id and queue a thread-scoped continuation")
+}
+
 func TestSlackSelectRepositoryUpdatesIdleSessionAndEnqueuesRun(t *testing.T) {
 	t.Parallel()
 
@@ -2740,6 +2806,100 @@ func workerAnyArgs(n int) []interface{} {
 		args[i] = pgxmock.AnyArg()
 	}
 	return args
+}
+
+type uuidPtrEqualsArg struct {
+	expected uuid.UUID
+}
+
+func (a uuidPtrEqualsArg) Match(v interface{}) bool {
+	switch got := v.(type) {
+	case *uuid.UUID:
+		return got != nil && *got == a.expected
+	case uuid.UUID:
+		return got == a.expected
+	default:
+		return false
+	}
+}
+
+type stringPtrEqualsArg struct {
+	expected string
+}
+
+func (a stringPtrEqualsArg) Match(v interface{}) bool {
+	got, ok := v.(*string)
+	return ok && got != nil && *got == a.expected
+}
+
+type jsonStringFieldsArg struct {
+	expected map[string]string
+}
+
+func (a jsonStringFieldsArg) Match(v interface{}) bool {
+	var raw []byte
+	switch got := v.(type) {
+	case []byte:
+		raw = got
+	case json.RawMessage:
+		raw = got
+	case string:
+		raw = []byte(got)
+	default:
+		return false
+	}
+	var payload map[string]string
+	if err := json.Unmarshal(raw, &payload); err != nil {
+		return false
+	}
+	for key, expected := range a.expected {
+		if payload[key] != expected {
+			return false
+		}
+	}
+	return true
+}
+
+type jsonPayloadFieldsArg struct {
+	expectedStrings map[string]string
+	expectedInts    map[string]int64
+}
+
+func (a jsonPayloadFieldsArg) Match(v interface{}) bool {
+	var raw []byte
+	switch got := v.(type) {
+	case []byte:
+		raw = got
+	case json.RawMessage:
+		raw = got
+	case string:
+		raw = []byte(got)
+	default:
+		return false
+	}
+	decoder := json.NewDecoder(bytes.NewReader(raw))
+	decoder.UseNumber()
+	var payload map[string]any
+	if err := decoder.Decode(&payload); err != nil {
+		return false
+	}
+	for key, expected := range a.expectedStrings {
+		got, ok := payload[key].(string)
+		if !ok || got != expected {
+			return false
+		}
+	}
+	for key, expected := range a.expectedInts {
+		number, ok := payload[key].(json.Number)
+		if !ok {
+			return false
+		}
+		got, err := number.Int64()
+		if err != nil || got != expected {
+			return false
+		}
+	}
+	return true
 }
 
 type fakeSlackMessagePoster struct {
@@ -9109,6 +9269,158 @@ func TestContinueSessionHandler_UsesRuntimeCeilingDeadline(t *testing.T) {
 	require.NoError(t, err, "continue_session should succeed when the orchestrator returns success")
 	require.Equal(t, 1, orch.continueSessionCalls, "continue_session should invoke the orchestrator once")
 	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
+}
+
+func TestContinueSessionHandler_EnqueuesSlackFinalAfterSuccess(t *testing.T) {
+	t.Parallel()
+
+	stores, mock := newTestStores(t)
+	defer mock.Close()
+	stores.SlackSessionLinks = db.NewSlackSessionLinkStore(mock)
+	stores.SessionMessages = db.NewSessionMessageStore(mock)
+
+	orgID := uuid.New()
+	sessionID := uuid.New()
+	issueID := uuid.New()
+	linkID := uuid.New()
+	installationID := uuid.New()
+	now := time.Now()
+	link := models.SlackSessionLink{
+		ID:                  linkID,
+		OrgID:               orgID,
+		SessionID:           sessionID,
+		SlackInstallationID: installationID,
+		SlackTeamID:         "T123",
+		SlackChannelID:      "C123",
+		SlackThreadTS:       "1700000000.000100",
+		SlackRootTS:         "1700000000.000100",
+		SlackUserID:         "U123",
+		TeamSession:         true,
+		CreatedAt:           now,
+		UpdatedAt:           now,
+	}
+
+	mock.ExpectQuery("SELECT .* FROM sessions").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(
+			pgxmock.NewRows(workerSessionColumns).AddRow(
+				workerSessionRow(sessionID, issueID, orgID, models.SessionStatusIdle, 2, nil, nil)...,
+			),
+		)
+	mock.ExpectQuery("SELECT id, org_id, session_id, slack_installation_id").
+		WithArgs(workerAnyArgs(2)...).
+		WillReturnRows(slackSessionLinkRows(link))
+	mock.ExpectQuery("SELECT .+ FROM session_messages").
+		WithArgs(workerAnyArgs(2)...).
+		WillReturnRows(sessionMessageRows(
+			models.SessionMessage{ID: 51, SessionID: sessionID, OrgID: orgID, TurnNumber: 1, Role: models.MessageRoleUser, Content: "next question", CreatedAt: now},
+			models.SessionMessage{ID: 52, SessionID: sessionID, OrgID: orgID, TurnNumber: 2, Role: models.MessageRoleAssistant, Content: "next answer", CreatedAt: now},
+		))
+	mock.ExpectQuery("INSERT INTO jobs").
+		WithArgs(orgID, "default", "slack_post_final_response", pgxmock.AnyArg(), 3, pgxmock.AnyArg()).
+		WillReturnRows(pgxmock.NewRows([]string{"id"}).AddRow(uuid.New()))
+
+	orch := &orchestratorServiceStub{}
+	handler := newContinueSessionHandler(stores, &Services{Orchestrator: orch}, zerolog.Nop())
+	payload := json.RawMessage(`{"session_id":"` + sessionID.String() + `","org_id":"` + orgID.String() + `"}`)
+
+	err := handler(context.Background(), "continue_session", payload)
+
+	require.NoError(t, err, "continue_session should succeed when the orchestrator returns success")
+	require.Equal(t, 1, orch.continueSessionCalls, "continue_session should invoke the orchestrator once")
+	require.NoError(t, mock.ExpectationsWereMet(), "Slack-linked continuations should enqueue a final response job")
+}
+
+func TestContinueSessionHandler_EnqueuesSlackFinalForCompletedThreadTurn(t *testing.T) {
+	t.Parallel()
+
+	stores, mock := newTestStores(t)
+	defer mock.Close()
+	stores.SlackSessionLinks = db.NewSlackSessionLinkStore(mock)
+	stores.SessionMessages = db.NewSessionMessageStore(mock)
+	stores.SessionThreads = db.NewSessionThreadStore(mock)
+
+	orgID := uuid.New()
+	sessionID := uuid.New()
+	threadID := uuid.New()
+	issueID := uuid.New()
+	linkID := uuid.New()
+	installationID := uuid.New()
+	now := time.Now()
+	link := models.SlackSessionLink{
+		ID:                  linkID,
+		OrgID:               orgID,
+		SessionID:           sessionID,
+		SlackInstallationID: installationID,
+		SlackTeamID:         "T123",
+		SlackChannelID:      "C123",
+		SlackThreadTS:       "1700000000.000100",
+		SlackRootTS:         "1700000000.000100",
+		SlackUserID:         "U123",
+		TeamSession:         true,
+		CreatedAt:           now,
+		UpdatedAt:           now,
+	}
+
+	mock.ExpectQuery("SELECT .* FROM sessions").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(
+			pgxmock.NewRows(workerSessionColumns).AddRow(
+				workerSessionRow(sessionID, issueID, orgID, models.SessionStatusIdle, 5, nil, nil)...,
+			),
+		)
+	mock.ExpectQuery("SELECT .* FROM session_threads").
+		WithArgs(workerAnyArgs(2)...).
+		WillReturnRows(pgxmock.NewRows(workerSessionThreadColumns).AddRow(
+			workerSessionThreadRow(threadID, sessionID, orgID, models.AgentTypeCodex, nil, models.ThreadStatusRunning)...,
+		))
+	mock.ExpectExec(`UPDATE session_threads`).
+		WithArgs(2, pgxmock.AnyArg(), threadID, orgID).
+		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
+	mock.ExpectQuery("SELECT id, org_id, session_id, slack_installation_id").
+		WithArgs(workerAnyArgs(2)...).
+		WillReturnRows(slackSessionLinkRows(link))
+	mock.ExpectQuery("SELECT .+ FROM session_messages[\\s\\S]+WHERE org_id = @org_id AND thread_id = @thread_id").
+		WithArgs(workerAnyArgs(2)...).
+		WillReturnRows(sessionMessageRows(
+			models.SessionMessage{ID: 51, SessionID: sessionID, OrgID: orgID, ThreadID: &threadID, TurnNumber: 2, Role: models.MessageRoleUser, Content: "thread question", CreatedAt: now},
+			models.SessionMessage{ID: 52, SessionID: sessionID, OrgID: orgID, ThreadID: &threadID, TurnNumber: 2, Role: models.MessageRoleAssistant, Content: "completed turn answer", CreatedAt: now},
+			models.SessionMessage{ID: 53, SessionID: sessionID, OrgID: orgID, ThreadID: &threadID, TurnNumber: 3, Role: models.MessageRoleAssistant, Content: "newer unrelated answer", CreatedAt: now},
+		))
+	mock.ExpectQuery("INSERT INTO jobs").
+		WithArgs(
+			orgID,
+			"default",
+			"slack_post_final_response",
+			jsonPayloadFieldsArg{
+				expectedStrings: map[string]string{
+					"org_id":                orgID.String(),
+					"session_id":            sessionID.String(),
+					"slack_session_link_id": linkID.String(),
+				},
+				expectedInts: map[string]int64{"final_message_id": 52},
+			},
+			3,
+			pgxmock.AnyArg(),
+		).
+		WillReturnRows(pgxmock.NewRows([]string{"id"}).AddRow(uuid.New()))
+
+	orch := &orchestratorServiceStub{
+		continueSessionFn: func(ctx context.Context, session *models.Session, opts *agent.ContinueSessionOptions) error {
+			require.NotNil(t, opts, "thread continuation should pass options to the orchestrator")
+			require.NotNil(t, opts.ThreadID, "thread continuation should include the thread id")
+			require.Equal(t, threadID, *opts.ThreadID, "thread continuation should preserve the requested thread id")
+			return nil
+		},
+	}
+	handler := newContinueSessionHandler(stores, &Services{Orchestrator: orch}, zerolog.Nop())
+	payload := json.RawMessage(`{"session_id":"` + sessionID.String() + `","org_id":"` + orgID.String() + `","thread_id":"` + threadID.String() + `"}`)
+
+	err := handler(context.Background(), "continue_session", payload)
+
+	require.NoError(t, err, "thread-scoped continue_session should succeed when the orchestrator returns success")
+	require.Equal(t, 1, orch.continueSessionCalls, "continue_session should invoke the orchestrator once")
+	require.NoError(t, mock.ExpectationsWereMet(), "Slack final response should use the assistant from the completed thread turn")
 }
 
 func TestContinueSessionHandler_PassesPRRepairCommandOptions(t *testing.T) {


### PR DESCRIPTION
## Summary
- Route Slack follow-up messages through the primary session thread before enqueueing continuation jobs.
- Scope Slack final-response jobs to the completed thread turn so the correct assistant message is selected.
- Add unit coverage for thread-aware continuation enqueueing and Slack final-response selection.

## Testing
- Unit tests added for Slack continuation message enqueueing and thread-scoped final-response handling.
- Not run (not requested).