### PR TITLE
Include empty reviewers when removing team-only review requests

### DIFF
--- a/internal/services/codereview/github_submitter.go
+++ b/internal/services/codereview/github_submitter.go
@@ -664,9 +664,8 @@ func (s *GitHubSubmitter) RemoveRequestedReviewers(ctx context.Context, req Requ
 	if err != nil {
 		return fmt.Errorf("get installation token: %w", err)
 	}
-	payload := map[string]any{}
-	if len(reviewers) > 0 {
-		payload["reviewers"] = reviewers
+	payload := map[string]any{
+		"reviewers": reviewers,
 	}
 	if len(teams) > 0 {
 		payload["team_reviewers"] = teams

--- a/internal/services/codereview/github_submitter_test.go
+++ b/internal/services/codereview/github_submitter_test.go
@@ -455,6 +455,32 @@ func TestGitHubSubmitter_RemoveRequestedReviewers(t *testing.T) {
 	require.Equal(t, []any{"ai-reviewers"}, gotPayload["team_reviewers"], "RemoveRequestedReviewers should include team reviewers")
 }
 
+func TestGitHubSubmitter_RemoveRequestedReviewersIncludesEmptyReviewersForTeamOnlyRemoval(t *testing.T) {
+	t.Parallel()
+
+	var gotPayload map[string]any
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&gotPayload), "request body should decode")
+		w.Header().Set("Content-Type", "application/json")
+		_, err := w.Write([]byte(`{}`))
+		require.NoError(t, err, "test response should write")
+	}))
+	defer server.Close()
+
+	submitter := NewGitHubSubmitter(&tokenStub{token: "ghs_token"}, WithGitHubSubmitterBaseURL(server.URL))
+
+	err := submitter.RemoveRequestedReviewers(context.Background(), RequestedReviewersRequest{
+		InstallationID: 99,
+		Repository:     "acme/repo",
+		PullNumber:     42,
+		TeamReviewers:  []string{"ai-reviewers"},
+	})
+
+	require.NoError(t, err, "RemoveRequestedReviewers should remove a team-only review request")
+	require.Equal(t, []any{}, gotPayload["reviewers"], "RemoveRequestedReviewers should include the required empty reviewers array")
+	require.Equal(t, []any{"ai-reviewers"}, gotPayload["team_reviewers"], "RemoveRequestedReviewers should include team reviewers")
+}
+
 func TestGitHubSubmitter_SubmitReviewRejectsInvalidInput(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- Always send the `reviewers` field when removing requested reviewers, even if it is empty
- Preserve `team_reviewers` so team-only removals match GitHub's expected payload shape
- Add a unit test covering team-only reviewer removal

## Testing
- Unit tests added for `GitHubSubmitter.RemoveRequestedReviewers`