### PR TITLE
Fix OpenCode OpenRouter model ids: drop the "~" prefix

### DIFF
--- a/internal/models/opencode_models.go
+++ b/internal/models/opencode_models.go
@@ -29,9 +29,9 @@ type OpenCodeRoute struct {
 	// NormalizedBackingProvider() equals this value.
 	Backing ProviderName
 	// PhysicalModelID is the route ID tracked by 143 (e.g.
-	// "openrouter/z-ai/glm-5.2" or "opencode/glm-5.2"). OpenRouter routes are
-	// converted to OpenCode's custom-model CLI form ("openrouter/~...") when
-	// building the sandbox runtime config.
+	// "openrouter/z-ai/glm-5.2" or "opencode/glm-5.2"). It is also the id passed
+	// to `opencode run --model`; for OpenRouter routes OpenCode forwards the
+	// "vendor/model" slug to OpenRouter as the API model id unchanged.
 	PhysicalModelID string
 	// USProviderList is the audited US-only OpenRouter inference-provider
 	// allowlist (only/order) pinned in the runtime config. Empty for non-OpenRouter

--- a/internal/models/opencode_models_test.go
+++ b/internal/models/opencode_models_test.go
@@ -155,16 +155,18 @@ func TestOpenCodeRouteForPhysicalModelAndDisplayName(t *testing.T) {
 	require.Equal(t, "glm-5.2", logical.ID)
 	require.Equal(t, ProviderOpenRouter, route.Backing)
 
+	// Legacy "openrouter/~..." ids (briefly emitted by #1771) must still resolve
+	// to their registry route for back-compat with any in-flight session.
 	logical, route, ok = OpenCodeRouteForPhysicalModel("openrouter/~z-ai/glm-5.2")
-	require.True(t, ok, "OpenCode CLI custom-model ids should resolve to their registry route")
+	require.True(t, ok, "legacy tilde ids should resolve to their registry route")
 	require.Equal(t, "glm-5.2", logical.ID)
 	require.Equal(t, ProviderOpenRouter, route.Backing)
-	require.True(t, IsKnownOpenCodePhysicalModel("openrouter/~z-ai/glm-5.2"), "OpenCode CLI custom-model ids should be recognized")
-	require.Equal(t, []string{"deepinfra", "together", "fireworks"}, OpenCodeUSProviderList("openrouter/~z-ai/glm-5.2"), "CLI custom-model id should retain audited routing")
+	require.True(t, IsKnownOpenCodePhysicalModel("openrouter/~z-ai/glm-5.2"), "legacy tilde ids should be recognized")
+	require.Equal(t, []string{"deepinfra", "together", "fireworks"}, OpenCodeUSProviderList("openrouter/~z-ai/glm-5.2"), "legacy tilde id should retain audited routing")
 
 	require.Equal(t, "GLM 5.2", OpenCodeDisplayName("glm-5.2"), "logical id should resolve to its display name")
 	require.Equal(t, "GLM 5.2", OpenCodeDisplayName(OpenCodeModelGLM52), "physical id should resolve to the owning model's display name")
-	require.Equal(t, "GLM 5.2", OpenCodeDisplayName("openrouter/~z-ai/glm-5.2"), "CLI custom-model id should resolve to the owning model's display name")
+	require.Equal(t, "GLM 5.2", OpenCodeDisplayName("openrouter/~z-ai/glm-5.2"), "legacy tilde id should resolve to the owning model's display name")
 	require.Equal(t, "vendor/custom", OpenCodeDisplayName("vendor/custom"), "uncurated slug should pass through")
 }
 
@@ -175,7 +177,7 @@ func TestAgentTypeForModel_OpenCodeLogicalIDs(t *testing.T) {
 
 	require.Equal(t, AgentTypeOpenCode, AgentTypeForModel("glm-5.2"), "open-weight logical id routes to OpenCode")
 	require.Equal(t, AgentTypeOpenCode, AgentTypeForModel("kimi-k2.6"))
-	require.Equal(t, AgentTypeOpenCode, AgentTypeForModel("openrouter/~z-ai/glm-5.2"), "OpenCode CLI custom-model id routes to OpenCode")
+	require.Equal(t, AgentTypeOpenCode, AgentTypeForModel("openrouter/~z-ai/glm-5.2"), "legacy tilde id routes to OpenCode")
 	require.Equal(t, AgentTypeCodex, AgentTypeForModel("gpt-5.5"), "bare gpt-5.5 stays owned by Codex")
 	require.Equal(t, AgentTypeClaudeCode, AgentTypeForModel("claude-fable-5"), "bare claude-fable-5 stays owned by Claude Code")
 }

--- a/internal/services/agent/env.go
+++ b/internal/services/agent/env.go
@@ -1372,8 +1372,9 @@ func openCodeRuntimeConfigContent(cfg models.OpenCodeConfig) string {
 // allowlist for an OpenRouter route. The allowlist is sourced from the logical
 // model registry (models.OpenCodeUSProviderList), the single source of truth;
 // see docs/design/implemented/95-opencode-agent-adapter.md and
-// docs/design/115-logical-models-and-route-resolution.md. The config key uses
-// OpenCode's "~upstream/provider-model" custom-model-key format.
+// docs/design/115-logical-models-and-route-resolution.md. The config key is the
+// upstream OpenRouter model slug (e.g. "z-ai/glm-5.2"); OpenCode forwards it to
+// OpenRouter as the API model id unchanged.
 func openCodeOpenRouterModelConfigs(model string) map[string]openCodeModelConfig {
 	modelKey, ok := openCodeOpenRouterModelKey(model)
 	if !ok {
@@ -1406,31 +1407,36 @@ func openCodeOpenRouterModelKey(model string) (string, bool) {
 	if !ok || !strings.Contains(upstreamModel, "/") {
 		return "", false
 	}
-	if strings.HasPrefix(upstreamModel, "~") {
-		return upstreamModel, true
-	}
-	return "~" + upstreamModel, true
+	// OpenCode sends this config-model key verbatim as the OpenRouter API model
+	// id (it resolves `model.id ?? existingModel.api.id ?? key`), so the key must
+	// be the real upstream slug — e.g. "z-ai/glm-5.2". Strip any legacy "~"
+	// prefix (briefly emitted by #1771), which OpenRouter rejects as an invalid
+	// model id.
+	return strings.TrimPrefix(upstreamModel, "~"), true
 }
 
+// openCodeCLIModelID returns the id passed to `opencode run --model` for a
+// resolved route. For OpenRouter routes it ensures the "openrouter/" provider
+// prefix on bare "vendor/model" slugs and strips any legacy "~" so the model
+// part matches the upstream OpenRouter id (and the runtime config model key).
+// OpenCode forwards that model part to OpenRouter unchanged, so a "~"-prefixed
+// id is rejected upstream as invalid.
 func openCodeCLIModelID(model string, backing models.ProviderName) string {
 	if backing != models.ProviderOpenRouter {
 		return model
 	}
 	model = strings.TrimSpace(model)
 	const prefix = "openrouter/"
-	if upstreamModel, ok := strings.CutPrefix(model, prefix); ok {
-		if strings.HasPrefix(upstreamModel, "~") {
-			return model
-		}
-		return prefix + "~" + upstreamModel
+	upstreamModel, ok := strings.CutPrefix(model, prefix)
+	if !ok {
+		upstreamModel = model
 	}
-	if strings.HasPrefix(model, "~") {
-		return prefix + model
+	upstreamModel = strings.TrimPrefix(upstreamModel, "~")
+	if !strings.Contains(upstreamModel, "/") {
+		// Bare logical/first-party id (no "vendor/model" slug): leave unchanged.
+		return model
 	}
-	if strings.Contains(model, "/") {
-		return prefix + "~" + model
-	}
-	return model
+	return prefix + upstreamModel
 }
 
 func openCodeProviderConfigIDAndKey(provider models.ProviderName) (string, string) {

--- a/internal/services/agent/env_test.go
+++ b/internal/services/agent/env_test.go
@@ -653,12 +653,12 @@ func TestOpenCodeRuntimeConfigContent_RestrictsOpenRouterGLMToAuditedUSProviders
 	}
 	require.NoError(t, json.Unmarshal([]byte(openCodeRuntimeConfigContent(cfg)), &config), "OpenCode runtime config should be valid JSON")
 	require.Equal(t, []any{"openrouter"}, config["enabled_providers"], "OpenCode should only enable the selected OpenRouter provider")
-	require.Equal(t, "openrouter/~z-ai/glm-5.2", config["model"], "OpenCode should select the custom OpenRouter model id")
+	require.Equal(t, "openrouter/z-ai/glm-5.2", config["model"], "OpenCode should select the upstream OpenRouter model id")
 
 	providers := config["provider"].(map[string]any)
 	openRouterProvider := providers["openrouter"].(map[string]any)
 	modelsConfig := openRouterProvider["models"].(map[string]any)
-	glmConfig := modelsConfig["~z-ai/glm-5.2"].(map[string]any)
+	glmConfig := modelsConfig["z-ai/glm-5.2"].(map[string]any)
 	options := glmConfig["options"].(map[string]any)
 	providerRouting := options["provider"].(map[string]any)
 
@@ -679,12 +679,12 @@ func TestOpenCodeRuntimeConfigContent_DefinesCustomOpenRouterModelKey(t *testing
 		Model:           openCodeCLIModelID("xai/grok-code-fast", models.ProviderOpenRouter),
 	}
 	require.NoError(t, json.Unmarshal([]byte(openCodeRuntimeConfigContent(cfg)), &config), "OpenCode runtime config should be valid JSON")
-	require.Equal(t, "openrouter/~xai/grok-code-fast", config["model"], "OpenCode should select the custom OpenRouter model id")
+	require.Equal(t, "openrouter/xai/grok-code-fast", config["model"], "OpenCode should select the upstream OpenRouter model id")
 
 	providers := config["provider"].(map[string]any)
 	openRouterProvider := providers["openrouter"].(map[string]any)
 	modelsConfig := openRouterProvider["models"].(map[string]any)
-	require.Contains(t, modelsConfig, "~xai/grok-code-fast", "OpenCode config should define custom OpenRouter model keys")
+	require.Contains(t, modelsConfig, "xai/grok-code-fast", "OpenCode config should define custom OpenRouter model keys")
 }
 
 func TestOpenCodeCLIModelID(t *testing.T) {
@@ -700,25 +700,25 @@ func TestOpenCodeCLIModelID(t *testing.T) {
 			name:     "curated OpenRouter route",
 			model:    "openrouter/z-ai/glm-5.2",
 			backing:  models.ProviderOpenRouter,
-			expected: "openrouter/~z-ai/glm-5.2",
+			expected: "openrouter/z-ai/glm-5.2",
 		},
 		{
-			name:     "already normalized OpenRouter route",
+			name:     "legacy tilde OpenRouter route is normalized away",
 			model:    "openrouter/~z-ai/glm-5.2",
 			backing:  models.ProviderOpenRouter,
-			expected: "openrouter/~z-ai/glm-5.2",
+			expected: "openrouter/z-ai/glm-5.2",
 		},
 		{
-			name:     "bare custom OpenRouter key",
+			name:     "bare legacy tilde OpenRouter key",
 			model:    "~xai/grok-code-fast",
 			backing:  models.ProviderOpenRouter,
-			expected: "openrouter/~xai/grok-code-fast",
+			expected: "openrouter/xai/grok-code-fast",
 		},
 		{
 			name:     "custom provider model through OpenRouter",
 			model:    "xai/grok-code-fast",
 			backing:  models.ProviderOpenRouter,
-			expected: "openrouter/~xai/grok-code-fast",
+			expected: "openrouter/xai/grok-code-fast",
 		},
 		{
 			name:     "native OpenCode route",
@@ -759,19 +759,19 @@ func TestOpenCodeRuntimeConfigContent_AllCuratedOpenRouterModelsHaveAuditedProvi
 	t.Parallel()
 
 	expectedProvidersByModelKey := map[string][]string{
-		"~deepseek/deepseek-v4-flash":    {"deepinfra", "cloudflare", "fireworks"},
-		"~deepseek/deepseek-v4-pro":      {"deepinfra", "together", "fireworks"},
-		"~google/gemini-3.1-pro-preview": {"google-ai-studio", "google-vertex/global"},
-		"~google/gemini-3.5-flash":       {"google-ai-studio", "google-vertex/global"},
-		"~minimax/minimax-m2.5":          {"deepinfra", "digitalocean", "parasail"},
-		"~minimax/minimax-m2.7":          {"deepinfra", "fireworks", "together"},
-		"~moonshotai/kimi-k2.5":          {"digitalocean", "deepinfra"},
-		"~moonshotai/kimi-k2.6":          {"deepinfra", "baseten", "fireworks"},
-		"~openai/gpt-5.2":                {"openai", "azure"},
-		"~openai/gpt-5.5":                {"openai", "azure"},
-		"~openai/gpt-5.5-pro":            {"openai"},
-		"~z-ai/glm-5.1":                  {"deepinfra", "baseten", "together"},
-		"~z-ai/glm-5.2":                  {"deepinfra", "together", "fireworks"},
+		"deepseek/deepseek-v4-flash":    {"deepinfra", "cloudflare", "fireworks"},
+		"deepseek/deepseek-v4-pro":      {"deepinfra", "together", "fireworks"},
+		"google/gemini-3.1-pro-preview": {"google-ai-studio", "google-vertex/global"},
+		"google/gemini-3.5-flash":       {"google-ai-studio", "google-vertex/global"},
+		"minimax/minimax-m2.5":          {"deepinfra", "digitalocean", "parasail"},
+		"minimax/minimax-m2.7":          {"deepinfra", "fireworks", "together"},
+		"moonshotai/kimi-k2.5":          {"digitalocean", "deepinfra"},
+		"moonshotai/kimi-k2.6":          {"deepinfra", "baseten", "fireworks"},
+		"openai/gpt-5.2":                {"openai", "azure"},
+		"openai/gpt-5.5":                {"openai", "azure"},
+		"openai/gpt-5.5-pro":            {"openai"},
+		"z-ai/glm-5.1":                  {"deepinfra", "baseten", "together"},
+		"z-ai/glm-5.2":                  {"deepinfra", "together", "fireworks"},
 	}
 
 	curatedOpenRouterModels := make([]string, 0, len(expectedProvidersByModelKey))
@@ -798,7 +798,7 @@ func TestOpenCodeRuntimeConfigContent_AllCuratedOpenRouterModelsHaveAuditedProvi
 				require.True(t, ok, "curated OpenRouter model should define provider routing options")
 				require.Equal(t, expectedProvidersByModelKey[modelKey], providerRouting["only"], "curated OpenRouter model should restrict provider routing to the audited provider")
 				require.Equal(t, expectedProvidersByModelKey[modelKey], providerRouting["order"], "curated OpenRouter model should prefer the audited provider in deterministic order")
-				if modelKey != "~openai/gpt-5.5-pro" {
+				if modelKey != "openai/gpt-5.5-pro" {
 					require.GreaterOrEqual(t, len(expectedProvidersByModelKey[modelKey]), 2, "curated OpenRouter model should include at least one audited fallback provider when OpenRouter exposes one")
 				}
 				require.Equal(t, false, providerRouting["allow_fallbacks"], "curated OpenRouter model should disable fallback to unaudited providers")
@@ -1764,7 +1764,7 @@ func TestAgentEnvResolveForModel_OpenCodeLogicalPrefersOpenRouter(t *testing.T) 
 	resolved := env.ResolveForModel(context.Background(), orgID, models.AgentTypeOpenCode, &userID, "glm-5.2")
 	require.Equal(t, "sk-or-opencode", resolved["OPENROUTER_API_KEY"], "logical glm-5.2 should prefer the OpenRouter route")
 	require.Empty(t, resolved["OPENCODE_API_KEY"], "OpenRouter route should not also inject the native key")
-	require.Equal(t, "openrouter/~z-ai/glm-5.2", resolved["OPENCODE_MODEL"], "resolved model should use OpenCode's OpenRouter custom-model id")
+	require.Equal(t, "openrouter/z-ai/glm-5.2", resolved["OPENCODE_MODEL"], "resolved model should use the upstream OpenRouter model id")
 	require.Contains(t, resolved["OPENCODE_CONFIG_CONTENT"], "deepinfra", "OpenRouter route must pin the audited US provider allowlist")
 }
 
@@ -1846,12 +1846,12 @@ func TestAgentEnvResolveForModel_OpenCodeResolvedRouteDrivesCLIAndConfig(t *test
 		})
 		resolved := env.ResolveForModel(context.Background(), orgID, models.AgentTypeOpenCode, &userID, "glm-5.2")
 
-		require.Equal(t, "openrouter/~z-ai/glm-5.2", resolved["OPENCODE_MODEL"],
-			"--model must receive OpenCode's OpenRouter custom-model id")
+		require.Equal(t, "openrouter/z-ai/glm-5.2", resolved["OPENCODE_MODEL"],
+			"--model must receive the upstream OpenRouter model id")
 		cfg := resolved["OPENCODE_CONFIG_CONTENT"]
 		require.Contains(t, cfg, "OPENROUTER_API_KEY", "runtime config must reference the OpenRouter key env")
 		require.Contains(t, cfg, "deepinfra", "OpenRouter route must pin the audited US provider allowlist")
-		require.Contains(t, cfg, "openrouter/~z-ai/glm-5.2", "runtime config model must be the resolved CLI model")
+		require.Contains(t, cfg, "openrouter/z-ai/glm-5.2", "runtime config model must be the resolved CLI model")
 	})
 
 	t.Run("native route", func(t *testing.T) {

--- a/internal/services/agent/orchestrator_test.go
+++ b/internal/services/agent/orchestrator_test.go
@@ -9794,9 +9794,9 @@ func TestRunAgent_OpenCodeLogicalModelOverrideReachesSandboxAsResolvedRoute(t *t
 	err := buildOrchestrator(d).RunAgent(context.Background(), run)
 	require.NoError(t, err, "RunAgent should execute with an OpenRouter-backed OpenCode credential")
 	require.Equal(t, "sk-or-opencode", capturedCfg.Env["OPENROUTER_API_KEY"], "OpenCode should use the OpenRouter-backed credential")
-	require.Equal(t, "openrouter/~z-ai/glm-5.2", capturedCfg.Env["OPENCODE_MODEL"], "logical OpenCode overrides should resolve to OpenCode's OpenRouter custom-model id before reaching the sandbox")
+	require.Equal(t, "openrouter/z-ai/glm-5.2", capturedCfg.Env["OPENCODE_MODEL"], "logical OpenCode overrides should resolve to the upstream OpenRouter model id before reaching the sandbox")
 	require.NotEqual(t, models.DefaultOpenCodeModel, capturedCfg.Env["OPENCODE_MODEL"], "the sandbox must not receive a bare logical OpenCode model id")
-	require.Contains(t, capturedCfg.Env["OPENCODE_CONFIG_CONTENT"], "openrouter/~z-ai/glm-5.2", "OpenCode runtime config should match the resolved CLI model")
+	require.Contains(t, capturedCfg.Env["OPENCODE_CONFIG_CONTENT"], "openrouter/z-ai/glm-5.2", "OpenCode runtime config should match the resolved CLI model")
 }
 
 // --- Amp/Pi agent env resolution ---


### PR DESCRIPTION
## Problem

OpenCode OpenRouter sessions (GLM 5.2 and every other `openrouter/*` route) fail at runtime with:

```
APIError: ~z-ai/glm-5.2 is not a valid model ID
```

[#1771](https://github.com/assembledhq/143/pull/1771) registered OpenRouter custom models under an OpenCode config key of `~z-ai/glm-5.2` and passed `--model openrouter/~z-ai/glm-5.2`, on the assumption that `~` is an OpenCode custom-model marker that gets stripped before the upstream call.

It is not. OpenCode resolves the upstream API model id as `model.id ?? existingModel.api.id ?? key` — the `provider.<id>.models` **key is forwarded to OpenRouter verbatim**, with no tilde handling anywhere ([opencode `provider.ts`](https://github.com/sst/opencode/blob/dev/packages/opencode/src/provider/provider.ts), [providers docs](https://opencode.ai/docs/providers/)). So `~z-ai/glm-5.2` reaches OpenRouter, which rejects it. `OPENCODE_CONFIG_CONTENT` *is* a real OpenCode inline-config override, so the config was applied faithfully — it was faithfully registering the broken key.

## Fix

Drop the `~`. `openCodeOpenRouterModelKey` and `openCodeCLIModelID` now emit the real upstream slug (`z-ai/glm-5.2`) and `openrouter/z-ai/glm-5.2`, and strip any stray `~`. `normalizeOpenCodePhysicalModelID` (Go + frontend `model-constants.ts`) is kept as a defensive shim that still **recognizes** legacy `openrouter/~...` ids for any in-flight session. Tests updated to the no-tilde form; legacy-recognition tests retained as back-compat coverage.

## Impact

No OpenCode OpenRouter route has worked since #1771 merged. The canonical OpenRouter slug `z-ai/glm-5.2` was confirmed valid.

## Testing

- `go build ./internal/services/agent/... ./internal/models/...` — clean
- `go test ./internal/models/ ./internal/services/agent/ -run 'OpenCode|OpenRouter|AgentTypeForModel'` — pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
