### PR TITLE
Surface specific .143/config.json readiness failures in preview settings

### DIFF
--- a/frontend/src/app/(dashboard)/settings/previews/page.tsx
+++ b/frontend/src/app/(dashboard)/settings/previews/page.tsx
@@ -549,7 +549,16 @@ function PublishDisabledHint({
     cancelScheduledClose();
     closeTimer.current = setTimeout(() => setOpen(false), 120);
   };
-  useEffect(() => cancelScheduledClose, []);
+  // Clear any pending close timer on unmount. Inlined (rather than referencing
+  // cancelScheduledClose) so the effect has no changing dependencies.
+  useEffect(
+    () => () => {
+      if (closeTimer.current) {
+        clearTimeout(closeTimer.current);
+      }
+    },
+    [],
+  );
 
   if (!hasDetails) {
     return (

--- a/frontend/src/app/(dashboard)/settings/previews/page.tsx
+++ b/frontend/src/app/(dashboard)/settings/previews/page.tsx
@@ -3,6 +3,7 @@
 import {
   useEffect,
   useMemo,
+  useRef,
   useState,
   type FormEvent,
   type ReactNode,
@@ -48,6 +49,11 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
@@ -512,6 +518,101 @@ function RuntimeEnvironmentCard() {
   );
 }
 
+// PublishDisabledHint shows the short reason the "Publish to PRs" toggle is
+// locked. When the backend provides specific details (config parse errors,
+// validation failures, or admin-setup requirements), the line becomes a target
+// that reveals them — kept compact so it stays out of the way until the user
+// wants the full story. The Popover is controlled so it opens on tap/click
+// (touch-friendly), pointer hover, and keyboard focus alike.
+function PublishDisabledHint({
+  id,
+  reason,
+  details,
+}: {
+  id: string;
+  reason: string;
+  details: string[];
+}) {
+  const hasDetails = details.length > 0;
+  const [open, setOpen] = useState(false);
+  const closeTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const cancelScheduledClose = () => {
+    if (closeTimer.current) {
+      clearTimeout(closeTimer.current);
+      closeTimer.current = null;
+    }
+  };
+  // Delay close slightly so moving the pointer from the trigger into the
+  // floating content does not close it across the gap.
+  const scheduleClose = () => {
+    cancelScheduledClose();
+    closeTimer.current = setTimeout(() => setOpen(false), 120);
+  };
+  useEffect(() => cancelScheduledClose, []);
+
+  if (!hasDetails) {
+    return (
+      <p
+        id={id}
+        className="flex items-start gap-1.5 text-xs leading-4 text-muted-foreground"
+      >
+        <HelpCircle className="mt-0.5 h-3 w-3 shrink-0" />
+        <span>{reason}</span>
+      </p>
+    );
+  }
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <button
+          type="button"
+          id={id}
+          onMouseEnter={() => {
+            cancelScheduledClose();
+            setOpen(true);
+          }}
+          onMouseLeave={scheduleClose}
+          onFocus={() => setOpen(true)}
+          onBlur={scheduleClose}
+          className="flex items-start gap-1.5 rounded text-left text-xs leading-4 text-muted-foreground underline decoration-dotted decoration-muted-foreground/50 underline-offset-2 transition-colors hover:text-foreground focus-visible:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+        >
+          <HelpCircle className="mt-0.5 h-3 w-3 shrink-0" />
+          <span>{reason}</span>
+        </button>
+      </PopoverTrigger>
+      <PopoverContent
+        align="start"
+        // Keep focus on the trigger so a hover/focus open does not yank the
+        // caret into the popover.
+        onOpenAutoFocus={(event) => event.preventDefault()}
+        onMouseEnter={cancelScheduledClose}
+        onMouseLeave={scheduleClose}
+        className="w-72 space-y-2 p-3"
+      >
+        <p className="text-xs font-medium text-foreground">
+          What&apos;s blocking publish
+        </p>
+        <ul className="list-disc space-y-1 pl-4 text-xs leading-4 text-muted-foreground">
+          {details.map((detail, index) => (
+            <li key={index} className="break-words">
+              {detail}
+            </li>
+          ))}
+        </ul>
+        <p className="text-xs leading-4 text-muted-foreground">
+          Update{" "}
+          <code className="rounded bg-muted px-1 py-0.5 font-mono text-xs">
+            .143/config.json
+          </code>{" "}
+          on the default branch, then run a test preview.
+        </p>
+      </PopoverContent>
+    </Popover>
+  );
+}
+
 function RepoPreviewCard({
   policy,
   sessionPrewarmEnabled,
@@ -556,6 +657,10 @@ function RepoPreviewCard({
   const canEnable = policy.preview_ready && !missingPermissions;
   const publishDisabled = !canEnable && !policy.pr_preview_surfaces_enabled;
   const publishDisabledReason = publishDisabled ? disabledReason : "";
+  const publishDisabledDetails =
+    publishDisabled && !policy.preview_ready
+      ? (policy.preview_readiness_missing_details ?? [])
+      : [];
   const configNames = policy.preview_config_names ?? [];
   const defaultConfigName = policy.preview_config_default_name ?? "";
 
@@ -738,13 +843,11 @@ function RepoPreviewCard({
                 internally when publishing is off.
               </p>
               {publishDisabledReason ? (
-                <p
+                <PublishDisabledHint
                   id={`preview-publish-disabled-${policy.repository_id}`}
-                  className="flex items-start gap-1.5 text-xs leading-4 text-muted-foreground"
-                >
-                  <HelpCircle className="mt-0.5 h-3 w-3 shrink-0" />
-                  <span>{publishDisabledReason}</span>
-                </p>
+                  reason={publishDisabledReason}
+                  details={publishDisabledDetails}
+                />
               ) : null}
             </div>
           </div>

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -620,6 +620,7 @@ export interface PreviewPolicySummary {
   preview_config_requires_selection?: boolean;
   preview_ready: boolean;
   preview_readiness_missing_reason?: string;
+  preview_readiness_missing_details?: string[];
   github_pr_comment_permission_ok: boolean;
   github_commit_status_permission_ok: boolean;
   last_surface_sync_sha?: string;

--- a/internal/api/handlers/branch_previews.go
+++ b/internal/api/handlers/branch_previews.go
@@ -2175,6 +2175,7 @@ func (h *BranchPreviewHandler) enrichPreviewPolicyConfigReadiness(ctx context.Co
 		policy.PreviewConfigured = false
 		policy.PreviewReady = false
 		policy.PreviewReadinessMissingReason = "Fix .143/config.json first"
+		policy.PreviewReadinessMissingDetails = previewConfigErrorDetails(err)
 		return
 	}
 	policy.PreviewConfigured = true
@@ -2190,18 +2191,71 @@ func (h *BranchPreviewHandler) enrichPreviewPolicyConfigReadiness(ctx context.Co
 	if err != nil {
 		policy.PreviewReady = false
 		policy.PreviewReadinessMissingReason = "Fix .143/config.json first"
+		policy.PreviewReadinessMissingDetails = previewConfigErrorDetails(err)
 		return
 	}
 	detection := preview.DetectReadiness(cfg)
-	if detection.Readiness != models.PreviewReadinessReady {
+	switch detection.Readiness {
+	case models.PreviewReadinessReady:
+		// Config is structurally valid and self-contained.
+	case models.PreviewReadinessAdminSetupRequired:
+		// The config parses fine; it just needs credentials, secrets, or
+		// network destinations wired up before a preview can run.
+		policy.PreviewReady = false
+		policy.PreviewReadinessMissingReason = "Finish preview setup before enabling GitHub PR links"
+		policy.PreviewReadinessMissingDetails = previewAdminSetupDetails(detection)
+		return
+	default:
 		policy.PreviewReady = false
 		policy.PreviewReadinessMissingReason = "Fix .143/config.json first"
+		policy.PreviewReadinessMissingDetails = detection.ValidationErrors
 		return
 	}
 	if !policy.PreviewSuccessRecorded {
 		policy.PreviewReady = false
 		policy.PreviewReadinessMissingReason = "Run a successful test preview before enabling GitHub PR links"
 	}
+}
+
+// previewConfigErrorDetails turns a parse/inspect error into a short, trimmed
+// detail list for the settings page. Returns nil when there is nothing useful
+// to show so the UI falls back to the headline reason alone.
+func previewConfigErrorDetails(err error) []string {
+	if err == nil {
+		return nil
+	}
+	msg := strings.TrimSpace(err.Error())
+	if msg == "" {
+		return nil
+	}
+	return []string{msg}
+}
+
+// previewAdminSetupDetails describes the credentials, secret bundles, and
+// network destinations a config declares that still need admin setup before a
+// preview can run.
+func previewAdminSetupDetails(detection models.PreviewDetectionResult) []string {
+	var details []string
+	for _, cred := range detection.MissingCredentials {
+		if name := strings.TrimSpace(cred.CredentialSet); name != "" {
+			details = append(details, fmt.Sprintf("Credential set %q needs admin setup", name))
+		} else {
+			details = append(details, "Credentials need admin setup")
+		}
+	}
+	for _, bundle := range detection.MissingSecretBundles {
+		if name := strings.TrimSpace(bundle.Bundle); name != "" {
+			details = append(details, fmt.Sprintf("Secret bundle %q needs admin setup", name))
+		} else {
+			details = append(details, "A secret bundle needs admin setup")
+		}
+	}
+	for _, dest := range detection.MissingDestinations {
+		if dest = strings.TrimSpace(dest); dest != "" {
+			details = append(details, fmt.Sprintf("Network destination %q needs admin approval", dest))
+		}
+	}
+	return details
 }
 
 func githubPermissionWrites(value string) bool {

--- a/internal/api/handlers/branch_previews_test.go
+++ b/internal/api/handlers/branch_previews_test.go
@@ -3272,3 +3272,41 @@ func TestEnrichPreviewPolicyConfigReadiness_SetsNotConfiguredOnMissingFile(t *te
 	require.False(t, policy.PreviewReady, "404 on config file should mark the repository as not ready")
 	require.Equal(t, "Add .143/config.json first", policy.PreviewReadinessMissingReason)
 }
+
+func TestPreviewConfigErrorDetails(t *testing.T) {
+	t.Parallel()
+
+	require.Nil(t, previewConfigErrorDetails(nil), "a nil error yields no details")
+	require.Nil(t, previewConfigErrorDetails(fmt.Errorf("   ")), "a blank error message yields no details")
+	require.Equal(t,
+		[]string{"unexpected end of JSON input"},
+		previewConfigErrorDetails(fmt.Errorf("  unexpected end of JSON input  ")),
+		"a real error is trimmed into a single detail line",
+	)
+}
+
+func TestPreviewAdminSetupDetails(t *testing.T) {
+	t.Parallel()
+
+	require.Empty(t, previewAdminSetupDetails(models.PreviewDetectionResult{}),
+		"a detection with nothing missing yields no details")
+
+	details := previewAdminSetupDetails(models.PreviewDetectionResult{
+		MissingCredentials: []models.MissingCredential{
+			{CredentialSet: "prod-db"},
+			{CredentialSet: "  "},
+		},
+		MissingSecretBundles: []models.MissingSecretBundle{
+			{Bundle: "stripe"},
+			{Bundle: ""},
+		},
+		MissingDestinations: []string{"api.example.com", "   "},
+	})
+	require.Equal(t, []string{
+		`Credential set "prod-db" needs admin setup`,
+		"Credentials need admin setup",
+		`Secret bundle "stripe" needs admin setup`,
+		"A secret bundle needs admin setup",
+		`Network destination "api.example.com" needs admin approval`,
+	}, details, "named items are quoted, blank names fall back, and blank destinations are skipped")
+}

--- a/internal/models/preview.go
+++ b/internal/models/preview.go
@@ -221,14 +221,19 @@ type RepositoryPreviewPolicySummary struct {
 	// settings-page selection). Distinct from PreviewConfigNames (the profiles
 	// available in .143/config.json) and PreviewConfigDefaultName (that file's
 	// own default).
-	PreviewConfigName              string     `db:"preview_config_name" json:"preview_config_name,omitempty"`
-	PreviewConfigured              bool       `db:"preview_configured" json:"preview_configured"`
-	PreviewSuccessRecorded         bool       `db:"preview_success_recorded" json:"preview_success_recorded"`
-	PreviewConfigNames             []string   `db:"-" json:"preview_config_names,omitempty"`
-	PreviewConfigDefaultName       string     `db:"-" json:"preview_config_default_name,omitempty"`
-	PreviewConfigRequiresSelection bool       `db:"-" json:"preview_config_requires_selection,omitempty"`
-	PreviewReady                   bool       `db:"preview_ready" json:"preview_ready"`
-	PreviewReadinessMissingReason  string     `db:"preview_readiness_missing_reason" json:"preview_readiness_missing_reason,omitempty"`
+	PreviewConfigName              string   `db:"preview_config_name" json:"preview_config_name,omitempty"`
+	PreviewConfigured              bool     `db:"preview_configured" json:"preview_configured"`
+	PreviewSuccessRecorded         bool     `db:"preview_success_recorded" json:"preview_success_recorded"`
+	PreviewConfigNames             []string `db:"-" json:"preview_config_names,omitempty"`
+	PreviewConfigDefaultName       string   `db:"-" json:"preview_config_default_name,omitempty"`
+	PreviewConfigRequiresSelection bool     `db:"-" json:"preview_config_requires_selection,omitempty"`
+	PreviewReady                   bool     `db:"preview_ready" json:"preview_ready"`
+	PreviewReadinessMissingReason  string   `db:"preview_readiness_missing_reason" json:"preview_readiness_missing_reason,omitempty"`
+	// PreviewReadinessMissingDetails carries the specific, actionable reasons
+	// behind the short PreviewReadinessMissingReason headline (config parse
+	// errors, ValidationConfig failures, or admin-setup requirements). The
+	// settings page reveals these on demand so the user knows what to fix.
+	PreviewReadinessMissingDetails []string   `db:"-" json:"preview_readiness_missing_details,omitempty"`
 	GitHubPRCommentPermissionOK    bool       `db:"github_pr_comment_permission_ok" json:"github_pr_comment_permission_ok"`
 	GitHubCommitStatusPermissionOK bool       `db:"github_commit_status_permission_ok" json:"github_commit_status_permission_ok"`
 	LastSurfaceSyncSHA             string     `db:"last_surface_sync_sha" json:"last_surface_sync_sha,omitempty"`


### PR DESCRIPTION
## What & why

On the **Settings → Previews** page, when a repo's `.143/config.json` isn't ready, the "Publish to PRs" toggle is disabled with a single opaque hint: **"Fix .143/config.json first"**. The backend already computes *exactly* what's wrong — parse errors and per-service `ValidateConfig` failures (`primary` missing, a service with no `command`, a port out of range, a missing `ready.http_path`, an unsupported infra template, …) — but `enrichPreviewPolicyConfigReadiness` was discarding all of it. So an admin couldn't tell what to fix without trial and error.

## Changes

- **Backend** — surface the specifics instead of dropping them:
  - New `PreviewReadinessMissingDetails []string` on `RepositoryPreviewPolicySummary` (`db:"-"`, JSON-only — no migration).
  - Populate it from parse errors and `detection.ValidationErrors` in `enrichPreviewPolicyConfigReadiness`.
  - Split the **admin-setup-required** case (credentials/secrets/network declared but not yet wired) into its own headline — *"Finish preview setup before enabling GitHub PR links"* — with the specific credential/bundle/destination listed, instead of mislabeling a structurally valid config as "Fix .143/config.json first".
- **Frontend** — make it clear but compact:
  - New `preview_readiness_missing_details?: string[]` on `PreviewPolicySummary`.
  - New `PublishDisabledHint` component: when details exist, the existing `?` help line becomes a dotted-underline target that opens a `Popover` with a bulleted list of what's failing plus the fix instruction. The Popover is controlled so it opens on **tap/click, pointer hover, and keyboard focus** (touch-friendly). With no details it falls back to the plain one-line text — nothing gets noisier than before.

## Verification

- `go build ./internal/api/handlers/... ./internal/models/...` — clean
- `gofmt` — clean; frontend `eslint` — clean; `tsc` — clean (in the fully-installed checkout)
- Not exercised in a live browser preview: the "Not ready" detail state only renders for a repo whose `.143/config.json` actually fails validation on its default branch, which needs the backend + GitHub App + a seeded broken-config repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
