### PR TITLE
Cache startup snapshots for previews that deliver secret files

### DIFF
--- a/internal/services/preview/snapshot_cache.go
+++ b/internal/services/preview/snapshot_cache.go
@@ -191,6 +191,7 @@ func (sc *SnapshotCache) CreateSnapshot(
 	sb *agent.Sandbox,
 	snapshotKey string,
 	metadata SnapshotMetadata,
+	excludePaths []string,
 ) error {
 	log := sc.logger.With().
 		Str("snapshot_key", snapshotKey).
@@ -203,15 +204,18 @@ func (sc *SnapshotCache) CreateSnapshot(
 	// 1. Create the archive inside the sandbox.
 	//    Using shell tar is significantly faster than Go's archive/tar for
 	//    large node_modules trees (parallel I/O, kernel-level buffering).
-	//    Compression and the exclude list are shared with the session-checkpoint
-	//    path via the agent package; excludeGit=true because preview workspaces
-	//    rebuild .git from the clone.
+	//    Compression and the base exclude list are shared with the
+	//    session-checkpoint path via the agent package; excludeGit=true because
+	//    preview workspaces rebuild .git from the clone. excludePaths are the
+	//    caller's per-config additions (runtime secret-file destinations and
+	//    separately-restored build caches — see previewSnapshotExcludePaths).
 	tarCmd := fmt.Sprintf(
-		"tar -c %s -f %s -C %s %s -- .",
+		"tar -c %s -f %s -C %s %s%s -- .",
 		agent.SnapshotTarCompressFlag,
 		snapshotTmpFile,
 		shellQuote(sb.WorkDir),
 		agent.SnapshotTarExcludeFlags(true),
+		snapshotExtraExcludeFlags(excludePaths),
 	)
 
 	var stderr bytes.Buffer
@@ -722,6 +726,39 @@ func (sc *SnapshotCache) blobPath(snapshotKey string) (string, error) {
 // user-controlled paths into shell commands.
 func shellQuote(s string) string {
 	return "'" + strings.ReplaceAll(s, "'", "'\\''") + "'"
+}
+
+// snapshotExtraExcludeFlags renders additional `--exclude=` flags for the
+// snapshot tar, appended after the shared base flags. It returns a string that
+// is either empty or begins with a leading space, so it can be concatenated
+// directly onto agent.SnapshotTarExcludeFlags(...).
+//
+// The archive is created with `tar -c -C workdir -- .`, so members are stored
+// with a leading "./". Each path is emitted in both its bare ("foo/bar") and
+// "./"-rooted ("./foo/bar") forms so the exclude matches regardless of how the
+// tar implementation anchors patterns. Each flag is shell-quoted as a whole so
+// any glob metacharacters in the path reach tar literally instead of being
+// expanded by the surrounding `sh -c`.
+func snapshotExtraExcludeFlags(paths []string) string {
+	if len(paths) == 0 {
+		return ""
+	}
+	var b strings.Builder
+	for _, p := range paths {
+		clean := strings.TrimSpace(p)
+		if clean == "" {
+			continue
+		}
+		clean = strings.TrimPrefix(clean, "./")
+		if clean == "" || clean == "." {
+			continue
+		}
+		b.WriteByte(' ')
+		b.WriteString(shellQuote("--exclude=" + clean))
+		b.WriteByte(' ')
+		b.WriteString(shellQuote("--exclude=./" + clean))
+	}
+	return b.String()
 }
 
 // totalSize sums the SizeBytes of all entries.

--- a/internal/services/preview/snapshot_cache_test.go
+++ b/internal/services/preview/snapshot_cache_test.go
@@ -268,3 +268,32 @@ func TestSnapshotCache_RestoreSnapshotStreamsBlobToSandbox(t *testing.T) {
 	require.Equal(t, body, executor.written, "RestoreSnapshot should stream the exact blob contents")
 	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
 }
+
+func TestSnapshotExtraExcludeFlags(t *testing.T) {
+	t.Parallel()
+
+	t.Run("empty input yields no flags", func(t *testing.T) {
+		t.Parallel()
+		require.Empty(t, snapshotExtraExcludeFlags(nil))
+		require.Empty(t, snapshotExtraExcludeFlags([]string{}))
+	})
+
+	t.Run("emits bare and ./-rooted forms, quoted", func(t *testing.T) {
+		t.Parallel()
+		flags := snapshotExtraExcludeFlags([]string{"config/dev.json"})
+		// Members are stored as "./config/dev.json"; both forms guarantee a match
+		// regardless of how the tar implementation anchors patterns.
+		require.Contains(t, flags, "'--exclude=config/dev.json'")
+		require.Contains(t, flags, "'--exclude=./config/dev.json'")
+		// Concatenated directly after the shared flags, so it must lead with a space.
+		require.True(t, strings.HasPrefix(flags, " "), "extra flags should begin with a separating space")
+	})
+
+	t.Run("normalizes a ./-prefixed path so it is not double-rooted", func(t *testing.T) {
+		t.Parallel()
+		flags := snapshotExtraExcludeFlags([]string{"./.env.local"})
+		require.Contains(t, flags, "'--exclude=.env.local'")
+		require.Contains(t, flags, "'--exclude=./.env.local'")
+		require.NotContains(t, flags, "././", "leading ./ must be trimmed before re-rooting")
+	})
+}

--- a/internal/services/preview/start_runner.go
+++ b/internal/services/preview/start_runner.go
@@ -129,7 +129,7 @@ type previewStartupCache interface {
 	FindBaseSnapshot(ctx context.Context, orgID, repoID uuid.UUID, baseKey, excludeCommitSHA string) (*CacheHit, error)
 	RestoreSnapshot(ctx context.Context, sb *agent.Sandbox, hit *CacheHit) error
 	ApplyPartialInvalidation(ctx context.Context, sb *agent.Sandbox, hit *CacheHit, gitDiff []byte) error
-	CreateSnapshot(ctx context.Context, sb *agent.Sandbox, snapshotKey string, metadata SnapshotMetadata) error
+	CreateSnapshot(ctx context.Context, sb *agent.Sandbox, snapshotKey string, metadata SnapshotMetadata, excludePaths []string) error
 }
 
 // branchPreviewStartupCacheKeys carries the cache keys computed for one branch
@@ -145,7 +145,6 @@ type StartupSnapshotResult string
 const (
 	StartupSnapshotSaved              StartupSnapshotResult = "saved"
 	StartupSnapshotSkippedNoLockfiles StartupSnapshotResult = "skipped_no_lockfiles"
-	StartupSnapshotSkippedSecretFiles StartupSnapshotResult = "skipped_secret_files"
 	StartupSnapshotFailed             StartupSnapshotResult = "failed"
 	StartupSnapshotTooLarge           StartupSnapshotResult = "too_large"
 	StartupSnapshotDisabled           StartupSnapshotResult = "disabled"
@@ -1724,16 +1723,12 @@ func (r *StartRunner) maybeRestoreBranchPreviewStartupCache(ctx context.Context,
 	if r == nil || r.snapshotCache == nil || r.sandboxProvider == nil || sb == nil || cfg == nil || commitSHA == "" {
 		return branchPreviewStartupCacheKeys{}, nil
 	}
-	if previewConfigHasRuntimeSecretFiles(cfg) {
-		// Runtime secret files are written into the shared workspace during
-		// LaunchPreview. The startup cache snapshots that workspace after
-		// launch, so do not read or write cache entries for these configs:
-		// otherwise worker-local cache blobs could retain plaintext secrets.
-		r.logger.Debug().
-			Str("repository_id", repoID.String()).
-			Msg("branch preview startup cache skipped because config delivers preview secrets as files")
-		return branchPreviewStartupCacheKeys{}, nil
-	}
+	// Configs that deliver runtime secret files used to be excluded from the
+	// startup cache entirely. They are no longer: the secret-file destinations
+	// are excluded from the snapshot blob at create time (see
+	// previewSnapshotExcludePaths) and re-injected on every launch by the
+	// runtime_secret_files phase, which runs after restore — so a restored
+	// workspace never carries persisted plaintext secrets.
 	keys, err := r.computeBranchPreviewStartupCacheKeys(ctx, sb, cfg, commitSHA)
 	if err != nil {
 		r.logger.Warn().Err(err).
@@ -1879,20 +1874,13 @@ func (r *StartRunner) createBranchPreviewStartupCache(ctx context.Context, orgID
 		}
 		return result
 	}
-	if previewConfigHasRuntimeSecretFiles(cfg) {
-		// See maybeRestoreBranchPreviewStartupCache for why secret-file
-		// configs are excluded from the workspace snapshot cache.
-		r.logger.Debug().
-			Str("repository_id", repoID.String()).
-			Str("snapshot_key", keys.SnapshotKey).
-			Msg("branch preview startup cache creation skipped because config delivers preview secrets as files")
-		r.logBranchPreviewStartupSnapshotResult(repoID, keys.SnapshotKey, StartupSnapshotSkippedSecretFiles, 0, started, nil)
-		return StartupSnapshotSkippedSecretFiles
-	}
 	cacheCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 10*time.Minute)
 	defer cancel()
 	metadata := SnapshotMetadata{OrgID: orgID, RepoID: repoID, BaseKey: keys.BaseKey, CommitSHA: keys.CommitSHA}
-	if err := r.snapshotCache.CreateSnapshot(cacheCtx, sb, keys.SnapshotKey, metadata); err != nil {
+	// Keep runtime secret-file destinations and separately-restored build caches
+	// out of the worker-local blob (see previewSnapshotExcludePaths).
+	excludePaths := previewSnapshotExcludePaths(cfg)
+	if err := r.snapshotCache.CreateSnapshot(cacheCtx, sb, keys.SnapshotKey, metadata, excludePaths); err != nil {
 		result := startupSnapshotResultForCreateError(err)
 		r.logger.Warn().Err(err).
 			Str("repository_id", repoID.String()).
@@ -1987,19 +1975,58 @@ func branchPreviewStartupCacheLockfiles(cfg *models.PreviewConfig) []string {
 	return lockfiles
 }
 
-func previewConfigHasRuntimeSecretFiles(cfg *models.PreviewConfig) bool {
+// previewSnapshotExcludePaths returns the workspace-relative paths that must be
+// kept out of a startup snapshot blob:
+//
+//   - Runtime secret-file destinations. These hold plaintext app secrets, so
+//     they must never persist in a worker-local snapshot blob. They are
+//     re-injected on every launch by the runtime_secret_files phase (which runs
+//     after the snapshot is restored), so excluding them is lossless. Both the
+//     resolved cfg.RuntimeSecretFiles (populated by the secret resolver during
+//     LaunchPreview) and the repo-declared SecretBundleRefs file destinations
+//     are covered, so the set is complete whether or not resolution has run.
+//   - Workspace build-cache paths (preview.install.cache.build). These are
+//     persisted and restored by the dedicated build-cache mechanism
+//     (restorePreviewBuildCache, which runs right before the build phase), so
+//     duplicating them in the snapshot is wasted bytes — and for a large
+//     monorepo's Go/turbo caches that bloat can push the blob past the size cap
+//     and silently defeat the whole snapshot.
+//
+// Dependency caches (node_modules, .venv, …) are deliberately NOT excluded: the
+// snapshot's value is bundling installed deps and build outputs into one restore
+// so the install phase fully skips, which needs those trees present.
+func previewSnapshotExcludePaths(cfg *models.PreviewConfig) []string {
 	if cfg == nil {
-		return false
+		return nil
 	}
-	if len(cfg.RuntimeSecretFiles) > 0 {
-		return true
+	seen := make(map[string]struct{})
+	var paths []string
+	add := func(raw string) {
+		clean, err := cleanBranchPreviewStartupCachePath(raw)
+		if err != nil {
+			return
+		}
+		if _, ok := seen[clean]; ok {
+			return
+		}
+		seen[clean] = struct{}{}
+		paths = append(paths, clean)
+	}
+	for _, file := range cfg.RuntimeSecretFiles {
+		add(file.Path)
 	}
 	for _, ref := range SecretBundleRefs(cfg) {
-		if len(ref.Files) > 0 {
-			return true
+		for _, file := range ref.Files {
+			add(file)
 		}
 	}
-	return false
+	if buildCachePaths, ok := ResolvePreviewBuildCachePaths(cfg.Install); ok {
+		for _, p := range buildCachePaths {
+			add(p)
+		}
+	}
+	sort.Strings(paths)
+	return paths
 }
 
 func cleanBranchPreviewStartupCachePath(raw string) (string, error) {

--- a/internal/services/preview/start_runner_test.go
+++ b/internal/services/preview/start_runner_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"sort"
 	"strings"
 	"testing"
 	"time"
@@ -639,6 +640,8 @@ type fakePreviewStartupCache struct {
 	restoreCalled bool
 	createKey     string
 	createMeta    SnapshotMetadata
+	createExclude []string
+	createCalled  bool
 	createErr     error
 	hit           *CacheHit
 
@@ -672,9 +675,11 @@ func (f *fakePreviewStartupCache) ApplyPartialInvalidation(_ context.Context, _ 
 	return f.partialErr
 }
 
-func (f *fakePreviewStartupCache) CreateSnapshot(_ context.Context, _ *agent.Sandbox, snapshotKey string, metadata SnapshotMetadata) error {
+func (f *fakePreviewStartupCache) CreateSnapshot(_ context.Context, _ *agent.Sandbox, snapshotKey string, metadata SnapshotMetadata, excludePaths []string) error {
+	f.createCalled = true
 	f.createKey = snapshotKey
 	f.createMeta = metadata
+	f.createExclude = append([]string(nil), excludePaths...)
 	return f.createErr
 }
 
@@ -1043,12 +1048,13 @@ func TestStartRunnerCreateBranchPreviewStartupCache_ReportsTooLarge(t *testing.T
 	require.Equal(t, "cache-key", cache.createKey, "startup snapshot creation should have been attempted before size classification")
 }
 
-func TestStartRunnerBranchPreviewStartupCache_SkipsFileDeliveredSecrets(t *testing.T) {
+func TestStartRunnerBranchPreviewStartupCache_ExcludesFileDeliveredSecrets(t *testing.T) {
 	t.Parallel()
 
-	// The current launch would overwrite restored secret files, but cache
-	// creation happens after launch and would otherwise persist plaintext
-	// generated secret files in worker-local cache blobs.
+	// Configs that deliver runtime secret files are now cached: the snapshot is
+	// created with the secret-file destinations excluded from the worker-local
+	// blob, and they are re-injected on every launch by the runtime_secret_files
+	// phase (which runs after restore). Restore is likewise no longer skipped.
 	orgID := uuid.New()
 	repoID := uuid.New()
 	cfg := &models.PreviewConfig{
@@ -1071,14 +1077,81 @@ func TestStartRunnerBranchPreviewStartupCache_SkipsFileDeliveredSecrets(t *testi
 	sb := &agent.Sandbox{ID: "sandbox-1", WorkDir: "/workspace/repo"}
 
 	keys, err := runner.maybeRestoreBranchPreviewStartupCache(context.Background(), orgID, repoID, "abc1234", sb, cfg)
-	require.NoError(t, err, "skipping secret-file configs should not surface an error")
+	require.NoError(t, err, "restoring secret-file configs should not surface an error")
+	require.NotEmpty(t, keys.SnapshotKey, "secret-file configs should now participate in the startup cache")
+	require.True(t, cache.restoreCalled, "secret-file configs should restore cached workspace files on a hit")
+
 	result := runner.createBranchPreviewStartupCache(context.Background(), orgID, repoID, branchPreviewStartupCacheKeys{SnapshotKey: "cache-key"}, sb, cfg)
 
-	require.Empty(t, keys.SnapshotKey, "branch preview startup cache should not restore snapshots for configs with generated secret files")
-	require.Empty(t, cache.findKey, "secret-file configs should not query startup cache entries")
-	require.Empty(t, cache.createKey, "secret-file configs should not write startup cache snapshots")
-	require.False(t, cache.restoreCalled, "secret-file configs should not restore cached workspace files")
-	require.Equal(t, StartupSnapshotSkippedSecretFiles, result, "secret-file configs should report the secret-file skip reason")
+	require.Equal(t, StartupSnapshotSaved, result, "secret-file configs should now be snapshotted")
+	require.True(t, cache.createCalled, "snapshot creation should run for secret-file configs")
+	require.Equal(t, "cache-key", cache.createKey)
+	require.Contains(t, cache.createExclude, ".env.local", "secret-file destinations must be excluded from the snapshot blob")
+}
+
+func TestPreviewSnapshotExcludePaths(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil config", func(t *testing.T) {
+		t.Parallel()
+		require.Nil(t, previewSnapshotExcludePaths(nil))
+	})
+
+	t.Run("collects secret files, bundle files, and build caches; deduped and sorted", func(t *testing.T) {
+		t.Parallel()
+		enabled := true
+		cfg := &models.PreviewConfig{
+			RuntimeSecretFiles: []models.PreviewRuntimeSecretFile{
+				{Path: "config/development.conf.json"},
+				{Path: "./.env.local"}, // normalizes to .env.local
+			},
+			Secrets: []models.PreviewSecretBundleRef{
+				{Bundle: "app", Files: []string{".env.local", "secrets/db.json"}},
+			},
+			Install: &models.PreviewInstallConfig{
+				Lockfiles: []string{"package-lock.json"},
+				Cache: &models.PreviewInstallCacheConfig{
+					Build: &models.PreviewBuildCacheConfig{
+						Enabled: &enabled,
+						Paths:   []string{"node_modules/.cache/turbo"},
+					},
+				},
+			},
+		}
+
+		got := previewSnapshotExcludePaths(cfg)
+
+		require.Contains(t, got, ".env.local")
+		require.Contains(t, got, "config/development.conf.json")
+		require.Contains(t, got, "secrets/db.json")
+		require.Contains(t, got, "node_modules/.cache/turbo")
+		// .env.local appears in both RuntimeSecretFiles and a bundle ref.
+		require.Equal(t, 1, countOccurrences(got, ".env.local"), "duplicate destinations must be collapsed")
+		require.True(t, sort.StringsAreSorted(got), "exclude paths should be sorted for deterministic tar commands")
+	})
+
+	t.Run("drops invalid paths", func(t *testing.T) {
+		t.Parallel()
+		cfg := &models.PreviewConfig{
+			RuntimeSecretFiles: []models.PreviewRuntimeSecretFile{
+				{Path: "/absolute/secret"}, // rejected: absolute
+				{Path: "../escape"},        // rejected: escapes workspace
+				{Path: "  "},               // rejected: empty
+				{Path: "ok/secret.json"},
+			},
+		}
+		require.Equal(t, []string{"ok/secret.json"}, previewSnapshotExcludePaths(cfg))
+	})
+}
+
+func countOccurrences(items []string, target string) int {
+	n := 0
+	for _, item := range items {
+		if item == target {
+			n++
+		}
+	}
+	return n
 }
 
 func TestSessionPreviewPrewarmStatusForCacheStatus(t *testing.T) {


### PR DESCRIPTION
## Problem

Previews whose `.143/config.json` delivers runtime secret files (via `secrets[].files`, e.g. assembled's `development.conf.json`) are **hard-excluded from the startup snapshot cache**. Both `maybeRestoreBranchPreviewStartupCache` and `createBranchPreviewStartupCache` short-circuit on `previewConfigHasRuntimeSecretFiles`, so plaintext secrets are never baked into a worker-local snapshot blob — but the cost is that these previews can never reuse a snapshot and pay the **full cold install + build on every launch** (~5–8 min for a large monorepo), leaving `preview_startup_cache` empty for every such repo.

## Fix

Instead of refusing to snapshot these configs, exclude only the paths that shouldn't live in the blob:

- **Runtime secret-file destinations** — so plaintext secrets never persist in a worker-local blob. They're re-injected on every launch by the `runtime_secret_files` phase, which runs *after* the snapshot is restored, so a restored workspace never carries stale/persisted secrets. The exclude set covers both the resolved `cfg.RuntimeSecretFiles` and the repo-declared `SecretBundleRefs` file destinations, normalized with the **same rule `buildWriteRuntimeSecretFileCmd` uses to accept a path** — so every secret actually written into the workspace is guaranteed to be excluded.
- **Workspace build-cache paths** (`preview.install.cache.build`) — already persisted/restored by the dedicated build-cache mechanism (`restorePreviewBuildCache` runs right before the build phase). Duplicating them in the snapshot is wasteful, and a large monorepo's Go/turbo caches can push the blob past the size cap and silently defeat the snapshot. Reuses the existing `ResolvePreviewBuildCachePaths` helper.

`CreateSnapshot` now takes `excludePaths []string`; `snapshotExtraExcludeFlags` emits each in both bare (`foo`) and `./`-rooted (`./foo`) forms (snapshot members are stored with a leading `./`) and shell-quotes each whole flag so glob metacharacters reach tar literally. Dependency caches (node_modules, .venv, …) are **not** excluded — the snapshot's value is bundling installed deps + build outputs into one restore so the install phase fully skips.

## Relationship to #1585

This is a **fresh re-implementation on current `main`** of the idea from #1585, which went stale and conflicting after the zstd / shared-tar-helper rework (#1615) and the retry-safe recovery changes (#1667) reworked the same functions. This version plugs into the new shared `agent.SnapshotTarExcludeFlags` path and reuses the now-existing `ResolvePreviewBuildCachePaths` helper instead of reinventing it. #1585 is being closed in favor of this.

## Tests

- `go build ./...` clean; full `internal/services/preview/...` package tests pass; `golangci-lint` clean on the package.
- New/updated: `TestStartRunnerBranchPreviewStartupCache_ExcludesFileDeliveredSecrets` (replaces the old `_SkipsFileDeliveredSecrets`), `TestPreviewSnapshotExcludePaths`, `TestSnapshotExtraExcludeFlags`.

## Note

As with #1585, this is half the fix for fast assembled previews. The snapshot restores the workspace but `runServiceBuilds` still runs the repo's `build` command unconditionally, so the repo's `.143/preview-build.sh` must self-skip when this commit's artifacts are already present (handled on the assembled side in `wangjohn/preview-seeded-postgres`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
