### PR TITLE
Allow explicit code review reruns after approval

### DIFF
--- a/internal/services/codereview/github_submitter_test.go
+++ b/internal/services/codereview/github_submitter_test.go
@@ -433,6 +433,59 @@ func TestGitHubSubmitter_SubmitReviewUpdatesExistingAssessment(t *testing.T) {
 	}}, result.Comments, "updated assessment should return the reused inline comment")
 }
 
+func TestGitHubSubmitter_SubmitReviewPreservesExistingApproval(t *testing.T) {
+	t.Parallel()
+
+	previousDecidedAt := time.Date(2026, time.July, 28, 19, 14, 8, 0, time.UTC)
+	var reviewUpdate map[string]any
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/repos/acme/repo/pulls/42/comments":
+			w.Header().Set("Content-Type", "application/json")
+			_, err := w.Write([]byte(`[]`))
+			require.NoError(t, err, "test response should write no inline comments")
+		case r.Method == http.MethodPut && r.URL.Path == "/repos/acme/repo/pulls/42/reviews/143":
+			require.NoError(t, json.NewDecoder(r.Body).Decode(&reviewUpdate), "approved review update should decode")
+			w.Header().Set("Content-Type", "application/json")
+			_, err := w.Write([]byte(`{"id":143,"html_url":"https://github.com/acme/repo/pull/42#pullrequestreview-143"}`))
+			require.NoError(t, err, "test response should write the preserved review")
+		default:
+			http.Error(w, "unexpected approval-changing request", http.StatusInternalServerError)
+		}
+	}))
+	defer server.Close()
+
+	submitter := NewGitHubSubmitter(&tokenStub{token: "ghs_token"}, WithGitHubSubmitterBaseURL(server.URL))
+	result, err := submitter.SubmitReview(context.Background(), SubmitReviewRequest{
+		InstallationID:    99,
+		Repository:        "acme/repo",
+		PullNumber:        42,
+		HeadSHA:           "same-head",
+		OutputKey:         "post-approval-output",
+		ExistingReviewID:  143,
+		ExistingReviewURL: "https://github.com/acme/repo/pull/42#pullrequestreview-143",
+		Decision:          SubmitReviewDecisionBlocked,
+		PreviousDecision:  SubmitReviewDecisionApproved,
+		PreviousDecidedAt: previousDecidedAt,
+		PreviousBody:      "143 Code Reviewer approved this PR.",
+		Body:              "143 Code Reviewer did not approve this follow-up review.",
+	})
+
+	require.NoError(t, err, "a non-approving follow-up should update the review without changing its approval state")
+	require.Equal(t, int64(143), result.ID, "follow-up should retain the approved GitHub review id")
+	require.Equal(t, map[string]any{
+		"body": withCodeReviewOutputMarker(
+			withCodeReviewHistory(
+				"143 Code Reviewer did not approve this follow-up review.",
+				"143 Code Reviewer approved this PR.",
+				SubmitReviewDecisionApproved,
+				previousDecidedAt,
+			),
+			"post-approval-output",
+		),
+	}, reviewUpdate, "follow-up should send only a body update and no approval-changing review event")
+}
+
 func TestGitHubSubmitter_SubmitReviewPromotesUpdatedAssessmentWithFormalApproval(t *testing.T) {
 	t.Parallel()
 

--- a/internal/services/codereview/service.go
+++ b/internal/services/codereview/service.go
@@ -451,13 +451,6 @@ func (s *Service) HandleReviewRequested(ctx context.Context, input ReviewRequest
 	if !ok {
 		return ReviewRequestedResult{IgnoredReason: "reviewer_not_configured"}, nil
 	}
-	approved, err := s.metadata.HasApprovedByPullRequest(ctx, input.OrgID, input.PullRequestID)
-	if err != nil {
-		return ReviewRequestedResult{}, fmt.Errorf("check prior code review approval: %w", err)
-	}
-	if approved {
-		return ReviewRequestedResult{IgnoredReason: "already_approved", TriggerSource: source}, nil
-	}
 	deliveryID := strings.TrimSpace(input.DeliveryID)
 	if deliveryID == "" {
 		s.logger.Warn().
@@ -484,6 +477,9 @@ func (s *Service) HandleReviewRequested(ctx context.Context, input ReviewRequest
 		changeKey:               changeKey,
 		changeReason:            explicitReviewRequestChangeReason,
 		previousOutputKey:       submitted.ReviewOutputKey,
+		previousReviewDecision:  submitted.Decision,
+		previousReviewDecidedAt: submitted.CompletedAt,
+		previousReviewBody:      submitted.FinalReviewBody,
 		existingGitHubReviewID:  submitted.GitHubReviewID,
 		existingGitHubReviewURL: submitted.GitHubReviewURL,
 	})
@@ -540,7 +536,7 @@ func (s *Service) QueueReviewChanged(ctx context.Context, input ReviewChangedInp
 	if err != nil {
 		return ReviewRequestedResult{}, fmt.Errorf("check prior code review approval before queueing reassessment: %w", err)
 	}
-	if approved {
+	if approved && !input.ExplicitRequest {
 		return ReviewRequestedResult{IgnoredReason: "already_approved"}, nil
 	}
 	latest, err := s.metadata.GetLatestByPullRequest(ctx, input.OrgID, input.PullRequestID)
@@ -586,7 +582,7 @@ func (s *Service) HandleReviewChanged(ctx context.Context, input ReviewChangedIn
 	if err != nil {
 		return ReviewRequestedResult{}, fmt.Errorf("check prior code review approval before reassessment: %w", err)
 	}
-	if approved {
+	if approved && !input.ExplicitRequest {
 		return ReviewRequestedResult{IgnoredReason: "already_approved"}, nil
 	}
 	latest, err := s.metadata.GetLatestByPullRequest(ctx, input.OrgID, input.PullRequestID)

--- a/internal/services/codereview/service_test.go
+++ b/internal/services/codereview/service_test.go
@@ -39,16 +39,32 @@ func TestService_HandleReviewRequested(t *testing.T) {
 			},
 		},
 		{
-			name:  "does not rereview after approval",
-			input: newReviewRequestedInput(nil),
+			name: "starts a fresh explicit review while preserving a prior approval",
+			input: newReviewRequestedInput(func(in *ReviewRequestedInput) {
+				in.DeliveryID = "delivery-after-approval"
+			}),
 			setup: func(_ *policyStub, metadata *metadataStub, _ *triggerStub) {
+				reviewID := int64(143)
+				reviewURL := "https://github.com/acme/repo/pull/42#pullrequestreview-143"
+				decision := models.CodeReviewDecisionApproved
+				decidedAt := time.Date(2026, time.July, 28, 12, 0, 0, 0, time.UTC)
+				body := "143 Code Reviewer approved this PR."
 				metadata.approved = true
+				metadata.latest = models.CodeReviewSessionMetadata{
+					ID: uuid.New(), SessionID: uuid.New(), Status: models.CodeReviewSessionStatusCompleted,
+					Decision: &decision, CompletedAt: &decidedAt, FinalReviewBody: &body,
+					ReviewOutputKey: "approved-output", GitHubReviewID: &reviewID, GitHubReviewURL: &reviewURL,
+				}
 			},
-			expected: func(t *testing.T, result ReviewRequestedResult, _ *policyStub, _ *metadataStub, sessions *sessionStub, jobs *jobStub) {
-				require.False(t, result.Processed, "approved pull request should not be reviewed again")
-				require.Equal(t, "already_approved", result.IgnoredReason, "rerequest should preserve the existing approval")
-				require.Equal(t, 0, sessions.createCalls, "approved rerequest should not create a new session")
-				require.Equal(t, 0, jobs.enqueueCalls, "approved rerequest should not enqueue new review work")
+			expected: func(t *testing.T, result ReviewRequestedResult, _ *policyStub, metadata *metadataStub, sessions *sessionStub, jobs *jobStub) {
+				require.True(t, result.Processed, "explicit rerequest should be accepted after approval")
+				require.False(t, result.Reused, "new delivery should create a distinct post-approval assessment")
+				require.Equal(t, 1, sessions.createCalls, "approved rerequest should create a new session")
+				require.Equal(t, 1, jobs.enqueueCalls, "approved rerequest should enqueue new review work")
+				require.Equal(t, metadata.latest.GitHubReviewID, jobs.payload.ExistingGitHubReviewID, "rerequest should retain the approved GitHub review instead of replacing it")
+				require.Equal(t, metadata.latest.Decision, jobs.payload.PreviousReviewDecision, "rerequest should preserve the prior approval in visible review history")
+				require.Equal(t, metadata.latest.CompletedAt, jobs.payload.PreviousReviewDecidedAt, "rerequest should preserve when the prior approval completed")
+				require.Equal(t, metadata.latest.FinalReviewBody, jobs.payload.PreviousReviewBody, "rerequest should preserve the prior approval body")
 			},
 		},
 		{
@@ -656,12 +672,14 @@ func TestService_HandleReviewChanged(t *testing.T) {
 			setup: func(metadata *metadataStub, sessions *sessionStub) {
 				reviewID := int64(143)
 				reviewURL := "https://github.com/acme/repo/pull/42#pullrequestreview-143"
+				decision := models.CodeReviewDecisionApproved
 				metadata.latest = models.CodeReviewSessionMetadata{
 					ID: uuid.New(), SessionID: uuid.New(), HeadSHA: "head",
 					TriggerSource: models.CodeReviewTriggerSourceAppReviewer,
 					Status:        models.CodeReviewSessionStatusCompleted, ReviewOutputKey: "newer-output-key",
-					GitHubReviewID: &reviewID, GitHubReviewURL: &reviewURL,
+					Decision: &decision, GitHubReviewID: &reviewID, GitHubReviewURL: &reviewURL,
 				}
+				metadata.approved = true
 				sessions.getResult = models.Session{RevisionContext: json.RawMessage(`{"pull_request_author":"anya"}`)}
 			},
 			mutateInput: func(input *ReviewChangedInput) {
@@ -681,6 +699,7 @@ func TestService_HandleReviewChanged(t *testing.T) {
 				require.Contains(t, jobs.payload.OutputKey, ":review-request:", "explicit delivery should retain its policy-independent identity")
 				require.Equal(t, "143-code-reviewer", jobs.payload.RequestedTeamSlug, "explicit request should carry team cleanup context into the worker")
 				require.Equal(t, metadata.latest.GitHubReviewID, jobs.payload.ExistingGitHubReviewID, "explicit request should update the persistent GitHub review")
+				require.Equal(t, metadata.latest.Decision, jobs.payload.PreviousReviewDecision, "explicit request should retain the prior approval as history")
 			},
 		},
 		{
@@ -774,6 +793,7 @@ func TestService_QueueReviewChanged(t *testing.T) {
 	tests := []struct {
 		name          string
 		setup         func(*metadataStub)
+		explicit      bool
 		expectedQueue bool
 		expectedWhy   string
 	}{
@@ -795,6 +815,15 @@ func TestService_QueueReviewChanged(t *testing.T) {
 			},
 			expectedWhy: "already_approved",
 		},
+		{
+			name: "queues an explicit rerequest after approval",
+			setup: func(metadata *metadataStub) {
+				metadata.approved = true
+				metadata.latest = models.CodeReviewSessionMetadata{ID: uuid.New(), SessionID: uuid.New(), Status: models.CodeReviewSessionStatusCompleted}
+			},
+			explicit:      true,
+			expectedQueue: true,
+		},
 	}
 
 	for _, tt := range tests {
@@ -808,6 +837,7 @@ func TestService_QueueReviewChanged(t *testing.T) {
 			jobs := &jobStub{jobID: uuid.New()}
 			svc := NewService(newPolicyStub(), metadata, &sessionStub{}, jobs, zerolog.Nop(), Config{})
 			input := newReviewChangedInput()
+			input.ExplicitRequest = tt.explicit
 
 			result, err := svc.QueueReviewChanged(context.Background(), input)
 


### PR DESCRIPTION
## Summary
- Allow explicit review requests to start a new assessment after approval
- Preserve the existing GitHub approval and include it in follow-up review history
- Keep automatic reassessments suppressed after approval

## Testing
- Added unit coverage for explicit post-approval requests and preserved GitHub review state