### PR TITLE
Fix fieldset overflow and button text wrapping on narrow viewports

### DIFF
--- a/frontend/src/app/(dashboard)/code-reviews/page.tsx
+++ b/frontend/src/app/(dashboard)/code-reviews/page.tsx
@@ -1412,7 +1412,7 @@ function AdvancedPolicyControls({ children, forceOpen, onOpened }: { children: R
     <Collapsible open={open || forceOpen} onOpenChange={(next) => { setOpen(next); if (next) onOpened(); }} className="rounded-md border border-border">
       <div className="flex items-center gap-1 border-border pr-3">
         <CollapsibleTrigger asChild>
-          <Button variant="ghost" className="group h-auto min-w-0 flex-1 justify-between rounded-md p-4 text-left sm:h-auto" aria-label="Advanced controls">
+          <Button variant="ghost" className="group h-auto min-w-0 flex-1 justify-between whitespace-normal rounded-md p-4 text-left sm:h-auto" aria-label="Advanced controls">
             <span className="min-w-0">
               <span className="block text-sm font-medium text-foreground">Advanced controls</span>
               <span className="mt-0.5 block text-xs font-normal text-muted-foreground">Safety gates, paths, agents, limits, and structured checks</span>

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -297,6 +297,13 @@
     font-family: var(--font-display);
     @apply tracking-[-0.025em];
   }
+  /* Fieldsets default to min-inline-size: min-content, so any child that
+     cannot wrap (e.g. a whitespace-nowrap button label) widens the fieldset
+     past its container and pushes content off-screen on narrow viewports.
+     Let fieldsets shrink like ordinary block containers. */
+  fieldset {
+    min-inline-size: 0;
+  }
   /* Prevent iOS Safari from auto-zooming when focusing form fields. Triggered
      when computed font-size is <16px. Scoped to mobile widths so desktop
      typography is unchanged. */


### PR DESCRIPTION
## Summary

Fieldsets have a default `min-inline-size: min-content` that prevents child elements with `whitespace-nowrap` from wrapping, causing content to overflow and push off-screen on narrow viewports. This fix allows fieldsets to shrink like normal block containers, and updates the Advanced controls button to use `whitespace-normal` so its multi-line label wraps properly on mobile.

## Changes

- Added `min-inline-size: 0` to fieldset styles to allow proper shrinking on narrow viewports
- Added `whitespace-normal` class to Advanced controls button to enable text wrapping of the multi-line label
- Includes detailed comment explaining the fieldset overflow issue and solution

## Validation

No testing needed. This is a CSS layout fix for responsive behavior on mobile viewports. The changes are straightforward style adjustments that improve text wrapping and prevent overflow on narrow screens.

https://claude.ai/code/session_01NXGnWwNVfA5q7Er9uSrV1P