### PR TITLE
Fix HOST env leak that mis-targets provision-worker's egress step

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -500,7 +500,11 @@ provision-worker:
 	$(check-ssh-key)
 	@test -n "$(EGRESS_SSH_KEY)" || { echo "EGRESS_SSH_KEY could not be auto-detected. Put the gateway key at ~/.ssh/143-egress or ~/.ssh/143-egress.pem, or set EGRESS_SSH_KEY=<path> or SSH_KEY=<path>."; exit 1; }
 	@PROVISION_WORKER_HOST=$(HOST) deploy/scripts/sync-static-egress-secrets.sh --apply
-	@deploy/scripts/provision-egress.sh "" "$(EGRESS_SSH_KEY)"
+	@# Unset HOST so provision-egress.sh resolves the egress gateway from FLEET_HOSTS
+	@# (its empty $$1 arg). make exports the HOST command-line var, and
+	@# provision-egress.sh falls back to $$HOST when $$1 is empty — without this it
+	@# would target the WORKER as an egress node (tag:prod-egress) instead.
+	@env -u HOST deploy/scripts/provision-egress.sh "" "$(EGRESS_SSH_KEY)"
 	./deploy/scripts/provision.sh worker $(HOST) $(SSH_KEY) $(if $(REPROVISION),--reprovision)
 
 provision-egress:


### PR DESCRIPTION
## Problem

`make provision-worker HOST=<worker>` fails (or silently mis-provisions) at its egress step:

```
Error: changing settings via 'tailscale up' requires mentioning all non-default flags ...
	tailscale up --advertise-tags=tag:prod-egress --hostname=143-egress-<worker> ...
```

The `provision-worker` target calls `provision-egress.sh ""` with an **empty** host, intending it to resolve the real egress gateway from `FLEET_HOSTS` (`egress:<ip>`). But:

- `provision-egress.sh` does `HOST="${1:-${HOST:-}}"` — an empty `$1` falls back to the **`HOST` env var**.
- GNU make auto-exports command-line variables, so `make provision-worker HOST=<worker>` leaks `HOST=<worker>` into the sub-script's environment.
- `provision-egress.sh` only resolves the gateway from `FLEET_HOSTS` when `[ -z "$HOST" ]`, which is now false.

→ The egress step targets the **worker** host instead of the gateway and tries to enroll it as `tag:prod-egress`. On an already-enrolled worker (`tag:prod-worker`) Tailscale rejects the conflicting `tailscale up`; on a fresh worker it would wrongly enroll it as an egress node. This stayed latent because new workers are normally provisioned via cloud-init at boot, not this target — it surfaces when repairing an existing node.

## Fix

Unset `HOST` for the egress sub-call so `provision-egress.sh` resolves the gateway from `FLEET_HOSTS` as intended:

```make
@env -u HOST deploy/scripts/provision-egress.sh "" "$(EGRESS_SSH_KEY)"
```

Minimal and contained to the Makefile — it doesn't change `provision-egress.sh`'s contract for direct callers (`HOST=x provision-egress.sh` still works).

## Test

`make -n provision-worker HOST=… EGRESS_SSH_KEY=…` now emits `env -u HOST deploy/scripts/provision-egress.sh "" …`; the egress step resolves `egress:<ip>` from `FLEET_HOSTS` instead of the worker IP.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
