### PR TITLE
Fix SSRF and git argument injection in integration paths

### DIFF
--- a/internal/api/handlers/automations_validation.go
+++ b/internal/api/handlers/automations_validation.go
@@ -55,6 +55,12 @@ func validateBaseBranch(b string) error {
 	if strings.Contains(b, "..") {
 		return fmt.Errorf("base_branch must not contain '..'")
 	}
+	// A leading '-' lets the value be parsed as an option (not a refspec) when
+	// it later reaches `git fetch origin <branch>`, so reject it here at the
+	// write rather than relying solely on --end-of-options at the call sites.
+	if strings.HasPrefix(b, "-") {
+		return fmt.Errorf("base_branch must not start with '-'")
+	}
 	return nil
 }
 

--- a/internal/api/handlers/integrations.go
+++ b/internal/api/handlers/integrations.go
@@ -204,6 +204,11 @@ type IntegrationHandler struct {
 	frontendURL      string
 	client           *http.Client
 
+	// untrustedURLClient fetches user-supplied URLs (e.g. a custom Mezmo
+	// base_url). It blocks private/loopback/metadata addresses at dial time;
+	// never use h.client for caller-controlled hosts. See ssrf_guard.go.
+	untrustedURLClient *http.Client
+
 	// Linear OAuth
 	linearClientID string
 	linearSecret   string
@@ -315,13 +320,14 @@ func NewIntegrationHandler(
 	opts ...IntegrationHandlerOption,
 ) *IntegrationHandler {
 	h := &IntegrationHandler{
-		integrationStore: integrationStore,
-		credentialStore:  credentialStore,
-		linearClientID:   linearClientID,
-		linearSecret:     linearSecret,
-		baseURL:          baseURL,
-		frontendURL:      frontendURL,
-		client:           http.DefaultClient,
+		integrationStore:   integrationStore,
+		credentialStore:    credentialStore,
+		linearClientID:     linearClientID,
+		linearSecret:       linearSecret,
+		baseURL:            baseURL,
+		frontendURL:        frontendURL,
+		client:             http.DefaultClient,
+		untrustedURLClient: newSSRFSafeHTTPClient(30 * time.Second),
 		slackUserInfoClient: ingestion.NewSlackAPIClient(
 			zerolog.Nop(),
 		),
@@ -4212,8 +4218,8 @@ func (h *IntegrationHandler) ConnectMezmo(w http.ResponseWriter, r *http.Request
 		return
 	}
 	if req.BaseURL != "" {
-		if u, err := url.Parse(req.BaseURL); err != nil || u.Scheme == "" || u.Host == "" {
-			writeError(w, r, http.StatusBadRequest, "INVALID_BASE_URL", "base_url must be an absolute URL (e.g. https://api.mezmo.com)")
+		if err := validatePublicHTTPURL(req.BaseURL); err != nil {
+			writeError(w, r, http.StatusBadRequest, "INVALID_BASE_URL", "base_url must be a public http(s) URL (e.g. https://api.mezmo.com)")
 			return
 		}
 	}
@@ -4306,7 +4312,9 @@ func (h *IntegrationHandler) validateMezmoTokenRequest(ctx context.Context, base
 	}
 	req.Header.Set(authHeader, authValue)
 
-	resp, err := h.client.Do(req)
+	// base_url is user-supplied, so use the SSRF-safe client (private/loopback/
+	// metadata addresses are blocked at dial time and across redirects).
+	resp, err := h.untrustedURLClient.Do(req)
 	if err != nil {
 		return 0, err
 	}

--- a/internal/api/handlers/integrations_test.go
+++ b/internal/api/handlers/integrations_test.go
@@ -3715,7 +3715,7 @@ func TestIntegrationHandler_ConnectMezmo_Success(t *testing.T) {
 	handler := NewIntegrationHandler(
 		store, credentialStore, "", "", "http://localhost:8080", "http://localhost:3000",
 	)
-	handler.client = &http.Client{Transport: transport}
+	handler.untrustedURLClient = &http.Client{Transport: transport}
 
 	mock.ExpectQuery("INSERT INTO org_credentials").
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
@@ -3786,6 +3786,49 @@ func TestIntegrationHandler_ConnectMezmo_RejectsMalformedBaseURL(t *testing.T) {
 	require.Contains(t, w.Body.String(), "INVALID_BASE_URL")
 }
 
+func TestIntegrationHandler_ConnectMezmo_RejectsSSRFBaseURL(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name    string
+		baseURL string
+	}{
+		{"cloud metadata endpoint", "http://169.254.169.254/latest/meta-data"},
+		{"loopback", "http://127.0.0.1:8080"},
+		{"localhost name as IP literal", "http://0.0.0.0:9000"},
+		{"rfc1918 private", "http://10.0.0.3:5432"},
+		{"rfc1918 192.168", "https://192.168.1.1"},
+		{"non-http scheme", "file:///etc/passwd"},
+		{"gopher scheme", "gopher://169.254.169.254"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			mock, err := pgxmock.NewPool()
+			require.NoError(t, err)
+			defer mock.Close()
+
+			store := db.NewIntegrationStore(mock)
+			handler := NewIntegrationHandler(store, nil, "", "", "http://localhost:8080", "http://localhost:3000")
+			// No HTTP client mock is set: a correct guard rejects before dialing,
+			// so the request must never reach validateMezmoTokenRequest.
+
+			body := `{"api_key":"key","base_url":"` + tc.baseURL + `"}`
+			req := httptest.NewRequest(http.MethodPost, "/api/v1/integrations/mezmo/connect", bytes.NewBufferString(body))
+			req.Header.Set("Content-Type", "application/json")
+			req = req.WithContext(middleware.WithOrgID(req.Context(), uuid.New()))
+			w := httptest.NewRecorder()
+
+			handler.ConnectMezmo(w, req)
+
+			require.Equal(t, http.StatusBadRequest, w.Code, "SSRF base_url %q must be rejected", tc.baseURL)
+			require.Contains(t, w.Body.String(), "INVALID_BASE_URL")
+			require.NoError(t, mock.ExpectationsWereMet())
+		})
+	}
+}
+
 func TestIntegrationHandler_ConnectMezmo_HonorsCustomBaseURL(t *testing.T) {
 	t.Parallel()
 
@@ -3811,7 +3854,7 @@ func TestIntegrationHandler_ConnectMezmo_HonorsCustomBaseURL(t *testing.T) {
 	})
 
 	handler := NewIntegrationHandler(store, credentialStore, "", "", "http://localhost:8080", "http://localhost:3000")
-	handler.client = &http.Client{Transport: transport}
+	handler.untrustedURLClient = &http.Client{Transport: transport}
 
 	mock.ExpectQuery("INSERT INTO org_credentials").
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
@@ -3853,7 +3896,7 @@ func TestIntegrationHandler_ConnectMezmo_InvalidToken(t *testing.T) {
 	})
 
 	handler := NewIntegrationHandler(store, nil, "", "", "http://localhost:8080", "http://localhost:3000")
-	handler.client = &http.Client{Transport: transport}
+	handler.untrustedURLClient = &http.Client{Transport: transport}
 
 	body := `{"api_key":"bad"}`
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/integrations/mezmo/connect", bytes.NewBufferString(body))
@@ -3929,7 +3972,7 @@ func TestIntegrationHandler_ConnectMezmo_RejectsNotFound(t *testing.T) {
 	})
 
 	handler := NewIntegrationHandler(store, nil, "", "", "http://localhost:8080", "http://localhost:3000")
-	handler.client = &http.Client{Transport: transport}
+	handler.untrustedURLClient = &http.Client{Transport: transport}
 
 	body := `{"api_key":"mezmo_key"}`
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/integrations/mezmo/connect", bytes.NewBufferString(body))
@@ -3970,7 +4013,7 @@ func TestIntegrationHandler_ConnectMezmo_AcceptsNonAuth4xx(t *testing.T) {
 	})
 
 	handler := NewIntegrationHandler(store, credentialStore, "", "", "http://localhost:8080", "http://localhost:3000")
-	handler.client = &http.Client{Transport: transport}
+	handler.untrustedURLClient = &http.Client{Transport: transport}
 
 	mock.ExpectQuery("INSERT INTO org_credentials").
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
@@ -4014,7 +4057,7 @@ func TestIntegrationHandler_ConnectMezmo_RejectsServerError(t *testing.T) {
 	})
 
 	handler := NewIntegrationHandler(store, nil, "", "", "http://localhost:8080", "http://localhost:3000")
-	handler.client = &http.Client{Transport: transport}
+	handler.untrustedURLClient = &http.Client{Transport: transport}
 
 	body := `{"api_key":"mezmo_key"}`
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/integrations/mezmo/connect", bytes.NewBufferString(body))

--- a/internal/api/handlers/pagerduty_integrations.go
+++ b/internal/api/handlers/pagerduty_integrations.go
@@ -1131,7 +1131,11 @@ func (h *PagerDutyIntegrationHandler) resolveIncidentSessionRepository(w http.Re
 		if !h.validatePagerDutyRepository(w, r, orgID, *requestedRepoID, "repository_id") {
 			return uuid.Nil, nil, false
 		}
-		return *requestedRepoID, trimOptionalStringPointer(requestedBaseBranch), true
+		baseBranch := trimOptionalStringPointer(requestedBaseBranch)
+		if !validatePagerDutyBaseBranch(w, r, baseBranch) {
+			return uuid.Nil, nil, false
+		}
+		return *requestedRepoID, baseBranch, true
 	}
 	if h.mappings != nil && incident.ServiceID != nil && strings.TrimSpace(*incident.ServiceID) != "" {
 		mapping, err := h.mappings.GetByServiceID(r.Context(), orgID, incident.PagerDutyIntegrationID, strings.TrimSpace(*incident.ServiceID))
@@ -1139,6 +1143,9 @@ func (h *PagerDutyIntegrationHandler) resolveIncidentSessionRepository(w http.Re
 			baseBranch := trimOptionalStringPointer(requestedBaseBranch)
 			if baseBranch == nil {
 				baseBranch = trimOptionalStringPointer(mapping.BaseBranch)
+			}
+			if !validatePagerDutyBaseBranch(w, r, baseBranch) {
+				return uuid.Nil, nil, false
 			}
 			return mapping.RepositoryID, baseBranch, true
 		}
@@ -1150,7 +1157,11 @@ func (h *PagerDutyIntegrationHandler) resolveIncidentSessionRepository(w http.Re
 	if h.pagerDutyIntegrations != nil {
 		integration, err := h.pagerDutyIntegrations.GetByID(r.Context(), orgID, incident.PagerDutyIntegrationID)
 		if err == nil && integration.DefaultRepositoryID != nil && *integration.DefaultRepositoryID != uuid.Nil {
-			return *integration.DefaultRepositoryID, trimOptionalStringPointer(requestedBaseBranch), true
+			baseBranch := trimOptionalStringPointer(requestedBaseBranch)
+			if !validatePagerDutyBaseBranch(w, r, baseBranch) {
+				return uuid.Nil, nil, false
+			}
+			return *integration.DefaultRepositoryID, baseBranch, true
 		}
 		if err != nil && !errors.Is(err, pgx.ErrNoRows) {
 			writeError(w, r, http.StatusInternalServerError, "INTEGRATION_LOOKUP_FAILED", "failed to resolve PagerDuty integration defaults", err)
@@ -1159,6 +1170,22 @@ func (h *PagerDutyIntegrationHandler) resolveIncidentSessionRepository(w http.Re
 	}
 	writeError(w, r, http.StatusBadRequest, "REPOSITORY_UNMAPPED", "PagerDuty incident service is not mapped to a repository")
 	return uuid.Nil, nil, false
+}
+
+// validatePagerDutyBaseBranch rejects a resolved base branch that isn't a safe
+// git ref before it becomes a session TargetBranch (and reaches `git fetch
+// origin <branch>`). A nil branch is allowed. On rejection it writes a 400 and
+// returns false. Both the request-supplied branch and a stored service-mapping
+// branch flow through here, so neither source can inject a git argument.
+func validatePagerDutyBaseBranch(w http.ResponseWriter, r *http.Request, branch *string) bool {
+	if branch == nil {
+		return true
+	}
+	if !isValidGitRef(*branch) {
+		writeError(w, r, http.StatusBadRequest, "INVALID_BASE_BRANCH", "base_branch is not a valid git branch name")
+		return false
+	}
+	return true
 }
 
 func (h *PagerDutyIntegrationHandler) lookupPagerDutyIncident(ctx context.Context, orgID uuid.UUID, integrationID *uuid.UUID, incidentID string) (models.PagerDutyIncident, error) {

--- a/internal/api/handlers/sessions.go
+++ b/internal/api/handlers/sessions.go
@@ -19,6 +19,7 @@ import (
 	"github.com/assembledhq/143/internal/api/sse"
 	"github.com/assembledhq/143/internal/cache"
 	"github.com/assembledhq/143/internal/db"
+	"github.com/assembledhq/143/internal/gitref"
 	"github.com/assembledhq/143/internal/llm"
 	"github.com/assembledhq/143/internal/metrics"
 	"github.com/assembledhq/143/internal/models"
@@ -4641,17 +4642,9 @@ func (h *SessionHandler) UnarchiveSession(w http.ResponseWriter, r *http.Request
 	writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
 }
 
-// gitRefPattern validates git ref names. Allows alphanumeric, dots, hyphens,
-// underscores, and forward slashes (for namespaced branches like feature/foo).
-var gitRefPattern = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9._/-]*$`)
-
-// isValidGitRef checks whether s is a plausible git branch/ref name.
+// isValidGitRef checks whether s is a plausible git branch/ref name. It
+// delegates to the shared gitref validator so the API, worker, and slackbot
+// paths all enforce identical rules (see internal/gitref).
 func isValidGitRef(s string) bool {
-	if s == "" || len(s) > 255 {
-		return false
-	}
-	if strings.Contains(s, "..") || strings.Contains(s, "~") || strings.Contains(s, "^") || strings.Contains(s, ":") || strings.Contains(s, " ") || strings.Contains(s, "\\") {
-		return false
-	}
-	return gitRefPattern.MatchString(s)
+	return gitref.IsValidRef(s)
 }

--- a/internal/api/handlers/ssrf_guard.go
+++ b/internal/api/handlers/ssrf_guard.go
@@ -77,7 +77,7 @@ func validatePublicHTTPURL(raw string) error {
 		return fmt.Errorf("URL must include a host")
 	}
 	if ip := net.ParseIP(host); ip != nil && isBlockedIP(ip) {
-		return fmt.Errorf("URL host resolves to a non-public address")
+		return fmt.Errorf("URL host is a non-public address")
 	}
 	return nil
 }
@@ -100,6 +100,19 @@ func ssrfSafeDialControl(_, address string, _ syscall.RawConn) error {
 	return nil
 }
 
+// ssrfSafeCheckRedirect re-validates the scheme of each redirect hop and caps
+// the chain. The dial-time control already blocks redirects to private targets;
+// this additionally refuses a redirect that switches to a non-http(s) scheme.
+func ssrfSafeCheckRedirect(req *http.Request, via []*http.Request) error {
+	if len(via) >= 10 {
+		return fmt.Errorf("ssrf guard: stopped after 10 redirects")
+	}
+	if s := strings.ToLower(req.URL.Scheme); s != "http" && s != "https" {
+		return fmt.Errorf("ssrf guard: refusing redirect to scheme %q", req.URL.Scheme)
+	}
+	return nil
+}
+
 // newSSRFSafeHTTPClient returns an *http.Client for fetching user-supplied URLs.
 // It blocks connections to private/loopback/link-local/metadata addresses at
 // dial time (DNS-rebind safe), re-validates each redirect hop's scheme, and
@@ -111,7 +124,12 @@ func newSSRFSafeHTTPClient(timeout time.Duration) *http.Client {
 		Control:   ssrfSafeDialControl,
 	}
 	transport := &http.Transport{
-		Proxy:                 http.ProxyFromEnvironment,
+		// Proxy is deliberately nil. An HTTP(S)_PROXY would make the dialer
+		// connect to the proxy (a public address that passes the dial-time
+		// control) while the real, possibly-private target host is sent to the
+		// proxy in the request — bypassing the SSRF guard entirely. We must dial
+		// the target directly so ssrfSafeDialControl inspects its actual IP.
+		Proxy:                 nil,
 		DialContext:           dialer.DialContext,
 		ForceAttemptHTTP2:     true,
 		MaxIdleConns:          10,
@@ -120,16 +138,8 @@ func newSSRFSafeHTTPClient(timeout time.Duration) *http.Client {
 		ExpectContinueTimeout: 1 * time.Second,
 	}
 	return &http.Client{
-		Timeout:   timeout,
-		Transport: transport,
-		CheckRedirect: func(req *http.Request, via []*http.Request) error {
-			if len(via) >= 10 {
-				return fmt.Errorf("ssrf guard: stopped after 10 redirects")
-			}
-			if s := strings.ToLower(req.URL.Scheme); s != "http" && s != "https" {
-				return fmt.Errorf("ssrf guard: refusing redirect to scheme %q", req.URL.Scheme)
-			}
-			return nil
-		},
+		Timeout:       timeout,
+		Transport:     transport,
+		CheckRedirect: ssrfSafeCheckRedirect,
 	}
 }

--- a/internal/api/handlers/ssrf_guard.go
+++ b/internal/api/handlers/ssrf_guard.go
@@ -1,0 +1,135 @@
+package handlers
+
+import (
+	"fmt"
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+	"syscall"
+	"time"
+)
+
+// SSRF (server-side request forgery) protection for outbound requests whose
+// target URL is supplied by a user. Trusted, hard-coded integration hosts
+// (GitHub, Slack, Notion, etc.) do not need this; only paths that fetch a
+// caller-provided URL should route through newSSRFSafeHTTPClient.
+
+// blockedIPNetworks are CIDR ranges that server-side requests must never reach:
+// loopback, RFC1918 private space, the cloud-metadata link-local range
+// (169.254.169.254 lives here), carrier-grade NAT, IPv6 unique-local, and the
+// Tailscale CGNAT range used for this fleet's internal mesh.
+var blockedIPNetworks = func() []*net.IPNet {
+	cidrs := []string{
+		"127.0.0.0/8",    // IPv4 loopback
+		"10.0.0.0/8",     // RFC1918
+		"172.16.0.0/12",  // RFC1918
+		"192.168.0.0/16", // RFC1918
+		"169.254.0.0/16", // link-local (incl. cloud metadata 169.254.169.254)
+		"100.64.0.0/10",  // CGNAT / Tailscale mesh
+		"0.0.0.0/8",      // "this host"
+		"::1/128",        // IPv6 loopback
+		"fe80::/10",      // IPv6 link-local
+		"fc00::/7",       // IPv6 unique-local
+		"ff00::/8",       // IPv6 multicast
+	}
+	nets := make([]*net.IPNet, 0, len(cidrs))
+	for _, c := range cidrs {
+		_, n, err := net.ParseCIDR(c)
+		if err != nil {
+			panic(fmt.Sprintf("ssrf_guard: bad CIDR %q: %v", c, err))
+		}
+		nets = append(nets, n)
+	}
+	return nets
+}()
+
+// isBlockedIP reports whether ip falls in a range outbound user-driven requests
+// must not reach. A nil/unspecified/multicast address is also blocked.
+func isBlockedIP(ip net.IP) bool {
+	if ip == nil || ip.IsUnspecified() || ip.IsMulticast() || ip.IsLoopback() {
+		return true
+	}
+	for _, n := range blockedIPNetworks {
+		if n.Contains(ip) {
+			return true
+		}
+	}
+	return false
+}
+
+// validatePublicHTTPURL parses raw and returns an error unless it is an absolute
+// http(s) URL with a host. If the host is an IP literal, it is checked against
+// the blocklist immediately so we can reject with a clean 4xx before dialing.
+// Hostnames are not resolved here (that happens at dial time, which is DNS-rebind
+// safe) — this is a cheap up-front filter, not the primary control.
+func validatePublicHTTPURL(raw string) error {
+	u, err := url.Parse(raw)
+	if err != nil {
+		return fmt.Errorf("invalid URL")
+	}
+	scheme := strings.ToLower(u.Scheme)
+	if scheme != "http" && scheme != "https" {
+		return fmt.Errorf("URL scheme must be http or https")
+	}
+	host := u.Hostname()
+	if host == "" {
+		return fmt.Errorf("URL must include a host")
+	}
+	if ip := net.ParseIP(host); ip != nil && isBlockedIP(ip) {
+		return fmt.Errorf("URL host resolves to a non-public address")
+	}
+	return nil
+}
+
+// ssrfSafeDialControl is a net.Dialer Control hook. It runs after DNS resolution
+// on the concrete address being dialed, so it defeats DNS rebinding and is
+// re-applied on every redirect hop.
+func ssrfSafeDialControl(_, address string, _ syscall.RawConn) error {
+	host, _, err := net.SplitHostPort(address)
+	if err != nil {
+		return fmt.Errorf("ssrf guard: malformed dial address %q", address)
+	}
+	ip := net.ParseIP(host)
+	if ip == nil {
+		return fmt.Errorf("ssrf guard: unresolved dial address %q", host)
+	}
+	if isBlockedIP(ip) {
+		return fmt.Errorf("ssrf guard: refusing to connect to non-public address %s", ip)
+	}
+	return nil
+}
+
+// newSSRFSafeHTTPClient returns an *http.Client for fetching user-supplied URLs.
+// It blocks connections to private/loopback/link-local/metadata addresses at
+// dial time (DNS-rebind safe), re-validates each redirect hop's scheme, and
+// caps redirects. timeout bounds the whole request.
+func newSSRFSafeHTTPClient(timeout time.Duration) *http.Client {
+	dialer := &net.Dialer{
+		Timeout:   10 * time.Second,
+		KeepAlive: 30 * time.Second,
+		Control:   ssrfSafeDialControl,
+	}
+	transport := &http.Transport{
+		Proxy:                 http.ProxyFromEnvironment,
+		DialContext:           dialer.DialContext,
+		ForceAttemptHTTP2:     true,
+		MaxIdleConns:          10,
+		IdleConnTimeout:       90 * time.Second,
+		TLSHandshakeTimeout:   10 * time.Second,
+		ExpectContinueTimeout: 1 * time.Second,
+	}
+	return &http.Client{
+		Timeout:   timeout,
+		Transport: transport,
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			if len(via) >= 10 {
+				return fmt.Errorf("ssrf guard: stopped after 10 redirects")
+			}
+			if s := strings.ToLower(req.URL.Scheme); s != "http" && s != "https" {
+				return fmt.Errorf("ssrf guard: refusing redirect to scheme %q", req.URL.Scheme)
+			}
+			return nil
+		},
+	}
+}

--- a/internal/api/handlers/ssrf_guard_test.go
+++ b/internal/api/handlers/ssrf_guard_test.go
@@ -1,0 +1,158 @@
+package handlers
+
+import (
+	"net"
+	"net/http"
+	"net/url"
+	"testing"
+)
+
+func TestIsBlockedIP(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		ip      string
+		blocked bool
+	}{
+		// Public addresses are allowed.
+		{"8.8.8.8", false},
+		{"1.1.1.1", false},
+		{"93.184.216.34", false}, // example.com
+		{"2606:4700:4700::1111", false},
+
+		// Loopback.
+		{"127.0.0.1", true},
+		{"127.0.0.53", true},
+		{"::1", true},
+
+		// Cloud metadata / link-local.
+		{"169.254.169.254", true},
+		{"169.254.0.1", true},
+		{"fe80::1", true},
+
+		// RFC1918 private.
+		{"10.0.0.3", true},
+		{"172.16.5.4", true},
+		{"192.168.1.1", true},
+
+		// CGNAT / Tailscale mesh.
+		{"100.64.0.1", true},
+		{"100.127.255.255", true},
+
+		// Unspecified / "this host".
+		{"0.0.0.0", true},
+		{"::", true},
+
+		// IPv6 unique-local and multicast.
+		{"fc00::1", true},
+		{"fd12:3456::1", true},
+		{"ff02::1", true},
+
+		// IPv4-mapped IPv6 must not bypass the IPv4 blocklist.
+		{"::ffff:127.0.0.1", true},
+		{"::ffff:169.254.169.254", true},
+		{"::ffff:10.0.0.1", true},
+		{"::ffff:8.8.8.8", false},
+	}
+	for _, tc := range cases {
+		ip := net.ParseIP(tc.ip)
+		if ip == nil {
+			t.Fatalf("test setup: could not parse IP %q", tc.ip)
+		}
+		if got := isBlockedIP(ip); got != tc.blocked {
+			t.Errorf("isBlockedIP(%s) = %v, want %v", tc.ip, got, tc.blocked)
+		}
+	}
+	if !isBlockedIP(nil) {
+		t.Errorf("isBlockedIP(nil) should be true")
+	}
+}
+
+func TestSSRFSafeDialControl(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name    string
+		address string
+		wantErr bool
+	}{
+		{"public ipv4", "8.8.8.8:443", false},
+		{"public ipv6 bracketed", "[2606:4700:4700::1111]:443", false},
+		{"loopback", "127.0.0.1:80", true},
+		{"loopback ipv6 bracketed", "[::1]:80", true},
+		{"metadata endpoint", "169.254.169.254:80", true},
+		{"rfc1918", "10.0.0.3:5432", true},
+		{"v4-mapped loopback", "[::ffff:127.0.0.1]:80", true},
+		{"missing port", "8.8.8.8", true},                // SplitHostPort fails
+		{"unresolved hostname", "example.com:443", true}, // ParseIP returns nil
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			err := ssrfSafeDialControl("tcp", tc.address, nil)
+			if (err != nil) != tc.wantErr {
+				t.Errorf("ssrfSafeDialControl(%q) err = %v, wantErr %v", tc.address, err, tc.wantErr)
+			}
+		})
+	}
+}
+
+func TestSSRFSafeCheckRedirect(t *testing.T) {
+	t.Parallel()
+
+	mkReq := func(rawurl string) *http.Request {
+		u, err := url.Parse(rawurl)
+		if err != nil {
+			t.Fatalf("test setup: bad url %q: %v", rawurl, err)
+		}
+		return &http.Request{URL: u}
+	}
+
+	if err := ssrfSafeCheckRedirect(mkReq("https://example.com/a"), nil); err != nil {
+		t.Errorf("https redirect should be allowed, got %v", err)
+	}
+	if err := ssrfSafeCheckRedirect(mkReq("http://example.com/a"), nil); err != nil {
+		t.Errorf("http redirect should be allowed, got %v", err)
+	}
+	if err := ssrfSafeCheckRedirect(mkReq("file:///etc/passwd"), nil); err == nil {
+		t.Errorf("file:// redirect should be refused")
+	}
+	if err := ssrfSafeCheckRedirect(mkReq("gopher://169.254.169.254"), nil); err == nil {
+		t.Errorf("gopher:// redirect should be refused")
+	}
+
+	// Redirect chain cap.
+	via := make([]*http.Request, 10)
+	if err := ssrfSafeCheckRedirect(mkReq("https://example.com/loop"), via); err == nil {
+		t.Errorf("redirect chain of 10 should be stopped")
+	}
+}
+
+func TestValidatePublicHTTPURL(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		raw     string
+		wantErr bool
+	}{
+		{"https://api.mezmo.com", false},
+		{"http://logs.example.com:8080/path", false},
+		{"https://8.8.8.8", false},
+		{"", true},
+		{"not-a-url", true},
+		{"ftp://example.com", true},
+		{"file:///etc/passwd", true},
+		{"gopher://169.254.169.254", true},
+		{"https://", true},                      // no host
+		{"http://169.254.169.254/latest", true}, // metadata literal
+		{"http://127.0.0.1:8080", true},         // loopback literal
+		{"http://10.0.0.3:5432", true},          // rfc1918 literal
+		{"http://[::1]:80", true},               // ipv6 loopback literal
+		{"http://[::ffff:127.0.0.1]:80", true},  // v4-mapped loopback literal
+	}
+	for _, tc := range cases {
+		if err := validatePublicHTTPURL(tc.raw); (err != nil) != tc.wantErr {
+			t.Errorf("validatePublicHTTPURL(%q) err = %v, wantErr %v", tc.raw, err, tc.wantErr)
+		}
+	}
+}

--- a/internal/gitref/gitref.go
+++ b/internal/gitref/gitref.go
@@ -1,0 +1,38 @@
+// Package gitref provides a single, shared validator for git ref/branch names
+// that originate from external input (REST bodies, Slack messages, PagerDuty
+// payloads, etc.). Centralizing it keeps the rules consistent across the API,
+// worker, and slackbot packages — the value eventually reaches shell commands
+// like `git fetch origin <branch>`, where a value that git can mistake for an
+// option (leading '-') or a malformed refspec must never slip through.
+package gitref
+
+import (
+	"regexp"
+	"strings"
+)
+
+// pattern requires an alphanumeric first character (so a value can never be
+// parsed as a `-flag`) and restricts the rest to characters that are safe in a
+// branch/ref name. It deliberately excludes ':' (refspec separator), '~', '^',
+// '?', '*', '[', whitespace, and backslashes.
+var pattern = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9._/-]*$`)
+
+// IsValidRef reports whether s is a safe git ref/branch name to forward into a
+// git command. It is intentionally stricter than git's own check-ref-format:
+// false negatives just surface a clear "invalid branch" error, whereas a false
+// positive could enable git argument injection.
+func IsValidRef(s string) bool {
+	if s == "" || len(s) > 255 {
+		return false
+	}
+	if strings.ContainsAny(s, " \t\n\r\\") {
+		return false
+	}
+	if strings.Contains(s, "..") ||
+		strings.Contains(s, "~") ||
+		strings.Contains(s, "^") ||
+		strings.Contains(s, ":") {
+		return false
+	}
+	return pattern.MatchString(s)
+}

--- a/internal/gitref/gitref_test.go
+++ b/internal/gitref/gitref_test.go
@@ -1,0 +1,59 @@
+package gitref
+
+import "testing"
+
+func TestIsValidRef(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		ref  string
+		want bool
+	}{
+		// Valid refs.
+		{"main", true},
+		{"feature/foo", true},
+		{"release-1.2.3", true},
+		{"a", true},
+		{"users/john/fix_bug", true},
+		{"v2.0.0", true},
+
+		// Invalid: empty / too long.
+		{"", false},
+
+		// Invalid: leading '-' would be parsed by git as an option, not a refspec.
+		{"-foo", false},
+		{"--upload-pack=touch /tmp/pwned", false},
+		{"-", false},
+
+		// Invalid: shell/ref-hostile characters.
+		{"foo bar", false},
+		{"foo;rm -rf /", false},
+		{"foo$(id)", false},
+		{"foo:bar", false},
+		{"foo..bar", false},
+		{"foo~1", false},
+		{"foo^", false},
+		{"foo\\bar", false},
+		{"foo\tbar", false},
+		{"foo\nbar", false},
+		{".hidden", false}, // must start alphanumeric
+		{"/abs", false},
+	}
+	for _, tc := range cases {
+		if got := IsValidRef(tc.ref); got != tc.want {
+			t.Errorf("IsValidRef(%q) = %v, want %v", tc.ref, got, tc.want)
+		}
+	}
+}
+
+func TestIsValidRef_LengthCap(t *testing.T) {
+	t.Parallel()
+
+	long := make([]byte, 256)
+	for i := range long {
+		long[i] = 'a'
+	}
+	if IsValidRef(string(long)) {
+		t.Errorf("IsValidRef should reject refs longer than 255 chars")
+	}
+}

--- a/internal/services/agent/orchestrator.go
+++ b/internal/services/agent/orchestrator.go
@@ -7617,7 +7617,9 @@ func (o *Orchestrator) resolveWorkspaceDiffBase(ctx context.Context, sandbox *Sa
 
 	escapedBranch := shellEscapeSingleQuote(targetBranch)
 	var fetchErr bytes.Buffer
-	fetchCmd := fmt.Sprintf("git fetch --quiet --no-tags origin '%s'", escapedBranch)
+	// --end-of-options ensures the branch is always parsed as a refspec, never
+	// as a git option, even if upstream ref validation is ever bypassed.
+	fetchCmd := fmt.Sprintf("git fetch --quiet --no-tags --end-of-options origin '%s'", escapedBranch)
 	fetchExit, fetchExecErr := o.provider.Exec(ctx, sandbox, fetchCmd, io.Discard, &fetchErr)
 
 	var mbOut, mbErr bytes.Buffer

--- a/internal/services/agent/orchestrator_test.go
+++ b/internal/services/agent/orchestrator_test.go
@@ -4227,7 +4227,7 @@ func TestRunAgent_RecomputesDiffWhenAdapterLeavesDiffEmpty(t *testing.T) {
 			}
 		case "git rev-parse --is-inside-work-tree":
 			_, _ = io.WriteString(stdout, "true\n")
-		case "git fetch --quiet --no-tags origin 'main'":
+		case "git fetch --quiet --no-tags --end-of-options origin 'main'":
 			return 0, nil
 		case "git merge-base 'origin/main' HEAD":
 			_, _ = io.WriteString(stdout, "base123\n")

--- a/internal/services/sessiondiff/service.go
+++ b/internal/services/sessiondiff/service.go
@@ -119,7 +119,9 @@ func resolveDiffBase(ctx context.Context, provider agent.SandboxProvider, sandbo
 	// debug log on the fallback path; stdout is discarded since fetch
 	// progress (suppressed by --quiet anyway) carries no signal.
 	var fetchErr bytes.Buffer
-	fetchCmd := fmt.Sprintf("git fetch --quiet --no-tags origin '%s'", escapedBranch)
+	// --end-of-options ensures the branch is always parsed as a refspec, never
+	// as a git option, even if upstream ref validation is ever bypassed.
+	fetchCmd := fmt.Sprintf("git fetch --quiet --no-tags --end-of-options origin '%s'", escapedBranch)
 	fetchExit, fetchExecErr := provider.Exec(ctx, sandbox, fetchCmd, io.Discard, &fetchErr)
 
 	var mbOut, mbErr bytes.Buffer

--- a/internal/services/sessiondiff/service_test.go
+++ b/internal/services/sessiondiff/service_test.go
@@ -83,7 +83,7 @@ func TestCollect(t *testing.T) {
 				switch cmd {
 				case "git rev-parse --is-inside-work-tree":
 					return 0, nil
-				case "git fetch --quiet --no-tags origin 'main'":
+				case "git fetch --quiet --no-tags --end-of-options origin 'main'":
 					return 0, nil
 				case "git merge-base 'origin/main' HEAD":
 					_, _ = io.WriteString(stdout, "deadbeef\n")
@@ -101,7 +101,7 @@ func TestCollect(t *testing.T) {
 			expected: "merge-base diff\n",
 			expectedCmd: []string{
 				"git rev-parse --is-inside-work-tree",
-				"git fetch --quiet --no-tags origin 'main'",
+				"git fetch --quiet --no-tags --end-of-options origin 'main'",
 				"git merge-base 'origin/main' HEAD",
 				"git diff --find-renames --binary deadbeef -- .",
 				"git ls-files --others --exclude-standard -- .",
@@ -116,7 +116,7 @@ func TestCollect(t *testing.T) {
 				switch cmd {
 				case "git rev-parse --is-inside-work-tree":
 					return 0, nil
-				case "git fetch --quiet --no-tags origin 'main'":
+				case "git fetch --quiet --no-tags --end-of-options origin 'main'":
 					_, _ = io.WriteString(stderr, "fatal: could not read from remote")
 					return 128, nil
 				case "git merge-base 'origin/main' HEAD":
@@ -135,7 +135,7 @@ func TestCollect(t *testing.T) {
 			expected: "fallback diff\n",
 			expectedCmd: []string{
 				"git rev-parse --is-inside-work-tree",
-				"git fetch --quiet --no-tags origin 'main'",
+				"git fetch --quiet --no-tags --end-of-options origin 'main'",
 				"git merge-base 'origin/main' HEAD",
 				"git diff --find-renames --binary abc123 -- .",
 				"git ls-files --others --exclude-standard -- .",
@@ -150,7 +150,7 @@ func TestCollect(t *testing.T) {
 				switch cmd {
 				case "git rev-parse --is-inside-work-tree":
 					return 0, nil
-				case "git fetch --quiet --no-tags origin 'main'":
+				case "git fetch --quiet --no-tags --end-of-options origin 'main'":
 					return 0, nil
 				case "git merge-base 'origin/main' HEAD":
 					_, _ = io.WriteString(stdout, "\n")
@@ -167,7 +167,7 @@ func TestCollect(t *testing.T) {
 			expected: "",
 			expectedCmd: []string{
 				"git rev-parse --is-inside-work-tree",
-				"git fetch --quiet --no-tags origin 'main'",
+				"git fetch --quiet --no-tags --end-of-options origin 'main'",
 				"git merge-base 'origin/main' HEAD",
 				"git diff --find-renames --binary abc123 -- .",
 				"git ls-files --others --exclude-standard -- .",
@@ -182,7 +182,7 @@ func TestCollect(t *testing.T) {
 				switch cmd {
 				case "git rev-parse --is-inside-work-tree":
 					return 0, nil
-				case "git fetch --quiet --no-tags origin 'main'":
+				case "git fetch --quiet --no-tags --end-of-options origin 'main'":
 					_, _ = io.WriteString(stderr, "fatal: network unreachable")
 					return 1, errors.New("exec failure")
 				case "git merge-base 'origin/main' HEAD":
@@ -201,7 +201,7 @@ func TestCollect(t *testing.T) {
 			expected: "stale-base diff\n",
 			expectedCmd: []string{
 				"git rev-parse --is-inside-work-tree",
-				"git fetch --quiet --no-tags origin 'main'",
+				"git fetch --quiet --no-tags --end-of-options origin 'main'",
 				"git merge-base 'origin/main' HEAD",
 				"git diff --find-renames --binary stalebase -- .",
 				"git ls-files --others --exclude-standard -- .",
@@ -216,7 +216,7 @@ func TestCollect(t *testing.T) {
 				switch cmd {
 				case "git rev-parse --is-inside-work-tree":
 					return 0, nil
-				case "git fetch --quiet --no-tags origin 'weird'\\''branch'":
+				case "git fetch --quiet --no-tags --end-of-options origin 'weird'\\''branch'":
 					return 0, nil
 				case "git merge-base 'origin/weird'\\''branch' HEAD":
 					_, _ = io.WriteString(stdout, "mb\n")
@@ -233,7 +233,7 @@ func TestCollect(t *testing.T) {
 			expected: "",
 			expectedCmd: []string{
 				"git rev-parse --is-inside-work-tree",
-				"git fetch --quiet --no-tags origin 'weird'\\''branch'",
+				"git fetch --quiet --no-tags --end-of-options origin 'weird'\\''branch'",
 				"git merge-base 'origin/weird'\\''branch' HEAD",
 				"git diff --find-renames --binary mb -- .",
 				"git ls-files --others --exclude-standard -- .",

--- a/internal/services/slackbot/context.go
+++ b/internal/services/slackbot/context.go
@@ -3,6 +3,7 @@ package slackbot
 import (
 	"strings"
 
+	"github.com/assembledhq/143/internal/gitref"
 	"github.com/assembledhq/143/internal/models"
 	"github.com/google/uuid"
 )
@@ -156,6 +157,14 @@ func ResolveSlackContext(input SlackContextResolveInput) SlackContextResolveResu
 			}
 			break
 		}
+	}
+	// Drop a branch parsed from Slack text that isn't a safe git ref. It would
+	// otherwise be persisted as the session TargetBranch and forwarded into
+	// `git fetch origin <branch>`; an unsafe value (e.g. a leading '-') could be
+	// parsed by git as an option rather than a refspec. Clearing it falls back
+	// to the repository default, which is the desired behavior for junk input.
+	if result.Branch != "" && !gitref.IsValidRef(result.Branch) {
+		result.Branch = ""
 	}
 	if result.ContextSummary.Branch == "" {
 		result.ContextSummary.Branch = result.Branch


### PR DESCRIPTION
## Summary

Two high-severity findings from the pre-open-source security audit. The Mezmo integration fetched a user-supplied `base_url` with no SSRF protection (and stored + re-fetched it), and branch names arriving from Slack/PagerDuty reached `git fetch origin '<branch>'` without the ref validation the REST path already enforces, allowing git-argument injection (e.g. a leading `-` parsed as an option). Both are fixed with layered, fail-closed guards plus defense-in-depth at the sinks.

## Changes

- **SSRF guard** (`internal/api/handlers/ssrf_guard.go`): new SSRF-safe HTTP client that blocks loopback/RFC1918/`169.254` metadata/CGNAT/IPv6-ULA at **dial time** (DNS-rebind safe, re-applied on every redirect hop) and re-validates the scheme in `CheckRedirect`. `ConnectMezmo` now rejects non-http(s) schemes and private IP literals up front, and validation requests use a dedicated `untrustedURLClient` — the trusted OAuth paths on `h.client` are untouched.
- **Shared git-ref validator** (`internal/gitref`): single source of truth (`handlers.isValidGitRef` delegates to it), applied at the previously-unvalidated **Slack** (`context.go`) and **PagerDuty** (`pagerduty_integrations.go`) branch sources; `validateBaseBranch` now also rejects a leading `-`.
- **Defense-in-depth**: both `git fetch origin '<branch>'` sinks (`sessiondiff`, `orchestrator`) now pass `--end-of-options`, so a branch can never be parsed as a git option even if upstream validation is bypassed.

## Validation

- `go build ./...` on all touched packages — passes.
- `go test` for `internal/gitref`, `internal/api/handlers`, `internal/services/{slackbot,sessiondiff,agent}` — all pass. New tests: SSRF rejection table (metadata IP, loopback, `0.0.0.0`, RFC1918, `file://`/`gopher://`) and `gitref` validation (leading `-`, `--upload-pack=…`, shell metachars, length cap). Existing fetch-string assertions updated for `--end-of-options`.
- `gofmt` clean; `golangci-lint run` on changed packages — 0 issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)