### PR TITLE
Handle GitHub rate limits in review jobs

### DIFF
--- a/docs/design/implemented/01-database-schema.md
+++ b/docs/design/implemented/01-database-schema.md
@@ -975,6 +975,7 @@ Durable, database-backed async work queue for the full pipeline (`ingest_webhook
 | locked_at | timestamptz | when worker claimed job |
 | last_error | text | latest error message |
 | dedupe_key | text | optional idempotency key for coalescing duplicates |
+| retry_window_started_at | timestamptz | first bounded external retry, preserved across worker restarts |
 | created_at | timestamptz | |
 | updated_at | timestamptz | |
 | completed_at | timestamptz | nullable |

--- a/docs/design/implemented/02-api-server.md
+++ b/docs/design/implemented/02-api-server.md
@@ -443,6 +443,7 @@ CREATE TABLE jobs (
     locked_at timestamptz,
     last_error text,
     dedupe_key text,
+    retry_window_started_at timestamptz,
     created_at timestamptz NOT NULL DEFAULT now(),
     updated_at timestamptz NOT NULL DEFAULT now(),
     completed_at timestamptz

--- a/internal/db/job_store_test.go
+++ b/internal/db/job_store_test.go
@@ -506,11 +506,13 @@ func TestJobStore_Notify_PublishFailureIsBestEffort(t *testing.T) {
 func TestJobStore_ClaimNextRunnable(t *testing.T) {
 	t.Parallel()
 
+	persistedRetryStart := time.Date(2026, time.July, 21, 19, 0, 0, 0, time.UTC)
 	tests := []struct {
-		name      string
-		setupMock func(mock pgxmock.PgxPoolIface, leaseDuration time.Duration, lockToken uuid.UUID)
-		expectNil bool
-		expectErr bool
+		name                     string
+		setupMock                func(mock pgxmock.PgxPoolIface, leaseDuration time.Duration, lockToken uuid.UUID)
+		expectNil                bool
+		expectErr                bool
+		expectedRetryWindowStart *time.Time
 	}{
 		{
 			name: "claims next due job with lease and fencing token",
@@ -524,10 +526,10 @@ func TestJobStore_ClaimNextRunnable(t *testing.T) {
 						"id", "org_id", "queue", "job_type", "payload", "priority", "status",
 						"attempts", "max_attempts", "run_at", "locked_by_node_id", "locked_at",
 						"lease_expires_at", "lock_token", "run_owner_id", "owner_kind", "last_error",
-						"dedupe_key", "target_node_id", "created_at", "updated_at", "completed_at",
+						"dedupe_key", "target_node_id", "retry_window_started_at", "created_at", "updated_at", "completed_at",
 					}).AddRow(
 						jobID, orgID, "default", "run_agent", []byte(`{"session_id":"abc"}`), 5, "running",
-						1, 3, now, "worker-1", now, now.Add(leaseDuration), lockToken.String(), "worker-1", "worker", nil, nil, nil, now, now, nil,
+						1, 3, now, "worker-1", now, now.Add(leaseDuration), lockToken.String(), "worker-1", "worker", nil, nil, nil, nil, now, now, nil,
 					))
 			},
 		},
@@ -544,12 +546,13 @@ func TestJobStore_ClaimNextRunnable(t *testing.T) {
 						"id", "org_id", "queue", "job_type", "payload", "priority", "status",
 						"attempts", "max_attempts", "run_at", "locked_by_node_id", "locked_at",
 						"lease_expires_at", "lock_token", "run_owner_id", "owner_kind", "last_error",
-						"dedupe_key", "target_node_id", "created_at", "updated_at", "completed_at",
+						"dedupe_key", "target_node_id", "retry_window_started_at", "created_at", "updated_at", "completed_at",
 					}).AddRow(
 						jobID, orgID, "default", "run_agent", []byte(`{"session_id":"abc"}`), 5, "running",
-						1, 3, now, "worker-1", now, now.Add(leaseDuration), lockToken.String(), "worker-1", "worker", "boom", "dedupe-1", "worker-1", now, now, completedAt,
+						1, 3, now, "worker-1", now, now.Add(leaseDuration), lockToken.String(), "worker-1", "worker", "boom", "dedupe-1", "worker-1", persistedRetryStart, now, now, completedAt,
 					))
 			},
+			expectedRetryWindowStart: &persistedRetryStart,
 		},
 		{
 			name: "returns nil when no pending job exists",
@@ -596,7 +599,83 @@ func TestJobStore_ClaimNextRunnable(t *testing.T) {
 			} else {
 				require.NotNil(t, job, "ClaimNextRunnable should return the claimed job")
 				require.Equal(t, lockToken, *job.LockToken, "ClaimNextRunnable should persist the fencing token")
+				require.Equal(t, tt.expectedRetryWindowStart, job.RetryWindowStartedAt, "ClaimNextRunnable should hydrate the durable retry window start")
 			}
+			require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
+		})
+	}
+}
+
+func TestJobStore_EnsureRetryWindowStartedAtWithLease(t *testing.T) {
+	t.Parallel()
+
+	requestedStart := time.Date(2026, time.July, 21, 19, 0, 0, 0, time.UTC)
+	existingStart := requestedStart.Add(-time.Hour)
+	tests := []struct {
+		name          string
+		setupMock     func(mock pgxmock.PgxPoolIface, jobID, lockToken uuid.UUID)
+		expectedStart time.Time
+		expectedOK    bool
+		expectErr     bool
+	}{
+		{
+			name: "records first retry window",
+			setupMock: func(mock pgxmock.PgxPoolIface, jobID, lockToken uuid.UUID) {
+				mock.ExpectQuery("UPDATE jobs[\\s\\S]+retry_window_started_at = COALESCE\\(retry_window_started_at, \\$1\\)").
+					WithArgs(requestedStart, jobID, lockToken).
+					WillReturnRows(pgxmock.NewRows([]string{"retry_window_started_at"}).AddRow(requestedStart))
+			},
+			expectedStart: requestedStart,
+			expectedOK:    true,
+		},
+		{
+			name: "preserves existing retry window",
+			setupMock: func(mock pgxmock.PgxPoolIface, jobID, lockToken uuid.UUID) {
+				mock.ExpectQuery("UPDATE jobs[\\s\\S]+retry_window_started_at = COALESCE\\(retry_window_started_at, \\$1\\)").
+					WithArgs(requestedStart, jobID, lockToken).
+					WillReturnRows(pgxmock.NewRows([]string{"retry_window_started_at"}).AddRow(existingStart))
+			},
+			expectedStart: existingStart,
+			expectedOK:    true,
+		},
+		{
+			name: "reports lost ownership",
+			setupMock: func(mock pgxmock.PgxPoolIface, jobID, lockToken uuid.UUID) {
+				mock.ExpectQuery("UPDATE jobs[\\s\\S]+retry_window_started_at").
+					WithArgs(requestedStart, jobID, lockToken).
+					WillReturnError(pgx.ErrNoRows)
+			},
+		},
+		{
+			name: "wraps database failure",
+			setupMock: func(mock pgxmock.PgxPoolIface, jobID, lockToken uuid.UUID) {
+				mock.ExpectQuery("UPDATE jobs[\\s\\S]+retry_window_started_at").
+					WithArgs(requestedStart, jobID, lockToken).
+					WillReturnError(errors.New("db unavailable"))
+			},
+			expectErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			mock, err := pgxmock.NewPool()
+			require.NoError(t, err, "pgxmock pool should initialize")
+			defer mock.Close()
+			jobID := uuid.New()
+			lockToken := uuid.New()
+			tt.setupMock(mock, jobID, lockToken)
+
+			actual, ok, err := NewJobStore(mock).EnsureRetryWindowStartedAtWithLease(context.Background(), jobID, lockToken, requestedStart)
+			if tt.expectErr {
+				require.Error(t, err, "EnsureRetryWindowStartedAtWithLease should return database failures")
+			} else {
+				require.NoError(t, err, "EnsureRetryWindowStartedAtWithLease should complete without error")
+			}
+			require.Equal(t, tt.expectedOK, ok, "EnsureRetryWindowStartedAtWithLease should report fenced ownership")
+			require.Equal(t, tt.expectedStart, actual, "EnsureRetryWindowStartedAtWithLease should return the durable first retry time")
 			require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
 		})
 	}

--- a/internal/db/jobs.go
+++ b/internal/db/jobs.go
@@ -645,7 +645,7 @@ func (s *JobStore) DeleteExpiredCompleted(ctx context.Context, retentionDays int
 const claimedJobColumns = `j.id, j.org_id, j.queue, j.job_type, j.payload, j.priority, j.status,
 	j.attempts, j.max_attempts, j.run_at, j.locked_by_node_id, j.locked_at,
 	j.lease_expires_at, j.lock_token, j.run_owner_id, j.owner_kind, j.last_error,
-	j.dedupe_key, j.target_node_id, j.created_at, j.updated_at, j.completed_at`
+	j.dedupe_key, j.target_node_id, j.retry_window_started_at, j.created_at, j.updated_at, j.completed_at`
 
 // nodeDeadHeartbeatThreshold is how long a node can go without heartbeating
 // before its pinned jobs become claimable by any worker. Set generously
@@ -737,12 +737,13 @@ func scanJobRow(row pgx.Row) (*models.Job, error) {
 	var lastError pgtype.Text
 	var dedupeKey pgtype.Text
 	var targetNodeID pgtype.Text
+	var retryWindowStartedAt pgtype.Timestamptz
 	var completedAt pgtype.Timestamptz
 	err := row.Scan(
 		&job.ID, &job.OrgID, &job.Queue, &job.JobType, &job.Payload, &job.Priority,
 		&job.Status, &job.Attempts, &job.MaxAttempts, &job.RunAt, &lockedByNodeID,
 		&lockedAt, &leaseExpiresAt, &persistedLockToken, &runOwnerID,
-		&ownerKind, &lastError, &dedupeKey, &targetNodeID, &job.CreatedAt, &job.UpdatedAt, &completedAt,
+		&ownerKind, &lastError, &dedupeKey, &targetNodeID, &retryWindowStartedAt, &job.CreatedAt, &job.UpdatedAt, &completedAt,
 	)
 	if err != nil {
 		return nil, err
@@ -773,10 +774,36 @@ func scanJobRow(row pgx.Row) (*models.Job, error) {
 	if targetNodeID.Valid {
 		job.TargetNodeID = &targetNodeID.String
 	}
+	if retryWindowStartedAt.Valid {
+		job.RetryWindowStartedAt = &retryWindowStartedAt.Time
+	}
 	if completedAt.Valid {
 		job.CompletedAt = &completedAt.Time
 	}
 	return &job, nil
+}
+
+// EnsureRetryWindowStartedAtWithLease records the first bounded retry under
+// the current fencing token and returns the durable start time. Repeated calls
+// preserve the original timestamp so worker restarts cannot extend the window.
+// lint:allow-no-orgid reason="worker queue consumer updates cross-org jobs by globally unique fenced job id"
+func (s *JobStore) EnsureRetryWindowStartedAtWithLease(ctx context.Context, jobID, lockToken uuid.UUID, startedAt time.Time) (time.Time, bool, error) {
+	var persisted time.Time
+	err := s.db.QueryRow(ctx, `
+		UPDATE jobs
+		SET retry_window_started_at = COALESCE(retry_window_started_at, $1),
+			updated_at = now()
+		WHERE id = $2
+		  AND status = 'running'
+		  AND lock_token = $3
+		RETURNING retry_window_started_at`, startedAt, jobID, lockToken).Scan(&persisted)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return time.Time{}, false, nil
+	}
+	if err != nil {
+		return time.Time{}, false, fmt.Errorf("ensure retry window started at with lease: %w", err)
+	}
+	return persisted, true, nil
 }
 
 // GetRunningForSessionExecutor returns the running job only when the executor

--- a/internal/db/session_executor_store_test.go
+++ b/internal/db/session_executor_store_test.go
@@ -533,11 +533,11 @@ func TestJobStore_GetRunningForSessionExecutor(t *testing.T) {
 			"id", "org_id", "queue", "job_type", "payload", "priority", "status",
 			"attempts", "max_attempts", "run_at", "locked_by_node_id", "locked_at",
 			"lease_expires_at", "lock_token", "run_owner_id", "owner_kind", "last_error",
-			"dedupe_key", "target_node_id", "created_at", "updated_at", "completed_at",
+			"dedupe_key", "target_node_id", "retry_window_started_at", "created_at", "updated_at", "completed_at",
 		}).AddRow(
 			jobID, orgID, "default", "run_agent", []byte(`{"session_id":"abc"}`), 5, "running",
 			1, 3, now, "worker-1", now, now.Add(time.Minute), lockToken.String(), executorID.String(), "session_executor", nil,
-			nil, nil, now, now, nil,
+			nil, nil, nil, now, now, nil,
 		))
 
 	job, ok, err := store.GetRunningForSessionExecutor(context.Background(), orgID, jobID, lockToken, executorID)

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -1124,10 +1124,14 @@ type Job struct {
 	// docker daemon as the session's recorded container_id. NULL means any
 	// worker can claim. A pinned job becomes claimable by any worker if its
 	// target node is marked dead in the `nodes` table (starvation safety).
-	TargetNodeID *string    `db:"target_node_id" json:"target_node_id,omitempty"`
-	CreatedAt    time.Time  `db:"created_at" json:"created_at"`
-	UpdatedAt    time.Time  `db:"updated_at" json:"updated_at"`
-	CompletedAt  *time.Time `db:"completed_at" json:"completed_at,omitempty"`
+	TargetNodeID *string `db:"target_node_id" json:"target_node_id,omitempty"`
+	// RetryWindowStartedAt records the first bounded external retry for this job.
+	// It is set once under the job's fencing token so retry limits survive worker
+	// restarts without counting unrelated queue or execution time.
+	RetryWindowStartedAt *time.Time `db:"retry_window_started_at" json:"retry_window_started_at,omitempty"`
+	CreatedAt            time.Time  `db:"created_at" json:"created_at"`
+	UpdatedAt            time.Time  `db:"updated_at" json:"updated_at"`
+	CompletedAt          *time.Time `db:"completed_at" json:"completed_at,omitempty"`
 }
 
 // SessionWorkerTarget returns the worker_node_id to pin sandbox-bound jobs

--- a/internal/services/codereview/github_submitter.go
+++ b/internal/services/codereview/github_submitter.go
@@ -5,12 +5,15 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
 	"net/url"
 	"strings"
 	"time"
+
+	ghservice "github.com/assembledhq/143/internal/services/github"
 )
 
 type InstallationTokenProvider interface {
@@ -240,7 +243,7 @@ func (s *GitHubSubmitter) SubmitReview(ctx context.Context, req SubmitReviewRequ
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return SubmitReviewResult{}, fmt.Errorf("submit GitHub review returned %d: %s", resp.StatusCode, readGitHubErrorBody(resp))
+		return SubmitReviewResult{}, fmt.Errorf("submit GitHub review: %w", readGitHubAPIResponseError(httpReq, resp))
 	}
 	var decoded struct {
 		ID      int64  `json:"id"`
@@ -361,7 +364,7 @@ func (s *GitHubSubmitter) ensureFormalApproval(ctx context.Context, token, owner
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return fmt.Errorf("submit formal GitHub approval returned %d: %s", resp.StatusCode, readGitHubErrorBody(resp))
+		return fmt.Errorf("submit formal GitHub approval: %w", readGitHubAPIResponseError(httpReq, resp))
 	}
 	return nil
 }
@@ -386,7 +389,7 @@ func (s *GitHubSubmitter) updateReviewSummary(ctx context.Context, token, owner,
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return SubmitReviewResult{}, fmt.Errorf("update GitHub review summary returned %d: %s", resp.StatusCode, readGitHubErrorBody(resp))
+		return SubmitReviewResult{}, fmt.Errorf("update GitHub review summary: %w", readGitHubAPIResponseError(httpReq, resp))
 	}
 	var decoded struct {
 		ID      int64  `json:"id"`
@@ -423,7 +426,7 @@ func (s *GitHubSubmitter) createReviewComment(ctx context.Context, token, owner,
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return SubmitReviewPostedComment{}, fmt.Errorf("create GitHub review comment returned %d: %s", resp.StatusCode, readGitHubErrorBody(resp))
+		return SubmitReviewPostedComment{}, fmt.Errorf("create GitHub review comment: %w", readGitHubAPIResponseError(httpReq, resp))
 	}
 	var decoded githubReviewCommentItem
 	if err := json.NewDecoder(resp.Body).Decode(&decoded); err != nil {
@@ -473,7 +476,7 @@ func (s *GitHubSubmitter) listReviewComments(ctx context.Context, token, owner, 
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, fmt.Errorf("list GitHub review comments returned %d: %s", resp.StatusCode, readGitHubErrorBody(resp))
+		return nil, fmt.Errorf("list GitHub review comments: %w", readGitHubAPIResponseError(httpReq, resp))
 	}
 	var decoded []struct {
 		ID   int64  `json:"id"`
@@ -570,7 +573,7 @@ func (s *GitHubSubmitter) updateReviewComment(ctx context.Context, token, owner,
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return fmt.Errorf("update GitHub review comment returned %d: %s", resp.StatusCode, readGitHubErrorBody(resp))
+		return fmt.Errorf("update GitHub review comment: %w", readGitHubAPIResponseError(httpReq, resp))
 	}
 	return nil
 }
@@ -589,7 +592,7 @@ func (s *GitHubSubmitter) getGitHubJSONPage(ctx context.Context, token, path str
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return "", fmt.Errorf("GitHub request returned %d: %s", resp.StatusCode, readGitHubErrorBody(resp))
+		return "", fmt.Errorf("GitHub request failed: %w", readGitHubAPIResponseError(httpReq, resp))
 	}
 	if err := json.NewDecoder(resp.Body).Decode(target); err != nil {
 		return "", fmt.Errorf("decode GitHub response: %w", err)
@@ -619,7 +622,7 @@ func (s *GitHubSubmitter) doGitHubGraphQL(ctx context.Context, token, query stri
 		return nil, fmt.Errorf("read GitHub GraphQL response: %w", err)
 	}
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, fmt.Errorf("GitHub GraphQL returned %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+		return nil, fmt.Errorf("GitHub GraphQL request failed: %w", newGitHubAPIResponseError(httpReq, resp, body))
 	}
 	return body, nil
 }
@@ -795,7 +798,7 @@ func (s *GitHubSubmitter) RemoveRequestedReviewers(ctx context.Context, req Requ
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return fmt.Errorf("remove GitHub requested reviewers returned %d: %s", resp.StatusCode, readGitHubErrorBody(resp))
+		return fmt.Errorf("remove GitHub requested reviewers: %w", readGitHubAPIResponseError(httpReq, resp))
 	}
 	return nil
 }
@@ -936,7 +939,7 @@ func (s *GitHubSubmitter) getPullRequestFilesPage(ctx context.Context, token, pa
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, "", fmt.Errorf("list GitHub pull request files returned %d: %s", resp.StatusCode, readGitHubErrorBody(resp))
+		return nil, "", fmt.Errorf("list GitHub pull request files: %w", readGitHubAPIResponseError(httpReq, resp))
 	}
 	var files []PullRequestFile
 	if err := json.NewDecoder(resp.Body).Decode(&files); err != nil {
@@ -945,12 +948,31 @@ func (s *GitHubSubmitter) getPullRequestFilesPage(ctx context.Context, token, pa
 	return files, parseNextGitHubPath(resp.Header.Get("Link")), nil
 }
 
-func readGitHubErrorBody(resp *http.Response) string {
-	errorBody, err := io.ReadAll(io.LimitReader(resp.Body, 4096))
-	if err != nil {
-		return fmt.Sprintf("failed to read error body: %v", err)
+func readGitHubAPIResponseError(req *http.Request, resp *http.Response) error {
+	errorBody, readErr := io.ReadAll(io.LimitReader(resp.Body, 4096))
+	apiErr := newGitHubAPIResponseError(req, resp, errorBody)
+	if readErr != nil {
+		return errors.Join(apiErr, fmt.Errorf("read GitHub error response: %w", readErr))
 	}
-	return strings.TrimSpace(string(errorBody))
+	return apiErr
+}
+
+func newGitHubAPIResponseError(req *http.Request, resp *http.Response, body []byte) *ghservice.GitHubAPIError {
+	method := ""
+	path := ""
+	if req != nil {
+		method = req.Method
+		if req.URL != nil {
+			path = req.URL.RequestURI()
+		}
+	}
+	return &ghservice.GitHubAPIError{
+		Method:     method,
+		Path:       path,
+		StatusCode: resp.StatusCode,
+		Body:       body,
+		Header:     resp.Header.Clone(),
+	}
 }
 
 func withCodeReviewOutputMarker(body, outputKey string) string {

--- a/internal/services/codereview/github_submitter_test.go
+++ b/internal/services/codereview/github_submitter_test.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 	"testing"
 
+	ghservice "github.com/assembledhq/143/internal/services/github"
 	"github.com/stretchr/testify/require"
 )
 
@@ -68,6 +69,36 @@ func TestGitHubSubmitter_SubmitReview(t *testing.T) {
 	comments, ok := gotPayload["comments"].([]any)
 	require.True(t, ok, "comments should be an array")
 	require.Len(t, comments, 1, "one inline comment should be submitted")
+}
+
+func TestGitHubSubmitter_SubmitReviewPreservesRateLimitResponse(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Retry-After", "29")
+		w.Header().Set("X-RateLimit-Remaining", "0")
+		w.WriteHeader(http.StatusTooManyRequests)
+		_, err := w.Write([]byte(`{"message":"API rate limit exceeded"}`))
+		require.NoError(t, err, "test response should write the rate-limit body")
+	}))
+	defer server.Close()
+
+	submitter := NewGitHubSubmitter(&tokenStub{token: "ghs_token"}, WithGitHubSubmitterBaseURL(server.URL))
+	_, err := submitter.SubmitReview(context.Background(), SubmitReviewRequest{
+		InstallationID: 99,
+		Repository:     "acme/repo",
+		PullNumber:     42,
+		HeadSHA:        "abc123",
+		OutputKey:      "review-output",
+		Decision:       SubmitReviewDecisionCommentOnly,
+		Body:           "Review summary",
+	})
+
+	var apiErr *ghservice.GitHubAPIError
+	require.ErrorAs(t, err, &apiErr, "SubmitReview should expose typed GitHub API errors through wrapped context")
+	require.Equal(t, http.StatusTooManyRequests, apiErr.StatusCode, "SubmitReview should preserve GitHub's response status")
+	require.Equal(t, "29", apiErr.Header.Get("Retry-After"), "SubmitReview should preserve GitHub's retry delay")
+	require.Equal(t, "0", apiErr.Header.Get("X-RateLimit-Remaining"), "SubmitReview should preserve GitHub's remaining budget")
 }
 
 func TestGitHubSubmitter_SubmitReviewReturnsExistingMarkedReview(t *testing.T) {

--- a/internal/services/codereview/github_trigger_setup.go
+++ b/internal/services/codereview/github_trigger_setup.go
@@ -266,12 +266,16 @@ func (s *GitHubTriggerSetupService) githubJSON(ctx context.Context, method, path
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != expectedStatus {
-		raw, _ := io.ReadAll(resp.Body)
-		apiErr := &ghservice.GitHubAPIError{Method: method, Path: path, StatusCode: resp.StatusCode, Body: raw}
-		if resp.StatusCode == http.StatusForbidden || resp.StatusCode == http.StatusNotFound {
-			return fmt.Errorf("%w: %w", ErrGitHubTriggerPermissionRequired, apiErr)
+		raw, readErr := io.ReadAll(resp.Body)
+		apiErr := &ghservice.GitHubAPIError{Method: method, Path: path, StatusCode: resp.StatusCode, Body: raw, Header: resp.Header.Clone()}
+		var responseErr error = apiErr
+		if readErr != nil {
+			responseErr = errors.Join(apiErr, fmt.Errorf("read GitHub error response: %w", readErr))
 		}
-		return apiErr
+		if resp.StatusCode == http.StatusForbidden || resp.StatusCode == http.StatusNotFound {
+			return fmt.Errorf("%w: %w", ErrGitHubTriggerPermissionRequired, responseErr)
+		}
+		return responseErr
 	}
 	if out == nil || resp.StatusCode == http.StatusNoContent {
 		return nil

--- a/internal/services/github/retry.go
+++ b/internal/services/github/retry.go
@@ -1,0 +1,88 @@
+package github
+
+import (
+	"context"
+	"errors"
+	"net"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// RetryClassification describes whether a GitHub request failure is safe to
+// retry and, for rate limits, how long GitHub asked the caller to wait.
+type RetryClassification struct {
+	Retryable   bool
+	RateLimited bool
+	RetryAfter  *time.Duration
+}
+
+// ClassifyRetry classifies GitHub API and transport failures without relying
+// on error strings. now is supplied by the caller so reset timestamps can be
+// tested deterministically.
+func ClassifyRetry(err error, now time.Time) RetryClassification {
+	if err == nil || errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return RetryClassification{}
+	}
+
+	var apiErr *GitHubAPIError
+	if errors.As(err, &apiErr) {
+		rateLimited := apiErr.StatusCode == http.StatusTooManyRequests || githubRateLimited(apiErr)
+		retryable := rateLimited ||
+			apiErr.StatusCode == http.StatusRequestTimeout ||
+			apiErr.StatusCode == http.StatusTooEarly ||
+			apiErr.StatusCode >= http.StatusInternalServerError
+		if !retryable {
+			return RetryClassification{}
+		}
+		return RetryClassification{
+			Retryable:   true,
+			RateLimited: rateLimited,
+			RetryAfter:  githubRetryAfter(apiErr, now),
+		}
+	}
+
+	var networkErr net.Error
+	return RetryClassification{Retryable: errors.As(err, &networkErr)}
+}
+
+func githubRateLimited(apiErr *GitHubAPIError) bool {
+	if apiErr == nil || apiErr.StatusCode != http.StatusForbidden {
+		return false
+	}
+	if strings.TrimSpace(apiErr.Header.Get("Retry-After")) != "" || strings.TrimSpace(apiErr.Header.Get("X-RateLimit-Remaining")) == "0" {
+		return true
+	}
+	message := strings.ToLower(strings.TrimSpace(apiErr.Message()))
+	return strings.Contains(message, "rate limit") || strings.Contains(message, "abuse detection")
+}
+
+func githubRetryAfter(apiErr *GitHubAPIError, now time.Time) *time.Duration {
+	if apiErr == nil {
+		return nil
+	}
+	if raw := strings.TrimSpace(apiErr.Header.Get("Retry-After")); raw != "" {
+		if seconds, err := strconv.Atoi(raw); err == nil && seconds >= 0 {
+			delay := time.Duration(seconds) * time.Second
+			return &delay
+		}
+		if retryAt, err := http.ParseTime(raw); err == nil {
+			return nonNegativeRetryDelay(retryAt, now)
+		}
+	}
+	if strings.TrimSpace(apiErr.Header.Get("X-RateLimit-Remaining")) == "0" {
+		if resetUnix, err := strconv.ParseInt(strings.TrimSpace(apiErr.Header.Get("X-RateLimit-Reset")), 10, 64); err == nil {
+			return nonNegativeRetryDelay(time.Unix(resetUnix, 0), now)
+		}
+	}
+	return nil
+}
+
+func nonNegativeRetryDelay(retryAt, now time.Time) *time.Duration {
+	delay := retryAt.Sub(now)
+	if delay < 0 {
+		delay = 0
+	}
+	return &delay
+}

--- a/internal/services/github/retry_test.go
+++ b/internal/services/github/retry_test.go
@@ -1,0 +1,127 @@
+package github
+
+import (
+	"context"
+	"errors"
+	"net"
+	"net/http"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestClassifyRetry(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, time.July, 21, 18, 0, 0, 0, time.UTC)
+	resetAt := now.Add(24 * time.Minute)
+	tests := []struct {
+		name               string
+		err                error
+		expected           RetryClassification
+		expectedRetryAfter *time.Duration
+	}{
+		{
+			name: "primary rate limit uses reset timestamp",
+			err: &GitHubAPIError{
+				StatusCode: http.StatusForbidden,
+				Header: githubTestHeaders(map[string]string{
+					"X-RateLimit-Remaining": "0",
+					"X-RateLimit-Reset":     strconv.FormatInt(resetAt.Unix(), 10),
+				}),
+			},
+			expected:           RetryClassification{Retryable: true, RateLimited: true},
+			expectedRetryAfter: durationPointer(24 * time.Minute),
+		},
+		{
+			name: "secondary rate limit uses retry after seconds",
+			err: &GitHubAPIError{
+				StatusCode: http.StatusForbidden,
+				Body:       []byte(`{"message":"You have exceeded a secondary rate limit"}`),
+				Header:     http.Header{"Retry-After": []string{"17"}},
+			},
+			expected:           RetryClassification{Retryable: true, RateLimited: true},
+			expectedRetryAfter: durationPointer(17 * time.Second),
+		},
+		{
+			name: "secondary rate limit uses retry after date",
+			err: &GitHubAPIError{
+				StatusCode: http.StatusForbidden,
+				Body:       []byte(`{"message":"secondary rate limit"}`),
+				Header:     githubTestHeaders(map[string]string{"Retry-After": resetAt.Format(http.TimeFormat)}),
+			},
+			expected:           RetryClassification{Retryable: true, RateLimited: true},
+			expectedRetryAfter: durationPointer(24 * time.Minute),
+		},
+		{
+			name: "too many requests without hint remains rate limited",
+			err:  &GitHubAPIError{StatusCode: http.StatusTooManyRequests},
+			expected: RetryClassification{
+				Retryable:   true,
+				RateLimited: true,
+			},
+		},
+		{
+			name: "service unavailable honors server retry delay",
+			err: &GitHubAPIError{
+				StatusCode: http.StatusServiceUnavailable,
+				Header:     githubTestHeaders(map[string]string{"Retry-After": "9"}),
+			},
+			expected:           RetryClassification{Retryable: true},
+			expectedRetryAfter: durationPointer(9 * time.Second),
+		},
+		{
+			name:     "network error is transient",
+			err:      &net.DNSError{Err: "temporary failure", IsTemporary: true},
+			expected: RetryClassification{Retryable: true},
+		},
+		{
+			name: "forbidden permission error is permanent",
+			err: &GitHubAPIError{
+				StatusCode: http.StatusForbidden,
+				Body:       []byte(`{"message":"Resource not accessible by integration"}`),
+			},
+			expected: RetryClassification{},
+		},
+		{
+			name:     "validation error is permanent",
+			err:      &GitHubAPIError{StatusCode: http.StatusUnprocessableEntity},
+			expected: RetryClassification{},
+		},
+		{
+			name:     "cancelled request is not retried",
+			err:      context.Canceled,
+			expected: RetryClassification{},
+		},
+		{
+			name:     "wrapped deadline is not retried",
+			err:      errors.Join(errors.New("request stopped"), context.DeadlineExceeded),
+			expected: RetryClassification{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			actual := ClassifyRetry(tt.err, now)
+			require.Equal(t, tt.expected.Retryable, actual.Retryable, "classification should identify retryable failures")
+			require.Equal(t, tt.expected.RateLimited, actual.RateLimited, "classification should distinguish rate limits from other transient failures")
+			require.Equal(t, tt.expectedRetryAfter, actual.RetryAfter, "classification should preserve GitHub's reset delay")
+		})
+	}
+}
+
+func durationPointer(value time.Duration) *time.Duration {
+	return &value
+}
+
+func githubTestHeaders(values map[string]string) http.Header {
+	header := make(http.Header, len(values))
+	for name, value := range values {
+		header.Set(name, value)
+	}
+	return header
+}

--- a/internal/services/github/service.go
+++ b/internal/services/github/service.go
@@ -210,13 +210,7 @@ func (s *Service) exchangeForInstallationTokenRequest(ctx context.Context, jwtTo
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusCreated {
-		body, _ := io.ReadAll(resp.Body)
-		return "", time.Time{}, &GitHubAPIError{
-			Method:     http.MethodPost,
-			Path:       path,
-			StatusCode: resp.StatusCode,
-			Body:       body,
-		}
+		return "", time.Time{}, newGitHubAPIResponseError(http.MethodPost, path, resp)
 	}
 
 	var result struct {
@@ -249,8 +243,7 @@ func (s *Service) GetInstallationDetails(ctx context.Context, installationID int
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		body, _ := io.ReadAll(resp.Body)
-		return InstallationDetails{}, &GitHubAPIError{Method: http.MethodGet, Path: path, StatusCode: resp.StatusCode, Body: body}
+		return InstallationDetails{}, newGitHubAPIResponseError(http.MethodGet, path, resp)
 	}
 	var result InstallationDetails
 	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
@@ -289,7 +282,7 @@ func (s *Service) ListOrgMembers(ctx context.Context, installationID int64, orgL
 			return nil, fmt.Errorf("close org members response: %w", closeErr)
 		}
 		if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-			return nil, &GitHubAPIError{Method: http.MethodGet, Path: nextPath, StatusCode: resp.StatusCode, Body: body}
+			return nil, &GitHubAPIError{Method: http.MethodGet, Path: nextPath, StatusCode: resp.StatusCode, Body: body, Header: resp.Header.Clone()}
 		}
 		var page []OrgMember
 		if err := json.Unmarshal(body, &page); err != nil {
@@ -322,8 +315,7 @@ func (s *Service) IsActiveOrgMember(ctx context.Context, installationID int64, o
 		return false, nil
 	}
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		body, _ := io.ReadAll(resp.Body)
-		return false, &GitHubAPIError{Method: http.MethodGet, Path: path, StatusCode: resp.StatusCode, Body: body}
+		return false, newGitHubAPIResponseError(http.MethodGet, path, resp)
 	}
 	var result struct {
 		State string `json:"state"`
@@ -332,6 +324,21 @@ func (s *Service) IsActiveOrgMember(ctx context.Context, installationID int64, o
 		return false, fmt.Errorf("decode org membership: %w", err)
 	}
 	return result.State == "active", nil
+}
+
+func newGitHubAPIResponseError(method, path string, resp *http.Response) error {
+	body, readErr := io.ReadAll(resp.Body)
+	apiErr := &GitHubAPIError{
+		Method:     method,
+		Path:       path,
+		StatusCode: resp.StatusCode,
+		Body:       body,
+		Header:     resp.Header.Clone(),
+	}
+	if readErr != nil {
+		return errors.Join(apiErr, fmt.Errorf("read GitHub error response: %w", readErr))
+	}
+	return apiErr
 }
 
 func (s *Service) apiURL(path string) string {

--- a/internal/services/github/service_test.go
+++ b/internal/services/github/service_test.go
@@ -165,6 +165,32 @@ func TestService_GetInstallationToken_FetchesAndCaches(t *testing.T) {
 	require.Equal(t, 1, callCount, "GetInstallationToken should exchange only once and use cache on subsequent calls")
 }
 
+func TestService_GetInstallationToken_PreservesRateLimitHeaders(t *testing.T) {
+	t.Parallel()
+
+	header := make(http.Header)
+	header.Set("Retry-After", "43")
+	header.Set("X-RateLimit-Remaining", "0")
+	svc, err := NewService(143, testPrivateKeyPEM(t))
+	require.NoError(t, err, "NewService should create a valid GitHub service")
+	svc.httpClient = &http.Client{
+		Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: http.StatusForbidden,
+				Body:       io.NopCloser(strings.NewReader(`{"message":"API rate limit exceeded"}`)),
+				Header:     header,
+			}, nil
+		}),
+	}
+
+	_, err = svc.GetInstallationToken(context.Background(), 77)
+
+	var apiErr *GitHubAPIError
+	require.ErrorAs(t, err, &apiErr, "installation token failure should retain typed GitHub response details")
+	require.Equal(t, "43", apiErr.Header.Get("Retry-After"), "installation token failure should preserve GitHub's retry delay")
+	require.Equal(t, "0", apiErr.Header.Get("X-RateLimit-Remaining"), "installation token failure should preserve GitHub's remaining budget")
+}
+
 func TestService_GetSandboxInstallationToken_ScopesRepositoryAndPermissions(t *testing.T) {
 	t.Parallel()
 

--- a/internal/worker/code_review_handler.go
+++ b/internal/worker/code_review_handler.go
@@ -6,8 +6,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"net"
-	"net/http"
 	"path/filepath"
 	"regexp"
 	"strconv"
@@ -493,76 +491,9 @@ func syncCodeReviewPullRequestState(ctx context.Context, services *Services, log
 			return nil
 		}
 		wrapped := fmt.Errorf("sync code review pull request state: %w", err)
-		if retryable, retryAfter := codeReviewGitHubSyncRetry(err); retryable {
-			return &RetryableError{Err: wrapped, ConsumeAttempt: true, RetryAfter: retryAfter}
-		}
-		var apiErr *ghservice.GitHubAPIError
-		if errors.As(err, &apiErr) {
-			return &FatalError{Err: wrapped}
-		}
-		return wrapped
+		return classifyGitHubJobError(wrapped)
 	}
 	return nil
-}
-
-func codeReviewGitHubSyncRetry(err error) (bool, *time.Duration) {
-	if err == nil || errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
-		return false, nil
-	}
-	var apiErr *ghservice.GitHubAPIError
-	if errors.As(err, &apiErr) {
-		retryable := apiErr.StatusCode == http.StatusRequestTimeout ||
-			apiErr.StatusCode == http.StatusTooEarly ||
-			apiErr.StatusCode == http.StatusTooManyRequests ||
-			apiErr.StatusCode >= http.StatusInternalServerError ||
-			codeReviewGitHubRateLimited(apiErr)
-		if !retryable {
-			return false, nil
-		}
-		return true, codeReviewGitHubRetryAfter(apiErr)
-	}
-	var networkErr net.Error
-	return errors.As(err, &networkErr), nil
-}
-
-func codeReviewGitHubRateLimited(apiErr *ghservice.GitHubAPIError) bool {
-	if apiErr == nil || apiErr.StatusCode != http.StatusForbidden {
-		return false
-	}
-	if strings.TrimSpace(apiErr.Header.Get("Retry-After")) != "" || strings.TrimSpace(apiErr.Header.Get("X-RateLimit-Remaining")) == "0" {
-		return true
-	}
-	message := strings.ToLower(strings.TrimSpace(apiErr.Message()))
-	return strings.Contains(message, "rate limit") || strings.Contains(message, "abuse detection")
-}
-
-func codeReviewGitHubRetryAfter(apiErr *ghservice.GitHubAPIError) *time.Duration {
-	if apiErr == nil {
-		return nil
-	}
-	if raw := strings.TrimSpace(apiErr.Header.Get("Retry-After")); raw != "" {
-		if seconds, err := strconv.Atoi(raw); err == nil && seconds >= 0 {
-			delay := time.Duration(seconds) * time.Second
-			return &delay
-		}
-		if retryAt, err := http.ParseTime(raw); err == nil {
-			return nonNegativeCodeReviewRetryDelay(retryAt)
-		}
-	}
-	if strings.TrimSpace(apiErr.Header.Get("X-RateLimit-Remaining")) == "0" {
-		if resetUnix, err := strconv.ParseInt(strings.TrimSpace(apiErr.Header.Get("X-RateLimit-Reset")), 10, 64); err == nil {
-			return nonNegativeCodeReviewRetryDelay(time.Unix(resetUnix, 0))
-		}
-	}
-	return nil
-}
-
-func nonNegativeCodeReviewRetryDelay(retryAt time.Time) *time.Duration {
-	delay := time.Until(retryAt)
-	if delay < 0 {
-		delay = 0
-	}
-	return &delay
 }
 
 func codeReviewCanRunReviewerThreads(stores *Stores) bool {
@@ -2295,7 +2226,7 @@ func loadCodeReviewChangedFiles(ctx context.Context, stores *Stores, services *S
 		PullNumber:     pr.GitHubPRNumber,
 	})
 	if err != nil {
-		return nil, false, err
+		return nil, false, classifyGitHubJobError(fmt.Errorf("list GitHub pull request files: %w", err))
 	}
 	return files, true, nil
 }
@@ -3227,7 +3158,7 @@ func submitCodeReviewToGitHub(ctx context.Context, stores *Stores, services *Ser
 		Comments:          comments,
 	})
 	if err != nil {
-		return codeReviewSubmission{}, false, fmt.Errorf("submit code review to GitHub: %w", err)
+		return codeReviewSubmission{}, false, classifyGitHubJobError(fmt.Errorf("submit code review to GitHub: %w", err))
 	}
 	if _, err := stores.CodeReviews.RecordGitHubReview(ctx, job.OrgID, job.SessionID, result.ID, result.URL, body); err != nil {
 		return codeReviewSubmission{}, true, fmt.Errorf("record submitted code review: %w", err)

--- a/internal/worker/code_review_handler.go
+++ b/internal/worker/code_review_handler.go
@@ -491,7 +491,7 @@ func syncCodeReviewPullRequestState(ctx context.Context, services *Services, log
 			return nil
 		}
 		wrapped := fmt.Errorf("sync code review pull request state: %w", err)
-		return classifyGitHubJobError(wrapped)
+		return classifyGitHubJobError(wrapped, job.SessionID.String())
 	}
 	return nil
 }
@@ -2226,7 +2226,7 @@ func loadCodeReviewChangedFiles(ctx context.Context, stores *Stores, services *S
 		PullNumber:     pr.GitHubPRNumber,
 	})
 	if err != nil {
-		return nil, false, classifyGitHubJobError(fmt.Errorf("list GitHub pull request files: %w", err))
+		return nil, false, classifyGitHubJobError(fmt.Errorf("list GitHub pull request files: %w", err), job.SessionID.String())
 	}
 	return files, true, nil
 }
@@ -3158,7 +3158,7 @@ func submitCodeReviewToGitHub(ctx context.Context, stores *Stores, services *Ser
 		Comments:          comments,
 	})
 	if err != nil {
-		return codeReviewSubmission{}, false, classifyGitHubJobError(fmt.Errorf("submit code review to GitHub: %w", err))
+		return codeReviewSubmission{}, false, classifyGitHubJobError(fmt.Errorf("submit code review to GitHub: %w", err), job.SessionID.String())
 	}
 	if _, err := stores.CodeReviews.RecordGitHubReview(ctx, job.OrgID, job.SessionID, result.ID, result.URL, body); err != nil {
 		return codeReviewSubmission{}, true, fmt.Errorf("record submitted code review: %w", err)

--- a/internal/worker/code_review_handler_test.go
+++ b/internal/worker/code_review_handler_test.go
@@ -89,17 +89,19 @@ func TestSyncCodeReviewPullRequestStateClassifiesTransientGitHubFailures(t *test
 		body               string
 		header             http.Header
 		retryable          bool
+		rateLimited        bool
 		fatal              bool
 		expectedRetryAfter time.Duration
 	}{
 		{name: "retries service unavailable", status: http.StatusServiceUnavailable, retryable: true},
-		{name: "retries rate limiting", status: http.StatusTooManyRequests, retryable: true},
+		{name: "retries rate limiting with fallback delay", status: http.StatusTooManyRequests, retryable: true, rateLimited: true, expectedRetryAfter: githubRateLimitFallbackRetryAfter},
 		{
 			name:               "retries forbidden secondary rate limit using server delay",
 			status:             http.StatusForbidden,
 			body:               `{"message":"You have exceeded a secondary rate limit"}`,
 			header:             http.Header{"Retry-After": []string{"17"}},
 			retryable:          true,
+			rateLimited:        true,
 			expectedRetryAfter: 17 * time.Second,
 		},
 		{name: "does not retry forbidden permission failure", status: http.StatusForbidden, body: `{"message":"Resource not accessible by integration"}`, fatal: true},
@@ -137,12 +139,18 @@ func TestSyncCodeReviewPullRequestStateClassifiesTransientGitHubFailures(t *test
 			var fatalErr *FatalError
 			require.Equal(t, tt.fatal, errors.As(err, &fatalErr), "non-transient GitHub status should receive the expected fatal classification")
 			if tt.retryable {
-				require.True(t, retryErr.ConsumeAttempt, "transient GitHub retries should consume attempts so exponential backoff increases")
+				require.Equal(t, !tt.rateLimited, retryErr.ConsumeAttempt, "only non-rate-limit transient failures should consume attempts")
 				if tt.expectedRetryAfter > 0 {
 					require.NotNil(t, retryErr.RetryAfter, "rate-limited response should preserve the upstream retry delay")
 					require.Equal(t, tt.expectedRetryAfter, *retryErr.RetryAfter, "rate-limited response should use the upstream retry delay")
 				} else {
 					require.Nil(t, retryErr.RetryAfter, "transient GitHub retries without a hint should use exponential backoff")
+				}
+				if tt.rateLimited {
+					require.NotNil(t, retryErr.MaxRetryDuration, "rate limits should use an extended but bounded retry window")
+					require.Equal(t, githubRateLimitMaxRetryDuration, *retryErr.MaxRetryDuration, "rate limits should survive GitHub's normal reset interval")
+				} else {
+					require.Nil(t, retryErr.MaxRetryDuration, "ordinary transient failures should use the standard retry window")
 				}
 			}
 		})

--- a/internal/worker/code_review_handler_test.go
+++ b/internal/worker/code_review_handler_test.go
@@ -83,6 +83,10 @@ func (s *codeReviewLifecycleStub) HandleReviewChanged(_ context.Context, input c
 func TestSyncCodeReviewPullRequestStateClassifiesTransientGitHubFailures(t *testing.T) {
 	t.Parallel()
 
+	sessionID := uuid.MustParse("00000000-0000-0000-0000-000000000143")
+	fallbackRetryAfter := *githubRateLimitRetryAfter(nil, sessionID.String())
+	secondaryRetryAfterHint := 117 * time.Second
+	secondaryRetryAfter := *githubRateLimitRetryAfter(&secondaryRetryAfterHint, sessionID.String())
 	tests := []struct {
 		name               string
 		status             int
@@ -94,15 +98,15 @@ func TestSyncCodeReviewPullRequestStateClassifiesTransientGitHubFailures(t *test
 		expectedRetryAfter time.Duration
 	}{
 		{name: "retries service unavailable", status: http.StatusServiceUnavailable, retryable: true},
-		{name: "retries rate limiting with fallback delay", status: http.StatusTooManyRequests, retryable: true, rateLimited: true, expectedRetryAfter: githubRateLimitFallbackRetryAfter},
+		{name: "retries rate limiting with fallback delay", status: http.StatusTooManyRequests, retryable: true, rateLimited: true, expectedRetryAfter: fallbackRetryAfter},
 		{
 			name:               "retries forbidden secondary rate limit using server delay",
 			status:             http.StatusForbidden,
 			body:               `{"message":"You have exceeded a secondary rate limit"}`,
-			header:             http.Header{"Retry-After": []string{"17"}},
+			header:             http.Header{"Retry-After": []string{"117"}},
 			retryable:          true,
 			rateLimited:        true,
-			expectedRetryAfter: 17 * time.Second,
+			expectedRetryAfter: secondaryRetryAfter,
 		},
 		{name: "does not retry forbidden permission failure", status: http.StatusForbidden, body: `{"message":"Resource not accessible by integration"}`, fatal: true},
 		{name: "does not retry validation failure", status: http.StatusUnprocessableEntity, fatal: true},
@@ -131,6 +135,7 @@ func TestSyncCodeReviewPullRequestStateClassifiesTransientGitHubFailures(t *test
 
 			err := syncCodeReviewPullRequestState(context.Background(), services, zerolog.Nop(), runCodeReviewPayload{
 				OrgID:         uuid.New(),
+				SessionID:     sessionID,
 				PullRequestID: uuid.New(),
 			})
 

--- a/internal/worker/github_retry.go
+++ b/internal/worker/github_retry.go
@@ -1,6 +1,8 @@
 package worker
 
 import (
+	"crypto/sha256"
+	"encoding/binary"
 	"errors"
 	"time"
 
@@ -8,11 +10,12 @@ import (
 )
 
 const (
-	githubRateLimitFallbackRetryAfter = time.Minute
-	githubRateLimitMaxRetryDuration   = 2 * time.Hour
+	githubRateLimitMinimumRetryAfter = time.Minute
+	githubRateLimitJitterRange       = 30 * time.Second
+	githubRateLimitMaxRetryDuration  = 2 * time.Hour
 )
 
-func githubRetryableError(err error) *RetryableError {
+func githubRetryableError(err error, retryKey string) *RetryableError {
 	classification := ghservice.ClassifyRetry(err, time.Now())
 	if !classification.Retryable {
 		return nil
@@ -23,18 +26,27 @@ func githubRetryableError(err error) *RetryableError {
 		RetryAfter:     classification.RetryAfter,
 	}
 	if classification.RateLimited {
-		if retryable.RetryAfter == nil {
-			retryAfter := githubRateLimitFallbackRetryAfter
-			retryable.RetryAfter = &retryAfter
-		}
+		retryable.RetryAfter = githubRateLimitRetryAfter(classification.RetryAfter, retryKey)
 		retryWindow := githubRateLimitMaxRetryDuration
 		retryable.MaxRetryDuration = &retryWindow
 	}
 	return retryable
 }
 
-func classifyGitHubJobError(err error) error {
-	if retryable := githubRetryableError(err); retryable != nil {
+func githubRateLimitRetryAfter(upstream *time.Duration, retryKey string) *time.Duration {
+	delay := githubRateLimitMinimumRetryAfter
+	if upstream != nil && *upstream > delay {
+		delay = *upstream
+	}
+	digest := sha256.Sum256([]byte(retryKey))
+	jitterSlots := uint32(githubRateLimitJitterRange / time.Second)
+	jitter := time.Duration(binary.BigEndian.Uint32(digest[:4])%jitterSlots) * time.Second
+	delay += jitter
+	return &delay
+}
+
+func classifyGitHubJobError(err error, retryKey string) error {
+	if retryable := githubRetryableError(err, retryKey); retryable != nil {
 		return retryable
 	}
 	var apiErr *ghservice.GitHubAPIError

--- a/internal/worker/github_retry.go
+++ b/internal/worker/github_retry.go
@@ -1,0 +1,45 @@
+package worker
+
+import (
+	"errors"
+	"time"
+
+	ghservice "github.com/assembledhq/143/internal/services/github"
+)
+
+const (
+	githubRateLimitFallbackRetryAfter = time.Minute
+	githubRateLimitMaxRetryDuration   = 2 * time.Hour
+)
+
+func githubRetryableError(err error) *RetryableError {
+	classification := ghservice.ClassifyRetry(err, time.Now())
+	if !classification.Retryable {
+		return nil
+	}
+	retryable := &RetryableError{
+		Err:            err,
+		ConsumeAttempt: !classification.RateLimited,
+		RetryAfter:     classification.RetryAfter,
+	}
+	if classification.RateLimited {
+		if retryable.RetryAfter == nil {
+			retryAfter := githubRateLimitFallbackRetryAfter
+			retryable.RetryAfter = &retryAfter
+		}
+		retryWindow := githubRateLimitMaxRetryDuration
+		retryable.MaxRetryDuration = &retryWindow
+	}
+	return retryable
+}
+
+func classifyGitHubJobError(err error) error {
+	if retryable := githubRetryableError(err); retryable != nil {
+		return retryable
+	}
+	var apiErr *ghservice.GitHubAPIError
+	if errors.As(err, &apiErr) {
+		return &FatalError{Err: err}
+	}
+	return err
+}

--- a/internal/worker/github_retry_test.go
+++ b/internal/worker/github_retry_test.go
@@ -1,0 +1,38 @@
+package worker
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGitHubRateLimitRetryAfter(t *testing.T) {
+	t.Parallel()
+
+	zero := time.Duration(0)
+	short := 17 * time.Second
+	long := 117 * time.Second
+	tests := []struct {
+		name     string
+		upstream *time.Duration
+		retryKey string
+		expected time.Duration
+	}{
+		{name: "missing hint uses floor and jitter", retryKey: "00000000-0000-0000-0000-000000000143", expected: 82 * time.Second},
+		{name: "zero hint uses floor and jitter", upstream: &zero, retryKey: "00000000-0000-0000-0000-000000000143", expected: 82 * time.Second},
+		{name: "short hint uses floor and jitter", upstream: &short, retryKey: "00000000-0000-0000-0000-000000000143", expected: 82 * time.Second},
+		{name: "long hint preserves upstream wait and adds jitter", upstream: &long, retryKey: "00000000-0000-0000-0000-000000000143", expected: 139 * time.Second},
+		{name: "different retry key receives different stable jitter", retryKey: "11111111-2222-3333-4444-555555555555", expected: 78 * time.Second},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			actual := githubRateLimitRetryAfter(tt.upstream, tt.retryKey)
+			require.NotNil(t, actual, "rate-limit policy should always return an explicit delay")
+			require.Equal(t, tt.expected, *actual, "rate-limit policy should apply the expected floor and deterministic jitter")
+		})
+	}
+}

--- a/internal/worker/handlers.go
+++ b/internal/worker/handlers.go
@@ -10816,7 +10816,7 @@ func newSyncPullRequestStateHandler(services *Services, logger zerolog.Logger) J
 				logger.Info().Str("org_id", orgID.String()).Str("pull_request_id", pullRequestID.String()).Msg("skipping pull request state sync for disconnected repository")
 				return nil
 			}
-			return err
+			return classifyGitHubJobError(fmt.Errorf("sync pull request state: %w", err))
 		}
 		decision, autoRepairErr := services.PR.MaybeStartAutoRepairForPullRequest(ctx, orgID, pullRequestID, "github_pr_health_updated")
 		if autoRepairErr != nil {

--- a/internal/worker/handlers.go
+++ b/internal/worker/handlers.go
@@ -10816,7 +10816,7 @@ func newSyncPullRequestStateHandler(services *Services, logger zerolog.Logger) J
 				logger.Info().Str("org_id", orgID.String()).Str("pull_request_id", pullRequestID.String()).Msg("skipping pull request state sync for disconnected repository")
 				return nil
 			}
-			return classifyGitHubJobError(fmt.Errorf("sync pull request state: %w", err))
+			return classifyGitHubJobError(fmt.Errorf("sync pull request state: %w", err), pullRequestID.String())
 		}
 		decision, autoRepairErr := services.PR.MaybeStartAutoRepairForPullRequest(ctx, orgID, pullRequestID, "github_pr_health_updated")
 		if autoRepairErr != nil {

--- a/internal/worker/handlers_test.go
+++ b/internal/worker/handlers_test.go
@@ -5787,7 +5787,7 @@ func TestSyncPullRequestStateHandlerWaitsForGitHubRateLimit(t *testing.T) {
 	t.Parallel()
 
 	orgID := uuid.New()
-	prID := uuid.New()
+	prID := uuid.MustParse("11111111-2222-3333-4444-555555555555")
 	services := &Services{
 		PR: &stubPRService{
 			syncPullRequestStateFn: func(context.Context, uuid.UUID, uuid.UUID) error {
@@ -5809,7 +5809,7 @@ func TestSyncPullRequestStateHandlerWaitsForGitHubRateLimit(t *testing.T) {
 	require.ErrorAs(t, err, &retryable, "rate-limited PR sync should remain pending until GitHub recovers")
 	require.False(t, retryable.ConsumeAttempt, "rate-limited PR sync should not consume its attempt budget")
 	require.NotNil(t, retryable.RetryAfter, "rate-limited PR sync should preserve GitHub's retry delay")
-	require.Equal(t, 37*time.Second, *retryable.RetryAfter, "rate-limited PR sync should wait for GitHub's requested delay")
+	require.Equal(t, 78*time.Second, *retryable.RetryAfter, "rate-limited PR sync should apply the minimum delay and stable per-job jitter")
 	require.NotNil(t, retryable.MaxRetryDuration, "rate-limited PR sync should use a longer bounded retry window")
 	require.Equal(t, githubRateLimitMaxRetryDuration, *retryable.MaxRetryDuration, "rate-limited PR sync should survive a normal GitHub reset interval")
 }

--- a/internal/worker/handlers_test.go
+++ b/internal/worker/handlers_test.go
@@ -5783,6 +5783,37 @@ func TestSyncPullRequestStateHandlerDefersPendingMergeability(t *testing.T) {
 	require.True(t, retryable.ConsumeAttempt, "pending mergeability should consume attempts so exponential backoff advances")
 }
 
+func TestSyncPullRequestStateHandlerWaitsForGitHubRateLimit(t *testing.T) {
+	t.Parallel()
+
+	orgID := uuid.New()
+	prID := uuid.New()
+	services := &Services{
+		PR: &stubPRService{
+			syncPullRequestStateFn: func(context.Context, uuid.UUID, uuid.UUID) error {
+				return &ghservice.GitHubAPIError{
+					Method:     http.MethodGet,
+					Path:       "/repos/acme/repo/pulls/42",
+					StatusCode: http.StatusForbidden,
+					Body:       []byte(`{"message":"API rate limit exceeded"}`),
+					Header:     http.Header{"Retry-After": []string{"37"}},
+				}
+			},
+		},
+	}
+	payload := json.RawMessage(`{"org_id":"` + orgID.String() + `","pull_request_id":"` + prID.String() + `"}`)
+
+	err := newSyncPullRequestStateHandler(services, zerolog.Nop())(context.Background(), "sync_pull_request_state", payload)
+
+	var retryable *RetryableError
+	require.ErrorAs(t, err, &retryable, "rate-limited PR sync should remain pending until GitHub recovers")
+	require.False(t, retryable.ConsumeAttempt, "rate-limited PR sync should not consume its attempt budget")
+	require.NotNil(t, retryable.RetryAfter, "rate-limited PR sync should preserve GitHub's retry delay")
+	require.Equal(t, 37*time.Second, *retryable.RetryAfter, "rate-limited PR sync should wait for GitHub's requested delay")
+	require.NotNil(t, retryable.MaxRetryDuration, "rate-limited PR sync should use a longer bounded retry window")
+	require.Equal(t, githubRateLimitMaxRetryDuration, *retryable.MaxRetryDuration, "rate-limited PR sync should survive a normal GitHub reset interval")
+}
+
 func TestSyncPullRequestStateHandlerTreatsAutoRepairEvaluationFailureAsNonFatal(t *testing.T) {
 	t.Parallel()
 

--- a/internal/worker/session_executor_runtime.go
+++ b/internal/worker/session_executor_runtime.go
@@ -401,8 +401,8 @@ func (r *SessionExecutorRuntime) finishAttempt(ctx context.Context, handlerCtx c
 			r.markExecutorTerminal(writeCtx, executor, models.SessionExecutorStatusFailed, 1, err.Error())
 			return nil
 		}
-		if !retryable.BypassMaxRetryDuration && time.Since(job.CreatedAt) > maxRetryableDuration {
-			timeoutErr := fmt.Errorf("retryable job timed out after %s: %w", maxRetryableDuration, err)
+		if timedOut, retryWindow := retryableDurationExceeded(job.CreatedAt, retryable, time.Now()); timedOut {
+			timeoutErr := fmt.Errorf("retryable job timed out after %s: %w", retryWindow, err)
 			r.markJobDeadLetter(writeCtx, handlerCtx, executor, job, timeoutErr)
 			r.markExecutorTerminal(writeCtx, executor, models.SessionExecutorStatusFailed, 1, timeoutErr.Error())
 			return nil

--- a/internal/worker/session_executor_runtime.go
+++ b/internal/worker/session_executor_runtime.go
@@ -31,6 +31,7 @@ type executorRuntimeExecutorStore interface {
 }
 
 type executorRuntimeJobStore interface {
+	retryWindowLeaseStore
 	GetRunningForSessionExecutor(ctx context.Context, orgID, jobID, lockToken, executorID uuid.UUID) (*models.Job, bool, error)
 	RenewLeaseForSessionExecutor(ctx context.Context, orgID, jobID, lockToken, executorID uuid.UUID, leaseDuration time.Duration) (*models.Job, bool, error)
 	RenewLease(ctx context.Context, jobID, lockToken uuid.UUID, leaseDuration time.Duration) (*models.Job, bool, error)
@@ -401,7 +402,15 @@ func (r *SessionExecutorRuntime) finishAttempt(ctx context.Context, handlerCtx c
 			r.markExecutorTerminal(writeCtx, executor, models.SessionExecutorStatusFailed, 1, err.Error())
 			return nil
 		}
-		if timedOut, retryWindow := retryableDurationExceeded(job.CreatedAt, retryable, time.Now()); timedOut {
+		now := time.Now()
+		retryWindowStartedAt, ok, startErr := ensureRetryWindowStartedAt(writeCtx, r.Jobs, job, retryable, now)
+		if startErr != nil {
+			return fmt.Errorf("persist session executor retry window start: %w", startErr)
+		}
+		if !ok {
+			return ErrExecutorLostLease
+		}
+		if timedOut, retryWindow := retryableDurationExceeded(retryWindowStartedAt, retryable, now); timedOut {
 			timeoutErr := fmt.Errorf("retryable job timed out after %s: %w", retryWindow, err)
 			r.markJobDeadLetter(writeCtx, handlerCtx, executor, job, timeoutErr)
 			r.markExecutorTerminal(writeCtx, executor, models.SessionExecutorStatusFailed, 1, timeoutErr.Error())

--- a/internal/worker/session_executor_runtime_test.go
+++ b/internal/worker/session_executor_runtime_test.go
@@ -115,6 +115,10 @@ func (s *executorRuntimeJobStoreStub) RenewLeaseForSessionExecutor(context.Conte
 	return &models.Job{LeaseExpiresAt: ptr(time.Now().Add(time.Minute))}, true, nil
 }
 
+func (s *executorRuntimeJobStoreStub) EnsureRetryWindowStartedAtWithLease(_ context.Context, _ uuid.UUID, _ uuid.UUID, startedAt time.Time) (time.Time, bool, error) {
+	return startedAt, true, nil
+}
+
 func (s *executorRuntimeJobStoreStub) MarkSucceededWithLease(ctx context.Context, _ uuid.UUID, lockToken uuid.UUID) (bool, error) {
 	s.succeededCalls++
 	s.succeededToken = lockToken

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -96,6 +96,7 @@ func jobOrgIDFromContext(ctx context.Context) (uuid.UUID, bool) {
 }
 
 type jobLeaseStore interface {
+	retryWindowLeaseStore
 	ClaimNextRunnable(ctx context.Context, nodeID, ownerID string, lockToken uuid.UUID, leaseDuration time.Duration) (*models.Job, error)
 	RenewLease(ctx context.Context, jobID, lockToken uuid.UUID, leaseDuration time.Duration) (*models.Job, bool, error)
 	MarkSucceededWithLease(ctx context.Context, jobID, lockToken uuid.UUID) (bool, error)
@@ -103,6 +104,10 @@ type jobLeaseStore interface {
 	RetryWithLease(ctx context.Context, jobID, lockToken uuid.UUID, errMsg string, runAt time.Time) (bool, error)
 	RetryWithoutConsumingAttemptWithLease(ctx context.Context, jobID, lockToken uuid.UUID, errMsg string, runAt time.Time) (bool, error)
 	DeadLetterWithLease(ctx context.Context, jobID, lockToken uuid.UUID, errMsg string) (bool, error)
+}
+
+type retryWindowLeaseStore interface {
+	EnsureRetryWindowStartedAtWithLease(ctx context.Context, jobID, lockToken uuid.UUID, startedAt time.Time) (time.Time, bool, error)
 }
 
 type targetRetryLeaseStore interface {
@@ -279,10 +284,20 @@ func (w *Worker) poll(ctx context.Context) {
 			w.runDeadLetterHooks(handlerCtx, err)
 			return
 		}
-		if timedOut, retryWindow := retryableDurationExceeded(job.CreatedAt, retryable, time.Now()); timedOut {
+		now := time.Now()
+		retryWindowStartedAt, ok, startErr := ensureRetryWindowStartedAt(ctx, w.jobs, job, retryable, now)
+		if startErr != nil {
+			w.logger.Error().Err(startErr).Str("job_id", job.ID.String()).Msg("failed to persist retry window start; leaving job for lease recovery")
+			return
+		}
+		if !ok {
+			w.logger.Warn().Str("job_id", job.ID.String()).Msg("lost ownership before persisting retry window start")
+			return
+		}
+		if timedOut, retryWindow := retryableDurationExceeded(retryWindowStartedAt, retryable, now); timedOut {
 			w.logger.Error().Err(err).
 				Str("job_id", job.ID.String()).
-				Dur("age", time.Since(job.CreatedAt)).
+				Dur("retry_window_age", now.Sub(retryWindowStartedAt)).
 				Msg("retryable job exceeded max duration, dead-lettering")
 			timeoutErr := fmt.Errorf("retryable job timed out after %s: %w", retryWindow, err)
 			w.deadLetterJob(ctx, job.ID, *job.LockToken, timeoutErr.Error())
@@ -303,7 +318,31 @@ func (w *Worker) poll(ctx context.Context) {
 	w.retryJob(ctx, job.ID, *job.LockToken, err.Error(), job.Attempts, false)
 }
 
-func retryableDurationExceeded(createdAt time.Time, retryable *RetryableError, now time.Time) (bool, time.Duration) {
+func ensureRetryWindowStartedAt(ctx context.Context, store retryWindowLeaseStore, job *models.Job, retryable *RetryableError, now time.Time) (time.Time, bool, error) {
+	if job == nil {
+		return time.Time{}, false, errors.New("ensure retry window start: job is nil")
+	}
+	if retryable == nil || retryable.MaxRetryDuration == nil || retryable.BypassMaxRetryDuration {
+		return job.CreatedAt, true, nil
+	}
+	if job.RetryWindowStartedAt != nil {
+		return *job.RetryWindowStartedAt, true, nil
+	}
+	if job.LockToken == nil {
+		return time.Time{}, false, errors.New("ensure retry window start: job lock token is nil")
+	}
+	if store == nil {
+		return time.Time{}, false, errors.New("ensure retry window start: store is nil")
+	}
+	startedAt, ok, err := store.EnsureRetryWindowStartedAtWithLease(ctx, job.ID, *job.LockToken, now)
+	if err != nil || !ok {
+		return time.Time{}, ok, err
+	}
+	job.RetryWindowStartedAt = &startedAt
+	return startedAt, true, nil
+}
+
+func retryableDurationExceeded(retryWindowStartedAt time.Time, retryable *RetryableError, now time.Time) (bool, time.Duration) {
 	retryWindow := maxRetryableDuration
 	if retryable != nil && retryable.MaxRetryDuration != nil {
 		retryWindow = *retryable.MaxRetryDuration
@@ -311,7 +350,7 @@ func retryableDurationExceeded(createdAt time.Time, retryable *RetryableError, n
 	if retryable == nil || retryable.BypassMaxRetryDuration {
 		return false, retryWindow
 	}
-	age := now.Sub(createdAt)
+	age := now.Sub(retryWindowStartedAt)
 	if age > retryWindow {
 		return true, retryWindow
 	}

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -40,7 +40,11 @@ type RetryableError struct {
 	// successful retry is expected immediately after the current attempt repaired
 	// durable state, not for capacity/backlog gates.
 	BypassMaxRetryDuration bool
-	RetryAfter             *time.Duration
+	// MaxRetryDuration overrides the default retry window for a bounded external
+	// wait. Unlike BypassMaxRetryDuration, the job is still guaranteed to
+	// terminate if the dependency does not recover.
+	MaxRetryDuration *time.Duration
+	RetryAfter       *time.Duration
 	// TargetNodeID updates jobs.target_node_id when requeueing this retry.
 	// Use this when an unpinned attempt discovers the session's live sandbox
 	// already belongs to a specific worker node.
@@ -275,12 +279,12 @@ func (w *Worker) poll(ctx context.Context) {
 			w.runDeadLetterHooks(handlerCtx, err)
 			return
 		}
-		if !retryable.BypassMaxRetryDuration && time.Since(job.CreatedAt) > maxRetryableDuration {
+		if timedOut, retryWindow := retryableDurationExceeded(job.CreatedAt, retryable, time.Now()); timedOut {
 			w.logger.Error().Err(err).
 				Str("job_id", job.ID.String()).
 				Dur("age", time.Since(job.CreatedAt)).
 				Msg("retryable job exceeded max duration, dead-lettering")
-			timeoutErr := fmt.Errorf("retryable job timed out after %s: %w", maxRetryableDuration, err)
+			timeoutErr := fmt.Errorf("retryable job timed out after %s: %w", retryWindow, err)
 			w.deadLetterJob(ctx, job.ID, *job.LockToken, timeoutErr.Error())
 			w.runDeadLetterHooks(handlerCtx, timeoutErr)
 			return
@@ -297,6 +301,30 @@ func (w *Worker) poll(ctx context.Context) {
 		return
 	}
 	w.retryJob(ctx, job.ID, *job.LockToken, err.Error(), job.Attempts, false)
+}
+
+func retryableDurationExceeded(createdAt time.Time, retryable *RetryableError, now time.Time) (bool, time.Duration) {
+	retryWindow := maxRetryableDuration
+	if retryable != nil && retryable.MaxRetryDuration != nil {
+		retryWindow = *retryable.MaxRetryDuration
+	}
+	if retryable == nil || retryable.BypassMaxRetryDuration {
+		return false, retryWindow
+	}
+	age := now.Sub(createdAt)
+	if age > retryWindow {
+		return true, retryWindow
+	}
+	if retryable.RetryAfter != nil {
+		delay := *retryable.RetryAfter
+		if delay < 0 {
+			delay = 0
+		}
+		if age+delay > retryWindow {
+			return true, retryWindow
+		}
+	}
+	return false, retryWindow
 }
 
 func (w *Worker) RequestDrain() {

--- a/internal/worker/worker_test.go
+++ b/internal/worker/worker_test.go
@@ -23,6 +23,18 @@ type wakeTestStore struct {
 	claims atomic.Int32
 }
 
+type retryWindowLeaseStoreStub struct {
+	startedAt time.Time
+	ok        bool
+	err       error
+	calls     int
+}
+
+func (s *retryWindowLeaseStoreStub) EnsureRetryWindowStartedAtWithLease(context.Context, uuid.UUID, uuid.UUID, time.Time) (time.Time, bool, error) {
+	s.calls++
+	return s.startedAt, s.ok, s.err
+}
+
 func (s *wakeTestStore) ClaimNextRunnable(context.Context, string, string, uuid.UUID, time.Duration) (*models.Job, error) {
 	s.claims.Add(1)
 	return nil, nil
@@ -30,6 +42,10 @@ func (s *wakeTestStore) ClaimNextRunnable(context.Context, string, string, uuid.
 
 func (s *wakeTestStore) RenewLease(context.Context, uuid.UUID, uuid.UUID, time.Duration) (*models.Job, bool, error) {
 	return nil, false, nil
+}
+
+func (s *wakeTestStore) EnsureRetryWindowStartedAtWithLease(context.Context, uuid.UUID, uuid.UUID, time.Time) (time.Time, bool, error) {
+	return time.Time{}, false, nil
 }
 
 func (s *wakeTestStore) MarkSucceededWithLease(context.Context, uuid.UUID, uuid.UUID) (bool, error) {
@@ -82,35 +98,35 @@ func TestRetryableDurationExceeded(t *testing.T) {
 	twentyOneMinutes := 21 * time.Minute
 	tests := []struct {
 		name           string
-		createdAt      time.Time
+		retryStartedAt time.Time
 		retryable      *RetryableError
 		expected       bool
 		expectedWindow time.Duration
 	}{
 		{
 			name:           "default window rejects an old job",
-			createdAt:      now.Add(-maxRetryableDuration - time.Second),
+			retryStartedAt: now.Add(-maxRetryableDuration - time.Second),
 			retryable:      &RetryableError{Err: errors.New("dependency unavailable")},
 			expected:       true,
 			expectedWindow: maxRetryableDuration,
 		},
 		{
-			name:           "custom window permits a bounded wait",
-			createdAt:      now.Add(-10 * time.Minute),
+			name:           "custom window permits a recent bounded retry for an older job",
+			retryStartedAt: now.Add(-10 * time.Minute),
 			retryable:      &RetryableError{Err: errors.New("rate limited"), MaxRetryDuration: &customWindow, RetryAfter: &fiveMinutes},
 			expected:       false,
 			expectedWindow: customWindow,
 		},
 		{
 			name:           "custom window rejects a retry scheduled beyond its deadline",
-			createdAt:      now.Add(-10 * time.Minute),
+			retryStartedAt: now.Add(-10 * time.Minute),
 			retryable:      &RetryableError{Err: errors.New("rate limited"), MaxRetryDuration: &customWindow, RetryAfter: &twentyOneMinutes},
 			expected:       true,
 			expectedWindow: customWindow,
 		},
 		{
 			name:           "explicit bypass remains unbounded",
-			createdAt:      now.Add(-time.Hour),
+			retryStartedAt: now.Add(-time.Hour),
 			retryable:      &RetryableError{Err: errors.New("durable owner recovery"), BypassMaxRetryDuration: true},
 			expected:       false,
 			expectedWindow: maxRetryableDuration,
@@ -121,9 +137,78 @@ func TestRetryableDurationExceeded(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			actual, retryWindow := retryableDurationExceeded(tt.createdAt, tt.retryable, now)
+			actual, retryWindow := retryableDurationExceeded(tt.retryStartedAt, tt.retryable, now)
 			require.Equal(t, tt.expected, actual, "retry window should make the expected terminal decision")
 			require.Equal(t, tt.expectedWindow, retryWindow, "retry window should report the applied duration")
+		})
+	}
+}
+
+func TestEnsureRetryWindowStartedAt(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, time.July, 21, 18, 0, 0, 0, time.UTC)
+	createdAt := now.Add(-3 * time.Hour)
+	persistedStart := now.Add(-10 * time.Minute)
+	customWindow := 2 * time.Hour
+	lockToken := uuid.New()
+	tests := []struct {
+		name          string
+		job           *models.Job
+		retryable     *RetryableError
+		store         *retryWindowLeaseStoreStub
+		expectedStart time.Time
+		expectedOK    bool
+		expectErr     bool
+		expectedCalls int
+	}{
+		{
+			name:          "default retry window remains based on job creation",
+			job:           &models.Job{CreatedAt: createdAt},
+			retryable:     &RetryableError{Err: errors.New("dependency unavailable")},
+			store:         &retryWindowLeaseStoreStub{},
+			expectedStart: createdAt,
+			expectedOK:    true,
+		},
+		{
+			name:          "new bounded retry gets a durable window independent of job age",
+			job:           &models.Job{ID: uuid.New(), LockToken: &lockToken, CreatedAt: createdAt},
+			retryable:     &RetryableError{Err: errors.New("rate limited"), MaxRetryDuration: &customWindow},
+			store:         &retryWindowLeaseStoreStub{startedAt: now, ok: true},
+			expectedStart: now,
+			expectedOK:    true,
+			expectedCalls: 1,
+		},
+		{
+			name:          "existing durable window is reused after restart",
+			job:           &models.Job{ID: uuid.New(), LockToken: &lockToken, CreatedAt: createdAt, RetryWindowStartedAt: &persistedStart},
+			retryable:     &RetryableError{Err: errors.New("rate limited"), MaxRetryDuration: &customWindow},
+			store:         &retryWindowLeaseStoreStub{},
+			expectedStart: persistedStart,
+			expectedOK:    true,
+		},
+		{
+			name:      "bounded retry requires a fencing token",
+			job:       &models.Job{ID: uuid.New(), CreatedAt: createdAt},
+			retryable: &RetryableError{Err: errors.New("rate limited"), MaxRetryDuration: &customWindow},
+			store:     &retryWindowLeaseStoreStub{},
+			expectErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			actual, ok, err := ensureRetryWindowStartedAt(context.Background(), tt.store, tt.job, tt.retryable, now)
+			if tt.expectErr {
+				require.Error(t, err, "bounded retry setup should reject invalid lease state")
+			} else {
+				require.NoError(t, err, "bounded retry setup should resolve its durable start time")
+			}
+			require.Equal(t, tt.expectedOK, ok, "bounded retry setup should report expected lease ownership")
+			require.Equal(t, tt.expectedStart, actual, "bounded retry setup should return the expected window start")
+			require.Equal(t, tt.expectedCalls, tt.store.calls, "bounded retry setup should persist only when the durable start is absent")
 		})
 	}
 }
@@ -261,6 +346,37 @@ func TestWorker_Poll(t *testing.T) {
 				})
 
 				expectClaim(mock, jobID, orgID, "retryable_job", json.RawMessage(`{}`), now, lockToken)
+				mock.ExpectExec("attempts = GREATEST\\(attempts - 1, 0\\)").
+					WithArgs(handlerErr.Error(), pgxmock.AnyArg(), jobID, lockToken).
+					WillReturnResult(pgxmock.NewResult("UPDATE", 1))
+			},
+		},
+		{
+			name: "bounded retry starts when an older job first observes the failure",
+			setupMock: func(t *testing.T, w *Worker, mock pgxmock.PgxPoolIface) {
+				t.Helper()
+
+				jobID := uuid.New()
+				lockToken := uuid.New()
+				orgID := uuid.New()
+				oldCreatedAt := time.Now().Add(-3 * time.Hour)
+				retryWindowStartedAt := time.Now()
+				retryAfter := time.Minute
+				customWindow := 2 * time.Hour
+				handlerErr := &RetryableError{
+					Err:              errors.New("rate limited"),
+					RetryAfter:       &retryAfter,
+					MaxRetryDuration: &customWindow,
+				}
+
+				w.Register("bounded_retry_job", func(ctx context.Context, jobType string, got json.RawMessage) error {
+					return handlerErr
+				})
+
+				expectClaim(mock, jobID, orgID, "bounded_retry_job", json.RawMessage(`{}`), oldCreatedAt, lockToken)
+				mock.ExpectQuery("UPDATE jobs[\\s\\S]+retry_window_started_at = COALESCE\\(retry_window_started_at, \\$1\\)").
+					WithArgs(pgxmock.AnyArg(), jobID, lockToken).
+					WillReturnRows(pgxmock.NewRows([]string{"retry_window_started_at"}).AddRow(retryWindowStartedAt))
 				mock.ExpectExec("attempts = GREATEST\\(attempts - 1, 0\\)").
 					WithArgs(handlerErr.Error(), pgxmock.AnyArg(), jobID, lockToken).
 					WillReturnResult(pgxmock.NewResult("UPDATE", 1))
@@ -467,10 +583,10 @@ func TestWorker_Poll(t *testing.T) {
 						"id", "org_id", "queue", "job_type", "payload", "priority", "status",
 						"attempts", "max_attempts", "run_at", "locked_by_node_id", "locked_at",
 						"lease_expires_at", "lock_token", "run_owner_id", "owner_kind", "last_error",
-						"dedupe_key", "target_node_id", "created_at", "updated_at", "completed_at",
+						"dedupe_key", "target_node_id", "retry_window_started_at", "created_at", "updated_at", "completed_at",
 					}).AddRow(
 						jobID, orgID, "default", "missing_token", json.RawMessage(`{}`), 5, "running",
-						1, 3, now, "test-node", now, now.Add(defaultLeaseDuration), nil, "test-node", string(models.JobOwnerKindWorker), nil, nil, nil, now, now, nil,
+						1, 3, now, "test-node", now, now.Add(defaultLeaseDuration), nil, "test-node", string(models.JobOwnerKindWorker), nil, nil, nil, nil, now, now, nil,
 					))
 			},
 		},
@@ -764,6 +880,10 @@ func (s *renewLeaseStoreStub) DeadLetterWithLease(ctx context.Context, jobID, lo
 	return false, nil
 }
 
+func (s *renewLeaseStoreStub) EnsureRetryWindowStartedAtWithLease(_ context.Context, _ uuid.UUID, _ uuid.UUID, startedAt time.Time) (time.Time, bool, error) {
+	return startedAt, true, nil
+}
+
 func TestWorker_RenewLeaseLoop_CancelsAfterLeaseExpiryOnRenewErrors(t *testing.T) {
 	t.Parallel()
 
@@ -877,6 +997,10 @@ func (s *terminalLeaseStoreStub) RetryWithoutConsumingAttemptWithLease(ctx conte
 
 func (s *terminalLeaseStoreStub) DeadLetterWithLease(ctx context.Context, jobID, lockToken uuid.UUID, errMsg string) (bool, error) {
 	return s.deadLetterFn(ctx, jobID, lockToken, errMsg)
+}
+
+func (s *terminalLeaseStoreStub) EnsureRetryWindowStartedAtWithLease(_ context.Context, _ uuid.UUID, _ uuid.UUID, startedAt time.Time) (time.Time, bool, error) {
+	return startedAt, true, nil
 }
 
 func TestWorker_StateAccessors(t *testing.T) {
@@ -1017,10 +1141,10 @@ func expectClaimWithAttemptsAndTarget(mock pgxmock.PgxPoolIface, jobID, orgID uu
 			"id", "org_id", "queue", "job_type", "payload", "priority", "status",
 			"attempts", "max_attempts", "run_at", "locked_by_node_id", "locked_at",
 			"lease_expires_at", "lock_token", "run_owner_id", "owner_kind", "last_error",
-			"dedupe_key", "target_node_id", "created_at", "updated_at", "completed_at",
+			"dedupe_key", "target_node_id", "retry_window_started_at", "created_at", "updated_at", "completed_at",
 		}).AddRow(
 			jobID, orgID, "default", jobType, payload, 5, "running",
 			attempts, maxAttempts, createdAt, "test-node", createdAt, createdAt.Add(defaultLeaseDuration),
-			lockToken.String(), "test-node", string(models.JobOwnerKindWorker), nil, nil, target, createdAt, createdAt, nil,
+			lockToken.String(), "test-node", string(models.JobOwnerKindWorker), nil, nil, target, nil, createdAt, createdAt, nil,
 		))
 }

--- a/internal/worker/worker_test.go
+++ b/internal/worker/worker_test.go
@@ -73,6 +73,61 @@ func TestRetryableError(t *testing.T) {
 	require.ErrorIs(t, retryable.Unwrap(), cause, "Unwrap should expose the wrapped error")
 }
 
+func TestRetryableDurationExceeded(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, time.July, 21, 18, 0, 0, 0, time.UTC)
+	customWindow := 30 * time.Minute
+	fiveMinutes := 5 * time.Minute
+	twentyOneMinutes := 21 * time.Minute
+	tests := []struct {
+		name           string
+		createdAt      time.Time
+		retryable      *RetryableError
+		expected       bool
+		expectedWindow time.Duration
+	}{
+		{
+			name:           "default window rejects an old job",
+			createdAt:      now.Add(-maxRetryableDuration - time.Second),
+			retryable:      &RetryableError{Err: errors.New("dependency unavailable")},
+			expected:       true,
+			expectedWindow: maxRetryableDuration,
+		},
+		{
+			name:           "custom window permits a bounded wait",
+			createdAt:      now.Add(-10 * time.Minute),
+			retryable:      &RetryableError{Err: errors.New("rate limited"), MaxRetryDuration: &customWindow, RetryAfter: &fiveMinutes},
+			expected:       false,
+			expectedWindow: customWindow,
+		},
+		{
+			name:           "custom window rejects a retry scheduled beyond its deadline",
+			createdAt:      now.Add(-10 * time.Minute),
+			retryable:      &RetryableError{Err: errors.New("rate limited"), MaxRetryDuration: &customWindow, RetryAfter: &twentyOneMinutes},
+			expected:       true,
+			expectedWindow: customWindow,
+		},
+		{
+			name:           "explicit bypass remains unbounded",
+			createdAt:      now.Add(-time.Hour),
+			retryable:      &RetryableError{Err: errors.New("durable owner recovery"), BypassMaxRetryDuration: true},
+			expected:       false,
+			expectedWindow: maxRetryableDuration,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			actual, retryWindow := retryableDurationExceeded(tt.createdAt, tt.retryable, now)
+			require.Equal(t, tt.expected, actual, "retry window should make the expected terminal decision")
+			require.Equal(t, tt.expectedWindow, retryWindow, "retry window should report the applied duration")
+		})
+	}
+}
+
 type nilStringPointerArg struct{}
 
 func (nilStringPointerArg) Match(v interface{}) bool {

--- a/migrations/000254_jobs_retry_window_started_at.down.sql
+++ b/migrations/000254_jobs_retry_window_started_at.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE jobs DROP COLUMN IF EXISTS retry_window_started_at;

--- a/migrations/000254_jobs_retry_window_started_at.up.sql
+++ b/migrations/000254_jobs_retry_window_started_at.up.sql
@@ -1,0 +1,3 @@
+-- Persist the first observation of a bounded retry condition so the retry
+-- window survives worker restarts and is not measured from job creation.
+ALTER TABLE jobs ADD COLUMN retry_window_started_at timestamptz;


### PR DESCRIPTION
## Summary

- centralize GitHub API and transport retry classification
- preserve status and rate-limit headers through installation-token, PR-sync, changed-file, and review-publish calls
- defer rate-limited jobs without consuming attempts, using GitHub's reset delay or a one-minute fallback
- extend rate-limit retries to a bounded two-hour window while retaining the existing durable Postgres job schedule across worker restarts
- keep ordinary 5xx/network failures attempt-consuming and fail permanent GitHub 4xx responses immediately

## Why

The investigation of assembledhq/assembled#54261 found that the code-review job hit the GitHub App installation rate limit, then exhausted the worker's generic eight-minute retry window before GitHub's reset roughly 24 minutes later. The normal PR-sync path also treated rate limits as generic failures, while the code-review publisher discarded the response headers needed to make a reset-aware decision.

This is PR 1 of the rate-limit work. It fixes failure handling and recovery; request-volume reduction and installation-level budgeting will follow in separate PRs.

## Verification

- `go test ./internal/services/github ./internal/services/codereview ./internal/worker`
- focused worker retry tests
- `go vet ./...`
- `go test ./...` passed all affected packages; the repository-wide run hit the existing Redis subscription-closure flake in `internal/api/handlers`, and the exact failing test passed when rerun in isolation
