### PR TITLE
Fix responsive navbar icon alignment and make settings menu float on small screens

### DIFF
--- a/frontend/src/components/authenticated-layout.tsx
+++ b/frontend/src/components/authenticated-layout.tsx
@@ -261,7 +261,7 @@ function SidebarBody({
               aria-current={isActive ? "page" : undefined}
               className={cn(
                 "relative flex items-center gap-2.5 rounded-md px-2.5 font-medium transition-all duration-[175ms] active:bg-sidebar-accent",
-                collapsed && "justify-center px-0",
+                collapsed && "justify-center gap-0 px-0",
                 navItemClasses,
                 isActive
                   ? "bg-accent/65 text-foreground before:absolute before:inset-y-1.5 before:left-0 before:w-0.5 before:rounded-full before:bg-primary"
@@ -306,7 +306,7 @@ function SidebarBody({
                 title={collapsed ? user.name : undefined}
                 className={cn(
                   "w-full justify-start gap-2 rounded-md px-2.5 font-medium transition-all duration-150 text-sidebar-foreground/70 hover:bg-sidebar-accent hover:text-sidebar-foreground",
-                  collapsed && "justify-center px-0",
+                  collapsed && "justify-center gap-0 px-0",
                   isMobile ? "h-11 text-sm" : "h-8 text-xs"
                 )}
               >

--- a/frontend/src/components/sidebar-settings-section.test.tsx
+++ b/frontend/src/components/sidebar-settings-section.test.tsx
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { renderWithProviders, screen } from "@/test/test-utils";
+import userEvent from "@testing-library/user-event";
 import { SidebarSettingsSection } from "./sidebar-settings-section";
 
 describe("SidebarSettingsSection", () => {
@@ -24,6 +25,23 @@ describe("SidebarSettingsSection", () => {
     );
 
     expect(screen.getByRole("button", { name: /Settings/ })).toHaveClass("px-2.5", "py-3", "text-sm");
+  });
+
+  it("opens collapsed settings in a floating menu", async () => {
+    const user = userEvent.setup();
+    renderWithProviders(
+      <SidebarSettingsSection pathname="/sessions" userRole="admin" collapsed />,
+    );
+
+    const trigger = screen.getByRole("button", { name: "Settings" });
+    expect(trigger).toHaveClass("justify-center", "px-0");
+    expect(screen.queryByRole("link", { name: "Account" })).not.toBeInTheDocument();
+
+    await user.click(trigger);
+
+    const menu = await screen.findByRole("menu");
+    expect(menu).toHaveAttribute("data-side", "right");
+    expect(screen.getByRole("menuitem", { name: "Account" })).toHaveAttribute("href", "/settings/account");
   });
 
   it("uses mobile-sized text for nested settings links in the mobile nav drawer", () => {

--- a/frontend/src/components/sidebar-settings-section.tsx
+++ b/frontend/src/components/sidebar-settings-section.tsx
@@ -25,6 +25,14 @@ import {
   CollapsibleTrigger,
   CollapsibleContent,
 } from "@/components/ui/collapsible";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 
 interface SettingsItem {
   label: string;
@@ -144,8 +152,71 @@ export function SidebarSettingsSection({
     localStorage.setItem(STORAGE_KEY, String(isOpen));
   }, [isOpen]);
 
+  const visibleGroups = settingsGroups
+    .map((group) => ({
+      ...group,
+      items: group.items.filter((item) => {
+        if (item.adminOnly && userRole !== "admin") return false;
+        if (item.hideForRoles?.includes(userRole ?? "")) return false;
+        return true;
+      }),
+    }))
+    .filter((group) => group.items.length > 0);
+
+  if (collapsed) {
+    return (
+      <DropdownMenu>
+        <div data-testid="sidebar-settings-divider" className="mx-0 my-1 border-t border-sidebar-border/70" />
+        <DropdownMenuTrigger asChild>
+          <Button
+            type="button"
+            title="Settings"
+            aria-label="Settings"
+            variant="ghost"
+            className={cn(
+              "relative flex h-auto w-full items-center justify-center rounded-md px-0 py-[7px] font-medium transition-colors duration-[175ms] type-dense",
+              onSettingsPage
+                ? "bg-accent/65 text-foreground before:absolute before:inset-y-1.5 before:left-0 before:w-0.5 before:rounded-full before:bg-primary"
+                : "text-sidebar-foreground/70 hover:bg-sidebar-accent hover:text-sidebar-foreground",
+            )}
+          >
+            <Settings className="h-4 w-4 shrink-0" />
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent
+          side="right"
+          align="start"
+          sideOffset={8}
+          className="w-56 max-h-[min(32rem,var(--radix-dropdown-menu-content-available-height))]"
+        >
+          {visibleGroups.map((group, groupIndex) => (
+            <div key={group.label ?? groupIndex}>
+              {groupIndex > 0 && <DropdownMenuSeparator />}
+              {group.label && (
+                <DropdownMenuLabel className="text-xs uppercase tracking-wider text-muted-foreground">
+                  {group.label}
+                </DropdownMenuLabel>
+              )}
+              {group.items.map((item) => {
+                const Icon = item.icon;
+                return (
+                  <DropdownMenuItem key={item.href} asChild>
+                    <Link href={item.href} onClick={onNavigate} className={cn(isItemActive(pathname, item.href) && "bg-accent text-accent-foreground")}>
+                      <Icon className="h-4 w-4" />
+                      {item.label}
+                    </Link>
+                  </DropdownMenuItem>
+                );
+              })}
+            </div>
+          ))}
+        </DropdownMenuContent>
+      </DropdownMenu>
+    );
+  }
+
   return (
-    <Collapsible open={!collapsed && isOpen} onOpenChange={setIsOpen}>
+    <Collapsible open={isOpen} onOpenChange={setIsOpen}>
       <div data-testid="sidebar-settings-divider" className="mx-0 my-1 border-t border-sidebar-border/70" />
       <CollapsibleTrigger asChild>
         <Button
@@ -155,20 +226,18 @@ export function SidebarSettingsSection({
           className={cn(
             "relative flex h-auto w-full items-center rounded-md px-2.5 font-medium transition-all duration-[175ms]",
             isMobile ? "gap-2.5 py-3 text-sm" : "gap-2.5 py-[7px] type-dense",
-            collapsed && "justify-center px-0",
             onSettingsPage
               ? "bg-accent/65 text-foreground before:absolute before:inset-y-1.5 before:left-0 before:w-0.5 before:rounded-full before:bg-primary"
               : "text-sidebar-foreground/70 hover:bg-sidebar-accent hover:text-sidebar-foreground"
           )}
         >
           <Settings className="h-4 w-4 shrink-0" />
-          <span className={cn("flex-1 overflow-hidden whitespace-nowrap text-left transition-[max-width,opacity] duration-150", collapsed ? "max-w-0 opacity-0" : "max-w-48 opacity-100")}>Settings</span>
+          <span className="flex-1 overflow-hidden whitespace-nowrap text-left">Settings</span>
           <ChevronRight
             className={cn(
               "shrink-0 opacity-50 transition-transform duration-200",
               isMobile ? "h-4 w-4" : "h-3.5 w-3.5",
               isOpen && "rotate-90",
-              collapsed && "hidden",
             )}
           />
         </Button>
@@ -179,14 +248,7 @@ export function SidebarSettingsSection({
       )}>
         <div className="min-h-0">
           <div className="mt-0.5 space-y-0.5">
-            {settingsGroups.map((group, groupIndex) => {
-              const visibleItems = group.items.filter((item) => {
-                if (item.adminOnly && userRole !== "admin") return false;
-                if (item.hideForRoles?.includes(userRole ?? "")) return false;
-                return true;
-              });
-              if (visibleItems.length === 0) return null;
-
+            {visibleGroups.map((group, groupIndex) => {
               return (
                 <div key={groupIndex}>
                   {group.label && (
@@ -199,7 +261,7 @@ export function SidebarSettingsSection({
                       {group.label}
                     </div>
                   )}
-                  {visibleItems.map((item) => {
+                  {group.items.map((item) => {
                     const active = isItemActive(pathname, item.href);
                     const Icon = item.icon;
                     return (


### PR DESCRIPTION
## Summary

On small screens, the collapsed sidebar’s Settings entry can misalign (icon/spacing regression) and the Settings links don’t remain easily accessible. This PR tightens the collapsed layout spacing and updates `SidebarSettingsSection` so “collapsed Settings” opens as a floating dropdown menu on the right, improving navigation reliability.

## Changes

- Adjusted collapsed sidebar nav item classes to keep consistent spacing: removed extra gap/padding mismatch by setting `gap-0` alongside `px-0` when collapsed.
- Updated `SidebarSettingsSection` to render a floating dropdown menu for collapsed state, with menu items grouped and labeled appropriately.
- Added/extended tests to cover the collapsed behavior: clicking “Settings” now asserts a right-floating menu and presence of expected menu items (e.g., “Account”).

## Validation

- Ran unit tests for the sidebar/settings components (Vitest), including the new interaction test for the collapsed floating menu behavior.

[143.dev](https://143.dev) | [session 1713b216](https://143.dev/sessions/1713b216-ed79-435f-b642-e3c0b2f0546f)

<!-- 143 readiness -->
**143 readiness:** Ready with warnings (workspace revision 7; 6 passed, 2 warnings, 0 blockers).

Preview: https://143.dev/previews/github/assembledhq/143/pull/1839?launch=1