### PR TITLE
Investigate and fix silent code review reviewer handling

### DIFF
--- a/internal/api/handlers/webhooks_test.go
+++ b/internal/api/handlers/webhooks_test.go
@@ -819,12 +819,12 @@ func (s *codeReviewWebhookMetadataStore) CreateSessionMetadata(_ context.Context
 	return nil
 }
 
-func (s *codeReviewWebhookMetadataStore) GetByOutputKey(context.Context, uuid.UUID, string) (models.CodeReviewSessionMetadata, error) {
+func (s *codeReviewWebhookMetadataStore) GetLatestByPullRequestHead(context.Context, uuid.UUID, uuid.UUID, string, uuid.UUID) (models.CodeReviewSessionMetadata, error) {
 	return models.CodeReviewSessionMetadata{}, pgx.ErrNoRows
 }
 
-func (s *codeReviewWebhookMetadataStore) GetRunningByPullRequestHead(context.Context, uuid.UUID, uuid.UUID, string, uuid.UUID) (models.CodeReviewSessionMetadata, error) {
-	return models.CodeReviewSessionMetadata{}, pgx.ErrNoRows
+func (s *codeReviewWebhookMetadataStore) FailReview(context.Context, uuid.UUID, uuid.UUID, string) (models.CodeReviewSessionMetadata, error) {
+	return models.CodeReviewSessionMetadata{}, nil
 }
 
 func (s *codeReviewWebhookMetadataStore) MarkStaleForPullRequestExceptHead(context.Context, uuid.UUID, uuid.UUID, string, *uuid.UUID) (int64, error) {
@@ -838,15 +838,27 @@ func (s *codeReviewWebhookSessionStore) Create(_ context.Context, session *model
 	return nil
 }
 
+func (s *codeReviewWebhookSessionStore) UpdateStatus(context.Context, uuid.UUID, uuid.UUID, models.SessionStatus) error {
+	return nil
+}
+
+func (s *codeReviewWebhookSessionStore) UpdateFailure(context.Context, uuid.UUID, uuid.UUID, string, string, []string, bool) error {
+	return nil
+}
+
 type codeReviewWebhookJobStore struct {
 	jobID   uuid.UUID
 	payload codereviewsvc.RunCodeReviewJobPayload
 }
 
-func (s *codeReviewWebhookJobStore) Enqueue(_ context.Context, _ uuid.UUID, _, _ string, payload any, _ int, _ *string) (uuid.UUID, error) {
-	typed, ok := payload.(codereviewsvc.RunCodeReviewJobPayload)
+func (s *codeReviewWebhookJobStore) EnqueueWithOpts(_ context.Context, _ uuid.UUID, opts db.EnqueueOpts) (uuid.UUID, error) {
+	typed, ok := opts.Payload.(codereviewsvc.RunCodeReviewJobPayload)
 	if ok {
 		s.payload = typed
 	}
 	return s.jobID, nil
+}
+
+func (s *codeReviewWebhookJobStore) HasActiveByDedupeKey(context.Context, uuid.UUID, string, string) (bool, error) {
+	return true, nil
 }

--- a/internal/db/code_reviews.go
+++ b/internal/db/code_reviews.go
@@ -549,6 +549,27 @@ func (s *CodeReviewStore) GetRunningByPullRequestHead(ctx context.Context, orgID
 	return collectOneCodeReviewMetadata(rows)
 }
 
+func (s *CodeReviewStore) GetLatestByPullRequestHead(ctx context.Context, orgID, pullRequestID uuid.UUID, headSHA string, policyID uuid.UUID) (models.CodeReviewSessionMetadata, error) {
+	rows, err := s.db.Query(ctx, `
+		SELECT `+codeReviewMetadataColumns+`
+		FROM code_review_session_metadata
+		WHERE org_id = @org_id
+		  AND pull_request_id = @pull_request_id
+		  AND head_sha = @head_sha
+		  AND policy_id = @policy_id
+		ORDER BY created_at DESC, id DESC
+		LIMIT 1`, pgx.NamedArgs{
+		"org_id":          orgID,
+		"pull_request_id": pullRequestID,
+		"head_sha":        headSHA,
+		"policy_id":       policyID,
+	})
+	if err != nil {
+		return models.CodeReviewSessionMetadata{}, fmt.Errorf("query latest code review: %w", err)
+	}
+	return collectOneCodeReviewMetadata(rows)
+}
+
 func (s *CodeReviewStore) MarkRunning(ctx context.Context, orgID, sessionID uuid.UUID) (models.CodeReviewSessionMetadata, error) {
 	rows, err := s.db.Query(ctx, `
 		UPDATE code_review_session_metadata
@@ -720,6 +741,7 @@ func (s *CodeReviewStore) FailReview(ctx context.Context, orgID, sessionID uuid.
 		    completed_at = now()
 		WHERE org_id = @org_id
 		  AND session_id = @session_id
+		  AND status IN ('queued', 'running')
 		RETURNING `+codeReviewMetadataColumns, pgx.NamedArgs{
 		"org_id":         orgID,
 		"session_id":     sessionID,

--- a/internal/db/code_reviews_test.go
+++ b/internal/db/code_reviews_test.go
@@ -499,6 +499,35 @@ func TestCodeReviewStore_GetByOutputKeyFiltersByOrg(t *testing.T) {
 	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
 }
 
+func TestCodeReviewStore_GetLatestByPullRequestHeadFiltersByOrgAndPolicy(t *testing.T) {
+	t.Parallel()
+
+	orgID := uuid.New()
+	sessionID := uuid.New()
+	repoID := uuid.New()
+	prID := uuid.New()
+	policyID := uuid.New()
+	metadataID := uuid.New()
+	now := time.Date(2026, 7, 16, 22, 55, 0, 0, time.UTC)
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "pgxmock should initialize")
+	defer mock.Close()
+
+	mock.ExpectQuery("pull_request_id = @pull_request_id[\\s\\S]+head_sha = @head_sha[\\s\\S]+policy_id = @policy_id[\\s\\S]+ORDER BY created_at DESC").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(pgxmock.NewRows([]string{
+			"id", "org_id", "session_id", "repository_id", "pull_request_id", "policy_id",
+			"base_sha", "head_sha", "from_fork", "trigger_source", "status", "decision", "acceptable", "stale",
+			"superseded_by_session_id", "review_output_key", "prompt_artifact_key", "github_review_id", "github_review_url", "final_review_body", "failure_reason", "completed_at", "created_at",
+		}).AddRow(metadataID, orgID, sessionID, repoID, prID, policyID, "base", "head", false, models.CodeReviewTriggerSourceTeamReviewer, models.CodeReviewSessionStatusFailed, nil, nil, false, nil, "output", nil, nil, nil, nil, nil, &now, now))
+
+	metadata, err := NewCodeReviewStore(mock).GetLatestByPullRequestHead(context.Background(), orgID, prID, "head", policyID)
+	require.NoError(t, err, "latest review lookup should succeed")
+	require.Equal(t, metadataID, metadata.ID, "latest review lookup should return the newest matching attempt")
+	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
+}
+
 func TestCodeReviewStore_MarkStaleForPullRequestExceptHead(t *testing.T) {
 	t.Parallel()
 

--- a/internal/db/job_store_test.go
+++ b/internal/db/job_store_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/alicebob/miniredis/v2"
 	"github.com/assembledhq/143/internal/cache"
+	"github.com/assembledhq/143/internal/models"
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
 	"github.com/pashagolub/pgxmock/v4"
@@ -298,6 +299,52 @@ func TestJobStore_EnqueueWithOpts_PinsTargetNode(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, generatedID, id, "EnqueueWithOpts should return the generated job id when the pin lands cleanly")
 	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestJobStore_EnqueueWithOpts_SetsCustomMaxAttempts(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "should create mock pool")
+	defer mock.Close()
+
+	store := NewJobStore(mock)
+	orgID := uuid.New()
+	generatedID := uuid.New()
+
+	mock.ExpectQuery("INSERT INTO jobs[\\s\\S]+max_attempts").
+		WithArgs(orgID, "agent", models.JobTypeRunCodeReview, pgxmock.AnyArg(), 5, jobDedupeKeyPtr("review"), 8).
+		WillReturnRows(pgxmock.NewRows([]string{"id"}).AddRow(generatedID))
+
+	id, err := store.EnqueueWithOpts(context.Background(), orgID, EnqueueOpts{
+		Queue:       "agent",
+		JobType:     models.JobTypeRunCodeReview,
+		Payload:     map[string]string{"session_id": "abc"},
+		Priority:    5,
+		DedupeKey:   jobDedupeKeyPtr("review"),
+		MaxAttempts: 8,
+	})
+	require.NoError(t, err, "custom retry budget enqueue should succeed")
+	require.Equal(t, generatedID, id, "custom retry budget enqueue should return the job id")
+	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
+}
+
+func TestJobStore_HasActiveByDedupeKeyFiltersByOrg(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "should create mock pool")
+	defer mock.Close()
+
+	orgID := uuid.New()
+	mock.ExpectQuery("SELECT EXISTS[\\s\\S]+org_id[\\s\\S]+dedupe_key[\\s\\S]+status IN").
+		WithArgs(orgID, "agent", "code_review:key").
+		WillReturnRows(pgxmock.NewRows([]string{"exists"}).AddRow(true))
+
+	active, err := NewJobStore(mock).HasActiveByDedupeKey(context.Background(), orgID, "agent", "code_review:key")
+	require.NoError(t, err, "active dedupe lookup should succeed")
+	require.True(t, active, "active dedupe lookup should return the stored state")
+	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
 }
 
 func TestJobStore_RetryWithoutConsumingAttemptWithLeaseAndTarget_PinsRetry(t *testing.T) {

--- a/internal/db/jobs.go
+++ b/internal/db/jobs.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/assembledhq/143/internal/cache"
@@ -169,6 +170,10 @@ type EnqueueOpts struct {
 	Payload   any
 	Priority  int
 	DedupeKey *string
+	// MaxAttempts overrides the jobs table default when positive. Zero keeps
+	// the schema default so existing enqueue call sites retain their current
+	// retry budget.
+	MaxAttempts int
 
 	// TargetNodeID, when set, restricts the job to be claimed by this
 	// specific worker node. Used for sandbox-bound jobs (continue_session,
@@ -205,6 +210,30 @@ func (s *JobStore) Enqueue(ctx context.Context, orgID uuid.UUID, queue, jobType 
 		Priority:  priority,
 		DedupeKey: dedupeKey,
 	})
+}
+
+// HasActiveByDedupeKey reports whether a pending or running job currently
+// owns a dedupe key. Terminal jobs intentionally do not count, matching the
+// partial unique index used by EnqueueWithOpts.
+func (s *JobStore) HasActiveByDedupeKey(ctx context.Context, orgID uuid.UUID, queue, dedupeKey string) (bool, error) {
+	var active bool
+	err := s.db.QueryRow(ctx, `
+		SELECT EXISTS (
+			SELECT 1
+			FROM jobs
+			WHERE org_id = @org_id
+			  AND queue = @queue
+			  AND dedupe_key = @dedupe_key
+			  AND status IN ('pending', 'running')
+		)`, pgx.NamedArgs{
+		"org_id":     orgID,
+		"queue":      queue,
+		"dedupe_key": dedupeKey,
+	}).Scan(&active)
+	if err != nil {
+		return false, fmt.Errorf("query active job by dedupe key: %w", err)
+	}
+	return active, nil
 }
 
 // QueueChangesetPRCreation atomically reserves a changeset's PR slot and
@@ -558,6 +587,9 @@ type jobQuerier interface {
 }
 
 func enqueueOn(ctx context.Context, q jobQuerier, orgID uuid.UUID, opts EnqueueOpts) (uuid.UUID, error) {
+	if opts.MaxAttempts < 0 {
+		return uuid.Nil, fmt.Errorf("max attempts must not be negative")
+	}
 	payloadJSON, err := json.Marshal(opts.Payload)
 	if err != nil {
 		return uuid.Nil, err
@@ -565,27 +597,30 @@ func enqueueOn(ctx context.Context, q jobQuerier, orgID uuid.UUID, opts EnqueueO
 
 	var id uuid.UUID
 	args := pgx.NamedArgs{
-		"org_id":         orgID,
-		"queue":          opts.Queue,
-		"job_type":       opts.JobType,
-		"payload":        payloadJSON,
-		"priority":       opts.Priority,
-		"dedupe_key":     opts.DedupeKey,
-		"target_node_id": opts.TargetNodeID,
+		"org_id":     orgID,
+		"queue":      opts.Queue,
+		"job_type":   opts.JobType,
+		"payload":    payloadJSON,
+		"priority":   opts.Priority,
+		"dedupe_key": opts.DedupeKey,
 	}
-	query := `
-		INSERT INTO jobs (org_id, queue, job_type, payload, priority, dedupe_key, target_node_id)
-		VALUES (@org_id, @queue, @job_type, @payload, @priority, @dedupe_key, @target_node_id)
+	columns := []string{"queue", "job_type", "payload", "priority", "dedupe_key"}
+	values := []string{"@queue", "@job_type", "@payload", "@priority", "@dedupe_key"}
+	if opts.TargetNodeID != nil {
+		columns = append(columns, "target_node_id")
+		values = append(values, "@target_node_id")
+		args["target_node_id"] = opts.TargetNodeID
+	}
+	if opts.MaxAttempts > 0 {
+		columns = append(columns, "max_attempts")
+		values = append(values, "@max_attempts")
+		args["max_attempts"] = opts.MaxAttempts
+	}
+	query := fmt.Sprintf(`
+		INSERT INTO jobs (org_id, %s)
+		VALUES (@org_id, %s)
 		ON CONFLICT DO NOTHING
-		RETURNING id`
-	if opts.TargetNodeID == nil {
-		query = `
-			INSERT INTO jobs (org_id, queue, job_type, payload, priority, dedupe_key)
-			VALUES (@org_id, @queue, @job_type, @payload, @priority, @dedupe_key)
-			ON CONFLICT DO NOTHING
-			RETURNING id`
-		delete(args, "target_node_id")
-	}
+		RETURNING id`, strings.Join(columns, ", "), strings.Join(values, ", "))
 
 	err = q.QueryRow(ctx, query, args).Scan(&id)
 	// ON CONFLICT DO NOTHING returns no row when a pending/running job with the

--- a/internal/services/codereview/service.go
+++ b/internal/services/codereview/service.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"reflect"
 	"strings"
+	"time"
 
 	"github.com/assembledhq/143/internal/db"
 	"github.com/assembledhq/143/internal/models"
@@ -22,18 +23,26 @@ type PolicyStore interface {
 
 type MetadataStore interface {
 	CreateSessionMetadata(ctx context.Context, metadata *models.CodeReviewSessionMetadata) error
-	GetByOutputKey(ctx context.Context, orgID uuid.UUID, outputKey string) (models.CodeReviewSessionMetadata, error)
-	GetRunningByPullRequestHead(ctx context.Context, orgID, pullRequestID uuid.UUID, headSHA string, policyID uuid.UUID) (models.CodeReviewSessionMetadata, error)
+	GetLatestByPullRequestHead(ctx context.Context, orgID, pullRequestID uuid.UUID, headSHA string, policyID uuid.UUID) (models.CodeReviewSessionMetadata, error)
+	FailReview(ctx context.Context, orgID, sessionID uuid.UUID, reason string) (models.CodeReviewSessionMetadata, error)
 	MarkStaleForPullRequestExceptHead(ctx context.Context, orgID, pullRequestID uuid.UUID, currentHeadSHA string, supersededBySessionID *uuid.UUID) (int64, error)
 }
 
 type SessionStore interface {
 	Create(ctx context.Context, session *models.Session) error
+	UpdateStatus(ctx context.Context, orgID, sessionID uuid.UUID, status models.SessionStatus) error
+	UpdateFailure(ctx context.Context, orgID, sessionID uuid.UUID, explanation, category string, nextSteps []string, retryAdvised bool) error
 }
 
 type JobStore interface {
-	Enqueue(ctx context.Context, orgID uuid.UUID, queue, jobType string, payload any, priority int, dedupeKey *string) (uuid.UUID, error)
+	EnqueueWithOpts(ctx context.Context, orgID uuid.UUID, opts db.EnqueueOpts) (uuid.UUID, error)
+	HasActiveByDedupeKey(ctx context.Context, orgID uuid.UUID, queue, dedupeKey string) (bool, error)
 }
+
+const (
+	codeReviewJobMaxAttempts        = 8
+	codeReviewJobEnqueueGracePeriod = time.Minute
+)
 
 type Service struct {
 	policies PolicyStore
@@ -146,22 +155,60 @@ func (s *Service) HandleReviewRequested(ctx context.Context, input ReviewRequest
 		}
 		policy = &record
 	}
-	if existing, err := s.metadata.GetRunningByPullRequestHead(ctx, input.OrgID, input.PullRequestID, input.HeadSHA, policy.ID); err == nil {
-		if _, staleErr := s.metadata.MarkStaleForPullRequestExceptHead(ctx, input.OrgID, input.PullRequestID, input.HeadSHA, &existing.SessionID); staleErr != nil {
-			return ReviewRequestedResult{}, staleErr
-		}
-		return ReviewRequestedResult{Processed: true, Reused: true, SessionID: existing.SessionID, MetadataID: existing.ID, TriggerSource: source}, nil
-	} else if !errors.Is(err, pgx.ErrNoRows) {
-		return ReviewRequestedResult{}, fmt.Errorf("lookup running code review: %w", err)
-	}
 	outputKey := StableOutputKey(input.PullRequestID, input.HeadSHA, policy.ID, policy.Version)
-	if existing, err := s.metadata.GetByOutputKey(ctx, input.OrgID, outputKey); err == nil {
-		if _, staleErr := s.metadata.MarkStaleForPullRequestExceptHead(ctx, input.OrgID, input.PullRequestID, input.HeadSHA, &existing.SessionID); staleErr != nil {
-			return ReviewRequestedResult{}, staleErr
+	latest, err := s.metadata.GetLatestByPullRequestHead(ctx, input.OrgID, input.PullRequestID, input.HeadSHA, policy.ID)
+	if err == nil {
+	resolveLatest:
+		for {
+			switch latest.Status {
+			case models.CodeReviewSessionStatusCompleted:
+				return reusedReviewRequestedResult(latest, source), nil
+			case models.CodeReviewSessionStatusQueued, models.CodeReviewSessionStatusRunning:
+				activeOutputKey := strings.TrimSpace(latest.ReviewOutputKey)
+				if activeOutputKey == "" {
+					activeOutputKey = outputKey
+				}
+				active, activeErr := s.jobs.HasActiveByDedupeKey(ctx, input.OrgID, "agent", "code_review:"+activeOutputKey)
+				if activeErr != nil {
+					return ReviewRequestedResult{}, fmt.Errorf("lookup active code review job: %w", activeErr)
+				}
+				if active {
+					return reusedReviewRequestedResult(latest, source), nil
+				}
+				if !latest.CreatedAt.IsZero() && time.Since(latest.CreatedAt) < codeReviewJobEnqueueGracePeriod {
+					return reusedReviewRequestedResult(latest, source), nil
+				}
+
+				const reason = "code review job is no longer active; replaced by a new reviewer request"
+				failed, failErr := s.metadata.FailReview(ctx, input.OrgID, latest.SessionID, reason)
+				if errors.Is(failErr, pgx.ErrNoRows) {
+					// Another request changed the latest attempt after our lookup.
+					// Re-run the complete state check so a newly queued winner gets
+					// the active-job and enqueue-grace protections above.
+					latest, failErr = s.metadata.GetLatestByPullRequestHead(ctx, input.OrgID, input.PullRequestID, input.HeadSHA, policy.ID)
+					if failErr != nil {
+						return ReviewRequestedResult{}, fmt.Errorf("reload code review after concurrent takeover: %w", failErr)
+					}
+					continue
+				}
+				if failErr != nil {
+					return ReviewRequestedResult{}, fmt.Errorf("fail stranded code review: %w", failErr)
+				}
+				s.reconcileStrandedSession(ctx, input.OrgID, failed.SessionID, reason)
+				latest = failed
+				break resolveLatest
+			case models.CodeReviewSessionStatusFailed, models.CodeReviewSessionStatusStale, models.CodeReviewSessionStatusCancelled:
+				// A reviewer rerequest is an explicit request for another attempt.
+				// Derive the next key from the latest terminal row so concurrent
+				// rerequests collapse onto the same replacement attempt.
+				break resolveLatest
+			default:
+				return ReviewRequestedResult{}, fmt.Errorf("unsupported existing code review status %q", latest.Status)
+			}
 		}
-		return ReviewRequestedResult{Processed: true, Reused: true, SessionID: existing.SessionID, MetadataID: existing.ID, TriggerSource: source}, nil
+		outputKey = retryOutputKey(outputKey, latest.ID)
 	} else if !errors.Is(err, pgx.ErrNoRows) {
-		return ReviewRequestedResult{}, fmt.Errorf("lookup code review by output key: %w", err)
+		return ReviewRequestedResult{}, fmt.Errorf("lookup latest code review: %w", err)
 	}
 
 	title := fmt.Sprintf("Code review for %s#%d", input.GitHubRepo, input.GitHubPRNumber)
@@ -244,7 +291,14 @@ func (s *Service) HandleReviewRequested(ctx context.Context, input ReviewRequest
 		RequestedTeamSlug:      input.RequestedTeam,
 	}
 	dedupeKey := "code_review:" + outputKey
-	jobID, err := s.jobs.Enqueue(ctx, input.OrgID, "agent", models.JobTypeRunCodeReview, payload, 5, &dedupeKey)
+	jobID, err := s.jobs.EnqueueWithOpts(ctx, input.OrgID, db.EnqueueOpts{
+		Queue:       "agent",
+		JobType:     models.JobTypeRunCodeReview,
+		Payload:     payload,
+		Priority:    5,
+		DedupeKey:   &dedupeKey,
+		MaxAttempts: codeReviewJobMaxAttempts,
+	})
 	if err != nil {
 		return ReviewRequestedResult{}, fmt.Errorf("enqueue code review job: %w", err)
 	}
@@ -257,8 +311,37 @@ func (s *Service) HandleReviewRequested(ctx context.Context, input ReviewRequest
 	}, nil
 }
 
+func (s *Service) reconcileStrandedSession(ctx context.Context, orgID, sessionID uuid.UUID, reason string) {
+	if err := s.sessions.UpdateStatus(ctx, orgID, sessionID, models.SessionStatusFailed); err != nil {
+		s.logger.Warn().Err(err).
+			Str("session_id", sessionID.String()).
+			Msg("failed to mark stranded code review session failed")
+		return
+	}
+	if err := s.sessions.UpdateFailure(ctx, orgID, sessionID, reason, "code_review_job_failed",
+		[]string{"Request the code reviewer again to start a fresh attempt."}, true); err != nil {
+		s.logger.Warn().Err(err).
+			Str("session_id", sessionID.String()).
+			Msg("failed to record stranded code review session failure")
+	}
+}
+
 func StableOutputKey(pullRequestID uuid.UUID, headSHA string, policyID uuid.UUID, policyVersion int) string {
 	return fmt.Sprintf("pr:%s:head:%s:policy:%s:v%d", pullRequestID, headSHA, policyID, policyVersion)
+}
+
+func retryOutputKey(base string, previousAttemptID uuid.UUID) string {
+	return fmt.Sprintf("%s:retry:%s", base, previousAttemptID)
+}
+
+func reusedReviewRequestedResult(metadata models.CodeReviewSessionMetadata, source models.CodeReviewTriggerSource) ReviewRequestedResult {
+	return ReviewRequestedResult{
+		Processed:     true,
+		Reused:        true,
+		SessionID:     metadata.SessionID,
+		MetadataID:    metadata.ID,
+		TriggerSource: source,
+	}
 }
 
 func (s *Service) matchRequestedReviewer(ctx context.Context, input ReviewRequestedInput) (models.CodeReviewTriggerSource, bool, error) {

--- a/internal/services/codereview/service_test.go
+++ b/internal/services/codereview/service_test.go
@@ -3,8 +3,8 @@ package codereview
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"testing"
+	"time"
 
 	"github.com/assembledhq/143/internal/db"
 	"github.com/assembledhq/143/internal/models"
@@ -18,10 +18,11 @@ func TestService_HandleReviewRequested(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name     string
-		input    ReviewRequestedInput
-		setup    func(*policyStub, *metadataStub, *triggerStub)
-		expected func(t *testing.T, result ReviewRequestedResult, policies *policyStub, metadata *metadataStub, sessions *sessionStub, jobs *jobStub)
+		name      string
+		input     ReviewRequestedInput
+		activeJob *bool
+		setup     func(*policyStub, *metadataStub, *triggerStub)
+		expected  func(t *testing.T, result ReviewRequestedResult, policies *policyStub, metadata *metadataStub, sessions *sessionStub, jobs *jobStub)
 	}{
 		{
 			name: "ignores unrelated reviewer",
@@ -52,6 +53,7 @@ func TestService_HandleReviewRequested(t *testing.T) {
 				require.True(t, metadata.created.FromFork, "service should persist fork source evidence on review metadata")
 				require.Equal(t, 1, jobs.enqueueCalls, "service should enqueue the code review worker job")
 				require.Equal(t, models.JobTypeRunCodeReview, jobs.jobType, "service should use the code review job type")
+				require.Equal(t, codeReviewJobMaxAttempts, jobs.opts.MaxAttempts, "code review jobs should get the extended retry budget")
 				require.NotEmpty(t, jobs.dedupeKey, "service should dedupe by stable output key")
 				require.True(t, jobs.payload.FromFork, "service should carry fork source evidence into worker payload")
 				require.Equal(t, "anya", jobs.payload.PullRequestAuthor, "service should carry GitHub author login into worker payload")
@@ -105,12 +107,17 @@ func TestService_HandleReviewRequested(t *testing.T) {
 			name:  "reuses running review for same head and policy",
 			input: newReviewRequestedInput(nil),
 			setup: func(_ *policyStub, m *metadataStub, _ *triggerStub) {
-				m.running = models.CodeReviewSessionMetadata{ID: uuid.New(), SessionID: uuid.New()}
+				m.latest = models.CodeReviewSessionMetadata{
+					ID:              uuid.New(),
+					SessionID:       uuid.New(),
+					Status:          models.CodeReviewSessionStatusRunning,
+					ReviewOutputKey: "running-output-key",
+				}
 			},
 			expected: func(t *testing.T, result ReviewRequestedResult, policies *policyStub, metadata *metadataStub, sessions *sessionStub, jobs *jobStub) {
 				require.True(t, result.Processed, "matching duplicate request should be processed")
 				require.True(t, result.Reused, "duplicate request for same head should reuse running review")
-				require.Equal(t, metadata.running.SessionID, result.SessionID, "result should point to running session")
+				require.Equal(t, metadata.latest.SessionID, result.SessionID, "result should point to running session")
 				require.Equal(t, 0, sessions.createCalls, "duplicate request should not create another session")
 				require.Equal(t, 0, jobs.enqueueCalls, "duplicate request should not enqueue another job")
 			},
@@ -119,15 +126,108 @@ func TestService_HandleReviewRequested(t *testing.T) {
 			name:  "reuses terminal review for same output key",
 			input: newReviewRequestedInput(nil),
 			setup: func(_ *policyStub, m *metadataStub, _ *triggerStub) {
-				m.byOutputKey = models.CodeReviewSessionMetadata{ID: uuid.New(), SessionID: uuid.New(), Status: models.CodeReviewSessionStatusCompleted}
+				m.latest = models.CodeReviewSessionMetadata{ID: uuid.New(), SessionID: uuid.New(), Status: models.CodeReviewSessionStatusCompleted}
 			},
 			expected: func(t *testing.T, result ReviewRequestedResult, policies *policyStub, metadata *metadataStub, sessions *sessionStub, jobs *jobStub) {
 				require.True(t, result.Processed, "matching duplicate terminal request should be processed")
 				require.True(t, result.Reused, "duplicate terminal request should reuse the existing review")
-				require.Equal(t, metadata.byOutputKey.SessionID, result.SessionID, "result should point to existing terminal session")
+				require.Equal(t, metadata.latest.SessionID, result.SessionID, "result should point to existing terminal session")
 				require.Equal(t, 0, sessions.createCalls, "duplicate terminal request should not create a detached session")
 				require.Equal(t, 0, metadata.createCalls, "duplicate terminal request should not create duplicate metadata")
 				require.Equal(t, 0, jobs.enqueueCalls, "duplicate terminal request should not enqueue a broken job")
+			},
+		},
+		{
+			name:      "replaces running review whose job is no longer active",
+			input:     newReviewRequestedInput(nil),
+			activeJob: boolPtr(false),
+			setup: func(_ *policyStub, m *metadataStub, _ *triggerStub) {
+				m.latest = models.CodeReviewSessionMetadata{
+					ID:              uuid.New(),
+					SessionID:       uuid.New(),
+					Status:          models.CodeReviewSessionStatusRunning,
+					ReviewOutputKey: "stranded-output-key",
+				}
+			},
+			expected: func(t *testing.T, result ReviewRequestedResult, policies *policyStub, metadata *metadataStub, sessions *sessionStub, jobs *jobStub) {
+				require.True(t, result.Processed, "rerequest should be processed")
+				require.False(t, result.Reused, "stranded review should not be silently reused")
+				require.Equal(t, 1, metadata.failCalls, "stranded review should be marked failed before replacement")
+				require.Equal(t, 1, sessions.updateStatusCalls, "stranded parent session should be terminalized")
+				require.Equal(t, models.SessionStatusFailed, sessions.updatedStatus, "stranded parent session should be marked failed")
+				require.Equal(t, 1, sessions.updateFailureCalls, "stranded parent session should record an actionable failure")
+				require.Equal(t, 1, sessions.createCalls, "rerequest should create a fresh session")
+				require.Equal(t, 1, jobs.enqueueCalls, "rerequest should enqueue a fresh review job")
+				require.Contains(t, metadata.created.ReviewOutputKey, metadata.latest.ID.String(), "replacement output key should identify the prior failed attempt")
+			},
+		},
+		{
+			name:      "reuses newly queued review while its job enqueue is in flight",
+			input:     newReviewRequestedInput(nil),
+			activeJob: boolPtr(false),
+			setup: func(_ *policyStub, m *metadataStub, _ *triggerStub) {
+				m.latest = models.CodeReviewSessionMetadata{
+					ID:              uuid.New(),
+					SessionID:       uuid.New(),
+					Status:          models.CodeReviewSessionStatusQueued,
+					ReviewOutputKey: "new-output-key",
+					CreatedAt:       time.Now(),
+				}
+			},
+			expected: func(t *testing.T, result ReviewRequestedResult, policies *policyStub, metadata *metadataStub, sessions *sessionStub, jobs *jobStub) {
+				require.True(t, result.Processed, "duplicate request during enqueue should be processed")
+				require.True(t, result.Reused, "new metadata should be reused during the enqueue grace period")
+				require.Equal(t, 0, metadata.failCalls, "enqueue grace period should not fail new metadata")
+				require.Equal(t, 0, sessions.createCalls, "enqueue grace period should not create a duplicate session")
+				require.Equal(t, 0, jobs.enqueueCalls, "the original request should remain responsible for enqueueing")
+			},
+		},
+		{
+			name:      "reuses concurrent replacement after losing stranded takeover",
+			input:     newReviewRequestedInput(nil),
+			activeJob: boolPtr(false),
+			setup: func(_ *policyStub, m *metadataStub, _ *triggerStub) {
+				m.latest = models.CodeReviewSessionMetadata{
+					ID:              uuid.New(),
+					SessionID:       uuid.New(),
+					Status:          models.CodeReviewSessionStatusRunning,
+					ReviewOutputKey: "stranded-output-key",
+				}
+				m.failErr = pgx.ErrNoRows
+				m.latestAfterFail = models.CodeReviewSessionMetadata{
+					ID:              uuid.New(),
+					SessionID:       uuid.New(),
+					Status:          models.CodeReviewSessionStatusQueued,
+					ReviewOutputKey: "replacement-output-key",
+					CreatedAt:       time.Now(),
+				}
+			},
+			expected: func(t *testing.T, result ReviewRequestedResult, policies *policyStub, metadata *metadataStub, sessions *sessionStub, jobs *jobStub) {
+				require.True(t, result.Processed, "concurrent replacement should satisfy the rerequest")
+				require.True(t, result.Reused, "losing takeover should reuse the winning replacement")
+				require.Equal(t, metadata.latestAfterFail.SessionID, result.SessionID, "result should point to the winning replacement session")
+				require.Equal(t, 1, metadata.failCalls, "service should attempt to claim the stranded record once")
+				require.Equal(t, 0, sessions.updateStatusCalls, "losing takeover must not fail the winning replacement session")
+				require.Equal(t, 0, sessions.createCalls, "losing takeover must not create another replacement")
+				require.Equal(t, 0, jobs.enqueueCalls, "the winning request remains responsible for enqueueing")
+			},
+		},
+		{
+			name:  "creates fresh review after failed attempt",
+			input: newReviewRequestedInput(nil),
+			setup: func(_ *policyStub, m *metadataStub, _ *triggerStub) {
+				m.latest = models.CodeReviewSessionMetadata{
+					ID:        uuid.New(),
+					SessionID: uuid.New(),
+					Status:    models.CodeReviewSessionStatusFailed,
+				}
+			},
+			expected: func(t *testing.T, result ReviewRequestedResult, policies *policyStub, metadata *metadataStub, sessions *sessionStub, jobs *jobStub) {
+				require.True(t, result.Processed, "failed review rerequest should be processed")
+				require.False(t, result.Reused, "failed review should get a fresh attempt")
+				require.Equal(t, 1, sessions.createCalls, "failed review rerequest should create a fresh session")
+				require.Equal(t, 1, jobs.enqueueCalls, "failed review rerequest should enqueue a fresh job")
+				require.Contains(t, metadata.created.ReviewOutputKey, metadata.latest.ID.String(), "retry output key should advance from the failed attempt")
 			},
 		},
 		{
@@ -167,13 +267,16 @@ func TestService_HandleReviewRequested(t *testing.T) {
 			t.Parallel()
 
 			policies := newPolicyStub()
-			metadata := &metadataStub{runningErr: pgx.ErrNoRows}
+			metadata := &metadataStub{}
 			triggers := &triggerStub{orgID: tt.input.OrgID, repositoryID: tt.input.RepositoryID, err: pgx.ErrNoRows}
 			if tt.setup != nil {
 				tt.setup(policies, metadata, triggers)
 			}
 			sessions := &sessionStub{}
-			jobs := &jobStub{jobID: uuid.New()}
+			jobs := &jobStub{jobID: uuid.New(), active: true}
+			if tt.activeJob != nil {
+				jobs.active = *tt.activeJob
+			}
 			svc := NewService(policies, metadata, sessions, jobs, zerolog.Nop(), Config{AppReviewerLogins: []string{"143-code-reviewer"}})
 			svc.SetGitHubTriggerStore(triggers)
 
@@ -252,14 +355,15 @@ func (s *policyStub) SavePolicy(_ context.Context, orgID uuid.UUID, repositoryID
 }
 
 type metadataStub struct {
-	createCalls  int
-	staleCalls   int
-	supersededBy *uuid.UUID
-	created      models.CodeReviewSessionMetadata
-	createResult models.CodeReviewSessionMetadata
-	running      models.CodeReviewSessionMetadata
-	byOutputKey  models.CodeReviewSessionMetadata
-	runningErr   error
+	createCalls     int
+	staleCalls      int
+	supersededBy    *uuid.UUID
+	created         models.CodeReviewSessionMetadata
+	createResult    models.CodeReviewSessionMetadata
+	latest          models.CodeReviewSessionMetadata
+	latestAfterFail models.CodeReviewSessionMetadata
+	failCalls       int
+	failErr         error
 }
 
 func (s *metadataStub) CreateSessionMetadata(_ context.Context, metadata *models.CodeReviewSessionMetadata) error {
@@ -274,21 +378,28 @@ func (s *metadataStub) CreateSessionMetadata(_ context.Context, metadata *models
 	return nil
 }
 
-func (s *metadataStub) GetByOutputKey(_ context.Context, _ uuid.UUID, _ string) (models.CodeReviewSessionMetadata, error) {
-	if s.byOutputKey.ID != uuid.Nil {
-		return s.byOutputKey, nil
+func (s *metadataStub) GetLatestByPullRequestHead(_ context.Context, _, _ uuid.UUID, _ string, _ uuid.UUID) (models.CodeReviewSessionMetadata, error) {
+	if s.latest.ID != uuid.Nil {
+		return s.latest, nil
 	}
 	return models.CodeReviewSessionMetadata{}, pgx.ErrNoRows
 }
 
-func (s *metadataStub) GetRunningByPullRequestHead(_ context.Context, _, _ uuid.UUID, _ string, _ uuid.UUID) (models.CodeReviewSessionMetadata, error) {
-	if s.running.ID != uuid.Nil {
-		return s.running, nil
+func (s *metadataStub) FailReview(_ context.Context, _ uuid.UUID, _ uuid.UUID, reason string) (models.CodeReviewSessionMetadata, error) {
+	s.failCalls++
+	if s.failErr != nil {
+		err := s.failErr
+		s.failErr = nil
+		if s.latestAfterFail.ID != uuid.Nil {
+			s.latest = s.latestAfterFail
+		}
+		return models.CodeReviewSessionMetadata{}, err
 	}
-	if s.runningErr != nil {
-		return models.CodeReviewSessionMetadata{}, s.runningErr
-	}
-	return models.CodeReviewSessionMetadata{}, errors.New("unexpected running lookup")
+	failed := s.latest
+	failed.Status = models.CodeReviewSessionStatusFailed
+	failed.FailureReason = &reason
+	s.latest = failed
+	return failed, nil
 }
 
 func (s *metadataStub) MarkStaleForPullRequestExceptHead(_ context.Context, _, _ uuid.UUID, _ string, supersededBySessionID *uuid.UUID) (int64, error) {
@@ -298,8 +409,11 @@ func (s *metadataStub) MarkStaleForPullRequestExceptHead(_ context.Context, _, _
 }
 
 type sessionStub struct {
-	createCalls int
-	created     models.Session
+	createCalls        int
+	updateStatusCalls  int
+	updateFailureCalls int
+	updatedStatus      models.SessionStatus
+	created            models.Session
 }
 
 func (s *sessionStub) Create(_ context.Context, session *models.Session) error {
@@ -309,22 +423,44 @@ func (s *sessionStub) Create(_ context.Context, session *models.Session) error {
 	return nil
 }
 
+func (s *sessionStub) UpdateStatus(_ context.Context, _, _ uuid.UUID, status models.SessionStatus) error {
+	s.updateStatusCalls++
+	s.updatedStatus = status
+	return nil
+}
+
+func (s *sessionStub) UpdateFailure(context.Context, uuid.UUID, uuid.UUID, string, string, []string, bool) error {
+	s.updateFailureCalls++
+	return nil
+}
+
 type jobStub struct {
 	enqueueCalls int
 	jobID        uuid.UUID
 	jobType      string
 	dedupeKey    string
 	payload      RunCodeReviewJobPayload
+	opts         db.EnqueueOpts
+	active       bool
 }
 
-func (s *jobStub) Enqueue(_ context.Context, _ uuid.UUID, _ string, jobType string, payload any, _ int, dedupeKey *string) (uuid.UUID, error) {
+func (s *jobStub) EnqueueWithOpts(_ context.Context, _ uuid.UUID, opts db.EnqueueOpts) (uuid.UUID, error) {
 	s.enqueueCalls++
-	s.jobType = jobType
-	if typed, ok := payload.(RunCodeReviewJobPayload); ok {
+	s.opts = opts
+	s.jobType = opts.JobType
+	if typed, ok := opts.Payload.(RunCodeReviewJobPayload); ok {
 		s.payload = typed
 	}
-	if dedupeKey != nil {
-		s.dedupeKey = *dedupeKey
+	if opts.DedupeKey != nil {
+		s.dedupeKey = *opts.DedupeKey
 	}
 	return s.jobID, nil
+}
+
+func (s *jobStub) HasActiveByDedupeKey(context.Context, uuid.UUID, string, string) (bool, error) {
+	return s.active, nil
+}
+
+func boolPtr(value bool) *bool {
+	return &value
 }

--- a/internal/services/github/pr.go
+++ b/internal/services/github/pr.go
@@ -2850,6 +2850,7 @@ func (s *PRService) doGitHubRequest(ctx context.Context, token, method, path str
 			Path:       path,
 			StatusCode: resp.StatusCode,
 			Body:       respBody,
+			Header:     resp.Header.Clone(),
 		}
 	}
 
@@ -2896,6 +2897,7 @@ func (s *PRService) doGitHubGraphQL(ctx context.Context, token, query string, va
 			Path:       "/graphql",
 			StatusCode: resp.StatusCode,
 			Body:       respBody,
+			Header:     resp.Header.Clone(),
 		}
 	}
 
@@ -2910,6 +2912,7 @@ type GitHubAPIError struct {
 	Path       string
 	StatusCode int
 	Body       []byte
+	Header     http.Header
 }
 
 func (e *GitHubAPIError) Error() string {

--- a/internal/services/github/pr_test.go
+++ b/internal/services/github/pr_test.go
@@ -950,6 +950,7 @@ func TestDoGitHubRequest_ErrorResponse(t *testing.T) {
 	t.Parallel()
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Retry-After", "19")
 		w.WriteHeader(http.StatusNotFound)
 		_, err := w.Write([]byte(`{"message":"Not Found"}`))
 		require.NoError(t, err, "test server should write not found response body")
@@ -966,6 +967,9 @@ func TestDoGitHubRequest_ErrorResponse(t *testing.T) {
 	require.Error(t, err, "doGitHubRequest should return an error for 404 response")
 	require.Contains(t, err.Error(), "404", "error should contain the HTTP status code")
 	require.Contains(t, err.Error(), "Not Found", "error should contain the response message")
+	var apiErr *GitHubAPIError
+	require.ErrorAs(t, err, &apiErr, "error response should retain its typed GitHub API details")
+	require.Equal(t, "19", apiErr.Header.Get("Retry-After"), "GitHub API error should preserve response headers for retry classification")
 }
 
 func TestDoGitHubRequest_SetsHeaders(t *testing.T) {

--- a/internal/worker/code_review_handler.go
+++ b/internal/worker/code_review_handler.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net"
+	"net/http"
 	"path/filepath"
 	"regexp"
 	"strconv"
@@ -12,6 +14,7 @@ import (
 	"time"
 
 	"github.com/assembledhq/143/internal/db"
+	"github.com/assembledhq/143/internal/jobctx"
 	"github.com/assembledhq/143/internal/models"
 	"github.com/assembledhq/143/internal/prompts"
 	codereviewsvc "github.com/assembledhq/143/internal/services/codereview"
@@ -69,6 +72,7 @@ func newRunCodeReviewHandler(stores *Stores, services *Services, logger zerolog.
 		if job.OrgID == uuid.Nil || job.SessionID == uuid.Nil {
 			return fmt.Errorf("org_id and session_id are required")
 		}
+		registerCodeReviewDeadLetterReconciliation(ctx, stores, services, logger, job)
 		metadata, err := stores.CodeReviews.MarkRunning(ctx, job.OrgID, job.SessionID)
 		if err != nil {
 			if errors.Is(err, pgx.ErrNoRows) {
@@ -348,6 +352,18 @@ func reconcileCodeReviewSessionCompletion(ctx context.Context, stores *Stores, l
 }
 
 func reconcileCodeReviewSessionFailure(ctx context.Context, stores *Stores, job runCodeReviewPayload, reason string) error {
+	return reconcileCodeReviewSessionFailureWithDetails(ctx, stores, job, reason,
+		"code_review_no_reviewer_output",
+		[]string{"Configure at least one reviewer credential and request the review again."})
+}
+
+func reconcileCodeReviewSessionJobFailure(ctx context.Context, stores *Stores, job runCodeReviewPayload, reason string) error {
+	return reconcileCodeReviewSessionFailureWithDetails(ctx, stores, job, reason,
+		"code_review_job_failed",
+		[]string{"Request the code reviewer again to start a fresh attempt."})
+}
+
+func reconcileCodeReviewSessionFailureWithDetails(ctx context.Context, stores *Stores, job runCodeReviewPayload, reason, category string, nextSteps []string) error {
 	if stores == nil || stores.Sessions == nil {
 		return nil
 	}
@@ -366,10 +382,72 @@ func reconcileCodeReviewSessionFailure(ctx context.Context, stores *Stores, job 
 			return fmt.Errorf("reconcile code review parent session to failed: %w", err)
 		}
 	}
-	if err := stores.Sessions.UpdateFailure(ctx, job.OrgID, job.SessionID, reason, "code_review_no_reviewer_output", []string{"Configure at least one reviewer credential and request the review again."}, true); err != nil {
+	if err := stores.Sessions.UpdateFailure(ctx, job.OrgID, job.SessionID, reason, category, nextSteps, true); err != nil {
 		return fmt.Errorf("record code review parent session failure details: %w", err)
 	}
 	return nil
+}
+
+func registerCodeReviewDeadLetterReconciliation(ctx context.Context, stores *Stores, services *Services, logger zerolog.Logger, job runCodeReviewPayload) {
+	jobctx.RegisterDeadLetterHook(ctx, func(hookCtx context.Context, deadLetterErr error) {
+		reason := codeReviewDeadLetterReason(deadLetterErr)
+		if stores != nil && stores.CodeReviews != nil {
+			if _, err := stores.CodeReviews.FailReview(hookCtx, job.OrgID, job.SessionID, reason); err != nil && !errors.Is(err, pgx.ErrNoRows) {
+				logger.Warn().Err(err).
+					Str("session_id", job.SessionID.String()).
+					Msg("failed to reconcile dead-lettered code review metadata")
+			}
+		}
+		if err := reconcileCodeReviewSessionJobFailure(hookCtx, stores, job, reason); err != nil {
+			logger.Warn().Err(err).
+				Str("session_id", job.SessionID.String()).
+				Msg("failed to reconcile dead-lettered code review session")
+		}
+		removeCodeReviewRequestedReviewerAfterDeadLetter(hookCtx, stores, services, logger, job)
+	})
+}
+
+func removeCodeReviewRequestedReviewerAfterDeadLetter(ctx context.Context, stores *Stores, services *Services, logger zerolog.Logger, job runCodeReviewPayload) {
+	if strings.TrimSpace(job.RequestedReviewerLogin) == "" && strings.TrimSpace(job.RequestedTeamSlug) == "" {
+		return
+	}
+	if services == nil || services.CodeReviews == nil {
+		return
+	}
+	if _, ok := services.CodeReviews.(codeReviewRequestedReviewerRemover); !ok {
+		return
+	}
+	if stores == nil || stores.PullRequests == nil {
+		logger.Warn().Str("session_id", job.SessionID.String()).Msg("skipping dead-lettered requested reviewer cleanup: pull request store unavailable")
+		return
+	}
+	pr, err := stores.PullRequests.GetByID(ctx, job.OrgID, job.PullRequestID)
+	if err != nil {
+		logger.Warn().Err(err).
+			Str("session_id", job.SessionID.String()).
+			Str("pull_request_id", job.PullRequestID.String()).
+			Msg("failed to load pull request for dead-lettered requested reviewer cleanup")
+		return
+	}
+	removeCodeReviewRequestedReviewer(ctx, stores, services, logger, job, pr)
+}
+
+func codeReviewDeadLetterReason(err error) string {
+	const maxRunes = 2000
+
+	detail := "unknown worker failure"
+	var apiErr *ghservice.GitHubAPIError
+	if errors.As(err, &apiErr) {
+		detail = fmt.Sprintf("GitHub API %s %s returned %d", apiErr.Method, apiErr.Path, apiErr.StatusCode)
+	} else if err != nil && strings.TrimSpace(err.Error()) != "" {
+		detail = strings.TrimSpace(err.Error())
+	}
+	reason := "code review job exhausted retries: " + detail
+	runes := []rune(reason)
+	if len(runes) > maxRunes {
+		reason = string(runes[:maxRunes-1]) + "…"
+	}
+	return reason
 }
 
 func syncCodeReviewPullRequestState(ctx context.Context, services *Services, logger zerolog.Logger, job runCodeReviewPayload) error {
@@ -388,9 +466,77 @@ func syncCodeReviewPullRequestState(ctx context.Context, services *Services, log
 				Msg("skipping code review PR state sync for disconnected repository")
 			return nil
 		}
-		return fmt.Errorf("sync code review pull request state: %w", err)
+		wrapped := fmt.Errorf("sync code review pull request state: %w", err)
+		if retryable, retryAfter := codeReviewGitHubSyncRetry(err); retryable {
+			return &RetryableError{Err: wrapped, ConsumeAttempt: true, RetryAfter: retryAfter}
+		}
+		var apiErr *ghservice.GitHubAPIError
+		if errors.As(err, &apiErr) {
+			return &FatalError{Err: wrapped}
+		}
+		return wrapped
 	}
 	return nil
+}
+
+func codeReviewGitHubSyncRetry(err error) (bool, *time.Duration) {
+	if err == nil || errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return false, nil
+	}
+	var apiErr *ghservice.GitHubAPIError
+	if errors.As(err, &apiErr) {
+		retryable := apiErr.StatusCode == http.StatusRequestTimeout ||
+			apiErr.StatusCode == http.StatusTooEarly ||
+			apiErr.StatusCode == http.StatusTooManyRequests ||
+			apiErr.StatusCode >= http.StatusInternalServerError ||
+			codeReviewGitHubRateLimited(apiErr)
+		if !retryable {
+			return false, nil
+		}
+		return true, codeReviewGitHubRetryAfter(apiErr)
+	}
+	var networkErr net.Error
+	return errors.As(err, &networkErr), nil
+}
+
+func codeReviewGitHubRateLimited(apiErr *ghservice.GitHubAPIError) bool {
+	if apiErr == nil || apiErr.StatusCode != http.StatusForbidden {
+		return false
+	}
+	if strings.TrimSpace(apiErr.Header.Get("Retry-After")) != "" || strings.TrimSpace(apiErr.Header.Get("X-RateLimit-Remaining")) == "0" {
+		return true
+	}
+	message := strings.ToLower(strings.TrimSpace(apiErr.Message()))
+	return strings.Contains(message, "rate limit") || strings.Contains(message, "abuse detection")
+}
+
+func codeReviewGitHubRetryAfter(apiErr *ghservice.GitHubAPIError) *time.Duration {
+	if apiErr == nil {
+		return nil
+	}
+	if raw := strings.TrimSpace(apiErr.Header.Get("Retry-After")); raw != "" {
+		if seconds, err := strconv.Atoi(raw); err == nil && seconds >= 0 {
+			delay := time.Duration(seconds) * time.Second
+			return &delay
+		}
+		if retryAt, err := http.ParseTime(raw); err == nil {
+			return nonNegativeCodeReviewRetryDelay(retryAt)
+		}
+	}
+	if strings.TrimSpace(apiErr.Header.Get("X-RateLimit-Remaining")) == "0" {
+		if resetUnix, err := strconv.ParseInt(strings.TrimSpace(apiErr.Header.Get("X-RateLimit-Reset")), 10, 64); err == nil {
+			return nonNegativeCodeReviewRetryDelay(time.Unix(resetUnix, 0))
+		}
+	}
+	return nil
+}
+
+func nonNegativeCodeReviewRetryDelay(retryAt time.Time) *time.Duration {
+	delay := time.Until(retryAt)
+	if delay < 0 {
+		delay = 0
+	}
+	return &delay
 }
 
 func codeReviewCanRunReviewerThreads(stores *Stores) bool {

--- a/internal/worker/code_review_handler_test.go
+++ b/internal/worker/code_review_handler_test.go
@@ -4,19 +4,186 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"net/http"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/assembledhq/143/internal/db"
+	"github.com/assembledhq/143/internal/jobctx"
 	"github.com/assembledhq/143/internal/models"
 	"github.com/assembledhq/143/internal/services/codereview"
+	ghservice "github.com/assembledhq/143/internal/services/github"
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
 	"github.com/pashagolub/pgxmock/v4"
 	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/require"
 )
+
+func TestSyncCodeReviewPullRequestStateClassifiesTransientGitHubFailures(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name               string
+		status             int
+		body               string
+		header             http.Header
+		retryable          bool
+		fatal              bool
+		expectedRetryAfter time.Duration
+	}{
+		{name: "retries service unavailable", status: http.StatusServiceUnavailable, retryable: true},
+		{name: "retries rate limiting", status: http.StatusTooManyRequests, retryable: true},
+		{
+			name:               "retries forbidden secondary rate limit using server delay",
+			status:             http.StatusForbidden,
+			body:               `{"message":"You have exceeded a secondary rate limit"}`,
+			header:             http.Header{"Retry-After": []string{"17"}},
+			retryable:          true,
+			expectedRetryAfter: 17 * time.Second,
+		},
+		{name: "does not retry forbidden permission failure", status: http.StatusForbidden, body: `{"message":"Resource not accessible by integration"}`, fatal: true},
+		{name: "does not retry validation failure", status: http.StatusUnprocessableEntity, fatal: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			body := tt.body
+			if body == "" {
+				body = "upstream response"
+			}
+			upstreamErr := &ghservice.GitHubAPIError{
+				Method:     http.MethodGet,
+				Path:       "/repos/acme/repo/pulls/42",
+				StatusCode: tt.status,
+				Body:       []byte(body),
+				Header:     tt.header,
+			}
+			services := &Services{PR: &stubPRService{
+				syncPullRequestStateFn: func(context.Context, uuid.UUID, uuid.UUID) error {
+					return upstreamErr
+				},
+			}}
+
+			err := syncCodeReviewPullRequestState(context.Background(), services, zerolog.Nop(), runCodeReviewPayload{
+				OrgID:         uuid.New(),
+				PullRequestID: uuid.New(),
+			})
+
+			var retryErr *RetryableError
+			require.Equal(t, tt.retryable, errors.As(err, &retryErr), "GitHub status should receive the expected retry classification")
+			var fatalErr *FatalError
+			require.Equal(t, tt.fatal, errors.As(err, &fatalErr), "non-transient GitHub status should receive the expected fatal classification")
+			if tt.retryable {
+				require.True(t, retryErr.ConsumeAttempt, "transient GitHub retries should consume attempts so exponential backoff increases")
+				if tt.expectedRetryAfter > 0 {
+					require.NotNil(t, retryErr.RetryAfter, "rate-limited response should preserve the upstream retry delay")
+					require.Equal(t, tt.expectedRetryAfter, *retryErr.RetryAfter, "rate-limited response should use the upstream retry delay")
+				} else {
+					require.Nil(t, retryErr.RetryAfter, "transient GitHub retries without a hint should use exponential backoff")
+				}
+			}
+		})
+	}
+}
+
+func TestCodeReviewDeadLetterReconciliationFailsMetadata(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "pgxmock pool should initialize")
+	defer mock.Close()
+
+	orgID := uuid.New()
+	sessionID := uuid.New()
+	repositoryID := uuid.New()
+	pullRequestID := uuid.New()
+	policyID := uuid.New()
+	metadataID := uuid.New()
+	now := time.Date(2026, 7, 16, 22, 56, 4, 0, time.UTC)
+	deadLetterErr := &ghservice.GitHubAPIError{
+		Method:     http.MethodGet,
+		Path:       "/repos/acme/repo/pulls/42",
+		StatusCode: http.StatusServiceUnavailable,
+		Body:       []byte("unavailable"),
+	}
+	reason := codeReviewDeadLetterReason(deadLetterErr)
+	decision := models.CodeReviewDecisionBlocked
+	acceptable := false
+
+	mock.ExpectQuery("UPDATE code_review_session_metadata").
+		WithArgs(pgx.NamedArgs{"org_id": orgID, "session_id": sessionID, "failure_reason": reason}).
+		WillReturnRows(newCodeReviewMetadataRows().
+			AddRow(metadataID, orgID, sessionID, repositoryID, pullRequestID, policyID,
+				"base", "head", false, models.CodeReviewTriggerSourceTeamReviewer,
+				models.CodeReviewSessionStatusFailed, &decision, &acceptable, false, nil,
+				"output-key", nil, nil, nil, nil, &reason, &now, now))
+	idleRow := workerSessionRow(sessionID, uuid.Nil, orgID, models.SessionStatusIdle, 0, nil, nil)
+	setWorkerSessionColumn(idleRow, "origin", models.SessionOriginCodeReview)
+	mock.ExpectQuery("(?s)SELECT .*FROM sessions").
+		WithArgs(pgx.NamedArgs{"id": sessionID, "org_id": orgID}).
+		WillReturnRows(pgxmock.NewRows(workerSessionColumns).AddRow(idleRow...))
+	failedRow := workerSessionRow(sessionID, uuid.Nil, orgID, models.SessionStatusFailed, 0, nil, nil)
+	setWorkerSessionColumn(failedRow, "origin", models.SessionOriginCodeReview)
+	mock.ExpectQuery("UPDATE sessions SET status = @status, completed_at = now").
+		WithArgs(workerAnyArgs(3)...).
+		WillReturnRows(pgxmock.NewRows(workerSessionColumns).AddRow(failedRow...))
+	mock.ExpectExec("UPDATE sessions[\\s\\S]+failure_explanation").
+		WithArgs(workerAnyArgs(6)...).
+		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
+	mock.ExpectQuery("(?s)FROM pull_requests.*WHERE id = @id AND org_id = @org_id").
+		WithArgs(pgx.NamedArgs{"id": pullRequestID, "org_id": orgID}).
+		WillReturnRows(pgxmock.NewRows(workerPullRequestColumns).
+			AddRow(workerPullRequestRow(pullRequestID, sessionID, orgID, "acme/repo", "feature", now)...))
+	mock.ExpectQuery("(?s)FROM repositories.*WHERE id = @id AND org_id = @org_id").
+		WithArgs(pgx.NamedArgs{"id": repositoryID, "org_id": orgID}).
+		WillReturnRows(workerRepositoryRows(models.Repository{
+			ID: repositoryID, OrgID: orgID, IntegrationID: uuid.New(), GitHubID: 42,
+			FullName: "acme/repo", DefaultBranch: "main", CloneURL: "https://github.com/acme/repo.git",
+			InstallationID: 143, Status: models.RepositoryStatusActive, Settings: json.RawMessage(`{}`),
+			CreatedAt: now, UpdatedAt: now,
+		}))
+
+	remover := &capturingCodeReviewSubmitter{}
+	ctx := jobctx.WithDeadLetterHooks(context.Background())
+	registerCodeReviewDeadLetterReconciliation(ctx, &Stores{
+		CodeReviews:  db.NewCodeReviewStore(mock),
+		Sessions:     db.NewSessionStore(mock),
+		PullRequests: db.NewPullRequestStore(mock),
+		Repositories: db.NewRepositoryStore(mock),
+	}, &Services{CodeReviews: remover}, zerolog.Nop(), runCodeReviewPayload{
+		OrgID:                  orgID,
+		SessionID:              sessionID,
+		RepositoryID:           repositoryID,
+		PullRequestID:          pullRequestID,
+		RequestedReviewerLogin: "143-code-reviewer",
+	})
+	jobctx.RunDeadLetterHooks(ctx, deadLetterErr)
+
+	require.NoError(t, mock.ExpectationsWereMet(), "dead-letter hook should fail the review metadata and parent session")
+	require.Equal(t, []codereview.RequestedReviewersRequest{{
+		InstallationID: 143,
+		Repository:     "acme/repo",
+		PullNumber:     42,
+		Reviewers:      []string{"143-code-reviewer"},
+	}}, remover.removeRequests, "dead-letter hook should remove the pending reviewer so GitHub can emit a new request")
+}
+
+type capturingCodeReviewSubmitter struct {
+	removeRequests []codereview.RequestedReviewersRequest
+}
+
+func (s *capturingCodeReviewSubmitter) SubmitReview(context.Context, codereview.SubmitReviewRequest) (codereview.SubmitReviewResult, error) {
+	return codereview.SubmitReviewResult{}, nil
+}
+
+func (s *capturingCodeReviewSubmitter) RemoveRequestedReviewers(_ context.Context, req codereview.RequestedReviewersRequest) error {
+	s.removeRequests = append(s.removeRequests, req)
+	return nil
+}
 
 func TestCodeReviewInlineComments(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
## Summary
- Track code review reviewer state more explicitly through the service, DB, and worker layers.
- Update GitHub PR review handling and webhook tests to cover the new behavior.
- Add and adjust tests around code review persistence, job processing, and reviewer selection to prevent silent failures.

## Testing
- Added and updated unit tests across `internal/services/codereview`, `internal/services/github`, `internal/db`, and `internal/worker`.
- Not run (not requested).