### PR TITLE
[codex] Reject PR pushes when base branch history is unrelated

### DIFF
--- a/internal/services/github/pr.go
+++ b/internal/services/github/pr.go
@@ -353,6 +353,12 @@ const (
 	// tree. This blocks a stale or start-over checkpoint from wiping out
 	// someone else's commits through --force-with-lease.
 	PushBranchDivergedPRMessage = "The PR branch has changes that are not in this session checkpoint. Pull the latest PR branch into the session before pushing again."
+	// BaseBranchUnrelatedPRMessage is shown when the repository's current PR
+	// base branch no longer shares git history with the session checkpoint.
+	// This usually means the repo history was rewritten after the session
+	// started. Refuse before pushing so stale private-history branches do not
+	// get published only to fail at GitHub's create-PR API.
+	BaseBranchUnrelatedPRMessage = "The repository's base branch could not be found or no longer shares history with this session. Recreate or rebase the session on the current base branch, then create the PR again."
 	// SandboxAuthUnavailablePRMessage is shown when 143 cannot prepare the
 	// sandbox credential socket needed for git push. Keep it distinct from the
 	// GitHub permissions fallback because these failures are often runtime or
@@ -422,6 +428,12 @@ var ErrPushRejected = errors.New("git push rejected by remote")
 // intentionally distinct from ErrPushRejected: the lease may be fresh, but the
 // local snapshot is still stale and must not overwrite the remote tree.
 var ErrPushBranchDiverged = errors.New("remote branch diverged from session snapshot")
+
+// ErrBaseBranchUnrelated is returned before pushing when the repository's
+// current PR base branch has no merge-base with the hydrated session branch.
+// GitHub would reject the PR after the push with "no history in common"; this
+// sentinel prevents publishing the stale branch first.
+var ErrBaseBranchUnrelated = errors.New("base branch has no history in common with session branch")
 
 // ErrSandboxAuthUnavailable is returned when the host cannot prepare the
 // sandbox credential socket used by git-credential. This is a 143 runtime/auth
@@ -541,10 +553,24 @@ type CreateBranchResult struct {
 	HeadSHA string
 }
 
+func targetBranchForPR(run *models.Session, repo *models.Repository) string {
+	if run != nil && run.TargetBranch != nil {
+		if branch := strings.TrimSpace(*run.TargetBranch); branch != "" {
+			return branch
+		}
+	}
+	if repo != nil {
+		if branch := strings.TrimSpace(repo.DefaultBranch); branch != "" {
+			return branch
+		}
+	}
+	return "main"
+}
+
 // CreatePR opens a GitHub PR from a completed agent session by restoring the
 // session's sandbox snapshot, committing any uncommitted changes, pushing to
-// a new remote branch, and opening a pull request against the repo's default
-// branch via the REST API.
+// a new remote branch, and opening a pull request against the session target
+// branch (falling back to the repo default branch) via the REST API.
 //
 // Pushing directly from the restored working tree preserves file modes,
 // symlinks, binaries, and `.gitattributes` normalization — all lost by the
@@ -649,10 +675,7 @@ func (s *PRService) CreatePR(ctx context.Context, run *models.Session, params ..
 	token := resolution.Token
 
 	owner, repoName := splitRepo(repo.FullName)
-	defaultBranch := repo.DefaultBranch
-	if defaultBranch == "" {
-		defaultBranch = "main"
-	}
+	defaultBranch := targetBranchForPR(run, &repo)
 
 	branchName := formatBranchName(run, issue)
 	commitMsg := formatCommitMessage(run, issue)
@@ -667,7 +690,7 @@ func (s *PRService) CreatePR(ctx context.Context, run *models.Session, params ..
 		}
 	}
 
-	pushed, err := s.pushSessionBranch(ctx, run, &repo, orgSettings, *run.SnapshotKey, branchName, commitMsg, authorName, authorEmail)
+	pushed, err := s.pushSessionBranch(ctx, run, &repo, orgSettings, *run.SnapshotKey, branchName, defaultBranch, commitMsg, authorName, authorEmail)
 	if err != nil {
 		return nil, err
 	}
@@ -882,7 +905,8 @@ func (s *PRService) CreateBranch(ctx context.Context, run *models.Session, param
 		}
 	}
 
-	pushed, err := s.pushSessionBranch(ctx, run, &repo, orgSettings, *run.SnapshotKey, branchName, commitMsg, authorName, authorEmail)
+	baseBranch := targetBranchForPR(run, &repo)
+	pushed, err := s.pushSessionBranch(ctx, run, &repo, orgSettings, *run.SnapshotKey, branchName, baseBranch, commitMsg, authorName, authorEmail)
 	if err != nil {
 		return nil, err
 	}
@@ -1044,7 +1068,7 @@ func (s *PRService) PushChangesToPR(ctx context.Context, run *models.Session, pa
 		}
 	}
 
-	pushed, err := s.pushSessionBranch(ctx, run, &repo, orgSettings, *run.SnapshotKey, branchName, commitMsg, authorName, authorEmail)
+	pushed, err := s.pushSessionBranch(ctx, run, &repo, orgSettings, *run.SnapshotKey, branchName, "", commitMsg, authorName, authorEmail)
 	if err != nil {
 		return nil, err
 	}
@@ -1236,7 +1260,7 @@ func (s *PRService) pushSessionBranch(
 	run *models.Session,
 	repo *models.Repository,
 	orgSettings models.OrgSettings,
-	snapshotKey, branchName, commitMsg, authorName, authorEmail string,
+	snapshotKey, branchName, baseBranch, commitMsg, authorName, authorEmail string,
 ) (*pushResult, error) {
 	if s.sandboxAuth == nil {
 		return nil, fmt.Errorf("%w: sandbox auth socket not configured", ErrSandboxAuthUnavailable)
@@ -1295,7 +1319,7 @@ func (s *PRService) pushSessionBranch(
 	}
 
 	pushURL := fmt.Sprintf("https://github.com/%s.git", repo.FullName)
-	script := buildPushScript(sandbox.WorkDir, commitMsgPath, authorName, authorEmail, branchName, pushURL)
+	script := buildPushScript(sandbox.WorkDir, commitMsgPath, authorName, authorEmail, branchName, baseBranch, pushURL)
 
 	var stdout, stderr bytes.Buffer
 	exitCode, execErr := s.sandboxProvider.Exec(ctx, sandbox, script, &stdout, &stderr)
@@ -1336,6 +1360,12 @@ func (s *PRService) pushSessionBranch(
 			msg = pushBranchDivergedMessage
 		}
 		return nil, fmt.Errorf("%w: %s", ErrPushBranchDiverged, msg)
+	case pushExitBaseUnrelated:
+		msg := strings.TrimSpace(stderr.String())
+		if msg == "" {
+			msg = pushBaseUnrelatedMessage
+		}
+		return nil, fmt.Errorf("%w: %s", ErrBaseBranchUnrelated, msg)
 	default:
 		msg := strings.TrimSpace(stderr.String())
 		if msg == "" {
@@ -1456,6 +1486,12 @@ const pushExitNoChanges = 77
 // work with a stale or start-over checkpoint.
 const pushExitBranchDiverged = 78
 
+// pushExitBaseUnrelated is the sentinel exit code the push script uses when
+// the current remote base branch has no merge-base with the session branch.
+// This prevents publishing stale-history session branches that GitHub will
+// reject as PR heads after the push.
+const pushExitBaseUnrelated = 79
+
 // pushHeadSHASentinel is a well-known prefix the push script writes to stdout
 // after a successful `git push`. The caller scans stdout for this line and
 // extracts the just-pushed commit SHA. Chosen to be unlikely to collide with
@@ -1463,6 +1499,8 @@ const pushExitBranchDiverged = 78
 const pushHeadSHASentinel = "__143_HEAD_SHA="
 
 const pushBranchDivergedMessage = "remote branch has changes that are not present in this session checkpoint; refusing to force push"
+
+const pushBaseUnrelatedMessage = "remote base branch could not be found or has no history in common with this session checkpoint; refusing to push"
 
 // pushScriptTemplate is the shell script executed inside the restored
 // sandbox. All variable interpolations are pre-quoted by the caller (see
@@ -1495,9 +1533,12 @@ const pushScriptTemplate = `set -eu
 cleanup() { rm -f %[1]s; }
 trap cleanup EXIT
 branch=%[7]s
+base_branch=%[8]s
 push_url=%[6]s
 remote_ref="refs/heads/$branch"
 remote_guard_ref="refs/remotes/__143_push_guard/$branch"
+base_ref="refs/heads/$base_branch"
+base_guard_ref="refs/remotes/__143_base_guard/$base_branch"
 cd %[2]s
 git config user.name %[3]s
 git config user.email %[4]s
@@ -1511,25 +1552,37 @@ if git rev-parse --abbrev-ref --symbolic-full-name @{u} >/dev/null 2>&1; then
         exit %[5]d
     fi
 fi
+if [ -n "$base_branch" ]; then
+    base_sha=$(git ls-remote "$push_url" "$base_ref" | awk 'NR==1 {print $1}')
+    if [ -z "$base_sha" ]; then
+        echo "%[10]s" >&2
+        exit %[11]d
+    fi
+    git fetch --no-tags --quiet "$push_url" "+${base_ref}:${base_guard_ref}"
+    if ! git merge-base "$base_guard_ref" HEAD >/dev/null 2>&1; then
+        echo "%[10]s" >&2
+        exit %[11]d
+    fi
+fi
 remote_sha=$(git ls-remote "$push_url" "$remote_ref" | awk 'NR==1 {print $1}')
 if [ -n "$remote_sha" ]; then
     git fetch --no-tags --quiet "$push_url" "+${remote_ref}:${remote_guard_ref}"
     if ! git merge-base --is-ancestor "$remote_guard_ref" HEAD; then
         if ! git diff --quiet HEAD "$remote_guard_ref"; then
-            echo "%[9]s" >&2
-            exit %[10]d
+            echo "%[12]s" >&2
+            exit %[13]d
         fi
     fi
 fi
 git push --force-with-lease="${remote_ref}:${remote_sha}" "$push_url" "HEAD:${remote_ref}"
-echo "%[8]s$(git rev-parse HEAD)"
+echo "%[9]s$(git rev-parse HEAD)"
 `
 
 // buildPushScript renders pushScriptTemplate with caller-supplied values.
 // Every %s interpolation is passed through shellQuote, which correctly
 // handles embedded single quotes (via the `'\”` trick) — so any UTF-8
 // string is safe to interpolate.
-func buildPushScript(workDir, commitMsgPath, authorName, authorEmail, branchName, pushURL string) string {
+func buildPushScript(workDir, commitMsgPath, authorName, authorEmail, branchName, baseBranch, pushURL string) string {
 	return fmt.Sprintf(
 		pushScriptTemplate,
 		shellQuote(commitMsgPath),
@@ -1539,11 +1592,14 @@ func buildPushScript(workDir, commitMsgPath, authorName, authorEmail, branchName
 		pushExitNoChanges,
 		shellQuote(pushURL),
 		shellQuote(branchName),
+		shellQuote(baseBranch),
 		// pushHeadSHASentinel is a compile-time string literal containing only
 		// safe shell characters ("__143_HEAD_SHA="), so it's intentionally
 		// interpolated raw — no shellQuote. Anyone who later changes the
 		// sentinel to include shell metacharacters MUST add quoting here.
 		pushHeadSHASentinel,
+		pushBaseUnrelatedMessage,
+		pushExitBaseUnrelated,
 		pushBranchDivergedMessage,
 		pushExitBranchDiverged,
 	)

--- a/internal/services/github/pr_test.go
+++ b/internal/services/github/pr_test.go
@@ -4089,6 +4089,7 @@ func TestBuildPushScript_Structure(t *testing.T) {
 		"Test User",
 		"test@example.com",
 		"143/abc123/fix-typo",
+		"main",
 		"https://github.com/owner/repo.git",
 	)
 
@@ -4108,6 +4109,7 @@ func TestBuildPushScript_Structure(t *testing.T) {
 	// referenced via variables so every later git command handles branch names
 	// and URLs consistently.
 	require.Contains(t, script, "branch='143/abc123/fix-typo'", "push script should assign the branch through shellQuote")
+	require.Contains(t, script, "base_branch='main'", "push script should assign the base branch through shellQuote")
 	require.Contains(t, script, "push_url='https://github.com/owner/repo.git'", "push script should assign the push URL through shellQuote")
 
 	// Hydrated snapshots may have been captured while the repo was on a stale
@@ -4124,6 +4126,13 @@ func TestBuildPushScript_Structure(t *testing.T) {
 	// already contains it. That still allows metadata-only retry rewrites.
 	require.Contains(t, script, `remote_ref="refs/heads/$branch"`, "push script should derive the remote branch ref from the persisted branch")
 	require.Contains(t, script, `remote_guard_ref="refs/remotes/__143_push_guard/$branch"`, "push script should derive a local guard ref for the remote branch")
+	require.Contains(t, script, `base_ref="refs/heads/$base_branch"`, "push script should derive the base branch ref from the persisted target branch")
+	require.Contains(t, script, `base_guard_ref="refs/remotes/__143_base_guard/$base_branch"`, "push script should derive a local guard ref for the base branch")
+	require.Contains(t, script, `git ls-remote "$push_url" "$base_ref"`, "push script should read the current base branch SHA before pushing")
+	require.Contains(t, script, `if [ -z "$base_sha" ]; then`, "push script should refuse to push when the base branch cannot be resolved")
+	require.Contains(t, script, `git fetch --no-tags --quiet "$push_url" "+${base_ref}:${base_guard_ref}"`, "push script should fetch the current base branch before pushing")
+	require.Contains(t, script, `git merge-base "$base_guard_ref" HEAD`, "push script should refuse unrelated base-branch history before pushing")
+	require.Contains(t, script, "exit 79", "push script should use the unrelated-base sentinel exit code")
 	require.Contains(t, script, `git ls-remote "$push_url" "$remote_ref"`, "push script should read the current remote SHA before pushing")
 	require.Contains(t, script, `git fetch --no-tags --quiet "$push_url" "+${remote_ref}:${remote_guard_ref}"`, "push script should fetch the current PR branch before force pushing")
 	require.Contains(t, script, `git merge-base --is-ancestor "$remote_guard_ref" HEAD`, "push script should allow pushes that include the remote PR head")
@@ -4152,13 +4161,53 @@ func TestBuildPushScript_QuotesHostileBranchName(t *testing.T) {
 		"Bot",
 		"bot@example.com",
 		"143/abc/it's-fine",
+		"release/2026.06",
 		"https://github.com/o/r.git",
 	)
 	// The branch is assigned through shellQuote once, so the embedded quote
 	// cannot break out and corrupt later variable-based git commands.
 	require.Contains(t, script, `branch='143/abc/it'\''s-fine'`, "push script should quote hostile branch names in the branch variable")
+	require.Contains(t, script, `base_branch='release/2026.06'`, "push script should quote the base branch in a variable")
 	require.Contains(t, script, `git checkout -B "$branch"`, "push script should use the safely assigned branch variable")
 	require.Contains(t, script, `--force-with-lease="${remote_ref}:${remote_sha}"`, "push script should lease through the safely derived remote ref")
+}
+
+func TestTargetBranchForPR(t *testing.T) {
+	t.Parallel()
+
+	ptr := func(s string) *string { return &s }
+	tests := []struct {
+		name string
+		run  *models.Session
+		repo *models.Repository
+		want string
+	}{
+		{
+			name: "session target branch wins",
+			run:  &models.Session{TargetBranch: ptr("release")},
+			repo: &models.Repository{DefaultBranch: "main"},
+			want: "release",
+		},
+		{
+			name: "repo default fallback",
+			run:  &models.Session{},
+			repo: &models.Repository{DefaultBranch: "main"},
+			want: "main",
+		},
+		{
+			name: "hard default",
+			run:  &models.Session{},
+			repo: &models.Repository{},
+			want: "main",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tt.want, targetBranchForPR(tt.run, tt.repo), "targetBranchForPR should resolve the base branch used for PR creation")
+		})
+	}
 }
 
 func TestIsPushRejection(t *testing.T) {
@@ -4406,6 +4455,13 @@ func TestPushSessionBranch(t *testing.T) {
 			wantDestroyCnt: 1,
 		},
 		{
+			name:           "unrelated base branch guard maps to ErrBaseBranchUnrelated",
+			snapshots:      &prTestSnapshotStore{payload: []byte("snapshot")},
+			provider:       &prTestSandboxProvider{execExit: pushExitBaseUnrelated, execStderr: pushBaseUnrelatedMessage},
+			wantErrIs:      ErrBaseBranchUnrelated,
+			wantDestroyCnt: 1,
+		},
+		{
 			name:           "missing head sha sentinel returns parse error",
 			snapshots:      &prTestSnapshotStore{payload: []byte("snapshot")},
 			provider:       &prTestSandboxProvider{execStdout: "no sentinel here\n"},
@@ -4451,6 +4507,7 @@ func TestPushSessionBranch(t *testing.T) {
 				models.OrgSettings{},
 				"snapshots/key.tar",
 				"143/abc123/fix",
+				"main",
 				"commit message",
 				"Test User",
 				"test@example.com",
@@ -4550,6 +4607,7 @@ func TestPushSessionBranch_RetryOnRejection_Succeeds(t *testing.T) {
 		models.OrgSettings{},
 		"snapshots/key.tar",
 		"143/abc/fix",
+		"main",
 		"commit message",
 		"Bot",
 		"bot@example.com",
@@ -4592,6 +4650,7 @@ func TestPushSessionBranch_RetryOnRejection_PersistentRejection(t *testing.T) {
 		models.OrgSettings{},
 		"snapshots/key.tar",
 		"143/abc/fix",
+		"main",
 		"commit message",
 		"Bot",
 		"bot@example.com",
@@ -4621,6 +4680,7 @@ func TestPushSessionBranch_NoRetryOnNonRejection(t *testing.T) {
 		models.OrgSettings{},
 		"snapshots/key.tar",
 		"143/abc/fix",
+		"main",
 		"commit message",
 		"Bot",
 		"bot@example.com",
@@ -4655,6 +4715,7 @@ func TestPushSessionBranch_AuthSocketWired(t *testing.T) {
 		models.OrgSettings{},
 		"snapshots/key.tar",
 		"143/abc/fix",
+		"main",
 		"commit message",
 		"Bot",
 		"bot@example.com",
@@ -4703,6 +4764,7 @@ func TestPushSessionBranch_AuthSocketListenFailureWrapsSentinel(t *testing.T) {
 		models.OrgSettings{},
 		"snapshots/key.tar",
 		"143/abc/fix",
+		"main",
 		"commit message",
 		"Bot",
 		"bot@example.com",
@@ -4728,7 +4790,7 @@ func TestPushSessionBranch_RequiresSandboxAuth(t *testing.T) {
 		&models.Session{ID: uuid.New(), OrgID: uuid.New()},
 		&models.Repository{FullName: "o/r"},
 		models.OrgSettings{},
-		"k", "b", "m", "n", "e@x",
+		"k", "b", "main", "m", "n", "e@x",
 	)
 	require.Error(t, err)
 	require.ErrorIs(t, err, ErrSandboxAuthUnavailable, "pushSessionBranch should preserve the sandbox auth sentinel")

--- a/internal/worker/handlers.go
+++ b/internal/worker/handlers.go
@@ -11127,6 +11127,8 @@ func userFacingPRError(err error) string {
 		return ghservice.PushRejectedPRMessage
 	case errors.Is(err, ghservice.ErrPushBranchDiverged):
 		return ghservice.PushBranchDivergedPRMessage
+	case errors.Is(err, ghservice.ErrBaseBranchUnrelated):
+		return ghservice.BaseBranchUnrelatedPRMessage
 	case errors.Is(err, ghservice.ErrSandboxAuthUnavailable):
 		return ghservice.SandboxAuthUnavailablePRMessage
 	default:
@@ -11394,6 +11396,8 @@ func shouldDeadLetterPRError(err error) bool {
 	case errors.Is(err, ghservice.ErrLegacyPRMissingHeadRef):
 		return true
 	case errors.Is(err, ghservice.ErrPushBranchDiverged):
+		return true
+	case errors.Is(err, ghservice.ErrBaseBranchUnrelated):
 		return true
 	default:
 		return false

--- a/internal/worker/handlers_test.go
+++ b/internal/worker/handlers_test.go
@@ -5999,6 +5999,11 @@ func TestUserFacingPRError(t *testing.T) {
 			want: "The PR branch has changes that are not in this session checkpoint. Pull the latest PR branch into the session before pushing again.",
 		},
 		{
+			name: "base branch unrelated",
+			err:  ghservice.ErrBaseBranchUnrelated,
+			want: "The repository's base branch could not be found or no longer shares history with this session. Recreate or rebase the session on the current base branch, then create the PR again.",
+		},
+		{
 			name: "sandbox auth unavailable",
 			err:  fmt.Errorf("open sandbox auth socket: %w", ghservice.ErrSandboxAuthUnavailable),
 			want: "143 could not prepare GitHub credentials for this push.",
@@ -6094,6 +6099,7 @@ func TestShouldDeadLetterPRError(t *testing.T) {
 		{name: "snapshot unavailable is terminal", err: ghservice.ErrSnapshotUnavailable, want: true},
 		{name: "no changes is terminal", err: ghservice.ErrNoChanges, want: true},
 		{name: "branch diverged is terminal", err: ghservice.ErrPushBranchDiverged, want: true},
+		{name: "base branch unrelated is terminal", err: ghservice.ErrBaseBranchUnrelated, want: true},
 		{name: "generic error retries", err: errors.New("boom"), want: false},
 	}
 


### PR DESCRIPTION
## Summary

This fixes a PR creation failure where 143 could push a session branch whose checkpoint no longer shared history with the repository's current base branch. GitHub then rejected pull request creation with a 422 "no history in common" response, while the UI surfaced the generic GitHub access/permissions message.

Changes:
- Resolve PR creation against the session target branch, falling back to the repository default branch.
- Add a pre-push base-branch guard to the PR/branch publish script. It fetches the current base branch and refuses to push if the base branch is missing or has no merge-base with the session checkpoint.
- Add a dedicated terminal error and user-facing message for the base-history mismatch.
- Cover the push script guard, target branch resolution, and worker error mapping with focused tests.

## Root Cause

The session branch could be created from an older repository history after the repository's `main` branch had been replaced. The platform pushed the branch first, then GitHub rejected PR creation because the pushed head and current base had unrelated roots.

## Verification

- `go test ./internal/services/github ./internal/worker`
- `go vet ./internal/services/github ./internal/worker`
- `git diff --check`