### PR TITLE
Swap README hero to the review-diff screenshot

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ The open-source platform where your whole team builds software together.
 [143.dev](https://www.143.dev) · [Getting started](#getting-started) · [Docs](docs/public/index.mdx) · [Architecture](docs/design/overall.md) · [Self-hosting](docs/self-hosting/README.md)
 
 <p align="center">
-  <img src="frontend/public/product/product-session-overview.png" alt="A 143 session: an agent working from an issue, with the diff and PR status alongside the conversation" width="900">
+  <img src="frontend/public/product/product-review-diff.png" alt="Reviewing an agent's change in 143: a code diff with the changed-files list and review controls" width="900">
 </p>
 
 ## What is this?


### PR DESCRIPTION
## Summary

The README hero (merged in #1765) used the session-overview screenshot, which relied on a seeded conversation with canned-sounding messages and tool calls collapsed into a generic "3 log entries" — it didn't show realistic agent activity. This swaps the hero to the review-diff view so the first thing visitors see is the actual deliverable: a reviewable code change.

## Changes

- Point the README hero image at `frontend/public/product/product-review-diff.png` instead of `product-session-overview.png`, and update the alt text. The review-diff shot shows a real code diff, the changed-files list with +/- counts, and the review controls — no canned chat.

## Validation

- Docs-only, one-line change. Verified the image path resolves to a committed asset.
