### PR TITLE
[codex] Capture OpenCode failure logs

### DIFF
--- a/internal/services/agent/adapters/opencode.go
+++ b/internal/services/agent/adapters/opencode.go
@@ -3,9 +3,13 @@
 package adapters
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
 	"time"
 
 	"github.com/rs/zerolog"
@@ -65,7 +69,11 @@ func (a *OpenCodeAdapter) PreparePrompt(ctx context.Context, input *agent.AgentI
 
 // Execute runs the OpenCode CLI inside the sandbox and streams output.
 func (a *OpenCodeAdapter) Execute(ctx context.Context, sandbox *agent.Sandbox, prompt *agent.AgentPrompt, logCh chan<- agent.LogEntry) (*agent.AgentResult, error) {
-	return runStreamingAgent(ctx, openCodeStreamingConfig, a.logger, sandbox, prompt, logCh)
+	result, err := runStreamingAgent(ctx, openCodeStreamingConfig, a.logger, sandbox, prompt, logCh)
+	if err != nil || (result != nil && (result.ExitCode != 0 || result.Error != "")) {
+		captureOpenCodeFailureLogs(ctx, sandbox, a.logger, logCh)
+	}
+	return result, err
 }
 
 var openCodeStreamingConfig = streamingAgentConfig{
@@ -106,7 +114,7 @@ type openCodeStreamEvent struct {
 	Input          json.RawMessage `json:"input,omitempty"`
 	Output         string          `json:"output,omitempty"`
 	Result         json.RawMessage `json:"result,omitempty"`
-	Error          string          `json:"error,omitempty"`
+	Error          json.RawMessage `json:"error,omitempty"`
 	ID             string          `json:"id,omitempty"`
 	SessionID      string          `json:"session_id,omitempty"`
 	SessionIDCamel string          `json:"sessionID,omitempty"`
@@ -188,7 +196,10 @@ func parseOpenCodeStreamLine(line []byte, result *agent.AgentResult, logCh chan<
 		}
 		logCh <- agent.LogEntry{Timestamp: time.Now(), Level: "info", Message: firstNonEmpty(event.Content, event.Message)}
 	case "error":
-		result.Error = firstNonEmpty(event.Error, event.Message, event.Content, "unknown error")
+		if sessionID := firstNonEmpty(event.SessionID, event.SessionIDCamel, event.ID); sessionID != "" {
+			result.AgentSessionID = sessionID
+		}
+		result.Error = firstNonEmpty(openCodeEventErrorMessage(event), event.Message, event.Content, "unknown error")
 		logCh <- agent.LogEntry{Timestamp: time.Now(), Level: "error", Message: result.Error}
 	case "permission", "permission_request":
 		result.Error = openCodePermissionError(event)
@@ -199,7 +210,7 @@ func parseOpenCodeStreamLine(line []byte, result *agent.AgentResult, logCh chan<
 }
 
 func openCodePermissionError(event openCodeStreamEvent) string {
-	message := firstNonEmpty(event.Error, event.Message, event.Content)
+	message := firstNonEmpty(openCodeEventErrorMessage(event), event.Message, event.Content)
 	if message != "" {
 		return "OpenCode requested interactive permission: " + message
 	}
@@ -207,4 +218,194 @@ func openCodePermissionError(event openCodeStreamEvent) string {
 		return "OpenCode requested interactive permission for " + tool
 	}
 	return "OpenCode requested interactive permission"
+}
+
+type openCodeErrorPayload struct {
+	Name    string `json:"name"`
+	Message string `json:"message"`
+	Ref     string `json:"ref"`
+	Data    struct {
+		Message string `json:"message"`
+		Ref     string `json:"ref"`
+	} `json:"data"`
+}
+
+func openCodeEventErrorMessage(event openCodeStreamEvent) string {
+	raw := bytes.TrimSpace(event.Error)
+	if len(raw) == 0 || bytes.Equal(raw, []byte("null")) {
+		return ""
+	}
+
+	var text string
+	if err := json.Unmarshal(raw, &text); err == nil {
+		return strings.TrimSpace(text)
+	}
+
+	var payload openCodeErrorPayload
+	if err := json.Unmarshal(raw, &payload); err != nil {
+		return string(raw)
+	}
+
+	name := strings.TrimSpace(payload.Name)
+	message := strings.TrimSpace(firstNonEmpty(payload.Message, payload.Data.Message))
+	ref := strings.TrimSpace(firstNonEmpty(payload.Ref, payload.Data.Ref))
+
+	switch {
+	case name != "" && message != "":
+		text = name + ": " + message
+	case message != "":
+		text = message
+	case name != "":
+		text = name
+	default:
+		text = string(raw)
+	}
+	if ref != "" {
+		text += " (ref: " + ref + ")"
+	}
+	return text
+}
+
+const (
+	openCodeFailureLogMaxFiles = 3
+	openCodeFailureLogMaxBytes = 64 * 1024
+)
+
+var (
+	openCodeBearerSecretPattern         = regexp.MustCompile(`(?i)\bBearer\s+[A-Za-z0-9._~+/=-]+`)
+	openCodeQuotedSecretPattern         = regexp.MustCompile(`(?i)(["'])([A-Za-z0-9_.-]*(?:api[_-]?key|authorization|token|secret|password)[A-Za-z0-9_.-]*)(["']\s*:\s*["'])[^"']*(["'])`)
+	openCodeAssignedQuotedSecretPattern = regexp.MustCompile(`(?i)\b([A-Za-z0-9_.-]*(?:api[_-]?key|authorization|token|secret|password)[A-Za-z0-9_.-]*)(\s*[:=]\s*["'])[^"']*(["'])`)
+	openCodeNamedSecretPattern          = regexp.MustCompile(`(?i)\b([A-Za-z0-9_.-]*(?:api[_-]?key|authorization|token|secret|password)[A-Za-z0-9_.-]*)(\s*[:=]\s*)[^"'\s,}]+`)
+	openCodeSecretPatterns              = []*regexp.Regexp{
+		regexp.MustCompile(`sk-or-v1-[A-Za-z0-9_-]+`),
+		regexp.MustCompile(`sk-or-[A-Za-z0-9_-]+`),
+		regexp.MustCompile(`sk-ant-[A-Za-z0-9_-]+`),
+		regexp.MustCompile(`sk-[A-Za-z0-9_-]{20,}`),
+		regexp.MustCompile(`AIza[0-9A-Za-z_-]{20,}`),
+		regexp.MustCompile(`ghp_[A-Za-z0-9_]{20,}`),
+		regexp.MustCompile(`github_pat_[A-Za-z0-9_]+`),
+		regexp.MustCompile(`xai-[A-Za-z0-9_-]{20,}`),
+	}
+)
+
+func captureOpenCodeFailureLogs(ctx context.Context, sandbox *agent.Sandbox, logger zerolog.Logger, logCh chan<- agent.LogEntry) {
+	provider := agent.SandboxProviderFromContext(ctx)
+	if provider == nil || sandbox == nil || strings.TrimSpace(sandbox.HomeDir) == "" {
+		return
+	}
+
+	logPaths, err := listOpenCodeFailureLogPaths(ctx, provider, sandbox)
+	if err != nil {
+		logger.Warn().Err(err).Msg("failed to list OpenCode failure logs")
+		return
+	}
+	for _, logPath := range logPaths {
+		raw, originalBytes, truncated, err := readOpenCodeFailureLogTail(ctx, provider, sandbox, logPath)
+		if err != nil {
+			logger.Warn().Err(err).Str("path", logPath).Msg("failed to read OpenCode failure log")
+			continue
+		}
+
+		content := strings.TrimSpace(redactOpenCodeDiagnosticLog(string(raw)))
+		if content == "" {
+			content = "<empty OpenCode log file>"
+		}
+
+		scope := "full"
+		if truncated {
+			scope = fmt.Sprintf("last %d bytes", openCodeFailureLogMaxBytes)
+		}
+
+		logCh <- agent.LogEntry{
+			Timestamp: time.Now(),
+			Level:     "error",
+			Message:   fmt.Sprintf("OpenCode failure log (%s, %s):\n%s", logPath, scope, content),
+			Metadata: map[string]interface{}{
+				"source":         "opencode_log",
+				"diagnostic":     "opencode_failure_log",
+				"path":           logPath,
+				"truncated":      truncated,
+				"original_bytes": originalBytes,
+			},
+		}
+	}
+}
+
+func readOpenCodeFailureLogTail(ctx context.Context, provider agent.SandboxProvider, sandbox *agent.Sandbox, logPath string) ([]byte, int, bool, error) {
+	escapedLogPath := shellEscapeSingle(logPath)
+
+	var sizeStdout, sizeStderr bytes.Buffer
+	sizeCmd := fmt.Sprintf("wc -c < '%s'", escapedLogPath)
+	sizeExit, err := provider.Exec(ctx, sandbox, sizeCmd, &sizeStdout, &sizeStderr)
+	if err != nil {
+		return nil, 0, false, fmt.Errorf("stat OpenCode log file: %w", err)
+	}
+	if sizeExit != 0 {
+		return nil, 0, false, fmt.Errorf("stat OpenCode log file exited with code %d: %s", sizeExit, strings.TrimSpace(sizeStderr.String()))
+	}
+
+	originalBytes, err := strconv.Atoi(strings.TrimSpace(sizeStdout.String()))
+	if err != nil {
+		return nil, 0, false, fmt.Errorf("parse OpenCode log file size %q: %w", strings.TrimSpace(sizeStdout.String()), err)
+	}
+
+	var tailStdout, tailStderr bytes.Buffer
+	tailCmd := fmt.Sprintf("tail -c %d '%s'", openCodeFailureLogMaxBytes, escapedLogPath)
+	tailExit, err := provider.Exec(ctx, sandbox, tailCmd, &tailStdout, &tailStderr)
+	if err != nil {
+		return nil, originalBytes, false, fmt.Errorf("tail OpenCode log file: %w", err)
+	}
+	if tailExit != 0 {
+		return nil, originalBytes, false, fmt.Errorf("tail OpenCode log file exited with code %d: %s", tailExit, strings.TrimSpace(tailStderr.String()))
+	}
+
+	return tailStdout.Bytes(), originalBytes, originalBytes > openCodeFailureLogMaxBytes, nil
+}
+
+func listOpenCodeFailureLogPaths(ctx context.Context, provider agent.SandboxProvider, sandbox *agent.Sandbox) ([]string, error) {
+	logDir := strings.TrimRight(sandbox.HomeDir, "/") + "/.local/share/opencode/log"
+	escapedLogDir := shellEscapeSingle(logDir)
+	cmd := fmt.Sprintf(
+		"if [ -d '%s' ]; then find '%s' -maxdepth 1 -type f -printf '%%T@ %%p\\n' 2>/dev/null | sort -nr | head -n %d | cut -d' ' -f2-; fi",
+		escapedLogDir,
+		escapedLogDir,
+		openCodeFailureLogMaxFiles,
+	)
+
+	var stdout, stderr bytes.Buffer
+	exitCode, err := provider.Exec(ctx, sandbox, cmd, &stdout, &stderr)
+	if err != nil {
+		return nil, fmt.Errorf("discover OpenCode log files: %w", err)
+	}
+	if exitCode != 0 {
+		return nil, fmt.Errorf("discover OpenCode log files exited with code %d: %s", exitCode, strings.TrimSpace(stderr.String()))
+	}
+
+	var paths []string
+	for _, line := range strings.Split(stdout.String(), "\n") {
+		path := strings.TrimSpace(line)
+		if path == "" {
+			continue
+		}
+		if path != logDir && !strings.HasPrefix(path, logDir+"/") {
+			continue
+		}
+		paths = append(paths, path)
+		if len(paths) >= openCodeFailureLogMaxFiles {
+			break
+		}
+	}
+	return paths, nil
+}
+
+func redactOpenCodeDiagnosticLog(input string) string {
+	output := strings.ReplaceAll(input, "\x00", "")
+	output = openCodeBearerSecretPattern.ReplaceAllString(output, "Bearer [REDACTED]")
+	output = openCodeQuotedSecretPattern.ReplaceAllString(output, "${1}${2}${3}[REDACTED]${4}")
+	output = openCodeAssignedQuotedSecretPattern.ReplaceAllString(output, "${1}${2}[REDACTED]${3}")
+	output = openCodeNamedSecretPattern.ReplaceAllString(output, "${1}${2}[REDACTED]")
+	for _, pattern := range openCodeSecretPatterns {
+		output = pattern.ReplaceAllString(output, "[REDACTED]")
+	}
+	return output
 }

--- a/internal/services/agent/adapters/opencode_test.go
+++ b/internal/services/agent/adapters/opencode_test.go
@@ -2,6 +2,9 @@ package adapters
 
 import (
 	"bufio"
+	"context"
+	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -184,14 +187,21 @@ func TestParseOpenCodeStreamLine_ErrorAndPermissionEvents(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name          string
-		line          string
-		expectedError string
+		name              string
+		line              string
+		expectedError     string
+		expectedSessionID string
 	}{
 		{
 			name:          "terminal error sets result error",
 			line:          `{"type":"error","error":"rate limited"}`,
 			expectedError: "rate limited",
+		},
+		{
+			name:              "terminal object error preserves message ref and session",
+			line:              `{"type":"error","sessionID":"ses_opencode","error":{"name":"UnknownError","data":{"message":"Unexpected server error. Check server logs for details.","ref":"err_123"}}}`,
+			expectedError:     "UnknownError: Unexpected server error. Check server logs for details. (ref: err_123)",
+			expectedSessionID: "ses_opencode",
 		},
 		{
 			name:          "permission event fails fast",
@@ -219,8 +229,191 @@ func TestParseOpenCodeStreamLine_ErrorAndPermissionEvents(t *testing.T) {
 
 			logs := drain(logCh)
 			require.Equal(t, tt.expectedError, result.Error, "OpenCode parser should convert terminal failures into result errors")
+			require.Equal(t, tt.expectedSessionID, result.AgentSessionID, "OpenCode parser should preserve session ids from terminal failures")
 			require.Len(t, logs, 1, "OpenCode parser should emit one log for failures")
 			require.Equal(t, "error", logs[0].Level, "OpenCode parser should log failures at error level")
 		})
 	}
+}
+
+func TestCaptureOpenCodeFailureLogs_RedactsAndEmitsLatestLogs(t *testing.T) {
+	t.Parallel()
+
+	const (
+		newLogPath = "/home/sandbox/.local/share/opencode/log/new.log"
+		oldLogPath = "/home/sandbox/.local/share/opencode/log/old.log"
+	)
+	sandbox := &agent.Sandbox{ID: "test", WorkDir: "/workspace", HomeDir: "/home/sandbox"}
+	provider := newMockProvider()
+	provider.Files[newLogPath] = []byte("request failed\nauthorization: Bearer sk-or-v1-secret\napi_key=\"AIzaabcdefghijklmnopqrstuvwxyz\"\n{\"token\":\"plain-json-token-value\",\"OPENROUTER_API_KEY\":\"plain-json-openrouter\"}\nOPENROUTER_API_KEY=plain-env-openrouter\nOPENROUTER_API_KEY=\"plain env key with spaces\"\n")
+	provider.Files[oldLogPath] = []byte("old log")
+	provider.ReadFileFn = func(ctx context.Context, sb *agent.Sandbox, path string) ([]byte, error) {
+		require.FailNow(t, "OpenCode log capture should use bounded tail commands instead of reading full files")
+		return nil, nil
+	}
+	provider.ExecFn = func(ctx context.Context, sb *agent.Sandbox, cmd string, stdout, stderr io.Writer) (int, error) {
+		require.Contains(t, cmd, "/home/sandbox/.local/share/opencode/log", "OpenCode log discovery should inspect the sandbox log directory")
+		if writeMockOpenCodeLogExec(t, cmd, stdout, provider.Files, []string{newLogPath, "/home/sandbox/not-opencode.log", oldLogPath}) {
+			return 0, nil
+		}
+		require.FailNow(t, "OpenCode log capture should only issue discovery, size, and tail commands", "cmd: %s", cmd)
+		return 0, nil
+	}
+
+	logCh := make(chan agent.LogEntry, 4)
+	ctx := WithSandboxProvider(context.Background(), provider)
+
+	captureOpenCodeFailureLogs(ctx, sandbox, zerolog.Nop(), logCh)
+	close(logCh)
+
+	logs := drain(logCh)
+	require.Len(t, logs, 2, "OpenCode log capture should emit logs only for files under the OpenCode log directory")
+	require.Equal(t, "error", logs[0].Level, "OpenCode diagnostic logs should be emitted at error level for failed runs")
+	require.Contains(t, logs[0].Message, "request failed", "OpenCode diagnostic log should include the captured log content")
+	require.NotContains(t, logs[0].Message, "sk-or-v1-secret", "OpenCode diagnostic log should redact OpenRouter keys")
+	require.NotContains(t, logs[0].Message, "AIzaabcdefghijklmnopqrstuvwxyz", "OpenCode diagnostic log should redact Google API keys")
+	require.NotContains(t, logs[0].Message, "plain-json-token-value", "OpenCode diagnostic log should redact quoted token values")
+	require.NotContains(t, logs[0].Message, "plain-json-openrouter", "OpenCode diagnostic log should redact quoted API key values")
+	require.NotContains(t, logs[0].Message, "plain-env-openrouter", "OpenCode diagnostic log should redact env-style API key values")
+	require.NotContains(t, logs[0].Message, "plain env key with spaces", "OpenCode diagnostic log should redact quoted env-style API key values")
+	require.Contains(t, logs[0].Message, `"token":"[REDACTED]"`, "OpenCode diagnostic log should preserve quoted token keys while redacting values")
+	require.Contains(t, logs[0].Message, `"OPENROUTER_API_KEY":"[REDACTED]"`, "OpenCode diagnostic log should preserve quoted API key names while redacting values")
+	require.Contains(t, logs[0].Message, "OPENROUTER_API_KEY=[REDACTED]", "OpenCode diagnostic log should preserve env-style key names while redacting values")
+	require.Contains(t, logs[0].Message, "OPENROUTER_API_KEY=\"[REDACTED]\"", "OpenCode diagnostic log should preserve quoted env-style key names while redacting values")
+	require.Contains(t, logs[0].Message, "api_key=\"[REDACTED]\"", "OpenCode diagnostic log should preserve key names while redacting values")
+	require.Equal(t, "opencode_log", logs[0].Metadata["source"], "OpenCode diagnostic log should identify its source")
+	require.Equal(t, "opencode_failure_log", logs[0].Metadata["diagnostic"], "OpenCode diagnostic log should identify diagnostic kind")
+	require.Equal(t, newLogPath, logs[0].Metadata["path"], "OpenCode diagnostic log should record the source file path")
+	require.Equal(t, false, logs[0].Metadata["truncated"], "small OpenCode diagnostic logs should not be marked truncated")
+}
+
+func TestOpenCodeAdapter_Execute_CapturesFailureLogs(t *testing.T) {
+	t.Parallel()
+
+	const logPath = "/home/sandbox/.local/share/opencode/log/server.log"
+	sandbox := &agent.Sandbox{
+		ID:      "test",
+		WorkDir: "/workspace",
+		HomeDir: "/home/sandbox",
+		Metadata: map[string]string{
+			agent.SandboxMetadataBaseCommitSHA: "abc123",
+		},
+	}
+	provider := newMockProvider()
+	provider.Files[logPath] = []byte("local OpenCode server stack trace\n")
+	provider.ReadFileFn = func(ctx context.Context, sb *agent.Sandbox, path string) ([]byte, error) {
+		require.FailNow(t, "OpenCode failure capture should use bounded tail commands instead of reading full files")
+		return nil, nil
+	}
+	provider.ExecStreamFn = func(ctx context.Context, sb *agent.Sandbox, cmd string, onLine func(line []byte), stderr io.Writer) (int, error) {
+		require.Contains(t, cmd, "opencode run", "OpenCode adapter should execute the OpenCode CLI")
+		onLine([]byte(`{"type":"error","sessionID":"ses_opencode","error":{"name":"UnknownError","data":{"message":"Unexpected server error. Check server logs for details.","ref":"err_123"}}}`))
+		return 1, nil
+	}
+	provider.ExecFn = func(ctx context.Context, sb *agent.Sandbox, cmd string, stdout, stderr io.Writer) (int, error) {
+		switch {
+		case writeMockOpenCodeLogExec(t, cmd, stdout, provider.Files, []string{logPath}):
+		case strings.HasPrefix(cmd, "git rev-parse"):
+			_, _ = stdout.Write([]byte("true\n"))
+		case strings.HasPrefix(cmd, "git diff"):
+			_, _ = stdout.Write([]byte(""))
+		}
+		return 0, nil
+	}
+
+	adapter := NewOpenCodeAdapter(zerolog.Nop())
+	logCh := make(chan agent.LogEntry, 16)
+	ctx := WithSandboxProvider(context.Background(), provider)
+
+	result, err := adapter.Execute(ctx, sandbox, &agent.AgentPrompt{
+		SystemPrompt: "Fix it.",
+		UserPrompt:   "Bug.",
+		MaxTokens:    50_000,
+	}, logCh)
+	require.NoError(t, err, "OpenCode execution should return a result for CLI non-zero exits")
+	require.NotNil(t, result, "OpenCode execution should return the non-zero result")
+	require.Equal(t, 1, result.ExitCode, "OpenCode execution should preserve the CLI exit code")
+	require.Contains(t, result.Error, "opencode CLI exited with code 1", "OpenCode execution should surface the non-zero exit")
+	require.Contains(t, result.Error, "UnknownError: Unexpected server error. Check server logs for details. (ref: err_123)", "OpenCode execution should preserve parsed terminal error details")
+	close(logCh)
+
+	logs := drain(logCh)
+	var capturedLog *agent.LogEntry
+	for i := range logs {
+		if logs[i].Metadata["source"] == "opencode_log" {
+			capturedLog = &logs[i]
+			break
+		}
+	}
+	require.NotNil(t, capturedLog, "OpenCode execution should attach local OpenCode logs after failures")
+	require.Contains(t, capturedLog.Message, "local OpenCode server stack trace", "captured OpenCode log should include local server diagnostics")
+	require.Equal(t, logPath, capturedLog.Metadata["path"], "captured OpenCode log should record the source log file")
+}
+
+func TestCaptureOpenCodeFailureLogs_TruncatesLargeLogs(t *testing.T) {
+	t.Parallel()
+
+	const largeLogPath = "/home/sandbox/.local/share/opencode/log/large.log"
+	sandbox := &agent.Sandbox{ID: "test", WorkDir: "/workspace", HomeDir: "/home/sandbox"}
+	provider := newMockProvider()
+	provider.Files[largeLogPath] = []byte(strings.Repeat("a", openCodeFailureLogMaxBytes+10) + "tail")
+	provider.ReadFileFn = func(ctx context.Context, sb *agent.Sandbox, path string) ([]byte, error) {
+		require.FailNow(t, "OpenCode log capture should not read oversized log files in full")
+		return nil, nil
+	}
+	provider.ExecFn = func(ctx context.Context, sb *agent.Sandbox, cmd string, stdout, stderr io.Writer) (int, error) {
+		if writeMockOpenCodeLogExec(t, cmd, stdout, provider.Files, []string{largeLogPath}) {
+			return 0, nil
+		}
+		require.FailNow(t, "OpenCode log capture should only issue discovery, size, and tail commands", "cmd: %s", cmd)
+		return 0, nil
+	}
+
+	logCh := make(chan agent.LogEntry, 2)
+	ctx := WithSandboxProvider(context.Background(), provider)
+
+	captureOpenCodeFailureLogs(ctx, sandbox, zerolog.Nop(), logCh)
+	close(logCh)
+
+	logs := drain(logCh)
+	require.Len(t, logs, 1, "OpenCode log capture should emit the large log")
+	require.Contains(t, logs[0].Message, "tail", "OpenCode diagnostic log should keep the end of oversized logs")
+	require.Equal(t, true, logs[0].Metadata["truncated"], "oversized OpenCode diagnostic logs should be marked truncated")
+	require.Equal(t, openCodeFailureLogMaxBytes+14, logs[0].Metadata["original_bytes"], "OpenCode diagnostic log should record original byte size")
+}
+
+func writeMockOpenCodeLogExec(t *testing.T, cmd string, stdout io.Writer, files map[string][]byte, listedPaths []string) bool {
+	t.Helper()
+
+	switch {
+	case strings.HasPrefix(cmd, "if [ -d "):
+		_, _ = stdout.Write([]byte(strings.Join(listedPaths, "\n") + "\n"))
+		return true
+	case strings.HasPrefix(cmd, "wc -c < "):
+		path := mockOpenCodeLogPathForCommand(t, cmd, listedPaths)
+		fmt.Fprintf(stdout, "%d\n", len(files[path]))
+		return true
+	case strings.HasPrefix(cmd, "tail -c "):
+		path := mockOpenCodeLogPathForCommand(t, cmd, listedPaths)
+		data := files[path]
+		if len(data) > openCodeFailureLogMaxBytes {
+			data = data[len(data)-openCodeFailureLogMaxBytes:]
+		}
+		_, _ = stdout.Write(data)
+		return true
+	default:
+		return false
+	}
+}
+
+func mockOpenCodeLogPathForCommand(t *testing.T, cmd string, paths []string) string {
+	t.Helper()
+
+	for _, path := range paths {
+		if strings.Contains(cmd, "'"+path+"'") {
+			return path
+		}
+	}
+	require.FailNow(t, "OpenCode log command should target a listed log path", "cmd: %s", cmd)
+	return ""
 }

--- a/internal/services/agent/adapters/stream_parser.go
+++ b/internal/services/agent/adapters/stream_parser.go
@@ -354,14 +354,18 @@ func runStreamingAgent(
 	}
 
 	if exitCode != 0 {
+		parsedError := strings.TrimSpace(result.Error)
 		result.Error = fmt.Sprintf("%s CLI exited with code %d", cfg.CLIName, exitCode)
 		errorDetail := strings.TrimSpace(string(stderr))
 		if errorDetail == "" {
+			if parsedError != "" {
+				errorDetail = parsedError
+			}
 			// TTY transports merge stderr into the visible output stream, so
 			// preserve the last visible line as the best-effort failure detail.
-			if len(summaryParts) > 0 {
+			if errorDetail == "" && len(summaryParts) > 0 {
 				errorDetail = strings.TrimSpace(summaryParts[len(summaryParts)-1])
-			} else if lastAssistantContent != "" {
+			} else if errorDetail == "" && lastAssistantContent != "" {
 				errorDetail = strings.TrimSpace(lastAssistantContent)
 			}
 		}


### PR DESCRIPTION
## Summary

Captures OpenCode local server logs after failed OpenCode runs so generic `UnknownError` failures include useful diagnostics in session logs.

## What changed

- Capture up to the latest three files from `~/.local/share/opencode/log` when OpenCode exits with an error.
- Read only a bounded tail of each log file and preserve original byte size/truncation metadata.
- Redact bearer tokens, provider keys, quoted JSON secret fields, and env-style secret assignments before persisting diagnostic logs.
- Parse object-shaped OpenCode error events so `UnknownError` messages and refs are surfaced instead of being treated as malformed stream output.
- Preserve parsed stream error details when the shared streaming runner reports non-zero CLI exits.

## Impact

Failed OpenCode sessions should now include actionable, redacted local diagnostic context in the normal run logs, without reading unbounded log files into memory.

## Validation

- `go test ./internal/services/agent/adapters`
- `go vet ./internal/services/agent/adapters`