### PR TITLE
Implement remaining session changesets and stacks design gaps

### DIFF
--- a/frontend/src/app/(dashboard)/sessions/[id]/pull-request-list.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/pull-request-list.test.tsx
@@ -46,6 +46,8 @@ describe('PullRequestList', () => {
             is_primary: false,
             order_index: 1,
             title: 'API integration',
+            active_lease_holder_type: 'agent_turn',
+            active_lease_holder_label: 'Tab 2',
             pull_request: {
               id: 'pr-2', session_id: 'session-1', org_id: 'org-1', changeset_id: 'changeset-2',
               github_pr_number: 102, github_pr_url: 'https://github.test/pull/102', github_repo: 'acme/repo',
@@ -61,6 +63,7 @@ describe('PullRequestList', () => {
 
     expect(screen.getByTestId('pull-request-list')).toBeInTheDocument();
     expect(screen.getByText('#102 · open')).toBeInTheDocument();
+    expect(screen.getByText('Being edited in Tab 2')).toBeInTheDocument();
     await userEvent.click(screen.getByRole('button', { name: /API integration/ }));
     expect(onSelect).toHaveBeenCalledWith('changeset-2');
   });

--- a/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
@@ -3391,6 +3391,11 @@ export function PullRequestList({
                   {changeset.base_branch} → {changeset.working_branch ?? "not materialized"}
                 </span>
                 {changeset.has_unpushed_changes && <span className="block text-xs text-amber-600">Unpushed changes</span>}
+                {changeset.active_lease_holder_label && (
+                  <span className="block truncate text-xs text-blue-600">
+                    {changeset.active_lease_holder_type === "agent_turn" ? "Being edited in" : "In use by"} {changeset.active_lease_holder_label}
+                  </span>
+                )}
               </span>
               <span className="flex shrink-0 items-center gap-1">
                 {pr?.ci_status && <Badge variant="outline" className="h-5 px-1 text-xs">CI {pr.ci_status}</Badge>}

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -1650,6 +1650,8 @@ export interface ChangesetSummary {
   restack_delta_kind?: "clean_replay" | "mechanical_fallout" | "semantic_change";
   restack_delta_summary?: string;
   restack_confirmation_required?: boolean;
+  active_lease_holder_type?: "agent_turn" | "materialize" | "publish" | "restack" | "readiness" | "preview";
+  active_lease_holder_label?: string;
   pull_request?: PullRequest;
   created_at: string;
   updated_at: string;

--- a/internal/db/session_changesets.go
+++ b/internal/db/session_changesets.go
@@ -40,6 +40,12 @@ const changesetSummaryColumns = `id, is_primary, order_index, title, summary, st
 	base_branch, working_branch, stacked_on_changeset_id, head_sha, worktree_path, materialization_error,
 	(head_sha IS NOT NULL AND head_sha IS DISTINCT FROM expected_remote_head_sha) AS has_unpushed_changes,
 	restack_delta_kind, restack_delta_summary, restack_confirmation_required,
+	(SELECT holder_type FROM session_changeset_leases l
+		WHERE l.org_id = session_changesets.org_id AND l.session_id = session_changesets.session_id
+			AND l.changeset_id = session_changesets.id AND l.expires_at > now()) AS active_lease_holder_type,
+	(SELECT holder_label FROM session_changeset_leases l
+		WHERE l.org_id = session_changesets.org_id AND l.session_id = session_changesets.session_id
+			AND l.changeset_id = session_changesets.id AND l.expires_at > now()) AS active_lease_holder_label,
 	created_at, updated_at`
 
 func (s *SessionChangesetStore) ListBySession(ctx context.Context, orgID, sessionID uuid.UUID) ([]models.ChangesetSummary, error) {

--- a/internal/db/session_changesets_test.go
+++ b/internal/db/session_changesets_test.go
@@ -128,6 +128,40 @@ func TestSessionChangesetStoreGetPrimaryScopesByOrgAndSession(t *testing.T) {
 	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
 }
 
+func TestSessionChangesetStoreListBySessionIncludesActiveLeaseOwnership(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "test should create the database mock")
+	t.Cleanup(mock.Close)
+
+	orgID, sessionID, changesetID := uuid.New(), uuid.New(), uuid.New()
+	now := time.Now()
+	holderLabel := "Tab 2"
+	holderType := models.ChangesetLeaseTypeAgentTurn
+	workingBranch := "143/api"
+	worktreePath := "/workspace/api"
+	mock.ExpectQuery(`SELECT .+holder_type.+expires_at > now\(\).+holder_label.+expires_at > now\(\).+FROM session_changesets.+WHERE org_id = .+ AND session_id = .+ORDER BY`).
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(pgxmock.NewRows([]string{
+			"id", "is_primary", "order_index", "title", "summary", "status", "target_branch", "base_branch",
+			"working_branch", "stacked_on_changeset_id", "head_sha", "worktree_path", "materialization_error",
+			"has_unpushed_changes", "restack_delta_kind", "restack_delta_summary", "restack_confirmation_required",
+			"active_lease_holder_type", "active_lease_holder_label", "created_at", "updated_at",
+		}).AddRow(
+			changesetID, false, 1, "API", "", models.ChangesetStatusPROpen, "main", "143/foundation",
+			&workingBranch, nil, nil, &worktreePath, nil, false, nil, nil, false,
+			&holderType, &holderLabel, now, now,
+		))
+
+	changesets, err := NewSessionChangesetStore(mock).ListBySession(context.Background(), orgID, sessionID)
+	require.NoError(t, err, "ListBySession should load active lease ownership")
+	require.Equal(t, 1, len(changesets), "ListBySession should return the changeset")
+	require.Equal(t, models.ChangesetLeaseTypeAgentTurn, *changesets[0].ActiveLeaseHolderType, "summary should identify an editing turn")
+	require.Equal(t, holderLabel, *changesets[0].ActiveLeaseHolderLabel, "summary should identify the owning tab")
+	require.NoError(t, mock.ExpectationsWereMet(), "the ownership query should remain tenant and session scoped")
+}
+
 func TestSessionChangesetStoreUpdatePrimaryBranchesScopesByOrgAndSession(t *testing.T) {
 	t.Parallel()
 	mock, err := pgxmock.NewPool()

--- a/internal/models/changeset.go
+++ b/internal/models/changeset.go
@@ -100,6 +100,8 @@ type ChangesetSummary struct {
 	RestackDeltaKind            *ChangesetRestackDeltaKind `db:"restack_delta_kind" json:"restack_delta_kind,omitempty"`
 	RestackDeltaSummary         *string                    `db:"restack_delta_summary" json:"restack_delta_summary,omitempty"`
 	RestackConfirmationRequired bool                       `db:"restack_confirmation_required" json:"restack_confirmation_required"`
+	ActiveLeaseHolderType       *ChangesetLeaseType        `db:"active_lease_holder_type" json:"active_lease_holder_type,omitempty"`
+	ActiveLeaseHolderLabel      *string                    `db:"active_lease_holder_label" json:"active_lease_holder_label,omitempty"`
 	PullRequest                 *PullRequest               `json:"pull_request,omitempty"`
 	CreatedAt                   time.Time                  `db:"created_at" json:"created_at"`
 	UpdatedAt                   time.Time                  `db:"updated_at" json:"updated_at"`


### PR DESCRIPTION
## Summary
Users reviewing a session’s pull requests can’t tell who is actively editing a given changeset, creating avoidable confusion and coordination risk. This change extends the changeset summary model and UI to surface the active lease holder type/label (e.g., “Being edited in Tab 2”) when a live lease exists.

## Changes
- Backend: include `active_lease_holder_type` and `active_lease_holder_label` in the session changesets summary query (derived from `session_changeset_leases` where the lease hasn’t expired).
- Frontend: add the lease-holder label line to the changeset summary UI when `active_lease_holder_label` is present.
- Types/tests: extend `ChangesetSummary` with the new optional fields and update pull request list tests to assert the new “Being edited in Tab 2” text.

## Validation
- Updated/ran frontend unit tests for `PullRequestList` (including the new label assertion).
- Ran backend session changesets tests to ensure the lease fields are returned as expected.

[143.dev](https://143.dev) | [session 86ed7af3](https://143.dev/sessions/86ed7af3-e0aa-462b-8079-d57bc1239d1a)

<!-- 143 readiness -->
**143 readiness:** Ready with warnings (workspace revision 7; 7 passed, 1 warnings, 0 blockers).

Preview: https://143.dev/previews/github/assembledhq/143/pull/1830?launch=1