### PR TITLE
Fix audit log row sizing and vertical alignment

### DIFF
--- a/frontend/src/components/audit/audit-log-entry.test.tsx
+++ b/frontend/src/components/audit/audit-log-entry.test.tsx
@@ -53,6 +53,28 @@ describe('AuditLogEntry', () => {
     );
   });
 
+  it('keeps audit rows auto-sized with vertically aligned content', () => {
+    const { container } = render(
+      <AuditLogEntry
+        entry={makeEntry({ details: { changed: 'value' } })}
+        members={mockMembers}
+      />
+    );
+
+    const row = screen.getByRole('button');
+    expect(row).toHaveClass(
+      'h-auto',
+      'sm:h-auto',
+      'leading-5'
+    );
+    expect(row).not.toHaveClass('sm:h-8');
+    expect(container.querySelector('.lucide-chevron-right')?.parentElement).toHaveClass(
+      'flex',
+      'self-stretch',
+      'items-center'
+    );
+  });
+
   it('labels team role changes without saying member role', () => {
     render(
       <AuditLogEntry

--- a/frontend/src/components/audit/audit-log-entry.tsx
+++ b/frontend/src/components/audit/audit-log-entry.tsx
@@ -109,10 +109,10 @@ export function AuditLogEntry({ entry, members, onSelect }: AuditLogEntryProps) 
             setExpanded(!expanded);
           }
         }}
-        className="flex w-full items-start gap-2 whitespace-normal px-6 py-3.5 text-left text-sm hover:bg-muted/30 transition-all duration-150 h-auto rounded-none"
+        className="flex h-auto w-full items-start gap-2 whitespace-normal rounded-none px-6 py-3.5 text-left text-sm leading-5 transition-all duration-150 hover:bg-muted/30 sm:h-auto"
         disabled={!onSelect && !hasDetails}
       >
-        <span className="shrink-0 w-14 text-xs text-muted-foreground/70 pt-0.5 tabular-nums">
+        <span className="w-14 shrink-0 text-xs leading-5 text-muted-foreground/70 tabular-nums">
           {formatTimeAgo(entry.created_at)}
         </span>
         <span className="flex-1 min-w-0 whitespace-normal break-words">
@@ -121,7 +121,7 @@ export function AuditLogEntry({ entry, members, onSelect }: AuditLogEntryProps) 
           <span className="text-muted-foreground">{actionLabel}</span>
         </span>
         {!onSelect && hasDetails && (
-          <span className="shrink-0 pt-0.5 text-muted-foreground/50">
+          <span className="flex shrink-0 self-stretch items-center text-muted-foreground/50">
             {expanded ? (
               <ChevronDown className="h-3.5 w-3.5" />
             ) : (


### PR DESCRIPTION
## Summary

- Keep audit log rows auto-sized for multi-line content.
- Apply consistent line height to row text and timestamps.
- Vertically center the details chevron across expanded row content.
- Add regression coverage for the updated layout classes.

## Testing

- Added a focused `AuditLogEntry` component test covering row sizing and chevron alignment.
- Not run (not requested).