### PR TITLE
Stabilize flaky GitHub-invite team settings test

### DIFF
--- a/frontend/src/app/(dashboard)/settings/team/page.test.tsx
+++ b/frontend/src/app/(dashboard)/settings/team/page.test.tsx
@@ -658,7 +658,11 @@ describe('TeamSettingsPage', () => {
     );
     await user.type(commandInput, 'octo');
 
-    const suggestion = await screen.findByRole('option', { name: '@octocat' });
+    const suggestion = await screen.findByRole(
+      'option',
+      { name: '@octocat' },
+      { timeout: 5000 },
+    );
     await user.click(suggestion);
 
     expect(await screen.findByText('Invite setup')).toBeInTheDocument();


### PR DESCRIPTION
## Summary

The team settings test `keeps the notification email editable after selecting a GitHub user when connected` failed intermittently in CI — passing in isolation but flaking in the full suite. It exercises a chain of a 50ms debounce (`pollMs(200)` shrunk by the test setup) plus an async React Query fetch before the GitHub suggestion `option` renders. The inner `findByRole` still used testing-library's default 1000ms `waitFor` timeout — the test's existing 15s budget only applies at the test level — so under full-suite shared-worker contention the chain occasionally crossed 1s and timed out.

## Changes

- Give the `findByRole('option', { name: '@octocat' })` call in `frontend/src/app/(dashboard)/settings/team/page.test.tsx` an explicit 5s timeout, consistent with the test's existing 15s budget.
- Test-only change; no source or behavior change.

## Validation

- `vitest run "src/app/(dashboard)/settings/team/page.test.tsx"` → 34/34 passing.
