### PR TITLE
Budget GitHub installation quota for code reviews

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -1320,6 +1320,9 @@ func buildServices(
 		logger.Error().Err(err).Msg("failed to initialize GitHub App service — all Phase 3+ services disabled")
 		return nil
 	}
+	githubRateBudget := ghservice.NewRateBudget(db.NewGitHubRateLimitStore(pool), logger)
+	githubRateBudget.SetSnapshotFetcher(ghSvc)
+	ghSvc.SetRateLimitBudget(githubRateBudget)
 
 	// Docker sandbox provider.
 	dockerCli, err := dockerclient.NewClientWithOpts(dockerclient.FromEnv, dockerclient.WithAPIVersionNegotiation())
@@ -1785,6 +1788,7 @@ func buildServices(
 		GitHub:              ghSvc,
 		CodeReviews:         codereviewsvc.NewGitHubSubmitter(ghSvc),
 		CodeReviewLifecycle: codeReviewLifecycle,
+		GitHubRateLimits:    githubRateBudget,
 		CodingAgents:        agentEnv,
 		GitHubOrgRoster:     ghSvc,
 		Snapshots:           snapshotStore,

--- a/docs/design/implemented/112-code-reviewer-bot-auto-approval.md
+++ b/docs/design/implemented/112-code-reviewer-bot-auto-approval.md
@@ -1,6 +1,6 @@
 # Design: Code Reviewer Bot And Acceptable-Risk Auto-Approval
 
-> **Status:** Implemented | **Last reviewed:** 2026-07-20
+> **Status:** Implemented | **Last reviewed:** 2026-07-21
 >
 > **Depends on:** [../overall.md](../overall.md), [78-review-agent-loops.md](78-review-agent-loops.md), [107-pr-readiness-checks.md](107-pr-readiness-checks.md), [61-pr-state-sync-and-repair-actions.md](61-pr-state-sync-and-repair-actions.md), [../backlog/11-review-feedback-loop.md](../backlog/11-review-feedback-loop.md)
 
@@ -24,6 +24,7 @@ Implemented:
 - event-driven reassessment after the initial reviewer request when the PR head/description, human reviews/comments/threads, or GitHub checks/statuses change, with durable follow-up jobs, self-authored webhook suppression, and a terminal stop once 143 approves
 - service-layer code review request orchestration that resolves/materializes policy, marks stale older heads, reuses running sessions, creates normal code-review sessions, and enqueues `run_code_review`
 - `run_code_review` worker handler that loads the captured policy version, fans out read-only reviewer threads running native `/review`, synthesizes via an orchestrator thread, records agent results, submits a GitHub review when the worker has GitHub credentials, and stores the GitHub review id/url
+- installation-wide GitHub quota observations and durable per-review reservations that defer queued reviews before they consume recovery capacity while allowing admitted reviews to finish
 - live reviewer/orchestrator evidence ingestion harvested from running review threads rather than pre-existing stored result rows
 - evidence-gated approval path that evaluates reviewer results, blocking findings, PR health, reviewed head SHA, required check state, changed-file size/path/category context from GitHub, and the captured policy before choosing approval vs comment-only
 - LLM-backed PR description requirement evaluation with prompt-injection screening
@@ -124,6 +125,16 @@ assessment and update the existing GitHub review summary. Approval is final.
 ```
 
 Reviewer assignment should be explicit in v1. Auto-running can come later after teams trust the signal.
+
+### GitHub Installation Quota Admission
+
+GitHub App primary limits are shared by every repository and 143 organization linked to one installation. They are therefore a global control-plane resource, not tenant-local state and not an optional Redis cache.
+
+Every installation-authenticated PR-sync, review-submission, repository-list, and team-search response records its `X-RateLimit-*` headers in `github_installation_rate_limits`. Updates are monotonic within one reset window (`remaining` can only decrease), while a newer reset window replaces the prior observation. `Retry-After`, 429 responses, and body-classified secondary-limit 403 responses record an installation-wide block across REST, GraphQL, and search; ordinary permission 403 responses and resource-local primary exhaustion do not. Observation persistence is best effort so a database write failure cannot turn a successful GitHub operation into an application failure.
+
+Before `run_code_review` marks queued metadata running or makes any GitHub request, it atomically obtains an installation/core reservation under a PostgreSQL advisory lock shared with quota observation. Admission includes reservations for queued/running reviews across every linked 143 organization and requires the projected balance to retain `max(500, 10% of limit)` for in-flight recovery. Each new review reserves 100 requests conservatively. The reservation is idempotent by code-review metadata ID, but a retry with an existing reservation still honors a newer installation-wide block. Terminal reservations are lazily released and excluded through a partial active index so admission cost scales with active reviews rather than installation history.
+
+Unknown, expired, or older-than-two-minutes observations allow one leased bootstrap refresh installation-wide. The lease owner calls GitHub's authenticated `/rate_limit` endpoint—which does not consume primary quota—persists the returned resource snapshot, and then repeats admission before metadata can become running. Additional queued reviews poll below the observation-staleness window, and the lease is independent of reservations from a prior reset window, so a long-running review cannot deadlock quota refresh after reset. Denied reviews stay visibly queued and retry at the reset with stable jitter. Already-running reviews do not pass through new-work admission, so the recovery reserve remains usable for reconciliation and GitHub review publication. Admission uses the repository installation ID that all later review calls consume; legacy repository-only IDs are materialized into the global installation table on migration and defensively on first use.
 
 ## Product Surfaces
 

--- a/docs/design/overall.md
+++ b/docs/design/overall.md
@@ -1,6 +1,6 @@
 # Design: 143.dev
 
-> **Status:** Partially Implemented | **Last reviewed:** 2026-06-30
+> **Status:** Partially Implemented | **Last reviewed:** 2026-07-21
 
 143.dev is shared coding-agent infrastructure for engineering teams. It turns production errors, issue-tracker work, PR feedback, automations, and human requests into repo-scoped coding sessions that run in isolated sandboxes, produce reviewable diffs, launch previews, and publish branches or pull requests through the team's normal GitHub workflow.
 
@@ -86,7 +86,7 @@ Vector -> VictoriaLogs / Grafana for centralized logs, dashboards, and alerts
 
 ### Integration Plane
 
-- GitHub is the repository, branch, PR, check, mergeability, review, and deploy-signal integration. Repository-native CI/CD is authoritative after 143 publishes a branch or PR. The Code reviews surface is the post-PR reviewer-bot view over code review sessions and versioned acceptable-risk policy; an explicit GitHub reviewer request starts monitoring, subsequent PR/review/check changes create durable reassessments and update the existing GitHub review summary, and a submitted 143 approval ends monitoring so automation cannot later undo it.
+- GitHub is the repository, branch, PR, check, mergeability, review, and deploy-signal integration. Repository-native CI/CD is authoritative after 143 publishes a branch or PR. The Code reviews surface is the post-PR reviewer-bot view over code review sessions and versioned acceptable-risk policy; an explicit GitHub reviewer request starts monitoring, subsequent PR/review/check changes create durable reassessments and update the existing GitHub review summary, and a submitted 143 approval ends monitoring so automation cannot later undo it. Installation-wide quota observations, shared secondary-limit blocks, pre-start stale-snapshot refresh leases, and durable active reservations defer queued reviews before they consume capacity reserved for in-flight review recovery; see [implemented/112-code-reviewer-bot-auto-approval.md](implemented/112-code-reviewer-bot-auto-approval.md).
 - Sentry is the primary production-error ingestion source and still anchors the canonical "error to PR" loop.
 - Linear integration supports issue linking, bidirectional session updates, agent-triggered work from assignments or mentions, and Linear issue create/update automation triggers with filters for teams, labels/tags, issue types, states, priorities, and title text. Linear-started sessions resolve the AgentSession creator through a persistent Linear-user-to-143-user bridge before PR authorship falls back to issue-creator email or the GitHub App. See [implemented/62-linear-session-linking.md](implemented/62-linear-session-linking.md), [implemented/69-linear-agent.md](implemented/69-linear-agent.md), and [implemented/112-linear-automation-event-triggers.md](implemented/112-linear-automation-event-triggers.md).
 - PagerDuty is a first-class incident source and automation trigger. Signed or shared-secret webhooks are persisted through the durable ingress ledger, normalized into issues and `pagerduty_incidents`, matched against generic automation event triggers, and exposed to sandbox agents through `143-tools pagerduty`. See [implemented/107-pagerduty-integration.md](implemented/107-pagerduty-integration.md).

--- a/internal/api/handlers/integrations.go
+++ b/internal/api/handlers/integrations.go
@@ -95,6 +95,14 @@ type githubAppService interface {
 	GetInstallationToken(ctx context.Context, installationID int64) (string, error)
 }
 
+type githubRateLimitObserver interface {
+	ObserveRateLimitForToken(ctx context.Context, token string, statusCode int, resource string, header http.Header)
+}
+
+type githubRateLimitBodyObserver interface {
+	ObserveRateLimitForTokenWithBody(ctx context.Context, token string, statusCode int, resource string, header http.Header, body []byte)
+}
+
 type githubOrgAutoJoinService interface {
 	GetInstallationDetails(ctx context.Context, installationID int64) (ghapp.InstallationDetails, error)
 	ListOrgMembers(ctx context.Context, installationID int64, orgLogin string) ([]ghapp.OrgMember, error)
@@ -1629,10 +1637,16 @@ func (h *IntegrationHandler) listInstallationRepos(ctx context.Context, token st
 		if err != nil {
 			return nil, err
 		}
+		h.observeGitHubRateLimit(ctx, token, resp.StatusCode, models.GitHubRateLimitResourceCore, resp.Header)
 
 		if resp.StatusCode != http.StatusOK {
+			body, readErr := io.ReadAll(io.LimitReader(resp.Body, 4096))
+			h.observeGitHubRateLimitBody(ctx, token, resp.StatusCode, models.GitHubRateLimitResourceCore, resp.Header, body)
 			if closeErr := resp.Body.Close(); closeErr != nil {
 				return nil, closeErr
+			}
+			if readErr != nil {
+				return nil, fmt.Errorf("read github API error response: %w", readErr)
 			}
 			return nil, fmt.Errorf("github API error %d", resp.StatusCode)
 		}
@@ -1653,6 +1667,22 @@ func (h *IntegrationHandler) listInstallationRepos(ctx context.Context, token st
 		repos = append(repos, result.Repositories...)
 	}
 	return repos, nil
+}
+
+func (h *IntegrationHandler) observeGitHubRateLimit(ctx context.Context, token string, statusCode int, resource models.GitHubRateLimitResource, header http.Header) {
+	observer, ok := h.githubService.(githubRateLimitObserver)
+	if !ok {
+		return
+	}
+	observer.ObserveRateLimitForToken(ctx, token, statusCode, string(resource), header)
+}
+
+func (h *IntegrationHandler) observeGitHubRateLimitBody(ctx context.Context, token string, statusCode int, resource models.GitHubRateLimitResource, header http.Header, body []byte) {
+	observer, ok := h.githubService.(githubRateLimitBodyObserver)
+	if !ok {
+		return
+	}
+	observer.ObserveRateLimitForTokenWithBody(ctx, token, statusCode, string(resource), header, body)
 }
 
 func githubNextLink(linkHeader string) string {

--- a/internal/api/handlers/integrations_test.go
+++ b/internal/api/handlers/integrations_test.go
@@ -35,8 +35,9 @@ func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
 }
 
 type fakeGitHubAppService struct {
-	token string
-	err   error
+	token        string
+	err          error
+	observations []githubRateLimitTestObservation
 }
 
 func (f *fakeGitHubAppService) GetInstallationToken(context.Context, int64) (string, error) {
@@ -44,6 +45,17 @@ func (f *fakeGitHubAppService) GetInstallationToken(context.Context, int64) (str
 		return "", f.err
 	}
 	return f.token, nil
+}
+
+type githubRateLimitTestObservation struct {
+	token      string
+	statusCode int
+	resource   string
+	header     http.Header
+}
+
+func (f *fakeGitHubAppService) ObserveRateLimitForToken(_ context.Context, token string, statusCode int, resource string, header http.Header) {
+	f.observations = append(f.observations, githubRateLimitTestObservation{token: token, statusCode: statusCode, resource: resource, header: header.Clone()})
 }
 
 type fakeGitHubAppUserAuth struct {
@@ -2646,6 +2658,8 @@ func TestIntegrationHandler_ListInstallationRepos_FollowsPagination(t *testing.T
 	t.Parallel()
 
 	handler := NewIntegrationHandler(nil, nil, "", "", "http://localhost:8080", "http://localhost:3000")
+	githubService := &fakeGitHubAppService{}
+	handler.githubService = githubService
 	requested := make([]string, 0, 2)
 	handler.client = &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
 		requested = append(requested, req.URL.String())
@@ -2655,7 +2669,8 @@ func TestIntegrationHandler_ListInstallationRepos_FollowsPagination(t *testing.T
 			return &http.Response{
 				StatusCode: http.StatusOK,
 				Header: http.Header{
-					"Link": []string{`<` + githubAPIURL + `/installation/repositories?per_page=100&page=2>; rel="next"`},
+					"Link":                  []string{`<` + githubAPIURL + `/installation/repositories?per_page=100&page=2>; rel="next"`},
+					"X-RateLimit-Remaining": []string{"4999"},
 				},
 				Body: io.NopCloser(strings.NewReader(`{"repositories":[{"id":1,"full_name":"org/one"}]}`)),
 			}, nil
@@ -2680,6 +2695,13 @@ func TestIntegrationHandler_ListInstallationRepos_FollowsPagination(t *testing.T
 		{ID: 2, FullName: "org/two"},
 	}, repos, "listInstallationRepos should concatenate paginated repositories")
 	require.Len(t, requested, 2, "listInstallationRepos should request exactly two pages")
+	require.Equal(t, []githubRateLimitTestObservation{
+		{token: "installation-token", statusCode: http.StatusOK, resource: string(models.GitHubRateLimitResourceCore), header: http.Header{
+			"Link":                  []string{`<` + githubAPIURL + `/installation/repositories?per_page=100&page=2>; rel="next"`},
+			"X-RateLimit-Remaining": []string{"4999"},
+		}},
+		{token: "installation-token", statusCode: http.StatusOK, resource: string(models.GitHubRateLimitResourceCore), header: http.Header{}},
+	}, githubService.observations, "every installation-token response should update the shared rate-limit observer")
 }
 
 func TestIntegrationHandler_HandleGitHubOAuthCallback_SavesCredentialAndIntegration(t *testing.T) {

--- a/internal/api/handlers/team.go
+++ b/internal/api/handlers/team.go
@@ -86,6 +86,10 @@ type teamGitHubService interface {
 	GetInstallationToken(ctx context.Context, installationID int64) (string, error)
 }
 
+type teamGitHubRateLimitObserver interface {
+	ObserveRateLimitForToken(ctx context.Context, token string, statusCode int, resource string, header http.Header)
+}
+
 // teamRepositoryStore supplies repo-scoped fallbacks for GitHub App metadata.
 // Some orgs predate integration.config.installation_id but already have active
 // repo rows populated from a prior install sync; those repos still carry the
@@ -861,9 +865,15 @@ func (h *TeamHandler) searchGitHubUsers(ctx context.Context, token, query string
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if observer, ok := h.githubSvc.(teamGitHubRateLimitObserver); ok {
+		observer.ObserveRateLimitForToken(ctx, token, resp.StatusCode, string(models.GitHubRateLimitResourceSearch), resp.Header)
+	}
 
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
+		if observer, ok := h.githubSvc.(githubRateLimitBodyObserver); ok {
+			observer.ObserveRateLimitForTokenWithBody(ctx, token, resp.StatusCode, string(models.GitHubRateLimitResourceSearch), resp.Header, body)
+		}
 		return nil, fmt.Errorf("github search returned %d: %s", resp.StatusCode, body)
 	}
 

--- a/internal/api/handlers/team_test.go
+++ b/internal/api/handlers/team_test.go
@@ -5,8 +5,10 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -129,6 +131,7 @@ func (m *mockTeamIntegrationStore) ListByOrgAndProvider(ctx context.Context, org
 
 type mockTeamGitHubService struct {
 	getInstallationTokenFn func(ctx context.Context, installationID int64) (string, error)
+	observations           []githubRateLimitTestObservation
 }
 
 func (m *mockTeamGitHubService) GetInstallationToken(ctx context.Context, installationID int64) (string, error) {
@@ -136,6 +139,36 @@ func (m *mockTeamGitHubService) GetInstallationToken(ctx context.Context, instal
 		return m.getInstallationTokenFn(ctx, installationID)
 	}
 	return "token", nil
+}
+
+func (m *mockTeamGitHubService) ObserveRateLimitForToken(_ context.Context, token string, statusCode int, resource string, header http.Header) {
+	m.observations = append(m.observations, githubRateLimitTestObservation{token: token, statusCode: statusCode, resource: resource, header: header.Clone()})
+}
+
+func TestTeamHandlerSearchGitHubUsersObservesSearchQuota(t *testing.T) {
+	t.Parallel()
+
+	githubService := &mockTeamGitHubService{}
+	handler := &TeamHandler{
+		githubSvc: githubService,
+		httpClient: &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			require.Equal(t, "token installation-token", req.Header.Get("Authorization"), "search should use the installation token")
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     http.Header{"X-RateLimit-Remaining": []string{"29"}},
+				Body:       io.NopCloser(strings.NewReader(`{"items":[{"login":"octocat","type":"User"}]}`)),
+			}, nil
+		})},
+	}
+
+	users, err := handler.searchGitHubUsers(context.Background(), "installation-token", "octo")
+
+	require.NoError(t, err, "GitHub user search should decode a successful response")
+	require.Equal(t, []GitHubUserSuggestion{{Login: "octocat"}}, users, "GitHub user search should return matching users")
+	require.Equal(t, []githubRateLimitTestObservation{{
+		token: "installation-token", statusCode: http.StatusOK, resource: string(models.GitHubRateLimitResourceSearch),
+		header: http.Header{"X-RateLimit-Remaining": []string{"29"}},
+	}}, githubService.observations, "search responses should update the installation-wide search quota")
 }
 
 func (m *mockTeamInvitationStore) Create(ctx context.Context, inv *models.Invitation) error {

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -178,6 +178,7 @@ func NewRouter(cfg *config.Config, pool *pgxpool.Pool, logger zerolog.Logger, se
 
 	// Create services
 	ingestionSvc := ingestion.NewService(issueStore, webhookDeliveryStore, jobStore, logger)
+	githubRateBudget := ghservice.NewRateBudget(db.NewGitHubRateLimitStore(pool), logger)
 
 	// Create PRService if GitHub App credentials are configured.
 	var prService *ghservice.PRService
@@ -187,6 +188,7 @@ func NewRouter(cfg *config.Config, pool *pgxpool.Pool, logger zerolog.Logger, se
 		if err != nil {
 			logger.Warn().Err(err).Msg("failed to initialize GitHub App service, PR webhooks will be disabled")
 		} else {
+			ghSvc.SetRateLimitBudget(githubRateBudget)
 			prService = ghservice.NewPRService(
 				ghSvc, pullRequestStore, sessionStore, issueStore,
 				deployStore, repoStore, jobStore, logger,
@@ -258,6 +260,7 @@ func NewRouter(cfg *config.Config, pool *pgxpool.Pool, logger zerolog.Logger, se
 	if cfg.GitHubAppID != 0 && cfg.GitHubAppPrivateKey != "" {
 		ghSvc, err := ghservice.NewService(cfg.GitHubAppID, cfg.GitHubAppPrivateKey)
 		if err == nil {
+			ghSvc.SetRateLimitBudget(githubRateBudget)
 			integrationOpts = append(integrationOpts, handlers.WithGitHubApp(ghSvc, repoStore))
 			authHandler.SetGitHubOrgAutoJoinDeps(githubInstallationStore, ghSvc)
 		}
@@ -645,6 +648,7 @@ func NewRouter(cfg *config.Config, pool *pgxpool.Pool, logger zerolog.Logger, se
 	if cfg.GitHubAppID != 0 && cfg.GitHubAppPrivateKey != "" {
 		ghSvc, err := ghservice.NewService(cfg.GitHubAppID, cfg.GitHubAppPrivateKey)
 		if err == nil {
+			ghSvc.SetRateLimitBudget(githubRateBudget)
 			teamHandler.SetGitHubIntegration(integrationStore, ghSvc)
 		}
 	}

--- a/internal/db/github_rate_limits.go
+++ b/internal/db/github_rate_limits.go
@@ -275,6 +275,37 @@ func (s *GitHubRateLimitStore) ReserveCodeReview(ctx context.Context, orgID uuid
 	return decision, nil
 }
 
+// CheckCodeReviewBlock checks only installation-wide secondary-limit state.
+// Admitted reviews use this on retries so they can consume recovery capacity
+// without making requests while GitHub has told the installation to stop.
+// lint:allow-no-orgid reason="GitHub API blocks are global per App installation, not per linked 143 organization"
+func (s *GitHubRateLimitStore) CheckCodeReviewBlock(ctx context.Context, installationID int64, now time.Time) (models.GitHubRateLimitDecision, error) {
+	if installationID <= 0 {
+		return models.GitHubRateLimitDecision{}, fmt.Errorf("GitHub installation ID must be positive")
+	}
+	if now.IsZero() {
+		now = time.Now().UTC()
+	}
+
+	var blockedUntil sql.NullTime
+	if err := s.db.QueryRow(ctx, `
+		SELECT MAX(blocked_until)
+		FROM github_installation_rate_limits
+		WHERE installation_id = @installation_id`, pgx.NamedArgs{
+		"installation_id": installationID,
+	}).Scan(&blockedUntil); err != nil {
+		return models.GitHubRateLimitDecision{}, fmt.Errorf("check GitHub installation rate-limit block: %w", err)
+	}
+
+	decision := models.GitHubRateLimitDecision{Allowed: true}
+	if blockedUntil.Valid && blockedUntil.Time.After(now) {
+		decision.Allowed = false
+		decision.BlockedUntil = blockedUntil.Time
+		decision.RetryAfter = blockedUntil.Time.Sub(now)
+	}
+	return decision, nil
+}
+
 func loadGitHubRateLimitState(ctx context.Context, tx pgx.Tx, installationID int64) (githubRateLimitState, error) {
 	rows, err := tx.Query(ctx, `
 		SELECT resource, limit_count, remaining_count, reset_at, blocked_until,

--- a/internal/db/github_rate_limits.go
+++ b/internal/db/github_rate_limits.go
@@ -1,0 +1,403 @@
+package db
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/assembledhq/143/internal/models"
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+)
+
+const (
+	codeReviewGitHubRateReservation = 100
+	githubRateRecoveryPercent       = 10
+	githubRateMinimumRecovery       = 500
+	githubRateBootstrapRetry        = 15 * time.Second
+	githubRateBootstrapLease        = 2 * time.Minute
+	githubRateObservationMaxAge     = 2 * time.Minute
+)
+
+type GitHubRateLimitStore struct {
+	db DBTX
+}
+
+func NewGitHubRateLimitStore(db DBTX) *GitHubRateLimitStore {
+	return &GitHubRateLimitStore{db: db}
+}
+
+// Observe records a quota shared by every 143 org linked to the installation.
+// lint:allow-no-orgid reason="GitHub API quotas are global per App installation, not per linked 143 organization"
+func (s *GitHubRateLimitStore) Observe(ctx context.Context, observation models.GitHubRateLimitObservation) error {
+	if observation.InstallationID <= 0 {
+		return fmt.Errorf("GitHub installation ID must be positive")
+	}
+	if err := observation.Resource.Validate(); err != nil {
+		return err
+	}
+	if observation.ObservedAt.IsZero() {
+		observation.ObservedAt = time.Now().UTC()
+	}
+	if err := validateGitHubRateLimitObservation(observation); err != nil {
+		return err
+	}
+	txStarter, ok := s.db.(TxStarter)
+	if !ok {
+		return fmt.Errorf("GitHub rate-limit observation requires transaction support")
+	}
+	tx, err := txStarter.Begin(ctx)
+	if err != nil {
+		return fmt.Errorf("begin GitHub rate-limit observation: %w", err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+	if _, err := tx.Exec(ctx, `SELECT pg_advisory_xact_lock(hashtextextended($1, 0))`, githubRateLimitLockKey(observation.InstallationID)); err != nil {
+		return fmt.Errorf("lock GitHub installation rate limit: %w", err)
+	}
+	if err := ensureGitHubInstallationForRateLimit(ctx, tx, observation.InstallationID); err != nil {
+		return err
+	}
+	_, err = tx.Exec(ctx, `
+		INSERT INTO github_installation_rate_limits (
+			installation_id, resource, limit_count, remaining_count, reset_at, blocked_until, observed_at
+		) VALUES (
+			@installation_id, @resource, @limit_count, @remaining_count, @reset_at, @blocked_until, @observed_at
+		)
+		ON CONFLICT (installation_id, resource) DO UPDATE
+		SET limit_count = CASE
+				WHEN EXCLUDED.reset_at IS NULL THEN github_installation_rate_limits.limit_count
+				WHEN github_installation_rate_limits.reset_at IS NULL OR EXCLUDED.reset_at > github_installation_rate_limits.reset_at THEN EXCLUDED.limit_count
+				WHEN EXCLUDED.reset_at = github_installation_rate_limits.reset_at THEN GREATEST(github_installation_rate_limits.limit_count, EXCLUDED.limit_count)
+				ELSE github_installation_rate_limits.limit_count
+			END,
+			remaining_count = CASE
+				WHEN EXCLUDED.reset_at IS NULL THEN github_installation_rate_limits.remaining_count
+				WHEN github_installation_rate_limits.reset_at IS NULL OR EXCLUDED.reset_at > github_installation_rate_limits.reset_at THEN EXCLUDED.remaining_count
+				WHEN EXCLUDED.reset_at = github_installation_rate_limits.reset_at THEN LEAST(github_installation_rate_limits.remaining_count, EXCLUDED.remaining_count)
+				ELSE github_installation_rate_limits.remaining_count
+			END,
+			reset_at = CASE
+				WHEN EXCLUDED.reset_at IS NULL THEN github_installation_rate_limits.reset_at
+				WHEN github_installation_rate_limits.reset_at IS NULL OR EXCLUDED.reset_at > github_installation_rate_limits.reset_at THEN EXCLUDED.reset_at
+				ELSE github_installation_rate_limits.reset_at
+			END,
+			blocked_until = CASE
+				WHEN EXCLUDED.blocked_until IS NULL THEN github_installation_rate_limits.blocked_until
+				WHEN github_installation_rate_limits.blocked_until IS NULL THEN EXCLUDED.blocked_until
+				ELSE GREATEST(github_installation_rate_limits.blocked_until, EXCLUDED.blocked_until)
+			END,
+			observed_at = CASE
+				WHEN EXCLUDED.reset_at IS NULL THEN github_installation_rate_limits.observed_at
+				WHEN github_installation_rate_limits.reset_at IS NULL OR EXCLUDED.reset_at >= github_installation_rate_limits.reset_at THEN GREATEST(github_installation_rate_limits.observed_at, EXCLUDED.observed_at)
+				ELSE github_installation_rate_limits.observed_at
+			END,
+			bootstrap_metadata_id = CASE
+				WHEN EXCLUDED.reset_at IS NOT NULL
+				 AND (github_installation_rate_limits.reset_at IS NULL OR EXCLUDED.reset_at >= github_installation_rate_limits.reset_at) THEN NULL
+				ELSE github_installation_rate_limits.bootstrap_metadata_id
+			END,
+			bootstrap_reserved_at = CASE
+				WHEN EXCLUDED.reset_at IS NOT NULL
+				 AND (github_installation_rate_limits.reset_at IS NULL OR EXCLUDED.reset_at >= github_installation_rate_limits.reset_at) THEN NULL
+				ELSE github_installation_rate_limits.bootstrap_reserved_at
+			END`, pgx.NamedArgs{
+		"installation_id": observation.InstallationID,
+		"resource":        observation.Resource,
+		"limit_count":     observation.Limit,
+		"remaining_count": observation.Remaining,
+		"reset_at":        observation.ResetAt,
+		"blocked_until":   observation.BlockedUntil,
+		"observed_at":     observation.ObservedAt,
+	})
+	if err != nil {
+		return fmt.Errorf("observe GitHub installation rate limit: %w", err)
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return fmt.Errorf("commit GitHub rate-limit observation: %w", err)
+	}
+	return nil
+}
+
+func validateGitHubRateLimitObservation(observation models.GitHubRateLimitObservation) error {
+	quotaFields := 0
+	if observation.Limit != nil {
+		quotaFields++
+	}
+	if observation.Remaining != nil {
+		quotaFields++
+	}
+	if observation.ResetAt != nil {
+		quotaFields++
+	}
+	if quotaFields != 0 && quotaFields != 3 {
+		return fmt.Errorf("GitHub rate-limit quota requires limit, remaining, and reset together")
+	}
+	if quotaFields == 3 && (*observation.Limit <= 0 || *observation.Remaining < 0 || *observation.Remaining > *observation.Limit) {
+		return fmt.Errorf("invalid GitHub rate-limit counts: remaining=%d limit=%d", *observation.Remaining, *observation.Limit)
+	}
+	if quotaFields == 0 && observation.BlockedUntil == nil {
+		return fmt.Errorf("GitHub rate-limit observation has no quota or block window")
+	}
+	return nil
+}
+
+type githubRateLimitState struct {
+	Limit        *int
+	Remaining    *int
+	ResetAt      *time.Time
+	BlockedUntil *time.Time
+	ObservedAt   *time.Time
+	BootstrapAt  *time.Time
+}
+
+// ReserveCodeReview serializes installation-wide admission and creates an
+// idempotent reservation for a queued review. Existing reservations retain
+// their units but must still honor a newly observed installation-wide block.
+func (s *GitHubRateLimitStore) ReserveCodeReview(ctx context.Context, orgID uuid.UUID, installationID int64, metadataID uuid.UUID, now time.Time) (models.GitHubRateLimitDecision, error) {
+	if orgID == uuid.Nil || installationID <= 0 || metadataID == uuid.Nil {
+		return models.GitHubRateLimitDecision{}, fmt.Errorf("org ID, installation ID, and code review metadata ID are required")
+	}
+	txStarter, ok := s.db.(TxStarter)
+	if !ok {
+		return models.GitHubRateLimitDecision{}, fmt.Errorf("GitHub rate-limit admission requires transaction support")
+	}
+	if now.IsZero() {
+		now = time.Now().UTC()
+	}
+	tx, err := txStarter.Begin(ctx)
+	if err != nil {
+		return models.GitHubRateLimitDecision{}, fmt.Errorf("begin GitHub rate-limit admission: %w", err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	if _, err := tx.Exec(ctx, `SELECT pg_advisory_xact_lock(hashtextextended($1, 0))`, githubRateLimitLockKey(installationID)); err != nil {
+		return models.GitHubRateLimitDecision{}, fmt.Errorf("lock GitHub installation rate limit: %w", err)
+	}
+	if err := ensureGitHubInstallationForRateLimit(ctx, tx, installationID); err != nil {
+		return models.GitHubRateLimitDecision{}, err
+	}
+
+	if _, err := tx.Exec(ctx, `
+		UPDATE github_installation_rate_reservations reservation
+		SET released_at = @released_at
+		FROM code_review_session_metadata metadata
+		WHERE reservation.installation_id = @installation_id
+		  AND reservation.released_at IS NULL
+		  AND metadata.org_id = reservation.org_id
+		  AND metadata.id = reservation.code_review_metadata_id
+		  AND metadata.status IN ('completed', 'failed', 'stale', 'cancelled')`, pgx.NamedArgs{
+		"installation_id": installationID,
+		"released_at":     now,
+	}); err != nil {
+		return models.GitHubRateLimitDecision{}, fmt.Errorf("release terminal GitHub rate-limit reservations: %w", err)
+	}
+
+	var existingUnits int
+	err = tx.QueryRow(ctx, `
+		SELECT reserved_units
+		FROM github_installation_rate_reservations
+		WHERE org_id = @org_id
+		  AND installation_id = @installation_id
+		  AND code_review_metadata_id = @metadata_id
+		  AND resource = @resource
+		  AND released_at IS NULL`, pgx.NamedArgs{
+		"org_id":          orgID,
+		"installation_id": installationID,
+		"metadata_id":     metadataID,
+		"resource":        models.GitHubRateLimitResourceCore,
+	}).Scan(&existingUnits)
+	existingReservation := err == nil
+	if !errors.Is(err, pgx.ErrNoRows) {
+		if !existingReservation {
+			return models.GitHubRateLimitDecision{}, fmt.Errorf("query existing GitHub rate-limit reservation: %w", err)
+		}
+	}
+
+	var activeReserved int
+	if err := tx.QueryRow(ctx, `
+		SELECT COALESCE(SUM(reserved_units), 0)
+		FROM github_installation_rate_reservations
+		WHERE installation_id = @installation_id
+		  AND resource = @resource
+		  AND released_at IS NULL`, pgx.NamedArgs{
+		"installation_id": installationID,
+		"resource":        models.GitHubRateLimitResourceCore,
+	}).Scan(&activeReserved); err != nil {
+		return models.GitHubRateLimitDecision{}, fmt.Errorf("sum active GitHub rate-limit reservations: %w", err)
+	}
+
+	state, err := loadGitHubRateLimitState(ctx, tx, installationID)
+	if err != nil {
+		return models.GitHubRateLimitDecision{}, err
+	}
+
+	decision := decideGitHubCodeReviewAdmission(state, activeReserved, existingReservation, metadataID, now)
+	if decision.RefreshRequired {
+		if _, err := tx.Exec(ctx, `
+			INSERT INTO github_installation_rate_limits (
+				installation_id, resource, observed_at, bootstrap_metadata_id, bootstrap_reserved_at
+			) VALUES (
+				@installation_id, @resource, @observed_at, @metadata_id, @bootstrap_reserved_at
+			)
+			ON CONFLICT (installation_id, resource) DO UPDATE
+			SET bootstrap_metadata_id = EXCLUDED.bootstrap_metadata_id,
+				bootstrap_reserved_at = EXCLUDED.bootstrap_reserved_at`, pgx.NamedArgs{
+			"installation_id":       installationID,
+			"resource":              models.GitHubRateLimitResourceCore,
+			"observed_at":           now,
+			"metadata_id":           metadataID,
+			"bootstrap_reserved_at": now,
+		}); err != nil {
+			return models.GitHubRateLimitDecision{}, fmt.Errorf("claim GitHub rate-limit bootstrap lease: %w", err)
+		}
+	}
+	if decision.Allowed && !existingReservation {
+		if _, err := tx.Exec(ctx, `
+			INSERT INTO github_installation_rate_reservations (
+				org_id, installation_id, code_review_metadata_id, resource, reserved_units
+			) VALUES (
+				@org_id, @installation_id, @metadata_id, @resource, @reserved_units
+			)`, pgx.NamedArgs{
+			"org_id":          orgID,
+			"installation_id": installationID,
+			"metadata_id":     metadataID,
+			"resource":        models.GitHubRateLimitResourceCore,
+			"reserved_units":  codeReviewGitHubRateReservation,
+		}); err != nil {
+			return models.GitHubRateLimitDecision{}, fmt.Errorf("insert GitHub rate-limit reservation: %w", err)
+		}
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return models.GitHubRateLimitDecision{}, fmt.Errorf("commit GitHub rate-limit admission: %w", err)
+	}
+	return decision, nil
+}
+
+func loadGitHubRateLimitState(ctx context.Context, tx pgx.Tx, installationID int64) (githubRateLimitState, error) {
+	rows, err := tx.Query(ctx, `
+		SELECT resource, limit_count, remaining_count, reset_at, blocked_until,
+		       observed_at, bootstrap_reserved_at
+		FROM github_installation_rate_limits
+		WHERE installation_id = @installation_id
+		FOR UPDATE`, pgx.NamedArgs{"installation_id": installationID})
+	if err != nil {
+		return githubRateLimitState{}, fmt.Errorf("load GitHub installation rate limits: %w", err)
+	}
+	defer rows.Close()
+	state := githubRateLimitState{}
+	for rows.Next() {
+		var resource models.GitHubRateLimitResource
+		var limitCount, remainingCount sql.NullInt64
+		var resetAt, blockedUntil, observedAt, bootstrapAt sql.NullTime
+		if err := rows.Scan(&resource, &limitCount, &remainingCount, &resetAt, &blockedUntil, &observedAt, &bootstrapAt); err != nil {
+			return githubRateLimitState{}, fmt.Errorf("scan GitHub installation rate limit: %w", err)
+		}
+		if blockedUntil.Valid && (state.BlockedUntil == nil || blockedUntil.Time.After(*state.BlockedUntil)) {
+			value := blockedUntil.Time
+			state.BlockedUntil = &value
+		}
+		if resource != models.GitHubRateLimitResourceCore {
+			continue
+		}
+		if limitCount.Valid {
+			value := int(limitCount.Int64)
+			state.Limit = &value
+		}
+		if remainingCount.Valid {
+			value := int(remainingCount.Int64)
+			state.Remaining = &value
+		}
+		if resetAt.Valid {
+			value := resetAt.Time
+			state.ResetAt = &value
+		}
+		if observedAt.Valid {
+			value := observedAt.Time
+			state.ObservedAt = &value
+		}
+		if bootstrapAt.Valid {
+			value := bootstrapAt.Time
+			state.BootstrapAt = &value
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return githubRateLimitState{}, fmt.Errorf("iterate GitHub installation rate limits: %w", err)
+	}
+	return state, nil
+}
+
+func decideGitHubCodeReviewAdmission(state githubRateLimitState, activeReserved int, existingReservation bool, metadataID uuid.UUID, now time.Time) models.GitHubRateLimitDecision {
+	decision := models.GitHubRateLimitDecision{ActiveReserved: activeReserved, ExistingReservation: existingReservation, MetadataID: metadataID}
+	if state.BlockedUntil != nil && state.BlockedUntil.After(now) {
+		decision.BlockedUntil = *state.BlockedUntil
+		decision.RetryAfter = state.BlockedUntil.Sub(now)
+		if state.Limit != nil && state.Remaining != nil && state.ResetAt != nil && state.ResetAt.After(now) {
+			decision.Known = true
+			decision.Limit = *state.Limit
+			decision.Remaining = *state.Remaining
+			decision.ResetAt = *state.ResetAt
+			decision.RecoveryReserve = githubRateRecoveryReserve(*state.Limit)
+		}
+		return decision
+	}
+	quotaFresh := state.Limit != nil && state.Remaining != nil && state.ResetAt != nil && state.ResetAt.After(now) &&
+		state.ObservedAt != nil && state.ObservedAt.After(now.Add(-githubRateObservationMaxAge))
+	if existingReservation {
+		decision.Allowed = true
+		if quotaFresh {
+			populateKnownGitHubRateLimitDecision(&decision, state)
+		}
+		return decision
+	}
+	if !quotaFresh {
+		decision.Bootstrap = true
+		decision.RefreshRequired = state.BootstrapAt == nil || !state.BootstrapAt.Add(githubRateBootstrapLease).After(now)
+		if !decision.RefreshRequired {
+			leaseRemaining := state.BootstrapAt.Add(githubRateBootstrapLease).Sub(now)
+			decision.RetryAfter = min(leaseRemaining, githubRateBootstrapRetry)
+		}
+		return decision
+	}
+
+	populateKnownGitHubRateLimitDecision(&decision, state)
+	decision.Allowed = decision.Remaining-activeReserved-codeReviewGitHubRateReservation >= decision.RecoveryReserve
+	if !decision.Allowed {
+		decision.RetryAfter = decision.ResetAt.Sub(now)
+	}
+	return decision
+}
+
+func populateKnownGitHubRateLimitDecision(decision *models.GitHubRateLimitDecision, state githubRateLimitState) {
+	decision.Known = true
+	decision.Limit = *state.Limit
+	decision.Remaining = *state.Remaining
+	decision.ResetAt = *state.ResetAt
+	decision.RecoveryReserve = githubRateRecoveryReserve(*state.Limit)
+}
+
+func githubRateLimitLockKey(installationID int64) string {
+	return fmt.Sprintf("github_rate_limit:%d", installationID)
+}
+
+func ensureGitHubInstallationForRateLimit(ctx context.Context, tx pgx.Tx, installationID int64) error {
+	if _, err := tx.Exec(ctx, `
+		INSERT INTO github_installations (installation_id, account_id, account_login, status)
+		VALUES (@installation_id, 0, @account_login, 'active')
+		ON CONFLICT (installation_id) DO NOTHING`, pgx.NamedArgs{
+		"installation_id": installationID,
+		"account_login":   fmt.Sprintf("installation-%d", installationID),
+	}); err != nil {
+		return fmt.Errorf("ensure GitHub installation for rate limiting: %w", err)
+	}
+	return nil
+}
+
+func githubRateRecoveryReserve(limit int) int {
+	reserve := (limit*githubRateRecoveryPercent + 99) / 100
+	if reserve < githubRateMinimumRecovery {
+		return githubRateMinimumRecovery
+	}
+	return reserve
+}

--- a/internal/db/github_rate_limits_test.go
+++ b/internal/db/github_rate_limits_test.go
@@ -164,6 +164,61 @@ func TestDecideGitHubCodeReviewAdmission(t *testing.T) {
 	}
 }
 
+func TestGitHubRateLimitStoreCheckCodeReviewBlock(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 7, 21, 18, 0, 0, 0, time.UTC)
+	activeBlock := now.Add(90 * time.Second)
+	expiredBlock := now.Add(-time.Second)
+	tests := []struct {
+		name         string
+		blockedUntil *time.Time
+		expected     models.GitHubRateLimitDecision
+	}{
+		{
+			name:         "active installation block defers running review",
+			blockedUntil: &activeBlock,
+			expected: models.GitHubRateLimitDecision{
+				BlockedUntil: activeBlock,
+				RetryAfter:   90 * time.Second,
+			},
+		},
+		{
+			name:         "expired installation block allows running review",
+			blockedUntil: &expiredBlock,
+			expected:     models.GitHubRateLimitDecision{Allowed: true},
+		},
+		{
+			name:     "unknown installation block allows running review",
+			expected: models.GitHubRateLimitDecision{Allowed: true},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			mock, err := pgxmock.NewPool()
+			require.NoError(t, err, "pgxmock should initialize")
+			defer mock.Close()
+
+			var blockedValue any
+			if tt.blockedUntil != nil {
+				blockedValue = *tt.blockedUntil
+			}
+			mock.ExpectQuery("SELECT MAX\\(blocked_until\\)").
+				WithArgs(pgx.NamedArgs{"installation_id": int64(143)}).
+				WillReturnRows(pgxmock.NewRows([]string{"blocked_until"}).AddRow(blockedValue))
+
+			actual, err := NewGitHubRateLimitStore(mock).CheckCodeReviewBlock(context.Background(), 143, now)
+
+			require.NoError(t, err, "installation block check should query durable shared state")
+			require.Equal(t, tt.expected, actual, "running review should only defer for an active installation-wide block")
+			require.NoError(t, mock.ExpectationsWereMet(), "block check should aggregate all installation resources")
+		})
+	}
+}
+
 func TestGitHubRateLimitStoreReserveCodeReviewCreatesAtomicReservation(t *testing.T) {
 	t.Parallel()
 

--- a/internal/db/github_rate_limits_test.go
+++ b/internal/db/github_rate_limits_test.go
@@ -1,0 +1,257 @@
+package db
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/assembledhq/143/internal/models"
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/pashagolub/pgxmock/v4"
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateGitHubRateLimitObservation(t *testing.T) {
+	t.Parallel()
+
+	limit := 5000
+	remaining := 4500
+	reset := time.Now().UTC().Add(time.Hour)
+	blocked := time.Now().UTC().Add(time.Minute)
+	tests := []struct {
+		name        string
+		observation models.GitHubRateLimitObservation
+		expectErr   bool
+	}{
+		{name: "complete quota", observation: models.GitHubRateLimitObservation{Limit: &limit, Remaining: &remaining, ResetAt: &reset}},
+		{name: "secondary block only", observation: models.GitHubRateLimitObservation{BlockedUntil: &blocked}},
+		{name: "missing remaining", observation: models.GitHubRateLimitObservation{Limit: &limit, ResetAt: &reset}, expectErr: true},
+		{name: "remaining exceeds limit", observation: models.GitHubRateLimitObservation{Limit: &remaining, Remaining: &limit, ResetAt: &reset}, expectErr: true},
+		{name: "empty observation", observation: models.GitHubRateLimitObservation{}, expectErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			err := validateGitHubRateLimitObservation(tt.observation)
+			if tt.expectErr {
+				require.Error(t, err, "invalid quota observations should be rejected before persistence")
+				return
+			}
+			require.NoError(t, err, "complete quota or secondary block observations should validate")
+		})
+	}
+}
+
+func TestGitHubRateLimitStoreObserveUsesMonotonicUpsert(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "pgxmock should initialize")
+	defer mock.Close()
+
+	now := time.Date(2026, 7, 21, 18, 0, 0, 0, time.UTC)
+	reset := now.Add(time.Hour)
+	limit := 5000
+	remaining := 4321
+	mock.ExpectBegin()
+	mock.ExpectExec("pg_advisory_xact_lock").
+		WithArgs("github_rate_limit:143").
+		WillReturnResult(pgxmock.NewResult("SELECT", 1))
+	mock.ExpectExec("INSERT INTO github_installations").
+		WithArgs(pgx.NamedArgs{"installation_id": int64(143), "account_login": "installation-143"}).
+		WillReturnResult(pgxmock.NewResult("INSERT", 0))
+	mock.ExpectExec("INSERT INTO github_installation_rate_limits").
+		WithArgs(pgx.NamedArgs{
+			"installation_id": int64(143),
+			"resource":        models.GitHubRateLimitResourceCore,
+			"limit_count":     &limit,
+			"remaining_count": &remaining,
+			"reset_at":        &reset,
+			"blocked_until":   (*time.Time)(nil),
+			"observed_at":     now,
+		}).
+		WillReturnResult(pgxmock.NewResult("INSERT", 1))
+	mock.ExpectCommit()
+
+	err = NewGitHubRateLimitStore(mock).Observe(context.Background(), models.GitHubRateLimitObservation{
+		InstallationID: 143,
+		Resource:       models.GitHubRateLimitResourceCore,
+		Limit:          &limit,
+		Remaining:      &remaining,
+		ResetAt:        &reset,
+		ObservedAt:     now,
+	})
+
+	require.NoError(t, err, "valid GitHub quota headers should persist")
+	require.NoError(t, mock.ExpectationsWereMet(), "observation should use the installation-global upsert")
+}
+
+func TestDecideGitHubCodeReviewAdmission(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 7, 21, 18, 0, 0, 0, time.UTC)
+	reset := now.Add(time.Hour)
+	blocked := now.Add(2 * time.Minute)
+	expired := now.Add(-time.Second)
+	staleObservation := now.Add(-githubRateObservationMaxAge - time.Second)
+	activeBootstrap := now.Add(-time.Minute)
+	limit := 5000
+	highRemaining := 1500
+	lowRemaining := 1099
+	tests := []struct {
+		name           string
+		state          githubRateLimitState
+		activeReserved int
+		existing       bool
+		expected       models.GitHubRateLimitDecision
+	}{
+		{
+			name:           "admits known capacity above recovery floor",
+			state:          githubRateLimitState{Limit: &limit, Remaining: &highRemaining, ResetAt: &reset, ObservedAt: &now},
+			activeReserved: 800,
+			expected:       models.GitHubRateLimitDecision{Allowed: true, Known: true, Limit: 5000, Remaining: 1500, ActiveReserved: 800, RecoveryReserve: 500, ResetAt: reset},
+		},
+		{
+			name:           "denies capacity that would cross recovery floor",
+			state:          githubRateLimitState{Limit: &limit, Remaining: &lowRemaining, ResetAt: &reset, ObservedAt: &now},
+			activeReserved: 500,
+			expected:       models.GitHubRateLimitDecision{Known: true, Limit: 5000, Remaining: 1099, ActiveReserved: 500, RecoveryReserve: 500, ResetAt: reset, RetryAfter: time.Hour},
+		},
+		{
+			name:     "requires a quota refresh when state is unknown",
+			state:    githubRateLimitState{},
+			expected: models.GitHubRateLimitDecision{Bootstrap: true, RefreshRequired: true},
+		},
+		{
+			name:           "old reservations do not prevent a new quota bootstrap",
+			state:          githubRateLimitState{Limit: &limit, Remaining: &highRemaining, ResetAt: &expired, ObservedAt: &staleObservation},
+			activeReserved: 100,
+			expected:       models.GitHubRateLimitDecision{Bootstrap: true, RefreshRequired: true, ActiveReserved: 100},
+		},
+		{
+			name:     "denies a second bootstrap while the lease is active",
+			state:    githubRateLimitState{BootstrapAt: &activeBootstrap},
+			expected: models.GitHubRateLimitDecision{Bootstrap: true, RetryAfter: githubRateBootstrapRetry},
+		},
+		{
+			name:     "treats a stale observation as bootstrap-only",
+			state:    githubRateLimitState{Limit: &limit, Remaining: &highRemaining, ResetAt: &reset, ObservedAt: &staleObservation},
+			expected: models.GitHubRateLimitDecision{Bootstrap: true, RefreshRequired: true},
+		},
+		{
+			name:     "lets an existing reservation resume against stale quota",
+			state:    githubRateLimitState{Limit: &limit, Remaining: &highRemaining, ResetAt: &reset, ObservedAt: &staleObservation},
+			existing: true,
+			expected: models.GitHubRateLimitDecision{Allowed: true, ExistingReservation: true},
+		},
+		{
+			name:     "honors secondary block",
+			state:    githubRateLimitState{Limit: &limit, Remaining: &highRemaining, ResetAt: &reset, BlockedUntil: &blocked, ObservedAt: &now},
+			expected: models.GitHubRateLimitDecision{Known: true, Limit: 5000, Remaining: 1500, RecoveryReserve: 500, ResetAt: reset, BlockedUntil: blocked, RetryAfter: 2 * time.Minute},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			metadataID := uuid.New()
+			tt.expected.MetadataID = metadataID
+			actual := decideGitHubCodeReviewAdmission(tt.state, tt.activeReserved, tt.existing, metadataID, now)
+			require.Equal(t, tt.expected, actual, "admission should preserve capacity for existing review recovery")
+		})
+	}
+}
+
+func TestGitHubRateLimitStoreReserveCodeReviewCreatesAtomicReservation(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "pgxmock should initialize")
+	defer mock.Close()
+
+	orgID := uuid.New()
+	metadataID := uuid.New()
+	now := time.Date(2026, 7, 21, 18, 0, 0, 0, time.UTC)
+	reset := now.Add(time.Hour)
+	mock.ExpectBegin()
+	mock.ExpectExec("pg_advisory_xact_lock").
+		WithArgs("github_rate_limit:143").
+		WillReturnResult(pgxmock.NewResult("SELECT", 1))
+	mock.ExpectExec("INSERT INTO github_installations").
+		WithArgs(pgx.NamedArgs{"installation_id": int64(143), "account_login": "installation-143"}).
+		WillReturnResult(pgxmock.NewResult("INSERT", 0))
+	mock.ExpectExec("UPDATE github_installation_rate_reservations").
+		WithArgs(pgx.NamedArgs{"installation_id": int64(143), "released_at": now}).
+		WillReturnResult(pgxmock.NewResult("UPDATE", 0))
+	mock.ExpectQuery("SELECT reserved_units").
+		WithArgs(pgx.NamedArgs{"org_id": orgID, "installation_id": int64(143), "metadata_id": metadataID, "resource": models.GitHubRateLimitResourceCore}).
+		WillReturnRows(pgxmock.NewRows([]string{"reserved_units"}))
+	mock.ExpectQuery("SELECT COALESCE\\(SUM").
+		WithArgs(pgx.NamedArgs{"installation_id": int64(143), "resource": models.GitHubRateLimitResourceCore}).
+		WillReturnRows(pgxmock.NewRows([]string{"active_reserved"}).AddRow(300))
+	mock.ExpectQuery("SELECT resource, limit_count, remaining_count").
+		WithArgs(pgx.NamedArgs{"installation_id": int64(143)}).
+		WillReturnRows(pgxmock.NewRows([]string{"resource", "limit_count", "remaining_count", "reset_at", "blocked_until", "observed_at", "bootstrap_reserved_at"}).
+			AddRow(models.GitHubRateLimitResourceCore, 5000, 1200, reset, nil, now, nil))
+	mock.ExpectExec("INSERT INTO github_installation_rate_reservations").
+		WithArgs(pgx.NamedArgs{
+			"org_id": orgID, "installation_id": int64(143), "metadata_id": metadataID,
+			"resource": models.GitHubRateLimitResourceCore, "reserved_units": 100,
+		}).
+		WillReturnResult(pgxmock.NewResult("INSERT", 1))
+	mock.ExpectCommit()
+
+	decision, err := NewGitHubRateLimitStore(mock).ReserveCodeReview(context.Background(), orgID, 143, metadataID, now)
+
+	require.NoError(t, err, "capacity above the recovery floor should create a reservation")
+	require.Equal(t, models.GitHubRateLimitDecision{
+		Allowed: true, Known: true, Limit: 5000, Remaining: 1200, ActiveReserved: 300,
+		RecoveryReserve: 500, ResetAt: reset, MetadataID: metadataID,
+	}, decision, "reservation should return the locked installation-wide budget decision")
+	require.NoError(t, mock.ExpectationsWereMet(), "admission should lock, calculate, insert, and commit atomically")
+}
+
+func TestGitHubRateLimitStoreReserveCodeReviewExistingReservationHonorsGraphQLBlock(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "pgxmock should initialize")
+	defer mock.Close()
+
+	orgID := uuid.New()
+	metadataID := uuid.New()
+	now := time.Date(2026, 7, 21, 18, 0, 0, 0, time.UTC)
+	blocked := now.Add(90 * time.Second)
+	mock.ExpectBegin()
+	mock.ExpectExec("pg_advisory_xact_lock").
+		WithArgs("github_rate_limit:143").
+		WillReturnResult(pgxmock.NewResult("SELECT", 1))
+	mock.ExpectExec("INSERT INTO github_installations").
+		WithArgs(pgx.NamedArgs{"installation_id": int64(143), "account_login": "installation-143"}).
+		WillReturnResult(pgxmock.NewResult("INSERT", 0))
+	mock.ExpectExec("UPDATE github_installation_rate_reservations").
+		WithArgs(pgx.NamedArgs{"installation_id": int64(143), "released_at": now}).
+		WillReturnResult(pgxmock.NewResult("UPDATE", 0))
+	mock.ExpectQuery("SELECT reserved_units").
+		WithArgs(pgx.NamedArgs{"org_id": orgID, "installation_id": int64(143), "metadata_id": metadataID, "resource": models.GitHubRateLimitResourceCore}).
+		WillReturnRows(pgxmock.NewRows([]string{"reserved_units"}).AddRow(100))
+	mock.ExpectQuery("SELECT COALESCE\\(SUM").
+		WithArgs(pgx.NamedArgs{"installation_id": int64(143), "resource": models.GitHubRateLimitResourceCore}).
+		WillReturnRows(pgxmock.NewRows([]string{"active_reserved"}).AddRow(100))
+	mock.ExpectQuery("SELECT resource, limit_count, remaining_count").
+		WithArgs(pgx.NamedArgs{"installation_id": int64(143)}).
+		WillReturnRows(pgxmock.NewRows([]string{"resource", "limit_count", "remaining_count", "reset_at", "blocked_until", "observed_at", "bootstrap_reserved_at"}).
+			AddRow(models.GitHubRateLimitResourceGraphQL, nil, nil, nil, blocked, now, nil))
+	mock.ExpectCommit()
+
+	decision, err := NewGitHubRateLimitStore(mock).ReserveCodeReview(context.Background(), orgID, 143, metadataID, now)
+
+	require.NoError(t, err, "a shared secondary block should produce a durable admission decision")
+	require.Equal(t, models.GitHubRateLimitDecision{
+		ExistingReservation: true, ActiveReserved: 100, BlockedUntil: blocked,
+		RetryAfter: 90 * time.Second, MetadataID: metadataID,
+	}, decision, "a retry must not bypass a GraphQL secondary block through its existing reservation")
+	require.NoError(t, mock.ExpectationsWereMet(), "existing admission should read installation-wide blocks before committing")
+}

--- a/internal/integration/github_rate_limit_test.go
+++ b/internal/integration/github_rate_limit_test.go
@@ -1,0 +1,217 @@
+//go:build integration
+
+package integration
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/assembledhq/143/internal/db"
+	"github.com/assembledhq/143/internal/models"
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIntegrationGitHubRateLimitObservationRejectsOutOfOrderSnapshots(t *testing.T) {
+	// Integration tests share and truncate one database, so they cannot run in parallel.
+	pool := setup(t)
+	seedGitHubInstallation(t, pool, 143)
+	store := db.NewGitHubRateLimitStore(pool)
+	now := time.Now().UTC().Truncate(time.Second)
+	reset := now.Add(time.Hour)
+
+	require.NoError(t, store.Observe(context.Background(), githubQuotaObservation(143, 4000, reset, now)), "fresh quota should persist")
+	require.NoError(t, store.Observe(context.Background(), githubQuotaObservation(143, 4500, reset, now.Add(-time.Minute))), "out-of-order same-window quota should be accepted conservatively")
+	require.NoError(t, store.Observe(context.Background(), githubQuotaObservation(143, 100, reset.Add(-time.Hour), now.Add(time.Minute))), "an older reset window should not replace the current window")
+
+	var limit, remaining int
+	var actualReset, observedAt time.Time
+	err := pool.QueryRow(context.Background(), `
+		SELECT limit_count, remaining_count, reset_at, observed_at
+		FROM github_installation_rate_limits
+		WHERE installation_id = $1 AND resource = 'core'
+	`, int64(143)).Scan(&limit, &remaining, &actualReset, &observedAt)
+	require.NoError(t, err, "persisted quota should be queryable")
+	require.Equal(t, 5000, limit, "the quota limit should remain exact")
+	require.Equal(t, 4000, remaining, "same-window observations must only decrease remaining quota")
+	require.True(t, reset.Equal(actualReset), "an older reset window must not replace the current window")
+	require.True(t, now.Equal(observedAt), "an ignored older window must not make the accepted quota snapshot appear fresh")
+}
+
+func TestIntegrationGitHubRateLimitConcurrentReservationsSerialize(t *testing.T) {
+	// Integration tests share and truncate one database, so they cannot run in parallel.
+	pool := setup(t)
+	orgID := seedOrg(t, pool)
+	seedGitHubInstallation(t, pool, 143)
+	metadataIDs := seedGitHubRateLimitMetadata(t, pool, orgID, 2)
+	store := db.NewGitHubRateLimitStore(pool)
+	now := time.Now().UTC().Truncate(time.Second)
+	require.NoError(t, store.Observe(context.Background(), githubQuotaObservation(143, 600, now.Add(time.Hour), now)), "initial quota should persist")
+
+	decisions, errs := reserveConcurrently(store, orgID, 143, metadataIDs, now)
+	require.NoError(t, errs[0], "first concurrent admission should complete")
+	require.NoError(t, errs[1], "second concurrent admission should complete")
+	allowed := 0
+	for _, decision := range decisions {
+		if decision.Allowed {
+			allowed++
+		}
+	}
+	require.Equal(t, 1, allowed, "the installation lock should admit only one review above the recovery floor")
+
+	var activeReserved int
+	err := pool.QueryRow(context.Background(), `
+		SELECT COALESCE(SUM(reserved_units), 0)
+		FROM github_installation_rate_reservations
+		WHERE installation_id = $1 AND released_at IS NULL
+	`, int64(143)).Scan(&activeReserved)
+	require.NoError(t, err, "active reservations should be queryable")
+	require.Equal(t, 100, activeReserved, "only the admitted review should reserve installation quota")
+}
+
+func TestIntegrationGitHubRateLimitConcurrentBootstrapUsesSingleLease(t *testing.T) {
+	// Integration tests share and truncate one database, so they cannot run in parallel.
+	pool := setup(t)
+	orgID := seedOrg(t, pool)
+	metadataIDs := seedGitHubRateLimitMetadata(t, pool, orgID, 2)
+	store := db.NewGitHubRateLimitStore(pool)
+	now := time.Now().UTC().Truncate(time.Second)
+
+	decisions, errs := reserveConcurrently(store, orgID, 1, metadataIDs, now)
+	require.NoError(t, errs[0], "first bootstrap admission should complete")
+	require.NoError(t, errs[1], "second bootstrap admission should complete")
+	refreshRequired := 0
+	bootstrap := 0
+	for _, decision := range decisions {
+		if decision.RefreshRequired {
+			refreshRequired++
+		}
+		if decision.Bootstrap {
+			bootstrap++
+		}
+	}
+	require.Equal(t, 1, refreshRequired, "only one review should own the bootstrap refresh lease")
+	require.Equal(t, 2, bootstrap, "both decisions should identify the unknown quota state")
+	var installationCount int
+	err := pool.QueryRow(context.Background(), `SELECT COUNT(*) FROM github_installations WHERE installation_id = 1`).Scan(&installationCount)
+	require.NoError(t, err, "legacy repository installation should be queryable")
+	require.Equal(t, 1, installationCount, "admission should materialize a missing global installation for a legacy repository")
+}
+
+func TestIntegrationGitHubRateLimitReleasesTerminalReservation(t *testing.T) {
+	// Integration tests share and truncate one database, so they cannot run in parallel.
+	pool := setup(t)
+	orgID := seedOrg(t, pool)
+	seedGitHubInstallation(t, pool, 143)
+	metadataIDs := seedGitHubRateLimitMetadata(t, pool, orgID, 2)
+	store := db.NewGitHubRateLimitStore(pool)
+	now := time.Now().UTC().Truncate(time.Second)
+	require.NoError(t, store.Observe(context.Background(), githubQuotaObservation(143, 600, now.Add(time.Hour), now)), "initial quota should persist")
+
+	first, err := store.ReserveCodeReview(context.Background(), orgID, 143, metadataIDs[0], now)
+	require.NoError(t, err, "first review admission should complete")
+	require.True(t, first.Allowed, "first review should fit above the recovery floor")
+	_, err = pool.Exec(context.Background(), `
+		UPDATE code_review_session_metadata
+		SET status = 'completed', completed_at = $1
+		WHERE org_id = $2 AND id = $3
+	`, now, orgID, metadataIDs[0])
+	require.NoError(t, err, "first review metadata should become terminal")
+
+	second, err := store.ReserveCodeReview(context.Background(), orgID, 143, metadataIDs[1], now.Add(time.Second))
+	require.NoError(t, err, "second review admission should complete")
+	require.True(t, second.Allowed, "terminal review units should be reusable by the next review")
+
+	var activeUnits, releasedRows int
+	err = pool.QueryRow(context.Background(), `
+		SELECT
+			COALESCE(SUM(reserved_units) FILTER (WHERE released_at IS NULL), 0),
+			COUNT(*) FILTER (WHERE released_at IS NOT NULL)
+		FROM github_installation_rate_reservations
+		WHERE installation_id = $1
+	`, int64(143)).Scan(&activeUnits, &releasedRows)
+	require.NoError(t, err, "reservation lifecycle should be queryable")
+	require.Equal(t, 100, activeUnits, "only the second review should retain active reserved units")
+	require.Equal(t, 1, releasedRows, "terminal review reservation should be marked released")
+}
+
+func githubQuotaObservation(installationID int64, remaining int, resetAt, observedAt time.Time) models.GitHubRateLimitObservation {
+	limit := 5000
+	return models.GitHubRateLimitObservation{
+		InstallationID: installationID,
+		Resource:       models.GitHubRateLimitResourceCore,
+		Limit:          &limit,
+		Remaining:      &remaining,
+		ResetAt:        &resetAt,
+		ObservedAt:     observedAt,
+	}
+}
+
+func reserveConcurrently(store *db.GitHubRateLimitStore, orgID uuid.UUID, installationID int64, metadataIDs []uuid.UUID, now time.Time) ([]models.GitHubRateLimitDecision, []error) {
+	decisions := make([]models.GitHubRateLimitDecision, len(metadataIDs))
+	errs := make([]error, len(metadataIDs))
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	for index, metadataID := range metadataIDs {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			decisions[index], errs[index] = store.ReserveCodeReview(context.Background(), orgID, installationID, metadataID, now)
+		}()
+	}
+	close(start)
+	wg.Wait()
+	return decisions, errs
+}
+
+func seedGitHubInstallation(t *testing.T, pool *pgxpool.Pool, installationID int64) {
+	t.Helper()
+	_, err := pool.Exec(context.Background(), `
+		INSERT INTO github_installations (installation_id, account_id, account_login)
+		VALUES ($1, $2, $3)
+	`, installationID, installationID, fmt.Sprintf("integration-%d", installationID))
+	require.NoError(t, err, "seed GitHub installation")
+}
+
+func seedGitHubRateLimitMetadata(t *testing.T, pool *pgxpool.Pool, orgID uuid.UUID, count int) []uuid.UUID {
+	t.Helper()
+	repoID := seedRepository(t, pool, orgID, "integration/rate-budget")
+	var policyID uuid.UUID
+	err := pool.QueryRow(context.Background(), `
+		INSERT INTO code_review_policies (
+			org_id, version, approval_mode, description_policy, risk_policy, agent_roster,
+			inline_comment_limit, review_instructions, automated_approval_policy
+		) VALUES ($1, 1, 'comment_only', '{}', '{}', '{}', 4, 'Review the change.', 'Approve routine changes.')
+		RETURNING id
+	`, orgID).Scan(&policyID)
+	require.NoError(t, err, "seed code review policy")
+
+	metadataIDs := make([]uuid.UUID, 0, count)
+	for index := 0; index < count; index++ {
+		session := seedSession(t, pool, orgID, sessionOpts{Status: models.SessionStatusPending, Origin: models.SessionOriginCodeReview, RepositoryID: &repoID})
+		var pullRequestID uuid.UUID
+		err := pool.QueryRow(context.Background(), `
+			INSERT INTO pull_requests (org_id, github_pr_number, github_pr_url, github_repo, title)
+			VALUES ($1, $2, $3, $4, $5)
+			RETURNING id
+		`, orgID, index+1, fmt.Sprintf("https://github.com/integration/rate-budget/pull/%d", index+1), "integration/rate-budget", fmt.Sprintf("PR %d", index+1)).Scan(&pullRequestID)
+		require.NoError(t, err, "seed pull request")
+
+		var metadataID uuid.UUID
+		err = pool.QueryRow(context.Background(), `
+			INSERT INTO code_review_session_metadata (
+				org_id, session_id, repository_id, pull_request_id, policy_id,
+				base_sha, head_sha, trigger_source, status, review_output_key
+			) VALUES ($1, $2, $3, $4, $5, 'base', $6, 'team_reviewer', 'queued', $7)
+			RETURNING id
+		`, orgID, session.ID, repoID, pullRequestID, policyID, fmt.Sprintf("head-%d", index), fmt.Sprintf("output-%d-%s", index, uuid.NewString())).Scan(&metadataID)
+		require.NoError(t, err, "seed code review metadata")
+		metadataIDs = append(metadataIDs, metadataID)
+	}
+	return metadataIDs
+}

--- a/internal/integration/testdb.go
+++ b/internal/integration/testdb.go
@@ -128,6 +128,9 @@ func resolveMigrationSource() (string, error) {
 var truncatedTables = []string{
 	"nodes",
 	"jobs",
+	"github_installation_rate_reservations",
+	"github_installation_rate_limits",
+	"github_installations",
 	"session_messages",
 	"session_logs",
 	"session_questions",

--- a/internal/models/github_rate_limit.go
+++ b/internal/models/github_rate_limit.go
@@ -1,0 +1,52 @@
+package models
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+type GitHubRateLimitResource string
+
+const (
+	GitHubRateLimitResourceCore    GitHubRateLimitResource = "core"
+	GitHubRateLimitResourceGraphQL GitHubRateLimitResource = "graphql"
+	GitHubRateLimitResourceSearch  GitHubRateLimitResource = "search"
+	GitHubRateLimitResourceUnknown GitHubRateLimitResource = "unknown"
+)
+
+func (r GitHubRateLimitResource) Validate() error {
+	switch r {
+	case GitHubRateLimitResourceCore, GitHubRateLimitResourceGraphQL, GitHubRateLimitResourceSearch, GitHubRateLimitResourceUnknown:
+		return nil
+	default:
+		return fmt.Errorf("invalid GitHub rate-limit resource %q", r)
+	}
+}
+
+type GitHubRateLimitObservation struct {
+	InstallationID int64
+	Resource       GitHubRateLimitResource
+	Limit          *int
+	Remaining      *int
+	ResetAt        *time.Time
+	BlockedUntil   *time.Time
+	ObservedAt     time.Time
+}
+
+type GitHubRateLimitDecision struct {
+	Allowed             bool
+	Known               bool
+	ExistingReservation bool
+	Bootstrap           bool
+	RefreshRequired     bool
+	Limit               int
+	Remaining           int
+	ActiveReserved      int
+	RecoveryReserve     int
+	ResetAt             time.Time
+	BlockedUntil        time.Time
+	RetryAfter          time.Duration
+	MetadataID          uuid.UUID
+}

--- a/internal/models/github_rate_limit_test.go
+++ b/internal/models/github_rate_limit_test.go
@@ -1,0 +1,35 @@
+package models
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGitHubRateLimitResourceValidate(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		resource  GitHubRateLimitResource
+		expectErr bool
+	}{
+		{name: "core", resource: GitHubRateLimitResourceCore},
+		{name: "graphql", resource: GitHubRateLimitResourceGraphQL},
+		{name: "search", resource: GitHubRateLimitResourceSearch},
+		{name: "unknown", resource: GitHubRateLimitResourceUnknown},
+		{name: "invalid", resource: GitHubRateLimitResource("code_review"), expectErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			err := tt.resource.Validate()
+			if tt.expectErr {
+				require.Error(t, err, "unknown GitHub rate-limit resources should be rejected")
+				return
+			}
+			require.NoError(t, err, "known GitHub rate-limit resources should validate")
+		})
+	}
+}

--- a/internal/services/codereview/github_submitter.go
+++ b/internal/services/codereview/github_submitter.go
@@ -20,6 +20,14 @@ type InstallationTokenProvider interface {
 	GetInstallationToken(ctx context.Context, installationID int64) (string, error)
 }
 
+type installationRateLimitObserver interface {
+	ObserveRateLimitForToken(ctx context.Context, token string, statusCode int, resource string, header http.Header)
+}
+
+type installationRateLimitBodyObserver interface {
+	ObserveRateLimitForTokenWithBody(ctx context.Context, token string, statusCode int, resource string, header http.Header, body []byte)
+}
+
 type GitHubSubmitter struct {
 	tokens  InstallationTokenProvider
 	client  *http.Client
@@ -52,6 +60,20 @@ func NewGitHubSubmitter(tokens InstallationTokenProvider, opts ...GitHubSubmitte
 		opt(s)
 	}
 	return s
+}
+
+func (s *GitHubSubmitter) do(httpReq *http.Request, token string) (*http.Response, error) {
+	resp, err := s.client.Do(httpReq)
+	if resp != nil {
+		if observer, ok := s.tokens.(installationRateLimitObserver); ok {
+			resource := "core"
+			if strings.HasSuffix(httpReq.URL.Path, "/graphql") {
+				resource = "graphql"
+			}
+			observer.ObserveRateLimitForToken(httpReq.Context(), token, resp.StatusCode, resource, resp.Header)
+		}
+	}
+	return resp, err
 }
 
 type SubmitReviewDecision string
@@ -237,13 +259,13 @@ func (s *GitHubSubmitter) SubmitReview(ctx context.Context, req SubmitReviewRequ
 	httpReq.Header.Set("Accept", "application/vnd.github+json")
 	httpReq.Header.Set("Content-Type", "application/json")
 	httpReq.Header.Set("X-GitHub-Api-Version", "2022-11-28")
-	resp, err := s.client.Do(httpReq)
+	resp, err := s.do(httpReq, token)
 	if err != nil {
 		return SubmitReviewResult{}, fmt.Errorf("submit GitHub review: %w", err)
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return SubmitReviewResult{}, fmt.Errorf("submit GitHub review: %w", readGitHubAPIResponseError(httpReq, resp))
+		return SubmitReviewResult{}, fmt.Errorf("submit GitHub review: %w", s.readGitHubAPIResponseError(httpReq, resp, token))
 	}
 	var decoded struct {
 		ID      int64  `json:"id"`
@@ -358,13 +380,13 @@ func (s *GitHubSubmitter) ensureFormalApproval(ctx context.Context, token, owner
 	httpReq.Header.Set("Accept", "application/vnd.github+json")
 	httpReq.Header.Set("Content-Type", "application/json")
 	httpReq.Header.Set("X-GitHub-Api-Version", "2022-11-28")
-	resp, err := s.client.Do(httpReq)
+	resp, err := s.do(httpReq, token)
 	if err != nil {
 		return fmt.Errorf("submit formal GitHub approval: %w", err)
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return fmt.Errorf("submit formal GitHub approval: %w", readGitHubAPIResponseError(httpReq, resp))
+		return fmt.Errorf("submit formal GitHub approval: %w", s.readGitHubAPIResponseError(httpReq, resp, token))
 	}
 	return nil
 }
@@ -383,13 +405,13 @@ func (s *GitHubSubmitter) updateReviewSummary(ctx context.Context, token, owner,
 	httpReq.Header.Set("Accept", "application/vnd.github+json")
 	httpReq.Header.Set("Content-Type", "application/json")
 	httpReq.Header.Set("X-GitHub-Api-Version", "2022-11-28")
-	resp, err := s.client.Do(httpReq)
+	resp, err := s.do(httpReq, token)
 	if err != nil {
 		return SubmitReviewResult{}, fmt.Errorf("update GitHub review summary: %w", err)
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return SubmitReviewResult{}, fmt.Errorf("update GitHub review summary: %w", readGitHubAPIResponseError(httpReq, resp))
+		return SubmitReviewResult{}, fmt.Errorf("update GitHub review summary: %w", s.readGitHubAPIResponseError(httpReq, resp, token))
 	}
 	var decoded struct {
 		ID      int64  `json:"id"`
@@ -420,13 +442,13 @@ func (s *GitHubSubmitter) createReviewComment(ctx context.Context, token, owner,
 	httpReq.Header.Set("Accept", "application/vnd.github+json")
 	httpReq.Header.Set("Content-Type", "application/json")
 	httpReq.Header.Set("X-GitHub-Api-Version", "2022-11-28")
-	resp, err := s.client.Do(httpReq)
+	resp, err := s.do(httpReq, token)
 	if err != nil {
 		return SubmitReviewPostedComment{}, fmt.Errorf("create GitHub review comment: %w", err)
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return SubmitReviewPostedComment{}, fmt.Errorf("create GitHub review comment: %w", readGitHubAPIResponseError(httpReq, resp))
+		return SubmitReviewPostedComment{}, fmt.Errorf("create GitHub review comment: %w", s.readGitHubAPIResponseError(httpReq, resp, token))
 	}
 	var decoded githubReviewCommentItem
 	if err := json.NewDecoder(resp.Body).Decode(&decoded); err != nil {
@@ -470,13 +492,13 @@ func (s *GitHubSubmitter) listReviewComments(ctx context.Context, token, owner, 
 	httpReq.Header.Set("Authorization", "Bearer "+token)
 	httpReq.Header.Set("Accept", "application/vnd.github+json")
 	httpReq.Header.Set("X-GitHub-Api-Version", "2022-11-28")
-	resp, err := s.client.Do(httpReq)
+	resp, err := s.do(httpReq, token)
 	if err != nil {
 		return nil, fmt.Errorf("list GitHub review comments: %w", err)
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, fmt.Errorf("list GitHub review comments: %w", readGitHubAPIResponseError(httpReq, resp))
+		return nil, fmt.Errorf("list GitHub review comments: %w", s.readGitHubAPIResponseError(httpReq, resp, token))
 	}
 	var decoded []struct {
 		ID   int64  `json:"id"`
@@ -567,13 +589,13 @@ func (s *GitHubSubmitter) updateReviewComment(ctx context.Context, token, owner,
 	httpReq.Header.Set("Accept", "application/vnd.github+json")
 	httpReq.Header.Set("Content-Type", "application/json")
 	httpReq.Header.Set("X-GitHub-Api-Version", "2022-11-28")
-	resp, err := s.client.Do(httpReq)
+	resp, err := s.do(httpReq, token)
 	if err != nil {
 		return fmt.Errorf("update GitHub review comment: %w", err)
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return fmt.Errorf("update GitHub review comment: %w", readGitHubAPIResponseError(httpReq, resp))
+		return fmt.Errorf("update GitHub review comment: %w", s.readGitHubAPIResponseError(httpReq, resp, token))
 	}
 	return nil
 }
@@ -586,13 +608,13 @@ func (s *GitHubSubmitter) getGitHubJSONPage(ctx context.Context, token, path str
 	httpReq.Header.Set("Authorization", "Bearer "+token)
 	httpReq.Header.Set("Accept", "application/vnd.github+json")
 	httpReq.Header.Set("X-GitHub-Api-Version", "2022-11-28")
-	resp, err := s.client.Do(httpReq)
+	resp, err := s.do(httpReq, token)
 	if err != nil {
 		return "", fmt.Errorf("GitHub request failed: %w", err)
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return "", fmt.Errorf("GitHub request failed: %w", readGitHubAPIResponseError(httpReq, resp))
+		return "", fmt.Errorf("GitHub request failed: %w", s.readGitHubAPIResponseError(httpReq, resp, token))
 	}
 	if err := json.NewDecoder(resp.Body).Decode(target); err != nil {
 		return "", fmt.Errorf("decode GitHub response: %w", err)
@@ -612,7 +634,7 @@ func (s *GitHubSubmitter) doGitHubGraphQL(ctx context.Context, token, query stri
 	httpReq.Header.Set("Authorization", "Bearer "+token)
 	httpReq.Header.Set("Accept", "application/vnd.github+json")
 	httpReq.Header.Set("Content-Type", "application/json")
-	resp, err := s.client.Do(httpReq)
+	resp, err := s.do(httpReq, token)
 	if err != nil {
 		return nil, fmt.Errorf("GitHub GraphQL request failed: %w", err)
 	}
@@ -622,6 +644,7 @@ func (s *GitHubSubmitter) doGitHubGraphQL(ctx context.Context, token, query stri
 		return nil, fmt.Errorf("read GitHub GraphQL response: %w", err)
 	}
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		s.observeGitHubRateLimitBody(httpReq, resp, token, body)
 		return nil, fmt.Errorf("GitHub GraphQL request failed: %w", newGitHubAPIResponseError(httpReq, resp, body))
 	}
 	return body, nil
@@ -792,13 +815,13 @@ func (s *GitHubSubmitter) RemoveRequestedReviewers(ctx context.Context, req Requ
 	httpReq.Header.Set("Accept", "application/vnd.github+json")
 	httpReq.Header.Set("Content-Type", "application/json")
 	httpReq.Header.Set("X-GitHub-Api-Version", "2022-11-28")
-	resp, err := s.client.Do(httpReq)
+	resp, err := s.do(httpReq, token)
 	if err != nil {
 		return fmt.Errorf("remove GitHub requested reviewers: %w", err)
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return fmt.Errorf("remove GitHub requested reviewers: %w", readGitHubAPIResponseError(httpReq, resp))
+		return fmt.Errorf("remove GitHub requested reviewers: %w", s.readGitHubAPIResponseError(httpReq, resp, token))
 	}
 	return nil
 }
@@ -933,13 +956,13 @@ func (s *GitHubSubmitter) getPullRequestFilesPage(ctx context.Context, token, pa
 	httpReq.Header.Set("Authorization", "Bearer "+token)
 	httpReq.Header.Set("Accept", "application/vnd.github+json")
 	httpReq.Header.Set("X-GitHub-Api-Version", "2022-11-28")
-	resp, err := s.client.Do(httpReq)
+	resp, err := s.do(httpReq, token)
 	if err != nil {
 		return nil, "", fmt.Errorf("list GitHub pull request files: %w", err)
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, "", fmt.Errorf("list GitHub pull request files: %w", readGitHubAPIResponseError(httpReq, resp))
+		return nil, "", fmt.Errorf("list GitHub pull request files: %w", s.readGitHubAPIResponseError(httpReq, resp, token))
 	}
 	var files []PullRequestFile
 	if err := json.NewDecoder(resp.Body).Decode(&files); err != nil {
@@ -948,13 +971,26 @@ func (s *GitHubSubmitter) getPullRequestFilesPage(ctx context.Context, token, pa
 	return files, parseNextGitHubPath(resp.Header.Get("Link")), nil
 }
 
-func readGitHubAPIResponseError(req *http.Request, resp *http.Response) error {
+func (s *GitHubSubmitter) readGitHubAPIResponseError(req *http.Request, resp *http.Response, token string) error {
 	errorBody, readErr := io.ReadAll(io.LimitReader(resp.Body, 4096))
+	s.observeGitHubRateLimitBody(req, resp, token, errorBody)
 	apiErr := newGitHubAPIResponseError(req, resp, errorBody)
 	if readErr != nil {
 		return errors.Join(apiErr, fmt.Errorf("read GitHub error response: %w", readErr))
 	}
 	return apiErr
+}
+
+func (s *GitHubSubmitter) observeGitHubRateLimitBody(req *http.Request, resp *http.Response, token string, body []byte) {
+	observer, ok := s.tokens.(installationRateLimitBodyObserver)
+	if !ok || req == nil || resp == nil {
+		return
+	}
+	resource := "core"
+	if req.URL != nil && strings.HasSuffix(req.URL.Path, "/graphql") {
+		resource = "graphql"
+	}
+	observer.ObserveRateLimitForTokenWithBody(req.Context(), token, resp.StatusCode, resource, resp.Header, body)
 }
 
 func newGitHubAPIResponseError(req *http.Request, resp *http.Response, body []byte) *ghservice.GitHubAPIError {

--- a/internal/services/codereview/github_submitter_test.go
+++ b/internal/services/codereview/github_submitter_test.go
@@ -688,10 +688,84 @@ func TestGitHubSubmitter_SubmitReviewRejectsInvalidInput(t *testing.T) {
 	}
 }
 
+func TestGitHubSubmitterObservesInstallationRateLimit(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("X-RateLimit-Limit", "5000")
+		w.Header().Set("X-RateLimit-Remaining", "4321")
+		w.Header().Set("X-RateLimit-Reset", "1784678400")
+		w.Header().Set("X-RateLimit-Resource", "core")
+		w.Header().Set("Content-Type", "application/json")
+		_, err := w.Write([]byte(`[]`))
+		require.NoError(t, err, "test response should write the file list")
+	}))
+	defer server.Close()
+
+	tokens := &observingTokenStub{tokenStub: tokenStub{token: "ghs_token"}}
+	submitter := NewGitHubSubmitter(tokens, WithGitHubSubmitterBaseURL(server.URL))
+	_, err := submitter.ListPullRequestFiles(context.Background(), PullRequestFilesRequest{
+		InstallationID: 143,
+		Repository:     "acme/repo",
+		PullNumber:     42,
+	})
+
+	require.NoError(t, err, "file retrieval should succeed")
+	require.Equal(t, "ghs_token", tokens.observedToken, "submitter should identify the installation token used by the response")
+	require.Equal(t, http.StatusOK, tokens.statusCode, "submitter should preserve the response status for secondary-limit detection")
+	require.Equal(t, "core", tokens.resource, "REST file retrieval should update the core resource budget")
+	require.Equal(t, "4321", tokens.header.Get("X-RateLimit-Remaining"), "submitter should preserve GitHub's quota headers")
+}
+
+func TestGitHubSubmitterClassifiesHeaderlessSecondaryLimitBody(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		_, err := w.Write([]byte(`{"message":"You have exceeded a secondary rate limit"}`))
+		require.NoError(t, err, "test response should write the secondary-limit body")
+	}))
+	defer server.Close()
+
+	tokens := &observingTokenStub{tokenStub: tokenStub{token: "ghs_token"}}
+	submitter := NewGitHubSubmitter(tokens, WithGitHubSubmitterBaseURL(server.URL))
+	_, err := submitter.ListPullRequestFiles(context.Background(), PullRequestFilesRequest{
+		InstallationID: 143,
+		Repository:     "acme/repo",
+		PullNumber:     42,
+	})
+
+	require.Error(t, err, "secondary limiting should remain visible to the caller")
+	require.Equal(t, []byte(`{"message":"You have exceeded a secondary rate limit"}`), tokens.body, "the observer should receive the response body needed to distinguish rate limiting from permissions")
+	require.Equal(t, http.StatusForbidden, tokens.statusCode, "the observer should retain the secondary-limit status")
+	require.Equal(t, "core", tokens.resource, "REST secondary limiting should block installation-wide admission")
+}
+
 type tokenStub struct {
 	token string
 }
 
 func (s *tokenStub) GetInstallationToken(context.Context, int64) (string, error) {
 	return s.token, nil
+}
+
+type observingTokenStub struct {
+	tokenStub
+	observedToken string
+	statusCode    int
+	resource      string
+	header        http.Header
+	body          []byte
+}
+
+func (s *observingTokenStub) ObserveRateLimitForTokenWithBody(_ context.Context, token string, statusCode int, resource string, header http.Header, body []byte) {
+	s.ObserveRateLimitForToken(context.Background(), token, statusCode, resource, header)
+	s.body = append([]byte(nil), body...)
+}
+
+func (s *observingTokenStub) ObserveRateLimitForToken(_ context.Context, token string, statusCode int, resource string, header http.Header) {
+	s.observedToken = token
+	s.statusCode = statusCode
+	s.resource = resource
+	s.header = header.Clone()
 }

--- a/internal/services/github/pr.go
+++ b/internal/services/github/pr.go
@@ -3604,6 +3604,7 @@ func (s *PRService) doGitHubRequest(ctx context.Context, token, method, path str
 	if err != nil {
 		return nil, err
 	}
+	s.tokenProvider.ObserveRateLimitForTokenWithBody(ctx, token, resp.StatusCode, string(models.GitHubRateLimitResourceCore), resp.Header, respBody)
 
 	if resp.StatusCode >= 400 {
 		return nil, &GitHubAPIError{
@@ -3651,6 +3652,7 @@ func (s *PRService) doGitHubGraphQL(ctx context.Context, token, query string, va
 	if err != nil {
 		return nil, err
 	}
+	s.tokenProvider.ObserveRateLimitForTokenWithBody(ctx, token, resp.StatusCode, string(models.GitHubRateLimitResourceGraphQL), resp.Header, respBody)
 
 	if resp.StatusCode >= 400 {
 		return nil, &GitHubAPIError{

--- a/internal/services/github/rate_budget.go
+++ b/internal/services/github/rate_budget.go
@@ -17,6 +17,7 @@ import (
 type GitHubRateLimitStore interface {
 	Observe(ctx context.Context, observation models.GitHubRateLimitObservation) error
 	ReserveCodeReview(ctx context.Context, orgID uuid.UUID, installationID int64, metadataID uuid.UUID, now time.Time) (models.GitHubRateLimitDecision, error)
+	CheckCodeReviewBlock(ctx context.Context, installationID int64, now time.Time) (models.GitHubRateLimitDecision, error)
 }
 
 type GitHubRateLimitSnapshotFetcher interface {
@@ -78,6 +79,16 @@ func (b *RateBudget) ReserveCodeReview(ctx context.Context, orgID uuid.UUID, ins
 		return models.GitHubRateLimitDecision{Allowed: true}, nil
 	}
 	return b.store.ReserveCodeReview(ctx, orgID, installationID, metadataID, b.now().UTC())
+}
+
+// CheckCodeReviewBlock lets an admitted review resume without reapplying the
+// primary-capacity floor while still honoring installation-wide secondary
+// limits observed by another worker.
+func (b *RateBudget) CheckCodeReviewBlock(ctx context.Context, installationID int64) (models.GitHubRateLimitDecision, error) {
+	if b == nil || b.store == nil {
+		return models.GitHubRateLimitDecision{Allowed: true}, nil
+	}
+	return b.store.CheckCodeReviewBlock(ctx, installationID, b.now().UTC())
 }
 
 // RefreshCodeReview synchronously fetches and durably persists GitHub's

--- a/internal/services/github/rate_budget.go
+++ b/internal/services/github/rate_budget.go
@@ -1,0 +1,172 @@
+package github
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/assembledhq/143/internal/models"
+	"github.com/google/uuid"
+	"github.com/rs/zerolog"
+)
+
+type GitHubRateLimitStore interface {
+	Observe(ctx context.Context, observation models.GitHubRateLimitObservation) error
+	ReserveCodeReview(ctx context.Context, orgID uuid.UUID, installationID int64, metadataID uuid.UUID, now time.Time) (models.GitHubRateLimitDecision, error)
+}
+
+type GitHubRateLimitSnapshotFetcher interface {
+	FetchRateLimitSnapshot(ctx context.Context, installationID int64) ([]models.GitHubRateLimitObservation, error)
+}
+
+// RateBudget persists installation-wide GitHub quota observations and owns the
+// durable admission decision for new code reviews.
+type RateBudget struct {
+	store   GitHubRateLimitStore
+	logger  zerolog.Logger
+	now     func() time.Time
+	fetcher GitHubRateLimitSnapshotFetcher
+}
+
+func (b *RateBudget) SetSnapshotFetcher(fetcher GitHubRateLimitSnapshotFetcher) {
+	if b != nil {
+		b.fetcher = fetcher
+	}
+}
+
+func NewRateBudget(store GitHubRateLimitStore, logger zerolog.Logger) *RateBudget {
+	return &RateBudget{store: store, logger: logger, now: time.Now}
+}
+
+// ObserveResponse is deliberately best effort: losing a quota observation
+// must never turn an otherwise successful GitHub operation into a failure.
+func (b *RateBudget) ObserveResponse(ctx context.Context, installationID int64, defaultResource models.GitHubRateLimitResource, statusCode int, header http.Header) {
+	b.observeResponse(ctx, installationID, defaultResource, statusCode, header, nil)
+}
+
+// ObserveResponseWithBody additionally classifies GitHub's headerless
+// secondary-limit 403 response without conflating ordinary permission errors.
+func (b *RateBudget) ObserveResponseWithBody(ctx context.Context, installationID int64, defaultResource models.GitHubRateLimitResource, statusCode int, header http.Header, body []byte) {
+	b.observeResponse(ctx, installationID, defaultResource, statusCode, header, body)
+}
+
+func (b *RateBudget) observeResponse(ctx context.Context, installationID int64, defaultResource models.GitHubRateLimitResource, statusCode int, header http.Header, body []byte) {
+	if b == nil || b.store == nil || installationID <= 0 {
+		return
+	}
+	now := b.now().UTC()
+	observation, ok := parseGitHubRateLimitObservationWithBody(installationID, defaultResource, statusCode, header, body, now)
+	if !ok {
+		return
+	}
+	observeCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), time.Second)
+	defer cancel()
+	if err := b.store.Observe(observeCtx, observation); err != nil {
+		b.logger.Warn().Err(err).
+			Int64("installation_id", installationID).
+			Str("rate_resource", string(observation.Resource)).
+			Msg("failed to persist GitHub rate-limit observation")
+	}
+}
+
+func (b *RateBudget) ReserveCodeReview(ctx context.Context, orgID uuid.UUID, installationID int64, metadataID uuid.UUID) (models.GitHubRateLimitDecision, error) {
+	if b == nil || b.store == nil {
+		return models.GitHubRateLimitDecision{Allowed: true}, nil
+	}
+	return b.store.ReserveCodeReview(ctx, orgID, installationID, metadataID, b.now().UTC())
+}
+
+// RefreshCodeReview synchronously fetches and durably persists GitHub's
+// non-primary-costing /rate_limit snapshot before a bootstrap review starts.
+func (b *RateBudget) RefreshCodeReview(ctx context.Context, installationID int64) error {
+	if b == nil || b.store == nil || b.fetcher == nil {
+		return errors.New("GitHub rate-limit snapshot refresh is unavailable")
+	}
+	observations, err := b.fetcher.FetchRateLimitSnapshot(ctx, installationID)
+	if err != nil {
+		return err
+	}
+	coreObserved := false
+	for _, observation := range observations {
+		if observation.InstallationID != installationID {
+			return fmt.Errorf("GitHub rate-limit snapshot installation mismatch: got %d, want %d", observation.InstallationID, installationID)
+		}
+		if err := b.store.Observe(ctx, observation); err != nil {
+			return fmt.Errorf("persist refreshed GitHub rate limit for %s: %w", observation.Resource, err)
+		}
+		coreObserved = coreObserved || observation.Resource == models.GitHubRateLimitResourceCore
+	}
+	if !coreObserved {
+		return errors.New("GitHub rate-limit snapshot did not include core quota")
+	}
+	return nil
+}
+
+func parseGitHubRateLimitObservation(installationID int64, defaultResource models.GitHubRateLimitResource, statusCode int, header http.Header, now time.Time) (models.GitHubRateLimitObservation, bool) {
+	return parseGitHubRateLimitObservationWithBody(installationID, defaultResource, statusCode, header, nil, now)
+}
+
+func parseGitHubRateLimitObservationWithBody(installationID int64, defaultResource models.GitHubRateLimitResource, statusCode int, header http.Header, body []byte, now time.Time) (models.GitHubRateLimitObservation, bool) {
+	resource := parseGitHubRateLimitResource(header.Get("X-RateLimit-Resource"), defaultResource)
+	observation := models.GitHubRateLimitObservation{
+		InstallationID: installationID,
+		Resource:       resource,
+		ObservedAt:     now,
+	}
+
+	limit, limitErr := strconv.Atoi(strings.TrimSpace(header.Get("X-RateLimit-Limit")))
+	remaining, remainingErr := strconv.Atoi(strings.TrimSpace(header.Get("X-RateLimit-Remaining")))
+	resetUnix, resetErr := strconv.ParseInt(strings.TrimSpace(header.Get("X-RateLimit-Reset")), 10, 64)
+	if limitErr == nil && remainingErr == nil && resetErr == nil && limit > 0 && remaining >= 0 && remaining <= limit {
+		resetAt := time.Unix(resetUnix, 0).UTC()
+		observation.Limit = &limit
+		observation.Remaining = &remaining
+		observation.ResetAt = &resetAt
+	}
+
+	if statusCode == http.StatusTooManyRequests || statusCode == http.StatusForbidden {
+		if retryAfter := parseGitHubRetryAfterHeader(header.Get("Retry-After"), now); retryAfter != nil {
+			blockedUntil := now.Add(*retryAfter)
+			observation.BlockedUntil = &blockedUntil
+		} else if statusCode == http.StatusTooManyRequests || (statusCode == http.StatusForbidden && githubSecondaryRateLimitBody(body)) {
+			blockedUntil := now.Add(time.Minute)
+			observation.BlockedUntil = &blockedUntil
+		}
+	}
+	return observation, observation.Limit != nil || observation.BlockedUntil != nil
+}
+
+func githubSecondaryRateLimitBody(body []byte) bool {
+	normalized := strings.ToLower(string(body))
+	return strings.Contains(normalized, "secondary rate limit") || strings.Contains(normalized, "abuse detection")
+}
+
+func parseGitHubRateLimitResource(raw string, fallback models.GitHubRateLimitResource) models.GitHubRateLimitResource {
+	resource := models.GitHubRateLimitResource(strings.ToLower(strings.TrimSpace(raw)))
+	if resource == "" {
+		resource = fallback
+	}
+	if err := resource.Validate(); err != nil {
+		return models.GitHubRateLimitResourceUnknown
+	}
+	return resource
+}
+
+func parseGitHubRetryAfterHeader(raw string, now time.Time) *time.Duration {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return nil
+	}
+	if seconds, err := strconv.Atoi(raw); err == nil && seconds >= 0 {
+		delay := time.Duration(seconds) * time.Second
+		return &delay
+	}
+	if retryAt, err := http.ParseTime(raw); err == nil {
+		return nonNegativeRetryDelay(retryAt, now)
+	}
+	return nil
+}

--- a/internal/services/github/rate_budget_test.go
+++ b/internal/services/github/rate_budget_test.go
@@ -1,0 +1,225 @@
+package github
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"net/http"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/assembledhq/143/internal/models"
+	"github.com/google/uuid"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseGitHubRateLimitObservation(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 7, 21, 18, 0, 0, 0, time.UTC)
+	reset := now.Add(time.Hour)
+	tests := []struct {
+		name              string
+		defaultResource   models.GitHubRateLimitResource
+		statusCode        int
+		header            http.Header
+		body              []byte
+		expectedResource  models.GitHubRateLimitResource
+		expectedLimit     *int
+		expectedRemaining *int
+		expectedReset     *time.Time
+		expectedBlocked   *time.Time
+		expectOK          bool
+	}{
+		{
+			name:             "parses REST core quota",
+			defaultResource:  models.GitHubRateLimitResourceCore,
+			statusCode:       http.StatusOK,
+			header:           githubRateHeaders("core", 5000, 4321, reset),
+			expectedResource: models.GitHubRateLimitResourceCore,
+			expectedLimit:    rateIntPointer(5000), expectedRemaining: rateIntPointer(4321), expectedReset: rateTimePointer(reset), expectOK: true,
+		},
+		{
+			name:             "uses GraphQL fallback when resource header is absent",
+			defaultResource:  models.GitHubRateLimitResourceGraphQL,
+			statusCode:       http.StatusOK,
+			header:           githubRateHeaders("", 5000, 4000, reset),
+			expectedResource: models.GitHubRateLimitResourceGraphQL,
+			expectedLimit:    rateIntPointer(5000), expectedRemaining: rateIntPointer(4000), expectedReset: rateTimePointer(reset), expectOK: true,
+		},
+		{
+			name:             "records secondary limit without primary headers",
+			defaultResource:  models.GitHubRateLimitResourceCore,
+			statusCode:       http.StatusForbidden,
+			header:           http.Header{"Retry-After": []string{"90"}},
+			expectedResource: models.GitHubRateLimitResourceCore,
+			expectedBlocked:  rateTimePointer(now.Add(90 * time.Second)), expectOK: true,
+		},
+		{
+			name:             "records resource-local primary exhaustion without a global block",
+			defaultResource:  models.GitHubRateLimitResourceCore,
+			statusCode:       http.StatusForbidden,
+			header:           githubRateHeaders("core", 5000, 0, reset),
+			expectedResource: models.GitHubRateLimitResourceCore,
+			expectedLimit:    rateIntPointer(5000), expectedRemaining: rateIntPointer(0), expectedReset: rateTimePointer(reset), expectOK: true,
+		},
+		{
+			name:             "applies fallback block to headerless 429",
+			defaultResource:  models.GitHubRateLimitResourceCore,
+			statusCode:       http.StatusTooManyRequests,
+			header:           make(http.Header),
+			expectedResource: models.GitHubRateLimitResourceCore,
+			expectedBlocked:  rateTimePointer(now.Add(time.Minute)), expectOK: true,
+		},
+		{
+			name:             "applies fallback block to classified secondary 403",
+			defaultResource:  models.GitHubRateLimitResourceGraphQL,
+			statusCode:       http.StatusForbidden,
+			header:           make(http.Header),
+			body:             []byte(`{"message":"You have exceeded a secondary rate limit"}`),
+			expectedResource: models.GitHubRateLimitResourceGraphQL,
+			expectedBlocked:  rateTimePointer(now.Add(time.Minute)), expectOK: true,
+		},
+		{
+			name:             "does not block ordinary permission 403",
+			defaultResource:  models.GitHubRateLimitResourceCore,
+			statusCode:       http.StatusForbidden,
+			header:           make(http.Header),
+			body:             []byte(`{"message":"Resource not accessible by integration"}`),
+			expectedResource: models.GitHubRateLimitResourceCore,
+		},
+		{
+			name:             "ignores malformed success headers",
+			defaultResource:  models.GitHubRateLimitResourceCore,
+			statusCode:       http.StatusOK,
+			header:           http.Header{"X-RateLimit-Limit": []string{"many"}},
+			expectedResource: models.GitHubRateLimitResourceCore,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			actual, ok := parseGitHubRateLimitObservationWithBody(143, tt.defaultResource, tt.statusCode, tt.header, tt.body, now)
+			require.Equal(t, tt.expectOK, ok, "parser should report whether the response carries usable rate-limit state")
+			require.Equal(t, int64(143), actual.InstallationID, "observation should retain the installation identity")
+			require.Equal(t, tt.expectedResource, actual.Resource, "observation should keep primary resources isolated")
+			require.Equal(t, tt.expectedLimit, actual.Limit, "observation should parse the quota limit exactly")
+			require.Equal(t, tt.expectedRemaining, actual.Remaining, "observation should parse remaining quota exactly")
+			require.Equal(t, tt.expectedReset, actual.ResetAt, "observation should parse the reset timestamp exactly")
+			require.Equal(t, tt.expectedBlocked, actual.BlockedUntil, "observation should preserve secondary or primary block windows")
+		})
+	}
+}
+
+func TestRateBudgetObserveResponseIsBestEffort(t *testing.T) {
+	t.Parallel()
+
+	store := &rateLimitStoreStub{observeErr: errors.New("database unavailable")}
+	var logs bytes.Buffer
+	now := time.Date(2026, 7, 21, 18, 0, 0, 0, time.UTC)
+	budget := NewRateBudget(store, zerolog.New(&logs))
+	budget.now = func() time.Time { return now }
+
+	budget.ObserveResponse(context.Background(), 143, models.GitHubRateLimitResourceCore, http.StatusOK,
+		githubRateHeaders("core", 5000, 4321, now.Add(time.Hour)))
+
+	require.Equal(t, int64(143), store.observation.InstallationID, "observer should attempt to persist the installation quota")
+	require.Contains(t, logs.String(), "failed to persist GitHub rate-limit observation", "observer failures should be logged without failing the GitHub request")
+}
+
+func TestRateBudgetReserveCodeReviewDelegatesDurableIdentity(t *testing.T) {
+	t.Parallel()
+
+	orgID := uuid.New()
+	metadataID := uuid.New()
+	now := time.Date(2026, 7, 21, 18, 0, 0, 0, time.UTC)
+	expected := models.GitHubRateLimitDecision{Allowed: true, MetadataID: metadataID}
+	store := &rateLimitStoreStub{decision: expected}
+	budget := NewRateBudget(store, zerolog.Nop())
+	budget.now = func() time.Time { return now }
+
+	actual, err := budget.ReserveCodeReview(context.Background(), orgID, 143, metadataID)
+
+	require.NoError(t, err, "durable admission should return the store decision")
+	require.Equal(t, expected, actual, "rate budget should preserve the durable admission result")
+	require.Equal(t, orgID, store.orgID, "admission should retain tenant ownership for the reservation")
+	require.Equal(t, int64(143), store.installationID, "admission should coordinate on the GitHub installation")
+	require.Equal(t, metadataID, store.metadataID, "admission should be idempotent for the code review metadata row")
+	require.Equal(t, now, store.now, "admission should use one deterministic decision timestamp")
+}
+
+func TestRateBudgetRefreshCodeReviewPersistsFetchedCoreSnapshot(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 7, 21, 18, 0, 0, 0, time.UTC)
+	reset := now.Add(time.Hour)
+	limit := 5000
+	remaining := 700
+	store := &rateLimitStoreStub{}
+	fetcher := &rateLimitSnapshotFetcherStub{observations: []models.GitHubRateLimitObservation{{
+		InstallationID: 143, Resource: models.GitHubRateLimitResourceCore,
+		Limit: &limit, Remaining: &remaining, ResetAt: &reset, ObservedAt: now,
+	}}}
+	budget := NewRateBudget(store, zerolog.Nop())
+	budget.SetSnapshotFetcher(fetcher)
+
+	err := budget.RefreshCodeReview(context.Background(), 143)
+
+	require.NoError(t, err, "pre-start quota refresh should persist a core snapshot")
+	require.Equal(t, int64(143), fetcher.installationID, "refresh should fetch the review installation")
+	require.Equal(t, fetcher.observations, store.observations, "refresh should durably persist the fetched snapshot before re-admission")
+}
+
+type rateLimitStoreStub struct {
+	observation    models.GitHubRateLimitObservation
+	observations   []models.GitHubRateLimitObservation
+	observeErr     error
+	orgID          uuid.UUID
+	installationID int64
+	metadataID     uuid.UUID
+	now            time.Time
+	decision       models.GitHubRateLimitDecision
+	reserveErr     error
+}
+
+func (s *rateLimitStoreStub) Observe(_ context.Context, observation models.GitHubRateLimitObservation) error {
+	s.observation = observation
+	s.observations = append(s.observations, observation)
+	return s.observeErr
+}
+
+func (s *rateLimitStoreStub) ReserveCodeReview(_ context.Context, orgID uuid.UUID, installationID int64, metadataID uuid.UUID, now time.Time) (models.GitHubRateLimitDecision, error) {
+	s.orgID = orgID
+	s.installationID = installationID
+	s.metadataID = metadataID
+	s.now = now
+	return s.decision, s.reserveErr
+}
+
+type rateLimitSnapshotFetcherStub struct {
+	installationID int64
+	observations   []models.GitHubRateLimitObservation
+	err            error
+}
+
+func (s *rateLimitSnapshotFetcherStub) FetchRateLimitSnapshot(_ context.Context, installationID int64) ([]models.GitHubRateLimitObservation, error) {
+	s.installationID = installationID
+	return s.observations, s.err
+}
+
+func githubRateHeaders(resource string, limit, remaining int, reset time.Time) http.Header {
+	header := make(http.Header)
+	header.Set("X-RateLimit-Limit", strconv.Itoa(limit))
+	header.Set("X-RateLimit-Remaining", strconv.Itoa(remaining))
+	header.Set("X-RateLimit-Reset", strconv.FormatInt(reset.Unix(), 10))
+	if resource != "" {
+		header.Set("X-RateLimit-Resource", resource)
+	}
+	return header
+}
+
+func rateIntPointer(value int) *int              { return &value }
+func rateTimePointer(value time.Time) *time.Time { return &value }

--- a/internal/services/github/rate_budget_test.go
+++ b/internal/services/github/rate_budget_test.go
@@ -151,6 +151,24 @@ func TestRateBudgetReserveCodeReviewDelegatesDurableIdentity(t *testing.T) {
 	require.Equal(t, now, store.now, "admission should use one deterministic decision timestamp")
 }
 
+func TestRateBudgetCheckCodeReviewBlockDelegatesInstallationIdentity(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 7, 21, 18, 0, 0, 0, time.UTC)
+	blockedUntil := now.Add(90 * time.Second)
+	expected := models.GitHubRateLimitDecision{BlockedUntil: blockedUntil, RetryAfter: 90 * time.Second}
+	store := &rateLimitStoreStub{blockDecision: expected}
+	budget := NewRateBudget(store, zerolog.Nop())
+	budget.now = func() time.Time { return now }
+
+	actual, err := budget.CheckCodeReviewBlock(context.Background(), 143)
+
+	require.NoError(t, err, "running-review block check should return the store decision")
+	require.Equal(t, expected, actual, "rate budget should preserve the installation-wide block")
+	require.Equal(t, int64(143), store.installationID, "block check should retain the GitHub installation identity")
+	require.Equal(t, now, store.now, "block check should use one deterministic decision timestamp")
+}
+
 func TestRateBudgetRefreshCodeReviewPersistsFetchedCoreSnapshot(t *testing.T) {
 	t.Parallel()
 
@@ -182,7 +200,15 @@ type rateLimitStoreStub struct {
 	metadataID     uuid.UUID
 	now            time.Time
 	decision       models.GitHubRateLimitDecision
+	blockDecision  models.GitHubRateLimitDecision
 	reserveErr     error
+	blockErr       error
+}
+
+func (s *rateLimitStoreStub) CheckCodeReviewBlock(_ context.Context, installationID int64, now time.Time) (models.GitHubRateLimitDecision, error) {
+	s.installationID = installationID
+	s.now = now
+	return s.blockDecision, s.blockErr
 }
 
 func (s *rateLimitStoreStub) Observe(_ context.Context, observation models.GitHubRateLimitObservation) error {

--- a/internal/services/github/service.go
+++ b/internal/services/github/service.go
@@ -13,17 +13,25 @@ import (
 	"sync"
 	"time"
 
+	"github.com/assembledhq/143/internal/models"
 	"github.com/golang-jwt/jwt/v5"
 )
 
 type Service struct {
-	appID        int64
-	privateKey   *rsa.PrivateKey
-	httpClient   *http.Client
-	apiBaseURL   string
-	cache        map[int64]*cachedToken
-	sandboxCache map[sandboxTokenCacheKey]*cachedToken
-	mu           sync.RWMutex
+	appID              int64
+	privateKey         *rsa.PrivateKey
+	httpClient         *http.Client
+	apiBaseURL         string
+	cache              map[int64]*cachedToken
+	sandboxCache       map[sandboxTokenCacheKey]*cachedToken
+	tokenInstallations map[string]installationTokenMetadata
+	rateLimitBudget    *RateBudget
+	mu                 sync.RWMutex
+}
+
+type installationTokenMetadata struct {
+	InstallationID int64
+	ExpiresAt      time.Time
 }
 
 type sandboxTokenCacheKey struct {
@@ -72,13 +80,25 @@ func NewService(appID int64, privateKeyPEM string) (*Service, error) {
 		return nil, fmt.Errorf("parse private key: %w", err)
 	}
 	return &Service{
-		appID:        appID,
-		privateKey:   key,
-		httpClient:   &http.Client{Timeout: 10 * time.Second},
-		apiBaseURL:   "https://api.github.com",
-		cache:        make(map[int64]*cachedToken),
-		sandboxCache: make(map[sandboxTokenCacheKey]*cachedToken),
+		appID:              appID,
+		privateKey:         key,
+		httpClient:         &http.Client{Timeout: 10 * time.Second},
+		apiBaseURL:         "https://api.github.com",
+		cache:              make(map[int64]*cachedToken),
+		sandboxCache:       make(map[sandboxTokenCacheKey]*cachedToken),
+		tokenInstallations: make(map[string]installationTokenMetadata),
 	}, nil
+}
+
+// SetRateLimitBudget enables installation-wide GitHub quota observation for
+// every API client that uses tokens issued by this service.
+func (s *Service) SetRateLimitBudget(budget *RateBudget) {
+	if s == nil {
+		return
+	}
+	s.mu.Lock()
+	s.rateLimitBudget = budget
+	s.mu.Unlock()
 }
 
 func (s *Service) GetInstallationToken(ctx context.Context, installationID int64) (string, error) {
@@ -86,6 +106,7 @@ func (s *Service) GetInstallationToken(ctx context.Context, installationID int64
 	cached, ok := s.cache[installationID]
 	s.mu.RUnlock()
 	if ok && time.Now().Add(5*time.Minute).Before(cached.ExpiresAt) {
+		s.rememberInstallationToken(installationID, cached.Token, cached.ExpiresAt)
 		return cached.Token, nil
 	}
 
@@ -101,6 +122,7 @@ func (s *Service) GetInstallationToken(ctx context.Context, installationID int64
 
 	s.mu.Lock()
 	s.cache[installationID] = &cachedToken{Token: token, ExpiresAt: expiresAt}
+	s.rememberInstallationTokenLocked(installationID, token, expiresAt)
 	s.mu.Unlock()
 
 	return token, nil
@@ -139,6 +161,7 @@ func (s *Service) GetSandboxInstallationToken(ctx context.Context, installationI
 	cached, ok := s.sandboxCache[key]
 	s.mu.RUnlock()
 	if ok && time.Now().Add(5*time.Minute).Before(cached.ExpiresAt) {
+		s.rememberInstallationToken(installationID, cached.Token, cached.ExpiresAt)
 		return cached.Token, nil
 	}
 
@@ -159,8 +182,139 @@ func (s *Service) GetSandboxInstallationToken(ctx context.Context, installationI
 		s.sandboxCache = make(map[sandboxTokenCacheKey]*cachedToken)
 	}
 	s.sandboxCache[key] = &cachedToken{Token: token, ExpiresAt: expiresAt}
+	s.rememberInstallationTokenLocked(installationID, token, expiresAt)
 	s.mu.Unlock()
 	return token, nil
+}
+
+func (s *Service) rememberInstallationToken(installationID int64, token string, expiresAt time.Time) {
+	if s == nil || installationID <= 0 || token == "" {
+		return
+	}
+	s.mu.Lock()
+	s.rememberInstallationTokenLocked(installationID, token, expiresAt)
+	s.mu.Unlock()
+}
+
+func (s *Service) rememberInstallationTokenLocked(installationID int64, token string, expiresAt time.Time) {
+	if s.tokenInstallations == nil {
+		s.tokenInstallations = make(map[string]installationTokenMetadata)
+	}
+	now := time.Now()
+	for cachedToken, metadata := range s.tokenInstallations {
+		if metadata.ExpiresAt.Before(now) {
+			delete(s.tokenInstallations, cachedToken)
+		}
+	}
+	s.tokenInstallations[token] = installationTokenMetadata{InstallationID: installationID, ExpiresAt: expiresAt}
+}
+
+// ObserveRateLimitForToken associates response headers with the installation
+// that owns the token without forcing every downstream GitHub helper to carry
+// installation identity through its call stack.
+func (s *Service) ObserveRateLimitForToken(ctx context.Context, token string, statusCode int, resource string, header http.Header) {
+	s.observeRateLimitForToken(ctx, token, statusCode, resource, header, nil)
+}
+
+func (s *Service) ObserveRateLimitForTokenWithBody(ctx context.Context, token string, statusCode int, resource string, header http.Header, body []byte) {
+	s.observeRateLimitForToken(ctx, token, statusCode, resource, header, body)
+}
+
+func (s *Service) observeRateLimitForToken(ctx context.Context, token string, statusCode int, resource string, header http.Header, body []byte) {
+	if s == nil || token == "" {
+		return
+	}
+	s.mu.RLock()
+	metadata, ok := s.tokenInstallations[token]
+	budget := s.rateLimitBudget
+	s.mu.RUnlock()
+	if !ok || budget == nil {
+		return
+	}
+	budget.ObserveResponseWithBody(ctx, metadata.InstallationID, models.GitHubRateLimitResource(resource), statusCode, header, body)
+}
+
+func (s *Service) observeRateLimit(ctx context.Context, installationID int64, statusCode int, resource models.GitHubRateLimitResource, header http.Header) {
+	s.observeRateLimitWithBody(ctx, installationID, statusCode, resource, header, nil)
+}
+
+func (s *Service) observeRateLimitWithBody(ctx context.Context, installationID int64, statusCode int, resource models.GitHubRateLimitResource, header http.Header, body []byte) {
+	if s == nil {
+		return
+	}
+	s.mu.RLock()
+	budget := s.rateLimitBudget
+	s.mu.RUnlock()
+	if budget != nil {
+		budget.ObserveResponseWithBody(ctx, installationID, resource, statusCode, header, body)
+	}
+}
+
+// FetchRateLimitSnapshot reads GitHub's authenticated quota status endpoint.
+// GitHub documents this endpoint as free of primary-rate-limit cost; callers
+// use it only when the durable observation is missing or stale.
+func (s *Service) FetchRateLimitSnapshot(ctx context.Context, installationID int64) ([]models.GitHubRateLimitObservation, error) {
+	token, err := s.GetInstallationToken(ctx, installationID)
+	if err != nil {
+		return nil, fmt.Errorf("get installation token for GitHub rate-limit snapshot: %w", err)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, s.apiURL("/rate_limit"), nil)
+	if err != nil {
+		return nil, fmt.Errorf("create GitHub rate-limit snapshot request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Accept", "application/vnd.github+json")
+	resp, err := s.httpClient.Do(req) // #nosec G704 -- URL is the configured GitHub API endpoint
+	if err != nil {
+		return nil, fmt.Errorf("fetch GitHub rate-limit snapshot: %w", err)
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("read GitHub rate-limit snapshot: %w", err)
+	}
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		s.ObserveRateLimitForTokenWithBody(ctx, token, resp.StatusCode, string(models.GitHubRateLimitResourceCore), resp.Header, body)
+		return nil, &GitHubAPIError{
+			Method: http.MethodGet, Path: "/rate_limit", StatusCode: resp.StatusCode,
+			Body: body, Header: resp.Header.Clone(),
+		}
+	}
+	var decoded struct {
+		Resources map[string]struct {
+			Limit     int   `json:"limit"`
+			Remaining int   `json:"remaining"`
+			Reset     int64 `json:"reset"`
+		} `json:"resources"`
+	}
+	if err := json.Unmarshal(body, &decoded); err != nil {
+		return nil, fmt.Errorf("decode GitHub rate-limit snapshot: %w", err)
+	}
+	now := time.Now().UTC()
+	resources := []models.GitHubRateLimitResource{
+		models.GitHubRateLimitResourceCore,
+		models.GitHubRateLimitResourceGraphQL,
+		models.GitHubRateLimitResourceSearch,
+	}
+	observations := make([]models.GitHubRateLimitObservation, 0, len(resources))
+	for _, resource := range resources {
+		quota, ok := decoded.Resources[string(resource)]
+		if !ok || quota.Limit <= 0 || quota.Remaining < 0 || quota.Remaining > quota.Limit || quota.Reset <= 0 {
+			continue
+		}
+		limit := quota.Limit
+		remaining := quota.Remaining
+		resetAt := time.Unix(quota.Reset, 0).UTC()
+		observations = append(observations, models.GitHubRateLimitObservation{
+			InstallationID: installationID,
+			Resource:       resource,
+			Limit:          &limit,
+			Remaining:      &remaining,
+			ResetAt:        &resetAt,
+			ObservedAt:     now,
+		})
+	}
+	return observations, nil
 }
 
 func (s *Service) generateJWT() (string, error) {
@@ -271,6 +425,7 @@ func (s *Service) ListOrgMembers(ctx context.Context, installationID int64, orgL
 			return nil, fmt.Errorf("request org members: %w", err)
 		}
 		body, readErr := io.ReadAll(resp.Body)
+		s.observeRateLimitWithBody(ctx, installationID, resp.StatusCode, models.GitHubRateLimitResourceCore, resp.Header, body)
 		closeErr := resp.Body.Close()
 		if readErr != nil {
 			if closeErr != nil {
@@ -310,17 +465,28 @@ func (s *Service) IsActiveOrgMember(ctx context.Context, installationID int64, o
 	if err != nil {
 		return false, fmt.Errorf("request org membership: %w", err)
 	}
-	defer resp.Body.Close()
+	body, readErr := io.ReadAll(resp.Body)
+	s.observeRateLimitWithBody(ctx, installationID, resp.StatusCode, models.GitHubRateLimitResourceCore, resp.Header, body)
+	closeErr := resp.Body.Close()
+	if readErr != nil {
+		if closeErr != nil {
+			return false, fmt.Errorf("read org membership response: %w", errors.Join(readErr, closeErr))
+		}
+		return false, fmt.Errorf("read org membership response: %w", readErr)
+	}
+	if closeErr != nil {
+		return false, fmt.Errorf("close org membership response: %w", closeErr)
+	}
 	if resp.StatusCode == http.StatusNotFound {
 		return false, nil
 	}
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return false, newGitHubAPIResponseError(http.MethodGet, path, resp)
+		return false, &GitHubAPIError{Method: http.MethodGet, Path: path, StatusCode: resp.StatusCode, Body: body, Header: resp.Header.Clone()}
 	}
 	var result struct {
 		State string `json:"state"`
 	}
-	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+	if err := json.Unmarshal(body, &result); err != nil {
 		return false, fmt.Errorf("decode org membership: %w", err)
 	}
 	return result.State == "active", nil

--- a/internal/services/github/service_test.go
+++ b/internal/services/github/service_test.go
@@ -8,12 +8,15 @@ import (
 	"encoding/json"
 	"encoding/pem"
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/assembledhq/143/internal/models"
+	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/require"
 )
 
@@ -82,6 +85,54 @@ func TestNewService(t *testing.T) {
 	}
 }
 
+func TestServiceObserveRateLimitForTokenResolvesInstallation(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 7, 21, 18, 0, 0, 0, time.UTC)
+	store := &rateLimitStoreStub{}
+	budget := NewRateBudget(store, zerolog.Nop())
+	budget.now = func() time.Time { return now }
+	svc := &Service{
+		tokenInstallations: map[string]installationTokenMetadata{
+			"ghs_installation": {InstallationID: 143, ExpiresAt: now.Add(time.Hour)},
+		},
+		rateLimitBudget: budget,
+	}
+
+	svc.ObserveRateLimitForToken(context.Background(), "ghs_installation", http.StatusOK, "core",
+		githubRateHeaders("core", 5000, 4321, now.Add(time.Hour)))
+
+	require.Equal(t, int64(143), store.observation.InstallationID, "token observations should be charged to the issuing installation")
+	require.Equal(t, models.GitHubRateLimitResourceCore, store.observation.Resource, "REST responses should update the core budget")
+	require.Equal(t, 4321, *store.observation.Remaining, "observer should persist GitHub's exact remaining quota")
+}
+
+func TestServiceFetchRateLimitSnapshotParsesResources(t *testing.T) {
+	t.Parallel()
+
+	reset := time.Date(2026, 7, 21, 19, 0, 0, 0, time.UTC)
+	svc := &Service{
+		httpClient: &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			require.Equal(t, "https://api.github.test/rate_limit", req.URL.String(), "snapshot should use GitHub's rate-limit status endpoint")
+			require.Equal(t, "Bearer cached-token", req.Header.Get("Authorization"), "snapshot should authenticate as the installation")
+			body := `{"resources":{"core":{"limit":5000,"remaining":700,"reset":` + fmt.Sprint(reset.Unix()) + `},"graphql":{"limit":5000,"remaining":4500,"reset":` + fmt.Sprint(reset.Unix()) + `}}}`
+			return &http.Response{StatusCode: http.StatusOK, Header: make(http.Header), Body: io.NopCloser(strings.NewReader(body))}, nil
+		})},
+		apiBaseURL:         "https://api.github.test",
+		cache:              map[int64]*cachedToken{143: {Token: "cached-token", ExpiresAt: time.Now().Add(time.Hour)}},
+		tokenInstallations: make(map[string]installationTokenMetadata),
+	}
+
+	observations, err := svc.FetchRateLimitSnapshot(context.Background(), 143)
+
+	require.NoError(t, err, "valid rate-limit status should parse")
+	require.Len(t, observations, 2, "snapshot should return each valid resource reported by GitHub")
+	require.Equal(t, models.GitHubRateLimitResourceCore, observations[0].Resource, "core quota should be first for deterministic persistence")
+	require.Equal(t, 700, *observations[0].Remaining, "snapshot should retain exact core remaining quota")
+	require.Equal(t, models.GitHubRateLimitResourceGraphQL, observations[1].Resource, "snapshot should include GraphQL quota")
+	require.True(t, reset.Equal(*observations[1].ResetAt), "snapshot should parse GitHub's reset epoch")
+}
+
 func TestService_ListOrgMembers_ReturnsBodyCloseError(t *testing.T) {
 	t.Parallel()
 
@@ -116,6 +167,34 @@ func TestService_ListOrgMembers_ReturnsBodyCloseError(t *testing.T) {
 	require.Error(t, err, "ListOrgMembers should return response body close errors")
 	require.ErrorIs(t, err, closeErr, "ListOrgMembers should preserve the close error for callers")
 	require.Nil(t, members, "ListOrgMembers should not return members when response cleanup fails")
+}
+
+func TestServiceListOrgMembersObservesHeaderlessSecondaryLimitBody(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 7, 21, 18, 0, 0, 0, time.UTC)
+	store := &rateLimitStoreStub{}
+	budget := NewRateBudget(store, zerolog.Nop())
+	budget.now = func() time.Time { return now }
+	svc := &Service{
+		httpClient: &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: http.StatusForbidden,
+				Header:     make(http.Header),
+				Body:       io.NopCloser(strings.NewReader(`{"message":"You have exceeded a secondary rate limit"}`)),
+			}, nil
+		})},
+		apiBaseURL:         "https://api.github.test",
+		cache:              map[int64]*cachedToken{143: {Token: "cached-token", ExpiresAt: time.Now().Add(time.Hour)}},
+		tokenInstallations: make(map[string]installationTokenMetadata),
+		rateLimitBudget:    budget,
+	}
+
+	_, err := svc.ListOrgMembers(context.Background(), 143, "assembled")
+
+	require.Error(t, err, "secondary limit should remain visible to roster sync")
+	require.NotNil(t, store.observation.BlockedUntil, "headerless secondary 403 should install a global block")
+	require.Equal(t, now.Add(time.Minute), *store.observation.BlockedUntil, "secondary fallback should block new reviews for one minute")
 }
 
 func TestService_GetInstallationToken_UsesCache(t *testing.T) {

--- a/internal/worker/code_review_handler.go
+++ b/internal/worker/code_review_handler.go
@@ -75,6 +75,10 @@ func newRunCodeReviewHandler(stores *Stores, services *Services, logger zerolog.
 			return fmt.Errorf("org_id and session_id are required")
 		}
 		registerCodeReviewDeadLetterReconciliation(ctx, stores, services, logger, job)
+		stopped, err := reserveQueuedCodeReviewRateLimit(ctx, stores, services, logger, job)
+		if stopped || err != nil {
+			return err
+		}
 		metadata, err := stores.CodeReviews.MarkRunning(ctx, job.OrgID, job.SessionID)
 		if err != nil {
 			if errors.Is(err, pgx.ErrNoRows) {
@@ -275,6 +279,91 @@ func newRunCodeReviewHandler(stores *Stores, services *Services, logger zerolog.
 		event.Str("decision", string(decision.Decision)).Msg("completed code review")
 		reconcileCodeReviewSessionSuccess(ctx, stores, logger, job)
 		return nil
+	}
+}
+
+func reserveQueuedCodeReviewRateLimit(ctx context.Context, stores *Stores, services *Services, logger zerolog.Logger, job runCodeReviewPayload) (bool, error) {
+	if services == nil || services.GitHubRateLimits == nil {
+		return false, nil
+	}
+	if stores == nil || stores.CodeReviews == nil || stores.Repositories == nil || stores.PullRequests == nil {
+		return false, fmt.Errorf("code review stores unavailable for GitHub rate-limit admission")
+	}
+	metadata, err := stores.CodeReviews.GetBySessionID(ctx, job.OrgID, job.SessionID)
+	if err != nil {
+		return false, fmt.Errorf("load code review for GitHub rate-limit admission: %w", err)
+	}
+	if metadata.Status != models.CodeReviewSessionStatusQueued {
+		return false, nil
+	}
+	pr, err := stores.PullRequests.GetByID(ctx, job.OrgID, job.PullRequestID)
+	if err != nil {
+		return false, fmt.Errorf("load pull request for GitHub rate-limit admission: %w", err)
+	}
+	if stopped, err := stopCodeReviewIfParentSessionCancelled(ctx, stores, services, logger, job, pr); stopped || err != nil {
+		return stopped, err
+	}
+	repo, err := stores.Repositories.GetByID(ctx, job.OrgID, job.RepositoryID)
+	if err != nil {
+		return false, fmt.Errorf("load code review repository for GitHub rate-limit admission: %w", err)
+	}
+	installationID := repo.InstallationID
+	if installationID <= 0 {
+		return false, fmt.Errorf("repository %s has no GitHub installation for rate-limit admission", repo.ID)
+	}
+	decision, err := services.GitHubRateLimits.ReserveCodeReview(ctx, job.OrgID, installationID, metadata.ID)
+	if err != nil {
+		return false, fmt.Errorf("reserve GitHub installation quota for code review: %w", err)
+	}
+	if decision.RefreshRequired {
+		logger.Info().
+			Str("org_id", job.OrgID.String()).
+			Str("session_id", job.SessionID.String()).
+			Int64("installation_id", installationID).
+			Msg("refreshing stale GitHub installation quota before code review admission")
+		if err := services.GitHubRateLimits.RefreshCodeReview(ctx, installationID); err != nil {
+			return false, classifyGitHubJobError(fmt.Errorf("refresh GitHub installation quota for code review: %w", err), job.SessionID.String())
+		}
+		decision, err = services.GitHubRateLimits.ReserveCodeReview(ctx, job.OrgID, installationID, metadata.ID)
+		if err != nil {
+			return false, fmt.Errorf("reserve refreshed GitHub installation quota for code review: %w", err)
+		}
+	}
+	if decision.Allowed {
+		return false, nil
+	}
+
+	retryHint := decision.RetryAfter
+	retryAfter := githubRateLimitRetryAfter(&retryHint, job.SessionID.String())
+	retryWindow := githubRateLimitMaxRetryDuration
+	logEvent := logger.Warn().
+		Str("org_id", job.OrgID.String()).
+		Str("session_id", job.SessionID.String()).
+		Int64("installation_id", installationID).
+		Int("rate_limit", decision.Limit).
+		Int("rate_remaining", decision.Remaining).
+		Int("active_reserved", decision.ActiveReserved).
+		Int("recovery_reserve", decision.RecoveryReserve).
+		Bool("bootstrap", decision.Bootstrap).
+		Dur("retry_after", *retryAfter)
+	if !decision.ResetAt.IsZero() {
+		logEvent = logEvent.Time("rate_reset_at", decision.ResetAt)
+	}
+	if !decision.BlockedUntil.IsZero() {
+		logEvent = logEvent.Time("rate_blocked_until", decision.BlockedUntil)
+	}
+	logEvent.Msg("deferring queued code review to preserve GitHub installation quota")
+	reason := fmt.Sprintf("GitHub installation %d quota is being refreshed before code review admission", installationID)
+	if !decision.BlockedUntil.IsZero() {
+		reason = fmt.Sprintf("GitHub installation %d is rate limited until %s", installationID, decision.BlockedUntil.Format(time.RFC3339))
+	} else if decision.Known {
+		reason = fmt.Sprintf("GitHub installation %d has %d of %d core API requests remaining with %d reserved for active reviews; preserving %d for recovery until %s",
+			installationID, decision.Remaining, decision.Limit, decision.ActiveReserved, decision.RecoveryReserve, decision.ResetAt.Format(time.RFC3339))
+	}
+	return false, &RetryableError{
+		Err:              errors.New(reason),
+		RetryAfter:       retryAfter,
+		MaxRetryDuration: &retryWindow,
 	}
 }
 

--- a/internal/worker/code_review_handler.go
+++ b/internal/worker/code_review_handler.go
@@ -75,7 +75,7 @@ func newRunCodeReviewHandler(stores *Stores, services *Services, logger zerolog.
 			return fmt.Errorf("org_id and session_id are required")
 		}
 		registerCodeReviewDeadLetterReconciliation(ctx, stores, services, logger, job)
-		stopped, err := reserveQueuedCodeReviewRateLimit(ctx, stores, services, logger, job)
+		stopped, err := enforceCodeReviewRateLimit(ctx, stores, services, logger, job)
 		if stopped || err != nil {
 			return err
 		}
@@ -282,7 +282,7 @@ func newRunCodeReviewHandler(stores *Stores, services *Services, logger zerolog.
 	}
 }
 
-func reserveQueuedCodeReviewRateLimit(ctx context.Context, stores *Stores, services *Services, logger zerolog.Logger, job runCodeReviewPayload) (bool, error) {
+func enforceCodeReviewRateLimit(ctx context.Context, stores *Stores, services *Services, logger zerolog.Logger, job runCodeReviewPayload) (bool, error) {
 	if services == nil || services.GitHubRateLimits == nil {
 		return false, nil
 	}
@@ -293,15 +293,17 @@ func reserveQueuedCodeReviewRateLimit(ctx context.Context, stores *Stores, servi
 	if err != nil {
 		return false, fmt.Errorf("load code review for GitHub rate-limit admission: %w", err)
 	}
-	if metadata.Status != models.CodeReviewSessionStatusQueued {
+	if metadata.Status != models.CodeReviewSessionStatusQueued && metadata.Status != models.CodeReviewSessionStatusRunning {
 		return false, nil
 	}
-	pr, err := stores.PullRequests.GetByID(ctx, job.OrgID, job.PullRequestID)
-	if err != nil {
-		return false, fmt.Errorf("load pull request for GitHub rate-limit admission: %w", err)
-	}
-	if stopped, err := stopCodeReviewIfParentSessionCancelled(ctx, stores, services, logger, job, pr); stopped || err != nil {
-		return stopped, err
+	if metadata.Status == models.CodeReviewSessionStatusQueued {
+		pr, err := stores.PullRequests.GetByID(ctx, job.OrgID, job.PullRequestID)
+		if err != nil {
+			return false, fmt.Errorf("load pull request for GitHub rate-limit admission: %w", err)
+		}
+		if stopped, err := stopCodeReviewIfParentSessionCancelled(ctx, stores, services, logger, job, pr); stopped || err != nil {
+			return stopped, err
+		}
 	}
 	repo, err := stores.Repositories.GetByID(ctx, job.OrgID, job.RepositoryID)
 	if err != nil {
@@ -311,22 +313,30 @@ func reserveQueuedCodeReviewRateLimit(ctx context.Context, stores *Stores, servi
 	if installationID <= 0 {
 		return false, fmt.Errorf("repository %s has no GitHub installation for rate-limit admission", repo.ID)
 	}
-	decision, err := services.GitHubRateLimits.ReserveCodeReview(ctx, job.OrgID, installationID, metadata.ID)
-	if err != nil {
-		return false, fmt.Errorf("reserve GitHub installation quota for code review: %w", err)
-	}
-	if decision.RefreshRequired {
-		logger.Info().
-			Str("org_id", job.OrgID.String()).
-			Str("session_id", job.SessionID.String()).
-			Int64("installation_id", installationID).
-			Msg("refreshing stale GitHub installation quota before code review admission")
-		if err := services.GitHubRateLimits.RefreshCodeReview(ctx, installationID); err != nil {
-			return false, classifyGitHubJobError(fmt.Errorf("refresh GitHub installation quota for code review: %w", err), job.SessionID.String())
+	var decision models.GitHubRateLimitDecision
+	if metadata.Status == models.CodeReviewSessionStatusRunning {
+		decision, err = services.GitHubRateLimits.CheckCodeReviewBlock(ctx, installationID)
+		if err != nil {
+			return false, fmt.Errorf("check GitHub installation block for running code review: %w", err)
 		}
+	} else {
 		decision, err = services.GitHubRateLimits.ReserveCodeReview(ctx, job.OrgID, installationID, metadata.ID)
 		if err != nil {
-			return false, fmt.Errorf("reserve refreshed GitHub installation quota for code review: %w", err)
+			return false, fmt.Errorf("reserve GitHub installation quota for code review: %w", err)
+		}
+		if decision.RefreshRequired {
+			logger.Info().
+				Str("org_id", job.OrgID.String()).
+				Str("session_id", job.SessionID.String()).
+				Int64("installation_id", installationID).
+				Msg("refreshing stale GitHub installation quota before code review admission")
+			if err := services.GitHubRateLimits.RefreshCodeReview(ctx, installationID); err != nil {
+				return false, classifyGitHubJobError(fmt.Errorf("refresh GitHub installation quota for code review: %w", err), job.SessionID.String())
+			}
+			decision, err = services.GitHubRateLimits.ReserveCodeReview(ctx, job.OrgID, installationID, metadata.ID)
+			if err != nil {
+				return false, fmt.Errorf("reserve refreshed GitHub installation quota for code review: %w", err)
+			}
 		}
 	}
 	if decision.Allowed {
@@ -339,6 +349,7 @@ func reserveQueuedCodeReviewRateLimit(ctx context.Context, stores *Stores, servi
 	logEvent := logger.Warn().
 		Str("org_id", job.OrgID.String()).
 		Str("session_id", job.SessionID.String()).
+		Str("review_status", string(metadata.Status)).
 		Int64("installation_id", installationID).
 		Int("rate_limit", decision.Limit).
 		Int("rate_remaining", decision.Remaining).
@@ -352,7 +363,7 @@ func reserveQueuedCodeReviewRateLimit(ctx context.Context, stores *Stores, servi
 	if !decision.BlockedUntil.IsZero() {
 		logEvent = logEvent.Time("rate_blocked_until", decision.BlockedUntil)
 	}
-	logEvent.Msg("deferring queued code review to preserve GitHub installation quota")
+	logEvent.Msg("deferring code review for GitHub installation rate limit")
 	reason := fmt.Sprintf("GitHub installation %d quota is being refreshed before code review admission", installationID)
 	if !decision.BlockedUntil.IsZero() {
 		reason = fmt.Sprintf("GitHub installation %d is rate limited until %s", installationID, decision.BlockedUntil.Format(time.RFC3339))

--- a/internal/worker/code_review_handler_test.go
+++ b/internal/worker/code_review_handler_test.go
@@ -162,7 +162,7 @@ func TestSyncCodeReviewPullRequestStateClassifiesTransientGitHubFailures(t *test
 	}
 }
 
-func TestReserveQueuedCodeReviewRateLimitDefersBeforeRunning(t *testing.T) {
+func TestEnforceCodeReviewRateLimitDefersQueuedReviewBeforeRunning(t *testing.T) {
 	t.Parallel()
 
 	mock, err := pgxmock.NewPool()
@@ -211,7 +211,7 @@ func TestReserveQueuedCodeReviewRateLimitDefersBeforeRunning(t *testing.T) {
 		RepositoryID: repositoryID, PullRequestID: pullRequestID,
 	}
 
-	stopped, err := reserveQueuedCodeReviewRateLimit(context.Background(), &Stores{
+	stopped, err := enforceCodeReviewRateLimit(context.Background(), &Stores{
 		CodeReviews: db.NewCodeReviewStore(mock), Repositories: db.NewRepositoryStore(mock),
 		PullRequests: db.NewPullRequestStore(mock),
 	}, &Services{GitHubRateLimits: budget}, zerolog.Nop(), job)
@@ -231,7 +231,7 @@ func TestReserveQueuedCodeReviewRateLimitDefersBeforeRunning(t *testing.T) {
 	require.NoError(t, mock.ExpectationsWereMet(), "deferred admission should perform only durable preflight reads")
 }
 
-func TestReserveQueuedCodeReviewRateLimitSkipsRunningReview(t *testing.T) {
+func TestEnforceCodeReviewRateLimitHonorsBlockForRunningReview(t *testing.T) {
 	t.Parallel()
 
 	mock, err := pgxmock.NewPool()
@@ -253,31 +253,58 @@ func TestReserveQueuedCodeReviewRateLimitSkipsRunningReview(t *testing.T) {
 			models.CodeReviewSessionStatusRunning, nil, nil, false, nil, "output-key",
 			nil, nil, nil, nil, nil, nil, now,
 		))
-	budget := &githubRateLimitBudgetStub{decision: models.GitHubRateLimitDecision{Allowed: false}}
+	mock.ExpectQuery("(?s)FROM repositories.*WHERE id = @id AND org_id = @org_id").
+		WithArgs(pgx.NamedArgs{"id": repositoryID, "org_id": orgID}).
+		WillReturnRows(workerRepositoryRows(models.Repository{
+			ID: repositoryID, OrgID: orgID, IntegrationID: uuid.New(), GitHubID: 42,
+			FullName: "acme/repo", DefaultBranch: "main", CloneURL: "https://github.com/acme/repo.git",
+			InstallationID: 143, Status: models.RepositoryStatusActive, Settings: json.RawMessage(`{}`),
+			CreatedAt: now, UpdatedAt: now,
+		}))
+	blockedUntil := now.Add(90 * time.Second)
+	budget := &githubRateLimitBudgetStub{blockDecision: models.GitHubRateLimitDecision{
+		BlockedUntil: blockedUntil,
+		RetryAfter:   90 * time.Second,
+	}}
 
-	stopped, err := reserveQueuedCodeReviewRateLimit(context.Background(), &Stores{
+	stopped, err := enforceCodeReviewRateLimit(context.Background(), &Stores{
 		CodeReviews: db.NewCodeReviewStore(mock), Repositories: db.NewRepositoryStore(mock),
 		PullRequests: db.NewPullRequestStore(mock),
 	}, &Services{GitHubRateLimits: budget}, zerolog.Nop(), runCodeReviewPayload{
 		OrgID: orgID, SessionID: sessionID, RepositoryID: repositoryID, PullRequestID: pullRequestID,
 	})
 
-	require.NoError(t, err, "running reviews should retain access to recovery quota")
-	require.False(t, stopped, "running reviews should continue through their normal workflow")
+	var retryable *RetryableError
+	require.ErrorAs(t, err, &retryable, "running review retries should defer while the installation has a shared secondary block")
+	require.Equal(t, githubRateLimitMaxRetryDuration, *retryable.MaxRetryDuration, "secondary-limit waits should remain bounded")
+	expectedDelay := githubRateLimitRetryAfter(&budget.blockDecision.RetryAfter, sessionID.String())
+	require.Equal(t, *expectedDelay, *retryable.RetryAfter, "running review should honor the shared block with stable jitter")
+	require.False(t, stopped, "secondary-limit deferral should leave the running review available for retry")
 	require.Equal(t, 0, budget.calls, "running reviews should not request a second reservation")
-	require.NoError(t, mock.ExpectationsWereMet(), "running admission should only inspect durable review state")
+	require.Equal(t, 1, budget.blockCalls, "running reviews should check the installation-wide block before making more GitHub calls")
+	require.Equal(t, int64(143), budget.installationID, "the block check should use the repository installation consumed by the review")
+	require.NoError(t, mock.ExpectationsWereMet(), "running admission should inspect review and repository identity")
 }
 
 type githubRateLimitBudgetStub struct {
 	decision         models.GitHubRateLimitDecision
+	blockDecision    models.GitHubRateLimitDecision
 	reserveDecisions []models.GitHubRateLimitDecision
 	err              error
+	blockErr         error
 	calls            int
+	blockCalls       int
 	refreshCalls     int
 	refreshErr       error
 	orgID            uuid.UUID
 	installationID   int64
 	metadataID       uuid.UUID
+}
+
+func (s *githubRateLimitBudgetStub) CheckCodeReviewBlock(_ context.Context, installationID int64) (models.GitHubRateLimitDecision, error) {
+	s.blockCalls++
+	s.installationID = installationID
+	return s.blockDecision, s.blockErr
 }
 
 func (s *githubRateLimitBudgetStub) ReserveCodeReview(_ context.Context, orgID uuid.UUID, installationID int64, metadataID uuid.UUID) (models.GitHubRateLimitDecision, error) {

--- a/internal/worker/code_review_handler_test.go
+++ b/internal/worker/code_review_handler_test.go
@@ -162,6 +162,141 @@ func TestSyncCodeReviewPullRequestStateClassifiesTransientGitHubFailures(t *test
 	}
 }
 
+func TestReserveQueuedCodeReviewRateLimitDefersBeforeRunning(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "pgxmock should initialize")
+	defer mock.Close()
+
+	orgID := uuid.New()
+	sessionID := uuid.MustParse("00000000-0000-0000-0000-000000000143")
+	metadataID := uuid.New()
+	repositoryID := uuid.New()
+	pullRequestID := uuid.New()
+	policyID := uuid.New()
+	now := time.Date(2026, 7, 21, 18, 0, 0, 0, time.UTC)
+	reset := now.Add(30 * time.Minute)
+	mock.ExpectQuery("FROM code_review_session_metadata").
+		WithArgs(pgx.NamedArgs{"org_id": orgID, "session_id": sessionID}).
+		WillReturnRows(newCodeReviewMetadataRows().AddRow(
+			metadataID, orgID, sessionID, repositoryID, pullRequestID, policyID,
+			"base", "head", false, models.CodeReviewTriggerSourceTeamReviewer,
+			models.CodeReviewSessionStatusQueued, nil, nil, false, nil, "output-key",
+			nil, nil, nil, nil, nil, nil, now,
+		))
+	mock.ExpectQuery("(?s)FROM pull_requests.*WHERE id = @id AND org_id = @org_id").
+		WithArgs(pgx.NamedArgs{"id": pullRequestID, "org_id": orgID}).
+		WillReturnRows(pgxmock.NewRows(workerPullRequestColumns).AddRow(
+			workerPullRequestRow(pullRequestID, sessionID, orgID, "acme/repo", "feature", now)...,
+		))
+	mock.ExpectQuery("(?s)FROM repositories.*WHERE id = @id AND org_id = @org_id").
+		WithArgs(pgx.NamedArgs{"id": repositoryID, "org_id": orgID}).
+		WillReturnRows(workerRepositoryRows(models.Repository{
+			ID: repositoryID, OrgID: orgID, IntegrationID: uuid.New(), GitHubID: 42,
+			FullName: "acme/repo", DefaultBranch: "main", CloneURL: "https://github.com/acme/repo.git",
+			InstallationID: 143, Status: models.RepositoryStatusActive, Settings: json.RawMessage(`{}`),
+			CreatedAt: now, UpdatedAt: now,
+		}))
+	lowDecision := models.GitHubRateLimitDecision{
+		Known: true, Limit: 5000, Remaining: 900, ActiveReserved: 400,
+		RecoveryReserve: 500, ResetAt: reset, RetryAfter: 30 * time.Minute,
+	}
+	budget := &githubRateLimitBudgetStub{reserveDecisions: []models.GitHubRateLimitDecision{
+		{Bootstrap: true, RefreshRequired: true},
+		lowDecision,
+	}}
+	job := runCodeReviewPayload{
+		OrgID: orgID, SessionID: sessionID, MetadataID: metadataID,
+		RepositoryID: repositoryID, PullRequestID: pullRequestID,
+	}
+
+	stopped, err := reserveQueuedCodeReviewRateLimit(context.Background(), &Stores{
+		CodeReviews: db.NewCodeReviewStore(mock), Repositories: db.NewRepositoryStore(mock),
+		PullRequests: db.NewPullRequestStore(mock),
+	}, &Services{GitHubRateLimits: budget}, zerolog.Nop(), job)
+
+	require.False(t, stopped, "quota deferral should leave the queued review available for retry")
+	var retryable *RetryableError
+	require.ErrorAs(t, err, &retryable, "low installation capacity should defer before the review is marked running")
+	require.False(t, retryable.ConsumeAttempt, "quota admission should not consume the normal job attempt budget")
+	require.Equal(t, githubRateLimitMaxRetryDuration, *retryable.MaxRetryDuration, "quota admission should remain bounded so persistent failures surface")
+	expectedDelay := githubRateLimitRetryAfter(&lowDecision.RetryAfter, sessionID.String())
+	require.Equal(t, *expectedDelay, *retryable.RetryAfter, "quota admission should honor reset time with stable per-session jitter")
+	require.Equal(t, orgID, budget.orgID, "admission should retain tenant ownership")
+	require.Equal(t, int64(143), budget.installationID, "admission should reserve the same repository installation used by review GitHub calls")
+	require.Equal(t, metadataID, budget.metadataID, "admission should be idempotent for the queued review")
+	require.Equal(t, 2, budget.calls, "bootstrap admission should re-check the durable budget after refresh")
+	require.Equal(t, 1, budget.refreshCalls, "stale quota should trigger exactly one pre-start snapshot refresh")
+	require.NoError(t, mock.ExpectationsWereMet(), "deferred admission should perform only durable preflight reads")
+}
+
+func TestReserveQueuedCodeReviewRateLimitSkipsRunningReview(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "pgxmock should initialize")
+	defer mock.Close()
+
+	orgID := uuid.New()
+	sessionID := uuid.New()
+	metadataID := uuid.New()
+	repositoryID := uuid.New()
+	pullRequestID := uuid.New()
+	policyID := uuid.New()
+	now := time.Now().UTC()
+	mock.ExpectQuery("FROM code_review_session_metadata").
+		WithArgs(pgx.NamedArgs{"org_id": orgID, "session_id": sessionID}).
+		WillReturnRows(newCodeReviewMetadataRows().AddRow(
+			metadataID, orgID, sessionID, repositoryID, pullRequestID, policyID,
+			"base", "head", false, models.CodeReviewTriggerSourceTeamReviewer,
+			models.CodeReviewSessionStatusRunning, nil, nil, false, nil, "output-key",
+			nil, nil, nil, nil, nil, nil, now,
+		))
+	budget := &githubRateLimitBudgetStub{decision: models.GitHubRateLimitDecision{Allowed: false}}
+
+	stopped, err := reserveQueuedCodeReviewRateLimit(context.Background(), &Stores{
+		CodeReviews: db.NewCodeReviewStore(mock), Repositories: db.NewRepositoryStore(mock),
+		PullRequests: db.NewPullRequestStore(mock),
+	}, &Services{GitHubRateLimits: budget}, zerolog.Nop(), runCodeReviewPayload{
+		OrgID: orgID, SessionID: sessionID, RepositoryID: repositoryID, PullRequestID: pullRequestID,
+	})
+
+	require.NoError(t, err, "running reviews should retain access to recovery quota")
+	require.False(t, stopped, "running reviews should continue through their normal workflow")
+	require.Equal(t, 0, budget.calls, "running reviews should not request a second reservation")
+	require.NoError(t, mock.ExpectationsWereMet(), "running admission should only inspect durable review state")
+}
+
+type githubRateLimitBudgetStub struct {
+	decision         models.GitHubRateLimitDecision
+	reserveDecisions []models.GitHubRateLimitDecision
+	err              error
+	calls            int
+	refreshCalls     int
+	refreshErr       error
+	orgID            uuid.UUID
+	installationID   int64
+	metadataID       uuid.UUID
+}
+
+func (s *githubRateLimitBudgetStub) ReserveCodeReview(_ context.Context, orgID uuid.UUID, installationID int64, metadataID uuid.UUID) (models.GitHubRateLimitDecision, error) {
+	s.calls++
+	s.orgID = orgID
+	s.installationID = installationID
+	s.metadataID = metadataID
+	if s.calls <= len(s.reserveDecisions) {
+		return s.reserveDecisions[s.calls-1], s.err
+	}
+	return s.decision, s.err
+}
+
+func (s *githubRateLimitBudgetStub) RefreshCodeReview(_ context.Context, installationID int64) error {
+	s.refreshCalls++
+	s.installationID = installationID
+	return s.refreshErr
+}
+
 func TestCodeReviewDeadLetterReconciliationFailsMetadata(t *testing.T) {
 	t.Parallel()
 

--- a/internal/worker/handlers.go
+++ b/internal/worker/handlers.go
@@ -793,6 +793,7 @@ type codeReviewLifecycle interface {
 
 type githubRateLimitBudget interface {
 	ReserveCodeReview(ctx context.Context, orgID uuid.UUID, installationID int64, metadataID uuid.UUID) (models.GitHubRateLimitDecision, error)
+	CheckCodeReviewBlock(ctx context.Context, installationID int64) (models.GitHubRateLimitDecision, error)
 	RefreshCodeReview(ctx context.Context, installationID int64) error
 }
 

--- a/internal/worker/handlers.go
+++ b/internal/worker/handlers.go
@@ -791,6 +791,11 @@ type codeReviewLifecycle interface {
 	HandleReviewChanged(ctx context.Context, input codereviewsvc.ReviewChangedInput) (codereviewsvc.ReviewRequestedResult, error)
 }
 
+type githubRateLimitBudget interface {
+	ReserveCodeReview(ctx context.Context, orgID uuid.UUID, installationID int64, metadataID uuid.UUID) (models.GitHubRateLimitDecision, error)
+	RefreshCodeReview(ctx context.Context, installationID int64) error
+}
+
 type codingAgentAvailability interface {
 	IsAgentAvailable(ctx context.Context, orgID uuid.UUID, userID *uuid.UUID, agentType models.AgentType, model string) (bool, error)
 }
@@ -819,6 +824,7 @@ type Services struct {
 	PagerDutyWrites     pagerDutyPRWritebacker        // nil-safe: PagerDuty writeback disabled if nil
 	CodeReviews         codeReviewSubmitter           // nil-safe: GitHub review submission disabled if nil
 	CodeReviewLifecycle codeReviewLifecycle           // nil-safe: starts durable follow-up assessments after webhook changes
+	GitHubRateLimits    githubRateLimitBudget         // nil-safe: reserves installation quota before starting queued reviews
 	CodingAgents        codingAgentAvailability       // nil-safe: code review falls back to the configured roster when nil
 	SlackbotMetrics     *metrics.SlackbotMetrics      // nil-safe: Slackbot observability disabled if nil
 	// Redis is optional and used for non-authoritative shared caches such as

--- a/migrations/000255_github_installation_rate_budgets.down.sql
+++ b/migrations/000255_github_installation_rate_budgets.down.sql
@@ -1,0 +1,3 @@
+DROP TABLE IF EXISTS github_installation_rate_reservations;
+DROP INDEX IF EXISTS idx_code_review_metadata_org_id;
+DROP TABLE IF EXISTS github_installation_rate_limits;

--- a/migrations/000255_github_installation_rate_budgets.up.sql
+++ b/migrations/000255_github_installation_rate_budgets.up.sql
@@ -1,0 +1,66 @@
+-- Repository-only legacy records predate integration.config.installation_id.
+-- Preserve their ability to run reviews by materializing the shared
+-- installation identity before rate-limit rows add their foreign keys.
+INSERT INTO github_installations (installation_id, account_id, account_login, status)
+SELECT
+    repository.installation_id,
+    0,
+    COALESCE(NULLIF(split_part(MIN(repository.full_name), '/', 1), ''), 'unknown'),
+    'active'
+FROM repositories repository
+WHERE repository.installation_id > 0
+GROUP BY repository.installation_id
+ON CONFLICT (installation_id) DO NOTHING;
+
+CREATE TABLE github_installation_rate_limits (
+    -- lint:no-org-id reason="GitHub rate limits are global per App installation and shared across linked 143 organizations"
+    installation_id bigint      NOT NULL REFERENCES github_installations(installation_id) ON DELETE CASCADE,
+    resource        text        NOT NULL,
+    limit_count     integer,
+    remaining_count integer,
+    reset_at        timestamptz,
+    blocked_until   timestamptz,
+    observed_at     timestamptz NOT NULL,
+    bootstrap_metadata_id uuid,
+    bootstrap_reserved_at timestamptz,
+    PRIMARY KEY (installation_id, resource),
+    CONSTRAINT chk_github_installation_rate_limits_resource
+        CHECK (resource IN ('core', 'graphql', 'search', 'unknown')),
+    CONSTRAINT chk_github_installation_rate_limits_counts
+        CHECK (
+            (limit_count IS NULL AND remaining_count IS NULL AND reset_at IS NULL)
+            OR
+            (limit_count > 0 AND remaining_count >= 0 AND remaining_count <= limit_count AND reset_at IS NOT NULL)
+        ),
+    CONSTRAINT chk_github_installation_rate_limits_bootstrap
+        CHECK (
+            (bootstrap_metadata_id IS NULL AND bootstrap_reserved_at IS NULL)
+            OR
+            (bootstrap_metadata_id IS NOT NULL AND bootstrap_reserved_at IS NOT NULL)
+        )
+);
+
+CREATE UNIQUE INDEX idx_code_review_metadata_org_id
+    ON code_review_session_metadata (org_id, id);
+
+CREATE TABLE github_installation_rate_reservations (
+    id                 uuid        PRIMARY KEY DEFAULT gen_random_uuid(),
+    org_id             uuid        NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+    installation_id    bigint      NOT NULL REFERENCES github_installations(installation_id) ON DELETE CASCADE,
+    code_review_metadata_id uuid    NOT NULL,
+    resource           text        NOT NULL,
+    reserved_units     integer     NOT NULL CHECK (reserved_units > 0),
+    created_at         timestamptz NOT NULL DEFAULT now(),
+    released_at        timestamptz,
+    CONSTRAINT fk_github_rate_reservation_metadata
+        FOREIGN KEY (org_id, code_review_metadata_id)
+        REFERENCES code_review_session_metadata (org_id, id) ON DELETE CASCADE,
+    CONSTRAINT chk_github_installation_rate_reservations_resource
+        CHECK (resource IN ('core', 'graphql', 'search', 'unknown')),
+    CONSTRAINT uq_github_installation_rate_reservation
+        UNIQUE (installation_id, code_review_metadata_id, resource)
+);
+
+CREATE INDEX idx_github_installation_rate_reservations_active
+    ON github_installation_rate_reservations (installation_id, resource, code_review_metadata_id)
+    WHERE released_at IS NULL;


### PR DESCRIPTION
## Summary

- add durable GitHub installation-wide rate-limit observations and active code-review reservations
- refresh unknown or stale budgets through GitHub's `/rate_limit` endpoint before a review starts
- serialize admission per installation, preserve a recovery floor, and propagate primary/secondary rate-limit blocks across workers and organizations
- observe GitHub responses from code-review, repository-list, team-search, and organization-membership paths
- backfill and defensively materialize legacy repository-only installation records
- release terminal reservations so completed reviews no longer consume the active budget

## Why

GitHub App quotas are shared by installation, but code-review workers previously made admission decisions independently. Multiple organizations or workers could therefore consume the same installation quota concurrently, while stale or missing observations allowed expensive reviews to start during quota pressure. A secondary-rate-limit response also was not consistently surfaced as an installation-wide block.

This change makes admission a durable, installation-scoped decision before a review is marked running.

## Safety invariants

- PostgreSQL advisory locks serialize observations and reservations per installation.
- Same-window observations can only reduce remaining quota; a newer reset window replaces the prior one.
- Unknown or stale observations grant one short refresh lease, not a speculative full-review reservation.
- The worker refreshes and re-runs admission before starting work.
- Known-budget admission reserves 100 core requests and keeps at least the larger of 500 requests or 10% of the limit available.
- Secondary limits block all resources for the installation; search primary exhaustion does not incorrectly block core.
- Existing reservations remain subject to newly observed installation blocks.
- Only active reservations count, and terminal review runs release their reservation.

## Verification

- `go test ./...`
- `go vet ./...`
- `go test -race ./internal/db ./internal/services/github ./internal/services/codereview`
- `make lint-tenancy`
- full integration suite against a fresh PostgreSQL 17 database, including concurrent admission, refresh-lease serialization, out-of-order observations, terminal reservation release, and legacy installation materialization
