### PR TITLE
Hide routine preview secret-bundle resolves from audit log

### DIFF
--- a/internal/db/audit_log_store.go
+++ b/internal/db/audit_log_store.go
@@ -186,6 +186,17 @@ func (s *AuditLogStore) List(ctx context.Context, orgID uuid.UUID, filters Audit
 		w.addArg("cursor_id", *filters.CursorID)
 	}
 
+	// Routine preview secret-bundle resolution events are emitted by the system
+	// on every hourly preview recycle. They are pure housekeeping noise in the
+	// org activity log, so hide them from the default listing while keeping the
+	// matching ".failed" events (and every other action) visible. An explicit
+	// action filter still surfaces them when a caller asks for them directly.
+	if filters.Action != models.AuditActionPreviewSecretBundleResolved {
+		w.add("NOT (resource_type = @hide_resolved_resource AND action = @hide_resolved_action)",
+			"hide_resolved_resource", models.AuditResourcePreviewSecretBundle)
+		w.addArg("hide_resolved_action", models.AuditActionPreviewSecretBundleResolved)
+	}
+
 	where, args := w.build()
 
 	query := `

--- a/internal/db/audit_log_store_test.go
+++ b/internal/db/audit_log_store_test.go
@@ -192,8 +192,10 @@ func TestAuditLogStore_List(t *testing.T) {
 			name:    "returns entries for org with no filters",
 			filters: AuditLogFilters{},
 			setupMock: func(mock pgxmock.PgxPoolIface, orgID, userID uuid.UUID, now time.Time) {
-				mock.ExpectQuery("(?s)SELECT .+ FROM audit_logs WHERE org_id").
-					WithArgs(pgxmock.AnyArg()).
+				// The default listing appends a NOT(...) clause to hide routine
+				// preview_secret_bundle.resolved events, adding two bound args.
+				mock.ExpectQuery("(?s)SELECT .+ FROM audit_logs WHERE org_id .+ AND NOT .+resource_type .+ action").
+					WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
 					WillReturnRows(
 						pgxmock.NewRows(newAuditLogColumns()).
 							AddRow(int64(1), orgID, "user", userID.String(), &userID,
@@ -227,8 +229,9 @@ func TestAuditLogStore_List(t *testing.T) {
 			name:    "filters by actor_type",
 			filters: AuditLogFilters{ActorType: models.AuditActorUser},
 			setupMock: func(mock pgxmock.PgxPoolIface, orgID, userID uuid.UUID, now time.Time) {
+				// org_id + actor_type + the two hide-resolved args.
 				mock.ExpectQuery("(?s)SELECT .+ FROM audit_logs WHERE org_id .+ AND actor_type").
-					WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+					WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
 					WillReturnRows(
 						pgxmock.NewRows(newAuditLogColumns()).
 							AddRow(int64(1), orgID, "user", userID.String(), &userID,
@@ -253,7 +256,7 @@ func TestAuditLogStore_List(t *testing.T) {
 			filters: AuditLogFilters{},
 			setupMock: func(mock pgxmock.PgxPoolIface, _, _ uuid.UUID, _ time.Time) {
 				mock.ExpectQuery("(?s)SELECT .+ FROM audit_logs WHERE org_id").
-					WithArgs(pgxmock.AnyArg()).
+					WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
 					WillReturnRows(pgxmock.NewRows(newAuditLogColumns()))
 			},
 			expected: func(_, _ uuid.UUID, _ time.Time) []models.AuditLog {
@@ -265,10 +268,63 @@ func TestAuditLogStore_List(t *testing.T) {
 			filters: AuditLogFilters{},
 			setupMock: func(mock pgxmock.PgxPoolIface, _, _ uuid.UUID, _ time.Time) {
 				mock.ExpectQuery("(?s)SELECT .+ FROM audit_logs WHERE org_id").
-					WithArgs(pgxmock.AnyArg()).
+					WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
 					WillReturnError(fmt.Errorf("connection refused"))
 			},
 			expectErr: true,
+		},
+		{
+			name:    "hides routine preview_secret_bundle.resolved events by default",
+			filters: AuditLogFilters{},
+			setupMock: func(mock pgxmock.PgxPoolIface, orgID, userID uuid.UUID, now time.Time) {
+				// The query must carry the NOT(...) exclusion clause. The mock
+				// returns only the rows the DB would (a ".failed" event survives).
+				mock.ExpectQuery("(?s)SELECT .+ FROM audit_logs WHERE org_id .+ AND NOT .resource_type = .+ AND action = ").
+					WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+					WillReturnRows(
+						pgxmock.NewRows(newAuditLogColumns()).
+							AddRow(int64(3), orgID, "system", "preview-secret-resolver", nil,
+								"preview_secret_bundle.failed", "preview_secret_bundle", nil,
+								nil, nil, nil, nil,
+								nil, nil, now),
+					)
+			},
+			expected: func(orgID, _ uuid.UUID, now time.Time) []models.AuditLog {
+				return []models.AuditLog{
+					{
+						ID: 3, OrgID: orgID, ActorType: "system",
+						ActorID: "preview-secret-resolver",
+						Action:  "preview_secret_bundle.failed", ResourceType: "preview_secret_bundle",
+						CreatedAt: now,
+					},
+				}
+			},
+		},
+		{
+			name:    "includes resolved events when explicitly filtered",
+			filters: AuditLogFilters{Action: models.AuditActionPreviewSecretBundleResolved},
+			setupMock: func(mock pgxmock.PgxPoolIface, orgID, userID uuid.UUID, now time.Time) {
+				// Explicit action filter: no NOT(...) clause, just org_id + action.
+				mock.ExpectQuery("(?s)SELECT .+ FROM audit_logs WHERE org_id .+ AND action = ").
+					WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+					WillReturnRows(
+						pgxmock.NewRows(newAuditLogColumns()).
+							AddRow(int64(4), orgID, "system", "preview-secret-resolver", nil,
+								"preview_secret_bundle.resolved", "preview_secret_bundle", nil,
+								nil, nil, nil, nil,
+								nil, nil, now),
+					)
+			},
+			expected: func(orgID, _ uuid.UUID, now time.Time) []models.AuditLog {
+				return []models.AuditLog{
+					{
+						ID: 4, OrgID: orgID, ActorType: "system",
+						ActorID: "preview-secret-resolver",
+						Action:  "preview_secret_bundle.resolved", ResourceType: "preview_secret_bundle",
+						CreatedAt: now,
+					},
+				}
+			},
 		},
 	}
 


### PR DESCRIPTION
## Summary

The org audit log UI was being flooded with `preview_secret_bundle resolved` system events — one (or more) every hour for each continuously-running preview, drowning out real activity. These come from the hourly preview `RecycleWorker`, which re-resolves each active preview's secret bundle on every recycle and emits a `preview_secret_bundle.resolved` audit per bundle. This filters them out of the listing at the query layer so no frontend change is needed.

## Changes

- `AuditLogStore.List` now appends a `NOT (resource_type = preview_secret_bundle AND action = resolved)` clause, hiding routine resolve events from the default audit-log listing.
- The exclusion is suppressed when a caller explicitly filters by the `resolved` action, so the events are hidden by default but still reachable on demand (e.g. via the action dropdown). `GetByID` is untouched, so direct links still work.
- `preview_secret_bundle.failed` events are left visible so resolution failures still surface.

## Validation

- `go test ./internal/db/ ./internal/api/handlers/ -run AuditLog` — pass
- New store tests cover default-hide (a `.failed` row survives) and explicit-include-when-filtered; pre-existing `List` cases updated for the added bound args.
- `go build ./internal/db/... ./internal/api/...`, `gofmt`, and pre-commit `lint-stores` — clean.

## Notes for reviewer

- Filtering happens before `LIMIT`, so pagination/cursors stay correct.
- Follow-up worth considering: these events are still *written* to `audit_logs` every hour. As volume grows, the listing pays a deeper index scan to skip them. The more durable fix is to stop emitting the routine `resolved` audit on recycle (emit only on first resolve / on change), or add a partial index.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
