### PR TITLE
Remove project intro text from Why 143 page

### DIFF
--- a/frontend/src/app/(landing)/why-143/page.tsx
+++ b/frontend/src/app/(landing)/why-143/page.tsx
@@ -318,21 +318,6 @@ export default function Why143Page() {
                 we&rsquo;re called 143, and it&rsquo;s how we think about the
                 product we&rsquo;re building.
               </p>
-              <p
-                className="mt-6 text-sm"
-                style={{
-                  color: isDark ? "rgba(255,255,255,0.35)" : "rgba(0,0,0,0.4)",
-                }}
-              >
-                Want the longer story of how 143 came to be?{" "}
-                <Link
-                  href="/about"
-                  className={`underline underline-offset-2 ${isDark ? "hover:text-white/70" : "hover:text-slate-800"} transition-colors`}
-                >
-                  Read about the project
-                </Link>
-                .
-              </p>
             </div>
           </Reveal>
         </div>


### PR DESCRIPTION
## Summary
- Remove the longer-story prompt and project link from the Why 143 landing page

## Testing
- Confirmed the removed copy no longer appears in `frontend/src/app/(landing)/why-143/page.tsx`
- Focused ESLint was not run because `frontend/node_modules` is not installed in this sandbox; `npm exec` attempted a transient ESLint 10 and failed to load the repo config