### PR TITLE
Split attention previews and ignore stale startup retries

### DIFF
--- a/frontend/src/app/(dashboard)/previews/page.test.tsx
+++ b/frontend/src/app/(dashboard)/previews/page.test.tsx
@@ -132,7 +132,7 @@ describe("PreviewsPage", () => {
     currentUserRole.value = "member";
   });
 
-  it("renders running, resumable, and recent sections with counts and pool usage", async () => {
+  it("renders running, attention, resumable, and recent sections with counts and pool usage", async () => {
     installPreviewHandlers({
       running: [
         preview({
@@ -166,15 +166,26 @@ describe("PreviewsPage", () => {
           preview_url: undefined,
         }),
       ],
+      attention: [
+        preview({
+          preview_group_id: "attention-group",
+          current_target_id: "attention-target",
+          current_preview_id: "attention-preview",
+          branch: "fix/startup-error",
+          status: "failed",
+          stopped_reason: "error",
+          error: "install failed",
+          preview_url: undefined,
+        }),
+      ],
       recent: [
         preview({
           preview_group_id: "recent-group",
           current_target_id: "recent-target",
           current_preview_id: "recent-preview",
-          branch: "fix/startup-error",
-          status: "failed",
-          stopped_reason: "error",
-          error: "install failed",
+          branch: "feature/stopped-cleanly",
+          status: "stopped",
+          stopped_reason: "warm_policy",
           preview_url: undefined,
         }),
       ],
@@ -190,14 +201,14 @@ describe("PreviewsPage", () => {
       screen.getByRole("heading", { level: 2, name: "Running (1)" }),
     ).toBeInTheDocument();
     expect(
+      screen.getByRole("heading", { level: 2, name: "Needs attention (1)" }),
+    ).toBeInTheDocument();
+    expect(
       screen.getByRole("heading", { level: 2, name: "Ready to resume (1)" }),
     ).toBeInTheDocument();
     expect(
       screen.getByRole("heading", { level: 2, name: "Recent (1)" }),
     ).toBeInTheDocument();
-    expect(
-      screen.queryByRole("region", { name: /needs attention/i }),
-    ).not.toBeInTheDocument();
     expect(screen.getByText("Pool: 3 of 10 previews")).toBeInTheDocument();
     expect(screen.getAllByText("PR #17 - feature/warm-link")[0]).toBeInTheDocument();
     expect(screen.getAllByText("Ready")[0]).toBeInTheDocument();
@@ -205,6 +216,7 @@ describe("PreviewsPage", () => {
     expect(screen.getAllByText("Failed")[0]).toBeInTheDocument();
     expect(screen.getByText("Resumes in ~30s")).toBeInTheDocument();
     expect(screen.getByText("Stopped after error")).toBeInTheDocument();
+    expect(screen.getByText("Hibernated by policy")).toBeInTheDocument();
     expect(screen.getAllByText("PR #17")[0]).toBeInTheDocument();
   });
 
@@ -413,7 +425,7 @@ describe("PreviewsPage", () => {
     renderWithProviders(<PreviewsPage />);
 
     expect(await screen.findAllByText("Failed to load previews.")).toHaveLength(
-      3,
+      4,
     );
     expect(screen.queryByText("No previews yet")).not.toBeInTheDocument();
     expect(screen.queryByText("Loading previews...")).not.toBeInTheDocument();
@@ -493,9 +505,6 @@ describe("PreviewsPage", () => {
     const runningSection = await screen.findByRole("region", {
       name: /running/i,
     });
-    expect(
-      screen.queryByRole("region", { name: /needs attention/i }),
-    ).not.toBeInTheDocument();
     expect(within(runningSection).getAllByText("Out of date")[0]).toBeInTheDocument();
     expect(
       within(runningSection).getAllByText(/Running aabb1122, branch is ccdd3344/)[0],
@@ -532,15 +541,15 @@ describe("PreviewsPage", () => {
     }
   });
 
-  it("shows a spinner on the start-latest button in the recent section while request is in flight", async () => {
+  it("shows a spinner on the start-latest button in the attention section while request is in flight", async () => {
     const restartReleased = deferred<void>();
     const mutationPaths: string[] = [];
     installPreviewHandlers({
       running: [],
       resumable: [],
-      recent: [
+      attention: [
         preview({
-          preview_group_id: "recent-group",
+          preview_group_id: "attention-group",
           branch: "fix/startup-error",
           status: "failed",
           stopped_reason: "error",
@@ -558,10 +567,10 @@ describe("PreviewsPage", () => {
 
     renderWithProviders(<PreviewsPage />);
 
-    const recentSection = await screen.findByRole("region", {
-      name: /recent/i,
+    const attentionSection = await screen.findByRole("region", {
+      name: /needs attention/i,
     });
-    const restartButton = within(recentSection).getAllByRole("button", {
+    const restartButton = within(attentionSection).getAllByRole("button", {
       name: /start a new preview from the latest source state/i,
     })[0];
 
@@ -569,7 +578,7 @@ describe("PreviewsPage", () => {
 
     await waitFor(() => {
       expect(mutationPaths).toEqual([
-        "/api/v1/previews/current/recent-group/start-latest",
+        "/api/v1/previews/current/attention-group/start-latest",
       ]);
     });
     expect(restartButton).toHaveAttribute("data-loading", "true");
@@ -731,7 +740,7 @@ describe("PreviewsPage", () => {
     ).toBeInTheDocument();
   });
 
-  it("promotes attention previews inside Recent ahead of ordinary recent activity", async () => {
+  it("shows attention previews separately from ordinary recent activity", async () => {
     installPreviewHandlers({
       attention: [
         preview({
@@ -759,15 +768,17 @@ describe("PreviewsPage", () => {
     const recentSection = await screen.findByRole("region", {
       name: /recent/i,
     });
-    expect(
-      screen.queryByRole("region", { name: /needs attention/i }),
-    ).not.toBeInTheDocument();
-    expect(within(recentSection).getAllByText("Failed")[0]).toBeInTheDocument();
+    const attentionSection = await screen.findByRole("region", {
+      name: /needs attention/i,
+    });
+    expect(within(attentionSection).getAllByText("Failed")[0]).toBeInTheDocument();
     expect(within(recentSection).getAllByText("Stopped")[0]).toBeInTheDocument();
+    expect(within(recentSection).queryByText("feature/failed")).not.toBeInTheDocument();
 
-    const rows = within(recentSection).getAllByRole("row");
-    expect(rows[1]).toHaveTextContent("feature/failed");
-    expect(rows[2]).toHaveTextContent("feature/stopped");
+    const attentionRows = within(attentionSection).getAllByRole("row");
+    const recentRows = within(recentSection).getAllByRole("row");
+    expect(attentionRows[1]).toHaveTextContent("feature/failed");
+    expect(recentRows[1]).toHaveTextContent("feature/stopped");
   });
 
   it("keeps mobile stacked row metadata available alongside the desktop table", async () => {

--- a/frontend/src/app/(dashboard)/previews/page.tsx
+++ b/frontend/src/app/(dashboard)/previews/page.tsx
@@ -5,6 +5,7 @@ import { useMemo, useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { parseAsString, useQueryState } from "nuqs";
 import {
+  AlertTriangle,
   ExternalLink,
   GitBranch,
   Loader2,
@@ -54,7 +55,7 @@ import type {
 } from "@/lib/types";
 import { safeExternalUrl } from "@/lib/utils";
 
-type PreviewScope = "running" | "resumable" | "recent";
+type PreviewScope = "running" | "attention" | "resumable" | "recent";
 
 const RESTART_LATEST_LABEL = "Start latest";
 const RESTART_LATEST_TOOLTIP = "Start a new preview from the latest source state";
@@ -70,6 +71,12 @@ const SECTIONS: {
     title: "Running",
     empty: "No previews are running.",
     interval: 5000,
+  },
+  {
+    scope: "attention",
+    title: "Needs attention",
+    empty: "No previews need attention.",
+    interval: 30000,
   },
   {
     scope: "resumable",
@@ -111,16 +118,6 @@ function previewNeedsAttention(preview: PreviewCurrentResponse): boolean {
   );
 }
 
-function previewIsRunning(preview: PreviewCurrentResponse): boolean {
-  return (
-    preview.status === "starting" ||
-    preview.status === "ready" ||
-    preview.status === "partially_ready" ||
-    preview.status === "unhealthy" ||
-    preview.status === "recycling"
-  );
-}
-
 function sortAttentionFirst(
   previews: PreviewCurrentResponse[],
 ): PreviewCurrentResponse[] {
@@ -132,20 +129,6 @@ function sortAttentionFirst(
     if (a.status !== "failed" && b.status === "failed") return 1;
     return 0;
   });
-}
-
-function mergePreviewRows(
-  primary: PreviewCurrentResponse[],
-  additions: PreviewCurrentResponse[],
-): PreviewCurrentResponse[] {
-  const seen = new Set(primary.map((preview) => preview.preview_group_id));
-  const merged = [...primary];
-  for (const preview of additions) {
-    if (seen.has(preview.preview_group_id)) continue;
-    seen.add(preview.preview_group_id);
-    merged.push(preview);
-  }
-  return merged;
 }
 
 function stoppedReasonLabel(
@@ -199,7 +182,9 @@ function statusDetail(preview: PreviewCurrentResponse, scope: PreviewScope): str
   if (scope === "resumable" && preview.resume_estimate_seconds) {
     return capitalizeStatusDetail(`resumes in ~${preview.resume_estimate_seconds}s`);
   }
-  if (scope === "recent") return capitalizeStatusDetail(stoppedReasonLabel(preview.stopped_reason));
+  if (scope === "recent" || scope === "attention") {
+    return capitalizeStatusDetail(stoppedReasonLabel(preview.stopped_reason));
+  }
   if (preview.expires_at) return capitalizeStatusDetail(`expires ${expiresIn(preview.expires_at)}`);
   return preview.current_phase ? formatPreviewStatus(preview.current_phase) : "";
 }
@@ -634,8 +619,8 @@ export default function PreviewsPage() {
     refetchInterval: pollMs(30000),
     placeholderData: (previous) => previous,
   });
-  const allSectionQueries = [runningQuery, resumableQuery, attentionQuery, recentQuery];
-  const visibleSectionQueries = [runningQuery, resumableQuery, recentQuery];
+  const allSectionQueries = [runningQuery, attentionQuery, resumableQuery, recentQuery];
+  const visibleSectionQueries = [runningQuery, attentionQuery, resumableQuery, recentQuery];
 
   const firstMeta = allSectionQueries.find((item) => item.data?.meta)?.data?.meta;
   // A query that has only ever errored holds no data, and React Query resets
@@ -662,45 +647,33 @@ export default function PreviewsPage() {
   );
 
   const attentionPreviews = useMemo(
-    () => attentionQuery.data?.data ?? [],
+    () => sortAttentionFirst(attentionQuery.data?.data ?? []),
     [attentionQuery.data?.data],
   );
+  const attentionPreviewIds = useMemo(
+    () => new Set(attentionPreviews.map((preview) => preview.preview_group_id)),
+    [attentionPreviews],
+  );
   const runningPreviews = useMemo(
-    () =>
-      sortAttentionFirst(
-        mergePreviewRows(
-          runningQuery.data?.data ?? [],
-          attentionPreviews.filter(previewIsRunning),
-        ),
-      ),
-    [attentionPreviews, runningQuery.data?.data],
+    () => sortAttentionFirst(runningQuery.data?.data ?? []),
+    [runningQuery.data?.data],
   );
   const resumablePreviews = useMemo(
-    () =>
-      sortAttentionFirst(
-        mergePreviewRows(
-          resumableQuery.data?.data ?? [],
-          attentionPreviews.filter(
-            (preview) => preview.resumable && !previewIsRunning(preview),
-          ),
-        ),
-      ),
-    [attentionPreviews, resumableQuery.data?.data],
+    () => sortAttentionFirst(resumableQuery.data?.data ?? []),
+    [resumableQuery.data?.data],
   );
   const recentPreviews = useMemo(
     () =>
-      sortAttentionFirst(
-        mergePreviewRows(
-          recentQuery.data?.data ?? [],
-          attentionPreviews.filter(
-            (preview) => !previewIsRunning(preview) && !preview.resumable,
-          ),
-        ),
+      (recentQuery.data?.data ?? []).filter(
+        (preview) =>
+          !previewNeedsAttention(preview) &&
+          !attentionPreviewIds.has(preview.preview_group_id),
       ),
-    [attentionPreviews, recentQuery.data?.data],
+    [attentionPreviewIds, recentQuery.data?.data],
   );
   const previewsByScope: Record<PreviewScope, PreviewCurrentResponse[]> = {
     running: runningPreviews,
+    attention: attentionPreviews,
     resumable: resumablePreviews,
     recent: recentPreviews,
   };
@@ -819,6 +792,8 @@ export default function PreviewsPage() {
                     <div className="flex items-center gap-2">
                       {section.scope === "running" ? (
                         <MonitorPlay className="h-4 w-4 text-muted-foreground" />
+                      ) : section.scope === "attention" ? (
+                        <AlertTriangle className="h-4 w-4 text-muted-foreground" />
                       ) : section.scope === "resumable" ? (
                         <Play className="h-4 w-4 text-muted-foreground" />
                       ) : (

--- a/internal/db/preview_store.go
+++ b/internal/db/preview_store.go
@@ -25,6 +25,11 @@ import (
 // run but the repository has no successful preview recorded yet.
 var ErrPreviewNotReady = errors.New("repository preview is not ready")
 
+// ErrPreviewReservationNotStarting is returned when a retry-only startup reset
+// cannot claim the reservation because another lifecycle transition already
+// moved it out of the starting state.
+var ErrPreviewReservationNotStarting = errors.New("branch preview reservation not found or no longer starting")
+
 // PreviewStore manages preview_instances and related tables.
 // It uses TxStarter because stop operations need transactional consistency
 // (stop preview + revoke all access sessions atomically).
@@ -1278,7 +1283,7 @@ func (s *PreviewStore) ResetStartingBranchPreviewForRetry(ctx context.Context, o
 		return fmt.Errorf("reset branch preview reservation: %w", err)
 	}
 	if tag.RowsAffected() == 0 {
-		return fmt.Errorf("branch preview reservation not found or no longer starting")
+		return ErrPreviewReservationNotStarting
 	}
 
 	if _, err := tx.Exec(ctx,

--- a/internal/services/preview/start_runner.go
+++ b/internal/services/preview/start_runner.go
@@ -1325,7 +1325,7 @@ func (r *StartRunner) retryBranchPreviewStartupInterruption(ctx context.Context,
 				Str("preview_id", payload.PreviewID.String()).
 				Str("preview_target_id", payload.PreviewTargetID.String()).
 				Msg("branch preview startup interruption reset skipped; reservation already transitioned")
-			return fmt.Errorf("reset branch preview after startup interruption: %w", err)
+			return nil
 		}
 		r.abort(ctx, reservation, sandboxID(sb), fmt.Sprintf("reset preview startup after interruption: %v", err))
 		return fmt.Errorf("reset branch preview after startup interruption: %w", err)

--- a/internal/services/preview/start_runner.go
+++ b/internal/services/preview/start_runner.go
@@ -1318,6 +1318,15 @@ func (r *StartRunner) retryBranchPreviewStartupInterruption(ctx context.Context,
 		"stage": phase,
 	})
 	if err := r.previews.ResetStartingBranchPreviewForRetry(ctx, payload.OrgID, payload.PreviewID, reason, models.PreviewUnavailableReasonOwnerLost); err != nil {
+		if errors.Is(err, db.ErrPreviewReservationNotStarting) {
+			r.destroyBranchPreviewSandboxAfterInterruption(ctx, payload.PreviewID, sb)
+			r.logger.Warn().
+				Err(err).
+				Str("preview_id", payload.PreviewID.String()).
+				Str("preview_target_id", payload.PreviewTargetID.String()).
+				Msg("branch preview startup interruption reset skipped; reservation already transitioned")
+			return fmt.Errorf("reset branch preview after startup interruption: %w", err)
+		}
 		r.abort(ctx, reservation, sandboxID(sb), fmt.Sprintf("reset preview startup after interruption: %v", err))
 		return fmt.Errorf("reset branch preview after startup interruption: %w", err)
 	}

--- a/internal/services/preview/start_runner_test.go
+++ b/internal/services/preview/start_runner_test.go
@@ -254,7 +254,7 @@ func TestStartRunnerRetryBranchPreviewStartupInterruptionDoesNotFailTransitioned
 
 	err = runner.retryBranchPreviewStartupInterruption(ctx, payload, reservation, sb, "launch_preview", errors.New("Error response from daemon: No such container: sandbox-1"))
 
-	require.ErrorIs(t, err, db.ErrPreviewReservationNotStarting, "stale branch preview startup reset should return the reservation-state sentinel")
+	require.NoError(t, err, "stale branch preview startup reset should complete without dead-lettering the job")
 	require.Equal(t, []string{"sandbox-1"}, provider.destroyed, "stale branch preview startup should still destroy the transient sandbox")
 	jobctx.RunDeadLetterHooks(ctx, err)
 	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")

--- a/internal/services/preview/start_runner_test.go
+++ b/internal/services/preview/start_runner_test.go
@@ -217,6 +217,49 @@ func TestStartRunnerRetryBranchPreviewStartupInterruptionResetsAndDestroysSandbo
 	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
 }
 
+func TestStartRunnerRetryBranchPreviewStartupInterruptionDoesNotFailTransitionedReservation(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "pgx mock should initialize")
+	defer mock.Close()
+
+	orgID := uuid.New()
+	previewID := uuid.New()
+	targetID := uuid.New()
+	now := time.Now()
+	provider := &destroyRecordingSandboxProvider{}
+	mock.ExpectQuery("INSERT INTO preview_logs").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(pgxmock.NewRows([]string{
+			"id", "preview_instance_id", "org_id", "level", "step", "message", "metadata", "created_at",
+		}).AddRow(uuid.New(), previewID, orgID, "warn", "start", "interrupted", json.RawMessage(`{}`), now))
+	mock.ExpectBegin()
+	mock.ExpectExec("UPDATE preview_instances").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnResult(pgxmock.NewResult("UPDATE", 0))
+	mock.ExpectRollback()
+
+	store := db.NewPreviewStore(mock)
+	runner := &StartRunner{
+		manager:         &Manager{store: store, logger: zerolog.Nop()},
+		previews:        store,
+		sandboxProvider: provider,
+		logger:          zerolog.Nop(),
+	}
+	reservation := &models.PreviewInstance{ID: previewID, OrgID: orgID, PreviewTargetID: &targetID, Status: models.PreviewStatusStarting}
+	payload := StartBranchPreviewJobPayload{OrgID: orgID, PreviewID: previewID, PreviewTargetID: targetID}
+	sb := &agent.Sandbox{ID: "sandbox-1", Provider: ProviderDocker}
+	ctx := jobctx.WithDeadLetterHooks(context.Background())
+
+	err = runner.retryBranchPreviewStartupInterruption(ctx, payload, reservation, sb, "launch_preview", errors.New("Error response from daemon: No such container: sandbox-1"))
+
+	require.ErrorIs(t, err, db.ErrPreviewReservationNotStarting, "stale branch preview startup reset should return the reservation-state sentinel")
+	require.Equal(t, []string{"sandbox-1"}, provider.destroyed, "stale branch preview startup should still destroy the transient sandbox")
+	jobctx.RunDeadLetterHooks(ctx, err)
+	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
+}
+
 func TestStartRunnerEnsureReservationRuntimeForClaimingWorkerCreatesRuntimeForSameWorkerRetry(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- Split previews needing attention into their own dashboard section instead of merging them into recent activity.
- Treat stale branch preview startup retries as a non-fatal no-op once the reservation has already transitioned.
- Add coverage for the new preview grouping and the transitioned-reservation retry path.

## Testing
- Added/updated unit tests for the previews page and preview startup retry flow.
- Not run (not requested).