### PR TITLE
Raise Postgres max_connections to 300 for launch headroom

### DIFF
--- a/deploy/postgres/postgresql.conf
+++ b/deploy/postgres/postgresql.conf
@@ -3,7 +3,7 @@
 # See docs/design/36-docker-agents-vps-architecture.md for scaling table.
 
 # -- Connections ---------------------------------------------------------------
-max_connections = 200
+max_connections = 300
 listen_addresses = '*'
 
 # -- Memory --------------------------------------------------------------------


### PR DESCRIPTION
## What

Raise Postgres `max_connections` from **200 → 300** ahead of the open-source launch.

## Why

Capacity review of the live fleet (6 workers / ~39 sandbox slots, 1 API node, 1 DB node) showed the DB **connection ceiling**, not worker compute, is the scaling chokepoint for a launch spike. With the planned launch topology the connection budget approaches the old 200 cap at peak:

| Source | Conns |
|--------|-------|
| 2 API nodes × `API_DATABASE_MAX_CONNS` (20) | 40 |
| ~9 workers × `WORKER_DATABASE_POOL_MAX_CONNS` (4) | 36 |
| session executors (~1–2 each, peak ~60–80) | ~120 |
| **total at peak** | **≈ 200** |

300 leaves headroom for spikes without exhausting the listener. Current usage is far below this (49/200 in use at review time), so this is purely burst insurance.

## Safety

Safe on the current ~8 GB DB box — most backends sit idle, and raising `max_connections` only grows shared-memory bookkeeping modestly at startup; the per-backend private memory only matters for *active* connections. Verified Postgres starts fine at this setting on the 8 GB profile.

## Upgrade path (documented inline)

- Resize DB VPS to 16 GB → bump to `400` + `shared_buffers = 4GB`.
- Durable fix beyond launch: front Postgres with **PgBouncer** (transaction pooling) so the app's many short-lived pools multiplex onto a small backend count.

## Deploy

`make deploy-db` (Postgres re-reads `max_connections` on restart).

## Not in this PR (intentionally minimal for launch eve)

These are operational, not repo changes — tracked separately:
- AWS NLB + 2 AWS app nodes (us-east-1) + VPC Tailscale subnet router for the redundant API tier.
- 2–3 AWS burst/redundancy workers.

Deferred code hardening (post-launch, carries behavior risk — not rushing before launch):
- Redis-back the in-process rate-limit buckets (`internal/api/middleware/ratelimit.go`) so limits don't diverge across API nodes.
- Leader-gate `RunControlPlaneHealthAlerts` (`cmd/server/main.go:398`) to avoid duplicate alerts with 2 API nodes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
