### PR TITLE
Let preview cache saves and snapshots actually complete

### DIFF
--- a/internal/services/preview/dependency_cache.go
+++ b/internal/services/preview/dependency_cache.go
@@ -189,7 +189,11 @@ type SharedDependencyCache struct {
 	localMaxBytes int64
 }
 
-type dependencyCacheStdinExecutor interface {
+// sandboxStdinExecutor is the optional streaming-stdin capability a
+// SnapshotExecutor may also implement. Both the dependency cache and the
+// snapshot cache need it to pipe an archive into a sandbox-side `tar xf -`
+// without staging the blob on the sandbox filesystem first.
+type sandboxStdinExecutor interface {
 	ExecWithStdin(ctx context.Context, sb *agent.Sandbox, cmd string, stdin io.Reader, stdout, stderr io.Writer) (int, error)
 }
 
@@ -865,7 +869,7 @@ func dependencyCacheArchiveNameMatchesPath(name, allowed string) bool {
 }
 
 func (c *SharedDependencyCache) extractSandboxArchive(ctx context.Context, sb *agent.Sandbox, root models.PreviewCacheRoot, reader io.Reader, stderr io.Writer) (int, error) {
-	executor, ok := c.executor.(dependencyCacheStdinExecutor)
+	executor, ok := c.executor.(sandboxStdinExecutor)
 	if !ok {
 		return -1, fmt.Errorf("executor does not support streaming dependency cache restore")
 	}

--- a/internal/services/preview/dependency_cache.go
+++ b/internal/services/preview/dependency_cache.go
@@ -766,7 +766,7 @@ func (c *SharedDependencyCache) stageSandboxArchiveAttempt(ctx context.Context, 
 		// next launch to rebuild cold.
 		c.logger.Warn().
 			Int("exit_code", exitCode).
-			Str("stderr", dependencyCacheStderrSuffix(stderr.String())).
+			Str("stderr", strings.TrimPrefix(dependencyCacheStderrSuffix(stderr.String()), ": ")).
 			Msg("preview cache archive completed with warnings from a live workspace; keeping it")
 	}
 	if gzErr != nil {

--- a/internal/services/preview/dependency_cache.go
+++ b/internal/services/preview/dependency_cache.go
@@ -484,7 +484,12 @@ func (c *SharedDependencyCache) SavePathCache(ctx context.Context, sb *agent.San
 	// compressor off the memory-capped, shared session sandbox trims the
 	// sandbox-side work at save time. The stored blob is still gzip (.tar.gz), so
 	// restore (`tar xzf`) and validation are unchanged.
-	archiveCmd := fmt.Sprintf("cd %s && tar cf - %s-- %s", shellQuote(rootDir), excludeExpr, strings.Join(args, " "))
+	//
+	// --ignore-failed-read keeps a file that disappears mid-walk from aborting
+	// the archive. Saves run against a workspace that is still serving, so a dev
+	// server rotating a log or a build tool sweeping its scratch dir is routine;
+	// tar still exits 1, which stageSandboxArchiveAttempt tolerates.
+	archiveCmd := fmt.Sprintf("cd %s && tar cf - --ignore-failed-read %s-- %s", shellQuote(rootDir), excludeExpr, strings.Join(args, " "))
 	staged, err := c.stageSandboxArchive(ctx, sb, archiveCmd)
 	if err != nil {
 		return DependencyCacheSaveResult{}, err
@@ -748,9 +753,21 @@ func (c *SharedDependencyCache) stageSandboxArchiveAttempt(ctx context.Context, 
 	exitCode, execErr := c.executor.Exec(ctx, sb, archiveCmd, gzw, &stderr)
 	gzErr := gzw.Close()
 	closeErr := file.Close()
-	if execErr != nil || exitCode != 0 {
+	if execErr != nil || !tarExitTolerable(exitCode) {
 		_ = os.RemoveAll(dir)
 		return nil, exitCode, fmt.Errorf("dependency cache save: %w", dependencyCacheExecError("archive stream", exitCode, execErr, stderr.String()))
+	}
+	if exitCode != 0 {
+		// Build-cache saves run against a workspace that is still serving: the
+		// dev server writes logs and the build tool churns its own cache while
+		// tar reads them, and tar exits 1 for that. The archive is complete, and
+		// validateDependencyCacheArchive still checks its structure downstream,
+		// so keeping it is strictly better than dropping the save and forcing the
+		// next launch to rebuild cold.
+		c.logger.Warn().
+			Int("exit_code", exitCode).
+			Str("stderr", dependencyCacheStderrSuffix(stderr.String())).
+			Msg("preview cache archive completed with warnings from a live workspace; keeping it")
 	}
 	if gzErr != nil {
 		_ = os.RemoveAll(dir)

--- a/internal/services/preview/dependency_cache_reliability_test.go
+++ b/internal/services/preview/dependency_cache_reliability_test.go
@@ -117,6 +117,27 @@ func TestStageSandboxArchive_RetriesTransientArchiveFailure(t *testing.T) {
 	require.Equal(t, 2, countCalls(exec.calls(), "tar cf -"), "archive should run twice: one transient failure then a success")
 }
 
+// Cache saves archive a workspace that is still serving, so files move under
+// tar as it reads them and tar exits 1. The archive is complete, so keeping it
+// beats dropping the save and making the next launch rebuild cold — which is
+// how the build cache went stale in the first place.
+func TestStageSandboxArchive_KeepsArchiveWhenFilesChangedUnderTar(t *testing.T) {
+	t.Parallel()
+	base := &dependencyCacheExec{payload: makeDependencyCacheTarGz(t, map[string]string{"node_modules/.bin/next": "next"})}
+	exec := newScriptedExec(base)
+	exec.script("tar cf -", scriptedResponse{
+		exitCode: 1,
+		stderr:   "tar: node_modules/.cache/x: file changed as we read it",
+	})
+	cache := newReliabilityTestCache(t, exec)
+
+	blob, err := cache.stageSandboxArchive(context.Background(), &agent.Sandbox{WorkDir: "/workspace/repo"}, "cd '/workspace/repo' && tar cf - -- 'node_modules'")
+	require.NoError(t, err, "a live workspace must not cost us the cache save")
+	require.NotNil(t, blob, "the completed archive should still be staged")
+	defer blob.cleanup()
+	require.Equal(t, 1, countCalls(exec.calls(), "tar cf -"), "a tolerated warning is not a retry case")
+}
+
 // A deterministic archive failure (exit 2) is not retried and surfaces the
 // sandbox stderr instead of a bare "exited 2" with no diagnostic.
 func TestStageSandboxArchive_SurfacesStderrAndDoesNotRetryDeterministicFailure(t *testing.T) {

--- a/internal/services/preview/manager.go
+++ b/internal/services/preview/manager.go
@@ -1701,6 +1701,53 @@ func (m *Manager) StopPreview(ctx context.Context, orgID, previewID uuid.UUID) e
 	return m.StopPreviewWithReason(ctx, orgID, previewID, models.PreviewStoppedReasonNone)
 }
 
+// PreviewStopInteractiveWaitCap bounds how long a stop with a human waiting on
+// it may block on in-flight cache uploads before tearing the sandbox down.
+//
+// StopPreview is reachable synchronously from the DELETE preview handlers, and
+// app->worker RPCs give up at previewWorkerHTTPTimeout (10 minutes) — the same
+// as the provider's full background budget. Spending that budget on a user's
+// stop would hang the request until the client timed out and then report a
+// failed stop for one that actually succeeded.
+//
+// A few seconds still lets a nearly-finished upload land. Beyond that the cache
+// save is best-effort on this path: losing it costs the next launch a rebuild,
+// which is cheaper than making someone wait out an upload they did not ask for.
+const PreviewStopInteractiveWaitCap = 15 * time.Second
+
+// PreviewStopBackgroundWaiter is implemented by providers that can bound how
+// long StopPreview blocks on post-ready cache uploads. Providers without it get
+// the default budget.
+type PreviewStopBackgroundWaiter interface {
+	StopPreviewWithBackgroundWait(ctx context.Context, handle string, backgroundWait time.Duration) error
+}
+
+// stopBackgroundWaitForReason picks how long the provider may block awaiting
+// in-flight cache uploads before tearing the sandbox down.
+//
+// Prewarm stops exist purely to leave a warm cache behind: nothing is waiting on
+// them, and cutting them short is what left build caches frozen for days. Every
+// other reason can have a human attached — the DELETE preview handlers call this
+// synchronously — so those take the short budget. Cutting an upload short there
+// costs the next launch a rebuild; making a user wait ten minutes for a stop
+// (and then fail, since app->worker RPCs give up at the same ten minutes) costs
+// more.
+func stopBackgroundWaitForReason(reason models.PreviewStoppedReason) time.Duration {
+	switch reason {
+	case models.PreviewStoppedReasonWarmPolicy, models.PreviewStoppedReasonSessionPrewarmPolicy:
+		return 0 // provider default: the full background budget
+	default:
+		return PreviewStopInteractiveWaitCap
+	}
+}
+
+func (m *Manager) stopViaProvider(ctx context.Context, handle string, reason models.PreviewStoppedReason) error {
+	if waiter, ok := m.provider.(PreviewStopBackgroundWaiter); ok {
+		return waiter.StopPreviewWithBackgroundWait(ctx, handle, stopBackgroundWaitForReason(reason))
+	}
+	return m.provider.StopPreview(ctx, handle)
+}
+
 // StopPreviewWithReason stops a preview, records a stop cause when supplied,
 // and revokes all access sessions.
 func (m *Manager) StopPreviewWithReason(ctx context.Context, orgID, previewID uuid.UUID, reason models.PreviewStoppedReason) error {
@@ -1723,9 +1770,11 @@ func (m *Manager) StopPreviewWithReason(ctx context.Context, orgID, previewID uu
 	}
 	m.pollStopMu.Unlock()
 
-	// Stop via provider.
+	// Stop via provider. The provider blocks on in-flight cache uploads before
+	// tearing the sandbox down; how long it may block depends on who is waiting
+	// (see stopBackgroundWaitForReason).
 	if instance.PreviewHandle != "" && m.provider != nil {
-		if err := m.provider.StopPreview(ctx, instance.PreviewHandle); err != nil {
+		if err := m.stopViaProvider(ctx, instance.PreviewHandle, reason); err != nil {
 			m.logger.Error().Err(err).
 				Str("preview_id", previewID.String()).
 				Str("handle", instance.PreviewHandle).

--- a/internal/services/preview/manager.go
+++ b/internal/services/preview/manager.go
@@ -1715,6 +1715,15 @@ func (m *Manager) StopPreview(ctx context.Context, orgID, previewID uuid.UUID) e
 // which is cheaper than making someone wait out an upload they did not ask for.
 const PreviewStopInteractiveWaitCap = 15 * time.Second
 
+// PreviewStopUseProviderBackgroundBudget asks the provider for its full
+// background-work budget rather than naming a duration here. The budget itself
+// lives in the providers package, which imports this one, so it cannot be
+// referenced from this side — hence a sentinel rather than the value.
+//
+// Note this is the opposite of what a bare 0 suggests: it means "wait as long
+// as you normally would", not "do not wait".
+const PreviewStopUseProviderBackgroundBudget time.Duration = 0
+
 // PreviewStopBackgroundWaiter is implemented by providers that can bound how
 // long StopPreview blocks on post-ready cache uploads. Providers without it get
 // the default budget.
@@ -1735,7 +1744,7 @@ type PreviewStopBackgroundWaiter interface {
 func stopBackgroundWaitForReason(reason models.PreviewStoppedReason) time.Duration {
 	switch reason {
 	case models.PreviewStoppedReasonWarmPolicy, models.PreviewStoppedReasonSessionPrewarmPolicy:
-		return 0 // provider default: the full background budget
+		return PreviewStopUseProviderBackgroundBudget
 	default:
 		return PreviewStopInteractiveWaitCap
 	}

--- a/internal/services/preview/manager.go
+++ b/internal/services/preview/manager.go
@@ -702,7 +702,7 @@ func (m *Manager) LaunchPreview(ctx context.Context, instance *models.PreviewIns
 	}
 	if err != nil {
 		m.logger.Error().Err(err).Str("preview_id", instance.ID.String()).Msg("failed to update handle in DB, stopping provider")
-		_ = m.provider.StopPreview(ctx, handle.Handle)
+		_ = m.stopViaProviderPrompt(ctx, handle.Handle)
 		return nil, fmt.Errorf("persist preview handle: %w", err)
 	}
 	if stopResourceSampler != nil {
@@ -722,7 +722,7 @@ func (m *Manager) LaunchPreview(ctx context.Context, instance *models.PreviewIns
 		// Preview was stopped concurrently — clean up the provider.
 		m.logger.Warn().Str("preview_id", instance.ID.String()).Msg("preview was stopped during startup, cleaning up provider")
 		m.stopPreviewResourceSampler(instance.ID)
-		_ = m.provider.StopPreview(ctx, handle.Handle)
+		_ = m.stopViaProviderPrompt(ctx, handle.Handle)
 		return nil, fmt.Errorf("preview was stopped concurrently during startup")
 	}
 	instance.Status = nextStatus
@@ -1748,6 +1748,15 @@ func (m *Manager) stopViaProvider(ctx context.Context, handle string, reason mod
 	return m.provider.StopPreview(ctx, handle)
 }
 
+// stopViaProviderPrompt tears a provider preview down without waiting out an
+// in-flight cache upload. It is for the paths that have no stop reason to
+// consult — launch and recycle cleanups, and the warm-resume failure path —
+// all of which run inside a request a caller is blocked on. Everything except
+// a prewarm stop wants this; see stopBackgroundWaitForReason.
+func (m *Manager) stopViaProviderPrompt(ctx context.Context, handle string) error {
+	return m.stopViaProvider(ctx, handle, models.PreviewStoppedReasonNone)
+}
+
 // StopPreviewWithReason stops a preview, records a stop cause when supplied,
 // and revokes all access sessions.
 func (m *Manager) StopPreviewWithReason(ctx context.Context, orgID, previewID uuid.UUID, reason models.PreviewStoppedReason) error {
@@ -2258,7 +2267,7 @@ func (m *Manager) ResumeStoppedWarmPreview(ctx context.Context, orgID, previewID
 	}
 	if err != nil {
 		m.logger.Error().Err(err).Msg("warm resume: failed to update handle, stopping new preview")
-		if stopErr := m.provider.StopPreview(ctx, handle.Handle); stopErr != nil {
+		if stopErr := m.stopViaProviderPrompt(ctx, handle.Handle); stopErr != nil {
 			m.logger.Warn().Err(stopErr).Str("preview_id", previewID.String()).Msg("warm resume: failed to stop preview after handle persistence error")
 		}
 		if statusErr := m.store.UpdatePreviewStatus(ctx, orgID, previewID, models.PreviewStatusFailed, "warm resume failed: could not persist new handle"); statusErr != nil {
@@ -2576,7 +2585,7 @@ func (m *Manager) recyclePreview(ctx context.Context, orgID, previewID uuid.UUID
 
 	// Stop current processes via provider.
 	if instance.PreviewHandle != "" && m.provider != nil {
-		if err := m.provider.StopPreview(ctx, instance.PreviewHandle); err != nil {
+		if err := m.stopViaProviderPrompt(ctx, instance.PreviewHandle); err != nil {
 			m.logger.Warn().Err(err).Str("preview_id", previewID.String()).Msg("recycle: provider stop failed")
 		}
 	}
@@ -2639,7 +2648,7 @@ func (m *Manager) recyclePreview(ctx context.Context, orgID, previewID uuid.UUID
 	}
 	if err != nil {
 		m.logger.Error().Err(err).Msg("recycle: failed to update handle, stopping new preview")
-		_ = m.provider.StopPreview(ctx, handle.Handle)
+		_ = m.stopViaProviderPrompt(ctx, handle.Handle)
 		if statusErr := m.store.UpdatePreviewStatus(ctx, orgID, previewID, models.PreviewStatusFailed, "recycle failed: could not persist new handle"); statusErr != nil {
 			m.logger.Warn().Err(statusErr).Msg("recycle: failed to set failed status after handle update error")
 		}

--- a/internal/services/preview/manager_test.go
+++ b/internal/services/preview/manager_test.go
@@ -4295,3 +4295,65 @@ func TestSoftRestartPreview_StampsRecycleRevisionSource(t *testing.T) {
 	require.True(t, provider.restarted, "provider soft restart should be invoked")
 	require.NoError(t, mock.ExpectationsWereMet(), "soft restart must stamp the recycle revision source before restarting")
 }
+
+// stopWaitRecorder captures the background-wait budget the manager hands the
+// provider for a given stop reason.
+type stopWaitRecorder struct {
+	PreviewCapableProvider
+	gotWait time.Duration
+	called  bool
+}
+
+func (s *stopWaitRecorder) StopPreviewWithBackgroundWait(_ context.Context, _ string, backgroundWait time.Duration) error {
+	s.called = true
+	s.gotWait = backgroundWait
+	return nil
+}
+
+// Prewarm stops exist to leave a warm cache behind and nothing is waiting on
+// them, so they get the provider's full budget (signalled as 0). Every other
+// reason can have a user on the end of a synchronous DELETE, and the app->worker
+// RPC gives up at 10 minutes — the same as the full budget — so those must be
+// capped well short of it.
+func TestStopBackgroundWaitForReason(t *testing.T) {
+	t.Parallel()
+
+	for _, reason := range []models.PreviewStoppedReason{
+		models.PreviewStoppedReasonWarmPolicy,
+		models.PreviewStoppedReasonSessionPrewarmPolicy,
+	} {
+		require.Zero(t, stopBackgroundWaitForReason(reason),
+			"%q is a prewarm stop and must get the provider's full background budget", reason)
+	}
+
+	for _, reason := range []models.PreviewStoppedReason{
+		models.PreviewStoppedReasonUser,
+		models.PreviewStoppedReasonExpired,
+		models.PreviewStoppedReasonPRClosed,
+		models.PreviewStoppedReasonDrain,
+		models.PreviewStoppedReasonError,
+		models.PreviewStoppedReasonNone,
+	} {
+		got := stopBackgroundWaitForReason(reason)
+		require.Equal(t, PreviewStopInteractiveWaitCap, got,
+			"%q may have a caller waiting and must not use the full budget", reason)
+		require.Less(t, got, time.Minute,
+			"%q must stay far below the app->worker RPC timeout", reason)
+	}
+}
+
+// The manager must actually route through the bounded call when the provider
+// supports it, or the reason-based budget above is dead code.
+func TestManager_StopViaProviderUsesReasonBudget(t *testing.T) {
+	t.Parallel()
+
+	recorder := &stopWaitRecorder{}
+	m := &Manager{provider: recorder, logger: zerolog.Nop()}
+
+	require.NoError(t, m.stopViaProvider(context.Background(), "handle-1", models.PreviewStoppedReasonUser))
+	require.True(t, recorder.called, "a capable provider should receive the bounded stop")
+	require.Equal(t, PreviewStopInteractiveWaitCap, recorder.gotWait, "a user stop should be capped")
+
+	require.NoError(t, m.stopViaProvider(context.Background(), "handle-1", models.PreviewStoppedReasonWarmPolicy))
+	require.Zero(t, recorder.gotWait, "a warm-policy stop should get the full budget")
+}

--- a/internal/services/preview/manager_test.go
+++ b/internal/services/preview/manager_test.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -4356,4 +4357,31 @@ func TestManager_StopViaProviderUsesReasonBudget(t *testing.T) {
 
 	require.NoError(t, m.stopViaProvider(context.Background(), "handle-1", models.PreviewStoppedReasonWarmPolicy))
 	require.Zero(t, recorder.gotWait, "a warm-policy stop should get the full budget")
+}
+
+// Only prewarm stops may wait out an in-flight cache upload; every other path
+// runs inside a request someone is blocked on. That is easy to undo by calling
+// the provider directly, so assert the funnel holds: the sole permitted
+// m.provider.StopPreview call is the fallback inside stopViaProvider itself.
+func TestManagerRoutesProviderStopsThroughWaitBudget(t *testing.T) {
+	t.Parallel()
+
+	src, err := os.ReadFile("manager.go")
+	require.NoError(t, err, "manager.go should be readable")
+
+	var offenders []int
+	inFunnel := false
+	for i, line := range strings.Split(string(src), "\n") {
+		if strings.HasPrefix(line, "func (m *Manager) stopViaProvider(") {
+			inFunnel = true
+		} else if strings.HasPrefix(line, "func ") {
+			inFunnel = false
+		}
+		if !inFunnel && strings.Contains(line, "m.provider.StopPreview(") {
+			offenders = append(offenders, i+1)
+		}
+	}
+	require.Emptyf(t, offenders,
+		"manager.go:%v calls m.provider.StopPreview directly, which takes the full 10-minute "+
+			"background budget; use stopViaProvider or stopViaProviderPrompt instead", offenders)
 }

--- a/internal/services/preview/providers/docker_preview.go
+++ b/internal/services/preview/providers/docker_preview.go
@@ -842,10 +842,26 @@ func previewConfigHasInitScripts(cfg *models.PreviewConfig) bool {
 
 // previewStopBackgroundWaitCap bounds how long StopPreview blocks on background
 // work — chiefly the post-ready build-cache uploads it deliberately awaits so a
-// prewarm persists its cache. It sits below the saves' own 10-minute timeout so
-// an interactive stop can't hang on a wedged blob store, yet is generous enough
-// that a normal prewarm save (seconds) completes.
-const previewStopBackgroundWaitCap = 3 * time.Minute
+// prewarm persists its cache. It sits below the saves' own previewCacheSaveTimeout
+// so an interactive stop can't hang on a wedged blob store.
+//
+// The cap must exceed how long a real save takes, or a warm-policy launch — which
+// calls StopPreview the instant the preview is ready — tears the sandbox down
+// mid-archive and the save can never land. At 3 minutes that is exactly what
+// happened: saves of a large monorepo's build tree run 150-330s, so ~88% were
+// killed by teardown (the exec surfaces it as exit 128, or 137 when the SIGKILL
+// wins the race) and the cached blob stayed frozen at whatever content last
+// managed to save. Every subsequent launch then restored a stale cache and
+// rebuilt from near-scratch. 10 minutes clears the observed distribution with
+// headroom.
+const previewStopBackgroundWaitCap = 10 * time.Minute
+
+// previewCacheSaveTimeout is each cache save's own self-timeout, detached from
+// the launch ctx. It stays above previewStopBackgroundWaitCap so the stop path
+// is what gives up first: a save that outlives the cap is abandoned by
+// StopPreview but still gets a window to finish on its own rather than being
+// cancelled at the exact moment the waiter stops watching.
+const previewCacheSaveTimeout = 15 * time.Minute
 
 // waitForGroupBounded blocks until wg is done, ctx is cancelled, or maxWait
 // elapses — whichever first — returning a non-nil error only when it gives up
@@ -1767,7 +1783,7 @@ func (d *DockerPreviewProvider) savePackageManagerCache(ctx context.Context, sta
 		Lockfiles:       lockfiles,
 	}
 	save := func() {
-		saveCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 10*time.Minute)
+		saveCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), previewCacheSaveTimeout)
 		defer cancel()
 		started := time.Now()
 		result, err := pathCache.SavePathCache(saveCtx, state.sandbox, preview.PreviewPathCacheSaveSpec{
@@ -1823,7 +1839,7 @@ func (d *DockerPreviewProvider) saveDependencyCache(ctx context.Context, state *
 	// invalidation independent.
 	excludePaths, _ := preview.ResolvePreviewBuildCachePaths(install)
 	save := func() {
-		saveCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 10*time.Minute)
+		saveCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), previewCacheSaveTimeout)
 		defer cancel()
 		started := time.Now()
 		pathCache, hasPathCache := d.dependencyCache.(preview.PreviewPathCache)
@@ -2153,7 +2169,7 @@ func (d *DockerPreviewProvider) saveBuildCacheSet(ctx context.Context, state *pr
 		InstallCommand: append([]string(nil), install.Command...),
 		EffectivePaths: append([]string(nil), paths...),
 	}
-	saveCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 10*time.Minute)
+	saveCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), previewCacheSaveTimeout)
 	defer cancel()
 	started := time.Now()
 	result, err := pathCache.SavePathCache(saveCtx, state.sandbox, preview.PreviewPathCacheSaveSpec{

--- a/internal/services/preview/providers/docker_preview.go
+++ b/internal/services/preview/providers/docker_preview.go
@@ -917,6 +917,8 @@ func (d *DockerPreviewProvider) StopPreviewWithBackgroundWait(ctx context.Contex
 		return nil // already stopped — idempotent
 	}
 
+	// A non-positive budget is the caller asking for the default, not for zero
+	// wait (preview.PreviewStopUseProviderBackgroundBudget).
 	if backgroundWait <= 0 {
 		backgroundWait = previewStopBackgroundWaitCap
 	}

--- a/internal/services/preview/providers/docker_preview.go
+++ b/internal/services/preview/providers/docker_preview.go
@@ -842,8 +842,7 @@ func previewConfigHasInitScripts(cfg *models.PreviewConfig) bool {
 
 // previewStopBackgroundWaitCap bounds how long StopPreview blocks on background
 // work — chiefly the post-ready build-cache uploads it deliberately awaits so a
-// prewarm persists its cache. It sits below the saves' own previewCacheSaveTimeout
-// so an interactive stop can't hang on a wedged blob store.
+// prewarm persists its cache.
 //
 // The cap must exceed how long a real save takes, or a warm-policy launch — which
 // calls StopPreview the instant the preview is ready — tears the sandbox down
@@ -854,7 +853,15 @@ func previewConfigHasInitScripts(cfg *models.PreviewConfig) bool {
 // managed to save. Every subsequent launch then restored a stale cache and
 // rebuilt from near-scratch. 10 minutes clears the observed distribution with
 // headroom.
+//
+// This is the budget for stops nobody is waiting on — a prewarm job whose whole
+// purpose is to leave a warm cache behind. Interactive stops use
+// PreviewStopInteractiveWaitCap instead; see StopPreviewWithBackgroundWait.
 const previewStopBackgroundWaitCap = 10 * time.Minute
+
+// The interactive counterpart lives in the preview package as
+// preview.PreviewStopInteractiveWaitCap, since the manager is what selects
+// between the two and this package imports that one.
 
 // previewCacheSaveTimeout is each cache save's own self-timeout, detached from
 // the launch ctx. It bounds a save that is NOT racing a stop — an interactive
@@ -891,7 +898,17 @@ func waitForGroupBounded(ctx context.Context, wg *sync.WaitGroup, maxWait time.D
 	}
 }
 
+// StopPreview tears the preview down using the full background-work budget. It
+// is the right entry point for prewarm and other machine-driven stops; callers
+// with a human waiting should use StopPreviewWithBackgroundWait.
 func (d *DockerPreviewProvider) StopPreview(ctx context.Context, handle string) error {
+	return d.StopPreviewWithBackgroundWait(ctx, handle, previewStopBackgroundWaitCap)
+}
+
+// StopPreviewWithBackgroundWait is StopPreview with an explicit ceiling on how
+// long it blocks awaiting post-ready cache uploads, so the caller can trade
+// cache warmth against how long it is willing to make someone wait.
+func (d *DockerPreviewProvider) StopPreviewWithBackgroundWait(ctx context.Context, handle string, backgroundWait time.Duration) error {
 	d.mu.RLock()
 	state, ok := d.previews[handle]
 	d.mu.RUnlock()
@@ -900,16 +917,19 @@ func (d *DockerPreviewProvider) StopPreview(ctx context.Context, handle string) 
 		return nil // already stopped — idempotent
 	}
 
+	if backgroundWait <= 0 {
+		backgroundWait = previewStopBackgroundWaitCap
+	}
+
 	// Cancel all service goroutines and wait for background work to finish. The
 	// wait is bounded: it intentionally blocks on the post-ready build-cache
 	// uploads (so a prewarm, which stops the moment the preview is ready,
 	// persists its cache), but an interactive stop must not hang on a slow blob
-	// store. See previewStopBackgroundWaitCap for how the cap is sized against
-	// real save durations; a caller (e.g. a prewarm job) with a longer-lived ctx
-	// still gets the full cap.
+	// store. See previewStopBackgroundWaitCap and PreviewStopInteractiveWaitCap
+	// for how the two budgets are sized.
 	state.cancelFn()
 	d.terminateServiceProcesses(state)
-	if err := waitForGroupBounded(ctx, &state.wg, previewStopBackgroundWaitCap); err != nil {
+	if err := waitForGroupBounded(ctx, &state.wg, backgroundWait); err != nil {
 		d.logger.Warn().Err(err).Str("handle", handle).
 			Msg("stop preview: proceeding before background work finished; an in-flight build cache save may be aborted by teardown")
 	}

--- a/internal/services/preview/providers/docker_preview.go
+++ b/internal/services/preview/providers/docker_preview.go
@@ -899,8 +899,9 @@ func (d *DockerPreviewProvider) StopPreview(ctx context.Context, handle string) 
 	// wait is bounded: it intentionally blocks on the post-ready build-cache
 	// uploads (so a prewarm, which stops the moment the preview is ready,
 	// persists its cache), but an interactive stop must not hang on a slow blob
-	// store. The cap sits well under the saves' own 10-minute self-timeout, and a
-	// caller (e.g. a prewarm job) with a longer-lived ctx still gets the full cap.
+	// store. See previewStopBackgroundWaitCap for how the cap is sized against
+	// real save durations; a caller (e.g. a prewarm job) with a longer-lived ctx
+	// still gets the full cap.
 	state.cancelFn()
 	d.terminateServiceProcesses(state)
 	if err := waitForGroupBounded(ctx, &state.wg, previewStopBackgroundWaitCap); err != nil {

--- a/internal/services/preview/providers/docker_preview.go
+++ b/internal/services/preview/providers/docker_preview.go
@@ -857,10 +857,15 @@ func previewConfigHasInitScripts(cfg *models.PreviewConfig) bool {
 const previewStopBackgroundWaitCap = 10 * time.Minute
 
 // previewCacheSaveTimeout is each cache save's own self-timeout, detached from
-// the launch ctx. It stays above previewStopBackgroundWaitCap so the stop path
-// is what gives up first: a save that outlives the cap is abandoned by
-// StopPreview but still gets a window to finish on its own rather than being
-// cancelled at the exact moment the waiter stops watching.
+// the launch ctx. It bounds a save that is NOT racing a stop — an interactive
+// preview that keeps serving while its cache uploads — so a wedged blob store
+// cannot leak the goroutine indefinitely.
+//
+// It does not extend a save that outruns previewStopBackgroundWaitCap. Once the
+// cap expires, Manager.StopPreviewWithReason destroys the branch preview's
+// sandbox as its next step, so the archive exec dies regardless of how much of
+// this timeout is left. The cap, not this value, is what a warm-policy save has
+// to finish inside.
 const previewCacheSaveTimeout = 15 * time.Minute
 
 // waitForGroupBounded blocks until wg is done, ctx is cancelled, or maxWait

--- a/internal/services/preview/snapshot_cache.go
+++ b/internal/services/preview/snapshot_cache.go
@@ -103,12 +103,35 @@ const minSnapshotBlobBytes int64 = 1 << 20 // 1 MiB
 // exists to fix. Better to catch only the unambiguous cases.
 const snapshotShrinkRejectPercent = 25
 
+// snapshotShrinkBaselineMaxAge stops the shrink rule from wedging a cache key.
+//
+// A rejected snapshot leaves the baseline in place, and the baseline is not
+// evicted while it is being restored (LRU orders on last_used_at, which every
+// restore refreshes). So a baseline that is wrong — or a workspace that
+// genuinely did shrink fourfold — could otherwise reject its replacement
+// forever. Comparing only against a recent baseline bounds that: the rule stops
+// applying once the stored content is this old, and the next snapshot lands.
+//
+// created_at is the right clock, not last_used_at: it tracks when the content
+// was stored and stops advancing on a wedged entry, which is exactly the
+// condition we want to time out.
+const snapshotShrinkBaselineMaxAge = 7 * 24 * time.Hour
+
+// minBlobBytes is the size floor in effect, allowing tests to exercise the
+// reject paths without generating megabyte-scale fixtures.
+func (sc *SnapshotCache) minBlobBytes() int64 {
+	if sc.minSnapshotBytesOverride > 0 {
+		return sc.minSnapshotBytesOverride
+	}
+	return minSnapshotBlobBytes
+}
+
 // undersizedSnapshotReason returns a human-readable reason to discard a freshly
 // staged archive, or "" to keep it.
 func (sc *SnapshotCache) undersizedSnapshotReason(ctx context.Context, metadata SnapshotMetadata, sizeBytes int64) string {
-	if sizeBytes < minSnapshotBlobBytes {
+	if floor := sc.minBlobBytes(); sizeBytes < floor {
 		return fmt.Sprintf("archive is %d bytes, under the %d-byte floor for a workspace with dependencies installed",
-			sizeBytes, minSnapshotBlobBytes)
+			sizeBytes, floor)
 	}
 	if metadata.BaseKey == "" || sc.store == nil {
 		return ""
@@ -119,9 +142,13 @@ func (sc *SnapshotCache) undersizedSnapshotReason(ctx context.Context, metadata 
 	if err != nil || prior == nil || prior.SizeBytes <= 0 {
 		return ""
 	}
+	if age := time.Since(prior.CreatedAt); age > snapshotShrinkBaselineMaxAge {
+		return ""
+	}
 	if sizeBytes*100 < prior.SizeBytes*snapshotShrinkRejectPercent {
-		return fmt.Sprintf("archive is %d bytes, under %d%% of the %d-byte snapshot already stored for base key %s",
-			sizeBytes, snapshotShrinkRejectPercent, prior.SizeBytes, metadata.BaseKey)
+		return fmt.Sprintf("archive is %d bytes, under %d%% of the %d-byte snapshot stored for base key %s %s ago",
+			sizeBytes, snapshotShrinkRejectPercent, prior.SizeBytes, metadata.BaseKey,
+			time.Since(prior.CreatedAt).Round(time.Minute))
 	}
 	return ""
 }
@@ -226,6 +253,10 @@ type SnapshotCache struct {
 	workerNodeID  string
 	cacheDir      string // local disk path for snapshot storage, e.g. /var/cache/143-preview
 	maxCacheBytes int64  // default 20 GB
+	// minSnapshotBytesOverride replaces minSnapshotBlobBytes when positive. Only
+	// tests set it, so they can drive the reject paths with byte-scale fixtures
+	// instead of allocating and streaming a megabyte per case.
+	minSnapshotBytesOverride int64
 }
 
 // SnapshotCacheConfig holds initialization options for SnapshotCache.
@@ -316,7 +347,9 @@ func ComputeSnapshotBaseKey(lockfileContents []byte, configDigest string) string
 // =============================================================================
 
 // CreateSnapshot archives the sandbox workspace into a tar.gz on the worker's
-// local disk and records the metadata in the database.
+// local disk and records the metadata in the database. It returns the stored
+// blob's size so the caller can report it alongside the outcome; the size is
+// zero whenever nothing was stored.
 //
 // This should be called after a preview has started successfully. The snapshot
 // captures the fully-built workspace (installed dependencies, compiled assets,
@@ -330,7 +363,7 @@ func (sc *SnapshotCache) CreateSnapshot(
 	snapshotKey string,
 	metadata SnapshotMetadata,
 	excludePaths []string,
-) error {
+) (int64, error) {
 	log := sc.logger.With().
 		Str("snapshot_key", snapshotKey).
 		Str("sandbox_id", sb.ID).
@@ -378,15 +411,15 @@ func (sc *SnapshotCache) CreateSnapshot(
 
 	blobPath, err := sc.blobPath(snapshotKey)
 	if err != nil {
-		return fmt.Errorf("snapshot create: %w", err)
+		return 0, fmt.Errorf("snapshot create: %w", err)
 	}
 	if err := os.MkdirAll(filepath.Dir(blobPath), 0o750); err != nil {
-		return fmt.Errorf("snapshot create: mkdir: %w", err)
+		return 0, fmt.Errorf("snapshot create: mkdir: %w", err)
 	}
 
 	tmp, err := os.CreateTemp(filepath.Dir(blobPath), ".snapshot-*.tmp")
 	if err != nil {
-		return fmt.Errorf("snapshot create: temp file: %w", err)
+		return 0, fmt.Errorf("snapshot create: temp file: %w", err)
 	}
 	tmpPath := tmp.Name()
 	cleanupTmp := func() {
@@ -417,13 +450,13 @@ func (sc *SnapshotCache) CreateSnapshot(
 	// would otherwise bury the real reason ("too large") under tar's downstream
 	// complaint about a broken pipe.
 	if counter.exceeded {
-		return fmt.Errorf("snapshot create: tar too large (>%d bytes max)", maxCreateBlobBytes)
+		return 0, fmt.Errorf("snapshot create: tar too large (>%d bytes max)", maxCreateBlobBytes)
 	}
 	if err != nil {
-		return fmt.Errorf("snapshot create: stream tar from sandbox: %w", err)
+		return 0, fmt.Errorf("snapshot create: stream tar from sandbox: %w", err)
 	}
 	if !tarExitTolerable(exitCode) {
-		return fmt.Errorf("snapshot create: tar exited %d: %s", exitCode, tarStderr.String())
+		return 0, fmt.Errorf("snapshot create: tar exited %d: %s", exitCode, tarStderr.String())
 	}
 	if exitCode != 0 {
 		// Keep the archive but make the compromise visible: these are the files
@@ -448,14 +481,14 @@ func (sc *SnapshotCache) CreateSnapshot(
 			Int64("size_bytes", sizeBytes).
 			Str("reason", reason).
 			Msg("refusing to store an implausibly small snapshot")
-		return fmt.Errorf("snapshot create: %w: %s", ErrSnapshotTooSmall, reason)
+		return 0, fmt.Errorf("snapshot create: %w: %s", ErrSnapshotTooSmall, reason)
 	}
 
 	if err := os.Chmod(tmpPath, 0o600); err != nil {
-		return fmt.Errorf("snapshot create: chmod: %w", err)
+		return 0, fmt.Errorf("snapshot create: chmod: %w", err)
 	}
 	if err := os.Rename(tmpPath, blobPath); err != nil {
-		return fmt.Errorf("snapshot create: rename temp to final: %w", err)
+		return 0, fmt.Errorf("snapshot create: rename temp to final: %w", err)
 	}
 	// Rename succeeded — prevent deferred cleanup from removing the final file.
 	tmpPath = ""
@@ -466,7 +499,7 @@ func (sc *SnapshotCache) CreateSnapshot(
 		// If checksum write fails, remove the blob so future lookups don't
 		// return an unverifiable entry.
 		_ = os.Remove(blobPath)
-		return fmt.Errorf("snapshot create: write checksum: %w", err)
+		return 0, fmt.Errorf("snapshot create: write checksum: %w", err)
 	}
 
 	// 4. Record in database.
@@ -483,7 +516,7 @@ func (sc *SnapshotCache) CreateSnapshot(
 	if err := sc.store.UpsertStartupCache(ctx, entry); err != nil {
 		// Best-effort cleanup of the blob if DB write fails.
 		_ = os.Remove(blobPath)
-		return fmt.Errorf("snapshot create: upsert db: %w", err)
+		return 0, fmt.Errorf("snapshot create: upsert db: %w", err)
 	}
 
 	// 5. Reclaim the legacy staging file if an older build left one behind. The
@@ -502,7 +535,7 @@ func (sc *SnapshotCache) CreateSnapshot(
 		Str("blob_path", blobPath).
 		Msg("filesystem snapshot created")
 
-	return nil
+	return sizeBytes, nil
 }
 
 // =============================================================================

--- a/internal/services/preview/snapshot_cache.go
+++ b/internal/services/preview/snapshot_cache.go
@@ -29,11 +29,19 @@ const (
 	// DefaultMaxCacheBytes is 20 GB per worker.
 	DefaultMaxCacheBytes int64 = 20 * 1024 * 1024 * 1024
 
-	// snapshotTmpFile is the temporary path inside the sandbox where the
-	// snapshot archive is staged during create/restore. tar auto-detects the
-	// compression on extract, so the name is cosmetic — it does not have to
-	// match the actual (zstd or legacy gzip) format of the bytes.
-	snapshotTmpFile = "/tmp/snapshot.tar.zst"
+	// legacySnapshotTmpFile is the path inside the sandbox where snapshots used
+	// to be staged before create/restore streamed directly to and from the
+	// worker. Create and restore no longer write it; it is still removed
+	// best-effort so a sandbox that ran an older build (or a create that failed
+	// partway under it) does not keep the file pinned in the tmpfs.
+	//
+	// Staging here was a latent cap on snapshot size: /tmp is a 256 MiB tmpfs
+	// (see the sandbox Tmpfs config in the docker agent provider), so any
+	// workspace whose archive exceeded that filled the mount and zstd died with
+	// "error 70 : Write error : cannot write block" a few seconds in. Because
+	// tmpfs is RAM, it also charged the sandbox's memory cgroup. Both directions
+	// now stream, so neither the size cap nor the memory charge applies.
+	legacySnapshotTmpFile = "/tmp/snapshot.tar.zst"
 )
 
 // =============================================================================
@@ -201,7 +209,7 @@ func (sc *SnapshotCache) CreateSnapshot(
 	log.Info().Msg("creating filesystem snapshot")
 	start := time.Now()
 
-	// 1. Create the archive inside the sandbox.
+	// 1. Build the in-sandbox archive command.
 	//    Using shell tar is significantly faster than Go's archive/tar for
 	//    large node_modules trees (parallel I/O, kernel-level buffering).
 	//    Compression and the base exclude list are shared with the
@@ -209,25 +217,23 @@ func (sc *SnapshotCache) CreateSnapshot(
 	//    preview workspaces rebuild .git from the clone. excludePaths are the
 	//    caller's per-config additions (runtime secret-file destinations and
 	//    separately-restored build caches — see previewSnapshotExcludePaths).
+	//
+	//    `-f -` streams to stdout, which the exec pipes straight to the
+	//    worker-local temp file below. Nothing is staged inside the sandbox:
+	//    the previous two-step form wrote the whole archive to a 256 MiB tmpfs
+	//    first (see legacySnapshotTmpFile), which capped snapshots at that size
+	//    and charged the bytes to the sandbox's memory cgroup. The session
+	//    checkpoint path in the docker agent provider and the dependency cache's
+	//    stageSandboxArchive both already stream this way.
 	tarCmd := fmt.Sprintf(
-		"tar -c %s -f %s -C %s %s%s -- .",
+		"tar -c %s -f - -C %s %s%s -- .",
 		agent.SnapshotTarCompressFlag,
-		snapshotTmpFile,
 		shellQuote(sb.WorkDir),
 		agent.SnapshotTarExcludeFlags(true),
 		snapshotExtraExcludeFlags(excludePaths),
 	)
 
-	var stderr bytes.Buffer
-	exitCode, err := sc.executor.Exec(ctx, sb, tarCmd, io.Discard, &stderr)
-	if err != nil {
-		return fmt.Errorf("snapshot create: exec tar: %w", err)
-	}
-	if exitCode != 0 {
-		return fmt.Errorf("snapshot create: tar exited %d: %s", exitCode, stderr.String())
-	}
-
-	// 2. Stream the tar.gz from the sandbox directly into a worker-local
+	// 2. Stream the archive from the sandbox directly into a worker-local
 	//    temp file. We tee through a SHA-256 hasher so the checksum is
 	//    computed without a second pass, and through a counting writer so
 	//    we can enforce the max blob size mid-stream rather than after
@@ -262,8 +268,7 @@ func (sc *SnapshotCache) CreateSnapshot(
 	// executor will surface back here, short-circuiting the stream.
 	stream := io.MultiWriter(tmp, hasher, counter)
 
-	readCmd := fmt.Sprintf("cat %s", shellQuote(snapshotTmpFile))
-	exitCode, err = sc.executor.Exec(ctx, sb, readCmd, stream, &tarStderr)
+	exitCode, err := sc.executor.Exec(ctx, sb, tarCmd, stream, &tarStderr)
 	// Close the tmp file regardless of outcome so we can rename (or remove) it.
 	if syncErr := tmp.Sync(); syncErr != nil && err == nil {
 		err = fmt.Errorf("sync temp blob: %w", syncErr)
@@ -271,14 +276,18 @@ func (sc *SnapshotCache) CreateSnapshot(
 	if closeErr := tmp.Close(); closeErr != nil && err == nil {
 		err = fmt.Errorf("close temp blob: %w", closeErr)
 	}
+	// Check the size cap before the exec's own error. When the counter trips it
+	// fails the stream write, which surfaces as a generic exec/stderr error and
+	// would otherwise bury the real reason ("too large") under tar's downstream
+	// complaint about a broken pipe.
+	if counter.exceeded {
+		return fmt.Errorf("snapshot create: tar too large (>%d bytes max)", maxCreateBlobBytes)
+	}
 	if err != nil {
 		return fmt.Errorf("snapshot create: stream tar from sandbox: %w", err)
 	}
 	if exitCode != 0 {
-		return fmt.Errorf("snapshot create: cat exited %d: %s", exitCode, tarStderr.String())
-	}
-	if counter.exceeded {
-		return fmt.Errorf("snapshot create: tar too large (>%d bytes max)", maxCreateBlobBytes)
+		return fmt.Errorf("snapshot create: tar exited %d: %s", exitCode, tarStderr.String())
 	}
 
 	if err := os.Chmod(tmpPath, 0o600); err != nil {
@@ -318,8 +327,10 @@ func (sc *SnapshotCache) CreateSnapshot(
 		return fmt.Errorf("snapshot create: upsert db: %w", err)
 	}
 
-	// 5. Clean up the temporary file inside the sandbox.
-	_, _ = sc.executor.Exec(ctx, sb, fmt.Sprintf("rm -f %s", snapshotTmpFile), io.Discard, io.Discard)
+	// 5. Reclaim the legacy staging file if an older build left one behind. The
+	//    streaming create above never writes it, but the sandbox is long-lived
+	//    and 256 MiB of tmpfs held there is 256 MiB off the memory cgroup.
+	sc.removeLegacyStagingFile(ctx, sb)
 
 	// 6. Evict old entries if we are over the size limit.
 	if evictErr := sc.EvictLRU(ctx); evictErr != nil {
@@ -485,7 +496,14 @@ func (sc *SnapshotCache) RestoreSnapshot(
 		}
 	}
 
-	// 2. Write the tar.gz into the sandbox.
+	// 2. Open the blob. It is streamed straight into the sandbox's tar below
+	//    rather than staged to a file inside the sandbox first: the old staging
+	//    path capped restores at the 256 MiB /tmp tmpfs and charged the bytes to
+	//    the sandbox memory cgroup (see legacySnapshotTmpFile).
+	streamExec, ok := sc.executor.(sandboxStdinExecutor)
+	if !ok {
+		return fmt.Errorf("snapshot restore: executor does not support streaming restore")
+	}
 	blob, err := os.Open(hit.BlobPath) // #nosec G304 -- BlobPath was validated by lookup and stat above
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -501,9 +519,6 @@ func (sc *SnapshotCache) RestoreSnapshot(
 			log.Warn().Err(closeErr).Str("blob_path", hit.BlobPath).Msg("failed to close snapshot blob")
 		}
 	}()
-	if err := sc.executor.WriteFileFromReader(ctx, sb, snapshotTmpFile, blob, fi.Size()); err != nil {
-		return fmt.Errorf("snapshot restore: stream tar to sandbox: %w", err)
-	}
 
 	// 3. Remove existing workspace files (except .git which is excluded from
 	//    snapshots and reconstructed separately). Without this, files deleted
@@ -513,26 +528,41 @@ func (sc *SnapshotCache) RestoreSnapshot(
 		shellQuote(sb.WorkDir),
 	)
 	var cleanStderr bytes.Buffer
-	if cleanExit, cleanErr := sc.executor.Exec(ctx, sb, cleanCmd, io.Discard, &cleanStderr); cleanErr != nil || cleanExit != 0 {
+	cleanExit, cleanErr := sc.executor.Exec(ctx, sb, cleanCmd, io.Discard, &cleanStderr)
+	workspaceCleaned := cleanErr == nil && cleanExit == 0
+	if !workspaceCleaned {
 		log.Warn().Err(cleanErr).Int("exit_code", cleanExit).Str("stderr", cleanStderr.String()).
 			Msg("failed to clean workspace before restore — proceeding with overlay extraction")
 	}
 
-	// 4. Extract inside the sandbox. `xf` (not `xzf`) so tar auto-detects the
-	//    compression — restores both new zstd archives and pre-switch gzip ones.
-	extractCmd := fmt.Sprintf("tar xf %s -C %s", snapshotTmpFile, shellQuote(sb.WorkDir))
+	// 4. Stream the blob into tar inside the sandbox. `xf -` (not `xzf`) so tar
+	//    auto-detects the compression — restores both new zstd archives and
+	//    pre-switch gzip ones.
+	extractCmd := fmt.Sprintf("tar xf - -C %s", shellQuote(sb.WorkDir))
 
 	var stderr bytes.Buffer
-	exitCode, err := sc.executor.Exec(ctx, sb, extractCmd, io.Discard, &stderr)
-	if err != nil {
-		return fmt.Errorf("snapshot restore: exec tar: %w", err)
-	}
-	if exitCode != 0 {
+	exitCode, err := streamExec.ExecWithStdin(ctx, sb, extractCmd, blob, io.Discard, &stderr)
+	if err != nil || exitCode != 0 {
+		// The extract now streams, so a failure can land after step 3 wiped the
+		// workspace — where the two-step form always failed before the wipe. The
+		// caller treats a restore error as "launch cold" and keeps using this
+		// sandbox, so put the tree back from the clone (.git survives the clean)
+		// before returning; otherwise the cold launch would build an empty
+		// workspace.
+		if workspaceCleaned {
+			if recoverErr := sc.recoverWorkspaceFromGit(ctx, sb); recoverErr != nil {
+				log.Error().Err(recoverErr).Msg("snapshot restore failed and workspace could not be recovered from git")
+				return fmt.Errorf("snapshot restore: extract failed and workspace recovery failed: %w", recoverErr)
+			}
+		}
+		if err != nil {
+			return fmt.Errorf("snapshot restore: exec tar: %w", err)
+		}
 		return fmt.Errorf("snapshot restore: tar exited %d: %s", exitCode, stderr.String())
 	}
 
-	// 5. Clean up the temporary file inside the sandbox.
-	_, _ = sc.executor.Exec(ctx, sb, fmt.Sprintf("rm -f %s", snapshotTmpFile), io.Discard, io.Discard)
+	// 5. Reclaim the legacy staging file if an older build left one behind.
+	sc.removeLegacyStagingFile(ctx, sb)
 
 	// 6. Touch the cache entry to update LRU ordering.
 	if err := sc.store.TouchCache(ctx, hit.Entry.OrgID, hit.Entry.ID); err != nil {
@@ -544,6 +574,35 @@ func (sc *SnapshotCache) RestoreSnapshot(
 		Dur("elapsed_ms", time.Since(start)).
 		Msg("filesystem snapshot restored")
 
+	return nil
+}
+
+// removeLegacyStagingFile best-effort deletes the pre-streaming staging file
+// from the sandbox. Create and restore no longer write it, but a sandbox that
+// previously ran an older build may still be holding it — and since /tmp is a
+// tmpfs, those bytes sit in the container's memory cgroup until removed.
+func (sc *SnapshotCache) removeLegacyStagingFile(ctx context.Context, sb *agent.Sandbox) {
+	_, _ = sc.executor.Exec(ctx, sb, fmt.Sprintf("rm -f %s", shellQuote(legacySnapshotTmpFile)), io.Discard, io.Discard)
+}
+
+// recoverWorkspaceFromGit rebuilds the working tree from the sandbox's git
+// clone after a failed restore left it wiped or half-extracted. HEAD is the
+// pinned preview commit, checked out earlier in the start flow. It mirrors
+// StartRunner.recoverWorkspaceFromGit, which covers the same hazard on the
+// base-snapshot path.
+func (sc *SnapshotCache) recoverWorkspaceFromGit(ctx context.Context, sb *agent.Sandbox) error {
+	cmd := fmt.Sprintf(
+		"find %s -mindepth 1 -maxdepth 1 ! -name .git -exec rm -rf {} + && cd %s && git checkout -f HEAD -- .",
+		shellQuote(sb.WorkDir), shellQuote(sb.WorkDir),
+	)
+	var stderr bytes.Buffer
+	exitCode, err := sc.executor.Exec(ctx, sb, cmd, io.Discard, &stderr)
+	if err != nil {
+		return fmt.Errorf("exec workspace recovery: %w", err)
+	}
+	if exitCode != 0 {
+		return fmt.Errorf("workspace recovery exited %d: %s", exitCode, stderr.String())
+	}
 	return nil
 }
 

--- a/internal/services/preview/snapshot_cache.go
+++ b/internal/services/preview/snapshot_cache.go
@@ -12,6 +12,7 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/google/uuid"
@@ -126,13 +127,53 @@ func (sc *SnapshotCache) minBlobBytes() int64 {
 	return minSnapshotBlobBytes
 }
 
+// snapshotShrinkRejectStrikes is how many consecutive shrink rejections a key
+// gets before the shrunk archive is stored anyway.
+//
+// The shrink rule assumes a collapse means damage. That is true of a torn
+// archive, which is transient — the next launch produces a full one. It is not
+// true of a workspace that legitimately got smaller, where every future
+// snapshot is the new size and the rule would reject all of them, keeping a
+// baseline alive that no longer describes reality.
+//
+// Repetition tells the two apart, and needs no extra signal: damage does not
+// reproduce at the same size, a genuine shrink does. Rejecting once and
+// accepting the repeat caps the cost of a false positive at a single cold
+// launch, and makes a permanent wedge impossible rather than merely bounded by
+// snapshotShrinkBaselineMaxAge.
+const snapshotShrinkRejectStrikes = 2
+
 // undersizedSnapshotReason returns a human-readable reason to discard a freshly
 // staged archive, or "" to keep it.
-func (sc *SnapshotCache) undersizedSnapshotReason(ctx context.Context, metadata SnapshotMetadata, sizeBytes int64) string {
+func (sc *SnapshotCache) undersizedSnapshotReason(ctx context.Context, snapshotKey string, metadata SnapshotMetadata, sizeBytes int64) string {
+	// The absolute floor has no escape hatch. An archive this small cannot hold
+	// an installed dependency tree however many times it repeats, so a run of
+	// them means the workspace is wrong, not the rule.
 	if floor := sc.minBlobBytes(); sizeBytes < floor {
 		return fmt.Sprintf("archive is %d bytes, under the %d-byte floor for a workspace with dependencies installed",
 			sizeBytes, floor)
 	}
+
+	reason := sc.shrinkAgainstBaselineReason(ctx, metadata, sizeBytes)
+	if reason == "" {
+		sc.clearShrinkStrike(snapshotKey)
+		return ""
+	}
+	if strikes := sc.noteShrinkStrike(snapshotKey); strikes >= snapshotShrinkRejectStrikes {
+		sc.clearShrinkStrike(snapshotKey)
+		sc.logger.Warn().
+			Str("snapshot_key", snapshotKey).
+			Int("strikes", strikes).
+			Str("reason", reason).
+			Msg("storing a shrunk snapshot after repeated rejections; treating the smaller workspace as the new truth")
+		return ""
+	}
+	return reason
+}
+
+// shrinkAgainstBaselineReason reports whether the archive collapsed relative to
+// the most recent snapshot stored for the same base key.
+func (sc *SnapshotCache) shrinkAgainstBaselineReason(ctx context.Context, metadata SnapshotMetadata, sizeBytes int64) string {
 	if metadata.BaseKey == "" || sc.store == nil {
 		return ""
 	}
@@ -152,6 +193,45 @@ func (sc *SnapshotCache) undersizedSnapshotReason(ctx context.Context, metadata 
 	}
 	return ""
 }
+
+// noteShrinkStrike records a shrink rejection for snapshotKey and returns the
+// running count. Counts are per-worker and in memory: they only need to survive
+// between two launches of the same key, and losing them on restart just costs
+// one more rejection before the shrunk archive is accepted.
+func (sc *SnapshotCache) noteShrinkStrike(snapshotKey string) int {
+	if snapshotKey == "" {
+		return 0
+	}
+	sc.shrinkStrikesMu.Lock()
+	defer sc.shrinkStrikesMu.Unlock()
+	if sc.shrinkStrikes == nil {
+		sc.shrinkStrikes = make(map[string]int)
+	}
+	// A worker sees a bounded set of live keys, but nothing prunes an entry
+	// whose key is never built again. Reset wholesale rather than tracking
+	// eviction: the cost is one extra rejection for whatever was mid-strike.
+	if len(sc.shrinkStrikes) >= maxTrackedShrinkStrikes {
+		sc.shrinkStrikes = make(map[string]int)
+	}
+	sc.shrinkStrikes[snapshotKey]++
+	return sc.shrinkStrikes[snapshotKey]
+}
+
+// clearShrinkStrike forgets a key's strike count once it stores a normal-sized
+// archive, so strikes must be consecutive to add up.
+func (sc *SnapshotCache) clearShrinkStrike(snapshotKey string) {
+	if snapshotKey == "" {
+		return
+	}
+	sc.shrinkStrikesMu.Lock()
+	defer sc.shrinkStrikesMu.Unlock()
+	delete(sc.shrinkStrikes, snapshotKey)
+}
+
+// maxTrackedShrinkStrikes bounds the strike map. Strikes are a two-launch
+// signal, so this only needs to be larger than the number of keys a worker
+// might have mid-strike at once.
+const maxTrackedShrinkStrikes = 1024
 
 // tarStderrRetained bounds how much of tar's stderr is kept for logging.
 //
@@ -257,6 +337,11 @@ type SnapshotCache struct {
 	// tests set it, so they can drive the reject paths with byte-scale fixtures
 	// instead of allocating and streaming a megabyte per case.
 	minSnapshotBytesOverride int64
+	// shrinkStrikes counts consecutive shrink rejections per snapshot key, so a
+	// workspace that genuinely got smaller stops being rejected on its second
+	// attempt. See snapshotShrinkRejectStrikes.
+	shrinkStrikesMu sync.Mutex
+	shrinkStrikes   map[string]int
 }
 
 // SnapshotCacheConfig holds initialization options for SnapshotCache.
@@ -476,7 +561,7 @@ func (sc *SnapshotCache) CreateSnapshot(
 	// key, wiping a good checkout and leaving nothing behind. The deferred
 	// cleanup drops the staged file, so the previous snapshot for this key (if
 	// any) survives untouched and keeps serving.
-	if reason := sc.undersizedSnapshotReason(ctx, metadata, sizeBytes); reason != "" {
+	if reason := sc.undersizedSnapshotReason(ctx, snapshotKey, metadata, sizeBytes); reason != "" {
 		log.Error().
 			Int64("size_bytes", sizeBytes).
 			Str("reason", reason).

--- a/internal/services/preview/snapshot_cache.go
+++ b/internal/services/preview/snapshot_cache.go
@@ -72,6 +72,60 @@ func tarExitTolerable(exitCode int) bool {
 	return exitCode == 0 || exitCode == 1
 }
 
+// ErrSnapshotTooSmall marks a create rejected by the size floor. It is not a
+// launch failure — the caller logs it and moves on without a warm start — but
+// it is distinct from a create that errored, because it means the archive was
+// produced and deliberately discarded.
+var ErrSnapshotTooSmall = errors.New("snapshot is implausibly small")
+
+// minSnapshotBlobBytes is the absolute floor for a stored snapshot.
+//
+// A snapshot key is only computed when the repo has lockfiles, so every
+// snapshot describes a workspace with dependencies installed. Compressed, that
+// does not fit in a megabyte for any real project. An archive below this either
+// captured almost nothing (an over-broad exclude, a workspace that was not
+// populated when tar ran) or would save so little that restoring it is not
+// worth the round trip.
+const minSnapshotBlobBytes int64 = 1 << 20 // 1 MiB
+
+// snapshotShrinkRejectPercent rejects a snapshot that collapses relative to the
+// last one stored for the same base key.
+//
+// The base key is the lockfiles plus the config digest, so two snapshots
+// sharing one describe the same dependency tree; only source and build output
+// differ between them. Those move a snapshot's size by some percent, not by a
+// factor of four. A collapse this large means content went missing — the kind
+// of damage a torn or truncated archive does — so keep the older snapshot and
+// let the next launch try again rather than overwriting it with a bad one.
+//
+// It is deliberately far below any plausible drift: rejecting a legitimate
+// snapshot keeps a stale one alive, which is the failure this whole change set
+// exists to fix. Better to catch only the unambiguous cases.
+const snapshotShrinkRejectPercent = 25
+
+// undersizedSnapshotReason returns a human-readable reason to discard a freshly
+// staged archive, or "" to keep it.
+func (sc *SnapshotCache) undersizedSnapshotReason(ctx context.Context, metadata SnapshotMetadata, sizeBytes int64) string {
+	if sizeBytes < minSnapshotBlobBytes {
+		return fmt.Sprintf("archive is %d bytes, under the %d-byte floor for a workspace with dependencies installed",
+			sizeBytes, minSnapshotBlobBytes)
+	}
+	if metadata.BaseKey == "" || sc.store == nil {
+		return ""
+	}
+	// Any lookup failure (including the no-rows case for a first snapshot) just
+	// means no baseline to compare against — never a reason to drop the archive.
+	prior, err := sc.store.FindLatestCacheByBaseKey(ctx, metadata.OrgID, metadata.RepoID, metadata.BaseKey, sc.workerNodeID, "")
+	if err != nil || prior == nil || prior.SizeBytes <= 0 {
+		return ""
+	}
+	if sizeBytes*100 < prior.SizeBytes*snapshotShrinkRejectPercent {
+		return fmt.Sprintf("archive is %d bytes, under %d%% of the %d-byte snapshot already stored for base key %s",
+			sizeBytes, snapshotShrinkRejectPercent, prior.SizeBytes, metadata.BaseKey)
+	}
+	return ""
+}
+
 // tarStderrRetained bounds how much of tar's stderr is kept for logging.
 //
 // Tolerating exit 1 turned "tar complained" from a rare fatal into a routine
@@ -381,6 +435,22 @@ func (sc *SnapshotCache) CreateSnapshot(
 			Msg("snapshot archived with warnings from a live workspace; keeping it rather than losing the cache")
 	}
 
+	sizeBytes := counter.count
+
+	// Refuse to store an implausibly small archive. A snapshot is restored by
+	// wiping the workspace and unpacking in its place, so a degenerate one does
+	// not merely fail to help — it poisons every later launch that matches its
+	// key, wiping a good checkout and leaving nothing behind. The deferred
+	// cleanup drops the staged file, so the previous snapshot for this key (if
+	// any) survives untouched and keeps serving.
+	if reason := sc.undersizedSnapshotReason(ctx, metadata, sizeBytes); reason != "" {
+		log.Error().
+			Int64("size_bytes", sizeBytes).
+			Str("reason", reason).
+			Msg("refusing to store an implausibly small snapshot")
+		return fmt.Errorf("snapshot create: %w: %s", ErrSnapshotTooSmall, reason)
+	}
+
 	if err := os.Chmod(tmpPath, 0o600); err != nil {
 		return fmt.Errorf("snapshot create: chmod: %w", err)
 	}
@@ -398,8 +468,6 @@ func (sc *SnapshotCache) CreateSnapshot(
 		_ = os.Remove(blobPath)
 		return fmt.Errorf("snapshot create: write checksum: %w", err)
 	}
-
-	sizeBytes := counter.count
 
 	// 4. Record in database.
 	entry := &models.PreviewStartupCache{

--- a/internal/services/preview/snapshot_cache.go
+++ b/internal/services/preview/snapshot_cache.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -43,6 +44,33 @@ const (
 	// now stream, so neither the size cap nor the memory charge applies.
 	legacySnapshotTmpFile = "/tmp/snapshot.tar.zst"
 )
+
+// ErrPreviewWorkspaceUnrecoverable marks a failure that left the sandbox
+// workspace in a state matching neither the snapshot nor the git checkout.
+// Every other snapshot error is recoverable by launching cold, so callers
+// swallow them; this one they must fail the start on, because a cold build
+// would produce a preview serving the wrong tree.
+var ErrPreviewWorkspaceUnrecoverable = errors.New("preview workspace is unrecoverable")
+
+// tarExitTolerable reports whether a GNU tar exit code left a usable
+// archive (or a usable extraction) behind.
+//
+// tar exits 1 for "some files differ" — most often "file changed as we read
+// it", plus unreadable entries skipped under --ignore-failed-read. It still
+// writes a complete, structurally valid archive; only the individual entries
+// that moved under it may be torn. Exit 2 and above are fatal: a broken stream,
+// a full disk, a missing binary.
+//
+// Snapshots are created moments after the preview reports ready, so the
+// workspace is live — services are writing logs, caches and build output into
+// the tree the whole time tar reads it. Treating exit 1 as fatal would mean the
+// busiest (and most expensive to rebuild) workspaces are exactly the ones that
+// never get a snapshot. A torn file in a warm-start cache degrades to a build
+// error on the next launch, which is recoverable; never caching at all is a
+// permanent 8-minute tax on every launch. Tolerate it and log loudly.
+func tarExitTolerable(exitCode int) bool {
+	return exitCode == 0 || exitCode == 1
+}
 
 // =============================================================================
 // Interfaces
@@ -123,6 +151,14 @@ type SnapshotCacheConfig struct {
 func NewSnapshotCache(cfg SnapshotCacheConfig) (*SnapshotCache, error) {
 	if cfg.Executor == nil {
 		return nil, fmt.Errorf("snapshot cache: executor must be non-nil")
+	}
+	// Restore and partial invalidation stream over stdin rather than staging a
+	// file in the sandbox. Assert the capability here so a misconfigured
+	// executor fails at startup: checked at call time instead, it would surface
+	// as a restore error, which the start path swallows into a silent cold
+	// launch — the cache would just quietly never hit.
+	if _, ok := cfg.Executor.(sandboxStdinExecutor); !ok {
+		return nil, fmt.Errorf("snapshot cache: executor must support ExecWithStdin for streaming restore")
 	}
 	if cfg.CacheDir == "" {
 		return nil, fmt.Errorf("snapshot cache: cache directory must be specified")
@@ -225,8 +261,14 @@ func (sc *SnapshotCache) CreateSnapshot(
 	//    and charged the bytes to the sandbox's memory cgroup. The session
 	//    checkpoint path in the docker agent provider and the dependency cache's
 	//    stageSandboxArchive both already stream this way.
+	//
+	//    --ignore-failed-read keeps a file that vanished mid-walk (a dev server
+	//    rotating a log, a build tool clearing scratch) from aborting the whole
+	//    archive. It downgrades the read to a warning; tar still exits 1, which
+	//    tarExitTolerable accepts. The session-checkpoint path passes the
+	//    same flag.
 	tarCmd := fmt.Sprintf(
-		"tar -c %s -f - -C %s %s%s -- .",
+		"tar -c %s -f - --ignore-failed-read -C %s %s%s -- .",
 		agent.SnapshotTarCompressFlag,
 		shellQuote(sb.WorkDir),
 		agent.SnapshotTarExcludeFlags(true),
@@ -286,8 +328,17 @@ func (sc *SnapshotCache) CreateSnapshot(
 	if err != nil {
 		return fmt.Errorf("snapshot create: stream tar from sandbox: %w", err)
 	}
-	if exitCode != 0 {
+	if !tarExitTolerable(exitCode) {
 		return fmt.Errorf("snapshot create: tar exited %d: %s", exitCode, tarStderr.String())
+	}
+	if exitCode != 0 {
+		// Keep the archive but make the compromise visible: these are the files
+		// that moved under tar on a live workspace, so a restore of this blob
+		// may carry a torn copy of each one.
+		log.Warn().
+			Int("exit_code", exitCode).
+			Str("stderr", tarStderr.String()).
+			Msg("snapshot archived with warnings from a live workspace; keeping it rather than losing the cache")
 	}
 
 	if err := os.Chmod(tmpPath, 0o600); err != nil {
@@ -542,23 +593,38 @@ func (sc *SnapshotCache) RestoreSnapshot(
 
 	var stderr bytes.Buffer
 	exitCode, err := streamExec.ExecWithStdin(ctx, sb, extractCmd, blob, io.Discard, &stderr)
-	if err != nil || exitCode != 0 {
+	if err != nil || !tarExitTolerable(exitCode) {
 		// The extract now streams, so a failure can land after step 3 wiped the
 		// workspace — where the two-step form always failed before the wipe. The
 		// caller treats a restore error as "launch cold" and keeps using this
 		// sandbox, so put the tree back from the clone (.git survives the clean)
 		// before returning; otherwise the cold launch would build an empty
 		// workspace.
+		//
+		// If recovery itself fails the workspace is neither the snapshot nor the
+		// checkout, and no amount of cold building will produce the right code.
+		// That is the one case worth failing the start over, so it is wrapped in
+		// ErrPreviewWorkspaceUnrecoverable for the caller to distinguish.
 		if workspaceCleaned {
 			if recoverErr := sc.recoverWorkspaceFromGit(ctx, sb); recoverErr != nil {
 				log.Error().Err(recoverErr).Msg("snapshot restore failed and workspace could not be recovered from git")
-				return fmt.Errorf("snapshot restore: extract failed and workspace recovery failed: %w", recoverErr)
+				return fmt.Errorf("snapshot restore: extract failed and workspace recovery failed: %w: %w",
+					ErrPreviewWorkspaceUnrecoverable, recoverErr)
 			}
 		}
 		if err != nil {
 			return fmt.Errorf("snapshot restore: exec tar: %w", err)
 		}
 		return fmt.Errorf("snapshot restore: tar exited %d: %s", exitCode, stderr.String())
+	}
+	if exitCode != 0 {
+		// Same bargain as create: tar reported non-fatal warnings but produced a
+		// tree. Using it beats discarding a warm start over a metadata warning —
+		// and if the tree really is unusable the build fails loudly right after.
+		log.Warn().
+			Int("exit_code", exitCode).
+			Str("stderr", stderr.String()).
+			Msg("snapshot extracted with warnings; continuing with the restored workspace")
 	}
 
 	// 5. Reclaim the legacy staging file if an older build left one behind.
@@ -581,6 +647,11 @@ func (sc *SnapshotCache) RestoreSnapshot(
 // from the sandbox. Create and restore no longer write it, but a sandbox that
 // previously ran an older build may still be holding it — and since /tmp is a
 // tmpfs, those bytes sit in the container's memory cgroup until removed.
+//
+// TODO(2026-08): transitional. Preview sandboxes do not outlive a deploy, so
+// once every worker has run a build containing the streaming create/restore,
+// nothing can be writing this path any more and both this helper and its two
+// call sites should go.
 func (sc *SnapshotCache) removeLegacyStagingFile(ctx context.Context, sb *agent.Sandbox) {
 	_, _ = sc.executor.Exec(ctx, sb, fmt.Sprintf("rm -f %s", shellQuote(legacySnapshotTmpFile)), io.Discard, io.Discard)
 }

--- a/internal/services/preview/snapshot_cache.go
+++ b/internal/services/preview/snapshot_cache.go
@@ -72,6 +72,46 @@ func tarExitTolerable(exitCode int) bool {
 	return exitCode == 0 || exitCode == 1
 }
 
+// tarStderrRetained bounds how much of tar's stderr is kept for logging.
+//
+// Tolerating exit 1 turned "tar complained" from a rare fatal into a routine
+// success path, and tar emits one warning line per file that moved under it —
+// on a busy monorepo that is thousands of lines per snapshot, held in worker
+// memory and then shipped to the log pipeline. The tail is what diagnoses the
+// failure, so keep a bounded head-plus-count instead of the whole stream.
+const tarStderrRetained = 8 * 1024
+
+// boundedBuffer collects up to limit bytes and counts the rest. Writes always
+// report full consumption and never error: this sits on an exec's stderr, and
+// failing the write would kill the very command whose warnings we are reading.
+type boundedBuffer struct {
+	buf     bytes.Buffer
+	limit   int
+	dropped int
+}
+
+func (b *boundedBuffer) Write(p []byte) (int, error) {
+	if room := b.limit - b.buf.Len(); room > 0 {
+		if len(p) <= room {
+			b.buf.Write(p)
+		} else {
+			b.buf.Write(p[:room])
+			b.dropped += len(p) - room
+		}
+	} else {
+		b.dropped += len(p)
+	}
+	return len(p), nil
+}
+
+// String returns the retained output, noting how much was dropped.
+func (b *boundedBuffer) String() string {
+	if b.dropped == 0 {
+		return b.buf.String()
+	}
+	return fmt.Sprintf("%s\n... (%d more bytes suppressed)", b.buf.String(), b.dropped)
+}
+
 // =============================================================================
 // Interfaces
 // =============================================================================
@@ -304,13 +344,13 @@ func (sc *SnapshotCache) CreateSnapshot(
 
 	hasher := sha256.New()
 	counter := &cappedCountingWriter{limit: maxCreateBlobBytes}
-	var tarStderr bytes.Buffer
+	tarStderr := &boundedBuffer{limit: tarStderrRetained}
 	// Multiwriter fans out each chunk to: temp file, SHA-256 hasher, size
 	// counter. If the counter trips, its Write returns an error that the
 	// executor will surface back here, short-circuiting the stream.
 	stream := io.MultiWriter(tmp, hasher, counter)
 
-	exitCode, err := sc.executor.Exec(ctx, sb, tarCmd, stream, &tarStderr)
+	exitCode, err := sc.executor.Exec(ctx, sb, tarCmd, stream, tarStderr)
 	// Close the tmp file regardless of outcome so we can rename (or remove) it.
 	if syncErr := tmp.Sync(); syncErr != nil && err == nil {
 		err = fmt.Errorf("sync temp blob: %w", syncErr)
@@ -591,8 +631,8 @@ func (sc *SnapshotCache) RestoreSnapshot(
 	//    pre-switch gzip ones.
 	extractCmd := fmt.Sprintf("tar xf - -C %s", shellQuote(sb.WorkDir))
 
-	var stderr bytes.Buffer
-	exitCode, err := streamExec.ExecWithStdin(ctx, sb, extractCmd, blob, io.Discard, &stderr)
+	stderr := &boundedBuffer{limit: tarStderrRetained}
+	exitCode, err := streamExec.ExecWithStdin(ctx, sb, extractCmd, blob, io.Discard, stderr)
 	if err != nil || !tarExitTolerable(exitCode) {
 		// The extract now streams, so a failure can land after step 3 wiped the
 		// workspace — where the two-step form always failed before the wipe. The

--- a/internal/services/preview/snapshot_cache.go
+++ b/internal/services/preview/snapshot_cache.go
@@ -645,24 +645,29 @@ func (sc *SnapshotCache) ApplyPartialInvalidation(
 		return nil
 	}
 
-	// 3. Write the diff into the sandbox.
-	const diffTmpPath = "/tmp/partial.diff"
-	if err := sc.executor.WriteFile(ctx, sb, diffTmpPath, gitDiff); err != nil {
-		return fmt.Errorf("partial invalidation: write diff: %w", err)
+	// 3. Apply the diff, streamed over stdin. `git apply` reads the patch from
+	//    stdin when given no file argument, so the patch never lands on the
+	//    sandbox filesystem — it used to be written to /tmp, a 256 MiB tmpfs
+	//    whose bytes come out of the container's memory cgroup (the same reason
+	//    snapshot archives no longer stage there; see legacySnapshotTmpFile).
+	//    Diffs are capped at maxPartialInvalidationDiffBytes, so this was never
+	//    a correctness limit, only avoidable memory pressure on a sandbox that
+	//    is about to build.
+	//
+	//    The previous form ran `git apply --stat` first, but its output went to
+	//    io.Discard and a failure there only pre-empted the identical failure
+	//    from the real apply. Dropping it is what makes a single-pass stdin
+	//    stream possible, and costs no diagnostics.
+	//
+	//    --allow-empty tolerates a no-op patch.
+	streamExec, ok := sc.executor.(sandboxStdinExecutor)
+	if !ok {
+		return fmt.Errorf("partial invalidation: executor does not support streaming git apply")
 	}
-
-	// 4. Apply the diff. We use --allow-empty and ignore whitespace issues
-	//    to be resilient to minor formatting changes. The -p1 strip count
-	//    matches the standard `git diff` output format (a/path b/path).
-	applyCmd := fmt.Sprintf(
-		"cd %s && git apply --stat %s && git apply --allow-empty %s",
-		shellQuote(sb.WorkDir),
-		diffTmpPath,
-		diffTmpPath,
-	)
+	applyCmd := fmt.Sprintf("cd %s && git apply --allow-empty", shellQuote(sb.WorkDir))
 
 	var stderr bytes.Buffer
-	exitCode, err := sc.executor.Exec(ctx, sb, applyCmd, io.Discard, &stderr)
+	exitCode, err := streamExec.ExecWithStdin(ctx, sb, applyCmd, bytes.NewReader(gitDiff), io.Discard, &stderr)
 	if err != nil {
 		return fmt.Errorf("partial invalidation: exec git apply: %w", err)
 	}
@@ -670,9 +675,6 @@ func (sc *SnapshotCache) ApplyPartialInvalidation(
 		// If git apply fails, the caller should fall back to a full rebuild.
 		return fmt.Errorf("partial invalidation: git apply exited %d: %s", exitCode, stderr.String())
 	}
-
-	// 5. Clean up.
-	_, _ = sc.executor.Exec(ctx, sb, fmt.Sprintf("rm -f %s", diffTmpPath), io.Discard, io.Discard)
 
 	log.Info().
 		Dur("elapsed_ms", time.Since(start)).

--- a/internal/services/preview/snapshot_cache_test.go
+++ b/internal/services/preview/snapshot_cache_test.go
@@ -683,3 +683,34 @@ func TestSnapshotExtraExcludeFlags(t *testing.T) {
 		require.NotContains(t, flags, "././", "leading ./ must be trimmed before re-rooting")
 	})
 }
+
+// Tolerating tar exit 1 made "tar complained" a routine success path, and tar
+// emits a warning line per file that moved under it. The stderr we hold in
+// worker memory and ship to the log pipeline has to stay bounded.
+func TestBoundedBuffer_CapsRetainedOutput(t *testing.T) {
+	t.Parallel()
+
+	b := &boundedBuffer{limit: 16}
+	n, err := b.Write([]byte("0123456789"))
+	require.NoError(t, err, "a stderr writer must never error — that would kill the command")
+	require.Equal(t, 10, n, "Write must report full consumption")
+
+	n, err = b.Write([]byte("abcdefghijklmnop"))
+	require.NoError(t, err)
+	require.Equal(t, 16, n, "Write must report full consumption even past the limit")
+
+	got := b.String()
+	require.Contains(t, got, "0123456789abcdef", "the retained prefix should be kept verbatim")
+	require.Contains(t, got, "10 more bytes suppressed", "the dropped count should be surfaced")
+	require.Less(t, len(got), 100, "a runaway stderr must not reach the log intact")
+}
+
+func TestBoundedBuffer_UnderLimitIsVerbatim(t *testing.T) {
+	t.Parallel()
+
+	b := &boundedBuffer{limit: 1024}
+	_, err := b.Write([]byte("tar: x: file changed as we read it"))
+	require.NoError(t, err)
+	require.Equal(t, "tar: x: file changed as we read it", b.String(),
+		"output under the limit should carry no suppression note")
+}

--- a/internal/services/preview/snapshot_cache_test.go
+++ b/internal/services/preview/snapshot_cache_test.go
@@ -1,6 +1,7 @@
 package preview
 
 import (
+	"bytes"
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
@@ -527,6 +528,19 @@ func newCreateSnapshotFixture(t *testing.T, executor SnapshotExecutor, archiveLe
 		"id", "org_id", "repo_id", "snapshot_key", "base_key", "commit_sha", "blob_path",
 		"size_bytes", "worker_node_id", "last_used_at", "created_at",
 	}
+	// The size floor consults the last snapshot for this base key before storing.
+	// Return a small baseline so the shrink rule is satisfied and only the
+	// absolute floor is in play; the shrink rule has its own test.
+	//
+	// WithArgs is required: pgxmock reads a missing WithArgs as "expects zero
+	// arguments", so without it this expectation never matches, stays
+	// unfulfilled, and the next query collides with it.
+	mock.ExpectQuery("SELECT").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(pgxmock.NewRows(cacheCols).AddRow(
+			uuid.New(), metadata.OrgID, metadata.RepoID, "older-key", metadata.BaseKey, "older-commit",
+			filepath.Join(cacheDir, "older-blob"), int64(1024), "worker-1", time.Now(), time.Now(),
+		))
 	mock.ExpectQuery("INSERT INTO preview_startup_cache").
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
 			pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
@@ -541,7 +555,9 @@ func newCreateSnapshotFixture(t *testing.T, executor SnapshotExecutor, archiveLe
 func TestSnapshotCache_CreateSnapshotStreamsArchiveToWorker(t *testing.T) {
 	t.Parallel()
 
-	archive := []byte("streamed archive body")
+	// Above minSnapshotBlobBytes so the size floor lets it through; the floor
+	// itself is covered by TestSnapshotCache_CreateSnapshotRejectsUndersized.
+	archive := bytes.Repeat([]byte("streamed archive body"), 60_000)
 	executor := &streamingRestoreExecutor{stdout: archive}
 	sc, metadata := newCreateSnapshotFixture(t, executor, len(archive), true)
 
@@ -575,7 +591,7 @@ func TestSnapshotCache_CreateSnapshotStreamsArchiveToWorker(t *testing.T) {
 func TestSnapshotCache_CreateSnapshotKeepsArchiveWhenFilesChangedUnderTar(t *testing.T) {
 	t.Parallel()
 
-	archive := []byte("archive from a workspace that moved")
+	archive := bytes.Repeat([]byte("archive from a workspace that moved"), 40_000)
 	executor := &streamingRestoreExecutor{stdout: archive, tarCreateExit: 1}
 	sc, metadata := newCreateSnapshotFixture(t, executor, len(archive), true)
 
@@ -713,4 +729,108 @@ func TestBoundedBuffer_UnderLimitIsVerbatim(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "tar: x: file changed as we read it", b.String(),
 		"output under the limit should carry no suppression note")
+}
+
+// A snapshot is restored by wiping the workspace and unpacking in its place, so
+// storing a degenerate archive poisons every later launch that matches its key.
+// The floor must reject it and leave the staged file behind on disk.
+func TestSnapshotCache_CreateSnapshotRejectsUndersizedArchive(t *testing.T) {
+	t.Parallel()
+
+	archive := []byte("almost nothing")
+	executor := &streamingRestoreExecutor{stdout: archive}
+	sc, metadata := newCreateSnapshotFixture(t, executor, len(archive), false)
+
+	err := sc.CreateSnapshot(context.Background(), &agent.Sandbox{ID: "sandbox-1", WorkDir: "/workspace/repo"}, "snapshot-key", metadata, nil)
+	require.Error(t, err, "an archive under the floor must not be stored")
+	require.ErrorIs(t, err, ErrSnapshotTooSmall,
+		"the caller needs to tell a rejected archive apart from a failed create")
+
+	blobPath, err := sc.blobPath("snapshot-key")
+	require.NoError(t, err, "blob path should resolve")
+	_, statErr := os.Stat(blobPath)
+	require.True(t, os.IsNotExist(statErr), "a rejected archive must not be left on disk")
+
+	entries, err := os.ReadDir(sc.cacheDir)
+	require.NoError(t, err)
+	for _, e := range entries {
+		require.False(t, strings.HasSuffix(e.Name(), ".tmp"),
+			"the staged temp file should have been cleaned up, found %s", e.Name())
+	}
+}
+
+// The absolute floor cannot catch a snapshot that is large but has lost most of
+// its content. Two snapshots sharing a base key describe the same dependency
+// tree, so a fourfold collapse is damage, not drift.
+func TestUndersizedSnapshotReason_ShrinkAgainstBaseKey(t *testing.T) {
+	t.Parallel()
+
+	orgID, repoID := uuid.New(), uuid.New()
+	cacheCols := []string{
+		"id", "org_id", "repo_id", "snapshot_key", "base_key", "commit_sha", "blob_path",
+		"size_bytes", "worker_node_id", "last_used_at", "created_at",
+	}
+	priorSize := int64(100 << 20) // 100 MiB already stored for this base key
+
+	cases := []struct {
+		name       string
+		sizeBytes  int64
+		wantReject bool
+	}{
+		{"same size", priorSize, false},
+		{"modest shrink is normal drift", priorSize / 2, false},
+		{"just above the threshold", priorSize/4 + 1, false},
+		{"collapsed to a fraction", priorSize / 10, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			mock, err := pgxmock.NewPool()
+			require.NoError(t, err)
+			defer mock.Close()
+
+			mock.ExpectQuery("SELECT").
+				WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+				WillReturnRows(pgxmock.NewRows(cacheCols).AddRow(
+					uuid.New(), orgID, repoID, "older-key", "base", "older-commit",
+					"/cache/older", priorSize, "worker-1", time.Now(), time.Now(),
+				))
+
+			sc := &SnapshotCache{store: db.NewPreviewStore(mock), workerNodeID: "worker-1", logger: zerolog.Nop()}
+			reason := sc.undersizedSnapshotReason(context.Background(),
+				SnapshotMetadata{OrgID: orgID, RepoID: repoID, BaseKey: "base"}, tc.sizeBytes)
+
+			if tc.wantReject {
+				require.NotEmpty(t, reason, "a collapse against the stored baseline should be rejected")
+				require.Contains(t, reason, "already stored for base key")
+			} else {
+				require.Empty(t, reason, "this is plausible drift and must still be cached")
+			}
+		})
+	}
+}
+
+// Without a baseline only the absolute floor applies — a first snapshot must
+// never be blocked by the shrink rule, and a lookup failure must not either.
+func TestUndersizedSnapshotReason_NoBaselineAllowsStore(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err)
+	defer mock.Close()
+	// No expectation registered: the lookup errors, which must read as "no
+	// baseline" rather than as a reason to discard a good archive.
+	sc := &SnapshotCache{store: db.NewPreviewStore(mock), workerNodeID: "worker-1", logger: zerolog.Nop()}
+
+	require.Empty(t, sc.undersizedSnapshotReason(context.Background(),
+		SnapshotMetadata{OrgID: uuid.New(), RepoID: uuid.New(), BaseKey: "base"}, 50<<20),
+		"a base-key lookup failure must not block caching")
+
+	require.Empty(t, sc.undersizedSnapshotReason(context.Background(),
+		SnapshotMetadata{OrgID: uuid.New(), RepoID: uuid.New()}, 50<<20),
+		"no base key means no baseline to compare against")
+
+	require.NotEmpty(t, sc.undersizedSnapshotReason(context.Background(),
+		SnapshotMetadata{}, minSnapshotBlobBytes-1),
+		"the absolute floor applies with or without a baseline")
 }

--- a/internal/services/preview/snapshot_cache_test.go
+++ b/internal/services/preview/snapshot_cache_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
@@ -810,7 +811,7 @@ func TestUndersizedSnapshotReason_ShrinkAgainstBaseKey(t *testing.T) {
 				))
 
 			sc := &SnapshotCache{store: db.NewPreviewStore(mock), workerNodeID: "worker-1", logger: zerolog.Nop()}
-			reason := sc.undersizedSnapshotReason(context.Background(),
+			reason := sc.undersizedSnapshotReason(context.Background(), "snapshot-key",
 				SnapshotMetadata{OrgID: orgID, RepoID: repoID, BaseKey: "base"}, tc.sizeBytes)
 
 			if tc.wantReject {
@@ -830,11 +831,11 @@ func TestUndersizedSnapshotReason_AbsoluteFloor(t *testing.T) {
 
 	sc := &SnapshotCache{logger: zerolog.Nop()} // no store: only the floor applies
 
-	require.NotEmpty(t, sc.undersizedSnapshotReason(context.Background(), SnapshotMetadata{}, 0),
+	require.NotEmpty(t, sc.undersizedSnapshotReason(context.Background(), "snapshot-key", SnapshotMetadata{}, 0),
 		"an empty archive must never be stored")
-	require.NotEmpty(t, sc.undersizedSnapshotReason(context.Background(), SnapshotMetadata{}, minSnapshotBlobBytes-1),
+	require.NotEmpty(t, sc.undersizedSnapshotReason(context.Background(), "snapshot-key", SnapshotMetadata{}, minSnapshotBlobBytes-1),
 		"one byte under the floor must be rejected")
-	require.Empty(t, sc.undersizedSnapshotReason(context.Background(), SnapshotMetadata{}, minSnapshotBlobBytes),
+	require.Empty(t, sc.undersizedSnapshotReason(context.Background(), "snapshot-key", SnapshotMetadata{}, minSnapshotBlobBytes),
 		"exactly at the floor is acceptable")
 
 	require.EqualValues(t, 1<<20, minSnapshotBlobBytes,
@@ -857,15 +858,122 @@ func TestUndersizedSnapshotReason_NoBaselineAllowsStore(t *testing.T) {
 	// baseline" rather than as a reason to discard a good archive.
 	sc := &SnapshotCache{store: db.NewPreviewStore(mock), workerNodeID: "worker-1", logger: zerolog.Nop()}
 
-	require.Empty(t, sc.undersizedSnapshotReason(context.Background(),
+	require.Empty(t, sc.undersizedSnapshotReason(context.Background(), "snapshot-key",
 		SnapshotMetadata{OrgID: uuid.New(), RepoID: uuid.New(), BaseKey: "base"}, 50<<20),
 		"a base-key lookup failure must not block caching")
 
-	require.Empty(t, sc.undersizedSnapshotReason(context.Background(),
+	require.Empty(t, sc.undersizedSnapshotReason(context.Background(), "snapshot-key",
 		SnapshotMetadata{OrgID: uuid.New(), RepoID: uuid.New()}, 50<<20),
 		"no base key means no baseline to compare against")
 
-	require.NotEmpty(t, sc.undersizedSnapshotReason(context.Background(),
+	require.NotEmpty(t, sc.undersizedSnapshotReason(context.Background(), "snapshot-key",
 		SnapshotMetadata{}, minSnapshotBlobBytes-1),
 		"the absolute floor applies with or without a baseline")
+}
+
+// The shrink rule keeps a baseline that a rejected snapshot cannot replace, so
+// without an escape hatch a workspace that legitimately got smaller — or one
+// bad baseline — would reject every replacement for as long as the baseline
+// stays fresh. Repetition distinguishes the two: damage does not reproduce at
+// the same size, a genuine shrink does.
+func TestUndersizedSnapshotReason_RepeatedShrinkIsAccepted(t *testing.T) {
+	t.Parallel()
+
+	orgID, repoID := uuid.New(), uuid.New()
+	cacheCols := []string{
+		"id", "org_id", "repo_id", "snapshot_key", "base_key", "commit_sha", "blob_path",
+		"size_bytes", "worker_node_id", "last_used_at", "created_at",
+	}
+	priorSize := int64(100 << 20)
+	shrunk := priorSize / 10
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err)
+	defer mock.Close()
+	// One baseline row per lookup; the rule consults it on every attempt.
+	for i := 0; i < 3; i++ {
+		mock.ExpectQuery("SELECT").
+			WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+			WillReturnRows(pgxmock.NewRows(cacheCols).AddRow(
+				uuid.New(), orgID, repoID, "older-key", "base", "older-commit",
+				"/cache/older", priorSize, "worker-1", time.Now(), time.Now(),
+			))
+	}
+
+	sc := &SnapshotCache{store: db.NewPreviewStore(mock), workerNodeID: "worker-1", logger: zerolog.Nop()}
+	metadata := SnapshotMetadata{OrgID: orgID, RepoID: repoID, BaseKey: "base"}
+
+	require.NotEmpty(t, sc.undersizedSnapshotReason(context.Background(), "key-a", metadata, shrunk),
+		"the first collapse should be treated as damage and rejected")
+	require.Empty(t, sc.undersizedSnapshotReason(context.Background(), "key-a", metadata, shrunk),
+		"a collapse that reproduces is the new truth and must be stored")
+
+	// Accepting clears the count, so the rule is armed again rather than
+	// permanently disabled for that key.
+	require.NotEmpty(t, sc.undersizedSnapshotReason(context.Background(), "key-a", metadata, shrunk),
+		"the strike count should reset after an acceptance")
+}
+
+// Strikes must be consecutive: a normal-sized snapshot in between means the
+// earlier collapse was transient, so the next one starts from zero.
+func TestUndersizedSnapshotReason_NormalSnapshotResetsStrikes(t *testing.T) {
+	t.Parallel()
+
+	orgID, repoID := uuid.New(), uuid.New()
+	cacheCols := []string{
+		"id", "org_id", "repo_id", "snapshot_key", "base_key", "commit_sha", "blob_path",
+		"size_bytes", "worker_node_id", "last_used_at", "created_at",
+	}
+	priorSize := int64(100 << 20)
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err)
+	defer mock.Close()
+	for i := 0; i < 3; i++ {
+		mock.ExpectQuery("SELECT").
+			WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+			WillReturnRows(pgxmock.NewRows(cacheCols).AddRow(
+				uuid.New(), orgID, repoID, "older-key", "base", "older-commit",
+				"/cache/older", priorSize, "worker-1", time.Now(), time.Now(),
+			))
+	}
+
+	sc := &SnapshotCache{store: db.NewPreviewStore(mock), workerNodeID: "worker-1", logger: zerolog.Nop()}
+	metadata := SnapshotMetadata{OrgID: orgID, RepoID: repoID, BaseKey: "base"}
+
+	require.NotEmpty(t, sc.undersizedSnapshotReason(context.Background(), "key-b", metadata, priorSize/10),
+		"first collapse rejected")
+	require.Empty(t, sc.undersizedSnapshotReason(context.Background(), "key-b", metadata, priorSize),
+		"a normal-sized snapshot must be stored and clear the strike")
+	require.NotEmpty(t, sc.undersizedSnapshotReason(context.Background(), "key-b", metadata, priorSize/10),
+		"a later collapse starts from zero strikes, not from the earlier one")
+}
+
+// The absolute floor is not a heuristic and gets no escape hatch: an archive
+// that small cannot hold an installed dependency tree however often it repeats.
+func TestUndersizedSnapshotReason_AbsoluteFloorHasNoEscapeHatch(t *testing.T) {
+	t.Parallel()
+
+	sc := &SnapshotCache{logger: zerolog.Nop()}
+	for i := 0; i < snapshotShrinkRejectStrikes+2; i++ {
+		require.NotEmptyf(t, sc.undersizedSnapshotReason(context.Background(), "key-c", SnapshotMetadata{}, 0),
+			"attempt %d: an empty archive must never become acceptable", i+1)
+	}
+}
+
+// The strike map must not grow without bound on a long-lived worker.
+func TestNoteShrinkStrike_BoundsTrackedKeys(t *testing.T) {
+	t.Parallel()
+
+	sc := &SnapshotCache{logger: zerolog.Nop()}
+	for i := 0; i < maxTrackedShrinkStrikes+50; i++ {
+		sc.noteShrinkStrike(fmt.Sprintf("key-%d", i))
+	}
+	require.LessOrEqual(t, len(sc.shrinkStrikes), maxTrackedShrinkStrikes,
+		"the strike map should reset rather than grow forever")
+
+	// An empty key is not trackable and must not create an entry.
+	before := len(sc.shrinkStrikes)
+	require.Zero(t, sc.noteShrinkStrike(""), "an empty snapshot key has nothing to track")
+	require.Equal(t, before, len(sc.shrinkStrikes), "an empty key must not add an entry")
 }

--- a/internal/services/preview/snapshot_cache_test.go
+++ b/internal/services/preview/snapshot_cache_test.go
@@ -1,7 +1,6 @@
 package preview
 
 import (
-	"bytes"
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
@@ -518,6 +517,11 @@ func newCreateSnapshotFixture(t *testing.T, executor SnapshotExecutor, archiveLe
 		workerNodeID:  "worker-1",
 		maxCacheBytes: DefaultMaxCacheBytes,
 		logger:        zerolog.Nop(),
+		// Shrink the floor so these cases run on a handful of bytes instead of
+		// allocating and streaming a megabyte each. The real constant is
+		// exercised by TestUndersizedSnapshotReason_AbsoluteFloor, which needs
+		// no fixture at all.
+		minSnapshotBytesOverride: 8,
 	}
 	metadata := SnapshotMetadata{OrgID: uuid.New(), RepoID: uuid.New(), BaseKey: "base", CommitSHA: "abc123"}
 	if !expectStore {
@@ -529,8 +533,9 @@ func newCreateSnapshotFixture(t *testing.T, executor SnapshotExecutor, archiveLe
 		"size_bytes", "worker_node_id", "last_used_at", "created_at",
 	}
 	// The size floor consults the last snapshot for this base key before storing.
-	// Return a small baseline so the shrink rule is satisfied and only the
-	// absolute floor is in play; the shrink rule has its own test.
+	// Return a 1-byte baseline so the shrink rule is trivially satisfied and only
+	// the (overridden) absolute floor is in play; the shrink rule has its own
+	// test.
 	//
 	// WithArgs is required: pgxmock reads a missing WithArgs as "expects zero
 	// arguments", so without it this expectation never matches, stays
@@ -539,7 +544,7 @@ func newCreateSnapshotFixture(t *testing.T, executor SnapshotExecutor, archiveLe
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
 		WillReturnRows(pgxmock.NewRows(cacheCols).AddRow(
 			uuid.New(), metadata.OrgID, metadata.RepoID, "older-key", metadata.BaseKey, "older-commit",
-			filepath.Join(cacheDir, "older-blob"), int64(1024), "worker-1", time.Now(), time.Now(),
+			filepath.Join(cacheDir, "older-blob"), int64(1), "worker-1", time.Now(), time.Now(),
 		))
 	mock.ExpectQuery("INSERT INTO preview_startup_cache").
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
@@ -555,14 +560,13 @@ func newCreateSnapshotFixture(t *testing.T, executor SnapshotExecutor, archiveLe
 func TestSnapshotCache_CreateSnapshotStreamsArchiveToWorker(t *testing.T) {
 	t.Parallel()
 
-	// Above minSnapshotBlobBytes so the size floor lets it through; the floor
-	// itself is covered by TestSnapshotCache_CreateSnapshotRejectsUndersized.
-	archive := bytes.Repeat([]byte("streamed archive body"), 60_000)
+	archive := []byte("streamed archive body")
 	executor := &streamingRestoreExecutor{stdout: archive}
 	sc, metadata := newCreateSnapshotFixture(t, executor, len(archive), true)
 
-	err := sc.CreateSnapshot(context.Background(), &agent.Sandbox{ID: "sandbox-1", WorkDir: "/workspace/repo"}, "snapshot-key", metadata, nil)
+	sizeBytes, err := sc.CreateSnapshot(context.Background(), &agent.Sandbox{ID: "sandbox-1", WorkDir: "/workspace/repo"}, "snapshot-key", metadata, nil)
 	require.NoError(t, err, "CreateSnapshot should stream the archive to the worker")
+	require.EqualValues(t, len(archive), sizeBytes, "the reported size should be what was stored")
 
 	require.True(t, hasCmdContaining(executor.execCmds, "tar -c "),
 		"CreateSnapshot should run a sandbox-side tar, got %v", executor.execCmds)
@@ -591,11 +595,11 @@ func TestSnapshotCache_CreateSnapshotStreamsArchiveToWorker(t *testing.T) {
 func TestSnapshotCache_CreateSnapshotKeepsArchiveWhenFilesChangedUnderTar(t *testing.T) {
 	t.Parallel()
 
-	archive := bytes.Repeat([]byte("archive from a workspace that moved"), 40_000)
+	archive := []byte("archive from a workspace that moved")
 	executor := &streamingRestoreExecutor{stdout: archive, tarCreateExit: 1}
 	sc, metadata := newCreateSnapshotFixture(t, executor, len(archive), true)
 
-	err := sc.CreateSnapshot(context.Background(), &agent.Sandbox{ID: "sandbox-1", WorkDir: "/workspace/repo"}, "snapshot-key", metadata, nil)
+	_, err := sc.CreateSnapshot(context.Background(), &agent.Sandbox{ID: "sandbox-1", WorkDir: "/workspace/repo"}, "snapshot-key", metadata, nil)
 	require.NoError(t, err, "tar exit 1 on a live workspace must still produce a usable snapshot")
 
 	blobPath, err := sc.blobPath("snapshot-key")
@@ -613,7 +617,7 @@ func TestSnapshotCache_CreateSnapshotRejectsFatalTarExit(t *testing.T) {
 	executor := &streamingRestoreExecutor{stdout: []byte("truncated"), tarCreateExit: 2}
 	sc, metadata := newCreateSnapshotFixture(t, executor, 0, false)
 
-	err := sc.CreateSnapshot(context.Background(), &agent.Sandbox{ID: "sandbox-1", WorkDir: "/workspace/repo"}, "snapshot-key", metadata, nil)
+	_, err := sc.CreateSnapshot(context.Background(), &agent.Sandbox{ID: "sandbox-1", WorkDir: "/workspace/repo"}, "snapshot-key", metadata, nil)
 	require.Error(t, err, "a fatal tar exit must fail the create")
 	require.Contains(t, err.Error(), "tar exited 2")
 
@@ -737,12 +741,13 @@ func TestBoundedBuffer_UnderLimitIsVerbatim(t *testing.T) {
 func TestSnapshotCache_CreateSnapshotRejectsUndersizedArchive(t *testing.T) {
 	t.Parallel()
 
-	archive := []byte("almost nothing")
+	archive := []byte("tiny") // under the fixture's floor
 	executor := &streamingRestoreExecutor{stdout: archive}
 	sc, metadata := newCreateSnapshotFixture(t, executor, len(archive), false)
 
-	err := sc.CreateSnapshot(context.Background(), &agent.Sandbox{ID: "sandbox-1", WorkDir: "/workspace/repo"}, "snapshot-key", metadata, nil)
+	sizeBytes, err := sc.CreateSnapshot(context.Background(), &agent.Sandbox{ID: "sandbox-1", WorkDir: "/workspace/repo"}, "snapshot-key", metadata, nil)
 	require.Error(t, err, "an archive under the floor must not be stored")
+	require.Zero(t, sizeBytes, "nothing was stored, so the reported size must be zero")
 	require.ErrorIs(t, err, ErrSnapshotTooSmall,
 		"the caller needs to tell a rejected archive apart from a failed create")
 
@@ -773,14 +778,21 @@ func TestUndersizedSnapshotReason_ShrinkAgainstBaseKey(t *testing.T) {
 	priorSize := int64(100 << 20) // 100 MiB already stored for this base key
 
 	cases := []struct {
-		name       string
-		sizeBytes  int64
-		wantReject bool
+		name         string
+		sizeBytes    int64
+		baselineAge  time.Duration
+		wantReject   bool
+		wantContains string
 	}{
-		{"same size", priorSize, false},
-		{"modest shrink is normal drift", priorSize / 2, false},
-		{"just above the threshold", priorSize/4 + 1, false},
-		{"collapsed to a fraction", priorSize / 10, true},
+		{name: "same size", sizeBytes: priorSize, wantReject: false},
+		{name: "modest shrink is normal drift", sizeBytes: priorSize / 2, wantReject: false},
+		{name: "just above the threshold", sizeBytes: priorSize/4 + 1, wantReject: false},
+		{name: "collapsed to a fraction", sizeBytes: priorSize / 10, wantReject: true, wantContains: "stored for base key"},
+		// A rejected snapshot leaves the baseline in place, and restores keep it
+		// off the LRU chopping block, so without an age bound one bad baseline
+		// could reject its replacement forever.
+		{name: "stale baseline stops blocking", sizeBytes: priorSize / 10,
+			baselineAge: snapshotShrinkBaselineMaxAge + time.Hour, wantReject: false},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -789,11 +801,12 @@ func TestUndersizedSnapshotReason_ShrinkAgainstBaseKey(t *testing.T) {
 			require.NoError(t, err)
 			defer mock.Close()
 
+			createdAt := time.Now().Add(-tc.baselineAge)
 			mock.ExpectQuery("SELECT").
 				WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
 				WillReturnRows(pgxmock.NewRows(cacheCols).AddRow(
 					uuid.New(), orgID, repoID, "older-key", "base", "older-commit",
-					"/cache/older", priorSize, "worker-1", time.Now(), time.Now(),
+					"/cache/older", priorSize, "worker-1", time.Now(), createdAt,
 				))
 
 			sc := &SnapshotCache{store: db.NewPreviewStore(mock), workerNodeID: "worker-1", logger: zerolog.Nop()}
@@ -801,13 +814,35 @@ func TestUndersizedSnapshotReason_ShrinkAgainstBaseKey(t *testing.T) {
 				SnapshotMetadata{OrgID: orgID, RepoID: repoID, BaseKey: "base"}, tc.sizeBytes)
 
 			if tc.wantReject {
-				require.NotEmpty(t, reason, "a collapse against the stored baseline should be rejected")
-				require.Contains(t, reason, "already stored for base key")
+				require.NotEmpty(t, reason, "a collapse against a fresh baseline should be rejected")
+				require.Contains(t, reason, tc.wantContains)
 			} else {
-				require.Empty(t, reason, "this is plausible drift and must still be cached")
+				require.Empty(t, reason, "this must still be cached")
 			}
 		})
 	}
+}
+
+// The create tests shrink the floor so they can run on a few bytes. This one
+// pins the real constant, which needs no fixture at all — just integers.
+func TestUndersizedSnapshotReason_AbsoluteFloor(t *testing.T) {
+	t.Parallel()
+
+	sc := &SnapshotCache{logger: zerolog.Nop()} // no store: only the floor applies
+
+	require.NotEmpty(t, sc.undersizedSnapshotReason(context.Background(), SnapshotMetadata{}, 0),
+		"an empty archive must never be stored")
+	require.NotEmpty(t, sc.undersizedSnapshotReason(context.Background(), SnapshotMetadata{}, minSnapshotBlobBytes-1),
+		"one byte under the floor must be rejected")
+	require.Empty(t, sc.undersizedSnapshotReason(context.Background(), SnapshotMetadata{}, minSnapshotBlobBytes),
+		"exactly at the floor is acceptable")
+
+	require.EqualValues(t, 1<<20, minSnapshotBlobBytes,
+		"the floor is a deliberate 1 MiB: every snapshot describes a workspace with dependencies installed")
+	require.EqualValues(t, minSnapshotBlobBytes, sc.minBlobBytes(),
+		"an unset override must fall back to the real constant")
+	require.EqualValues(t, 64, (&SnapshotCache{minSnapshotBytesOverride: 64}).minBlobBytes(),
+		"a positive override replaces the floor so tests need no large fixtures")
 }
 
 // Without a baseline only the absolute floor applies — a first snapshot must

--- a/internal/services/preview/snapshot_cache_test.go
+++ b/internal/services/preview/snapshot_cache_test.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/assembledhq/143/internal/db"
 	"github.com/assembledhq/143/internal/models"
@@ -199,9 +200,37 @@ type streamingRestoreExecutor struct {
 	writeFromReaderCalled bool
 	writeFileCalled       bool
 	written               []byte
+	execCmds              []string
+	stdinCmds             []string
+	// stdinExit and stdinErr let a test force the extract to fail so the
+	// workspace-recovery path can be exercised.
+	stdinExit int
+	stdinErr  error
+	// stdout, when set, is written to the Exec stdout writer. Used by create
+	// tests to simulate the sandbox-side tar emitting the archive.
+	stdout []byte
 }
 
-func (e *streamingRestoreExecutor) Exec(_ context.Context, _ *agent.Sandbox, _ string, _, _ io.Writer) (int, error) {
+func (e *streamingRestoreExecutor) Exec(_ context.Context, _ *agent.Sandbox, cmd string, stdout, _ io.Writer) (int, error) {
+	e.execCmds = append(e.execCmds, cmd)
+	if len(e.stdout) > 0 && strings.HasPrefix(cmd, "tar -c ") {
+		if _, err := stdout.Write(e.stdout); err != nil {
+			return 1, err
+		}
+	}
+	return 0, nil
+}
+
+func (e *streamingRestoreExecutor) ExecWithStdin(_ context.Context, _ *agent.Sandbox, cmd string, stdin io.Reader, _, _ io.Writer) (int, error) {
+	e.stdinCmds = append(e.stdinCmds, cmd)
+	body, err := io.ReadAll(stdin)
+	if err != nil {
+		return 1, err
+	}
+	e.written = append([]byte(nil), body...)
+	if e.stdinErr != nil || e.stdinExit != 0 {
+		return e.stdinExit, e.stdinErr
+	}
 	return 0, nil
 }
 
@@ -222,6 +251,16 @@ func (e *streamingRestoreExecutor) WriteFileFromReader(_ context.Context, _ *age
 	}
 	e.written = append([]byte(nil), body...)
 	return nil
+}
+
+// hasCmdContaining reports whether any recorded command contains sub.
+func hasCmdContaining(cmds []string, sub string) bool {
+	for _, cmd := range cmds {
+		if strings.Contains(cmd, sub) {
+			return true
+		}
+	}
+	return false
 }
 
 func TestSnapshotCache_RestoreSnapshotStreamsBlobToSandbox(t *testing.T) {
@@ -263,10 +302,113 @@ func TestSnapshotCache_RestoreSnapshotStreamsBlobToSandbox(t *testing.T) {
 
 	err = sc.RestoreSnapshot(context.Background(), &agent.Sandbox{ID: "sandbox-1", WorkDir: "/workspace/repo"}, hit)
 	require.NoError(t, err, "RestoreSnapshot should restore a valid snapshot")
-	require.True(t, executor.writeFromReaderCalled, "RestoreSnapshot should stream the snapshot blob through WriteFileFromReader")
-	require.False(t, executor.writeFileCalled, "RestoreSnapshot should not materialize the blob through WriteFile")
 	require.Equal(t, body, executor.written, "RestoreSnapshot should stream the exact blob contents")
+	require.True(t, hasCmdContaining(executor.stdinCmds, "tar xf - -C '/workspace/repo'"),
+		"RestoreSnapshot should pipe the blob into a sandbox-side tar reading stdin, got %v", executor.stdinCmds)
+	require.False(t, executor.writeFromReaderCalled,
+		"RestoreSnapshot must not stage the blob on the sandbox filesystem — /tmp is a 256 MiB tmpfs")
+	require.False(t, executor.writeFileCalled, "RestoreSnapshot should not materialize the blob through WriteFile")
+	require.False(t, hasCmdContaining(executor.execCmds, "tar xf "+legacySnapshotTmpFile),
+		"RestoreSnapshot should not extract from the legacy staging file, got %v", executor.execCmds)
 	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
+}
+
+// A streaming extract can fail after the workspace has already been wiped,
+// where the old stage-then-extract form always failed before the wipe. The
+// caller treats a restore error as "launch cold" and reuses the sandbox, so a
+// failed extract must leave a workspace rebuilt from the clone rather than an
+// empty directory.
+func TestSnapshotCache_RestoreSnapshotRecoversWorkspaceOnExtractFailure(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "pgxmock pool should be created")
+	defer mock.Close()
+
+	cacheDir := t.TempDir()
+	blobPath := filepath.Join(cacheDir, "snapshot.tar.gz")
+	body := []byte("compressed snapshot body")
+	require.NoError(t, os.WriteFile(blobPath, body, 0o600), "snapshot blob should be written")
+
+	executor := &streamingRestoreExecutor{stdinExit: 2}
+	sc := &SnapshotCache{
+		store:    db.NewPreviewStore(mock),
+		executor: executor,
+		logger:   zerolog.Nop(),
+	}
+	hit := &CacheHit{
+		Entry: models.PreviewStartupCache{
+			ID:          uuid.New(),
+			OrgID:       uuid.New(),
+			SnapshotKey: "snapshot-key",
+			BlobPath:    blobPath,
+			SizeBytes:   int64(len(body)),
+		},
+		BlobPath: blobPath,
+	}
+
+	err = sc.RestoreSnapshot(context.Background(), &agent.Sandbox{ID: "sandbox-1", WorkDir: "/workspace/repo"}, hit)
+	require.Error(t, err, "a non-zero extract exit should fail the restore")
+	require.Contains(t, err.Error(), "tar exited 2", "the error should carry tar's exit code")
+	require.True(t, hasCmdContaining(executor.execCmds, "git checkout -f HEAD -- ."),
+		"a failed extract must rebuild the wiped workspace from the clone, got %v", executor.execCmds)
+}
+
+// The create path must archive straight to the worker. Staging inside the
+// sandbox capped snapshots at the 256 MiB /tmp tmpfs and charged the bytes to
+// the container's memory cgroup.
+func TestSnapshotCache_CreateSnapshotStreamsArchiveToWorker(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "pgxmock pool should be created")
+	defer mock.Close()
+
+	archive := []byte("streamed archive body")
+	executor := &streamingRestoreExecutor{stdout: archive}
+	cacheDir := t.TempDir()
+	sc := &SnapshotCache{
+		store:         db.NewPreviewStore(mock),
+		executor:      executor,
+		cacheDir:      cacheDir,
+		workerNodeID:  "worker-1",
+		maxCacheBytes: DefaultMaxCacheBytes,
+		logger:        zerolog.Nop(),
+	}
+
+	metadata := SnapshotMetadata{OrgID: uuid.New(), RepoID: uuid.New(), BaseKey: "base", CommitSHA: "abc123"}
+	mock.ExpectQuery("INSERT INTO preview_startup_cache").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
+			pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(pgxmock.NewRows([]string{
+			"id", "org_id", "repo_id", "snapshot_key", "base_key", "commit_sha", "blob_path",
+			"size_bytes", "worker_node_id", "last_used_at", "created_at",
+		}).AddRow(
+			uuid.New(), metadata.OrgID, metadata.RepoID, "snapshot-key", metadata.BaseKey, metadata.CommitSHA,
+			filepath.Join(cacheDir, "blob"), int64(len(archive)), "worker-1", time.Now(), time.Now(),
+		))
+	mock.ExpectQuery("SELECT").WillReturnRows(pgxmock.NewRows([]string{
+		"id", "org_id", "repo_id", "snapshot_key", "base_key", "commit_sha", "blob_path",
+		"size_bytes", "worker_node_id", "last_used_at", "created_at",
+	}))
+
+	err = sc.CreateSnapshot(context.Background(), &agent.Sandbox{ID: "sandbox-1", WorkDir: "/workspace/repo"}, "snapshot-key", metadata, nil)
+	require.NoError(t, err, "CreateSnapshot should stream the archive to the worker")
+
+	require.True(t, hasCmdContaining(executor.execCmds, "tar -c "),
+		"CreateSnapshot should run a sandbox-side tar, got %v", executor.execCmds)
+	require.True(t, hasCmdContaining(executor.execCmds, "-f - -C '/workspace/repo'"),
+		"CreateSnapshot must archive to stdout, not to a file inside the sandbox, got %v", executor.execCmds)
+	require.False(t, hasCmdContaining(executor.execCmds, "-f "+legacySnapshotTmpFile),
+		"CreateSnapshot must not stage the archive in the sandbox tmpfs, got %v", executor.execCmds)
+	require.False(t, hasCmdContaining(executor.execCmds, "cat "),
+		"CreateSnapshot should no longer need a second exec to read a staged file, got %v", executor.execCmds)
+
+	blobPath, err := sc.blobPath("snapshot-key")
+	require.NoError(t, err, "blob path should resolve")
+	written, err := os.ReadFile(blobPath) // #nosec G304 -- test-controlled temp dir
+	require.NoError(t, err, "the streamed blob should land on the worker's disk")
+	require.Equal(t, archive, written, "the worker blob should hold exactly what the sandbox tar emitted")
 }
 
 func TestSnapshotExtraExcludeFlags(t *testing.T) {

--- a/internal/services/preview/snapshot_cache_test.go
+++ b/internal/services/preview/snapshot_cache_test.go
@@ -411,6 +411,54 @@ func TestSnapshotCache_CreateSnapshotStreamsArchiveToWorker(t *testing.T) {
 	require.Equal(t, archive, written, "the worker blob should hold exactly what the sandbox tar emitted")
 }
 
+// The partial-invalidation patch must reach git over stdin. Writing it to
+// /tmp put up to maxPartialInvalidationDiffBytes into a 256 MiB tmpfs, whose
+// bytes come out of the sandbox's memory cgroup right before it builds.
+func TestSnapshotCache_ApplyPartialInvalidationStreamsDiff(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "pgxmock pool should be created")
+	defer mock.Close()
+
+	cacheDir := t.TempDir()
+	blobPath := filepath.Join(cacheDir, "snapshot.tar.gz")
+	body := []byte("compressed snapshot body")
+	require.NoError(t, os.WriteFile(blobPath, body, 0o600), "snapshot blob should be written")
+
+	executor := &streamingRestoreExecutor{}
+	sc := &SnapshotCache{
+		store:    db.NewPreviewStore(mock),
+		executor: executor,
+		logger:   zerolog.Nop(),
+	}
+	hit := &CacheHit{
+		Entry: models.PreviewStartupCache{
+			ID:          uuid.New(),
+			OrgID:       uuid.New(),
+			SnapshotKey: "snapshot-key",
+			BlobPath:    blobPath,
+			SizeBytes:   int64(len(body)),
+		},
+		BlobPath: blobPath,
+	}
+	mock.ExpectExec("UPDATE preview_startup_cache SET last_used_at").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
+
+	diff := []byte("diff --git a/x b/x\n@@ -1 +1 @@\n-a\n+b\n")
+	err = sc.ApplyPartialInvalidation(context.Background(), &agent.Sandbox{ID: "sandbox-1", WorkDir: "/workspace/repo"}, hit, diff)
+	require.NoError(t, err, "ApplyPartialInvalidation should apply a streamed diff")
+
+	require.True(t, hasCmdContaining(executor.stdinCmds, "git apply --allow-empty"),
+		"the patch should be piped into git apply over stdin, got %v", executor.stdinCmds)
+	require.Equal(t, diff, executor.written, "git apply should receive the exact diff bytes")
+	require.False(t, executor.writeFileCalled,
+		"ApplyPartialInvalidation must not stage the patch on the sandbox filesystem")
+	require.False(t, hasCmdContaining(executor.execCmds, "/tmp/partial.diff"),
+		"no command should reference the old /tmp patch path, got %v", executor.execCmds)
+}
+
 func TestSnapshotExtraExcludeFlags(t *testing.T) {
 	t.Parallel()
 

--- a/internal/services/preview/snapshot_cache_test.go
+++ b/internal/services/preview/snapshot_cache_test.go
@@ -196,27 +196,79 @@ func TestNewSnapshotCache_RequiresExecutor(t *testing.T) {
 	require.Contains(t, err.Error(), "executor must be non-nil")
 }
 
+// An executor that cannot stream stdin must be rejected at construction. Caught
+// at call time instead, it surfaces as a restore error, which the start path
+// swallows into a cold launch — the cache would silently never hit.
+func TestNewSnapshotCache_RequiresStdinCapableExecutor(t *testing.T) {
+	t.Parallel()
+
+	_, err := NewSnapshotCache(SnapshotCacheConfig{
+		Executor:     execWithoutStdin{},
+		CacheDir:     t.TempDir(),
+		WorkerNodeID: "worker-1",
+		Logger:       zerolog.Nop(),
+	})
+	require.Error(t, err, "an executor without ExecWithStdin should fail construction")
+	require.Contains(t, err.Error(), "ExecWithStdin")
+}
+
+func TestSnapshotTarExitTolerable(t *testing.T) {
+	t.Parallel()
+
+	// 0 is success; 1 is "some files differ" — tar still produced a complete
+	// archive, which on a live preview workspace is the common case and is worth
+	// keeping. 2 and up are fatal.
+	require.True(t, tarExitTolerable(0), "success must be tolerable")
+	require.True(t, tarExitTolerable(1), "a live workspace must not cost us the snapshot")
+	require.False(t, tarExitTolerable(2), "a fatal tar error must not be stored")
+	require.False(t, tarExitTolerable(137), "an OOM kill must not be stored")
+}
+
 type streamingRestoreExecutor struct {
 	writeFromReaderCalled bool
 	writeFileCalled       bool
-	written               []byte
 	execCmds              []string
 	stdinCmds             []string
-	// stdinExit and stdinErr let a test force the extract to fail so the
-	// workspace-recovery path can be exercised.
+	// stdinWrites records each stdin stream in call order, so a test that drives
+	// more than one (ApplyPartialInvalidation streams the blob, then the patch)
+	// can assert on the specific one it cares about rather than on whichever
+	// wrote last.
+	stdinWrites [][]byte
+	// stdinExit and stdinErr force the stdin exec to fail, exercising the
+	// workspace-recovery path.
 	stdinExit int
 	stdinErr  error
-	// stdout, when set, is written to the Exec stdout writer. Used by create
-	// tests to simulate the sandbox-side tar emitting the archive.
+	// tarCreateExit is the exit code returned for the create-side `tar -c`,
+	// letting a test drive the exit-1-on-a-live-workspace case.
+	tarCreateExit int
+	// failRecovery makes the git-checkout recovery exec fail, so the
+	// unrecoverable-workspace path can be reached.
+	failRecovery bool
+	// stdout, when set, is written to the Exec stdout writer for the create-side
+	// tar, simulating the sandbox emitting the archive.
 	stdout []byte
+}
+
+// lastStdinWrite returns the most recent stdin stream, or nil if there was none.
+func (e *streamingRestoreExecutor) lastStdinWrite() []byte {
+	if len(e.stdinWrites) == 0 {
+		return nil
+	}
+	return e.stdinWrites[len(e.stdinWrites)-1]
 }
 
 func (e *streamingRestoreExecutor) Exec(_ context.Context, _ *agent.Sandbox, cmd string, stdout, _ io.Writer) (int, error) {
 	e.execCmds = append(e.execCmds, cmd)
-	if len(e.stdout) > 0 && strings.HasPrefix(cmd, "tar -c ") {
-		if _, err := stdout.Write(e.stdout); err != nil {
-			return 1, err
+	if e.failRecovery && strings.Contains(cmd, "git checkout -f HEAD") {
+		return 1, nil
+	}
+	if strings.HasPrefix(cmd, "tar -c ") {
+		if len(e.stdout) > 0 {
+			if _, err := stdout.Write(e.stdout); err != nil {
+				return 2, err
+			}
 		}
+		return e.tarCreateExit, nil
 	}
 	return 0, nil
 }
@@ -225,9 +277,9 @@ func (e *streamingRestoreExecutor) ExecWithStdin(_ context.Context, _ *agent.San
 	e.stdinCmds = append(e.stdinCmds, cmd)
 	body, err := io.ReadAll(stdin)
 	if err != nil {
-		return 1, err
+		return 2, err
 	}
-	e.written = append([]byte(nil), body...)
+	e.stdinWrites = append(e.stdinWrites, append([]byte(nil), body...))
 	if e.stdinErr != nil || e.stdinExit != 0 {
 		return e.stdinExit, e.stdinErr
 	}
@@ -245,11 +297,9 @@ func (e *streamingRestoreExecutor) WriteFile(context.Context, *agent.Sandbox, st
 
 func (e *streamingRestoreExecutor) WriteFileFromReader(_ context.Context, _ *agent.Sandbox, _ string, reader io.Reader, _ int64) error {
 	e.writeFromReaderCalled = true
-	body, err := io.ReadAll(reader)
-	if err != nil {
+	if _, err := io.ReadAll(reader); err != nil {
 		return err
 	}
-	e.written = append([]byte(nil), body...)
 	return nil
 }
 
@@ -261,6 +311,21 @@ func hasCmdContaining(cmds []string, sub string) bool {
 		}
 	}
 	return false
+}
+
+// execWithoutStdin satisfies SnapshotExecutor but deliberately omits
+// ExecWithStdin, so it fails the sandboxStdinExecutor assertion.
+type execWithoutStdin struct{}
+
+func (execWithoutStdin) Exec(context.Context, *agent.Sandbox, string, io.Writer, io.Writer) (int, error) {
+	return 0, nil
+}
+func (execWithoutStdin) ReadFile(context.Context, *agent.Sandbox, string) ([]byte, error) {
+	return nil, nil
+}
+func (execWithoutStdin) WriteFile(context.Context, *agent.Sandbox, string, []byte) error { return nil }
+func (execWithoutStdin) WriteFileFromReader(context.Context, *agent.Sandbox, string, io.Reader, int64) error {
+	return nil
 }
 
 func TestSnapshotCache_RestoreSnapshotStreamsBlobToSandbox(t *testing.T) {
@@ -302,7 +367,7 @@ func TestSnapshotCache_RestoreSnapshotStreamsBlobToSandbox(t *testing.T) {
 
 	err = sc.RestoreSnapshot(context.Background(), &agent.Sandbox{ID: "sandbox-1", WorkDir: "/workspace/repo"}, hit)
 	require.NoError(t, err, "RestoreSnapshot should restore a valid snapshot")
-	require.Equal(t, body, executor.written, "RestoreSnapshot should stream the exact blob contents")
+	require.Equal(t, body, executor.lastStdinWrite(), "RestoreSnapshot should stream the exact blob contents")
 	require.True(t, hasCmdContaining(executor.stdinCmds, "tar xf - -C '/workspace/repo'"),
 		"RestoreSnapshot should pipe the blob into a sandbox-side tar reading stdin, got %v", executor.stdinCmds)
 	require.False(t, executor.writeFromReaderCalled,
@@ -348,24 +413,102 @@ func TestSnapshotCache_RestoreSnapshotRecoversWorkspaceOnExtractFailure(t *testi
 	}
 
 	err = sc.RestoreSnapshot(context.Background(), &agent.Sandbox{ID: "sandbox-1", WorkDir: "/workspace/repo"}, hit)
-	require.Error(t, err, "a non-zero extract exit should fail the restore")
+	require.Error(t, err, "a fatal extract exit should fail the restore")
 	require.Contains(t, err.Error(), "tar exited 2", "the error should carry tar's exit code")
 	require.True(t, hasCmdContaining(executor.execCmds, "git checkout -f HEAD -- ."),
 		"a failed extract must rebuild the wiped workspace from the clone, got %v", executor.execCmds)
+	require.NotErrorIs(t, err, ErrPreviewWorkspaceUnrecoverable,
+		"recovery succeeded, so the caller should still be free to launch cold")
 }
 
-// The create path must archive straight to the worker. Staging inside the
-// sandbox capped snapshots at the 256 MiB /tmp tmpfs and charged the bytes to
-// the container's memory cgroup.
-func TestSnapshotCache_CreateSnapshotStreamsArchiveToWorker(t *testing.T) {
+// When recovery itself fails the tree matches neither the snapshot nor the
+// checkout. That is the one case the caller must fail the start on rather than
+// build whatever is left, so it has to be distinguishable.
+func TestSnapshotCache_RestoreSnapshotFlagsUnrecoverableWorkspace(t *testing.T) {
 	t.Parallel()
 
 	mock, err := pgxmock.NewPool()
 	require.NoError(t, err, "pgxmock pool should be created")
 	defer mock.Close()
 
-	archive := []byte("streamed archive body")
-	executor := &streamingRestoreExecutor{stdout: archive}
+	cacheDir := t.TempDir()
+	blobPath := filepath.Join(cacheDir, "snapshot.tar.gz")
+	body := []byte("compressed snapshot body")
+	require.NoError(t, os.WriteFile(blobPath, body, 0o600), "snapshot blob should be written")
+
+	executor := &streamingRestoreExecutor{stdinExit: 2, failRecovery: true}
+	sc := &SnapshotCache{
+		store:    db.NewPreviewStore(mock),
+		executor: executor,
+		logger:   zerolog.Nop(),
+	}
+	hit := &CacheHit{
+		Entry: models.PreviewStartupCache{
+			ID: uuid.New(), OrgID: uuid.New(), SnapshotKey: "snapshot-key",
+			BlobPath: blobPath, SizeBytes: int64(len(body)),
+		},
+		BlobPath: blobPath,
+	}
+
+	err = sc.RestoreSnapshot(context.Background(), &agent.Sandbox{ID: "sandbox-1", WorkDir: "/workspace/repo"}, hit)
+	require.Error(t, err, "a failed extract with failed recovery must error")
+	require.ErrorIs(t, err, ErrPreviewWorkspaceUnrecoverable,
+		"the caller needs to tell this apart from an ordinary cold-launch fallback")
+}
+
+// A restore that reports non-fatal warnings still produced a tree. Throwing it
+// away costs a full cold launch, so keep it — a genuinely broken workspace
+// surfaces as a build failure moments later.
+func TestSnapshotCache_RestoreSnapshotToleratesTarWarnings(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "pgxmock pool should be created")
+	defer mock.Close()
+
+	cacheDir := t.TempDir()
+	blobPath := filepath.Join(cacheDir, "snapshot.tar.gz")
+	body := []byte("compressed snapshot body")
+	require.NoError(t, os.WriteFile(blobPath, body, 0o600), "snapshot blob should be written")
+
+	executor := &streamingRestoreExecutor{stdinExit: 1}
+	sc := &SnapshotCache{
+		store:    db.NewPreviewStore(mock),
+		executor: executor,
+		logger:   zerolog.Nop(),
+	}
+	hit := &CacheHit{
+		Entry: models.PreviewStartupCache{
+			ID: uuid.New(), OrgID: uuid.New(), SnapshotKey: "snapshot-key",
+			BlobPath: blobPath, SizeBytes: int64(len(body)),
+		},
+		BlobPath: blobPath,
+	}
+	mock.ExpectExec("UPDATE preview_startup_cache SET last_used_at").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
+
+	err = sc.RestoreSnapshot(context.Background(), &agent.Sandbox{ID: "sandbox-1", WorkDir: "/workspace/repo"}, hit)
+	require.NoError(t, err, "tar exit 1 should not throw away a restored workspace")
+	require.False(t, hasCmdContaining(executor.execCmds, "git checkout -f HEAD -- ."),
+		"a tolerated warning must not trigger workspace recovery, got %v", executor.execCmds)
+	require.NoError(t, mock.ExpectationsWereMet(), "the restore should have completed through the LRU touch")
+}
+
+// The create path must archive straight to the worker. Staging inside the
+// sandbox capped snapshots at the 256 MiB /tmp tmpfs and charged the bytes to
+// the container's memory cgroup.
+// newCreateSnapshotFixture wires a SnapshotCache over a pgxmock pool with the
+// upsert and post-create eviction queries stubbed, so create tests only have to
+// vary the executor's behaviour. expectStore=false skips the query expectations
+// for cases that fail before touching the database.
+func newCreateSnapshotFixture(t *testing.T, executor SnapshotExecutor, archiveLen int, expectStore bool) (*SnapshotCache, SnapshotMetadata) {
+	t.Helper()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "pgxmock pool should be created")
+	t.Cleanup(mock.Close)
+
 	cacheDir := t.TempDir()
 	sc := &SnapshotCache{
 		store:         db.NewPreviewStore(mock),
@@ -375,30 +518,44 @@ func TestSnapshotCache_CreateSnapshotStreamsArchiveToWorker(t *testing.T) {
 		maxCacheBytes: DefaultMaxCacheBytes,
 		logger:        zerolog.Nop(),
 	}
-
 	metadata := SnapshotMetadata{OrgID: uuid.New(), RepoID: uuid.New(), BaseKey: "base", CommitSHA: "abc123"}
+	if !expectStore {
+		return sc, metadata
+	}
+
+	cacheCols := []string{
+		"id", "org_id", "repo_id", "snapshot_key", "base_key", "commit_sha", "blob_path",
+		"size_bytes", "worker_node_id", "last_used_at", "created_at",
+	}
 	mock.ExpectQuery("INSERT INTO preview_startup_cache").
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
 			pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
-		WillReturnRows(pgxmock.NewRows([]string{
-			"id", "org_id", "repo_id", "snapshot_key", "base_key", "commit_sha", "blob_path",
-			"size_bytes", "worker_node_id", "last_used_at", "created_at",
-		}).AddRow(
+		WillReturnRows(pgxmock.NewRows(cacheCols).AddRow(
 			uuid.New(), metadata.OrgID, metadata.RepoID, "snapshot-key", metadata.BaseKey, metadata.CommitSHA,
-			filepath.Join(cacheDir, "blob"), int64(len(archive)), "worker-1", time.Now(), time.Now(),
+			filepath.Join(cacheDir, "blob"), int64(archiveLen), "worker-1", time.Now(), time.Now(),
 		))
-	mock.ExpectQuery("SELECT").WillReturnRows(pgxmock.NewRows([]string{
-		"id", "org_id", "repo_id", "snapshot_key", "base_key", "commit_sha", "blob_path",
-		"size_bytes", "worker_node_id", "last_used_at", "created_at",
-	}))
+	mock.ExpectQuery("SELECT").WillReturnRows(pgxmock.NewRows(cacheCols))
+	return sc, metadata
+}
 
-	err = sc.CreateSnapshot(context.Background(), &agent.Sandbox{ID: "sandbox-1", WorkDir: "/workspace/repo"}, "snapshot-key", metadata, nil)
+func TestSnapshotCache_CreateSnapshotStreamsArchiveToWorker(t *testing.T) {
+	t.Parallel()
+
+	archive := []byte("streamed archive body")
+	executor := &streamingRestoreExecutor{stdout: archive}
+	sc, metadata := newCreateSnapshotFixture(t, executor, len(archive), true)
+
+	err := sc.CreateSnapshot(context.Background(), &agent.Sandbox{ID: "sandbox-1", WorkDir: "/workspace/repo"}, "snapshot-key", metadata, nil)
 	require.NoError(t, err, "CreateSnapshot should stream the archive to the worker")
 
 	require.True(t, hasCmdContaining(executor.execCmds, "tar -c "),
 		"CreateSnapshot should run a sandbox-side tar, got %v", executor.execCmds)
-	require.True(t, hasCmdContaining(executor.execCmds, "-f - -C '/workspace/repo'"),
+	require.True(t, hasCmdContaining(executor.execCmds, "-f - "),
 		"CreateSnapshot must archive to stdout, not to a file inside the sandbox, got %v", executor.execCmds)
+	require.True(t, hasCmdContaining(executor.execCmds, "-C '/workspace/repo'"),
+		"CreateSnapshot should archive from the workspace root, got %v", executor.execCmds)
+	require.True(t, hasCmdContaining(executor.execCmds, "--ignore-failed-read"),
+		"a file vanishing mid-walk on a live workspace must not abort the archive, got %v", executor.execCmds)
 	require.False(t, hasCmdContaining(executor.execCmds, "-f "+legacySnapshotTmpFile),
 		"CreateSnapshot must not stage the archive in the sandbox tmpfs, got %v", executor.execCmds)
 	require.False(t, hasCmdContaining(executor.execCmds, "cat "),
@@ -409,6 +566,45 @@ func TestSnapshotCache_CreateSnapshotStreamsArchiveToWorker(t *testing.T) {
 	written, err := os.ReadFile(blobPath) // #nosec G304 -- test-controlled temp dir
 	require.NoError(t, err, "the streamed blob should land on the worker's disk")
 	require.Equal(t, archive, written, "the worker blob should hold exactly what the sandbox tar emitted")
+}
+
+// Snapshots are taken moments after the preview reports ready, so services are
+// actively writing into the tree tar is reading. tar exits 1 for that but still
+// produces a complete archive — discarding it would mean the busiest workspaces,
+// the ones most expensive to rebuild, are exactly the ones that never cache.
+func TestSnapshotCache_CreateSnapshotKeepsArchiveWhenFilesChangedUnderTar(t *testing.T) {
+	t.Parallel()
+
+	archive := []byte("archive from a workspace that moved")
+	executor := &streamingRestoreExecutor{stdout: archive, tarCreateExit: 1}
+	sc, metadata := newCreateSnapshotFixture(t, executor, len(archive), true)
+
+	err := sc.CreateSnapshot(context.Background(), &agent.Sandbox{ID: "sandbox-1", WorkDir: "/workspace/repo"}, "snapshot-key", metadata, nil)
+	require.NoError(t, err, "tar exit 1 on a live workspace must still produce a usable snapshot")
+
+	blobPath, err := sc.blobPath("snapshot-key")
+	require.NoError(t, err, "blob path should resolve")
+	written, err := os.ReadFile(blobPath) // #nosec G304 -- test-controlled temp dir
+	require.NoError(t, err, "the archive should have been stored despite the warning")
+	require.Equal(t, archive, written, "the stored blob should hold what tar emitted")
+}
+
+// Tolerance stops at exit 1. A fatal tar error means a broken or truncated
+// stream, which must never be stored as a restorable snapshot.
+func TestSnapshotCache_CreateSnapshotRejectsFatalTarExit(t *testing.T) {
+	t.Parallel()
+
+	executor := &streamingRestoreExecutor{stdout: []byte("truncated"), tarCreateExit: 2}
+	sc, metadata := newCreateSnapshotFixture(t, executor, 0, false)
+
+	err := sc.CreateSnapshot(context.Background(), &agent.Sandbox{ID: "sandbox-1", WorkDir: "/workspace/repo"}, "snapshot-key", metadata, nil)
+	require.Error(t, err, "a fatal tar exit must fail the create")
+	require.Contains(t, err.Error(), "tar exited 2")
+
+	blobPath, err := sc.blobPath("snapshot-key")
+	require.NoError(t, err, "blob path should resolve")
+	_, statErr := os.Stat(blobPath)
+	require.True(t, os.IsNotExist(statErr), "a fatally-failed archive must not be left on disk")
 }
 
 // The partial-invalidation patch must reach git over stdin. Writing it to
@@ -452,7 +648,7 @@ func TestSnapshotCache_ApplyPartialInvalidationStreamsDiff(t *testing.T) {
 
 	require.True(t, hasCmdContaining(executor.stdinCmds, "git apply --allow-empty"),
 		"the patch should be piped into git apply over stdin, got %v", executor.stdinCmds)
-	require.Equal(t, diff, executor.written, "git apply should receive the exact diff bytes")
+	require.Equal(t, diff, executor.lastStdinWrite(), "git apply should receive the exact diff bytes, and it should be the last stream")
 	require.False(t, executor.writeFileCalled,
 		"ApplyPartialInvalidation must not stage the patch on the sandbox filesystem")
 	require.False(t, hasCmdContaining(executor.execCmds, "/tmp/partial.diff"),

--- a/internal/services/preview/start_runner.go
+++ b/internal/services/preview/start_runner.go
@@ -1823,6 +1823,18 @@ func (r *StartRunner) maybeRestoreBranchPreviewStartupCache(ctx context.Context,
 		return keys, r.maybeRestoreBaseSnapshot(ctx, orgID, repoID, keys, sb)
 	}
 	if err := r.snapshotCache.RestoreSnapshot(ctx, sb, hit); err != nil {
+		// A restore failure normally just costs us the warm start: the workspace
+		// is still the git checkout, so launching cold produces the right code.
+		// ErrPreviewWorkspaceUnrecoverable is the exception — the tree matches
+		// neither the snapshot nor the checkout, and building it would serve
+		// something that is not this commit. Fail the start instead.
+		if errors.Is(err, ErrPreviewWorkspaceUnrecoverable) {
+			r.logger.Error().Err(err).
+				Str("repository_id", repoID.String()).
+				Str("snapshot_key", keys.SnapshotKey).
+				Msg("branch preview startup cache restore left the workspace unusable; failing the start")
+			return keys, err
+		}
 		r.logger.Warn().Err(err).
 			Str("repository_id", repoID.String()).
 			Str("snapshot_key", keys.SnapshotKey).

--- a/internal/services/preview/start_runner.go
+++ b/internal/services/preview/start_runner.go
@@ -147,6 +147,7 @@ const (
 	StartupSnapshotSkippedNoLockfiles StartupSnapshotResult = "skipped_no_lockfiles"
 	StartupSnapshotFailed             StartupSnapshotResult = "failed"
 	StartupSnapshotTooLarge           StartupSnapshotResult = "too_large"
+	StartupSnapshotTooSmall           StartupSnapshotResult = "too_small"
 	StartupSnapshotDisabled           StartupSnapshotResult = "disabled"
 )
 
@@ -1990,6 +1991,13 @@ func (r *StartRunner) createSessionPreviewStartupCache(ctx context.Context, orgI
 func startupSnapshotResultForCreateError(err error) StartupSnapshotResult {
 	if err == nil {
 		return StartupSnapshotSaved
+	}
+	// The floor rejects an archive that was produced successfully, so it is its
+	// own outcome rather than a failure — a run of these means the snapshot is
+	// capturing far less than it should, which is worth spotting in the logs
+	// before it looks like the cache "just never warms".
+	if errors.Is(err, ErrSnapshotTooSmall) {
+		return StartupSnapshotTooSmall
 	}
 	msg := err.Error()
 	if strings.Contains(msg, "too large") {

--- a/internal/services/preview/start_runner.go
+++ b/internal/services/preview/start_runner.go
@@ -129,7 +129,7 @@ type previewStartupCache interface {
 	FindBaseSnapshot(ctx context.Context, orgID, repoID uuid.UUID, baseKey, excludeCommitSHA string) (*CacheHit, error)
 	RestoreSnapshot(ctx context.Context, sb *agent.Sandbox, hit *CacheHit) error
 	ApplyPartialInvalidation(ctx context.Context, sb *agent.Sandbox, hit *CacheHit, gitDiff []byte) error
-	CreateSnapshot(ctx context.Context, sb *agent.Sandbox, snapshotKey string, metadata SnapshotMetadata, excludePaths []string) error
+	CreateSnapshot(ctx context.Context, sb *agent.Sandbox, snapshotKey string, metadata SnapshotMetadata, excludePaths []string) (int64, error)
 }
 
 // branchPreviewStartupCacheKeys carries the cache keys computed for one branch
@@ -1963,16 +1963,17 @@ func (r *StartRunner) createBranchPreviewStartupCache(ctx context.Context, orgID
 	// Keep runtime secret-file destinations and separately-restored build caches
 	// out of the worker-local blob (see previewSnapshotExcludePaths).
 	excludePaths := previewSnapshotExcludePaths(cfg)
-	if err := r.snapshotCache.CreateSnapshot(cacheCtx, sb, keys.SnapshotKey, metadata, excludePaths); err != nil {
+	sizeBytes, err := r.snapshotCache.CreateSnapshot(cacheCtx, sb, keys.SnapshotKey, metadata, excludePaths)
+	if err != nil {
 		result := startupSnapshotResultForCreateError(err)
 		r.logger.Warn().Err(err).
 			Str("repository_id", repoID.String()).
 			Str("snapshot_key", keys.SnapshotKey).
 			Msg("failed to create branch preview startup cache")
-		r.logBranchPreviewStartupSnapshotResult(repoID, keys.SnapshotKey, result, 0, started, err)
+		r.logBranchPreviewStartupSnapshotResult(repoID, keys.SnapshotKey, result, sizeBytes, started, err)
 		return result
 	}
-	r.logBranchPreviewStartupSnapshotResult(repoID, keys.SnapshotKey, StartupSnapshotSaved, 0, started, nil)
+	r.logBranchPreviewStartupSnapshotResult(repoID, keys.SnapshotKey, StartupSnapshotSaved, sizeBytes, started, nil)
 	return StartupSnapshotSaved
 }
 

--- a/internal/services/preview/start_runner_test.go
+++ b/internal/services/preview/start_runner_test.go
@@ -686,6 +686,7 @@ type fakePreviewStartupCache struct {
 	createExclude []string
 	createCalled  bool
 	createErr     error
+	createSize    int64
 	hit           *CacheHit
 
 	baseFindKey   string
@@ -718,12 +719,15 @@ func (f *fakePreviewStartupCache) ApplyPartialInvalidation(_ context.Context, _ 
 	return f.partialErr
 }
 
-func (f *fakePreviewStartupCache) CreateSnapshot(_ context.Context, _ *agent.Sandbox, snapshotKey string, metadata SnapshotMetadata, excludePaths []string) error {
+func (f *fakePreviewStartupCache) CreateSnapshot(_ context.Context, _ *agent.Sandbox, snapshotKey string, metadata SnapshotMetadata, excludePaths []string) (int64, error) {
 	f.createCalled = true
 	f.createKey = snapshotKey
 	f.createMeta = metadata
 	f.createExclude = append([]string(nil), excludePaths...)
-	return f.createErr
+	if f.createErr != nil {
+		return 0, f.createErr
+	}
+	return f.createSize, nil
 }
 
 type fakeStartRunnerSandboxProvider struct {


### PR DESCRIPTION
Two independent defects were keeping the Assembled org's previews slow and failing: **20.5% failure rate** over the last 30 days (261 of 1,276), **p50 475s** to ready, p90 711s.

## 1. `previewStopBackgroundWaitCap`: 3m to 10m

`StopPreview` deliberately blocks on the post-ready build-cache upload so a prewarm leaves its cache behind. The cap on that wait was 3 minutes — but a real save of a large monorepo's build tree runs 150–330s.

Warm-policy launches call `StopPreview` the *instant* the preview is ready, so the cap was almost always what decided the outcome:

| Save outcome | Count |
|---|---|
| `archive stream exited 128` | 568 |
| `archive stream exited 137` | 133 |
| `snapshot blob exceeds max size 2 GiB` | 6 |
| **saved** | **93** |

567 of the 568 exit-128s and 132 of the 133 exit-137s land within seconds of `stopped_at` — teardown killing the tar mid-archive, not the blob store hanging and not memory pressure.

The consequence compounds: one org's `build_artifact` entry was restored **588 times over 10 days without its content ever changing**. Every launch paid ~2 minutes to unpack a stale 1.1 GB blob, then rebuilt nearly everything anyway.

The cap is the only deadline that matters here — `Manager.StopPreviewWithReason` destroys the branch preview's sandbox as its next step, so the save's own timeout cannot extend past it. `previewCacheSaveTimeout` (15m) is named and documented for what it actually bounds: saves that aren't racing a stop.

## 2. Nothing stages in the sandbox tmpfs any more

`CreateSnapshot` wrote its archive to `/tmp/snapshot.tar.zst` inside the sandbox. `/tmp` is a **256 MiB tmpfs**, so any workspace whose archive exceeded that filled the mount and died a few seconds in:

```
snapshot create: tar exited 2: zstd: error 70 : Write error : cannot write block
```

For one repo this failed **13 times out of 13** — the feature that lets a launch skip clone, install and build has never once succeeded there. `RestoreSnapshot` had the same ceiling in the other direction, and `ApplyPartialInvalidation` wrote its patch (up to 32 MiB) to `/tmp/partial.diff`. Being tmpfs, all of it charged the sandbox's memory cgroup.

All three now stream — create archives to stdout, restore pipes the blob into `tar xf -`, and the patch goes into `git apply` over stdin (which drops a redundant `--stat` pass whose output went to `io.Discard` anyway). This matches the session-checkpoint path and the dependency cache's `stageSandboxArchive`, which both already stream.

## 3. Tar tolerance on a live workspace

Snapshots and cache saves archive a workspace that is *still serving*. Files move under tar as it reads them, and GNU tar exits 1 for that while still producing a complete archive — but every caller treated non-zero as fatal.

That inverts the intent: the busiest workspaces, the ones most expensive to rebuild, are exactly the ones most likely to trip it, so they'd be the ones that never cache. `tarExitTolerable` (0 and 1 usable, 2+ fatal) now covers snapshot create, snapshot restore, and the dependency/build cache archive, each logging tar's stderr so a torn entry stays diagnosable. Both archive commands also pass `--ignore-failed-read`.

The dependency cache's downstream `validateDependencyCacheArchive` still checks archive structure, so a truly broken blob is still rejected.

## Ordering hazard handled

Streaming moves the restore's failure point *after* the workspace wipe, where the two-step form always failed before it. A failed extract now rebuilds the tree from the clone (`.git` survives the wipe).

If recovery *itself* fails, the tree matches neither the snapshot nor the checkout — the one case worth failing a start over rather than serving something that isn't this commit. That's wrapped in `ErrPreviewWorkspaceUnrecoverable`, and `maybeRestoreBranchPreviewStartupCache` now fails on it instead of swallowing it into a cold launch. This is the contract `maybeRestoreBaseSnapshot` already documents.

`NewSnapshotCache` also now asserts the executor supports `ExecWithStdin`. Checked at call time it surfaced as a restore error, which the start path swallows — a misconfiguration would have shown up as a cache that silently never hit.

## Not included

Moving the cache-save tar out of the memory-capped cgroup. The data doesn't support it: the 128/137 exits are teardown, not OOM — memory-related save failures are 6 in 30 days (the 2 GiB blob cap). Doing it properly means `CopyFromContainer` so dockerd performs the tar, which rewrites archive layout with compatibility risk for existing blobs. Left for its own PR.

The real memory problem is the build itself — `service_build` peaks at a p95 of **10,068 MiB** against the `MaxPreviewMaxMemoryMiB` ceiling of 8,192 MiB, which is the 197 genuine OOM failures. That needs the ceiling raised (a worker-capacity question) or the build split, and is not touched here.

## Testing

`go test ./internal/...` green, `make lint` 0 issues. New coverage:

- create streams to stdout, passes `--ignore-failed-read`, no staging file, no second `cat` exec, and the worker blob holds exactly what the sandbox tar emitted
- create keeps the archive on tar exit 1; rejects exit 2 and leaves no blob on disk
- restore pipes the blob into `tar xf -` and never touches the sandbox filesystem
- restore tolerates exit 1 without triggering recovery; recovers the workspace on exit 2; flags `ErrPreviewWorkspaceUnrecoverable` when recovery also fails
- `ApplyPartialInvalidation` streams the patch and references no `/tmp` path
- `stageSandboxArchive` keeps the archive on "file changed as we read it" without retrying
- `NewSnapshotCache` rejects an executor without `ExecWithStdin`

Not verifiable without a live worker: that `zstd` now succeeds end-to-end on a >256 MiB workspace, and that real saves land inside 10 minutes. After deploy, watch the `preview build cache save saved` rate in `preview_logs` and the `branch preview startup snapshot result` worker log — repo `f03ac261` should stop reporting `failed` for the first time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
