### PR TITLE
Remove pull request action from code review rows

### DIFF
--- a/frontend/src/app/(dashboard)/code-reviews/page.test.tsx
+++ b/frontend/src/app/(dashboard)/code-reviews/page.test.tsx
@@ -353,6 +353,8 @@ describe("CodeReviewsPage", () => {
     expect(finalReviewLinks).toHaveLength(2);
     for (const link of finalReviewLinks) {
       expect(link).toHaveAttribute("href", review.github_review_url);
+      expect(link).toHaveAttribute("target", "_blank");
+      expect(link.querySelector('[data-slot="external-link-icon"]')).toBeInTheDocument();
     }
     expect(screen.queryByRole("link", { name: "Open final review" })).not.toBeInTheDocument();
     const filterToggle = screen.getByRole("button", {
@@ -362,7 +364,7 @@ describe("CodeReviewsPage", () => {
     await user.click(filterToggle);
     expect(filterToggle).toHaveAttribute("aria-expanded", "true");
     expect(screen.getByRole("textbox", { name: "Search code reviews" })).toBeInTheDocument();
-    expect(screen.getAllByRole("link", { name: "Open pull request" })).toHaveLength(2);
+    expect(screen.queryByRole("link", { name: "Open pull request" })).not.toBeInTheDocument();
     const reviewTable = screen.getByRole("table");
     const reviewRow = within(reviewTable).getByRole("row", {
       name: /#428 Fix invoice rounding/i,

--- a/frontend/src/app/(dashboard)/code-reviews/page.tsx
+++ b/frontend/src/app/(dashboard)/code-reviews/page.tsx
@@ -10,7 +10,6 @@ import {
   ChevronDown,
   CircleHelp,
   ClipboardCheck,
-  ExternalLink,
   FileSearch,
   Plus,
   PowerOff,
@@ -25,6 +24,7 @@ import { ResourceRow } from "@/components/resource-row";
 import { SectionGroup } from "@/components/section-group";
 import { StatusLabel, type StatusTone } from "@/components/status-label";
 import { Button } from "@/components/ui/button";
+import { ExternalLink } from "@/components/ui/external-link";
 import { DisabledTooltip } from "@/components/ui/disabled-tooltip";
 import { ErrorNotice } from "@/components/ui/error-notice";
 import { Badge } from "@/components/ui/badge";
@@ -209,15 +209,12 @@ function ReviewTitle({ review }: { review: CodeReviewListItem }) {
   if (!review.github_review_url) return title;
 
   return (
-    <Link
+    <ExternalLink
       href={review.github_review_url}
-      target="_blank"
-      rel="noreferrer"
       title="Open final review"
-      className="underline-offset-4 hover:underline focus-visible:rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
     >
       {title}
-    </Link>
+    </ExternalLink>
   );
 }
 
@@ -260,33 +257,11 @@ function ReviewOutcome({
 
 function ReviewActions({ review }: { review: CodeReviewListItem }) {
   return (
-    <TooltipProvider>
-      <div className="grid w-full grid-cols-2 gap-2 md:flex md:w-auto md:flex-wrap md:justify-end">
-        <Button className="min-h-11 justify-center md:min-h-0" variant="ghost" size="sm" asChild>
-          <Link href={`/sessions/${review.session_id}`}>
-            <ExternalLink className="h-4 w-4 md:hidden" />
-            Session
-          </Link>
-        </Button>
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <Button
-              className="min-h-11 justify-center md:size-7 md:min-h-0"
-              variant="ghost"
-              size="sm"
-              asChild
-              aria-label="Open pull request"
-            >
-              <Link href={review.github_pr_url} target="_blank" rel="noreferrer">
-                <ExternalLink className="h-4 w-4" />
-                <span className="md:sr-only">Pull request</span>
-              </Link>
-            </Button>
-          </TooltipTrigger>
-          <TooltipContent className="hidden md:block">Open pull request</TooltipContent>
-        </Tooltip>
-      </div>
-    </TooltipProvider>
+    <div className="flex w-full md:w-auto md:justify-end">
+      <Button className="min-h-11 w-full justify-center md:min-h-0 md:w-auto" variant="ghost" size="sm" asChild>
+        <Link href={`/sessions/${review.session_id}`}>Session</Link>
+      </Button>
+    </div>
   );
 }
 

--- a/frontend/src/components/ui/external-link.test.tsx
+++ b/frontend/src/components/ui/external-link.test.tsx
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest"
+
+import { renderWithProviders, screen } from "@/test/test-utils"
+
+import { ExternalLink } from "./external-link"
+
+describe("ExternalLink", () => {
+  it("renders a recognizable external link with safe new-tab defaults", () => {
+    const { container } = renderWithProviders(
+      <ExternalLink href="https://example.com/review">Final review</ExternalLink>,
+    )
+
+    const link = screen.getByRole("link", { name: "Final review" })
+    expect(link).toHaveAttribute("href", "https://example.com/review")
+    expect(link).toHaveAttribute("target", "_blank")
+    expect(link).toHaveAttribute("rel", "noopener noreferrer")
+    expect(link).toHaveClass("text-primary", "underline")
+    expect(container.querySelector('[data-slot="external-link-icon"]')).toHaveAttribute("aria-hidden", "true")
+  })
+})

--- a/frontend/src/components/ui/external-link.tsx
+++ b/frontend/src/components/ui/external-link.tsx
@@ -1,0 +1,34 @@
+import * as React from "react"
+import { ExternalLink as ExternalLinkIcon } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+
+function ExternalLink({
+  className,
+  children,
+  target = "_blank",
+  rel = "noopener noreferrer",
+  ...props
+}: React.ComponentProps<"a">) {
+  return (
+    <a
+      data-slot="external-link"
+      className={cn(
+        "inline-flex items-baseline gap-1 font-medium text-primary underline decoration-primary/40 underline-offset-4 transition-colors hover:decoration-primary focus-visible:rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+        className,
+      )}
+      target={target}
+      rel={rel}
+      {...props}
+    >
+      <span>{children}</span>
+      <ExternalLinkIcon
+        data-slot="external-link-icon"
+        aria-hidden="true"
+        className="size-3.5 shrink-0 translate-y-px"
+      />
+    </a>
+  )
+}
+
+export { ExternalLink }


### PR DESCRIPTION
## Summary

- Remove the pull request button from code review actions.
- Add a reusable external link component with safe new-tab defaults.
- Use the component for final review links with an external-link indicator.

## Testing

- Updated code review page tests.
- Added external link component coverage.