### PR TITLE
Clean up landing CTA buttons

### DIFF
--- a/frontend/src/components/landing/hero-section.tsx
+++ b/frontend/src/components/landing/hero-section.tsx
@@ -40,19 +40,6 @@ export default function HeroSection({ isDark }: HeroSectionProps) {
         </Link>
 
         <div className="flex items-center gap-4">
-          {demoURL && (
-            <Button
-              asChild
-              variant="ghost"
-              className={`hidden ${type.button} px-3 sm:inline-flex ${
-                isDark
-                  ? "text-white/60 hover:bg-white/5 hover:text-white"
-                  : "text-slate-600 hover:bg-slate-900/5 hover:text-slate-900"
-              }`}
-            >
-              <a href={demoURL}>Try demo</a>
-            </Button>
-          )}
           <Button
             asChild
             variant="ghost"
@@ -84,7 +71,7 @@ export default function HeroSection({ isDark }: HeroSectionProps) {
             }`}
           >
             <Link href="/login?tab=signup">
-              Start
+              Start building
               <ArrowRight className="ml-2 size-3.5" aria-hidden="true" />
             </Link>
           </Button>
@@ -125,24 +112,21 @@ export default function HeroSection({ isDark }: HeroSectionProps) {
                 </a>
               </Button>
             )}
-            <Button
-              asChild
-              variant={demoURL ? "outline" : "default"}
-              className={`${type.button} ${demoURL ? "rounded-md shadow-sm" : "rounded-full"} transition-all ${
-                isDark
-                  ? demoURL
-                    ? "border-white/15 bg-white/[0.04] text-white/80 hover:border-white/35 hover:bg-white/[0.08] hover:text-white"
-                    : "bg-white text-[#08080f] hover:bg-white/90"
-                  : demoURL
-                    ? "border-slate-300 bg-white text-slate-900 hover:border-slate-500 hover:bg-slate-50"
+            {!demoURL && (
+              <Button
+                asChild
+                className={`${type.button} rounded-full transition-all ${
+                  isDark
+                    ? "bg-white text-[#08080f] hover:bg-white/90"
                     : "bg-slate-900 text-white hover:bg-slate-800"
-              }`}
-            >
-              <Link href="/login?tab=signup">
-                Get started
-                <ArrowRight className="ml-2 size-3.5" aria-hidden="true" />
-              </Link>
-            </Button>
+                }`}
+              >
+                <Link href="/login?tab=signup">
+                  Start building
+                  <ArrowRight className="ml-2 size-3.5" aria-hidden="true" />
+                </Link>
+              </Button>
+            )}
             <Button
               asChild
               variant="outline"


### PR DESCRIPTION
## What

Tidies the action buttons on the marketing landing page.

**Top nav:** removed the "Try demo" link (added by #1776), restoring it to **Docs · Sign in · Start building**.

**Hero:** dropped "Get started" so the main buttons are **Try demo · View source code** (demo-first). When `NEXT_PUBLIC_DEMO_URL` is unset, the hero falls back to a filled **Start building** so there's always a primary CTA.

**Consistency:** unified the signup label to **"Start building"** across the nav and hero (the bottom CTA already used it). Previously the same `/login?tab=signup` destination was labeled "Start", "Get started", and "Start building".

## Final button map
- **Nav:** Docs · Sign in · Start building
- **Hero:** Try demo *(or Start building if no demo URL)* · View source code
- **Bottom CTA:** Try demo · Start building

## Testing
- `tsc --noEmit` clean for the touched components.
- Browser preview not run — the local preview harness's Node is too old to parse Next.js; changes are static JSX.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
