### PR TITLE
Allow editing automation repositories

### DIFF
--- a/frontend/src/app/(dashboard)/automations/[id]/page.test.tsx
+++ b/frontend/src/app/(dashboard)/automations/[id]/page.test.tsx
@@ -1198,6 +1198,126 @@ describe("AutomationDetailPage", () => {
     });
   });
 
+  it("updates the repository and resets the base branch to its default", async () => {
+    const user = userEvent.setup();
+    let updateBody: Record<string, unknown> | null = null;
+
+    server.use(
+      http.get("*/api/v1/automations/auto-1", () =>
+        HttpResponse.json({
+          data: {
+            id: "auto-1",
+            org_id: "org-1",
+            repository_id: "repo-1",
+            name: "Weekly audit",
+            goal: "Check release health",
+            scope: "",
+            interval_value: 1,
+            interval_unit: "weeks",
+            base_branch: "main",
+            enabled: true,
+            timezone: "UTC",
+            last_run_at: null,
+            next_run_at: null,
+            priority: 50,
+            created_at: "2026-01-01T00:00:00Z",
+            updated_at: "2026-01-01T00:00:00Z",
+          },
+        }),
+      ),
+      http.get("*/api/v1/repositories", () =>
+        HttpResponse.json({
+          data: [
+            {
+              id: "repo-1",
+              org_id: "org-1",
+              integration_id: "int-1",
+              github_id: 1,
+              full_name: "acme/repo",
+              default_branch: "main",
+              private: false,
+              clone_url: "https://github.com/acme/repo.git",
+              installation_id: 10,
+              status: "active",
+              settings: {},
+              created_at: "2026-01-01T00:00:00Z",
+              updated_at: "2026-01-01T00:00:00Z",
+            },
+            {
+              id: "repo-2",
+              org_id: "org-1",
+              integration_id: "int-1",
+              github_id: 2,
+              full_name: "acme/worker",
+              default_branch: "trunk",
+              private: false,
+              clone_url: "https://github.com/acme/worker.git",
+              installation_id: 10,
+              status: "active",
+              settings: {},
+              created_at: "2026-01-01T00:00:00Z",
+              updated_at: "2026-01-01T00:00:00Z",
+            },
+          ],
+          meta: {},
+        }),
+      ),
+      http.get("*/api/v1/automations/auto-1/runs*", () =>
+        HttpResponse.json({ data: [], meta: {} }),
+      ),
+      http.get("*/api/v1/automations/auto-1/stats*", () =>
+        HttpResponse.json({
+          data: {
+            since: "2026-01-01T00:00:00Z",
+            until: "2026-01-31T00:00:00Z",
+            buckets: [],
+            totals: {
+              total: 0,
+              completed: 0,
+              completed_noop: 0,
+              failed: 0,
+              skipped: 0,
+              running: 0,
+              pending: 0,
+              success_rate: 0,
+              avg_duration_seconds: 0,
+            },
+          },
+        }),
+      ),
+      http.patch("*/api/v1/automations/auto-1", async ({ request }) => {
+        updateBody = (await request.json()) as Record<string, unknown>;
+        return HttpResponse.json({ data: { id: "auto-1" } });
+      }),
+    );
+
+    renderWithProviders(<AutomationDetailPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Weekly audit")).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole("button", { name: "Edit" }));
+    await user.click(screen.getByRole("combobox", { name: "Repository" }));
+    await user.click(
+      await screen.findByRole("option", { name: "acme/worker" }),
+    );
+    await user.click(screen.getByRole("button", { name: "Advanced settings" }));
+
+    expect(
+      screen.getByRole("button", { name: "Base branch" }),
+    ).toHaveTextContent("trunk");
+
+    await user.click(screen.getByRole("button", { name: "Save changes" }));
+
+    await waitFor(() => {
+      expect(updateBody).toMatchObject({
+        repository_id: "repo-2",
+        base_branch: "trunk",
+      });
+    });
+  });
+
   it("saves the selected personal automation identity scope", async () => {
     const user = userEvent.setup();
     let updateBody: Record<string, unknown> | null = null;

--- a/frontend/src/app/(dashboard)/automations/[id]/page.tsx
+++ b/frontend/src/app/(dashboard)/automations/[id]/page.tsx
@@ -87,6 +87,7 @@ import type {
   AutomationGitHubEventFilters,
   AutomationRun,
   ListResponse,
+  Repository,
 } from "@/lib/types";
 import { cn, formatDateTime, formatTimeAgo } from "@/lib/utils";
 import {
@@ -128,6 +129,9 @@ function SettingsTab({
   canManage: boolean;
 }) {
   const queryClient = useQueryClient();
+  const [repositoryId, setRepositoryId] = useState(
+    automation.repository_id ?? "",
+  );
   const [scope, setScope] = useState(automation.scope ?? "");
   // Form state is seeded from the automation prop on first mount only. The
   // parent polls every 10s and may refetch into a new `automation` object.
@@ -191,6 +195,18 @@ function SettingsTab({
   const [capabilityDraft, setCapabilityDraft] = useState<
     AgentCapabilityGrant[] | null
   >(null);
+
+  const { data: repositoriesResponse } = useQuery<ListResponse<Repository>>({
+    queryKey: queryKeys.repositories.all,
+    queryFn: () => api.repositories.list(),
+  });
+  const repositories = useMemo(
+    () => repositoriesResponse?.data ?? [],
+    [repositoriesResponse?.data],
+  );
+  const selectedRepository = repositories.find(
+    (repository) => repository.id === repositoryId,
+  );
 
   const { data: settingsResponse } = useQuery({
     queryKey: ["settings"],
@@ -278,6 +294,9 @@ function SettingsTab({
   const updateMutation = useMutation({
     mutationFn: () =>
       api.automations.update(automation.id, {
+        ...(repositoryId === (automation.repository_id ?? "")
+          ? {}
+          : { repository_id: repositoryId }),
         scope: scope.trim() || undefined,
         ...(sameScheduleDraft(scheduleDraft, initialScheduleDraftRef.current)
           ? {}
@@ -314,6 +333,37 @@ function SettingsTab({
 
   return (
     <div className="space-y-4 rounded-lg border border-border bg-card p-5">
+      <div className="space-y-1.5">
+        <Label htmlFor="automation-repository">Repository</Label>
+        <Select
+          value={repositoryId}
+          onValueChange={(nextRepositoryId) => {
+            setRepositoryId(nextRepositoryId);
+            const nextRepository = repositories.find(
+              (repository) => repository.id === nextRepositoryId,
+            );
+            if (nextRepository) {
+              setBaseBranch(nextRepository.default_branch);
+            }
+          }}
+          disabled={!canManage || repositories.length === 0}
+        >
+          <SelectTrigger id="automation-repository" aria-label="Repository">
+            <SelectValue placeholder="Select repository" />
+          </SelectTrigger>
+          <SelectContent>
+            {repositories.map((repository) => (
+              <SelectItem key={repository.id} value={repository.id}>
+                {repository.full_name}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+        <p className="text-xs text-muted-foreground">
+          Changing the repository resets the base branch to that
+          repository&apos;s default.
+        </p>
+      </div>
       <div className="space-y-1.5">
         <Label htmlFor="scope">
           Scope{" "}
@@ -443,9 +493,11 @@ function SettingsTab({
           <div className="space-y-1.5">
             <Label>Base branch</Label>
             <BranchPicker
-              repositoryId={automation.repository_id ?? ""}
+              repositoryId={repositoryId}
               value={baseBranch}
-              defaultBranch={automation.base_branch}
+              defaultBranch={
+                selectedRepository?.default_branch ?? automation.base_branch
+              }
               onValueChange={setBaseBranch}
               label="Base branch"
               buttonClassName="w-full justify-between"


### PR DESCRIPTION
## Summary

- add an active-repository selector to the automation edit sheet
- include `repository_id` in the automation PATCH only when the selection changes
- reset the base branch to the selected repository's default and use the new repository for branch lookup
- cover repository retargeting and default-branch behavior with a focused component test

## Why

The automation API already supports changing `repository_id`, but the edit UI did not expose that field. Automations created against the wrong repository therefore ran with repository-scoped credentials for the original repository and could not be corrected in the dashboard.

## User impact

Members and admins can retarget an existing automation without recreating it or using the API. Choosing a new repository also selects a valid default branch for that repository.

## Validation

- `npm test -- --run 'src/app/(dashboard)/automations/[id]/page.test.tsx'` — 28 tests passed
- `npm run typecheck`
- `npm run lint`
- `npm run build`