### PR TITLE
Use shared notify toasts for “Apply template” success and failure in code review configurations

### DIFF
--- a/frontend/src/app/(dashboard)/code-reviews/page.test.tsx
+++ b/frontend/src/app/(dashboard)/code-reviews/page.test.tsx
@@ -1,7 +1,16 @@
-import { describe, it, expect, vi } from "vitest";
+import { beforeEach, describe, it, expect, vi } from "vitest";
 import { http, HttpResponse } from "msw";
 import { renderWithProviders, screen, userEvent, waitFor } from "@/test/test-utils";
 import { server } from "@/test/mocks/server";
+
+const toast = vi.hoisted(() => ({
+  success: vi.fn(),
+  info: vi.fn(),
+  error: vi.fn(),
+}));
+
+vi.mock("@/lib/notify", () => ({ notify: toast }));
+
 import CodeReviewsPage from "./page";
 
 // jsdom has no EventSource; stub the SSE hook so the live-refresh subscription
@@ -233,6 +242,12 @@ function mockCodeReviewBaseHandlers(trigger: CodeReviewGitHubTriggerResponse = g
 }
 
 describe("CodeReviewsPage", () => {
+  beforeEach(() => {
+    toast.success.mockReset();
+    toast.info.mockReset();
+    toast.error.mockReset();
+  });
+
   it("renders review sessions and policy configuration", async () => {
     const user = userEvent.setup();
     mockCodeReviewBaseHandlers();
@@ -284,6 +299,9 @@ describe("CodeReviewsPage", () => {
     await user.click(screen.getByRole("combobox", { name: /Starter template/i }));
     await user.click(await screen.findByRole("option", { name: "Small backend change" }));
     await user.click(screen.getByRole("button", { name: /Apply template/i }));
+    await waitFor(() => {
+      expect(toast.success).toHaveBeenCalledWith("Applied Small backend change");
+    });
     await user.click(screen.getByRole("button", { name: /Approval criteria/i }));
     expect((await screen.findAllByDisplayValue("4")).length).toBeGreaterThan(0);
     expect(screen.getByLabelText("Timeout value")).toHaveValue(30);
@@ -291,6 +309,30 @@ describe("CodeReviewsPage", () => {
 
     await user.click(screen.getByRole("button", { name: /Add requirement/i }));
     expect(await screen.findByDisplayValue("Custom requirement")).toBeInTheDocument();
+  });
+
+  it("surfaces template apply save failures through the shared toast", async () => {
+    const user = userEvent.setup();
+    mockCodeReviewBaseHandlers();
+    server.use(
+      http.put("/api/v1/code-review-policies", () =>
+        HttpResponse.json(
+          { error: { code: "SAVE_FAILED", message: "Policy could not be saved" } },
+          { status: 500 },
+        ),
+      ),
+    );
+
+    renderWithProviders(<CodeReviewsPage />);
+
+    await user.click(await screen.findByRole("tab", { name: /Configurations/i }));
+    await user.click(screen.getByRole("combobox", { name: /Starter template/i }));
+    await user.click(await screen.findByRole("option", { name: "Small backend change" }));
+    await user.click(screen.getByRole("button", { name: /Apply template/i }));
+
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith("Couldn't save. Your change was reverted.");
+    });
   });
 
   it("saves code review timeout in seconds from the selected unit", async () => {

--- a/frontend/src/app/(dashboard)/code-reviews/page.tsx
+++ b/frontend/src/app/(dashboard)/code-reviews/page.tsx
@@ -47,6 +47,7 @@ import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 import { DurationInput } from "@/components/duration-input";
 import { ApiError, api } from "@/lib/api";
+import { notify as toast } from "@/lib/notify";
 import { queryKeys } from "@/lib/query-keys";
 import { getActiveOrgId } from "@/lib/active-org";
 import { buildCodeReviewStreamURL, SSE_EVENT } from "@/lib/sse";
@@ -153,6 +154,7 @@ export default function CodeReviewsPage() {
   const [statusFilter, setStatusFilter] = useState(ALL_STATUSES);
   const [search, setSearch] = useState("");
   const [selectedTemplateKey, setSelectedTemplateKey] = useState(NO_TEMPLATE);
+  const [pendingTemplateApply, setPendingTemplateApply] = useState<{ key: string; title: string } | null>(null);
   const [selectedEvidenceSessionId, setSelectedEvidenceSessionId] = useState<string | null>(null);
   const repositoryId = repositoryFilter === ALL_REPOSITORIES ? undefined : repositoryFilter;
   const reviewFilters = useMemo(
@@ -276,6 +278,22 @@ export default function CodeReviewsPage() {
   const repositories = repositoriesQuery.data?.data ?? [];
   const templates = templatesQuery.data?.data ?? [];
   const selectedTemplate = templates.find((template) => template.key === selectedTemplateKey);
+  const selectedTemplateAlreadyApplied = useMemo(() => {
+    if (!selectedTemplate || !config) return false;
+    return JSON.stringify(config) === JSON.stringify(selectedTemplate.config);
+  }, [config, selectedTemplate]);
+  useEffect(() => {
+    setPendingTemplateApply(null);
+  }, [selectedTemplateKey, repositoryId]);
+  useEffect(() => {
+    if (!pendingTemplateApply) return;
+    if (autosave.status === "saved") {
+      toast.success(`Applied ${pendingTemplateApply.title}`);
+      setPendingTemplateApply(null);
+    } else if (autosave.status === "error") {
+      setPendingTemplateApply(null);
+    }
+  }, [autosave.status, pendingTemplateApply]);
   // Build a fully-merged config from the freshest cache value. Returns null
   // only before the policy has loaded (controls are disabled until then).
   const draftFrom = (mutate: (next: CodeReviewPolicyConfig) => void): CodeReviewPolicyConfig | null => {
@@ -566,6 +584,20 @@ export default function CodeReviewsPage() {
                       disabled={!selectedTemplate || !config}
                       onClick={() => {
                         if (!selectedTemplate) return;
+                        const latestConfig = readLatestConfig();
+                        const alreadyApplied =
+                          selectedTemplateAlreadyApplied ||
+                          (latestConfig
+                            ? JSON.stringify(latestConfig) === JSON.stringify(selectedTemplate.config)
+                            : false);
+                        if (alreadyApplied) {
+                          toast.info(`${selectedTemplate.title} is already applied`);
+                          return;
+                        }
+                        setPendingTemplateApply({
+                          key: selectedTemplate.key,
+                          title: selectedTemplate.title,
+                        });
                         autosave.save(clonePolicy(selectedTemplate.config));
                       }}
                     >


### PR DESCRIPTION
## Summary

The “Apply template” flow on the Code Reviews configurations page didn’t consistently use the app’s shared toast system, leaving users without reliable feedback on whether changes were applied or reverted. This PR wires the template apply outcomes to the shared `notify` toasts (success, already-applied info, and save-failure error) so the UI and tests reflect the same workflow.

## Changes

- Updated `code-reviews/page.tsx` to use the shared `notify` toast system for template apply results:
  - Success toast message: `Applied <template name>`
  - Already applied: info toast
  - Save failure: `Couldn't save. Your change was reverted.`
- Extended coverage in `code-reviews/page.test.tsx` to assert toast calls for both the success path and the 500/save-failure path via MSW.

## Validation

- `npm test -- --run 'src/app/(dashboard)/code-reviews/page.test.tsx'`
- `npx eslint 'src/app/(dashboard)/code-reviews/page.tsx' 'src/app/(dashboard)/code-reviews/page.test.tsx' --max-warnings=0`

[143.dev](https://143.dev) | [session 193d8302](https://143.dev/sessions/193d8302-82b0-4111-a755-345686dcf887)

<!-- 143 readiness -->
**143 readiness:** not available for this revision.

Preview: https://143.dev/previews/github/assembledhq/143/pull/1714?launch=1