### PR TITLE
Fix skill/chip remove button sizing to keep chips slim

### DIFF
--- a/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
@@ -1645,7 +1645,7 @@ function SessionComposer({
                     type="button"
                     variant="ghost"
                     size="icon"
-                    className="h-5 w-5 rounded-full"
+                    className="!size-5 rounded-full"
                     aria-label={`Remove ${reference.display}`}
                     onClick={() => removeReference(reference)}
                   >
@@ -1671,7 +1671,7 @@ function SessionComposer({
                       type="button"
                       variant="ghost"
                       size="icon"
-                      className="h-5 w-5 rounded-full"
+                      className="!size-5 rounded-full"
                       aria-label={`Remove ${command.token}`}
                       onClick={() => removeCommand(command)}
                     >

--- a/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
@@ -1644,8 +1644,8 @@ function SessionComposer({
                   <Button
                     type="button"
                     variant="ghost"
-                    size="icon"
-                    className="!size-5 rounded-full"
+                    size="icon-compact"
+                    className="rounded-full"
                     aria-label={`Remove ${reference.display}`}
                     onClick={() => removeReference(reference)}
                   >
@@ -1670,8 +1670,8 @@ function SessionComposer({
                     <Button
                       type="button"
                       variant="ghost"
-                      size="icon"
-                      className="!size-5 rounded-full"
+                      size="icon-compact"
+                      className="rounded-full"
                       aria-label={`Remove ${command.token}`}
                       onClick={() => removeCommand(command)}
                     >

--- a/frontend/src/components/manual-session-composer.tsx
+++ b/frontend/src/components/manual-session-composer.tsx
@@ -1303,8 +1303,8 @@ export function ManualSessionComposer({
                       <Button
                         type="button"
                         variant="ghost"
-                        size="icon"
-                        className="!size-5 rounded-full"
+                        size="icon-compact"
+                        className="rounded-full"
                         aria-label={`Remove ${reference.display}`}
                         onClick={() => removeReference(reference)}
                       >
@@ -1332,8 +1332,8 @@ export function ManualSessionComposer({
                         <Button
                           type="button"
                           variant="ghost"
-                          size="icon"
-                          className="!size-5 rounded-full"
+                          size="icon-compact"
+                          className="rounded-full"
                           aria-label={`Remove ${command.token}`}
                           onClick={() => removeCommand(command)}
                         >

--- a/frontend/src/components/manual-session-composer.tsx
+++ b/frontend/src/components/manual-session-composer.tsx
@@ -1304,7 +1304,7 @@ export function ManualSessionComposer({
                         type="button"
                         variant="ghost"
                         size="icon"
-                        className="h-5 w-5 rounded-full"
+                        className="!size-5 rounded-full"
                         aria-label={`Remove ${reference.display}`}
                         onClick={() => removeReference(reference)}
                       >
@@ -1333,7 +1333,7 @@ export function ManualSessionComposer({
                           type="button"
                           variant="ghost"
                           size="icon"
-                          className="h-5 w-5 rounded-full"
+                          className="!size-5 rounded-full"
                           aria-label={`Remove ${command.token}`}
                           onClick={() => removeCommand(command)}
                         >

--- a/frontend/src/components/ui/button.tsx
+++ b/frontend/src/components/ui/button.tsx
@@ -27,6 +27,7 @@ const buttonVariants = cva(
         sm: "h-10 rounded-md gap-1 px-2 sm:h-7 has-[>svg]:px-1.5",
         lg: "h-10 px-4 sm:h-9 has-[>svg]:px-3",
         icon: "size-10 sm:size-8",
+        "icon-compact": "size-5",
         "icon-xs": "size-10 rounded-md sm:size-6 [&_svg:not([class*='size-'])]:size-3",
         "icon-sm": "size-10 sm:size-7",
         "icon-lg": "size-10 sm:size-9",


### PR DESCRIPTION
## Summary

The skill/command “X” controls in the session composer were inheriting the larger mobile icon-button sizing, making chips look inconsistent and harder to scan. This PR forces the remove buttons to stay a compact 20×20px (Tailwind `size-5`) across both the session detail and manual session composer, reducing visual clutter without changing chip layout logic.

## Changes

- Updated the remove “X” icon button class overrides in both composers:
  - `frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx`
  - `frontend/src/components/manual-session-composer.tsx`
- Switched from hardcoded `h-5 w-5` to `!size-5` to ensure the intended size wins over any inherited button sizing.
- Kept behavior/handlers unchanged—only the rendered control dimensions are adjusted.

## Validation

- `git diff --check` (passes)
- Note: focused frontend tests could not be run because `vitest`/frontend dependencies are not installed (`vitest: not found`).

[143.dev](https://143.dev) | [session 31119226](https://143.dev/sessions/31119226-4a02-465e-89b4-4199a24b18ad)

<!-- 143 readiness -->
**143 readiness:** not available for this revision.

Preview: https://143.dev/previews/github/assembledhq/143/pull/1829?launch=1