### PR TITLE
Configure reasoning levels independently for reviewers and orchestrator

### DIFF
--- a/docs/design/implemented/112-code-reviewer-bot-auto-approval.md
+++ b/docs/design/implemented/112-code-reviewer-bot-auto-approval.md
@@ -78,7 +78,7 @@ Recommended v1 scope:
 - Normal 143 code review sessions keyed by org, repository, PR, head SHA, and policy version.
 - Editable PR-description policy and acceptable-risk starter templates.
 - Two reviewer agents plus one orchestrator by default.
-- One policy-versioned reasoning-effort setting applies across reviewer and orchestrator execution; omitted legacy values resolve to `high`.
+- Each reviewer has a policy-versioned reasoning-effort value aligned by index with `reviewers` and `reviewer_models`; the orchestrator keeps its own `reasoning_effort`. Omitted legacy reviewer values inherit the former roster-wide value, or `high` when that value is also absent.
 - GitHub final review with summary body and a configurable number of inline comments.
 - Approval only for acceptable PRs; otherwise comment with escalation reasons.
 - Idempotent reruns for duplicate requests, stale heads, and GitHub review retries.
@@ -530,6 +530,12 @@ code_review_policies (
     inline_comment_limit int not null default 4,
     created_at timestamptz not null default now()
 );
+
+-- Reviewer tabs persist their policy-captured override here so the generic
+-- thread worker can execute each reviewer independently of the parent
+-- orchestrator session's reasoning level.
+ALTER TABLE session_threads
+    ADD COLUMN reasoning_effort text;
 
 code_review_session_metadata (
     id uuid primary key,

--- a/docs/public/guides/code-review-policy.mdx
+++ b/docs/public/guides/code-review-policy.mdx
@@ -34,7 +34,7 @@ Once 143 submits an approval, that approval is final for the PR: later changes a
 
 Use a prompt example when it matches your intent. Previewing and applying an example replaces only its corresponding prompt; it never changes enablement, outcome, reviewers, paths, thresholds, or safety gates. Advanced policy presets are different: they replace the complete policy, including safeguards and agent settings.
 
-Under **Advanced controls → Reviewers & agents**, choose the reasoning level used for the review run. The default is **High**. The setting applies to each reviewer and the orchestrator when its selected agent supports explicit reasoning levels.
+Under **Advanced controls → Reviewers & agents**, choose a reasoning level beside each reviewer model. Reviewers can use different levels in the same run. The default is **High**, and the available choices follow the agent selected in that row. Configure the orchestrator's reasoning separately beside its model.
 
 ## Apply one policy everywhere
 

--- a/frontend/src/app/(dashboard)/code-reviews/page.test.tsx
+++ b/frontend/src/app/(dashboard)/code-reviews/page.test.tsx
@@ -108,6 +108,7 @@ const policy: CodeReviewResolvedPolicy = {
       reviewers: ["codex", "claude_code"],
       orchestrator: "claude_code",
       reviewer_models: ["gpt-5.4", "claude-sonnet-4-6"],
+      reviewer_reasoning_efforts: ["high", "high"],
       orchestrator_model: "claude-sonnet-4-6",
       reasoning_effort: "high",
       disagreement_blocks: true,
@@ -465,7 +466,9 @@ describe("CodeReviewsPage", () => {
     expect(await screen.findByRole("combobox", { name: "Reviewer 1 model" })).toBeInTheDocument();
     expect(screen.getByRole("combobox", { name: "Reviewer 2 model" })).toBeInTheDocument();
     expect(screen.getByRole("combobox", { name: "Orchestrator model" })).toBeInTheDocument();
-    expect(screen.getByRole("combobox", { name: "Reasoning level" })).toHaveTextContent("High");
+    expect(screen.getByRole("combobox", { name: "Reviewer 1 reasoning level" })).toHaveTextContent("High");
+    expect(screen.getByRole("combobox", { name: "Reviewer 2 reasoning level" })).toHaveTextContent("High");
+    expect(screen.getByRole("combobox", { name: "Orchestrator reasoning level" })).toHaveTextContent("High");
 
     // Autosave: applying a template persists without a Save button.
     await user.click(screen.getByRole("combobox", { name: /Advanced policy preset/i }));
@@ -853,7 +856,7 @@ describe("CodeReviewsPage", () => {
     expect(screen.getByRole("radio", { name: /^Approve acceptable PRs/i })).toBeChecked();
   });
 
-  it("saves the code review reasoning level", async () => {
+  it("saves independent reasoning levels for each reviewer", async () => {
     const user = userEvent.setup();
     const state = mockCodeReviewBaseHandlers();
 
@@ -861,11 +864,26 @@ describe("CodeReviewsPage", () => {
     await user.click(await screen.findByRole("tab", { name: /Policy/i }));
     await user.click(screen.getByRole("button", { name: "Advanced controls" }));
     await user.click(screen.getByRole("button", { name: /Reviewers & agents/i }));
-    await user.click(await screen.findByRole("combobox", { name: "Reasoning level" }));
+    await user.click(await screen.findByRole("combobox", { name: "Reviewer 1 reasoning level" }));
     await user.click(await screen.findByRole("option", { name: "Extra high" }));
 
     await waitFor(() => {
-      expect(state.getCurrentConfig().agent_roster.reasoning_effort).toBe("xhigh");
+      expect(state.getCurrentConfig().agent_roster.reviewer_reasoning_efforts).toEqual(["xhigh", "high"]);
+      expect(state.getCurrentConfig().agent_roster.reasoning_effort).toBe("high");
+    });
+
+    await user.click(screen.getByRole("combobox", { name: "Reviewer 2 reasoning level" }));
+    await user.click(await screen.findByRole("option", { name: "Max" }));
+
+    await waitFor(() => {
+      expect(state.getCurrentConfig().agent_roster.reviewer_reasoning_efforts).toEqual(["xhigh", "max"]);
+    });
+
+    await user.click(screen.getByRole("button", { name: "Remove reviewer 1" }));
+    await waitFor(() => {
+      expect(state.getCurrentConfig().agent_roster.reviewers).toEqual(["claude_code"]);
+      expect(state.getCurrentConfig().agent_roster.reviewer_models).toEqual(["claude-sonnet-4-6"]);
+      expect(state.getCurrentConfig().agent_roster.reviewer_reasoning_efforts).toEqual(["max"]);
     });
   });
 
@@ -877,6 +895,7 @@ describe("CodeReviewsPage", () => {
         ...policy.config.agent_roster,
         reviewers: ["claude_code"],
         reviewer_models: ["claude-sonnet-4-6"],
+        reviewer_reasoning_efforts: ["max"],
         orchestrator: "claude_code",
         orchestrator_model: "claude-sonnet-4-6",
         reasoning_effort: "max",
@@ -910,7 +929,7 @@ describe("CodeReviewsPage", () => {
     await user.click(screen.getByRole("button", { name: "Advanced controls" }));
     await user.click(screen.getByRole("button", { name: /Reviewers & agents/i }));
 
-    const reasoningSelect = await screen.findByRole("combobox", { name: "Reasoning level" });
+    const reasoningSelect = await screen.findByRole("combobox", { name: "Reviewer 1 reasoning level" });
     expect(reasoningSelect).toHaveTextContent("Max");
     await user.click(reasoningSelect);
     expect(await screen.findByRole("option", { name: "Max" })).toBeInTheDocument();
@@ -921,7 +940,8 @@ describe("CodeReviewsPage", () => {
 
     await waitFor(() => {
       expect(state.getCurrentConfig().agent_roster.reviewers).toEqual(["codex"]);
-      expect(state.getCurrentConfig().agent_roster.reasoning_effort).toBe("high");
+      expect(state.getCurrentConfig().agent_roster.reviewer_reasoning_efforts).toEqual(["high"]);
+      expect(state.getCurrentConfig().agent_roster.reasoning_effort).toBe("max");
     });
   });
 

--- a/frontend/src/app/(dashboard)/code-reviews/page.tsx
+++ b/frontend/src/app/(dashboard)/code-reviews/page.tsx
@@ -327,21 +327,32 @@ function ensureReviewerModels(config: CodeReviewPolicyConfig, modelGroups: Agent
 
 type CodeReviewReasoningEffort = NonNullable<CodeReviewPolicyConfig["agent_roster"]["reasoning_effort"]>;
 
-function reasoningOptionsForRoster(config: CodeReviewPolicyConfig) {
-  const agents = [...config.agent_roster.reviewers, config.agent_roster.orchestrator];
-  return CODE_REVIEW_REASONING_OPTIONS.filter((option) =>
-    agents.every((agent) => {
-      const supported = getCodingAgentReasoningOptions(agent);
-      return supported.length === 0 || supported.some((effort) => effort.value === option.value);
-    }),
+function reasoningOptionsForAgent(agent: string) {
+  const supported = getCodingAgentReasoningOptions(agent);
+  return supported.length > 0
+    ? CODE_REVIEW_REASONING_OPTIONS.filter((option) => supported.some((effort) => effort.value === option.value))
+    : CODE_REVIEW_REASONING_OPTIONS.filter((option) => option.value !== "max");
+}
+
+function normalizeReasoningEffortForAgent(agent: string, effort: CodeReviewReasoningEffort | undefined): CodeReviewReasoningEffort {
+  const current = effort ?? "high";
+  return reasoningOptionsForAgent(agent).some((option) => option.value === current) ? current : "high";
+}
+
+function ensureReviewerReasoningEfforts(config: CodeReviewPolicyConfig): CodeReviewReasoningEffort[] {
+  return config.agent_roster.reviewers.map((agent, index) =>
+    normalizeReasoningEffortForAgent(
+      agent,
+      config.agent_roster.reviewer_reasoning_efforts?.[index] ?? config.agent_roster.reasoning_effort,
+    ),
   );
 }
 
-function normalizeReasoningEffortForRoster(config: CodeReviewPolicyConfig): void {
-  const current = config.agent_roster.reasoning_effort ?? "high";
-  if (!reasoningOptionsForRoster(config).some((option) => option.value === current)) {
-    config.agent_roster.reasoning_effort = "high";
-  }
+function normalizeOrchestratorReasoningEffort(config: CodeReviewPolicyConfig): void {
+  config.agent_roster.reasoning_effort = normalizeReasoningEffortForAgent(
+    config.agent_roster.orchestrator,
+    config.agent_roster.reasoning_effort,
+  );
 }
 
 export default function CodeReviewsPage() {
@@ -2183,18 +2194,18 @@ function AgentRosterControls({
 }) {
   const reviewers = config?.agent_roster.reviewers ?? [];
   const reviewerModels = config ? ensureReviewerModels(config, modelGroups) : [];
+  const reviewerReasoningEfforts = config ? ensureReviewerReasoningEfforts(config) : [];
   const canAddReviewer = Boolean(config) && reviewers.length < MAX_REVIEWER_MODELS && modelGroups.length > 0;
   const fallbackGroup = modelGroups[0];
-  const reasoningOptions = config ? reasoningOptionsForRoster(config) : CODE_REVIEW_REASONING_OPTIONS.filter((option) => option.value !== "max");
   const orchestratorModel =
     config?.agent_roster.orchestrator_model && modelBelongsToAgent(config.agent_roster.orchestrator, config.agent_roster.orchestrator_model)
       ? config.agent_roster.orchestrator_model
       : defaultModelForAgent(config?.agent_roster.orchestrator ?? "", modelGroups);
 
   return (
-    <div className="grid gap-5 lg:grid-cols-[minmax(0,1fr)_minmax(18rem,22rem)]">
+    <div className="space-y-5">
       <div className="space-y-3">
-        <div className="flex items-center justify-between gap-3">
+        <div className="grid items-end gap-3 sm:grid-cols-[minmax(0,1fr)_minmax(10rem,14rem)_auto]">
           <div>
             <SettingLabel
               label="Reviewer models"
@@ -2202,33 +2213,46 @@ function AgentRosterControls({
             />
             <p className="mt-1 text-xs text-muted-foreground">Run one to three independent reviewers. Quorum stays in Approval criteria.</p>
           </div>
-          <Button
-            type="button"
-            size="sm"
-            variant="outline"
-            disabled={!canAddReviewer}
-            onClick={() =>
-              commitPolicy((next) => {
-                if (!fallbackGroup || next.agent_roster.reviewers.length >= MAX_REVIEWER_MODELS) return;
-                const reviewerModels = ensureReviewerModels(next, modelGroups);
-                next.agent_roster.reviewers = [...next.agent_roster.reviewers, fallbackGroup.key];
-                next.agent_roster.reviewer_models = [...reviewerModels, fallbackGroup.models[0] ?? ""];
-                normalizeReasoningEffortForRoster(next);
-              })
-            }
-          >
-            <Plus className="mr-2 h-4 w-4" />
-            Add
-          </Button>
-          <SettingInfoTooltip
-            label="Add reviewer model"
-            description="Adds another independent reviewer agent, up to three. Automatic approval still requires the configured reviewer quorum."
+          <SettingLabel
+            label="Reasoning level"
+            info="Sets reasoning independently for each reviewer. Available levels follow the agent selected in that row; High is the default."
           />
+          <div className="flex items-center gap-1.5">
+            <Button
+              type="button"
+              size="sm"
+              variant="outline"
+              disabled={!canAddReviewer}
+              onClick={() =>
+                commitPolicy((next) => {
+                  if (!fallbackGroup || next.agent_roster.reviewers.length >= MAX_REVIEWER_MODELS) return;
+                  const reviewerModels = ensureReviewerModels(next, modelGroups);
+                  const reasoningEfforts = ensureReviewerReasoningEfforts(next);
+                  next.agent_roster.reviewers = [...next.agent_roster.reviewers, fallbackGroup.key];
+                  next.agent_roster.reviewer_models = [...reviewerModels, fallbackGroup.models[0] ?? ""];
+                  next.agent_roster.reviewer_reasoning_efforts = [
+                    ...reasoningEfforts,
+                    normalizeReasoningEffortForAgent(fallbackGroup.key, "high"),
+                  ];
+                })
+              }
+            >
+              <Plus className="mr-2 h-4 w-4" />
+              Add
+            </Button>
+            <SettingInfoTooltip
+              label="Add reviewer model"
+              description="Adds another independent reviewer agent, up to three. Automatic approval still requires the configured reviewer quorum."
+            />
+          </div>
         </div>
 
         <div className="space-y-2">
           {reviewers.map((agent, index) => (
-            <div key={`${agent}-${index}`} className="grid gap-2 rounded-md border border-border p-3 sm:grid-cols-[1fr_auto]">
+            <div
+              key={`${agent}-${index}`}
+              className="grid gap-2 rounded-md border border-border p-3 sm:grid-cols-[minmax(0,1fr)_minmax(10rem,14rem)_auto]"
+            >
               <AgentModelSelect
                 ariaLabel={`Reviewer ${index + 1} model`}
                 infoDescription="Chooses the agent and model for this independent review slot. Each slot must have a selection; the current resolved default remains until changed and contributes to quorum and disagreement handling."
@@ -2242,10 +2266,26 @@ function AgentRosterControls({
                   commitPolicy((next) => {
                     const selection = parseSelectionValue(value);
                     const reviewerModels = ensureReviewerModels(next, modelGroups);
+                    const reasoningEfforts = ensureReviewerReasoningEfforts(next);
                     next.agent_roster.reviewers[index] = selection.agent;
                     reviewerModels[index] = selection.model;
+                    reasoningEfforts[index] = normalizeReasoningEffortForAgent(selection.agent, reasoningEfforts[index]);
                     next.agent_roster.reviewer_models = reviewerModels;
-                    normalizeReasoningEffortForRoster(next);
+                    next.agent_roster.reviewer_reasoning_efforts = reasoningEfforts;
+                  })
+                }
+              />
+              <ReasoningEffortSelect
+                ariaLabel={`Reviewer ${index + 1} reasoning level`}
+                agent={agent}
+                value={reviewerReasoningEfforts[index] ?? "high"}
+                disabled={disabled}
+                infoDescription="Sets the reasoning effort for this reviewer only. The available levels depend on the agent selected in this row."
+                onValueChange={(value) =>
+                  commitPolicy((next) => {
+                    const reasoningEfforts = ensureReviewerReasoningEfforts(next);
+                    reasoningEfforts[index] = value;
+                    next.agent_roster.reviewer_reasoning_efforts = reasoningEfforts;
                   })
                 }
               />
@@ -2258,8 +2298,10 @@ function AgentRosterControls({
                 onClick={() =>
                   commitPolicy((next) => {
                     const reviewerModels = ensureReviewerModels(next, modelGroups);
+                    const reasoningEfforts = ensureReviewerReasoningEfforts(next);
                     next.agent_roster.reviewers = next.agent_roster.reviewers.filter((_, i) => i !== index);
                     next.agent_roster.reviewer_models = reviewerModels.filter((_, i) => i !== index);
+                    next.agent_roster.reviewer_reasoning_efforts = reasoningEfforts.filter((_, i) => i !== index);
                     next.agent_roster.require_reviewer_quorum = Math.min(
                       next.agent_roster.require_reviewer_quorum,
                       Math.max(1, next.agent_roster.reviewers.length),
@@ -2274,56 +2316,84 @@ function AgentRosterControls({
         </div>
       </div>
 
-      <div className="space-y-3">
-        <div className="space-y-2">
-          <SettingLabel
-            label="Reasoning level"
-            info="Controls the reasoning effort used by every reviewer and the orchestrator when the selected agent supports explicit reasoning. High is the default."
-          />
-          <Select
-            value={config?.agent_roster.reasoning_effort ?? "high"}
+      <div className="space-y-3 border-t border-border pt-4">
+        <div className="grid items-end gap-2 sm:grid-cols-[minmax(0,1fr)_minmax(10rem,14rem)]">
+          <div>
+            <Label className="text-xs text-muted-foreground">Orchestrator model</Label>
+            <p className="mt-1 text-xs text-muted-foreground">Synthesizes reviewer evidence and decides the final review outcome.</p>
+          </div>
+          <Label className="text-xs text-muted-foreground">Reasoning level</Label>
+        </div>
+        <div className="grid gap-2 sm:grid-cols-[minmax(0,1fr)_minmax(10rem,14rem)]">
+          <AgentModelSelect
+            ariaLabel="Orchestrator model"
+            infoDescription="Chooses the agent and model that combines reviewer evidence. A selection is required; the resolved default remains until changed, and its recommendation remains subject to every deterministic safeguard."
+            value={selectionValue(config?.agent_roster.orchestrator ?? "", orchestratorModel)}
+            modelGroups={modelGroups}
+            openCodeAvailability={openCodeAvailability}
+            currentAgent={config?.agent_roster.orchestrator}
+            currentModel={orchestratorModel}
             disabled={disabled}
             onValueChange={(value) =>
               commitPolicy((next) => {
-                next.agent_roster.reasoning_effort = value as CodeReviewReasoningEffort;
+                const selection = parseSelectionValue(value);
+                next.agent_roster.orchestrator = selection.agent;
+                next.agent_roster.orchestrator_model = selection.model;
+                normalizeOrchestratorReasoningEffort(next);
               })
             }
-          >
-            <SelectTrigger aria-label="Reasoning level">
-              <SelectValue />
-            </SelectTrigger>
-            <SelectContent>
-              {reasoningOptions.map((option) => (
-                <SelectItem key={option.value} value={option.value}>
-                  {option.label}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
+          />
+          <ReasoningEffortSelect
+            ariaLabel="Orchestrator reasoning level"
+            agent={config?.agent_roster.orchestrator ?? ""}
+            value={normalizeReasoningEffortForAgent(
+              config?.agent_roster.orchestrator ?? "",
+              config?.agent_roster.reasoning_effort,
+            )}
+            disabled={disabled}
+            infoDescription="Sets reasoning for the orchestrator only; reviewer reasoning is configured independently in each reviewer row."
+            onValueChange={(value) =>
+              commitPolicy((next) => {
+                next.agent_roster.reasoning_effort = value;
+              })
+            }
+          />
         </div>
-        <div>
-          <Label className="text-xs text-muted-foreground">Orchestrator model</Label>
-          <p className="mt-1 text-xs text-muted-foreground">Synthesizes reviewer evidence and decides the final review outcome.</p>
-        </div>
-        <AgentModelSelect
-          ariaLabel="Orchestrator model"
-          infoDescription="Chooses the agent and model that combines reviewer evidence. A selection is required; the resolved default remains until changed, and its recommendation remains subject to every deterministic safeguard."
-          value={selectionValue(config?.agent_roster.orchestrator ?? "", orchestratorModel)}
-          modelGroups={modelGroups}
-          openCodeAvailability={openCodeAvailability}
-          currentAgent={config?.agent_roster.orchestrator}
-          currentModel={orchestratorModel}
-          disabled={disabled}
-          onValueChange={(value) =>
-            commitPolicy((next) => {
-              const selection = parseSelectionValue(value);
-              next.agent_roster.orchestrator = selection.agent;
-              next.agent_roster.orchestrator_model = selection.model;
-              normalizeReasoningEffortForRoster(next);
-            })
-          }
-        />
       </div>
+    </div>
+  );
+}
+
+function ReasoningEffortSelect({
+  ariaLabel,
+  agent,
+  value,
+  disabled,
+  infoDescription,
+  onValueChange,
+}: {
+  ariaLabel: string;
+  agent: string;
+  value: CodeReviewReasoningEffort;
+  disabled?: boolean;
+  infoDescription: string;
+  onValueChange: (value: CodeReviewReasoningEffort) => void;
+}) {
+  return (
+    <div className="flex min-w-0 items-center gap-1.5">
+      <Select value={value} disabled={disabled} onValueChange={(next) => onValueChange(next as CodeReviewReasoningEffort)}>
+        <SelectTrigger aria-label={ariaLabel}>
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          {reasoningOptionsForAgent(agent).map((option) => (
+            <SelectItem key={option.value} value={option.value}>
+              {option.label}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+      <SettingInfoTooltip label={ariaLabel} description={infoDescription} />
     </div>
   );
 }

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -202,6 +202,7 @@ export interface CodeReviewPolicyConfig {
     reviewers: string[];
     orchestrator: string;
     reviewer_models?: string[];
+    reviewer_reasoning_efforts?: ("low" | "medium" | "high" | "xhigh" | "max")[];
     orchestrator_model?: string;
     reasoning_effort?: "low" | "medium" | "high" | "xhigh" | "max";
     disagreement_blocks: boolean;
@@ -1412,6 +1413,7 @@ export interface SessionThread {
   org_id: string;
   agent_type: string;
   model_override?: string;
+  reasoning_effort?: "low" | "medium" | "high" | "xhigh" | "max";
   label: string;
   instructions?: string;
   file_scope?: string[];

--- a/internal/db/session_thread_store.go
+++ b/internal/db/session_thread_store.go
@@ -38,7 +38,7 @@ func (s *SessionThreadStore) SetLogger(logger zerolog.Logger) {
 	s.logger = logger
 }
 
-const sessionThreadSelectColumns = `id, session_id, org_id, agent_type, model_override,
+const sessionThreadSelectColumns = `id, session_id, org_id, agent_type, model_override, reasoning_effort,
 	label, instructions, file_scope, status, agent_session_id, current_turn, last_activity_at,
 	result_summary, diff, failure_explanation, failure_category,
 	started_at, completed_at, created_at, created_by_source, created_by_thread_id, archived_at,
@@ -49,7 +49,7 @@ const sessionThreadSelectColumns = `id, session_id, org_id, agent_type, model_ov
 // sessionThreadListColumns omits the raw diff while preserving a lightweight
 // truthy marker for UI affordances such as "Revert tab". Server-side actions
 // that need the real patch use GetByID and sessionThreadSelectColumns.
-const sessionThreadListColumns = `id, session_id, org_id, agent_type, model_override,
+const sessionThreadListColumns = `id, session_id, org_id, agent_type, model_override, reasoning_effort,
 	label, instructions, file_scope, status, agent_session_id, current_turn, last_activity_at,
 	result_summary,
 	CASE WHEN diff IS NULL THEN NULL ELSE '__diff_present__' END AS diff,
@@ -75,26 +75,27 @@ func (s *SessionThreadStore) Create(ctx context.Context, thread *models.SessionT
 	normalizeSessionThreadExecutionDefaults(thread)
 	query := `
 		INSERT INTO session_threads (
-			session_id, org_id, agent_type, model_override,
+			session_id, org_id, agent_type, model_override, reasoning_effort,
 			label, instructions, file_scope, status, execution_mode, filesystem_mode
 		)
-		SELECT @session_id, @org_id, @agent_type, @model_override,
+		SELECT @session_id, @org_id, @agent_type, @model_override, @reasoning_effort,
 			@label, @instructions, @file_scope, @status, @execution_mode, @filesystem_mode
 		WHERE (SELECT count(*) FROM session_threads WHERE session_id = @session_id AND org_id = @org_id AND archived_at IS NULL) < @max_threads
 		RETURNING id, created_at`
 
 	args := pgx.NamedArgs{
-		"session_id":      thread.SessionID,
-		"org_id":          thread.OrgID,
-		"agent_type":      thread.AgentType,
-		"model_override":  thread.ModelOverride,
-		"label":           thread.Label,
-		"instructions":    thread.Instructions,
-		"file_scope":      thread.FileScope,
-		"status":          thread.Status,
-		"execution_mode":  thread.ExecutionMode,
-		"filesystem_mode": thread.FilesystemMode,
-		"max_threads":     maxThreads,
+		"session_id":       thread.SessionID,
+		"org_id":           thread.OrgID,
+		"agent_type":       thread.AgentType,
+		"model_override":   thread.ModelOverride,
+		"reasoning_effort": thread.ReasoningEffort,
+		"label":            thread.Label,
+		"instructions":     thread.Instructions,
+		"file_scope":       thread.FileScope,
+		"status":           thread.Status,
+		"execution_mode":   thread.ExecutionMode,
+		"filesystem_mode":  thread.FilesystemMode,
+		"max_threads":      maxThreads,
 	}
 
 	row := s.db.QueryRow(ctx, query, args)
@@ -116,11 +117,11 @@ func (s *SessionThreadStore) CreateWithProvenance(ctx context.Context, thread *m
 	}
 	query := `
 		INSERT INTO session_threads (
-			session_id, org_id, agent_type, model_override,
+			session_id, org_id, agent_type, model_override, reasoning_effort,
 			label, instructions, file_scope, status, created_by_source, created_by_thread_id,
 			execution_mode, filesystem_mode
 		)
-		SELECT @session_id, @org_id, @agent_type, @model_override,
+		SELECT @session_id, @org_id, @agent_type, @model_override, @reasoning_effort,
 			@label, @instructions, @file_scope, @status, @created_by_source, @created_by_thread_id,
 			@execution_mode, @filesystem_mode
 		WHERE (SELECT count(*) FROM session_threads WHERE session_id = @session_id AND org_id = @org_id AND archived_at IS NULL) < @max_threads
@@ -131,6 +132,7 @@ func (s *SessionThreadStore) CreateWithProvenance(ctx context.Context, thread *m
 		"org_id":               thread.OrgID,
 		"agent_type":           thread.AgentType,
 		"model_override":       thread.ModelOverride,
+		"reasoning_effort":     thread.ReasoningEffort,
 		"label":                thread.Label,
 		"instructions":         thread.Instructions,
 		"file_scope":           thread.FileScope,
@@ -376,6 +378,7 @@ func (s *SessionThreadStore) UpdateEditable(ctx context.Context, thread *models.
 		UPDATE session_threads
 		SET agent_type = @agent_type,
 		    model_override = @model_override,
+		    reasoning_effort = @reasoning_effort,
 		    label = @label
 		WHERE id = @id
 		  AND org_id = @org_id
@@ -385,12 +388,13 @@ func (s *SessionThreadStore) UpdateEditable(ctx context.Context, thread *models.
 		RETURNING ` + sessionThreadSelectColumns
 
 	rows, err := s.db.Query(ctx, query, pgx.NamedArgs{
-		"id":             thread.ID,
-		"org_id":         thread.OrgID,
-		"session_id":     thread.SessionID,
-		"agent_type":     thread.AgentType,
-		"model_override": thread.ModelOverride,
-		"label":          thread.Label,
+		"id":               thread.ID,
+		"org_id":           thread.OrgID,
+		"session_id":       thread.SessionID,
+		"agent_type":       thread.AgentType,
+		"model_override":   thread.ModelOverride,
+		"reasoning_effort": thread.ReasoningEffort,
+		"label":            thread.Label,
 	})
 	if err != nil {
 		return fmt.Errorf("update editable thread fields: %w", err)

--- a/internal/db/session_thread_store_test.go
+++ b/internal/db/session_thread_store_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 var sessionThreadTestColumns = []string{
-	"id", "session_id", "org_id", "agent_type", "model_override",
+	"id", "session_id", "org_id", "agent_type", "model_override", "reasoning_effort",
 	"label", "instructions", "file_scope", "status", "agent_session_id",
 	"current_turn", "last_activity_at",
 	"result_summary", "diff", "failure_explanation", "failure_category",
@@ -27,7 +27,7 @@ var sessionThreadTestColumns = []string{
 
 func newSessionThreadRow(threadID, sessionID, orgID uuid.UUID, label string, now time.Time) []interface{} {
 	return []interface{}{
-		threadID, sessionID, orgID, "claude_code", nil,
+		threadID, sessionID, orgID, "claude_code", nil, nil,
 		label, nil, nil, "pending", nil,
 		0, nil,
 		nil, nil, nil, nil,
@@ -50,18 +50,22 @@ func TestSessionThreadStore_Create(t *testing.T) {
 	sessionID := uuid.New()
 	orgID := uuid.New()
 	now := time.Now()
+	reasoningEffort := models.ReasoningEffortXHigh
 
-	// Create has 11 named args: session_id, org_id, agent_type, model_override, label, instructions, file_scope, status, execution_mode, filesystem_mode, max_threads
+	// Create has 12 named args, including the optional per-thread reasoning effort.
+	args := anyArgs(12)
+	args[4] = &reasoningEffort
 	mock.ExpectQuery("INSERT INTO session_threads").
-		WithArgs(anyArgs(11)...).
+		WithArgs(args...).
 		WillReturnRows(pgxmock.NewRows([]string{"id", "created_at"}).AddRow(threadID, now))
 
 	thread := &models.SessionThread{
-		SessionID: sessionID,
-		OrgID:     orgID,
-		AgentType: models.AgentTypeClaudeCode,
-		Label:     "Backend API",
-		Status:    models.ThreadStatusPending,
+		SessionID:       sessionID,
+		OrgID:           orgID,
+		AgentType:       models.AgentTypeClaudeCode,
+		ReasoningEffort: &reasoningEffort,
+		Label:           "Backend API",
+		Status:          models.ThreadStatusPending,
 	}
 
 	err = store.Create(context.Background(), thread, 4)
@@ -85,7 +89,7 @@ func TestSessionThreadStore_CreateWithProvenance(t *testing.T) {
 	sourceThreadID := uuid.New()
 	now := time.Now()
 
-	args := append(anyArgs(8), models.ThreadCreatedBySourceAgentTool, &sourceThreadID, models.ThreadExecutionModeWork, models.ThreadFilesystemModeReadWrite, 4)
+	args := append(anyArgs(9), models.ThreadCreatedBySourceAgentTool, &sourceThreadID, models.ThreadExecutionModeWork, models.ThreadFilesystemModeReadWrite, 4)
 	mock.ExpectQuery("INSERT INTO session_threads").
 		WithArgs(args...).
 		WillReturnRows(pgxmock.NewRows([]string{"id", "created_at"}).AddRow(threadID, now))
@@ -370,7 +374,7 @@ func TestSessionThreadStore_GetRetryTarget(t *testing.T) {
 			rows := pgxmock.NewRows(sessionThreadTestColumns)
 			if !tt.expectErr {
 				row := newSessionThreadRow(threadID, sessionID, orgID, "Backend", now)
-				row[8] = tt.rowStatus
+				row[9] = tt.rowStatus
 				rows.AddRow(row...)
 			}
 
@@ -410,8 +414,8 @@ func TestSessionThreadStore_ListStuckRunningThreads(t *testing.T) {
 	// Build a 'running' row variant of the standard test row.
 	row := func(id uuid.UUID) []interface{} {
 		base := newSessionThreadRow(id, sessionID, orgID, "thread", now)
-		base[8] = "running"   // status
-		base[16] = &startedAt // started_at
+		base[9] = "running"   // status
+		base[17] = &startedAt // started_at
 		return base
 	}
 
@@ -484,8 +488,8 @@ func TestSessionThreadStore_Archive(t *testing.T) {
 	threadID := uuid.New()
 	now := time.Now()
 	row := newSessionThreadRow(threadID, sessionID, orgID, "Review", now)
-	row[8] = "completed"
-	row[21] = &now
+	row[9] = "completed"
+	row[22] = &now
 
 	mock.ExpectQuery(`WITH visible_threads AS[\s\S]*FOR UPDATE[\s\S]*UPDATE session_threads[\s\S]*SET archived_at = now\(\)[\s\S]*WHERE id = @id[\s\S]*session_id = @session_id[\s\S]*org_id = @org_id[\s\S]*archived_at IS NULL[\s\S]*RETURNING`).
 		WithArgs(anyArgs(3)...).
@@ -574,12 +578,14 @@ func TestSessionThreadStore_UpdateEditable(t *testing.T) {
 		{
 			name: "updates blank idle threads",
 			setupMock: func(mock pgxmock.PgxPoolIface, orgID, sessionID, threadID uuid.UUID, now time.Time, model string) {
+				reasoningEffort := models.ReasoningEffortHigh
 				row := newSessionThreadRow(threadID, sessionID, orgID, "Codex 2", now)
 				row[3] = "codex"
 				row[4] = &model
-				row[8] = "idle"
+				row[5] = &reasoningEffort
+				row[9] = "idle"
 				mock.ExpectQuery(`UPDATE session_threads[\s\S]*WHERE id = @id[\s\S]*org_id = @org_id[\s\S]*session_id = @session_id[\s\S]*status = 'idle'[\s\S]*current_turn = 0[\s\S]*RETURNING`).
-					WithArgs(anyArgs(6)...).
+					WithArgs(anyArgs(7)...).
 					WillReturnRows(
 						pgxmock.NewRows(sessionThreadTestColumns).
 							AddRow(row...),
@@ -590,7 +596,7 @@ func TestSessionThreadStore_UpdateEditable(t *testing.T) {
 			name: "returns no rows when thread is no longer editable",
 			setupMock: func(mock pgxmock.PgxPoolIface, _ uuid.UUID, _ uuid.UUID, _ uuid.UUID, _ time.Time, _ string) {
 				mock.ExpectQuery(`UPDATE session_threads[\s\S]*WHERE id = @id[\s\S]*org_id = @org_id[\s\S]*session_id = @session_id[\s\S]*status = 'idle'[\s\S]*current_turn = 0[\s\S]*RETURNING`).
-					WithArgs(anyArgs(6)...).
+					WithArgs(anyArgs(7)...).
 					WillReturnRows(pgxmock.NewRows(sessionThreadTestColumns))
 			},
 			expectErr: pgx.ErrNoRows,
@@ -611,17 +617,19 @@ func TestSessionThreadStore_UpdateEditable(t *testing.T) {
 			threadID := uuid.New()
 			now := time.Now()
 			model := models.CodexModelGPT54
+			reasoningEffort := models.ReasoningEffortHigh
 
 			tt.setupMock(mock, orgID, sessionID, threadID, now, model)
 
 			thread := &models.SessionThread{
-				ID:            threadID,
-				SessionID:     sessionID,
-				OrgID:         orgID,
-				AgentType:     models.AgentTypeCodex,
-				ModelOverride: &model,
-				Label:         "Codex 2",
-				Status:        models.ThreadStatusIdle,
+				ID:              threadID,
+				SessionID:       sessionID,
+				OrgID:           orgID,
+				AgentType:       models.AgentTypeCodex,
+				ModelOverride:   &model,
+				ReasoningEffort: &reasoningEffort,
+				Label:           "Codex 2",
+				Status:          models.ThreadStatusIdle,
 			}
 
 			err = store.UpdateEditable(context.Background(), thread)
@@ -636,6 +644,8 @@ func TestSessionThreadStore_UpdateEditable(t *testing.T) {
 			require.Equal(t, "Codex 2", thread.Label, "UpdateEditable should preserve the updated label")
 			require.NotNil(t, thread.ModelOverride, "UpdateEditable should preserve the updated model override")
 			require.Equal(t, model, *thread.ModelOverride, "UpdateEditable should preserve the updated model override")
+			require.NotNil(t, thread.ReasoningEffort, "UpdateEditable should preserve the reasoning override")
+			require.Equal(t, reasoningEffort, *thread.ReasoningEffort, "UpdateEditable should return the updated reasoning override")
 			require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
 		})
 	}
@@ -681,7 +691,7 @@ func TestSessionThreadStore_ClaimIdle(t *testing.T) {
 				sessionID := uuid.New()
 				now := time.Now()
 				row := newSessionThreadRow(threadID, sessionID, orgID, "Backend", now)
-				row[8] = "running" // status after claim
+				row[9] = "running" // status after claim
 				// ClaimIdle has 2 named args: id, org_id
 				mock.ExpectQuery("UPDATE session_threads").
 					WithArgs(anyArgs(2)...).
@@ -773,9 +783,9 @@ func TestSessionThreadStore_ClaimIdleForSessionLocksSiblings(t *testing.T) {
 	threadID := uuid.New()
 	now := time.Now()
 	row := newSessionThreadRow(threadID, sessionID, orgID, "Backend", now)
-	row[8] = models.ThreadStatusRunning
-	row[11] = &now
-	row[17] = &now
+	row[9] = models.ThreadStatusRunning
+	row[12] = &now
+	row[18] = &now
 
 	// Pin the guard explicitly: the CTE locks every session_threads row,
 	// requires target.status to match the claimable-statuses list, counts
@@ -806,9 +816,9 @@ func TestSessionThreadStore_ClaimForResumeInSession(t *testing.T) {
 	threadID := uuid.New()
 	now := time.Now()
 	row := newSessionThreadRow(threadID, sessionID, orgID, "Backend", now)
-	row[8] = models.ThreadStatusRunning
-	row[11] = &now
-	row[17] = &now
+	row[9] = models.ThreadStatusRunning
+	row[12] = &now
+	row[18] = &now
 
 	// Pin the resume claim's distinguishing properties: it should refresh
 	// started_at for the new turn so the stuck-running reaper measures this

--- a/internal/models/code_review.go
+++ b/internal/models/code_review.go
@@ -395,14 +395,28 @@ func CodeReviewLowRiskLaneApplies(lane CodeReviewLowRiskLane, categories []strin
 }
 
 type CodeReviewAgentRoster struct {
-	Reviewers             []AgentType     `json:"reviewers"`
-	Orchestrator          AgentType       `json:"orchestrator"`
-	ReviewerModels        []string        `json:"reviewer_models,omitempty"`
-	OrchestratorModel     *string         `json:"orchestrator_model,omitempty"`
-	ReasoningEffort       ReasoningEffort `json:"reasoning_effort,omitempty"`
-	DisagreementBlocks    bool            `json:"disagreement_blocks"`
-	RequireReviewerQuorum int             `json:"require_reviewer_quorum"`
-	TimeoutSeconds        int             `json:"timeout_seconds"`
+	Reviewers                []AgentType       `json:"reviewers"`
+	Orchestrator             AgentType         `json:"orchestrator"`
+	ReviewerModels           []string          `json:"reviewer_models,omitempty"`
+	ReviewerReasoningEfforts []ReasoningEffort `json:"reviewer_reasoning_efforts,omitempty"`
+	OrchestratorModel        *string           `json:"orchestrator_model,omitempty"`
+	ReasoningEffort          ReasoningEffort   `json:"reasoning_effort,omitempty"`
+	DisagreementBlocks       bool              `json:"disagreement_blocks"`
+	RequireReviewerQuorum    int               `json:"require_reviewer_quorum"`
+	TimeoutSeconds           int               `json:"timeout_seconds"`
+}
+
+// ReviewerReasoningEffort returns the explicit effort for one reviewer. The
+// legacy roster-wide value remains the fallback for policies saved before
+// reviewer_reasoning_efforts was introduced.
+func (r CodeReviewAgentRoster) ReviewerReasoningEffort(index int) ReasoningEffort {
+	if index >= 0 && index < len(r.ReviewerReasoningEfforts) && r.ReviewerReasoningEfforts[index] != "" {
+		return r.ReviewerReasoningEfforts[index]
+	}
+	if r.ReasoningEffort != "" {
+		return r.ReasoningEffort
+	}
+	return ReasoningEffortHigh
 }
 
 type CodeReviewPolicyConfig struct {
@@ -504,14 +518,15 @@ func DefaultCodeReviewPolicyConfig() CodeReviewPolicyConfig {
 			},
 		},
 		AgentRoster: CodeReviewAgentRoster{
-			Reviewers:             []AgentType{AgentTypeCodex, AgentTypeClaudeCode},
-			Orchestrator:          AgentTypeOpenCode,
-			ReviewerModels:        []string{DefaultCodexModel, DefaultClaudeCodeModel},
-			OrchestratorModel:     strPtr(OpenCodeModelGPT55),
-			ReasoningEffort:       ReasoningEffortHigh,
-			DisagreementBlocks:    true,
-			RequireReviewerQuorum: 2,
-			TimeoutSeconds:        1800,
+			Reviewers:                []AgentType{AgentTypeCodex, AgentTypeClaudeCode},
+			Orchestrator:             AgentTypeOpenCode,
+			ReviewerModels:           []string{DefaultCodexModel, DefaultClaudeCodeModel},
+			ReviewerReasoningEfforts: []ReasoningEffort{ReasoningEffortHigh, ReasoningEffortHigh},
+			OrchestratorModel:        strPtr(OpenCodeModelGPT55),
+			ReasoningEffort:          ReasoningEffortHigh,
+			DisagreementBlocks:       true,
+			RequireReviewerQuorum:    2,
+			TimeoutSeconds:           1800,
 		},
 		InlineCommentLimit: 4,
 	}
@@ -578,6 +593,12 @@ func ResolveCodeReviewPolicyConfig(config *CodeReviewPolicyConfig) CodeReviewPol
 		defaults.AgentRoster = config.AgentRoster
 		if defaults.AgentRoster.ReasoningEffort == "" {
 			defaults.AgentRoster.ReasoningEffort = ReasoningEffortHigh
+		}
+		if len(defaults.AgentRoster.ReviewerReasoningEfforts) == 0 {
+			defaults.AgentRoster.ReviewerReasoningEfforts = make([]ReasoningEffort, len(defaults.AgentRoster.Reviewers))
+			for i := range defaults.AgentRoster.ReviewerReasoningEfforts {
+				defaults.AgentRoster.ReviewerReasoningEfforts[i] = defaults.AgentRoster.ReasoningEffort
+			}
 		}
 	}
 	if config.InlineCommentLimit != 0 {
@@ -647,15 +668,25 @@ func (c CodeReviewPolicyConfig) Validate() error {
 	if len(c.AgentRoster.Reviewers) == 0 {
 		return codeReviewPolicyFieldError(CodeReviewPolicyFieldAgentRoster, "at least one reviewer agent is required")
 	}
-	for _, agentType := range c.AgentRoster.Reviewers {
+	if len(c.AgentRoster.ReviewerReasoningEfforts) > 0 && len(c.AgentRoster.ReviewerReasoningEfforts) != len(c.AgentRoster.Reviewers) {
+		return codeReviewPolicyFieldError(CodeReviewPolicyFieldAgentRoster, "reviewer_reasoning_efforts must match reviewer count")
+	}
+	for idx, agentType := range c.AgentRoster.Reviewers {
 		if err := agentType.Validate(); err != nil {
 			return codeReviewPolicyFieldError(CodeReviewPolicyFieldAgentRoster, err.Error())
 		}
 		if !AgentSupportsNativeReview(agentType) {
 			return codeReviewPolicyFieldError(CodeReviewPolicyFieldAgentRoster, fmt.Sprintf("agent %q does not support native review", agentType))
 		}
-		if agentType.SupportsReasoningEffort() && !agentType.SupportsReasoningEffortLevel(c.AgentRoster.ReasoningEffort) {
-			return codeReviewPolicyFieldError(CodeReviewPolicyFieldAgentRoster, fmt.Sprintf("reasoning effort %q is not supported by reviewer %q", c.AgentRoster.ReasoningEffort, agentType))
+		reasoningEffort := c.AgentRoster.ReviewerReasoningEffort(idx)
+		if len(c.AgentRoster.ReviewerReasoningEfforts) > 0 && c.AgentRoster.ReviewerReasoningEfforts[idx] == "" {
+			return codeReviewPolicyFieldError(CodeReviewPolicyFieldAgentRoster, fmt.Sprintf("reviewer reasoning effort %d must be non-empty", idx+1))
+		}
+		if err := reasoningEffort.Validate(); err != nil {
+			return codeReviewPolicyFieldError(CodeReviewPolicyFieldAgentRoster, fmt.Sprintf("invalid reviewer reasoning effort %d: %v", idx+1, err))
+		}
+		if agentType.SupportsReasoningEffort() && !agentType.SupportsReasoningEffortLevel(reasoningEffort) {
+			return codeReviewPolicyFieldError(CodeReviewPolicyFieldAgentRoster, fmt.Sprintf("reasoning effort %q is not supported by reviewer %q", reasoningEffort, agentType))
 		}
 	}
 	if len(c.AgentRoster.ReviewerModels) > 0 && len(c.AgentRoster.ReviewerModels) != len(c.AgentRoster.Reviewers) {

--- a/internal/models/code_review_test.go
+++ b/internal/models/code_review_test.go
@@ -82,8 +82,9 @@ func TestDefaultCodeReviewPolicyConfig(t *testing.T) {
 	require.False(t, config.RiskPolicy.RequirePassingChecks, "default approval policy should evaluate code without requiring GitHub checks")
 	require.Equal(t, []AgentType{AgentTypeCodex, AgentTypeClaudeCode}, config.AgentRoster.Reviewers, "default roster should run two reviewers")
 	require.Equal(t, []string{DefaultCodexModel, DefaultClaudeCodeModel}, config.AgentRoster.ReviewerModels, "default roster should pin reviewer models")
+	require.Equal(t, []ReasoningEffort{ReasoningEffortHigh, ReasoningEffortHigh}, config.AgentRoster.ReviewerReasoningEfforts, "each default reviewer should use high reasoning")
 	require.Equal(t, OpenCodeModelGPT55, *config.AgentRoster.OrchestratorModel, "default roster should pin the orchestrator model")
-	require.Equal(t, ReasoningEffortHigh, config.AgentRoster.ReasoningEffort, "code review agents should default to high reasoning")
+	require.Equal(t, ReasoningEffortHigh, config.AgentRoster.ReasoningEffort, "code review orchestrator should default to high reasoning")
 	require.NoError(t, config.Validate(), "default code review policy should be valid")
 }
 
@@ -91,17 +92,20 @@ func TestResolveCodeReviewPolicyConfigDefaultsLegacyRosterReasoning(t *testing.T
 	t.Parallel()
 
 	config := DefaultCodeReviewPolicyConfig()
+	config.AgentRoster.ReviewerReasoningEfforts = nil
 	config.AgentRoster.ReasoningEffort = ""
 
 	resolved := ResolveCodeReviewPolicyConfig(&config)
 
 	require.Equal(t, ReasoningEffortHigh, resolved.AgentRoster.ReasoningEffort, "legacy code review policies should inherit high reasoning")
+	require.Equal(t, []ReasoningEffort{ReasoningEffortHigh, ReasoningEffortHigh}, resolved.AgentRoster.ReviewerReasoningEfforts, "legacy reviewers should inherit the roster reasoning level")
 }
 
 func TestCodeReviewPolicyRecordConfigDefaultsLegacyRosterReasoning(t *testing.T) {
 	t.Parallel()
 
 	config := DefaultCodeReviewPolicyConfig()
+	config.AgentRoster.ReviewerReasoningEfforts = nil
 	config.AgentRoster.ReasoningEffort = ""
 	record := CodeReviewPolicyRecord{
 		Enabled:                 config.Enabled,
@@ -117,6 +121,7 @@ func TestCodeReviewPolicyRecordConfigDefaultsLegacyRosterReasoning(t *testing.T)
 	resolved := record.Config()
 
 	require.Equal(t, ReasoningEffortHigh, resolved.AgentRoster.ReasoningEffort, "stored legacy code review policies should run with high reasoning")
+	require.Equal(t, []ReasoningEffort{ReasoningEffortHigh, ReasoningEffortHigh}, resolved.AgentRoster.ReviewerReasoningEfforts, "stored legacy reviewers should inherit high reasoning")
 }
 
 func TestResolveCodeReviewPolicyConfigDoesNotMutateInput(t *testing.T) {
@@ -163,12 +168,24 @@ func TestCodeReviewPolicyConfigValidate(t *testing.T) {
 		{name: "rejects no reviewers", mutate: func(c *CodeReviewPolicyConfig) { c.AgentRoster.Reviewers = nil }, expectErr: true},
 		{name: "rejects unsupported reviewer", mutate: func(c *CodeReviewPolicyConfig) { c.AgentRoster.Reviewers = []AgentType{AgentTypePMAgent} }, expectErr: true},
 		{name: "rejects reviewer model count mismatch", mutate: func(c *CodeReviewPolicyConfig) { c.AgentRoster.ReviewerModels = []string{DefaultCodexModel} }, expectErr: true},
+		{name: "rejects reviewer reasoning count mismatch", mutate: func(c *CodeReviewPolicyConfig) {
+			c.AgentRoster.ReviewerReasoningEfforts = []ReasoningEffort{ReasoningEffortHigh}
+		}, expectErr: true},
 		{name: "rejects invalid reviewer model", mutate: func(c *CodeReviewPolicyConfig) {
 			c.AgentRoster.ReviewerModels = []string{DefaultCodexModel, DefaultCodexModel}
 		}, expectErr: true},
 		{name: "rejects invalid orchestrator model", mutate: func(c *CodeReviewPolicyConfig) { c.AgentRoster.OrchestratorModel = strPtr(DefaultCodexModel) }, expectErr: true},
+		{name: "accepts independent reviewer reasoning", mutate: func(c *CodeReviewPolicyConfig) {
+			c.AgentRoster.ReviewerReasoningEfforts = []ReasoningEffort{ReasoningEffortXHigh, ReasoningEffortMax}
+		}},
+		{name: "rejects invalid reviewer reasoning effort", mutate: func(c *CodeReviewPolicyConfig) {
+			c.AgentRoster.ReviewerReasoningEfforts[1] = ReasoningEffort("turbo")
+		}, expectErr: true},
+		{name: "rejects empty reviewer reasoning effort", mutate: func(c *CodeReviewPolicyConfig) {
+			c.AgentRoster.ReviewerReasoningEfforts[1] = ""
+		}, expectErr: true},
 		{name: "rejects invalid reasoning effort", mutate: func(c *CodeReviewPolicyConfig) { c.AgentRoster.ReasoningEffort = ReasoningEffort("turbo") }, expectErr: true},
-		{name: "rejects reasoning effort unsupported by reviewer", mutate: func(c *CodeReviewPolicyConfig) { c.AgentRoster.ReasoningEffort = ReasoningEffortMax }, expectErr: true},
+		{name: "rejects reasoning effort unsupported by reviewer", mutate: func(c *CodeReviewPolicyConfig) { c.AgentRoster.ReviewerReasoningEfforts[0] = ReasoningEffortMax }, expectErr: true},
 		{name: "rejects oversized quorum", mutate: func(c *CodeReviewPolicyConfig) { c.AgentRoster.RequireReviewerQuorum = 3 }, expectErr: true},
 		{name: "rejects too short timeout", mutate: func(c *CodeReviewPolicyConfig) { c.AgentRoster.TimeoutSeconds = 30 }, expectErr: true},
 	}

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -936,6 +936,7 @@ type SessionThread struct {
 	OrgID                 uuid.UUID                   `db:"org_id" json:"org_id"`
 	AgentType             AgentType                   `db:"agent_type" json:"agent_type"`
 	ModelOverride         *string                     `db:"model_override" json:"model_override,omitempty"`
+	ReasoningEffort       *ReasoningEffort            `db:"reasoning_effort" json:"reasoning_effort,omitempty"`
 	Label                 string                      `db:"label" json:"label"`
 	Instructions          *string                     `db:"instructions" json:"instructions,omitempty"`
 	FileScope             []string                    `db:"file_scope" json:"file_scope,omitempty"`

--- a/internal/services/agent/orchestrator.go
+++ b/internal/services/agent/orchestrator.go
@@ -1259,6 +1259,7 @@ type DurableCheckpoint struct {
 type ContinueSessionOptions struct {
 	AgentType            models.AgentType
 	ModelOverride        *string
+	ReasoningEffort      *models.ReasoningEffort
 	ThreadAgentSessionID *string
 	ResultAgentSessionID *string
 	PRRepair             *PRRepairContinueOptions
@@ -3912,6 +3913,9 @@ func (o *Orchestrator) ContinueSession(ctx context.Context, session *models.Sess
 		executionSession := *session
 		executionSession.AgentType = opts.AgentType
 		executionSession.ModelOverride = opts.ModelOverride
+		if opts.ReasoningEffort != nil {
+			executionSession.ReasoningEffort = opts.ReasoningEffort
+		}
 		executionSession.AgentSessionID = opts.ThreadAgentSessionID
 		session = &executionSession
 	}

--- a/internal/services/agent/orchestrator_test.go
+++ b/internal/services/agent/orchestrator_test.go
@@ -5480,9 +5480,11 @@ func TestContinueSession_UsesThreadExecutionOptions(t *testing.T) {
 		*session.SnapshotKey: []byte("restored-snapshot"),
 	}
 
+	threadReasoning := models.ReasoningEffortXHigh
 	err := buildOrchestrator(d).ContinueSession(context.Background(), session, &agent.ContinueSessionOptions{
 		AgentType:            models.AgentTypeOpenCode,
 		ModelOverride:        &threadModel,
+		ReasoningEffort:      &threadReasoning,
 		ThreadAgentSessionID: nil,
 		ResultAgentSessionID: &threadAgentSessionID,
 		ThreadID:             &threadID,
@@ -5491,6 +5493,7 @@ func TestContinueSession_UsesThreadExecutionOptions(t *testing.T) {
 	require.Equal(t, threadModel, createdCfg.Env["OPENCODE_MODEL"], "ContinueSession should apply the thread model to the thread agent env")
 	require.NotContains(t, createdCfg.Env, "ANTHROPIC_MODEL", "ContinueSession should not apply the parent session model when a thread override is provided")
 	require.NotNil(t, promptSeen, "ContinueSession should execute the thread adapter")
+	require.Equal(t, threadReasoning, promptSeen.ReasoningEffort, "ContinueSession should apply the thread reasoning override")
 	require.False(t, promptSeen.Continuation, "first turn in a blank thread should start a fresh agent transcript")
 	require.Empty(t, promptSeen.ResumeSessionID, "blank thread should not resume the parent session's agent session id")
 	require.Equal(t, "thread-opencode-session", threadAgentSessionID, "ContinueSession should report the thread agent session id to the worker")

--- a/internal/services/thread/service.go
+++ b/internal/services/thread/service.go
@@ -185,6 +185,7 @@ type CreateThreadInput struct {
 	OrgID             uuid.UUID
 	AgentType         string
 	Model             string
+	ReasoningEffort   *models.ReasoningEffort
 	Label             string
 	Instructions      string
 	FileScope         []string
@@ -207,13 +208,17 @@ type threadStoreWithListOptions interface {
 //   - nil:       field absent from the patch — keep the existing override
 //   - non-nil "": field present as JSON null or empty string — clear the override
 //   - non-nil v: field present with a value — set/validate to v
+//
+// ReasoningEffort is internal-only today: nil preserves the existing value and
+// a non-nil value replaces it after agent compatibility validation.
 type UpdateThreadInput struct {
-	SessionID uuid.UUID
-	OrgID     uuid.UUID
-	ThreadID  uuid.UUID
-	AgentType string
-	Model     *string
-	Label     string
+	SessionID       uuid.UUID
+	OrgID           uuid.UUID
+	ThreadID        uuid.UUID
+	AgentType       string
+	Model           *string
+	ReasoningEffort *models.ReasoningEffort
+	Label           string
 }
 
 // SendMessageInput holds the input for sending a message to a thread.
@@ -420,6 +425,14 @@ func (s *Service) CreateThread(ctx context.Context, input CreateThreadInput) (*m
 		}
 		modelOverride = &input.Model
 	}
+	if input.ReasoningEffort != nil {
+		if err := input.ReasoningEffort.Validate(); err != nil {
+			return nil, err
+		}
+		if agentType.SupportsReasoningEffort() && !agentType.SupportsReasoningEffortLevel(*input.ReasoningEffort) {
+			return nil, fmt.Errorf("reasoning effort %q is not supported by agent type %q", *input.ReasoningEffort, agentType)
+		}
+	}
 	executionMode := input.ExecutionMode
 	if executionMode == "" {
 		executionMode = models.ThreadExecutionModeWork
@@ -445,6 +458,7 @@ func (s *Service) CreateThread(ctx context.Context, input CreateThreadInput) (*m
 		OrgID:             input.OrgID,
 		AgentType:         agentType,
 		ModelOverride:     modelOverride,
+		ReasoningEffort:   input.ReasoningEffort,
 		Label:             input.Label,
 		Instructions:      instructions,
 		FileScope:         input.FileScope,
@@ -529,6 +543,19 @@ func (s *Service) UpdateThread(ctx context.Context, input UpdateThreadInput) (*m
 		// Agent switched without an explicit model: drop the inherited override
 		// because it was scoped to the previous agent.
 		thread.ModelOverride = nil
+	}
+	if input.ReasoningEffort != nil {
+		if *input.ReasoningEffort == "" {
+			return nil, fmt.Errorf("reasoning effort must be non-empty")
+		}
+		if err := input.ReasoningEffort.Validate(); err != nil {
+			return nil, err
+		}
+		if agentType.SupportsReasoningEffort() && !agentType.SupportsReasoningEffortLevel(*input.ReasoningEffort) {
+			return nil, fmt.Errorf("reasoning effort %q is not supported by agent type %q", *input.ReasoningEffort, agentType)
+		}
+		reasoningEffort := *input.ReasoningEffort
+		thread.ReasoningEffort = &reasoningEffort
 	}
 
 	if err := s.threadStore.UpdateEditable(ctx, &thread); err != nil {

--- a/internal/services/thread/service_test.go
+++ b/internal/services/thread/service_test.go
@@ -394,6 +394,7 @@ func TestService_CreateThread(t *testing.T) {
 	sessionID := uuid.New()
 	threadID := uuid.New()
 	now := time.Now()
+	highReasoning := models.ReasoningEffortHigh
 
 	tests := []struct {
 		name      string
@@ -422,12 +423,13 @@ func TestService_CreateThread(t *testing.T) {
 		{
 			name: "success with explicit agent type and instructions",
 			input: CreateThreadInput{
-				SessionID:    sessionID,
-				OrgID:        orgID,
-				AgentType:    "claude_code",
-				Label:        "Frontend",
-				Instructions: "focus on UI",
-				FileScope:    []string{"src/"},
+				SessionID:       sessionID,
+				OrgID:           orgID,
+				AgentType:       "claude_code",
+				ReasoningEffort: &highReasoning,
+				Label:           "Frontend",
+				Instructions:    "focus on UI",
+				FileScope:       []string{"src/"},
 			},
 			setupDeps: func(deps *testDeps) {
 				deps.sessionStore.getByIDFn = func(_ context.Context, _, _ uuid.UUID) (models.Session, error) {
@@ -560,6 +562,7 @@ func TestService_CreateThread(t *testing.T) {
 			require.NotNil(t, result, "should return a thread")
 			require.Equal(t, threadID, result.ID, "should set the thread ID")
 			require.Equal(t, tt.input.Label, result.Label, "should set the label")
+			require.Equal(t, tt.input.ReasoningEffort, result.ReasoningEffort, "should preserve the thread reasoning override")
 			require.Equal(t, models.ThreadStatusIdle, result.Status, "new tab should wait for first user message")
 		})
 	}
@@ -603,13 +606,14 @@ func TestService_UpdateThread(t *testing.T) {
 	threadID := uuid.New()
 
 	tests := []struct {
-		name          string
-		input         UpdateThreadInput
-		setupDeps     func(deps *testDeps)
-		expectErr     error
-		expectedType  models.AgentType
-		expectedLabel string
-		expectedModel *string
+		name              string
+		input             UpdateThreadInput
+		setupDeps         func(deps *testDeps)
+		expectErr         error
+		expectedType      models.AgentType
+		expectedLabel     string
+		expectedModel     *string
+		expectedReasoning *models.ReasoningEffort
 	}{
 		{
 			name: "updates blank idle thread and clears inherited model override",
@@ -651,12 +655,13 @@ func TestService_UpdateThread(t *testing.T) {
 		{
 			name: "accepts an explicit model override for the replacement agent",
 			input: UpdateThreadInput{
-				SessionID: sessionID,
-				OrgID:     orgID,
-				ThreadID:  threadID,
-				AgentType: "codex",
-				Model:     stringPtr(models.CodexModelGPT54Mini),
-				Label:     "Codex 2",
+				SessionID:       sessionID,
+				OrgID:           orgID,
+				ThreadID:        threadID,
+				AgentType:       "codex",
+				Model:           stringPtr(models.CodexModelGPT54Mini),
+				ReasoningEffort: reasoningEffortTestPtr(models.ReasoningEffortHigh),
+				Label:           "Codex 2",
 			},
 			setupDeps: func(deps *testDeps) {
 				deps.sessionStore.getByIDFn = func(_ context.Context, _, _ uuid.UUID) (models.Session, error) {
@@ -676,12 +681,15 @@ func TestService_UpdateThread(t *testing.T) {
 				deps.threadStore.updateFn = func(_ context.Context, updated *models.SessionThread) error {
 					require.NotNil(t, updated.ModelOverride, "UpdateThread should persist the requested model override")
 					require.Equal(t, models.CodexModelGPT54Mini, *updated.ModelOverride, "UpdateThread should persist the requested model override")
+					require.NotNil(t, updated.ReasoningEffort, "UpdateThread should persist the requested reasoning override")
+					require.Equal(t, models.ReasoningEffortHigh, *updated.ReasoningEffort, "UpdateThread should persist a reasoning level supported by the replacement agent")
 					return nil
 				}
 			},
-			expectedType:  models.AgentTypeCodex,
-			expectedLabel: "Codex 2",
-			expectedModel: stringPtr(models.CodexModelGPT54Mini),
+			expectedType:      models.AgentTypeCodex,
+			expectedLabel:     "Codex 2",
+			expectedModel:     stringPtr(models.CodexModelGPT54Mini),
+			expectedReasoning: reasoningEffortTestPtr(models.ReasoningEffortHigh),
 		},
 		{
 			name: "explicit empty model clears an existing override without switching agent",
@@ -989,6 +997,7 @@ func TestService_UpdateThread(t *testing.T) {
 			require.Equal(t, tt.expectedType, result.AgentType, "UpdateThread should return the updated agent type")
 			require.Equal(t, tt.expectedLabel, result.Label, "UpdateThread should return the updated label")
 			require.Equal(t, tt.expectedModel, result.ModelOverride, "UpdateThread should return the updated model override")
+			require.Equal(t, tt.expectedReasoning, result.ReasoningEffort, "UpdateThread should return the updated reasoning override")
 		})
 	}
 }
@@ -1099,6 +1108,10 @@ func TestService_ArchiveThread(t *testing.T) {
 }
 
 func stringPtr(value string) *string {
+	return &value
+}
+
+func reasoningEffortTestPtr(value models.ReasoningEffort) *models.ReasoningEffort {
 	return &value
 }
 

--- a/internal/worker/code_review_handler.go
+++ b/internal/worker/code_review_handler.go
@@ -654,6 +654,7 @@ func ensureCodeReviewReviewerThreads(ctx context.Context, stores *Stores, servic
 			OrgID:           job.OrgID,
 			AgentType:       string(agentType),
 			Model:           stringPtrValue(agentModel),
+			ReasoningEffort: reasoningEffortPtr(cfg.AgentRoster.ReviewerReasoningEffort(idx)),
 			Label:           codeReviewReviewerThreadLabel(agentType),
 			FileScope:       fileScope,
 			ExecutionMode:   models.ThreadExecutionModeReview,
@@ -726,9 +727,10 @@ type codeReviewReviewerSelection struct {
 }
 
 type codeReviewOrchestratorSelection struct {
-	AgentType  models.AgentType
-	AgentModel *string
-	Available  bool
+	AgentType       models.AgentType
+	AgentModel      *string
+	ReasoningEffort *models.ReasoningEffort
+	Available       bool
 }
 
 func resolveCodeReviewReviewerAvailability(ctx context.Context, services *Services, orgID uuid.UUID, cfg models.CodeReviewPolicyConfig) ([]codeReviewReviewerSelection, error) {
@@ -754,9 +756,10 @@ func resolveCodeReviewReviewerAvailability(ctx context.Context, services *Servic
 
 func resolveCodeReviewOrchestratorAvailability(ctx context.Context, services *Services, orgID uuid.UUID, cfg models.CodeReviewPolicyConfig) (codeReviewOrchestratorSelection, error) {
 	configured := codeReviewOrchestratorSelection{
-		AgentType:  cfg.AgentRoster.Orchestrator,
-		AgentModel: codeReviewOrchestratorAgentModel(cfg),
-		Available:  true,
+		AgentType:       cfg.AgentRoster.Orchestrator,
+		AgentModel:      codeReviewOrchestratorAgentModel(cfg),
+		ReasoningEffort: reasoningEffortPtr(cfg.AgentRoster.ReasoningEffort),
+		Available:       true,
 	}
 	if services == nil || services.CodingAgents == nil {
 		return configured, nil
@@ -778,9 +781,10 @@ func resolveCodeReviewOrchestratorAvailability(ctx context.Context, services *Se
 		}
 		if available {
 			return codeReviewOrchestratorSelection{
-				AgentType:  agentType,
-				AgentModel: agentModel,
-				Available:  true,
+				AgentType:       agentType,
+				AgentModel:      agentModel,
+				ReasoningEffort: reasoningEffortPtr(cfg.AgentRoster.ReviewerReasoningEffort(idx)),
+				Available:       true,
 			}, nil
 		}
 	}
@@ -1059,6 +1063,10 @@ func codeReviewReviewerAgentModel(cfg models.CodeReviewPolicyConfig, idx int, ag
 		}
 	}
 	return codeReviewDefaultAgentModel(agentType)
+}
+
+func reasoningEffortPtr(value models.ReasoningEffort) *models.ReasoningEffort {
+	return &value
 }
 
 func codeReviewOrchestratorAgentModel(cfg models.CodeReviewPolicyConfig) *string {
@@ -1846,6 +1854,7 @@ func ensureCodeReviewOrchestratorThread(ctx context.Context, stores *Stores, ser
 	}
 	agentType := selection.AgentType
 	agentModel := selection.AgentModel
+	reasoningEffort := selection.ReasoningEffort
 	if !selection.Available {
 		raw := "orchestrator skipped because no authenticated coding agent is configured"
 		result := &models.CodeReviewAgentResult{
@@ -1939,18 +1948,21 @@ func ensureCodeReviewOrchestratorThread(ctx context.Context, stores *Stores, ser
 	if err != nil {
 		return fmt.Errorf("load code review primary thread for orchestrator: %w", err)
 	}
-	if primaryThread.AgentType != agentType || !codeReviewAgentModelsEqual(primaryThread.ModelOverride, agentModel) {
+	if primaryThread.AgentType != agentType ||
+		!codeReviewAgentModelsEqual(primaryThread.ModelOverride, agentModel) ||
+		!codeReviewReasoningEffortsEqual(primaryThread.ReasoningEffort, reasoningEffort) {
 		model := ""
 		if agentModel != nil {
 			model = *agentModel
 		}
 		_, updateErr := threads.UpdateThread(ctx, threadsvc.UpdateThreadInput{
-			SessionID: job.SessionID,
-			OrgID:     job.OrgID,
-			ThreadID:  threadID,
-			AgentType: string(agentType),
-			Model:     &model,
-			Label:     primaryThread.Label,
+			SessionID:       job.SessionID,
+			OrgID:           job.OrgID,
+			ThreadID:        threadID,
+			AgentType:       string(agentType),
+			Model:           &model,
+			ReasoningEffort: reasoningEffort,
+			Label:           primaryThread.Label,
 		})
 		if updateErr != nil {
 			return fmt.Errorf("retarget code review primary thread to available orchestrator %s: %w", agentType, updateErr)
@@ -2030,6 +2042,13 @@ func codeReviewAgentModelsEqual(left, right *string) bool {
 		return left == nil && right == nil
 	}
 	return strings.TrimSpace(*left) == strings.TrimSpace(*right)
+}
+
+func codeReviewReasoningEffortsEqual(left, right *models.ReasoningEffort) bool {
+	if left == nil || right == nil {
+		return left == nil && right == nil
+	}
+	return *left == *right
 }
 
 func harvestCodeReviewOrchestratorResult(ctx context.Context, stores *Stores, services *Services, logger zerolog.Logger, job runCodeReviewPayload, policy models.CodeReviewPolicyRecord, metadata models.CodeReviewSessionMetadata, changedFiles []codereviewsvc.PullRequestFile) error {

--- a/internal/worker/code_review_handler_test.go
+++ b/internal/worker/code_review_handler_test.go
@@ -750,7 +750,7 @@ func TestHarvestCodeReviewReviewerResultsIgnoresReadOnlyWorkspaceChanges(t *test
 	mock.ExpectQuery("(?s)SELECT .*FROM session_threads").
 		WithArgs(pgx.NamedArgs{"id": threadID, "org_id": orgID}).
 		WillReturnRows(newSessionThreadRows().
-			AddRow(threadID, sessionID, orgID, models.AgentTypeCodex, nil,
+			AddRow(threadID, sessionID, orgID, models.AgentTypeCodex, nil, nil,
 				"Code review: codex", nil, []string{"internal/db/users.go"}, models.ThreadStatusCompleted,
 				nil, 1, &now, nil, &rawDiff, nil, nil,
 				&now, &now, now, models.ThreadCreatedBySourceSystem, nil, nil,
@@ -820,7 +820,7 @@ func TestHarvestCodeReviewReviewerResultsCompletesIdleReadOnlyViolationWithoutAs
 	mock.ExpectQuery("(?s)SELECT .*FROM session_threads").
 		WithArgs(pgx.NamedArgs{"id": threadID, "org_id": orgID}).
 		WillReturnRows(newSessionThreadRows().
-			AddRow(threadID, sessionID, orgID, models.AgentTypeCodex, nil,
+			AddRow(threadID, sessionID, orgID, models.AgentTypeCodex, nil, nil,
 				"Code review: codex", nil, []string{"internal/db/users.go"}, models.ThreadStatusIdle,
 				nil, 1, &now, nil, &rawDiff, &failure, stringPtr("read_only_violation"),
 				&now, &now, now, models.ThreadCreatedBySourceSystem, nil, nil,
@@ -912,7 +912,7 @@ func TestHarvestCodeReviewReviewerResultsClassifiesFailedThreadOutput(t *testing
 			mock.ExpectQuery("(?s)SELECT .*FROM session_threads").
 				WithArgs(pgx.NamedArgs{"id": threadID, "org_id": orgID}).
 				WillReturnRows(newSessionThreadRows().
-					AddRow(threadID, sessionID, orgID, models.AgentTypeClaudeCode, nil,
+					AddRow(threadID, sessionID, orgID, models.AgentTypeClaudeCode, nil, nil,
 						"Code review: claude_code", nil, []string{"internal/db/users.go"}, models.ThreadStatusFailed,
 						nil, 1, &now, nil, nil, &tt.failure, &tt.failureCategory,
 						&now, &now, now, models.ThreadCreatedBySourceSystem, nil, nil,
@@ -1372,7 +1372,7 @@ func TestHarvestCodeReviewOrchestratorResultPersistsFindings(t *testing.T) {
 	mock.ExpectQuery("(?s)SELECT .*FROM session_threads").
 		WithArgs(pgx.NamedArgs{"id": threadID, "org_id": orgID}).
 		WillReturnRows(newSessionThreadRows().
-			AddRow(threadID, sessionID, orgID, models.AgentTypeCodex, nil,
+			AddRow(threadID, sessionID, orgID, models.AgentTypeCodex, nil, nil,
 				"Main", nil, []string{"internal/worker/code_review_handler.go"}, models.ThreadStatusCompleted,
 				nil, 1, &now, nil, nil, nil, nil,
 				&now, &now, now, models.ThreadCreatedBySourceSystem, nil, nil,
@@ -1546,7 +1546,7 @@ func TestHarvestCodeReviewOrchestratorResultRejectsMalformedSynthesis(t *testing
 	mock.ExpectQuery("(?s)SELECT .*FROM session_threads").
 		WithArgs(pgx.NamedArgs{"id": threadID, "org_id": orgID}).
 		WillReturnRows(newSessionThreadRows().
-			AddRow(threadID, sessionID, orgID, models.AgentTypeCodex, nil,
+			AddRow(threadID, sessionID, orgID, models.AgentTypeCodex, nil, nil,
 				"Main", nil, []string{"internal/worker/code_review_handler.go"}, models.ThreadStatusCompleted,
 				nil, 1, &now, nil, nil, nil, nil,
 				&now, &now, now, models.ThreadCreatedBySourceSystem, nil, nil,
@@ -1904,6 +1904,53 @@ func TestCodeReviewReviewerAgentModel(t *testing.T) {
 		"missing reviewer_models should fall back to the per-agent default")
 }
 
+func TestCodeReviewReviewerReasoningEffort(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		index     int
+		configure func(*models.CodeReviewPolicyConfig)
+		expected  models.ReasoningEffort
+	}{
+		{
+			name:  "uses first reviewer override",
+			index: 0,
+			configure: func(cfg *models.CodeReviewPolicyConfig) {
+				cfg.AgentRoster.ReviewerReasoningEfforts = []models.ReasoningEffort{models.ReasoningEffortLow, models.ReasoningEffortMax}
+			},
+			expected: models.ReasoningEffortLow,
+		},
+		{
+			name:  "uses second reviewer override independently",
+			index: 1,
+			configure: func(cfg *models.CodeReviewPolicyConfig) {
+				cfg.AgentRoster.ReviewerReasoningEfforts = []models.ReasoningEffort{models.ReasoningEffortLow, models.ReasoningEffortMax}
+			},
+			expected: models.ReasoningEffortMax,
+		},
+		{
+			name:  "falls back for legacy policy",
+			index: 0,
+			configure: func(cfg *models.CodeReviewPolicyConfig) {
+				cfg.AgentRoster.ReviewerReasoningEfforts = nil
+				cfg.AgentRoster.ReasoningEffort = models.ReasoningEffortMedium
+			},
+			expected: models.ReasoningEffortMedium,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			cfg := models.DefaultCodeReviewPolicyConfig()
+			tt.configure(&cfg)
+			require.Equal(t, tt.expected, cfg.AgentRoster.ReviewerReasoningEffort(tt.index), "reviewer should use the expected reasoning effort")
+		})
+	}
+}
+
 type codeReviewAgentAvailabilityStub struct {
 	available      map[models.AgentType]bool
 	availableModel map[models.AgentType]map[string]bool
@@ -1996,6 +2043,7 @@ func TestResolveCodeReviewOrchestratorAvailability(t *testing.T) {
 	cfg := models.DefaultCodeReviewPolicyConfig()
 	tests := []struct {
 		name      string
+		configure func(*models.CodeReviewPolicyConfig)
 		services  *Services
 		expected  codeReviewOrchestratorSelection
 		expectErr bool
@@ -2007,9 +2055,10 @@ func TestResolveCodeReviewOrchestratorAvailability(t *testing.T) {
 				models.AgentTypeCodex:    true,
 			}}},
 			expected: codeReviewOrchestratorSelection{
-				AgentType:  models.AgentTypeOpenCode,
-				AgentModel: stringPtr(models.OpenCodeModelGPT55),
-				Available:  true,
+				AgentType:       models.AgentTypeOpenCode,
+				AgentModel:      stringPtr(models.OpenCodeModelGPT55),
+				ReasoningEffort: reasoningEffortPtr(models.ReasoningEffortHigh),
+				Available:       true,
 			},
 		},
 		{
@@ -2018,9 +2067,10 @@ func TestResolveCodeReviewOrchestratorAvailability(t *testing.T) {
 				models.AgentTypeCodex: true,
 			}}},
 			expected: codeReviewOrchestratorSelection{
-				AgentType:  models.AgentTypeCodex,
-				AgentModel: stringPtr(models.DefaultCodexModel),
-				Available:  true,
+				AgentType:       models.AgentTypeCodex,
+				AgentModel:      stringPtr(models.DefaultCodexModel),
+				ReasoningEffort: reasoningEffortPtr(models.ReasoningEffortHigh),
+				Available:       true,
 			},
 		},
 		{
@@ -2036,9 +2086,10 @@ func TestResolveCodeReviewOrchestratorAvailability(t *testing.T) {
 				},
 			}},
 			expected: codeReviewOrchestratorSelection{
-				AgentType:  models.AgentTypeCodex,
-				AgentModel: stringPtr(models.DefaultCodexModel),
-				Available:  true,
+				AgentType:       models.AgentTypeCodex,
+				AgentModel:      stringPtr(models.DefaultCodexModel),
+				ReasoningEffort: reasoningEffortPtr(models.ReasoningEffortHigh),
+				Available:       true,
 			},
 		},
 		{
@@ -2047,26 +2098,49 @@ func TestResolveCodeReviewOrchestratorAvailability(t *testing.T) {
 				models.AgentTypeClaudeCode: true,
 			}}},
 			expected: codeReviewOrchestratorSelection{
-				AgentType:  models.AgentTypeClaudeCode,
-				AgentModel: stringPtr(models.DefaultClaudeCodeModel),
-				Available:  true,
+				AgentType:       models.AgentTypeClaudeCode,
+				AgentModel:      stringPtr(models.DefaultClaudeCodeModel),
+				ReasoningEffort: reasoningEffortPtr(models.ReasoningEffortHigh),
+				Available:       true,
+			},
+		},
+		{
+			name: "uses the fallback reviewer's reasoning instead of an incompatible orchestrator level",
+			configure: func(cfg *models.CodeReviewPolicyConfig) {
+				cfg.AgentRoster.Orchestrator = models.AgentTypeClaudeCode
+				cfg.AgentRoster.OrchestratorModel = stringPtr(models.DefaultClaudeCodeModel)
+				cfg.AgentRoster.ReasoningEffort = models.ReasoningEffortMax
+				cfg.AgentRoster.Reviewers = []models.AgentType{models.AgentTypeCodex}
+				cfg.AgentRoster.ReviewerModels = []string{models.DefaultCodexModel}
+				cfg.AgentRoster.ReviewerReasoningEfforts = []models.ReasoningEffort{models.ReasoningEffortHigh}
+			},
+			services: &Services{CodingAgents: codeReviewAgentAvailabilityStub{available: map[models.AgentType]bool{
+				models.AgentTypeCodex: true,
+			}}},
+			expected: codeReviewOrchestratorSelection{
+				AgentType:       models.AgentTypeCodex,
+				AgentModel:      stringPtr(models.DefaultCodexModel),
+				ReasoningEffort: reasoningEffortPtr(models.ReasoningEffortHigh),
+				Available:       true,
 			},
 		},
 		{
 			name:     "does not select an unauthenticated agent",
 			services: &Services{CodingAgents: codeReviewAgentAvailabilityStub{available: map[models.AgentType]bool{}}},
 			expected: codeReviewOrchestratorSelection{
-				AgentType:  models.AgentTypeOpenCode,
-				AgentModel: stringPtr(models.OpenCodeModelGPT55),
-				Available:  false,
+				AgentType:       models.AgentTypeOpenCode,
+				AgentModel:      stringPtr(models.OpenCodeModelGPT55),
+				ReasoningEffort: reasoningEffortPtr(models.ReasoningEffortHigh),
+				Available:       false,
 			},
 		},
 		{
 			name: "preserves the configured orchestrator without an availability service",
 			expected: codeReviewOrchestratorSelection{
-				AgentType:  models.AgentTypeOpenCode,
-				AgentModel: stringPtr(models.OpenCodeModelGPT55),
-				Available:  true,
+				AgentType:       models.AgentTypeOpenCode,
+				AgentModel:      stringPtr(models.OpenCodeModelGPT55),
+				ReasoningEffort: reasoningEffortPtr(models.ReasoningEffortHigh),
+				Available:       true,
 			},
 		},
 		{
@@ -2080,7 +2154,11 @@ func TestResolveCodeReviewOrchestratorAvailability(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			actual, err := resolveCodeReviewOrchestratorAvailability(context.Background(), tt.services, uuid.New(), cfg)
+			testConfig := cfg
+			if tt.configure != nil {
+				tt.configure(&testConfig)
+			}
+			actual, err := resolveCodeReviewOrchestratorAvailability(context.Background(), tt.services, uuid.New(), testConfig)
 			if tt.expectErr {
 				require.Error(t, err, "orchestrator availability resolution should propagate lookup failures")
 				return
@@ -2871,7 +2949,7 @@ func newCodeReviewMetadataRows() *pgxmock.Rows {
 
 func newSessionThreadRows() *pgxmock.Rows {
 	return pgxmock.NewRows([]string{
-		"id", "session_id", "org_id", "agent_type", "model_override",
+		"id", "session_id", "org_id", "agent_type", "model_override", "reasoning_effort",
 		"label", "instructions", "file_scope", "status", "agent_session_id", "current_turn", "last_activity_at",
 		"result_summary", "diff", "failure_explanation", "failure_category",
 		"started_at", "completed_at", "created_at", "created_by_source", "created_by_thread_id", "archived_at",

--- a/internal/worker/handlers.go
+++ b/internal/worker/handlers.go
@@ -9729,6 +9729,7 @@ func newContinueSessionHandler(stores *Stores, services *Services, logger zerolo
 				threadOpts := &agent.ContinueSessionOptions{
 					AgentType:            thread.AgentType,
 					ModelOverride:        thread.ModelOverride,
+					ReasoningEffort:      thread.ReasoningEffort,
 					ThreadAgentSessionID: thread.AgentSessionID,
 					ResultAgentSessionID: &resultAgentSessionID,
 					HumanInputRequestID:  humanInputRequestID,

--- a/internal/worker/handlers_test.go
+++ b/internal/worker/handlers_test.go
@@ -2615,7 +2615,7 @@ var workerSessionColumns = []string{
 }
 
 var workerSessionThreadColumns = []string{
-	"id", "session_id", "org_id", "agent_type", "model_override",
+	"id", "session_id", "org_id", "agent_type", "model_override", "reasoning_effort",
 	"label", "instructions", "file_scope", "status", "agent_session_id", "current_turn", "last_activity_at",
 	"result_summary", "diff", "failure_explanation", "failure_category",
 	"started_at", "completed_at", "created_at",
@@ -2656,7 +2656,7 @@ func workerSessionThreadRow(threadID, sessionID, orgID uuid.UUID, agentType mode
 	now := time.Now()
 	nowPtr := &now
 	return []any{
-		threadID, sessionID, orgID, agentType, modelOverride,
+		threadID, sessionID, orgID, agentType, modelOverride, nil,
 		"Thread", nil, []string{}, status, nil, 1, nowPtr,
 		nil, nil, nil, nil,
 		nowPtr, nil, now,
@@ -11901,6 +11901,7 @@ func TestContinueSessionHandler_ReleasesThreadOnContinuationFailure(t *testing.T
 	threadID := uuid.New()
 	issueID := uuid.New()
 	threadModel := models.OpenCodeModelGemini3Flash
+	threadReasoning := models.ReasoningEffortXHigh
 	continuationErr := errors.New("sandbox hydrate failed")
 
 	mock.ExpectQuery("SELECT .* FROM sessions").
@@ -11910,10 +11911,12 @@ func TestContinueSessionHandler_ReleasesThreadOnContinuationFailure(t *testing.T
 				workerSessionRow(sessionID, issueID, orgID, models.SessionStatusIdle, 2, nil, nil)...,
 			),
 		)
+	threadRow := workerSessionThreadRow(threadID, sessionID, orgID, models.AgentTypeOpenCode, &threadModel, models.ThreadStatusRunning)
+	threadRow[5] = &threadReasoning
 	mock.ExpectQuery("SELECT .* FROM session_threads").
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
 		WillReturnRows(pgxmock.NewRows(workerSessionThreadColumns).AddRow(
-			workerSessionThreadRow(threadID, sessionID, orgID, models.AgentTypeOpenCode, &threadModel, models.ThreadStatusRunning)...,
+			threadRow...,
 		))
 	mock.ExpectExec("UPDATE session_threads SET status = @status").
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
@@ -11925,6 +11928,8 @@ func TestContinueSessionHandler_ReleasesThreadOnContinuationFailure(t *testing.T
 			require.Equal(t, models.AgentTypeOpenCode, opts.AgentType, "thread execution should use the thread agent type")
 			require.NotNil(t, opts.ModelOverride, "thread execution should include the thread model override")
 			require.Equal(t, threadModel, *opts.ModelOverride, "thread execution should use the thread model")
+			require.NotNil(t, opts.ReasoningEffort, "thread execution should include the thread reasoning override")
+			require.Equal(t, threadReasoning, *opts.ReasoningEffort, "thread execution should use the thread reasoning effort")
 			return continuationErr
 		},
 	}

--- a/internal/worker/thread_actions.go
+++ b/internal/worker/thread_actions.go
@@ -78,14 +78,15 @@ func newForkSessionThreadHandler(stores *Stores, services *Services, logger zero
 		title := label
 
 		newSession := &models.Session{
-			OrgID:         orgID,
-			RepositoryID:  source.RepositoryID,
-			AgentType:     thread.AgentType,
-			ModelOverride: thread.ModelOverride,
-			Status:        models.SessionStatusIdle,
-			Origin:        models.SessionOriginManual,
-			TargetBranch:  source.TargetBranch,
-			Title:         &title,
+			OrgID:           orgID,
+			RepositoryID:    source.RepositoryID,
+			AgentType:       thread.AgentType,
+			ModelOverride:   thread.ModelOverride,
+			ReasoningEffort: thread.ReasoningEffort,
+			Status:          models.SessionStatusIdle,
+			Origin:          models.SessionOriginManual,
+			TargetBranch:    source.TargetBranch,
+			Title:           &title,
 		}
 		if input.UserID != "" {
 			if uid, err := uuid.Parse(input.UserID); err == nil {

--- a/migrations/000255_session_thread_reasoning_effort.down.sql
+++ b/migrations/000255_session_thread_reasoning_effort.down.sql
@@ -1,0 +1,5 @@
+ALTER TABLE session_threads
+    DROP CONSTRAINT IF EXISTS session_threads_reasoning_effort_check;
+
+ALTER TABLE session_threads
+    DROP COLUMN IF EXISTS reasoning_effort;

--- a/migrations/000255_session_thread_reasoning_effort.up.sql
+++ b/migrations/000255_session_thread_reasoning_effort.up.sql
@@ -1,0 +1,9 @@
+-- Migration 000255: allow each agent tab to override the parent session's
+-- reasoning effort. Code-review reviewer tabs use this to run heterogeneous
+-- reviewer rosters without changing the orchestrator's reasoning level.
+ALTER TABLE session_threads
+    ADD COLUMN reasoning_effort text;
+
+ALTER TABLE session_threads
+    ADD CONSTRAINT session_threads_reasoning_effort_check
+    CHECK (reasoning_effort IS NULL OR reasoning_effort IN ('low', 'medium', 'high', 'xhigh', 'max'));


### PR DESCRIPTION
## Summary
- Add per-reviewer reasoning effort settings with agent-specific option normalization.
- Keep orchestrator reasoning configuration separate from reviewer settings.
- Persist reasoning overrides on session threads and update related types, stores, docs, and tests.

## Testing
- Updated frontend code review interaction tests.
- Updated session thread store tests for reasoning effort persistence.