### PR TITLE
Scope preview failures to preview requests

### DIFF
--- a/deploy/Caddyfile
+++ b/deploy/Caddyfile
@@ -45,10 +45,10 @@
 	}
 }
 
-# Preview gateway responses can reflect a single preview, worker, or sandbox
-# becoming unavailable. Do not apply passive 5xx health marking here: the
-# wildcard route has one API gateway upstream, so poisoning it turns one
-# preview failure into a short wildcard-preview outage.
+# Preview data-plane responses can reflect a single preview, worker, or sandbox
+# becoming unavailable. Do not apply passive 5xx health marking to those
+# routes: poisoning the shared API gateway turns one preview failure into a
+# short wildcard-preview or main-app outage.
 (preview_gateway_upstream_defaults) {
 	lb_try_duration 10s
 	lb_try_interval 250ms
@@ -110,6 +110,36 @@ www.{$DOMAIN:143.dev} {
 	# handler with lb_retries 0 and rely on active/passive health checks
 	# alone to keep bad upstreams out of rotation.
 	@safe method GET HEAD OPTIONS
+	@preview_data_plane path /api/v1/sessions/*/preview /api/v1/sessions/*/preview/* /api/v1/previews /api/v1/previews/*
+
+	# Preview endpoints can proxy worker-owned browsers and sandbox runtimes. A
+	# worker timeout may legitimately fail one request; it must not passively
+	# quarantine the shared API upstream and fan out to the rest of the app.
+	# Active /healthz checks still remove an API container that is actually down.
+	handle @preview_data_plane {
+		handle @safe {
+			reverse_proxy {
+				dynamic a {
+					name api
+					port 8080
+					refresh 2s
+				}
+				lb_retries 5
+				import preview_gateway_upstream_defaults
+			}
+		}
+		handle {
+			reverse_proxy {
+				dynamic a {
+					name api
+					port 8080
+					refresh 2s
+				}
+				lb_retries 0
+				import preview_gateway_upstream_defaults
+			}
+		}
+	}
 
 	handle /api/* {
 		handle @safe {

--- a/deploy/deploy_config_test.go
+++ b/deploy/deploy_config_test.go
@@ -213,6 +213,29 @@ func TestPreviewWildcardProxyDoesNotUseMainAppPassiveHealth(t *testing.T) {
 	require.NotContains(t, previewDefaults, "fail_duration 10s", "preview gateway proxying should not fan out one preview failure into a 10s wildcard outage")
 }
 
+func TestPreviewAPIProxyDoesNotUseMainAppPassiveHealth(t *testing.T) {
+	t.Parallel()
+
+	caddyfile, err := os.ReadFile("../deploy/Caddyfile")
+	require.NoError(t, err, "test should read the Caddyfile")
+	caddyText := string(caddyfile)
+
+	// Prefix the bare-domain site with a newline so it cannot match the same
+	// substring inside the preceding www.{$DOMAIN:143.dev} site label.
+	appBlock := extractCaddyBlock(t, caddyText, "\n{$DOMAIN:143.dev}")
+	previewAPIBlock := extractCaddyBlock(t, appBlock, "handle @preview_data_plane")
+	previewDefaults := extractCaddySnippetBlock(t, caddyText, "preview_gateway_upstream_defaults")
+	require.Contains(t, appBlock, "@preview_data_plane path /api/v1/sessions/*/preview /api/v1/sessions/*/preview/* /api/v1/previews /api/v1/previews/*", "main app routing should identify session and branch preview API endpoints")
+	require.Contains(t, previewAPIBlock, "name api", "preview API requests should still route through the API service")
+	require.Contains(t, previewAPIBlock, "port 8080", "preview API requests should use the public API port")
+	require.Contains(t, previewAPIBlock, "lb_retries 5", "safe preview API requests should retain transient retries")
+	require.Contains(t, previewAPIBlock, "lb_retries 0", "mutating preview API requests should not be replayed")
+	require.Equal(t, 2, strings.Count(previewAPIBlock, "import preview_gateway_upstream_defaults"), "both safe and mutating preview API requests should use preview-safe upstream health settings")
+	require.NotContains(t, previewAPIBlock, "import upstream_defaults", "preview API failures must not inherit main app passive health penalties")
+	require.NotContains(t, previewDefaults, "fail_duration", "preview-safe proxying should not quarantine the API after a worker-side preview failure")
+	require.Less(t, strings.Index(appBlock, "handle @preview_data_plane"), strings.Index(appBlock, "handle /api/*"), "preview API routing should run before the general API handler")
+}
+
 func extractCaddySnippetBlock(t *testing.T, caddyText, snippetName string) string {
 	t.Helper()
 


### PR DESCRIPTION
## Summary
- route session and branch preview API traffic through preview-safe upstream health settings
- retain retries for GET/HEAD/OPTIONS and avoid replaying mutating requests
- add deploy configuration coverage for route ordering and health behavior

## Root cause
A failed session preview browser poll returned a proxy error. Caddy's shared main API passive-health rule then marked the only API upstream unhealthy for 10 seconds, causing unrelated session page requests to receive 503 responses.

## Impact
Preview worker or sandbox failures now remain scoped to preview requests. Active `/healthz` checks still remove genuinely unhealthy API containers.

## Validation
- `go test ./deploy`
- `go vet ./deploy`
- `git diff --check`