### PR TITLE
Add Grill Me skill to Matt Pocock repository

### DIFF
--- a/.agents/skills/grill-me/SKILL.md
+++ b/.agents/skills/grill-me/SKILL.md
@@ -1,0 +1,7 @@
+---
+name: grill-me
+description: A relentless interview to sharpen a plan or design.
+disable-model-invocation: true
+---
+
+Run a `/grilling` session.

--- a/.agents/skills/grill-me/agents/openai.yaml
+++ b/.agents/skills/grill-me/agents/openai.yaml
@@ -1,0 +1,5 @@
+interface:
+  display_name: "Grill Me"
+  short_description: "Sharpen a plan through interview"
+policy:
+  allow_implicit_invocation: false

--- a/.agents/skills/grilling/SKILL.md
+++ b/.agents/skills/grilling/SKILL.md
@@ -1,0 +1,12 @@
+---
+name: grilling
+description: Grill the user relentlessly about a plan, decision, or idea. Use when the user wants to stress-test their thinking, or uses any 'grill' trigger phrases.
+---
+
+Interview me relentlessly about every aspect of this until we reach a shared understanding. Walk down each branch of the decision tree, resolving dependencies between decisions one-by-one. For each question, provide your recommended answer.
+
+Ask the questions one at a time, waiting for feedback on each question before continuing. Asking multiple questions at once is bewildering.
+
+If a *fact* can be found by exploring the environment (filesystem, tools, etc.), look it up rather than asking me. The *decisions*, though, are mine — put each one to me and wait for my answer.
+
+Do not act on it until I confirm we have reached a shared understanding.

--- a/.agents/skills/grilling/agents/openai.yaml
+++ b/.agents/skills/grilling/agents/openai.yaml
@@ -1,0 +1,3 @@
+interface:
+  display_name: "Grilling"
+  short_description: "Stress-test thinking one question at a time"


### PR DESCRIPTION
## Summary

Users needed a reliable, repo-local way to run a “grill me” interview workflow (triggered via `/grilling`) to stress-test plans and reach a shared understanding. This change adds two local skills—`grill-me` (entrypoint) and `grilling` (the interview behavior)—so the experience is consistent without relying on external/global skill configuration.

## Changes

- Added `.agents/skills/grill-me/SKILL.md` implementing the `/grilling` session entrypoint, with model invocation disabled (defer to the grilling skill behavior).
- Added OpenAI agent metadata for `grill-me` to control how it appears and is invoked (`allow_implicit_invocation: false`).
- Added `.agents/skills/grilling/SKILL.md` defining the “relentless” interview protocol (one question at a time, environment facts via lookup, don’t act until shared understanding).
- Added OpenAI agent metadata for `grilling` to present it as the “Grilling” capability.

## Validation

- N/A (no automated tests/CI changes included; change is limited to new repo-local skill configuration files).

[143.dev](https://143.dev) | [session 92cdbf7a](https://143.dev/sessions/92cdbf7a-7e8c-4064-9e5a-716aa7574fa1)

<!-- 143 readiness -->
**143 readiness:** not available for this revision.

<!-- 143-publication session=92cdbf7a-7e8c-4064-9e5a-716aa7574fa1 changeset=12fb3e05-f835-4d2c-9210-87e5e49a4c31 -->

Preview: https://143.dev/previews/github/assembledhq/143/pull/1932?launch=1