### PR TITLE
Attach org's first repo as Slack session fallback

### DIFF
--- a/internal/services/slackbot/context.go
+++ b/internal/services/slackbot/context.go
@@ -42,6 +42,7 @@ const (
 	SlackRepositoryResolutionSourceInstallDefault    SlackRepositoryResolutionSource = "slack_install_default"
 	SlackRepositoryResolutionSourceOrgDefault        SlackRepositoryResolutionSource = "org_default"
 	SlackRepositoryResolutionSourceSingleRepo        SlackRepositoryResolutionSource = "single_repo_fallback"
+	SlackRepositoryResolutionSourceFirstRepo         SlackRepositoryResolutionSource = "first_repo_fallback"
 	SlackRepositoryResolutionSourceMissing           SlackRepositoryResolutionSource = "missing"
 )
 

--- a/internal/worker/handlers.go
+++ b/internal/worker/handlers.go
@@ -2652,17 +2652,25 @@ func slackRepositoryDefaultsForContext(ctx context.Context, stores *Stores, logg
 		}
 	}
 	if stores.Repositories != nil {
+		// Last-resort fallback: when no channel/install/org default is configured,
+		// attach the org's first connected repository so a Slack session still has
+		// code context instead of dropping to research-only mode. ListByOrg returns
+		// active repos ordered by full_name, so repos[0] is deterministic.
 		repos, err := stores.Repositories.ListByOrg(ctx, orgID, db.RepositoryFilters{})
-		if err == nil && len(repos) == 1 {
+		if err == nil && len(repos) > 0 {
 			repo := repos[0]
+			source := slackbotsvc.SlackRepositoryResolutionSourceFirstRepo
+			if len(repos) == 1 {
+				source = slackbotsvc.SlackRepositoryResolutionSourceSingleRepo
+			}
 			defaults = append(defaults, slackbotsvc.SlackRepositoryDefault{
 				RepositoryID:   repo.ID,
 				RepositoryName: repo.FullName,
 				Branch:         repo.DefaultBranch,
-				Source:         slackbotsvc.SlackRepositoryResolutionSourceSingleRepo,
+				Source:         source,
 			})
 		} else if err != nil {
-			logger.Warn().Err(err).Str("org_id", orgID.String()).Msg("failed to list repositories for Slack single-repo fallback")
+			logger.Warn().Err(err).Str("org_id", orgID.String()).Msg("failed to list repositories for Slack repository fallback")
 		}
 	}
 	return defaults

--- a/internal/worker/handlers_test.go
+++ b/internal/worker/handlers_test.go
@@ -668,6 +668,68 @@ func TestSlackRepositoryDefaultsForContextUsesMatchingInstallationDefault(t *tes
 	require.NoError(t, mock.ExpectationsWereMet(), "helper should scope Slack install default lookup to installation id")
 }
 
+func TestSlackRepositoryDefaultsForContextFallsBackToFirstRepo(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "pgxmock should initialize")
+	defer mock.Close()
+
+	orgID := uuid.New()
+	installationID := uuid.New()
+	firstRepoID := uuid.New()
+	secondRepoID := uuid.New()
+	integrationID := uuid.New()
+	now := time.Now()
+	stores := &Stores{
+		SlackChannels:    db.NewSlackChannelSettingsStore(mock),
+		SlackBotSettings: db.NewSlackBotSettingsStore(mock),
+		Repositories:     db.NewRepositoryStore(mock),
+	}
+
+	// No channel default configured.
+	mock.ExpectQuery("SELECT id, org_id, slack_installation_id").
+		WithArgs(workerAnyArgs(3)...).
+		WillReturnRows(pgxmock.NewRows([]string{
+			"id", "org_id", "slack_installation_id", "slack_team_id", "slack_channel_id", "slack_channel_name",
+			"channel_type", "default_repository_id", "default_branch", "routing_mode", "response_visibility", "allowed_actions",
+			"notification_preset", "notification_subscriptions", "active", "created_at", "updated_at",
+		}))
+	// No install default configured.
+	mock.ExpectQuery("FROM slack_bot_settings").
+		WithArgs(orgID, installationID).
+		WillReturnRows(pgxmock.NewRows([]string{
+			"id", "org_id", "slack_installation_id", "default_repository_id", "default_branch",
+			"routing_mode", "response_visibility", "allowed_actions", "notification_preset",
+			"notification_subscriptions", "active", "created_at", "updated_at",
+		}))
+	// Org has multiple connected repos; ListByOrg returns them ordered by full_name.
+	mock.ExpectQuery("SELECT .+ FROM repositories").
+		WithArgs(pgxmock.AnyArg()).
+		WillReturnRows(pgxmock.NewRows([]string{
+			"id", "org_id", "integration_id", "github_id", "full_name", "default_branch",
+			"private", "language", "description", "clone_url", "installation_id", "status",
+			"last_synced_at", "context_quality", "settings", "created_at", "updated_at",
+		}).AddRow(
+			firstRepoID, orgID, integrationID, int64(1), "assembledhq/aardvark", "main",
+			false, nil, nil, "https://github.com/assembledhq/aardvark.git", int64(123), models.RepositoryStatusActive,
+			nil, nil, []byte(`{}`), now, now,
+		).AddRow(
+			secondRepoID, orgID, integrationID, int64(2), "assembledhq/zebra", "main",
+			false, nil, nil, "https://github.com/assembledhq/zebra.git", int64(123), models.RepositoryStatusActive,
+			nil, nil, []byte(`{}`), now, now,
+		))
+
+	defaults := slackRepositoryDefaultsForContext(context.Background(), stores, zerolog.Nop(), orgID, installationID, "T123", "C123")
+
+	require.Len(t, defaults, 1, "with no configured default the helper should fall back to the first repo")
+	require.Equal(t, firstRepoID, defaults[0].RepositoryID, "fallback should attach the first repository in the list")
+	require.Equal(t, "assembledhq/aardvark", defaults[0].RepositoryName, "fallback should carry the repo name")
+	require.Equal(t, "main", defaults[0].Branch, "fallback should default to the repo's default branch")
+	require.Equal(t, slackbotsvc.SlackRepositoryResolutionSourceFirstRepo, defaults[0].Source, "multi-repo fallback should be tagged as first_repo_fallback")
+	require.NoError(t, mock.ExpectationsWereMet(), "fallback should query repositories once defaults are exhausted")
+}
+
 func TestSlackContextReferencesForSessionInput(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Problem

A Slack-started 143 session only gets code context if a repository is attached. Today the last-resort fallback in `slackRepositoryDefaultsForContext` only fires when the org has **exactly one** connected repo (`len(repos) == 1`). An org with multiple repos and no channel/install/org default produces a session with `RepositoryID == nil` — which drops the agent to research-only mode (web search, no code).

This is what happened in [a recent Slack session](https://assembled-hq.slack.com/archives/C0983MNTCNA/p1782503061864339): the bot answered an Assembled product question purely from public support docs, with no repository attached.

## Change

Widen the fallback to attach the org's **first connected repository** whenever no higher-priority default resolved:

- `len(repos) > 0` instead of `== 1`; take `repos[0]`.
- `ListByOrg` returns active repos ordered by `full_name ASC`, so `repos[0]` is deterministic (alphabetically-first active repo).
- The fallback is still appended **last** in the ordered defaults list, so explicit repo references and channel/install/org defaults continue to win when present — `ResolveSlackContext` picks the first valid candidate.

Added a new `first_repo_fallback` resolution source for the multi-repo case so source attribution stays honest; `single_repo_fallback` still means the org had exactly one repo.

## Notes

- The deliberate `contextSettings.DefaultRepositoryID = nil` at the call site (from #1463) is intentionally left as-is — it routes channel/install default resolution through the ordered list with correct per-source attribution rather than the pre-merged effective value, and does **not** drop the repo. Removing it would bypass this new fallback in some paths.
- This only changes which repo is *suggested* as a default; answer-only routing and explicit references are unaffected.

## Test

Added `TestSlackRepositoryDefaultsForContextFallsBackToFirstRepo` covering the multi-repo case (asserts first repo, name, branch, and `first_repo_fallback` source). Existing `TestSlackRepositoryDefaultsForContext*` and `TestResolveSlackContext` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
