### PR TITLE
Clarify code review policy UX

### DIFF
--- a/frontend/src/app/(dashboard)/code-reviews/page.test.tsx
+++ b/frontend/src/app/(dashboard)/code-reviews/page.test.tsx
@@ -273,9 +273,17 @@ describe("CodeReviewsPage", () => {
 
     await user.click(screen.getByRole("combobox", { name: /Repository/i }));
     await user.click(await screen.findByRole("option", { name: "acme/api" }));
-    await user.click(await screen.findByRole("tab", { name: /Configurations/i }));
+    await user.click(await screen.findByRole("tab", { name: /Policy/i }));
 
-    // Essentials and the GitHub trigger are visible without expanding anything.
+    // Policy scope, current behavior, outcome, and the GitHub trigger are visible without expanding anything.
+    expect(await screen.findByText("Editing acme/api inherited policy.")).toBeInTheDocument();
+    expect(screen.getByText("Uses organization default")).toBeInTheDocument();
+    expect(screen.getByText("Current behavior")).toBeInTheDocument();
+    expect(screen.getByText("Comment-only reviews")).toBeInTheDocument();
+    expect(screen.getByText("GitHub reviewer ready")).toBeInTheDocument();
+    expect(screen.getByText("2 reviewers")).toBeInTheDocument();
+    expect(screen.getByText("quorum 2")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Comment only/i })).toBeInTheDocument();
     expect(await screen.findByText("@acme/143-code-reviewer")).toBeInTheDocument();
     expect(screen.getByText("Ready")).toBeInTheDocument();
     expect(screen.queryByRole("button", { name: /Repair GitHub reviewer/i })).not.toBeInTheDocument();
@@ -335,7 +343,7 @@ describe("CodeReviewsPage", () => {
 
     renderWithProviders(<CodeReviewsPage />);
 
-    await user.click(await screen.findByRole("tab", { name: /Configurations/i }));
+    await user.click(await screen.findByRole("tab", { name: /Policy/i }));
     await user.click(await screen.findByRole("button", { name: /Description requirements/i }));
     await user.click(await screen.findByRole("button", { name: "Edit Testing evidence" }));
 
@@ -357,6 +365,32 @@ describe("CodeReviewsPage", () => {
     expect(await screen.findByText("Paths: no paths set")).toBeInTheDocument();
   });
 
+  it("saves outcome choices to the existing policy fields", async () => {
+    const user = userEvent.setup();
+    const state = mockCodeReviewBaseHandlers();
+
+    renderWithProviders(<CodeReviewsPage />);
+
+    await user.click(await screen.findByRole("tab", { name: /Policy/i }));
+
+    await user.click(await screen.findByRole("button", { name: /^Comment only/i }));
+    await waitFor(() => {
+      expect(state.getCurrentConfig().enabled).toBe(true);
+    });
+    expect(state.getCurrentConfig().approval_mode).toBe("comment_only");
+
+    await user.click(screen.getByRole("button", { name: /^Disabled/i }));
+    await waitFor(() => {
+      expect(state.getCurrentConfig().enabled).toBe(false);
+    });
+
+    await user.click(screen.getByRole("button", { name: /^Approve acceptable PRs/i }));
+    await waitFor(() => {
+      expect(state.getCurrentConfig().enabled).toBe(true);
+    });
+    expect(state.getCurrentConfig().approval_mode).toBe("approve_acceptable");
+  });
+
   it("edits paths, authors, and checks as compact autosaved lists", async () => {
     const user = userEvent.setup();
     const policyUpdates = vi.fn();
@@ -366,7 +400,7 @@ describe("CodeReviewsPage", () => {
 
     await user.click(await screen.findByRole("combobox", { name: /Repository/i }));
     await user.click(await screen.findByRole("option", { name: "acme/api" }));
-    await user.click(await screen.findByRole("tab", { name: /Configurations/i }));
+    await user.click(await screen.findByRole("tab", { name: /Policy/i }));
     await user.click(await screen.findByRole("button", { name: /Paths, authors & checks/i }));
 
     const sensitivePathsInput = await screen.findByRole("textbox", { name: "Sensitive paths" });
@@ -436,7 +470,7 @@ describe("CodeReviewsPage", () => {
 
     renderWithProviders(<CodeReviewsPage />);
 
-    await user.click(await screen.findByRole("tab", { name: /Configurations/i }));
+    await user.click(await screen.findByRole("tab", { name: /Policy/i }));
     await user.click(screen.getByRole("combobox", { name: /Starter template/i }));
     await user.click(await screen.findByRole("option", { name: "Small backend change" }));
     await user.click(screen.getByRole("button", { name: /Apply template/i }));
@@ -452,7 +486,7 @@ describe("CodeReviewsPage", () => {
 
     renderWithProviders(<CodeReviewsPage />);
 
-    await user.click(await screen.findByRole("tab", { name: /Configurations/i }));
+    await user.click(await screen.findByRole("tab", { name: /Policy/i }));
     await user.click(screen.getByRole("button", { name: /Approval criteria/i }));
 
     expect(await screen.findByLabelText("Timeout value")).toHaveValue(30);
@@ -482,7 +516,7 @@ describe("CodeReviewsPage", () => {
 
     await user.click(await screen.findByRole("combobox", { name: /Repository/i }));
     await user.click(await screen.findByRole("option", { name: "acme/api" }));
-    await user.click(await screen.findByRole("tab", { name: /Configurations/i }));
+    await user.click(await screen.findByRole("tab", { name: /Policy/i }));
 
     expect(await screen.findByText("Needs GitHub account")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /Connect GitHub/i })).toBeInTheDocument();
@@ -506,7 +540,7 @@ describe("CodeReviewsPage", () => {
 
     await user.click(await screen.findByRole("combobox", { name: /Repository/i }));
     await user.click(await screen.findByRole("option", { name: "acme/api" }));
-    await user.click(await screen.findByRole("tab", { name: /Configurations/i }));
+    await user.click(await screen.findByRole("tab", { name: /Policy/i }));
 
     const setupButton = await screen.findByRole("button", { name: /Set up GitHub reviewer/i });
     expect(setupButton).toBeDisabled();
@@ -547,7 +581,7 @@ describe("CodeReviewsPage", () => {
 
     await user.click(await screen.findByRole("combobox", { name: /Repository/i }));
     await user.click(await screen.findByRole("option", { name: "acme/api" }));
-    await user.click(await screen.findByRole("tab", { name: /Configurations/i }));
+    await user.click(await screen.findByRole("tab", { name: /Policy/i }));
     await user.click(await screen.findByRole("button", { name: /Set up GitHub reviewer/i }));
 
     await waitFor(() => {

--- a/frontend/src/app/(dashboard)/code-reviews/page.tsx
+++ b/frontend/src/app/(dashboard)/code-reviews/page.tsx
@@ -328,6 +328,7 @@ export default function CodeReviewsPage() {
     [reviews, selectedEvidenceSessionId],
   );
   const repositories = repositoriesQuery.data?.data ?? [];
+  const selectedRepository = repositories.find((repo) => repo.id === repositoryId);
   const templates = templatesQuery.data?.data ?? [];
   const selectedTemplate = templates.find((template) => template.key === selectedTemplateKey);
   const orgSettings = (settingsQuery.data?.data?.settings ?? {}) as OrgSettings;
@@ -467,7 +468,7 @@ export default function CodeReviewsPage() {
             </TabsTrigger>
             <TabsTrigger value="config">
               <Settings2 className="h-4 w-4" />
-              Configurations
+              Policy
             </TabsTrigger>
           </TabsList>
 
@@ -571,18 +572,22 @@ export default function CodeReviewsPage() {
             <Card>
               <CardHeader className="space-y-1">
                 <div className="flex items-center justify-between gap-3">
-                  <CardTitle>Bot behavior</CardTitle>
+                  <CardTitle>Review policy</CardTitle>
                   <AutosaveIndicator status={autosave.status} />
                 </div>
-                <p className="text-xs text-muted-foreground">
-                  {repositoryId
-                    ? policyQuery.data?.data.source === "repository"
-                      ? "This repository has review policy overrides and inherits organization defaults where fields are unset."
-                      : "This repository uses the organization default review policy."
-                    : "Organization defaults apply to repositories without their own review policy override."}
-                </p>
+                <PolicyScopeHeader
+                  repositoryName={selectedRepository?.full_name}
+                  repositorySelected={Boolean(repositoryId)}
+                  source={policyQuery.data?.data.source}
+                />
               </CardHeader>
               <CardContent className="space-y-5">
+                <PolicySummary
+                  config={config}
+                  repositorySelected={Boolean(repositoryId)}
+                  githubTriggerStatus={githubTriggerQuery.data?.data?.status}
+                />
+
                 <GitHubTriggerPanel
                   repositorySelected={Boolean(repositoryId)}
                   trigger={githubTriggerQuery.data?.data}
@@ -602,39 +607,22 @@ export default function CodeReviewsPage() {
                 />
 
                 <div className="space-y-3">
-                  <div className="text-sm font-medium text-foreground">Essentials</div>
+                  <div className="text-sm font-medium text-foreground">Outcome</div>
 
-                  <div className="flex flex-col gap-3 rounded-md border border-border p-4 sm:flex-row sm:items-center sm:justify-between">
-                    <div>
-                      <div className="text-sm font-medium text-foreground">Enable 143 Code Reviewer</div>
-                      <div className="mt-1 text-xs text-muted-foreground">
-                        When off, reviewer requests are acknowledged but no review session is started.
-                      </div>
-                    </div>
-                    <Switch
-                      checked={config?.enabled ?? false}
-                      disabled={!config}
-                      onCheckedChange={(checked) => commitPolicy((next) => { next.enabled = checked; })}
-                    />
-                  </div>
-
-                  <div className="flex flex-col gap-3 rounded-md border border-border p-4 sm:flex-row sm:items-center sm:justify-between">
-                    <div>
-                      <div className="text-sm font-medium text-foreground">Approve acceptable PRs</div>
-                      <div className="mt-1 text-xs text-muted-foreground">
-                        When off, the bot always submits comment-only GitHub reviews.
-                      </div>
-                    </div>
-                    <Switch
-                      checked={config?.approval_mode === "approve_acceptable"}
-                      disabled={!config}
-                      onCheckedChange={(checked) =>
-                        commitPolicy((next) => {
-                          next.approval_mode = (checked ? "approve_acceptable" : "comment_only") as CodeReviewApprovalMode;
-                        })
-                      }
-                    />
-                  </div>
+                  <OutcomeControl
+                    config={config}
+                    disabled={!config}
+                    onChange={(outcome) =>
+                      commitPolicy((next) => {
+                        if (outcome === "disabled") {
+                          next.enabled = false;
+                          return;
+                        }
+                        next.enabled = true;
+                        next.approval_mode = (outcome === "approve" ? "approve_acceptable" : "comment_only") as CodeReviewApprovalMode;
+                      })
+                    }
+                  />
 
                   <div className="grid gap-3 rounded-md border border-border p-4 md:grid-cols-[1fr_auto] md:items-end">
                     <FilterSelect label="Starter template" value={selectedTemplateKey} onValueChange={setSelectedTemplateKey}>
@@ -898,6 +886,145 @@ export default function CodeReviewsPage() {
         </Tabs>
       </div>
     </main>
+  );
+}
+
+function PolicyScopeHeader({
+  repositoryName,
+  repositorySelected,
+  source,
+}: {
+  repositoryName?: string;
+  repositorySelected: boolean;
+  source?: CodeReviewResolvedPolicy["source"];
+}) {
+  if (!repositorySelected) {
+    return (
+      <p className="text-xs text-muted-foreground">
+        Editing organization default. Repositories without an override inherit this policy.
+      </p>
+    );
+  }
+
+  const inherited = source !== "repository";
+  return (
+    <div className="flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
+      <span>
+        Editing {repositoryName ?? "selected repository"} {inherited ? "inherited policy" : "override"}.
+      </span>
+      <Badge variant={inherited ? "outline" : "secondary"}>{inherited ? "Uses organization default" : "Repository override"}</Badge>
+    </div>
+  );
+}
+
+function policyOutcome(config: CodeReviewPolicyConfig | null): "disabled" | "comment" | "approve" {
+  if (!config?.enabled) return "disabled";
+  return config.approval_mode === "approve_acceptable" ? "approve" : "comment";
+}
+
+function PolicySummary({
+  config,
+  repositorySelected,
+  githubTriggerStatus,
+}: {
+  config: CodeReviewPolicyConfig | null;
+  repositorySelected: boolean;
+  githubTriggerStatus?: CodeReviewGitHubTriggerResponse["status"];
+}) {
+  if (!config) {
+    return (
+      <div className="rounded-md border border-border bg-muted/30 px-4 py-3 text-sm text-muted-foreground">
+        Loading review policy...
+      </div>
+    );
+  }
+
+  const outcome = policyOutcome(config);
+  const reviewers = config.agent_roster.reviewers.length;
+  const summaryItems = [
+    outcome === "disabled"
+      ? "Reviewer disabled"
+      : outcome === "approve"
+        ? "Approves acceptable PRs"
+        : "Comment-only reviews",
+    repositorySelected ? `GitHub reviewer ${githubTriggerStatusLabel(githubTriggerStatus ?? "unconfigured").toLowerCase()}` : "Select a repository for GitHub setup",
+    `${reviewers} ${reviewers === 1 ? "reviewer" : "reviewers"}`,
+    `quorum ${config.agent_roster.require_reviewer_quorum}`,
+  ];
+
+  if (config.risk_policy.require_passing_checks) summaryItems.push("passing checks required");
+  if (config.agent_roster.disagreement_blocks) summaryItems.push("disagreement blocks approval");
+
+  return (
+    <div className="rounded-md border border-border bg-muted/30 px-4 py-3">
+      <div className="text-sm font-medium text-foreground">Current behavior</div>
+      <div className="mt-2 flex flex-wrap gap-2">
+        {summaryItems.map((item) => (
+          <Badge key={item} variant="outline">
+            {item}
+          </Badge>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function OutcomeControl({
+  config,
+  disabled,
+  onChange,
+}: {
+  config: CodeReviewPolicyConfig | null;
+  disabled?: boolean;
+  onChange: (outcome: "disabled" | "comment" | "approve") => void;
+}) {
+  const selected = policyOutcome(config);
+  const options: Array<{
+    value: "disabled" | "comment" | "approve";
+    title: string;
+    description: string;
+  }> = [
+    {
+      value: "disabled",
+      title: "Disabled",
+      description: "Reviewer requests are acknowledged, but no review session starts.",
+    },
+    {
+      value: "comment",
+      title: "Comment only",
+      description: "The bot reviews PRs and leaves feedback without approving.",
+    },
+    {
+      value: "approve",
+      title: "Approve acceptable PRs",
+      description: "The bot can approve when the PR passes this policy.",
+    },
+  ];
+
+  return (
+    <div className="grid gap-2 rounded-md border border-border p-2 md:grid-cols-3">
+      {options.map((option) => {
+        const active = option.value === selected;
+        return (
+          <Button
+            key={option.value}
+            type="button"
+            variant={active ? "secondary" : "ghost"}
+            className="h-auto justify-start whitespace-normal px-3 py-3 text-left"
+            disabled={disabled}
+            aria-pressed={active}
+            onClick={() => {
+              if (!active) onChange(option.value);
+            }}
+          >
+            <span className="flex min-w-0 flex-col gap-1">
+              <span className="text-sm font-medium">{option.title}</span>
+              <span className="text-xs font-normal leading-5 text-muted-foreground">{option.description}</span>
+            </span>
+          </Button>
+        );
+      })}
+    </div>
   );
 }
 


### PR DESCRIPTION
## Summary

- rename the Code reviews configuration tab to Policy
- add explicit policy scope and current-behavior summary copy
- replace separate enable/approval switches with a single outcome selector backed by the existing policy fields
- update code review page tests for the new UX and outcome persistence

## Verification

- npm test -- --run src/app/(dashboard)/code-reviews/page.test.tsx
- npx eslint 'src/app/(dashboard)/code-reviews/page.tsx' 'src/app/(dashboard)/code-reviews/page.test.tsx'\n- npm run typecheck\n- git diff --check\n