### PR TITLE
Clarify preview restart labels and harden dependency cache restores

### DIFF
--- a/frontend/src/app/(dashboard)/previews/github/[owner]/[repo]/pull/[number]/page.test.tsx
+++ b/frontend/src/app/(dashboard)/previews/github/[owner]/[repo]/pull/[number]/page.test.tsx
@@ -135,7 +135,7 @@ describe("PullRequestPreviewPage", () => {
               reason: "stale",
               auto_open: true,
               represents_latest: false,
-              primary_label: "Restart",
+              primary_label: "Start latest preview",
               secondary_label: "Open stale preview",
               stale_preview_url: "https://prev-old.preview.143.dev",
             },
@@ -404,7 +404,7 @@ describe("PullRequestPreviewPage", () => {
     }
   });
 
-  it("does not auto-open stale previews and makes Restart primary", async () => {
+  it("does not auto-open stale previews and makes Start latest preview primary", async () => {
     let startLatestCalled = false;
     server.use(
       http.get("*/api/v1/previews/github/acme/web/pull/42", () =>
@@ -429,7 +429,7 @@ describe("PullRequestPreviewPage", () => {
               reason: "stale",
               auto_open: false,
               represents_latest: false,
-              primary_label: "Restart",
+              primary_label: "Start latest preview",
               secondary_label: "Open stale preview",
               stale_preview_url: "https://prev-old.preview.143.dev",
               message: "This preview is for abc123; the pull request is now at def456.",
@@ -462,7 +462,7 @@ describe("PullRequestPreviewPage", () => {
     expect(screen.getByText("This preview is for abc123; the pull request is now at def456.")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /Open stale preview/ })).toBeInTheDocument();
 
-    await userEvent.click(screen.getByRole("button", { name: /Restart/ }));
+    await userEvent.click(screen.getByRole("button", { name: /Start latest preview/ }));
 
     await waitFor(() => {
       expect(startLatestCalled).toBe(true);
@@ -573,7 +573,7 @@ describe("PullRequestPreviewPage", () => {
 
     expect(await screen.findByText("Preview blocked")).toBeInTheDocument();
     expect(screen.getByText("You can open existing previews, but you do not have permission to start a new preview for this pull request.")).toBeInTheDocument();
-    expect(screen.queryByRole("button", { name: /Restart|Start preview|Resume preview/ })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /Start latest preview|Start preview|Resume preview/ })).not.toBeInTheDocument();
   });
 
   it("prefers failed preview diagnostics over blocked launch copy", async () => {

--- a/frontend/src/app/(dashboard)/previews/github/[owner]/[repo]/pull/[number]/page.tsx
+++ b/frontend/src/app/(dashboard)/previews/github/[owner]/[repo]/pull/[number]/page.tsx
@@ -13,7 +13,7 @@ import { safeExternalUrl } from "@/lib/utils";
 import { pollMs } from "@/lib/poll-intervals";
 
 const ZERO_UUID = "00000000-0000-0000-0000-000000000000";
-const RESTART_LATEST_LABEL = "Restart";
+const RESTART_LATEST_LABEL = "Start latest preview";
 
 export default function PullRequestPreviewPage({
   params,
@@ -261,7 +261,7 @@ function launchStateCopy(preview: BranchPreviewResponse | undefined): {
       return {
         title: preview?.status === "expired" ? "Preview expired" : "Preview not started",
         description: launch.message ?? (preview?.status === "expired"
-          ? "Restart to launch a fresh runtime for this pull request."
+          ? "Start a fresh preview for this pull request."
           : "Start a preview for the latest pull request head."),
       };
     case "retry":

--- a/frontend/src/app/(dashboard)/previews/page.test.tsx
+++ b/frontend/src/app/(dashboard)/previews/page.test.tsx
@@ -277,7 +277,7 @@ describe("PreviewsPage", () => {
     await userEvent.click(screen.getAllByRole("button", { name: /stop/i })[0]);
     await userEvent.click(screen.getAllByRole("button", { name: /resume/i })[0]);
     await userEvent.click(
-      screen.getAllByRole("button", { name: /restart/i })[0],
+      screen.getAllByRole("button", { name: /start a new preview from the latest source state/i })[0],
     );
 
     await waitFor(() => {
@@ -305,7 +305,7 @@ describe("PreviewsPage", () => {
     expect(screen.queryByRole("link", { name: /new preview/i })).not.toBeInTheDocument();
     expect(screen.queryByRole("button", { name: /stop/i })).not.toBeInTheDocument();
     expect(screen.queryByRole("button", { name: /resume/i })).not.toBeInTheDocument();
-    expect(screen.queryByRole("button", { name: /restart/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /start a new preview from the latest source state/i })).not.toBeInTheDocument();
   });
 
   it("opens the create preview dialog from the empty state action", async () => {
@@ -501,7 +501,7 @@ describe("PreviewsPage", () => {
       within(runningSection).getAllByText(/Running aabb1122, branch is ccdd3344/)[0],
     ).toBeInTheDocument();
     expect(
-      within(runningSection).getAllByRole("button", { name: /restart/i })[0],
+      within(runningSection).getAllByRole("button", { name: /start a new preview from the latest source state/i })[0],
     ).toBeInTheDocument();
   });
 
@@ -562,7 +562,7 @@ describe("PreviewsPage", () => {
       name: /recent/i,
     });
     const restartButton = within(recentSection).getAllByRole("button", {
-      name: /restart preview from the latest source state/i,
+      name: /start a new preview from the latest source state/i,
     })[0];
 
     await userEvent.click(restartButton);
@@ -660,7 +660,7 @@ describe("PreviewsPage", () => {
       name: /running/i,
     });
     const restartLatestButton = within(runningSection).getAllByRole("button", {
-      name: /restart preview from the latest source state/i,
+      name: /start a new preview from the latest source state/i,
     })[0];
 
     await userEvent.click(restartLatestButton);

--- a/frontend/src/app/(dashboard)/previews/page.tsx
+++ b/frontend/src/app/(dashboard)/previews/page.tsx
@@ -60,8 +60,8 @@ import { safeExternalUrl } from "@/lib/utils";
 
 type PreviewScope = "running" | "resumable" | "recent";
 
-const RESTART_LATEST_LABEL = "Restart";
-const RESTART_LATEST_TOOLTIP = "Restart preview from the latest source state";
+const RESTART_LATEST_LABEL = "Start latest preview";
+const RESTART_LATEST_TOOLTIP = "Start a new preview from the latest source state";
 
 const SECTIONS: {
   scope: PreviewScope;

--- a/frontend/src/components/preview/preview-detail-surface.tsx
+++ b/frontend/src/components/preview/preview-detail-surface.tsx
@@ -440,7 +440,7 @@ function PreviewActions({
         ) : null}
         <DropdownMenuItem onSelect={onStartLatest} disabled={restartPending || isStarting}>
           <GitBranch className="h-4 w-4" />
-          Restart
+          Start latest preview
         </DropdownMenuItem>
         {canRestart && onRestart ? (
           <DropdownMenuItem onSelect={onRestart} disabled={restartPending}>

--- a/internal/api/handlers/branch_previews.go
+++ b/internal/api/handlers/branch_previews.go
@@ -1962,13 +1962,13 @@ func currentPreviewLaunch(summary models.PreviewCurrentSummary) models.PreviewLa
 	}
 	switch {
 	case summary.Status == models.PreviewStatusReady && summary.Freshness == models.PreviewCurrentFreshnessOutdated:
-		return models.PreviewLaunchRecommendation{Action: models.PreviewLaunchActionStart, PrimaryLabel: "Start", SecondaryLabel: "Open stale"}
+		return models.PreviewLaunchRecommendation{Action: models.PreviewLaunchActionStart, PrimaryLabel: "Start latest preview", SecondaryLabel: "Open stale"}
 	case summary.Status == models.PreviewStatusReady:
-		return models.PreviewLaunchRecommendation{Action: models.PreviewLaunchActionOpen, PrimaryLabel: "Open", SecondaryLabel: "Restart"}
+		return models.PreviewLaunchRecommendation{Action: models.PreviewLaunchActionOpen, PrimaryLabel: "Open", SecondaryLabel: "Restart runtime"}
 	case summary.Status == models.PreviewStatusStarting:
 		return models.PreviewLaunchRecommendation{Action: models.PreviewLaunchActionCancel, PrimaryLabel: "Cancel"}
 	case summary.Resumable:
-		return models.PreviewLaunchRecommendation{Action: models.PreviewLaunchActionResume, PrimaryLabel: "Resume", SecondaryLabel: "Restart"}
+		return models.PreviewLaunchRecommendation{Action: models.PreviewLaunchActionResume, PrimaryLabel: "Resume", SecondaryLabel: "Restart runtime"}
 	case summary.Status == models.PreviewStatusFailed && summary.Freshness == models.PreviewCurrentFreshnessCurrent:
 		return models.PreviewLaunchRecommendation{Action: models.PreviewLaunchActionRetry, PrimaryLabel: "Retry", SecondaryLabel: "Start"}
 	case summary.Status == models.PreviewStatusFailed:
@@ -3084,7 +3084,7 @@ func derivePRPreviewLaunch(resp branchPreviewResponse, opts prPreviewLaunchOptio
 			Reason:           models.PreviewLaunchReasonStale,
 			AutoOpen:         false,
 			RepresentsLatest: false,
-			PrimaryLabel:     "Restart",
+			PrimaryLabel:     "Start latest preview",
 			SecondaryLabel:   "Open stale preview",
 			StalePreviewURL:  resp.PreviewURL,
 			Message:          stalePreviewMessage(resp.CommitSHA, latest),

--- a/internal/api/handlers/branch_previews_test.go
+++ b/internal/api/handlers/branch_previews_test.go
@@ -406,7 +406,7 @@ func TestDerivePRPreviewLaunch(t *testing.T) {
 				Reason:           models.PreviewLaunchReasonStale,
 				AutoOpen:         false,
 				RepresentsLatest: false,
-				PrimaryLabel:     "Restart",
+				PrimaryLabel:     "Start latest preview",
 				SecondaryLabel:   "Open stale preview",
 				StalePreviewURL:  &staleURL,
 				Message:          "This preview is for abc123; the pull request is now at def456.",

--- a/internal/db/preview_store.go
+++ b/internal/db/preview_store.go
@@ -3756,6 +3756,17 @@ func (s *PreviewStore) DeleteDependencyCache(ctx context.Context, orgID, id uuid
 	return nil
 }
 
+func (s *PreviewStore) DeleteDependencyCacheIfBlobKey(ctx context.Context, orgID, id uuid.UUID, blobKey string) error {
+	_, err := s.db.Exec(ctx,
+		`DELETE FROM preview_dependency_cache WHERE id = @id AND org_id = @org_id AND blob_key = @blob_key`,
+		pgx.NamedArgs{"id": id, "org_id": orgID, "blob_key": blobKey},
+	)
+	if err != nil {
+		return fmt.Errorf("delete dependency cache by blob key: %w", err)
+	}
+	return nil
+}
+
 func (s *PreviewStore) ListDependencyCacheLRU(ctx context.Context, orgID, repoID uuid.UUID, keepNewest, limit int) ([]models.PreviewDependencyCache, error) {
 	if limit <= 0 {
 		limit = 500

--- a/internal/services/preview/dependency_cache.go
+++ b/internal/services/preview/dependency_cache.go
@@ -301,10 +301,10 @@ func (c *SharedDependencyCache) RestorePathCache(ctx context.Context, sb *agent.
 	if hit.Entry.SizeBytes > dependencyCacheMaxBlobBytes {
 		return fmt.Errorf("dependency cache restore: blob too large (%d bytes, max %d); narrow preview.install.cache.paths or disable dependency caching for this preview", hit.Entry.SizeBytes, dependencyCacheMaxBlobBytes)
 	}
-	blob, err := c.stageBlob(ctx, hit)
+	blob, err := c.stageBlob(ctx, hit, metadata.ChecksumSHA256)
 	if err != nil {
 		if errors.Is(err, storage.ErrSnapshotNotFound) && c.store.Configured() {
-			if deleteErr := c.store.DeleteDependencyCache(ctx, hit.Entry.OrgID, hit.Entry.ID); deleteErr != nil {
+			if deleteErr := c.store.DeleteDependencyCacheIfBlobKey(ctx, hit.Entry.OrgID, hit.Entry.ID, hit.BlobKey); deleteErr != nil {
 				c.logger.Warn().Err(deleteErr).Str("cache_key", hit.Entry.CacheKey).Msg("failed to delete stale dependency cache metadata after missing blob")
 			}
 		}
@@ -316,7 +316,7 @@ func (c *SharedDependencyCache) RestorePathCache(ctx context.Context, sb *agent.
 			c.removeLocalBlob(ctx, hit.Entry.CacheKind, hit.Entry.CacheKey)
 		}
 		if c.store.Configured() {
-			if deleteErr := c.store.DeleteDependencyCache(ctx, hit.Entry.OrgID, hit.Entry.ID); deleteErr != nil {
+			if deleteErr := c.store.DeleteDependencyCacheIfBlobKey(ctx, hit.Entry.OrgID, hit.Entry.ID, hit.BlobKey); deleteErr != nil {
 				c.logger.Warn().Err(deleteErr).Str("cache_key", hit.Entry.CacheKey).Msg("failed to delete corrupted dependency cache metadata")
 			}
 		}
@@ -561,23 +561,45 @@ func (c *SharedDependencyCache) makeStagingDir(pattern string) (string, error) {
 	return os.MkdirTemp(c.stagingDir, pattern)
 }
 
-func (c *SharedDependencyCache) stageBlob(ctx context.Context, hit *DependencyCacheHit) (*dependencyCacheStagedBlob, error) {
+func (c *SharedDependencyCache) stageBlob(ctx context.Context, hit *DependencyCacheHit, expectedChecksum string) (*dependencyCacheStagedBlob, error) {
 	if c.localDir != "" {
 		localPath := c.localBlobPath(hit.Entry.CacheKind, hit.Entry.CacheKey)
 		if blob, err := c.stageLocalBlob(localPath); err == nil {
-			if err := os.Chtimes(localPath, time.Now(), time.Now()); err != nil {
-				c.logger.Warn().Err(err).Str("path", localPath).Msg("failed to touch dependency cache local blob")
+			if expectedChecksum != "" && !strings.EqualFold(expectedChecksum, blob.checksum) {
+				blob.cleanup()
+				c.logger.Warn().
+					Str("path", localPath).
+					Str("cache_key", hit.Entry.CacheKey).
+					Str("expected_checksum", expectedChecksum).
+					Str("actual_checksum", blob.checksum).
+					Msg("dependency cache local blob checksum mismatch; falling back to object storage")
+				c.removeLocalBlob(ctx, hit.Entry.CacheKind, hit.Entry.CacheKey)
+			} else {
+				if err := os.Chtimes(localPath, time.Now(), time.Now()); err != nil {
+					c.logger.Warn().Err(err).Str("path", localPath).Msg("failed to touch dependency cache local blob")
+				}
+				return blob, nil
 			}
-			return blob, nil
 		} else if !errors.Is(err, os.ErrNotExist) {
 			c.logger.Warn().Err(err).Str("path", localPath).Msg("failed to read dependency cache local blob; falling back to object storage")
 		} else if hit.Entry.CacheKind == "" || hit.Entry.CacheKind == models.PreviewCacheKindInstallArtifact {
 			legacyLocalPath := c.legacyLocalBlobPath(hit.Entry.CacheKey)
 			if blob, legacyErr := c.stageLocalBlob(legacyLocalPath); legacyErr == nil {
-				if touchErr := os.Chtimes(legacyLocalPath, time.Now(), time.Now()); touchErr != nil {
-					c.logger.Warn().Err(touchErr).Str("path", legacyLocalPath).Msg("failed to touch legacy dependency cache local blob")
+				if expectedChecksum != "" && !strings.EqualFold(expectedChecksum, blob.checksum) {
+					blob.cleanup()
+					c.logger.Warn().
+						Str("path", legacyLocalPath).
+						Str("cache_key", hit.Entry.CacheKey).
+						Str("expected_checksum", expectedChecksum).
+						Str("actual_checksum", blob.checksum).
+						Msg("legacy dependency cache local blob checksum mismatch; falling back to object storage")
+					c.removeLocalBlobPath(legacyLocalPath)
+				} else {
+					if touchErr := os.Chtimes(legacyLocalPath, time.Now(), time.Now()); touchErr != nil {
+						c.logger.Warn().Err(touchErr).Str("path", legacyLocalPath).Msg("failed to touch legacy dependency cache local blob")
+					}
+					return blob, nil
 				}
-				return blob, nil
 			} else if !errors.Is(legacyErr, os.ErrNotExist) {
 				c.logger.Warn().Err(legacyErr).Str("path", legacyLocalPath).Msg("failed to read legacy dependency cache local blob; falling back to object storage")
 			}
@@ -945,16 +967,20 @@ func (c *SharedDependencyCache) removeLocalBlob(ctx context.Context, kind models
 		return
 	}
 	path := c.localBlobPath(kind, cacheKey)
+	c.removeLocalBlobPath(path)
+	if c.workerNodeID != "" {
+		if err := c.store.DeleteDependencyCacheLocationByWorkerCacheKey(ctx, c.workerNodeID, kind, cacheKey); err != nil {
+			c.logger.Warn().Err(err).Str("cache_key", cacheKey).Msg("failed to delete dependency cache local location")
+		}
+	}
+}
+
+func (c *SharedDependencyCache) removeLocalBlobPath(path string) {
 	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
 		c.logger.Warn().Err(err).Str("path", path).Msg("failed to remove dependency cache local blob")
 	}
 	if err := os.Remove(path + ".sha256"); err != nil && !os.IsNotExist(err) {
 		c.logger.Warn().Err(err).Str("path", path+".sha256").Msg("failed to remove dependency cache local checksum")
-	}
-	if c.workerNodeID != "" {
-		if err := c.store.DeleteDependencyCacheLocationByWorkerCacheKey(ctx, c.workerNodeID, kind, cacheKey); err != nil {
-			c.logger.Warn().Err(err).Str("cache_key", cacheKey).Msg("failed to delete dependency cache local location")
-		}
 	}
 }
 

--- a/internal/services/preview/dependency_cache_test.go
+++ b/internal/services/preview/dependency_cache_test.go
@@ -398,7 +398,7 @@ func TestSharedDependencyCache_StageBlobUsesLocalCacheStagingDir(t *testing.T) {
 			LastUsedAt: time.Now().UTC(),
 		},
 		BlobKey: blobKey,
-	})
+	}, "")
 	require.NoError(t, err, "stageBlob should download the remote dependency cache blob")
 	defer blob.cleanup()
 
@@ -497,7 +497,7 @@ func TestSharedDependencyCache_RestoreDeletesMetadataWhenObjectMissing(t *testin
 	require.NoError(t, err, "pgx mock should initialize")
 	defer mock.Close()
 	mock.ExpectExec("DELETE FROM preview_dependency_cache").
-		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WithArgs(entryID, orgID, "deps/missing.tar.gz").
 		WillReturnResult(pgxmock.NewResult("DELETE", 1))
 
 	cache, err := NewDependencyCache(DependencyCacheConfig{
@@ -547,7 +547,7 @@ func TestSharedDependencyCache_RestoreDeletesMetadataOnChecksumMismatch(t *testi
 	require.NoError(t, err, "pgx mock should initialize")
 	defer mock.Close()
 	mock.ExpectExec("DELETE FROM preview_dependency_cache").
-		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WithArgs(entryID, orgID, "deps/blob.tar.gz").
 		WillReturnResult(pgxmock.NewResult("DELETE", 1))
 
 	cache, err := NewDependencyCache(DependencyCacheConfig{
@@ -573,6 +573,79 @@ func TestSharedDependencyCache_RestoreDeletesMetadataOnChecksumMismatch(t *testi
 	})
 	require.Error(t, err, "Restore should reject corrupted cache blobs")
 	require.Contains(t, err.Error(), "checksum mismatch", "Restore should explain checksum failures")
+	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
+}
+
+func TestSharedDependencyCache_RestoreFallsBackToObjectStoreWhenLocalBlobChecksumMismatches(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	localDir := t.TempDir()
+	orgID := uuid.New()
+	repoID := uuid.New()
+	entryID := uuid.New()
+	cacheKey := strings.Repeat("e", 64)
+	remotePayload := makeDependencyCacheTarGz(t, map[string]string{"node_modules/.cache/build": "fresh"})
+	remoteSum := sha256.Sum256(remotePayload)
+	remoteChecksum := fmt.Sprintf("%x", remoteSum[:])
+	metadataJSON, err := json.Marshal(DependencyCacheMetadata{
+		EffectivePaths: []string{"node_modules"},
+		ChecksumSHA256: remoteChecksum,
+	})
+	require.NoError(t, err, "dependency cache metadata should marshal")
+	blobStore := newMemorySnapshotStore()
+	require.NoError(t, blobStore.Save(ctx, "deps/blob.tar.gz", bytes.NewReader(remotePayload)), "test blob should save")
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "pgx mock should initialize")
+	defer mock.Close()
+	mock.ExpectExec("DELETE FROM preview_dependency_cache_locations").
+		WithArgs("worker-1", models.PreviewCacheKindBuildArtifact, cacheKey).
+		WillReturnResult(pgxmock.NewResult("DELETE", 1))
+	now := time.Now().UTC()
+	mock.ExpectQuery("INSERT INTO preview_dependency_cache_locations").
+		WithArgs(orgID, repoID, models.PreviewCacheKindBuildArtifact, cacheKey, "placement", "worker-1", int64(len(remotePayload))).
+		WillReturnRows(pgxmock.NewRows([]string{
+			"id", "org_id", "repo_id", "cache_kind", "cache_key", "placement_key",
+			"worker_node_id", "size_bytes", "last_used_at", "created_at",
+		}).AddRow(uuid.New(), orgID, repoID, models.PreviewCacheKindBuildArtifact, cacheKey, "placement", "worker-1", int64(len(remotePayload)), now, now))
+
+	cache, err := NewDependencyCache(DependencyCacheConfig{
+		Store:        db.NewPreviewStore(mock),
+		Executor:     &dependencyCacheExec{},
+		BlobStore:    blobStore,
+		Logger:       zerolog.Nop(),
+		Prefix:       "deps",
+		WorkerNodeID: "worker-1",
+		LocalDir:     localDir,
+	})
+	require.NoError(t, err, "dependency cache should initialize")
+
+	localPath := cache.localBlobPath(models.PreviewCacheKindBuildArtifact, cacheKey)
+	require.NoError(t, os.MkdirAll(filepath.Dir(localPath), 0o750), "local cache directory should be created")
+	localPayload := makeDependencyCacheTarGz(t, map[string]string{"node_modules/.cache/build": "stale"})
+	require.NoError(t, os.WriteFile(localPath, localPayload, 0o600), "stale local blob should be written")
+
+	err = cache.RestorePathCache(ctx, &agent.Sandbox{WorkDir: "/workspace/repo"}, &DependencyCacheHit{
+		Entry: models.PreviewDependencyCache{
+			ID:           entryID,
+			OrgID:        orgID,
+			RepoID:       repoID,
+			CacheKind:    models.PreviewCacheKindBuildArtifact,
+			CacheKey:     cacheKey,
+			PlacementKey: "placement",
+			BlobKey:      "deps/blob.tar.gz",
+			SizeBytes:    int64(len(remotePayload)),
+			Metadata:     metadataJSON,
+			LastUsedAt:   time.Now().UTC(),
+		},
+		BlobKey: "deps/blob.tar.gz",
+	}, models.PreviewCacheRootWorkDir)
+	require.NoError(t, err, "RestorePathCache should fall back to object storage when the local blob is stale")
+
+	replacedPayload, err := os.ReadFile(localPath)
+	require.NoError(t, err, "fallback restore should rewrite the worker-local cache blob")
+	require.Equal(t, remotePayload, replacedPayload, "fallback restore should replace the stale local blob with the shared object blob")
 	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
 }
 


### PR DESCRIPTION
## Summary
- Rename preview restart affordances to "Start latest preview" and update related helper text in the dashboard UI.
- Update branch preview launch recommendations and stale-preview handling to use the new wording consistently.
- Add blob checksum validation for local dependency cache restores and fall back to object storage when the local copy is stale or corrupted.
- Narrow dependency-cache metadata cleanup to the matching blob key and cover the new restore path with unit tests.

## Testing
- Added and updated frontend unit tests for preview action labels and stale-preview behavior.
- Added backend unit tests for dependency cache fallback and checksum-mismatch handling.