### PR TITLE
Make automation text input span full container width to prevent long titles from being cut off

### DIFF
--- a/frontend/src/app/(dashboard)/automations/[id]/page.tsx
+++ b/frontend/src/app/(dashboard)/automations/[id]/page.tsx
@@ -1152,7 +1152,7 @@ export default function AutomationDetailPage() {
         </Sheet>
         <PageHeader
           title={
-            <span className="inline-flex min-w-0 items-center gap-2">
+            <span className="flex w-full min-w-0 items-center gap-2">
               {canManage ? (
                 <AutomationEmojiPicker
                   value={automation.icon_value || "⚙️"}

--- a/frontend/src/components/page-header.test.tsx
+++ b/frontend/src/components/page-header.test.tsx
@@ -15,7 +15,10 @@ describe("PageHeader", () => {
 
     const actionButton = screen.getByRole("button", { name: "Invite" });
     const actionWrapper = actionButton.parentElement;
+    const title = screen.getByRole("heading", { name: "Settings" });
 
+    expect(title).toHaveClass("w-full");
+    expect(title.parentElement).toHaveClass("min-w-0", "flex-1");
     expect(actionWrapper).toHaveClass("w-full");
     expect(actionWrapper).toHaveClass("sm:w-auto");
     expect(actionWrapper).toHaveClass("[&>*]:w-full");

--- a/frontend/src/components/page-header.tsx
+++ b/frontend/src/components/page-header.tsx
@@ -10,8 +10,8 @@ interface PageHeaderProps {
 export function PageHeader({ title, description, subtitle, action }: PageHeaderProps) {
   return (
     <div data-slot="page-header" className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
-      <div>
-        <h1 className="font-display text-2xl leading-[1.25] font-semibold tracking-[-0.035em] text-foreground sm:text-[1.75rem] sm:leading-[2.125rem]">{title}</h1>
+      <div className="min-w-0 flex-1">
+        <h1 className="w-full font-display text-2xl leading-[1.25] font-semibold tracking-[-0.035em] text-foreground sm:text-[1.75rem] sm:leading-[2.125rem]">{title}</h1>
         {description && (
           <p className="mt-1.5 max-w-2xl text-sm leading-5 text-muted-foreground">{description}</p>
         )}


### PR DESCRIPTION
## Summary

Long automation titles could be cut off in the PageHeader area due to shrink-to-content layout behavior. This change updates the PageHeader title container and the automation page’s title wrapper to use full available width, preventing truncation and improving consistent layout across responsive breakpoints.

## Changes

- Updated `PageHeader` to make the title region `flex-1` with `min-w-0`, and set the `<h1>` to `w-full` so long content can wrap/fit properly.
- Changed the automation page header title wrapper from `inline-flex` shrink-to-content to `flex w-full` so it respects the container width.
- Extended `page-header.test.tsx` with assertions verifying the title’s width and flex/min-width constraints.

## Validation

- `git diff --check` passes.
- Note: automated frontend tests could not be run because `vitest`/frontend dependencies were not available (`vitest: not found`) and the preview environment was still starting when verification ended.

[143.dev](https://143.dev) | [session f5113316](https://143.dev/sessions/f5113316-1b7c-47c5-839b-86ba377d5a93)

<!-- 143 readiness -->
**143 readiness:** not available for this revision.

<!-- 143-publication session=f5113316-1b7c-47c5-839b-86ba377d5a93 changeset=f2a39191-90f5-4779-9ac1-02341497422c -->

Preview: https://143.dev/previews/github/assembledhq/143/pull/1969?launch=1