### PR TITLE
Enable automation management by default in coding agent session capability grants

### DIFF
--- a/frontend/src/components/automation-capabilities-editor.test.tsx
+++ b/frontend/src/components/automation-capabilities-editor.test.tsx
@@ -37,6 +37,7 @@ const CATALOG: AgentCapabilityDefinition[] = [
     category: "Actions",
     scope: "integration",
   }),
+  def("automation_management", { max_access_level: "write", risk: "high", category: "Actions" }),
 ];
 
 describe("recommendedDefaultGrants", () => {
@@ -60,6 +61,7 @@ describe("recommendedDefaultGrants", () => {
     expect(byID.get("issue_sources")?.enabled).toBe(true);
     expect(byID.get("production_diagnostics")?.enabled).toBe(true);
     expect(byID.get("slack_notifications")?.enabled).toBe(true);
+    expect(byID.get("automation_management")?.enabled).toBe(true);
   });
 
   it("uses each capability's max access level for its grant", () => {
@@ -69,6 +71,7 @@ describe("recommendedDefaultGrants", () => {
     expect(byID.get("repo_context")?.access_level).toBe("read");
     expect(byID.get("publishing")?.access_level).toBe("publish");
     expect(byID.get("slack_notifications")?.access_level).toBe("write");
+    expect(byID.get("automation_management")?.access_level).toBe("write");
   });
 });
 

--- a/frontend/src/components/automation-capabilities-editor.tsx
+++ b/frontend/src/components/automation-capabilities-editor.tsx
@@ -15,8 +15,8 @@ export function capabilityAccessFor(definition: AgentCapabilityDefinition) {
 // Capabilities that ship enabled by default for the org session-default policy
 // when an admin has not configured one yet. These are the broadly-useful
 // capabilities (code/PR/test context, integration issue context, read-only
-// production diagnostics, Slack status notifications, plus branch & PR
-// publishing).
+// production diagnostics, Slack status notifications, automation management,
+// plus branch & PR publishing).
 // Keep in sync with recommendedDefaultGrants in
 // internal/services/agentcapabilities/service.go.
 export const RECOMMENDED_DEFAULT_CAPABILITY_IDS: readonly AgentCapabilityID[] = [
@@ -27,6 +27,7 @@ export const RECOMMENDED_DEFAULT_CAPABILITY_IDS: readonly AgentCapabilityID[] = 
   "issue_sources",
   "production_diagnostics",
   "slack_notifications",
+  "automation_management",
   "publishing",
 ];
 

--- a/internal/services/agentcapabilities/service.go
+++ b/internal/services/agentcapabilities/service.go
@@ -297,7 +297,7 @@ func (s *Service) resolvePolicyGrants(ctx context.Context, in ResolveInput) ([]m
 // enabled by default when an org has not configured a session-default policy.
 // These cover broadly-useful capabilities (code/PR/test context, integration
 // issue context, read-only production diagnostics, Slack status notifications,
-// plus branch & PR publishing). Keep in sync with
+// automation management, plus branch & PR publishing). Keep in sync with
 // RECOMMENDED_DEFAULT_CAPABILITY_IDS in
 // frontend/src/components/automation-capabilities-editor.tsx.
 var recommendedDefaultEnabledCapabilities = map[models.AgentCapabilityID]bool{
@@ -308,6 +308,7 @@ var recommendedDefaultEnabledCapabilities = map[models.AgentCapabilityID]bool{
 	models.AgentCapabilityIssueSources:          true,
 	models.AgentCapabilityProductionDiagnostics: true,
 	models.AgentCapabilitySlackNotifications:    true,
+	models.AgentCapabilityAutomationManagement:  true,
 	models.AgentCapabilityPublishing:            true,
 }
 

--- a/internal/services/agentcapabilities/service_test.go
+++ b/internal/services/agentcapabilities/service_test.go
@@ -68,6 +68,7 @@ func TestServiceResolveForSessionUsesRecommendedDefaultsWhenNoPolicyExists(t *te
 		models.AgentCapabilityIssueSources,
 		models.AgentCapabilityProductionDiagnostics,
 		models.AgentCapabilitySlackNotifications,
+		models.AgentCapabilityAutomationManagement,
 		models.AgentCapabilityPublishing,
 	}, snapshotIDs(snapshot), "manual repository sessions should get recommended commonly-used defaults")
 }

--- a/migrations/000234_session_default_automation_management.down.sql
+++ b/migrations/000234_session_default_automation_management.down.sql
@@ -1,0 +1,8 @@
+UPDATE agent_capability_policy_grants g
+SET enabled = false
+FROM agent_capability_policies p
+WHERE g.org_id = p.org_id
+  AND g.policy_id = p.id
+  AND p.policy_type = 'session_default'
+  AND p.active = true
+  AND g.capability_id = 'automation_management';

--- a/migrations/000234_session_default_automation_management.up.sql
+++ b/migrations/000234_session_default_automation_management.up.sql
@@ -1,0 +1,31 @@
+WITH default_capabilities(capability_id, access_level) AS (
+    VALUES
+        ('automation_management', 'write')
+),
+active_defaults AS (
+    SELECT id, org_id
+    FROM agent_capability_policies
+    WHERE policy_type = 'session_default'
+      AND active = true
+)
+INSERT INTO agent_capability_policy_grants (
+    org_id,
+    policy_id,
+    capability_id,
+    access_level,
+    enabled,
+    config
+)
+SELECT
+    p.org_id,
+    p.id,
+    c.capability_id,
+    c.access_level,
+    true,
+    '{}'::jsonb
+FROM active_defaults p
+CROSS JOIN default_capabilities c
+WHERE true
+ON CONFLICT (org_id, policy_id, capability_id) DO UPDATE
+SET enabled = true,
+    access_level = EXCLUDED.access_level;


### PR DESCRIPTION
## Summary

Users enabling a coding-agent session with no org session-default policy currently miss the **automation management** capability, creating a workflow gap and inconsistent behavior across environments. This change updates both backend and frontend “recommended default” capability grants to include `automation_management` (with `write` access) and adds a DB migration so existing active session-default policies get the new default enabled setting.

## Changes

- Added `automation_management` to the frontend recommended default capability IDs and updated the corresponding `recommendedDefaultGrants` expectations.
- Updated backend recommended default enabled capabilities to include `automation_management` so `resolvePolicyGrants` returns it by default.
- Adjusted frontend/unit tests and updated service tests/fixtures to reflect the new default grant.
- Introduced migration `000234_session_default_automation_management.up.sql` (and matching `.down.sql`) to backfill existing active session-default policies.

## Validation

- `go test ./internal/services/agentcapabilities`
- `go vet ./internal/services/agentcapabilities`
- `npm run test:ci -- automation-capabilities-editor.test.tsx`
- `make lint-tenancy`

Notes: `npm ci` was required due to missing `frontend/node_modules`; it completed but reported pre-existing npm audit findings.

[143.dev](https://143.dev) | [session 406e1c21](https://143.dev/sessions/406e1c21-702f-44d6-917a-bad8bfb07216)

<!-- 143 readiness -->
**143 readiness:** not available for this revision.

Preview: https://143.dev/previews/github/assembledhq/143/pull/1715?launch=1