### PR TITLE
Resolve OpenCode model overrides before passing sandbox env

### DIFF
--- a/internal/services/agent/orchestrator.go
+++ b/internal/services/agent/orchestrator.go
@@ -2549,11 +2549,7 @@ func (o *Orchestrator) RunAgent(ctx context.Context, run *models.Session) error 
 	}
 	// Apply per-run model override before the auth pre-flight so the sandbox
 	// sees the effective model/mode selection rather than only the org default.
-	if run.ModelOverride != nil && *run.ModelOverride != "" {
-		if envVar := models.ModelEnvVarForAgentType(run.AgentType); envVar != "" {
-			sandboxCfg.Env[envVar] = *run.ModelOverride
-		}
-	}
+	applyDirectModelOverrideEnv(run.AgentType, run.ModelOverride, sandboxCfg.Env)
 	if designatedWorkingBranch != "" {
 		sandboxCfg.Env[sandboxauth.WorkingBranchEnvVar] = designatedWorkingBranch
 	}
@@ -3473,11 +3469,7 @@ func (o *Orchestrator) ContinueSession(ctx context.Context, session *models.Sess
 	}
 	// Apply the per-session model override before the auth pre-flight so the
 	// sandbox sees the effective model/mode selection.
-	if session.ModelOverride != nil && *session.ModelOverride != "" {
-		if envVar := models.ModelEnvVarForAgentType(session.AgentType); envVar != "" {
-			sandboxCfg.Env[envVar] = *session.ModelOverride
-		}
-	}
+	applyDirectModelOverrideEnv(session.AgentType, session.ModelOverride, sandboxCfg.Env)
 	if branch := sessionWorkingBranch(session, promptIssue); branch != "" {
 		sandboxCfg.Env[sandboxauth.WorkingBranchEnvVar] = branch
 	}
@@ -7760,11 +7752,7 @@ func (o *Orchestrator) resolveSessionCredentialEnv(ctx context.Context, session 
 	if refreshedEnv == nil {
 		refreshedEnv = make(map[string]string)
 	}
-	if session.ModelOverride != nil && *session.ModelOverride != "" {
-		if envVar := models.ModelEnvVarForAgentType(session.AgentType); envVar != "" {
-			refreshedEnv[envVar] = *session.ModelOverride
-		}
-	}
+	applyDirectModelOverrideEnv(session.AgentType, session.ModelOverride, refreshedEnv)
 	if branch := sandboxCfg.Env[sandboxauth.WorkingBranchEnvVar]; branch != "" {
 		refreshedEnv[sandboxauth.WorkingBranchEnvVar] = branch
 	}
@@ -7772,6 +7760,21 @@ func (o *Orchestrator) resolveSessionCredentialEnv(ctx context.Context, session 
 		refreshedEnv["HOME"] = sandboxCfg.HomeDir
 	}
 	return refreshedEnv
+}
+
+func applyDirectModelOverrideEnv(agentType models.AgentType, modelOverride *string, env map[string]string) {
+	if env == nil || modelOverride == nil || strings.TrimSpace(*modelOverride) == "" {
+		return
+	}
+	if agentType == models.AgentTypeOpenCode {
+		// OpenCode accepts logical model IDs in stored session config, but its
+		// CLI requires the resolved physical provider/model route. ResolveForModel
+		// has already translated the override into OPENCODE_MODEL.
+		return
+	}
+	if envVar := models.ModelEnvVarForAgentType(agentType); envVar != "" {
+		env[envVar] = *modelOverride
+	}
 }
 
 func refreshAgentCredentialEnv(current, resolved map[string]string, agentType models.AgentType) map[string]string {

--- a/internal/services/agent/orchestrator_test.go
+++ b/internal/services/agent/orchestrator_test.go
@@ -9641,6 +9641,50 @@ func TestRunAgent_UserCancelTakesPrecedenceOverDeadline(t *testing.T) {
 	require.NotContains(t, d.jobs.getEnqueued(), "analyze_failure", "cancel path must not enqueue failure analysis")
 }
 
+func TestRunAgent_OpenCodeLogicalModelOverrideReachesSandboxAsResolvedRoute(t *testing.T) {
+	t.Parallel()
+
+	orgID := testOrg()
+	issue := testIssue(orgID)
+	run := testRun(orgID, issue.ID)
+	run.AgentType = models.AgentTypeOpenCode
+	run.ModelOverride = strPtr(models.DefaultOpenCodeModel)
+
+	d := defaultDeps()
+	d.adapter.name = models.AgentTypeOpenCode
+	d.issues.issue = issue
+	d.codingCreds = &mockCodingCredentialProvider{
+		resolvable: map[models.ProviderName][]models.DecryptedCodingCredential{
+			models.ProviderOpenCode: {
+				{
+					ID:       uuid.New(),
+					OrgID:    orgID,
+					Provider: models.ProviderOpenCode,
+					Priority: 1,
+					Status:   models.CodingCredentialStatusActive,
+					Config: models.OpenCodeConfig{
+						APIKey:          "sk-or-opencode",
+						BackingProvider: models.ProviderOpenRouter,
+					},
+				},
+			},
+		},
+	}
+
+	var capturedCfg agent.SandboxConfig
+	d.provider.CreateFn = func(ctx context.Context, cfg agent.SandboxConfig) (*agent.Sandbox, error) {
+		capturedCfg = cfg
+		return &agent.Sandbox{ID: "opencode-route", Provider: "mock", WorkDir: "/workspace"}, nil
+	}
+
+	err := buildOrchestrator(d).RunAgent(context.Background(), run)
+	require.NoError(t, err, "RunAgent should execute with an OpenRouter-backed OpenCode credential")
+	require.Equal(t, "sk-or-opencode", capturedCfg.Env["OPENROUTER_API_KEY"], "OpenCode should use the OpenRouter-backed credential")
+	require.Equal(t, models.OpenCodeModelOpenRouterGLM52, capturedCfg.Env["OPENCODE_MODEL"], "logical OpenCode overrides should resolve to the physical OpenRouter route before reaching the sandbox")
+	require.NotEqual(t, models.DefaultOpenCodeModel, capturedCfg.Env["OPENCODE_MODEL"], "the sandbox must not receive a bare logical OpenCode model id")
+	require.Contains(t, capturedCfg.Env["OPENCODE_CONFIG_CONTENT"], models.OpenCodeModelOpenRouterGLM52, "OpenCode runtime config should match the resolved physical model")
+}
+
 // --- Amp/Pi agent env resolution ---
 
 // TestRunAgent_AmpCredentialEnv asserts that Amp sessions receive auth from


### PR DESCRIPTION
## Summary
- Route OpenCode model overrides through the resolved physical provider/model before sandbox startup.
- Centralize direct override env injection so OpenCode sessions do not receive a bare logical model id.
- Add coverage for OpenCode runs backed by OpenRouter credentials.

## Testing
- Added a focused orchestrator test covering OpenCode model override resolution and sandbox env propagation.
- Existing orchestrator test suite continues to pass for the affected flow.