### PR TITLE
Surface OpenCode backing provider in credential summary

### DIFF
--- a/internal/api/handlers/coding_credentials.go
+++ b/internal/api/handlers/coding_credentials.go
@@ -535,6 +535,16 @@ func summaryFromDecryptedCoding(cred models.DecryptedCodingCredential) models.Co
 	if cred.UserID != nil {
 		scope = models.CodingCredentialScopePersonal
 	}
+	// OpenCode rows are always stored under ProviderOpenCode; the backing
+	// provider (openrouter/opencode/openai/...) that decides which logical-model
+	// routes are runnable lives inside the OpenCodeConfig. Surface the backing as
+	// the summary provider so the model picker (runnableOpenCodeBackings on the
+	// frontend) can light up OpenRouter-backed models instead of treating every
+	// OpenCode credential as native.
+	provider := cred.Provider
+	if oc, ok := cred.Config.(models.OpenCodeConfig); ok {
+		provider = oc.NormalizedBackingProvider()
+	}
 	return models.CodingCredentialSummary{
 		ID:               cred.ID,
 		OrgID:            cred.OrgID,
@@ -543,7 +553,7 @@ func summaryFromDecryptedCoding(cred models.DecryptedCodingCredential) models.Co
 		Priority:         cred.Priority,
 		Agent:            agent,
 		AuthType:         authType,
-		Provider:         cred.Provider,
+		Provider:         provider,
 		Label:            coalesce(cred.Label, defaultLabelFor(agent, authType)),
 		Status:           codingStatusFor(cred),
 		UsageNote:        usageNoteFor(cred),

--- a/internal/api/handlers/coding_credentials_test.go
+++ b/internal/api/handlers/coding_credentials_test.go
@@ -744,6 +744,22 @@ func TestCodingCredentialSummaryHelpers(t *testing.T) {
 	require.Equal(t, "Setup token renews by Jan 15, 2027", orgRows[4].UsageNote, "setup-token usage note should show the stored expiry")
 	require.Equal(t, "Pi API key", defaultLabelFor(models.AgentTypePi, models.CodingAuthTypeAPIKey), "defaultLabelFor should cover pi")
 	require.Equal(t, "OpenCode API key", defaultLabelFor(models.AgentTypeOpenCode, models.CodingAuthTypeAPIKey), "defaultLabelFor should cover opencode")
+
+	// OpenCode rows are stored under ProviderOpenCode, but the summary must
+	// surface the config's backing provider so the model picker can light up
+	// the OpenRouter-backed routes instead of treating every key as native.
+	openRouterRow := models.DecryptedCodingCredential{
+		ID: uuid.New(), OrgID: orgID, UserID: &userID, Provider: models.ProviderOpenCode,
+		Config:   models.OpenCodeConfig{APIKey: "sk-or-v1-abc123", BackingProvider: models.ProviderOpenRouter},
+		Priority: 1, Status: models.CodingCredentialStatusActive, CreatedAt: now, UpdatedAt: now,
+	}
+	openRouterSummary := summaryFromDecryptedCoding(openRouterRow)
+	require.Equal(t, models.AgentTypeOpenCode, openRouterSummary.Agent, "OpenCode row should map to the opencode agent")
+	require.Equal(t, models.ProviderOpenRouter, openRouterSummary.Provider, "OpenCode summary should surface the openrouter backing provider")
+
+	nativeRow := openRouterRow
+	nativeRow.Config = models.OpenCodeConfig{APIKey: "oc-key"}
+	require.Equal(t, models.ProviderOpenCode, summaryFromDecryptedCoding(nativeRow).Provider, "OpenCode summary should default to native backing when none is stored")
 	require.Equal(t, "Coding auth", defaultLabelFor("", ""), "defaultLabelFor should cover unknown agents")
 
 	cfg, provider, err := codingCredentialConfigFromInput(models.CreateCodingCredentialInput{Agent: models.AgentTypeClaudeCode, AuthType: models.CodingAuthTypeAPIKey, APIKey: "sk-ant", BaseURL: "https://anthropic.test"})


### PR DESCRIPTION
## Problem

On the 143.dev org, the OpenCode model picker showed **only "OpenCode native"** models and disabled every OpenRouter-backed model with "· add a key" — even though a valid OpenRouter key was configured.

## Root cause

`summaryFromDecryptedCoding` (internal/api/handlers/coding_credentials.go) set:

```go
Provider: cred.Provider,
```

For every OpenCode credential `cred.Provider` is **always** `ProviderOpenCode` (the row-level provider). The real backing (`openrouter`, `openai`, …) lives inside the encrypted `OpenCodeConfig.BackingProvider` and was never surfaced.

The frontend's `runnableOpenCodeBackings` (frontend/src/hooks/use-opencode-models.ts) reads `row.provider` **expecting the backing**, so the available-backings set was always `{"opencode"}` regardless of the key. Walking each logical model's routes (OpenRouter first, native fallback), the OpenRouter route never matched → every dual-route model fell through to "· OpenCode native" and provider-only models showed "· add a key".

This was **display/availability only** — session launch was unaffected because `resolveAcrossOpenCodeRoutes` reads the decrypted `cfg.NormalizedBackingProvider()` directly, so sessions already routed through OpenRouter.

## Fix

In `summaryFromDecryptedCoding`, surface the config's `NormalizedBackingProvider()` as the summary provider for OpenCode rows — matching the contract the frontend already documents ("the summary's `provider` field carries the backing provider for opencode rows"). No data migration needed; the backing is read from the already-stored config.

**Verified safe:** the only consumers of an OpenCode row's `provider` are the model picker (wants the backing) and `pmUsableResolvedCredentials` (resolves via `row.agent`'s providerKey, not `provider`). The settings credential list (`coding-auth-stack.tsx`) labels rows by `row.agent`.

## Testing

- Added assertions to `TestCodingCredentialSummaryHelpers`: openrouter backing surfaces as `provider`; empty backing still defaults to native.
- `internal/api/handlers` coding-credential suite passes; `make lint` clean (0 issues).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
