### PR TITLE
Fix preview browser session failures and successful-turn verification

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -537,7 +537,7 @@ func main() {
 						concreteOrchestrator.SetSuccessfulTurnVerifier(preview.NewSuccessfulTurnVerifier(
 							previewManager,
 							previewStore,
-							preview.NewBrowserSessionService(db.NewPreviewBrowserSessionStore(pool), sessionBrowserInspector),
+							preview.NewBrowserSessionService(db.NewPreviewBrowserSessionStore(pool), sessionBrowserInspector, previewManager),
 							db.NewPreviewVerificationRunStore(pool),
 						))
 					}

--- a/frontend/src/components/preview/open-preview-button.test.tsx
+++ b/frontend/src/components/preview/open-preview-button.test.tsx
@@ -138,6 +138,69 @@ describe("OpenPreviewButton", () => {
     );
   });
 
+  it("resets cleanly when a cross-origin popup rejects listener cleanup", async () => {
+    const user = userEvent.setup();
+    const popupListeners = new Map<string, EventListener>();
+    const popup = {
+      opener: window,
+      close: vi.fn(),
+      document: {
+        write: vi.fn(),
+        close: vi.fn(),
+      },
+      location: {
+        href: "",
+      },
+      addEventListener: vi.fn((type: string, listener: EventListener) => {
+        popupListeners.set(type, listener);
+      }),
+      removeEventListener: vi.fn(() => {
+        throw new DOMException(
+          "Blocked a frame with origin from accessing a cross-origin frame.",
+          "SecurityError",
+        );
+      }),
+    } as unknown as Window;
+    vi.spyOn(window, "open").mockReturnValue(popup);
+
+    renderWithProviders(
+      <OpenPreviewButton
+        previewId="prev-1"
+        previewUrl="https://prev-1.preview.143.dev"
+        bootstrapPreview={() => Promise.resolve({ token: "tok-1" })}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Open preview" }));
+    await act(async () => {
+      window.dispatchEvent(
+        new MessageEvent("message", {
+          origin: "https://prev-1.preview.143.dev",
+          data: { type: "preview_bootstrap_ready" },
+        }),
+      );
+    });
+    await act(async () => {
+      window.dispatchEvent(
+        new MessageEvent("message", {
+          origin: "https://prev-1.preview.143.dev",
+          data: { type: "preview_bootstrap_complete" },
+        }),
+      );
+    });
+    await waitFor(() => {
+      expect(popupListeners.has("load")).toBe(true);
+    });
+
+    await expect(
+      act(async () => {
+        popupListeners.get("load")?.(new Event("load"));
+      }),
+    ).resolves.toBeUndefined();
+    expect(screen.getByRole("button", { name: "Open preview" })).toBeEnabled();
+    expect(popup.removeEventListener).toHaveBeenCalledTimes(1);
+  });
+
   it("recovers if the popup closes before the preview load event", async () => {
     const user = userEvent.setup();
     const popup = {

--- a/frontend/src/components/preview/open-preview-button.tsx
+++ b/frontend/src/components/preview/open-preview-button.tsx
@@ -90,10 +90,23 @@ export function usePreviewLauncher(bootstrapPreview?: (previewId: string) => Pro
     }
   }, []);
 
+  const clearPopupLoadListener = useCallback(() => {
+    const cleanup = popupLoadCleanupRef.current;
+    popupLoadCleanupRef.current = null;
+    if (!cleanup) return;
+    try {
+      cleanup();
+    } catch {
+      // Once the popup reaches the preview origin, its WindowProxy is
+      // cross-origin and some browsers reject even removeEventListener.
+      // The listener is registered with { once: true }, so clearing our local
+      // reference is sufficient and must never take down the opener UI.
+    }
+  }, []);
+
   const resetPendingOpen = useCallback(() => {
     clearTimeoutRef();
-    popupLoadCleanupRef.current?.();
-    popupLoadCleanupRef.current = null;
+    clearPopupLoadListener();
     if (popupNavigationPollRef.current !== null) {
       window.clearInterval(popupNavigationPollRef.current);
       popupNavigationPollRef.current = null;
@@ -105,11 +118,11 @@ export function usePreviewLauncher(bootstrapPreview?: (previewId: string) => Pro
     pendingRef.current = null;
     setIframeSrc(undefined);
     setIsOpening(false);
-  }, [clearTimeoutRef]);
+  }, [clearPopupLoadListener, clearTimeoutRef]);
 
   const completeOpenWhenPopupLoads = useCallback(
     (popup: Window) => {
-      popupLoadCleanupRef.current?.();
+      clearPopupLoadListener();
 
       const onLoad = () => {
         resetPendingOpen();
@@ -137,7 +150,7 @@ export function usePreviewLauncher(bootstrapPreview?: (previewId: string) => Pro
         resetPendingOpen();
       }, POPUP_NAVIGATION_TIMEOUT_MS);
     },
-    [resetPendingOpen],
+    [clearPopupLoadListener, resetPendingOpen],
   );
 
   const failOpen = useCallback(
@@ -269,8 +282,7 @@ export function usePreviewLauncher(bootstrapPreview?: (previewId: string) => Pro
   useEffect(() => {
     return () => {
       clearTimeoutRef();
-      popupLoadCleanupRef.current?.();
-      popupLoadCleanupRef.current = null;
+      clearPopupLoadListener();
       if (popupNavigationPollRef.current !== null) {
         window.clearInterval(popupNavigationPollRef.current);
         popupNavigationPollRef.current = null;
@@ -284,7 +296,7 @@ export function usePreviewLauncher(bootstrapPreview?: (previewId: string) => Pro
       }
       pendingRef.current = null;
     };
-  }, [clearTimeoutRef]);
+  }, [clearPopupLoadListener, clearTimeoutRef]);
 
   const bootstrapFrame = iframeSrc ? (
     <iframe

--- a/frontend/src/components/preview/shared-browser-surface.tsx
+++ b/frontend/src/components/preview/shared-browser-surface.tsx
@@ -33,7 +33,7 @@ export function SharedBrowserSurface({ sessionId }: { sessionId: string }) {
   });
   const observation = useQuery({
     queryKey: ["preview-browser-observation", sessionId],
-    queryFn: () => api.sessions.preview.observeBrowser(sessionId),
+    queryFn: ({ signal }) => api.sessions.preview.observeBrowser(sessionId, { signal }),
     refetchInterval: 1500,
   });
   const refresh = useCallback(() => {

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -116,8 +116,9 @@ function timeoutSignal(timeoutMs: number, parent?: AbortSignal): AbortSignal {
   return controller.signal;
 }
 
-function post<T>(path: string, body?: unknown): Promise<T> {
+function post<T>(path: string, body?: unknown, options?: RequestInit): Promise<T> {
   return request<T>(path, {
+    ...options,
     method: 'POST',
     body: body ? JSON.stringify(body) : undefined,
   });
@@ -735,8 +736,12 @@ export const api = {
       inspect: (sessionId: string, x: number, y: number) =>
         post<import('./types').SingleResponse<import('./preview-types').ElementInfo>>(`/api/v1/sessions/${sessionId}/preview/inspect`, { x, y })
           .then(r => r.data),
-      observeBrowser: (sessionId: string) =>
-        post<import('./types').SingleResponse<import('./preview-types').PreviewBrowserObservation>>(`/api/v1/sessions/${sessionId}/preview/watch`, {})
+      observeBrowser: (sessionId: string, opts?: { signal?: AbortSignal; timeoutMs?: number }) =>
+        post<import('./types').SingleResponse<import('./preview-types').PreviewBrowserObservation>>(
+          `/api/v1/sessions/${sessionId}/preview/watch`,
+          {},
+          { signal: timeoutSignal(opts?.timeoutMs ?? 55_000, opts?.signal) },
+        )
           .then(r => r.data),
       browserControl: (sessionId: string) =>
         get<import('./types').SingleResponse<import('./preview-types').PreviewBrowserControlStatus>>(`/api/v1/sessions/${sessionId}/preview/control`)

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -919,7 +919,7 @@ func NewRouter(cfg *config.Config, pool *pgxpool.Pool, logger zerolog.Logger, se
 	if resolved, ok := previewInspector.(preview.SessionBrowserInspector); ok {
 		browserInspector = resolved
 	}
-	previewHandler.SetBrowserSessionService(preview.NewBrowserSessionService(previewBrowserSessionStore, browserInspector))
+	previewHandler.SetBrowserSessionService(preview.NewBrowserSessionService(previewBrowserSessionStore, browserInspector, previewManager))
 	branchPreviewHandler := handlers.NewBranchPreviewHandler(previewStore, repoStore, prService, previewManager, cfg.FrontendURL, cfg.PreviewOriginTemplate)
 	previewHandler.SetAuditEmitter(auditEmitter)
 	branchPreviewHandler.SetAuditEmitter(auditEmitter)

--- a/internal/services/preview/browser_session.go
+++ b/internal/services/preview/browser_session.go
@@ -16,7 +16,10 @@ import (
 	"github.com/jackc/pgx/v5"
 )
 
-const maxBrowserStorageStateBytes = 1024 * 1024
+const (
+	maxBrowserStorageStateBytes      = 1024 * 1024
+	previewBrowserObservationTimeout = 45 * time.Second
+)
 
 var (
 	ErrBrowserUnavailable   = errors.New("preview browser unavailable")
@@ -109,10 +112,16 @@ type BrowserSessionPolicy struct {
 }
 
 type BrowserSessionService struct {
-	store     BrowserSessionStore
-	inspector SessionBrowserInspector
-	locksMu   sync.Mutex
-	locks     map[uuid.UUID]*browserSessionLock
+	store              BrowserSessionStore
+	inspector          SessionBrowserInspector
+	accessTokenMinter  BrowserAccessTokenMinter
+	observationTimeout time.Duration
+	locksMu            sync.Mutex
+	locks              map[uuid.UUID]*browserSessionLock
+}
+
+type BrowserAccessTokenMinter interface {
+	MintBrowserAccessToken(ctx context.Context, orgID, sessionID, previewID uuid.UUID) (string, error)
 }
 
 type browserSessionLock struct {
@@ -120,8 +129,14 @@ type browserSessionLock struct {
 	refs int
 }
 
-func NewBrowserSessionService(store BrowserSessionStore, inspector SessionBrowserInspector) *BrowserSessionService {
-	return &BrowserSessionService{store: store, inspector: inspector, locks: make(map[uuid.UUID]*browserSessionLock)}
+func NewBrowserSessionService(store BrowserSessionStore, inspector SessionBrowserInspector, accessTokenMinter BrowserAccessTokenMinter) *BrowserSessionService {
+	return &BrowserSessionService{
+		store:              store,
+		inspector:          inspector,
+		accessTokenMinter:  accessTokenMinter,
+		observationTimeout: previewBrowserObservationTimeout,
+		locks:              make(map[uuid.UUID]*browserSessionLock),
+	}
 }
 
 func (s *BrowserSessionService) EnsureIdentity(ctx context.Context, orgID, sessionID, previewID uuid.UUID, policy BrowserSessionPolicy) (*models.PreviewBrowserContextStatus, error) {
@@ -181,26 +196,63 @@ func (s *BrowserSessionService) prepare(ctx context.Context, orgID, sessionID, p
 	if err != nil {
 		return target, nil, models.PreviewBrowserRestorationUnavailable, "browser session persistence failed", fmt.Errorf("ensure browser session: %w", err)
 	}
-	if s.inspector.HasContext(target) {
+	hadContext := s.inspector.HasContext(target)
+	if err := s.ensurePreviewAccess(ctx, orgID, sessionID, previewID, target); err != nil {
+		return target, record, models.PreviewBrowserRestorationUnavailable, "preview browser access could not be established", err
+	}
+	if hadContext {
 		return target, record, models.PreviewBrowserRestorationPreserved, "live browser context reused", nil
 	}
 	if !policy.PersistSession || len(record.StorageState) == 0 || string(record.StorageState) == "{}" {
 		return target, record, models.PreviewBrowserRestorationReset, "no restorable browser state was available", nil
 	}
 	if err := s.inspector.RestoreStorage(ctx, target, record.StorageState); err != nil {
+		if accessErr := s.ensurePreviewAccess(ctx, orgID, sessionID, previewID, target); accessErr != nil {
+			return target, record, models.PreviewBrowserRestorationUnavailable, "preview browser access could not be re-established after restore failure", errors.Join(err, accessErr)
+		}
 		return target, record, models.PreviewBrowserRestorationReset, "stored browser state was incompatible or could not be restored", nil
 	}
 	return target, record, models.PreviewBrowserRestorationRestored, "stored browser state restored", nil
 }
 
+func (s *BrowserSessionService) ensurePreviewAccess(ctx context.Context, orgID, sessionID, previewID uuid.UUID, target models.BrowserTarget) error {
+	if s.accessTokenMinter == nil {
+		return nil
+	}
+	accessInspector, ok := s.inspector.(SessionBrowserAccessInspector)
+	if !ok {
+		return fmt.Errorf("%w: inspector does not support preview gateway access", ErrBrowserUnavailable)
+	}
+	if accessInspector.HasPreviewAccess(target) {
+		return nil
+	}
+	token, err := s.accessTokenMinter.MintBrowserAccessToken(ctx, orgID, sessionID, previewID)
+	if err != nil {
+		return fmt.Errorf("mint preview browser access: %w", err)
+	}
+	if strings.TrimSpace(token) == "" {
+		return fmt.Errorf("mint preview browser access: empty token")
+	}
+	if err := accessInspector.BootstrapPreviewAccess(ctx, target, token); err != nil {
+		return fmt.Errorf("bootstrap preview browser access: %w", err)
+	}
+	return nil
+}
+
 func (s *BrowserSessionService) Observe(ctx context.Context, orgID, sessionID, previewID uuid.UUID, policy BrowserSessionPolicy, opts models.PreviewObservationOpts) (*models.PreviewObservation, error) {
+	timeout := s.observationTimeout
+	if timeout <= 0 {
+		timeout = previewBrowserObservationTimeout
+	}
+	observeCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
 	if opts.Path == "" {
-		return s.observe(ctx, orgID, sessionID, previewID, policy, opts)
+		return s.observe(observeCtx, orgID, sessionID, previewID, policy, opts)
 	}
 	var result *models.PreviewObservation
-	err := s.RunAgentOperation(ctx, orgID, sessionID, 5*time.Minute, func() error {
+	err := s.RunAgentOperation(observeCtx, orgID, sessionID, 5*time.Minute, func() error {
 		var observeErr error
-		result, observeErr = s.observe(ctx, orgID, sessionID, previewID, policy, opts)
+		result, observeErr = s.observe(observeCtx, orgID, sessionID, previewID, policy, opts)
 		return observeErr
 	})
 	return result, err

--- a/internal/services/preview/browser_session_test.go
+++ b/internal/services/preview/browser_session_test.go
@@ -91,7 +91,7 @@ func (s *fakeBrowserSessionStore) SaveState(_ context.Context, _, _ uuid.UUID, c
 func TestBrowserSessionService_PersistsViewportAction(t *testing.T) {
 	t.Parallel()
 	store := &fakeBrowserSessionStore{}
-	service := NewBrowserSessionService(store, &fakeSessionBrowserInspector{hasContext: true})
+	service := NewBrowserSessionService(store, &fakeSessionBrowserInspector{hasContext: true}, nil)
 	_, err := service.Act(context.Background(), uuid.New(), uuid.New(), uuid.New(), BrowserSessionPolicy{PersistSession: true}, []models.InteractionStep{{Action: "viewport", Value: "390x844"}}, models.PreviewObservationOpts{})
 	require.NoError(t, err, "viewport action should succeed")
 	var viewport models.ViewportSpec
@@ -103,7 +103,7 @@ func TestBrowserSessionService_ControlHandoffLifecycle(t *testing.T) {
 	t.Parallel()
 	store := &fakeBrowserSessionStore{}
 	orgID, sessionID, previewID, userID := uuid.New(), uuid.New(), uuid.New(), uuid.New()
-	service := NewBrowserSessionService(store, &fakeSessionBrowserInspector{hasContext: true})
+	service := NewBrowserSessionService(store, &fakeSessionBrowserInspector{hasContext: true}, nil)
 	_, err := service.EnsureIdentity(context.Background(), orgID, sessionID, previewID, BrowserSessionPolicy{})
 	require.NoError(t, err, "browser identity should be created before control transitions")
 	waiting, err := service.RequestHandoff(context.Background(), orgID, sessionID, "MFA is required")
@@ -120,7 +120,7 @@ func TestBrowserSessionService_ControlHandoffLifecycle(t *testing.T) {
 func TestBrowserSessionService_AgentActionFailsWhileHumanControls(t *testing.T) {
 	t.Parallel()
 	store := &fakeBrowserSessionStore{record: &models.PreviewBrowserSession{ControlState: models.PreviewBrowserControlHuman}}
-	service := NewBrowserSessionService(store, &fakeSessionBrowserInspector{hasContext: true})
+	service := NewBrowserSessionService(store, &fakeSessionBrowserInspector{hasContext: true}, nil)
 	_, err := service.Act(context.Background(), uuid.New(), uuid.New(), uuid.New(), BrowserSessionPolicy{}, []models.InteractionStep{{Action: "press", Value: "Enter"}}, models.PreviewObservationOpts{})
 	require.ErrorIs(t, err, ErrBrowserControlHeld, "agent actions should fail while a human lease is active")
 }
@@ -129,7 +129,7 @@ func TestBrowserSessionService_HumanActionRequiresExactLeaseOwner(t *testing.T) 
 	t.Parallel()
 	ownerID := uuid.New()
 	store := &fakeBrowserSessionStore{record: &models.PreviewBrowserSession{ControlState: models.PreviewBrowserControlHuman, ControlLeaseOwnerID: &ownerID}}
-	service := NewBrowserSessionService(store, &fakeSessionBrowserInspector{hasContext: true})
+	service := NewBrowserSessionService(store, &fakeSessionBrowserInspector{hasContext: true}, nil)
 	_, err := service.ActAsHuman(context.Background(), uuid.New(), uuid.New(), uuid.New(), uuid.New(), BrowserSessionPolicy{}, []models.InteractionStep{{Action: "press", Value: "Enter"}}, models.PreviewObservationOpts{})
 	require.ErrorIs(t, err, ErrBrowserControlHeld, "a different human must not use another user's browser lease")
 }
@@ -138,7 +138,7 @@ func TestBrowserSessionService_AgentResumesSameContextAfterHumanHandoff(t *testi
 	t.Parallel()
 	store := &fakeBrowserSessionStore{}
 	inspector := &fakeSessionBrowserInspector{hasContext: true}
-	service := NewBrowserSessionService(store, inspector)
+	service := NewBrowserSessionService(store, inspector, nil)
 	orgID, sessionID, previewID, userID := uuid.New(), uuid.New(), uuid.New(), uuid.New()
 	_, err := service.EnsureIdentity(context.Background(), orgID, sessionID, previewID, BrowserSessionPolicy{PersistSession: true})
 	require.NoError(t, err, "shared browser identity should initialize")
@@ -158,7 +158,7 @@ func TestBrowserSessionService_EnsureIdentityWithoutLocalInspector(t *testing.T)
 	t.Parallel()
 	store := &fakeBrowserSessionStore{}
 	sessionID := uuid.New()
-	service := NewBrowserSessionService(store, nil)
+	service := NewBrowserSessionService(store, nil, nil)
 	status, err := service.EnsureIdentity(context.Background(), uuid.New(), sessionID, uuid.New(), BrowserSessionPolicy{PersistSession: true})
 	require.NoError(t, err, "API nodes should persist browser identity without a local inspector")
 	require.Equal(t, "session:"+sessionID.String(), status.ContextKey, "ensure should create the stable session context key")
@@ -168,7 +168,7 @@ func TestBrowserSessionService_EnsureIdentityWithoutLocalInspector(t *testing.T)
 func TestBrowserSessionService_RejectsOversizedStorageState(t *testing.T) {
 	t.Parallel()
 	inspector := &fakeSessionBrowserInspector{hasContext: true, storage: json.RawMessage(bytes.Repeat([]byte("x"), maxBrowserStorageStateBytes+1))}
-	service := NewBrowserSessionService(&fakeBrowserSessionStore{}, inspector)
+	service := NewBrowserSessionService(&fakeBrowserSessionStore{}, inspector, nil)
 	_, err := service.Observe(context.Background(), uuid.New(), uuid.New(), uuid.New(), BrowserSessionPolicy{PersistSession: true}, models.PreviewObservationOpts{ScreenshotOpts: models.ScreenshotOpts{Path: "/"}})
 	require.Error(t, err, "oversized browser state should not be persisted")
 	require.Contains(t, err.Error(), "exceeds", "oversized state error should explain the configured bound")
@@ -177,22 +177,26 @@ func TestBrowserSessionService_RejectsOversizedStorageState(t *testing.T) {
 func TestBrowserSessionService_ReadOnlyObservationAvoidsPersistenceWrites(t *testing.T) {
 	t.Parallel()
 	store := &fakeBrowserSessionStore{}
-	service := NewBrowserSessionService(store, &fakeSessionBrowserInspector{hasContext: true})
+	service := NewBrowserSessionService(store, &fakeSessionBrowserInspector{hasContext: true}, nil)
 	_, err := service.Observe(context.Background(), uuid.New(), uuid.New(), uuid.New(), BrowserSessionPolicy{PersistSession: true}, models.PreviewObservationOpts{ReadOnly: true, SkipSemantic: true})
 	require.NoError(t, err, "read-only watch observation should succeed")
 	require.Equal(t, 0, store.saves, "high-frequency preview-panel observations should not write browser state")
 }
 
 type fakeSessionBrowserInspector struct {
-	mu         sync.Mutex
-	hasContext bool
-	restores   int
-	acts       int
-	active     int
-	maxActive  int
-	delay      time.Duration
-	storage    json.RawMessage
-	restoreErr error
+	mu                   sync.Mutex
+	hasContext           bool
+	authorizedPreviewID  string
+	bootstrapTokens      []string
+	bootstrapErr         error
+	restores             int
+	acts                 int
+	active               int
+	maxActive            int
+	delay                time.Duration
+	observeUntilCanceled bool
+	storage              json.RawMessage
+	restoreErr           error
 }
 
 func (i *fakeSessionBrowserInspector) HasContext(models.BrowserTarget) bool {
@@ -200,10 +204,31 @@ func (i *fakeSessionBrowserInspector) HasContext(models.BrowserTarget) bool {
 	defer i.mu.Unlock()
 	return i.hasContext
 }
-func (i *fakeSessionBrowserInspector) Observe(_ context.Context, target models.BrowserTarget, opts models.PreviewObservationOpts) (*models.PreviewObservation, error) {
+func (i *fakeSessionBrowserInspector) HasPreviewAccess(target models.BrowserTarget) bool {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	return i.hasContext && i.authorizedPreviewID == target.PreviewID
+}
+func (i *fakeSessionBrowserInspector) BootstrapPreviewAccess(_ context.Context, target models.BrowserTarget, token string) error {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	i.bootstrapTokens = append(i.bootstrapTokens, token)
+	if i.bootstrapErr != nil {
+		return i.bootstrapErr
+	}
+	i.hasContext = true
+	i.authorizedPreviewID = target.PreviewID
+	return nil
+}
+func (i *fakeSessionBrowserInspector) Observe(ctx context.Context, target models.BrowserTarget, opts models.PreviewObservationOpts) (*models.PreviewObservation, error) {
 	i.mu.Lock()
 	i.hasContext = true
+	waitForCancellation := i.observeUntilCanceled
 	i.mu.Unlock()
+	if waitForCancellation {
+		<-ctx.Done()
+		return nil, ctx.Err()
+	}
 	now := time.Now()
 	return &models.PreviewObservation{URL: "https://preview.test/app", Title: "App", Viewport: models.ViewportSpec{Width: opts.ViewportW, Height: opts.ViewportH}, CapturedAt: now, ConsoleCursor: 4, Ready: true, Context: models.PreviewBrowserContextStatus{ContextKey: target.ContextKey}}, nil
 }
@@ -238,6 +263,129 @@ func (i *fakeSessionBrowserInspector) RestoreStorage(context.Context, models.Bro
 	return i.restoreErr
 }
 
+type fakeBrowserAccessTokenMinter struct {
+	mu        sync.Mutex
+	token     string
+	err       error
+	calls     int
+	orgID     uuid.UUID
+	sessionID uuid.UUID
+	previewID uuid.UUID
+}
+
+func (m *fakeBrowserAccessTokenMinter) MintBrowserAccessToken(_ context.Context, orgID, sessionID, previewID uuid.UUID) (string, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.calls++
+	m.orgID = orgID
+	m.sessionID = sessionID
+	m.previewID = previewID
+	return m.token, m.err
+}
+
+func TestBrowserSessionService_BootstrapsPreviewAccess(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name                  string
+		hasContext            bool
+		authorizedPreviewID   string
+		expectedBootstrapCall int
+		expectedRestoration   models.PreviewBrowserRestorationStatus
+	}{
+		{name: "fresh browser context", expectedBootstrapCall: 1, expectedRestoration: models.PreviewBrowserRestorationReset},
+		{name: "existing unauthenticated context", hasContext: true, expectedBootstrapCall: 1, expectedRestoration: models.PreviewBrowserRestorationPreserved},
+		{name: "existing authorized context", hasContext: true, authorizedPreviewID: "active", expectedRestoration: models.PreviewBrowserRestorationPreserved},
+		{name: "replacement preview origin", hasContext: true, authorizedPreviewID: "replaced", expectedBootstrapCall: 1, expectedRestoration: models.PreviewBrowserRestorationPreserved},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			orgID, sessionID, previewID := uuid.New(), uuid.New(), uuid.New()
+			authorizedPreviewID := tt.authorizedPreviewID
+			if authorizedPreviewID == "active" {
+				authorizedPreviewID = previewID.String()
+			}
+			inspector := &fakeSessionBrowserInspector{
+				hasContext:          tt.hasContext,
+				authorizedPreviewID: authorizedPreviewID,
+			}
+			minter := &fakeBrowserAccessTokenMinter{token: "browser-token"}
+			service := NewBrowserSessionService(&fakeBrowserSessionStore{}, inspector, minter)
+
+			observation, err := service.Observe(
+				context.Background(),
+				orgID,
+				sessionID,
+				previewID,
+				BrowserSessionPolicy{PersistSession: true},
+				models.PreviewObservationOpts{ScreenshotOpts: models.ScreenshotOpts{Path: "/"}},
+			)
+
+			require.NoError(t, err, "authenticated browser observation should succeed")
+			require.Equal(t, tt.expectedRestoration, observation.Context.Restoration, "observation should preserve the browser restoration result")
+			require.Equal(t, tt.expectedBootstrapCall, minter.calls, "access tokens should be minted only when the preview origin lacks authorization")
+			require.Len(t, inspector.bootstrapTokens, tt.expectedBootstrapCall, "browser bootstrap should match access-token minting")
+			if tt.expectedBootstrapCall == 1 {
+				require.Equal(t, "browser-token", inspector.bootstrapTokens[0], "browser should exchange the minted access token")
+				require.Equal(t, orgID, minter.orgID, "access token minting should preserve org scope")
+				require.Equal(t, sessionID, minter.sessionID, "access token minting should preserve session scope")
+				require.Equal(t, previewID, minter.previewID, "access token minting should preserve preview scope")
+			}
+		})
+	}
+}
+
+func TestBrowserSessionService_FailsClosedWhenPreviewAccessCannotBeEstablished(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name          string
+		minterErr     error
+		bootstrapErr  error
+		expectedError string
+	}{
+		{name: "token mint fails", minterErr: context.DeadlineExceeded, expectedError: "mint preview browser access"},
+		{name: "token exchange fails", bootstrapErr: context.DeadlineExceeded, expectedError: "bootstrap preview browser access"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			inspector := &fakeSessionBrowserInspector{bootstrapErr: tt.bootstrapErr}
+			minter := &fakeBrowserAccessTokenMinter{token: "browser-token", err: tt.minterErr}
+			service := NewBrowserSessionService(&fakeBrowserSessionStore{}, inspector, minter)
+
+			_, err := service.Observe(
+				context.Background(),
+				uuid.New(),
+				uuid.New(),
+				uuid.New(),
+				BrowserSessionPolicy{},
+				models.PreviewObservationOpts{ScreenshotOpts: models.ScreenshotOpts{Path: "/"}},
+			)
+
+			require.Error(t, err, "observation should fail without an authorized preview context")
+			require.Contains(t, err.Error(), tt.expectedError, "access setup failure should identify the failed stage")
+		})
+	}
+}
+
+func TestBrowserSessionService_BoundsObservationDuration(t *testing.T) {
+	t.Parallel()
+	inspector := &fakeSessionBrowserInspector{hasContext: true, observeUntilCanceled: true}
+	service := NewBrowserSessionService(&fakeBrowserSessionStore{}, inspector, nil)
+	service.observationTimeout = 10 * time.Millisecond
+
+	_, err := service.Observe(
+		context.Background(),
+		uuid.New(),
+		uuid.New(),
+		uuid.New(),
+		BrowserSessionPolicy{},
+		models.PreviewObservationOpts{ReadOnly: true},
+	)
+
+	require.ErrorIs(t, err, context.DeadlineExceeded, "browser observation should return at its service deadline")
+}
+
 func TestBrowserSessionService_ObserveLifecycle(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
@@ -263,7 +411,7 @@ func TestBrowserSessionService_ObserveLifecycle(t *testing.T) {
 				store.record = &models.PreviewBrowserSession{ID: uuid.New(), OrgID: orgID, SessionID: sessionID, ContextKey: "session:" + sessionID.String(), Viewport: raw, StorageState: tt.storage}
 			}
 			inspector := &fakeSessionBrowserInspector{hasContext: tt.existingContext}
-			service := NewBrowserSessionService(store, inspector)
+			service := NewBrowserSessionService(store, inspector, nil)
 			result, err := service.Observe(context.Background(), orgID, sessionID, previewID, BrowserSessionPolicy{PersistSession: tt.persist, AllowedPaths: []string{"/app/**"}}, models.PreviewObservationOpts{})
 			require.NoError(t, err, "observe should complete")
 			require.Equal(t, tt.expected, result.Context.Restoration, "observe should report the browser restoration outcome")
@@ -278,7 +426,7 @@ func TestBrowserSessionService_ReportsRestoreFailure(t *testing.T) {
 	orgID, sessionID, previewID := uuid.New(), uuid.New(), uuid.New()
 	viewport, _ := json.Marshal(models.ViewportSpec{Width: 1440, Height: 900})
 	store := &fakeBrowserSessionStore{record: &models.PreviewBrowserSession{ID: uuid.New(), OrgID: orgID, SessionID: sessionID, ContextKey: "session:" + sessionID.String(), Viewport: viewport, StorageState: json.RawMessage(`{"cookies":[]}`)}}
-	service := NewBrowserSessionService(store, &fakeSessionBrowserInspector{restoreErr: context.DeadlineExceeded})
+	service := NewBrowserSessionService(store, &fakeSessionBrowserInspector{restoreErr: context.DeadlineExceeded}, nil)
 	observation, err := service.Observe(context.Background(), orgID, sessionID, previewID, BrowserSessionPolicy{PersistSession: true}, models.PreviewObservationOpts{ScreenshotOpts: models.ScreenshotOpts{Path: "/"}})
 	require.NoError(t, err, "restore failure should reset to a fresh browser instead of failing observation")
 	require.Equal(t, models.PreviewBrowserRestorationReset, observation.Context.Restoration, "restore failure should be reported as a reset")
@@ -311,7 +459,7 @@ func TestBrowserSessionService_ActRejectsDisallowedNavigation(t *testing.T) {
 	t.Parallel()
 	store := &fakeBrowserSessionStore{}
 	inspector := &fakeSessionBrowserInspector{}
-	service := NewBrowserSessionService(store, inspector)
+	service := NewBrowserSessionService(store, inspector, nil)
 	_, err := service.Act(context.Background(), uuid.New(), uuid.New(), uuid.New(), BrowserSessionPolicy{AllowedPaths: []string{"/app/**"}}, []models.InteractionStep{{Action: "navigate", Value: "/admin"}}, models.PreviewObservationOpts{})
 	require.ErrorIs(t, err, ErrNavigationNotAllowed, "act should reject navigation outside configured paths")
 	require.Equal(t, 0, inspector.acts, "rejected navigation should not reach the browser")
@@ -321,7 +469,7 @@ func TestBrowserSessionService_SerializesActions(t *testing.T) {
 	t.Parallel()
 	store := &fakeBrowserSessionStore{}
 	inspector := &fakeSessionBrowserInspector{hasContext: true, delay: 20 * time.Millisecond}
-	service := NewBrowserSessionService(store, inspector)
+	service := NewBrowserSessionService(store, inspector, nil)
 	orgID, sessionID, previewID := uuid.New(), uuid.New(), uuid.New()
 	start := make(chan struct{})
 	done := make(chan error, 2)
@@ -341,7 +489,7 @@ func TestBrowserSessionService_SerializesActions(t *testing.T) {
 
 func TestBrowserSessionService_IsolatesSessionContextKeys(t *testing.T) {
 	t.Parallel()
-	service := NewBrowserSessionService(&fakeBrowserSessionStore{}, &fakeSessionBrowserInspector{})
+	service := NewBrowserSessionService(&fakeBrowserSessionStore{}, &fakeSessionBrowserInspector{}, nil)
 	orgID, previewID := uuid.New(), uuid.New()
 	first, err := service.Observe(context.Background(), orgID, uuid.New(), previewID, BrowserSessionPolicy{PersistSession: true}, models.PreviewObservationOpts{ScreenshotOpts: models.ScreenshotOpts{Path: "/"}})
 	require.NoError(t, err, "first session observation should succeed")

--- a/internal/services/preview/chromedp_inspector.go
+++ b/internal/services/preview/chromedp_inspector.go
@@ -13,6 +13,7 @@ import (
 	"image/gif"
 	"image/png"
 	"math"
+	"net/http"
 	"net/url"
 	"regexp"
 	"strconv"
@@ -54,6 +55,7 @@ func mergeContexts(primary, caller context.Context) (context.Context, context.Ca
 const (
 	browserIdleTimeout    = 5 * time.Minute
 	defaultOpTimeout      = 30 * time.Second
+	browserResetTimeout   = 5 * time.Second
 	maxInteractionSteps   = 20
 	maxInteractionTimeout = 60 * time.Second
 	maxViewports          = 5
@@ -129,10 +131,11 @@ type ChromeDPInspector struct {
 	idleTimer     *time.Timer
 	running       bool
 
-	previews    map[string]*previewContext
-	contextKeys map[string]string
-	screencasts map[string]*screencastSession
-	closed      bool
+	previews      map[string]*previewContext
+	contextKeys   map[string]string
+	previewAccess map[string]string
+	screencasts   map[string]*screencastSession
+	closed        bool
 }
 
 // NewChromeDPInspector creates a new ChromeDPInspector.
@@ -141,11 +144,12 @@ func NewChromeDPInspector(cfg ChromeDPInspectorConfig, logger zerolog.Logger) *C
 		cfg.PreviewURLTemplate = "http://{{.PreviewID}}.preview.localhost:9090{{.Path}}"
 	}
 	return &ChromeDPInspector{
-		cfg:         cfg,
-		logger:      logger.With().Str("component", "chromedp_inspector").Logger(),
-		previews:    make(map[string]*previewContext),
-		contextKeys: make(map[string]string),
-		screencasts: make(map[string]*screencastSession),
+		cfg:           cfg,
+		logger:        logger.With().Str("component", "chromedp_inspector").Logger(),
+		previews:      make(map[string]*previewContext),
+		contextKeys:   make(map[string]string),
+		previewAccess: make(map[string]string),
+		screencasts:   make(map[string]*screencastSession),
 	}
 }
 
@@ -176,10 +180,15 @@ func (c *ChromeDPInspector) BindSessionBrowser(previewID, sessionID string) {
 		// leftover — release it instead of leaking it.
 		raw.cancel()
 		delete(c.previews, previewID)
+		delete(c.previewAccess, previewID)
 		return
 	}
 	c.previews[sessionKey] = raw
 	delete(c.previews, previewID)
+	if authorizedPreviewID := c.previewAccess[previewID]; authorizedPreviewID != "" {
+		c.previewAccess[sessionKey] = authorizedPreviewID
+		delete(c.previewAccess, previewID)
+	}
 }
 
 // =============================================================================
@@ -291,6 +300,7 @@ func (c *ChromeDPInspector) resetIdleTimer() {
 			if pc.lastUsed.Before(cutoff) {
 				pc.cancel()
 				delete(c.previews, key)
+				delete(c.previewAccess, key)
 			}
 		}
 		for previewID, key := range c.contextKeys {
@@ -629,7 +639,9 @@ func (c *ChromeDPInspector) Observe(ctx context.Context, target models.BrowserTa
 	if err := validateObservationOrigin(screenshot.URL, expectedOrigin); err != nil {
 		if pc, contextErr := c.getOrCreatePreviewCtx(target.PreviewID); contextErr == nil {
 			merged, cancel := mergeContexts(pc.ctx, ctx)
-			blankErr := chromedp.Run(merged, chromedp.Navigate("about:blank"))
+			resetCtx, resetCancel := context.WithTimeout(merged, browserResetTimeout)
+			blankErr := chromedp.Run(resetCtx, chromedp.Navigate("about:blank"))
+			resetCancel()
 			cancel()
 			if blankErr != nil {
 				return nil, errors.Join(err, fmt.Errorf("reset browser after unauthorized navigation: %w", blankErr))
@@ -717,17 +729,90 @@ func consoleMessagesAfter(messages []ConsoleMessage, cursor int64) []models.Cons
 }
 
 func (c *ChromeDPInspector) HasContext(target models.BrowserTarget) bool {
-	key := target.ContextKey
-	if key == "" && target.SessionID != "" {
-		key = "session:" + target.SessionID
-	}
-	if key == "" {
-		key = target.PreviewID
-	}
+	key := browserTargetContextKey(target)
 	c.mu.Lock()
 	_, ok := c.previews[key]
 	c.mu.Unlock()
 	return ok
+}
+
+func (c *ChromeDPInspector) HasPreviewAccess(target models.BrowserTarget) bool {
+	if target.SessionID != "" {
+		c.BindSessionBrowser(target.PreviewID, target.SessionID)
+	}
+	key := browserTargetContextKey(target)
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	_, hasContext := c.previews[key]
+	return hasContext && c.previewAccess[key] == target.PreviewID
+}
+
+func (c *ChromeDPInspector) BootstrapPreviewAccess(ctx context.Context, target models.BrowserTarget, token string) error {
+	if strings.TrimSpace(token) == "" {
+		return fmt.Errorf("preview bootstrap token is required")
+	}
+	if target.SessionID != "" {
+		c.BindSessionBrowser(target.PreviewID, target.SessionID)
+	}
+	bootstrapURL, err := c.previewURL(target.PreviewID, "/bootstrap")
+	if err != nil {
+		return fmt.Errorf("resolve preview bootstrap URL: %w", err)
+	}
+	previewURL, err := c.previewURL(target.PreviewID, "/")
+	if err != nil {
+		return fmt.Errorf("resolve preview URL: %w", err)
+	}
+	pc, err := c.getOrCreatePreviewCtx(target.PreviewID)
+	if err != nil {
+		return err
+	}
+	merged, mergeCancel := mergeContexts(pc.ctx, ctx)
+	defer mergeCancel()
+	timeoutCtx, cancel := context.WithTimeout(merged, defaultOpTimeout)
+	defer cancel()
+
+	var exchangeStatus int
+	exchangeScript := fmt.Sprintf(`(async () => {
+		const response = await fetch("/bootstrap/exchange", {
+			method: "POST",
+			headers: {"Content-Type": "application/json"},
+			body: JSON.stringify({token: %s}),
+			credentials: "same-origin"
+		});
+		return response.status;
+	})()`, strconv.Quote(token))
+	if err := chromedp.Run(
+		timeoutCtx,
+		chromedp.Navigate(bootstrapURL),
+		chromedp.WaitReady("body", chromedp.ByQuery),
+		chromedp.Evaluate(exchangeScript, &exchangeStatus),
+	); err != nil {
+		c.dropBrowserContext(target)
+		return fmt.Errorf("exchange preview browser access: %w", err)
+	}
+	if exchangeStatus < http.StatusOK || exchangeStatus >= http.StatusMultipleChoices {
+		c.dropBrowserContext(target)
+		return fmt.Errorf("exchange preview browser access returned status %d", exchangeStatus)
+	}
+	var currentURL string
+	if err := chromedp.Run(
+		timeoutCtx,
+		chromedp.Navigate(previewURL),
+		chromedp.WaitReady("body", chromedp.ByQuery),
+		chromedp.Location(&currentURL),
+	); err != nil {
+		c.dropBrowserContext(target)
+		return fmt.Errorf("open authenticated preview: %w", err)
+	}
+	if err := validateObservationOrigin(currentURL, previewURL); err != nil {
+		c.dropBrowserContext(target)
+		return fmt.Errorf("authenticated preview left its authorized origin: %w", err)
+	}
+	key := browserTargetContextKey(target)
+	c.mu.Lock()
+	c.previewAccess[key] = target.PreviewID
+	c.mu.Unlock()
+	return nil
 }
 
 func (c *ChromeDPInspector) Act(ctx context.Context, target models.BrowserTarget, steps []models.InteractionStep, opts models.PreviewObservationOpts) (*models.PreviewActResult, error) {
@@ -765,7 +850,7 @@ func (c *ChromeDPInspector) ExportStorage(ctx context.Context, target models.Bro
 	var state browserStorageState
 	if err := chromedp.Run(merged, chromedp.Location(&state.URL), chromedp.Evaluate(`Object.fromEntries(Object.entries(localStorage))`, &state.LocalStorage), chromedp.ActionFunc(func(runCtx context.Context) error {
 		cookies, cookieErr := network.GetCookies().Do(runCtx)
-		state.Cookies = cookies
+		state.Cookies = persistableBrowserCookies(cookies)
 		return cookieErr
 	})); err != nil {
 		return nil, fmt.Errorf("export browser storage: %w", err)
@@ -811,6 +896,9 @@ func (c *ChromeDPInspector) RestoreStorage(ctx context.Context, target models.Br
 	newURL, _ := url.Parse(destinationURL)
 	err = chromedp.Run(merged, chromedp.ActionFunc(func(runCtx context.Context) error {
 		for _, cookie := range state.Cookies {
+			if cookie == nil || isPreviewGatewaySessionCookie(cookie.Name) {
+				continue
+			}
 			domain := cookie.Domain
 			if strings.TrimPrefix(domain, ".") == oldURL.Hostname() {
 				domain = newURL.Hostname()
@@ -830,19 +918,39 @@ func (c *ChromeDPInspector) RestoreStorage(ctx context.Context, target models.Br
 }
 
 func (c *ChromeDPInspector) dropBrowserContext(target models.BrowserTarget) {
-	key := target.ContextKey
-	if key == "" && target.SessionID != "" {
-		key = "session:" + target.SessionID
-	}
-	if key == "" {
-		key = target.PreviewID
-	}
+	key := browserTargetContextKey(target)
 	c.mu.Lock()
 	if pc := c.previews[key]; pc != nil {
 		pc.cancel()
 		delete(c.previews, key)
 	}
+	delete(c.previewAccess, key)
 	c.mu.Unlock()
+}
+
+func browserTargetContextKey(target models.BrowserTarget) string {
+	if target.ContextKey != "" {
+		return target.ContextKey
+	}
+	if target.SessionID != "" {
+		return "session:" + target.SessionID
+	}
+	return target.PreviewID
+}
+
+func persistableBrowserCookies(cookies []*network.Cookie) []*network.Cookie {
+	result := make([]*network.Cookie, 0, len(cookies))
+	for _, cookie := range cookies {
+		if cookie == nil || isPreviewGatewaySessionCookie(cookie.Name) {
+			continue
+		}
+		result = append(result, cookie)
+	}
+	return result
+}
+
+func isPreviewGatewaySessionCookie(name string) bool {
+	return name == "__Host-preview_session" || name == "preview_session"
 }
 
 func compatiblePreviewRestoreURL(stored, active string) (bool, string) {
@@ -2260,6 +2368,7 @@ func (c *ChromeDPInspector) Close() error {
 	for id, pc := range c.previews {
 		pc.cancel()
 		delete(c.previews, id)
+		delete(c.previewAccess, id)
 	}
 
 	// Shut down the browser.

--- a/internal/services/preview/chromedp_inspector_test.go
+++ b/internal/services/preview/chromedp_inspector_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/assembledhq/143/internal/models"
+	"github.com/chromedp/cdproto/network"
 	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/require"
 )
@@ -29,9 +30,12 @@ func TestChromeDPInspector_BindAdoptsRawContext(t *testing.T) {
 	// creates a second Chrome tab, orphaning (and leaking) this one.
 	cancelled := false
 	inspector.previews["preview-1"] = &previewContext{cancel: func() { cancelled = true }}
+	inspector.previewAccess["preview-1"] = "preview-1"
 	inspector.BindSessionBrowser("preview-1", "session-1")
 	require.NotContains(t, inspector.previews, "preview-1", "raw-keyed context should be reconciled away")
 	require.Contains(t, inspector.previews, "session:session-1", "context should be adopted under the session key")
+	require.Equal(t, "preview-1", inspector.previewAccess["session:session-1"], "adopted context should retain its gateway authorization")
+	require.NotContains(t, inspector.previewAccess, "preview-1", "raw-keyed gateway authorization should be reconciled away")
 	require.False(t, cancelled, "adopted context must not be torn down")
 }
 
@@ -67,6 +71,18 @@ func TestCompatiblePreviewRestoreURL(t *testing.T) {
 			require.Equal(t, tt.expectedURL, url, "compatible restore should retain the stored path on the active origin")
 		})
 	}
+}
+
+func TestPersistableBrowserCookiesExcludesPreviewGatewaySessions(t *testing.T) {
+	t.Parallel()
+	cookies := []*network.Cookie{
+		{Name: "__Host-preview_session", Value: "secure-gateway"},
+		{Name: "preview_session", Value: "local-gateway"},
+		{Name: "app_session", Value: "application"},
+	}
+	expected := []*network.Cookie{{Name: "app_session", Value: "application"}}
+
+	require.Equal(t, expected, persistableBrowserCookies(cookies), "persisted application state must not retain platform preview-access cookies")
 }
 
 func TestConsoleMessagesAfter(t *testing.T) {

--- a/internal/services/preview/inspector.go
+++ b/internal/services/preview/inspector.go
@@ -69,6 +69,15 @@ type SessionBrowserInspector interface {
 	RestoreStorage(ctx context.Context, target models.BrowserTarget, state json.RawMessage) error
 }
 
+// SessionBrowserAccessInspector establishes the platform preview-gateway
+// session in the same browser context used for observation and interaction.
+// The gateway remains the only path to preview content; workers never receive
+// direct runtime URLs or bypass credentials.
+type SessionBrowserAccessInspector interface {
+	HasPreviewAccess(target models.BrowserTarget) bool
+	BootstrapPreviewAccess(ctx context.Context, target models.BrowserTarget, token string) error
+}
+
 // =============================================================================
 // Supporting types
 // =============================================================================

--- a/internal/services/preview/manager.go
+++ b/internal/services/preview/manager.go
@@ -1867,6 +1867,24 @@ func (m *Manager) MintBootstrapToken(ctx context.Context, orgID, userID, preview
 		return "", fmt.Errorf("get preview instance: %w", err)
 	}
 
+	return m.mintBootstrapTokenForInstance(ctx, instance, userID)
+}
+
+// MintBrowserAccessToken creates preview-gateway access for the durable
+// session-owned browser. The instance must belong to the exact requested
+// session so an internal browser request cannot cross session boundaries.
+func (m *Manager) MintBrowserAccessToken(ctx context.Context, orgID, sessionID, previewID uuid.UUID) (string, error) {
+	instance, err := m.store.GetPreviewInstance(ctx, orgID, previewID)
+	if err != nil {
+		return "", fmt.Errorf("get preview instance: %w", err)
+	}
+	if instance.SessionID == uuid.Nil || instance.SessionID != sessionID {
+		return "", fmt.Errorf("preview does not belong to requested session")
+	}
+	return m.mintBootstrapTokenForInstance(ctx, instance, instance.UserID)
+}
+
+func (m *Manager) mintBootstrapTokenForInstance(ctx context.Context, instance *models.PreviewInstance, userID uuid.UUID) (string, error) {
 	if !instance.Status.IsActive() {
 		return "", fmt.Errorf("preview is not active (status=%s)", instance.Status)
 	}
@@ -1879,9 +1897,9 @@ func (m *Manager) MintBootstrapToken(ctx context.Context, orgID, userID, preview
 	tokenHash := hashToken(token)
 
 	sess := &models.PreviewAccessSession{
-		OrgID:             orgID,
+		OrgID:             instance.OrgID,
 		UserID:            userID,
-		PreviewInstanceID: previewID,
+		PreviewInstanceID: instance.ID,
 		SessionTokenHash:  tokenHash,
 		// Deliberately short: this initial window only needs to cover token
 		// redemption. The gateway extends the session to its full sliding

--- a/internal/services/preview/manager_test.go
+++ b/internal/services/preview/manager_test.go
@@ -601,6 +601,60 @@ func TestMintBootstrapToken_InactivePreview(t *testing.T) {
 	require.NoError(t, mock.ExpectationsWereMet())
 }
 
+func TestMintBrowserAccessToken_RequiresExactSessionScope(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name        string
+		matching    bool
+		expectError bool
+	}{
+		{name: "matching session", matching: true},
+		{name: "different session", expectError: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			mock, err := pgxmock.NewPool()
+			require.NoError(t, err, "preview store mock should initialize")
+			defer mock.Close()
+
+			mgr := newTestManager(mock, &mockProvider{})
+			orgID, ownerID, previewID := uuid.New(), uuid.New(), uuid.New()
+			instanceSessionID, requestedSessionID := uuid.New(), uuid.New()
+			if tt.matching {
+				requestedSessionID = instanceSessionID
+			}
+			now := time.Now()
+
+			mock.ExpectQuery("SELECT .+ FROM preview_instances WHERE id").
+				WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+				WillReturnRows(
+					pgxmock.NewRows(previewInstanceTestCols).
+						AddRow(newPreviewInstanceRow(previewID, instanceSessionID, orgID, ownerID, models.PreviewStatusReady, "handle-abc", now)...),
+				)
+			if !tt.expectError {
+				mock.ExpectQuery("INSERT INTO preview_access_sessions").
+					WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+					WillReturnRows(
+						pgxmock.NewRows(previewAccessSessionTestCols).
+							AddRow(newAccessSessionRow(uuid.New(), orgID, ownerID, previewID, "somehash", now.Add(5*time.Minute), nil, now)...),
+					)
+			}
+
+			token, mintErr := mgr.MintBrowserAccessToken(context.Background(), orgID, requestedSessionID, previewID)
+			if tt.expectError {
+				require.Error(t, mintErr, "a preview from another session must not mint browser access")
+				require.Contains(t, mintErr.Error(), "session", "scope mismatch should identify the session boundary")
+				require.Empty(t, token, "scope mismatch must not return an access token")
+			} else {
+				require.NoError(t, mintErr, "matching session preview should mint browser access")
+				require.Len(t, token, 64, "browser access token should use the standard random token format")
+			}
+			require.NoError(t, mock.ExpectationsWereMet(), "all scoped preview-store expectations should be met")
+		})
+	}
+}
+
 // =============================================================================
 // ValidateBootstrapToken tests
 // =============================================================================

--- a/internal/services/preview/successful_turn_verifier_test.go
+++ b/internal/services/preview/successful_turn_verifier_test.go
@@ -57,7 +57,7 @@ func TestBrowserVerificationObserverUsesSessionPolicyAndLease(t *testing.T) {
 				ContextKey: "session:" + sessionID.String(), ControlState: tt.control,
 			}}
 			observer := browserVerificationObserver{
-				browser: NewBrowserSessionService(store, &fakeSessionBrowserInspector{}),
+				browser: NewBrowserSessionService(store, &fakeSessionBrowserInspector{}, nil),
 				orgID:   orgID, sessionID: sessionID, previewID: previewID,
 				policy: BrowserSessionPolicy{PersistSession: true, AllowedPaths: []string{"/safe"}},
 			}

--- a/internal/services/preview/worker_client.go
+++ b/internal/services/preview/worker_client.go
@@ -24,6 +24,7 @@ const previewWorkerTokenTTL = 30 * time.Second
 // probes, each defaulting to 90s) or the API gives up before the worker
 // finishes, surfacing as "context canceled" on a readiness probe.
 const previewWorkerHTTPTimeout = 10 * time.Minute
+const previewWorkerObservationTimeout = 50 * time.Second
 
 const PreviewSoftRestartUnsupportedCode = "PREVIEW_SOFT_RESTART_UNSUPPORTED"
 
@@ -488,7 +489,9 @@ func (c *WorkerPreviewClient) ExecuteInteraction(ctx context.Context, worker Wor
 }
 
 func (c *WorkerPreviewClient) Observe(ctx context.Context, worker WorkerNode, orgID, sessionID, previewID uuid.UUID, body RemoteObserveRequest) (*models.PreviewObservation, error) {
-	req, err := c.newRequest(ctx, http.MethodPost, fmt.Sprintf("%s/internal/preview/%s/observe", worker.BaseURL, previewID), auth.PreviewTokenClaims{OrgID: orgID, TargetNodeID: worker.ID, PreviewID: &previewID, SessionID: &sessionID, Action: "observe", ExpiresAt: time.Now().Add(previewWorkerTokenTTL)}, body)
+	observeCtx, cancel := context.WithTimeout(ctx, previewWorkerObservationTimeout)
+	defer cancel()
+	req, err := c.newRequest(observeCtx, http.MethodPost, fmt.Sprintf("%s/internal/preview/%s/observe", worker.BaseURL, previewID), auth.PreviewTokenClaims{OrgID: orgID, TargetNodeID: worker.ID, PreviewID: &previewID, SessionID: &sessionID, Action: "observe", ExpiresAt: time.Now().Add(previewWorkerTokenTTL)}, body)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Summary

- Improve preview browser-session startup, inspection, and worker-client handling.
- Add successful-turn verification to distinguish completed previews from failed sessions.
- Update preview API routing and frontend behavior for opening and sharing browser surfaces.
- Add backend and frontend tests covering session management, inspection, verification, and preview interactions.

## Testing

- Added focused Go unit tests for preview sessions, inspectors, manager behavior, and turn verification.
- Added frontend tests for the open-preview button.
- Not run (not requested).