### PR TITLE
Debounce code review policy edits before versioning

### DIFF
--- a/frontend/src/app/(dashboard)/code-reviews/page.test.tsx
+++ b/frontend/src/app/(dashboard)/code-reviews/page.test.tsx
@@ -861,6 +861,7 @@ describe("CodeReviewsPage", () => {
     await user.type(reviewInstructions, "Review tenant boundaries and authorization.");
     await user.clear(approvalPolicy);
     await user.type(approvalPolicy, "Approve only routine changes with proportionate tests.");
+    fireEvent.blur(approvalPolicy);
 
     await waitFor(() => {
       const latest = updates.at(-1);
@@ -875,6 +876,25 @@ describe("CodeReviewsPage", () => {
     expect(within(screen.getByRole("region", { name: "Automated approval policy" })).getByRole("textbox")).toHaveValue("Approve only routine changes with proportionate tests.");
   });
 
+  it("waits through a short typing pause before versioning textarea edits and flushes on blur", async () => {
+    const user = userEvent.setup();
+    const updates: CodeReviewPolicyConfig[] = [];
+    mockCodeReviewBaseHandlers(githubTriggerReady, (config) => updates.push(config));
+    renderWithProviders(<CodeReviewsPage />);
+    await user.click(await screen.findByRole("tab", { name: /Policy/i }));
+
+    const reviewInstructions = within(
+      screen.getByRole("region", { name: "Additional review instructions (optional)" }),
+    ).getByRole("textbox");
+    fireEvent.change(reviewInstructions, { target: { value: "Review tenant boundaries." } });
+
+    await act(async () => { await new Promise((resolve) => setTimeout(resolve, 450)); });
+    expect(updates).toHaveLength(0);
+
+    fireEvent.blur(reviewInstructions);
+    await waitFor(() => expect(updates.at(-1)?.review_instructions).toBe("Review tenant boundaries."));
+  });
+
   it("keeps a word-separating space in the approval policy while an autosave is canonicalized", async () => {
     const user = userEvent.setup();
     const state = mockCodeReviewBaseHandlers();
@@ -886,11 +906,13 @@ describe("CodeReviewsPage", () => {
     const approvalPolicy = within(screen.getByRole("region", { name: "Automated approval policy" })).getByRole("textbox");
     await user.clear(approvalPolicy);
     await user.type(approvalPolicy, "Approve routine ");
+    fireEvent.blur(approvalPolicy);
     await waitFor(() => expect(state.getCurrentConfig().automated_approval_policy).toBe("Approve routine"));
     expect(approvalPolicy).toHaveValue("Approve routine ");
 
     await user.type(approvalPolicy, "changes");
     expect(approvalPolicy).toHaveValue("Approve routine changes");
+    fireEvent.blur(approvalPolicy);
     await waitFor(() => expect(state.getCurrentConfig().automated_approval_policy).toBe("Approve routine changes"));
   });
 
@@ -940,6 +962,7 @@ describe("CodeReviewsPage", () => {
     await user.click(await screen.findByRole("tab", { name: /Policy/i }));
     const input = within(screen.getByRole("region", { name: "Additional review instructions (optional)" })).getByRole("textbox");
     await user.type(input, "Keep this unsaved local guidance");
+    fireEvent.blur(input);
 
     expect(await screen.findAllByText("Couldn't save")).not.toHaveLength(0);
     expect(input).toHaveValue("Keep this unsaved local guidance");

--- a/frontend/src/app/(dashboard)/code-reviews/page.tsx
+++ b/frontend/src/app/(dashboard)/code-reviews/page.tsx
@@ -94,6 +94,10 @@ const NO_TEMPLATE = "none";
 const CODE_REVIEW_INVALIDATE_COALESCE_MS = 300;
 const MAX_REVIEWER_MODELS = 3;
 const CODE_REVIEW_PROMPT_MAX_LENGTH = 8000;
+// Policy textareas create a new version on every commit. Give authors enough
+// time to pause while composing without turning ordinary typing into a stream
+// of short-lived versions; leaving the field still flushes immediately.
+const CODE_REVIEW_TEXTAREA_DEBOUNCE_MS = 2_000;
 const codeReviewPromptValuesEqual = (left: string, right: string) => left.trim() === right.trim();
 const DEFAULT_AUTOMATED_APPROVAL_POLICY = `Automatically approve routine, well-tested changes when:
 - the intent is clear and the change has a small, understandable scope
@@ -1031,6 +1035,7 @@ function CodeReviewPromptComposerBase({ title, description, tooltip, value, disa
   const field = useDebouncedTextField({
     serverValue: value,
     onCommit: (next) => { if (!invalidValue(next)) onCommit(next); },
+    debounceMs: CODE_REVIEW_TEXTAREA_DEBOUNCE_MS,
     preserveLocalOnServerChange: autosave.status === "error",
     valuesEqual: codeReviewPromptValuesEqual,
   });
@@ -2561,6 +2566,7 @@ function ListTextArea({
           .map((item) => item.trim())
           .filter(Boolean),
       ),
+    debounceMs: CODE_REVIEW_TEXTAREA_DEBOUNCE_MS,
   });
   return (
     <div className="space-y-2">
@@ -2595,7 +2601,7 @@ function PolicyTextarea({
   serverValue: string;
   onCommit: (value: string) => void;
 } & Omit<ComponentProps<typeof Textarea>, "value" | "onChange" | "onBlur">) {
-  const field = useDebouncedTextField({ serverValue, onCommit });
+  const field = useDebouncedTextField({ serverValue, onCommit, debounceMs: CODE_REVIEW_TEXTAREA_DEBOUNCE_MS });
   return <Textarea {...props} value={field.value} disabled={disabled} onChange={(event) => field.onChange(event.target.value)} onBlur={field.onBlur} />;
 }
 

--- a/frontend/src/app/(dashboard)/code-reviews/page.tsx
+++ b/frontend/src/app/(dashboard)/code-reviews/page.tsx
@@ -97,7 +97,7 @@ const CODE_REVIEW_PROMPT_MAX_LENGTH = 8000;
 // Policy textareas create a new version on every commit. Give authors enough
 // time to pause while composing without turning ordinary typing into a stream
 // of short-lived versions; leaving the field still flushes immediately.
-const CODE_REVIEW_TEXTAREA_DEBOUNCE_MS = 2_000;
+const CODE_REVIEW_TEXTAREA_DEBOUNCE_MS = 5_000;
 const codeReviewPromptValuesEqual = (left: string, right: string) => left.trim() === right.trim();
 const DEFAULT_AUTOMATED_APPROVAL_POLICY = `Automatically approve routine, well-tested changes when:
 - the intent is clear and the change has a small, understandable scope


### PR DESCRIPTION
## Summary
- Debounce policy textarea commits for 2 seconds while typing
- Flush pending edits immediately on blur
- Add coverage for delayed commits and blur behavior

## Testing
- Not run (not requested)