### PR TITLE
Support OpenCode CLI custom OpenRouter model IDs

### DIFF
--- a/frontend/src/lib/agents.test.ts
+++ b/frontend/src/lib/agents.test.ts
@@ -188,6 +188,7 @@ describe("agentTypeForModel", () => {
   it("routes OpenCode logical ids to OpenCode but leaves bare first-party names with their owner", () => {
     expect(agentTypeForModel("glm-5.2")).toBe("opencode");
     expect(agentTypeForModel("kimi-k2.6")).toBe("opencode");
+    expect(agentTypeForModel("openrouter/~z-ai/glm-5.2")).toBe("opencode");
     // Bare names owned by a first-party agent keep that owner.
     expect(agentTypeForModel("gpt-5.5")).toBe("codex");
     expect(agentTypeForModel("claude-fable-5")).toBe("claude_code");

--- a/frontend/src/lib/agents.ts
+++ b/frontend/src/lib/agents.ts
@@ -9,6 +9,7 @@ import {
   AVAILABLE_CODEX_MODELS,
   OPENCODE_LOGICAL_MODELS,
   AVAILABLE_PI_MODELS,
+  isKnownOpenCodePhysicalModel,
   isOpenCodeLogicalModel,
   openCodeModelLabel,
 } from "@/lib/model-constants";
@@ -160,6 +161,7 @@ export function agentTypeForModel(model: string): string | undefined {
   // curated lists so bare names a first-party agent owns (e.g. "gpt-5.5" →
   // Codex, "claude-fable-5" → Claude Code) keep their existing owner. Mirrors
   // the backend AgentTypeForModel ordering.
+  if (isKnownOpenCodePhysicalModel(model)) return "opencode";
   if (isOpenCodeLogicalModel(model)) return "opencode";
   if (AGENTS_BY_KEY.pi.models.includes(model)) return "pi";
   // Unknown provider/model strings (custom Pi or custom OpenCode models) cannot

--- a/frontend/src/lib/model-constants.test.ts
+++ b/frontend/src/lib/model-constants.test.ts
@@ -267,6 +267,7 @@ describe("OpenCode logical models", () => {
   it("labels logical and physical ids with a friendly name and passes through custom slugs", () => {
     expect(openCodeModelLabel("glm-5.2")).toBe("GLM 5.2");
     expect(openCodeModelLabel("openrouter/z-ai/glm-5.2")).toBe("GLM 5.2");
+    expect(openCodeModelLabel("openrouter/~z-ai/glm-5.2")).toBe("GLM 5.2");
     expect(openCodeModelLabel("opencode/glm-5.2")).toBe("GLM 5.2");
     expect(openCodeModelLabel("xai/grok-code-fast")).toBe("xai/grok-code-fast");
   });

--- a/frontend/src/lib/model-constants.ts
+++ b/frontend/src/lib/model-constants.ts
@@ -259,18 +259,23 @@ export const OPENCODE_MODEL_LABELS: Readonly<Record<string, string>> = {
 };
 
 const OPENCODE_LOGICAL_MODEL_SET: ReadonlySet<string> = new Set(OPENCODE_LOGICAL_MODELS);
+const OPENCODE_PHYSICAL_MODEL_SET: ReadonlySet<string> = new Set(AVAILABLE_OPENCODE_MODELS);
 
 export function isOpenCodeLogicalModel(model: string): boolean {
   return OPENCODE_LOGICAL_MODEL_SET.has(model);
 }
 
+export function isKnownOpenCodePhysicalModel(model: string): boolean {
+  return OPENCODE_PHYSICAL_MODEL_SET.has(normalizeOpenCodePhysicalModelID(model));
+}
+
 // openCodeModelLabel returns a friendly display name for an OpenCode logical or
 // physical model id, falling back to the raw id for uncurated custom slugs.
 export function openCodeModelLabel(model: string): string {
-  return OPENCODE_MODEL_LABELS[normalizeOpenCodeModelLabelID(model)] ?? model;
+  return OPENCODE_MODEL_LABELS[normalizeOpenCodePhysicalModelID(model)] ?? model;
 }
 
-function normalizeOpenCodeModelLabelID(model: string): string {
+function normalizeOpenCodePhysicalModelID(model: string): string {
   if (model.startsWith("openrouter/~")) {
     return `openrouter/${model.slice("openrouter/~".length)}`;
   }

--- a/frontend/src/lib/model-constants.ts
+++ b/frontend/src/lib/model-constants.ts
@@ -267,12 +267,19 @@ export function isOpenCodeLogicalModel(model: string): boolean {
 // openCodeModelLabel returns a friendly display name for an OpenCode logical or
 // physical model id, falling back to the raw id for uncurated custom slugs.
 export function openCodeModelLabel(model: string): string {
-  return OPENCODE_MODEL_LABELS[model] ?? model;
+  return OPENCODE_MODEL_LABELS[normalizeOpenCodeModelLabelID(model)] ?? model;
+}
+
+function normalizeOpenCodeModelLabelID(model: string): string {
+  if (model.startsWith("openrouter/~")) {
+    return `openrouter/${model.slice("openrouter/~".length)}`;
+  }
+  return model;
 }
 
 // openCodeTransportLabelForModel derives the human transport name from a
 // resolved physical OpenCode model id by its prefix (e.g.
-// "openrouter/z-ai/glm-5.2" → "OpenRouter"). Returns null for a logical id or
+// "openrouter/~z-ai/glm-5.2" → "OpenRouter"). Returns null for a logical id or
 // an uncurated slug whose transport can't be determined from the id alone.
 // Mirror of OpenCodeTransportLabel in internal/models/opencode_models.go.
 export function openCodeTransportLabelForModel(model: string): string | null {

--- a/internal/models/agent_model_constants.go
+++ b/internal/models/agent_model_constants.go
@@ -226,6 +226,9 @@ func AgentTypeForModel(model string) AgentType {
 			return AgentTypeOpenCode
 		}
 	}
+	if IsKnownOpenCodePhysicalModel(model) {
+		return AgentTypeOpenCode
+	}
 	// OpenCode logical model ids (e.g. "glm-5.2") route to OpenCode. Checked
 	// after the curated physical lists so bare names a first-party agent owns
 	// (e.g. "gpt-5.5" → Codex, "claude-fable-5" → Claude Code) keep their
@@ -303,6 +306,9 @@ func IsSupportedPiModel(model string) bool {
 }
 
 func IsSupportedOpenCodeModel(model string) bool {
+	if IsKnownOpenCodePhysicalModel(model) {
+		return true
+	}
 	for _, supportedModel := range AvailableOpenCodeModels {
 		if model == supportedModel {
 			return true

--- a/internal/models/opencode_models.go
+++ b/internal/models/opencode_models.go
@@ -19,17 +19,19 @@ import "strings"
 // OpenCode-native gateway.
 
 // OpenCodeRoute is one physical way to reach a logical model: a backing
-// provider (which credential serves it), the physical model ID passed to
-// `opencode run --model`, and — for OpenRouter routes — the audited US-only
-// inference-provider allowlist pinned into the runtime config.
+// provider (which credential serves it), the registry route ID, and — for
+// OpenRouter routes — the audited US-only inference-provider allowlist pinned
+// into the runtime config.
 type OpenCodeRoute struct {
 	// Backing is the credential's backing provider. OpenCode credentials are
 	// all stored under ProviderOpenCode with a backing_provider discriminator;
 	// resolution matches a route to a credential whose
 	// NormalizedBackingProvider() equals this value.
 	Backing ProviderName
-	// PhysicalModelID is the OpenCode CLI model ID (e.g. "openrouter/z-ai/glm-5.2"
-	// or "opencode/glm-5.2"). It is what flows to OPENCODE_MODEL once resolved.
+	// PhysicalModelID is the route ID tracked by 143 (e.g.
+	// "openrouter/z-ai/glm-5.2" or "opencode/glm-5.2"). OpenRouter routes are
+	// converted to OpenCode's custom-model CLI form ("openrouter/~...") when
+	// building the sandbox runtime config.
 	PhysicalModelID string
 	// USProviderList is the audited US-only OpenRouter inference-provider
 	// allowlist (only/order) pinned in the runtime config. Empty for non-OpenRouter
@@ -252,7 +254,7 @@ func IsOpenCodeLogicalModel(id string) bool {
 // IsKnownOpenCodePhysicalModel reports whether id is a curated physical route
 // ID (used to recognize pinned selections that predate logical models).
 func IsKnownOpenCodePhysicalModel(id string) bool {
-	_, ok := openCodePhysicalModelIDSet[strings.TrimSpace(id)]
+	_, ok := openCodePhysicalModelIDSet[normalizeOpenCodePhysicalModelID(id)]
 	return ok
 }
 
@@ -260,7 +262,7 @@ func IsKnownOpenCodePhysicalModel(id string) bool {
 // model for a physical model ID. Used to resolve pinned selections and to look
 // up the audited US-provider allowlist for a resolved route.
 func OpenCodeRouteForPhysicalModel(physicalID string) (OpenCodeModel, OpenCodeRoute, bool) {
-	id := strings.TrimSpace(physicalID)
+	id := normalizeOpenCodePhysicalModelID(physicalID)
 	route, ok := openCodeRouteByPhysicalID[id]
 	if !ok {
 		return OpenCodeModel{}, OpenCodeRoute{}, false
@@ -272,7 +274,7 @@ func OpenCodeRouteForPhysicalModel(physicalID string) (OpenCodeModel, OpenCodeRo
 // allowlist for a physical model ID, or nil when the model has none (native or
 // first-party routes, or uncurated custom slugs).
 func OpenCodeUSProviderList(physicalID string) []string {
-	route, ok := openCodeRouteByPhysicalID[strings.TrimSpace(physicalID)]
+	route, ok := openCodeRouteByPhysicalID[normalizeOpenCodePhysicalModelID(physicalID)]
 	if !ok {
 		return nil
 	}
@@ -367,8 +369,17 @@ func OpenCodeDisplayName(idOrPhysical string) string {
 	if m, ok := openCodeModelsByID[id]; ok {
 		return m.DisplayName
 	}
-	if m, ok := openCodeModelByPhysicalID[id]; ok {
+	if m, ok := openCodeModelByPhysicalID[normalizeOpenCodePhysicalModelID(id)]; ok {
 		return m.DisplayName
+	}
+	return id
+}
+
+func normalizeOpenCodePhysicalModelID(id string) string {
+	id = strings.TrimSpace(id)
+	const openRouterCustomPrefix = "openrouter/~"
+	if upstreamModel, ok := strings.CutPrefix(id, openRouterCustomPrefix); ok {
+		return "openrouter/" + upstreamModel
 	}
 	return id
 }

--- a/internal/models/opencode_models_test.go
+++ b/internal/models/opencode_models_test.go
@@ -120,8 +120,16 @@ func TestOpenCodeRouteForPhysicalModelAndDisplayName(t *testing.T) {
 	require.Equal(t, "glm-5.2", logical.ID)
 	require.Equal(t, ProviderOpenRouter, route.Backing)
 
+	logical, route, ok = OpenCodeRouteForPhysicalModel("openrouter/~z-ai/glm-5.2")
+	require.True(t, ok, "OpenCode CLI custom-model ids should resolve to their registry route")
+	require.Equal(t, "glm-5.2", logical.ID)
+	require.Equal(t, ProviderOpenRouter, route.Backing)
+	require.True(t, IsKnownOpenCodePhysicalModel("openrouter/~z-ai/glm-5.2"), "OpenCode CLI custom-model ids should be recognized")
+	require.Equal(t, []string{"deepinfra", "together", "fireworks"}, OpenCodeUSProviderList("openrouter/~z-ai/glm-5.2"), "CLI custom-model id should retain audited routing")
+
 	require.Equal(t, "GLM 5.2", OpenCodeDisplayName("glm-5.2"), "logical id should resolve to its display name")
 	require.Equal(t, "GLM 5.2", OpenCodeDisplayName(OpenCodeModelGLM52), "physical id should resolve to the owning model's display name")
+	require.Equal(t, "GLM 5.2", OpenCodeDisplayName("openrouter/~z-ai/glm-5.2"), "CLI custom-model id should resolve to the owning model's display name")
 	require.Equal(t, "vendor/custom", OpenCodeDisplayName("vendor/custom"), "uncurated slug should pass through")
 }
 
@@ -132,6 +140,7 @@ func TestAgentTypeForModel_OpenCodeLogicalIDs(t *testing.T) {
 
 	require.Equal(t, AgentTypeOpenCode, AgentTypeForModel("glm-5.2"), "open-weight logical id routes to OpenCode")
 	require.Equal(t, AgentTypeOpenCode, AgentTypeForModel("kimi-k2.6"))
+	require.Equal(t, AgentTypeOpenCode, AgentTypeForModel("openrouter/~z-ai/glm-5.2"), "OpenCode CLI custom-model id routes to OpenCode")
 	require.Equal(t, AgentTypeCodex, AgentTypeForModel("gpt-5.5"), "bare gpt-5.5 stays owned by Codex")
 	require.Equal(t, AgentTypeClaudeCode, AgentTypeForModel("claude-fable-5"), "bare claude-fable-5 stays owned by Claude Code")
 }

--- a/internal/services/agent/env.go
+++ b/internal/services/agent/env.go
@@ -845,6 +845,7 @@ func (e *AgentEnv) ResolveForModel(ctx context.Context, orgID uuid.UUID, agentTy
 			if strings.TrimSpace(oc.Model) == "" {
 				oc.Model = e.effectiveOpenCodeModel(ctx, orgID, oc.NormalizedBackingProvider())
 			}
+			oc.Model = openCodeCLIModelID(oc.Model, oc.NormalizedBackingProvider())
 			applyOpenCodeEnv(merged, oc)
 			e.updateRuntimeCredentialBindingModel(orgID, userID, models.ProviderOpenCode, oc.Model)
 		} else if block, ok := e.lookupCredentialBlock(orgID, userID, models.ProviderOpenCode); ok {
@@ -1073,9 +1074,9 @@ func applyOpenCodeEnv(env map[string]string, cfg models.OpenCodeConfig) {
 // first-party OpenAI model rather than a GLM route it can't reach).
 func (e *AgentEnv) effectiveOpenCodeModel(ctx context.Context, orgID uuid.UUID, backing models.ProviderName) string {
 	if selection := e.openCodeModelFromAgentConfig(ctx, orgID); selection != "" {
-		return models.OpenCodePhysicalModelForBacking(selection, backing)
+		return openCodeCLIModelID(models.OpenCodePhysicalModelForBacking(selection, backing), backing)
 	}
-	return models.DefaultOpenCodePhysicalModelForBacking(backing)
+	return openCodeCLIModelID(models.DefaultOpenCodePhysicalModelForBacking(backing), backing)
 }
 
 // resolveOpenCodeProviderConfig resolves an OpenCode model selection to a
@@ -1209,7 +1210,7 @@ func (e *AgentEnv) resolveAcrossOpenCodeRoutes(ctx context.Context, orgID uuid.U
 					Msg("opencode route resolution fell back to a non-preferred transport after rate limiting")
 			}
 			cfg.BackingProvider = route.Backing
-			cfg.Model = route.PhysicalModelID
+			cfg.Model = openCodeCLIModelID(route.PhysicalModelID, route.Backing)
 			e.recordCredentialPick(orgID, userID, models.ProviderOpenCode, cred)
 			return cfg
 		}
@@ -1380,7 +1381,9 @@ func openCodeOpenRouterModelConfigs(model string) map[string]openCodeModelConfig
 	}
 	providers := models.OpenCodeUSProviderList(model)
 	if len(providers) == 0 {
-		return nil
+		return map[string]openCodeModelConfig{
+			modelKey: {},
+		}
 	}
 	return map[string]openCodeModelConfig{
 		modelKey: {
@@ -1403,7 +1406,31 @@ func openCodeOpenRouterModelKey(model string) (string, bool) {
 	if !ok || !strings.Contains(upstreamModel, "/") {
 		return "", false
 	}
+	if strings.HasPrefix(upstreamModel, "~") {
+		return upstreamModel, true
+	}
 	return "~" + upstreamModel, true
+}
+
+func openCodeCLIModelID(model string, backing models.ProviderName) string {
+	if backing != models.ProviderOpenRouter {
+		return model
+	}
+	model = strings.TrimSpace(model)
+	const prefix = "openrouter/"
+	if upstreamModel, ok := strings.CutPrefix(model, prefix); ok {
+		if strings.HasPrefix(upstreamModel, "~") {
+			return model
+		}
+		return prefix + "~" + upstreamModel
+	}
+	if strings.HasPrefix(model, "~") {
+		return prefix + model
+	}
+	if strings.Contains(model, "/") {
+		return prefix + "~" + model
+	}
+	return model
 }
 
 func openCodeProviderConfigIDAndKey(provider models.ProviderName) (string, string) {

--- a/internal/services/agent/env_test.go
+++ b/internal/services/agent/env_test.go
@@ -649,10 +649,11 @@ func TestOpenCodeRuntimeConfigContent_RestrictsOpenRouterGLMToAuditedUSProviders
 	cfg := models.OpenCodeConfig{
 		APIKey:          "or-key",
 		BackingProvider: models.ProviderOpenRouter,
-		Model:           models.OpenCodeModelOpenRouterGLM52,
+		Model:           openCodeCLIModelID(models.OpenCodeModelOpenRouterGLM52, models.ProviderOpenRouter),
 	}
 	require.NoError(t, json.Unmarshal([]byte(openCodeRuntimeConfigContent(cfg)), &config), "OpenCode runtime config should be valid JSON")
 	require.Equal(t, []any{"openrouter"}, config["enabled_providers"], "OpenCode should only enable the selected OpenRouter provider")
+	require.Equal(t, "openrouter/~z-ai/glm-5.2", config["model"], "OpenCode should select the custom OpenRouter model id")
 
 	providers := config["provider"].(map[string]any)
 	openRouterProvider := providers["openrouter"].(map[string]any)
@@ -666,6 +667,92 @@ func TestOpenCodeRuntimeConfigContent_RestrictsOpenRouterGLMToAuditedUSProviders
 	require.Equal(t, false, providerRouting["allow_fallbacks"], "OpenRouter GLM should not fall back to unaudited providers")
 	require.Equal(t, "deny", providerRouting["data_collection"], "OpenRouter GLM should deny providers that may collect data")
 	require.Equal(t, true, providerRouting["require_parameters"], "OpenRouter GLM should require full parameter support")
+}
+
+func TestOpenCodeRuntimeConfigContent_DefinesCustomOpenRouterModelKey(t *testing.T) {
+	t.Parallel()
+
+	var config map[string]any
+	cfg := models.OpenCodeConfig{
+		APIKey:          "or-key",
+		BackingProvider: models.ProviderOpenRouter,
+		Model:           openCodeCLIModelID("xai/grok-code-fast", models.ProviderOpenRouter),
+	}
+	require.NoError(t, json.Unmarshal([]byte(openCodeRuntimeConfigContent(cfg)), &config), "OpenCode runtime config should be valid JSON")
+	require.Equal(t, "openrouter/~xai/grok-code-fast", config["model"], "OpenCode should select the custom OpenRouter model id")
+
+	providers := config["provider"].(map[string]any)
+	openRouterProvider := providers["openrouter"].(map[string]any)
+	modelsConfig := openRouterProvider["models"].(map[string]any)
+	require.Contains(t, modelsConfig, "~xai/grok-code-fast", "OpenCode config should define custom OpenRouter model keys")
+}
+
+func TestOpenCodeCLIModelID(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		model    string
+		backing  models.ProviderName
+		expected string
+	}{
+		{
+			name:     "curated OpenRouter route",
+			model:    "openrouter/z-ai/glm-5.2",
+			backing:  models.ProviderOpenRouter,
+			expected: "openrouter/~z-ai/glm-5.2",
+		},
+		{
+			name:     "already normalized OpenRouter route",
+			model:    "openrouter/~z-ai/glm-5.2",
+			backing:  models.ProviderOpenRouter,
+			expected: "openrouter/~z-ai/glm-5.2",
+		},
+		{
+			name:     "bare custom OpenRouter key",
+			model:    "~xai/grok-code-fast",
+			backing:  models.ProviderOpenRouter,
+			expected: "openrouter/~xai/grok-code-fast",
+		},
+		{
+			name:     "custom provider model through OpenRouter",
+			model:    "xai/grok-code-fast",
+			backing:  models.ProviderOpenRouter,
+			expected: "openrouter/~xai/grok-code-fast",
+		},
+		{
+			name:     "native OpenCode route",
+			model:    models.OpenCodeModelGLM52,
+			backing:  models.ProviderOpenCode,
+			expected: models.OpenCodeModelGLM52,
+		},
+		{
+			name:     "OpenAI first-party route",
+			model:    models.OpenCodeModelGPT54Mini,
+			backing:  models.ProviderOpenAI,
+			expected: models.OpenCodeModelGPT54Mini,
+		},
+		{
+			name:     "Anthropic first-party route",
+			model:    models.OpenCodeModelClaudeHaiku45,
+			backing:  models.ProviderAnthropic,
+			expected: models.OpenCodeModelClaudeHaiku45,
+		},
+		{
+			name:     "Gemini first-party route",
+			model:    models.OpenCodeModelGemini3Flash,
+			backing:  models.ProviderGemini,
+			expected: models.OpenCodeModelGemini3Flash,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			require.Equal(t, tt.expected, openCodeCLIModelID(tt.model, tt.backing), "OpenCode CLI model id should match the backing provider")
+		})
+	}
 }
 
 func TestOpenCodeRuntimeConfigContent_AllCuratedOpenRouterModelsHaveAuditedProviderRouting(t *testing.T) {
@@ -703,6 +790,9 @@ func TestOpenCodeRuntimeConfigContent_AllCuratedOpenRouterModelsHaveAuditedProvi
 
 			configs := openCodeOpenRouterModelConfigs(model)
 			require.NotEmpty(t, configs, "curated OpenRouter model should define audited provider routing")
+			runtimeModel := openCodeCLIModelID(model, models.ProviderOpenRouter)
+			runtimeConfigs := openCodeOpenRouterModelConfigs(runtimeModel)
+			require.Equal(t, configs, runtimeConfigs, "curated OpenRouter model should define the same routing for the CLI custom-model id")
 			for modelKey, config := range configs {
 				require.NotEmpty(t, modelKey, "curated OpenRouter model should define a model config key")
 				providerRouting, ok := config.Options["provider"].(map[string]any)
@@ -717,6 +807,44 @@ func TestOpenCodeRuntimeConfigContent_AllCuratedOpenRouterModelsHaveAuditedProvi
 				require.Equal(t, true, providerRouting["require_parameters"], "curated OpenRouter model should require full parameter support")
 			}
 		})
+	}
+}
+
+func TestAgentEnvResolveForModel_AllCuratedOpenRouterRoutesUseCustomModelIDs(t *testing.T) {
+	t.Parallel()
+
+	for _, logical := range models.OpenCodeModelRegistry {
+		for _, route := range logical.Routes {
+			if route.Backing != models.ProviderOpenRouter {
+				continue
+			}
+			logicalID := logical.ID
+			route := route
+			t.Run(route.PhysicalModelID, func(t *testing.T) {
+				t.Parallel()
+
+				orgID, userID := uuid.New(), uuid.New()
+				env := openCodeRoutingEnv(t, orgID, nil, []models.DecryptedCodingCredential{
+					openCodeCred(orgID, &userID, 0, "sk-or-opencode", models.ProviderOpenRouter),
+				})
+				resolved := env.ResolveForModel(context.Background(), orgID, models.AgentTypeOpenCode, &userID, route.PhysicalModelID)
+				expectedModel := openCodeCLIModelID(route.PhysicalModelID, models.ProviderOpenRouter)
+
+				require.Equal(t, "sk-or-opencode", resolved["OPENROUTER_API_KEY"], "OpenRouter route should use the OpenRouter-backed key")
+				require.Empty(t, resolved["OPENCODE_API_KEY"], "OpenRouter route should not inject the native OpenCode key")
+				require.Equal(t, expectedModel, resolved["OPENCODE_MODEL"], "OpenRouter route should use OpenCode's custom-model CLI id")
+
+				var config map[string]any
+				require.NoError(t, json.Unmarshal([]byte(resolved["OPENCODE_CONFIG_CONTENT"]), &config), "runtime config for %s should be valid JSON", logicalID)
+				require.Equal(t, expectedModel, config["model"], "runtime config should select the same CLI model")
+				providers := config["provider"].(map[string]any)
+				openRouterProvider := providers["openrouter"].(map[string]any)
+				modelsConfig := openRouterProvider["models"].(map[string]any)
+				modelKey, ok := openCodeOpenRouterModelKey(expectedModel)
+				require.True(t, ok, "resolved OpenRouter CLI model should have a custom model key")
+				require.Contains(t, modelsConfig, modelKey, "runtime config should define the selected OpenRouter custom model key")
+			})
+		}
 	}
 }
 
@@ -1637,7 +1765,7 @@ func TestAgentEnvResolveForModel_OpenCodeLogicalPrefersOpenRouter(t *testing.T) 
 	resolved := env.ResolveForModel(context.Background(), orgID, models.AgentTypeOpenCode, &userID, "glm-5.2")
 	require.Equal(t, "sk-or-opencode", resolved["OPENROUTER_API_KEY"], "logical glm-5.2 should prefer the OpenRouter route")
 	require.Empty(t, resolved["OPENCODE_API_KEY"], "OpenRouter route should not also inject the native key")
-	require.Equal(t, models.OpenCodeModelOpenRouterGLM52, resolved["OPENCODE_MODEL"], "resolved physical model should be the OpenRouter route id")
+	require.Equal(t, "openrouter/~z-ai/glm-5.2", resolved["OPENCODE_MODEL"], "resolved model should use OpenCode's OpenRouter custom-model id")
 	require.Contains(t, resolved["OPENCODE_CONFIG_CONTENT"], "deepinfra", "OpenRouter route must pin the audited US provider allowlist")
 }
 
@@ -1719,12 +1847,12 @@ func TestAgentEnvResolveForModel_OpenCodeResolvedRouteDrivesCLIAndConfig(t *test
 		})
 		resolved := env.ResolveForModel(context.Background(), orgID, models.AgentTypeOpenCode, &userID, "glm-5.2")
 
-		require.Equal(t, models.OpenCodeModelOpenRouterGLM52, resolved["OPENCODE_MODEL"],
-			"--model must receive the OpenRouter route's physical id")
+		require.Equal(t, "openrouter/~z-ai/glm-5.2", resolved["OPENCODE_MODEL"],
+			"--model must receive OpenCode's OpenRouter custom-model id")
 		cfg := resolved["OPENCODE_CONFIG_CONTENT"]
 		require.Contains(t, cfg, "OPENROUTER_API_KEY", "runtime config must reference the OpenRouter key env")
 		require.Contains(t, cfg, "deepinfra", "OpenRouter route must pin the audited US provider allowlist")
-		require.Contains(t, cfg, models.OpenCodeModelOpenRouterGLM52, "runtime config model must be the resolved physical id")
+		require.Contains(t, cfg, "openrouter/~z-ai/glm-5.2", "runtime config model must be the resolved CLI model")
 	})
 
 	t.Run("native route", func(t *testing.T) {

--- a/internal/services/agent/orchestrator_test.go
+++ b/internal/services/agent/orchestrator_test.go
@@ -9794,9 +9794,9 @@ func TestRunAgent_OpenCodeLogicalModelOverrideReachesSandboxAsResolvedRoute(t *t
 	err := buildOrchestrator(d).RunAgent(context.Background(), run)
 	require.NoError(t, err, "RunAgent should execute with an OpenRouter-backed OpenCode credential")
 	require.Equal(t, "sk-or-opencode", capturedCfg.Env["OPENROUTER_API_KEY"], "OpenCode should use the OpenRouter-backed credential")
-	require.Equal(t, models.OpenCodeModelOpenRouterGLM52, capturedCfg.Env["OPENCODE_MODEL"], "logical OpenCode overrides should resolve to the physical OpenRouter route before reaching the sandbox")
+	require.Equal(t, "openrouter/~z-ai/glm-5.2", capturedCfg.Env["OPENCODE_MODEL"], "logical OpenCode overrides should resolve to OpenCode's OpenRouter custom-model id before reaching the sandbox")
 	require.NotEqual(t, models.DefaultOpenCodeModel, capturedCfg.Env["OPENCODE_MODEL"], "the sandbox must not receive a bare logical OpenCode model id")
-	require.Contains(t, capturedCfg.Env["OPENCODE_CONFIG_CONTENT"], models.OpenCodeModelOpenRouterGLM52, "OpenCode runtime config should match the resolved physical model")
+	require.Contains(t, capturedCfg.Env["OPENCODE_CONFIG_CONTENT"], "openrouter/~z-ai/glm-5.2", "OpenCode runtime config should match the resolved CLI model")
 }
 
 // --- Amp/Pi agent env resolution ---


### PR DESCRIPTION
## Summary
- Normalize OpenRouter custom-model IDs (`openrouter/~...`) across OpenCode model labeling and route resolution
- Ensure OpenCode agent env resolution emits the CLI-form model ID and preserves audited OpenRouter routing
- Extend model and env tests to cover custom OpenRouter IDs end to end

## Testing
- Added and updated unit tests for model constants, OpenCode route resolution, and agent env runtime config generation