### PR TITLE
Remove code review cost ceiling and keep only timeout-based enforcement

### DIFF
--- a/docs/design/implemented/112-code-reviewer-bot-auto-approval.md
+++ b/docs/design/implemented/112-code-reviewer-bot-auto-approval.md
@@ -294,7 +294,7 @@ Organizations configure:
 - reviewer agents: Codex, Claude Code, OpenCode, Amp, Pi, or future providers
 - orchestrator agent: the model/provider that reads all outputs and produces the final structured decision
 - review depth: quick, standard, deep
-- timeout and cost ceilings
+- timeout ceiling
 - whether disagreement forces human review
 
 Defaults:

--- a/frontend/src/app/(dashboard)/code-reviews/page.test.tsx
+++ b/frontend/src/app/(dashboard)/code-reviews/page.test.tsx
@@ -81,7 +81,6 @@ const policy: CodeReviewResolvedPolicy = {
       disagreement_blocks: true,
       require_reviewer_quorum: 2,
       timeout_seconds: 1800,
-      max_cost_cents: 500,
     },
     inline_comment_limit: 4,
     inheritance: {

--- a/frontend/src/app/(dashboard)/code-reviews/page.tsx
+++ b/frontend/src/app/(dashboard)/code-reviews/page.tsx
@@ -582,14 +582,6 @@ export default function CodeReviewsPage() {
                         buildPatch={(value) => buildConfig((next) => { next.agent_roster.timeout_seconds = value; })}
                       />
                       <NumberPolicyInput
-                        label="Cost ceiling cents"
-                        serverValue={config?.agent_roster.max_cost_cents}
-                        min={0}
-                        disabled={!config}
-                        autosave={autosave}
-                        buildPatch={(value) => buildConfig((next) => { next.agent_roster.max_cost_cents = value; })}
-                      />
-                      <NumberPolicyInput
                         label="Reviewer quorum"
                         serverValue={config?.agent_roster.require_reviewer_quorum}
                         min={1}
@@ -1088,6 +1080,7 @@ function NumberPolicyInput({
       <Input
         className="mt-2"
         type="number"
+        aria-label={label}
         min={min}
         max={max}
         value={field.value}

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -142,7 +142,6 @@ export interface CodeReviewPolicyConfig {
     disagreement_blocks: boolean;
     require_reviewer_quorum: number;
     timeout_seconds: number;
-    max_cost_cents: number;
   };
   inline_comment_limit: number;
   final_review_template?: string;

--- a/internal/models/code_review.go
+++ b/internal/models/code_review.go
@@ -333,7 +333,6 @@ type CodeReviewAgentRoster struct {
 	DisagreementBlocks    bool        `json:"disagreement_blocks"`
 	RequireReviewerQuorum int         `json:"require_reviewer_quorum"`
 	TimeoutSeconds        int         `json:"timeout_seconds"`
-	MaxCostCents          int         `json:"max_cost_cents"`
 }
 
 type CodeReviewPolicyConfig struct {
@@ -409,7 +408,6 @@ func DefaultCodeReviewPolicyConfig() CodeReviewPolicyConfig {
 			DisagreementBlocks:    true,
 			RequireReviewerQuorum: 2,
 			TimeoutSeconds:        1800,
-			MaxCostCents:          500,
 		},
 		InlineCommentLimit: 4,
 		Inheritance: CodeReviewPolicyInheritance{
@@ -547,9 +545,6 @@ func (c CodeReviewPolicyConfig) Validate() error {
 	}
 	if c.AgentRoster.TimeoutSeconds < 60 {
 		return fmt.Errorf("timeout_seconds must be at least 60")
-	}
-	if c.AgentRoster.MaxCostCents < 0 {
-		return fmt.Errorf("max_cost_cents must not be negative")
 	}
 	return nil
 }
@@ -910,7 +905,6 @@ type CodeReviewRiskInput struct {
 	UnresolvedHumanThreads int
 	BlockingFindings       int
 	ReviewerDisagreement   bool
-	ReviewCostCents        float64
 	ScopeMismatch          bool
 	UnresolvedUncertainty  bool
 	PromptInjectionFound   bool
@@ -992,9 +986,6 @@ func EvaluateCodeReviewRisk(policy CodeReviewPolicyConfig, input CodeReviewRiskI
 	}
 	if input.ReviewerDisagreement && policy.AgentRoster.DisagreementBlocks {
 		reasons = append(reasons, "reviewer agents disagreed on material risk")
-	}
-	if policy.AgentRoster.MaxCostCents > 0 && input.ReviewCostCents > float64(policy.AgentRoster.MaxCostCents) {
-		reasons = append(reasons, fmt.Sprintf("review cost %.2f cents exceeds policy limit %d cents", input.ReviewCostCents, policy.AgentRoster.MaxCostCents))
 	}
 	if input.ScopeMismatch {
 		reasons = append(reasons, "orchestrator reported the change may not match the stated intent")

--- a/internal/models/code_review_test.go
+++ b/internal/models/code_review_test.go
@@ -77,7 +77,6 @@ func TestCodeReviewPolicyConfigValidate(t *testing.T) {
 		{name: "rejects unsupported reviewer", mutate: func(c *CodeReviewPolicyConfig) { c.AgentRoster.Reviewers = []AgentType{AgentTypePMAgent} }, expectErr: true},
 		{name: "rejects oversized quorum", mutate: func(c *CodeReviewPolicyConfig) { c.AgentRoster.RequireReviewerQuorum = 3 }, expectErr: true},
 		{name: "rejects too short timeout", mutate: func(c *CodeReviewPolicyConfig) { c.AgentRoster.TimeoutSeconds = 30 }, expectErr: true},
-		{name: "rejects negative cost", mutate: func(c *CodeReviewPolicyConfig) { c.AgentRoster.MaxCostCents = -1 }, expectErr: true},
 	}
 
 	for _, tt := range tests {
@@ -320,24 +319,6 @@ func TestEvaluateCodeReviewRisk(t *testing.T) {
 			},
 			expected: CodeReviewRiskEvaluation{Acceptable: false, Reasons: []string{
 				"blocked path changed: internal/db/schema/users.go",
-			}},
-		},
-		{
-			name: "blocks review cost above ceiling",
-			mutate: func(c *CodeReviewPolicyConfig) {
-				c.AgentRoster.MaxCostCents = 25
-			},
-			input: CodeReviewRiskInput{
-				FilesChanged:      1,
-				LinesChanged:      20,
-				ChecksPassing:     true,
-				DescriptionPassed: true,
-				Mergeable:         true,
-				Author:            "devin",
-				ReviewCostCents:   25.1,
-			},
-			expected: CodeReviewRiskEvaluation{Acceptable: false, Reasons: []string{
-				"review cost 25.10 cents exceeds policy limit 25 cents",
 			}},
 		},
 	}

--- a/internal/worker/code_review_handler.go
+++ b/internal/worker/code_review_handler.go
@@ -892,7 +892,6 @@ func codeReviewPromptRiskReasons(job runCodeReviewPayload, pr models.PullRequest
 		BlockingFindings:       codeReviewBlockingFindings(findings),
 		ReviewerDisagreement:   reviewerFailures > 0,
 		UnresolvedHumanThreads: unresolvedHumanThreads,
-		ReviewCostCents:        codeReviewAgentResultCostCents(agentResults),
 		PromptInjectionFound:   description.PromptInjectionFound,
 	})
 	if reviewerQuorum < cfg.AgentRoster.RequireReviewerQuorum {
@@ -1589,7 +1588,6 @@ func evaluateLiveCodeReviewOutcome(input liveCodeReviewOutcomeInput) (models.Cod
 		BlockingFindings:       blockingFindings,
 		ReviewerDisagreement:   reviewerFailures > 0 || input.OrchestratorSynthesis.ReviewerDisagreement,
 		UnresolvedHumanThreads: unresolvedHumanThreads,
-		ReviewCostCents:        codeReviewAgentResultCostCents(input.AgentResults),
 		ScopeMismatch:          input.OrchestratorSynthesis.ScopeMismatch,
 		UnresolvedUncertainty:  input.OrchestratorSynthesis.UnresolvedUncertainty,
 		PromptInjectionFound:   input.DescriptionEvaluation.PromptInjectionFound || input.OrchestratorSynthesis.PromptInjectionDetected,
@@ -1877,25 +1875,6 @@ func codeReviewReviewerEvidence(results []models.CodeReviewAgentResult) (quorum 
 		}
 	}
 	return quorum, failures
-}
-
-func codeReviewAgentResultCostCents(results []models.CodeReviewAgentResult) float64 {
-	total := 0.0
-	for _, result := range results {
-		switch result.Role {
-		case models.CodeReviewAgentRoleReviewer:
-			state, ok := parseCodeReviewReviewerStructuredResult(result.StructuredResult)
-			if ok {
-				total += state.CostCents
-			}
-		case models.CodeReviewAgentRoleOrchestrator:
-			state, ok := parseCodeReviewOrchestratorStructuredResult(result.StructuredResult)
-			if ok {
-				total += state.CostCents
-			}
-		}
-	}
-	return total
 }
 
 func codeReviewBlockingFindings(findings []models.CodeReviewFinding) int {


### PR DESCRIPTION
## Summary

Code review configuration currently includes a “cost ceiling” (max cost in cents), which adds review-policy complexity and forces additional UI/backend wiring with little workflow value. This PR removes that setting end-to-end and shifts enforcement to the existing timeout ceiling, simplifying the policy contract and reducing reliability risk from stale/unused approval-cost evaluation.

## Changes

- Removed “Cost ceiling cents” from the Code Review config UI and policy update flow.
- Deleted `max_cost_cents` from the frontend policy types and from the backend `CodeReviewAgentRoster` model/defaults/validation.
- Removed approval risk input/evaluation wiring that previously depended on review cost (`ReviewCostCents`) and worker logic that passed review cost into approval eligibility.
- Updated a shared `NumberPolicyInput` to set `aria-label` (minor accessibility fix while touching the component).

## Validation

- `go test ./internal/models ./internal/worker`
- `go vet ./internal/models ./internal/worker`
- `npm test -- --run src/app/'(dashboard)'/code-reviews/page.test.tsx`
- `npx eslint src/app/'(dashboard)'/code-reviews/page.tsx src/app/'(dashboard)'/code-reviews/page.test.tsx src/lib/types.ts --max-warnings=0`
- `npm run typecheck`

[143.dev](https://143.dev) | [session 3940fcfb](https://143.dev/sessions/3940fcfb-17b1-43ad-8f9a-d7874ec49494)

<!-- 143 readiness -->
**143 readiness:** not available for this revision.

Preview: https://143.dev/previews/github/assembledhq/143/pull/1713?launch=1