### PR TITLE
Align Previews table actions UI: switch to ghost buttons, fix spacing, shorten restart label

### DIFF
--- a/frontend/src/app/(dashboard)/previews/page.tsx
+++ b/frontend/src/app/(dashboard)/previews/page.tsx
@@ -56,7 +56,7 @@ import { safeExternalUrl } from "@/lib/utils";
 
 type PreviewScope = "running" | "resumable" | "recent";
 
-const RESTART_LATEST_LABEL = "Start latest preview";
+const RESTART_LATEST_LABEL = "Start latest";
 const RESTART_LATEST_TOOLTIP = "Start a new preview from the latest source state";
 
 const SECTIONS: {
@@ -325,15 +325,20 @@ function PreviewActions({
   const previewHref = safeExternalUrl(preview.preview_url);
 
   return (
-    <div className="flex flex-wrap justify-end gap-2">
+    <div className="flex flex-wrap items-center justify-end gap-1.5 whitespace-nowrap">
       {previewHref ? (
-        <Button asChild size="sm">
+        <Button
+          asChild
+          size="sm"
+          variant="ghost"
+          className="h-7 px-2 text-muted-foreground hover:text-foreground"
+        >
           <a
             href={previewHref}
             target="_blank"
             rel="noreferrer"
           >
-            <ExternalLink className="h-4 w-4" />
+            <ExternalLink className="h-3.5 w-3.5" />
             Open
           </a>
         </Button>
@@ -341,10 +346,11 @@ function PreviewActions({
       {canMutate && scope === "running" && preview.current_preview_id ? (
         <Button
           size="sm"
-          variant="outline"
+          variant="ghost"
+          className="h-7 px-2 text-muted-foreground hover:text-foreground"
           onClick={() => onStop(preview)}
         >
-          <Square className="h-4 w-4" />
+          <Square className="h-3.5 w-3.5" />
           Stop
         </Button>
       ) : null}
@@ -357,11 +363,12 @@ function PreviewActions({
       {canMutate && scope === "resumable" ? (
         <Button
           size="sm"
-          variant="outline"
+          variant="ghost"
+          className="h-7 px-2 text-muted-foreground hover:text-foreground"
           loading={isRestartPending(preview)}
           onClick={() => onRestart(preview)}
         >
-          <Play className="h-4 w-4" />
+          <Play className="h-3.5 w-3.5" />
           Resume
         </Button>
       ) : null}
@@ -433,8 +440,8 @@ function previewColumns(
     {
       id: "actions",
       header: <span className="sr-only">Actions</span>,
-      className: "w-[20%] text-right",
-      cellClassName: "text-right",
+      className: "w-[20%] min-w-[13rem] text-right",
+      cellClassName: "text-right align-middle",
       render: (preview) => <PreviewActions preview={preview} {...props} />,
     },
   ];
@@ -540,10 +547,11 @@ function RestartLatestButton({
             size="sm"
             variant="ghost"
             aria-label={RESTART_LATEST_TOOLTIP}
+            className="h-7 px-2 text-muted-foreground hover:text-foreground"
             loading={loading}
             onClick={onClick}
           >
-            <RotateCw className="h-4 w-4" />
+            <RotateCw className="h-3.5 w-3.5" />
             {RESTART_LATEST_LABEL}
           </Button>
         </TooltipTrigger>


### PR DESCRIPTION
## Summary

The previews table actions area can feel inconsistent and cramped, increasing the likelihood of misaligned/overflowing controls on narrower widths. This change unifies the row actions into quiet `ghost` buttons with consistent sizing (height/padding), smaller icons, and a stabilized actions column layout, while also shortening the “Start latest preview” visible label to “Start latest” without changing the tooltip/aria-label.

## Changes

- Update all PreviewActions row controls (Open/Stop/Resume) to use `Button` with `variant="ghost"` and consistent Tailwind classes (`h-7`, `px-2`, muted/hover text).
- Standardize icon sizing across actions and restart control (`h-3.5 w-3.5`) and shorten visible restart button label to `Start latest` (tooltip unchanged).
- Improve actions column layout reliability by setting `min-w-[13rem]` and using `align-middle`; keep `flex-wrap` plus `whitespace-nowrap` to prevent clipping when multiple actions are present.

## Validation

- `npm run test:ci` (previews/page.test.tsx) — 17/17 passing
- `eslint` clean

[143.dev](https://143.dev) | [session 25ae33ab](https://143.dev/sessions/25ae33ab-7fa3-45f4-a168-6c55ad143cd5)

<!-- 143 readiness -->
**143 readiness:** Ready with warnings (workspace revision 11; 7 passed, 1 warnings, 0 blockers).

Preview: https://143.dev/previews/github/assembledhq/143/pull/1760?launch=1