### PR TITLE
Format code review outputs with emphasis and status emojis

### DIFF
--- a/internal/models/code_review_output.go
+++ b/internal/models/code_review_output.go
@@ -35,11 +35,11 @@ func BuildCodeReviewFinalReviewBody(input CodeReviewFinalReviewInput) string {
 func buildDefaultCodeReviewFinalReviewBody(input CodeReviewFinalReviewInput) string {
 	paragraphs := make([]string, 0, 9)
 	if input.Decision == CodeReviewDecisionApproved {
-		paragraphs = append(paragraphs, "143 Code Reviewer approved this PR")
+		paragraphs = append(paragraphs, "✅ **143 Code Reviewer approved this PR**")
 	} else if input.Acceptable {
-		paragraphs = append(paragraphs, "143 Code Reviewer completed its review without approving this PR")
+		paragraphs = append(paragraphs, "❌ **143 Code Reviewer completed its review without approving this PR**")
 	} else {
-		paragraphs = append(paragraphs, "143 Code Reviewer did not approve this PR")
+		paragraphs = append(paragraphs, "❌ **143 Code Reviewer did not approve this PR**")
 	}
 
 	generatedSummary := codeReviewGeneratedSummary(input.GeneratedSummary)
@@ -47,12 +47,12 @@ func buildDefaultCodeReviewFinalReviewBody(input CodeReviewFinalReviewInput) str
 	if explanation == "" {
 		explanation = codeReviewDecisionExplanation(input)
 	}
-	paragraphs = append(paragraphs, "Why: "+explanation)
+	paragraphs = append(paragraphs, "**Why:** "+explanation)
 
 	if generatedSummary != "" && !input.Acceptable {
 		if blockers := codeReviewRiskReasonExplanations(input.RiskReasons, input.DescriptionIssues); len(blockers) > 0 {
 			var policyBlockers strings.Builder
-			policyBlockers.WriteString("Policy blockers:\n")
+			policyBlockers.WriteString("**Policy blockers:**\n")
 			for _, blocker := range blockers {
 				policyBlockers.WriteString("- " + blocker + "\n")
 			}
@@ -62,22 +62,22 @@ func buildDefaultCodeReviewFinalReviewBody(input CodeReviewFinalReviewInput) str
 
 	if generatedSummary != "" {
 		if facts := codeReviewFacts(input); len(facts) > 0 {
-			paragraphs = append(paragraphs, "Review facts: "+strings.Join(facts, " · "))
+			paragraphs = append(paragraphs, "**Review facts:** "+strings.Join(facts, " · "))
 		}
 	}
 	if agentSummaries := nonEmptyStrings(input.AgentSummaries); len(agentSummaries) > 0 {
 		for i := range agentSummaries {
 			agentSummaries[i] = strings.TrimRight(agentSummaries[i], ".")
 		}
-		paragraphs = append(paragraphs, "Reviewer evidence: "+strings.Join(agentSummaries, "; ")+".")
+		paragraphs = append(paragraphs, "**Reviewer evidence:** "+strings.Join(agentSummaries, "; ")+".")
 	}
 
 	if len(input.Findings) > 0 {
 		var findings strings.Builder
 		if input.Acceptable {
-			findings.WriteString("Review notes:\n")
+			findings.WriteString("**Review notes:**\n")
 		} else {
-			findings.WriteString("Review findings:\n")
+			findings.WriteString("**Review findings:**\n")
 		}
 		for _, finding := range groupedCodeReviewFindings(input.Findings) {
 			findings.WriteString("- " + finding + "\n")
@@ -85,10 +85,10 @@ func buildDefaultCodeReviewFinalReviewBody(input CodeReviewFinalReviewInput) str
 		paragraphs = append(paragraphs, strings.TrimSpace(findings.String()))
 	}
 	if reviewers := nonEmptyStrings(input.RecommendedHumanReviewers); len(reviewers) > 0 {
-		paragraphs = append(paragraphs, "Suggested human reviewers: "+strings.Join(reviewers, ", "))
+		paragraphs = append(paragraphs, "**Suggested human reviewers:** "+strings.Join(reviewers, ", "))
 	}
 	if !input.Acceptable && generatedSummary == "" {
-		paragraphs = append(paragraphs, "Address the items above and request another review, or ask a human reviewer to decide.")
+		paragraphs = append(paragraphs, "**Next steps:** Address the items above and request another review, or ask a human reviewer to decide.")
 	}
 	if assessment := codeReviewAssessmentSummary(input.HeadSHA, input.AssessedAt); assessment != "" {
 		paragraphs = append(paragraphs, assessment)
@@ -108,7 +108,7 @@ func codeReviewAssessmentSummary(headSHA string, assessedAt time.Time) string {
 	if len(shortSHA) > 7 {
 		shortSHA = shortSHA[:7]
 	}
-	summary := "Latest assessment: `" + shortSHA + "`"
+	summary := "**Latest assessment:** `" + shortSHA + "`"
 	if !assessedAt.IsZero() {
 		summary += " at " + assessedAt.UTC().Format(time.RFC3339)
 	}

--- a/internal/models/code_review_output_test.go
+++ b/internal/models/code_review_output_test.go
@@ -28,10 +28,10 @@ func TestBuildCodeReviewFinalReviewBody(t *testing.T) {
 				AssessedAt: time.Date(2026, time.July, 22, 23, 42, 57, 0, time.UTC),
 				SessionURL: "https://143.dev/sessions/sess_latest",
 			},
-			expected: "143 Code Reviewer did not approve this PR\n\n" +
-				"Why: The available review evidence did not meet the configured approval policy.\n\n" +
-				"Address the items above and request another review, or ask a human reviewer to decide.\n\n" +
-				"Latest assessment: `696c4a2` at 2026-07-22T23:42:57Z\n\n" +
+			expected: "❌ **143 Code Reviewer did not approve this PR**\n\n" +
+				"**Why:** The available review evidence did not meet the configured approval policy.\n\n" +
+				"**Next steps:** Address the items above and request another review, or ask a human reviewer to decide.\n\n" +
+				"**Latest assessment:** `696c4a2` at 2026-07-22T23:42:57Z\n\n" +
 				"[View the full review](https://143.dev/sessions/sess_latest)",
 		},
 		{
@@ -52,15 +52,15 @@ func TestBuildCodeReviewFinalReviewBody(t *testing.T) {
 				},
 				AgentSummaries: []string{"Codex found no blocking issues", "Claude Code timed out"},
 			},
-			expected: `143 Code Reviewer did not approve this PR
+			expected: `❌ **143 Code Reviewer did not approve this PR**
 
-Why: The change is focused, but the description does not explain the testing evidence and only one review agent returned usable output. Add that context and rerun the missing review before asking for approval.
+**Why:** The change is focused, but the description does not explain the testing evidence and only one review agent returned usable output. Add that context and rerun the missing review before asking for approval.
 
-Policy blockers:
+**Policy blockers:**
 - The PR description did not meet the configured requirements: Testing evidence (say how the change was tested); Screenshots or preview link (add a before/after screenshot).
 - Only 1 of 2 required review agents completed a usable review.
 
-Reviewer evidence: Codex found no blocking issues; Claude Code timed out.
+**Reviewer evidence:** Codex found no blocking issues; Claude Code timed out.
 
 [View the full review](https://143.dev/sessions/sess_123)`,
 		},
@@ -80,13 +80,13 @@ Reviewer evidence: Codex found no blocking issues; Claude Code timed out.
 				ReviewerQuorum:         2,
 				RequiredReviewerQuorum: 2,
 			},
-			expected: `143 Code Reviewer approved this PR
+			expected: `✅ **143 Code Reviewer approved this PR**
 
-Why: The settings update is narrowly scoped and both review agents found no blocking issues. The description and test evidence are sufficient for an engineer to verify the change quickly.
+**Why:** The settings update is narrowly scoped and both review agents found no blocking issues. The description and test evidence are sufficient for an engineer to verify the change quickly.
 
-Review facts: 180 changed lines across 4 files · required checks passed · reviewer quorum 2/2
+**Review facts:** 180 changed lines across 4 files · required checks passed · reviewer quorum 2/2
 
-Reviewer evidence: Codex found no blocking issues; Claude Code found no blocking issues.
+**Reviewer evidence:** Codex found no blocking issues; Claude Code found no blocking issues.
 
 [View the full review](https://143.dev/sessions/sess_approved)`,
 		},
@@ -99,9 +99,9 @@ Reviewer evidence: Codex found no blocking issues; Claude Code found no blocking
 				ReviewerQuorum:         1,
 				RequiredReviewerQuorum: 1,
 			},
-			expected: `143 Code Reviewer completed its review without approving this PR
+			expected: `❌ **143 Code Reviewer completed its review without approving this PR**
 
-Why: It met the configured policy: the PR description passed and 1 usable reviewer report met the required quorum of 1. Automated approval is disabled by organization policy.`,
+**Why:** It met the configured policy: the PR description passed and 1 usable reviewer report met the required quorum of 1. Automated approval is disabled by organization policy.`,
 		},
 		{
 			name: "keeps actionable findings and reviewer recommendation",
@@ -117,16 +117,16 @@ Why: It met the configured policy: the PR description passed and 1 usable review
 				}},
 				RecommendedHumanReviewers: []string{"security/platform"},
 			},
-			expected: `143 Code Reviewer did not approve this PR
+			expected: `❌ **143 Code Reviewer did not approve this PR**
 
-Why: Review agents reported blocking findings.
+**Why:** Review agents reported blocking findings.
 
-Review findings:
+**Review findings:**
 - high: src/auth/session.go:88 - Authorization edge case
 
-Suggested human reviewers: security/platform
+**Suggested human reviewers:** security/platform
 
-Address the items above and request another review, or ask a human reviewer to decide.`,
+**Next steps:** Address the items above and request another review, or ask a human reviewer to decide.`,
 		},
 		{
 			name: "makes scope limits easy to compare",
@@ -138,11 +138,11 @@ Address the items above and request another review, or ask a human reviewer to d
 					{Code: CodeReviewRiskReasonFilesLimitExceeded, Actual: 34, Limit: 20},
 				},
 			},
-			expected: `143 Code Reviewer did not approve this PR
+			expected: `❌ **143 Code Reviewer did not approve this PR**
 
-Why: This change has 1842 changed lines; the policy limit is 1000. This change touches 34 files; the policy limit is 20.
+**Why:** This change has 1842 changed lines; the policy limit is 1000. This change touches 34 files; the policy limit is 20.
 
-Address the items above and request another review, or ask a human reviewer to decide.`,
+**Next steps:** Address the items above and request another review, or ask a human reviewer to decide.`,
 		},
 	}
 

--- a/internal/worker/code_review_handler_test.go
+++ b/internal/worker/code_review_handler_test.go
@@ -2824,7 +2824,7 @@ func TestEvaluateLiveCodeReviewOutcome(t *testing.T) {
 				},
 			},
 			expected:     models.CodeReviewDecisionApproved,
-			bodyContains: "Why: The router update is focused, and both review agents found no blocking issues.",
+			bodyContains: "**Why:** The router update is focused, and both review agents found no blocking issues.",
 		},
 		{
 			name: "withholds approval when orchestrator synthesis is malformed",
@@ -2964,7 +2964,7 @@ func TestEvaluateLiveCodeReviewOutcome(t *testing.T) {
 			},
 			expected:     models.CodeReviewDecisionNeedsHumanReview,
 			reason:       "reviewer quorum 1 is below policy requirement 2",
-			bodyContains: "Reviewer evidence: Codex found no blocking issues; Claude Code failed",
+			bodyContains: "**Reviewer evidence:** Codex found no blocking issues; Claude Code failed",
 		},
 		{
 			name: "explains a description requirement the coding agent marked missing",


### PR DESCRIPTION
### Motivation

- Improve readability and scannability of automated code review messages by adding visual emphasis to status and section headings.
- Ensure the human-facing final review body communicates key items (decision, reasons, blockers, facts, evidence, next steps, and assessment) more clearly.

### Description

- Updated `BuildCodeReviewFinalReviewBody` output strings to add emoji status markers and bold section headings (e.g., decision lines, `Why:`, `Policy blockers:`, `Review facts:`, `Reviewer evidence:`, `Review notes/findings:`, `Suggested human reviewers:`, and `Next steps:`).
- Adjusted `codeReviewAssessmentSummary` to bold the `Latest assessment:` label.
- Cleaned up several message templates to include punctuation and consistent emphasis formatting across paragraphs.
- Updated expectations in `internal/models/code_review_output_test.go` to match the new formatted output.

### Testing

- Ran the package unit tests for the updated code, including `TestBuildCodeReviewFinalReviewBody`, and the tests passed after updating the expected strings to the new formatting.
- Ran `go test ./internal/models` to validate changes within the package and observed all tests succeeding.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6449668b548320a4dacaa7fc24d035)