### PR TITLE
Preserve code review history on GitHub reassessments

### DIFF
--- a/internal/services/codereview/github_submitter.go
+++ b/internal/services/codereview/github_submitter.go
@@ -57,8 +57,10 @@ func NewGitHubSubmitter(tokens InstallationTokenProvider, opts ...GitHubSubmitte
 type SubmitReviewDecision string
 
 const (
-	SubmitReviewDecisionApproved    SubmitReviewDecision = "approved"
-	SubmitReviewDecisionCommentOnly SubmitReviewDecision = "comment_only"
+	SubmitReviewDecisionApproved         SubmitReviewDecision = "approved"
+	SubmitReviewDecisionCommentOnly      SubmitReviewDecision = "comment_only"
+	SubmitReviewDecisionNeedsHumanReview SubmitReviewDecision = "needs_human_review"
+	SubmitReviewDecisionBlocked          SubmitReviewDecision = "blocked"
 )
 
 type SubmitReviewRequest struct {
@@ -71,6 +73,9 @@ type SubmitReviewRequest struct {
 	ExistingReviewID  int64
 	ExistingReviewURL string
 	Decision          SubmitReviewDecision
+	PreviousDecision  SubmitReviewDecision
+	PreviousDecidedAt time.Time
+	PreviousBody      string
 	Body              string
 	Comments          []SubmitReviewComment
 }
@@ -85,6 +90,7 @@ type SubmitReviewComment struct {
 type SubmitReviewResult struct {
 	ID       int64
 	URL      string
+	Body     string
 	Comments []SubmitReviewPostedComment
 }
 
@@ -154,16 +160,22 @@ func (s *GitHubSubmitter) SubmitReview(ctx context.Context, req SubmitReviewRequ
 	if err != nil {
 		return SubmitReviewResult{}, fmt.Errorf("get installation token: %w", err)
 	}
-	reviewBody := withCodeReviewOutputMarker(req.Body, req.OutputKey)
+	visibleReviewBody := strings.TrimSpace(req.Body)
 	if req.ExistingReviewID > 0 {
-		return s.updateExistingReview(ctx, token, owner, repo, req, reviewBody)
+		visibleReviewBody = withCodeReviewHistory(visibleReviewBody, req.PreviousBody, req.PreviousDecision, req.PreviousDecidedAt)
+		reviewBody := withCodeReviewOutputMarker(visibleReviewBody, req.OutputKey)
+		result, err := s.updateExistingReview(ctx, token, owner, repo, req, reviewBody)
+		result.Body = visibleReviewBody
+		return result, err
 	}
+	reviewBody := withCodeReviewOutputMarker(visibleReviewBody, req.OutputKey)
 	if strings.TrimSpace(req.OutputKey) != "" {
 		existing, found, err := s.findExistingReview(ctx, token, owner, repo, req.PullNumber, req.OutputKey)
 		if err != nil {
 			return SubmitReviewResult{}, err
 		}
 		if found {
+			existing.Body = visibleReviewBody
 			return existing, nil
 		}
 	}
@@ -252,7 +264,7 @@ func (s *GitHubSubmitter) SubmitReview(ctx context.Context, req SubmitReviewRequ
 	if err := json.NewDecoder(resp.Body).Decode(&decoded); err != nil {
 		return SubmitReviewResult{}, fmt.Errorf("decode GitHub review response: %w", err)
 	}
-	result := SubmitReviewResult{ID: decoded.ID, URL: decoded.HTMLURL}
+	result := SubmitReviewResult{ID: decoded.ID, URL: decoded.HTMLURL, Body: visibleReviewBody}
 	result.Comments = append(result.Comments, knownPostedComments...)
 	if decoded.ID != 0 && len(req.Comments) > 0 {
 		if comments, commentsErr := s.listReviewComments(ctx, token, owner, repo, req.PullNumber, decoded.ID); commentsErr == nil {
@@ -1007,6 +1019,100 @@ func withCodeReviewFindingMarker(body, markerKey string) string {
 	return body + "\n\n" + marker
 }
 
+const (
+	codeReviewHistoryStartMarker = "<!-- 143-code-review-history:start -->"
+	codeReviewHistoryEndMarker   = "<!-- 143-code-review-history:end -->"
+)
+
+func withCodeReviewHistory(body, previousBody string, decision SubmitReviewDecision, decidedAt time.Time) string {
+	body = stripCodeReviewHistory(body)
+	entries := codeReviewHistoryEntries(previousBody)
+	if entry := codeReviewHistoryEntry(decision, decidedAt); entry != "" && !containsString(entries, entry) {
+		entries = append(entries, entry)
+	}
+	if len(entries) == 0 {
+		return body
+	}
+	history := codeReviewHistoryStartMarker + "\nPrevious 143 code reviews:\n" + strings.Join(entries, "\n") + "\n" + codeReviewHistoryEndMarker
+	if body == "" {
+		return history
+	}
+	return body + "\n\n" + history
+}
+
+func codeReviewHistoryEntries(body string) []string {
+	start := strings.Index(body, codeReviewHistoryStartMarker)
+	if start < 0 {
+		return nil
+	}
+	rest := body[start+len(codeReviewHistoryStartMarker):]
+	end := strings.Index(rest, codeReviewHistoryEndMarker)
+	if end < 0 {
+		return nil
+	}
+	lines := strings.Split(rest[:end], "\n")
+	entries := make([]string, 0, len(lines))
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		if strings.HasPrefix(line, "- ") {
+			entries = append(entries, line)
+		}
+	}
+	return entries
+}
+
+func stripCodeReviewHistory(body string) string {
+	start := strings.Index(body, codeReviewHistoryStartMarker)
+	if start < 0 {
+		return strings.TrimSpace(body)
+	}
+	rest := body[start+len(codeReviewHistoryStartMarker):]
+	end := strings.Index(rest, codeReviewHistoryEndMarker)
+	if end < 0 {
+		return strings.TrimSpace(body)
+	}
+	before := strings.TrimSpace(body[:start])
+	after := strings.TrimSpace(rest[end+len(codeReviewHistoryEndMarker):])
+	if before == "" {
+		return after
+	}
+	if after == "" {
+		return before
+	}
+	return before + "\n\n" + after
+}
+
+func codeReviewHistoryEntry(decision SubmitReviewDecision, decidedAt time.Time) string {
+	if decidedAt.IsZero() || decision.validate() != nil {
+		return ""
+	}
+	return fmt.Sprintf("- `%s` — **%s**", decidedAt.UTC().Format(time.RFC3339), codeReviewDecisionLabel(decision))
+}
+
+func codeReviewDecisionLabel(decision SubmitReviewDecision) string {
+	switch decision {
+	case SubmitReviewDecisionApproved:
+		return "Approved"
+	case SubmitReviewDecisionCommentOnly:
+		return "Not approved"
+	case SubmitReviewDecisionNeedsHumanReview:
+		return "Not approved — needs human review"
+	case SubmitReviewDecisionBlocked:
+		return "Not approved — blocked"
+	default:
+		return string(decision)
+	}
+}
+
+func containsString(values []string, target string) bool {
+	for _, value := range values {
+		if value == target {
+			return true
+		}
+	}
+	return false
+}
+
 func codeReviewOutputMarker(outputKey string) string {
 	return "<!-- 143-code-review-output:" + codeReviewMarkerDigest(outputKey) + " -->"
 }
@@ -1077,7 +1183,8 @@ func githubReviewEvent(decision SubmitReviewDecision) string {
 
 func (d SubmitReviewDecision) validate() error {
 	switch d {
-	case SubmitReviewDecisionApproved, SubmitReviewDecisionCommentOnly:
+	case SubmitReviewDecisionApproved, SubmitReviewDecisionCommentOnly,
+		SubmitReviewDecisionNeedsHumanReview, SubmitReviewDecisionBlocked:
 		return nil
 	default:
 		return fmt.Errorf("invalid submit review decision: %q", d)

--- a/internal/services/codereview/github_submitter_test.go
+++ b/internal/services/codereview/github_submitter_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"sync"
 	"testing"
+	"time"
 
 	ghservice "github.com/assembledhq/143/internal/services/github"
 	"github.com/stretchr/testify/require"
@@ -57,6 +58,7 @@ func TestGitHubSubmitter_SubmitReview(t *testing.T) {
 	require.NoError(t, err, "SubmitReview should post a GitHub review")
 	require.Equal(t, int64(123), result.ID, "SubmitReview should return review id")
 	require.Equal(t, "https://github.com/acme/repo/pull/42#pullrequestreview-123", result.URL, "SubmitReview should return review URL")
+	require.Equal(t, "143 Code Reviewer approved this PR", result.Body, "SubmitReview should return the visible body persisted for future history updates")
 	require.Equal(t, []SubmitReviewPostedComment{
 		{ID: 456, Path: "src/auth/session.go", Line: 42, Body: "Check this edge case."},
 	}, result.Comments, "SubmitReview should recover posted inline comment ids")
@@ -159,6 +161,7 @@ func TestGitHubSubmitter_SubmitReviewReturnsExistingMarkedReview(t *testing.T) {
 func TestGitHubSubmitter_SubmitReviewUpdatesExistingAssessment(t *testing.T) {
 	t.Parallel()
 
+	previousDecidedAt := time.Date(2026, time.July, 22, 19, 14, 8, 0, time.FixedZone("PDT", -7*60*60))
 	var (
 		reviewUpdate  map[string]string
 		commentUpdate map[string]string
@@ -199,6 +202,9 @@ func TestGitHubSubmitter_SubmitReviewUpdatesExistingAssessment(t *testing.T) {
 		ExistingReviewID:  143,
 		ExistingReviewURL: "https://github.com/acme/repo/pull/42#pullrequestreview-143",
 		Decision:          SubmitReviewDecisionCommentOnly,
+		PreviousDecision:  SubmitReviewDecisionBlocked,
+		PreviousDecidedAt: previousDecidedAt,
+		PreviousBody:      "143 Code Reviewer did not approve this PR\n\nWhy: blocking findings remained.",
 		Body:              "143 Code Reviewer did not approve this PR\n\nWhy: required checks are failing.",
 		Comments: []SubmitReviewComment{{
 			Path: "src/auth/session.go", Line: 42, Body: "Updated finding.", DedupeKey: "finding-key",
@@ -208,8 +214,10 @@ func TestGitHubSubmitter_SubmitReviewUpdatesExistingAssessment(t *testing.T) {
 	require.NoError(t, err, "SubmitReview should update an existing GitHub assessment")
 	require.Equal(t, int64(143), result.ID, "updated assessment should retain the original review id")
 	require.Equal(t, "https://github.com/acme/repo/pull/42#pullrequestreview-143", result.URL, "updated assessment should retain the original review URL")
-	require.Contains(t, reviewUpdate["body"], "required checks are failing", "review summary should contain the updated pass assessment")
-	require.Contains(t, reviewUpdate["body"], codeReviewOutputMarker("updated-output"), "review summary should carry the new idempotency marker")
+	expectedVisibleBody := "143 Code Reviewer did not approve this PR\n\nWhy: required checks are failing.\n\n" +
+		codeReviewHistoryStartMarker + "\nPrevious 143 code reviews:\n- `2026-07-23T02:14:08Z` — **Not approved — blocked**\n" + codeReviewHistoryEndMarker
+	require.Equal(t, expectedVisibleBody, result.Body, "updated assessment should return the visible review body with prior decision history")
+	require.Equal(t, withCodeReviewOutputMarker(expectedVisibleBody, "updated-output"), reviewUpdate["body"], "review summary update should retain one timestamped line for the prior decision")
 	require.Equal(t, withCodeReviewFindingMarker("Updated finding.", "finding-key"), commentUpdate["body"], "matching prior inline finding should be updated in place with a stable reassessment marker")
 	require.Equal(t, []SubmitReviewPostedComment{{
 		ID: 456, Path: "src/auth/session.go", Line: 42,
@@ -317,6 +325,89 @@ func TestIsCodeReviewAuthoredBody(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			require.Equal(t, tt.expected, IsCodeReviewAuthoredBody(tt.body), "marker detection should classify review authorship")
+		})
+	}
+}
+
+func TestWithCodeReviewHistory(t *testing.T) {
+	t.Parallel()
+
+	firstDecisionAt := time.Date(2026, time.July, 20, 10, 30, 0, 0, time.UTC)
+	secondDecisionAt := time.Date(2026, time.July, 21, 15, 45, 12, 0, time.UTC)
+	firstHistory := codeReviewHistoryStartMarker + "\nPrevious 143 code reviews:\n" +
+		"- `2026-07-20T10:30:00Z` — **Not approved — needs human review**\n" + codeReviewHistoryEndMarker
+	tests := []struct {
+		name         string
+		body         string
+		previousBody string
+		decision     SubmitReviewDecision
+		decidedAt    time.Time
+		expected     string
+	}{
+		{
+			name:         "leaves current body unchanged without a complete prior decision",
+			body:         "Current assessment.",
+			previousBody: "Prior assessment.",
+			expected:     "Current assessment.",
+		},
+		{
+			name:         "adds one timestamped line for the prior decision",
+			body:         "Current assessment.",
+			previousBody: "Prior assessment.",
+			decision:     SubmitReviewDecisionNeedsHumanReview,
+			decidedAt:    firstDecisionAt,
+			expected:     "Current assessment.\n\n" + firstHistory,
+		},
+		{
+			name:         "preserves earlier history when another assessment replaces the comment",
+			body:         "Newest assessment.",
+			previousBody: "Prior assessment.\n\n" + firstHistory,
+			decision:     SubmitReviewDecisionCommentOnly,
+			decidedAt:    secondDecisionAt,
+			expected: "Newest assessment.\n\n" + codeReviewHistoryStartMarker + "\nPrevious 143 code reviews:\n" +
+				"- `2026-07-20T10:30:00Z` — **Not approved — needs human review**\n" +
+				"- `2026-07-21T15:45:12Z` — **Not approved**\n" + codeReviewHistoryEndMarker,
+		},
+		{
+			name:         "does not duplicate an entry when publishing is retried",
+			body:         "Current assessment.",
+			previousBody: "Prior assessment.\n\n" + firstHistory,
+			decision:     SubmitReviewDecisionNeedsHumanReview,
+			decidedAt:    firstDecisionAt,
+			expected:     "Current assessment.\n\n" + firstHistory,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			actual := withCodeReviewHistory(tt.body, tt.previousBody, tt.decision, tt.decidedAt)
+
+			require.Equal(t, tt.expected, actual, "history rendering should preserve the current assessment and expected prior-decision lines")
+		})
+	}
+}
+
+func TestCodeReviewDecisionLabel(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		decision SubmitReviewDecision
+		expected string
+	}{
+		{name: "approved", decision: SubmitReviewDecisionApproved, expected: "Approved"},
+		{name: "comment only", decision: SubmitReviewDecisionCommentOnly, expected: "Not approved"},
+		{name: "needs human review", decision: SubmitReviewDecisionNeedsHumanReview, expected: "Not approved — needs human review"},
+		{name: "blocked", decision: SubmitReviewDecisionBlocked, expected: "Not approved — blocked"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			actual := codeReviewDecisionLabel(tt.decision)
+
+			require.Equal(t, tt.expected, actual, "history should use an approval-oriented label for every decision")
 		})
 	}
 }

--- a/internal/services/codereview/service.go
+++ b/internal/services/codereview/service.go
@@ -161,22 +161,25 @@ type RetryReviewConflictError struct {
 func (e *RetryReviewConflictError) Error() string { return e.Message }
 
 type RunCodeReviewJobPayload struct {
-	OrgID                   uuid.UUID `json:"org_id"`
-	SessionID               uuid.UUID `json:"session_id"`
-	MetadataID              uuid.UUID `json:"metadata_id"`
-	RepositoryID            uuid.UUID `json:"repository_id"`
-	PullRequestID           uuid.UUID `json:"pull_request_id"`
-	PolicyID                uuid.UUID `json:"policy_id"`
-	PolicyVersion           int       `json:"policy_version"`
-	HeadSHA                 string    `json:"head_sha"`
-	FromFork                bool      `json:"from_fork"`
-	PullRequestAuthor       string    `json:"pull_request_author,omitempty"`
-	OutputKey               string    `json:"review_output_key"`
-	RequestedReviewerLogin  string    `json:"requested_reviewer_login,omitempty"`
-	RequestedTeamSlug       string    `json:"requested_team_slug,omitempty"`
-	PreviousOutputKey       string    `json:"previous_review_output_key,omitempty"`
-	ExistingGitHubReviewID  *int64    `json:"existing_github_review_id,omitempty"`
-	ExistingGitHubReviewURL *string   `json:"existing_github_review_url,omitempty"`
+	OrgID                   uuid.UUID                  `json:"org_id"`
+	SessionID               uuid.UUID                  `json:"session_id"`
+	MetadataID              uuid.UUID                  `json:"metadata_id"`
+	RepositoryID            uuid.UUID                  `json:"repository_id"`
+	PullRequestID           uuid.UUID                  `json:"pull_request_id"`
+	PolicyID                uuid.UUID                  `json:"policy_id"`
+	PolicyVersion           int                        `json:"policy_version"`
+	HeadSHA                 string                     `json:"head_sha"`
+	FromFork                bool                       `json:"from_fork"`
+	PullRequestAuthor       string                     `json:"pull_request_author,omitempty"`
+	OutputKey               string                     `json:"review_output_key"`
+	RequestedReviewerLogin  string                     `json:"requested_reviewer_login,omitempty"`
+	RequestedTeamSlug       string                     `json:"requested_team_slug,omitempty"`
+	PreviousOutputKey       string                     `json:"previous_review_output_key,omitempty"`
+	PreviousReviewDecision  *models.CodeReviewDecision `json:"previous_review_decision,omitempty"`
+	PreviousReviewDecidedAt *time.Time                 `json:"previous_review_decided_at,omitempty"`
+	PreviousReviewBody      *string                    `json:"previous_review_body,omitempty"`
+	ExistingGitHubReviewID  *int64                     `json:"existing_github_review_id,omitempty"`
+	ExistingGitHubReviewURL *string                    `json:"existing_github_review_url,omitempty"`
 }
 
 type reviewStartOptions struct {
@@ -185,6 +188,9 @@ type reviewStartOptions struct {
 	changeKey               string
 	changeReason            string
 	previousOutputKey       string
+	previousReviewDecision  *models.CodeReviewDecision
+	previousReviewDecidedAt *time.Time
+	previousReviewBody      *string
 	existingGitHubReviewID  *int64
 	existingGitHubReviewURL *string
 }
@@ -299,6 +305,9 @@ func (s *Service) RetryReview(ctx context.Context, input RetryReviewInput) (Retr
 	started, err := s.startReview(ctx, requested, reviewStartOptions{
 		triggerSource:           failed.TriggerSource,
 		previousOutputKey:       submitted.ReviewOutputKey,
+		previousReviewDecision:  submitted.Decision,
+		previousReviewDecidedAt: submitted.CompletedAt,
+		previousReviewBody:      submitted.FinalReviewBody,
 		existingGitHubReviewID:  submitted.GitHubReviewID,
 		existingGitHubReviewURL: submitted.GitHubReviewURL,
 	})
@@ -543,6 +552,9 @@ func (s *Service) HandleReviewChanged(ctx context.Context, input ReviewChangedIn
 		changeKey:               input.ChangeKey,
 		changeReason:            input.ChangeReason,
 		previousOutputKey:       submitted.ReviewOutputKey,
+		previousReviewDecision:  submitted.Decision,
+		previousReviewDecidedAt: submitted.CompletedAt,
+		previousReviewBody:      submitted.FinalReviewBody,
 		existingGitHubReviewID:  submitted.GitHubReviewID,
 		existingGitHubReviewURL: submitted.GitHubReviewURL,
 	})
@@ -739,6 +751,9 @@ func (s *Service) startReview(ctx context.Context, input ReviewRequestedInput, o
 		RequestedReviewerLogin:  input.RequestedLogin,
 		RequestedTeamSlug:       input.RequestedTeam,
 		PreviousOutputKey:       opts.previousOutputKey,
+		PreviousReviewDecision:  opts.previousReviewDecision,
+		PreviousReviewDecidedAt: opts.previousReviewDecidedAt,
+		PreviousReviewBody:      opts.previousReviewBody,
 		ExistingGitHubReviewID:  opts.existingGitHubReviewID,
 		ExistingGitHubReviewURL: opts.existingGitHubReviewURL,
 	}

--- a/internal/services/codereview/service_test.go
+++ b/internal/services/codereview/service_test.go
@@ -314,6 +314,9 @@ func TestService_HandleReviewChanged(t *testing.T) {
 
 	priorReviewID := int64(143)
 	priorReviewURL := "https://github.com/acme/repo/pull/42#pullrequestreview-143"
+	priorDecision := models.CodeReviewDecisionNeedsHumanReview
+	priorDecidedAt := time.Date(2026, time.July, 22, 18, 45, 0, 0, time.UTC)
+	priorReviewBody := "143 Code Reviewer did not approve this PR"
 	tests := []struct {
 		name              string
 		usePriorSessionID bool
@@ -353,9 +356,12 @@ func TestService_HandleReviewChanged(t *testing.T) {
 					FromFork:        true,
 					TriggerSource:   models.CodeReviewTriggerSourceTeamReviewer,
 					Status:          models.CodeReviewSessionStatusCompleted,
+					Decision:        &priorDecision,
 					ReviewOutputKey: "prior-output-key",
 					GitHubReviewID:  &priorReviewID,
 					GitHubReviewURL: &priorReviewURL,
+					FinalReviewBody: &priorReviewBody,
+					CompletedAt:     &priorDecidedAt,
 				}
 				sessions.getResult = models.Session{RevisionContext: json.RawMessage(`{"pull_request_author":"anya"}`)}
 			},
@@ -369,6 +375,9 @@ func TestService_HandleReviewChanged(t *testing.T) {
 				require.Equal(t, &priorReviewID, jobs.payload.ExistingGitHubReviewID, "worker should update the existing GitHub review")
 				require.Equal(t, &priorReviewURL, jobs.payload.ExistingGitHubReviewURL, "worker should retain the existing review URL")
 				require.Equal(t, "prior-output-key", jobs.payload.PreviousOutputKey, "worker should be able to match prior inline findings")
+				require.Equal(t, &priorDecision, jobs.payload.PreviousReviewDecision, "worker should retain the prior decision for the visible history line")
+				require.Equal(t, &priorDecidedAt, jobs.payload.PreviousReviewDecidedAt, "worker should retain when the prior decision completed")
+				require.Equal(t, &priorReviewBody, jobs.payload.PreviousReviewBody, "worker should retain any earlier visible review history")
 				require.Equal(t, "anya", jobs.payload.PullRequestAuthor, "reassessment should retain author eligibility context")
 				require.True(t, jobs.payload.FromFork, "reassessment should retain fork eligibility context")
 			},

--- a/internal/worker/code_review_handler.go
+++ b/internal/worker/code_review_handler.go
@@ -25,22 +25,25 @@ import (
 )
 
 type runCodeReviewPayload struct {
-	OrgID                   uuid.UUID `json:"org_id"`
-	SessionID               uuid.UUID `json:"session_id"`
-	MetadataID              uuid.UUID `json:"metadata_id"`
-	RepositoryID            uuid.UUID `json:"repository_id"`
-	PullRequestID           uuid.UUID `json:"pull_request_id"`
-	PolicyID                uuid.UUID `json:"policy_id"`
-	PolicyVersion           int       `json:"policy_version"`
-	HeadSHA                 string    `json:"head_sha"`
-	FromFork                bool      `json:"from_fork"`
-	PullRequestAuthor       string    `json:"pull_request_author,omitempty"`
-	OutputKey               string    `json:"review_output_key"`
-	RequestedReviewerLogin  string    `json:"requested_reviewer_login,omitempty"`
-	RequestedTeamSlug       string    `json:"requested_team_slug,omitempty"`
-	PreviousOutputKey       string    `json:"previous_review_output_key,omitempty"`
-	ExistingGitHubReviewID  *int64    `json:"existing_github_review_id,omitempty"`
-	ExistingGitHubReviewURL *string   `json:"existing_github_review_url,omitempty"`
+	OrgID                   uuid.UUID                  `json:"org_id"`
+	SessionID               uuid.UUID                  `json:"session_id"`
+	MetadataID              uuid.UUID                  `json:"metadata_id"`
+	RepositoryID            uuid.UUID                  `json:"repository_id"`
+	PullRequestID           uuid.UUID                  `json:"pull_request_id"`
+	PolicyID                uuid.UUID                  `json:"policy_id"`
+	PolicyVersion           int                        `json:"policy_version"`
+	HeadSHA                 string                     `json:"head_sha"`
+	FromFork                bool                       `json:"from_fork"`
+	PullRequestAuthor       string                     `json:"pull_request_author,omitempty"`
+	OutputKey               string                     `json:"review_output_key"`
+	RequestedReviewerLogin  string                     `json:"requested_reviewer_login,omitempty"`
+	RequestedTeamSlug       string                     `json:"requested_team_slug,omitempty"`
+	PreviousOutputKey       string                     `json:"previous_review_output_key,omitempty"`
+	PreviousReviewDecision  *models.CodeReviewDecision `json:"previous_review_decision,omitempty"`
+	PreviousReviewDecidedAt *time.Time                 `json:"previous_review_decided_at,omitempty"`
+	PreviousReviewBody      *string                    `json:"previous_review_body,omitempty"`
+	ExistingGitHubReviewID  *int64                     `json:"existing_github_review_id,omitempty"`
+	ExistingGitHubReviewURL *string                    `json:"existing_github_review_url,omitempty"`
 }
 
 const codeReviewRawOutputInlineLimit = 32 * 1024
@@ -303,6 +306,10 @@ func newRunCodeReviewHandler(stores *Stores, services *Services, logger zerolog.
 		if err != nil {
 			return err
 		}
+		finalReviewBody := body
+		if strings.TrimSpace(submission.FinalReviewBody) != "" {
+			finalReviewBody = submission.FinalReviewBody
+		}
 		removeCodeReviewRequestedReviewer(ctx, stores, services, logger, job, pr)
 		if _, err := stores.CodeReviews.CompleteReview(ctx, job.OrgID, db.CompleteCodeReviewParams{
 			SessionID:       job.SessionID,
@@ -310,7 +317,7 @@ func newRunCodeReviewHandler(stores *Stores, services *Services, logger zerolog.
 			Acceptable:      decision.Acceptable,
 			GitHubReviewID:  submission.GitHubReviewID,
 			GitHubReviewURL: submission.GitHubReviewURL,
-			FinalReviewBody: body,
+			FinalReviewBody: finalReviewBody,
 		}); err != nil {
 			return fmt.Errorf("complete code review: %w", err)
 		}
@@ -2278,6 +2285,7 @@ func codeReviewWaitingForOrchestrator(policy models.CodeReviewPolicyConfig) erro
 type codeReviewSubmission struct {
 	GitHubReviewID  *int64
 	GitHubReviewURL *string
+	FinalReviewBody string
 }
 
 type codeReviewRequestedReviewerRemover interface {
@@ -3337,6 +3345,7 @@ func submitCodeReviewToGitHub(ctx context.Context, stores *Stores, services *Ser
 		return codeReviewSubmission{
 			GitHubReviewID:  metadata.GitHubReviewID,
 			GitHubReviewURL: metadata.GitHubReviewURL,
+			FinalReviewBody: stringPtrValue(metadata.FinalReviewBody),
 		}, false, nil
 	}
 
@@ -3371,19 +3380,27 @@ func submitCodeReviewToGitHub(ctx context.Context, stores *Stores, services *Ser
 		ExistingReviewID:  int64PtrValue(job.ExistingGitHubReviewID),
 		ExistingReviewURL: stringPtrValue(job.ExistingGitHubReviewURL),
 		Decision:          codeReviewSubmitDecision(decision),
+		PreviousDecision:  codeReviewSubmitDecisionPtr(job.PreviousReviewDecision),
+		PreviousDecidedAt: timePtrValue(job.PreviousReviewDecidedAt),
+		PreviousBody:      stringPtrValue(job.PreviousReviewBody),
 		Body:              body,
 		Comments:          comments,
 	})
 	if err != nil {
 		return codeReviewSubmission{}, false, classifyGitHubJobError(fmt.Errorf("submit code review to GitHub: %w", err), job.SessionID.String())
 	}
-	if _, err := stores.CodeReviews.RecordGitHubReview(ctx, job.OrgID, job.SessionID, result.ID, result.URL, body); err != nil {
+	finalReviewBody := strings.TrimSpace(result.Body)
+	if finalReviewBody == "" {
+		finalReviewBody = body
+	}
+	if _, err := stores.CodeReviews.RecordGitHubReview(ctx, job.OrgID, job.SessionID, result.ID, result.URL, finalReviewBody); err != nil {
 		return codeReviewSubmission{}, true, fmt.Errorf("record submitted code review: %w", err)
 	}
 	markPostedCodeReviewFindings(ctx, stores.CodeReviews, job.OrgID, findings, result.Comments)
 	return codeReviewSubmission{
 		GitHubReviewID:  &result.ID,
 		GitHubReviewURL: &result.URL,
+		FinalReviewBody: finalReviewBody,
 	}, true, nil
 }
 
@@ -3395,10 +3412,21 @@ func int64PtrValue(value *int64) int64 {
 }
 
 func codeReviewSubmitDecision(decision models.CodeReviewDecision) codereviewsvc.SubmitReviewDecision {
-	if decision == models.CodeReviewDecisionApproved {
-		return codereviewsvc.SubmitReviewDecisionApproved
+	return codereviewsvc.SubmitReviewDecision(decision)
+}
+
+func codeReviewSubmitDecisionPtr(decision *models.CodeReviewDecision) codereviewsvc.SubmitReviewDecision {
+	if decision == nil {
+		return ""
 	}
-	return codereviewsvc.SubmitReviewDecisionCommentOnly
+	return codeReviewSubmitDecision(*decision)
+}
+
+func timePtrValue(value *time.Time) time.Time {
+	if value == nil {
+		return time.Time{}
+	}
+	return *value
 }
 
 func codeReviewInlineComments(findings []models.CodeReviewFinding) []codereviewsvc.SubmitReviewComment {

--- a/internal/worker/code_review_handler_test.go
+++ b/internal/worker/code_review_handler_test.go
@@ -334,6 +334,30 @@ func TestCodeReviewTerminalFailureStatus(t *testing.T) {
 	}
 }
 
+func TestCodeReviewSubmitDecision(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		decision models.CodeReviewDecision
+		expected codereview.SubmitReviewDecision
+	}{
+		{name: "approved", decision: models.CodeReviewDecisionApproved, expected: codereview.SubmitReviewDecisionApproved},
+		{name: "comment only", decision: models.CodeReviewDecisionCommentOnly, expected: codereview.SubmitReviewDecisionCommentOnly},
+		{name: "needs human review", decision: models.CodeReviewDecisionNeedsHumanReview, expected: codereview.SubmitReviewDecisionNeedsHumanReview},
+		{name: "blocked", decision: models.CodeReviewDecisionBlocked, expected: codereview.SubmitReviewDecisionBlocked},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			actual := codeReviewSubmitDecision(tt.decision)
+
+			require.Equal(t, tt.expected, actual, "GitHub submission should retain the exact 143 decision while mapping non-approvals to comment reviews")
+		})
+	}
+}
+
 type capturingCodeReviewSubmitter struct {
 	removeRequests   []codereview.RequestedReviewersRequest
 	fileListRequests []codereview.PullRequestFilesRequest


### PR DESCRIPTION
## Summary
- Preserve prior review decisions, timestamps, and visible bodies across reassessments.
- Append deduplicated, timestamped decision history to updated GitHub reviews.
- Retain the visible review body when recording completed reviews.
- Support needs-human-review and blocked decision types.

## Testing
- Added focused unit tests for history rendering, decision labels, payload propagation, and decision mapping.