### PR TITLE
Make session details sidepanel buttons sm by default and xs on mobile only

### DIFF
--- a/frontend/src/app/(dashboard)/sessions/[id]/page-pr-creation.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/page-pr-creation.test.tsx
@@ -6,7 +6,7 @@ import { server } from '@/test/mocks/server';
 import { mockSessions, mockMembers, mockPR } from '@/test/mocks/handlers';
 import { SessionDetailContent } from './session-detail-content';
 import type { Session, User, SingleResponse } from '@/lib/types';
-import { installSessionDetailPageTestHooks, mockSessionDetailWithLazyDiff } from './session-detail-test-kit';
+import { installSessionDetailPageTestHooks, mockSessionDetailWithLazyDiff, setMobileViewport } from './session-detail-test-kit';
 
 const { toast } = vi.hoisted(() => ({
   toast: {
@@ -180,14 +180,42 @@ describe('SessionDetailPage PR creation', () => {
 
     renderWithProviders(<SessionDetailContent id="session-abcdef12-3456-7890" />);
     await screen.findAllByText('Fixed TypeError by adding null check');
-    expect(await screen.findByRole('button', { name: /Create PR/ })).toHaveAttribute('data-size', 'xs');
+    expect(await screen.findByRole('button', { name: /Create PR/ })).toHaveAttribute('data-size', 'sm');
     expect(screen.getByRole('button', { name: /Create PR/ })).not.toBeDisabled();
-    expect(screen.getByRole('button', { name: 'More publish actions' })).toHaveAttribute('data-size', 'icon-xs');
+    expect(screen.getByRole('button', { name: 'More publish actions' })).toHaveAttribute('data-size', 'icon-sm');
 
     const user = userEvent.setup();
     await user.click(screen.getByRole('button', { name: 'More publish actions' }));
 
     expect(await screen.findByRole('menuitem', { name: /Create branch/ })).toHaveClass('text-xs');
+  });
+
+  it('uses xs publish actions on mobile', async () => {
+    setMobileViewport(true);
+    const sessionWithDiff: Session = {
+      ...mockSessions[0],
+      status: 'completed',
+      diff: '--- a/file.ts\n+++ b/file.ts\n@@ -1 +1 @@\n-old\n+new',
+      diff_stats: { added: 1, removed: 1, files_changed: 1 },
+      snapshot_key: 'snap-abc',
+    };
+
+    server.use(
+      http.get('/api/v1/sessions/:id', () => {
+        return HttpResponse.json({ data: sessionWithDiff } satisfies SingleResponse<Session>);
+      }),
+      http.get('/api/v1/sessions/:id/pr', () => {
+        return HttpResponse.json(
+          { error: { code: 'NOT_FOUND', message: 'pull request not found' } },
+          { status: 404 },
+        );
+      }),
+    );
+
+    renderWithProviders(<SessionDetailContent id="session-abcdef12-3456-7890" />);
+
+    expect(await screen.findByRole('button', { name: /Create PR/ })).toHaveAttribute('data-size', 'xs');
+    expect(screen.getByRole('button', { name: 'More publish actions' })).toHaveAttribute('data-size', 'icon-xs');
   });
 
   it('shows a durable View branch link after branch-only publish succeeds', async () => {

--- a/frontend/src/app/(dashboard)/sessions/[id]/page-pr-health.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/page-pr-health.test.tsx
@@ -301,7 +301,7 @@ describe('SessionDetailPage PR health and merge', () => {
     expect(viewPRLink).toHaveAttribute('href', 'https://github.com/example/repo/pull/42');
     expect(viewPRLink).toHaveAttribute('target', '_blank');
     expect(viewPRLink).toHaveAttribute('rel', expect.stringContaining('noopener'));
-    expect(viewPRLink).toHaveAttribute('data-size', 'xs');
+    expect(viewPRLink).toHaveAttribute('data-size', 'sm');
     expect(within(viewPRLink).queryByRole('button')).not.toBeInTheDocument();
   });
 

--- a/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
@@ -6445,6 +6445,8 @@ export function SessionDetailContent({ id }: { id: string }) {
     setDraftTitle(currentTitle);
     setMobileRenameOpen(true);
   };
+  const detailActionSize = isMobileReviewViewport ? "xs" : "sm";
+  const detailActionIconSize = isMobileReviewViewport ? "icon-xs" : "icon-sm";
   // Right-panel content. Rendered inline on desktop and inside a bottom sheet
   // on mobile — the same JSX in both places so tab state stays consistent.
   const panelTabsEl = (
@@ -6493,7 +6495,7 @@ export function SessionDetailContent({ id }: { id: string }) {
                     {closedPRLabel}
                   </Badge>
                 )}
-                <Button asChild variant="outline" size="xs" className="gap-1.5" title="View PR (p v)">
+                <Button asChild variant="outline" size={detailActionSize} className="gap-1.5" title="View PR (p v)">
                   <a href={selectedPR.github_pr_url} target="_blank" rel="noopener noreferrer">
                     <ExternalLink className="h-3 w-3" />
                     View PR
@@ -6503,7 +6505,7 @@ export function SessionDetailContent({ id }: { id: string }) {
             ) : showPRAction && !prErrorNotice ? (
               <>
                 {branchURL ? (
-                  <Button asChild variant="outline" size="xs" className="gap-1.5" title="View branch">
+                  <Button asChild variant="outline" size={detailActionSize} className="gap-1.5" title="View branch">
                     <a href={branchURL} target="_blank" rel="noopener noreferrer">
                       <GitBranch className="h-3 w-3" />
                       View branch
@@ -6511,10 +6513,10 @@ export function SessionDetailContent({ id }: { id: string }) {
                   </Button>
                 ) : null}
                 <DisabledTooltip disabled={prActionDisabled} content={prActionTitle}>
-                  <ButtonGroup size="xs">
+                  <ButtonGroup size={detailActionSize}>
                     <Button
                       variant="outline"
-                      size="xs"
+                      size={detailActionSize}
                       className="rounded-r-none border-r-0 text-xs gap-1.5"
                       loading={prActionSpinning}
                       disabled={prActionDisabled}
@@ -6532,7 +6534,7 @@ export function SessionDetailContent({ id }: { id: string }) {
                       <DropdownMenuTrigger asChild>
                         <Button
                           variant="outline"
-                          size="icon-xs"
+                          size={detailActionIconSize}
                           className="rounded-l-none"
                           disabled={prActionDisabled}
                           aria-label="More publish actions"


### PR DESCRIPTION
## Summary

Session details side-panel actions were using `xs` sizing on desktop, making the UI look inconsistent and harder to scan. This change updates the default button sizing to `sm`, while keeping `xs` sizing for mobile-only, and aligns split-button icon sizing to the same breakpoint to avoid mixed visual hierarchy.

## Changes

- Updated desktop sizing expectations for side-panel actions: `Create PR` now uses `data-size="sm"` and “More publish actions” icons use `data-size="icon-sm"`.
- Added a dedicated mobile test that sets a mobile viewport and asserts `Create PR` uses `data-size="xs"` and publish action icons use `data-size="icon-xs"`.
- Updated PR health/merge related assertions to reflect the new default desktop sizing.
- Adjusted session-detail UI implementation (`session-detail-content.tsx`) to follow the breakpoint rules consistently for both buttons and split-button icons.

## Validation

- Ran `git diff --check` (passes).
- Frontend test execution was not fully possible due to an existing incomplete `node_modules` install and an `npm` repair failure (`ENOTEMPTY`). No dependency files were modified.

[143.dev](https://143.dev) | [session a362eb7c](https://143.dev/sessions/a362eb7c-31d3-426b-8b74-6dd5beb03864)

<!-- 143 readiness -->
**143 readiness:** not available for this revision.

Preview: https://143.dev/previews/github/assembledhq/143/pull/1845?launch=1