### PR TITLE
Automate Postgres backups on the db node

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,7 @@ jobs:
       frontend: ${{ steps.filter.outputs.frontend }}
       migrations: ${{ steps.filter.outputs.migrations }}
       docker: ${{ steps.filter.outputs.docker }}
+      deploy: ${{ steps.filter.outputs.deploy }}
       ci: ${{ steps.filter.outputs.ci }}
     steps:
       - uses: actions/checkout@v6
@@ -62,6 +63,8 @@ jobs:
               - 'frontend/Dockerfile*'
               - 'sandbox/Dockerfile*'
               - '.dockerignore'
+            deploy:
+              - 'deploy/scripts/**'
             ci:
               - '.github/workflows/**'
 
@@ -369,9 +372,24 @@ jobs:
           go install github.com/securego/gosec/v2/cmd/gosec@v2.22.4
           gosec ./...
 
+  deploy-scripts-test:
+    name: Deploy Scripts Test
+    needs: changes
+    if: needs.changes.outputs.deploy == 'true' || needs.changes.outputs.ci == 'true' || github.event_name == 'push'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Run deploy shell tests
+        run: |
+          set -euo pipefail
+          for t in deploy/scripts/*_test.sh; do
+            echo "--- $t"
+            bash "$t"
+          done
+
   required-checks:
     name: All Checks Pass
-    needs: [changes, backend-lint, backend-test, frontend-lint, frontend-test, migration-check, docker-build, security]
+    needs: [changes, backend-lint, backend-test, frontend-lint, frontend-test, migration-check, docker-build, security, deploy-scripts-test]
     runs-on: ubuntu-latest
     if: always()
     steps:
@@ -384,6 +402,7 @@ jobs:
           echo "migration-check: ${{ needs.migration-check.result }}"
           echo "docker-build: ${{ needs.docker-build.result }}"
           echo "security: ${{ needs.security.result }}"
+          echo "deploy-scripts-test: ${{ needs.deploy-scripts-test.result }}"
 
           for result in \
             "${{ needs.backend-lint.result }}" \
@@ -392,7 +411,8 @@ jobs:
             "${{ needs.frontend-test.result }}" \
             "${{ needs.migration-check.result }}" \
             "${{ needs.docker-build.result }}" \
-            "${{ needs.security.result }}"; do
+            "${{ needs.security.result }}" \
+            "${{ needs.deploy-scripts-test.result }}"; do
             if [[ "$result" != "success" && "$result" != "skipped" ]]; then
               echo "::error::One or more required checks failed"
               exit 1

--- a/Makefile
+++ b/Makefile
@@ -574,8 +574,16 @@ provision-db:
 provision-db-backups:
 	$(check-ssh-key)
 	@HOST="$(HOST)"; \
-	if [ -z "$$HOST" ]; then $(read-fleet-hosts); HOST="$$(echo "$$FLEET" | tr ',' '\n' | grep '^db:' | cut -d: -f2 | head -1)"; fi; \
+	ENV_DUMP="$$(sops --decrypt --input-type dotenv --output-type dotenv $(_PROD_ENC) 2>/dev/null || true)"; \
+	if [ -z "$$HOST" ]; then \
+		FLEET="$$(printf '%s\n' "$$ENV_DUMP" | grep '^FLEET_HOSTS=' | cut -d= -f2-)"; \
+		HOST="$$(echo "$$FLEET" | tr ',' '\n' | grep '^db:' | cut -d: -f2 | head -1)"; \
+	fi; \
 	test -n "$$HOST" || { echo "ERROR: no HOST given and no db:<ip> in FLEET_HOSTS."; exit 1; }; \
+	export BACKUP_S3_BUCKET="$$(printf '%s\n' "$$ENV_DUMP" | grep '^BACKUP_S3_BUCKET=' | cut -d= -f2-)"; \
+	export BACKUP_S3_REGION="$$(printf '%s\n' "$$ENV_DUMP" | grep '^BACKUP_S3_REGION=' | cut -d= -f2-)"; \
+	export BACKUP_AWS_ACCESS_KEY_ID="$$(printf '%s\n' "$$ENV_DUMP" | grep '^BACKUP_AWS_ACCESS_KEY_ID=' | cut -d= -f2-)"; \
+	export BACKUP_AWS_SECRET_ACCESS_KEY="$$(printf '%s\n' "$$ENV_DUMP" | grep '^BACKUP_AWS_SECRET_ACCESS_KEY=' | cut -d= -f2-)"; \
 	echo "Configuring DB backups on $$HOST..."; \
 	./deploy/scripts/provision-db-backups.sh "$$HOST" "$(SSH_KEY)"
 

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 SANDBOX_STAMP := sandbox/.build-stamp
 SANDBOX_SOURCES := sandbox/Dockerfile sandbox/versions.json
 
-.PHONY: dev dev-ngrok dev-local dev-frontend-only setup test test-race test-coverage test-pr test-coverage-diff test-main test-integration migrate-up migrate-down demo-seed-check demo-seed-apply build build-cli frontend-dev frontend-lint frontend-typecheck frontend-check lint lint-bootstrap lint-schema lint-stores lint-tenancy hooks-install hooks-uninstall secrets-setup secrets-encrypt secrets-decrypt secrets-edit secrets-rotate single-node-prepare single-node-up single-node-down provision-app provision-worker provision-workers provision-egress provision-db provision-logging provision-redis tailscale-enroll repair-deploy-sudoers repair-worker-host spin-down-worker deploy deploy-app deploy-worker deploy-worker-preflight deploy-db deploy-logging deploy-fleet logs logs-query setup-readonly-user db-psql db-query
+.PHONY: dev dev-ngrok dev-local dev-frontend-only setup test test-race test-coverage test-pr test-coverage-diff test-main test-integration migrate-up migrate-down demo-seed-check demo-seed-apply build build-cli frontend-dev frontend-lint frontend-typecheck frontend-check lint lint-bootstrap lint-schema lint-stores lint-tenancy hooks-install hooks-uninstall secrets-setup secrets-encrypt secrets-decrypt secrets-edit secrets-rotate single-node-prepare single-node-up single-node-down provision-app provision-worker provision-workers provision-egress provision-db provision-db-backups provision-logging provision-redis tailscale-enroll repair-deploy-sudoers repair-worker-host spin-down-worker deploy deploy-app deploy-worker deploy-worker-preflight deploy-db deploy-logging deploy-fleet logs logs-query setup-readonly-user db-psql db-query
 
 GOLANGCI_LINT_VERSION ?= v2.10.1
 GOLANGCI_LINT_BIN := $(CURDIR)/bin/golangci-lint
@@ -562,6 +562,22 @@ provision-db:
 	@test -n "$(HOST)" || { echo "HOST is required. Usage: make provision-db HOST=<ip> [SSH_KEY=<path>]"; exit 1; }
 	$(check-ssh-key)
 	./deploy/scripts/provision.sh db $(HOST) $(SSH_KEY) $(if $(REPROVISION),--reprovision)
+
+# Install/refresh automated DB backups (pg_dump every 6h + weekly restore
+# test) on the db host. Runs automatically at the end of provision-db; this
+# target is the standalone entry point for an already-provisioned db node and
+# is idempotent (safe to re-run). Resolves the db host from FLEET_HOSTS when
+# HOST is unset.
+# Usage:
+#   make provision-db-backups
+#   make provision-db-backups HOST=87.99.157.99
+provision-db-backups:
+	$(check-ssh-key)
+	@HOST="$(HOST)"; \
+	if [ -z "$$HOST" ]; then $(read-fleet-hosts); HOST="$$(echo "$$FLEET" | tr ',' '\n' | grep '^db:' | cut -d: -f2 | head -1)"; fi; \
+	test -n "$$HOST" || { echo "ERROR: no HOST given and no db:<ip> in FLEET_HOSTS."; exit 1; }; \
+	echo "Configuring DB backups on $$HOST..."; \
+	./deploy/scripts/provision-db-backups.sh "$$HOST" "$(SSH_KEY)"
 
 provision-logging:
 	@test -n "$(HOST)" || { echo "HOST is required. Usage: make provision-logging HOST=<ip> [SSH_KEY=<path>]"; exit 1; }

--- a/Makefile
+++ b/Makefile
@@ -575,11 +575,14 @@ provision-db-backups:
 	$(check-ssh-key)
 	@HOST="$(HOST)"; \
 	ENV_DUMP="$$(sops --decrypt --input-type dotenv --output-type dotenv $(_PROD_ENC) 2>/dev/null || true)"; \
+	if [ -z "$$ENV_DUMP" ]; then \
+		echo "WARNING: could not decrypt $(_PROD_ENC) (missing age key?). Offsite sync config will be left unchanged; cron will still be (re)installed." >&2; \
+	fi; \
 	if [ -z "$$HOST" ]; then \
 		FLEET="$$(printf '%s\n' "$$ENV_DUMP" | grep '^FLEET_HOSTS=' | cut -d= -f2-)"; \
 		HOST="$$(echo "$$FLEET" | tr ',' '\n' | grep '^db:' | cut -d: -f2 | head -1)"; \
 	fi; \
-	test -n "$$HOST" || { echo "ERROR: no HOST given and no db:<ip> in FLEET_HOSTS."; exit 1; }; \
+	test -n "$$HOST" || { echo "ERROR: no HOST given and no db:<ip> in FLEET_HOSTS (set HOST=<ip> or fix the age key)."; exit 1; }; \
 	export BACKUP_S3_BUCKET="$$(printf '%s\n' "$$ENV_DUMP" | grep '^BACKUP_S3_BUCKET=' | cut -d= -f2-)"; \
 	export BACKUP_S3_REGION="$$(printf '%s\n' "$$ENV_DUMP" | grep '^BACKUP_S3_REGION=' | cut -d= -f2-)"; \
 	export BACKUP_AWS_ACCESS_KEY_ID="$$(printf '%s\n' "$$ENV_DUMP" | grep '^BACKUP_AWS_ACCESS_KEY_ID=' | cut -d= -f2-)"; \

--- a/deploy/scripts/deploy_remote_env_test.sh
+++ b/deploy/scripts/deploy_remote_env_test.sh
@@ -78,6 +78,14 @@ HOME_DIR="$TMP_DIR/home"
 mkdir -p "$HOME_DIR/.config/sops/age"
 printf 'AGE-SECRET-KEY-test\n' >"$HOME_DIR/.config/sops/age/keys.txt"
 
+# deploy.sh resolves the encrypted bundle from SECRETS_DIR and checks it exists
+# on disk before decrypting (sops is stubbed). Point it at a temp stub so the
+# test is hermetic — without this it needs a real ../143-infra sibling checkout.
+SECRETS_DIR="$TMP_DIR/secrets"
+mkdir -p "$SECRETS_DIR"
+printf 'sops-stub\n' >"$SECRETS_DIR/.env.production.enc"
+export SECRETS_DIR
+
 CAPTURE_FILE="$TMP_DIR/deploy.capture"
 : >"$CAPTURE_FILE"
 OUTPUT_FILE="$TMP_DIR/deploy.out"

--- a/deploy/scripts/install-pg-backups.sh
+++ b/deploy/scripts/install-pg-backups.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# Install/refresh automated Postgres backups on a db host.
+#
+# Writes /etc/cron.d/143-pg-backup, which runs:
+#   - pg-backup.sh   every 6 hours  (pg_dump custom-format, verified, 30d retention)
+#   - restore-test.sh weekly        (restores the newest dump into a throwaway
+#                                    Postgres to prove it is recoverable)
+#
+# Idempotent: the cron file is only rewritten when its desired content
+# changes, so re-running on every provision/deploy is a no-op. cron picks up
+# /etc/cron.d changes automatically — no service restart needed.
+#
+# Runs as root. provision.sh invokes it over its root SSH session, and the
+# standalone `make provision-db-backups` path (deploy/scripts/provision-db-backups.sh)
+# does the same. It never runs as the deploy user, so it needs no sudoers grant.
+#
+# Offsite sync (true disaster recovery) is opt-in — see deploy/scripts/pg-backup.sh.
+#
+# Usage (on the db host, as root):
+#   install-pg-backups.sh
+# Env overrides:
+#   BACKUP_DIR             (default /backups/postgres)
+#   BACKUP_RETENTION_DAYS  (default 7 — ~25 GB at 900 MB/dump every 6h; long-term
+#                           history belongs in the offsite sync, not local disk)
+#   SCRIPTS_DIR            (default /opt/143/deploy/scripts)
+#   BACKUP_CRON            (default "0 */6 * * *")
+#   RESTORE_TEST_CRON      (default "0 5 * * 0")
+
+set -euo pipefail
+
+BACKUP_DIR="${BACKUP_DIR:-/backups/postgres}"
+BACKUP_RETENTION_DAYS="${BACKUP_RETENTION_DAYS:-7}"
+SCRIPTS_DIR="${SCRIPTS_DIR:-/opt/143/deploy/scripts}"
+BACKUP_CRON="${BACKUP_CRON:-0 */6 * * *}"
+RESTORE_TEST_CRON="${RESTORE_TEST_CRON:-0 5 * * 0}"
+
+CRON_FILE="/etc/cron.d/143-pg-backup"
+
+# The backup scripts must already be on the host (provision.sh / the wrapper
+# copy them to SCRIPTS_DIR before invoking this installer).
+for s in pg-backup.sh restore-test.sh; do
+  if [ ! -f "$SCRIPTS_DIR/$s" ]; then
+    echo "ERROR: $SCRIPTS_DIR/$s not found — copy the deploy scripts to this host first." >&2
+    exit 1
+  fi
+  chmod +x "$SCRIPTS_DIR/$s"
+done
+
+mkdir -p "$BACKUP_DIR"
+
+# Per-job env (BACKUP_DIR / retention) is set in the cron.d file so the jobs
+# honor the same values configured here. cron.d entries take a user field.
+DESIRED="$(cat <<EOF
+# Managed by deploy/scripts/install-pg-backups.sh — do not edit by hand.
+# Automated Postgres backups for the 143 db node.
+SHELL=/bin/bash
+PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+BACKUP_DIR=$BACKUP_DIR
+BACKUP_RETENTION_DAYS=$BACKUP_RETENTION_DAYS
+
+$BACKUP_CRON root $SCRIPTS_DIR/pg-backup.sh >> /var/log/pg-backup.log 2>&1
+$RESTORE_TEST_CRON root $SCRIPTS_DIR/restore-test.sh >> /var/log/restore-test.log 2>&1
+EOF
+)"
+
+if [ -f "$CRON_FILE" ] && [ "$(cat "$CRON_FILE")" = "$DESIRED" ]; then
+  echo "pg-backups: $CRON_FILE already up to date; nothing to do."
+else
+  # Atomic install. Temp name carries dots/leading dot so cron's run-parts
+  # naming rules ignore it until the mv completes.
+  TMP="$(mktemp /etc/cron.d/.143-pg-backup.XXXXXX)"
+  trap 'rm -f "$TMP"' EXIT
+  printf '%s\n' "$DESIRED" > "$TMP"
+  chmod 0644 "$TMP"
+  chown root:root "$TMP"
+  mv "$TMP" "$CRON_FILE"
+  trap - EXIT
+  echo "pg-backups: installed $CRON_FILE (backup '$BACKUP_CRON', restore-test '$RESTORE_TEST_CRON')."
+fi
+
+# Pre-create the log files so the first cron run can append.
+touch /var/log/pg-backup.log /var/log/restore-test.log
+chmod 0640 /var/log/pg-backup.log /var/log/restore-test.log
+
+echo "pg-backups: dumps -> $BACKUP_DIR (retention ${BACKUP_RETENTION_DAYS}d)."
+if [ -f /opt/143/backup-sync.env ]; then
+  echo "pg-backups: offsite sync configured (/opt/143/backup-sync.env)."
+else
+  echo "pg-backups: NOTE no offsite sync — dumps are local-only (not disaster-safe). See deploy/scripts/pg-backup.sh to enable."
+fi

--- a/deploy/scripts/install-pg-backups.sh
+++ b/deploy/scripts/install-pg-backups.sh
@@ -2,7 +2,7 @@
 # Install/refresh automated Postgres backups on a db host.
 #
 # Writes /etc/cron.d/143-pg-backup, which runs:
-#   - pg-backup.sh   every 6 hours  (pg_dump custom-format, verified, 30d retention)
+#   - pg-backup.sh   every 6 hours  (pg_dump custom-format, verified, 7d retention)
 #   - restore-test.sh weekly        (restores the newest dump into a throwaway
 #                                    Postgres to prove it is recoverable)
 #
@@ -25,6 +25,7 @@
 #   SCRIPTS_DIR            (default /opt/143/deploy/scripts)
 #   BACKUP_CRON            (default "0 */6 * * *")
 #   RESTORE_TEST_CRON      (default "0 5 * * 0")
+#   CRON_FILE / PG_BACKUP_LOG / RESTORE_TEST_LOG — overridable for tests
 
 set -euo pipefail
 
@@ -34,7 +35,9 @@ SCRIPTS_DIR="${SCRIPTS_DIR:-/opt/143/deploy/scripts}"
 BACKUP_CRON="${BACKUP_CRON:-0 */6 * * *}"
 RESTORE_TEST_CRON="${RESTORE_TEST_CRON:-0 5 * * 0}"
 
-CRON_FILE="/etc/cron.d/143-pg-backup"
+CRON_FILE="${CRON_FILE:-/etc/cron.d/143-pg-backup}"
+PG_BACKUP_LOG="${PG_BACKUP_LOG:-/var/log/pg-backup.log}"
+RESTORE_TEST_LOG="${RESTORE_TEST_LOG:-/var/log/restore-test.log}"
 
 # The backup scripts must already be on the host (provision.sh / the wrapper
 # copy them to SCRIPTS_DIR before invoking this installer).
@@ -58,8 +61,8 @@ PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 BACKUP_DIR=$BACKUP_DIR
 BACKUP_RETENTION_DAYS=$BACKUP_RETENTION_DAYS
 
-$BACKUP_CRON root $SCRIPTS_DIR/pg-backup.sh >> /var/log/pg-backup.log 2>&1
-$RESTORE_TEST_CRON root $SCRIPTS_DIR/restore-test.sh >> /var/log/restore-test.log 2>&1
+$BACKUP_CRON root $SCRIPTS_DIR/pg-backup.sh >> $PG_BACKUP_LOG 2>&1
+$RESTORE_TEST_CRON root $SCRIPTS_DIR/restore-test.sh >> $RESTORE_TEST_LOG 2>&1
 EOF
 )"
 
@@ -68,19 +71,21 @@ if [ -f "$CRON_FILE" ] && [ "$(cat "$CRON_FILE")" = "$DESIRED" ]; then
 else
   # Atomic install. Temp name carries dots/leading dot so cron's run-parts
   # naming rules ignore it until the mv completes.
-  TMP="$(mktemp /etc/cron.d/.143-pg-backup.XXXXXX)"
+  TMP="$(mktemp "$(dirname "$CRON_FILE")/.143-pg-backup.XXXXXX")"
   trap 'rm -f "$TMP"' EXIT
   printf '%s\n' "$DESIRED" > "$TMP"
   chmod 0644 "$TMP"
-  chown root:root "$TMP"
+  # Already root-owned when run as root on the db host (root created the temp);
+  # tolerate failure so the script is testable unprivileged.
+  chown root:root "$TMP" 2>/dev/null || true
   mv "$TMP" "$CRON_FILE"
   trap - EXIT
   echo "pg-backups: installed $CRON_FILE (backup '$BACKUP_CRON', restore-test '$RESTORE_TEST_CRON')."
 fi
 
 # Pre-create the log files so the first cron run can append.
-touch /var/log/pg-backup.log /var/log/restore-test.log
-chmod 0640 /var/log/pg-backup.log /var/log/restore-test.log
+touch "$PG_BACKUP_LOG" "$RESTORE_TEST_LOG"
+chmod 0640 "$PG_BACKUP_LOG" "$RESTORE_TEST_LOG"
 
 echo "pg-backups: dumps -> $BACKUP_DIR (retention ${BACKUP_RETENTION_DAYS}d)."
 if [ -f /opt/143/backup-sync.env ]; then

--- a/deploy/scripts/install_pg_backups_test.sh
+++ b/deploy/scripts/install_pg_backups_test.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# Tests for install-pg-backups.sh: cron-file rendering, idempotency, the
+# missing-script guard, and env overrides. Everything is redirected to a
+# tempdir (CRON_FILE / *_LOG / SCRIPTS_DIR / BACKUP_DIR overrides), so this
+# runs unprivileged and touches nothing real.
+# Run directly: bash deploy/scripts/install_pg_backups_test.sh
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+INSTALLER="$SCRIPT_DIR/install-pg-backups.sh"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+fail() {
+  # %b so embedded \n in messages (e.g. dumped cron contents) render.
+  printf 'FAIL: %b\n' "$*" >&2
+  exit 1
+}
+
+# Sandbox layout: fake scripts dir + dump dir + cron/log targets.
+SCRIPTS="$TMP_DIR/scripts"
+mkdir -p "$SCRIPTS"
+: > "$SCRIPTS/pg-backup.sh"
+: > "$SCRIPTS/restore-test.sh"
+CRON_FILE="$TMP_DIR/143-pg-backup"
+
+# Extra "KEY=val" args (quoted, so values may contain spaces) are forwarded to
+# `env` as overrides — env parses them even though a bare assignment prefix
+# from "$@" expansion would not.
+run_installer() {
+  env \
+    CRON_FILE="$CRON_FILE" \
+    PG_BACKUP_LOG="$TMP_DIR/pg-backup.log" \
+    RESTORE_TEST_LOG="$TMP_DIR/restore-test.log" \
+    SCRIPTS_DIR="$SCRIPTS" \
+    BACKUP_DIR="$TMP_DIR/backups" \
+    "$@" \
+    bash "$INSTALLER"
+}
+
+# 1. Fresh install renders the expected cron file.
+out="$(run_installer)"
+[ -f "$CRON_FILE" ] || fail "cron file not created"
+grep -q '^0 \*/6 \* \* \* root '"$SCRIPTS"'/pg-backup.sh >> '"$TMP_DIR"'/pg-backup.log 2>&1$' "$CRON_FILE" \
+  || fail "backup cron line missing/wrong:\n$(cat "$CRON_FILE")"
+grep -q '^0 5 \* \* 0 root '"$SCRIPTS"'/restore-test.sh >> '"$TMP_DIR"'/restore-test.log 2>&1$' "$CRON_FILE" \
+  || fail "restore-test cron line missing/wrong:\n$(cat "$CRON_FILE")"
+grep -q '^BACKUP_RETENTION_DAYS=7$' "$CRON_FILE" || fail "default retention not 7"
+grep -q "^BACKUP_DIR=$TMP_DIR/backups$" "$CRON_FILE" || fail "BACKUP_DIR not in cron env"
+[ -d "$TMP_DIR/backups" ] || fail "backup dir not created"
+[ -f "$TMP_DIR/pg-backup.log" ] || fail "pg-backup log not pre-created"
+case "$out" in *"installed $CRON_FILE"*) ;; *) fail "expected install message, got: $out" ;; esac
+
+# 2. Re-run is a no-op (idempotent): same content, "already up to date".
+before="$(cat "$CRON_FILE")"
+out="$(run_installer)"
+[ "$(cat "$CRON_FILE")" = "$before" ] || fail "cron file changed on idempotent re-run"
+case "$out" in *"already up to date"*) ;; *) fail "expected up-to-date message, got: $out" ;; esac
+
+# 3. Env overrides flow into the cron file.
+out="$(run_installer BACKUP_CRON='30 */4 * * *' BACKUP_RETENTION_DAYS=14)"
+grep -q '^30 \*/4 \* \* \* root ' "$CRON_FILE" || fail "custom BACKUP_CRON not applied"
+grep -q '^BACKUP_RETENTION_DAYS=14$' "$CRON_FILE" || fail "custom retention not applied"
+
+# 4. Missing backup script is a hard error.
+rm -f "$SCRIPTS/restore-test.sh"
+if run_installer >/dev/null 2>&1; then
+  fail "expected non-zero exit when restore-test.sh is missing"
+fi
+
+echo "PASS: install_pg_backups_test.sh"

--- a/deploy/scripts/pg-backup.sh
+++ b/deploy/scripts/pg-backup.sh
@@ -55,9 +55,11 @@ echo "$(date -Iseconds) Backup complete: $BACKUP_FILE ($BACKUP_SIZE)"
 find "$BACKUP_DIR" -name "*.dump" -mtime +"$RETENTION_DAYS" -delete
 echo "$(date -Iseconds) Cleaned backups older than $RETENTION_DAYS days"
 
-# Optional offsite sync (true disaster recovery). Without it, dumps live only
-# on this host's disk — a disk/VPS loss takes the backups with it. To enable,
-# drop a BACKUP_SYNC_CMD into /opt/143/backup-sync.env, e.g.:
+# Offsite sync (true disaster recovery). Without it, dumps live only on this
+# host's disk — a disk/VPS loss takes the backups with it. /opt/143/backup-sync.env
+# is written by deploy/scripts/provision-db-backups.sh from the BACKUP_* vars in
+# .env.production.enc; it exports AWS creds + a BACKUP_SYNC_CMD that pushes
+# $BACKUP_DIR to S3. To wire a different target by hand, set e.g.:
 #   BACKUP_SYNC_CMD='rclone sync /backups/postgres s3:143-backups/postgres/'
 SYNC_ENV="${BACKUP_SYNC_ENV:-/opt/143/backup-sync.env}"
 # shellcheck disable=SC1090

--- a/deploy/scripts/pg-backup.sh
+++ b/deploy/scripts/pg-backup.sh
@@ -2,14 +2,33 @@
 set -euo pipefail
 
 # Automated pg_dump backup with verification and retention.
-# Usage: run via cron every 6 hours.
-#   0 */6 * * * /opt/143/deploy/scripts/pg-backup.sh >> /var/log/pg-backup.log 2>&1
+# Installed as a cron job by deploy/scripts/install-pg-backups.sh; runs every
+# 6 hours as root on the db host.
+#
+# The postgres container authenticates with scram-sha-256 even for local
+# connections (see deploy/postgres/pg_hba.conf), so pg_dump needs the
+# password. It is read from $DB_PASSWORD if exported, otherwise from
+# /opt/143/.env (written by provision.sh).
 
 BACKUP_DIR="${BACKUP_DIR:-/backups/postgres}"
-RETENTION_DAYS="${BACKUP_RETENTION_DAYS:-30}"
+# Local retention defaults to 7 days. At ~900 MB/dump every 6h that is ~25 GB;
+# 30 days would be ~108 GB and risk filling the disk. Long-term history is the
+# job of the offsite sync, not the local disk.
+RETENTION_DAYS="${BACKUP_RETENTION_DAYS:-7}"
 CONTAINER_NAME="${POSTGRES_CONTAINER:-143-postgres-1}"
 DB_USER="${POSTGRES_USER:-onefortythree}"
 DB_NAME="${POSTGRES_DB:-onefortythree}"
+ENV_FILE="${ENV_FILE:-/opt/143/.env}"
+
+# Resolve the DB password (needed for the in-container pg_dump connection).
+DB_PASSWORD="${DB_PASSWORD:-}"
+if [ -z "$DB_PASSWORD" ] && [ -f "$ENV_FILE" ]; then
+  DB_PASSWORD="$(grep -E '^DB_PASSWORD=' "$ENV_FILE" | cut -d= -f2- || true)"
+fi
+if [ -z "$DB_PASSWORD" ]; then
+  echo "ERROR: DB_PASSWORD not set and not found in $ENV_FILE" >&2
+  exit 1
+fi
 
 mkdir -p "$BACKUP_DIR"
 
@@ -17,7 +36,7 @@ TIMESTAMP=$(date +%Y%m%d-%H%M%S)
 BACKUP_FILE="$BACKUP_DIR/$DB_NAME-$TIMESTAMP.dump"
 
 # Custom format: compressed, supports selective restore
-docker exec "$CONTAINER_NAME" \
+docker exec -e PGPASSWORD="$DB_PASSWORD" "$CONTAINER_NAME" \
   pg_dump -U "$DB_USER" -Fc "$DB_NAME" > "$BACKUP_FILE"
 
 # Verify the backup is valid (runs pg_restore inside the container
@@ -35,3 +54,20 @@ echo "$(date -Iseconds) Backup complete: $BACKUP_FILE ($BACKUP_SIZE)"
 # Clean up old backups
 find "$BACKUP_DIR" -name "*.dump" -mtime +"$RETENTION_DAYS" -delete
 echo "$(date -Iseconds) Cleaned backups older than $RETENTION_DAYS days"
+
+# Optional offsite sync (true disaster recovery). Without it, dumps live only
+# on this host's disk — a disk/VPS loss takes the backups with it. To enable,
+# drop a BACKUP_SYNC_CMD into /opt/143/backup-sync.env, e.g.:
+#   BACKUP_SYNC_CMD='rclone sync /backups/postgres s3:143-backups/postgres/'
+SYNC_ENV="${BACKUP_SYNC_ENV:-/opt/143/backup-sync.env}"
+# shellcheck disable=SC1090
+[ -f "$SYNC_ENV" ] && . "$SYNC_ENV"
+if [ -n "${BACKUP_SYNC_CMD:-}" ]; then
+  echo "$(date -Iseconds) Running offsite sync..."
+  if eval "$BACKUP_SYNC_CMD"; then
+    echo "$(date -Iseconds) Offsite sync complete"
+  else
+    echo "ERROR: offsite sync failed (BACKUP_SYNC_CMD)" >&2
+    exit 1
+  fi
+fi

--- a/deploy/scripts/pg-backup.sh
+++ b/deploy/scripts/pg-backup.sh
@@ -62,8 +62,10 @@ echo "$(date -Iseconds) Cleaned backups older than $RETENTION_DAYS days"
 # $BACKUP_DIR to S3. To wire a different target by hand, set e.g.:
 #   BACKUP_SYNC_CMD='rclone sync /backups/postgres s3:143-backups/postgres/'
 SYNC_ENV="${BACKUP_SYNC_ENV:-/opt/143/backup-sync.env}"
-# shellcheck disable=SC1090
-[ -f "$SYNC_ENV" ] && . "$SYNC_ENV"
+if [ -f "$SYNC_ENV" ]; then
+  # shellcheck disable=SC1090
+  . "$SYNC_ENV"
+fi
 if [ -n "${BACKUP_SYNC_CMD:-}" ]; then
   echo "$(date -Iseconds) Running offsite sync..."
   if eval "$BACKUP_SYNC_CMD"; then

--- a/deploy/scripts/provision-db-backups.sh
+++ b/deploy/scripts/provision-db-backups.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Install/refresh automated Postgres backups on the db host.
+#
+# Copies the current backup scripts to the host and runs the installer over
+# root SSH (the same transport provision.sh uses). The installer is
+# idempotent, so this is safe to run any time. Invoked automatically at the
+# end of provision-db and exposed for standalone runs as
+# `make provision-db-backups`.
+#
+# Usage:
+#   provision-db-backups.sh <host> [ssh_key]
+
+set -euo pipefail
+
+HOST="${1:?usage: provision-db-backups.sh <host> [ssh_key]}"
+SSH_KEY="${2:-$HOME/.ssh/143-deploy}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+SSH_OPTS=(-i "$SSH_KEY" -o StrictHostKeyChecking=accept-new -o ConnectTimeout=20)
+SCP_OPTS=(-i "$SSH_KEY" -o StrictHostKeyChecking=accept-new)
+
+echo "--- Installing automated DB backups on $HOST ---"
+ssh "${SSH_OPTS[@]}" root@"$HOST" "mkdir -p /opt/143/deploy/scripts"
+scp "${SCP_OPTS[@]}" \
+  "$SCRIPT_DIR/pg-backup.sh" \
+  "$SCRIPT_DIR/restore-test.sh" \
+  "$SCRIPT_DIR/install-pg-backups.sh" \
+  root@"$HOST":/opt/143/deploy/scripts/
+ssh "${SSH_OPTS[@]}" root@"$HOST" \
+  "chmod +x /opt/143/deploy/scripts/pg-backup.sh /opt/143/deploy/scripts/restore-test.sh /opt/143/deploy/scripts/install-pg-backups.sh && /opt/143/deploy/scripts/install-pg-backups.sh"
+echo "--- DB backups configured on $HOST ---"

--- a/deploy/scripts/provision-db-backups.sh
+++ b/deploy/scripts/provision-db-backups.sh
@@ -49,8 +49,10 @@ if [ -n "${BACKUP_S3_BUCKET:-}" ]; then
   # The official AWS CLI image syncs the local backup dir to S3 with no host
   # package install. `s3 sync` (no --delete) never removes remote objects, so
   # offsite retention is governed by the bucket lifecycle, independent of the
-  # shorter local retention.
-  SYNC_CMD="docker run --rm -e AWS_ACCESS_KEY_ID -e AWS_SECRET_ACCESS_KEY -e AWS_DEFAULT_REGION -v /backups/postgres:/backups:ro public.ecr.aws/aws-cli/aws-cli:latest s3 sync /backups s3://$BACKUP_S3_BUCKET/postgres/ --only-show-errors"
+  # shorter local retention. The image is pinned by digest (not :latest) for
+  # reproducibility — bump AWS_CLI_IMAGE deliberately. (aws-cli v2.35.11.)
+  AWS_CLI_IMAGE="public.ecr.aws/aws-cli/aws-cli@sha256:749bfaf91d690b9a1768083822d620f96c19defdf9ca2dc227eb3695281fda5b"
+  SYNC_CMD="docker run --rm -e AWS_ACCESS_KEY_ID -e AWS_SECRET_ACCESS_KEY -e AWS_DEFAULT_REGION -v /backups/postgres:/backups:ro $AWS_CLI_IMAGE s3 sync /backups s3://$BACKUP_S3_BUCKET/postgres/ --only-show-errors"
   printf '# Managed by deploy/scripts/provision-db-backups.sh — do not edit by hand.\n# Offsite sync config sourced by pg-backup.sh after each verified dump.\nexport AWS_ACCESS_KEY_ID=%s\nexport AWS_SECRET_ACCESS_KEY=%s\nexport AWS_DEFAULT_REGION=%s\nexport BACKUP_SYNC_CMD=%s\n' \
     "$BACKUP_AWS_ACCESS_KEY_ID" "$BACKUP_AWS_SECRET_ACCESS_KEY" "$BACKUP_S3_REGION" "'$SYNC_CMD'" \
     | ssh "${SSH_OPTS[@]}" root@"$HOST" 'cat > /opt/143/backup-sync.env && chown deploy:deploy /opt/143/backup-sync.env && chmod 600 /opt/143/backup-sync.env'

--- a/deploy/scripts/provision-db-backups.sh
+++ b/deploy/scripts/provision-db-backups.sh
@@ -7,6 +7,16 @@
 # end of provision-db and exposed for standalone runs as
 # `make provision-db-backups`.
 #
+# Offsite sync: if BACKUP_S3_BUCKET is set in the environment (the Makefile
+# target and provision.sh resolve it from .env.production.enc), this also
+# writes /opt/143/backup-sync.env so pg-backup.sh ships each verified dump to
+# S3. When it is unset, any existing backup-sync.env on the host is left
+# untouched and offsite stays as-is.
+#
+# Required env for offsite (all four, or none):
+#   BACKUP_S3_BUCKET, BACKUP_S3_REGION,
+#   BACKUP_AWS_ACCESS_KEY_ID, BACKUP_AWS_SECRET_ACCESS_KEY
+#
 # Usage:
 #   provision-db-backups.sh <host> [ssh_key]
 
@@ -27,6 +37,27 @@ scp "${SCP_OPTS[@]}" \
   "$SCRIPT_DIR/restore-test.sh" \
   "$SCRIPT_DIR/install-pg-backups.sh" \
   root@"$HOST":/opt/143/deploy/scripts/
+
+# Offsite sync config (optional). Write /opt/143/backup-sync.env from the
+# BACKUP_* env vars when a bucket is configured. The AWS creds are streamed in
+# over SSH stdin (never on the command line) and the file is locked to deploy.
+if [ -n "${BACKUP_S3_BUCKET:-}" ]; then
+  : "${BACKUP_S3_REGION:?BACKUP_S3_REGION required when BACKUP_S3_BUCKET is set}"
+  : "${BACKUP_AWS_ACCESS_KEY_ID:?BACKUP_AWS_ACCESS_KEY_ID required when BACKUP_S3_BUCKET is set}"
+  : "${BACKUP_AWS_SECRET_ACCESS_KEY:?BACKUP_AWS_SECRET_ACCESS_KEY required when BACKUP_S3_BUCKET is set}"
+  echo "--- Writing offsite sync config (s3://$BACKUP_S3_BUCKET/postgres/) ---"
+  # The official AWS CLI image syncs the local backup dir to S3 with no host
+  # package install. `s3 sync` (no --delete) never removes remote objects, so
+  # offsite retention is governed by the bucket lifecycle, independent of the
+  # shorter local retention.
+  SYNC_CMD="docker run --rm -e AWS_ACCESS_KEY_ID -e AWS_SECRET_ACCESS_KEY -e AWS_DEFAULT_REGION -v /backups/postgres:/backups:ro public.ecr.aws/aws-cli/aws-cli:latest s3 sync /backups s3://$BACKUP_S3_BUCKET/postgres/ --only-show-errors"
+  printf '# Managed by deploy/scripts/provision-db-backups.sh — do not edit by hand.\n# Offsite sync config sourced by pg-backup.sh after each verified dump.\nexport AWS_ACCESS_KEY_ID=%s\nexport AWS_SECRET_ACCESS_KEY=%s\nexport AWS_DEFAULT_REGION=%s\nexport BACKUP_SYNC_CMD=%s\n' \
+    "$BACKUP_AWS_ACCESS_KEY_ID" "$BACKUP_AWS_SECRET_ACCESS_KEY" "$BACKUP_S3_REGION" "'$SYNC_CMD'" \
+    | ssh "${SSH_OPTS[@]}" root@"$HOST" 'cat > /opt/143/backup-sync.env && chown deploy:deploy /opt/143/backup-sync.env && chmod 600 /opt/143/backup-sync.env'
+else
+  echo "--- No BACKUP_S3_BUCKET set; leaving offsite sync config unchanged ---"
+fi
+
 ssh "${SSH_OPTS[@]}" root@"$HOST" \
   "chmod +x /opt/143/deploy/scripts/pg-backup.sh /opt/143/deploy/scripts/restore-test.sh /opt/143/deploy/scripts/install-pg-backups.sh && /opt/143/deploy/scripts/install-pg-backups.sh"
 echo "--- DB backups configured on $HOST ---"

--- a/deploy/scripts/provision.sh
+++ b/deploy/scripts/provision.sh
@@ -684,11 +684,12 @@ ssh "${SSH_OPTS[@]}" root@"$HOST" << START
 START
 
 # For db nodes: install automated backups (pg_dump every 6h + weekly restore
-# test). The scripts were copied with the rest of deploy/ above; the installer
-# is idempotent, so this is a no-op on reprovision.
+# test) and the offsite sync config. The wrapper is idempotent, so this is a
+# no-op on reprovision. BACKUP_* (if present in .env.production.enc) were
+# exported above and drive /opt/143/backup-sync.env.
 if [ "$ROLE" = "db" ]; then
-  echo "Installing automated DB backups..."
-  ssh "${SSH_OPTS[@]}" root@"$HOST" "/opt/143/deploy/scripts/install-pg-backups.sh"
+  echo "Configuring DB backups..."
+  "$SCRIPT_DIR/provision-db-backups.sh" "$HOST" "$SSH_KEY"
 fi
 
 # For app nodes: wait for health + run migrations (single SSH session)

--- a/deploy/scripts/provision.sh
+++ b/deploy/scripts/provision.sh
@@ -540,7 +540,7 @@ if [ "$ROLE" = "app" ]; then
   scp "${SCP_OPTS[@]}" "$PROJECT_DIR/Dockerfile.caddy" root@"$HOST":/opt/143/
 fi
 scp "${SCP_OPTS[@]}" -r "$PROJECT_DIR/deploy" root@"$HOST":/opt/143/
-ssh "${SSH_OPTS[@]}" root@"$HOST" "chown -R deploy:deploy /opt/143 && chmod +x /opt/143/deploy/scripts/configure-docker-daemon.sh /opt/143/deploy/scripts/install-log-rotation.sh /opt/143/deploy/scripts/install-docker-dns.sh /opt/143/deploy/scripts/install-tailscale.sh /opt/143/deploy/scripts/reconcile-worker-host.sh /opt/143/deploy/scripts/install-pg-backups.sh /opt/143/deploy/scripts/pg-backup.sh /opt/143/deploy/scripts/restore-test.sh"
+ssh "${SSH_OPTS[@]}" root@"$HOST" "chown -R deploy:deploy /opt/143 && chmod +x /opt/143/deploy/scripts/configure-docker-daemon.sh /opt/143/deploy/scripts/install-log-rotation.sh /opt/143/deploy/scripts/install-docker-dns.sh /opt/143/deploy/scripts/install-tailscale.sh /opt/143/deploy/scripts/reconcile-worker-host.sh"
 
 # Step 2a: Configure Docker daemon hardening in one pass BEFORE step 5
 # starts services. This pins bounded json-file logs and multi-provider DNS

--- a/deploy/scripts/provision.sh
+++ b/deploy/scripts/provision.sh
@@ -540,7 +540,7 @@ if [ "$ROLE" = "app" ]; then
   scp "${SCP_OPTS[@]}" "$PROJECT_DIR/Dockerfile.caddy" root@"$HOST":/opt/143/
 fi
 scp "${SCP_OPTS[@]}" -r "$PROJECT_DIR/deploy" root@"$HOST":/opt/143/
-ssh "${SSH_OPTS[@]}" root@"$HOST" "chown -R deploy:deploy /opt/143 && chmod +x /opt/143/deploy/scripts/configure-docker-daemon.sh /opt/143/deploy/scripts/install-log-rotation.sh /opt/143/deploy/scripts/install-docker-dns.sh /opt/143/deploy/scripts/install-tailscale.sh /opt/143/deploy/scripts/reconcile-worker-host.sh"
+ssh "${SSH_OPTS[@]}" root@"$HOST" "chown -R deploy:deploy /opt/143 && chmod +x /opt/143/deploy/scripts/configure-docker-daemon.sh /opt/143/deploy/scripts/install-log-rotation.sh /opt/143/deploy/scripts/install-docker-dns.sh /opt/143/deploy/scripts/install-tailscale.sh /opt/143/deploy/scripts/reconcile-worker-host.sh /opt/143/deploy/scripts/install-pg-backups.sh /opt/143/deploy/scripts/pg-backup.sh /opt/143/deploy/scripts/restore-test.sh"
 
 # Step 2a: Configure Docker daemon hardening in one pass BEFORE step 5
 # starts services. This pins bounded json-file logs and multi-provider DNS
@@ -682,6 +682,14 @@ ssh "${SSH_OPTS[@]}" root@"$HOST" << START
   set -euo pipefail
   su - deploy -c 'cd /opt/143 && docker compose -f $COMPOSE_FILE_REMOTE up -d'
 START
+
+# For db nodes: install automated backups (pg_dump every 6h + weekly restore
+# test). The scripts were copied with the rest of deploy/ above; the installer
+# is idempotent, so this is a no-op on reprovision.
+if [ "$ROLE" = "db" ]; then
+  echo "Installing automated DB backups..."
+  ssh "${SSH_OPTS[@]}" root@"$HOST" "/opt/143/deploy/scripts/install-pg-backups.sh"
+fi
 
 # For app nodes: wait for health + run migrations (single SSH session)
 if [ "$ROLE" = "app" ]; then

--- a/deploy/scripts/restore-test.sh
+++ b/deploy/scripts/restore-test.sh
@@ -2,12 +2,17 @@
 set -euo pipefail
 
 # Automated backup restore verification.
-# Run weekly via cron to confirm backups are actually restorable.
-#   0 4 * * 0 /opt/143/deploy/scripts/restore-test.sh >> /var/log/restore-test.log 2>&1
+# Run weekly via cron (installed by install-pg-backups.sh) to confirm backups
+# are actually restorable.
 
 BACKUP_DIR="${BACKUP_DIR:-/backups/postgres}"
 DB_USER="${POSTGRES_USER:-onefortythree}"
 DB_NAME="${POSTGRES_DB:-onefortythree}"
+# Must match the major version of the production server (docker-compose.db.yml):
+# pg_restore from an older server rejects a newer custom-format archive
+# ("unsupported version in file header"), which would fail the drill it is
+# meant to validate. Override only to test against a different image.
+POSTGRES_IMAGE="${POSTGRES_IMAGE:-postgres:18}"
 # Minimum number of non-system tables expected after restore.
 MIN_TABLE_COUNT="${MIN_TABLE_COUNT:-5}"
 
@@ -26,7 +31,7 @@ docker run -d --name "$TEST_CONTAINER" \
   -e POSTGRES_USER="$DB_USER" \
   -e POSTGRES_PASSWORD=test \
   -e POSTGRES_DB="$DB_NAME" \
-  postgres:17
+  "$POSTGRES_IMAGE"
 
 # Wait for Postgres to be ready
 for i in $(seq 1 30); do

--- a/docs/design/36-docker-agents-vps-architecture.md
+++ b/docs/design/36-docker-agents-vps-architecture.md
@@ -976,12 +976,16 @@ These checks are provider-agnostic — they query Postgres directly.
       blast-radius isolation. Versioning on, public access blocked, SSE-S3,
       30-day lifecycle (offsite retention is independent of the 7-day local
       retention because `s3 sync` never deletes). Scoped IAM user
-      `143-db-backup-bot` (s3:ListBucket/PutObject/GetObject on that bucket
-      only). Verified 2026-06-27.
+      `143-db-backup-bot` is **write-only** — `s3:ListBucket` + `s3:PutObject`
+      on that bucket only (no GetObject/Delete), so the creds (which propagate
+      to app/worker hosts via the enc bundle) can't exfiltrate or destroy
+      backups; restores use admin creds. The `aws-cli` image is pinned by
+      digest. Verified 2026-06-27.
 - [ ] Enable WAL-G archiving (Layer 3) — **required before accepting users**
 - [x] Run a restore drill — `restore-test.sh` runs weekly and restores the
-      newest dump into a throwaway Postgres; verified manually on 2026-06-27.
-      WAL-G restore still pending Layer 3.
+      newest dump into a throwaway Postgres (image pinned to the prod major,
+      `postgres:18`); verified manually on 2026-06-27. WAL-G restore still
+      pending Layer 3.
 - [ ] Set up monitoring (Datadog, Prometheus, or even just cron + email alerts)
 
 ### Environment Variables (Backup & Recovery)

--- a/docs/design/36-docker-agents-vps-architecture.md
+++ b/docs/design/36-docker-agents-vps-architecture.md
@@ -966,10 +966,18 @@ These checks are provider-agnostic — they query Postgres directly.
       Installs `/etc/cron.d/143-pg-backup`: `pg-backup.sh` every 6h (verified
       pg_dump, 7-day local retention) + `restore-test.sh` weekly. Note: local
       retention is 7 days (not 30) so 6-hourly ~900 MB dumps don't fill the disk.
-- [ ] Configure offsite backup sync (`rclone` to S3-compatible storage) —
-      hook is wired: set `BACKUP_SYNC_CMD` in `/opt/143/backup-sync.env` and
-      `pg-backup.sh` ships each verified dump offsite. Still needs a bucket +
-      `rclone` config on the db host.
+- [x] Configure offsite backup sync — `pg-backup.sh` ships each verified dump
+      to S3 after every run, via `BACKUP_SYNC_CMD` in `/opt/143/backup-sync.env`
+      (the official `aws-cli` Docker image, so no host package installs).
+      `provision-db-backups.sh` writes that file from the `BACKUP_*` vars in
+      `.env.production.enc`, so reprovision recreates it. Bucket
+      `143-prod-db-backups-407539787773-us-east-1` lives in the **isolated
+      143.dev account (407539787773)**, not the shared prod account — DR
+      blast-radius isolation. Versioning on, public access blocked, SSE-S3,
+      30-day lifecycle (offsite retention is independent of the 7-day local
+      retention because `s3 sync` never deletes). Scoped IAM user
+      `143-db-backup-bot` (s3:ListBucket/PutObject/GetObject on that bucket
+      only). Verified 2026-06-27.
 - [ ] Enable WAL-G archiving (Layer 3) — **required before accepting users**
 - [x] Run a restore drill — `restore-test.sh` runs weekly and restores the
       newest dump into a throwaway Postgres; verified manually on 2026-06-27.

--- a/docs/design/36-docker-agents-vps-architecture.md
+++ b/docs/design/36-docker-agents-vps-architecture.md
@@ -960,10 +960,20 @@ These checks are provider-agnostic — they query Postgres directly.
 
 ### Phase 2 Checklist
 
-- [ ] Set up `pg-backup.sh` cron (Layer 2)
-- [ ] Configure offsite backup sync (`rclone` to S3-compatible storage)
+- [x] Set up `pg-backup.sh` cron (Layer 2) — automated via
+      `deploy/scripts/install-pg-backups.sh`, run at the end of `make
+      provision-db` and re-runnable standalone with `make provision-db-backups`.
+      Installs `/etc/cron.d/143-pg-backup`: `pg-backup.sh` every 6h (verified
+      pg_dump, 7-day local retention) + `restore-test.sh` weekly. Note: local
+      retention is 7 days (not 30) so 6-hourly ~900 MB dumps don't fill the disk.
+- [ ] Configure offsite backup sync (`rclone` to S3-compatible storage) —
+      hook is wired: set `BACKUP_SYNC_CMD` in `/opt/143/backup-sync.env` and
+      `pg-backup.sh` ships each verified dump offsite. Still needs a bucket +
+      `rclone` config on the db host.
 - [ ] Enable WAL-G archiving (Layer 3) — **required before accepting users**
-- [ ] Run a restore drill — verify both pg_dump and WAL-G restores work
+- [x] Run a restore drill — `restore-test.sh` runs weekly and restores the
+      newest dump into a throwaway Postgres; verified manually on 2026-06-27.
+      WAL-G restore still pending Layer 3.
 - [ ] Set up monitoring (Datadog, Prometheus, or even just cron + email alerts)
 
 ### Environment Variables (Backup & Recovery)


### PR DESCRIPTION
## Summary

The prod db node had **no automated backups**. `pg-backup.sh` existed but was never scheduled — and would have failed anyway: it ran `pg_dump` with no password while the container requires `scram-sha-256` even on the local socket, so every run errored and `/backups/postgres` never existed.

This PR ships verified, scheduled backups and makes them part of standard db provisioning, plus a standalone make target.

## Changes

- **`deploy/scripts/pg-backup.sh`** — read `DB_PASSWORD` from `/opt/143/.env` and pass `PGPASSWORD` to the in-container `pg_dump` so it can actually connect. Add an opt-in offsite-sync hook (`BACKUP_SYNC_CMD` from `/opt/143/backup-sync.env`) that ships each verified dump offsite. Lower default local retention **30 → 7 days**.
- **`deploy/scripts/install-pg-backups.sh`** (new) — idempotent host-side installer; writes `/etc/cron.d/143-pg-backup` (`pg-backup.sh` every 6h + `restore-test.sh` weekly) and creates `/backups/postgres`. Re-running is a no-op.
- **`deploy/scripts/provision-db-backups.sh`** (new) — local wrapper that ships the scripts and runs the installer over root SSH.
- **`deploy/scripts/provision.sh`** — install backups automatically at the end of db provisioning.
- **`Makefile`** — new **`make provision-db-backups`** target (resolves the db host from `FLEET_HOSTS`, idempotent, runnable standalone).

Satisfies both: part of `make provision-db` **and** a separate `make provision-db-backups` runnable any time.

## Retention math

~900 MB/dump × 4/day × 30 days ≈ 108 GB would nearly fill the 130 GB-free disk, so local retention is 7 days (~25 GB). Long-term history is meant to live offsite.

## Verification (run against prod `87.99.157.99`)

- `make provision-db-backups` installed `/etc/cron.d/143-pg-backup`; cron daemon active.
- A real backup run produced a **valid 902 MB dump (211 tables)** in `/backups/postgres`, confirmed restorable via `pg_restore --list`.
- Re-running the installer is a clean no-op (idempotent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)