### PR TITLE
Refactor code review list to surface final review links

### DIFF
--- a/frontend/src/app/(dashboard)/code-reviews/page.test.tsx
+++ b/frontend/src/app/(dashboard)/code-reviews/page.test.tsx
@@ -126,6 +126,7 @@ const review: CodeReviewListItem = {
   github_repo: "acme/api",
   github_pr_number: 428,
   github_pr_url: "https://github.com/acme/api/pull/428",
+  github_review_url: "https://github.com/acme/api/pull/428#pullrequestreview-143428",
   pull_request_title: "Fix invoice rounding",
   pull_request_author: "anya",
 };
@@ -270,12 +271,26 @@ describe("CodeReviewsPage", () => {
     expect(screen.getAllByText("Acceptable")).toHaveLength(2);
     expect(screen.getAllByText("Automatically approved")).toHaveLength(2);
     expect(screen.getAllByText("Ran successfully")).toHaveLength(2);
+    const finalReviewLinks = screen.getAllByRole("link", { name: "#428 Fix invoice rounding" });
+    expect(finalReviewLinks).toHaveLength(2);
+    for (const link of finalReviewLinks) {
+      expect(link).toHaveAttribute("href", review.github_review_url);
+    }
+    expect(screen.queryByRole("link", { name: "Open final review" })).not.toBeInTheDocument();
     const filterToggle = screen.getByRole("button", { name: /Filter reviews/i });
     expect(filterToggle).toHaveAttribute("aria-expanded", "false");
     await user.click(filterToggle);
     expect(filterToggle).toHaveAttribute("aria-expanded", "true");
     expect(screen.getByRole("textbox", { name: "Search code reviews" })).toBeInTheDocument();
     expect(screen.getAllByRole("link", { name: "Open pull request" })).toHaveLength(2);
+    const reviewTable = screen.getByRole("table");
+    const reviewRow = within(reviewTable).getByRole("row", { name: /#428 Fix invoice rounding/i });
+    const reviewCells = within(reviewRow).getAllByRole("cell");
+    expect(within(reviewCells[2]).getByText("Acceptable").closest('[data-slot="status-label"]')).toBeNull();
+    expect(within(reviewCells[3]).getByText("Automatically approved").closest('[data-slot="status-label"]')).not.toBeNull();
+    expect(within(reviewCells[3]).getByRole("button", { name: "Evidence" })).toBeInTheDocument();
+    expect(within(reviewCells[4]).getByText("Ran successfully").closest('[data-slot="status-label"]')).toBeNull();
+    expect(within(reviewCells[6]).queryByRole("button", { name: "Evidence" })).not.toBeInTheDocument();
     await user.click(screen.getAllByRole("button", { name: /Evidence/i })[0]);
     const evidenceSheet = await screen.findByRole("dialog", { name: /Evidence for #428/i });
     expect(evidenceSheet).toBeInTheDocument();

--- a/frontend/src/app/(dashboard)/code-reviews/page.tsx
+++ b/frontend/src/app/(dashboard)/code-reviews/page.tsx
@@ -182,7 +182,45 @@ function reviewStatusTone(status: string): StatusTone {
   return "neutral";
 }
 
-function ReviewActions({
+function ReviewTitle({ review }: { review: CodeReviewListItem }) {
+  const title = `#${review.github_pr_number} ${review.pull_request_title}`;
+
+  if (!review.github_review_url) return title;
+
+  return (
+    <Link
+      href={review.github_review_url}
+      target="_blank"
+      rel="noreferrer"
+      title="Open final review"
+      className="underline-offset-4 hover:underline focus-visible:rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+    >
+      {title}
+    </Link>
+  );
+}
+
+function EvidenceButton({
+  selected,
+  onToggleEvidence,
+}: {
+  selected: boolean;
+  onToggleEvidence: () => void;
+}) {
+  return (
+    <Button
+      variant={selected ? "secondary" : "ghost"}
+      size="sm"
+      className="-ml-2 min-h-8 px-2 text-muted-foreground"
+      onClick={onToggleEvidence}
+    >
+      <FileSearch className="h-4 w-4" />
+      Evidence
+    </Button>
+  );
+}
+
+function ReviewOutcome({
   review,
   selected,
   onToggleEvidence,
@@ -192,17 +230,20 @@ function ReviewActions({
   onToggleEvidence: () => void;
 }) {
   return (
+    <div className="space-y-1">
+      <StatusLabel label={decisionLabel(review)} tone={reviewDecisionTone(review)} />
+      {decisionDetailLabel(review) ? (
+        <div className="text-xs text-muted-foreground">{decisionDetailLabel(review)}</div>
+      ) : null}
+      <EvidenceButton selected={selected} onToggleEvidence={onToggleEvidence} />
+    </div>
+  );
+}
+
+function ReviewActions({ review }: { review: CodeReviewListItem }) {
+  return (
     <TooltipProvider>
       <div className="grid w-full grid-cols-2 gap-2 md:flex md:w-auto md:flex-wrap md:justify-end">
-        <Button
-          variant={selected ? "secondary" : "ghost"}
-          size="sm"
-          className="min-h-11 justify-center md:min-h-0"
-          onClick={onToggleEvidence}
-        >
-          <FileSearch className="h-4 w-4" />
-          Evidence
-        </Button>
         <Button className="min-h-11 justify-center md:min-h-0" variant="ghost" size="sm" asChild>
           <Link href={`/sessions/${review.session_id}`}>
             <ExternalLink className="h-4 w-4 md:hidden" />
@@ -212,7 +253,7 @@ function ReviewActions({
         <Tooltip>
           <TooltipTrigger asChild>
             <Button
-              className={`min-h-11 justify-center md:size-7 md:min-h-0 ${review.github_review_url ? "" : "col-span-2 md:col-span-1"}`}
+              className="min-h-11 justify-center md:size-7 md:min-h-0"
               variant="ghost"
               size="sm"
               asChild
@@ -226,19 +267,6 @@ function ReviewActions({
           </TooltipTrigger>
           <TooltipContent className="hidden md:block">Open pull request</TooltipContent>
         </Tooltip>
-        {review.github_review_url ? (
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <Button className="min-h-11 justify-center md:size-7 md:min-h-0" variant="ghost" size="sm" asChild aria-label="Open final review">
-                <Link href={review.github_review_url} target="_blank" rel="noreferrer">
-                  <ClipboardCheck className="h-4 w-4" />
-                  <span className="md:sr-only">Final review</span>
-                </Link>
-              </Button>
-            </TooltipTrigger>
-            <TooltipContent className="hidden md:block">Open final review</TooltipContent>
-          </Tooltip>
-        ) : null}
       </div>
     </TooltipProvider>
   );
@@ -658,34 +686,16 @@ export default function CodeReviewsPage() {
                         <TableRow key={review.id}>
                           <TableCell className="min-w-[18rem]">
                             <div className="font-medium text-foreground">
-                              #{review.github_pr_number} {review.pull_request_title}
+                              <ReviewTitle review={review} />
                             </div>
                             <div className="mt-1 text-xs text-muted-foreground">
                               {review.pull_request_author || "Unknown author"} · {review.head_sha.slice(0, 7)}
                             </div>
                           </TableCell>
                           <TableCell>{review.repository_name || review.github_repo}</TableCell>
+                          <TableCell>{review.acceptable ? "Acceptable" : "Needs review"}</TableCell>
                           <TableCell>
-                            <StatusLabel label={review.acceptable ? "Acceptable" : "Needs review"} tone={review.acceptable ? "success" : "warning"} />
-                          </TableCell>
-                          <TableCell>
-                            <div className="space-y-1">
-                              <StatusLabel label={decisionLabel(review)} tone={reviewDecisionTone(review)} />
-                              {decisionDetailLabel(review) ? (
-                                <div className="text-xs text-muted-foreground">{decisionDetailLabel(review)}</div>
-                              ) : null}
-                            </div>
-                          </TableCell>
-                          <TableCell>
-                            <StatusLabel
-                              label={reviewStatusLabel(review)}
-                              tone={reviewStatusTone(review.stale ? "stale" : review.status)}
-                              active={!review.stale && (review.status === "running" || review.status === "queued")}
-                            />
-                          </TableCell>
-                          <TableCell>{formatDate(review.completed_at)}</TableCell>
-                          <TableCell>
-                            <ReviewActions
+                            <ReviewOutcome
                               review={review}
                               selected={selectedEvidenceSessionId === review.session_id}
                               onToggleEvidence={() =>
@@ -695,6 +705,11 @@ export default function CodeReviewsPage() {
                               }
                             />
                           </TableCell>
+                          <TableCell>{reviewStatusLabel(review)}</TableCell>
+                          <TableCell>{formatDate(review.completed_at)}</TableCell>
+                          <TableCell>
+                            <ReviewActions review={review} />
+                          </TableCell>
                         </TableRow>
                       ))}
                     </TableBody>
@@ -702,38 +717,29 @@ export default function CodeReviewsPage() {
                 </CardContent>
               </Card>
               <Card className="divide-y divide-border/70 md:hidden" aria-label="Code review activity">
-                {reviews.map((review) => {
-                  const effectiveStatus = review.stale ? "stale" : review.status;
-                  return (
-                    <ResourceRow
-                      key={review.id}
-                      title={(
-                        <span className="break-words text-sm">
-                          #{review.github_pr_number} {review.pull_request_title}
-                        </span>
-                      )}
-                      metadata={(
-                        <span>
-                          {review.repository_name || review.github_repo} · {review.pull_request_author || "Unknown author"} · {review.head_sha.slice(0, 7)}
-                        </span>
-                      )}
-                      status={(
-                        <StatusLabel
-                          label={reviewStatusLabel(review)}
-                          tone={reviewStatusTone(effectiveStatus)}
-                          active={!review.stale && (review.status === "running" || review.status === "queued")}
-                        />
-                      )}
-                      detail={(
-                        <div className="flex flex-wrap items-center gap-x-4 gap-y-2">
-                          <StatusLabel label={review.acceptable ? "Acceptable" : "Needs review"} tone={review.acceptable ? "success" : "warning"} />
-                          <StatusLabel label={decisionLabel(review)} tone={reviewDecisionTone(review)} />
-                          {decisionDetailLabel(review) ? <span>{decisionDetailLabel(review)}</span> : null}
+                {reviews.map((review) => (
+                  <ResourceRow
+                    key={review.id}
+                    title={(
+                      <span className="break-words text-sm">
+                        <ReviewTitle review={review} />
+                      </span>
+                    )}
+                    metadata={(
+                      <span>
+                        {review.repository_name || review.github_repo} · {review.pull_request_author || "Unknown author"} · {review.head_sha.slice(0, 7)}
+                      </span>
+                    )}
+                    status={(
+                      <span className="text-foreground">{reviewStatusLabel(review)}</span>
+                    )}
+                    detail={(
+                      <div className="space-y-2">
+                        <div className="flex flex-wrap items-center gap-x-4 gap-y-2 text-foreground">
+                          <span>{review.acceptable ? "Acceptable" : "Needs review"}</span>
                           <span>Completed {formatDate(review.completed_at)}</span>
                         </div>
-                      )}
-                      actions={(
-                        <ReviewActions
+                        <ReviewOutcome
                           review={review}
                           selected={selectedEvidenceSessionId === review.session_id}
                           onToggleEvidence={() =>
@@ -742,11 +748,14 @@ export default function CodeReviewsPage() {
                             )
                           }
                         />
-                      )}
-                      className="[&_[data-slot=resource-row-actions]]:ml-0"
-                    />
-                  );
-                })}
+                      </div>
+                    )}
+                    actions={(
+                      <ReviewActions review={review} />
+                    )}
+                    className="[&_[data-slot=resource-row-actions]]:ml-0"
+                  />
+                ))}
               </Card>
               <CodeReviewEvidenceSheet
                 review={selectedEvidenceReview}


### PR DESCRIPTION
## Summary
- Promote the review title to a clickable link when a final GitHub review URL is available.
- Move the decision/evidence content into a dedicated review outcome block for clearer table and mobile layouts.
- Simplify the action column by keeping session and PR links there while removing the final review action button.
- Update page tests to cover the new link behavior and the revised cell structure.

## Testing
- Updated and expanded frontend page tests for the code reviews view.
- Not run (not requested).