### PR TITLE
Coalesce pull request health webhook syncs

### DIFF
--- a/internal/db/job_store_test.go
+++ b/internal/db/job_store_test.go
@@ -329,6 +329,35 @@ func TestJobStore_EnqueueWithOpts_SetsCustomMaxAttempts(t *testing.T) {
 	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
 }
 
+func TestJobStore_EnqueueWithOpts_DefersRunAt(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "should create pgx mock pool")
+	defer mock.Close()
+
+	store := NewJobStore(mock)
+	orgID := uuid.New()
+	generatedID := uuid.New()
+	runAt := time.Now().UTC().Add(5 * time.Second)
+
+	mock.ExpectQuery("INSERT INTO jobs[\\s\\S]+run_at").
+		WithArgs(orgID, "default", "deferred", pgxmock.AnyArg(), 4, jobDedupeKeyPtr("deferred:key"), runAt).
+		WillReturnRows(pgxmock.NewRows([]string{"id"}).AddRow(generatedID))
+
+	id, err := store.EnqueueWithOpts(context.Background(), orgID, EnqueueOpts{
+		Queue:     "default",
+		JobType:   "deferred",
+		Payload:   map[string]string{"kind": "debounced"},
+		Priority:  4,
+		DedupeKey: jobDedupeKeyPtr("deferred:key"),
+		RunAt:     &runAt,
+	})
+	require.NoError(t, err, "deferred enqueue should succeed")
+	require.Equal(t, generatedID, id, "deferred enqueue should return the generated job ID")
+	require.NoError(t, mock.ExpectationsWereMet(), "deferred enqueue should persist the requested run time")
+}
+
 func TestJobStore_HasActiveByDedupeKeyFiltersByOrg(t *testing.T) {
 	t.Parallel()
 

--- a/internal/db/jobs.go
+++ b/internal/db/jobs.go
@@ -170,6 +170,9 @@ type EnqueueOpts struct {
 	Payload   any
 	Priority  int
 	DedupeKey *string
+	// RunAt defers the job until the requested time. Nil keeps the jobs table
+	// default of now(), preserving immediate execution for existing callers.
+	RunAt *time.Time
 	// MaxAttempts overrides the jobs table default when positive. Zero keeps
 	// the schema default so existing enqueue call sites retain their current
 	// retry budget.
@@ -610,6 +613,11 @@ func enqueueOn(ctx context.Context, q jobQuerier, orgID uuid.UUID, opts EnqueueO
 		columns = append(columns, "target_node_id")
 		values = append(values, "@target_node_id")
 		args["target_node_id"] = opts.TargetNodeID
+	}
+	if opts.RunAt != nil {
+		columns = append(columns, "run_at")
+		values = append(values, "@run_at")
+		args["run_at"] = opts.RunAt.UTC()
 	}
 	if opts.MaxAttempts > 0 {
 		columns = append(columns, "max_attempts")

--- a/internal/services/github/pr_handlers_test.go
+++ b/internal/services/github/pr_handlers_test.go
@@ -1213,7 +1213,7 @@ func TestHandlePullRequestEvent_ClosedWithoutMergeFlow(t *testing.T) {
 	prMock.ExpectExec("UPDATE pull_requests SET status").
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
 		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
-	dedupeKey := pullRequestStateSyncDedupeKey(prID, "")
+	dedupeKey := pullRequestStateSyncDedupeKey(prID)
 	jobMock.ExpectQuery("INSERT INTO jobs").
 		WithArgs(pgx.NamedArgs{
 			"org_id":     orgID,
@@ -2481,15 +2481,16 @@ func TestHandleCheckSuiteEvent_Success(t *testing.T) {
 	prMock.ExpectExec("UPDATE pull_requests SET ci_status").
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
 		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
-	dedupeKey := pullRequestStateSyncDedupeKey(prID, "check_suite_completed")
+	dedupeKey := pullRequestStateSyncDedupeKey(prID)
 	jobMock.ExpectQuery("INSERT INTO jobs").
 		WithArgs(pgx.NamedArgs{
 			"org_id":     orgID,
 			"queue":      prHealthSyncQueue,
 			"job_type":   prHealthSyncJobType,
 			"payload":    pgxmock.AnyArg(),
-			"priority":   6,
+			"priority":   4,
 			"dedupe_key": &dedupeKey,
+			"run_at":     pgxmock.AnyArg(),
 		}).
 		WillReturnRows(pgxmock.NewRows([]string{"id"}).AddRow(uuid.New()))
 	conclusion := "success"
@@ -2575,15 +2576,16 @@ func TestHandleCheckRunEvent_CompletedEnqueuesHealthSync(t *testing.T) {
 			pgxmock.NewRows(handlerPRColumns).
 				AddRow(handlerPRRow(prID, &sessionID, orgID, "testorg/testrepo", now)...),
 		)
-	dedupeKey := pullRequestStateSyncDedupeKey(prID, "check_run_completed")
+	dedupeKey := pullRequestStateSyncDedupeKey(prID)
 	jobMock.ExpectQuery("INSERT INTO jobs").
 		WithArgs(pgx.NamedArgs{
 			"org_id":     orgID,
 			"queue":      prHealthSyncQueue,
 			"job_type":   prHealthSyncJobType,
 			"payload":    pgxmock.AnyArg(),
-			"priority":   6,
+			"priority":   4,
 			"dedupe_key": &dedupeKey,
+			"run_at":     pgxmock.AnyArg(),
 		}).
 		WillReturnRows(pgxmock.NewRows([]string{"id"}).AddRow(uuid.New()))
 	event := CheckRunEvent{Action: "completed"}
@@ -2623,15 +2625,16 @@ func TestHandleStatusEvent_EnqueuesHealthSyncForHeadSHA(t *testing.T) {
 			pgxmock.NewRows(handlerPRColumns).
 				AddRow(handlerPRRow(prID, &sessionID, orgID, "testorg/testrepo", now)...),
 		)
-	dedupeKey := pullRequestStateSyncDedupeKey(prID, "status:ci/circleci: frontend_lint_format_license:failure")
+	dedupeKey := pullRequestStateSyncDedupeKey(prID)
 	jobMock.ExpectQuery("INSERT INTO jobs").
 		WithArgs(pgx.NamedArgs{
 			"org_id":     orgID,
 			"queue":      prHealthSyncQueue,
 			"job_type":   prHealthSyncJobType,
 			"payload":    pgxmock.AnyArg(),
-			"priority":   6,
+			"priority":   4,
 			"dedupe_key": &dedupeKey,
+			"run_at":     pgxmock.AnyArg(),
 		}).
 		WillReturnRows(pgxmock.NewRows([]string{"id"}).AddRow(uuid.New()))
 

--- a/internal/services/github/pr_health_service.go
+++ b/internal/services/github/pr_health_service.go
@@ -31,6 +31,7 @@ const (
 	prHealthReconcileJobType = "reconcile_pull_request_state"
 	prHealthEnrichJobType    = "enrich_pull_request_health"
 	prMergeWhenReadyJobType  = "merge_pull_request_when_ready"
+	prHealthWebhookDebounce  = 5 * time.Second
 	requiredChecksCacheTTL   = 24 * time.Hour
 	noRequiredChecksCacheTTL = 6 * time.Hour
 )
@@ -1690,22 +1691,32 @@ func (s *PRService) enqueuePullRequestStateSyncWithScope(ctx context.Context, pr
 	if s.jobs == nil {
 		return
 	}
-	dedupeKey := pullRequestStateSyncDedupeKey(pr.ID, scope)
-	_, err := s.jobs.Enqueue(ctx, pr.OrgID, prHealthSyncQueue, prHealthSyncJobType, map[string]string{
-		"org_id":          pr.OrgID.String(),
-		"pull_request_id": pr.ID.String(),
-	}, 6, &dedupeKey)
+	dedupeKey := pullRequestStateSyncDedupeKey(pr.ID)
+	priority := 6
+	var runAt *time.Time
+	if scope != "" {
+		deferred := time.Now().UTC().Add(prHealthWebhookDebounce)
+		runAt = &deferred
+		priority = 4
+	}
+	_, err := s.jobs.EnqueueWithOpts(ctx, pr.OrgID, db.EnqueueOpts{
+		Queue:   prHealthSyncQueue,
+		JobType: prHealthSyncJobType,
+		Payload: map[string]string{
+			"org_id":          pr.OrgID.String(),
+			"pull_request_id": pr.ID.String(),
+		},
+		Priority:  priority,
+		DedupeKey: &dedupeKey,
+		RunAt:     runAt,
+	})
 	if err != nil {
 		s.logger.Warn().Err(err).Str("pull_request_id", pr.ID.String()).Msg("failed to enqueue pull request health sync")
 	}
 }
 
-func pullRequestStateSyncDedupeKey(pullRequestID uuid.UUID, scope string) string {
-	dedupeKey := fmt.Sprintf("%s:%s", prHealthSyncJobType, pullRequestID.String())
-	if scope != "" {
-		dedupeKey = fmt.Sprintf("%s:%s", dedupeKey, scope)
-	}
-	return dedupeKey
+func pullRequestStateSyncDedupeKey(pullRequestID uuid.UUID) string {
+	return fmt.Sprintf("%s:%s", prHealthSyncJobType, pullRequestID.String())
 }
 
 func (s *PRService) enqueuePullRequestHealthEnrichment(ctx context.Context, pr models.PullRequest, version int64) {

--- a/internal/services/github/pr_health_service_test.go
+++ b/internal/services/github/pr_health_service_test.go
@@ -1006,30 +1006,12 @@ func TestPullRequestStateSyncDedupeKey(t *testing.T) {
 	t.Parallel()
 
 	prID := uuid.MustParse("11111111-1111-1111-1111-111111111111")
-	tests := []struct {
-		name     string
-		scope    string
-		expected string
-	}{
-		{
-			name:     "generic per pull request sync key",
-			scope:    "",
-			expected: "sync_pull_request_state:11111111-1111-1111-1111-111111111111",
-		},
-		{
-			name:     "check completion sync key",
-			scope:    "check_run_completed",
-			expected: "sync_pull_request_state:11111111-1111-1111-1111-111111111111:check_run_completed",
-		},
-	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-
-			require.Equal(t, tt.expected, pullRequestStateSyncDedupeKey(prID, tt.scope), "dedupe key should include the optional sync wake-up scope")
-		})
-	}
+	require.Equal(t,
+		"sync_pull_request_state:11111111-1111-1111-1111-111111111111",
+		pullRequestStateSyncDedupeKey(prID),
+		"all sync triggers for one pull request should share a dedupe key",
+	)
 }
 
 func TestPRServiceGetPullRequestHealthEnqueuesFollowUpWhenInlineMergeabilityPending(t *testing.T) {


### PR DESCRIPTION
## What changed

- exposes deferred `run_at` scheduling through the job enqueue options
- gives every pull request health sync one PR-scoped dedupe key
- debounces webhook-triggered health syncs for five seconds
- lowers only webhook-triggered syncs below code review priority while keeping lifecycle/manual syncs immediate

## Why

Status and check webhooks used context/state-specific dedupe keys, so a CI burst produced many full GitHub health syncs for the same pull request. Each sync made multiple GitHub API calls and could consume the installation's shared quota, delaying code reviews.

## Impact

A webhook burst now creates at most one active full health sync per pull request during the debounce window. This is the containment step; the follow-up PR replaces webhook-triggered GitHub reads with a durable local check projection.

## Validation

- `go test ./internal/db ./internal/services/github`
- `go vet ./internal/db ./internal/services/github`
- pre-commit `lint-stores` and `gofmt`