### PR TITLE
Set default Codex/PM model to GPT 5.6 Sol

### DIFF
--- a/frontend/src/lib/model-constants.test.ts
+++ b/frontend/src/lib/model-constants.test.ts
@@ -14,15 +14,15 @@ import {
   DEFAULT_PM_MODEL,
   DEFAULT_LLM_MODEL,
   CLAUDE_CODE_MODEL_OPUS_48,
-  CODEX_MODEL_GPT_5_5,
+  CODEX_MODEL_GPT_5_6_SOL,
   LLM_PROVIDER_INFO,
   LLM_MODELS_BY_PROVIDER,
   ownerProviderForModel,
 } from "./model-constants";
 
 describe("model constants", () => {
-  it("uses GPT 5.5 as the Codex and PM default", () => {
-    expect(DEFAULT_CODEX_MODEL).toBe(CODEX_MODEL_GPT_5_5);
+  it("uses GPT 5.6 Sol as the Codex and PM default", () => {
+    expect(DEFAULT_CODEX_MODEL).toBe(CODEX_MODEL_GPT_5_6_SOL);
     expect(DEFAULT_PM_MODEL).toBe(DEFAULT_CODEX_MODEL);
   });
 

--- a/frontend/src/lib/model-constants.ts
+++ b/frontend/src/lib/model-constants.ts
@@ -52,7 +52,7 @@ export const AVAILABLE_CODEX_MODELS = [
   CODEX_MODEL_GPT_5_3_CODEX_SPARK,
 ] as const;
 
-export const DEFAULT_CODEX_MODEL = CODEX_MODEL_GPT_5_5;
+export const DEFAULT_CODEX_MODEL = CODEX_MODEL_GPT_5_6_SOL;
 
 // Amp uses agent "modes" instead of model names; each mode bundles a model,
 // system prompt, and tool set on Sourcegraph's side.

--- a/internal/models/agent_model_constants.go
+++ b/internal/models/agent_model_constants.go
@@ -86,7 +86,7 @@ const (
 	CodexModelGPT53CodexSpark = "gpt-5.3-codex-spark"
 )
 
-const DefaultCodexModel = CodexModelGPT55
+const DefaultCodexModel = CodexModelGPT56Sol
 
 var AvailableCodexModels = []string{
 	CodexModelGPT56Sol,

--- a/internal/models/agent_model_constants_test.go
+++ b/internal/models/agent_model_constants_test.go
@@ -36,7 +36,7 @@ func TestClaudeCodeModelConstants(t *testing.T) {
 func TestCodexModelConstants(t *testing.T) {
 	t.Parallel()
 
-	require.Equal(t, CodexModelGPT55, DefaultCodexModel, "DefaultCodexModel should use GPT 5.5")
+	require.Equal(t, CodexModelGPT56Sol, DefaultCodexModel, "DefaultCodexModel should use GPT 5.6 Sol")
 	require.Equal(t,
 		[]string{
 			CodexModelGPT56Sol,

--- a/internal/services/agent/adapters/codex_test.go
+++ b/internal/services/agent/adapters/codex_test.go
@@ -3,6 +3,7 @@ package adapters
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"strings"
 	"testing"
@@ -144,7 +145,7 @@ func TestCodexModelArgs(t *testing.T) {
 		{
 			name:     "uses the Codex default when no env model is set",
 			env:      map[string]string{},
-			expected: ` -m 'gpt-5.5'`,
+			expected: fmt.Sprintf(" -m '%s'", models.DefaultCodexModel),
 		},
 		{
 			name:           "uses resolved effective model when env model is absent",


### PR DESCRIPTION
## Summary

The default Coding Agent model was still pinned to GPT 5.5, creating a mismatch between the expected “high reasoning” workflow and the model actually used. This change updates both frontend and backend defaults to GPT 5.6 Sol so new sessions consistently launch with the intended model, and aligns tests to prevent future regressions.

## Changes

- Updated frontend model constants so the Codex/PM default is now `CODEX_MODEL_GPT_5_6_SOL` (was GPT 5.5).
- Updated backend default Codex model constant to `CodexModelGPT56Sol`.
- Adjusted Codex adapter tests to assert the default model via `models.DefaultCodexModel`, improving resilience to future renames.

## Validation

- `npm test -- --run src/app/'(dashboard)'/sessions/new/manual-session-create-page-content.test.tsx src/components/create-session-dialog.test.tsx`

[143.dev](https://143.dev) | [session 201346fc](https://143.dev/sessions/201346fc-b23d-4072-9862-068099ac9a59)

<!-- 143 readiness -->
**143 readiness:** not available for this revision.

Preview: https://143.dev/previews/github/assembledhq/143/pull/1799?launch=1