### PR TITLE
Add guarded code-cleanliness-refactor automation template with behavior-protecting test coverage

### DIFF
--- a/frontend/src/lib/automation-templates.test.ts
+++ b/frontend/src/lib/automation-templates.test.ts
@@ -102,4 +102,30 @@ describe("automation template catalog", () => {
     expect(template?.tags).toContain("agents");
     expect(template?.defaultUnit).toBe("weeks");
   });
+
+  it("guides code-cleanliness automations toward guarded behavior-preserving refactors", () => {
+    const template = getAutomationTemplate("code-cleanliness-refactor");
+
+    expect(template?.name).toBe("Code cleanliness refactor");
+    expect(template?.summary).toContain("behavior-preserving cleanup PRs");
+    expect(template?.goal).toContain("behavior should not change");
+    expect(template?.goal).toContain("duplicated code");
+    expect(template?.goal).toContain("duplicated implementations");
+    expect(template?.goal).toContain("small helper function");
+    expect(template?.goal).toContain("Do not perform broad rewrites");
+    expect(template?.goal).toContain("add focused characterization tests first");
+    expect(template?.goal).toContain("Open one or more focused PRs");
+    expect(template?.goal).toContain("If no safe candidate exists, create no PR");
+    expect(template?.goal).toContain("Use existing helpers, conventions, and test patterns");
+    expect(template?.goal).toContain("Do not update internal design docs or public docs");
+    expect(template?.goal).toContain("Add or update focused tests");
+    expect(template?.goal).toContain("accidental behavior changes");
+    expect(template?.goal).toContain("tenant scoping");
+    expect(template?.goal).toContain("Avoid cleanup when the safety case depends mostly on intuition");
+    expect(template?.outcomes).toContain("One or more small behavior-preserving cleanup PRs");
+    expect(template?.outcomes).toContain("Focused tests that protect the existing behavior");
+    expect(template?.tags).toContain("refactor");
+    expect(template?.tags).toContain("tests");
+    expect(template?.defaultUnit).toBe("weeks");
+  });
 });

--- a/frontend/src/lib/automation-templates.ts
+++ b/frontend/src/lib/automation-templates.ts
@@ -250,6 +250,41 @@ Verification
     defaultUnit: "weeks",
   },
   {
+    id: "code-cleanliness-refactor",
+    name: "Code cleanliness refactor",
+    icon: Wrench,
+    category: "maintenance",
+    summary: "Make small, behavior-preserving cleanup PRs that reduce duplication and clarify local code without taking on risky refactors.",
+    goal: `What to do
+- Inspect the repository for small, contained code-cleanliness opportunities where behavior should not change: duplicated code, duplicated implementations, confusing local branching, stale helper shapes, repetitive test fixtures, or simple extraction opportunities.
+- Prioritize cleanup that makes future changes safer: removing duplication, consolidating equivalent logic behind an existing local pattern, improving names only when they reduce real ambiguity, or adding a small helper function when it clearly removes repeated implementation detail.
+- Be conservative. Do not perform broad rewrites, cross-cutting architecture changes, dependency swaps, public API changes, data model changes, styling churn, or refactors that require guessing at intended behavior.
+- Before editing, identify the existing behavior and the tests or commands that can prove it. If coverage is missing for the behavior you need to preserve, add focused characterization tests first, then make the cleanup.
+- Keep each change independently reviewable. If you find unrelated cleanup candidates, split them into separate PRs or list them as follow-up candidates instead of bundling them.
+
+Output requirements
+- Open one or more focused PRs only for cleanup with a clear no-behavior-change argument and enough tests to protect the existing behavior. If no safe candidate exists, create no PR and explain why.
+- Each PR should describe the duplicated or confusing code removed, the behavior that is expected to remain unchanged, and the verification performed.
+- Keep diffs small and local to the affected module or workflow. Prefer one high-confidence cleanup over several loosely related edits.
+- Use existing helpers, conventions, and test patterns before introducing a new abstraction. Add a new helper only when it removes meaningful duplication without hiding important domain behavior.
+- Do not update internal design docs or public docs unless the cleanup unexpectedly changes a durable contract, which should usually disqualify it from this template.
+
+Verification
+- Add or update focused tests that would fail if the refactor changed existing behavior. Characterization tests are required when the behavior is not already covered.
+- Run the narrowest relevant test, lint, typecheck, or vet commands for the touched files or packages, then broaden only if the cleanup crosses package or shared-contract boundaries.
+- Review the final diff for accidental behavior changes: inputs, outputs, errors, ordering, persistence, auth/tenant scoping, API responses, UI text, accessibility semantics, logging, and side effects should remain equivalent.
+- Avoid cleanup when the safety case depends mostly on intuition. Leave risky, large, or ambiguous refactors as explicit follow-up notes instead of implementing them.`,
+    outcomes: [
+      "One or more small behavior-preserving cleanup PRs",
+      "Focused tests that protect the existing behavior",
+      "Clear notes on deferred larger refactors",
+    ],
+    tags: ["refactor", "cleanup", "tests"],
+    defaultInterval: 2,
+    defaultUnit: "weeks",
+    featured: true,
+  },
+  {
     id: "backlog-triage",
     name: "Backlog triage",
     icon: ClipboardList,


### PR DESCRIPTION
## Summary

This PR addresses a reliability gap in automation templates: code-cleanliness requests can drift into broad, behavior-changing refactors unless strong guardrails are encoded. It adds a new `code-cleanliness-refactor` featured maintenance template that explicitly targets small, behavior-preserving cleanup (and instructs “no PR” when the safety case is weak), and locks those expectations in with unit tests.

## Changes

- Added `code-cleanliness-refactor` automation template in `frontend/src/lib/automation-templates.ts`, including a conservative goal/outcomes contract: reduce duplication, prefer small helper extractions, and avoid broad rewrites, architecture churn, or public/data/API changes.
- Included explicit process guidance: identify existing behavior and prove it via tests/commands; if coverage is missing, add focused characterization tests before cleanup.
- Added a new Jest assertion in `frontend/src/lib/automation-templates.test.ts` to verify the template’s name/summary/goal/outcomes/tags/defaultUnit match the intended behavior-preserving guardrails.

## Validation

- `npm test -- --run src/lib/automation-templates.test.ts`  
- `npx eslint src/lib/automation-templates.ts src/lib/automation-templates.test.ts --max-warnings=0`

[143.dev](https://143.dev) | [session 2adcb1dd](https://143.dev/sessions/2adcb1dd-0e7c-4c01-a99e-9cbbb122055a)

<!-- 143 readiness -->
**143 readiness:** not available for this revision.

Preview: https://143.dev/previews/github/assembledhq/143/pull/1699?launch=1