### PR TITLE
Ensure selected model stays visible while filtering unavailable OpenCode options

### DIFF
--- a/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
@@ -1463,6 +1463,7 @@ function SessionComposer({
                 models={availableModels}
                 agentType={agentType}
                 openCodeAvailability={openCodeAvailability}
+                selectedModel={selectedModel}
               />
             </SelectContent>
           </Select>
@@ -1852,6 +1853,7 @@ function SessionComposer({
                         models={availableModels}
                         agentType={agentType}
                         openCodeAvailability={openCodeAvailability}
+                        selectedModel={selectedModel}
                       />
                     </SelectContent>
                   </Select>

--- a/frontend/src/components/automation-model-select.tsx
+++ b/frontend/src/components/automation-model-select.tsx
@@ -113,7 +113,7 @@ export function AutomationModelSelect({
             <SelectItem value={value}>{value}</SelectItem>
           </SelectGroup>
         ) : null}
-        <ModelOptionGroups modelGroups={modelGroups} openCodeAvailability={openCodeAvailability} />
+        <ModelOptionGroups modelGroups={modelGroups} openCodeAvailability={openCodeAvailability} selectedModel={value} />
       </SelectContent>
     </Select>
   );

--- a/frontend/src/components/manual-session-composer.tsx
+++ b/frontend/src/components/manual-session-composer.tsx
@@ -253,7 +253,7 @@ const ComposerSettingsControls = memo(function ComposerSettingsControls({
         </SelectTrigger>
         <SelectContent>
           <SelectItem value="__default__">Default model</SelectItem>
-          <ModelOptionGroups modelGroups={modelGroups} openCodeAvailability={openCodeAvailability} />
+          <ModelOptionGroups modelGroups={modelGroups} openCodeAvailability={openCodeAvailability} selectedModel={selectedModel} />
         </SelectContent>
       </Select>
 
@@ -1126,7 +1126,7 @@ export function ManualSessionComposer({
           </SelectTrigger>
           <SelectContent>
             <SelectItem value="__default__">Default model</SelectItem>
-            <ModelOptionGroups modelGroups={modelGroups} openCodeAvailability={openCodeAvailability} />
+            <ModelOptionGroups modelGroups={modelGroups} openCodeAvailability={openCodeAvailability} selectedModel={selectedModel} />
           </SelectContent>
         </Select>
       </div>

--- a/frontend/src/components/model-option-groups.test.ts
+++ b/frontend/src/components/model-option-groups.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+
+import type { OpenCodeModelAvailability } from "@/hooks/use-opencode-models";
+import { isModelOptionVisible, shouldRenderModelOption } from "./model-option-groups";
+
+describe("shouldRenderModelOption", () => {
+  it("hides OpenCode models with no runnable route", () => {
+    const availability = new Map<string, OpenCodeModelAvailability>([
+      ["glm-5.2", { hasRunnableRoute: true, transportLabel: "OpenRouter" }],
+      ["gpt-5.4", { hasRunnableRoute: false, transportLabel: null }],
+    ]);
+
+    expect(shouldRenderModelOption("glm-5.2", true, availability)).toBe(true);
+    expect(shouldRenderModelOption("gpt-5.4", true, availability)).toBe(false);
+  });
+
+  it("keeps non-OpenCode and unknown-availability options visible", () => {
+    const availability = new Map<string, OpenCodeModelAvailability>([
+      ["gpt-5.5", { hasRunnableRoute: false, transportLabel: null }],
+    ]);
+
+    expect(shouldRenderModelOption("gpt-5.5", false, availability)).toBe(true);
+    expect(shouldRenderModelOption("not-yet-loaded", true, availability)).toBe(true);
+  });
+});
+
+describe("isModelOptionVisible", () => {
+  const availability = new Map<string, OpenCodeModelAvailability>([
+    ["glm-5.2", { hasRunnableRoute: true, transportLabel: "OpenRouter" }],
+    ["gpt-5.4", { hasRunnableRoute: false, transportLabel: null }],
+  ]);
+
+  it("keeps an unavailable model visible when it is the current selection", () => {
+    expect(isModelOptionVisible("gpt-5.4", true, availability)).toBe(false);
+    expect(isModelOptionVisible("gpt-5.4", true, availability, "gpt-5.4")).toBe(true);
+  });
+
+  it("hides an unavailable model that is not selected", () => {
+    expect(isModelOptionVisible("gpt-5.4", true, availability, "glm-5.2")).toBe(false);
+  });
+
+  it("shows available models regardless of selection", () => {
+    expect(isModelOptionVisible("glm-5.2", true, availability)).toBe(true);
+    expect(isModelOptionVisible("glm-5.2", true, availability, "gpt-5.4")).toBe(true);
+  });
+});

--- a/frontend/src/components/model-option-groups.tsx
+++ b/frontend/src/components/model-option-groups.tsx
@@ -14,11 +14,35 @@ interface ModelOptionGroupsProps {
   // When absent (registry still loading / API failed) OpenCode models render
   // as normal, enabled options with no transport badge.
   openCodeAvailability?: Map<string, OpenCodeModelAvailability>;
+  // selectedModel is always kept visible even when it has no runnable route, so
+  // the trigger keeps displaying the current value instead of falling back to
+  // the placeholder while the stored selection silently persists.
+  selectedModel?: string;
 }
 
-// openCodeModelItemDecor computes the per-item badge/disabled state for an
-// OpenCode model. Returns plain (no badge, enabled) for non-OpenCode models or
-// when availability data is absent.
+export function shouldRenderModelOption(
+  model: string,
+  isOpenCode: boolean,
+  availabilityById?: Map<string, OpenCodeModelAvailability>,
+): boolean {
+  const availability = isOpenCode ? availabilityById?.get(model) : undefined;
+  return !availability || availability.hasRunnableRoute;
+}
+
+// isModelOptionVisible decides whether a model renders in the picker. Available
+// models always show; an unavailable model shows only when it is the current
+// selection (so the trigger stays truthful).
+export function isModelOptionVisible(
+  model: string,
+  isOpenCode: boolean,
+  availabilityById?: Map<string, OpenCodeModelAvailability>,
+  selectedModel?: string,
+): boolean {
+  return model === selectedModel || shouldRenderModelOption(model, isOpenCode, availabilityById);
+}
+
+// openCodeModelItemDecor computes the per-item transport badge for an OpenCode
+// model. Unavailable OpenCode models are filtered before this runs.
 function openCodeModelItemDecor(
   model: string,
   isOpenCode: boolean,
@@ -27,8 +51,8 @@ function openCodeModelItemDecor(
   const availability = isOpenCode ? availabilityById?.get(model) : undefined;
   if (!availability) return { disabled: false, trailing: null };
   return {
-    disabled: !availability.hasRunnableRoute,
-    trailing: availability.transportLabel ?? (availability.hasRunnableRoute ? null : "add a key"),
+    disabled: false,
+    trailing: availability.transportLabel,
   };
 }
 
@@ -36,11 +60,14 @@ function ModelSelectItem({
   model,
   isOpenCode,
   availabilityById,
+  selectedModel,
 }: {
   model: string;
   isOpenCode: boolean;
   availabilityById?: Map<string, OpenCodeModelAvailability>;
+  selectedModel?: string;
 }) {
+  if (!isModelOptionVisible(model, isOpenCode, availabilityById, selectedModel)) return null;
   const { disabled, trailing } = openCodeModelItemDecor(model, isOpenCode, availabilityById);
   return (
     <SelectItem value={model} disabled={disabled}>
@@ -54,51 +81,65 @@ function ModelSelectItem({
 
 // ModelOptionGroups renders the grouped model options for the session/PM model
 // pickers. For OpenCode models it adds a "· OpenRouter" transport badge (the
-// route that would run given current keys) and disables models with no runnable
-// transport. Centralized so the three pickers stay consistent.
-export function ModelOptionGroups({ modelGroups, openCodeAvailability }: ModelOptionGroupsProps) {
+// route that would run given current keys) and hides models with no runnable
+// transport, except the current selection which always stays visible.
+// Centralized so the three pickers stay consistent.
+export function ModelOptionGroups({ modelGroups, openCodeAvailability, selectedModel }: ModelOptionGroupsProps) {
   return (
     <>
-      {modelGroups.map((group) => (
-        <SelectGroup key={group.key}>
-          <SelectLabel>{group.label}</SelectLabel>
-          {group.models.map((model) => (
-            <ModelSelectItem
-              key={model}
-              model={model}
-              isOpenCode={group.key === "opencode"}
-              availabilityById={openCodeAvailability}
-            />
-          ))}
-        </SelectGroup>
-      ))}
+      {modelGroups.map((group) => {
+        const isOpenCode = group.key === "opencode";
+        const models = group.models.filter((model) =>
+          isModelOptionVisible(model, isOpenCode, openCodeAvailability, selectedModel),
+        );
+        if (models.length === 0) return null;
+        return (
+          <SelectGroup key={group.key}>
+            <SelectLabel>{group.label}</SelectLabel>
+            {models.map((model) => (
+              <ModelSelectItem
+                key={model}
+                model={model}
+                isOpenCode={isOpenCode}
+                availabilityById={openCodeAvailability}
+                selectedModel={selectedModel}
+              />
+            ))}
+          </SelectGroup>
+        );
+      })}
     </>
   );
 }
 
 // FlatModelOptions renders a single agent's model list (no groups) with the same
-// OpenCode transport badge + disabled treatment. Used by the in-session composer
-// where the picker is scoped to one agent.
+// OpenCode transport badge + availability filtering. Used by the in-session
+// composer where the picker is scoped to one agent.
 export function FlatModelOptions({
   models,
   agentType,
   openCodeAvailability,
+  selectedModel,
 }: {
   models: readonly string[];
   agentType: string;
   openCodeAvailability?: Map<string, OpenCodeModelAvailability>;
+  selectedModel?: string;
 }) {
   const isOpenCode = agentType === "opencode";
   return (
     <>
-      {models.map((model) => (
-        <ModelSelectItem
-          key={model}
-          model={model}
-          isOpenCode={isOpenCode}
-          availabilityById={openCodeAvailability}
-        />
-      ))}
+      {models
+        .filter((model) => isModelOptionVisible(model, isOpenCode, openCodeAvailability, selectedModel))
+        .map((model) => (
+          <ModelSelectItem
+            key={model}
+            model={model}
+            isOpenCode={isOpenCode}
+            availabilityById={openCodeAvailability}
+            selectedModel={selectedModel}
+          />
+        ))}
     </>
   );
 }

--- a/frontend/src/components/repo-pm-settings.tsx
+++ b/frontend/src/components/repo-pm-settings.tsx
@@ -353,6 +353,7 @@ export function RepoPMSettingsEditor({ repository }: RepoPMSettingsProps) {
                         <ModelOptionGroups
                           modelGroups={pmModelGroups}
                           openCodeAvailability={openCodeAvailability}
+                          selectedModel={effectiveModel}
                         />
                       )}
                     </SelectContent>


### PR DESCRIPTION
## Summary

When a previously-selected OpenCode model becomes unavailable, the model picker could hide the selected value—causing the `SelectTrigger` to fall back to a placeholder and desync the displayed choice from the stored selection. This PR keeps the currently-selected model visible even when it has no runnable route, while still filtering out unavailable “Add a key”/non-runnable OpenCode entries from the option lists.

## Changes

- Centralized visibility logic in `model-option-groups.tsx` via new exported `isModelOptionVisible` helper, and threaded a `selectedModel` prop through `ModelOptionGroups`, `FlatModelOptions`, and `ModelSelectItem`.
- Updated all picker call sites (`automation-model-select.tsx`, `manual-session-composer.tsx`, and session composer) to pass `selectedModel` so the UI can decide whether to suppress options.
- Adjusted option grouping behavior and documentation so empty/unavailable groups are handled correctly without duplicating the currently-selected option in the “current selection” fallback.

## Validation

- `tsc --noEmit`
- `vitest run model-option-groups.test.ts`
- Manual check of `automation-model-select.tsx` selection rendering: confirmed the “Current selection” fallback and kept-visible option paths are mutually exclusive, preventing duplicate `SelectItem value={value}`.

[143.dev](https://143.dev) | [session dc4379c8](https://143.dev/sessions/dc4379c8-534b-4433-9a19-4e51486e44f2)

<!-- 143 readiness -->
**143 readiness:** Ready with warnings (workspace revision 4; 7 passed, 2 warnings, 0 blockers).

Preview: https://143.dev/previews/github/assembledhq/143/pull/1739?launch=1