### PR TITLE
Update about page tests to match current copy

### DIFF
--- a/frontend/src/app/(landing)/about/page.test.tsx
+++ b/frontend/src/app/(landing)/about/page.test.tsx
@@ -16,12 +16,12 @@ describe("AboutPage", () => {
   it("explains why 143 was built for production teams", () => {
     renderWithProviders(<AboutPage />);
 
-    expect(screen.getByText(/Code volume, especially these days, is a bad metric/i)).toBeInTheDocument();
-    expect(screen.getByText(/keeping the codebase healthy/i)).toBeInTheDocument();
+    expect(screen.getByText(/non-engineers can fix things too/i)).toBeInTheDocument();
+    expect(screen.getByText(/built for engineers by engineers/i)).toBeInTheDocument();
     expect(screen.getByText(/real product work, not just demos and internal tools/i)).toBeInTheDocument();
-    expect(screen.getByText(/velocity gains we expected/i)).toBeInTheDocument();
-    expect(screen.getByText(/shared infrastructure problem/i)).toBeInTheDocument();
-    expect(screen.getByText(/That is why we built 143.dev/i)).toBeInTheDocument();
+    expect(screen.getByText(/shared across the team/i)).toBeInTheDocument();
+    expect(screen.getByText(/Stripe Minions and Ramp Inspect/i)).toBeInTheDocument();
+    expect(screen.getByText(/That's why we built 143\./i)).toBeInTheDocument();
     expect(screen.queryByText(/We had real FOMO/i)).not.toBeInTheDocument();
     expect(screen.queryByText(/Also, vibe coding/i)).not.toBeInTheDocument();
   });
@@ -31,7 +31,7 @@ describe("AboutPage", () => {
 
     expect(screen.getByRole("heading", { name: "Where it started" })).toBeInTheDocument();
     expect(screen.getByRole("heading", { name: "What we built" })).toBeInTheDocument();
-    expect(screen.getByRole("heading", { name: "Open source from day one" })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Open source for everyone" })).toBeInTheDocument();
   });
 
   it("describes team-visible agent infrastructure", () => {
@@ -45,7 +45,7 @@ describe("AboutPage", () => {
   it("covers the team-level product choices behind 143", () => {
     renderWithProviders(<AboutPage />);
 
-    expect(screen.getByText(/automations should be visible to the team/i)).toBeInTheDocument();
+    expect(screen.getByText(/Automations shouldn't be hidden/i)).toBeInTheDocument();
     expect(screen.getByText(/swap out intelligence/i)).toBeInTheDocument();
     expect(screen.getByText(/set up a great environment once/i)).toBeInTheDocument();
   });


### PR DESCRIPTION
## What changed

Updated the stale assertions in `frontend/src/app/(landing)/about/page.test.tsx` to reference copy that is actually rendered by the about page.

## Why

The about page copy was rewritten in `dcba195cd` ("minor adjustments to about page"), but the test file still asserted the old text, breaking the frontend suite on `main`. Three assertions were stale:

- **"explains why 143 was built for production teams"** — replaced old phrases (`Code volume…`, `keeping the codebase healthy`, `velocity gains…`, `shared infrastructure problem`, `That is why we built 143.dev`) with text that is in the page: `non-engineers can fix things too`, `built for engineers by engineers`, `shared across the team`, `Stripe Minions and Ramp Inspect`, `That's why we built 143.`
- **"organizes the editorial note into readable sections"** — heading `Open source from day one` → `Open source for everyone`.
- **"covers the team-level product choices behind 143"** — `automations should be visible to the team` → `Automations shouldn't be hidden`.

Each test's intent is preserved; only the matched strings changed to follow the page.

## Reviewer notes

- The CI failure on main reported 2 failing assertions; a 3rd (the `Open source` heading) was also stale and is fixed here.
- `That's why we built 143.` is scoped tightly because `/why we built 143/i` alone also matched the `<h1>` ("Why we built 143.dev").

## Test plan

- [x] `vitest run "src/app/(landing)/about/page.test.tsx"` — 8 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
