### PR TITLE
Capitalize code review policy summary badges

### DIFF
--- a/frontend/src/app/(dashboard)/code-reviews/page.test.tsx
+++ b/frontend/src/app/(dashboard)/code-reviews/page.test.tsx
@@ -396,7 +396,17 @@ describe("CodeReviewsPage", () => {
     expect(screen.getByText("Comments only")).toBeInTheDocument();
     expect(screen.getByText("GitHub reviewer ready")).toBeInTheDocument();
     expect(screen.getByText("2 reviewers")).toBeInTheDocument();
-    expect(screen.getByText("quorum 2")).toBeInTheDocument();
+    expect(screen.getByText("Quorum 2")).toBeInTheDocument();
+    expect(screen.getByText("Passing checks required")).toBeInTheDocument();
+    expect(screen.getByText("Disagreement blocks approval")).toBeInTheDocument();
+    expect(screen.getByText("Sensitive paths need human review")).toBeInTheDocument();
+
+    const currentBehaviorCard = screen.getByText("Current behavior").parentElement;
+    expect(currentBehaviorCard).not.toBeNull();
+    const summaryBadges = currentBehaviorCard?.querySelectorAll('[data-slot="badge"]') ?? [];
+    for (const badge of summaryBadges) {
+      expect(badge.textContent).toMatch(/^[A-Z0-9]/);
+    }
     expect(screen.getByRole("radio", { name: /Comment only/i })).toBeChecked();
     expect(screen.getByRole("region", { name: "Additional review instructions (optional)" })).toBeInTheDocument();
     expect(screen.getByText(/native \/review behavior without extra guidance/i)).toBeInTheDocument();

--- a/frontend/src/app/(dashboard)/code-reviews/page.tsx
+++ b/frontend/src/app/(dashboard)/code-reviews/page.tsx
@@ -1432,6 +1432,10 @@ function policyOutcome(config: CodeReviewPolicyConfig | null): "disabled" | "com
   return config.approval_mode === "approve_acceptable" ? "approve" : "comment";
 }
 
+function capitalizeSummaryItem(item: string): string {
+  return item.charAt(0).toUpperCase() + item.slice(1);
+}
+
 function PolicySummary({
   config,
   repositorySelected,
@@ -1464,11 +1468,14 @@ function PolicySummary({
     <div className="rounded-md border border-border bg-muted/30 px-4 py-3">
       <div className="text-sm font-medium text-foreground">Current behavior</div>
       <div className="mt-2 flex flex-wrap gap-2">
-        {summaryItems.map((item) => (
-          <Badge key={item} variant="outline">
-            {item}
-          </Badge>
-        ))}
+        {summaryItems.map((item) => {
+          const label = capitalizeSummaryItem(item);
+          return (
+            <Badge key={label} variant="outline">
+              {label}
+            </Badge>
+          );
+        })}
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- Capitalize code review policy summary badge labels for consistent presentation.
- Add regression coverage for capitalization and expected policy summary items.

## Testing
- Updated the CodeReviewsPage test assertions to verify capitalized badges and summary content.