### PR TITLE
Standardize PR and Session detail button sizing using shared component styles

### DIFF
--- a/frontend/src/app/(dashboard)/sessions/[id]/page-pr-creation.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/page-pr-creation.test.tsx
@@ -180,8 +180,9 @@ describe('SessionDetailPage PR creation', () => {
 
     renderWithProviders(<SessionDetailContent id="session-abcdef12-3456-7890" />);
     await screen.findAllByText('Fixed TypeError by adding null check');
-    expect(await screen.findByRole('button', { name: /Create PR/ })).toBeInTheDocument();
+    expect(await screen.findByRole('button', { name: /Create PR/ })).toHaveAttribute('data-size', 'xs');
     expect(screen.getByRole('button', { name: /Create PR/ })).not.toBeDisabled();
+    expect(screen.getByRole('button', { name: 'More publish actions' })).toHaveAttribute('data-size', 'icon-xs');
 
     const user = userEvent.setup();
     await user.click(screen.getByRole('button', { name: 'More publish actions' }));

--- a/frontend/src/app/(dashboard)/sessions/[id]/page-pr-health.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/page-pr-health.test.tsx
@@ -301,6 +301,7 @@ describe('SessionDetailPage PR health and merge', () => {
     expect(viewPRLink).toHaveAttribute('href', 'https://github.com/example/repo/pull/42');
     expect(viewPRLink).toHaveAttribute('target', '_blank');
     expect(viewPRLink).toHaveAttribute('rel', expect.stringContaining('noopener'));
+    expect(viewPRLink).toHaveAttribute('data-size', 'xs');
     expect(within(viewPRLink).queryByRole('button')).not.toBeInTheDocument();
   });
 

--- a/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
@@ -6493,7 +6493,7 @@ export function SessionDetailContent({ id }: { id: string }) {
                     {closedPRLabel}
                   </Badge>
                 )}
-                <Button asChild variant="outline" size="sm" className="text-xs gap-1.5" title="View PR (p v)">
+                <Button asChild variant="outline" size="xs" className="gap-1.5" title="View PR (p v)">
                   <a href={selectedPR.github_pr_url} target="_blank" rel="noopener noreferrer">
                     <ExternalLink className="h-3 w-3" />
                     View PR
@@ -6503,7 +6503,7 @@ export function SessionDetailContent({ id }: { id: string }) {
             ) : showPRAction && !prErrorNotice ? (
               <>
                 {branchURL ? (
-                  <Button asChild variant="outline" size="sm" className="text-xs gap-1.5" title="View branch">
+                  <Button asChild variant="outline" size="xs" className="gap-1.5" title="View branch">
                     <a href={branchURL} target="_blank" rel="noopener noreferrer">
                       <GitBranch className="h-3 w-3" />
                       View branch
@@ -6511,10 +6511,10 @@ export function SessionDetailContent({ id }: { id: string }) {
                   </Button>
                 ) : null}
                 <DisabledTooltip disabled={prActionDisabled} content={prActionTitle}>
-                  <ButtonGroup size="sm">
+                  <ButtonGroup size="xs">
                     <Button
                       variant="outline"
-                      size="sm"
+                      size="xs"
                       className="rounded-r-none border-r-0 text-xs gap-1.5"
                       loading={prActionSpinning}
                       disabled={prActionDisabled}
@@ -6532,7 +6532,7 @@ export function SessionDetailContent({ id }: { id: string }) {
                       <DropdownMenuTrigger asChild>
                         <Button
                           variant="outline"
-                          size="icon-sm"
+                          size="icon-xs"
                           className="rounded-l-none"
                           disabled={prActionDisabled}
                           aria-label="More publish actions"

--- a/frontend/src/components/pr-health-banner.test.tsx
+++ b/frontend/src/components/pr-health-banner.test.tsx
@@ -334,7 +334,7 @@ describe("PRHealthBanner", () => {
     expect(onQueue).toHaveBeenCalledTimes(1);
   });
 
-  it("matches the Create PR split button sizing and menu alignment", async () => {
+  it("uses compact shared sizing for PR actions and keeps the menu aligned", async () => {
     renderWithProviders(
       <PRHealthBanner
         health={{
@@ -356,11 +356,11 @@ describe("PRHealthBanner", () => {
     const mergeAction = screen.getByRole("button", { name: "Merge" });
     const moreActions = screen.getByRole("button", { name: "More merge actions" });
     const actionGroup = moreActions.closest("[data-slot='button-group']");
-    expect(actionGroup).toHaveAttribute("data-size", "sm");
-    expect(mergeAction).toHaveAttribute("data-size", "sm");
-    expect(mergeAction).toHaveClass("h-10", "sm:h-7");
-    expect(moreActions).toHaveAttribute("data-size", "icon-sm");
-    expect(moreActions).toHaveClass("size-10", "sm:size-7", "rounded-l-none");
+    expect(actionGroup).toHaveAttribute("data-size", "xs");
+    expect(mergeAction).toHaveAttribute("data-size", "xs");
+    expect(mergeAction).toHaveClass("h-10", "sm:h-6");
+    expect(moreActions).toHaveAttribute("data-size", "icon-xs");
+    expect(moreActions).toHaveClass("size-10", "sm:size-6", "rounded-l-none");
     expect(moreActions).not.toHaveClass("h-7", "w-7");
 
     await userEvent.setup().click(moreActions);

--- a/frontend/src/components/pr-health-banner.tsx
+++ b/frontend/src/components/pr-health-banner.tsx
@@ -229,7 +229,7 @@ export function PRHealthBanner({
                   <AlertTriangle className="mt-0.5 h-3.5 w-3.5 shrink-0" />
                   <span className="text-warning">Reconnect this repository to update PR status and resume PR actions.</span>
                 </div>
-                <Button asChild size="sm" variant="outline" className="w-fit bg-background text-foreground">
+                <Button asChild size="xs" variant="outline" className="w-fit bg-background text-foreground">
                   <Link href="/settings/integrations">
                     Open GitHub settings
                   </Link>
@@ -246,7 +246,7 @@ export function PRHealthBanner({
                     </Badge>
                     {activeRepairState.openSessionID && onOpenRepairSession && (
                       <Button
-                        size="sm"
+                        size="xs"
                         variant="outline"
                         onClick={() => onOpenRepairSession(activeRepairState.openSessionID!, activeRepairState.openThreadID ?? undefined)}
                       >
@@ -255,7 +255,7 @@ export function PRHealthBanner({
                     )}
                     {activeRepairState.isAutoRepair && activeRepairState.repairSessionID && onStopAutoRepair && (
                       <Button
-                        size="sm"
+                        size="xs"
                         variant="outline"
                         loading={stopAutoRepairPending}
                         onClick={() => onStopAutoRepair(activeRepairState.repairSessionID!, activeRepairState.openThreadID ?? undefined)}
@@ -267,10 +267,10 @@ export function PRHealthBanner({
                 )}
                 <div className="flex flex-wrap items-stretch gap-2">
                   {canShowMergeButton && (
-                    <ButtonGroup size="sm">
+                    <ButtonGroup size="xs">
                       <DisabledTooltip disabled={mergeAction.disabled} content={mergeAction.disabledReason}>
                         <Button
-                          size="sm"
+                          size="xs"
                           variant="default"
                           className={cn(canShowMergeWhenReady && "rounded-r-none border-r border-primary-foreground/20")}
                           disabled={mergeAction.disabled}
@@ -289,7 +289,7 @@ export function PRHealthBanner({
                         <DropdownMenu>
                           <DropdownMenuTrigger asChild>
                             <Button
-                              size="icon-sm"
+                              size="icon-xs"
                               variant="default"
                               className="rounded-l-none"
                               disabled={mergeWhenReadyAction.disabled}
@@ -319,9 +319,9 @@ export function PRHealthBanner({
                   )}
                   {canShowResolveConflictsButton && (
                     <DisabledTooltip disabled={pendingAction !== null} content="Wait for the current PR action to finish">
-                      <ButtonGroup size="sm">
+                      <ButtonGroup size="xs">
                         <Button
-                          size="sm"
+                          size="xs"
                           variant="outline"
                           className={onResolveConflictsWithoutPushing ? "rounded-r-none" : undefined}
                           disabled={pendingAction !== null}
@@ -339,7 +339,7 @@ export function PRHealthBanner({
                           <DropdownMenu>
                             <DropdownMenuTrigger asChild>
                               <Button
-                                size="icon-sm"
+                                size="icon-xs"
                                 variant="outline"
                                 className="rounded-l-none border-l-0"
                                 disabled={pendingAction !== null}
@@ -362,9 +362,9 @@ export function PRHealthBanner({
                   )}
                   {canShowFixTestsButton && (
                     <DisabledTooltip disabled={pendingAction !== null} content="Wait for the current PR action to finish">
-                      <ButtonGroup size="sm">
+                      <ButtonGroup size="xs">
                         <Button
-                          size="sm"
+                          size="xs"
                           variant="outline"
                           className={onFixTestsWithoutPushing ? "rounded-r-none" : undefined}
                           disabled={pendingAction !== null}
@@ -382,7 +382,7 @@ export function PRHealthBanner({
                           <DropdownMenu>
                             <DropdownMenuTrigger asChild>
                               <Button
-                                size="icon-sm"
+                                size="icon-xs"
                                 variant="outline"
                                 className="rounded-l-none border-l-0"
                                 disabled={pendingAction !== null}
@@ -409,7 +409,7 @@ export function PRHealthBanner({
                       content={pendingAction !== null ? "Wait for the current PR action to finish" : reviewAction.title}
                     >
                       <Button
-                        size="sm"
+                        size="xs"
                         variant="outline"
                         disabled={reviewAction.disabled || pendingAction !== null}
                         title={pendingAction !== null ? "Wait for the current PR action to finish" : reviewAction.title}
@@ -430,7 +430,7 @@ export function PRHealthBanner({
                       content={pendingAction !== null ? "Wait for the current PR action to finish" : pushChanges.title}
                     >
                       <Button
-                        size="sm"
+                        size="xs"
                         variant="outline"
                         disabled={pushChanges.disabled || pendingAction !== null}
                         title={pendingAction !== null ? "Wait for the current PR action to finish" : pushChanges.title ?? "Push changes (p p)"}
@@ -476,9 +476,9 @@ export function PRHealthBanner({
                     {onQueueMergeWhenReady && (
                       <DisabledTooltip disabled={mergeWhenReadyAction.disabled || mergeWhenReadyPending} content={mergeWhenReadyAction.disabledReason}>
                         <Button
-                          size="sm"
+                          size="xs"
                           variant="ghost"
-                          className="h-6 w-fit shrink-0 px-2 text-xs"
+                          className="w-fit shrink-0"
                           onClick={onQueueMergeWhenReady}
                           disabled={mergeWhenReadyAction.disabled || mergeWhenReadyPending}
                           title={mergeWhenReadyAction.disabledReason}


### PR DESCRIPTION
## Summary

Users viewing session details and creating PRs were seeing inconsistent button sizing (including leftover “one-off” retry sizing), which risks uneven mobile touch targets and confusing UI behavior. This change standardizes the PR/session-detail button components to use shared `xs` and `icon-xs` variants, ensuring consistent spacing and reliable sizing across related actions.

## Changes

- Updated Session detail UI buttons to use `size="xs"` (e.g., “View PR”, “View branch”) instead of `size="sm"` plus ad-hoc text sizing classes.
- Standardized grouped action controls by switching `ButtonGroup` from `size="sm"` to `size="xs"` so all child buttons align to the same sizing contract.
- Updated/strengthened tests to assert the expected `data-size` attributes for `Create PR`, `More publish actions`, and “View PR” links.

## Validation

- Updated frontend tests:
  - `frontend/src/app/(dashboard)/sessions/[id]/page-pr-creation.test.tsx`
  - `frontend/src/app/(dashboard)/sessions/[id]/page-pr-health.test.tsx`
  - `frontend/src/components/pr-health-banner.test.tsx`
- `git diff --check` passes.
- Note: automated test execution was not possible because frontend dependencies are not installed in this environment (`vitest: not found`).

[143.dev](https://143.dev) | [session c2ede148](https://143.dev/sessions/c2ede148-37af-4d89-afd6-917079bcaf4e)

<!-- 143 readiness -->
**143 readiness:** not available for this revision.

Preview: https://143.dev/previews/github/assembledhq/143/pull/1837?launch=1