### PR TITLE
Make automation history decision-first

### DIFF
--- a/docs/public/guides/automations.mdx
+++ b/docs/public/guides/automations.mdx
@@ -1,0 +1,58 @@
+---
+title: Automations
+description: Configure recurring or GitHub-triggered work and interpret PR decisions separately from execution runs.
+section: Guides
+order: 14
+status: stable
+audience: engineer
+tags:
+  - automations
+  - pull requests
+  - review outcomes
+llm_summary: Automations create agent sessions from schedules or GitHub events; the automation page groups PR decisions by revision and keeps review outcomes separate from execution status.
+---
+
+Use automations for work that should start from a repeatable schedule or a repository event instead of a person opening a session. Choose a narrow goal, the repository and base branch, the identity and model, and one or more triggers.
+
+## Choose a trigger
+
+An automation can run on a schedule, a supported integration event, or GitHub pull-request activity. GitHub triggers include PR creation and updates, completed checks, review submissions, inline review comments, and issue comments on a PR.
+
+Filters such as base branch, author, path, feedback type, and review state reduce unnecessary runs. Keep filters as specific as the workflow allows; an automation that reacts to every comment and every check can evaluate the same revision several times.
+
+## Read PR decisions
+
+For GitHub-triggered review work, the default history view shows one decision for each pull-request revision. The summary separates:
+
+- **PRs**: distinct pull requests evaluated.
+- **Revisions**: distinct PR head revisions evaluated.
+- **Attempts**: raw automation executions, including retries or repeated events for the same revision.
+
+Each decision identifies the repository, PR number, revision SHA when available, and the number of evaluation attempts. Open the PR directly from the decision card.
+
+## Understand outcome labels
+
+Review outcomes and execution status answer different questions:
+
+| Label | Meaning |
+| --- | --- |
+| Passed | The automation reported that the evaluated revision passed its review criteria. |
+| Changes requested | The automation found blocking changes and reported a rejection-style review outcome. |
+| Advisory | The automation reported non-blocking guidance. |
+| Not applicable | The automation determined that its review did not apply to this revision. |
+| Evaluating | The latest run for the revision is still pending or running. |
+| Execution failed | The automation failed before it reported a review decision. |
+| Outcome not reported | The run finished, but no structured decision was recorded. Do not infer that the PR passed. |
+
+When an outcome includes a GitHub review or comment, use the action link to inspect the exact external result. Some older outcomes are marked **Inferred from legacy summary**; these were recovered only from a strict historical summary format rather than reported through the structured outcome contract.
+
+<AgentNote>
+A completed run means the automation infrastructure finished. It does not, by itself, mean the pull request passed review.
+</AgentNote>
+
+## Debug raw runs
+
+Switch to **Raw runs** when you need every execution attempt, session failure details, or retry history. This view is intentionally operational: statuses such as completed, failed, skipped, and no-op describe execution, not the business decision about a PR.
+
+If structured decisions are not available on a deployment yet, the page falls back to execution history and displays this distinction inline.
+

--- a/docs/public/guides/index.mdx
+++ b/docs/public/guides/index.mdx
@@ -7,7 +7,7 @@ status: stable
 audience: engineer
 tags:
   - guides
-llm_summary: Browse task-based 143 guides for repo configuration, preview environments, Linear and Slack agent usage, Autopilot, and coding-agent auth.
+llm_summary: Browse task-based 143 guides for repo configuration, preview environments, Linear and Slack agent usage, automations, Autopilot, and coding-agent auth.
 ---
 
 Guides are the shortest path to a working workflow. Use references when you need every field or constraint.
@@ -17,6 +17,7 @@ Guides are the shortest path to a working workflow. Use references when you need
   <Card title="Preview environments" href="/docs/guides/previews" description="Expose a live app from inside a session." />
   <Card title="Linear agent" href="/docs/guides/linear-agent" description="Assign or mention `@143` in Linear to start work." />
   <Card title="Slack agent" href="/docs/guides/slack-agent" description="Mention `@143` in Slack to start or continue work." />
+  <Card title="Automations" href="/docs/guides/automations" description="Configure triggers and interpret PR decisions separately from execution runs." />
   <Card title="Autopilot" href="/docs/guides/autopilot" description="Understand automatic issue routing and human review gates." />
   <Card title="Coding-agent auth" href="/docs/guides/coding-agent-auth" description="Configure Codex, Claude Code, OpenCode, and fallback coding agents." />
 </Cards>

--- a/docs/public/guides/meta.json
+++ b/docs/public/guides/meta.json
@@ -1,5 +1,5 @@
 {
   "title": "Guides",
   "description": "Task-based guides for configuring and using 143.",
-  "pages": ["index", "repo-config", "previews", "linear-agent", "slack-agent", "autopilot", "coding-agent-auth"]
+  "pages": ["index", "repo-config", "previews", "linear-agent", "slack-agent", "automations", "autopilot", "coding-agent-auth"]
 }

--- a/frontend/src/app/(dashboard)/automations/[id]/automation-stats-card.tsx
+++ b/frontend/src/app/(dashboard)/automations/[id]/automation-stats-card.tsx
@@ -185,10 +185,10 @@ export function AutomationStatsCard({ automationId }: AutomationStatsCardProps) 
       <CardContent className="p-4">
         <div className="flex items-center justify-between mb-3">
           <div>
-            <h3 className="text-sm font-medium">Runs · last {STATS_WINDOW_DAYS} days</h3>
+            <h3 className="text-sm font-medium">Execution runs · last {STATS_WINDOW_DAYS} days</h3>
             {stats && (
               <p className="text-xs text-muted-foreground tabular-nums mt-0.5">
-                {stats.totals.total} total · {successPct}% success · avg {formatDuration(stats.totals.avg_duration_seconds)}
+                {stats.totals.total} total · {successPct}% completed/no-op · avg {formatDuration(stats.totals.avg_duration_seconds)}
               </p>
             )}
           </div>

--- a/frontend/src/app/(dashboard)/automations/[id]/decision-history.test.tsx
+++ b/frontend/src/app/(dashboard)/automations/[id]/decision-history.test.tsx
@@ -1,0 +1,211 @@
+import { describe, expect, it, vi } from "vitest";
+import { http, HttpResponse } from "msw";
+
+import type {
+  AutomationDecision,
+  AutomationDecisionStats,
+  AutomationOutcomeDecision,
+  AutomationRunStatus,
+} from "@/lib/types";
+import {
+  renderWithProviders,
+  screen,
+  waitFor,
+} from "@/test/test-utils";
+import { server } from "@/test/mocks/server";
+
+import { DecisionHistory } from "./decision-history";
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn() }),
+}));
+
+const stats: AutomationDecisionStats = {
+  unique_pull_requests: 4,
+  unique_revisions: 7,
+  total_runs: 9,
+  evaluating: 1,
+  passed: 1,
+  changes_requested: 1,
+  advisory: 1,
+  not_applicable: 1,
+  outcome_not_reported: 1,
+  execution_failed: 1,
+};
+
+function makeDecision({
+  id,
+  status = "completed",
+  outcome,
+  attemptCount = 1,
+}: {
+  id: string;
+  status?: AutomationRunStatus;
+  outcome?: AutomationOutcomeDecision;
+  attemptCount?: number;
+}): AutomationDecision {
+  const prNumber = Number(id.replace(/\D/g, "")) || 1;
+  return {
+    automation_id: "auto-1",
+    run_id: `run-${id}`,
+    session_id: `session-${id}`,
+    target: {
+      repository: "acme/api",
+      pull_request_number: prNumber,
+      pull_request_url: `https://github.com/acme/api/pull/${prNumber}`,
+      pull_request_title: `PR ${prNumber} title`,
+      head_sha: `abcdef0${prNumber}`,
+    },
+    execution_status: status,
+    triggered_at: "2026-07-14T12:00:00Z",
+    completed_at:
+      status === "pending" || status === "running"
+        ? undefined
+        : "2026-07-14T12:05:00Z",
+    attempt_count: attemptCount,
+    outcome: outcome
+      ? {
+          id: `outcome-${id}`,
+          org_id: "org-1",
+          automation_id: "auto-1",
+          automation_run_id: `run-${id}`,
+          session_id: `session-${id}`,
+          repository: "acme/api",
+          pull_request_number: prNumber,
+          pull_request_url: `https://github.com/acme/api/pull/${prNumber}`,
+          pull_request_title: `PR ${prNumber} title`,
+          head_sha: `abcdef0${prNumber}`,
+          decision: outcome,
+          reason: `${outcome} because the review found this result.`,
+          source:
+            outcome === "changes_requested"
+              ? "legacy_inferred"
+              : "agent_reported",
+          reported_at: "2026-07-14T12:04:00Z",
+          created_at: "2026-07-14T12:04:00Z",
+          external_action:
+            outcome === "changes_requested"
+              ? {
+                  id: "action-1",
+                  org_id: "org-1",
+                  outcome_id: `outcome-${id}`,
+                  provider: "github",
+                  action_type: "github_review_changes_requested",
+                  url: "https://github.com/acme/api/pull/2#pullrequestreview-1",
+                  verification_status: "reported",
+                  created_at: "2026-07-14T12:04:00Z",
+                }
+              : undefined,
+        }
+      : undefined,
+  };
+}
+
+function useDecisionHandlers(decisions: AutomationDecision[]) {
+  server.use(
+    http.get("*/api/v1/automations/auto-1/decisions*", () =>
+      HttpResponse.json({ data: decisions, meta: {} }),
+    ),
+    http.get("*/api/v1/automations/auto-1/decision-stats", () =>
+      HttpResponse.json({ data: stats }),
+    ),
+  );
+}
+
+describe("DecisionHistory", () => {
+  it("separates PR outcomes from execution state and links external actions", async () => {
+    useDecisionHandlers([
+      makeDecision({ id: "1", outcome: "passed" }),
+      makeDecision({
+        id: "2",
+        outcome: "changes_requested",
+        attemptCount: 2,
+      }),
+      makeDecision({ id: "3", outcome: "advisory" }),
+      makeDecision({ id: "4", outcome: "not_applicable" }),
+      makeDecision({ id: "5", status: "running" }),
+      makeDecision({ id: "6", status: "failed" }),
+      makeDecision({ id: "7" }),
+    ]);
+
+    renderWithProviders(<DecisionHistory automationId="auto-1" />);
+
+    expect(
+      await screen.findByRole("heading", { name: "PR decisions" }),
+    ).toBeInTheDocument();
+    expect(await screen.findByText("Passed")).toBeInTheDocument();
+    expect(screen.getByText("Changes requested")).toBeInTheDocument();
+    expect(screen.getByText("Advisory")).toBeInTheDocument();
+    expect(screen.getByText("Not applicable")).toBeInTheDocument();
+    expect(screen.getByText("Evaluating")).toBeInTheDocument();
+    expect(screen.getByText("Execution failed")).toBeInTheDocument();
+    expect(screen.getByText("Outcome not reported")).toBeInTheDocument();
+    expect(screen.getByText("Evaluated 2 times")).toBeInTheDocument();
+    expect(
+      screen.getByText("Inferred from legacy summary"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "The automation failed before it reported a review decision.",
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/Do not infer that the PR passed/),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: /View requested changes/ }),
+    ).toHaveAttribute(
+      "href",
+      "https://github.com/acme/api/pull/2#pullrequestreview-1",
+    );
+    expect(screen.getByText("PRs").previousSibling).toHaveTextContent("4");
+    expect(screen.getByText("Revisions").previousSibling).toHaveTextContent(
+      "7",
+    );
+    expect(screen.getByText("Attempts").previousSibling).toHaveTextContent(
+      "9",
+    );
+  });
+
+  it("falls back to execution history when decision endpoints are unavailable", async () => {
+    server.use(
+      http.get("*/api/v1/automations/auto-1/runs*", () =>
+        HttpResponse.json({ data: [], meta: {} }),
+      ),
+    );
+
+    renderWithProviders(<DecisionHistory automationId="auto-1" />);
+
+    expect(
+      await screen.findByRole("heading", { name: "Execution history" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/Run status below describes execution only/),
+    ).toBeInTheDocument();
+    expect(screen.queryByRole("tab", { name: "Decisions" })).not.toBeInTheDocument();
+    expect(await screen.findByText("No runs yet")).toBeInTheDocument();
+  });
+
+  it("sends bookmarkable outcome and PR filters to the decisions API", async () => {
+    const requestURL = vi.fn<(value: string) => void>();
+    server.use(
+      http.get("*/api/v1/automations/auto-1/decisions*", ({ request }) => {
+        requestURL(request.url);
+        return HttpResponse.json({ data: [], meta: {} });
+      }),
+      http.get("*/api/v1/automations/auto-1/decision-stats", () =>
+        HttpResponse.json({ data: stats }),
+      ),
+    );
+
+    renderWithProviders(<DecisionHistory automationId="auto-1" />, {
+      searchParams: { outcome: "changes_requested", pr: "42" },
+    });
+
+    await waitFor(() => expect(requestURL).toHaveBeenCalled());
+    const url = new URL(requestURL.mock.calls.at(-1)?.[0] ?? "http://test");
+    expect(url.searchParams.get("outcome")).toBe("changes_requested");
+    expect(url.searchParams.get("pr")).toBe("42");
+    expect(await screen.findByText("No matching PR decisions")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/app/(dashboard)/automations/[id]/decision-history.tsx
+++ b/frontend/src/app/(dashboard)/automations/[id]/decision-history.tsx
@@ -1,0 +1,594 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { useMutation, useQuery } from "@tanstack/react-query";
+import Link from "next/link";
+import {
+  AlertTriangle,
+  CheckCircle2,
+  CircleHelp,
+  ExternalLink,
+  LoaderCircle,
+  MessageSquareWarning,
+  MinusCircle,
+  XCircle,
+} from "lucide-react";
+import { parseAsString, useQueryState } from "nuqs";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { ApiError, api } from "@/lib/api";
+import type {
+  AutomationDecision,
+  AutomationDecisionStats,
+  AutomationOutcomeDecision,
+  AutomationRunStatus,
+  ListResponse,
+} from "@/lib/types";
+import { formatDateTime, formatTimeAgo } from "@/lib/utils";
+
+import { RunsTab } from "./runs-tab";
+
+const PAGE_SIZE = 25;
+const POLL_MS = 10_000;
+
+type DecisionView = "decisions" | "runs";
+type DecisionDisplayState =
+  | AutomationOutcomeDecision
+  | "evaluating"
+  | "execution_failed"
+  | "outcome_not_reported";
+
+const OUTCOME_FILTERS = [
+  "all",
+  "passed",
+  "changes_requested",
+  "advisory",
+  "not_applicable",
+  "outcome_not_reported",
+] as const;
+
+type OutcomeFilter = (typeof OUTCOME_FILTERS)[number];
+
+function toDecisionView(value: string): DecisionView {
+  return value === "runs" ? "runs" : "decisions";
+}
+
+function toOutcomeFilter(value: string): OutcomeFilter {
+  return OUTCOME_FILTERS.includes(value as OutcomeFilter)
+    ? (value as OutcomeFilter)
+    : "all";
+}
+
+function decisionsUnavailable(error: unknown): boolean {
+  return error instanceof ApiError && (error.status === 404 || error.status === 501);
+}
+
+export function DecisionHistory({ automationId }: { automationId: string }) {
+  const [viewParam, setViewParam] = useQueryState(
+    "view",
+    parseAsString.withDefault("decisions"),
+  );
+  const [outcomeParam, setOutcomeParam] = useQueryState(
+    "outcome",
+    parseAsString.withDefault("all"),
+  );
+  const [prParam, setPRParam] = useQueryState(
+    "pr",
+    parseAsString.withDefault(""),
+  );
+
+  const view = toDecisionView(viewParam);
+  const outcome = toOutcomeFilter(outcomeParam);
+  const normalizedPR = /^\d+$/.test(prParam) && Number(prParam) > 0 ? prParam : "";
+  const filterParams = {
+    outcome: outcome === "all" ? undefined : outcome,
+    pr: normalizedPR || undefined,
+  };
+
+  const decisionsQuery = useQuery({
+    queryKey: ["automation-decisions", automationId, filterParams],
+    queryFn: () =>
+      api.automations.listDecisions(automationId, {
+        limit: PAGE_SIZE,
+        ...filterParams,
+      }),
+    refetchInterval: POLL_MS,
+    retry: false,
+  });
+  const statsQuery = useQuery({
+    queryKey: ["automation-decision-stats", automationId],
+    queryFn: () => api.automations.decisionStats(automationId),
+    refetchInterval: 60_000,
+    retry: false,
+  });
+
+  if (decisionsUnavailable(decisionsQuery.error)) {
+    return (
+      <div className="space-y-3">
+        <div>
+          <h2 className="text-sm font-semibold text-foreground">
+            Execution history
+          </h2>
+          <p className="mt-1 text-xs text-muted-foreground">
+            Structured PR decisions are not available yet. Run status below
+            describes execution only; it does not mean a PR passed review.
+          </p>
+        </div>
+        <RunsTab automationId={automationId} />
+      </div>
+    );
+  }
+
+  if (decisionsQuery.isLoading) {
+    return (
+      <div className="space-y-4">
+        <div>
+          <h2 className="text-sm font-semibold text-foreground">PR decisions</h2>
+          <p className="mt-1 text-xs text-muted-foreground">
+            Loading review outcomes separately from execution status.
+          </p>
+        </div>
+        <DecisionSkeleton />
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      <div>
+        <h2 className="text-sm font-semibold text-foreground">PR decisions</h2>
+        <p className="mt-1 text-xs text-muted-foreground">
+          One row per PR revision. Decisions describe the review outcome;
+          execution status only describes whether the automation ran.
+        </p>
+      </div>
+
+      <DecisionSummary
+        stats={statsQuery.data?.data}
+        isLoading={statsQuery.isLoading}
+        isError={statsQuery.isError}
+      />
+
+      <Tabs
+        value={view}
+        onValueChange={(value) => void setViewParam(toDecisionView(value))}
+      >
+        <TabsList variant="line" size="sm" aria-label="Automation history view">
+          <TabsTrigger value="decisions">Decisions</TabsTrigger>
+          <TabsTrigger value="runs">Raw runs</TabsTrigger>
+        </TabsList>
+        <TabsContent value="decisions" className="mt-3 space-y-3">
+          <DecisionFilters
+            outcome={outcome}
+            pr={prParam}
+            onOutcomeChange={(value) => void setOutcomeParam(value)}
+            onPRChange={(value) => void setPRParam(value)}
+          />
+          {prParam !== "" && normalizedPR === "" ? (
+            <p className="text-xs text-destructive">
+              PR number must be a positive whole number.
+            </p>
+          ) : null}
+          <DecisionList
+            key={`${outcome}:${normalizedPR}`}
+            automationId={automationId}
+            response={decisionsQuery.data}
+            isLoading={decisionsQuery.isLoading}
+            isError={decisionsQuery.isError}
+            filterParams={filterParams}
+          />
+        </TabsContent>
+        <TabsContent value="runs" className="mt-3 space-y-3">
+          <Card variant="recessed">
+            <CardContent className="p-3 text-xs text-muted-foreground">
+              Raw runs show every execution attempt, including retries and
+              no-ops. Use this view to debug execution, not to infer whether a
+              PR was accepted or rejected.
+            </CardContent>
+          </Card>
+          <RunsTab automationId={automationId} />
+        </TabsContent>
+      </Tabs>
+    </div>
+  );
+}
+
+function DecisionSummary({
+  stats,
+  isLoading,
+  isError,
+}: {
+  stats?: AutomationDecisionStats;
+  isLoading: boolean;
+  isError: boolean;
+}) {
+  if (isLoading) {
+    return <div className="h-28 animate-pulse rounded-xl bg-muted/25" />;
+  }
+  if (isError || !stats) {
+    return (
+      <Card variant="recessed">
+        <CardContent className="p-3 text-xs text-muted-foreground">
+          Decision totals are temporarily unavailable. Individual decisions
+          are still shown below.
+        </CardContent>
+      </Card>
+    );
+  }
+
+  const counts: Array<[string, number, DecisionDisplayState]> = [
+    ["Passed", stats.passed, "passed"],
+    ["Changes requested", stats.changes_requested, "changes_requested"],
+    ["Advisory", stats.advisory, "advisory"],
+    ["Not applicable", stats.not_applicable, "not_applicable"],
+    ["Evaluating", stats.evaluating, "evaluating"],
+    ["Execution failed", stats.execution_failed, "execution_failed"],
+    ["Outcome not reported", stats.outcome_not_reported, "outcome_not_reported"],
+  ];
+
+  return (
+    <Card>
+      <CardContent className="space-y-4 p-4">
+        <div className="grid grid-cols-3 gap-3">
+          <SummaryMetric label="PRs" value={stats.unique_pull_requests} />
+          <SummaryMetric label="Revisions" value={stats.unique_revisions} />
+          <SummaryMetric label="Attempts" value={stats.total_runs} />
+        </div>
+        <div className="flex flex-wrap gap-2">
+          {counts.map(([label, count, state]) => (
+            <OutcomeBadge key={state} state={state} label={`${label} ${count}`} />
+          ))}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+function SummaryMetric({ label, value }: { label: string; value: number }) {
+  return (
+    <div>
+      <p className="text-lg font-semibold tabular-nums text-foreground">{value}</p>
+      <p className="text-xs text-muted-foreground">{label}</p>
+    </div>
+  );
+}
+
+function DecisionFilters({
+  outcome,
+  pr,
+  onOutcomeChange,
+  onPRChange,
+}: {
+  outcome: OutcomeFilter;
+  pr: string;
+  onOutcomeChange: (value: OutcomeFilter) => void;
+  onPRChange: (value: string) => void;
+}) {
+  return (
+    <div className="flex flex-col gap-2 sm:flex-row">
+      <Select
+        value={outcome}
+        onValueChange={(value) => onOutcomeChange(toOutcomeFilter(value))}
+      >
+        <SelectTrigger className="w-full sm:w-52" aria-label="Filter by outcome">
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value="all">All outcomes</SelectItem>
+          <SelectItem value="passed">Passed</SelectItem>
+          <SelectItem value="changes_requested">Changes requested</SelectItem>
+          <SelectItem value="advisory">Advisory</SelectItem>
+          <SelectItem value="not_applicable">Not applicable</SelectItem>
+          <SelectItem value="outcome_not_reported">Outcome not reported</SelectItem>
+        </SelectContent>
+      </Select>
+      <Input
+        value={pr}
+        onChange={(event) => onPRChange(event.target.value.trim())}
+        inputMode="numeric"
+        placeholder="PR number"
+        aria-label="Filter by PR number"
+        className="w-full sm:w-40"
+      />
+      {outcome !== "all" || pr !== "" ? (
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={() => {
+            onOutcomeChange("all");
+            onPRChange("");
+          }}
+        >
+          Clear filters
+        </Button>
+      ) : null}
+    </div>
+  );
+}
+
+function DecisionList({
+  automationId,
+  response,
+  isLoading,
+  isError,
+  filterParams,
+}: {
+  automationId: string;
+  response?: ListResponse<AutomationDecision>;
+  isLoading: boolean;
+  isError: boolean;
+  filterParams: { outcome?: string; pr?: string };
+}) {
+  const [extraPages, setExtraPages] = useState<AutomationDecision[][]>([]);
+  const [cursor, setCursor] = useState(response?.meta?.next_cursor || "");
+  const firstCursor = response?.meta?.next_cursor || "";
+  const nextCursor = extraPages.length > 0 ? cursor : firstCursor;
+  const decisions = useMemo(
+    () => [response?.data ?? [], ...extraPages].flat(),
+    [extraPages, response?.data],
+  );
+  const loadMore = useMutation({
+    mutationFn: () =>
+      api.automations.listDecisions(automationId, {
+        limit: PAGE_SIZE,
+        cursor: nextCursor,
+        ...filterParams,
+      }),
+    onSuccess: (next) => {
+      if (next.data.length > 0) {
+        setExtraPages((pages) => [...pages, next.data]);
+      }
+      setCursor(next.meta?.next_cursor || "");
+    },
+  });
+
+  if (isLoading) return <DecisionSkeleton />;
+  if (isError) {
+    return (
+      <Card variant="recessed">
+        <CardContent className="p-5 text-sm text-destructive">
+          Failed to load PR decisions. Raw runs remain available in the next
+          tab.
+        </CardContent>
+      </Card>
+    );
+  }
+  if (decisions.length === 0) {
+    return (
+      <Card variant="recessed">
+        <CardContent className="p-8 text-center">
+          <p className="text-sm font-medium text-foreground">
+            No matching PR decisions
+          </p>
+          <p className="mt-1 text-xs text-muted-foreground">
+            Decisions appear after a GitHub-triggered run evaluates a pull
+            request revision. Try clearing filters or inspect Raw runs.
+          </p>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <div className="space-y-3">
+      {decisions.map((decision) => (
+        <DecisionCard key={decision.run_id} decision={decision} />
+      ))}
+      {loadMore.isError ? (
+        <p className="text-center text-xs text-destructive">
+          Failed to load more decisions. Please try again.
+        </p>
+      ) : null}
+      {nextCursor ? (
+        <Button
+          variant="ghost"
+          size="sm"
+          className="w-full rounded-xl border border-dashed border-border/70"
+          onClick={() => loadMore.mutate()}
+          disabled={loadMore.isPending}
+        >
+          {loadMore.isPending ? "Loading…" : "Load more decisions"}
+        </Button>
+      ) : null}
+    </div>
+  );
+}
+
+export function DecisionCard({ decision }: { decision: AutomationDecision }) {
+  const state = decisionDisplayState(decision);
+  const title =
+    decision.target.pull_request_title ||
+    `${decision.target.repository} #${decision.target.pull_request_number}`;
+  const action = decision.outcome?.external_action;
+
+  return (
+    <Card>
+      <CardContent className="space-y-3 p-4">
+        <div className="flex flex-col justify-between gap-3 sm:flex-row sm:items-start">
+          <div className="min-w-0">
+            <div className="flex flex-wrap items-center gap-2">
+              <OutcomeBadge state={state} />
+              {decision.attempt_count > 1 ? (
+                <Badge variant="outline">
+                  Evaluated {decision.attempt_count} times
+                </Badge>
+              ) : null}
+              {decision.outcome?.source === "legacy_inferred" ? (
+                <Badge variant="outline">Inferred from legacy summary</Badge>
+              ) : null}
+            </div>
+            <p className="mt-2 break-words text-sm font-medium text-foreground">
+              {title}
+            </p>
+            <p className="mt-1 text-xs text-muted-foreground">
+              {decision.target.repository} #{decision.target.pull_request_number}
+              {decision.target.head_sha
+                ? ` · revision ${decision.target.head_sha.slice(0, 8)}`
+                : ""}
+            </p>
+          </div>
+          <Button asChild variant="outline" size="sm">
+            <a
+              href={decision.target.pull_request_url}
+              target="_blank"
+              rel="noreferrer"
+            >
+              Open PR
+              <ExternalLink className="ml-1 h-3.5 w-3.5" />
+            </a>
+          </Button>
+        </div>
+
+        {decision.outcome?.reason ? (
+          <p className="text-sm leading-6 text-foreground">
+            {decision.outcome.reason}
+          </p>
+        ) : (
+          <p className="text-sm text-muted-foreground">
+            {missingOutcomeExplanation(state)}
+          </p>
+        )}
+
+        <div className="flex flex-wrap items-center gap-x-3 gap-y-2 text-xs text-muted-foreground">
+          <span>{formatTimeAgo(decision.triggered_at)}</span>
+          <span>Execution: {executionLabel(decision.execution_status)}</span>
+          {decision.completed_at ? (
+            <span>Completed {formatDateTime(decision.completed_at)}</span>
+          ) : null}
+        </div>
+
+        {action || decision.session_id ? (
+          <div className="flex flex-wrap gap-2 border-t border-border/70 pt-3">
+            {action ? (
+              <Button asChild variant="outline" size="sm">
+                <a href={action.url} target="_blank" rel="noreferrer">
+                  {externalActionLabel(action.action_type)}
+                  <ExternalLink className="ml-1 h-3.5 w-3.5" />
+                </a>
+              </Button>
+            ) : null}
+            {decision.session_id ? (
+              <Button asChild variant="ghost" size="sm">
+                <Link href={`/sessions/${decision.session_id}`}>Open session</Link>
+              </Button>
+            ) : null}
+          </div>
+        ) : null}
+      </CardContent>
+    </Card>
+  );
+}
+
+function decisionDisplayState(decision: AutomationDecision): DecisionDisplayState {
+  if (decision.outcome) return decision.outcome.decision;
+  if (
+    decision.execution_status === "pending" ||
+    decision.execution_status === "running"
+  ) {
+    return "evaluating";
+  }
+  if (decision.execution_status === "failed") return "execution_failed";
+  return "outcome_not_reported";
+}
+
+function OutcomeBadge({
+  state,
+  label,
+}: {
+  state: DecisionDisplayState;
+  label?: string;
+}) {
+  const config = {
+    passed: { label: "Passed", variant: "success" as const, icon: CheckCircle2 },
+    changes_requested: {
+      label: "Changes requested",
+      variant: "destructive" as const,
+      icon: XCircle,
+    },
+    advisory: {
+      label: "Advisory",
+      variant: "warning" as const,
+      icon: MessageSquareWarning,
+    },
+    not_applicable: {
+      label: "Not applicable",
+      variant: "secondary" as const,
+      icon: MinusCircle,
+    },
+    evaluating: {
+      label: "Evaluating",
+      variant: "info" as const,
+      icon: LoaderCircle,
+    },
+    execution_failed: {
+      label: "Execution failed",
+      variant: "destructive" as const,
+      icon: AlertTriangle,
+    },
+    outcome_not_reported: {
+      label: "Outcome not reported",
+      variant: "outline" as const,
+      icon: CircleHelp,
+    },
+  }[state];
+  const Icon = config.icon;
+  return (
+    <Badge variant={config.variant}>
+      <Icon className={state === "evaluating" ? "animate-spin" : undefined} />
+      {label ?? config.label}
+    </Badge>
+  );
+}
+
+function missingOutcomeExplanation(state: DecisionDisplayState): string {
+  switch (state) {
+    case "evaluating":
+      return "This PR revision is still being evaluated.";
+    case "execution_failed":
+      return "The automation failed before it reported a review decision.";
+    case "outcome_not_reported":
+      return "The run finished without a structured review decision. Do not infer that the PR passed.";
+    default:
+      return "No outcome reason was reported.";
+  }
+}
+
+function executionLabel(status: AutomationRunStatus): string {
+  return status === "completed_noop" ? "no-op" : status.replaceAll("_", " ");
+}
+
+function externalActionLabel(actionType: string): string {
+  switch (actionType) {
+    case "github_review_changes_requested":
+      return "View requested changes";
+    case "github_review_approved":
+      return "View approval";
+    default:
+      return "View GitHub comment";
+  }
+}
+
+function DecisionSkeleton() {
+  return (
+    <div
+      className="space-y-3"
+      aria-busy
+      aria-live="polite"
+      aria-label="Loading PR decisions"
+    >
+      <div className="h-36 animate-pulse rounded-xl bg-muted/25" />
+      <div className="h-28 animate-pulse rounded-xl bg-muted/25" />
+    </div>
+  );
+}

--- a/frontend/src/app/(dashboard)/automations/[id]/page.test.tsx
+++ b/frontend/src/app/(dashboard)/automations/[id]/page.test.tsx
@@ -557,8 +557,12 @@ describe("AutomationDetailPage", () => {
     renderWithProviders(<AutomationDetailPage />);
 
     expect(
-      await screen.findByRole("heading", { name: "Run history" }),
+      await screen.findByRole("heading", { name: "Execution history" }),
     ).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { name: "Latest execution" }),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/Operational status only/)).toBeInTheDocument();
     expect(
       screen.queryByRole("heading", { name: "Previous runs" }),
     ).not.toBeInTheDocument();

--- a/frontend/src/app/(dashboard)/automations/[id]/page.tsx
+++ b/frontend/src/app/(dashboard)/automations/[id]/page.tsx
@@ -85,7 +85,7 @@ import {
   toCodingAgentReasoningEffort,
   type CodingAgentReasoningEffort,
 } from "@/lib/coding-agent-reasoning";
-import { RunsTab } from "./runs-tab";
+import { DecisionHistory } from "./decision-history";
 import {
   browserTimezone,
   formatAutomationSchedule,
@@ -1168,12 +1168,7 @@ export default function AutomationDetailPage() {
 
             <LatestRunSummary automationId={automationId} />
 
-            <section className="space-y-3">
-              <h2 className="text-sm font-semibold text-foreground">
-                Run history
-              </h2>
-              <RunsTab automationId={automationId} />
-            </section>
+            <DecisionHistory automationId={automationId} />
           </main>
 
           <aside className="hidden space-y-4 lg:sticky lg:top-4 lg:block">
@@ -1300,7 +1295,12 @@ function LatestRunSummary({ automationId }: { automationId: string }) {
 
   return (
     <section className="rounded-lg border border-border bg-card p-5">
-      <h2 className="text-sm font-semibold text-foreground">Latest run</h2>
+      <h2 className="text-sm font-semibold text-foreground">
+        Latest execution
+      </h2>
+      <p className="mt-1 text-xs text-muted-foreground">
+        Operational status only. Review outcomes are shown in PR decisions.
+      </p>
       {isLoading ? (
         <p className="mt-3 text-sm text-muted-foreground">
           Loading latest run...
@@ -1324,7 +1324,7 @@ function LatestRunBody({ run }: { run: AutomationRun }) {
     <div className="mt-3 space-y-2">
       <div className="flex flex-wrap items-center gap-2">
         <Badge variant={run.status === "failed" ? "destructive" : "secondary"}>
-          {statusLabel(run.status)}
+          Execution: {statusLabel(run.status)}
         </Badge>
         <span className="text-xs text-muted-foreground">
           {formatTimeAgo(run.triggered_at)}
@@ -1348,6 +1348,8 @@ function statusLabel(status: AutomationRun["status"]): string {
     case "completed_noop":
       return "No-op";
     default:
-      return status.replaceAll("_", " ");
+      return status
+        .replaceAll("_", " ")
+        .replace(/^./, (letter) => letter.toUpperCase());
   }
 }

--- a/frontend/src/lib/api.test.ts
+++ b/frontend/src/lib/api.test.ts
@@ -1231,6 +1231,57 @@ describe('api client', () => {
         },
       ]);
     });
+
+    it('lists structured decisions with outcome and PR filters', async () => {
+      let capturedURL = '';
+      server.use(
+        http.get('/api/v1/automations/:id/decisions', ({ params, request }) => {
+          expect(params.id).toBe('automation-1');
+          capturedURL = request.url;
+          return HttpResponse.json({ data: [], meta: { next_cursor: '' } });
+        }),
+      );
+
+      const result = await api.automations.listDecisions('automation-1', {
+        limit: 25,
+        cursor: 'run-1',
+        outcome: 'changes_requested',
+        pr: '42',
+      });
+
+      const url = new URL(capturedURL);
+      expect(url.searchParams.get('limit')).toBe('25');
+      expect(url.searchParams.get('cursor')).toBe('run-1');
+      expect(url.searchParams.get('outcome')).toBe('changes_requested');
+      expect(url.searchParams.get('pr')).toBe('42');
+      expect(result.data).toEqual([]);
+    });
+
+    it('gets structured decision totals', async () => {
+      server.use(
+        http.get('/api/v1/automations/:id/decision-stats', ({ params }) => {
+          expect(params.id).toBe('automation-1');
+          return HttpResponse.json({
+            data: {
+              unique_pull_requests: 2,
+              unique_revisions: 3,
+              total_runs: 4,
+              evaluating: 0,
+              passed: 1,
+              changes_requested: 1,
+              advisory: 0,
+              not_applicable: 0,
+              outcome_not_reported: 1,
+              execution_failed: 0,
+            },
+          });
+        }),
+      );
+
+      const result = await api.automations.decisionStats('automation-1');
+      expect(result.data.unique_revisions).toBe(3);
+      expect(result.data.changes_requested).toBe(1);
+    });
   });
 
   describe('memories', () => {

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1301,6 +1301,17 @@ export const api = {
       const qs = searchParams.toString();
       return get<import('./types').ListResponse<import('./types').AutomationRun>>(`/api/v1/automations/${id}/runs${qs ? `?${qs}` : ''}`);
     },
+    listDecisions: (id: string, params?: { cursor?: string; limit?: number; outcome?: string; pr?: string }) => {
+      const searchParams = new URLSearchParams();
+      if (params?.cursor) searchParams.set('cursor', params.cursor);
+      if (params?.limit) searchParams.set('limit', String(params.limit));
+      if (params?.outcome) searchParams.set('outcome', params.outcome);
+      if (params?.pr) searchParams.set('pr', params.pr);
+      const qs = searchParams.toString();
+      return get<import('./types').ListResponse<import('./types').AutomationDecision>>(`/api/v1/automations/${id}/decisions${qs ? `?${qs}` : ''}`);
+    },
+    decisionStats: (id: string) =>
+      get<import('./types').SingleResponse<import('./types').AutomationDecisionStats>>(`/api/v1/automations/${id}/decision-stats`),
     getRun: (id: string, runId: string) =>
       get<import('./types').SingleResponse<import('./types').AutomationRun>>(`/api/v1/automations/${id}/runs/${runId}`),
     getCapabilities: (id: string) =>

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -3427,7 +3427,7 @@ export type AutomationGitHubEvent =
   | "github.pull_request_review.submitted"
   | "github.pull_request_review_comment.created";
 
-export type AutomationEventProvider = "pagerduty" | "linear";
+export type AutomationEventProvider = "github" | "pagerduty" | "linear";
 export type PagerDutyEventType =
   | "incident.triggered"
   | "incident.acknowledged"
@@ -3611,6 +3611,9 @@ export interface AutomationRun {
   triggered_by: "schedule" | "manual" | "github";
   triggered_by_user_id?: string;
   scheduled_time?: string;
+  provider?: AutomationEventProvider;
+  provider_event_id?: string;
+  trigger_context?: Record<string, unknown>;
   goal_snapshot: string;
   config_snapshot?: Record<string, unknown>;
   status: AutomationRunStatus;
@@ -3624,6 +3627,100 @@ export interface AutomationRun {
   // when the run hasn't spawned a session yet (pending/skipped, or
   // mid-flight before the worker creates the session).
   session?: AutomationRunSession;
+  trigger_target?: AutomationRunTriggerTarget;
+  trigger_details?: AutomationRunTriggerDetails;
+}
+
+export interface AutomationRunTriggerTarget {
+  repository: string;
+  pull_request_number: number;
+  pull_request_url: string;
+  pull_request_title?: string;
+  head_sha?: string;
+}
+
+export interface AutomationRunTriggerDetails {
+  event: AutomationGitHubEvent;
+  provider_event_id?: string;
+  event_id?: string;
+  dedupe_group_id?: string;
+  actor?: string;
+  actor_type?: string;
+  bot_triggered: boolean;
+}
+
+export type AutomationOutcomeDecision =
+  | "passed"
+  | "changes_requested"
+  | "advisory"
+  | "not_applicable";
+
+export type AutomationOutcomeSource = "agent_reported" | "legacy_inferred";
+
+export type AutomationExternalActionType =
+  | "github_review_changes_requested"
+  | "github_review_approved"
+  | "github_comment";
+
+export type AutomationExternalActionVerificationStatus =
+  | "reported"
+  | "verified"
+  | "unavailable";
+
+export interface AutomationRunExternalAction {
+  id: string;
+  org_id: string;
+  outcome_id: string;
+  provider: string;
+  action_type: AutomationExternalActionType;
+  external_id?: string;
+  url: string;
+  verification_status: AutomationExternalActionVerificationStatus;
+  created_at: string;
+}
+
+export interface AutomationRunOutcome {
+  id: string;
+  org_id: string;
+  automation_id: string;
+  automation_run_id: string;
+  session_id: string;
+  repository: string;
+  pull_request_number: number;
+  pull_request_url: string;
+  pull_request_title?: string;
+  head_sha?: string;
+  decision: AutomationOutcomeDecision;
+  reason: string;
+  source: AutomationOutcomeSource;
+  reported_at: string;
+  created_at: string;
+  external_action?: AutomationRunExternalAction;
+}
+
+export interface AutomationDecision {
+  automation_id: string;
+  run_id: string;
+  session_id?: string;
+  target: AutomationRunTriggerTarget;
+  execution_status: AutomationRunStatus;
+  triggered_at: string;
+  completed_at?: string;
+  attempt_count: number;
+  outcome?: AutomationRunOutcome;
+}
+
+export interface AutomationDecisionStats {
+  unique_pull_requests: number;
+  unique_revisions: number;
+  total_runs: number;
+  evaluating: number;
+  passed: number;
+  changes_requested: number;
+  advisory: number;
+  not_applicable: number;
+  outcome_not_reported: number;
+  execution_failed: number;
 }
 
 // Mirrors the session publish lifecycle enums in internal/models/session_enums.go.

--- a/frontend/src/test/mocks/handlers.ts
+++ b/frontend/src/test/mocks/handlers.ts
@@ -1120,6 +1120,24 @@ export const handlers = [
     });
   }),
 
+  // The decision-first automation UI is independently deployable from the
+  // structured-outcomes backend. Default to the pre-outcomes response so
+  // existing page tests exercise its raw-run fallback; focused tests override
+  // these handlers with decision data.
+  http.get('/api/v1/automations/:id/decisions', () => {
+    return HttpResponse.json(
+      { error: { code: 'NOT_FOUND', message: 'Decisions not available' } },
+      { status: 404 },
+    );
+  }),
+
+  http.get('/api/v1/automations/:id/decision-stats', () => {
+    return HttpResponse.json(
+      { error: { code: 'NOT_FOUND', message: 'Decision stats not available' } },
+      { status: 404 },
+    );
+  }),
+
   http.get('/api/v1/pm/documents', () => {
     return HttpResponse.json({
       data: [],


### PR DESCRIPTION
## Summary

- make PR decisions the default automation history view, grouped by PR revision rather than raw attempts
- show explicit Passed, Changes requested, Advisory, Not applicable, Evaluating, Execution failed, and Outcome not reported states
- add decision totals, bookmarkable outcome/PR filters, repeated-evaluation counts, and direct PR/GitHub-action links
- relabel latest and aggregate run status as execution-only data
- fall back safely to the existing raw-run history when the outcome API is not deployed
- add a public automation guide explaining how to interpret decisions versus executions

## Verification

- full `npm run lint`
- 139 focused Vitest tests across the decision component, automation page, run history, and API client
- `npm run typecheck`
- `npm run build` (including Fumadocs/MDX generation)
- `git diff --check`

## Independence

This PR is based directly on `main`. It can merge before the structured-outcomes backend: 404/501 responses automatically render the existing execution history with explanatory copy. Once the backend endpoints are available, the decision-first view activates without another frontend deployment.