### PR TITLE
Investigate PR card button size and mobile padding differences between Review and Merge actions

### DIFF
--- a/frontend/src/components/pr-health-banner.test.tsx
+++ b/frontend/src/components/pr-health-banner.test.tsx
@@ -74,6 +74,27 @@ describe("PRHealthBanner", () => {
     expect(button).toHaveAttribute("title", "GitHub is not allowing this PR to merge yet.");
   });
 
+  it("uses compact spacing for the merge and review actions", () => {
+    renderWithProviders(
+      <PRHealthBanner
+        health={{ ...baseHealth, checks_confirmed: true }}
+        pendingAction={null}
+        repairError={null}
+        mergeAuthRequired={false}
+        mergeWhenReadyPending={false}
+        onFixTests={vi.fn()}
+        onResolveConflicts={vi.fn()}
+        onMerge={vi.fn()}
+        onQueueMergeWhenReady={vi.fn()}
+        reviewAction={{ disabled: false, spinning: false, onClick: vi.fn() }}
+      />,
+    );
+
+    expect(screen.getByRole("button", { name: "More merge actions" })).toHaveClass("w-8", "sm:w-6");
+    expect(screen.getByRole("button", { name: /^Merge$/ }).querySelector("svg")).not.toHaveClass("mr-1.5");
+    expect(screen.getByRole("button", { name: "Review" }).querySelector("svg")).not.toHaveClass("mr-1.5");
+  });
+
   it("shows Fix tests for failed checks even when the legacy failing test count is zero", async () => {
     const onFixTests = vi.fn();
     renderWithProviders(

--- a/frontend/src/components/pr-health-banner.tsx
+++ b/frontend/src/components/pr-health-banner.tsx
@@ -278,9 +278,9 @@ export function PRHealthBanner({
                           onClick={onMerge}
                         >
                           {mergeAction.spinning ? (
-                            <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />
+                            <Loader2 className="h-3.5 w-3.5 animate-spin" />
                           ) : (
-                            <GitMerge className="mr-1.5 h-3.5 w-3.5" />
+                            <GitMerge className="h-3.5 w-3.5" />
                           )}
                           {mergeAction.label}
                         </Button>
@@ -291,7 +291,7 @@ export function PRHealthBanner({
                             <Button
                               size="icon-xs"
                               variant="default"
-                              className="rounded-l-none shadow-none"
+                              className="w-8 rounded-l-none shadow-none sm:w-6"
                               disabled={mergeWhenReadyAction.disabled}
                               title={mergeWhenReadyAction.disabledReason ?? "More merge actions"}
                               aria-label="More merge actions"
@@ -416,9 +416,9 @@ export function PRHealthBanner({
                         onClick={reviewAction.onClick}
                       >
                         {reviewAction.spinning ? (
-                          <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />
+                          <Loader2 className="h-3.5 w-3.5 animate-spin" />
                         ) : (
-                          <ClipboardList className="mr-1.5 h-3.5 w-3.5" />
+                          <ClipboardList className="h-3.5 w-3.5" />
                         )}
                         Review
                       </Button>


### PR DESCRIPTION
## Summary

The PR health banner’s Merge and Review actions had inconsistent icon/padding spacing, leading to a visually misaligned and harder-to-scan action row—especially on mobile. This change makes the Merge “more actions” segment compact (32px mobile / 24px desktop), removes redundant per-button icon margins, and relies on the shared layout gap for consistent spacing.  

## Changes

- Adjusted the “More merge actions” icon-only button width to `w-8` (mobile) and `sm:w-6` (desktop) to match intended compact sizing.
- Removed redundant `mr-1.5` icon margins from the Merge and Review action buttons; spacing is now controlled by their shared `gap-1`.
- Added a focused regression test to lock in the compact spacing and margin removal for both actions.

## Validation

- All 35 PR health component tests pass.
- ESLint passes.
- `git diff --check` passes.
- Visual preview was unavailable because the preview service returned HTTP 404.

[143.dev](https://143.dev) | [session 68bced4e](https://143.dev/sessions/68bced4e-b280-4bf2-bd0b-db1180e08f9d)

<!-- 143 readiness -->
**143 readiness:** not available for this revision.

Preview: https://143.dev/previews/github/assembledhq/143/pull/1872?launch=1