### PR TITLE
Update public docs to remove non-canonical repo/infrastructure references

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,12 @@ See the [development setup guide](docs/contributing/development-setup.md) for th
 
 Start with [docs/self-hosting/](docs/self-hosting/README.md). The hosted version at [143.dev](https://www.143.dev) is the managed path; hosted billing is based on container runtime minutes, and 143 does not mark up LLM usage.
 
+## Hosted vs self-hosted
+
+The open-source repo contains the application code, Dockerfiles, migrations, local development setup, single-node self-hosting path, public docs, and the reusable operational scripts needed to run your own 143 deployment.
+
+The production deployment for the managed 143.dev service is Assembled-operated. Workflows and scripts that reference Assembled's private infrastructure, encrypted production env bundles, deploy keys, fleet hosts, or `assembledhq/143-infra` are for the hosted service and are not required for ordinary self-hosting.
+
 ## Contributing
 
 If you want to work on the product, read the [development setup guide](docs/contributing/development-setup.md) and the [design overview](docs/design/overall.md). The design docs are intentionally part of the repo because a lot of the product decisions are architectural, not just UI copy.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -37,12 +37,16 @@ Out of scope:
 
 Please do **not** open a public GitHub issue for security vulnerabilities.
 
-**Preferred channel:**
+**Preferred open-source channel:**
 
 - Use GitHub's private security advisory reporting flow:
   [`github.com/assembledhq/143/security/advisories/new`](https://github.com/assembledhq/143/security/advisories/new)
 
-**Alternative channel:**
+This is the best path for vulnerabilities in the open-source codebase because
+it keeps the report private while preserving the advisory, patch, credit, and
+release workflow in GitHub.
+
+**Hosted-service fallback:**
 
 - Email [`security@assembled.com`](mailto:security@assembled.com)
 
@@ -157,8 +161,8 @@ release notes, and a SECURITY_ACKNOWLEDGMENTS file after a fix is available.
 
 | Channel | Address |
 |---------|---------|
-| **Security advisories** (preferred) | [`github.com/assembledhq/143/security/advisories/new`](https://github.com/assembledhq/143/security/advisories/new) |
-| **Email** | [`security@assembled.com`](mailto:security@assembled.com) |
+| **Open-source security advisories** (preferred) | [`github.com/assembledhq/143/security/advisories/new`](https://github.com/assembledhq/143/security/advisories/new) |
+| **Hosted-service fallback email** | [`security@assembled.com`](mailto:security@assembled.com) |
 
 For non-security bugs, please open a regular [GitHub issue](https://github.com/assembledhq/143/issues).
 

--- a/docs/public/reference/agent-tools.mdx
+++ b/docs/public/reference/agent-tools.mdx
@@ -425,7 +425,7 @@ Create or reuse a preview.
 
 ```bash
 143-tools preview create --session-id "$143_SESSION_ID" --wait
-143-tools preview create --repository assembledhq/143 --branch feature/foo --wait
+143-tools preview create --repository example-org/example-app --branch feature/foo --wait
 ```
 
 ### `preview status`


### PR DESCRIPTION
## Summary

Public documentation was steering self-hosters and contributors toward non-canonical repositories and hosted-only infrastructure details, creating a reliability risk (commands/workflows that won’t work) and developer confusion. This change clarifies the hosted vs self-hosted split and updates the public CLI example to use a neutral repository placeholder, while rewording security guidance to emphasize the correct open-source intake path.

## Changes

- Added a “Hosted vs self-hosted” section to README to separate open-source deployment materials from Assembled-operated hosted infrastructure references (private env bundles, deploy keys, fleet hosts, infra repo).
- Clarified SECURITY.md “Preferred open-source channel” wording to consistently point reporters to GitHub private security advisories for the open-source codebase, with an explicit hosted fallback email.
- Updated `docs/public/reference/agent-tools.mdx` CLI example to use a generic `example-org/example-app` repository instead of the original internal `assembledhq/143` reference.

## Validation

- Reviewed the Markdown/MDX changes for correctness and consistency with the intended documentation scope.
- Verified there were no code or workflow changes—only documentation text/examples were updated.

[143.dev](https://143.dev) | [session 88a0fa1a](https://143.dev/sessions/88a0fa1a-02b4-4793-9558-c49959051ef3)

<!-- 143 readiness -->
**143 readiness:** not available for this revision.

Preview: https://143.dev/previews/github/assembledhq/143/pull/1746?launch=1