### PR TITLE
Add GPT-5.6 models and preserve code review policy inputs

### DIFF
--- a/frontend/src/lib/agents.test.ts
+++ b/frontend/src/lib/agents.test.ts
@@ -190,6 +190,8 @@ describe("agentTypeForModel", () => {
     expect(agentTypeForModel("kimi-k2.6")).toBe("opencode");
     expect(agentTypeForModel("openrouter/~z-ai/glm-5.2")).toBe("opencode");
     // Bare names owned by a first-party agent keep that owner.
+    expect(agentTypeForModel("gpt-5.6-sol")).toBe("codex");
+    expect(agentTypeForModel("gpt-5.6-luna-fast")).toBe("codex");
     expect(agentTypeForModel("gpt-5.5")).toBe("codex");
     expect(agentTypeForModel("claude-fable-5")).toBe("claude_code");
   });

--- a/frontend/src/lib/model-constants.test.ts
+++ b/frontend/src/lib/model-constants.test.ts
@@ -118,6 +118,12 @@ describe("model constants", () => {
 
   it("includes latest Codex models", () => {
     expect(AVAILABLE_CODEX_MODELS).toEqual([
+      "gpt-5.6-sol",
+      "gpt-5.6-sol-fast",
+      "gpt-5.6-terra",
+      "gpt-5.6-terra-fast",
+      "gpt-5.6-luna",
+      "gpt-5.6-luna-fast",
       "gpt-5.5",
       "gpt-5.5-fast",
       "gpt-5.4",

--- a/frontend/src/lib/model-constants.ts
+++ b/frontend/src/lib/model-constants.ts
@@ -18,6 +18,12 @@ export const AVAILABLE_CLAUDE_CODE_MODELS = [
 
 export const DEFAULT_CLAUDE_CODE_MODEL = CLAUDE_CODE_MODEL_OPUS_48;
 
+export const CODEX_MODEL_GPT_5_6_SOL = "gpt-5.6-sol";
+export const CODEX_MODEL_GPT_5_6_SOL_FAST = "gpt-5.6-sol-fast";
+export const CODEX_MODEL_GPT_5_6_TERRA = "gpt-5.6-terra";
+export const CODEX_MODEL_GPT_5_6_TERRA_FAST = "gpt-5.6-terra-fast";
+export const CODEX_MODEL_GPT_5_6_LUNA = "gpt-5.6-luna";
+export const CODEX_MODEL_GPT_5_6_LUNA_FAST = "gpt-5.6-luna-fast";
 export const CODEX_MODEL_GPT_5_5 = "gpt-5.5";
 export const CODEX_MODEL_GPT_5_5_FAST = "gpt-5.5-fast";
 export const CODEX_MODEL_GPT_5_4 = "gpt-5.4";
@@ -29,6 +35,12 @@ export const CODEX_MODEL_GPT_5_CODEX = "gpt-5-codex";
 export const CODEX_MODEL_GPT_5_3_CODEX_SPARK = "gpt-5.3-codex-spark";
 
 export const AVAILABLE_CODEX_MODELS = [
+  CODEX_MODEL_GPT_5_6_SOL,
+  CODEX_MODEL_GPT_5_6_SOL_FAST,
+  CODEX_MODEL_GPT_5_6_TERRA,
+  CODEX_MODEL_GPT_5_6_TERRA_FAST,
+  CODEX_MODEL_GPT_5_6_LUNA,
+  CODEX_MODEL_GPT_5_6_LUNA_FAST,
   CODEX_MODEL_GPT_5_5,
   CODEX_MODEL_GPT_5_5_FAST,
   CODEX_MODEL_GPT_5_4,

--- a/internal/models/agent_model_constants.go
+++ b/internal/models/agent_model_constants.go
@@ -69,6 +69,12 @@ const DefaultClaudeCodeModel = ClaudeCodeModelOpus48
 var AvailableClaudeCodeModels = []string{ClaudeCodeModelFable5, ClaudeCodeModelOpus48, ClaudeCodeModelOpus47, ClaudeCodeModelOpus46, ClaudeCodeModelSonnet46, ClaudeCodeModelSonnet45, ClaudeCodeModelHaiku45}
 
 const (
+	CodexModelGPT56Sol        = "gpt-5.6-sol"
+	CodexModelGPT56SolFast    = "gpt-5.6-sol-fast"
+	CodexModelGPT56Terra      = "gpt-5.6-terra"
+	CodexModelGPT56TerraFast  = "gpt-5.6-terra-fast"
+	CodexModelGPT56Luna       = "gpt-5.6-luna"
+	CodexModelGPT56LunaFast   = "gpt-5.6-luna-fast"
 	CodexModelGPT55           = "gpt-5.5"
 	CodexModelGPT55Fast       = "gpt-5.5-fast"
 	CodexModelGPT54           = "gpt-5.4"
@@ -83,6 +89,12 @@ const (
 const DefaultCodexModel = CodexModelGPT55
 
 var AvailableCodexModels = []string{
+	CodexModelGPT56Sol,
+	CodexModelGPT56SolFast,
+	CodexModelGPT56Terra,
+	CodexModelGPT56TerraFast,
+	CodexModelGPT56Luna,
+	CodexModelGPT56LunaFast,
 	CodexModelGPT55,
 	CodexModelGPT55Fast,
 	CodexModelGPT54,
@@ -182,6 +194,12 @@ type CodexRuntimeSpec struct {
 // model ID Codex CLI accepts plus a priority-service-tier flag.
 func CodexRuntimeModel(model string) CodexRuntimeSpec {
 	switch model {
+	case CodexModelGPT56SolFast:
+		return CodexRuntimeSpec{Model: CodexModelGPT56Sol, PriorityTier: true}
+	case CodexModelGPT56TerraFast:
+		return CodexRuntimeSpec{Model: CodexModelGPT56Terra, PriorityTier: true}
+	case CodexModelGPT56LunaFast:
+		return CodexRuntimeSpec{Model: CodexModelGPT56Luna, PriorityTier: true}
 	case CodexModelGPT55Fast:
 		return CodexRuntimeSpec{Model: CodexModelGPT55, PriorityTier: true}
 	case CodexModelGPT54Fast:

--- a/internal/models/agent_model_constants_test.go
+++ b/internal/models/agent_model_constants_test.go
@@ -38,7 +38,23 @@ func TestCodexModelConstants(t *testing.T) {
 
 	require.Equal(t, CodexModelGPT55, DefaultCodexModel, "DefaultCodexModel should use GPT 5.5")
 	require.Equal(t,
-		[]string{CodexModelGPT55, CodexModelGPT55Fast, CodexModelGPT54, CodexModelGPT54Fast, CodexModelGPT54Mini, CodexModelGPT53Codex, CodexModelGPT52Codex, CodexModelGPT5Codex, CodexModelGPT53CodexSpark},
+		[]string{
+			CodexModelGPT56Sol,
+			CodexModelGPT56SolFast,
+			CodexModelGPT56Terra,
+			CodexModelGPT56TerraFast,
+			CodexModelGPT56Luna,
+			CodexModelGPT56LunaFast,
+			CodexModelGPT55,
+			CodexModelGPT55Fast,
+			CodexModelGPT54,
+			CodexModelGPT54Fast,
+			CodexModelGPT54Mini,
+			CodexModelGPT53Codex,
+			CodexModelGPT52Codex,
+			CodexModelGPT5Codex,
+			CodexModelGPT53CodexSpark,
+		},
 		AvailableCodexModels,
 		"AvailableCodexModels should include the latest Codex model family and fast tiers",
 	)
@@ -130,8 +146,12 @@ func TestCodexRuntimeModel(t *testing.T) {
 		expected     string
 		priorityTier bool
 	}{
+		{name: "gpt 5.6 sol fast maps to gpt 5.6 sol priority", model: CodexModelGPT56SolFast, expected: CodexModelGPT56Sol, priorityTier: true},
+		{name: "gpt 5.6 terra fast maps to gpt 5.6 terra priority", model: CodexModelGPT56TerraFast, expected: CodexModelGPT56Terra, priorityTier: true},
+		{name: "gpt 5.6 luna fast maps to gpt 5.6 luna priority", model: CodexModelGPT56LunaFast, expected: CodexModelGPT56Luna, priorityTier: true},
 		{name: "gpt 5.5 fast maps to gpt 5.5 priority", model: CodexModelGPT55Fast, expected: CodexModelGPT55, priorityTier: true},
 		{name: "gpt 5.4 fast maps to gpt 5.4 priority", model: CodexModelGPT54Fast, expected: CodexModelGPT54, priorityTier: true},
+		{name: "regular gpt 5.6 sol stays unchanged", model: CodexModelGPT56Sol, expected: CodexModelGPT56Sol},
 		{name: "regular gpt 5.5 stays unchanged", model: CodexModelGPT55, expected: CodexModelGPT55},
 		{name: "unknown model stays unchanged", model: "custom-model", expected: "custom-model"},
 	}
@@ -281,6 +301,8 @@ func TestAgentTypeForModel(t *testing.T) {
 		want  AgentType
 	}{
 		{"", ""},
+		{CodexModelGPT56Sol, AgentTypeCodex},
+		{CodexModelGPT56LunaFast, AgentTypeCodex},
 		{CodexModelGPT54, AgentTypeCodex},
 		{ClaudeCodeModelOpus48, AgentTypeClaudeCode},
 		{AmpModeSmart, AgentTypeAmp},

--- a/internal/models/code_review.go
+++ b/internal/models/code_review.go
@@ -519,6 +519,9 @@ func ResolveCodeReviewPolicyConfig(config *CodeReviewPolicyConfig) CodeReviewPol
 }
 
 func normalizeCodeReviewDescriptionPolicy(policy CodeReviewDescriptionPolicy) CodeReviewDescriptionPolicy {
+	// Policy configs are frequently copied by value, so clone the slice before
+	// normalizing its elements to avoid mutating a caller's shared backing array.
+	policy.Requirements = append([]CodeReviewDescriptionRequirement(nil), policy.Requirements...)
 	for i := range policy.Requirements {
 		if !policy.Requirements[i].AppliesWhen.Empty() {
 			continue

--- a/internal/models/code_review_test.go
+++ b/internal/models/code_review_test.go
@@ -64,6 +64,20 @@ func TestDefaultCodeReviewPolicyConfig(t *testing.T) {
 	require.NoError(t, config.Validate(), "default code review policy should be valid")
 }
 
+func TestResolveCodeReviewPolicyConfigDoesNotMutateInput(t *testing.T) {
+	t.Parallel()
+
+	config := DefaultCodeReviewPolicyConfig()
+	config.DescriptionPolicy.Requirements[1].AppliesWhen = CodeReviewDescriptionApplicability{}
+
+	resolved := ResolveCodeReviewPolicyConfig(&config)
+
+	require.True(t, config.DescriptionPolicy.Requirements[1].AppliesWhen.Empty(), "resolving legacy applicability should leave the input policy unchanged")
+	require.Equal(t, CodeReviewDescriptionApplicabilityNontrivial, resolved.DescriptionPolicy.Requirements[1].AppliesWhen.Kind, "resolving legacy applicability should populate the typed rule")
+	resolved.DescriptionPolicy.Requirements[1].Title = "changed"
+	require.Equal(t, "Testing evidence", config.DescriptionPolicy.Requirements[1].Title, "the resolved requirements should not share mutable slice storage with the input policy")
+}
+
 func TestCodeReviewPolicyConfigValidate(t *testing.T) {
 	t.Parallel()
 

--- a/internal/services/agent/adapters/codex_test.go
+++ b/internal/services/agent/adapters/codex_test.go
@@ -112,6 +112,21 @@ func TestCodexModelArgs(t *testing.T) {
 		expected       string
 	}{
 		{
+			name:     "adds priority service tier for gpt 5.6 sol fast",
+			env:      map[string]string{"OPENAI_MODEL": models.CodexModelGPT56SolFast},
+			expected: ` -m 'gpt-5.6-sol' -c 'service_tier="priority"'`,
+		},
+		{
+			name:     "adds priority service tier for gpt 5.6 terra fast",
+			env:      map[string]string{"OPENAI_MODEL": models.CodexModelGPT56TerraFast},
+			expected: ` -m 'gpt-5.6-terra' -c 'service_tier="priority"'`,
+		},
+		{
+			name:     "adds priority service tier for gpt 5.6 luna fast",
+			env:      map[string]string{"OPENAI_MODEL": models.CodexModelGPT56LunaFast},
+			expected: ` -m 'gpt-5.6-luna' -c 'service_tier="priority"'`,
+		},
+		{
 			name:     "adds priority service tier for gpt 5.5 fast",
 			env:      map[string]string{"OPENAI_MODEL": models.CodexModelGPT55Fast},
 			expected: ` -m 'gpt-5.5' -c 'service_tier="priority"'`,

--- a/internal/services/agent/token_usage_cost.go
+++ b/internal/services/agent/token_usage_cost.go
@@ -16,6 +16,10 @@ type tokenRate struct {
 }
 
 var openAIAPIRates = map[string]tokenRate{
+	models.CodexModelGPT56Sol:   {inputPerMTok: 5.00, cachedInputPerMTok: 0.50, cacheCreationPerMTok: 6.25, outputPerMTok: 30.00, unit: TokenCostUnitUSD, detail: "openai_api_pricing"},
+	models.CodexModelGPT56Terra: {inputPerMTok: 2.50, cachedInputPerMTok: 0.25, cacheCreationPerMTok: 3.125, outputPerMTok: 15.00, unit: TokenCostUnitUSD, detail: "openai_api_pricing"},
+	models.CodexModelGPT56Luna:  {inputPerMTok: 1.00, cachedInputPerMTok: 0.10, cacheCreationPerMTok: 1.25, outputPerMTok: 6.00, unit: TokenCostUnitUSD, detail: "openai_api_pricing"},
+	// GPT-5.6 priority rates are not published, so fast aliases remain cost-unavailable.
 	models.CodexModelGPT55:      {inputPerMTok: 5.00, cachedInputPerMTok: 0.50, outputPerMTok: 30.00, unit: TokenCostUnitUSD, detail: "openai_api_pricing"},
 	models.CodexModelGPT55Fast:  {inputPerMTok: 12.50, cachedInputPerMTok: 1.25, outputPerMTok: 75.00, unit: TokenCostUnitUSD, detail: "openai_priority_pricing"},
 	models.CodexModelGPT54:      {inputPerMTok: 2.50, cachedInputPerMTok: 0.25, outputPerMTok: 15.00, unit: TokenCostUnitUSD, detail: "openai_api_pricing"},
@@ -28,6 +32,10 @@ var openAIAPIRates = map[string]tokenRate{
 }
 
 var codexCreditRates = map[string]tokenRate{
+	models.CodexModelGPT56Sol:   {inputPerMTok: 125.00, cachedInputPerMTok: 12.50, outputPerMTok: 750.00, unit: TokenCostUnitCredits, detail: "codex_rate_card"},
+	models.CodexModelGPT56Terra: {inputPerMTok: 62.50, cachedInputPerMTok: 6.250, outputPerMTok: 375.00, unit: TokenCostUnitCredits, detail: "codex_rate_card"},
+	models.CodexModelGPT56Luna:  {inputPerMTok: 25.00, cachedInputPerMTok: 2.50, outputPerMTok: 150.00, unit: TokenCostUnitCredits, detail: "codex_rate_card"},
+	// GPT-5.6 fast-mode credit rates are not published, so fast aliases remain cost-unavailable.
 	models.CodexModelGPT55:      {inputPerMTok: 125.00, cachedInputPerMTok: 12.50, outputPerMTok: 750.00, unit: TokenCostUnitCredits, detail: "codex_rate_card"},
 	models.CodexModelGPT55Fast:  {inputPerMTok: 312.50, cachedInputPerMTok: 31.25, outputPerMTok: 1875.00, unit: TokenCostUnitCredits, detail: "codex_priority_rate_card"},
 	models.CodexModelGPT54:      {inputPerMTok: 62.50, cachedInputPerMTok: 6.250, outputPerMTok: 375.00, unit: TokenCostUnitCredits, detail: "codex_rate_card"},

--- a/internal/services/agent/token_usage_cost_test.go
+++ b/internal/services/agent/token_usage_cost_test.go
@@ -312,6 +312,60 @@ func TestFinalizeTokenUsage_DerivesPublishedRateModels(t *testing.T) {
 	}
 }
 
+func TestFinalizeTokenUsage_DerivesGPT56PublishedRates(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name                  string
+		model                 string
+		expectedAPIAmount     float64
+		expectedCreditsAmount float64
+	}{
+		{name: "sol", model: models.CodexModelGPT56Sol, expectedAPIAmount: 41.75, expectedCreditsAmount: 887.5},
+		{name: "terra", model: models.CodexModelGPT56Terra, expectedAPIAmount: 20.875, expectedCreditsAmount: 443.75},
+		{name: "luna", model: models.CodexModelGPT56Luna, expectedAPIAmount: 8.35, expectedCreditsAmount: 177.5},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			usage := TokenUsage{
+				InputTokens:         1_000_000,
+				CachedInputTokens:   1_000_000,
+				CacheCreationTokens: 1_000_000,
+				OutputTokens:        1_000_000,
+			}
+			apiUsage := FinalizeTokenUsage(usage, TokenUsageHint{
+				AgentType:      models.AgentTypeCodex,
+				EffectiveModel: tt.model,
+				BillingMode:    TokenBillingModeAPIKey,
+			})
+
+			require.NotNil(t, apiUsage.Cost, "GPT-5.6 API-key usage should derive a published USD cost")
+			require.Equal(t, TokenCostUnitUSD, apiUsage.Cost.Unit, "GPT-5.6 API-key cost should use USD")
+			require.Equal(t, TokenCostSourceDerived, apiUsage.Cost.Source, "GPT-5.6 API-key cost should be marked derived")
+			require.InDelta(t, tt.expectedAPIAmount, apiUsage.Cost.Amount, 0.0001, "GPT-5.6 API cost should include input, cache read, cache write, and output pricing")
+			require.InDelta(t, tt.expectedAPIAmount, apiUsage.TotalCostUSD, 0.0001, "GPT-5.6 total_cost_usd should mirror the derived amount")
+
+			subscriptionUsage := FinalizeTokenUsage(TokenUsage{
+				InputTokens:       1_000_000,
+				CachedInputTokens: 1_000_000,
+				OutputTokens:      1_000_000,
+			}, TokenUsageHint{
+				AgentType:      models.AgentTypeCodex,
+				EffectiveModel: tt.model,
+				BillingMode:    TokenBillingModeSubscription,
+			})
+
+			require.NotNil(t, subscriptionUsage.NativeCost, "GPT-5.6 subscription usage should derive published Codex credits")
+			require.Equal(t, TokenCostUnitCredits, subscriptionUsage.NativeCost.Unit, "GPT-5.6 subscription cost should use credits")
+			require.Equal(t, TokenCostSourceDerived, subscriptionUsage.NativeCost.Source, "GPT-5.6 subscription cost should be marked derived")
+			require.InDelta(t, tt.expectedCreditsAmount, subscriptionUsage.NativeCost.Amount, 0.0001, "GPT-5.6 subscription cost should include input, cache read, and output credit rates")
+		})
+	}
+}
+
 func TestFinalizeTokenUsage_CodexSparkLeavesCostUnavailable(t *testing.T) {
 	t.Parallel()
 

--- a/sandbox/versions.json
+++ b/sandbox/versions.json
@@ -1,6 +1,6 @@
 {
-  "claude_code": "2.1.150",
-  "codex_cli": "0.133.0",
+  "claude_code": "2.1.205",
+  "codex_cli": "0.144.0",
   "amp_cli": "0.0.1779786108-g751b94",
   "pi_cli": "0.75.5",
   "opencode_cli": "1.17.3",


### PR DESCRIPTION
## Summary

- add GPT-5.6 Sol, Terra, and Luna to the Codex model catalog, including Fast aliases backed by the priority service tier
- add published GPT-5.6 API USD and Codex credit rates, including cache-read and cache-write pricing where published
- upgrade the sandbox pins to Codex CLI 0.144.0 and Claude Code 2.1.205
- clone code-review description requirements before legacy applicability normalization so resolving a policy does not mutate the caller's input

## Why

The Codex picker and runtime need to recognize the GPT-5.6 preview family consistently across frontend selection, backend validation, and CLI execution. Once those models are selectable, reported token usage also needs the published rate-card entries so cost and credit estimates do not silently remain unavailable.

Separately, code-review policy resolution normalized a shallow-copied requirements slice in place. Parallel callers could therefore mutate the same backing array and trigger a data race.

## Impact

Users can select GPT-5.6 Sol, Terra, and Luna while existing GPT-5.5 defaults remain unchanged. Standard GPT-5.6 API-key runs now derive USD estimates, and subscription-backed runs derive Codex credit estimates. Unpublished GPT-5.6 Fast rates remain intentionally unavailable.

Code-review policy resolution now returns normalized requirements without sharing the mutable outer requirements slice with its input.

## Validation

- GitHub CI: all required checks pass
- `go test ./internal/models ./internal/services/agent/adapters`
- `go test ./internal/services/agent -count=1`
- `go test -race ./internal/models ./internal/worker -count=1 -timeout=180s`
- targeted GPT-5.6 pricing and policy-resolution race tests repeated under `-race`
- `go vet ./internal/models ./internal/services/agent ./internal/worker`
- `npm run test -- --run src/lib/model-constants.test.ts src/lib/agents.test.ts`
