### PR TITLE
Prevent diff view blips by stabilizing diff identity during active polling

### DIFF
--- a/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.performance.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.performance.test.tsx
@@ -393,6 +393,58 @@ describe("SessionDetailContent performance", () => {
     expect(diffRequestCount).toBe(1);
   });
 
+  it("does not refetch the diff when active detail polling only changes collection time", async () => {
+    const { SessionDetailContent } = await import("./session-detail-content");
+    let sessionRequestCount = 0;
+    let diffRequestCount = 0;
+
+    server.use(
+      http.get("/api/v1/sessions/:id", () => {
+        sessionRequestCount += 1;
+        return HttpResponse.json({
+          data: {
+            ...mockSessions[0],
+            primary_issue_id: undefined,
+            status: "running",
+            sandbox_state: "running",
+            diff: undefined,
+            diff_stats: { added: 2, removed: 2, files_changed: 2 },
+            latest_diff_snapshot_id: "snapshot-1",
+            diff_collected_at: `2026-02-17T07:05:0${Math.min(sessionRequestCount, 9)}Z`,
+          },
+        } satisfies SingleResponse<Session>);
+      }),
+      http.get("/api/v1/sessions/:id/timeline", () => {
+        return HttpResponse.json({ data: [], meta: {} } satisfies ListResponse<SessionTimelineEntry>);
+      }),
+      http.get("/api/v1/sessions/:id/diff", () => {
+        diffRequestCount += 1;
+        return HttpResponse.json({
+          data: {
+            session_id: "session-abcdef12-3456-7890",
+            diff: reviewPerfDiff,
+            diff_stats: { added: 2, removed: 2, files_changed: 2 },
+            diff_history: [],
+            diff_truncated: false,
+            diff_history_truncated: false,
+          },
+        });
+      }),
+    );
+
+    renderWithProviders(
+      <SessionDetailContent id="session-abcdef12-3456-7890" />,
+      { searchParams: { review: "active" } },
+    );
+
+    await screen.findByTestId("review-diff-view-mock");
+    await waitFor(() => {
+      expect(sessionRequestCount).toBeGreaterThanOrEqual(2);
+    });
+
+    expect(diffRequestCount).toBe(1);
+  });
+
   it("does not load the hidden transcript before direct review links render the diff", async () => {
     const { SessionDetailContent } = await import("./session-detail-content");
     let timelineRequestCount = 0;

--- a/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
@@ -3602,9 +3602,9 @@ export function SessionDetailContent({ id }: { id: string }) {
   );
   const diffRevisionKey = useMemo(() => {
     if (!session) return null;
+    const diffIdentity = session.latest_diff_snapshot_id ?? session.diff_collected_at ?? "";
     return [
-      session.diff_collected_at ?? "",
-      session.latest_diff_snapshot_id ?? "",
+      diffIdentity,
       session.diff_stats?.added ?? "",
       session.diff_stats?.removed ?? "",
       session.diff_stats?.files_changed ?? "",

--- a/frontend/src/components/code-review/file-diff-section.test.tsx
+++ b/frontend/src/components/code-review/file-diff-section.test.tsx
@@ -219,6 +219,33 @@ describe("FileDiffSection", () => {
     expect(screen.getByText(/added line 800\|old:null\|new:801/)).toBeInTheDocument();
   });
 
+  it("does not collapse expanded large diffs when the same diff is reparsed", async () => {
+    const user = userEvent.setup();
+    const lines = Array.from({ length: 901 }, (_, index) =>
+      makeLine("add", `added line ${index}`, null, index + 1)
+    );
+    const file = makeDiffFile({ hunks: [makeHunk(lines)] });
+    const { rerender } = render(<FileDiffSection file={file} viewMode="unified" />);
+
+    await user.click(screen.getByRole("button", { name: "Show more diff lines" }));
+    expect(screen.getByText(/added line 800\|old:null\|new:801/)).toBeInTheDocument();
+
+    rerender(
+      <FileDiffSection
+        file={{
+          ...file,
+          hunks: file.hunks.map((hunk) => ({
+            ...hunk,
+            lines: hunk.lines.map((line) => ({ ...line })),
+          })),
+        }}
+        viewMode="unified"
+      />
+    );
+
+    expect(screen.getByText(/added line 800\|old:null\|new:801/)).toBeInTheDocument();
+  });
+
   it("renders multiple hunks with context expanders between them", () => {
     const hunk1 = makeHunk(
       [

--- a/frontend/src/components/code-review/file-diff-section.tsx
+++ b/frontend/src/components/code-review/file-diff-section.tsx
@@ -202,6 +202,36 @@ function sliceHunk(hunk: DiffFile["hunks"][number], lineLimit: number): DiffFile
   };
 }
 
+function diffFileContentKey(file: DiffFile): string {
+  let hash = 0;
+  const append = (value: string | number | null | undefined) => {
+    const text = value == null ? "null" : String(value);
+    for (let i = 0; i < text.length; i++) {
+      hash = ((hash << 5) - hash + text.charCodeAt(i)) | 0;
+    }
+    hash = ((hash << 5) - hash + 31) | 0;
+  };
+
+  append(file.oldPath);
+  append(file.newPath);
+  append(file.stats.added);
+  append(file.stats.removed);
+  for (const hunk of file.hunks) {
+    append(hunk.oldStart);
+    append(hunk.oldCount);
+    append(hunk.newStart);
+    append(hunk.newCount);
+    append(hunk.header);
+    for (const line of hunk.lines) {
+      append(line.type);
+      append(line.content);
+      append(line.oldLineNumber);
+      append(line.newLineNumber);
+    }
+  }
+  return `${file.newPath}:${file.hunks.length}:${hash}`;
+}
+
 export const FileDiffSection = forwardRef<HTMLDivElement, FileDiffSectionProps>(
   function FileDiffSection({
     file,
@@ -222,15 +252,17 @@ export const FileDiffSection = forwardRef<HTMLDivElement, FileDiffSectionProps>(
     showInlineCommentComposer = true,
     onRequestEditComment,
   }, ref) {
+    const fileContentKey = useMemo(() => diffFileContentKey(file), [file]);
     const [gapStates, setGapStates] = useState<Map<string, ContextGapState>>(new Map());
     const [visibleLineState, setVisibleLineState] = useState({
-      file,
+      fileContentKey,
       count: INITIAL_RENDERED_DIFF_LINES,
     });
     let visibleLineLimit = visibleLineState.count;
-    if (visibleLineState.file !== file) {
+    if (visibleLineState.fileContentKey !== fileContentKey) {
       visibleLineLimit = INITIAL_RENDERED_DIFF_LINES;
-      setVisibleLineState({ file, count: INITIAL_RENDERED_DIFF_LINES });
+      setVisibleLineState({ fileContentKey, count: INITIAL_RENDERED_DIFF_LINES });
+      setGapStates(new Map());
     }
 
     const buildGapState = useCallback((kind: GapKind, key: string, hiddenStart: number, hiddenEnd: number | undefined, lineDelta: number) => {
@@ -510,7 +542,7 @@ export const FileDiffSection = forwardRef<HTMLDivElement, FileDiffSectionProps>(
                   size="sm"
                   className="text-xs"
                   onClick={() => setVisibleLineState((state) => ({
-                    file,
+                    fileContentKey,
                     count: state.count + RENDERED_DIFF_LINE_INCREMENT,
                   }))}
                 >


### PR DESCRIPTION
## Summary

Active detail polling can cause the session detail page to re-render in a way that makes the diff view “blip” (unnecessarily re-fetching/re-initializing the diff). This change stabilizes the diff identity used for the diff revision key and adds/extends tests to ensure we don’t refetch the diff when only the collection timestamp changes.

## Changes

- Stabilize `diffRevisionKey` by using `latest_diff_snapshot_id` (falling back to `diff_collected_at`) so re-renders from active polling don’t invalidate the diff.
- Add a performance regression test asserting `/api/v1/sessions/:id/diff` is fetched only once when active polling updates only `diff_collected_at`.
- Extend `FileDiffSection` tests to ensure expanded large diffs don’t collapse when the same diff is reparsed.

## Validation

- Frontend tests: `session-detail-content.performance.test.tsx`
- Frontend tests: `file-diff-section.test.tsx`
- Verified updated behavior by asserting request counts for session vs diff endpoints under active polling scenario.

[143.dev](https://143.dev) | [session f51f7ba3](https://143.dev/sessions/f51f7ba3-32da-4b15-8285-3ae85ad7c1fd)

<!-- 143 readiness -->
**143 readiness:** not available for this revision.

Preview: https://143.dev/previews/github/assembledhq/143/pull/1692?launch=1