### PR TITLE
Harden preview secrets, env-key injection, security headers, and preview-origin check

### DIFF
--- a/frontend/next.config.mjs
+++ b/frontend/next.config.mjs
@@ -7,6 +7,28 @@ const apiTarget = process.env.API_PROXY_TARGET || "http://localhost:8080";
 const frontendRoot = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = path.resolve(frontendRoot, "..");
 
+// Baseline security headers applied to every app response. These are
+// defense-in-depth: the app sanitizes rendered content, but a CSP frame-ancestors
+// directive plus X-Frame-Options prevents clickjacking, nosniff blocks MIME
+// sniffing, and Referrer-Policy limits referrer leakage. The CSP intentionally
+// only sets frame-ancestors so it does not constrain scripts/styles/connections
+// (the app uses inline styles from Shiki/motion). HSTS is production-only so it
+// does not pin http on localhost during development.
+const securityHeaders = [
+  { key: "X-Frame-Options", value: "SAMEORIGIN" },
+  { key: "Content-Security-Policy", value: "frame-ancestors 'self'" },
+  { key: "X-Content-Type-Options", value: "nosniff" },
+  { key: "Referrer-Policy", value: "strict-origin-when-cross-origin" },
+  ...(process.env.NODE_ENV === "production"
+    ? [
+        {
+          key: "Strict-Transport-Security",
+          value: "max-age=63072000; includeSubDomains",
+        },
+      ]
+    : []),
+];
+
 /**
  * @type {import("next").NextConfig}
  */
@@ -31,6 +53,14 @@ const nextConfig = {
       {
         source: "/api/:path*",
         destination: `${apiTarget}/api/:path*`,
+      },
+    ];
+  },
+  async headers() {
+    return [
+      {
+        source: "/:path*",
+        headers: securityHeaders,
       },
     ];
   },

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -608,6 +608,10 @@ func (c *Config) LogStatus(logger zerolog.Logger) {
 		logger.Warn().Msg("CSRF_SIGNING_KEY is empty — CSRF protection will be ineffective")
 	}
 
+	if c.Env == "production" && c.PreviewSecretBundleKEK == "" {
+		logger.Warn().Msg("PREVIEW_SECRET_BUNDLE_KEK is not set — preview secret bundles fall back to ENCRYPTION_MASTER_KEY rather than a dedicated key-encryption key. Set PREVIEW_SECRET_BUNDLE_KEK for key separation so a leaked master key does not also expose preview bundle secrets.")
+	}
+
 	if c.Env == "production" && previewOriginHostIsLocal(c.PreviewOriginTemplate) {
 		logger.Warn().Str("preview_origin_template", c.PreviewOriginTemplate).Msg("PREVIEW_ORIGIN_TEMPLATE points at localhost in production — preview URLs in PR comments and the gateway will not resolve. Set PREVIEW_ORIGIN_TEMPLATE to e.g. https://{id}.preview.example.com.")
 	}

--- a/internal/db/preview_secret_bundles.go
+++ b/internal/db/preview_secret_bundles.go
@@ -323,6 +323,15 @@ func (s *PreviewSecretBundleStore) decryptJSON(raw json.RawMessage, out any) err
 	var plaintext []byte
 	switch blob.Alg {
 	case "dev-plaintext":
+		// dev-plaintext is only ever written when no encryption key is
+		// configured (s.crypto == nil), which cannot happen in production
+		// because ENCRYPTION_MASTER_KEY is required and is the KEK fallback.
+		// If we have a key but encounter a plaintext blob, it is anomalous
+		// (e.g. data copied from a dev/staging environment) — refuse it rather
+		// than silently consuming an unencrypted secret.
+		if s.crypto != nil {
+			return fmt.Errorf("refusing to read dev-plaintext preview secret bundle while encryption is configured")
+		}
 		plaintext, err = crypto.DevDecrypt(data)
 	case "aes-256-gcm-envelope":
 		if s.crypto == nil {

--- a/internal/db/preview_secret_bundles_test.go
+++ b/internal/db/preview_secret_bundles_test.go
@@ -11,8 +11,33 @@ import (
 	"github.com/pashagolub/pgxmock/v4"
 	"github.com/stretchr/testify/require"
 
+	"github.com/assembledhq/143/internal/crypto"
 	"github.com/assembledhq/143/internal/models"
 )
+
+// TestPreviewSecretBundleStore_DecryptRejectsPlaintextWhenEncrypted verifies the
+// tripwire: a dev-plaintext blob is only legitimate when no encryption key is
+// configured (which never happens in production). With a key configured, reading
+// a plaintext blob must fail rather than silently returning an unencrypted secret.
+func TestPreviewSecretBundleStore_DecryptRejectsPlaintextWhenEncrypted(t *testing.T) {
+	t.Parallel()
+
+	cryptoSvc, err := crypto.NewService("test-master-key-at-least-32-chars-long!!")
+	require.NoError(t, err)
+
+	// "djA6e30=" base64-decodes to "v0:{}" — a dev-plaintext blob of `{}`.
+	blob := json.RawMessage(`{"alg":"dev-plaintext","ciphertext":"djA6e30="}`)
+	var out map[string]string
+
+	encryptedStore := NewPreviewSecretBundleStore(nil, cryptoSvc, "test-key")
+	err = encryptedStore.decryptJSON(blob, &out)
+	require.Error(t, err, "a key-configured store must refuse to read a dev-plaintext blob")
+	require.Contains(t, err.Error(), "refusing to read dev-plaintext")
+
+	// Without a key (the local dev workflow), dev-plaintext is still readable.
+	plaintextStore := NewPreviewSecretBundleStore(nil, nil, "test-key")
+	require.NoError(t, plaintextStore.decryptJSON(blob, &out), "a keyless store should still read dev-plaintext")
+}
 
 func TestPreviewSecretBundleStore_UpsertEncryptsAndVersions(t *testing.T) {
 	t.Parallel()

--- a/internal/services/preview/chromedp_inspector.go
+++ b/internal/services/preview/chromedp_inspector.go
@@ -12,6 +12,7 @@ import (
 	"image/gif"
 	"image/png"
 	"math"
+	"net/url"
 	"strconv"
 	"strings"
 	"sync"
@@ -152,10 +153,28 @@ func (c *ChromeDPInspector) previewURL(previewID, path string) (string, error) {
 	if strings.Contains(path, "..") {
 		return "", fmt.Errorf("path must not contain .., got %q", path)
 	}
-	url := c.cfg.PreviewURLTemplate
-	url = strings.ReplaceAll(url, "{{.PreviewID}}", previewID)
-	url = strings.ReplaceAll(url, "{{.Path}}", path)
-	return url, nil
+	rendered := c.cfg.PreviewURLTemplate
+	rendered = strings.ReplaceAll(rendered, "{{.PreviewID}}", previewID)
+	rendered = strings.ReplaceAll(rendered, "{{.Path}}", path)
+	return rendered, nil
+}
+
+// sameOrigin reports whether rawURL has the same scheme and host (including
+// port) as expectedURL. It is used to confine the server-side headless browser
+// to the preview origin. A prefix check is unsafe here because
+// "https://x.preview.dev" is a prefix of both "https://x.preview.dev.evil.com"
+// and "https://x.preview.dev@evil.com" — comparing parsed scheme+host closes
+// both bypasses. A parse failure or scheme/host mismatch returns false.
+func sameOrigin(rawURL, expectedURL string) bool {
+	target, err := url.Parse(rawURL)
+	if err != nil {
+		return false
+	}
+	expected, err := url.Parse(expectedURL)
+	if err != nil {
+		return false
+	}
+	return target.Scheme == expected.Scheme && target.Host == expected.Host
 }
 
 // =============================================================================
@@ -919,7 +938,7 @@ func (c *ChromeDPInspector) ExecuteInteraction(ctx context.Context, previewID st
 					stepErr = fmt.Errorf("invalid navigate URL: %w", urlErr)
 					break
 				}
-				if !strings.HasPrefix(url, strings.TrimSuffix(expectedURL, "/")) {
+				if !sameOrigin(url, expectedURL) {
 					stepErr = fmt.Errorf("navigate URL must match preview origin, got %q", url)
 					break
 				}

--- a/internal/services/preview/chromedp_inspector_test.go
+++ b/internal/services/preview/chromedp_inspector_test.go
@@ -1,0 +1,38 @@
+package preview
+
+import "testing"
+
+func TestSameOrigin(t *testing.T) {
+	t.Parallel()
+
+	const preview = "https://abc.preview.143.dev/"
+
+	cases := []struct {
+		name      string
+		rawURL    string
+		expected  string
+		wantMatch bool
+	}{
+		{"exact origin root", "https://abc.preview.143.dev/", preview, true},
+		{"same origin with path", "https://abc.preview.143.dev/dashboard?q=1", preview, true},
+		{"same origin no trailing slash", "https://abc.preview.143.dev", preview, true},
+
+		// The bypasses a prefix check would have allowed.
+		{"suffix attack subdomain", "https://abc.preview.143.dev.evil.com/", preview, false},
+		{"userinfo attack", "https://abc.preview.143.dev@evil.com/", preview, false},
+
+		// Other mismatches.
+		{"different host", "https://evil.com/", preview, false},
+		{"different scheme", "http://abc.preview.143.dev/", preview, false},
+		{"different port", "https://abc.preview.143.dev:8443/", preview, false},
+		{"unparseable target", "://not a url", preview, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := sameOrigin(tc.rawURL, tc.expected); got != tc.wantMatch {
+				t.Errorf("sameOrigin(%q, %q) = %v, want %v", tc.rawURL, tc.expected, got, tc.wantMatch)
+			}
+		})
+	}
+}

--- a/internal/services/preview/config.go
+++ b/internal/services/preview/config.go
@@ -614,6 +614,9 @@ func ValidateConfigWithResourcePolicy(cfg *models.PreviewConfig, resourcePolicy 
 			if isReservedPlatformPreviewEnvName(envName) {
 				errs = append(errs, fmt.Sprintf("service %q: env %q is reserved for platform-injected preview runtime metadata", name, envName))
 			}
+			if !isValidSecretEnvName(envName) {
+				errs = append(errs, fmt.Sprintf("service %q: env %q is not a valid environment variable name", name, envName))
+			}
 		}
 		if svc.Ready.HTTPPath == "" {
 			errs = append(errs, fmt.Sprintf("service %q: ready.http_path is required", name))
@@ -636,6 +639,9 @@ func ValidateConfigWithResourcePolicy(cfg *models.PreviewConfig, resourcePolicy 
 		for envName := range infra.InjectEnv {
 			if isReservedPlatformPreviewEnvName(envName) {
 				errs = append(errs, fmt.Sprintf("infrastructure %q: inject_env %q is reserved for platform-injected preview runtime metadata", name, envName))
+			}
+			if !isValidSecretEnvName(envName) {
+				errs = append(errs, fmt.Sprintf("infrastructure %q: inject_env %q is not a valid environment variable name", name, envName))
 			}
 		}
 		for _, svcName := range infra.InjectInto {
@@ -662,6 +668,9 @@ func ValidateConfigWithResourcePolicy(cfg *models.PreviewConfig, resourcePolicy 
 	for _, envName := range cfg.Credentials.Env {
 		if isReservedPlatformPreviewEnvName(envName) {
 			errs = append(errs, fmt.Sprintf("credentials: env %q is reserved for platform-injected preview runtime metadata", envName))
+		}
+		if !isValidSecretEnvName(envName) {
+			errs = append(errs, fmt.Sprintf("credentials: env %q is not a valid environment variable name", envName))
 		}
 	}
 	for i, ref := range cfg.Secrets {

--- a/internal/services/preview/config_test.go
+++ b/internal/services/preview/config_test.go
@@ -931,6 +931,90 @@ func TestValidateConfig_RejectsReservedPreviewModeEnv(t *testing.T) {
 	}
 }
 
+// TestValidateConfig_RejectsInvalidEnvKeyNames covers the env-var KEY validation:
+// the key (not just the value) is interpolated into the preview build/run shell
+// command, so a key containing shell metacharacters or '=' would be a command
+// injection. Keys must match isValidSecretEnvName, mirroring the secrets[].Env
+// check.
+func TestValidateConfig_RejectsInvalidEnvKeyNames(t *testing.T) {
+	t.Parallel()
+
+	base := func() models.PreviewConfig {
+		return models.PreviewConfig{
+			Primary: "web",
+			Services: map[string]models.ServiceConfig{
+				"web": {
+					Command: []string{"npm", "start"},
+					Port:    3000,
+					Ready:   models.ReadinessProbe{HTTPPath: "/"},
+				},
+			},
+			Infrastructure: map[string]models.InfrastructureConfig{},
+			Credentials:    models.CredentialConfig{Mode: "none"},
+			Network:        models.NetworkConfig{Mode: "managed"},
+		}
+	}
+
+	tests := []struct {
+		name       string
+		mutate     func(*models.PreviewConfig)
+		wantErrSub string
+	}{
+		{
+			name: "service env key with command substitution",
+			mutate: func(cfg *models.PreviewConfig) {
+				svc := cfg.Services["web"]
+				svc.Env = map[string]string{"X=$(id) Y": "v"}
+				cfg.Services["web"] = svc
+			},
+			wantErrSub: `service "web": env "X=$(id) Y" is not a valid environment variable name`,
+		},
+		{
+			name: "service env key with space",
+			mutate: func(cfg *models.PreviewConfig) {
+				svc := cfg.Services["web"]
+				svc.Env = map[string]string{"BAD KEY": "v"}
+				cfg.Services["web"] = svc
+			},
+			wantErrSub: `service "web": env "BAD KEY" is not a valid environment variable name`,
+		},
+		{
+			name: "infrastructure inject_env key with metacharacters",
+			mutate: func(cfg *models.PreviewConfig) {
+				cfg.Infrastructure["db"] = models.InfrastructureConfig{
+					Template:  "postgres-17",
+					InjectEnv: map[string]string{"FOO;rm -rf /": "v"},
+				}
+			},
+			wantErrSub: `infrastructure "db": inject_env "FOO;rm -rf /" is not a valid environment variable name`,
+		},
+		{
+			name: "credential env key invalid",
+			mutate: func(cfg *models.PreviewConfig) {
+				cfg.Credentials = models.CredentialConfig{
+					Mode: "managed_env",
+					Env:  []string{"1INVALID"},
+				}
+			},
+			wantErrSub: `credentials: env "1INVALID" is not a valid environment variable name`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			cfg := base()
+			tt.mutate(&cfg)
+
+			errs := ValidateConfig(&cfg)
+
+			require.NotEmpty(t, errs, "invalid env key names should fail preview config validation")
+			require.Contains(t, strings.Join(errs, "\n"), tt.wantErrSub, "validation error should identify the invalid env key")
+		})
+	}
+}
+
 func TestValidateConfig_Resources(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

Addresses four MEDIUM-severity findings from the pre-open-source security audit (findings 4, 5, 6, 8). These are defense-in-depth hardening on the preview/secrets surface plus baseline app security headers — separate from the SSRF/git-injection HIGHs in #1757. Finding 7 (`validateBaseBranch` leading `-`) was already fixed in #1757.

## Changes

- **Preview secret bundles at rest (#4):** `decryptJSON` now refuses a `dev-plaintext` blob when an encryption key is configured (always the case in production, since `ENCRYPTION_MASTER_KEY` is the KEK fallback) — a plaintext blob copied from a dev/staging DB can no longer be silently consumed. Added a production startup warning recommending a dedicated `PREVIEW_SECRET_BUNDLE_KEK` for key separation. *(Note: the original "silent plaintext in prod" risk is already mitigated by the master-key fallback; this is the remaining tripwire + key-separation hardening.)*
- **Preview env-var key injection (#5):** `ValidateConfig` now validates env-var **keys** (not just values) for service `env`, infrastructure `inject_env`, and credential `env` against `isValidSecretEnvName`, mirroring the existing `secrets[].Env` check. Keys are interpolated into the preview build/run shell command, so a key with metacharacters or `=` was an in-sandbox command injection.
- **Frontend security headers (#6):** `next.config.mjs` now sets baseline headers on every app response — `Content-Security-Policy: frame-ancestors 'self'` + `X-Frame-Options: SAMEORIGIN` (clickjacking), `X-Content-Type-Options: nosniff`, `Referrer-Policy: strict-origin-when-cross-origin`, and production-only HSTS. The CSP intentionally sets only `frame-ancestors` so it doesn't constrain the app's inline styles (Shiki/motion).
- **Preview-origin confinement (#8):** the headless-browser `navigate` guard now compares parsed scheme+host instead of a string prefix, closing the `x.preview.143.dev.evil.com` and `x.preview.143.dev@evil.com` bypasses.

## Validation

- `go test ./internal/config/... ./internal/db/... ./internal/services/preview/...` — all pass. New tests: dev-plaintext rejection when a key is configured (and still readable without one), invalid env-key names across all three sources, and a `sameOrigin` table covering the suffix/userinfo bypasses.
- `gofmt` clean; `golangci-lint run` on changed packages — 0 issues; pre-commit `lint-stores` passed.
- `node --check frontend/next.config.mjs` — syntax valid. CI enforces ESLint + typecheck on the frontend (no prettier); the change is idiomatic with no unused symbols.

🤖 Generated with [Claude Code](https://claude.com/claude-code)