### PR TITLE
Disable retired Slack notification events and stop per-session subscription DB queries

### DIFF
--- a/frontend/src/app/(dashboard)/settings/integrations/page.test.tsx
+++ b/frontend/src/app/(dashboard)/settings/integrations/page.test.tsx
@@ -1178,7 +1178,7 @@ describe("IntegrationsPage", () => {
     await waitFor(() => {
       expect(updateSlackSettingsMock).toHaveBeenCalledWith({
         notification_preset: "custom",
-        notification_subscriptions: { events: ["session.completed", "session.failed"], automations: [], slack_user_ids: [] },
+        notification_subscriptions: { events: ["session.failed"], automations: [], slack_user_ids: [] },
       });
     });
   });

--- a/frontend/src/app/(dashboard)/settings/integrations/page.tsx
+++ b/frontend/src/app/(dashboard)/settings/integrations/page.tsx
@@ -89,15 +89,11 @@ const SLACK_ACTIONS: Array<{ value: SlackChannelAction; label: string }> = [
   { value: "human_input", label: "Human input" },
 ];
 const SLACK_NOTIFICATION_EVENTS = [
-  { value: "session.completed", label: "Session completed" },
   { value: "session.failed", label: "Session failed" },
   { value: "human_input.requested", label: "Human input requested" },
   { value: "automation.run.completed", label: "Automation completed" },
   { value: "automation.run.failed", label: "Automation failed" },
   { value: "automation.run.failure_streak", label: "Automation failure streak" },
-  { value: "pr.opened", label: "PR opened" },
-  { value: "preview.stale", label: "Preview stale" },
-  { value: "preview.*", label: "All preview events" },
 ] as const;
 
 // Coalesce multi-toggle bursts: the later selection wins. Hoisted so every
@@ -138,7 +134,8 @@ function slackPresetLabel(value?: SlackNotificationPreset): string {
 
 function slackNotificationEvents(settings?: { notification_subscriptions?: Record<string, unknown> }): string[] {
   const events = settings?.notification_subscriptions?.events;
-  return Array.isArray(events) ? events.filter((event): event is string => typeof event === "string") : [];
+  const allowedEvents = new Set(SLACK_NOTIFICATION_EVENTS.map((event) => event.value));
+  return Array.isArray(events) ? events.filter((event): event is string => typeof event === "string" && allowedEvents.has(event)) : [];
 }
 
 function slackNotificationAutomations(settings?: { notification_subscriptions?: Record<string, unknown> }): string[] {

--- a/frontend/src/app/(dashboard)/settings/integrations/page.tsx
+++ b/frontend/src/app/(dashboard)/settings/integrations/page.tsx
@@ -134,7 +134,7 @@ function slackPresetLabel(value?: SlackNotificationPreset): string {
 
 function slackNotificationEvents(settings?: { notification_subscriptions?: Record<string, unknown> }): string[] {
   const events = settings?.notification_subscriptions?.events;
-  const allowedEvents = new Set(SLACK_NOTIFICATION_EVENTS.map((event) => event.value));
+  const allowedEvents = new Set<string>(SLACK_NOTIFICATION_EVENTS.map((event) => event.value));
   return Array.isArray(events) ? events.filter((event): event is string => typeof event === "string" && allowedEvents.has(event)) : [];
 }
 

--- a/internal/worker/handlers.go
+++ b/internal/worker/handlers.go
@@ -3831,9 +3831,25 @@ type slackNotificationSubscriptionConfig struct {
 	DMUserIDs    []string `json:"dm_user_ids"`
 }
 
-func slackNotificationSubscriptionMatches(raw json.RawMessage, preset *models.SlackNotificationPreset, eventKind string, automationID *uuid.UUID) bool {
+// slackNotificationEventDisabled reports whether an event kind has been retired
+// from Slack notifications. Disabled kinds are never delivered regardless of a
+// channel's preset or custom subscription.
+func slackNotificationEventDisabled(eventKind string) bool {
 	switch eventKind {
-	case string(models.SlackNotificationPreviewReady), string(models.SlackNotificationPreviewFailed):
+	case string(models.SlackNotificationSessionCompleted),
+		string(models.SlackNotificationPROpened),
+		string(models.SlackNotificationPreviewReady),
+		string(models.SlackNotificationPreviewFailed),
+		string(models.SlackNotificationPreviewStale),
+		string(models.SlackNotificationPRAutoRepairAttention),
+		string(models.SlackNotificationPRReadinessAttention):
+		return true
+	}
+	return false
+}
+
+func slackNotificationSubscriptionMatches(raw json.RawMessage, preset *models.SlackNotificationPreset, eventKind string, automationID *uuid.UUID) bool {
+	if slackNotificationEventDisabled(eventKind) {
 		return false
 	}
 	if len(raw) == 0 || string(raw) == "null" {
@@ -3866,19 +3882,13 @@ func slackNotificationPresetEvents(preset *models.SlackNotificationPreset) []str
 			string(models.SlackNotificationAutomationFailed),
 			string(models.SlackNotificationAutomationFailureStreak),
 			string(models.SlackNotificationHumanInputRequested),
-			string(models.SlackNotificationPRAutoRepairAttention),
-			string(models.SlackNotificationPRReadinessAttention),
 		}
 	case models.SlackNotificationPresetBalanced:
 		return []string{
-			string(models.SlackNotificationSessionCompleted),
 			string(models.SlackNotificationSessionFailed),
 			string(models.SlackNotificationAutomationFailed),
 			string(models.SlackNotificationAutomationFailureStreak),
-			string(models.SlackNotificationPROpened),
 			string(models.SlackNotificationHumanInputRequested),
-			string(models.SlackNotificationPRAutoRepairAttention),
-			string(models.SlackNotificationPRReadinessAttention),
 		}
 	case models.SlackNotificationPresetVerbose:
 		return []string{"*"}
@@ -3946,6 +3956,9 @@ func slackNotificationDestinations(setting models.SlackChannelSettings, input sl
 
 func enqueueSlackNotificationSubscribers(ctx context.Context, stores *Stores, logger zerolog.Logger, orgID uuid.UUID, input slackNotificationFanoutInput) {
 	if stores == nil || stores.SlackChannels == nil || stores.Jobs == nil || input.EventKind == "" {
+		return
+	}
+	if slackNotificationEventDisabled(input.EventKind) {
 		return
 	}
 	settings, err := stores.SlackChannels.ListNotificationSubscriptions(ctx, orgID)
@@ -4104,13 +4117,17 @@ func enqueueSlackSessionNotifications(ctx context.Context, stores *Stores, logge
 		return
 	}
 	automationKind := string(models.SlackNotificationAutomationCompleted)
+	automationTitle := "Automation completed"
+	automationBody := "An automation run completed."
 	if eventKind == string(models.SlackNotificationSessionFailed) {
 		automationKind = string(models.SlackNotificationAutomationFailed)
+		automationTitle = title
+		automationBody = body
 	}
 	enqueueSlackNotificationSubscribers(ctx, stores, logger, orgID, slackNotificationFanoutInput{
 		EventKind:       automationKind,
-		Title:           title,
-		Body:            body,
+		Title:           automationTitle,
+		Body:            automationBody,
 		SessionID:       &sessionID,
 		AutomationID:    &run.AutomationID,
 		AutomationRunID: automationRunID,
@@ -4930,12 +4947,10 @@ func slackConfigureChannelModal(input models.SlackInteractionJobPayload, repos [
 				"type":      "checkboxes",
 				"action_id": "selected",
 				"options": []map[string]any{
-					{"text": map[string]string{"type": "plain_text", "text": "Session completed"}, "value": "session.completed"},
 					{"text": map[string]string{"type": "plain_text", "text": "Session failed"}, "value": "session.failed"},
 					{"text": map[string]string{"type": "plain_text", "text": "Automation completed"}, "value": "automation.run.completed"},
 					{"text": map[string]string{"type": "plain_text", "text": "Automation failed"}, "value": "automation.run.failed"},
 					{"text": map[string]string{"type": "plain_text", "text": "Automation failure streak"}, "value": "automation.run.failure_streak"},
-					{"text": map[string]string{"type": "plain_text", "text": "All preview events (ready, failed, stale)"}, "value": "preview.*"},
 				},
 			},
 		}},

--- a/internal/worker/handlers_test.go
+++ b/internal/worker/handlers_test.go
@@ -310,9 +310,15 @@ func TestSlackNotificationSubscriptionMatches(t *testing.T) {
 		expected     bool
 	}{
 		{
-			name:      "event list matches event",
+			name:      "explicit session completed does not match",
 			raw:       json.RawMessage(`{"events":["session.completed"]}`),
 			eventKind: "session.completed",
+			expected:  false,
+		},
+		{
+			name:      "event list matches event",
+			raw:       json.RawMessage(`{"events":["session.failed"]}`),
+			eventKind: "session.failed",
 			expected:  true,
 		},
 		{
@@ -358,10 +364,28 @@ func TestSlackNotificationSubscriptionMatches(t *testing.T) {
 			expected:  false,
 		},
 		{
-			name:      "event family wildcard matches event",
+			name:      "event family wildcard does not match preview stale",
 			raw:       json.RawMessage(`{"events":["preview.*"]}`),
 			eventKind: "preview.stale",
-			expected:  true,
+			expected:  false,
+		},
+		{
+			name:      "explicit pr opened does not match",
+			raw:       json.RawMessage(`{"events":["pr.opened"]}`),
+			eventKind: "pr.opened",
+			expected:  false,
+		},
+		{
+			name:      "explicit auto repair attention does not match",
+			raw:       json.RawMessage(`{"events":["pr.auto_repair_attention"]}`),
+			eventKind: "pr.auto_repair_attention",
+			expected:  false,
+		},
+		{
+			name:      "explicit readiness attention does not match",
+			raw:       json.RawMessage(`{"events":["pr.readiness_attention"]}`),
+			eventKind: "pr.readiness_attention",
+			expected:  false,
 		},
 		{
 			name:      "event family wildcard rejects other family",
@@ -414,15 +438,16 @@ func TestSlackNotificationSubscriptionMatchesPresets(t *testing.T) {
 		eventKind string
 		expected  bool
 	}{
-		{name: "balanced includes PR opened", preset: &balanced, eventKind: string(models.SlackNotificationPROpened), expected: true},
-		{name: "balanced includes auto repair attention", preset: &balanced, eventKind: string(models.SlackNotificationPRAutoRepairAttention), expected: true},
-		{name: "balanced includes readiness attention", preset: &balanced, eventKind: string(models.SlackNotificationPRReadinessAttention), expected: true},
+		{name: "balanced excludes PR opened", preset: &balanced, eventKind: string(models.SlackNotificationPROpened), expected: false},
+		{name: "balanced excludes auto repair attention", preset: &balanced, eventKind: string(models.SlackNotificationPRAutoRepairAttention), expected: false},
+		{name: "balanced excludes readiness attention", preset: &balanced, eventKind: string(models.SlackNotificationPRReadinessAttention), expected: false},
+		{name: "balanced excludes session completed", preset: &balanced, eventKind: string(models.SlackNotificationSessionCompleted), expected: false},
 		{name: "balanced excludes preview ready", preset: &balanced, eventKind: string(models.SlackNotificationPreviewReady), expected: false},
 		{name: "balanced excludes preview failed", preset: &balanced, eventKind: string(models.SlackNotificationPreviewFailed), expected: false},
 		{name: "balanced excludes preview stale", preset: &balanced, eventKind: string(models.SlackNotificationPreviewStale), expected: false},
 		{name: "quiet includes human input", preset: &quiet, eventKind: string(models.SlackNotificationHumanInputRequested), expected: true},
-		{name: "quiet includes auto repair attention", preset: &quiet, eventKind: string(models.SlackNotificationPRAutoRepairAttention), expected: true},
-		{name: "quiet includes readiness attention", preset: &quiet, eventKind: string(models.SlackNotificationPRReadinessAttention), expected: true},
+		{name: "quiet excludes auto repair attention", preset: &quiet, eventKind: string(models.SlackNotificationPRAutoRepairAttention), expected: false},
+		{name: "quiet excludes readiness attention", preset: &quiet, eventKind: string(models.SlackNotificationPRReadinessAttention), expected: false},
 		{name: "quiet excludes preview failed", preset: &quiet, eventKind: string(models.SlackNotificationPreviewFailed), expected: false},
 		{name: "quiet excludes session completed", preset: &quiet, eventKind: string(models.SlackNotificationSessionCompleted), expected: false},
 		{name: "verbose includes any typed event", preset: &verbose, eventKind: string(models.SlackNotificationSessionFailed), expected: true},
@@ -437,6 +462,34 @@ func TestSlackNotificationSubscriptionMatchesPresets(t *testing.T) {
 			got := slackNotificationSubscriptionMatches(json.RawMessage(`{}`), tt.preset, tt.eventKind, nil)
 			require.Equal(t, tt.expected, got, "preset subscription matcher should return the expected decision")
 		})
+	}
+}
+
+func TestSlackNotificationEventDisabled(t *testing.T) {
+	t.Parallel()
+
+	disabled := []string{
+		string(models.SlackNotificationSessionCompleted),
+		string(models.SlackNotificationPROpened),
+		string(models.SlackNotificationPreviewReady),
+		string(models.SlackNotificationPreviewFailed),
+		string(models.SlackNotificationPreviewStale),
+		string(models.SlackNotificationPRAutoRepairAttention),
+		string(models.SlackNotificationPRReadinessAttention),
+	}
+	for _, eventKind := range disabled {
+		require.True(t, slackNotificationEventDisabled(eventKind), "%s should be a retired notification event", eventKind)
+	}
+
+	enabled := []string{
+		string(models.SlackNotificationSessionFailed),
+		string(models.SlackNotificationAutomationCompleted),
+		string(models.SlackNotificationAutomationFailed),
+		string(models.SlackNotificationAutomationFailureStreak),
+		string(models.SlackNotificationHumanInputRequested),
+	}
+	for _, eventKind := range enabled {
+		require.False(t, slackNotificationEventDisabled(eventKind), "%s should still be deliverable", eventKind)
 	}
 }
 
@@ -892,7 +945,11 @@ func TestSlackConfigureChannelModalIncludesNotificationSubscriptions(t *testing.
 	require.NoError(t, err, "channel config modal blocks should marshal to JSON")
 	blocksStr := string(blocksJSON)
 	require.Contains(t, blocksStr, "automation.run.failure_streak", "channel config modal should expose automation failure-streak notifications")
-	require.Contains(t, blocksStr, `"preview.*"`, "channel config modal should expose all-preview-events wildcard subscription")
+	require.NotContains(t, blocksStr, "session.completed", "channel config modal should not expose session-completed notifications")
+	require.NotContains(t, blocksStr, "pr.opened", "channel config modal should not expose PR-opened notifications")
+	require.NotContains(t, blocksStr, "preview.ready", "channel config modal should not expose preview-ready notifications")
+	require.NotContains(t, blocksStr, "preview.stale", "channel config modal should not expose preview-stale notifications")
+	require.NotContains(t, blocksStr, `"preview.*"`, "channel config modal should not expose preview wildcard subscriptions")
 }
 
 func TestSlackHomeOrgSelectorBlockIsActionable(t *testing.T) {


### PR DESCRIPTION
## Summary

Slack notifications for retired event kinds (e.g., `session.completed`, `pr.opened`, and preview/PR auto-repair & readiness attention) were still causing unnecessary per-org subscription DB queries on hot paths, even though those events are effectively no-ops. This PR removes those events from the UI selectable list and adds an early worker-side short-circuit so disabled kinds never query or enqueue subscribers.

## Changes

- **Frontend**: Removed retired Slack notification events from `SLACK_NOTIFICATION_EVENTS`, and constrained saved custom events to only allowed active kinds.
- **Worker**: Added `slackNotificationEventDisabled(eventKind)` and routed retired-kind logic through it for a single source of truth.
- **Worker**: Updated `enqueueSlackNotificationSubscribers` to **return early before `ListNotificationSubscriptions`** when the event kind is disabled, eliminating wasted DB work on session completion / PR activity flows.
- **Tests**: Added `TestSlackNotificationEventDisabled` and updated related UI expectation coverage.

## Validation

- `go build ./internal/worker/`
- `go vet ./internal/worker/`
- `go test ./internal/worker/ -run 'TestSlackNotification|TestSlackConfigureChannelModalIncludesNotificationSubscriptions|TestSlackPreview'`

[143.dev](https://143.dev) | [session 510004ab](https://143.dev/sessions/510004ab-fdaa-4b4f-89b4-3333d19fbfbb)

<!-- 143 readiness -->
**143 readiness:** not available for this revision.

Preview: https://143.dev/previews/github/assembledhq/143/pull/1742?launch=1