### PR TITLE
Implement Design Doc PR 4: Remove PM Autopilot

### DIFF
--- a/docs/design/implemented/120-remove-pm-autopilot.md
+++ b/docs/design/implemented/120-remove-pm-autopilot.md
@@ -10,7 +10,7 @@
 
 Remove the PM Agent and Autopilot product from 143.
 
-All three PRs are implemented. The product, background execution paths, feature
+All four PRs are implemented. The product, background execution paths, feature
 APIs, settings, UI, and obsolete backend machinery are removed. Historical PM
 records remain readable, while shared eval and session context use neutral
 reference-document and execution-context contracts.
@@ -22,7 +22,7 @@ started manually, triggered by integration setup, refreshed periodically, and
 can create sessions, issues, and project proposals through several independent
 paths.
 
-The removal will use three pull requests:
+The removal used four pull requests:
 
 1. **Make PM and Autopilot inert.** Stop every automatic PM job and every
    PM-owned path that can create or dispatch work. Preserve compatibility with
@@ -34,6 +34,9 @@ The removal will use three pull requests:
    shutdown has been deployed and observed. Retain standalone priority scoring,
    preserve eval reference-document pins under neutral names, remove PM Project
    planning, and neutralize shared session-context names.
+4. **Contract rollout compatibility.** Promote the neutral schema projections
+   to base tables, remove legacy dual-write columns and triggers, retire the
+   temporary disabled-job barrier, and remove PM-only Project provenance.
 
 This sequencing creates clear rollout and rollback boundaries:
 
@@ -482,7 +485,7 @@ The table cannot be dropped with PM:
   PagerDuty, evals, Automations, internal issues, and other session starts;
 - `pm_reasoning` is used for prompt and session presentation.
 
-PR 3 will perform a neutral rename:
+PR 3 introduces the neutral contract and PR 4 completes the physical rename:
 
 ```text
 session_pm_context      -> session_execution_context
@@ -785,6 +788,23 @@ views or synchronized columns while legacy tables and columns remain available
 to draining binaries. Destructive contraction is intentionally deferred until
 the whole fleet has run neutral code through a complete deployment.
 
+### PR 4 - Contract Rollout Compatibility
+
+**Purpose:** remove the expand-phase compatibility layer after the fleet has
+completed a deployment on neutral application contracts.
+
+- Promote `session_execution_context`, `reference_documents`, and
+  reference-context pin projections to physical tables by renaming the
+  historical base tables.
+- Remove legacy eval pin columns and their synchronization triggers while
+  preserving neutral pin foreign keys and snapshots.
+- Preserve PM plans, decisions, and Project cycles as renamed archive tables.
+- Remove `pm_plan_id` from session execution context and PM-only Project
+  proposal provenance, including the obsolete source-issue join table.
+- Remove the temporary database trigger that rejected retired PM job types.
+- Preserve historical Sessions, Projects, issues, archive rows, reference
+  documents, and eval reproducibility.
+
 #### Required Verification
 
 - Focused store/service tests for every migrated contract.
@@ -809,7 +829,7 @@ That would make it difficult to establish that automatic work has stopped,
 harder to review unrelated regressions, and expensive to roll back if the
 shutdown affects normal session or Automation workflows.
 
-## Why Three PRs Instead Of Two
+## Why Four PRs Instead Of Two
 
 Two PRs are possible:
 
@@ -821,13 +841,14 @@ data-model and shared-contract changes. Eval document pins, Project planning,
 priority sorting, runtime concurrency, and shared session context each require
 separate judgment.
 
-Three PRs provide the clearest invariants:
+Four PRs provide the clearest invariants:
 
 | PR | Invariant after deploy |
 | --- | --- |
 | 1 | PM and Autopilot cannot create work or consume background agent compute. |
 | 2 | Users and API clients can no longer access the PM/Autopilot product. |
 | 3 | Obsolete backend and schema machinery is removed or renamed safely. |
+| 4 | Rolling compatibility objects are contracted after neutral code is fully deployed. |
 
 ## Acceptance Criteria
 

--- a/internal/db/migrations_test.go
+++ b/internal/db/migrations_test.go
@@ -474,33 +474,74 @@ func TestRemovePMMachineryMigrationPostgresBehavior(t *testing.T) {
 	require.NoError(t, err, "test should isolate migration objects to the test schema")
 
 	_, err = conn.Exec(ctx, `
+		CREATE TABLE organizations (id uuid PRIMARY KEY);
+		CREATE TABLE users (id uuid PRIMARY KEY);
+		CREATE TABLE sessions (id uuid PRIMARY KEY);
+		CREATE TABLE project_tasks (id uuid PRIMARY KEY);
+		CREATE TABLE pm_plans (id uuid PRIMARY KEY);
 		CREATE TABLE session_pm_context (
-			session_id uuid PRIMARY KEY,
-			org_id uuid NOT NULL,
-			pm_plan_id uuid,
+			session_id uuid PRIMARY KEY REFERENCES sessions(id),
+			org_id uuid NOT NULL REFERENCES organizations(id),
+			pm_plan_id uuid REFERENCES pm_plans(id),
 			pm_approach text,
 			pm_reasoning text,
-			project_task_id uuid,
+			project_task_id uuid REFERENCES project_tasks(id),
 			created_at timestamptz NOT NULL DEFAULT now(),
-			updated_at timestamptz NOT NULL DEFAULT now()
+			updated_at timestamptz NOT NULL DEFAULT now(),
+			CONSTRAINT chk_session_pm_context_has_data CHECK (
+				pm_plan_id IS NOT NULL
+				OR pm_approach IS NOT NULL
+				OR pm_reasoning IS NOT NULL
+				OR project_task_id IS NOT NULL
+			)
 		);
+		CREATE UNIQUE INDEX idx_session_pm_context_org_session
+			ON session_pm_context (org_id, session_id);
+		CREATE INDEX idx_session_pm_context_project_task
+			ON session_pm_context (org_id, project_task_id)
+			WHERE project_task_id IS NOT NULL;
 		CREATE TABLE pm_documents (
 			id uuid PRIMARY KEY,
-			org_id uuid NOT NULL,
-			title text NOT NULL
+			org_id uuid NOT NULL REFERENCES organizations(id),
+			title text NOT NULL,
+			doc_type text NOT NULL DEFAULT 'context',
+			source_type text NOT NULL DEFAULT 'manual',
+			source_id text,
+			active boolean NOT NULL DEFAULT true,
+			logical_id uuid NOT NULL DEFAULT gen_random_uuid(),
+			created_by uuid REFERENCES users(id),
+			CONSTRAINT chk_pm_documents_doc_type CHECK (doc_type IN ('roadmap', 'context')),
+			CONSTRAINT chk_pm_documents_source_type CHECK (source_type IN ('manual', 'url'))
 		);
+		CREATE INDEX idx_pm_documents_org ON pm_documents(org_id);
+		CREATE INDEX idx_pm_documents_source
+			ON pm_documents(org_id, source_type, source_id)
+			WHERE source_id IS NOT NULL;
+		CREATE UNIQUE INDEX idx_pm_documents_active_logical
+			ON pm_documents(org_id, logical_id)
+			WHERE active = true;
 		CREATE TABLE pm_document_set_pins (
 			id uuid PRIMARY KEY,
-			org_id uuid NOT NULL
+			org_id uuid NOT NULL REFERENCES organizations(id)
 		);
+		CREATE INDEX idx_pm_document_set_pins_org ON pm_document_set_pins(org_id);
 		CREATE TABLE pm_document_set_pin_members (
 			pin_id uuid NOT NULL REFERENCES pm_document_set_pins(id),
 			document_id uuid NOT NULL REFERENCES pm_documents(id),
 			PRIMARY KEY (pin_id, document_id)
 		);
-		CREATE TABLE pm_plans (id uuid PRIMARY KEY);
-		CREATE TABLE pm_decision_log (id uuid PRIMARY KEY);
-		CREATE TABLE project_cycles (id uuid PRIMARY KEY);
+		CREATE TABLE pm_decision_log (
+			id uuid PRIMARY KEY,
+			plan_id uuid NOT NULL REFERENCES pm_plans(id)
+		);
+		CREATE TABLE project_cycles (
+			id uuid PRIMARY KEY,
+			pm_plan_id uuid REFERENCES pm_plans(id)
+		);
+		CREATE TABLE jobs (
+			id uuid PRIMARY KEY,
+			job_type text NOT NULL
+		);
 		CREATE TABLE eval_tasks (
 			id uuid PRIMARY KEY,
 			pm_document_set_pin_id uuid REFERENCES pm_document_set_pins(id)
@@ -516,6 +557,40 @@ func TestRemovePMMachineryMigrationPostgresBehavior(t *testing.T) {
 				source IN ('sentry', 'linear', 'pagerduty', 'manual', 'pm_agent')
 			)
 		);
+		CREATE TABLE projects (
+			id uuid PRIMARY KEY,
+			proposed_by_pm boolean NOT NULL DEFAULT false,
+			source_issue_ids uuid[],
+			proposal_reasoning text
+		);
+		CREATE TABLE project_source_issues (
+			project_id uuid NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+			issue_id uuid NOT NULL REFERENCES issues(id) ON DELETE CASCADE,
+			PRIMARY KEY (project_id, issue_id)
+		);
+		CREATE FUNCTION reject_legacy_array_write()
+		RETURNS trigger LANGUAGE plpgsql AS $$
+		BEGIN
+			RAISE EXCEPTION 'legacy array is frozen';
+		END
+		$$;
+		CREATE TRIGGER trg_freeze_source_issue_ids
+		BEFORE UPDATE OF source_issue_ids ON projects
+		FOR EACH ROW
+		WHEN (OLD.source_issue_ids IS DISTINCT FROM NEW.source_issue_ids)
+		EXECUTE FUNCTION reject_legacy_array_write();
+		CREATE FUNCTION reject_disabled_pm_jobs()
+		RETURNS trigger LANGUAGE plpgsql AS $$
+		BEGIN
+			IF NEW.job_type = 'pm_analyze' THEN
+				RAISE EXCEPTION 'disabled';
+			END IF;
+			RETURN NEW;
+		END
+		$$;
+		CREATE TRIGGER trg_reject_disabled_pm_jobs
+		BEFORE INSERT OR UPDATE OF job_type ON jobs
+		FOR EACH ROW EXECUTE FUNCTION reject_disabled_pm_jobs();
 	`)
 	require.NoError(t, err, "test should create the pre-migration compatibility schema")
 
@@ -526,11 +601,24 @@ func TestRemovePMMachineryMigrationPostgresBehavior(t *testing.T) {
 
 	orgID := uuid.New()
 	sessionID := uuid.New()
+	planOnlySessionID := uuid.New()
+	planArchiveID := uuid.New()
+	_, err = conn.Exec(ctx, `INSERT INTO organizations (id) VALUES ($1)`, orgID)
+	require.NoError(t, err, "test should seed the organization referenced by retained rows")
+	_, err = conn.Exec(ctx, `INSERT INTO sessions (id) VALUES ($1), ($2)`, sessionID, planOnlySessionID)
+	require.NoError(t, err, "test should seed sessions referenced by execution context")
+	_, err = conn.Exec(ctx, `INSERT INTO pm_plans (id) VALUES ($1)`, planArchiveID)
+	require.NoError(t, err, "test should seed a historical PM plan")
 	_, err = conn.Exec(ctx, `
 		INSERT INTO session_execution_context (session_id, org_id, execution_brief)
 		VALUES ($1, $2, 'neutral brief')
 	`, sessionID, orgID)
 	require.NoError(t, err, "new code should write through the neutral session view")
+	_, err = conn.Exec(ctx, `
+		INSERT INTO session_pm_context (session_id, org_id, pm_plan_id)
+		VALUES ($1, $2, $3)
+	`, planOnlySessionID, orgID, planArchiveID)
+	require.NoError(t, err, "test should seed historical context containing only the retired plan link")
 	var legacyBrief string
 	err = conn.QueryRow(ctx, `SELECT pm_approach FROM session_pm_context WHERE session_id = $1`, sessionID).Scan(&legacyBrief)
 	require.NoError(t, err, "old code should read the row written through the neutral view")
@@ -582,6 +670,159 @@ func TestRemovePMMachineryMigrationPostgresBehavior(t *testing.T) {
 	require.NoError(t, err, "test should read synchronized eval-run pin columns")
 	require.Equal(t, pinID, legacyPinID, "neutral eval-run writes should synchronize the legacy pin column")
 	require.Equal(t, pinID, neutralPinID, "neutral eval-run writes should preserve the neutral pin column")
+
+	decisionArchiveID := uuid.New()
+	cycleArchiveID := uuid.New()
+	_, err = conn.Exec(ctx, `
+		INSERT INTO pm_decision_log (id, plan_id) VALUES ($1, $2)
+	`, decisionArchiveID, planArchiveID)
+	require.NoError(t, err, "test should seed a historical PM decision")
+	_, err = conn.Exec(ctx, `
+		INSERT INTO project_cycles (id, pm_plan_id) VALUES ($1, $2)
+	`, cycleArchiveID, planArchiveID)
+	require.NoError(t, err, "test should seed a historical Project cycle")
+
+	contractionUpSQL, err := os.ReadFile("../../migrations/000261_contract_pm_compatibility.up.sql")
+	require.NoError(t, err, "test should read the PM compatibility contraction up migration")
+	_, err = conn.Exec(ctx, string(contractionUpSQL))
+	require.NoError(t, err, "contraction up migration should promote neutral objects")
+
+	var physicalNeutralTables int
+	err = conn.QueryRow(ctx, `
+		SELECT count(*)
+		FROM pg_class c
+		JOIN pg_namespace n ON n.oid = c.relnamespace
+		WHERE n.nspname = current_schema()
+		  AND c.relkind = 'r'
+		  AND c.relname IN (
+		      'session_execution_context',
+		      'reference_documents',
+		      'reference_context_set_pins',
+		      'reference_context_set_pin_members'
+		  )
+	`).Scan(&physicalNeutralTables)
+	require.NoError(t, err, "test should inspect neutral relation kinds")
+	require.Equal(t, 4, physicalNeutralTables, "contraction should promote every neutral projection to a physical table")
+
+	var archivedRows int
+	err = conn.QueryRow(ctx, `
+		SELECT
+		    (SELECT count(*) FROM pm_plan_archive WHERE id = $1)
+		  + (SELECT count(*) FROM pm_decision_archive WHERE id = $2)
+		  + (SELECT count(*) FROM project_cycle_archive WHERE id = $3)
+	`, planArchiveID, decisionArchiveID, cycleArchiveID).Scan(&archivedRows)
+	require.NoError(t, err, "test should read renamed planning archives")
+	require.Equal(t, 3, archivedRows, "contraction should preserve every historical planning archive row")
+
+	_, err = conn.Exec(ctx, `
+		INSERT INTO pm_decision_archive (id, plan_id) VALUES ($1, $2)
+	`, uuid.New(), uuid.New())
+	require.Error(t, err, "archived PM decisions should retain their plan foreign key")
+	_, err = conn.Exec(ctx, `
+		INSERT INTO project_cycle_archive (id, pm_plan_id) VALUES ($1, $2)
+	`, uuid.New(), uuid.New())
+	require.Error(t, err, "archived Project cycles should retain their plan foreign key")
+
+	var contractedBrief string
+	err = conn.QueryRow(ctx, `
+		SELECT execution_brief
+		FROM session_execution_context
+		WHERE session_id = $1
+	`, sessionID).Scan(&contractedBrief)
+	require.NoError(t, err, "contracted session table should retain execution context")
+	require.Equal(t, "neutral brief", contractedBrief, "contraction should preserve session context data")
+
+	var planOnlyContextCount int
+	err = conn.QueryRow(ctx, `
+		SELECT count(*) FROM session_execution_context WHERE session_id = $1
+	`, planOnlySessionID).Scan(&planOnlyContextCount)
+	require.NoError(t, err, "test should inspect plan-only execution context after contraction")
+	require.Equal(t, 0, planOnlyContextCount, "plan-only context should be removed when its retired link is dropped")
+
+	_, err = conn.Exec(ctx, `
+		INSERT INTO session_execution_context (session_id, org_id)
+		VALUES ($1, $2)
+	`, planOnlySessionID, orgID)
+	require.Error(t, err, "contracted execution context should reject rows without neutral context")
+
+	var retainedDocumentID uuid.UUID
+	err = conn.QueryRow(ctx, `
+		SELECT reference_document_id
+		FROM reference_context_set_pin_members
+		WHERE pin_id = $1
+	`, pinID).Scan(&retainedDocumentID)
+	require.NoError(t, err, "contracted reference tables should retain pin membership")
+	require.Equal(t, documentID, retainedDocumentID, "contraction should preserve pinned reference documents")
+
+	var legacyColumnCount int
+	err = conn.QueryRow(ctx, `
+		SELECT count(*)
+		FROM information_schema.columns
+		WHERE table_schema = current_schema()
+		  AND table_name IN ('eval_tasks', 'eval_runs')
+		  AND column_name = 'pm_document_set_pin_id'
+	`).Scan(&legacyColumnCount)
+	require.NoError(t, err, "test should inspect contracted eval columns")
+	require.Equal(t, 0, legacyColumnCount, "contraction should remove both legacy eval pin columns")
+
+	_, err = conn.Exec(ctx, `
+		INSERT INTO eval_tasks (id, reference_context_set_pin_id) VALUES ($1, $2)
+	`, uuid.New(), uuid.New())
+	require.Error(t, err, "eval tasks should retain their neutral reference-context pin foreign key")
+	_, err = conn.Exec(ctx, `
+		INSERT INTO eval_runs (id, reference_context_set_pin_id) VALUES ($1, $2)
+	`, uuid.New(), uuid.New())
+	require.Error(t, err, "eval runs should retain their neutral reference-context pin foreign key")
+
+	var pmNamedNeutralObjects int
+	err = conn.QueryRow(ctx, `
+		SELECT count(*)
+		FROM (
+			SELECT indexname AS object_name
+			FROM pg_indexes
+			WHERE schemaname = current_schema()
+			  AND tablename IN (
+			      'session_execution_context',
+			      'reference_documents',
+			      'reference_context_set_pins',
+			      'reference_context_set_pin_members'
+			  )
+			UNION ALL
+			SELECT conname AS object_name
+			FROM pg_constraint c
+			JOIN pg_class r ON r.oid = c.conrelid
+			JOIN pg_namespace n ON n.oid = r.relnamespace
+			WHERE n.nspname = current_schema()
+			  AND r.relname IN (
+			      'session_execution_context',
+			      'reference_documents',
+			      'reference_context_set_pins',
+			      'reference_context_set_pin_members'
+			  )
+		) objects
+		WHERE object_name LIKE '%pm%'
+	`).Scan(&pmNamedNeutralObjects)
+	require.NoError(t, err, "test should inspect neutral table object names")
+	require.Equal(t, 0, pmNamedNeutralObjects, "neutral tables should not retain PM-named indexes or constraints")
+
+	_, err = conn.Exec(ctx, `INSERT INTO jobs (id, job_type) VALUES ($1, 'pm_analyze')`, uuid.New())
+	require.NoError(t, err, "retired job barrier should no longer own queue validation")
+
+	contractionDownSQL, err := os.ReadFile("../../migrations/000261_contract_pm_compatibility.down.sql")
+	require.NoError(t, err, "test should read the PM compatibility contraction down migration")
+	_, err = conn.Exec(ctx, string(contractionDownSQL))
+	require.NoError(t, err, "contraction down migration should restore expand-phase compatibility")
+
+	var restoredLegacyColumns int
+	err = conn.QueryRow(ctx, `
+		SELECT count(*)
+		FROM information_schema.columns
+		WHERE table_schema = current_schema()
+		  AND table_name IN ('eval_tasks', 'eval_runs')
+		  AND column_name = 'pm_document_set_pin_id'
+	`).Scan(&restoredLegacyColumns)
+	require.NoError(t, err, "test should inspect restored eval compatibility columns")
+	require.Equal(t, 2, restoredLegacyColumns, "down migration should restore both legacy eval pin columns")
 
 	downSQL, err := os.ReadFile("../../migrations/000260_remove_pm_machinery.down.sql")
 	require.NoError(t, err, "test should read the PM machinery down migration")

--- a/migrations/000261_contract_pm_compatibility.down.sql
+++ b/migrations/000261_contract_pm_compatibility.down.sql
@@ -1,0 +1,170 @@
+-- Restore the expand-phase compatibility schema. Dropped PM provenance values
+-- cannot be reconstructed; restored columns are intentionally empty/defaulted.
+
+ALTER TABLE projects
+    ADD COLUMN proposed_by_pm boolean NOT NULL DEFAULT false,
+    ADD COLUMN source_issue_ids uuid[],
+    ADD COLUMN proposal_reasoning text;
+
+CREATE TABLE project_source_issues (
+    project_id uuid NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+    issue_id uuid NOT NULL REFERENCES issues(id) ON DELETE CASCADE,
+    PRIMARY KEY (project_id, issue_id)
+);
+CREATE INDEX idx_project_source_issues_issue ON project_source_issues (issue_id);
+
+CREATE TRIGGER trg_freeze_source_issue_ids
+BEFORE UPDATE OF source_issue_ids ON projects
+FOR EACH ROW
+WHEN (OLD.source_issue_ids IS DISTINCT FROM NEW.source_issue_ids)
+EXECUTE FUNCTION reject_legacy_array_write();
+
+ALTER TABLE project_cycle_archive RENAME TO project_cycles;
+ALTER TABLE pm_decision_archive RENAME TO pm_decision_log;
+ALTER TABLE pm_plan_archive RENAME TO pm_plans;
+
+ALTER TABLE reference_context_set_pin_members
+    RENAME COLUMN reference_document_id TO document_id;
+ALTER TABLE reference_context_set_pin_members
+    RENAME CONSTRAINT reference_context_set_pin_members_reference_document_id_fkey TO pm_document_set_pin_members_document_id_fkey;
+ALTER TABLE reference_context_set_pin_members
+    RENAME CONSTRAINT reference_context_set_pin_members_pin_id_fkey TO pm_document_set_pin_members_pin_id_fkey;
+ALTER TABLE reference_context_set_pin_members
+    RENAME CONSTRAINT reference_context_set_pin_members_pkey TO pm_document_set_pin_members_pkey;
+ALTER TABLE reference_context_set_pins
+    RENAME CONSTRAINT reference_context_set_pins_org_id_fkey TO pm_document_set_pins_org_id_fkey;
+ALTER INDEX idx_reference_context_set_pins_org RENAME TO idx_pm_document_set_pins_org;
+ALTER TABLE reference_context_set_pins
+    RENAME CONSTRAINT reference_context_set_pins_pkey TO pm_document_set_pins_pkey;
+ALTER TABLE reference_documents
+    RENAME CONSTRAINT chk_reference_documents_source_type TO chk_pm_documents_source_type;
+ALTER TABLE reference_documents
+    RENAME CONSTRAINT chk_reference_documents_doc_type TO chk_pm_documents_doc_type;
+ALTER TABLE reference_documents
+    RENAME CONSTRAINT reference_documents_created_by_fkey TO pm_documents_created_by_fkey;
+ALTER TABLE reference_documents
+    RENAME CONSTRAINT reference_documents_org_id_fkey TO pm_documents_org_id_fkey;
+ALTER INDEX idx_reference_documents_active_logical RENAME TO idx_pm_documents_active_logical;
+ALTER INDEX idx_reference_documents_source RENAME TO idx_pm_documents_source;
+ALTER INDEX idx_reference_documents_org RENAME TO idx_pm_documents_org;
+ALTER TABLE reference_documents
+    RENAME CONSTRAINT reference_documents_pkey TO pm_documents_pkey;
+ALTER TABLE reference_context_set_pin_members RENAME TO pm_document_set_pin_members;
+ALTER TABLE reference_context_set_pins RENAME TO pm_document_set_pins;
+ALTER TABLE reference_documents RENAME TO pm_documents;
+
+ALTER TABLE session_execution_context ADD COLUMN pm_plan_id uuid REFERENCES pm_plans(id);
+ALTER TABLE session_execution_context
+    DROP CONSTRAINT chk_session_execution_context_has_data;
+ALTER TABLE session_execution_context RENAME COLUMN planning_reasoning TO pm_reasoning;
+ALTER TABLE session_execution_context RENAME COLUMN execution_brief TO pm_approach;
+ALTER TABLE session_execution_context RENAME TO session_pm_context;
+ALTER TABLE session_pm_context
+    ADD CONSTRAINT chk_session_pm_context_has_data CHECK (
+        pm_plan_id IS NOT NULL
+        OR pm_approach IS NOT NULL
+        OR pm_reasoning IS NOT NULL
+        OR project_task_id IS NOT NULL
+    );
+ALTER INDEX idx_session_execution_context_org_session
+    RENAME TO idx_session_pm_context_org_session;
+ALTER INDEX idx_session_execution_context_project_task
+    RENAME TO idx_session_pm_context_project_task;
+ALTER TABLE session_pm_context
+    RENAME CONSTRAINT session_execution_context_project_task_id_fkey TO session_pm_context_project_task_id_fkey;
+ALTER TABLE session_pm_context
+    RENAME CONSTRAINT session_execution_context_org_id_fkey TO session_pm_context_org_id_fkey;
+ALTER TABLE session_pm_context
+    RENAME CONSTRAINT session_execution_context_session_id_fkey TO session_pm_context_session_id_fkey;
+ALTER TABLE session_pm_context
+    RENAME CONSTRAINT session_execution_context_pkey TO session_pm_context_pkey;
+ALTER TABLE session_pm_context
+    RENAME CONSTRAINT session_execution_context_pm_plan_id_fkey TO session_pm_context_pm_plan_id_fkey;
+
+CREATE VIEW session_execution_context AS
+SELECT
+    session_id,
+    org_id,
+    pm_approach AS execution_brief,
+    pm_reasoning AS planning_reasoning,
+    project_task_id,
+    created_at,
+    updated_at
+FROM session_pm_context;
+
+CREATE VIEW reference_documents AS SELECT * FROM pm_documents;
+CREATE VIEW reference_context_set_pins AS SELECT * FROM pm_document_set_pins;
+CREATE VIEW reference_context_set_pin_members AS
+SELECT pin_id, document_id AS reference_document_id
+FROM pm_document_set_pin_members;
+CREATE VIEW pm_plan_archive AS SELECT * FROM pm_plans;
+CREATE VIEW pm_decision_archive AS SELECT * FROM pm_decision_log;
+CREATE VIEW project_cycle_archive AS SELECT * FROM project_cycles;
+
+ALTER TABLE eval_tasks
+    ADD COLUMN pm_document_set_pin_id uuid REFERENCES pm_document_set_pins(id);
+ALTER TABLE eval_runs
+    ADD COLUMN pm_document_set_pin_id uuid REFERENCES pm_document_set_pins(id);
+UPDATE eval_tasks SET pm_document_set_pin_id = reference_context_set_pin_id;
+UPDATE eval_runs SET pm_document_set_pin_id = reference_context_set_pin_id;
+
+CREATE FUNCTION sync_reference_context_set_pin_columns()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    IF TG_OP = 'INSERT' THEN
+        IF NEW.reference_context_set_pin_id IS NOT NULL
+           AND NEW.pm_document_set_pin_id IS NOT NULL
+           AND NEW.reference_context_set_pin_id IS DISTINCT FROM NEW.pm_document_set_pin_id THEN
+            RAISE EXCEPTION 'conflicting reference-context pin IDs';
+        END IF;
+        NEW.reference_context_set_pin_id :=
+            COALESCE(NEW.reference_context_set_pin_id, NEW.pm_document_set_pin_id);
+        NEW.pm_document_set_pin_id :=
+            COALESCE(NEW.pm_document_set_pin_id, NEW.reference_context_set_pin_id);
+        RETURN NEW;
+    END IF;
+
+    IF NEW.reference_context_set_pin_id IS DISTINCT FROM OLD.reference_context_set_pin_id
+       AND NEW.pm_document_set_pin_id IS NOT DISTINCT FROM OLD.pm_document_set_pin_id THEN
+        NEW.pm_document_set_pin_id := NEW.reference_context_set_pin_id;
+    ELSIF NEW.pm_document_set_pin_id IS DISTINCT FROM OLD.pm_document_set_pin_id
+       AND NEW.reference_context_set_pin_id IS NOT DISTINCT FROM OLD.reference_context_set_pin_id THEN
+        NEW.reference_context_set_pin_id := NEW.pm_document_set_pin_id;
+    ELSIF NEW.reference_context_set_pin_id IS DISTINCT FROM NEW.pm_document_set_pin_id THEN
+        RAISE EXCEPTION 'conflicting reference-context pin IDs';
+    END IF;
+    RETURN NEW;
+END;
+$$;
+
+CREATE TRIGGER trg_eval_tasks_sync_reference_context_set_pin
+BEFORE INSERT OR UPDATE OF pm_document_set_pin_id, reference_context_set_pin_id
+ON eval_tasks
+FOR EACH ROW
+EXECUTE FUNCTION sync_reference_context_set_pin_columns();
+
+CREATE TRIGGER trg_eval_runs_sync_reference_context_set_pin
+BEFORE INSERT OR UPDATE OF pm_document_set_pin_id, reference_context_set_pin_id
+ON eval_runs
+FOR EACH ROW
+EXECUTE FUNCTION sync_reference_context_set_pin_columns();
+
+CREATE FUNCTION reject_disabled_pm_jobs()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    IF NEW.job_type IN ('pm_analyze', 'pm_bootstrap', 'pm_context_refresh', 'project_cycle') THEN
+        RAISE EXCEPTION 'job type % is disabled by the PM shutdown', NEW.job_type
+            USING ERRCODE = 'check_violation';
+    END IF;
+    RETURN NEW;
+END
+$$;
+
+CREATE TRIGGER trg_reject_disabled_pm_jobs
+BEFORE INSERT OR UPDATE OF job_type ON jobs
+FOR EACH ROW
+EXECUTE FUNCTION reject_disabled_pm_jobs();

--- a/migrations/000261_contract_pm_compatibility.up.sql
+++ b/migrations/000261_contract_pm_compatibility.up.sql
@@ -1,0 +1,95 @@
+-- Contract the rolling-compatibility layer introduced by migration 000260.
+-- Every application query now uses the neutral execution/reference-context
+-- names, so the legacy objects and dual-write machinery can be removed.
+
+DROP TRIGGER trg_reject_disabled_pm_jobs ON jobs;
+DROP FUNCTION reject_disabled_pm_jobs();
+
+DROP TRIGGER trg_eval_runs_sync_reference_context_set_pin ON eval_runs;
+DROP TRIGGER trg_eval_tasks_sync_reference_context_set_pin ON eval_tasks;
+DROP FUNCTION sync_reference_context_set_pin_columns();
+
+ALTER TABLE eval_runs DROP COLUMN pm_document_set_pin_id;
+ALTER TABLE eval_tasks DROP COLUMN pm_document_set_pin_id;
+
+DROP VIEW project_cycle_archive;
+DROP VIEW pm_decision_archive;
+DROP VIEW pm_plan_archive;
+DROP VIEW reference_context_set_pin_members;
+DROP VIEW reference_context_set_pins;
+DROP VIEW reference_documents;
+DROP VIEW session_execution_context;
+
+ALTER TABLE session_pm_context RENAME TO session_execution_context;
+ALTER TABLE session_execution_context RENAME COLUMN pm_approach TO execution_brief;
+ALTER TABLE session_execution_context RENAME COLUMN pm_reasoning TO planning_reasoning;
+ALTER TABLE session_execution_context
+    DROP CONSTRAINT chk_session_pm_context_has_data;
+ALTER TABLE session_execution_context DROP COLUMN pm_plan_id;
+DELETE FROM session_execution_context
+WHERE execution_brief IS NULL
+  AND planning_reasoning IS NULL
+  AND project_task_id IS NULL;
+ALTER TABLE session_execution_context
+    ADD CONSTRAINT chk_session_execution_context_has_data CHECK (
+        execution_brief IS NOT NULL
+        OR planning_reasoning IS NOT NULL
+        OR project_task_id IS NOT NULL
+    );
+ALTER INDEX idx_session_pm_context_org_session
+    RENAME TO idx_session_execution_context_org_session;
+ALTER INDEX idx_session_pm_context_project_task
+    RENAME TO idx_session_execution_context_project_task;
+ALTER TABLE session_execution_context
+    RENAME CONSTRAINT session_pm_context_pkey TO session_execution_context_pkey;
+ALTER TABLE session_execution_context
+    RENAME CONSTRAINT session_pm_context_session_id_fkey TO session_execution_context_session_id_fkey;
+ALTER TABLE session_execution_context
+    RENAME CONSTRAINT session_pm_context_org_id_fkey TO session_execution_context_org_id_fkey;
+ALTER TABLE session_execution_context
+    RENAME CONSTRAINT session_pm_context_project_task_id_fkey TO session_execution_context_project_task_id_fkey;
+
+ALTER TABLE pm_documents RENAME TO reference_documents;
+ALTER TABLE pm_document_set_pins RENAME TO reference_context_set_pins;
+ALTER TABLE pm_document_set_pin_members RENAME TO reference_context_set_pin_members;
+ALTER TABLE reference_context_set_pin_members
+    RENAME COLUMN document_id TO reference_document_id;
+ALTER TABLE reference_documents
+    RENAME CONSTRAINT pm_documents_pkey TO reference_documents_pkey;
+ALTER INDEX idx_pm_documents_org RENAME TO idx_reference_documents_org;
+ALTER INDEX idx_pm_documents_source RENAME TO idx_reference_documents_source;
+ALTER INDEX idx_pm_documents_active_logical RENAME TO idx_reference_documents_active_logical;
+ALTER TABLE reference_documents
+    RENAME CONSTRAINT pm_documents_org_id_fkey TO reference_documents_org_id_fkey;
+ALTER TABLE reference_documents
+    RENAME CONSTRAINT pm_documents_created_by_fkey TO reference_documents_created_by_fkey;
+ALTER TABLE reference_documents
+    RENAME CONSTRAINT chk_pm_documents_doc_type TO chk_reference_documents_doc_type;
+ALTER TABLE reference_documents
+    RENAME CONSTRAINT chk_pm_documents_source_type TO chk_reference_documents_source_type;
+ALTER TABLE reference_context_set_pins
+    RENAME CONSTRAINT pm_document_set_pins_pkey TO reference_context_set_pins_pkey;
+ALTER INDEX idx_pm_document_set_pins_org RENAME TO idx_reference_context_set_pins_org;
+ALTER TABLE reference_context_set_pins
+    RENAME CONSTRAINT pm_document_set_pins_org_id_fkey TO reference_context_set_pins_org_id_fkey;
+ALTER TABLE reference_context_set_pin_members
+    RENAME CONSTRAINT pm_document_set_pin_members_pkey TO reference_context_set_pin_members_pkey;
+ALTER TABLE reference_context_set_pin_members
+    RENAME CONSTRAINT pm_document_set_pin_members_pin_id_fkey TO reference_context_set_pin_members_pin_id_fkey;
+ALTER TABLE reference_context_set_pin_members
+    RENAME CONSTRAINT pm_document_set_pin_members_document_id_fkey TO reference_context_set_pin_members_reference_document_id_fkey;
+
+-- Preserve obsolete planning data as archives. Renaming the tables keeps rows,
+-- foreign keys, and audit history intact without exposing live PM contracts.
+ALTER TABLE pm_plans RENAME TO pm_plan_archive;
+ALTER TABLE pm_decision_log RENAME TO pm_decision_archive;
+ALTER TABLE project_cycles RENAME TO project_cycle_archive;
+
+-- PM proposal provenance is no longer part of user-authored Projects. The
+-- archived Project rows themselves remain intact.
+DROP TRIGGER trg_freeze_source_issue_ids ON projects;
+DROP TABLE project_source_issues;
+ALTER TABLE projects
+    DROP COLUMN proposed_by_pm,
+    DROP COLUMN source_issue_ids,
+    DROP COLUMN proposal_reasoning;


### PR DESCRIPTION
## Summary

The PM Autopilot removal required a safe rollout from temporary “neutral contract” projections to stable physical database tables. This change promotes the neutral schema projections to base tables, removes legacy dual-write/trigger machinery, and tightens migration-level validation so archived PM references and eval/session pins correctly reject nonexistent plan/context IDs.

## Changes

- Updated the design docs to reflect the full rollout plan: PR 4 adds contract rollout compatibility (physical rename, remove expand-phase layer).
- Added/adjusted `migrations/000261_contract_pm_compatibility` up/down SQL to promote neutral contract tables and remove PM-only/legacy columns, triggers, and provenance joins.
- Extended `internal/db/migrations_test.go` to model real foreign keys for:
  - Decisions + project cycles → PM plans
  - Sessions → PM plans
  - Eval tasks/runs → neutral reference-context pins
  and verify rejection when referencing nonexistent plan/pin IDs (especially for archived rows).

## Validation

- Ran database migration tests (`internal/db/migrations_test.go`) covering FK enforcement and archive rejection behavior.
- Verified repo checks for database tests, vet, tenancy lints, and diff checks (per existing CI).

[143.dev](https://143.dev) | [session 1f4632b3](https://143.dev/sessions/1f4632b3-67e0-4223-9f8e-c1eb66f49881)

<!-- 143 readiness -->
**143 readiness:** not available for this revision.

<!-- 143-publication session=1f4632b3-67e0-4223-9f8e-c1eb66f49881 changeset=044c6c95-98a7-4a8a-80c2-f382af213631 -->

Preview: https://143.dev/previews/github/assembledhq/143/pull/1950?launch=1