### PR TITLE
Add audit history to code review policy settings

### DIFF
--- a/frontend/src/app/(dashboard)/code-reviews/page.test.tsx
+++ b/frontend/src/app/(dashboard)/code-reviews/page.test.tsx
@@ -34,10 +34,12 @@ import type {
   CodeReviewResolvedPolicy,
   CodeReviewTemplateOption,
   CodeReviewPromptExamplesResponse,
+  AuditLog,
   ListResponse,
   OpenCodeModelInfo,
   Repository,
   SingleResponse,
+  User,
 } from "@/lib/types";
 
 const repo: Repository = {
@@ -496,6 +498,77 @@ describe("CodeReviewsPage", () => {
 
     expect(await within(evidenceSheet).findByText("No blocking issues found.")).toBeInTheDocument();
     expect(evidenceRequests).toBe(2);
+  });
+
+  it("shows who changed the review policy over time", async () => {
+    const user = userEvent.setup();
+    const members: User[] = [
+      {
+        id: "user-1",
+        org_id: "org-1",
+        email: "alice@example.com",
+        name: "Alice Smith",
+        role: "admin",
+        created_at: "2026-01-01T00:00:00Z",
+      },
+      {
+        id: "user-2",
+        org_id: "org-1",
+        email: "bob@example.com",
+        name: "Bob Chen",
+        role: "admin",
+        created_at: "2026-01-02T00:00:00Z",
+      },
+    ];
+    const entries: AuditLog[] = [
+      {
+        id: 2,
+        org_id: "org-1",
+        actor_type: "user",
+        actor_id: "user-1",
+        user_id: "user-1",
+        action: "code_review_policy.updated",
+        resource_type: "code_review_policy",
+        resource_id: "policy-2",
+        details: { source: "manual", version: 2 },
+        created_at: "2026-06-26T12:05:00Z",
+      },
+      {
+        id: 1,
+        org_id: "org-1",
+        actor_type: "user",
+        actor_id: "user-2",
+        user_id: "user-2",
+        action: "code_review_policy.updated",
+        resource_type: "code_review_policy",
+        resource_id: "policy-1",
+        details: { source: "example", version: 1 },
+        created_at: "2026-06-25T09:00:00Z",
+      },
+    ];
+    mockCodeReviewBaseHandlers();
+    server.use(
+      http.get("/api/v1/team/members", () =>
+        HttpResponse.json({ data: members, meta: {} } satisfies ListResponse<User>),
+      ),
+      http.get("/api/v1/audit-logs", ({ request }) => {
+        const url = new URL(request.url);
+        const data = url.searchParams.get("limit") === "1" ? entries.slice(0, 1) : entries;
+        return HttpResponse.json({ data, meta: {} } satisfies ListResponse<AuditLog>);
+      }),
+    );
+
+    renderWithProviders(<CodeReviewsPage />);
+    await user.click(await screen.findByRole("tab", { name: "Policy" }));
+
+    const historyTrigger = await screen.findByRole("button", { name: /Last activity:.*Alice Smith/i });
+    expect(historyTrigger).toBeInTheDocument();
+    await user.click(historyTrigger);
+
+    const history = await screen.findByRole("dialog", { name: "Review policy history" });
+    expect(within(history).getByText("Alice Smith")).toBeInTheDocument();
+    expect(within(history).getByText("Bob Chen")).toBeInTheDocument();
+    expect(within(history).getAllByText("updated review policy")).toHaveLength(2);
   });
 
   it("exposes accessible policy guidance and the compact GitHub management disclosure", async () => {

--- a/frontend/src/app/(dashboard)/code-reviews/page.tsx
+++ b/frontend/src/app/(dashboard)/code-reviews/page.tsx
@@ -56,6 +56,7 @@ import { useDebouncedTextField } from "@/hooks/useDebouncedTextField";
 import { useOpenCodeAvailability, type OpenCodeModelAvailability } from "@/hooks/use-opencode-models";
 import { useAuth } from "@/hooks/use-auth";
 import { AutosaveIndicator } from "@/components/AutosaveIndicator";
+import { AuditLogTrigger } from "@/components/audit/audit-log-trigger";
 import { applyCodeReviewPolicyOptimistic, coalesceCodeReviewPolicy } from "@/lib/code-review-autosave";
 import { AGENTS_BY_KEY, availableAgentModelGroups, modelOptionLabel, pmUsableResolvedCredentials, type AgentModelGroup } from "@/lib/agents";
 import type {
@@ -524,6 +525,7 @@ export default function CodeReviewsPage() {
         };
       }
       setInvalidPolicyField(null);
+      void queryClient.invalidateQueries({ queryKey: ["audit-logs"] });
     },
   });
   const readLatestConfig = (): CodeReviewPolicyConfig | null =>
@@ -911,6 +913,12 @@ export default function CodeReviewsPage() {
                     analyticsScope="organization"
                   />
                 </fieldset>
+
+                <AuditLogTrigger
+                  filters={{ resource_type: "code_review_policy" }}
+                  title="Review policy history"
+                  variant="footer"
+                />
               </CardContent>
             </Card>
             <CodeReviewPromptExampleDialog

--- a/frontend/src/components/audit/audit-log-entry.test.tsx
+++ b/frontend/src/components/audit/audit-log-entry.test.tsx
@@ -65,6 +65,24 @@ describe('AuditLogEntry', () => {
     expect(screen.queryByText('changed member role')).not.toBeInTheDocument();
   });
 
+  it('labels code review policy changes', () => {
+    render(
+      <>
+        <AuditLogEntry
+          entry={makeEntry({ id: 2, action: 'code_review_policy.updated', resource_type: 'code_review_policy' })}
+          members={mockMembers}
+        />
+        <AuditLogEntry
+          entry={makeEntry({ id: 3, action: 'code_review_policy.reset', resource_type: 'code_review_policy' })}
+          members={mockMembers}
+        />
+      </>
+    );
+
+    expect(screen.getByText('updated review policy')).toBeInTheDocument();
+    expect(screen.getByText('reset review policy')).toBeInTheDocument();
+  });
+
   it('labels auto-join audit actions without assuming a domain source', () => {
     render(
       <>

--- a/frontend/src/components/audit/audit-log-entry.tsx
+++ b/frontend/src/components/audit/audit-log-entry.tsx
@@ -56,6 +56,8 @@ const actionLabels: Record<string, string> = {
   "integration.connected": "connected integration",
   "credential.updated": "updated credential",
   "credential.deleted": "deleted credential",
+  "code_review_policy.updated": "updated review policy",
+  "code_review_policy.reset": "reset review policy",
   "auth.login": "logged in",
   "auth.logout": "logged out",
   "auth.register": "registered",

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -3115,6 +3115,7 @@ export type AuditResourceType =
   | "organization"
   | "preview_secret_bundle"
   | "preview_policy"
+  | "code_review_policy"
   | "pr_readiness_policy"
   | "pr_readiness_custom_check"
   | "pr_readiness_bypass"


### PR DESCRIPTION
## Summary

- Add a review policy history trigger to the Code Reviews policy settings.
- Display policy changes with actor names and readable action labels.
- Invalidate audit-log queries after policy updates.
- Add frontend coverage for policy history and action labels.

## Testing

- Added and updated Vitest component tests for policy audit history and labels.