### PR TITLE
Remove preview Slack notifications from integrations

### DIFF
--- a/frontend/src/app/(dashboard)/settings/integrations/page.tsx
+++ b/frontend/src/app/(dashboard)/settings/integrations/page.tsx
@@ -95,8 +95,6 @@ const SLACK_NOTIFICATION_EVENTS = [
   { value: "automation.run.failed", label: "Automation failed" },
   { value: "automation.run.failure_streak", label: "Automation failure streak" },
   { value: "pr.opened", label: "PR opened" },
-  { value: "preview.ready", label: "Preview ready" },
-  { value: "preview.failed", label: "Preview failed" },
   { value: "preview.stale", label: "Preview stale" },
   { value: "preview.*", label: "All preview events" },
 ] as const;

--- a/internal/worker/handlers.go
+++ b/internal/worker/handlers.go
@@ -829,22 +829,8 @@ func newStartPreviewHandler(stores *Stores, services *Services, logger zerolog.L
 				logEvent.Msg("preview sandbox is busy; retrying start_preview")
 				return &RetryableError{Err: err, RetryAfter: &retryAfter, TargetNodeID: targetNodeID}
 			}
-			enqueueSlackNotificationSubscribers(ctx, stores, logger, input.OrgID, slackNotificationFanoutInput{
-				EventKind: string(models.SlackNotificationPreviewFailed),
-				Title:     "Preview failed",
-				Body:      err.Error(),
-				SessionID: &input.SessionID,
-				PreviewID: &input.PreviewID,
-			})
 			return &FatalError{Err: err}
 		}
-		enqueueSlackNotificationSubscribers(ctx, stores, logger, input.OrgID, slackNotificationFanoutInput{
-			EventKind: string(models.SlackNotificationPreviewReady),
-			Title:     "Preview ready",
-			Body:      "The preview is ready.",
-			SessionID: &input.SessionID,
-			PreviewID: &input.PreviewID,
-		})
 		return nil
 	}
 }
@@ -893,20 +879,8 @@ func newStartBranchPreviewHandler(stores *Stores, services *Services, logger zer
 					ClearTargetNodeID:      true,
 				}
 			}
-			enqueueSlackNotificationSubscribers(ctx, stores, logger, input.OrgID, slackNotificationFanoutInput{
-				EventKind: string(models.SlackNotificationPreviewFailed),
-				Title:     "Preview failed",
-				Body:      err.Error(),
-				PreviewID: &input.PreviewID,
-			})
 			return &FatalError{Err: err}
 		}
-		enqueueSlackNotificationSubscribers(ctx, stores, logger, input.OrgID, slackNotificationFanoutInput{
-			EventKind: string(models.SlackNotificationPreviewReady),
-			Title:     "Preview ready",
-			Body:      "The preview is ready.",
-			PreviewID: &input.PreviewID,
-		})
 		return nil
 	}
 }
@@ -3710,6 +3684,10 @@ type slackNotificationSubscriptionConfig struct {
 }
 
 func slackNotificationSubscriptionMatches(raw json.RawMessage, preset *models.SlackNotificationPreset, eventKind string, automationID *uuid.UUID) bool {
+	switch eventKind {
+	case string(models.SlackNotificationPreviewReady), string(models.SlackNotificationPreviewFailed):
+		return false
+	}
 	if len(raw) == 0 || string(raw) == "null" {
 		raw = json.RawMessage(`{}`)
 	}
@@ -3739,7 +3717,6 @@ func slackNotificationPresetEvents(preset *models.SlackNotificationPreset) []str
 			string(models.SlackNotificationSessionFailed),
 			string(models.SlackNotificationAutomationFailed),
 			string(models.SlackNotificationAutomationFailureStreak),
-			string(models.SlackNotificationPreviewFailed),
 			string(models.SlackNotificationHumanInputRequested),
 		}
 	case models.SlackNotificationPresetBalanced:
@@ -3749,8 +3726,6 @@ func slackNotificationPresetEvents(preset *models.SlackNotificationPreset) []str
 			string(models.SlackNotificationAutomationFailed),
 			string(models.SlackNotificationAutomationFailureStreak),
 			string(models.SlackNotificationPROpened),
-			string(models.SlackNotificationPreviewReady),
-			string(models.SlackNotificationPreviewFailed),
 			string(models.SlackNotificationHumanInputRequested),
 		}
 	case models.SlackNotificationPresetVerbose:

--- a/internal/worker/handlers_test.go
+++ b/internal/worker/handlers_test.go
@@ -317,8 +317,44 @@ func TestSlackNotificationSubscriptionMatches(t *testing.T) {
 		{
 			name:      "wildcard matches event",
 			raw:       json.RawMessage(`{"events":["*"]}`),
-			eventKind: "preview.ready",
+			eventKind: "session.failed",
 			expected:  true,
+		},
+		{
+			name:      "explicit preview ready does not match",
+			raw:       json.RawMessage(`{"events":["preview.ready"]}`),
+			eventKind: "preview.ready",
+			expected:  false,
+		},
+		{
+			name:      "wildcard does not match preview ready",
+			raw:       json.RawMessage(`{"events":["*"]}`),
+			eventKind: "preview.ready",
+			expected:  false,
+		},
+		{
+			name:      "event family wildcard does not match preview ready",
+			raw:       json.RawMessage(`{"events":["preview.*"]}`),
+			eventKind: "preview.ready",
+			expected:  false,
+		},
+		{
+			name:      "explicit preview failed does not match",
+			raw:       json.RawMessage(`{"events":["preview.failed"]}`),
+			eventKind: "preview.failed",
+			expected:  false,
+		},
+		{
+			name:      "wildcard does not match preview failed",
+			raw:       json.RawMessage(`{"events":["*"]}`),
+			eventKind: "preview.failed",
+			expected:  false,
+		},
+		{
+			name:      "event family wildcard does not match preview failed",
+			raw:       json.RawMessage(`{"events":["preview.*"]}`),
+			eventKind: "preview.failed",
+			expected:  false,
 		},
 		{
 			name:      "event family wildcard matches event",
@@ -378,12 +414,15 @@ func TestSlackNotificationSubscriptionMatchesPresets(t *testing.T) {
 		expected  bool
 	}{
 		{name: "balanced includes PR opened", preset: &balanced, eventKind: string(models.SlackNotificationPROpened), expected: true},
-		{name: "balanced includes preview failed", preset: &balanced, eventKind: string(models.SlackNotificationPreviewFailed), expected: true},
+		{name: "balanced excludes preview ready", preset: &balanced, eventKind: string(models.SlackNotificationPreviewReady), expected: false},
+		{name: "balanced excludes preview failed", preset: &balanced, eventKind: string(models.SlackNotificationPreviewFailed), expected: false},
 		{name: "balanced excludes preview stale", preset: &balanced, eventKind: string(models.SlackNotificationPreviewStale), expected: false},
 		{name: "quiet includes human input", preset: &quiet, eventKind: string(models.SlackNotificationHumanInputRequested), expected: true},
-		{name: "quiet includes preview failed", preset: &quiet, eventKind: string(models.SlackNotificationPreviewFailed), expected: true},
+		{name: "quiet excludes preview failed", preset: &quiet, eventKind: string(models.SlackNotificationPreviewFailed), expected: false},
 		{name: "quiet excludes session completed", preset: &quiet, eventKind: string(models.SlackNotificationSessionCompleted), expected: false},
-		{name: "verbose includes any typed event", preset: &verbose, eventKind: string(models.SlackNotificationPreviewFailed), expected: true},
+		{name: "verbose includes any typed event", preset: &verbose, eventKind: string(models.SlackNotificationSessionFailed), expected: true},
+		{name: "verbose excludes preview ready", preset: &verbose, eventKind: string(models.SlackNotificationPreviewReady), expected: false},
+		{name: "verbose excludes preview failed", preset: &verbose, eventKind: string(models.SlackNotificationPreviewFailed), expected: false},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary
- Remove preview ready and preview failed events from the Slack integrations UI
- Stop emitting Slack notifications for preview start success and failure paths
- Prevent preview notification subscriptions from matching those event kinds
- Update worker tests to cover the new preview notification behavior

## Testing
- Updated unit tests for Slack notification subscription matching and preset coverage