### PR TITLE
Relax code review auto-approval for docs-only PRs

### DIFF
--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -135,6 +135,12 @@ export interface CodeReviewPolicyConfig {
     allow_policy_changes: boolean;
     eligible_authors?: string[];
     required_checks?: string[];
+    low_risk_lane?: {
+      enabled: boolean;
+      categories?: string[];
+      max_lines_changed?: number;
+      waive_reviewer_quorum?: boolean;
+    };
   };
   agent_roster: {
     reviewers: string[];

--- a/internal/models/code_review.go
+++ b/internal/models/code_review.go
@@ -311,20 +311,51 @@ type CodeReviewDescriptionPolicy struct {
 }
 
 type CodeReviewRiskPolicy struct {
-	MaxFilesChanged       int      `json:"max_files_changed"`
-	MaxLinesChanged       int      `json:"max_lines_changed"`
-	RequirePassingChecks  bool     `json:"require_passing_checks"`
-	ExcludeSensitivePaths bool     `json:"exclude_sensitive_paths"`
-	SensitivePaths        []string `json:"sensitive_paths,omitempty"`
-	AllowedPathPatterns   []string `json:"allowed_path_patterns,omitempty"`
-	BlockedPathPatterns   []string `json:"blocked_path_patterns,omitempty"`
-	ExcludeCategories     []string `json:"exclude_categories,omitempty"`
-	RequireMergeable      bool     `json:"require_mergeable"`
-	RequireUpToDate       bool     `json:"require_up_to_date"`
-	AllowForks            bool     `json:"allow_forks"`
-	AllowPolicyChanges    bool     `json:"allow_policy_changes"`
-	EligibleAuthors       []string `json:"eligible_authors,omitempty"`
-	RequiredChecks        []string `json:"required_checks,omitempty"`
+	MaxFilesChanged       int                   `json:"max_files_changed"`
+	MaxLinesChanged       int                   `json:"max_lines_changed"`
+	RequirePassingChecks  bool                  `json:"require_passing_checks"`
+	ExcludeSensitivePaths bool                  `json:"exclude_sensitive_paths"`
+	SensitivePaths        []string              `json:"sensitive_paths,omitempty"`
+	AllowedPathPatterns   []string              `json:"allowed_path_patterns,omitempty"`
+	BlockedPathPatterns   []string              `json:"blocked_path_patterns,omitempty"`
+	ExcludeCategories     []string              `json:"exclude_categories,omitempty"`
+	RequireMergeable      bool                  `json:"require_mergeable"`
+	RequireUpToDate       bool                  `json:"require_up_to_date"`
+	AllowForks            bool                  `json:"allow_forks"`
+	AllowPolicyChanges    bool                  `json:"allow_policy_changes"`
+	EligibleAuthors       []string              `json:"eligible_authors,omitempty"`
+	RequiredChecks        []string              `json:"required_checks,omitempty"`
+	LowRiskLane           CodeReviewLowRiskLane `json:"low_risk_lane,omitempty"`
+}
+
+// CodeReviewLowRiskLane relaxes a subset of approval prerequisites for changes
+// whose risk categories all fall within a low-risk allowlist (e.g. docs-only
+// changes). It never bypasses the substantive gates (sensitive/blocked paths,
+// description policy, passing checks, mergeability, prompt injection, blocking
+// findings); it only raises the churn ceiling and, optionally, waives the
+// reviewer-quorum requirement so a clean low-risk change can approve on the
+// heuristic gates even when the review agents time out.
+type CodeReviewLowRiskLane struct {
+	Enabled             bool     `json:"enabled"`
+	Categories          []string `json:"categories,omitempty"`
+	MaxLinesChanged     int      `json:"max_lines_changed,omitempty"`
+	WaiveReviewerQuorum bool     `json:"waive_reviewer_quorum,omitempty"`
+}
+
+// CodeReviewLowRiskLaneApplies reports whether the lane is enabled and every
+// risk category present in the change is contained in the lane's allowlist. An
+// empty category set never qualifies — we only relax changes we can positively
+// classify as low risk.
+func CodeReviewLowRiskLaneApplies(lane CodeReviewLowRiskLane, categories []string) bool {
+	if !lane.Enabled || len(lane.Categories) == 0 || len(categories) == 0 {
+		return false
+	}
+	for _, category := range categories {
+		if !stringInSlice(category, lane.Categories) {
+			return false
+		}
+	}
+	return true
 }
 
 type CodeReviewAgentRoster struct {
@@ -402,6 +433,12 @@ func DefaultCodeReviewPolicyConfig() CodeReviewPolicyConfig {
 			RequireUpToDate:       false,
 			AllowForks:            false,
 			AllowPolicyChanges:    false,
+			LowRiskLane: CodeReviewLowRiskLane{
+				Enabled:             true,
+				Categories:          []string{"docs"},
+				MaxLinesChanged:     1000,
+				WaiveReviewerQuorum: true,
+			},
 		},
 		AgentRoster: CodeReviewAgentRoster{
 			Reviewers:             []AgentType{AgentTypeCodex, AgentTypeClaudeCode},
@@ -464,6 +501,14 @@ func ResolveCodeReviewPolicyConfig(config *CodeReviewPolicyConfig) CodeReviewPol
 	}
 	if len(config.RiskPolicy.RequiredChecks) > 0 {
 		defaults.RiskPolicy.RequiredChecks = config.RiskPolicy.RequiredChecks
+	}
+	// Only override the low-risk lane when the stored policy specifies one;
+	// otherwise inherit the default docs lane so existing policies pick up the
+	// relaxed handling without needing to be re-saved.
+	if config.RiskPolicy.LowRiskLane.Enabled ||
+		len(config.RiskPolicy.LowRiskLane.Categories) > 0 ||
+		config.RiskPolicy.LowRiskLane.MaxLinesChanged != 0 {
+		defaults.RiskPolicy.LowRiskLane = config.RiskPolicy.LowRiskLane
 	}
 	if len(config.AgentRoster.Reviewers) > 0 {
 		defaults.AgentRoster = config.AgentRoster
@@ -960,11 +1005,16 @@ func EvaluateCodeReviewRisk(policy CodeReviewPolicyConfig, input CodeReviewRiskI
 	if input.HeadSHAChanged {
 		reasons = append(reasons, "PR head changed after review started")
 	}
+	lowRisk := CodeReviewLowRiskLaneApplies(policy.RiskPolicy.LowRiskLane, input.Categories)
 	if input.FilesChanged > policy.RiskPolicy.MaxFilesChanged {
 		reasons = append(reasons, fmt.Sprintf("changed files %d exceeds policy limit %d", input.FilesChanged, policy.RiskPolicy.MaxFilesChanged))
 	}
-	if input.LinesChanged > policy.RiskPolicy.MaxLinesChanged {
-		reasons = append(reasons, fmt.Sprintf("changed lines %d exceeds policy limit %d", input.LinesChanged, policy.RiskPolicy.MaxLinesChanged))
+	maxLinesChanged := policy.RiskPolicy.MaxLinesChanged
+	if lowRisk && policy.RiskPolicy.LowRiskLane.MaxLinesChanged > maxLinesChanged {
+		maxLinesChanged = policy.RiskPolicy.LowRiskLane.MaxLinesChanged
+	}
+	if input.LinesChanged > maxLinesChanged {
+		reasons = append(reasons, fmt.Sprintf("changed lines %d exceeds policy limit %d", input.LinesChanged, maxLinesChanged))
 	}
 	if policy.RiskPolicy.RequirePassingChecks && !input.ChecksPassing {
 		reasons = append(reasons, "required GitHub checks are not passing")

--- a/internal/models/code_review_test.go
+++ b/internal/models/code_review_test.go
@@ -310,6 +310,52 @@ func TestEvaluateCodeReviewRisk(t *testing.T) {
 				"blocked path changed: internal/db/schema/users.go",
 			}},
 		},
+		{
+			name: "low-risk docs lane raises the churn ceiling",
+			input: CodeReviewRiskInput{
+				FilesChanged:      1,
+				LinesChanged:      607,
+				ChangedPaths:      []string{"docs/design/future/111-session-changesets-and-stacks.md"},
+				Categories:        []string{"docs"},
+				ChecksPassing:     true,
+				DescriptionPassed: true,
+				Mergeable:         true,
+				Author:            "devin",
+			},
+			expected: CodeReviewRiskEvaluation{Acceptable: true},
+		},
+		{
+			name: "low-risk docs lane still enforces its own ceiling",
+			input: CodeReviewRiskInput{
+				FilesChanged:      1,
+				LinesChanged:      1200,
+				ChangedPaths:      []string{"docs/huge.md"},
+				Categories:        []string{"docs"},
+				ChecksPassing:     true,
+				DescriptionPassed: true,
+				Mergeable:         true,
+				Author:            "devin",
+			},
+			expected: CodeReviewRiskEvaluation{Acceptable: false, Reasons: []string{
+				"changed lines 1200 exceeds policy limit 1000",
+			}},
+		},
+		{
+			name: "low-risk lane does not apply to mixed docs and code changes",
+			input: CodeReviewRiskInput{
+				FilesChanged:      2,
+				LinesChanged:      607,
+				ChangedPaths:      []string{"docs/x.md", "internal/api/router.go"},
+				Categories:        []string{"docs", "backend"},
+				ChecksPassing:     true,
+				DescriptionPassed: true,
+				Mergeable:         true,
+				Author:            "devin",
+			},
+			expected: CodeReviewRiskEvaluation{Acceptable: false, Reasons: []string{
+				"changed lines 607 exceeds policy limit 300",
+			}},
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/worker/code_review_handler.go
+++ b/internal/worker/code_review_handler.go
@@ -885,7 +885,7 @@ func codeReviewOrchestratorPrompt(job runCodeReviewPayload, pr models.PullReques
 }
 
 func codeReviewPromptRiskReasons(job runCodeReviewPayload, pr models.PullRequest, health *models.PullRequestHealthResponse, cfg models.CodeReviewPolicyConfig, changedFiles []codereviewsvc.PullRequestFile, description codeReviewDescriptionEvaluation, reviewContext *codereviewsvc.ReviewContext, reviewContextAvailable bool, agentResults []models.CodeReviewAgentResult, findings []models.CodeReviewFinding) []string {
-	reviewerQuorum, reviewerFailures := codeReviewReviewerEvidence(agentResults)
+	reviewerQuorum, _ := codeReviewReviewerEvidence(agentResults)
 	descriptionPassed := description.Passed
 	if len(description.RequirementSummaries) == 0 {
 		descriptionPassed = codeReviewDescriptionPassed(cfg, pr, changedFiles)
@@ -910,14 +910,26 @@ func codeReviewPromptRiskReasons(job runCodeReviewPayload, pr models.PullRequest
 		ContextFetchFailed:     health == nil || !reviewContextAvailable,
 		HeadSHAChanged:         codeReviewHeadChanged(job.HeadSHA, pr, health),
 		BlockingFindings:       codeReviewBlockingFindings(findings),
-		ReviewerDisagreement:   reviewerFailures > 0,
+		ReviewerDisagreement:   false,
 		UnresolvedHumanThreads: unresolvedHumanThreads,
 		PromptInjectionFound:   description.PromptInjectionFound,
 	})
-	if reviewerQuorum < cfg.AgentRoster.RequireReviewerQuorum {
+	if reviewerQuorum < cfg.AgentRoster.RequireReviewerQuorum && !codeReviewLowRiskQuorumWaived(cfg, changedFiles) {
 		risk.Reasons = append(risk.Reasons, fmt.Sprintf("reviewer quorum %d is below policy requirement %d", reviewerQuorum, cfg.AgentRoster.RequireReviewerQuorum))
 	}
 	return risk.Reasons
+}
+
+// codeReviewLowRiskQuorumWaived reports whether the resolved policy's low-risk
+// lane waives the reviewer-quorum requirement for this change. It lets a clean
+// low-risk change (e.g. docs-only) approve on the heuristic gates even when the
+// review agents fail or time out, which is otherwise the dominant blocker.
+func codeReviewLowRiskQuorumWaived(policy models.CodeReviewPolicyConfig, changedFiles []codereviewsvc.PullRequestFile) bool {
+	lane := models.ResolveCodeReviewPolicyConfig(&policy).RiskPolicy.LowRiskLane
+	if !lane.WaiveReviewerQuorum {
+		return false
+	}
+	return models.CodeReviewLowRiskLaneApplies(lane, codeReviewChangedCategories(changedFiles))
 }
 
 func codeReviewReviewerOutputsForPrompt(results []models.CodeReviewAgentResult) []string {
@@ -1582,7 +1594,7 @@ type liveCodeReviewOutcomeInput struct {
 
 func evaluateLiveCodeReviewOutcome(input liveCodeReviewOutcomeInput) (models.CodeReviewDecisionEvaluation, string) {
 	policy := models.ResolveCodeReviewPolicyConfig(&input.Policy)
-	reviewerQuorum, reviewerFailures := codeReviewReviewerEvidence(input.AgentResults)
+	reviewerQuorum, _ := codeReviewReviewerEvidence(input.AgentResults)
 	blockingFindings := codeReviewBlockingFindings(input.Findings)
 	descriptionPassed := input.DescriptionEvaluation.Passed
 	if len(input.DescriptionEvaluation.RequirementSummaries) == 0 {
@@ -1609,13 +1621,13 @@ func evaluateLiveCodeReviewOutcome(input liveCodeReviewOutcomeInput) (models.Cod
 		ContextFetchFailed:     input.Health == nil || !input.ChangedFilesAvailable || reviewContextFetchFailed,
 		HeadSHAChanged:         codeReviewHeadChanged(input.Job.HeadSHA, input.PullRequest, input.Health),
 		BlockingFindings:       blockingFindings,
-		ReviewerDisagreement:   reviewerFailures > 0 || input.OrchestratorSynthesis.ReviewerDisagreement,
+		ReviewerDisagreement:   input.OrchestratorSynthesis.ReviewerDisagreement,
 		UnresolvedHumanThreads: unresolvedHumanThreads,
 		ScopeMismatch:          input.OrchestratorSynthesis.ScopeMismatch,
 		UnresolvedUncertainty:  input.OrchestratorSynthesis.UnresolvedUncertainty,
 		PromptInjectionFound:   input.DescriptionEvaluation.PromptInjectionFound || input.OrchestratorSynthesis.PromptInjectionDetected,
 	})
-	if reviewerQuorum < policy.AgentRoster.RequireReviewerQuorum {
+	if reviewerQuorum < policy.AgentRoster.RequireReviewerQuorum && !codeReviewLowRiskQuorumWaived(policy, input.ChangedFiles) {
 		risk.Acceptable = false
 		risk.Reasons = append(risk.Reasons, fmt.Sprintf("reviewer quorum %d is below policy requirement %d", reviewerQuorum, policy.AgentRoster.RequireReviewerQuorum))
 	}
@@ -1947,12 +1959,12 @@ func codeReviewChangedCategories(files []codereviewsvc.PullRequestFile) []string
 func codeReviewPathCategories(path string) []string {
 	normalized := strings.ToLower(strings.TrimSpace(path))
 	categories := make([]string, 0, 2)
-	if strings.HasPrefix(normalized, "docs/") ||
-		strings.HasSuffix(normalized, ".md") ||
-		strings.HasSuffix(normalized, ".mdx") ||
-		strings.HasSuffix(normalized, ".rst") ||
-		strings.HasSuffix(normalized, ".adoc") {
-		categories = append(categories, "docs")
+	if codeReviewDocsPath(normalized) {
+		// Documentation is prose, not code. Returning only "docs" keeps the
+		// substring-based code-risk heuristics below (auth/crypto/permissions/
+		// etc.) from misclassifying a doc whose filename merely contains a
+		// sensitive word, e.g. "111-session-changesets.md" reading as "auth".
+		return []string{"docs"}
 	}
 	if strings.Contains(normalized, "/test/") ||
 		strings.Contains(normalized, "/tests/") ||
@@ -2006,6 +2018,15 @@ func codeReviewPathCategories(path string) []string {
 		categories = append(categories, "infra")
 	}
 	return categories
+}
+
+func codeReviewDocsPath(normalized string) bool {
+	normalized = strings.ToLower(strings.TrimSpace(normalized))
+	return strings.HasPrefix(normalized, "docs/") ||
+		strings.HasSuffix(normalized, ".md") ||
+		strings.HasSuffix(normalized, ".mdx") ||
+		strings.HasSuffix(normalized, ".rst") ||
+		strings.HasSuffix(normalized, ".adoc")
 }
 
 func codeReviewDescriptionPassed(policy models.CodeReviewPolicyConfig, pr models.PullRequest, changedFiles []codereviewsvc.PullRequestFile) bool {
@@ -2211,7 +2232,31 @@ func codeReviewChecksPassing(policy models.CodeReviewPolicyConfig, health *model
 	if health == nil {
 		return false
 	}
-	return codeReviewAllChecksPassing(health.ChecksConfirmed, health.Checks)
+	return codeReviewAllChecksPassing(health.ChecksConfirmed, codeReviewExternalChecks(health.Checks))
+}
+
+// codeReviewExternalChecks drops 143's own non-CI status contexts before the
+// checks-passing gate is evaluated. The code reviewer publishes its own
+// "143 Code Reviewer" commit status (and the preview integration publishes
+// "preview/143"); both are pending by construction while the review runs, so
+// counting them would make the reviewer block its own approval.
+func codeReviewExternalChecks(checks []models.PullRequestCheckSummary) []models.PullRequestCheckSummary {
+	filtered := make([]models.PullRequestCheckSummary, 0, len(checks))
+	for _, check := range checks {
+		if codeReviewSelfReportedCheck(check.Name) {
+			continue
+		}
+		filtered = append(filtered, check)
+	}
+	return filtered
+}
+
+func codeReviewSelfReportedCheck(name string) bool {
+	normalized := strings.ToLower(strings.TrimSpace(name))
+	if normalized == "" {
+		return false
+	}
+	return strings.Contains(normalized, "143 code reviewer") || strings.HasPrefix(normalized, "preview/143")
 }
 
 func codeReviewRequiredChecksPassing(policy models.CodeReviewPolicyConfig, health *models.PullRequestHealthResponse) map[string]bool {

--- a/internal/worker/code_review_handler_test.go
+++ b/internal/worker/code_review_handler_test.go
@@ -687,6 +687,76 @@ func TestEvaluateLiveCodeReviewOutcome(t *testing.T) {
 			expected: models.CodeReviewDecisionNeedsHumanReview,
 			reason:   "excluded risk category changed: dependencies",
 		},
+		{
+			name: "approves large docs-only change through the low-risk lane despite timed-out reviewers",
+			input: liveCodeReviewOutcomeInput{
+				Policy: policy,
+				Job:    runCodeReviewPayload{OrgID: orgID, SessionID: sessionID, PolicyVersion: 3, HeadSHA: "head"},
+				PullRequest: models.PullRequest{
+					OrgID:   orgID,
+					Body:    &prBody,
+					HeadSHA: stringPtr("head"),
+					Status:  models.PullRequestStatusOpen,
+				},
+				Health: &models.PullRequestHealthResponse{
+					HeadSHA:         "head",
+					Status:          models.PullRequestStatusOpen,
+					CanMerge:        true,
+					ChecksConfirmed: true,
+					Checks: []models.PullRequestCheckSummary{
+						{Name: "All Checks Pass", Status: models.PullRequestCheckStatusPassed},
+						// The reviewer's own status is pending while it runs; it must
+						// not be counted as a failing check against its own approval.
+						{Name: "143 Code Reviewer", Status: models.PullRequestCheckStatusPending},
+					},
+					MergeState: models.PullRequestMergeStateClean,
+				},
+				AgentResults: []models.CodeReviewAgentResult{
+					{Role: models.CodeReviewAgentRoleReviewer, Status: models.CodeReviewAgentResultStatusTimedOut},
+					{Role: models.CodeReviewAgentRoleReviewer, Status: models.CodeReviewAgentResultStatusTimedOut},
+				},
+				ChangedFiles: []codereview.PullRequestFile{
+					// Filename contains "session" — must not be classified as auth.
+					// 607 lines exceeds the base 300 cap but is under the docs lane cap.
+					{Filename: "docs/design/future/111-session-changesets-and-stacks.md", Additions: 607, Deletions: 0},
+				},
+				ChangedFilesAvailable: true,
+			},
+			expected: models.CodeReviewDecisionApproved,
+		},
+		{
+			name: "still requires human review for a docs change above the low-risk lane ceiling",
+			input: liveCodeReviewOutcomeInput{
+				Policy: policy,
+				Job:    runCodeReviewPayload{OrgID: orgID, SessionID: sessionID, PolicyVersion: 3, HeadSHA: "head"},
+				PullRequest: models.PullRequest{
+					OrgID:   orgID,
+					Body:    &prBody,
+					HeadSHA: stringPtr("head"),
+					Status:  models.PullRequestStatusOpen,
+				},
+				Health: &models.PullRequestHealthResponse{
+					HeadSHA:         "head",
+					Status:          models.PullRequestStatusOpen,
+					CanMerge:        true,
+					ChecksConfirmed: true,
+					Checks: []models.PullRequestCheckSummary{
+						{Name: "All Checks Pass", Status: models.PullRequestCheckStatusPassed},
+					},
+					MergeState: models.PullRequestMergeStateClean,
+				},
+				AgentResults: []models.CodeReviewAgentResult{
+					{Role: models.CodeReviewAgentRoleReviewer, Status: models.CodeReviewAgentResultStatusCompleted},
+					{Role: models.CodeReviewAgentRoleReviewer, Status: models.CodeReviewAgentResultStatusCompleted},
+				},
+				ChangedFiles: []codereview.PullRequestFile{
+					{Filename: "docs/design/future/huge.md", Additions: 1200, Deletions: 0},
+				},
+				ChangedFilesAvailable: true,
+			},
+			expected: models.CodeReviewDecisionNeedsHumanReview,
+			reason:   "changed lines 1200 exceeds policy limit 1000",
+		},
 	}
 
 	for _, tt := range tests {
@@ -705,6 +775,55 @@ func TestEvaluateLiveCodeReviewOutcome(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestCodeReviewPathCategoriesDocsOnly(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		path     string
+		expected []string
+	}{
+		{
+			name:     "docs filename containing session is not classified as auth",
+			path:     "docs/design/future/111-session-changesets-and-stacks.md",
+			expected: []string{"docs"},
+		},
+		{
+			name:     "docs filename containing token is not classified as crypto",
+			path:     "docs/auth-token-rotation.md",
+			expected: []string{"docs"},
+		},
+		{
+			name:     "non-docs auth path still classified as auth",
+			path:     "internal/auth/session.go",
+			expected: []string{"backend", "auth"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tt.expected, codeReviewPathCategories(tt.path), "docs prose must not inherit code-risk categories")
+		})
+	}
+}
+
+func TestCodeReviewChecksPassingIgnoresSelfReportedStatuses(t *testing.T) {
+	t.Parallel()
+
+	policy := models.DefaultCodeReviewPolicyConfig()
+	health := &models.PullRequestHealthResponse{
+		Checks: []models.PullRequestCheckSummary{
+			{Name: "All Checks Pass", Status: models.PullRequestCheckStatusPassed},
+			{Name: "143 Code Reviewer", Status: models.PullRequestCheckStatusPending},
+			{Name: "preview/143", Status: models.PullRequestCheckStatusPending},
+		},
+	}
+
+	require.True(t, codeReviewChecksPassing(policy, health),
+		"the reviewer's own pending status must not block its own approval")
 }
 
 func stringPtr(value string) *string {


### PR DESCRIPTION
## Summary

Documentation-only PRs are getting blocked from automated approval for reasons that don't reflect real risk (see #1709, a 607-line design doc that failed most gates). A filename containing "session" was classified as an **auth** change, the reviewer's *own* pending status counted as a failing check, reviewer timeouts were reported as "disagreement", and the line/quorum gates applied full code-change strictness to prose. This change makes the policy docs-aware and adds a configurable low-risk lane so clean low-risk changes can auto-approve on the heuristic gates.

## Changes

- **Docs aren't code-risk:** `codeReviewPathCategories` returns only `docs` for `.md`/`docs/` paths, so a prose filename no longer trips the substring auth/crypto/permissions heuristics.
- **Reviewer's own status doesn't block itself:** the checks-passing gate filters out 143's self-reported status contexts (`143 Code Reviewer`, `preview/143`), which are pending by construction during review.
- **Timeouts ≠ disagreement:** reviewer failures/timeouts are surfaced via the quorum check only, not relabeled as material "disagreement".
- **Configurable low-risk lane** (`risk_policy.low_risk_lane`, default: `docs`, 1000-line ceiling, quorum waiver): raises the churn cap and waives reviewer quorum when every changed-file category is in the allowlist, so a clean low-risk change approves even if review agents time out. It does **not** bypass sensitive/blocked paths, description, checks, mergeability, prompt injection, or blocking findings. Existing stored policies inherit the default lane via `ResolveCodeReviewPolicyConfig` without re-saving.

## Validation

- `go test ./internal/models/ ./internal/worker/` — pass (new unit + end-to-end cases, incl. "approves large docs-only change despite timed-out reviewers" and the lane ceiling/mixed-change guards).
- `tsc --noEmit` on frontend — clean (mirrored the `low_risk_lane` type).

## Notes for reviewers

Two gates remain that this PR intentionally does **not** touch, so a PR exactly like #1709 still won't fully auto-approve end-to-end:
- **Description policy** — testing-evidence requirement is agent-graded and applies to any >30-line diff; arguably wrong for docs but lives in a separate subsystem.
- **Mergeability** — GitHub marks the PR `unstable`/blocked while the reviewer's own pending status sits on the commit; can't be filtered the same way as the checks gate.

Happy to extend the lane to relax those two for docs-only changes as a follow-up if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
