### PR TITLE
Add missing from_fork column to code_review_session_metadata

### DIFF
--- a/migrations/000236_code_review_metadata_from_fork.down.sql
+++ b/migrations/000236_code_review_metadata_from_fork.down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE code_review_session_metadata
+    DROP COLUMN IF EXISTS from_fork;

--- a/migrations/000236_code_review_metadata_from_fork.up.sql
+++ b/migrations/000236_code_review_metadata_from_fork.up.sql
@@ -1,0 +1,7 @@
+-- The from_fork column was added to migration 000221 after that migration had
+-- already been applied to existing databases, so golang-migrate never created
+-- the column there. Add it idempotently: fresh databases that ran the edited
+-- 000221 already have it, while databases that applied 000221 before the edit
+-- are missing it (and crash the code review webhook handler without it).
+ALTER TABLE code_review_session_metadata
+    ADD COLUMN IF NOT EXISTS from_fork boolean NOT NULL DEFAULT false;


### PR DESCRIPTION
## Problem

The **143 Code Reviewer never runs.** Adding the `143 Code Reviewer` team as a reviewer on a PR (e.g. assembledhq/143#1709) does nothing — no session, no metadata row. The pipeline has in fact *never* successfully created a code review session in prod.

## Root cause

The `review_requested` webhook arrives and matches the trigger, but the handler 500s before creating anything:

```
failed to process code review request
error = lookup running code review: query running code review:
        ERROR: column "from_fork" does not exist (SQLSTATE 42703)
```

`code_review_session_metadata` is created by migration `000221_code_reviewer_bot`, which today lists `from_fork`. But prod's table has no such column:

- Migration 221 first shipped in #1647 (`ae25921c0`) **without** `from_fork` — that's when prod applied it.
- `from_fork` was **added to the same already-applied file 221** later in #1655 (`3e2220620`).

`golang-migrate` never re-runs an applied migration (prod is at version 235), so the column was never created in prod, while the deployed Go code (`GetRunningByPullRequestHead` and the metadata insert) expects it. Every review request crashes on it.

This is the immutable-migration trap: never edit a migration that has already shipped.

## Fix

A new forward migration adds the column. It's idempotent (`ADD COLUMN IF NOT EXISTS`) so databases that built the table from the *edited* 000221 (fresh local/dev DBs) are unaffected, while prod gets the column.

## After deploy

GitHub won't resend the failed delivery, so re-trigger by removing and re-adding the `143 Code Reviewer` team on any affected PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)