### PR TITLE
Keep automations list/detail React Query caches in sync after automation mutations

### DIFF
--- a/frontend/src/app/(dashboard)/automations/[id]/page.tsx
+++ b/frontend/src/app/(dashboard)/automations/[id]/page.tsx
@@ -52,6 +52,11 @@ import {
 import { BranchPicker } from "@/components/branch-picker";
 import { AutomationModelSelect } from "@/components/automation-model-select";
 import { api } from "@/lib/api";
+import {
+  removeAutomationFromListCaches,
+  upsertAutomationInListCaches,
+} from "@/lib/automation-list-cache";
+import { queryKeys } from "@/lib/query-keys";
 import { agentTypeForModel } from "@/lib/agents";
 import {
   automationProductTriggerOptions,
@@ -312,10 +317,13 @@ function SettingsTab({
           showReasoningSelector && reasoningEffort ? reasoningEffort : "",
         base_branch: baseBranch.trim() || undefined,
       }),
-    onSuccess: () => {
+    onSuccess: (res) => {
+      upsertAutomationInListCaches(queryClient, res.data);
+      queryClient.setQueryData(queryKeys.automations.detail(res.data.id), res);
       queryClient.invalidateQueries({
-        queryKey: ["automation", automation.id],
+        queryKey: queryKeys.automations.detail(res.data.id),
       });
+      queryClient.invalidateQueries({ queryKey: queryKeys.automations.all });
     },
   });
   const capabilityMutation = useMutation({
@@ -366,8 +374,16 @@ function SettingsTab({
                 disabled={updateMutation.isPending}
                 onSavedApply={(updated) => {
                   setGoal(updated.goal);
+                  upsertAutomationInListCaches(queryClient, updated);
+                  queryClient.setQueryData(
+                    queryKeys.automations.detail(updated.id),
+                    { data: updated },
+                  );
                   queryClient.invalidateQueries({
-                    queryKey: ["automation", automation.id],
+                    queryKey: queryKeys.automations.detail(updated.id),
+                  });
+                  queryClient.invalidateQueries({
+                    queryKey: queryKeys.automations.all,
                   });
                 }}
               />
@@ -809,7 +825,7 @@ export default function AutomationDetailPage() {
   const [detailsOpen, setDetailsOpen] = useState(false);
 
   const { data, isLoading } = useQuery({
-    queryKey: ["automation", automationId],
+    queryKey: queryKeys.automations.detail(automationId),
     queryFn: () => api.automations.get(automationId),
     refetchInterval: 10000,
   });
@@ -825,14 +841,30 @@ export default function AutomationDetailPage() {
 
   const pauseMutation = useMutation({
     mutationFn: () => api.automations.pause(automationId),
-    onSuccess: () =>
-      queryClient.invalidateQueries({ queryKey: ["automation", automationId] }),
+    onSuccess: (res) => {
+      upsertAutomationInListCaches(queryClient, res.data);
+      queryClient.setQueryData(queryKeys.automations.detail(res.data.id), res);
+      return Promise.all([
+        queryClient.invalidateQueries({
+          queryKey: queryKeys.automations.detail(res.data.id),
+        }),
+        queryClient.invalidateQueries({ queryKey: queryKeys.automations.all }),
+      ]);
+    },
   });
 
   const resumeMutation = useMutation({
     mutationFn: () => api.automations.resume(automationId),
-    onSuccess: () =>
-      queryClient.invalidateQueries({ queryKey: ["automation", automationId] }),
+    onSuccess: (res) => {
+      upsertAutomationInListCaches(queryClient, res.data);
+      queryClient.setQueryData(queryKeys.automations.detail(res.data.id), res);
+      return Promise.all([
+        queryClient.invalidateQueries({
+          queryKey: queryKeys.automations.detail(res.data.id),
+        }),
+        queryClient.invalidateQueries({ queryKey: queryKeys.automations.all }),
+      ]);
+    },
   });
 
   // runNowInFlight guards against rapid double-clicks that can slip through
@@ -859,7 +891,14 @@ export default function AutomationDetailPage() {
 
   const deleteMutation = useMutation({
     mutationFn: () => api.automations.del(automationId),
-    onSuccess: () => router.push("/automations"),
+    onSuccess: () => {
+      removeAutomationFromListCaches(queryClient, automationId);
+      queryClient.removeQueries({
+        queryKey: queryKeys.automations.detail(automationId),
+      });
+      queryClient.invalidateQueries({ queryKey: queryKeys.automations.all });
+      router.push("/automations");
+    },
   });
 
   const iconMutation = useMutation({
@@ -870,14 +909,13 @@ export default function AutomationDetailPage() {
       }),
     onMutate: async (iconValue: string) => {
       await queryClient.cancelQueries({
-        queryKey: ["automation", automationId],
+        queryKey: queryKeys.automations.detail(automationId),
       });
-      const previous = queryClient.getQueryData<typeof data>([
-        "automation",
-        automationId,
-      ]);
+      const previous = queryClient.getQueryData<typeof data>(
+        queryKeys.automations.detail(automationId),
+      );
       queryClient.setQueryData<typeof data>(
-        ["automation", automationId],
+        queryKeys.automations.detail(automationId),
         (current) => {
           if (!current?.data) return current;
           return {
@@ -895,16 +933,23 @@ export default function AutomationDetailPage() {
     onError: (_err, _iconValue, context) => {
       if (context?.previous) {
         queryClient.setQueryData(
-          ["automation", automationId],
+          queryKeys.automations.detail(automationId),
           context.previous,
         );
       }
     },
     onSuccess: (updated) => {
-      queryClient.setQueryData(["automation", automationId], updated);
+      upsertAutomationInListCaches(queryClient, updated.data);
+      queryClient.setQueryData(
+        queryKeys.automations.detail(automationId),
+        updated,
+      );
+      queryClient.invalidateQueries({ queryKey: queryKeys.automations.all });
     },
     onSettled: () => {
-      queryClient.invalidateQueries({ queryKey: ["automation", automationId] });
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.automations.detail(automationId),
+      });
     },
   });
 

--- a/frontend/src/app/(dashboard)/automations/new/page.test.tsx
+++ b/frontend/src/app/(dashboard)/automations/new/page.test.tsx
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi, beforeEach } from "vitest";
 import { http, HttpResponse } from "msw";
+import { QueryClient } from "@tanstack/react-query";
 import {
   fireEvent,
   renderWithProviders,
@@ -11,6 +12,8 @@ import {
 import { server } from "@/test/mocks/server";
 import NewAutomationPage from "./page";
 import { AUTOMATION_GOAL_MAX_LENGTH } from "@/lib/automation-validation";
+import { queryKeys } from "@/lib/query-keys";
+import type { Automation, ListResponse, SingleResponse } from "@/lib/types";
 
 const DRAFT_STORAGE_KEY = "143:new-automation-draft";
 const pushMock = vi.fn();
@@ -403,6 +406,118 @@ describe("NewAutomationPage", () => {
     expect(requestBody).not.toHaveProperty("interval_value");
     expect(requestBody).not.toHaveProperty("interval_unit");
     expect(requestBody).not.toHaveProperty("interval_run_at");
+  });
+
+  it("updates the automations list and detail caches after creating an automation", async () => {
+    const user = userEvent.setup();
+    const queryClient = new QueryClient({
+      defaultOptions: {
+        queries: {
+          retry: false,
+        },
+      },
+    });
+    const existingAutomation: Automation = {
+      id: "automation-existing",
+      org_id: "org-1",
+      repository_id: "repo-1",
+      name: "Existing automation",
+      goal: "Keep existing recurring work visible.",
+      icon_type: "emoji",
+      icon_value: "⚙️",
+      execution_mode: "sequential",
+      max_concurrent: 1,
+      base_branch: "main",
+      identity_scope: "org",
+      pre_pr_review_loops: 1,
+      schedule_type: "interval",
+      interval_value: 1,
+      interval_unit: "days",
+      interval_run_at: "09:00",
+      timezone: "UTC",
+      enabled: true,
+      priority: 50,
+      github_event_triggers: [],
+      created_at: "2026-03-04T12:00:00Z",
+      updated_at: "2026-03-04T12:00:00Z",
+    };
+    const createdAutomation: Automation = {
+      ...existingAutomation,
+      id: "automation-1",
+      name: "PR feedback responder",
+      goal: "Respond to new PR feedback.",
+      schedule_type: "none",
+      interval_value: undefined,
+      interval_unit: undefined,
+      interval_run_at: undefined,
+      created_at: "2026-03-05T12:00:00Z",
+      updated_at: "2026-03-05T12:00:00Z",
+    };
+    const createdResponse: SingleResponse<Automation> = {
+      data: createdAutomation,
+    };
+
+    queryClient.setQueryData<ListResponse<Automation>>(
+      queryKeys.automations.all,
+      {
+        data: [existingAutomation],
+        meta: {},
+      },
+    );
+
+    server.use(
+      http.get("/api/v1/repositories", () =>
+        HttpResponse.json({
+          data: [
+            {
+              id: "repo-1",
+              org_id: "org-1",
+              integration_id: "int-1",
+              github_id: 1,
+              full_name: "acme/repo",
+              default_branch: "main",
+              private: false,
+              clone_url: "https://github.com/acme/repo.git",
+              installation_id: 10,
+              status: "active",
+              settings: {},
+              created_at: "2026-03-05T12:00:00Z",
+              updated_at: "2026-03-05T12:00:00Z",
+            },
+          ],
+          meta: {},
+        }),
+      ),
+      http.post("/api/v1/automations", () =>
+        HttpResponse.json(createdResponse, { status: 201 }),
+      ),
+    );
+
+    renderWithProviders(<NewAutomationPage />, { queryClient });
+
+    fireEvent.change(await screen.findByLabelText("Name"), {
+      target: { value: "PR feedback responder" },
+    });
+    fireEvent.change(screen.getByLabelText("Goal"), {
+      target: { value: "Respond to new PR feedback." },
+    });
+    await user.click(screen.getByLabelText("On a schedule"));
+    await user.click(screen.getByLabelText("When there is new PR feedback"));
+    await user.click(screen.getByRole("button", { name: "Create automation" }));
+
+    await waitFor(() => {
+      expect(pushMock).toHaveBeenCalledWith("/automations/automation-1");
+    });
+    expect(
+      queryClient.getQueryData<ListResponse<Automation>>(
+        queryKeys.automations.all,
+      )?.data,
+    ).toEqual([createdAutomation, existingAutomation]);
+    expect(
+      queryClient.getQueryData<SingleResponse<Automation>>(
+        queryKeys.automations.detail("automation-1"),
+      ),
+    ).toEqual(createdResponse);
   });
 
   it("submits an event-only PagerDuty incident automation", async () => {

--- a/frontend/src/app/(dashboard)/automations/new/page.tsx
+++ b/frontend/src/app/(dashboard)/automations/new/page.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { useMutation, useQuery } from "@tanstack/react-query";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import {
   ChevronDown,
   Loader2,
@@ -84,6 +84,7 @@ import {
   saveAutomationDraft,
   type AutomationFormState,
 } from "@/lib/automation-draft";
+import { upsertAutomationInListCaches } from "@/lib/automation-list-cache";
 import type {
   AgentCapabilityDefinition,
   AutomationEventTriggerInput,
@@ -189,6 +190,7 @@ function formatWeeklyRunHint(
 
 export default function NewAutomationPage() {
   const router = useRouter();
+  const queryClient = useQueryClient();
   const searchParams = useSearchParams();
   const { user, isLoading } = useAuth();
   const canManage = user?.role === "admin" || user?.role === "member";
@@ -593,6 +595,11 @@ export default function NewAutomationPage() {
         ...(capabilityOverride ? { capabilities: capabilityOverride } : {}),
       }),
     onSuccess: (res) => {
+      upsertAutomationInListCaches(queryClient, res.data, {
+        prependIfMissing: true,
+      });
+      queryClient.setQueryData(queryKeys.automations.detail(res.data.id), res);
+      queryClient.invalidateQueries({ queryKey: queryKeys.automations.all });
       draftPersistenceDisabledRef.current = true;
       if (draftSaveTimerRef.current) {
         clearTimeout(draftSaveTimerRef.current);

--- a/frontend/src/app/(dashboard)/automations/page.tsx
+++ b/frontend/src/app/(dashboard)/automations/page.tsx
@@ -5,6 +5,11 @@ import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { ArrowRight, Pause, Play, MoreHorizontal, Plus, Search, Trash2 } from "lucide-react";
 import Link from "next/link";
 import { api } from "@/lib/api";
+import {
+  removeAutomationFromListCaches,
+  upsertAutomationInListCaches,
+} from "@/lib/automation-list-cache";
+import { queryKeys } from "@/lib/query-keys";
 import { formatDateTime, formatTimeAgo } from "@/lib/utils";
 import type { Automation } from "@/lib/types";
 import {
@@ -394,12 +399,20 @@ function AutomationActions({ automation, canManage }: { automation: Automation; 
 
   const pauseMutation = useMutation({
     mutationFn: () => api.automations.pause(automation.id),
-    onSuccess: () => queryClient.invalidateQueries({ queryKey: ["automations"] }),
+    onSuccess: (res) => {
+      upsertAutomationInListCaches(queryClient, res.data);
+      queryClient.setQueryData(queryKeys.automations.detail(res.data.id), res);
+      queryClient.invalidateQueries({ queryKey: queryKeys.automations.all });
+    },
   });
 
   const resumeMutation = useMutation({
     mutationFn: () => api.automations.resume(automation.id),
-    onSuccess: () => queryClient.invalidateQueries({ queryKey: ["automations"] }),
+    onSuccess: (res) => {
+      upsertAutomationInListCaches(queryClient, res.data);
+      queryClient.setQueryData(queryKeys.automations.detail(res.data.id), res);
+      queryClient.invalidateQueries({ queryKey: queryKeys.automations.all });
+    },
   });
 
   // deleteInFlight closes the same render-tick race that runNowInFlight does on
@@ -409,7 +422,13 @@ function AutomationActions({ automation, canManage }: { automation: Automation; 
   const deleteInFlight = useRef(false);
   const deleteMutation = useMutation({
     mutationFn: () => api.automations.del(automation.id),
-    onSuccess: () => queryClient.invalidateQueries({ queryKey: ["automations"] }),
+    onSuccess: () => {
+      removeAutomationFromListCaches(queryClient, automation.id);
+      queryClient.removeQueries({
+        queryKey: queryKeys.automations.detail(automation.id),
+      });
+      queryClient.invalidateQueries({ queryKey: queryKeys.automations.all });
+    },
     onSettled: () => {
       deleteInFlight.current = false;
     },
@@ -522,7 +541,7 @@ export default function AutomationsPage() {
   const { user } = useAuth();
   const canManage = user?.role === "admin" || user?.role === "member";
   const { data, isLoading } = useQuery({
-    queryKey: ["automations"],
+    queryKey: queryKeys.automations.all,
     queryFn: () => api.automations.list(),
     refetchInterval: 10000,
   });

--- a/frontend/src/lib/automation-list-cache.test.ts
+++ b/frontend/src/lib/automation-list-cache.test.ts
@@ -1,0 +1,131 @@
+import { QueryClient } from "@tanstack/react-query";
+import { describe, expect, it } from "vitest";
+import {
+  removeAutomationFromListCaches,
+  upsertAutomationInListCaches,
+} from "./automation-list-cache";
+import { queryKeys } from "./query-keys";
+import type { Automation, ListResponse } from "./types";
+
+function makeAutomation(overrides: Partial<Automation> = {}): Automation {
+  return {
+    id: "automation-1",
+    org_id: "org-1",
+    repository_id: "repo-1",
+    name: "Automation",
+    goal: "Do recurring work.",
+    icon_type: "emoji",
+    icon_value: "⚙️",
+    execution_mode: "sequential",
+    max_concurrent: 1,
+    base_branch: "main",
+    identity_scope: "org",
+    pre_pr_review_loops: 1,
+    schedule_type: "interval",
+    interval_value: 1,
+    interval_unit: "days",
+    interval_run_at: "09:00",
+    timezone: "UTC",
+    enabled: true,
+    priority: 50,
+    github_event_triggers: [],
+    created_at: "2026-03-04T12:00:00Z",
+    updated_at: "2026-03-04T12:00:00Z",
+    ...overrides,
+  };
+}
+
+describe("upsertAutomationInListCaches", () => {
+  it("updates existing automations in cached list responses", () => {
+    const queryClient = new QueryClient();
+    const existing = makeAutomation();
+    const other = makeAutomation({ id: "automation-2", name: "Other" });
+    const updated = makeAutomation({
+      name: "Updated automation",
+      enabled: false,
+      updated_at: "2026-03-05T12:00:00Z",
+    });
+
+    queryClient.setQueryData<ListResponse<Automation>>(
+      queryKeys.automations.all,
+      { data: [existing, other], meta: {} },
+    );
+
+    upsertAutomationInListCaches(queryClient, updated);
+
+    expect(
+      queryClient.getQueryData<ListResponse<Automation>>(
+        queryKeys.automations.all,
+      )?.data,
+    ).toEqual([updated, other]);
+  });
+
+  it("does not touch caches that merely share the automations key prefix", () => {
+    const queryClient = new QueryClient();
+    const created = makeAutomation({ id: "automation-created" });
+    const eventTriggersKey = queryKeys.automations.eventTriggers("automation-1");
+    const eventTriggers = { data: [{ id: "trigger-1" }], meta: {} };
+
+    queryClient.setQueryData(eventTriggersKey, eventTriggers);
+
+    upsertAutomationInListCaches(queryClient, created, {
+      prependIfMissing: true,
+    });
+
+    expect(queryClient.getQueryData(eventTriggersKey)).toEqual(eventTriggers);
+  });
+
+  it("prepends missing automations only when requested", () => {
+    const queryClient = new QueryClient();
+    const existing = makeAutomation({ id: "automation-existing" });
+    const created = makeAutomation({ id: "automation-created" });
+
+    queryClient.setQueryData<ListResponse<Automation>>(
+      queryKeys.automations.all,
+      { data: [existing], meta: {} },
+    );
+
+    upsertAutomationInListCaches(queryClient, created);
+    expect(
+      queryClient.getQueryData<ListResponse<Automation>>(
+        queryKeys.automations.all,
+      )?.data,
+    ).toEqual([existing]);
+
+    upsertAutomationInListCaches(queryClient, created, {
+      prependIfMissing: true,
+    });
+    expect(
+      queryClient.getQueryData<ListResponse<Automation>>(
+        queryKeys.automations.all,
+      )?.data,
+    ).toEqual([created, existing]);
+  });
+});
+
+describe("removeAutomationFromListCaches", () => {
+  it("removes deleted automations from cached list responses", () => {
+    const queryClient = new QueryClient();
+    const deleted = makeAutomation({ id: "automation-deleted" });
+    const other = makeAutomation({ id: "automation-2", name: "Other" });
+
+    queryClient.setQueryData<ListResponse<Automation>>(
+      queryKeys.automations.all,
+      { data: [deleted, other], meta: {} },
+    );
+    queryClient.setQueryData(queryKeys.automations.detail(deleted.id), {
+      data: deleted,
+    });
+
+    removeAutomationFromListCaches(queryClient, deleted.id);
+
+    expect(
+      queryClient.getQueryData<ListResponse<Automation>>(
+        queryKeys.automations.all,
+      )?.data,
+    ).toEqual([other]);
+    expect(
+      queryClient.getQueryData(queryKeys.automations.detail(deleted.id)),
+    ).toEqual({ data: deleted });
+  });
+});

--- a/frontend/src/lib/automation-list-cache.ts
+++ b/frontend/src/lib/automation-list-cache.ts
@@ -1,0 +1,73 @@
+import type { QueryClient } from "@tanstack/react-query";
+import { queryKeys } from "./query-keys";
+import type { Automation, ListResponse } from "./types";
+
+function isAutomationListResponse(value: unknown): value is ListResponse<Automation> {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "data" in value &&
+    Array.isArray((value as { data?: unknown }).data)
+  );
+}
+
+export function upsertAutomationInListCaches(
+  queryClient: QueryClient,
+  automation: Automation,
+  options: { prependIfMissing?: boolean } = {},
+): void {
+  const cachedLists = queryClient.getQueriesData<ListResponse<Automation>>({
+    queryKey: queryKeys.automations.all,
+    exact: true,
+  });
+
+  for (const [key, current] of cachedLists) {
+    if (!isAutomationListResponse(current)) {
+      continue;
+    }
+
+    let changed = false;
+    const nextData = current.data.map((cachedAutomation) => {
+      if (cachedAutomation.id !== automation.id) {
+        return cachedAutomation;
+      }
+      changed = true;
+      return automation;
+    });
+
+    if (!changed && options.prependIfMissing) {
+      queryClient.setQueryData(key, {
+        ...current,
+        data: [automation, ...current.data],
+      });
+      continue;
+    }
+
+    if (changed) {
+      queryClient.setQueryData(key, { ...current, data: nextData });
+    }
+  }
+}
+
+export function removeAutomationFromListCaches(
+  queryClient: QueryClient,
+  automationID: string,
+): void {
+  const cachedLists = queryClient.getQueriesData<ListResponse<Automation>>({
+    queryKey: queryKeys.automations.all,
+    exact: true,
+  });
+
+  for (const [key, current] of cachedLists) {
+    if (!isAutomationListResponse(current)) {
+      continue;
+    }
+
+    const nextData = current.data.filter(
+      (automation) => automation.id !== automationID,
+    );
+    if (nextData.length !== current.data.length) {
+      queryClient.setQueryData(key, { ...current, data: nextData });
+    }
+  }
+}

--- a/frontend/src/lib/query-keys.test.ts
+++ b/frontend/src/lib/query-keys.test.ts
@@ -91,6 +91,16 @@ describe("queryKeys", () => {
     });
   });
 
+  describe("automations", () => {
+    it("all returns static key", () => {
+      expect(queryKeys.automations.all).toEqual(["automations"]);
+    });
+
+    it("detail includes automation id", () => {
+      expect(queryKeys.automations.detail("automation-1")).toEqual(["automation", "automation-1"]);
+    });
+  });
+
   describe("evals", () => {
     it("tasks returns key with optional params", () => {
       expect(queryKeys.evals.tasks()).toEqual(["evals", "tasks", undefined]);

--- a/frontend/src/lib/query-keys.ts
+++ b/frontend/src/lib/query-keys.ts
@@ -92,6 +92,8 @@ export const queryKeys = {
     pagerDutyIncidents: (integrationId?: string | null) => ["integrations", "pagerduty", "incidents", integrationId ?? null] as const,
   },
   automations: {
+    all: ["automations"] as const,
+    detail: (id: string) => ["automation", id] as const,
     eventTriggers: (id: string) => ["automations", id, "event-triggers"] as const,
   },
   autopilot: {

--- a/frontend/src/test/test-utils.tsx
+++ b/frontend/src/test/test-utils.tsx
@@ -30,17 +30,22 @@ function TestProviders({ children }: { children: React.ReactNode }) {
 
 interface RenderWithProvidersOptions extends Omit<RenderOptions, 'wrapper'> {
   searchParams?: Record<string, string>;
+  queryClient?: QueryClient;
 }
 
 function renderWithProviders(
   ui: React.ReactElement,
   options?: RenderWithProvidersOptions,
 ) {
-  const { searchParams, ...renderOptions } = options ?? {};
+  const {
+    searchParams,
+    queryClient: providedQueryClient,
+    ...renderOptions
+  } = options ?? {};
 
-  if (searchParams) {
+  if (searchParams || providedQueryClient) {
     const wrapper = ({ children }: { children: React.ReactNode }) => {
-      const queryClient = createTestQueryClient();
+      const queryClient = providedQueryClient ?? createTestQueryClient();
       return (
         <NuqsTestingAdapter searchParams={searchParams}>
           <QueryClientProvider client={queryClient}>


### PR DESCRIPTION
## Summary

The automations UI could show stale list/detail data after creating or mutating an automation, forcing users to wait for the next refetch (~10s). This change formalizes shared automation query keys and adds a cache-sync helper so every mutation updates the list cache and the specific detail cache immediately.

## Changes

- Added `automation-list-cache.ts` helper to upsert/remove automation entries across the list-related caches (without relying on delayed invalidation/refetch).
- Standardized query keys in `query-keys.ts` with `queryKeys.automations.all` and `queryKeys.automations.detail(id)`, and updated consumers to use them.
- Wired the cache-sync helper into all relevant automation mutation flows (create/edit/pause/resume) in `[id]/page.tsx` to update list + detail caches and then invalidate `all`/detail as needed.
- Added/updated tests to ensure prefix-sharing cache keys aren’t accidentally mutated and that query key contracts remain stable.

## Validation

- Ran the frontend test suite covering the new helper and query-key behavior, including regression coverage for “prefix-sharing cache landmine”.
- Verified `tsc --noEmit` is clean.
- Confirmed affected page flows (new automation -> list refresh) now reflect changes immediately after mutations, without waiting for the periodic refetch.

[143.dev](https://143.dev) | [session 9195f8ab](https://143.dev/sessions/9195f8ab-da86-45d5-bc79-9bf4460984ab)

<!-- 143 readiness -->
**143 readiness:** not available for this revision.

Preview: https://143.dev/previews/github/assembledhq/143/pull/1696?launch=1