### PR TITLE
Replace code reviews Refresh button with live SSE updates

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -188,6 +188,13 @@ func main() {
 	// publishEvalBatchSignal helper skips publish.
 	evalBatchStreams := cache.NewEvalBatchStreams(redisClient, logger)
 	evalBootstrapStreams := cache.NewEvalBootstrapStreams(redisClient, logger)
+	// Org-scoped code review pub/sub fanout. The worker publishes lifecycle
+	// changes here as it runs reviews; the API subscribes for the live code
+	// reviews list. nil-safe when redisClient is nil (publish becomes a no-op).
+	codeReviewStreams := cache.NewCodeReviewStreams(redisClient, logger)
+	codeReviewStore := db.NewCodeReviewStore(pool)
+	codeReviewStore.SetStreams(codeReviewStreams)
+	codeReviewStore.SetLogger(logger)
 
 	// Create codex auth service (shared between router and orchestrator).
 	var cryptoSvc *crypto.Service
@@ -487,7 +494,7 @@ func main() {
 			AutomationRuns:      automationRunStore,
 			ReviewLoops:         db.NewSessionReviewLoopStore(pool),
 			PRReadiness:         db.NewPRReadinessStore(pool),
-			CodeReviews:         db.NewCodeReviewStore(pool),
+			CodeReviews:         codeReviewStore,
 			SessionIssueLinks:   db.NewSessionIssueLinkStore(pool),
 			Previews:            previewStore,
 			PullRequests:        pullRequestStore,

--- a/cmd/server/session_executor_main.go
+++ b/cmd/server/session_executor_main.go
@@ -172,6 +172,12 @@ func buildSessionExecutorRuntime(ctx context.Context, cfg *config.Config, pool *
 		sessionLogStore.SetStreams(sessionStreams)
 		sessionThreadStore.SetStreams(sessionStreams)
 	}
+	// Code review lifecycle fanout so reviews run by the executor refresh the
+	// live code reviews list. nil-safe when redisClient is unavailable.
+	codeReviewStreams := cache.NewCodeReviewStreams(redisClient, logger)
+	codeReviewStore := db.NewCodeReviewStore(pool)
+	codeReviewStore.SetStreams(codeReviewStreams)
+	codeReviewStore.SetLogger(logger)
 
 	containerUsageStore := db.NewContainerUsageStore(pool)
 	billingMetrics, err := metrics.NewBillingMetrics(containerUsageStore.CountActive)
@@ -300,6 +306,7 @@ func buildSessionExecutorRuntime(ctx context.Context, cfg *config.Config, pool *
 		SessionThreads:      sessionThreadStore,
 		AutomationRuns:      automationRunStore,
 		PullRequests:        pullRequestStore,
+		CodeReviews:         codeReviewStore,
 	})
 	if services.LinearAgentDeps != nil {
 		services.LinearAgentDeps.Stores = stores
@@ -344,6 +351,7 @@ type sessionExecutorStoreDeps struct {
 	SessionThreads      *db.SessionThreadStore
 	AutomationRuns      *db.AutomationRunStore
 	PullRequests        *db.PullRequestStore
+	CodeReviews         *db.CodeReviewStore
 }
 
 func buildSessionExecutorStores(deps sessionExecutorStoreDeps) *worker.Stores {
@@ -399,6 +407,9 @@ func buildSessionExecutorStores(deps sessionExecutorStoreDeps) *worker.Stores {
 	if deps.PullRequests == nil {
 		deps.PullRequests = db.NewPullRequestStore(pool)
 	}
+	if deps.CodeReviews == nil {
+		deps.CodeReviews = db.NewCodeReviewStore(pool)
+	}
 	return &worker.Stores{
 		Issues:              deps.Issues,
 		Sessions:            deps.Sessions,
@@ -431,7 +442,7 @@ func buildSessionExecutorStores(deps sessionExecutorStoreDeps) *worker.Stores {
 		AutomationRuns:      deps.AutomationRuns,
 		ReviewLoops:         db.NewSessionReviewLoopStore(pool),
 		PRReadiness:         db.NewPRReadinessStore(pool),
-		CodeReviews:         db.NewCodeReviewStore(pool),
+		CodeReviews:         deps.CodeReviews,
 		SessionIssueLinks:   db.NewSessionIssueLinkStore(pool),
 		Previews:            db.NewPreviewStore(pool),
 		PullRequests:        deps.PullRequests,

--- a/frontend/src/app/(dashboard)/code-reviews/page.test.tsx
+++ b/frontend/src/app/(dashboard)/code-reviews/page.test.tsx
@@ -1,8 +1,19 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import { http, HttpResponse } from "msw";
 import { renderWithProviders, screen, userEvent, waitFor } from "@/test/test-utils";
 import { server } from "@/test/mocks/server";
 import CodeReviewsPage from "./page";
+
+// jsdom has no EventSource; stub the SSE hook so the live-refresh subscription
+// is a no-op in tests (the list refreshes via React Query as usual). Mirrors
+// the eval batch page test.
+vi.mock("@/lib/use-resource-sse", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/use-resource-sse")>("@/lib/use-resource-sse");
+  return {
+    ...actual,
+    useResourceSSE: () => ({ healthy: true }),
+  };
+});
 import type {
   CodeReviewEvidence,
   CodeReviewGitHubTriggerResponse,

--- a/frontend/src/app/(dashboard)/code-reviews/page.tsx
+++ b/frontend/src/app/(dashboard)/code-reviews/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Link from "next/link";
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { ComponentProps, ReactNode } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { ClipboardCheck, ChevronDown, ExternalLink, Settings2, Plus, Trash2, FileSearch, Users, ShieldCheck, AlertTriangle } from "lucide-react";
@@ -60,6 +60,8 @@ const ALL_DECISIONS = "all";
 const ALL_RISKS = "all";
 const ALL_STATUSES = "all";
 const NO_TEMPLATE = "none";
+// Coalesce a burst of SSE lifecycle events into a single list refetch.
+const CODE_REVIEW_INVALIDATE_COALESCE_MS = 300;
 const APPLICABILITY_KIND_LABELS: Record<CodeReviewDescriptionApplicabilityKind, string> = {
   all: "All PRs",
   nontrivial: "Nontrivial",
@@ -151,9 +153,23 @@ export default function CodeReviewsPage() {
     const apiBase = process.env.NEXT_PUBLIC_API_URL || "";
     return buildCodeReviewStreamURL(apiBase, getActiveOrgId());
   }, []);
+  // A single review lifecycle emits several events (queued → running →
+  // completed), and a batch-stale transition can fan out across the org — so
+  // coalesce bursts into one refetch per window rather than one per event.
+  const invalidateTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const onCodeReviewEvent = useCallback(() => {
-    void queryClient.invalidateQueries({ queryKey: queryKeys.codeReviews.lists() });
+    if (invalidateTimerRef.current) return;
+    invalidateTimerRef.current = setTimeout(() => {
+      invalidateTimerRef.current = null;
+      void queryClient.invalidateQueries({ queryKey: queryKeys.codeReviews.lists() });
+    }, pollMs(CODE_REVIEW_INVALIDATE_COALESCE_MS));
   }, [queryClient]);
+  useEffect(
+    () => () => {
+      if (invalidateTimerRef.current) clearTimeout(invalidateTimerRef.current);
+    },
+    [],
+  );
   const { healthy: codeReviewStreamHealthy } = useResourceSSE({
     url: codeReviewStreamURL,
     event: SSE_EVENT.CODE_REVIEW_UPDATED,

--- a/frontend/src/app/(dashboard)/code-reviews/page.tsx
+++ b/frontend/src/app/(dashboard)/code-reviews/page.tsx
@@ -1,10 +1,10 @@
 "use client";
 
 import Link from "next/link";
-import { useMemo, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 import type { ComponentProps, ReactNode } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { ClipboardCheck, ChevronDown, ExternalLink, Settings2, RefreshCw, Plus, Trash2, FileSearch, Users, ShieldCheck, AlertTriangle } from "lucide-react";
+import { ClipboardCheck, ChevronDown, ExternalLink, Settings2, Plus, Trash2, FileSearch, Users, ShieldCheck, AlertTriangle } from "lucide-react";
 import { PageHeader } from "@/components/page-header";
 import { EmptyState } from "@/components/empty-state";
 import { Button } from "@/components/ui/button";
@@ -33,6 +33,10 @@ import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 import { ApiError, api } from "@/lib/api";
 import { queryKeys } from "@/lib/query-keys";
+import { getActiveOrgId } from "@/lib/active-org";
+import { buildCodeReviewStreamURL, SSE_EVENT } from "@/lib/sse";
+import { useResourceSSE } from "@/lib/use-resource-sse";
+import { pollMs } from "@/lib/poll-intervals";
 import { useAutosave, type UseAutosaveResult } from "@/hooks/useAutosave";
 import { useAutosaveNumericField } from "@/hooks/useAutosaveNumericField";
 import { useDebouncedTextField } from "@/hooks/useDebouncedTextField";
@@ -134,9 +138,31 @@ export default function CodeReviewsPage() {
     queryKey: queryKeys.repositories.all,
     queryFn: () => api.repositories.list(),
   });
+  // The reviews list refreshes live via the org-scoped SSE stream below; the
+  // polling backstop only kicks in (faster) while the stream is unhealthy so a
+  // Redis hiccup still surfaces new reviews. Replaces the old manual Refresh
+  // button — mirrors the eval batch/bootstrap stream pattern.
+  //
+  // The URL is pinned to the org active at mount (empty deps) on purpose: the
+  // only org→org switch path (org-switcher) navigates away to /sessions and
+  // replaces the QueryClient (see providers.tsx), so this page never stays
+  // mounted across an org change — there's nothing to react to here.
+  const codeReviewStreamURL = useMemo(() => {
+    const apiBase = process.env.NEXT_PUBLIC_API_URL || "";
+    return buildCodeReviewStreamURL(apiBase, getActiveOrgId());
+  }, []);
+  const onCodeReviewEvent = useCallback(() => {
+    void queryClient.invalidateQueries({ queryKey: queryKeys.codeReviews.lists() });
+  }, [queryClient]);
+  const { healthy: codeReviewStreamHealthy } = useResourceSSE({
+    url: codeReviewStreamURL,
+    event: SSE_EVENT.CODE_REVIEW_UPDATED,
+    onEvent: onCodeReviewEvent,
+  });
   const reviewsQuery = useQuery({
     queryKey: queryKeys.codeReviews.list(reviewFilters),
     queryFn: () => api.codeReviews.list(reviewFilters),
+    refetchInterval: codeReviewStreamHealthy ? pollMs(30_000) : pollMs(5_000),
   });
   const policyQuery = useQuery({
     queryKey: queryKeys.codeReviews.policy(repositoryId ?? null),
@@ -240,12 +266,6 @@ export default function CodeReviewsPage() {
         <PageHeader
           title="Code reviews"
           description="Bot-requested PR reviews, acceptable-risk policy, and review outcomes."
-          action={
-            <Button variant="outline" size="sm" onClick={() => reviewsQuery.refetch()}>
-              <RefreshCw className="h-4 w-4" />
-              Refresh
-            </Button>
-          }
         />
 
         <div className="grid gap-3 md:grid-cols-[minmax(12rem,18rem)_minmax(10rem,12rem)_minmax(10rem,12rem)_minmax(10rem,12rem)_1fr]">

--- a/frontend/src/app/(dashboard)/settings/evals/batch/[id]/page.test.tsx
+++ b/frontend/src/app/(dashboard)/settings/evals/batch/[id]/page.test.tsx
@@ -14,11 +14,11 @@ vi.mock("next/navigation", () => ({
   useParams: () => ({ id: "batch-1" }),
 }));
 
-vi.mock("@/lib/use-eval-sse", async () => {
-  const actual = await vi.importActual<typeof import("@/lib/use-eval-sse")>("@/lib/use-eval-sse");
+vi.mock("@/lib/use-resource-sse", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/use-resource-sse")>("@/lib/use-resource-sse");
   return {
     ...actual,
-    useEvalSSE: () => ({ healthy: true }),
+    useResourceSSE: () => ({ healthy: true }),
   };
 });
 

--- a/frontend/src/app/(dashboard)/settings/evals/batch/[id]/page.tsx
+++ b/frontend/src/app/(dashboard)/settings/evals/batch/[id]/page.tsx
@@ -8,7 +8,8 @@ import { api } from "@/lib/api";
 import { queryKeys } from "@/lib/query-keys";
 import { getActiveOrgId } from "@/lib/active-org";
 import { buildEvalBatchStreamURL, SSE_EVENT } from "@/lib/sse";
-import { shouldSubscribeToEvalBatchStream, useEvalSSE } from "@/lib/use-eval-sse";
+import { shouldSubscribeToEvalBatchStream } from "@/lib/eval-streams";
+import { useResourceSSE } from "@/lib/use-resource-sse";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import { PageContainer } from "@/components/page-container";
@@ -23,7 +24,7 @@ import { evalRunStatusConfig } from "@/lib/types";
 // blip on the publish side, subscription disconnect that re-establishes
 // after the missed event) without doing anything close to the prior 5s
 // load on Postgres. When SSE itself is unavailable (Redis down) we drop
-// back to the original 5s cadence — see streamHealthy from useEvalSSE.
+// back to the original 5s cadence — see streamHealthy from useResourceSSE.
 const SSE_BACKSTOP_POLL_MS = 30_000;
 const SSE_DOWN_POLL_MS = 5_000;
 
@@ -48,7 +49,7 @@ export default function BatchDetailPage() {
   const onBatchEvent = useCallback(() => {
     queryClient.invalidateQueries({ queryKey: queryKeys.evals.batch(batchId) });
   }, [queryClient, batchId]);
-  const { healthy: streamHealthy } = useEvalSSE({
+  const { healthy: streamHealthy } = useResourceSSE({
     url: sseURL,
     event: SSE_EVENT.EVAL_BATCH_UPDATED,
     onEvent: onBatchEvent,

--- a/frontend/src/app/(dashboard)/settings/evals/page.tsx
+++ b/frontend/src/app/(dashboard)/settings/evals/page.tsx
@@ -43,7 +43,8 @@ import type { EvalTask, EvalBatch, EvalTaskSource, EvalBootstrapRun, EvalBootstr
 import { evalComplexityConfig, evalSourceConfig } from "@/lib/types";
 import { formatDateTime } from "@/lib/utils";
 import { addSSEListener, SSE_EVENT, buildEvalBootstrapStreamURL, buildSessionLogsStreamURL } from "@/lib/sse";
-import { shouldSubscribeToEvalBootstrapStream, useEvalSSE } from "@/lib/use-eval-sse";
+import { shouldSubscribeToEvalBootstrapStream } from "@/lib/eval-streams";
+import { useResourceSSE } from "@/lib/use-resource-sse";
 import { getActiveOrgId } from "@/lib/active-org";
 
 type SourceFilter = "all" | EvalTaskSource | "archived";
@@ -148,7 +149,7 @@ export default function EvalsSettingsPage() {
     if (!effectiveBootstrapRunId) return;
     queryClient.invalidateQueries({ queryKey: queryKeys.evals.bootstrapRun(effectiveBootstrapRunId) });
   }, [queryClient, effectiveBootstrapRunId]);
-  const { healthy: bootstrapStreamHealthy } = useEvalSSE({
+  const { healthy: bootstrapStreamHealthy } = useResourceSSE({
     url: bootstrapSSEURL,
     event: SSE_EVENT.EVAL_BOOTSTRAP_UPDATED,
     onEvent: onBootstrapEvent,

--- a/frontend/src/lib/eval-streams.test.ts
+++ b/frontend/src/lib/eval-streams.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   shouldSubscribeToEvalBatchStream,
   shouldSubscribeToEvalBootstrapStream,
-} from "./use-eval-sse";
+} from "./eval-streams";
 
 describe("eval SSE stream subscription gating", () => {
   it("keeps batch streams only for active batch statuses", () => {

--- a/frontend/src/lib/eval-streams.ts
+++ b/frontend/src/lib/eval-streams.ts
@@ -1,0 +1,13 @@
+import type { EvalBatchStatus, EvalBootstrapStatus } from "./types";
+
+// Eval-specific gating for the shared SSE hook (useResourceSSE): only keep a
+// stream open while the batch/bootstrap run is still in flight. Terminal runs
+// emit no further events, so the calling page drops to its polling cadence.
+
+export function shouldSubscribeToEvalBatchStream(status: EvalBatchStatus | undefined): boolean {
+  return status === "pending" || status === "running";
+}
+
+export function shouldSubscribeToEvalBootstrapStream(status: EvalBootstrapStatus | undefined): boolean {
+  return status === "pending" || status === "running";
+}

--- a/frontend/src/lib/query-keys.ts
+++ b/frontend/src/lib/query-keys.ts
@@ -43,6 +43,7 @@ export const queryKeys = {
   },
   codeReviews: {
     all: ["code-reviews"] as const,
+    lists: () => ["code-reviews", "list"] as const,
     list: (params?: unknown) => ["code-reviews", "list", params ?? null] as const,
     policy: (repositoryId?: string | null) => ["code-reviews", "policy", repositoryId ?? null] as const,
     githubTrigger: (repositoryId?: string | null) => ["code-reviews", "github-trigger", repositoryId ?? null] as const,

--- a/frontend/src/lib/sse.test.ts
+++ b/frontend/src/lib/sse.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import { addSSEListener, SSE_EVENT } from "./sse";
+import { addSSEListener, buildCodeReviewStreamURL, SSE_EVENT } from "./sse";
 
 /** Minimal mock that captures handlers like a real EventSource. */
 function createMockEventSource() {
@@ -144,9 +144,24 @@ describe("SSE_EVENT constants", () => {
     expect(SSE_EVENT.HUMAN_INPUT_CREATED).toBe("session_human_input.created");
     expect(SSE_EVENT.HUMAN_INPUT_UPDATED).toBe("session_human_input.updated");
     expect(SSE_EVENT.PULL_REQUEST_UPDATED).toBe("pull_request.updated");
+    expect(SSE_EVENT.CODE_REVIEW_UPDATED).toBe("code_review.updated");
     expect(SSE_EVENT.THREAD_INBOX_QUEUED).toBe("thread.inbox.queued");
     expect(SSE_EVENT.THREAD_INBOX_CLEARED).toBe("thread.inbox.cleared");
     expect(SSE_EVENT.THREAD_RUNTIME_UPDATED).toBe("thread.runtime.updated");
     expect(SSE_EVENT.SESSION_WORKSPACE_GENERATION_CHANGED).toBe("session.workspace.generation_changed");
+  });
+});
+
+describe("buildCodeReviewStreamURL", () => {
+  it("builds the stream URL with an org_id query param", () => {
+    expect(buildCodeReviewStreamURL("https://api.example.com", "org-123")).toBe(
+      "https://api.example.com/api/v1/code-reviews/stream?org_id=org-123",
+    );
+  });
+
+  it("omits the query string when there is no active org", () => {
+    expect(buildCodeReviewStreamURL("https://api.example.com", null)).toBe(
+      "https://api.example.com/api/v1/code-reviews/stream",
+    );
   });
 });

--- a/frontend/src/lib/sse.ts
+++ b/frontend/src/lib/sse.ts
@@ -1,4 +1,5 @@
 import type {
+  CodeReviewUpdatedEvent,
   EvalBatchUpdatedEvent,
   EvalBootstrapUpdatedEvent,
   PullRequestUpdatedEvent,
@@ -43,6 +44,21 @@ export function buildPullRequestStreamURL(
   }
   const qs = searchParams.toString();
   return `${apiBase}/api/v1/pull-requests/stream${qs ? `?${qs}` : ""}`;
+}
+
+// Org-scoped SSE that wakes whenever a code review row is created or changes
+// status/decision. Replaces the manual "Refresh" button on the code reviews
+// page. Same X-Active-Org-ID workaround as buildSessionLogsStreamURL.
+export function buildCodeReviewStreamURL(
+  apiBase: string,
+  activeOrgId: string | null,
+): string {
+  const searchParams = new URLSearchParams();
+  if (activeOrgId) {
+    searchParams.set("org_id", activeOrgId);
+  }
+  const qs = searchParams.toString();
+  return `${apiBase}/api/v1/code-reviews/stream${qs ? `?${qs}` : ""}`;
 }
 
 // Per-batch SSE that wakes whenever an eval batch or one of its runs flips
@@ -92,6 +108,8 @@ export const SSE_EVENT = {
   HUMAN_INPUT_UPDATED: "session_human_input.updated",
   /** Sent when a pull request health snapshot is updated. */
   PULL_REQUEST_UPDATED: "pull_request.updated",
+  /** Sent when a code review row is created or changes status/decision. */
+  CODE_REVIEW_UPDATED: "code_review.updated",
   /** Sent when an eval batch or one of its runs changes state. */
   EVAL_BATCH_UPDATED: "eval_batch.updated",
   /** Sent when an eval bootstrap run changes state. */
@@ -116,6 +134,7 @@ export interface SSEEventPayloads {
   [SSE_EVENT.HUMAN_INPUT_CREATED]: SessionLog;
   [SSE_EVENT.HUMAN_INPUT_UPDATED]: SessionLog;
   [SSE_EVENT.PULL_REQUEST_UPDATED]: PullRequestUpdatedEvent;
+  [SSE_EVENT.CODE_REVIEW_UPDATED]: CodeReviewUpdatedEvent;
   [SSE_EVENT.EVAL_BATCH_UPDATED]: EvalBatchUpdatedEvent;
   [SSE_EVENT.EVAL_BOOTSTRAP_UPDATED]: EvalBootstrapUpdatedEvent;
   [SSE_EVENT.THREAD_INBOX_QUEUED]: ThreadInboxEvent;

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -1980,6 +1980,14 @@ export interface PullRequestUpdatedEvent {
   synced_at: string;
 }
 
+export interface CodeReviewUpdatedEvent {
+  org_id: string;
+  session_id?: string;
+  status?: CodeReviewSessionStatus;
+  decision?: CodeReviewDecision;
+  updated_at: string;
+}
+
 export interface SessionReviewComment {
   id: string;
   session_id: string;

--- a/frontend/src/lib/use-resource-sse.ts
+++ b/frontend/src/lib/use-resource-sse.ts
@@ -3,34 +3,25 @@
 import { useEffect, useState } from "react";
 import { addSSEListener, type SSEEventPayloads } from "./sse";
 import { pollMs } from "./poll-intervals";
-import type { EvalBatchStatus, EvalBootstrapStatus } from "./types";
 
-// Connect cadence shared between the two eval SSE consumers (batch detail
-// page + bootstrap detail sheet). Capped exponential backoff (1s → 2s → 4s
-// → 8s → 15s ceiling) so a transient Redis outage doesn't burn into the
-// page lifecycle, but a sustained outage hands off to the polling backstop
-// in the calling component without retrying forever.
+// Connect cadence shared across SSE consumers (eval batch/bootstrap pages, the
+// code reviews list, …). Capped exponential backoff (1s → 2s → 4s → 8s → 15s
+// ceiling) so a transient Redis outage doesn't burn into the page lifecycle,
+// but a sustained outage hands off to the polling backstop in the calling
+// component without retrying forever.
 const SSE_INITIAL_RECONNECT_DELAY_MS = pollMs(1_000);
 const SSE_MAX_RECONNECT_DELAY_MS = 15_000;
 const SSE_MAX_RECONNECT_ATTEMPTS = 5;
 
-export function shouldSubscribeToEvalBatchStream(status: EvalBatchStatus | undefined): boolean {
-  return status === "pending" || status === "running";
-}
-
-export function shouldSubscribeToEvalBootstrapStream(status: EvalBootstrapStatus | undefined): boolean {
-  return status === "pending" || status === "running";
-}
-
-export interface UseEvalSSEOptions<K extends keyof SSEEventPayloads> {
+export interface UseResourceSSEOptions<K extends keyof SSEEventPayloads> {
   /**
-   * Fully-qualified SSE URL (typically built by buildEvalBatchStreamURL or
-   * buildEvalBootstrapStreamURL). Pass null when there's nothing to
-   * subscribe to (e.g. no active bootstrap run); the hook stays idle and
-   * the previous connection is torn down on transition.
+   * Fully-qualified SSE URL (typically built by one of the build*StreamURL
+   * helpers). Pass null when there's nothing to subscribe to (e.g. no active
+   * bootstrap run); the hook stays idle and the previous connection is torn
+   * down on transition.
    */
   url: string | null;
-  /** SSE event name to listen for, e.g. SSE_EVENT.EVAL_BATCH_UPDATED. */
+  /** SSE event name to listen for, e.g. SSE_EVENT.CODE_REVIEW_UPDATED. */
   event: K;
   /**
    * Fires on every received event. Typically just a queryClient.invalidate.
@@ -41,7 +32,7 @@ export interface UseEvalSSEOptions<K extends keyof SSEEventPayloads> {
   onEvent: (payload: SSEEventPayloads[K]) => void;
 }
 
-export interface UseEvalSSEResult {
+export interface UseResourceSSEResult {
   /**
    * True after EventSource.onopen fires; flips to false on any error so
    * callers can drive a faster polling backstop while Redis recovers.
@@ -53,16 +44,17 @@ export interface UseEvalSSEResult {
 }
 
 /**
- * useEvalSSE wires an EventSource for the eval batch / bootstrap SSE
- * channels with capped exponential reconnect and stream-health tracking.
- * Extracted so the batch detail page and the evals page share one
- * implementation — see batch/[id]/page.tsx and settings/evals/page.tsx.
+ * useResourceSSE wires an EventSource for a single org/resource-scoped SSE
+ * channel with capped exponential reconnect and stream-health tracking.
+ * Shared by the eval batch/bootstrap pages and the code reviews list — see
+ * settings/evals/batch/[id]/page.tsx, settings/evals/page.tsx, and
+ * code-reviews/page.tsx.
  */
-export function useEvalSSE<K extends keyof SSEEventPayloads>({
+export function useResourceSSE<K extends keyof SSEEventPayloads>({
   url,
   event,
   onEvent,
-}: UseEvalSSEOptions<K>): UseEvalSSEResult {
+}: UseResourceSSEOptions<K>): UseResourceSSEResult {
   const [healthy, setHealthy] = useState(true);
 
   useEffect(() => {

--- a/internal/api/handlers/code_reviews.go
+++ b/internal/api/handlers/code_reviews.go
@@ -1,25 +1,42 @@
 package handlers
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"net/http"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/assembledhq/143/internal/api/middleware"
+	"github.com/assembledhq/143/internal/api/sse"
+	"github.com/assembledhq/143/internal/cache"
 	"github.com/assembledhq/143/internal/db"
 	"github.com/assembledhq/143/internal/models"
 	codereviewsvc "github.com/assembledhq/143/internal/services/codereview"
 	"github.com/go-chi/chi/v5"
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
+	"github.com/rs/zerolog"
 )
+
+var (
+	errCodeReviewStreamOrgInvalid   = errors.New("invalid code review stream org")
+	errCodeReviewStreamOrgForbidden = errors.New("forbidden code review stream org")
+	errCodeReviewStreamUnauthorized = errors.New("unauthorized code review stream request")
+)
+
+type codeReviewMembershipStore interface {
+	Get(ctx context.Context, userID, orgID uuid.UUID) (models.OrganizationMembership, error)
+}
 
 type CodeReviewHandler struct {
 	store        *db.CodeReviewStore
 	repos        *db.RepositoryStore
 	triggerSetup *codereviewsvc.GitHubTriggerSetupService
+	streams      *cache.CodeReviewStreams
+	memberships  codeReviewMembershipStore
 }
 
 func NewCodeReviewHandler(store *db.CodeReviewStore, repos *db.RepositoryStore) *CodeReviewHandler {
@@ -28,6 +45,112 @@ func NewCodeReviewHandler(store *db.CodeReviewStore, repos *db.RepositoryStore) 
 
 func (h *CodeReviewHandler) SetGitHubTriggerSetupService(service *codereviewsvc.GitHubTriggerSetupService) {
 	h.triggerSetup = service
+}
+
+func (h *CodeReviewHandler) SetStreams(streams *cache.CodeReviewStreams) {
+	h.streams = streams
+}
+
+func (h *CodeReviewHandler) SetMembershipStore(store codeReviewMembershipStore) {
+	h.memberships = store
+}
+
+// StreamUpdates is the org-scoped SSE endpoint backing the live code reviews
+// list. It mirrors PullRequestHandler.StreamUpdates: subscribe to the org's
+// Redis channel, heartbeat every 15s, and forward each lifecycle event as a
+// named "code_review.updated" SSE event.
+func (h *CodeReviewHandler) StreamUpdates(w http.ResponseWriter, r *http.Request) {
+	if h.streams == nil || !h.streams.Available() {
+		http.Error(w, "code review streams unavailable", http.StatusServiceUnavailable)
+		return
+	}
+	_ = middleware.OrgIDFromContext(r.Context())
+
+	sw := sse.NewWriter(w)
+	if sw == nil {
+		http.Error(w, "streaming unsupported", http.StatusInternalServerError)
+		return
+	}
+
+	orgID, err := h.streamOrgIDFromRequest(r)
+	if err != nil {
+		switch {
+		case errors.Is(err, errCodeReviewStreamOrgInvalid):
+			http.Error(w, "invalid code review stream org", http.StatusBadRequest)
+		case errors.Is(err, errCodeReviewStreamOrgForbidden):
+			http.Error(w, "forbidden code review stream org", http.StatusForbidden)
+		case errors.Is(err, errCodeReviewStreamUnauthorized):
+			http.Error(w, "unauthorized", http.StatusUnauthorized)
+		default:
+			http.Error(w, "failed to authorize code review stream", http.StatusInternalServerError)
+		}
+		return
+	}
+	sub, err := h.streams.Subscribe(orgID)
+	if err != nil {
+		http.Error(w, "code review streams unavailable", http.StatusServiceUnavailable)
+		return
+	}
+	defer sub.Close()
+
+	logger := zerolog.Ctx(r.Context())
+	heartbeat := time.NewTicker(15 * time.Second)
+	defer heartbeat.Stop()
+
+	for {
+		select {
+		case <-r.Context().Done():
+			return
+		case <-heartbeat.C:
+			if err := sw.WriteHeartbeat(); err != nil {
+				logger.Warn().Err(err).Msg("failed to write code review stream heartbeat")
+				return
+			}
+			sw.Flush()
+		case event, ok := <-sub.C:
+			if !ok {
+				logger.Warn().Str("reason", sub.CloseReason()).Msg("code review update subscription closed")
+				return
+			}
+			if err := sw.WriteEvent(sse.EventType("code_review.updated"), event); err != nil {
+				logger.Warn().Err(err).Str("session_id", event.SessionID.String()).Msg("failed to write code review update event")
+				return
+			}
+			sw.Flush()
+		}
+	}
+}
+
+func (h *CodeReviewHandler) streamOrgIDFromRequest(r *http.Request) (uuid.UUID, error) {
+	orgID := middleware.OrgIDFromContext(r.Context())
+	requestedRaw := strings.TrimSpace(r.URL.Query().Get("org_id"))
+	if requestedRaw == "" {
+		return orgID, nil
+	}
+
+	requestedOrgID, err := uuid.Parse(requestedRaw)
+	if err != nil {
+		return uuid.Nil, errCodeReviewStreamOrgInvalid
+	}
+	if requestedOrgID == orgID {
+		return requestedOrgID, nil
+	}
+
+	user := middleware.UserFromContext(r.Context())
+	if user == nil {
+		return uuid.Nil, errCodeReviewStreamUnauthorized
+	}
+	if h.memberships == nil {
+		return uuid.Nil, errors.New("membership store not configured")
+	}
+	if _, err := h.memberships.Get(r.Context(), user.ID, requestedOrgID); err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return uuid.Nil, errCodeReviewStreamOrgForbidden
+		}
+		return uuid.Nil, err
+	}
+
+	return requestedOrgID, nil
 }
 
 func (h *CodeReviewHandler) List(w http.ResponseWriter, r *http.Request) {

--- a/internal/api/handlers/code_reviews.go
+++ b/internal/api/handlers/code_reviews.go
@@ -113,7 +113,11 @@ func (h *CodeReviewHandler) StreamUpdates(w http.ResponseWriter, r *http.Request
 				return
 			}
 			if err := sw.WriteEvent(sse.EventType("code_review.updated"), event); err != nil {
-				logger.Warn().Err(err).Str("session_id", event.SessionID.String()).Msg("failed to write code review update event")
+				logEvent := logger.Warn().Err(err).Str("org_id", event.OrgID.String())
+				if event.SessionID != nil {
+					logEvent = logEvent.Str("session_id", event.SessionID.String())
+				}
+				logEvent.Msg("failed to write code review update event")
 				return
 			}
 			sw.Flush()

--- a/internal/api/handlers/code_reviews_test.go
+++ b/internal/api/handlers/code_reviews_test.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"bytes"
 	"context"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -72,4 +73,145 @@ type codeReviewTriggerHandlerAuthStub struct {
 
 func (s *codeReviewTriggerHandlerAuthStub) GetValidCredential(context.Context, uuid.UUID, uuid.UUID) (*models.GitHubAppUserConfig, error) {
 	return nil, s.err
+}
+
+func TestCodeReviewHandler_streamOrgIDFromRequest(t *testing.T) {
+	t.Parallel()
+
+	ctxOrgID := uuid.New()
+	userID := uuid.New()
+	requestedOrgID := uuid.New()
+
+	tests := []struct {
+		name             string
+		query            string
+		setupMemberships func() *stubPullRequestMembershipStore
+		expectedOrgID    uuid.UUID
+		expectedErr      error
+	}{
+		{
+			name:          "uses active org when request does not override it",
+			expectedOrgID: ctxOrgID,
+		},
+		{
+			name:  "uses requested org when user belongs to it",
+			query: "?org_id=" + requestedOrgID.String(),
+			setupMemberships: func() *stubPullRequestMembershipStore {
+				return &stubPullRequestMembershipStore{
+					getFunc: func(_ context.Context, gotUserID, gotOrgID uuid.UUID) (models.OrganizationMembership, error) {
+						require.Equal(t, userID, gotUserID, "streamOrgIDFromRequest should validate membership for the current user")
+						require.Equal(t, requestedOrgID, gotOrgID, "streamOrgIDFromRequest should validate the explicitly requested org")
+						return models.OrganizationMembership{UserID: gotUserID, OrgID: gotOrgID, Role: models.RoleMember}, nil
+					},
+				}
+			},
+			expectedOrgID: requestedOrgID,
+		},
+		{
+			name:        "rejects malformed requested org IDs",
+			query:       "?org_id=not-a-uuid",
+			expectedErr: errCodeReviewStreamOrgInvalid,
+		},
+		{
+			name:  "rejects requested orgs the user is not a member of",
+			query: "?org_id=" + requestedOrgID.String(),
+			setupMemberships: func() *stubPullRequestMembershipStore {
+				return &stubPullRequestMembershipStore{
+					getFunc: func(context.Context, uuid.UUID, uuid.UUID) (models.OrganizationMembership, error) {
+						return models.OrganizationMembership{}, pgx.ErrNoRows
+					},
+				}
+			},
+			expectedErr: errCodeReviewStreamOrgForbidden,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			handler := NewCodeReviewHandler(nil, nil)
+			if tt.setupMemberships != nil {
+				handler.SetMembershipStore(tt.setupMemberships())
+			}
+
+			req := httptest.NewRequest(http.MethodGet, "/api/v1/code-reviews/stream"+tt.query, nil)
+			req = req.WithContext(middleware.WithOrgID(req.Context(), ctxOrgID))
+			req = req.WithContext(middleware.WithUser(req.Context(), &models.User{ID: userID, OrgID: ctxOrgID}))
+
+			orgID, err := handler.streamOrgIDFromRequest(req)
+			if tt.expectedErr != nil {
+				require.Error(t, err, "streamOrgIDFromRequest should reject invalid explicit org selections")
+				require.True(t, errors.Is(err, tt.expectedErr), "streamOrgIDFromRequest should return the expected error sentinel")
+				return
+			}
+
+			require.NoError(t, err, "streamOrgIDFromRequest should resolve the stream org without error")
+			require.Equal(t, tt.expectedOrgID, orgID, "streamOrgIDFromRequest should resolve the expected org ID")
+		})
+	}
+}
+
+func TestCodeReviewHandler_streamOrgIDFromRequest_AdditionalErrors(t *testing.T) {
+	t.Parallel()
+
+	ctxOrgID := uuid.New()
+	requestedOrgID := uuid.New()
+
+	tests := []struct {
+		name           string
+		withUser       bool
+		membershipErr  error
+		expectedErr    error
+		expectedSubstr string
+	}{
+		{
+			name:        "returns unauthorized when explicit org requested without user",
+			withUser:    false,
+			expectedErr: errCodeReviewStreamUnauthorized,
+		},
+		{
+			name:           "returns config error when membership store missing",
+			withUser:       true,
+			expectedSubstr: "membership store not configured",
+		},
+		{
+			name:           "returns membership lookup errors",
+			withUser:       true,
+			membershipErr:  errors.New("db down"),
+			expectedSubstr: "db down",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			handler := NewCodeReviewHandler(nil, nil)
+			if tt.membershipErr != nil {
+				handler.SetMembershipStore(&stubPullRequestMembershipStore{
+					getFunc: func(context.Context, uuid.UUID, uuid.UUID) (models.OrganizationMembership, error) {
+						return models.OrganizationMembership{}, tt.membershipErr
+					},
+				})
+			}
+
+			req := httptest.NewRequest(http.MethodGet, "/api/v1/code-reviews/stream?org_id="+requestedOrgID.String(), nil)
+			req = req.WithContext(middleware.WithOrgID(req.Context(), ctxOrgID))
+			if tt.withUser {
+				req = req.WithContext(middleware.WithUser(req.Context(), &models.User{ID: uuid.New(), OrgID: ctxOrgID}))
+			}
+
+			_, err := handler.streamOrgIDFromRequest(req)
+			require.Error(t, err, "streamOrgIDFromRequest should fail for this scenario")
+			if tt.expectedErr != nil {
+				require.True(t, errors.Is(err, tt.expectedErr), "streamOrgIDFromRequest should return the expected sentinel error")
+			}
+			if tt.expectedSubstr != "" {
+				require.Contains(t, err.Error(), tt.expectedSubstr, "streamOrgIDFromRequest should preserve the underlying error context")
+			}
+		})
+	}
 }

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -349,6 +349,9 @@ func NewRouter(cfg *config.Config, pool *pgxpool.Pool, logger zerolog.Logger, se
 	reviewLoopStore := db.NewSessionReviewLoopStore(pool)
 	prReadinessStore := db.NewPRReadinessStore(pool)
 	codeReviewStore := db.NewCodeReviewStore(pool)
+	codeReviewStreams := cache.NewCodeReviewStreams(redisClient, logger)
+	codeReviewStore.SetStreams(codeReviewStreams)
+	codeReviewStore.SetLogger(logger)
 	codeReviewSvc := codereviewsvc.NewService(codeReviewStore, codeReviewStore, sessionStore, jobStore, logger, codereviewsvc.Config{
 		AppReviewerLogins: cfg.CodeReviewAppReviewerLogins,
 		AliasLogins:       cfg.CodeReviewAliasLogins,
@@ -466,6 +469,8 @@ func NewRouter(cfg *config.Config, pool *pgxpool.Pool, logger zerolog.Logger, se
 	sessionHandler.SetMembershipStore(membershipStore)
 	pullRequestHandler.SetStreams(prHealthStreams)
 	pullRequestHandler.SetMembershipStore(membershipStore)
+	codeReviewHandler.SetStreams(codeReviewStreams)
+	codeReviewHandler.SetMembershipStore(membershipStore)
 	if prService != nil {
 		sessionHandler.SetPRTitleSyncer(prService)
 	}
@@ -1173,6 +1178,7 @@ func NewRouter(cfg *config.Config, pool *pgxpool.Pool, logger zerolog.Logger, se
 
 				r.Get("/api/v1/version", healthHandler.Version)
 				r.Get("/api/v1/code-reviews", codeReviewHandler.List)
+				r.Get("/api/v1/code-reviews/stream", codeReviewHandler.StreamUpdates)
 				r.Get("/api/v1/code-reviews/templates", codeReviewHandler.Templates)
 				r.Get("/api/v1/code-reviews/{id}/evidence", codeReviewHandler.Evidence)
 				r.Get("/api/v1/code-review-policies", codeReviewHandler.GetPolicy)

--- a/internal/cache/code_review_streams.go
+++ b/internal/cache/code_review_streams.go
@@ -1,0 +1,153 @@
+package cache
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sync"
+
+	"github.com/google/uuid"
+	"github.com/redis/go-redis/v9"
+	"github.com/rs/zerolog"
+
+	"github.com/assembledhq/143/internal/models"
+)
+
+// CodeReviewStreams fans org-scoped code review lifecycle events out over Redis
+// pub/sub so the code reviews page can refresh live instead of polling or
+// relying on a manual refresh button. Mirrors PullRequestStreams.
+type CodeReviewStreams struct {
+	client *Client
+	logger zerolog.Logger
+}
+
+type CodeReviewSubscription struct {
+	C <-chan models.CodeReviewUpdatedEvent
+
+	ch     chan models.CodeReviewUpdatedEvent
+	cancel context.CancelFunc
+	pubsub *redis.PubSub
+
+	mu          sync.Mutex
+	closeReason string
+}
+
+func (s *CodeReviewSubscription) setCloseReason(reason string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.closeReason = reason
+}
+
+func NewCodeReviewStreams(client *Client, logger zerolog.Logger) *CodeReviewStreams {
+	if client == nil {
+		return nil
+	}
+	return &CodeReviewStreams{
+		client: client,
+		logger: logger,
+	}
+}
+
+func (s *CodeReviewStreams) Available() bool {
+	return s != nil && s.client != nil && s.client.Available()
+}
+
+func (s *CodeReviewStreams) PublishUpdated(ctx context.Context, orgID uuid.UUID, event models.CodeReviewUpdatedEvent) error {
+	if s == nil || s.client == nil {
+		return nil
+	}
+
+	payload, err := json.Marshal(event)
+	if err != nil {
+		return fmt.Errorf("marshal code review update event: %w", err)
+	}
+
+	if err := s.client.doCommand(ctx, "publish", func() error {
+		return s.client.raw().Publish(ctx, codeReviewStreamChannel(orgID), payload).Err()
+	}); err != nil {
+		return fmt.Errorf("publish code review update event: %w", err)
+	}
+	return nil
+}
+
+func (s *CodeReviewStreams) Subscribe(orgID uuid.UUID) (*CodeReviewSubscription, error) {
+	if s == nil || s.client == nil {
+		return nil, errors.New("redis unavailable")
+	}
+	if !s.client.Available() {
+		return nil, errors.New("redis unavailable")
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	pubsub := s.client.raw().Subscribe(ctx, codeReviewStreamChannel(orgID))
+	if _, err := pubsub.Receive(ctx); err != nil {
+		cancel()
+		_ = pubsub.Close()
+		return nil, fmt.Errorf("subscribe code review stream: %w", err)
+	}
+
+	sub := &CodeReviewSubscription{
+		ch:     make(chan models.CodeReviewUpdatedEvent, 32),
+		C:      nil,
+		cancel: cancel,
+		pubsub: pubsub,
+	}
+	sub.C = sub.ch
+
+	go func() {
+		defer close(sub.ch)
+		defer cancel()
+
+		for msg := range pubsub.Channel() {
+			var event models.CodeReviewUpdatedEvent
+			if err := json.Unmarshal([]byte(msg.Payload), &event); err != nil {
+				s.logger.Warn().Err(err).Str("channel", msg.Channel).Msg("failed to decode code review update event")
+				continue
+			}
+
+			select {
+			case sub.ch <- event:
+			case <-ctx.Done():
+				sub.setCloseReason(ctx.Err().Error())
+				return
+			}
+		}
+
+		if err := ctx.Err(); err != nil {
+			sub.setCloseReason(err.Error())
+			return
+		}
+		sub.setCloseReason("subscription closed")
+	}()
+
+	return sub, nil
+}
+
+func (s *CodeReviewSubscription) Close() {
+	if s == nil {
+		return
+	}
+	if s.cancel != nil {
+		s.cancel()
+	}
+	if s.pubsub != nil {
+		_ = s.pubsub.Close()
+	}
+}
+
+func (s *CodeReviewSubscription) CloseReason() string {
+	if s == nil {
+		return "subscription closed"
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.closeReason == "" {
+		return "subscription closed"
+	}
+	return s.closeReason
+}
+
+func codeReviewStreamChannel(orgID uuid.UUID) string {
+	return fmt.Sprintf("143:stream:{org:%s}:code_reviews", orgID.String())
+}

--- a/internal/cache/code_review_streams_test.go
+++ b/internal/cache/code_review_streams_test.go
@@ -1,0 +1,117 @@
+package cache
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/assembledhq/143/internal/models"
+	"github.com/google/uuid"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCodeReviewStreams_AvailabilityAndHelpers(t *testing.T) {
+	t.Parallel()
+
+	require.Nil(t, NewCodeReviewStreams(nil, zerolog.Nop()), "constructor should return nil when Redis client is missing")
+
+	client, _ := testRedisClient(t)
+	streams := NewCodeReviewStreams(client, zerolog.Nop())
+	require.True(t, streams.Available(), "streams should report available when Redis is healthy")
+
+	sub, err := streams.Subscribe(uuid.New())
+	require.NoError(t, err, "subscribe should succeed against a healthy Redis instance")
+	require.Equal(t, "subscription closed", sub.CloseReason(), "fresh subscriptions should report the default close reason")
+	sub.Close()
+	require.NotEmpty(t, sub.CloseReason(), "closing a subscription should leave a non-empty close reason")
+
+	require.Equal(t, "subscription closed", (*CodeReviewSubscription)(nil).CloseReason(), "nil subscription receivers should report the default close reason")
+
+	naturalSub, err := streams.Subscribe(uuid.New())
+	require.NoError(t, err, "subscribe should succeed for the natural-close case")
+	require.NoError(t, naturalSub.pubsub.Close(), "closing pubsub directly should drive the goroutine to its default close path")
+	select {
+	case <-naturalSub.C:
+	case <-time.After(2 * time.Second):
+		t.Fatal("subscription goroutine did not exit after pubsub close")
+	}
+	require.Equal(t, "subscription closed", naturalSub.CloseReason(), "natural pubsub closure should record the default close reason")
+
+	require.Equal(t, "143:stream:{org:00000000-0000-0000-0000-000000000000}:code_reviews", codeReviewStreamChannel(uuid.Nil), "channel helper should scope code review streams by org")
+}
+
+func TestCodeReviewStreams_PublishAndSubscribe(t *testing.T) {
+	t.Parallel()
+
+	client, _ := testRedisClient(t)
+	streams := NewCodeReviewStreams(client, zerolog.Nop())
+	orgID := uuid.New()
+
+	sub, err := streams.Subscribe(orgID)
+	require.NoError(t, err, "subscribe should succeed against a healthy Redis instance")
+	defer sub.Close()
+
+	event := models.CodeReviewUpdatedEvent{
+		OrgID:     orgID,
+		SessionID: uuid.New(),
+		Status:    models.CodeReviewSessionStatusCompleted,
+		UpdatedAt: time.Now().UTC(),
+	}
+
+	require.NoError(t, streams.PublishUpdated(context.Background(), orgID, event), "publish should succeed for valid events")
+	require.Eventually(t, func() bool {
+		select {
+		case got := <-sub.C:
+			return got.SessionID == event.SessionID && got.Status == event.Status
+		default:
+			return false
+		}
+	}, 2*time.Second, 20*time.Millisecond, "published code review events should be delivered to subscribers")
+}
+
+func TestCodeReviewStreams_HandlesInvalidPayloadAndUnavailableRedis(t *testing.T) {
+	t.Parallel()
+
+	require.NoError(t, (*CodeReviewStreams)(nil).PublishUpdated(context.Background(), uuid.New(), models.CodeReviewUpdatedEvent{}), "publishing with nil streams should be a no-op")
+
+	client, _ := testRedisClient(t)
+	streams := NewCodeReviewStreams(client, zerolog.Nop())
+	orgID := uuid.New()
+
+	sub, err := streams.Subscribe(orgID)
+	require.NoError(t, err, "subscribe should succeed against a healthy Redis instance")
+	defer sub.Close()
+
+	require.NoError(t, client.raw().Publish(context.Background(), codeReviewStreamChannel(orgID), "{not-json").Err(), "test should inject an invalid payload into the channel")
+	require.Never(t, func() bool {
+		select {
+		case <-sub.C:
+			return true
+		default:
+			return false
+		}
+	}, 150*time.Millisecond, 20*time.Millisecond, "invalid JSON payloads should be skipped rather than delivered")
+
+	sub.Close()
+	require.NotEmpty(t, sub.CloseReason(), "closing the subscription should record a close reason")
+
+	unavailable := &Client{logger: zerolog.Nop()}
+	unavailable.breaker = NewCircuitBreaker(zerolog.Nop())
+	streams = NewCodeReviewStreams(unavailable, zerolog.Nop())
+	require.False(t, streams.Available(), "streams should report unavailable when the underlying Redis client is not ready")
+	_, err = streams.Subscribe(uuid.New())
+	require.Error(t, err, "subscribe should fail cleanly when Redis is unavailable")
+	require.Contains(t, err.Error(), "redis unavailable", "subscribe should explain that Redis is unavailable")
+
+	unavailable.rdb = client.raw()
+	unavailable.breaker.ForceOpen()
+	err = streams.PublishUpdated(context.Background(), uuid.New(), models.CodeReviewUpdatedEvent{})
+	require.Error(t, err, "publish should fail when the breaker is open")
+	require.Contains(t, err.Error(), "publish code review update event", "publish should wrap Redis publish failures with operation context")
+
+	_, err = streams.Subscribe(uuid.New())
+	require.Error(t, err, "subscribe should fail when availability probes fail")
+	require.True(t, strings.Contains(err.Error(), "redis unavailable") || strings.Contains(err.Error(), "subscribe code review stream"), "subscribe should surface Redis availability errors")
+}

--- a/internal/cache/code_review_streams_test.go
+++ b/internal/cache/code_review_streams_test.go
@@ -53,9 +53,10 @@ func TestCodeReviewStreams_PublishAndSubscribe(t *testing.T) {
 	require.NoError(t, err, "subscribe should succeed against a healthy Redis instance")
 	defer sub.Close()
 
+	sessionID := uuid.New()
 	event := models.CodeReviewUpdatedEvent{
 		OrgID:     orgID,
-		SessionID: uuid.New(),
+		SessionID: &sessionID,
 		Status:    models.CodeReviewSessionStatusCompleted,
 		UpdatedAt: time.Now().UTC(),
 	}
@@ -64,7 +65,7 @@ func TestCodeReviewStreams_PublishAndSubscribe(t *testing.T) {
 	require.Eventually(t, func() bool {
 		select {
 		case got := <-sub.C:
-			return got.SessionID == event.SessionID && got.Status == event.Status
+			return got.SessionID != nil && *got.SessionID == sessionID && got.Status == event.Status
 		default:
 			return false
 		}

--- a/internal/db/code_reviews.go
+++ b/internal/db/code_reviews.go
@@ -45,9 +45,16 @@ func (s *CodeReviewStore) publishUpdated(ctx context.Context, metadata models.Co
 	if s.streams == nil {
 		return
 	}
+	// Batch transitions publish a synthetic metadata with a zero session ID;
+	// surface that as a nil pointer so the event omits session_id entirely.
+	var sessionID *uuid.UUID
+	if metadata.SessionID != uuid.Nil {
+		id := metadata.SessionID
+		sessionID = &id
+	}
 	if err := s.streams.PublishUpdated(ctx, metadata.OrgID, models.CodeReviewUpdatedEvent{
 		OrgID:     metadata.OrgID,
-		SessionID: metadata.SessionID,
+		SessionID: sessionID,
 		Status:    metadata.Status,
 		Decision:  metadata.Decision,
 		UpdatedAt: time.Now().UTC(),

--- a/internal/db/code_reviews.go
+++ b/internal/db/code_reviews.go
@@ -6,18 +6,57 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"time"
 
+	"github.com/assembledhq/143/internal/cache"
 	"github.com/assembledhq/143/internal/models"
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
+	"github.com/rs/zerolog"
 )
 
 type CodeReviewStore struct {
-	db DBTX
+	db      DBTX
+	streams *cache.CodeReviewStreams
+	logger  zerolog.Logger
 }
 
 func NewCodeReviewStore(db DBTX) *CodeReviewStore {
-	return &CodeReviewStore{db: db}
+	return &CodeReviewStore{db: db, logger: zerolog.Nop()}
+}
+
+// SetStreams injects the Redis helper used to fan code review lifecycle changes
+// out to the org-scoped SSE stream. Publishing is best-effort: a nil helper (no
+// Redis) simply means no live events and the frontend falls back to polling.
+// lint:allow-no-orgid reason="process-wide dependency injection for Redis code review streaming"
+func (s *CodeReviewStore) SetStreams(streams *cache.CodeReviewStreams) {
+	s.streams = streams
+}
+
+// SetLogger injects the structured logger used for best-effort stream publishing.
+// lint:allow-no-orgid reason="process-wide dependency injection for store logging"
+func (s *CodeReviewStore) SetLogger(logger zerolog.Logger) {
+	s.logger = logger
+}
+
+// publishUpdated emits a best-effort code review lifecycle event. Failures are
+// logged and swallowed so a Redis hiccup never fails the underlying DB write.
+func (s *CodeReviewStore) publishUpdated(ctx context.Context, metadata models.CodeReviewSessionMetadata) {
+	if s.streams == nil {
+		return
+	}
+	if err := s.streams.PublishUpdated(ctx, metadata.OrgID, models.CodeReviewUpdatedEvent{
+		OrgID:     metadata.OrgID,
+		SessionID: metadata.SessionID,
+		Status:    metadata.Status,
+		Decision:  metadata.Decision,
+		UpdatedAt: time.Now().UTC(),
+	}); err != nil {
+		s.logger.Warn().Err(err).
+			Str("org_id", metadata.OrgID.String()).
+			Str("session_id", metadata.SessionID.String()).
+			Msg("failed to publish code review update to Redis")
+	}
 }
 
 const codeReviewPolicyColumns = `id, org_id, repository_id, active, version, enabled, approval_mode,
@@ -448,6 +487,7 @@ func (s *CodeReviewStore) CreateSessionMetadata(ctx context.Context, metadata *m
 		return err
 	}
 	*metadata = created
+	s.publishUpdated(ctx, created)
 	return nil
 }
 
@@ -517,7 +557,12 @@ func (s *CodeReviewStore) MarkRunning(ctx context.Context, orgID, sessionID uuid
 	if err != nil {
 		return models.CodeReviewSessionMetadata{}, fmt.Errorf("mark code review running: %w", err)
 	}
-	return collectOneCodeReviewMetadata(rows)
+	metadata, err := collectOneCodeReviewMetadata(rows)
+	if err != nil {
+		return models.CodeReviewSessionMetadata{}, err
+	}
+	s.publishUpdated(ctx, metadata)
+	return metadata, nil
 }
 
 func (s *CodeReviewStore) SetPromptArtifactKey(ctx context.Context, orgID, sessionID uuid.UUID, artifactKey string) (models.CodeReviewSessionMetadata, error) {
@@ -556,7 +601,14 @@ func (s *CodeReviewStore) MarkStaleForPullRequestExceptHead(ctx context.Context,
 	if err != nil {
 		return 0, fmt.Errorf("mark stale code reviews: %w", err)
 	}
-	return tag.RowsAffected(), nil
+	affected := tag.RowsAffected()
+	if affected > 0 {
+		// Batch update touches multiple rows; publish one org-scoped signal so
+		// the list refreshes. SessionID is left zero — the frontend refetches
+		// the whole list rather than reading individual fields off the event.
+		s.publishUpdated(ctx, models.CodeReviewSessionMetadata{OrgID: orgID, Status: models.CodeReviewSessionStatusStale})
+	}
+	return affected, nil
 }
 
 func (s *CodeReviewStore) MarkStale(ctx context.Context, orgID, sessionID uuid.UUID, reason string) (models.CodeReviewSessionMetadata, error) {
@@ -578,7 +630,12 @@ func (s *CodeReviewStore) MarkStale(ctx context.Context, orgID, sessionID uuid.U
 	if err != nil {
 		return models.CodeReviewSessionMetadata{}, fmt.Errorf("mark code review stale: %w", err)
 	}
-	return collectOneCodeReviewMetadata(rows)
+	metadata, err := collectOneCodeReviewMetadata(rows)
+	if err != nil {
+		return models.CodeReviewSessionMetadata{}, err
+	}
+	s.publishUpdated(ctx, metadata)
+	return metadata, nil
 }
 
 type CompleteCodeReviewParams struct {
@@ -618,7 +675,12 @@ func (s *CodeReviewStore) CompleteReview(ctx context.Context, orgID uuid.UUID, p
 	if err != nil {
 		return models.CodeReviewSessionMetadata{}, fmt.Errorf("complete code review: %w", err)
 	}
-	return collectOneCodeReviewMetadata(rows)
+	metadata, err := collectOneCodeReviewMetadata(rows)
+	if err != nil {
+		return models.CodeReviewSessionMetadata{}, err
+	}
+	s.publishUpdated(ctx, metadata)
+	return metadata, nil
 }
 
 func (s *CodeReviewStore) RecordGitHubReview(ctx context.Context, orgID, sessionID uuid.UUID, githubReviewID int64, githubReviewURL string, finalReviewBody string) (models.CodeReviewSessionMetadata, error) {
@@ -660,7 +722,12 @@ func (s *CodeReviewStore) FailReview(ctx context.Context, orgID, sessionID uuid.
 	if err != nil {
 		return models.CodeReviewSessionMetadata{}, fmt.Errorf("fail code review: %w", err)
 	}
-	return collectOneCodeReviewMetadata(rows)
+	metadata, err := collectOneCodeReviewMetadata(rows)
+	if err != nil {
+		return models.CodeReviewSessionMetadata{}, err
+	}
+	s.publishUpdated(ctx, metadata)
+	return metadata, nil
 }
 
 type CodeReviewListFilters struct {

--- a/internal/db/code_reviews_test.go
+++ b/internal/db/code_reviews_test.go
@@ -379,11 +379,96 @@ func TestCodeReviewStore_CompleteReviewPublishesUpdate(t *testing.T) {
 	require.Eventually(t, func() bool {
 		select {
 		case event := <-sub.C:
-			return event.SessionID == sessionID && event.Status == models.CodeReviewSessionStatusCompleted
+			return event.SessionID != nil && *event.SessionID == sessionID && event.Status == models.CodeReviewSessionStatusCompleted
 		default:
 			return false
 		}
 	}, 2*time.Second, 20*time.Millisecond, "CompleteReview should publish a code review update event to subscribers")
+}
+
+// TestCodeReviewStore_MarkStaleForPullRequestExceptHeadPublishesUpdate covers
+// the batch transition: it touches many rows at once, so it publishes a single
+// org-scoped event with no session ID (session_id omitted) when any rows change.
+func TestCodeReviewStore_MarkStaleForPullRequestExceptHeadPublishesUpdate(t *testing.T) {
+	t.Parallel()
+
+	orgID := uuid.New()
+	pullRequestID := uuid.New()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "pgxmock should initialize")
+	defer mock.Close()
+
+	mr := miniredis.RunT(t)
+	client := cache.New(cache.Config{Topology: "standalone", URL: "redis://" + mr.Addr()}, zerolog.Nop(), nil)
+	require.NotNil(t, client, "Redis client should initialize against miniredis")
+	streams := cache.NewCodeReviewStreams(client, zerolog.Nop())
+	sub, err := streams.Subscribe(orgID)
+	require.NoError(t, err, "subscribe should succeed against miniredis")
+	defer sub.Close()
+
+	mock.ExpectExec(regexp.QuoteMeta("UPDATE code_review_session_metadata")).
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnResult(pgxmock.NewResult("UPDATE", 2))
+
+	store := NewCodeReviewStore(mock)
+	store.SetStreams(streams)
+	store.SetLogger(zerolog.Nop())
+
+	affected, err := store.MarkStaleForPullRequestExceptHead(context.Background(), orgID, pullRequestID, "newhead", nil)
+	require.NoError(t, err, "MarkStaleForPullRequestExceptHead should run the batch update")
+	require.Equal(t, int64(2), affected, "MarkStaleForPullRequestExceptHead should report rows affected")
+	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
+
+	require.Eventually(t, func() bool {
+		select {
+		case event := <-sub.C:
+			return event.SessionID == nil && event.OrgID == orgID && event.Status == models.CodeReviewSessionStatusStale
+		default:
+			return false
+		}
+	}, 2*time.Second, 20*time.Millisecond, "batch stale transition should publish one org-scoped event with no session id")
+}
+
+func TestCodeReviewStore_MarkStaleForPullRequestExceptHeadSkipsPublishWhenNoRows(t *testing.T) {
+	t.Parallel()
+
+	orgID := uuid.New()
+	pullRequestID := uuid.New()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "pgxmock should initialize")
+	defer mock.Close()
+
+	mr := miniredis.RunT(t)
+	client := cache.New(cache.Config{Topology: "standalone", URL: "redis://" + mr.Addr()}, zerolog.Nop(), nil)
+	require.NotNil(t, client, "Redis client should initialize against miniredis")
+	streams := cache.NewCodeReviewStreams(client, zerolog.Nop())
+	sub, err := streams.Subscribe(orgID)
+	require.NoError(t, err, "subscribe should succeed against miniredis")
+	defer sub.Close()
+
+	mock.ExpectExec(regexp.QuoteMeta("UPDATE code_review_session_metadata")).
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnResult(pgxmock.NewResult("UPDATE", 0))
+
+	store := NewCodeReviewStore(mock)
+	store.SetStreams(streams)
+	store.SetLogger(zerolog.Nop())
+
+	affected, err := store.MarkStaleForPullRequestExceptHead(context.Background(), orgID, pullRequestID, "newhead", nil)
+	require.NoError(t, err, "MarkStaleForPullRequestExceptHead should run the batch update")
+	require.Equal(t, int64(0), affected, "no rows should be affected")
+	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
+
+	require.Never(t, func() bool {
+		select {
+		case <-sub.C:
+			return true
+		default:
+			return false
+		}
+	}, 150*time.Millisecond, 20*time.Millisecond, "a no-op batch update should not publish an event")
 }
 
 func TestCodeReviewStore_GetByOutputKeyFiltersByOrg(t *testing.T) {

--- a/internal/db/code_reviews_test.go
+++ b/internal/db/code_reviews_test.go
@@ -7,9 +7,12 @@ import (
 	"testing"
 	"time"
 
+	"github.com/alicebob/miniredis/v2"
+	"github.com/assembledhq/143/internal/cache"
 	"github.com/assembledhq/143/internal/models"
 	"github.com/google/uuid"
 	"github.com/pashagolub/pgxmock/v4"
+	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/require"
 )
 
@@ -314,6 +317,73 @@ func TestCodeReviewStore_CreateSessionMetadataReusesOutputKey(t *testing.T) {
 	require.Equal(t, metadataID, metadata.ID, "CreateSessionMetadata should scan metadata id")
 	require.True(t, metadata.FromFork, "CreateSessionMetadata should persist fork source evidence")
 	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
+}
+
+// TestCodeReviewStore_CompleteReviewPublishesUpdate verifies the store fans a
+// lifecycle event out to the org-scoped SSE stream after a status transition,
+// so the live code reviews list refreshes. miniredis-backed, mirroring the
+// SessionStore publish tests.
+func TestCodeReviewStore_CompleteReviewPublishesUpdate(t *testing.T) {
+	t.Parallel()
+
+	orgID := uuid.New()
+	sessionID := uuid.New()
+	metadataID := uuid.New()
+	now := time.Date(2026, 6, 26, 12, 0, 0, 0, time.UTC)
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "pgxmock should initialize")
+	defer mock.Close()
+
+	decisionApproved := models.CodeReviewDecisionApproved
+	acceptableTrue := true
+	finalBody := "final review body"
+	completedAt := now
+
+	mr := miniredis.RunT(t)
+	client := cache.New(cache.Config{Topology: "standalone", URL: "redis://" + mr.Addr()}, zerolog.Nop(), nil)
+	require.NotNil(t, client, "Redis client should initialize against miniredis")
+	streams := cache.NewCodeReviewStreams(client, zerolog.Nop())
+	sub, err := streams.Subscribe(orgID)
+	require.NoError(t, err, "subscribe should succeed against miniredis")
+	defer sub.Close()
+
+	mock.ExpectQuery(regexp.QuoteMeta("UPDATE code_review_session_metadata")).
+		WithArgs(
+			pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
+			pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
+		).
+		WillReturnRows(pgxmock.NewRows([]string{
+			"id", "org_id", "session_id", "repository_id", "pull_request_id", "policy_id",
+			"base_sha", "head_sha", "from_fork", "trigger_source", "status", "decision", "acceptable", "stale",
+			"superseded_by_session_id", "review_output_key", "prompt_artifact_key", "github_review_id", "github_review_url", "final_review_body", "failure_reason", "completed_at", "created_at",
+		}).AddRow(
+			metadataID, orgID, sessionID, uuid.New(), uuid.New(), uuid.New(),
+			"base", "head", false, models.CodeReviewTriggerSourceAppReviewer, models.CodeReviewSessionStatusCompleted, &decisionApproved, &acceptableTrue, false,
+			nil, "pr:head:policy", nil, nil, nil, &finalBody, nil, &completedAt, now,
+		))
+
+	store := NewCodeReviewStore(mock)
+	store.SetStreams(streams)
+	store.SetLogger(zerolog.Nop())
+
+	_, err = store.CompleteReview(context.Background(), orgID, CompleteCodeReviewParams{
+		SessionID:       sessionID,
+		Decision:        models.CodeReviewDecisionApproved,
+		Acceptable:      true,
+		FinalReviewBody: "final review body",
+	})
+	require.NoError(t, err, "CompleteReview should persist the completed transition")
+	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
+
+	require.Eventually(t, func() bool {
+		select {
+		case event := <-sub.C:
+			return event.SessionID == sessionID && event.Status == models.CodeReviewSessionStatusCompleted
+		default:
+			return false
+		}
+	}, 2*time.Second, 20*time.Millisecond, "CompleteReview should publish a code review update event to subscribers")
 }
 
 func TestCodeReviewStore_GetByOutputKeyFiltersByOrg(t *testing.T) {

--- a/internal/models/code_review.go
+++ b/internal/models/code_review.go
@@ -67,6 +67,19 @@ func (d CodeReviewDecision) Validate() error {
 	}
 }
 
+// CodeReviewUpdatedEvent is fanned out over the org-scoped code review SSE
+// stream whenever a review row is created or its status/decision changes. The
+// frontend treats it as a "the list moved, refetch" signal rather than reading
+// individual fields off it (Redis pub/sub is at-most-once and unordered, so the
+// canonical record is whatever the list endpoint returns on invalidation).
+type CodeReviewUpdatedEvent struct {
+	OrgID     uuid.UUID               `json:"org_id"`
+	SessionID uuid.UUID               `json:"session_id,omitempty"`
+	Status    CodeReviewSessionStatus `json:"status,omitempty"`
+	Decision  *CodeReviewDecision     `json:"decision,omitempty"`
+	UpdatedAt time.Time               `json:"updated_at"`
+}
+
 type CodeReviewTriggerSource string
 
 const (

--- a/internal/models/code_review.go
+++ b/internal/models/code_review.go
@@ -73,8 +73,12 @@ func (d CodeReviewDecision) Validate() error {
 // individual fields off it (Redis pub/sub is at-most-once and unordered, so the
 // canonical record is whatever the list endpoint returns on invalidation).
 type CodeReviewUpdatedEvent struct {
-	OrgID     uuid.UUID               `json:"org_id"`
-	SessionID uuid.UUID               `json:"session_id,omitempty"`
+	OrgID uuid.UUID `json:"org_id"`
+	// SessionID is nil for batch transitions that touch many rows at once
+	// (e.g. marking a PR's prior reviews stale on a new head), which have no
+	// single session. A pointer is required for omitempty to actually fire —
+	// uuid.UUID is a fixed-size array and never counts as "empty" to encoding/json.
+	SessionID *uuid.UUID              `json:"session_id,omitempty"`
 	Status    CodeReviewSessionStatus `json:"status,omitempty"`
 	Decision  *CodeReviewDecision     `json:"decision,omitempty"`
 	UpdatedAt time.Time               `json:"updated_at"`


### PR DESCRIPTION
## Summary

The code reviews page was the only live list still gated behind a manual **Refresh** button — every other surface (sessions, PR health, eval batches) is pushed over an org-scoped SSE stream. This makes the reviews list refresh itself as bot-requested reviews are created and transition state, removing the inconsistent button and the stale-data window it left open.

## Changes

- **Backend SSE stream** mirroring `PullRequestStreams`: a new `CodeReviewStreams` Redis pub/sub on a per-org channel, published best-effort from **every** `CodeReviewStore` lifecycle mutation (create / running / stale / complete / fail / batch-stale) so no transition is missed regardless of which worker path runs it. A nil Redis client degrades to a no-op.
- **New endpoint** `GET /api/v1/code-reviews/stream` with the same multi-org `?org_id=` membership check as the PR stream; wired into the API router, worker, and executor.
- **Frontend** subscribes via a generalized `useResourceSSE` hook (renamed from `useEvalSSE`; eval-specific gating predicates split into `eval-streams.ts`) and invalidates the reviews-list query on each event. React Query polling is kept only as a degraded-mode backstop (5s while the stream is unhealthy, 30s otherwise). The manual Refresh button is removed.

## Validation

- **Go:** `go build ./...` clean · `make lint` → 0 issues · tenancy checks OK · gofmt clean. New tests: `CodeReviewStreams` pub/sub, `CodeReviewStore_CompleteReviewPublishesUpdate` (miniredis + pgxmock), and `CodeReviewHandler_streamOrgIDFromRequest` (+ AdditionalErrors) for the cross-org auth path.
- **Frontend:** `tsc` clean (one pre-existing unrelated `source.ts` error) · `eslint` 0 on all touched files · `vitest` green across `sse`, `eval-streams`, the code-reviews page, and the eval batch page.

## Reviewer notes

- The stream is scoped **per-org, not per-filter**: any change in the org wakes the page, which refetches with whatever filters are active (cheap, matches the PR-stream precedent).
- End-to-end push behavior (Redis event → list refresh) needs the full backend + Redis + a real review transition, so it's verified at build/type/lint/unit level here; first live check should be post-deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
