### PR TITLE
Improve code review policy UI with compact list editor for paths, authors, and checks

### DIFF
--- a/frontend/src/app/(dashboard)/code-reviews/page.test.tsx
+++ b/frontend/src/app/(dashboard)/code-reviews/page.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi } from "vitest";
 import { http, HttpResponse } from "msw";
-import { renderWithProviders, screen, userEvent, waitFor } from "@/test/test-utils";
+import { renderWithProviders, screen, userEvent, waitFor, within } from "@/test/test-utils";
 import { server } from "@/test/mocks/server";
 import CodeReviewsPage from "./page";
 
@@ -70,6 +70,8 @@ const policy: CodeReviewResolvedPolicy = {
       allowed_path_patterns: ["internal/**"],
       blocked_path_patterns: ["migrations/**"],
       exclude_categories: ["auth", "billing"],
+      required_checks: ["lint", "test"],
+      eligible_authors: ["anya"],
       require_mergeable: true,
       require_up_to_date: false,
       allow_forks: false,
@@ -199,7 +201,10 @@ const githubTriggerReady: CodeReviewGitHubTriggerResponse = {
   },
 };
 
-function mockCodeReviewBaseHandlers(trigger: CodeReviewGitHubTriggerResponse = githubTriggerReady) {
+function mockCodeReviewBaseHandlers(
+  trigger: CodeReviewGitHubTriggerResponse = githubTriggerReady,
+  onPolicyUpdate?: (config: CodeReviewPolicyConfig) => void,
+) {
   // Autosave issues whole-config PUTs and refetches on settle, so the GET must
   // reflect the last saved config for optimistic values to stick across the
   // invalidation round-trip.
@@ -215,6 +220,7 @@ function mockCodeReviewBaseHandlers(trigger: CodeReviewGitHubTriggerResponse = g
     http.put("/api/v1/code-review-policies", async ({ request }) => {
       const body = (await request.json()) as { config: CodeReviewPolicyConfig };
       currentConfig = body.config;
+      onPolicyUpdate?.(body.config);
       return HttpResponse.json({
         data: {
           ...currentConfig,
@@ -257,10 +263,13 @@ describe("CodeReviewsPage", () => {
 
     // Fine-tuning groups are collapsed by default; expand the ones we assert on.
     await user.click(screen.getByRole("button", { name: /Paths, authors & checks/i }));
-    expect(await screen.findByDisplayValue("*auth*")).toBeInTheDocument();
-    expect(screen.getByDisplayValue("internal/**")).toBeInTheDocument();
-    expect(screen.getByDisplayValue("migrations/**")).toBeInTheDocument();
-    expect(screen.getByDisplayValue(/auth\s+billing/)).toBeInTheDocument();
+    expect(await screen.findByText("*auth*")).toBeInTheDocument();
+    expect(screen.getByText("internal/**")).toBeInTheDocument();
+    expect(screen.getByText("migrations/**")).toBeInTheDocument();
+    expect(screen.getByText("billing")).toBeInTheDocument();
+    expect(screen.getByText("lint")).toBeInTheDocument();
+    expect(screen.getByText("anya")).toBeInTheDocument();
+    expect(screen.getAllByText("1 item").length).toBeGreaterThan(0);
 
     await user.click(screen.getByRole("button", { name: /Quality gates/i }));
     expect(await screen.findByText("Enforce sensitive paths")).toBeInTheDocument();
@@ -283,6 +292,71 @@ describe("CodeReviewsPage", () => {
 
     await user.click(screen.getByRole("button", { name: /Add requirement/i }));
     expect(await screen.findByDisplayValue("Custom requirement")).toBeInTheDocument();
+  });
+
+  it("edits paths, authors, and checks as compact autosaved lists", async () => {
+    const user = userEvent.setup();
+    const policyUpdates = vi.fn();
+    mockCodeReviewBaseHandlers(githubTriggerReady, policyUpdates);
+
+    renderWithProviders(<CodeReviewsPage />);
+
+    await user.click(await screen.findByRole("combobox", { name: /Repository/i }));
+    await user.click(await screen.findByRole("option", { name: "acme/api" }));
+    await user.click(await screen.findByRole("tab", { name: /Configurations/i }));
+    await user.click(await screen.findByRole("button", { name: /Paths, authors & checks/i }));
+
+    const sensitivePathsInput = await screen.findByRole("textbox", { name: "Sensitive paths" });
+    await user.type(sensitivePathsInput, " src/payments/** {enter}");
+
+    await waitFor(() => {
+      expect(policyUpdates).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          risk_policy: expect.objectContaining({
+            sensitive_paths: ["*auth*", "src/payments/**"],
+          }),
+        }),
+      );
+    });
+    expect(await screen.findByText("src/payments/**")).toBeInTheDocument();
+
+    await user.click(sensitivePathsInput);
+    await user.paste("src/admin/**\nsrc/reports/**\nsrc/admin/**");
+
+    await waitFor(() => {
+      expect(policyUpdates).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          risk_policy: expect.objectContaining({
+            sensitive_paths: ["*auth*", "src/payments/**", "src/admin/**", "src/reports/**"],
+          }),
+        }),
+      );
+    });
+    expect(await screen.findByText("src/admin/**")).toBeInTheDocument();
+    expect(screen.getByText("src/reports/**")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Remove *auth*" }));
+
+    await waitFor(() => {
+      expect(policyUpdates).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          risk_policy: expect.objectContaining({
+            sensitive_paths: ["src/payments/**", "src/admin/**", "src/reports/**"],
+          }),
+        }),
+      );
+    });
+    expect(screen.queryByText("*auth*")).not.toBeInTheDocument();
+
+    const requiredChecksEditor = screen.getByText("Required checks").closest("section");
+    expect(requiredChecksEditor).not.toBeNull();
+    expect(within(requiredChecksEditor as HTMLElement).getByText("2 items")).toBeInTheDocument();
+    expect(within(requiredChecksEditor as HTMLElement).getByText("lint")).toBeInTheDocument();
+    expect(within(requiredChecksEditor as HTMLElement).getByText("test")).toBeInTheDocument();
+
+    // Add-button labels are singularized correctly, including "categories" -> "category".
+    expect(screen.getByRole("button", { name: "Add excluded category" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Add required check" })).toBeInTheDocument();
   });
 
   it("renders GitHub trigger account-required state", async () => {

--- a/frontend/src/app/(dashboard)/code-reviews/page.tsx
+++ b/frontend/src/app/(dashboard)/code-reviews/page.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import type { ComponentProps, ReactNode } from "react";
+import type { ClipboardEvent, ComponentProps, KeyboardEvent, ReactNode } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { ClipboardCheck, ChevronDown, ExternalLink, Settings2, Plus, Trash2, FileSearch, Users, ShieldCheck, AlertTriangle } from "lucide-react";
 import { PageHeader } from "@/components/page-header";
@@ -649,39 +649,61 @@ export default function CodeReviewsPage() {
                   </FineTuningSection>
 
                   <FineTuningSection title="Paths, authors & checks" summary="Path filters, eligible authors, and required checks">
-                <div className="grid gap-3 lg:grid-cols-2">
-                      <ListTextArea
+                    <div className="grid gap-3 lg:grid-cols-2">
+                      <PolicyStringListEditor
                         label="Sensitive paths"
+                        description="Paths that should be treated as higher-risk changes."
+                        placeholder="Add glob pattern, e.g. src/auth/**"
+                        emptyText="No sensitive paths configured."
+                        monospace
                         serverValue={config?.risk_policy.sensitive_paths ?? []}
                         disabled={!config}
                         onCommitItems={(items) => commitPolicy((next) => { next.risk_policy.sensitive_paths = items; })}
                       />
-                      <ListTextArea
+                      <PolicyStringListEditor
                         label="Allowed path patterns"
+                        description="When set, only matching paths are eligible for automated approval."
+                        placeholder="Add allowed glob pattern"
+                        emptyText="No allowlist configured. All paths are eligible unless blocked."
+                        monospace
                         serverValue={config?.risk_policy.allowed_path_patterns ?? []}
                         disabled={!config}
                         onCommitItems={(items) => commitPolicy((next) => { next.risk_policy.allowed_path_patterns = items; })}
                       />
-                      <ListTextArea
+                      <PolicyStringListEditor
                         label="Blocked path patterns"
+                        description="Matching paths prevent automated approval."
+                        placeholder="Add blocked glob pattern"
+                        emptyText="No blocked paths configured."
+                        monospace
                         serverValue={config?.risk_policy.blocked_path_patterns ?? []}
                         disabled={!config}
                         onCommitItems={(items) => commitPolicy((next) => { next.risk_policy.blocked_path_patterns = items; })}
                       />
-                      <ListTextArea
+                      <PolicyStringListEditor
                         label="Excluded categories"
+                        description="Review categories to ignore for this policy."
+                        placeholder="Add category"
+                        emptyText="No excluded categories configured."
                         serverValue={config?.risk_policy.exclude_categories ?? []}
                         disabled={!config}
                         onCommitItems={(items) => commitPolicy((next) => { next.risk_policy.exclude_categories = items; })}
                       />
-                      <ListTextArea
+                      <PolicyStringListEditor
                         label="Required checks"
+                        description="Check names that must pass before approval."
+                        placeholder="Add required check"
+                        emptyText="No required checks configured."
+                        monospace
                         serverValue={config?.risk_policy.required_checks ?? []}
                         disabled={!config}
                         onCommitItems={(items) => commitPolicy((next) => { next.risk_policy.required_checks = items; })}
                       />
-                      <ListTextArea
+                      <PolicyStringListEditor
                         label="Eligible authors"
+                        description="Authors allowed by this policy. Leave empty to allow any author."
+                        placeholder="Add GitHub handle or author"
+                        emptyText="Any author is eligible."
                         serverValue={config?.risk_policy.eligible_authors ?? []}
                         disabled={!config}
                         onCommitItems={(items) => commitPolicy((next) => { next.risk_policy.eligible_authors = items; })}
@@ -1116,6 +1138,128 @@ function PolicyToggle({
 			<Switch checked={checked} disabled={disabled} onCheckedChange={onCheckedChange} />
 		</div>
 	);
+}
+
+function normalizeListItems(items: string[]): string[] {
+  const seen = new Set<string>();
+  const normalized: string[] = [];
+  for (const item of items) {
+    const trimmed = item.trim();
+    if (!trimmed || seen.has(trimmed)) continue;
+    seen.add(trimmed);
+    normalized.push(trimmed);
+  }
+  return normalized;
+}
+
+function PolicyStringListEditor({
+  label,
+  description,
+  placeholder,
+  emptyText,
+  serverValue,
+  disabled,
+  monospace = false,
+  onCommitItems,
+}: {
+  label: string;
+  description?: string;
+  placeholder: string;
+  emptyText: string;
+  serverValue: string[];
+  disabled?: boolean;
+  monospace?: boolean;
+  onCommitItems: (items: string[]) => void;
+}) {
+  const [draft, setDraft] = useState("");
+  const items = normalizeListItems(serverValue);
+  const addLabel = `Add ${label.toLowerCase().replace(/ies$/, "y").replace(/s$/, "")}`;
+  const countLabel = `${items.length} ${items.length === 1 ? "item" : "items"}`;
+
+  const commitNext = (nextItems: string[]) => {
+    onCommitItems(normalizeListItems(nextItems));
+  };
+
+  const addItems = (rawItems: string[]) => {
+    const nextItems = normalizeListItems([...items, ...rawItems]);
+    if (nextItems.length === items.length) return;
+    commitNext(nextItems);
+    setDraft("");
+  };
+
+  const handleAdd = () => addItems([draft]);
+
+  const handleKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
+    if (event.key !== "Enter") return;
+    event.preventDefault();
+    handleAdd();
+  };
+
+  const handlePaste = (event: ClipboardEvent<HTMLInputElement>) => {
+    const text = event.clipboardData.getData("text");
+    if (!text.includes("\n")) return;
+    event.preventDefault();
+    addItems(text.split(/\r?\n/));
+  };
+
+  const removeItem = (item: string) => {
+    commitNext(items.filter((current) => current !== item));
+  };
+
+  return (
+    <section className="rounded-md border border-border bg-background">
+      <div className="space-y-1 p-4">
+        <div className="flex items-center justify-between gap-3">
+          <Label htmlFor={`${label.toLowerCase().replace(/[^a-z0-9]+/g, "-")}-input`} className="text-sm font-medium text-foreground">
+            {label}
+          </Label>
+          <Badge variant="outline" className="shrink-0 text-xs">
+            {countLabel}
+          </Badge>
+        </div>
+        {description ? <p className="text-xs text-muted-foreground">{description}</p> : null}
+      </div>
+      <div className="divide-y divide-border border-t border-border">
+        {items.length === 0 ? (
+          <div className="px-4 py-3 text-xs text-muted-foreground">{emptyText}</div>
+        ) : (
+          items.map((item) => (
+            <div key={item} className="flex min-h-10 items-center gap-3 px-4 py-2">
+              <span className={`min-w-0 flex-1 truncate text-sm text-foreground ${monospace ? "font-mono" : ""}`}>
+                {item}
+              </span>
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon-sm"
+                disabled={disabled}
+                aria-label={`Remove ${item}`}
+                onClick={() => removeItem(item)}
+              >
+                <Trash2 className="h-4 w-4" />
+              </Button>
+            </div>
+          ))
+        )}
+        <div className="grid gap-2 p-3 sm:grid-cols-[1fr_auto]">
+          <Input
+            id={`${label.toLowerCase().replace(/[^a-z0-9]+/g, "-")}-input`}
+            value={draft}
+            disabled={disabled}
+            placeholder={placeholder}
+            aria-label={label}
+            onChange={(event) => setDraft(event.target.value)}
+            onKeyDown={handleKeyDown}
+            onPaste={handlePaste}
+          />
+          <Button type="button" variant="outline" disabled={disabled || !draft.trim()} onClick={handleAdd}>
+            <Plus className="h-4 w-4" />
+            {addLabel}
+          </Button>
+        </div>
+      </div>
+    </section>
+  );
 }
 
 function ListTextArea({


### PR DESCRIPTION
## Summary

Users configuring code review policies currently interact with six multi-line text areas for paths/authors/checks, which makes adding/removing items error-prone and harder to reason about during autosave. This change replaces those controls with a compact `PolicyStringListEditor` that renders each entry as a removable row (with counts/empty-state help) and supports Enter-to-add plus multi-line paste.

## Changes

- Replace the “Paths, authors & checks” multi-line list text areas with `PolicyStringListEditor` rows to improve editing clarity and reduce formatting mistakes.
- Add normalization behavior (trim/dedup) so pasted or repeatedly-added values don’t create duplicate/whitespace-only entries in the saved config.
- Update and expand `code-reviews/page.test.tsx` to cover autosaved compact list editing flows (add/paste/remove/dedup) and ensure the UI renders the expected list items and counts.

## Validation

- `frontend/src/app/(dashboard)/code-reviews/page.test.tsx`: updated/added tests for the compact list editor behavior.
- `page.test.tsx` suite passes (4/4).
- `tsc --noEmit` was clean after the related follow-up change.

[143.dev](https://143.dev) | [session a5e489b2](https://143.dev/sessions/a5e489b2-8763-49ef-b512-8d1ab8c73774)

<!-- 143 readiness -->
**143 readiness:** Ready with warnings (workspace revision 6; 7 passed, 2 warnings, 0 blockers).

Preview: https://143.dev/previews/github/assembledhq/143/pull/1719?launch=1