### PR TITLE
Fix preview CLI/API wait behavior, conflicts, and ambiguous create parameters

### DIFF
--- a/internal/api/handlers/preview.go
+++ b/internal/api/handlers/preview.go
@@ -1970,6 +1970,10 @@ func (h *PreviewHandler) UpdatePreview(w http.ResponseWriter, r *http.Request) {
 	}
 
 	freshness := h.previewFreshness(r.Context(), orgID, sessionID, instance)
+	if freshness != nil && freshness.State == models.PreviewFreshnessUpdating {
+		writeError(w, r, http.StatusConflict, "PREVIEW_UPDATE_CONFLICT", "preview start or update is already in progress")
+		return
+	}
 	mode := h.recommendedPreviewUpdateMode(instance, freshness, reloadBrowser)
 	if body.ForceMode != "" {
 		mode = body.ForceMode

--- a/internal/cli/preview_tools.go
+++ b/internal/cli/preview_tools.go
@@ -298,13 +298,6 @@ func (e *previewToolExecutor) waitSessionReady(ctx context.Context, sessionID st
 	ticker := time.NewTicker(3 * time.Second)
 	defer ticker.Stop()
 	for {
-		select {
-		case <-ctx.Done():
-			return mcp.ErrorResult(ctx.Err().Error())
-		case <-deadline.C:
-			return mcp.ErrorResult(fmt.Sprintf("timed out waiting for session preview %s", sessionID))
-		case <-ticker.C:
-		}
 		result := e.sessionStatus(ctx, sessionID)
 		if result.IsError {
 			return result
@@ -319,6 +312,13 @@ func (e *previewToolExecutor) waitSessionReady(ctx context.Context, sessionID st
 			return result
 		case "failed", "stopped", "expired", "unavailable":
 			return mcp.ErrorResult(fmt.Sprintf("preview %s: %v", state, status["error"]))
+		}
+		select {
+		case <-ctx.Done():
+			return mcp.ErrorResult(ctx.Err().Error())
+		case <-deadline.C:
+			return mcp.ErrorResult(fmt.Sprintf("timed out waiting for session preview %s", sessionID))
+		case <-ticker.C:
 		}
 	}
 }
@@ -399,7 +399,11 @@ func (e *previewToolExecutor) create(ctx context.Context, args json.RawMessage) 
 	if err := json.Unmarshal(args, &params); err != nil {
 		return mcp.ErrorResult("invalid preview create arguments")
 	}
+	hasBranchTarget := strings.TrimSpace(params.Repository) != "" || strings.TrimSpace(params.Branch) != ""
 	if params.SessionID != "" {
+		if hasBranchTarget {
+			return mcp.ErrorResult("specify session_id or repository and branch, not both")
+		}
 		var resp struct {
 			Data ensurePreviewWire `json:"data"`
 		}
@@ -437,7 +441,46 @@ func (e *previewToolExecutor) create(ctx context.Context, args json.RawMessage) 
 	if err != nil {
 		return mcp.ErrorResult(fmt.Sprintf("preview create failed: %s", err))
 	}
+	if params.Wait {
+		return e.waitBranchReady(ctx, resp.Data.view().PreviewID)
+	}
 	return jsonResult(resp.Data.view())
+}
+
+func (e *previewToolExecutor) waitBranchReady(ctx context.Context, previewID string) *mcp.ToolCallResult {
+	if strings.TrimSpace(previewID) == "" {
+		return mcp.ErrorResult("preview create did not return a preview_id to wait on")
+	}
+	deadline := time.NewTimer(previewWaitTimeout)
+	defer deadline.Stop()
+	ticker := time.NewTicker(3 * time.Second)
+	defer ticker.Stop()
+	for {
+		result := e.status(ctx, mustJSON(map[string]string{"preview_id": previewID}))
+		if result.IsError {
+			return result
+		}
+		var status previewView
+		if err := json.Unmarshal([]byte(firstText(result)), &status); err != nil {
+			return result
+		}
+		switch status.Status {
+		case "running", "ready", "partially_ready":
+			return result
+		case "failed", "stopped", "expired", "unavailable":
+			if status.Error != "" {
+				return mcp.ErrorResult(fmt.Sprintf("preview %s: %s", status.Status, status.Error))
+			}
+			return mcp.ErrorResult(fmt.Sprintf("preview %s", status.Status))
+		}
+		select {
+		case <-ctx.Done():
+			return mcp.ErrorResult(ctx.Err().Error())
+		case <-deadline.C:
+			return mcp.ErrorResult(fmt.Sprintf("timed out waiting for preview %s", previewID))
+		case <-ticker.C:
+		}
+	}
 }
 
 func (e *previewToolExecutor) status(ctx context.Context, args json.RawMessage) *mcp.ToolCallResult {
@@ -548,7 +591,7 @@ func (e *previewToolExecutor) update(ctx context.Context, args json.RawMessage) 
 	if err := json.Unmarshal(args, &params); err != nil || params.SessionID == "" {
 		return mcp.ErrorResult("session_id is required")
 	}
-	body := map[string]any{"path": params.Path, "wait": false, "force_mode": params.ForceMode}
+	body := map[string]any{"path": params.Path, "wait": params.Wait, "force_mode": params.ForceMode}
 	if params.ReloadBrowser != nil {
 		body["reload_browser"] = *params.ReloadBrowser
 	}
@@ -564,9 +607,6 @@ func (e *previewToolExecutor) update(ctx context.Context, args json.RawMessage) 
 	}
 	if err := e.client.Do(ctx, http.MethodPost, "/api/v1/sessions/"+params.SessionID+"/preview/update", body, &resp); err != nil {
 		return mcp.ErrorResult(fmt.Sprintf("preview update failed: %s", err))
-	}
-	if params.Wait {
-		return e.waitSessionReady(ctx, params.SessionID)
 	}
 	return jsonResult(resp.Data)
 }

--- a/internal/cli/preview_tools_test.go
+++ b/internal/cli/preview_tools_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"sync/atomic"
 	"testing"
 
 	"github.com/assembledhq/143/internal/services/mcp"
@@ -112,6 +113,74 @@ func TestPreviewToolExecutor_ListSessionPreview(t *testing.T) {
 	require.Contains(t, firstText(result), `"preview_id": "preview-1"`, "list should wrap the session preview status in a list")
 }
 
+func TestPreviewToolExecutor_BranchCreateWaitPollsUntilReady(t *testing.T) {
+	t.Parallel()
+
+	var statusCalls int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.Method + " " + r.URL.Path {
+		case http.MethodGet + " /api/v1/repositories":
+			_, err := w.Write([]byte(`{"data":[{"id":"repo-1","full_name":"acme/app"}]}`))
+			require.NoError(t, err, "repositories response should write")
+		case http.MethodGet + " /api/v1/repositories/repo-1/branches":
+			_, err := w.Write([]byte(`{"data":[{"name":"feature"}]}`))
+			require.NoError(t, err, "branches response should write")
+		case http.MethodPost + " /api/v1/previews":
+			var body map[string]string
+			require.NoError(t, json.NewDecoder(r.Body).Decode(&body), "create request body should decode")
+			require.Equal(t, "repo-1", body["repository_id"], "create should use resolved repository id")
+			require.Equal(t, "feature", body["branch"], "create should use requested branch")
+			_, err := w.Write([]byte(`{"data":{"target_id":"target-1","preview_id":"preview-1","repository_full_name":"acme/app","branch":"feature","status":"starting"}}`))
+			require.NoError(t, err, "create response should write")
+		case http.MethodGet + " /api/v1/previews/preview-1":
+			atomic.AddInt32(&statusCalls, 1)
+			_, err := w.Write([]byte(`{"data":{"target_id":"target-1","preview_id":"preview-1","repository_full_name":"acme/app","branch":"feature","status":"running","preview_url":"https://preview.test"}}`))
+			require.NoError(t, err, "status response should write")
+		default:
+			t.Errorf("unexpected request %s %s", r.Method, r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	executor := &previewToolExecutor{client: NewClient(Config{ServerURL: server.URL, Token: "token"})}
+	result := executor.create(context.Background(), mustJSON(map[string]any{
+		"repository": "acme/app",
+		"branch":     "feature",
+		"wait":       true,
+	}))
+
+	require.False(t, result.IsError, "branch create with wait should succeed")
+	require.EqualValues(t, 1, atomic.LoadInt32(&statusCalls), "branch create wait should poll status until live")
+	require.Contains(t, firstText(result), `"status": "running"`, "wait result should return the ready preview status")
+}
+
+func TestPreviewToolExecutor_UpdateWaitReturnsUpdateResponse(t *testing.T) {
+	t.Parallel()
+
+	var gotBody map[string]any
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/api/v1/sessions/session-1/preview/update", r.URL.Path, "update should target session preview endpoint")
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&gotBody), "update request body should decode")
+		w.Header().Set("Content-Type", "application/json")
+		_, err := w.Write([]byte(`{"data":{"preview_id":"preview-1","session_id":"session-1","mode":"soft_service_restart","action":"restarting","status":"ready","message":"preview service restart started"}}`))
+		require.NoError(t, err, "update response should write")
+	}))
+	defer server.Close()
+
+	executor := &previewToolExecutor{client: NewClient(Config{ServerURL: server.URL, Token: "token"})}
+	result := executor.update(context.Background(), mustJSON(map[string]any{
+		"session_id": "session-1",
+		"wait":       true,
+	}))
+
+	require.False(t, result.IsError, "update with wait should succeed")
+	require.Equal(t, true, gotBody["wait"], "update should let the server perform the bounded wait")
+	require.Contains(t, firstText(result), `"mode": "soft_service_restart"`, "update wait should preserve selected mode")
+	require.Contains(t, firstText(result), `"action": "restarting"`, "update wait should preserve selected action")
+}
+
 func TestPreviewToolExecutor_InspectAllowsTopLeftCoordinate(t *testing.T) {
 	t.Parallel()
 
@@ -182,4 +251,23 @@ func TestPreviewToolExecutor_RejectsAmbiguousTarget(t *testing.T) {
 			require.Contains(t, firstText(result), "not both", "error should explain the ambiguity")
 		})
 	}
+}
+
+func TestPreviewToolExecutor_CreateRejectsAmbiguousTarget(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Errorf("no HTTP request should be made when create target is ambiguous, got %s %s", r.Method, r.URL.Path)
+	}))
+	defer server.Close()
+
+	executor := &previewToolExecutor{client: NewClient(Config{ServerURL: server.URL, Token: "token"})}
+	result := executor.create(context.Background(), mustJSON(map[string]string{
+		"session_id": "session-1",
+		"repository": "acme/app",
+		"branch":     "feature",
+	}))
+
+	require.True(t, result.IsError, "supplying session_id and branch target should be rejected")
+	require.Contains(t, firstText(result), "not both", "error should explain the ambiguity")
 }

--- a/internal/services/preview/restart_classifier.go
+++ b/internal/services/preview/restart_classifier.go
@@ -57,7 +57,7 @@ func (DefaultPreviewRestartClassifier) SelectUpdateMode(status models.PreviewSta
 	}
 	switch status {
 	case models.PreviewStatusStarting:
-		return models.PreviewUpdateModeFullRecycle
+		return ""
 	case models.PreviewStatusFailed, models.PreviewStatusStopped, models.PreviewStatusExpired, models.PreviewStatusUnavailable:
 		return models.PreviewUpdateModeColdRelaunch
 	}
@@ -76,7 +76,7 @@ func (DefaultPreviewRestartClassifier) SelectUpdateMode(status models.PreviewSta
 		}
 		return models.PreviewUpdateModeSoftServiceRestart
 	case models.PreviewFreshnessUpdating:
-		return models.PreviewUpdateModeFullRecycle
+		return ""
 	default:
 		return models.PreviewUpdateModeColdRelaunch
 	}

--- a/internal/services/preview/restart_classifier_test.go
+++ b/internal/services/preview/restart_classifier_test.go
@@ -128,6 +128,18 @@ func TestDefaultPreviewRestartClassifier_SelectUpdateMode(t *testing.T) {
 			freshness: &models.PreviewFreshness{State: models.PreviewFreshnessOutOfDate},
 			expected:  models.PreviewUpdateModeColdRelaunch,
 		},
+		{
+			name:      "starting preview has no recommended update mode",
+			status:    models.PreviewStatusStarting,
+			freshness: &models.PreviewFreshness{State: models.PreviewFreshnessCurrent},
+			expected:  "",
+		},
+		{
+			name:      "updating freshness has no recommended update mode",
+			status:    models.PreviewStatusReady,
+			freshness: &models.PreviewFreshness{State: models.PreviewFreshnessUpdating},
+			expected:  "",
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary

Preview update/start actions could race or return incomplete/incorrect results in the CLI/API workflow (e.g., recommending a mode while another update was already in progress, or waiting without preserving the real update response). This PR tightens reliability around bounded waits, rejects ambiguous `session_id` usage, and returns explicit conflict errors so users get deterministic behavior.

## Changes

- API: `UpdatePreview` now detects when a preview is already in `Updating` freshness state and returns `409 PREVIEW_UPDATE_CONFLICT` instead of proceeding.
- CLI: `preview create --wait` now polls branch preview status until it becomes live/ready (or fails/timeout), rather than returning too early.
- CLI: `preview update --wait` behavior is adjusted to let the server perform the bounded wait and to return the actual update response including `mode`/`action`.
- CLI: wait loops now check status immediately before sleeping to improve responsiveness; `preview create` now rejects specifying both `session_id` and `repository`/`branch` targets.

## Validation

- `go test ./internal/cli ./internal/services/preview ./internal/api/handlers ./internal/api`
- `go vet ./internal/cli ./internal/services/preview ./internal/api/handlers ./internal/api`

(Go temp/cache paths were redirected under `/home/sandbox` to avoid tmpfs space issues.)

[143.dev](https://143.dev) | [session 57751914](https://143.dev/sessions/57751914-4327-4c9d-8cd9-412f158701a3)

<!-- 143 readiness -->
**143 readiness:** not available for this revision.

Preview: https://143.dev/previews/github/assembledhq/143/pull/1705?launch=1