### PR TITLE
Unify PR details and session panel button sizes across merge and review actions

### DIFF
--- a/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
@@ -6488,7 +6488,7 @@ export function SessionDetailContent({ id }: { id: string }) {
                     {closedPRLabel}
                   </Badge>
                 )}
-                <Button asChild variant="outline" size="sm" className="h-7 text-xs gap-1.5" title="View PR (p v)">
+                <Button asChild variant="outline" size="sm" className="text-xs gap-1.5" title="View PR (p v)">
                   <a href={selectedPR.github_pr_url} target="_blank" rel="noopener noreferrer">
                     <ExternalLink className="h-3 w-3" />
                     View PR
@@ -6498,7 +6498,7 @@ export function SessionDetailContent({ id }: { id: string }) {
             ) : showPRAction && !prErrorNotice ? (
               <>
                 {branchURL ? (
-                  <Button asChild variant="outline" size="sm" className="h-7 text-xs gap-1.5" title="View branch">
+                  <Button asChild variant="outline" size="sm" className="text-xs gap-1.5" title="View branch">
                     <a href={branchURL} target="_blank" rel="noopener noreferrer">
                       <GitBranch className="h-3 w-3" />
                       View branch

--- a/frontend/src/components/pr-health-banner.test.tsx
+++ b/frontend/src/components/pr-health-banner.test.tsx
@@ -353,15 +353,15 @@ describe("PRHealthBanner", () => {
       />,
     );
 
+    const mergeAction = screen.getByRole("button", { name: "Merge" });
     const moreActions = screen.getByRole("button", { name: "More merge actions" });
+    const actionGroup = moreActions.closest("[data-slot='button-group']");
+    expect(actionGroup).toHaveAttribute("data-size", "sm");
+    expect(mergeAction).toHaveAttribute("data-size", "sm");
+    expect(mergeAction).toHaveClass("h-10", "sm:h-7");
     expect(moreActions).toHaveAttribute("data-size", "icon-sm");
     expect(moreActions).toHaveClass("size-10", "sm:size-7", "rounded-l-none");
     expect(moreActions).not.toHaveClass("h-7", "w-7");
-    expect(moreActions.closest("[data-slot='button-group']")).toHaveClass(
-      "h-10",
-      "sm:h-7",
-      "[&_[data-slot=button]]:!h-full",
-    );
 
     await userEvent.setup().click(moreActions);
     const menuItem = await screen.findByRole("menuitem", { name: "Merge when ready" });

--- a/frontend/src/components/pr-health-banner.tsx
+++ b/frontend/src/components/pr-health-banner.tsx
@@ -265,10 +265,7 @@ export function PRHealthBanner({
                     )}
                   </div>
                 )}
-                <div
-                  data-testid="pr-health-actions"
-                  className="flex flex-wrap items-stretch gap-2 [&>[data-slot=button-group]]:h-10 [&>[data-slot=button]]:h-10 [&>span]:h-10 sm:[&>[data-slot=button-group]]:h-7 sm:[&>[data-slot=button]]:h-7 sm:[&>span]:h-7 [&>span>[data-slot=button]]:h-full"
-                >
+                <div className="flex flex-wrap items-stretch gap-2">
                   {canShowMergeButton && (
                     <ButtonGroup size="sm">
                       <DisabledTooltip disabled={mergeAction.disabled} content={mergeAction.disabledReason}>

--- a/frontend/src/components/pr-health-banner.tsx
+++ b/frontend/src/components/pr-health-banner.tsx
@@ -265,7 +265,10 @@ export function PRHealthBanner({
                     )}
                   </div>
                 )}
-                <div className="flex flex-wrap gap-2">
+                <div
+                  data-testid="pr-health-actions"
+                  className="flex flex-wrap items-stretch gap-2 [&>[data-slot=button-group]]:h-10 [&>[data-slot=button]]:h-10 [&>span]:h-10 sm:[&>[data-slot=button-group]]:h-7 sm:[&>[data-slot=button]]:h-7 sm:[&>span]:h-7 [&>span>[data-slot=button]]:h-full"
+                >
                   {canShowMergeButton && (
                     <ButtonGroup size="sm">
                       <DisabledTooltip disabled={mergeAction.disabled} content={mergeAction.disabledReason}>

--- a/frontend/src/components/ui/button-group.test.tsx
+++ b/frontend/src/components/ui/button-group.test.tsx
@@ -6,7 +6,7 @@ import { Button } from "./button"
 import { ButtonGroup } from "./button-group"
 
 describe("ButtonGroup", () => {
-  it("owns one height for text buttons and attached icon buttons", () => {
+  it("uses the shared button sizes for text and attached icon buttons", () => {
     renderWithProviders(
       <ButtonGroup size="sm" aria-label="Publish actions">
         <Button size="sm">Publish</Button>
@@ -18,8 +18,11 @@ describe("ButtonGroup", () => {
 
     const group = screen.getByRole("group", { name: "Publish actions" })
     expect(group).toHaveAttribute("data-size", "sm")
-    expect(group).toHaveClass("h-10", "sm:h-7", "[&_[data-slot=button]]:!h-full")
+    expect(group).not.toHaveClass("h-10")
+    expect(group).not.toHaveClass("sm:h-7")
+    expect(group).not.toHaveClass("[&_[data-slot=button]]:!h-full")
     expect(screen.getByRole("button", { name: "Publish" })).toHaveAttribute("data-size", "sm")
+    expect(screen.getByRole("button", { name: "Publish" })).toHaveClass("h-10", "sm:h-7")
     expect(screen.getByRole("button", { name: "More publish actions" })).toHaveAttribute("data-size", "icon-sm")
     expect(screen.getByRole("button", { name: "More publish actions" })).toHaveClass("size-10", "sm:size-7")
   })

--- a/frontend/src/components/ui/button-group.tsx
+++ b/frontend/src/components/ui/button-group.tsx
@@ -1,32 +1,17 @@
 import * as React from "react"
-import { cva, type VariantProps } from "class-variance-authority"
+import { cva } from "class-variance-authority"
 
 import { cn } from "@/lib/utils"
 import { ButtonGroupSizeContext, type ButtonGroupSize } from "./button-group-context"
 
-const buttonGroupVariants = cva(
-  "inline-flex w-fit items-stretch [&_[data-slot=button]]:!h-full",
-  {
-    variants: {
-      size: {
-        default: "h-10 sm:h-8",
-        xs: "h-10 sm:h-6",
-        sm: "h-10 sm:h-7",
-        lg: "h-10 sm:h-9",
-      },
-    },
-    defaultVariants: {
-      size: "default",
-    },
-  },
-)
+const buttonGroupVariants = cva("inline-flex w-fit items-stretch")
 
 function ButtonGroup({
   className,
   size = "default",
   ...props
-}: React.ComponentProps<"div"> & VariantProps<typeof buttonGroupVariants>) {
-  const resolvedSize: ButtonGroupSize = size ?? "default"
+}: React.ComponentProps<"div"> & { size?: ButtonGroupSize }) {
+  const resolvedSize = size
 
   return (
     <ButtonGroupSizeContext.Provider value={resolvedSize}>
@@ -34,7 +19,7 @@ function ButtonGroup({
         role="group"
         data-slot="button-group"
         data-size={resolvedSize}
-        className={cn(buttonGroupVariants({ size: resolvedSize }), className)}
+        className={cn(buttonGroupVariants(), className)}
         {...props}
       />
     </ButtonGroupSizeContext.Provider>


### PR DESCRIPTION
## Summary

PR action rows in the PR health banner can render grouped actions (e.g., Merge button group) and standalone actions (e.g., Review) at different heights, causing misalignment on desktop and mobile. This change standardizes the action container and button sizing so all actions share the same height regardless of grouping.

## Changes

- Updated `frontend/src/components/pr-health-banner.tsx` to add a `data-testid="pr-health-actions"` wrapper around the action row.
- Applied consistent Tailwind height utilities to:
  - the action container
  - button groups and individual buttons
  - the `span`/inner wrapper elements used by the layout
- Introduced responsive sizing so desktop and small screens share the same visual height rules.

## Validation

- `git diff --check` passes.
- Note: focused unit test could not run because frontend dependencies are not installed in this environment (`vitest: not found`).

[143.dev](https://143.dev) | [session 72773daf](https://143.dev/sessions/72773daf-ab6e-4463-9d73-4b0d80257b71)

<!-- 143 readiness -->
**143 readiness:** not available for this revision.

Preview: https://143.dev/previews/github/assembledhq/143/pull/1831?launch=1