### PR TITLE
Raise app node memory limits for launch headroom

### DIFF
--- a/docker-compose.app.yml
+++ b/docker-compose.app.yml
@@ -59,7 +59,7 @@ services:
     deploy:
       resources:
         limits:
-          memory: 2G
+          memory: 4G
           cpus: "4.0"
 
   frontend:
@@ -84,7 +84,7 @@ services:
     deploy:
       resources:
         limits:
-          memory: 1G
+          memory: 2G
           cpus: "2.0"
 
 volumes:


### PR DESCRIPTION
## What

Double the app node's container memory limits:

| Service | Before | After |
|---------|--------|-------|
| `api` | 2 GB | **4 GB** |
| `frontend` | 1 GB | **2 GB** |

CPU limits unchanged.

## Why

Capacity review ahead of the open-source launch: the single app node is the launch-day risk, and its **most likely failure mode under a spike is OOM, not CPU**. The app node is a stateless HTTP + SSR tier — all agent compute runs on the worker fleet — so on a CCX23 (4 vCPU / 16 GB) it has ample RAM headroom that the old 2G/1G limits left on the table.

## Sizing rationale (constrained by the deploy flow)

The blue/green rollout in `deploy/scripts/deploy.sh` momentarily runs **two copies** of a service during a rollout (scale +1, health-check, kill old, reconcile to 1). So each limit must fit *doubled*:

- Worst-case deploy-time peak: `2×4 + 2×2 = 12 GB` + caddy/vector ≈ **13 GB < 16 GB** ✅
- Steady state (1 each): ~7 GB, leaving ~9 GB for page cache / OS.

Going higher (e.g. api 6 GB) would push the deploy-time peak into the ceiling, so 4 GB is the safe maximum here.

## Not included (intentionally)

Persistent 2-replica scaling was considered and **dropped for launch eve**: the deploy tooling reconciles every app service back to `--scale=1` after each rollout (`deploy.sh:1421`), so persistent replicas would require changing the blue/green logic — too risky tonight. Container crash recovery is already handled by `restart: unless-stopped` + Caddy's 2s health checks routing around a dead container. Revisit replicas with the NLB / multi-node API work post-launch.

## Deploy

`make deploy-app` (rolling restart re-reads the limits).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
