### PR TITLE
Implement Phase 2 core for agent-native preview verification in MCP and CLI

### DIFF
--- a/docs/design/future/115-agent-native-preview-verification.md
+++ b/docs/design/future/115-agent-native-preview-verification.md
@@ -1,10 +1,10 @@
 # Design: Agent-Native Preview Verification
 
-> **Status:** In progress — Phase 1 complete | **Last reviewed:** 2026-07-11
+> **Status:** In progress — Phase 1 complete; Phase 2 core implemented | **Last reviewed:** 2026-07-12
 
 ## Implementation Status
 
-Phase 1 now provides the durable session-owned browser
+Phase 1 and the Phase 2 core now provide the durable session-owned browser
 foundation and native `ensure`/`observe`/`act` path: persisted browser identity and storage state,
 compatible-origin restoration, bounded accessibility/DOM and console-cursor
 observations, serialized structured actions, configured path enforcement,
@@ -12,10 +12,15 @@ worker routing, explicit session-token preview capabilities, artifact-backed
 screenshots, implicit session targeting, an audited human/agent control lease,
 and a preview panel that watches and controls the same worker-owned browser
 context used by the agent. Active-action fencing prevents human takeover and
-agent input from racing.
+agent input from racing. MCP observations carry compact semantic context plus
+native PNG image content; CLI-only runtimes retain a private workspace-file
+fallback, and durable artifact references remain authoritative evidence.
 
-Native model image attachments, verification evidence, and automatic
-diff-aware verification remain future phases.
+Adapter-by-adapter native-image compatibility still needs rollout validation;
+CLI-only runtimes can use the implemented workspace fallback. Verification
+evidence and automatic diff-aware verification remain future phases. Repository
+`browser` and `verification` policy parsing, defaults, and validation are already
+implemented as groundwork for Phase 3.
 
 ## Summary
 
@@ -78,7 +83,7 @@ available for diagnostics and privileged workflows.
 
 ## P0 Feature Set
 
-### 1. Session-Owned Preview And Browser Context
+### 1. Session-Owned Preview And Browser Context — Implemented
 
 Add `preview ensure` as the idempotent agent entry point. It resolves the
 current session, starts configured services when necessary, waits for the
@@ -103,7 +108,7 @@ Playwright/CDP bridge may be added for complex scripted flows, but it must bind
 to the same authorized browser context and remain unreachable outside the
 session tool path.
 
-### 2. Unified Observe And Act
+### 2. Unified Observe And Act — Core Implemented
 
 Add a high-signal `preview observe` operation. One response includes:
 
@@ -134,6 +139,13 @@ selector match count, browser error, screenshot, and relevant console messages.
 Existing `screenshot`, `inspect`, `interact`, and `console` commands remain
 available as lower-level and compatibility operations.
 
+The MCP transport now returns the bounded observation as text followed by a
+validated native `image/png` content block. It removes inline base64 from the
+text block, retains durable artifact metadata, rejects missing, malformed,
+unsupported, or oversized image payloads, and preserves `--output` as a private
+workspace-file fallback. Confirming native image consumption in each supported
+coding-agent adapter remains rollout work.
+
 ### 3. Automatic Verification Loop
 
 The orchestrator should trigger preview verification after an agent changes
@@ -155,7 +167,7 @@ This loop belongs in orchestration policy rather than prompt text alone. Agent
 guidance still explains the tools, but the runtime is responsible for deciding
 that verification is due and making image observations available to the model.
 
-### 4. Shared Human/Agent Browser
+### 4. Shared Human/Agent Browser — Implemented
 
 The existing preview UI should render the session browser's live page rather
 than opening an unrelated browser context. It exposes three explicit states:
@@ -281,8 +293,9 @@ New responsibilities should remain separated:
 - The preview manager owns app runtime lifecycle and config application.
 - A browser-session service owns persistent browser context and control leases.
 - `PreviewInspector` owns bounded observation and actions.
-- The agent runtime adapter turns screenshot artifacts into native model image
-  content.
+- The preview tool transport turns screenshot bytes into native MCP image
+  content while preserving artifact references and the CLI workspace fallback;
+  coding-agent adapters consume the richest form they support.
 - A verification coordinator owns trigger policy, bounded retries, plans, and
   evidence records.
 
@@ -309,30 +322,36 @@ New responsibilities should remain separated:
 
 ### Phase 0: Repair The Existing Agent Path
 
-- Separate public and internal API base URLs and normalize legacy environment
+- **Complete:** Separate public and internal API base URLs and normalize legacy environment
   values.
-- Default preview tools to `143_SESSION_ID` and inject it in every coding-agent
+- **Complete:** Default preview tools to `143_SESSION_ID` and inject it in every coding-agent
   launch path.
-- Add explicit preview capability mappings and same-session authorization tests.
-- Verify sandbox-token access to preview endpoints and artifact downloads.
+- **Complete:** Add explicit preview capability mappings and same-session authorization tests.
+- **Complete:** Verify sandbox-token access to preview endpoints and artifact downloads.
 
 ### Phase 1: Persistent Session Browser
 
-- Add `preview ensure` and session-default targeting.
-- Introduce browser-context identity and persistence across update modes.
-- Route the preview UI and agent inspector to the same context.
-- Add control-lease APIs and cross-session isolation tests.
+- **Complete:** Add `preview ensure` and session-default targeting.
+- **Complete:** Introduce browser-context identity and persistence across update modes.
+- **Complete:** Route the preview UI and agent inspector to the same context.
+- **Complete:** Add control-lease APIs and cross-session isolation tests.
 
 ### Phase 2: Native Observe/Act
 
-- Add combined observation responses and actionable step failures.
-- Store screenshots and provide workspace paths plus signed URLs.
-- Update coding-agent adapters to attach images natively to model turns.
-- Add semantic actions and optional platform-owned Playwright/CDP attachment.
+- **Complete:** Add combined observation responses and actionable step failures.
+- **Complete:** Store screenshots and provide workspace paths plus signed URLs.
+- **Complete:** Return screenshots as native MCP image content while preserving
+  the workspace-file fallback for CLI-only runtimes.
+- **Complete:** Add semantic actions against the platform-owned shared browser
+  context. A general-purpose Playwright/CDP attachment remains optional and is
+  deferred until a workflow requires it.
+- **Pending rollout validation:** Confirm which supported coding-agent adapters
+  consume MCP image blocks directly and document/use the workspace fallback for
+  adapters that do not.
 
 ### Phase 3: Automatic Verification And Evidence
 
-- Parse and validate `.143/config.json` browser/verification policy.
+- **Complete:** Parse and validate `.143/config.json` browser/verification policy.
 - Add diff-aware verification triggers, bounded retries, and smoke plans.
 - Persist verification summaries and artifact references.
 - Render evidence and handoff state in session/preview UI.
@@ -359,6 +378,13 @@ The P0 product is complete when a fresh coding-agent session can:
 7. Fail closed when the sandbox token targets another session or navigation
    leaves the preview origin.
 
+Criteria 1, 2, 3, 5, and 7 are implemented at the platform/tool-contract
+level. Criterion 4 has the required observe/act/update and diagnostic
+primitives, but automatic failure-driven re-verification remains Phase 3.
+Criterion 6 remains pending durable verification-run evidence. Criterion 2
+also retains adapter rollout validation before native image consumption can be
+claimed uniformly across every supported coding-agent runtime.
+
 ## Deferred Features
 
 - General computer/desktop use outside web previews.
@@ -370,8 +396,9 @@ The P0 product is complete when a fresh coding-agent session can:
 
 ## Open Questions
 
-- Which coding-agent adapters can consume tool-returned image content directly,
-  and which require workspace-file fallback?
+- Which coding-agent adapters consume MCP image content directly in production,
+  and which should be configured or guided to use the implemented workspace-file
+  fallback?
 - Should a full preview recycle restore cookies only, or cookies plus local and
   session storage?
 - How should the verifier identify user-facing diffs in repositories with

--- a/internal/cli/preview_tools.go
+++ b/internal/cli/preview_tools.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -1024,10 +1025,38 @@ func writePreviewObservationImage(result *mcp.ToolCallResult, output string, act
 	return textResult
 }
 
-func writePrivatePreviewImage(path string, png []byte) error {
-	file, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o600)
+func writePrivatePreviewImage(path string, png []byte) (returnErr error) {
+	workspace, err := os.Getwd()
 	if err != nil {
-		return err
+		return fmt.Errorf("resolve workspace: %w", err)
+	}
+	absPath, err := filepath.Abs(path)
+	if err != nil {
+		return fmt.Errorf("resolve output path: %w", err)
+	}
+	relPath, err := filepath.Rel(workspace, absPath)
+	if err != nil {
+		return fmt.Errorf("resolve workspace-relative output path: %w", err)
+	}
+	if !filepath.IsLocal(relPath) {
+		return fmt.Errorf("output path must stay within the current workspace")
+	}
+	root, err := os.OpenRoot(workspace)
+	if err != nil {
+		return fmt.Errorf("open workspace root: %w", err)
+	}
+	defer func() {
+		if err := root.Close(); err != nil {
+			if returnErr == nil {
+				returnErr = fmt.Errorf("close workspace root: %w", err)
+			} else {
+				returnErr = fmt.Errorf("%w (close workspace root: %v)", returnErr, err)
+			}
+		}
+	}()
+	file, err := root.OpenFile(relPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o600)
+	if err != nil {
+		return fmt.Errorf("open workspace output: %w", err)
 	}
 	if err := file.Chmod(0o600); err != nil {
 		closeErr := file.Close()

--- a/internal/cli/preview_tools.go
+++ b/internal/cli/preview_tools.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"bytes"
 	"context"
 	"encoding/base64"
 	"encoding/json"
@@ -13,6 +14,13 @@ import (
 
 	"github.com/assembledhq/143/internal/services/mcp"
 )
+
+const (
+	previewImageMIMEType = "image/png"
+	maxPreviewImageBytes = 10 << 20
+)
+
+var pngSignature = []byte{'\x89', 'P', 'N', 'G', '\r', '\n', '\x1a', '\n'}
 
 // previewToolExecutor implements the platform preview tools as thin
 // client-side wrappers over /api/v1. Session-preview actions target
@@ -139,7 +147,7 @@ func (e *previewToolExecutor) tools() []mcp.Tool {
 			"viewport_h":         {Type: "number", Description: "Viewport height"},
 			"full_page":          {Type: "boolean", Description: "Capture the full page"},
 			"max_semantic_bytes": {Type: "number", Description: "Bound semantic and DOM output size"},
-			"inline_base64":      {Type: "boolean", Description: "Include screenshot bytes; defaults false"},
+			"inline_base64":      {Type: "boolean", Description: "Ignored; screenshot bytes are always captured, returned as native image content, and stripped from the text block"},
 			"output":             {Type: "string", Description: "Write screenshot PNG to this workspace path"},
 			"console_cursor":     {Type: "number", Description: "Return console messages after this cursor"},
 		})},
@@ -150,7 +158,7 @@ func (e *previewToolExecutor) tools() []mcp.Tool {
 			"viewport_w":         {Type: "number", Description: "Final observation viewport width"},
 			"viewport_h":         {Type: "number", Description: "Final observation viewport height"},
 			"max_semantic_bytes": {Type: "number", Description: "Bound semantic and DOM output size"},
-			"inline_base64":      {Type: "boolean", Description: "Include screenshot bytes; defaults false"},
+			"inline_base64":      {Type: "boolean", Description: "Ignored; screenshot bytes are always captured, returned as native image content, and stripped from the text block"},
 			"output":             {Type: "string", Description: "Write the final screenshot PNG to this workspace path"},
 			"console_cursor":     {Type: "number", Description: "Return console messages after this cursor"},
 		})},
@@ -925,9 +933,10 @@ func (e *previewToolExecutor) observe(ctx context.Context, args json.RawMessage)
 	delete(params, "session_id")
 	delete(params, "preview_id")
 	delete(params, "output")
-	if strings.TrimSpace(output) != "" {
-		params["inline_base64"] = true
-	}
+	// Native MCP image content and the workspace fallback both require the
+	// screenshot bytes for this call. The bytes are removed from the text block
+	// before it is returned, so they do not inflate the model transcript.
+	params["inline_base64"] = true
 	result := e.postPreviewTarget(ctx, target, "observe", params, "preview observe failed")
 	return writePreviewObservationImage(result, output, false)
 }
@@ -951,15 +960,13 @@ func (e *previewToolExecutor) act(ctx context.Context, args json.RawMessage) *mc
 	delete(params, "session_id")
 	delete(params, "preview_id")
 	delete(params, "output")
-	if strings.TrimSpace(output) != "" {
-		params["inline_base64"] = true
-	}
+	params["inline_base64"] = true
 	result := e.postPreviewTarget(ctx, target, "act", params, "preview act failed")
 	return writePreviewObservationImage(result, output, true)
 }
 
 func writePreviewObservationImage(result *mcp.ToolCallResult, output string, act bool) *mcp.ToolCallResult {
-	if result == nil || result.IsError || strings.TrimSpace(output) == "" {
+	if result == nil || result.IsError {
 		return result
 	}
 	var payload map[string]any
@@ -970,21 +977,76 @@ func writePreviewObservationImage(result *mcp.ToolCallResult, output string, act
 	if act {
 		observation, _ = payload["observation"].(map[string]any)
 	}
+	if observation == nil {
+		return mcp.ErrorResult("preview response did not include an observation")
+	}
 	screenshot, _ := observation["screenshot"].(map[string]any)
+	if screenshot == nil {
+		return mcp.ErrorResult("preview response did not include a screenshot")
+	}
 	encoded, _ := screenshot["png_base64"].(string)
 	if encoded == "" {
 		return mcp.ErrorResult("preview response did not include screenshot bytes")
+	}
+	mimeType := previewImageMIMEType
+	if value, _ := screenshot["mime_type"].(string); strings.TrimSpace(value) != "" {
+		mimeType = strings.ToLower(strings.TrimSpace(value))
+	}
+	if mimeType != previewImageMIMEType {
+		return mcp.ErrorResult(fmt.Sprintf("preview screenshot has unsupported MIME type %q", mimeType))
+	}
+	if len(encoded) > base64.StdEncoding.EncodedLen(maxPreviewImageBytes) {
+		return mcp.ErrorResult(fmt.Sprintf("preview screenshot exceeds %d byte limit", maxPreviewImageBytes))
 	}
 	png, err := base64.StdEncoding.DecodeString(encoded)
 	if err != nil {
 		return mcp.ErrorResult(fmt.Sprintf("decode preview screenshot: %s", err))
 	}
-	if err := os.WriteFile(output, png, 0o600); err != nil {
-		return mcp.ErrorResult(fmt.Sprintf("write preview screenshot: %s", err))
+	if len(png) > maxPreviewImageBytes {
+		return mcp.ErrorResult(fmt.Sprintf("preview screenshot exceeds %d byte limit", maxPreviewImageBytes))
+	}
+	if !bytes.HasPrefix(png, pngSignature) {
+		return mcp.ErrorResult("preview screenshot is not a valid PNG")
 	}
 	delete(screenshot, "png_base64")
-	observation["workspace_path"] = output
-	return jsonResult(payload)
+	delete(screenshot, "mime_type")
+
+	if strings.TrimSpace(output) != "" {
+		if err := writePrivatePreviewImage(output, png); err != nil {
+			return mcp.ErrorResult(fmt.Sprintf("write preview screenshot: %s", err))
+		}
+		observation["workspace_path"] = output
+		return jsonResult(payload)
+	}
+
+	textResult := jsonResult(payload)
+	textResult.Content = append(textResult.Content, mcp.ImageContent(encoded, previewImageMIMEType))
+	return textResult
+}
+
+func writePrivatePreviewImage(path string, png []byte) error {
+	file, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o600)
+	if err != nil {
+		return err
+	}
+	if err := file.Chmod(0o600); err != nil {
+		closeErr := file.Close()
+		if closeErr != nil {
+			return fmt.Errorf("set permissions: %w (close: %v)", err, closeErr)
+		}
+		return fmt.Errorf("set permissions: %w", err)
+	}
+	if _, err := file.Write(png); err != nil {
+		closeErr := file.Close()
+		if closeErr != nil {
+			return fmt.Errorf("write image: %w (close: %v)", err, closeErr)
+		}
+		return fmt.Errorf("write image: %w", err)
+	}
+	if err := file.Close(); err != nil {
+		return fmt.Errorf("close image: %w", err)
+	}
+	return nil
 }
 
 func (e *previewToolExecutor) multiViewport(ctx context.Context, args json.RawMessage) *mcp.ToolCallResult {

--- a/internal/cli/preview_tools_test.go
+++ b/internal/cli/preview_tools_test.go
@@ -290,6 +290,42 @@ func TestPreviewToolExecutor_ObserveRejectsOversizedImageBeforeDecode(t *testing
 	require.Contains(t, firstText(result), "exceeds", "oversized image error should identify the size limit")
 }
 
+func TestWritePrivatePreviewImageRejectsWorkspaceEscape(t *testing.T) {
+	t.Parallel()
+
+	workspace, err := os.Getwd()
+	require.NoError(t, err, "test should resolve the current workspace")
+	outsideDir, err := os.MkdirTemp(filepath.Dir(workspace), "preview-output-outside-")
+	require.NoError(t, err, "outside output directory should be created")
+	defer func() { require.NoError(t, os.RemoveAll(outsideDir), "outside output directory should be removed") }()
+
+	insideDir, err := os.MkdirTemp(".", "preview-output-links-")
+	require.NoError(t, err, "workspace symlink directory should be created")
+	defer func() { require.NoError(t, os.RemoveAll(insideDir), "workspace symlink directory should be removed") }()
+	symlinkPath := filepath.Join(insideDir, "outside")
+	require.NoError(t, os.Symlink(outsideDir, symlinkPath), "workspace symlink should target the outside directory")
+
+	tests := []struct {
+		name string
+		path string
+	}{
+		{name: "parent traversal", path: filepath.Join("..", filepath.Base(outsideDir), "image.png")},
+		{name: "absolute outside path", path: filepath.Join(outsideDir, "image.png")},
+		{name: "symlink escape", path: filepath.Join(symlinkPath, "image.png")},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := writePrivatePreviewImage(tt.path, pngSignature)
+			require.Error(t, err, "workspace image writer should reject paths that escape the workspace")
+			_, statErr := os.Stat(filepath.Join(outsideDir, "image.png"))
+			require.ErrorIs(t, statErr, os.ErrNotExist, "rejected output should not create a file outside the workspace")
+		})
+	}
+}
+
 func TestPreviewToolExecutor_ScreenshotTargetsPreviewID(t *testing.T) {
 	t.Parallel()
 

--- a/internal/cli/preview_tools_test.go
+++ b/internal/cli/preview_tools_test.go
@@ -2,11 +2,13 @@ package cli
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync/atomic"
 	"testing"
 
@@ -129,7 +131,7 @@ func TestPreviewToolExecutor_ObserveUsesUnifiedEndpoint(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		gotPath = r.URL.Path
 		w.Header().Set("Content-Type", "application/json")
-		_, err := w.Write([]byte(`{"data":{"url":"https://preview.test/app","semantic_state":"[]","ready":true}}`))
+		_, err := w.Write([]byte(`{"data":{"url":"https://preview.test/app","semantic_state":"[]","screenshot":{"png_base64":"iVBORw0KGgo="},"ready":true}}`))
 		require.NoError(t, err, "observe response should write")
 	}))
 	defer server.Close()
@@ -137,6 +139,10 @@ func TestPreviewToolExecutor_ObserveUsesUnifiedEndpoint(t *testing.T) {
 	result := executor.observe(context.Background(), mustJSON(map[string]any{"session_id": "session-1", "path": "/app", "include_dom": true}))
 	require.False(t, result.IsError, "observe should succeed")
 	require.Equal(t, "/api/v1/sessions/session-1/preview/observe", gotPath, "observe should use the unified endpoint")
+	require.Len(t, result.Content, 2, "observe should return semantic context and a native image")
+	require.Equal(t, "image", result.Content[1].Type, "second observation block should be a native image")
+	require.Equal(t, "image/png", result.Content[1].MIMEType, "native observation should identify PNG content")
+	require.NotContains(t, firstText(result), "png_base64", "semantic context should not duplicate native image bytes")
 }
 
 func TestPreviewToolExecutor_InternalObserveUsesSessionScopedEndpoint(t *testing.T) {
@@ -145,7 +151,7 @@ func TestPreviewToolExecutor_InternalObserveUsesSessionScopedEndpoint(t *testing
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		gotPath = r.URL.Path
 		w.Header().Set("Content-Type", "application/json")
-		_, err := w.Write([]byte(`{"data":{"ready":true}}`))
+		_, err := w.Write([]byte(`{"data":{"screenshot":{"png_base64":"iVBORw0KGgo="},"ready":true}}`))
 		require.NoError(t, err, "internal observe response should write")
 	}))
 	defer server.Close()
@@ -162,7 +168,7 @@ func TestPreviewToolExecutor_ActUsesUnifiedEndpoint(t *testing.T) {
 		require.Equal(t, "/api/v1/sessions/session-1/preview/act", r.URL.Path, "act should use the unified endpoint")
 		require.NoError(t, json.NewDecoder(r.Body).Decode(&gotBody), "act body should decode")
 		w.Header().Set("Content-Type", "application/json")
-		_, err := w.Write([]byte(`{"data":{"interaction":{"steps":[{"success":true}]},"observation":{"ready":true}}}`))
+		_, err := w.Write([]byte(`{"data":{"interaction":{"steps":[{"success":true}]},"observation":{"screenshot":{"png_base64":"iVBORw0KGgo=","artifact":{"id":"artifact-1"}},"ready":true}}}`))
 		require.NoError(t, err, "act response should write")
 	}))
 	defer server.Close()
@@ -172,6 +178,10 @@ func TestPreviewToolExecutor_ActUsesUnifiedEndpoint(t *testing.T) {
 	steps, ok := gotBody["steps"].([]any)
 	require.True(t, ok, "act should send steps as a JSON array")
 	require.Len(t, steps, 1, "act should send every requested step")
+	require.Len(t, result.Content, 2, "act should return its structured result and final native image")
+	require.Equal(t, "image", result.Content[1].Type, "act should extract the image from its nested observation")
+	require.Contains(t, firstText(result), "artifact-1", "act should retain durable screenshot artifact metadata")
+	require.NotContains(t, firstText(result), "png_base64", "act text should not duplicate native image bytes")
 }
 
 func TestPreviewToolExecutor_RequestHandoffUsesSessionScopedEndpoint(t *testing.T) {
@@ -207,9 +217,10 @@ func TestPreviewToolExecutor_ObserveWritesWorkspaceImage(t *testing.T) {
 	require.NoError(t, err, "repository-backed image directory should be created")
 	defer func() { require.NoError(t, os.RemoveAll(dir), "image test directory should be removed") }()
 	output := filepath.Join(dir, "observation.png")
+	require.NoError(t, os.WriteFile(output, []byte("old"), 0o644), "workspace fixture should begin with broad permissions")
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		_, writeErr := w.Write([]byte(`{"data":{"screenshot":{"png_base64":"cG5n"},"ready":true}}`))
+		_, writeErr := w.Write([]byte(`{"data":{"screenshot":{"png_base64":"iVBORw0KGgo="},"ready":true}}`))
 		require.NoError(t, writeErr, "observe response should write")
 	}))
 	defer server.Close()
@@ -218,9 +229,65 @@ func TestPreviewToolExecutor_ObserveWritesWorkspaceImage(t *testing.T) {
 	require.False(t, result.IsError, "observe with output should succeed")
 	actual, err := os.ReadFile(output)
 	require.NoError(t, err, "workspace screenshot should be readable")
-	require.Equal(t, []byte("png"), actual, "workspace screenshot should contain decoded PNG bytes")
+	require.Equal(t, pngSignature, actual, "workspace screenshot should contain decoded PNG bytes")
 	require.NotContains(t, firstText(result), "png_base64", "workspace output should remove base64 from the CLI transcript")
 	require.Contains(t, firstText(result), output, "workspace output should report the written path")
+	info, err := os.Stat(output)
+	require.NoError(t, err, "workspace screenshot metadata should be readable")
+	require.Equal(t, os.FileMode(0o600), info.Mode().Perm(), "workspace screenshot should remain private")
+	require.Len(t, result.Content, 1, "workspace fallback should not duplicate the screenshot as native image content")
+}
+
+func TestPreviewToolExecutor_ObserveRejectsInvalidImages(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		screenshot    string
+		expectedError string
+	}{
+		{name: "missing screenshot", screenshot: ``, expectedError: "did not include a screenshot"},
+		{name: "missing bytes", screenshot: `"screenshot":{}`, expectedError: "did not include screenshot bytes"},
+		{name: "invalid base64", screenshot: `"screenshot":{"png_base64":"%%%"}`, expectedError: "decode preview screenshot"},
+		{name: "invalid png", screenshot: `"screenshot":{"png_base64":"bm90LXBuZw=="}`, expectedError: "not a valid PNG"},
+		{name: "wrong mime", screenshot: `"screenshot":{"png_base64":"iVBORw0KGgo=","mime_type":"image/jpeg"}`, expectedError: "unsupported MIME type"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			body := `{"data":{"ready":true` + func() string {
+				if tt.screenshot == "" {
+					return ""
+				}
+				return "," + tt.screenshot
+			}() + `}}`
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				_, err := w.Write([]byte(body))
+				require.NoError(t, err, "invalid image fixture should write")
+			}))
+			defer server.Close()
+
+			executor := &previewToolExecutor{client: NewClient(Config{ServerURL: server.URL, Token: "token"})}
+			result := executor.observe(context.Background(), mustJSON(map[string]any{"session_id": "session-1"}))
+			require.True(t, result.IsError, "invalid screenshot should fail the observation")
+			require.Contains(t, firstText(result), tt.expectedError, "observation error should identify the image problem")
+		})
+	}
+}
+
+func TestPreviewToolExecutor_ObserveRejectsOversizedImageBeforeDecode(t *testing.T) {
+	t.Parallel()
+
+	encoded := strings.Repeat("A", base64.StdEncoding.EncodedLen(maxPreviewImageBytes)+1)
+	result := writePreviewObservationImage(jsonResult(map[string]any{
+		"screenshot": map[string]any{"png_base64": encoded},
+	}), "", false)
+
+	require.True(t, result.IsError, "oversized native image should be rejected")
+	require.Contains(t, firstText(result), "exceeds", "oversized image error should identify the size limit")
 }
 
 func TestPreviewToolExecutor_ScreenshotTargetsPreviewID(t *testing.T) {

--- a/internal/services/mcp/capability_filter_test.go
+++ b/internal/services/mcp/capability_filter_test.go
@@ -10,7 +10,8 @@ import (
 )
 
 type staticToolSource struct {
-	tools []Tool
+	tools  []Tool
+	result *ToolCallResult
 }
 
 func (s staticToolSource) ListTools() []Tool {
@@ -18,6 +19,9 @@ func (s staticToolSource) ListTools() []Tool {
 }
 
 func (s staticToolSource) CallTool(ctx context.Context, name string, args json.RawMessage) *ToolCallResult {
+	if s.result != nil {
+		return s.result
+	}
 	return TextResult("called " + name)
 }
 

--- a/internal/services/mcp/cli.go
+++ b/internal/services/mcp/cli.go
@@ -149,7 +149,9 @@ func RunCLI(ctx context.Context, tr ToolSource, args []string, stdout, stderr io
 
 	// Print output.
 	for _, c := range result.Content {
-		fmt.Fprintln(stdout, c.Text)
+		if c.Type == "text" {
+			fmt.Fprintln(stdout, c.Text)
+		}
 	}
 
 	return 0

--- a/internal/services/mcp/cli_test.go
+++ b/internal/services/mcp/cli_test.go
@@ -264,6 +264,24 @@ func TestRunCLI_UnknownUnderscoreNameIsUnknownNamespace(t *testing.T) {
 	require.NotContains(t, stderr.String(), "no longer supported", "unknown underscore-name should not falsely claim the command was deprecated")
 }
 
+func TestRunCLI_PrintsOnlyTextContent(t *testing.T) {
+	t.Parallel()
+
+	source := staticToolSource{
+		tools: []Tool{{Name: "preview_observe", InputSchema: ToolSchema{Type: "object"}}},
+		result: &ToolCallResult{Content: []ToolContent{
+			{Type: "text", Text: `{"ready":true}`},
+			ImageContent("iVBORw0KGgo=", "image/png"),
+		}},
+	}
+	var stdout, stderr bytes.Buffer
+	code := RunCLI(context.Background(), source, []string{"preview", "observe"}, &stdout, &stderr)
+
+	require.Equal(t, 0, code, "CLI should succeed for compound tool content")
+	require.Equal(t, "{\"ready\":true}\n", stdout.String(), "CLI should print semantic text without image bytes or blank lines")
+	require.Empty(t, stderr.String(), "successful compound output should not write stderr")
+}
+
 func TestRunCLI_ParsingErrorsAreSelfCorrecting(t *testing.T) {
 	t.Parallel()
 

--- a/internal/services/mcp/protocol.go
+++ b/internal/services/mcp/protocol.go
@@ -130,8 +130,10 @@ type ToolCallResult struct {
 
 // ToolContent is a single content block in a tool result.
 type ToolContent struct {
-	Type string `json:"type"` // "text"
-	Text string `json:"text"`
+	Type     string `json:"type"` // "text" or "image"
+	Text     string `json:"text,omitempty"`
+	Data     string `json:"data,omitempty"`
+	MIMEType string `json:"mimeType,omitempty"`
 }
 
 // TextResult creates a ToolCallResult with a single text block.
@@ -139,6 +141,12 @@ func TextResult(text string) *ToolCallResult {
 	return &ToolCallResult{
 		Content: []ToolContent{{Type: "text", Text: text}},
 	}
+}
+
+// ImageContent creates an MCP image content block. Data must be base64-encoded
+// image bytes; callers remain responsible for validating the encoded payload.
+func ImageContent(data, mimeType string) ToolContent {
+	return ToolContent{Type: "image", Data: data, MIMEType: mimeType}
 }
 
 // ErrorResult creates a ToolCallResult indicating an error.

--- a/internal/services/mcp/protocol_content_test.go
+++ b/internal/services/mcp/protocol_content_test.go
@@ -1,0 +1,39 @@
+package mcp
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestToolContentJSON(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		content  ToolContent
+		expected string
+	}{
+		{
+			name:     "text omits image fields",
+			content:  ToolContent{Type: "text", Text: "ready"},
+			expected: `{"type":"text","text":"ready"}`,
+		},
+		{
+			name:     "image uses MCP field names",
+			content:  ImageContent("iVBORw0KGgo=", "image/png"),
+			expected: `{"type":"image","data":"iVBORw0KGgo=","mimeType":"image/png"}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			actual, err := json.Marshal(tt.content)
+			require.NoError(t, err, "tool content should serialize")
+			require.JSONEq(t, tt.expected, string(actual), "tool content should match the MCP wire contract")
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Agent-native preview verification was missing Phase 2 core plumbing, creating a reliability gap where MCP observation payloads and CLI image handling could not be validated consistently for downstream model consumption. This change implements the bounded `observe`/`act` core and upgrades the MCP transport to return text plus validated native PNG content, with a workspace-file fallback for CLI-only runtimes.

## Changes

- Implemented Phase 2 core behavior in the preview tooling path, including a higher-signal `preview observe` response contract suitable for verification workflows.
- Updated MCP transport to return bounded observation text plus a validated native `image/png` block; removed inline base64 from the text payload and enforced payload size/type correctness.
- Preserved `--output` semantics via a private workspace-file fallback when native image consumption isn’t available (CLI-only runtimes).
- Strengthened MCP protocol/payload parsing and added/updated tests for capability filtering and protocol content handling to prevent malformed/oversized image payloads from reaching the model.

## Validation

- Ran unit tests covering MCP protocol/content parsing, CLI/MCP integration, and capability filtering:
  - `internal/cli/preview_tools_test.go`
  - `internal/services/mcp/cli_test.go`
  - `internal/services/mcp/protocol_content_test.go`
  - `internal/services/mcp/capability_filter_test.go`
- Verified the updated preview tooling contract matches the Phase 2 core design expectations in `docs/design/future/115-agent-native-preview-verification.md`.

[143.dev](https://143.dev) | [session 8d11d3bb](https://143.dev/sessions/8d11d3bb-9db4-48af-b4b8-c0db73a177c9)

<!-- 143 readiness -->
**143 readiness:** Ready with warnings (workspace revision 14; 7 passed, 1 warnings, 0 blockers).

Preview: https://143.dev/previews/github/assembledhq/143/pull/1812?launch=1