### PR TITLE
Add hover tooltips for disabled GitHub reviewer team setup with reasons & next steps

### DIFF
--- a/frontend/AGENTS.md
+++ b/frontend/AGENTS.md
@@ -24,6 +24,7 @@ Design 143 as a **professional engineering control plane** — not a marketing s
 - **Disclose progressively.** Show routine controls inline; move rare, destructive, advanced, or high-detail actions into menus, dialogs, sheets, or expandable sections.
 - **Speak one state language.** Use the shared status components and state tokens. Every status must convey what is happening, whether attention is needed, and the available action.
 - **Stay accessible.** Preserve shadcn/Radix keyboard behavior, focus rings, aria labels, disabled states, and contrast. Give icon-only buttons tooltips and accessible names.
+- **Explain disabled actions.** Whenever a button can be disabled, wrap it with `DisabledTooltip` from `@/components/ui/disabled-tooltip` and provide concise hover/focus copy explaining why the action is unavailable and what will make it available. Loading-only disabled states may use a short wait message.
 - **Cut decoration.** No gradient blobs, ornamental illustrations, nested cards, or tinted feature panes. Derive visual weight from layout, typography, borders, shadows, and state tokens.
 - **Match existing patterns.** Before adding a new pattern, check this file, nearby pages, and shared components, and extend what exists unless there is a concrete product reason not to.
 

--- a/frontend/src/app/(dashboard)/code-reviews/page.test.tsx
+++ b/frontend/src/app/(dashboard)/code-reviews/page.test.tsx
@@ -309,6 +309,38 @@ describe("CodeReviewsPage", () => {
     expect(screen.getByRole("button", { name: /Connect GitHub/i })).toBeInTheDocument();
   });
 
+  it("explains why GitHub reviewer team setup is disabled", async () => {
+    const user = userEvent.setup();
+    mockCodeReviewBaseHandlers({
+      status: "auth_required",
+      repository_id: "repo-1",
+      repository_full_name: "acme/api",
+      github_org: "acme",
+      team_slug: "143-code-reviewer",
+      team_name: "143 Code Reviewer",
+      team_reviewer: "@acme/143-code-reviewer",
+      repo_permission: "pull",
+      message: "Connect your GitHub account before creating the reviewer team.",
+    });
+
+    renderWithProviders(<CodeReviewsPage />);
+
+    await user.click(await screen.findByRole("combobox", { name: /Repository/i }));
+    await user.click(await screen.findByRole("option", { name: "acme/api" }));
+    await user.click(await screen.findByRole("tab", { name: /Configurations/i }));
+
+    const setupButton = await screen.findByRole("button", { name: /Create \/ repair team/i });
+    expect(setupButton).toBeDisabled();
+
+    await user.hover(setupButton);
+
+    expect(
+      await screen.findByRole("tooltip", {
+        name: "Connect your GitHub account first so 143 can create or repair the reviewer team.",
+      }),
+    ).toBeInTheDocument();
+  });
+
   it("surfaces GitHub trigger setup permission errors", async () => {
     const user = userEvent.setup();
     let setupCalls = 0;

--- a/frontend/src/app/(dashboard)/code-reviews/page.tsx
+++ b/frontend/src/app/(dashboard)/code-reviews/page.tsx
@@ -8,6 +8,7 @@ import { ClipboardCheck, ChevronDown, ExternalLink, Settings2, Plus, Trash2, Fil
 import { PageHeader } from "@/components/page-header";
 import { EmptyState } from "@/components/empty-state";
 import { Button } from "@/components/ui/button";
+import { DisabledTooltip } from "@/components/ui/disabled-tooltip";
 import { Badge } from "@/components/ui/badge";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import {
@@ -935,6 +936,13 @@ function GitHubTriggerPanel({
   const authRequired = status === "auth_required";
   const permissionRequired = status === "permission_required";
   const reviewer = trigger?.team_reviewer ?? "@org/143-code-reviewer";
+  const setupDisabledReason = githubTriggerSetupDisabledReason({
+    repositorySelected,
+    authRequired,
+    setupPending,
+    deletePending,
+    isLoading,
+  });
 
   return (
     <div className="rounded-md border border-border p-4">
@@ -989,15 +997,17 @@ function GitHubTriggerPanel({
               Connect GitHub
             </Button>
           ) : null}
-          <Button
-            variant={ready ? "outline" : "default"}
-            size="sm"
-            disabled={!repositorySelected || authRequired || setupPending || deletePending || isLoading}
-            onClick={onSetup}
-          >
-            {ready ? <ShieldCheck className="h-4 w-4" /> : <Users className="h-4 w-4" />}
-            {ready ? "Repair team" : "Create / repair team"}
-          </Button>
+          <DisabledTooltip disabled={!!setupDisabledReason} content={setupDisabledReason}>
+            <Button
+              variant={ready ? "outline" : "default"}
+              size="sm"
+              disabled={!!setupDisabledReason}
+              onClick={onSetup}
+            >
+              {ready ? <ShieldCheck className="h-4 w-4" /> : <Users className="h-4 w-4" />}
+              {ready ? "Repair team" : "Create / repair team"}
+            </Button>
+          </DisabledTooltip>
           {ready ? (
             <Button variant="ghost" size="sm" disabled={setupPending || deletePending} onClick={onDelete}>
               <Trash2 className="h-4 w-4" />
@@ -1011,6 +1021,37 @@ function GitHubTriggerPanel({
       </div>
     </div>
   );
+}
+
+function githubTriggerSetupDisabledReason({
+  repositorySelected,
+  authRequired,
+  setupPending,
+  deletePending,
+  isLoading,
+}: {
+  repositorySelected: boolean;
+  authRequired: boolean;
+  setupPending: boolean;
+  deletePending: boolean;
+  isLoading: boolean;
+}): string | undefined {
+  if (!repositorySelected) {
+    return "Select a repository before creating the GitHub reviewer team.";
+  }
+  if (authRequired) {
+    return "Connect your GitHub account first so 143 can create or repair the reviewer team.";
+  }
+  if (setupPending) {
+    return "Team setup is already running. Wait for it to finish before trying again.";
+  }
+  if (deletePending) {
+    return "The reviewer team trigger is being disabled. Wait for that action to finish before repairing it.";
+  }
+  if (isLoading) {
+    return "143 is checking the repository's reviewer team status. Wait for the check to finish.";
+  }
+  return undefined;
 }
 
 function githubTriggerStatusLabel(status: CodeReviewGitHubTriggerResponse["status"]): string {


### PR DESCRIPTION
## Summary

Users can’t tell why “Create / repair team” is disabled on the Code Reviews page, which slows troubleshooting and increases support friction. This change wraps the disabled GitHub reviewer team setup button in `DisabledTooltip` so the UI explains the block (e.g., connect GitHub first) and what action will enable it, and it enforces the pattern via `AGENTS.md`.

## Changes

- Wrapped the “Create / repair team” disabled state in `DisabledTooltip` with specific hover/focus copy and next-step guidance.
- Added a test to verify the tooltip appears when the setup button is disabled.
- Updated `frontend/AGENTS.md` to require disabled buttons explain why they’re unavailable and how to make them available using `DisabledTooltip`.

## Validation

- `npm run test:ci -- src/app/\(dashboard\)/code-reviews/page.test.tsx`
- `npx eslint src/app/\(dashboard\)/code-reviews/page.tsx src/app/\(dashboard\)/code-reviews/page.test.tsx`

[143.dev](https://143.dev) | [session 4fc9ef25](https://143.dev/sessions/4fc9ef25-9b7e-47e0-9758-addd1d37fd0b)

<!-- 143 readiness -->
**143 readiness:** not available for this revision.

Preview: https://143.dev/previews/github/assembledhq/143/pull/1710?launch=1