### PR TITLE
Prevent looping code reviews on equivalent webhook events

### DIFF
--- a/internal/api/handlers/code_review_reassessment.go
+++ b/internal/api/handlers/code_review_reassessment.go
@@ -16,8 +16,11 @@ import (
 )
 
 type codeReviewReassessmentWebhook struct {
-	Action     string `json:"action"`
-	Number     int    `json:"number"`
+	Action string `json:"action"`
+	Number int    `json:"number"`
+	Sender struct {
+		Login string `json:"login"`
+	} `json:"sender"`
 	Repository struct {
 		FullName string `json:"full_name"`
 	} `json:"repository"`
@@ -41,25 +44,51 @@ type codeReviewReassessmentWebhook struct {
 		} `json:"base"`
 	} `json:"pull_request"`
 	Review struct {
-		Body string `json:"body"`
+		ID       int64  `json:"id"`
+		State    string `json:"state"`
+		Body     string `json:"body"`
+		CommitID string `json:"commit_id"`
+		User     struct {
+			Login string `json:"login"`
+		} `json:"user"`
+		PerformedViaGitHubApp *codeReviewGitHubAppIdentity `json:"performed_via_github_app"`
 	} `json:"review"`
 	Comment struct {
-		Body string `json:"body"`
+		ID       int64  `json:"id"`
+		Body     string `json:"body"`
+		Path     string `json:"path"`
+		Line     *int   `json:"line"`
+		CommitID string `json:"commit_id"`
+		User     struct {
+			Login string `json:"login"`
+		} `json:"user"`
+		PerformedViaGitHubApp *codeReviewGitHubAppIdentity `json:"performed_via_github_app"`
 	} `json:"comment"`
+	Thread struct {
+		ID string `json:"id"`
+	} `json:"thread"`
 	CheckSuite struct {
+		Conclusion   *string `json:"conclusion"`
 		PullRequests []struct {
 			Number int `json:"number"`
 		} `json:"pull_requests"`
 	} `json:"check_suite"`
 	CheckRun struct {
+		Conclusion   *string `json:"conclusion"`
 		PullRequests []struct {
 			Number int `json:"number"`
 		} `json:"pull_requests"`
 	} `json:"check_run"`
-	SHA string `json:"sha"`
+	SHA   string `json:"sha"`
+	State string `json:"state"`
 }
 
-func (h *WebhookHandler) reassessCodeReviewsForGitHubEvent(ctx context.Context, owner db.GitHubRepoOwner, eventType string, body []byte, deliveryID string) error {
+type codeReviewGitHubAppIdentity struct {
+	ID   int64  `json:"id"`
+	Slug string `json:"slug"`
+}
+
+func (h *WebhookHandler) reassessCodeReviewsForGitHubEvent(ctx context.Context, owner db.GitHubRepoOwner, eventType string, body []byte, _ string) error {
 	if h.codeReviews == nil || h.pullRequests == nil || owner.OrgID == uuid.Nil || owner.RepositoryID == uuid.Nil {
 		return nil
 	}
@@ -70,8 +99,7 @@ func (h *WebhookHandler) reassessCodeReviewsForGitHubEvent(ctx context.Context, 
 	if !codeReviewEventChangesAssessment(eventType, event) {
 		return nil
 	}
-	if (eventType == "pull_request_review" && event.Action != "dismissed" && codereviewsvc.IsCodeReviewAuthoredBody(event.Review.Body)) ||
-		(eventType == "pull_request_review_comment" && codereviewsvc.IsCodeReviewAuthoredBody(event.Comment.Body)) {
+	if h.codeReviewReassessmentIsSelfAuthored(eventType, event) {
 		return nil
 	}
 
@@ -82,7 +110,7 @@ func (h *WebhookHandler) reassessCodeReviewsForGitHubEvent(ctx context.Context, 
 			return fmt.Errorf("list pull requests for code review status reassessment: %w", err)
 		}
 		for _, pr := range prs {
-			if err := h.reassessCodeReviewTarget(ctx, owner, eventType, deliveryID, body, event, pr); err != nil {
+			if err := h.reassessCodeReviewTarget(ctx, owner, eventType, event, pr); err != nil {
 				return err
 			}
 		}
@@ -96,14 +124,14 @@ func (h *WebhookHandler) reassessCodeReviewsForGitHubEvent(ctx context.Context, 
 		if err != nil {
 			return fmt.Errorf("load pull request for code review reassessment: %w", err)
 		}
-		if err := h.reassessCodeReviewTarget(ctx, owner, eventType, deliveryID, body, event, pr); err != nil {
+		if err := h.reassessCodeReviewTarget(ctx, owner, eventType, event, pr); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
-func (h *WebhookHandler) reassessCodeReviewTarget(ctx context.Context, owner db.GitHubRepoOwner, eventType, deliveryID string, body []byte, event codeReviewReassessmentWebhook, pr models.PullRequest) error {
+func (h *WebhookHandler) reassessCodeReviewTarget(ctx context.Context, owner db.GitHubRepoOwner, eventType string, event codeReviewReassessmentWebhook, pr models.PullRequest) error {
 	if strings.TrimSpace(event.PullRequest.Head.SHA) != "" {
 		snapshot := db.PullRequestGitHubSnapshot{
 			GitHubPRURL: event.PullRequest.HTMLURL,
@@ -123,12 +151,11 @@ func (h *WebhookHandler) reassessCodeReviewTarget(ctx context.Context, owner db.
 		pr.HeadRef = snapshot.HeadRef
 		pr.BaseSHA = snapshot.BaseSHA
 	}
-	changeKey := strings.TrimSpace(deliveryID)
-	if changeKey == "" {
-		sum := sha256.Sum256(append([]byte(eventType+"\n"), body...))
-		changeKey = fmt.Sprintf("%x", sum[:])
+	changeKey, err := codeReviewMaterialChangeKey(eventType, event, pr)
+	if err != nil {
+		return fmt.Errorf("build code review material change key: %w", err)
 	}
-	_, err := h.codeReviews.QueueReviewChanged(ctx, codereviewsvc.ReviewChangedInput{
+	_, err = h.codeReviews.QueueReviewChanged(ctx, codereviewsvc.ReviewChangedInput{
 		OrgID:             owner.OrgID,
 		RepositoryID:      owner.RepositoryID,
 		PullRequestID:     pr.ID,
@@ -140,13 +167,188 @@ func (h *WebhookHandler) reassessCodeReviewTarget(ctx context.Context, owner db.
 		BaseSHA:           codeReviewStringValue(pr.BaseSHA),
 		HeadSHA:           codeReviewStringValue(pr.HeadSHA),
 		FromFork:          event.PullRequest.Head.Repo.Fork,
-		ChangeKey:         eventType + ":" + changeKey,
+		ChangeKey:         changeKey,
 		ChangeReason:      eventType + "." + event.Action,
 	})
 	if err != nil {
 		return fmt.Errorf("queue code review reassessment: %w", err)
 	}
 	return nil
+}
+
+func (h *WebhookHandler) codeReviewReassessmentIsSelfAuthored(eventType string, event codeReviewReassessmentWebhook) bool {
+	switch eventType {
+	case "pull_request_review":
+		if event.Action == "dismissed" {
+			return false
+		}
+		// Standalone inline comments can produce an empty-body COMMENTED review
+		// container, so app identity must be authoritative when no marker exists.
+		return codereviewsvc.IsCodeReviewAuthoredBody(event.Review.Body) ||
+			h.codeReviewActorIsOwnApp(firstNonEmptyString(event.Review.User.Login, event.Sender.Login), event.Review.PerformedViaGitHubApp)
+	case "pull_request_review_comment":
+		if event.Action == "deleted" {
+			return false
+		}
+		return codereviewsvc.IsCodeReviewAuthoredBody(event.Comment.Body) ||
+			h.codeReviewActorIsOwnApp(firstNonEmptyString(event.Comment.User.Login, event.Sender.Login), event.Comment.PerformedViaGitHubApp)
+	default:
+		return false
+	}
+}
+
+func (h *WebhookHandler) codeReviewActorIsOwnApp(login string, app *codeReviewGitHubAppIdentity) bool {
+	if h == nil || h.cfg == nil {
+		return false
+	}
+	if app != nil && h.cfg.GitHubAppID > 0 && app.ID == h.cfg.GitHubAppID {
+		return true
+	}
+	ownSlug := canonicalCodeReviewBotLogin(h.cfg.GitHubAppSlug)
+	if ownSlug == "" {
+		return false
+	}
+	return canonicalCodeReviewBotLogin(login) == ownSlug ||
+		(app != nil && canonicalCodeReviewBotLogin(app.Slug) == ownSlug)
+}
+
+func canonicalCodeReviewBotLogin(login string) string {
+	return strings.TrimSuffix(strings.ToLower(strings.TrimSpace(login)), "[bot]")
+}
+
+type codeReviewMaterialPullRequestState struct {
+	HeadSHA          string                         `json:"head_sha"`
+	BaseSHA          string                         `json:"base_sha"`
+	Title            string                         `json:"title"`
+	Body             string                         `json:"body"`
+	Status           models.PullRequestStatus       `json:"status"`
+	ReviewStatus     models.PullRequestReviewStatus `json:"review_status"`
+	CIStatus         models.PullRequestCIStatus     `json:"ci_status"`
+	MergeState       models.PullRequestMergeState   `json:"merge_state"`
+	HasConflicts     bool                           `json:"has_conflicts"`
+	FailingTestCount int                            `json:"failing_test_count"`
+}
+
+type codeReviewMaterialEventState struct {
+	Class       string `json:"class"`
+	ObjectID    string `json:"object_id,omitempty"`
+	State       string `json:"state,omitempty"`
+	Body        string `json:"body,omitempty"`
+	Path        string `json:"path,omitempty"`
+	Line        int    `json:"line,omitempty"`
+	CommitID    string `json:"commit_id,omitempty"`
+	AuthorLogin string `json:"author_login,omitempty"`
+}
+
+type codeReviewMaterialAssessmentState struct {
+	PullRequest codeReviewMaterialPullRequestState `json:"pull_request"`
+	Event       codeReviewMaterialEventState       `json:"event"`
+}
+
+func codeReviewMaterialChangeKey(eventType string, event codeReviewReassessmentWebhook, pr models.PullRequest) (string, error) {
+	state := codeReviewMaterialAssessmentState{
+		PullRequest: codeReviewMaterialPullRequestState{
+			HeadSHA:          codeReviewStringValue(pr.HeadSHA),
+			BaseSHA:          codeReviewStringValue(pr.BaseSHA),
+			Title:            strings.TrimSpace(pr.Title),
+			Body:             strings.TrimSpace(codeReviewStringValue(pr.Body)),
+			Status:           pr.Status,
+			ReviewStatus:     pr.ReviewStatus,
+			CIStatus:         pr.CIStatus,
+			MergeState:       pr.MergeState,
+			HasConflicts:     pr.HasConflicts,
+			FailingTestCount: pr.FailingTestCount,
+		},
+	}
+	switch eventType {
+	case "pull_request":
+		state.Event = codeReviewMaterialEventState{Class: "pull_request", State: codeReviewPullRequestEventState(event.Action)}
+	case "pull_request_review":
+		reviewState := strings.ToLower(strings.TrimSpace(event.Review.State))
+		if event.Action == "dismissed" {
+			reviewState = "dismissed"
+		}
+		state.Event = codeReviewMaterialEventState{
+			Class:       "review",
+			ObjectID:    fmt.Sprintf("%d", event.Review.ID),
+			State:       reviewState,
+			Body:        strings.TrimSpace(event.Review.Body),
+			CommitID:    strings.TrimSpace(event.Review.CommitID),
+			AuthorLogin: canonicalCodeReviewBotLogin(event.Review.User.Login),
+		}
+	case "pull_request_review_comment":
+		commentState := "present"
+		if event.Action == "deleted" {
+			commentState = "deleted"
+		}
+		state.Event = codeReviewMaterialEventState{
+			Class:       "review_comment",
+			ObjectID:    fmt.Sprintf("%d", event.Comment.ID),
+			State:       commentState,
+			Body:        strings.TrimSpace(event.Comment.Body),
+			Path:        strings.TrimSpace(event.Comment.Path),
+			Line:        codeReviewIntValue(event.Comment.Line),
+			CommitID:    strings.TrimSpace(event.Comment.CommitID),
+			AuthorLogin: canonicalCodeReviewBotLogin(event.Comment.User.Login),
+		}
+	case "pull_request_review_thread":
+		state.Event = codeReviewMaterialEventState{
+			Class:    "review_thread",
+			ObjectID: strings.TrimSpace(event.Thread.ID),
+			State:    strings.ToLower(strings.TrimSpace(event.Action)),
+		}
+	case "check_suite":
+		state.Event = codeReviewMaterialEventState{Class: "checks", State: codeReviewCheckState(event.CheckSuite.Conclusion, "")}
+	case "check_run":
+		state.Event = codeReviewMaterialEventState{Class: "checks", State: codeReviewCheckState(event.CheckRun.Conclusion, "")}
+	case "status":
+		state.Event = codeReviewMaterialEventState{Class: "checks", State: codeReviewCheckState(nil, event.State)}
+	default:
+		state.Event = codeReviewMaterialEventState{Class: eventType, State: strings.ToLower(strings.TrimSpace(event.Action))}
+	}
+	raw, err := json.Marshal(state)
+	if err != nil {
+		return "", fmt.Errorf("marshal material assessment state: %w", err)
+	}
+	sum := sha256.Sum256(raw)
+	return fmt.Sprintf("material:%x", sum[:]), nil
+}
+
+func codeReviewPullRequestEventState(action string) string {
+	switch strings.ToLower(strings.TrimSpace(action)) {
+	case "ready_for_review":
+		return "ready"
+	case "converted_to_draft":
+		return "draft"
+	default:
+		// Synchronize, edit, and reopen events are fully represented by the
+		// mirrored pull-request state included in the material key.
+		return ""
+	}
+}
+
+func codeReviewCheckState(conclusion *string, statusState string) string {
+	value := strings.ToLower(strings.TrimSpace(statusState))
+	if conclusion != nil {
+		value = strings.ToLower(strings.TrimSpace(*conclusion))
+	}
+	switch value {
+	case "success", "neutral", "skipped":
+		return "success"
+	case "failure", "error", "cancelled", "timed_out", "action_required", "startup_failure", "stale":
+		return "failure"
+	case "pending", "queued", "in_progress", "requested", "waiting":
+		return "pending"
+	default:
+		return "unknown"
+	}
+}
+
+func codeReviewIntValue(value *int) int {
+	if value == nil {
+		return 0
+	}
+	return *value
 }
 
 func codeReviewStringValue(value *string) string {

--- a/internal/api/handlers/code_review_reassessment.go
+++ b/internal/api/handlers/code_review_reassessment.go
@@ -65,22 +65,25 @@ type codeReviewReassessmentWebhook struct {
 		PerformedViaGitHubApp *codeReviewGitHubAppIdentity `json:"performed_via_github_app"`
 	} `json:"comment"`
 	Thread struct {
-		ID string `json:"id"`
+		NodeID string `json:"node_id"`
 	} `json:"thread"`
 	CheckSuite struct {
+		ID           int64   `json:"id"`
 		Conclusion   *string `json:"conclusion"`
 		PullRequests []struct {
 			Number int `json:"number"`
 		} `json:"pull_requests"`
 	} `json:"check_suite"`
 	CheckRun struct {
+		ID           int64   `json:"id"`
 		Conclusion   *string `json:"conclusion"`
 		PullRequests []struct {
 			Number int `json:"number"`
 		} `json:"pull_requests"`
 	} `json:"check_run"`
-	SHA   string `json:"sha"`
-	State string `json:"state"`
+	SHA     string `json:"sha"`
+	State   string `json:"state"`
+	Context string `json:"context"`
 }
 
 type codeReviewGitHubAppIdentity struct {
@@ -294,15 +297,30 @@ func codeReviewMaterialChangeKey(eventType string, event codeReviewReassessmentW
 	case "pull_request_review_thread":
 		state.Event = codeReviewMaterialEventState{
 			Class:    "review_thread",
-			ObjectID: strings.TrimSpace(event.Thread.ID),
+			ObjectID: strings.TrimSpace(event.Thread.NodeID),
 			State:    strings.ToLower(strings.TrimSpace(event.Action)),
 		}
 	case "check_suite":
-		state.Event = codeReviewMaterialEventState{Class: "checks", State: codeReviewCheckState(event.CheckSuite.Conclusion, "")}
+		state.Event = codeReviewMaterialCheckEventState(
+			pr.CIStatus,
+			fmt.Sprintf("check_suite:%d", event.CheckSuite.ID),
+			event.CheckSuite.Conclusion,
+			"",
+		)
 	case "check_run":
-		state.Event = codeReviewMaterialEventState{Class: "checks", State: codeReviewCheckState(event.CheckRun.Conclusion, "")}
+		state.Event = codeReviewMaterialCheckEventState(
+			pr.CIStatus,
+			fmt.Sprintf("check_run:%d", event.CheckRun.ID),
+			event.CheckRun.Conclusion,
+			"",
+		)
 	case "status":
-		state.Event = codeReviewMaterialEventState{Class: "checks", State: codeReviewCheckState(nil, event.State)}
+		state.Event = codeReviewMaterialCheckEventState(
+			pr.CIStatus,
+			"status:"+strings.ToLower(strings.TrimSpace(event.Context)),
+			nil,
+			event.State,
+		)
 	default:
 		state.Event = codeReviewMaterialEventState{Class: eventType, State: strings.ToLower(strings.TrimSpace(event.Action))}
 	}
@@ -338,6 +356,28 @@ func codeReviewCheckState(conclusion *string, statusState string) string {
 	case "failure", "error", "cancelled", "timed_out", "action_required", "startup_failure", "stale":
 		return "failure"
 	case "pending", "queued", "in_progress", "requested", "waiting":
+		return "pending"
+	default:
+		return "unknown"
+	}
+}
+
+func codeReviewMaterialCheckEventState(prCIStatus models.PullRequestCIStatus, objectID string, conclusion *string, statusState string) codeReviewMaterialEventState {
+	state := codeReviewCheckState(conclusion, statusState)
+	event := codeReviewMaterialEventState{Class: "checks", State: state}
+	if codeReviewStoredCIState(prCIStatus) != state {
+		event.ObjectID = strings.TrimSpace(objectID)
+	}
+	return event
+}
+
+func codeReviewStoredCIState(status models.PullRequestCIStatus) string {
+	switch status {
+	case models.PullRequestCIStatusSuccess:
+		return "success"
+	case models.PullRequestCIStatusFailure:
+		return "failure"
+	case models.PullRequestCIStatusPending:
 		return "pending"
 	default:
 		return "unknown"

--- a/internal/api/handlers/webhooks_test.go
+++ b/internal/api/handlers/webhooks_test.go
@@ -801,7 +801,8 @@ func TestWebhook_ReassessesRequestedCodeReviewAfterPullRequestEdit(t *testing.T)
 	require.Equal(t, prID, jobs.reassessmentPayload.PullRequestID, "reassessment should target the reviewed pull request")
 	require.Equal(t, priorSessionID, jobs.reassessmentPayload.PriorSessionID, "queued reassessment should remain ordered behind the assessment active when the event arrived")
 	require.Equal(t, "head-sha", jobs.reassessmentPayload.HeadSHA, "queued reassessment should capture the current PR head")
-	require.Equal(t, "pull_request:delivery-143", jobs.reassessmentPayload.ChangeKey, "queued reassessment should retain the delivery idempotency key")
+	require.Contains(t, jobs.reassessmentPayload.ChangeKey, "material:", "queued reassessment should use a material-state key")
+	require.NotContains(t, jobs.reassessmentPayload.ChangeKey, "delivery-143", "queued reassessment should not use the webhook delivery id")
 	require.Equal(t, 0, sessions.createCalls, "webhook should defer session creation to the durable starter job")
 	require.NoError(t, mock.ExpectationsWereMet(), "pull request mirror refresh should be org-scoped")
 }
@@ -809,21 +810,223 @@ func TestWebhook_ReassessesRequestedCodeReviewAfterPullRequestEdit(t *testing.T)
 func TestWebhook_CodeReviewReassessmentIgnores143ReviewWrites(t *testing.T) {
 	t.Parallel()
 
+	tests := []struct {
+		name      string
+		eventType string
+		body      string
+	}{
+		{
+			name:      "marked review summary",
+			eventType: "pull_request_review",
+			body: `{
+				"action":"submitted","repository":{"full_name":"assembledhq/143"},"pull_request":{"number":42},
+				"review":{"body":"Updated assessment\n\n<!-- 143-code-review-output:abc -->"}
+			}`,
+		},
+		{
+			name:      "empty review body from app bot sender",
+			eventType: "pull_request_review",
+			body: `{
+				"action":"submitted","repository":{"full_name":"assembledhq/143"},"pull_request":{"number":42},
+				"sender":{"login":"143-dev[bot]"},"review":{"body":""}
+			}`,
+		},
+		{
+			name:      "empty review body from configured app identity",
+			eventType: "pull_request_review",
+			body: `{
+				"action":"submitted","repository":{"full_name":"assembledhq/143"},"pull_request":{"number":42},
+				"review":{"body":"","performed_via_github_app":{"id":143,"slug":"renamed-app"}}
+			}`,
+		},
+		{
+			name:      "unmarked inline comment from app bot login",
+			eventType: "pull_request_review_comment",
+			body: `{
+				"action":"created","repository":{"full_name":"assembledhq/143"},"pull_request":{"number":42},
+				"comment":{"body":"Automated finding without a marker","user":{"login":"143-dev[bot]"}}
+			}`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			mock, err := pgxmock.NewPool()
+			require.NoError(t, err, "pgxmock pool should initialize")
+			defer mock.Close()
+			handler := &WebhookHandler{
+				cfg:          &config.Config{GitHubAppID: 143, GitHubAppSlug: "143-dev"},
+				pullRequests: db.NewPullRequestStore(mock),
+				codeReviews:  &codereviewsvc.Service{},
+			}
+
+			err = handler.reassessCodeReviewsForGitHubEvent(context.Background(), db.GitHubRepoOwner{
+				OrgID: uuid.New(), RepositoryID: uuid.New(), FullName: "assembledhq/143", Status: "active",
+			}, tt.eventType, []byte(tt.body), "delivery-self")
+
+			require.NoError(t, err, "143-authored review webhook should be ignored without a feedback loop")
+			require.NoError(t, mock.ExpectationsWereMet(), "self-authored review should not query pull request state")
+		})
+	}
+}
+
+func TestCodeReviewMaterialChangeKey(t *testing.T) {
+	t.Parallel()
+
+	body := "Description with tests"
+	headSHA := "head-sha"
+	baseSHA := "base-sha"
+	pr := models.PullRequest{
+		Title:            "Improve reviewer reassessment",
+		Body:             &body,
+		HeadSHA:          &headSHA,
+		BaseSHA:          &baseSHA,
+		ReviewStatus:     models.PullRequestReviewStatusPending,
+		CIStatus:         models.PullRequestCIStatusSuccess,
+		MergeState:       models.PullRequestMergeStateClean,
+		FailingTestCount: 0,
+	}
+	success := "success"
+	failure := "failure"
+	checkRunSuccess := codeReviewReassessmentWebhook{Action: "completed"}
+	checkRunSuccess.CheckRun.Conclusion = &success
+	checkSuiteSuccess := codeReviewReassessmentWebhook{Action: "completed"}
+	checkSuiteSuccess.CheckSuite.Conclusion = &success
+	checkRunFailure := codeReviewReassessmentWebhook{Action: "completed"}
+	checkRunFailure.CheckRun.Conclusion = &failure
+	humanReview := codeReviewReassessmentWebhook{Action: "submitted"}
+	humanReview.Review.ID = 101
+	humanReview.Review.State = "commented"
+	humanReview.Review.Body = "Please add a regression test."
+	editedHumanReview := humanReview
+	editedHumanReview.Action = "edited"
+	editedHumanReview.Review.Body = "Please add two regression tests."
+	synchronizedPullRequest := codeReviewReassessmentWebhook{Action: "synchronize"}
+	editedPullRequest := codeReviewReassessmentWebhook{Action: "edited"}
+
+	tests := []struct {
+		name       string
+		leftType   string
+		left       codeReviewReassessmentWebhook
+		rightType  string
+		right      codeReviewReassessmentWebhook
+		rightCI    models.PullRequestCIStatus
+		expectSame bool
+	}{
+		{
+			name:     "check run and suite with same aggregate result",
+			leftType: "check_run", left: checkRunSuccess,
+			rightType: "check_suite", right: checkSuiteSuccess,
+			expectSame: true,
+		},
+		{
+			name:     "changed check result",
+			leftType: "check_run", left: checkRunSuccess,
+			rightType: "check_run", right: checkRunFailure,
+			expectSame: false,
+		},
+		{
+			name:     "edited human review body",
+			leftType: "pull_request_review", left: humanReview,
+			rightType: "pull_request_review", right: editedHumanReview,
+			expectSame: false,
+		},
+		{
+			name:       "different deliveries for unchanged pull request state",
+			leftType:   "pull_request",
+			left:       synchronizedPullRequest,
+			rightType:  "pull_request",
+			right:      editedPullRequest,
+			expectSame: true,
+		},
+		{
+			name:       "aggregate CI state changed",
+			leftType:   "check_run",
+			left:       checkRunSuccess,
+			rightType:  "check_run",
+			right:      checkRunSuccess,
+			rightCI:    models.PullRequestCIStatusFailure,
+			expectSame: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			left, err := codeReviewMaterialChangeKey(tt.leftType, tt.left, pr)
+			require.NoError(t, err, "left material state should serialize")
+			rightPR := pr
+			if tt.rightCI != "" {
+				rightPR.CIStatus = tt.rightCI
+			}
+			right, err := codeReviewMaterialChangeKey(tt.rightType, tt.right, rightPR)
+			require.NoError(t, err, "right material state should serialize")
+			if tt.expectSame {
+				require.Equal(t, left, right, "equivalent material assessment state should share a dedupe key")
+				return
+			}
+			require.NotEqual(t, left, right, "materially different assessment state should use a new dedupe key")
+		})
+	}
+}
+
+func TestWebhook_CodeReviewReassessmentUsesSameKeyForEquivalentDeliveries(t *testing.T) {
+	t.Parallel()
+
 	mock, err := pgxmock.NewPool()
 	require.NoError(t, err, "pgxmock pool should initialize")
 	defer mock.Close()
-	handler := &WebhookHandler{pullRequests: db.NewPullRequestStore(mock), codeReviews: &codereviewsvc.Service{}}
-	body := []byte(`{
+
+	orgID := uuid.New()
+	repoID := uuid.New()
+	prID := uuid.New()
+	policyID := uuid.New()
+	priorSessionID := uuid.New()
+	now := time.Now().UTC()
+	metadata := &codeReviewWebhookMetadataStore{latest: models.CodeReviewSessionMetadata{
+		ID: uuid.New(), SessionID: priorSessionID, RepositoryID: repoID, PullRequestID: prID, PolicyID: policyID,
+		HeadSHA: "head-sha", TriggerSource: models.CodeReviewTriggerSourceTeamReviewer,
+		Status: models.CodeReviewSessionStatusCompleted, ReviewOutputKey: "prior-output",
+	}}
+	jobs := &codeReviewWebhookJobStore{jobID: uuid.New()}
+	cfg := models.DefaultCodeReviewPolicyConfig()
+	codeReviews := codereviewsvc.NewService(
+		&codeReviewWebhookPolicyStore{policyID: policyID, config: cfg}, metadata,
+		&codeReviewWebhookSessionStore{}, jobs, zerolog.Nop(), codereviewsvc.Config{},
+	)
+	handler := &WebhookHandler{pullRequests: db.NewPullRequestStore(mock), codeReviews: codeReviews}
+	body := "Description with tests"
+	headSHA := "head-sha"
+	headRef := "feature/code-review"
+	baseSHA := "base-sha"
+	expectPullRequest := func() {
+		mock.ExpectQuery("SELECT .+ FROM pull_requests[\\s\\S]*WHERE org_id").
+			WithArgs(pgx.NamedArgs{"org_id": orgID, "github_repo": "assembledhq/143", "github_pr_number": 42}).
+			WillReturnRows(pgxmock.NewRows(codeReviewWebhookPullRequestColumns()).AddRow(
+				prID, nil, orgID, 42, "https://github.com/assembledhq/143/pull/42", "assembledhq/143",
+				"Improve reviewer reassessment", &body, "open", "pending", "user", "success", &headSHA, &headRef, &baseSHA,
+				"clean", false, 0, false, nil, int64(1),
+				models.PullRequestMergeWhenReadyStateOff, nil, nil, "", nil, "", nil,
+				nil, now, now,
+			))
+	}
+	eventBody := []byte(`{
 		"action":"submitted","repository":{"full_name":"assembledhq/143"},"pull_request":{"number":42},
-		"review":{"body":"Updated assessment\n\n<!-- 143-code-review-output:abc -->"}
+		"review":{"id":101,"state":"commented","body":"Please add a regression test.","user":{"login":"anya"}}
 	}`)
+	owner := db.GitHubRepoOwner{OrgID: orgID, RepositoryID: repoID, FullName: "assembledhq/143", Status: "active"}
+	for _, deliveryID := range []string{"delivery-one", "delivery-two"} {
+		expectPullRequest()
+		require.NoError(t, handler.reassessCodeReviewsForGitHubEvent(
+			context.Background(), owner, "pull_request_review", eventBody, deliveryID,
+		), "equivalent delivery should queue without error")
+	}
 
-	err = handler.reassessCodeReviewsForGitHubEvent(context.Background(), db.GitHubRepoOwner{
-		OrgID: uuid.New(), RepositoryID: uuid.New(), FullName: "assembledhq/143", Status: "active",
-	}, "pull_request_review", body, "delivery-self")
-
-	require.NoError(t, err, "143-authored review webhook should be ignored without a feedback loop")
-	require.NoError(t, mock.ExpectationsWereMet(), "self-authored review should not query pull request state")
+	require.Len(t, jobs.reassessmentPayloads, 2, "both deliveries should reach the durable queue boundary")
+	require.Equal(t, jobs.reassessmentPayloads[0].ChangeKey, jobs.reassessmentPayloads[1].ChangeKey, "equivalent deliveries should share a semantic dedupe key")
+	require.NotContains(t, jobs.reassessmentPayloads[0].ChangeKey, "delivery-", "semantic dedupe key should not contain delivery identity")
+	require.NoError(t, mock.ExpectationsWereMet(), "equivalent deliveries should use org-scoped pull request lookups")
 }
 
 func TestCodeReviewEventChangesAssessment(t *testing.T) {
@@ -1007,9 +1210,10 @@ func (s *codeReviewWebhookSessionStore) UpdateFailure(context.Context, uuid.UUID
 }
 
 type codeReviewWebhookJobStore struct {
-	jobID               uuid.UUID
-	payload             codereviewsvc.RunCodeReviewJobPayload
-	reassessmentPayload codereviewsvc.ReviewChangedInput
+	jobID                uuid.UUID
+	payload              codereviewsvc.RunCodeReviewJobPayload
+	reassessmentPayload  codereviewsvc.ReviewChangedInput
+	reassessmentPayloads []codereviewsvc.ReviewChangedInput
 }
 
 func (s *codeReviewWebhookJobStore) EnqueueWithOpts(_ context.Context, _ uuid.UUID, opts db.EnqueueOpts) (uuid.UUID, error) {
@@ -1020,6 +1224,7 @@ func (s *codeReviewWebhookJobStore) EnqueueWithOpts(_ context.Context, _ uuid.UU
 	changed, ok := opts.Payload.(codereviewsvc.ReviewChangedInput)
 	if ok {
 		s.reassessmentPayload = changed
+		s.reassessmentPayloads = append(s.reassessmentPayloads, changed)
 	}
 	return s.jobID, nil
 }

--- a/internal/api/handlers/webhooks_test.go
+++ b/internal/api/handlers/webhooks_test.go
@@ -890,11 +890,22 @@ func TestCodeReviewMaterialChangeKey(t *testing.T) {
 	success := "success"
 	failure := "failure"
 	checkRunSuccess := codeReviewReassessmentWebhook{Action: "completed"}
+	checkRunSuccess.CheckRun.ID = 501
 	checkRunSuccess.CheckRun.Conclusion = &success
+	secondCheckRunSuccess := checkRunSuccess
+	secondCheckRunSuccess.CheckRun.ID = 502
 	checkSuiteSuccess := codeReviewReassessmentWebhook{Action: "completed"}
+	checkSuiteSuccess.CheckSuite.ID = 601
 	checkSuiteSuccess.CheckSuite.Conclusion = &success
 	checkRunFailure := codeReviewReassessmentWebhook{Action: "completed"}
+	checkRunFailure.CheckRun.ID = 501
 	checkRunFailure.CheckRun.Conclusion = &failure
+	statusSuccess := codeReviewReassessmentWebhook{State: "success", Context: "ci/unit-tests"}
+	secondStatusSuccess := codeReviewReassessmentWebhook{State: "success", Context: "ci/integration-tests"}
+	var firstResolvedThread codeReviewReassessmentWebhook
+	require.NoError(t, json.Unmarshal([]byte(`{"action":"resolved","thread":{"node_id":"PRRT_first"}}`), &firstResolvedThread), "first review thread webhook should decode")
+	var secondResolvedThread codeReviewReassessmentWebhook
+	require.NoError(t, json.Unmarshal([]byte(`{"action":"resolved","thread":{"node_id":"PRRT_second"}}`), &secondResolvedThread), "second review thread webhook should decode")
 	humanReview := codeReviewReassessmentWebhook{Action: "submitted"}
 	humanReview.Review.ID = 101
 	humanReview.Review.State = "commented"
@@ -911,6 +922,7 @@ func TestCodeReviewMaterialChangeKey(t *testing.T) {
 		left       codeReviewReassessmentWebhook
 		rightType  string
 		right      codeReviewReassessmentWebhook
+		leftCI     models.PullRequestCIStatus
 		rightCI    models.PullRequestCIStatus
 		expectSame bool
 	}{
@@ -919,6 +931,44 @@ func TestCodeReviewMaterialChangeKey(t *testing.T) {
 			leftType: "check_run", left: checkRunSuccess,
 			rightType: "check_suite", right: checkSuiteSuccess,
 			expectSame: true,
+		},
+		{
+			name:       "same check run redelivery while aggregate state is stale",
+			leftType:   "check_run",
+			left:       checkRunSuccess,
+			rightType:  "check_run",
+			right:      checkRunSuccess,
+			leftCI:     models.PullRequestCIStatusPending,
+			rightCI:    models.PullRequestCIStatusPending,
+			expectSame: true,
+		},
+		{
+			name:       "distinct check runs while aggregate state is stale",
+			leftType:   "check_run",
+			left:       checkRunSuccess,
+			rightType:  "check_run",
+			right:      secondCheckRunSuccess,
+			leftCI:     models.PullRequestCIStatusPending,
+			rightCI:    models.PullRequestCIStatusPending,
+			expectSame: false,
+		},
+		{
+			name:       "distinct status contexts while aggregate state is stale",
+			leftType:   "status",
+			left:       statusSuccess,
+			rightType:  "status",
+			right:      secondStatusSuccess,
+			leftCI:     models.PullRequestCIStatusPending,
+			rightCI:    models.PullRequestCIStatusPending,
+			expectSame: false,
+		},
+		{
+			name:       "distinct resolved review threads",
+			leftType:   "pull_request_review_thread",
+			left:       firstResolvedThread,
+			rightType:  "pull_request_review_thread",
+			right:      secondResolvedThread,
+			expectSame: false,
 		},
 		{
 			name:     "changed check result",
@@ -954,7 +1004,11 @@ func TestCodeReviewMaterialChangeKey(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			left, err := codeReviewMaterialChangeKey(tt.leftType, tt.left, pr)
+			leftPR := pr
+			if tt.leftCI != "" {
+				leftPR.CIStatus = tt.leftCI
+			}
+			left, err := codeReviewMaterialChangeKey(tt.leftType, tt.left, leftPR)
 			require.NoError(t, err, "left material state should serialize")
 			rightPR := pr
 			if tt.rightCI != "" {

--- a/internal/services/codereview/service.go
+++ b/internal/services/codereview/service.go
@@ -83,7 +83,8 @@ type ReviewRequestedInput struct {
 
 // ReviewChangedInput describes a new externally-observed state for a pull
 // request that has already been assigned to 143 Code Reviewer. ChangeKey must
-// be stable for a webhook delivery so redeliveries reuse the same assessment.
+// be stable for the material PR/review/check state so equivalent webhook
+// deliveries reuse the same assessment.
 type ReviewChangedInput struct {
 	OrgID             uuid.UUID `json:"org_id"`
 	RepositoryID      uuid.UUID `json:"repository_id"`


### PR DESCRIPTION
## Problem

Code-review reassessment was keyed by GitHub webhook delivery ID. GitHub assigns a new delivery ID to every delivery, so duplicate deliveries of the same logical event could enqueue new reviewer sessions.

The reviewer could also react to its own GitHub writes. In particular, GitHub emits an empty-body `pull_request_review` wrapper when an app creates a standalone inline comment, so the existing hidden-body marker check could not identify every 143-authored event. Together, these behaviors could make 143 Code Reviewer repeatedly reassess an unchanged PR.

## What changed

### Suppress 143-authored review events

Reassessment now treats both output markers and configured GitHub App identity as authoritative:

- Hidden 143 output markers still suppress marked review summaries and inline comments.
- `performed_via_github_app.id` is compared with the configured GitHub App ID.
- App slugs and bot logins are normalized so `143-code-reviewer` and `143-code-reviewer[bot]` match.
- Empty-body review containers emitted for standalone app comments are suppressed.
- Dismissed reviews and deleted inline comments are intentionally not suppressed because removing existing feedback is a material external change.

### Replace delivery IDs with material change keys

Each reassessment now hashes normalized PR and event state into a `material:<sha256>` key. GitHub delivery IDs are no longer part of the dedupe key.

| Event | Material identity |
| --- | --- |
| Pull request | Head/base SHA, title, body, PR/review/CI/merge state, conflicts, failing-test count, and draft/ready state |
| Review | PR state plus review ID, state, body, commit SHA, and author |
| Inline review comment | PR state plus comment ID, present/deleted state, body, path, line, commit SHA, and author |
| Review thread | PR state plus GitHub `thread.node_id` and resolved/unresolved action |
| Check suite | PR head SHA plus check-suite ID and normalized conclusion |
| Check run | PR head SHA plus check-run ID and normalized conclusion |
| Commit status | PR head SHA plus status ID (or context fallback) and normalized state |

Equivalent redeliveries therefore produce the same key, while distinct reviews, comments, threads, checks, and statuses remain independently reassessable.

### Keep CI keys stable across asynchronous health synchronization

Check-suite, check-run, and commit-status keys intentionally use stable GitHub event identity plus the PR head SHA instead of the mutable mirrored CI aggregate.

The webhook path enqueues full PR-health synchronization asynchronously. Keying directly from the mirrored CI status or failing-test count would create two failure modes:

- distinct failures could collapse while the mirror still contained the previous aggregate; or
- the same webhook could receive a different key after synchronization updated the mirror.

Identity-based check keys avoid both cases: redeliveries remain stable across aggregate refreshes, and distinct GitHub check/status objects remain distinct.

### Preserve the existing durable reassessment flow

The material key is passed through `ReviewChangedInput.ChangeKey` to the existing durable reassessment job. That key continues to drive both active-job deduplication and completed-assessment reuse, so equivalent webhook deliveries converge on one assessment without bypassing the existing queue/retry behavior.

## Testing

Added focused coverage for:

- marked review summaries authored by 143;
- empty-body review wrappers from the configured app bot;
- GitHub App ID/slug identity matching;
- unmarked inline comments authored by the app;
- equivalent deliveries with different GitHub delivery IDs;
- edited human review content;
- distinct review-thread `node_id` values;
- distinct check runs and commit statuses when the PR is already failing;
- stable check-event keys across asynchronous aggregate refreshes; and
- equivalent PR events that represent the same material state.

Verified with:

```text
go test ./internal/api/handlers ./internal/services/codereview
go vet ./internal/api/handlers ./internal/services/codereview
git diff --check
```
