### PR TITLE
Default Slack notifications to quiet and add gpt-5.6 Codex models

### DIFF
--- a/docs/public/guides/slack-agent.mdx
+++ b/docs/public/guides/slack-agent.mdx
@@ -69,6 +69,10 @@ When Slack asks for durable coding work, 143 resolves the repository in this ord
 
 Reply in the same Slack thread to continue the linked 143 session. 143 reuses the Slack thread as long as the session can be continued; if the previous session is already in a terminal non-resumable state, a new session is started and linked back to the thread.
 
+## Notifications
+
+New Slack integrations default to the **Quiet** notification preset. Notification channels are reserved for lightweight, actionable updates such as human-input requests; session failures, automation failures, and repeated-failure streaks stay in 143 instead of being broadcast into Slack channels. Sessions started from Slack still report their outcome in the originating thread.
+
 ## How it works
 
 When the Slack agent receives a mention, DM, App Home start, or slash command, it creates or continues a normal 143 session with `origin = slack`. The bot posts a quick acknowledgement with the session link, sends sparse progress updates, then posts the final answer and useful outcome links such as branch, PR, preview, CI state, diff stats, or required next action.

--- a/frontend/src/app/(dashboard)/settings/integrations/page.test.tsx
+++ b/frontend/src/app/(dashboard)/settings/integrations/page.test.tsx
@@ -1173,12 +1173,12 @@ describe("IntegrationsPage", () => {
     await user.click(await screen.findByRole("button", { name: "Manage Slack" }));
     const sheet = await screen.findByRole("dialog", { name: "Slack" });
 
-    await user.click(await within(sheet).findByLabelText("Session failed"));
+    await user.click(await within(sheet).findByLabelText("Human input requested"));
 
     await waitFor(() => {
       expect(updateSlackSettingsMock).toHaveBeenCalledWith({
         notification_preset: "custom",
-        notification_subscriptions: { events: ["session.failed"], automations: [], slack_user_ids: [] },
+        notification_subscriptions: { events: ["human_input.requested"], automations: [], slack_user_ids: [] },
       });
     });
   });

--- a/frontend/src/app/(dashboard)/settings/integrations/page.tsx
+++ b/frontend/src/app/(dashboard)/settings/integrations/page.tsx
@@ -89,11 +89,8 @@ const SLACK_ACTIONS: Array<{ value: SlackChannelAction; label: string }> = [
   { value: "human_input", label: "Human input" },
 ];
 const SLACK_NOTIFICATION_EVENTS = [
-  { value: "session.failed", label: "Session failed" },
   { value: "human_input.requested", label: "Human input requested" },
   { value: "automation.run.completed", label: "Automation completed" },
-  { value: "automation.run.failed", label: "Automation failed" },
-  { value: "automation.run.failure_streak", label: "Automation failure streak" },
 ] as const;
 
 // Coalesce multi-toggle bursts: the later selection wins. Hoisted so every
@@ -120,15 +117,15 @@ function slackVisibilityLabel(value?: SlackResponseVisibility): string {
 
 function slackPresetLabel(value?: SlackNotificationPreset): string {
   switch (value) {
-    case "quiet":
-      return "Quiet";
     case "verbose":
       return "Verbose";
     case "custom":
       return "Custom";
     case "balanced":
-    default:
       return "Balanced";
+    case "quiet":
+    default:
+      return "Quiet";
   }
 }
 
@@ -479,7 +476,7 @@ function SlackBotDefaults({ repositories }: { repositories: Repository[] }) {
   const selectedNotificationEvents = slackNotificationEvents(settings);
   const selectedNotificationAutomations = slackNotificationAutomations(settings);
   const selectedNotificationSlackUsers = slackNotificationSlackUsers(settings);
-  const showCustomNotificationControls = (settings?.notification_preset ?? "balanced") === "custom";
+  const showCustomNotificationControls = (settings?.notification_preset ?? "quiet") === "custom";
 
   const patch = (body: SlackBotSettingsUpdate) => updateSettings.mutate(body);
   const toggleAction = (action: SlackChannelAction) => {
@@ -627,7 +624,7 @@ function SlackBotDefaults({ repositories }: { repositories: Repository[] }) {
               <div className="grid gap-2">
                 <Label>Notifications</Label>
                 <Select
-                  value={settings?.notification_preset ?? "balanced"}
+                  value={settings?.notification_preset ?? "quiet"}
                   onValueChange={(value) => patch({ notification_preset: value as SlackNotificationPreset })}
                   disabled={updateSettings.isPending}
                 >
@@ -842,7 +839,7 @@ function SlackChannelPicker() {
                   </SelectContent>
                 </Select>
                 <Select
-                  value={channel.effective_settings?.notification_preset ?? "balanced"}
+                  value={channel.effective_settings?.notification_preset ?? "quiet"}
                   disabled={updateChannelSettings.isPending}
                   onValueChange={(value) =>
                     updateChannelSettings.mutate({ channel, body: { notification_preset: value as SlackNotificationPreset } })

--- a/internal/api/handlers/integrations.go
+++ b/internal/api/handlers/integrations.go
@@ -2503,7 +2503,7 @@ func defaultSlackBotSettings(orgID, installationID uuid.UUID) models.SlackBotSet
 		RoutingMode:               models.SlackRoutingModeAuto,
 		ResponseVisibility:        models.SlackResponseVisibilityThread,
 		AllowedActions:            []string{string(models.SlackChannelActionSession), string(models.SlackChannelActionPreview)},
-		NotificationPreset:        models.SlackNotificationPresetBalanced,
+		NotificationPreset:        models.SlackNotificationPresetQuiet,
 		NotificationSubscriptions: json.RawMessage(`{}`),
 		Active:                    true,
 	}

--- a/internal/api/handlers/integrations_test.go
+++ b/internal/api/handlers/integrations_test.go
@@ -4269,6 +4269,14 @@ func TestIntegrationHandler_UpdateGitHubOrgAutoJoin_EnableNotAnOrganization(t *t
 	require.NoError(t, mock.ExpectationsWereMet())
 }
 
+func TestDefaultSlackBotSettingsUsesQuietNotifications(t *testing.T) {
+	t.Parallel()
+
+	settings := defaultSlackBotSettings(uuid.New(), uuid.New())
+
+	require.Equal(t, models.SlackNotificationPresetQuiet, settings.NotificationPreset, "new Slack integrations should default to quiet notifications")
+}
+
 func TestSlackSettingsPatchRequestApply(t *testing.T) {
 	t.Parallel()
 

--- a/internal/db/slackbot.go
+++ b/internal/db/slackbot.go
@@ -704,7 +704,7 @@ func (s *SlackChannelSettingsStore) GetEffectiveByChannel(ctx context.Context, o
 			COALESCE(sc.routing_mode, bs.routing_mode, 'auto') AS routing_mode,
 			COALESCE(sc.response_visibility, bs.response_visibility, 'thread') AS response_visibility,
 			COALESCE(sc.allowed_actions, bs.allowed_actions, ARRAY['session','preview']::text[]) AS allowed_actions,
-			COALESCE(sc.notification_preset, bs.notification_preset, 'balanced') AS notification_preset,
+			COALESCE(sc.notification_preset, bs.notification_preset, 'quiet') AS notification_preset,
 			COALESCE(sc.notification_subscriptions, bs.notification_subscriptions, '{}'::jsonb) AS notification_subscriptions,
 			(sc.id IS NOT NULL) AS has_channel_override
 		FROM slack_installations si

--- a/internal/worker/handlers.go
+++ b/internal/worker/handlers.go
@@ -3939,12 +3939,17 @@ func newSlackDeliverHumanInputHandler(stores *Stores, services *Services, logger
 func newSlackSendNotificationHandler(stores *Stores, services *Services, logger zerolog.Logger) JobHandler {
 	slackClient := ingestion.NewSlackAPIClient(logger)
 	return func(ctx context.Context, jobType string, payload json.RawMessage) error {
-		if stores == nil || stores.Credentials == nil {
-			return fmt.Errorf("slack notification dependencies are not configured")
-		}
 		var input models.SlackSendNotificationJobPayload
 		if err := json.Unmarshal(payload, &input); err != nil {
 			return fmt.Errorf("unmarshal slack notification payload: %w", err)
+		}
+		// Drop retired events at delivery time too, so jobs queued before a
+		// deployment cannot leak obsolete channel notifications afterward.
+		if slackNotificationEventDisabled(input.Kind) {
+			return nil
+		}
+		if stores == nil || stores.Credentials == nil {
+			return fmt.Errorf("slack notification dependencies are not configured")
 		}
 		orgID, err := uuid.Parse(input.OrgID)
 		if err != nil {
@@ -4192,6 +4197,9 @@ type slackNotificationSubscriptionConfig struct {
 func slackNotificationEventDisabled(eventKind string) bool {
 	switch eventKind {
 	case string(models.SlackNotificationSessionCompleted),
+		string(models.SlackNotificationSessionFailed),
+		string(models.SlackNotificationAutomationFailed),
+		string(models.SlackNotificationAutomationFailureStreak),
 		string(models.SlackNotificationPROpened),
 		string(models.SlackNotificationPreviewReady),
 		string(models.SlackNotificationPreviewFailed),
@@ -4233,16 +4241,10 @@ func slackNotificationPresetEvents(preset *models.SlackNotificationPreset) []str
 	switch *preset {
 	case models.SlackNotificationPresetQuiet:
 		return []string{
-			string(models.SlackNotificationSessionFailed),
-			string(models.SlackNotificationAutomationFailed),
-			string(models.SlackNotificationAutomationFailureStreak),
 			string(models.SlackNotificationHumanInputRequested),
 		}
 	case models.SlackNotificationPresetBalanced:
 		return []string{
-			string(models.SlackNotificationSessionFailed),
-			string(models.SlackNotificationAutomationFailed),
-			string(models.SlackNotificationAutomationFailureStreak),
 			string(models.SlackNotificationHumanInputRequested),
 		}
 	case models.SlackNotificationPresetVerbose:
@@ -4457,6 +4459,11 @@ func recordSlackMessageUpdateLatency(ctx context.Context, services *Services, me
 }
 
 func enqueueSlackSessionNotifications(ctx context.Context, stores *Stores, logger zerolog.Logger, orgID, sessionID uuid.UUID, automationRunID *uuid.UUID, eventKind, title, body string) {
+	// Session failures stay in 143 (and in the originating Slack thread for
+	// Slack-started work) instead of being broadcast into notification channels.
+	if eventKind == string(models.SlackNotificationSessionFailed) {
+		return
+	}
 	enqueueSlackNotificationSubscribers(ctx, stores, logger, orgID, slackNotificationFanoutInput{
 		EventKind: eventKind,
 		Title:     title,

--- a/internal/worker/handlers_test.go
+++ b/internal/worker/handlers_test.go
@@ -317,14 +317,14 @@ func TestSlackNotificationSubscriptionMatches(t *testing.T) {
 		},
 		{
 			name:      "event list matches event",
-			raw:       json.RawMessage(`{"events":["session.failed"]}`),
-			eventKind: "session.failed",
+			raw:       json.RawMessage(`{"events":["human_input.requested"]}`),
+			eventKind: "human_input.requested",
 			expected:  true,
 		},
 		{
 			name:      "wildcard matches event",
 			raw:       json.RawMessage(`{"events":["*"]}`),
-			eventKind: "session.failed",
+			eventKind: "human_input.requested",
 			expected:  true,
 		},
 		{
@@ -385,6 +385,12 @@ func TestSlackNotificationSubscriptionMatches(t *testing.T) {
 			name:      "explicit readiness attention does not match",
 			raw:       json.RawMessage(`{"events":["pr.readiness_attention"]}`),
 			eventKind: "pr.readiness_attention",
+			expected:  false,
+		},
+		{
+			name:      "explicit session failure does not match",
+			raw:       json.RawMessage(`{"events":["session.failed"]}`),
+			eventKind: "session.failed",
 			expected:  false,
 		},
 		{
@@ -450,7 +456,9 @@ func TestSlackNotificationSubscriptionMatchesPresets(t *testing.T) {
 		{name: "quiet excludes readiness attention", preset: &quiet, eventKind: string(models.SlackNotificationPRReadinessAttention), expected: false},
 		{name: "quiet excludes preview failed", preset: &quiet, eventKind: string(models.SlackNotificationPreviewFailed), expected: false},
 		{name: "quiet excludes session completed", preset: &quiet, eventKind: string(models.SlackNotificationSessionCompleted), expected: false},
-		{name: "verbose includes any typed event", preset: &verbose, eventKind: string(models.SlackNotificationSessionFailed), expected: true},
+		{name: "quiet excludes session failed", preset: &quiet, eventKind: string(models.SlackNotificationSessionFailed), expected: false},
+		{name: "verbose excludes session failed", preset: &verbose, eventKind: string(models.SlackNotificationSessionFailed), expected: false},
+		{name: "verbose includes automation completed", preset: &verbose, eventKind: string(models.SlackNotificationAutomationCompleted), expected: true},
 		{name: "verbose excludes preview ready", preset: &verbose, eventKind: string(models.SlackNotificationPreviewReady), expected: false},
 		{name: "verbose excludes preview failed", preset: &verbose, eventKind: string(models.SlackNotificationPreviewFailed), expected: false},
 	}
@@ -470,6 +478,9 @@ func TestSlackNotificationEventDisabled(t *testing.T) {
 
 	disabled := []string{
 		string(models.SlackNotificationSessionCompleted),
+		string(models.SlackNotificationSessionFailed),
+		string(models.SlackNotificationAutomationFailed),
+		string(models.SlackNotificationAutomationFailureStreak),
 		string(models.SlackNotificationPROpened),
 		string(models.SlackNotificationPreviewReady),
 		string(models.SlackNotificationPreviewFailed),
@@ -482,15 +493,21 @@ func TestSlackNotificationEventDisabled(t *testing.T) {
 	}
 
 	enabled := []string{
-		string(models.SlackNotificationSessionFailed),
 		string(models.SlackNotificationAutomationCompleted),
-		string(models.SlackNotificationAutomationFailed),
-		string(models.SlackNotificationAutomationFailureStreak),
 		string(models.SlackNotificationHumanInputRequested),
 	}
 	for _, eventKind := range enabled {
 		require.False(t, slackNotificationEventDisabled(eventKind), "%s should still be deliverable", eventKind)
 	}
+}
+
+func TestSlackSendNotificationHandlerDropsDisabledEvents(t *testing.T) {
+	t.Parallel()
+
+	handler := newSlackSendNotificationHandler(nil, nil, zerolog.Nop())
+	err := handler(context.Background(), "slack_send_notification", json.RawMessage(`{"kind":"session.failed"}`))
+
+	require.NoError(t, err, "disabled notifications should be dropped before delivery dependencies are required")
 }
 
 func TestSlackNotificationDeliveryPolicyHonorsChannelDMVisibility(t *testing.T) {

--- a/migrations/000246_slack_notifications_quiet_default.down.sql
+++ b/migrations/000246_slack_notifications_quiet_default.down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE slack_bot_settings
+    ALTER COLUMN notification_preset SET DEFAULT 'balanced';

--- a/migrations/000246_slack_notifications_quiet_default.up.sql
+++ b/migrations/000246_slack_notifications_quiet_default.up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE slack_bot_settings
+    ALTER COLUMN notification_preset SET DEFAULT 'quiet';


### PR DESCRIPTION
## Summary
- Default new Slack integrations to the Quiet notification preset and keep failure-style notifications out of Slack channels.
- Update Slack notification handling to drop retired failure events at delivery time and align the settings UI/tests with the new defaults.
- Add support for the latest gpt-5.6 Codex model family, including fast-tier mapping and agent/model constants.
- Prevent code review policy normalization from mutating shared slice backing arrays.

## Testing
- Added and updated unit tests for Slack defaults, notification filtering, Codex model constants, runtime mapping, and code review policy immutability.
- Updated frontend integration tests for the Slack settings panel.
- Not run (not requested).