### PR TITLE
Make code review reviewer prompt self-healing on SHA drift

### DIFF
--- a/internal/prompts/templates/code_review_reviewer.template
+++ b/internal/prompts/templates/code_review_reviewer.template
@@ -18,7 +18,11 @@ Pull request: #{{.PullNumber}}{{if .PullRequestURL}} ({{.PullRequestURL}}){{end}
 Base SHA: {{.BaseSHA}}
 {{- end}}
 Head SHA: {{.HeadSHA}}
-Review exactly this pull request's changes{{if .BaseSHA}} (`git diff {{.BaseSHA}}...{{.HeadSHA}}`){{end}}, not whatever happens to be checked out. Confirm the workspace HEAD matches the head SHA before reviewing; if it does not, report the mismatch in your output instead of silently reviewing a different commit.
+Review exactly this pull request's changes, not whatever happens to be checked out. Workspace setup — fetching commits and detached checkouts are permitted and do not count as workspace modifications:
+1. Verify both SHAs exist locally (`git cat-file -e <sha>^{commit}`). Fetch any that are missing: `git fetch origin {{.HeadSHA}}`{{if .PullNumber}} (or `git fetch origin pull/{{.PullNumber}}/head`){{end}}{{if .BaseSHA}}; `git fetch origin {{.BaseSHA}}` for the base{{end}}.
+2. If the workspace HEAD does not match the head SHA, run `git checkout --detach {{.HeadSHA}}`. Only if the head SHA cannot be fetched at all, stop and report the mismatch in your output instead of reviewing a different commit.
+3. Diff against the merge base: `git diff $(git merge-base {{if .BaseSHA}}{{.BaseSHA}}{{else}}origin/HEAD{{end}} {{.HeadSHA}}) {{.HeadSHA}}`.{{if .BaseSHA}} If the base SHA is unavailable even after fetching (deleted or force-pushed base branch), substitute `origin/HEAD` for it.{{end}} If `git merge-base` fails, the clone may be shallow — run `git fetch --deepen=200 origin` and retry.
+4. Sanity-check the diff: it should touch the changed files listed below (when provided) and nothing unrelated. An implausibly large diff, or one missing those files, means the base is wrong — recompute the merge base before reviewing.
 {{- if .ChangedFiles}}
 Changed files:
 {{- range .ChangedFiles}}

--- a/internal/worker/code_review_handler_test.go
+++ b/internal/worker/code_review_handler_test.go
@@ -509,7 +509,11 @@ func TestCodeReviewReviewerPromptIncludesPullRequestTarget(t *testing.T) {
 	require.Contains(t, prompt, "Pull request: #53873", "reviewer prompt should identify the PR number")
 	require.Contains(t, prompt, "Base SHA: "+baseSHA, "reviewer prompt should pin the base SHA")
 	require.Contains(t, prompt, "Head SHA: "+job.HeadSHA, "reviewer prompt should pin the head SHA")
-	require.Contains(t, prompt, "git diff "+baseSHA+"..."+job.HeadSHA, "reviewer prompt should spell out the diff range")
+	require.Contains(t, prompt, "git diff $(git merge-base "+baseSHA+" "+job.HeadSHA+") "+job.HeadSHA, "reviewer prompt should spell out the merge-base diff command")
+	require.Contains(t, prompt, "git fetch origin "+job.HeadSHA, "reviewer prompt should tell the reviewer how to fetch a missing head SHA")
+	require.Contains(t, prompt, "git fetch origin pull/53873/head", "reviewer prompt should offer the PR ref as a fetch fallback")
+	require.Contains(t, prompt, "git checkout --detach "+job.HeadSHA, "reviewer prompt should permit a detached checkout of the head SHA")
+	require.Contains(t, prompt, "substitute `origin/HEAD`", "reviewer prompt should offer a fallback when the base SHA is unreachable")
 	require.Contains(t, prompt, "report the mismatch", "reviewer prompt should require reporting a workspace/head mismatch")
 	require.Contains(t, prompt, "- gocode/timeutils/interval.go", "reviewer prompt should list changed files")
 


### PR DESCRIPTION
## Summary
### Motivation
A merged downstack PR meant that there was a stale base commit SHA ([example](https://143.dev/sessions/a971fd6a-0b93-4464-9a12-6cb695e4bc43))

### Changes
The reviewer template hard-coded `git diff BASE...HEAD` and forbade any workspace change, so a deleted base SHA (force-pushed base branch), a shallow clone with no merge-base, or a workspace prepared at a different head made the reviewer either produce a garbage diff or refuse the review outright.

This teaches the prompt a recovery procedure instead:
- fetch missing SHAs by SHA or via `refs/pull/N/head`
- detached checkout of the pinned head SHA (explicitly carved out of the no-workspace-modification rule)
- diff against the computed merge base, with an `origin/HEAD` fallback when the base SHA is unreachable
- deepen shallow clones when `git merge-base` fails
- sanity-check the diff against the changed-file list

Refusal is now reserved for a head SHA that cannot be fetched at all.

## Test plan
- `go test ./internal/prompts/... ./internal/worker/ -run CodeReview`

🤖 Generated with [Claude Code](https://claude.com/claude-code)