### PR TITLE
Set default OpenCode orchestrator model to GPT-5.5 for code reviewer orchestration

### DIFF
--- a/internal/models/code_review.go
+++ b/internal/models/code_review.go
@@ -407,7 +407,7 @@ func DefaultCodeReviewPolicyConfig() CodeReviewPolicyConfig {
 			Reviewers:             []AgentType{AgentTypeCodex, AgentTypeClaudeCode},
 			Orchestrator:          AgentTypeOpenCode,
 			ReviewerModels:        []string{DefaultCodexModel, DefaultClaudeCodeModel},
-			OrchestratorModel:     strPtr(OpenCodeModelGPT54Mini),
+			OrchestratorModel:     strPtr(OpenCodeModelGPT55),
 			DisagreementBlocks:    true,
 			RequireReviewerQuorum: 2,
 			TimeoutSeconds:        1800,

--- a/internal/models/code_review_test.go
+++ b/internal/models/code_review_test.go
@@ -60,7 +60,7 @@ func TestDefaultCodeReviewPolicyConfig(t *testing.T) {
 	require.Equal(t, 300, config.RiskPolicy.MaxLinesChanged, "default acceptable-risk line threshold should be conservative")
 	require.Equal(t, []AgentType{AgentTypeCodex, AgentTypeClaudeCode}, config.AgentRoster.Reviewers, "default roster should run two reviewers")
 	require.Equal(t, []string{DefaultCodexModel, DefaultClaudeCodeModel}, config.AgentRoster.ReviewerModels, "default roster should pin reviewer models")
-	require.Equal(t, OpenCodeModelGPT54Mini, *config.AgentRoster.OrchestratorModel, "default roster should pin the orchestrator model")
+	require.Equal(t, OpenCodeModelGPT55, *config.AgentRoster.OrchestratorModel, "default roster should pin the orchestrator model")
 	require.NoError(t, config.Validate(), "default code review policy should be valid")
 }
 

--- a/internal/worker/code_review_handler.go
+++ b/internal/worker/code_review_handler.go
@@ -654,7 +654,7 @@ func codeReviewDefaultAgentModel(agentType models.AgentType) *string {
 	case models.AgentTypePi:
 		model = models.PiModelClaudeOpus48
 	case models.AgentTypeOpenCode:
-		model = models.OpenCodeModelGPT54Mini
+		model = models.OpenCodeModelGPT55
 	default:
 		return nil
 	}

--- a/internal/worker/code_review_handler_test.go
+++ b/internal/worker/code_review_handler_test.go
@@ -375,12 +375,12 @@ func TestCodeReviewOrchestratorAgentModel(t *testing.T) {
 	whitespace := cfg
 	blank := "   "
 	whitespace.AgentRoster.OrchestratorModel = &blank
-	require.Equal(t, models.OpenCodeModelGPT54Mini, *codeReviewOrchestratorAgentModel(whitespace),
+	require.Equal(t, models.OpenCodeModelGPT55, *codeReviewOrchestratorAgentModel(whitespace),
 		"whitespace-only orchestrator model should fall back to the per-agent default")
 
 	unset := cfg
 	unset.AgentRoster.OrchestratorModel = nil
-	require.Equal(t, models.OpenCodeModelGPT54Mini, *codeReviewOrchestratorAgentModel(unset),
+	require.Equal(t, models.OpenCodeModelGPT55, *codeReviewOrchestratorAgentModel(unset),
 		"nil orchestrator model should fall back to the per-agent default")
 }
 


### PR DESCRIPTION
## Summary

The code reviewer orchestrator was defaulting to an older OpenCode model (GPT-5.4 mini), creating a reliability risk of inconsistent review quality when no explicit orchestrator model is provided. This change updates both the default policy config and the worker fallback logic to use `OpenCodeModelGPT55`, and adjusts the focused unit tests accordingly.

## Changes

- Updated the default code review policy to pin `OrchestratorModel` to `OpenCodeModelGPT55` (was `OpenCodeModelGPT54Mini`).
- Updated the worker’s `AgentTypeOpenCode` default model to `OpenCodeModelGPT55` so orchestrator runs with no explicit model consistently fall back correctly.
- Updated unit tests in `internal/models` and `internal/worker` to assert the new GPT-5.5 defaults and fallback behavior.

## Validation

- `go test ./internal/models ./internal/worker`

[143.dev](https://143.dev) | [session 7d68cd75](https://143.dev/sessions/7d68cd75-49c6-4f5d-a41a-5e401b8abd71)

<!-- 143 readiness -->
**143 readiness:** not available for this revision.

Preview: https://143.dev/previews/github/assembledhq/143/pull/1726?launch=1