### PR TITLE
Align session textarea image X close button to top-right

### DIFF
--- a/frontend/src/components/pending-attachment-strip.test.tsx
+++ b/frontend/src/components/pending-attachment-strip.test.tsx
@@ -51,7 +51,10 @@ describe("PendingAttachmentStrip", () => {
       />,
     );
 
-    await user.click(screen.getByRole("button", { name: "Remove screenshot.png" }));
+    const removeButton = screen.getByRole("button", { name: "Remove screenshot.png" });
+    expect(removeButton).toHaveClass("top-0", "right-0");
+
+    await user.click(removeButton);
 
     expect(onRemove).toHaveBeenCalledWith("/api/v1/uploads/files/org-1/2026-04/screenshot.png");
   });

--- a/frontend/src/components/pending-attachment-strip.tsx
+++ b/frontend/src/components/pending-attachment-strip.tsx
@@ -120,7 +120,7 @@ export function PendingAttachmentStrip({
   return (
     <div className={cn("flex flex-wrap items-center gap-2", className)}>
       {normalizedAttachments.map(({ url, isImage, fileName }) => (
-        <div key={url} className="relative">
+        <div key={url} className="relative pt-1.5 pr-1.5">
           {isImage ? (
             <AttachmentImageTile url={url} fileName={fileName} size={size} />
           ) : (
@@ -141,7 +141,7 @@ export function PendingAttachmentStrip({
             onClick={() => onRemove(url)}
             aria-label={`Remove ${fileName}`}
             className={cn(
-              "absolute -top-1.5 -right-1.5 rounded-full bg-background p-0 shadow-sm",
+              "absolute top-0 right-0 rounded-full bg-background p-0 shadow-sm",
               styles.removeButton,
             )}
           >


### PR DESCRIPTION
## Summary

Adjusted the session input attachment layout:

- Moved image thumbnails slightly downward.
- Anchored the X control at the thumbnail’s top-right corner.
- Added a focused positioning assertion.
- `git diff --check` passes.

Tests couldn’t run because frontend dependencies are not installed (`vitest: not found`).

## Test plan

Validated by automated agent run.


[143.dev](https://143.dev) | [session 8078b140](https://143.dev/sessions/8078b140-8d53-4ee7-97a7-98e709e8a947)

<!-- 143 readiness -->
**143 readiness:** not available for this revision.

Preview: https://143.dev/previews/github/assembledhq/143/pull/1842?launch=1