### PR TITLE
Fix PR-review sandbox auth: authenticate PR-head fetch and configure credential helper before git ops

### DIFF
--- a/internal/services/agent/orchestrator.go
+++ b/internal/services/agent/orchestrator.go
@@ -4267,7 +4267,7 @@ func (o *Orchestrator) ContinueSession(ctx context.Context, session *models.Sess
 		// reconstruct the prior state.
 		log.Info().Msg("continuing session without snapshot, starting fresh")
 
-		issue, repoFullName, authMode, err := o.setupFreshSandbox(ctx, session, sandbox, sandboxCfg.Env, prRepairOpts)
+		issue, repoFullName, authMode, err := o.setupFreshSandbox(ctx, session, sandbox, sandboxCfg.Env, log, prRepairOpts)
 		if err != nil {
 			if errors.Is(err, ErrStalePullRequestHead) {
 				if revertErr := o.sessions.UpdateStatus(ctx, session.OrgID, session.ID, fallbackStatus); revertErr != nil {
@@ -4282,7 +4282,6 @@ func (o *Orchestrator) ContinueSession(ctx context.Context, session *models.Sess
 			return fmt.Errorf("setup fresh sandbox: %w", err)
 		}
 		authBillingMode = authMode
-		o.runSandboxGitBootstrap(ctx, sandbox, sandboxCfg.WorkDir, log)
 		if err := o.prepareSandboxRepository(ctx, sandbox, sandboxCfg.WorkDir, log, session); err != nil {
 			o.failRun(ctx, session, fmt.Sprintf("prepare repository: %s", err))
 			return fmt.Errorf("prepare repository: %w", err)
@@ -4753,7 +4752,7 @@ func continueSessionDrainDedupeKey(sessionID uuid.UUID, processedMessageID int64
 // full name (for memory lookup). Handles sessions with or without a repository.
 // The resolved env is passed in from the caller so auth injection honors the
 // exact credential selection already baked into SandboxConfig.
-func (o *Orchestrator) setupFreshSandbox(ctx context.Context, session *models.Session, sandbox *Sandbox, env map[string]string, repairOpts *PRRepairContinueOptions) (models.Issue, string, TokenBillingMode, error) {
+func (o *Orchestrator) setupFreshSandbox(ctx context.Context, session *models.Session, sandbox *Sandbox, env map[string]string, log zerolog.Logger, repairOpts *PRRepairContinueOptions) (models.Issue, string, TokenBillingMode, error) {
 	var issue models.Issue
 	if session.PrimaryIssueID != nil {
 		fetched, err := o.issues.GetByID(ctx, session.OrgID, *session.PrimaryIssueID)
@@ -4799,9 +4798,17 @@ func (o *Orchestrator) setupFreshSandbox(ctx context.Context, session *models.Se
 		if err := o.provider.CloneRepo(ctx, sandbox, repo.CloneURL, branch, token); err != nil {
 			return models.Issue{}, "", TokenBillingModeUnknown, fmt.Errorf("clone repo: %w", err)
 		}
+		// Configure the git credential helper immediately after the clone, so any
+		// subsequent authenticated git operation in this fresh workspace can reach
+		// GitHub through the per-session auth socket. CloneRepo scrubs the
+		// installation token out of origin, so without the helper in place git
+		// would fall back to an interactive credential prompt and fail in the
+		// sandbox. (The PR-head fetch below authenticates explicitly and does not
+		// depend on this, but running bootstrap here keeps any future git op safe.)
+		o.runSandboxGitBootstrap(ctx, sandbox, sandbox.WorkDir, log)
 		workingBranch := sessionWorkingBranch(session, &issue)
 		if repairOpts != nil && repairOpts.WorkspaceMode == models.PullRequestRepairWorkspaceModePRHeadReconstruction {
-			if err := o.checkoutPullRequestHead(ctx, sandbox, workingBranch, repairOpts); err != nil {
+			if err := o.checkoutPullRequestHead(ctx, sandbox, repo.CloneURL, token, workingBranch, repairOpts); err != nil {
 				return models.Issue{}, "", TokenBillingModeUnknown, err
 			}
 			session.WorkingBranch = &workingBranch
@@ -4809,7 +4816,7 @@ func (o *Orchestrator) setupFreshSandbox(ctx context.Context, session *models.Se
 			if workingBranch == "" {
 				return models.Issue{}, "", TokenBillingModeUnknown, fmt.Errorf("code review session is missing working branch")
 			}
-			if err := o.checkoutExpectedPullRequestHead(ctx, sandbox, codeReviewPRNumber, workingBranch, codeReviewHeadSHA); err != nil {
+			if err := o.checkoutExpectedPullRequestHead(ctx, sandbox, repo.CloneURL, token, codeReviewPRNumber, workingBranch, codeReviewHeadSHA); err != nil {
 				return models.Issue{}, "", TokenBillingModeUnknown, err
 			}
 			session.WorkingBranch = &workingBranch
@@ -4874,7 +4881,7 @@ func codeReviewCheckoutContextFromSession(session *models.Session) (int, string,
 	return parsed.GitHubPRNumber, headSHA, true, nil
 }
 
-func (o *Orchestrator) checkoutPullRequestHead(ctx context.Context, sandbox *Sandbox, workingBranch string, repairOpts *PRRepairContinueOptions) error {
+func (o *Orchestrator) checkoutPullRequestHead(ctx context.Context, sandbox *Sandbox, repoURL, token, workingBranch string, repairOpts *PRRepairContinueOptions) error {
 	if repairOpts == nil {
 		return nil
 	}
@@ -4888,18 +4895,31 @@ func (o *Orchestrator) checkoutPullRequestHead(ctx context.Context, sandbox *San
 	if repairOpts.PullRequestNumber <= 0 {
 		return fmt.Errorf("pull request repair reconstruction missing pull request number")
 	}
-	return o.checkoutExpectedPullRequestHead(ctx, sandbox, repairOpts.PullRequestNumber, workingBranch, repairOpts.HeadSHA)
+	return o.checkoutExpectedPullRequestHead(ctx, sandbox, repoURL, token, repairOpts.PullRequestNumber, workingBranch, repairOpts.HeadSHA)
 }
 
-func (o *Orchestrator) checkoutExpectedPullRequestHead(ctx context.Context, sandbox *Sandbox, pullRequestNumber int, workingBranch, expectedHeadSHA string) error {
-	fetchCmd := fmt.Sprintf("git fetch --quiet --no-tags origin 'pull/%d/head'", pullRequestNumber)
+func (o *Orchestrator) checkoutExpectedPullRequestHead(ctx context.Context, sandbox *Sandbox, repoURL, token string, pullRequestNumber int, workingBranch, expectedHeadSHA string) error {
+	// Fetch the PR head from an explicitly authenticated URL rather than the
+	// `origin` remote. CloneRepo scrubs the installation token out of origin
+	// after cloning, so `git fetch origin` relies entirely on the credential
+	// helper being configured. Authenticating the fetch directly makes it
+	// self-sufficient: it does not depend on git-bootstrap having run, so it
+	// cannot regress into git falling back to an interactive username prompt
+	// (which fails in the sandbox with "could not read Username for
+	// 'https://github.com': No such device or address"). Embedding the
+	// short-lived token in the fetch URL leaves nothing at rest in .git/config.
+	fetchRemote := "origin"
+	if token != "" && repoURL != "" {
+		fetchRemote = authenticatedGitURL(repoURL, token)
+	}
+	fetchCmd := fmt.Sprintf("git fetch --quiet --no-tags '%s' 'pull/%d/head'", shellEscapeSingleQuote(fetchRemote), pullRequestNumber)
 	var fetchErr bytes.Buffer
 	fetchExit, fetchExecErr := o.provider.Exec(ctx, sandbox, fetchCmd, io.Discard, &fetchErr)
 	if fetchExecErr != nil {
 		return fmt.Errorf("fetch pull request head: %w", fetchExecErr)
 	}
 	if fetchExit != 0 {
-		return fmt.Errorf("fetch pull request head: exit=%d stderr=%s", fetchExit, fetchErr.String())
+		return fmt.Errorf("fetch pull request head: exit=%d stderr=%s", fetchExit, redactGitToken(fetchErr.String(), token))
 	}
 
 	checkoutCmd := fmt.Sprintf("git checkout -B '%s' FETCH_HEAD", shellEscapeSingleQuote(workingBranch))
@@ -7475,6 +7495,25 @@ func formatWorkingBranch(run *models.Session, issue *models.Issue) string {
 // shellEscapeSingleQuote escapes single quotes for safe use in shell commands.
 func shellEscapeSingleQuote(s string) string {
 	return strings.ReplaceAll(s, "'", "'\\''")
+}
+
+// authenticatedGitURL embeds a short-lived installation token into an https git
+// URL, mirroring DockerProvider.CloneRepo so authenticated fetches work without
+// relying on the credential helper being configured yet.
+func authenticatedGitURL(repoURL, token string) string {
+	if token == "" {
+		return repoURL
+	}
+	return strings.Replace(repoURL, "https://", fmt.Sprintf("https://x-access-token:%s@", token), 1)
+}
+
+// redactGitToken removes an installation token from a string so it is safe to
+// surface in error messages.
+func redactGitToken(s, token string) string {
+	if token == "" {
+		return s
+	}
+	return strings.ReplaceAll(s, token, "***")
 }
 
 func derefString(value *string) string {

--- a/internal/services/agent/orchestrator_internal_test.go
+++ b/internal/services/agent/orchestrator_internal_test.go
@@ -541,7 +541,7 @@ func TestSetupFreshSandbox_CodexAPIKeyUsesResolvedEnv(t *testing.T) {
 
 	_, _, _, err := orch.setupFreshSandbox(context.Background(), session, &Sandbox{ID: "sandbox-1", HomeDir: "/home/sandbox", WorkDir: "/home/sandbox/work"}, map[string]string{
 		"OPENAI_API_KEY": "sk-openai",
-	}, nil)
+	}, zerolog.Nop(), nil)
 
 	require.NoError(t, err, "setupFreshSandbox should accept the already-resolved Codex API key")
 	require.NotContains(t, provider.writes, "/home/sandbox/.codex/auth.json", "setupFreshSandbox should not require Codex auth.json when the selected unified credential is an API key")
@@ -584,7 +584,7 @@ func TestSetupFreshSandbox_CodexOrgAPIKeyFallbackUsesResolvedEnv(t *testing.T) {
 	}
 	envVars := env.Resolve(context.Background(), orgID, models.AgentTypeCodex, &userID)
 
-	_, _, billingMode, err := orch.setupFreshSandbox(context.Background(), session, &Sandbox{ID: "sandbox-legacy", HomeDir: "/home/sandbox", WorkDir: "/home/sandbox/work"}, envVars, nil)
+	_, _, billingMode, err := orch.setupFreshSandbox(context.Background(), session, &Sandbox{ID: "sandbox-legacy", HomeDir: "/home/sandbox", WorkDir: "/home/sandbox/work"}, envVars, zerolog.Nop(), nil)
 
 	require.NoError(t, err, "setupFreshSandbox should honor the org-scoped OpenAI API-key fallback")
 	require.Equal(t, TokenBillingModeAPIKey, billingMode, "setupFreshSandbox should classify the org OpenAI credential as an API-key billing mode")
@@ -707,7 +707,7 @@ func TestSetupFreshSandbox_CodexAPIKeyDoesNotRePickSubscriptionAtSamePriority(t 
 	}
 	envVars := env.Resolve(context.Background(), orgID, models.AgentTypeCodex, &userID)
 
-	_, _, _, err := orch.setupFreshSandbox(context.Background(), session, &Sandbox{ID: "sandbox-1", HomeDir: "/home/sandbox", WorkDir: "/home/sandbox/work"}, envVars, nil)
+	_, _, _, err := orch.setupFreshSandbox(context.Background(), session, &Sandbox{ID: "sandbox-1", HomeDir: "/home/sandbox", WorkDir: "/home/sandbox/work"}, envVars, zerolog.Nop(), nil)
 
 	require.NoError(t, err, "setupFreshSandbox should use the already-resolved Codex API key")
 	require.NotContains(t, provider.writes, "/home/sandbox/.codex/auth.json", "setupFreshSandbox should not re-pick a same-priority Codex subscription after env resolution selected an API key")
@@ -777,7 +777,7 @@ func TestSetupFreshSandbox_ClaudeAPIKeyDoesNotInjectLowerPrioritySubscription(t 
 
 	_, _, _, err := orch.setupFreshSandbox(context.Background(), session, &Sandbox{ID: "sandbox-1", HomeDir: "/home/sandbox", WorkDir: "/home/sandbox/work"}, map[string]string{
 		"ANTHROPIC_API_KEY": "sk-ant-api-key",
-	}, nil)
+	}, zerolog.Nop(), nil)
 
 	require.NoError(t, err, "setupFreshSandbox should accept the already-resolved Claude API key")
 	require.NotContains(t, provider.writes, "/home/sandbox/.claude/.credentials.json", "setupFreshSandbox should not inject a lower-priority Claude subscription over the selected API key")
@@ -846,7 +846,7 @@ func TestSetupFreshSandbox_ClaudeAPIKeyDoesNotRePickSubscriptionAtSamePriority(t
 	}
 	envVars := env.Resolve(context.Background(), orgID, models.AgentTypeClaudeCode, &userID)
 
-	_, _, _, err := orch.setupFreshSandbox(context.Background(), session, &Sandbox{ID: "sandbox-1", HomeDir: "/home/sandbox", WorkDir: "/home/sandbox/work"}, envVars, nil)
+	_, _, _, err := orch.setupFreshSandbox(context.Background(), session, &Sandbox{ID: "sandbox-1", HomeDir: "/home/sandbox", WorkDir: "/home/sandbox/work"}, envVars, zerolog.Nop(), nil)
 
 	require.NoError(t, err, "setupFreshSandbox should use the already-resolved Claude API key")
 	require.NotContains(t, provider.writes, "/home/sandbox/.claude/.credentials.json", "setupFreshSandbox should not re-pick a same-priority subscription after env resolution selected an API key")
@@ -907,7 +907,7 @@ func TestSetupFreshSandbox_ClaudeSubscriptionUsesUnifiedPickedToken(t *testing.T
 		TriggeredByUserID: &userID,
 	}
 
-	_, _, _, err := orch.setupFreshSandbox(context.Background(), session, &Sandbox{ID: "sandbox-1", HomeDir: "/home/sandbox", WorkDir: "/home/sandbox/work"}, map[string]string{}, nil)
+	_, _, _, err := orch.setupFreshSandbox(context.Background(), session, &Sandbox{ID: "sandbox-1", HomeDir: "/home/sandbox", WorkDir: "/home/sandbox/work"}, map[string]string{}, zerolog.Nop(), nil)
 
 	require.NoError(t, err, "setupFreshSandbox should inject the selected unified Claude subscription")
 	written := provider.writes["/home/sandbox/.claude/.credentials.json"]
@@ -966,7 +966,7 @@ func TestSetupFreshSandbox_ReturnsResolvedAuthBillingMode(t *testing.T) {
 		TriggeredByUserID: &userID,
 	}
 
-	_, _, billingMode, err := orch.setupFreshSandbox(context.Background(), session, &Sandbox{ID: "sandbox-1", HomeDir: "/home/sandbox", WorkDir: "/home/sandbox/work"}, map[string]string{}, nil)
+	_, _, billingMode, err := orch.setupFreshSandbox(context.Background(), session, &Sandbox{ID: "sandbox-1", HomeDir: "/home/sandbox", WorkDir: "/home/sandbox/work"}, map[string]string{}, zerolog.Nop(), nil)
 
 	require.NoError(t, err, "setupFreshSandbox should succeed for a fresh Claude subscription run")
 	require.Equal(t, TokenBillingModeSubscription, billingMode, "setupFreshSandbox should return the auth-selected billing mode for fresh runs")
@@ -1626,13 +1626,31 @@ func TestSetupFreshSandbox_CodeReviewChecksOutPullRequestHead(t *testing.T) {
 		logger:       zerolog.Nop(),
 	}
 
-	_, _, _, err := orch.setupFreshSandbox(context.Background(), session, &Sandbox{ID: "sandbox-1", WorkDir: "/home/sandbox/backend", HomeDir: "/home/sandbox"}, nil, nil)
+	_, _, _, err := orch.setupFreshSandbox(context.Background(), session, &Sandbox{ID: "sandbox-1", WorkDir: "/home/sandbox/backend", HomeDir: "/home/sandbox"}, nil, zerolog.Nop(), nil)
 
 	require.NoError(t, err, "setupFreshSandbox should check out the recorded PR head for code review sessions")
-	require.Contains(t, provider.execCalls, "git fetch --quiet --no-tags origin 'pull/42/head'", "code review checkout should fetch the GitHub PR head ref")
+	require.Contains(t, provider.execCalls, "git fetch --quiet --no-tags 'https://x-access-token:ghp_test123@github.com/assembledhq/143.git' 'pull/42/head'", "code review checkout should fetch the GitHub PR head ref using an authenticated URL, since origin has been scrubbed of its token and the credential helper is not configured yet")
+	require.NotContains(t, provider.execCalls, "git fetch --quiet --no-tags origin 'pull/42/head'", "code review checkout must not fetch from the token-less origin remote")
 	require.Contains(t, provider.execCalls, "git checkout -B '143/88888888/code-review-for-assembledhq-143-42' FETCH_HEAD", "code review checkout should reset the session branch to the PR head")
 	require.Contains(t, provider.execCalls, "git rev-parse HEAD", "code review checkout should verify the checked-out head SHA")
 	require.NotContains(t, provider.execCalls, "git checkout -b '143/88888888/code-review-for-assembledhq-143-42'", "code review checkout should not branch from the cloned target branch tip")
+
+	// Defense-in-depth ordering: the git credential helper must be configured
+	// right after the clone, before any authenticated git operation, so future
+	// git ops added to fresh-sandbox setup can reach GitHub via the auth socket.
+	bootstrapIdx := indexOfExecCall(provider.execCalls, "143-tools git-bootstrap --workdir=/home/sandbox/backend")
+	fetchIdx := indexOfExecCall(provider.execCalls, "git fetch --quiet --no-tags 'https://x-access-token:ghp_test123@github.com/assembledhq/143.git' 'pull/42/head'")
+	require.GreaterOrEqual(t, bootstrapIdx, 0, "code review setup should run git-bootstrap to install the credential helper")
+	require.Less(t, bootstrapIdx, fetchIdx, "git-bootstrap should run before the PR head fetch so the credential helper is configured first")
+}
+
+func indexOfExecCall(calls []string, want string) int {
+	for i, c := range calls {
+		if c == want {
+			return i
+		}
+	}
+	return -1
 }
 
 func TestSetupFreshSandbox_WorkingBranchCheckoutFailures(t *testing.T) {
@@ -1697,7 +1715,7 @@ func TestSetupFreshSandbox_WorkingBranchCheckoutFailures(t *testing.T) {
 				logger:       zerolog.Nop(),
 			}
 
-			_, _, _, err := orch.setupFreshSandbox(context.Background(), session, &Sandbox{ID: "sandbox-1", WorkDir: "/home/sandbox/backend", HomeDir: "/home/sandbox"}, nil, nil)
+			_, _, _, err := orch.setupFreshSandbox(context.Background(), session, &Sandbox{ID: "sandbox-1", WorkDir: "/home/sandbox/backend", HomeDir: "/home/sandbox"}, nil, zerolog.Nop(), nil)
 			require.Error(t, err, "setupFreshSandbox should fail when the working branch cannot be created")
 			require.Contains(t, err.Error(), tt.wantErr, "setupFreshSandbox should surface the working-branch checkout failure")
 		})

--- a/internal/services/agent/orchestrator_test.go
+++ b/internal/services/agent/orchestrator_test.go
@@ -2973,7 +2973,7 @@ func TestContinueSession_PRRepairReconstructsFromExpectedHead(t *testing.T) {
 	})
 	require.NoError(t, err, "ContinueSession should reconstruct PR repairs even while a post-PR snapshot upload is pending")
 	require.Equal(t, "main", cloneBranch, "PR repair reconstruction should start from the repository target branch before fetching the PR head")
-	require.Contains(t, d.provider.ExecCalls, "git fetch --quiet --no-tags origin 'pull/42/head'", "PR repair reconstruction should fetch the GitHub PR head ref")
+	require.Contains(t, d.provider.ExecCalls, "git fetch --quiet --no-tags 'https://x-access-token:ghp_test123@github.com/acme/backend.git' 'pull/42/head'", "PR repair reconstruction should fetch the GitHub PR head ref using an authenticated URL, since origin has been scrubbed of its token and the credential helper is not configured yet")
 	require.Contains(t, d.provider.ExecCalls, "git checkout -B '143/00000000/nullpointerexception-in-handler' FETCH_HEAD", "PR repair reconstruction should check out the expected head into the session working branch")
 	require.NotContains(t, d.provider.ExecCalls, "git checkout -b '143/00000000/nullpointerexception-in-handler'", "PR repair reconstruction should not create a branch from the target branch tip")
 }
@@ -3040,7 +3040,7 @@ func TestContinueSession_PRRepairReconstructionClearsRecordedContainer(t *testin
 	require.Equal(t, containerID, clearedContainer, "PR repair reconstruction should clear the recorded container before creating a fresh workspace")
 	require.Equal(t, containerID, destroyedContainer, "PR repair reconstruction should destroy the unheld recorded container after clearing it from the session row")
 	require.Equal(t, "main", cloneBranch, "PR repair reconstruction should clone from the repository target branch")
-	require.Contains(t, d.provider.ExecCalls, "git fetch --quiet --no-tags origin 'pull/42/head'", "PR repair reconstruction should fetch the GitHub PR head ref")
+	require.Contains(t, d.provider.ExecCalls, "git fetch --quiet --no-tags 'https://x-access-token:ghp_test123@github.com/acme/backend.git' 'pull/42/head'", "PR repair reconstruction should fetch the GitHub PR head ref using an authenticated URL, since origin has been scrubbed of its token and the credential helper is not configured yet")
 	require.Contains(t, d.provider.ExecCalls, "git checkout -B '143/00000000/nullpointerexception-in-handler' FETCH_HEAD", "PR repair reconstruction should check out the expected head in the fresh workspace")
 }
 


### PR DESCRIPTION
## Problem

Kicking off a code-review (or PR-repair) session on the fresh-sandbox path failed with:

```
setup fresh sandbox: fetch pull request head: exit=128 stderr=fatal:
could not read Username for 'https://github.com': No such device or address
```

**Root cause:** `CloneRepo` scrubs the installation token out of the `origin` remote after cloning (so the token isn't left at rest in `.git/config`), and `git-bootstrap` — which installs the `143-tools git-credential` helper — only ran *after* `setupFreshSandbox` returned. So `git fetch origin pull/N/head` had neither a token in the remote nor a configured credential helper, and git fell back to an interactive username prompt that fails in the headless sandbox.

Normal sessions were unaffected because their only post-clone git op is a local `git checkout -b`, which needs no auth. The PR-head fetch is the one network git op in `setupFreshSandbox` that runs before bootstrap.

## Fix

1. **Authenticate the PR-head fetch directly** with the installation token (`x-access-token` URL), mirroring `CloneRepo`. The fetch is now self-sufficient and no longer depends on credential-helper ordering. The token is redacted from fetch error output and never written to `.git/config`.
2. **Defense-in-depth ordering:** run `git-bootstrap` immediately after the clone, inside `setupFreshSandbox`, so any future authenticated git op in fresh-sandbox setup can reach GitHub via the per-session auth socket.

Both the code-review checkout and the PR-repair reconstruction path share `checkoutExpectedPullRequestHead`, so both are fixed.

## Tests

- Assert the authenticated fetch URL and a `NotContains` guard so it can't regress to the token-less `origin` remote.
- Add an ordering assertion proving `git-bootstrap` runs before the PR-head fetch.
- Update all `setupFreshSandbox` call sites for the new `log` parameter.

`go build`, the `internal/services/agent/...` suite, and `make lint` (0 issues) all pass.

## Note

One behavior change worth flagging: `git-bootstrap` now runs only when the session has a repository (it moved inside the repo block) — previously it ran unconditionally, but with no repo there's no `.git`, so that was a no-op/warning anyway.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
