### PR TITLE
Extract PR readiness enqueue into reusable backend service

### DIFF
--- a/docs/design/113-automated-pr-repair-and-readiness.md
+++ b/docs/design/113-automated-pr-repair-and-readiness.md
@@ -43,9 +43,9 @@ Defaults are off for existing and new orgs until internal rollout proves this is
 
 ## Implementation Status
 
-Phase 1 is implemented: the org and user settings contracts exist, validation covers the new enum/settings shapes, frontend types mirror the backend, the Organization settings page has a compact **Session automation** section, and Account settings has personal inherit/on/off controls that display the current organization default. No backend automation behavior is wired yet.
+Phases 1-2 are implemented: the org and user settings contracts exist, validation covers the new enum/settings shapes, frontend types mirror the backend, the Organization settings page has a compact **Session automation** section, Account settings has personal inherit/on/off controls that display the current organization default, and PR readiness enqueueing now lives in a reusable backend service without changing runtime behavior.
 
-Phases 2-8 remain planned. The next implementation chunk should extract the PR readiness enqueue logic into a reusable service without changing runtime behavior.
+Phases 3-8 remain planned. The next implementation chunk should add clean-loop auto-readiness behind the existing session automation policy, reusing the extracted readiness service.
 
 ## Principles and Boundaries
 

--- a/internal/api/handlers/sessions.go
+++ b/internal/api/handlers/sessions.go
@@ -27,6 +27,7 @@ import (
 	humaninputsvc "github.com/assembledhq/143/internal/services/humaninput"
 	"github.com/assembledhq/143/internal/services/linear"
 	previewsvc "github.com/assembledhq/143/internal/services/preview"
+	prreadinesssvc "github.com/assembledhq/143/internal/services/prreadiness"
 	"github.com/assembledhq/143/internal/services/sessiontimeline"
 	"github.com/assembledhq/143/internal/services/storage"
 	"github.com/go-chi/chi/v5"
@@ -83,13 +84,16 @@ type SessionHandler struct {
 	slackSessionLinks  *db.SlackSessionLinkStore
 	issueSnapshots     *db.SessionTurnIssueSnapshotStore
 	threadStore        *db.SessionThreadStore
-	threadInboxStore   *db.ThreadInboxStore
-	attributionStore   *db.SessionAttributionStore
-	sandboxHolders     *db.SessionSandboxHolderStore
-	viewStore          *db.SessionViewStore
-	memberships        sessionMembershipStore
-	prCredentials      githubStatusCredentialStore
-	prAuthChecker      interface {
+	readinessRunner    interface {
+		EnqueueRun(ctx context.Context, req prreadinesssvc.EnqueueRunRequest) (*models.PRReadinessRun, error)
+	}
+	threadInboxStore *db.ThreadInboxStore
+	attributionStore *db.SessionAttributionStore
+	sandboxHolders   *db.SessionSandboxHolderStore
+	viewStore        *db.SessionViewStore
+	memberships      sessionMembershipStore
+	prCredentials    githubStatusCredentialStore
+	prAuthChecker    interface {
 		HasValidCredential(ctx context.Context, orgID, userID uuid.UUID) (bool, error)
 	}
 	snapshotStore    storage.SnapshotStore // optional — enables snapshot cleanup on archive
@@ -1985,6 +1989,12 @@ func (h *SessionHandler) SetReadinessStore(store *db.PRReadinessStore) {
 	h.readinessStore = store
 }
 
+func (h *SessionHandler) SetReadinessRunner(runner interface {
+	EnqueueRun(ctx context.Context, req prreadinesssvc.EnqueueRunRequest) (*models.PRReadinessRun, error)
+}) {
+	h.readinessRunner = runner
+}
+
 func (h *SessionHandler) GetReadiness(w http.ResponseWriter, r *http.Request) {
 	if h.readinessStore == nil {
 		writeError(w, r, http.StatusNotImplemented, "READINESS_NOT_CONFIGURED", "PR readiness is not configured")
@@ -2089,7 +2099,7 @@ func (h *SessionHandler) UpsertReadinessContext(w http.ResponseWriter, r *http.R
 }
 
 func (h *SessionHandler) RunReadiness(w http.ResponseWriter, r *http.Request) {
-	if h.readinessStore == nil || h.jobStore == nil {
+	if h.readinessRunner == nil {
 		writeError(w, r, http.StatusNotImplemented, "READINESS_NOT_CONFIGURED", "PR readiness is not configured")
 		return
 	}
@@ -2111,51 +2121,16 @@ func (h *SessionHandler) RunReadiness(w http.ResponseWriter, r *http.Request) {
 	if user := middleware.UserFromContext(r.Context()); user != nil {
 		triggeredByUserID = &user.ID
 	}
-	run, err := h.enqueuePRReadinessRun(r.Context(), orgID, session, triggeredByUserID)
+	run, err := h.readinessRunner.EnqueueRun(r.Context(), prreadinesssvc.EnqueueRunRequest{
+		OrgID:             orgID,
+		Session:           session,
+		TriggeredByUserID: triggeredByUserID,
+	})
 	if err != nil {
 		writeError(w, r, http.StatusInternalServerError, "READINESS_ENQUEUE_FAILED", "failed to enqueue PR readiness checks", err)
 		return
 	}
 	writeJSON(w, http.StatusAccepted, models.SingleResponse[models.PRReadinessRun]{Data: *run})
-}
-
-func (h *SessionHandler) enqueuePRReadinessRun(ctx context.Context, orgID uuid.UUID, session models.Session, triggeredByUserID *uuid.UUID) (*models.PRReadinessRun, error) {
-	// Return the existing run if one is already queued or running for this session
-	// to avoid creating orphaned runs that no worker will ever process.
-	existing, err := h.readinessStore.GetLatestBySession(ctx, orgID, session.ID)
-	if err == nil && existing != nil && (existing.Status == models.PRReadinessRunStatusQueued || existing.Status == models.PRReadinessRunStatusRunning) {
-		return existing, nil
-	}
-	if err != nil && !errors.Is(err, pgx.ErrNoRows) {
-		return nil, err
-	}
-	snapshotKey := stringPtrValue(session.SnapshotKey)
-	run := &models.PRReadinessRun{
-		OrgID:                      orgID,
-		SessionID:                  session.ID,
-		RepositoryID:               session.RepositoryID,
-		Status:                     models.PRReadinessRunStatusQueued,
-		EvaluatedWorkspaceRevision: session.WorkspaceGeneration,
-		EvaluatedSnapshotKey:       nil,
-		Summary:                    "Queued",
-	}
-	if snapshotKey != "" {
-		run.EvaluatedSnapshotKey = &snapshotKey
-	}
-	run.TriggeredByUserID = triggeredByUserID
-	if err := h.readinessStore.CreateRun(ctx, run); err != nil {
-		return nil, err
-	}
-	payload := map[string]string{
-		"org_id":       orgID.String(),
-		"session_id":   session.ID.String(),
-		"readiness_id": run.ID.String(),
-	}
-	dedupeKey := "pr_readiness:" + session.ID.String()
-	if _, err := h.jobStore.Enqueue(ctx, orgID, "agent", "run_pr_readiness", payload, 6, &dedupeKey); err != nil {
-		return nil, err
-	}
-	return run, nil
 }
 
 // maxReadinessReasonLength caps free-text reasons (bypass reason, issue-less
@@ -2686,7 +2661,7 @@ func (h *SessionHandler) CreatePR(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *SessionHandler) maybeAutoRunPRReadinessOnCreatePR(w http.ResponseWriter, r *http.Request, orgID uuid.UUID, session models.Session) bool {
-	if h.readinessStore == nil || h.jobStore == nil {
+	if h.readinessStore == nil || h.readinessRunner == nil {
 		return false
 	}
 	resolved, err := h.readinessStore.ResolvePolicy(r.Context(), orgID, session.RepositoryID)
@@ -2715,7 +2690,11 @@ func (h *SessionHandler) maybeAutoRunPRReadinessOnCreatePR(w http.ResponseWriter
 	if user := middleware.UserFromContext(r.Context()); user != nil {
 		userID = &user.ID
 	}
-	run, err := h.enqueuePRReadinessRun(r.Context(), orgID, session, userID)
+	run, err := h.readinessRunner.EnqueueRun(r.Context(), prreadinesssvc.EnqueueRunRequest{
+		OrgID:             orgID,
+		Session:           session,
+		TriggeredByUserID: userID,
+	})
 	if err != nil {
 		writeError(w, r, http.StatusInternalServerError, "READINESS_ENQUEUE_FAILED", "failed to enqueue PR readiness checks", err)
 		return true

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -44,6 +44,7 @@ import (
 	"github.com/assembledhq/143/internal/services/ownerloss"
 	pagerdutysvc "github.com/assembledhq/143/internal/services/pagerduty"
 	"github.com/assembledhq/143/internal/services/preview"
+	prreadinesssvc "github.com/assembledhq/143/internal/services/prreadiness"
 	"github.com/assembledhq/143/internal/services/reviewartifact"
 	reviewloopservice "github.com/assembledhq/143/internal/services/reviewloop"
 	"github.com/assembledhq/143/internal/services/sandbox"
@@ -348,6 +349,7 @@ func NewRouter(cfg *config.Config, pool *pgxpool.Pool, logger zerolog.Logger, se
 	sessionSandboxHolderStore := db.NewSessionSandboxHolderStore(pool)
 	reviewLoopStore := db.NewSessionReviewLoopStore(pool)
 	prReadinessStore := db.NewPRReadinessStore(pool)
+	prReadinessRunner := prreadinesssvc.NewService(prReadinessStore, jobStore)
 	codeReviewStore := db.NewCodeReviewStore(pool)
 	codeReviewSvc := codereviewsvc.NewService(codeReviewStore, codeReviewStore, sessionStore, jobStore, logger, codereviewsvc.Config{
 		AppReviewerLogins: cfg.CodeReviewAppReviewerLogins,
@@ -384,6 +386,7 @@ func NewRouter(cfg *config.Config, pool *pgxpool.Pool, logger zerolog.Logger, se
 	sessionHandler.SetReviewCommentStore(sessionReviewCommentStore)
 	sessionHandler.SetReviewLoopStore(reviewLoopStore)
 	sessionHandler.SetReadinessStore(prReadinessStore)
+	sessionHandler.SetReadinessRunner(prReadinessRunner)
 	if prService != nil {
 		prService.SetReadinessStore(prReadinessStore)
 	}

--- a/internal/services/prreadiness/service.go
+++ b/internal/services/prreadiness/service.go
@@ -1,0 +1,95 @@
+package prreadiness
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/assembledhq/143/internal/models"
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+)
+
+const (
+	runJobQueue    = "agent"
+	runJobType     = "run_pr_readiness"
+	runJobPriority = 6
+)
+
+type Store interface {
+	GetLatestBySession(ctx context.Context, orgID, sessionID uuid.UUID) (*models.PRReadinessRun, error)
+	CreateRun(ctx context.Context, run *models.PRReadinessRun) error
+}
+
+type JobStore interface {
+	Enqueue(ctx context.Context, orgID uuid.UUID, queue, jobType string, payload any, priority int, dedupeKey *string) (uuid.UUID, error)
+}
+
+type Service struct {
+	store Store
+	jobs  JobStore
+}
+
+func NewService(store Store, jobs JobStore) *Service {
+	return &Service{store: store, jobs: jobs}
+}
+
+type EnqueueRunRequest struct {
+	OrgID             uuid.UUID
+	Session           models.Session
+	TriggeredByUserID *uuid.UUID
+}
+
+func (s *Service) EnqueueRun(ctx context.Context, req EnqueueRunRequest) (*models.PRReadinessRun, error) {
+	if s == nil || s.store == nil || s.jobs == nil {
+		return nil, fmt.Errorf("PR readiness service is not configured")
+	}
+	sessionID := req.Session.ID
+	if req.OrgID == uuid.Nil || sessionID == uuid.Nil {
+		return nil, fmt.Errorf("org_id and session_id are required")
+	}
+
+	existing, err := s.store.GetLatestBySession(ctx, req.OrgID, sessionID)
+	if err == nil && existing != nil && isQueuedOrRunning(existing.Status) {
+		return existing, nil
+	}
+	if err != nil && !errors.Is(err, pgx.ErrNoRows) {
+		return nil, err
+	}
+
+	run := &models.PRReadinessRun{
+		OrgID:                      req.OrgID,
+		SessionID:                  sessionID,
+		RepositoryID:               req.Session.RepositoryID,
+		Status:                     models.PRReadinessRunStatusQueued,
+		EvaluatedWorkspaceRevision: req.Session.WorkspaceGeneration,
+		Summary:                    "Queued",
+		TriggeredByUserID:          req.TriggeredByUserID,
+	}
+	if req.Session.SnapshotKey != nil && *req.Session.SnapshotKey != "" {
+		snapshotKey := *req.Session.SnapshotKey
+		run.EvaluatedSnapshotKey = &snapshotKey
+	}
+	if err := s.store.CreateRun(ctx, run); err != nil {
+		return nil, err
+	}
+
+	payload := map[string]string{
+		"org_id":       req.OrgID.String(),
+		"session_id":   sessionID.String(),
+		"readiness_id": run.ID.String(),
+	}
+	dedupeKey := DedupeKey(sessionID)
+	if _, err := s.jobs.Enqueue(ctx, req.OrgID, runJobQueue, runJobType, payload, runJobPriority, &dedupeKey); err != nil {
+		return nil, err
+	}
+	return run, nil
+}
+
+func DedupeKey(sessionID uuid.UUID) string {
+	return "pr_readiness:" + sessionID.String()
+}
+
+func isQueuedOrRunning(status models.PRReadinessRunStatus) bool {
+	return status == models.PRReadinessRunStatusQueued || status == models.PRReadinessRunStatusRunning
+}

--- a/internal/services/prreadiness/service_test.go
+++ b/internal/services/prreadiness/service_test.go
@@ -1,0 +1,214 @@
+package prreadiness
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/assembledhq/143/internal/models"
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/stretchr/testify/require"
+)
+
+func TestService_EnqueueRun(t *testing.T) {
+	t.Parallel()
+
+	errLatest := errors.New("latest failed")
+	errEnqueue := errors.New("enqueue failed")
+	orgID := uuid.New()
+	sessionID := uuid.New()
+	repositoryID := uuid.New()
+	userID := uuid.New()
+	snapshotKey := "snapshot.tar.zst"
+
+	tests := []struct {
+		name           string
+		latest         *models.PRReadinessRun
+		latestErr      error
+		enqueueErr     error
+		expectErr      error
+		expectExisting bool
+		expectEnqueue  bool
+	}{
+		{
+			name: "returns existing queued run",
+			latest: &models.PRReadinessRun{
+				ID:        uuid.New(),
+				OrgID:     orgID,
+				SessionID: sessionID,
+				Status:    models.PRReadinessRunStatusQueued,
+			},
+			expectExisting: true,
+		},
+		{
+			name: "returns existing running run",
+			latest: &models.PRReadinessRun{
+				ID:        uuid.New(),
+				OrgID:     orgID,
+				SessionID: sessionID,
+				Status:    models.PRReadinessRunStatusRunning,
+			},
+			expectExisting: true,
+		},
+		{
+			name:          "creates run and enqueues job when no run exists",
+			latestErr:     pgx.ErrNoRows,
+			expectEnqueue: true,
+		},
+		{
+			name: "creates run and enqueues job after terminal run",
+			latest: &models.PRReadinessRun{
+				ID:        uuid.New(),
+				OrgID:     orgID,
+				SessionID: sessionID,
+				Status:    models.PRReadinessRunStatusPassed,
+			},
+			expectEnqueue: true,
+		},
+		{
+			name:      "returns latest lookup error",
+			latestErr: errLatest,
+			expectErr: errLatest,
+		},
+		{
+			name:          "returns enqueue error after creating run",
+			latestErr:     pgx.ErrNoRows,
+			enqueueErr:    errEnqueue,
+			expectErr:     errEnqueue,
+			expectEnqueue: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			store := &fakeStore{latest: tt.latest, latestErr: tt.latestErr, nextID: uuid.New()}
+			jobs := &fakeJobStore{err: tt.enqueueErr}
+			svc := NewService(store, jobs)
+			session := models.Session{
+				ID:                  sessionID,
+				OrgID:               orgID,
+				RepositoryID:        &repositoryID,
+				WorkspaceGeneration: 42,
+				SnapshotKey:         &snapshotKey,
+			}
+
+			run, err := svc.EnqueueRun(context.Background(), EnqueueRunRequest{
+				OrgID:             orgID,
+				Session:           session,
+				TriggeredByUserID: &userID,
+			})
+			if tt.expectErr != nil {
+				require.ErrorIs(t, err, tt.expectErr, "EnqueueRun should return the expected error")
+				if tt.expectEnqueue {
+					require.Len(t, store.created, 1, "EnqueueRun should create the readiness run before returning an enqueue error")
+					require.Len(t, jobs.enqueued, 1, "EnqueueRun should attempt to enqueue the worker job before returning an enqueue error")
+				}
+				return
+			}
+			require.NoError(t, err, "EnqueueRun should succeed")
+			require.NotNil(t, run, "EnqueueRun should return a run")
+
+			if tt.expectExisting {
+				require.Same(t, tt.latest, run, "EnqueueRun should return the existing queued or running run")
+				require.Empty(t, store.created, "EnqueueRun should not create another run")
+				require.Empty(t, jobs.enqueued, "EnqueueRun should not enqueue another job")
+				return
+			}
+
+			require.Len(t, store.created, 1, "EnqueueRun should create exactly one readiness run")
+			created := store.created[0]
+			require.Equal(t, store.nextID, created.ID, "EnqueueRun should return the persisted run ID")
+			require.Equal(t, orgID, created.OrgID, "created run should be scoped to the org")
+			require.Equal(t, sessionID, created.SessionID, "created run should target the requested session")
+			require.Equal(t, &repositoryID, created.RepositoryID, "created run should retain repository scope")
+			require.Equal(t, models.PRReadinessRunStatusQueued, created.Status, "created run should start queued")
+			require.Equal(t, int64(42), created.EvaluatedWorkspaceRevision, "created run should capture workspace revision")
+			require.Equal(t, &snapshotKey, created.EvaluatedSnapshotKey, "created run should capture snapshot key")
+			require.Equal(t, "Queued", created.Summary, "created run should use the queued summary")
+			require.Equal(t, &userID, created.TriggeredByUserID, "created run should preserve nullable user attribution")
+			if tt.expectEnqueue {
+				require.Len(t, jobs.enqueued, 1, "EnqueueRun should enqueue exactly one worker job")
+				enqueued := jobs.enqueued[0]
+				require.Equal(t, orgID, enqueued.orgID, "job should be scoped to the org")
+				require.Equal(t, runJobQueue, enqueued.queue, "job should use the readiness queue")
+				require.Equal(t, runJobType, enqueued.jobType, "job should use the readiness job type")
+				require.Equal(t, runJobPriority, enqueued.priority, "job should use the readiness priority")
+				require.NotNil(t, enqueued.dedupeKey, "job should include a dedupe key")
+				require.Equal(t, DedupeKey(sessionID), *enqueued.dedupeKey, "job should dedupe by session")
+				require.Equal(t, map[string]string{
+					"org_id":       orgID.String(),
+					"session_id":   sessionID.String(),
+					"readiness_id": created.ID.String(),
+				}, enqueued.payload, "job payload should identify the readiness run")
+			}
+		})
+	}
+}
+
+func TestService_EnqueueRunRejectsMissingDependencies(t *testing.T) {
+	t.Parallel()
+
+	_, err := (*Service)(nil).EnqueueRun(context.Background(), EnqueueRunRequest{})
+	require.Error(t, err, "nil service should reject enqueue requests")
+
+	svc := NewService(nil, nil)
+	_, err = svc.EnqueueRun(context.Background(), EnqueueRunRequest{})
+	require.Error(t, err, "service without stores should reject enqueue requests")
+}
+
+type fakeStore struct {
+	latest    *models.PRReadinessRun
+	latestErr error
+	nextID    uuid.UUID
+	created   []*models.PRReadinessRun
+}
+
+func (s *fakeStore) GetLatestBySession(context.Context, uuid.UUID, uuid.UUID) (*models.PRReadinessRun, error) {
+	return s.latest, s.latestErr
+}
+
+func (s *fakeStore) CreateRun(_ context.Context, run *models.PRReadinessRun) error {
+	run.ID = s.nextID
+	now := time.Now()
+	run.StartedAt = now
+	run.CreatedAt = now
+	run.UpdatedAt = now
+	copyRun := *run
+	s.created = append(s.created, &copyRun)
+	return nil
+}
+
+type enqueuedJob struct {
+	orgID     uuid.UUID
+	queue     string
+	jobType   string
+	payload   any
+	priority  int
+	dedupeKey *string
+}
+
+type fakeJobStore struct {
+	err      error
+	enqueued []enqueuedJob
+}
+
+func (s *fakeJobStore) Enqueue(_ context.Context, orgID uuid.UUID, queue, jobType string, payload any, priority int, dedupeKey *string) (uuid.UUID, error) {
+	var dedupeCopy *string
+	if dedupeKey != nil {
+		value := *dedupeKey
+		dedupeCopy = &value
+	}
+	s.enqueued = append(s.enqueued, enqueuedJob{
+		orgID:     orgID,
+		queue:     queue,
+		jobType:   jobType,
+		payload:   payload,
+		priority:  priority,
+		dedupeKey: dedupeCopy,
+	})
+	return uuid.New(), s.err
+}


### PR DESCRIPTION
## Summary

PR readiness enqueueing logic was hard to reuse across session automation phases, creating a developer pain point and a reliability risk if the same behavior is reimplemented in multiple handlers. This change introduces a reusable backend readiness service and wires it into the session API so future “clean-loop” auto-readiness can be added without altering runtime behavior.

## Changes

- Add a dedicated `prreadiness` service contract (e.g., `EnqueueRun`) and inject it into `SessionHandler` via a `SetReadinessRunner` hook.
- Update the sessions API wiring to call the readiness service runner instead of embedding enqueue logic in handler-specific code paths.
- Implement the PR readiness service and expand its unit tests to cover the new reusable enqueue behavior.
- Update the design doc to reflect Phase 1–2 completion and clarify that the next step (Phase 3) will build on the extracted service.

## Validation

- Ran `go test ./...`, including `internal/services/prreadiness/service_test.go`, to confirm the service contract and enqueue behavior work as expected.
- Verified no runtime behavior changes prior to Phase 3 by keeping existing configuration/behavior gates intact and focusing this PR on refactoring + reusable wiring.

[143.dev](https://143.dev) | [session 18488857](https://143.dev/sessions/18488857-1f62-4ba5-a6b6-f032727386ea)

<!-- 143 readiness -->
**143 readiness:** not available for this revision.

Preview: https://143.dev/previews/github/assembledhq/143/pull/1685?launch=1