### PR TITLE
Normalize attached button icon sizing with shared ButtonGroup for consistent alignment

### DIFF
--- a/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
@@ -39,6 +39,7 @@ import { notify as toast } from "@/lib/notify";
 import { Badge } from "@/components/ui/badge";
 import { LazyMarkdownContent } from "@/components/lazy-markdown-content";
 import { Button } from "@/components/ui/button";
+import { ButtonGroup } from "@/components/ui/button-group";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -744,7 +745,7 @@ function OverviewTab({ session, members, prStatus }: { session: Session; members
                 )}
               </CardTitle>
               {session.failure_retry_advised && (
-                <div className="inline-flex">
+                <ButtonGroup size="xs">
                   <DisabledTooltip
                     disabled={retryMutation.isPending || checkpointRetryUnavailable}
                     content={recoveryActive ? "Runtime recovery is already in progress." : checkpointRetryUnavailable ? "No saved progress is available." : "Retrying session..."}
@@ -778,7 +779,7 @@ function OverviewTab({ session, members, prStatus }: { session: Session; members
                       </DropdownMenuItem>
                     </DropdownMenuContent>
                   </DropdownMenu>
-                </div>
+                </ButtonGroup>
               )}
             </div>
           </CardHeader>
@@ -6475,7 +6476,7 @@ export function SessionDetailContent({ id }: { id: string }) {
                   </Button>
                 ) : null}
                 <DisabledTooltip disabled={prActionDisabled} content={prActionTitle}>
-                  <div className="inline-flex">
+                  <ButtonGroup size="sm">
                     <Button
                       variant="outline"
                       size="sm"
@@ -6534,7 +6535,7 @@ export function SessionDetailContent({ id }: { id: string }) {
                         </DropdownMenuItem>
                       </DropdownMenuContent>
                     </DropdownMenu>
-                  </div>
+                  </ButtonGroup>
                 </DisabledTooltip>
               </>
             ) : null}

--- a/frontend/src/components/automation-goal-improvement.tsx
+++ b/frontend/src/components/automation-goal-improvement.tsx
@@ -15,6 +15,7 @@ import { ApiError, api } from "@/lib/api";
 import type { Automation, AutomationGoalImprovement } from "@/lib/types";
 import { formatDateTime } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
+import { ButtonGroup } from "@/components/ui/button-group";
 import {
   Dialog,
   DialogContent,
@@ -214,7 +215,7 @@ export function AutomationGoalImprovementControl({
 
   return (
     <>
-      <div className="flex items-center">
+      <ButtonGroup size="sm">
         <Button
           type="button"
           variant="outline"
@@ -267,7 +268,7 @@ export function AutomationGoalImprovementControl({
             <History className="h-4 w-4" />
           </Button>
         )}
-      </div>
+      </ButtonGroup>
       {error && <p className="text-xs text-destructive">{error}</p>}
       <Dialog
         open={proposal !== null}

--- a/frontend/src/components/pr-health-banner.test.tsx
+++ b/frontend/src/components/pr-health-banner.test.tsx
@@ -357,6 +357,11 @@ describe("PRHealthBanner", () => {
     expect(moreActions).toHaveAttribute("data-size", "icon-sm");
     expect(moreActions).toHaveClass("size-10", "sm:size-7", "rounded-l-none");
     expect(moreActions).not.toHaveClass("h-7", "w-7");
+    expect(moreActions.closest("[data-slot='button-group']")).toHaveClass(
+      "h-10",
+      "sm:h-7",
+      "[&_[data-slot=button]]:!h-full",
+    );
 
     await userEvent.setup().click(moreActions);
     const menuItem = await screen.findByRole("menuitem", { name: "Merge when ready" });

--- a/frontend/src/components/pr-health-banner.tsx
+++ b/frontend/src/components/pr-health-banner.tsx
@@ -7,6 +7,7 @@ import type { PullRequestHealthResponse } from "@/lib/types";
 import { cn } from "@/lib/utils";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { ButtonGroup } from "@/components/ui/button-group";
 import { Card, CardContent } from "@/components/ui/card";
 import { DisabledTooltip } from "@/components/ui/disabled-tooltip";
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "@/components/ui/dropdown-menu";
@@ -266,7 +267,7 @@ export function PRHealthBanner({
                 )}
                 <div className="flex flex-wrap gap-2">
                   {canShowMergeButton && (
-                    <div className="inline-flex">
+                    <ButtonGroup size="sm">
                       <DisabledTooltip disabled={mergeAction.disabled} content={mergeAction.disabledReason}>
                         <Button
                           size="sm"
@@ -314,11 +315,11 @@ export function PRHealthBanner({
                           </DropdownMenuContent>
                         </DropdownMenu>
                       )}
-                    </div>
+                    </ButtonGroup>
                   )}
                   {canShowResolveConflictsButton && (
                     <DisabledTooltip disabled={pendingAction !== null} content="Wait for the current PR action to finish">
-                      <span className="inline-flex">
+                      <ButtonGroup size="sm">
                         <Button
                           size="sm"
                           variant="outline"
@@ -356,12 +357,12 @@ export function PRHealthBanner({
                             </DropdownMenuContent>
                           </DropdownMenu>
                         )}
-                      </span>
+                      </ButtonGroup>
                     </DisabledTooltip>
                   )}
                   {canShowFixTestsButton && (
                     <DisabledTooltip disabled={pendingAction !== null} content="Wait for the current PR action to finish">
-                      <span className="inline-flex">
+                      <ButtonGroup size="sm">
                         <Button
                           size="sm"
                           variant="outline"
@@ -399,7 +400,7 @@ export function PRHealthBanner({
                             </DropdownMenuContent>
                           </DropdownMenu>
                         )}
-                      </span>
+                      </ButtonGroup>
                     </DisabledTooltip>
                   )}
                   {canShowReviewAction && reviewAction && (

--- a/frontend/src/components/ui/button-group-context.ts
+++ b/frontend/src/components/ui/button-group-context.ts
@@ -1,0 +1,5 @@
+import * as React from "react"
+
+export type ButtonGroupSize = "default" | "xs" | "sm" | "lg"
+
+export const ButtonGroupSizeContext = React.createContext<ButtonGroupSize | null>(null)

--- a/frontend/src/components/ui/button-group.test.tsx
+++ b/frontend/src/components/ui/button-group.test.tsx
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest"
+import { ChevronDown } from "lucide-react"
+
+import { renderWithProviders, screen } from "@/test/test-utils"
+import { Button } from "./button"
+import { ButtonGroup } from "./button-group"
+
+describe("ButtonGroup", () => {
+  it("owns one height for text buttons and attached icon buttons", () => {
+    renderWithProviders(
+      <ButtonGroup size="sm" aria-label="Publish actions">
+        <Button size="sm">Publish</Button>
+        <Button size="icon" aria-label="More publish actions">
+          <ChevronDown />
+        </Button>
+      </ButtonGroup>,
+    )
+
+    const group = screen.getByRole("group", { name: "Publish actions" })
+    expect(group).toHaveAttribute("data-size", "sm")
+    expect(group).toHaveClass("h-10", "sm:h-7", "[&_[data-slot=button]]:!h-full")
+  })
+})

--- a/frontend/src/components/ui/button-group.test.tsx
+++ b/frontend/src/components/ui/button-group.test.tsx
@@ -19,5 +19,8 @@ describe("ButtonGroup", () => {
     const group = screen.getByRole("group", { name: "Publish actions" })
     expect(group).toHaveAttribute("data-size", "sm")
     expect(group).toHaveClass("h-10", "sm:h-7", "[&_[data-slot=button]]:!h-full")
+    expect(screen.getByRole("button", { name: "Publish" })).toHaveAttribute("data-size", "sm")
+    expect(screen.getByRole("button", { name: "More publish actions" })).toHaveAttribute("data-size", "icon-sm")
+    expect(screen.getByRole("button", { name: "More publish actions" })).toHaveClass("size-10", "sm:size-7")
   })
 })

--- a/frontend/src/components/ui/button-group.tsx
+++ b/frontend/src/components/ui/button-group.tsx
@@ -1,0 +1,39 @@
+import * as React from "react"
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "@/lib/utils"
+
+const buttonGroupVariants = cva(
+  "inline-flex w-fit items-stretch [&_[data-slot=button]]:!h-full",
+  {
+    variants: {
+      size: {
+        default: "h-10 sm:h-8",
+        xs: "h-10 sm:h-6",
+        sm: "h-10 sm:h-7",
+        lg: "h-10 sm:h-9",
+      },
+    },
+    defaultVariants: {
+      size: "default",
+    },
+  },
+)
+
+function ButtonGroup({
+  className,
+  size = "default",
+  ...props
+}: React.ComponentProps<"div"> & VariantProps<typeof buttonGroupVariants>) {
+  return (
+    <div
+      role="group"
+      data-slot="button-group"
+      data-size={size}
+      className={cn(buttonGroupVariants({ size }), className)}
+      {...props}
+    />
+  )
+}
+
+export { ButtonGroup, buttonGroupVariants }

--- a/frontend/src/components/ui/button-group.tsx
+++ b/frontend/src/components/ui/button-group.tsx
@@ -2,6 +2,7 @@ import * as React from "react"
 import { cva, type VariantProps } from "class-variance-authority"
 
 import { cn } from "@/lib/utils"
+import { ButtonGroupSizeContext, type ButtonGroupSize } from "./button-group-context"
 
 const buttonGroupVariants = cva(
   "inline-flex w-fit items-stretch [&_[data-slot=button]]:!h-full",
@@ -25,14 +26,18 @@ function ButtonGroup({
   size = "default",
   ...props
 }: React.ComponentProps<"div"> & VariantProps<typeof buttonGroupVariants>) {
+  const resolvedSize: ButtonGroupSize = size ?? "default"
+
   return (
-    <div
-      role="group"
-      data-slot="button-group"
-      data-size={size}
-      className={cn(buttonGroupVariants({ size }), className)}
-      {...props}
-    />
+    <ButtonGroupSizeContext.Provider value={resolvedSize}>
+      <div
+        role="group"
+        data-slot="button-group"
+        data-size={resolvedSize}
+        className={cn(buttonGroupVariants({ size: resolvedSize }), className)}
+        {...props}
+      />
+    </ButtonGroupSizeContext.Provider>
   )
 }
 

--- a/frontend/src/components/ui/button.tsx
+++ b/frontend/src/components/ui/button.tsx
@@ -4,6 +4,7 @@ import { Loader2 } from "lucide-react"
 import { Slot } from "radix-ui"
 
 import { cn } from "@/lib/utils"
+import { ButtonGroupSizeContext, type ButtonGroupSize } from "./button-group-context"
 
 const buttonVariants = cva(
   "inline-flex cursor-pointer items-center justify-center gap-1 whitespace-nowrap rounded-md type-dense font-medium transition-[color,background-color,border-color,box-shadow,transform] duration-[125ms] ease-[cubic-bezier(0.16,1,0.3,1)] disabled:pointer-events-none disabled:opacity-50 disabled:data-[loading=true]:opacity-100 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/25 focus-visible:ring-2 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
@@ -52,7 +53,9 @@ function Button({
   VariantProps<typeof buttonVariants> & {
     asChild?: boolean
     loading?: boolean
-  }) {
+}) {
+  const groupSize = React.useContext(ButtonGroupSizeContext)
+  const resolvedSize = resolveGroupedButtonSize(size, groupSize)
   const Comp = asChild ? Slot.Root : "button"
   const isDisabled = loading || disabled
   const showSpinner = loading && !asChild
@@ -73,14 +76,34 @@ function Button({
     <Comp
       data-slot="button"
       data-variant={variant}
-      data-size={size}
+      data-size={resolvedSize}
       data-loading={loading ? "true" : undefined}
-      className={cn(buttonVariants({ variant, size, className }), isDisabled && "pointer-events-none")}
+      className={cn(buttonVariants({ variant, size: resolvedSize, className }), isDisabled && "pointer-events-none")}
       disabled={!asChild ? isDisabled : undefined}
       aria-disabled={isDisabled || undefined}
       {...props}
     >{content}</Comp>
   )
 }
+
+function resolveGroupedButtonSize(
+  size: VariantProps<typeof buttonVariants>["size"],
+  groupSize: ButtonGroupSize | null,
+) {
+  if (!groupSize) return size
+
+  if (size?.startsWith("icon")) {
+    return groupedIconSizes[groupSize]
+  }
+
+  return groupSize
+}
+
+const groupedIconSizes = {
+  default: "icon",
+  xs: "icon-xs",
+  sm: "icon-sm",
+  lg: "icon-lg",
+} as const satisfies Record<ButtonGroupSize, NonNullable<VariantProps<typeof buttonVariants>["size"]>>
 
 export { Button, buttonVariants }


### PR DESCRIPTION
## Summary

Attached button groups could render with inconsistent height/icon scaling, leading to misaligned dropdown triggers and control buttons. This PR introduces a reusable `ButtonGroup` component to enforce a consistent responsive height across nested buttons (including icon/dropdown triggers), then updates key session and automation controls to use it.

## Changes

- Added `frontend/src/components/ui/button-group.tsx` (and tests) to normalize “attached” button sizing via a single responsive height contract.
- Migrated session failure retry controls and PR health actions to use `ButtonGroup` instead of ad-hoc `div` wrappers.
- Migrated automation goal improvement controls to use `ButtonGroup size="sm"` for consistent icon alignment.
- Updated/added regression coverage for mixed text+icon button groups and adjusted PR health banner tests to match the new structure.

## Validation

- Ran 48 focused tests (including new `button-group` coverage and updated `pr-health-banner` tests).
- ESLint passed on all touched files.
- Manual visual preview was not available because no session ID was provided.

[143.dev](https://143.dev) | [session e3581e9e](https://143.dev/sessions/e3581e9e-db8a-4182-b4d0-c834fb995d27)

<!-- 143 readiness -->
**143 readiness:** not available for this revision.

Preview: https://143.dev/previews/github/assembledhq/143/pull/1826?launch=1