### PR TITLE
Adjust modal image vertical offset to lower content and align close button

### DIFF
--- a/frontend/src/components/manual-session-composer.tsx
+++ b/frontend/src/components/manual-session-composer.tsx
@@ -1345,7 +1345,7 @@ export function ManualSessionComposer({
                 isUploading={isUploading}
                 onRemove={removeAttachment}
                 size="md"
-                className="pt-2 pb-3"
+                className="pt-3 pb-1"
               />
 
               {showImageInput && (


### PR DESCRIPTION
## Summary

The modal’s attachment strip spacing was slightly misaligned vertically, making the content feel “high” relative to the close button and surrounding UI. This change updates the attachment strip padding classes to better match the intended layout, improving visual consistency without altering behavior.

## Changes

- Updated the attachment strip spacing in `frontend/src/components/manual-session-composer.tsx`:
  - Changed `className` from `pt-2 pb-3` to `pt-3 pb-1` to shift vertical offset down.

## Validation

- Manually verified the modal layout in the Manual Session Composer to confirm the attachment strip and close button alignment looks correct.

[143.dev](https://143.dev) | [session a7e00ead](https://143.dev/sessions/a7e00ead-1961-4ee7-a929-9ead11c76eeb)

<!-- 143 readiness -->
**143 readiness:** not available for this revision.

Preview: https://143.dev/previews/github/assembledhq/143/pull/1832?launch=1