### PR TITLE
Fix session composer textarea overflow and attachment overlap by reserving space before thumbnails render

### DIFF
--- a/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
@@ -1693,7 +1693,7 @@ function SessionComposer({
             isUploading={isUploading}
             onRemove={onRemoveAttachment}
             size="md"
-            className="px-3 pb-2"
+            className="px-3 pt-2 pb-2"
           />
 
           {showImageInput && (

--- a/frontend/src/app/(dashboard)/sessions/new/page.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/new/page.test.tsx
@@ -677,6 +677,20 @@ describe('ManualSessionCreatePage', () => {
     });
   });
 
+  it('grows the prompt to reserve space for wrapped text', () => {
+    renderWithProviders(<ManualSessionCreatePageContent />);
+
+    const textarea = screen.getByPlaceholderText('Tell the agent what to do...') as HTMLTextAreaElement;
+    Object.defineProperty(textarea, 'scrollHeight', { configurable: true, value: 112 });
+
+    fireEvent.change(textarea, {
+      target: { value: 'A long prompt that wraps across several lines before its attachment.' },
+    });
+
+    expect(textarea.style.height).toBe('112px');
+    expect(textarea.style.overflowY).toBe('hidden');
+  });
+
   it('opens an image lightbox from the composer attachment thumbnail', async () => {
     const user = userEvent.setup();
 

--- a/frontend/src/components/manual-session-composer.tsx
+++ b/frontend/src/components/manual-session-composer.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { memo, useCallback, useDeferredValue, useEffect, useMemo, useRef, useState, type ReactNode } from "react";
+import { memo, useCallback, useDeferredValue, useEffect, useLayoutEffect, useMemo, useRef, useState, type ReactNode } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import {
   ArrowUp,
@@ -301,7 +301,6 @@ export function ManualSessionComposer({
   const composerCardRef = useRef<HTMLDivElement>(null);
   const draftSaveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const pendingDraftRef = useRef<Parameters<typeof saveDraft>[0] | null>(null);
-  const resizeFrameRef = useRef<number | null>(null);
   // Synchronous guard: React Query's isPending flips on the next render, so
   // rapid Enter presses can all pass the isPending check in the same tick.
   const submittingRef = useRef(false);
@@ -486,9 +485,6 @@ export function ManualSessionComposer({
   useEffect(() => {
     return () => {
       flushDraftSave();
-      if (resizeFrameRef.current !== null) {
-        cancelAnimationFrame(resizeFrameRef.current);
-      }
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
@@ -783,29 +779,22 @@ export function ManualSessionComposer({
     createManualSessionMutation.mutate();
   }
 
-  function resizeMessageInput() {
-    if (resizeFrameRef.current !== null) {
-      cancelAnimationFrame(resizeFrameRef.current);
+  const resizeMessageInput = useCallback((input?: HTMLTextAreaElement) => {
+    const element = input ?? messageInputRef.current;
+    if (!element) {
+      return;
     }
 
-    resizeFrameRef.current = requestAnimationFrame(() => {
-      resizeFrameRef.current = null;
-      const element = messageInputRef.current;
-      if (!element) {
-        return;
-      }
+    const maxHeight = 240;
+    element.style.height = "auto";
+    const nextHeight = Math.min(element.scrollHeight, maxHeight);
+    element.style.height = `${nextHeight}px`;
+    element.style.overflowY = element.scrollHeight > maxHeight ? "auto" : "hidden";
+  }, []);
 
-      const maxHeight = 240;
-      element.style.height = "auto";
-      const nextHeight = Math.min(element.scrollHeight, maxHeight);
-      element.style.height = `${nextHeight}px`;
-      element.style.overflowY = element.scrollHeight > maxHeight ? "auto" : "hidden";
-    });
-  }
-
-  useEffect(() => {
+  useLayoutEffect(() => {
     resizeMessageInput();
-  }, [message]);
+  }, [message, resizeMessageInput]);
 
   useEffect(() => {
     if (!messageInputRef.current || document.activeElement !== messageInputRef.current) {
@@ -1236,6 +1225,7 @@ export function ManualSessionComposer({
                 autoFocus={autoFocus}
                 onChange={(event) => {
                   updateMessage(event.target.value, event.target.selectionStart ?? event.target.value.length);
+                  resizeMessageInput(event.currentTarget);
                 }}
                 onPaste={handlePaste}
                 onBlur={flushDraftSave}
@@ -1355,7 +1345,7 @@ export function ManualSessionComposer({
                 isUploading={isUploading}
                 onRemove={removeAttachment}
                 size="md"
-                className="pb-3"
+                className="pt-2 pb-3"
               />
 
               {showImageInput && (


### PR DESCRIPTION
## Summary

Session creation can visually overflow: the prompt textarea can resize too late when text wraps, causing it to overlap with session attachment thumbnails/margins. This PR adjusts the composer so textarea sizing happens synchronously and ensures consistent spacing above attachment thumbnails across both new-session and follow-up composers.

## Changes

- Updated session composer attachment thumbnail container spacing (`pt-2 pb-2`) to prevent thumbnails from colliding with textarea content.
- Changed textarea resize behavior to reserve space synchronously for wrapped text before attachment UI renders (removing the deferred/RAF-based resize frame approach).
- Added a regression test that validates multiline textarea sizing + `overflowY: hidden` to ensure reserved space is applied consistently.
- Ensured code cleanliness by removing now-unneeded resize frame bookkeeping.

## Validation

- Added/updated frontend test: `frontend/src/app/(dashboard)/sessions/new/page.test.tsx`
  - Covers multiline prompt growth/reserved space behavior.
- `git diff --check` passes.
- Note: focused frontend tests could not run in this environment because frontend dependencies are not installed (`vitest: not found`).

[143.dev](https://143.dev) | [session 10a2f7dc](https://143.dev/sessions/10a2f7dc-0372-4588-a065-d62995b6f634)

<!-- 143 readiness -->
**143 readiness:** not available for this revision.

Preview: https://143.dev/previews/github/assembledhq/143/pull/1827?launch=1