### PR TITLE
Fix mobile automations row overflow by keeping side action compact

### DIFF
--- a/frontend/src/app/(dashboard)/automations/page.test.tsx
+++ b/frontend/src/app/(dashboard)/automations/page.test.tsx
@@ -179,6 +179,14 @@ describe("AutomationsPage", () => {
     });
     expect(menuButtons.length).toBeGreaterThan(0);
     expect(menuButtons[0]).toHaveClass("shrink-0");
+    const mobileMenuButton = menuButtons.find((button) =>
+      button.closest('[data-slot="resource-row"]'),
+    );
+    expect(mobileMenuButton).toBeTruthy();
+    expect(mobileMenuButton?.closest('[data-slot="resource-row-actions"]')).not.toHaveClass(
+      "w-full",
+      "ml-7",
+    );
 
     // Computed via the same helper so the assertion is independent of the host
     // timezone (the fixture's next_run_at is a UTC instant).

--- a/frontend/src/app/(dashboard)/automations/page.tsx
+++ b/frontend/src/app/(dashboard)/automations/page.tsx
@@ -536,6 +536,7 @@ function AutomationMobileRow({ automation, canManage }: { automation: Automation
         </span>
       )}
       actions={<AutomationActions automation={automation} canManage={canManage} />}
+      actionLayout="side"
     />
   );
 }

--- a/frontend/src/components/resource-row.test.tsx
+++ b/frontend/src/components/resource-row.test.tsx
@@ -27,4 +27,21 @@ describe("ResourceRow", () => {
     expect(screen.getByTestId("row")).toHaveClass("bg-accent/55");
     expect(screen.getByTestId("row")).toHaveAttribute("data-selected", "true");
   });
+
+  it("keeps a compact side action in the primary mobile row", () => {
+    render(
+      <ResourceRow
+        title="Automation"
+        actions={<button type="button">More options</button>}
+        actionLayout="side"
+        data-testid="row"
+      />,
+    );
+
+    expect(screen.getByTestId("row")).not.toHaveClass("flex-wrap");
+    expect(screen.getByRole("button", { name: "More options" }).parentElement).not.toHaveClass(
+      "w-full",
+      "ml-7",
+    );
+  });
 });

--- a/frontend/src/components/resource-row.tsx
+++ b/frontend/src/components/resource-row.tsx
@@ -9,16 +9,18 @@ type ResourceRowProps = Omit<HTMLAttributes<HTMLDivElement>, "title"> & {
   status?: ReactNode;
   detail?: ReactNode;
   actions?: ReactNode;
+  actionLayout?: "wrap" | "side";
   selected?: boolean;
 };
 
-export function ResourceRow({ leading, title, metadata, status, detail, actions, selected = false, className, ...props }: ResourceRowProps) {
+export function ResourceRow({ leading, title, metadata, status, detail, actions, actionLayout = "wrap", selected = false, className, ...props }: ResourceRowProps) {
   return (
     <div
       data-slot="resource-row"
       data-selected={selected || undefined}
       className={cn(
-        "group/resource-row relative flex min-w-0 flex-wrap items-start gap-3 px-3.5 py-3 type-dense transition-colors duration-[175ms] hover:bg-accent/25 data-[selected=true]:bg-accent/55 sm:flex-nowrap",
+        "group/resource-row relative flex min-w-0 items-start gap-3 px-3.5 py-3 type-dense transition-colors duration-[175ms] hover:bg-accent/25 data-[selected=true]:bg-accent/55",
+        actionLayout === "wrap" && "flex-wrap sm:flex-nowrap",
         selected && "bg-accent/55 before:absolute before:inset-y-2 before:left-0 before:w-0.5 before:rounded-full before:bg-primary",
         className,
       )}
@@ -33,7 +35,17 @@ export function ResourceRow({ leading, title, metadata, status, detail, actions,
         {metadata ? <div className="mt-0.5 truncate text-muted-foreground">{metadata}</div> : null}
         {detail ? <div className="mt-1.5 text-muted-foreground">{detail}</div> : null}
       </div>
-      {actions ? <div className="ml-7 w-full shrink-0 self-center sm:ml-0 sm:w-auto">{actions}</div> : null}
+      {actions ? (
+        <div
+          data-slot="resource-row-actions"
+          className={cn(
+            "shrink-0 self-center",
+            actionLayout === "wrap" && "ml-7 w-full sm:ml-0 sm:w-auto",
+          )}
+        >
+          {actions}
+        </div>
+      ) : null}
     </div>
   );
 }


### PR DESCRIPTION
## Summary

Mobile users couldn’t access the automations “more options” reliably because the action area expanded into a full-width/wrongly-offset row, causing overflow and awkward spacing. This change adds an explicit `ResourceRow` `actionLayout="side"` mode so the three-dot action stays beside the content (preserving the 44px touch target) instead of wrapping like the desktop layout.

## Changes

- Added `actionLayout?: "wrap" | "side"` to `ResourceRow` and updated layout styling to control wrapping/spacing.
- Updated `AutomationMobileRow` to pass `actionLayout="side"` so mobile action menus remain compact and aligned.
- Strengthened `ResourceRow` and `AutomationsPage` tests to assert the mobile row does **not** get `w-full/ml-7` action styling and does not wrap.

## Validation

- `pnpm vitest` (9 focused tests)  
- ESLint on touched files passed  
- `git diff --check` passed

[143.dev](https://143.dev) | [session 8f27ba8b](https://143.dev/sessions/8f27ba8b-2fdd-4ece-aad3-cc39aa001a16)

<!-- 143 readiness -->
**143 readiness:** not available for this revision.

Preview: https://143.dev/previews/github/assembledhq/143/pull/1821?launch=1