### PR TITLE
Implement shared Phase 3 preview verification turn hook and evidence/attempt tagging

### DIFF
--- a/docs/design/future/115-agent-native-preview-verification.md
+++ b/docs/design/future/115-agent-native-preview-verification.md
@@ -1,6 +1,6 @@
 # Design: Agent-Native Preview Verification
 
-> **Status:** In progress — Phases 1–2 complete; Phase 3 evidence core implemented | **Last reviewed:** 2026-07-13
+> **Status:** In progress — Phases 1–2 complete; Phase 3 evidence core and shared turn hook implemented | **Last reviewed:** 2026-07-14
 
 ## Implementation Status
 
@@ -19,9 +19,11 @@ fallback, and durable artifact references remain authoritative evidence.
 Adapter-by-adapter native-image compatibility still needs rollout validation;
 CLI-only runtimes can use the implemented workspace fallback. Verification
 evidence now has a durable revision-keyed run model, a bounded coordinator,
-diff-aware smoke planning, and a session preview summary surface. Wiring the
-coordinator into every agent adapter's successful-turn lifecycle remains rollout
-work. Repository
+diff-aware smoke planning, and a session preview summary surface. Successful
+initial and continuation turns now share one adapter-independent verification
+hook, so every supported adapter has the same integration seam. Binding that
+hook to the worker-local coordinator, preview lifecycle, and fix callback remains
+rollout work. Repository
 `browser` and `verification` policy parsing, defaults, and validation are already
 implemented as groundwork for Phase 3.
 
@@ -360,8 +362,10 @@ New responsibilities should remain separated:
 - **Complete:** Persist revision-keyed verification summaries, ordered action outcomes,
   console counts, and artifact references.
 - **Complete:** Render the latest evidence and handoff result in the session preview UI.
-- **Pending rollout wiring:** Invoke the coordinator from successful agent turns for each
-  supported adapter and supply the adapter-specific fix-and-resume callback.
+- **Complete:** Invoke one shared verification hook from successful initial and
+  continuation turns, covering every supported adapter without branching.
+- **Pending rollout wiring:** Bind the shared hook to the worker-local coordinator and
+  preview ensure/update path, and supply the adapter-specific fix-and-resume callback.
 
 ### Phase 4: Quality Improvements
 
@@ -388,7 +392,7 @@ The P0 product is complete when a fresh coding-agent session can:
 Criteria 1, 2, 3, 5, and 7 are implemented at the platform/tool-contract
 level. Criteria 4 and 6 now have the bounded retry coordinator, durable
 verification-run evidence, and UI summary contracts; production completion
-still requires the pending successful-turn adapter wiring described in Phase 3. Criterion 2
+still requires the pending worker-local coordinator binding described in Phase 3. Criterion 2
 also retains adapter rollout validation before native image consumption can be
 claimed uniformly across every supported coding-agent runtime.
 

--- a/frontend/src/lib/preview-types.ts
+++ b/frontend/src/lib/preview-types.ts
@@ -424,6 +424,7 @@ export interface PreviewVerificationRun {
   plan: Array<{ path: string; viewport: { width: number; height: number } }>;
   steps: Array<{
     index: number;
+    attempt?: number;
     path: string;
     viewport: { width: number; height: number };
     outcome: string;

--- a/internal/models/preview_verification.go
+++ b/internal/models/preview_verification.go
@@ -52,6 +52,7 @@ type PreviewVerificationPlanStep struct {
 
 type PreviewVerificationStep struct {
 	Index        int              `json:"index"`
+	Attempt      int              `json:"attempt"`
 	Path         string           `json:"path"`
 	Viewport     ViewportSpec     `json:"viewport"`
 	Outcome      string           `json:"outcome"`

--- a/internal/services/agent/orchestrator.go
+++ b/internal/services/agent/orchestrator.go
@@ -584,6 +584,24 @@ type EvalBootstrapLookup interface {
 	GetBySessionThread(ctx context.Context, orgID, sessionID, threadID uuid.UUID) (models.EvalBootstrapRun, error)
 }
 
+// SuccessfulTurnVerification describes the adapter-independent output of a
+// completed coding turn. Preview verification is deliberately attached here,
+// rather than to individual adapters, so credential retries and resume
+// fallbacks cannot bypass it.
+type SuccessfulTurnVerification struct {
+	Session           *models.Session
+	Sandbox           *Sandbox
+	Result            *AgentResult
+	WorkspaceRevision int64
+	Diff              string
+}
+
+// SuccessfulTurnVerifier runs bounded, evidence-producing verification after
+// a successful turn has been durably persisted.
+type SuccessfulTurnVerifier interface {
+	VerifySuccessfulTurn(ctx context.Context, input SuccessfulTurnVerification) error
+}
+
 // Orchestrator coordinates end-to-end agent execution: sandbox lifecycle,
 // agent invocation, log streaming, result handling, and follow-up job enqueuing.
 type Orchestrator struct {
@@ -627,6 +645,7 @@ type Orchestrator struct {
 	sandboxAuth                SandboxAuthServer  // can be nil — paired with identityResolver
 	users                      UserLookup         // can be nil — needed for App-token Co-authored-by trailer
 	evalBootstraps             EvalBootstrapLookup
+	successfulTurnVerifier     SuccessfulTurnVerifier
 	internalAPIURL             string
 	internalAPISecret          string
 	logger                     zerolog.Logger
@@ -1034,14 +1053,15 @@ type OrchestratorConfig struct {
 	// Users looks up the triggering user record for the App-token
 	// Co-authored-by trailer. Required when IdentityResolver is set and
 	// the org has any user-triggered sessions.
-	Users             UserLookup
-	EvalBootstraps    EvalBootstrapLookup
-	InternalAPIURL    string
-	InternalAPISecret string
-	NodeID            string
-	IsDraining        func() bool
-	Logger            zerolog.Logger
-	MaxConcurrent     int
+	Users                  UserLookup
+	EvalBootstraps         EvalBootstrapLookup
+	SuccessfulTurnVerifier SuccessfulTurnVerifier // optional — automatic preview verification
+	InternalAPIURL         string
+	InternalAPISecret      string
+	NodeID                 string
+	IsDraining             func() bool
+	Logger                 zerolog.Logger
+	MaxConcurrent          int
 }
 
 type sandboxGitHubAuthState struct {
@@ -1113,6 +1133,7 @@ func NewOrchestrator(cfg OrchestratorConfig) *Orchestrator {
 		sandboxAuth:                cfg.SandboxAuth,
 		users:                      cfg.Users,
 		evalBootstraps:             cfg.EvalBootstraps,
+		successfulTurnVerifier:     cfg.SuccessfulTurnVerifier,
 		internalAPIURL:             cfg.InternalAPIURL,
 		internalAPISecret:          cfg.InternalAPISecret,
 		cancels:                    cfg.Cancels,
@@ -1121,6 +1142,28 @@ func NewOrchestrator(cfg OrchestratorConfig) *Orchestrator {
 		maxConcurrent:              maxConcurrent,
 		nodeID:                     cfg.NodeID,
 		isDraining:                 cfg.IsDraining,
+	}
+}
+
+// SetSuccessfulTurnVerifier supports late binding on worker processes, where
+// the preview manager is constructed after the core agent services.
+func (o *Orchestrator) SetSuccessfulTurnVerifier(verifier SuccessfulTurnVerifier) {
+	o.successfulTurnVerifier = verifier
+}
+
+func (o *Orchestrator) verifySuccessfulTurn(ctx context.Context, session *models.Session, sandbox *Sandbox, result *AgentResult, log zerolog.Logger) {
+	if o.successfulTurnVerifier == nil || session == nil || result == nil {
+		return
+	}
+	diff := strings.TrimSpace(result.Diff)
+	revision := session.WorkspaceRevision
+	if diff != "" {
+		revision++
+	}
+	if err := o.successfulTurnVerifier.VerifySuccessfulTurn(ctx, SuccessfulTurnVerification{
+		Session: session, Sandbox: sandbox, Result: result, WorkspaceRevision: revision, Diff: diff,
+	}); err != nil {
+		log.Warn().Err(err).Int64("workspace_revision", revision).Msg("automatic preview verification did not complete")
 	}
 }
 
@@ -3328,6 +3371,7 @@ func (o *Orchestrator) RunAgent(ctx context.Context, run *models.Session) error 
 				log.Warn().Err(err).Str("thread_id", primaryThreadID.String()).Msg("failed to mark primary thread turn complete")
 			}
 		}
+		o.verifySuccessfulTurn(ctx, run, sandbox, result, log)
 
 		log.Info().
 			Int("turn", turnNumber).
@@ -3343,6 +3387,7 @@ func (o *Orchestrator) RunAgent(ctx context.Context, run *models.Session) error 
 		o.cleanupReviewArtifact(ctx, runResult, log)
 		return fmt.Errorf("update run result: %w", err)
 	}
+	o.verifySuccessfulTurn(ctx, run, sandbox, result, log)
 	if primaryThreadID != nil && o.sessionThreads != nil {
 		if err := o.sessionThreads.UpdateResult(ctx, run.OrgID, *primaryThreadID, models.ThreadStatusCompleted, runResult); err != nil {
 			log.Warn().Err(err).Str("thread_id", primaryThreadID.String()).Msg("failed to persist primary thread result")
@@ -4821,6 +4866,7 @@ func (o *Orchestrator) ContinueSession(ctx context.Context, session *models.Sess
 		o.cleanupReviewArtifact(ctx, runResult, log)
 		return fmt.Errorf("update turn complete: %w", err)
 	}
+	o.verifySuccessfulTurn(ctx, session, sandbox, result, log)
 
 	drainAfterRelease = true
 

--- a/internal/services/agent/orchestrator_preview_verification_test.go
+++ b/internal/services/agent/orchestrator_preview_verification_test.go
@@ -1,0 +1,50 @@
+package agent
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/require"
+
+	"github.com/assembledhq/143/internal/models"
+)
+
+type recordingSuccessfulTurnVerifier struct {
+	inputs []SuccessfulTurnVerification
+}
+
+func (v *recordingSuccessfulTurnVerifier) VerifySuccessfulTurn(_ context.Context, input SuccessfulTurnVerification) error {
+	v.inputs = append(v.inputs, input)
+	return nil
+}
+
+func TestVerifySuccessfulTurn(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name             string
+		diff             string
+		expectedRevision int64
+	}{
+		{name: "increments revision for changed workspace", diff: "diff --git a/page.tsx b/page.tsx", expectedRevision: 8},
+		{name: "keeps revision for unchanged workspace", diff: "", expectedRevision: 7},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			verifier := &recordingSuccessfulTurnVerifier{}
+			orchestrator := &Orchestrator{successfulTurnVerifier: verifier}
+			session := &models.Session{ID: uuid.New(), WorkspaceRevision: 7}
+			result := &AgentResult{Diff: tt.diff}
+
+			orchestrator.verifySuccessfulTurn(context.Background(), session, &Sandbox{ID: "sandbox-1"}, result, zerolog.Nop())
+
+			require.Len(t, verifier.inputs, 1, "successful coding turns should invoke preview verification exactly once")
+			require.Equal(t, tt.expectedRevision, verifier.inputs[0].WorkspaceRevision, "verification evidence should use the resulting workspace revision")
+			require.Equal(t, tt.diff, verifier.inputs[0].Diff, "verification should receive the adapter-produced workspace diff")
+		})
+	}
+}

--- a/internal/services/preview/verification_coordinator.go
+++ b/internal/services/preview/verification_coordinator.go
@@ -81,39 +81,49 @@ func (c *VerificationCoordinator) Run(ctx context.Context, request VerificationR
 	if request.Observer == nil {
 		return c.completeFailure(ctx, request.OrgID, run, 1, nil, "preview observer is unavailable")
 	}
+	if request.Config.TimeoutSeconds > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, time.Duration(request.Config.TimeoutSeconds)*time.Second)
+		defer cancel()
+	}
 
-	var lastSteps []models.PreviewVerificationStep
+	allSteps := make([]models.PreviewVerificationStep, 0, len(decision.Plan)*maxAttempts)
 	var lastFailure string
 	lastAttempt := 1
 	for attempt := 1; attempt <= maxAttempts; attempt++ {
 		lastAttempt = attempt
-		steps, failure, humanRequired := executeVerificationPlan(ctx, request.Observer, decision.Plan, request.Config.FailOnConsoleError)
-		lastSteps, lastFailure = steps, failure
+		steps, failure, humanRequired := executeVerificationPlan(ctx, request.Observer, decision.Plan, request.Config.FailOnConsoleError, attempt)
+		allSteps = append(allSteps, steps...)
+		lastFailure = failure
+		if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+			lastFailure = fmt.Sprintf("preview verification timed out after %d seconds", request.Config.TimeoutSeconds)
+			break
+		}
 		if humanRequired {
-			return c.complete(ctx, request.OrgID, run, models.PreviewVerificationStatusHumanInterventionRequired, attempt, steps, failure)
+			return c.complete(ctx, request.OrgID, run, models.PreviewVerificationStatusHumanInterventionRequired, attempt, allSteps, failure)
 		}
 		if failure == "" {
-			return c.complete(ctx, request.OrgID, run, models.PreviewVerificationStatusPassed, attempt, steps, "")
+			return c.complete(ctx, request.OrgID, run, models.PreviewVerificationStatusPassed, attempt, allSteps, "")
 		}
 		if attempt == maxAttempts || request.Fixer == nil {
 			break
 		}
 		if fixErr := request.Fixer.FixVerificationFailure(ctx, attempt, failure); fixErr != nil {
 			if errors.Is(fixErr, ErrVerificationHumanIntervention) {
-				return c.complete(ctx, request.OrgID, run, models.PreviewVerificationStatusHumanInterventionRequired, attempt, steps, fixErr.Error())
+				return c.complete(ctx, request.OrgID, run, models.PreviewVerificationStatusHumanInterventionRequired, attempt, allSteps, fixErr.Error())
 			}
 			lastFailure = fmt.Sprintf("%s; fix attempt failed: %v", failure, fixErr)
 			break
 		}
 	}
-	return c.completeFailure(ctx, request.OrgID, run, lastAttempt, lastSteps, lastFailure)
+	return c.completeFailure(ctx, request.OrgID, run, lastAttempt, allSteps, lastFailure)
 }
 
-func executeVerificationPlan(ctx context.Context, observer VerificationObserver, plan []models.PreviewVerificationPlanStep, failOnConsole bool) ([]models.PreviewVerificationStep, string, bool) {
+func executeVerificationPlan(ctx context.Context, observer VerificationObserver, plan []models.PreviewVerificationPlanStep, failOnConsole bool, attempt int) ([]models.PreviewVerificationStep, string, bool) {
 	steps := make([]models.PreviewVerificationStep, 0, len(plan))
 	for index, planned := range plan {
 		observation, err := observer.Observe(ctx, planned.Path, planned.Viewport)
-		step := models.PreviewVerificationStep{Index: index, Path: planned.Path, Viewport: planned.Viewport, Outcome: "passed"}
+		step := models.PreviewVerificationStep{Index: index, Attempt: attempt, Path: planned.Path, Viewport: planned.Viewport, Outcome: "passed"}
 		if err != nil {
 			step.Outcome, step.Error = "failed", err.Error()
 			steps = append(steps, step)

--- a/internal/services/preview/verification_coordinator_test.go
+++ b/internal/services/preview/verification_coordinator_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
@@ -62,6 +63,12 @@ func (f *fakeVerificationFixer) FixVerificationFailure(_ context.Context, _ int,
 	return nil
 }
 
+type contextVerificationObserver struct{}
+
+func (contextVerificationObserver) Observe(ctx context.Context, _ string, _ models.ViewportSpec) (*models.PreviewObservation, error) {
+	return nil, ctx.Err()
+}
+
 func TestVerificationCoordinatorRun(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
@@ -74,9 +81,10 @@ func TestVerificationCoordinatorRun(t *testing.T) {
 		expectedStatus  models.PreviewVerificationStatus
 		expectedFixes   int
 		expectedAttempt int
+		expectedSteps   int
 	}{
-		{name: "passes and records screenshot", auto: true, observations: []*models.PreviewObservation{{Ready: true, Screenshot: &models.ScreenshotResult{Artifact: &models.PreviewArtifact{ID: "shot-1"}}}}, maxAttempts: 1, expectedStatus: models.PreviewVerificationStatusPassed, expectedAttempt: 1},
-		{name: "fixes console failure and retries", auto: true, observations: []*models.PreviewObservation{{Ready: true, Console: []models.ConsoleMessage{{Level: "error"}}}, {Ready: true}}, maxAttempts: 2, expectedStatus: models.PreviewVerificationStatusPassed, expectedFixes: 1, expectedAttempt: 2},
+		{name: "passes and records screenshot", auto: true, observations: []*models.PreviewObservation{{Ready: true, Screenshot: &models.ScreenshotResult{Artifact: &models.PreviewArtifact{ID: "shot-1"}}}}, maxAttempts: 1, expectedStatus: models.PreviewVerificationStatusPassed, expectedAttempt: 1, expectedSteps: 1},
+		{name: "fixes console failure and retains both attempts", auto: true, observations: []*models.PreviewObservation{{Ready: true, Console: []models.ConsoleMessage{{Level: "error"}}}, {Ready: true}}, maxAttempts: 2, expectedStatus: models.PreviewVerificationStatusPassed, expectedFixes: 1, expectedAttempt: 2, expectedSteps: 2},
 		{name: "records disabled skip", auto: false, maxAttempts: 1, expectedStatus: models.PreviewVerificationStatusSkipped},
 		{name: "reports the real attempt when no fixer is wired", auto: true, observations: []*models.PreviewObservation{{Ready: false}}, maxAttempts: 3, withoutFixer: true, expectedStatus: models.PreviewVerificationStatusFailed, expectedAttempt: 1},
 		{name: "fails when the observer is unavailable", auto: true, maxAttempts: 3, withoutObserver: true, expectedStatus: models.PreviewVerificationStatusFailed, expectedAttempt: 1},
@@ -106,6 +114,36 @@ func TestVerificationCoordinatorRun(t *testing.T) {
 			if tt.expectedAttempt > 0 && tt.expectedStatus != models.PreviewVerificationStatusSkipped {
 				require.Equal(t, tt.expectedAttempt, actual.Attempt, "coordinator should record the attempt where the run resolved")
 			}
+			if tt.expectedSteps > 0 {
+				var steps []models.PreviewVerificationStep
+				require.NoError(t, json.Unmarshal(actual.Steps, &steps), "completed evidence steps should be valid JSON")
+				require.Len(t, steps, tt.expectedSteps, "completed evidence should retain every attempted check")
+				for index, step := range steps {
+					require.Equal(t, index+1, step.Attempt, "each retained check should identify its verification attempt")
+				}
+			}
 		})
 	}
+}
+
+func TestVerificationCoordinatorRun_StopsAtTotalTimeout(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(-time.Second))
+	defer cancel()
+	runs := &fakeVerificationRuns{}
+	fixer := &fakeVerificationFixer{}
+	request := VerificationRequest{
+		OrgID: uuid.New(), SessionID: uuid.New(), WorkspaceRevision: 4,
+		Diff: "+++ b/frontend/src/page.tsx", Observer: contextVerificationObserver{}, Fixer: fixer,
+		Config: models.PreviewVerificationConfig{Auto: true, MaxAttempts: 3, TimeoutSeconds: 300, SmokePaths: []string{"/"}},
+	}
+
+	actual, err := NewVerificationCoordinator(runs).Run(ctx, request)
+
+	require.NoError(t, err, "coordinator should persist a timed-out verification outcome")
+	require.Equal(t, models.PreviewVerificationStatusFailed, actual.Status, "a total-budget timeout should fail verification")
+	require.Equal(t, 1, actual.Attempt, "a timed-out verification should not consume further attempts")
+	require.Equal(t, 0, fixer.calls, "a timed-out verification should not start a fix outside its budget")
+	require.Equal(t, "preview verification timed out after 300 seconds", actual.FailureReason, "timeout evidence should state the configured total budget")
 }


### PR DESCRIPTION
## Summary

Agent preview verification was inconsistent across adapters because “successful-turn” wiring still required adapter-specific branching, creating a reliability risk that different runtimes would produce different evidence. This change completes the Phase 3 shared verification hook so both initial and continuation turns use the same verification entry point, with attempt-aware evidence preserved across retries.

## Changes

- Added an adapter-independent successful-turn verification hook covering both initial and continuation turns, eliminating per-adapter integration seam differences.
- Enforced the configured verification timeout and preserved verification evidence across retry attempts.
- Tagged preview verification steps with the attempt number, and updated the frontend evidence typing/design status accordingly.
- Added focused coordinator/orchestrator tests to validate the shared hook behavior, evidence retention, and timeout handling.

## Validation

- `go test ./...` (affected packages: preview verification coordinator + orchestrator tests)
- `go vet ./...`
- `git diff --check`
- Frontend typechecking: not run (TypeScript tooling/dependencies not available; `tsc` unavailable)

[143.dev](https://143.dev) | [session b946d651](https://143.dev/sessions/b946d651-f6e2-477e-a918-e32499052ee7)

<!-- 143 readiness -->
**143 readiness:** not available for this revision.

Preview: https://143.dev/previews/github/assembledhq/143/pull/1824?launch=1