### PR TITLE
Make preview resource migration replay-safe

### DIFF
--- a/cmd/migrate/main_test.go
+++ b/cmd/migrate/main_test.go
@@ -120,6 +120,32 @@ func TestMigrationsDoNotUseConcurrentIndexes(t *testing.T) {
 	}
 }
 
+func TestRenumberedPreviewResourceMigrationIsReplaySafe(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		required string
+	}{
+		{name: "peak memory bytes column", required: "ADD COLUMN IF NOT EXISTS peak_memory_bytes"},
+		{name: "peak memory sampled at column", required: "ADD COLUMN IF NOT EXISTS peak_memory_sampled_at"},
+		{name: "peak memory phase column", required: "ADD COLUMN IF NOT EXISTS peak_memory_phase"},
+		{name: "resource samples table", required: "CREATE TABLE IF NOT EXISTS preview_resource_samples"},
+		{name: "preview samples index", required: "CREATE INDEX IF NOT EXISTS idx_preview_resource_samples_preview"},
+		{name: "sampled at index", required: "CREATE INDEX IF NOT EXISTS idx_preview_resource_samples_sampled_at"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			body, err := os.ReadFile(filepath.Join("..", "..", "migrations", "000249_preview_resource_samples.up.sql"))
+			require.NoError(t, err, "renumbered preview resource migration should be readable")
+			require.Contains(t, string(body), tt.required, "renumbered preview resource migration should tolerate schema applied under its former version")
+		})
+	}
+}
+
 func TestHotTableFKRemovalDownMigrationIsExplicitNoop(t *testing.T) {
 	t.Parallel()
 

--- a/migrations/000249_preview_resource_samples.up.sql
+++ b/migrations/000249_preview_resource_samples.up.sql
@@ -1,9 +1,13 @@
+-- This migration originally shipped as 000237 before a duplicate migration
+-- number was discovered. Some databases applied that version before it was
+-- renumbered to 000249, so every operation must tolerate the schema already
+-- being present.
 ALTER TABLE preview_instances
-    ADD COLUMN peak_memory_bytes bigint NOT NULL DEFAULT 0,
-    ADD COLUMN peak_memory_sampled_at timestamptz,
-    ADD COLUMN peak_memory_phase text NOT NULL DEFAULT '';
+    ADD COLUMN IF NOT EXISTS peak_memory_bytes bigint NOT NULL DEFAULT 0,
+    ADD COLUMN IF NOT EXISTS peak_memory_sampled_at timestamptz,
+    ADD COLUMN IF NOT EXISTS peak_memory_phase text NOT NULL DEFAULT '';
 
-CREATE TABLE preview_resource_samples (
+CREATE TABLE IF NOT EXISTS preview_resource_samples (
     id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
     org_id uuid NOT NULL REFERENCES organizations(id),
     preview_instance_id uuid NOT NULL REFERENCES preview_instances(id) ON DELETE CASCADE,
@@ -18,8 +22,8 @@ CREATE TABLE preview_resource_samples (
     created_at timestamptz NOT NULL DEFAULT now()
 );
 
-CREATE INDEX idx_preview_resource_samples_preview
+CREATE INDEX IF NOT EXISTS idx_preview_resource_samples_preview
     ON preview_resource_samples (org_id, preview_instance_id, sampled_at DESC);
 
-CREATE INDEX idx_preview_resource_samples_sampled_at
+CREATE INDEX IF NOT EXISTS idx_preview_resource_samples_sampled_at
     ON preview_resource_samples (sampled_at);


### PR DESCRIPTION
## Summary
- Make the renumbered preview resource migration safe to replay.
- Add unit coverage for idempotent columns, table, and indexes.

## Testing
- Not run (not requested)