### PR TITLE
Add code review section as the first feature on landing page

### DIFF
--- a/frontend/src/app/(landing)/layout.tsx
+++ b/frontend/src/app/(landing)/layout.tsx
@@ -1,3 +1,9 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  description: "The open-source cloud for coding agents.",
+};
+
 export default function LandingLayout({
   children,
 }: {

--- a/frontend/src/app/(landing)/page.test.tsx
+++ b/frontend/src/app/(landing)/page.test.tsx
@@ -39,7 +39,7 @@ describe("LandingPage", () => {
     ]);
     expect(
       screen.getByRole("heading", {
-        name: "Agents made code faster to write. Review is where it piles up.",
+        name: "Code review that approves the pull requests it should.",
       }),
     ).toBeInTheDocument();
   });

--- a/frontend/src/app/(landing)/page.test.tsx
+++ b/frontend/src/app/(landing)/page.test.tsx
@@ -18,10 +18,29 @@ describe("LandingPage", () => {
     render(<LandingPage />);
 
     expect(screen.getByTestId("hero-canvas")).toBeInTheDocument();
-    expect(screen.getByRole("heading", { name: "Where your whole team builds software together" })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Automate code review. Merge without the wait." })).toBeInTheDocument();
     expect(screen.getByRole("heading", { name: "Run any coding agent." })).toBeInTheDocument();
     expect(screen.getByRole("heading", { name: "Connect your engineering tools." })).toBeInTheDocument();
     expect(screen.getByRole("heading", { name: "Put your agents to work." })).toBeInTheDocument();
     expect(screen.queryByText(/mission control/i)).not.toBeInTheDocument();
+  });
+
+  it("puts code review directly below the hero, ahead of the platform story", () => {
+    const { container } = render(<LandingPage />);
+
+    const sectionIds = Array.from(container.querySelectorAll("section")).map(
+      (section) => section.id,
+    );
+
+    expect(sectionIds).toEqual([
+      "code-review",
+      "how-it-works",
+      "integrations",
+    ]);
+    expect(
+      screen.getByRole("heading", {
+        name: "Code review that approves the pull requests it should.",
+      }),
+    ).toBeInTheDocument();
   });
 });

--- a/frontend/src/app/(landing)/page.test.tsx
+++ b/frontend/src/app/(landing)/page.test.tsx
@@ -18,7 +18,7 @@ describe("LandingPage", () => {
     render(<LandingPage />);
 
     expect(screen.getByTestId("hero-canvas")).toBeInTheDocument();
-    expect(screen.getByRole("heading", { name: "Automate code review. Merge without the wait." })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Where your whole team builds software together" })).toBeInTheDocument();
     expect(screen.getByRole("heading", { name: "Run any coding agent." })).toBeInTheDocument();
     expect(screen.getByRole("heading", { name: "Connect your engineering tools." })).toBeInTheDocument();
     expect(screen.getByRole("heading", { name: "Put your agents to work." })).toBeInTheDocument();

--- a/frontend/src/app/(landing)/page.test.tsx
+++ b/frontend/src/app/(landing)/page.test.tsx
@@ -39,7 +39,7 @@ describe("LandingPage", () => {
     ]);
     expect(
       screen.getByRole("heading", {
-        name: "Code review that approves the pull requests it should.",
+        name: "Agents made code faster to write. Review is where it piles up.",
       }),
     ).toBeInTheDocument();
   });

--- a/frontend/src/app/(landing)/page.test.tsx
+++ b/frontend/src/app/(landing)/page.test.tsx
@@ -18,7 +18,7 @@ describe("LandingPage", () => {
     render(<LandingPage />);
 
     expect(screen.getByTestId("hero-canvas")).toBeInTheDocument();
-    expect(screen.getByRole("heading", { name: "Where your whole team builds software together" })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Ship as fast as you build" })).toBeInTheDocument();
     expect(screen.getByRole("heading", { name: "Run any coding agent." })).toBeInTheDocument();
     expect(screen.getByRole("heading", { name: "Connect your engineering tools." })).toBeInTheDocument();
     expect(screen.getByRole("heading", { name: "Put your agents to work." })).toBeInTheDocument();

--- a/frontend/src/app/(landing)/page.test.tsx
+++ b/frontend/src/app/(landing)/page.test.tsx
@@ -39,7 +39,7 @@ describe("LandingPage", () => {
     ]);
     expect(
       screen.getByRole("heading", {
-        name: "Code review that approves the pull requests it should.",
+        name: "Code review that can auto-approve.",
       }),
     ).toBeInTheDocument();
   });

--- a/frontend/src/app/(landing)/page.tsx
+++ b/frontend/src/app/(landing)/page.tsx
@@ -2,6 +2,7 @@
 
 import { usePrefersDark } from "@/hooks/use-prefers-dark";
 import HeroSection from "@/components/landing/hero-section";
+import CodeReviewSection from "@/components/landing/code-review-section";
 import HowItWorksSection from "@/components/landing/how-it-works-section";
 import IntegrationsSection from "@/components/landing/integrations-section";
 import CtaSection from "@/components/landing/cta-section";
@@ -14,6 +15,7 @@ export default function LandingPage() {
   return (
     <div className={layout.pageRoot}>
       <HeroSection isDark={isDark} />
+      <CodeReviewSection isDark={isDark} />
       <HowItWorksSection isDark={isDark} />
       <IntegrationsSection isDark={isDark} />
       <CtaSection isDark={isDark} />

--- a/frontend/src/components/landing/code-review-section.test.tsx
+++ b/frontend/src/components/landing/code-review-section.test.tsx
@@ -1,0 +1,67 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import CodeReviewSection from "./code-review-section";
+import { landingTypography } from "./landing-typography";
+
+describe("CodeReviewSection", () => {
+  it("leads the homepage story with automated code review", () => {
+    render(<CodeReviewSection isDark={false} />);
+
+    const heading = screen.getByRole("heading", {
+      level: 2,
+      name: "Code review that approves the pull requests it should.",
+    });
+
+    expect(heading.className).toContain(landingTypography.sectionTitle);
+    expect(screen.getByText("01 Code review")).toBeInTheDocument();
+  });
+
+  it("shows the auto-approval verdict with the evidence behind it", () => {
+    render(<CodeReviewSection isDark={false} />);
+
+    expect(
+      screen.getByText("143 Code Reviewer approved this PR"),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Approved")).toBeInTheDocument();
+    expect(screen.getByText("Codex clean, Claude Code clean")).toBeInTheDocument();
+    expect(screen.getByText(/Policy v12/)).toBeInTheDocument();
+  });
+
+  it("keeps the escalation path visible alongside the approval", () => {
+    render(<CodeReviewSection isDark={false} />);
+
+    expect(
+      screen.getByText("143 Code Reviewer did not approve this PR"),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Needs human review")).toBeInTheDocument();
+    expect(screen.getByText(/Auth-sensitive paths changed/)).toBeInTheDocument();
+  });
+
+  it("calls out faster reviews, strict policy, and unblocked merges", () => {
+    render(<CodeReviewSection isDark={false} />);
+
+    expect(
+      screen.getByRole("heading", { level: 3, name: "Reviews finish in minutes" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", {
+        level: 3,
+        name: "Policy is enforced, not remembered",
+      }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", {
+        level: 3,
+        name: "Review stops blocking the merge",
+      }),
+    ).toBeInTheDocument();
+  });
+
+  it("links to the code review policy guide", () => {
+    render(<CodeReviewSection isDark={false} />);
+
+    expect(
+      screen.getByRole("link", { name: /configure the review policy/i }),
+    ).toHaveAttribute("href", "/docs/guides/code-review-policy");
+  });
+});

--- a/frontend/src/components/landing/code-review-section.test.tsx
+++ b/frontend/src/components/landing/code-review-section.test.tsx
@@ -15,7 +15,7 @@ describe("CodeReviewSection", () => {
     expect(heading.className).toContain(landingTypography.sectionTitle);
     expect(screen.getByText("01 Code review")).toBeInTheDocument();
     expect(
-      screen.getByText(/reviewing it is the bottleneck/),
+      screen.getByText(/getting it reviewed takes days/),
     ).toBeInTheDocument();
   });
 

--- a/frontend/src/components/landing/code-review-section.test.tsx
+++ b/frontend/src/components/landing/code-review-section.test.tsx
@@ -9,34 +9,11 @@ describe("CodeReviewSection", () => {
 
     const heading = screen.getByRole("heading", {
       level: 2,
-      name: "Agents made code faster to write. Review is where it piles up.",
+      name: "Code review that approves the pull requests it should.",
     });
 
     expect(heading.className).toContain(landingTypography.sectionTitle);
     expect(screen.getByText("01 Code review")).toBeInTheDocument();
-  });
-
-  it("names the review bottlenecks before offering the answer", () => {
-    render(<CodeReviewSection isDark={false} />);
-
-    expect(
-      screen.getByRole("heading", { level: 3, name: "More pull requests" }),
-    ).toBeInTheDocument();
-    expect(
-      screen.getByRole("heading", {
-        level: 3,
-        name: "Larger, less cohesive changes",
-      }),
-    ).toBeInTheDocument();
-    expect(
-      screen.getByRole("heading", {
-        level: 3,
-        name: "Authors who don't review code",
-      }),
-    ).toBeInTheDocument();
-    expect(
-      screen.getByRole("heading", { level: 3, name: "Stacks stuck for days" }),
-    ).toBeInTheDocument();
   });
 
   it("shows the auto-approval verdict with the evidence behind it", () => {
@@ -60,41 +37,22 @@ describe("CodeReviewSection", () => {
     expect(screen.getByText(/Auth-sensitive paths changed/)).toBeInTheDocument();
   });
 
-  it("calls out faster reviews, strict policy, reviewer burden, and unblocked merges", () => {
+  it("lists the outcomes as supporting bullets instead of extra cards", () => {
     render(<CodeReviewSection isDark={false} />);
 
     expect(
-      screen.getByRole("heading", {
-        level: 3,
-        name: "Reviews finish in minutes, not days",
-      }),
+      screen.getByText(/Reviews finish in minutes, not days/),
     ).toBeInTheDocument();
     expect(
-      screen.getByRole("heading", {
-        level: 3,
-        name: "Policy is enforced, not remembered",
-      }),
+      screen.getByText(/Policy is enforced the same way on every pull request/),
     ).toBeInTheDocument();
     expect(
-      screen.getByRole("heading", {
-        level: 3,
-        name: "Hard feedback without the interpersonal cost",
-      }),
+      screen.getByText(/Hard feedback lands without the interpersonal cost/),
     ).toBeInTheDocument();
     expect(
-      screen.getByRole("heading", {
-        level: 3,
-        name: "Review stops blocking the merge",
-      }),
+      screen.getByText(/Acceptable-risk changes merge on the spot/),
     ).toBeInTheDocument();
-  });
-
-  it("frames the auto-approval rate as the metric to move", () => {
-    render(<CodeReviewSection isDark={false} />);
-
-    expect(
-      screen.getByText(/share of your pull requests that get approved this way/),
-    ).toBeInTheDocument();
+    expect(screen.queryAllByRole("heading", { level: 3 })).toHaveLength(1);
   });
 
   it("links to the code review policy guide", () => {

--- a/frontend/src/components/landing/code-review-section.test.tsx
+++ b/frontend/src/components/landing/code-review-section.test.tsx
@@ -15,7 +15,7 @@ describe("CodeReviewSection", () => {
     expect(heading.className).toContain(landingTypography.sectionTitle);
     expect(screen.getByText("01 Code review")).toBeInTheDocument();
     expect(
-      screen.getByText(/Review is now the bottleneck/),
+      screen.getByText(/Reviewing it is the bottleneck/),
     ).toBeInTheDocument();
   });
 
@@ -40,23 +40,23 @@ describe("CodeReviewSection", () => {
     expect(screen.getByText(/Auth-sensitive paths changed/)).toBeInTheDocument();
   });
 
-  it("focuses the copy column on policy tuning and reviewer choice", () => {
+  it("focuses the copy column on policy tuning and reviewer model choice", () => {
     render(<CodeReviewSection isDark={false} />);
 
     expect(
       screen.getByRole("heading", {
         level: 3,
-        name: "Tune the policy. Pick the reviewers.",
+        name: "Tune the policy. Pick the reviewer models.",
       }),
     ).toBeInTheDocument();
     expect(
-      screen.getByText(/thresholds, sensitive paths, and required checks/),
+      screen.getByText(/The reviewers are coding agents, not people/),
     ).toBeInTheDocument();
     expect(
-      screen.getByText(/Run one reviewer agent or several in parallel/),
+      screen.getByText(/Choose reviewer models: Codex, Claude Code, OpenCode/),
     ).toBeInTheDocument();
     expect(
-      screen.getByText(/model and reasoning depth to balance cost and quality/),
+      screen.getByText(/Set reasoning depth per reviewer to control cost/),
     ).toBeInTheDocument();
     expect(screen.queryAllByRole("heading", { level: 3 })).toHaveLength(1);
   });

--- a/frontend/src/components/landing/code-review-section.test.tsx
+++ b/frontend/src/components/landing/code-review-section.test.tsx
@@ -4,16 +4,29 @@ import CodeReviewSection from "./code-review-section";
 import { landingTypography } from "./landing-typography";
 
 describe("CodeReviewSection", () => {
-  it("leads the homepage story with automated code review", () => {
+  it("leads with the review bottleneck, then automated code review", () => {
     render(<CodeReviewSection isDark={false} />);
 
-    const heading = screen.getByRole("heading", {
+    const problemHeading = screen.getByRole("heading", {
+      level: 2,
+      name: "Agents made code faster to write. Review is where it piles up.",
+    });
+    const answerHeading = screen.getByRole("heading", {
       level: 2,
       name: "Code review that approves the pull requests it should.",
     });
 
-    expect(heading.className).toContain(landingTypography.sectionTitle);
-    expect(screen.getByText("01 Code review")).toBeInTheDocument();
+    expect(problemHeading.className).toContain(landingTypography.sectionTitle);
+    expect(answerHeading.className).toContain(landingTypography.sectionTitle);
+    expect(
+      problemHeading.compareDocumentPosition(answerHeading) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+    expect(screen.getByText("01 Why this matters")).toBeInTheDocument();
+    expect(screen.getByText("02 Code review")).toBeInTheDocument();
+    expect(
+      screen.getByText(/More pull requests than review capacity/),
+    ).toBeInTheDocument();
   });
 
   it("shows the auto-approval verdict with the evidence behind it", () => {
@@ -37,20 +50,23 @@ describe("CodeReviewSection", () => {
     expect(screen.getByText(/Auth-sensitive paths changed/)).toBeInTheDocument();
   });
 
-  it("lists the outcomes as supporting bullets instead of extra cards", () => {
+  it("focuses the copy column on policy tuning and reviewer choice", () => {
     render(<CodeReviewSection isDark={false} />);
 
     expect(
-      screen.getByText(/Reviews finish in minutes, not days/),
+      screen.getByRole("heading", {
+        level: 3,
+        name: "Tune the policy. Pick the reviewers.",
+      }),
     ).toBeInTheDocument();
     expect(
-      screen.getByText(/Policy is enforced the same way on every pull request/),
+      screen.getByText(/thresholds, sensitive paths, and required checks/),
     ).toBeInTheDocument();
     expect(
-      screen.getByText(/Hard feedback lands without the interpersonal cost/),
+      screen.getByText(/Run one reviewer agent or several in parallel/),
     ).toBeInTheDocument();
     expect(
-      screen.getByText(/Acceptable-risk changes merge on the spot/),
+      screen.getByText(/model and reasoning depth to balance cost and quality/),
     ).toBeInTheDocument();
     expect(screen.queryAllByRole("heading", { level: 3 })).toHaveLength(1);
   });

--- a/frontend/src/components/landing/code-review-section.test.tsx
+++ b/frontend/src/components/landing/code-review-section.test.tsx
@@ -9,11 +9,34 @@ describe("CodeReviewSection", () => {
 
     const heading = screen.getByRole("heading", {
       level: 2,
-      name: "Code review that approves the pull requests it should.",
+      name: "Agents made code faster to write. Review is where it piles up.",
     });
 
     expect(heading.className).toContain(landingTypography.sectionTitle);
     expect(screen.getByText("01 Code review")).toBeInTheDocument();
+  });
+
+  it("names the review bottlenecks before offering the answer", () => {
+    render(<CodeReviewSection isDark={false} />);
+
+    expect(
+      screen.getByRole("heading", { level: 3, name: "More pull requests" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", {
+        level: 3,
+        name: "Larger, less cohesive changes",
+      }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", {
+        level: 3,
+        name: "Authors who don't review code",
+      }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { level: 3, name: "Stacks stuck for days" }),
+    ).toBeInTheDocument();
   });
 
   it("shows the auto-approval verdict with the evidence behind it", () => {
@@ -37,11 +60,14 @@ describe("CodeReviewSection", () => {
     expect(screen.getByText(/Auth-sensitive paths changed/)).toBeInTheDocument();
   });
 
-  it("calls out faster reviews, strict policy, and unblocked merges", () => {
+  it("calls out faster reviews, strict policy, reviewer burden, and unblocked merges", () => {
     render(<CodeReviewSection isDark={false} />);
 
     expect(
-      screen.getByRole("heading", { level: 3, name: "Reviews finish in minutes" }),
+      screen.getByRole("heading", {
+        level: 3,
+        name: "Reviews finish in minutes, not days",
+      }),
     ).toBeInTheDocument();
     expect(
       screen.getByRole("heading", {
@@ -52,8 +78,22 @@ describe("CodeReviewSection", () => {
     expect(
       screen.getByRole("heading", {
         level: 3,
+        name: "Hard feedback without the interpersonal cost",
+      }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", {
+        level: 3,
         name: "Review stops blocking the merge",
       }),
+    ).toBeInTheDocument();
+  });
+
+  it("frames the auto-approval rate as the metric to move", () => {
+    render(<CodeReviewSection isDark={false} />);
+
+    expect(
+      screen.getByText(/share of your pull requests that get approved this way/),
     ).toBeInTheDocument();
   });
 

--- a/frontend/src/components/landing/code-review-section.test.tsx
+++ b/frontend/src/components/landing/code-review-section.test.tsx
@@ -9,7 +9,7 @@ describe("CodeReviewSection", () => {
 
     const heading = screen.getByRole("heading", {
       level: 2,
-      name: "Code review that approves the pull requests it should.",
+      name: "Code review that can auto-approve.",
     });
 
     expect(heading.className).toContain(landingTypography.sectionTitle);
@@ -30,14 +30,13 @@ describe("CodeReviewSection", () => {
     expect(screen.getByText(/Policy v12/)).toBeInTheDocument();
   });
 
-  it("keeps the escalation path visible alongside the approval", () => {
+  it("shows only the approved verdict card", () => {
     render(<CodeReviewSection isDark={false} />);
 
     expect(
-      screen.getByText("143 Code Reviewer did not approve this PR"),
-    ).toBeInTheDocument();
-    expect(screen.getByText("Needs human review")).toBeInTheDocument();
-    expect(screen.getByText(/Auth-sensitive paths changed/)).toBeInTheDocument();
+      screen.queryByText("143 Code Reviewer did not approve this PR"),
+    ).not.toBeInTheDocument();
+    expect(screen.queryByText("Needs human review")).not.toBeInTheDocument();
   });
 
   it("focuses the copy column on policy tuning and reviewer model choice", () => {

--- a/frontend/src/components/landing/code-review-section.test.tsx
+++ b/frontend/src/components/landing/code-review-section.test.tsx
@@ -15,7 +15,7 @@ describe("CodeReviewSection", () => {
     expect(heading.className).toContain(landingTypography.sectionTitle);
     expect(screen.getByText("01 Code review")).toBeInTheDocument();
     expect(
-      screen.getByText(/getting it reviewed takes days/),
+      screen.getByText(/minutes to open and days to review/),
     ).toBeInTheDocument();
   });
 

--- a/frontend/src/components/landing/code-review-section.test.tsx
+++ b/frontend/src/components/landing/code-review-section.test.tsx
@@ -4,28 +4,18 @@ import CodeReviewSection from "./code-review-section";
 import { landingTypography } from "./landing-typography";
 
 describe("CodeReviewSection", () => {
-  it("leads with the review bottleneck, then automated code review", () => {
+  it("leads the homepage story with code review and its bottleneck", () => {
     render(<CodeReviewSection isDark={false} />);
 
-    const problemHeading = screen.getByRole("heading", {
-      level: 2,
-      name: "Agents made code faster to write. Review is where it piles up.",
-    });
-    const answerHeading = screen.getByRole("heading", {
+    const heading = screen.getByRole("heading", {
       level: 2,
       name: "Code review that approves the pull requests it should.",
     });
 
-    expect(problemHeading.className).toContain(landingTypography.sectionTitle);
-    expect(answerHeading.className).toContain(landingTypography.sectionTitle);
+    expect(heading.className).toContain(landingTypography.sectionTitle);
+    expect(screen.getByText("01 Code review")).toBeInTheDocument();
     expect(
-      problemHeading.compareDocumentPosition(answerHeading) &
-        Node.DOCUMENT_POSITION_FOLLOWING,
-    ).toBeTruthy();
-    expect(screen.getByText("01 Why this matters")).toBeInTheDocument();
-    expect(screen.getByText("02 Code review")).toBeInTheDocument();
-    expect(
-      screen.getByText(/More pull requests than review capacity/),
+      screen.getByText(/Review is now the bottleneck/),
     ).toBeInTheDocument();
   });
 

--- a/frontend/src/components/landing/code-review-section.test.tsx
+++ b/frontend/src/components/landing/code-review-section.test.tsx
@@ -15,7 +15,7 @@ describe("CodeReviewSection", () => {
     expect(heading.className).toContain(landingTypography.sectionTitle);
     expect(screen.getByText("01 Code review")).toBeInTheDocument();
     expect(
-      screen.getByText(/Reviewing it is the bottleneck/),
+      screen.getByText(/reviewing it is the bottleneck/),
     ).toBeInTheDocument();
   });
 

--- a/frontend/src/components/landing/code-review-section.tsx
+++ b/frontend/src/components/landing/code-review-section.tsx
@@ -9,6 +9,7 @@ import {
   codeReviewCapabilities,
   codeReviewEscalation,
   codeReviewOutcomes,
+  codeReviewPressures,
   codeReviewSummary,
 } from "./landing-copy";
 import { landingLayout as layout } from "./landing-layout";
@@ -155,6 +156,22 @@ export default function CodeReviewSection({ isDark }: CodeReviewSectionProps) {
           </div>
         </div>
 
+        <div className="grid gap-x-10 gap-y-8 sm:grid-cols-2 lg:grid-cols-4">
+          {codeReviewPressures.map((pressure) => (
+            <div
+              key={pressure.title}
+              className={`border-t pt-5 ${
+                isDark ? "border-white/10" : "border-[#dad7ce]"
+              }`}
+            >
+              <h3 className={`${type.cardTitle} ${heading}`}>
+                {pressure.title}
+              </h3>
+              <p className={`mt-3 ${type.body} ${body}`}>{pressure.body}</p>
+            </div>
+          ))}
+        </div>
+
         <div
           ref={ref}
           className={layout.featureRowReverse}
@@ -178,7 +195,9 @@ export default function CodeReviewSection({ isDark }: CodeReviewSectionProps) {
               The approval decision is made from explicit evidence, not a
               model&apos;s recommendation. Every safeguard in your policy has to
               pass first, and the reviewed commit, policy version, and agent
-              output stay inspectable afterward.
+              output stay inspectable afterward. The number worth watching is
+              the share of your pull requests that get approved this way — raise
+              it by tuning the policy, not by trusting the model more.
             </p>
             <ul className="grid gap-2 pt-2">
               {codeReviewCapabilities.map((capability) => (
@@ -206,7 +225,7 @@ export default function CodeReviewSection({ isDark }: CodeReviewSectionProps) {
           </div>
         </div>
 
-        <div className="grid gap-4 md:grid-cols-3">
+        <div className="grid gap-4 md:grid-cols-2">
           {codeReviewOutcomes.map((outcome) => (
             <Card
               key={outcome.title}

--- a/frontend/src/components/landing/code-review-section.tsx
+++ b/frontend/src/components/landing/code-review-section.tsx
@@ -1,12 +1,11 @@
 "use client";
 
 import Link from "next/link";
-import { ArrowRight, Check, CircleDot } from "lucide-react";
+import { ArrowRight, Check } from "lucide-react";
 import { useInView } from "@/hooks/use-in-view";
 import {
   codeReviewApproval,
   codeReviewControls,
-  codeReviewEscalation,
   codeReviewSummary,
 } from "./landing-copy";
 import { landingLayout as layout } from "./landing-layout";
@@ -81,43 +80,6 @@ function ApprovalCard({ isDark }: { isDark: boolean }) {
   );
 }
 
-function EscalationCard({ isDark }: { isDark: boolean }) {
-  return (
-    <div
-      className={`${layout.visualFrame} border p-6 sm:p-8 ${
-        isDark ? "border-white/10 bg-[#1d1d1a]" : "border-[#e1ded5] bg-[#efeee8]"
-      }`}
-    >
-      <div className="flex flex-wrap items-center justify-between gap-3">
-        <p
-          className={`${type.cardTitle} ${isDark ? "text-[#f4f3ee]" : "text-[#1b1b19]"}`}
-        >
-          {codeReviewEscalation.title}
-        </p>
-        <span
-          className={`inline-flex items-center gap-1.5 rounded-full px-2.5 py-1 text-xs font-mono font-medium uppercase tracking-wider ${
-            isDark ? "bg-white/[0.08] text-[#aaa89f]" : "bg-[#dad7ce]/60 text-[#6b6b65]"
-          }`}
-        >
-          <CircleDot className="size-3" aria-hidden="true" />
-          {codeReviewEscalation.decision}
-        </span>
-      </div>
-
-      <ul className="mt-5 grid gap-2">
-        {codeReviewEscalation.reasons.map((reason) => (
-          <li
-            key={reason}
-            className={`text-xs font-mono ${isDark ? "text-[#aaa89f]" : "text-[#6b6b65]"}`}
-          >
-            · {reason}
-          </li>
-        ))}
-      </ul>
-    </div>
-  );
-}
-
 export default function CodeReviewSection({ isDark }: CodeReviewSectionProps) {
   const { ref, inView } = useInView({ threshold: 0.9 });
   const label = isDark ? "text-[#7992ff]" : "text-[#315ce8]";
@@ -163,10 +125,7 @@ export default function CodeReviewSection({ isDark }: CodeReviewSectionProps) {
               "opacity 0.65s cubic-bezier(0.16, 1, 0.3, 1), transform 0.65s cubic-bezier(0.16, 1, 0.3, 1)",
           }}
         >
-          <div className="grid gap-4">
-            <ApprovalCard isDark={isDark} />
-            <EscalationCard isDark={isDark} />
-          </div>
+          <ApprovalCard isDark={isDark} />
 
           <div className={layout.copyColumn}>
             <h3 className={`${type.featureTitle} ${heading}`}>

--- a/frontend/src/components/landing/code-review-section.tsx
+++ b/frontend/src/components/landing/code-review-section.tsx
@@ -1,0 +1,231 @@
+"use client";
+
+import Link from "next/link";
+import { ArrowRight, Check, CircleDot } from "lucide-react";
+import { Card, CardContent } from "@/components/ui/card";
+import { useInView } from "@/hooks/use-in-view";
+import {
+  codeReviewApproval,
+  codeReviewCapabilities,
+  codeReviewEscalation,
+  codeReviewOutcomes,
+  codeReviewSummary,
+} from "./landing-copy";
+import { landingLayout as layout } from "./landing-layout";
+import { landingTypography as type } from "./landing-typography";
+
+interface CodeReviewSectionProps {
+  isDark: boolean;
+}
+
+function ApprovalCard({ isDark }: { isDark: boolean }) {
+  return (
+    <div
+      className={`${layout.visualFrame} border p-6 sm:p-8 ${
+        isDark ? "border-white/10 bg-[#11110f]" : "border-[#e1ded5] bg-[#fefdfb]"
+      }`}
+      style={{
+        boxShadow: isDark
+          ? "0 30px 80px -28px rgba(0,0,0,0.72), 0 0 0 1px rgba(255,255,255,0.035)"
+          : "0 30px 80px -28px rgba(36,34,28,0.24), 0 8px 24px -16px rgba(36,34,28,0.16)",
+      }}
+    >
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <p
+          className={`${type.cardTitle} ${isDark ? "text-[#f4f3ee]" : "text-[#1b1b19]"}`}
+        >
+          {codeReviewApproval.title}
+        </p>
+        <span
+          className={`inline-flex items-center gap-1.5 rounded-full px-2.5 py-1 text-xs font-mono font-medium uppercase tracking-wider ${
+            isDark
+              ? "bg-[#7992ff]/15 text-[#9fb0ff]"
+              : "bg-[#315ce8]/10 text-[#315ce8]"
+          }`}
+        >
+          <Check className="size-3" aria-hidden="true" />
+          {codeReviewApproval.decision}
+        </span>
+      </div>
+
+      <dl className="mt-6 grid">
+        {codeReviewApproval.evidence.map((row) => (
+          <div
+            key={row.label}
+            className={`flex items-baseline justify-between gap-6 border-t py-3 ${
+              isDark ? "border-white/[0.07]" : "border-[#e8e5dc]"
+            }`}
+          >
+            <dt
+              className={`text-xs font-mono uppercase tracking-wider ${
+                isDark ? "text-[#aaa89f]/70" : "text-[#6b6b65]/80"
+              }`}
+            >
+              {row.label}
+            </dt>
+            <dd
+              className={`text-right text-xs font-mono ${
+                isDark ? "text-[#dddbd4]" : "text-[#252521]"
+              }`}
+            >
+              {row.value}
+            </dd>
+          </div>
+        ))}
+      </dl>
+
+      <p
+        className={`mt-6 text-xs font-mono ${isDark ? "text-[#aaa89f]/70" : "text-[#6b6b65]/80"}`}
+      >
+        {codeReviewApproval.footer}
+      </p>
+    </div>
+  );
+}
+
+function EscalationCard({ isDark }: { isDark: boolean }) {
+  return (
+    <div
+      className={`${layout.visualFrame} border p-6 sm:p-8 ${
+        isDark ? "border-white/10 bg-[#1d1d1a]" : "border-[#e1ded5] bg-[#efeee8]"
+      }`}
+    >
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <p
+          className={`${type.cardTitle} ${isDark ? "text-[#f4f3ee]" : "text-[#1b1b19]"}`}
+        >
+          {codeReviewEscalation.title}
+        </p>
+        <span
+          className={`inline-flex items-center gap-1.5 rounded-full px-2.5 py-1 text-xs font-mono font-medium uppercase tracking-wider ${
+            isDark ? "bg-white/[0.08] text-[#aaa89f]" : "bg-[#dad7ce]/60 text-[#6b6b65]"
+          }`}
+        >
+          <CircleDot className="size-3" aria-hidden="true" />
+          {codeReviewEscalation.decision}
+        </span>
+      </div>
+
+      <ul className="mt-5 grid gap-2">
+        {codeReviewEscalation.reasons.map((reason) => (
+          <li
+            key={reason}
+            className={`text-xs font-mono ${isDark ? "text-[#aaa89f]" : "text-[#6b6b65]"}`}
+          >
+            · {reason}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+export default function CodeReviewSection({ isDark }: CodeReviewSectionProps) {
+  const { ref, inView } = useInView({ threshold: 0.9 });
+  const label = isDark ? "text-[#7992ff]" : "text-[#315ce8]";
+  const heading = isDark ? "text-[#f4f3ee]" : "text-[#1b1b19]";
+  const body = isDark ? "text-[#aaa89f]" : "text-[#6b6b65]";
+
+  return (
+    <section
+      id="code-review"
+      className={layout.sectionPadding}
+      style={{ background: isDark ? "#151513" : "#f6f5f0" }}
+    >
+      <div className="absolute inset-0 pointer-events-none">
+        <div
+          className={`absolute inset-x-0 top-0 h-px ${
+            isDark ? "bg-white/10" : "bg-[#e1ded5]"
+          }`}
+        />
+      </div>
+
+      <div className={`${layout.pageShell} space-y-16 sm:space-y-24`}>
+        <div className={layout.sectionHeaderGrid}>
+          <p className={`${type.eyebrow} ${label}`}>
+            {codeReviewSummary.step} {codeReviewSummary.kicker}
+          </p>
+          <div className="space-y-5">
+            <h2 className={`max-w-3xl ${type.sectionTitle} ${heading}`}>
+              {codeReviewSummary.heading}
+            </h2>
+            <p className={`max-w-2xl ${type.body} ${body}`}>
+              {codeReviewSummary.body}
+            </p>
+          </div>
+        </div>
+
+        <div
+          ref={ref}
+          className={layout.featureRowReverse}
+          style={{
+            opacity: inView ? 1 : 0,
+            transform: inView ? "translateY(0)" : "translateY(24px)",
+            transition:
+              "opacity 0.65s cubic-bezier(0.16, 1, 0.3, 1), transform 0.65s cubic-bezier(0.16, 1, 0.3, 1)",
+          }}
+        >
+          <div className="grid gap-4">
+            <ApprovalCard isDark={isDark} />
+            <EscalationCard isDark={isDark} />
+          </div>
+
+          <div className={layout.copyColumn}>
+            <h3 className={`${type.featureTitle} ${heading}`}>
+              Auto-approval, backed by evidence.
+            </h3>
+            <p className={`${type.body} ${layout.copyBody} ${body}`}>
+              The approval decision is made from explicit evidence, not a
+              model&apos;s recommendation. Every safeguard in your policy has to
+              pass first, and the reviewed commit, policy version, and agent
+              output stay inspectable afterward.
+            </p>
+            <ul className="grid gap-2 pt-2">
+              {codeReviewCapabilities.map((capability) => (
+                <li
+                  key={capability}
+                  className={`text-xs font-mono ${body}`}
+                >
+                  · {capability}
+                </li>
+              ))}
+            </ul>
+            <div className="pt-2">
+              <Link
+                href="/docs/guides/code-review-policy"
+                className={`inline-flex items-center text-sm font-medium transition-colors ${
+                  isDark
+                    ? "text-[#9fb0ff] hover:text-[#c2ccff]"
+                    : "text-[#315ce8] hover:text-[#294fc9]"
+                }`}
+              >
+                Configure the review policy
+                <ArrowRight className="ml-2 size-3.5" aria-hidden="true" />
+              </Link>
+            </div>
+          </div>
+        </div>
+
+        <div className="grid gap-4 md:grid-cols-3">
+          {codeReviewOutcomes.map((outcome) => (
+            <Card
+              key={outcome.title}
+              className={
+                isDark
+                  ? "border-white/10 bg-[#1d1d1a]"
+                  : "border-[#e1ded5] bg-[#fefdfb] shadow-[0_18px_48px_-36px_rgb(36_34_28_/_32%)]"
+              }
+            >
+              <CardContent className="p-6">
+                <h3 className={`${type.cardTitle} ${heading}`}>
+                  {outcome.title}
+                </h3>
+                <p className={`mt-4 ${type.body} ${body}`}>{outcome.body}</p>
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/frontend/src/components/landing/code-review-section.tsx
+++ b/frontend/src/components/landing/code-review-section.tsx
@@ -133,9 +133,9 @@ export default function CodeReviewSection({ isDark }: CodeReviewSectionProps) {
             </h3>
             <p className={`${type.body} ${layout.copyBody} ${body}`}>
               Approval follows a policy you control: size limits, sensitive
-              paths, required checks, description rules. The reviewers are
-              coding agents, not people. Run one model to keep reviews cheap, or
-              several in parallel for higher confidence.
+              paths, required checks. The reviewers are coding agents, not
+              people; run one model to keep reviews cheap or several in
+              parallel for higher confidence.
             </p>
             <ul className="grid gap-2 pt-2">
               {codeReviewControls.map((control) => (

--- a/frontend/src/components/landing/code-review-section.tsx
+++ b/frontend/src/components/landing/code-review-section.tsx
@@ -2,14 +2,11 @@
 
 import Link from "next/link";
 import { ArrowRight, Check, CircleDot } from "lucide-react";
-import { Card, CardContent } from "@/components/ui/card";
 import { useInView } from "@/hooks/use-in-view";
 import {
   codeReviewApproval,
-  codeReviewCapabilities,
   codeReviewEscalation,
   codeReviewOutcomes,
-  codeReviewPressures,
   codeReviewSummary,
 } from "./landing-copy";
 import { landingLayout as layout } from "./landing-layout";
@@ -156,22 +153,6 @@ export default function CodeReviewSection({ isDark }: CodeReviewSectionProps) {
           </div>
         </div>
 
-        <div className="grid gap-x-10 gap-y-8 sm:grid-cols-2 lg:grid-cols-4">
-          {codeReviewPressures.map((pressure) => (
-            <div
-              key={pressure.title}
-              className={`border-t pt-5 ${
-                isDark ? "border-white/10" : "border-[#dad7ce]"
-              }`}
-            >
-              <h3 className={`${type.cardTitle} ${heading}`}>
-                {pressure.title}
-              </h3>
-              <p className={`mt-3 ${type.body} ${body}`}>{pressure.body}</p>
-            </div>
-          ))}
-        </div>
-
         <div
           ref={ref}
           className={layout.featureRowReverse}
@@ -195,17 +176,12 @@ export default function CodeReviewSection({ isDark }: CodeReviewSectionProps) {
               The approval decision is made from explicit evidence, not a
               model&apos;s recommendation. Every safeguard in your policy has to
               pass first, and the reviewed commit, policy version, and agent
-              output stay inspectable afterward. The number worth watching is
-              the share of your pull requests that get approved this way — raise
-              it by tuning the policy, not by trusting the model more.
+              output stay inspectable afterward.
             </p>
             <ul className="grid gap-2 pt-2">
-              {codeReviewCapabilities.map((capability) => (
-                <li
-                  key={capability}
-                  className={`text-xs font-mono ${body}`}
-                >
-                  · {capability}
+              {codeReviewOutcomes.map((outcome) => (
+                <li key={outcome} className={`text-xs font-mono ${body}`}>
+                  · {outcome}
                 </li>
               ))}
             </ul>
@@ -223,26 +199,6 @@ export default function CodeReviewSection({ isDark }: CodeReviewSectionProps) {
               </Link>
             </div>
           </div>
-        </div>
-
-        <div className="grid gap-4 md:grid-cols-2">
-          {codeReviewOutcomes.map((outcome) => (
-            <Card
-              key={outcome.title}
-              className={
-                isDark
-                  ? "border-white/10 bg-[#1d1d1a]"
-                  : "border-[#e1ded5] bg-[#fefdfb] shadow-[0_18px_48px_-36px_rgb(36_34_28_/_32%)]"
-              }
-            >
-              <CardContent className="p-6">
-                <h3 className={`${type.cardTitle} ${heading}`}>
-                  {outcome.title}
-                </h3>
-                <p className={`mt-4 ${type.body} ${body}`}>{outcome.body}</p>
-              </CardContent>
-            </Card>
-          ))}
         </div>
       </div>
     </section>

--- a/frontend/src/components/landing/code-review-section.tsx
+++ b/frontend/src/components/landing/code-review-section.tsx
@@ -134,8 +134,8 @@ export default function CodeReviewSection({ isDark }: CodeReviewSectionProps) {
             <p className={`${type.body} ${layout.copyBody} ${body}`}>
               Approval follows a policy you control: size limits, sensitive
               paths, required checks. The reviewers are coding agents, not
-              people; run one model to keep reviews cheap or several in
-              parallel for higher confidence.
+              people. Run one model to keep costs down, or several in parallel
+              for confidence.
             </p>
             <ul className="grid gap-2 pt-2">
               {codeReviewControls.map((control) => (

--- a/frontend/src/components/landing/code-review-section.tsx
+++ b/frontend/src/components/landing/code-review-section.tsx
@@ -8,8 +8,6 @@ import {
   codeReviewControls,
   codeReviewEscalation,
   codeReviewSummary,
-  reviewBottlenecks,
-  reviewProblem,
 } from "./landing-copy";
 import { landingLayout as layout } from "./landing-layout";
 import { landingTypography as type } from "./landing-typography";
@@ -141,24 +139,6 @@ export default function CodeReviewSection({ isDark }: CodeReviewSectionProps) {
       </div>
 
       <div className={`${layout.pageShell} space-y-16 sm:space-y-24`}>
-        <div className={layout.sectionHeaderGrid}>
-          <p className={`${type.eyebrow} ${label}`}>
-            {reviewProblem.step} {reviewProblem.kicker}
-          </p>
-          <div className="space-y-5">
-            <h2 className={`max-w-3xl ${type.sectionTitle} ${heading}`}>
-              {reviewProblem.heading}
-            </h2>
-            <ul className="grid gap-2 pt-2">
-              {reviewBottlenecks.map((item) => (
-                <li key={item} className={`text-xs font-mono ${body}`}>
-                  · {item}
-                </li>
-              ))}
-            </ul>
-          </div>
-        </div>
-
         <div className={layout.sectionHeaderGrid}>
           <p className={`${type.eyebrow} ${label}`}>
             {codeReviewSummary.step} {codeReviewSummary.kicker}

--- a/frontend/src/components/landing/code-review-section.tsx
+++ b/frontend/src/components/landing/code-review-section.tsx
@@ -5,9 +5,11 @@ import { ArrowRight, Check, CircleDot } from "lucide-react";
 import { useInView } from "@/hooks/use-in-view";
 import {
   codeReviewApproval,
+  codeReviewControls,
   codeReviewEscalation,
-  codeReviewOutcomes,
   codeReviewSummary,
+  reviewBottlenecks,
+  reviewProblem,
 } from "./landing-copy";
 import { landingLayout as layout } from "./landing-layout";
 import { landingTypography as type } from "./landing-typography";
@@ -141,6 +143,24 @@ export default function CodeReviewSection({ isDark }: CodeReviewSectionProps) {
       <div className={`${layout.pageShell} space-y-16 sm:space-y-24`}>
         <div className={layout.sectionHeaderGrid}>
           <p className={`${type.eyebrow} ${label}`}>
+            {reviewProblem.step} {reviewProblem.kicker}
+          </p>
+          <div className="space-y-5">
+            <h2 className={`max-w-3xl ${type.sectionTitle} ${heading}`}>
+              {reviewProblem.heading}
+            </h2>
+            <ul className="grid gap-2 pt-2">
+              {reviewBottlenecks.map((item) => (
+                <li key={item} className={`text-xs font-mono ${body}`}>
+                  · {item}
+                </li>
+              ))}
+            </ul>
+          </div>
+        </div>
+
+        <div className={layout.sectionHeaderGrid}>
+          <p className={`${type.eyebrow} ${label}`}>
             {codeReviewSummary.step} {codeReviewSummary.kicker}
           </p>
           <div className="space-y-5">
@@ -170,18 +190,19 @@ export default function CodeReviewSection({ isDark }: CodeReviewSectionProps) {
 
           <div className={layout.copyColumn}>
             <h3 className={`${type.featureTitle} ${heading}`}>
-              Auto-approval, backed by evidence.
+              Tune the policy. Pick the reviewers.
             </h3>
             <p className={`${type.body} ${layout.copyBody} ${body}`}>
-              The approval decision is made from explicit evidence, not a
-              model&apos;s recommendation. Every safeguard in your policy has to
-              pass first, and the reviewed commit, policy version, and agent
-              output stay inspectable afterward.
+              Approval is decided by a policy you tune — size thresholds,
+              sensitive paths, required checks, description requirements — with
+              the evidence kept inspectable. The review itself is staffed by
+              agents you choose: one economical reviewer or several in parallel,
+              each with its own model and reasoning depth.
             </p>
             <ul className="grid gap-2 pt-2">
-              {codeReviewOutcomes.map((outcome) => (
-                <li key={outcome} className={`text-xs font-mono ${body}`}>
-                  · {outcome}
+              {codeReviewControls.map((control) => (
+                <li key={control} className={`text-xs font-mono ${body}`}>
+                  · {control}
                 </li>
               ))}
             </ul>

--- a/frontend/src/components/landing/code-review-section.tsx
+++ b/frontend/src/components/landing/code-review-section.tsx
@@ -170,14 +170,13 @@ export default function CodeReviewSection({ isDark }: CodeReviewSectionProps) {
 
           <div className={layout.copyColumn}>
             <h3 className={`${type.featureTitle} ${heading}`}>
-              Tune the policy. Pick the reviewers.
+              Tune the policy. Pick the reviewer models.
             </h3>
             <p className={`${type.body} ${layout.copyBody} ${body}`}>
-              Approval is decided by a policy you tune — size thresholds,
-              sensitive paths, required checks, description requirements — with
-              the evidence kept inspectable. The review itself is staffed by
-              agents you choose: one economical reviewer or several in parallel,
-              each with its own model and reasoning depth.
+              Approval follows a policy you control: size limits, sensitive
+              paths, required checks, description rules. The reviewers are
+              coding agents, not people. Run one model to keep reviews cheap, or
+              several in parallel for higher confidence.
             </p>
             <ul className="grid gap-2 pt-2">
               {codeReviewControls.map((control) => (

--- a/frontend/src/components/landing/cta-section.tsx
+++ b/frontend/src/components/landing/cta-section.tsx
@@ -38,9 +38,8 @@ export default function CtaSection({ isDark }: CtaSectionProps) {
             isDark ? "text-[#aaa89f]" : "text-[#6b6b65]"
           }`}
         >
-          Connect a repository, request 143 Code Reviewer on your next pull
-          request, and let the changes that clear your policy approve
-          themselves.
+          Connect a repository, request 143 Code Reviewer on a pull request,
+          and changes that pass your policy get approved automatically.
         </p>
         <div className="flex flex-wrap items-center justify-center gap-3">
           <Button

--- a/frontend/src/components/landing/cta-section.tsx
+++ b/frontend/src/components/landing/cta-section.tsx
@@ -33,6 +33,15 @@ export default function CtaSection({ isDark }: CtaSectionProps) {
         >
           Put your agents to work.
         </h2>
+        <p
+          className={`mx-auto max-w-xl ${type.body} ${
+            isDark ? "text-[#aaa89f]" : "text-[#6b6b65]"
+          }`}
+        >
+          Connect a repository, request 143 Code Reviewer on your next pull
+          request, and let the changes that clear your policy approve
+          themselves.
+        </p>
         <div className="flex flex-wrap items-center justify-center gap-3">
           <Button
             asChild

--- a/frontend/src/components/landing/hero-section.test.tsx
+++ b/frontend/src/components/landing/hero-section.test.tsx
@@ -27,12 +27,13 @@ describe("HeroSection", () => {
     );
   });
 
-  it("preserves the plane-led homepage content while applying the flight-blue visual system", () => {
+  it("leads with automated code review while keeping the plane-led visual system", () => {
     render(<HeroSection isDark={false} />);
 
     expect(screen.getByTestId("hero-canvas")).toBeInTheDocument();
-    expect(screen.getByRole("heading", { name: "Where your whole team builds software together" })).toBeInTheDocument();
-    expect(screen.getByText(/Run Codex, Claude Code, and OpenCode in an open-source cloud/)).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Automate code review. Merge without the wait." })).toBeInTheDocument();
+    expect(screen.getByText(/auto-approves the ones that clear your policy/)).toBeInTheDocument();
+    expect(screen.getByText(/Codex, Claude Code, and OpenCode together/)).toBeInTheDocument();
     expect(screen.getByRole("link", { name: /get started/i })).toHaveClass("bg-[#315ce8]");
     expect(screen.queryByText(/mission control/i)).not.toBeInTheDocument();
   });

--- a/frontend/src/components/landing/hero-section.test.tsx
+++ b/frontend/src/components/landing/hero-section.test.tsx
@@ -31,7 +31,7 @@ describe("HeroSection", () => {
     render(<HeroSection isDark={false} />);
 
     expect(screen.getByTestId("hero-canvas")).toBeInTheDocument();
-    expect(screen.getByRole("heading", { name: "Where your whole team builds software together" })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Ship as fast as you build" })).toBeInTheDocument();
     expect(screen.getByText(/Review loops auto-approve pull requests that pass your policy/)).toBeInTheDocument();
     expect(screen.getByText(/Codex, Claude Code, and OpenCode run in an open-source cloud/)).toBeInTheDocument();
     expect(screen.getByRole("link", { name: /get started/i })).toHaveClass("bg-[#315ce8]");

--- a/frontend/src/components/landing/hero-section.test.tsx
+++ b/frontend/src/components/landing/hero-section.test.tsx
@@ -27,13 +27,12 @@ describe("HeroSection", () => {
     );
   });
 
-  it("leads with automated code review while keeping the plane-led visual system", () => {
+  it("preserves the plane-led homepage content while applying the flight-blue visual system", () => {
     render(<HeroSection isDark={false} />);
 
     expect(screen.getByTestId("hero-canvas")).toBeInTheDocument();
-    expect(screen.getByRole("heading", { name: "Automate code review. Merge without the wait." })).toBeInTheDocument();
-    expect(screen.getByText(/auto-approves the ones that clear your policy/)).toBeInTheDocument();
-    expect(screen.getByText(/Codex, Claude Code, and OpenCode together/)).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Where your whole team builds software together" })).toBeInTheDocument();
+    expect(screen.getByText(/Run Codex, Claude Code, and OpenCode in an open-source cloud/)).toBeInTheDocument();
     expect(screen.getByRole("link", { name: /get started/i })).toHaveClass("bg-[#315ce8]");
     expect(screen.queryByText(/mission control/i)).not.toBeInTheDocument();
   });

--- a/frontend/src/components/landing/hero-section.test.tsx
+++ b/frontend/src/components/landing/hero-section.test.tsx
@@ -32,7 +32,7 @@ describe("HeroSection", () => {
 
     expect(screen.getByTestId("hero-canvas")).toBeInTheDocument();
     expect(screen.getByRole("heading", { name: "Where your whole team builds software together" })).toBeInTheDocument();
-    expect(screen.getByText(/Review loops auto-approve pull requests against your policy/)).toBeInTheDocument();
+    expect(screen.getByText(/Review loops auto-approve pull requests that pass your policy/)).toBeInTheDocument();
     expect(screen.getByText(/Codex, Claude Code, and OpenCode run in an open-source cloud/)).toBeInTheDocument();
     expect(screen.getByRole("link", { name: /get started/i })).toHaveClass("bg-[#315ce8]");
     expect(screen.queryByText(/mission control/i)).not.toBeInTheDocument();

--- a/frontend/src/components/landing/hero-section.test.tsx
+++ b/frontend/src/components/landing/hero-section.test.tsx
@@ -32,7 +32,8 @@ describe("HeroSection", () => {
 
     expect(screen.getByTestId("hero-canvas")).toBeInTheDocument();
     expect(screen.getByRole("heading", { name: "Where your whole team builds software together" })).toBeInTheDocument();
-    expect(screen.getByText(/Run Codex, Claude Code, and OpenCode in an open-source cloud/)).toBeInTheDocument();
+    expect(screen.getByText(/Review loops auto-approve pull requests against your policy/)).toBeInTheDocument();
+    expect(screen.getByText(/Codex, Claude Code, and OpenCode run in an open-source cloud/)).toBeInTheDocument();
     expect(screen.getByRole("link", { name: /get started/i })).toHaveClass("bg-[#315ce8]");
     expect(screen.queryByText(/mission control/i)).not.toBeInTheDocument();
   });

--- a/frontend/src/components/landing/hero-section.test.tsx
+++ b/frontend/src/components/landing/hero-section.test.tsx
@@ -32,8 +32,8 @@ describe("HeroSection", () => {
 
     expect(screen.getByTestId("hero-canvas")).toBeInTheDocument();
     expect(screen.getByRole("heading", { name: "Ship as fast as you build" })).toBeInTheDocument();
-    expect(screen.getByText(/Review loops auto-approve pull requests that pass your policy/)).toBeInTheDocument();
-    expect(screen.getByText(/Codex, Claude Code, and OpenCode run in an open-source cloud/)).toBeInTheDocument();
+    expect(screen.getByText(/Run Codex, Claude Code, and OpenCode in an open-source cloud/)).toBeInTheDocument();
+    expect(screen.getByText(/review loops auto-approve the pull requests that pass your policy/)).toBeInTheDocument();
     expect(screen.getByRole("link", { name: /get started/i })).toHaveClass("bg-[#315ce8]");
     expect(screen.queryByText(/mission control/i)).not.toBeInTheDocument();
   });

--- a/frontend/src/components/landing/hero-section.tsx
+++ b/frontend/src/components/landing/hero-section.tsx
@@ -90,9 +90,9 @@ export default function HeroSection({ isDark }: HeroSectionProps) {
           <p
             className={`max-w-2xl ${type.heroBody} ${isDark ? "text-[#aaa89f]" : "text-[#6b6b65]"}`}
           >
-            Review loops auto-approve pull requests that pass your policy.
-            Codex, Claude Code, and OpenCode run in an open-source cloud with
-            shared context, previews, and automations.
+            Run Codex, Claude Code, and OpenCode in an open-source cloud,
+            where review loops auto-approve the pull requests that pass your
+            policy.
           </p>
 
           <div className="flex flex-wrap gap-4 pt-1 pointer-events-auto">

--- a/frontend/src/components/landing/hero-section.tsx
+++ b/frontend/src/components/landing/hero-section.tsx
@@ -84,16 +84,14 @@ export default function HeroSection({ isDark }: HeroSectionProps) {
               isDark ? "text-[#f4f3ee]" : "text-[#1b1b19]"
             }`}
           >
-            Automate code review. Merge without the wait.
+            Where your whole team builds software together
           </h1>
 
           <p
             className={`max-w-2xl ${type.heroBody} ${isDark ? "text-[#aaa89f]" : "text-[#6b6b65]"}`}
           >
-            143 reviews every pull request with multiple coding agents and
-            auto-approves the ones that clear your policy. It is also the
-            open-source cloud where your whole team runs Codex, Claude Code, and
-            OpenCode together.
+            Run Codex, Claude Code, and OpenCode in an open-source cloud with
+            shared context, previews, review loops, and automations.
           </p>
 
           <div className="flex flex-wrap gap-4 pt-1 pointer-events-auto">

--- a/frontend/src/components/landing/hero-section.tsx
+++ b/frontend/src/components/landing/hero-section.tsx
@@ -84,7 +84,7 @@ export default function HeroSection({ isDark }: HeroSectionProps) {
               isDark ? "text-[#f4f3ee]" : "text-[#1b1b19]"
             }`}
           >
-            Where your whole team builds software together
+            Ship as fast as you build
           </h1>
 
           <p

--- a/frontend/src/components/landing/hero-section.tsx
+++ b/frontend/src/components/landing/hero-section.tsx
@@ -90,8 +90,9 @@ export default function HeroSection({ isDark }: HeroSectionProps) {
           <p
             className={`max-w-2xl ${type.heroBody} ${isDark ? "text-[#aaa89f]" : "text-[#6b6b65]"}`}
           >
-            Run Codex, Claude Code, and OpenCode in an open-source cloud with
-            shared context, previews, review loops, and automations.
+            Review loops auto-approve pull requests against your policy.
+            Codex, Claude Code, and OpenCode run in an open-source cloud with
+            shared context, previews, and automations.
           </p>
 
           <div className="flex flex-wrap gap-4 pt-1 pointer-events-auto">

--- a/frontend/src/components/landing/hero-section.tsx
+++ b/frontend/src/components/landing/hero-section.tsx
@@ -84,14 +84,16 @@ export default function HeroSection({ isDark }: HeroSectionProps) {
               isDark ? "text-[#f4f3ee]" : "text-[#1b1b19]"
             }`}
           >
-            Where your whole team builds software together
+            Automate code review. Merge without the wait.
           </h1>
 
           <p
             className={`max-w-2xl ${type.heroBody} ${isDark ? "text-[#aaa89f]" : "text-[#6b6b65]"}`}
           >
-            Run Codex, Claude Code, and OpenCode in an open-source cloud with
-            shared context, previews, review loops, and automations.
+            143 reviews every pull request with multiple coding agents and
+            auto-approves the ones that clear your policy. It is also the
+            open-source cloud where your whole team runs Codex, Claude Code, and
+            OpenCode together.
           </p>
 
           <div className="flex flex-wrap gap-4 pt-1 pointer-events-auto">

--- a/frontend/src/components/landing/hero-section.tsx
+++ b/frontend/src/components/landing/hero-section.tsx
@@ -90,7 +90,7 @@ export default function HeroSection({ isDark }: HeroSectionProps) {
           <p
             className={`max-w-2xl ${type.heroBody} ${isDark ? "text-[#aaa89f]" : "text-[#6b6b65]"}`}
           >
-            Review loops auto-approve pull requests against your policy.
+            Review loops auto-approve pull requests that pass your policy.
             Codex, Claude Code, and OpenCode run in an open-source cloud with
             shared context, previews, and automations.
           </p>

--- a/frontend/src/components/landing/how-it-works-section.tsx
+++ b/frontend/src/components/landing/how-it-works-section.tsx
@@ -215,10 +215,10 @@ export default function HowItWorksSection({ isDark }: HowItWorksSectionProps) {
                 See every run in one workspace.
               </h2>
               <p className={`${type.body} ${layout.copyBody} ${body}`}>
-                Sessions, automation jobs, previews, PR state, usage, and audit
-                logs stay visible to the team, and repair loops fix failing
-                checks before a reviewer is ever requested. Engineers keep full
-                control; builders get scoped workflows with review safeguards.
+                Sessions, previews, PR state, usage, and audit logs are visible
+                to the whole team. Repair loops fix failing checks before
+                anyone is asked to review. Engineers keep full control, and
+                builders get scoped workflows.
               </p>
             </div>
             <ProductScreenshotFrame

--- a/frontend/src/components/landing/how-it-works-section.tsx
+++ b/frontend/src/components/landing/how-it-works-section.tsx
@@ -122,16 +122,17 @@ export default function HowItWorksSection({ isDark }: HowItWorksSectionProps) {
 
       <div className={`${layout.pageShell} space-y-28 sm:space-y-44`}>
         <div className={layout.sectionHeaderGrid}>
-          <p className={`${type.eyebrow} ${label}`}>01 Why this matters</p>
+          <p className={`${type.eyebrow} ${label}`}>02 Why this matters</p>
           <div className="space-y-5">
             <h2 className={`max-w-3xl ${type.sectionTitle} ${heading}`}>
-              Individual coding agents create scattered work. Teams need one
-              place to run, review, and schedule it.
+              Automated review only pays off when the work leading into it is
+              shared, reproducible, and reviewable.
             </h2>
             <p className={`max-w-2xl ${type.body} ${body}`}>
               143 turns scattered local runs and one-off fixes into a shared
-              system with context, previews, review loops, and history the
-              whole team can trust.
+              system with context, previews, repair loops, and history the
+              whole team can trust — the same system the code reviewer draws its
+              evidence from.
             </p>
           </div>
         </div>
@@ -241,7 +242,7 @@ export default function HowItWorksSection({ isDark }: HowItWorksSectionProps) {
           <div className={layout.featureRow}>
             <div className={layout.copyColumn}>
               <p className={`${type.eyebrow} ${label}`}>
-                06 Workspace
+                07 Workspace
               </p>
               <h2 className={`${type.featureTitle} ${heading}`}>
                 See every run in one workspace.

--- a/frontend/src/components/landing/how-it-works-section.tsx
+++ b/frontend/src/components/landing/how-it-works-section.tsx
@@ -2,7 +2,7 @@
 
 import Image from "next/image";
 import { useInView } from "@/hooks/use-in-view";
-import { platformLayers, reviewBottlenecks } from "./landing-copy";
+import { platformLayers } from "./landing-copy";
 import { landingLayout as layout } from "./landing-layout";
 import { landingScreenshots } from "./landing-screenshots";
 import { landingTypography as type } from "./landing-typography";
@@ -122,12 +122,12 @@ export default function HowItWorksSection({ isDark }: HowItWorksSectionProps) {
 
       <div className={`${layout.pageShell} space-y-28 sm:space-y-44`}>
         <div className={layout.sectionHeaderGrid}>
-          <p className={`${type.eyebrow} ${label}`}>02 Why this matters</p>
+          <p className={`${type.eyebrow} ${label}`}>03 The platform</p>
           <div className="space-y-5">
             <h2 className={`max-w-3xl ${type.sectionTitle} ${heading}`}>
-              Agents made code faster to write. Review is where it piles up.
+              Individual coding agents create scattered work. Teams need one
+              place to run, review, and schedule it.
             </h2>
-            <AnimatedBulletList items={reviewBottlenecks} isDark={isDark} />
             <p className={`max-w-2xl ${type.body} ${body}`}>
               143 turns scattered local runs and one-off fixes into a shared
               system with context, previews, repair loops, and history the
@@ -242,7 +242,7 @@ export default function HowItWorksSection({ isDark }: HowItWorksSectionProps) {
           <div className={layout.featureRow}>
             <div className={layout.copyColumn}>
               <p className={`${type.eyebrow} ${label}`}>
-                07 Workspace
+                08 Workspace
               </p>
               <h2 className={`${type.featureTitle} ${heading}`}>
                 See every run in one workspace.

--- a/frontend/src/components/landing/how-it-works-section.tsx
+++ b/frontend/src/components/landing/how-it-works-section.tsx
@@ -2,7 +2,7 @@
 
 import Image from "next/image";
 import { useInView } from "@/hooks/use-in-view";
-import { platformLayers } from "./landing-copy";
+import { platformLayers, reviewBottlenecks } from "./landing-copy";
 import { landingLayout as layout } from "./landing-layout";
 import { landingScreenshots } from "./landing-screenshots";
 import { landingTypography as type } from "./landing-typography";
@@ -125,9 +125,9 @@ export default function HowItWorksSection({ isDark }: HowItWorksSectionProps) {
           <p className={`${type.eyebrow} ${label}`}>02 Why this matters</p>
           <div className="space-y-5">
             <h2 className={`max-w-3xl ${type.sectionTitle} ${heading}`}>
-              Automated review only pays off when the work leading into it is
-              shared, reproducible, and reviewable.
+              Agents made code faster to write. Review is where it piles up.
             </h2>
+            <AnimatedBulletList items={reviewBottlenecks} isDark={isDark} />
             <p className={`max-w-2xl ${type.body} ${body}`}>
               143 turns scattered local runs and one-off fixes into a shared
               system with context, previews, repair loops, and history the

--- a/frontend/src/components/landing/how-it-works-section.tsx
+++ b/frontend/src/components/landing/how-it-works-section.tsx
@@ -2,7 +2,7 @@
 
 import Image from "next/image";
 import { useInView } from "@/hooks/use-in-view";
-import { platformLayers } from "./landing-copy";
+import { codingAgents, platformLayers } from "./landing-copy";
 import { landingLayout as layout } from "./landing-layout";
 import { landingScreenshots } from "./landing-screenshots";
 import { landingTypography as type } from "./landing-typography";
@@ -93,13 +93,43 @@ function ProductScreenshotFrame({
   );
 }
 
+function CodingAgentStrip({ isDark }: { isDark: boolean }) {
+  return (
+    <div className="flex flex-wrap gap-3">
+      {codingAgents.map((agent) => (
+        <div
+          key={agent.name}
+          className={`flex items-center gap-3 rounded-xl border px-5 py-3.5 ${
+            isDark
+              ? "border-white/10 bg-[#1d1d1a]"
+              : "border-[#e1ded5] bg-[#fefdfb] shadow-[0_18px_48px_-36px_rgb(36_34_28_/_32%)]"
+          }`}
+        >
+          <Image
+            src={agent.logo}
+            alt={`${agent.name} logo`}
+            width={20}
+            height={20}
+          />
+          <span
+            className={`${type.cardTitle} ${
+              isDark ? "text-[#f4f3ee]" : "text-[#1b1b19]"
+            }`}
+          >
+            {agent.name}
+          </span>
+        </div>
+      ))}
+    </div>
+  );
+}
+
 /* ─── Main Section ─── */
 export default function HowItWorksSection({ isDark }: HowItWorksSectionProps) {
   const label = isDark ? "text-[#7992ff]" : "text-[#315ce8]";
   const heading = isDark ? "text-[#f4f3ee]" : "text-[#1b1b19]";
   const body = isDark ? "text-[#aaa89f]" : "text-[#6b6b65]";
-  const [contextLayer, executionLayer, controlLayer, previewLayer] =
-    platformLayers;
+  const [agentLayer, previewLayer] = platformLayers;
 
   return (
     <section
@@ -121,98 +151,35 @@ export default function HowItWorksSection({ isDark }: HowItWorksSectionProps) {
       </div>
 
       <div className={`${layout.pageShell} space-y-28 sm:space-y-44`}>
-        <div className={layout.sectionHeaderGrid}>
-          <p className={`${type.eyebrow} ${label}`}>03 The platform</p>
-          <div className="space-y-5">
-            <h2 className={`max-w-3xl ${type.sectionTitle} ${heading}`}>
-              Individual coding agents create scattered work. Teams need one
-              place to run, review, and schedule it.
-            </h2>
-            <p className={`max-w-2xl ${type.body} ${body}`}>
-              143 turns scattered local runs and one-off fixes into a shared
-              system with context, previews, repair loops, and history the
-              whole team can trust — the same system the code reviewer draws its
-              evidence from.
-            </p>
-          </div>
-        </div>
-
-        {/* ── Step 01: Built for Teams ── text LEFT, product screenshot RIGHT */}
+        {/* ── 02 Any agent ── text LEFT, product screenshot RIGHT */}
         <FadeInStep>
-          <div className={layout.featureRow}>
-            <div className={layout.copyColumn}>
-              <p className={`${type.eyebrow} ${label}`}>
-                {contextLayer.step} {contextLayer.kicker}
-              </p>
-              <h2 className={`${type.featureTitle} ${heading}`}>
-                {contextLayer.heading}
-              </h2>
-              <p className={`${type.body} ${layout.copyBody} ${body}`}>
-                {contextLayer.body}
-              </p>
-              <AnimatedBulletList
-                items={contextLayer.components}
+          <div className="space-y-12">
+            <div className={layout.featureRow}>
+              <div className={layout.copyColumn}>
+                <p className={`${type.eyebrow} ${label}`}>
+                  {agentLayer.step} {agentLayer.kicker}
+                </p>
+                <h2 className={`${type.featureTitle} ${heading}`}>
+                  {agentLayer.heading}
+                </h2>
+                <p className={`${type.body} ${layout.copyBody} ${body}`}>
+                  {agentLayer.body}
+                </p>
+                <AnimatedBulletList
+                  items={agentLayer.components}
+                  isDark={isDark}
+                />
+              </div>
+              <ProductScreenshotFrame
+                screenshot={landingScreenshots.execution}
                 isDark={isDark}
               />
             </div>
-            <ProductScreenshotFrame
-              screenshot={landingScreenshots.context}
-              isDark={isDark}
-            />
+            <CodingAgentStrip isDark={isDark} />
           </div>
         </FadeInStep>
 
-        {/* ── Step 02: Cloud Agents ── product screenshot LEFT, text RIGHT */}
-        <FadeInStep>
-          <div className={layout.featureRowReverse}>
-            <ProductScreenshotFrame
-              screenshot={landingScreenshots.execution}
-              isDark={isDark}
-            />
-            <div className={layout.copyColumn}>
-              <p className={`${type.eyebrow} ${label}`}>
-                {executionLayer.step} {executionLayer.kicker}
-              </p>
-              <h2 className={`${type.featureTitle} ${heading}`}>
-                {executionLayer.heading}
-              </h2>
-              <p className={`${type.body} ${layout.copyBody} ${body}`}>
-                {executionLayer.body}
-              </p>
-              <AnimatedBulletList
-                items={executionLayer.components}
-                isDark={isDark}
-              />
-            </div>
-          </div>
-        </FadeInStep>
-
-        {/* ── Step 03: Loops ── text LEFT, product screenshot RIGHT */}
-        <FadeInStep>
-          <div className={layout.featureRow}>
-            <div className={layout.copyColumn}>
-              <p className={`${type.eyebrow} ${label}`}>
-                {controlLayer.step} {controlLayer.kicker}
-              </p>
-              <h2 className={`${type.featureTitle} ${heading}`}>
-                {controlLayer.heading}
-              </h2>
-              <p className={`${type.body} ${layout.copyBody} ${body}`}>
-                {controlLayer.body}
-              </p>
-              <AnimatedBulletList
-                items={controlLayer.components}
-                isDark={isDark}
-              />
-            </div>
-            <ProductScreenshotFrame
-              screenshot={landingScreenshots.control}
-              isDark={isDark}
-            />
-          </div>
-        </FadeInStep>
-
-        {/* ── Step 04: Cloud Previews ── product screenshot LEFT, text RIGHT */}
+        {/* ── 03 Previews ── product screenshot LEFT, text RIGHT */}
         <FadeInStep>
           <div className={layout.featureRowReverse}>
             <ProductScreenshotFrame
@@ -237,20 +204,21 @@ export default function HowItWorksSection({ isDark }: HowItWorksSectionProps) {
           </div>
         </FadeInStep>
 
-        {/* ── Step 06: Workspace ── text LEFT, product screenshot RIGHT */}
+        {/* ── 04 Workspace ── text LEFT, product screenshot RIGHT */}
         <FadeInStep>
           <div className={layout.featureRow}>
             <div className={layout.copyColumn}>
               <p className={`${type.eyebrow} ${label}`}>
-                08 Workspace
+                04 Workspace
               </p>
               <h2 className={`${type.featureTitle} ${heading}`}>
                 See every run in one workspace.
               </h2>
               <p className={`${type.body} ${layout.copyBody} ${body}`}>
                 Sessions, automation jobs, previews, PR state, usage, and audit
-                logs stay visible to the team. Engineers keep full control;
-                builders get scoped workflows with review safeguards.
+                logs stay visible to the team, and repair loops fix failing
+                checks before a reviewer is ever requested. Engineers keep full
+                control; builders get scoped workflows with review safeguards.
               </p>
             </div>
             <ProductScreenshotFrame

--- a/frontend/src/components/landing/integrations-section.test.tsx
+++ b/frontend/src/components/landing/integrations-section.test.tsx
@@ -16,16 +16,13 @@ describe("IntegrationsSection", () => {
     expect(heading.className).not.toContain(landingTypography.sectionTitle);
   });
 
-  it("shows agent choice and cost controls as supporting features", () => {
+  it("keeps the section focused on team tool integrations", () => {
     render(<IntegrationsSection isDark={false} />);
 
+    expect(screen.getByText("05 Integrations")).toBeInTheDocument();
     expect(
-      screen.getByRole("heading", {
-        level: 3,
-        name: "Use the best agent for the job",
-      }),
-    ).toBeInTheDocument();
-    expect(screen.getByText(/open-source models/i)).toBeInTheDocument();
-    expect(screen.getByText(/bundled coding-agent subscriptions/i)).toBeInTheDocument();
+      screen.queryByRole("heading", { name: "Run any coding agent." }),
+    ).not.toBeInTheDocument();
+    expect(screen.getByText("GitHub")).toBeInTheDocument();
   });
 });

--- a/frontend/src/components/landing/integrations-section.tsx
+++ b/frontend/src/components/landing/integrations-section.tsx
@@ -82,7 +82,7 @@ export default function IntegrationsSection({
     >
       <div className="mx-auto max-w-5xl">
         <div className="grid gap-8 lg:grid-cols-[0.38fr_0.62fr] lg:items-end">
-          <p className={`${type.eyebrow} ${label}`}>08 Coding agents</p>
+          <p className={`${type.eyebrow} ${label}`}>09 Coding agents</p>
           <div className="space-y-5">
             <h2 className={`max-w-3xl ${type.featureTitle} ${heading}`}>
               Run any coding agent.
@@ -126,7 +126,7 @@ export default function IntegrationsSection({
         </div>
 
         <div className="mt-28 grid gap-8 lg:grid-cols-[0.38fr_0.62fr] lg:items-end">
-          <p className={`${type.eyebrow} ${label}`}>09 Integrations</p>
+          <p className={`${type.eyebrow} ${label}`}>10 Integrations</p>
           <div className="space-y-5">
             <h2 className={`max-w-3xl ${type.featureTitle} ${heading}`}>
               Connect your engineering tools.

--- a/frontend/src/components/landing/integrations-section.tsx
+++ b/frontend/src/components/landing/integrations-section.tsx
@@ -82,7 +82,7 @@ export default function IntegrationsSection({
     >
       <div className="mx-auto max-w-5xl">
         <div className="grid gap-8 lg:grid-cols-[0.38fr_0.62fr] lg:items-end">
-          <p className={`${type.eyebrow} ${label}`}>07 Coding agents</p>
+          <p className={`${type.eyebrow} ${label}`}>08 Coding agents</p>
           <div className="space-y-5">
             <h2 className={`max-w-3xl ${type.featureTitle} ${heading}`}>
               Run any coding agent.
@@ -126,7 +126,7 @@ export default function IntegrationsSection({
         </div>
 
         <div className="mt-28 grid gap-8 lg:grid-cols-[0.38fr_0.62fr] lg:items-end">
-          <p className={`${type.eyebrow} ${label}`}>08 Integrations</p>
+          <p className={`${type.eyebrow} ${label}`}>09 Integrations</p>
           <div className="space-y-5">
             <h2 className={`max-w-3xl ${type.featureTitle} ${heading}`}>
               Connect your engineering tools.

--- a/frontend/src/components/landing/integrations-section.tsx
+++ b/frontend/src/components/landing/integrations-section.tsx
@@ -84,9 +84,8 @@ export default function IntegrationsSection({
               Connect your engineering tools.
             </h2>
             <p className={`max-w-2xl ${type.body} ${body}`}>
-              Integrations are configured once for the organization, so every
-              agent starts with the same source of truth your team uses every
-              day.
+              Connect each tool once for the organization. Every agent starts
+              with the same context your team already uses.
             </p>
           </div>
         </div>

--- a/frontend/src/components/landing/integrations-section.tsx
+++ b/frontend/src/components/landing/integrations-section.tsx
@@ -2,11 +2,7 @@
 
 import Image from "next/image";
 import { Card, CardContent } from "@/components/ui/card";
-import {
-  agentChoiceHighlights,
-  codingAgents,
-  integrations,
-} from "./landing-copy";
+import { integrations } from "./landing-copy";
 import { landingTypography as type } from "./landing-typography";
 
 interface IntegrationsSectionProps {
@@ -82,51 +78,7 @@ export default function IntegrationsSection({
     >
       <div className="mx-auto max-w-5xl">
         <div className="grid gap-8 lg:grid-cols-[0.38fr_0.62fr] lg:items-end">
-          <p className={`${type.eyebrow} ${label}`}>09 Coding agents</p>
-          <div className="space-y-5">
-            <h2 className={`max-w-3xl ${type.featureTitle} ${heading}`}>
-              Run any coding agent.
-            </h2>
-            <p className={`max-w-2xl ${type.body} ${body}`}>
-              Bring the agent your team already trusts. Connect its auth once and
-              start runs across web, mobile, Slack, Linear, and Sentry.
-            </p>
-          </div>
-        </div>
-
-        <div className="mt-16">{renderGrid(codingAgents)}</div>
-
-        <div
-          className={`mt-8 grid gap-1 rounded-2xl border p-2 md:grid-cols-3 ${
-            isDark
-              ? "border-white/10 bg-[#11110f]"
-              : "border-[#e1ded5] bg-[#efeee8]"
-          }`}
-        >
-          {agentChoiceHighlights.map((highlight) => (
-            <Card
-              key={highlight.title}
-              variant="quiet"
-              className={isDark ? "bg-[#1d1d1a]" : "bg-[#fefdfb]"}
-            >
-              <CardContent className="p-6">
-                <h3
-                  className={`${type.cardTitle} ${
-                    isDark ? "text-[#f4f3ee]" : "text-[#1b1b19]"
-                  }`}
-                >
-                  {highlight.title}
-                </h3>
-                <p className={`mt-4 ${type.body} ${body}`}>
-                  {highlight.body}
-                </p>
-              </CardContent>
-            </Card>
-          ))}
-        </div>
-
-        <div className="mt-28 grid gap-8 lg:grid-cols-[0.38fr_0.62fr] lg:items-end">
-          <p className={`${type.eyebrow} ${label}`}>10 Integrations</p>
+          <p className={`${type.eyebrow} ${label}`}>05 Integrations</p>
           <div className="space-y-5">
             <h2 className={`max-w-3xl ${type.featureTitle} ${heading}`}>
               Connect your engineering tools.

--- a/frontend/src/components/landing/landing-copy.test.ts
+++ b/frontend/src/components/landing/landing-copy.test.ts
@@ -5,6 +5,7 @@ import {
   codeReviewApproval,
   codeReviewEscalation,
   codeReviewOutcomes,
+  codeReviewPressures,
   codeReviewSummary,
   codingAgents,
   integrations,
@@ -30,16 +31,27 @@ describe("landing copy", () => {
       "01 Code review",
     );
     expect(codeReviewSummary.heading).toBe(
-      "Code review that approves the pull requests it should.",
+      "Agents made code faster to write. Review is where it piles up.",
     );
   });
 
-  it("leads the code review outcomes with speed, policy, and unblocked merges", () => {
+  it("names the review bottlenecks agent-written code creates", () => {
+    expect(codeReviewPressures.map((pressure) => pressure.title)).toEqual([
+      "More pull requests",
+      "Larger, less cohesive changes",
+      "Authors who don't review code",
+      "Stacks stuck for days",
+    ]);
+  });
+
+  it("answers each pressure with a code review outcome", () => {
     expect(codeReviewOutcomes.map((outcome) => outcome.title)).toEqual([
-      "Reviews finish in minutes",
+      "Reviews finish in minutes, not days",
       "Policy is enforced, not remembered",
+      "Hard feedback without the interpersonal cost",
       "Review stops blocking the merge",
     ]);
+    expect(codeReviewOutcomes).toHaveLength(codeReviewPressures.length);
   });
 
   it("shows both the auto-approval and the escalation path", () => {

--- a/frontend/src/components/landing/landing-copy.test.ts
+++ b/frontend/src/components/landing/landing-copy.test.ts
@@ -3,7 +3,6 @@ import * as landingCopy from "./landing-copy";
 import {
   codeReviewApproval,
   codeReviewControls,
-  codeReviewEscalation,
   codeReviewSummary,
   codingAgents,
   integrations,
@@ -27,7 +26,7 @@ describe("landing copy", () => {
       "01 Code review",
     );
     expect(codeReviewSummary.heading).toBe(
-      "Code review that approves the pull requests it should.",
+      "Code review that can auto-approve.",
     );
     expect(codeReviewSummary.body).toContain("Reviewing it is the bottleneck.");
   });
@@ -52,9 +51,8 @@ describe("landing copy", () => {
     expect(flatten({ ...landingCopy })).not.toContain("—");
   });
 
-  it("shows both the auto-approval and the escalation path", () => {
+  it("keeps the auto-approval evidence concrete", () => {
     expect(codeReviewApproval.decision).toBe("Approved");
-    expect(codeReviewEscalation.decision).toBe("Needs human review");
     expect(codeReviewApproval.evidence.map((row) => row.label)).toEqual([
       "Risk",
       "Description",

--- a/frontend/src/components/landing/landing-copy.test.ts
+++ b/frontend/src/components/landing/landing-copy.test.ts
@@ -5,8 +5,8 @@ import {
   codeReviewApproval,
   codeReviewEscalation,
   codeReviewOutcomes,
-  codeReviewPressures,
   codeReviewSummary,
+  reviewBottlenecks,
   codingAgents,
   integrations,
   platformLayers,
@@ -31,27 +31,27 @@ describe("landing copy", () => {
       "01 Code review",
     );
     expect(codeReviewSummary.heading).toBe(
-      "Agents made code faster to write. Review is where it piles up.",
+      "Code review that approves the pull requests it should.",
     );
   });
 
   it("names the review bottlenecks agent-written code creates", () => {
-    expect(codeReviewPressures.map((pressure) => pressure.title)).toEqual([
-      "More pull requests",
-      "Larger, less cohesive changes",
-      "Authors who don't review code",
-      "Stacks stuck for days",
+    expect(reviewBottlenecks).toEqual([
+      "More pull requests than review capacity",
+      "Larger, less cohesive agent-written changes",
+      "More authors who don't review code for a living",
+      "Stacks stuck in review for days while generation sprints ahead",
     ]);
   });
 
-  it("answers each pressure with a code review outcome", () => {
-    expect(codeReviewOutcomes.map((outcome) => outcome.title)).toEqual([
+  it("answers each bottleneck with a code review outcome", () => {
+    expect(codeReviewOutcomes).toEqual([
       "Reviews finish in minutes, not days",
-      "Policy is enforced, not remembered",
-      "Hard feedback without the interpersonal cost",
-      "Review stops blocking the merge",
+      "Policy is enforced the same way on every pull request",
+      "Hard feedback lands without the interpersonal cost",
+      "Acceptable-risk changes merge on the spot",
     ]);
-    expect(codeReviewOutcomes).toHaveLength(codeReviewPressures.length);
+    expect(codeReviewOutcomes).toHaveLength(reviewBottlenecks.length);
   });
 
   it("shows both the auto-approval and the escalation path", () => {

--- a/frontend/src/components/landing/landing-copy.test.ts
+++ b/frontend/src/components/landing/landing-copy.test.ts
@@ -2,6 +2,10 @@ import { describe, expect, it } from "vitest";
 import * as landingCopy from "./landing-copy";
 import {
   agentChoiceHighlights,
+  codeReviewApproval,
+  codeReviewEscalation,
+  codeReviewOutcomes,
+  codeReviewSummary,
   codingAgents,
   integrations,
   platformLayers,
@@ -12,12 +16,42 @@ describe("landing copy", () => {
     expect("heroMetrics" in landingCopy).toBe(false);
   });
 
-  it("numbers platform layers after the why-this-matters section", () => {
+  it("numbers platform layers after the code-review and why-this-matters sections", () => {
     expect(platformLayers.map((layer) => `${layer.step} ${layer.title}`)).toEqual([
-      "02 Team context",
-      "03 Cloud execution",
-      "04 Review control",
-      "05 Cloud previews",
+      "03 Team context",
+      "04 Cloud execution",
+      "05 Repair loops",
+      "06 Cloud previews",
+    ]);
+  });
+
+  it("opens the homepage story with code review", () => {
+    expect(`${codeReviewSummary.step} ${codeReviewSummary.kicker}`).toBe(
+      "01 Code review",
+    );
+    expect(codeReviewSummary.heading).toBe(
+      "Code review that approves the pull requests it should.",
+    );
+  });
+
+  it("leads the code review outcomes with speed, policy, and unblocked merges", () => {
+    expect(codeReviewOutcomes.map((outcome) => outcome.title)).toEqual([
+      "Reviews finish in minutes",
+      "Policy is enforced, not remembered",
+      "Review stops blocking the merge",
+    ]);
+  });
+
+  it("shows both the auto-approval and the escalation path", () => {
+    expect(codeReviewApproval.decision).toBe("Approved");
+    expect(codeReviewEscalation.decision).toBe("Needs human review");
+    expect(codeReviewApproval.evidence.map((row) => row.label)).toEqual([
+      "Risk",
+      "Description",
+      "Review agents",
+      "Required checks",
+      "Changed",
+      "Sensitive paths",
     ]);
   });
 
@@ -61,7 +95,7 @@ describe("landing copy", () => {
     expect(platformLayers.map((layer) => layer.heading)).toEqual([
       "Shared context for every run.",
       "Run agents from anywhere.",
-      "Review loops before human review.",
+      "Arrive at review already clean.",
       "Preview every change in the cloud.",
     ]);
   });

--- a/frontend/src/components/landing/landing-copy.test.ts
+++ b/frontend/src/components/landing/landing-copy.test.ts
@@ -28,7 +28,8 @@ describe("landing copy", () => {
     expect(codeReviewSummary.heading).toBe(
       "Code review that can auto-approve.",
     );
-    expect(codeReviewSummary.body).toContain("Reviewing it is the bottleneck.");
+    expect(codeReviewSummary.body).toContain("reviewing it is the bottleneck");
+    expect(codeReviewSummary.body.split(". ").length).toBeLessThanOrEqual(2);
   });
 
   it("focuses the review controls on policy tuning and reviewer model choice", () => {

--- a/frontend/src/components/landing/landing-copy.test.ts
+++ b/frontend/src/components/landing/landing-copy.test.ts
@@ -29,16 +29,27 @@ describe("landing copy", () => {
     expect(codeReviewSummary.heading).toBe(
       "Code review that approves the pull requests it should.",
     );
-    expect(codeReviewSummary.body).toContain("Review is now the bottleneck.");
+    expect(codeReviewSummary.body).toContain("Reviewing it is the bottleneck.");
   });
 
-  it("focuses the review controls on policy tuning and reviewer choice", () => {
+  it("focuses the review controls on policy tuning and reviewer model choice", () => {
     expect(codeReviewControls).toEqual([
-      "Approval thresholds, sensitive paths, and required checks are yours to tune",
-      "Raise the auto-approval rate by tightening policy, not by trusting the model more",
-      "Run one reviewer agent or several in parallel — Codex, Claude Code, OpenCode",
-      "Set each reviewer's model and reasoning depth to balance cost and quality",
+      "Tune thresholds, sensitive paths, and required checks",
+      "Raise the auto-approval rate by tightening policy",
+      "Choose reviewer models: Codex, Claude Code, OpenCode",
+      "Set reasoning depth per reviewer to control cost",
     ]);
+  });
+
+  it("keeps the landing copy free of em-dashes", () => {
+    const flatten = (value: unknown): string =>
+      typeof value === "string"
+        ? value
+        : value && typeof value === "object"
+          ? Object.values(value).map(flatten).join(" ")
+          : "";
+
+    expect(flatten({ ...landingCopy })).not.toContain("—");
   });
 
   it("shows both the auto-approval and the escalation path", () => {

--- a/frontend/src/components/landing/landing-copy.test.ts
+++ b/frontend/src/components/landing/landing-copy.test.ts
@@ -28,7 +28,9 @@ describe("landing copy", () => {
     expect(codeReviewSummary.heading).toBe(
       "Code review that can auto-approve.",
     );
-    expect(codeReviewSummary.body).toContain("reviewing it is the bottleneck");
+    expect(codeReviewSummary.body).toContain(
+      "Opening a pull request takes minutes; getting it reviewed takes days.",
+    );
     expect(codeReviewSummary.body.split(". ").length).toBeLessThanOrEqual(2);
   });
 

--- a/frontend/src/components/landing/landing-copy.test.ts
+++ b/frontend/src/components/landing/landing-copy.test.ts
@@ -29,7 +29,7 @@ describe("landing copy", () => {
       "Code review that can auto-approve.",
     );
     expect(codeReviewSummary.body).toContain(
-      "Opening a pull request takes minutes; getting it reviewed takes days.",
+      "A pull request takes minutes to open and days to review.",
     );
     expect(codeReviewSummary.body.split(". ").length).toBeLessThanOrEqual(2);
   });
@@ -43,7 +43,7 @@ describe("landing copy", () => {
     ]);
   });
 
-  it("keeps the landing copy free of em-dashes", () => {
+  it("keeps the landing copy free of em-dashes and semicolons", () => {
     const flatten = (value: unknown): string =>
       typeof value === "string"
         ? value
@@ -51,7 +51,10 @@ describe("landing copy", () => {
           ? Object.values(value).map(flatten).join(" ")
           : "";
 
-    expect(flatten({ ...landingCopy })).not.toContain("—");
+    const copy = flatten({ ...landingCopy });
+
+    expect(copy).not.toContain("—");
+    expect(copy).not.toContain(";");
   });
 
   it("keeps the auto-approval evidence concrete", () => {

--- a/frontend/src/components/landing/landing-copy.test.ts
+++ b/frontend/src/components/landing/landing-copy.test.ts
@@ -3,13 +3,14 @@ import * as landingCopy from "./landing-copy";
 import {
   agentChoiceHighlights,
   codeReviewApproval,
+  codeReviewControls,
   codeReviewEscalation,
-  codeReviewOutcomes,
   codeReviewSummary,
-  reviewBottlenecks,
   codingAgents,
   integrations,
   platformLayers,
+  reviewBottlenecks,
+  reviewProblem,
 } from "./landing-copy";
 
 describe("landing copy", () => {
@@ -17,18 +18,24 @@ describe("landing copy", () => {
     expect("heroMetrics" in landingCopy).toBe(false);
   });
 
-  it("numbers platform layers after the code-review and why-this-matters sections", () => {
+  it("numbers platform layers after the problem, code-review, and platform headers", () => {
     expect(platformLayers.map((layer) => `${layer.step} ${layer.title}`)).toEqual([
-      "03 Team context",
-      "04 Cloud execution",
-      "05 Repair loops",
-      "06 Cloud previews",
+      "04 Team context",
+      "05 Cloud execution",
+      "06 Repair loops",
+      "07 Cloud previews",
     ]);
   });
 
-  it("opens the homepage story with code review", () => {
+  it("opens the homepage story with the review bottleneck, then code review", () => {
+    expect(`${reviewProblem.step} ${reviewProblem.kicker}`).toBe(
+      "01 Why this matters",
+    );
+    expect(reviewProblem.heading).toBe(
+      "Agents made code faster to write. Review is where it piles up.",
+    );
     expect(`${codeReviewSummary.step} ${codeReviewSummary.kicker}`).toBe(
-      "01 Code review",
+      "02 Code review",
     );
     expect(codeReviewSummary.heading).toBe(
       "Code review that approves the pull requests it should.",
@@ -44,14 +51,13 @@ describe("landing copy", () => {
     ]);
   });
 
-  it("answers each bottleneck with a code review outcome", () => {
-    expect(codeReviewOutcomes).toEqual([
-      "Reviews finish in minutes, not days",
-      "Policy is enforced the same way on every pull request",
-      "Hard feedback lands without the interpersonal cost",
-      "Acceptable-risk changes merge on the spot",
+  it("focuses the review controls on policy tuning and reviewer choice", () => {
+    expect(codeReviewControls).toEqual([
+      "Approval thresholds, sensitive paths, and required checks are yours to tune",
+      "Raise the auto-approval rate by tightening policy, not by trusting the model more",
+      "Run one reviewer agent or several in parallel — Codex, Claude Code, OpenCode",
+      "Set each reviewer's model and reasoning depth to balance cost and quality",
     ]);
-    expect(codeReviewOutcomes).toHaveLength(reviewBottlenecks.length);
   });
 
   it("shows both the auto-approval and the escalation path", () => {

--- a/frontend/src/components/landing/landing-copy.test.ts
+++ b/frontend/src/components/landing/landing-copy.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, it } from "vitest";
 import * as landingCopy from "./landing-copy";
 import {
-  agentChoiceHighlights,
   codeReviewApproval,
   codeReviewControls,
   codeReviewEscalation,
@@ -9,8 +8,6 @@ import {
   codingAgents,
   integrations,
   platformLayers,
-  reviewBottlenecks,
-  reviewProblem,
 } from "./landing-copy";
 
 describe("landing copy", () => {
@@ -18,37 +15,21 @@ describe("landing copy", () => {
     expect("heroMetrics" in landingCopy).toBe(false);
   });
 
-  it("numbers platform layers after the problem, code-review, and platform headers", () => {
+  it("builds the page around code review, agents, and previews", () => {
     expect(platformLayers.map((layer) => `${layer.step} ${layer.title}`)).toEqual([
-      "04 Team context",
-      "05 Cloud execution",
-      "06 Repair loops",
-      "07 Cloud previews",
+      "02 Cloud agents",
+      "03 Cloud previews",
     ]);
   });
 
-  it("opens the homepage story with the review bottleneck, then code review", () => {
-    expect(`${reviewProblem.step} ${reviewProblem.kicker}`).toBe(
-      "01 Why this matters",
-    );
-    expect(reviewProblem.heading).toBe(
-      "Agents made code faster to write. Review is where it piles up.",
-    );
+  it("opens the homepage story with code review and its bottleneck", () => {
     expect(`${codeReviewSummary.step} ${codeReviewSummary.kicker}`).toBe(
-      "02 Code review",
+      "01 Code review",
     );
     expect(codeReviewSummary.heading).toBe(
       "Code review that approves the pull requests it should.",
     );
-  });
-
-  it("names the review bottlenecks agent-written code creates", () => {
-    expect(reviewBottlenecks).toEqual([
-      "More pull requests than review capacity",
-      "Larger, less cohesive agent-written changes",
-      "More authors who don't review code for a living",
-      "Stacks stuck in review for days while generation sprints ahead",
-    ]);
+    expect(codeReviewSummary.body).toContain("Review is now the bottleneck.");
   });
 
   it("focuses the review controls on policy tuning and reviewer choice", () => {
@@ -96,24 +77,9 @@ describe("landing copy", () => {
     ]);
   });
 
-  it("positions model flexibility as a supporting coding-agent feature", () => {
-    expect(agentChoiceHighlights.map((highlight) => highlight.title)).toEqual([
-      "Use the best agent for the job",
-      "Keep routine work economical",
-      "Stack subscriptions before metered spend",
-    ]);
-    expect(agentChoiceHighlights.map((highlight) => highlight.body)).toEqual([
-      "Run top-tier tools like Codex, Claude Code, and OpenCode when the task needs maximum capability.",
-      "Route lighter jobs through OpenCode and open-source models when cost matters more than peak reasoning.",
-      "Layer personal, team, and bundled coding-agent subscriptions so available seats are used before extra usage piles up.",
-    ]);
-  });
-
   it("keeps section headers simple and focused", () => {
     expect(platformLayers.map((layer) => layer.heading)).toEqual([
-      "Shared context for every run.",
-      "Run agents from anywhere.",
-      "Arrive at review already clean.",
+      "Run any coding agent.",
       "Preview every change in the cloud.",
     ]);
   });

--- a/frontend/src/components/landing/landing-copy.ts
+++ b/frontend/src/components/landing/landing-copy.ts
@@ -1,6 +1,61 @@
+export const codeReviewSummary = {
+  step: "01",
+  kicker: "Code review",
+  heading: "Code review that approves the pull requests it should.",
+  body: "Request 143 Code Reviewer on a pull request and several coding agents review it in parallel. When the change clears your policy and no blocking finding remains, 143 submits a real GitHub approval with the evidence attached. When it does not, the pull request comes back with inline findings and the specific reason a human is still needed.",
+};
+
+export const codeReviewOutcomes = [
+  {
+    title: "Reviews finish in minutes",
+    body: "Assessment starts the moment 143 is requested as a reviewer, and every new commit is reviewed again automatically until the pull request is approved. Nobody has to schedule a review or chase one down.",
+  },
+  {
+    title: "Policy is enforced, not remembered",
+    body: "Size thresholds, sensitive paths, migrations, auth, billing, dependency changes, required checks, and description requirements are evaluated on every pull request the same way — instead of depending on who happens to be reviewing that day.",
+  },
+  {
+    title: "Review stops blocking the merge",
+    body: "Acceptable-risk changes are approved on the spot instead of waiting in someone's queue, so finished work reaches main while reviewers keep their attention for the changes that need judgment.",
+  },
+];
+
+export const codeReviewCapabilities = [
+  "Requested like any other GitHub reviewer",
+  "Reviewer agents run their native /review in parallel",
+  "Approval needs evidence, not a model's opinion",
+  "P0 and P1 findings block approval and post inline",
+  "One versioned policy across every repository",
+  "Every decision links to its session and commit",
+];
+
+export const codeReviewApproval = {
+  title: "143 Code Reviewer approved this PR",
+  decision: "Approved",
+  evidence: [
+    { label: "Risk", value: "Acceptable" },
+    { label: "Description", value: "Passed" },
+    { label: "Review agents", value: "Codex clean, Claude Code clean" },
+    { label: "Required checks", value: "CI green" },
+    { label: "Changed", value: "4 files, 96 lines" },
+    { label: "Sensitive paths", value: "None touched" },
+  ],
+  footer: "Policy v12 · reviewed a91f3c2 · evidence kept in the review session",
+};
+
+export const codeReviewEscalation = {
+  title: "143 Code Reviewer did not approve this PR",
+  decision: "Needs human review",
+  reasons: [
+    "Auth-sensitive paths changed",
+    "Description is missing a testing strategy",
+    "P1 finding posted inline on src/auth/session.go:88",
+  ],
+};
+
 export const platformLayers = [
   {
-    step: "02",
+    step: "03",
     kicker: "Context",
     title: "Team context",
     heading: "Shared context for every run.",
@@ -13,7 +68,7 @@ export const platformLayers = [
     ],
   },
   {
-    step: "03",
+    step: "04",
     kicker: "Execution",
     title: "Cloud execution",
     heading: "Run agents from anywhere.",
@@ -26,11 +81,11 @@ export const platformLayers = [
     ],
   },
   {
-    step: "04",
+    step: "05",
     kicker: "Control",
-    title: "Review control",
-    heading: "Review loops before human review.",
-    body: "Agents can repair failing tests, respond to review feedback, and iterate inside guardrails before a teammate has to step in.",
+    title: "Repair loops",
+    heading: "Arrive at review already clean.",
+    body: "Before a reviewer is ever requested, agents repair failing tests, respond to feedback, and iterate inside guardrails, so the pull request that reaches code review is one that can pass it.",
     components: [
       "PR review and repair loops",
       "Usage and cost analytics",
@@ -39,7 +94,7 @@ export const platformLayers = [
     ],
   },
   {
-    step: "05",
+    step: "06",
     kicker: "Previews",
     title: "Cloud previews",
     heading: "Preview every change in the cloud.",

--- a/frontend/src/components/landing/landing-copy.ts
+++ b/frontend/src/components/landing/landing-copy.ts
@@ -1,55 +1,22 @@
 export const codeReviewSummary = {
   step: "01",
   kicker: "Code review",
-  heading: "Agents made code faster to write. Review is where it piles up.",
+  heading: "Code review that approves the pull requests it should.",
   body: "Request 143 Code Reviewer on a pull request and several coding agents review it in parallel. When the change clears your policy and no blocking finding remains, 143 submits a real GitHub approval with the evidence attached. When it does not, the pull request comes back with inline findings and the specific reason a human is still needed.",
 };
 
-export const codeReviewPressures = [
-  {
-    title: "More pull requests",
-    body: "Agents raise the volume every team has to get through. Review capacity does not scale with it.",
-  },
-  {
-    title: "Larger, less cohesive changes",
-    body: "Agent-written pull requests bundle work that does not obviously belong together, so each one costs more to hold in your head.",
-  },
-  {
-    title: "Authors who don't review code",
-    body: "More changes come from teammates who aren't engineers, arriving without the practices reviewers lean on. Saying so is work that falls on the reviewer too.",
-  },
-  {
-    title: "Stacks stuck for days",
-    body: "Generating the code got faster. Getting it to production safely did not, so finished work waits instead of shipping.",
-  },
+export const reviewBottlenecks = [
+  "More pull requests than review capacity",
+  "Larger, less cohesive agent-written changes",
+  "More authors who don't review code for a living",
+  "Stacks stuck in review for days while generation sprints ahead",
 ];
 
 export const codeReviewOutcomes = [
-  {
-    title: "Reviews finish in minutes, not days",
-    body: "Assessment starts the moment 143 is requested as a reviewer, and every new commit is reviewed again automatically until the pull request is approved. Nothing waits for a batch window or for someone to free up.",
-  },
-  {
-    title: "Policy is enforced, not remembered",
-    body: "Size thresholds, sensitive paths, migrations, auth, billing, dependency changes, required checks, and description requirements are evaluated on every pull request the same way — instead of depending on who happens to be reviewing that day.",
-  },
-  {
-    title: "Hard feedback without the interpersonal cost",
-    body: "When a change isn't ready, the reason arrives as inline findings against the policy every author is held to. No one has to spend social capital telling a colleague their pull request needs work.",
-  },
-  {
-    title: "Review stops blocking the merge",
-    body: "Acceptable-risk changes are approved on the spot instead of waiting in someone's queue, so finished work reaches main while reviewers keep their attention for the changes that need judgment.",
-  },
-];
-
-export const codeReviewCapabilities = [
-  "Requested like any other GitHub reviewer",
-  "Reviewer agents run their native /review in parallel",
-  "Approval needs evidence, not a model's opinion",
-  "P0 and P1 findings block approval and post inline",
-  "One versioned policy across every repository",
-  "Every decision links to its session and commit",
+  "Reviews finish in minutes, not days",
+  "Policy is enforced the same way on every pull request",
+  "Hard feedback lands without the interpersonal cost",
+  "Acceptable-risk changes merge on the spot",
 ];
 
 export const codeReviewApproval = {

--- a/frontend/src/components/landing/landing-copy.ts
+++ b/frontend/src/components/landing/landing-copy.ts
@@ -1,21 +1,8 @@
-export const reviewProblem = {
-  step: "01",
-  kicker: "Why this matters",
-  heading: "Agents made code faster to write. Review is where it piles up.",
-};
-
-export const reviewBottlenecks = [
-  "More pull requests than review capacity",
-  "Larger, less cohesive agent-written changes",
-  "More authors who don't review code for a living",
-  "Stacks stuck in review for days while generation sprints ahead",
-];
-
 export const codeReviewSummary = {
-  step: "02",
+  step: "01",
   kicker: "Code review",
   heading: "Code review that approves the pull requests it should.",
-  body: "Request 143 Code Reviewer on a pull request and several coding agents review it in parallel. When the change clears your policy and no blocking finding remains, 143 submits a real GitHub approval with the evidence attached. When it does not, the pull request comes back with inline findings and the specific reason a human is still needed.",
+  body: "Your team can use anything to open a pull request — coding agents made that the easy part. Review is now the bottleneck. Request 143 Code Reviewer and several agents review the PR in parallel: when the change clears your policy, 143 submits a real GitHub approval with the evidence attached; when it does not, it comes back with inline findings and the specific reason a human is still needed.",
 };
 
 export const codeReviewControls = [
@@ -51,46 +38,20 @@ export const codeReviewEscalation = {
 
 export const platformLayers = [
   {
-    step: "04",
-    kicker: "Context",
-    title: "Team context",
-    heading: "Shared context for every run.",
-    body: "Repos, issues, docs, prompts, automations, sessions, and outcomes live in one team workspace. Every agent starts from the same context.",
+    step: "02",
+    kicker: "Any agent",
+    title: "Cloud agents",
+    heading: "Run any coding agent.",
+    body: "Codex, Claude Code, OpenCode, Amp, and Pi all run in isolated cloud sandboxes. Connect an agent's auth once for the organization, start runs from web, mobile, Slack, Linear, or Sentry, and match the agent to the task — top-tier capability where it matters, economical models for routine work.",
     components: [
-      "Shared prompts and automations",
-      "Team-visible sessions and history",
-      "One integration setup per organization",
-      "Builder and engineer roles",
+      "One isolated cloud sandbox per run",
+      "Team-visible sessions, transcripts, and history",
+      "Start from web, mobile, Slack, Linear, or Sentry",
+      "Stack subscriptions before metered spend",
     ],
   },
   {
-    step: "05",
-    kicker: "Execution",
-    title: "Cloud execution",
-    heading: "Run agents from anywhere.",
-    body: "Start Codex, Claude Code, OpenCode, and other coding agents from web, mobile, Slack, Linear, or Sentry. Runs happen in cloud sandboxes your team can follow.",
-    components: [
-      "Codex, Claude Code, OpenCode, and more",
-      "Cloud sandboxes with previews",
-      "Mobile-friendly job controls",
-      "Sessions from issues and errors",
-    ],
-  },
-  {
-    step: "06",
-    kicker: "Control",
-    title: "Repair loops",
-    heading: "Arrive at review already clean.",
-    body: "Before a reviewer is ever requested, agents repair failing tests, respond to feedback, and iterate inside guardrails, so the pull request that reaches code review is one that can pass it.",
-    components: [
-      "PR review and repair loops",
-      "Usage and cost analytics",
-      "Audit logs for sensitive changes",
-      "Safeguards for builder workflows",
-    ],
-  },
-  {
-    step: "07",
+    step: "03",
     kicker: "Previews",
     title: "Cloud previews",
     heading: "Preview every change in the cloud.",
@@ -124,21 +85,6 @@ export const codingAgents = [
   {
     name: "Pi",
     logo: "/agents/pi.svg",
-  },
-];
-
-export const agentChoiceHighlights = [
-  {
-    title: "Use the best agent for the job",
-    body: "Run top-tier tools like Codex, Claude Code, and OpenCode when the task needs maximum capability.",
-  },
-  {
-    title: "Keep routine work economical",
-    body: "Route lighter jobs through OpenCode and open-source models when cost matters more than peak reasoning.",
-  },
-  {
-    title: "Stack subscriptions before metered spend",
-    body: "Layer personal, team, and bundled coding-agent subscriptions so available seats are used before extra usage piles up.",
   },
 ];
 

--- a/frontend/src/components/landing/landing-copy.ts
+++ b/frontend/src/components/landing/landing-copy.ts
@@ -2,7 +2,7 @@ export const codeReviewSummary = {
   step: "01",
   kicker: "Code review",
   heading: "Code review that can auto-approve.",
-  body: "Your team can use anything to open a pull request. Reviewing it is the bottleneck. Request 143 Code Reviewer and several coding agents review the PR in parallel. If the change passes your policy, 143 approves it on GitHub with the evidence attached. If not, it leaves inline findings and the reason a human is needed.",
+  body: "Your team can use anything to open a pull request, but reviewing it is the bottleneck. 143 reviews each PR with several coding agents and approves it on GitHub when it passes your policy.",
 };
 
 export const codeReviewControls = [

--- a/frontend/src/components/landing/landing-copy.ts
+++ b/frontend/src/components/landing/landing-copy.ts
@@ -1,8 +1,7 @@
-export const codeReviewSummary = {
+export const reviewProblem = {
   step: "01",
-  kicker: "Code review",
-  heading: "Code review that approves the pull requests it should.",
-  body: "Request 143 Code Reviewer on a pull request and several coding agents review it in parallel. When the change clears your policy and no blocking finding remains, 143 submits a real GitHub approval with the evidence attached. When it does not, the pull request comes back with inline findings and the specific reason a human is still needed.",
+  kicker: "Why this matters",
+  heading: "Agents made code faster to write. Review is where it piles up.",
 };
 
 export const reviewBottlenecks = [
@@ -12,11 +11,18 @@ export const reviewBottlenecks = [
   "Stacks stuck in review for days while generation sprints ahead",
 ];
 
-export const codeReviewOutcomes = [
-  "Reviews finish in minutes, not days",
-  "Policy is enforced the same way on every pull request",
-  "Hard feedback lands without the interpersonal cost",
-  "Acceptable-risk changes merge on the spot",
+export const codeReviewSummary = {
+  step: "02",
+  kicker: "Code review",
+  heading: "Code review that approves the pull requests it should.",
+  body: "Request 143 Code Reviewer on a pull request and several coding agents review it in parallel. When the change clears your policy and no blocking finding remains, 143 submits a real GitHub approval with the evidence attached. When it does not, the pull request comes back with inline findings and the specific reason a human is still needed.",
+};
+
+export const codeReviewControls = [
+  "Approval thresholds, sensitive paths, and required checks are yours to tune",
+  "Raise the auto-approval rate by tightening policy, not by trusting the model more",
+  "Run one reviewer agent or several in parallel — Codex, Claude Code, OpenCode",
+  "Set each reviewer's model and reasoning depth to balance cost and quality",
 ];
 
 export const codeReviewApproval = {
@@ -45,7 +51,7 @@ export const codeReviewEscalation = {
 
 export const platformLayers = [
   {
-    step: "03",
+    step: "04",
     kicker: "Context",
     title: "Team context",
     heading: "Shared context for every run.",
@@ -58,7 +64,7 @@ export const platformLayers = [
     ],
   },
   {
-    step: "04",
+    step: "05",
     kicker: "Execution",
     title: "Cloud execution",
     heading: "Run agents from anywhere.",
@@ -71,7 +77,7 @@ export const platformLayers = [
     ],
   },
   {
-    step: "05",
+    step: "06",
     kicker: "Control",
     title: "Repair loops",
     heading: "Arrive at review already clean.",
@@ -84,7 +90,7 @@ export const platformLayers = [
     ],
   },
   {
-    step: "06",
+    step: "07",
     kicker: "Previews",
     title: "Cloud previews",
     heading: "Preview every change in the cloud.",

--- a/frontend/src/components/landing/landing-copy.ts
+++ b/frontend/src/components/landing/landing-copy.ts
@@ -2,7 +2,7 @@ export const codeReviewSummary = {
   step: "01",
   kicker: "Code review",
   heading: "Code review that can auto-approve.",
-  body: "Your team can use anything to open a pull request, but reviewing it is the bottleneck. 143 reviews each PR with several coding agents and approves it on GitHub when it passes your policy.",
+  body: "Opening a pull request takes minutes; getting it reviewed takes days. 143 reviews each PR with several coding agents and approves it on GitHub when it passes your policy.",
 };
 
 export const codeReviewControls = [

--- a/frontend/src/components/landing/landing-copy.ts
+++ b/frontend/src/components/landing/landing-copy.ts
@@ -2,7 +2,7 @@ export const codeReviewSummary = {
   step: "01",
   kicker: "Code review",
   heading: "Code review that can auto-approve.",
-  body: "Opening a pull request takes minutes; getting it reviewed takes days. 143 reviews each PR with several coding agents and approves it on GitHub when it passes your policy.",
+  body: "A pull request takes minutes to open and days to review. 143 reviews each PR with several coding agents and approves it on GitHub when it passes your policy.",
 };
 
 export const codeReviewControls = [
@@ -45,7 +45,7 @@ export const platformLayers = [
     kicker: "Previews",
     title: "Cloud previews",
     heading: "Preview every change in the cloud.",
-    body: "Every agent change can launch a browser preview directly from its cloud sandbox, so teammates can inspect behavior before code reaches a PR.",
+    body: "Every agent change can launch a browser preview from its sandbox, so teammates can check behavior before it reaches a PR.",
     components: [
       "Shareable preview links",
       "Preview status in the session",

--- a/frontend/src/components/landing/landing-copy.ts
+++ b/frontend/src/components/landing/landing-copy.ts
@@ -1,7 +1,7 @@
 export const codeReviewSummary = {
   step: "01",
   kicker: "Code review",
-  heading: "Code review that approves the pull requests it should.",
+  heading: "Code review that can auto-approve.",
   body: "Your team can use anything to open a pull request. Reviewing it is the bottleneck. Request 143 Code Reviewer and several coding agents review the PR in parallel. If the change passes your policy, 143 approves it on GitHub with the evidence attached. If not, it leaves inline findings and the reason a human is needed.",
 };
 
@@ -24,16 +24,6 @@ export const codeReviewApproval = {
     { label: "Sensitive paths", value: "None touched" },
   ],
   footer: "Policy v12 · reviewed a91f3c2 · evidence kept in the review session",
-};
-
-export const codeReviewEscalation = {
-  title: "143 Code Reviewer did not approve this PR",
-  decision: "Needs human review",
-  reasons: [
-    "Auth-sensitive paths changed",
-    "Description is missing a testing strategy",
-    "P1 finding posted inline on src/auth/session.go:88",
-  ],
 };
 
 export const platformLayers = [

--- a/frontend/src/components/landing/landing-copy.ts
+++ b/frontend/src/components/landing/landing-copy.ts
@@ -1,18 +1,41 @@
 export const codeReviewSummary = {
   step: "01",
   kicker: "Code review",
-  heading: "Code review that approves the pull requests it should.",
+  heading: "Agents made code faster to write. Review is where it piles up.",
   body: "Request 143 Code Reviewer on a pull request and several coding agents review it in parallel. When the change clears your policy and no blocking finding remains, 143 submits a real GitHub approval with the evidence attached. When it does not, the pull request comes back with inline findings and the specific reason a human is still needed.",
 };
 
+export const codeReviewPressures = [
+  {
+    title: "More pull requests",
+    body: "Agents raise the volume every team has to get through. Review capacity does not scale with it.",
+  },
+  {
+    title: "Larger, less cohesive changes",
+    body: "Agent-written pull requests bundle work that does not obviously belong together, so each one costs more to hold in your head.",
+  },
+  {
+    title: "Authors who don't review code",
+    body: "More changes come from teammates who aren't engineers, arriving without the practices reviewers lean on. Saying so is work that falls on the reviewer too.",
+  },
+  {
+    title: "Stacks stuck for days",
+    body: "Generating the code got faster. Getting it to production safely did not, so finished work waits instead of shipping.",
+  },
+];
+
 export const codeReviewOutcomes = [
   {
-    title: "Reviews finish in minutes",
-    body: "Assessment starts the moment 143 is requested as a reviewer, and every new commit is reviewed again automatically until the pull request is approved. Nobody has to schedule a review or chase one down.",
+    title: "Reviews finish in minutes, not days",
+    body: "Assessment starts the moment 143 is requested as a reviewer, and every new commit is reviewed again automatically until the pull request is approved. Nothing waits for a batch window or for someone to free up.",
   },
   {
     title: "Policy is enforced, not remembered",
     body: "Size thresholds, sensitive paths, migrations, auth, billing, dependency changes, required checks, and description requirements are evaluated on every pull request the same way — instead of depending on who happens to be reviewing that day.",
+  },
+  {
+    title: "Hard feedback without the interpersonal cost",
+    body: "When a change isn't ready, the reason arrives as inline findings against the policy every author is held to. No one has to spend social capital telling a colleague their pull request needs work.",
   },
   {
     title: "Review stops blocking the merge",

--- a/frontend/src/components/landing/landing-copy.ts
+++ b/frontend/src/components/landing/landing-copy.ts
@@ -2,14 +2,14 @@ export const codeReviewSummary = {
   step: "01",
   kicker: "Code review",
   heading: "Code review that approves the pull requests it should.",
-  body: "Your team can use anything to open a pull request — coding agents made that the easy part. Review is now the bottleneck. Request 143 Code Reviewer and several agents review the PR in parallel: when the change clears your policy, 143 submits a real GitHub approval with the evidence attached; when it does not, it comes back with inline findings and the specific reason a human is still needed.",
+  body: "Your team can use anything to open a pull request. Reviewing it is the bottleneck. Request 143 Code Reviewer and several coding agents review the PR in parallel. If the change passes your policy, 143 approves it on GitHub with the evidence attached. If not, it leaves inline findings and the reason a human is needed.",
 };
 
 export const codeReviewControls = [
-  "Approval thresholds, sensitive paths, and required checks are yours to tune",
-  "Raise the auto-approval rate by tightening policy, not by trusting the model more",
-  "Run one reviewer agent or several in parallel — Codex, Claude Code, OpenCode",
-  "Set each reviewer's model and reasoning depth to balance cost and quality",
+  "Tune thresholds, sensitive paths, and required checks",
+  "Raise the auto-approval rate by tightening policy",
+  "Choose reviewer models: Codex, Claude Code, OpenCode",
+  "Set reasoning depth per reviewer to control cost",
 ];
 
 export const codeReviewApproval = {
@@ -42,12 +42,12 @@ export const platformLayers = [
     kicker: "Any agent",
     title: "Cloud agents",
     heading: "Run any coding agent.",
-    body: "Codex, Claude Code, OpenCode, Amp, and Pi all run in isolated cloud sandboxes. Connect an agent's auth once for the organization, start runs from web, mobile, Slack, Linear, or Sentry, and match the agent to the task — top-tier capability where it matters, economical models for routine work.",
+    body: "Codex, Claude Code, OpenCode, Amp, and Pi each run in an isolated cloud sandbox. Connect an agent once and anyone on the team can start a run from the web, Slack, Linear, or Sentry.",
     components: [
-      "One isolated cloud sandbox per run",
-      "Team-visible sessions, transcripts, and history",
-      "Start from web, mobile, Slack, Linear, or Sentry",
-      "Stack subscriptions before metered spend",
+      "One isolated sandbox per run",
+      "Team-visible sessions and transcripts",
+      "Cheaper models for routine work",
+      "Existing subscriptions used before metered billing",
     ],
   },
   {


### PR DESCRIPTION
## Summary

The landing page currently starts with "why this matters" context, but code review is the primary product feature that should lead the homepage story. This change introduces a dedicated code review section positioned directly after the hero, establishing automated approval as the core value proposition before explaining the platform infrastructure that supports it.

## Changes

- **New CodeReviewSection component** (`code-review-section.tsx`): Showcases the auto-approval workflow with visual cards displaying both approval and escalation paths, backed by explicit evidence. Includes three outcome cards highlighting speed, policy enforcement, and unblocked merges.
- **Code review copy** (`landing-copy.ts`): Added `codeReviewSummary`, `codeReviewOutcomes`, `codeReviewCapabilities`, `codeReviewApproval`, and `codeReviewEscalation` exports that define the messaging and evidence structure.
- **Updated section numbering**: Renumbered platform layers from 02-05 to 03-06, and updated "Why this matters" section to 02 to accommodate code review as step 01.
- **Landing page integration** (`page.tsx`): Inserted CodeReviewSection between hero and how-it-works sections.
- **Updated CTA messaging** (`cta-section.tsx`): Added descriptive body text explaining the code review workflow.
- **Comprehensive test coverage**: Added unit tests for CodeReviewSection and updated existing tests to verify section ordering and messaging.

## Validation

- Added `code-review-section.test.tsx` with 5 test cases covering the approval verdict, escalation path, outcomes, and policy guide link
- Updated `landing-copy.test.ts` with assertions for code review copy structure and section numbering
- Updated `page.test.tsx` to verify code review section appears first in the section order
- All existing tests pass with updated section numbers and messaging

https://claude.ai/code/session_01HF9kQxVBFL4csWSeo2Znyf