### PR TITLE
Make left sidebar resizable with smooth collapse to icon-only mode preserving vertical alignment

### DIFF
--- a/frontend/src/components/authenticated-layout.test.tsx
+++ b/frontend/src/components/authenticated-layout.test.tsx
@@ -203,6 +203,78 @@ describe("AuthenticatedLayout", () => {
     expect(window.localStorage.getItem("143:app-sidebar-width")).toBe("300");
   });
 
+  it("shrinks to an icon-only sidebar while keeping the same navigation rows mounted", () => {
+    const { container } = renderWithProviders(
+      <AuthenticatedLayout>
+        <div>content</div>
+      </AuthenticatedLayout>
+    );
+
+    const sidebar = container.querySelector("[data-testid='app-sidebar']");
+    const handle = container.querySelector("[data-testid='app-sidebar-resize-handle']");
+    const sessionsLink = within(sidebar as HTMLElement).getByRole("link", { name: "Sessions" });
+    expect(handle).not.toBeNull();
+
+    fireEvent.pointerDown(handle!, { clientX: 300, pointerId: 1, button: 0 });
+    fireEvent.pointerMove(document, { clientX: 0, pointerId: 1 });
+    fireEvent.pointerUp(document, { pointerId: 1 });
+
+    expect(sidebar).toHaveStyle({ "--app-sidebar-w": "56px" });
+    expect(sidebar).toHaveAttribute("data-collapsed", "true");
+    expect(window.localStorage.getItem("143:app-sidebar-width")).toBe("56");
+    expect(within(sidebar as HTMLElement).getByRole("link", { name: "Sessions" })).toBe(sessionsLink);
+    expect(sessionsLink).toHaveClass("justify-center", "px-0");
+    expect(within(sidebar as HTMLElement).getByText("Sessions")).toHaveClass("max-w-0", "opacity-0");
+    expect(sessionsLink).toHaveAttribute("title", "Sessions");
+    expect(within(sidebar as HTMLElement).getByRole("button", { name: "Settings" })).toHaveClass("justify-center", "px-0");
+  });
+
+  it("snaps out of the collapsed dead zone to the icon-rail width on release", () => {
+    const { container } = renderWithProviders(
+      <AuthenticatedLayout>
+        <div>content</div>
+      </AuthenticatedLayout>
+    );
+
+    const sidebar = container.querySelector("[data-testid='app-sidebar']");
+    const handle = container.querySelector("[data-testid='app-sidebar-resize-handle']");
+    expect(handle).not.toBeNull();
+
+    fireEvent.pointerDown(handle!, { clientX: 236, pointerId: 1, button: 0 });
+    // While the pointer drives the width, the edge tracks the cursor 1:1 (no
+    // width transition) and does not snap yet even inside the collapsed band.
+    expect(sidebar).not.toHaveClass("transition-[width]");
+    fireEvent.pointerMove(document, { clientX: 100, pointerId: 1 });
+    expect(sidebar).toHaveStyle({ "--app-sidebar-w": "100px" });
+    expect(sidebar).toHaveAttribute("data-collapsed", "true");
+
+    fireEvent.pointerUp(document, { pointerId: 1 });
+    // On release it settles to the icon-rail min width and re-enables the
+    // width transition so the snap animates.
+    expect(sidebar).toHaveStyle({ "--app-sidebar-w": "56px" });
+    expect(sidebar).toHaveClass("transition-[width]");
+    expect(window.localStorage.getItem("143:app-sidebar-width")).toBe("56");
+  });
+
+  it("does not snap when the drag ends above the collapse threshold", () => {
+    const { container } = renderWithProviders(
+      <AuthenticatedLayout>
+        <div>content</div>
+      </AuthenticatedLayout>
+    );
+
+    const sidebar = container.querySelector("[data-testid='app-sidebar']");
+    const handle = container.querySelector("[data-testid='app-sidebar-resize-handle']");
+
+    fireEvent.pointerDown(handle!, { clientX: 236, pointerId: 1, button: 0 });
+    fireEvent.pointerMove(document, { clientX: 216, pointerId: 1 });
+    fireEvent.pointerUp(document, { pointerId: 1 });
+
+    expect(sidebar).toHaveStyle({ "--app-sidebar-w": "216px" });
+    expect(sidebar).toHaveAttribute("data-collapsed", "false");
+    expect(window.localStorage.getItem("143:app-sidebar-width")).toBe("216");
+  });
+
   it("uses a full-width content area with responsive padding", () => {
     const { container } = renderWithProviders(
       <AuthenticatedLayout>

--- a/frontend/src/components/authenticated-layout.tsx
+++ b/frontend/src/components/authenticated-layout.tsx
@@ -80,8 +80,9 @@ function isPlainNavClick(e: React.MouseEvent): boolean {
 const buildSha = process.env.NEXT_PUBLIC_BUILD_SHA || "dev";
 const shortSha = buildSha === "dev" ? "dev" : buildSha.slice(0, 7);
 const APP_SIDEBAR_DEFAULT_WIDTH = 236;
-const APP_SIDEBAR_MIN_WIDTH = 200;
+const APP_SIDEBAR_MIN_WIDTH = 56;
 const APP_SIDEBAR_MAX_WIDTH = 300;
+const APP_SIDEBAR_COLLAPSE_AT = 152;
 const APP_SIDEBAR_STORAGE_KEY = "143:app-sidebar-width";
 
 function prefetchAuthGateRouteData(queryClient: QueryClient, pathname: string): void {
@@ -151,6 +152,7 @@ type SidebarBodyProps = {
   canCreateSession: boolean;
   onNavigate?: () => void;
   onLogout: () => void;
+  collapsed?: boolean;
 };
 
 function SidebarBody({
@@ -162,6 +164,7 @@ function SidebarBody({
   canCreateSession,
   onNavigate,
   onLogout,
+  collapsed = false,
 }: SidebarBodyProps) {
   const isMobile = variant === "mobile";
   // Touch-friendly sizing on mobile: nav items ~44px tall, icon buttons 44×44.
@@ -177,10 +180,15 @@ function SidebarBody({
       <div
         className={cn(
           "relative flex items-center justify-between",
-          isMobile ? "px-3 py-3" : "px-4 py-3.5"
+          isMobile ? "px-3 py-3" : "h-14 px-2",
+          collapsed && "justify-center",
         )}
       >
-        <div className="flex items-center min-w-0 flex-1">
+        <div
+          aria-hidden={collapsed || undefined}
+          inert={collapsed || undefined}
+          className={cn("flex items-center min-w-0 flex-1 transition-opacity duration-150", collapsed && "pointer-events-none absolute opacity-0")}
+        >
           <OrgSwitcher userEmail={user?.email} />
         </div>
         {isMobile ? (
@@ -196,7 +204,7 @@ function SidebarBody({
           </SheetClose>
         ) : (
           <TooltipProvider>
-            <div className="flex items-center gap-0.5">
+            <div className={cn("flex items-center gap-0.5", collapsed && "w-full justify-center")}>
               <Tooltip>
                 <TooltipTrigger asChild>
                   <Button
@@ -216,7 +224,7 @@ function SidebarBody({
                   Search <Kbd variant="inverted">⌘K</Kbd>
                 </TooltipContent>
               </Tooltip>
-              {canCreateSession && (
+              {canCreateSession && !collapsed && (
                 <Tooltip>
                   <TooltipTrigger asChild>
                     <Button
@@ -241,17 +249,19 @@ function SidebarBody({
       </div>
 
       {/* Navigation */}
-      <nav className="relative flex-1 px-2 space-y-0.5 overflow-y-auto">
+      <nav className="relative flex-1 px-2 space-y-0.5 overflow-y-auto overflow-x-hidden">
         {navItems.map((item) => {
           const isActive = pathname === item.href || pathname.startsWith(item.href + "/");
           return (
             <Link
               key={item.href}
               href={item.href}
+              title={collapsed ? item.label : undefined}
               onClick={onNavigate ? (e) => { if (isPlainNavClick(e)) onNavigate(); } : undefined}
               aria-current={isActive ? "page" : undefined}
               className={cn(
-                "relative flex items-center gap-2.5 rounded-md px-2.5 font-medium transition-colors duration-[175ms] active:bg-sidebar-accent",
+                "relative flex items-center gap-2.5 rounded-md px-2.5 font-medium transition-all duration-[175ms] active:bg-sidebar-accent",
+                collapsed && "justify-center px-0",
                 navItemClasses,
                 isActive
                   ? "bg-accent/65 text-foreground before:absolute before:inset-y-1.5 before:left-0 before:w-0.5 before:rounded-full before:bg-primary"
@@ -259,7 +269,7 @@ function SidebarBody({
               )}
             >
               <item.icon className="h-4 w-4 shrink-0" />
-              <span className="flex-1">{item.label}</span>
+              <span className={cn("flex-1 overflow-hidden whitespace-nowrap transition-[max-width,opacity] duration-150", collapsed ? "max-w-0 opacity-0" : "max-w-48 opacity-100")}>{item.label}</span>
             </Link>
           );
         })}
@@ -268,13 +278,14 @@ function SidebarBody({
           userRole={user?.role}
           onNavigate={onNavigate}
           variant={variant}
+          collapsed={collapsed}
         />
       </nav>
 
       {/* Repo context switcher */}
       <div
         data-testid="repo-context-switcher-slot"
-        className="relative px-2 pb-1 border-t border-sidebar-border/70 pt-2 empty:hidden"
+        className={cn("relative px-2 pb-1 border-t border-sidebar-border/70 pt-2 empty:hidden", collapsed && "hidden")}
       >
         <RepoContextSwitcher />
       </div>
@@ -292,8 +303,10 @@ function SidebarBody({
               <Button
                 variant="ghost"
                 size="sm"
+                title={collapsed ? user.name : undefined}
                 className={cn(
-                  "w-full justify-start gap-2 rounded-md px-2.5 font-medium transition-colors duration-150 text-sidebar-foreground/70 hover:bg-sidebar-accent hover:text-sidebar-foreground",
+                  "w-full justify-start gap-2 rounded-md px-2.5 font-medium transition-all duration-150 text-sidebar-foreground/70 hover:bg-sidebar-accent hover:text-sidebar-foreground",
+                  collapsed && "justify-center px-0",
                   isMobile ? "h-11 text-sm" : "h-8 text-xs"
                 )}
               >
@@ -309,8 +322,8 @@ function SidebarBody({
                     {user.name?.[0]?.toUpperCase() ?? "?"}
                   </div>
                 )}
-                <span className="truncate flex-1 text-left">{user.name}</span>
-                <ChevronsUpDown className="h-3.5 w-3.5 shrink-0 opacity-40" />
+                <span className={cn("truncate flex-1 text-left transition-[max-width,opacity] duration-150", collapsed ? "max-w-0 opacity-0" : "max-w-48 opacity-100")}>{user.name}</span>
+                <ChevronsUpDown className={cn("h-3.5 w-3.5 shrink-0 opacity-40", collapsed && "hidden")} />
               </Button>
             </DropdownMenuTrigger>
             <DropdownMenuContent align="start" side="top" className="w-48">
@@ -601,12 +614,20 @@ export function AuthenticatedLayout({ children }: { children: React.ReactNode })
     prefetchedPathRef.current = pathname;
     prefetchAuthGateRouteData(queryClient, pathname);
   }, [isLoading, pathname, queryClient, user]);
-  const { width: appSidebarWidth, resizeBy: resizeAppSidebar } = usePersistedPanelWidth({
+  const { width: appSidebarWidth, resizeBy: resizeAppSidebar, settle: settleAppSidebar } = usePersistedPanelWidth({
     storageKey: APP_SIDEBAR_STORAGE_KEY,
     defaultWidth: APP_SIDEBAR_DEFAULT_WIDTH,
     minWidth: APP_SIDEBAR_MIN_WIDTH,
     maxWidth: APP_SIDEBAR_MAX_WIDTH,
+    collapseBelow: APP_SIDEBAR_COLLAPSE_AT,
   });
+  const appSidebarCollapsed = appSidebarWidth < APP_SIDEBAR_COLLAPSE_AT;
+  const [isResizingAppSidebar, setIsResizingAppSidebar] = useState(false);
+  const handleAppSidebarResizeStart = useCallback(() => setIsResizingAppSidebar(true), []);
+  const handleAppSidebarResizeEnd = useCallback(() => {
+    setIsResizingAppSidebar(false);
+    settleAppSidebar();
+  }, [settleAppSidebar]);
 
   // Global Cmd+K / Ctrl+K shortcut
   useEffect(() => {
@@ -723,7 +744,8 @@ export function AuthenticatedLayout({ children }: { children: React.ReactNode })
           data-testid="app-sidebar"
           style={{ "--app-sidebar-w": `${appSidebarWidth}px` } as React.CSSProperties}
           className={cn(
-            "hidden xl:flex bg-sidebar border-r border-sidebar-border flex-col w-[var(--app-sidebar-w)]"
+            "hidden xl:flex bg-sidebar border-r border-sidebar-border flex-col w-[var(--app-sidebar-w)] overflow-hidden",
+            !isResizingAppSidebar && "transition-[width] duration-150 ease-out"
           )}
         >
           <div className="px-4 py-4">
@@ -745,7 +767,12 @@ export function AuthenticatedLayout({ children }: { children: React.ReactNode })
           </div>
         </aside>
         <div className="hidden xl:block">
-          <ResizeHandle onResize={resizeAppSidebar} testId="app-sidebar-resize-handle" />
+          <ResizeHandle
+            onResize={resizeAppSidebar}
+            onResizeStart={handleAppSidebarResizeStart}
+            onResizeEnd={handleAppSidebarResizeEnd}
+            testId="app-sidebar-resize-handle"
+          />
         </div>
         <div className="flex flex-1 min-w-0 flex-col">
           <header className="md:hidden flex h-14 items-center gap-2 border-b border-sidebar-border bg-sidebar px-3">
@@ -793,8 +820,12 @@ export function AuthenticatedLayout({ children }: { children: React.ReactNode })
         data-testid="app-sidebar"
         style={{ "--app-sidebar-w": `${appSidebarWidth}px` } as React.CSSProperties}
         className={cn(
-          "hidden xl:flex bg-sidebar border-r border-sidebar-border flex-col relative w-[var(--app-sidebar-w)]"
+          "hidden xl:flex bg-sidebar border-r border-sidebar-border flex-col relative w-[var(--app-sidebar-w)] overflow-hidden",
+          // Animate width only when settling/collapsing, not while the pointer is
+          // driving the width directly — otherwise the edge lags behind the cursor.
+          !isResizingAppSidebar && "transition-[width] duration-150 ease-out"
         )}
+        data-collapsed={appSidebarCollapsed ? "true" : "false"}
       >
         <SidebarBody
           variant="desktop"
@@ -804,10 +835,16 @@ export function AuthenticatedLayout({ children }: { children: React.ReactNode })
           onCreateSession={handleCreateSessionOpen}
           canCreateSession={canCreateSession}
           onLogout={logout}
+          collapsed={appSidebarCollapsed}
         />
       </aside>
       <div className="hidden xl:block">
-        <ResizeHandle onResize={resizeAppSidebar} testId="app-sidebar-resize-handle" />
+        <ResizeHandle
+          onResize={resizeAppSidebar}
+          onResizeStart={handleAppSidebarResizeStart}
+          onResizeEnd={handleAppSidebarResizeEnd}
+          testId="app-sidebar-resize-handle"
+        />
       </div>
 
       {/* Mobile drawer (below md) */}

--- a/frontend/src/components/resize-handle.tsx
+++ b/frontend/src/components/resize-handle.tsx
@@ -8,11 +8,15 @@ interface ResizeHandleProps {
   direction?: "horizontal";
   /** Called continuously during drag with the delta in px (positive = right/down) */
   onResize: (delta: number) => void;
+  /** Called once when a drag begins */
+  onResizeStart?: () => void;
+  /** Called once when a drag ends (pointer up or cancel) */
+  onResizeEnd?: () => void;
   className?: string;
   testId?: string;
 }
 
-export function ResizeHandle({ direction = "horizontal", onResize, className, testId }: ResizeHandleProps) {
+export function ResizeHandle({ direction = "horizontal", onResize, onResizeStart, onResizeEnd, className, testId }: ResizeHandleProps) {
   const activePointerId = useRef<number | null>(null);
   const lastPos = useRef(0);
   const [isDragging, setIsDragging] = useState(false);
@@ -37,11 +41,13 @@ export function ResizeHandle({ direction = "horizontal", onResize, className, te
 
   const stopDragging = useCallback((pointerId?: number) => {
     if (pointerId !== undefined && activePointerId.current !== pointerId) return;
+    if (activePointerId.current === null) return;
 
     activePointerId.current = null;
     setIsDragging(false);
     resetDocumentDragStyles();
-  }, [resetDocumentDragStyles]);
+    onResizeEnd?.();
+  }, [resetDocumentDragStyles, onResizeEnd]);
 
   const handlePointerUp = useCallback((e: PointerEvent) => {
     stopDragging(e.pointerId);
@@ -71,6 +77,7 @@ export function ResizeHandle({ direction = "horizontal", onResize, className, te
     document.body.style.cursor = "col-resize";
     document.body.style.userSelect = "none";
     e.currentTarget.setPointerCapture?.(e.pointerId);
+    onResizeStart?.();
   }
 
   return (

--- a/frontend/src/components/sidebar-settings-section.tsx
+++ b/frontend/src/components/sidebar-settings-section.tsx
@@ -104,11 +104,13 @@ export function SidebarSettingsSection({
   userRole,
   onNavigate,
   variant = "desktop",
+  collapsed = false,
 }: {
   pathname: string;
   userRole: string | undefined;
   onNavigate?: () => void;
   variant?: "desktop" | "mobile";
+  collapsed?: boolean;
 }) {
   const onSettingsPage = isSettingsPath(pathname);
   const isMobile = variant === "mobile";
@@ -143,27 +145,30 @@ export function SidebarSettingsSection({
   }, [isOpen]);
 
   return (
-    <Collapsible open={isOpen} onOpenChange={setIsOpen}>
+    <Collapsible open={!collapsed && isOpen} onOpenChange={setIsOpen}>
       <div data-testid="sidebar-settings-divider" className="mx-0 my-1 border-t border-sidebar-border/70" />
       <CollapsibleTrigger asChild>
         <Button
           type="button"
+          title={collapsed ? "Settings" : undefined}
           variant="ghost"
           className={cn(
-            "relative flex h-auto w-full items-center rounded-md px-2.5 font-medium transition-colors duration-[175ms]",
+            "relative flex h-auto w-full items-center rounded-md px-2.5 font-medium transition-all duration-[175ms]",
             isMobile ? "gap-2.5 py-3 text-sm" : "gap-2.5 py-[7px] type-dense",
+            collapsed && "justify-center px-0",
             onSettingsPage
               ? "bg-accent/65 text-foreground before:absolute before:inset-y-1.5 before:left-0 before:w-0.5 before:rounded-full before:bg-primary"
               : "text-sidebar-foreground/70 hover:bg-sidebar-accent hover:text-sidebar-foreground"
           )}
         >
           <Settings className="h-4 w-4 shrink-0" />
-          <span className="flex-1 text-left">Settings</span>
+          <span className={cn("flex-1 overflow-hidden whitespace-nowrap text-left transition-[max-width,opacity] duration-150", collapsed ? "max-w-0 opacity-0" : "max-w-48 opacity-100")}>Settings</span>
           <ChevronRight
             className={cn(
               "shrink-0 opacity-50 transition-transform duration-200",
               isMobile ? "h-4 w-4" : "h-3.5 w-3.5",
-              isOpen && "rotate-90"
+              isOpen && "rotate-90",
+              collapsed && "hidden",
             )}
           />
         </Button>

--- a/frontend/src/hooks/use-persisted-panel-width.ts
+++ b/frontend/src/hooks/use-persisted-panel-width.ts
@@ -7,6 +7,12 @@ interface UsePersistedPanelWidthOptions {
   defaultWidth: number;
   minWidth: number;
   maxWidth: number;
+  /**
+   * When set, calling `settle()` after a drag that ended below this width snaps
+   * the panel to `minWidth` (the icon-rail width), so it never rests in the
+   * dead zone between `minWidth` and the collapse threshold.
+   */
+  collapseBelow?: number;
 }
 
 function clampWidth(width: number, minWidth: number, maxWidth: number): number {
@@ -48,8 +54,17 @@ export function usePersistedPanelWidth({
   defaultWidth,
   minWidth,
   maxWidth,
+  collapseBelow,
 }: UsePersistedPanelWidthOptions) {
   const [width, setWidth] = useState(defaultWidth);
+
+  const persistWidth = useCallback((nextWidth: number) => {
+    try {
+      window.localStorage.setItem(storageKey, String(nextWidth));
+    } catch (error) {
+      console.error("failed to persist panel width", { storageKey, width: nextWidth, error });
+    }
+  }, [storageKey]);
 
   useEffect(() => {
     const syncWidthFromStorage = () => {
@@ -64,16 +79,19 @@ export function usePersistedPanelWidth({
   const resizeBy = useCallback((delta: number) => {
     setWidth((current) => {
       const nextWidth = clampWidth(current + delta, minWidth, maxWidth);
-
-      try {
-        window.localStorage.setItem(storageKey, String(nextWidth));
-      } catch (error) {
-        console.error("failed to persist panel width", { storageKey, width: nextWidth, error });
-      }
-
+      persistWidth(nextWidth);
       return nextWidth;
     });
-  }, [maxWidth, minWidth, storageKey]);
+  }, [maxWidth, minWidth, persistWidth]);
 
-  return { width, resizeBy };
+  const settle = useCallback(() => {
+    if (collapseBelow === undefined) return;
+    setWidth((current) => {
+      if (current >= collapseBelow || current === minWidth) return current;
+      persistWidth(minWidth);
+      return minWidth;
+    });
+  }, [collapseBelow, minWidth, persistWidth]);
+
+  return { width, resizeBy, settle };
 }


### PR DESCRIPTION
## Summary

The left sidebar resize/collapse behavior was unreliable: when shrinking into the collapsed (dead) zone, navigation could unmount/reflow and the sidebar could “snap” at the wrong time. This PR makes the sidebar smoothly collapse to icon-only width while preserving vertical alignment by keeping the same navigation rows mounted and only switching visibility/alignment classes; it also ensures snapping happens correctly on pointer release and persists the final width in localStorage.

## Changes

- Update sidebar resizing/collapse logic to support a smooth drag into icon-only mode without remounting navigation rows.
- Ensure collapse state is reflected via `data-collapsed` and CSS variable `--app-sidebar-w`, with correct snap behavior on pointer release.
- Persist the final sidebar width to `143:app-sidebar-width` and keep edge/transition behavior consistent to avoid premature snapping.
- Add/extend tests to validate: icon-only mode preserves mounted “Sessions” row, snaps correctly on release, and does not snap if released above the collapse threshold.

## Validation

- Frontend unit tests: `authenticated-layout.test.tsx` (pointer drag/collapse/release scenarios; localStorage persistence; row mounting and alignment class assertions).

[143.dev](https://143.dev) | [session a9b4ec9c](https://143.dev/sessions/a9b4ec9c-0d46-4ebe-bfb5-40c3644b1291)

<!-- 143 readiness -->
**143 readiness:** Ready with warnings (workspace revision 11; 6 passed, 2 warnings, 0 blockers).

Preview: https://143.dev/previews/github/assembledhq/143/pull/1833?launch=1