### PR TITLE
Make automated approval independent of human review activity

### DIFF
--- a/docs/design/implemented/112-code-reviewer-bot-auto-approval.md
+++ b/docs/design/implemented/112-code-reviewer-bot-auto-approval.md
@@ -24,7 +24,7 @@ Implemented:
 - service-layer code review request orchestration that resolves/materializes policy, marks stale older heads, reuses running sessions, creates normal code-review sessions, and enqueues `run_code_review`
 - `run_code_review` worker handler that loads the captured policy version, fans out read-only reviewer threads running native `/review`, synthesizes via an orchestrator thread, records agent results, submits a GitHub review when the worker has GitHub credentials, and stores the GitHub review id/url
 - live reviewer/orchestrator evidence ingestion harvested from running review threads rather than pre-existing stored result rows
-- evidence-gated approval path that evaluates reviewer results, blocking findings, PR health, reviewed head SHA, required check state, changed-file size/path/category context from GitHub, unresolved human review threads, and the captured policy before choosing approval vs comment-only
+- evidence-gated approval path that evaluates reviewer results, blocking findings, PR health, reviewed head SHA, required check state, changed-file size/path/category context from GitHub, and the captured policy before choosing approval vs comment-only
 - LLM-backed PR description requirement evaluation with prompt-injection screening
 - prompt artifact storage and recovery for rendered reviewer/orchestrator/description prompts and their structured outputs
 - inline-comment posting with marker-based dedupe/update and posted-comment id persistence
@@ -320,7 +320,8 @@ Configurable deterministic signals:
 - PR description passes required sections
 - branch is mergeable and up to date according to policy
 - author is in an eligible role or team
-- no unresolved human review threads
+
+Existing human comments, review decisions, and open or resolved review threads are deliberately not risk signals. The bot evaluates the current pull request independently.
 
 Configurable synthesized signals:
 
@@ -388,11 +389,12 @@ Approval requires all of these by default:
 
 - PR head SHA still matches the reviewed SHA at submission time.
 - No blocking GitHub checks are failing.
-- No unresolved human blocking review exists.
 - No reviewer-agent blocking finding exists.
 - Orchestrator classifies the PR as acceptable under the active risk policy.
 - Policy allows approval for this repository, author class, and changed paths.
 - The bot has not already approved a stale previous head.
+
+Existing human comments, review decisions, and unresolved review threads are excluded from the bot's approval decision. GitHub branch protection and merge rules remain authoritative independently.
 
 The bot should not approve:
 

--- a/docs/design/implemented/117-code-review-policy-simplification.md
+++ b/docs/design/implemented/117-code-review-policy-simplification.md
@@ -188,6 +188,8 @@ Require human review when:
 - the change introduces a new architectural pattern or crosses unclear ownership boundaries
 - reviewers disagree or the risk cannot be evaluated confidently
 - the intended behavior cannot be determined from the pull request and repository context
+
+Evaluate the pull request independently. Disregard existing human review comments, review decisions, and review threads, whether open or resolved. Unresolved human review threads must not count against approval.
 ```
 
 The automated approval policy guides the orchestrator's recommendation. It can make the outcome more conservative, but it cannot bypass deterministic safeguards. Passing checks, size thresholds, sensitive or blocked paths, fork restrictions, reviewer quorum, disagreement handling, and every other hard gate retain final veto power.

--- a/docs/public/guides/code-review-policy.mdx
+++ b/docs/public/guides/code-review-policy.mdx
@@ -26,6 +26,8 @@ Turning code reviews off pauses new reviewer-triggered runs without forgetting t
 
 **Automated approval policy** guides only the orchestrator's approve-or-escalate recommendation. It cannot override passing checks, path restrictions, size limits, quorum, disagreement handling, fork restrictions, or other deterministic safeguards.
 
+143 evaluates the current pull request independently of existing human review activity. Human comments, review decisions, and open or resolved review threads—including unresolved change requests—do not become findings or block 143's approval. Repository branch protection and merge rules still apply independently on GitHub.
+
 Use a prompt example when it matches your intent. Previewing and applying an example replaces only its corresponding prompt; it never changes enablement, outcome, reviewers, paths, thresholds, or safety gates. Advanced policy presets are different: they replace the complete policy, including safeguards and agent settings.
 
 ## Use repository inheritance

--- a/frontend/src/app/(dashboard)/code-reviews/page.tsx
+++ b/frontend/src/app/(dashboard)/code-reviews/page.tsx
@@ -104,7 +104,9 @@ Require human review when:
 - the change affects authentication, billing, permissions, infrastructure, or production data
 - the change introduces a new architectural pattern or crosses unclear ownership boundaries
 - reviewers disagree or the risk cannot be evaluated confidently
-- the intended behavior cannot be determined from the pull request and repository context`;
+- the intended behavior cannot be determined from the pull request and repository context
+
+Evaluate the pull request independently. Disregard existing human review comments, review decisions, and review threads, whether open or resolved. Unresolved human review threads must not count against approval.`;
 const APPLICABILITY_KIND_LABELS: Record<CodeReviewDescriptionApplicabilityKind, string> = {
   all: "All PRs",
   nontrivial: "Nontrivial",

--- a/internal/models/code_review.go
+++ b/internal/models/code_review.go
@@ -429,6 +429,10 @@ func codeReviewPolicyFieldError(field, message string) error {
 	return &CodeReviewPolicyValidationError{Field: field, Message: message}
 }
 
+const codeReviewIndependentApprovalPolicy = `
+
+Evaluate the pull request independently. Disregard existing human review comments, review decisions, and review threads, whether open or resolved. Unresolved human review threads must not count against approval.`
+
 const DefaultCodeReviewAutomatedApprovalPolicy = `Automatically approve routine, well-tested changes when:
 - the intent is clear and the change has a small, understandable scope
 - there are no blocking findings
@@ -439,7 +443,7 @@ Require human review when:
 - the change affects authentication, billing, permissions, infrastructure, or production data
 - the change introduces a new architectural pattern or crosses unclear ownership boundaries
 - reviewers disagree or the risk cannot be evaluated confidently
-- the intended behavior cannot be determined from the pull request and repository context`
+- the intended behavior cannot be determined from the pull request and repository context` + codeReviewIndependentApprovalPolicy
 
 type CodeReviewPolicyInheritance struct {
 	InheritOrgDefaults bool     `json:"inherit_org_defaults"`
@@ -1008,8 +1012,8 @@ func CodeReviewPromptExamples() []CodeReviewPromptExampleOption {
 func CodeReviewAutomatedApprovalExamples() []CodeReviewAutomatedApprovalExampleOption {
 	return []CodeReviewAutomatedApprovalExampleOption{
 		{Key: CodeReviewAutomatedApprovalExampleConservative, Title: "Conservative low-risk approval", Description: "Approve routine changes and escalate uncertainty.", Policy: DefaultCodeReviewAutomatedApprovalPolicy},
-		{Key: CodeReviewAutomatedApprovalExampleDocumentation, Title: "Documentation-only approval", Description: "Approve clear documentation changes while escalating executable or generated changes.", Policy: "Automatically approve clear, accurate documentation-only changes when they match the implementation and contain no executable, configuration, generated, or security-sensitive changes.\n\nRequire human review whenever the change affects runtime behavior, configuration, generated files, permissions, secrets, or the intended documentation behavior is ambiguous."},
-		{Key: CodeReviewAutomatedApprovalExampleSmallRoutine, Title: "Small routine changes", Description: "Approve narrow changes that follow established patterns with proportionate tests.", Policy: "Automatically approve small, narrowly scoped changes that follow established repository patterns, have no blocking findings, and include test evidence proportionate to their risk.\n\nRequire human review for architectural changes, sensitive areas, unclear intent, reviewer disagreement, weak evidence, or any change whose impact cannot be evaluated confidently."},
+		{Key: CodeReviewAutomatedApprovalExampleDocumentation, Title: "Documentation-only approval", Description: "Approve clear documentation changes while escalating executable or generated changes.", Policy: "Automatically approve clear, accurate documentation-only changes when they match the implementation and contain no executable, configuration, generated, or security-sensitive changes.\n\nRequire human review whenever the change affects runtime behavior, configuration, generated files, permissions, secrets, or the intended documentation behavior is ambiguous." + codeReviewIndependentApprovalPolicy},
+		{Key: CodeReviewAutomatedApprovalExampleSmallRoutine, Title: "Small routine changes", Description: "Approve narrow changes that follow established patterns with proportionate tests.", Policy: "Automatically approve small, narrowly scoped changes that follow established repository patterns, have no blocking findings, and include test evidence proportionate to their risk.\n\nRequire human review for architectural changes, sensitive areas, unclear intent, reviewer disagreement, weak evidence, or any change whose impact cannot be evaluated confidently." + codeReviewIndependentApprovalPolicy},
 	}
 }
 
@@ -1108,41 +1112,42 @@ func templatePolicy(base CodeReviewPolicyConfig, opts templatePolicyOptions) Cod
 }
 
 type CodeReviewRiskInput struct {
-	FilesChanged           int
-	LinesChanged           int
-	ChangedPaths           []string
-	Categories             []string
-	ChecksPassing          bool
-	RequiredChecksPassing  map[string]bool
-	DescriptionPassed      bool
-	UpToDate               bool
-	Author                 string
-	AuthorClass            string
-	FromFork               bool
-	UnresolvedHumanThreads int
-	BlockingFindings       int
-	ReviewerDisagreement   bool
-	ScopeMismatch          bool
-	UnresolvedUncertainty  bool
-	PromptInjectionFound   bool
-	ContextFetchFailed     bool
-	HeadSHAChanged         bool
+	FilesChanged          int
+	LinesChanged          int
+	ChangedPaths          []string
+	Categories            []string
+	ChecksPassing         bool
+	RequiredChecksPassing map[string]bool
+	DescriptionPassed     bool
+	UpToDate              bool
+	Author                string
+	AuthorClass           string
+	FromFork              bool
+	BlockingFindings      int
+	ReviewerDisagreement  bool
+	ScopeMismatch         bool
+	UnresolvedUncertainty bool
+	PromptInjectionFound  bool
+	ContextFetchFailed    bool
+	HeadSHAChanged        bool
 }
 
 type CodeReviewRiskReasonCode string
 
 const (
-	CodeReviewRiskReasonReviewerDisabled             CodeReviewRiskReasonCode = "reviewer_disabled"
-	CodeReviewRiskReasonContextUnavailable           CodeReviewRiskReasonCode = "context_unavailable"
-	CodeReviewRiskReasonHeadChanged                  CodeReviewRiskReasonCode = "head_changed"
-	CodeReviewRiskReasonFilesLimitExceeded           CodeReviewRiskReasonCode = "files_limit_exceeded"
-	CodeReviewRiskReasonLinesLimitExceeded           CodeReviewRiskReasonCode = "lines_limit_exceeded"
-	CodeReviewRiskReasonChecksFailing                CodeReviewRiskReasonCode = "checks_failing"
-	CodeReviewRiskReasonRequiredCheckFailing         CodeReviewRiskReasonCode = "required_check_failing"
-	CodeReviewRiskReasonDescriptionFailed            CodeReviewRiskReasonCode = "description_failed"
-	CodeReviewRiskReasonBranchOutOfDate              CodeReviewRiskReasonCode = "branch_out_of_date"
-	CodeReviewRiskReasonForkIneligible               CodeReviewRiskReasonCode = "fork_ineligible"
-	CodeReviewRiskReasonAuthorIneligible             CodeReviewRiskReasonCode = "author_ineligible"
+	CodeReviewRiskReasonReviewerDisabled     CodeReviewRiskReasonCode = "reviewer_disabled"
+	CodeReviewRiskReasonContextUnavailable   CodeReviewRiskReasonCode = "context_unavailable"
+	CodeReviewRiskReasonHeadChanged          CodeReviewRiskReasonCode = "head_changed"
+	CodeReviewRiskReasonFilesLimitExceeded   CodeReviewRiskReasonCode = "files_limit_exceeded"
+	CodeReviewRiskReasonLinesLimitExceeded   CodeReviewRiskReasonCode = "lines_limit_exceeded"
+	CodeReviewRiskReasonChecksFailing        CodeReviewRiskReasonCode = "checks_failing"
+	CodeReviewRiskReasonRequiredCheckFailing CodeReviewRiskReasonCode = "required_check_failing"
+	CodeReviewRiskReasonDescriptionFailed    CodeReviewRiskReasonCode = "description_failed"
+	CodeReviewRiskReasonBranchOutOfDate      CodeReviewRiskReasonCode = "branch_out_of_date"
+	CodeReviewRiskReasonForkIneligible       CodeReviewRiskReasonCode = "fork_ineligible"
+	CodeReviewRiskReasonAuthorIneligible     CodeReviewRiskReasonCode = "author_ineligible"
+	// CodeReviewRiskReasonUnresolvedHumanReview is retained so historical decisions remain renderable.
+	// New risk evaluations deliberately do not emit it.
 	CodeReviewRiskReasonUnresolvedHumanReview        CodeReviewRiskReasonCode = "unresolved_human_review"
 	CodeReviewRiskReasonBlockingFindings             CodeReviewRiskReasonCode = "blocking_findings"
 	CodeReviewRiskReasonReviewerDisagreement         CodeReviewRiskReasonCode = "reviewer_disagreement"
@@ -1338,9 +1343,6 @@ func EvaluateCodeReviewRisk(policy CodeReviewPolicyConfig, input CodeReviewRiskI
 	}
 	if len(policy.RiskPolicy.EligibleAuthors) > 0 && !codeReviewAuthorAllowed(input.Author, input.AuthorClass, policy.RiskPolicy.EligibleAuthors) {
 		risk.AddReason(CodeReviewRiskReason{Code: CodeReviewRiskReasonAuthorIneligible})
-	}
-	if input.UnresolvedHumanThreads > 0 {
-		risk.AddReason(CodeReviewRiskReason{Code: CodeReviewRiskReasonUnresolvedHumanReview})
 	}
 	if input.BlockingFindings > 0 {
 		risk.AddReason(CodeReviewRiskReason{Code: CodeReviewRiskReasonBlockingFindings})

--- a/internal/models/code_review_test.go
+++ b/internal/models/code_review_test.go
@@ -71,6 +71,7 @@ func TestDefaultCodeReviewPolicyConfig(t *testing.T) {
 	config := DefaultCodeReviewPolicyConfig()
 	require.Empty(t, config.ReviewInstructions, "default review instructions should preserve native review behavior")
 	require.Equal(t, DefaultCodeReviewAutomatedApprovalPolicy, config.AutomatedApprovalPolicy, "default approval policy should be conservative")
+	require.Contains(t, config.AutomatedApprovalPolicy, "Unresolved human review threads must not count against approval.", "default approval policy should require an independent decision")
 
 	require.Equal(t, CodeReviewApprovalModeCommentOnly, config.ApprovalMode, "code reviewer should default to comment-only mode")
 	require.True(t, config.Enabled, "code reviewer should default enabled so explicit reviewer requests are honored")
@@ -221,6 +222,7 @@ func TestCodeReviewPolicyTemplates(t *testing.T) {
 
 			require.NotEmpty(t, template.Title, "template should have a display title")
 			require.Equal(t, CodeReviewApprovalModeApproveAcceptable, template.Config.ApprovalMode, "starter templates should be editable approval policies")
+			require.Contains(t, template.Config.AutomatedApprovalPolicy, "Unresolved human review threads must not count against approval.", "starter templates should require an independent decision")
 			require.NoError(t, template.Config.Validate(), "template config should be valid")
 		})
 	}
@@ -250,16 +252,15 @@ func TestEvaluateCodeReviewRisk(t *testing.T) {
 		{
 			name: "blocks oversized sensitive fork with agent concerns",
 			input: CodeReviewRiskInput{
-				FilesChanged:           6,
-				LinesChanged:           350,
-				ChangedPaths:           []string{"internal/auth/session.go"},
-				Categories:             []string{"auth"},
-				ChecksPassing:          false,
-				DescriptionPassed:      false,
-				FromFork:               true,
-				UnresolvedHumanThreads: 1,
-				BlockingFindings:       1,
-				ReviewerDisagreement:   true,
+				FilesChanged:         6,
+				LinesChanged:         350,
+				ChangedPaths:         []string{"internal/auth/session.go"},
+				Categories:           []string{"auth"},
+				ChecksPassing:        false,
+				DescriptionPassed:    false,
+				FromFork:             true,
+				BlockingFindings:     1,
+				ReviewerDisagreement: true,
 			},
 			expected: codeReviewRiskEvaluationForTest(
 				CodeReviewRiskReason{Code: CodeReviewRiskReasonFilesLimitExceeded, Actual: 6, Limit: 5},
@@ -267,7 +268,6 @@ func TestEvaluateCodeReviewRisk(t *testing.T) {
 				CodeReviewRiskReason{Code: CodeReviewRiskReasonChecksFailing},
 				CodeReviewRiskReason{Code: CodeReviewRiskReasonDescriptionFailed},
 				CodeReviewRiskReason{Code: CodeReviewRiskReasonForkIneligible},
-				CodeReviewRiskReason{Code: CodeReviewRiskReasonUnresolvedHumanReview},
 				CodeReviewRiskReason{Code: CodeReviewRiskReasonBlockingFindings},
 				CodeReviewRiskReason{Code: CodeReviewRiskReasonReviewerDisagreement},
 				CodeReviewRiskReason{Code: CodeReviewRiskReasonSensitivePath, Subject: "internal/auth/session.go"},
@@ -623,6 +623,9 @@ func TestCodeReviewPromptExamples(t *testing.T) {
 	require.Equal(t, DefaultCodeReviewAutomatedApprovalPolicy, approval[0].Policy, "the conservative example should match the built-in approval policy")
 	for _, example := range append([]CodeReviewPromptExampleOption(nil), review...) {
 		require.NotEmpty(t, example.Instructions, "every review example should contain usable instructions")
+	}
+	for _, example := range append([]CodeReviewAutomatedApprovalExampleOption(nil), approval...) {
+		require.Contains(t, example.Policy, "Unresolved human review threads must not count against approval.", "every approval example should require an independent decision")
 	}
 }
 

--- a/internal/prompts/prompts.go
+++ b/internal/prompts/prompts.go
@@ -366,7 +366,6 @@ type CodeReviewOrchestratorPromptData struct {
 	ReviewerOutputs            []string
 	Findings                   []string
 	ChangedFiles               []string
-	Checklist                  []string
 	ReviewInstructions         string
 	AutomatedApprovalPolicy    string
 	UseAutomatedApprovalPolicy bool

--- a/internal/prompts/templates/code_review_orchestrator.template
+++ b/internal/prompts/templates/code_review_orchestrator.template
@@ -64,14 +64,7 @@ Findings:
 - none
 {{- end}}
 
-Checklist:
-{{- range .Checklist}}
-- {{.}}
-{{- else}}
-- unavailable
-{{- end}}
-
-You own the final reviewer-facing comments and risk assessment. Use the reviewer outputs as evidence only; do not assume they used 143's directive format. Reconcile their findings with the deterministic risk reasons, changed files, description results, and checklist. Base the risk assessment solely on the evidence supplied in this prompt: disregard pre-existing PR discussion — issue comments, review comments, and review threads, open or resolved — that is not part of the PR description. Prior commentary and unresolved threads are not findings and must not lower the recommendation or block approval.
+You own the final reviewer-facing comments and risk assessment. Use the reviewer outputs as evidence only; do not assume they used 143's directive format. Reconcile their findings with the deterministic risk reasons, changed files, and description results. Base the risk assessment solely on the evidence supplied in this prompt: disregard pre-existing PR discussion — issue comments, review comments, and review threads, open or resolved — that is not part of the PR description. Prior commentary and unresolved threads are not findings and must not lower the recommendation or block approval.
 
 For each actionable line-specific issue that should become a GitHub inline comment, emit exactly one directive in this form:
 ::code-comment{title="[P2] Short issue title" body="Explain the concrete scenario and fix." file="path/from/repo/root.go" start=123 end=123 priority=2}

--- a/internal/worker/code_review_handler.go
+++ b/internal/worker/code_review_handler.go
@@ -148,10 +148,6 @@ func newRunCodeReviewHandler(stores *Stores, services *Services, logger zerolog.
 		if err != nil {
 			return err
 		}
-		reviewContext, reviewContextChecked, reviewContextAvailable, err := loadCodeReviewReviewContext(ctx, stores, services, job, pr)
-		if err != nil {
-			return err
-		}
 		if codeReviewCanRunReviewerThreads(stores) {
 			if err := ensureCodeReviewReviewerThreads(ctx, stores, services, logger, job, pr, policy, metadata, changedFiles); err != nil {
 				return err
@@ -176,7 +172,7 @@ func newRunCodeReviewHandler(stores *Stores, services *Services, logger zerolog.
 			if codeReviewReviewerExecutionFailed(policy.Config(), agentResults) {
 				return failCodeReviewWithoutReviewerOutput(ctx, stores, services, logger, job, pr, agentResults)
 			}
-			if err := ensureCodeReviewOrchestratorThread(ctx, stores, services, logger, job, pr, health, policy, metadata, changedFiles, descriptionEvaluation, reviewContext, reviewContextAvailable, agentResults, findings); err != nil {
+			if err := ensureCodeReviewOrchestratorThread(ctx, stores, services, logger, job, pr, health, policy, metadata, changedFiles, descriptionEvaluation, agentResults, findings); err != nil {
 				return err
 			}
 			if err := harvestCodeReviewOrchestratorResult(ctx, stores, services, logger, job, policy, metadata, changedFiles); err != nil {
@@ -205,20 +201,17 @@ func newRunCodeReviewHandler(stores *Stores, services *Services, logger zerolog.
 			return err
 		}
 		decision, body := evaluateLiveCodeReviewOutcome(liveCodeReviewOutcomeInput{
-			Policy:                 policy.Config(),
-			Job:                    job,
-			SessionURL:             codeReviewSessionURL(services.FrontendURL, job.SessionID),
-			PullRequest:            pr,
-			Health:                 health,
-			AgentResults:           agentResults,
-			Findings:               findings,
-			ChangedFiles:           changedFiles,
-			ChangedFilesAvailable:  changedFilesAvailable,
-			DescriptionEvaluation:  descriptionEvaluation,
-			ReviewContext:          reviewContext,
-			ReviewContextChecked:   reviewContextChecked,
-			ReviewContextAvailable: reviewContextAvailable,
-			OrchestratorSynthesis:  codeReviewOrchestratorSynthesisFromResults(agentResults),
+			Policy:                policy.Config(),
+			Job:                   job,
+			SessionURL:            codeReviewSessionURL(services.FrontendURL, job.SessionID),
+			PullRequest:           pr,
+			Health:                health,
+			AgentResults:          agentResults,
+			Findings:              findings,
+			ChangedFiles:          changedFiles,
+			ChangedFilesAvailable: changedFilesAvailable,
+			DescriptionEvaluation: descriptionEvaluation,
+			OrchestratorSynthesis: codeReviewOrchestratorSynthesisFromResults(agentResults),
 		})
 		if err := ensureCodeReviewInlineSelection(ctx, stores.CodeReviews, job, findings, changedFiles, policy.Config().InlineCommentLimit); err != nil {
 			return fmt.Errorf("select code review inline findings: %w", err)
@@ -1207,11 +1200,7 @@ func codeReviewReviewerPrompt(job runCodeReviewPayload, pr models.PullRequest, c
 	}))
 }
 
-func codeReviewOrchestratorPrompt(job runCodeReviewPayload, pr models.PullRequest, health *models.PullRequestHealthResponse, cfg models.CodeReviewPolicyConfig, policyVersion int, baseSHA string, changedFiles []codereviewsvc.PullRequestFile, description codeReviewDescriptionEvaluation, reviewContext *codereviewsvc.ReviewContext, reviewContextAvailable bool, agentResults []models.CodeReviewAgentResult, findings []models.CodeReviewFinding) string {
-	reviewContextSummary := "GitHub review context unavailable"
-	if reviewContextAvailable && reviewContext != nil {
-		reviewContextSummary = fmt.Sprintf("Unresolved human threads: %d; blocking human reviews: %d", reviewContext.UnresolvedHumanThreads, reviewContext.BlockingHumanReviews)
-	}
+func codeReviewOrchestratorPrompt(job runCodeReviewPayload, pr models.PullRequest, health *models.PullRequestHealthResponse, cfg models.CodeReviewPolicyConfig, policyVersion int, baseSHA string, changedFiles []codereviewsvc.PullRequestFile, description codeReviewDescriptionEvaluation, agentResults []models.CodeReviewAgentResult, findings []models.CodeReviewFinding) string {
 	return prompts.CodeReviewOrchestratorPrompt(prompts.CodeReviewOrchestratorPromptData{
 		Repository:                 pr.GitHubRepo,
 		PullNumber:                 pr.GitHubPRNumber,
@@ -1225,45 +1214,39 @@ func codeReviewOrchestratorPrompt(job runCodeReviewPayload, pr models.PullReques
 		RequiredReviewerQuorum:     codeReviewRequiredReviewerQuorum(cfg, agentResults),
 		InlineCommentLimit:         cfg.InlineCommentLimit,
 		DescriptionResults:         append([]string(nil), description.RequirementSummaries...),
-		RiskReasons:                models.CodeReviewRiskReasonMessages(codeReviewPromptRiskReasons(job, pr, health, cfg, changedFiles, description, reviewContext, reviewContextAvailable, agentResults, findings)),
+		RiskReasons:                models.CodeReviewRiskReasonMessages(codeReviewPromptRiskReasons(job, pr, health, cfg, changedFiles, description, agentResults, findings)),
 		ReviewerOutputs:            codeReviewReviewerOutputsForPrompt(agentResults),
 		Findings:                   codeReviewFindingsForPrompt(findings),
 		ChangedFiles:               codeReviewChangedPaths(changedFiles),
-		Checklist:                  []string{reviewContextSummary},
 		ReviewInstructions:         cfg.ReviewInstructions,
 		AutomatedApprovalPolicy:    cfg.AutomatedApprovalPolicy,
 		UseAutomatedApprovalPolicy: cfg.ApprovalMode == models.CodeReviewApprovalModeApproveAcceptable,
 	})
 }
 
-func codeReviewPromptRiskReasons(job runCodeReviewPayload, pr models.PullRequest, health *models.PullRequestHealthResponse, cfg models.CodeReviewPolicyConfig, changedFiles []codereviewsvc.PullRequestFile, description codeReviewDescriptionEvaluation, reviewContext *codereviewsvc.ReviewContext, reviewContextAvailable bool, agentResults []models.CodeReviewAgentResult, findings []models.CodeReviewFinding) []models.CodeReviewRiskReason {
+func codeReviewPromptRiskReasons(job runCodeReviewPayload, pr models.PullRequest, health *models.PullRequestHealthResponse, cfg models.CodeReviewPolicyConfig, changedFiles []codereviewsvc.PullRequestFile, description codeReviewDescriptionEvaluation, agentResults []models.CodeReviewAgentResult, findings []models.CodeReviewFinding) []models.CodeReviewRiskReason {
 	reviewerQuorum, _ := codeReviewReviewerEvidence(agentResults)
 	descriptionPassed := description.Passed
 	if len(description.RequirementSummaries) == 0 {
 		descriptionPassed = codeReviewDescriptionPassed(cfg, pr, changedFiles)
 	}
-	unresolvedHumanThreads := codeReviewUnresolvedHumanThreads(pr)
-	if reviewContext != nil {
-		unresolvedHumanThreads += reviewContext.UnresolvedHumanThreads + reviewContext.BlockingHumanReviews
-	}
 	risk := models.EvaluateCodeReviewRisk(cfg, models.CodeReviewRiskInput{
-		FilesChanged:           len(changedFiles),
-		LinesChanged:           codeReviewLinesChanged(changedFiles),
-		ChangedPaths:           codeReviewChangedPaths(changedFiles),
-		Categories:             codeReviewChangedCategories(changedFiles),
-		ChecksPassing:          codeReviewChecksPassing(cfg, health),
-		RequiredChecksPassing:  codeReviewRequiredChecksPassing(cfg, health),
-		DescriptionPassed:      descriptionPassed,
-		UpToDate:               codeReviewUpToDate(health),
-		Author:                 codeReviewAuthor(job, pr),
-		AuthorClass:            codeReviewAuthorClass(pr),
-		FromFork:               job.FromFork,
-		ContextFetchFailed:     health == nil || !reviewContextAvailable,
-		HeadSHAChanged:         codeReviewHeadChanged(job.HeadSHA, pr, health),
-		BlockingFindings:       codeReviewBlockingFindings(findings),
-		ReviewerDisagreement:   false,
-		UnresolvedHumanThreads: unresolvedHumanThreads,
-		PromptInjectionFound:   description.PromptInjectionFound,
+		FilesChanged:          len(changedFiles),
+		LinesChanged:          codeReviewLinesChanged(changedFiles),
+		ChangedPaths:          codeReviewChangedPaths(changedFiles),
+		Categories:            codeReviewChangedCategories(changedFiles),
+		ChecksPassing:         codeReviewChecksPassing(cfg, health),
+		RequiredChecksPassing: codeReviewRequiredChecksPassing(cfg, health),
+		DescriptionPassed:     descriptionPassed,
+		UpToDate:              codeReviewUpToDate(health),
+		Author:                codeReviewAuthor(job, pr),
+		AuthorClass:           codeReviewAuthorClass(pr),
+		FromFork:              job.FromFork,
+		ContextFetchFailed:    health == nil,
+		HeadSHAChanged:        codeReviewHeadChanged(job.HeadSHA, pr, health),
+		BlockingFindings:      codeReviewBlockingFindings(findings),
+		ReviewerDisagreement:  false,
+		PromptInjectionFound:  description.PromptInjectionFound,
 	})
 	requiredReviewerQuorum := codeReviewRequiredReviewerQuorum(cfg, agentResults)
 	if reviewerQuorum < requiredReviewerQuorum && !codeReviewLowRiskQuorumWaived(cfg, changedFiles) {
@@ -1752,7 +1735,7 @@ func codeReviewWaitingForReviewers(policy models.CodeReviewPolicyConfig) error {
 	}
 }
 
-func ensureCodeReviewOrchestratorThread(ctx context.Context, stores *Stores, services *Services, logger zerolog.Logger, job runCodeReviewPayload, pr models.PullRequest, health *models.PullRequestHealthResponse, policy models.CodeReviewPolicyRecord, metadata models.CodeReviewSessionMetadata, changedFiles []codereviewsvc.PullRequestFile, description codeReviewDescriptionEvaluation, reviewContext *codereviewsvc.ReviewContext, reviewContextAvailable bool, agentResults []models.CodeReviewAgentResult, findings []models.CodeReviewFinding) error {
+func ensureCodeReviewOrchestratorThread(ctx context.Context, stores *Stores, services *Services, logger zerolog.Logger, job runCodeReviewPayload, pr models.PullRequest, health *models.PullRequestHealthResponse, policy models.CodeReviewPolicyRecord, metadata models.CodeReviewSessionMetadata, changedFiles []codereviewsvc.PullRequestFile, description codeReviewDescriptionEvaluation, agentResults []models.CodeReviewAgentResult, findings []models.CodeReviewFinding) error {
 	for _, result := range agentResults {
 		if result.Role == models.CodeReviewAgentRoleOrchestrator {
 			return nil
@@ -1807,7 +1790,7 @@ func ensureCodeReviewOrchestratorThread(ctx context.Context, stores *Stores, ser
 	}
 	rootKey := codeReviewPromptArtifactRoot(metadata, job)
 	artifactKey := fmt.Sprintf("%s/orchestrator-%s", rootKey, agentType)
-	promptText := codeReviewOrchestratorPrompt(job, pr, health, cfg, policy.Version, metadata.BaseSHA, changedFiles, description, reviewContext, reviewContextAvailable, agentResults, findings)
+	promptText := codeReviewOrchestratorPrompt(job, pr, health, cfg, policy.Version, metadata.BaseSHA, changedFiles, description, agentResults, findings)
 	if err := storeCodeReviewPromptArtifact(ctx, stores, models.CodeReviewPromptArtifact{
 		OrgID:         job.OrgID,
 		SessionID:     job.SessionID,
@@ -2106,20 +2089,17 @@ type codeReviewRequestedReviewerRemover interface {
 }
 
 type liveCodeReviewOutcomeInput struct {
-	Policy                 models.CodeReviewPolicyConfig
-	Job                    runCodeReviewPayload
-	SessionURL             string
-	PullRequest            models.PullRequest
-	Health                 *models.PullRequestHealthResponse
-	AgentResults           []models.CodeReviewAgentResult
-	Findings               []models.CodeReviewFinding
-	ChangedFiles           []codereviewsvc.PullRequestFile
-	ChangedFilesAvailable  bool
-	DescriptionEvaluation  codeReviewDescriptionEvaluation
-	ReviewContext          *codereviewsvc.ReviewContext
-	ReviewContextChecked   bool
-	ReviewContextAvailable bool
-	OrchestratorSynthesis  codeReviewOrchestratorSynthesis
+	Policy                models.CodeReviewPolicyConfig
+	Job                   runCodeReviewPayload
+	SessionURL            string
+	PullRequest           models.PullRequest
+	Health                *models.PullRequestHealthResponse
+	AgentResults          []models.CodeReviewAgentResult
+	Findings              []models.CodeReviewFinding
+	ChangedFiles          []codereviewsvc.PullRequestFile
+	ChangedFilesAvailable bool
+	DescriptionEvaluation codeReviewDescriptionEvaluation
+	OrchestratorSynthesis codeReviewOrchestratorSynthesis
 }
 
 func evaluateLiveCodeReviewOutcome(input liveCodeReviewOutcomeInput) (models.CodeReviewDecisionEvaluation, string) {
@@ -2132,31 +2112,25 @@ func evaluateLiveCodeReviewOutcome(input liveCodeReviewOutcomeInput) (models.Cod
 	if len(input.DescriptionEvaluation.RequirementSummaries) == 0 {
 		descriptionPassed = codeReviewDescriptionPassed(policy, input.PullRequest, input.ChangedFiles)
 	}
-	reviewContextFetchFailed := input.ReviewContextChecked && !input.ReviewContextAvailable
-	unresolvedHumanThreads := codeReviewUnresolvedHumanThreads(input.PullRequest)
-	if input.ReviewContext != nil {
-		unresolvedHumanThreads += input.ReviewContext.UnresolvedHumanThreads + input.ReviewContext.BlockingHumanReviews
-	}
 	risk := models.EvaluateCodeReviewRisk(policy, models.CodeReviewRiskInput{
-		FilesChanged:           len(input.ChangedFiles),
-		LinesChanged:           codeReviewLinesChanged(input.ChangedFiles),
-		ChangedPaths:           codeReviewChangedPaths(input.ChangedFiles),
-		Categories:             codeReviewChangedCategories(input.ChangedFiles),
-		ChecksPassing:          codeReviewChecksPassing(policy, input.Health),
-		RequiredChecksPassing:  codeReviewRequiredChecksPassing(policy, input.Health),
-		DescriptionPassed:      descriptionPassed,
-		UpToDate:               codeReviewUpToDate(input.Health),
-		Author:                 codeReviewAuthor(input.Job, input.PullRequest),
-		AuthorClass:            codeReviewAuthorClass(input.PullRequest),
-		FromFork:               input.Job.FromFork,
-		ContextFetchFailed:     input.Health == nil || !input.ChangedFilesAvailable || reviewContextFetchFailed,
-		HeadSHAChanged:         codeReviewHeadChanged(input.Job.HeadSHA, input.PullRequest, input.Health),
-		BlockingFindings:       blockingFindings,
-		ReviewerDisagreement:   input.OrchestratorSynthesis.ReviewerDisagreement,
-		UnresolvedHumanThreads: unresolvedHumanThreads,
-		ScopeMismatch:          input.OrchestratorSynthesis.ScopeMismatch,
-		UnresolvedUncertainty:  input.OrchestratorSynthesis.UnresolvedUncertainty,
-		PromptInjectionFound:   input.DescriptionEvaluation.PromptInjectionFound || input.OrchestratorSynthesis.PromptInjectionDetected,
+		FilesChanged:          len(input.ChangedFiles),
+		LinesChanged:          codeReviewLinesChanged(input.ChangedFiles),
+		ChangedPaths:          codeReviewChangedPaths(input.ChangedFiles),
+		Categories:            codeReviewChangedCategories(input.ChangedFiles),
+		ChecksPassing:         codeReviewChecksPassing(policy, input.Health),
+		RequiredChecksPassing: codeReviewRequiredChecksPassing(policy, input.Health),
+		DescriptionPassed:     descriptionPassed,
+		UpToDate:              codeReviewUpToDate(input.Health),
+		Author:                codeReviewAuthor(input.Job, input.PullRequest),
+		AuthorClass:           codeReviewAuthorClass(input.PullRequest),
+		FromFork:              input.Job.FromFork,
+		ContextFetchFailed:    input.Health == nil || !input.ChangedFilesAvailable,
+		HeadSHAChanged:        codeReviewHeadChanged(input.Job.HeadSHA, input.PullRequest, input.Health),
+		BlockingFindings:      blockingFindings,
+		ReviewerDisagreement:  input.OrchestratorSynthesis.ReviewerDisagreement,
+		ScopeMismatch:         input.OrchestratorSynthesis.ScopeMismatch,
+		UnresolvedUncertainty: input.OrchestratorSynthesis.UnresolvedUncertainty,
+		PromptInjectionFound:  input.DescriptionEvaluation.PromptInjectionFound || input.OrchestratorSynthesis.PromptInjectionDetected,
 	})
 	if reviewerQuorum < requiredReviewerQuorum && !reviewerQuorumWaived {
 		risk.AddReason(models.CodeReviewRiskReason{Code: models.CodeReviewRiskReasonReviewerQuorum, Actual: reviewerQuorum, Limit: requiredReviewerQuorum})
@@ -2189,10 +2163,6 @@ func evaluateLiveCodeReviewOutcome(input liveCodeReviewOutcomeInput) (models.Cod
 
 type codeReviewFileLister interface {
 	ListPullRequestFiles(ctx context.Context, req codereviewsvc.PullRequestFilesRequest) ([]codereviewsvc.PullRequestFile, error)
-}
-
-type codeReviewContextLister interface {
-	ListReviewContext(ctx context.Context, req codereviewsvc.ReviewContextRequest) (codereviewsvc.ReviewContext, error)
 }
 
 func removeCodeReviewRequestedReviewer(ctx context.Context, stores *Stores, services *Services, logger zerolog.Logger, job runCodeReviewPayload, pr models.PullRequest) {
@@ -2280,66 +2250,6 @@ func loadCodeReviewChangedFiles(ctx context.Context, stores *Stores, services *S
 		return nil, false, err
 	}
 	return files, true, nil
-}
-
-func loadCodeReviewReviewContext(ctx context.Context, stores *Stores, services *Services, job runCodeReviewPayload, pr models.PullRequest) (*codereviewsvc.ReviewContext, bool, bool, error) {
-	if services == nil || services.CodeReviews == nil {
-		return nil, false, false, nil
-	}
-	lister, ok := services.CodeReviews.(codeReviewContextLister)
-	if !ok {
-		return nil, false, false, nil
-	}
-	if stores == nil || stores.Repositories == nil {
-		return nil, true, false, fmt.Errorf("repository store is required")
-	}
-	repo, err := stores.Repositories.GetByID(ctx, job.OrgID, job.RepositoryID)
-	if err != nil {
-		return nil, true, false, fmt.Errorf("load code review repository: %w", err)
-	}
-	if repo.InstallationID == 0 {
-		return nil, true, false, fmt.Errorf("repository %s has no GitHub installation id", repo.ID)
-	}
-	repository := strings.TrimSpace(pr.GitHubRepo)
-	if repository == "" {
-		repository = strings.TrimSpace(repo.FullName)
-	}
-	context, err := lister.ListReviewContext(ctx, codereviewsvc.ReviewContextRequest{
-		InstallationID: repo.InstallationID,
-		Repository:     repository,
-		PullNumber:     pr.GitHubPRNumber,
-		BotLogins:      codeReviewBotLogins(job),
-	})
-	if err != nil {
-		return nil, true, false, err
-	}
-	return &context, true, true, nil
-}
-
-func codeReviewBotLogins(job runCodeReviewPayload) []string {
-	logins := []string{"143", "143-code-reviewer", "143 Code Reviewer", "github-actions[bot]"}
-	if reviewer := strings.TrimSpace(job.RequestedReviewerLogin); reviewer != "" {
-		logins = append(logins, reviewer)
-	}
-	return compactCodeReviewStrings(logins)
-}
-
-func compactCodeReviewStrings(values []string) []string {
-	out := make([]string, 0, len(values))
-	seen := make(map[string]struct{})
-	for _, value := range values {
-		value = strings.TrimSpace(value)
-		if value == "" {
-			continue
-		}
-		key := strings.ToLower(value)
-		if _, ok := seen[key]; ok {
-			continue
-		}
-		seen[key] = struct{}{}
-		out = append(out, value)
-	}
-	return out
 }
 
 func loadStoredCodeReviewHealth(ctx context.Context, stores *Stores, job runCodeReviewPayload, pr models.PullRequest) (*models.PullRequestHealthResponse, error) {
@@ -2860,13 +2770,6 @@ func codeReviewAuthorClass(pr models.PullRequest) string {
 	default:
 		return ""
 	}
-}
-
-func codeReviewUnresolvedHumanThreads(pr models.PullRequest) int {
-	if pr.ReviewStatus == models.PullRequestReviewStatusChangesRequested {
-		return 1
-	}
-	return 0
 }
 
 func ensureCodeReviewInlineSelection(ctx context.Context, store *db.CodeReviewStore, job runCodeReviewPayload, findings []models.CodeReviewFinding, changedFiles []codereviewsvc.PullRequestFile, limit int) error {

--- a/internal/worker/code_review_handler_test.go
+++ b/internal/worker/code_review_handler_test.go
@@ -1975,7 +1975,7 @@ func TestEvaluateLiveCodeReviewOutcome(t *testing.T) {
 			reason:   "fork PRs are not eligible for approval",
 		},
 		{
-			name: "withholds approval when prior human review requested changes",
+			name: "ignores a prior human changes-requested review",
 			input: liveCodeReviewOutcomeInput{
 				Policy: policy,
 				Job:    runCodeReviewPayload{OrgID: orgID, SessionID: sessionID, PolicyVersion: 3, HeadSHA: "head"},
@@ -2005,8 +2005,7 @@ func TestEvaluateLiveCodeReviewOutcome(t *testing.T) {
 				},
 				ChangedFilesAvailable: true,
 			},
-			expected: models.CodeReviewDecisionNeedsHumanReview,
-			reason:   "unresolved human review threads are present",
+			expected: models.CodeReviewDecisionApproved,
 		},
 		{
 			name: "withholds approval when PR head moved",


### PR DESCRIPTION
## Summary
- Remove human comments, review decisions, and review threads from automated approval risk evaluation.
- Simplify reviewer and orchestrator prompts to rely on current PR evidence only.
- Clarify independent approval behavior in design docs, public guidance, and default policy examples.
- Preserve the historical unresolved-human-review reason code for rendering older decisions.

## Testing
- Updated code review policy and risk evaluation tests to verify independent approval guidance and behavior.