### PR TITLE
[codex] fix opencode tool stream parsing

### DIFF
--- a/frontend/src/lib/tool-label.test.ts
+++ b/frontend/src/lib/tool-label.test.ts
@@ -157,7 +157,18 @@ describe("deriveToolDisplay", () => {
 
     it("handles null metadata without crashing", () => {
       const log = makeLog(null);
-      expect(deriveToolDisplay(log).label).toBe("Ran unknown");
+      expect(deriveToolDisplay(log)).toEqual({
+        label: "Ran tool",
+        canonical: "unknown",
+      });
+    });
+
+    it("handles empty tool names without rendering unknown", () => {
+      const log = makeLog({ tool: "" });
+      expect(deriveToolDisplay(log)).toEqual({
+        label: "Ran tool",
+        canonical: "unknown",
+      });
     });
 
     it("handles missing input without crashing", () => {

--- a/frontend/src/lib/tool-label.ts
+++ b/frontend/src/lib/tool-label.ts
@@ -106,8 +106,8 @@ function asRecord(v: unknown): Record<string, unknown> | undefined {
  */
 export function deriveToolDisplay(toolUse: SessionLog): ToolDisplay {
   const metadata = toolUse.metadata ?? {};
-  const rawTool = asString(metadata.tool) ?? "unknown";
-  const canonical = canonicalize(rawTool);
+  const rawTool = asString(metadata.tool);
+  const canonical = canonicalize(rawTool ?? "unknown");
   const input = asRecord(metadata.input);
 
   // 1. Model-supplied description (Claude Bash) — most specific, use as-is.
@@ -116,6 +116,10 @@ export function deriveToolDisplay(toolUse: SessionLog): ToolDisplay {
   const description = input && asString(input.description);
   if (description && canonical !== "agent") {
     return { label: `Ran ${description}`, canonical };
+  }
+
+  if (!rawTool) {
+    return { label: "Ran tool", canonical: "unknown" };
   }
 
   // 2. Per-canonical-tool templates.

--- a/internal/services/agent/adapters/opencode.go
+++ b/internal/services/agent/adapters/opencode.go
@@ -118,6 +118,7 @@ type openCodeStreamEvent struct {
 	ID             string          `json:"id,omitempty"`
 	SessionID      string          `json:"session_id,omitempty"`
 	SessionIDCamel string          `json:"sessionID,omitempty"`
+	Part           json.RawMessage `json:"part,omitempty"`
 	CostUSD        *float64        `json:"cost_usd,omitempty"`
 	TotalCostUSD   *float64        `json:"total_cost_usd,omitempty"`
 	Usage          *struct {
@@ -126,6 +127,38 @@ type openCodeStreamEvent struct {
 		CacheCreationTokens int `json:"cache_creation_input_tokens"`
 		OutputTokens        int `json:"output_tokens"`
 	} `json:"usage,omitempty"`
+}
+
+type openCodeStreamPart struct {
+	ID        string            `json:"id,omitempty"`
+	SessionID string            `json:"sessionID,omitempty"`
+	MessageID string            `json:"messageID,omitempty"`
+	Type      string            `json:"type,omitempty"`
+	CallID    string            `json:"callID,omitempty"`
+	Tool      string            `json:"tool,omitempty"`
+	Text      string            `json:"text,omitempty"`
+	Reason    string            `json:"reason,omitempty"`
+	Cost      *float64          `json:"cost,omitempty"`
+	State     openCodeToolState `json:"state,omitempty"`
+	Tokens    *struct {
+		Total     int `json:"total,omitempty"`
+		Input     int `json:"input"`
+		Output    int `json:"output"`
+		Reasoning int `json:"reasoning"`
+		Cache     struct {
+			Read  int `json:"read"`
+			Write int `json:"write"`
+		} `json:"cache"`
+	} `json:"tokens,omitempty"`
+}
+
+type openCodeToolState struct {
+	Status   string          `json:"status,omitempty"`
+	Input    json.RawMessage `json:"input,omitempty"`
+	Output   string          `json:"output,omitempty"`
+	Title    string          `json:"title,omitempty"`
+	Error    json.RawMessage `json:"error,omitempty"`
+	Metadata json.RawMessage `json:"metadata,omitempty"`
 }
 
 func parseOpenCodeStreamLine(line []byte, result *agent.AgentResult, logCh chan<- agent.LogEntry, summaryParts *[]string, lastAssistant *string) {
@@ -137,13 +170,35 @@ func parseOpenCodeStreamLine(line []byte, result *agent.AgentResult, logCh chan<
 		return
 	}
 
+	if sessionID := firstNonEmpty(event.SessionID, event.SessionIDCamel); sessionID != "" {
+		result.AgentSessionID = sessionID
+	}
+
 	switch event.Type {
 	case "session", "session_start", "started":
 		if sessionID := firstNonEmpty(event.SessionID, event.SessionIDCamel, event.ID); sessionID != "" {
 			result.AgentSessionID = sessionID
 		}
 		logCh <- agent.LogEntry{Timestamp: time.Now(), Level: "debug", Message: string(line)}
+	case "step_start":
+		logCh <- agent.LogEntry{Timestamp: time.Now(), Level: "debug", Message: string(line)}
+	case "step_finish":
+		if part, ok := decodeOpenCodePart(event.Part); ok {
+			mergeOpenCodeStepUsage(&result.TokenUsage, part)
+		}
+		logCh <- agent.LogEntry{Timestamp: time.Now(), Level: "debug", Message: string(line)}
 	case "assistant", "message", "text":
+		if part, ok := decodeOpenCodePart(event.Part); ok && part.Type == "text" {
+			content := strings.TrimSpace(part.Text)
+			if content == "" {
+				logCh <- agent.LogEntry{Timestamp: time.Now(), Level: "debug", Message: string(line)}
+				return
+			}
+			logCh <- agent.LogEntry{Timestamp: time.Now(), Level: "output", Message: content}
+			*summaryParts = append(*summaryParts, content)
+			*lastAssistant = content
+			return
+		}
 		content := firstNonEmpty(event.Content, event.Message, event.Text)
 		if content == "" || (event.Type == "message" && event.Role != "" && event.Role != "assistant") {
 			logCh <- agent.LogEntry{Timestamp: time.Now(), Level: "debug", Message: string(line)}
@@ -153,7 +208,15 @@ func parseOpenCodeStreamLine(line []byte, result *agent.AgentResult, logCh chan<
 		*summaryParts = append(*summaryParts, content)
 		*lastAssistant = content
 	case "tool_call", "tool_use":
+		if part, ok := decodeOpenCodePart(event.Part); ok && part.Type == "tool" {
+			emitOpenCodeToolPart(part, logCh)
+			return
+		}
 		toolName := firstNonEmpty(event.Name, event.Tool)
+		if toolName == "" {
+			logCh <- agent.LogEntry{Timestamp: time.Now(), Level: "debug", Message: string(line)}
+			return
+		}
 		metadata := map[string]interface{}{"tool": toolName}
 		if len(event.Input) > 0 {
 			var inputMap map[string]interface{}
@@ -207,6 +270,120 @@ func parseOpenCodeStreamLine(line []byte, result *agent.AgentResult, logCh chan<
 	default:
 		logCh <- agent.LogEntry{Timestamp: time.Now(), Level: "debug", Message: string(line)}
 	}
+}
+
+func decodeOpenCodePart(raw json.RawMessage) (openCodeStreamPart, bool) {
+	if len(bytes.TrimSpace(raw)) == 0 || bytes.Equal(bytes.TrimSpace(raw), []byte("null")) {
+		return openCodeStreamPart{}, false
+	}
+	var part openCodeStreamPart
+	if err := json.Unmarshal(raw, &part); err != nil {
+		return openCodeStreamPart{}, false
+	}
+	return part, true
+}
+
+func emitOpenCodeToolPart(part openCodeStreamPart, logCh chan<- agent.LogEntry) {
+	toolName := strings.TrimSpace(part.Tool)
+	if toolName == "" {
+		return
+	}
+
+	metadata := map[string]interface{}{"tool": toolName}
+	if part.CallID != "" {
+		metadata["call_id"] = part.CallID
+	}
+	if input, ok := openCodeRawObject(part.State.Input); ok {
+		metadata["input"] = input
+	}
+	if part.State.Status != "" {
+		metadata["status"] = part.State.Status
+	}
+
+	message := "using tool: " + toolName
+	if part.State.Title != "" {
+		message = part.State.Title
+	}
+	logCh <- agent.LogEntry{
+		Timestamp: time.Now(),
+		Level:     "tool_use",
+		Message:   message,
+		Metadata:  metadata,
+	}
+
+	resultMetadata := map[string]interface{}{"type": "tool_result", "tool": toolName}
+	if part.CallID != "" {
+		resultMetadata["call_id"] = part.CallID
+	}
+	resultMessage := part.State.Output
+	if part.State.Status == "error" {
+		resultMessage = firstNonEmpty(openCodeRawMessage(part.State.Error), resultMessage)
+		resultMetadata["status"] = "error"
+	} else if part.State.Status != "" {
+		resultMetadata["status"] = part.State.Status
+	}
+	if resultMessage == "" {
+		resultMessage = firstNonEmpty(openCodeRawMessage(part.State.Metadata), part.State.Title)
+	}
+	if resultMessage == "" {
+		return
+	}
+	logCh <- agent.LogEntry{
+		Timestamp: time.Now(),
+		Level:     "output",
+		Message:   resultMessage,
+		Metadata:  resultMetadata,
+	}
+}
+
+func openCodeRawObject(raw json.RawMessage) (map[string]interface{}, bool) {
+	if len(bytes.TrimSpace(raw)) == 0 || bytes.Equal(bytes.TrimSpace(raw), []byte("null")) {
+		return nil, false
+	}
+	var out map[string]interface{}
+	if err := json.Unmarshal(raw, &out); err != nil {
+		return nil, false
+	}
+	return out, true
+}
+
+func openCodeRawMessage(raw json.RawMessage) string {
+	raw = bytes.TrimSpace(raw)
+	if len(raw) == 0 || bytes.Equal(raw, []byte("null")) {
+		return ""
+	}
+	var text string
+	if err := json.Unmarshal(raw, &text); err == nil {
+		return strings.TrimSpace(text)
+	}
+	return string(raw)
+}
+
+func mergeOpenCodeStepUsage(dst *agent.TokenUsage, part openCodeStreamPart) {
+	if part.Tokens != nil {
+		dst.Reported = true
+		dst.InputTokens += part.Tokens.Input
+		dst.CachedInputTokens += part.Tokens.Cache.Read
+		dst.CacheCreationTokens += part.Tokens.Cache.Write
+		dst.OutputTokens += part.Tokens.Output
+		dst.TotalTokens += part.Tokens.Total
+	}
+	if part.Cost != nil {
+		addOpenCodeStepCost(dst, *part.Cost)
+	}
+}
+
+func addOpenCodeStepCost(dst *agent.TokenUsage, amount float64) {
+	dst.Reported = true
+	dst.TotalCostUSD += amount
+	if dst.Cost == nil || dst.Cost.Unit != agent.TokenCostUnitUSD || dst.Cost.Source != agent.TokenCostSourceDirect {
+		dst.Cost = &agent.TokenCost{
+			Unit:   agent.TokenCostUnitUSD,
+			Source: agent.TokenCostSourceDirect,
+		}
+	}
+	dst.Cost.Amount += amount
+	dst.Cost.Detail = "opencode_step_finish_cost"
 }
 
 func openCodePermissionError(event openCodeStreamEvent) string {

--- a/internal/services/agent/adapters/opencode_test.go
+++ b/internal/services/agent/adapters/opencode_test.go
@@ -183,6 +183,81 @@ func TestParseOpenCodeStreamLine(t *testing.T) {
 	require.Equal(t, "bash", logs[2].Metadata["tool"], "OpenCode parser should preserve tool names")
 }
 
+func TestParseOpenCodeStreamLine_OpenCodePartEvents(t *testing.T) {
+	t.Parallel()
+
+	result := &agent.AgentResult{}
+	logCh := make(chan agent.LogEntry, 8)
+	summary := []string{}
+	last := ""
+
+	lines := []string{
+		`{"type":"step_start","timestamp":1782800233819,"sessionID":"ses_part","part":{"id":"prt_step_start","messageID":"msg_part","sessionID":"ses_part","snapshot":"abc123","type":"step-start"}}`,
+		`{"type":"tool_use","timestamp":1782800235638,"sessionID":"ses_part","part":{"id":"prt_tool","messageID":"msg_part","sessionID":"ses_part","type":"tool","callID":"call_pwd","tool":"bash","state":{"status":"completed","input":{"command":"pwd"},"output":"/workspace","title":"pwd","metadata":{},"time":{"start":1782800235500,"end":1782800235638}}}}`,
+		`{"type":"step_finish","timestamp":1782800235758,"sessionID":"ses_part","part":{"id":"prt_step_finish","messageID":"msg_part","sessionID":"ses_part","reason":"tool-calls","snapshot":"abc123","type":"step-finish","tokens":{"total":42,"input":30,"output":7,"reasoning":5,"cache":{"write":2,"read":10}},"cost":0.0123}}`,
+		`{"type":"step_finish","timestamp":1782800235900,"sessionID":"ses_part","part":{"id":"prt_step_finish_2","messageID":"msg_part","sessionID":"ses_part","reason":"stop","snapshot":"def456","type":"step-finish","tokens":{"total":18,"input":11,"output":4,"reasoning":3,"cache":{"write":1,"read":2}},"cost":0.0042}}`,
+		`{"type":"text","timestamp":1782800236000,"sessionID":"ses_part","part":{"id":"prt_text","messageID":"msg_part","sessionID":"ses_part","type":"text","text":"Done."}}`,
+	}
+
+	for _, line := range lines {
+		parseOpenCodeStreamLine([]byte(line), result, logCh, &summary, &last)
+	}
+	close(logCh)
+
+	logs := drain(logCh)
+	require.Equal(t, "ses_part", result.AgentSessionID, "OpenCode parser should capture session id from v1.17 event envelopes")
+	require.True(t, result.TokenUsage.Reported, "OpenCode parser should capture step-finish token usage")
+	require.Equal(t, 41, result.TokenUsage.InputTokens, "OpenCode parser should accumulate step-finish input tokens")
+	require.Equal(t, 12, result.TokenUsage.CachedInputTokens, "OpenCode parser should accumulate step-finish cached input tokens")
+	require.Equal(t, 3, result.TokenUsage.CacheCreationTokens, "OpenCode parser should accumulate step-finish cache write tokens")
+	require.Equal(t, 11, result.TokenUsage.OutputTokens, "OpenCode parser should accumulate step-finish output tokens")
+	require.Equal(t, 60, result.TokenUsage.TotalTokens, "OpenCode parser should accumulate step-finish total tokens")
+	require.NotNil(t, result.TokenUsage.Cost, "OpenCode parser should capture step-finish reported cost")
+	require.Equal(t, agent.TokenCostSourceDirect, result.TokenUsage.Cost.Source, "OpenCode parser should mark step-finish reported cost as direct")
+	require.InDelta(t, 0.0165, result.TokenUsage.TotalCostUSD, 0.0000001, "OpenCode parser should accumulate step-finish total cost")
+	require.InDelta(t, 0.0165, result.TokenUsage.Cost.Amount, 0.0000001, "OpenCode parser should accumulate step-finish direct cost")
+	require.Equal(t, "Done.", last, "OpenCode parser should track v1.17 text parts as assistant output")
+	require.Contains(t, strings.Join(summary, "\n"), "Done.", "OpenCode parser should add v1.17 text parts to the summary")
+	require.Len(t, logs, 6, "OpenCode parser should expand v1.17 tool parts into use/result logs while preserving step debug logs")
+	require.Equal(t, "debug", logs[0].Level, "step-start events should remain debug logs")
+	require.Equal(t, "tool_use", logs[1].Level, "completed tool parts should emit a tool_use log")
+	require.Equal(t, "bash", logs[1].Metadata["tool"], "completed tool parts should preserve the nested tool name")
+	require.Equal(t, "call_pwd", logs[1].Metadata["call_id"], "completed tool parts should preserve the nested call id")
+	require.Equal(t, map[string]interface{}{"command": "pwd"}, logs[1].Metadata["input"], "completed tool parts should preserve the nested input")
+	require.Equal(t, "output", logs[2].Level, "completed tool parts should emit a paired tool_result log")
+	require.Equal(t, "tool_result", logs[2].Metadata["type"], "paired tool result should be tagged for timeline grouping")
+	require.Equal(t, "bash", logs[2].Metadata["tool"], "paired tool result should preserve the tool name")
+	require.Equal(t, "call_pwd", logs[2].Metadata["call_id"], "paired tool result should preserve the call id")
+	require.Equal(t, "/workspace", logs[2].Message, "paired tool result should preserve tool output")
+	require.Equal(t, "debug", logs[3].Level, "step-finish events should remain debug logs")
+	require.Equal(t, "debug", logs[4].Level, "additional step-finish events should remain debug logs")
+	require.Equal(t, "output", logs[5].Level, "text parts should emit assistant output logs")
+}
+
+func TestParseOpenCodeStreamLine_OpenCodeErroredToolPart(t *testing.T) {
+	t.Parallel()
+
+	result := &agent.AgentResult{}
+	logCh := make(chan agent.LogEntry, 4)
+	summary := []string{}
+	last := ""
+
+	line := `{"type":"tool_use","timestamp":1782800235638,"sessionID":"ses_part","part":{"id":"prt_tool","messageID":"msg_part","sessionID":"ses_part","type":"tool","callID":"call_test","tool":"bash","state":{"status":"error","input":{"command":"go test ./..."},"error":"exit status 1","metadata":{},"time":{"start":1782800235500,"end":1782800235638}}}}`
+	parseOpenCodeStreamLine([]byte(line), result, logCh, &summary, &last)
+	close(logCh)
+
+	logs := drain(logCh)
+	require.Equal(t, "ses_part", result.AgentSessionID, "OpenCode parser should capture session id from errored tool events")
+	require.Len(t, logs, 2, "errored tool parts should still emit use/result logs for timeline grouping")
+	require.Equal(t, "tool_use", logs[0].Level, "errored tool parts should emit the tool use first")
+	require.Equal(t, "bash", logs[0].Metadata["tool"], "errored tool use should preserve the tool name")
+	require.Equal(t, map[string]interface{}{"command": "go test ./..."}, logs[0].Metadata["input"], "errored tool use should preserve input")
+	require.Equal(t, "output", logs[1].Level, "errored tool parts should emit a paired result log")
+	require.Equal(t, "tool_result", logs[1].Metadata["type"], "errored tool result should be tagged for timeline grouping")
+	require.Equal(t, "error", logs[1].Metadata["status"], "errored tool result should preserve status")
+	require.Equal(t, "exit status 1", logs[1].Message, "errored tool result should preserve the error message")
+}
+
 func TestParseOpenCodeStreamLine_ErrorAndPermissionEvents(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

Fixes OpenCode JSON stream parsing so newer part-based events produce useful session logs instead of falling back to unknown tool labels.

## Root Cause

OpenCode v1.17 emits tool, text, and step usage details under a nested `part` payload. The adapter only handled older flat event fields, so nested tool events arrived without a top-level tool name and the UI rendered them as `Ran unknown`. Step-finish usage events are per model step, so token and cost values also need to be accumulated rather than replaced.

## Changes

- Parse nested OpenCode `part` events for text, tool use, tool result, and step-finish usage.
- Preserve tool names, call IDs, inputs, outputs, statuses, and session IDs from part-based events.
- Accumulate OpenCode step-finish token and cost totals across multi-step sessions.
- Change the frontend fallback from `Ran unknown` to `Ran tool` when metadata still lacks a tool name.

## Validation

- `go test ./internal/services/agent/adapters`
- `go vet ./internal/services/agent/adapters`
- `npm test -- --run src/lib/tool-label.test.ts`
- `npx eslint src/lib/tool-label.ts src/lib/tool-label.test.ts --max-warnings=0`
- `git diff --check`