### PR TITLE
Fix auto-repair policy mismatch by applying per-user overrides and syncing post-repair state

### DIFF
--- a/frontend/src/app/(dashboard)/settings/account/page.tsx
+++ b/frontend/src/app/(dashboard)/settings/account/page.tsx
@@ -247,11 +247,11 @@ const PERSONAL_AUTOMATION_COPY: Record<PersonalAutomationKey, { title: string; d
   },
   resolve_conflicts_when_idle: {
     title: "Resolve conflicts when idle",
-    description: "Allow automatic conflict repair for your idle sessions when the org also permits it.",
+    description: "Allow automatic conflict repair for your idle sessions, overriding the organization default when needed.",
   },
   fix_tests_when_idle: {
     title: "Fix failing tests when idle",
-    description: "Allow automatic test repair for your idle sessions when the org also permits it.",
+    description: "Allow automatic test repair for your idle sessions, overriding the organization default when needed.",
   },
 };
 

--- a/internal/services/github/pr_auto_repair.go
+++ b/internal/services/github/pr_auto_repair.go
@@ -156,8 +156,15 @@ func (s *PRService) resolveAutoRepairPolicy(ctx context.Context, orgID uuid.UUID
 		ResolveConflicts: followThrough.ResolveConflictsWhenIdle,
 		FixTests:         followThrough.FixTestsWhenIdle,
 	}
-	source := "organization default"
+	return s.applySessionAutoRepairOverride(ctx, policy, session)
+}
 
+// applySessionAutoRepairOverride layers the session owner's per-user automatic
+// follow-through preferences on top of the supplied organization-default
+// policy. Shared by the auto-repair scheduler and the PR health endpoint so
+// both surfaces resolve the same effective policy.
+func (s *PRService) applySessionAutoRepairOverride(ctx context.Context, policy autoRepairPolicy, session models.Session) (autoRepairPolicy, string, error) {
+	source := "organization default"
 	if session.TriggeredByUserID == nil || s.users == nil {
 		return policy, source, nil
 	}

--- a/internal/services/github/pr_health_service.go
+++ b/internal/services/github/pr_health_service.go
@@ -337,7 +337,7 @@ func (s *PRService) populateActiveRepairs(ctx context.Context, pr models.PullReq
 }
 
 func (s *PRService) populateAutoRepairAttemptState(ctx context.Context, pr models.PullRequest, resp *models.PullRequestHealthResponse) error {
-	if pr.Status != models.PullRequestStatusOpen || resp.HeadSHA == "" || s.pullRequests == nil || s.orgs == nil || s.users == nil {
+	if pr.Status != models.PullRequestStatusOpen || resp.HeadSHA == "" || s.pullRequests == nil || s.orgs == nil {
 		return nil
 	}
 	org, err := s.orgs.GetByID(ctx, pr.OrgID)
@@ -348,15 +348,35 @@ func (s *PRService) populateAutoRepairAttemptState(ctx context.Context, pr model
 	if err != nil {
 		return fmt.Errorf("parse organization settings for automatic repair state: %w", err)
 	}
-	followThrough := settings.SessionAutomation.AutomaticFollowThrough
-	if !followThrough.ResolveConflictsWhenIdle && !followThrough.FixTestsWhenIdle {
+	policy := autoRepairPolicy{
+		ResolveConflicts: settings.SessionAutomation.AutomaticFollowThrough.ResolveConflictsWhenIdle,
+		FixTests:         settings.SessionAutomation.AutomaticFollowThrough.FixTestsWhenIdle,
+	}
+	// Personal preferences can independently flip either action on or off, so
+	// resolve the effective policy whenever the PR has an owning session. This
+	// keeps the exhausted-action badges aligned with what MaybeStartAutoRepair
+	// would actually attempt.
+	if pr.SessionID != nil && s.sessions != nil && s.users != nil {
+		session, err := s.sessions.GetByID(ctx, pr.OrgID, *pr.SessionID)
+		if err != nil {
+			if !errors.Is(err, pgx.ErrNoRows) {
+				return fmt.Errorf("load session for automatic repair state: %w", err)
+			}
+		} else {
+			policy, _, err = s.applySessionAutoRepairOverride(ctx, policy, session)
+			if err != nil {
+				return err
+			}
+		}
+	}
+	if !policy.ResolveConflicts && !policy.FixTests {
 		return nil
 	}
 	for _, action := range []models.PullRequestRepairActionType{models.PullRequestRepairActionTypeResolveConflicts, models.PullRequestRepairActionTypeFixTests} {
-		if action == models.PullRequestRepairActionTypeResolveConflicts && !followThrough.ResolveConflictsWhenIdle {
+		if action == models.PullRequestRepairActionTypeResolveConflicts && !policy.ResolveConflicts {
 			continue
 		}
-		if action == models.PullRequestRepairActionTypeFixTests && !followThrough.FixTestsWhenIdle {
+		if action == models.PullRequestRepairActionTypeFixTests && !policy.FixTests {
 			continue
 		}
 		exhausted, err := s.autoRepairBudgetExhausted(ctx, pr.OrgID, pr.ID, action, resp.HeadSHA)

--- a/internal/services/github/pr_health_service_test.go
+++ b/internal/services/github/pr_health_service_test.go
@@ -595,6 +595,125 @@ func TestPRServiceGetPullRequestHealthEnqueuesSyncAndEnrichment(t *testing.T) {
 	require.NoError(t, mock.ExpectationsWereMet(), "all stale health expectations should be met")
 }
 
+func TestPRServicePopulateAutoRepairAttemptStateUsesPersonalOverride(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "should create pgx mock pool")
+	defer mock.Close()
+
+	orgID := uuid.New()
+	prID := uuid.New()
+	sessionID := uuid.New()
+	userID := uuid.New()
+	now := time.Now().UTC()
+
+	mock.ExpectQuery("SELECT .+ FROM organizations WHERE id = @id").
+		WithArgs(pgx.NamedArgs{"id": orgID}).
+		WillReturnRows(pgxmock.NewRows(prTestOrganizationColumns).AddRow(orgID, "Acme", []byte(`{}`), now, now))
+
+	sessionRow := newPRHealthSessionRow(sessionID, orgID, now, models.SessionStatusCompleted)
+	for i, column := range prHealthSessionColumns {
+		if column == "triggered_by_user_id" {
+			sessionRow[i] = &userID
+			break
+		}
+	}
+	mock.ExpectQuery("SELECT .* FROM sessions WHERE id").
+		WithArgs(pgx.NamedArgs{"id": sessionID, "org_id": orgID}).
+		WillReturnRows(pgxmock.NewRows(prHealthSessionColumns).AddRow(sessionRow...))
+
+	mock.ExpectQuery("SELECT .+ FROM users").
+		WithArgs(pgx.NamedArgs{"id": userID}).
+		WillReturnRows(pgxmock.NewRows([]string{
+			"id", "org_id", "email", "name", "role", "github_id", "github_login", "avatar_url", "google_id", "email_verified_at", "created_at", "settings",
+		}).AddRow(
+			userID, orgID, "dev@example.com", "Dev", "member", (*int64)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*time.Time)(nil), now,
+			[]byte(`{"automatic_pr_follow_through":{"fix_tests_when_idle":"on"}}`),
+		))
+	expectAutoRepairCount(mock, orgID, prID, models.PullRequestRepairActionTypeFixTests, "head-user-on", 1)
+
+	service := &PRService{
+		pullRequests: db.NewPullRequestStore(mock),
+		sessions:     db.NewSessionStore(mock),
+		users:        db.NewUserStore(mock),
+		orgs:         db.NewOrganizationStore(mock),
+		logger:       zerolog.New(io.Discard),
+	}
+	resp := &models.PullRequestHealthResponse{HeadSHA: "head-user-on"}
+	pr := models.PullRequest{
+		ID:        prID,
+		OrgID:     orgID,
+		SessionID: &sessionID,
+		Status:    models.PullRequestStatusOpen,
+	}
+
+	err = service.populateAutoRepairAttemptState(context.Background(), pr, resp)
+	require.NoError(t, err, "populateAutoRepairAttemptState should resolve personal automation overrides")
+	require.Equal(t, []models.PullRequestRepairActionType{models.PullRequestRepairActionTypeFixTests}, resp.AutoRepairExhaustedActions, "personal override should expose exhausted automatic test repair state")
+	require.NoError(t, mock.ExpectationsWereMet(), "all automatic repair state expectations should be met")
+}
+
+func TestPRServicePopulateAutoRepairAttemptStatePersonalOverrideDisablesOrgDefault(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "should create pgx mock pool")
+	defer mock.Close()
+
+	orgID := uuid.New()
+	prID := uuid.New()
+	sessionID := uuid.New()
+	userID := uuid.New()
+	now := time.Now().UTC()
+
+	mock.ExpectQuery("SELECT .+ FROM organizations WHERE id = @id").
+		WithArgs(pgx.NamedArgs{"id": orgID}).
+		WillReturnRows(pgxmock.NewRows(prTestOrganizationColumns).AddRow(
+			orgID, "Acme", []byte(`{"session_automation":{"automatic_follow_through":{"resolve_conflicts_when_idle":true}}}`), now, now,
+		))
+
+	sessionRow := newPRHealthSessionRow(sessionID, orgID, now, models.SessionStatusCompleted)
+	for i, column := range prHealthSessionColumns {
+		if column == "triggered_by_user_id" {
+			sessionRow[i] = &userID
+			break
+		}
+	}
+	mock.ExpectQuery("SELECT .* FROM sessions WHERE id").
+		WithArgs(pgx.NamedArgs{"id": sessionID, "org_id": orgID}).
+		WillReturnRows(pgxmock.NewRows(prHealthSessionColumns).AddRow(sessionRow...))
+
+	mock.ExpectQuery("SELECT .+ FROM users").
+		WithArgs(pgx.NamedArgs{"id": userID}).
+		WillReturnRows(pgxmock.NewRows([]string{
+			"id", "org_id", "email", "name", "role", "github_id", "github_login", "avatar_url", "google_id", "email_verified_at", "created_at", "settings",
+		}).AddRow(
+			userID, orgID, "dev@example.com", "Dev", "member", (*int64)(nil), (*string)(nil), (*string)(nil), (*string)(nil), (*time.Time)(nil), now,
+			[]byte(`{"automatic_pr_follow_through":{"resolve_conflicts_when_idle":"off"}}`),
+		))
+
+	service := &PRService{
+		pullRequests: db.NewPullRequestStore(mock),
+		sessions:     db.NewSessionStore(mock),
+		users:        db.NewUserStore(mock),
+		orgs:         db.NewOrganizationStore(mock),
+		logger:       zerolog.New(io.Discard),
+	}
+	resp := &models.PullRequestHealthResponse{HeadSHA: "head-user-off"}
+	pr := models.PullRequest{
+		ID:        prID,
+		OrgID:     orgID,
+		SessionID: &sessionID,
+		Status:    models.PullRequestStatusOpen,
+	}
+
+	err = service.populateAutoRepairAttemptState(context.Background(), pr, resp)
+	require.NoError(t, err, "populateAutoRepairAttemptState should resolve personal automation overrides")
+	require.Empty(t, resp.AutoRepairExhaustedActions, "a personal override disabling the org default should suppress exhausted-action state and skip the budget query")
+	require.NoError(t, mock.ExpectationsWereMet(), "all automatic repair state expectations should be met")
+}
+
 func TestPullRequestStateSyncDedupeKey(t *testing.T) {
 	t.Parallel()
 

--- a/internal/services/github/pr_merge_when_ready_test.go
+++ b/internal/services/github/pr_merge_when_ready_test.go
@@ -127,6 +127,11 @@ func TestPRServiceQueueMergeWhenReadyPreflightsUserRequiredGitHubAuth(t *testing
 		WillReturnRows(pgxmock.NewRows(prTestOrganizationColumns).AddRow(
 			orgID, "Acme", []byte(`{"pr_authorship":"user_required"}`), now, now,
 		))
+	orgMock.ExpectQuery("SELECT .+ FROM organizations WHERE id = @id").
+		WithArgs(pgx.NamedArgs{"id": orgID}).
+		WillReturnRows(pgxmock.NewRows(prTestOrganizationColumns).AddRow(
+			orgID, "Acme", []byte(`{"pr_authorship":"user_required"}`), now, now,
+		))
 	repoMock.ExpectQuery("SELECT .+ FROM repositories WHERE org_id = .+ AND full_name = .+ AND status = 'active'").
 		WithArgs(pgx.NamedArgs{"org_id": orgID, "full_name": "assembledhq/143"}).
 		WillReturnRows(pgxmock.NewRows(prTestRepoColumns).AddRow(

--- a/internal/worker/handlers.go
+++ b/internal/worker/handlers.go
@@ -9264,6 +9264,7 @@ func newContinueSessionHandler(stores *Stores, services *Services, logger zerolo
 				logger.Warn().Err(titleErr).Str("session_id", sessionID.String()).Msg("failed to regenerate session title")
 			}
 		}
+		autoRepairAfterContinue := true
 		if continueOpts != nil && continueOpts.PRRepair != nil && services.PR != nil {
 			if completionErr := services.PR.CompletePullRequestRepairRun(ctx, orgID, continueOpts.PRRepair.PullRequestID, continueOpts.PRRepair.RepairRunID); completionErr != nil {
 				logger.Warn().
@@ -9276,8 +9277,28 @@ func newContinueSessionHandler(stores *Stores, services *Services, logger zerolo
 			if input.AutoAttempt {
 				metrics.RecordPRAutoRepairOutcome(ctx, orgID.String(), "", string(continueOpts.PRRepair.CommandType), "completed")
 			}
+			if syncErr := services.PR.SyncPullRequestState(ctx, orgID, continueOpts.PRRepair.PullRequestID); syncErr != nil {
+				if errors.Is(syncErr, ghservice.ErrPullRequestMergeabilityPending) {
+					// The health snapshot was refreshed to the post-repair head;
+					// only GitHub's mergeability flag is still settling. The
+					// blocker signals the follow-through relies on are current,
+					// so proceed rather than stranding the repair chain.
+					logger.Debug().
+						Err(syncErr).
+						Str("session_id", sessionID.String()).
+						Str("pull_request_id", continueOpts.PRRepair.PullRequestID.String()).
+						Msg("pull request mergeability still settling after repair; continuing automatic repair follow-through on refreshed health")
+				} else {
+					autoRepairAfterContinue = false
+					logger.Warn().
+						Err(syncErr).
+						Str("session_id", sessionID.String()).
+						Str("pull_request_id", continueOpts.PRRepair.PullRequestID.String()).
+						Msg("skipping automatic pull request repair follow-through until PR health is fresh")
+				}
+			}
 		}
-		if services.PR != nil {
+		if services.PR != nil && autoRepairAfterContinue {
 			if decision, autoRepairErr := services.PR.MaybeStartAutoRepair(ctx, orgID, sessionID, "session_idle"); autoRepairErr != nil {
 				logger.Warn().
 					Err(autoRepairErr).

--- a/internal/worker/handlers_test.go
+++ b/internal/worker/handlers_test.go
@@ -9855,12 +9855,20 @@ func TestContinueSessionHandler_CompletesPRRepairAfterSuccess(t *testing.T) {
 		},
 	}
 	var completed bool
+	var synced bool
 	prSvc := &stubPRService{
 		completePullRequestRepairRunFn: func(ctx context.Context, gotOrgID, gotPullRequestID, gotRepairRunID uuid.UUID) error {
 			completed = true
 			require.Equal(t, orgID, gotOrgID, "repair completion should use the payload org")
 			require.Equal(t, prID, gotPullRequestID, "repair completion should use the payload PR")
 			require.Equal(t, repairRunID, gotRepairRunID, "repair completion should use the payload repair run")
+			return nil
+		},
+		syncPullRequestStateFn: func(ctx context.Context, gotOrgID, gotPullRequestID uuid.UUID) error {
+			synced = true
+			require.True(t, completed, "repair health sync should run after repair completion bookkeeping")
+			require.Equal(t, orgID, gotOrgID, "repair health sync should use the payload org")
+			require.Equal(t, prID, gotPullRequestID, "repair health sync should use the payload PR")
 			return nil
 		},
 	}
@@ -9883,6 +9891,74 @@ func TestContinueSessionHandler_CompletesPRRepairAfterSuccess(t *testing.T) {
 	err = handler(context.Background(), "continue_session", payloadJSON)
 	require.NoError(t, err, "continue_session should succeed when repair completion notification succeeds")
 	require.True(t, completed, "continue_session should complete the linked PR repair run after a successful repair turn")
+	require.True(t, synced, "continue_session should refresh PR health after repair completion")
+	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
+}
+
+func TestContinueSessionHandler_PendingMergeabilityStillEvaluatesAutoRepair(t *testing.T) {
+	t.Parallel()
+
+	stores, mock := newTestStores(t)
+	defer mock.Close()
+
+	orgID := uuid.New()
+	sessionID := uuid.New()
+	issueID := uuid.New()
+	prID := uuid.New()
+	repairRunID := uuid.New()
+
+	mock.ExpectQuery("SELECT .* FROM sessions").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(
+			pgxmock.NewRows(workerSessionColumns).AddRow(
+				workerSessionRow(sessionID, issueID, orgID, models.SessionStatusIdle, 2, nil, nil)...,
+			),
+		)
+
+	orch := &orchestratorServiceStub{
+		continueSessionFn: func(ctx context.Context, session *models.Session, opts *agent.ContinueSessionOptions) error {
+			require.NotNil(t, opts, "continue_session should pass PR repair metadata to the orchestrator")
+			require.NotNil(t, opts.PRRepair, "continue_session should decode PR repair metadata before completion")
+			return nil
+		},
+	}
+	var synced bool
+	var evaluated bool
+	prSvc := &stubPRService{
+		syncPullRequestStateFn: func(ctx context.Context, gotOrgID, gotPullRequestID uuid.UUID) error {
+			synced = true
+			// GitHub has refreshed the snapshot to the post-repair head but is
+			// still computing mergeability; the follow-through should proceed.
+			return ghservice.ErrPullRequestMergeabilityPending
+		},
+		maybeStartAutoRepairFn: func(ctx context.Context, gotOrgID, gotSessionID uuid.UUID, reason string) (*ghservice.AutoRepairDecision, error) {
+			evaluated = true
+			require.True(t, synced, "auto-repair evaluation should run after the post-repair health sync")
+			require.Equal(t, orgID, gotOrgID, "auto-repair evaluation should use the payload org")
+			require.Equal(t, sessionID, gotSessionID, "auto-repair evaluation should use the continued session")
+			return nil, nil
+		},
+	}
+
+	handler := newContinueSessionHandler(stores, &Services{Orchestrator: orch, PR: prSvc}, zerolog.Nop())
+	payload := map[string]any{
+		"session_id":          sessionID.String(),
+		"org_id":              orgID.String(),
+		"pull_request_id":     prID.String(),
+		"repair_run_id":       repairRunID.String(),
+		"command_type":        "fix_tests",
+		"health_version":      12,
+		"head_sha":            "head-sha",
+		"workspace_mode":      "snapshot_continuation",
+		"pull_request_number": 42,
+	}
+	payloadJSON, err := json.Marshal(payload)
+	require.NoError(t, err, "test payload should marshal")
+
+	err = handler(context.Background(), "continue_session", payloadJSON)
+	require.NoError(t, err, "continue_session should succeed when only mergeability is still pending")
+	require.True(t, synced, "continue_session should refresh PR health after repair completion")
+	require.True(t, evaluated, "pending mergeability should not strand the automatic repair follow-through")
 	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
 }
 


### PR DESCRIPTION
## Summary
Auto-repair availability and readiness UI/logic could diverge because the PR health endpoint evaluated org defaults while the repair scheduler effectively considered per-user overrides. This caused “exhausted”/pending signals and follow-through decisions to be inconsistent for PRs owned by a session.  
This change centralizes session override resolution, ensures both surfaces compute the same effective policy, and updates worker syncing so mergeability-pending repairs aren’t stranded.

## Changes
- Extracted session-level auto-repair override logic into `applySessionAutoRepairOverride` and made `resolveAutoRepairPolicy` delegate to it, so scheduler + health endpoint share the same contract.
- Updated `populateAutoRepairAttemptState` to resolve the *effective* policy (org defaults + per-user override) when the PR has an owning session, avoiding mismatched badges/states.
- Adjusted worker flow after a repair turn to sync PR state; if sync returns mergeability-pending, `MaybeStartAutoRepair` is still evaluated using the updated snapshot.
- Updated UI copy for personal automation toggles to clarify they can override org defaults when needed.

## Validation
- `go test ./internal/services/github/ ./internal/worker/`
- `go build`
- `go vet`
- Updated/added unit tests covering personal override interaction and the “mergeability pending still starts auto-repair” path.

[143.dev](https://143.dev) | [session 004a817f](https://143.dev/sessions/004a817f-e910-4a88-873c-9fc6c03cf0ab)

<!-- 143 readiness -->
**143 readiness:** not available for this revision.

Preview: https://143.dev/previews/github/assembledhq/143/pull/1704?launch=1