### PR TITLE
Harden open-source security defaults

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,7 +5,6 @@
 .env
 .env.*
 !.env.example
-!.env*.enc
 bin/
 coverage.html
 frontend/node_modules

--- a/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
@@ -1915,7 +1915,7 @@ function SessionComposer({
             <input
               ref={uploadInputRef}
               type="file"
-              accept="image/*,.heic,.heif,.pdf,.txt,.md,.json,.csv"
+              accept="image/png,image/jpeg,image/gif,image/webp,.heic,.heif,.pdf,.txt,.md,.json,.csv"
               multiple
               className="hidden"
               onChange={onUpload}

--- a/frontend/src/components/manual-session-composer.tsx
+++ b/frontend/src/components/manual-session-composer.tsx
@@ -1506,7 +1506,7 @@ export function ManualSessionComposer({
                 <Input
                   ref={uploadInputRef}
                   type="file"
-                  accept="image/*,.heic,.heif,.pdf,.txt,.md,.json,.csv"
+                  accept="image/png,image/jpeg,image/gif,image/webp,.heic,.heif,.pdf,.txt,.md,.json,.csv"
                   multiple
                   className="hidden"
                   onChange={onUploadChange}

--- a/frontend/src/lib/utils.test.ts
+++ b/frontend/src/lib/utils.test.ts
@@ -132,7 +132,6 @@ describe("isImageURL", () => {
     expect(isImageURL("/uploads/photo.jpeg")).toBe(true);
     expect(isImageURL("/uploads/photo.gif")).toBe(true);
     expect(isImageURL("/uploads/photo.webp")).toBe(true);
-    expect(isImageURL("/uploads/photo.svg")).toBe(true);
   });
 
   it("matches data: image URLs", () => {
@@ -141,6 +140,7 @@ describe("isImageURL", () => {
 
   it("rejects non-image URLs", () => {
     expect(isImageURL("/uploads/doc.pdf")).toBe(false);
+    expect(isImageURL("/uploads/photo.svg")).toBe(false);
     expect(isImageURL("/uploads/file.txt")).toBe(false);
     expect(isImageURL("/uploads/data.json")).toBe(false);
   });

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -26,7 +26,7 @@ export function sessionTitle(session: Session): string {
 export function isImageURL(url: string): boolean {
   if (url.startsWith("data:image/")) return true;
   const pathname = url.split("?")[0].split("#")[0];
-  return /\.(png|jpe?g|gif|webp|svg)$/i.test(pathname);
+  return /\.(png|jpe?g|gif|webp)$/i.test(pathname);
 }
 
 /**

--- a/internal/api/handlers/uploads.go
+++ b/internal/api/handlers/uploads.go
@@ -35,7 +35,6 @@ var allowedUploadTypes = map[string]bool{
 	"image/heif":          true,
 	"image/heic-sequence": true,
 	"image/heif-sequence": true,
-	"image/svg+xml":       true,
 	"application/pdf":     true,
 	"text/plain":          true,
 	"text/markdown":       true,
@@ -234,8 +233,6 @@ func extensionFromMIME(mime string) string {
 		return ".heic"
 	case "image/heif-sequence":
 		return ".heif"
-	case "image/svg+xml":
-		return ".svg"
 	case "application/pdf":
 		return ".pdf"
 	case "text/plain":

--- a/internal/api/handlers/uploads_test.go
+++ b/internal/api/handlers/uploads_test.go
@@ -154,6 +154,20 @@ func TestUploadHandler_InvalidFileType(t *testing.T) {
 	require.Contains(t, w.Body.String(), "INVALID_FILE_TYPE")
 }
 
+func TestUploadHandler_RejectsSVG(t *testing.T) {
+	t.Parallel()
+
+	store := storage.NewFileUploadStore(t.TempDir(), "/uploads")
+	h := NewUploadHandler(store)
+	req := newUploadRequest(t, "file", "diagram.svg", "image/svg+xml", []byte(`<svg onload="alert(1)"></svg>`))
+	w := httptest.NewRecorder()
+
+	h.Upload(w, req)
+
+	require.Equal(t, http.StatusBadRequest, w.Code, "SVG uploads should be rejected")
+	require.Contains(t, w.Body.String(), "INVALID_FILE_TYPE", "SVG rejection should use the invalid file type response")
+}
+
 func TestUploadHandler_Success(t *testing.T) {
 	t.Parallel()
 
@@ -459,7 +473,6 @@ func TestExtensionFromMIME(t *testing.T) {
 		{"image/heif", ".heif"},
 		{"image/heic-sequence", ".heic"},
 		{"image/heif-sequence", ".heif"},
-		{"image/svg+xml", ".svg"},
 		{"application/pdf", ".pdf"},
 		{"text/plain", ".txt"},
 		{"text/markdown", ".md"},

--- a/internal/api/handlers/webhooks.go
+++ b/internal/api/handlers/webhooks.go
@@ -123,7 +123,7 @@ func (h *WebhookHandler) handleIssueComment(w http.ResponseWriter, r *http.Reque
 
 func (h *WebhookHandler) verifySignature(payload []byte, signature string) bool {
 	if h.cfg.GitHubWebhookSecret == "" {
-		return true // no secret configured, skip verification
+		return h.cfg.Env != "production"
 	}
 	if !strings.HasPrefix(signature, "sha256=") {
 		return false

--- a/internal/api/handlers/webhooks_test.go
+++ b/internal/api/handlers/webhooks_test.go
@@ -42,6 +42,14 @@ func setupWebhookHandler(t *testing.T, mock pgxmock.PgxPoolIface, secret string)
 	return NewWebhookHandler(cfg, orgStore, userStore, repoStore, integrationStore, nil)
 }
 
+func TestWebhook_VerifySignature_ProductionRequiresConfiguredSecret(t *testing.T) {
+	t.Parallel()
+
+	handler := &WebhookHandler{cfg: &config.Config{Env: "production"}}
+
+	require.False(t, handler.verifySignature([]byte(`{"ok":true}`), ""), "production webhooks should fail closed when no secret is configured")
+}
+
 func TestWebhook_HandleGitHub(t *testing.T) {
 	t.Parallel()
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -665,5 +665,9 @@ func (c *Config) ValidateSecrets() error {
 		return errors.New("CSRF_SIGNING_KEY must be set to a strong random value in production (min 32 characters)")
 	}
 
+	if c.GitHubWebhookSecret == "" {
+		return errors.New("GITHUB_WEBHOOK_SECRET must be set in production")
+	}
+
 	return nil
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -485,6 +485,7 @@ func TestValidateSecrets_ProductionAllValid(t *testing.T) {
 		SessionSecret:       strings.Repeat("s", 32),
 		EncryptionMasterKey: strings.Repeat("k", 32),
 		CSRFSigningKey:      strings.Repeat("c", 32),
+		GitHubWebhookSecret: "github-webhook-secret",
 	}
 	require.NoError(t, cfg.ValidateSecrets(), "valid production config should not error")
 }
@@ -513,6 +514,20 @@ func TestValidateSecrets_ProductionMissingCSRFKey(t *testing.T) {
 	err := cfg.ValidateSecrets()
 	require.Error(t, err, "missing CSRF_SIGNING_KEY in production should error")
 	require.Contains(t, err.Error(), "CSRF_SIGNING_KEY")
+}
+
+func TestValidateSecrets_ProductionMissingGitHubWebhookSecret(t *testing.T) {
+	t.Parallel()
+
+	cfg := &Config{
+		Env:                 "production",
+		SessionSecret:       strings.Repeat("s", 32),
+		EncryptionMasterKey: strings.Repeat("k", 32),
+		CSRFSigningKey:      strings.Repeat("c", 32),
+	}
+	err := cfg.ValidateSecrets()
+	require.Error(t, err, "missing GITHUB_WEBHOOK_SECRET in production should error")
+	require.Contains(t, err.Error(), "GITHUB_WEBHOOK_SECRET")
 }
 
 func TestGitHubAppEnabled(t *testing.T) {

--- a/internal/services/storage/uploads.go
+++ b/internal/services/storage/uploads.go
@@ -135,13 +135,14 @@ func (s *S3UploadStore) Serve(w http.ResponseWriter, r *http.Request, key string
 	if out.ContentLength != nil {
 		w.Header().Set("Content-Length", fmt.Sprintf("%d", *out.ContentLength))
 	}
-	// Images display inline; other file types download as attachments.
+	// Safe raster images display inline; SVG and other file types download as attachments.
 	fileName := path.Base(cleanKey)
-	if out.ContentType != nil && strings.HasPrefix(*out.ContentType, "image/") {
+	if out.ContentType != nil && inlineUploadContentType(*out.ContentType) {
 		w.Header().Set("Content-Disposition", "inline")
 	} else {
 		w.Header().Set("Content-Disposition", fmt.Sprintf("attachment; filename=%q", fileName))
 	}
+	w.Header().Set("X-Content-Type-Options", "nosniff")
 	w.Header().Set("Cache-Control", "private, max-age=86400")
 	if _, err := io.Copy(w, out.Body); err != nil {
 		log.Printf("upload serve: streaming %s: %v", key, err)
@@ -197,6 +198,13 @@ func (f *FileUploadStore) Serve(w http.ResponseWriter, r *http.Request, key stri
 		return
 	}
 	filePath := filepath.Join(f.baseDir, filepath.FromSlash(cleanKey))
+	// http.ServeFile derives Content-Type from the (attacker-controlled) file
+	// extension, so anything that isn't a known-safe inline image — SVG, HTML,
+	// etc. — must download as an attachment to avoid stored XSS in this origin.
+	if !inlineUploadContentType(mime.TypeByExtension(path.Ext(cleanKey))) {
+		w.Header().Set("Content-Disposition", fmt.Sprintf("attachment; filename=%q", path.Base(cleanKey)))
+	}
+	w.Header().Set("X-Content-Type-Options", "nosniff")
 	http.ServeFile(w, r, filePath)
 }
 
@@ -235,4 +243,9 @@ func validateUploadKey(key string) (string, error) {
 		}
 	}
 	return path.Clean(key), nil
+}
+
+func inlineUploadContentType(contentType string) bool {
+	baseType := strings.ToLower(strings.TrimSpace(strings.Split(contentType, ";")[0]))
+	return strings.HasPrefix(baseType, "image/") && baseType != "image/svg+xml"
 }

--- a/internal/services/storage/uploads_test.go
+++ b/internal/services/storage/uploads_test.go
@@ -253,6 +253,91 @@ func TestS3UploadStore_Serve_NonImageAttachment(t *testing.T) {
 	require.Equal(t, `attachment; filename="data.json"`, w.Header().Get("Content-Disposition"))
 }
 
+func TestS3UploadStore_Serve_SVGAttachment(t *testing.T) {
+	t.Parallel()
+
+	body := []byte(`<svg onload="alert(1)"></svg>`)
+	contentType := "image/svg+xml"
+	contentLength := int64(len(body))
+
+	mock := &mockS3Client{
+		getObjectFunc: func(_ context.Context, _ *s3.GetObjectInput, _ ...func(*s3.Options)) (*s3.GetObjectOutput, error) {
+			return &s3.GetObjectOutput{
+				Body:          io.NopCloser(bytes.NewReader(body)),
+				ContentType:   &contentType,
+				ContentLength: &contentLength,
+			}, nil
+		},
+	}
+
+	store := NewS3UploadStore(mock, "mybucket", "uploads")
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/uploads/files/org-1/2026-01/unsafe.svg", nil)
+	w := httptest.NewRecorder()
+
+	store.Serve(w, req, "org-1/2026-01/unsafe.svg")
+
+	require.Equal(t, http.StatusOK, w.Code, "legacy SVG objects should still be retrievable")
+	require.Equal(t, `attachment; filename="unsafe.svg"`, w.Header().Get("Content-Disposition"), "legacy SVG objects should download instead of rendering inline")
+	require.Equal(t, "nosniff", w.Header().Get("X-Content-Type-Options"), "legacy SVG responses should prevent content sniffing")
+}
+
+func TestFileUploadStore_Serve_SVGAttachment(t *testing.T) {
+	t.Parallel()
+
+	baseDir := t.TempDir()
+	key := "org-1/2026-01/unsafe.svg"
+	require.NoError(t, os.MkdirAll(filepath.Join(baseDir, "org-1/2026-01"), 0o750), "test fixture directory should be created")
+	require.NoError(t, os.WriteFile(filepath.Join(baseDir, key), []byte(`<svg onload="alert(1)"></svg>`), 0o600), "test SVG fixture should be written")
+
+	store := NewFileUploadStore(baseDir, "/api/v1/uploads/files")
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/uploads/files/"+key, nil)
+	w := httptest.NewRecorder()
+
+	store.Serve(w, req, key)
+
+	require.Equal(t, http.StatusOK, w.Code, "legacy local SVG uploads should still be retrievable")
+	require.Equal(t, `attachment; filename="unsafe.svg"`, w.Header().Get("Content-Disposition"), "legacy local SVG uploads should download instead of rendering inline")
+	require.Equal(t, "nosniff", w.Header().Get("X-Content-Type-Options"), "legacy local SVG responses should prevent content sniffing")
+}
+
+func TestFileUploadStore_Serve_HTMLAttachment(t *testing.T) {
+	t.Parallel()
+
+	baseDir := t.TempDir()
+	key := "org-1/2026-01/evil.html"
+	require.NoError(t, os.MkdirAll(filepath.Join(baseDir, "org-1/2026-01"), 0o750), "test fixture directory should be created")
+	require.NoError(t, os.WriteFile(filepath.Join(baseDir, key), []byte(`<script>alert(1)</script>`), 0o600), "test HTML fixture should be written")
+
+	store := NewFileUploadStore(baseDir, "/api/v1/uploads/files")
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/uploads/files/"+key, nil)
+	w := httptest.NewRecorder()
+
+	store.Serve(w, req, key)
+
+	require.Equal(t, http.StatusOK, w.Code, "HTML uploads should still be retrievable")
+	require.Equal(t, `attachment; filename="evil.html"`, w.Header().Get("Content-Disposition"), "HTML uploads must download instead of rendering inline to prevent stored XSS")
+	require.Equal(t, "nosniff", w.Header().Get("X-Content-Type-Options"), "HTML responses should prevent content sniffing")
+}
+
+func TestFileUploadStore_Serve_ImageInline(t *testing.T) {
+	t.Parallel()
+
+	baseDir := t.TempDir()
+	key := "org-1/2026-01/photo.png"
+	require.NoError(t, os.MkdirAll(filepath.Join(baseDir, "org-1/2026-01"), 0o750), "test fixture directory should be created")
+	require.NoError(t, os.WriteFile(filepath.Join(baseDir, key), []byte("\x89PNG\r\n\x1a\n"), 0o600), "test PNG fixture should be written")
+
+	store := NewFileUploadStore(baseDir, "/api/v1/uploads/files")
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/uploads/files/"+key, nil)
+	w := httptest.NewRecorder()
+
+	store.Serve(w, req, key)
+
+	require.Equal(t, http.StatusOK, w.Code, "image uploads should be retrievable")
+	require.Empty(t, w.Header().Get("Content-Disposition"), "safe raster images should render inline")
+	require.Equal(t, "nosniff", w.Header().Get("X-Content-Type-Options"), "all upload responses should prevent content sniffing")
+}
+
 func TestS3UploadStore_Serve_GetObjectError(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- require `GITHUB_WEBHOOK_SECRET` in production and fail closed for unsigned GitHub webhooks
- reject SVG uploads and force legacy SVG/user-uploaded non-safe content to download with `nosniff`
- keep encrypted `.env*.enc` bundles out of Docker build contexts

## Verification
- `go test ./internal/config ./internal/api/handlers ./internal/services/storage`
- `npm run test -- src/lib/utils.test.ts`
- `git diff --check`