### PR TITLE
Gate code review harvesting on durable turn completion

### DIFF
--- a/internal/worker/code_review_handler.go
+++ b/internal/worker/code_review_handler.go
@@ -578,6 +578,8 @@ type codeReviewReviewerStructuredResult struct {
 	ReviewerKey       string  `json:"reviewer_key"`
 	ReviewerIndex     int     `json:"reviewer_index"`
 	ThreadID          string  `json:"thread_id"`
+	RequestMessageID  int64   `json:"request_message_id,omitempty"`
+	ExpectedTurn      int     `json:"expected_turn,omitempty"`
 	PromptArtifactKey string  `json:"prompt_artifact_key,omitempty"`
 	FindingCount      int     `json:"finding_count,omitempty"`
 	CostCents         float64 `json:"cost_cents,omitempty"`
@@ -704,14 +706,15 @@ func ensureCodeReviewReviewerThreads(ctx context.Context, stores *Stores, servic
 		if err != nil {
 			return fmt.Errorf("create code review reviewer thread: %w", err)
 		}
-		structured := marshalCodeReviewReviewerStructuredResult(codeReviewReviewerStructuredResult{
+		reviewerState := codeReviewReviewerStructuredResult{
 			ReviewerKey:       key,
 			ReviewerIndex:     idx,
 			ThreadID:          thread.ID.String(),
 			PromptArtifactKey: artifactKey,
 			NativeReview:      codeReviewAgentHasBuiltinReviewCommand(agentType),
 			ReadOnly:          true,
-		})
+		}
+		structured := marshalCodeReviewReviewerStructuredResult(reviewerState)
 		result := &models.CodeReviewAgentResult{
 			OrgID:            job.OrgID,
 			SessionID:        job.SessionID,
@@ -724,14 +727,18 @@ func ensureCodeReviewReviewerThreads(ctx context.Context, stores *Stores, servic
 		if err := stores.CodeReviews.CreateAgentResult(ctx, result); err != nil {
 			return fmt.Errorf("create code review reviewer result: %w", err)
 		}
-		if _, err := threads.SendMessage(ctx, threadsvc.SendMessageInput{
+		sendResult, err := threads.SendMessage(ctx, threadsvc.SendMessageInput{
 			SessionID:     job.SessionID,
 			OrgID:         job.OrgID,
 			ThreadID:      thread.ID,
 			Message:       codeReviewReviewerMessage(agentType, promptText),
 			Commands:      codeReviewNativeReviewCommands(agentType, promptText),
 			MessageSource: models.SessionMessageSourceAgentTool,
-		}); err != nil {
+		})
+		if err == nil && (sendResult == nil || sendResult.Message == nil) {
+			err = errors.New("code review reviewer message send returned no message")
+		}
+		if err != nil {
 			raw := err.Error()
 			if _, updateErr := stores.CodeReviews.UpdateAgentResultOutcome(ctx, job.OrgID, result.ID, models.CodeReviewAgentResultStatusFailed, &raw, marshalCodeReviewReviewerStructuredResult(codeReviewReviewerStructuredResult{
 				ReviewerKey:       key,
@@ -753,6 +760,9 @@ func ensureCodeReviewReviewerThreads(ctx context.Context, stores *Stores, servic
 				Msg("failed to start code review reviewer thread")
 			continue
 		}
+		reviewerState.RequestMessageID = sendResult.Message.ID
+		reviewerState.ExpectedTurn = sendResult.Message.TurnNumber
+		structured = marshalCodeReviewReviewerStructuredResult(reviewerState)
 		if _, err := stores.CodeReviews.UpdateAgentResultOutcome(ctx, job.OrgID, result.ID, models.CodeReviewAgentResultStatusRunning, nil, structured); err != nil {
 			return fmt.Errorf("mark code review reviewer running: %w", err)
 		}
@@ -898,6 +908,22 @@ func harvestCodeReviewReviewerResults(ctx context.Context, stores *Stores, servi
 			return fmt.Errorf("load code review reviewer thread: %w", err)
 		}
 		state.CostCents = thread.CostCents
+		expectedTurn := state.ExpectedTurn
+		if expectedTurn <= 0 {
+			// Reviewer threads are created solely for the review request, so
+			// historic in-flight results written before expected_turn was added
+			// always target their first turn.
+			expectedTurn = 1
+		}
+		threadFailed := thread.Status == models.ThreadStatusFailed || thread.Status == models.ThreadStatusCancelled
+		turnPersistenceFailed := strings.EqualFold(strings.TrimSpace(stringPtrValue(thread.FailureCategory)), "turn_persistence_failed")
+		if thread.CurrentTurn < expectedTurn && (!threadFailed || turnPersistenceFailed) {
+			// Assistant messages are written before the session and thread turn
+			// completion records. An idle thread with an assistant message but an
+			// older current_turn is an incomplete/retrying attempt, not a review
+			// result that can be harvested.
+			continue
+		}
 		if codeReviewThreadStillRunning(thread.Status) {
 			continue
 		}
@@ -911,12 +937,11 @@ func harvestCodeReviewReviewerResults(ctx context.Context, stores *Stores, servi
 				Str("reviewer", result.AgentProvider).
 				Msg("code review reviewer thread produced workspace changes; continuing")
 		}
-		raw, ok, err := latestAssistantMessageForThread(ctx, stores, job.OrgID, threadID)
+		raw, ok, err := latestAssistantMessageForThreadTurn(ctx, stores, job.OrgID, threadID, expectedTurn, state.RequestMessageID)
 		if err != nil {
 			return err
 		}
-		threadFailed := thread.Status == models.ThreadStatusFailed || thread.Status == models.ThreadStatusCancelled
-		if threadFailed && !codeReviewFailedReviewerThreadOutputUsable(thread, raw, ok) {
+		if threadFailed {
 			failure := strings.TrimSpace(stringPtrValue(thread.FailureExplanation))
 			if !ok {
 				raw = failure
@@ -938,13 +963,6 @@ func harvestCodeReviewReviewerResults(ctx context.Context, stores *Stores, servi
 				return fmt.Errorf("mark reviewer failed: %w", err)
 			}
 			continue
-		}
-		if threadFailed {
-			logger.Warn().
-				Str("session_id", job.SessionID.String()).
-				Str("thread_id", thread.ID.String()).
-				Str("reviewer", result.AgentProvider).
-				Msg("using persisted reviewer output from a subsequently failed thread")
 		}
 		if !ok {
 			if readOnlyViolation {
@@ -986,22 +1004,6 @@ func harvestCodeReviewReviewerResults(ctx context.Context, stores *Stores, servi
 		}
 	}
 	return nil
-}
-
-func codeReviewFailedReviewerThreadOutputUsable(thread models.SessionThread, raw string, ok bool) bool {
-	if !ok {
-		return false
-	}
-	output := strings.TrimSpace(raw)
-	if output == "" {
-		return false
-	}
-	failure := strings.TrimSpace(stringPtrValue(thread.FailureExplanation))
-	if failure != "" && strings.EqualFold(output, failure) {
-		return false
-	}
-	category := strings.ToLower(strings.TrimSpace(stringPtrValue(thread.FailureCategory)))
-	return category == "turn_persistence_failed"
 }
 
 func codeReviewReviewerResultsByKey(results []models.CodeReviewAgentResult) map[string]models.CodeReviewAgentResult {
@@ -1732,6 +1734,25 @@ func latestAssistantMessageForThread(ctx context.Context, stores *Stores, orgID,
 			continue
 		}
 		content := strings.TrimSpace(messages[i].Content)
+		if content == "" {
+			continue
+		}
+		return content, true, nil
+	}
+	return "", false, nil
+}
+
+func latestAssistantMessageForThreadTurn(ctx context.Context, stores *Stores, orgID, threadID uuid.UUID, turn int, afterMessageID int64) (string, bool, error) {
+	messages, err := stores.SessionMessages.ListByThread(ctx, orgID, threadID)
+	if err != nil {
+		return "", false, fmt.Errorf("list reviewer thread messages: %w", err)
+	}
+	for i := len(messages) - 1; i >= 0; i-- {
+		message := messages[i]
+		if message.Role != models.MessageRoleAssistant || message.TurnNumber != turn || message.ID <= afterMessageID {
+			continue
+		}
+		content := strings.TrimSpace(message.Content)
 		if content == "" {
 			continue
 		}

--- a/internal/worker/code_review_handler.go
+++ b/internal/worker/code_review_handler.go
@@ -595,6 +595,8 @@ type codeReviewReviewerStructuredResult struct {
 
 type codeReviewOrchestratorStructuredResult struct {
 	ThreadID           string                          `json:"thread_id,omitempty"`
+	RequestMessageID   int64                           `json:"request_message_id,omitempty"`
+	ExpectedTurn       int                             `json:"expected_turn,omitempty"`
 	PromptArtifactKey  string                          `json:"prompt_artifact_key,omitempty"`
 	FindingCount       int                             `json:"finding_count,omitempty"`
 	CostCents          float64                         `json:"cost_cents,omitempty"`
@@ -941,7 +943,7 @@ func harvestCodeReviewReviewerResults(ctx context.Context, stores *Stores, servi
 		if err != nil {
 			return err
 		}
-		if threadFailed {
+		if threadFailed && !codeReviewFailedThreadOutputUsable(thread, raw, ok, expectedTurn) {
 			failure := strings.TrimSpace(stringPtrValue(thread.FailureExplanation))
 			if !ok {
 				raw = failure
@@ -963,6 +965,14 @@ func harvestCodeReviewReviewerResults(ctx context.Context, stores *Stores, servi
 				return fmt.Errorf("mark reviewer failed: %w", err)
 			}
 			continue
+		}
+		if threadFailed {
+			logger.Warn().
+				Str("session_id", job.SessionID.String()).
+				Str("thread_id", thread.ID.String()).
+				Str("reviewer", result.AgentProvider).
+				Int("expected_turn", expectedTurn).
+				Msg("using durably completed reviewer output from a subsequently failed thread")
 		}
 		if !ok {
 			if readOnlyViolation {
@@ -1004,6 +1014,22 @@ func harvestCodeReviewReviewerResults(ctx context.Context, stores *Stores, servi
 		}
 	}
 	return nil
+}
+
+func codeReviewFailedThreadOutputUsable(thread models.SessionThread, raw string, ok bool, expectedTurn int) bool {
+	if !ok || thread.CurrentTurn < expectedTurn {
+		return false
+	}
+	output := strings.TrimSpace(raw)
+	if output == "" {
+		return false
+	}
+	failure := strings.TrimSpace(stringPtrValue(thread.FailureExplanation))
+	if failure != "" && strings.EqualFold(output, failure) {
+		return false
+	}
+	category := strings.ToLower(strings.TrimSpace(stringPtrValue(thread.FailureCategory)))
+	return category == "turn_persistence_failed"
 }
 
 func codeReviewReviewerResultsByKey(results []models.CodeReviewAgentResult) map[string]models.CodeReviewAgentResult {
@@ -1724,24 +1750,6 @@ func codeReviewThreadStillRunning(status models.ThreadStatus) bool {
 	return status == models.ThreadStatusPending || status == models.ThreadStatusRunning || status == models.ThreadStatusAwaitingInput
 }
 
-func latestAssistantMessageForThread(ctx context.Context, stores *Stores, orgID, threadID uuid.UUID) (string, bool, error) {
-	messages, err := stores.SessionMessages.ListByThread(ctx, orgID, threadID)
-	if err != nil {
-		return "", false, fmt.Errorf("list reviewer thread messages: %w", err)
-	}
-	for i := len(messages) - 1; i >= 0; i-- {
-		if messages[i].Role != models.MessageRoleAssistant {
-			continue
-		}
-		content := strings.TrimSpace(messages[i].Content)
-		if content == "" {
-			continue
-		}
-		return content, true, nil
-	}
-	return "", false, nil
-}
-
 func latestAssistantMessageForThreadTurn(ctx context.Context, stores *Stores, orgID, threadID uuid.UUID, turn int, afterMessageID int64) (string, bool, error) {
 	messages, err := stores.SessionMessages.ListByThread(ctx, orgID, threadID)
 	if err != nil {
@@ -1932,21 +1940,25 @@ func ensureCodeReviewOrchestratorThread(ctx context.Context, stores *Stores, ser
 			Str("orchestrator", string(agentType)).
 			Msg("retargeted code review primary thread to available orchestrator")
 	}
-	structured := marshalCodeReviewOrchestratorStructuredResult(codeReviewOrchestratorStructuredResult{
+	orchestratorState := codeReviewOrchestratorStructuredResult{
 		ThreadID:          threadID.String(),
 		PromptArtifactKey: artifactKey,
 		ReadOnly:          false,
-	})
+	}
 	// The orchestrator agent result is created only once the thread is actually
 	// dispatched. A transient claim race leaves no result behind, so the next
 	// run_code_review poll re-enters this function cleanly and retries.
-	if _, err := threads.SendMessage(ctx, threadsvc.SendMessageInput{
+	sendResult, err := threads.SendMessage(ctx, threadsvc.SendMessageInput{
 		SessionID:     job.SessionID,
 		OrgID:         job.OrgID,
 		ThreadID:      threadID,
 		Message:       promptText,
 		MessageSource: models.SessionMessageSourceAgentTool,
-	}); err != nil {
+	})
+	if err == nil && (sendResult == nil || sendResult.Message == nil) {
+		err = errors.New("code review orchestrator message send returned no message")
+	}
+	if err != nil {
 		// Transient: the session was momentarily non-resumable despite the reset
 		// above (e.g. re-parked by a sibling's sandbox-node retry between the
 		// reset and the claim). Don't record a permanent orchestrator failure —
@@ -1981,6 +1993,9 @@ func ensureCodeReviewOrchestratorThread(ctx context.Context, stores *Stores, ser
 		logger.Warn().Err(err).Str("thread_id", threadID.String()).Msg("failed to start code review orchestrator thread")
 		return nil
 	}
+	orchestratorState.RequestMessageID = sendResult.Message.ID
+	orchestratorState.ExpectedTurn = sendResult.Message.TurnNumber
+	structured := marshalCodeReviewOrchestratorStructuredResult(orchestratorState)
 	result := &models.CodeReviewAgentResult{
 		OrgID:            job.OrgID,
 		SessionID:        job.SessionID,
@@ -2048,6 +2063,17 @@ func harvestCodeReviewOrchestratorResult(ctx context.Context, stores *Stores, se
 			return fmt.Errorf("load code review orchestrator thread: %w", err)
 		}
 		state.CostCents = thread.CostCents
+		expectedTurn := state.ExpectedTurn
+		if expectedTurn <= 0 {
+			// Historic code-review primary threads had not run before the
+			// orchestrator request, so pre-field results target turn one.
+			expectedTurn = 1
+		}
+		threadFailed := thread.Status == models.ThreadStatusFailed || thread.Status == models.ThreadStatusCancelled
+		turnPersistenceFailed := strings.EqualFold(strings.TrimSpace(stringPtrValue(thread.FailureCategory)), "turn_persistence_failed")
+		if thread.CurrentTurn < expectedTurn && (!threadFailed || turnPersistenceFailed) {
+			continue
+		}
 		if codeReviewThreadStillRunning(thread.Status) {
 			continue
 		}
@@ -2064,26 +2090,41 @@ func harvestCodeReviewOrchestratorResult(ctx context.Context, stores *Stores, se
 				Bool("reverted", state.Reverted).
 				Msg("code review orchestrator thread produced workspace changes; ignoring for review validity")
 		}
-		raw, ok, err := latestAssistantMessageForThread(ctx, stores, job.OrgID, threadID)
+		raw, ok, err := latestAssistantMessageForThreadTurn(ctx, stores, job.OrgID, threadID, expectedTurn, state.RequestMessageID)
 		if err != nil {
 			return err
 		}
-		if !ok {
-			if thread.Status == models.ThreadStatusFailed || thread.Status == models.ThreadStatusCancelled {
-				raw = strings.TrimSpace(stringPtrValue(thread.FailureExplanation))
+		if threadFailed && !codeReviewFailedThreadOutputUsable(thread, raw, ok, expectedTurn) {
+			failure := strings.TrimSpace(stringPtrValue(thread.FailureExplanation))
+			if !ok {
+				raw = failure
 				if raw == "" {
 					raw = "orchestrator thread did not complete successfully"
 				}
-				state.Error = raw
-				rawOutput, rawArtifactKey, err := codeReviewRawOutputForStorage(ctx, stores, job, result.ID, models.CodeReviewAgentRoleOrchestrator, result.AgentProvider, raw)
-				if err != nil {
-					return err
-				}
-				state.RawArtifactKey = rawArtifactKey
-				if _, err := stores.CodeReviews.UpdateAgentResultOutcome(ctx, job.OrgID, result.ID, models.CodeReviewAgentResultStatusFailed, rawOutput, marshalCodeReviewOrchestratorStructuredResult(state)); err != nil {
-					return fmt.Errorf("mark orchestrator failed: %w", err)
-				}
 			}
+			if failure == "" {
+				failure = raw
+			}
+			state.Error = failure
+			rawOutput, rawArtifactKey, err := codeReviewRawOutputForStorage(ctx, stores, job, result.ID, models.CodeReviewAgentRoleOrchestrator, result.AgentProvider, raw)
+			if err != nil {
+				return err
+			}
+			state.RawArtifactKey = rawArtifactKey
+			if _, err := stores.CodeReviews.UpdateAgentResultOutcome(ctx, job.OrgID, result.ID, models.CodeReviewAgentResultStatusFailed, rawOutput, marshalCodeReviewOrchestratorStructuredResult(state)); err != nil {
+				return fmt.Errorf("mark orchestrator failed: %w", err)
+			}
+			continue
+		}
+		if threadFailed {
+			logger.Warn().
+				Str("session_id", job.SessionID.String()).
+				Str("thread_id", thread.ID.String()).
+				Str("orchestrator", result.AgentProvider).
+				Int("expected_turn", expectedTurn).
+				Msg("using durably completed orchestrator output from a subsequently failed thread")
+		}
+		if !ok {
 			continue
 		}
 		synthesis, synthesisErr := parseCodeReviewOrchestratorSynthesis(raw)

--- a/internal/worker/code_review_handler_test.go
+++ b/internal/worker/code_review_handler_test.go
@@ -926,11 +926,11 @@ func TestHarvestCodeReviewReviewerResultsClassifiesFailedThreadOutput(t *testing
 			expectedStatus:  models.CodeReviewAgentResultStatusFailed,
 		},
 		{
-			name:            "rejects assistant output after bookkeeping failure",
+			name:            "keeps durably completed review after bookkeeping failure",
 			failure:         "update interactive turn result: connection reset",
 			failureCategory: "turn_persistence_failed",
 			assistantOutput: "No actionable issues found.",
-			expectedStatus:  models.CodeReviewAgentResultStatusFailed,
+			expectedStatus:  models.CodeReviewAgentResultStatusCompleted,
 		},
 		{
 			name:            "rejects assistant text from an operational failure",
@@ -997,6 +997,42 @@ func TestHarvestCodeReviewReviewerResultsClassifiesFailedThreadOutput(t *testing
 
 			require.NoError(t, err, "failed reviewer output should be classified without stopping the harvest")
 			require.NoError(t, mock.ExpectationsWereMet(), "failed reviewer output should use valid completed reviews but reject operational error text")
+		})
+	}
+}
+
+func TestCodeReviewFailedThreadOutputUsableRequiresDurableTurn(t *testing.T) {
+	t.Parallel()
+
+	failure := "update interactive turn result: connection reset"
+	category := "turn_persistence_failed"
+	otherCategory := "sandbox_capacity"
+	tests := []struct {
+		name         string
+		currentTurn  int
+		expectedTurn int
+		output       string
+		failure      *string
+		category     *string
+		expected     bool
+	}{
+		{name: "rejects output before durable turn completion", currentTurn: 0, expectedTurn: 1, output: "No findings.", failure: &failure, category: &category},
+		{name: "accepts durable output after bookkeeping failure", currentTurn: 1, expectedTurn: 1, output: "No findings.", failure: &failure, category: &category, expected: true},
+		{name: "rejects operational failure output", currentTurn: 1, expectedTurn: 1, output: "No findings.", failure: &failure, category: &otherCategory},
+		{name: "rejects failure text echoed as output", currentTurn: 1, expectedTurn: 1, output: failure, failure: &failure, category: &category},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			thread := models.SessionThread{
+				CurrentTurn:        tt.currentTurn,
+				FailureExplanation: tt.failure,
+				FailureCategory:    tt.category,
+			}
+			actual := codeReviewFailedThreadOutputUsable(thread, tt.output, true, tt.expectedTurn)
+			require.Equal(t, tt.expected, actual, "failed reviewer output should only be usable after its exact turn durably completes")
 		})
 	}
 }
@@ -1262,6 +1298,53 @@ func TestHarvestCodeReviewOrchestratorResultPersistsFindings(t *testing.T) {
 
 	require.NoError(t, err, "orchestrator harvest should persist directive-backed findings")
 	require.NoError(t, mock.ExpectationsWereMet(), "orchestrator harvest should parse findings and mark the result completed")
+}
+
+func TestHarvestCodeReviewOrchestratorResultWaitsForDurableTurn(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "pgxmock pool should initialize")
+	defer mock.Close()
+
+	orgID := uuid.New()
+	sessionID := uuid.New()
+	threadID := uuid.New()
+	resultID := uuid.New()
+	now := time.Now().UTC()
+	state := marshalCodeReviewOrchestratorStructuredResult(codeReviewOrchestratorStructuredResult{
+		ThreadID:         threadID.String(),
+		RequestMessageID: 10,
+		ExpectedTurn:     1,
+	})
+
+	mock.ExpectQuery("(?s)SELECT .*FROM code_review_agent_results").
+		WithArgs(pgx.NamedArgs{"org_id": orgID, "session_id": sessionID}).
+		WillReturnRows(newCodeReviewAgentResultRows().
+			AddRow(resultID, orgID, sessionID, "codex", nil, models.CodeReviewAgentRoleOrchestrator, models.CodeReviewAgentResultStatusRunning, nil, state, now))
+	mock.ExpectQuery("(?s)SELECT .*FROM session_threads").
+		WithArgs(pgx.NamedArgs{"id": threadID, "org_id": orgID}).
+		WillReturnRows(newSessionThreadRows().
+			AddRow(threadID, sessionID, orgID, models.AgentTypeCodex, nil,
+				"Main", nil, []string{"internal/worker/code_review_handler.go"}, models.ThreadStatusIdle,
+				nil, 0, &now, nil, nil, nil, nil,
+				&now, nil, now, models.ThreadCreatedBySourceSystem, nil, nil,
+				nil, 0.25, 0, nil, "", nil, "", "", json.RawMessage(`[]`),
+				models.ThreadExecutionModeWork, models.ThreadFilesystemModeReadWrite))
+
+	policy := codeReviewPolicyRecordForTest(models.DefaultCodeReviewPolicyConfig())
+	stores := &Stores{
+		CodeReviews:     db.NewCodeReviewStore(mock),
+		SessionThreads:  db.NewSessionThreadStore(mock),
+		SessionMessages: db.NewSessionMessageStore(mock),
+	}
+	err = harvestCodeReviewOrchestratorResult(context.Background(), stores, nil, zerolog.Nop(), runCodeReviewPayload{
+		OrgID:     orgID,
+		SessionID: sessionID,
+	}, policy, models.CodeReviewSessionMetadata{CreatedAt: now}, []codereview.PullRequestFile{{Filename: "internal/worker/code_review_handler.go"}})
+
+	require.NoError(t, err, "orchestrator harvest should wait for the requested turn to durably complete")
+	require.NoError(t, mock.ExpectationsWereMet(), "orchestrator harvest should not read or finalize pre-commit assistant output")
 }
 
 type validatedOrchestratorResultArg struct{}

--- a/internal/worker/code_review_handler_test.go
+++ b/internal/worker/code_review_handler_test.go
@@ -773,6 +773,81 @@ func TestHarvestCodeReviewReviewerResultsIgnoresReadOnlyWorkspaceChanges(t *test
 	require.NoError(t, mock.ExpectationsWereMet(), "reviewer harvest should parse output and mark the result completed")
 }
 
+func TestHarvestCodeReviewReviewerResultsWaitsForDurableTurnAndUsesRetryOutput(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "pgxmock pool should initialize")
+	defer mock.Close()
+
+	orgID := uuid.New()
+	sessionID := uuid.New()
+	threadID := uuid.New()
+	resultID := uuid.New()
+	now := time.Now().UTC()
+	staleReview := "Review blocked: workspace HEAD does not match the required PR head."
+	completedReview := "No actionable issues found."
+	state := marshalCodeReviewReviewerStructuredResult(codeReviewReviewerStructuredResult{
+		ReviewerKey:      codeReviewReviewerKey(0, models.AgentTypeCodex),
+		ReviewerIndex:    0,
+		ThreadID:         threadID.String(),
+		RequestMessageID: 10,
+		ExpectedTurn:     1,
+		ReadOnly:         true,
+	})
+
+	expectResult := func() {
+		mock.ExpectQuery("(?s)SELECT .*FROM code_review_agent_results").
+			WithArgs(pgx.NamedArgs{"org_id": orgID, "session_id": sessionID}).
+			WillReturnRows(newCodeReviewAgentResultRows().
+				AddRow(resultID, orgID, sessionID, "codex", nil, models.CodeReviewAgentRoleReviewer, models.CodeReviewAgentResultStatusRunning, nil, state, now))
+	}
+	expectThread := func(currentTurn int) {
+		mock.ExpectQuery("(?s)SELECT .*FROM session_threads").
+			WithArgs(pgx.NamedArgs{"id": threadID, "org_id": orgID}).
+			WillReturnRows(newSessionThreadRows().
+				AddRow(threadID, sessionID, orgID, models.AgentTypeCodex, nil,
+					"Code review: codex", nil, []string{"internal/db/users.go"}, models.ThreadStatusIdle,
+					nil, currentTurn, &now, nil, nil, nil, nil,
+					&now, nil, now, models.ThreadCreatedBySourceSystem, nil, nil,
+					nil, 0.25, 0, nil, "", nil, "", "", json.RawMessage(`[]`),
+					models.ThreadExecutionModeReview, models.ThreadFilesystemModeReadOnly))
+	}
+
+	cfg := models.DefaultCodeReviewPolicyConfig()
+	policy := codeReviewPolicyRecordForTest(cfg)
+	stores := &Stores{
+		CodeReviews:     db.NewCodeReviewStore(mock),
+		SessionThreads:  db.NewSessionThreadStore(mock),
+		SessionMessages: db.NewSessionMessageStore(mock),
+	}
+	job := runCodeReviewPayload{OrgID: orgID, SessionID: sessionID}
+	metadata := models.CodeReviewSessionMetadata{CreatedAt: now}
+	changedFiles := []codereview.PullRequestFile{{Filename: "internal/db/users.go"}}
+
+	expectResult()
+	expectThread(0)
+	err = harvestCodeReviewReviewerResults(context.Background(), stores, nil, zerolog.Nop(), job, policy, metadata, changedFiles)
+	require.NoError(t, err, "harvest should wait while the requested turn has not durably completed")
+
+	expectResult()
+	expectThread(1)
+	mock.ExpectQuery("(?s)SELECT .*FROM session_messages").
+		WithArgs(pgx.NamedArgs{"org_id": orgID, "thread_id": threadID}).
+		WillReturnRows(newSessionMessageRows().
+			AddRow(int64(10), sessionID, orgID, &threadID, nil, 1, models.MessageRoleUser, "review this PR", nil, nil, nil, nil, "", now).
+			AddRow(int64(11), sessionID, orgID, &threadID, nil, 1, models.MessageRoleAssistant, staleReview, nil, nil, nil, nil, "", now).
+			AddRow(int64(12), sessionID, orgID, &threadID, nil, 1, models.MessageRoleAssistant, completedReview, nil, nil, nil, nil, "", now.Add(time.Second)))
+	mock.ExpectQuery("UPDATE code_review_agent_results").
+		WithArgs(models.CodeReviewAgentResultStatusCompleted, &completedReview, pgxmock.AnyArg(), orgID, resultID).
+		WillReturnRows(newCodeReviewAgentResultRows().
+			AddRow(resultID, orgID, sessionID, "codex", nil, models.CodeReviewAgentRoleReviewer, models.CodeReviewAgentResultStatusCompleted, &completedReview, state, now))
+
+	err = harvestCodeReviewReviewerResults(context.Background(), stores, nil, zerolog.Nop(), job, policy, metadata, changedFiles)
+	require.NoError(t, err, "harvest should complete from the newest output for the durably completed turn")
+	require.NoError(t, mock.ExpectationsWereMet(), "harvest should ignore stale retry output until the thread turn commits")
+}
+
 func TestHarvestCodeReviewReviewerResultsCompletesIdleReadOnlyViolationWithoutAssistantMessage(t *testing.T) {
 	t.Parallel()
 
@@ -851,11 +926,11 @@ func TestHarvestCodeReviewReviewerResultsClassifiesFailedThreadOutput(t *testing
 			expectedStatus:  models.CodeReviewAgentResultStatusFailed,
 		},
 		{
-			name:            "keeps a completed review after bookkeeping failure",
+			name:            "rejects assistant output after bookkeeping failure",
 			failure:         "update interactive turn result: connection reset",
 			failureCategory: "turn_persistence_failed",
 			assistantOutput: "No actionable issues found.",
-			expectedStatus:  models.CodeReviewAgentResultStatusCompleted,
+			expectedStatus:  models.CodeReviewAgentResultStatusFailed,
 		},
 		{
 			name:            "rejects assistant text from an operational failure",

--- a/internal/worker/handlers.go
+++ b/internal/worker/handlers.go
@@ -10083,7 +10083,13 @@ func newContinueSessionHandler(stores *Stores, services *Services, logger zerolo
 					Diff:          diffPtr,
 				}
 				if err := stores.SessionThreads.UpdateTurnComplete(ctx, orgID, threadID, threadTurnBefore+1, threadResult, resultAgentSessionID); err != nil {
-					return fmt.Errorf("persist session thread turn result: %w", err)
+					if session.Origin == models.SessionOriginCodeReview {
+						return fmt.Errorf("persist code review thread turn result: %w", err)
+					}
+					logger.Warn().Err(err).
+						Str("session_id", sessionID.String()).
+						Str("thread_id", threadID.String()).
+						Msg("failed to persist session thread turn result")
 				}
 				if services.ReviewLoops != nil {
 					if err := services.ReviewLoops.OnThreadTurnComplete(ctx, orgID, threadID, lastTurnResult.Summary); err != nil && !errors.Is(err, reviewloopsvc.ErrNoRunningReviewLoop) {

--- a/internal/worker/handlers.go
+++ b/internal/worker/handlers.go
@@ -10083,10 +10083,7 @@ func newContinueSessionHandler(stores *Stores, services *Services, logger zerolo
 					Diff:          diffPtr,
 				}
 				if err := stores.SessionThreads.UpdateTurnComplete(ctx, orgID, threadID, threadTurnBefore+1, threadResult, resultAgentSessionID); err != nil {
-					logger.Warn().Err(err).
-						Str("session_id", sessionID.String()).
-						Str("thread_id", threadID.String()).
-						Msg("failed to persist session thread turn result")
+					return fmt.Errorf("persist session thread turn result: %w", err)
 				}
 				if services.ReviewLoops != nil {
 					if err := services.ReviewLoops.OnThreadTurnComplete(ctx, orgID, threadID, lastTurnResult.Summary); err != nil && !errors.Is(err, reviewloopsvc.ErrNoRunningReviewLoop) {

--- a/internal/worker/handlers_test.go
+++ b/internal/worker/handlers_test.go
@@ -12114,47 +12114,64 @@ func TestContinueSessionHandler_ThreadCompleteTurnUsesThreadTurn(t *testing.T) {
 func TestContinueSessionHandler_ReturnsThreadTurnPersistenceFailure(t *testing.T) {
 	t.Parallel()
 
-	stores, mock := newTestStores(t)
-	defer mock.Close()
-	stores.SessionThreads = db.NewSessionThreadStore(mock)
-
-	orgID := uuid.New()
-	sessionID := uuid.New()
-	threadID := uuid.New()
-	issueID := uuid.New()
-	threadModel := models.OpenCodeModelGemini3Flash
-	persistErr := errors.New("database unavailable")
-
-	mock.ExpectQuery("SELECT .* FROM sessions").
-		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
-		WillReturnRows(
-			pgxmock.NewRows(workerSessionColumns).AddRow(
-				workerSessionRow(sessionID, issueID, orgID, models.SessionStatusIdle, 5, nil, nil)...,
-			),
-		)
-	mock.ExpectQuery("SELECT .* FROM session_threads").
-		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
-		WillReturnRows(pgxmock.NewRows(workerSessionThreadColumns).AddRow(
-			workerSessionThreadRow(threadID, sessionID, orgID, models.AgentTypeOpenCode, &threadModel, models.ThreadStatusRunning)...,
-		))
-	mock.ExpectExec(`UPDATE session_threads`).
-		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), threadID, orgID).
-		WillReturnError(persistErr)
-
-	orch := &orchestratorServiceStub{
-		continueSessionFn: func(_ context.Context, _ *models.Session, opts *agent.ContinueSessionOptions) error {
-			require.NotNil(t, opts, "thread continuation should pass execution options")
-			require.NotNil(t, opts.OnTurnComplete, "thread continuation should expose the completed result")
-			opts.OnTurnComplete(&agent.AgentResult{Summary: "review complete"})
-			return nil
-		},
+	tests := []struct {
+		name         string
+		origin       models.SessionOrigin
+		expectsError bool
+	}{
+		{name: "code review retries", origin: models.SessionOriginCodeReview, expectsError: true},
+		{name: "ordinary thread preserves best effort behavior", origin: models.SessionOriginManual},
 	}
-	handler := newContinueSessionHandler(stores, &Services{Orchestrator: orch}, zerolog.Nop())
-	payload := json.RawMessage(`{"session_id":"` + sessionID.String() + `","org_id":"` + orgID.String() + `","thread_id":"` + threadID.String() + `"}`)
 
-	err := handler(context.Background(), "continue_session", payload)
-	require.ErrorIs(t, err, persistErr, "continue_session should retry when the durable thread completion marker cannot be written")
-	require.NoError(t, mock.ExpectationsWereMet(), "thread completion persistence failure should be returned after the agent result is available")
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			stores, mock := newTestStores(t)
+			defer mock.Close()
+			stores.SessionThreads = db.NewSessionThreadStore(mock)
+
+			orgID := uuid.New()
+			sessionID := uuid.New()
+			threadID := uuid.New()
+			issueID := uuid.New()
+			threadModel := models.OpenCodeModelGemini3Flash
+			persistErr := errors.New("database unavailable")
+
+			sessionRow := workerSessionRow(sessionID, issueID, orgID, models.SessionStatusIdle, 5, nil, nil)
+			setWorkerSessionColumn(sessionRow, "origin", tt.origin)
+			mock.ExpectQuery("SELECT .* FROM sessions").
+				WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+				WillReturnRows(pgxmock.NewRows(workerSessionColumns).AddRow(sessionRow...))
+			mock.ExpectQuery("SELECT .* FROM session_threads").
+				WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+				WillReturnRows(pgxmock.NewRows(workerSessionThreadColumns).AddRow(
+					workerSessionThreadRow(threadID, sessionID, orgID, models.AgentTypeOpenCode, &threadModel, models.ThreadStatusRunning)...,
+				))
+			mock.ExpectExec(`UPDATE session_threads`).
+				WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), threadID, orgID).
+				WillReturnError(persistErr)
+
+			orch := &orchestratorServiceStub{
+				continueSessionFn: func(_ context.Context, _ *models.Session, opts *agent.ContinueSessionOptions) error {
+					require.NotNil(t, opts, "thread continuation should pass execution options")
+					require.NotNil(t, opts.OnTurnComplete, "thread continuation should expose the completed result")
+					opts.OnTurnComplete(&agent.AgentResult{Summary: "review complete"})
+					return nil
+				},
+			}
+			handler := newContinueSessionHandler(stores, &Services{Orchestrator: orch}, zerolog.Nop())
+			payload := json.RawMessage(`{"session_id":"` + sessionID.String() + `","org_id":"` + orgID.String() + `","thread_id":"` + threadID.String() + `"}`)
+
+			err := handler(context.Background(), "continue_session", payload)
+			if tt.expectsError {
+				require.ErrorIs(t, err, persistErr, "code review continuation should retry when the durable thread completion marker cannot be written")
+			} else {
+				require.NoError(t, err, "ordinary thread continuation should preserve best-effort thread result persistence")
+			}
+			require.NoError(t, mock.ExpectationsWereMet(), "thread completion persistence should follow the origin-specific retry policy")
+		})
+	}
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/worker/handlers_test.go
+++ b/internal/worker/handlers_test.go
@@ -12111,6 +12111,52 @@ func TestContinueSessionHandler_ThreadCompleteTurnUsesThreadTurn(t *testing.T) {
 	require.NoError(t, mock.ExpectationsWereMet(), "thread current_turn must come from the thread's own counter, not the session's")
 }
 
+func TestContinueSessionHandler_ReturnsThreadTurnPersistenceFailure(t *testing.T) {
+	t.Parallel()
+
+	stores, mock := newTestStores(t)
+	defer mock.Close()
+	stores.SessionThreads = db.NewSessionThreadStore(mock)
+
+	orgID := uuid.New()
+	sessionID := uuid.New()
+	threadID := uuid.New()
+	issueID := uuid.New()
+	threadModel := models.OpenCodeModelGemini3Flash
+	persistErr := errors.New("database unavailable")
+
+	mock.ExpectQuery("SELECT .* FROM sessions").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(
+			pgxmock.NewRows(workerSessionColumns).AddRow(
+				workerSessionRow(sessionID, issueID, orgID, models.SessionStatusIdle, 5, nil, nil)...,
+			),
+		)
+	mock.ExpectQuery("SELECT .* FROM session_threads").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(pgxmock.NewRows(workerSessionThreadColumns).AddRow(
+			workerSessionThreadRow(threadID, sessionID, orgID, models.AgentTypeOpenCode, &threadModel, models.ThreadStatusRunning)...,
+		))
+	mock.ExpectExec(`UPDATE session_threads`).
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), threadID, orgID).
+		WillReturnError(persistErr)
+
+	orch := &orchestratorServiceStub{
+		continueSessionFn: func(_ context.Context, _ *models.Session, opts *agent.ContinueSessionOptions) error {
+			require.NotNil(t, opts, "thread continuation should pass execution options")
+			require.NotNil(t, opts.OnTurnComplete, "thread continuation should expose the completed result")
+			opts.OnTurnComplete(&agent.AgentResult{Summary: "review complete"})
+			return nil
+		},
+	}
+	handler := newContinueSessionHandler(stores, &Services{Orchestrator: orch}, zerolog.Nop())
+	payload := json.RawMessage(`{"session_id":"` + sessionID.String() + `","org_id":"` + orgID.String() + `","thread_id":"` + threadID.String() + `"}`)
+
+	err := handler(context.Background(), "continue_session", payload)
+	require.ErrorIs(t, err, persistErr, "continue_session should retry when the durable thread completion marker cannot be written")
+	require.NoError(t, mock.ExpectationsWereMet(), "thread completion persistence failure should be returned after the agent result is available")
+}
+
 // ---------------------------------------------------------------------------
 // parseOrgID additional tests
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- bind reviewer and orchestrator results to the exact request message and thread turn
- wait for `session_threads.current_turn` to confirm durable completion before harvesting assistant output
- select the newest assistant output from only the expected turn, so successful retries supersede provisional output
- retry code-review thread-result persistence failures without changing best-effort behavior for ordinary mutable threads

## Root cause

Code-review assistant messages are persisted before the session and thread turn-completion records. If bookkeeping fails after the message write, the review harvester could treat provisional output as terminal. In the investigated incident, it captured an early mismatched-HEAD response even though a retry later completed successfully.

Main now also guards reused code-review workspaces before execution. This PR complements that execution barrier by ensuring downstream reviewer and orchestrator results are accepted only after their exact turns commit.

## Impact

Code reviews no longer finalize from stale output left by an incomplete attempt. Retries for the same turn can safely supersede earlier assistant messages, while durably completed output remains usable after a later bookkeeping-only failure.

## Validation

- `go test ./internal/worker`
- focused reused-workspace tests in `./internal/services/agent`
- `go vet ./internal/worker ./internal/services/agent`
- `git diff --check`
