### PR TITLE
Add paginated code reviews count and improve pagination UX

### DIFF
--- a/docs/design/implemented/36-code-review-display.md
+++ b/docs/design/implemented/36-code-review-display.md
@@ -1,6 +1,6 @@
 # 36 - Code Review Display
 
-> **Status:** Implemented | **Last reviewed:** 2026-05-06
+> **Status:** Implemented | **Last reviewed:** 2026-07-28
 >
 > **Implementation notes:** The rich diff viewer is shipped: parsed file/hunk rendering, unified and split modes, syntax highlighting, file tree navigation, inline review comments, keyboard navigation, repo explorer integration, basic between-hunk context expansion, and scroll-synced active-file highlighting between the diff pane and file tree. PR creation has also moved onto snapshot-backed workspace pushes. The two remaining design-area concerns — (1) GitHub-style incremental context navigation from the current diff position and (2) stronger diff provenance so the rendered diff is explicitly tied to an immutable branch basis instead of an ad hoc stored patch — were spun out into [55-code-diff-context-navigation.md](55-code-diff-context-navigation.md).
 
@@ -19,6 +19,25 @@ For a tool targeting developers, the code review surface is the highest-leverage
 3. **Comments are commands** — Every inline comment is a directive to the agent. The review UI is the steering wheel, not just a read-only display.
 4. **Keyboard-first** — File navigation, comment creation, and approval should all be possible without touching a mouse.
 5. **Progressive disclosure** — Start with the diff summary, expand to file-level detail, drill into full repo exploration. Never force all the complexity up front.
+
+## Code Reviews Activity List
+
+The dashboard Code reviews activity list is a newest-first, cursor-paginated
+operational feed. The public list API returns at most 50 rows by default,
+an exact `meta.total_count` for the complete filtered collection, and
+`meta.next_cursor` when more history exists. The cursor follows the stable
+`(created_at DESC, id DESC)` ordering and is scoped to the active organization.
+Reusing a cursor with a different filter collection is rejected.
+
+Repository, outcome, risk, status, and search filters are URL-backed so views
+are shareable and browser-navigation safe. The UI presents `Showing N of M`
+and loads history explicitly in batches of 50 rather than using automatic
+infinite scrolling.
+
+Live SSE refreshes update the newest page automatically. After a user loads
+older pages, automatic replacement pauses to preserve the cursor snapshot;
+subsequent events show a “New reviews are available” action that returns the
+list to a freshly loaded newest page.
 
 ---
 

--- a/frontend/src/app/(dashboard)/code-reviews/page.test.tsx
+++ b/frontend/src/app/(dashboard)/code-reviews/page.test.tsx
@@ -1,13 +1,17 @@
 import { beforeEach, describe, it, expect, vi } from "vitest";
 import { act } from "react";
 import { http, HttpResponse } from "msw";
-import { fireEvent, renderWithProviders, screen, userEvent, waitFor, within } from "@/test/test-utils";
+import { createTestQueryClient, fireEvent, renderWithProviders, screen, userEvent, waitFor, within } from "@/test/test-utils";
 import { server } from "@/test/mocks/server";
+import { queryKeys } from "@/lib/query-keys";
 
 const toast = vi.hoisted(() => ({
   success: vi.fn(),
   info: vi.fn(),
   error: vi.fn(),
+}));
+const sse = vi.hoisted(() => ({
+  onEvent: undefined as undefined | (() => void),
 }));
 
 vi.mock("@/lib/notify", () => ({ notify: toast }));
@@ -21,7 +25,10 @@ vi.mock("@/lib/use-resource-sse", async () => {
   const actual = await vi.importActual<typeof import("@/lib/use-resource-sse")>("@/lib/use-resource-sse");
   return {
     ...actual,
-    useResourceSSE: () => ({ healthy: true }),
+    useResourceSSE: ({ onEvent }: { onEvent: () => void }) => {
+      sse.onEvent = onEvent;
+      return { healthy: true };
+    },
   };
 });
 import type {
@@ -251,7 +258,7 @@ function mockCodeReviewBaseHandlers(
     http.get("/api/v1/code-reviews", () =>
       HttpResponse.json({
         data: [review],
-        meta: {},
+        meta: { total_count: 1 },
       } satisfies ListResponse<CodeReviewListItem>),
     ),
     http.get("/api/v1/code-reviews/session-1/evidence", () =>
@@ -350,6 +357,7 @@ describe("CodeReviewsPage", () => {
     toast.success.mockReset();
     toast.info.mockReset();
     toast.error.mockReset();
+    sse.onEvent = undefined;
   });
 
   it("renders review sessions and policy configuration", async () => {
@@ -384,6 +392,7 @@ describe("CodeReviewsPage", () => {
     expect(filterToggle).toHaveAttribute("aria-expanded", "true");
     expect(screen.getByRole("textbox", { name: "Search code reviews" })).toBeInTheDocument();
     expect(screen.queryByRole("link", { name: "Open pull request" })).not.toBeInTheDocument();
+    expect(screen.getByText("Showing 1 of 1")).toBeInTheDocument();
     const reviewTable = screen.getByRole("table");
     const reviewRow = within(reviewTable).getByRole("row", {
       name: /#428 Fix invoice rounding/i,
@@ -521,6 +530,163 @@ describe("CodeReviewsPage", () => {
 
     expect(await within(evidenceSheet).findByText("No blocking issues found.")).toBeInTheDocument();
     expect(evidenceRequests).toBe(2);
+  });
+
+  it("loads the next cursor page and updates the visible count", async () => {
+    const secondReview = {
+      ...review,
+      id: "review-2",
+      session_id: "session-2",
+      github_pr_number: 429,
+      pull_request_title: "Fix tax rounding",
+    };
+    const requestedCursors: Array<string | null> = [];
+    mockCodeReviewBaseHandlers();
+    server.use(
+      http.get("/api/v1/code-reviews", ({ request }) => {
+        const cursor = new URL(request.url).searchParams.get("cursor");
+        requestedCursors.push(cursor);
+        return HttpResponse.json(cursor
+          ? { data: [secondReview], meta: { total_count: 2 } }
+          : { data: [review], meta: { next_cursor: "review-1", total_count: 2 } });
+      }),
+    );
+    renderWithProviders(<CodeReviewsPage />);
+
+    expect(await screen.findByText("Showing 1 of 2")).toBeInTheDocument();
+    await userEvent.click(screen.getByRole("button", { name: "Show 50 more" }));
+
+    expect(await screen.findByText("Showing 2 of 2")).toBeInTheDocument();
+    expect(screen.getAllByText("#429 Fix tax rounding")).toHaveLength(2);
+    expect(requestedCursors).toContain("review-1");
+    expect(screen.queryByRole("button", { name: "Show 50 more" })).not.toBeInTheDocument();
+  });
+
+  it("preserves loaded history and offers a refresh when a live review arrives", async () => {
+    mockCodeReviewBaseHandlers();
+    server.use(
+      http.get("/api/v1/code-reviews", ({ request }) =>
+        HttpResponse.json(new URL(request.url).searchParams.has("cursor")
+          ? { data: [], meta: { total_count: 2 } }
+          : { data: [review], meta: { next_cursor: "review-1", total_count: 2 } })),
+    );
+    renderWithProviders(<CodeReviewsPage />);
+    await userEvent.click(await screen.findByRole("button", { name: "Show 50 more" }));
+
+    act(() => sse.onEvent?.());
+
+    expect(await screen.findByText("New reviews are available.")).toBeInTheDocument();
+    expect(screen.getAllByText("#428 Fix invoice rounding")).toHaveLength(2);
+    await userEvent.click(screen.getByRole("button", { name: "Refresh" }));
+    expect(screen.queryByText("New reviews are available.")).not.toBeInTheDocument();
+    expect(await screen.findByRole("button", { name: "Show 50 more" })).toBeInTheDocument();
+  });
+
+  it("does not replace the first page when another feature invalidates review lists", async () => {
+    const queryClient = createTestQueryClient();
+    let firstPageRequests = 0;
+    mockCodeReviewBaseHandlers();
+    server.use(
+      http.get("/api/v1/code-reviews", ({ request }) => {
+        if (new URL(request.url).searchParams.has("cursor")) {
+          return HttpResponse.json({ data: [], meta: { total_count: 2 } });
+        }
+        firstPageRequests += 1;
+        return HttpResponse.json({
+          data: [review],
+          meta: { next_cursor: "review-1", total_count: 2 },
+        });
+      }),
+    );
+    renderWithProviders(<CodeReviewsPage />, { queryClient });
+    await userEvent.click(await screen.findByRole("button", { name: "Show 50 more" }));
+
+    await act(async () => {
+      await queryClient.invalidateQueries({ queryKey: queryKeys.codeReviews.lists() });
+    });
+
+    expect(firstPageRequests).toBe(1);
+    expect(screen.getAllByText("#428 Fix invoice rounding")).toHaveLength(2);
+  });
+
+  it("does not append an in-flight history page after the filter scope changes", async () => {
+    const staleReview = {
+      ...review,
+      id: "review-stale",
+      session_id: "session-stale",
+      github_pr_number: 429,
+      pull_request_title: "Stale history result",
+    };
+    let resolveHistory: (() => void) | undefined;
+    const historyGate = new Promise<void>((resolve) => {
+      resolveHistory = resolve;
+    });
+    mockCodeReviewBaseHandlers();
+    server.use(
+      http.get("/api/v1/code-reviews", async ({ request }) => {
+        const params = new URL(request.url).searchParams;
+        if (params.has("cursor")) {
+          await historyGate;
+          return HttpResponse.json({ data: [staleReview], meta: { total_count: 2 } });
+        }
+        return HttpResponse.json({
+          data: [review],
+          meta: params.get("decision") === "blocked"
+            ? { total_count: 1 }
+            : { next_cursor: "review-1", total_count: 2 },
+        });
+      }),
+    );
+    renderWithProviders(<CodeReviewsPage />, { nuqsHasMemory: true });
+    await userEvent.click(await screen.findByRole("button", { name: "Show 50 more" }));
+    await userEvent.click(screen.getByRole("combobox", { name: "Outcome" }));
+    await userEvent.click(await screen.findByRole("option", { name: "Blocked" }));
+
+    act(() => resolveHistory?.());
+
+    await waitFor(() => {
+      expect(screen.queryByText("#429 Stale history result")).not.toBeInTheDocument();
+      expect(screen.getByText("Showing 1 of 1")).toBeInTheDocument();
+    });
+  });
+
+  it("preserves loaded reviews and allows retry after a history-page failure", async () => {
+    const secondReview = {
+      ...review,
+      id: "review-2",
+      session_id: "session-2",
+      github_pr_number: 429,
+      pull_request_title: "Recovered history page",
+    };
+    let historyAttempts = 0;
+    mockCodeReviewBaseHandlers();
+    server.use(
+      http.get("/api/v1/code-reviews", ({ request }) => {
+        if (!new URL(request.url).searchParams.has("cursor")) {
+          return HttpResponse.json({
+            data: [review],
+            meta: { next_cursor: "review-1", total_count: 2 },
+          });
+        }
+        historyAttempts += 1;
+        if (historyAttempts === 1) {
+          return HttpResponse.json(
+            { error: { code: "CODE_REVIEWS_LOAD_FAILED", message: "temporary failure" } },
+            { status: 500 },
+          );
+        }
+        return HttpResponse.json({ data: [secondReview], meta: { total_count: 2 } });
+      }),
+    );
+    renderWithProviders(<CodeReviewsPage />);
+
+    await userEvent.click(await screen.findByRole("button", { name: "Show 50 more" }));
+    expect(await screen.findByText("Couldn't load more reviews.")).toBeInTheDocument();
+    expect(screen.getAllByText("#428 Fix invoice rounding")).toHaveLength(2);
+
+    await userEvent.click(screen.getByRole("button", { name: "Show 50 more" }));
+    expect(await screen.findByText("Showing 2 of 2")).toBeInTheDocument();
+    expect(screen.getAllByText("#429 Recovered history page")).toHaveLength(2);
   });
 
   it("omits the mobile completion timestamp until a review completes", async () => {
@@ -1016,6 +1182,59 @@ describe("CodeReviewsPage", () => {
     expect(await screen.findAllByText("#428 Fix invoice rounding")).toHaveLength(2);
     await waitFor(() => {
       expect(requestedOutcomes).toContain("automatically_approved");
+    });
+  });
+
+  it("restores every review filter from the URL and sends the complete filtered request", async () => {
+    const requests: URLSearchParams[] = [];
+    mockCodeReviewBaseHandlers();
+    server.use(
+      http.get("/api/v1/code-reviews", ({ request }) => {
+        requests.push(new URL(request.url).searchParams);
+        return HttpResponse.json({ data: [review], meta: { total_count: 1 } });
+      }),
+    );
+
+    renderWithProviders(<CodeReviewsPage />, {
+      searchParams: {
+        repository: repo.id,
+        outcome: "blocked",
+        risk: "needs_review",
+        status: "completed",
+        search: "invoice",
+      },
+    });
+
+    expect(await screen.findByRole("textbox", { name: "Search code reviews" })).toHaveValue("invoice");
+    await waitFor(() => {
+      expect(requests.some((params) =>
+        params.get("repository_id") === repo.id
+        && params.get("decision") === "blocked"
+        && params.get("risk") === "needs_review"
+        && params.get("status") === "completed"
+        && params.get("search") === "invoice"
+        && params.get("limit") === "50",
+      )).toBe(true);
+    });
+  });
+
+  it("distinguishes a filtered empty result and clears the active filters", async () => {
+    mockCodeReviewBaseHandlers();
+    server.use(
+      http.get("/api/v1/code-reviews", () =>
+        HttpResponse.json({ data: [], meta: { total_count: 0 } })),
+    );
+    renderWithProviders(<CodeReviewsPage />, {
+      searchParams: { outcome: "blocked", search: "missing" },
+      nuqsHasMemory: true,
+    });
+
+    expect(await screen.findByText("No reviews match these filters")).toBeInTheDocument();
+    await userEvent.click(screen.getByRole("button", { name: "Clear filters" }));
+
+    await waitFor(() => {
+      expect(screen.getByRole("textbox", { name: "Search code reviews" })).toHaveValue("");
+      expect(screen.getByRole("combobox", { name: "Outcome" })).toHaveTextContent("All outcomes");
     });
   });
 

--- a/frontend/src/app/(dashboard)/code-reviews/page.tsx
+++ b/frontend/src/app/(dashboard)/code-reviews/page.tsx
@@ -4,7 +4,7 @@ import Link from "next/link";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { ClipboardEvent, ComponentProps, KeyboardEvent, ReactNode } from "react";
 import { useMutation, useQueries, useQuery, useQueryClient } from "@tanstack/react-query";
-import { parseAsStringLiteral, useQueryState } from "nuqs";
+import { parseAsString, parseAsStringLiteral, useQueryState } from "nuqs";
 import {
   AlertTriangle,
   ChevronDown,
@@ -95,9 +95,13 @@ const AUTOMATICALLY_APPROVED = "automatically_approved" satisfies CodeReviewList
 const COMPLETED_NOT_APPROVED = "completed_not_approved" satisfies CodeReviewListOutcome;
 const OUTCOME_FILTER_VALUES = [ALL_OUTCOMES, AUTOMATICALLY_APPROVED, COMPLETED_NOT_APPROVED, "needs_human_review", "comment_only", "blocked"] as const;
 type OutcomeFilter = (typeof OUTCOME_FILTER_VALUES)[number];
+const RISK_FILTER_VALUES = [ALL_RISKS, "acceptable", "needs_review"] as const;
+const STATUS_FILTER_VALUES = [ALL_STATUSES, "queued", "running", "completed", "failed", "stale", "cancelled"] as const;
 const NO_TEMPLATE = "none";
 // Coalesce a burst of SSE lifecycle events into a single list refetch.
 const CODE_REVIEW_INVALIDATE_COALESCE_MS = 300;
+const CODE_REVIEW_PAGE_SIZE = 50;
+const CODE_REVIEW_SEARCH_DEBOUNCE_MS = 300;
 const MAX_REVIEWER_MODELS = 3;
 const CODE_REVIEW_REASONING_OPTIONS = [
   { value: "low", label: "Low" },
@@ -431,14 +435,24 @@ export default function CodeReviewsPage() {
   const { user } = useAuth();
   const canManagePolicy = user?.role === "admin";
   const canRetryReviews = user?.role === "admin" || user?.role === "member";
-  const [repositoryFilter, setRepositoryFilter] = useState(ALL_REPOSITORIES);
+  const [repositoryFilter, setRepositoryFilter] = useQueryState("repository", parseAsString.withDefault(ALL_REPOSITORIES));
   const [outcomeFilter, setOutcomeParam] = useQueryState(
     "outcome",
     parseAsStringLiteral(OUTCOME_FILTER_VALUES).withDefault(ALL_OUTCOMES),
   );
-  const [riskFilter, setRiskFilter] = useState(ALL_RISKS);
-  const [statusFilter, setStatusFilter] = useState(ALL_STATUSES);
-  const [search, setSearch] = useState("");
+  const [riskFilter, setRiskFilter] = useQueryState("risk", parseAsStringLiteral(RISK_FILTER_VALUES).withDefault(ALL_RISKS));
+  const [statusFilter, setStatusFilter] = useQueryState("status", parseAsStringLiteral(STATUS_FILTER_VALUES).withDefault(ALL_STATUSES));
+  const [searchParam, setSearchParam] = useQueryState("search", parseAsString.withDefault(""));
+  const [search, setSearch] = useState(searchParam);
+  useEffect(() => {
+    setSearch(searchParam);
+  }, [searchParam]);
+  useEffect(() => {
+    const timer = window.setTimeout(() => {
+      void setSearchParam(search.trim() || null);
+    }, CODE_REVIEW_SEARCH_DEBOUNCE_MS);
+    return () => window.clearTimeout(timer);
+  }, [search, setSearchParam]);
   const [selectedTemplateKey, setSelectedTemplateKey] = useState(NO_TEMPLATE);
   const [pendingTemplateApply, setPendingTemplateApply] = useState<{ key: string; title: string } | null>(null);
   const [selectedEvidenceSessionId, setSelectedEvidenceSessionId] = useState<string | null>(null);
@@ -469,11 +483,31 @@ export default function CodeReviewsPage() {
       outcome: outcomeFilter === AUTOMATICALLY_APPROVED || outcomeFilter === COMPLETED_NOT_APPROVED ? (outcomeFilter as CodeReviewListOutcome) : undefined,
       risk: riskFilter === ALL_RISKS ? undefined : (riskFilter as "acceptable" | "needs_review"),
       status: statusFilter === ALL_STATUSES ? undefined : (statusFilter as CodeReviewSessionStatus),
-      search: search.trim() || undefined,
-      limit: 100,
+      search: searchParam.trim() || undefined,
+      limit: CODE_REVIEW_PAGE_SIZE,
     }),
-    [outcomeFilter, reviewRepositoryId, riskFilter, search, statusFilter],
+    [outcomeFilter, reviewRepositoryId, riskFilter, searchParam, statusFilter],
   );
+  const hasActiveReviewFilters = Boolean(
+    reviewRepositoryId
+    || outcomeFilter !== ALL_OUTCOMES
+    || riskFilter !== ALL_RISKS
+    || statusFilter !== ALL_STATUSES
+    || searchParam.trim(),
+  );
+  const reviewScopeKey = JSON.stringify(reviewFilters);
+  const [extraReviewPages, setExtraReviewPages] = useState<CodeReviewListItem[][]>([]);
+  const [loadMoreCursor, setLoadMoreCursor] = useState<string | undefined>();
+  const [newReviewsAvailable, setNewReviewsAvailable] = useState(false);
+  const isViewingReviewHistory = extraReviewPages.length > 0;
+  const [previousReviewScopeKey, setPreviousReviewScopeKey] = useState(reviewScopeKey);
+  if (previousReviewScopeKey !== reviewScopeKey) {
+    setPreviousReviewScopeKey(reviewScopeKey);
+    setExtraReviewPages([]);
+    setLoadMoreCursor(undefined);
+    setNewReviewsAvailable(false);
+    setSelectedEvidenceSessionId(null);
+  }
   const repositoriesQuery = useQuery({
     queryKey: queryKeys.repositories.all,
     queryFn: () => api.repositories.list(),
@@ -496,6 +530,10 @@ export default function CodeReviewsPage() {
   // coalesce bursts into one refetch per window rather than one per event.
   const invalidateTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const onCodeReviewEvent = useCallback(() => {
+    if (isViewingReviewHistory) {
+      setNewReviewsAvailable(true);
+      return;
+    }
     if (invalidateTimerRef.current) return;
     invalidateTimerRef.current = setTimeout(() => {
       invalidateTimerRef.current = null;
@@ -503,7 +541,7 @@ export default function CodeReviewsPage() {
         queryKey: queryKeys.codeReviews.lists(),
       });
     }, pollMs(CODE_REVIEW_INVALIDATE_COALESCE_MS));
-  }, [queryClient]);
+  }, [isViewingReviewHistory, queryClient]);
   useEffect(
     () => () => {
       if (invalidateTimerRef.current) clearTimeout(invalidateTimerRef.current);
@@ -518,7 +556,11 @@ export default function CodeReviewsPage() {
   const reviewsQuery = useQuery({
     queryKey: queryKeys.codeReviews.list(reviewFilters),
     queryFn: () => api.codeReviews.list(reviewFilters),
-    refetchInterval: codeReviewStreamHealthy ? pollMs(30_000) : pollMs(5_000),
+    // A loaded history window must remain a coherent cursor snapshot. Disabling
+    // the observer blocks reconnects and unrelated broad invalidations from
+    // replacing page one while the older pages remain appended.
+    enabled: !isViewingReviewHistory,
+    refetchInterval: isViewingReviewHistory ? false : (codeReviewStreamHealthy ? pollMs(30_000) : pollMs(5_000)),
   });
   const policyQuery = useQuery({
     queryKey: queryKeys.codeReviews.policy,
@@ -645,11 +687,13 @@ export default function CodeReviewsPage() {
     },
     onSuccess: (_result, sessionId) => {
       setSelectedEvidenceSessionId((current) => (current === sessionId ? null : current));
-      void queryClient.invalidateQueries({ queryKey: queryKeys.codeReviews.lists() });
+      if (isViewingReviewHistory) setNewReviewsAvailable(true);
+      else void queryClient.invalidateQueries({ queryKey: queryKeys.codeReviews.lists() });
       toast.success("Code review retry started");
     },
     onError: (error) => {
-      void queryClient.invalidateQueries({ queryKey: queryKeys.codeReviews.lists() });
+      if (isViewingReviewHistory) setNewReviewsAvailable(true);
+      else void queryClient.invalidateQueries({ queryKey: queryKeys.codeReviews.lists() });
       toast.error("Code review could not be retried", {
         description: apiErrorMessage(error) ?? "Try again after checking the review failure details.",
       });
@@ -662,7 +706,38 @@ export default function CodeReviewsPage() {
       });
     },
   });
-  const reviews = useMemo(() => reviewsQuery.data?.data ?? [], [reviewsQuery.data?.data]);
+  const firstReviewPage = useMemo(() => reviewsQuery.data?.data ?? [], [reviewsQuery.data?.data]);
+  const reviews = useMemo(() => {
+    const byID = new Map<string, CodeReviewListItem>();
+    for (const review of [firstReviewPage, ...extraReviewPages].flat()) byID.set(review.id, review);
+    return [...byID.values()];
+  }, [extraReviewPages, firstReviewPage]);
+  const firstReviewCursor = reviewsQuery.data?.meta?.next_cursor || undefined;
+  const nextReviewCursor = isViewingReviewHistory ? loadMoreCursor : firstReviewCursor;
+  const totalReviewCount = reviewsQuery.data?.meta?.total_count;
+  const loadMoreReviews = useMutation({
+    mutationFn: (request: {
+      filters: typeof reviewFilters;
+      cursor: string;
+      scopeKey: string;
+    }) => api.codeReviews.list({ ...request.filters, cursor: request.cursor }),
+    onSuccess: (response, request) => {
+      if (request.scopeKey !== reviewScopeKey) return;
+      setExtraReviewPages((pages) => [...pages, response.data ?? []]);
+      setLoadMoreCursor(response.meta?.next_cursor || undefined);
+    },
+  });
+  useEffect(() => {
+    loadMoreReviews.reset();
+  // reset is stable for the lifetime of the mutation observer.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [reviewScopeKey]);
+  const refreshNewestReviews = useCallback(() => {
+    setExtraReviewPages([]);
+    setLoadMoreCursor(undefined);
+    setNewReviewsAvailable(false);
+    void reviewsQuery.refetch();
+  }, [reviewsQuery]);
   const [countdownNowMs, setCountdownNowMs] = useState(() => Date.now());
   const hasScheduledReviewRetry = reviews.some((item) => Boolean(item.retry_at));
   useEffect(() => {
@@ -851,7 +926,7 @@ export default function CodeReviewsPage() {
               id="code-review-filters"
               className={`${mobileFiltersOpen ? "grid" : "hidden"} gap-3 rounded-xl border border-border bg-card p-3 shadow-sm md:grid md:grid-cols-[minmax(12rem,18rem)_minmax(10rem,12rem)_minmax(10rem,12rem)_minmax(10rem,12rem)_1fr] md:rounded-none md:border-0 md:bg-transparent md:p-0 md:shadow-none`}
             >
-              <FilterSelect label="Repository" value={repositoryFilter} onValueChange={setRepositoryFilter}>
+              <FilterSelect label="Repository" value={repositoryFilter} onValueChange={(value) => void setRepositoryFilter(value === ALL_REPOSITORIES ? null : value)}>
                 <SelectItem value={ALL_REPOSITORIES}>All repositories</SelectItem>
                 {repositories.map((repo) => (
                   <SelectItem key={repo.id} value={repo.id}>
@@ -867,12 +942,12 @@ export default function CodeReviewsPage() {
                 <SelectItem value="comment_only">Comment-only decision</SelectItem>
                 <SelectItem value="blocked">Blocked</SelectItem>
               </FilterSelect>
-              <FilterSelect label="Risk" value={riskFilter} onValueChange={setRiskFilter}>
+              <FilterSelect label="Risk" value={riskFilter} onValueChange={(value) => void setRiskFilter(value === ALL_RISKS ? null : value as (typeof RISK_FILTER_VALUES)[number])}>
                 <SelectItem value={ALL_RISKS}>All risk</SelectItem>
                 <SelectItem value="acceptable">Acceptable</SelectItem>
                 <SelectItem value="needs_review">Needs review</SelectItem>
               </FilterSelect>
-              <FilterSelect label="Status" value={statusFilter} onValueChange={setStatusFilter}>
+              <FilterSelect label="Status" value={statusFilter} onValueChange={(value) => void setStatusFilter(value === ALL_STATUSES ? null : value as (typeof STATUS_FILTER_VALUES)[number])}>
                 <SelectItem value={ALL_STATUSES}>All statuses</SelectItem>
                 <SelectItem value="queued">Queued</SelectItem>
                 <SelectItem value="running">Running</SelectItem>
@@ -886,15 +961,53 @@ export default function CodeReviewsPage() {
                 <Input value={search} onChange={(event) => setSearch(event.target.value)} placeholder="PR, repo, or title" aria-label="Search code reviews" />
               </div>
             </div>
-            <SectionGroup title="Review activity" description="Pull requests reviewed by the team policy and their current outcome.">
-            {reviews.length === 0 ? (
-              <EmptyState
-                icon={ClipboardCheck}
-                title="No code review sessions"
-                description="Reviews will appear here after the GitHub reviewer bot is requested on a pull request."
-              />
-            ) : (
-              <>
+            <SectionGroup
+              title={
+                <span className="flex items-baseline gap-2">
+                  Review activity
+                  {totalReviewCount !== undefined ? (
+                    <span className="text-sm font-normal tabular-nums text-muted-foreground">
+                      {totalReviewCount} {hasActiveReviewFilters ? "matching " : ""}
+                      {totalReviewCount === 1 ? "review" : "reviews"}
+                    </span>
+                  ) : null}
+                </span>
+              }
+              description="Pull requests reviewed by the team policy and their current outcome."
+            >
+              {newReviewsAvailable ? (
+                <div className="flex items-center justify-between gap-3 rounded-md border border-border bg-muted/30 px-3 py-2 text-sm">
+                  <span>New reviews are available.</span>
+                  <Button variant="outline" size="sm" onClick={refreshNewestReviews}>Refresh</Button>
+                </div>
+              ) : null}
+              {reviewsQuery.isLoading ? (
+                <div className="py-12 text-center text-sm text-muted-foreground">Loading code reviews…</div>
+              ) : reviewsQuery.isError ? (
+                <ErrorNotice
+                  title="Code reviews could not be loaded"
+                  description="Try again to load review activity."
+                  action={{ label: "Retry", onClick: () => void reviewsQuery.refetch() }}
+                />
+              ) : reviews.length === 0 ? (
+                <EmptyState
+                  icon={ClipboardCheck}
+                  title={hasActiveReviewFilters ? "No reviews match these filters" : "No code review sessions"}
+                  description={hasActiveReviewFilters ? "Adjust or clear the filters to see more review activity." : "Reviews will appear here after the GitHub reviewer bot is requested on a pull request."}
+                  action={hasActiveReviewFilters ? {
+                    label: "Clear filters",
+                    onClick: () => {
+                      void setRepositoryFilter(null);
+                      void setOutcomeParam(null);
+                      void setRiskFilter(null);
+                      void setStatusFilter(null);
+                      setSearch("");
+                      void setSearchParam(null);
+                    },
+                  } : undefined}
+                />
+              ) : (
+                <>
                 <ResponsiveResourceList
                   ariaLabel="Code reviews"
                   mobileAriaLabel="Code review activity"
@@ -902,6 +1015,34 @@ export default function CodeReviewsPage() {
                   getItemKey={(review) => review.id}
                   columns={reviewColumns}
                   emptyState="No code review sessions."
+                  footer={
+                    <div className="flex flex-wrap items-center justify-between gap-3 border-t border-border/50 bg-muted/20 px-4 py-2.5">
+                      <span className="text-xs tabular-nums text-muted-foreground" aria-live="polite">
+                        {totalReviewCount !== undefined
+                          ? `Showing ${reviews.length} of ${totalReviewCount}`
+                          : `${reviews.length} review${reviews.length === 1 ? "" : "s"}`}
+                      </span>
+                      <div className="flex items-center gap-3">
+                        {loadMoreReviews.isError ? (
+                          <span className="text-xs text-destructive">Couldn&apos;t load more reviews.</span>
+                        ) : null}
+                        {nextReviewCursor ? (
+                          <Button
+                            variant="ghost"
+                            size="sm"
+                            onClick={() => loadMoreReviews.mutate({
+                              filters: reviewFilters,
+                              cursor: nextReviewCursor,
+                              scopeKey: reviewScopeKey,
+                            })}
+                            disabled={loadMoreReviews.isPending}
+                          >
+                            {loadMoreReviews.isPending ? "Loading…" : "Show 50 more"}
+                          </Button>
+                        ) : null}
+                      </div>
+                    </div>
+                  }
                   renderMobileItem={(review) => (
                   <ResourceRow
                     title={
@@ -973,7 +1114,7 @@ export default function CodeReviewsPage() {
                     if (!open) setSelectedEvidenceSessionId(null);
                   }}
                 />
-              </>
+                </>
               )}
             </SectionGroup>
           </TabsContent>

--- a/frontend/src/components/responsive-resource-list.test.tsx
+++ b/frontend/src/components/responsive-resource-list.test.tsx
@@ -35,6 +35,7 @@ describe("ResponsiveResourceList", () => {
         getItemKey={(item) => item.id}
         columns={columns}
         emptyState="No automations."
+        footer={<div>Showing 1 of 2</div>}
         tableClassName="min-w-[64rem]"
         getDesktopRowProps={(item) => ({ "aria-label": `Desktop ${item.name}` })}
         renderMobileItem={(item) => <div>Mobile {item.name}</div>}
@@ -48,9 +49,11 @@ describe("ResponsiveResourceList", () => {
     expect(within(table).getByRole("row", { name: "Desktop Release check" })).toBeInTheDocument();
 
     const mobileList = screen.getByRole("list", { name: "Automations mobile list" });
+    const footer = screen.getByText("Showing 1 of 2");
     expect(within(mobileList).getByText("Mobile Release check")).toBeInTheDocument();
     expect(within(mobileList).getByRole("listitem")).toBeInTheDocument();
     expect(table.closest('[data-slot="card"]')).toBe(mobileList.closest('[data-slot="card"]'));
+    expect(table.closest('[data-slot="card"]')).toBe(footer.closest('[data-slot="card"]'));
   });
 
   it("uses the shared card treatment for empty resource lists", () => {

--- a/frontend/src/components/responsive-resource-list.tsx
+++ b/frontend/src/components/responsive-resource-list.tsx
@@ -32,6 +32,7 @@ type ResponsiveResourceListProps<TItem> = {
   emptyState: ReactNode;
   ariaLabel: string;
   mobileAriaLabel?: string;
+  footer?: ReactNode;
   className?: string;
   tableClassName?: string;
   getDesktopRowProps?: (item: TItem) => ResponsiveResourceListRowProps;
@@ -45,6 +46,7 @@ export function ResponsiveResourceList<TItem>({
   emptyState,
   ariaLabel,
   mobileAriaLabel,
+  footer,
   className,
   tableClassName,
   getDesktopRowProps,
@@ -101,6 +103,7 @@ export function ResponsiveResourceList<TItem>({
             </div>
           ))}
         </div>
+        {footer}
       </CardContent>
     </Card>
   );

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -273,6 +273,7 @@ export const api = {
       risk?: "acceptable" | "needs_review";
       search?: string;
       limit?: number;
+      cursor?: string;
     }) => {
       const searchParams = new URLSearchParams();
       if (params?.repository_id) searchParams.set('repository_id', params.repository_id);
@@ -282,6 +283,7 @@ export const api = {
       if (params?.risk) searchParams.set('risk', params.risk);
       if (params?.search) searchParams.set('search', params.search);
       if (params?.limit) searchParams.set('limit', String(params.limit));
+      if (params?.cursor) searchParams.set('cursor', params.cursor);
       const qs = searchParams.toString();
       return get<import('./types').ListResponse<import('./types').CodeReviewListItem>>(`/api/v1/code-reviews${qs ? `?${qs}` : ''}`);
     },

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -2611,6 +2611,7 @@ export interface ListResponse<T> {
   data: T[];
   meta: {
     next_cursor?: string;
+    total_count?: number;
     default_repository_id?: string;
   };
 }

--- a/internal/api/handlers/code_reviews.go
+++ b/internal/api/handlers/code_reviews.go
@@ -2,6 +2,8 @@ package handlers
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"net/http"
@@ -36,6 +38,76 @@ type codeReviewMembershipStore interface {
 
 type codeReviewRetryService interface {
 	RetryReview(ctx context.Context, input codereviewsvc.RetryReviewInput) (codereviewsvc.RetryReviewResult, error)
+}
+
+type codeReviewListCursor struct {
+	ID        uuid.UUID `json:"id"`
+	CreatedAt time.Time `json:"created_at"`
+	Scope     [32]byte  `json:"scope"`
+}
+
+type codeReviewCursorScope struct {
+	OrgID         uuid.UUID                       `json:"org_id"`
+	RepositoryID  *uuid.UUID                      `json:"repository_id,omitempty"`
+	Decision      *models.CodeReviewDecision      `json:"decision,omitempty"`
+	Outcome       *models.CodeReviewListOutcome   `json:"outcome,omitempty"`
+	Status        *models.CodeReviewSessionStatus `json:"status,omitempty"`
+	Acceptable    *bool                           `json:"acceptable,omitempty"`
+	Search        string                          `json:"search,omitempty"`
+	CreatedAfter  *time.Time                      `json:"created_after,omitempty"`
+	CreatedBefore *time.Time                      `json:"created_before,omitempty"`
+}
+
+func codeReviewListCursorScopeHash(orgID uuid.UUID, filters db.CodeReviewListFilters) ([32]byte, error) {
+	encoded, err := json.Marshal(codeReviewCursorScope{
+		OrgID:         orgID,
+		RepositoryID:  filters.RepositoryID,
+		Decision:      filters.Decision,
+		Outcome:       filters.Outcome,
+		Status:        filters.Status,
+		Acceptable:    filters.Acceptable,
+		Search:        strings.TrimSpace(filters.Search),
+		CreatedAfter:  filters.CreatedAfter,
+		CreatedBefore: filters.CreatedBefore,
+	})
+	if err != nil {
+		return [32]byte{}, err
+	}
+	return sha256.Sum256(encoded), nil
+}
+
+func encodeCodeReviewListCursor(orgID uuid.UUID, filters db.CodeReviewListFilters, id uuid.UUID, createdAt time.Time) (string, error) {
+	scope, err := codeReviewListCursorScopeHash(orgID, filters)
+	if err != nil {
+		return "", err
+	}
+	encoded, err := json.Marshal(codeReviewListCursor{ID: id, CreatedAt: createdAt, Scope: scope})
+	if err != nil {
+		return "", err
+	}
+	return base64.RawURLEncoding.EncodeToString(encoded), nil
+}
+
+func decodeCodeReviewListCursor(raw string, orgID uuid.UUID, filters db.CodeReviewListFilters) (uuid.UUID, time.Time, error) {
+	encoded, err := base64.RawURLEncoding.DecodeString(raw)
+	if err != nil {
+		return uuid.Nil, time.Time{}, err
+	}
+	var cursor codeReviewListCursor
+	if err := json.Unmarshal(encoded, &cursor); err != nil {
+		return uuid.Nil, time.Time{}, err
+	}
+	if cursor.ID == uuid.Nil || cursor.CreatedAt.IsZero() {
+		return uuid.Nil, time.Time{}, errors.New("cursor anchor is incomplete")
+	}
+	scope, err := codeReviewListCursorScopeHash(orgID, filters)
+	if err != nil {
+		return uuid.Nil, time.Time{}, err
+	}
+	if cursor.Scope != scope {
+		return uuid.Nil, time.Time{}, errors.New("cursor does not match the active filters")
+	}
+	return cursor.ID, cursor.CreatedAt, nil
 }
 
 type CodeReviewHandler struct {
@@ -192,6 +264,7 @@ func (h *CodeReviewHandler) List(w http.ResponseWriter, r *http.Request) {
 		Search:       strings.TrimSpace(r.URL.Query().Get("search")),
 		Limit:        limit,
 	}
+	rawCursor := strings.TrimSpace(r.URL.Query().Get("cursor"))
 	if raw := strings.TrimSpace(r.URL.Query().Get("decision")); raw != "" {
 		decision := models.CodeReviewDecision(raw)
 		if err := decision.Validate(); err != nil {
@@ -229,12 +302,37 @@ func (h *CodeReviewHandler) List(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 	}
-	reviews, err := h.store.ListReviews(r.Context(), orgID, filters)
+	if rawCursor != "" {
+		cursorID, cursorCreatedAt, err := decodeCodeReviewListCursor(rawCursor, orgID, filters)
+		if err != nil {
+			writeError(w, r, http.StatusBadRequest, "INVALID_CURSOR", "cursor is invalid or does not match the active filters")
+			return
+		}
+		filters.Cursor = &cursorID
+		filters.CursorCreatedAt = &cursorCreatedAt
+	}
+	page, err := h.store.ListReviewsPage(r.Context(), orgID, filters)
 	if err != nil {
 		writeError(w, r, http.StatusInternalServerError, "CODE_REVIEWS_LOAD_FAILED", "failed to load code reviews", err)
 		return
 	}
-	writeJSON(w, http.StatusOK, models.ListResponse[models.CodeReviewListItem]{Data: reviews})
+	nextCursor := ""
+	if page.NextCursor != "" {
+		cursorID, err := uuid.Parse(page.NextCursor)
+		if err != nil {
+			writeError(w, r, http.StatusInternalServerError, "CODE_REVIEWS_LOAD_FAILED", "failed to encode code review cursor", err)
+			return
+		}
+		nextCursor, err = encodeCodeReviewListCursor(orgID, filters, cursorID, page.NextCursorCreatedAt)
+		if err != nil {
+			writeError(w, r, http.StatusInternalServerError, "CODE_REVIEWS_LOAD_FAILED", "failed to encode code review cursor", err)
+			return
+		}
+	}
+	writeJSON(w, http.StatusOK, models.ListResponse[models.CodeReviewListItem]{
+		Data: page.Items,
+		Meta: models.PaginationMeta{NextCursor: nextCursor, TotalCount: &page.TotalCount},
+	})
 }
 
 func (h *CodeReviewHandler) Templates(w http.ResponseWriter, r *http.Request) {

--- a/internal/api/handlers/code_reviews_test.go
+++ b/internal/api/handlers/code_reviews_test.go
@@ -261,6 +261,98 @@ func TestCodeReviewHandler_ListRejectsInvalidOutcome(t *testing.T) {
 	require.Contains(t, rr.Body.String(), "INVALID_OUTCOME", "the response should identify the invalid outcome filter")
 }
 
+func TestCodeReviewHandler_ListRejectsInvalidCursor(t *testing.T) {
+	t.Parallel()
+
+	handler := NewCodeReviewHandler(nil, nil)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/code-reviews?cursor=not-a-uuid", nil)
+	req = req.WithContext(middleware.WithOrgID(req.Context(), uuid.New()))
+	rr := httptest.NewRecorder()
+
+	handler.List(rr, req)
+
+	require.Equal(t, http.StatusBadRequest, rr.Code, "a malformed cursor should return a bad request")
+	require.Contains(t, rr.Body.String(), "INVALID_CURSOR", "the response should identify the invalid cursor")
+}
+
+func TestCodeReviewHandler_ListReturnsPaginationMetadata(t *testing.T) {
+	t.Parallel()
+
+	orgID := uuid.New()
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "pgxmock should initialize")
+	defer mock.Close()
+	mock.ExpectQuery(`SELECT COUNT\(\*\)`).
+		WithArgs(pgxmock.AnyArg()).
+		WillReturnRows(pgxmock.NewRows([]string{"count"}).AddRow(int64(0)))
+	mock.ExpectQuery(`ORDER BY m\.created_at DESC, m\.id DESC`).
+		WithArgs(pgxmock.AnyArg(), 51).
+		WillReturnRows(pgxmock.NewRows([]string{
+			"id", "org_id", "session_id", "repository_id", "pull_request_id", "policy_id",
+			"base_sha", "head_sha", "from_fork", "trigger_source", "status", "phase", "status_code",
+			"status_message", "retry_at", "last_error_at", "retryable_failure", "decision", "acceptable", "stale",
+			"superseded_by_session_id", "review_output_key", "prompt_artifact_key", "github_review_id",
+			"github_review_url", "final_review_body", "failure_reason", "completed_at", "created_at",
+			"retry_eligible", "session_title", "repository_name", "github_repo", "github_pr_number",
+			"github_pr_url", "pull_request_title", "pull_request_author",
+		}))
+	handler := NewCodeReviewHandler(db.NewCodeReviewStore(mock), nil)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/code-reviews", nil)
+	req = req.WithContext(middleware.WithOrgID(req.Context(), orgID))
+	rr := httptest.NewRecorder()
+
+	handler.List(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code, "an empty code review page should load successfully")
+	require.JSONEq(t, `{"data":[],"meta":{"total_count":0}}`, rr.Body.String(), "the response should include an exact zero total")
+	require.NoError(t, mock.ExpectationsWereMet(), "the handler should execute count and page queries")
+}
+
+func TestCodeReviewHandler_ListRejectsCursorOutsideOrganization(t *testing.T) {
+	t.Parallel()
+
+	orgID := uuid.New()
+	cursor, err := encodeCodeReviewListCursor(
+		uuid.New(),
+		db.CodeReviewListFilters{Limit: 50},
+		uuid.New(),
+		time.Date(2026, 7, 28, 12, 0, 0, 0, time.UTC),
+	)
+	require.NoError(t, err, "a cursor for another organization should encode")
+	handler := NewCodeReviewHandler(nil, nil)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/code-reviews?cursor="+cursor, nil)
+	req = req.WithContext(middleware.WithOrgID(req.Context(), orgID))
+	rr := httptest.NewRecorder()
+
+	handler.List(rr, req)
+
+	require.Equal(t, http.StatusBadRequest, rr.Code, "a cursor outside the organization should return a bad request")
+	require.Contains(t, rr.Body.String(), "INVALID_CURSOR", "the response should identify an inaccessible cursor")
+}
+
+func TestCodeReviewListCursorRejectsChangedFilterButAllowsMutableRowChanges(t *testing.T) {
+	t.Parallel()
+
+	orgID := uuid.New()
+	running := models.CodeReviewSessionStatusRunning
+	filters := db.CodeReviewListFilters{Status: &running, Search: "invoice", Limit: 50}
+	id := uuid.New()
+	createdAt := time.Date(2026, 7, 28, 12, 0, 0, 0, time.UTC)
+	cursor, err := encodeCodeReviewListCursor(orgID, filters, id, createdAt)
+	require.NoError(t, err, "the cursor should encode immutable ordering values and filter scope")
+
+	decodedID, decodedCreatedAt, err := decodeCodeReviewListCursor(cursor, orgID, filters)
+
+	require.NoError(t, err, "the same request filters should decode without consulting mutable row state")
+	require.Equal(t, id, decodedID, "the cursor should preserve the review ID anchor")
+	require.Equal(t, createdAt, decodedCreatedAt, "the cursor should preserve the creation-time anchor")
+
+	changedFilters := filters
+	changedFilters.Search = "payments"
+	_, _, err = decodeCodeReviewListCursor(cursor, orgID, changedFilters)
+	require.Error(t, err, "a cursor reused with a different filter collection should be rejected")
+}
+
 func TestCodeReviewHandler_Retry(t *testing.T) {
 	t.Parallel()
 

--- a/internal/db/code_reviews.go
+++ b/internal/db/code_reviews.go
@@ -1081,6 +1081,12 @@ const codeReviewListItemSelect = `
 			LEFT JOIN pull_request_health_current current_health
 			       ON current_health.pull_request_id = m.pull_request_id AND current_health.org_id = m.org_id`
 
+const codeReviewListCountFrom = `
+		FROM code_review_session_metadata m
+		JOIN sessions s ON s.id = m.session_id AND s.org_id = m.org_id
+		JOIN repositories r ON r.id = m.repository_id AND r.org_id = m.org_id
+		JOIN pull_requests pr ON pr.id = m.pull_request_id AND pr.org_id = m.org_id`
+
 // GetListItemBySessionID returns one review with the same joined pull request
 // and repository context as ListReviews rows. Used by the internal (sandbox)
 // code review history API where agents need PR context alongside the review.
@@ -1115,7 +1121,98 @@ type CodeReviewListFilters struct {
 	// Cursor is the metadata row ID of the last item from the previous page.
 	// Rows strictly after it in the (created_at DESC, id DESC) order are
 	// returned, matching the session-history keyset pagination contract.
-	Cursor *uuid.UUID
+	Cursor          *uuid.UUID
+	CursorCreatedAt *time.Time
+}
+
+type CodeReviewPage struct {
+	Items               []models.CodeReviewListItem
+	NextCursor          string
+	NextCursorCreatedAt time.Time
+	TotalCount          int64
+}
+
+func codeReviewListWhere(orgID uuid.UUID, filters CodeReviewListFilters, includeCursor bool) (string, pgx.NamedArgs, error) {
+	args := pgx.NamedArgs{"org_id": orgID}
+	query := ` WHERE m.org_id = @org_id`
+	if filters.RepositoryID != nil {
+		query += ` AND m.repository_id = @repository_id`
+		args["repository_id"] = *filters.RepositoryID
+	}
+	if filters.Decision != nil {
+		if err := filters.Decision.Validate(); err != nil {
+			return "", nil, err
+		}
+		query += ` AND m.decision = @decision`
+		args["decision"] = *filters.Decision
+	}
+	if filters.Outcome != nil {
+		if err := filters.Outcome.Validate(); err != nil {
+			return "", nil, err
+		}
+		switch *filters.Outcome {
+		case models.CodeReviewListOutcomeAutomaticallyApproved:
+			query += ` AND m.status = 'completed' AND m.decision = 'approved' AND m.github_review_id IS NOT NULL`
+		case models.CodeReviewListOutcomeCompletedNotApproved:
+			query += ` AND m.status = 'completed' AND (m.decision IS DISTINCT FROM 'approved' OR m.github_review_id IS NULL)`
+		}
+	}
+	if filters.Status != nil {
+		if err := filters.Status.Validate(); err != nil {
+			return "", nil, err
+		}
+		query += ` AND m.status = @status`
+		args["status"] = *filters.Status
+	}
+	if filters.Acceptable != nil {
+		query += ` AND m.acceptable = @acceptable`
+		args["acceptable"] = *filters.Acceptable
+	}
+	if filters.CreatedAfter != nil {
+		query += ` AND m.created_at >= @created_after`
+		args["created_after"] = *filters.CreatedAfter
+	}
+	if filters.CreatedBefore != nil {
+		query += ` AND m.created_at <= @created_before`
+		args["created_before"] = *filters.CreatedBefore
+	}
+	if includeCursor && filters.Cursor != nil {
+		args["cursor"] = *filters.Cursor
+		if filters.CursorCreatedAt != nil {
+			query += ` AND (m.created_at, m.id) < (@cursor_created_at, @cursor)`
+			args["cursor_created_at"] = *filters.CursorCreatedAt
+		} else {
+			// Internal callers predating the opaque HTTP cursor still pass only
+			// the row ID. Keep that contract while public pagination uses the
+			// immutable timestamp embedded in its cursor.
+			query += ` AND (m.created_at, m.id) < (
+				SELECT created_at, id FROM code_review_session_metadata
+				WHERE id = @cursor AND org_id = @org_id
+			)`
+		}
+	}
+	if search := strings.TrimSpace(filters.Search); search != "" {
+		query += ` AND (pr.title ILIKE @search OR pr.github_repo ILIKE @search OR pr.github_pr_number::text = @search_exact OR COALESCE(s.title, '') ILIKE @search)`
+		args["search"] = "%" + search + "%"
+		args["search_exact"] = strings.TrimPrefix(search, "#")
+	}
+	return query, args, nil
+}
+
+func (s *CodeReviewStore) listReviews(ctx context.Context, orgID uuid.UUID, filters CodeReviewListFilters, limit int) ([]models.CodeReviewListItem, error) {
+	where, args, err := codeReviewListWhere(orgID, filters, true)
+	if err != nil {
+		return nil, err
+	}
+	args["limit"] = limit
+	query := codeReviewListItemSelect + where + `
+		ORDER BY m.created_at DESC, m.id DESC
+		LIMIT @limit`
+	rows, err := s.db.Query(ctx, query, args)
+	if err != nil {
+		return nil, fmt.Errorf("query code review list: %w", err)
+	}
+	return pgx.CollectRows(rows, pgx.RowToStructByName[models.CodeReviewListItem])
 }
 
 func (s *CodeReviewStore) ListReviews(ctx context.Context, orgID uuid.UUID, filters CodeReviewListFilters) ([]models.CodeReviewListItem, error) {
@@ -1123,87 +1220,33 @@ func (s *CodeReviewStore) ListReviews(ctx context.Context, orgID uuid.UUID, filt
 	if limit <= 0 || limit > 100 {
 		limit = 50
 	}
-	args := pgx.NamedArgs{
-		"org_id": orgID,
-		"limit":  limit,
+	return s.listReviews(ctx, orgID, filters, limit)
+}
+
+func (s *CodeReviewStore) ListReviewsPage(ctx context.Context, orgID uuid.UUID, filters CodeReviewListFilters) (CodeReviewPage, error) {
+	limit := filters.Limit
+	if limit <= 0 || limit > 100 {
+		limit = 50
 	}
-	query := codeReviewListItemSelect + `
-			WHERE m.org_id = @org_id`
-	if filters.RepositoryID != nil {
-		query += `
-			  AND m.repository_id = @repository_id`
-		args["repository_id"] = *filters.RepositoryID
-	}
-	if filters.Decision != nil {
-		if err := filters.Decision.Validate(); err != nil {
-			return nil, err
-		}
-		query += `
-			  AND m.decision = @decision`
-		args["decision"] = *filters.Decision
-	}
-	if filters.Outcome != nil {
-		if err := filters.Outcome.Validate(); err != nil {
-			return nil, err
-		}
-		switch *filters.Outcome {
-		case models.CodeReviewListOutcomeAutomaticallyApproved:
-			query += `
-			  AND m.status = 'completed'
-			  AND m.decision = 'approved'
-			  AND m.github_review_id IS NOT NULL`
-		case models.CodeReviewListOutcomeCompletedNotApproved:
-			query += `
-			  AND m.status = 'completed'
-			  AND (m.decision IS DISTINCT FROM 'approved'
-			       OR m.github_review_id IS NULL)`
-		}
-	}
-	if filters.Status != nil {
-		if err := filters.Status.Validate(); err != nil {
-			return nil, err
-		}
-		query += `
-			  AND m.status = @status`
-		args["status"] = *filters.Status
-	}
-	if filters.Acceptable != nil {
-		query += `
-			  AND m.acceptable = @acceptable`
-		args["acceptable"] = *filters.Acceptable
-	}
-	if filters.CreatedAfter != nil {
-		query += `
-			  AND m.created_at >= @created_after`
-		args["created_after"] = *filters.CreatedAfter
-	}
-	if filters.CreatedBefore != nil {
-		query += `
-			  AND m.created_at <= @created_before`
-		args["created_before"] = *filters.CreatedBefore
-	}
-	if filters.Cursor != nil {
-		query += `
-			  AND (m.created_at, m.id) < (
-			    SELECT created_at, id FROM code_review_session_metadata
-			    WHERE id = @cursor AND org_id = @org_id
-			  )`
-		args["cursor"] = *filters.Cursor
-	}
-	if search := strings.TrimSpace(filters.Search); search != "" {
-		query += `
-			  AND (pr.title ILIKE @search OR pr.github_repo ILIKE @search OR pr.github_pr_number::text = @search_exact OR COALESCE(s.title, '') ILIKE @search)`
-		args["search"] = "%" + search + "%"
-		args["search_exact"] = strings.TrimPrefix(search, "#")
-	}
-	query += `
-			ORDER BY m.created_at DESC, m.id DESC
-			LIMIT @limit`
-	rows, err := s.db.Query(ctx, query, args)
+	where, args, err := codeReviewListWhere(orgID, filters, false)
 	if err != nil {
-		return nil, fmt.Errorf("query code review list: %w", err)
+		return CodeReviewPage{}, err
 	}
-	return pgx.CollectRows(rows, pgx.RowToStructByName[models.CodeReviewListItem])
+	var total int64
+	if err := s.db.QueryRow(ctx, `SELECT COUNT(*)`+codeReviewListCountFrom+where, args).Scan(&total); err != nil {
+		return CodeReviewPage{}, fmt.Errorf("count code reviews: %w", err)
+	}
+	items, err := s.listReviews(ctx, orgID, filters, limit+1)
+	if err != nil {
+		return CodeReviewPage{}, err
+	}
+	page := CodeReviewPage{Items: items, TotalCount: total}
+	if len(items) > limit {
+		page.Items = items[:limit]
+		page.NextCursor = page.Items[len(page.Items)-1].ID.String()
+		page.NextCursorCreatedAt = page.Items[len(page.Items)-1].CreatedAt
+	}
+	return page, nil
 }
 
 func (s *CodeReviewStore) CreateAgentResult(ctx context.Context, result *models.CodeReviewAgentResult) error {

--- a/internal/db/code_reviews_test.go
+++ b/internal/db/code_reviews_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"regexp"
 	"testing"
 	"time"
@@ -1082,6 +1083,177 @@ func TestCodeReviewStore_ListReviewsAppliesCursorAndTimeFilters(t *testing.T) {
 	require.NoError(t, err, "ListReviews should accept cursor and time filters")
 	require.Empty(t, reviews, "ListReviews should return the mocked empty result")
 	require.NoError(t, mock.ExpectationsWereMet(), "cursor pagination should add the keyset comparison")
+}
+
+func TestCodeReviewStore_ListReviewsPageReturnsExactCountForEmptyPage(t *testing.T) {
+	t.Parallel()
+
+	orgID := uuid.New()
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "pgxmock should initialize")
+	defer mock.Close()
+
+	mock.ExpectQuery(`SELECT COUNT\(\*\).*WHERE m\.org_id = @org_id`).
+		WithArgs(pgxmock.AnyArg()).
+		WillReturnRows(pgxmock.NewRows([]string{"count"}).AddRow(int64(0)))
+	mock.ExpectQuery(`ORDER BY m\.created_at DESC, m\.id DESC`).
+		WithArgs(pgxmock.AnyArg(), 51).
+		WillReturnRows(pgxmock.NewRows([]string{
+			"id", "org_id", "session_id", "repository_id", "pull_request_id", "policy_id",
+			"base_sha", "head_sha", "from_fork", "trigger_source", "status", "phase", "status_code",
+			"status_message", "retry_at", "last_error_at", "retryable_failure", "decision", "acceptable", "stale",
+			"superseded_by_session_id", "review_output_key", "prompt_artifact_key", "github_review_id",
+			"github_review_url", "final_review_body", "failure_reason", "completed_at", "created_at",
+			"retry_eligible", "session_title", "repository_name", "github_repo", "github_pr_number",
+			"github_pr_url", "pull_request_title", "pull_request_author",
+		}))
+
+	page, err := NewCodeReviewStore(mock).ListReviewsPage(context.Background(), orgID, CodeReviewListFilters{})
+
+	require.NoError(t, err, "ListReviewsPage should return an empty first page")
+	require.Equal(t, int64(0), page.TotalCount, "ListReviewsPage should return the exact zero count")
+	require.Equal(t, []models.CodeReviewListItem{}, page.Items, "ListReviewsPage should normalize an empty result")
+	require.Empty(t, page.NextCursor, "an empty page should not return a next cursor")
+	require.NoError(t, mock.ExpectationsWereMet(), "count and page queries should both be executed")
+}
+
+func TestCodeReviewStore_ListReviewsPageUsesImmutableCursorAnchorWithMutableFilters(t *testing.T) {
+	t.Parallel()
+
+	orgID, cursor := uuid.New(), uuid.New()
+	cursorCreatedAt := time.Date(2026, 7, 28, 12, 0, 0, 0, time.UTC)
+	status := models.CodeReviewSessionStatusRunning
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "pgxmock should initialize")
+	defer mock.Close()
+
+	mock.ExpectQuery(`SELECT COUNT\(\*\).*m\.status = @status`).
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(pgxmock.NewRows([]string{"count"}).AddRow(int64(0)))
+	mock.ExpectQuery(`\(m\.created_at, m\.id\) < \(@cursor_created_at, @cursor\)`).
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), 51).
+		WillReturnRows(pgxmock.NewRows([]string{
+			"id", "org_id", "session_id", "repository_id", "pull_request_id", "policy_id",
+			"base_sha", "head_sha", "from_fork", "trigger_source", "status", "phase", "status_code",
+			"status_message", "retry_at", "last_error_at", "retryable_failure", "decision", "acceptable", "stale",
+			"superseded_by_session_id", "review_output_key", "prompt_artifact_key", "github_review_id",
+			"github_review_url", "final_review_body", "failure_reason", "completed_at", "created_at",
+			"retry_eligible", "session_title", "repository_name", "github_repo", "github_pr_number",
+			"github_pr_url", "pull_request_title", "pull_request_author",
+		}))
+
+	page, err := NewCodeReviewStore(mock).ListReviewsPage(context.Background(), orgID, CodeReviewListFilters{
+		Status:          &status,
+		Cursor:          &cursor,
+		CursorCreatedAt: &cursorCreatedAt,
+	})
+
+	require.NoError(t, err, "an immutable cursor anchor should not depend on the cursor row still matching mutable filters")
+	require.Empty(t, page.Items, "the mocked continuation page should be empty")
+	require.NoError(t, mock.ExpectationsWereMet(), "the page query should compare directly with the immutable cursor anchor")
+}
+
+func TestCodeReviewStore_ListReviewsPageAppliesOutcomeToCountAndRows(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		outcome models.CodeReviewListOutcome
+		pattern string
+	}{
+		{
+			name:    "automatically approved",
+			outcome: models.CodeReviewListOutcomeAutomaticallyApproved,
+			pattern: `m\.status = 'completed' AND m\.decision = 'approved' AND m\.github_review_id IS NOT NULL`,
+		},
+		{
+			name:    "completed not approved",
+			outcome: models.CodeReviewListOutcomeCompletedNotApproved,
+			pattern: `m\.status = 'completed' AND \(m\.decision IS DISTINCT FROM 'approved' OR m\.github_review_id IS NULL\)`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			orgID := uuid.New()
+			mock, err := pgxmock.NewPool()
+			require.NoError(t, err, "pgxmock should initialize for each outcome")
+			defer mock.Close()
+			mock.ExpectQuery(`(?s)SELECT COUNT\(\*\).*` + tt.pattern).
+				WithArgs(pgxmock.AnyArg()).
+				WillReturnRows(pgxmock.NewRows([]string{"count"}).AddRow(int64(0)))
+			mock.ExpectQuery(tt.pattern).
+				WithArgs(pgxmock.AnyArg(), 51).
+				WillReturnRows(pgxmock.NewRows([]string{
+					"id", "org_id", "session_id", "repository_id", "pull_request_id", "policy_id",
+					"base_sha", "head_sha", "from_fork", "trigger_source", "status", "phase", "status_code",
+					"status_message", "retry_at", "last_error_at", "retryable_failure", "decision", "acceptable", "stale",
+					"superseded_by_session_id", "review_output_key", "prompt_artifact_key", "github_review_id",
+					"github_review_url", "final_review_body", "failure_reason", "completed_at", "created_at",
+					"retry_eligible", "session_title", "repository_name", "github_repo", "github_pr_number",
+					"github_pr_url", "pull_request_title", "pull_request_author",
+				}))
+
+			page, err := NewCodeReviewStore(mock).ListReviewsPage(context.Background(), orgID, CodeReviewListFilters{
+				Outcome: &tt.outcome,
+			})
+
+			require.NoError(t, err, "ListReviewsPage should accept the selected outcome")
+			require.Equal(t, int64(0), page.TotalCount, "the filtered count should be returned")
+			require.NoError(t, mock.ExpectationsWereMet(), "count and rows should use the same outcome predicate")
+		})
+	}
+}
+
+func TestCodeReviewStore_ListReviewsPageUsesExtraRowForNextCursor(t *testing.T) {
+	t.Parallel()
+
+	orgID, repoID, policyID, prID := uuid.New(), uuid.New(), uuid.New(), uuid.New()
+	firstID, secondID := uuid.New(), uuid.New()
+	firstSessionID, secondSessionID := uuid.New(), uuid.New()
+	now := time.Date(2026, 7, 28, 12, 0, 0, 0, time.UTC)
+	repositoryName := "acme/repo"
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "pgxmock should initialize")
+	defer mock.Close()
+	mock.ExpectQuery(`SELECT COUNT\(\*\)`).
+		WithArgs(pgxmock.AnyArg()).
+		WillReturnRows(pgxmock.NewRows([]string{"count"}).AddRow(int64(2)))
+	rows := pgxmock.NewRows([]string{
+		"id", "org_id", "session_id", "repository_id", "pull_request_id", "policy_id",
+		"base_sha", "head_sha", "from_fork", "trigger_source", "status", "phase", "status_code",
+		"status_message", "retry_at", "last_error_at", "retryable_failure", "decision", "acceptable", "stale",
+		"superseded_by_session_id", "review_output_key", "prompt_artifact_key", "github_review_id",
+		"github_review_url", "final_review_body", "failure_reason", "completed_at", "created_at",
+		"retry_eligible", "session_title", "repository_name", "github_repo", "github_pr_number",
+		"github_pr_url", "pull_request_title", "pull_request_author",
+	})
+	addRow := func(id, sessionID uuid.UUID, createdAt time.Time, number int) {
+		rows.AddRow(
+			id, orgID, sessionID, repoID, prID, policyID,
+			"base", "head", false, models.CodeReviewTriggerSourceAppReviewer,
+			models.CodeReviewSessionStatusCompleted, nil, nil, nil, nil, nil, false,
+			nil, nil, false, nil, "output", nil, nil, nil, nil, nil, &createdAt, createdAt,
+			false, nil, &repositoryName, "acme/repo", number,
+			fmt.Sprintf("https://github.com/acme/repo/pull/%d", number), "Review", "dev",
+		)
+	}
+	addRow(firstID, firstSessionID, now, 2)
+	addRow(secondID, secondSessionID, now.Add(-time.Minute), 1)
+	mock.ExpectQuery(`ORDER BY m\.created_at DESC, m\.id DESC`).
+		WithArgs(pgxmock.AnyArg(), 2).
+		WillReturnRows(rows)
+
+	page, err := NewCodeReviewStore(mock).ListReviewsPage(context.Background(), orgID, CodeReviewListFilters{Limit: 1})
+
+	require.NoError(t, err, "ListReviewsPage should load one requested row plus one sentinel row")
+	require.Equal(t, int64(2), page.TotalCount, "the page should retain the exact filtered total")
+	require.Len(t, page.Items, 1, "the sentinel row should be removed from the response")
+	require.Equal(t, firstID, page.Items[0].ID, "the newest requested row should be returned")
+	require.Equal(t, firstID.String(), page.NextCursor, "the next cursor should identify the final returned row")
+	require.NoError(t, mock.ExpectationsWereMet(), "the page query should request limit plus one rows")
 }
 
 func TestCodeReviewStore_GetListItemBySessionIDScopesByOrgAndSession(t *testing.T) {

--- a/internal/models/responses.go
+++ b/internal/models/responses.go
@@ -36,6 +36,7 @@ type ErrorDetail struct {
 // PaginationMeta contains cursor-based pagination info.
 type PaginationMeta struct {
 	NextCursor          string `json:"next_cursor,omitempty"`
+	TotalCount          *int64 `json:"total_count,omitempty"`
 	DefaultRepositoryID string `json:"default_repository_id,omitempty"`
 	Counts              any    `json:"counts,omitempty"`
 	Pool                any    `json:"pool,omitempty"`

--- a/migrations/000262_code_review_activity_pagination_index.down.sql
+++ b/migrations/000262_code_review_activity_pagination_index.down.sql
@@ -1,0 +1,1 @@
+DROP INDEX IF EXISTS idx_code_review_metadata_org_created;

--- a/migrations/000262_code_review_activity_pagination_index.up.sql
+++ b/migrations/000262_code_review_activity_pagination_index.up.sql
@@ -1,0 +1,5 @@
+-- Supports the organization-wide newest-first activity feed and its stable
+-- (created_at, id) keyset cursor. The existing index leads with repository_id
+-- and cannot serve the unfiltered organization view in this order.
+CREATE INDEX idx_code_review_metadata_org_created
+    ON code_review_session_metadata (org_id, created_at DESC, id DESC);


### PR DESCRIPTION
## Summary

The Code Reviews dashboard could lose its history snapshot during pagination because cursor data was affected by mutable fields and by reconnect/broad invalidation behavior—leading users to see inconsistent or replaced “older page” results. This change makes pagination cursors immutable and filter-scoped, pauses newest-page replacement after older pages load, and adds end-to-end regression coverage (backend + frontend) to prevent cursor corruption.  

## Changes

- Updated cursor structure to include immutable `(created_at, id)` anchors and to reject cursor reuse across different organization/filter collections (while scoping to active org + filters).
- Prevented first-page queries from overwriting the in-progress paginated history while older pages are appended, avoiding reconnect/broad invalidation from corrupting the list snapshot.
- Added backend cursor regression tests plus a frontend broad-invalidation regression test to ensure continuation works across filter-preserving navigation and SSE refreshes.

## Validation

- `go test ./...`
- `go vet ./...`
- Frontend: `pnpm test` (45 code-review page tests)
- Frontend: `pnpm lint` (ESLint) and TypeScript typecheck
- Schema/tenancy linting
- `git diff --check`

Note: browser-level verification was unavailable because the preview relaunch timed out at the preview service.

[143.dev](https://143.dev) | [session 702656e9](https://143.dev/sessions/702656e9-a0e9-4ea3-b874-ad17870d42a1)

<!-- 143 readiness -->
**143 readiness:** not available for this revision.

<!-- 143-publication session=702656e9-a0e9-4ea3-b874-ad17870d42a1 changeset=e6fe03f4-e210-4e0e-830e-c9841d7d9bca -->

Preview: https://143.dev/previews/github/assembledhq/143/pull/1966?launch=1