### PR TITLE
Surface real cause of preview cache extract failures

### DIFF
--- a/internal/services/agent/providers/docker.go
+++ b/internal/services/agent/providers/docker.go
@@ -1062,13 +1062,22 @@ func (d *DockerProvider) ExecWithStdin(ctx context.Context, sb *agent.Sandbox, c
 		<-writeErrCh
 		return -1, fmt.Errorf("read exec output: %w", err)
 	}
-	if err := <-writeErrCh; err != nil {
-		return -1, fmt.Errorf("write exec stdin: %w", err)
-	}
+	writeErr := <-writeErrCh
 
 	inspectResp, err := d.client.ContainerExecInspect(ctx, execResp.ID)
 	if err != nil {
 		return -1, fmt.Errorf("inspect exec: %w", err)
+	}
+
+	// A stdin copy error (typically EPIPE) usually means the process closed its
+	// stdin and exited before consuming the whole stream — e.g. tar aborting on a
+	// corrupt archive or being OOM-killed mid-extract. In that case the exec's
+	// real exit code is the authoritative signal, so return it (callers inspect
+	// non-zero codes alongside captured stderr) instead of masking it behind a
+	// generic "broken pipe". Only when the process exited cleanly does a write
+	// error indicate a genuine streaming failure worth surfacing on its own.
+	if writeErr != nil && inspectResp.ExitCode == 0 {
+		return 0, fmt.Errorf("write exec stdin: %w", writeErr)
 	}
 
 	return inspectResp.ExitCode, nil

--- a/internal/services/agent/providers/docker_test.go
+++ b/internal/services/agent/providers/docker_test.go
@@ -2701,6 +2701,53 @@ func TestDockerProvider_ExecWithStdin(t *testing.T) {
 	require.Contains(t, gotConfig.Env, "NODE_ENV=test", "ExecWithStdin should pass sandbox environment variables")
 }
 
+func TestDockerProvider_ExecWithStdin_StdinWriteError(t *testing.T) {
+	t.Parallel()
+
+	t.Run("non-zero exit takes precedence over a broken-pipe write error", func(t *testing.T) {
+		t.Parallel()
+
+		// The process drops stdin and exits non-zero (e.g. tar aborting on a
+		// corrupt archive or OOM kill), so the stdin copy fails with EPIPE. The
+		// real signal is the exit code + stderr, not the writer-side broken pipe.
+		stderrPayload := []byte("\ngzip: stdin: invalid compressed data--crc error\n")
+		mock := &mockDockerClient{}
+		mock.containerExecAttachFn = func(ctx context.Context, execID string, config container.ExecAttachOptions) (types.HijackedResponse, error) {
+			return newFailWriteHijackedResponse(dockerMultiplexed(nil, stderrPayload), errors.New("write: broken pipe")), nil
+		}
+		mock.containerExecInspectFn = func(ctx context.Context, execID string) (container.ExecInspect, error) {
+			return container.ExecInspect{Running: false, ExitCode: 2}, nil
+		}
+		p := NewDockerProvider(mock, newTestLogger())
+		sb := &agent.Sandbox{ID: "test-container", WorkDir: "/workspace/repo"}
+
+		var stderr bytes.Buffer
+		exitCode, err := p.ExecWithStdin(context.Background(), sb, "tar xzf - -C /workspace/repo", strings.NewReader("archive-bytes"), io.Discard, &stderr)
+		require.NoError(t, err, "a broken-pipe write must not mask a non-zero exit; the exit code is the signal")
+		require.Equal(t, 2, exitCode, "ExecWithStdin should return tar's real exit code, not -1")
+		require.Contains(t, stderr.String(), "crc error", "tar's stderr should be captured for diagnosis")
+	})
+
+	t.Run("write error surfaces when the process exited cleanly", func(t *testing.T) {
+		t.Parallel()
+
+		mock := &mockDockerClient{}
+		mock.containerExecAttachFn = func(ctx context.Context, execID string, config container.ExecAttachOptions) (types.HijackedResponse, error) {
+			return newFailWriteHijackedResponse(dockerMultiplexed(nil, nil), errors.New("write: broken pipe")), nil
+		}
+		mock.containerExecInspectFn = func(ctx context.Context, execID string) (container.ExecInspect, error) {
+			return container.ExecInspect{Running: false, ExitCode: 0}, nil
+		}
+		p := NewDockerProvider(mock, newTestLogger())
+		sb := &agent.Sandbox{ID: "test-container", WorkDir: "/workspace/repo"}
+
+		exitCode, err := p.ExecWithStdin(context.Background(), sb, "tar xzf - -C /workspace/repo", strings.NewReader("archive-bytes"), io.Discard, io.Discard)
+		require.Error(t, err, "a clean exit with a failed stdin copy is a genuine streaming failure")
+		require.Contains(t, err.Error(), "write exec stdin")
+		require.Equal(t, 0, exitCode)
+	})
+}
+
 func TestDockerProvider_Options(t *testing.T) {
 	t.Parallel()
 

--- a/internal/services/preview/dependency_cache.go
+++ b/internal/services/preview/dependency_cache.go
@@ -368,11 +368,21 @@ func (c *SharedDependencyCache) RestorePathCache(ctx context.Context, sb *agent.
 	if cleanExecErr != nil || exitCode != 0 {
 		return fmt.Errorf("dependency cache restore: %w", dependencyCacheExecError("remove existing paths", exitCode, cleanExecErr, cleanErr.String()))
 	}
-	if err := blob.rewind(); err != nil {
-		return fmt.Errorf("dependency cache restore: %w", err)
-	}
-	if exitCode, err := c.extractSandboxArchive(ctx, sb, root, blob.file); err != nil || exitCode != 0 {
-		return fmt.Errorf("dependency cache restore: extract exited %d: %w", exitCode, err)
+	// Retry a transient extract failure (signal kill / momentarily-unavailable
+	// container) once before degrading to a cold launch, matching the cleanup and
+	// save paths. The stderr buffer is declared outside the closure and reset per
+	// attempt so the surfaced error carries tar's own diagnostic, and blob.file is
+	// rewound at the start of each attempt since a partial stream advances it.
+	var extractErr bytes.Buffer
+	extractExit, extractExecErr := c.execWithTransientRetry(ctx, "restore_extract", func() (int, error) {
+		extractErr.Reset()
+		if err := blob.rewind(); err != nil {
+			return -1, fmt.Errorf("rewind blob: %w", err)
+		}
+		return c.extractSandboxArchive(ctx, sb, root, blob.file, &extractErr)
+	})
+	if extractExecErr != nil || extractExit != 0 {
+		return fmt.Errorf("dependency cache restore: %w", dependencyCacheExecError("extract archive", extractExit, extractExecErr, extractErr.String()))
 	}
 	if !blob.fromLocal {
 		c.writeLocalBlobFromFile(ctx, hit, blob.path, blob.sizeBytes, blob.checksum)
@@ -854,7 +864,7 @@ func dependencyCacheArchiveNameMatchesPath(name, allowed string) bool {
 	return false
 }
 
-func (c *SharedDependencyCache) extractSandboxArchive(ctx context.Context, sb *agent.Sandbox, root models.PreviewCacheRoot, reader io.Reader) (int, error) {
+func (c *SharedDependencyCache) extractSandboxArchive(ctx context.Context, sb *agent.Sandbox, root models.PreviewCacheRoot, reader io.Reader, stderr io.Writer) (int, error) {
 	executor, ok := c.executor.(dependencyCacheStdinExecutor)
 	if !ok {
 		return -1, fmt.Errorf("executor does not support streaming dependency cache restore")
@@ -864,7 +874,11 @@ func (c *SharedDependencyCache) extractSandboxArchive(ctx context.Context, sb *a
 		return -1, err
 	}
 	cmd := fmt.Sprintf("tar xzf - -C %s", shellQuote(rootDir))
-	return executor.ExecWithStdin(ctx, sb, cmd, reader, io.Discard, io.Discard)
+	// Capture tar's stderr (the caller passes a buffer) so a genuine extract
+	// failure — "Cannot write: No space left on device", a gzip CRC error, an
+	// OOM kill — is diagnosable. Previously this discarded stderr and the failure
+	// surfaced only as the writer-side "broken pipe", hiding the real cause.
+	return executor.ExecWithStdin(ctx, sb, cmd, reader, io.Discard, stderr)
 }
 
 func (c *SharedDependencyCache) writeLocalBlobFromFile(ctx context.Context, hit *DependencyCacheHit, sourcePath string, sizeBytes int64, checksum string) {


### PR DESCRIPTION
## Summary

Assembled previews were OOMing on cold builds, but the *cache* layer that's supposed to skip those builds was also failing — and its failures were undiagnosable. Build/dependency cache restores surfaced only a misleading `sendfile: broken pipe`, hiding whether the real cause was a corrupt blob, no disk space, or an OOM kill. This makes those restore failures legible and adds a retry, so a transient kill degrades to a cold launch instead of an opaque hard error.

The streaming restore execs `tar xzf -` in the sandbox via `ExecWithStdin`. It discarded tar's stderr, and a stdin `EPIPE` — which just means tar exited early — was returned as `-1, "write exec stdin"` *before* the exec's real exit code was inspected. So tar's actual exit (2 = corrupt, 137 = OOM) and its stderr were both thrown away.

## Changes

- **`ExecWithStdin`**: on a stdin-write EPIPE, inspect the exec and let a non-zero exit code take precedence over the writer-side pipe error; only surface the write error when the process exited cleanly (a genuine streaming failure).
- **`extractSandboxArchive`**: capture tar's stderr (mirroring the existing save path) so the fatal line reaches the error/log instead of `io.Discard`.
- **Restore extract** is now wrapped in `execWithTransientRetry`, matching the cleanup and save paths, so a momentary signal-kill rides out one retry before degrading to cold.

## Validation

- `go test ./internal/services/preview/ ./internal/services/agent/providers/` — pass
- `make lint` — 0 issues
- New `TestDockerProvider_ExecWithStdin_StdinWriteError` covers both the exit-code-precedence (broken pipe + exit 2 → returns 2 with stderr) and clean-exit-write-error cases.

## Context

This is the platform half of a preview-reliability investigation. Assembled previews aren't broken (151 reached ready in the last 7 days), but a vicious cycle drives the visible failures: the cold frontend build peaks above the 8 GiB ceiling → OOM-kills the container → the "warm even on failure" build-cache flush then can't `tar` artifacts out of the dead container (23 of 24 build-OOM previews also logged a cache-save failure) → the cache stays empty → every launch is cold → OOMs again. These changes don't stop the OOM (that needs a frontend build-memory fix on the `assembledhq/assembled` side), but they make the next cache failure diagnosable instead of a `broken pipe` mystery, and add the missing retry symmetry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)