### PR TITLE
Fix data race in preview fakeBrowserSessionStore causing flaky backend tests

### DIFF
--- a/internal/services/preview/browser_session_test.go
+++ b/internal/services/preview/browser_session_test.go
@@ -20,6 +20,8 @@ type fakeBrowserSessionStore struct {
 }
 
 func (s *fakeBrowserSessionStore) GetBySession(context.Context, uuid.UUID, uuid.UUID) (*models.PreviewBrowserSession, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	return s.record, nil
 }
 func (s *fakeBrowserSessionStore) Ensure(_ context.Context, orgID, sessionID, previewID uuid.UUID, contextKey string, viewport models.ViewportSpec) (*models.PreviewBrowserSession, error) {
@@ -35,22 +37,32 @@ func (s *fakeBrowserSessionStore) Ensure(_ context.Context, orgID, sessionID, pr
 	return &copy, nil
 }
 func (s *fakeBrowserSessionStore) GetControl(context.Context, uuid.UUID, uuid.UUID) (*models.PreviewBrowserSession, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	return s.record, nil
 }
 func (s *fakeBrowserSessionStore) RequestHandoff(_ context.Context, _, _ uuid.UUID, reason string) (*models.PreviewBrowserSession, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	s.record.ControlState, s.record.HandoffReason = models.PreviewBrowserControlWaiting, reason
 	return s.record, nil
 }
 func (s *fakeBrowserSessionStore) AcquireHumanControl(_ context.Context, _, _, userID uuid.UUID, duration time.Duration) (*models.PreviewBrowserSession, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	expires := time.Now().Add(duration)
 	s.record.ControlState, s.record.ControlLeaseOwnerID, s.record.ControlLeaseExpiresAt = models.PreviewBrowserControlHuman, &userID, &expires
 	return s.record, nil
 }
 func (s *fakeBrowserSessionStore) ReturnAgentControl(context.Context, uuid.UUID, uuid.UUID, uuid.UUID) (*models.PreviewBrowserSession, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	s.record.ControlState, s.record.ControlLeaseOwnerID, s.record.ControlLeaseExpiresAt = models.PreviewBrowserControlAgent, nil, nil
 	return s.record, nil
 }
 func (s *fakeBrowserSessionStore) BeginAgentAction(_ context.Context, _, _ uuid.UUID, token uuid.UUID, _ time.Duration) (bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	if s.record == nil || s.record.ControlState == "" || s.record.ControlState == models.PreviewBrowserControlAgent {
 		return true, nil
 	}
@@ -60,6 +72,8 @@ func (s *fakeBrowserSessionStore) EndAgentAction(context.Context, uuid.UUID, uui
 	return nil
 }
 func (s *fakeBrowserSessionStore) BeginHumanAction(_ context.Context, _, _, userID, _ uuid.UUID, _ time.Duration) (bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	return s.record != nil && s.record.ControlState == models.PreviewBrowserControlHuman && s.record.ControlLeaseOwnerID != nil && *s.record.ControlLeaseOwnerID == userID, nil
 }
 func (s *fakeBrowserSessionStore) SaveState(_ context.Context, _, _ uuid.UUID, currentURL string, viewport models.ViewportSpec, storage json.RawMessage, cursor int64, observedAt time.Time) error {


### PR DESCRIPTION
## Summary

Fixes a reliability issue where preview backend tests intermittently fail under `-race` due to concurrent access to shared state in `fakeBrowserSessionStore`. The fake store now synchronizes all shared-record reads and mutations with its mutex to prevent races during overlapping `BeginAgentAction`/`Ensure` flows.

## Changes

- Wrapped `fakeBrowserSessionStore` methods that read or mutate the shared `record` (`GetBySession`, `GetControl`, `RequestHandoff`, `AcquireHumanControl`, `ReturnAgentControl`, `BeginAgentAction`, `BeginHumanAction`) with `s.mu.Lock()` / `defer s.mu.Unlock()`
- Ensures the fake store’s behavior remains consistent even when tests trigger concurrent control/ensure operations

## Validation

- `go test -race ./internal/services/preview`
- Re-ran the previously failing serialization test 25 times with `-race`
- `go vet ./internal/services/preview`
- `git diff --check`

[143.dev](https://143.dev) | [session 0807275e](https://143.dev/sessions/0807275e-d80c-494b-9998-3fe8395a2dd2)

<!-- 143 readiness -->
**143 readiness:** not available for this revision.

Preview: https://143.dev/previews/github/assembledhq/143/pull/1813?launch=1