### PR TITLE
Fix New Session X Button Position and Image Preview Alignment

### DIFF
--- a/frontend/src/components/manual-session-composer.tsx
+++ b/frontend/src/components/manual-session-composer.tsx
@@ -1345,7 +1345,7 @@ export function ManualSessionComposer({
                 isUploading={isUploading}
                 onRemove={removeAttachment}
                 size="md"
-                className="pt-3 pb-1"
+                className="pt-3"
               />
 
               {showImageInput && (
@@ -1400,7 +1400,10 @@ export function ManualSessionComposer({
                 </div>
               )}
 
-              <div className="pt-2">
+              <div className={cn(
+                "pt-2",
+                (attachments.length > 0 || isUploading) && "pt-1",
+              )}>
                 {isMobile ? (
                   <>
                     <div className="flex items-center gap-2">

--- a/frontend/src/components/pending-attachment-strip.test.tsx
+++ b/frontend/src/components/pending-attachment-strip.test.tsx
@@ -53,6 +53,7 @@ describe("PendingAttachmentStrip", () => {
 
     const removeButton = screen.getByRole("button", { name: "Remove screenshot.png" });
     expect(removeButton).toHaveClass("top-0", "right-0");
+    expect(removeButton).toHaveClass("size-5");
 
     await user.click(removeButton);
 

--- a/frontend/src/components/pending-attachment-strip.tsx
+++ b/frontend/src/components/pending-attachment-strip.tsx
@@ -120,7 +120,7 @@ export function PendingAttachmentStrip({
   return (
     <div className={cn("flex flex-wrap items-center gap-2", className)}>
       {normalizedAttachments.map(({ url, isImage, fileName }) => (
-        <div key={url} className="relative pt-1.5 pr-1.5">
+        <div key={url} className="relative pt-3 pr-2">
           {isImage ? (
             <AttachmentImageTile url={url} fileName={fileName} size={size} />
           ) : (
@@ -137,7 +137,7 @@ export function PendingAttachmentStrip({
           <Button
             type="button"
             variant="outline"
-            size="icon-xs"
+            size="icon-compact"
             onClick={() => onRemove(url)}
             aria-label={`Remove ${fileName}`}
             className={cn(


### PR DESCRIPTION
## Summary

Adjusted the spacing below the image preview from 12px to 4px, bringing it closer to the bottom controls while keeping the X at the top-right.

Verification: ESLint passed and all 52 focused tests passed.

## Test plan

Validated by automated agent run.


[143.dev](https://143.dev) | [session 17089e0d](https://143.dev/sessions/17089e0d-f3cf-4074-819b-b301934a2b20)

<!-- 143 readiness -->
**143 readiness:** not available for this revision.

<!-- 143-publication session=17089e0d-f3cf-4074-819b-b301934a2b20 changeset=0983e841-a71b-4c12-8790-f9ea0ddb8e5c -->

Preview: https://143.dev/previews/github/assembledhq/143/pull/1954?launch=1