### PR TITLE
Collapse repo-context-switcher slot when switcher is absent to remove extra navbar bar

### DIFF
--- a/frontend/src/components/authenticated-layout.test.tsx
+++ b/frontend/src/components/authenticated-layout.test.tsx
@@ -368,6 +368,7 @@ describe("AuthenticatedLayout", () => {
     await waitFor(() => {
       expect(container.querySelector('[data-testid="repo-context-switcher"]')).not.toBeInTheDocument();
     });
+    expect(screen.getByTestId("repo-context-switcher-slot")).toHaveClass("empty:hidden");
   });
 
   // --- New nav header tests ---

--- a/frontend/src/components/authenticated-layout.tsx
+++ b/frontend/src/components/authenticated-layout.tsx
@@ -272,7 +272,10 @@ function SidebarBody({
       </nav>
 
       {/* Repo context switcher */}
-      <div className="relative px-2 pb-1 border-t border-sidebar-border/70 pt-2">
+      <div
+        data-testid="repo-context-switcher-slot"
+        className="relative px-2 pb-1 border-t border-sidebar-border/70 pt-2 empty:hidden"
+      >
         <RepoContextSwitcher />
       </div>
 


### PR DESCRIPTION
## Summary

An empty repo-context-switcher container was still rendering a bottom bar in the authenticated navbar for single-repo orgs, creating unnecessary UI chrome. This change conditionally collapses that slot via Tailwind’s `empty:hidden`, while keeping the switcher visible for multi-repository organizations.

## Changes

- Updated `authenticated-layout.tsx` to wrap `RepoContextSwitcher` in a slot `<div>` that hides itself when empty (`empty:hidden`)
- Added a regression assertion in `authenticated-layout.test.tsx` to verify the slot collapses when `repo-context-switcher` is not rendered
- Included a stable `data-testid` (`repo-context-switcher-slot`) to make the UI behavior testable

## Validation

- `git diff --check` passes
- Test run: N/A (frontend dependencies not installed; `vitest: not found`)

[143.dev](https://143.dev) | [session 9fc9ee6e](https://143.dev/sessions/9fc9ee6e-bb11-4720-b138-b7282eed6bf4)

<!-- 143 readiness -->
**143 readiness:** not available for this revision.

Preview: https://143.dev/previews/github/assembledhq/143/pull/1810?launch=1