### PR TITLE
Prevent empty interval values in automation editor by restoring on blur

### DIFF
--- a/frontend/src/app/(dashboard)/automations/[id]/page.test.tsx
+++ b/frontend/src/app/(dashboard)/automations/[id]/page.test.tsx
@@ -315,7 +315,7 @@ describe("AutomationDetailPage", () => {
     });
   });
 
-  it("allows the interval value to be cleared while editing", async () => {
+  it("allows a blank interval while editing and restores it on blur", async () => {
     const user = userEvent.setup();
     let updateBody: Record<string, unknown> | null = null;
 
@@ -384,11 +384,14 @@ describe("AutomationDetailPage", () => {
     expect(intervalInput).toHaveValue(null);
     expect(screen.getByRole("button", { name: "Save changes" })).toBeDisabled();
 
-    await user.type(intervalInput, "2");
+    await user.tab();
+
+    expect(intervalInput).toHaveValue(1);
+    expect(screen.getByRole("button", { name: "Save changes" })).toBeEnabled();
     await user.click(screen.getByRole("button", { name: "Save changes" }));
 
     await waitFor(() => {
-      expect(updateBody).toMatchObject({ interval_value: 2 });
+      expect(updateBody).toMatchObject({ interval_value: 1 });
     });
   });
 

--- a/frontend/src/app/(dashboard)/automations/[id]/page.tsx
+++ b/frontend/src/app/(dashboard)/automations/[id]/page.tsx
@@ -52,6 +52,7 @@ import {
 import { BranchPicker } from "@/components/branch-picker";
 import { AutomationModelSelect } from "@/components/automation-model-select";
 import { api } from "@/lib/api";
+import { parseAutomationIntervalInput } from "@/lib/automation-draft";
 import {
   removeAutomationFromListCaches,
   upsertAutomationInListCaches,
@@ -479,6 +480,11 @@ function SettingsTab({
                   max={365}
                   value={intervalValue}
                   onChange={(e) => setIntervalValue(e.target.value)}
+                  onBlur={() =>
+                    setIntervalValue(
+                      String(parseAutomationIntervalInput(intervalValue)),
+                    )
+                  }
                   aria-invalid={!intervalValueIsValid}
                   className="w-20"
                 />

--- a/frontend/src/app/(dashboard)/automations/new/page.test.tsx
+++ b/frontend/src/app/(dashboard)/automations/new/page.test.tsx
@@ -696,6 +696,46 @@ describe("NewAutomationPage", () => {
     ).toContain("Review the repository for concrete, actionable security risk");
   });
 
+  it("allows a blank interval while editing a template-backed form and restores it on blur", async () => {
+    const user = userEvent.setup();
+    server.use(
+      http.get("/api/v1/repositories", () =>
+        HttpResponse.json({
+          data: [
+            {
+              id: "repo-1",
+              org_id: "org-1",
+              integration_id: "int-1",
+              github_id: 1,
+              full_name: "acme/repo",
+              default_branch: "main",
+              private: false,
+              clone_url: "https://github.com/acme/repo.git",
+              installation_id: 10,
+              status: "active",
+              settings: {},
+              created_at: "2026-03-05T12:00:00Z",
+              updated_at: "2026-03-05T12:00:00Z",
+            },
+          ],
+          meta: {},
+        }),
+      ),
+    );
+
+    renderWithProviders(<NewAutomationPage />);
+
+    const intervalInput = await screen.findByLabelText("Interval value");
+    await user.clear(intervalInput);
+
+    expect(intervalInput).toHaveValue(null);
+    expect(screen.getByRole("button", { name: "Create automation" })).toBeDisabled();
+
+    await user.tab();
+
+    expect(intervalInput).toHaveValue(1);
+  });
+
   it("restores the latest in-progress automation draft when no template is selected", async () => {
     searchParamsState.value = "";
     window.sessionStorage.setItem(

--- a/frontend/src/app/(dashboard)/automations/new/page.tsx
+++ b/frontend/src/app/(dashboard)/automations/new/page.tsx
@@ -81,6 +81,7 @@ import {
   clearAutomationDraft,
   defaultAutomationFormState,
   loadAutomationDraft,
+  parseAutomationIntervalInput,
   saveAutomationDraft,
   type AutomationFormState,
 } from "@/lib/automation-draft";
@@ -220,6 +221,9 @@ export default function NewAutomationPage() {
       intervalUnit: initialTemplate?.defaultUnit ?? "days",
       timezone: detectedTimezone,
     }),
+  );
+  const [intervalValueInput, setIntervalValueInput] = useState(
+    String(initialTemplate?.defaultInterval ?? 1),
   );
   const [advancedOpen, setAdvancedOpen] = useState(false);
   const [templateOpen, setTemplateOpen] = useState(false);
@@ -375,6 +379,10 @@ export default function NewAutomationPage() {
   useEffect(() => {
     latestFormRef.current = form;
   }, [form]);
+
+  useEffect(() => {
+    setIntervalValueInput(String(intervalValue));
+  }, [intervalValue]);
 
   useEffect(() => {
     draftHydratedRef.current = draftHydrated;
@@ -637,6 +645,7 @@ export default function NewAutomationPage() {
     repoId.length > 0 &&
     pagerDutyTriggerValid &&
     linearTriggerValid &&
+    (!scheduleEnabled || intervalValueInput.trim().length > 0) &&
     (scheduleEnabled || hasEventTriggers);
   const submitDisabledReason = createMutation.isPending || redirecting
     ? undefined
@@ -648,6 +657,7 @@ export default function NewAutomationPage() {
         pagerDutyTriggerValid,
         linearTriggerValid,
         scheduleEnabled,
+        intervalValueValid: intervalValueInput.trim().length > 0,
         hasEventTriggers,
       });
 
@@ -745,13 +755,22 @@ export default function NewAutomationPage() {
                         type="number"
                         min={1}
                         max={365}
-                        value={intervalValue}
+                        value={intervalValueInput}
                         onChange={(e) => {
-                          const parsed = parseInt(e.target.value, 10);
-                          setFormField(
-                            "intervalValue",
-                            Number.isNaN(parsed) ? 1 : Math.max(1, parsed),
-                          );
+                          const nextValue = e.target.value;
+                          setIntervalValueInput(nextValue);
+                          if (nextValue.trim().length > 0) {
+                            setFormField(
+                              "intervalValue",
+                              parseAutomationIntervalInput(nextValue),
+                            );
+                          }
+                        }}
+                        onBlur={() => {
+                          const normalized =
+                            parseAutomationIntervalInput(intervalValueInput);
+                          setIntervalValueInput(String(normalized));
+                          setFormField("intervalValue", normalized);
                         }}
                         className="h-8 w-20 px-2 text-base sm:text-xs"
                       />
@@ -1492,6 +1511,7 @@ function getCreateDisabledReason({
   pagerDutyTriggerValid,
   linearTriggerValid,
   scheduleEnabled,
+  intervalValueValid,
   hasEventTriggers,
 }: {
   name: string;
@@ -1501,6 +1521,7 @@ function getCreateDisabledReason({
   pagerDutyTriggerValid: boolean;
   linearTriggerValid: boolean;
   scheduleEnabled: boolean;
+  intervalValueValid: boolean;
   hasEventTriggers: boolean;
 }): string | undefined {
   if (!name && !goal) {
@@ -1520,6 +1541,9 @@ function getCreateDisabledReason({
   }
   if (!scheduleEnabled && !hasEventTriggers) {
     return "Select at least one trigger before creating the automation.";
+  }
+  if (scheduleEnabled && !intervalValueValid) {
+    return "Add a schedule interval before creating the automation.";
   }
   if (!pagerDutyTriggerValid) {
     return "Add at least one PagerDuty service ID before creating the automation.";

--- a/frontend/src/lib/automation-draft.test.ts
+++ b/frontend/src/lib/automation-draft.test.ts
@@ -5,6 +5,7 @@ import {
   clearAutomationDraft,
   defaultAutomationFormState,
   loadAutomationDraft,
+  parseAutomationIntervalInput,
   saveAutomationDraft,
   type AutomationFormState,
 } from "./automation-draft";
@@ -238,6 +239,13 @@ describe("automation-draft storage", () => {
         ],
       }),
     );
+  });
+
+  it("normalizes interval input to the supported range", () => {
+    expect(parseAutomationIntervalInput("")).toBe(1);
+    expect(parseAutomationIntervalInput("0")).toBe(1);
+    expect(parseAutomationIntervalInput("14")).toBe(14);
+    expect(parseAutomationIntervalInput("999")).toBe(365);
   });
 
   it("clears the stored draft", () => {

--- a/frontend/src/lib/automation-draft.ts
+++ b/frontend/src/lib/automation-draft.ts
@@ -90,6 +90,11 @@ function getStorage(): Storage | null {
   }
 }
 
+export function parseAutomationIntervalInput(value: string): number {
+  const parsed = parseInt(value, 10);
+  return Number.isNaN(parsed) ? 1 : clampInteger(parsed, 1, 365, 1);
+}
+
 export function defaultAutomationFormState(
   overrides: Partial<AutomationFormState> = {},
 ): AutomationFormState {


### PR DESCRIPTION
## Summary

Clearing the “Interval value” field in the automation template editor could leave the UI in an invalid/empty state, blocking actions and causing mismatched values on save. This change updates the interval input to support temporarily blank editing while reliably restoring a valid numeric value on blur, and adjusts/extends tests to cover the workflow.

## Changes

- Use `parseAutomationIntervalInput(intervalValue)` on input `onBlur` to normalize restored interval values instead of leaving the field empty.
- Update the automation detail page test expectation: when a blank interval is blurred/restored, the saved `interval_value` matches the restored number (was 2, now 1).
- Add a new test for the “new automation” page to ensure a blank interval is allowed during editing and restored on blur for template-backed form behavior.
- Centralize interval parsing in `frontend/src/lib/automation-draft.ts` (covered by existing unit tests) to ensure consistent handling across screens.

## Validation

- Updated/added frontend unit + integration tests:
  - `frontend/src/app/(dashboard)/automations/[id]/page.test.tsx`
  - `frontend/src/app/(dashboard)/automations/new/page.test.tsx`
  - `frontend/src/lib/automation-draft.test.ts`
- Verified expected UI state transitions (disabled/enabled) and saved payload contents in tests.

[143.dev](https://143.dev) | [session 245ae152](https://143.dev/sessions/245ae152-c01d-4004-909c-4deff98f2d54)

<!-- 143 readiness -->
**143 readiness:** Ready with warnings (workspace revision 4; 7 passed, 2 warnings, 0 blockers).

Preview: https://143.dev/previews/github/assembledhq/143/pull/1733?launch=1