### PR TITLE
Add Split PRs button to trigger coding agent PR splitting via changeset tools

### DIFF
--- a/frontend/src/app/(dashboard)/sessions/[id]/pull-request-list.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/pull-request-list.test.tsx
@@ -1,11 +1,10 @@
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { describe, expect, it, vi } from 'vitest';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import type { ChangesetSummary } from '@/lib/types';
 import {
   CHANGESET_SPLIT_MIN_ADDITIONS,
-  ChangesetSplitPlanner,
+  ChangesetSplitPrompt,
   PullRequestList,
   shouldOfferChangesetSplit,
 } from './session-detail-content';
@@ -69,7 +68,7 @@ describe('PullRequestList', () => {
   });
 });
 
-describe('ChangesetSplitPlanner', () => {
+describe('ChangesetSplitPrompt', () => {
   it.each([
     { additions: undefined, expected: false },
     { additions: CHANGESET_SPLIT_MIN_ADDITIONS - 1, expected: false },
@@ -79,25 +78,18 @@ describe('ChangesetSplitPlanner', () => {
     expect(shouldOfferChangesetSplit(additions)).toBe(expected);
   });
 
-  it('shows verified split progress and enables acceptance only when complete', () => {
-    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false, staleTime: Infinity } } });
-    queryClient.setQueryData(['session', 'session-1', 'changeset-split'], {
-      data: {
-        status: 'draft', source_diff_snapshot_id: 'snapshot-1', source_paths: ['api.go'],
-        assignments: [{ changeset_id: 'changeset-2', paths: ['api.go'] }], unassigned_paths: [],
-        duplicates: [], conflicts: [], omissions: [], unexpected_paths: [], verification: 'verified', complete: true,
-      },
-    });
+  it('asks the coding agent to split the diff instead of initializing a manual split', async () => {
+    const onRequestSplit = vi.fn();
+
     render(
-      <QueryClientProvider client={queryClient}>
-        <ChangesetSplitPlanner sessionID="session-1" changesets={[
-          changeset(),
-          changeset({ id: 'changeset-2', is_primary: false, order_index: 1, title: 'API', worktree_path: '/work/api' }),
-        ]} />
-      </QueryClientProvider>,
+      <ChangesetSplitPrompt
+        additions={CHANGESET_SPLIT_MIN_ADDITIONS}
+        onRequestSplit={onRequestSplit}
+      />,
     );
-    expect(screen.getByTestId('changeset-split-planner')).toBeInTheDocument();
-    expect(screen.getByText('1 of 1 files accounted for')).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Accept split' })).toBeEnabled();
+
+    await userEvent.click(await screen.findByRole('button', { name: 'Split PRs' }));
+
+    expect(onRequestSplit).toHaveBeenCalledOnce();
   });
 });

--- a/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
@@ -144,7 +144,7 @@ import {
   writeStoredViewedThreadIds,
 } from "@/lib/session-thread-views";
 import { applySessionDetailToSessionListCaches } from "@/lib/session-list-cache";
-import type { ChangesetSplitStatus, ChangesetSummary, CodingCredentialSummary, HumanInputAnswerBody, HumanInputRequest, ListResponse, PRReadinessBypass, PRReadinessCheck, PRReadinessEnforcement, PRReadinessPolicyConfig, PRReadinessRun, ReviewLoopFixMode, Session, SessionDetail, SessionInputCommand, SessionInputReference, SessionLog, SessionMessage, SessionReviewComment, SessionReviewLoop, SessionRetryMode, SessionStatus, SessionThread, SessionThreadFileEvent, SessionTimelineEntry, ThreadInboxEvent, ThreadRuntimeEvent, ThreadStatus, User, CodexAuthStatus, PullRequestHealthResponse, PullRequestStatus, SessionWorkspaceGenerationChangedEvent, SingleResponse, SessionTranscriptWindowResponse, SessionTranscriptTurn, SessionTranscriptEntry } from "@/lib/types";
+import type { ChangesetSummary, CodingCredentialSummary, HumanInputAnswerBody, HumanInputRequest, ListResponse, PRReadinessBypass, PRReadinessCheck, PRReadinessEnforcement, PRReadinessPolicyConfig, PRReadinessRun, ReviewLoopFixMode, Session, SessionDetail, SessionInputCommand, SessionInputReference, SessionLog, SessionMessage, SessionReviewComment, SessionReviewLoop, SessionRetryMode, SessionStatus, SessionThread, SessionThreadFileEvent, SessionTimelineEntry, ThreadInboxEvent, ThreadRuntimeEvent, ThreadStatus, User, CodexAuthStatus, PullRequestHealthResponse, PullRequestStatus, SessionWorkspaceGenerationChangedEvent, SingleResponse, SessionTranscriptWindowResponse, SessionTranscriptTurn, SessionTranscriptEntry } from "@/lib/types";
 import { AgentTabStrip, computeThreadOverlap } from "./agent-tab-strip";
 import { AuditLogTrigger } from "@/components/audit/audit-log-trigger";
 import { ResizeHandle } from "@/components/resize-handle";
@@ -3410,103 +3410,22 @@ export function PullRequestList({
   );
 }
 
-export function ChangesetSplitPlanner({
-  sessionID,
-  changesets,
+export function ChangesetSplitPrompt({
   additions,
+  onRequestSplit,
+  requestSplitPending = false,
 }: {
-  sessionID: string;
-  changesets: ChangesetSummary[];
   additions?: number;
+  onRequestSplit?: () => void;
+  requestSplitPending?: boolean;
 }) {
-  const queryClient = useQueryClient();
-  const splitKey = ["session", sessionID, "changeset-split"] as const;
-  const splitQuery = useQuery({
-    queryKey: splitKey,
-    queryFn: () => api.sessions.getChangesetSplitStatus(sessionID),
-    enabled: true,
-    retry: false,
-  });
-  const refresh = async () => {
-    await queryClient.invalidateQueries({ queryKey: splitKey });
-    await queryClient.invalidateQueries({ queryKey: queryKeys.sessions.detail(sessionID) });
-  };
-  const action = useMutation({
-    mutationFn: async (run: () => Promise<unknown>) => run(),
-    onSuccess: refresh,
-    onError: (error) => toast.error(error instanceof Error ? error.message : "Split action failed"),
-  });
-  if (splitQuery.isError) {
-    if (!shouldOfferChangesetSplit(additions)) return null;
-    return (
-      <Card className="border-border/60">
-        <CardContent className="flex items-center justify-between gap-3 p-4">
-          <div><p className="text-sm font-medium">Need smaller pull requests?</p><p className="text-xs text-muted-foreground">Freeze the current diff and split it into reviewable branches.</p></div>
-          <Button size="sm" variant="outline" disabled={action.isPending} onClick={() => action.mutate(() => api.sessions.initializeChangesetSplit(sessionID))}>Split into PRs</Button>
-        </CardContent>
-      </Card>
-    );
-  }
-  const status: ChangesetSplitStatus | undefined = splitQuery.data?.data;
-  if (!status) return null;
-  if (status.status === "accepted") {
-    return <Card className="border-border/60"><CardContent className="p-4"><p className="text-sm font-medium">Split accepted</p><p className="text-xs text-muted-foreground">The original session diff is archived and the pull request branches are now the session rollup.</p></CardContent></Card>;
-  }
-  const candidates = changesets.filter((changeset) => !changeset.is_primary);
-  const ownerByPath = new Map(status.assignments.flatMap((assignment) => assignment.paths.map((path) => [path, assignment.changeset_id] as const)));
-  const omittedPaths = new Set(status.omissions.map((omission) => omission.path));
-  const assign = async (path: string, nextOwner: string) => {
-    const previous = ownerByPath.get(path);
-    if (previous && previous !== nextOwner) {
-      const paths = status.assignments.find((assignment) => assignment.changeset_id === previous)?.paths.filter((item) => item !== path) ?? [];
-      await api.sessions.replaceChangesetSplitPaths(sessionID, previous, paths);
-    }
-    if (nextOwner === "__omit") {
-      await api.sessions.replaceChangesetSplitOmissions(sessionID, [
-        ...status.omissions.filter((omission) => omission.path !== path).map(({ path: omittedPath, reason }) => ({ path: omittedPath, reason })),
-        { path, reason: "Explicitly omitted while accepting the split" },
-      ]);
-      return;
-    }
-    if (omittedPaths.has(path)) {
-      await api.sessions.replaceChangesetSplitOmissions(sessionID, status.omissions.filter((omission) => omission.path !== path).map(({ path: omittedPath, reason }) => ({ path: omittedPath, reason })));
-    }
-    const paths = status.assignments.find((assignment) => assignment.changeset_id === nextOwner)?.paths ?? [];
-    await api.sessions.replaceChangesetSplitPaths(sessionID, nextOwner, [...paths, path]);
-  };
+  if (!shouldOfferChangesetSplit(additions)) return null;
+
   return (
-    <Card className="border-border/60" data-testid="changeset-split-planner">
-      <CardHeader className="p-4 pb-2"><CardTitle className="flex items-center justify-between text-sm"><span>Split progress</span><Badge variant={status.complete ? "default" : "secondary"}>{status.verification === "verified" ? "Verified" : "Planning"}</Badge></CardTitle></CardHeader>
-      <CardContent className="space-y-3 p-4 pt-1">
-        <p className="text-xs text-muted-foreground">{status.source_paths.length - status.unassigned_paths.length} of {status.source_paths.length} files accounted for</p>
-        <div className="max-h-64 space-y-1 overflow-y-auto">
-          {status.source_paths.map((path) => (
-            <div key={path} className="flex items-center gap-2 rounded-md border border-border p-2">
-              <span className="min-w-0 flex-1 truncate text-xs" title={path}>{path}</span>
-              <Select value={ownerByPath.get(path) ?? (omittedPaths.has(path) ? "__omit" : "unassigned")} onValueChange={(value) => value !== "unassigned" && action.mutate(() => assign(path, value))}>
-                <SelectTrigger className="h-8 w-44 text-xs"><SelectValue /></SelectTrigger>
-                <SelectContent><SelectItem value="unassigned">Unassigned</SelectItem><SelectItem value="__omit">Omit with confirmation</SelectItem>{candidates.map((changeset) => <SelectItem key={changeset.id} value={changeset.id}>{changeset.title}</SelectItem>)}</SelectContent>
-              </Select>
-            </div>
-          ))}
-        </div>
-        {(status.duplicates.length > 0 || status.conflicts.length > 0 || status.unexpected_paths.length > 0) && <ErrorNotice title={`${status.duplicates.length} duplicate, ${status.conflicts.length} conflicting, and ${status.unexpected_paths.length} unexpected files require attention.`} />}
-        <div className="space-y-1">
-          {candidates.map((changeset, index) => (
-            <div key={changeset.id} className="flex items-center gap-2 text-xs">
-              <span className="min-w-0 flex-1 truncate">PR {index + 1}: {changeset.title}</span>
-              {index > 0 && !changeset.worktree_path && !candidates[index - 1].worktree_path && <Button size="sm" variant="ghost" className="h-7 px-2 text-xs" disabled={action.isPending} onClick={() => action.mutate(() => api.sessions.foldChangeset(sessionID, changeset.id, candidates[index - 1].id))}>Fold up</Button>}
-              <Button size="icon" variant="ghost" className="h-7 w-7" disabled={index === 0 || action.isPending} aria-label={`Move ${changeset.title} up`} onClick={() => action.mutate(() => { const ids = candidates.map((item) => item.id); [ids[index - 1], ids[index]] = [ids[index], ids[index - 1]]; return api.sessions.reorderChangesets(sessionID, ids); })}><ArrowUp className="h-3.5 w-3.5" /></Button>
-              <Button size="icon" variant="ghost" className="h-7 w-7" disabled={index === candidates.length - 1 || action.isPending} aria-label={`Move ${changeset.title} down`} onClick={() => action.mutate(() => { const ids = candidates.map((item) => item.id); [ids[index], ids[index + 1]] = [ids[index + 1], ids[index]]; return api.sessions.reorderChangesets(sessionID, ids); })}><ArrowDown className="h-3.5 w-3.5" /></Button>
-            </div>
-          ))}
-        </div>
-        <div className="flex flex-wrap gap-2">
-          <Button size="sm" variant="outline" disabled={action.isPending} onClick={() => action.mutate(() => api.sessions.createChangeset(sessionID, { title: `Pull request ${candidates.length + 1}` }))}><Plus className="h-3.5 w-3.5" />Add PR</Button>
-          {candidates.filter((changeset) => !changeset.worktree_path).map((changeset) => <Button key={changeset.id} size="sm" variant="outline" disabled={action.isPending} onClick={() => action.mutate(() => api.sessions.materializeChangeset(sessionID, changeset.id))}>Materialize {changeset.title}</Button>)}
-          <Button size="sm" variant="outline" disabled={action.isPending || candidates.some((changeset) => !changeset.worktree_path)} onClick={() => action.mutate(() => api.sessions.verifyChangesetSplit(sessionID))}>Verify split</Button>
-          <Button size="sm" disabled={action.isPending || !status.complete} onClick={() => action.mutate(() => api.sessions.acceptChangesetSplit(sessionID))}>Accept split</Button>
-        </div>
+    <Card className="border-border/60">
+      <CardContent className="flex items-center justify-between gap-3 p-4">
+        <div><p className="text-sm font-medium">Need smaller pull requests?</p><p className="text-xs text-muted-foreground">Ask the coding agent to split the current diff into reviewable branches.</p></div>
+        <Button size="sm" variant="outline" disabled={requestSplitPending || !onRequestSplit} onClick={onRequestSplit}>Split PRs</Button>
       </CardContent>
     </Card>
   );
@@ -6646,10 +6565,12 @@ export function SessionDetailContent({ id }: { id: string }) {
               </CardContent>
             </Card>
           )}
-          <ChangesetSplitPlanner
-            sessionID={id}
-            changesets={changesets}
+          <ChangesetSplitPrompt
             additions={session.diff_stats?.added}
+            onRequestSplit={() => queueSend({
+              overrideMessage: "Split the current diff into smaller, independently reviewable pull requests. Before making changes, run `143-tools changesets list`, `143-tools changesets current`, and `143-tools changesets status` so the platform changeset state is authoritative. Then use the changeset tools to create and materialize the split; do not create worktrees manually. Keep each pull request cohesive, account for every changed file, and verify the completed split with the changeset tools.",
+            })}
+            requestSplitPending={sendMutation.isPending || !composerCanSendMessage}
           />
           {hasMultipleChangesets && selectedChangeset && (
             <Card className="border-border/60" data-testid="selected-pull-request-panel">

--- a/frontend/src/lib/api.test.ts
+++ b/frontend/src/lib/api.test.ts
@@ -1558,19 +1558,6 @@ describe('api client', () => {
           calls.push(JSON.stringify(await request.json()));
           return HttpResponse.json({ data: { id: 'changeset-2' } });
         }),
-        http.get('/api/v1/sessions/:id/changesets/split-status', ({ request }) => {
-          calls.push(new URL(request.url).pathname);
-          return HttpResponse.json({ data: { source_paths: [], assignments: [], unassigned_paths: [], duplicates: [], complete: false } });
-        }),
-        http.put('/api/v1/sessions/:id/changesets/:changesetId/split-paths', async ({ request }) => {
-          calls.push(JSON.stringify(await request.json()));
-          return HttpResponse.json({ data: { source_paths: ['api.go'], assignments: [], unassigned_paths: [], duplicates: [], complete: true } });
-        }),
-        http.post('/api/v1/sessions/:id/changesets/split', () => HttpResponse.json({ data: { status: 'draft' } }, { status: 201 })),
-        http.post('/api/v1/sessions/:id/changesets/:changesetId/materialize', () => HttpResponse.json({ status: 'queued', job_id: 'job-1' })),
-        http.post('/api/v1/sessions/:id/changesets/verify', () => HttpResponse.json({ status: 'queued', job_id: 'job-2' })),
-        http.put('/api/v1/sessions/:id/changesets/order', async ({ request }) => { calls.push(JSON.stringify(await request.json())); return new HttpResponse(null, { status: 204 }); }),
-        http.post('/api/v1/sessions/:id/changesets/:changesetId/fold', async ({ request }) => { calls.push(JSON.stringify(await request.json())); return new HttpResponse(null, { status: 204 }); }),
         http.get('/api/v1/sessions/:id/pr', ({ request }) => {
           calls.push(new URL(request.url).search);
           return HttpResponse.json({ data: null });
@@ -1580,23 +1567,12 @@ describe('api client', () => {
       await api.sessions.listChangesets('session-1');
       await api.sessions.createChangeset('session-1', { title: 'API', summary: 'Endpoints' });
       await api.sessions.updateChangeset('session-1', 'changeset-2', { title: 'API integration' });
-      await api.sessions.getChangesetSplitStatus('session-1');
-      await api.sessions.replaceChangesetSplitPaths('session-1', 'changeset-2', ['api.go']);
-      await api.sessions.initializeChangesetSplit('session-1');
-      await api.sessions.materializeChangeset('session-1', 'changeset-2');
-      await api.sessions.verifyChangesetSplit('session-1');
-      await api.sessions.reorderChangesets('session-1', ['changeset-2']);
-      await api.sessions.foldChangeset('session-1', 'changeset-2', 'changeset-1');
       await api.sessions.getPR('session-1', 'changeset-2');
 
       expect(calls).toEqual([
         '/api/v1/sessions/session-1/changesets',
         JSON.stringify({ title: 'API', summary: 'Endpoints' }),
         JSON.stringify({ title: 'API integration' }),
-        '/api/v1/sessions/session-1/changesets/split-status',
-        JSON.stringify({ paths: ['api.go'] }),
-        JSON.stringify({ changeset_ids: ['changeset-2'] }),
-        JSON.stringify({ target_changeset_id: 'changeset-1' }),
         '?changeset_id=changeset-2',
       ]);
     });

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -562,16 +562,6 @@ export const api = {
       post<import('./types').SingleResponse<import('./types').ChangesetSummary>>(`/api/v1/sessions/${sessionId}/changesets`, body),
     updateChangeset: (sessionId: string, changesetId: string, body: { title?: string; summary?: string }) =>
       patch<import('./types').SingleResponse<import('./types').ChangesetSummary>>(`/api/v1/sessions/${sessionId}/changesets/${changesetId}`, body),
-    getChangesetSplitStatus: (sessionId: string) =>
-      get<import('./types').SingleResponse<import('./types').ChangesetSplitStatus>>(`/api/v1/sessions/${sessionId}/changesets/split-status`),
-    replaceChangesetSplitPaths: (sessionId: string, changesetId: string, paths: string[]) =>
-      put<import('./types').SingleResponse<import('./types').ChangesetSplitStatus>>(`/api/v1/sessions/${sessionId}/changesets/${changesetId}/split-paths`, { paths }),
-    initializeChangesetSplit: (sessionId: string) =>
-      post<import('./types').SingleResponse<import('./types').ChangesetSplitStatus>>(`/api/v1/sessions/${sessionId}/changesets/split`),
-    replaceChangesetSplitOmissions: (sessionId: string, omissions: Array<{ path: string; reason: string }>) =>
-      put<import('./types').SingleResponse<import('./types').ChangesetSplitStatus>>(`/api/v1/sessions/${sessionId}/changesets/split-omissions`, { omissions }),
-    materializeChangeset: (sessionId: string, changesetId: string) =>
-      post<{ status: string; job_id: string }>(`/api/v1/sessions/${sessionId}/changesets/${changesetId}/materialize`),
     publishChangeset: (sessionId: string, changesetId: string) =>
       post<{ status: string; job_id?: string }>(`/api/v1/sessions/${sessionId}/changesets/${changesetId}/publish`),
     publishChangesetStack: (sessionId: string) =>
@@ -580,14 +570,6 @@ export const api = {
       post<{ status: string; job_id: string }>(`/api/v1/sessions/${sessionId}/changesets/${changesetId}/restack-descendants`),
     confirmChangesetRestack: (sessionId: string, changesetId: string) =>
       post<{ status: string }>(`/api/v1/sessions/${sessionId}/changesets/${changesetId}/confirm-restack`),
-    verifyChangesetSplit: (sessionId: string) =>
-      post<{ status: string; job_id: string }>(`/api/v1/sessions/${sessionId}/changesets/verify`),
-    acceptChangesetSplit: (sessionId: string) =>
-      post<void>(`/api/v1/sessions/${sessionId}/changesets/accept-split`),
-    reorderChangesets: (sessionId: string, changesetIds: string[]) =>
-      put<void>(`/api/v1/sessions/${sessionId}/changesets/order`, { changeset_ids: changesetIds }),
-    foldChangeset: (sessionId: string, sourceId: string, targetId: string) =>
-      post<void>(`/api/v1/sessions/${sessionId}/changesets/${sourceId}/fold`, { target_changeset_id: targetId }),
     getReadiness: (sessionId: string, changesetId?: string) =>
       get<import('./types').SingleResponse<import('./types').PRReadinessResponse>>(`/api/v1/sessions/${sessionId}/pr-readiness-runs/latest${changesetId ? `?changeset_id=${encodeURIComponent(changesetId)}` : ''}`),
     runReadiness: (sessionId: string, changesetId?: string) =>

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -130,13 +130,6 @@ function patch<T>(path: string, body: unknown): Promise<T> {
   });
 }
 
-function put<T>(path: string, body: unknown): Promise<T> {
-  return request<T>(path, {
-    method: 'PUT',
-    body: JSON.stringify(body),
-  });
-}
-
 function del<T>(path: string): Promise<T> {
   return request<T>(path, { method: 'DELETE' });
 }

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -1657,20 +1657,6 @@ export interface ChangesetSummary {
   updated_at: string;
 }
 
-export interface ChangesetSplitStatus {
-  status: "draft" | "accepted";
-  source_diff_snapshot_id: string;
-  source_paths: string[];
-  assignments: Array<{ changeset_id: string; paths: string[] }>;
-  unassigned_paths: string[];
-  duplicates: Array<{ path: string; changeset_ids: string[] }>;
-  conflicts: Array<{ path: string; changeset_id: string; reason: string }>;
-  omissions: Array<{ path: string; reason: string; confirmed_by_user_id: string; created_at: string }>;
-  unexpected_paths: string[];
-  verification: "planned" | "verified";
-  complete: boolean;
-}
-
 export interface SessionDiff {
   session_id: string;
   diff?: string;


### PR DESCRIPTION
## Summary

The current session “changeset split” workflow relies on a manual PR-splitting planner, which creates a mismatch with the agent-driven experience and adds reliability risk by coordinating partial split/verification state in the UI. This change removes the manual split progress/acceptance flow and replaces it with a single “Split PRs” prompt that delegates splitting to the coding agent via the existing changeset prompt.

## Changes

- Replaced the `ChangesetSplitPlanner` UI with `ChangesetSplitPrompt`, removing manual progress/accept split behavior and simplifying the component contract.
- Updated session UI tests to assert that clicking **“Split PRs”** triggers `onRequestSplit` instead of rendering/enabling manual acceptance controls.
- Removed unused split-management API client methods and response types, and consolidated related types to match the agent-driven flow.

## Validation

- Updated frontend unit tests: `pull-request-list.test.tsx` now covers `ChangesetSplitPrompt`.
- `git diff --check` passes.
- Frontend tests could not be executed in this environment because dependencies are not installed (existing limitation noted in repo workflows).

[143.dev](https://143.dev) | [session b425e50f](https://143.dev/sessions/b425e50f-967c-48eb-90ee-cfd316602b29)

<!-- 143 readiness -->
**143 readiness:** not available for this revision.

Preview: https://143.dev/previews/github/assembledhq/143/pull/1843?launch=1