### PR TITLE
Refine Code Review Table Layout, Button Styling, and Evidence Display Design Ideas

### DIFF
--- a/frontend/src/app/(dashboard)/code-reviews/page.test.tsx
+++ b/frontend/src/app/(dashboard)/code-reviews/page.test.tsx
@@ -388,13 +388,22 @@ describe("CodeReviewsPage", () => {
     const reviewRow = within(reviewTable).getByRole("row", {
       name: /#428 Fix invoice rounding/i,
     });
+    expect(within(reviewTable).getAllByRole("columnheader").map((header) => header.textContent)).toEqual([
+      "PR",
+      "Outcome",
+      "Risk",
+      "Run status",
+      "Repo",
+      "Completed",
+      "Actions",
+    ]);
     const reviewCells = within(reviewRow).getAllByRole("cell");
     expect(within(reviewCells[2]).getByText("Acceptable").closest('[data-slot="status-label"]')).not.toBeNull();
-    expect(within(reviewCells[3]).getByText("Approved").closest('[data-slot="status-label"]')).not.toBeNull();
-    expect(within(reviewCells[3]).getByRole("button", { name: "Evidence" })).toBeInTheDocument();
-    expect(within(reviewCells[4]).getByText("Completed").closest('[data-slot="status-label"]')).not.toBeNull();
+    expect(within(reviewCells[1]).getByText("Approved").closest('[data-slot="status-label"]')).not.toBeNull();
+    expect(within(reviewCells[3]).getByText("Completed").closest('[data-slot="status-label"]')).not.toBeNull();
     expect(reviewCells[2].querySelector('[aria-hidden="true"]')).toBeNull();
-    expect(within(reviewCells[6]).queryByRole("button", { name: "Evidence" })).not.toBeInTheDocument();
+    expect(within(reviewCells[6]).getByRole("button", { name: "Evidence" })).toBeInTheDocument();
+    expect(within(reviewCells[6]).getByRole("link", { name: "Session" }).querySelector("svg")).toBeInTheDocument();
     await user.click(screen.getAllByRole("button", { name: /Evidence/i })[0]);
     const evidenceSheet = await screen.findByRole("dialog", {
       name: /Evidence for #428/i,

--- a/frontend/src/app/(dashboard)/code-reviews/page.tsx
+++ b/frontend/src/app/(dashboard)/code-reviews/page.tsx
@@ -11,6 +11,7 @@ import {
   CircleHelp,
   ClipboardCheck,
   FileSearch,
+  MessageSquareText,
   Plus,
   PowerOff,
   RefreshCw,
@@ -249,29 +250,12 @@ function EvidenceButton({
     <Button
       variant={selected ? "secondary" : "ghost"}
       size="sm"
-      className="-ml-2 min-h-8 px-2 text-muted-foreground"
+      className="h-7 px-2 text-muted-foreground hover:text-foreground"
       onClick={onToggleEvidence}
     >
       <FileSearch className="h-4 w-4" />
       Evidence
     </Button>
-  );
-}
-
-function ReviewOutcome({
-  review,
-  selected,
-  onToggleEvidence,
-}: {
-  review: CodeReviewListItem;
-  selected: boolean;
-  onToggleEvidence: () => void;
-}) {
-  return (
-    <div className="space-y-1">
-      <StatusLabel label={decisionLabel(review)} tone={reviewDecisionTone(review)} indicator={false} />
-      <EvidenceButton selected={selected} onToggleEvidence={onToggleEvidence} />
-    </div>
   );
 }
 
@@ -283,17 +267,22 @@ function ReviewActions({
   review,
   canRetry,
   isRetrying,
+  evidenceSelected,
   onRetry,
+  onToggleEvidence,
   className,
 }: {
   review: CodeReviewListItem;
   canRetry: boolean;
   isRetrying: boolean;
+  evidenceSelected: boolean;
   onRetry: () => void;
+  onToggleEvidence: () => void;
   className?: string;
 }) {
   return (
-    <div className={cn("flex w-full gap-1 md:w-auto md:justify-end", className)}>
+    <div className={cn("flex w-full items-center gap-1 md:w-auto md:justify-end", className)}>
+      <EvidenceButton selected={evidenceSelected} onToggleEvidence={onToggleEvidence} />
       {canRetry && reviewCanBeRetried(review) ? (
         <Button
           className="min-h-11 flex-1 justify-center md:min-h-0 md:flex-none"
@@ -306,8 +295,11 @@ function ReviewActions({
           {isRetrying ? "Retrying…" : "Retry review"}
         </Button>
       ) : null}
-      <Button className="min-h-11 flex-1 justify-center md:min-h-0 md:flex-none" variant="ghost" size="sm" asChild>
-        <Link href={`/sessions/${review.session_id}`}>Session</Link>
+      <Button className="h-7 min-h-11 flex-1 justify-center px-2 text-muted-foreground hover:text-foreground md:min-h-0 md:flex-none" variant="ghost" size="sm" asChild>
+        <Link href={`/sessions/${review.session_id}`}>
+          <MessageSquareText className="h-3.5 w-3.5" />
+          Session
+        </Link>
       </Button>
     </div>
   );
@@ -774,9 +766,11 @@ export default function CodeReviewsPage() {
       ),
     },
     {
-      id: "repository",
-      header: "Repo",
-      render: (review) => review.repository_name || review.github_repo,
+      id: "outcome",
+      header: "Outcome",
+      render: (review) => (
+        <StatusLabel label={decisionLabel(review)} tone={reviewDecisionTone(review)} indicator={false} />
+      ),
     },
     {
       id: "risk",
@@ -790,22 +784,14 @@ export default function CodeReviewsPage() {
       ),
     },
     {
-      id: "outcome",
-      header: "Outcome",
-      render: (review) => (
-        <ReviewOutcome
-          review={review}
-          selected={selectedEvidenceSessionId === review.session_id}
-          onToggleEvidence={() => setSelectedEvidenceSessionId((current) => (
-            current === review.session_id ? null : review.session_id
-          ))}
-        />
-      ),
-    },
-    {
       id: "run-status",
       header: "Run status",
       render: (review) => <ReviewOperationalStatus review={review} nowMs={countdownNowMs} />,
+    },
+    {
+      id: "repository",
+      header: "Repo",
+      render: (review) => review.repository_name || review.github_repo,
     },
     {
       id: "completed",
@@ -822,7 +808,11 @@ export default function CodeReviewsPage() {
           review={review}
           canRetry={canRetryReviews}
           isRetrying={retryingReviewSessionIds.has(review.session_id)}
+          evidenceSelected={selectedEvidenceSessionId === review.session_id}
           onRetry={() => retryReview.mutate(review.session_id)}
+          onToggleEvidence={() => setSelectedEvidenceSessionId((current) => (
+            current === review.session_id ? null : review.session_id
+          ))}
         />
       ),
     },
@@ -953,15 +943,15 @@ export default function CodeReviewsPage() {
                     }
                     actions={
                       <div className="flex w-full flex-wrap items-center gap-2">
-                        <EvidenceButton
-                          selected={selectedEvidenceSessionId === review.session_id}
-                          onToggleEvidence={() => setSelectedEvidenceSessionId((current) => (current === review.session_id ? null : review.session_id))}
-                        />
                         <ReviewActions
                           review={review}
                           canRetry={canRetryReviews}
                           isRetrying={retryingReviewSessionIds.has(review.session_id)}
+                          evidenceSelected={selectedEvidenceSessionId === review.session_id}
                           onRetry={() => retryReview.mutate(review.session_id)}
+                          onToggleEvidence={() => setSelectedEvidenceSessionId((current) => (
+                            current === review.session_id ? null : review.session_id
+                          ))}
                           className="ml-auto w-auto"
                         />
                       </div>


### PR DESCRIPTION
## Summary

The Code Reviews table was hard to scan because the Outcome column mixed “status” with evidence/secondary actions, inflating row height and blurring what each cell represents. This change refactors the table layout so Outcome becomes status-only and evidence/session actions move into a dedicated Actions area, matching the existing “Open” behavior in previews.

## Changes

- Reordered code review table columns to: **PR, Outcome, Risk, Run status, Repo, Completed, Actions**.
- Updated the Actions cell to include the Evidence toggle (ghost + icon) and keep the **Session** link visible, aligning with the Previews table’s Open action style.
- Moved evidence UI out of Outcome into Actions, and adjusted the component logic accordingly.
- Strengthened the page test to assert the new column headers order and that **Evidence**/**Session** controls are located in the correct column.

## Validation

- `git diff --check` passes.
- Updated unit/component test expectations in `page.test.tsx` for the new layout and action placement.
- Note: automated frontend test execution wasn’t possible in this environment due to missing frontend dependencies; manual visual preview remained stuck provisioning.

[143.dev](https://143.dev) | [session 25f74590](https://143.dev/sessions/25f74590-03c5-4cd3-94f3-44d6652d88b1)

<!-- 143 readiness -->
**143 readiness:** not available for this revision.

<!-- 143-publication session=25f74590-03c5-4cd3-94f3-44d6652d88b1 changeset=0b816332-c39e-423e-9b54-e7c57dfd00f4 -->

Preview: https://143.dev/previews/github/assembledhq/143/pull/1934?launch=1