### PR TITLE
Add skeleton loading components for Automations page and remove “Loading ...” indicator

### DIFF
--- a/frontend/src/app/(dashboard)/automations/[id]/page.test.tsx
+++ b/frontend/src/app/(dashboard)/automations/[id]/page.test.tsx
@@ -84,7 +84,7 @@ describe("AutomationDetailPage", () => {
 
   it("renders the automation detail skeleton while the automation loads", () => {
     server.use(
-      http.get("*/api/v1/automations/auto-1", async () => new Promise<HttpResponse>(() => {})),
+      http.get("*/api/v1/automations/auto-1", async () => new Promise<never>(() => {})),
     );
 
     renderWithProviders(<AutomationDetailPage />);

--- a/frontend/src/app/(dashboard)/automations/[id]/page.test.tsx
+++ b/frontend/src/app/(dashboard)/automations/[id]/page.test.tsx
@@ -82,6 +82,19 @@ describe("AutomationDetailPage", () => {
     );
   });
 
+  it("renders the automation detail skeleton while the automation loads", () => {
+    server.use(
+      http.get("*/api/v1/automations/auto-1", async () => new Promise<HttpResponse>(() => {})),
+    );
+
+    renderWithProviders(<AutomationDetailPage />);
+
+    expect(screen.getByLabelText("Loading automation")).toHaveAttribute("aria-busy", "true");
+    expect(screen.getByRole("link", { name: "Back to automations" })).toBeInTheDocument();
+    expect(screen.queryByText("Loading...")).not.toBeInTheDocument();
+    expect(screen.getByTestId("automation-detail-header-skeleton-copy")).toHaveClass("min-w-0", "flex-1");
+  });
+
   it("matches the schedule controls and labels to the app input sizing", async () => {
     server.use(
       http.get("*/api/v1/automations/auto-1", () =>

--- a/frontend/src/app/(dashboard)/automations/[id]/page.tsx
+++ b/frontend/src/app/(dashboard)/automations/[id]/page.tsx
@@ -847,6 +847,51 @@ function SettingsTab({
   );
 }
 
+function AutomationDetailPageSkeleton() {
+  return (
+    <PageContainer size="wide">
+      <div className="space-y-6" aria-busy="true" aria-label="Loading automation">
+        <MobileBackButton to="/automations" label="Back to automations" />
+        <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+          <div className="flex min-w-0 items-center gap-3">
+            <div className="h-9 w-9 shrink-0 animate-pulse rounded-lg bg-muted" />
+            <div
+              className="min-w-0 flex-1 space-y-2"
+              data-testid="automation-detail-header-skeleton-copy"
+            >
+              <div className="h-6 w-full max-w-56 animate-pulse rounded bg-muted sm:max-w-72" />
+              <div className="h-4 w-full max-w-72 animate-pulse rounded bg-muted/70 sm:max-w-96" />
+            </div>
+          </div>
+          <div className="flex gap-2">
+            <div className="h-8 w-16 animate-pulse rounded-lg bg-muted" />
+            <div className="h-8 w-20 animate-pulse rounded-lg bg-muted" />
+          </div>
+        </div>
+        <div className="grid gap-6 lg:grid-cols-[minmax(0,1fr)_20rem]">
+          <div className="space-y-4">
+            <div className="h-9 w-64 animate-pulse rounded-lg bg-muted" />
+            <div className="space-y-3">
+              <div className="h-28 animate-pulse rounded-xl border border-border bg-muted/30" />
+              <div className="h-20 animate-pulse rounded-xl border border-border bg-muted/30" />
+              <div className="h-20 animate-pulse rounded-xl border border-border bg-muted/30" />
+            </div>
+          </div>
+          <div className="hidden space-y-4 rounded-xl border border-border p-4 lg:block">
+            <div className="h-4 w-28 animate-pulse rounded bg-muted" />
+            {[0, 1, 2, 3].map((row) => (
+              <div key={row} className="space-y-2">
+                <div className="h-3 w-20 animate-pulse rounded bg-muted/70" />
+                <div className="h-4 w-4/5 animate-pulse rounded bg-muted" />
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+    </PageContainer>
+  );
+}
+
 export default function AutomationDetailPage() {
   const params = useParams();
   const router = useRouter();
@@ -987,16 +1032,7 @@ export default function AutomationDetailPage() {
   });
 
   if (isLoading) {
-    return (
-      <PageContainer size="default">
-        <div className="space-y-6">
-          <MobileBackButton to="/automations" label="Back to automations" />
-          <div className="text-center py-12 text-sm text-muted-foreground">
-            Loading...
-          </div>
-        </div>
-      </PageContainer>
-    );
+    return <AutomationDetailPageSkeleton />;
   }
 
   if (!automation) {

--- a/frontend/src/app/(dashboard)/automations/page.test.tsx
+++ b/frontend/src/app/(dashboard)/automations/page.test.tsx
@@ -26,8 +26,8 @@ describe("AutomationsPage", () => {
 
     renderWithProviders(<AutomationsPage />);
 
-    expect(await screen.findByRole("heading", { name: "Template library" })).toBeInTheDocument();
-    expect(screen.getByPlaceholderText("Search templates...")).toBeInTheDocument();
+    expect(await screen.findByPlaceholderText("Search templates...")).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Template library" })).toBeInTheDocument();
     expect(screen.queryByRole("link", { name: /Start from blank/i })).not.toBeInTheDocument();
     expect(screen.getByRole("link", { name: /^New automation$/i })).toHaveAttribute("href", "/automations/new");
     expect(screen.getByRole("tab", { name: "Popular" })).toBeInTheDocument();
@@ -50,8 +50,8 @@ describe("AutomationsPage", () => {
 
     renderWithProviders(<AutomationsPage />);
 
-    expect(await screen.findByRole("heading", { name: "Template library" })).toBeInTheDocument();
-    expect(screen.getByText("Find flaky tests")).toBeInTheDocument();
+    expect(await screen.findByText("Find flaky tests")).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Template library" })).toBeInTheDocument();
     expect(screen.getByText("Security sweep")).toBeInTheDocument();
     expect(screen.getByPlaceholderText("Search templates...")).toBeInTheDocument();
     expect(screen.queryByRole("link", { name: /Start from blank/i })).not.toBeInTheDocument();
@@ -299,5 +299,18 @@ describe("AutomationsPage", () => {
     expect(await screen.findAllByText("Weekly sweep")).toHaveLength(2);
     expect(screen.queryByRole("link", { name: /new/i })).not.toBeInTheDocument();
     expect(screen.queryByRole("button", { name: /more options for weekly sweep/i })).not.toBeInTheDocument();
+  });
+
+  it("renders the automation workspace skeleton while automations load", () => {
+    server.use(
+      http.get("*/api/v1/automations", async () => new Promise<HttpResponse>(() => {})),
+    );
+
+    renderWithProviders(<AutomationsPage />);
+
+    expect(screen.getByLabelText("Loading automations")).toHaveAttribute("aria-busy", "true");
+    expect(screen.getByRole("heading", { name: "Your automations" })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Template library" })).toBeInTheDocument();
+    expect(screen.queryByText("Loading automations...")).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/app/(dashboard)/automations/page.test.tsx
+++ b/frontend/src/app/(dashboard)/automations/page.test.tsx
@@ -303,7 +303,7 @@ describe("AutomationsPage", () => {
 
   it("renders the automation workspace skeleton while automations load", () => {
     server.use(
-      http.get("*/api/v1/automations", async () => new Promise<HttpResponse>(() => {})),
+      http.get("*/api/v1/automations", async () => new Promise<never>(() => {})),
     );
 
     renderWithProviders(<AutomationsPage />);

--- a/frontend/src/app/(dashboard)/automations/page.tsx
+++ b/frontend/src/app/(dashboard)/automations/page.tsx
@@ -541,6 +541,62 @@ function AutomationMobileRow({ automation, canManage }: { automation: Automation
   );
 }
 
+function AutomationsPageSkeleton() {
+  return (
+    <div className="space-y-8" aria-busy="true" aria-label="Loading automations">
+      <SectionGroup
+        aria-label="Your automations"
+        title="Your automations"
+        description="Recurring agents currently configured for this team."
+      >
+        <div className="space-y-3">
+          <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
+            <div className="h-8 w-64 animate-pulse rounded-lg bg-muted" />
+            <div className="h-8 w-full animate-pulse rounded-lg bg-muted lg:max-w-72" />
+          </div>
+          <Card>
+            <CardContent className="p-0">
+              <div className="hidden h-10 border-b border-border bg-muted/30 md:block" />
+              {[0, 1, 2].map((row) => (
+                <div
+                  key={row}
+                  className="flex h-[72px] items-center gap-4 border-b border-border px-4 last:border-b-0"
+                >
+                  <div className="h-7 w-7 shrink-0 animate-pulse rounded-md bg-muted" />
+                  <div className="min-w-0 flex-1 space-y-2">
+                    <div className="h-4 w-2/5 animate-pulse rounded bg-muted" />
+                    <div className="h-3 w-3/5 animate-pulse rounded bg-muted/70" />
+                  </div>
+                  <div className="hidden h-5 w-16 animate-pulse rounded-full bg-muted md:block" />
+                  <div className="hidden h-3 w-28 animate-pulse rounded bg-muted md:block" />
+                  <div className="hidden h-3 w-20 animate-pulse rounded bg-muted lg:block" />
+                </div>
+              ))}
+            </CardContent>
+          </Card>
+        </div>
+      </SectionGroup>
+
+      <SectionGroup
+        aria-label="Template library"
+        title="Template library"
+        description="Start with a proven recurring workflow and tailor it to your team."
+      >
+        <Card>
+          <CardContent className="space-y-4 p-4">
+            <div className="h-8 w-full animate-pulse rounded-lg bg-muted sm:w-72" />
+            <div className="grid gap-3 md:grid-cols-2">
+              {[0, 1, 2, 3].map((card) => (
+                <div key={card} className="h-32 animate-pulse rounded-xl border border-border bg-muted/30" />
+              ))}
+            </div>
+          </CardContent>
+        </Card>
+      </SectionGroup>
+    </div>
+  );
+}
+
 export default function AutomationsPage() {
   const { user } = useAuth();
   const canManage = user?.role === "admin" || user?.role === "member";
@@ -570,11 +626,7 @@ export default function AutomationsPage() {
           ) : undefined}
         />
 
-        {isLoading && (
-          <div className="text-center py-12 text-sm text-muted-foreground">
-            Loading automations...
-          </div>
-        )}
+        {isLoading && <AutomationsPageSkeleton />}
 
         {!isLoading && (
           <AutomationsWorkspace enabled={enabled} paused={paused} canManage={canManage} />


### PR DESCRIPTION
## Summary

Mobile users could see header overflow while the Automations detail page loaded (the layout failed to properly shrink/collapse). This PR replaces the old “Loading ...” indicator with a responsive skeleton that uses shrink-safe flex sizing, improving perceived performance and preventing layout shifts.  

## Changes

- Added `AutomationDetailPageSkeleton` shown while the automation is loading, including a skeleton header and content placeholders.
- Updated header skeleton sizing to be shrink-safe (`min-w-0 flex-1`) so text/controls don’t overflow on small screens.
- Removed the plain “Loading ...” text path and added a regression test to ensure the skeleton renders and the old indicator is gone.

## Validation

- Ran frontend test suite: **21 tests passed**
- **ESLint passed**
- `git diff --check` is clean

[143.dev](https://143.dev) | [session 15a8c285](https://143.dev/sessions/15a8c285-b2d7-401a-ae10-a5106ff91c96)

<!-- 143 readiness -->
**143 readiness:** not available for this revision.

Preview: https://143.dev/previews/github/assembledhq/143/pull/1853?launch=1