### PR TITLE
Add configurable code review timeout with unit selector (seconds/minutes/hours)

### DIFF
--- a/frontend/src/app/(dashboard)/code-reviews/page.test.tsx
+++ b/frontend/src/app/(dashboard)/code-reviews/page.test.tsx
@@ -228,6 +228,9 @@ function mockCodeReviewBaseHandlers(trigger: CodeReviewGitHubTriggerResponse = g
     }),
     http.get("/api/v1/code-review-github-trigger", () => HttpResponse.json({ data: trigger } satisfies SingleResponse<CodeReviewGitHubTriggerResponse>)),
   );
+  return {
+    getCurrentConfig: () => currentConfig,
+  };
 }
 
 describe("CodeReviewsPage", () => {
@@ -280,9 +283,29 @@ describe("CodeReviewsPage", () => {
     await user.click(screen.getByRole("button", { name: /Apply template/i }));
     await user.click(screen.getByRole("button", { name: /Approval criteria/i }));
     expect((await screen.findAllByDisplayValue("4")).length).toBeGreaterThan(0);
+    expect(screen.getByLabelText("Timeout value")).toHaveValue(30);
+    expect(screen.getByRole("combobox", { name: "Timeout unit" })).toHaveTextContent("Minutes");
 
     await user.click(screen.getByRole("button", { name: /Add requirement/i }));
     expect(await screen.findByDisplayValue("Custom requirement")).toBeInTheDocument();
+  });
+
+  it("saves code review timeout in seconds from the selected unit", async () => {
+    const user = userEvent.setup();
+    const state = mockCodeReviewBaseHandlers();
+
+    renderWithProviders(<CodeReviewsPage />);
+
+    await user.click(await screen.findByRole("tab", { name: /Configurations/i }));
+    await user.click(screen.getByRole("button", { name: /Approval criteria/i }));
+
+    expect(await screen.findByLabelText("Timeout value")).toHaveValue(30);
+    await user.click(screen.getByRole("combobox", { name: "Timeout unit" }));
+    await user.click(await screen.findByRole("option", { name: "Hours" }));
+
+    await waitFor(() => {
+      expect(state.getCurrentConfig().agent_roster.timeout_seconds).toBe(30 * 60 * 60);
+    });
   });
 
   it("renders GitHub trigger account-required state", async () => {

--- a/frontend/src/app/(dashboard)/code-reviews/page.tsx
+++ b/frontend/src/app/(dashboard)/code-reviews/page.tsx
@@ -31,6 +31,7 @@ import { Switch } from "@/components/ui/switch";
 import { Label } from "@/components/ui/label";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
+import { DurationInput } from "@/components/duration-input";
 import { ApiError, api } from "@/lib/api";
 import { queryKeys } from "@/lib/query-keys";
 import { getActiveOrgId } from "@/lib/active-org";
@@ -573,13 +574,15 @@ export default function CodeReviewsPage() {
                         autosave={autosave}
                         buildPatch={(value) => buildConfig((next) => { next.inline_comment_limit = value; })}
                       />
-                      <NumberPolicyInput
-                        label="Timeout seconds"
-                        serverValue={config?.agent_roster.timeout_seconds}
-                        min={60}
+                      <DurationInput
+                        label="Timeout"
+                        valueSeconds={config?.agent_roster.timeout_seconds ?? 60}
+                        minSeconds={60}
                         disabled={!config}
-                        autosave={autosave}
-                        buildPatch={(value) => buildConfig((next) => { next.agent_roster.timeout_seconds = value; })}
+                        defaultUnit="minutes"
+                        onChangeSeconds={(seconds) =>
+                          autosave.save(buildConfig((next) => { next.agent_roster.timeout_seconds = seconds; }))
+                        }
                       />
                       <NumberPolicyInput
                         label="Cost ceiling cents"

--- a/frontend/src/components/duration-input.test.tsx
+++ b/frontend/src/components/duration-input.test.tsx
@@ -1,0 +1,69 @@
+import { describe, expect, it, vi } from "vitest";
+import { render } from "@testing-library/react";
+import { screen, userEvent } from "@/test/test-utils";
+import { DurationInput } from "./duration-input";
+
+describe("DurationInput", () => {
+  it("defaults whole-minute values to minutes", () => {
+    const onChangeSeconds = vi.fn();
+
+    render(<DurationInput label="Timeout" valueSeconds={1800} onChangeSeconds={onChangeSeconds} />);
+
+    expect(screen.getByLabelText("Timeout value")).toHaveValue(30);
+    expect(screen.getByRole("combobox", { name: "Timeout unit" })).toHaveTextContent("Minutes");
+  });
+
+  it("commits seconds when the unit suffix changes", async () => {
+    const user = userEvent.setup();
+    const onChangeSeconds = vi.fn();
+
+    render(<DurationInput label="Timeout" valueSeconds={30 * 60} onChangeSeconds={onChangeSeconds} />);
+
+    await user.click(screen.getByRole("combobox", { name: "Timeout unit" }));
+    await user.click(await screen.findByRole("option", { name: "Hours" }));
+
+    expect(onChangeSeconds).toHaveBeenLastCalledWith(30 * 60 * 60);
+  });
+
+  it("clamps the displayed amount when switching to a smaller unit", async () => {
+    const user = userEvent.setup();
+    const onChangeSeconds = vi.fn();
+
+    render(
+      <DurationInput
+        label="Timeout"
+        valueSeconds={30 * 60}
+        minSeconds={60}
+        onChangeSeconds={onChangeSeconds}
+      />,
+    );
+
+    await user.click(screen.getByRole("combobox", { name: "Timeout unit" }));
+    await user.click(await screen.findByRole("option", { name: "Seconds" }));
+
+    expect(onChangeSeconds).toHaveBeenLastCalledWith(60);
+    expect(screen.getByLabelText("Timeout value")).toHaveValue(60);
+  });
+
+  it("clamps values on blur", async () => {
+    const user = userEvent.setup();
+    const onChangeSeconds = vi.fn();
+
+    render(
+      <DurationInput
+        label="Timeout"
+        valueSeconds={5 * 60}
+        minSeconds={60}
+        onChangeSeconds={onChangeSeconds}
+      />,
+    );
+
+    const input = screen.getByLabelText("Timeout value");
+    await user.clear(input);
+    await user.type(input, "0");
+    await user.tab();
+
+    expect(onChangeSeconds).toHaveBeenLastCalledWith(60);
+    expect(input).toHaveValue(1);
+  });
+});

--- a/frontend/src/components/duration-input.tsx
+++ b/frontend/src/components/duration-input.tsx
@@ -1,0 +1,194 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { cn } from "@/lib/utils";
+
+export type DurationUnit = "seconds" | "minutes" | "hours";
+
+const UNIT_SECONDS: Record<DurationUnit, number> = {
+  seconds: 1,
+  minutes: 60,
+  hours: 60 * 60,
+};
+
+const UNIT_LABELS: Record<DurationUnit, string> = {
+  seconds: "Seconds",
+  minutes: "Minutes",
+  hours: "Hours",
+};
+
+export interface DurationInputProps {
+  label: string;
+  valueSeconds: number;
+  onChangeSeconds: (seconds: number) => void;
+  minSeconds?: number;
+  maxSeconds?: number;
+  disabled?: boolean;
+  defaultUnit?: DurationUnit;
+  debounceMs?: number;
+  className?: string;
+}
+
+function clampSeconds(value: number, minSeconds?: number, maxSeconds?: number): number {
+  const minClamped = minSeconds === undefined ? value : Math.max(minSeconds, value);
+  return maxSeconds === undefined ? minClamped : Math.min(maxSeconds, minClamped);
+}
+
+function chooseDurationUnit(valueSeconds: number, defaultUnit: DurationUnit): DurationUnit {
+  if (valueSeconds > 0 && valueSeconds % UNIT_SECONDS.hours === 0) return "hours";
+  if (valueSeconds > 0 && valueSeconds % UNIT_SECONDS.minutes === 0) return "minutes";
+  return defaultUnit;
+}
+
+function formatAmount(valueSeconds: number, unit: DurationUnit): string {
+  const amount = valueSeconds / UNIT_SECONDS[unit];
+  return Number.isInteger(amount) ? String(amount) : String(Number(amount.toFixed(2)));
+}
+
+function parseAmount(value: string): number | null {
+  if (value.trim() === "") return null;
+  const parsed = Number.parseFloat(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+export function DurationInput({
+  label,
+  valueSeconds,
+  onChangeSeconds,
+  minSeconds,
+  maxSeconds,
+  disabled,
+  defaultUnit = "minutes",
+  debounceMs = 400,
+  className,
+}: DurationInputProps) {
+  const [unit, setUnit] = useState<DurationUnit>(() => chooseDurationUnit(valueSeconds, defaultUnit));
+  const [amount, setAmount] = useState(() => formatAmount(valueSeconds, chooseDurationUnit(valueSeconds, defaultUnit)));
+  const [trackedValueSeconds, setTrackedValueSeconds] = useState(valueSeconds);
+  const [lastSentSeconds, setLastSentSeconds] = useState(valueSeconds);
+  const debounceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const pendingSecondsRef = useRef<number | null>(null);
+  const onChangeSecondsRef = useRef(onChangeSeconds);
+
+  useEffect(() => {
+    onChangeSecondsRef.current = onChangeSeconds;
+  }, [onChangeSeconds]);
+
+  if (valueSeconds !== trackedValueSeconds) {
+    setTrackedValueSeconds(valueSeconds);
+    const hasPendingEdit = amount !== formatAmount(lastSentSeconds, unit);
+    if (valueSeconds !== lastSentSeconds && !hasPendingEdit) {
+      const nextUnit = chooseDurationUnit(valueSeconds, defaultUnit);
+      setUnit(nextUnit);
+      setAmount(formatAmount(valueSeconds, nextUnit));
+      setLastSentSeconds(valueSeconds);
+    }
+  }
+
+  useEffect(() => {
+    return () => {
+      if (debounceTimerRef.current) {
+        clearTimeout(debounceTimerRef.current);
+        debounceTimerRef.current = null;
+      }
+    };
+  }, []);
+
+  const dispatch = (nextSeconds: number) => {
+    const clamped = Math.round(clampSeconds(nextSeconds, minSeconds, maxSeconds));
+    setLastSentSeconds(clamped);
+    onChangeSecondsRef.current(clamped);
+  };
+
+  const scheduleDispatch = (nextSeconds: number) => {
+    pendingSecondsRef.current = nextSeconds;
+    if (debounceTimerRef.current) clearTimeout(debounceTimerRef.current);
+    debounceTimerRef.current = setTimeout(() => {
+      debounceTimerRef.current = null;
+      const pending = pendingSecondsRef.current;
+      pendingSecondsRef.current = null;
+      if (pending !== null) dispatch(pending);
+    }, debounceMs);
+  };
+
+  const flush = () => {
+    if (debounceTimerRef.current) {
+      clearTimeout(debounceTimerRef.current);
+      debounceTimerRef.current = null;
+    }
+    const parsed = parseAmount(amount);
+    if (parsed === null) {
+      pendingSecondsRef.current = null;
+      setAmount(formatAmount(valueSeconds, unit));
+      setLastSentSeconds(valueSeconds);
+      return;
+    }
+    const clamped = Math.round(clampSeconds(parsed * UNIT_SECONDS[unit], minSeconds, maxSeconds));
+    pendingSecondsRef.current = null;
+    setAmount(formatAmount(clamped, unit));
+    if (clamped !== lastSentSeconds) dispatch(clamped);
+  };
+
+  const updateUnit = (nextUnit: DurationUnit) => {
+    if (debounceTimerRef.current) {
+      clearTimeout(debounceTimerRef.current);
+      debounceTimerRef.current = null;
+    }
+    pendingSecondsRef.current = null;
+    setUnit(nextUnit);
+    const parsed = parseAmount(amount);
+    if (parsed === null) {
+      setAmount(formatAmount(valueSeconds, nextUnit));
+      return;
+    }
+    const clamped = Math.round(clampSeconds(parsed * UNIT_SECONDS[nextUnit], minSeconds, maxSeconds));
+    setAmount(formatAmount(clamped, nextUnit));
+    if (clamped !== lastSentSeconds) dispatch(clamped);
+  };
+
+  return (
+    <div className={cn("rounded-md border border-border p-4", className)}>
+      <Label className="text-xs text-muted-foreground">{label}</Label>
+      <div className="mt-2 grid grid-cols-[minmax(0,1fr)_8.5rem] gap-2">
+        <Input
+          aria-label={`${label} value`}
+          type="number"
+          min={minSeconds === undefined ? undefined : minSeconds / UNIT_SECONDS[unit]}
+          max={maxSeconds === undefined ? undefined : maxSeconds / UNIT_SECONDS[unit]}
+          step={unit === "seconds" ? 1 : 0.25}
+          value={amount}
+          disabled={disabled}
+          onChange={(event) => {
+            const nextAmount = event.target.value;
+            setAmount(nextAmount);
+            const parsed = parseAmount(nextAmount);
+            if (parsed !== null) scheduleDispatch(parsed * UNIT_SECONDS[unit]);
+          }}
+          onBlur={flush}
+        />
+        <Select value={unit} disabled={disabled} onValueChange={(value) => updateUnit(value as DurationUnit)}>
+          <SelectTrigger aria-label={`${label} unit`}>
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            {Object.entries(UNIT_LABELS).map(([value, unitLabel]) => (
+              <SelectItem key={value} value={value}>
+                {unitLabel}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary

Code review configuration currently only accepts a raw “timeout seconds” value, which makes it easy to misread/change and harder to set common values (e.g., 30 minutes). This change replaces the single-unit input with a reusable `DurationInput` that lets users enter a duration plus a selectable unit, and reliably converts/saves it to `agent_roster.timeout_seconds`.

## Changes

- Replaced the timeout seconds field in `CodeReviewsPage` with the reusable `DurationInput` component.
- Added unit-aware editing: the UI defaults to **minutes**, and changes persist as `timeout_seconds` via `onChangeSeconds`.
- Extended tests to assert the default unit/value and that switching units (e.g., Hours) saves the correct `timeout_seconds` (e.g., `30 * 60 * 60`).

## Validation

- Frontend unit tests:
  - `frontend/src/app/(dashboard)/code-reviews/page.test.tsx`
  - `frontend/src/components/duration-input.test.tsx`

[143.dev](https://143.dev) | [session 82762955](https://143.dev/sessions/82762955-90c6-4669-93ff-91248c6f5b48)

<!-- 143 readiness -->
**143 readiness:** not available for this revision.

Preview: https://143.dev/previews/github/assembledhq/143/pull/1712?launch=1