### PR TITLE
Trigger auto-repair after GitHub PR health sync to avoid CI/session timing gaps

### DIFF
--- a/docs/design/implemented/113-automated-pr-repair-and-readiness.md
+++ b/docs/design/implemented/113-automated-pr-repair-and-readiness.md
@@ -43,7 +43,7 @@ Defaults remain off for existing orgs. New orgs default automatic conflict repai
 
 ## Implementation Status
 
-All implementation phases are complete. The org/user settings contracts and UI shell exist, PR readiness enqueueing is extracted into a reusable runner, clean review-loop completion can atomically enqueue readiness behind the org policy, session messages support `system_auto_repair` attribution, repair runs persist automatic-attempt accounting fields, auto-repair evaluates after successful `continue_session`, and the PR health UI shows automatic progress, exhausted attempt state, and a stop path.
+All implementation phases are complete. The org/user settings contracts and UI shell exist, PR readiness enqueueing is extracted into a reusable runner, clean review-loop completion can atomically enqueue readiness behind the org policy, session messages support `system_auto_repair` attribution, repair runs persist automatic-attempt accounting fields, auto-repair evaluates after successful `continue_session` and GitHub-backed PR health synchronization, and the PR health UI shows automatic progress, exhausted attempt state, and a stop path.
 
 Outcome notifications cover automatic repair failures, exhausted attempt budgets, and blocked/failed automatic readiness checks. Metrics cover auto-repair decisions, outcomes, explicit user stop requests, and repair-regret signals for user reverts of automatic repair work and PR-head changes while automatic repair is running.
 
@@ -106,7 +106,7 @@ Readiness evaluates the current session revision/snapshot. If a new turn changes
 
 ### Auto-Repair
 
-Evaluate after a successful `continue_session` completion when the session has a linked open PR. This is the highest-signal v1 trigger: the session just became available for a continuation. PR-health-sync-triggered repair can be added later.
+Evaluate after a successful `continue_session` completion when the session has a linked open PR, and after a GitHub event produces a successful `sync_pull_request_state` health refresh. Both paths delegate to the same auto-repair coordinator; health synchronization resolves the PR's linked session before evaluation. This closes the window where CI fails only after the session turn and PR publication have completed.
 
 Because this hook runs on the hot path of session completion, do cheap local checks before calling `GetPullRequestHealth` or GitHub: policy enabled, linked open PR present, automatic budget available, and session idle/resumable. Only then read fresh enough PR health.
 

--- a/internal/services/github/pr_auto_repair.go
+++ b/internal/services/github/pr_auto_repair.go
@@ -41,6 +41,24 @@ type AutoRepairDecision struct {
 	Response      *models.PullRequestRepairResponse
 }
 
+// MaybeStartAutoRepairForPullRequest resolves the session linked to a pull
+// request and delegates to MaybeStartAutoRepair. GitHub health updates know the
+// pull request before they know the owning session, while the coordinator keeps
+// all policy, budget, dedupe, and head-SHA checks session-centric.
+func (s *PRService) MaybeStartAutoRepairForPullRequest(ctx context.Context, orgID uuid.UUID, pullRequestID uuid.UUID, reason string) (*AutoRepairDecision, error) {
+	if s == nil || s.pullRequests == nil {
+		return autoRepairDecision(AutoRepairDecisionDisabled, &pullRequestID, "", "", "auto-repair dependencies are not configured"), nil
+	}
+	pr, err := s.pullRequests.GetByID(ctx, orgID, pullRequestID)
+	if err != nil {
+		return nil, fmt.Errorf("load pull request for auto-repair: %w", err)
+	}
+	if pr.SessionID == nil {
+		return autoRepairDecision(AutoRepairDecisionNoPullRequest, &pr.ID, "", headSHAValue(pr.HeadSHA), "pull request has no linked session"), nil
+	}
+	return s.MaybeStartAutoRepair(ctx, orgID, *pr.SessionID, reason)
+}
+
 func (s *PRService) MaybeStartAutoRepair(ctx context.Context, orgID uuid.UUID, sessionID uuid.UUID, reason string) (*AutoRepairDecision, error) {
 	repository := ""
 	returnDecision := func(decision *AutoRepairDecision) (*AutoRepairDecision, error) {

--- a/internal/services/github/pr_auto_repair_test.go
+++ b/internal/services/github/pr_auto_repair_test.go
@@ -88,6 +88,37 @@ func TestApplyAutoRepairPreference(t *testing.T) {
 	}
 }
 
+func TestPRServiceMaybeStartAutoRepairForPullRequestDelegatesToLinkedSession(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "should create mock pool")
+	defer mock.Close()
+
+	orgID := uuid.New()
+	prID := uuid.New()
+	sessionID := uuid.New()
+	now := time.Now()
+	row := handlerPRRow(prID, &sessionID, orgID, "org/repo", now)
+	headSHA := "head-from-github"
+	setAutoRepairPRRowValue(row, "head_sha", &headSHA)
+	mock.ExpectQuery("FROM pull_requests").
+		WithArgs(pgx.NamedArgs{"id": prID, "org_id": orgID}).
+		WillReturnRows(pgxmock.NewRows(handlerPRColumns).AddRow(row...))
+	expectAutoRepairSession(mock, orgID, sessionID, now, models.SessionStatusRunning)
+
+	service := &PRService{
+		pullRequests: db.NewPullRequestStore(mock),
+		sessions:     db.NewSessionStore(mock),
+		orgs:         db.NewOrganizationStore(mock),
+	}
+	decision, err := service.MaybeStartAutoRepairForPullRequest(context.Background(), orgID, prID, "github_pr_health_updated")
+
+	require.NoError(t, err, "pull-request-triggered auto-repair evaluation should delegate without error")
+	require.Equal(t, AutoRepairDecisionNotResumable, decision.Status, "delegation should apply the existing session eligibility checks")
+	require.NoError(t, mock.ExpectationsWereMet(), "all pull request and session lookup expectations should be met")
+}
+
 func expectAutoRepairCount(mock pgxmock.PgxPoolIface, orgID, prID uuid.UUID, action models.PullRequestRepairActionType, headSHA string, count int) {
 	mock.ExpectQuery("SELECT count.+ FROM pull_request_repair_runs").
 		WithArgs(pgx.NamedArgs{

--- a/internal/services/preview/config_test.go
+++ b/internal/services/preview/config_test.go
@@ -2236,12 +2236,20 @@ func TestCommittedDogfoodFrontendScriptBindsExternally(t *testing.T) {
 			raw, err := os.ReadFile(candidate)
 			require.NoError(t, err, "test should read committed dogfood frontend preview script")
 			require.Contains(t, string(raw), "HOSTNAME=0.0.0.0", "dogfood Next preview must bind externally so the worker proxy can dial the sandbox IP")
-			require.Contains(t, string(raw), "npm run build", "dogfood Next preview should run a production build before serving")
-			require.Contains(t, string(raw), "sh .143/preview-install-frontend.sh", "dogfood Next preview should run the shared install script as a fallback when the platform install phase did not run")
-			require.Contains(t, string(raw), "cp -R .next/static .next/standalone/frontend/.next/static", "dogfood Next preview should stage generated CSS and other static chunks next to the standalone server")
-			require.Contains(t, string(raw), "cp -R public .next/standalone/frontend/public", "dogfood Next preview should stage public assets next to the standalone server")
 			require.Contains(t, string(raw), "node .next/standalone/frontend/server.js", "dogfood Next preview should serve the standalone production build")
+			require.Contains(t, string(raw), "sh .143/preview-build-frontend.sh", "dogfood Next preview run phase should rebuild via the build script as a restart fallback when standalone output is missing")
+			require.NotContains(t, string(raw), "npm run build", "dogfood Next preview must not run the multi-GB next build in the run phase; it belongs in the build phase to avoid OOM")
 			require.NotContains(t, string(raw), "npm run dev", "dogfood Next preview must avoid dev server HMR in the preview gateway")
+
+			// The production build moved out of the run-phase entrypoint into the
+			// build-phase script (see PR #1800). Assert the moved responsibilities
+			// still live there so we don't silently lose build coverage.
+			buildScript, err := os.ReadFile(filepath.Join(dir, ".143", "preview-build-frontend.sh"))
+			require.NoError(t, err, "test should read committed dogfood frontend build script")
+			require.Contains(t, string(buildScript), "npm run build", "dogfood Next preview build phase should run a production build before serving")
+			require.Contains(t, string(buildScript), "sh .143/preview-install-frontend.sh", "dogfood Next preview build phase should run the shared install script as a fallback when the platform install phase did not run")
+			require.Contains(t, string(buildScript), "cp -R .next/static .next/standalone/frontend/.next/static", "dogfood Next preview build phase should stage generated CSS and other static chunks next to the standalone server")
+			require.Contains(t, string(buildScript), "cp -R public .next/standalone/frontend/public", "dogfood Next preview build phase should stage public assets next to the standalone server")
 
 			installScript, err := os.ReadFile(filepath.Join(dir, ".143", "preview-install-frontend.sh"))
 			require.NoError(t, err, "test should read committed dogfood frontend install script")

--- a/internal/worker/handlers.go
+++ b/internal/worker/handlers.go
@@ -672,6 +672,7 @@ type prCreator interface {
 	EnrichPullRequestHealth(ctx context.Context, orgID, pullRequestID uuid.UUID, version int64) error
 	CompletePullRequestRepairRun(ctx context.Context, orgID, pullRequestID, repairRunID uuid.UUID) error
 	MaybeStartAutoRepair(ctx context.Context, orgID uuid.UUID, sessionID uuid.UUID, reason string) (*ghservice.AutoRepairDecision, error)
+	MaybeStartAutoRepairForPullRequest(ctx context.Context, orgID uuid.UUID, pullRequestID uuid.UUID, reason string) (*ghservice.AutoRepairDecision, error)
 	QueueMergeWhenReady(ctx context.Context, orgID, pullRequestID, userID uuid.UUID) (*models.PullRequestMergeWhenReadyStatus, error)
 	ProcessMergeWhenReady(ctx context.Context, orgID, pullRequestID uuid.UUID) error
 	SyncPRPreviewSurfaces(ctx context.Context, payload ghservice.SyncPRPreviewSurfacesPayload) error
@@ -10097,6 +10098,23 @@ func newSyncPullRequestStateHandler(services *Services, logger zerolog.Logger) J
 				return nil
 			}
 			return err
+		}
+		decision, autoRepairErr := services.PR.MaybeStartAutoRepairForPullRequest(ctx, orgID, pullRequestID, "github_pr_health_updated")
+		if autoRepairErr != nil {
+			logger.Warn().
+				Err(autoRepairErr).
+				Str("org_id", orgID.String()).
+				Str("pull_request_id", pullRequestID.String()).
+				Msg("failed to evaluate automatic pull request repair after GitHub health update")
+			return nil
+		}
+		if decision != nil && decision.Status == ghservice.AutoRepairDecisionStarted {
+			logger.Info().
+				Str("org_id", orgID.String()).
+				Str("pull_request_id", pullRequestID.String()).
+				Str("auto_repair_action", string(decision.Action)).
+				Str("head_sha", decision.HeadSHA).
+				Msg("started automatic pull request repair after GitHub health update")
 		}
 		return nil
 	}

--- a/internal/worker/handlers_test.go
+++ b/internal/worker/handlers_test.go
@@ -4704,6 +4704,7 @@ type stubPRService struct {
 	enrichPullRequestHealthFn      func(context.Context, uuid.UUID, uuid.UUID, int64) error
 	completePullRequestRepairRunFn func(context.Context, uuid.UUID, uuid.UUID, uuid.UUID) error
 	maybeStartAutoRepairFn         func(context.Context, uuid.UUID, uuid.UUID, string) (*ghservice.AutoRepairDecision, error)
+	maybeStartAutoRepairForPRFn    func(context.Context, uuid.UUID, uuid.UUID, string) (*ghservice.AutoRepairDecision, error)
 	queueMergeWhenReadyFn          func(context.Context, uuid.UUID, uuid.UUID, uuid.UUID) (*models.PullRequestMergeWhenReadyStatus, error)
 	processMergeWhenReadyFn        func(context.Context, uuid.UUID, uuid.UUID) error
 	syncPRPreviewSurfacesFn        func(context.Context, ghservice.SyncPRPreviewSurfacesPayload) error
@@ -4761,6 +4762,13 @@ func (s *stubPRService) CompletePullRequestRepairRun(ctx context.Context, orgID,
 func (s *stubPRService) MaybeStartAutoRepair(ctx context.Context, orgID uuid.UUID, sessionID uuid.UUID, reason string) (*ghservice.AutoRepairDecision, error) {
 	if s.maybeStartAutoRepairFn != nil {
 		return s.maybeStartAutoRepairFn(ctx, orgID, sessionID, reason)
+	}
+	return nil, nil
+}
+
+func (s *stubPRService) MaybeStartAutoRepairForPullRequest(ctx context.Context, orgID uuid.UUID, pullRequestID uuid.UUID, reason string) (*ghservice.AutoRepairDecision, error) {
+	if s.maybeStartAutoRepairForPRFn != nil {
+		return s.maybeStartAutoRepairForPRFn(ctx, orgID, pullRequestID, reason)
 	}
 	return nil, nil
 }
@@ -5434,6 +5442,13 @@ func TestPullRequestHealthJobHandlers(t *testing.T) {
 						called.prID = gotPRID
 						return nil
 					},
+					maybeStartAutoRepairForPRFn: func(_ context.Context, gotOrgID, gotPRID uuid.UUID, reason string) (*ghservice.AutoRepairDecision, error) {
+						called.autoRepairCalls++
+						called.orgID = gotOrgID
+						called.prID = gotPRID
+						called.autoRepairReason = reason
+						return &ghservice.AutoRepairDecision{Status: ghservice.AutoRepairDecisionNoBlocker}, nil
+					},
 					reconcilePullRequestFn: func(_ context.Context, gotOrgID uuid.UUID, gotLimit int) error {
 						called.reconcileCalls++
 						called.orgID = gotOrgID
@@ -5472,8 +5487,10 @@ func TestPullRequestHealthJobHandlers(t *testing.T) {
 			switch tt.name {
 			case "sync pull request state passes parsed ids":
 				require.Equal(t, 1, called.syncCalls, "sync handler should invoke the PR service once")
+				require.Equal(t, 1, called.autoRepairCalls, "sync handler should evaluate automatic repair after fresh GitHub health is persisted")
 				require.Equal(t, orgID, called.orgID, "sync handler should parse and pass the org ID")
 				require.Equal(t, prID, called.prID, "sync handler should parse and pass the pull request ID")
+				require.Equal(t, "github_pr_health_updated", called.autoRepairReason, "sync handler should identify GitHub health as the automatic repair trigger")
 			case "reconcile pull request state defaults the limit":
 				require.Equal(t, 1, called.reconcileCalls, "reconcile handler should invoke the PR service once")
 				require.Equal(t, orgID, called.orgID, "reconcile handler should parse and pass the org ID")
@@ -5525,8 +5542,31 @@ func TestSyncPullRequestStateHandlerDefersPendingMergeability(t *testing.T) {
 	require.True(t, retryable.ConsumeAttempt, "pending mergeability should consume attempts so exponential backoff advances")
 }
 
+func TestSyncPullRequestStateHandlerTreatsAutoRepairEvaluationFailureAsNonFatal(t *testing.T) {
+	t.Parallel()
+
+	orgID := uuid.New()
+	prID := uuid.New()
+	services := &Services{
+		PR: &stubPRService{
+			syncPullRequestStateFn: func(context.Context, uuid.UUID, uuid.UUID) error {
+				return nil
+			},
+			maybeStartAutoRepairForPRFn: func(context.Context, uuid.UUID, uuid.UUID, string) (*ghservice.AutoRepairDecision, error) {
+				return nil, fmt.Errorf("policy lookup failed")
+			},
+		},
+	}
+	payload := json.RawMessage(`{"org_id":"` + orgID.String() + `","pull_request_id":"` + prID.String() + `"}`)
+
+	err := newSyncPullRequestStateHandler(services, zerolog.Nop())(context.Background(), "sync_pull_request_state", payload)
+
+	require.NoError(t, err, "persisted GitHub health should remain successful when follow-through evaluation fails")
+}
+
 type prHandlerCalls struct {
 	syncCalls           int
+	autoRepairCalls     int
 	reconcileCalls      int
 	enrichCalls         int
 	mergeWhenReadyCalls int
@@ -5535,6 +5575,7 @@ type prHandlerCalls struct {
 	prID                uuid.UUID
 	limit               int
 	version             int64
+	autoRepairReason    string
 	surfacePayload      ghservice.SyncPRPreviewSurfacesPayload
 }
 


### PR DESCRIPTION
## Summary

Auto test repair didn’t run in a failing CI session because the auto-repair trigger depended solely on a successful `continue_session`, while GitHub PR health/state can update slightly later. This change adds a second, health-driven entry point so the same auto-repair coordinator can run once the PR’s linked session is resolved after `sync_pull_request_state`.

## Changes

- Add `MaybeStartAutoRepairForPullRequest` to resolve the owning session for a PR and delegate to the existing session-centric `MaybeStartAutoRepair` (preserving policy, budget, dedupe, and head-SHA checks).
- Update the auto-repair evaluation trigger to run after either:
  - `continue_session` succeeds, **or**
  - a successful `sync_pull_request_state` health refresh produces updated PR state.
- Adjust design docs to reflect the new synchronization-aware trigger, closing the timing window where CI fails after session/PR publication.

## Validation

- `go test ./...`
- Reviewed updated unit coverage in `internal/services/github/pr_auto_repair_test.go` and worker handler tests (`internal/worker/handlers_test.go`) to confirm the new health-sync path routes into the same coordinator logic.

[143.dev](https://143.dev) | [session 0df3b992](https://143.dev/sessions/0df3b992-7236-4aa9-acc9-f0aeaed034fd)

<!-- 143 readiness -->
**143 readiness:** Ready with warnings (workspace revision 10; 7 passed, 1 warnings, 0 blockers).

Preview: https://143.dev/previews/github/assembledhq/143/pull/1805?launch=1