### PR TITLE
Add build-cache key diagnostics to debug cold preview launches

### DIFF
--- a/internal/services/preview/dependency_cache_keys.go
+++ b/internal/services/preview/dependency_cache_keys.go
@@ -164,8 +164,20 @@ func ComputePreviewDependencyCachePlacementKey(orgID, repoID uuid.UUID, configNa
 // and a stale blob degrades to partial build-tool hits rather than wrong
 // output.
 func ComputePreviewBuildCacheKey(orgID, repoID uuid.UUID, configName, configDigest string, install *models.PreviewInstallConfig, effectivePaths []string) (string, error) {
+	key, err := stableJSONSHA256(newPreviewBuildCachePlacementPayload(PreviewBuildCacheRuntimeVersion, orgID, repoID, configName, configDigest, install, effectivePaths))
+	if err != nil {
+		return "", fmt.Errorf("marshal build cache key: %w", err)
+	}
+	return key, nil
+}
+
+// newPreviewBuildCachePlacementPayload builds the canonical placement-key
+// payload shared by the workdir and home build-artifact slots. Centralizing it
+// guarantees that ComputePreviewBuildCacheKey, ComputePreviewBuildCacheHomeKey,
+// and PreviewBuildCacheKeyDebug all hash byte-identical bytes.
+func newPreviewBuildCachePlacementPayload(runtimeVersion string, orgID, repoID uuid.UUID, configName, configDigest string, install *models.PreviewInstallConfig, effectivePaths []string) previewDependencyCachePlacementKey {
 	payload := previewDependencyCachePlacementKey{
-		RuntimeVersion: PreviewBuildCacheRuntimeVersion,
+		RuntimeVersion: runtimeVersion,
 		OrgID:          orgID,
 		RepoID:         repoID,
 		ConfigName:     strings.TrimSpace(configName),
@@ -180,11 +192,29 @@ func ComputePreviewBuildCacheKey(orgID, repoID uuid.UUID, configName, configDige
 		}
 		payload.LockfilePaths = sortedNormalizedDependencyPaths(install.Lockfiles)
 	}
-	key, err := stableJSONSHA256(payload)
+	return payload
+}
+
+// PreviewBuildCacheKeyDebug recomputes a build-artifact placement key and also
+// returns the exact canonical JSON payload that is SHA-256'd to produce it.
+//
+// TEMPORARY INSTRUMENTATION: this exists only to diagnose build-cache key
+// instability across launches. Because it shares newPreviewBuildCachePlacementPayload
+// and the same json.Marshal as the production key functions, the returned key is
+// byte-identical to ComputePreviewBuildCacheKey/ComputePreviewBuildCacheHomeKey,
+// and payloadJSON is exactly the bytes that were hashed — diff payloadJSON across
+// two launches to pinpoint, in a single pass, which field changed. Pass the
+// runtime-version constant for the slot under diagnosis
+// (PreviewBuildCacheRuntimeVersion for workdir, PreviewBuildCacheHomeRuntimeVersion
+// for home). Safe to delete once the unstable input is identified.
+func PreviewBuildCacheKeyDebug(runtimeVersion string, orgID, repoID uuid.UUID, configName, configDigest string, install *models.PreviewInstallConfig, effectivePaths []string) (key string, payloadJSON string, err error) {
+	payload := newPreviewBuildCachePlacementPayload(runtimeVersion, orgID, repoID, configName, configDigest, install, effectivePaths)
+	raw, err := json.Marshal(payload)
 	if err != nil {
-		return "", fmt.Errorf("marshal build cache key: %w", err)
+		return "", "", fmt.Errorf("marshal build cache debug payload: %w", err)
 	}
-	return key, nil
+	sum := sha256.Sum256(raw)
+	return fmt.Sprintf("%x", sum[:]), string(raw), nil
 }
 
 // ComputePreviewBuildCacheHomeKey returns the latest-wins key for the
@@ -193,23 +223,7 @@ func ComputePreviewBuildCacheKey(orgID, repoID uuid.UUID, configName, configDige
 // home-rooted blob occupies its own slot, separate from the workdir build
 // blob, within the build_artifact cache kind.
 func ComputePreviewBuildCacheHomeKey(orgID, repoID uuid.UUID, configName, configDigest string, install *models.PreviewInstallConfig, effectivePaths []string) (string, error) {
-	payload := previewDependencyCachePlacementKey{
-		RuntimeVersion: PreviewBuildCacheHomeRuntimeVersion,
-		OrgID:          orgID,
-		RepoID:         repoID,
-		ConfigName:     strings.TrimSpace(configName),
-		ConfigDigest:   strings.TrimSpace(configDigest),
-		EffectivePaths: sortedNormalizedDependencyPaths(effectivePaths),
-	}
-	if install != nil {
-		payload.InstallCommand = append([]string(nil), install.Command...)
-		payload.InstallCwd = install.Cwd
-		if payload.InstallCwd == "" {
-			payload.InstallCwd = "."
-		}
-		payload.LockfilePaths = sortedNormalizedDependencyPaths(install.Lockfiles)
-	}
-	key, err := stableJSONSHA256(payload)
+	key, err := stableJSONSHA256(newPreviewBuildCachePlacementPayload(PreviewBuildCacheHomeRuntimeVersion, orgID, repoID, configName, configDigest, install, effectivePaths))
 	if err != nil {
 		return "", fmt.Errorf("marshal build cache home key: %w", err)
 	}

--- a/internal/services/preview/providers/docker_preview.go
+++ b/internal/services/preview/providers/docker_preview.go
@@ -1656,6 +1656,113 @@ func (d *DockerPreviewProvider) saveDependencyCache(ctx context.Context, state *
 	save()
 }
 
+// logBuildCacheKeyDiagnostics emits one structured record capturing every input
+// that feeds a build-artifact placement key, the resulting key, the exact bytes
+// hashed, and the lookup outcome.
+//
+// TEMPORARY INSTRUMENTATION (diagnosing build-cache misses across launches whose
+// config looks identical): emit it on two launches and diff the fields —
+// key_payload_json alone usually shows what moved; config_json and the dual
+// config_digest_* fields cover the case where the digest itself is the unstable
+// input (e.g. opts.ConfigDigest empty → recomputed from a per-launch state.config).
+// root is "workdir" or "home"; runtimeVersion is the matching slot constant;
+// outcome is one of disabled|key_failed|hit|miss|lookup_failed. Safe to delete
+// once the unstable input is identified.
+func (d *DockerPreviewProvider) logBuildCacheKeyDiagnostics(
+	state *previewState,
+	opts preview.StartPreviewOptions,
+	install *models.PreviewInstallConfig,
+	root string,
+	runtimeVersion string,
+	paths []string,
+	pathsEnabled bool,
+	configDigestUsed string,
+	computedKey string,
+	outcome string,
+	hitKey string,
+) {
+	var configName string
+	if state != nil && state.config != nil {
+		configName = state.config.Name
+	}
+	// Recompute the digest from state.config regardless of which source the key
+	// actually used, so we can tell whether opts.ConfigDigest was empty and the
+	// key fell back to a digest derived from a possibly per-launch state.config.
+	recomputedDigest, _ := preview.ComputePreviewConfigDigest(stateConfig(state))
+	digestSource := "opts.ConfigDigest"
+	if strings.TrimSpace(opts.ConfigDigest) == "" {
+		digestSource = "recomputed_from_state_config"
+	}
+
+	ev := d.logger.Info().
+		Str("diag", "build_cache_key").
+		Str("root", root).
+		Str("runtime_version", runtimeVersion).
+		Str("outcome", outcome).
+		Str("preview_handle", previewHandle(state)).
+		Str("org_id", opts.OrgID.String()).
+		Str("repo_id", opts.RepositoryID.String()).
+		Str("session_id", opts.SessionID.String()).
+		Str("config_name", configName).
+		Str("config_digest_used", configDigestUsed).
+		Str("config_digest_opts", opts.ConfigDigest).
+		Str("config_digest_recomputed", recomputedDigest).
+		Str("config_digest_source", digestSource).
+		Bool("paths_enabled", pathsEnabled).
+		Strs("resolved_paths", paths).
+		Str("computed_key", computedKey)
+	if hitKey != "" {
+		ev = ev.Str("hit_key", hitKey)
+	}
+
+	// Raw, pre-normalization install inputs so ordering/whitespace drift is visible.
+	if install != nil {
+		ev = ev.
+			Strs("install_command", install.Command).
+			Str("install_cwd", install.Cwd).
+			Strs("install_lockfiles", install.Lockfiles).
+			Strs("install_clean_paths", install.CleanPaths)
+		if install.Cache != nil && install.Cache.Build != nil {
+			if buildJSON, mErr := json.Marshal(install.Cache.Build); mErr == nil {
+				ev = ev.RawJSON("install_cache_build", buildJSON)
+			}
+		}
+	}
+
+	// The exact bytes that get SHA-256'd into the key — the primary diff target.
+	if dbgKey, payloadJSON, dErr := preview.PreviewBuildCacheKeyDebug(runtimeVersion, opts.OrgID, opts.RepositoryID, configName, configDigestUsed, install, paths); dErr == nil {
+		ev = ev.Str("key_payload_json", payloadJSON)
+		// Sanity check: the debug recompute must reproduce the production key.
+		if computedKey != "" && dbgKey != computedKey {
+			ev = ev.Str("key_payload_mismatch", dbgKey)
+		}
+	}
+
+	// Full committed preview config feeding config_digest_recomputed. Runtime
+	// secret env/files are json:"-" and excluded, so no secret values appear.
+	if state != nil && state.config != nil {
+		if cfgJSON, mErr := json.Marshal(state.config); mErr == nil {
+			ev = ev.RawJSON("config_json", cfgJSON)
+		}
+	}
+
+	ev.Msg("build cache key diagnostics")
+}
+
+func stateConfig(state *previewState) *models.PreviewConfig {
+	if state == nil {
+		return nil
+	}
+	return state.config
+}
+
+func previewHandle(state *previewState) string {
+	if state == nil {
+		return ""
+	}
+	return state.handle
+}
+
 // restorePreviewBuildCache restores the latest build-artifact blob (e.g.
 // Turborepo's local cache) into the sandbox workdir. It runs after the install
 // phase so install commands that wipe node_modules cannot delete the restored
@@ -1671,6 +1778,7 @@ func (d *DockerPreviewProvider) restorePreviewBuildCache(ctx context.Context, st
 	}
 	paths, enabled := preview.ResolvePreviewBuildCachePaths(install)
 	if !enabled {
+		d.logBuildCacheKeyDiagnostics(state, opts, install, "workdir", preview.PreviewBuildCacheRuntimeVersion, paths, false, strings.TrimSpace(opts.ConfigDigest), "", "disabled", "")
 		notifyBuildCacheRestore(observer, "disabled", "", 0, nil)
 		metrics.RecordSessionBuildCacheRestore(ctx, opts.OrgID.String(), "disabled", 0)
 		return
@@ -1683,6 +1791,7 @@ func (d *DockerPreviewProvider) restorePreviewBuildCache(ctx context.Context, st
 	}
 	cacheKey, err := preview.ComputePreviewBuildCacheKey(opts.OrgID, opts.RepositoryID, state.config.Name, configDigest, install, paths)
 	if err != nil {
+		d.logBuildCacheKeyDiagnostics(state, opts, install, "workdir", preview.PreviewBuildCacheRuntimeVersion, paths, true, configDigest, "", "key_failed", "")
 		notifyBuildCacheRestore(observer, "key_failed", "", 0, err)
 		metrics.RecordSessionBuildCacheRestore(ctx, opts.OrgID.String(), "key_failed", 0)
 		d.logger.Warn().Err(err).Msg("preview build cache key unavailable; continuing cold")
@@ -1696,6 +1805,18 @@ func (d *DockerPreviewProvider) restorePreviewBuildCache(ctx context.Context, st
 	hit, findErr := pathCache.FindPathCache(ctx, opts.OrgID, opts.RepositoryID, models.PreviewCacheKindBuildArtifact, cacheKey)
 	notifyPhaseEnd(observer, "build_cache_lookup", findErr)
 	metrics.RecordSessionPreviewPhaseDuration(ctx, opts.OrgID.String(), "build_cache_lookup", time.Since(lookupStarted))
+	{
+		outcome := "hit"
+		hitKey := ""
+		if findErr != nil {
+			outcome = "lookup_failed"
+		} else if hit == nil {
+			outcome = "miss"
+		} else {
+			hitKey = cacheKey // FindPathCache matched this exact key
+		}
+		d.logBuildCacheKeyDiagnostics(state, opts, install, "workdir", preview.PreviewBuildCacheRuntimeVersion, paths, true, configDigest, cacheKey, outcome, hitKey)
+	}
 	if findErr != nil {
 		notifyBuildCacheRestore(observer, "restore_failed", cacheKey, 0, findErr)
 		metrics.RecordSessionBuildCacheRestore(ctx, opts.OrgID.String(), "restore_failed", time.Since(lookupStarted))
@@ -1742,6 +1863,7 @@ func (d *DockerPreviewProvider) restorePreviewBuildCacheHome(ctx context.Context
 	}
 	paths, enabled := preview.ResolvePreviewBuildCacheHomePaths(install)
 	if !enabled {
+		d.logBuildCacheKeyDiagnostics(state, opts, install, "home", preview.PreviewBuildCacheHomeRuntimeVersion, paths, false, strings.TrimSpace(opts.ConfigDigest), "", "disabled", "")
 		return
 	}
 	configDigest := opts.ConfigDigest
@@ -1752,6 +1874,7 @@ func (d *DockerPreviewProvider) restorePreviewBuildCacheHome(ctx context.Context
 	}
 	cacheKey, err := preview.ComputePreviewBuildCacheHomeKey(opts.OrgID, opts.RepositoryID, state.config.Name, configDigest, install, paths)
 	if err != nil {
+		d.logBuildCacheKeyDiagnostics(state, opts, install, "home", preview.PreviewBuildCacheHomeRuntimeVersion, paths, true, configDigest, "", "key_failed", "")
 		d.logger.Warn().Err(err).Msg("preview home build cache key unavailable; continuing cold")
 		return
 	}
@@ -1763,6 +1886,18 @@ func (d *DockerPreviewProvider) restorePreviewBuildCacheHome(ctx context.Context
 	hit, findErr := pathCache.FindPathCache(ctx, opts.OrgID, opts.RepositoryID, models.PreviewCacheKindBuildArtifact, cacheKey)
 	notifyPhaseEnd(observer, "build_cache_home_lookup", findErr)
 	metrics.RecordSessionPreviewPhaseDuration(ctx, opts.OrgID.String(), "build_cache_home_lookup", time.Since(lookupStarted))
+	{
+		outcome := "hit"
+		hitKey := ""
+		if findErr != nil {
+			outcome = "lookup_failed"
+		} else if hit == nil {
+			outcome = "miss"
+		} else {
+			hitKey = cacheKey // FindPathCache matched this exact key
+		}
+		d.logBuildCacheKeyDiagnostics(state, opts, install, "home", preview.PreviewBuildCacheHomeRuntimeVersion, paths, true, configDigest, cacheKey, outcome, hitKey)
+	}
 	if findErr != nil {
 		d.logger.Warn().Err(findErr).Str("cache_key", cacheKey).Msg("preview home build cache lookup failed; continuing cold")
 		return


### PR DESCRIPTION
## Summary

Session previews of large Go + Turborepo repos spend ~10 min in a cold `service_build` because the build-artifact cache misses on **every** launch. Investigation of one stuck launch showed a fresh, same-day workdir build blob existing in the cache, yet the launch computed a build cache key that didn't match it and then saved a new blob under a *different* key (`23e8c2ac…` vs `6c57bf6b…`) for an apparently identical config — same org/repo/`config_digest`/paths/install_command. The build key is meant to be a stable "latest-wins" slot, so something is making it unstable launch-to-launch. This PR adds temporary, log-only instrumentation to pinpoint the unstable input in a single diagnostic pass, with no behavior change to the cache.

## Changes

- **`dependency_cache_keys.go`**: factor the build placement-key payload into a shared `newPreviewBuildCachePlacementPayload` used by the workdir key, the home key, and a new `PreviewBuildCacheKeyDebug` helper that returns the key plus the **exact canonical JSON bytes** that get SHA-256'd (guaranteed byte-identical to the production key path).
- **`docker_preview.go`**: `logBuildCacheKeyDiagnostics`, wired into both `restorePreviewBuildCache` (workdir) and `restorePreviewBuildCacheHome` (home) at every exit (`disabled` | `key_failed` | `hit` | `miss` | `lookup_failed`). Each record dumps `key_payload_json` (the primary diff target), the computed key + outcome, dual `config_digest_used`/`_opts`/`_recomputed` + source (catches `opts.ConfigDigest` being empty and falling back to a per-launch `state.config` digest), full `config_json` (runtime secrets are `json:"-"`, so no secret values are logged), and raw pre-normalization install inputs.

Diffing `key_payload_json` across two launches names the moved field in one pass; if it's identical, the key is stable and the miss is a storage/eviction problem instead. **This is temporary — safe to delete once the cause is identified.**

## Validation

- `go build ./internal/services/preview/...` and `go vet` (both packages) — clean
- `go test ./internal/services/preview/ -run 'BuildCache|CacheKey|ConfigDigest'` and `./providers/ -run 'BuildCache|Restore'` — pass
- `gofmt -l` — clean
- Pinned `golangci-lint` (go1.26) couldn't bootstrap in the offline sandbox; no vet/format issues otherwise

### Runbook
1. Deploy to workers: `make deploy-fleet ROLES=worker`
2. Launch the affected session's preview twice (both miss, both emit the diagnostic)
3. `make logs-query Q='_msg:"build cache key diagnostics" AND _time:[now-30m,now]' LIMIT=40`
4. Diff `key_payload_json` (and `config_digest_*` / `config_json` if the digest moved) between the two `root=workdir` / `outcome=miss` records

🤖 Generated with [Claude Code](https://claude.com/claude-code)
