### PR TITLE
Check live PR head on GitHub before publishing a code review

### DIFF
--- a/internal/prompts/templates/code_review_reviewer.template
+++ b/internal/prompts/templates/code_review_reviewer.template
@@ -18,7 +18,11 @@ Pull request: #{{.PullNumber}}{{if .PullRequestURL}} ({{.PullRequestURL}}){{end}
 Base SHA: {{.BaseSHA}}
 {{- end}}
 Head SHA: {{.HeadSHA}}
-Review exactly this pull request's changes{{if .BaseSHA}} (`git diff {{.BaseSHA}}...{{.HeadSHA}}`){{end}}, not whatever happens to be checked out. Confirm the workspace HEAD matches the head SHA before reviewing; if it does not, report the mismatch in your output instead of silently reviewing a different commit.
+Review exactly this pull request's changes, not whatever happens to be checked out. Workspace setup — fetching commits and detached checkouts are permitted and do not count as workspace modifications:
+1. Verify both SHAs exist locally (`git cat-file -e <sha>^{commit}`). Fetch any that are missing: `git fetch origin {{.HeadSHA}}`{{if .PullNumber}} (or `git fetch origin pull/{{.PullNumber}}/head`){{end}}{{if .BaseSHA}}; `git fetch origin {{.BaseSHA}}` for the base{{end}}.
+2. If the workspace HEAD does not match the head SHA, run `git checkout --detach {{.HeadSHA}}`. Only if the head SHA cannot be fetched at all, stop and report the mismatch in your output instead of reviewing a different commit.
+3. Diff against the merge base: `git diff $(git merge-base {{if .BaseSHA}}{{.BaseSHA}}{{else}}origin/HEAD{{end}} {{.HeadSHA}}) {{.HeadSHA}}`.{{if .BaseSHA}} If the base SHA is unavailable even after fetching (deleted or force-pushed base branch), substitute `origin/HEAD` for it.{{end}} If `git merge-base` fails, the clone may be shallow — run `git fetch --deepen=200 origin` and retry.
+4. Sanity-check the diff: it should touch the changed files listed below (when provided) and nothing unrelated. An implausibly large diff, or one missing those files, means the base is wrong — recompute the merge base before reviewing.
 {{- if .ChangedFiles}}
 Changed files:
 {{- range .ChangedFiles}}

--- a/internal/services/codereview/github_submitter.go
+++ b/internal/services/codereview/github_submitter.go
@@ -124,6 +124,17 @@ type RequestedReviewersRequest struct {
 	TeamReviewers  []string
 }
 
+type PullRequestHeadRequest struct {
+	InstallationID int64
+	Repository     string
+	PullNumber     int
+}
+
+type PullRequestHead struct {
+	HeadSHA string
+	BaseSHA string
+}
+
 func (s *GitHubSubmitter) SubmitReview(ctx context.Context, req SubmitReviewRequest) (SubmitReviewResult, error) {
 	if s == nil || s.tokens == nil {
 		return SubmitReviewResult{}, fmt.Errorf("github submitter is not configured")
@@ -651,6 +662,42 @@ func (s *GitHubSubmitter) ListPullRequestFiles(ctx context.Context, req PullRequ
 		path = nextPath
 	}
 	return files, nil
+}
+
+func (s *GitHubSubmitter) GetPullRequestHead(ctx context.Context, req PullRequestHeadRequest) (PullRequestHead, error) {
+	if s == nil || s.tokens == nil {
+		return PullRequestHead{}, fmt.Errorf("github submitter is not configured")
+	}
+	owner, repo, ok := strings.Cut(req.Repository, "/")
+	if !ok || owner == "" || repo == "" {
+		return PullRequestHead{}, fmt.Errorf("repository must be owner/name")
+	}
+	if req.PullNumber <= 0 {
+		return PullRequestHead{}, fmt.Errorf("pull number is required")
+	}
+	if req.InstallationID <= 0 {
+		return PullRequestHead{}, fmt.Errorf("installation id is required")
+	}
+	token, err := s.tokens.GetInstallationToken(ctx, req.InstallationID)
+	if err != nil {
+		return PullRequestHead{}, fmt.Errorf("get installation token: %w", err)
+	}
+	var payload struct {
+		Head struct {
+			SHA string `json:"sha"`
+		} `json:"head"`
+		Base struct {
+			SHA string `json:"sha"`
+		} `json:"base"`
+	}
+	path := fmt.Sprintf("/repos/%s/%s/pulls/%d", url.PathEscape(owner), url.PathEscape(repo), req.PullNumber)
+	if _, err := s.getGitHubJSONPage(ctx, token, path, &payload); err != nil {
+		return PullRequestHead{}, err
+	}
+	if payload.Head.SHA == "" {
+		return PullRequestHead{}, fmt.Errorf("GitHub pull request %s#%d has no head SHA", req.Repository, req.PullNumber)
+	}
+	return PullRequestHead{HeadSHA: payload.Head.SHA, BaseSHA: payload.Base.SHA}, nil
 }
 
 func (s *GitHubSubmitter) ListReviewContext(ctx context.Context, req ReviewContextRequest) (ReviewContext, error) {

--- a/internal/services/codereview/github_submitter_test.go
+++ b/internal/services/codereview/github_submitter_test.go
@@ -263,6 +263,54 @@ func TestGitHubSubmitter_SubmitReviewDoesNotReuseMarkedInlineCommentFromDifferen
 	}, result.Comments, "SubmitReview should return the newly posted comment with the original finding key")
 }
 
+func TestGitHubSubmitter_GetPullRequestHead(t *testing.T) {
+	t.Parallel()
+
+	var gotPath string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.RequestURI()
+		w.Header().Set("Content-Type", "application/json")
+		_, err := w.Write([]byte(`{"head":{"sha":"f315eeaf17eaf85e5793dbb738d71201e50f6beb"},"base":{"sha":"572f3a9793ade453d559ec2ae5367297514a9476"}}`))
+		require.NoError(t, err, "test response should write")
+	}))
+	defer server.Close()
+
+	submitter := NewGitHubSubmitter(&tokenStub{token: "ghs_token"}, WithGitHubSubmitterBaseURL(server.URL))
+
+	head, err := submitter.GetPullRequestHead(context.Background(), PullRequestHeadRequest{
+		InstallationID: 99,
+		Repository:     "acme/repo",
+		PullNumber:     42,
+	})
+
+	require.NoError(t, err, "GetPullRequestHead should load the pull request from GitHub")
+	require.Equal(t, "/repos/acme/repo/pulls/42", gotPath, "GetPullRequestHead should call the GitHub pull request endpoint")
+	require.Equal(t, PullRequestHead{
+		HeadSHA: "f315eeaf17eaf85e5793dbb738d71201e50f6beb",
+		BaseSHA: "572f3a9793ade453d559ec2ae5367297514a9476",
+	}, head, "GetPullRequestHead should decode the head and base SHAs")
+}
+
+func TestGitHubSubmitter_GetPullRequestHeadRejectsMissingHead(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, err := w.Write([]byte(`{}`))
+		require.NoError(t, err, "test response should write")
+	}))
+	defer server.Close()
+
+	submitter := NewGitHubSubmitter(&tokenStub{token: "ghs_token"}, WithGitHubSubmitterBaseURL(server.URL))
+
+	_, err := submitter.GetPullRequestHead(context.Background(), PullRequestHeadRequest{
+		InstallationID: 99,
+		Repository:     "acme/repo",
+		PullNumber:     42,
+	})
+	require.Error(t, err, "GetPullRequestHead should reject a response without a head SHA")
+}
+
 func TestGitHubSubmitter_ListPullRequestFiles(t *testing.T) {
 	t.Parallel()
 

--- a/internal/worker/code_review_handler.go
+++ b/internal/worker/code_review_handler.go
@@ -226,6 +226,21 @@ func newRunCodeReviewHandler(stores *Stores, services *Services, logger zerolog.
 		if cancelled, err := stopCodeReviewIfParentSessionCancelled(ctx, stores, services, logger, job, pr); cancelled || err != nil {
 			return err
 		}
+		// Last line of defense before publishing: the DB head only moves once
+		// the push webhook lands, so ask GitHub directly whether the PR still
+		// points at the head this review actually reviewed.
+		if liveHeadChanged, liveHeadChecked := codeReviewLiveHeadChanged(ctx, stores, services, logger, job, pr); liveHeadChecked && liveHeadChanged {
+			if _, staleErr := stores.CodeReviews.MarkStale(ctx, job.OrgID, job.SessionID, "PR head changed before the review could be published"); staleErr != nil {
+				return fmt.Errorf("mark code review stale before publish: %w", staleErr)
+			}
+			logger.Info().
+				Str("org_id", job.OrgID.String()).
+				Str("session_id", job.SessionID.String()).
+				Str("reviewed_head", job.HeadSHA).
+				Msg("marked code review stale: live PR head moved before publish")
+			reconcileCodeReviewSessionStale(ctx, stores, logger, job)
+			return nil
+		}
 		submission, submitted, err := submitCodeReviewToGitHub(ctx, stores, services, job, metadata, decision.Decision, body)
 		if err != nil {
 			return err
@@ -2193,6 +2208,51 @@ type codeReviewFileLister interface {
 
 type codeReviewContextLister interface {
 	ListReviewContext(ctx context.Context, req codereviewsvc.ReviewContextRequest) (codereviewsvc.ReviewContext, error)
+}
+
+type codeReviewHeadFetcher interface {
+	GetPullRequestHead(ctx context.Context, req codereviewsvc.PullRequestHeadRequest) (codereviewsvc.PullRequestHead, error)
+}
+
+// codeReviewLiveHeadChanged asks GitHub for the PR's current head SHA and
+// reports whether it has moved away from the head this review pinned. The DB
+// copy of the head only advances when the corresponding webhook has been
+// processed, so this closes the window where a force-push races the review.
+// Best-effort: checked=false when the service cannot do live lookups or the
+// lookup fails, so a GitHub flake can never wedge an otherwise-ready review.
+func codeReviewLiveHeadChanged(ctx context.Context, stores *Stores, services *Services, logger zerolog.Logger, job runCodeReviewPayload, pr models.PullRequest) (changed bool, checked bool) {
+	if services == nil || services.CodeReviews == nil {
+		return false, false
+	}
+	fetcher, ok := services.CodeReviews.(codeReviewHeadFetcher)
+	if !ok {
+		return false, false
+	}
+	if stores == nil || stores.Repositories == nil || pr.GitHubPRNumber <= 0 || strings.TrimSpace(job.HeadSHA) == "" {
+		return false, false
+	}
+	repo, err := stores.Repositories.GetByID(ctx, job.OrgID, job.RepositoryID)
+	if err != nil {
+		logger.Warn().Err(err).Str("session_id", job.SessionID.String()).Msg("skipping live code review head check: failed to load repository")
+		return false, false
+	}
+	if repo.InstallationID == 0 {
+		return false, false
+	}
+	repository := strings.TrimSpace(pr.GitHubRepo)
+	if repository == "" {
+		repository = strings.TrimSpace(repo.FullName)
+	}
+	head, err := fetcher.GetPullRequestHead(ctx, codereviewsvc.PullRequestHeadRequest{
+		InstallationID: repo.InstallationID,
+		Repository:     repository,
+		PullNumber:     pr.GitHubPRNumber,
+	})
+	if err != nil {
+		logger.Warn().Err(err).Str("session_id", job.SessionID.String()).Msg("skipping live code review head check: GitHub lookup failed")
+		return false, false
+	}
+	return head.HeadSHA != strings.TrimSpace(job.HeadSHA), true
 }
 
 func removeCodeReviewRequestedReviewer(ctx context.Context, stores *Stores, services *Services, logger zerolog.Logger, job runCodeReviewPayload, pr models.PullRequest) {

--- a/internal/worker/code_review_handler_test.go
+++ b/internal/worker/code_review_handler_test.go
@@ -186,6 +186,86 @@ func (s *capturingCodeReviewSubmitter) RemoveRequestedReviewers(_ context.Contex
 	return nil
 }
 
+type stubHeadCodeReviewSubmitter struct {
+	capturingCodeReviewSubmitter
+	head     codereview.PullRequestHead
+	err      error
+	requests []codereview.PullRequestHeadRequest
+}
+
+func (s *stubHeadCodeReviewSubmitter) GetPullRequestHead(_ context.Context, req codereview.PullRequestHeadRequest) (codereview.PullRequestHead, error) {
+	s.requests = append(s.requests, req)
+	return s.head, s.err
+}
+
+func TestCodeReviewLiveHeadChanged(t *testing.T) {
+	t.Parallel()
+
+	orgID := uuid.New()
+	sessionID := uuid.New()
+	repositoryID := uuid.New()
+	now := time.Date(2026, 7, 20, 12, 0, 0, 0, time.UTC)
+	job := runCodeReviewPayload{OrgID: orgID, SessionID: sessionID, RepositoryID: repositoryID, HeadSHA: "reviewed-head"}
+	pr := models.PullRequest{GitHubRepo: "acme/repo", GitHubPRNumber: 42}
+
+	expectRepositoryLookup := func(t *testing.T, mock pgxmock.PgxPoolIface) {
+		t.Helper()
+		mock.ExpectQuery("(?s)FROM repositories.*WHERE id = @id AND org_id = @org_id").
+			WithArgs(pgx.NamedArgs{"id": repositoryID, "org_id": orgID}).
+			WillReturnRows(workerRepositoryRows(models.Repository{
+				ID: repositoryID, OrgID: orgID, IntegrationID: uuid.New(), GitHubID: 42,
+				FullName: "acme/repo", DefaultBranch: "main", CloneURL: "https://github.com/acme/repo.git",
+				InstallationID: 143, Status: models.RepositoryStatusActive, Settings: json.RawMessage(`{}`),
+				CreatedAt: now, UpdatedAt: now,
+			}))
+	}
+
+	t.Run("service without live head support reports unchecked", func(t *testing.T) {
+		t.Parallel()
+		changed, checked := codeReviewLiveHeadChanged(context.Background(), &Stores{}, &Services{CodeReviews: &capturingCodeReviewSubmitter{}}, zerolog.Nop(), job, pr)
+		require.False(t, checked, "a submitter without head lookups should be reported as unchecked")
+		require.False(t, changed, "an unchecked head should never be reported as changed")
+	})
+
+	t.Run("moved live head reports changed", func(t *testing.T) {
+		t.Parallel()
+		mock, err := pgxmock.NewPool()
+		require.NoError(t, err, "mock pool should be created")
+		defer mock.Close()
+		expectRepositoryLookup(t, mock)
+		submitter := &stubHeadCodeReviewSubmitter{head: codereview.PullRequestHead{HeadSHA: "new-head"}}
+		changed, checked := codeReviewLiveHeadChanged(context.Background(), &Stores{Repositories: db.NewRepositoryStore(mock)}, &Services{CodeReviews: submitter}, zerolog.Nop(), job, pr)
+		require.True(t, checked, "a successful live lookup should be reported as checked")
+		require.True(t, changed, "a moved live head should be reported as changed")
+		require.Equal(t, []codereview.PullRequestHeadRequest{{InstallationID: 143, Repository: "acme/repo", PullNumber: 42}}, submitter.requests, "live head lookup should target the PR via the repository installation")
+		require.NoError(t, mock.ExpectationsWereMet(), "repository lookup should be performed")
+	})
+
+	t.Run("matching live head reports unchanged", func(t *testing.T) {
+		t.Parallel()
+		mock, err := pgxmock.NewPool()
+		require.NoError(t, err, "mock pool should be created")
+		defer mock.Close()
+		expectRepositoryLookup(t, mock)
+		submitter := &stubHeadCodeReviewSubmitter{head: codereview.PullRequestHead{HeadSHA: "reviewed-head"}}
+		changed, checked := codeReviewLiveHeadChanged(context.Background(), &Stores{Repositories: db.NewRepositoryStore(mock)}, &Services{CodeReviews: submitter}, zerolog.Nop(), job, pr)
+		require.True(t, checked, "a successful live lookup should be reported as checked")
+		require.False(t, changed, "a matching live head should not be reported as changed")
+	})
+
+	t.Run("lookup failure reports unchecked", func(t *testing.T) {
+		t.Parallel()
+		mock, err := pgxmock.NewPool()
+		require.NoError(t, err, "mock pool should be created")
+		defer mock.Close()
+		expectRepositoryLookup(t, mock)
+		submitter := &stubHeadCodeReviewSubmitter{err: errors.New("github unavailable")}
+		changed, checked := codeReviewLiveHeadChanged(context.Background(), &Stores{Repositories: db.NewRepositoryStore(mock)}, &Services{CodeReviews: submitter}, zerolog.Nop(), job, pr)
+		require.False(t, checked, "a failed live lookup should be reported as unchecked so it cannot wedge the review")
+		require.False(t, changed, "a failed live lookup should never be reported as changed")
+	})
+}
+
 func TestCodeReviewInlineComments(t *testing.T) {
 	t.Parallel()
 

--- a/internal/worker/code_review_handler_test.go
+++ b/internal/worker/code_review_handler_test.go
@@ -509,7 +509,11 @@ func TestCodeReviewReviewerPromptIncludesPullRequestTarget(t *testing.T) {
 	require.Contains(t, prompt, "Pull request: #53873", "reviewer prompt should identify the PR number")
 	require.Contains(t, prompt, "Base SHA: "+baseSHA, "reviewer prompt should pin the base SHA")
 	require.Contains(t, prompt, "Head SHA: "+job.HeadSHA, "reviewer prompt should pin the head SHA")
-	require.Contains(t, prompt, "git diff "+baseSHA+"..."+job.HeadSHA, "reviewer prompt should spell out the diff range")
+	require.Contains(t, prompt, "git diff $(git merge-base "+baseSHA+" "+job.HeadSHA+") "+job.HeadSHA, "reviewer prompt should spell out the merge-base diff command")
+	require.Contains(t, prompt, "git fetch origin "+job.HeadSHA, "reviewer prompt should tell the reviewer how to fetch a missing head SHA")
+	require.Contains(t, prompt, "git fetch origin pull/53873/head", "reviewer prompt should offer the PR ref as a fetch fallback")
+	require.Contains(t, prompt, "git checkout --detach "+job.HeadSHA, "reviewer prompt should permit a detached checkout of the head SHA")
+	require.Contains(t, prompt, "substitute `origin/HEAD`", "reviewer prompt should offer a fallback when the base SHA is unreachable")
 	require.Contains(t, prompt, "report the mismatch", "reviewer prompt should require reporting a workspace/head mismatch")
 	require.Contains(t, prompt, "- gocode/timeutils/interval.go", "reviewer prompt should list changed files")
 


### PR DESCRIPTION
## Summary
Stacked on #1883.

The stale-head guard compared the reviewed head against the DB copy of the PR, which only advances once the push webhook has been processed. A force-push racing the review could slip through both checkpoints and get a review published against a head the PR no longer points at.

This asks GitHub directly for the PR's current head right before submitting the review; if it moved, the review is marked stale and reconciled instead of published.

- New `GetPullRequestHead` on `GitHubSubmitter` (`GET /repos/{owner}/{repo}/pulls/{n}`)
- Optional `codeReviewHeadFetcher` interface in the worker, following the existing `codeReviewFileLister` pattern — services and test fakes without the method are unaffected
- Best-effort: a failed or unavailable lookup is logged and skipped so a GitHub flake can never wedge an otherwise-ready review
- Deliberately NOT added to the per-poll staleness check (runs every 5-10s per review; would burn API rate limit) — the DB-backed check continues to cover that path

## Test plan
- `go test ./internal/worker/ ./internal/services/codereview/ -count=1`
- New unit tests: `TestGitHubSubmitter_GetPullRequestHead`, `TestCodeReviewLiveHeadChanged`

🤖 Generated with [Claude Code](https://claude.com/claude-code)