### PR TITLE
Fix stuck "Agent is working…" on failed and interrupted sessions

### DIFF
--- a/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
@@ -2231,6 +2231,10 @@ function ChatPanel({
 
   const activeThreadId = activeThread?.id;
   const isRunning = activeThread ? activeThread.status === "running" : session.status === "running";
+  // A worker drain / deploy interruption leaves the thread "running" while the
+  // runtime waits to resume. Surface that as "Resuming after maintenance…" in the
+  // timeline spinner instead of an honest-looking "Agent is working…".
+  const recoveryActive = isRuntimeRecoveryActive(session);
   const isPending = activeThread ? activeThread.status === "pending" : session.status === "pending";
   const isSnapshotExpired = session.sandbox_state === "destroyed";
   const canSendMessage = session.status !== "skipped" && session.status !== "pending" && !isSnapshotExpired;
@@ -3133,6 +3137,7 @@ function ChatPanel({
             <ChatTimeline
               entries={timelineEntries}
               isRunning={isRunning}
+              recoveryActive={recoveryActive}
               stoppingLabel={isStopRequested ? "Stopping agent..." : undefined}
               stoppedLabel={
                 session.status === "cancelled" || activeThread?.status === "cancelled"

--- a/frontend/src/components/chat-timeline.test.tsx
+++ b/frontend/src/components/chat-timeline.test.tsx
@@ -368,6 +368,25 @@ describe("ChatTimeline", () => {
     expect(screen.queryByText("Agent is working...")).not.toBeInTheDocument();
   });
 
+  it("shows recovery indicator instead of working indicator while resuming after an interruption", () => {
+    render(<ChatTimeline entries={[]} isRunning={true} recoveryActive={true} />);
+    expect(screen.getByText("Resuming after maintenance...")).toBeInTheDocument();
+    expect(screen.queryByText("Agent is working...")).not.toBeInTheDocument();
+  });
+
+  it("prefers the stopping indicator over the recovery indicator when both apply", () => {
+    render(
+      <ChatTimeline entries={[]} isRunning={true} recoveryActive={true} stoppingLabel="Stopping agent..." />,
+    );
+    expect(screen.getByText("Stopping agent...")).toBeInTheDocument();
+    expect(screen.queryByText("Resuming after maintenance...")).not.toBeInTheDocument();
+  });
+
+  it("does not show recovery indicator when not running", () => {
+    render(<ChatTimeline entries={[]} isRunning={false} recoveryActive={true} />);
+    expect(screen.queryByText("Resuming after maintenance...")).not.toBeInTheDocument();
+  });
+
   it("does not show working indicator when not running", () => {
     render(<ChatTimeline entries={[]} isRunning={false} />);
     expect(screen.queryByText("Agent is working...")).not.toBeInTheDocument();

--- a/frontend/src/components/chat-timeline.tsx
+++ b/frontend/src/components/chat-timeline.tsx
@@ -626,6 +626,10 @@ const CodeDiffSummary = memo(function CodeDiffSummary({
 interface ChatTimelineProps {
   entries: TimelineEntry[];
   isRunning: boolean;
+  // When the runtime was interrupted (worker drain / deploy) and is waiting to
+  // resume, the thread is still "running" but the agent is not actively working.
+  // Show a recovery label instead of "Agent is working…" so the spinner is honest.
+  recoveryActive?: boolean;
   stoppingLabel?: string;
   stoppedLabel?: string;
   diffStats?: { added: number; removed: number; files_changed: number } | null;
@@ -644,7 +648,7 @@ interface ChatTimelineProps {
   ) => React.HTMLAttributes<HTMLDivElement> & Record<`data-${string}`, string | number | undefined>;
 }
 
-function ChatTimelineImpl({ entries, isRunning, stoppingLabel, stoppedLabel, diffStats, onDiffClick, onApprovePlan, onAdjustPlan, humanInputSubmittingId, autoOpenHumanInputId, humanInputAnswerable = true, onAnswerHumanInput, onCancelHumanInput, onDismissHumanInputAutoOpen, getEntryContainerProps }: ChatTimelineProps) {
+function ChatTimelineImpl({ entries, isRunning, recoveryActive = false, stoppingLabel, stoppedLabel, diffStats, onDiffClick, onApprovePlan, onAdjustPlan, humanInputSubmittingId, autoOpenHumanInputId, humanInputAnswerable = true, onAnswerHumanInput, onCancelHumanInput, onDismissHumanInputAutoOpen, getEntryContainerProps }: ChatTimelineProps) {
   // Separate visible entries (messages, tool groups, errors) from hidden logs.
   // Group consecutive hidden logs together so they share a single "Show more" toggle.
   const rendered: React.ReactNode[] = [];
@@ -824,6 +828,17 @@ function ChatTimelineImpl({ entries, isRunning, stoppingLabel, stoppedLabel, dif
         </div>
       </div>
     );
+  } else if (isRunning && recoveryActive) {
+    rendered.push(
+      <div key="recovering" className="flex justify-start">
+        <div className="bg-muted rounded-lg px-3 py-2 text-sm">
+          <span className="flex items-center gap-2 text-muted-foreground">
+            <Loader2 className="h-3 w-3 animate-spin" aria-hidden />
+            Resuming after maintenance...
+          </span>
+        </div>
+      </div>
+    );
   } else if (isRunning) {
     rendered.push(
       <div key="working" className="flex justify-start">
@@ -884,6 +899,7 @@ export const ChatTimeline = memo(ChatTimelineImpl, (prev, next) => {
   return (
     prev.entries === next.entries &&
     prev.isRunning === next.isRunning &&
+    prev.recoveryActive === next.recoveryActive &&
     prev.stoppingLabel === next.stoppingLabel &&
     prev.stoppedLabel === next.stoppedLabel &&
     prev.onDiffClick === next.onDiffClick &&

--- a/internal/services/agent/orchestrator.go
+++ b/internal/services/agent/orchestrator.go
@@ -1424,10 +1424,7 @@ func (o *Orchestrator) RecoverSession(ctx context.Context, session *models.Sessi
 		cleanupCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 		defer cancel()
 		o.failRunWithCategory(cleanupCtx, session, errMsg, FailureCategoryRecovery, explanation, nextSteps)
-		o.updatePrimaryThreadTerminal(cleanupCtx, session, models.ThreadStatusFailed, &models.SessionResult{
-			Error:           &explanation,
-			FailureCategory: strPtr(FailureCategoryRecovery),
-		}, log)
+		// failRun (via failRunWithCategory) terminalizes the primary thread.
 		if err := o.sessions.UpdateRecoveryState(cleanupCtx, session.OrgID, session.ID, models.RecoveryStateNone, nil, nil, false); err != nil {
 			log.Warn().Err(err).Msg("failed to clear recovery state after exhausting no-checkpoint recovery")
 		}
@@ -3032,9 +3029,7 @@ func (o *Orchestrator) RunAgent(ctx context.Context, run *models.Session) error 
 		}
 		o.failRun(ctx, run, err.Error())
 		logAgentRunFailed(log, run, err, "failed", runStartedAt, nil)
-		o.updatePrimaryThreadTerminal(ctx, run, models.ThreadStatusFailed, &models.SessionResult{
-			Error: strPtr(err.Error()),
-		}, log)
+		// failRun now terminalizes the primary thread; no explicit update needed here.
 		o.enqueueJob(ctx, run.OrgID, "agent", "analyze_failure", map[string]interface{}{
 			"session_id": run.ID.String(),
 			"org_id":     run.OrgID.String(),
@@ -5617,6 +5612,12 @@ func (o *Orchestrator) failRun(ctx context.Context, run *models.Session, errMsg 
 	if err := o.sessions.UpdateResult(ctx, run.OrgID, run.ID, models.SessionStatusFailed, result); err != nil {
 		o.logger.Error().Err(err).Str("run_id", run.ID.String()).Msg("failed to update run to failed")
 	}
+	// Drive the primary thread terminal too. The frontend's "Agent is working…"
+	// indicator is bound to the thread status, not the session status, so failing
+	// only the session leaves the thread stuck at "running" — the UI keeps spinning
+	// until the reaper sweeps it (~2.5h later). updatePrimaryThreadTerminal also
+	// publishes a thread-runtime SSE event so any open page flips immediately.
+	o.updatePrimaryThreadTerminal(ctx, run, models.ThreadStatusFailed, result, o.logger)
 	if run.ProjectTaskID != nil && o.projectTasks != nil {
 		if err := o.projectTasks.OnSessionComplete(ctx, run, "failed"); err != nil {
 			o.logger.Warn().Err(err).Str("run_id", run.ID.String()).Msg("failed to update project task on run failure")
@@ -5750,10 +5751,7 @@ func (o *Orchestrator) failTimedOutSession(run *models.Session, elapsed time.Dur
 			"Retry the session — transient slowness (LLM latency, git clone) may have pushed the run over the edge",
 		},
 	)
-	o.updatePrimaryThreadTerminal(cleanupCtx, run, models.ThreadStatusFailed, &models.SessionResult{
-		Error:           &explanation,
-		FailureCategory: strPtr(FailureCategoryTimeout),
-	}, log)
+	// failRun (via failRunWithCategory) terminalizes the primary thread.
 }
 
 // ensureCodexAuth injects Codex auth credentials into the sandbox. On failure
@@ -6898,6 +6896,16 @@ func (o *Orchestrator) handleSystemInterruptedSession(ctx context.Context, sessi
 	if err := o.sessions.UpdateStatus(bgCtx, session.OrgID, session.ID, fallbackStatus); err != nil {
 		log.Warn().Err(err).Str("status", string(fallbackStatus)).Msg("failed to restore session status after system interruption")
 	}
+	// Surface the interruption at the session level so the UI's recovery banner
+	// ("Restoring runtime from checkpoint") fires while the requeued turn waits to
+	// resume — matching how lost-job reclaim queues session recovery. Without this
+	// the banner stays hidden (it reads session.recovery_state, not the thread's)
+	// and the only signal is a "running" thread, i.e. a bare "Agent is working…".
+	// BeginRuntime / RecoverSession clear recovery_state once the turn resumes.
+	queuedAt := time.Now().UTC()
+	if err := o.sessions.UpdateRecoveryState(bgCtx, session.OrgID, session.ID, models.RecoveryStateQueued, &queuedAt, nil, false); err != nil {
+		log.Warn().Err(err).Msg("failed to mark session recovery as queued after system interruption")
+	}
 	if o.sessionThreads != nil && session.PrimaryThreadID != nil && *session.PrimaryThreadID != uuid.Nil {
 		if recorder, ok := o.sessionThreads.(sessionThreadRecoveryMetadataStore); ok {
 			if err := recorder.RecordRecoveryMetadata(bgCtx, session.OrgID, *session.PrimaryThreadID, runtimeReason, time.Now().UTC(), string(models.RecoveryStateQueued), string(runtimeReason)); err != nil {
@@ -7252,10 +7260,7 @@ func (o *Orchestrator) handlePolicyStoppedSession(ctx context.Context, session *
 	terminalCtx, terminalCancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer terminalCancel()
 	o.failRunWithCategory(terminalCtx, session, errMsg, FailureCategoryTimeout, explanation, nextSteps)
-	o.updatePrimaryThreadTerminal(terminalCtx, session, models.ThreadStatusFailed, &models.SessionResult{
-		Error:           &explanation,
-		FailureCategory: strPtr(FailureCategoryTimeout),
-	}, log)
+	// failRun (via failRunWithCategory) terminalizes the primary thread.
 
 	if snapshotKey != "" {
 		warmCtx, warmCancel := context.WithTimeout(context.Background(), 15*time.Second)

--- a/internal/services/agent/orchestrator_test.go
+++ b/internal/services/agent/orchestrator_test.go
@@ -6500,6 +6500,13 @@ func TestContinueSession_ContextCanceledWithoutUserCancelIsInterruptedNotCancell
 	require.NotErrorIs(t, err, agent.ErrSessionCancelled, "plain parent context cancellation should not be classified as user cancellation")
 	require.NotContains(t, d.sessions.getStatusUpdates(), string(models.SessionStatusCancelled), "system interruptions must not mark the session cancelled")
 	require.Contains(t, d.sessions.getStatusUpdates(), string(models.SessionStatusIdle), "system interruptions without a checkpoint should restore the pre-turn status")
+	queuedRecovery := false
+	for _, update := range d.sessions.recoveryStates {
+		if update.state == models.RecoveryStateQueued {
+			queuedRecovery = true
+		}
+	}
+	require.True(t, queuedRecovery, "system interruptions should queue session recovery so the UI's recovery banner fires instead of a bare \"Agent is working…\"")
 }
 
 // TestContinueSession_RoutesToRequestedThreadAcrossSiblingTurns is the
@@ -9799,6 +9806,50 @@ func TestRunAgent_AmpMissingAPIKeyFailsFast(t *testing.T) {
 		"error should name the missing credential so users know what to configure")
 	require.False(t, sandboxCreated,
 		"pre-flight auth check must fire before sandbox creation")
+}
+
+// TestRunAgent_AuthFailureTerminalizesPrimaryThread is a regression test for the
+// stuck "Agent is working…" indicator: a pre-flight auth failure (e.g. the user
+// picks a model with no backing credential) marked the session failed but left
+// the primary thread at "running". Because the UI binds that indicator to the
+// thread status — not the session status — the spinner kept running until the
+// reaper swept the thread ~2.5h later. failRun must now terminalize the thread
+// on every early-exit failure path, not just the main run loop.
+func TestRunAgent_AuthFailureTerminalizesPrimaryThread(t *testing.T) {
+	t.Parallel()
+
+	orgID := testOrg()
+	run := testRun(orgID, testIssue(orgID).ID)
+	run.AgentType = models.AgentTypeAmp
+	threadID := uuid.New()
+	run.PrimaryThreadID = &threadID
+
+	d := defaultDeps()
+	d.adapter.name = models.AgentTypeAmp
+	d.sessionThreads = &mockSessionThreadStore{}
+
+	var sandboxCreated bool
+	d.provider.CreateFn = func(context.Context, agent.SandboxConfig) (*agent.Sandbox, error) {
+		sandboxCreated = true
+		return &agent.Sandbox{ID: "amp-unreachable", Provider: "mock", WorkDir: "/workspace"}, nil
+	}
+
+	err := buildOrchestrator(d).RunAgent(context.Background(), run)
+	require.Error(t, err, "missing-credential run must fail fast")
+	require.False(t, sandboxCreated, "auth check must fire before sandbox creation")
+
+	results := d.sessions.getResultUpdates()
+	require.NotEmpty(t, results, "auth failure should persist a session result")
+	require.Equal(t, models.SessionStatusFailed, results[len(results)-1].status,
+		"pre-flight auth failure should mark the session failed")
+
+	statuses := d.sessionThreads.statuses()
+	require.NotEmpty(t, statuses, "the primary thread should have been touched")
+	require.Equal(t, models.ThreadStatusRunning, statuses[0],
+		"thread is marked running at launch, before the auth check")
+	require.Equal(t, models.ThreadStatusFailed, statuses[len(statuses)-1],
+		"pre-flight auth failure must terminalize the primary thread so the UI's "+
+			"thread-bound \"Agent is working…\" indicator clears instead of spinning until the reaper")
 }
 
 // TestRunAgent_PiModelOverrideReachesSandbox asserts that a per-run override

--- a/internal/worker/handlers.go
+++ b/internal/worker/handlers.go
@@ -62,6 +62,7 @@ var enqueuePRPushChangesJobAfterContinue = enqueuePRPushChangesJob
 const prePRReviewMaxWait = 30 * time.Minute
 const defaultSessionPrewarmQueuedTimeout = 15 * time.Minute
 const failureCategoryStaleSandbox = "stale_sandbox"
+const failureCategoryInterrupted = "interrupted_unrecovered"
 
 var sandboxCapacityDetailPattern = regexp.MustCompile(`sandbox capacity reached:\s*(\d+)/(\d+)\s+sandboxes active or reserved`)
 
@@ -314,6 +315,102 @@ func registerSandboxCapacityDeadLetter(ctx context.Context, stores *Stores, serv
 					Str("session_id", failedSession.ID.String()).
 					Str("job_type", jobType).
 					Msg("failed to update automation run after sandbox capacity dead-letter")
+			}
+		}
+		if stores.Jobs != nil {
+			linear.EnqueueMilestone(writeCtx, stores.Jobs, logger, failedSession.OrgID, failedSession.ID, "failed", 0)
+		}
+		enqueueSlackRunUpdateIfLinked(writeCtx, stores, logger, failedSession.OrgID, failedSession.ID, "failed", "143 session failed", errMsg, true)
+		enqueueSlackSessionNotifications(writeCtx, stores, logger, failedSession.OrgID, failedSession.ID, failedSession.AutomationRunID, string(models.SlackNotificationSessionFailed), "143 session failed", errMsg)
+	})
+}
+
+// registerSystemInterruptDeadLetter terminalizes a session (and its primary
+// thread) when a turn interrupted by a system stop — a worker drain or rolling
+// deploy — never manages to resume and the requeued job ultimately dead-letters.
+// The interrupt branch returns a RetryableError so the same turn re-runs on
+// another worker; this hook is the deterministic give-up cleanup. Without it the
+// session sits at its pre-turn status with the primary thread still "running"
+// (so the UI keeps showing "Agent is working…") until the reaper sweeps it
+// ~2.5h later — exactly the orphan the reaper's phase-0.5 comment describes.
+func registerSystemInterruptDeadLetter(ctx context.Context, stores *Stores, services *Services, logger zerolog.Logger, session models.Session, threadID *uuid.UUID, jobType string) {
+	if stores == nil || stores.Sessions == nil {
+		return
+	}
+	jobctx.RegisterDeadLetterHook(ctx, func(hookCtx context.Context, deadLetterErr error) {
+		writeCtx, cancel := context.WithTimeout(context.WithoutCancel(hookCtx), 10*time.Second)
+		defer cancel()
+
+		errMsg := "Session stopped: it was interrupted by maintenance and could not be resumed before the retry window expired."
+		explanation := "A worker drain or system stop interrupted this run and the requeued attempt never completed — the job dead-lettered, e.g. during a rolling deploy. No further automatic retry will happen."
+		nextSteps := []string{
+			"Retry the session — the interruption was most likely a transient deploy or worker restart",
+			"Check worker logs if sessions repeatedly fail to resume after deploys",
+		}
+		if deadLetterErr != nil {
+			logger.Warn().
+				Err(deadLetterErr).
+				Str("session_id", session.ID.String()).
+				Str("job_type", jobType).
+				Msg("session job dead-lettered after a system interruption could not resume")
+		}
+
+		failedSession := session
+		failureCategory := failureCategoryInterrupted
+		failedSession.Status = models.SessionStatusFailed
+		failedSession.Error = &errMsg
+		failedSession.FailureCategory = &failureCategory
+		failedSession.FailureExplanation = &explanation
+		failedSession.FailureNextSteps = nextSteps
+		failedSession.FailureRetryAdvised = true
+
+		result := &models.SessionResult{Error: &errMsg}
+		if err := stores.Sessions.UpdateResult(writeCtx, session.OrgID, session.ID, models.SessionStatusFailed, result); err != nil {
+			logger.Error().
+				Err(err).
+				Str("session_id", session.ID.String()).
+				Str("job_type", jobType).
+				Msg("failed to mark session failed after system-interrupt dead-letter")
+			return
+		}
+		if err := stores.Sessions.UpdateFailure(writeCtx, session.OrgID, session.ID, explanation, failureCategoryInterrupted, nextSteps, true); err != nil {
+			logger.Error().
+				Err(err).
+				Str("session_id", session.ID.String()).
+				Str("job_type", jobType).
+				Msg("failed to persist system-interrupt failure details")
+		}
+		if threadID != nil && *threadID != uuid.Nil && stores.SessionThreads != nil {
+			threadCategory := failureCategoryInterrupted
+			threadResult := &models.SessionResult{
+				Error:           &errMsg,
+				FailureCategory: &threadCategory,
+			}
+			if err := stores.SessionThreads.UpdateResult(writeCtx, session.OrgID, *threadID, models.ThreadStatusFailed, threadResult); err != nil {
+				logger.Error().
+					Err(err).
+					Str("session_id", session.ID.String()).
+					Str("thread_id", threadID.String()).
+					Str("job_type", jobType).
+					Msg("failed to mark session thread failed after system-interrupt dead-letter")
+			}
+		}
+		if services != nil && services.ProjectTasks != nil && failedSession.ProjectTaskID != nil {
+			if err := services.ProjectTasks.OnSessionComplete(writeCtx, &failedSession, models.SessionStatusFailed); err != nil {
+				logger.Warn().
+					Err(err).
+					Str("session_id", failedSession.ID.String()).
+					Str("job_type", jobType).
+					Msg("failed to update project task after system-interrupt dead-letter")
+			}
+		}
+		if services != nil && services.AutomationRuns != nil && failedSession.AutomationRunID != nil {
+			if err := services.AutomationRuns.OnSessionComplete(writeCtx, &failedSession, models.SessionStatusFailed); err != nil {
+				logger.Warn().
+					Err(err).
+					Str("session_id", failedSession.ID.String()).
+					Str("job_type", jobType).
+					Msg("failed to update automation run after system-interrupt dead-letter")
 			}
 		}
 		if stores.Jobs != nil {
@@ -7722,6 +7819,10 @@ func newRunAgentHandler(stores *Stores, services *Services, logger zerolog.Logge
 			}
 			if errors.Is(err, agent.ErrSessionInterrupted) {
 				retryAfter := 2 * time.Second
+				// Deterministically fail the session + thread if this interrupted
+				// turn never resumes and the requeued job dead-letters, instead of
+				// orphaning them at "running" until the reaper.
+				registerSystemInterruptDeadLetter(ctx, stores, services, logger, run, run.PrimaryThreadID, "run_agent")
 				logger.Info().
 					Str("session_id", runID.String()).
 					Err(err).
@@ -9072,6 +9173,15 @@ func newContinueSessionHandler(stores *Stores, services *Services, logger zerolo
 			}
 			if errors.Is(err, agent.ErrSessionInterrupted) {
 				retryAfter := 2 * time.Second
+				var interruptThreadID *uuid.UUID
+				if hasThread {
+					threadIDLocal := threadID
+					interruptThreadID = &threadIDLocal
+				}
+				// Deterministically fail the session + thread if this interrupted
+				// turn never resumes and the requeued job dead-letters, instead of
+				// orphaning them at "running" until the reaper.
+				registerSystemInterruptDeadLetter(ctx, stores, services, logger, session, interruptThreadID, "continue_session")
 				logger.Info().
 					Str("session_id", sessionID.String()).
 					Err(err).

--- a/internal/worker/handlers_test.go
+++ b/internal/worker/handlers_test.go
@@ -9544,6 +9544,116 @@ func TestRunAgentHandler_SandboxCapacityDeadLetterFailsSessionAndThread(t *testi
 	require.NoError(t, mock.ExpectationsWereMet(), "dead-letter hook should fail the session and active thread after capacity retries exhaust; logs: %s", logBuf.String())
 }
 
+func TestRunAgentHandler_SystemInterruptDeadLetterFailsSessionAndThread(t *testing.T) {
+	t.Parallel()
+
+	stores, mock := newTestStores(t)
+	defer mock.Close()
+	stores.SessionThreads = db.NewSessionThreadStore(mock)
+	stores.ProjectTasks = db.NewProjectTaskStore(mock)
+	stores.Projects = db.NewProjectStore(mock)
+	stores.AutomationRuns = db.NewAutomationRunStore(mock)
+
+	orgID := uuid.New()
+	runID := uuid.New()
+	issueID := uuid.New()
+	threadID := uuid.New()
+	projectID := uuid.New()
+	projectTaskID := uuid.New()
+	automationRunID := uuid.New()
+
+	sessionRow := workerSessionRow(runID, issueID, orgID, models.SessionStatusRunning, 0, nil, nil)
+	setWorkerSessionColumnValue(sessionRow, "project_task_id", &projectTaskID)
+	setWorkerSessionColumnValue(sessionRow, "automation_run_id", &automationRunID)
+	mock.ExpectQuery("SELECT .* FROM sessions").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(
+			pgxmock.NewRows(workerSessionColumns).AddRow(
+				sessionRow...,
+			),
+		)
+
+	orch := &orchestratorServiceStub{
+		recoverSessionFn: func(ctx context.Context, run *models.Session) error {
+			require.NotNil(t, run.PrimaryThreadID, "run_agent recovery should carry the payload thread ID into the orchestrator")
+			require.Equal(t, threadID, *run.PrimaryThreadID, "run_agent recovery should preserve the primary thread ID from the job payload")
+			return fmt.Errorf("worker draining: %w", agent.ErrSessionInterrupted)
+		},
+	}
+	var logBuf bytes.Buffer
+	handler := newRunAgentHandler(stores, &Services{
+		Orchestrator:   orch,
+		ProjectTasks:   pm.NewProjectHooks(stores.ProjectTasks, stores.Projects, zerolog.New(&logBuf)),
+		AutomationRuns: automations.NewAutomationHooks(stores.AutomationRuns, zerolog.New(&logBuf)),
+	}, zerolog.New(&logBuf))
+	handlerCtx := jobctx.WithDeadLetterHooks(context.Background())
+	payload := json.RawMessage(`{"session_id":"` + runID.String() + `","org_id":"` + orgID.String() + `","thread_id":"` + threadID.String() + `"}`)
+
+	err := handler(handlerCtx, "run_agent", payload)
+	require.Error(t, err, "run_agent should keep system interruptions retryable so the turn can resume on another worker")
+	var retryable *RetryableError
+	require.ErrorAs(t, err, &retryable, "system interruptions should remain retryable until the worker dead-letters the job")
+	require.NoError(t, mock.ExpectationsWereMet(), "an interrupted turn should not mark the session failed before dead-letter")
+	require.Equal(t, 1, orch.recoverSessionCalls, "running sessions should use the recovery path")
+
+	// Same failure cascade as the capacity dead-letter path (minus the dynamic
+	// capacity explanation query): session result + structured failure details,
+	// primary thread failed, project-task and automation-run completion, and a
+	// failed Linear milestone job.
+	mock.ExpectQuery("UPDATE sessions").
+		WithArgs(workerAnyArgs(11)...).
+		WillReturnRows(pgxmock.NewRows(workerSessionColumns).AddRow(
+			workerSessionRow(runID, issueID, orgID, models.SessionStatusFailed, 0, nil, nil)...,
+		))
+	mock.ExpectExec("UPDATE sessions[\\s\\S]+SET failure_explanation").
+		WithArgs(
+			pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
+			pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
+		).
+		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
+	mock.ExpectExec("UPDATE session_threads[\\s\\S]+SET status = @status").
+		WithArgs(workerAnyArgs(7)...).
+		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
+	now := time.Now()
+	mock.ExpectQuery("SELECT [\\s\\S]+ FROM project_tasks WHERE id").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(pgxmock.NewRows(workerProjectTaskColumns).AddRow(
+			workerProjectTaskRow(projectTaskID, projectID, orgID, models.ProjectTaskStatusRunning, now)...,
+		))
+	mock.ExpectBegin()
+	mock.ExpectExec("UPDATE project_tasks SET").
+		WithArgs(
+			pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
+			pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
+			pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
+			pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
+			pgxmock.AnyArg(), pgxmock.AnyArg(),
+		).
+		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
+	mock.ExpectExec("DELETE FROM project_task_dependencies").
+		WithArgs(pgxmock.AnyArg()).
+		WillReturnResult(pgxmock.NewResult("DELETE", 0))
+	mock.ExpectCommit()
+	mock.ExpectExec("UPDATE projects SET").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
+	mock.ExpectExec("UPDATE automation_runs").
+		WithArgs(
+			pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
+			pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
+		).
+		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
+	mock.ExpectQuery("INSERT INTO jobs").
+		WithArgs(
+			pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
+			pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
+		).
+		WillReturnRows(pgxmock.NewRows([]string{"id"}).AddRow(uuid.New()))
+
+	jobctx.RunDeadLetterHooks(handlerCtx, err)
+	require.NoError(t, mock.ExpectationsWereMet(), "dead-letter hook should fail the session and active thread after an unrecoverable interruption; logs: %s", logBuf.String())
+}
+
 func TestRunAgentHandler_RecoveryAttemptsExhaustedDeadLetters(t *testing.T) {
 	t.Parallel()
 
@@ -10559,6 +10669,94 @@ func TestContinueSessionHandler_SandboxCapacityDeadLetterFailsSessionAndThread(t
 	require.NotContains(t, failureExplanation, "2/2", "failure explanation should not expose local slot counts")
 	require.NotContains(t, failureExplanation, "Current worker load", "failure explanation should not expose fleet load details")
 	require.NoError(t, mock.ExpectationsWereMet(), "dead-letter hook should fail both the session and thread after capacity retry exhaustion")
+}
+
+func TestContinueSessionHandler_SystemInterruptDeadLetterFailsSessionAndThread(t *testing.T) {
+	t.Parallel()
+
+	stores, mock := newTestStores(t)
+	defer mock.Close()
+	stores.SessionThreads = db.NewSessionThreadStore(mock)
+
+	orgID := uuid.New()
+	sessionID := uuid.New()
+	threadID := uuid.New()
+	issueID := uuid.New()
+	projectTaskID := uuid.New()
+	automationRunID := uuid.New()
+	sessionRow := workerSessionRow(sessionID, issueID, orgID, models.SessionStatusRunning, 2, nil, nil)
+	setWorkerSessionColumnValue(sessionRow, "project_task_id", &projectTaskID)
+	setWorkerSessionColumnValue(sessionRow, "automation_run_id", &automationRunID)
+
+	mock.ExpectQuery("SELECT .* FROM sessions").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(
+			pgxmock.NewRows(workerSessionColumns).AddRow(
+				sessionRow...,
+			),
+		)
+	mock.ExpectQuery("SELECT .* FROM session_threads").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(
+			pgxmock.NewRows(workerSessionThreadColumns).AddRow(
+				workerSessionThreadRow(threadID, sessionID, orgID, models.AgentTypeCodex, nil, models.ThreadStatusRunning)...,
+			),
+		)
+
+	orch := &orchestratorServiceStub{
+		continueSessionFn: func(ctx context.Context, session *models.Session, opts *agent.ContinueSessionOptions) error {
+			return fmt.Errorf("worker draining: %w", agent.ErrSessionInterrupted)
+		},
+	}
+	projectHooks := &sessionCompleteRecorder{}
+	automationHooks := &sessionCompleteRecorder{}
+	handler := newContinueSessionHandler(stores, &Services{
+		Orchestrator:   orch,
+		ProjectTasks:   projectHooks,
+		AutomationRuns: automationHooks,
+	}, zerolog.Nop())
+	handlerCtx := jobctx.WithDeadLetterHooks(context.Background())
+	payload := json.RawMessage(`{"session_id":"` + sessionID.String() + `","org_id":"` + orgID.String() + `","thread_id":"` + threadID.String() + `"}`)
+
+	err := handler(handlerCtx, "continue_session", payload)
+
+	require.Error(t, err, "continue_session should stay retryable so an interrupted turn can resume on another worker")
+	var retryable *RetryableError
+	require.ErrorAs(t, err, &retryable, "system interruptions should remain retryable before dead-letter")
+
+	mock.ExpectQuery("UPDATE sessions").
+		WithArgs(workerAnyArgs(11)...).
+		WillReturnRows(
+			pgxmock.NewRows(workerSessionColumns).AddRow(
+				workerSessionRow(sessionID, issueID, orgID, models.SessionStatusFailed, 2, nil, nil)...,
+			),
+		)
+	mock.ExpectExec("UPDATE sessions[\\s\\S]+failure_explanation").
+		WithArgs(
+			pgxmock.AnyArg(),
+			pgxmock.AnyArg(),
+			pgxmock.AnyArg(),
+			pgxmock.AnyArg(),
+			pgxmock.AnyArg(),
+			pgxmock.AnyArg(),
+		).
+		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
+	mock.ExpectExec("UPDATE session_threads").
+		WithArgs(workerAnyArgs(7)...).
+		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
+	mock.ExpectQuery("INSERT INTO jobs").
+		WithArgs(workerAnyArgs(6)...).
+		WillReturnRows(pgxmock.NewRows([]string{"id"}).AddRow(uuid.New()))
+
+	jobctx.RunDeadLetterHooks(handlerCtx, err)
+	expectedCompletionCalls := []sessionCompleteCall{{
+		sessionID: sessionID,
+		status:    models.SessionStatusFailed,
+		errText:   "Session stopped: it was interrupted by maintenance and could not be resumed before the retry window expired.",
+	}}
+	require.Equal(t, expectedCompletionCalls, projectHooks.calls, "dead-letter hook should update the owning project task")
+	require.Equal(t, expectedCompletionCalls, automationHooks.calls, "dead-letter hook should update the owning automation run")
+	require.NoError(t, mock.ExpectationsWereMet(), "dead-letter hook should fail both the session and thread after an unrecoverable interruption")
 }
 
 func TestContinueSessionHandler_StaleSandboxClearDeadLetterFailsSessionAndThread(t *testing.T) {


### PR DESCRIPTION
## Problem

The session-detail UI binds its **"Agent is working…"** indicator to the **primary thread's** status, not the session status. Several terminal paths updated only the session row, leaving the thread stuck at `running` — so the spinner kept running until the reaper swept the thread ~2.5h later. Reported case: a session that failed instantly on a missing-credential auth check still showed "Agent is working…".

## Changes

**1. `failRun` terminalizes the primary thread (root cause)**
`failRun` now drives the primary thread terminal on every early-exit failure path (missing-credential auth check, repo/prompt prep, `continue_session`, timeout, recovery-exhausted, policy-stop, …) and publishes the thread-runtime SSE event so an open page flips immediately. Removed the 4 now-redundant paired `updatePrimaryThreadTerminal` calls so each path writes the thread exactly once.

**2. Dead-letter hook on the worker-drain interrupt path**
The `ErrSessionInterrupted` branches (`run_agent` and `continue_session`) returned a `RetryableError` with no dead-letter hook — unlike the sandbox-capacity / stale-sandbox paths. So a turn that never resumed (job dead-letters during a rolling deploy) orphaned both session and thread until the reaper. Added `registerSystemInterruptDeadLetter` (mirrors the existing capacity hook) to deterministically fail both on give-up.

**3. Honest recovery UX during a graceful drain**
- `handleSystemInterruptedSession` now sets session-level `recovery_state=queued`, so the existing "Restoring runtime from checkpoint" banner fires during a graceful drain (parity with lost-job reclaim; `BeginRuntime`/`RecoverSession` clear it on resume).
- The timeline now shows **"Resuming after maintenance…"** instead of "Agent is working…" while the runtime is recovering.

## Tests
- `TestRunAgent_AuthFailureTerminalizesPrimaryThread` — the reported scenario.
- `TestRunAgentHandler_SystemInterruptDeadLetterFailsSessionAndThread` + `TestContinueSessionHandler_SystemInterruptDeadLetterFailsSessionAndThread`.
- Agent interrupt test extended to assert session `recovery_state=queued`.
- `chat-timeline.test.tsx`: recovery bubble shows/precedence/hidden-when-not-running.

## Verification
`go build`, `make lint` (0 issues), worker + agent suites, frontend `tsc`, eslint, and `chat-timeline` / `page-session-states` vitest all pass.

The recovery bubble only renders during a live drain (`recovery_state=queued` while `running`), which can't be reproduced in a static preview without orchestrating a worker drain — covered by deterministic unit/integration tests instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)