### PR TITLE
Add GitHub API rate-limit metrics and alerting

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -46,6 +46,7 @@ import (
 	"github.com/assembledhq/143/internal/services/domains"
 	ghservice "github.com/assembledhq/143/internal/services/github"
 	"github.com/assembledhq/143/internal/services/github/identity"
+	githubtelemetry "github.com/assembledhq/143/internal/services/github/telemetry"
 	"github.com/assembledhq/143/internal/services/ingestion"
 	"github.com/assembledhq/143/internal/services/linear"
 	"github.com/assembledhq/143/internal/services/ownerloss"
@@ -1315,7 +1316,7 @@ func buildServices(
 	fileReader sandbox.FileReader,
 ) *worker.Services {
 	// GitHub App service (for installation tokens, PR creation).
-	ghSvc, err := ghservice.NewService(cfg.GitHubAppID, cfg.GitHubAppPrivateKey)
+	ghSvc, err := ghservice.NewService(cfg.GitHubAppID, cfg.GitHubAppPrivateKey, logger)
 	if err != nil {
 		logger.Error().Err(err).Msg("failed to initialize GitHub App service — all Phase 3+ services disabled")
 		return nil
@@ -1772,18 +1773,21 @@ func buildServices(
 		},
 	)
 	svc := &worker.Services{
-		Orchestrator:        orchestrator,
-		PR:                  prService,
-		Failure:             failureSvc,
-		SandboxProvider:     sandboxProvider,
-		ProjectTasks:        projectTaskUpdater,
-		AutomationRuns:      automationRunUpdater,
-		Prioritization:      prioritizationSvc,
-		PM:                  pmSvc,
-		SlackSummarizer:     slackSummarizer,
-		LLM:                 llmClient,
-		GitHub:              ghSvc,
-		CodeReviews:         codereviewsvc.NewGitHubSubmitter(ghSvc),
+		Orchestrator:    orchestrator,
+		PR:              prService,
+		Failure:         failureSvc,
+		SandboxProvider: sandboxProvider,
+		ProjectTasks:    projectTaskUpdater,
+		AutomationRuns:  automationRunUpdater,
+		Prioritization:  prioritizationSvc,
+		PM:              pmSvc,
+		SlackSummarizer: slackSummarizer,
+		LLM:             llmClient,
+		GitHub:          ghSvc,
+		CodeReviews: codereviewsvc.NewGitHubSubmitter(
+			ghSvc,
+			codereviewsvc.WithGitHubSubmitterHTTPClient(githubtelemetry.NewHTTPClient(15*time.Second, logger)),
+		),
 		CodeReviewLifecycle: codeReviewLifecycle,
 		CodingAgents:        agentEnv,
 		GitHubOrgRoster:     ghSvc,

--- a/deploy/deploy_config_test.go
+++ b/deploy/deploy_config_test.go
@@ -1884,6 +1884,7 @@ func TestGrafanaProvisionedDashboardsUseValidDatasourcesAndRangeQueries(t *testi
 	require.True(t, dashboardNames["primary-operations.json"], "primary operations dashboard should be provisioned from the repo")
 	require.True(t, dashboardNames["preview-health.json"], "preview health dashboard should be provisioned from the repo")
 	require.True(t, dashboardNames["worker-runtime.json"], "worker runtime dashboard should be provisioned from the repo")
+	require.True(t, dashboardNames["github-api-health.json"], "GitHub API health dashboard should be provisioned from the repo")
 
 	for _, dashboardFile := range dashboardFiles {
 		if dashboardFile.IsDir() || !strings.HasSuffix(dashboardFile.Name(), ".json") {
@@ -1932,6 +1933,76 @@ func TestGrafanaProvisionedDashboardsUseValidDatasourcesAndRangeQueries(t *testi
 			}
 		}
 	}
+}
+
+func TestGitHubAPIHealthDashboardUsesFocusedStructuredTelemetry(t *testing.T) {
+	t.Parallel()
+
+	rawDashboard, err := os.ReadFile("../deploy/grafana/provisioning/dashboards/github-api-health.json")
+	require.NoError(t, err, "test should read the GitHub API health dashboard")
+
+	var dashboard struct {
+		Title   string `json:"title"`
+		Refresh string `json:"refresh"`
+		Time    struct {
+			From string `json:"from"`
+		} `json:"time"`
+		Panels []struct {
+			Type        string `json:"type"`
+			Title       string `json:"title"`
+			Description string `json:"description"`
+			Targets     []struct {
+				Expr string `json:"expr"`
+			} `json:"targets"`
+		} `json:"panels"`
+	}
+	require.NoError(t, json.Unmarshal(rawDashboard, &dashboard), "GitHub API health dashboard should be valid JSON")
+	require.Equal(t, "GitHub API Health", dashboard.Title, "dashboard should have the stable operator-facing title")
+	require.Equal(t, "1m", dashboard.Refresh, "dashboard should refresh frequently enough for quota incidents without creating continuous churn")
+	require.Equal(t, "now-6h", dashboard.Time.From, "dashboard should default to a focused operational time window")
+
+	expectedPanels := map[string]bool{
+		"API requests":                                false,
+		"Rate limits hit":                             false,
+		"Upstream / transport failures":               false,
+		"Lowest quota headroom":                       false,
+		"Request volume by result":                    false,
+		"Rate-limit rejections by kind":               false,
+		"Quota headroom by installation and resource": false,
+		"GitHub API latency":                          false,
+		"Top API routes":                              false,
+		"Rate-limit sources":                          false,
+		"Recent rate-limit responses":                 false,
+	}
+	nonRowPanels := 0
+	for _, panel := range dashboard.Panels {
+		if panel.Type == "row" {
+			continue
+		}
+		nonRowPanels++
+		require.NotEmpty(t, panel.Description, "panel %q should explain how operators should interpret it", panel.Title)
+		if _, ok := expectedPanels[panel.Title]; ok {
+			expectedPanels[panel.Title] = true
+		}
+		for _, target := range panel.Targets {
+			require.Contains(t, target.Expr, `_msg:"github api request"`, "panel %q should use the canonical structured telemetry event", panel.Title)
+			require.NotContains(t, target.Expr, "API rate limit exceeded", "panel %q should not scrape unstable GitHub error prose", panel.Title)
+		}
+	}
+	require.Equal(t, 11, nonRowPanels, "dashboard should stay focused instead of accumulating low-value panels")
+	require.Equal(t, map[string]bool{
+		"API requests":                                true,
+		"Rate limits hit":                             true,
+		"Upstream / transport failures":               true,
+		"Lowest quota headroom":                       true,
+		"Request volume by result":                    true,
+		"Rate-limit rejections by kind":               true,
+		"Quota headroom by installation and resource": true,
+		"GitHub API latency":                          true,
+		"Top API routes":                              true,
+		"Rate-limit sources":                          true,
+		"Recent rate-limit responses":                 true,
+	}, expectedPanels, "dashboard should contain the complete curated panel set")
 }
 
 func TestPreviewHealthDashboardStaysFocused(t *testing.T) {
@@ -2146,6 +2217,9 @@ func TestProductionAlertsUseValidLogsQLRangeFilters(t *testing.T) {
 	alertConfig := string(alerts)
 	require.NotContains(t, alertConfig, "status:[", "VictoriaLogs numeric ranges should use field:range[...] syntax so vmalert can parse the rules")
 	require.GreaterOrEqual(t, strings.Count(alertConfig, "status:range[500,599]"), 3, "API 5xx alert rules should filter inclusive 500-599 statuses with valid LogsQL range syntax")
+	require.Contains(t, alertConfig, "GitHubAPIRateLimitSustained", "production alerts should detect sustained GitHub throttling")
+	require.Contains(t, alertConfig, `_msg:"github api request" AND github_rate_limited:true`, "GitHub alert should use the canonical structured rate-limit signal")
+	require.Contains(t, alertConfig, "for: 5m", "GitHub rate-limit alert should require sustained impact to avoid paging on one transient rejection")
 }
 
 func TestLoggingDesignDocsTrackProvisionedDashboardsAndAlerts(t *testing.T) {

--- a/deploy/grafana/provisioning/dashboards/github-api-health.json
+++ b/deploy/grafana/provisioning/dashboards/github-api-health.json
@@ -1,0 +1,390 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": { "type": "grafana", "uid": "-- Grafana --" },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "description": "Focused health view for server-owned GitHub HTTP API traffic. Shows exact request volume, throttling, quota headroom, upstream reliability, and latency from structured request summaries. Git protocol traffic and GitHub calls made directly inside sandboxes are intentionally out of scope.",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "type": "row",
+      "id": 100,
+      "title": "Health summary for selected range",
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 0 },
+      "collapsed": false,
+      "panels": []
+    },
+    {
+      "type": "stat",
+      "id": 1,
+      "title": "API requests",
+      "description": "Completed and transport-failed server-owned GitHub API requests in the selected time range. OAuth token exchange and git protocol traffic are excluded.",
+      "datasource": { "type": "victoriametrics-logs-datasource", "uid": "victorialogs" },
+      "gridPos": { "h": 5, "w": 6, "x": 0, "y": 1 },
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "orientation": "auto",
+        "textMode": "auto",
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "fixed-color", "fixedColor": "blue" },
+          "unit": "short",
+          "min": 0
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "queryType": "stats",
+          "expr": "_msg:\"github api request\" | stats count() as requests"
+        }
+      ]
+    },
+    {
+      "type": "stat",
+      "id": 2,
+      "title": "Rate limits hit",
+      "description": "Requests rejected by GitHub primary or secondary rate limiting. One transient rejection is visible; ten or more in the selected range is treated as an incident signal.",
+      "datasource": { "type": "victoriametrics-logs-datasource", "uid": "victorialogs" },
+      "gridPos": { "h": 5, "w": 6, "x": 6, "y": 1 },
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "orientation": "auto",
+        "textMode": "auto",
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "auto"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 1 },
+              { "color": "red", "value": 10 }
+            ]
+          },
+          "unit": "short",
+          "min": 0
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "queryType": "stats",
+          "expr": "_msg:\"github api request\" AND github_rate_limited:true | stats count() as rate_limits"
+        }
+      ]
+    },
+    {
+      "type": "stat",
+      "id": 3,
+      "title": "Upstream / transport failures",
+      "description": "GitHub 5xx responses plus network-level failures. Expected 4xx responses are excluded so this remains a reliability signal instead of a general error counter.",
+      "datasource": { "type": "victoriametrics-logs-datasource", "uid": "victorialogs" },
+      "gridPos": { "h": 5, "w": 6, "x": 12, "y": 1 },
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "orientation": "auto",
+        "textMode": "auto",
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "auto"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 1 },
+              { "color": "red", "value": 5 }
+            ]
+          },
+          "unit": "short",
+          "min": 0
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "queryType": "stats",
+          "expr": "_msg:\"github api request\" AND (github_result:\"server_error\" OR github_result:\"transport_error\") | stats count() as failures"
+        }
+      ]
+    },
+    {
+      "type": "stat",
+      "id": 4,
+      "title": "Lowest quota headroom",
+      "description": "Lowest X-RateLimit-Remaining percentage observed in the selected range across all installations and resources. This is a low-water mark, not the current value.",
+      "datasource": { "type": "victoriametrics-logs-datasource", "uid": "victorialogs" },
+      "gridPos": { "h": 5, "w": 6, "x": 18, "y": 1 },
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "orientation": "auto",
+        "textMode": "auto",
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "auto"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "red", "value": null },
+              { "color": "yellow", "value": 10 },
+              { "color": "green", "value": 20 }
+            ]
+          },
+          "unit": "percent",
+          "min": 0,
+          "max": 100,
+          "decimals": 1
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "queryType": "stats",
+          "expr": "_msg:\"github api request\" | stats min(github_rate_limit_remaining_pct) as lowest_remaining_pct"
+        }
+      ]
+    },
+    {
+      "type": "row",
+      "id": 101,
+      "title": "Traffic, throttling, and headroom",
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 6 },
+      "collapsed": false,
+      "panels": []
+    },
+    {
+      "type": "timeseries",
+      "id": 5,
+      "title": "Request volume by result",
+      "description": "Request throughput split into success, expected client errors, GitHub/server failures, transport failures, and rate limiting.",
+      "datasource": { "type": "victoriametrics-logs-datasource", "uid": "victorialogs" },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 7 },
+      "fieldConfig": {
+        "defaults": { "unit": "short", "min": 0 },
+        "overrides": []
+      },
+      "options": {
+        "legend": { "displayMode": "list", "placement": "bottom", "calcs": [] },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "queryType": "statsRange",
+          "expr": "_msg:\"github api request\" | stats by (github_result) count() as requests",
+          "step": "$__interval"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "id": 6,
+      "title": "Rate-limit rejections by kind",
+      "description": "Primary quota exhaustion versus secondary/abuse throttling. Empty is healthy.",
+      "datasource": { "type": "victoriametrics-logs-datasource", "uid": "victorialogs" },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 7 },
+      "fieldConfig": {
+        "defaults": { "unit": "short", "min": 0 },
+        "overrides": []
+      },
+      "options": {
+        "legend": { "displayMode": "list", "placement": "bottom", "calcs": [] },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "queryType": "statsRange",
+          "expr": "_msg:\"github api request\" AND github_rate_limited:true | stats by (github_rate_limit_kind) count() as rate_limits",
+          "step": "$__interval"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "id": 7,
+      "title": "Quota headroom by installation and resource",
+      "description": "Low-water quota percentage per time bucket. Series are separated by auth mode, GitHub App installation when applicable, and rate-limit resource; a sustained fall below 20% warrants investigation.",
+      "datasource": { "type": "victoriametrics-logs-datasource", "uid": "victorialogs" },
+      "gridPos": { "h": 9, "w": 12, "x": 0, "y": 15 },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent",
+          "min": 0,
+          "max": 100,
+          "decimals": 1,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "red", "value": null },
+              { "color": "yellow", "value": 10 },
+              { "color": "green", "value": 20 }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["lastNotNull", "min"] },
+        "tooltip": { "mode": "multi", "sort": "asc" }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "queryType": "statsRange",
+          "expr": "_msg:\"github api request\" | stats by (github_auth_type, github_installation_id, github_rate_limit_resource) min(github_rate_limit_remaining_pct) as remaining_pct",
+          "step": "$__interval"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "id": 8,
+      "title": "GitHub API latency",
+      "description": "End-to-end HTTP latency for all server-owned GitHub API requests. Overall p50 and p95 avoid a noisy series per endpoint; route-level p95 is available below.",
+      "datasource": { "type": "victoriametrics-logs-datasource", "uid": "victorialogs" },
+      "gridPos": { "h": 9, "w": 12, "x": 12, "y": 15 },
+      "fieldConfig": {
+        "defaults": { "unit": "ms", "min": 0 },
+        "overrides": []
+      },
+      "options": {
+        "legend": { "displayMode": "list", "placement": "bottom", "calcs": ["lastNotNull"] },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "queryType": "statsRange",
+          "expr": "_msg:\"github api request\" | stats quantile(0.50, github_duration_ms) as p50_ms",
+          "step": "$__interval"
+        },
+        {
+          "refId": "B",
+          "queryType": "statsRange",
+          "expr": "_msg:\"github api request\" | stats quantile(0.95, github_duration_ms) as p95_ms",
+          "step": "$__interval"
+        }
+      ]
+    },
+    {
+      "type": "row",
+      "id": 102,
+      "title": "Focused drilldowns",
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 24 },
+      "collapsed": false,
+      "panels": []
+    },
+    {
+      "type": "table",
+      "id": 9,
+      "title": "Top API routes",
+      "description": "The twenty busiest normalized routes with p95 latency. Repository owners, names, IDs, refs, paths, and query strings are excluded from the route dimension to prevent cardinality noise.",
+      "datasource": { "type": "victoriametrics-logs-datasource", "uid": "victorialogs" },
+      "gridPos": { "h": 9, "w": 12, "x": 0, "y": 25 },
+      "options": { "showHeader": true },
+      "fieldConfig": {
+        "defaults": { "custom": { "align": "auto", "displayMode": "auto" } },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "queryType": "stats",
+          "expr": "_msg:\"github api request\" | stats by (github_method, github_route) count() as requests, quantile(0.95, github_duration_ms) as p95_ms | sort by (requests desc) | limit 20"
+        }
+      ]
+    },
+    {
+      "type": "table",
+      "id": 10,
+      "title": "Rate-limit sources",
+      "description": "Installations, auth modes, routes, and repositories that actually received rate-limit responses. Limited to the top twenty combinations to keep the table actionable.",
+      "datasource": { "type": "victoriametrics-logs-datasource", "uid": "victorialogs" },
+      "gridPos": { "h": 9, "w": 12, "x": 12, "y": 25 },
+      "options": { "showHeader": true },
+      "fieldConfig": {
+        "defaults": { "custom": { "align": "auto", "displayMode": "auto" } },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "queryType": "stats",
+          "expr": "_msg:\"github api request\" AND github_rate_limited:true | stats by (github_installation_id, github_auth_type, github_rate_limit_kind, github_route, github_repository) count() as rate_limits | sort by (rate_limits desc) | limit 20"
+        }
+      ]
+    },
+    {
+      "type": "logs",
+      "id": 11,
+      "title": "Recent rate-limit responses",
+      "description": "Raw structured request summaries for the latest primary and secondary rate-limit responses. Expand a row for reset time, remaining quota, retry guidance, request ID, and repository context.",
+      "datasource": { "type": "victoriametrics-logs-datasource", "uid": "victorialogs" },
+      "gridPos": { "h": 10, "w": 24, "x": 0, "y": 34 },
+      "options": {
+        "showTime": true,
+        "showLabels": false,
+        "showCommonLabels": false,
+        "wrapLogMessage": true,
+        "prettifyLogMessage": false,
+        "enableLogDetails": true,
+        "dedupStrategy": "none",
+        "sortOrder": "Descending"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "queryType": "instant",
+          "expr": "_msg:\"github api request\" AND github_rate_limited:true",
+          "maxLines": 100
+        }
+      ]
+    }
+  ],
+  "refresh": "1m",
+  "schemaVersion": 42,
+  "tags": ["github", "api", "rate-limits", "platform"],
+  "templating": { "list": [] },
+  "time": { "from": "now-6h", "to": "now" },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "GitHub API Health",
+  "uid": "github-api-health",
+  "version": 1,
+  "weekStart": ""
+}

--- a/deploy/vmalert/rules/production-alerts.yml
+++ b/deploy/vmalert/rules/production-alerts.yml
@@ -182,6 +182,26 @@ groups:
           description: 'Workers logged {{ $value }} `push_pr_changes failed` errors in the last 15 minutes.'
           runbook: 'Filter VictoriaLogs for service=worker _msg="push_pr_changes failed". Common causes: snapshot hydration, git push (token / branch protection), or sandbox creation.'
 
+  - name: github-api-health
+    type: vlogs
+    interval: 1m
+    rules:
+      # Do not alert on a single transient rejection. This requires a sustained
+      # burst: at least ten rejected requests in each rolling 10-minute window
+      # for five minutes. The dashboard still exposes every individual hit.
+      - alert: GitHubAPIRateLimitSustained
+        expr: '_time:10m _msg:"github api request" AND github_rate_limited:true | stats count() as rate_limits | filter rate_limits:>9'
+        for: 5m
+        labels:
+          service: github
+          severity: warning
+          team: platform
+          signal: logs
+        annotations:
+          summary: 'GitHub API rate limiting is sustained'
+          description: 'GitHub rejected {{ $value }} server-owned API requests for rate limiting in the rolling 10-minute window, sustained for five minutes.'
+          runbook: 'Open the GitHub API Health dashboard. Check quota headroom, installation ID, rate-limit kind, and the top affected normalized routes before increasing retries or concurrency.'
+
   - name: dns-health
     type: vlogs
     interval: 1m

--- a/docs/design/implemented/47-logging-victorialogs.md
+++ b/docs/design/implemented/47-logging-victorialogs.md
@@ -2,7 +2,7 @@
 
 > **Status:** Implemented | **Last reviewed:** 2026-05-06
 >
-> **Implementation notes:** VictoriaLogs/Grafana Docker Compose, Vector collector config, logging-node cloud-init, deploy/provision script support, `make logs` / `make logs-query`, provisioned Grafana error, platform health, primary operations, preview health, worker deploy, and worker runtime dashboards, and repo-owned `vmalert` alert rules are implemented. Scheduler heartbeat alerts are tracked as ongoing operational work outside this doc.
+> **Implementation notes:** VictoriaLogs/Grafana Docker Compose, Vector collector config, logging-node cloud-init, deploy/provision script support, `make logs` / `make logs-query`, provisioned Grafana error, platform health, primary operations, preview health, worker deploy, worker runtime, and GitHub API health dashboards, and repo-owned `vmalert` alert rules are implemented. Scheduler heartbeat alerts are tracked as ongoing operational work outside this doc.
 
 Self-hosted VictoriaLogs + Grafana stack on a dedicated Hetzner logging server, with Vector collectors on the app, worker, and logging servers.
 
@@ -354,10 +354,11 @@ Provisioning workflow:
 2. The provisioned platform health dashboard lives at `deploy/grafana/provisioning/dashboards/platform-health.json` and is organized around actionable queue and worker-capacity signals first: ready jobs waiting, oldest wait, dead-letter jobs, active sandbox containers, and lowest CPU/RAM headroom from runtime samples. API health and session failure drilldowns remain below the headline operational snapshot.
 3. The primary operations dashboard lives at `deploy/grafana/provisioning/dashboards/primary-operations.json` and gives the broad fleet view: active sessions, previews, containers, queue pressure, host CPU/RAM, and worker load.
 4. The worker runtime dashboard lives at `deploy/grafana/provisioning/dashboards/worker-runtime.json` and is the preferred Grafana view for current worker execution: running jobs by worker and type, active sandbox containers by worker, and active container CPU/RAM/disk allocation by worker. It uses DB-backed low-cardinality structured samples (`platform health: worker load sample` and `platform health: running job sample`) instead of raw Docker log metadata, because Docker stdout does not contain authoritative job ownership or cgroup allocation state.
-5. The Grafana dashboard provider uses `disableDeletion: false`, so removed dashboard JSON files are deleted from Grafana after provisioning resync.
-6. The repo-owned alert rules live at `deploy/vmalert/rules/production-alerts.yml` and are evaluated by `vmalert` against VictoriaLogs, then routed through Alertmanager.
-7. `deploy-logging` syncs `deploy/grafana/provisioning/`, `deploy/vmalert/rules`, `docker-compose.vector.yml`, and `deploy/vector.yaml` before recreating the logging stack. This makes dashboard, datasource, Vector, and alert rule edits apply through normal deploys. App, worker, and logging deploys wait for Vector's Docker healthcheck to leave the initial `starting` state before deciding whether log collection is healthy.
-8. Scheduler heartbeat alerts should wait for dedicated heartbeat signals so the rules are not guesswork.
+5. The GitHub API health dashboard lives at `deploy/grafana/provisioning/dashboards/github-api-health.json`. It uses the canonical `_msg:"github api request"` event emitted once per server-owned GitHub HTTP API request. Endpoint paths are normalized before logging; authorization headers and query values are never logged. The event carries request result and latency plus rate-limit limit, remaining, used, reset, resource, retry-after, auth type, installation ID, and repository dimensions when GitHub supplies them. The dashboard intentionally excludes git protocol traffic and calls made directly inside sandboxes.
+6. The Grafana dashboard provider uses `disableDeletion: false`, so removed dashboard JSON files are deleted from Grafana after provisioning resync.
+7. The repo-owned alert rules live at `deploy/vmalert/rules/production-alerts.yml` and are evaluated by `vmalert` against VictoriaLogs, then routed through Alertmanager. GitHub throttling alerts require a sustained burst rather than firing on one transient rate-limit response.
+8. `deploy-logging` syncs `deploy/grafana/provisioning/`, `deploy/vmalert/rules`, `docker-compose.vector.yml`, and `deploy/vector.yaml` before recreating the logging stack. This makes dashboard, datasource, Vector, and alert rule edits apply through normal deploys. App, worker, and logging deploys wait for Vector's Docker healthcheck to leave the initial `starting` state before deciding whether log collection is healthy.
+9. Scheduler heartbeat alerts should wait for dedicated heartbeat signals so the rules are not guesswork.
 
 Vector's API is enabled in `deploy/vector.yaml` via top-level `api.enabled` and
 `api.address`; do not pass API settings as CLI flags in compose. Deploy
@@ -393,6 +394,10 @@ service:api AND duration_ms:range(1000, Inf)
 
 # API request traffic by status class
 service:api AND (_msg:"request" OR _msg:"request failed") | stats by (status_class) count() as requests
+
+# GitHub API request volume and rate-limit responses
+_msg:"github api request" | stats by (github_result) count() as requests
+_msg:"github api request" AND github_rate_limited:true | stats by (github_installation_id, github_rate_limit_kind) count() as rate_limits
 ```
 
 ## Alerting

--- a/internal/api/handlers/auth.go
+++ b/internal/api/handlers/auth.go
@@ -26,6 +26,7 @@ import (
 	"github.com/assembledhq/143/internal/models"
 	"github.com/assembledhq/143/internal/services/domains"
 	"github.com/assembledhq/143/internal/services/email"
+	githubtelemetry "github.com/assembledhq/143/internal/services/github/telemetry"
 )
 
 type githubOrgAutoJoinVerifier interface {
@@ -73,6 +74,14 @@ func (h *AuthHandler) SetGitHubURLsForTest(apiBaseURL, oauthBaseURL string, clie
 	h.gitHubAPIBaseURL = apiBaseURL
 	h.gitHubOAuthBaseURL = oauthBaseURL
 	h.httpClient = client
+}
+
+// SetGitHubHTTPClient wires the instrumented client used for server-owned
+// GitHub OAuth and API requests.
+func (h *AuthHandler) SetGitHubHTTPClient(client *http.Client) {
+	if client != nil {
+		h.httpClient = client
+	}
 }
 
 func (h *AuthHandler) gitHubAPIBase() string {
@@ -539,14 +548,14 @@ func (h *AuthHandler) Callback(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Exchange code for access token
-	tokenResp, err := h.exchangeGitHubCode(code)
+	tokenResp, err := h.exchangeGitHubCode(r.Context(), code)
 	if err != nil {
 		writeError(w, r, http.StatusInternalServerError, "TOKEN_EXCHANGE_FAILED", "failed to exchange code", err)
 		return
 	}
 
 	// Fetch GitHub user
-	ghUser, err := h.fetchGitHubUser(tokenResp.AccessToken)
+	ghUser, err := h.fetchGitHubUser(r.Context(), tokenResp.AccessToken)
 	if err != nil {
 		writeError(w, r, http.StatusInternalServerError, "GITHUB_API_FAILED", "failed to fetch GitHub user", err)
 		return
@@ -1638,14 +1647,18 @@ type githubUser struct {
 	AvatarURL string `json:"avatar_url"`
 }
 
-func (h *AuthHandler) exchangeGitHubCode(code string) (*githubTokenResponse, error) {
+func (h *AuthHandler) exchangeGitHubCode(ctx context.Context, code string) (*githubTokenResponse, error) {
 	data := url.Values{
 		"client_id":     {h.cfg.GitHubOAuthClientID},
 		"client_secret": {h.cfg.GitHubOAuthClientSecret},
 		"code":          {code},
 	}
 
-	req, err := http.NewRequest("POST", h.gitHubOAuthBase()+"/login/oauth/access_token", nil)
+	ctx = githubtelemetry.WithRequestMetadata(ctx, githubtelemetry.RequestMetadata{
+		Kind:     githubtelemetry.RequestKindOAuth,
+		AuthType: githubtelemetry.AuthTypeOAuth,
+	})
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, h.gitHubOAuthBase()+"/login/oauth/access_token", nil)
 	if err != nil {
 		return nil, err
 	}
@@ -1668,8 +1681,12 @@ func (h *AuthHandler) exchangeGitHubCode(code string) (*githubTokenResponse, err
 	return &tokenResp, nil
 }
 
-func (h *AuthHandler) fetchGitHubUser(accessToken string) (*githubUser, error) {
-	req, err := http.NewRequest("GET", h.gitHubAPIBase()+"/user", nil)
+func (h *AuthHandler) fetchGitHubUser(ctx context.Context, accessToken string) (*githubUser, error) {
+	ctx = githubtelemetry.WithRequestMetadata(ctx, githubtelemetry.RequestMetadata{
+		Kind:     githubtelemetry.RequestKindAPI,
+		AuthType: githubtelemetry.AuthTypeUser,
+	})
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, h.gitHubAPIBase()+"/user", nil)
 	if err != nil {
 		return nil, err
 	}
@@ -1739,6 +1756,10 @@ func fetchGitHubNoreplyEmailFrom(ctx context.Context, client *http.Client, email
 // missing list as "no information" (fallback noreply address, email not
 // provider-verified).
 func fetchGitHubEmailsFrom(ctx context.Context, client *http.Client, emailsURL, accessToken string) []gitHubEmail {
+	ctx = githubtelemetry.WithRequestMetadata(ctx, githubtelemetry.RequestMetadata{
+		Kind:     githubtelemetry.RequestKindAPI,
+		AuthType: githubtelemetry.AuthTypeUser,
+	})
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, emailsURL, nil)
 	if err != nil {
 		return nil

--- a/internal/api/handlers/integrations.go
+++ b/internal/api/handlers/integrations.go
@@ -24,6 +24,7 @@ import (
 	"github.com/assembledhq/143/internal/models"
 	"github.com/assembledhq/143/internal/services/externalidentity"
 	ghapp "github.com/assembledhq/143/internal/services/github"
+	githubtelemetry "github.com/assembledhq/143/internal/services/github/telemetry"
 	"github.com/assembledhq/143/internal/services/ingestion"
 	linearservice "github.com/assembledhq/143/internal/services/linear"
 	"github.com/go-chi/chi/v5"
@@ -203,6 +204,7 @@ type IntegrationHandler struct {
 	baseURL          string
 	frontendURL      string
 	client           *http.Client
+	githubHTTPClient *http.Client
 
 	// untrustedURLClient fetches user-supplied URLs (e.g. a custom Mezmo
 	// base_url). It blocks private/loopback/metadata addresses at dial time;
@@ -356,6 +358,23 @@ func WithGitHubIntegrationOAuth(clientID, secret string) IntegrationHandlerOptio
 		h.githubClientID = clientID
 		h.githubSecret = secret
 	}
+}
+
+// WithGitHubHTTPClient configures the instrumented client used only for
+// server-owned GitHub requests. Other provider calls continue to use client.
+func WithGitHubHTTPClient(client *http.Client) IntegrationHandlerOption {
+	return func(h *IntegrationHandler) {
+		if client != nil {
+			h.githubHTTPClient = client
+		}
+	}
+}
+
+func (h *IntegrationHandler) gitHubClient() *http.Client {
+	if h.githubHTTPClient != nil {
+		return h.githubHTTPClient
+	}
+	return h.client
 }
 
 // WithGitHubAppSlug configures the GitHub App slug for the installation flow.
@@ -1582,7 +1601,7 @@ func (h *IntegrationHandler) SyncGitHubRepos(w http.ResponseWriter, r *http.Requ
 		return
 	}
 
-	repos, err := h.listInstallationRepos(ctx, token)
+	repos, err := h.listInstallationRepos(ctx, token, config.InstallationID)
 	if err != nil {
 		zerolog.Ctx(ctx).Warn().Err(err).Msg("failed to list installation repos for sync")
 		writeError(w, r, http.StatusBadGateway, "LIST_REPOS_FAILED", "failed to list github repositories")
@@ -1614,7 +1633,12 @@ type githubInstallationRepo struct {
 
 // listInstallationRepos calls the GitHub API to list all repos accessible
 // to the given installation token.
-func (h *IntegrationHandler) listInstallationRepos(ctx context.Context, token string) ([]githubInstallationRepo, error) {
+func (h *IntegrationHandler) listInstallationRepos(ctx context.Context, token string, installationID int64) ([]githubInstallationRepo, error) {
+	ctx = githubtelemetry.WithRequestMetadata(ctx, githubtelemetry.RequestMetadata{
+		Kind:           githubtelemetry.RequestKindAPI,
+		AuthType:       githubtelemetry.AuthTypeAppInstallation,
+		InstallationID: installationID,
+	})
 	nextURL := githubAPIURL + "/installation/repositories?per_page=100"
 	var repos []githubInstallationRepo
 	for nextURL != "" {
@@ -1625,7 +1649,7 @@ func (h *IntegrationHandler) listInstallationRepos(ctx context.Context, token st
 		req.Header.Set("Authorization", "token "+token)
 		req.Header.Set("Accept", "application/vnd.github+json")
 
-		resp, err := h.client.Do(req)
+		resp, err := h.gitHubClient().Do(req)
 		if err != nil {
 			return nil, err
 		}
@@ -1687,7 +1711,7 @@ func (h *IntegrationHandler) ListGitHubInstallationRepositories(w http.ResponseW
 		writeError(w, r, http.StatusBadGateway, "GITHUB_TOKEN_FAILED", "failed to get github installation token", err)
 		return
 	}
-	repos, err := h.listInstallationRepos(ctx, token)
+	repos, err := h.listInstallationRepos(ctx, token, link.InstallationID)
 	if err != nil {
 		writeError(w, r, http.StatusBadGateway, "LIST_REPOS_FAILED", "failed to list github repositories", err)
 		return
@@ -1780,7 +1804,7 @@ func (h *IntegrationHandler) ClaimGitHubInstallationRepositories(w http.Response
 		writeError(w, r, http.StatusBadGateway, "GITHUB_TOKEN_FAILED", "failed to get github installation token", err)
 		return
 	}
-	installationRepos, err := h.listInstallationRepos(ctx, appToken)
+	installationRepos, err := h.listInstallationRepos(ctx, appToken, link.InstallationID)
 	if err != nil {
 		writeError(w, r, http.StatusBadGateway, "LIST_REPOS_FAILED", "failed to list github repositories", err)
 		return
@@ -2007,13 +2031,17 @@ func (h *IntegrationHandler) userIsAdminInOrg(ctx context.Context, userID, orgID
 }
 
 func (h *IntegrationHandler) githubUserCanAccessRepo(ctx context.Context, token, fullName string) (bool, error) {
+	ctx = githubtelemetry.WithRequestMetadata(ctx, githubtelemetry.RequestMetadata{
+		Kind:     githubtelemetry.RequestKindAPI,
+		AuthType: githubtelemetry.AuthTypeUser,
+	})
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, githubAPIURL+"/repos/"+fullName, nil)
 	if err != nil {
 		return false, err
 	}
 	req.Header.Set("Authorization", "Bearer "+token)
 	req.Header.Set("Accept", "application/vnd.github+json")
-	resp, err := h.client.Do(req)
+	resp, err := h.gitHubClient().Do(req)
 	if err != nil {
 		return false, err
 	}
@@ -3930,6 +3958,10 @@ func (h *IntegrationHandler) fetchSentryOrganization(ctx context.Context, access
 // --- GitHub token exchange ---
 
 func (h *IntegrationHandler) exchangeGitHubCode(ctx context.Context, code string) (*githubIntegrationTokenResponse, error) {
+	ctx = githubtelemetry.WithRequestMetadata(ctx, githubtelemetry.RequestMetadata{
+		Kind:     githubtelemetry.RequestKindOAuth,
+		AuthType: githubtelemetry.AuthTypeOAuth,
+	})
 	body, err := json.Marshal(map[string]string{
 		"client_id":     h.githubClientID,
 		"client_secret": h.githubSecret,
@@ -3947,7 +3979,7 @@ func (h *IntegrationHandler) exchangeGitHubCode(ctx context.Context, code string
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Accept", "application/json")
 
-	resp, err := h.client.Do(req)
+	resp, err := h.gitHubClient().Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("github oauth token request failed: %w", err)
 	}

--- a/internal/api/handlers/integrations_test.go
+++ b/internal/api/handlers/integrations_test.go
@@ -2645,9 +2645,8 @@ func TestIntegrationHandler_StartGitHubOAuth_AppSlugSetsStateCookie(t *testing.T
 func TestIntegrationHandler_ListInstallationRepos_FollowsPagination(t *testing.T) {
 	t.Parallel()
 
-	handler := NewIntegrationHandler(nil, nil, "", "", "http://localhost:8080", "http://localhost:3000")
 	requested := make([]string, 0, 2)
-	handler.client = &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+	githubClient := &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
 		requested = append(requested, req.URL.String())
 		switch len(requested) {
 		case 1:
@@ -2671,8 +2670,20 @@ func TestIntegrationHandler_ListInstallationRepos_FollowsPagination(t *testing.T
 			return nil, errors.New("unexpected request")
 		}
 	})}
+	handler := NewIntegrationHandler(
+		nil,
+		nil,
+		"",
+		"",
+		"http://localhost:8080",
+		"http://localhost:3000",
+		WithGitHubHTTPClient(githubClient),
+	)
+	handler.client = &http.Client{Transport: roundTripFunc(func(_ *http.Request) (*http.Response, error) {
+		return nil, errors.New("generic provider client should not handle GitHub requests")
+	})}
 
-	repos, err := handler.listInstallationRepos(context.Background(), "installation-token")
+	repos, err := handler.listInstallationRepos(context.Background(), "installation-token", 123)
 
 	require.NoError(t, err, "listInstallationRepos should read every GitHub page")
 	require.Equal(t, []githubInstallationRepo{

--- a/internal/api/handlers/team.go
+++ b/internal/api/handlers/team.go
@@ -22,6 +22,7 @@ import (
 	"github.com/assembledhq/143/internal/db"
 	"github.com/assembledhq/143/internal/models"
 	"github.com/assembledhq/143/internal/services/email"
+	githubtelemetry "github.com/assembledhq/143/internal/services/github/telemetry"
 )
 
 // teamUserStore is the interface the team handler depends on for user lookups.
@@ -123,6 +124,14 @@ func (h *TeamHandler) SetCLITokenStore(cliTokens teamCLITokenStore) {
 func (h *TeamHandler) SetGitHubIntegration(integrations teamIntegrationStore, ghSvc teamGitHubService) {
 	h.integrations = integrations
 	h.githubSvc = ghSvc
+}
+
+// SetGitHubHTTPClient wires the instrumented client used for server-owned
+// GitHub API requests. Tests may continue to use the constructor default.
+func (h *TeamHandler) SetGitHubHTTPClient(client *http.Client) {
+	if client != nil {
+		h.httpClient = client
+	}
 }
 
 func (h *TeamHandler) SetRepositoryStore(repositories teamRepositoryStore) {
@@ -785,7 +794,12 @@ func (h *TeamHandler) SearchGitHubUsers(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	users, err := h.searchGitHubUsers(r.Context(), token, q)
+	githubCtx := githubtelemetry.WithRequestMetadata(r.Context(), githubtelemetry.RequestMetadata{
+		Kind:           githubtelemetry.RequestKindAPI,
+		AuthType:       githubtelemetry.AuthTypeAppInstallation,
+		InstallationID: installationID,
+	})
+	users, err := h.searchGitHubUsers(githubCtx, token, q)
 	if err != nil {
 		zerolog.Ctx(r.Context()).Warn().Err(err).Str("query", q).Msg("failed to search github users")
 		writeError(w, r, http.StatusBadGateway, "GITHUB_SEARCH_FAILED", "failed to search github users")

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -39,6 +39,7 @@ import (
 	"github.com/assembledhq/143/internal/services/domains"
 	"github.com/assembledhq/143/internal/services/email"
 	ghservice "github.com/assembledhq/143/internal/services/github"
+	githubtelemetry "github.com/assembledhq/143/internal/services/github/telemetry"
 	"github.com/assembledhq/143/internal/services/ingestion"
 	"github.com/assembledhq/143/internal/services/linear"
 	"github.com/assembledhq/143/internal/services/ownerloss"
@@ -183,7 +184,7 @@ func NewRouter(cfg *config.Config, pool *pgxpool.Pool, logger zerolog.Logger, se
 	var prService *ghservice.PRService
 	var appUserAuthSvc *ghservice.AppUserAuthService
 	if cfg.GitHubAppID != 0 && cfg.GitHubAppPrivateKey != "" {
-		ghSvc, err := ghservice.NewService(cfg.GitHubAppID, cfg.GitHubAppPrivateKey)
+		ghSvc, err := ghservice.NewService(cfg.GitHubAppID, cfg.GitHubAppPrivateKey, logger)
 		if err != nil {
 			logger.Warn().Err(err).Msg("failed to initialize GitHub App service, PR webhooks will be disabled")
 		} else {
@@ -214,6 +215,7 @@ func NewRouter(cfg *config.Config, pool *pgxpool.Pool, logger zerolog.Logger, se
 		healthHandler.SetRedisHealthCheck(redisClient.Healthy)
 	}
 	authHandler := handlers.NewAuthHandler(cfg, pool, userStore, authSessionStore, invitationStore, membershipStore)
+	authHandler.SetGitHubHTTPClient(githubtelemetry.NewHTTPClient(10*time.Second, logger))
 	// CLI login flow stores (browser-based `143-tools login`, join-token JIT).
 	cliAuthCodeStore := db.NewCLIAuthCodeStore(pool)
 	userCLITokenStore := db.NewUserCLITokenStore(pool)
@@ -240,6 +242,7 @@ func NewRouter(cfg *config.Config, pool *pgxpool.Pool, logger zerolog.Logger, se
 	integrationOpts := []handlers.IntegrationHandlerOption{
 		handlers.WithSentryOAuth(cfg.SentryOAuthClientID, cfg.SentryOAuthClientSecret),
 		handlers.WithGitHubIntegrationOAuth(cfg.GitHubOAuthClientID, cfg.GitHubOAuthClientSecret),
+		handlers.WithGitHubHTTPClient(githubtelemetry.NewHTTPClient(30*time.Second, logger)),
 		handlers.WithGitHubAppSlug(cfg.GitHubAppSlug),
 		handlers.WithGitHubInstallationStore(githubInstallationStore),
 		handlers.WithIntegrationMembershipStore(membershipStore),
@@ -256,7 +259,7 @@ func NewRouter(cfg *config.Config, pool *pgxpool.Pool, logger zerolog.Logger, se
 	// If the GitHub App service is available, let the integration handler list
 	// installation repos for explicit repository claims.
 	if cfg.GitHubAppID != 0 && cfg.GitHubAppPrivateKey != "" {
-		ghSvc, err := ghservice.NewService(cfg.GitHubAppID, cfg.GitHubAppPrivateKey)
+		ghSvc, err := ghservice.NewService(cfg.GitHubAppID, cfg.GitHubAppPrivateKey, logger)
 		if err == nil {
 			integrationOpts = append(integrationOpts, handlers.WithGitHubApp(ghSvc, repoStore))
 			authHandler.SetGitHubOrgAutoJoinDeps(githubInstallationStore, ghSvc)
@@ -635,6 +638,7 @@ func NewRouter(cfg *config.Config, pool *pgxpool.Pool, logger zerolog.Logger, se
 		logger.Info().Str("smtp_host", cfg.SMTPHost).Msg("SMTP email sender configured")
 	}
 	teamHandler := handlers.NewTeamHandler(userStore, membershipStore, authSessionStore, invitationStore, orgStore, cfg.FrontendURL, emailSender)
+	teamHandler.SetGitHubHTTPClient(githubtelemetry.NewHTTPClient(10*time.Second, logger))
 	teamHandler.SetRepositoryStore(repoStore)
 	teamHandler.SetCLITokenStore(userCLITokenStore)
 	orgDomainStore := db.NewOrganizationDomainStore(pool)
@@ -647,7 +651,7 @@ func NewRouter(cfg *config.Config, pool *pgxpool.Pool, logger zerolog.Logger, se
 	apiClientHandler.SetTxStarter(pool)
 	apiClientHandler.SetLogger(logger)
 	if cfg.GitHubAppID != 0 && cfg.GitHubAppPrivateKey != "" {
-		ghSvc, err := ghservice.NewService(cfg.GitHubAppID, cfg.GitHubAppPrivateKey)
+		ghSvc, err := ghservice.NewService(cfg.GitHubAppID, cfg.GitHubAppPrivateKey, logger)
 		if err == nil {
 			teamHandler.SetGitHubIntegration(integrationStore, ghSvc)
 		}

--- a/internal/services/codereview/github_submitter.go
+++ b/internal/services/codereview/github_submitter.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	ghservice "github.com/assembledhq/143/internal/services/github"
+	githubtelemetry "github.com/assembledhq/143/internal/services/github/telemetry"
 )
 
 type InstallationTokenProvider interface {
@@ -52,6 +53,14 @@ func NewGitHubSubmitter(tokens InstallationTokenProvider, opts ...GitHubSubmitte
 		opt(s)
 	}
 	return s
+}
+
+func withGitHubInstallationTelemetry(ctx context.Context, installationID int64) context.Context {
+	return githubtelemetry.WithRequestMetadata(ctx, githubtelemetry.RequestMetadata{
+		Kind:           githubtelemetry.RequestKindAPI,
+		AuthType:       githubtelemetry.AuthTypeAppInstallation,
+		InstallationID: installationID,
+	})
 }
 
 type SubmitReviewDecision string
@@ -150,6 +159,7 @@ func (s *GitHubSubmitter) SubmitReview(ctx context.Context, req SubmitReviewRequ
 	if err := req.Decision.validate(); err != nil {
 		return SubmitReviewResult{}, err
 	}
+	ctx = withGitHubInstallationTelemetry(ctx, req.InstallationID)
 	token, err := s.tokens.GetInstallationToken(ctx, req.InstallationID)
 	if err != nil {
 		return SubmitReviewResult{}, fmt.Errorf("get installation token: %w", err)
@@ -769,6 +779,7 @@ func (s *GitHubSubmitter) RemoveRequestedReviewers(ctx context.Context, req Requ
 	if len(reviewers) == 0 && len(teams) == 0 {
 		return nil
 	}
+	ctx = withGitHubInstallationTelemetry(ctx, req.InstallationID)
 	token, err := s.tokens.GetInstallationToken(ctx, req.InstallationID)
 	if err != nil {
 		return fmt.Errorf("get installation token: %w", err)
@@ -817,6 +828,7 @@ func (s *GitHubSubmitter) ListPullRequestFiles(ctx context.Context, req PullRequ
 	if req.InstallationID <= 0 {
 		return nil, fmt.Errorf("installation id is required")
 	}
+	ctx = withGitHubInstallationTelemetry(ctx, req.InstallationID)
 	token, err := s.tokens.GetInstallationToken(ctx, req.InstallationID)
 	if err != nil {
 		return nil, fmt.Errorf("get installation token: %w", err)
@@ -848,6 +860,7 @@ func (s *GitHubSubmitter) ListReviewContext(ctx context.Context, req ReviewConte
 	if req.InstallationID <= 0 {
 		return ReviewContext{}, fmt.Errorf("installation id is required")
 	}
+	ctx = withGitHubInstallationTelemetry(ctx, req.InstallationID)
 	token, err := s.tokens.GetInstallationToken(ctx, req.InstallationID)
 	if err != nil {
 		return ReviewContext{}, fmt.Errorf("get installation token: %w", err)

--- a/internal/services/codereview/github_submitter_test.go
+++ b/internal/services/codereview/github_submitter_test.go
@@ -1,16 +1,64 @@
 package codereview
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"sync"
 	"testing"
+	"time"
 
 	ghservice "github.com/assembledhq/143/internal/services/github"
+	githubtelemetry "github.com/assembledhq/143/internal/services/github/telemetry"
+	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/require"
 )
+
+func TestGitHubSubmitter_EmitsInstallationTelemetry(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/repos/acme/repo/pulls/42/files", r.URL.Path, "file lookup should use the expected GitHub route")
+		w.Header().Set("Content-Type", "application/json")
+		require.NoError(t, json.NewEncoder(w).Encode([]PullRequestFile{}), "test response should encode")
+	}))
+	defer server.Close()
+
+	var logs bytes.Buffer
+	client := githubtelemetry.NewHTTPClient(time.Second, zerolog.New(&logs))
+	submitter := NewGitHubSubmitter(
+		&tokenStub{token: "ghs_token"},
+		WithGitHubSubmitterBaseURL(server.URL),
+		WithGitHubSubmitterHTTPClient(client),
+	)
+
+	files, err := submitter.ListPullRequestFiles(context.Background(), PullRequestFilesRequest{
+		InstallationID: 99,
+		Repository:     "acme/repo",
+		PullNumber:     42,
+	})
+
+	require.NoError(t, err, "file lookup should succeed")
+	require.Equal(t, []PullRequestFile{}, files, "file lookup should preserve the empty GitHub response")
+	var event map[string]any
+	require.NoError(t, json.Unmarshal(logs.Bytes(), &event), "GitHub telemetry should be valid JSON")
+	delete(event, "github_duration_ms")
+	require.Equal(t, map[string]any{
+		"level":                  "info",
+		"message":                "github api request",
+		"github_method":          http.MethodGet,
+		"github_route":           "/repos/:owner/:repo/pulls/:id/files",
+		"github_auth_type":       githubtelemetry.AuthTypeAppInstallation,
+		"github_status_code":     float64(http.StatusOK),
+		"github_status_class":    "2xx",
+		"github_result":          "success",
+		"github_rate_limited":    false,
+		"github_repository":      "acme/repo",
+		"github_installation_id": float64(99),
+	}, event, "submitter requests should emit bounded installation-scoped telemetry")
+}
 
 func TestGitHubSubmitter_SubmitReview(t *testing.T) {
 	t.Parallel()

--- a/internal/services/codereview/github_trigger_setup.go
+++ b/internal/services/codereview/github_trigger_setup.go
@@ -15,6 +15,7 @@ import (
 	"github.com/assembledhq/143/internal/db"
 	"github.com/assembledhq/143/internal/models"
 	ghservice "github.com/assembledhq/143/internal/services/github"
+	githubtelemetry "github.com/assembledhq/143/internal/services/github/telemetry"
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
 	"github.com/rs/zerolog"
@@ -67,7 +68,7 @@ func NewGitHubTriggerSetupService(triggers GitHubTriggerStore, repos GitHubTrigg
 		triggers:    triggers,
 		repos:       repos,
 		appUserAuth: appUserAuth,
-		httpClient:  &http.Client{Timeout: 15 * time.Second},
+		httpClient:  githubtelemetry.NewHTTPClient(15*time.Second, logger),
 		apiBaseURL:  defaultGitHubAPIBaseURL,
 		logger:      logger,
 	}
@@ -242,6 +243,10 @@ func (s *GitHubTriggerSetupService) grantTeamRepository(ctx context.Context, tok
 }
 
 func (s *GitHubTriggerSetupService) githubJSON(ctx context.Context, method, path, token string, body any, expectedStatus int, out any) error {
+	ctx = githubtelemetry.WithRequestMetadata(ctx, githubtelemetry.RequestMetadata{
+		Kind:     githubtelemetry.RequestKindAPI,
+		AuthType: githubtelemetry.AuthTypeUser,
+	})
 	var reader io.Reader
 	if body != nil {
 		payload, err := json.Marshal(body)

--- a/internal/services/github/app_user_auth.go
+++ b/internal/services/github/app_user_auth.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/assembledhq/143/internal/db"
 	"github.com/assembledhq/143/internal/models"
+	githubtelemetry "github.com/assembledhq/143/internal/services/github/telemetry"
 )
 
 const (
@@ -56,7 +57,7 @@ func NewAppUserAuthService(credentials *db.UserCredentialStore, clientID, client
 		redirectURI:   strings.TrimRight(baseURL, "/") + "/api/v1/users/me/github/callback",
 		oauthBaseURL:  defaultGitHubOAuthBaseURL,
 		apiBaseURL:    defaultGitHubAPI,
-		httpClient:    &http.Client{Timeout: 15 * time.Second},
+		httpClient:    githubtelemetry.NewHTTPClient(15*time.Second, logger),
 		logger:        logger,
 		now:           time.Now,
 		refreshWindow: githubAppUserRefreshWindow,
@@ -179,6 +180,10 @@ func (s *AppUserAuthService) exchangeToken(ctx context.Context, values url.Value
 	if s.clientID == "" || s.clientSecret == "" {
 		return nil, errors.New("github app user auth is not configured")
 	}
+	ctx = githubtelemetry.WithRequestMetadata(ctx, githubtelemetry.RequestMetadata{
+		Kind:     githubtelemetry.RequestKindOAuth,
+		AuthType: githubtelemetry.AuthTypeOAuth,
+	})
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, s.oauthBaseURL+"/login/oauth/access_token", strings.NewReader(values.Encode()))
 	if err != nil {
 		return nil, fmt.Errorf("build token exchange request: %w", err)
@@ -235,6 +240,10 @@ func (s *AppUserAuthService) exchangeToken(ctx context.Context, values url.Value
 }
 
 func (s *AppUserAuthService) validateAccessToken(ctx context.Context, token string) (bool, error) {
+	ctx = githubtelemetry.WithRequestMetadata(ctx, githubtelemetry.RequestMetadata{
+		Kind:     githubtelemetry.RequestKindAPI,
+		AuthType: githubtelemetry.AuthTypeUser,
+	})
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, s.apiBaseURL+"/user", nil)
 	if err != nil {
 		return false, fmt.Errorf("build github user validation request: %w", err)

--- a/internal/services/github/identity/identity.go
+++ b/internal/services/github/identity/identity.go
@@ -27,6 +27,7 @@ import (
 	"github.com/rs/zerolog"
 
 	"github.com/assembledhq/143/internal/models"
+	githubtelemetry "github.com/assembledhq/143/internal/services/github/telemetry"
 )
 
 const defaultAPIBaseURL = "https://api.github.com"
@@ -132,7 +133,7 @@ type Resolver struct {
 func NewResolver(tokens InstallationTokenSource, logger zerolog.Logger) *Resolver {
 	return &Resolver{
 		tokens:     tokens,
-		httpClient: &http.Client{Timeout: 30 * time.Second},
+		httpClient: githubtelemetry.NewHTTPClient(30*time.Second, logger),
 		apiBaseURL: defaultAPIBaseURL,
 		logger:     logger,
 	}
@@ -394,6 +395,10 @@ func integrationInstallationID(integration *models.Integration) (int64, error) {
 // distinguish "user has GitHub but isn't a collaborator" (403/404 — fall
 // through) from real errors (500, network — propagate).
 func (r *Resolver) userTokenCanAccessRepo(ctx context.Context, token, fullName string) (bool, error) {
+	ctx = githubtelemetry.WithRequestMetadata(ctx, githubtelemetry.RequestMetadata{
+		Kind:     githubtelemetry.RequestKindAPI,
+		AuthType: githubtelemetry.AuthTypeUser,
+	})
 	owner, repo := splitRepo(fullName)
 	if owner == "" || repo == "" {
 		return false, fmt.Errorf("invalid repo full name %q", fullName)

--- a/internal/services/github/pr.go
+++ b/internal/services/github/pr.go
@@ -31,6 +31,7 @@ import (
 	"github.com/assembledhq/143/internal/services/agent"
 	automationevents "github.com/assembledhq/143/internal/services/automations"
 	"github.com/assembledhq/143/internal/services/github/identity"
+	githubtelemetry "github.com/assembledhq/143/internal/services/github/telemetry"
 	"github.com/assembledhq/143/internal/services/preview"
 	"github.com/assembledhq/143/internal/services/sandboxauth"
 	"github.com/assembledhq/143/internal/services/storage"
@@ -194,7 +195,7 @@ func NewPRService(
 		logger:                   logger,
 		baseURL:                  defaultGitHubAPI,
 		appBaseURL:               defaultAppBaseURL,
-		httpClient:               &http.Client{Timeout: 30 * time.Second},
+		httpClient:               githubtelemetry.NewHTTPClient(30*time.Second, logger),
 		prPreviewSurfacesEnabled: true,
 	}
 }
@@ -3669,6 +3670,7 @@ func (s *PRService) enqueueReinforceMemories(ctx context.Context, orgID uuid.UUI
 // --- GitHub API helpers ---
 
 func (s *PRService) doGitHubRequest(ctx context.Context, token, method, path string, body any) ([]byte, error) {
+	ctx = githubtelemetry.WithRequestMetadata(ctx, s.githubRequestMetadataForToken(token))
 	var bodyReader io.Reader
 	if body != nil {
 		b, err := json.Marshal(body)
@@ -3722,6 +3724,7 @@ func (s *PRService) doGitHubRequest(ctx context.Context, token, method, path str
 // GitHub Enterprise Server splits these differently (REST at /api/v3, GraphQL at
 // /api/graphql); revisit this if 143 ever targets a GHES base URL.
 func (s *PRService) doGitHubGraphQL(ctx context.Context, token, query string, variables map[string]any) ([]byte, error) {
+	ctx = githubtelemetry.WithRequestMetadata(ctx, s.githubRequestMetadataForToken(token))
 	payload, err := json.Marshal(map[string]any{"query": query, "variables": variables})
 	if err != nil {
 		return nil, err
@@ -3757,6 +3760,20 @@ func (s *PRService) doGitHubGraphQL(ctx context.Context, token, query string, va
 	}
 
 	return respBody, nil
+}
+
+func (s *PRService) githubRequestMetadataForToken(token string) githubtelemetry.RequestMetadata {
+	metadata := githubtelemetry.RequestMetadata{
+		Kind:     githubtelemetry.RequestKindAPI,
+		AuthType: githubtelemetry.AuthTypeUser,
+	}
+	if s != nil && s.tokenProvider != nil {
+		if installationID, ok := s.tokenProvider.installationIDForToken(token); ok {
+			metadata.AuthType = githubtelemetry.AuthTypeAppInstallation
+			metadata.InstallationID = installationID
+		}
+	}
+	return metadata
 }
 
 // GitHubAPIError wraps a non-2xx response from the GitHub REST API so callers

--- a/internal/services/github/service.go
+++ b/internal/services/github/service.go
@@ -14,6 +14,9 @@ import (
 	"time"
 
 	"github.com/golang-jwt/jwt/v5"
+	"github.com/rs/zerolog"
+
+	githubtelemetry "github.com/assembledhq/143/internal/services/github/telemetry"
 )
 
 type Service struct {
@@ -63,7 +66,26 @@ type cachedToken struct {
 	ExpiresAt time.Time
 }
 
-func NewService(appID int64, privateKeyPEM string) (*Service, error) {
+func (s *Service) installationIDForToken(token string) (int64, bool) {
+	if s == nil || token == "" {
+		return 0, false
+	}
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	for installationID, cached := range s.cache {
+		if cached != nil && cached.Token == token {
+			return installationID, true
+		}
+	}
+	for key, cached := range s.sandboxCache {
+		if cached != nil && cached.Token == token {
+			return key.InstallationID, true
+		}
+	}
+	return 0, false
+}
+
+func NewService(appID int64, privateKeyPEM string, loggers ...zerolog.Logger) (*Service, error) {
 	// Env vars often encode newlines as literal "\n"; convert to real newlines
 	// so PEM parsing succeeds.
 	privateKeyPEM = strings.ReplaceAll(privateKeyPEM, `\n`, "\n")
@@ -71,10 +93,14 @@ func NewService(appID int64, privateKeyPEM string) (*Service, error) {
 	if err != nil {
 		return nil, fmt.Errorf("parse private key: %w", err)
 	}
+	logger := zerolog.Nop()
+	if len(loggers) > 0 {
+		logger = loggers[0]
+	}
 	return &Service{
 		appID:        appID,
 		privateKey:   key,
-		httpClient:   &http.Client{Timeout: 10 * time.Second},
+		httpClient:   githubtelemetry.NewHTTPClient(10*time.Second, logger),
 		apiBaseURL:   "https://api.github.com",
 		cache:        make(map[int64]*cachedToken),
 		sandboxCache: make(map[sandboxTokenCacheKey]*cachedToken),
@@ -183,6 +209,11 @@ func (s *Service) exchangeForScopedInstallationToken(ctx context.Context, jwtTok
 }
 
 func (s *Service) exchangeForInstallationTokenRequest(ctx context.Context, jwtToken string, installationID int64, tokenRequest *installationTokenRequest) (string, time.Time, error) {
+	ctx = githubtelemetry.WithRequestMetadata(ctx, githubtelemetry.RequestMetadata{
+		Kind:           githubtelemetry.RequestKindAPI,
+		AuthType:       githubtelemetry.AuthTypeAppJWT,
+		InstallationID: installationID,
+	})
 	path := fmt.Sprintf("/app/installations/%d/access_tokens", installationID)
 	url := s.apiURL(path)
 	var body io.Reader
@@ -225,6 +256,11 @@ func (s *Service) exchangeForInstallationTokenRequest(ctx context.Context, jwtTo
 }
 
 func (s *Service) GetInstallationDetails(ctx context.Context, installationID int64) (InstallationDetails, error) {
+	ctx = githubtelemetry.WithRequestMetadata(ctx, githubtelemetry.RequestMetadata{
+		Kind:           githubtelemetry.RequestKindAPI,
+		AuthType:       githubtelemetry.AuthTypeAppJWT,
+		InstallationID: installationID,
+	})
 	jwtToken, err := s.generateJWT()
 	if err != nil {
 		return InstallationDetails{}, err
@@ -253,6 +289,11 @@ func (s *Service) GetInstallationDetails(ctx context.Context, installationID int
 }
 
 func (s *Service) ListOrgMembers(ctx context.Context, installationID int64, orgLogin string) ([]OrgMember, error) {
+	ctx = githubtelemetry.WithRequestMetadata(ctx, githubtelemetry.RequestMetadata{
+		Kind:           githubtelemetry.RequestKindAPI,
+		AuthType:       githubtelemetry.AuthTypeAppInstallation,
+		InstallationID: installationID,
+	})
 	token, err := s.GetInstallationToken(ctx, installationID)
 	if err != nil {
 		return nil, err
@@ -295,6 +336,11 @@ func (s *Service) ListOrgMembers(ctx context.Context, installationID int64, orgL
 }
 
 func (s *Service) IsActiveOrgMember(ctx context.Context, installationID int64, orgLogin, username string) (bool, error) {
+	ctx = githubtelemetry.WithRequestMetadata(ctx, githubtelemetry.RequestMetadata{
+		Kind:           githubtelemetry.RequestKindAPI,
+		AuthType:       githubtelemetry.AuthTypeAppInstallation,
+		InstallationID: installationID,
+	})
 	token, err := s.GetInstallationToken(ctx, installationID)
 	if err != nil {
 		return false, err

--- a/internal/services/github/service_test.go
+++ b/internal/services/github/service_test.go
@@ -82,6 +82,61 @@ func TestNewService(t *testing.T) {
 	}
 }
 
+func TestServiceInstallationIDForToken(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name                   string
+		service                *Service
+		token                  string
+		expectedInstallationID int64
+		expectedFound          bool
+	}{
+		{
+			name: "finds standard installation token",
+			service: &Service{
+				cache: map[int64]*cachedToken{42: {Token: "standard-token"}},
+			},
+			token:                  "standard-token",
+			expectedInstallationID: 42,
+			expectedFound:          true,
+		},
+		{
+			name: "finds sandbox-scoped installation token",
+			service: &Service{
+				sandboxCache: map[sandboxTokenCacheKey]*cachedToken{
+					{InstallationID: 73, RepositoryID: 99, Action: "api"}: {Token: "sandbox-token"},
+				},
+			},
+			token:                  "sandbox-token",
+			expectedInstallationID: 73,
+			expectedFound:          true,
+		},
+		{
+			name:          "does not guess an unknown token",
+			service:       &Service{cache: map[int64]*cachedToken{42: {Token: "known-token"}}},
+			token:         "unknown-token",
+			expectedFound: false,
+		},
+		{
+			name:          "nil service is safe",
+			service:       nil,
+			token:         "token",
+			expectedFound: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			actualInstallationID, actualFound := tt.service.installationIDForToken(tt.token)
+			require.Equal(t, tt.expectedInstallationID, actualInstallationID, "token lookup should return the expected installation ID")
+			require.Equal(t, tt.expectedFound, actualFound, "token lookup should report whether the installation is known")
+		})
+	}
+}
+
 func TestService_ListOrgMembers_ReturnsBodyCloseError(t *testing.T) {
 	t.Parallel()
 

--- a/internal/services/github/telemetry/transport.go
+++ b/internal/services/github/telemetry/transport.go
@@ -1,0 +1,390 @@
+package telemetry
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/rs/zerolog"
+)
+
+const (
+	RequestKindAPI   = "api"
+	RequestKindOAuth = "oauth"
+
+	AuthTypeAppInstallation = "app_installation"
+	AuthTypeAppJWT          = "app_jwt"
+	AuthTypeUser            = "user"
+	AuthTypeOAuth           = "oauth"
+	AuthTypeUnknown         = "unknown"
+)
+
+type requestMetadataKey struct{}
+
+// RequestMetadata carries bounded dimensions that cannot be derived safely
+// from the HTTP request. It deliberately excludes tokens, query values, and
+// other secrets.
+type RequestMetadata struct {
+	Kind           string
+	AuthType       string
+	InstallationID int64
+}
+
+// WithRequestMetadata attaches safe GitHub telemetry dimensions to a request.
+func WithRequestMetadata(ctx context.Context, metadata RequestMetadata) context.Context {
+	return context.WithValue(ctx, requestMetadataKey{}, metadata)
+}
+
+// NewHTTPClient returns an HTTP client that emits one structured summary per
+// GitHub request. Routes are normalized before logging to keep cardinality
+// bounded; raw query strings and authorization headers are never logged.
+func NewHTTPClient(timeout time.Duration, logger zerolog.Logger) *http.Client {
+	return &http.Client{
+		Timeout: timeout,
+		Transport: &transport{
+			base:   http.DefaultTransport,
+			logger: logger,
+			now:    time.Now,
+		},
+	}
+}
+
+type transport struct {
+	base   http.RoundTripper
+	logger zerolog.Logger
+	now    func() time.Time
+}
+
+func (t *transport) RoundTrip(req *http.Request) (*http.Response, error) {
+	startedAt := t.now()
+	resp, err := t.base.RoundTrip(req)
+	if err != nil || resp == nil || resp.Body == nil {
+		t.logRequest(req, resp, err, nil, startedAt, t.now())
+		return resp, err
+	}
+	resp.Body = &observedResponseBody{
+		ReadCloser: resp.Body,
+		capture:    resp.StatusCode == http.StatusForbidden || req.URL.Path == "/graphql",
+		onClose: func(body []byte) {
+			t.logRequest(req, resp, nil, body, startedAt, t.now())
+		},
+	}
+	return resp, err
+}
+
+const maxRateLimitResponseBytes = 16 * 1024
+
+type observedResponseBody struct {
+	io.ReadCloser
+	capture  bool
+	body     []byte
+	onClose  func([]byte)
+	once     sync.Once
+	closeErr error
+}
+
+func (b *observedResponseBody) Read(p []byte) (int, error) {
+	n, err := b.ReadCloser.Read(p)
+	if b.capture && len(b.body) < maxRateLimitResponseBytes {
+		remaining := maxRateLimitResponseBytes - len(b.body)
+		captured := n
+		if captured > remaining {
+			captured = remaining
+		}
+		b.body = append(b.body, p[:captured]...)
+	}
+	return n, err
+}
+
+func (b *observedResponseBody) Close() error {
+	b.once.Do(func() {
+		if b.capture && len(b.body) < maxRateLimitResponseBytes {
+			remaining := int64(maxRateLimitResponseBytes - len(b.body))
+			unread, _ := io.ReadAll(io.LimitReader(b.ReadCloser, remaining))
+			b.body = append(b.body, unread...)
+		}
+		b.closeErr = b.ReadCloser.Close()
+		if b.onClose != nil {
+			b.onClose(b.body)
+		}
+	})
+	return b.closeErr
+}
+
+func (t *transport) logRequest(req *http.Request, resp *http.Response, requestErr error, responseBody []byte, startedAt, finishedAt time.Time) {
+	metadata, _ := req.Context().Value(requestMetadataKey{}).(RequestMetadata)
+	if metadata.Kind == "" {
+		metadata.Kind = requestKindForURL(req.URL)
+	}
+	if metadata.AuthType == "" {
+		metadata.AuthType = AuthTypeUnknown
+	}
+
+	route, repository := normalizeRoute(req.URL)
+	statusCode := 0
+	statusClass := "transport_error"
+	result := "transport_error"
+	rateLimited := false
+	rateLimitKind := ""
+	var header http.Header
+	if resp != nil {
+		statusCode = resp.StatusCode
+		statusClass = fmt.Sprintf("%dxx", resp.StatusCode/100)
+		result = githubRequestResult(resp.StatusCode)
+		header = resp.Header
+		rateLimited, rateLimitKind = classifyRateLimitResponse(resp, responseBody)
+		if rateLimited {
+			result = "rate_limited"
+		}
+	}
+
+	event := t.logger.Info()
+	if requestErr != nil || rateLimited || statusCode >= http.StatusInternalServerError {
+		event = t.logger.Warn()
+	}
+	event = event.
+		Err(requestErr).
+		Str("github_method", req.Method).
+		Str("github_route", route).
+		Str("github_auth_type", metadata.AuthType).
+		Int("github_status_code", statusCode).
+		Str("github_status_class", statusClass).
+		Str("github_result", result).
+		Float64("github_duration_ms", float64(finishedAt.Sub(startedAt).Microseconds())/1000).
+		Bool("github_rate_limited", rateLimited)
+	if repository != "" {
+		event = event.Str("github_repository", repository)
+	}
+	if metadata.InstallationID > 0 {
+		event = event.Int64("github_installation_id", metadata.InstallationID)
+	}
+	if rateLimitKind != "" {
+		event = event.Str("github_rate_limit_kind", rateLimitKind)
+	}
+
+	limit, hasLimit := headerInt64(header, "X-RateLimit-Limit")
+	remaining, hasRemaining := headerInt64(header, "X-RateLimit-Remaining")
+	used, hasUsed := headerInt64(header, "X-RateLimit-Used")
+	resetUnix, hasReset := headerInt64(header, "X-RateLimit-Reset")
+	if hasLimit {
+		event = event.Int64("github_rate_limit_limit", limit)
+	}
+	if hasRemaining {
+		event = event.Int64("github_rate_limit_remaining", remaining)
+	}
+	if hasUsed {
+		event = event.Int64("github_rate_limit_used", used)
+	}
+	if hasLimit && limit > 0 && hasRemaining {
+		event = event.Float64("github_rate_limit_remaining_pct", float64(remaining)*100/float64(limit))
+	}
+	if hasReset {
+		resetAt := time.Unix(resetUnix, 0).UTC()
+		resetSeconds := resetAt.Sub(finishedAt).Seconds()
+		if resetSeconds < 0 {
+			resetSeconds = 0
+		}
+		event = event.
+			Int64("github_rate_limit_reset_unix", resetUnix).
+			Time("github_rate_limit_reset_at", resetAt).
+			Float64("github_rate_limit_reset_seconds", resetSeconds)
+	}
+	if resource := strings.TrimSpace(header.Get("X-RateLimit-Resource")); resource != "" {
+		event = event.Str("github_rate_limit_resource", resource)
+	}
+	if requestID := strings.TrimSpace(header.Get("X-GitHub-Request-Id")); requestID != "" {
+		event = event.Str("github_request_id", requestID)
+	}
+	if retryAfter, ok := retryAfterSeconds(header.Get("Retry-After"), finishedAt); ok {
+		event = event.Float64("github_retry_after_seconds", retryAfter)
+	}
+
+	message := "github api request"
+	if metadata.Kind == RequestKindOAuth {
+		message = "github oauth request"
+	}
+	event.Msg(message)
+}
+
+func requestKindForURL(requestURL *url.URL) string {
+	if requestURL != nil && strings.EqualFold(requestURL.Hostname(), "github.com") {
+		return RequestKindOAuth
+	}
+	return RequestKindAPI
+}
+
+func githubRequestResult(statusCode int) string {
+	switch {
+	case statusCode >= 200 && statusCode < 400:
+		return "success"
+	case statusCode >= 400 && statusCode < 500:
+		return "client_error"
+	case statusCode >= 500:
+		return "server_error"
+	default:
+		return "http_error"
+	}
+}
+
+func classifyRateLimitResponse(resp *http.Response, responseBody []byte) (bool, string) {
+	if resp == nil {
+		return false, ""
+	}
+	throttleStatus := resp.StatusCode == http.StatusForbidden || resp.StatusCode == http.StatusTooManyRequests
+	message := strings.ToLower(strings.TrimSpace(string(responseBody)))
+	bodyRateLimited := strings.Contains(message, "rate limit") || strings.Contains(message, "abuse detection")
+	if !throttleStatus && !bodyRateLimited {
+		return false, ""
+	}
+	if remaining, ok := headerInt64(resp.Header, "X-RateLimit-Remaining"); ok && remaining == 0 {
+		return true, "primary"
+	}
+	if strings.TrimSpace(resp.Header.Get("Retry-After")) != "" || resp.StatusCode == http.StatusTooManyRequests {
+		return true, "secondary"
+	}
+	if strings.Contains(message, "secondary rate limit") || strings.Contains(message, "abuse detection") {
+		return true, "secondary"
+	}
+	if strings.Contains(message, "rate limit") {
+		return true, "unknown"
+	}
+	return false, ""
+}
+
+func headerInt64(header http.Header, name string) (int64, bool) {
+	if header == nil {
+		return 0, false
+	}
+	raw := strings.TrimSpace(header.Get(name))
+	if raw == "" {
+		return 0, false
+	}
+	value, err := strconv.ParseInt(raw, 10, 64)
+	return value, err == nil
+}
+
+func retryAfterSeconds(raw string, now time.Time) (float64, bool) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return 0, false
+	}
+	if seconds, err := strconv.ParseFloat(raw, 64); err == nil && seconds >= 0 {
+		return seconds, true
+	}
+	retryAt, err := http.ParseTime(raw)
+	if err != nil {
+		return 0, false
+	}
+	seconds := retryAt.Sub(now).Seconds()
+	if seconds < 0 {
+		seconds = 0
+	}
+	return seconds, true
+}
+
+func normalizeRoute(requestURL *url.URL) (string, string) {
+	if requestURL == nil {
+		return "/", ""
+	}
+	segments := strings.Split(strings.Trim(requestURL.Path, "/"), "/")
+	if len(segments) == 1 && segments[0] == "" {
+		return "/", ""
+	}
+
+	repository := ""
+	if len(segments) >= 3 && segments[0] == "repos" {
+		repository = segments[1] + "/" + segments[2]
+		segments[1] = ":owner"
+		segments[2] = ":repo"
+		normalizeRepositorySegments(&segments)
+	} else if len(segments) >= 2 && segments[0] == "orgs" {
+		segments[1] = ":org"
+		if len(segments) >= 4 {
+			switch segments[2] {
+			case "members", "memberships":
+				segments[3] = ":user"
+			case "teams":
+				segments[3] = ":team"
+				if len(segments) >= 7 && segments[4] == "repos" {
+					repository = segments[5] + "/" + segments[6]
+					segments[5] = ":owner"
+					segments[6] = ":repo"
+				}
+			}
+		}
+	} else if len(segments) >= 3 && segments[0] == "app" && segments[1] == "installations" {
+		segments[2] = ":installation_id"
+	} else {
+		for i := range segments {
+			segments[i] = normalizeOpaqueSegment(segments[i])
+		}
+	}
+
+	return "/" + strings.Join(segments, "/"), repository
+}
+
+func normalizeRepositorySegments(segments *[]string) {
+	parts := *segments
+	if len(parts) < 4 {
+		return
+	}
+	switch parts[3] {
+	case "pulls", "check-runs":
+		if len(parts) >= 5 {
+			parts[4] = ":id"
+		}
+	case "issues":
+		if len(parts) >= 6 && parts[4] == "comments" {
+			parts[5] = ":id"
+		} else if len(parts) >= 5 {
+			parts[4] = ":id"
+		}
+	case "commits", "branches", "statuses":
+		if len(parts) >= 5 {
+			parts = append(parts[:4], ":ref")
+		}
+	case "contents":
+		parts = append(parts[:4], ":path")
+	case "git":
+		if len(parts) >= 6 {
+			switch parts[4] {
+			case "commits", "trees":
+				parts[5] = ":ref"
+			case "ref":
+				parts = append(parts[:5], ":ref")
+			}
+		}
+	}
+	for i := 3; i < len(parts); i++ {
+		parts[i] = normalizeOpaqueSegment(parts[i])
+	}
+	*segments = parts
+}
+
+func normalizeOpaqueSegment(segment string) string {
+	if segment == "" || strings.HasPrefix(segment, ":") {
+		return segment
+	}
+	if _, err := strconv.ParseInt(segment, 10, 64); err == nil {
+		return ":id"
+	}
+	if len(segment) >= 20 && isHex(segment) {
+		return ":ref"
+	}
+	return segment
+}
+
+func isHex(value string) bool {
+	for _, char := range value {
+		if !((char >= '0' && char <= '9') || (char >= 'a' && char <= 'f') || (char >= 'A' && char <= 'F')) {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/services/github/telemetry/transport_test.go
+++ b/internal/services/github/telemetry/transport_test.go
@@ -1,0 +1,309 @@
+package telemetry
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/require"
+)
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+func TestTransportRoundTripLogsStructuredGitHubTelemetry(t *testing.T) {
+	t.Parallel()
+
+	startedAt := time.Date(2026, time.July, 22, 12, 0, 0, 0, time.UTC)
+	resetAt := startedAt.Add(5 * time.Minute)
+	tests := []struct {
+		name             string
+		metadata         RequestMetadata
+		requestURL       string
+		response         *http.Response
+		requestErr       error
+		expectedLogEvent map[string]any
+	}{
+		{
+			name: "successful installation request records quota and normalized route",
+			metadata: RequestMetadata{
+				Kind:           RequestKindAPI,
+				AuthType:       AuthTypeAppInstallation,
+				InstallationID: 42,
+			},
+			requestURL: "https://api.github.com/repos/assembledhq/143/pulls/99?ignored=true",
+			response: &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(bytes.NewBufferString(`{}`)),
+				Header: http.Header{
+					"X-Ratelimit-Limit":     []string{"5000"},
+					"X-Ratelimit-Remaining": []string{"1250"},
+					"X-Ratelimit-Used":      []string{"3750"},
+					"X-Ratelimit-Reset":     []string{strconv.FormatInt(resetAt.Unix(), 10)},
+					"X-Ratelimit-Resource":  []string{"core"},
+					"X-Github-Request-Id":   []string{"request-123"},
+				},
+			},
+			expectedLogEvent: map[string]any{
+				"level":                           "info",
+				"message":                         "github api request",
+				"github_method":                   http.MethodGet,
+				"github_route":                    "/repos/:owner/:repo/pulls/:id",
+				"github_repository":               "assembledhq/143",
+				"github_auth_type":                AuthTypeAppInstallation,
+				"github_installation_id":          float64(42),
+				"github_status_code":              float64(http.StatusOK),
+				"github_status_class":             "2xx",
+				"github_result":                   "success",
+				"github_duration_ms":              float64(250),
+				"github_rate_limited":             false,
+				"github_rate_limit_limit":         float64(5000),
+				"github_rate_limit_remaining":     float64(1250),
+				"github_rate_limit_used":          float64(3750),
+				"github_rate_limit_remaining_pct": float64(25),
+				"github_rate_limit_reset_unix":    float64(resetAt.Unix()),
+				"github_rate_limit_reset_at":      resetAt.Format(time.RFC3339),
+				"github_rate_limit_reset_seconds": float64(299.75),
+				"github_rate_limit_resource":      "core",
+				"github_request_id":               "request-123",
+			},
+		},
+		{
+			name: "primary rate limit is a warning",
+			metadata: RequestMetadata{
+				Kind:           RequestKindAPI,
+				AuthType:       AuthTypeAppInstallation,
+				InstallationID: 42,
+			},
+			requestURL: "https://api.github.com/repos/assembledhq/143/pulls/99",
+			response: &http.Response{
+				StatusCode: http.StatusForbidden,
+				Body:       io.NopCloser(bytes.NewBufferString(`{"message":"rate limited"}`)),
+				Header: http.Header{
+					"X-Ratelimit-Limit":     []string{"5000"},
+					"X-Ratelimit-Remaining": []string{"0"},
+					"X-Ratelimit-Used":      []string{"5000"},
+					"X-Ratelimit-Reset":     []string{strconv.FormatInt(resetAt.Unix(), 10)},
+					"X-Ratelimit-Resource":  []string{"core"},
+				},
+			},
+			expectedLogEvent: map[string]any{
+				"level":                           "warn",
+				"message":                         "github api request",
+				"github_method":                   http.MethodGet,
+				"github_route":                    "/repos/:owner/:repo/pulls/:id",
+				"github_repository":               "assembledhq/143",
+				"github_auth_type":                AuthTypeAppInstallation,
+				"github_installation_id":          float64(42),
+				"github_status_code":              float64(http.StatusForbidden),
+				"github_status_class":             "4xx",
+				"github_result":                   "rate_limited",
+				"github_duration_ms":              float64(250),
+				"github_rate_limited":             true,
+				"github_rate_limit_kind":          "primary",
+				"github_rate_limit_limit":         float64(5000),
+				"github_rate_limit_remaining":     float64(0),
+				"github_rate_limit_used":          float64(5000),
+				"github_rate_limit_remaining_pct": float64(0),
+				"github_rate_limit_reset_unix":    float64(resetAt.Unix()),
+				"github_rate_limit_reset_at":      resetAt.Format(time.RFC3339),
+				"github_rate_limit_reset_seconds": float64(299.75),
+				"github_rate_limit_resource":      "core",
+			},
+		},
+		{
+			name: "secondary rate limit records retry guidance",
+			metadata: RequestMetadata{
+				Kind:     RequestKindAPI,
+				AuthType: AuthTypeUser,
+			},
+			requestURL: "https://api.github.com/graphql",
+			response: &http.Response{
+				StatusCode: http.StatusForbidden,
+				Body:       io.NopCloser(bytes.NewBufferString(`{"message":"secondary rate limit"}`)),
+				Header: http.Header{
+					"Retry-After":           []string{"60"},
+					"X-Ratelimit-Limit":     []string{"5000"},
+					"X-Ratelimit-Remaining": []string{"4999"},
+				},
+			},
+			expectedLogEvent: map[string]any{
+				"level":                           "warn",
+				"message":                         "github api request",
+				"github_method":                   http.MethodGet,
+				"github_route":                    "/graphql",
+				"github_auth_type":                AuthTypeUser,
+				"github_status_code":              float64(http.StatusForbidden),
+				"github_status_class":             "4xx",
+				"github_result":                   "rate_limited",
+				"github_duration_ms":              float64(250),
+				"github_rate_limited":             true,
+				"github_rate_limit_kind":          "secondary",
+				"github_rate_limit_limit":         float64(5000),
+				"github_rate_limit_remaining":     float64(4999),
+				"github_rate_limit_remaining_pct": float64(99.98),
+				"github_retry_after_seconds":      float64(60),
+			},
+		},
+		{
+			name:       "body-only secondary rate limit remains countable",
+			metadata:   RequestMetadata{Kind: RequestKindAPI, AuthType: AuthTypeUser},
+			requestURL: "https://api.github.com/user",
+			response: &http.Response{
+				StatusCode: http.StatusForbidden,
+				Body:       io.NopCloser(bytes.NewBufferString(`{"message":"You have exceeded a secondary rate limit"}`)),
+				Header:     make(http.Header),
+			},
+			expectedLogEvent: map[string]any{
+				"level":                  "warn",
+				"message":                "github api request",
+				"github_method":          http.MethodGet,
+				"github_route":           "/user",
+				"github_auth_type":       AuthTypeUser,
+				"github_status_code":     float64(http.StatusForbidden),
+				"github_status_class":    "4xx",
+				"github_result":          "rate_limited",
+				"github_duration_ms":     float64(250),
+				"github_rate_limited":    true,
+				"github_rate_limit_kind": "secondary",
+			},
+		},
+		{
+			name:       "graphql primary rate-limit error in a successful HTTP envelope remains countable",
+			metadata:   RequestMetadata{Kind: RequestKindAPI, AuthType: AuthTypeUser},
+			requestURL: "https://api.github.com/graphql",
+			response: &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(bytes.NewBufferString(`{"errors":[{"message":"API rate limit exceeded"}]}`)),
+				Header: http.Header{
+					"X-Ratelimit-Limit":     []string{"5000"},
+					"X-Ratelimit-Remaining": []string{"0"},
+				},
+			},
+			expectedLogEvent: map[string]any{
+				"level":                           "warn",
+				"message":                         "github api request",
+				"github_method":                   http.MethodGet,
+				"github_route":                    "/graphql",
+				"github_auth_type":                AuthTypeUser,
+				"github_status_code":              float64(http.StatusOK),
+				"github_status_class":             "2xx",
+				"github_result":                   "rate_limited",
+				"github_duration_ms":              float64(250),
+				"github_rate_limited":             true,
+				"github_rate_limit_kind":          "primary",
+				"github_rate_limit_limit":         float64(5000),
+				"github_rate_limit_remaining":     float64(0),
+				"github_rate_limit_remaining_pct": float64(0),
+			},
+		},
+		{
+			name:       "transport failure remains countable",
+			metadata:   RequestMetadata{Kind: RequestKindAPI, AuthType: AuthTypeUnknown},
+			requestURL: "https://api.github.com/user",
+			requestErr: errors.New("connection reset"),
+			expectedLogEvent: map[string]any{
+				"level":               "warn",
+				"message":             "github api request",
+				"error":               "connection reset",
+				"github_method":       http.MethodGet,
+				"github_route":        "/user",
+				"github_auth_type":    AuthTypeUnknown,
+				"github_status_code":  float64(0),
+				"github_status_class": "transport_error",
+				"github_result":       "transport_error",
+				"github_duration_ms":  float64(250),
+				"github_rate_limited": false,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var logs bytes.Buffer
+			clockCalls := 0
+			telemetryTransport := &transport{
+				base: roundTripFunc(func(_ *http.Request) (*http.Response, error) {
+					return tt.response, tt.requestErr
+				}),
+				logger: zerolog.New(&logs),
+				now: func() time.Time {
+					clockCalls++
+					if clockCalls == 1 {
+						return startedAt
+					}
+					return startedAt.Add(250 * time.Millisecond)
+				},
+			}
+			request, err := http.NewRequestWithContext(
+				WithRequestMetadata(context.Background(), tt.metadata),
+				http.MethodGet,
+				tt.requestURL,
+				nil,
+			)
+			require.NoError(t, err, "test request should be valid")
+
+			actualResponse, actualErr := telemetryTransport.RoundTrip(request)
+			if actualResponse != nil {
+				_, readErr := io.Copy(io.Discard, actualResponse.Body)
+				require.NoError(t, readErr, "test response body should remain readable through telemetry")
+				require.NoError(t, actualResponse.Body.Close(), "test response body should close through telemetry")
+			}
+
+			require.Equal(t, tt.response, actualResponse, "RoundTrip should preserve the underlying response")
+			require.Equal(t, tt.requestErr, actualErr, "RoundTrip should preserve the underlying error")
+			var actualLogEvent map[string]any
+			require.NoError(t, json.Unmarshal(logs.Bytes(), &actualLogEvent), "telemetry should be valid JSON")
+			require.Equal(t, tt.expectedLogEvent, actualLogEvent, "telemetry should contain the exact bounded request summary")
+		})
+	}
+}
+
+func TestNormalizeRoute(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name               string
+		rawURL             string
+		expectedRoute      string
+		expectedRepository string
+	}{
+		{name: "pull request", rawURL: "https://api.github.com/repos/acme/widget/pulls/42", expectedRoute: "/repos/:owner/:repo/pulls/:id", expectedRepository: "acme/widget"},
+		{name: "issue comment collection", rawURL: "https://api.github.com/repos/acme/widget/issues/42/comments?page=3", expectedRoute: "/repos/:owner/:repo/issues/:id/comments", expectedRepository: "acme/widget"},
+		{name: "issue comment resource", rawURL: "https://api.github.com/repos/acme/widget/issues/comments/123", expectedRoute: "/repos/:owner/:repo/issues/comments/:id", expectedRepository: "acme/widget"},
+		{name: "git ref", rawURL: "https://api.github.com/repos/acme/widget/git/ref/heads/feature/branch", expectedRoute: "/repos/:owner/:repo/git/ref/:ref", expectedRepository: "acme/widget"},
+		{name: "escaped branch ref", rawURL: "https://api.github.com/repos/acme/widget/branches/feature%2Fbranch", expectedRoute: "/repos/:owner/:repo/branches/:ref", expectedRepository: "acme/widget"},
+		{name: "decoded branch ref", rawURL: "https://api.github.com/repos/acme/widget/branches/feature/branch", expectedRoute: "/repos/:owner/:repo/branches/:ref", expectedRepository: "acme/widget"},
+		{name: "contents", rawURL: "https://api.github.com/repos/acme/widget/contents/.github/workflows/test.yml?ref=main", expectedRoute: "/repos/:owner/:repo/contents/:path", expectedRepository: "acme/widget"},
+		{name: "org membership", rawURL: "https://api.github.com/orgs/acme/memberships/octocat", expectedRoute: "/orgs/:org/memberships/:user"},
+		{name: "org member", rawURL: "https://api.github.com/orgs/acme/members/octocat", expectedRoute: "/orgs/:org/members/:user"},
+		{name: "org team repository", rawURL: "https://api.github.com/orgs/acme/teams/reviewers/repos/acme/widget", expectedRoute: "/orgs/:org/teams/:team/repos/:owner/:repo", expectedRepository: "acme/widget"},
+		{name: "installation token", rawURL: "https://api.github.com/app/installations/123/access_tokens", expectedRoute: "/app/installations/:installation_id/access_tokens"},
+		{name: "graphql", rawURL: "https://api.github.com/graphql", expectedRoute: "/graphql"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			parsedURL, err := url.Parse(tt.rawURL)
+			require.NoError(t, err, "test URL should parse")
+			actualRoute, actualRepository := normalizeRoute(parsedURL)
+			require.Equal(t, tt.expectedRoute, actualRoute, "route should use a bounded endpoint template")
+			require.Equal(t, tt.expectedRepository, actualRepository, "repository should remain available as an explicit drilldown dimension")
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Track GitHub API rate-limit usage across requests and authentication flows
- Expose telemetry for dashboards and production alerts
- Update related handlers, services, and tests

## Testing

- Added and updated Go unit tests for GitHub telemetry, services, and integrations
- Not run (not requested)