### PR TITLE
Repair malformed code review orchestrator synthesis

### DIFF
--- a/internal/prompts/prompts.go
+++ b/internal/prompts/prompts.go
@@ -361,6 +361,15 @@ func CodeReviewOrchestratorPrompt(data CodeReviewOrchestratorPromptData) string 
 	return render("code_review_orchestrator.template", data)
 }
 
+type CodeReviewOrchestratorRepairPromptData struct {
+	ValidationError         string
+	DescriptionRequirements []CodeReviewDescriptionRequirementPromptData
+}
+
+func CodeReviewOrchestratorRepairPrompt(data CodeReviewOrchestratorRepairPromptData) string {
+	return render("code_review_orchestrator_repair.template", data)
+}
+
 // ─── Automations ────────────────────────────────────────────────────────────
 
 type AutomationGoalFastImprovementPromptData struct {

--- a/internal/prompts/prompts_test.go
+++ b/internal/prompts/prompts_test.go
@@ -636,8 +636,26 @@ func TestCodeReviewPolicyPromptComposition(t *testing.T) {
 			require.Contains(t, orchestrator, "You own the substantive approve-or-escalate recommendation", "coding-agent orchestrator should own the substantive approval recommendation")
 			require.Contains(t, orchestrator, "Comment-only ESLint cleanup", "orchestrator should receive the pull-request description as evidence")
 			require.Contains(t, orchestrator, "Screenshots are not required for non-visible or comment-only changes.", "orchestrator should receive the trusted description rubric")
-			require.Contains(t, orchestrator, `"approval_recommended": true|false`, "orchestrator output contract should include the approval recommendation")
+			require.Contains(t, orchestrator, `"approval_recommended": false`, "orchestrator output contract should include a valid JSON approval recommendation example")
 			require.Contains(t, orchestrator, `"description_assessments":`, "orchestrator output contract should include structured description assessments")
+			require.Contains(t, orchestrator, "the review fails if any top-level key above is absent", "orchestrator output contract should explicitly reject omitted schema fields")
 		})
 	}
+}
+
+func TestCodeReviewOrchestratorRepairPrompt(t *testing.T) {
+	t.Parallel()
+
+	result := CodeReviewOrchestratorRepairPrompt(CodeReviewOrchestratorRepairPromptData{
+		ValidationError: "orchestrator synthesis is missing required fields",
+		DescriptionRequirements: []CodeReviewDescriptionRequirementPromptData{{
+			Key:    "testing",
+			Prompt: "Explain how the change was tested.",
+		}},
+	})
+
+	require.Contains(t, result, "Return exactly one fenced `json` object and nothing else.", "repair prompt should request an isolated machine-readable response")
+	require.Contains(t, result, `"approval_recommended": false`, "repair prompt should require the approval recommendation with valid JSON")
+	require.Contains(t, result, `"description_assessments":`, "repair prompt should require description assessments")
+	require.Contains(t, result, "testing: Explain how the change was tested.", "repair prompt should enumerate every required description assessment")
 }

--- a/internal/prompts/templates/code_review_orchestrator.template
+++ b/internal/prompts/templates/code_review_orchestrator.template
@@ -84,7 +84,7 @@ Use priority 0 for critical, 1 for high, 2 for medium, and 3 for low. Keep line 
 
 Return concise Markdown, then include a final JSON object fenced as ```json with:
 {
-  "approval_recommended": true|false,
+  "approval_recommended": false,
   "description_assessments": [
     {
       "key": "requirement key",
@@ -92,13 +92,15 @@ Return concise Markdown, then include a final JSON object fenced as ```json with
       "reason": "short evidence-based reason"
     }
   ],
-  "scope_mismatch": true|false,
-  "unresolved_uncertainty": true|false,
-  "reviewer_disagreement": true|false,
-  "prompt_injection_detected": true|false,
+  "scope_mismatch": false,
+  "unresolved_uncertainty": false,
+  "reviewer_disagreement": false,
+  "prompt_injection_detected": false,
   "summary": "one sentence summary of what changed",
   "review_summary": "two to four concise reviewer-facing sentences explaining the evidence, policy blockers, and the most useful next step",
   "risk_notes": ["short note"]
 }
+
+STRICT OUTPUT CONTRACT: the final JSON object is machine-validated and the review fails if any top-level key above is absent. Include every key exactly once, even when a boolean is false or an array is empty. In particular, `approval_recommended` and `description_assessments` are mandatory additions to the current schema; never reuse an older synthesis schema. Before finishing, verify that the object contains all nine top-level keys and exactly one description assessment for every applicable requirement listed above.
 
 The `review_summary` is used as the main prose in the final GitHub review. Ground it in the supplied evidence, write it as one paragraph, and make it useful to the PR author. Keep the approval recommendation in the structured field rather than announcing a final GitHub action in prose; the backend adds the final status after applying non-bypassable safeguards.

--- a/internal/prompts/templates/code_review_orchestrator_repair.template
+++ b/internal/prompts/templates/code_review_orchestrator_repair.template
@@ -1,0 +1,36 @@
+Your previous code review synthesis could not be accepted because it did not match the required JSON schema:
+{{.ValidationError}}
+
+Do not repeat the review, inspect more files, change any conclusions, or emit Markdown or `::code-comment` directives. Return exactly one fenced `json` object and nothing else.
+
+The object MUST contain every top-level key shown below, including `approval_recommended` and `description_assessments`. Never omit a boolean when its value is false. Never reuse an older synthesis schema.
+
+Return exactly:
+```json
+{
+  "approval_recommended": false,
+  "description_assessments": [
+    {
+      "key": "requirement key",
+      "status": "satisfied|not_applicable|missing",
+      "reason": "short evidence-based reason"
+    }
+  ],
+  "scope_mismatch": false,
+  "unresolved_uncertainty": false,
+  "reviewer_disagreement": false,
+  "prompt_injection_detected": false,
+  "summary": "one sentence summary of what changed",
+  "review_summary": "two to four concise reviewer-facing sentences explaining the evidence, policy blockers, and the most useful next step",
+  "risk_notes": ["short note"]
+}
+```
+
+For `description_assessments`, return exactly one assessment for each required key below, with no extra keys:
+{{- range .DescriptionRequirements}}
+- {{.Key}}: {{.Prompt}}
+{{- else}}
+- none; return an empty array
+{{- end}}
+
+Preserve the conclusions from your previous answer. Set `approval_recommended` to false when those conclusions call for a fix or human decision.

--- a/internal/worker/code_review_handler.go
+++ b/internal/worker/code_review_handler.go
@@ -652,20 +652,22 @@ type codeReviewReviewerStructuredResult struct {
 }
 
 type codeReviewOrchestratorStructuredResult struct {
-	ThreadID             string                          `json:"thread_id,omitempty"`
-	PromptArtifactKey    string                          `json:"prompt_artifact_key,omitempty"`
-	DescriptionInputHash string                          `json:"description_input_hash,omitempty"`
-	FindingCount         int                             `json:"finding_count,omitempty"`
-	CostCents            float64                         `json:"cost_cents,omitempty"`
-	RawArtifactKey       string                          `json:"raw_artifact_key,omitempty"`
-	Synthesis            codeReviewOrchestratorSynthesis `json:"synthesis,omitempty"`
-	SynthesisValidated   bool                            `json:"synthesis_validated,omitempty"`
-	SynthesisRepairCount int                             `json:"synthesis_repair_count,omitempty"`
-	ReadOnly             bool                            `json:"read_only,omitempty"`
-	ReadOnlyViolation    bool                            `json:"read_only_violation,omitempty"`
-	Reverted             bool                            `json:"reverted,omitempty"`
-	Error                string                          `json:"error,omitempty"`
-	CompletedAt          string                          `json:"completed_at,omitempty"`
+	ThreadID                string                          `json:"thread_id,omitempty"`
+	PromptArtifactKey       string                          `json:"prompt_artifact_key,omitempty"`
+	DescriptionInputHash    string                          `json:"description_input_hash,omitempty"`
+	FindingCount            int                             `json:"finding_count,omitempty"`
+	CostCents               float64                         `json:"cost_cents,omitempty"`
+	RawArtifactKey          string                          `json:"raw_artifact_key,omitempty"`
+	Synthesis               codeReviewOrchestratorSynthesis `json:"synthesis,omitempty"`
+	SynthesisValidated      bool                            `json:"synthesis_validated,omitempty"`
+	SynthesisRepairCount    int                             `json:"synthesis_repair_count,omitempty"`
+	SynthesisRepairPending  bool                            `json:"synthesis_repair_pending,omitempty"`
+	SynthesisRepairBaseTurn int                             `json:"synthesis_repair_base_turn,omitempty"`
+	ReadOnly                bool                            `json:"read_only,omitempty"`
+	ReadOnlyViolation       bool                            `json:"read_only_violation,omitempty"`
+	Reverted                bool                            `json:"reverted,omitempty"`
+	Error                   string                          `json:"error,omitempty"`
+	CompletedAt             string                          `json:"completed_at,omitempty"`
 }
 
 func ensureCodeReviewReviewerThreads(ctx context.Context, stores *Stores, services *Services, logger zerolog.Logger, job runCodeReviewPayload, pr models.PullRequest, policy models.CodeReviewPolicyRecord, metadata models.CodeReviewSessionMetadata, changedFiles []codereviewsvc.PullRequestFile) error {
@@ -1581,6 +1583,18 @@ func codeReviewOrchestratorCombinedOutput(previous *string, current string, repa
 	return strings.TrimSpace(*previous) + "\n\n--- synthesis repair response ---\n\n" + current
 }
 
+func codeReviewOrchestratorObserveRepairCompletion(state codeReviewOrchestratorStructuredResult, currentTurn int) codeReviewOrchestratorStructuredResult {
+	if !state.SynthesisRepairPending || currentTurn <= state.SynthesisRepairBaseTurn {
+		return state
+	}
+	nextState := state
+	nextState.SynthesisRepairPending = false
+	if nextState.SynthesisRepairCount < codeReviewOrchestratorSynthesisRepairLimit {
+		nextState.SynthesisRepairCount++
+	}
+	return nextState
+}
+
 func extractCodeReviewJSON(raw string) string {
 	raw = strings.TrimSpace(raw)
 	if raw == "" {
@@ -1604,6 +1618,26 @@ type codeReviewOrchestratorRepairSender interface {
 	SendMessage(context.Context, threadsvc.SendMessageInput) (*threadsvc.SendMessageResult, error)
 }
 
+func persistCodeReviewOrchestratorFindings(
+	ctx context.Context,
+	stores *Stores,
+	job runCodeReviewPayload,
+	resultID uuid.UUID,
+	raw string,
+	changedPaths []string,
+) (int, error) {
+	findings := parseCodeReviewFindings(raw, changedPaths)
+	for i := range findings {
+		findings[i].OrgID = job.OrgID
+		findings[i].SessionID = job.SessionID
+		findings[i].AgentResultID = &resultID
+		if err := stores.CodeReviews.ReplaceFinding(ctx, &findings[i]); err != nil {
+			return 0, fmt.Errorf("create harvested orchestrator code review finding: %w", err)
+		}
+	}
+	return len(findings), nil
+}
+
 func requestCodeReviewOrchestratorSynthesisRepair(
 	ctx context.Context,
 	stores *Stores,
@@ -1614,6 +1648,7 @@ func requestCodeReviewOrchestratorSynthesisRepair(
 	changedFiles []codereviewsvc.PullRequestFile,
 	result models.CodeReviewAgentResult,
 	state codeReviewOrchestratorStructuredResult,
+	threadCurrentTurn int,
 	raw string,
 	validationErr error,
 ) (bool, bool, error) {
@@ -1625,10 +1660,20 @@ func requestCodeReviewOrchestratorSynthesisRepair(
 		return false, false, fmt.Errorf("parse orchestrator thread id for synthesis repair: %w", err)
 	}
 
+	findingCount, err := persistCodeReviewOrchestratorFindings(ctx, stores, job, result.ID, raw, codeReviewChangedPaths(changedFiles))
+	if err != nil {
+		return false, false, err
+	}
 	nextState := state
 	nextState.Synthesis = codeReviewOrchestratorSynthesis{}
 	nextState.SynthesisValidated = false
-	nextState.SynthesisRepairCount++
+	nextState.SynthesisRepairPending = true
+	if !state.SynthesisRepairPending {
+		nextState.SynthesisRepairBaseTurn = threadCurrentTurn
+	}
+	if findingCount > nextState.FindingCount {
+		nextState.FindingCount = findingCount
+	}
 	nextState.Error = "repairing invalid orchestrator synthesis: " + validationErr.Error()
 	nextState.CompletedAt = ""
 
@@ -1655,30 +1700,18 @@ func requestCodeReviewOrchestratorSynthesisRepair(
 		Message:       codeReviewOrchestratorRepairPrompt(validationErr, policy, changedFiles),
 		MessageSource: models.SessionMessageSourceAgentTool,
 	}); err != nil {
-		failedState := nextState
-		failedState.Error = "request orchestrator synthesis repair: " + err.Error()
-		failedState.CompletedAt = time.Now().UTC().Format(time.RFC3339)
-		if _, updateErr := stores.CodeReviews.UpdateAgentResultOutcome(
-			ctx,
-			job.OrgID,
-			result.ID,
-			models.CodeReviewAgentResultStatusFailed,
-			rawOutput,
-			marshalCodeReviewOrchestratorStructuredResult(failedState),
-		); updateErr != nil {
-			return false, false, fmt.Errorf("record failed orchestrator synthesis repair after %v: %w", err, updateErr)
-		}
 		logger.Warn().Err(err).
 			Str("session_id", job.SessionID.String()).
 			Str("thread_id", nextState.ThreadID).
 			Msg("failed to request orchestrator synthesis repair")
-		return true, false, nil
+		return true, false, fmt.Errorf("request orchestrator synthesis repair: %w", err)
 	}
 
 	logger.Info().
 		Str("session_id", job.SessionID.String()).
 		Str("thread_id", nextState.ThreadID).
 		Int("repair_count", nextState.SynthesisRepairCount).
+		Bool("repair_pending", nextState.SynthesisRepairPending).
 		Msg("requested orchestrator synthesis repair")
 	return true, true, nil
 }
@@ -2115,6 +2148,7 @@ func harvestCodeReviewOrchestratorResult(ctx context.Context, stores *Stores, se
 			return fmt.Errorf("load code review orchestrator thread: %w", err)
 		}
 		state.CostCents = thread.CostCents
+		state = codeReviewOrchestratorObserveRepairCompletion(state, thread.CurrentTurn)
 		if codeReviewThreadStillRunning(thread.Status) {
 			continue
 		}
@@ -2170,6 +2204,7 @@ func harvestCodeReviewOrchestratorResult(ctx context.Context, stores *Stores, se
 				changedFiles,
 				result,
 				state,
+				thread.CurrentTurn,
 				combinedRaw,
 				synthesisErr,
 			)
@@ -2199,18 +2234,15 @@ func harvestCodeReviewOrchestratorResult(ctx context.Context, stores *Stores, se
 			}
 			continue
 		}
-		findings := parseCodeReviewFindings(combinedRaw, changedPaths)
-		for i := range findings {
-			findings[i].OrgID = job.OrgID
-			findings[i].SessionID = job.SessionID
-			findings[i].AgentResultID = &result.ID
-			if err := stores.CodeReviews.ReplaceFinding(ctx, &findings[i]); err != nil {
-				return fmt.Errorf("create harvested orchestrator code review finding: %w", err)
-			}
+		findingCount, err := persistCodeReviewOrchestratorFindings(ctx, stores, job, result.ID, combinedRaw, changedPaths)
+		if err != nil {
+			return err
 		}
 		state.Synthesis = synthesis
 		state.SynthesisValidated = true
-		state.FindingCount = len(findings)
+		if findingCount > state.FindingCount {
+			state.FindingCount = findingCount
+		}
 		state.CompletedAt = time.Now().UTC().Format(time.RFC3339)
 		state.Error = ""
 		rawOutput, rawArtifactKey, err := codeReviewRawOutputForStorage(ctx, stores, job, result.ID, models.CodeReviewAgentRoleOrchestrator, result.AgentProvider, combinedRaw)

--- a/internal/worker/code_review_handler.go
+++ b/internal/worker/code_review_handler.go
@@ -47,6 +47,7 @@ type runCodeReviewPayload struct {
 }
 
 const codeReviewRawOutputInlineLimit = 32 * 1024
+const codeReviewOrchestratorSynthesisRepairLimit = 1
 
 type codeReviewDescriptionEvaluation struct {
 	Passed               bool
@@ -659,6 +660,7 @@ type codeReviewOrchestratorStructuredResult struct {
 	RawArtifactKey       string                          `json:"raw_artifact_key,omitempty"`
 	Synthesis            codeReviewOrchestratorSynthesis `json:"synthesis,omitempty"`
 	SynthesisValidated   bool                            `json:"synthesis_validated,omitempty"`
+	SynthesisRepairCount int                             `json:"synthesis_repair_count,omitempty"`
 	ReadOnly             bool                            `json:"read_only,omitempty"`
 	ReadOnlyViolation    bool                            `json:"read_only_violation,omitempty"`
 	Reverted             bool                            `json:"reverted,omitempty"`
@@ -1564,6 +1566,21 @@ func codeReviewOrchestratorReviewSummary(synthesis codeReviewOrchestratorSynthes
 	return strings.TrimSpace(synthesis.Summary)
 }
 
+func codeReviewOrchestratorRepairPrompt(validationErr error, policy models.CodeReviewPolicyConfig, changedFiles []codereviewsvc.PullRequestFile) string {
+	return strings.TrimSpace(prompts.CodeReviewOrchestratorRepairPrompt(prompts.CodeReviewOrchestratorRepairPromptData{
+		ValidationError:         validationErr.Error(),
+		DescriptionRequirements: codeReviewDescriptionRequirementsForPrompt(policy, changedFiles),
+	}))
+}
+
+func codeReviewOrchestratorCombinedOutput(previous *string, current string, repairCount int) string {
+	current = strings.TrimSpace(current)
+	if repairCount <= 0 || previous == nil || strings.TrimSpace(*previous) == "" {
+		return current
+	}
+	return strings.TrimSpace(*previous) + "\n\n--- synthesis repair response ---\n\n" + current
+}
+
 func extractCodeReviewJSON(raw string) string {
 	raw = strings.TrimSpace(raw)
 	if raw == "" {
@@ -1581,6 +1598,89 @@ func extractCodeReviewJSON(raw string) string {
 		return strings.TrimSpace(raw[start : end+1])
 	}
 	return raw
+}
+
+type codeReviewOrchestratorRepairSender interface {
+	SendMessage(context.Context, threadsvc.SendMessageInput) (*threadsvc.SendMessageResult, error)
+}
+
+func requestCodeReviewOrchestratorSynthesisRepair(
+	ctx context.Context,
+	stores *Stores,
+	sender codeReviewOrchestratorRepairSender,
+	logger zerolog.Logger,
+	job runCodeReviewPayload,
+	policy models.CodeReviewPolicyConfig,
+	changedFiles []codereviewsvc.PullRequestFile,
+	result models.CodeReviewAgentResult,
+	state codeReviewOrchestratorStructuredResult,
+	raw string,
+	validationErr error,
+) (bool, bool, error) {
+	if state.SynthesisRepairCount >= codeReviewOrchestratorSynthesisRepairLimit {
+		return false, false, nil
+	}
+	threadID, err := uuid.Parse(strings.TrimSpace(state.ThreadID))
+	if err != nil {
+		return false, false, fmt.Errorf("parse orchestrator thread id for synthesis repair: %w", err)
+	}
+
+	nextState := state
+	nextState.Synthesis = codeReviewOrchestratorSynthesis{}
+	nextState.SynthesisValidated = false
+	nextState.SynthesisRepairCount++
+	nextState.Error = "repairing invalid orchestrator synthesis: " + validationErr.Error()
+	nextState.CompletedAt = ""
+
+	rawOutput, rawArtifactKey, err := codeReviewRawOutputForStorage(ctx, stores, job, result.ID, models.CodeReviewAgentRoleOrchestrator, result.AgentProvider, raw)
+	if err != nil {
+		return false, false, err
+	}
+	nextState.RawArtifactKey = rawArtifactKey
+	if _, err := stores.CodeReviews.UpdateAgentResultOutcome(
+		ctx,
+		job.OrgID,
+		result.ID,
+		models.CodeReviewAgentResultStatusRunning,
+		rawOutput,
+		marshalCodeReviewOrchestratorStructuredResult(nextState),
+	); err != nil {
+		return false, false, fmt.Errorf("record orchestrator synthesis repair: %w", err)
+	}
+
+	if _, err := sender.SendMessage(ctx, threadsvc.SendMessageInput{
+		SessionID:     job.SessionID,
+		OrgID:         job.OrgID,
+		ThreadID:      threadID,
+		Message:       codeReviewOrchestratorRepairPrompt(validationErr, policy, changedFiles),
+		MessageSource: models.SessionMessageSourceAgentTool,
+	}); err != nil {
+		failedState := nextState
+		failedState.Error = "request orchestrator synthesis repair: " + err.Error()
+		failedState.CompletedAt = time.Now().UTC().Format(time.RFC3339)
+		if _, updateErr := stores.CodeReviews.UpdateAgentResultOutcome(
+			ctx,
+			job.OrgID,
+			result.ID,
+			models.CodeReviewAgentResultStatusFailed,
+			rawOutput,
+			marshalCodeReviewOrchestratorStructuredResult(failedState),
+		); updateErr != nil {
+			return false, false, fmt.Errorf("record failed orchestrator synthesis repair after %v: %w", err, updateErr)
+		}
+		logger.Warn().Err(err).
+			Str("session_id", job.SessionID.String()).
+			Str("thread_id", nextState.ThreadID).
+			Msg("failed to request orchestrator synthesis repair")
+		return true, false, nil
+	}
+
+	logger.Info().
+		Str("session_id", job.SessionID.String()).
+		Str("thread_id", nextState.ThreadID).
+		Int("repair_count", nextState.SynthesisRepairCount).
+		Msg("requested orchestrator synthesis repair")
+	return true, true, nil
 }
 
 func codeReviewReviewerResultTerminal(status models.CodeReviewAgentResultStatus) bool {
@@ -2053,26 +2153,53 @@ func harvestCodeReviewOrchestratorResult(ctx context.Context, stores *Stores, se
 			}
 			continue
 		}
+		combinedRaw := codeReviewOrchestratorCombinedOutput(result.RawOutput, raw, state.SynthesisRepairCount)
 		synthesis, synthesisErr := parseCodeReviewOrchestratorSynthesis(raw)
 		if synthesisErr == nil {
 			_, synthesisErr = codeReviewDescriptionEvaluationFromSynthesis(policy.Config(), changedFiles, synthesis)
 		}
 		if synthesisErr != nil {
+			threads := threadsvc.NewService(stores.SessionThreads, stores.Sessions, stores.SessionMessages, stores.SessionLogs, stores.Jobs, logger)
+			repairHandled, repairStarted, repairErr := requestCodeReviewOrchestratorSynthesisRepair(
+				ctx,
+				stores,
+				threads,
+				logger,
+				job,
+				policy.Config(),
+				changedFiles,
+				result,
+				state,
+				combinedRaw,
+				synthesisErr,
+			)
+			if repairErr != nil {
+				return repairErr
+			}
+			if repairStarted {
+				return codeReviewWaitingForOrchestrator(policy.Config())
+			}
+			if repairHandled {
+				continue
+			}
+
 			state.Synthesis = codeReviewOrchestratorSynthesis{}
 			state.SynthesisValidated = false
 			state.Error = "invalid orchestrator synthesis: " + synthesisErr.Error()
 			state.CompletedAt = time.Now().UTC().Format(time.RFC3339)
-			rawOutput, rawArtifactKey, err := codeReviewRawOutputForStorage(ctx, stores, job, result.ID, models.CodeReviewAgentRoleOrchestrator, result.AgentProvider, raw)
+			rawOutput, rawArtifactKey, err := codeReviewRawOutputForStorage(ctx, stores, job, result.ID, models.CodeReviewAgentRoleOrchestrator, result.AgentProvider, combinedRaw)
 			if err != nil {
 				return err
 			}
-			state.RawArtifactKey = rawArtifactKey
+			if rawArtifactKey != "" {
+				state.RawArtifactKey = rawArtifactKey
+			}
 			if _, err := stores.CodeReviews.UpdateAgentResultOutcome(ctx, job.OrgID, result.ID, models.CodeReviewAgentResultStatusFailed, rawOutput, marshalCodeReviewOrchestratorStructuredResult(state)); err != nil {
 				return fmt.Errorf("mark malformed orchestrator synthesis failed: %w", err)
 			}
 			continue
 		}
-		findings := parseCodeReviewFindings(raw, changedPaths)
+		findings := parseCodeReviewFindings(combinedRaw, changedPaths)
 		for i := range findings {
 			findings[i].OrgID = job.OrgID
 			findings[i].SessionID = job.SessionID
@@ -2085,11 +2212,14 @@ func harvestCodeReviewOrchestratorResult(ctx context.Context, stores *Stores, se
 		state.SynthesisValidated = true
 		state.FindingCount = len(findings)
 		state.CompletedAt = time.Now().UTC().Format(time.RFC3339)
-		rawOutput, rawArtifactKey, err := codeReviewRawOutputForStorage(ctx, stores, job, result.ID, models.CodeReviewAgentRoleOrchestrator, result.AgentProvider, raw)
+		state.Error = ""
+		rawOutput, rawArtifactKey, err := codeReviewRawOutputForStorage(ctx, stores, job, result.ID, models.CodeReviewAgentRoleOrchestrator, result.AgentProvider, combinedRaw)
 		if err != nil {
 			return err
 		}
-		state.RawArtifactKey = rawArtifactKey
+		if rawArtifactKey != "" {
+			state.RawArtifactKey = rawArtifactKey
+		}
 		if _, err := stores.CodeReviews.UpdateAgentResultOutcome(ctx, job.OrgID, result.ID, models.CodeReviewAgentResultStatusCompleted, rawOutput, marshalCodeReviewOrchestratorStructuredResult(state)); err != nil {
 			return fmt.Errorf("mark orchestrator completed: %w", err)
 		}

--- a/internal/worker/code_review_handler_test.go
+++ b/internal/worker/code_review_handler_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/assembledhq/143/internal/prompts"
 	"github.com/assembledhq/143/internal/services/codereview"
 	ghservice "github.com/assembledhq/143/internal/services/github"
+	threadsvc "github.com/assembledhq/143/internal/services/thread"
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
 	"github.com/pashagolub/pgxmock/v4"
@@ -1493,6 +1494,130 @@ func (validatedOrchestratorResultArg) Match(value any) bool {
 	return ok && state.SynthesisValidated && codeReviewOrchestratorSynthesisUsable(state.Synthesis)
 }
 
+type repairingOrchestratorResultArg struct{}
+
+func (repairingOrchestratorResultArg) Match(value any) bool {
+	var raw json.RawMessage
+	switch typed := value.(type) {
+	case json.RawMessage:
+		raw = typed
+	case []byte:
+		raw = typed
+	case string:
+		raw = json.RawMessage(typed)
+	default:
+		return false
+	}
+	state, ok := parseCodeReviewOrchestratorStructuredResult(raw)
+	return ok &&
+		!state.SynthesisValidated &&
+		state.SynthesisRepairCount == 1 &&
+		strings.Contains(state.Error, "missing required fields")
+}
+
+type codeReviewOrchestratorRepairSenderStub struct {
+	inputs []threadsvc.SendMessageInput
+}
+
+func (s *codeReviewOrchestratorRepairSenderStub) SendMessage(_ context.Context, input threadsvc.SendMessageInput) (*threadsvc.SendMessageResult, error) {
+	s.inputs = append(s.inputs, input)
+	return &threadsvc.SendMessageResult{}, nil
+}
+
+func TestRequestCodeReviewOrchestratorSynthesisRepair(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "pgxmock pool should initialize")
+	defer mock.Close()
+
+	orgID := uuid.New()
+	sessionID := uuid.New()
+	threadID := uuid.New()
+	resultID := uuid.New()
+	now := time.Now().UTC()
+	rawReview := "```json\n{\"summary\":\"The change is focused.\"}\n```"
+	state := codeReviewOrchestratorStructuredResult{
+		ThreadID:             threadID.String(),
+		DescriptionInputHash: "description-hash",
+	}
+	mock.ExpectQuery("UPDATE code_review_agent_results").
+		WithArgs(models.CodeReviewAgentResultStatusRunning, &rawReview, repairingOrchestratorResultArg{}, orgID, resultID).
+		WillReturnRows(newCodeReviewAgentResultRows().
+			AddRow(resultID, orgID, sessionID, "codex", nil, models.CodeReviewAgentRoleOrchestrator, models.CodeReviewAgentResultStatusRunning, &rawReview, marshalCodeReviewOrchestratorStructuredResult(state), now))
+
+	sender := &codeReviewOrchestratorRepairSenderStub{}
+	stores := &Stores{CodeReviews: db.NewCodeReviewStore(mock)}
+	handled, started, err := requestCodeReviewOrchestratorSynthesisRepair(
+		context.Background(),
+		stores,
+		sender,
+		zerolog.Nop(),
+		runCodeReviewPayload{OrgID: orgID, SessionID: sessionID},
+		models.DefaultCodeReviewPolicyConfig(),
+		[]codereview.PullRequestFile{{Filename: "internal/worker/code_review_handler.go"}},
+		models.CodeReviewAgentResult{
+			ID:            resultID,
+			OrgID:         orgID,
+			SessionID:     sessionID,
+			AgentProvider: "codex",
+			Role:          models.CodeReviewAgentRoleOrchestrator,
+		},
+		state,
+		rawReview,
+		errors.New("orchestrator synthesis is missing required fields"),
+	)
+
+	require.NoError(t, err, "repair request should be persisted and dispatched")
+	require.True(t, handled, "repair request should handle the malformed synthesis")
+	require.True(t, started, "repair request should start one bounded correction turn")
+	require.Len(t, sender.inputs, 1, "repair request should dispatch exactly one correction message")
+	require.Equal(t, threadID, sender.inputs[0].ThreadID, "repair request should continue the existing orchestrator thread")
+	require.Contains(t, sender.inputs[0].Message, `"approval_recommended": false`, "correction message should require the omitted approval field with valid JSON")
+	require.NoError(t, mock.ExpectationsWereMet(), "repair request should preserve the invalid output and increment the durable repair count")
+}
+
+func TestCodeReviewOrchestratorCombinedOutputPreservesFindingsAfterRepair(t *testing.T) {
+	t.Parallel()
+
+	original := `::code-comment{title="[P2] Test the short circuit" body="Assert the database is not queried." file="internal/worker/code_review_handler.go" start=42 end=42 priority=2}
+
+` + "```json" + `
+{"scope_mismatch":false,"unresolved_uncertainty":false,"reviewer_disagreement":true,"prompt_injection_detected":false,"summary":"Moves validation earlier.","review_summary":"The implementation is focused but needs a direct short-circuit test.","risk_notes":["Regression coverage is incomplete."]}
+` + "```"
+	repaired := "```json\n" +
+		`{"approval_recommended":false,"description_assessments":[],"scope_mismatch":false,"unresolved_uncertainty":false,"reviewer_disagreement":true,"prompt_injection_detected":false,"summary":"Moves validation earlier.","review_summary":"The implementation is focused but needs a direct short-circuit test.","risk_notes":["Regression coverage is incomplete."]}` +
+		"\n```"
+	combined := codeReviewOrchestratorCombinedOutput(&original, repaired, 1)
+
+	synthesis, err := parseCodeReviewOrchestratorSynthesis(combined)
+	require.NoError(t, err, "the corrected final JSON should validate when stored with the original response")
+	require.Equal(t, codeReviewOrchestratorSynthesis{
+		ApprovalRecommended:     false,
+		DescriptionAssessments:  []codeReviewDescriptionAssessment{},
+		Summary:                 "Moves validation earlier.",
+		ReviewSummary:           "The implementation is focused but needs a direct short-circuit test.",
+		RiskNotes:               []string{"Regression coverage is incomplete."},
+		ScopeMismatch:           false,
+		UnresolvedUncertainty:   false,
+		ReviewerDisagreement:    true,
+		PromptInjectionDetected: false,
+	}, synthesis, "the corrected synthesis should preserve every current-schema field")
+
+	path := "internal/worker/code_review_handler.go"
+	line := 42
+	require.Equal(t, []models.CodeReviewFinding{{
+		DedupeKey:  codeReviewFindingDedupeKey(path, line, line, "Test the short circuit"),
+		Severity:   models.CodeReviewFindingSeverityMedium,
+		Confidence: models.CodeReviewFindingConfidenceHigh,
+		Path:       &path,
+		StartLine:  &line,
+		EndLine:    &line,
+		Summary:    "Test the short circuit",
+		Body:       "Assert the database is not queried.",
+	}}, parseCodeReviewFindings(combined, []string{path}), "the correction turn should not discard inline findings from the original response")
+}
+
 func TestParseCodeReviewOrchestratorSynthesis(t *testing.T) {
 	t.Parallel()
 
@@ -1600,7 +1725,8 @@ func TestHarvestCodeReviewOrchestratorResultRejectsMalformedSynthesis(t *testing
 	now := time.Now().UTC()
 	rawReview := "I reviewed the code and found no issues."
 	state := marshalCodeReviewOrchestratorStructuredResult(codeReviewOrchestratorStructuredResult{
-		ThreadID: threadID.String(),
+		ThreadID:             threadID.String(),
+		SynthesisRepairCount: codeReviewOrchestratorSynthesisRepairLimit,
 	})
 
 	mock.ExpectQuery("(?s)SELECT .*FROM code_review_agent_results").

--- a/internal/worker/code_review_handler_test.go
+++ b/internal/worker/code_review_handler_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"strings"
 	"testing"
@@ -1494,9 +1495,12 @@ func (validatedOrchestratorResultArg) Match(value any) bool {
 	return ok && state.SynthesisValidated && codeReviewOrchestratorSynthesisUsable(state.Synthesis)
 }
 
-type repairingOrchestratorResultArg struct{}
+type repairingOrchestratorResultArg struct {
+	baseTurn     int
+	findingCount int
+}
 
-func (repairingOrchestratorResultArg) Match(value any) bool {
+func (matcher repairingOrchestratorResultArg) Match(value any) bool {
 	var raw json.RawMessage
 	switch typed := value.(type) {
 	case json.RawMessage:
@@ -1511,7 +1515,10 @@ func (repairingOrchestratorResultArg) Match(value any) bool {
 	state, ok := parseCodeReviewOrchestratorStructuredResult(raw)
 	return ok &&
 		!state.SynthesisValidated &&
-		state.SynthesisRepairCount == 1 &&
+		state.SynthesisRepairCount == 0 &&
+		state.SynthesisRepairPending &&
+		state.SynthesisRepairBaseTurn == matcher.baseTurn &&
+		state.FindingCount == matcher.findingCount &&
 		strings.Contains(state.Error, "missing required fields")
 }
 
@@ -1542,7 +1549,7 @@ func TestRequestCodeReviewOrchestratorSynthesisRepair(t *testing.T) {
 		DescriptionInputHash: "description-hash",
 	}
 	mock.ExpectQuery("UPDATE code_review_agent_results").
-		WithArgs(models.CodeReviewAgentResultStatusRunning, &rawReview, repairingOrchestratorResultArg{}, orgID, resultID).
+		WithArgs(models.CodeReviewAgentResultStatusRunning, &rawReview, repairingOrchestratorResultArg{baseTurn: 1}, orgID, resultID).
 		WillReturnRows(newCodeReviewAgentResultRows().
 			AddRow(resultID, orgID, sessionID, "codex", nil, models.CodeReviewAgentRoleOrchestrator, models.CodeReviewAgentResultStatusRunning, &rawReview, marshalCodeReviewOrchestratorStructuredResult(state), now))
 
@@ -1564,6 +1571,7 @@ func TestRequestCodeReviewOrchestratorSynthesisRepair(t *testing.T) {
 			Role:          models.CodeReviewAgentRoleOrchestrator,
 		},
 		state,
+		1,
 		rawReview,
 		errors.New("orchestrator synthesis is missing required fields"),
 	)
@@ -1574,7 +1582,202 @@ func TestRequestCodeReviewOrchestratorSynthesisRepair(t *testing.T) {
 	require.Len(t, sender.inputs, 1, "repair request should dispatch exactly one correction message")
 	require.Equal(t, threadID, sender.inputs[0].ThreadID, "repair request should continue the existing orchestrator thread")
 	require.Contains(t, sender.inputs[0].Message, `"approval_recommended": false`, "correction message should require the omitted approval field with valid JSON")
-	require.NoError(t, mock.ExpectationsWereMet(), "repair request should preserve the invalid output and increment the durable repair count")
+	require.NoError(t, mock.ExpectationsWereMet(), "repair request should preserve the invalid output as a durable pending repair")
+}
+
+func TestRequestCodeReviewOrchestratorSynthesisRepairRedispatchesPendingRepair(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "pgxmock pool should initialize")
+	defer mock.Close()
+
+	orgID := uuid.New()
+	sessionID := uuid.New()
+	threadID := uuid.New()
+	resultID := uuid.New()
+	now := time.Now().UTC()
+	rawReview := "```json\n{\"summary\":\"The change is focused.\"}\n```"
+	state := codeReviewOrchestratorStructuredResult{
+		ThreadID:                threadID.String(),
+		DescriptionInputHash:    "description-hash",
+		SynthesisRepairPending:  true,
+		SynthesisRepairBaseTurn: 1,
+	}
+	mock.ExpectQuery("UPDATE code_review_agent_results").
+		WithArgs(models.CodeReviewAgentResultStatusRunning, &rawReview, repairingOrchestratorResultArg{baseTurn: 1}, orgID, resultID).
+		WillReturnRows(newCodeReviewAgentResultRows().
+			AddRow(resultID, orgID, sessionID, "codex", nil, models.CodeReviewAgentRoleOrchestrator, models.CodeReviewAgentResultStatusRunning, &rawReview, marshalCodeReviewOrchestratorStructuredResult(state), now))
+
+	sender := &codeReviewOrchestratorRepairSenderStub{}
+	stores := &Stores{CodeReviews: db.NewCodeReviewStore(mock)}
+	handled, started, err := requestCodeReviewOrchestratorSynthesisRepair(
+		context.Background(),
+		stores,
+		sender,
+		zerolog.Nop(),
+		runCodeReviewPayload{OrgID: orgID, SessionID: sessionID},
+		models.DefaultCodeReviewPolicyConfig(),
+		[]codereview.PullRequestFile{{Filename: "internal/worker/code_review_handler.go"}},
+		models.CodeReviewAgentResult{
+			ID:            resultID,
+			OrgID:         orgID,
+			SessionID:     sessionID,
+			AgentProvider: "codex",
+			Role:          models.CodeReviewAgentRoleOrchestrator,
+		},
+		state,
+		1,
+		rawReview,
+		errors.New("orchestrator synthesis is missing required fields"),
+	)
+
+	require.NoError(t, err, "a persisted pending repair should be safe to dispatch after a worker restart")
+	require.True(t, handled, "the persisted pending repair should handle the malformed synthesis")
+	require.True(t, started, "the persisted pending repair should start the correction turn")
+	require.Len(t, sender.inputs, 1, "the retry should dispatch the correction message exactly once in this attempt")
+	require.NoError(t, mock.ExpectationsWereMet(), "the retry should retain the pending repair without consuming the repair count")
+}
+
+func TestRequestCodeReviewOrchestratorSynthesisRepairPersistsOversizedFindingsBeforeArtifactSubstitution(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "pgxmock pool should initialize")
+	defer mock.Close()
+
+	orgID := uuid.New()
+	sessionID := uuid.New()
+	threadID := uuid.New()
+	resultID := uuid.New()
+	findingID := uuid.New()
+	artifactID := uuid.New()
+	now := time.Now().UTC()
+	rawReview := `::code-comment{title="[P2] Preserve this finding" body="The finding must survive synthesis repair." file="internal/worker/code_review_handler.go" start=42 priority=2}
+
+` + strings.Repeat("x", codeReviewRawOutputInlineLimit) + `
+` + "```json\n{\"summary\":\"The change is focused.\"}\n```"
+	artifactKey := fmt.Sprintf("code-review-prompts/%s/orchestrator-output-%s", sessionID, resultID)
+	storedSummary := fmt.Sprintf("Raw output stored in prompt artifact %s (%d bytes).", artifactKey, len(rawReview))
+	state := codeReviewOrchestratorStructuredResult{
+		ThreadID:             threadID.String(),
+		DescriptionInputHash: "description-hash",
+	}
+
+	mock.ExpectQuery("INSERT INTO code_review_findings").
+		WithArgs(
+			pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
+			pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
+			pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
+		).
+		WillReturnRows(newCodeReviewFindingRows().
+			AddRow(findingID, orgID, sessionID, &resultID, "internal/worker/code_review_handler.go:42:42:preserve this finding",
+				models.CodeReviewFindingSeverityMedium, models.CodeReviewFindingConfidenceHigh,
+				stringPtr("internal/worker/code_review_handler.go"), intPtr(42), intPtr(42), "Preserve this finding",
+				"The finding must survive synthesis repair.", false, nil, now))
+	mock.ExpectQuery("INSERT INTO code_review_prompt_artifacts").
+		WithArgs(orgID, sessionID, artifactKey, "orchestrator_output", "codex", rawReview, pgxmock.AnyArg()).
+		WillReturnRows(pgxmock.NewRows([]string{
+			"id", "org_id", "session_id", "artifact_key", "role", "agent_provider", "content", "metadata", "created_at",
+		}).AddRow(artifactID, orgID, sessionID, artifactKey, "orchestrator_output", "codex", rawReview, json.RawMessage(`{}`), now))
+	mock.ExpectQuery("UPDATE code_review_agent_results").
+		WithArgs(models.CodeReviewAgentResultStatusRunning, &storedSummary, repairingOrchestratorResultArg{baseTurn: 1, findingCount: 1}, orgID, resultID).
+		WillReturnRows(newCodeReviewAgentResultRows().
+			AddRow(resultID, orgID, sessionID, "codex", nil, models.CodeReviewAgentRoleOrchestrator, models.CodeReviewAgentResultStatusRunning, &storedSummary, marshalCodeReviewOrchestratorStructuredResult(state), now))
+
+	sender := &codeReviewOrchestratorRepairSenderStub{}
+	stores := &Stores{CodeReviews: db.NewCodeReviewStore(mock)}
+	handled, started, err := requestCodeReviewOrchestratorSynthesisRepair(
+		context.Background(),
+		stores,
+		sender,
+		zerolog.Nop(),
+		runCodeReviewPayload{OrgID: orgID, SessionID: sessionID},
+		models.DefaultCodeReviewPolicyConfig(),
+		[]codereview.PullRequestFile{{Filename: "internal/worker/code_review_handler.go"}},
+		models.CodeReviewAgentResult{
+			ID:            resultID,
+			OrgID:         orgID,
+			SessionID:     sessionID,
+			AgentProvider: "codex",
+			Role:          models.CodeReviewAgentRoleOrchestrator,
+		},
+		state,
+		1,
+		rawReview,
+		errors.New("orchestrator synthesis is missing required fields"),
+	)
+
+	require.NoError(t, err, "oversized malformed output should persist findings before starting repair")
+	require.True(t, handled, "oversized malformed output should be handled by synthesis repair")
+	require.True(t, started, "oversized malformed output should start the correction turn")
+	require.Len(t, sender.inputs, 1, "oversized malformed output should dispatch exactly one correction message")
+	require.NoError(t, mock.ExpectationsWereMet(), "finding persistence should precede replacement of oversized raw output with an artifact summary")
+}
+
+func TestCodeReviewOrchestratorObserveRepairCompletion(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		state       codeReviewOrchestratorStructuredResult
+		currentTurn int
+		expected    codeReviewOrchestratorStructuredResult
+	}{
+		{
+			name:        "leaves non-pending state unchanged",
+			state:       codeReviewOrchestratorStructuredResult{SynthesisRepairCount: 0},
+			currentTurn: 2,
+			expected:    codeReviewOrchestratorStructuredResult{SynthesisRepairCount: 0},
+		},
+		{
+			name: "keeps repair pending until its turn completes",
+			state: codeReviewOrchestratorStructuredResult{
+				SynthesisRepairPending:  true,
+				SynthesisRepairBaseTurn: 2,
+			},
+			currentTurn: 2,
+			expected: codeReviewOrchestratorStructuredResult{
+				SynthesisRepairPending:  true,
+				SynthesisRepairBaseTurn: 2,
+			},
+		},
+		{
+			name: "consumes repair only after its turn completes",
+			state: codeReviewOrchestratorStructuredResult{
+				SynthesisRepairPending:  true,
+				SynthesisRepairBaseTurn: 2,
+			},
+			currentTurn: 3,
+			expected: codeReviewOrchestratorStructuredResult{
+				SynthesisRepairCount:    1,
+				SynthesisRepairBaseTurn: 2,
+			},
+		},
+		{
+			name: "does not exceed repair limit",
+			state: codeReviewOrchestratorStructuredResult{
+				SynthesisRepairCount:    codeReviewOrchestratorSynthesisRepairLimit,
+				SynthesisRepairPending:  true,
+				SynthesisRepairBaseTurn: 2,
+			},
+			currentTurn: 3,
+			expected: codeReviewOrchestratorStructuredResult{
+				SynthesisRepairCount:    codeReviewOrchestratorSynthesisRepairLimit,
+				SynthesisRepairBaseTurn: 2,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			actual := codeReviewOrchestratorObserveRepairCompletion(tt.state, tt.currentTurn)
+
+			require.Equal(t, tt.expected, actual, "repair state should advance only when the correction turn has completed")
+		})
+	}
 }
 
 func TestCodeReviewOrchestratorCombinedOutputPreservesFindingsAfterRepair(t *testing.T) {


### PR DESCRIPTION
## Why

The 143 Code Reviewer relies on the orchestrator's final synthesis as a machine-readable contract: it supplies the approval recommendation, description-policy assessments, reviewer-facing summary, and risk signals used to produce the final GitHub review.

We observed the orchestrator returning an older or incomplete JSON shape—most notably omitting `approval_recommended` and `description_assessments`. The backend correctly rejected that payload, but the review could then finish without a usable structured synthesis or a proper response. The initial repair path also had two reliability gaps: a worker restart could consume the only repair attempt before dispatching it, and responses larger than 32 KiB could lose their inline findings when raw output was replaced by an artifact summary.

This PR makes that boundary self-healing while preserving the existing fail-closed behavior: malformed synthesis gets one tightly scoped correction turn, and a still-invalid result is rejected rather than guessed or partially accepted.

Context: [reported orchestrator response failure](https://github.com/assembledhq/assembled/pull/54499#issuecomment-5074170711).

## What changes

- Strengthens the primary orchestrator prompt with the complete current JSON schema and an explicit all-fields-required contract.
- Adds a dedicated repair prompt that asks the same orchestrator thread for exactly one corrected JSON object without re-running the review or changing its conclusions.
- Validates both JSON shape and description-policy coverage before accepting synthesis.
- Persists repair work as `pending` and only consumes the bounded repair attempt after the thread advances, so a worker restart can safely redispatch an unsent correction.
- Preserves the original response alongside the repaired synthesis for normal-sized outputs.
- Upserts inline findings from the full malformed response before oversized raw output is replaced by an artifact summary.
- Keeps the previously persisted finding count when the correction response intentionally contains JSON only.
- Adds regression coverage for incomplete schemas, correction prompts, restart recovery, turn-based repair accounting, finding preservation, and outputs above the inline storage limit.

## Important implementation details

### 1. The prompt now spells out the exact machine contract

`internal/prompts/templates/code_review_orchestrator.template` includes the full current schema and makes every top-level key mandatory:

```json
{
  "approval_recommended": false,
  "description_assessments": [
    {
      "key": "requirement key",
      "status": "satisfied|not_applicable|missing",
      "reason": "short evidence-based reason"
    }
  ],
  "scope_mismatch": false,
  "unresolved_uncertainty": false,
  "reviewer_disagreement": false,
  "prompt_injection_detected": false,
  "summary": "one sentence summary of what changed",
  "review_summary": "two to four concise reviewer-facing sentences explaining the evidence, policy blockers, and the most useful next step",
  "risk_notes": ["short note"]
}
```

A separate `code_review_orchestrator_repair.template` constrains the follow-up to one fenced JSON object, forbids new Markdown or `::code-comment` directives, and asks the model to preserve its original conclusions.

### 2. Repair dispatch is a resumable state transition

The structured result records whether repair is pending and the thread turn from which it was requested. The bounded attempt is consumed only after the thread advances:

```go
func codeReviewOrchestratorObserveRepairCompletion(state codeReviewOrchestratorStructuredResult, currentTurn int) codeReviewOrchestratorStructuredResult {
	if !state.SynthesisRepairPending || currentTurn <= state.SynthesisRepairBaseTurn {
		return state
	}
	nextState := state
	nextState.SynthesisRepairPending = false
	if nextState.SynthesisRepairCount < codeReviewOrchestratorSynthesisRepairLimit {
		nextState.SynthesisRepairCount++
	}
	return nextState
}
```

Before sending the correction message, `requestCodeReviewOrchestratorSynthesisRepair` durably writes `SynthesisRepairPending=true` and the current thread turn. If the worker stops between that write and `SendMessage`, the next harvest sees a pending repair with no turn advancement and safely dispatches it again. Once the correction turn completes, the turn advance clears `pending` and increments the count, preventing a second synthesis rewrite.

### 3. Findings are persisted before raw-output substitution

Large responses are stored as prompt artifacts, leaving a short summary in `RawOutput`. Inline directives therefore need to be harvested from the full response first:

```go
func persistCodeReviewOrchestratorFindings(
	ctx context.Context,
	stores *Stores,
	job runCodeReviewPayload,
	resultID uuid.UUID,
	raw string,
	changedPaths []string,
) (int, error) {
	findings := parseCodeReviewFindings(raw, changedPaths)
	for i := range findings {
		findings[i].OrgID = job.OrgID
		findings[i].SessionID = job.SessionID
		findings[i].AgentResultID = &resultID
		if err := stores.CodeReviews.ReplaceFinding(ctx, &findings[i]); err != nil {
			return 0, fmt.Errorf("create harvested orchestrator code review finding: %w", err)
		}
	}
	return len(findings), nil
}
```

The repair path invokes this helper before `codeReviewRawOutputForStorage`. That guarantees directives in responses over 32 KiB are durable even though the later correction turn returns JSON only. On successful synthesis, the result keeps the maximum persisted finding count rather than resetting it to zero.

### 4. Validation remains fail closed

The harvester first parses the latest assistant response, then validates description assessments against the applicable policy requirements. Only validated synthesis can complete the orchestrator result. One malformed response triggers the bounded correction turn; a malformed correction marks the result failed and cannot recommend approval.

## Resulting behavior

1. The orchestrator returns Markdown/findings plus the required JSON synthesis.
2. Valid output is persisted and used for the final review as before.
3. Invalid output is preserved, its findings are harvested, and one JSON-only correction turn is requested on the same thread.
4. Worker restarts can resume a pending-but-undispatched correction.
5. A valid correction completes the result without losing original findings; an invalid correction fails closed.

## Validation

- `go test ./internal/worker -count=1`
- `go vet ./internal/worker`
- `go test ./internal/prompts -count=1`
- `git diff --check`

## Reviewer reading path

1. `internal/prompts/templates/code_review_orchestrator.template` — primary structured-output contract.
2. `internal/prompts/templates/code_review_orchestrator_repair.template` — constrained correction turn.
3. `codeReviewOrchestratorObserveRepairCompletion` and `requestCodeReviewOrchestratorSynthesisRepair` in `internal/worker/code_review_handler.go` — durable repair state machine.
4. `harvestCodeReviewOrchestratorResult` in `internal/worker/code_review_handler.go` — validation, repair, and final persistence flow.
5. `internal/worker/code_review_handler_test.go` — restart and oversized-output regression coverage.