### PR TITLE
Align time window with Reviews/Policy header on right side

### DIFF
--- a/frontend/src/app/(dashboard)/code-reviews/page.test.tsx
+++ b/frontend/src/app/(dashboard)/code-reviews/page.test.tsx
@@ -397,7 +397,11 @@ describe("CodeReviewsPage", () => {
     expect(within(stats).getByText("16% of completed reviews")).toBeInTheDocument();
     expect(within(stats).getByText("Median turnaround")).toBeInTheDocument();
     expect(within(stats).getByText("8m")).toBeInTheDocument();
-    expect(screen.getByRole("combobox", { name: "Time window" })).toHaveTextContent("Last 30 days");
+    const timeWindow = screen.getByRole("combobox", { name: "Time window" });
+    expect(timeWindow).toHaveTextContent("Last 30 days");
+    const filters = timeWindow.closest("#code-review-filters");
+    expect(filters).toContainElement(screen.getByRole("combobox", { name: "Repository" }));
+    expect(filters?.lastElementChild).toContainElement(timeWindow);
     expect(await screen.findAllByText("#428 Fix invoice rounding")).toHaveLength(2);
     expect(screen.getAllByText("Acceptable")).toHaveLength(2);
     expect(screen.getAllByText("Approved")).toHaveLength(2);

--- a/frontend/src/app/(dashboard)/code-reviews/page.tsx
+++ b/frontend/src/app/(dashboard)/code-reviews/page.tsx
@@ -1068,28 +1068,18 @@ export default function CodeReviewsPage() {
       description="Bot-requested PR reviews, acceptable-risk policy, and review outcomes."
     >
       <Tabs defaultValue="reviews" className="space-y-4">
-          <TabsList>
-            <TabsTrigger value="reviews">
-              <ClipboardCheck className="h-4 w-4" />
-              Reviews
-            </TabsTrigger>
-            <TabsTrigger value="config">
-              <Settings2 className="h-4 w-4" />
-              Policy
-            </TabsTrigger>
-          </TabsList>
+        <TabsList>
+          <TabsTrigger value="reviews">
+            <ClipboardCheck className="h-4 w-4" />
+            Reviews
+          </TabsTrigger>
+          <TabsTrigger value="config">
+            <Settings2 className="h-4 w-4" />
+            Policy
+          </TabsTrigger>
+        </TabsList>
 
-          <TabsContent value="reviews" className="space-y-3">
-            <div className="flex justify-end">
-              <div className="w-full sm:w-44">
-                <FilterSelect label="Time window" value={timeRangeFilter} onValueChange={setTimeRangeFilter}>
-                  <SelectItem value="7d">Last 7 days</SelectItem>
-                  <SelectItem value="30d">Last 30 days</SelectItem>
-                  <SelectItem value="90d">Last 90 days</SelectItem>
-                  <SelectItem value="all">All time</SelectItem>
-                </FilterSelect>
-              </div>
-            </div>
+        <TabsContent value="reviews" className="space-y-3">
             <CodeReviewStatsCards
               stats={statsQuery.data?.data}
               isLoading={statsQuery.isLoading}
@@ -1113,7 +1103,7 @@ export default function CodeReviewsPage() {
             </Button>
             <div
               id="code-review-filters"
-              className={`${mobileFiltersOpen ? "grid" : "hidden"} gap-3 rounded-xl border border-border bg-card p-3 shadow-sm md:grid md:grid-cols-2 md:rounded-none md:border-0 md:bg-transparent md:p-0 md:shadow-none lg:grid-cols-3 xl:grid-cols-[minmax(12rem,18rem)_repeat(3,minmax(9rem,11rem))_1fr]`}
+              className={`${mobileFiltersOpen ? "grid" : "hidden"} gap-3 rounded-xl border border-border bg-card p-3 shadow-sm md:grid md:grid-cols-2 md:rounded-none md:border-0 md:bg-transparent md:p-0 md:shadow-none lg:grid-cols-3 xl:grid-cols-[minmax(12rem,18rem)_repeat(3,minmax(9rem,11rem))_minmax(12rem,1fr)_minmax(9rem,11rem)]`}
             >
               <FilterSelect label="Repository" value={repositoryFilter} onValueChange={(value) => void setRepositoryFilter(value === ALL_REPOSITORIES ? null : value)}>
                 <SelectItem value={ALL_REPOSITORIES}>All repositories</SelectItem>
@@ -1149,6 +1139,16 @@ export default function CodeReviewsPage() {
                 <Label className="text-xs text-muted-foreground">Search</Label>
                 <Input value={search} onChange={(event) => setSearch(event.target.value)} placeholder="PR, repo, or title" aria-label="Search code reviews" />
               </div>
+              <FilterSelect
+                label="Time window"
+                value={timeRangeFilter}
+                onValueChange={setTimeRangeFilter}
+              >
+                <SelectItem value="7d">Last 7 days</SelectItem>
+                <SelectItem value="30d">Last 30 days</SelectItem>
+                <SelectItem value="90d">Last 90 days</SelectItem>
+                <SelectItem value="all">All time</SelectItem>
+              </FilterSelect>
             </div>
             <SectionGroup
               title={


### PR DESCRIPTION
## Summary

The Code Reviews page had the “Time window” filter positioned differently than the rest of the main filter row (Repository/Outcome/Risk/Status/Search), creating a UI inconsistency and making the expected layout harder to reason about in tests. This change moves the time window into the main filter grid on the right and preserves the existing responsive behavior, then updates the regression assertion to validate it’s placed within the filter container.

## Changes

- Moved the “Time window” FilterSelect into the main `#code-review-filters` row (right side on desktop) to align with the Reviews/Policy header filters.
- Adjusted the filter grid column template (`xl:grid-cols-[...]`) to keep the responsive layout while accommodating the time window as the rightmost filter.
- Updated `code-reviews/page.test.tsx` to assert the time window belongs to `#code-review-filters` and appears after the Repository combobox.

## Validation

- Updated and ran frontend regression for `CodeReviewsPage` (`frontend/src/app/(dashboard)/code-reviews/page.test.tsx`) to match the new DOM/layout expectations.

[143.dev](https://143.dev) | [session ebd32157](https://143.dev/sessions/ebd32157-6344-415c-8a52-f9e741588a1e)

<!-- 143 readiness -->
**143 readiness:** not available for this revision.

<!-- 143-publication session=ebd32157-6344-415c-8a52-f9e741588a1e changeset=63cb4596-0bfa-438d-b757-669a0e629f89 -->

Preview: https://143.dev/previews/github/assembledhq/143/pull/1972?launch=1