### PR TITLE
Update frontend design system direction to use shadcn/ui + enforce engineering control-plane UI rules

### DIFF
--- a/frontend/AGENTS.md
+++ b/frontend/AGENTS.md
@@ -12,6 +12,21 @@ This file applies to the entire `frontend/` tree. Follow these patterns strictly
 - **Icons:** lucide-react
 - **Fonts:** Geist Sans (primary), Geist Mono (monospace)
 
+## Design System Direction
+
+Keep **shadcn/ui + Tailwind tokens as the implementation system**: shadcn/ui primitives, local app components, semantic Tailwind tokens, and lucide icons. Do not migrate dashboard work to another component framework unless the user explicitly asks for a framework migration.
+
+Design 143 as a **professional engineering control plane** — not a marketing surface, not a consumer app. Apply these rules:
+
+- **Lead with the task.** Make the next responsible action (inspect, compare, configure, launch, pause, repair, review, publish) obvious without large explanatory copy.
+- **Stay dense but calm.** Use compact rows, tables, split panes, filters, badges, and inline actions. Avoid oversized cards, decorative sections, large empty spacing, and hero-style composition inside the app.
+- **Enforce hierarchy.** Make the primary object, current state, owner/repo/session context, and allowed actions scannable in the first pass. Keep secondary metadata subordinate to the main action.
+- **Disclose progressively.** Show routine controls inline; move rare, destructive, advanced, or high-detail actions into menus, dialogs, sheets, or expandable sections.
+- **Speak one state language.** Use the shared status components and state tokens. Every status must convey what is happening, whether attention is needed, and the available action.
+- **Stay accessible.** Preserve shadcn/Radix keyboard behavior, focus rings, aria labels, disabled states, and contrast. Give icon-only buttons tooltips and accessible names.
+- **Cut decoration.** No gradient blobs, ornamental illustrations, nested cards, or tinted feature panes. Derive visual weight from layout, typography, borders, shadows, and state tokens.
+- **Match existing patterns.** Before adding a new pattern, check this file, nearby pages, and shared components, and extend what exists unless there is a concrete product reason not to.
+
 ## Design System
 
 ### Surface Hierarchy


### PR DESCRIPTION
## Summary

The current frontend UI guidance mixes named “borrow/avoid” design systems, creating ambiguity about what to use and when—an ongoing reliability risk for consistent dashboard layout. This change removes the named-system references and makes the direction prescriptive around using shadcn/ui + Tailwind tokens as the implementation system, while enforcing control-plane-focused, accessible, and consistent interaction patterns.

## Changes

- Set **shadcn/ui + Tailwind tokens (semantic tokens, lucide icons, local components)** as the single implementation system; avoid framework migrations unless explicitly requested by users.
- Reframed “Design 143” as a **professional engineering control plane**, with imperative, consistent rules for layout and interaction (e.g., lead with the task, dense but calm, enforce hierarchy).
- Removed all named design system “borrow from X / avoid Material Design” guidance and collapsed redundant prose to keep the file skimmable and easier to follow during reviews.
- Strengthened guidance on progressive disclosure, state language consistency, and accessibility (focus rings, aria labels, disabled states, tooltips for icon-only actions).

## Validation

- Verified by updating only `frontend/AGENTS.md` and ensuring the guidance is self-consistent (no remaining duplicated/contradictory named framework references like Polaris/Spectrum in both borrow/avoid lists).

[143.dev](https://143.dev) | [session 16afc002](https://143.dev/sessions/16afc002-531b-402c-be68-a9c193908a38)

<!-- 143 readiness -->
**143 readiness:** not available for this revision.

Preview: https://143.dev/previews/github/assembledhq/143/pull/1678?launch=1