### PR TITLE
Fix dogfood preview OOM: 8Gi cap, build-phase next build, lean preview build

### DIFF
--- a/.143/config.json
+++ b/.143/config.json
@@ -16,12 +16,13 @@
     },
     "services": {
       "frontend": {
+        "build": ["sh", ".143/preview-build-frontend.sh"],
         "command": ["sh", ".143/preview-frontend.sh"],
         "port": 3000,
         "env": {
           "API_PROXY_TARGET": "http://localhost:8080",
           "NEXT_PUBLIC_API_URL": "",
-          "NODE_OPTIONS": "--max-old-space-size=1280"
+          "NODE_OPTIONS": "--max-old-space-size=4096"
         },
         "ready": {
           "http_path": "/",
@@ -58,6 +59,16 @@
     },
     "network": {
       "mode": "managed"
+    },
+    "resources": {
+      "limits": {
+        "cpu": "2",
+        "memory": "8Gi"
+      },
+      "requests": {
+        "cpu": "1",
+        "memory": "4Gi"
+      }
     }
   }
 }

--- a/.143/preview-build-frontend.sh
+++ b/.143/preview-build-frontend.sh
@@ -1,0 +1,38 @@
+#!/bin/sh
+# preview-build-frontend.sh — dogfood preview frontend BUILD phase.
+#
+# Runs the Next production build during the platform-managed build phase, not
+# at service start. Previously the build lived in preview-frontend.sh (the
+# service command) and ran `next build` at readiness time — inside the same
+# sandbox memory cgroup as the Go server, the DB seed, and the readiness probe.
+# `next build` peaks at several GB, so with everything sharing one cap the
+# sandbox OOM-killed (exit 137) before the frontend ever became ready. Building
+# here isolates that peak from the run phase, and the launch hot path becomes
+# "just start the prebuilt standalone server" (see preview-frontend.sh).
+#
+# -u catches typos in required env vars, matching preview-frontend.sh.
+set -eu
+
+# The install phase (preview.install in .143/config.json) normally populates
+# frontend/node_modules before any build runs. Run the install here too as a
+# fallback: the lock-hash marker inside node_modules makes this a no-op when the
+# platform phase (or a cache restore) already completed, but it keeps a service
+# restart in a fresh sandbox from failing with "next: not found" (exit 127).
+sh .143/preview-install-frontend.sh
+
+cd frontend
+
+echo '[143-preview] building next production bundle...'
+npm run build
+
+echo '[143-preview] staging next standalone static assets...'
+# Next's standalone output includes the minimal server and traced Node
+# dependencies, but it does not copy generated CSS/JS chunks or public assets.
+# The production Dockerfile performs these copies into /app; the preview runs
+# the generated server from .next/standalone/frontend, so stage them there.
+rm -rf .next/standalone/frontend/.next/static .next/standalone/frontend/public
+mkdir -p .next/standalone/frontend/.next
+cp -R .next/static .next/standalone/frontend/.next/static
+cp -R public .next/standalone/frontend/public
+
+echo '[143-preview] next standalone bundle ready'

--- a/.143/preview-frontend.sh
+++ b/.143/preview-frontend.sh
@@ -1,45 +1,34 @@
 #!/bin/sh
-# preview-frontend.sh — dogfood preview frontend entrypoint.
+# preview-frontend.sh — dogfood preview frontend entrypoint (RUN phase only).
 #
-# Symmetric with preview-start.sh on the server side: a fresh sandbox
-# restored from snapshot has frontend/package.json + package-lock.json but
-# no frontend/node_modules (gitignored, never tarred into the snapshot).
-# Without an install step here, the npm scripts shell out to `next` via
-# node_modules/.bin/next, sh can't find it, and the readiness probe sees
-# "exited with code 127". This script makes the install part of the launch
-# instead of expecting a side-channel to populate node_modules.
+# The production build is produced in the platform build phase by
+# .143/preview-build-frontend.sh, so the launch hot path here just starts the
+# prebuilt Next standalone server. Building at readiness time (as this script
+# used to) put the multi-GB `next build` peak in the same sandbox memory cgroup
+# as the running server + DB seed + readiness probe and OOM-killed the sandbox
+# (exit 137).
 #
-# The preview serves a production build instead of the Next dev server. The
-# dev server's HMR endpoint streams framework internals through the preview
-# gateway and can leave App Router pages partially hydrated with raw Flight
-# payload visible in the document. Production mode removes HMR from the
-# browser path and matches the way reviewers inspect dogfood previews.
+# The preview serves a production build instead of the Next dev server. The dev
+# server's HMR endpoint streams framework internals through the preview gateway
+# and can leave App Router pages partially hydrated with raw Flight payload
+# visible in the document. Production mode removes HMR from the browser path and
+# matches the way reviewers inspect dogfood previews.
 #
 # -u catches typos in required env vars (HOST, NODE_OPTIONS) the same way
 # preview-start.sh does for DATABASE_URL.
 set -eu
 
-# Install normally happens in the platform-managed preview.install phase (see
-# .143/config.json), where the dependency cache can restore node_modules
-# before any command runs. Run it here too as a fallback for service restarts
-# inside a live sandbox; the lock-hash marker inside node_modules makes this
-# a no-op when the platform phase (or a cache restore) already completed.
-sh .143/preview-install-frontend.sh
+# Restart safety: a service restart can land in a sandbox whose build output is
+# gone (e.g. a fresh sandbox restored from a snapshot, which never tars
+# .next/standalone). Rebuild before serving so a restart never 404s. On the
+# normal launch path the build phase already produced this, so the check is a
+# cheap no-op.
+if [ ! -f frontend/.next/standalone/frontend/server.js ]; then
+  echo '[143-preview] standalone build missing; building now (restart fallback)...'
+  sh .143/preview-build-frontend.sh
+fi
 
 cd frontend
-
-echo '[143-preview] building next production bundle...'
-npm run build
-
-echo '[143-preview] staging next standalone static assets...'
-# Next's standalone output includes the minimal server and traced Node
-# dependencies, but it does not copy generated CSS/JS chunks or public assets.
-# The production Dockerfile performs these copies into /app; this script runs
-# the generated server from .next/standalone/frontend, so stage them there.
-rm -rf .next/standalone/frontend/.next/static .next/standalone/frontend/public
-mkdir -p .next/standalone/frontend/.next
-cp -R .next/static .next/standalone/frontend/.next/static
-cp -R public .next/standalone/frontend/public
 
 echo '[143-preview] starting next production server...'
 # The frontend config emits Next's standalone server for production builds.

--- a/frontend/next.config.mjs
+++ b/frontend/next.config.mjs
@@ -7,6 +7,17 @@ const apiTarget = process.env.API_PROXY_TARGET || "http://localhost:8080";
 const frontendRoot = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = path.resolve(frontendRoot, "..");
 
+// Dogfood previews (143.dev) build inside a memory-capped sandbox whose cgroup
+// is shared by the frontend build, the Go server, and the DB seed. The platform
+// sets ONEFORTYTHREE_ENV=preview (reserved; repos can't override it). In that
+// mode we trim the build's peak RSS: type checking and ESLint each spawn their
+// own long-lived process/heap during `next build`, and the Sentry webpack
+// plugin instruments the whole graph. The branch is already typechecked and
+// linted in CI, and preview builds upload no source maps, so none of that work
+// needs to run again on the launch hot path — skipping it keeps the build under
+// the sandbox cap.
+const isPreview = process.env.ONEFORTYTHREE_ENV === "preview";
+
 // Baseline security headers applied to every app response. These are
 // defense-in-depth: the app sanitizes rendered content, but a CSP frame-ancestors
 // directive plus X-Frame-Options prevents clickjacking, nosniff blocks MIME
@@ -35,6 +46,14 @@ const securityHeaders = [
 const nextConfig = {
   output: process.env.NODE_ENV === "production" ? "standalone" : undefined,
   allowedDevOrigins: ["*.ngrok.dev", "localhost", "127.0.0.1"],
+  // Preview-only: skip the type-check and lint passes during `next build` to
+  // cut build-time memory (they already ran in CI). No effect on real builds.
+  ...(isPreview
+    ? {
+        typescript: { ignoreBuildErrors: true },
+        eslint: { ignoreDuringBuilds: true },
+      }
+    : {}),
   turbopack: {
     root: repoRoot,
   },
@@ -68,13 +87,19 @@ const nextConfig = {
 
 const withMDX = createMDX();
 
-export default withSentryConfig(withMDX(nextConfig), {
-  // Suppress Sentry CLI logs during build.
-  silent: true,
+// In dogfood previews, skip the Sentry webpack plugin entirely: it instruments
+// the whole module graph at build time (memory + wall-clock) and uploads no
+// source maps here anyway (no SENTRY_AUTH_TOKEN), so it is pure build overhead
+// in the memory-capped sandbox. Real builds keep full Sentry instrumentation.
+export default isPreview
+  ? withMDX(nextConfig)
+  : withSentryConfig(withMDX(nextConfig), {
+      // Suppress Sentry CLI logs during build.
+      silent: true,
 
-  // Upload source maps for readable stack traces.
-  // Requires SENTRY_AUTH_TOKEN, SENTRY_ORG, and SENTRY_PROJECT env vars at build time.
-  sourcemaps: {
-    disable: !process.env.SENTRY_AUTH_TOKEN,
-  },
-});
+      // Upload source maps for readable stack traces.
+      // Requires SENTRY_AUTH_TOKEN, SENTRY_ORG, and SENTRY_PROJECT env vars at build time.
+      sourcemaps: {
+        disable: !process.env.SENTRY_AUTH_TOKEN,
+      },
+    });


### PR DESCRIPTION
## Problem

The frontend dogfood preview was failing with `OOM (exit 137); capped at 4096 MiB` during the readiness phase (example instance peaked at 3093 MiB before the fatal spike). Two root causes compounded.

**1. The cap was 4096, not 8192.** `.143/config.json` declared no `resources` block, so the resolver fell back to `DefaultInfraServiceMemory = 4096` for a multi-service (`frontend` + `server`) + infra (`db`) preview — leaving half the available memory (the 8192 ceiling) on the table.

**2. `next build` ran at readiness time.** The production build lived in the frontend service *command* and executed inside the shared sandbox memory cgroup alongside the Go server, the DB seed, and the readiness probe. A multi-GB `next build` on top of everything else pushed the sandbox past the cap.

## Changes

- **`.143/config.json`** — add a `resources` block (`limits.memory: 8Gi`, `requests.memory: 4Gi`). `limits` is applied last and clamped to the 8192 ceiling, so the sandbox now gets the full 8 GiB. Also add a `build:` key to the `frontend` service and raise its `NODE_OPTIONS` heap 1280 → 4096.
- **`.143/preview-build-frontend.sh`** (new) — runs `next build` + stages the standalone output in the platform **build phase**, isolated from the run phase.
- **`.143/preview-frontend.sh`** — slimmed to just start the prebuilt Next standalone server, with a restart-safe rebuild fallback if the build output is missing.
- **`frontend/next.config.mjs`** — when `ONEFORTYTHREE_ENV=preview`, skip the TypeScript type-check, ESLint, and Sentry webpack passes during `next build` (all already run in CI; preview uploads no source maps). Real builds are unchanged.

The platform injects `ONEFORTYTHREE_ENV=preview` and the service `env` block into the **build** command (verified in `runServiceBuilds`), so both the preview gating and the raised heap apply during `next build`.

## Verification

- `config.json` is valid JSON; `next.config.mjs` passes `node --check`; both shell scripts pass `sh -n`.
- End-to-end proof is relaunching the preview so the platform rebuilds from this branch.

## Test plan

- [ ] Relaunch a preview for this branch and confirm it reaches ready without OOM.
- [ ] Confirm the frontend build runs in the build phase (build logs) and the run phase only starts `server.js`.
