### PR TITLE
Drop the transitional legacy snapshot staging cleanup

### DIFF
--- a/internal/services/preview/snapshot_cache.go
+++ b/internal/services/preview/snapshot_cache.go
@@ -30,20 +30,6 @@ import (
 const (
 	// DefaultMaxCacheBytes is 20 GB per worker.
 	DefaultMaxCacheBytes int64 = 20 * 1024 * 1024 * 1024
-
-	// legacySnapshotTmpFile is the path inside the sandbox where snapshots used
-	// to be staged before create/restore streamed directly to and from the
-	// worker. Create and restore no longer write it; it is still removed
-	// best-effort so a sandbox that ran an older build (or a create that failed
-	// partway under it) does not keep the file pinned in the tmpfs.
-	//
-	// Staging here was a latent cap on snapshot size: /tmp is a 256 MiB tmpfs
-	// (see the sandbox Tmpfs config in the docker agent provider), so any
-	// workspace whose archive exceeded that filled the mount and zstd died with
-	// "error 70 : Write error : cannot write block" a few seconds in. Because
-	// tmpfs is RAM, it also charged the sandbox's memory cgroup. Both directions
-	// now stream, so neither the size cap nor the memory charge applies.
-	legacySnapshotTmpFile = "/tmp/snapshot.tar.zst"
 )
 
 // ErrPreviewWorkspaceUnrecoverable marks a failure that left the sandbox
@@ -468,10 +454,10 @@ func (sc *SnapshotCache) CreateSnapshot(
 	//
 	//    `-f -` streams to stdout, which the exec pipes straight to the
 	//    worker-local temp file below. Nothing is staged inside the sandbox:
-	//    the previous two-step form wrote the whole archive to a 256 MiB tmpfs
-	//    first (see legacySnapshotTmpFile), which capped snapshots at that size
-	//    and charged the bytes to the sandbox's memory cgroup. The session
-	//    checkpoint path in the docker agent provider and the dependency cache's
+	//    the previous two-step form wrote the whole archive to /tmp — a 256 MiB
+	//    tmpfs — first, which capped snapshots at that size and charged the
+	//    bytes to the sandbox's memory cgroup. The session checkpoint path in
+	//    the docker agent provider and the dependency cache's
 	//    stageSandboxArchive both already stream this way.
 	//
 	//    --ignore-failed-read keeps a file that vanished mid-walk (a dev server
@@ -604,12 +590,7 @@ func (sc *SnapshotCache) CreateSnapshot(
 		return 0, fmt.Errorf("snapshot create: upsert db: %w", err)
 	}
 
-	// 5. Reclaim the legacy staging file if an older build left one behind. The
-	//    streaming create above never writes it, but the sandbox is long-lived
-	//    and 256 MiB of tmpfs held there is 256 MiB off the memory cgroup.
-	sc.removeLegacyStagingFile(ctx, sb)
-
-	// 6. Evict old entries if we are over the size limit.
+	// 5. Evict old entries if we are over the size limit.
 	if evictErr := sc.EvictLRU(ctx); evictErr != nil {
 		log.Warn().Err(evictErr).Msg("post-snapshot LRU eviction failed")
 	}
@@ -776,7 +757,7 @@ func (sc *SnapshotCache) RestoreSnapshot(
 	// 2. Open the blob. It is streamed straight into the sandbox's tar below
 	//    rather than staged to a file inside the sandbox first: the old staging
 	//    path capped restores at the 256 MiB /tmp tmpfs and charged the bytes to
-	//    the sandbox memory cgroup (see legacySnapshotTmpFile).
+	//    the sandbox memory cgroup.
 	streamExec, ok := sc.executor.(sandboxStdinExecutor)
 	if !ok {
 		return fmt.Errorf("snapshot restore: executor does not support streaming restore")
@@ -853,10 +834,7 @@ func (sc *SnapshotCache) RestoreSnapshot(
 			Msg("snapshot extracted with warnings; continuing with the restored workspace")
 	}
 
-	// 5. Reclaim the legacy staging file if an older build left one behind.
-	sc.removeLegacyStagingFile(ctx, sb)
-
-	// 6. Touch the cache entry to update LRU ordering.
+	// 5. Touch the cache entry to update LRU ordering.
 	if err := sc.store.TouchCache(ctx, hit.Entry.OrgID, hit.Entry.ID); err != nil {
 		log.Warn().Err(err).Msg("failed to touch cache entry after restore")
 	}
@@ -867,19 +845,6 @@ func (sc *SnapshotCache) RestoreSnapshot(
 		Msg("filesystem snapshot restored")
 
 	return nil
-}
-
-// removeLegacyStagingFile best-effort deletes the pre-streaming staging file
-// from the sandbox. Create and restore no longer write it, but a sandbox that
-// previously ran an older build may still be holding it — and since /tmp is a
-// tmpfs, those bytes sit in the container's memory cgroup until removed.
-//
-// TODO(2026-08): transitional. Preview sandboxes do not outlive a deploy, so
-// once every worker has run a build containing the streaming create/restore,
-// nothing can be writing this path any more and both this helper and its two
-// call sites should go.
-func (sc *SnapshotCache) removeLegacyStagingFile(ctx context.Context, sb *agent.Sandbox) {
-	_, _ = sc.executor.Exec(ctx, sb, fmt.Sprintf("rm -f %s", shellQuote(legacySnapshotTmpFile)), io.Discard, io.Discard)
 }
 
 // recoverWorkspaceFromGit rebuilds the working tree from the sandbox's git
@@ -946,7 +911,7 @@ func (sc *SnapshotCache) ApplyPartialInvalidation(
 	//    stdin when given no file argument, so the patch never lands on the
 	//    sandbox filesystem — it used to be written to /tmp, a 256 MiB tmpfs
 	//    whose bytes come out of the container's memory cgroup (the same reason
-	//    snapshot archives no longer stage there; see legacySnapshotTmpFile).
+	//    snapshot archives no longer stage there).
 	//    Diffs are capped at maxPartialInvalidationDiffBytes, so this was never
 	//    a correctness limit, only avoidable memory pressure on a sandbox that
 	//    is about to build.

--- a/internal/services/preview/snapshot_cache_test.go
+++ b/internal/services/preview/snapshot_cache_test.go
@@ -374,8 +374,8 @@ func TestSnapshotCache_RestoreSnapshotStreamsBlobToSandbox(t *testing.T) {
 	require.False(t, executor.writeFromReaderCalled,
 		"RestoreSnapshot must not stage the blob on the sandbox filesystem — /tmp is a 256 MiB tmpfs")
 	require.False(t, executor.writeFileCalled, "RestoreSnapshot should not materialize the blob through WriteFile")
-	require.False(t, hasCmdContaining(executor.execCmds, "tar xf "+legacySnapshotTmpFile),
-		"RestoreSnapshot should not extract from the legacy staging file, got %v", executor.execCmds)
+	require.False(t, hasCmdContaining(executor.execCmds, "tar xf /tmp/snapshot.tar.zst"),
+		"RestoreSnapshot should not extract from the pre-streaming staging path, got %v", executor.execCmds)
 	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
 }
 
@@ -577,7 +577,7 @@ func TestSnapshotCache_CreateSnapshotStreamsArchiveToWorker(t *testing.T) {
 		"CreateSnapshot should archive from the workspace root, got %v", executor.execCmds)
 	require.True(t, hasCmdContaining(executor.execCmds, "--ignore-failed-read"),
 		"a file vanishing mid-walk on a live workspace must not abort the archive, got %v", executor.execCmds)
-	require.False(t, hasCmdContaining(executor.execCmds, "-f "+legacySnapshotTmpFile),
+	require.False(t, hasCmdContaining(executor.execCmds, "-f /tmp/snapshot.tar.zst"),
 		"CreateSnapshot must not stage the archive in the sandbox tmpfs, got %v", executor.execCmds)
 	require.False(t, hasCmdContaining(executor.execCmds, "cat "),
 		"CreateSnapshot should no longer need a second exec to read a staged file, got %v", executor.execCmds)


### PR DESCRIPTION
## Summary

#1959 switched snapshot create/restore to stream to and from the worker, so nothing stages an archive at `/tmp/snapshot.tar.zst` inside the sandbox any more. It kept a best-effort `rm -f` on that path to reclaim the file from sandboxes carried over from pre-streaming builds — costing an extra sandbox exec on every create and every restore, forever. Preview sandboxes do not outlive a deploy, so a sandbox only ever runs the build of the worker that owns it; the helper had nothing to reclaim even during the rollout it was written for. #1959 is on main now, so every build cut from here contains the streaming create/restore.

## Changes

- Remove `removeLegacyStagingFile`, the `legacySnapshotTmpFile` constant, and both call sites; renumber the trailing steps in `CreateSnapshot` and `RestoreSnapshot`. No behavior change beyond dropping two per-operation sandbox execs.
- Keep the two regression assertions that referenced the constant, with the path inlined — they pin that create/restore do not regress to a staged archive, which is still worth guarding.
- Three comments in `CreateSnapshot`, `RestoreSnapshot`, and `ApplyPartialInvalidation` cited the constant by name; they keep the 256 MiB tmpfs rationale and drop the dangling reference.

## Validation

- `make lint` — 0 issues.
- `go test ./internal/services/preview/...` — passes, including the two streaming regression tests above.

## Notes for reviewers

The `TODO(2026-08)` this closes out set a precondition: every alive worker on a build containing the streaming change. That is **not yet true** — all 6 alive workers still run pre-streaming builds (5 on `5819312cd`, 1 on `5693f11c2`). It becomes true by the time this matters, since this removal ships through the same merge-and-deploy and any build from main now contains the change, and sandboxes are destroyed on deploy. Worth confirming the fleet has rolled before merging, but there is no ordering where the helper's absence bites.

Two gotchas if you re-run the check yourself:

- #1959 landed rebased as `a3b799077`, not `e8113998d` (identical patch-id `e07974ab`), so an ancestry test against the original SHA gives a false negative — compare file content instead.
- In `nodes`, the live status value is `active`, not `alive`; querying `status='alive'` returns zero rows, which reads as "no workers" rather than "wrong query."

Unrelated, but surfaced while checking: worker `worker-100-94-241-12` has been on `5693f11c2` since 18:22 while the rest of the fleet rolled at 22:40 — it may have missed a deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
