### PR TITLE
Handle agent result errors as failed sessions

### DIFF
--- a/internal/services/agent/orchestrator.go
+++ b/internal/services/agent/orchestrator.go
@@ -3079,6 +3079,18 @@ func (o *Orchestrator) RunAgent(ctx context.Context, run *models.Session) error 
 		})
 		return nil
 	}
+	if result != nil && strings.TrimSpace(result.Error) != "" {
+		agentErr := errors.New(strings.TrimSpace(result.Error))
+		err = agentErr
+		runResult := o.buildRunResult(ctx, run, sandbox, result)
+		o.failRunWithResult(ctx, run, runResult, agentErr.Error())
+		logAgentRunFailed(log, run, agentErr, "failed", runStartedAt, nil)
+		o.enqueueJob(ctx, run.OrgID, "agent", "analyze_failure", map[string]interface{}{
+			"session_id": run.ID.String(),
+			"org_id":     run.OrgID.String(),
+		})
+		return fmt.Errorf("execute agent: %w", agentErr)
+	}
 
 	// 11b. Snapshot workspace for multi-turn support (does not change session status).
 	currentRuntimeID := uuid.Nil
@@ -4499,6 +4511,14 @@ func (o *Orchestrator) ContinueSession(ctx context.Context, session *models.Sess
 			return nil
 		}
 	}
+	if result != nil && strings.TrimSpace(result.Error) != "" {
+		agentErr := errors.New(strings.TrimSpace(result.Error))
+		err = agentErr
+		runResult := o.buildRunResult(ctx, session, sandbox, result)
+		o.failRunWithResult(ctx, session, runResult, agentErr.Error())
+		o.failNonPrimaryThreadWithResult(ctx, session, threadID, runResult, log)
+		return fmt.Errorf("execute agent on continue: %w", agentErr)
+	}
 
 	// 7. Create assistant message with result summary.
 	if err := o.createAssistantMessage(ctx, session.ID, session.OrgID, threadID, messageTurnNumber, result); err != nil {
@@ -5629,6 +5649,16 @@ func (o *Orchestrator) failRun(ctx context.Context, run *models.Session, errMsg 
 	result := &models.SessionResult{
 		Error: strPtr(errMsg),
 	}
+	o.failRunWithResult(ctx, run, result, errMsg)
+}
+
+func (o *Orchestrator) failRunWithResult(ctx context.Context, run *models.Session, result *models.SessionResult, errMsg string) {
+	if result == nil {
+		result = &models.SessionResult{}
+	}
+	if result.Error == nil || strings.TrimSpace(*result.Error) == "" {
+		result.Error = strPtr(errMsg)
+	}
 	if err := o.sessions.UpdateResult(ctx, run.OrgID, run.ID, models.SessionStatusFailed, result); err != nil {
 		o.logger.Error().Err(err).Str("run_id", run.ID.String()).Msg("failed to update run to failed")
 	}
@@ -5655,6 +5685,20 @@ func (o *Orchestrator) failRun(ctx context.Context, run *models.Session, errMsg 
 	}
 	o.notifyPagerDutySessionComplete(ctx, run, models.SessionStatusFailed, errMsg)
 	o.enqueueLinearMilestone(ctx, run, "failed")
+}
+
+func (o *Orchestrator) failNonPrimaryThreadWithResult(ctx context.Context, run *models.Session, threadID *uuid.UUID, result *models.SessionResult, log zerolog.Logger) {
+	if o.sessionThreads == nil || run == nil || threadID == nil || *threadID == uuid.Nil {
+		return
+	}
+	if run.PrimaryThreadID != nil && *run.PrimaryThreadID == *threadID {
+		return
+	}
+	if err := o.sessionThreads.UpdateResult(ctx, run.OrgID, *threadID, models.ThreadStatusFailed, result); err != nil {
+		log.Warn().Err(err).
+			Str("thread_id", threadID.String()).
+			Msg("failed to update active thread terminal status")
+	}
 }
 
 func (o *Orchestrator) notifyPagerDutySessionComplete(ctx context.Context, run *models.Session, status models.SessionStatus, summary string) {

--- a/internal/services/agent/orchestrator_test.go
+++ b/internal/services/agent/orchestrator_test.go
@@ -1403,6 +1403,18 @@ func (m *mockSessionThreadStore) statuses() []models.ThreadStatus {
 	return out
 }
 
+func (m *mockSessionThreadStore) statusesForThread(threadID uuid.UUID) []models.ThreadStatus {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	out := make([]models.ThreadStatus, 0)
+	for _, c := range m.updateStatusCalls {
+		if c.threadID == threadID {
+			out = append(out, c.status)
+		}
+	}
+	return out
+}
+
 func (m *mockSessionThreadStore) completedTurns() []struct {
 	threadID uuid.UUID
 	turn     int
@@ -1659,6 +1671,45 @@ func TestRunAgent_SuccessfulRun(t *testing.T) {
 
 	// Sandbox should be destroyed.
 	require.Equal(t, 1, d.provider.GetDestroyCalls())
+}
+
+func TestRunAgent_ResultErrorMarksRunFailed(t *testing.T) {
+	t.Parallel()
+
+	orgID := testOrg()
+	issue := testIssue(orgID)
+	run := testRun(orgID, issue.ID)
+	threadID := uuid.New()
+	run.PrimaryThreadID = &threadID
+
+	d := defaultDeps()
+	d.sessionThreads = &mockSessionThreadStore{}
+	d.adapter.executeFn = func(ctx context.Context, sandbox *agent.Sandbox, prompt *agent.AgentPrompt, logCh chan<- agent.LogEntry) (*agent.AgentResult, error) {
+		return &agent.AgentResult{
+			Summary:  `{"type":"error","error":{"name":"UnknownError"}}`,
+			Error:    `opencode CLI exited with code 1: {"type":"error","error":{"name":"UnknownError"}}`,
+			ExitCode: 1,
+		}, nil
+	}
+
+	err := buildOrchestrator(d).RunAgent(context.Background(), run)
+	require.Error(t, err, "RunAgent should return an error when the adapter result contains an error")
+	require.Contains(t, err.Error(), "execute agent", "RunAgent should wrap the adapter result error")
+
+	results := d.sessions.getResultUpdates()
+	require.Len(t, results, 1, "RunAgent should persist one terminal result")
+	require.Equal(t, models.SessionStatusFailed, results[0].status, "RunAgent should mark the session failed")
+	require.NotNil(t, results[0].result.Error, "RunAgent should persist the adapter error")
+	require.Contains(t, *results[0].result.Error, "opencode CLI exited with code 1", "RunAgent should preserve the adapter error detail")
+
+	threadStatuses := d.sessionThreads.statuses()
+	require.Contains(t, threadStatuses, models.ThreadStatusFailed, "RunAgent should mark the primary thread failed")
+	require.NotContains(t, threadStatuses, models.ThreadStatusCompleted, "RunAgent should not mark an errored result completed")
+
+	enqueued := d.jobs.getEnqueued()
+	require.Contains(t, enqueued, "analyze_failure", "RunAgent should enqueue failure analysis for adapter result errors")
+	require.NotContains(t, enqueued, "open_pr", "RunAgent should not enqueue PR creation after an adapter result error")
+	require.Empty(t, d.messages.getMessages(), "RunAgent should not create an assistant success message for an adapter result error")
 }
 
 func TestRunAgent_RateLimitRetriesWithFallbackCredential(t *testing.T) {
@@ -6349,6 +6400,69 @@ func TestContinueSession_PersistsTurnResultAndReturnsToIdle(t *testing.T) {
 	require.Equal(t, threadID, *d.logs.logs[0].ThreadID, "persisted output logs should keep the triggering thread id")
 	require.NotNil(t, d.logs.markedThreadID, "duplicate marker should preserve the thread id")
 	require.Equal(t, threadID, *d.logs.markedThreadID, "duplicate marker should use the triggering thread id")
+}
+
+func TestContinueSession_ResultErrorMarksActiveThreadFailed(t *testing.T) {
+	t.Parallel()
+
+	orgID := testOrg()
+	primaryThreadID := uuid.New()
+	activeThreadID := uuid.New()
+	issue := testIssue(orgID)
+	issue.Source = models.IssueSourceManual
+	session := testRun(orgID, issue.ID)
+	session.Origin = models.SessionOriginManual
+	session.InteractionMode = models.SessionInteractionModeInteractive
+	session.ValidationPolicy = models.SessionValidationPolicyOnSessionEnd
+	session.Status = models.SessionStatusIdle
+	session.CurrentTurn = 1
+	session.SnapshotKey = strPtr("snapshots/test/session.tar")
+	session.PrimaryThreadID = &primaryThreadID
+
+	d := defaultDeps()
+	d.issues.issue = issue
+	d.sessionThreads = &mockSessionThreadStore{}
+	d.messages.messages = []models.SessionMessage{
+		{
+			ID:         1,
+			SessionID:  session.ID,
+			OrgID:      orgID,
+			ThreadID:   &activeThreadID,
+			TurnNumber: 2,
+			Role:       models.MessageRoleUser,
+			Content:    "Please continue this secondary tab.",
+		},
+	}
+	d.provider.RestoreFn = func(ctx context.Context, sb *agent.Sandbox, reader io.Reader) error {
+		_, err := io.ReadAll(reader)
+		return err
+	}
+	d.adapter.executeFn = func(ctx context.Context, sandbox *agent.Sandbox, prompt *agent.AgentPrompt, logCh chan<- agent.LogEntry) (*agent.AgentResult, error) {
+		return &agent.AgentResult{
+			Summary:  `{"type":"error","error":{"name":"UnknownError"}}`,
+			Error:    `opencode CLI exited with code 1: {"type":"error","error":{"name":"UnknownError"}}`,
+			ExitCode: 1,
+		}, nil
+	}
+	d.snapshots.data = map[string][]byte{
+		*session.SnapshotKey: []byte("restored-snapshot"),
+	}
+
+	err := buildOrchestrator(d).ContinueSession(context.Background(), session, &agent.ContinueSessionOptions{ThreadID: &activeThreadID})
+	require.Error(t, err, "continue_session should return an error when the adapter result contains an error")
+	require.Contains(t, err.Error(), "execute agent on continue", "continue_session should wrap the adapter result error")
+
+	results := d.sessions.getResultUpdates()
+	require.Len(t, results, 1, "continue_session should persist one terminal result")
+	require.Equal(t, models.SessionStatusFailed, results[0].status, "continue_session should mark the session failed")
+	require.NotNil(t, results[0].result.Error, "continue_session should persist the adapter error")
+	require.Contains(t, *results[0].result.Error, "opencode CLI exited with code 1", "continue_session should preserve the adapter error detail")
+
+	require.Contains(t, d.sessionThreads.statusesForThread(primaryThreadID), models.ThreadStatusFailed, "continue_session should still fail the primary thread through session failure bookkeeping")
+	require.Contains(t, d.sessionThreads.statusesForThread(activeThreadID), models.ThreadStatusFailed, "continue_session should fail the active secondary thread")
+	require.NotContains(t, d.sessionThreads.statusesForThread(activeThreadID), models.ThreadStatusCompleted, "continue_session should not mark an errored secondary thread completed")
+	require.Empty(t, d.sessions.getTurnUpdates(), "continue_session should not persist a successful turn for an adapter result error")
+	require.Len(t, d.messages.getMessages(), 1, "continue_session should not append an assistant success message for an adapter result error")
 }
 
 func TestContinueSession_CancelReturnsPayloadThreadToIdle(t *testing.T) {


### PR DESCRIPTION
## Summary
- Treat non-empty agent result errors as terminal failures in both `RunAgent` and `ContinueSession`
- Persist the failure result before exiting so the session keeps the adapter error details
- Mark the active non-primary thread failed when continuation exits with an agent result error
- Add unit coverage for both run and continuation failure paths

## Testing
- Added unit tests covering failed agent results for `RunAgent` and `ContinueSession`
- Verified failure state, persisted error details, thread status updates, and skipped success-side effects