### PR TITLE
Fix session changeset ordering and selection fallback for single- vs multi-PR sessions

### DIFF
--- a/docs/design/future/111-session-changesets-and-stacks.md
+++ b/docs/design/future/111-session-changesets-and-stacks.md
@@ -1,6 +1,14 @@
 # Design: Session Changesets and Stacked PRs
 
-> **Status:** Future
+> **Status:** Partially Implemented
+
+> **Implementation note (2026-07-11):** Phases 1 and 2 are complete. Session
+> detail exposes ordered, PR-hydrated changeset summaries and shows a pull
+> request selector only for multi-PR sessions. PR-native actions (health,
+> repair, and merge) follow the selected PR. Until Phase 3 materializes a
+> non-primary branch/worktree, its Changes, Preview, readiness, Create PR, and
+> push surfaces are explicitly unavailable rather than falling back to the
+> primary session workspace. The one-PR compatibility path is unchanged.
 
 ## Summary
 
@@ -624,6 +632,13 @@ Tasks:
 
 Goal: let the app represent multiple changesets, but avoid branch splitting and
 restack behavior.
+
+Phase 2 selection is deliberately safe for planned, non-primary changesets:
+PR-native read/actions that already have a PR identity follow the selected
+changeset, while Changes, Preview, readiness, review, push, and Create PR show
+an explicit materialization-required state. They must never fall through to the
+primary session workspace. Making those branch-backed actions executable is
+owned by Phases 3 and 4.
 
 Tasks:
 

--- a/frontend/src/app/(dashboard)/sessions/[id]/page-overview.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/page-overview.test.tsx
@@ -2,8 +2,9 @@ import { describe, it, expect, vi } from 'vitest';
 import { http, HttpResponse } from 'msw';
 import { renderWithProviders, screen, userEvent, waitFor, within } from '@/test/test-utils';
 import { QueryClient } from '@tanstack/react-query';
+import { act } from '@testing-library/react';
 import { server } from '@/test/mocks/server';
-import { mockSessions, mockMembers } from '@/test/mocks/handlers';
+import { mockSessions, mockMembers, mockPR } from '@/test/mocks/handlers';
 import { SessionDetailContent } from './session-detail-content';
 import { queryKeys } from '@/lib/query-keys';
 import { markProvisionalSessionDetail } from '@/lib/session-detail-cache';
@@ -94,6 +95,7 @@ describe('SessionDetailPage overview and review loop', () => {
         ...mockSessions[0],
         result_summary: 'Provisional list title',
         threads: [],
+        changesets: [],
       }),
     } satisfies SingleResponse<Session>);
     let detailRequests = 0;
@@ -840,4 +842,92 @@ describe('SessionDetailPage overview and review loop', () => {
       expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
     });
   });
+
+  it('keeps the legacy full-page layout when the session has one pull request slot', async () => {
+    const primaryChangesetID = '11111111-1111-4111-8111-111111111111';
+    server.use(http.get('/api/v1/sessions/:id', () => HttpResponse.json({
+      data: {
+        ...mockSessions[0],
+        changesets: [{
+          id: primaryChangesetID, is_primary: true, order_index: 0, title: 'Foundation', summary: '',
+          status: 'planned', target_branch: 'main', base_branch: 'main',
+          created_at: '2026-07-11T00:00:00Z', updated_at: '2026-07-11T00:00:00Z',
+        }],
+      },
+    })));
+
+    renderWithProviders(<SessionDetailContent id={mockSessions[0].id} />);
+    await screen.findAllByText('Fixed TypeError by adding null check');
+    expect(screen.queryByTestId('pull-request-list')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('selected-pull-request-panel')).not.toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: 'Overview' })).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: 'Changes' })).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: 'Preview' })).toBeInTheDocument();
+  });
+
+  it('scopes the full PR details surface when a different pull request is selected', async () => {
+    const primaryChangesetID = '11111111-1111-4111-8111-111111111111';
+    const childChangesetID = '22222222-2222-4222-8222-222222222222';
+    const primaryPR = { ...mockPR, id: 'pr-primary', changeset_id: primaryChangesetID, github_pr_number: 101, title: 'Foundation' };
+    const childPR = {
+      ...mockPR,
+      id: 'pr-child',
+      changeset_id: childChangesetID,
+      github_pr_number: 102,
+      github_pr_url: 'https://github.com/org/repo/pull/102',
+      title: 'API integration',
+      branch_name: '143/api',
+      head_ref: '143/api',
+      ci_status: 'failure' as const,
+      review_status: 'changes_requested' as const,
+    };
+    const multiPRSession = {
+      ...mockSessions[0],
+      changesets: [
+        {
+          id: primaryChangesetID, is_primary: true, order_index: 0, title: 'Foundation', summary: 'Shared types',
+          status: 'pr_open', target_branch: 'main', base_branch: 'main', working_branch: '143/foundation',
+          pull_request: primaryPR, created_at: '2026-07-11T00:00:00Z', updated_at: '2026-07-11T00:00:00Z',
+        },
+        {
+          id: childChangesetID, is_primary: false, order_index: 1, title: 'API integration', summary: 'Connect the API',
+          status: 'pr_open', target_branch: 'main', base_branch: '143/foundation', working_branch: '143/api',
+          stacked_on_changeset_id: primaryChangesetID, pull_request: childPR,
+          created_at: '2026-07-11T00:00:00Z', updated_at: '2026-07-11T00:00:00Z',
+        },
+      ],
+    };
+    const requestedChangesets: string[] = [];
+    server.use(
+      http.get('/api/v1/sessions/:id', () => HttpResponse.json({ data: multiPRSession })),
+      http.get('/api/v1/sessions/:id/pr', ({ request }) => {
+        const selected = new URL(request.url).searchParams.get('changeset_id') ?? primaryChangesetID;
+        requestedChangesets.push(selected);
+        return HttpResponse.json({ data: selected === childChangesetID ? childPR : primaryPR });
+      }),
+    );
+
+    const user = userEvent.setup();
+    renderWithProviders(<SessionDetailContent id={multiPRSession.id} />);
+    expect(await screen.findByTestId('pull-request-list')).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: /API integration/ }));
+
+    await waitFor(() => {
+      expect(within(screen.getByTestId('selected-pull-request-panel')).getByText('Connect the API')).toBeInTheDocument();
+    });
+    const selectedPanel = screen.getByTestId('selected-pull-request-panel');
+    expect(within(selectedPanel).getByText('143/foundation')).toBeInTheDocument();
+    expect(within(selectedPanel).getByText('changes requested')).toBeInTheDocument();
+    expect(screen.getByTestId('branch-actions-unavailable')).toBeInTheDocument();
+    await waitFor(() => expect(requestedChangesets).toContain(childChangesetID));
+    expect(screen.getByRole('link', { name: 'View PR' })).toHaveAttribute('href', childPR.github_pr_url);
+
+    act(() => {
+      window.history.replaceState({}, '', window.location.pathname);
+      window.dispatchEvent(new PopStateEvent('popstate'));
+    });
+    await waitFor(() => {
+      expect(within(screen.getByTestId('selected-pull-request-panel')).getByText('Shared types')).toBeInTheDocument();
+    });
+  }, 10_000);
 });

--- a/frontend/src/app/(dashboard)/sessions/[id]/page-overview.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/page-overview.test.tsx
@@ -4,7 +4,7 @@ import { renderWithProviders, screen, userEvent, waitFor, within } from '@/test/
 import { QueryClient } from '@tanstack/react-query';
 import { act } from '@testing-library/react';
 import { server } from '@/test/mocks/server';
-import { mockSessions, mockMembers, mockPR } from '@/test/mocks/handlers';
+import { mockSessions, mockMembers, mockPR, mockPRHealth } from '@/test/mocks/handlers';
 import { SessionDetailContent } from './session-detail-content';
 import { queryKeys } from '@/lib/query-keys';
 import { markProvisionalSessionDetail } from '@/lib/session-detail-cache';
@@ -898,12 +898,36 @@ describe('SessionDetailPage overview and review loop', () => {
       ],
     };
     const requestedChangesets: string[] = [];
+    const requestedHealthPRs: string[] = [];
+    const requestedRepairPRs: string[] = [];
     server.use(
       http.get('/api/v1/sessions/:id', () => HttpResponse.json({ data: multiPRSession })),
       http.get('/api/v1/sessions/:id/pr', ({ request }) => {
         const selected = new URL(request.url).searchParams.get('changeset_id') ?? primaryChangesetID;
         requestedChangesets.push(selected);
         return HttpResponse.json({ data: selected === childChangesetID ? childPR : primaryPR });
+      }),
+      http.get('/api/v1/pull-requests/:id/health', ({ params }) => {
+        requestedHealthPRs.push(String(params.id));
+        return HttpResponse.json({
+          data: params.id === childPR.id
+            ? { ...mockPRHealth, pull_request_id: childPR.id, failing_test_count: 1, can_fix_tests: true, needs_agent_action: true }
+            : { ...mockPRHealth, pull_request_id: primaryPR.id },
+        });
+      }),
+      http.post('/api/v1/pull-requests/:id/repair/fix-tests', ({ params }) => {
+        requestedRepairPRs.push(String(params.id));
+        return HttpResponse.json({
+          data: {
+            session_id: multiPRSession.id,
+            mode: 'resumed',
+            reused_in_flight: false,
+            head_sha: 'head-sha',
+            base_sha: 'base-sha',
+            health_version: 1,
+            repair_action_type: 'fix_tests',
+          },
+        });
       }),
     );
 
@@ -920,7 +944,10 @@ describe('SessionDetailPage overview and review loop', () => {
     expect(within(selectedPanel).getByText('changes requested')).toBeInTheDocument();
     expect(screen.getByTestId('branch-actions-unavailable')).toBeInTheDocument();
     await waitFor(() => expect(requestedChangesets).toContain(childChangesetID));
+    await waitFor(() => expect(requestedHealthPRs).toContain(childPR.id));
     expect(screen.getByRole('link', { name: 'View PR' })).toHaveAttribute('href', childPR.github_pr_url);
+    await user.click(await screen.findByRole('button', { name: 'Fix tests' }));
+    await waitFor(() => expect(requestedRepairPRs).toEqual([childPR.id]));
 
     act(() => {
       window.history.replaceState({}, '', window.location.pathname);
@@ -929,5 +956,47 @@ describe('SessionDetailPage overview and review loop', () => {
     await waitFor(() => {
       expect(within(screen.getByTestId('selected-pull-request-panel')).getByText('Shared types')).toBeInTheDocument();
     });
+  }, 10_000);
+
+  it('keeps every branch-backed action on the materialization boundary for a planned pull request slot', async () => {
+    const primaryChangesetID = '33333333-3333-4333-8333-333333333333';
+    const plannedChangesetID = '44444444-4444-4444-8444-444444444444';
+    const session = {
+      ...mockSessions[0],
+      diff_stats: { added: 1, removed: 1, files_changed: 1 },
+      changesets: [
+        {
+          id: primaryChangesetID, is_primary: true, order_index: 0, title: 'Foundation', summary: '',
+          status: 'planned', target_branch: 'main', base_branch: 'main',
+          created_at: '2026-07-11T00:00:00Z', updated_at: '2026-07-11T00:00:00Z',
+        },
+        {
+          id: plannedChangesetID, is_primary: false, order_index: 1, title: 'API integration', summary: 'Not materialized yet',
+          status: 'planned', target_branch: 'main', base_branch: 'main',
+          created_at: '2026-07-11T00:00:00Z', updated_at: '2026-07-11T00:00:00Z',
+        },
+      ],
+    };
+    server.use(
+      http.get('/api/v1/sessions/:id', () => HttpResponse.json({ data: session })),
+      http.get('/api/v1/sessions/:id/pr', () => HttpResponse.json({ data: null })),
+    );
+
+    const user = userEvent.setup();
+    renderWithProviders(<SessionDetailContent id={session.id} />);
+    await user.click(await screen.findByRole('button', { name: /API integration/ }));
+
+    const selectedPanel = screen.getByTestId('selected-pull-request-panel');
+    expect(within(selectedPanel).getByRole('button', { name: 'Create PR' })).toBeDisabled();
+    expect(screen.queryByRole('button', { name: 'Check readiness' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Review' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Push changes' })).not.toBeInTheDocument();
+
+    await user.click(screen.getByTitle('View changes'));
+    expect(await screen.findByText('Changes for this pull request will be available after its branch is materialized.')).toBeInTheDocument();
+    expect(new URL(window.location.href).searchParams.get('review')).toBeNull();
+
+    await user.click(screen.getByRole('tab', { name: 'Preview' }));
+    expect(await screen.findByText('Preview for this pull request will be available after its branch is materialized.')).toBeInTheDocument();
   }, 10_000);
 });

--- a/frontend/src/app/(dashboard)/sessions/[id]/pull-request-list.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/pull-request-list.test.tsx
@@ -1,0 +1,61 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+import type { ChangesetSummary } from '@/lib/types';
+import { PullRequestList } from './session-detail-content';
+
+function changeset(overrides: Partial<ChangesetSummary> = {}): ChangesetSummary {
+  return {
+    id: 'changeset-1',
+    is_primary: true,
+    order_index: 0,
+    title: 'Foundation',
+    summary: 'Shared types',
+    status: 'planned',
+    target_branch: 'main',
+    base_branch: 'main',
+    created_at: '2026-07-11T00:00:00Z',
+    updated_at: '2026-07-11T00:00:00Z',
+    ...overrides,
+  };
+}
+
+describe('PullRequestList', () => {
+  it('stays hidden for the compatible one-PR path', () => {
+    const { queryByTestId } = render(
+      <PullRequestList changesets={[changeset()]} selectedID="changeset-1" onSelect={vi.fn()} />,
+    );
+
+    expect(queryByTestId('pull-request-list')).not.toBeInTheDocument();
+  });
+
+  it('renders multiple pull requests and changes selection', async () => {
+    const onSelect = vi.fn();
+    render(
+      <PullRequestList
+        changesets={[
+          changeset(),
+          changeset({
+            id: 'changeset-2',
+            is_primary: false,
+            order_index: 1,
+            title: 'API integration',
+            pull_request: {
+              id: 'pr-2', session_id: 'session-1', org_id: 'org-1', changeset_id: 'changeset-2',
+              github_pr_number: 102, github_pr_url: 'https://github.test/pull/102', github_repo: 'acme/repo',
+              title: 'API integration', body: '', status: 'open', branch_name: '143/api', review_status: null,
+              ci_status: 'success', merged_at: null, closed_at: null, created_at: '2026-07-11T00:00:00Z', updated_at: '2026-07-11T00:00:00Z',
+            },
+          }),
+        ]}
+        selectedID="changeset-1"
+        onSelect={onSelect}
+      />,
+    );
+
+    expect(screen.getByTestId('pull-request-list')).toBeInTheDocument();
+    expect(screen.getByText('#102 · open')).toBeInTheDocument();
+    await userEvent.click(screen.getByRole('button', { name: /API integration/ }));
+    expect(onSelect).toHaveBeenCalledWith('changeset-2');
+  });
+});

--- a/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
@@ -3679,6 +3679,11 @@ export function SessionDetailContent({ id }: { id: string }) {
   const selectedChangeset = changesets.find((changeset) => changeset.id === selectedChangesetID) ?? primaryChangeset;
   const hasMultipleChangesets = changesets.length > 1;
   const selectedIsPrimary = selectedChangeset?.is_primary !== false;
+  // The primary changeset keeps the legacy null-tolerant PR lookup: sending a
+  // changeset_id would route the backend to GetByChangesetID, which cannot
+  // match legacy PR rows whose changeset_id is still NULL. Only non-primary
+  // slots, whose PRs always carry a changeset_id, are looked up by changeset.
+  const selectedChangesetPRParam = selectedIsPrimary ? undefined : selectedChangeset?.id;
   const changesetSessionIDRef = useRef(id);
   useEffect(() => {
     const syncSelectionFromURL = () => setSelectedChangesetID(new URL(window.location.href).searchParams.get("changeset"));
@@ -4166,8 +4171,8 @@ export function SessionDetailContent({ id }: { id: string }) {
   // transition within milliseconds, and the SSE polling fallback re-reads the
   // session row on a 1s tick when Redis is unavailable.
   const { data: prData } = useQuery({
-    queryKey: queryKeys.sessions.pr(id, selectedChangeset?.id),
-    queryFn: () => api.sessions.getPR(id, selectedChangeset?.id),
+    queryKey: queryKeys.sessions.pr(id, selectedChangesetPRParam),
+    queryFn: () => api.sessions.getPR(id, selectedChangesetPRParam),
     enabled: !isProvisionalSession,
     // Updates flow in via mutation invalidations and the session SSE stream
     // (pr_creation_state / pr_push_state); a small staleTime suppresses

--- a/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
@@ -141,7 +141,7 @@ import {
   writeStoredViewedThreadIds,
 } from "@/lib/session-thread-views";
 import { applySessionDetailToSessionListCaches } from "@/lib/session-list-cache";
-import type { CodingCredentialSummary, HumanInputAnswerBody, HumanInputRequest, ListResponse, PRReadinessBypass, PRReadinessCheck, PRReadinessEnforcement, PRReadinessPolicyConfig, PRReadinessRun, ReviewLoopFixMode, Session, SessionDetail, SessionInputCommand, SessionInputReference, SessionLog, SessionMessage, SessionReviewComment, SessionReviewLoop, SessionRetryMode, SessionStatus, SessionThread, SessionThreadFileEvent, SessionTimelineEntry, ThreadInboxEvent, ThreadRuntimeEvent, ThreadStatus, User, CodexAuthStatus, PullRequestHealthResponse, PullRequestStatus, SessionWorkspaceGenerationChangedEvent, SingleResponse, SessionTranscriptWindowResponse, SessionTranscriptTurn, SessionTranscriptEntry } from "@/lib/types";
+import type { ChangesetSummary, CodingCredentialSummary, HumanInputAnswerBody, HumanInputRequest, ListResponse, PRReadinessBypass, PRReadinessCheck, PRReadinessEnforcement, PRReadinessPolicyConfig, PRReadinessRun, ReviewLoopFixMode, Session, SessionDetail, SessionInputCommand, SessionInputReference, SessionLog, SessionMessage, SessionReviewComment, SessionReviewLoop, SessionRetryMode, SessionStatus, SessionThread, SessionThreadFileEvent, SessionTimelineEntry, ThreadInboxEvent, ThreadRuntimeEvent, ThreadStatus, User, CodexAuthStatus, PullRequestHealthResponse, PullRequestStatus, SessionWorkspaceGenerationChangedEvent, SingleResponse, SessionTranscriptWindowResponse, SessionTranscriptTurn, SessionTranscriptEntry } from "@/lib/types";
 import { AgentTabStrip, computeThreadOverlap } from "./agent-tab-strip";
 import { AuditLogTrigger } from "@/components/audit/audit-log-trigger";
 import { ResizeHandle } from "@/components/resize-handle";
@@ -3330,6 +3330,59 @@ const TRANSCRIPT_PAGE_MIN_PX = 160;
 const TRANSCRIPT_PAGE_VIEWPORT_RATIO = 0.85;
 const REVIEW_AGENT_KEYS = ["codex", "claude_code", "amp", "pi"] as const;
 
+export function PullRequestList({
+  changesets,
+  selectedID,
+  onSelect,
+}: {
+  changesets: ChangesetSummary[];
+  selectedID: string;
+  onSelect: (id: string) => void;
+}) {
+  if (changesets.length <= 1) return null;
+
+  return (
+    <Card className="border-border/60" data-testid="pull-request-list">
+      <CardHeader className="p-3 pb-2">
+        <CardTitle className="text-sm">Pull requests</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-1 p-2 pt-0">
+        {changesets.map((changeset, index) => {
+          const selected = changeset.id === selectedID;
+          const pr = changeset.pull_request;
+          return (
+            <Button
+              key={changeset.id}
+              type="button"
+              variant={selected ? "secondary" : "ghost"}
+              className="h-auto w-full justify-start gap-2 px-2 py-2 text-left"
+              aria-pressed={selected}
+              onClick={() => onSelect(changeset.id)}
+            >
+              <span className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-muted text-xs font-medium">
+                {index + 1}
+              </span>
+              <span className="min-w-0 flex-1">
+                <span className="block truncate text-sm font-medium">{changeset.title}</span>
+                <span className="block truncate text-xs text-muted-foreground">
+                  {pr ? `#${pr.github_pr_number} · ${pr.status}` : changeset.status.replaceAll("_", " ")}
+                </span>
+                <span className="block truncate text-xs text-muted-foreground">
+                  {changeset.base_branch} → {changeset.working_branch ?? "not materialized"}
+                </span>
+              </span>
+              <span className="flex shrink-0 items-center gap-1">
+                {pr?.ci_status && <Badge variant="outline" className="h-5 px-1 text-xs">CI {pr.ci_status}</Badge>}
+                {changeset.stacked_on_changeset_id && <GitBranch className="h-3.5 w-3.5 text-muted-foreground" />}
+              </span>
+            </Button>
+          );
+        })}
+      </CardContent>
+    </Card>
+  );
+}
+
 function getDefaultReviewAgentType(sessionAgentType?: string): string {
   return REVIEW_AGENT_KEYS.find((agentType) => agentType !== sessionAgentType) ?? sessionAgentType ?? "codex";
 }
@@ -3346,6 +3399,7 @@ export function SessionDetailContent({ id }: { id: string }) {
   const [resumePRParam, setResumePRParam] = useQueryState("resume_pr");
   const [resumeActionParam, setResumeActionParam] = useQueryState("resume_action");
   const [githubPRParam, setGithubPRParam] = useQueryState("github_pr");
+  const [changesetParam, setChangesetParam] = useQueryState("changeset");
   const [centerMode, setCenterMode] = useState<"chat" | "review">(
     reviewParam === "active" ? "review" : "chat"
   );
@@ -3619,6 +3673,24 @@ export function SessionDetailContent({ id }: { id: string }) {
   const rawSession = data?.data;
   const isProvisionalSession = isProvisionalSessionDetail(rawSession);
   const session = isProvisionalSession ? undefined : rawSession;
+  const changesets = session?.changesets ?? [];
+  const primaryChangeset = changesets.find((changeset) => changeset.is_primary) ?? changesets[0];
+  const [selectedChangesetID, setSelectedChangesetID] = useState<string | null>(changesetParam);
+  const selectedChangeset = changesets.find((changeset) => changeset.id === selectedChangesetID) ?? primaryChangeset;
+  const hasMultipleChangesets = changesets.length > 1;
+  const selectedIsPrimary = selectedChangeset?.is_primary !== false;
+  const changesetSessionIDRef = useRef(id);
+  useEffect(() => {
+    const syncSelectionFromURL = () => setSelectedChangesetID(new URL(window.location.href).searchParams.get("changeset"));
+    window.addEventListener("popstate", syncSelectionFromURL);
+    return () => window.removeEventListener("popstate", syncSelectionFromURL);
+  }, []);
+  useEffect(() => {
+    if (changesetSessionIDRef.current === id) return;
+    changesetSessionIDRef.current = id;
+    setSelectedChangesetID(null);
+    void setChangesetParam(null);
+  }, [id, setChangesetParam]);
   // Tab title from whatever payload is available — the provisional row's
   // title matches what the user just clicked, so don't wait for the
   // authoritative detail to label the tab.
@@ -4094,19 +4166,20 @@ export function SessionDetailContent({ id }: { id: string }) {
   // transition within milliseconds, and the SSE polling fallback re-reads the
   // session row on a 1s tick when Redis is unavailable.
   const { data: prData } = useQuery({
-    queryKey: ["session", id, "pr"],
-    queryFn: () => api.sessions.getPR(id),
+    queryKey: queryKeys.sessions.pr(id, selectedChangeset?.id),
+    queryFn: () => api.sessions.getPR(id, selectedChangeset?.id),
     enabled: !isProvisionalSession,
     // Updates flow in via mutation invalidations and the session SSE stream
     // (pr_creation_state / pr_push_state); a small staleTime suppresses
     // redundant refetches on remount or unrelated cache invalidations.
     staleTime: 30_000,
   });
-  const pullRequestId = prData?.data?.id;
+  const selectedPR = prData?.data ?? selectedChangeset?.pull_request;
+  const pullRequestId = selectedPR?.id;
   const { data: prHealthData, isLoading: isPRHealthLoading } = useQuery({
     queryKey: ["pull-request", pullRequestId, "health"],
     queryFn: () => api.pullRequests.getHealth(pullRequestId!),
-    enabled: !!pullRequestId && prData?.data?.status === "open",
+    enabled: !!pullRequestId && selectedPR?.status === "open",
     // Pushed via the PULL_REQUEST_UPDATED SSE event. The stream onopen handler
     // below also reconciles once because Redis pub/sub does not replay PR row
     // or health events missed while the tab was hidden or the EventSource was
@@ -4116,9 +4189,9 @@ export function SessionDetailContent({ id }: { id: string }) {
   });
   const prHealth = prHealthData?.data;
   const prHealthActionsBlocked = prHealthBlocksPRActions(prHealth);
-  const rawPRStatus = prData?.data?.status;
+  const rawPRStatus = selectedPR?.status;
   const prStatus = deriveEffectivePRStatus(rawPRStatus, prHealth?.status);
-  const prNumber = prData?.data?.github_pr_number;
+  const prNumber = selectedPR?.github_pr_number;
   const closedPRNumber = prNumber;
   const closedPRLabel = closedPRNumber ? `PR #${closedPRNumber} closed` : "PR closed";
   const closedPRSummary = closedPRNumber
@@ -4174,7 +4247,7 @@ export function SessionDetailContent({ id }: { id: string }) {
   useReconcileOptimisticAction({ phase: localPushState, serverState: session?.pr_push_state, onResolved: resolvePushAction });
   useReconcileOptimisticAction({ phase: localBranchState, serverState: session?.branch_creation_state, onResolved: resolveBranchAction });
 
-  const prUrl = prData?.data?.github_pr_url;
+  const prUrl = selectedPR?.github_pr_url;
   const serverPRState = session?.pr_creation_state;
   const localPRWaitingForServer =
     localPRState === "queued" &&
@@ -4369,7 +4442,7 @@ export function SessionDetailContent({ id }: { id: string }) {
     // as the session log stream above. The onerror branch already invalidates
     // the health query on disconnect, so reconnecting on visibility refreshes
     // the cached health to whatever happened while we were away.
-    if (!pullRequestId || prData?.data?.status !== "open" || !isDocumentVisible) {
+    if (!pullRequestId || selectedPR?.status !== "open" || !isDocumentVisible) {
       return;
     }
 
@@ -4424,7 +4497,7 @@ export function SessionDetailContent({ id }: { id: string }) {
         clearTimeout(reconnectTimer);
       }
     };
-  }, [apiBase, prData?.data?.status, pullRequestId, queryClient, isDocumentVisible, id]);
+  }, [apiBase, selectedPR?.status, pullRequestId, queryClient, isDocumentVisible, id]);
   const previousSessionStatusRef = useRef<SessionStatus | undefined>(undefined);
   const resetSessionNotificationRefs = useCallback(() => {
     previousSessionStatusRef.current = undefined;
@@ -4459,7 +4532,7 @@ export function SessionDetailContent({ id }: { id: string }) {
     }
   }, [id, queryClient, session?.id]);
 
-  const hasPR = !!prData?.data;
+  const hasPR = !!selectedPR;
   const hasSnapshot = !!session?.snapshot_key;
   const hasSessionChanges = !!session?.diff || !!session?.diff_stats;
   const isTerminalSession = session ? terminalSessionStatuses.has(session.status) : false;
@@ -4488,7 +4561,7 @@ export function SessionDetailContent({ id }: { id: string }) {
   const { data: readinessData } = useQuery({
     queryKey: queryKeys.sessions.readiness(id),
     queryFn: () => api.sessions.getReadiness(id),
-    enabled: !!session,
+    enabled: !!session && selectedIsPrimary,
     refetchInterval: (query) => {
       const status = query.state.data?.data.latest?.status;
       return status === "queued" || status === "running" ? pollMs(3000) : false;
@@ -4542,10 +4615,10 @@ export function SessionDetailContent({ id }: { id: string }) {
       latestReadiness.status === "queued" ||
       latestReadiness.status === "running");
   const createPRAllowsSubmission = builderReviewAllowsPR || readinessAutoRunCanQueue;
-  const canAttemptCreatePR = canShipPR && hasSnapshot && !hasPR && !isRunning;
+  const canAttemptCreatePR = canShipPR && hasSnapshot && !hasPR && !isRunning && selectedIsPrimary;
   const canCreatePR = canAttemptCreatePR && createPRAllowsSubmission;
   const canCreateBranch = canAttemptCreatePR && builderReviewAllowsPR;
-  const needsGitHubStatus = canCreatePR || (hasPR && prData?.data?.status === "open");
+  const needsGitHubStatus = canCreatePR || (hasPR && selectedPR?.status === "open");
   const reviewLoopRunning = latestReviewLoop?.status === "running";
   const canStartReviewLoop = !!session && canManageSession && canUseNativeReviewLoop && hasSnapshot && !isRunning && !reviewLoopRunning;
   const reviewUnavailableReason = reviewLoopRunning
@@ -4573,7 +4646,7 @@ export function SessionDetailContent({ id }: { id: string }) {
 
   const createPRMutation = useMutation({
     mutationFn: (options?: { draft?: boolean; authorMode?: PRAuthorMode; resumeToken?: string; mergeWhenReady?: boolean }) =>
-      api.sessions.createPR(id, options),
+      api.sessions.createPR(id, selectedChangeset ? { ...options, changesetId: selectedChangeset.id } : options),
     onMutate: () => {
       setLocalPRActionError(null);
       setLocalPRState("submitting");
@@ -4708,7 +4781,7 @@ export function SessionDetailContent({ id }: { id: string }) {
     latestReadiness?.status === "running" ||
     runReadinessMutation.isPending;
   const readinessStale = !!session && readinessIsStale(latestReadiness, session);
-  const readinessCheckDisabled = readinessRunning || isRunning;
+  const readinessCheckDisabled = readinessRunning || isRunning || !selectedIsPrimary;
 
   // Readiness findings, grouped with role-aware enforcement so the merged
   // Review card can surface blockers, bypasses, and the review packet inline.
@@ -4916,7 +4989,7 @@ export function SessionDetailContent({ id }: { id: string }) {
 
   const continueFromPRBranchMutation = useMutation({
     mutationFn: async () => {
-      const headRef = prData?.data?.head_ref ?? prData?.data?.branch_name;
+      const headRef = selectedPR?.head_ref ?? selectedPR?.branch_name;
       const message = continueFromPRBranchMessage(headRef);
       if (activeThread?.id) {
         const clientMessageID =
@@ -5942,11 +6015,11 @@ export function SessionDetailContent({ id }: { id: string }) {
   }, [continueFromPRBranchMutation, ghBlocked, localPushState, pushBranchDiverged, pushChangesMutation]);
 
   const viewPRFromKeyboard = useCallback(() => {
-    if (!prData?.data?.github_pr_url) {
+    if (!selectedPR?.github_pr_url) {
       return;
     }
-    window.open(prData.data.github_pr_url, "_blank", "noopener,noreferrer");
-  }, [prData?.data?.github_pr_url]);
+    window.open(selectedPR.github_pr_url, "_blank", "noopener,noreferrer");
+  }, [selectedPR?.github_pr_url]);
 
   useSessionKeyboardShortcuts({
     enabled: !isLoading && !!session,
@@ -5987,8 +6060,8 @@ export function SessionDetailContent({ id }: { id: string }) {
     },
     pr: {
       canCreate: canCreatePR && localPRState === "idle" && !createPRMutation.isPending,
-      canView: !!prData?.data?.github_pr_url,
-      canPush: !prHealthActionsBlocked && canShipPR && builderReviewAllowsPR && hasPR && prStatus === "open" && !!session?.has_unpushed_changes && hasSnapshot && !isRunning && localPushState === "idle" && !pushChangesMutation.isPending && !continueFromPRBranchMutation.isPending,
+      canView: !!selectedPR?.github_pr_url,
+      canPush: selectedIsPrimary && !prHealthActionsBlocked && canShipPR && builderReviewAllowsPR && hasPR && prStatus === "open" && !!session?.has_unpushed_changes && hasSnapshot && !isRunning && localPushState === "idle" && !pushChangesMutation.isPending && !continueFromPRBranchMutation.isPending,
       canFixTests: !prHealthActionsBlocked && canManagePR && hasRepairableFailedChecks(prHealth) && pendingPRAction === null,
       canResolveConflicts: !prHealthActionsBlocked && canManagePR && !!prHealth?.can_resolve_conflicts && pendingPRAction === null,
       canMerge: !prHealthActionsBlocked && canManagePR && prHealthAllowsMerge(prHealth) && pendingPRAction === null,
@@ -6114,7 +6187,7 @@ export function SessionDetailContent({ id }: { id: string }) {
   const pushAction = derivePushChangesActionState({
     canShipPR,
     hasOpenPR: hasPR && prStatus === "open",
-    hasUnpushedChanges: !!session.has_unpushed_changes,
+    hasUnpushedChanges: selectedIsPrimary && !!session.has_unpushed_changes,
     hasSnapshot,
     isRunning,
     builderReviewAllowsPR,
@@ -6231,7 +6304,7 @@ export function SessionDetailContent({ id }: { id: string }) {
             </TabsList>
           </div>
           <div aria-label="Session detail actions" className="flex items-center justify-end gap-2 shrink-0 pl-2">
-            {hasPR && prData?.data?.github_pr_url ? (
+            {hasPR && selectedPR?.github_pr_url ? (
               <>
                 {prStatus === "closed" && (
                   <Badge variant="secondary" className="h-7 px-2 text-xs">
@@ -6239,7 +6312,7 @@ export function SessionDetailContent({ id }: { id: string }) {
                   </Badge>
                 )}
                 <Button asChild variant="outline" size="sm" className="h-7 text-xs gap-1.5" title="View PR (p v)">
-                  <a href={prData.data.github_pr_url} target="_blank" rel="noopener noreferrer">
+                  <a href={selectedPR.github_pr_url} target="_blank" rel="noopener noreferrer">
                     <ExternalLink className="h-3 w-3" />
                     View PR
                   </a>
@@ -6342,7 +6415,7 @@ export function SessionDetailContent({ id }: { id: string }) {
 
       <TabsContent value="changes" className="flex-1 min-h-0">
         <ChangesTab
-          filteredFiles={visibleFilteredFiles}
+          filteredFiles={selectedIsPrimary ? visibleFilteredFiles : []}
           activeFileIndex={activeFileIndex}
           onFileSelect={setActiveFileIndex}
           onOpenReview={openReview}
@@ -6352,7 +6425,9 @@ export function SessionDetailContent({ id }: { id: string }) {
           passRange={passRange}
           onPassRangeChange={setPassRange}
           emptyStatusText={
-            isDiffDisplayLoading
+            !selectedIsPrimary
+              ? "Changes for this pull request will be available after its branch is materialized."
+              : isDiffDisplayLoading
               ? "Loading changes..."
               : session.status === "running" || session.status === "pending"
               ? "Changes will appear here as the agent modifies files."
@@ -6366,6 +6441,43 @@ export function SessionDetailContent({ id }: { id: string }) {
       </TabsContent>
       <TabsContent value="overview" className="flex-1 overflow-y-auto scrollbar-hide p-4">
         <div className="space-y-4">
+          <PullRequestList
+            changesets={changesets}
+            selectedID={selectedChangeset?.id ?? ""}
+            onSelect={(changesetID) => {
+              setSelectedChangesetID(changesetID);
+              void setChangesetParam(changesetID);
+            }}
+          />
+          {hasMultipleChangesets && selectedChangeset && (
+            <Card className="border-border/60" data-testid="selected-pull-request-panel">
+              <CardContent className="space-y-1 p-4">
+                <div className="text-sm font-medium">{selectedChangeset.title}</div>
+                {selectedChangeset.summary && <p className="text-xs text-muted-foreground">{selectedChangeset.summary}</p>}
+                <dl className="grid grid-cols-[auto_1fr] gap-x-3 gap-y-1 pt-1 text-xs">
+                  <dt className="text-muted-foreground">Base</dt><dd className="truncate">{selectedChangeset.base_branch}</dd>
+                  <dt className="text-muted-foreground">Head</dt><dd className="truncate">{selectedChangeset.working_branch ?? "Not materialized"}</dd>
+                  <dt className="text-muted-foreground">Target</dt><dd className="truncate">{selectedChangeset.target_branch}</dd>
+                  <dt className="text-muted-foreground">State</dt><dd>{selectedChangeset.pull_request?.status ?? selectedChangeset.status.replaceAll("_", " ")}</dd>
+                  {selectedChangeset.pull_request?.ci_status && <><dt className="text-muted-foreground">CI</dt><dd>{selectedChangeset.pull_request.ci_status}</dd></>}
+                  {selectedChangeset.pull_request?.review_status && <><dt className="text-muted-foreground">Review</dt><dd>{selectedChangeset.pull_request.review_status.replaceAll("_", " ")}</dd></>}
+                </dl>
+                {!selectedChangeset.pull_request && !selectedChangeset.is_primary && (
+                  <DisabledTooltip disabled content="Create PR becomes available after branch materialization">
+                    <Button type="button" size="sm" disabled className="mt-2">
+                      <GitPullRequest className="h-3.5 w-3.5" />
+                      Create PR
+                    </Button>
+                  </DisabledTooltip>
+                )}
+                {!selectedChangeset.is_primary && (
+                  <p className="pt-2 text-xs text-muted-foreground" data-testid="branch-actions-unavailable">
+                    Changes, preview, readiness, review, and push become available after branch materialization.
+                  </p>
+                )}
+              </CardContent>
+            </Card>
+          )}
           {pullRequestId && prStatus === "open" && (
             prHealth ? (
               <PRHealthBanner
@@ -6392,7 +6504,7 @@ export function SessionDetailContent({ id }: { id: string }) {
                 }}
                 onStopAutoRepair={(sessionId, threadId) => stopAutoRepairMutation.mutate({ sessionId, threadId })}
                 stopAutoRepairPending={stopAutoRepairMutation.isPending}
-                reviewAction={canManageSession && canUseNativeReviewLoop ? {
+                reviewAction={selectedIsPrimary && canManageSession && canUseNativeReviewLoop ? {
                   disabled: reviewActionDisabled,
                   spinning: startReviewLoopMutation.isPending || reviewLoopRunning,
                   title: reviewActionDisabledReason,
@@ -6422,7 +6534,7 @@ export function SessionDetailContent({ id }: { id: string }) {
               </Card>
             ) : null
           )}
-          {canManageSession && !hasPR && hasSessionChanges ? (
+          {selectedIsPrimary && canManageSession && !hasPR && hasSessionChanges ? (
             <Card className="border-border/60">
               <CardContent className="space-y-3 p-4">
                 <div className="flex flex-col gap-3">
@@ -6617,12 +6729,20 @@ export function SessionDetailContent({ id }: { id: string }) {
         </div>
       </TabsContent>
       <TabsContent value="preview" className="flex-1 overflow-y-auto scrollbar-hide p-4">
-        <ErrorBoundary fallback={<PreviewTabErrorFallback />}>
-          <PreviewPanel
-            sessionId={id}
-            previewOriginTemplate={PREVIEW_ORIGIN_TEMPLATE}
-          />
-        </ErrorBoundary>
+        {selectedIsPrimary ? (
+          <ErrorBoundary fallback={<PreviewTabErrorFallback />}>
+            <PreviewPanel
+              sessionId={id}
+              previewOriginTemplate={PREVIEW_ORIGIN_TEMPLATE}
+            />
+          </ErrorBoundary>
+        ) : (
+          <Card className="border-border/60">
+            <CardContent className="p-4 text-sm text-muted-foreground">
+              Preview for this pull request will be available after its branch is materialized.
+            </CardContent>
+          </Card>
+        )}
       </TabsContent>
     </Tabs>
   );

--- a/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
@@ -3521,9 +3521,18 @@ export function SessionDetailContent({ id }: { id: string }) {
   const handleDetailResize = useCallback((delta: number) => {
     setDetailWidth((w) => Math.min(MAX_DETAIL, Math.max(MIN_DETAIL, w - delta)));
   }, []);
+  const selectedIsPrimaryRef = useRef(true);
 
   // --- Enter review mode ---
   const openReview = useCallback((fileIndex?: number) => {
+    if (!selectedIsPrimaryRef.current) {
+      setDetailTab("changes");
+      setShowDetailPanel(true);
+      if (isMobileReviewViewport) {
+        setMobileDetailOpen(true);
+      }
+      return;
+    }
     if (fileIndex !== undefined) setActiveFileIndex(fileIndex);
     setCenterMode("review");
     suppressNextReviewParamClearRef.current = true;
@@ -3679,6 +3688,7 @@ export function SessionDetailContent({ id }: { id: string }) {
   const selectedChangeset = changesets.find((changeset) => changeset.id === selectedChangesetID) ?? primaryChangeset;
   const hasMultipleChangesets = changesets.length > 1;
   const selectedIsPrimary = selectedChangeset?.is_primary !== false;
+  selectedIsPrimaryRef.current = selectedIsPrimary;
   // The primary changeset keeps the legacy null-tolerant PR lookup: sending a
   // changeset_id would route the backend to GetByChangesetID, which cannot
   // match legacy PR rows whose changeset_id is still NULL. Only non-primary
@@ -3696,6 +3706,15 @@ export function SessionDetailContent({ id }: { id: string }) {
     setSelectedChangesetID(null);
     void setChangesetParam(null);
   }, [id, setChangesetParam]);
+  useEffect(() => {
+    if (selectedIsPrimary || centerMode !== "review") return;
+    exitReview();
+    setDetailTab("changes");
+    setShowDetailPanel(true);
+    if (isMobileReviewViewport) {
+      setMobileDetailOpen(true);
+    }
+  }, [centerMode, exitReview, isMobileReviewViewport, selectedIsPrimary]);
   // Tab title from whatever payload is available — the provisional row's
   // title matches what the user just clicked, so don't wait for the
   // authoritative detail to label the tab.

--- a/frontend/src/app/(dashboard)/sessions/[id]/session-detail-state.test.ts
+++ b/frontend/src/app/(dashboard)/sessions/[id]/session-detail-state.test.ts
@@ -290,6 +290,7 @@ describe("mergeSessionDetailStatusUpdate", () => {
     current_turn: 1,
     last_activity_at: "2026-01-01T00:00:00.000Z",
     sandbox_state: "running",
+    changesets: [],
     created_at: "2026-01-01T00:00:00.000Z",
     threads: [baseThread],
   };

--- a/frontend/src/lib/api.test.ts
+++ b/frontend/src/lib/api.test.ts
@@ -1486,6 +1486,19 @@ describe('api client', () => {
       expect(capturedBody).toEqual({ draft: true, author_mode: 'user', resume_token: 'resume-123', merge_when_ready: true });
     });
 
+    it('targets the selected pull request slot', async () => {
+      let capturedUrl = '';
+      server.use(
+        http.post('/api/v1/sessions/:id/pr', ({ request }) => {
+          capturedUrl = request.url;
+          return HttpResponse.json({ status: 'queued' }, { status: 202 });
+        }),
+      );
+
+      await api.sessions.createPR('session-abc', { changesetId: 'changeset-2' });
+      expect(capturedUrl).toContain('changeset_id=changeset-2');
+    });
+
     it('throws on conflict when PR already exists', async () => {
       server.use(
         http.post('/api/v1/sessions/:id/pr', () => {
@@ -1526,6 +1539,42 @@ describe('api client', () => {
           resume_token: 'resume-123',
         }),
       });
+    });
+  });
+
+  describe('sessions - changesets', () => {
+    it('lists, creates, updates, and selects pull request slots', async () => {
+      const calls: string[] = [];
+      server.use(
+        http.get('/api/v1/sessions/:id/changesets', ({ request }) => {
+          calls.push(new URL(request.url).pathname);
+          return HttpResponse.json({ data: [], meta: {} });
+        }),
+        http.post('/api/v1/sessions/:id/changesets', async ({ request }) => {
+          calls.push(JSON.stringify(await request.json()));
+          return HttpResponse.json({ data: { id: 'changeset-2' } }, { status: 201 });
+        }),
+        http.patch('/api/v1/sessions/:id/changesets/:changesetId', async ({ request }) => {
+          calls.push(JSON.stringify(await request.json()));
+          return HttpResponse.json({ data: { id: 'changeset-2' } });
+        }),
+        http.get('/api/v1/sessions/:id/pr', ({ request }) => {
+          calls.push(new URL(request.url).search);
+          return HttpResponse.json({ data: null });
+        }),
+      );
+
+      await api.sessions.listChangesets('session-1');
+      await api.sessions.createChangeset('session-1', { title: 'API', summary: 'Endpoints' });
+      await api.sessions.updateChangeset('session-1', 'changeset-2', { title: 'API integration' });
+      await api.sessions.getPR('session-1', 'changeset-2');
+
+      expect(calls).toEqual([
+        '/api/v1/sessions/session-1/changesets',
+        JSON.stringify({ title: 'API', summary: 'Endpoints' }),
+        JSON.stringify({ title: 'API integration' }),
+        '?changeset_id=changeset-2',
+      ]);
     });
   });
 

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -546,7 +546,15 @@ export const api = {
     getLogDetail: (sessionId: string, logId: number) =>
       get<import('./types').SingleResponse<import('./types').SessionLogDetail>>(`/api/v1/sessions/${sessionId}/logs/${logId}`),
     getTimeline: (sessionId: string) => get<import('./types').ListResponse<import('./types').SessionTimelineEntry>>(`/api/v1/sessions/${sessionId}/timeline`),
-    getPR: (sessionId: string) => get<import('./types').SingleResponse<import('./types').PullRequest | null>>(`/api/v1/sessions/${sessionId}/pr`),
+    getPR: (sessionId: string, changesetId?: string) => get<import('./types').SingleResponse<import('./types').PullRequest | null>>(
+      `/api/v1/sessions/${sessionId}/pr${changesetId ? `?changeset_id=${encodeURIComponent(changesetId)}` : ''}`,
+    ),
+	listChangesets: (sessionId: string) =>
+	  get<import('./types').ListResponse<import('./types').ChangesetSummary>>(`/api/v1/sessions/${sessionId}/changesets`),
+	createChangeset: (sessionId: string, body: { title: string; summary?: string; stacked_on_changeset_id?: string }) =>
+	  post<import('./types').SingleResponse<import('./types').ChangesetSummary>>(`/api/v1/sessions/${sessionId}/changesets`, body),
+	updateChangeset: (sessionId: string, changesetId: string, body: { title?: string; summary?: string }) =>
+	  patch<import('./types').SingleResponse<import('./types').ChangesetSummary>>(`/api/v1/sessions/${sessionId}/changesets/${changesetId}`, body),
     getReadiness: (sessionId: string) =>
       get<import('./types').SingleResponse<import('./types').PRReadinessResponse>>(`/api/v1/sessions/${sessionId}/pr-readiness-runs/latest`),
     runReadiness: (sessionId: string) =>
@@ -557,8 +565,8 @@ export const api = {
       get<import('./types').SingleResponse<import('./types').PRReadinessContext>>(`/api/v1/sessions/${sessionId}/pr-readiness-context`),
     updateReadinessContext: (sessionId: string, issueLessReason: string) =>
       post<import('./types').SingleResponse<import('./types').PRReadinessContext>>(`/api/v1/sessions/${sessionId}/pr-readiness-context`, { issue_less_reason: issueLessReason }),
-    createPR: (sessionId: string, options?: { draft?: boolean; authorMode?: 'auto' | 'user' | 'app'; resumeToken?: string; mergeWhenReady?: boolean }) =>
-      post<{ status: string }>(`/api/v1/sessions/${sessionId}/pr`, options ? {
+    createPR: (sessionId: string, options?: { draft?: boolean; authorMode?: 'auto' | 'user' | 'app'; resumeToken?: string; mergeWhenReady?: boolean; changesetId?: string }) =>
+      post<{ status: string }>(`/api/v1/sessions/${sessionId}/pr${options?.changesetId ? `?changeset_id=${encodeURIComponent(options.changesetId)}` : ''}`, options ? {
         ...(options.draft !== undefined ? { draft: options.draft } : {}),
         ...(options.authorMode ? { author_mode: options.authorMode } : {}),
         ...(options.resumeToken ? { resume_token: options.resumeToken } : {}),

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -549,12 +549,12 @@ export const api = {
     getPR: (sessionId: string, changesetId?: string) => get<import('./types').SingleResponse<import('./types').PullRequest | null>>(
       `/api/v1/sessions/${sessionId}/pr${changesetId ? `?changeset_id=${encodeURIComponent(changesetId)}` : ''}`,
     ),
-	listChangesets: (sessionId: string) =>
-	  get<import('./types').ListResponse<import('./types').ChangesetSummary>>(`/api/v1/sessions/${sessionId}/changesets`),
-	createChangeset: (sessionId: string, body: { title: string; summary?: string; stacked_on_changeset_id?: string }) =>
-	  post<import('./types').SingleResponse<import('./types').ChangesetSummary>>(`/api/v1/sessions/${sessionId}/changesets`, body),
-	updateChangeset: (sessionId: string, changesetId: string, body: { title?: string; summary?: string }) =>
-	  patch<import('./types').SingleResponse<import('./types').ChangesetSummary>>(`/api/v1/sessions/${sessionId}/changesets/${changesetId}`, body),
+    listChangesets: (sessionId: string) =>
+      get<import('./types').ListResponse<import('./types').ChangesetSummary>>(`/api/v1/sessions/${sessionId}/changesets`),
+    createChangeset: (sessionId: string, body: { title: string; summary?: string; stacked_on_changeset_id?: string }) =>
+      post<import('./types').SingleResponse<import('./types').ChangesetSummary>>(`/api/v1/sessions/${sessionId}/changesets`, body),
+    updateChangeset: (sessionId: string, changesetId: string, body: { title?: string; summary?: string }) =>
+      patch<import('./types').SingleResponse<import('./types').ChangesetSummary>>(`/api/v1/sessions/${sessionId}/changesets/${changesetId}`, body),
     getReadiness: (sessionId: string) =>
       get<import('./types').SingleResponse<import('./types').PRReadinessResponse>>(`/api/v1/sessions/${sessionId}/pr-readiness-runs/latest`),
     runReadiness: (sessionId: string) =>

--- a/frontend/src/lib/query-keys.ts
+++ b/frontend/src/lib/query-keys.ts
@@ -17,7 +17,9 @@ export const queryKeys = {
     diff: (id: string, revision?: string | null) => ["session", id, "diff", revision ?? null] as const,
     timeline: (id: string) => ["session", id, "timeline"] as const,
     logDetail: (sessionId: string, logId: number) => ["session", sessionId, "logs", logId, "detail"] as const,
-    pr: (id: string) => ["session", id, "pr"] as const,
+    pr: (id: string, changesetId?: string | null) => changesetId
+      ? ["session", id, "pr", changesetId] as const
+      : ["session", id, "pr"] as const,
     messages: (id: string) => ["session", id, "messages"] as const,
     humanInputRequests: (id: string, status?: string | null, threadId?: string | null) =>
       ["session", id, "human-input-requests", status ?? null, threadId ?? null] as const,

--- a/frontend/src/lib/session-detail-cache.ts
+++ b/frontend/src/lib/session-detail-cache.ts
@@ -22,6 +22,7 @@ export function provisionalSessionDetailFromListItem(session: Session): SingleRe
     data: markProvisionalSessionDetail({
       ...session,
       threads: session.threads ?? [],
+      changesets: [],
     }),
   };
 }

--- a/frontend/src/lib/session-list-cache.test.ts
+++ b/frontend/src/lib/session-list-cache.test.ts
@@ -23,6 +23,7 @@ function makeSessionDetail(overrides: Partial<SessionDetail> = {}): SessionDetai
   return {
     ...makeSession(overrides),
     threads: [],
+    changesets: [],
     ...overrides,
   };
 }

--- a/frontend/src/lib/session-list-cache.ts
+++ b/frontend/src/lib/session-list-cache.ts
@@ -16,12 +16,19 @@ function isArchivedListKey(key: QueryKey): boolean {
 }
 
 function mergeSessionListItem(existing: SessionListItem, updated: SessionDetail): SessionListItem {
+  const {
+    changesets,
+    threads,
+    ...updatedListFields
+  } = updated;
+  void [changesets, threads];
+
   return {
     ...existing,
-    ...updated,
-    last_viewed_at: existing.last_viewed_at,
-    pr_summary: existing.pr_summary,
-    threads: existing.threads,
+    ...updatedListFields,
+    ...(Object.hasOwn(existing, "last_viewed_at") ? { last_viewed_at: existing.last_viewed_at } : {}),
+    ...(Object.hasOwn(existing, "pr_summary") ? { pr_summary: existing.pr_summary } : {}),
+    ...(Object.hasOwn(existing, "threads") ? { threads: existing.threads } : {}),
   };
 }
 

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -1611,6 +1611,37 @@ export interface ForkResult {
 
 export interface SessionDetail extends Session {
   threads: SessionThread[];
+  changesets: ChangesetSummary[];
+}
+
+export type ChangesetStatus =
+  | "planned"
+  | "materializing"
+  | "published_branch"
+  | "pr_open"
+  | "needs_restack"
+  | "restacking"
+  | "restack_conflict"
+  | "external_update_detected"
+  | "ready"
+  | "merged"
+  | "abandoned";
+
+export interface ChangesetSummary {
+  id: string;
+  is_primary: boolean;
+  order_index: number;
+  title: string;
+  summary: string;
+  status: ChangesetStatus;
+  target_branch: string;
+  base_branch: string;
+  working_branch?: string;
+  stacked_on_changeset_id?: string;
+  head_sha?: string;
+  pull_request?: PullRequest;
+  created_at: string;
+  updated_at: string;
 }
 
 export interface SessionDiff {
@@ -1862,6 +1893,7 @@ export interface SessionTranscriptWindowResponse {
 export interface PullRequest {
   id: string;
   session_id: string;
+  changeset_id?: string;
   org_id: string;
   github_pr_number: number;
   github_pr_url: string;

--- a/internal/api/handlers/session_changesets_test.go
+++ b/internal/api/handlers/session_changesets_test.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -106,20 +107,37 @@ func TestSessionHandlerUpdateChangeset(t *testing.T) {
 	require.NoError(t, mock.ExpectationsWereMet(), "update should scope by org, session, and changeset")
 }
 
-func TestSessionHandlerListChangesetsRejectsMissingSession(t *testing.T) {
+func TestSessionHandlerListChangesetsHandlesSessionLookupErrors(t *testing.T) {
 	t.Parallel()
-	mock, err := pgxmock.NewPool()
-	require.NoError(t, err, "test should create database mock")
-	t.Cleanup(mock.Close)
-	orgID, sessionID := uuid.New(), uuid.New()
-	mock.ExpectQuery(`(?s)SELECT .+ FROM sessions`).
-		WithArgs(sessionID, orgID).
-		WillReturnError(pgx.ErrNoRows)
-	h := newSessionHandler(t, mock)
-	h.SetChangesetStore(db.NewSessionChangesetStore(mock))
-	w := httptest.NewRecorder()
-	h.ListChangesets(w, changesetRequest(http.MethodGet, "/changesets", sessionID.String(), nil, orgID, ""))
-	require.Equal(t, http.StatusNotFound, w.Code, "unknown tenant-scoped session should return not found")
-	require.Contains(t, w.Body.String(), "NOT_FOUND", "handler should return the API error envelope")
-	require.NoError(t, mock.ExpectationsWereMet(), "session existence lookup should be tenant scoped")
+
+	tests := []struct {
+		name       string
+		lookupErr  error
+		wantStatus int
+		wantCode   string
+	}{
+		{name: "missing session", lookupErr: pgx.ErrNoRows, wantStatus: http.StatusNotFound, wantCode: "NOT_FOUND"},
+		{name: "database failure", lookupErr: fmt.Errorf("connection reset by peer"), wantStatus: http.StatusInternalServerError, wantCode: "SESSION_LOOKUP_FAILED"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			mock, err := pgxmock.NewPool()
+			require.NoError(t, err, "test should create database mock")
+			t.Cleanup(mock.Close)
+			orgID, sessionID := uuid.New(), uuid.New()
+			mock.ExpectQuery(`(?s)SELECT .+ FROM sessions`).
+				WithArgs(sessionID, orgID).
+				WillReturnError(tt.lookupErr)
+			h := newSessionHandler(t, mock)
+			h.SetChangesetStore(db.NewSessionChangesetStore(mock))
+			w := httptest.NewRecorder()
+			h.ListChangesets(w, changesetRequest(http.MethodGet, "/changesets", sessionID.String(), nil, orgID, ""))
+			require.Equal(t, tt.wantStatus, w.Code, "handler should classify the session lookup error")
+			require.Contains(t, w.Body.String(), tt.wantCode, "handler should return the expected API error code")
+			require.NoError(t, mock.ExpectationsWereMet(), "session existence lookup should be tenant scoped")
+		})
+	}
 }

--- a/internal/api/handlers/session_changesets_test.go
+++ b/internal/api/handlers/session_changesets_test.go
@@ -1,0 +1,125 @@
+package handlers
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/assembledhq/143/internal/api/middleware"
+	"github.com/assembledhq/143/internal/db"
+	"github.com/assembledhq/143/internal/models"
+	"github.com/go-chi/chi/v5"
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/pashagolub/pgxmock/v4"
+	"github.com/stretchr/testify/require"
+)
+
+var sessionChangesetColumns = []string{
+	"id", "org_id", "session_id", "is_primary", "order_index", "title", "summary",
+	"status", "target_branch", "base_branch", "working_branch", "stacked_on_changeset_id",
+	"head_sha", "expected_remote_head_sha", "base_head_sha", "pr_creation_state", "pr_creation_error", "created_at", "updated_at",
+}
+
+func changesetRequest(method, target, sessionID string, changesetID *uuid.UUID, orgID uuid.UUID, body string) *http.Request {
+	req := httptest.NewRequest(method, target, strings.NewReader(body))
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("id", sessionID)
+	if changesetID != nil {
+		rctx.URLParams.Add("changeset_id", changesetID.String())
+	}
+	ctx := context.WithValue(req.Context(), chi.RouteCtxKey, rctx)
+	return req.WithContext(middleware.WithOrgID(ctx, orgID))
+}
+
+func TestSessionHandlerCreateChangeset(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name       string
+		sessionID  string
+		body       string
+		setup      func(pgxmock.PgxPoolIface, uuid.UUID, uuid.UUID)
+		wantStatus int
+		wantBody   string
+	}{
+		{name: "rejects invalid session", sessionID: "invalid", body: `{"title":"API"}`, wantStatus: http.StatusBadRequest, wantBody: "INVALID_ID"},
+		{name: "requires title", sessionID: uuid.NewString(), body: `{"title":"  "}`, wantStatus: http.StatusBadRequest, wantBody: "TITLE_REQUIRED"},
+		{
+			name: "creates tenant scoped metadata", sessionID: uuid.NewString(), body: `{"title":" API ","summary":" Endpoints "}`,
+			setup: func(mock pgxmock.PgxPoolIface, orgID, sessionID uuid.UUID) {
+				now, changesetID := time.Now().UTC(), uuid.New()
+				mock.ExpectQuery(`INSERT INTO session_changesets .+ RETURNING`).
+					WithArgs(orgID, sessionID, "API", "Endpoints", (*uuid.UUID)(nil)).
+					WillReturnRows(pgxmock.NewRows(sessionChangesetColumns).AddRow(
+						changesetID, orgID, sessionID, false, 1, "API", "Endpoints", models.ChangesetStatusPlanned,
+						"main", "main", nil, nil, nil, nil, nil, models.PRCreationStateIdle, nil, now, now,
+					))
+			},
+			wantStatus: http.StatusCreated, wantBody: `"title":"API"`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			mock, err := pgxmock.NewPool()
+			require.NoError(t, err, "test should create database mock")
+			t.Cleanup(mock.Close)
+			orgID := uuid.New()
+			sessionID, _ := uuid.Parse(tt.sessionID)
+			if tt.setup != nil {
+				tt.setup(mock, orgID, sessionID)
+			}
+			h := newSessionHandler(t, mock)
+			h.SetChangesetStore(db.NewSessionChangesetStore(mock))
+			w := httptest.NewRecorder()
+			h.CreateChangeset(w, changesetRequest(http.MethodPost, "/changesets", tt.sessionID, nil, orgID, tt.body))
+			require.Equal(t, tt.wantStatus, w.Code, "handler should return expected status")
+			require.Contains(t, w.Body.String(), tt.wantBody, "handler should return expected response")
+			require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
+		})
+	}
+}
+
+func TestSessionHandlerUpdateChangeset(t *testing.T) {
+	t.Parallel()
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "test should create database mock")
+	t.Cleanup(mock.Close)
+	orgID, sessionID, changesetID := uuid.New(), uuid.New(), uuid.New()
+	now := time.Now().UTC()
+	title := "API integration"
+	mock.ExpectQuery(`UPDATE session_changesets SET.+WHERE org_id = .+ AND session_id = .+ AND id = .+RETURNING`).
+		WithArgs(&title, (*string)(nil), orgID, sessionID, changesetID).
+		WillReturnRows(pgxmock.NewRows(sessionChangesetColumns).AddRow(
+			changesetID, orgID, sessionID, false, 1, title, "Endpoints", models.ChangesetStatusPlanned,
+			"main", "main", nil, nil, nil, nil, nil, models.PRCreationStateIdle, nil, now, now,
+		))
+	h := newSessionHandler(t, mock)
+	h.SetChangesetStore(db.NewSessionChangesetStore(mock))
+	w := httptest.NewRecorder()
+	h.UpdateChangeset(w, changesetRequest(http.MethodPatch, "/changesets/"+changesetID.String(), sessionID.String(), &changesetID, orgID, `{"title":" API integration "}`))
+	require.Equal(t, http.StatusOK, w.Code, "metadata update should succeed")
+	require.Contains(t, w.Body.String(), `"title":"API integration"`, "response should contain normalized title")
+	require.NoError(t, mock.ExpectationsWereMet(), "update should scope by org, session, and changeset")
+}
+
+func TestSessionHandlerListChangesetsRejectsMissingSession(t *testing.T) {
+	t.Parallel()
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "test should create database mock")
+	t.Cleanup(mock.Close)
+	orgID, sessionID := uuid.New(), uuid.New()
+	mock.ExpectQuery(`(?s)SELECT .+ FROM sessions`).
+		WithArgs(sessionID, orgID).
+		WillReturnError(pgx.ErrNoRows)
+	h := newSessionHandler(t, mock)
+	h.SetChangesetStore(db.NewSessionChangesetStore(mock))
+	w := httptest.NewRecorder()
+	h.ListChangesets(w, changesetRequest(http.MethodGet, "/changesets", sessionID.String(), nil, orgID, ""))
+	require.Equal(t, http.StatusNotFound, w.Code, "unknown tenant-scoped session should return not found")
+	require.Contains(t, w.Body.String(), "NOT_FOUND", "handler should return the API error envelope")
+	require.NoError(t, mock.ExpectationsWereMet(), "session existence lookup should be tenant scoped")
+}

--- a/internal/api/handlers/sessions.go
+++ b/internal/api/handlers/sessions.go
@@ -955,7 +955,11 @@ func (h *SessionHandler) ListChangesets(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 	if _, err := h.runStore.GetAPIDetailByID(r.Context(), orgID, sessionID); err != nil {
-		writeError(w, r, http.StatusNotFound, "NOT_FOUND", "session not found")
+		if errors.Is(err, pgx.ErrNoRows) {
+			writeError(w, r, http.StatusNotFound, "NOT_FOUND", "session not found")
+			return
+		}
+		writeError(w, r, http.StatusInternalServerError, "SESSION_LOOKUP_FAILED", "failed to load session", err)
 		return
 	}
 	changesets, err := h.listChangesetSummaries(r.Context(), orgID, sessionID)

--- a/internal/api/handlers/sessions.go
+++ b/internal/api/handlers/sessions.go
@@ -573,6 +573,10 @@ func (h *SessionHandler) primaryChangesetID(ctx context.Context, orgID, sessionI
 	return changeset.ID, nil
 }
 
+// errInvalidChangesetID marks a malformed changeset_id query parameter so
+// callers can distinguish a client error (400) from a store/DB failure (500).
+var errInvalidChangesetID = errors.New("invalid changeset ID")
+
 func (h *SessionHandler) requestedChangeset(ctx context.Context, orgID, sessionID uuid.UUID, raw string) (models.SessionChangeset, error) {
 	if h.changesetStore == nil {
 		return models.SessionChangeset{ID: sessionID, OrgID: orgID, SessionID: sessionID, IsPrimary: true}, nil
@@ -582,7 +586,7 @@ func (h *SessionHandler) requestedChangeset(ctx context.Context, orgID, sessionI
 	}
 	id, err := uuid.Parse(raw)
 	if err != nil {
-		return models.SessionChangeset{}, fmt.Errorf("invalid changeset ID: %w", err)
+		return models.SessionChangeset{}, fmt.Errorf("%w: %v", errInvalidChangesetID, err)
 	}
 	return h.changesetStore.GetByID(ctx, orgID, sessionID, id)
 }
@@ -2685,10 +2689,13 @@ func (h *SessionHandler) CreatePR(w http.ResponseWriter, r *http.Request) {
 	}
 	targetChangeset, err := h.requestedChangeset(r.Context(), orgID, sessionID, r.URL.Query().Get("changeset_id"))
 	if err != nil {
-		if errors.Is(err, pgx.ErrNoRows) {
-			writeError(w, r, http.StatusNotFound, "CHANGESET_NOT_FOUND", "pull request target not found")
-		} else {
+		switch {
+		case errors.Is(err, errInvalidChangesetID):
 			writeError(w, r, http.StatusBadRequest, "INVALID_CHANGESET_ID", "invalid pull request target", err)
+		case errors.Is(err, pgx.ErrNoRows):
+			writeError(w, r, http.StatusNotFound, "CHANGESET_NOT_FOUND", "pull request target not found")
+		default:
+			writeError(w, r, http.StatusInternalServerError, "CHANGESET_LOOKUP_FAILED", "failed to resolve the pull request target", err)
 		}
 		return
 	}
@@ -2709,24 +2716,20 @@ func (h *SessionHandler) CreatePR(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if targetChangeset.IsPrimary {
-		switch session.PRCreationState {
-		case models.PRCreationStateQueued, models.PRCreationStatePushing:
-			writeError(w, r, http.StatusConflict, "PR_IN_FLIGHT", "PR creation already in progress")
-			return
-		case models.PRCreationStateSucceeded:
-			// Succeeded means a PR row should exist; fall through to the
-			// PR_EXISTS check below so the 409 path is consistent.
-		}
+	// Non-primary changesets are rejected above with CHANGESET_NOT_MATERIALIZED,
+	// so from here the target is always the primary changeset and only the
+	// legacy session-scoped creation guards apply.
+	switch session.PRCreationState {
+	case models.PRCreationStateQueued, models.PRCreationStatePushing:
+		writeError(w, r, http.StatusConflict, "PR_IN_FLIGHT", "PR creation already in progress")
+		return
+	case models.PRCreationStateSucceeded:
+		// Succeeded means a PR row should exist; fall through to the
+		// PR_EXISTS check below so the 409 path is consistent.
 	}
 
 	// Check whether a PR already exists for this session.
-	var prErr error
-	if targetChangeset.IsPrimary {
-		_, prErr = h.pullRequestStore.GetPrimaryBySessionID(r.Context(), orgID, sessionID)
-	} else {
-		_, prErr = h.pullRequestStore.GetByChangesetID(r.Context(), orgID, sessionID, targetChangeset.ID)
-	}
+	_, prErr := h.pullRequestStore.GetPrimaryBySessionID(r.Context(), orgID, sessionID)
 	if prErr == nil {
 		writeError(w, r, http.StatusConflict, "PR_EXISTS", "a pull request already exists for this session")
 		return
@@ -2735,7 +2738,7 @@ func (h *SessionHandler) CreatePR(w http.ResponseWriter, r *http.Request) {
 		writeError(w, r, http.StatusInternalServerError, "INTERNAL_ERROR", "failed to check for existing PR", prErr)
 		return
 	}
-	if targetChangeset.PRCreationState == models.PRCreationStateSucceeded || (targetChangeset.IsPrimary && session.PRCreationState == models.PRCreationStateSucceeded) {
+	if targetChangeset.PRCreationState == models.PRCreationStateSucceeded || session.PRCreationState == models.PRCreationStateSucceeded {
 		writeError(w, r, http.StatusConflict, "PR_ALREADY_CREATED", "PR creation already completed for this session")
 		return
 	}

--- a/internal/api/handlers/sessions.go
+++ b/internal/api/handlers/sessions.go
@@ -573,6 +573,20 @@ func (h *SessionHandler) primaryChangesetID(ctx context.Context, orgID, sessionI
 	return changeset.ID, nil
 }
 
+func (h *SessionHandler) requestedChangeset(ctx context.Context, orgID, sessionID uuid.UUID, raw string) (models.SessionChangeset, error) {
+	if h.changesetStore == nil {
+		return models.SessionChangeset{ID: sessionID, OrgID: orgID, SessionID: sessionID, IsPrimary: true}, nil
+	}
+	if strings.TrimSpace(raw) == "" {
+		return h.changesetStore.GetPrimary(ctx, orgID, sessionID)
+	}
+	id, err := uuid.Parse(raw)
+	if err != nil {
+		return models.SessionChangeset{}, fmt.Errorf("invalid changeset ID: %w", err)
+	}
+	return h.changesetStore.GetByID(ctx, orgID, sessionID, id)
+}
+
 type publishActionTxError struct {
 	phase string
 	err   error
@@ -870,6 +884,12 @@ func (h *SessionHandler) Get(w http.ResponseWriter, r *http.Request) {
 	h.enrichSessionLinks(r.Context(), orgID, &run)
 
 	detail := models.SessionDetail{Session: run}
+	changesets, err := h.listChangesetSummaries(r.Context(), orgID, runID)
+	if err != nil {
+		writeError(w, r, http.StatusInternalServerError, "CHANGESETS_FAILED", "failed to load pull requests", err)
+		return
+	}
+	detail.Changesets = changesets
 	if h.repoStore != nil && run.RepositoryID != nil {
 		repo, err := h.repoStore.GetByID(r.Context(), orgID, *run.RepositoryID)
 		if err != nil {
@@ -895,6 +915,136 @@ func (h *SessionHandler) Get(w http.ResponseWriter, r *http.Request) {
 	}
 
 	writeJSON(w, http.StatusOK, models.SingleResponse[models.SessionDetail]{Data: detail})
+}
+
+func (h *SessionHandler) listChangesetSummaries(ctx context.Context, orgID, sessionID uuid.UUID) ([]models.ChangesetSummary, error) {
+	if h.changesetStore == nil {
+		return []models.ChangesetSummary{}, nil
+	}
+	changesets, err := h.changesetStore.ListBySession(ctx, orgID, sessionID)
+	if err != nil {
+		return nil, err
+	}
+	if changesets == nil {
+		changesets = []models.ChangesetSummary{}
+	}
+	if h.pullRequestStore == nil || len(changesets) == 0 {
+		return changesets, nil
+	}
+	prs, err := h.pullRequestStore.ListBySessionChangesets(ctx, orgID, sessionID)
+	if err != nil {
+		return nil, err
+	}
+	for i := range changesets {
+		if pr, ok := prs[changesets[i].ID]; ok {
+			changesets[i].PullRequest = &pr
+		}
+	}
+	return changesets, nil
+}
+
+func (h *SessionHandler) ListChangesets(w http.ResponseWriter, r *http.Request) {
+	orgID := middleware.OrgIDFromContext(r.Context())
+	sessionID, err := uuid.Parse(chi.URLParam(r, "id"))
+	if err != nil {
+		writeError(w, r, http.StatusBadRequest, "INVALID_ID", "invalid session ID")
+		return
+	}
+	if _, err := h.runStore.GetAPIDetailByID(r.Context(), orgID, sessionID); err != nil {
+		writeError(w, r, http.StatusNotFound, "NOT_FOUND", "session not found")
+		return
+	}
+	changesets, err := h.listChangesetSummaries(r.Context(), orgID, sessionID)
+	if err != nil {
+		writeError(w, r, http.StatusInternalServerError, "CHANGESETS_FAILED", "failed to load pull requests", err)
+		return
+	}
+	writeJSON(w, http.StatusOK, models.ListResponse[models.ChangesetSummary]{Data: changesets})
+}
+
+type createChangesetRequest struct {
+	Title     string     `json:"title"`
+	Summary   string     `json:"summary"`
+	StackedOn *uuid.UUID `json:"stacked_on_changeset_id"`
+}
+
+func (h *SessionHandler) CreateChangeset(w http.ResponseWriter, r *http.Request) {
+	orgID := middleware.OrgIDFromContext(r.Context())
+	sessionID, err := uuid.Parse(chi.URLParam(r, "id"))
+	if err != nil {
+		writeError(w, r, http.StatusBadRequest, "INVALID_ID", "invalid session ID")
+		return
+	}
+	var req createChangesetRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, r, http.StatusBadRequest, "INVALID_BODY", "invalid request body")
+		return
+	}
+	req.Title = strings.TrimSpace(req.Title)
+	if req.Title == "" {
+		writeError(w, r, http.StatusBadRequest, "TITLE_REQUIRED", "title is required")
+		return
+	}
+	changeset, err := h.changesetStore.Create(r.Context(), orgID, sessionID, req.Title, strings.TrimSpace(req.Summary), req.StackedOn)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			writeError(w, r, http.StatusNotFound, "NOT_FOUND", "session or parent pull request not found")
+			return
+		}
+		writeError(w, r, http.StatusInternalServerError, "CHANGESET_CREATE_FAILED", "failed to create pull request", err)
+		return
+	}
+	writeJSON(w, http.StatusCreated, models.SingleResponse[models.ChangesetSummary]{Data: changeset.SummaryView()})
+}
+
+type updateChangesetRequest struct {
+	Title   *string `json:"title"`
+	Summary *string `json:"summary"`
+}
+
+func (h *SessionHandler) UpdateChangeset(w http.ResponseWriter, r *http.Request) {
+	orgID := middleware.OrgIDFromContext(r.Context())
+	sessionID, err := uuid.Parse(chi.URLParam(r, "id"))
+	if err != nil {
+		writeError(w, r, http.StatusBadRequest, "INVALID_ID", "invalid session ID")
+		return
+	}
+	changesetID, err := uuid.Parse(chi.URLParam(r, "changeset_id"))
+	if err != nil {
+		writeError(w, r, http.StatusBadRequest, "INVALID_CHANGESET_ID", "invalid changeset ID")
+		return
+	}
+	var req updateChangesetRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, r, http.StatusBadRequest, "INVALID_BODY", "invalid request body")
+		return
+	}
+	if req.Title == nil && req.Summary == nil {
+		writeError(w, r, http.StatusBadRequest, "NO_CHANGES", "provide a title or summary")
+		return
+	}
+	if req.Title != nil {
+		trimmed := strings.TrimSpace(*req.Title)
+		if trimmed == "" {
+			writeError(w, r, http.StatusBadRequest, "TITLE_REQUIRED", "title cannot be empty")
+			return
+		}
+		req.Title = &trimmed
+	}
+	if req.Summary != nil {
+		trimmed := strings.TrimSpace(*req.Summary)
+		req.Summary = &trimmed
+	}
+	changeset, err := h.changesetStore.UpdateMetadata(r.Context(), orgID, sessionID, changesetID, req.Title, req.Summary)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			writeError(w, r, http.StatusNotFound, "NOT_FOUND", "pull request not found")
+			return
+		}
+		writeError(w, r, http.StatusInternalServerError, "CHANGESET_UPDATE_FAILED", "failed to update pull request", err)
+		return
+	}
+	writeJSON(w, http.StatusOK, models.SingleResponse[models.ChangesetSummary]{Data: changeset.SummaryView()})
 }
 
 func (h *SessionHandler) attachThreadInboxDeliverySummaries(ctx context.Context, orgID, sessionID uuid.UUID, threads []models.SessionThread) error {
@@ -988,7 +1138,6 @@ func (h *SessionHandler) Update(w http.ResponseWriter, r *http.Request) {
 		writeError(w, r, http.StatusNotFound, "NOT_FOUND", "session not found")
 		return
 	}
-
 	if session.Title != nil && *session.Title == title {
 		writeJSON(w, http.StatusOK, models.SingleResponse[models.Session]{Data: session})
 		return
@@ -1984,7 +2133,18 @@ func (h *SessionHandler) GetPullRequest(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	pr, err := h.pullRequestStore.GetPrimaryBySessionID(r.Context(), orgID, runID)
+	var pr models.PullRequest
+	changesetIDParam := strings.TrimSpace(r.URL.Query().Get("changeset_id"))
+	if changesetIDParam == "" {
+		pr, err = h.pullRequestStore.GetPrimaryBySessionID(r.Context(), orgID, runID)
+	} else {
+		changesetID, parseErr := uuid.Parse(changesetIDParam)
+		if parseErr != nil {
+			writeError(w, r, http.StatusBadRequest, "INVALID_CHANGESET_ID", "invalid changeset ID")
+			return
+		}
+		pr, err = h.pullRequestStore.GetByChangesetID(r.Context(), orgID, runID, changesetID)
+	}
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			writeJSON(w, http.StatusOK, models.SingleResponse[*models.PullRequest]{Data: nil})
@@ -2523,6 +2683,19 @@ func (h *SessionHandler) CreatePR(w http.ResponseWriter, r *http.Request) {
 		writeError(w, r, http.StatusNotFound, "NOT_FOUND", "session not found")
 		return
 	}
+	targetChangeset, err := h.requestedChangeset(r.Context(), orgID, sessionID, r.URL.Query().Get("changeset_id"))
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			writeError(w, r, http.StatusNotFound, "CHANGESET_NOT_FOUND", "pull request target not found")
+		} else {
+			writeError(w, r, http.StatusBadRequest, "INVALID_CHANGESET_ID", "invalid pull request target", err)
+		}
+		return
+	}
+	if !targetChangeset.IsPrimary {
+		writeError(w, r, http.StatusConflict, "CHANGESET_NOT_MATERIALIZED", "this pull request branch must be materialized before it can be created")
+		return
+	}
 
 	if session.SandboxState == models.SandboxStateDestroyed {
 		writeError(w, r, http.StatusGone, "SNAPSHOT_EXPIRED", ghservice.SnapshotExpiredPRMessage)
@@ -2536,17 +2709,24 @@ func (h *SessionHandler) CreatePR(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	switch session.PRCreationState {
-	case models.PRCreationStateQueued, models.PRCreationStatePushing:
-		writeError(w, r, http.StatusConflict, "PR_IN_FLIGHT", "PR creation already in progress")
-		return
-	case models.PRCreationStateSucceeded:
-		// Succeeded means a PR row should exist; fall through to the
-		// PR_EXISTS check below so the 409 path is consistent.
+	if targetChangeset.IsPrimary {
+		switch session.PRCreationState {
+		case models.PRCreationStateQueued, models.PRCreationStatePushing:
+			writeError(w, r, http.StatusConflict, "PR_IN_FLIGHT", "PR creation already in progress")
+			return
+		case models.PRCreationStateSucceeded:
+			// Succeeded means a PR row should exist; fall through to the
+			// PR_EXISTS check below so the 409 path is consistent.
+		}
 	}
 
 	// Check whether a PR already exists for this session.
-	_, prErr := h.pullRequestStore.GetPrimaryBySessionID(r.Context(), orgID, sessionID)
+	var prErr error
+	if targetChangeset.IsPrimary {
+		_, prErr = h.pullRequestStore.GetPrimaryBySessionID(r.Context(), orgID, sessionID)
+	} else {
+		_, prErr = h.pullRequestStore.GetByChangesetID(r.Context(), orgID, sessionID, targetChangeset.ID)
+	}
 	if prErr == nil {
 		writeError(w, r, http.StatusConflict, "PR_EXISTS", "a pull request already exists for this session")
 		return
@@ -2555,7 +2735,7 @@ func (h *SessionHandler) CreatePR(w http.ResponseWriter, r *http.Request) {
 		writeError(w, r, http.StatusInternalServerError, "INTERNAL_ERROR", "failed to check for existing PR", prErr)
 		return
 	}
-	if session.PRCreationState == models.PRCreationStateSucceeded {
+	if targetChangeset.PRCreationState == models.PRCreationStateSucceeded || (targetChangeset.IsPrimary && session.PRCreationState == models.PRCreationStateSucceeded) {
 		writeError(w, r, http.StatusConflict, "PR_ALREADY_CREATED", "PR creation already completed for this session")
 		return
 	}
@@ -2617,11 +2797,7 @@ func (h *SessionHandler) CreatePR(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	changesetID, err := h.primaryChangesetID(r.Context(), orgID, sessionID)
-	if err != nil {
-		writeError(w, r, http.StatusInternalServerError, "PRIMARY_CHANGESET_FAILED", "failed to resolve the primary pull request target", err)
-		return
-	}
+	changesetID := targetChangeset.ID
 	payload := map[string]any{
 		"session_id":     sessionID.String(),
 		"changeset_id":   changesetID.String(),

--- a/internal/api/handlers/sessions_test.go
+++ b/internal/api/handlers/sessions_test.go
@@ -7261,6 +7261,72 @@ func TestSessionHandler_CreatePR_Success(t *testing.T) {
 	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
 }
 
+func TestSessionHandler_CreatePR_ChangesetLookupErrorReturns500(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "pgxmock pool should be created")
+	defer mock.Close()
+
+	now := time.Now()
+	snapshotKey := "snap-TestSessionHandler_CreatePR_ChangesetLookupError"
+	orgID := uuid.New()
+	sessionID := uuid.New()
+	issueID := uuid.New()
+	handler := newSessionHandler(t, mock)
+	handler.SetChangesetStore(db.NewSessionChangesetStore(mock))
+
+	diff := "--- a/file.go\n+++ b/file.go\n@@ -1 +1 @@\n-old\n+new"
+
+	mock.ExpectQuery("SELECT .+ FROM sessions").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(
+			addSessionRow(pgxmock.NewRows(sessionColumns),
+				sessionID, issueID, orgID, "claude_code", "completed", "semi", "low",
+				nil, nil, nil, nil,
+				nil, false, &now, &now, nil,
+				nil, nil, nil, false,
+				nil, nil, nil, nil, &diff,
+				nil, nil, nil, nil,
+				nil, nil,
+				nil,
+				nil, 0, now, "none", &snapshotKey,
+				nil,
+				nil,
+				nil,
+				nil,
+				nil,
+				nil,
+				nil, nil,
+				nil,
+				"idle",
+				(*string)(nil),
+				nil,
+				now,
+			),
+		)
+
+	// The primary changeset lookup fails with a transient (non-ErrNoRows)
+	// error; the handler must surface it as a 500, not a 400.
+	mock.ExpectQuery("SELECT .+ FROM session_changesets").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnError(fmt.Errorf("connection reset by peer"))
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/sessions/"+sessionID.String()+"/pr", nil)
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("id", sessionID.String())
+	ctx := context.WithValue(req.Context(), chi.RouteCtxKey, rctx)
+	ctx = middleware.WithOrgID(ctx, orgID)
+	req = req.WithContext(ctx)
+	w := httptest.NewRecorder()
+
+	handler.CreatePR(w, req)
+
+	require.Equal(t, http.StatusInternalServerError, w.Code, "transient changeset lookup failure should be a 500, not a 400: %s", w.Body.String())
+	require.Contains(t, w.Body.String(), "CHANGESET_LOOKUP_FAILED", "response should use the server-error envelope")
+	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
+}
+
 func TestSessionHandler_CreatePR_WithMergeWhenReadyIncludesIntentInJobPayload(t *testing.T) {
 	t.Parallel()
 

--- a/internal/api/handlers/sessions_test.go
+++ b/internal/api/handlers/sessions_test.go
@@ -2332,6 +2332,30 @@ func TestSessionHandler_GetPullRequest_Success(t *testing.T) {
 	require.NoError(t, mock.ExpectationsWereMet())
 }
 
+func TestSessionHandler_GetPullRequest_TargetsChangeset(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "should create pgxmock pool without error")
+	defer mock.Close()
+	orgID, sessionID, changesetID := uuid.New(), uuid.New(), uuid.New()
+	mock.ExpectQuery(`SELECT .+ FROM pull_requests.+changeset_id =`).
+		WithArgs(orgID, sessionID, changesetID).
+		WillReturnError(pgx.ErrNoRows)
+	handler := newSessionHandler(t, mock)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/sessions/"+sessionID.String()+"/pr?changeset_id="+changesetID.String(), nil)
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("id", sessionID.String())
+	ctx := context.WithValue(req.Context(), chi.RouteCtxKey, rctx)
+	req = req.WithContext(middleware.WithOrgID(ctx, orgID))
+	w := httptest.NewRecorder()
+
+	handler.GetPullRequest(w, req)
+	require.Equal(t, http.StatusOK, w.Code, "missing PR in selected changeset should be a normal empty state")
+	require.JSONEq(t, `{"data":null}`, w.Body.String(), "response should preserve the nullable PR contract")
+	require.NoError(t, mock.ExpectationsWereMet(), "selected changeset lookup should be tenant and session scoped")
+}
+
 func TestSessionHandler_GetPullRequest_NoPR_Returns200Null(t *testing.T) {
 	t.Parallel()
 

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -1232,6 +1232,7 @@ func NewRouter(cfg *config.Config, pool *pgxpool.Pool, logger zerolog.Logger, se
 				r.Get("/api/v1/sessions", sessionHandler.List)
 				r.Get("/api/v1/sessions/counts", sessionHandler.Counts)
 				r.Get("/api/v1/sessions/{id}", sessionHandler.Get)
+				r.Get("/api/v1/sessions/{id}/changesets", sessionHandler.ListChangesets)
 				r.Get("/api/v1/sessions/{id}/diff", sessionHandler.GetDiff)
 				r.Patch("/api/v1/sessions/{id}", sessionHandler.Update)
 				r.Get("/api/v1/sessions/{id}/logs", sessionHandler.GetLogs)
@@ -1465,6 +1466,8 @@ func NewRouter(cfg *config.Config, pool *pgxpool.Pool, logger zerolog.Logger, se
 				r.Use(middleware.RequireRole("admin", "builder", "member"))
 
 				r.Post("/api/v1/sessions/{id}/pr", sessionHandler.CreatePR)
+				r.Post("/api/v1/sessions/{id}/changesets", sessionHandler.CreateChangeset)
+				r.Patch("/api/v1/sessions/{id}/changesets/{changeset_id}", sessionHandler.UpdateChangeset)
 				r.Post("/api/v1/sessions/{id}/branch", sessionHandler.CreateBranch)
 				r.Post("/api/v1/sessions/{id}/pr/push", sessionHandler.PushChangesToPR)
 			})

--- a/internal/db/pull_request_store_test.go
+++ b/internal/db/pull_request_store_test.go
@@ -125,6 +125,35 @@ func TestPullRequestStoreGetByChangesetIDScopesByOrgAndSession(t *testing.T) {
 	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
 }
 
+func TestPullRequestStoreBatchListBySessionChangesetsPreservesEveryPR(t *testing.T) {
+	t.Parallel()
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "test should create the database mock")
+	defer mock.Close()
+	orgID, sessionOne, sessionTwo := uuid.New(), uuid.New(), uuid.New()
+	changesetOne, changesetTwo := uuid.New(), uuid.New()
+	now := time.Now()
+	columns := append([]string{}, prColumns[:2]...)
+	columns = append(columns, "changeset_id")
+	columns = append(columns, prColumns[2:]...)
+	row := func(prID, sessionID, changesetID uuid.UUID) []any {
+		values := newPRRow(prID, sessionID, orgID, now)
+		return append(values[:2], append([]any{&changesetID}, values[2:]...)...)
+	}
+	prOne, prTwo := uuid.New(), uuid.New()
+	mock.ExpectQuery(`(?s)SELECT DISTINCT ON \(changeset_id\).+FROM pull_requests.+session_id = ANY`).
+		WithArgs(orgID, []uuid.UUID{sessionOne, sessionTwo}).
+		WillReturnRows(pgxmock.NewRows(columns).
+			AddRow(row(prOne, sessionOne, changesetOne)...).
+			AddRow(row(prTwo, sessionTwo, changesetTwo)...))
+
+	actual, err := NewPullRequestStore(mock).BatchListBySessionChangesets(context.Background(), orgID, []uuid.UUID{sessionOne, sessionTwo})
+	require.NoError(t, err, "batch changeset hydration should succeed")
+	require.Equal(t, prOne, actual[sessionOne][changesetOne].ID, "first session should retain its changeset PR")
+	require.Equal(t, prTwo, actual[sessionTwo][changesetTwo].ID, "second session should retain its changeset PR")
+	require.NoError(t, mock.ExpectationsWereMet(), "batch lookup should use one tenant-scoped query")
+}
+
 func TestPullRequestStore_GetByID_Success(t *testing.T) {
 	t.Parallel()
 	mock, err := pgxmock.NewPool()

--- a/internal/db/pull_requests.go
+++ b/internal/db/pull_requests.go
@@ -377,6 +377,47 @@ func (s *PullRequestStore) BatchGetBySessionIDs(ctx context.Context, orgID uuid.
 	return s.BatchGetPrimaryBySessionIDs(ctx, orgID, sessionIDs)
 }
 
+// ListBySessionChangesets returns at most one current PR for each changeset.
+// Legacy PRs without a changeset remain represented by the primary changeset
+// through the migration backfill, so callers never need a second join path.
+func (s *PullRequestStore) ListBySessionChangesets(ctx context.Context, orgID, sessionID uuid.UUID) (map[uuid.UUID]models.PullRequest, error) {
+	batched, err := s.BatchListBySessionChangesets(ctx, orgID, []uuid.UUID{sessionID})
+	if err != nil {
+		return nil, err
+	}
+	return batched[sessionID], nil
+}
+
+// BatchListBySessionChangesets preserves every changeset PR while hydrating
+// multiple sessions. The outer key is session ID and the inner key is
+// changeset ID; unlike the scalar compatibility helper, no PR is collapsed.
+func (s *PullRequestStore) BatchListBySessionChangesets(ctx context.Context, orgID uuid.UUID, sessionIDs []uuid.UUID) (map[uuid.UUID]map[uuid.UUID]models.PullRequest, error) {
+	if len(sessionIDs) == 0 {
+		return map[uuid.UUID]map[uuid.UUID]models.PullRequest{}, nil
+	}
+	rows, err := s.db.Query(ctx, `SELECT DISTINCT ON (changeset_id) `+prSelectColumns+`
+		FROM pull_requests
+		WHERE org_id = @org_id AND session_id = ANY(@session_ids) AND changeset_id IS NOT NULL
+		ORDER BY changeset_id, created_at DESC, id DESC`, pgx.NamedArgs{"org_id": orgID, "session_ids": sessionIDs})
+	if err != nil {
+		return nil, fmt.Errorf("list pull requests by changeset: %w", err)
+	}
+	prs, err := pgx.CollectRows(rows, pgx.RowToStructByNameLax[models.PullRequest])
+	if err != nil {
+		return nil, fmt.Errorf("collect pull requests by changeset: %w", err)
+	}
+	result := make(map[uuid.UUID]map[uuid.UUID]models.PullRequest)
+	for _, pr := range prs {
+		if pr.SessionID != nil && pr.ChangesetID != nil {
+			if result[*pr.SessionID] == nil {
+				result[*pr.SessionID] = make(map[uuid.UUID]models.PullRequest)
+			}
+			result[*pr.SessionID][*pr.ChangesetID] = pr
+		}
+	}
+	return result, nil
+}
+
 // BatchGetPrimaryBySessionIDs returns only the PR attached to each session's
 // primary changeset. It is the scalar compatibility read for session list and
 // sidebar surfaces; Phase 2 multi-PR hydration must use a changeset-keyed read.

--- a/internal/db/session_changesets.go
+++ b/internal/db/session_changesets.go
@@ -2,10 +2,12 @@ package db
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
 
 	"github.com/assembledhq/143/internal/models"
 )
@@ -22,6 +24,86 @@ const changesetSelectColumns = `id, org_id, session_id, is_primary, order_index,
 	status, target_branch, base_branch, working_branch, stacked_on_changeset_id, head_sha,
 	expected_remote_head_sha, base_head_sha, pr_creation_state, pr_creation_error, created_at, updated_at`
 
+const changesetSummaryColumns = `id, is_primary, order_index, title, summary, status, target_branch,
+	base_branch, working_branch, stacked_on_changeset_id, head_sha, created_at, updated_at`
+
+func (s *SessionChangesetStore) ListBySession(ctx context.Context, orgID, sessionID uuid.UUID) ([]models.ChangesetSummary, error) {
+	rows, err := s.db.Query(ctx, `SELECT `+changesetSummaryColumns+`
+		FROM session_changesets
+		WHERE org_id = @org_id AND session_id = @session_id
+		ORDER BY order_index, created_at, id`, pgx.NamedArgs{"org_id": orgID, "session_id": sessionID})
+	if err != nil {
+		return nil, fmt.Errorf("list session changesets: %w", err)
+	}
+	changesets, err := pgx.CollectRows(rows, pgx.RowToStructByNameLax[models.ChangesetSummary])
+	if err != nil {
+		return nil, fmt.Errorf("collect session changesets: %w", err)
+	}
+	return changesets, nil
+}
+
+func (s *SessionChangesetStore) Create(ctx context.Context, orgID, sessionID uuid.UUID, title, summary string, stackedOn *uuid.UUID) (models.SessionChangeset, error) {
+	const maxOrderAttempts = 3
+	for attempt := 0; attempt < maxOrderAttempts; attempt++ {
+		changeset, err := s.create(ctx, orgID, sessionID, title, summary, stackedOn)
+		if err == nil {
+			return changeset, nil
+		}
+		if !isChangesetOrderConflict(err) || attempt == maxOrderAttempts-1 {
+			return models.SessionChangeset{}, err
+		}
+	}
+	return models.SessionChangeset{}, fmt.Errorf("create session changeset: exhausted order allocation retries")
+}
+
+func (s *SessionChangesetStore) create(ctx context.Context, orgID, sessionID uuid.UUID, title, summary string, stackedOn *uuid.UUID) (models.SessionChangeset, error) {
+	rows, err := s.db.Query(ctx, `INSERT INTO session_changesets (
+		org_id, session_id, order_index, title, summary, target_branch, base_branch, stacked_on_changeset_id
+	)
+	SELECT @org_id, @session_id,
+		COALESCE((SELECT MAX(order_index) + 1 FROM session_changesets WHERE org_id = @org_id AND session_id = @session_id), 0),
+		@title, @summary, primary_cs.target_branch,
+		CASE WHEN parent.id IS NULL THEN primary_cs.target_branch ELSE COALESCE(parent.working_branch, parent.base_branch) END,
+		parent.id
+	FROM session_changesets primary_cs
+	LEFT JOIN session_changesets parent ON parent.org_id = @org_id AND parent.session_id = @session_id AND parent.id = @stacked_on
+	WHERE primary_cs.org_id = @org_id AND primary_cs.session_id = @session_id AND primary_cs.is_primary
+	  AND (@stacked_on::uuid IS NULL OR parent.id IS NOT NULL)
+	RETURNING `+changesetSelectColumns, pgx.NamedArgs{
+		"org_id": orgID, "session_id": sessionID, "title": title, "summary": summary, "stacked_on": stackedOn,
+	})
+	if err != nil {
+		return models.SessionChangeset{}, fmt.Errorf("create session changeset: %w", err)
+	}
+	changeset, err := pgx.CollectOneRow(rows, pgx.RowToStructByName[models.SessionChangeset])
+	if err != nil {
+		return models.SessionChangeset{}, fmt.Errorf("create session changeset: %w", err)
+	}
+	return changeset, nil
+}
+
+func isChangesetOrderConflict(err error) bool {
+	var pgErr *pgconn.PgError
+	return errors.As(err, &pgErr) && pgErr.Code == "23505" && pgErr.ConstraintName == "session_changesets_org_id_session_id_order_index_key"
+}
+
+func (s *SessionChangesetStore) UpdateMetadata(ctx context.Context, orgID, sessionID, changesetID uuid.UUID, title, summary *string) (models.SessionChangeset, error) {
+	rows, err := s.db.Query(ctx, `UPDATE session_changesets SET
+		title = COALESCE(@title, title), summary = COALESCE(@summary, summary), updated_at = now()
+		WHERE org_id = @org_id AND session_id = @session_id AND id = @changeset_id
+		RETURNING `+changesetSelectColumns, pgx.NamedArgs{
+		"org_id": orgID, "session_id": sessionID, "changeset_id": changesetID, "title": title, "summary": summary,
+	})
+	if err != nil {
+		return models.SessionChangeset{}, fmt.Errorf("update session changeset: %w", err)
+	}
+	changeset, err := pgx.CollectOneRow(rows, pgx.RowToStructByName[models.SessionChangeset])
+	if err != nil {
+		return models.SessionChangeset{}, fmt.Errorf("update session changeset: %w", err)
+	}
+	return changeset, nil
+}
+
 func (s *SessionChangesetStore) GetPrimary(ctx context.Context, orgID, sessionID uuid.UUID) (models.SessionChangeset, error) {
 	rows, err := s.db.Query(ctx, `SELECT `+changesetSelectColumns+`
 		FROM session_changesets
@@ -31,6 +113,18 @@ func (s *SessionChangesetStore) GetPrimary(ctx context.Context, orgID, sessionID
 	})
 	if err != nil {
 		return models.SessionChangeset{}, fmt.Errorf("get primary session changeset: %w", err)
+	}
+	return pgx.CollectOneRow(rows, pgx.RowToStructByName[models.SessionChangeset])
+}
+
+func (s *SessionChangesetStore) GetByID(ctx context.Context, orgID, sessionID, changesetID uuid.UUID) (models.SessionChangeset, error) {
+	rows, err := s.db.Query(ctx, `SELECT `+changesetSelectColumns+`
+		FROM session_changesets
+		WHERE org_id = @org_id AND session_id = @session_id AND id = @changeset_id`, pgx.NamedArgs{
+		"org_id": orgID, "session_id": sessionID, "changeset_id": changesetID,
+	})
+	if err != nil {
+		return models.SessionChangeset{}, fmt.Errorf("get session changeset: %w", err)
 	}
 	return pgx.CollectOneRow(rows, pgx.RowToStructByName[models.SessionChangeset])
 }

--- a/internal/db/session_changesets_test.go
+++ b/internal/db/session_changesets_test.go
@@ -6,6 +6,8 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/pashagolub/pgxmock/v4"
 	"github.com/stretchr/testify/require"
 
@@ -103,4 +105,73 @@ func TestSessionChangesetStoreRecordPushedHeadUpdatesBothSHAFields(t *testing.T)
 	err = NewSessionChangesetStore(mock).RecordPushedHead(context.Background(), uuid.New(), uuid.New(), uuid.New(), "head-sha")
 	require.NoError(t, err, "successful platform push should update local and expected remote heads")
 	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
+}
+
+func TestSessionChangesetStoreListBySessionScopesAndOrders(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "test should create database mock")
+	t.Cleanup(mock.Close)
+	orgID, sessionID := uuid.New(), uuid.New()
+	changesetID := uuid.New()
+	now := time.Now().UTC()
+	mock.ExpectQuery(`SELECT .+ FROM session_changesets.+WHERE org_id = .+ AND session_id = .+ORDER BY order_index`).
+		WithArgs(orgID, sessionID).
+		WillReturnRows(pgxmock.NewRows([]string{
+			"id", "is_primary", "order_index", "title", "summary", "status", "target_branch",
+			"base_branch", "working_branch", "stacked_on_changeset_id", "head_sha", "created_at", "updated_at",
+		}).AddRow(changesetID, true, 0, "Foundation", "Base work", "planned", "main", "main", nil, nil, nil, now, now))
+
+	actual, err := NewSessionChangesetStore(mock).ListBySession(context.Background(), orgID, sessionID)
+	require.NoError(t, err, "listing changesets should succeed")
+	require.Equal(t, []models.ChangesetSummary{{
+		ID: changesetID, IsPrimary: true, OrderIndex: 0, Title: "Foundation", Summary: "Base work",
+		Status: models.ChangesetStatusPlanned, TargetBranch: "main", BaseBranch: "main", CreatedAt: now, UpdatedAt: now,
+	}}, actual, "changesets should retain their stable order and complete summary")
+	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
+}
+
+func TestSessionChangesetStoreUpdateMetadataScopesByTenantAndParent(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "test should create database mock")
+	t.Cleanup(mock.Close)
+	orgID, sessionID, changesetID := uuid.New(), uuid.New(), uuid.New()
+	title := "API integration"
+	mock.ExpectQuery(`UPDATE session_changesets SET.+WHERE org_id = .+ AND session_id = .+ AND id = .+RETURNING`).
+		WithArgs(&title, (*string)(nil), orgID, sessionID, changesetID).
+		WillReturnError(pgx.ErrNoRows)
+
+	_, err = NewSessionChangesetStore(mock).UpdateMetadata(context.Background(), orgID, sessionID, changesetID, &title, nil)
+	require.ErrorIs(t, err, pgx.ErrNoRows, "missing tenant-scoped changeset should remain distinguishable")
+	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
+}
+
+func TestSessionChangesetStoreCreateRetriesConcurrentOrderConflict(t *testing.T) {
+	t.Parallel()
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "test should create database mock")
+	t.Cleanup(mock.Close)
+	orgID, sessionID, changesetID := uuid.New(), uuid.New(), uuid.New()
+	now := time.Now().UTC()
+	query := `INSERT INTO session_changesets .+ RETURNING`
+	args := []any{orgID, sessionID, "API", "Endpoints", (*uuid.UUID)(nil)}
+	mock.ExpectQuery(query).WithArgs(args...).WillReturnError(&pgconn.PgError{
+		Code: "23505", ConstraintName: "session_changesets_org_id_session_id_order_index_key",
+	})
+	mock.ExpectQuery(query).WithArgs(args...).WillReturnRows(pgxmock.NewRows([]string{
+		"id", "org_id", "session_id", "is_primary", "order_index", "title", "summary",
+		"status", "target_branch", "base_branch", "working_branch", "stacked_on_changeset_id",
+		"head_sha", "expected_remote_head_sha", "base_head_sha", "pr_creation_state", "pr_creation_error", "created_at", "updated_at",
+	}).AddRow(
+		changesetID, orgID, sessionID, false, 1, "API", "Endpoints", models.ChangesetStatusPlanned,
+		"main", "main", nil, nil, nil, nil, nil, models.PRCreationStateIdle, nil, now, now,
+	))
+
+	actual, err := NewSessionChangesetStore(mock).Create(context.Background(), orgID, sessionID, "API", "Endpoints", nil)
+	require.NoError(t, err, "concurrent order allocation should retry")
+	require.Equal(t, changesetID, actual.ID, "retry should return the created changeset")
+	require.NoError(t, mock.ExpectationsWereMet(), "create should retry only the order uniqueness conflict")
 }

--- a/internal/models/changeset.go
+++ b/internal/models/changeset.go
@@ -56,3 +56,30 @@ type SessionChangeset struct {
 	CreatedAt             time.Time       `db:"created_at" json:"created_at"`
 	UpdatedAt             time.Time       `db:"updated_at" json:"updated_at"`
 }
+
+// ChangesetSummary is the stable session-detail and list representation. It
+// deliberately omits internal push coordination and PR creation error fields.
+type ChangesetSummary struct {
+	ID                   uuid.UUID       `db:"id" json:"id"`
+	IsPrimary            bool            `db:"is_primary" json:"is_primary"`
+	OrderIndex           int             `db:"order_index" json:"order_index"`
+	Title                string          `db:"title" json:"title"`
+	Summary              string          `db:"summary" json:"summary"`
+	Status               ChangesetStatus `db:"status" json:"status"`
+	TargetBranch         string          `db:"target_branch" json:"target_branch"`
+	BaseBranch           string          `db:"base_branch" json:"base_branch"`
+	WorkingBranch        *string         `db:"working_branch" json:"working_branch,omitempty"`
+	StackedOnChangesetID *uuid.UUID      `db:"stacked_on_changeset_id" json:"stacked_on_changeset_id,omitempty"`
+	HeadSHA              *string         `db:"head_sha" json:"head_sha,omitempty"`
+	PullRequest          *PullRequest    `json:"pull_request,omitempty"`
+	CreatedAt            time.Time       `db:"created_at" json:"created_at"`
+	UpdatedAt            time.Time       `db:"updated_at" json:"updated_at"`
+}
+
+func (c SessionChangeset) SummaryView() ChangesetSummary {
+	return ChangesetSummary{
+		ID: c.ID, IsPrimary: c.IsPrimary, OrderIndex: c.OrderIndex, Title: c.Title, Summary: c.Summary,
+		Status: c.Status, TargetBranch: c.TargetBranch, BaseBranch: c.BaseBranch, WorkingBranch: c.WorkingBranch,
+		StackedOnChangesetID: c.StackedOnChangesetID, HeadSHA: c.HeadSHA, CreatedAt: c.CreatedAt, UpdatedAt: c.UpdatedAt,
+	}
+}

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -433,8 +433,9 @@ type Session struct {
 // SessionDetail is the API response for a single session, enriched with threads.
 type SessionDetail struct {
 	Session
-	RepositoryFullName *string         `json:"repository_full_name,omitempty"`
-	Threads            []SessionThread `json:"threads"`
+	RepositoryFullName *string            `json:"repository_full_name,omitempty"`
+	Threads            []SessionThread    `json:"threads"`
+	Changesets         []ChangesetSummary `json:"changesets"`
 }
 
 // SessionDiff is the large, lazily-loaded diff payload for a session. It is


### PR DESCRIPTION
## Summary

Phase 2 had reliability and workflow gaps in session changesets: ordering could collide under concurrent writes, and the UI/back/forward navigation could inconsistently hydrate PR-native changeset selection. This change makes changeset ordering concurrency-safe (with a targeted retry for the specific order-index conflict) and hardens the session detail UI so selection stays consistent across navigation and correctly preserves the legacy one-PR layout.

## Changes

- Backend: make changeset ordering deterministic and concurrency-safe in `internal/db/session_changesets*`, including a targeted retry when the unique `order_index` constraint is hit.
- Backend/API: add/adjust session changesets handlers and contracts (`internal/api/handlers/sessions*.go`, `session_changesets_test.go`) for tenant scoping, missing-session behavior, validation, and normalization.
- Frontend: add direct HTTP handler coverage + session detail UI changeset selection synchronization and PR hydration (`session-detail-content.tsx`, overview/state tests).
- Frontend: ensure one-PR sessions keep the legacy full-page layout, while multi-PR sessions show the selector/panels and correctly handle unavailable branch actions; add back/forward sync tests.

## Validation

- Backend DB/handler tests (`go test ./...` via existing suite in `internal/api/handlers/*` and `internal/db/*`)
- `go vet`
- Schema/store tenancy lints
- Frontend typecheck
- 171 focused frontend tests
- One-PR and multi-PR full-page tests (including selection metadata, PR lookup, and unavailable branch actions)
- ESLint
- `git diff --check`

[143.dev](https://143.dev) | [session bddbbf84](https://143.dev/sessions/bddbbf84-0293-47de-aafc-e39622767b4c)

<!-- 143 readiness -->
**143 readiness:** not available for this revision.

Preview: https://143.dev/previews/github/assembledhq/143/pull/1808?launch=1