### PR TITLE
Add supporting “best agent / open-source / bundled savings” messaging to landing Integrations section

### DIFF
--- a/frontend/src/components/landing/integrations-section.test.tsx
+++ b/frontend/src/components/landing/integrations-section.test.tsx
@@ -15,4 +15,17 @@ describe("IntegrationsSection", () => {
     expect(heading.className).toContain(landingTypography.featureTitle);
     expect(heading.className).not.toContain(landingTypography.sectionTitle);
   });
+
+  it("shows agent choice and cost controls as supporting features", () => {
+    render(<IntegrationsSection isDark={false} />);
+
+    expect(
+      screen.getByRole("heading", {
+        level: 3,
+        name: "Use the best agent for the job",
+      }),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/open-source models/i)).toBeInTheDocument();
+    expect(screen.getByText(/bundled coding-agent subscriptions/i)).toBeInTheDocument();
+  });
 });

--- a/frontend/src/components/landing/integrations-section.tsx
+++ b/frontend/src/components/landing/integrations-section.tsx
@@ -2,7 +2,11 @@
 
 import Image from "next/image";
 import { Card, CardContent } from "@/components/ui/card";
-import { codingAgents, integrations } from "./landing-copy";
+import {
+  agentChoiceHighlights,
+  codingAgents,
+  integrations,
+} from "./landing-copy";
 import { landingTypography as type } from "./landing-typography";
 
 interface IntegrationsSectionProps {
@@ -85,6 +89,34 @@ export default function IntegrationsSection({
         </div>
 
         <div className="mt-14">{renderGrid(codingAgents)}</div>
+
+        <div
+          className={`mt-8 grid gap-3 rounded-lg border p-3 md:grid-cols-3 ${
+            isDark
+              ? "border-white/10 bg-white/[0.03]"
+              : "border-slate-200 bg-white/60"
+          }`}
+        >
+          {agentChoiceHighlights.map((highlight) => (
+            <Card
+              key={highlight.title}
+              className={isDark ? "bg-[#0d0d15]" : "bg-white/80"}
+            >
+              <CardContent className="p-5">
+                <h3
+                  className={`${type.cardTitle} ${
+                    isDark ? "text-white/85" : "text-slate-900"
+                  }`}
+                >
+                  {highlight.title}
+                </h3>
+                <p className={`mt-4 ${type.body} ${body}`}>
+                  {highlight.body}
+                </p>
+              </CardContent>
+            </Card>
+          ))}
+        </div>
 
         <div className="mt-24 grid gap-8 lg:grid-cols-[0.38fr_0.62fr] lg:items-end">
           <p className={`${type.eyebrow} ${label}`}>08 Integrations</p>

--- a/frontend/src/components/landing/landing-copy.test.ts
+++ b/frontend/src/components/landing/landing-copy.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from "vitest";
 import * as landingCopy from "./landing-copy";
-import { codingAgents, integrations, platformLayers } from "./landing-copy";
+import {
+  agentChoiceHighlights,
+  codingAgents,
+  integrations,
+  platformLayers,
+} from "./landing-copy";
 
 describe("landing copy", () => {
   it("keeps hero copy focused instead of exposing summary cards", () => {
@@ -36,6 +41,19 @@ describe("landing copy", () => {
       "Amp:/agents/amp.svg",
       "Pi:/agents/pi.svg",
       "OpenCode:/agents/opencode.svg",
+    ]);
+  });
+
+  it("positions model flexibility as a supporting coding-agent feature", () => {
+    expect(agentChoiceHighlights.map((highlight) => highlight.title)).toEqual([
+      "Use the best agent for the job",
+      "Keep routine work economical",
+      "Stack subscriptions before metered spend",
+    ]);
+    expect(agentChoiceHighlights.map((highlight) => highlight.body)).toEqual([
+      "Run top-tier tools like Claude Code and Codex when the task needs maximum capability.",
+      "Route lighter jobs through OpenCode and open-source models when cost matters more than peak reasoning.",
+      "Layer personal, team, and bundled coding-agent subscriptions so available seats are used before extra usage piles up.",
     ]);
   });
 

--- a/frontend/src/components/landing/landing-copy.ts
+++ b/frontend/src/components/landing/landing-copy.ts
@@ -76,6 +76,21 @@ export const codingAgents = [
   },
 ];
 
+export const agentChoiceHighlights = [
+  {
+    title: "Use the best agent for the job",
+    body: "Run top-tier tools like Claude Code and Codex when the task needs maximum capability.",
+  },
+  {
+    title: "Keep routine work economical",
+    body: "Route lighter jobs through OpenCode and open-source models when cost matters more than peak reasoning.",
+  },
+  {
+    title: "Stack subscriptions before metered spend",
+    body: "Layer personal, team, and bundled coding-agent subscriptions so available seats are used before extra usage piles up.",
+  },
+];
+
 export const integrations = [
   {
     name: "GitHub",


### PR DESCRIPTION
## Summary

The landing page previously didn’t clearly communicate how users should choose between coding agents (including open-source options and bundled savings), leaving a messaging gap in the “Run any coding agent” workflow. This change adds the guidance as supporting cards under the existing agent area (rather than hero copy), reducing cognitive load while making the tradeoffs obvious.

## Changes

- Added `agentChoiceHighlights` copy to `landing-copy.ts` and used it to render three supporting cards in `integrations-section.tsx`.
- Extended `IntegrationsSection` to display the agent choice, open-source models, and bundled subscription savings messaging with light/dark styling parity.
- Added/updated tests to lock in the new card titles and supporting text content (`landing-copy.test.ts`, `integrations-section.test.tsx`) so regressions are caught in CI.

## Validation

- `npm run test:ci -- landing-copy.test.ts integrations-section.test.tsx`
- `npx eslint src/components/landing/landing-copy.ts src/components/landing/landing-copy.test.ts src/components/landing/integrations-section.tsx src/components/landing/integrations-section.test.tsx`
- Manual check: verified homepage rendering shows the new supporting messaging under the agent grid.

[143.dev](https://143.dev) | [session 6dfb2e9f](https://143.dev/sessions/6dfb2e9f-bd62-4d80-b141-b17329b91463)

<!-- 143 readiness -->
**143 readiness:** not available for this revision.

Preview: https://143.dev/previews/github/assembledhq/143/pull/1687?launch=1