### PR TITLE
Forward FORCE_INTERRUPT_ACTIVE_RUNTIMES to the remote worker drain

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -617,14 +617,20 @@ TAG ?= latest
 ROLES ?= app,worker
 force ?=
 # interrupt=true force-interrupts active runtimes (previews/running jobs) during a
-# maintenance worker drain. Only honored with DEPLOY_MODE=maintenance; set
-# DEPLOY_REASON and DEPLOY_REQUESTED_BY alongside it so the drain is auditable.
+# maintenance worker drain. Ignored in routine mode (blue/green never blocking-drains).
+# Requires DEPLOY_REASON and DEPLOY_REQUESTED_BY to be set so the forced drain is
+# auditable — make aborts otherwise rather than recording a generic default reason.
 interrupt ?=
 DEPLOY_JOBS ?= 4
 WORKER_BLUE_GREEN_PORT_START ?= 8080
 WORKER_BLUE_GREEN_PORT_END ?= 8087
 
-deploy-force-env = FORCE_DEPLOY_WITH_ACTIVE_SESSIONS=$(if $(filter true 1 yes,$(force)),1,$(FORCE_DEPLOY_WITH_ACTIVE_SESSIONS)) FORCE_INTERRUPT_ACTIVE_RUNTIMES=$(if $(filter true 1 yes,$(interrupt)),1,$(FORCE_INTERRUPT_ACTIVE_RUNTIMES))
+# Resolve the force-interrupt flag for an opt-in maintenance drain. When
+# interrupt=true, require an auditable reason+requester instead of letting the
+# drain fall back to the generic default reason.
+resolve-interrupt = $(if $(filter true 1 yes,$(interrupt)),$(if $(and $(strip $(DEPLOY_REASON)),$(strip $(DEPLOY_REQUESTED_BY))),1,$(error interrupt=true requires DEPLOY_REASON and DEPLOY_REQUESTED_BY to be set so the forced drain is auditable)),$(FORCE_INTERRUPT_ACTIVE_RUNTIMES))
+
+deploy-force-env = FORCE_DEPLOY_WITH_ACTIVE_SESSIONS=$(if $(filter true 1 yes,$(force)),1,$(FORCE_DEPLOY_WITH_ACTIVE_SESSIONS)) FORCE_INTERRUPT_ACTIVE_RUNTIMES=$(resolve-interrupt)
 worker-blue-green-env = WORKER_BLUE_GREEN_PORT_START=$(WORKER_BLUE_GREEN_PORT_START) WORKER_BLUE_GREEN_PORT_END=$(WORKER_BLUE_GREEN_PORT_END)
 
 # Deploy (update) an already-provisioned node.

--- a/Makefile
+++ b/Makefile
@@ -616,11 +616,15 @@ spin-down-worker:
 TAG ?= latest
 ROLES ?= app,worker
 force ?=
+# interrupt=true force-interrupts active runtimes (previews/running jobs) during a
+# maintenance worker drain. Only honored with DEPLOY_MODE=maintenance; set
+# DEPLOY_REASON and DEPLOY_REQUESTED_BY alongside it so the drain is auditable.
+interrupt ?=
 DEPLOY_JOBS ?= 4
 WORKER_BLUE_GREEN_PORT_START ?= 8080
 WORKER_BLUE_GREEN_PORT_END ?= 8087
 
-deploy-force-env = FORCE_DEPLOY_WITH_ACTIVE_SESSIONS=$(if $(filter true 1 yes,$(force)),1,$(FORCE_DEPLOY_WITH_ACTIVE_SESSIONS))
+deploy-force-env = FORCE_DEPLOY_WITH_ACTIVE_SESSIONS=$(if $(filter true 1 yes,$(force)),1,$(FORCE_DEPLOY_WITH_ACTIVE_SESSIONS)) FORCE_INTERRUPT_ACTIVE_RUNTIMES=$(if $(filter true 1 yes,$(interrupt)),1,$(FORCE_INTERRUPT_ACTIVE_RUNTIMES))
 worker-blue-green-env = WORKER_BLUE_GREEN_PORT_START=$(WORKER_BLUE_GREEN_PORT_START) WORKER_BLUE_GREEN_PORT_END=$(WORKER_BLUE_GREEN_PORT_END)
 
 # Deploy (update) an already-provisioned node.
@@ -632,6 +636,9 @@ worker-blue-green-env = WORKER_BLUE_GREEN_PORT_START=$(WORKER_BLUE_GREEN_PORT_ST
 #   make deploy-app    TAG=<sha>
 #   make deploy-worker force=true
 #   make deploy-fleet ROLES=app,worker
+#   # Force a maintenance worker drain past active previews/running jobs (interrupts them):
+#   DEPLOY_REASON="re-baseline host-runtime" DEPLOY_REQUESTED_BY=john \
+#     DEPLOY_MODE=maintenance make deploy-fleet ROLES=worker interrupt=true
 
 # Shell snippet to read FLEET_HOSTS from env var or $(_PROD_ENC) via SOPS.
 # Sets $$FLEET. Use inside a recipe with: $(read-fleet-hosts);

--- a/deploy/deploy_config_test.go
+++ b/deploy/deploy_config_test.go
@@ -1353,6 +1353,22 @@ func TestWorkerMaintenanceBlockingDrainUsesDeployControl(t *testing.T) {
 	require.NotContains(t, functionBody, `docker kill --signal=TERM "$cid"`, "maintenance drain must not bypass DB-backed drain state with a direct TERM")
 }
 
+// TestForceInterruptActiveRuntimesIsForwardedToRemote guards the plumbing gap
+// where the maintenance drain reads FORCE_INTERRUPT_ACTIVE_RUNTIMES on the
+// remote host, but deploy.sh never forwarded it over SSH — so the documented
+// force flag silently no-opped from `make deploy-fleet`. The remote drain only
+// receives env that is explicitly listed in the remote_env_assignment block.
+func TestForceInterruptActiveRuntimesIsForwardedToRemote(t *testing.T) {
+	t.Parallel()
+
+	deployScript, err := os.ReadFile("../deploy/scripts/deploy.sh")
+	require.NoError(t, err, "test should read deploy.sh")
+	deploy := string(deployScript)
+
+	require.Contains(t, deploy, `remote_env_assignment FORCE_INTERRUPT_ACTIVE_RUNTIMES "${FORCE_INTERRUPT_ACTIVE_RUNTIMES:-}"`,
+		"deploy.sh must forward FORCE_INTERRUPT_ACTIVE_RUNTIMES to the remote host, or the maintenance drain force flag is unreachable from make deploy-fleet")
+}
+
 func extractShellFunction(t *testing.T, script, startFunc, nextFunc string) string {
 	t.Helper()
 

--- a/deploy/scripts/deploy.sh
+++ b/deploy/scripts/deploy.sh
@@ -860,6 +860,7 @@ ssh "${SSH_OPTS[@]}" deploy@"$HOST" \
   "$(remote_env_assignment DEPLOY_REQUESTED_BY "${DEPLOY_REQUESTED_BY:-deploy-script}")" \
   "$(remote_env_assignment DEPLOY_REASON "${DEPLOY_REASON:-routine worker rollout}")" \
   "$(remote_env_assignment FORCE_DEPLOY_WITH_ACTIVE_SESSIONS "${FORCE_DEPLOY_WITH_ACTIVE_SESSIONS:-}")" \
+  "$(remote_env_assignment FORCE_INTERRUPT_ACTIVE_RUNTIMES "${FORCE_INTERRUPT_ACTIVE_RUNTIMES:-}")" \
   "$(remote_env_assignment SESSION_EXECUTOR_DOCKER_NETWORK "${SESSION_EXECUTOR_DOCKER_NETWORK:-}")" \
   "$(remote_env_assignment DEPLOY_DOCKER_PRUNE "${DEPLOY_DOCKER_PRUNE:-1}")" \
   "$(remote_env_assignment DOCKER_PRUNE_UNTIL "${DOCKER_PRUNE_UNTIL:-24h}")" \


### PR DESCRIPTION
## Problem

The maintenance worker drain (`drain_worker_containers_blocking` in `deploy/scripts/deploy.sh`) reads `FORCE_INTERRUPT_ACTIVE_RUNTIMES` **on the remote worker host** to decide whether to force-interrupt active runtimes (previews / running jobs). The guardrail's own error message tells operators to set it:

```
maintenance/emergency drain would affect active runtimes; pass --force or
FORCE_INTERRUPT_ACTIVE_RUNTIMES=1 with --reason and --requested-by (...)
```

But `deploy.sh` never forwarded that variable in the `remote_env_assignment` block sent over SSH (unlike `DEPLOY_MODE`, `DEPLOY_REASON`, `FORCE_DEPLOY_WITH_ACTIVE_SESSIONS`, …). So setting it via `make deploy-fleet` silently no-opped — there was no working way to force a maintenance drain past active runtimes. This blocked re-baselining workers (host-runtime fingerprint reconciliation) whenever any preview or job was live.

## Fix

- **`deploy.sh`** — forward `FORCE_INTERRUPT_ACTIVE_RUNTIMES` alongside the other drain-control env in the remote SSH invocation.
- **`Makefile`** — expose an `interrupt=true` knob (mirrors the existing `force`) and document it; it also honors a pre-set `FORCE_INTERRUPT_ACTIVE_RUNTIMES` env var.
- **`deploy_config_test.go`** — regression test asserting the var is forwarded. The existing test only checked that the drain function *reads* it on the remote side, not that it was *delivered* there.

## Usage

```bash
DEPLOY_REASON="re-baseline host-runtime" DEPLOY_REQUESTED_BY=you \
  DEPLOY_MODE=maintenance make deploy-fleet ROLES=worker interrupt=true
```

## Test

```
go test ./deploy/ -run 'TestForceInterruptActiveRuntimesIsForwardedToRemote|TestWorkerMaintenanceBlockingDrainUsesDeployControl'
ok  github.com/assembledhq/143/deploy
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
