### PR TITLE
Investigate failed code review handling and model constants

### DIFF
--- a/frontend/src/lib/agents.test.ts
+++ b/frontend/src/lib/agents.test.ts
@@ -191,7 +191,7 @@ describe("agentTypeForModel", () => {
     expect(agentTypeForModel("openrouter/~z-ai/glm-5.2")).toBe("opencode");
     // Bare names owned by a first-party agent keep that owner.
     expect(agentTypeForModel("gpt-5.6-sol")).toBe("codex");
-    expect(agentTypeForModel("gpt-5.6-luna-fast")).toBe("codex");
+    expect(agentTypeForModel("gpt-5.6-luna")).toBe("codex");
     expect(agentTypeForModel("gpt-5.5")).toBe("codex");
     expect(agentTypeForModel("claude-fable-5")).toBe("claude_code");
   });

--- a/frontend/src/lib/model-constants.test.ts
+++ b/frontend/src/lib/model-constants.test.ts
@@ -119,11 +119,8 @@ describe("model constants", () => {
   it("includes latest Codex models", () => {
     expect(AVAILABLE_CODEX_MODELS).toEqual([
       "gpt-5.6-sol",
-      "gpt-5.6-sol-fast",
       "gpt-5.6-terra",
-      "gpt-5.6-terra-fast",
       "gpt-5.6-luna",
-      "gpt-5.6-luna-fast",
       "gpt-5.5",
       "gpt-5.5-fast",
       "gpt-5.4",

--- a/frontend/src/lib/model-constants.ts
+++ b/frontend/src/lib/model-constants.ts
@@ -19,11 +19,8 @@ export const AVAILABLE_CLAUDE_CODE_MODELS = [
 export const DEFAULT_CLAUDE_CODE_MODEL = CLAUDE_CODE_MODEL_OPUS_48;
 
 export const CODEX_MODEL_GPT_5_6_SOL = "gpt-5.6-sol";
-export const CODEX_MODEL_GPT_5_6_SOL_FAST = "gpt-5.6-sol-fast";
 export const CODEX_MODEL_GPT_5_6_TERRA = "gpt-5.6-terra";
-export const CODEX_MODEL_GPT_5_6_TERRA_FAST = "gpt-5.6-terra-fast";
 export const CODEX_MODEL_GPT_5_6_LUNA = "gpt-5.6-luna";
-export const CODEX_MODEL_GPT_5_6_LUNA_FAST = "gpt-5.6-luna-fast";
 export const CODEX_MODEL_GPT_5_5 = "gpt-5.5";
 export const CODEX_MODEL_GPT_5_5_FAST = "gpt-5.5-fast";
 export const CODEX_MODEL_GPT_5_4 = "gpt-5.4";
@@ -36,11 +33,8 @@ export const CODEX_MODEL_GPT_5_3_CODEX_SPARK = "gpt-5.3-codex-spark";
 
 export const AVAILABLE_CODEX_MODELS = [
   CODEX_MODEL_GPT_5_6_SOL,
-  CODEX_MODEL_GPT_5_6_SOL_FAST,
   CODEX_MODEL_GPT_5_6_TERRA,
-  CODEX_MODEL_GPT_5_6_TERRA_FAST,
   CODEX_MODEL_GPT_5_6_LUNA,
-  CODEX_MODEL_GPT_5_6_LUNA_FAST,
   CODEX_MODEL_GPT_5_5,
   CODEX_MODEL_GPT_5_5_FAST,
   CODEX_MODEL_GPT_5_4,

--- a/internal/db/code_reviews.go
+++ b/internal/db/code_reviews.go
@@ -736,6 +736,31 @@ func (s *CodeReviewStore) FailReview(ctx context.Context, orgID, sessionID uuid.
 	return metadata, nil
 }
 
+func (s *CodeReviewStore) CancelReview(ctx context.Context, orgID, sessionID uuid.UUID, reason string) (models.CodeReviewSessionMetadata, error) {
+	rows, err := s.db.Query(ctx, `
+		UPDATE code_review_session_metadata
+		SET status = 'cancelled',
+		    failure_reason = @failure_reason,
+		    completed_at = COALESCE(completed_at, now())
+		WHERE org_id = @org_id
+		  AND session_id = @session_id
+		  AND status IN ('queued', 'running')
+		RETURNING `+codeReviewMetadataColumns, pgx.NamedArgs{
+		"org_id":         orgID,
+		"session_id":     sessionID,
+		"failure_reason": reason,
+	})
+	if err != nil {
+		return models.CodeReviewSessionMetadata{}, fmt.Errorf("cancel code review: %w", err)
+	}
+	metadata, err := collectOneCodeReviewMetadata(rows)
+	if err != nil {
+		return models.CodeReviewSessionMetadata{}, err
+	}
+	s.publishUpdated(ctx, metadata)
+	return metadata, nil
+}
+
 type CodeReviewListFilters struct {
 	RepositoryID *uuid.UUID
 	Decision     *models.CodeReviewDecision

--- a/internal/models/agent_model_constants.go
+++ b/internal/models/agent_model_constants.go
@@ -70,11 +70,8 @@ var AvailableClaudeCodeModels = []string{ClaudeCodeModelFable5, ClaudeCodeModelO
 
 const (
 	CodexModelGPT56Sol        = "gpt-5.6-sol"
-	CodexModelGPT56SolFast    = "gpt-5.6-sol-fast"
 	CodexModelGPT56Terra      = "gpt-5.6-terra"
-	CodexModelGPT56TerraFast  = "gpt-5.6-terra-fast"
 	CodexModelGPT56Luna       = "gpt-5.6-luna"
-	CodexModelGPT56LunaFast   = "gpt-5.6-luna-fast"
 	CodexModelGPT55           = "gpt-5.5"
 	CodexModelGPT55Fast       = "gpt-5.5-fast"
 	CodexModelGPT54           = "gpt-5.4"
@@ -90,11 +87,8 @@ const DefaultCodexModel = CodexModelGPT56Sol
 
 var AvailableCodexModels = []string{
 	CodexModelGPT56Sol,
-	CodexModelGPT56SolFast,
 	CodexModelGPT56Terra,
-	CodexModelGPT56TerraFast,
 	CodexModelGPT56Luna,
-	CodexModelGPT56LunaFast,
 	CodexModelGPT55,
 	CodexModelGPT55Fast,
 	CodexModelGPT54,
@@ -194,12 +188,6 @@ type CodexRuntimeSpec struct {
 // model ID Codex CLI accepts plus a priority-service-tier flag.
 func CodexRuntimeModel(model string) CodexRuntimeSpec {
 	switch model {
-	case CodexModelGPT56SolFast:
-		return CodexRuntimeSpec{Model: CodexModelGPT56Sol, PriorityTier: true}
-	case CodexModelGPT56TerraFast:
-		return CodexRuntimeSpec{Model: CodexModelGPT56Terra, PriorityTier: true}
-	case CodexModelGPT56LunaFast:
-		return CodexRuntimeSpec{Model: CodexModelGPT56Luna, PriorityTier: true}
 	case CodexModelGPT55Fast:
 		return CodexRuntimeSpec{Model: CodexModelGPT55, PriorityTier: true}
 	case CodexModelGPT54Fast:

--- a/internal/models/agent_model_constants_test.go
+++ b/internal/models/agent_model_constants_test.go
@@ -40,11 +40,8 @@ func TestCodexModelConstants(t *testing.T) {
 	require.Equal(t,
 		[]string{
 			CodexModelGPT56Sol,
-			CodexModelGPT56SolFast,
 			CodexModelGPT56Terra,
-			CodexModelGPT56TerraFast,
 			CodexModelGPT56Luna,
-			CodexModelGPT56LunaFast,
 			CodexModelGPT55,
 			CodexModelGPT55Fast,
 			CodexModelGPT54,
@@ -146,9 +143,6 @@ func TestCodexRuntimeModel(t *testing.T) {
 		expected     string
 		priorityTier bool
 	}{
-		{name: "gpt 5.6 sol fast maps to gpt 5.6 sol priority", model: CodexModelGPT56SolFast, expected: CodexModelGPT56Sol, priorityTier: true},
-		{name: "gpt 5.6 terra fast maps to gpt 5.6 terra priority", model: CodexModelGPT56TerraFast, expected: CodexModelGPT56Terra, priorityTier: true},
-		{name: "gpt 5.6 luna fast maps to gpt 5.6 luna priority", model: CodexModelGPT56LunaFast, expected: CodexModelGPT56Luna, priorityTier: true},
 		{name: "gpt 5.5 fast maps to gpt 5.5 priority", model: CodexModelGPT55Fast, expected: CodexModelGPT55, priorityTier: true},
 		{name: "gpt 5.4 fast maps to gpt 5.4 priority", model: CodexModelGPT54Fast, expected: CodexModelGPT54, priorityTier: true},
 		{name: "regular gpt 5.6 sol stays unchanged", model: CodexModelGPT56Sol, expected: CodexModelGPT56Sol},
@@ -302,7 +296,7 @@ func TestAgentTypeForModel(t *testing.T) {
 	}{
 		{"", ""},
 		{CodexModelGPT56Sol, AgentTypeCodex},
-		{CodexModelGPT56LunaFast, AgentTypeCodex},
+		{CodexModelGPT56Luna, AgentTypeCodex},
 		{CodexModelGPT54, AgentTypeCodex},
 		{ClaudeCodeModelOpus48, AgentTypeClaudeCode},
 		{AmpModeSmart, AgentTypeAmp},

--- a/internal/services/agent/adapters/codex_test.go
+++ b/internal/services/agent/adapters/codex_test.go
@@ -113,21 +113,6 @@ func TestCodexModelArgs(t *testing.T) {
 		expected       string
 	}{
 		{
-			name:     "adds priority service tier for gpt 5.6 sol fast",
-			env:      map[string]string{"OPENAI_MODEL": models.CodexModelGPT56SolFast},
-			expected: ` -m 'gpt-5.6-sol' -c 'service_tier="priority"'`,
-		},
-		{
-			name:     "adds priority service tier for gpt 5.6 terra fast",
-			env:      map[string]string{"OPENAI_MODEL": models.CodexModelGPT56TerraFast},
-			expected: ` -m 'gpt-5.6-terra' -c 'service_tier="priority"'`,
-		},
-		{
-			name:     "adds priority service tier for gpt 5.6 luna fast",
-			env:      map[string]string{"OPENAI_MODEL": models.CodexModelGPT56LunaFast},
-			expected: ` -m 'gpt-5.6-luna' -c 'service_tier="priority"'`,
-		},
-		{
 			name:     "adds priority service tier for gpt 5.5 fast",
 			env:      map[string]string{"OPENAI_MODEL": models.CodexModelGPT55Fast},
 			expected: ` -m 'gpt-5.5' -c 'service_tier="priority"'`,

--- a/internal/services/agent/token_usage_cost.go
+++ b/internal/services/agent/token_usage_cost.go
@@ -19,7 +19,6 @@ var openAIAPIRates = map[string]tokenRate{
 	models.CodexModelGPT56Sol:   {inputPerMTok: 5.00, cachedInputPerMTok: 0.50, cacheCreationPerMTok: 6.25, outputPerMTok: 30.00, unit: TokenCostUnitUSD, detail: "openai_api_pricing"},
 	models.CodexModelGPT56Terra: {inputPerMTok: 2.50, cachedInputPerMTok: 0.25, cacheCreationPerMTok: 3.125, outputPerMTok: 15.00, unit: TokenCostUnitUSD, detail: "openai_api_pricing"},
 	models.CodexModelGPT56Luna:  {inputPerMTok: 1.00, cachedInputPerMTok: 0.10, cacheCreationPerMTok: 1.25, outputPerMTok: 6.00, unit: TokenCostUnitUSD, detail: "openai_api_pricing"},
-	// GPT-5.6 priority rates are not published, so fast aliases remain cost-unavailable.
 	models.CodexModelGPT55:      {inputPerMTok: 5.00, cachedInputPerMTok: 0.50, outputPerMTok: 30.00, unit: TokenCostUnitUSD, detail: "openai_api_pricing"},
 	models.CodexModelGPT55Fast:  {inputPerMTok: 12.50, cachedInputPerMTok: 1.25, outputPerMTok: 75.00, unit: TokenCostUnitUSD, detail: "openai_priority_pricing"},
 	models.CodexModelGPT54:      {inputPerMTok: 2.50, cachedInputPerMTok: 0.25, outputPerMTok: 15.00, unit: TokenCostUnitUSD, detail: "openai_api_pricing"},
@@ -35,7 +34,6 @@ var codexCreditRates = map[string]tokenRate{
 	models.CodexModelGPT56Sol:   {inputPerMTok: 125.00, cachedInputPerMTok: 12.50, outputPerMTok: 750.00, unit: TokenCostUnitCredits, detail: "codex_rate_card"},
 	models.CodexModelGPT56Terra: {inputPerMTok: 62.50, cachedInputPerMTok: 6.250, outputPerMTok: 375.00, unit: TokenCostUnitCredits, detail: "codex_rate_card"},
 	models.CodexModelGPT56Luna:  {inputPerMTok: 25.00, cachedInputPerMTok: 2.50, outputPerMTok: 150.00, unit: TokenCostUnitCredits, detail: "codex_rate_card"},
-	// GPT-5.6 fast-mode credit rates are not published, so fast aliases remain cost-unavailable.
 	models.CodexModelGPT55:      {inputPerMTok: 125.00, cachedInputPerMTok: 12.50, outputPerMTok: 750.00, unit: TokenCostUnitCredits, detail: "codex_rate_card"},
 	models.CodexModelGPT55Fast:  {inputPerMTok: 312.50, cachedInputPerMTok: 31.25, outputPerMTok: 1875.00, unit: TokenCostUnitCredits, detail: "codex_priority_rate_card"},
 	models.CodexModelGPT54:      {inputPerMTok: 62.50, cachedInputPerMTok: 6.250, outputPerMTok: 375.00, unit: TokenCostUnitCredits, detail: "codex_rate_card"},
@@ -60,7 +58,7 @@ var anthropicRates = map[string]tokenRate{
 }
 
 var googleRates = map[string]tokenRate{
-	models.PiModelGemini25Pro:        {inputPerMTok: 1.25, cachedInputPerMTok: 0.125, outputPerMTok: 10.00, unit: TokenCostUnitUSD, detail: "google_api_pricing"},
+	models.PiModelGemini25Pro: {inputPerMTok: 1.25, cachedInputPerMTok: 0.125, outputPerMTok: 10.00, unit: TokenCostUnitUSD, detail: "google_api_pricing"},
 }
 
 // FinalizeTokenUsage normalizes adapter-parsed usage into a single persisted

--- a/internal/worker/code_review_handler.go
+++ b/internal/worker/code_review_handler.go
@@ -78,7 +78,20 @@ func newRunCodeReviewHandler(stores *Stores, services *Services, logger zerolog.
 						Str("session_id", job.SessionID.String()).
 						Str("status", string(existing.Status)).
 						Msg("skipping terminal code review job")
-					reconcileCodeReviewSessionStatus(ctx, stores, logger, job)
+					switch existing.Status {
+					case models.CodeReviewSessionStatusCompleted:
+						reconcileCodeReviewSessionSuccess(ctx, stores, logger, job)
+					case models.CodeReviewSessionStatusStale:
+						reconcileCodeReviewSessionStale(ctx, stores, logger, job)
+					case models.CodeReviewSessionStatusFailed:
+						reason := strings.TrimSpace(stringPtrValue(existing.FailureReason))
+						if reason == "" {
+							reason = "code review failed without usable reviewer output"
+						}
+						if reconcileErr := reconcileCodeReviewSessionFailure(ctx, stores, job, reason); reconcileErr != nil {
+							return reconcileErr
+						}
+					}
 					return nil
 				}
 			}
@@ -95,7 +108,7 @@ func newRunCodeReviewHandler(stores *Stores, services *Services, logger zerolog.
 		if err != nil {
 			return fmt.Errorf("load code review pull request: %w", err)
 		}
-		if terminal, err := failCodeReviewIfParentSessionTerminal(ctx, stores, services, logger, job, pr); terminal || err != nil {
+		if cancelled, err := stopCodeReviewIfParentSessionCancelled(ctx, stores, services, logger, job, pr); cancelled || err != nil {
 			return err
 		}
 		publishCodeReviewStatus(ctx, stores, services, logger, job, pr, codereviewsvc.CommitStatusStatePending, "143 Code Reviewer is running")
@@ -125,7 +138,7 @@ func newRunCodeReviewHandler(stores *Stores, services *Services, logger zerolog.
 				Str("session_id", job.SessionID.String()).
 				Str("reviewed_head", job.HeadSHA).
 				Msg("marked code review stale after PR head changed")
-			reconcileCodeReviewSessionStatus(ctx, stores, logger, job)
+			reconcileCodeReviewSessionStale(ctx, stores, logger, job)
 			return nil
 		}
 		descriptionEvaluation, err := evaluateCodeReviewDescriptionPolicy(ctx, stores, services, logger, job, pr, policy, metadata, changedFiles)
@@ -154,6 +167,12 @@ func newRunCodeReviewHandler(stores *Stores, services *Services, logger zerolog.
 			if !codeReviewReviewerRosterTerminal(policy.Config(), agentResults) {
 				return codeReviewWaitingForReviewers(policy.Config())
 			}
+			if cancelled, err := stopCodeReviewIfParentSessionCancelled(ctx, stores, services, logger, job, pr); cancelled || err != nil {
+				return err
+			}
+			if codeReviewReviewerExecutionFailed(policy.Config(), agentResults) {
+				return failCodeReviewWithoutReviewerOutput(ctx, stores, services, logger, job, pr, agentResults)
+			}
 			if err := ensureCodeReviewOrchestratorThread(ctx, stores, logger, job, pr, health, policy, metadata, changedFiles, descriptionEvaluation, reviewContext, reviewContextAvailable, agentResults, findings); err != nil {
 				return err
 			}
@@ -171,30 +190,16 @@ func newRunCodeReviewHandler(stores *Stores, services *Services, logger zerolog.
 			if err != nil {
 				return fmt.Errorf("list orchestrator code review findings: %w", err)
 			}
-		} else if !codeReviewHasReviewerEvidence(agentResults) {
-			decision, body := buildUnavailableCodeReviewOutcome(policy.Config(), job)
-			if err := ensureCodeReviewOrchestratorResult(ctx, stores.CodeReviews, job, decision, "Automated reviewer agents are not configured for this worker."); err != nil {
-				return fmt.Errorf("create code review unavailable result: %w", err)
-			}
-			submission, submitted, err := submitCodeReviewToGitHub(ctx, stores, services, job, metadata, decision.Decision, body)
-			if err != nil {
+		} else {
+			if cancelled, err := stopCodeReviewIfParentSessionCancelled(ctx, stores, services, logger, job, pr); cancelled || err != nil {
 				return err
 			}
-			removeCodeReviewRequestedReviewer(ctx, stores, services, logger, job, pr)
-			if _, err := stores.CodeReviews.CompleteReview(ctx, job.OrgID, db.CompleteCodeReviewParams{
-				SessionID:       job.SessionID,
-				Decision:        decision.Decision,
-				Acceptable:      decision.Acceptable,
-				GitHubReviewID:  submission.GitHubReviewID,
-				GitHubReviewURL: submission.GitHubReviewURL,
-				FinalReviewBody: body,
-			}); err != nil {
-				return fmt.Errorf("complete unavailable code review: %w", err)
+			if !codeReviewHasUsableReviewerOutput(agentResults) {
+				return failCodeReviewWithoutReviewerOutput(ctx, stores, services, logger, job, pr, agentResults)
 			}
-			publishCodeReviewStatus(ctx, stores, services, logger, job, pr, codereviewsvc.CommitStatusStateSuccess, codeReviewFinalStatusDescription(decision.Decision))
-			logger.Info().Str("session_id", job.SessionID.String()).Bool("github_submitted", submitted).Msg("completed unavailable code review")
-			reconcileCodeReviewSessionStatus(ctx, stores, logger, job)
-			return nil
+		}
+		if cancelled, err := stopCodeReviewIfParentSessionCancelled(ctx, stores, services, logger, job, pr); cancelled || err != nil {
+			return err
 		}
 		decision, body := evaluateLiveCodeReviewOutcome(liveCodeReviewOutcomeInput{
 			Policy:                 policy.Config(),
@@ -214,6 +219,9 @@ func newRunCodeReviewHandler(stores *Stores, services *Services, logger zerolog.
 		})
 		if err := ensureCodeReviewInlineSelection(ctx, stores.CodeReviews, job, findings, changedFiles, policy.Config().InlineCommentLimit); err != nil {
 			return fmt.Errorf("select code review inline findings: %w", err)
+		}
+		if cancelled, err := stopCodeReviewIfParentSessionCancelled(ctx, stores, services, logger, job, pr); cancelled || err != nil {
+			return err
 		}
 		submission, submitted, err := submitCodeReviewToGitHub(ctx, stores, services, job, metadata, decision.Decision, body)
 		if err != nil {
@@ -239,50 +247,54 @@ func newRunCodeReviewHandler(stores *Stores, services *Services, logger zerolog.
 		}
 		publishCodeReviewStatus(ctx, stores, services, logger, job, pr, codereviewsvc.CommitStatusStateSuccess, codeReviewFinalStatusDescription(decision.Decision))
 		event.Str("decision", string(decision.Decision)).Msg("completed code review")
-		reconcileCodeReviewSessionStatus(ctx, stores, logger, job)
+		reconcileCodeReviewSessionSuccess(ctx, stores, logger, job)
 		return nil
 	}
 }
 
-func failCodeReviewIfParentSessionTerminal(ctx context.Context, stores *Stores, services *Services, logger zerolog.Logger, job runCodeReviewPayload, pr models.PullRequest) (bool, error) {
+func stopCodeReviewIfParentSessionCancelled(ctx context.Context, stores *Stores, services *Services, logger zerolog.Logger, job runCodeReviewPayload, pr models.PullRequest) (bool, error) {
 	if stores == nil || stores.Sessions == nil || stores.CodeReviews == nil {
 		return false, nil
 	}
 	session, err := stores.Sessions.GetByID(ctx, job.OrgID, job.SessionID)
 	if err != nil {
-		return false, fmt.Errorf("load code review parent session: %w", err)
+		return false, fmt.Errorf("load code review parent session for cancellation: %w", err)
 	}
-	if !session.Status.IsTerminal() {
+	if session.Status != models.SessionStatusCancelled {
 		return false, nil
 	}
-	reason := fmt.Sprintf("parent code review session is terminal: %s", session.Status)
+	reason := "parent code review session was cancelled"
 	if detail := strings.TrimSpace(stringPtrValue(session.FailureExplanation)); detail != "" {
 		reason += ": " + detail
 	}
-	if _, err := stores.CodeReviews.FailReview(ctx, job.OrgID, job.SessionID, reason); err != nil {
-		return false, fmt.Errorf("fail code review after terminal parent session: %w", err)
+	if _, err := stores.CodeReviews.CancelReview(ctx, job.OrgID, job.SessionID, reason); err != nil {
+		if !errors.Is(err, pgx.ErrNoRows) {
+			return false, fmt.Errorf("cancel code review after parent cancellation: %w", err)
+		}
 	}
-	publishCodeReviewStatus(ctx, stores, services, logger, job, pr, codereviewsvc.CommitStatusStateFailure, "143 Code Reviewer failed")
-	logger.Warn().
+	publishCodeReviewStatus(ctx, stores, services, logger, job, pr, codereviewsvc.CommitStatusStateError, "143 Code Reviewer was cancelled")
+	removeCodeReviewRequestedReviewer(ctx, stores, services, logger, job, pr)
+	logger.Info().
 		Str("session_id", job.SessionID.String()).
-		Str("session_status", string(session.Status)).
-		Msg("failed code review because parent session is terminal")
+		Msg("stopped code review because parent session was cancelled")
 	return true, nil
 }
 
-func buildUnavailableCodeReviewOutcome(policy models.CodeReviewPolicyConfig, job runCodeReviewPayload) (models.CodeReviewDecisionEvaluation, string) {
-	reason := "Automated reviewer agents are not configured for this worker."
-	risk := models.CodeReviewRiskEvaluation{Acceptable: false, Reasons: []string{reason}}
-	decision := models.EvaluateCodeReviewDecision(policy, risk)
-	body := models.BuildCodeReviewFinalReviewBody(models.CodeReviewFinalReviewInput{
-		Decision:      decision.Decision,
-		Acceptable:    decision.Acceptable,
-		RiskReasons:   decision.RiskReasons,
-		PolicyVersion: job.PolicyVersion,
-		HeadSHA:       job.HeadSHA,
-		Summary:       "143 recorded the review request and withheld automated approval.",
-	})
-	return decision, body
+func failCodeReviewWithoutReviewerOutput(ctx context.Context, stores *Stores, services *Services, logger zerolog.Logger, job runCodeReviewPayload, pr models.PullRequest, results []models.CodeReviewAgentResult) error {
+	reason := codeReviewNoUsableReviewerOutputReason(results)
+	if _, err := stores.CodeReviews.FailReview(ctx, job.OrgID, job.SessionID, reason); err != nil {
+		return fmt.Errorf("fail code review without usable reviewer output: %w", err)
+	}
+	publishCodeReviewStatus(ctx, stores, services, logger, job, pr, codereviewsvc.CommitStatusStateFailure, "143 Code Reviewer failed: no reviewer completed")
+	removeCodeReviewRequestedReviewer(ctx, stores, services, logger, job, pr)
+	if err := reconcileCodeReviewSessionFailure(ctx, stores, job, reason); err != nil {
+		return err
+	}
+	logger.Warn().
+		Str("session_id", job.SessionID.String()).
+		Str("reason", reason).
+		Msg("failed code review because no reviewer produced usable output")
+	return nil
 }
 
 func codeReviewMetadataTerminal(status models.CodeReviewSessionStatus) bool {
@@ -294,8 +306,8 @@ func codeReviewMetadataTerminal(status models.CodeReviewSessionStatus) bool {
 	}
 }
 
-// reconcileCodeReviewSessionStatus drives the parent session to a terminal
-// status once the review itself is finished. The run_code_review job — not the
+// reconcileCodeReviewSessionSuccess drives the parent session to completed
+// once the review itself finishes successfully. The run_code_review job — not the
 // per-thread runtime — owns the lifecycle of an origin=code_review session, so
 // when the handler reaches a terminal outcome it must stop leaving the session
 // in whatever transient state (e.g. a 'pending' parked by a sibling reviewer's
@@ -304,7 +316,17 @@ func codeReviewMetadataTerminal(status models.CodeReviewSessionStatus) bool {
 // it and stamps the misleading "unable to start within the expected time"
 // failure on an already-successful review. Best-effort: a reconciliation
 // failure is logged, not surfaced, so it can never undo a posted review.
-func reconcileCodeReviewSessionStatus(ctx context.Context, stores *Stores, logger zerolog.Logger, job runCodeReviewPayload) {
+func reconcileCodeReviewSessionSuccess(ctx context.Context, stores *Stores, logger zerolog.Logger, job runCodeReviewPayload) {
+	reconcileCodeReviewSessionCompletion(ctx, stores, logger, job, true)
+}
+
+// reconcileCodeReviewSessionStale finishes a non-terminal parent without
+// converting a prior reviewer failure into a successful session.
+func reconcileCodeReviewSessionStale(ctx context.Context, stores *Stores, logger zerolog.Logger, job runCodeReviewPayload) {
+	reconcileCodeReviewSessionCompletion(ctx, stores, logger, job, false)
+}
+
+func reconcileCodeReviewSessionCompletion(ctx context.Context, stores *Stores, logger zerolog.Logger, job runCodeReviewPayload, recoverFailed bool) {
 	if stores == nil || stores.Sessions == nil {
 		return
 	}
@@ -313,7 +335,10 @@ func reconcileCodeReviewSessionStatus(ctx context.Context, stores *Stores, logge
 		logger.Warn().Err(err).Str("session_id", job.SessionID.String()).Msg("failed to load session for code review reconciliation")
 		return
 	}
-	if session.Status.IsTerminal() {
+	if session.Status == models.SessionStatusCancelled {
+		return
+	}
+	if session.Status.IsTerminal() && !(recoverFailed && session.Status == models.SessionStatusFailed && session.Origin == models.SessionOriginCodeReview) {
 		return
 	}
 	if err := stores.Sessions.UpdateStatus(ctx, job.OrgID, job.SessionID, models.SessionStatusCompleted); err != nil {
@@ -324,6 +349,31 @@ func reconcileCodeReviewSessionStatus(ctx context.Context, stores *Stores, logge
 		Str("session_id", job.SessionID.String()).
 		Str("prev_status", string(session.Status)).
 		Msg("reconciled code review session to completed")
+}
+
+func reconcileCodeReviewSessionFailure(ctx context.Context, stores *Stores, job runCodeReviewPayload, reason string) error {
+	if stores == nil || stores.Sessions == nil {
+		return nil
+	}
+	session, err := stores.Sessions.GetByID(ctx, job.OrgID, job.SessionID)
+	if err != nil {
+		return fmt.Errorf("load parent session for code review failure reconciliation: %w", err)
+	}
+	if session.Status.IsTerminal() && session.Status != models.SessionStatusFailed {
+		return nil
+	}
+	if session.Status == models.SessionStatusFailed && session.Origin != models.SessionOriginCodeReview {
+		return nil
+	}
+	if session.Status != models.SessionStatusFailed {
+		if err := stores.Sessions.UpdateStatus(ctx, job.OrgID, job.SessionID, models.SessionStatusFailed); err != nil {
+			return fmt.Errorf("reconcile code review parent session to failed: %w", err)
+		}
+	}
+	if err := stores.Sessions.UpdateFailure(ctx, job.OrgID, job.SessionID, reason, "code_review_no_reviewer_output", []string{"Configure at least one reviewer credential and request the review again."}, true); err != nil {
+		return fmt.Errorf("record code review parent session failure details: %w", err)
+	}
+	return nil
 }
 
 func syncCodeReviewPullRequestState(ctx context.Context, services *Services, logger zerolog.Logger, job runCodeReviewPayload) error {
@@ -588,6 +638,37 @@ func harvestCodeReviewReviewerResults(ctx context.Context, stores *Stores, servi
 		if err != nil {
 			return err
 		}
+		threadFailed := thread.Status == models.ThreadStatusFailed || thread.Status == models.ThreadStatusCancelled
+		if threadFailed && !codeReviewFailedReviewerThreadOutputUsable(thread, raw, ok) {
+			failure := strings.TrimSpace(stringPtrValue(thread.FailureExplanation))
+			if !ok {
+				raw = failure
+				if raw == "" {
+					raw = "reviewer thread did not complete successfully"
+				}
+			}
+			if failure == "" {
+				failure = raw
+			}
+			state.Error = failure
+			state.CompletedAt = time.Now().UTC().Format(time.RFC3339)
+			rawOutput, rawArtifactKey, err := codeReviewRawOutputForStorage(ctx, stores, job, result.ID, models.CodeReviewAgentRoleReviewer, result.AgentProvider, raw)
+			if err != nil {
+				return err
+			}
+			state.RawArtifactKey = rawArtifactKey
+			if _, err := stores.CodeReviews.UpdateAgentResultOutcome(ctx, job.OrgID, result.ID, models.CodeReviewAgentResultStatusFailed, rawOutput, marshalCodeReviewReviewerStructuredResult(state)); err != nil {
+				return fmt.Errorf("mark reviewer failed: %w", err)
+			}
+			continue
+		}
+		if threadFailed {
+			logger.Warn().
+				Str("session_id", job.SessionID.String()).
+				Str("thread_id", thread.ID.String()).
+				Str("reviewer", result.AgentProvider).
+				Msg("using persisted reviewer output from a subsequently failed thread")
+		}
 		if !ok {
 			if readOnlyViolation {
 				raw = strings.TrimSpace(stringPtrValue(thread.FailureExplanation))
@@ -603,21 +684,6 @@ func harvestCodeReviewReviewerResults(ctx context.Context, stores *Stores, servi
 				state.RawArtifactKey = rawArtifactKey
 				if _, err := stores.CodeReviews.UpdateAgentResultOutcome(ctx, job.OrgID, result.ID, models.CodeReviewAgentResultStatusCompleted, rawOutput, marshalCodeReviewReviewerStructuredResult(state)); err != nil {
 					return fmt.Errorf("mark read-only-violating reviewer completed: %w", err)
-				}
-			} else if thread.Status == models.ThreadStatusFailed || thread.Status == models.ThreadStatusCancelled {
-				raw = strings.TrimSpace(stringPtrValue(thread.FailureExplanation))
-				if raw == "" {
-					raw = "reviewer thread did not complete successfully"
-				}
-				state.Error = raw
-				state.CompletedAt = time.Now().UTC().Format(time.RFC3339)
-				rawOutput, rawArtifactKey, err := codeReviewRawOutputForStorage(ctx, stores, job, result.ID, models.CodeReviewAgentRoleReviewer, result.AgentProvider, raw)
-				if err != nil {
-					return err
-				}
-				state.RawArtifactKey = rawArtifactKey
-				if _, err := stores.CodeReviews.UpdateAgentResultOutcome(ctx, job.OrgID, result.ID, models.CodeReviewAgentResultStatusFailed, rawOutput, marshalCodeReviewReviewerStructuredResult(state)); err != nil {
-					return fmt.Errorf("mark reviewer failed: %w", err)
 				}
 			}
 			continue
@@ -643,6 +709,22 @@ func harvestCodeReviewReviewerResults(ctx context.Context, stores *Stores, servi
 		}
 	}
 	return nil
+}
+
+func codeReviewFailedReviewerThreadOutputUsable(thread models.SessionThread, raw string, ok bool) bool {
+	if !ok {
+		return false
+	}
+	output := strings.TrimSpace(raw)
+	if output == "" {
+		return false
+	}
+	failure := strings.TrimSpace(stringPtrValue(thread.FailureExplanation))
+	if failure != "" && strings.EqualFold(output, failure) {
+		return false
+	}
+	category := strings.ToLower(strings.TrimSpace(stringPtrValue(thread.FailureCategory)))
+	return category == "turn_persistence_failed"
 }
 
 func codeReviewReviewerResultsByKey(results []models.CodeReviewAgentResult) map[string]models.CodeReviewAgentResult {
@@ -1321,13 +1403,24 @@ func codeReviewReviewerRosterTerminal(policy models.CodeReviewPolicyConfig, resu
 	return true
 }
 
-func codeReviewHasReviewerEvidence(results []models.CodeReviewAgentResult) bool {
-	for _, result := range results {
-		if result.Role == models.CodeReviewAgentRoleReviewer {
-			return true
-		}
+func codeReviewReviewerExecutionFailed(policy models.CodeReviewPolicyConfig, results []models.CodeReviewAgentResult) bool {
+	if !codeReviewReviewerRosterTerminal(policy, results) {
+		return false
 	}
-	return false
+	return !codeReviewHasUsableReviewerOutput(results)
+}
+
+func codeReviewHasUsableReviewerOutput(results []models.CodeReviewAgentResult) bool {
+	quorum, _ := codeReviewReviewerEvidence(results)
+	return quorum > 0
+}
+
+func codeReviewNoUsableReviewerOutputReason(results []models.CodeReviewAgentResult) string {
+	summaries := codeReviewAgentSummaries(results, nil)
+	if len(summaries) == 0 {
+		return "no code review reviewer agents were able to run"
+	}
+	return "no code review reviewer produced usable output: " + strings.Join(summaries, ", ")
 }
 
 func codeReviewWaitingForReviewers(policy models.CodeReviewPolicyConfig) error {
@@ -2718,36 +2811,6 @@ func codeReviewRecommendedHumanReviewers(reasons []string, changedFiles []codere
 		}
 	}
 	return out
-}
-
-func ensureCodeReviewOrchestratorResult(ctx context.Context, store *db.CodeReviewStore, job runCodeReviewPayload, decision models.CodeReviewDecisionEvaluation, raw string) error {
-	results, err := store.ListAgentResults(ctx, job.OrgID, job.SessionID)
-	if err != nil {
-		return err
-	}
-	for _, result := range results {
-		if result.Role == models.CodeReviewAgentRoleOrchestrator {
-			return nil
-		}
-	}
-	structured, err := json.Marshal(map[string]any{
-		"decision":     decision.Decision,
-		"acceptable":   decision.Acceptable,
-		"risk_reasons": decision.RiskReasons,
-	})
-	if err != nil {
-		return fmt.Errorf("marshal code review orchestrator result: %w", err)
-	}
-	result := &models.CodeReviewAgentResult{
-		OrgID:            job.OrgID,
-		SessionID:        job.SessionID,
-		AgentProvider:    "143",
-		Role:             models.CodeReviewAgentRoleOrchestrator,
-		Status:           models.CodeReviewAgentResultStatusCompleted,
-		RawOutput:        &raw,
-		StructuredResult: structured,
-	}
-	return store.CreateAgentResult(ctx, result)
 }
 
 func submitCodeReviewToGitHub(ctx context.Context, stores *Stores, services *Services, job runCodeReviewPayload, metadata models.CodeReviewSessionMetadata, decision models.CodeReviewDecision, body string) (codeReviewSubmission, bool, error) {

--- a/internal/worker/code_review_handler_test.go
+++ b/internal/worker/code_review_handler_test.go
@@ -460,7 +460,101 @@ func TestHarvestCodeReviewReviewerResultsCompletesIdleReadOnlyViolationWithoutAs
 	require.NoError(t, mock.ExpectationsWereMet(), "reviewer harvest should keep code review moving after a read-only violation")
 }
 
-func TestFailCodeReviewIfParentSessionTerminalFailsMetadata(t *testing.T) {
+func TestHarvestCodeReviewReviewerResultsClassifiesFailedThreadOutput(t *testing.T) {
+	t.Parallel()
+
+	authError := "no credentials configured for Claude Code: connect a Claude subscription or add an Anthropic API key"
+	tests := []struct {
+		name            string
+		failure         string
+		failureCategory string
+		assistantOutput string
+		expectedStatus  models.CodeReviewAgentResultStatus
+	}{
+		{
+			name:            "keeps auth error failed",
+			failure:         authError,
+			failureCategory: "claude_code_auth_expired",
+			assistantOutput: authError,
+			expectedStatus:  models.CodeReviewAgentResultStatusFailed,
+		},
+		{
+			name:            "keeps a completed review after bookkeeping failure",
+			failure:         "update interactive turn result: connection reset",
+			failureCategory: "turn_persistence_failed",
+			assistantOutput: "No actionable issues found.",
+			expectedStatus:  models.CodeReviewAgentResultStatusCompleted,
+		},
+		{
+			name:            "rejects assistant text from an operational failure",
+			failure:         "sandbox capacity stayed full until the retry window expired",
+			failureCategory: "sandbox_capacity",
+			assistantOutput: "The sandbox is unavailable; retry this review later.",
+			expectedStatus:  models.CodeReviewAgentResultStatusFailed,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			mock, err := pgxmock.NewPool()
+			require.NoError(t, err, "pgxmock pool should initialize")
+			defer mock.Close()
+
+			orgID := uuid.New()
+			sessionID := uuid.New()
+			threadID := uuid.New()
+			resultID := uuid.New()
+			now := time.Now().UTC()
+			state := marshalCodeReviewReviewerStructuredResult(codeReviewReviewerStructuredResult{
+				ReviewerKey:   codeReviewReviewerKey(1, models.AgentTypeClaudeCode),
+				ReviewerIndex: 1,
+				ThreadID:      threadID.String(),
+				ReadOnly:      true,
+			})
+
+			mock.ExpectQuery("(?s)SELECT .*FROM code_review_agent_results").
+				WithArgs(pgx.NamedArgs{"org_id": orgID, "session_id": sessionID}).
+				WillReturnRows(newCodeReviewAgentResultRows().
+					AddRow(resultID, orgID, sessionID, "claude_code", nil, models.CodeReviewAgentRoleReviewer, models.CodeReviewAgentResultStatusRunning, nil, state, now))
+			mock.ExpectQuery("(?s)SELECT .*FROM session_threads").
+				WithArgs(pgx.NamedArgs{"id": threadID, "org_id": orgID}).
+				WillReturnRows(newSessionThreadRows().
+					AddRow(threadID, sessionID, orgID, models.AgentTypeClaudeCode, nil,
+						"Code review: claude_code", nil, []string{"internal/db/users.go"}, models.ThreadStatusFailed,
+						nil, 1, &now, nil, nil, &tt.failure, &tt.failureCategory,
+						&now, &now, now, models.ThreadCreatedBySourceSystem, nil, nil,
+						nil, 0.0, 0, nil, "", nil, "", "", json.RawMessage(`[]`),
+						models.ThreadExecutionModeReview, models.ThreadFilesystemModeReadOnly))
+			mock.ExpectQuery("(?s)SELECT .*FROM session_messages").
+				WithArgs(pgx.NamedArgs{"org_id": orgID, "thread_id": threadID}).
+				WillReturnRows(newSessionMessageRows().
+					AddRow(int64(1), sessionID, orgID, &threadID, nil, 1, models.MessageRoleAssistant, tt.assistantOutput, nil, nil, nil, nil, "", now))
+			mock.ExpectQuery("UPDATE code_review_agent_results").
+				WithArgs(tt.expectedStatus, &tt.assistantOutput, pgxmock.AnyArg(), orgID, resultID).
+				WillReturnRows(newCodeReviewAgentResultRows().
+					AddRow(resultID, orgID, sessionID, "claude_code", nil, models.CodeReviewAgentRoleReviewer, tt.expectedStatus, &tt.assistantOutput, state, now))
+
+			cfg := models.DefaultCodeReviewPolicyConfig()
+			policy := codeReviewPolicyRecordForTest(cfg)
+			stores := &Stores{
+				CodeReviews:     db.NewCodeReviewStore(mock),
+				SessionThreads:  db.NewSessionThreadStore(mock),
+				SessionMessages: db.NewSessionMessageStore(mock),
+			}
+			err = harvestCodeReviewReviewerResults(context.Background(), stores, nil, zerolog.Nop(), runCodeReviewPayload{
+				OrgID:     orgID,
+				SessionID: sessionID,
+			}, policy, models.CodeReviewSessionMetadata{CreatedAt: now}, []codereview.PullRequestFile{{Filename: "internal/db/users.go"}})
+
+			require.NoError(t, err, "failed reviewer output should be classified without stopping the harvest")
+			require.NoError(t, mock.ExpectationsWereMet(), "failed reviewer output should use valid completed reviews but reject operational error text")
+		})
+	}
+}
+
+func TestFailCodeReviewWithoutReviewerOutputFailsMetadata(t *testing.T) {
 	t.Parallel()
 
 	mock, err := pgxmock.NewPool()
@@ -474,17 +568,107 @@ func TestFailCodeReviewIfParentSessionTerminalFailsMetadata(t *testing.T) {
 	policyID := uuid.New()
 	metadataID := uuid.New()
 	now := time.Now().UTC()
-	failure := "This session was unable to start within the expected time."
-	reason := "parent code review session is terminal: failed: " + failure
+	reason := "no code review reviewer produced usable output: codex failed, claude_code failed"
 	decision := models.CodeReviewDecisionBlocked
 	acceptable := false
-	sessionRow := workerSessionRow(sessionID, uuid.Nil, orgID, models.SessionStatusFailed, 0, nil, nil)
-	for i, col := range workerSessionColumns {
-		if col == "failure_explanation" {
-			sessionRow[i] = &failure
-			break
-		}
+	mock.ExpectQuery("UPDATE code_review_session_metadata").
+		WithArgs(pgx.NamedArgs{"org_id": orgID, "session_id": sessionID, "failure_reason": reason}).
+		WillReturnRows(newCodeReviewMetadataRows().
+			AddRow(metadataID, orgID, sessionID, repositoryID, pullRequestID, policyID,
+				"base", "head", false, models.CodeReviewTriggerSourceTeamReviewer,
+				models.CodeReviewSessionStatusFailed, &decision, &acceptable, false, nil,
+				"output-key", nil, nil, nil, nil, &reason, &now, now))
+
+	err = failCodeReviewWithoutReviewerOutput(context.Background(), &Stores{
+		CodeReviews: db.NewCodeReviewStore(mock),
+	}, nil, zerolog.Nop(), runCodeReviewPayload{
+		OrgID:     orgID,
+		SessionID: sessionID,
+	}, models.PullRequest{}, []models.CodeReviewAgentResult{
+		{Role: models.CodeReviewAgentRoleReviewer, AgentProvider: "codex", Status: models.CodeReviewAgentResultStatusFailed},
+		{Role: models.CodeReviewAgentRoleReviewer, AgentProvider: "claude_code", Status: models.CodeReviewAgentResultStatusFailed},
+	})
+
+	require.NoError(t, err, "missing reviewer output should terminate the code review cleanly")
+	require.NoError(t, mock.ExpectationsWereMet(), "missing reviewer output should fail the code review metadata")
+}
+
+func TestRunCodeReviewHandlerReconcilesTerminalFailedMetadata(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "pgxmock pool should initialize")
+	defer mock.Close()
+
+	orgID := uuid.New()
+	sessionID := uuid.New()
+	repositoryID := uuid.New()
+	pullRequestID := uuid.New()
+	policyID := uuid.New()
+	metadataID := uuid.New()
+	now := time.Now().UTC()
+	reason := "no code review reviewer produced usable output: claude_code failed"
+
+	mock.ExpectQuery("UPDATE code_review_session_metadata").
+		WithArgs(pgx.NamedArgs{"org_id": orgID, "session_id": sessionID}).
+		WillReturnRows(newCodeReviewMetadataRows())
+	mock.ExpectQuery("(?s)SELECT .*FROM code_review_session_metadata").
+		WithArgs(pgx.NamedArgs{"org_id": orgID, "session_id": sessionID}).
+		WillReturnRows(newCodeReviewMetadataRows().
+			AddRow(metadataID, orgID, sessionID, repositoryID, pullRequestID, policyID,
+				"base", "head", false, models.CodeReviewTriggerSourceTeamReviewer,
+				models.CodeReviewSessionStatusFailed, nil, nil, false, nil,
+				"output-key", nil, nil, nil, nil, &reason, &now, now))
+
+	pendingRow := workerSessionRow(sessionID, uuid.Nil, orgID, models.SessionStatusPending, 0, nil, nil)
+	setWorkerSessionColumn(pendingRow, "origin", models.SessionOriginCodeReview)
+	mock.ExpectQuery("(?s)SELECT .*FROM sessions").
+		WithArgs(pgx.NamedArgs{"id": sessionID, "org_id": orgID}).
+		WillReturnRows(pgxmock.NewRows(workerSessionColumns).AddRow(pendingRow...))
+	failedRow := workerSessionRow(sessionID, uuid.Nil, orgID, models.SessionStatusFailed, 0, nil, nil)
+	setWorkerSessionColumn(failedRow, "origin", models.SessionOriginCodeReview)
+	mock.ExpectQuery("UPDATE sessions SET status = @status, completed_at = now").
+		WithArgs(workerAnyArgs(3)...).
+		WillReturnRows(pgxmock.NewRows(workerSessionColumns).AddRow(failedRow...))
+	mock.ExpectExec("UPDATE sessions[\\s\\S]+failure_explanation").
+		WithArgs(workerAnyArgs(6)...).
+		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
+
+	job := runCodeReviewPayload{
+		OrgID:         orgID,
+		SessionID:     sessionID,
+		RepositoryID:  repositoryID,
+		PullRequestID: pullRequestID,
+		PolicyID:      policyID,
 	}
+	payload, err := json.Marshal(job)
+	require.NoError(t, err, "code review job payload should marshal")
+	err = newRunCodeReviewHandler(&Stores{
+		CodeReviews: db.NewCodeReviewStore(mock),
+		Sessions:    db.NewSessionStore(mock),
+	}, nil, zerolog.Nop())(context.Background(), "run_code_review", payload)
+
+	require.NoError(t, err, "terminal failed metadata should reconcile a parent left non-terminal by a prior transient failure")
+	require.NoError(t, mock.ExpectationsWereMet(), "terminal failed metadata should retry parent failure reconciliation")
+}
+
+func TestStopCodeReviewIfParentSessionCancelledCancelsMetadata(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "pgxmock pool should initialize")
+	defer mock.Close()
+
+	orgID := uuid.New()
+	sessionID := uuid.New()
+	repositoryID := uuid.New()
+	pullRequestID := uuid.New()
+	policyID := uuid.New()
+	metadataID := uuid.New()
+	now := time.Now().UTC()
+	reason := "parent code review session was cancelled"
+	sessionRow := workerSessionRow(sessionID, uuid.Nil, orgID, models.SessionStatusCancelled, 0, nil, nil)
+	setWorkerSessionColumn(sessionRow, "origin", models.SessionOriginCodeReview)
 
 	mock.ExpectQuery("(?s)SELECT .*FROM sessions").
 		WithArgs(pgx.NamedArgs{"id": sessionID, "org_id": orgID}).
@@ -494,10 +678,10 @@ func TestFailCodeReviewIfParentSessionTerminalFailsMetadata(t *testing.T) {
 		WillReturnRows(newCodeReviewMetadataRows().
 			AddRow(metadataID, orgID, sessionID, repositoryID, pullRequestID, policyID,
 				"base", "head", false, models.CodeReviewTriggerSourceTeamReviewer,
-				models.CodeReviewSessionStatusFailed, &decision, &acceptable, false, nil,
+				models.CodeReviewSessionStatusCancelled, nil, nil, false, nil,
 				"output-key", nil, nil, nil, nil, &reason, &now, now))
 
-	terminal, err := failCodeReviewIfParentSessionTerminal(context.Background(), &Stores{
+	stopped, err := stopCodeReviewIfParentSessionCancelled(context.Background(), &Stores{
 		Sessions:    db.NewSessionStore(mock),
 		CodeReviews: db.NewCodeReviewStore(mock),
 	}, nil, zerolog.Nop(), runCodeReviewPayload{
@@ -505,9 +689,61 @@ func TestFailCodeReviewIfParentSessionTerminalFailsMetadata(t *testing.T) {
 		SessionID: sessionID,
 	}, models.PullRequest{})
 
-	require.NoError(t, err, "terminal parent session should not return an error")
-	require.True(t, terminal, "terminal parent session should stop the code review job")
-	require.NoError(t, mock.ExpectationsWereMet(), "terminal parent guard should fail the code review metadata")
+	require.NoError(t, err, "parent cancellation should stop the code review cleanly")
+	require.True(t, stopped, "parent cancellation should prevent any later orchestrator or GitHub submission")
+	require.NoError(t, mock.ExpectationsWereMet(), "parent cancellation should persist cancelled code review metadata")
+}
+
+func TestReconcileCodeReviewSessionSuccess(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		status       models.SessionStatus
+		origin       models.SessionOrigin
+		stale        bool
+		expectUpdate bool
+	}{
+		{name: "completes a failed code review parent after degraded success", status: models.SessionStatusFailed, origin: models.SessionOriginCodeReview, expectUpdate: true},
+		{name: "preserves a failed code review parent when the review becomes stale", status: models.SessionStatusFailed, origin: models.SessionOriginCodeReview, stale: true, expectUpdate: false},
+		{name: "preserves a cancelled code review parent", status: models.SessionStatusCancelled, origin: models.SessionOriginCodeReview, expectUpdate: false},
+		{name: "preserves a failed non-code-review parent", status: models.SessionStatusFailed, origin: models.SessionOriginManual, expectUpdate: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			mock, err := pgxmock.NewPool()
+			require.NoError(t, err, "pgxmock pool should initialize")
+			defer mock.Close()
+
+			orgID := uuid.New()
+			sessionID := uuid.New()
+			sessionRow := workerSessionRow(sessionID, uuid.Nil, orgID, tt.status, 0, nil, nil)
+			setWorkerSessionColumn(sessionRow, "origin", tt.origin)
+			mock.ExpectQuery("(?s)SELECT .*FROM sessions").
+				WithArgs(pgx.NamedArgs{"id": sessionID, "org_id": orgID}).
+				WillReturnRows(pgxmock.NewRows(workerSessionColumns).AddRow(sessionRow...))
+			if tt.expectUpdate {
+				completedRow := workerSessionRow(sessionID, uuid.Nil, orgID, models.SessionStatusCompleted, 0, nil, nil)
+				setWorkerSessionColumn(completedRow, "origin", tt.origin)
+				mock.ExpectQuery("UPDATE sessions SET status = @status, completed_at = now").
+					WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+					WillReturnRows(pgxmock.NewRows(workerSessionColumns).AddRow(completedRow...))
+			}
+
+			stores := &Stores{Sessions: db.NewSessionStore(mock)}
+			job := runCodeReviewPayload{OrgID: orgID, SessionID: sessionID}
+			if tt.stale {
+				reconcileCodeReviewSessionStale(context.Background(), stores, zerolog.Nop(), job)
+			} else {
+				reconcileCodeReviewSessionSuccess(context.Background(), stores, zerolog.Nop(), job)
+			}
+
+			require.NoError(t, mock.ExpectationsWereMet(), "review reconciliation should recover failed parents only after successful completion")
+		})
+	}
 }
 
 func TestHarvestCodeReviewOrchestratorResultPersistsFindings(t *testing.T) {
@@ -591,20 +827,63 @@ func (s *codeReviewDescriptionLLMStub) Complete(context.Context, string, string)
 	return s.response, nil
 }
 
-func TestBuildUnavailableCodeReviewOutcome(t *testing.T) {
+func TestCodeReviewReviewerExecutionFailed(t *testing.T) {
 	t.Parallel()
 
 	policy := models.DefaultCodeReviewPolicyConfig()
-	policy.ApprovalMode = models.CodeReviewApprovalModeApproveAcceptable
-	job := runCodeReviewPayload{PolicyVersion: 7, HeadSHA: "abc123"}
+	codexState := marshalCodeReviewReviewerStructuredResult(codeReviewReviewerStructuredResult{ReviewerKey: codeReviewReviewerKey(0, models.AgentTypeCodex)})
+	claudeState := marshalCodeReviewReviewerStructuredResult(codeReviewReviewerStructuredResult{ReviewerKey: codeReviewReviewerKey(1, models.AgentTypeClaudeCode)})
+	noOutputState := marshalCodeReviewReviewerStructuredResult(codeReviewReviewerStructuredResult{
+		ReviewerKey:       codeReviewReviewerKey(0, models.AgentTypeCodex),
+		ReadOnlyViolation: true,
+		Error:             "reviewer produced no assistant output",
+	})
+	tests := []struct {
+		name     string
+		results  []models.CodeReviewAgentResult
+		expected bool
+	}{
+		{
+			name: "continues with one successful reviewer",
+			results: []models.CodeReviewAgentResult{
+				{Role: models.CodeReviewAgentRoleReviewer, AgentProvider: "codex", Status: models.CodeReviewAgentResultStatusCompleted, StructuredResult: codexState},
+				{Role: models.CodeReviewAgentRoleReviewer, AgentProvider: "claude_code", Status: models.CodeReviewAgentResultStatusFailed, StructuredResult: claudeState},
+			},
+			expected: false,
+		},
+		{
+			name: "fails when all reviewers fail",
+			results: []models.CodeReviewAgentResult{
+				{Role: models.CodeReviewAgentRoleReviewer, AgentProvider: "codex", Status: models.CodeReviewAgentResultStatusFailed, StructuredResult: codexState},
+				{Role: models.CodeReviewAgentRoleReviewer, AgentProvider: "claude_code", Status: models.CodeReviewAgentResultStatusTimedOut, StructuredResult: claudeState},
+			},
+			expected: true,
+		},
+		{
+			name: "waits while a reviewer is still running",
+			results: []models.CodeReviewAgentResult{
+				{Role: models.CodeReviewAgentRoleReviewer, AgentProvider: "codex", Status: models.CodeReviewAgentResultStatusRunning, StructuredResult: codexState},
+				{Role: models.CodeReviewAgentRoleReviewer, AgentProvider: "claude_code", Status: models.CodeReviewAgentResultStatusFailed, StructuredResult: claudeState},
+			},
+			expected: false,
+		},
+		{
+			name: "fails when completed output is unusable",
+			results: []models.CodeReviewAgentResult{
+				{Role: models.CodeReviewAgentRoleReviewer, AgentProvider: "codex", Status: models.CodeReviewAgentResultStatusCompleted, StructuredResult: noOutputState},
+				{Role: models.CodeReviewAgentRoleReviewer, AgentProvider: "claude_code", Status: models.CodeReviewAgentResultStatusFailed, StructuredResult: claudeState},
+			},
+			expected: true,
+		},
+	}
 
-	decision, body := buildUnavailableCodeReviewOutcome(policy, job)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 
-	require.Equal(t, models.CodeReviewDecisionNeedsHumanReview, decision.Decision, "unavailable live reviewer evidence should require human review")
-	require.False(t, decision.Acceptable, "unavailable live reviewer evidence should not be acceptable risk")
-	require.Contains(t, decision.RiskReasons, "Automated reviewer agents are not configured for this worker.", "decision should explain missing live reviewers")
-	require.Contains(t, body, "Policy version: 7", "final body should include captured policy version")
-	require.Contains(t, body, "Reviewed head: abc123", "final body should include reviewed head")
+			require.Equal(t, tt.expected, codeReviewReviewerExecutionFailed(policy, tt.results), "review execution should fail only when every configured reviewer is terminal without usable output")
+		})
+	}
 }
 
 func TestCodeReviewReviewerAgentModel(t *testing.T) {
@@ -793,6 +1072,37 @@ func TestEvaluateLiveCodeReviewOutcome(t *testing.T) {
 			},
 			expected: models.CodeReviewDecisionNeedsHumanReview,
 			reason:   "reviewer quorum 1 is below policy requirement 2",
+		},
+		{
+			name: "uses successful reviewer output when a sibling reviewer fails",
+			input: liveCodeReviewOutcomeInput{
+				Policy: policy,
+				Job:    runCodeReviewPayload{OrgID: orgID, SessionID: sessionID, PolicyVersion: 3, HeadSHA: "head"},
+				PullRequest: models.PullRequest{
+					OrgID:   orgID,
+					Body:    &prBody,
+					HeadSHA: stringPtr("head"),
+					Status:  models.PullRequestStatusOpen,
+				},
+				Health: &models.PullRequestHealthResponse{
+					HeadSHA:         "head",
+					Status:          models.PullRequestStatusOpen,
+					CanMerge:        true,
+					ChecksConfirmed: true,
+					MergeState:      models.PullRequestMergeStateClean,
+				},
+				AgentResults: []models.CodeReviewAgentResult{
+					{Role: models.CodeReviewAgentRoleReviewer, AgentProvider: "codex", Status: models.CodeReviewAgentResultStatusCompleted},
+					{Role: models.CodeReviewAgentRoleReviewer, AgentProvider: "claude_code", Status: models.CodeReviewAgentResultStatusFailed},
+				},
+				ChangedFiles: []codereview.PullRequestFile{
+					{Filename: "internal/api/router.go", Additions: 10, Deletions: 2},
+				},
+				ChangedFilesAvailable: true,
+			},
+			expected:     models.CodeReviewDecisionNeedsHumanReview,
+			reason:       "reviewer quorum 1 is below policy requirement 2",
+			bodyContains: "Review agents: codex clean, claude_code failed",
 		},
 		{
 			name: "withholds approval when completed read-only reviewer has no usable output",


### PR DESCRIPTION
## Summary
- Add and test agent model constant definitions in the frontend and backend model layers.
- Update code review data handling and worker logic to better support failed review investigation.
- Adjust token usage cost calculation and related database access paths.
- Refresh sandbox version metadata to match the updated behavior.

## Testing
- Added and updated unit tests across frontend library code, backend models, service logic, and worker handling.
- Validation focused on model constant parsing, code review behavior, and token cost calculations.