### PR TITLE
Align buttons and inputs to consistent sizes across UI

### DIFF
--- a/frontend/src/app/(dashboard)/sessions/session-sidebar.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/session-sidebar.test.tsx
@@ -182,6 +182,12 @@ describe('SessionSidebar', () => {
     expect(capturedUserId).toBe('user-1');
   });
 
+  it('keeps the desktop search field aligned with the people filter', () => {
+    renderWithProviders(<SessionSidebar />);
+
+    expect(screen.getByPlaceholderText('Search sessions...')).toHaveClass('h-8', 'sm:h-8');
+  });
+
   it('does not fetch sessions until the Mine scope can resolve the current user', async () => {
     mockAuthState.isAuthenticated = false;
     mockAuthState.user = null;

--- a/frontend/src/app/(dashboard)/sessions/session-sidebar.tsx
+++ b/frontend/src/app/(dashboard)/sessions/session-sidebar.tsx
@@ -1081,7 +1081,7 @@ export function SessionSidebar() {
                   e.currentTarget.blur();
                 }
               }}
-              className="h-8 pl-8 pr-8 text-xs"
+              className="h-8 pl-8 pr-8 text-xs sm:h-8"
             />
             <Kbd className="absolute right-2 top-1/2 hidden -translate-y-1/2 md:inline-flex">/</Kbd>
           </div>

--- a/frontend/src/components/pr-health-banner.test.tsx
+++ b/frontend/src/components/pr-health-banner.test.tsx
@@ -358,9 +358,9 @@ describe("PRHealthBanner", () => {
     const actionGroup = moreActions.closest("[data-slot='button-group']");
     expect(actionGroup).toHaveAttribute("data-size", "xs");
     expect(mergeAction).toHaveAttribute("data-size", "xs");
-    expect(mergeAction).toHaveClass("h-10", "sm:h-6");
+    expect(mergeAction).toHaveClass("h-10", "sm:h-6", "shadow-none");
     expect(moreActions).toHaveAttribute("data-size", "icon-xs");
-    expect(moreActions).toHaveClass("size-10", "sm:size-6", "rounded-l-none");
+    expect(moreActions).toHaveClass("size-10", "sm:size-6", "rounded-l-none", "shadow-none");
     expect(moreActions).not.toHaveClass("h-7", "w-7");
 
     await userEvent.setup().click(moreActions);

--- a/frontend/src/components/pr-health-banner.tsx
+++ b/frontend/src/components/pr-health-banner.tsx
@@ -272,7 +272,7 @@ export function PRHealthBanner({
                         <Button
                           size="xs"
                           variant="default"
-                          className={cn(canShowMergeWhenReady && "rounded-r-none border-r border-primary-foreground/20")}
+                          className={cn("shadow-none", canShowMergeWhenReady && "rounded-r-none border-r border-primary-foreground/20")}
                           disabled={mergeAction.disabled}
                           title={mergeAction.disabledReason ?? "Merge PR (p m)"}
                           onClick={onMerge}
@@ -291,7 +291,7 @@ export function PRHealthBanner({
                             <Button
                               size="icon-xs"
                               variant="default"
-                              className="rounded-l-none"
+                              className="rounded-l-none shadow-none"
                               disabled={mergeWhenReadyAction.disabled}
                               title={mergeWhenReadyAction.disabledReason ?? "More merge actions"}
                               aria-label="More merge actions"


### PR DESCRIPTION
## Summary

Users were seeing inconsistent visual sizing in key controls: the SessionSidebar desktop search input didn’t match the People filter height, and the PRHealthBanner merge split-button looked taller due to an extra shadow style. This PR standardizes the relevant Tailwind sizing/visual styles and adds regression tests to prevent reintroducing misalignment.

## Changes

- Updated `SessionSidebar` desktop search field to explicitly use `sm:h-8` so it aligns with the People selector height.
- Removed unintended visual height perception in `PRHealthBanner` by forcing `shadow-none` on the merge split button and the “more actions” icon button.
- Added a regression assertion in `SessionSidebar` tests to verify the search input height classes stay aligned.

## Validation

- Ran 102 focused tests (including the new alignment test)
- ESLint
- `git diff --check` (clean)

Note: rendered preview verification wasn’t available because the preview service returned a 404.

[143.dev](https://143.dev) | [session 43e671f0](https://143.dev/sessions/43e671f0-807f-4976-822d-b556464d85b2)

<!-- 143 readiness -->
**143 readiness:** not available for this revision.

Preview: https://143.dev/previews/github/assembledhq/143/pull/1865?launch=1