### PR TITLE
Add configurable reasoning levels to code review agents

### DIFF
--- a/docs/design/implemented/112-code-reviewer-bot-auto-approval.md
+++ b/docs/design/implemented/112-code-reviewer-bot-auto-approval.md
@@ -78,6 +78,7 @@ Recommended v1 scope:
 - Normal 143 code review sessions keyed by org, repository, PR, head SHA, and policy version.
 - Editable PR-description policy and acceptable-risk starter templates.
 - Two reviewer agents plus one orchestrator by default.
+- One policy-versioned reasoning-effort setting applies across reviewer and orchestrator execution; omitted legacy values resolve to `high`.
 - GitHub final review with summary body and a configurable number of inline comments.
 - Approval only for acceptable PRs; otherwise comment with escalation reasons.
 - Idempotent reruns for duplicate requests, stale heads, and GitHub review retries.

--- a/docs/public/guides/code-review-policy.mdx
+++ b/docs/public/guides/code-review-policy.mdx
@@ -34,6 +34,8 @@ Once 143 submits an approval, that approval is final for the PR: later changes a
 
 Use a prompt example when it matches your intent. Previewing and applying an example replaces only its corresponding prompt; it never changes enablement, outcome, reviewers, paths, thresholds, or safety gates. Advanced policy presets are different: they replace the complete policy, including safeguards and agent settings.
 
+Under **Advanced controls → Reviewers & agents**, choose the reasoning level used for the review run. The default is **High**. The setting applies to each reviewer and the orchestrator when its selected agent supports explicit reasoning levels.
+
 ## Apply one policy everywhere
 
 Policy changes apply to new reviews in every repository. There are no repository overrides or inheritance rules to reconcile.

--- a/frontend/src/app/(dashboard)/code-reviews/page.test.tsx
+++ b/frontend/src/app/(dashboard)/code-reviews/page.test.tsx
@@ -109,6 +109,7 @@ const policy: CodeReviewResolvedPolicy = {
       orchestrator: "claude_code",
       reviewer_models: ["gpt-5.4", "claude-sonnet-4-6"],
       orchestrator_model: "claude-sonnet-4-6",
+      reasoning_effort: "high",
       disagreement_blocks: true,
       require_reviewer_quorum: 2,
       timeout_seconds: 1800,
@@ -228,11 +229,15 @@ const githubTriggerReady: CodeReviewGitHubTriggerResponse = {
   },
 };
 
-function mockCodeReviewBaseHandlers(trigger: CodeReviewGitHubTriggerResponse = githubTriggerReady, onPolicyUpdate?: (config: CodeReviewPolicyConfig, source?: string) => void) {
+function mockCodeReviewBaseHandlers(
+  trigger: CodeReviewGitHubTriggerResponse = githubTriggerReady,
+  onPolicyUpdate?: (config: CodeReviewPolicyConfig, source?: string) => void,
+  initialConfig: CodeReviewPolicyConfig = policy.config,
+) {
   // Autosave issues whole-config PUTs and refetches on settle, so the GET must
   // reflect the last saved config for optimistic values to stick across the
   // invalidation round-trip.
-  let currentConfig: CodeReviewPolicyConfig = policy.config;
+  let currentConfig: CodeReviewPolicyConfig = initialConfig;
   server.use(
     http.get("/api/v1/repositories", () =>
       HttpResponse.json({
@@ -460,6 +465,7 @@ describe("CodeReviewsPage", () => {
     expect(await screen.findByRole("combobox", { name: "Reviewer 1 model" })).toBeInTheDocument();
     expect(screen.getByRole("combobox", { name: "Reviewer 2 model" })).toBeInTheDocument();
     expect(screen.getByRole("combobox", { name: "Orchestrator model" })).toBeInTheDocument();
+    expect(screen.getByRole("combobox", { name: "Reasoning level" })).toHaveTextContent("High");
 
     // Autosave: applying a template persists without a Save button.
     await user.click(screen.getByRole("combobox", { name: /Advanced policy preset/i }));
@@ -679,6 +685,7 @@ describe("CodeReviewsPage", () => {
       "Add reviewer model",
       "Reviewer 1 model",
       "Reviewer 2 model",
+      "Reasoning level",
       "Orchestrator model",
     ]) {
       expect(screen.getByRole("button", { name: `About ${label}` })).toBeInTheDocument();
@@ -844,6 +851,78 @@ describe("CodeReviewsPage", () => {
     });
     expect(state.getCurrentConfig().approval_mode).toBe("approve_acceptable");
     expect(screen.getByRole("radio", { name: /^Approve acceptable PRs/i })).toBeChecked();
+  });
+
+  it("saves the code review reasoning level", async () => {
+    const user = userEvent.setup();
+    const state = mockCodeReviewBaseHandlers();
+
+    renderWithProviders(<CodeReviewsPage />);
+    await user.click(await screen.findByRole("tab", { name: /Policy/i }));
+    await user.click(screen.getByRole("button", { name: "Advanced controls" }));
+    await user.click(screen.getByRole("button", { name: /Reviewers & agents/i }));
+    await user.click(await screen.findByRole("combobox", { name: "Reasoning level" }));
+    await user.click(await screen.findByRole("option", { name: "Extra high" }));
+
+    await waitFor(() => {
+      expect(state.getCurrentConfig().agent_roster.reasoning_effort).toBe("xhigh");
+    });
+  });
+
+  it("supports max reasoning for Claude-only rosters and normalizes it when Codex is selected", async () => {
+    const user = userEvent.setup();
+    const claudeOnlyConfig: CodeReviewPolicyConfig = {
+      ...policy.config,
+      agent_roster: {
+        ...policy.config.agent_roster,
+        reviewers: ["claude_code"],
+        reviewer_models: ["claude-sonnet-4-6"],
+        orchestrator: "claude_code",
+        orchestrator_model: "claude-sonnet-4-6",
+        reasoning_effort: "max",
+        require_reviewer_quorum: 1,
+      },
+    };
+    const state = mockCodeReviewBaseHandlers(githubTriggerReady, undefined, claudeOnlyConfig);
+    const codexCredential: CodingCredentialSummary = {
+      id: "cred-codex",
+      org_id: "org-1",
+      scope: "org",
+      priority: 1,
+      agent: "codex",
+      auth_type: "api_key",
+      provider: "openai",
+      label: "OpenAI",
+      status: "healthy",
+      is_default: true,
+      created_at: "2026-06-26T12:00:00Z",
+      updated_at: "2026-06-26T12:00:00Z",
+    };
+    server.use(
+      http.get("/api/v1/coding-credentials", ({ request }) => {
+        const scope = new URL(request.url).searchParams.get("scope");
+        return HttpResponse.json({ data: scope === "personal" ? [] : [codexCredential], meta: { scope } });
+      }),
+    );
+
+    renderWithProviders(<CodeReviewsPage />);
+    await user.click(await screen.findByRole("tab", { name: /Policy/i }));
+    await user.click(screen.getByRole("button", { name: "Advanced controls" }));
+    await user.click(screen.getByRole("button", { name: /Reviewers & agents/i }));
+
+    const reasoningSelect = await screen.findByRole("combobox", { name: "Reasoning level" });
+    expect(reasoningSelect).toHaveTextContent("Max");
+    await user.click(reasoningSelect);
+    expect(await screen.findByRole("option", { name: "Max" })).toBeInTheDocument();
+    await user.keyboard("{Escape}");
+
+    await user.click(screen.getByRole("combobox", { name: "Reviewer 1 model" }));
+    await user.click(await screen.findByRole("option", { name: "gpt-5.4" }));
+
+    await waitFor(() => {
+      expect(state.getCurrentConfig().agent_roster.reviewers).toEqual(["codex"]);
+      expect(state.getCurrentConfig().agent_roster.reasoning_effort).toBe("high");
+    });
   });
 
   it("debounces both prompt composers and autosaves the latest full config without clobbering", async () => {

--- a/frontend/src/app/(dashboard)/code-reviews/page.tsx
+++ b/frontend/src/app/(dashboard)/code-reviews/page.tsx
@@ -58,6 +58,7 @@ import { useAuth } from "@/hooks/use-auth";
 import { AutosaveIndicator } from "@/components/AutosaveIndicator";
 import { AuditLogTrigger } from "@/components/audit/audit-log-trigger";
 import { applyCodeReviewPolicyOptimistic, coalesceCodeReviewPolicy } from "@/lib/code-review-autosave";
+import { getCodingAgentReasoningOptions } from "@/lib/coding-agent-reasoning";
 import { AGENTS_BY_KEY, availableAgentModelGroups, modelOptionLabel, pmUsableResolvedCredentials, type AgentModelGroup } from "@/lib/agents";
 import type {
   CodingCredentialSummary,
@@ -93,6 +94,13 @@ const NO_TEMPLATE = "none";
 // Coalesce a burst of SSE lifecycle events into a single list refetch.
 const CODE_REVIEW_INVALIDATE_COALESCE_MS = 300;
 const MAX_REVIEWER_MODELS = 3;
+const CODE_REVIEW_REASONING_OPTIONS = [
+  { value: "low", label: "Low" },
+  { value: "medium", label: "Medium" },
+  { value: "high", label: "High" },
+  { value: "xhigh", label: "Extra high" },
+  { value: "max", label: "Max" },
+] as const;
 const CODE_REVIEW_PROMPT_MAX_LENGTH = 8000;
 const codeReviewPromptValuesEqual = (left: string, right: string) => left.trim() === right.trim();
 const DEFAULT_AUTOMATED_APPROVAL_POLICY = `Automatically approve routine, well-tested changes when:
@@ -311,6 +319,25 @@ function ensureReviewerModels(config: CodeReviewPolicyConfig, modelGroups: Agent
     if (configured && modelBelongsToAgent(agent, configured)) return configured;
     return defaultModelForAgent(agent, modelGroups);
   });
+}
+
+type CodeReviewReasoningEffort = NonNullable<CodeReviewPolicyConfig["agent_roster"]["reasoning_effort"]>;
+
+function reasoningOptionsForRoster(config: CodeReviewPolicyConfig) {
+  const agents = [...config.agent_roster.reviewers, config.agent_roster.orchestrator];
+  return CODE_REVIEW_REASONING_OPTIONS.filter((option) =>
+    agents.every((agent) => {
+      const supported = getCodingAgentReasoningOptions(agent);
+      return supported.length === 0 || supported.some((effort) => effort.value === option.value);
+    }),
+  );
+}
+
+function normalizeReasoningEffortForRoster(config: CodeReviewPolicyConfig): void {
+  const current = config.agent_roster.reasoning_effort ?? "high";
+  if (!reasoningOptionsForRoster(config).some((option) => option.value === current)) {
+    config.agent_roster.reasoning_effort = "high";
+  }
 }
 
 export default function CodeReviewsPage() {
@@ -2153,6 +2180,7 @@ function AgentRosterControls({
   const reviewerModels = config ? ensureReviewerModels(config, modelGroups) : [];
   const canAddReviewer = Boolean(config) && reviewers.length < MAX_REVIEWER_MODELS && modelGroups.length > 0;
   const fallbackGroup = modelGroups[0];
+  const reasoningOptions = config ? reasoningOptionsForRoster(config) : CODE_REVIEW_REASONING_OPTIONS.filter((option) => option.value !== "max");
   const orchestratorModel =
     config?.agent_roster.orchestrator_model && modelBelongsToAgent(config.agent_roster.orchestrator, config.agent_roster.orchestrator_model)
       ? config.agent_roster.orchestrator_model
@@ -2180,6 +2208,7 @@ function AgentRosterControls({
                 const reviewerModels = ensureReviewerModels(next, modelGroups);
                 next.agent_roster.reviewers = [...next.agent_roster.reviewers, fallbackGroup.key];
                 next.agent_roster.reviewer_models = [...reviewerModels, fallbackGroup.models[0] ?? ""];
+                normalizeReasoningEffortForRoster(next);
               })
             }
           >
@@ -2211,6 +2240,7 @@ function AgentRosterControls({
                     next.agent_roster.reviewers[index] = selection.agent;
                     reviewerModels[index] = selection.model;
                     next.agent_roster.reviewer_models = reviewerModels;
+                    normalizeReasoningEffortForRoster(next);
                   })
                 }
               />
@@ -2240,6 +2270,32 @@ function AgentRosterControls({
       </div>
 
       <div className="space-y-3">
+        <div className="space-y-2">
+          <SettingLabel
+            label="Reasoning level"
+            info="Controls the reasoning effort used by every reviewer and the orchestrator when the selected agent supports explicit reasoning. High is the default."
+          />
+          <Select
+            value={config?.agent_roster.reasoning_effort ?? "high"}
+            disabled={disabled}
+            onValueChange={(value) =>
+              commitPolicy((next) => {
+                next.agent_roster.reasoning_effort = value as CodeReviewReasoningEffort;
+              })
+            }
+          >
+            <SelectTrigger aria-label="Reasoning level">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {reasoningOptions.map((option) => (
+                <SelectItem key={option.value} value={option.value}>
+                  {option.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
         <div>
           <Label className="text-xs text-muted-foreground">Orchestrator model</Label>
           <p className="mt-1 text-xs text-muted-foreground">Synthesizes reviewer evidence and decides the final review outcome.</p>
@@ -2258,6 +2314,7 @@ function AgentRosterControls({
               const selection = parseSelectionValue(value);
               next.agent_roster.orchestrator = selection.agent;
               next.agent_roster.orchestrator_model = selection.model;
+              normalizeReasoningEffortForRoster(next);
             })
           }
         />

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -203,6 +203,7 @@ export interface CodeReviewPolicyConfig {
     orchestrator: string;
     reviewer_models?: string[];
     orchestrator_model?: string;
+    reasoning_effort?: "low" | "medium" | "high" | "xhigh" | "max";
     disagreement_blocks: boolean;
     require_reviewer_quorum: number;
     timeout_seconds: number;

--- a/internal/models/code_review.go
+++ b/internal/models/code_review.go
@@ -395,13 +395,14 @@ func CodeReviewLowRiskLaneApplies(lane CodeReviewLowRiskLane, categories []strin
 }
 
 type CodeReviewAgentRoster struct {
-	Reviewers             []AgentType `json:"reviewers"`
-	Orchestrator          AgentType   `json:"orchestrator"`
-	ReviewerModels        []string    `json:"reviewer_models,omitempty"`
-	OrchestratorModel     *string     `json:"orchestrator_model,omitempty"`
-	DisagreementBlocks    bool        `json:"disagreement_blocks"`
-	RequireReviewerQuorum int         `json:"require_reviewer_quorum"`
-	TimeoutSeconds        int         `json:"timeout_seconds"`
+	Reviewers             []AgentType     `json:"reviewers"`
+	Orchestrator          AgentType       `json:"orchestrator"`
+	ReviewerModels        []string        `json:"reviewer_models,omitempty"`
+	OrchestratorModel     *string         `json:"orchestrator_model,omitempty"`
+	ReasoningEffort       ReasoningEffort `json:"reasoning_effort,omitempty"`
+	DisagreementBlocks    bool            `json:"disagreement_blocks"`
+	RequireReviewerQuorum int             `json:"require_reviewer_quorum"`
+	TimeoutSeconds        int             `json:"timeout_seconds"`
 }
 
 type CodeReviewPolicyConfig struct {
@@ -507,6 +508,7 @@ func DefaultCodeReviewPolicyConfig() CodeReviewPolicyConfig {
 			Orchestrator:          AgentTypeOpenCode,
 			ReviewerModels:        []string{DefaultCodexModel, DefaultClaudeCodeModel},
 			OrchestratorModel:     strPtr(OpenCodeModelGPT55),
+			ReasoningEffort:       ReasoningEffortHigh,
 			DisagreementBlocks:    true,
 			RequireReviewerQuorum: 2,
 			TimeoutSeconds:        1800,
@@ -574,6 +576,9 @@ func ResolveCodeReviewPolicyConfig(config *CodeReviewPolicyConfig) CodeReviewPol
 	}
 	if len(config.AgentRoster.Reviewers) > 0 {
 		defaults.AgentRoster = config.AgentRoster
+		if defaults.AgentRoster.ReasoningEffort == "" {
+			defaults.AgentRoster.ReasoningEffort = ReasoningEffortHigh
+		}
 	}
 	if config.InlineCommentLimit != 0 {
 		defaults.InlineCommentLimit = config.InlineCommentLimit
@@ -649,6 +654,9 @@ func (c CodeReviewPolicyConfig) Validate() error {
 		if !AgentSupportsNativeReview(agentType) {
 			return codeReviewPolicyFieldError(CodeReviewPolicyFieldAgentRoster, fmt.Sprintf("agent %q does not support native review", agentType))
 		}
+		if agentType.SupportsReasoningEffort() && !agentType.SupportsReasoningEffortLevel(c.AgentRoster.ReasoningEffort) {
+			return codeReviewPolicyFieldError(CodeReviewPolicyFieldAgentRoster, fmt.Sprintf("reasoning effort %q is not supported by reviewer %q", c.AgentRoster.ReasoningEffort, agentType))
+		}
 	}
 	if len(c.AgentRoster.ReviewerModels) > 0 && len(c.AgentRoster.ReviewerModels) != len(c.AgentRoster.Reviewers) {
 		return codeReviewPolicyFieldError(CodeReviewPolicyFieldAgentRoster, "reviewer_models must match reviewer count")
@@ -672,6 +680,12 @@ func (c CodeReviewPolicyConfig) Validate() error {
 		if err := ValidateModelForAgentType(c.AgentRoster.Orchestrator, strings.TrimSpace(*c.AgentRoster.OrchestratorModel)); err != nil {
 			return codeReviewPolicyFieldError(CodeReviewPolicyFieldAgentRoster, fmt.Sprintf("invalid orchestrator model: %v", err))
 		}
+	}
+	if err := c.AgentRoster.ReasoningEffort.Validate(); err != nil {
+		return codeReviewPolicyFieldError(CodeReviewPolicyFieldAgentRoster, err.Error())
+	}
+	if c.AgentRoster.Orchestrator.SupportsReasoningEffort() && !c.AgentRoster.Orchestrator.SupportsReasoningEffortLevel(c.AgentRoster.ReasoningEffort) {
+		return codeReviewPolicyFieldError(CodeReviewPolicyFieldAgentRoster, fmt.Sprintf("reasoning effort %q is not supported by orchestrator %q", c.AgentRoster.ReasoningEffort, c.AgentRoster.Orchestrator))
 	}
 	if c.AgentRoster.RequireReviewerQuorum < 1 || c.AgentRoster.RequireReviewerQuorum > len(c.AgentRoster.Reviewers) {
 		return codeReviewPolicyFieldError(CodeReviewPolicyFieldAgentRoster, "require_reviewer_quorum must be between 1 and reviewer count")
@@ -719,7 +733,7 @@ type CodeReviewPolicyRecord struct {
 }
 
 func (r CodeReviewPolicyRecord) Config() CodeReviewPolicyConfig {
-	return CodeReviewPolicyConfig{
+	config := CodeReviewPolicyConfig{
 		ApprovalMode:            r.ApprovalMode,
 		Enabled:                 r.Enabled,
 		ReviewInstructions:      r.ReviewInstructions,
@@ -729,6 +743,7 @@ func (r CodeReviewPolicyRecord) Config() CodeReviewPolicyConfig {
 		AgentRoster:             r.AgentRoster,
 		InlineCommentLimit:      r.InlineCommentLimit,
 	}
+	return ResolveCodeReviewPolicyConfig(&config)
 }
 
 type CodeReviewResolvedPolicy struct {

--- a/internal/models/code_review_test.go
+++ b/internal/models/code_review_test.go
@@ -81,7 +81,40 @@ func TestDefaultCodeReviewPolicyConfig(t *testing.T) {
 	require.Equal(t, []AgentType{AgentTypeCodex, AgentTypeClaudeCode}, config.AgentRoster.Reviewers, "default roster should run two reviewers")
 	require.Equal(t, []string{DefaultCodexModel, DefaultClaudeCodeModel}, config.AgentRoster.ReviewerModels, "default roster should pin reviewer models")
 	require.Equal(t, OpenCodeModelGPT55, *config.AgentRoster.OrchestratorModel, "default roster should pin the orchestrator model")
+	require.Equal(t, ReasoningEffortHigh, config.AgentRoster.ReasoningEffort, "code review agents should default to high reasoning")
 	require.NoError(t, config.Validate(), "default code review policy should be valid")
+}
+
+func TestResolveCodeReviewPolicyConfigDefaultsLegacyRosterReasoning(t *testing.T) {
+	t.Parallel()
+
+	config := DefaultCodeReviewPolicyConfig()
+	config.AgentRoster.ReasoningEffort = ""
+
+	resolved := ResolveCodeReviewPolicyConfig(&config)
+
+	require.Equal(t, ReasoningEffortHigh, resolved.AgentRoster.ReasoningEffort, "legacy code review policies should inherit high reasoning")
+}
+
+func TestCodeReviewPolicyRecordConfigDefaultsLegacyRosterReasoning(t *testing.T) {
+	t.Parallel()
+
+	config := DefaultCodeReviewPolicyConfig()
+	config.AgentRoster.ReasoningEffort = ""
+	record := CodeReviewPolicyRecord{
+		Enabled:                 config.Enabled,
+		ApprovalMode:            config.ApprovalMode,
+		ReviewInstructions:      config.ReviewInstructions,
+		AutomatedApprovalPolicy: config.AutomatedApprovalPolicy,
+		DescriptionPolicy:       config.DescriptionPolicy,
+		RiskPolicy:              config.RiskPolicy,
+		AgentRoster:             config.AgentRoster,
+		InlineCommentLimit:      config.InlineCommentLimit,
+	}
+
+	resolved := record.Config()
+
+	require.Equal(t, ReasoningEffortHigh, resolved.AgentRoster.ReasoningEffort, "stored legacy code review policies should run with high reasoning")
 }
 
 func TestResolveCodeReviewPolicyConfigDoesNotMutateInput(t *testing.T) {
@@ -132,6 +165,8 @@ func TestCodeReviewPolicyConfigValidate(t *testing.T) {
 			c.AgentRoster.ReviewerModels = []string{DefaultCodexModel, DefaultCodexModel}
 		}, expectErr: true},
 		{name: "rejects invalid orchestrator model", mutate: func(c *CodeReviewPolicyConfig) { c.AgentRoster.OrchestratorModel = strPtr(DefaultCodexModel) }, expectErr: true},
+		{name: "rejects invalid reasoning effort", mutate: func(c *CodeReviewPolicyConfig) { c.AgentRoster.ReasoningEffort = ReasoningEffort("turbo") }, expectErr: true},
+		{name: "rejects reasoning effort unsupported by reviewer", mutate: func(c *CodeReviewPolicyConfig) { c.AgentRoster.ReasoningEffort = ReasoningEffortMax }, expectErr: true},
 		{name: "rejects oversized quorum", mutate: func(c *CodeReviewPolicyConfig) { c.AgentRoster.RequireReviewerQuorum = 3 }, expectErr: true},
 		{name: "rejects too short timeout", mutate: func(c *CodeReviewPolicyConfig) { c.AgentRoster.TimeoutSeconds = 30 }, expectErr: true},
 	}

--- a/internal/services/codereview/service.go
+++ b/internal/services/codereview/service.go
@@ -406,6 +406,7 @@ func (s *Service) startReview(ctx context.Context, input ReviewRequestedInput, o
 
 	title := fmt.Sprintf("Code review for %s#%d", input.GitHubRepo, input.GitHubPRNumber)
 	modelOverride := resolved.Config.AgentRoster.OrchestratorModel
+	reasoningEffort := resolved.Config.AgentRoster.ReasoningEffort
 	revisionContext, err := json.Marshal(map[string]any{
 		"kind":                "code_review",
 		"github_repo":         input.GitHubRepo,
@@ -431,6 +432,7 @@ func (s *Service) startReview(ctx context.Context, input ReviewRequestedInput, o
 		ValidationPolicy: models.SessionValidationPolicySkip,
 		AgentType:        resolved.Config.AgentRoster.Orchestrator,
 		ModelOverride:    modelOverride,
+		ReasoningEffort:  &reasoningEffort,
 		Status:           models.SessionStatusIdle,
 		AutonomyLevel:    models.SessionAutonomySupervised,
 		TokenMode:        models.DefaultSessionTokenMode,

--- a/internal/services/codereview/service_test.go
+++ b/internal/services/codereview/service_test.go
@@ -62,6 +62,8 @@ func TestService_HandleReviewRequested(t *testing.T) {
 				require.Equal(t, models.SessionOriginCodeReview, sessions.created.Origin, "session should use code_review origin")
 				require.Equal(t, models.SessionInteractionModeSingleRun, sessions.created.InteractionMode, "review sessions should be single-run")
 				require.Equal(t, models.SessionStatusIdle, sessions.created.Status, "review sessions should start idle so reviewer tabs can claim the first turn")
+				require.NotNil(t, sessions.created.ReasoningEffort, "review sessions should carry the policy reasoning level")
+				require.Equal(t, models.ReasoningEffortHigh, *sessions.created.ReasoningEffort, "review sessions should default to high reasoning")
 				require.Equal(t, 1, metadata.createCalls, "service should create code review metadata")
 				require.True(t, metadata.created.FromFork, "service should persist fork source evidence on review metadata")
 				require.Equal(t, 1, jobs.enqueueCalls, "service should enqueue the code review worker job")


### PR DESCRIPTION
## Summary
- Add a policy-level reasoning setting shared by reviewers and the orchestrator, defaulting legacy policies to High
- Limit available levels to those supported by the selected agent roster and normalize incompatible values
- Persist the setting on review sessions and document the new control

## Testing
- Added Go unit tests for defaults, legacy resolution, and validation
- Added frontend UI tests for saving reasoning levels and roster compatibility