### PR TITLE
Remove code reviewer commit statuses

### DIFF
--- a/docs/design/implemented/112-code-reviewer-bot-auto-approval.md
+++ b/docs/design/implemented/112-code-reviewer-bot-auto-approval.md
@@ -1,6 +1,6 @@
 # Design: Code Reviewer Bot And Acceptable-Risk Auto-Approval
 
-> **Status:** Implemented | **Last reviewed:** 2026-06-26
+> **Status:** Implemented | **Last reviewed:** 2026-07-15
 >
 > **Depends on:** [../overall.md](../overall.md), [78-review-agent-loops.md](78-review-agent-loops.md), [107-pr-readiness-checks.md](107-pr-readiness-checks.md), [61-pr-state-sync-and-repair-actions.md](61-pr-state-sync-and-repair-actions.md), [../backlog/11-review-feedback-loop.md](../backlog/11-review-feedback-loop.md)
 
@@ -29,7 +29,7 @@ Implemented:
 - prompt artifact storage and recovery for rendered reviewer/orchestrator/description prompts and their structured outputs
 - inline-comment posting with marker-based dedupe/update and posted-comment id persistence
 - GitHub changed-file fetch support for PR file/line threshold and coarse risk-category evaluation
-- GitHub pending/final commit-status publication for code review runs when the worker has GitHub credentials
+- GitHub review submission as the sole GitHub result surface, avoiding a redundant commit status that could be mistaken for a required CI check
 - stale requested-reviewer cleanup after final review submission for reviewer-login and team-slug triggers carried in the durable job payload
 - productized GitHub team-trigger setup that creates or repairs the `143-code-reviewer` org team, grants repository read access, and persists repo-scoped active trigger settings
 - final-review template rendering from persisted policy data with safe fallback to the built-in body
@@ -127,7 +127,7 @@ Primary interaction:
 - A 143 admin creates or repairs the `143-code-reviewer` GitHub team from the Code reviews configuration page.
 - 143 grants that team read access to the selected repository and stores the team slug as the repo's active trigger.
 - A user requests `@org/143-code-reviewer` as a team reviewer on a PR.
-- The bot posts one pending/running status, then submits a final GitHub review with a summary body and a configurable number of inline comments on changed lines.
+- The bot submits a final GitHub review with a summary body and a configurable number of inline comments on changed lines; it does not publish a separate commit status.
 
 This does not use CODEOWNERS and does not auto-request reviews on PR open. The team is only the selectable GitHub reviewer trigger; normal review submission still uses the installed GitHub App.
 

--- a/internal/services/codereview/github_submitter.go
+++ b/internal/services/codereview/github_submitter.go
@@ -116,25 +116,6 @@ type ReviewContext struct {
 	BlockingHumanReviews   int
 }
 
-type CommitStatusState string
-
-const (
-	CommitStatusStateError   CommitStatusState = "error"
-	CommitStatusStateFailure CommitStatusState = "failure"
-	CommitStatusStatePending CommitStatusState = "pending"
-	CommitStatusStateSuccess CommitStatusState = "success"
-)
-
-type CommitStatusRequest struct {
-	InstallationID int64
-	Repository     string
-	SHA            string
-	State          CommitStatusState
-	Context        string
-	Description    string
-	TargetURL      string
-}
-
 type RequestedReviewersRequest struct {
 	InstallationID int64
 	Repository     string
@@ -588,59 +569,6 @@ func loginInSet(login string, set map[string]struct{}) bool {
 	return ok
 }
 
-func (s *GitHubSubmitter) PublishCommitStatus(ctx context.Context, req CommitStatusRequest) error {
-	if s == nil || s.tokens == nil {
-		return fmt.Errorf("github submitter is not configured")
-	}
-	owner, repo, ok := strings.Cut(req.Repository, "/")
-	if !ok || owner == "" || repo == "" {
-		return fmt.Errorf("repository must be owner/name")
-	}
-	if req.InstallationID <= 0 {
-		return fmt.Errorf("installation id is required")
-	}
-	if strings.TrimSpace(req.SHA) == "" {
-		return fmt.Errorf("sha is required")
-	}
-	if err := req.State.validate(); err != nil {
-		return err
-	}
-	token, err := s.tokens.GetInstallationToken(ctx, req.InstallationID)
-	if err != nil {
-		return fmt.Errorf("get installation token: %w", err)
-	}
-	payload := map[string]any{
-		"state":       req.State,
-		"context":     firstNonEmpty(req.Context, "143 Code Reviewer"),
-		"description": req.Description,
-	}
-	if strings.TrimSpace(req.TargetURL) != "" {
-		payload["target_url"] = req.TargetURL
-	}
-	body, err := json.Marshal(payload)
-	if err != nil {
-		return fmt.Errorf("marshal commit status payload: %w", err)
-	}
-	statusURL := fmt.Sprintf("%s/repos/%s/%s/statuses/%s", s.baseURL, url.PathEscape(owner), url.PathEscape(repo), url.PathEscape(req.SHA))
-	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, statusURL, bytes.NewReader(body))
-	if err != nil {
-		return fmt.Errorf("create commit status request: %w", err)
-	}
-	httpReq.Header.Set("Authorization", "Bearer "+token)
-	httpReq.Header.Set("Accept", "application/vnd.github+json")
-	httpReq.Header.Set("Content-Type", "application/json")
-	httpReq.Header.Set("X-GitHub-Api-Version", "2022-11-28")
-	resp, err := s.client.Do(httpReq)
-	if err != nil {
-		return fmt.Errorf("publish GitHub commit status: %w", err)
-	}
-	defer resp.Body.Close()
-	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return fmt.Errorf("publish GitHub commit status returned %d: %s", resp.StatusCode, readGitHubErrorBody(resp))
-	}
-	return nil
-}
-
 func (s *GitHubSubmitter) RemoveRequestedReviewers(ctx context.Context, req RequestedReviewersRequest) error {
 	if s == nil || s.tokens == nil {
 		return fmt.Errorf("github submitter is not configured")
@@ -945,15 +873,6 @@ func (d SubmitReviewDecision) validate() error {
 		return nil
 	default:
 		return fmt.Errorf("invalid submit review decision: %q", d)
-	}
-}
-
-func (s CommitStatusState) validate() error {
-	switch s {
-	case CommitStatusStateError, CommitStatusStateFailure, CommitStatusStatePending, CommitStatusStateSuccess:
-		return nil
-	default:
-		return fmt.Errorf("invalid commit status state: %q", s)
 	}
 }
 

--- a/internal/services/codereview/github_submitter_test.go
+++ b/internal/services/codereview/github_submitter_test.go
@@ -387,42 +387,6 @@ func TestGitHubSubmitter_ListReviewContextPaginatesGraphQLConnections(t *testing
 	require.Len(t, gotPayloads, 2, "ListReviewContext should stop after both GraphQL connections are exhausted")
 }
 
-func TestGitHubSubmitter_PublishCommitStatus(t *testing.T) {
-	t.Parallel()
-
-	var (
-		gotPath    string
-		gotPayload map[string]any
-	)
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		gotPath = r.URL.Path
-		require.NoError(t, json.NewDecoder(r.Body).Decode(&gotPayload), "request body should decode")
-		w.Header().Set("Content-Type", "application/json")
-		_, err := w.Write([]byte(`{"id":321}`))
-		require.NoError(t, err, "test response should write")
-	}))
-	defer server.Close()
-
-	submitter := NewGitHubSubmitter(&tokenStub{token: "ghs_token"}, WithGitHubSubmitterBaseURL(server.URL))
-
-	err := submitter.PublishCommitStatus(context.Background(), CommitStatusRequest{
-		InstallationID: 99,
-		Repository:     "acme/repo",
-		SHA:            "abc123",
-		State:          CommitStatusStatePending,
-		Context:        "143 Code Reviewer",
-		Description:    "Review is running",
-		TargetURL:      "https://143.dev/sessions/sess_123",
-	})
-
-	require.NoError(t, err, "PublishCommitStatus should post commit status")
-	require.Equal(t, "/repos/acme/repo/statuses/abc123", gotPath, "PublishCommitStatus should call the commit status endpoint")
-	require.Equal(t, "pending", gotPayload["state"], "PublishCommitStatus should send requested state")
-	require.Equal(t, "143 Code Reviewer", gotPayload["context"], "PublishCommitStatus should send status context")
-	require.Equal(t, "Review is running", gotPayload["description"], "PublishCommitStatus should send description")
-	require.Equal(t, "https://143.dev/sessions/sess_123", gotPayload["target_url"], "PublishCommitStatus should include target URL")
-}
-
 func TestGitHubSubmitter_RemoveRequestedReviewers(t *testing.T) {
 	t.Parallel()
 

--- a/internal/worker/code_review_handler.go
+++ b/internal/worker/code_review_handler.go
@@ -111,7 +111,6 @@ func newRunCodeReviewHandler(stores *Stores, services *Services, logger zerolog.
 		if cancelled, err := stopCodeReviewIfParentSessionCancelled(ctx, stores, services, logger, job, pr); cancelled || err != nil {
 			return err
 		}
-		publishCodeReviewStatus(ctx, stores, services, logger, job, pr, codereviewsvc.CommitStatusStatePending, "143 Code Reviewer is running")
 		health, err := loadStoredCodeReviewHealth(ctx, stores, job, pr)
 		if err != nil {
 			return fmt.Errorf("load code review health: %w", err)
@@ -132,7 +131,6 @@ func newRunCodeReviewHandler(stores *Stores, services *Services, logger zerolog.
 			if _, staleErr := stores.CodeReviews.MarkStale(ctx, job.OrgID, job.SessionID, "PR head changed after review started"); staleErr != nil {
 				return fmt.Errorf("mark code review stale: %w", staleErr)
 			}
-			publishCodeReviewStatus(ctx, stores, services, logger, job, pr, codereviewsvc.CommitStatusStateFailure, "143 Code Reviewer stopped because the PR head changed")
 			logger.Info().
 				Str("org_id", job.OrgID.String()).
 				Str("session_id", job.SessionID.String()).
@@ -204,7 +202,7 @@ func newRunCodeReviewHandler(stores *Stores, services *Services, logger zerolog.
 		decision, body := evaluateLiveCodeReviewOutcome(liveCodeReviewOutcomeInput{
 			Policy:                 policy.Config(),
 			Job:                    job,
-			SessionURL:             codeReviewStatusTargetURL(services.FrontendURL, job.SessionID),
+			SessionURL:             codeReviewSessionURL(services.FrontendURL, job.SessionID),
 			PullRequest:            pr,
 			Health:                 health,
 			AgentResults:           agentResults,
@@ -245,7 +243,6 @@ func newRunCodeReviewHandler(stores *Stores, services *Services, logger zerolog.
 		if submission.GitHubReviewID != nil {
 			event = event.Int64("github_review_id", *submission.GitHubReviewID)
 		}
-		publishCodeReviewStatus(ctx, stores, services, logger, job, pr, codereviewsvc.CommitStatusStateSuccess, codeReviewFinalStatusDescription(decision.Decision))
 		event.Str("decision", string(decision.Decision)).Msg("completed code review")
 		reconcileCodeReviewSessionSuccess(ctx, stores, logger, job)
 		return nil
@@ -272,7 +269,6 @@ func stopCodeReviewIfParentSessionCancelled(ctx context.Context, stores *Stores,
 			return false, fmt.Errorf("cancel code review after parent cancellation: %w", err)
 		}
 	}
-	publishCodeReviewStatus(ctx, stores, services, logger, job, pr, codereviewsvc.CommitStatusStateError, "143 Code Reviewer was cancelled")
 	removeCodeReviewRequestedReviewer(ctx, stores, services, logger, job, pr)
 	logger.Info().
 		Str("session_id", job.SessionID.String()).
@@ -285,7 +281,6 @@ func failCodeReviewWithoutReviewerOutput(ctx context.Context, stores *Stores, se
 	if _, err := stores.CodeReviews.FailReview(ctx, job.OrgID, job.SessionID, reason); err != nil {
 		return fmt.Errorf("fail code review without usable reviewer output: %w", err)
 	}
-	publishCodeReviewStatus(ctx, stores, services, logger, job, pr, codereviewsvc.CommitStatusStateFailure, "143 Code Reviewer failed: no reviewer completed")
 	removeCodeReviewRequestedReviewer(ctx, stores, services, logger, job, pr)
 	if err := reconcileCodeReviewSessionFailure(ctx, stores, job, reason); err != nil {
 		return err
@@ -1708,10 +1703,6 @@ type codeReviewSubmission struct {
 	GitHubReviewURL *string
 }
 
-type codeReviewStatusPublisher interface {
-	PublishCommitStatus(ctx context.Context, req codereviewsvc.CommitStatusRequest) error
-}
-
 type codeReviewRequestedReviewerRemover interface {
 	RemoveRequestedReviewers(ctx context.Context, req codereviewsvc.RequestedReviewersRequest) error
 }
@@ -1796,44 +1787,6 @@ type codeReviewContextLister interface {
 	ListReviewContext(ctx context.Context, req codereviewsvc.ReviewContextRequest) (codereviewsvc.ReviewContext, error)
 }
 
-func publishCodeReviewStatus(ctx context.Context, stores *Stores, services *Services, logger zerolog.Logger, job runCodeReviewPayload, pr models.PullRequest, state codereviewsvc.CommitStatusState, description string) {
-	if services == nil || services.CodeReviews == nil {
-		return
-	}
-	publisher, ok := services.CodeReviews.(codeReviewStatusPublisher)
-	if !ok {
-		return
-	}
-	if stores == nil || stores.Repositories == nil {
-		logger.Warn().Str("session_id", job.SessionID.String()).Msg("skipping code review status: repository store unavailable")
-		return
-	}
-	repo, err := stores.Repositories.GetByID(ctx, job.OrgID, job.RepositoryID)
-	if err != nil {
-		logger.Warn().Err(err).Str("session_id", job.SessionID.String()).Msg("failed to load repository for code review status")
-		return
-	}
-	if repo.InstallationID == 0 {
-		logger.Warn().Str("repository_id", repo.ID.String()).Str("session_id", job.SessionID.String()).Msg("skipping code review status: repository has no GitHub installation id")
-		return
-	}
-	repository := strings.TrimSpace(pr.GitHubRepo)
-	if repository == "" {
-		repository = strings.TrimSpace(repo.FullName)
-	}
-	if err := publisher.PublishCommitStatus(ctx, codereviewsvc.CommitStatusRequest{
-		InstallationID: repo.InstallationID,
-		Repository:     repository,
-		SHA:            job.HeadSHA,
-		State:          state,
-		Context:        "143 Code Reviewer",
-		Description:    description,
-		TargetURL:      codeReviewStatusTargetURL(services.FrontendURL, job.SessionID),
-	}); err != nil {
-		logger.Warn().Err(err).Str("session_id", job.SessionID.String()).Str("state", string(state)).Msg("failed to publish code review status")
-	}
-}
-
 func removeCodeReviewRequestedReviewer(ctx context.Context, stores *Stores, services *Services, logger zerolog.Logger, job runCodeReviewPayload, pr models.PullRequest) {
 	reviewer := strings.TrimSpace(job.RequestedReviewerLogin)
 	team := strings.TrimSpace(job.RequestedTeamSlug)
@@ -1880,19 +1833,12 @@ func removeCodeReviewRequestedReviewer(ctx context.Context, stores *Stores, serv
 	}
 }
 
-func codeReviewStatusTargetURL(frontendURL string, sessionID uuid.UUID) string {
+func codeReviewSessionURL(frontendURL string, sessionID uuid.UUID) string {
 	base := strings.TrimRight(strings.TrimSpace(frontendURL), "/")
 	if base == "" || sessionID == uuid.Nil {
 		return ""
 	}
 	return base + "/sessions/" + sessionID.String()
-}
-
-func codeReviewFinalStatusDescription(decision models.CodeReviewDecision) string {
-	if decision == models.CodeReviewDecisionApproved {
-		return "143 Code Reviewer approved this PR"
-	}
-	return "143 Code Reviewer completed without approval"
 }
 
 func loadCodeReviewChangedFiles(ctx context.Context, stores *Stores, services *Services, job runCodeReviewPayload, pr models.PullRequest) ([]codereviewsvc.PullRequestFile, bool, error) {
@@ -2392,10 +2338,9 @@ func codeReviewChecksPassing(policy models.CodeReviewPolicyConfig, health *model
 }
 
 // codeReviewExternalChecks drops 143's own non-CI status contexts before the
-// checks-passing gate is evaluated. The code reviewer publishes its own
-// "143 Code Reviewer" commit status (and the preview integration publishes
-// "preview/143"); both are pending by construction while the review runs, so
-// counting them would make the reviewer block its own approval.
+// checks-passing gate is evaluated. Historical "143 Code Reviewer" statuses
+// and current "preview/143" statuses are not CI signals and must not affect
+// the reviewer's approval decision.
 func codeReviewExternalChecks(checks []models.PullRequestCheckSummary) []models.PullRequestCheckSummary {
 	filtered := make([]models.PullRequestCheckSummary, 0, len(checks))
 	for _, check := range checks {

--- a/internal/worker/code_review_handler_test.go
+++ b/internal/worker/code_review_handler_test.go
@@ -930,7 +930,7 @@ func TestCodeReviewOrchestratorAgentModel(t *testing.T) {
 		"nil orchestrator model should fall back to the per-agent default")
 }
 
-func TestCodeReviewStatusTargetURL(t *testing.T) {
+func TestCodeReviewSessionURL(t *testing.T) {
 	t.Parallel()
 
 	sessionID := uuid.New()
@@ -940,7 +940,7 @@ func TestCodeReviewStatusTargetURL(t *testing.T) {
 		frontendURL string
 		expected    string
 	}{
-		{name: "empty frontend URL omits target", expected: ""},
+		{name: "empty frontend URL omits link", expected: ""},
 		{name: "trims trailing slash", frontendURL: "https://143.dev/", expected: "https://143.dev/sessions/" + sessionID.String()},
 		{name: "uses base URL", frontendURL: "https://app.143.dev", expected: "https://app.143.dev/sessions/" + sessionID.String()},
 	}
@@ -949,9 +949,9 @@ func TestCodeReviewStatusTargetURL(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			actual := codeReviewStatusTargetURL(tt.frontendURL, sessionID)
+			actual := codeReviewSessionURL(tt.frontendURL, sessionID)
 
-			require.Equal(t, tt.expected, actual, "codeReviewStatusTargetURL should build stable session links")
+			require.Equal(t, tt.expected, actual, "codeReviewSessionURL should build stable session links")
 		})
 	}
 }


### PR DESCRIPTION
## Summary

- stop the code review worker from publishing pending, success, failure, or error commit statuses
- remove the code-review-specific GitHub commit-status request types, publisher method, and test
- keep legacy `143 Code Reviewer` contexts excluded from PR-health evaluation while leaving preview statuses unchanged
- rename the remaining session-link helper and update the implemented design

## Why

The GitHub review and linked 143 session already communicate the reviewer outcome. The separate classic commit status adds no useful signal, and an unfinished reviewer run can be mistaken for a missing or failed CI requirement.

## Protection audit

No branch-protection migration is needed for this repository: both classic protection and the active repository ruleset require only `All Checks Pass`. An exact-match scan across the accessible active Assembled repositories and inherited/repository rulesets found no `143 Code Reviewer` requirement.

## Verification

- `go test ./internal/worker ./internal/services/codereview -count=1`
- `go vet ./internal/worker ./internal/services/codereview`
- `git diff --check`
