### PR TITLE
Design: Code Review Decision Feedback And Policy Tuning

### DIFF
--- a/docs/design/future/121-code-review-decision-feedback-and-policy-tuning.md
+++ b/docs/design/future/121-code-review-decision-feedback-and-policy-tuning.md
@@ -2,764 +2,446 @@
 
 > **Status:** Not Started | **Last reviewed:** 2026-07-30
 >
-> **Depends on:** [../implemented/112-code-reviewer-bot-auto-approval.md](../implemented/112-code-reviewer-bot-auto-approval.md), [../backlog/11-review-feedback-loop.md](../backlog/11-review-feedback-loop.md), [../future/18-fix-quality-feedback.md](18-fix-quality-feedback.md), [../future/116-automatic-pr-feedback-follow-through.md](116-automatic-pr-feedback-follow-through.md), [../future/16-ai-agent-evals.md](16-ai-agent-evals.md)
+> **Depends on:** [../implemented/112-code-reviewer-bot-auto-approval.md](../implemented/112-code-reviewer-bot-auto-approval.md), [../backlog/11-review-feedback-loop.md](../backlog/11-review-feedback-loop.md), [../future/116-automatic-pr-feedback-follow-through.md](116-automatic-pr-feedback-follow-through.md), [../future/16-ai-agent-evals.md](16-ai-agent-evals.md)
 
 ## Summary
 
-The 143 Code Reviewer decides; nobody can argue with it. When the bot withholds
-approval, the PR author's only recourse is "ask a human." That disagreement —
-the highest-signal data the system could collect about its own policy — is
-discarded, and the org never learns which of its rules are actually miscalibrated.
+Today the Code Reviewer decides and nobody can argue with it. If the bot won't
+approve your PR, your only option is to go find a human. That disagreement is the
+best data we could possibly collect about whether our policy is right, and we
+throw all of it away.
 
-This document proposes a **decision feedback loop**:
+This adds a feedback loop:
 
-- a first-class way to contest a code review decision in plain language, in
-  either direction — "this should have been approved" and "this should not have
-  been approved"
-- automated triage that reruns the review immediately when the objection carries
-  information a rerun could act on, and answers plainly when it does not
-- proactive sampling of approvals near the policy frontier, because false
-  approvals are silent and nobody files a complaint about them
-- a deliberately narrow evidence standard for which objections may influence
-  policy at all
-- per-dispute policy proposals, centred on the editable rubric and description
-  prompts, each carrying a replay of what it would have changed
+- **Disagree in plain English.** Reply to the bot like you'd reply to a person —
+  no command to remember, no form to fill in.
+- **Both directions.** "This should have been approved" and "this should never
+  have been approved" are both first-class.
+- **Rerun when a rerun would help.** If your objection contains something the
+  review didn't know, it runs again immediately. If it doesn't, the bot says why
+  rather than going quiet.
+- **Spot-check approvals.** Nobody complains about a PR that sailed through, so
+  sample the risky ones and ask a human.
+- **Turn what we learn into policy changes** — mostly edits to the review
+  prompts, each showing what it would have changed before anyone clicks approve.
 
-Disagreeing must cost nothing. There is no command syntax and no form: a
-developer replies to the bot the way they would reply to a human reviewer, and
-143 works out what they meant.
-
-Doc 112 explicitly deferred "automatic policy learning from past approvals" and
-"aggregate reporting/insights across reviews." This document fills both gaps and
-treats them as one system, because insights without a dispute channel measure
-only the bot's own opinion of itself.
+Doc 112 deferred both "automatic policy learning" and "aggregate insights." This
+covers both, because insights without a way to disagree only measure the bot's
+opinion of itself.
 
 ## Problem
 
-### What works today
+### What already works
 
-The decision path is already better instrumented than most review bots:
+- Every non-approval has a typed reason code (`CodeReviewRiskReasonCode`), and
+  numeric ones carry the actual value and the limit.
+- The rolling PR comment shows **Why**, **Policy blockers**, **Blocking
+  findings**, and **Next steps**.
+- Policies are versioned and insert-only, so every decision points at the exact
+  policy that produced it.
 
-- Every non-approval is attributable to typed `CodeReviewRiskReasonCode` values
-  (`internal/models/code_review.go`), and numeric reasons carry `Actual` and
-  `Limit` alongside the code.
-- The rolling PR comment renders `**Why:**`, `**Policy blockers:**`,
-  `**Blocking findings:**`, and `**Next steps:**`
-  (`internal/models/code_review_output.go`).
-- Policies are insert-only and versioned, and every session captures the policy
-  id, rendered prompts, and reviewed head SHA. Decisions are auditable after
-  the fact.
+The raw material is there. The loop isn't.
 
-The raw material for a feedback loop already exists. What is missing is the loop.
+### Why people can't tell why
 
-### Why "people aren't sure why"
+1. **Every blocker looks the same.** "6 files, limit is 5" (a threshold you can
+   edit), "possible auth bug" (a model's code judgment), and "needs architectural
+   review" (a model saying ask a human) render as identical bullets. You can't
+   tell which lever to pull, and "I don't know why" usually means "I don't know
+   what to change or who to ask."
+2. **No sense of how close you were.** One threshold away and blocked on eleven
+   things read exactly alike.
+3. **Advisory findings are just a number.** "4 non-blocking observations" without
+   showing them reads as the bot hiding something.
+4. **Our failures look like your fault.** `context_unavailable` means 143 broke,
+   but it sits in the same blocker list as a real policy violation.
+5. **Cheap checks run last.** `EvaluateCodeReviewRisk` runs after the full agent
+   fan-out, so a PR that trips the file limit waits minutes to be told something
+   we knew from one API call.
 
-Five concrete gaps, each independently fixable:
+### Why admins can't fix it either
 
-1. **Blockers of different kinds are rendered identically.** `files_limit_exceeded`
-   (an objective policy threshold), `blocking_findings` (a model's code judgment),
-   and `architecture` (a model's judgment that a human should weigh in) all appear
-   as bullets under `**Policy blockers:**`. The author cannot tell which lever
-   would change the outcome: edit the policy, argue with the finding, or accept
-   that a human must look. "I don't know why" is usually "I don't know who to
-   ask or what to change."
+Doc 112 lists "top non-approval reasons" as a success metric. We can't compute
+it. There's no aggregate view — the Code reviews page has only Reviews and
+Configurations — and `policy-events` tracks which config sections admins opened,
+not how decisions turned out. So an admin asking "is our policy too strict?" has
+no data, and a developer who thinks the bot was wrong has nowhere to say so.
 
-2. **No counterfactual.** The comment lists what blocked. It never says whether a
-   single blocker was the only one. "One threshold away" and "blocked on eleven
-   separate things" read the same.
+### Two traps
 
-3. **Advisory findings are a bare count.** P2/P3 observations appear as
-   "N non-blocking observations available in the full review." A reader who
-   cannot see them cannot confirm they were correctly classified as non-blocking,
-   which reads as withholding rather than as concision.
+**Complaints alone will loosen policy forever.** The person most likely to complain
+is the author whose PR was blocked — the most biased judge available — and they're
+arguing with a safety control. Build the obvious version and you get a system that
+relaxes its own rules whenever someone pushes back, with nobody acting in bad faith.
 
-4. **System faults look like the PR's fault.** `context_unavailable` and
-   `orchestrator_synthesis_invalid` mean 143 failed, not that the change is
-   risky. There is partial special-casing for the orchestrator case, but a
-   context-fetch failure still lands in the same blocker list as a genuine
-   policy violation.
+**Nobody complains about a bad approval.** False approvals are the dangerous error
+and they're invisible: the PR merges and everyone moves on. A complaint-driven loop
+can therefore only ever find evidence for loosening. That's why disputes go both
+directions and why we sample approvals proactively.
 
-5. **Deterministic gates run last.** `EvaluateCodeReviewRisk` is called after
-   reviewer fan-out and orchestrator synthesis
-   (`internal/worker/code_review_handler.go`). A PR that trips `max_files_changed`
-   waits for a full multi-agent review to be told a fact that was knowable from
-   the PR file list in one API call.
+A dispute is a claim, not a fact. The evidence rules below keep both traps closed.
 
-### Why the org can't fix it either
+## What Counts As Evidence
 
-Doc 112 lists "Top non-approval reasons, used to tune PR templates and readiness
-checks" as a success metric. That metric is not computable today: there is no
-aggregate surface, and the `Code reviews` page ships only `Reviews` and
-`Configurations` tabs. `POST /api/v1/code-reviews/policy-events` records *policy
-editing* telemetry (which config sections admins opened), not decision outcomes.
+Only two things let a dispute change policy.
 
-So an admin asking "is our policy too strict?" has no data, and a developer who
-believes the bot was wrong has nowhere to put that belief. The result is the
-reported failure mode: silent frustration, no correction, eroding trust in the
-signal.
-
-### The trap to avoid
-
-The naive version of this feature — "let people flag bad decisions, then loosen
-the policy where flags pile up" — is worse than nothing. The person most likely
-to file a dispute is the author whose PR was blocked, i.e. the single most biased
-available judge, and the thing they are disputing is a *security and quality
-control*. A system that automatically relaxes its approval criteria in response
-to complaints from the people it blocked is gameable by construction, and the
-gaming does not even have to be deliberate.
-
-**A dispute is a claim, not a fact.** The evidence standard below is what
-separates this design from that one.
-
-### The asymmetry that makes complaints insufficient
-
-Blocked authors complain. Nobody complains about a PR that sailed through.
-
-False approvals — the dangerous error, and the one doc 112 tracks as its headline
-safety metric — are **silent by construction**. A purely complaint-driven loop can
-therefore only ever discover evidence for loosening policy, and over any time
-horizon becomes a one-way ratchet no matter how careful its evidence standard is.
-
-This design answers that in two ways: disputes are **bidirectional**, so
-"this should not have been approved" is a first-class input; and approvals near
-the policy frontier are **proactively sampled** for human spot-check, so the
-tightening direction has a source of evidence that does not depend on anyone
-noticing a problem.
-
-## Evidence Standard
-
-Only two signals may generate a policy proposal. Everything else is visible in
-Insights and inert.
-
-**Proposal-generating:**
-
-| Signal | Direction | Why it qualifies |
+| Qualifies | Applies to | Why |
 | --- | --- | --- |
-| Admin adjudicates `upheld` | Both | Authoritative. A policy owner has looked and agreed. Overrides everything |
-| **Independent human contradiction** — a human who is neither the PR author nor the disputer approved a PR 143 blocked, or left a blocking review / requested changes on a PR 143 approved | Both | Genuine independent judgment, contradicting the bot, from someone with no stake in the complaint. `ReviewContext.BlockingHumanReviews` already counts the second case |
+| **An admin says it's right** | Both directions | A policy owner looked and agreed. Overrides everything else |
+| **An independent human contradicted the bot** — someone who is neither the author nor the disputer approved a PR we blocked, or left a blocking review on a PR we approved | Both directions | Real human judgment, going against the bot, from someone with nothing at stake in the complaint. `ReviewContext.BlockingHumanReviews` already counts the second case |
 
-**Insights-only — never generates a proposal:**
+Everything else shows up in Insights and changes nothing:
 
-| Signal | Why it is excluded |
+| Doesn't qualify | Why not |
 | --- | --- |
-| A reassessment flipped the decision | The PR description is a mutable input that neither the head SHA nor the policy version pins — doc 112 hashes title/body separately for exactly this reason. An author who reads the blocker, improves the description, and gets approved is the system working correctly, not evidence the first call was wrong |
-| PR merged with no blocking human review | Frequently circular: after a non-approval, a human approving is the normal escalation path, so treating it as evidence reads the escalation as proof escalation was unnecessary. It also cannot distinguish a careful review from a rubber stamp, and without branch-protection data — which 143 does not track — it cannot exclude self-merge |
-| Reverted, or linked to an incident | Attribution is guesswork and the lag is months. Too weak to draft a change to a security control |
-| Any signal, where the disputer is not an org member | See the trust model below |
+| A rerun flipped the decision | The PR description can change without the head SHA changing — doc 112 hashes title and body separately for this reason. Someone reading the blocker, improving their description, and getting approved is the system working, not proof the first call was wrong |
+| The PR merged with no blocking review | Usually circular: after a non-approval, a human approving *is* the normal escalation path. It also can't tell a careful review from a rubber stamp, and we don't track branch protection, so it can't rule out self-merge |
+| It got reverted, or caused an incident | Attribution is guesswork and it takes months. Too weak to justify editing a safety control |
+| The disputer isn't an org member | See trust, below |
 
-This standard is deliberately strict, because there is no clustering step behind
-it: one qualifying dispute drafts a proposal. In the steady state most proposals
-will therefore originate from admin adjudication, including adjudications
-produced by frontier spot-checks. **Throughput is bounded by admin attention by
-design** — the alternative is volume of proposals nobody reads carefully, which
-converts the human activation gate into a rubber stamp and defeats its purpose.
+This bar is deliberately high because nothing sits behind it — there's no
+clustering step, so a single qualifying dispute drafts a proposal. In practice
+most proposals will come from admin adjudication, including spot-check verdicts.
+**Throughput is limited by admin attention on purpose.** The alternative is more
+proposals than anyone reads properly, which turns the human approval step into a
+rubber stamp.
 
-### Trust model
+### Who gets to influence policy
 
-Capture and influence are separate privileges. Reuse
+Capturing a complaint and acting on it are different privileges. Reuse
 `evaluatePRFeedbackEligibility` (`internal/services/github/pr_feedback_policy.go`)
-for capture rather than reinventing eligibility.
+rather than writing a new eligibility check.
 
-| Author | Captured | Answered | Can trigger a rerun | Can influence policy |
+| Who | Recorded | Answered | Can trigger a rerun | Can change policy |
 | --- | --- | --- | --- | --- |
 | `OWNER` / `MEMBER` / `COLLABORATOR` | yes | yes | yes | yes |
-| Any human on a private repository | yes | yes | yes | yes |
-| Other humans (incl. fork contributors on public repos) | yes | yes | **no** | **no** |
+| Anyone on a private repo | yes | yes | yes | yes |
+| Everyone else, including fork contributors | yes | yes | **no** | **no** |
 | Bots | no | no | no | no |
 
-Untrusted objections are still recorded, triaged, and answered — silently
-dropping a fork contributor's point is the exact failure this document exists to
-fix — and they appear in Insights flagged `untrusted`, so if outside
-contributors are consistently right about a rule, a human can still notice and
-adjudicate it into the loop deliberately.
-
-Untrusted authors cannot trigger reassessments. Reassessment is the expensive
-action, and on a public repository an unbounded supply of anonymous authors
-triggering unbounded agent runs is a denial-of-service surface. Spending an
-organization's compute is a form of influence.
-
-Bots cannot file disputes at all. The `self_authored` and hidden-marker checks in
-`evaluatePRFeedbackEligibility` already prevent the obvious self-loop, and there
-is no case where a bot should be arguing with approval policy.
-
-## Options
-
-### Option A — Insights surface only, manual tuning
-
-Add the deferred `Insights` tab. Aggregate existing decision data by repository,
-reason code, decision, and time. No dispute object; admins infer miscalibration
-from reason-code frequency and tune policy by hand.
-
-**Pros**
-- Smallest change: read-only queries over `code_review_session_metadata` and
-  existing reason details, one new tab, no schema beyond indexes.
-- Makes doc 112's stated success metrics computable for the first time.
-- No new trust surface, no LLM in the loop, nothing to game.
-- Ships in days and is a strict prerequisite for every other option.
-
-**Cons**
-- Measures only what the bot already believes. Frequency is not error: the top
-  reason code is probably `blocking_findings`, which may be entirely correct.
-- Does not give the frustrated developer anywhere to put their disagreement, so
-  it does not address the reported problem.
-- Manual tuning depends on an admin noticing, caring, and acting.
-
-### Option B — Disputes plus a deterministic auto-tuner
-
-Same free-text intake as Option C, but no reassessment and no prompt proposals —
-the options differ in what happens to a dispute, not in how one is filed. A rules
-engine proposes mechanical adjustments to numeric and enumerable dimensions from
-the `Actual`/`Limit` values the reason codes already carry.
-
-**Pros**
-- Fully explainable and unit-testable; the tuner is arithmetic.
-- No LLM anywhere in the policy-authoring path.
-- Maps cleanly onto insert-only policy versioning.
-
-**Cons**
-- **Tunes the dimensions that matter least here.** 143's deterministic gates are
-  deliberately set lenient, so relatively few non-approvals are caused by them.
-  The volume arrives through judgment reasons — `blocking_findings`,
-  `scope_mismatch`, `unresolved_uncertainty`, `architecture` — which are governed
-  by rubric and description prompt text and are untouchable by arithmetic.
-- Threshold ratcheting: repeated disputes monotonically loosen limits, and each
-  individual step looks reasonable.
-- Deterministic thresholds are also the rules teams are most able to set
-  correctly by hand, so this automates the easy half and leaves the hard half
-  untouched.
-
-### Option C — Disputes, triage-driven reassessment, and per-dispute proposals (recommended)
-
-Capture disagreement as free-text replies in either direction. Triage with one
-LLM pass that attributes the objection to the decision's own reason codes and
-decides whether a rerun could change the answer; rerun when it could. Apply the
-evidence standard above. Each qualifying dispute produces a **proposed policy
-version** — most often an edit to the rubric or description prompts — carrying a
-replay of what it would have changed. An admin reviews and activates in one
-click; activation creates the next insert-only version and an audit event.
-Separately, sample approvals near the policy frontier for spot-check so the
-tightening direction has evidence that does not require a complaint.
-
-**Pros**
-- Tunes the dimension that actually drives outcomes: the prompts.
-- Two response times. A wrong judgment call is fixed in minutes by a rerun; a
-  wrong rule is fixed in the next proposal. Options A and B can only do the slow
-  one, which is why they read as unresponsive to the developer blocked right now.
-- Bidirectional, with frontier sampling, so policy can tighten as well as loosen.
-- Human activation keeps the security boundary intact — the system proposes,
-  a person disposes — while removing essentially all of the analysis toil.
-- Free-text intake has no adoption curve: nobody has to learn a command, and
-  objections filed before it shipped are still parseable.
-- Reuses infrastructure wholesale: 143 sessions, the job queue, insert-only
-  policies, the audit log, notifications, and the existing PR-comment
-  eligibility model.
-
-**Cons**
-- The largest build.
-- A classifier decides what counts as a dispute. A missed dispute is silent —
-  the failure mode this document exists to fix — so triage must bias toward
-  recording. Over-recording is cheap; routing and the evidence standard filter
-  downstream.
-- Prompt proposals are the least legible kind of change: an admin cannot
-  evaluate a reworded rubric by reading it. Replay against a held-out guard set
-  is what makes the review real rather than nominal, and it is load-bearing
-  rather than optional.
-- Unbounded reruns for trusted humans means agent spend scales with argument
-  volume. Accepted deliberately; see the reassessment section.
-
-### Option D — Policy-as-code with proposal PRs
-
-Same capture and evidence standard as C, but policy lives in the repository
-(`.143/code-review-policy.yml`) and proposals arrive as ordinary pull requests,
-following the `.143/learned-conventions.md` pattern from doc 11.
-
-**Pros**
-- Policy changes get the team's real review process, CODEOWNERS, and git history
-  for free — a strong fit for a control that governs approvals.
-- Fully transparent and diffable.
-- No new approval UI to build.
-
-**Cons**
-- Forks the source of truth. Policy is DB-owned, versioned, and resolvable with
-  org-default plus repo-override inheritance; a repo file needs sync, conflict,
-  and precedence rules against that model, and doc 112's requirement that
-  approvals point at the exact policy version that produced them becomes harder
-  to guarantee.
-- Repo-scoped files cannot express org-level defaults inherited by repositories
-  with no override.
-- A PR proposing to loosen the reviewer bot's own rules is exactly the category
-  doc 112 says the bot must not approve — workable, but needs a carve-out.
-- Slower loop: prompt tuning now requires a merge, and prompt tuning is the part
-  that needs the fastest iteration.
-
-Worth revisiting once policy stabilizes. Not the right first move.
-
-### Rejected — Fully autonomous closed-loop adaptation
-
-C or D with automatic activation and metric-triggered rollback.
-
-Rejected on principle rather than effort. Approval policy is a security control;
-an automated system that relaxes its own controls in response to pressure from
-blocked authors is unsound regardless of how good the rollback is, and "reverts
-within 7 days" is far too slow a signal for a gate whose failure mode is
-unreviewed code reaching main. Doc 112's product principle — *approval requires
-evidence* — applies to changes in what counts as evidence.
-
-The defensible bounded form, if a team later wants it: admin pre-authorizes
-auto-application for named low-risk deterministic dimensions only, within an
-admin-set ceiling, never for prompts, path rules, sensitive categories, required
-checks, or agent roster. That is a later configuration option on top of C.
-
-## Recommendation
-
-Ship **Option C** in three phases. Each phase stands alone and is useful if the
-next never ships.
-
-### Phase 0 — Make the decision legible (no new subsystem)
-
-Changes to `internal/models/code_review_output.go`, the worker, and the session
-detail view:
-
-1. **Group blockers by lever.** Render three labelled groups instead of one list:
-   *Policy thresholds* (deterministic, tunable in Configurations — deep-link to
-   the exact setting), *Review findings* (agent code judgment, contestable),
-   *Human judgment required* (typed non-finding reasons). Derive grouping from
-   the existing `CodeReviewRiskReasonCode` — no new taxonomy.
-2. **State the scope of the blocker, not a promise.** When exactly one blocker
-   exists, say so as of a commit: *"This is the only blocker as of `abc1234`."*
-   Not "resolving it would get this approved" — fixing it triggers a fresh review
-   that may legitimately surface something new, and a promise the system cannot
-   keep is worse than no promise.
-3. **Separate system faults from risk.** Give `context_unavailable` and
-   `orchestrator_synthesis_invalid` a distinct rendering — 143 could not complete
-   the review — and keep them out of the policy-blocker list entirely.
-4. **Expose advisory findings.** Put P2/P3 observations in a collapsed
-   `<details>` block instead of a count. They remain non-blocking and still
-   generate no inline comments.
-5. **Fast-fail deterministic gates.** Evaluate size, path, author, and fork
-   eligibility from the PR file list *before* reviewer fan-out. If policy makes
-   the PR categorically ineligible, post the result immediately and skip the
-   agent run. Cuts cost and turns a multi-minute wait into seconds.
-
-Phase 0 alone likely resolves a large share of "I'm not sure why," and every
-later phase depends on the reason-code grouping it introduces.
-
-### Phase 1 — Capture, triage, reassess, corroborate
-
-**Capture, with no syntax.** Two surfaces, one record:
-
-- **GitHub-native (primary).** The developer replies in plain language, either in
-  the thread rooted on the bot's rolling comment or by mentioning
-  `@143-code-reviewer` anywhere on a PR it reviewed. "this is test-only, why is it
-  blocked?", "the migration is additive so there's no risk here", and "hold on,
-  this shouldn't have been auto-approved, it touches auth" are all valid. The
-  `issue_comment` and `pull_request_review_comment` webhooks are already routed.
-- **143-native (secondary).** A "Disagree with this decision" action on the code
-  review session detail, opening a free-text box. Reason codes from the actual
-  decision are shown for reference and may optionally be ticked; nothing beyond
-  prose is required.
-
-Capture is deliberately over-inclusive. Eligibility comes from
-`evaluatePRFeedbackEligibility`; meaning is assigned by triage, not by the
-webhook handler.
-
-**Triage.** Every captured comment enqueues `triage_code_review_dispute`, which
-runs `deterministicPRFeedbackTriage` first as a free pre-filter for
-acknowledgements and empty bodies, then a single LLM pass over the comment, the
-decision it responds to, that decision's reason codes, the diff summary, and the
-surrounding thread. It produces:
-
-| Field | Meaning |
-| --- | --- |
-| `is_dispute` | Does this contest the decision? Questions, thanks, and chatter are not disputes |
-| `direction` | `should_have_approved` or `should_not_have_approved`, inferred from the decision being responded to |
-| `contested_reason_codes` | Which of the decision's actual reason codes the objection targets, inferred from prose |
-| `dispute_kind` | See the enum in the schema; covers both directions |
-| `asserts_new_information` | Does the comment supply a fact the review did not have — "that path isn't auth-sensitive, it's a fixture" |
-| `routing` | `reassess`, `policy_signal_only`, `answer_only`, `not_a_dispute` |
-
-Routing matters because the two kinds of objection need opposite responses:
-
-- **`reassess`** — the objection asserts new information or contests an
-  agent-judgment reason. A rerun can genuinely reach a different conclusion.
-  Requires a trusted author and the `should_have_approved` direction.
-- **`policy_signal_only`** — the objection contests a deterministic gate. A rerun
-  is pointless: the threshold evaluates identically. The bot says exactly that,
-  names the policy setting and its current value, links to it, and records the
-  dispute.
-- **`answer_only`** — a question, not a disagreement. Answered from existing
-  session evidence; no dispute record survives.
-- **`not_a_dispute`** — recorded as `discarded`. No reply, no influence.
-
-A `should_not_have_approved` dispute never reassesses. Doc 112 makes approval
-monotonic and this design does not touch that: automation must never dismiss or
-contradict an approval that has already occurred. That direction is
-record-and-propose only, which makes it simpler than the blocked direction.
-
-**Reassessment.** A `reassess` routing enqueues the normal code review request
-path with a new trigger source `dispute_reassessment`, keyed by dispute id. This
-fits doc 112's existing idempotency model unchanged: a genuinely new explicit
-request after a non-approval already creates a distinct assessment at the same
-head SHA, and requests arriving mid-review are already held behind a durable
-starter job. A dispute is one more kind of explicit request.
-
-The dispute text enters as **untrusted evidence** under exactly the screening
-doc 112 applies to PR descriptions and diffs. It is a claim to verify against the
-code, never an instruction. "Approve this" and "ignore your policy" are prompt
-injection, not information.
-
-There is **no cap** on dispute-triggered reassessments per PR for trusted
-authors. A cap would not be a security boundary anyway: doc 112 already
-auto-enqueues a fresh assessment on every new commit until approval, so
-`git commit --allow-empty && git push` is an existing unlimited-rerun path that
-predates this feature. Rationing arguments while leaving that open would buy
-nothing and be hostile to people with a real problem. What actually bounds risk:
-
-- Deterministic gates are re-evaluated from source on every reassessment and can
-  never be waived by a dispute. This is the real security boundary and it does
-  not depend on any cap.
-- Untrusted authors cannot trigger reruns at all (trust model above).
-- Approval remains monotonic; each reassessment remains an immutable session.
-
-If rerolling a stochastic judge until it approves is a concern, the fix is not in
-this document — it is judgment-layer variance in doc 112, and the empty-commit
-path is the one to close. Track reassessment-flip rate by attempt number: if
-attempt 2 flips as often as attempt 1 on unchanged inputs, fix the judge rather
-than ration the reruns.
-
-**Loop safety between bot subsystems.** The reviewer's dispute reply is a comment
-on the PR, and doc 116's feedback follow-through ingests PR comments including
-bot-authored ones — an installed app on a private repo is eligible by two of its
-provenance tiers. Reply → ingested → commit pushed → doc 112 auto-enqueues a
-review → new reply is a loop that forms without anyone behaving incorrectly, and
-with no cap there is no counter in it.
-
-Two guards, reusing what doc 116 already built:
-
-- Dispute replies carry the hidden marker doc 116 already checks
-  (`prFeedbackHiddenMarker` → `IgnoreReason: "hidden_response_marker"`), so
-  follow-through skips them and the loop never forms.
-- A reviewer-side **cycle budget per epoch**, mirroring
-  `feedback_bot_epoch` / `feedback_bot_cycles_in_epoch`
-  (`internal/db/pull_request_feedback.go`): any human comment on the PR resets
-  the epoch and refills the budget; consecutive machine-only rounds decrement it.
-  Human-driven rounds stay unlimited; machine-only rounds are bounded.
-
-Markers get dropped in refactors. The epoch budget is the backstop.
-
-**Corroboration.** A scheduled `corroborate_code_review_dispute` job applies the
-evidence standard once the reassessment settles, the PR reaches a terminal state,
-or the window expires.
-
-**Surfacing.** Ship the `Insights` tab here, and a weekly digest to policy owners
-over the existing notification path. This is the "store the data and send the
-results" half of the ask, and it is independently valuable.
-
-**GitHub surface discipline.** Doc 112 fights to keep exactly one visible 143
-comment per PR, and unlimited disputes could easily undo that:
-
-- Reassessment results update the **rolling comment in place**, as every other
-  assessment already does. No new comment.
-- `policy_signal_only` and `answer_only` get **one threaded reply** each — these
-  are conversational turns and silence is the failure being fixed. GitHub threads
-  them under the comment they answer. Never a follow-up chain.
-- The rolling comment carries a compact state line: *"2 objections · 1
-  reassessment · [view](link)"*.
-- Full dispute history, triage reasoning, and reassessment lineage live on the
-  143 session, which is already the detail surface.
-
-### Phase 2 — Propose
-
-**Per-dispute, not clustered.** One dispute that meets the evidence standard
-produces one proposal. Clustering is a de-noising mechanism, and at realistic
-review volumes split across repositories, reason codes, and dispute kinds the
-modal cluster size is one — de-noising would discard the entire signal. It also
-tightens the loop from a month to days. If proposal volume ever becomes the
-complaint, clustering is a later optimization.
-
-**Proposal kinds.** Two, with the emphasis inverted from the obvious ordering:
-
-- **Prompt proposals (primary).** A 143 session reads the dispute, its review
-  session, findings, reviewer evidence, and current prompt text, and proposes a
-  scoped edit to the acceptable-risk rubric or a PR-description requirement.
-  Edits are scoped to a named section and may add **or remove** — an
-  additions-only rule would mean the rubric can only ever grow and a genuinely
-  wrong rule could never be deleted, which is its own ratchet. Dispute text
-  enters the session as untrusted evidence.
-- **Deterministic proposals (secondary).** A rules engine computes threshold,
-  path, category, check, and author-eligibility changes directly from
-  `Actual`/`Limit`. No LLM. Bounded by admin-set ceilings, and may widen a path
-  or category set by at most one named entry at a time.
-
-**Replay is what makes review real.** An admin cannot evaluate a reworded rubric
-by reading it. Every proposal is replayed before an admin sees it, against two
-sets, and both are shown:
-
-- the **target set** — the dispute(s) that motivated it. Did it fix them?
-- a **guard set** — held-out decisions believed correct, weighted toward
-  approvals near the frontier. Replaying only the target set is worthless: the
-  prompt was written to fix those cases, so it always passes. The guard set is
-  what catches "fixed 1 dispute, would have flipped 11 correct approvals."
-
-Replaying a prompt change does **not** require rerunning the review. The editable
-rubric and description prompts feed the *orchestrator*, and
-`code_review_agent_results` stores per-role `raw_output` and `structured_result`
-while doc 112 requires rendered prompts to be recoverable from audit state. So
-replay reruns the **orchestrator step alone against stored reviewer outputs** —
-no sandboxes, no repo clones, no reviewer fan-out. One cheap agent call per
-historical review, 20–30 per proposal. Deterministic proposals replay exactly and
-offline by re-evaluating `EvaluateCodeReviewRisk` against stored inputs.
-
-**Seeding the guard set.** On day one there is no corpus of agreed-correct
-decisions. Bootstrap from decisions that merged with no blocking human review —
-weak evidence individually, but adequate as a regression baseline, which is a
-lower bar than proposal-generating evidence. Curate it thereafter from
-spot-check verdicts, which are real human judgments. The guard set doubles as a
-small approval-decision eval corpus, giving doc 16 a dataset to build on rather
-than something to compete with.
-
-**Frontier sampling.** Because false approvals are silent, sample them instead of
-waiting. A scheduled job scores each approval by proximity to the policy
-boundary and queues the top-K per week for admin spot-check:
-
-| Component | Signal |
-| --- | --- |
-| **Margin** | How close to the deterministic limits — 5/5 files, 296/300 lines |
-| **Thin judgment** | Approved despite P2 findings, `low` confidence on clean verdicts, or reviewer disagreement that did not reach blocking |
-| **Novelty** | First approval touching a path or risk category this policy has never approved before |
-
-Novelty carries the highest weight: margin says the policy is being exercised at
-its edge, novelty says it is being applied somewhere it has never been tested,
-and untested is where an unexamined rule turns out to be wrong.
-
-Alongside the frontier picks, include a **blind random sample** the reviewer
-cannot distinguish. If random spot-checks surface bad approvals at the same rate
-as frontier picks, the frontier score is worthless and there is no other way to
-find that out. The random arm also yields an unbiased false-approval rate —
-doc 112's success metric, currently uncomputable.
-
-Queue size should be a few minutes of work per week. A verdict of "should not
-have been approved" writes a dispute with `direction = should_not_have_approved`
-and `corroboration_status = upheld`, which is an admin adjudication and therefore
-already proposal-generating. Frontier sampling needs no new evidence tier; it is
-a discovery mechanism feeding a signal that already qualifies.
-
-**Guardrails, non-negotiable:**
-
-- Proposals never auto-apply.
-- Proposals can never touch approval mode, fork eligibility, prompt-injection
+Outside contributors still get recorded, triaged, and answered — silently ignoring
+them is exactly the failure we're fixing — and show up in Insights marked
+untrusted, so if they're consistently right an admin can pull it in deliberately.
+They can't trigger reruns, because a rerun is the expensive action and on a public
+repo an unlimited supply of anonymous people triggering unlimited agent runs is a
+denial-of-service hole. Spending the org's compute is a form of influence.
+
+Bots can't file at all. `evaluatePRFeedbackEligibility` already blocks
+self-authored comments, and a bot arguing with approval policy has no good use
+case.
+
+## Approach
+
+Four ways to build this. We're recommending the third.
+
+| Option | What it does | Why not / why |
+| --- | --- | --- |
+| **A. Insights only** | Aggregate tab, admins tune by hand | Cheap and a prerequisite for the rest, but only measures what the bot already believes and gives the frustrated developer nowhere to go. Ship it *inside* C, not instead of it |
+| **B. Disputes + numeric auto-tuner** | Same intake, mechanical threshold changes only | Tunes what matters least. Our deterministic gates are lenient on purpose, so most non-approvals come from judgment reasons living in prompt text, which arithmetic can't fix |
+| **C. Disputes + rerun + per-dispute proposals** | Recommended; see below | Tunes the prompts, which drive outcomes. Two speeds: a wrong judgment call fixed in minutes by a rerun, a wrong rule in the next proposal |
+| **D. Policy-as-code, proposals as PRs** | Policy in the repo, changes arrive as PRs | Attractive later. Today it forks the source of truth from the versioned DB model, can't express org defaults, and makes prompt iteration need a merge — and that's the part that must be fast |
+
+**Not doing: fully autonomous tuning.** Approval policy is a safety control. A
+system that relaxes its own controls under pressure from blocked authors is unsound
+however good the rollback is, and "reverted within 7 days" is far too slow when the
+failure mode is unreviewed code reaching main.
+
+C's real costs: biggest build; a classifier decides what counts as a dispute, so it
+must err toward recording; prompt changes are the hardest kind to review, which is
+why replay is mandatory rather than nice-to-have; and agent spend scales with how
+much people argue.
+
+## Phase 0 — Make the decision readable
+
+No new subsystem. Changes to `code_review_output.go`, the worker, and session detail.
+
+1. **Group blockers by what would fix them.** Three labelled groups instead of
+   one list: *Policy thresholds* (deep-link to the setting), *Review findings*
+   (arguable), *Human judgment needed*. Derived from the existing reason codes.
+2. **Say how close it was, without promising anything.** When there's one
+   blocker: *"This is the only blocker as of `abc1234`."* Not "fix this and
+   you're approved" — fixing it triggers a fresh review that may legitimately
+   find something new, and a promise we can't keep is worse than no promise.
+3. **Separate our failures from your risk.** `context_unavailable` and
+   `orchestrator_synthesis_invalid` get their own rendering and leave the
+   blocker list.
+4. **Show advisory findings** in a collapsed `<details>` instead of a count.
+   Still non-blocking, still no inline comments.
+5. **Run cheap checks first.** Evaluate size, path, author, and fork eligibility
+   from the file list *before* the agent fan-out. If the PR can't be approved
+   either way, say so in seconds and skip the agent run.
+
+This probably fixes most of "I'm not sure why" on its own, and everything later
+depends on the grouping it introduces.
+
+## Phase 1 — Capture, triage, rerun
+
+### Capture
+
+Two ways in, one record, no syntax anywhere. **On GitHub (primary):** reply in the
+bot's comment thread, or mention `@143-code-reviewer` on any PR it reviewed —
+"this is test-only, why is it blocked?" and "hold on, this shouldn't have been
+auto-approved, it touches auth" both work. The `issue_comment` and
+`pull_request_review_comment` webhooks are already wired up. **In 143
+(secondary):** a "Disagree with this decision" button on the session opening a text
+box, with reason codes shown for reference and tickable, though prose alone is
+enough.
+
+Capture on the generous side. Eligibility comes from
+`evaluatePRFeedbackEligibility`; what a comment *means* is triage's job, not the
+webhook handler's.
+
+### Triage
+
+Every captured comment runs `triage_code_review_dispute`:
+`deterministicPRFeedbackTriage` first as a free filter for acknowledgements and
+empty bodies, then one LLM pass over the comment, the decision it's answering,
+that decision's reason codes, the diff summary, and the surrounding thread. It
+works out whether this is actually a disagreement, which direction
+(`should_have_approved` / `should_not_have_approved`), which reason codes it's
+arguing with, whether it contains information the review didn't have, and what to
+do about it.
+
+| Route | When | What happens |
+| --- | --- | --- |
+| `reassess` | Contains new information, or argues with a judgment call. Trusted author, blocked direction only | Rerun the review now |
+| `policy_signal_only` | Argues with a threshold or path rule | A rerun would change nothing — the threshold evaluates the same way every time. Say so, name the setting and its value, link to it, record the dispute |
+| `answer_only` | It's a question, not a disagreement | Answer from the session evidence. No dispute record |
+| `not_a_dispute` | Chatter | Recorded as discarded. No reply, no influence |
+
+A `should_not_have_approved` dispute never reruns. Doc 112 makes approval
+monotonic and we're not touching that — automation must never walk back an
+approval it already gave. That direction is record-and-propose only, which makes
+it simpler than the blocked direction, not harder.
+
+### Reruns
+
+A `reassess` goes through the normal review path with a new trigger source
+`dispute_reassessment`, keyed by dispute id. This needs no change to doc 112's
+idempotency model: a new explicit request after a non-approval already creates a
+fresh assessment at the same head SHA, and requests arriving mid-review are
+already queued behind a starter job. A dispute is just another explicit request.
+
+The dispute text goes in as **untrusted evidence**, screened the same way PR
+descriptions and diffs already are. It's a claim to check against the code, not
+an instruction. "Approve this" is prompt injection, not information.
+
+**No limit on reruns** for trusted authors. A limit wouldn't be a security
+boundary anyway: doc 112 already queues a fresh assessment on every new commit
+until approval, so `git commit --allow-empty && git push` is an unlimited rerun
+path that exists today. Rationing arguments while that stays open buys nothing.
+What actually bounds the risk is that deterministic gates are re-checked from
+source on every rerun and can never be waived by a dispute, untrusted authors
+can't trigger reruns at all, and approval stays monotonic with each rerun its own
+immutable session.
+
+If rerolling until the bot gives in is a worry, the fix isn't here — it's
+judgment variance in doc 112, and the empty-commit path is the one to close.
+Watch flip rate by attempt number: if attempt 2 flips as often as attempt 1 on
+unchanged input, fix the judge rather than ration the reruns.
+
+### Don't let the bots talk to each other
+
+The bot's reply is a PR comment, and doc 116's follow-through reads PR comments —
+including from bots, and an installed app on a private repo qualifies under two of
+its rules. Reply → ingested → commit pushed → doc 112 queues a review → new reply.
+That loop forms with everyone behaving correctly, and with no rerun limit nothing
+counts it. Two guards, both already built for doc 116:
+
+- Dispute replies carry the hidden marker doc 116 checks for
+  (`prFeedbackHiddenMarker`), so follow-through skips them and the loop never
+  starts.
+- A cycle budget per epoch, mirroring `feedback_bot_epoch` /
+  `feedback_bot_cycles_in_epoch` (`internal/db/pull_request_feedback.go`): any
+  human comment resets the epoch and refills the budget; machine-only rounds spend
+  it. Humans stay unlimited, machines don't. Markers get dropped in refactors, so
+  this is the backstop.
+
+### Keeping the PR quiet
+
+Doc 112 works hard to keep exactly one visible 143 comment per PR, and unlimited
+disputes could wreck that. Rerun results **update the rolling comment in place**,
+like every other assessment. `policy_signal_only` and `answer_only` get **one
+threaded reply** each — these are conversations, and silence is the thing we're
+fixing — nested by GitHub under the comment they answer, never a chain. The
+rolling comment carries a one-line summary: *"2 objections · 1 rerun ·
+[view](link)"*. Everything else lives on the session.
+
+Corroboration runs as a scheduled job once the rerun settles, the PR closes, or
+the window expires. Ship the **Insights** tab and a weekly digest to policy owners
+in this phase — that's the "store the data and send the results" half, and it's
+worth having on its own.
+
+## Phase 2 — Propose changes
+
+### One dispute, one proposal
+
+No clustering. At realistic review volume, split across repos and reason codes
+and dispute kinds, most clusters would have exactly one member — de-noising would
+throw away the entire signal. Per-dispute also cuts the loop from a month to
+days. If proposal volume ever becomes the complaint, clustering can come later.
+
+### Two kinds of proposal
+
+- **Prompt changes (the main event).** A 143 session reads the dispute, its
+  review, the findings, and the current prompt text, then proposes a scoped edit
+  to the acceptable-risk rubric or a description requirement. Edits are limited to
+  a named section and can **add or remove** — additions-only would mean the rubric
+  can only ever grow and a genuinely wrong rule could never be deleted. Dispute
+  text enters as untrusted evidence.
+- **Threshold changes (secondary).** A rules engine computes limit, path,
+  category, check, and author-eligibility changes straight from the recorded
+  actual-vs-limit values. No LLM. Bounded by admin ceilings, and widens a path or
+  category set by at most one entry at a time.
+
+### Replay is what makes review real
+
+Nobody can evaluate a reworded rubric by reading it. So every proposal is replayed
+before an admin sees it, against two sets, and both are shown: the **target set**
+(the dispute that prompted it — did it fix the problem?) and the **guard set**
+(held-out decisions we believe were right, weighted toward approvals near the
+frontier).
+
+The guard set is the important half. Replaying only the target set proves nothing:
+the prompt was written to fix that case, so it always passes. The guard set is what
+catches "fixed 1 complaint, would have flipped 11 good approvals."
+
+Replaying a prompt change **doesn't require rerunning the review**. The editable
+prompts feed the orchestrator, `code_review_agent_results` already stores each
+reviewer's raw and structured output, and doc 112 requires rendered prompts to be
+recoverable. So replay reruns **only the orchestrator step against stored reviewer
+output** — no sandboxes, no clones, no fan-out. One cheap call per historical
+review, 20–30 per proposal. Threshold proposals replay exactly and offline via
+`EvaluateCodeReviewRisk` against stored inputs.
+
+**Seeding the guard set.** Day one has no corpus of known-good decisions.
+Bootstrap from decisions that merged with no blocking human review — weak
+individually, but a regression baseline is a lower bar than evidence that changes
+policy — then curate from spot-check verdicts, which are real judgments. The guard
+set doubles as a small eval corpus, giving doc 16 something to build on.
+
+### Spot-checking approvals
+
+Since nobody reports a bad approval, go looking. A scheduled job scores each
+approval by how close it came to the edge of policy and queues the top few per week
+for an admin:
+
+- **Margin** — how near the limits: 5 of 5 files, 296 of 300 lines.
+- **Thin judgment** — approved despite P2 findings, low-confidence clean verdicts,
+  or reviewer disagreement that didn't quite block.
+- **Novelty** — first approval touching a path or category this policy has never
+  approved before. Weight this highest: margin means the policy is being used at
+  its edge, novelty means it's being used somewhere untested, and untested is
+  where a bad rule hides.
+
+Mix in a **blind random sample** the admin can't tell from the frontier picks. If
+random spot-checks find bad approvals at the same rate as targeted ones, the score
+is worthless and there's no other way to learn that. The random arm also gives an
+unbiased false-approval rate — doc 112's headline safety metric, currently
+uncomputable.
+
+Keep the queue to a few minutes a week. A "shouldn't have been approved" verdict
+writes an already-adjudicated dispute in that direction, which qualifies — so
+spot-checking needs no new evidence rule, it just finds cases for one we have.
+
+### Guardrails
+
+- Proposals never apply themselves.
+- They can never touch approval mode, fork eligibility, prompt-injection
   handling, agent roster, or the bot's own policy paths.
-- Every activation is attributable to a user, in the audit log, and revertible by
-  activating the prior version — policies are already insert-only, so revert is
-  one click.
-- Insights tracks decision-mix shift and false-approval rate per policy version,
-  so a bad prompt change is visible in days rather than discovered by incident.
+- Every activation is attributed to a user, audit-logged, and reversible by
+  activating the previous version — policies are insert-only, so revert is one
+  click.
+- Insights tracks decision mix and false-approval rate per policy version, so a
+  bad prompt change shows up in days rather than via an incident.
 
 ## Database Schema
 
-Four new tables plus alterations, all tenant-scoped by `org_id`, following the
-insert-only and partial-unique-index conventions in doc 112.
+Every table below carries `id uuid PRIMARY KEY`, `org_id uuid NOT NULL REFERENCES
+organizations(id)`, and `created_at timestamptz NOT NULL DEFAULT now()`. Tenancy
+is `org_id` throughout. Only the distinctive columns are listed.
+
+**`code_review_decision_disputes`** — one row per objection.
+
+| Column | Type | Notes |
+| --- | --- | --- |
+| `session_id`, `pull_request_id`, `repository_id`, `policy_id` | uuid NOT NULL | FKs; session/PR cascade on delete |
+| `reviewed_head_sha`, `decision` | text NOT NULL | What was being disputed |
+| `direction` | text NOT NULL | `should_have_approved` \| `should_not_have_approved` |
+| `filed_by_user_id`, `filed_by_login`, `author_association`, `author_is_pr_author` | uuid / text / bool | Filer identity |
+| `trusted` | boolean NOT NULL | Gates both reruns and policy influence |
+| `source` | text NOT NULL | `github_comment` \| `app_ui` \| `api` \| `spot_check` |
+| `github_comment_id`, `github_delivery_id`, `github_thread_root_comment_id`, `reply_comment_id` | bigint / text | Dedupe, threading, and the one reply |
+| `body` | text NOT NULL | Verbatim. No syntax is parsed from it |
+| `contested_reason_codes` | text[] | Inferred by triage |
+| `dispute_kind` | text | `threshold_too_strict`, `path_rule_too_broad`, `description_requirement_wrong`, `finding_incorrect`, `judgment_overreach`, `threshold_too_lenient`, `path_rule_too_narrow`, `missed_finding`, `judgment_underreach`, `bot_correct`, `other` |
+| `asserts_new_information` | boolean NOT NULL | Drives the `reassess` route |
+| `routing` | text | `reassess` \| `policy_signal_only` \| `answer_only` \| `not_a_dispute` |
+| `intake_status`, `intake_confidence` | text | `pending` \| `triaged` \| `discarded` \| `failed` |
+| `reassessment_session_id`, `reassessment_decision`, `reassessment_flipped` | uuid / text / bool | Rerun linkage |
+| `corroboration_status` | text NOT NULL | `pending` \| `independent_contradiction` \| `upheld` \| `rejected` \| `weak` \| `inconclusive`. Only the middle two qualify, and only when `trusted` |
+| `corroboration_detail` | jsonb | Which signal fired, and its inputs |
+| `adjudicated_by_user_id`, `adjudicated_at`, `adjudication_note` | uuid / timestamptz / text | Admin verdict |
+
+Indexes: unique on `github_comment_id` and on `github_delivery_id` (both partial,
+`WHERE NOT NULL`) so redelivery and edits update in place — deliberately *not*
+unique per `(session, filer)`, since one person may raise two genuinely different
+objections. Partial index on `intake_status = 'pending'`; partial on
+`(org_id, corroboration_status)` where triaged and pending; partial on
+`(org_id, repository_id, direction, corroborated_at DESC)` where `trusted` and
+the status qualifies, to find disputes awaiting a proposal.
+
+**`code_review_policy_proposals`** — one row per proposal. `repository_id`,
+`base_policy_id`, and `source_dispute_id` (uuid; exactly one, no clustering);
+`direction` (`loosen` | `tighten`); `change_kind` (`prompt` | `deterministic`);
+`origin` (`deterministic_rule` | `agent_session` | `manual`) with
+`generator_session_id`; `status` (`replaying` | `open` | `activated` |
+`dismissed` | `superseded` | `expired`); `proposed_changes jsonb NOT NULL` — a
+structured validated delta, never a raw config replacement; `rationale text NOT
+NULL` citing its dispute and review; `replay_status`, `replay_target_result
+jsonb`, `replay_guard_result jsonb`, `guard_regressions int`; and the outcome
+columns `activated_policy_id`, `decided_by_user_id`, `decided_at`,
+`decision_note`. Unique index on `source_dispute_id` where status is `replaying`
+or `open`; plus `(org_id, status, created_at DESC)`.
+
+**`code_review_approval_audits`** — the spot-check queue. `session_id`,
+`repository_id`, `pull_request_id`, `policy_id` identify the approval under
+review. `selection` (`frontier` | `random`) is **never exposed while queued** —
+the control only works blind. `frontier_score numeric` and `frontier_factors
+jsonb` record margin, thin judgment, and novelty. `status` (`queued` | `reviewed`
+| `expired`) and `verdict` (`correct` | `should_not_have_approved`) carry the
+outcome, with `resulting_dispute_id`, `reviewed_by_user_id`, `reviewed_at`, and
+`note`. Unique index on `session_id`; partial on `(org_id, status, created_at)`
+where queued.
+
+**`code_review_guard_set_members`** — held-out decisions for replay.
+`session_id` (unique where active), `repository_id`, `expected_decision`,
+`added_by` (`bootstrap` \| `spot_check` \| `admin`), `active boolean`.
+
+**`code_review_decision_outcomes`** — denormalized per-decision facts, keyed by
+`session_id` as PK, so Insights and corroboration don't re-derive PR history on
+every read. Carries `decision`, `reason_codes text[]` (GIN indexed), `merged`,
+`merged_at`, `independent_approver_login`, `independent_blocking_review_login`,
+`human_review_comment_count`, `reverted`, `terminal`, `observed_until`.
+
+**Changes to existing tables:**
 
 ```sql
-CREATE TABLE code_review_decision_disputes (
-    id                     uuid PRIMARY KEY DEFAULT gen_random_uuid(),
-    org_id                 uuid NOT NULL REFERENCES organizations(id),
-    session_id             uuid NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
-    pull_request_id        uuid NOT NULL REFERENCES pull_requests(id) ON DELETE CASCADE,
-    repository_id          uuid NOT NULL REFERENCES repositories(id),
-    policy_id              uuid NOT NULL REFERENCES code_review_policies(id),
-    reviewed_head_sha      text NOT NULL,
-    decision               text NOT NULL,
-    direction              text NOT NULL DEFAULT 'should_have_approved'
-                               CHECK (direction IN ('should_have_approved','should_not_have_approved')),
-    -- Filer identity and trust. `trusted` gates both reruns and policy influence.
-    filed_by_user_id       uuid REFERENCES users(id),
-    filed_by_login         text NOT NULL DEFAULT '',
-    author_association     text NOT NULL DEFAULT '',
-    author_is_pr_author    boolean NOT NULL DEFAULT false,
-    trusted                boolean NOT NULL DEFAULT false,
-    source                 text NOT NULL CHECK (source IN ('github_comment','app_ui','api','spot_check')),
-    github_comment_id      bigint,
-    github_delivery_id     text,
-    github_thread_root_comment_id bigint,
-    -- Verbatim natural-language objection. No command syntax is parsed from it.
-    body                   text NOT NULL DEFAULT '',
-    -- Everything below is inferred by triage, not supplied by the filer.
-    contested_reason_codes text[] NOT NULL DEFAULT '{}',
-    dispute_kind           text CHECK (dispute_kind IS NULL OR dispute_kind IN (
-                               -- should_have_approved
-                               'threshold_too_strict','path_rule_too_broad',
-                               'description_requirement_wrong','finding_incorrect',
-                               'judgment_overreach',
-                               -- should_not_have_approved
-                               'threshold_too_lenient','path_rule_too_narrow',
-                               'missed_finding','judgment_underreach',
-                               -- either
-                               'bot_correct','other')),
-    asserts_new_information boolean NOT NULL DEFAULT false,
-    routing                text CHECK (routing IS NULL OR routing IN (
-                               'reassess','policy_signal_only','answer_only','not_a_dispute')),
-    intake_status          text NOT NULL DEFAULT 'pending'
-                               CHECK (intake_status IN ('pending','triaged','discarded','failed')),
-    intake_confidence      text CHECK (intake_confidence IS NULL OR intake_confidence IN ('low','medium','high')),
-    reassessment_session_id uuid REFERENCES sessions(id) ON DELETE SET NULL,
-    reassessment_decision   text,
-    reassessment_flipped    boolean NOT NULL DEFAULT false,
-    reply_comment_id        bigint,
-    -- Evidence standard. Only 'independent_contradiction' and 'upheld' may
-    -- generate a proposal, and only when `trusted` is true.
-    corroboration_status   text NOT NULL DEFAULT 'pending'
-                               CHECK (corroboration_status IN (
-                                   'pending','independent_contradiction','upheld',
-                                   'rejected','weak','inconclusive')),
-    corroboration_detail   jsonb NOT NULL DEFAULT '{}',
-    corroborated_at        timestamptz,
-    adjudicated_by_user_id uuid REFERENCES users(id),
-    adjudicated_at         timestamptz,
-    adjudication_note      text,
-    created_at             timestamptz NOT NULL DEFAULT now(),
-    updated_at             timestamptz NOT NULL DEFAULT now()
-);
-
--- Each GitHub comment yields at most one dispute; redelivery and comment edits
--- update in place. Deliberately not unique per (session, filer): one person may
--- raise two distinct objections and collapsing them would lose a signal.
-CREATE UNIQUE INDEX idx_cr_disputes_github_comment
-    ON code_review_decision_disputes (github_comment_id) WHERE github_comment_id IS NOT NULL;
-CREATE UNIQUE INDEX idx_cr_disputes_delivery
-    ON code_review_decision_disputes (github_delivery_id) WHERE github_delivery_id IS NOT NULL;
-CREATE INDEX idx_cr_disputes_intake
-    ON code_review_decision_disputes (org_id, intake_status, created_at)
-    WHERE intake_status = 'pending';
-CREATE INDEX idx_cr_disputes_pending
-    ON code_review_decision_disputes (org_id, corroboration_status, created_at)
-    WHERE corroboration_status = 'pending' AND intake_status = 'triaged';
--- Proposal-eligible disputes awaiting a proposal.
-CREATE INDEX idx_cr_disputes_eligible
-    ON code_review_decision_disputes (org_id, repository_id, direction, corroborated_at DESC)
-    WHERE trusted = true AND corroboration_status IN ('independent_contradiction','upheld');
-CREATE INDEX idx_cr_disputes_session
-    ON code_review_decision_disputes (session_id, created_at);
-
-CREATE TABLE code_review_policy_proposals (
-    id                   uuid PRIMARY KEY DEFAULT gen_random_uuid(),
-    org_id               uuid NOT NULL REFERENCES organizations(id),
-    repository_id        uuid REFERENCES repositories(id),
-    base_policy_id       uuid NOT NULL REFERENCES code_review_policies(id),
-    source_dispute_id    uuid NOT NULL REFERENCES code_review_decision_disputes(id),
-    direction            text NOT NULL CHECK (direction IN ('loosen','tighten')),
-    change_kind          text NOT NULL CHECK (change_kind IN ('prompt','deterministic')),
-    origin               text NOT NULL CHECK (origin IN ('deterministic_rule','agent_session','manual')),
-    generator_session_id uuid REFERENCES sessions(id),
-    status               text NOT NULL DEFAULT 'replaying'
-                             CHECK (status IN ('replaying','open','activated','dismissed','superseded','expired')),
-    -- Structured, validated policy delta. Never raw config replacement.
-    proposed_changes     jsonb NOT NULL,
-    rationale            text NOT NULL,
-    -- Replay outcomes. Target = the motivating dispute; guard = held-out set.
-    replay_status        text NOT NULL DEFAULT 'pending'
-                             CHECK (replay_status IN ('pending','running','complete','failed')),
-    replay_target_result jsonb NOT NULL DEFAULT '{}',
-    replay_guard_result  jsonb NOT NULL DEFAULT '{}',
-    guard_regressions    int NOT NULL DEFAULT 0,
-    activated_policy_id  uuid REFERENCES code_review_policies(id),
-    decided_by_user_id   uuid REFERENCES users(id),
-    decided_at           timestamptz,
-    decision_note        text,
-    created_at           timestamptz NOT NULL DEFAULT now()
-);
-
-CREATE UNIQUE INDEX idx_cr_proposals_open_dispute
-    ON code_review_policy_proposals (source_dispute_id) WHERE status IN ('replaying','open');
-CREATE INDEX idx_cr_proposals_org_status
-    ON code_review_policy_proposals (org_id, status, created_at DESC);
-
--- Frontier + random sampling of approvals for human spot-check.
-CREATE TABLE code_review_approval_audits (
-    id                 uuid PRIMARY KEY DEFAULT gen_random_uuid(),
-    org_id             uuid NOT NULL REFERENCES organizations(id),
-    session_id         uuid NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
-    repository_id      uuid NOT NULL REFERENCES repositories(id),
-    pull_request_id    uuid NOT NULL REFERENCES pull_requests(id) ON DELETE CASCADE,
-    policy_id          uuid NOT NULL REFERENCES code_review_policies(id),
-    -- Never exposed to the reviewing admin: the random arm is the control.
-    selection          text NOT NULL CHECK (selection IN ('frontier','random')),
-    frontier_score     numeric(6,4) NOT NULL DEFAULT 0,
-    frontier_factors   jsonb NOT NULL DEFAULT '{}',
-    status             text NOT NULL DEFAULT 'queued'
-                           CHECK (status IN ('queued','reviewed','expired')),
-    verdict            text CHECK (verdict IS NULL OR verdict IN ('correct','should_not_have_approved')),
-    resulting_dispute_id uuid REFERENCES code_review_decision_disputes(id),
-    reviewed_by_user_id uuid REFERENCES users(id),
-    reviewed_at        timestamptz,
-    note               text,
-    created_at         timestamptz NOT NULL DEFAULT now()
-);
-
-CREATE UNIQUE INDEX idx_cr_audits_session ON code_review_approval_audits (session_id);
-CREATE INDEX idx_cr_audits_queue ON code_review_approval_audits (org_id, status, created_at)
-    WHERE status = 'queued';
-
--- Held-out decisions used as the replay regression baseline.
-CREATE TABLE code_review_guard_set_members (
-    id                uuid PRIMARY KEY DEFAULT gen_random_uuid(),
-    org_id            uuid NOT NULL REFERENCES organizations(id),
-    repository_id     uuid NOT NULL REFERENCES repositories(id),
-    session_id        uuid NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
-    expected_decision text NOT NULL,
-    added_by          text NOT NULL CHECK (added_by IN ('bootstrap','spot_check','admin')),
-    active            boolean NOT NULL DEFAULT true,
-    created_at        timestamptz NOT NULL DEFAULT now()
-);
-
-CREATE UNIQUE INDEX idx_cr_guard_session ON code_review_guard_set_members (session_id) WHERE active = true;
-CREATE INDEX idx_cr_guard_repo ON code_review_guard_set_members (org_id, repository_id) WHERE active = true;
-
--- Denormalized per-decision outcome facts for Insights and corroboration.
-CREATE TABLE code_review_decision_outcomes (
-    session_id                 uuid PRIMARY KEY REFERENCES sessions(id) ON DELETE CASCADE,
-    org_id                     uuid NOT NULL REFERENCES organizations(id),
-    repository_id              uuid NOT NULL REFERENCES repositories(id),
-    pull_request_id            uuid NOT NULL REFERENCES pull_requests(id) ON DELETE CASCADE,
-    policy_id                  uuid NOT NULL REFERENCES code_review_policies(id),
-    decision                   text NOT NULL,
-    reason_codes               text[] NOT NULL DEFAULT '{}',
-    merged                     boolean NOT NULL DEFAULT false,
-    merged_at                  timestamptz,
-    -- Independent human contradiction inputs. Author and disputer are excluded
-    -- when evaluating these.
-    independent_approver_login text,
-    independent_blocking_review_login text,
-    human_review_comment_count int NOT NULL DEFAULT 0,
-    reverted                   boolean NOT NULL DEFAULT false,
-    reverted_at                timestamptz,
-    terminal                   boolean NOT NULL DEFAULT false,
-    observed_until             timestamptz,
-    updated_at                 timestamptz NOT NULL DEFAULT now()
-);
-
-CREATE INDEX idx_cr_outcomes_org_repo ON code_review_decision_outcomes (org_id, repository_id, updated_at DESC);
-CREATE INDEX idx_cr_outcomes_reason_codes ON code_review_decision_outcomes USING gin (reason_codes);
-```
-
-Alterations to existing tables:
-
-```sql
--- internal/models/code_review.go gains CodeReviewTriggerSourceDisputeReassessment.
+-- New trigger source; models gains CodeReviewTriggerSourceDisputeReassessment.
 ALTER TABLE code_review_session_metadata
     DROP CONSTRAINT chk_code_review_session_metadata_trigger_source,
     ADD CONSTRAINT chk_code_review_session_metadata_trigger_source
         CHECK (trigger_source IN ('app_reviewer','alias_reviewer','team_reviewer',
                                   'slash_command','auto_policy','dispute_reassessment'));
 
+-- Risk reasons are only recorded when a gate FAILS, so an approval leaves no
+-- record of how close it came. Frontier margin scoring needs these.
 ALTER TABLE code_review_session_metadata
     ADD COLUMN triggering_dispute_id uuid REFERENCES code_review_decision_disputes(id),
-    -- Risk reasons are only recorded when a gate FAILS, so an approval currently
-    -- leaves no record of how close it came. Frontier margin scoring needs these.
     ADD COLUMN files_changed int,
     ADD COLUMN lines_changed int;
 
--- Reviewer-side bot-loop budget, mirroring the doc 116 epoch mechanic.
+-- Bot-loop budget, mirroring the doc 116 epoch mechanic.
 ALTER TABLE pull_requests
     ADD COLUMN code_review_dispute_epoch bigint NOT NULL DEFAULT 0,
     ADD COLUMN code_review_dispute_cycles_in_epoch integer NOT NULL DEFAULT 0,
@@ -767,142 +449,84 @@ ALTER TABLE pull_requests
         CHECK (code_review_dispute_cycles_in_epoch >= 0);
 ```
 
-New job types on the existing queue:
+**Jobs**, on the existing queue:
 
-| Job type | Queue | Trigger |
+| Job | Queue | Fires when |
 | --- | --- | --- |
-| `triage_code_review_dispute` | `feedback` | Comment captured on a reviewed PR, or dispute filed in the app |
-| `run_code_review` (existing) | `agent` | Triage routed `reassess`; `trigger_source = 'dispute_reassessment'`, deduped on dispute id |
-| `reply_code_review_dispute` | `feedback` | Triage routed `policy_signal_only` / `answer_only`, or a reassessment completed |
-| `corroborate_code_review_dispute` | `feedback` | Reassessment settles, PR reaches terminal state, or window expires |
-| `generate_code_review_policy_proposal` | `agent` | A dispute becomes proposal-eligible |
-| `replay_code_review_policy_proposal` | `agent` | Proposal created; orchestrator-only replay over target + guard sets |
-| `sample_code_review_approvals` | `feedback` | Scheduled weekly per org; frontier + random selection |
-| `digest_code_review_insights` | `feedback` | Scheduled weekly per org |
+| `triage_code_review_dispute` | `feedback` | A comment is captured, or a dispute is filed in-app |
+| `run_code_review` (existing) | `agent` | Triage routed `reassess`; deduped on dispute id |
+| `reply_code_review_dispute` | `feedback` | Triage routed `policy_signal_only` / `answer_only`, or a rerun finished |
+| `corroborate_code_review_dispute` | `feedback` | Rerun settles, PR closes, or the window expires |
+| `generate_code_review_policy_proposal` | `agent` | A dispute qualifies |
+| `replay_code_review_policy_proposal` | `agent` | Proposal created |
+| `sample_code_review_approvals` | `feedback` | Weekly per org |
+| `digest_code_review_insights` | `feedback` | Weekly per org |
 
-Reassessment reuses the `run_code_review` handler unchanged; only request
-orchestration in `internal/services/codereview` learns the new trigger source and
-the trust gate.
+Reruns reuse the existing `run_code_review` handler unchanged; only request
+orchestration learns the new trigger source and the trust gate.
 
-New audit actions: `code_review_dispute.filed`, `code_review_dispute.reassessed`,
-`code_review_dispute.adjudicated`, `code_review_approval_audit.reviewed`,
-`code_review_policy_proposal.activated`, `code_review_policy_proposal.dismissed`.
+**Audit actions:** `code_review_dispute.filed`, `.reassessed`, `.adjudicated`,
+`code_review_approval_audit.reviewed`,
+`code_review_policy_proposal.activated`, `.dismissed`.
 
 ## API Contract
 
-All routes are org-scoped and follow existing auth conventions. Filing and
-reading disputes is member-level; adjudication, spot-check verdicts, and proposal
-decisions are admin-level.
+Org-scoped, existing auth conventions. Filing and reading are member-level;
+adjudication, spot-check verdicts, and proposal decisions are admin-level.
 
-```
-POST   /api/v1/code-reviews/{session_id}/disputes
-       body:    { "body": string,                        // required, free text
-                  "contested_reason_codes": string[]? }  // optional hint; triage may override
-       201 ->   CodeReviewDispute   // intake_status "pending"; triage runs async
-       errors:  404 review not found · 422 empty body
-       note:    No 409. Multiple distinct objections on one review are legitimate;
-                only GitHub-sourced disputes dedupe, on comment id. Direction is
-                inferred by triage, never supplied by the caller.
-
-GET    /api/v1/code-reviews/{session_id}/disputes
-       200 ->   { "data": CodeReviewDispute[] }   // routing, trust, reassessment linkage
-
-PATCH  /api/v1/code-review-disputes/{id}            (admin)
-       body:    { "corroboration_status": "upheld" | "rejected", "adjudication_note": string? }
-       200 ->   CodeReviewDispute
-       errors:  403 not an admin · 409 already adjudicated
-
-GET    /api/v1/code-review-approval-audits          (admin)
-       query:   status?, repository_id?
-       200 ->   { "data": CodeReviewApprovalAudit[] }
-       note:    `selection` is omitted from the response while status = "queued";
-                the random control only works if the reviewer cannot see the arm.
-
-POST   /api/v1/code-review-approval-audits/{id}/verdict   (admin)
-       body:    { "verdict": "correct" | "should_not_have_approved", "note": string? }
-       200 ->   { "audit": CodeReviewApprovalAudit, "dispute": CodeReviewDispute? }
-       note:    A "should_not_have_approved" verdict creates an upheld dispute in
-                the should_not_have_approved direction. A "correct" verdict adds
-                the session to the guard set.
-
-GET    /api/v1/code-review-insights
-       query:   repository_id?, from?, to?, decision?, reason_code?, direction?
-       200 ->   { "data": {
-                    "decisions_by_reason":  [{ "reason_code","count","dispute_count",
-                                               "qualifying_count","dispute_rate" }],
-                    "decision_totals":      { "approved","comment_only","needs_human_review","blocked" },
-                    "disputes_by_direction":{ "should_have_approved","should_not_have_approved" },
-                    "reassessment_flip_rate_by_attempt": [{ "attempt","flips","runs" }],
-                    "spot_check":           { "frontier_hit_rate","random_hit_rate","false_approval_rate" },
-                    "median_decision_seconds": number,
-                    "policy_versions":      [{ "policy_id","version","decision_mix","false_approval_rate" }]
-                 } }
-
-GET    /api/v1/code-review-policy-proposals
-       query:   status?, repository_id?, direction?
-       200 ->   { "data": CodeReviewPolicyProposal[] }   // includes replay results
-
-POST   /api/v1/code-review-policy-proposals/{id}/activate      (admin)
-       body:    { "proposed_changes": object? }   // optional edited delta
-       200 ->   { "policy": CodeReviewPolicy, "proposal": CodeReviewPolicyProposal }
-       errors:  409 not open / replay incomplete / base policy superseded
-                422 delta fails policy validation
-                403 delta touches a locked dimension
-
-POST   /api/v1/code-review-policy-proposals/{id}/dismiss       (admin)
-       body:    { "decision_note": string }
-       200 ->   CodeReviewPolicyProposal
-```
+| Route | Body / query | Returns |
+| --- | --- | --- |
+| `POST /api/v1/code-reviews/{session_id}/disputes` | `{ body: string, contested_reason_codes?: string[] }` | `201` dispute with `intake_status: "pending"`. `422` if body empty, `404` if no such review. **No 409** — several distinct objections on one review are legitimate; only GitHub-sourced ones dedupe, on comment id. Direction is inferred, never supplied |
+| `GET /api/v1/code-reviews/{session_id}/disputes` | — | Disputes with routing, trust, and rerun linkage |
+| `PATCH /api/v1/code-review-disputes/{id}` *(admin)* | `{ corroboration_status: "upheld"\|"rejected", adjudication_note? }` | Updated dispute. `409` if already adjudicated |
+| `GET /api/v1/code-review-approval-audits` *(admin)* | `status?`, `repository_id?` | Spot-check queue. `selection` is **omitted while queued** — the random control only works if the reviewer can't see the arm |
+| `POST /api/v1/code-review-approval-audits/{id}/verdict` *(admin)* | `{ verdict: "correct"\|"should_not_have_approved", note? }` | `should_not_have_approved` creates an already-upheld dispute; `correct` adds the session to the guard set |
+| `GET /api/v1/code-review-insights` | `repository_id?`, `from?`, `to?`, `decision?`, `reason_code?`, `direction?` | Decisions and dispute rate by reason code; totals; disputes by direction; flip rate by attempt; `spot_check` (frontier vs random hit rate, false-approval rate); median decision time; per-policy-version decision mix |
+| `GET /api/v1/code-review-policy-proposals` | `status?`, `repository_id?`, `direction?` | Proposals including replay results |
+| `POST /api/v1/code-review-policy-proposals/{id}/activate` *(admin)* | `{ proposed_changes? }` (optional edited delta) | New policy + proposal. `409` if not open, replay incomplete, or base policy superseded; `422` invalid delta; `403` touches a locked dimension |
+| `POST /api/v1/code-review-policy-proposals/{id}/dismiss` *(admin)* | `{ decision_note }` | Updated proposal |
 
 The GitHub path adds no route and parses no syntax. The existing `issue_comment`
-and `pull_request_review_comment` handlers capture replies in the bot's
-rolling-comment thread and comments mentioning the bot on any PR it reviewed,
-evaluate eligibility via `evaluatePRFeedbackEligibility`, create the record with
-`source = 'github_comment'` deduplicated on `github_delivery_id`, and enqueue
-triage. Whether a captured comment is a dispute at all is decided by triage, not
-by the handler.
+and `pull_request_review_comment` handlers capture replies in the bot's thread and
+mentions on reviewed PRs, check eligibility, dedupe on `github_delivery_id`, and
+enqueue triage. Whether a comment is a dispute is triage's call, not the
+handler's.
 
-Activation validates the delta against the same validation used by
-`PUT /api/v1/code-review-policies`, then writes a new insert-only version. It
-never patches a policy row in place, so approvals continue to point at the exact
-version that produced them.
+Activation runs the same validation as `PUT /api/v1/code-review-policies`, then
+writes a new insert-only version. It never patches a policy row in place, so
+approvals keep pointing at the version that produced them.
 
 ## Success Metrics
 
-- **Share of non-approvals where someone objects.** The miscalibration signal
-  that does not exist today. Expect it to rise when intake becomes free-text —
-  that is the feature working, not the bot getting worse.
-- **Triage accuracy**, sampled by hand. Objections wrongly recorded as
-  `not_a_dispute` are the silent failure this document exists to prevent, and
-  matter far more than the reverse error.
-- **Frontier hit rate vs random hit rate.** If the two are equal, the frontier
-  score is worthless. This is the only check on the sampler.
-- **False approval rate**, from the random control arm — unbiased, and doc 112's
-  headline safety metric, currently uncomputable.
-- **Guard-set regression rate per activated proposal.** How often an activated
-  change flipped decisions that were correct. The metric that says whether
-  one-click activation is safe.
-- **Reassessment flip rate by attempt number.** Flips on new information are the
-  loop working; flips on unchanged inputs mean judgment-layer variance, which is
-  a different bug and should be fixed rather than tuned around.
-- **Median time from objection to a substantive reply**, and to a flipped
-  decision where one occurs. The developer-facing latency this is judged on.
-- **Proposal activation and dismissal rates**, split by `direction`. Persistent
-  asymmetry means the loop is drifting one way.
+- **How often non-approvals get an objection.** The miscalibration signal we don't
+  have today. Expect it to jump when intake becomes free-text — that's the feature
+  working, not the bot getting worse.
+- **Triage accuracy**, hand-sampled. Objections wrongly filed as `not_a_dispute`
+  are the silent failure this exists to prevent, and matter far more than the
+  opposite error.
+- **Frontier hit rate vs random hit rate.** If they're equal the frontier score is
+  worthless, and this is the only way to find that out.
+- **False approval rate** from the random arm — unbiased, and doc 112's headline
+  safety metric.
+- **Guard-set regressions per activated proposal.** How often a change broke
+  decisions that were right; the number that says whether one-click activation is
+  safe.
+- **Flip rate by rerun attempt.** Flips on new information mean the loop works;
+  flips on unchanged input mean judgment variance, a different bug.
+- **Time from objection to a real reply**, and to a flipped decision.
+- **Activation and dismissal rates by direction.** Lasting asymmetry means drift.
 
 ## Open Questions
 
-- What is the right weekly spot-check queue size, and what frontier/random split?
-  Too large and nobody opens it; too small and the random arm never reaches
-  significance.
-- Should a proposal with any guard-set regression be blocked from one-click
-  activation and require an explicit override, or is showing the number enough?
-  Leaning toward blocking above a threshold, since the number is easy to skim past.
-- How long should the guard set retain a member before it becomes stale? Codebases
-  move, and a two-year-old decision may no longer be the right baseline.
-- Should triage treat a dispute from someone other than the PR author as
-  `reassess`-eligible on a wider set of reason codes, given the weaker bias?
-- Does the reviewer-side epoch budget need to be policy-configurable, or is a
-  fixed constant adequate given the marker should prevent the loop outright?
-- Should `should_not_have_approved` disputes on already-merged PRs trigger any
-  notification beyond the proposal, given the code is already in main?
+- How big should the weekly spot-check queue be, and what frontier/random split?
+  Too big and nobody opens it; too small and the random arm never says anything.
+- Should guard-set regressions block one-click activation above some threshold and
+  force an explicit override? Leaning yes — a number on screen is easy to skim past.
+- How long should a guard-set member stay valid? Codebases move, and a two-year-old
+  decision may no longer be the right baseline.
+- Should a dispute from someone other than the PR author be `reassess`-eligible on
+  more reason codes, given the weaker bias?
+- Does the bot-loop budget need to be configurable, or is a constant fine given the
+  marker should stop the loop outright?
+- Should a `should_not_have_approved` dispute on an already-merged PR notify anyone
+  beyond creating the proposal?

--- a/docs/design/future/121-code-review-decision-feedback-and-policy-tuning.md
+++ b/docs/design/future/121-code-review-decision-feedback-and-policy-tuning.md
@@ -12,9 +12,15 @@ the highest-signal data the system could collect about its own policy — is
 discarded, and the org never learns which of its rules are actually miscalibrated.
 
 This document proposes a **decision feedback loop**: a first-class way to
-contest a code review decision, a durable record of that contest, corroboration
-against what actually happened to the PR, and an automated engine that turns
-recurring corroborated disputes into concrete, reviewable policy changes.
+contest a code review decision in plain language, a durable record of that
+contest, an automated triage step that can immediately rerun the review when the
+objection carries new information, corroboration against what actually happened
+to the PR, and an engine that turns recurring corroborated disputes into
+concrete, reviewable policy changes.
+
+Disagreeing must cost nothing. There is no command syntax and no form: a
+developer replies to the bot the way they would reply to a human reviewer, and
+143 works out what they meant.
 
 Doc 112 explicitly deferred "automatic policy learning from past approvals" and
 "aggregate reporting/insights across reviews." This document fills both gaps and
@@ -115,6 +121,14 @@ comments, threads, checks, and merge state. For a disputed non-approval:
 | Reverted, or linked to an incident within N days of merge | **Strongly refutes** — feeds the false-approval metric in doc 112 |
 | Still open past the window | **Inconclusive** — expires, never counted |
 
+**Reassessment outcome (automatic, immediate).** When triage reruns the review
+(below) and the rerun approves the same head SHA under the same policy version,
+the original decision was demonstrably wrong on its own terms — the strongest and
+fastest corroboration available, and the only one that does not require waiting
+for the PR to reach a terminal state. A rerun that reaches the same conclusion is
+not by itself a refutation; it is `inconclusive`, because a rerun cannot fix a
+threshold that is genuinely miscalibrated.
+
 **Explicit adjudication (human, authoritative).** A policy owner — not the PR
 author — marks a dispute `upheld` or `rejected`. Adjudication always overrides
 telemetry.
@@ -147,8 +161,11 @@ from reason-code frequency and tune policy by hand.
 
 ### Option B — Structured disputes plus a deterministic auto-tuner
 
-Add a dispute record. When N disputes cluster on the same *deterministic* reason
-code in the same repo, a rules engine proposes a mechanical adjustment —
+Add a dispute record with the same free-text intake as Option C, but no
+reassessment and no agent proposals — the options differ in what happens to a
+dispute, not in how one is filed. When N disputes cluster on the same
+*deterministic* reason code in the same repo, a rules engine proposes a
+mechanical adjustment —
 `files_limit_exceeded` with disputed `Actual` values consistently at 7 against a
 `Limit` of 5 proposes raising the limit to 8.
 
@@ -170,19 +187,28 @@ code in the same repo, a rules engine proposes a mechanical adjustment —
 
 ### Option C — Disputes, corroboration, and agent-authored proposals (recommended)
 
-Capture disputes as first-class records attributed to specific reason codes.
-Corroborate each against PR outcome telemetry and optional human adjudication.
-Cluster the survivors. When a cluster crosses a threshold, a scheduled 143
-session reads the cluster, its evidence, and the current policy, and emits a
-**proposed policy version** with a concrete diff and a rationale citing the
-sessions behind it. An admin reviews and activates it in one click; activation
-creates the next insert-only version and an audit event.
+Capture disagreement as free-text replies, triage it with one LLM pass that
+attributes it to the decision's own reason codes and decides whether a rerun
+could change the answer, and rerun the review when it could. Corroborate each
+dispute against the reassessment outcome, PR outcome telemetry, and optional
+human adjudication. Cluster the survivors. When a cluster crosses a threshold, a
+scheduled 143 session reads the cluster, its evidence, and the current policy,
+and emits a **proposed policy version** with a concrete diff and a rationale
+citing the sessions behind it. An admin reviews and activates it in one click;
+activation creates the next insert-only version and an audit event.
 
 **Pros**
 - Handles both halves: deterministic dimensions get mechanical proposals, prompt
   and rubric text gets agent-authored edits. Judgment reasons become tunable.
+- Two response times. A wrong judgment call is fixed in minutes by a rerun; a
+  wrong policy rule is fixed in the next tuning cycle. Options A and B can only
+  ever do the slow one, which is why they read as unresponsive to the developer
+  who is blocked right now.
 - The corroboration gate means only disputes that reality agreed with can move
   policy.
+- Free-text intake means the feature has no adoption curve — nobody has to learn
+  or remember a command to use it, and objections filed before it shipped are
+  still parseable.
 - Human activation keeps the security boundary intact — the system proposes,
   a person disposes — while removing essentially all of the analysis toil.
 - Reuses infrastructure wholesale: 143 sessions for the proposal agent, the job
@@ -201,6 +227,14 @@ creates the next insert-only version and an audit event.
   activation, this needs the same untrusted-input discipline doc 112 applies to
   PR content: dispute text is written by the people the bot blocked and must be
   treated as evidence, never as instructions.
+- Free-text intake means a classifier decides what counts as a dispute. A missed
+  dispute is silent, which is the failure mode this whole document exists to fix,
+  so triage must bias toward recording. Over-recording is cheap; the routing step
+  and the corroboration gate both filter downstream.
+- Dispute-triggered reruns cost agent time and create a reroll surface. Bounded
+  by the per-head cap and by deterministic gates being non-waivable, but the
+  reassessment-flip rate needs watching: if reruns frequently flip the outcome on
+  identical inputs, the problem is judgment-layer variance, not policy.
 
 ### Option D — Policy-as-code with proposal PRs
 
@@ -283,34 +317,96 @@ detail view:
 Phase 0 alone likely resolves a large share of "I'm not sure why," and every
 later phase depends on the reason-code grouping it introduces.
 
-### Phase 1 — Capture and corroborate
+### Phase 1 — Capture, triage, and corroborate
 
-Two capture surfaces, one record:
+Two capture surfaces, one record, no syntax:
 
-- **GitHub-native (primary).** Reply to the rolling comment with
-  `@143-code-reviewer disagree: <reason>`. The `issue_comment` and
-  `pull_request_review_comment` webhooks are already routed
-  (`internal/api/handlers/webhooks.go`); this adds a command parser. Disputes are
-  filed where the frustration happens, with no context switch.
+- **GitHub-native (primary).** The developer replies in plain language, either
+  in the thread rooted on the bot's rolling comment or by mentioning
+  `@143-code-reviewer` anywhere on a PR the bot reviewed. No command, no prefix,
+  no structured form. "this is test-only, why is it blocked?", "the migration is
+  additive so there's no risk here", and "I think this should have been approved"
+  are all valid disputes. The `issue_comment` and `pull_request_review_comment`
+  webhooks are already routed (`internal/api/handlers/webhooks.go`).
 - **143-native (secondary).** A "Disagree with this decision" action on the code
-  review session detail, with a reason-code multi-select prefilled from the
-  decision's actual blockers. The rolling comment links to it.
+  review session detail opening a free-text box. The reason codes from the actual
+  decision are shown for reference and can optionally be ticked, but nothing is
+  required beyond prose. The rolling comment links here.
 
-Both write `code_review_decision_disputes`, attributed to the session, the policy
-version, the reviewed head SHA, and the specific contested reason codes.
+Both write a `code_review_decision_disputes` row attributed to the session, the
+policy version, and the reviewed head SHA, with `intake_status = 'pending'`.
 
-A light LLM classification pass maps free text to a `dispute_kind`
-(`threshold_too_strict`, `path_rule_too_broad`, `description_requirement_wrong`,
-`finding_incorrect`, `judgment_overreach`, `bot_correct`, `other`). Classification
-is advisory metadata for clustering; it never decides anything on its own.
+Capture is deliberately over-inclusive and triage is where meaning gets assigned.
+It is much better to record a comment that turns out to be a question than to
+drop a real objection because it did not match a pattern.
 
-A scheduled `corroborate_code_review_dispute` job resolves telemetry per the
-table above, once the PR reaches a terminal state or the window expires.
+**Intake and routing.** Every captured comment enqueues
+`triage_code_review_dispute`, a single LLM pass that reads the comment, the
+decision it is responding to, the reason codes that decision emitted, the diff
+summary, and the thread it sits in. It produces:
 
-Ship the `Insights` tab here (Option A's content, plus dispute rate and
-corroboration rate by reason code), and a weekly digest to policy owners over the
-existing notification path — this is the "store the data and send the results"
-half of the ask, and it is independently valuable.
+| Field | Meaning |
+| --- | --- |
+| `is_dispute` | Does this actually contest the decision? Questions, thanks, unrelated chatter, and comments aimed at other bots are not disputes |
+| `contested_reason_codes` | Which of the decision's actual reason codes the objection targets, inferred from prose. Empty when the objection is general |
+| `dispute_kind` | `threshold_too_strict`, `path_rule_too_broad`, `description_requirement_wrong`, `finding_incorrect`, `judgment_overreach`, `bot_correct`, `other` |
+| `asserts_new_information` | Does the comment supply a fact the review did not have — "that path isn't auth-sensitive, it's a fixture", "the generated file is checked in but not executed" |
+| `routing` | `reassess`, `policy_signal_only`, `answer_only`, or `not_a_dispute` |
+
+Routing is the useful part, because the two kinds of objection need opposite
+responses:
+
+- **`reassess`** — the objection asserts new information or contests an
+  agent-judgment reason (`blocking_findings`, `scope_mismatch`,
+  `unresolved_uncertainty`, `architecture`, and the other typed human-review
+  reasons). A rerun can genuinely reach a different conclusion, so triage
+  enqueues one immediately.
+- **`policy_signal_only`** — the objection contests a deterministic gate
+  (`files_limit_exceeded`, `sensitive_path`, `required_check_failing`). Rerunning
+  is pointless: the threshold will evaluate identically. The bot replies saying
+  exactly that, names the policy setting and its current value, links to it, and
+  records the dispute for clustering. This is the honest answer to "why won't you
+  approve this," and it is the case that most needs Phase 2.
+- **`answer_only`** — a question rather than a disagreement. The bot answers from
+  the existing session evidence. No dispute record survives triage.
+- **`not_a_dispute`** — recorded as `discarded`, no reply, no clustering weight.
+
+**Dispute-triggered reassessment.** A `reassess` routing enqueues the normal code
+review request path with a new trigger source `dispute_reassessment`, keyed by
+dispute id. This fits doc 112's existing idempotency model without changing it:
+doc 112 already specifies that a genuinely new explicit request after a
+non-approval creates a distinct assessment even at the same head SHA, and that
+requests arriving while a review is running are held behind a durable starter job.
+A dispute is one more kind of explicit request.
+
+The dispute text enters the reassessment as **untrusted evidence**, under exactly
+the screening doc 112 applies to PR descriptions and diffs. It is a claim by the
+author to be verified against the code, never an instruction. "Approve this" and
+"ignore your policy" are prompt injection, not information, and are handled as
+doc 112 already handles them.
+
+Bounds, so that disputing is cheap but rerolling is not a strategy:
+
+- Deterministic gates are re-evaluated from source on every reassessment and can
+  never be waived by a dispute. Only the agent-judgment half of the decision can
+  move.
+- A configurable cap on dispute-triggered reassessments per PR head SHA
+  (default 2). Beyond it, further disputes are recorded and clustered but do not
+  rerun; the bot says so and points at human review.
+- Approval remains monotonic, and each reassessment remains an immutable session,
+  so the full history of "blocked, disputed, reassessed, approved" is auditable.
+- Reassessments triggered by a dispute are labelled as such in Insights, so a
+  repo where they routinely flip the outcome is visibly a repo with an unreliable
+  judgment layer.
+
+**Corroboration.** A scheduled `corroborate_code_review_dispute` job resolves
+each dispute per the corroboration table once the reassessment settles, the PR
+reaches a terminal state, or the window expires.
+
+Ship the `Insights` tab here (Option A's content, plus dispute rate,
+corroboration rate, and reassessment-flip rate by reason code), and a weekly
+digest to policy owners over the existing notification path — this is the "store
+the data and send the results" half of the ask, and it is independently valuable.
 
 ### Phase 2 — Propose
 
@@ -368,15 +464,27 @@ CREATE TABLE code_review_decision_disputes (
     source                 text NOT NULL CHECK (source IN ('github_comment','app_ui','api')),
     github_comment_id      bigint,
     github_delivery_id     text,
+    github_thread_root_comment_id bigint,
+    -- Verbatim natural-language objection. No command syntax is parsed from it.
     body                   text NOT NULL DEFAULT '',
-    -- Reason codes from the disputed decision that this dispute contests.
+    -- Everything below is inferred by triage, not supplied by the filer.
+    -- The app UI may pre-tick reason codes, but never requires them.
     contested_reason_codes text[] NOT NULL DEFAULT '{}',
     dispute_kind           text CHECK (dispute_kind IS NULL OR dispute_kind IN (
                                'threshold_too_strict','path_rule_too_broad',
                                'description_requirement_wrong','finding_incorrect',
                                'judgment_overreach','bot_correct','other')),
-    classification_status  text NOT NULL DEFAULT 'pending'
-                               CHECK (classification_status IN ('pending','classified','failed','skipped')),
+    asserts_new_information boolean NOT NULL DEFAULT false,
+    routing                text CHECK (routing IS NULL OR routing IN (
+                               'reassess','policy_signal_only','answer_only','not_a_dispute')),
+    intake_status          text NOT NULL DEFAULT 'pending'
+                               CHECK (intake_status IN ('pending','triaged','discarded','failed')),
+    intake_confidence      text CHECK (intake_confidence IS NULL OR intake_confidence IN ('low','medium','high')),
+    -- Reassessment kicked off by this dispute, when routing = 'reassess'.
+    reassessment_session_id uuid REFERENCES sessions(id) ON DELETE SET NULL,
+    reassessment_decision   text,
+    reassessment_flipped    boolean NOT NULL DEFAULT false,
+    reply_comment_id        bigint,
     -- Ground truth. Only 'upheld' or 'corroborated' feed the tuning engine.
     corroboration_status   text NOT NULL DEFAULT 'pending'
                                CHECK (corroboration_status IN (
@@ -391,17 +499,27 @@ CREATE TABLE code_review_decision_disputes (
     updated_at             timestamptz NOT NULL DEFAULT now()
 );
 
--- One dispute per filer per review session; re-filing updates in place.
-CREATE UNIQUE INDEX idx_cr_disputes_session_filer
-    ON code_review_decision_disputes (session_id, COALESCE(filed_by_user_id::text, filed_by_login));
+-- Each GitHub comment yields at most one dispute; webhook redelivery and comment
+-- edits update in place rather than filing a second objection. Deliberately not
+-- unique per (session, filer): one person may raise two distinct objections, and
+-- collapsing them would lose a signal.
+CREATE UNIQUE INDEX idx_cr_disputes_github_comment
+    ON code_review_decision_disputes (github_comment_id) WHERE github_comment_id IS NOT NULL;
 CREATE UNIQUE INDEX idx_cr_disputes_delivery
     ON code_review_decision_disputes (github_delivery_id) WHERE github_delivery_id IS NOT NULL;
 CREATE INDEX idx_cr_disputes_cluster
     ON code_review_decision_disputes (org_id, repository_id, cluster_key, created_at DESC)
     WHERE corroboration_status IN ('corroborated','upheld');
+CREATE INDEX idx_cr_disputes_intake
+    ON code_review_decision_disputes (org_id, intake_status, created_at)
+    WHERE intake_status = 'pending';
 CREATE INDEX idx_cr_disputes_pending
     ON code_review_decision_disputes (org_id, corroboration_status, created_at)
-    WHERE corroboration_status = 'pending';
+    WHERE corroboration_status = 'pending' AND intake_status = 'triaged';
+-- Enforces the per-head reassessment cap without a table scan.
+CREATE INDEX idx_cr_disputes_reassessments
+    ON code_review_decision_disputes (pull_request_id, reviewed_head_sha)
+    WHERE reassessment_session_id IS NOT NULL;
 
 CREATE TABLE code_review_policy_proposals (
     id                   uuid PRIMARY KEY DEFAULT gen_random_uuid(),
@@ -456,18 +574,47 @@ CREATE INDEX idx_cr_outcomes_org_repo ON code_review_decision_outcomes (org_id, 
 CREATE INDEX idx_cr_outcomes_reason_codes ON code_review_decision_outcomes USING gin (reason_codes);
 ```
 
+The reassessment path needs a new trigger source on existing tables:
+
+```sql
+-- internal/models/code_review.go gains CodeReviewTriggerSourceDisputeReassessment.
+ALTER TABLE code_review_session_metadata
+    DROP CONSTRAINT chk_code_review_session_metadata_trigger_source,
+    ADD CONSTRAINT chk_code_review_session_metadata_trigger_source
+        CHECK (trigger_source IN ('app_reviewer','alias_reviewer','team_reviewer',
+                                  'slash_command','auto_policy','dispute_reassessment'));
+
+-- Links a reassessment session back to the objection that caused it.
+ALTER TABLE code_review_session_metadata
+    ADD COLUMN triggering_dispute_id uuid REFERENCES code_review_decision_disputes(id);
+```
+
 New job types on the existing queue:
 
 | Job type | Queue | Trigger |
 | --- | --- | --- |
-| `classify_code_review_dispute` | `feedback` | Dispute created |
-| `corroborate_code_review_dispute` | `feedback` | PR reaches terminal state, or corroboration window expires |
+| `triage_code_review_dispute` | `feedback` | Comment captured on a reviewed PR, or a dispute filed in the app |
+| `run_code_review` (existing) | `agent` | Triage routed `reassess`; enqueued with `trigger_source = 'dispute_reassessment'`, deduped on dispute id |
+| `reply_code_review_dispute` | `feedback` | Triage routed `policy_signal_only` or `answer_only`, or a reassessment completed |
+| `corroborate_code_review_dispute` | `feedback` | Reassessment settles, PR reaches terminal state, or corroboration window expires |
 | `cluster_code_review_disputes` | `feedback` | Scheduled, hourly per org with new corroborated disputes |
 | `generate_code_review_policy_proposal` | `agent` | Cluster crosses threshold |
 | `digest_code_review_insights` | `feedback` | Scheduled, weekly per org |
 
-New audit actions: `code_review_dispute.filed`, `code_review_dispute.adjudicated`,
-`code_review_policy_proposal.activated`, `code_review_policy_proposal.dismissed`.
+Reassessment reuses the existing `run_code_review` handler unchanged; only the
+request-orchestration path in `internal/services/codereview` learns the new
+trigger source and the per-head cap.
+
+Two new policy knobs, versioned with the rest of `code_review_policies`:
+
+| Field | Default | Meaning |
+| --- | --- | --- |
+| `dispute_reassessment_enabled` | `true` | Whether a dispute may rerun the review at all |
+| `max_dispute_reassessments_per_head` | `2` | Cap per PR head SHA before disputes become record-only |
+
+New audit actions: `code_review_dispute.filed`, `code_review_dispute.reassessed`,
+`code_review_dispute.adjudicated`, `code_review_policy_proposal.activated`,
+`code_review_policy_proposal.dismissed`.
 
 ## API Contract
 
@@ -477,13 +624,15 @@ admin-level.
 
 ```
 POST   /api/v1/code-reviews/{session_id}/disputes
-       body:    { "body": string, "contested_reason_codes": string[] }
-       201 ->   CodeReviewDispute
-       errors:  404 review not found · 409 already filed by this user
-                422 reason code not present on the disputed decision
+       body:    { "body": string,                        // required, free text
+                  "contested_reason_codes": string[]? }  // optional hint; triage may override
+       201 ->   CodeReviewDispute   // intake_status "pending"; triage runs async
+       errors:  404 review not found · 422 empty body
+       note:    No 409. Multiple distinct objections on one review are legitimate;
+                only GitHub-sourced disputes dedupe, on comment id.
 
 GET    /api/v1/code-reviews/{session_id}/disputes
-       200 ->   { "data": CodeReviewDispute[] }
+       200 ->   { "data": CodeReviewDispute[] }   // includes routing, reassessment linkage
 
 PATCH  /api/v1/code-review-disputes/{id}            (admin)
        body:    { "corroboration_status": "upheld" | "rejected", "adjudication_note": string? }
@@ -516,10 +665,12 @@ POST   /api/v1/code-review-policy-proposals/{id}/dismiss       (admin)
        200 ->   CodeReviewPolicyProposal
 ```
 
-The GitHub command path adds no route: `@143-code-reviewer disagree: <reason>`
-is parsed in the existing `issue_comment` and `pull_request_review_comment`
-webhook handlers and creates the same record with `source = 'github_comment'`,
-deduplicated on `github_delivery_id`.
+The GitHub path adds no route and parses no syntax. The existing `issue_comment`
+and `pull_request_review_comment` webhook handlers capture replies in the bot's
+rolling-comment thread and comments mentioning the bot on any PR it has reviewed,
+create the record with `source = 'github_comment'` deduplicated on
+`github_delivery_id`, and enqueue triage. Whether a captured comment is a dispute
+at all is decided by triage, not by the handler.
 
 Activation validates the delta against the same policy validation used by
 `PUT /api/v1/code-review-policies`, then writes a new insert-only version. It
@@ -528,8 +679,18 @@ version that produced them.
 
 ## Success Metrics
 
-- Share of non-approvals where the author files a dispute — the miscalibration
-  signal that does not exist today.
+- Share of non-approvals where someone objects — the miscalibration signal that
+  does not exist today. Expect this to rise when intake becomes free-text, which
+  is the feature working, not the bot getting worse.
+- Triage accuracy, sampled by hand: objections recorded as `not_a_dispute` are
+  the silent failure this document exists to prevent, and matter far more than
+  the reverse error.
+- Reassessment flip rate, split by whether the dispute asserted new information.
+  Flips on genuinely new facts are the loop working. Flips on identical inputs
+  mean the judgment layer is non-deterministic, which is a different bug and
+  should be fixed rather than tuned around.
+- Median time from objection to a substantive reply, and to a flipped decision
+  where one occurs — the developer-facing latency this feature is judged on.
 - Corroboration rate of disputes, by reason code. A reason code with a high
   dispute rate *and* high corroboration is a genuinely miscalibrated rule; high
   dispute rate with low corroboration means the explanation is unclear, not the
@@ -544,10 +705,14 @@ version that produced them.
   filed by a third party, or is corroboration sufficient to handle bias alone?
 - What is the right corroboration window? 7 days captures most merges; revert and
   incident signal needs 30.
-- Should filing a dispute trigger an immediate re-review under the same policy
-  (cheap, sometimes resolves flaky judgment reasons), or is that an invitation to
-  reroll until the bot approves? Leaning: no automatic re-review, since approval
-  is monotonic and re-rolling a stochastic judge is exactly the gaming path.
+- Is 2 the right per-head reassessment cap? Too low and a legitimate two-round
+  clarification hits the wall; too high and rerolling becomes viable. Instrument
+  the flip rate by attempt number before settling it.
+- Should a reassessment that flips to approval require the new information to be
+  verifiable in the diff, rather than merely asserted by the author? Stricter and
+  safer, but it narrows the cases a rerun can resolve.
+- Should triage treat a dispute from someone other than the PR author as
+  `reassess`-eligible on a wider set of reason codes, given the weaker bias?
 - Should Insights be org-wide only, or per-repository with its own tuning
   thresholds?
 - Do dismissed proposals suppress the cluster permanently, or decay back after a

--- a/docs/design/future/121-code-review-decision-feedback-and-policy-tuning.md
+++ b/docs/design/future/121-code-review-decision-feedback-and-policy-tuning.md
@@ -22,8 +22,11 @@ This adds a feedback loop:
   rather than going quiet.
 - **Spot-check approvals.** Nobody complains about a PR that sailed through, so
   sample the risky ones and ask a human.
-- **Turn what we learn into policy changes** — mostly edits to the review
-  prompts, each showing what it would have changed before anyone clicks approve.
+- **One rule for changing policy: an admin agreed.** Every other signal ranks the
+  admin's queue rather than deciding anything.
+- **Turn what we learn into policy changes** — edits to the review prompts, each
+  showing what it would have changed before anyone clicks approve. That machinery
+  waits for a volume trigger; until then admins tune by hand from Insights.
 
 Doc 112 deferred both "automatic policy learning" and "aggregate insights." This
 covers both, because insights without a way to disagree only measure the bot's
@@ -83,28 +86,44 @@ A dispute is a claim, not a fact. The evidence rules below keep both traps close
 
 ## What Counts As Evidence
 
-Only two things let a dispute change policy.
+**One rule: a policy owner read the dispute and agreed with it.** Nothing else
+changes policy — not a rerun that flipped, not a clean merge, not a revert three
+weeks later, not a complaint that reads convincingly.
 
-| Qualifies | Applies to | Why |
-| --- | --- | --- |
-| **An admin says it's right** | Both directions | A policy owner looked and agreed. Overrides everything else |
-| **An independent human contradicted the bot** — someone who is neither the author nor the disputer approved a PR we blocked, or left a blocking review on a PR we approved | Both directions | Real human judgment, going against the bot, from someone with nothing at stake in the complaint. `ReviewContext.BlockingHumanReviews` already counts the second case |
-
-Everything else shows up in Insights and changes nothing:
-
-| Doesn't qualify | Why not |
-| --- | --- |
-| A rerun flipped the decision | The PR description can change without the head SHA changing — doc 112 hashes title and body separately for this reason. Someone reading the blocker, improving their description, and getting approved is the system working, not proof the first call was wrong |
-| The PR merged with no blocking review | Usually circular: after a non-approval, a human approving *is* the normal escalation path. It also can't tell a careful review from a rubber stamp, and we don't track branch protection, so it can't rule out self-merge |
-| It got reverted, or caused an incident | Attribution is guesswork and it takes months. Too weak to justify editing a safety control |
-| The disputer isn't an org member | See trust, below |
-
-This bar is deliberately high because nothing sits behind it — there's no
-clustering step, so a single qualifying dispute drafts a proposal. In practice
-most proposals will come from admin adjudication, including spot-check verdicts.
+That's the highest bar available, and it's set there because nothing sits behind
+it: there's no clustering step, so one upheld dispute drafts one proposal.
 **Throughput is limited by admin attention on purpose.** The alternative is more
 proposals than anyone reads properly, which turns the human approval step into a
-rubber stamp.
+rubber stamp. Spot-check verdicts are adjudications too, so the approval direction
+feeds the same gate.
+
+### Why "an independent human contradicted the bot" isn't a second rule
+
+It's the tempting one — someone who is neither the author nor the disputer approved a
+PR we blocked — and it doesn't hold up. When the bot blocks a PR and a teammate
+clicks approve, that approval *is* the escalation path we told them to use. It can't
+tell a careful second look from an unblock-my-colleague rubber stamp, and since we
+don't track branch protection it can't rule out a self-merge with extra steps. On a
+small team, "independent" approvers are the people sitting next to the author. That
+objection sinks every automatic signal we could think of.
+
+### Signals rank the queue instead
+
+Admin attention is the bottleneck, so every other signal earns its keep by deciding
+what an admin sees first. These order the queue and decide nothing:
+
+| Signal | Why it raises rank |
+| --- | --- |
+| An independent human approved a PR we blocked, or left a blocking review on one we approved | Weak as proof, decent as a pointer. `ReviewContext.BlockingHumanReviews` already counts the second case |
+| The rerun ran and didn't flip | The disputer still disagrees and the cheap fix didn't work. A live standoff is worth a human's time |
+| The filer isn't the PR author | Nothing at stake in the complaint, so less of the bias the whole design is guarding against |
+| Repeat disputes against the same reason code in the same repo | One person may be wrong; five in a fortnight is a pattern, and it's the closest thing to clustering we need |
+
+Two things stay out entirely, even as ranking: **reverts and incidents** (attribution
+is guesswork and it arrives months late) and **a rerun that flipped** — the PR
+description can change without the head SHA changing, which is why doc 112 hashes
+title and body separately, so someone reading the blocker, fixing their description,
+and getting approved is the system working rather than proof the first call was wrong.
 
 ### Who gets to influence policy
 
@@ -112,23 +131,28 @@ Capturing a complaint and acting on it are different privileges. Reuse
 `evaluatePRFeedbackEligibility` (`internal/services/github/pr_feedback_policy.go`)
 rather than writing a new eligibility check.
 
-| Who | Recorded | Answered | Can trigger a rerun | Can change policy |
+| Who | Recorded | Answered | Can trigger a rerun | Queued for adjudication |
 | --- | --- | --- | --- | --- |
 | `OWNER` / `MEMBER` / `COLLABORATOR` | yes | yes | yes | yes |
 | Anyone on a private repo | yes | yes | yes | yes |
-| Everyone else, including fork contributors | yes | yes | **no** | **no** |
+| Everyone else, including fork contributors | yes | yes | **no** | **not by default** |
 | Bots | no | no | no | no |
 
 Outside contributors still get recorded, triaged, and answered — silently ignoring
-them is exactly the failure we're fixing — and show up in Insights marked
-untrusted, so if they're consistently right an admin can pull it in deliberately.
-They can't trigger reruns, because a rerun is the expensive action and on a public
-repo an unlimited supply of anonymous people triggering unlimited agent runs is a
-denial-of-service hole. Spending the org's compute is a form of influence.
+them is exactly the failure we're fixing — and show up in Insights marked untrusted,
+so an admin who notices one is consistently right can pull it into the queue
+deliberately. They can't trigger reruns, because a rerun is the expensive action and
+on a public repo an unlimited supply of anonymous people triggering unlimited agent
+runs is a denial-of-service hole. Spending the org's compute is a form of influence.
 
-Bots can't file at all. `evaluatePRFeedbackEligibility` already blocks
-self-authored comments, and a bot arguing with approval policy has no good use
-case.
+**Trust is derived, not frozen.** Store `author_association` as observed and compute
+`trusted` at read time from an org setting, with a per-person and per-dispute admin
+override. The rule above is a default we fully expect to get wrong — the contractor
+with fork-only access who is functionally on the team is a real case — and changing
+a derivation is a deploy while changing a stored boolean is a backfill.
+
+Bots can't file at all. `evaluatePRFeedbackEligibility` already blocks self-authored
+comments, and a bot arguing with approval policy has no good use case.
 
 ## Approach
 
@@ -207,7 +231,14 @@ do about it.
 | `reassess` | Contains new information, or argues with a judgment call. Trusted author, blocked direction only | Rerun the review now |
 | `policy_signal_only` | Argues with a threshold or path rule | A rerun would change nothing — the threshold evaluates the same way every time. Say so, name the setting and its value, link to it, record the dispute |
 | `answer_only` | It's a question, not a disagreement | Answer from the session evidence. No dispute record |
-| `not_a_dispute` | Chatter | Recorded as discarded. No reply, no influence |
+| `not_a_dispute` | Chatter | Recorded as discarded, with a one-line acknowledgement carrying the override link. No influence |
+
+**A wrong `not_a_dispute` produces exactly the silence this doc exists to fix**, so
+it doesn't get to be silent. The acknowledgement is one line — *"noted; if you meant
+to challenge this decision, [say so here]"* — and the link opens the in-app form,
+which files unconditionally, because an explicit human act never needs a classifier's
+permission to count. Triage's worst failure goes from invisible to one click
+recoverable.
 
 A `should_not_have_approved` dispute never reruns. Doc 112 makes approval
 monotonic and we're not touching that — automation must never walk back an
@@ -226,19 +257,27 @@ The dispute text goes in as **untrusted evidence**, screened the same way PR
 descriptions and diffs already are. It's a claim to check against the code, not
 an instruction. "Approve this" is prompt injection, not information.
 
-**No limit on reruns** for trusted authors. A limit wouldn't be a security
-boundary anyway: doc 112 already queues a fresh assessment on every new commit
-until approval, so `git commit --allow-empty && git push` is an unlimited rerun
-path that exists today. Rationing arguments while that stays open buys nothing.
-What actually bounds the risk is that deterministic gates are re-checked from
-source on every rerun and can never be waived by a dispute, untrusted authors
-can't trigger reruns at all, and approval stays monotonic with each rerun its own
-immutable session.
+**No rerun limit as a security control.** A limit wouldn't be one: doc 112 already
+queues a fresh assessment on every new commit until approval, so `git commit
+--allow-empty && git push` is an unlimited rerun path that exists today, and
+rationing arguments while that stays open buys nothing. What actually bounds the
+risk is that deterministic gates are re-checked from source on every rerun and can
+never be waived by a dispute, untrusted authors can't trigger reruns at all, and
+approval stays monotonic with each rerun its own immutable session.
 
-If rerolling until the bot gives in is a worry, the fix isn't here — it's
-judgment variance in doc 112, and the empty-commit path is the one to close.
-Watch flip rate by attempt number: if attempt 2 flips as often as attempt 1 on
-unchanged input, fix the judge rather than ration the reruns.
+**A soft spend budget, though, yes.** The real cost of unlimited reassessment is the
+agent bill — a product problem, not a security one, so it gets a product answer:
+after N reassessments on one PR, stop rerunning and reply with where the argument
+goes next — *"this PR has used its reassessment budget; here's the setting, and
+here's how to ask a human."* A per-org monthly ceiling behind it, surfaced in
+Insights, both numbers org settings so nobody has to guess right the first time.
+Degrading beats blocking because the person still gets an answer, and the outcome to
+avoid is discovering any of this on an invoice.
+
+If rerolling until the bot gives in is a worry, the fix isn't here — it's judgment
+variance in doc 112, and the empty-commit path is the one to close. Watch flip rate
+by attempt number: if attempt 2 flips as often as attempt 1 on unchanged input, fix
+the judge rather than ration the reruns.
 
 ### Don't let the bots talk to each other
 
@@ -267,32 +306,54 @@ fixing — nested by GitHub under the comment they answer, never a chain. The
 rolling comment carries a one-line summary: *"2 objections · 1 rerun ·
 [view](link)"*. Everything else lives on the session.
 
-Corroboration runs as a scheduled job once the rerun settles, the PR closes, or
-the window expires. Ship the **Insights** tab and a weekly digest to policy owners
-in this phase — that's the "store the data and send the results" half, and it's
-worth having on its own.
+Queue ranking runs as a scheduled job once the rerun settles, the PR closes, or the
+window expires. Ship the **adjudication queue**, the **Insights** tab, and a weekly
+digest to policy owners in this phase. That's the whole loop end to end at low
+volume: developers get answers, admins see the pattern and edit policy by hand. It's
+worth having on its own, and it's what tells us whether Phase 2 is warranted.
 
 ## Phase 2 — Propose changes
 
-### One dispute, one proposal
+### Start it on a volume trigger, not a date
 
-No clustering. At realistic review volume, split across repos and reason codes
-and dispute kinds, most clusters would have exactly one member — de-noising would
-throw away the entire signal. Per-dispute also cuts the loop from a month to
-days. If proposal volume ever becomes the complaint, clustering can come later.
+Phase 2 is a proposal generator, a replay harness, and a guard set with a curation
+lifecycle. It's worth building when hand-editing policy is the bottleneck and not
+before — at low volume an admin reading Insights and editing the rubric directly is
+genuinely competitive, and that path already exists.
 
-### Two kinds of proposal
+**Build it when both hold, sustained over two months:** at least **5 upheld disputes
+a month**, and a guard set of **30+ members** with a meaningful share adjudicated
+rather than bootstrapped. Below that an admin is handling about one case a week by
+hand, and a pipeline would be ceremony around a trickle.
 
-- **Prompt changes (the main event).** A 143 session reads the dispute, its
-  review, the findings, and the current prompt text, then proposes a scoped edit
-  to the acceptable-risk rubric or a description requirement. Edits are limited to
-  a named section and can **add or remove** — additions-only would mean the rubric
-  can only ever grow and a genuinely wrong rule could never be deleted. Dispute
-  text enters as untrusted evidence.
-- **Threshold changes (secondary).** A rules engine computes limit, path,
-  category, check, and author-eligibility changes straight from the recorded
-  actual-vs-limit values. No LLM. Bounded by admin ceilings, and widens a path or
-  category set by at most one entry at a time.
+Waiting is cheap because Phase 1 produces the inputs: the wait is spent gathering the
+data that says what shape a proposal should take, including the real distribution of
+`dispute_kind`, which we're currently guessing. **Spot-checking shouldn't wait** —
+it's a scheduled job and a queue, it yields the false-approval rate on its own, and
+it's the source of curated guard members. Ship it in Phase 1 if there's room.
+
+That same low volume is why there's **no clustering**: one upheld dispute drafts one
+proposal. Split across repos, reason codes, and dispute kinds, most clusters would
+have exactly one member, so de-noising would throw away the entire signal — and
+per-dispute cuts the loop from a month to days. If proposal volume ever becomes the
+complaint, clustering can come later.
+
+### Proposals change prompts, and only prompts
+
+A 143 session reads the dispute, its review, the findings, and the current prompt
+text, then proposes a scoped edit to the acceptable-risk rubric or a description
+requirement. Edits are limited to a named section and can **add or remove** —
+additions-only would mean the rubric can only ever grow and a genuinely wrong rule
+could never be deleted. Dispute text enters as untrusted evidence.
+
+**Thresholds are not proposed at all.** An earlier draft added a second,
+deterministic generator for limits, path rules, categories, checks, and author
+eligibility; it's cut. The Approach section argues thresholds are the lever that
+matters least, and a whole second generator for the least important lever — one that
+then has to stay consistent with the first — is the wrong trade. Insights already
+knows the numbers: *"11 non-approvals this month tripped the 5-file limit; median was
+6."* Show that with a deep link to the setting and let the admin type a 7. One
+generator, one replay path, and the arithmetic stays a chart rather than a subsystem.
 
 ### Replay is what makes review real
 
@@ -311,14 +372,25 @@ prompts feed the orchestrator, `code_review_agent_results` already stores each
 reviewer's raw and structured output, and doc 112 requires rendered prompts to be
 recoverable. So replay reruns **only the orchestrator step against stored reviewer
 output** — no sandboxes, no clones, no fan-out. One cheap call per historical
-review, 20–30 per proposal. Threshold proposals replay exactly and offline via
-`EvaluateCodeReviewRisk` against stored inputs.
+review, 20–30 per proposal.
 
-**Seeding the guard set.** Day one has no corpus of known-good decisions.
-Bootstrap from decisions that merged with no blocking human review — weak
-individually, but a regression baseline is a lower bar than evidence that changes
-policy — then curate from spot-check verdicts, which are real judgments. The guard
-set doubles as a small eval corpus, giving doc 16 something to build on.
+**Seeding the guard set, and not trusting it yet.** Day one has no corpus of
+known-good decisions, so bootstrap from decisions that merged with no blocking human
+review, then curate from spot-check verdicts, which are real judgments.
+
+Those bootstrapped members carry a label this doc rejects everywhere else, and it's
+wrong in one specific direction: a bad approval that merged quietly enters the set
+marked correct. Replay a proposal that rightly *tightens* policy against it and the
+proposal is charged with a regression for fixing the thing we wanted fixed. Early
+guard numbers therefore run pessimistic against tightening, and that bias doesn't
+average out with more members — only with better-labelled ones.
+
+So **guard regressions are advisory until the set holds 30+ members added by
+`spot_check` or `admin`**, with composition shown beside the count — *"3 regressions ·
+12 of 40 members adjudicated."* After that they can gate. Gating on a bootstrapped set
+would block good tightening on mislabels, admins would learn to override, and an
+override people always click is worth less than no gate. The guard set doubles as a
+small eval corpus, giving doc 16 something to build on.
 
 ### Spot-checking approvals
 
@@ -340,9 +412,11 @@ is worthless and there's no other way to learn that. The random arm also gives a
 unbiased false-approval rate — doc 112's headline safety metric, currently
 uncomputable.
 
-Keep the queue to a few minutes a week. A "shouldn't have been approved" verdict
-writes an already-adjudicated dispute in that direction, which qualifies — so
-spot-checking needs no new evidence rule, it just finds cases for one we have.
+Keep the queue to a few minutes a week. A "shouldn't have been approved" verdict is
+an admin adjudication, so it writes a dispute that's already upheld — spot-checking
+needs no evidence rule of its own, it just manufactures cases for the one rule we
+have. A "correct" verdict adds the session to the guard set as a curated member,
+which is the other reason to start spot-checking early.
 
 ### Guardrails
 
@@ -368,41 +442,50 @@ is `org_id` throughout. Only the distinctive columns are listed.
 | `session_id`, `pull_request_id`, `repository_id`, `policy_id` | uuid NOT NULL | FKs; session/PR cascade on delete |
 | `reviewed_head_sha`, `decision` | text NOT NULL | What was being disputed |
 | `direction` | text NOT NULL | `should_have_approved` \| `should_not_have_approved` |
-| `filed_by_user_id`, `filed_by_login`, `author_association`, `author_is_pr_author` | uuid / text / bool | Filer identity |
-| `trusted` | boolean NOT NULL | Gates both reruns and policy influence |
+| `filed_by_user_id`, `filed_by_login`, `author_association`, `author_is_pr_author` | uuid / text / bool | Filer identity. `author_association` is stored as observed; trust is derived from it at read time, never stored as a verdict |
+| `trust_override` | boolean | Admin escape hatch. NULL means "use the org rule" |
 | `source` | text NOT NULL | `github_comment` \| `app_ui` \| `api` \| `spot_check` |
 | `github_comment_id`, `github_delivery_id`, `github_thread_root_comment_id`, `reply_comment_id` | bigint / text | Dedupe, threading, and the one reply |
 | `body` | text NOT NULL | Verbatim. No syntax is parsed from it |
 | `contested_reason_codes` | text[] | Inferred by triage |
-| `dispute_kind` | text | `threshold_too_strict`, `path_rule_too_broad`, `description_requirement_wrong`, `finding_incorrect`, `judgment_overreach`, `threshold_too_lenient`, `path_rule_too_narrow`, `missed_finding`, `judgment_underreach`, `bot_correct`, `other` |
+| `dispute_kind` | text | **Free text from triage, no constraint.** See below |
 | `asserts_new_information` | boolean NOT NULL | Drives the `reassess` route |
 | `routing` | text | `reassess` \| `policy_signal_only` \| `answer_only` \| `not_a_dispute` |
 | `intake_status`, `intake_confidence` | text | `pending` \| `triaged` \| `discarded` \| `failed` |
 | `reassessment_session_id`, `reassessment_decision`, `reassessment_flipped` | uuid / text / bool | Rerun linkage |
-| `corroboration_status` | text NOT NULL | `pending` \| `independent_contradiction` \| `upheld` \| `rejected` \| `weak` \| `inconclusive`. Only the middle two qualify, and only when `trusted` |
-| `corroboration_detail` | jsonb | Which signal fired, and its inputs |
-| `adjudicated_by_user_id`, `adjudicated_at`, `adjudication_note` | uuid / timestamptz / text | Admin verdict |
+| `adjudication_status` | text NOT NULL | `pending` \| `upheld` \| `rejected` \| `expired`. `upheld` is the only thing that drafts a proposal |
+| `adjudicated_by_user_id`, `adjudicated_at`, `adjudication_note` | uuid / timestamptz / text | Who decided, and why |
+| `queue_signals` | jsonb | The ranking signals observed on this dispute, with their inputs |
+| `queue_priority` | numeric | Derived from `queue_signals`; orders the admin queue and decides nothing |
+
+`dispute_kind` is **deliberately unconstrained**. An enum here would be a dozen
+guesses about a distribution we haven't observed, frozen into the least flexible part
+of the system — categories we invented rather than ones we saw. Triage writes a short
+slug, Insights charts the frequencies, and the values that turn out to be real get
+promoted to a constraint later. `direction` and `contested_reason_codes` stay
+structured; those we actually know.
 
 Indexes: unique on `github_comment_id` and on `github_delivery_id` (both partial,
 `WHERE NOT NULL`) so redelivery and edits update in place — deliberately *not*
 unique per `(session, filer)`, since one person may raise two genuinely different
-objections. Partial index on `intake_status = 'pending'`; partial on
-`(org_id, corroboration_status)` where triaged and pending; partial on
-`(org_id, repository_id, direction, corroborated_at DESC)` where `trusted` and
-the status qualifies, to find disputes awaiting a proposal.
+objections. Partial index on `intake_status = 'pending'`; partial on `(org_id,
+repository_id, queue_priority DESC)` where `adjudication_status = 'pending'` and
+triage kept it, to build the admin queue; partial on `(org_id, adjudicated_at DESC)`
+where `upheld`, to find disputes awaiting a proposal.
 
 **`code_review_policy_proposals`** — one row per proposal. `repository_id`,
 `base_policy_id`, and `source_dispute_id` (uuid; exactly one, no clustering);
-`direction` (`loosen` | `tighten`); `change_kind` (`prompt` | `deterministic`);
-`origin` (`deterministic_rule` | `agent_session` | `manual`) with
-`generator_session_id`; `status` (`replaying` | `open` | `activated` |
-`dismissed` | `superseded` | `expired`); `proposed_changes jsonb NOT NULL` — a
-structured validated delta, never a raw config replacement; `rationale text NOT
-NULL` citing its dispute and review; `replay_status`, `replay_target_result
-jsonb`, `replay_guard_result jsonb`, `guard_regressions int`; and the outcome
-columns `activated_policy_id`, `decided_by_user_id`, `decided_at`,
-`decision_note`. Unique index on `source_dispute_id` where status is `replaying`
-or `open`; plus `(org_id, status, created_at DESC)`.
+`direction` (`loosen` | `tighten`); `origin` (`agent_session` | `manual`) with
+`generator_session_id`; `status` (`replaying` | `open` | `activated` | `dismissed` |
+`superseded` | `expired`); `proposed_changes jsonb NOT NULL` — a structured validated
+prompt-section delta, never a raw config replacement; `rationale text NOT NULL`
+citing its dispute and review; `replay_status`, `replay_target_result jsonb`,
+`replay_guard_result jsonb`, `guard_regressions int`, and `guard_set_size` /
+`guard_set_adjudicated int` so a reader can tell a meaningful regression count from a
+provisional one; and the outcome columns `activated_policy_id`, `decided_by_user_id`,
+`decided_at`, `decision_note`. There's no `change_kind` — every proposal is a prompt
+edit. Unique index on `source_dispute_id` where status is `replaying` or `open`; plus
+`(org_id, status, created_at DESC)`.
 
 **`code_review_approval_audits`** — the spot-check queue. `session_id`,
 `repository_id`, `pull_request_id`, `policy_id` identify the approval under
@@ -419,9 +502,9 @@ where queued.
 `added_by` (`bootstrap` \| `spot_check` \| `admin`), `active boolean`.
 
 **`code_review_decision_outcomes`** — denormalized per-decision facts, keyed by
-`session_id` as PK, so Insights and corroboration don't re-derive PR history on
-every read. Carries `decision`, `reason_codes text[]` (GIN indexed), `merged`,
-`merged_at`, `independent_approver_login`, `independent_blocking_review_login`,
+`session_id` as PK, so Insights and queue ranking don't re-derive PR history on every
+read. Carries `decision`, `reason_codes text[]` (GIN indexed), `merged`, `merged_at`,
+`independent_approver_login`, `independent_blocking_review_login`,
 `human_review_comment_count`, `reverted`, `terminal`, `observed_until`.
 
 **Changes to existing tables:**
@@ -455,15 +538,18 @@ ALTER TABLE pull_requests
 | --- | --- | --- |
 | `triage_code_review_dispute` | `feedback` | A comment is captured, or a dispute is filed in-app |
 | `run_code_review` (existing) | `agent` | Triage routed `reassess`; deduped on dispute id |
-| `reply_code_review_dispute` | `feedback` | Triage routed `policy_signal_only` / `answer_only`, or a rerun finished |
-| `corroborate_code_review_dispute` | `feedback` | Rerun settles, PR closes, or the window expires |
-| `generate_code_review_policy_proposal` | `agent` | A dispute qualifies |
+| `reply_code_review_dispute` | `feedback` | Triage routed `policy_signal_only` / `answer_only` / `not_a_dispute`, or a rerun finished |
+| `rank_code_review_dispute` | `feedback` | Rerun settles, PR closes, or the window expires. Recomputes `queue_signals` and `queue_priority` |
+| `generate_code_review_policy_proposal` | `agent` | An admin upholds a dispute |
 | `replay_code_review_policy_proposal` | `agent` | Proposal created |
 | `sample_code_review_approvals` | `feedback` | Weekly per org |
 | `digest_code_review_insights` | `feedback` | Weekly per org |
 
 Reruns reuse the existing `run_code_review` handler unchanged; only request
-orchestration learns the new trigger source and the trust gate.
+orchestration learns the new trigger source, the trust gate, and the reassessment
+budget. The budget needs no new columns — per-PR spend is a count of sessions with
+`trigger_source = 'dispute_reassessment'`, and the org ceiling is the same count over
+a month.
 
 **Audit actions:** `code_review_dispute.filed`, `.reassessed`, `.adjudicated`,
 `code_review_approval_audit.reviewed`,
@@ -478,10 +564,11 @@ adjudication, spot-check verdicts, and proposal decisions are admin-level.
 | --- | --- | --- |
 | `POST /api/v1/code-reviews/{session_id}/disputes` | `{ body: string, contested_reason_codes?: string[] }` | `201` dispute with `intake_status: "pending"`. `422` if body empty, `404` if no such review. **No 409** — several distinct objections on one review are legitimate; only GitHub-sourced ones dedupe, on comment id. Direction is inferred, never supplied |
 | `GET /api/v1/code-reviews/{session_id}/disputes` | — | Disputes with routing, trust, and rerun linkage |
-| `PATCH /api/v1/code-review-disputes/{id}` *(admin)* | `{ corroboration_status: "upheld"\|"rejected", adjudication_note? }` | Updated dispute. `409` if already adjudicated |
+| `GET /api/v1/code-review-disputes` *(admin)* | `adjudication_status?`, `repository_id?`, `direction?` | The adjudication queue, ordered by `queue_priority`, each dispute showing which signals raised it |
+| `PATCH /api/v1/code-review-disputes/{id}` *(admin)* | `{ adjudication_status: "upheld"\|"rejected", adjudication_note?, trust_override? }` | Updated dispute. `upheld` enqueues proposal generation. `409` if already adjudicated |
 | `GET /api/v1/code-review-approval-audits` *(admin)* | `status?`, `repository_id?` | Spot-check queue. `selection` is **omitted while queued** — the random control only works if the reviewer can't see the arm |
 | `POST /api/v1/code-review-approval-audits/{id}/verdict` *(admin)* | `{ verdict: "correct"\|"should_not_have_approved", note? }` | `should_not_have_approved` creates an already-upheld dispute; `correct` adds the session to the guard set |
-| `GET /api/v1/code-review-insights` | `repository_id?`, `from?`, `to?`, `decision?`, `reason_code?`, `direction?` | Decisions and dispute rate by reason code; totals; disputes by direction; flip rate by attempt; `spot_check` (frontier vs random hit rate, false-approval rate); median decision time; per-policy-version decision mix |
+| `GET /api/v1/code-review-insights` | `repository_id?`, `from?`, `to?`, `decision?`, `reason_code?`, `direction?` | Decisions and dispute rate by reason code, with actual-vs-limit distributions and a deep link to each setting — this is what admins tune from before Phase 2 exists; totals; disputes by direction; **`dispute_kind` frequencies**, the input to eventually constraining that column; flip rate by attempt; reassessment spend against budget; `spot_check` (frontier vs random hit rate, false-approval rate); median decision time; per-policy-version decision mix |
 | `GET /api/v1/code-review-policy-proposals` | `status?`, `repository_id?`, `direction?` | Proposals including replay results |
 | `POST /api/v1/code-review-policy-proposals/{id}/activate` *(admin)* | `{ proposed_changes? }` (optional edited delta) | New policy + proposal. `409` if not open, replay incomplete, or base policy superseded; `422` invalid delta; `403` touches a locked dimension |
 | `POST /api/v1/code-review-policy-proposals/{id}/dismiss` *(admin)* | `{ decision_note }` | Updated proposal |
@@ -508,9 +595,15 @@ approvals keep pointing at the version that produced them.
   worthless, and this is the only way to find that out.
 - **False approval rate** from the random arm — unbiased, and doc 112's headline
   safety metric.
-- **Guard-set regressions per activated proposal.** How often a change broke
-  decisions that were right; the number that says whether one-click activation is
-  safe.
+- **Guard-set regressions per activated proposal**, always read next to the set's
+  adjudicated share. How often a change broke decisions that were right; the number
+  that says whether one-click activation is safe, and it means little until the set
+  is mostly curated.
+- **Upheld disputes per month**, the Phase 2 volume trigger. Also the number that
+  tells us whether hand-tuning from Insights was enough all along.
+- **Reassessment spend per PR and per org.** Hitting the budget is a product signal
+  and not just a bill — a PR that exhausts it is an argument the loop couldn't
+  settle.
 - **Flip rate by rerun attempt.** Flips on new information mean the loop works;
   flips on unchanged input mean judgment variance, a different bug.
 - **Time from objection to a real reply**, and to a flipped decision.
@@ -520,8 +613,8 @@ approvals keep pointing at the version that produced them.
 
 - How big should the weekly spot-check queue be, and what frontier/random split?
   Too big and nobody opens it; too small and the random arm never says anything.
-- Should guard-set regressions block one-click activation above some threshold and
-  force an explicit override? Leaning yes — a number on screen is easy to skim past.
+- What are the starting numbers for the reassessment budget — per PR and per org per
+  month? Cheap to change, but the first guess sets the tone.
 - How long should a guard-set member stay valid? Codebases move, and a two-year-old
   decision may no longer be the right baseline.
 - Should a dispute from someone other than the PR author be `reassess`-eligible on

--- a/docs/design/future/121-code-review-decision-feedback-and-policy-tuning.md
+++ b/docs/design/future/121-code-review-decision-feedback-and-policy-tuning.md
@@ -1,0 +1,554 @@
+# Design: Code Review Decision Feedback And Policy Tuning
+
+> **Status:** Not Started | **Last reviewed:** 2026-07-29
+>
+> **Depends on:** [../implemented/112-code-reviewer-bot-auto-approval.md](../implemented/112-code-reviewer-bot-auto-approval.md), [../backlog/11-review-feedback-loop.md](../backlog/11-review-feedback-loop.md), [../future/18-fix-quality-feedback.md](18-fix-quality-feedback.md), [../future/116-automatic-pr-feedback-follow-through.md](116-automatic-pr-feedback-follow-through.md)
+
+## Summary
+
+The 143 Code Reviewer decides; nobody can argue with it. When the bot withholds
+approval, the PR author's only recourse is "ask a human." That disagreement —
+the highest-signal data the system could collect about its own policy — is
+discarded, and the org never learns which of its rules are actually miscalibrated.
+
+This document proposes a **decision feedback loop**: a first-class way to
+contest a code review decision, a durable record of that contest, corroboration
+against what actually happened to the PR, and an automated engine that turns
+recurring corroborated disputes into concrete, reviewable policy changes.
+
+Doc 112 explicitly deferred "automatic policy learning from past approvals" and
+"aggregate reporting/insights across reviews." This document fills both gaps and
+treats them as one system, because insights without a dispute channel measure
+only the bot's own opinion of itself.
+
+## Problem
+
+### What works today
+
+The decision path is already better instrumented than most review bots:
+
+- Every non-approval is attributable to typed `CodeReviewRiskReasonCode` values
+  (`internal/models/code_review.go`), and numeric reasons carry `Actual` and
+  `Limit` alongside the code.
+- The rolling PR comment renders `**Why:**`, `**Policy blockers:**`,
+  `**Blocking findings:**`, and `**Next steps:**`
+  (`internal/models/code_review_output.go`).
+- Policies are insert-only and versioned, and every session captures the policy
+  id, rendered prompts, and reviewed head SHA. Decisions are auditable after
+  the fact.
+
+The raw material for a feedback loop already exists. What is missing is the loop.
+
+### Why "people aren't sure why"
+
+Five concrete gaps, each independently fixable:
+
+1. **Blockers of different kinds are rendered identically.** `files_limit_exceeded`
+   (an objective policy threshold), `blocking_findings` (a model's code judgment),
+   and `architecture` (a model's judgment that a human should weigh in) all appear
+   as bullets under `**Policy blockers:**`. The author cannot tell which lever
+   would change the outcome: edit the policy, argue with the finding, or accept
+   that a human must look. "I don't know why" is usually "I don't know who to
+   ask or what to change."
+
+2. **No counterfactual.** The comment lists what blocked. It never says what
+   *unblocking* would take, or that a single blocker was the only one. "Would
+   have been approved except for one threshold" and "blocked on eleven separate
+   things" read the same.
+
+3. **Advisory findings are a bare count.** P2/P3 observations appear as
+   "N non-blocking observations available in the full review." A reader who
+   cannot see them cannot confirm they were correctly classified as non-blocking,
+   which reads as withholding rather than as concision.
+
+4. **System faults look like the PR's fault.** `context_unavailable` and
+   `orchestrator_synthesis_invalid` mean 143 failed, not that the change is
+   risky. There is partial special-casing for the orchestrator case, but a
+   context-fetch failure still lands in the same blocker list as a genuine
+   policy violation.
+
+5. **Deterministic gates run last.** `EvaluateCodeReviewRisk` is called after
+   reviewer fan-out and orchestrator synthesis
+   (`internal/worker/code_review_handler.go`). A PR that trips `max_files_changed`
+   waits for a full multi-agent review to be told a fact that was knowable from
+   the PR file list in one API call.
+
+### Why the org can't fix it either
+
+Doc 112 lists "Top non-approval reasons, used to tune PR templates and readiness
+checks" as a success metric. That metric is not computable today: there is no
+aggregate surface, and the `Code reviews` page ships only `Reviews` and
+`Configurations` tabs. `POST /api/v1/code-reviews/policy-events` records *policy
+editing* telemetry (which config sections admins opened), not decision outcomes.
+
+So an admin asking "is our policy too strict?" has no data, and a developer who
+believes the bot was wrong has nowhere to put that belief. The result is the
+reported failure mode: silent frustration, no correction, eroding trust in the
+signal.
+
+### The trap to avoid
+
+The naive version of this feature — "let people flag bad decisions, then loosen
+the policy where flags pile up" — is worse than nothing. The person most likely
+to file a dispute is the author whose PR was blocked, i.e. the single most biased
+available judge, and the thing they are disputing is a *security and quality
+control*. A system that automatically relaxes its approval criteria in response
+to complaints from the people it blocked is gameable by construction, and the
+gaming does not even have to be deliberate.
+
+**A dispute is a claim, not a fact.** Every option below is evaluated on how it
+establishes ground truth before acting.
+
+## Corroboration: establishing ground truth
+
+Two independent signals, both already available, decide whether a dispute was
+right:
+
+**Outcome telemetry (automatic, unbiased).** 143 already syncs PR reviews,
+comments, threads, checks, and merge state. For a disputed non-approval:
+
+| Observed outcome | Reading |
+| --- | --- |
+| Merged with no human requested-changes and no substantive human review comments | **Corroborates** — a human reviewer saw nothing the bot should have blocked on |
+| A human subsequently requested changes, or blocking comments landed | **Refutes** — the bot's caution was warranted |
+| Closed without merge | **Refutes** (weakly) |
+| Reverted, or linked to an incident within N days of merge | **Strongly refutes** — feeds the false-approval metric in doc 112 |
+| Still open past the window | **Inconclusive** — expires, never counted |
+
+**Explicit adjudication (human, authoritative).** A policy owner — not the PR
+author — marks a dispute `upheld` or `rejected`. Adjudication always overrides
+telemetry.
+
+Only `upheld` disputes and `corroborated` telemetry feed the tuning engine.
+Disputes from the PR author corroborated by nothing are visible in Insights and
+inert everywhere else. This single rule is what makes the loop safe.
+
+## Options
+
+### Option A — Insights surface only, manual tuning
+
+Add the deferred `Insights` tab. Aggregate existing decision data by repository,
+reason code, decision, and time. No dispute object; admins infer miscalibration
+from reason-code frequency and tune policy by hand.
+
+**Pros**
+- Smallest change: read-only queries over `code_review_session_metadata` and
+  existing reason details, one new tab, no schema beyond indexes.
+- Makes doc 112's stated success metrics computable for the first time.
+- No new trust surface, no LLM in the loop, nothing to game.
+- Ships in days and is a strict prerequisite for every other option.
+
+**Cons**
+- Measures only what the bot already believes. Frequency is not error: the top
+  reason code is probably `blocking_findings`, which may be entirely correct.
+- Does not give the frustrated developer anywhere to put their disagreement, so
+  it does not address the reported problem.
+- Manual tuning depends on an admin noticing, caring, and acting.
+
+### Option B — Structured disputes plus a deterministic auto-tuner
+
+Add a dispute record. When N disputes cluster on the same *deterministic* reason
+code in the same repo, a rules engine proposes a mechanical adjustment —
+`files_limit_exceeded` with disputed `Actual` values consistently at 7 against a
+`Limit` of 5 proposes raising the limit to 8.
+
+**Pros**
+- Fully explainable and unit-testable; the tuner is arithmetic over data the
+  reason codes already carry in `Actual`/`Limit`.
+- No LLM anywhere in the approval-policy path.
+- Maps cleanly onto insert-only policy versioning: each adjustment is a new version.
+
+**Cons**
+- Covers only the mechanical dimensions. The judgment reasons — `scope_mismatch`,
+  `unresolved_uncertainty`, `architecture`, `blocking_findings` — are where
+  disagreement actually concentrates, and none of them are tunable by arithmetic.
+  They need prompt and rubric changes.
+- Threshold ratcheting is the exact failure mode described above: repeated
+  disputes monotonically loosen limits, and each individual step looks reasonable.
+- Deterministic thresholds are the rules teams are *most* able to set correctly
+  by hand, so this automates the easy half and leaves the hard half untouched.
+
+### Option C — Disputes, corroboration, and agent-authored proposals (recommended)
+
+Capture disputes as first-class records attributed to specific reason codes.
+Corroborate each against PR outcome telemetry and optional human adjudication.
+Cluster the survivors. When a cluster crosses a threshold, a scheduled 143
+session reads the cluster, its evidence, and the current policy, and emits a
+**proposed policy version** with a concrete diff and a rationale citing the
+sessions behind it. An admin reviews and activates it in one click; activation
+creates the next insert-only version and an audit event.
+
+**Pros**
+- Handles both halves: deterministic dimensions get mechanical proposals, prompt
+  and rubric text gets agent-authored edits. Judgment reasons become tunable.
+- The corroboration gate means only disputes that reality agreed with can move
+  policy.
+- Human activation keeps the security boundary intact — the system proposes,
+  a person disposes — while removing essentially all of the analysis toil.
+- Reuses infrastructure wholesale: 143 sessions for the proposal agent, the job
+  queue for clustering, insert-only policies for versioning, the audit log for
+  attribution, notifications for the digest.
+- Proposals carry evidence, so the review is genuinely reviewable rather than a
+  rubber stamp.
+
+**Cons**
+- The largest build: capture surfaces, schema, corroboration job, clustering,
+  proposal agent, review UI, digest.
+- Proposal quality depends on cluster quality; thin clusters produce noisy
+  proposals and admins learn to ignore the queue. Thresholds must start
+  conservative.
+- Introduces an agent that writes approval policy. Even gated behind human
+  activation, this needs the same untrusted-input discipline doc 112 applies to
+  PR content: dispute text is written by the people the bot blocked and must be
+  treated as evidence, never as instructions.
+
+### Option D — Policy-as-code with proposal PRs
+
+Same capture and corroboration as C, but the policy lives in the repository
+(`.143/code-review-policy.yml`) and proposals arrive as ordinary pull requests,
+following the `.143/learned-conventions.md` pattern from doc 11.
+
+**Pros**
+- Policy changes get the team's real review process, CODEOWNERS, and git history
+  for free — a strong fit for a control that governs approvals.
+- Fully transparent and diffable; the same reviewers who care about the rules
+  are the ones who see changes to them.
+- No new approval UI to build.
+
+**Cons**
+- Forks the source of truth. Today policy is DB-owned, versioned, and resolvable
+  with org-default plus repo-override inheritance; a repo file needs sync,
+  conflict, and precedence rules against that model, and doc 112's requirement
+  that approvals point at the exact policy version that produced them becomes
+  harder to guarantee.
+- Repo-scoped files cannot express org-level defaults inherited by repositories
+  that have no override.
+- A PR proposing to loosen the reviewer bot's own approval rules is exactly the
+  category doc 112 says the bot must not approve — workable, but it needs an
+  explicit carve-out.
+- Slower loop: policy edits now require a merge.
+
+Worth revisiting once policy stabilizes, and a reasonable later export path. Not
+the right first move.
+
+### Rejected — Fully autonomous closed-loop adaptation
+
+C or D with automatic activation and metric-triggered rollback.
+
+Rejected on principle rather than on effort. Approval policy is a security
+control; an automated system that relaxes its own controls in response to
+pressure from blocked authors is unsound regardless of how good the rollback is,
+and "reverts within 7 days" is far too slow a feedback signal for a gate whose
+failure mode is unreviewed code reaching main. Doc 112's product principle —
+*approval requires evidence* — applies to changes in what counts as evidence.
+
+If a team eventually wants some of this, the defensible bounded form is: admin
+pre-authorizes auto-application for named low-risk dimensions only (e.g. line
+thresholds, within an admin-set ceiling, on repos with no sensitive paths), never
+for path rules, sensitive categories, required checks, agent roster, or prompt
+text. That is a later configuration option on top of C, not a different design.
+
+## Recommendation
+
+Ship **Option C**, in three phases, and do the transparency fixes in Phase 0
+because they reduce disputes at the source rather than processing them better.
+
+The phases stand alone. Each is useful if the next never ships.
+
+### Phase 0 — Make the decision legible (no new subsystem)
+
+Changes to `internal/models/code_review_output.go`, the worker, and the session
+detail view:
+
+1. **Group blockers by lever.** Render three labelled groups instead of one list:
+   *Policy thresholds* (deterministic, tunable in Configurations — deep-link to
+   the exact setting), *Review findings* (agent code judgment, contestable),
+   *Human judgment required* (typed non-finding reasons). Derive grouping from
+   the existing `CodeReviewRiskReasonCode` — no new taxonomy.
+2. **State the counterfactual.** When exactly one blocker exists, say so:
+   "This is the only blocker. Resolving it would make this PR eligible for
+   automated approval under policy vN." Requires no new computation; the
+   evaluator already has the full reason list.
+3. **Separate system faults from risk.** Give `context_unavailable` and
+   `orchestrator_synthesis_invalid` a distinct rendering — 143 could not complete
+   the review — and keep them out of the policy-blocker list entirely.
+4. **Expose advisory findings.** Put P2/P3 observations in a collapsed
+   `<details>` block on the rolling comment instead of a count. They remain
+   non-blocking and still generate no inline comments.
+5. **Fast-fail deterministic gates.** Evaluate size, path, author, and fork
+   eligibility from the PR file list *before* reviewer fan-out. If policy makes
+   the PR categorically ineligible, post the result immediately and skip the
+   agent run. Cuts cost and turns a multi-minute wait into seconds.
+
+Phase 0 alone likely resolves a large share of "I'm not sure why," and every
+later phase depends on the reason-code grouping it introduces.
+
+### Phase 1 — Capture and corroborate
+
+Two capture surfaces, one record:
+
+- **GitHub-native (primary).** Reply to the rolling comment with
+  `@143-code-reviewer disagree: <reason>`. The `issue_comment` and
+  `pull_request_review_comment` webhooks are already routed
+  (`internal/api/handlers/webhooks.go`); this adds a command parser. Disputes are
+  filed where the frustration happens, with no context switch.
+- **143-native (secondary).** A "Disagree with this decision" action on the code
+  review session detail, with a reason-code multi-select prefilled from the
+  decision's actual blockers. The rolling comment links to it.
+
+Both write `code_review_decision_disputes`, attributed to the session, the policy
+version, the reviewed head SHA, and the specific contested reason codes.
+
+A light LLM classification pass maps free text to a `dispute_kind`
+(`threshold_too_strict`, `path_rule_too_broad`, `description_requirement_wrong`,
+`finding_incorrect`, `judgment_overreach`, `bot_correct`, `other`). Classification
+is advisory metadata for clustering; it never decides anything on its own.
+
+A scheduled `corroborate_code_review_dispute` job resolves telemetry per the
+table above, once the PR reaches a terminal state or the window expires.
+
+Ship the `Insights` tab here (Option A's content, plus dispute rate and
+corroboration rate by reason code), and a weekly digest to policy owners over the
+existing notification path — this is the "store the data and send the results"
+half of the ask, and it is independently valuable.
+
+### Phase 2 — Propose
+
+A scheduled clustering job groups `upheld` and `corroborated` disputes by
+`(org, repository, reason_code, dispute_kind)`. Clusters crossing a configurable
+threshold (default: 3 corroborated disputes within 30 days) create a
+`code_review_policy_proposals` row.
+
+Proposal generation is split by reason kind:
+
+- **Deterministic reasons** — a rules engine computes the change directly from
+  `Actual`/`Limit` values across the cluster. No LLM. Proposals are bounded by
+  admin-set ceilings and can never widen path/category/check rules by more than
+  one named entry at a time.
+- **Judgment reasons** — a 143 session reads the cluster's sessions, findings,
+  disputes, and current prompt text, and proposes edited rubric or description
+  prompt text. Dispute bodies enter that prompt as untrusted evidence under the
+  same screening doc 112 applies to PR content.
+
+Every proposal carries a structured diff, a rationale, and links to the sessions
+that produced it. Admins activate, edit-then-activate, or dismiss with a reason.
+Activation writes a new insert-only policy version and an audit event. Dismissals
+are training data for the threshold, and a dismissed cluster does not re-propose
+until materially new evidence arrives.
+
+**Guardrails, non-negotiable:**
+
+- Proposals never auto-apply in v1.
+- Proposals can never touch approval mode, fork eligibility, prompt-injection
+  handling, or the bot's own policy paths.
+- Every activation is attributable to a user, in the audit log, and revertible by
+  activating the prior version.
+- Insights tracks post-activation false-approval rate per policy version, so a
+  loosening that goes wrong is visible against the version that caused it.
+
+## Database Schema
+
+Three new tables, all tenant-scoped by `org_id`, following the insert-only and
+partial-unique-index conventions in doc 112.
+
+```sql
+CREATE TABLE code_review_decision_disputes (
+    id                     uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    org_id                 uuid NOT NULL REFERENCES organizations(id),
+    session_id             uuid NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
+    pull_request_id        uuid NOT NULL REFERENCES pull_requests(id) ON DELETE CASCADE,
+    repository_id          uuid NOT NULL REFERENCES repositories(id),
+    policy_id              uuid NOT NULL REFERENCES code_review_policies(id),
+    reviewed_head_sha      text NOT NULL,
+    decision               text NOT NULL,
+    -- Who filed it. author_is_pr_author drives the bias weighting in clustering.
+    filed_by_user_id       uuid REFERENCES users(id),
+    filed_by_login         text NOT NULL DEFAULT '',
+    author_is_pr_author    boolean NOT NULL DEFAULT false,
+    source                 text NOT NULL CHECK (source IN ('github_comment','app_ui','api')),
+    github_comment_id      bigint,
+    github_delivery_id     text,
+    body                   text NOT NULL DEFAULT '',
+    -- Reason codes from the disputed decision that this dispute contests.
+    contested_reason_codes text[] NOT NULL DEFAULT '{}',
+    dispute_kind           text CHECK (dispute_kind IS NULL OR dispute_kind IN (
+                               'threshold_too_strict','path_rule_too_broad',
+                               'description_requirement_wrong','finding_incorrect',
+                               'judgment_overreach','bot_correct','other')),
+    classification_status  text NOT NULL DEFAULT 'pending'
+                               CHECK (classification_status IN ('pending','classified','failed','skipped')),
+    -- Ground truth. Only 'upheld' or 'corroborated' feed the tuning engine.
+    corroboration_status   text NOT NULL DEFAULT 'pending'
+                               CHECK (corroboration_status IN (
+                                   'pending','corroborated','refuted','inconclusive','upheld','rejected')),
+    corroboration_detail   jsonb NOT NULL DEFAULT '{}',
+    corroborated_at        timestamptz,
+    adjudicated_by_user_id uuid REFERENCES users(id),
+    adjudicated_at         timestamptz,
+    adjudication_note      text,
+    cluster_key            text,
+    created_at             timestamptz NOT NULL DEFAULT now(),
+    updated_at             timestamptz NOT NULL DEFAULT now()
+);
+
+-- One dispute per filer per review session; re-filing updates in place.
+CREATE UNIQUE INDEX idx_cr_disputes_session_filer
+    ON code_review_decision_disputes (session_id, COALESCE(filed_by_user_id::text, filed_by_login));
+CREATE UNIQUE INDEX idx_cr_disputes_delivery
+    ON code_review_decision_disputes (github_delivery_id) WHERE github_delivery_id IS NOT NULL;
+CREATE INDEX idx_cr_disputes_cluster
+    ON code_review_decision_disputes (org_id, repository_id, cluster_key, created_at DESC)
+    WHERE corroboration_status IN ('corroborated','upheld');
+CREATE INDEX idx_cr_disputes_pending
+    ON code_review_decision_disputes (org_id, corroboration_status, created_at)
+    WHERE corroboration_status = 'pending';
+
+CREATE TABLE code_review_policy_proposals (
+    id                   uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    org_id               uuid NOT NULL REFERENCES organizations(id),
+    repository_id        uuid REFERENCES repositories(id),
+    base_policy_id       uuid NOT NULL REFERENCES code_review_policies(id),
+    cluster_key          text NOT NULL,
+    origin               text NOT NULL CHECK (origin IN ('deterministic_rule','agent_session','manual')),
+    generator_session_id uuid REFERENCES sessions(id),
+    status               text NOT NULL DEFAULT 'open'
+                             CHECK (status IN ('open','activated','dismissed','superseded','expired')),
+    -- Structured, validated policy delta. Never raw config replacement.
+    proposed_changes     jsonb NOT NULL,
+    rationale            text NOT NULL,
+    evidence_session_ids uuid[] NOT NULL DEFAULT '{}',
+    dispute_count        int NOT NULL DEFAULT 0,
+    activated_policy_id  uuid REFERENCES code_review_policies(id),
+    decided_by_user_id   uuid REFERENCES users(id),
+    decided_at           timestamptz,
+    decision_note        text,
+    created_at           timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE UNIQUE INDEX idx_cr_proposals_open_cluster
+    ON code_review_policy_proposals (org_id, COALESCE(repository_id, '00000000-0000-0000-0000-000000000000'::uuid), cluster_key)
+    WHERE status = 'open';
+CREATE INDEX idx_cr_proposals_org_status
+    ON code_review_policy_proposals (org_id, status, created_at DESC);
+
+-- Denormalized per-decision outcome facts, so Insights and corroboration do not
+-- re-derive PR history on every read.
+CREATE TABLE code_review_decision_outcomes (
+    session_id                uuid PRIMARY KEY REFERENCES sessions(id) ON DELETE CASCADE,
+    org_id                    uuid NOT NULL REFERENCES organizations(id),
+    repository_id             uuid NOT NULL REFERENCES repositories(id),
+    pull_request_id           uuid NOT NULL REFERENCES pull_requests(id) ON DELETE CASCADE,
+    policy_id                 uuid NOT NULL REFERENCES code_review_policies(id),
+    decision                  text NOT NULL,
+    reason_codes              text[] NOT NULL DEFAULT '{}',
+    merged                    boolean NOT NULL DEFAULT false,
+    merged_at                 timestamptz,
+    human_requested_changes   boolean NOT NULL DEFAULT false,
+    human_review_comment_count int NOT NULL DEFAULT 0,
+    reverted                  boolean NOT NULL DEFAULT false,
+    reverted_at               timestamptz,
+    terminal                  boolean NOT NULL DEFAULT false,
+    observed_until            timestamptz,
+    updated_at                timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_cr_outcomes_org_repo ON code_review_decision_outcomes (org_id, repository_id, updated_at DESC);
+CREATE INDEX idx_cr_outcomes_reason_codes ON code_review_decision_outcomes USING gin (reason_codes);
+```
+
+New job types on the existing queue:
+
+| Job type | Queue | Trigger |
+| --- | --- | --- |
+| `classify_code_review_dispute` | `feedback` | Dispute created |
+| `corroborate_code_review_dispute` | `feedback` | PR reaches terminal state, or corroboration window expires |
+| `cluster_code_review_disputes` | `feedback` | Scheduled, hourly per org with new corroborated disputes |
+| `generate_code_review_policy_proposal` | `agent` | Cluster crosses threshold |
+| `digest_code_review_insights` | `feedback` | Scheduled, weekly per org |
+
+New audit actions: `code_review_dispute.filed`, `code_review_dispute.adjudicated`,
+`code_review_policy_proposal.activated`, `code_review_policy_proposal.dismissed`.
+
+## API Contract
+
+All routes are org-scoped and follow existing auth conventions. Filing and
+reading disputes is member-level; adjudication and proposal decisions are
+admin-level.
+
+```
+POST   /api/v1/code-reviews/{session_id}/disputes
+       body:    { "body": string, "contested_reason_codes": string[] }
+       201 ->   CodeReviewDispute
+       errors:  404 review not found · 409 already filed by this user
+                422 reason code not present on the disputed decision
+
+GET    /api/v1/code-reviews/{session_id}/disputes
+       200 ->   { "data": CodeReviewDispute[] }
+
+PATCH  /api/v1/code-review-disputes/{id}            (admin)
+       body:    { "corroboration_status": "upheld" | "rejected", "adjudication_note": string? }
+       200 ->   CodeReviewDispute
+       errors:  403 not an admin · 409 already adjudicated
+
+GET    /api/v1/code-review-insights
+       query:   repository_id?, from?, to?, decision?, reason_code?
+       200 ->   { "data": {
+                    "decisions_by_reason": [{ "reason_code", "count", "dispute_count",
+                                              "corroborated_count", "dispute_rate" }],
+                    "decision_totals":     { "approved", "comment_only", "needs_human_review", "blocked" },
+                    "outcomes":            { "merged_clean", "human_requested_changes", "reverted" },
+                    "median_decision_seconds": number,
+                    "false_approval_rate_by_policy_version": [{ "policy_id", "version", "rate" }]
+                 } }
+
+GET    /api/v1/code-review-policy-proposals
+       query:   status?, repository_id?
+       200 ->   { "data": CodeReviewPolicyProposal[] }
+
+POST   /api/v1/code-review-policy-proposals/{id}/activate      (admin)
+       body:    { "proposed_changes": object? }   // optional edited delta
+       200 ->   { "policy": CodeReviewPolicy, "proposal": CodeReviewPolicyProposal }
+       errors:  409 not open / base policy superseded · 422 delta fails policy validation
+                403 delta touches a locked dimension
+
+POST   /api/v1/code-review-policy-proposals/{id}/dismiss       (admin)
+       body:    { "decision_note": string }
+       200 ->   CodeReviewPolicyProposal
+```
+
+The GitHub command path adds no route: `@143-code-reviewer disagree: <reason>`
+is parsed in the existing `issue_comment` and `pull_request_review_comment`
+webhook handlers and creates the same record with `source = 'github_comment'`,
+deduplicated on `github_delivery_id`.
+
+Activation validates the delta against the same policy validation used by
+`PUT /api/v1/code-review-policies`, then writes a new insert-only version. It
+never patches a policy row in place, so approvals continue to point at the exact
+version that produced them.
+
+## Success Metrics
+
+- Share of non-approvals where the author files a dispute — the miscalibration
+  signal that does not exist today.
+- Corroboration rate of disputes, by reason code. A reason code with a high
+  dispute rate *and* high corroboration is a genuinely miscalibrated rule; high
+  dispute rate with low corroboration means the explanation is unclear, not the
+  policy wrong. Phase 0 should move the second number without moving the first.
+- Proposal activation rate, and dismissal reasons.
+- False-approval rate per policy version after activation — the guardrail metric.
+- Median time from non-approval to policy correction, versus today's unbounded.
+
+## Open Questions
+
+- Should a dispute filed by the PR author carry less clustering weight than one
+  filed by a third party, or is corroboration sufficient to handle bias alone?
+- What is the right corroboration window? 7 days captures most merges; revert and
+  incident signal needs 30.
+- Should filing a dispute trigger an immediate re-review under the same policy
+  (cheap, sometimes resolves flaky judgment reasons), or is that an invitation to
+  reroll until the bot approves? Leaning: no automatic re-review, since approval
+  is monotonic and re-rolling a stochastic judge is exactly the gaming path.
+- Should Insights be org-wide only, or per-repository with its own tuning
+  thresholds?
+- Do dismissed proposals suppress the cluster permanently, or decay back after a
+  policy change makes the evidence newly relevant?

--- a/docs/design/future/121-code-review-decision-feedback-and-policy-tuning.md
+++ b/docs/design/future/121-code-review-decision-feedback-and-policy-tuning.md
@@ -1,8 +1,8 @@
 # Design: Code Review Decision Feedback And Policy Tuning
 
-> **Status:** Not Started | **Last reviewed:** 2026-07-29
+> **Status:** Not Started | **Last reviewed:** 2026-07-30
 >
-> **Depends on:** [../implemented/112-code-reviewer-bot-auto-approval.md](../implemented/112-code-reviewer-bot-auto-approval.md), [../backlog/11-review-feedback-loop.md](../backlog/11-review-feedback-loop.md), [../future/18-fix-quality-feedback.md](18-fix-quality-feedback.md), [../future/116-automatic-pr-feedback-follow-through.md](116-automatic-pr-feedback-follow-through.md)
+> **Depends on:** [../implemented/112-code-reviewer-bot-auto-approval.md](../implemented/112-code-reviewer-bot-auto-approval.md), [../backlog/11-review-feedback-loop.md](../backlog/11-review-feedback-loop.md), [../future/18-fix-quality-feedback.md](18-fix-quality-feedback.md), [../future/116-automatic-pr-feedback-follow-through.md](116-automatic-pr-feedback-follow-through.md), [../future/16-ai-agent-evals.md](16-ai-agent-evals.md)
 
 ## Summary
 
@@ -11,12 +11,19 @@ approval, the PR author's only recourse is "ask a human." That disagreement —
 the highest-signal data the system could collect about its own policy — is
 discarded, and the org never learns which of its rules are actually miscalibrated.
 
-This document proposes a **decision feedback loop**: a first-class way to
-contest a code review decision in plain language, a durable record of that
-contest, an automated triage step that can immediately rerun the review when the
-objection carries new information, corroboration against what actually happened
-to the PR, and an engine that turns recurring corroborated disputes into
-concrete, reviewable policy changes.
+This document proposes a **decision feedback loop**:
+
+- a first-class way to contest a code review decision in plain language, in
+  either direction — "this should have been approved" and "this should not have
+  been approved"
+- automated triage that reruns the review immediately when the objection carries
+  information a rerun could act on, and answers plainly when it does not
+- proactive sampling of approvals near the policy frontier, because false
+  approvals are silent and nobody files a complaint about them
+- a deliberately narrow evidence standard for which objections may influence
+  policy at all
+- per-dispute policy proposals, centred on the editable rubric and description
+  prompts, each carrying a replay of what it would have changed
 
 Disagreeing must cost nothing. There is no command syntax and no form: a
 developer replies to the bot the way they would reply to a human reviewer, and
@@ -57,10 +64,9 @@ Five concrete gaps, each independently fixable:
    that a human must look. "I don't know why" is usually "I don't know who to
    ask or what to change."
 
-2. **No counterfactual.** The comment lists what blocked. It never says what
-   *unblocking* would take, or that a single blocker was the only one. "Would
-   have been approved except for one threshold" and "blocked on eleven separate
-   things" read the same.
+2. **No counterfactual.** The comment lists what blocked. It never says whether a
+   single blocker was the only one. "One threshold away" and "blocked on eleven
+   separate things" read the same.
 
 3. **Advisory findings are a bare count.** P2/P3 observations appear as
    "N non-blocking observations available in the full review." A reader who
@@ -102,40 +108,79 @@ control*. A system that automatically relaxes its approval criteria in response
 to complaints from the people it blocked is gameable by construction, and the
 gaming does not even have to be deliberate.
 
-**A dispute is a claim, not a fact.** Every option below is evaluated on how it
-establishes ground truth before acting.
+**A dispute is a claim, not a fact.** The evidence standard below is what
+separates this design from that one.
 
-## Corroboration: establishing ground truth
+### The asymmetry that makes complaints insufficient
 
-Two independent signals, both already available, decide whether a dispute was
-right:
+Blocked authors complain. Nobody complains about a PR that sailed through.
 
-**Outcome telemetry (automatic, unbiased).** 143 already syncs PR reviews,
-comments, threads, checks, and merge state. For a disputed non-approval:
+False approvals — the dangerous error, and the one doc 112 tracks as its headline
+safety metric — are **silent by construction**. A purely complaint-driven loop can
+therefore only ever discover evidence for loosening policy, and over any time
+horizon becomes a one-way ratchet no matter how careful its evidence standard is.
 
-| Observed outcome | Reading |
+This design answers that in two ways: disputes are **bidirectional**, so
+"this should not have been approved" is a first-class input; and approvals near
+the policy frontier are **proactively sampled** for human spot-check, so the
+tightening direction has a source of evidence that does not depend on anyone
+noticing a problem.
+
+## Evidence Standard
+
+Only two signals may generate a policy proposal. Everything else is visible in
+Insights and inert.
+
+**Proposal-generating:**
+
+| Signal | Direction | Why it qualifies |
+| --- | --- | --- |
+| Admin adjudicates `upheld` | Both | Authoritative. A policy owner has looked and agreed. Overrides everything |
+| **Independent human contradiction** — a human who is neither the PR author nor the disputer approved a PR 143 blocked, or left a blocking review / requested changes on a PR 143 approved | Both | Genuine independent judgment, contradicting the bot, from someone with no stake in the complaint. `ReviewContext.BlockingHumanReviews` already counts the second case |
+
+**Insights-only — never generates a proposal:**
+
+| Signal | Why it is excluded |
 | --- | --- |
-| Merged with no human requested-changes and no substantive human review comments | **Corroborates** — a human reviewer saw nothing the bot should have blocked on |
-| A human subsequently requested changes, or blocking comments landed | **Refutes** — the bot's caution was warranted |
-| Closed without merge | **Refutes** (weakly) |
-| Reverted, or linked to an incident within N days of merge | **Strongly refutes** — feeds the false-approval metric in doc 112 |
-| Still open past the window | **Inconclusive** — expires, never counted |
+| A reassessment flipped the decision | The PR description is a mutable input that neither the head SHA nor the policy version pins — doc 112 hashes title/body separately for exactly this reason. An author who reads the blocker, improves the description, and gets approved is the system working correctly, not evidence the first call was wrong |
+| PR merged with no blocking human review | Frequently circular: after a non-approval, a human approving is the normal escalation path, so treating it as evidence reads the escalation as proof escalation was unnecessary. It also cannot distinguish a careful review from a rubber stamp, and without branch-protection data — which 143 does not track — it cannot exclude self-merge |
+| Reverted, or linked to an incident | Attribution is guesswork and the lag is months. Too weak to draft a change to a security control |
+| Any signal, where the disputer is not an org member | See the trust model below |
 
-**Reassessment outcome (automatic, immediate).** When triage reruns the review
-(below) and the rerun approves the same head SHA under the same policy version,
-the original decision was demonstrably wrong on its own terms — the strongest and
-fastest corroboration available, and the only one that does not require waiting
-for the PR to reach a terminal state. A rerun that reaches the same conclusion is
-not by itself a refutation; it is `inconclusive`, because a rerun cannot fix a
-threshold that is genuinely miscalibrated.
+This standard is deliberately strict, because there is no clustering step behind
+it: one qualifying dispute drafts a proposal. In the steady state most proposals
+will therefore originate from admin adjudication, including adjudications
+produced by frontier spot-checks. **Throughput is bounded by admin attention by
+design** — the alternative is volume of proposals nobody reads carefully, which
+converts the human activation gate into a rubber stamp and defeats its purpose.
 
-**Explicit adjudication (human, authoritative).** A policy owner — not the PR
-author — marks a dispute `upheld` or `rejected`. Adjudication always overrides
-telemetry.
+### Trust model
 
-Only `upheld` disputes and `corroborated` telemetry feed the tuning engine.
-Disputes from the PR author corroborated by nothing are visible in Insights and
-inert everywhere else. This single rule is what makes the loop safe.
+Capture and influence are separate privileges. Reuse
+`evaluatePRFeedbackEligibility` (`internal/services/github/pr_feedback_policy.go`)
+for capture rather than reinventing eligibility.
+
+| Author | Captured | Answered | Can trigger a rerun | Can influence policy |
+| --- | --- | --- | --- | --- |
+| `OWNER` / `MEMBER` / `COLLABORATOR` | yes | yes | yes | yes |
+| Any human on a private repository | yes | yes | yes | yes |
+| Other humans (incl. fork contributors on public repos) | yes | yes | **no** | **no** |
+| Bots | no | no | no | no |
+
+Untrusted objections are still recorded, triaged, and answered — silently
+dropping a fork contributor's point is the exact failure this document exists to
+fix — and they appear in Insights flagged `untrusted`, so if outside
+contributors are consistently right about a rule, a human can still notice and
+adjudicate it into the loop deliberately.
+
+Untrusted authors cannot trigger reassessments. Reassessment is the expensive
+action, and on a public repository an unbounded supply of anonymous authors
+triggering unbounded agent runs is a denial-of-service surface. Spending an
+organization's compute is a form of influence.
+
+Bots cannot file disputes at all. The `self_authored` and hidden-marker checks in
+`evaluatePRFeedbackEligibility` already prevent the obvious self-loop, and there
+is no case where a bot should be arguing with approval policy.
 
 ## Options
 
@@ -159,135 +204,116 @@ from reason-code frequency and tune policy by hand.
   it does not address the reported problem.
 - Manual tuning depends on an admin noticing, caring, and acting.
 
-### Option B — Structured disputes plus a deterministic auto-tuner
+### Option B — Disputes plus a deterministic auto-tuner
 
-Add a dispute record with the same free-text intake as Option C, but no
-reassessment and no agent proposals — the options differ in what happens to a
-dispute, not in how one is filed. When N disputes cluster on the same
-*deterministic* reason code in the same repo, a rules engine proposes a
-mechanical adjustment —
-`files_limit_exceeded` with disputed `Actual` values consistently at 7 against a
-`Limit` of 5 proposes raising the limit to 8.
+Same free-text intake as Option C, but no reassessment and no prompt proposals —
+the options differ in what happens to a dispute, not in how one is filed. A rules
+engine proposes mechanical adjustments to numeric and enumerable dimensions from
+the `Actual`/`Limit` values the reason codes already carry.
 
 **Pros**
-- Fully explainable and unit-testable; the tuner is arithmetic over data the
-  reason codes already carry in `Actual`/`Limit`.
-- No LLM anywhere in the approval-policy path.
-- Maps cleanly onto insert-only policy versioning: each adjustment is a new version.
+- Fully explainable and unit-testable; the tuner is arithmetic.
+- No LLM anywhere in the policy-authoring path.
+- Maps cleanly onto insert-only policy versioning.
 
 **Cons**
-- Covers only the mechanical dimensions. The judgment reasons — `scope_mismatch`,
-  `unresolved_uncertainty`, `architecture`, `blocking_findings` — are where
-  disagreement actually concentrates, and none of them are tunable by arithmetic.
-  They need prompt and rubric changes.
-- Threshold ratcheting is the exact failure mode described above: repeated
-  disputes monotonically loosen limits, and each individual step looks reasonable.
-- Deterministic thresholds are the rules teams are *most* able to set correctly
-  by hand, so this automates the easy half and leaves the hard half untouched.
+- **Tunes the dimensions that matter least here.** 143's deterministic gates are
+  deliberately set lenient, so relatively few non-approvals are caused by them.
+  The volume arrives through judgment reasons — `blocking_findings`,
+  `scope_mismatch`, `unresolved_uncertainty`, `architecture` — which are governed
+  by rubric and description prompt text and are untouchable by arithmetic.
+- Threshold ratcheting: repeated disputes monotonically loosen limits, and each
+  individual step looks reasonable.
+- Deterministic thresholds are also the rules teams are most able to set
+  correctly by hand, so this automates the easy half and leaves the hard half
+  untouched.
 
-### Option C — Disputes, corroboration, and agent-authored proposals (recommended)
+### Option C — Disputes, triage-driven reassessment, and per-dispute proposals (recommended)
 
-Capture disagreement as free-text replies, triage it with one LLM pass that
-attributes it to the decision's own reason codes and decides whether a rerun
-could change the answer, and rerun the review when it could. Corroborate each
-dispute against the reassessment outcome, PR outcome telemetry, and optional
-human adjudication. Cluster the survivors. When a cluster crosses a threshold, a
-scheduled 143 session reads the cluster, its evidence, and the current policy,
-and emits a **proposed policy version** with a concrete diff and a rationale
-citing the sessions behind it. An admin reviews and activates it in one click;
-activation creates the next insert-only version and an audit event.
+Capture disagreement as free-text replies in either direction. Triage with one
+LLM pass that attributes the objection to the decision's own reason codes and
+decides whether a rerun could change the answer; rerun when it could. Apply the
+evidence standard above. Each qualifying dispute produces a **proposed policy
+version** — most often an edit to the rubric or description prompts — carrying a
+replay of what it would have changed. An admin reviews and activates in one
+click; activation creates the next insert-only version and an audit event.
+Separately, sample approvals near the policy frontier for spot-check so the
+tightening direction has evidence that does not require a complaint.
 
 **Pros**
-- Handles both halves: deterministic dimensions get mechanical proposals, prompt
-  and rubric text gets agent-authored edits. Judgment reasons become tunable.
+- Tunes the dimension that actually drives outcomes: the prompts.
 - Two response times. A wrong judgment call is fixed in minutes by a rerun; a
-  wrong policy rule is fixed in the next tuning cycle. Options A and B can only
-  ever do the slow one, which is why they read as unresponsive to the developer
-  who is blocked right now.
-- The corroboration gate means only disputes that reality agreed with can move
-  policy.
-- Free-text intake means the feature has no adoption curve — nobody has to learn
-  or remember a command to use it, and objections filed before it shipped are
-  still parseable.
+  wrong rule is fixed in the next proposal. Options A and B can only do the slow
+  one, which is why they read as unresponsive to the developer blocked right now.
+- Bidirectional, with frontier sampling, so policy can tighten as well as loosen.
 - Human activation keeps the security boundary intact — the system proposes,
   a person disposes — while removing essentially all of the analysis toil.
-- Reuses infrastructure wholesale: 143 sessions for the proposal agent, the job
-  queue for clustering, insert-only policies for versioning, the audit log for
-  attribution, notifications for the digest.
-- Proposals carry evidence, so the review is genuinely reviewable rather than a
-  rubber stamp.
+- Free-text intake has no adoption curve: nobody has to learn a command, and
+  objections filed before it shipped are still parseable.
+- Reuses infrastructure wholesale: 143 sessions, the job queue, insert-only
+  policies, the audit log, notifications, and the existing PR-comment
+  eligibility model.
 
 **Cons**
-- The largest build: capture surfaces, schema, corroboration job, clustering,
-  proposal agent, review UI, digest.
-- Proposal quality depends on cluster quality; thin clusters produce noisy
-  proposals and admins learn to ignore the queue. Thresholds must start
-  conservative.
-- Introduces an agent that writes approval policy. Even gated behind human
-  activation, this needs the same untrusted-input discipline doc 112 applies to
-  PR content: dispute text is written by the people the bot blocked and must be
-  treated as evidence, never as instructions.
-- Free-text intake means a classifier decides what counts as a dispute. A missed
-  dispute is silent, which is the failure mode this whole document exists to fix,
-  so triage must bias toward recording. Over-recording is cheap; the routing step
-  and the corroboration gate both filter downstream.
-- Dispute-triggered reruns cost agent time and create a reroll surface. Bounded
-  by the per-head cap and by deterministic gates being non-waivable, but the
-  reassessment-flip rate needs watching: if reruns frequently flip the outcome on
-  identical inputs, the problem is judgment-layer variance, not policy.
+- The largest build.
+- A classifier decides what counts as a dispute. A missed dispute is silent —
+  the failure mode this document exists to fix — so triage must bias toward
+  recording. Over-recording is cheap; routing and the evidence standard filter
+  downstream.
+- Prompt proposals are the least legible kind of change: an admin cannot
+  evaluate a reworded rubric by reading it. Replay against a held-out guard set
+  is what makes the review real rather than nominal, and it is load-bearing
+  rather than optional.
+- Unbounded reruns for trusted humans means agent spend scales with argument
+  volume. Accepted deliberately; see the reassessment section.
 
 ### Option D — Policy-as-code with proposal PRs
 
-Same capture and corroboration as C, but the policy lives in the repository
+Same capture and evidence standard as C, but policy lives in the repository
 (`.143/code-review-policy.yml`) and proposals arrive as ordinary pull requests,
 following the `.143/learned-conventions.md` pattern from doc 11.
 
 **Pros**
 - Policy changes get the team's real review process, CODEOWNERS, and git history
   for free — a strong fit for a control that governs approvals.
-- Fully transparent and diffable; the same reviewers who care about the rules
-  are the ones who see changes to them.
+- Fully transparent and diffable.
 - No new approval UI to build.
 
 **Cons**
-- Forks the source of truth. Today policy is DB-owned, versioned, and resolvable
-  with org-default plus repo-override inheritance; a repo file needs sync,
-  conflict, and precedence rules against that model, and doc 112's requirement
-  that approvals point at the exact policy version that produced them becomes
-  harder to guarantee.
+- Forks the source of truth. Policy is DB-owned, versioned, and resolvable with
+  org-default plus repo-override inheritance; a repo file needs sync, conflict,
+  and precedence rules against that model, and doc 112's requirement that
+  approvals point at the exact policy version that produced them becomes harder
+  to guarantee.
 - Repo-scoped files cannot express org-level defaults inherited by repositories
-  that have no override.
-- A PR proposing to loosen the reviewer bot's own approval rules is exactly the
-  category doc 112 says the bot must not approve — workable, but it needs an
-  explicit carve-out.
-- Slower loop: policy edits now require a merge.
+  with no override.
+- A PR proposing to loosen the reviewer bot's own rules is exactly the category
+  doc 112 says the bot must not approve — workable, but needs a carve-out.
+- Slower loop: prompt tuning now requires a merge, and prompt tuning is the part
+  that needs the fastest iteration.
 
-Worth revisiting once policy stabilizes, and a reasonable later export path. Not
-the right first move.
+Worth revisiting once policy stabilizes. Not the right first move.
 
 ### Rejected — Fully autonomous closed-loop adaptation
 
 C or D with automatic activation and metric-triggered rollback.
 
-Rejected on principle rather than on effort. Approval policy is a security
-control; an automated system that relaxes its own controls in response to
-pressure from blocked authors is unsound regardless of how good the rollback is,
-and "reverts within 7 days" is far too slow a feedback signal for a gate whose
-failure mode is unreviewed code reaching main. Doc 112's product principle —
-*approval requires evidence* — applies to changes in what counts as evidence.
+Rejected on principle rather than effort. Approval policy is a security control;
+an automated system that relaxes its own controls in response to pressure from
+blocked authors is unsound regardless of how good the rollback is, and "reverts
+within 7 days" is far too slow a signal for a gate whose failure mode is
+unreviewed code reaching main. Doc 112's product principle — *approval requires
+evidence* — applies to changes in what counts as evidence.
 
-If a team eventually wants some of this, the defensible bounded form is: admin
-pre-authorizes auto-application for named low-risk dimensions only (e.g. line
-thresholds, within an admin-set ceiling, on repos with no sensitive paths), never
-for path rules, sensitive categories, required checks, agent roster, or prompt
-text. That is a later configuration option on top of C, not a different design.
+The defensible bounded form, if a team later wants it: admin pre-authorizes
+auto-application for named low-risk deterministic dimensions only, within an
+admin-set ceiling, never for prompts, path rules, sensitive categories, required
+checks, or agent roster. That is a later configuration option on top of C.
 
 ## Recommendation
 
-Ship **Option C**, in three phases, and do the transparency fixes in Phase 0
-because they reduce disputes at the source rather than processing them better.
-
-The phases stand alone. Each is useful if the next never ships.
+Ship **Option C** in three phases. Each phase stands alone and is useful if the
+next never ships.
 
 ### Phase 0 — Make the decision legible (no new subsystem)
 
@@ -299,16 +325,17 @@ detail view:
    the exact setting), *Review findings* (agent code judgment, contestable),
    *Human judgment required* (typed non-finding reasons). Derive grouping from
    the existing `CodeReviewRiskReasonCode` — no new taxonomy.
-2. **State the counterfactual.** When exactly one blocker exists, say so:
-   "This is the only blocker. Resolving it would make this PR eligible for
-   automated approval under policy vN." Requires no new computation; the
-   evaluator already has the full reason list.
+2. **State the scope of the blocker, not a promise.** When exactly one blocker
+   exists, say so as of a commit: *"This is the only blocker as of `abc1234`."*
+   Not "resolving it would get this approved" — fixing it triggers a fresh review
+   that may legitimately surface something new, and a promise the system cannot
+   keep is worse than no promise.
 3. **Separate system faults from risk.** Give `context_unavailable` and
    `orchestrator_synthesis_invalid` a distinct rendering — 143 could not complete
    the review — and keep them out of the policy-blocker list entirely.
 4. **Expose advisory findings.** Put P2/P3 observations in a collapsed
-   `<details>` block on the rolling comment instead of a count. They remain
-   non-blocking and still generate no inline comments.
+   `<details>` block instead of a count. They remain non-blocking and still
+   generate no inline comments.
 5. **Fast-fail deterministic gates.** Evaluate size, path, author, and fork
    eligibility from the PR file list *before* reviewer fan-out. If policy makes
    the PR categorically ineligible, post the result immediately and skip the
@@ -317,135 +344,221 @@ detail view:
 Phase 0 alone likely resolves a large share of "I'm not sure why," and every
 later phase depends on the reason-code grouping it introduces.
 
-### Phase 1 — Capture, triage, and corroborate
+### Phase 1 — Capture, triage, reassess, corroborate
 
-Two capture surfaces, one record, no syntax:
+**Capture, with no syntax.** Two surfaces, one record:
 
-- **GitHub-native (primary).** The developer replies in plain language, either
-  in the thread rooted on the bot's rolling comment or by mentioning
-  `@143-code-reviewer` anywhere on a PR the bot reviewed. No command, no prefix,
-  no structured form. "this is test-only, why is it blocked?", "the migration is
-  additive so there's no risk here", and "I think this should have been approved"
-  are all valid disputes. The `issue_comment` and `pull_request_review_comment`
-  webhooks are already routed (`internal/api/handlers/webhooks.go`).
+- **GitHub-native (primary).** The developer replies in plain language, either in
+  the thread rooted on the bot's rolling comment or by mentioning
+  `@143-code-reviewer` anywhere on a PR it reviewed. "this is test-only, why is it
+  blocked?", "the migration is additive so there's no risk here", and "hold on,
+  this shouldn't have been auto-approved, it touches auth" are all valid. The
+  `issue_comment` and `pull_request_review_comment` webhooks are already routed.
 - **143-native (secondary).** A "Disagree with this decision" action on the code
-  review session detail opening a free-text box. The reason codes from the actual
-  decision are shown for reference and can optionally be ticked, but nothing is
-  required beyond prose. The rolling comment links here.
+  review session detail, opening a free-text box. Reason codes from the actual
+  decision are shown for reference and may optionally be ticked; nothing beyond
+  prose is required.
 
-Both write a `code_review_decision_disputes` row attributed to the session, the
-policy version, and the reviewed head SHA, with `intake_status = 'pending'`.
+Capture is deliberately over-inclusive. Eligibility comes from
+`evaluatePRFeedbackEligibility`; meaning is assigned by triage, not by the
+webhook handler.
 
-Capture is deliberately over-inclusive and triage is where meaning gets assigned.
-It is much better to record a comment that turns out to be a question than to
-drop a real objection because it did not match a pattern.
-
-**Intake and routing.** Every captured comment enqueues
-`triage_code_review_dispute`, a single LLM pass that reads the comment, the
-decision it is responding to, the reason codes that decision emitted, the diff
-summary, and the thread it sits in. It produces:
+**Triage.** Every captured comment enqueues `triage_code_review_dispute`, which
+runs `deterministicPRFeedbackTriage` first as a free pre-filter for
+acknowledgements and empty bodies, then a single LLM pass over the comment, the
+decision it responds to, that decision's reason codes, the diff summary, and the
+surrounding thread. It produces:
 
 | Field | Meaning |
 | --- | --- |
-| `is_dispute` | Does this actually contest the decision? Questions, thanks, unrelated chatter, and comments aimed at other bots are not disputes |
-| `contested_reason_codes` | Which of the decision's actual reason codes the objection targets, inferred from prose. Empty when the objection is general |
-| `dispute_kind` | `threshold_too_strict`, `path_rule_too_broad`, `description_requirement_wrong`, `finding_incorrect`, `judgment_overreach`, `bot_correct`, `other` |
-| `asserts_new_information` | Does the comment supply a fact the review did not have — "that path isn't auth-sensitive, it's a fixture", "the generated file is checked in but not executed" |
-| `routing` | `reassess`, `policy_signal_only`, `answer_only`, or `not_a_dispute` |
+| `is_dispute` | Does this contest the decision? Questions, thanks, and chatter are not disputes |
+| `direction` | `should_have_approved` or `should_not_have_approved`, inferred from the decision being responded to |
+| `contested_reason_codes` | Which of the decision's actual reason codes the objection targets, inferred from prose |
+| `dispute_kind` | See the enum in the schema; covers both directions |
+| `asserts_new_information` | Does the comment supply a fact the review did not have — "that path isn't auth-sensitive, it's a fixture" |
+| `routing` | `reassess`, `policy_signal_only`, `answer_only`, `not_a_dispute` |
 
-Routing is the useful part, because the two kinds of objection need opposite
-responses:
+Routing matters because the two kinds of objection need opposite responses:
 
 - **`reassess`** — the objection asserts new information or contests an
-  agent-judgment reason (`blocking_findings`, `scope_mismatch`,
-  `unresolved_uncertainty`, `architecture`, and the other typed human-review
-  reasons). A rerun can genuinely reach a different conclusion, so triage
-  enqueues one immediately.
-- **`policy_signal_only`** — the objection contests a deterministic gate
-  (`files_limit_exceeded`, `sensitive_path`, `required_check_failing`). Rerunning
-  is pointless: the threshold will evaluate identically. The bot replies saying
-  exactly that, names the policy setting and its current value, links to it, and
-  records the dispute for clustering. This is the honest answer to "why won't you
-  approve this," and it is the case that most needs Phase 2.
-- **`answer_only`** — a question rather than a disagreement. The bot answers from
-  the existing session evidence. No dispute record survives triage.
-- **`not_a_dispute`** — recorded as `discarded`, no reply, no clustering weight.
+  agent-judgment reason. A rerun can genuinely reach a different conclusion.
+  Requires a trusted author and the `should_have_approved` direction.
+- **`policy_signal_only`** — the objection contests a deterministic gate. A rerun
+  is pointless: the threshold evaluates identically. The bot says exactly that,
+  names the policy setting and its current value, links to it, and records the
+  dispute.
+- **`answer_only`** — a question, not a disagreement. Answered from existing
+  session evidence; no dispute record survives.
+- **`not_a_dispute`** — recorded as `discarded`. No reply, no influence.
 
-**Dispute-triggered reassessment.** A `reassess` routing enqueues the normal code
-review request path with a new trigger source `dispute_reassessment`, keyed by
-dispute id. This fits doc 112's existing idempotency model without changing it:
-doc 112 already specifies that a genuinely new explicit request after a
-non-approval creates a distinct assessment even at the same head SHA, and that
-requests arriving while a review is running are held behind a durable starter job.
-A dispute is one more kind of explicit request.
+A `should_not_have_approved` dispute never reassesses. Doc 112 makes approval
+monotonic and this design does not touch that: automation must never dismiss or
+contradict an approval that has already occurred. That direction is
+record-and-propose only, which makes it simpler than the blocked direction.
 
-The dispute text enters the reassessment as **untrusted evidence**, under exactly
-the screening doc 112 applies to PR descriptions and diffs. It is a claim by the
-author to be verified against the code, never an instruction. "Approve this" and
-"ignore your policy" are prompt injection, not information, and are handled as
-doc 112 already handles them.
+**Reassessment.** A `reassess` routing enqueues the normal code review request
+path with a new trigger source `dispute_reassessment`, keyed by dispute id. This
+fits doc 112's existing idempotency model unchanged: a genuinely new explicit
+request after a non-approval already creates a distinct assessment at the same
+head SHA, and requests arriving mid-review are already held behind a durable
+starter job. A dispute is one more kind of explicit request.
 
-Bounds, so that disputing is cheap but rerolling is not a strategy:
+The dispute text enters as **untrusted evidence** under exactly the screening
+doc 112 applies to PR descriptions and diffs. It is a claim to verify against the
+code, never an instruction. "Approve this" and "ignore your policy" are prompt
+injection, not information.
+
+There is **no cap** on dispute-triggered reassessments per PR for trusted
+authors. A cap would not be a security boundary anyway: doc 112 already
+auto-enqueues a fresh assessment on every new commit until approval, so
+`git commit --allow-empty && git push` is an existing unlimited-rerun path that
+predates this feature. Rationing arguments while leaving that open would buy
+nothing and be hostile to people with a real problem. What actually bounds risk:
 
 - Deterministic gates are re-evaluated from source on every reassessment and can
-  never be waived by a dispute. Only the agent-judgment half of the decision can
-  move.
-- A configurable cap on dispute-triggered reassessments per PR head SHA
-  (default 2). Beyond it, further disputes are recorded and clustered but do not
-  rerun; the bot says so and points at human review.
-- Approval remains monotonic, and each reassessment remains an immutable session,
-  so the full history of "blocked, disputed, reassessed, approved" is auditable.
-- Reassessments triggered by a dispute are labelled as such in Insights, so a
-  repo where they routinely flip the outcome is visibly a repo with an unreliable
-  judgment layer.
+  never be waived by a dispute. This is the real security boundary and it does
+  not depend on any cap.
+- Untrusted authors cannot trigger reruns at all (trust model above).
+- Approval remains monotonic; each reassessment remains an immutable session.
 
-**Corroboration.** A scheduled `corroborate_code_review_dispute` job resolves
-each dispute per the corroboration table once the reassessment settles, the PR
-reaches a terminal state, or the window expires.
+If rerolling a stochastic judge until it approves is a concern, the fix is not in
+this document — it is judgment-layer variance in doc 112, and the empty-commit
+path is the one to close. Track reassessment-flip rate by attempt number: if
+attempt 2 flips as often as attempt 1 on unchanged inputs, fix the judge rather
+than ration the reruns.
 
-Ship the `Insights` tab here (Option A's content, plus dispute rate,
-corroboration rate, and reassessment-flip rate by reason code), and a weekly
-digest to policy owners over the existing notification path — this is the "store
-the data and send the results" half of the ask, and it is independently valuable.
+**Loop safety between bot subsystems.** The reviewer's dispute reply is a comment
+on the PR, and doc 116's feedback follow-through ingests PR comments including
+bot-authored ones — an installed app on a private repo is eligible by two of its
+provenance tiers. Reply → ingested → commit pushed → doc 112 auto-enqueues a
+review → new reply is a loop that forms without anyone behaving incorrectly, and
+with no cap there is no counter in it.
+
+Two guards, reusing what doc 116 already built:
+
+- Dispute replies carry the hidden marker doc 116 already checks
+  (`prFeedbackHiddenMarker` → `IgnoreReason: "hidden_response_marker"`), so
+  follow-through skips them and the loop never forms.
+- A reviewer-side **cycle budget per epoch**, mirroring
+  `feedback_bot_epoch` / `feedback_bot_cycles_in_epoch`
+  (`internal/db/pull_request_feedback.go`): any human comment on the PR resets
+  the epoch and refills the budget; consecutive machine-only rounds decrement it.
+  Human-driven rounds stay unlimited; machine-only rounds are bounded.
+
+Markers get dropped in refactors. The epoch budget is the backstop.
+
+**Corroboration.** A scheduled `corroborate_code_review_dispute` job applies the
+evidence standard once the reassessment settles, the PR reaches a terminal state,
+or the window expires.
+
+**Surfacing.** Ship the `Insights` tab here, and a weekly digest to policy owners
+over the existing notification path. This is the "store the data and send the
+results" half of the ask, and it is independently valuable.
+
+**GitHub surface discipline.** Doc 112 fights to keep exactly one visible 143
+comment per PR, and unlimited disputes could easily undo that:
+
+- Reassessment results update the **rolling comment in place**, as every other
+  assessment already does. No new comment.
+- `policy_signal_only` and `answer_only` get **one threaded reply** each — these
+  are conversational turns and silence is the failure being fixed. GitHub threads
+  them under the comment they answer. Never a follow-up chain.
+- The rolling comment carries a compact state line: *"2 objections · 1
+  reassessment · [view](link)"*.
+- Full dispute history, triage reasoning, and reassessment lineage live on the
+  143 session, which is already the detail surface.
 
 ### Phase 2 — Propose
 
-A scheduled clustering job groups `upheld` and `corroborated` disputes by
-`(org, repository, reason_code, dispute_kind)`. Clusters crossing a configurable
-threshold (default: 3 corroborated disputes within 30 days) create a
-`code_review_policy_proposals` row.
+**Per-dispute, not clustered.** One dispute that meets the evidence standard
+produces one proposal. Clustering is a de-noising mechanism, and at realistic
+review volumes split across repositories, reason codes, and dispute kinds the
+modal cluster size is one — de-noising would discard the entire signal. It also
+tightens the loop from a month to days. If proposal volume ever becomes the
+complaint, clustering is a later optimization.
 
-Proposal generation is split by reason kind:
+**Proposal kinds.** Two, with the emphasis inverted from the obvious ordering:
 
-- **Deterministic reasons** — a rules engine computes the change directly from
-  `Actual`/`Limit` values across the cluster. No LLM. Proposals are bounded by
-  admin-set ceilings and can never widen path/category/check rules by more than
-  one named entry at a time.
-- **Judgment reasons** — a 143 session reads the cluster's sessions, findings,
-  disputes, and current prompt text, and proposes edited rubric or description
-  prompt text. Dispute bodies enter that prompt as untrusted evidence under the
-  same screening doc 112 applies to PR content.
+- **Prompt proposals (primary).** A 143 session reads the dispute, its review
+  session, findings, reviewer evidence, and current prompt text, and proposes a
+  scoped edit to the acceptable-risk rubric or a PR-description requirement.
+  Edits are scoped to a named section and may add **or remove** — an
+  additions-only rule would mean the rubric can only ever grow and a genuinely
+  wrong rule could never be deleted, which is its own ratchet. Dispute text
+  enters the session as untrusted evidence.
+- **Deterministic proposals (secondary).** A rules engine computes threshold,
+  path, category, check, and author-eligibility changes directly from
+  `Actual`/`Limit`. No LLM. Bounded by admin-set ceilings, and may widen a path
+  or category set by at most one named entry at a time.
 
-Every proposal carries a structured diff, a rationale, and links to the sessions
-that produced it. Admins activate, edit-then-activate, or dismiss with a reason.
-Activation writes a new insert-only policy version and an audit event. Dismissals
-are training data for the threshold, and a dismissed cluster does not re-propose
-until materially new evidence arrives.
+**Replay is what makes review real.** An admin cannot evaluate a reworded rubric
+by reading it. Every proposal is replayed before an admin sees it, against two
+sets, and both are shown:
+
+- the **target set** — the dispute(s) that motivated it. Did it fix them?
+- a **guard set** — held-out decisions believed correct, weighted toward
+  approvals near the frontier. Replaying only the target set is worthless: the
+  prompt was written to fix those cases, so it always passes. The guard set is
+  what catches "fixed 1 dispute, would have flipped 11 correct approvals."
+
+Replaying a prompt change does **not** require rerunning the review. The editable
+rubric and description prompts feed the *orchestrator*, and
+`code_review_agent_results` stores per-role `raw_output` and `structured_result`
+while doc 112 requires rendered prompts to be recoverable from audit state. So
+replay reruns the **orchestrator step alone against stored reviewer outputs** —
+no sandboxes, no repo clones, no reviewer fan-out. One cheap agent call per
+historical review, 20–30 per proposal. Deterministic proposals replay exactly and
+offline by re-evaluating `EvaluateCodeReviewRisk` against stored inputs.
+
+**Seeding the guard set.** On day one there is no corpus of agreed-correct
+decisions. Bootstrap from decisions that merged with no blocking human review —
+weak evidence individually, but adequate as a regression baseline, which is a
+lower bar than proposal-generating evidence. Curate it thereafter from
+spot-check verdicts, which are real human judgments. The guard set doubles as a
+small approval-decision eval corpus, giving doc 16 a dataset to build on rather
+than something to compete with.
+
+**Frontier sampling.** Because false approvals are silent, sample them instead of
+waiting. A scheduled job scores each approval by proximity to the policy
+boundary and queues the top-K per week for admin spot-check:
+
+| Component | Signal |
+| --- | --- |
+| **Margin** | How close to the deterministic limits — 5/5 files, 296/300 lines |
+| **Thin judgment** | Approved despite P2 findings, `low` confidence on clean verdicts, or reviewer disagreement that did not reach blocking |
+| **Novelty** | First approval touching a path or risk category this policy has never approved before |
+
+Novelty carries the highest weight: margin says the policy is being exercised at
+its edge, novelty says it is being applied somewhere it has never been tested,
+and untested is where an unexamined rule turns out to be wrong.
+
+Alongside the frontier picks, include a **blind random sample** the reviewer
+cannot distinguish. If random spot-checks surface bad approvals at the same rate
+as frontier picks, the frontier score is worthless and there is no other way to
+find that out. The random arm also yields an unbiased false-approval rate —
+doc 112's success metric, currently uncomputable.
+
+Queue size should be a few minutes of work per week. A verdict of "should not
+have been approved" writes a dispute with `direction = should_not_have_approved`
+and `corroboration_status = upheld`, which is an admin adjudication and therefore
+already proposal-generating. Frontier sampling needs no new evidence tier; it is
+a discovery mechanism feeding a signal that already qualifies.
 
 **Guardrails, non-negotiable:**
 
-- Proposals never auto-apply in v1.
+- Proposals never auto-apply.
 - Proposals can never touch approval mode, fork eligibility, prompt-injection
-  handling, or the bot's own policy paths.
+  handling, agent roster, or the bot's own policy paths.
 - Every activation is attributable to a user, in the audit log, and revertible by
-  activating the prior version.
-- Insights tracks post-activation false-approval rate per policy version, so a
-  loosening that goes wrong is visible against the version that caused it.
+  activating the prior version — policies are already insert-only, so revert is
+  one click.
+- Insights tracks decision-mix shift and false-approval rate per policy version,
+  so a bad prompt change is visible in days rather than discovered by incident.
 
 ## Database Schema
 
-Three new tables, all tenant-scoped by `org_id`, following the insert-only and
-partial-unique-index conventions in doc 112.
+Four new tables plus alterations, all tenant-scoped by `org_id`, following the
+insert-only and partial-unique-index conventions in doc 112.
 
 ```sql
 CREATE TABLE code_review_decision_disputes (
@@ -457,85 +570,98 @@ CREATE TABLE code_review_decision_disputes (
     policy_id              uuid NOT NULL REFERENCES code_review_policies(id),
     reviewed_head_sha      text NOT NULL,
     decision               text NOT NULL,
-    -- Who filed it. author_is_pr_author drives the bias weighting in clustering.
+    direction              text NOT NULL DEFAULT 'should_have_approved'
+                               CHECK (direction IN ('should_have_approved','should_not_have_approved')),
+    -- Filer identity and trust. `trusted` gates both reruns and policy influence.
     filed_by_user_id       uuid REFERENCES users(id),
     filed_by_login         text NOT NULL DEFAULT '',
+    author_association     text NOT NULL DEFAULT '',
     author_is_pr_author    boolean NOT NULL DEFAULT false,
-    source                 text NOT NULL CHECK (source IN ('github_comment','app_ui','api')),
+    trusted                boolean NOT NULL DEFAULT false,
+    source                 text NOT NULL CHECK (source IN ('github_comment','app_ui','api','spot_check')),
     github_comment_id      bigint,
     github_delivery_id     text,
     github_thread_root_comment_id bigint,
     -- Verbatim natural-language objection. No command syntax is parsed from it.
     body                   text NOT NULL DEFAULT '',
     -- Everything below is inferred by triage, not supplied by the filer.
-    -- The app UI may pre-tick reason codes, but never requires them.
     contested_reason_codes text[] NOT NULL DEFAULT '{}',
     dispute_kind           text CHECK (dispute_kind IS NULL OR dispute_kind IN (
+                               -- should_have_approved
                                'threshold_too_strict','path_rule_too_broad',
                                'description_requirement_wrong','finding_incorrect',
-                               'judgment_overreach','bot_correct','other')),
+                               'judgment_overreach',
+                               -- should_not_have_approved
+                               'threshold_too_lenient','path_rule_too_narrow',
+                               'missed_finding','judgment_underreach',
+                               -- either
+                               'bot_correct','other')),
     asserts_new_information boolean NOT NULL DEFAULT false,
     routing                text CHECK (routing IS NULL OR routing IN (
                                'reassess','policy_signal_only','answer_only','not_a_dispute')),
     intake_status          text NOT NULL DEFAULT 'pending'
                                CHECK (intake_status IN ('pending','triaged','discarded','failed')),
     intake_confidence      text CHECK (intake_confidence IS NULL OR intake_confidence IN ('low','medium','high')),
-    -- Reassessment kicked off by this dispute, when routing = 'reassess'.
     reassessment_session_id uuid REFERENCES sessions(id) ON DELETE SET NULL,
     reassessment_decision   text,
     reassessment_flipped    boolean NOT NULL DEFAULT false,
     reply_comment_id        bigint,
-    -- Ground truth. Only 'upheld' or 'corroborated' feed the tuning engine.
+    -- Evidence standard. Only 'independent_contradiction' and 'upheld' may
+    -- generate a proposal, and only when `trusted` is true.
     corroboration_status   text NOT NULL DEFAULT 'pending'
                                CHECK (corroboration_status IN (
-                                   'pending','corroborated','refuted','inconclusive','upheld','rejected')),
+                                   'pending','independent_contradiction','upheld',
+                                   'rejected','weak','inconclusive')),
     corroboration_detail   jsonb NOT NULL DEFAULT '{}',
     corroborated_at        timestamptz,
     adjudicated_by_user_id uuid REFERENCES users(id),
     adjudicated_at         timestamptz,
     adjudication_note      text,
-    cluster_key            text,
     created_at             timestamptz NOT NULL DEFAULT now(),
     updated_at             timestamptz NOT NULL DEFAULT now()
 );
 
--- Each GitHub comment yields at most one dispute; webhook redelivery and comment
--- edits update in place rather than filing a second objection. Deliberately not
--- unique per (session, filer): one person may raise two distinct objections, and
--- collapsing them would lose a signal.
+-- Each GitHub comment yields at most one dispute; redelivery and comment edits
+-- update in place. Deliberately not unique per (session, filer): one person may
+-- raise two distinct objections and collapsing them would lose a signal.
 CREATE UNIQUE INDEX idx_cr_disputes_github_comment
     ON code_review_decision_disputes (github_comment_id) WHERE github_comment_id IS NOT NULL;
 CREATE UNIQUE INDEX idx_cr_disputes_delivery
     ON code_review_decision_disputes (github_delivery_id) WHERE github_delivery_id IS NOT NULL;
-CREATE INDEX idx_cr_disputes_cluster
-    ON code_review_decision_disputes (org_id, repository_id, cluster_key, created_at DESC)
-    WHERE corroboration_status IN ('corroborated','upheld');
 CREATE INDEX idx_cr_disputes_intake
     ON code_review_decision_disputes (org_id, intake_status, created_at)
     WHERE intake_status = 'pending';
 CREATE INDEX idx_cr_disputes_pending
     ON code_review_decision_disputes (org_id, corroboration_status, created_at)
     WHERE corroboration_status = 'pending' AND intake_status = 'triaged';
--- Enforces the per-head reassessment cap without a table scan.
-CREATE INDEX idx_cr_disputes_reassessments
-    ON code_review_decision_disputes (pull_request_id, reviewed_head_sha)
-    WHERE reassessment_session_id IS NOT NULL;
+-- Proposal-eligible disputes awaiting a proposal.
+CREATE INDEX idx_cr_disputes_eligible
+    ON code_review_decision_disputes (org_id, repository_id, direction, corroborated_at DESC)
+    WHERE trusted = true AND corroboration_status IN ('independent_contradiction','upheld');
+CREATE INDEX idx_cr_disputes_session
+    ON code_review_decision_disputes (session_id, created_at);
 
 CREATE TABLE code_review_policy_proposals (
     id                   uuid PRIMARY KEY DEFAULT gen_random_uuid(),
     org_id               uuid NOT NULL REFERENCES organizations(id),
     repository_id        uuid REFERENCES repositories(id),
     base_policy_id       uuid NOT NULL REFERENCES code_review_policies(id),
-    cluster_key          text NOT NULL,
+    source_dispute_id    uuid NOT NULL REFERENCES code_review_decision_disputes(id),
+    direction            text NOT NULL CHECK (direction IN ('loosen','tighten')),
+    change_kind          text NOT NULL CHECK (change_kind IN ('prompt','deterministic')),
     origin               text NOT NULL CHECK (origin IN ('deterministic_rule','agent_session','manual')),
     generator_session_id uuid REFERENCES sessions(id),
-    status               text NOT NULL DEFAULT 'open'
-                             CHECK (status IN ('open','activated','dismissed','superseded','expired')),
+    status               text NOT NULL DEFAULT 'replaying'
+                             CHECK (status IN ('replaying','open','activated','dismissed','superseded','expired')),
     -- Structured, validated policy delta. Never raw config replacement.
     proposed_changes     jsonb NOT NULL,
     rationale            text NOT NULL,
-    evidence_session_ids uuid[] NOT NULL DEFAULT '{}',
-    dispute_count        int NOT NULL DEFAULT 0,
+    -- Replay outcomes. Target = the motivating dispute; guard = held-out set.
+    replay_status        text NOT NULL DEFAULT 'pending'
+                             CHECK (replay_status IN ('pending','running','complete','failed')),
+    replay_target_result jsonb NOT NULL DEFAULT '{}',
+    replay_guard_result  jsonb NOT NULL DEFAULT '{}',
+    guard_regressions    int NOT NULL DEFAULT 0,
     activated_policy_id  uuid REFERENCES code_review_policies(id),
     decided_by_user_id   uuid REFERENCES users(id),
     decided_at           timestamptz,
@@ -543,38 +669,80 @@ CREATE TABLE code_review_policy_proposals (
     created_at           timestamptz NOT NULL DEFAULT now()
 );
 
-CREATE UNIQUE INDEX idx_cr_proposals_open_cluster
-    ON code_review_policy_proposals (org_id, COALESCE(repository_id, '00000000-0000-0000-0000-000000000000'::uuid), cluster_key)
-    WHERE status = 'open';
+CREATE UNIQUE INDEX idx_cr_proposals_open_dispute
+    ON code_review_policy_proposals (source_dispute_id) WHERE status IN ('replaying','open');
 CREATE INDEX idx_cr_proposals_org_status
     ON code_review_policy_proposals (org_id, status, created_at DESC);
 
--- Denormalized per-decision outcome facts, so Insights and corroboration do not
--- re-derive PR history on every read.
+-- Frontier + random sampling of approvals for human spot-check.
+CREATE TABLE code_review_approval_audits (
+    id                 uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    org_id             uuid NOT NULL REFERENCES organizations(id),
+    session_id         uuid NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
+    repository_id      uuid NOT NULL REFERENCES repositories(id),
+    pull_request_id    uuid NOT NULL REFERENCES pull_requests(id) ON DELETE CASCADE,
+    policy_id          uuid NOT NULL REFERENCES code_review_policies(id),
+    -- Never exposed to the reviewing admin: the random arm is the control.
+    selection          text NOT NULL CHECK (selection IN ('frontier','random')),
+    frontier_score     numeric(6,4) NOT NULL DEFAULT 0,
+    frontier_factors   jsonb NOT NULL DEFAULT '{}',
+    status             text NOT NULL DEFAULT 'queued'
+                           CHECK (status IN ('queued','reviewed','expired')),
+    verdict            text CHECK (verdict IS NULL OR verdict IN ('correct','should_not_have_approved')),
+    resulting_dispute_id uuid REFERENCES code_review_decision_disputes(id),
+    reviewed_by_user_id uuid REFERENCES users(id),
+    reviewed_at        timestamptz,
+    note               text,
+    created_at         timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE UNIQUE INDEX idx_cr_audits_session ON code_review_approval_audits (session_id);
+CREATE INDEX idx_cr_audits_queue ON code_review_approval_audits (org_id, status, created_at)
+    WHERE status = 'queued';
+
+-- Held-out decisions used as the replay regression baseline.
+CREATE TABLE code_review_guard_set_members (
+    id                uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    org_id            uuid NOT NULL REFERENCES organizations(id),
+    repository_id     uuid NOT NULL REFERENCES repositories(id),
+    session_id        uuid NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
+    expected_decision text NOT NULL,
+    added_by          text NOT NULL CHECK (added_by IN ('bootstrap','spot_check','admin')),
+    active            boolean NOT NULL DEFAULT true,
+    created_at        timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE UNIQUE INDEX idx_cr_guard_session ON code_review_guard_set_members (session_id) WHERE active = true;
+CREATE INDEX idx_cr_guard_repo ON code_review_guard_set_members (org_id, repository_id) WHERE active = true;
+
+-- Denormalized per-decision outcome facts for Insights and corroboration.
 CREATE TABLE code_review_decision_outcomes (
-    session_id                uuid PRIMARY KEY REFERENCES sessions(id) ON DELETE CASCADE,
-    org_id                    uuid NOT NULL REFERENCES organizations(id),
-    repository_id             uuid NOT NULL REFERENCES repositories(id),
-    pull_request_id           uuid NOT NULL REFERENCES pull_requests(id) ON DELETE CASCADE,
-    policy_id                 uuid NOT NULL REFERENCES code_review_policies(id),
-    decision                  text NOT NULL,
-    reason_codes              text[] NOT NULL DEFAULT '{}',
-    merged                    boolean NOT NULL DEFAULT false,
-    merged_at                 timestamptz,
-    human_requested_changes   boolean NOT NULL DEFAULT false,
+    session_id                 uuid PRIMARY KEY REFERENCES sessions(id) ON DELETE CASCADE,
+    org_id                     uuid NOT NULL REFERENCES organizations(id),
+    repository_id              uuid NOT NULL REFERENCES repositories(id),
+    pull_request_id            uuid NOT NULL REFERENCES pull_requests(id) ON DELETE CASCADE,
+    policy_id                  uuid NOT NULL REFERENCES code_review_policies(id),
+    decision                   text NOT NULL,
+    reason_codes               text[] NOT NULL DEFAULT '{}',
+    merged                     boolean NOT NULL DEFAULT false,
+    merged_at                  timestamptz,
+    -- Independent human contradiction inputs. Author and disputer are excluded
+    -- when evaluating these.
+    independent_approver_login text,
+    independent_blocking_review_login text,
     human_review_comment_count int NOT NULL DEFAULT 0,
-    reverted                  boolean NOT NULL DEFAULT false,
-    reverted_at               timestamptz,
-    terminal                  boolean NOT NULL DEFAULT false,
-    observed_until            timestamptz,
-    updated_at                timestamptz NOT NULL DEFAULT now()
+    reverted                   boolean NOT NULL DEFAULT false,
+    reverted_at                timestamptz,
+    terminal                   boolean NOT NULL DEFAULT false,
+    observed_until             timestamptz,
+    updated_at                 timestamptz NOT NULL DEFAULT now()
 );
 
 CREATE INDEX idx_cr_outcomes_org_repo ON code_review_decision_outcomes (org_id, repository_id, updated_at DESC);
 CREATE INDEX idx_cr_outcomes_reason_codes ON code_review_decision_outcomes USING gin (reason_codes);
 ```
 
-The reassessment path needs a new trigger source on existing tables:
+Alterations to existing tables:
 
 ```sql
 -- internal/models/code_review.go gains CodeReviewTriggerSourceDisputeReassessment.
@@ -584,43 +752,47 @@ ALTER TABLE code_review_session_metadata
         CHECK (trigger_source IN ('app_reviewer','alias_reviewer','team_reviewer',
                                   'slash_command','auto_policy','dispute_reassessment'));
 
--- Links a reassessment session back to the objection that caused it.
 ALTER TABLE code_review_session_metadata
-    ADD COLUMN triggering_dispute_id uuid REFERENCES code_review_decision_disputes(id);
+    ADD COLUMN triggering_dispute_id uuid REFERENCES code_review_decision_disputes(id),
+    -- Risk reasons are only recorded when a gate FAILS, so an approval currently
+    -- leaves no record of how close it came. Frontier margin scoring needs these.
+    ADD COLUMN files_changed int,
+    ADD COLUMN lines_changed int;
+
+-- Reviewer-side bot-loop budget, mirroring the doc 116 epoch mechanic.
+ALTER TABLE pull_requests
+    ADD COLUMN code_review_dispute_epoch bigint NOT NULL DEFAULT 0,
+    ADD COLUMN code_review_dispute_cycles_in_epoch integer NOT NULL DEFAULT 0,
+    ADD CONSTRAINT chk_pr_code_review_dispute_cycles
+        CHECK (code_review_dispute_cycles_in_epoch >= 0);
 ```
 
 New job types on the existing queue:
 
 | Job type | Queue | Trigger |
 | --- | --- | --- |
-| `triage_code_review_dispute` | `feedback` | Comment captured on a reviewed PR, or a dispute filed in the app |
-| `run_code_review` (existing) | `agent` | Triage routed `reassess`; enqueued with `trigger_source = 'dispute_reassessment'`, deduped on dispute id |
-| `reply_code_review_dispute` | `feedback` | Triage routed `policy_signal_only` or `answer_only`, or a reassessment completed |
-| `corroborate_code_review_dispute` | `feedback` | Reassessment settles, PR reaches terminal state, or corroboration window expires |
-| `cluster_code_review_disputes` | `feedback` | Scheduled, hourly per org with new corroborated disputes |
-| `generate_code_review_policy_proposal` | `agent` | Cluster crosses threshold |
-| `digest_code_review_insights` | `feedback` | Scheduled, weekly per org |
+| `triage_code_review_dispute` | `feedback` | Comment captured on a reviewed PR, or dispute filed in the app |
+| `run_code_review` (existing) | `agent` | Triage routed `reassess`; `trigger_source = 'dispute_reassessment'`, deduped on dispute id |
+| `reply_code_review_dispute` | `feedback` | Triage routed `policy_signal_only` / `answer_only`, or a reassessment completed |
+| `corroborate_code_review_dispute` | `feedback` | Reassessment settles, PR reaches terminal state, or window expires |
+| `generate_code_review_policy_proposal` | `agent` | A dispute becomes proposal-eligible |
+| `replay_code_review_policy_proposal` | `agent` | Proposal created; orchestrator-only replay over target + guard sets |
+| `sample_code_review_approvals` | `feedback` | Scheduled weekly per org; frontier + random selection |
+| `digest_code_review_insights` | `feedback` | Scheduled weekly per org |
 
-Reassessment reuses the existing `run_code_review` handler unchanged; only the
-request-orchestration path in `internal/services/codereview` learns the new
-trigger source and the per-head cap.
-
-Two new policy knobs, versioned with the rest of `code_review_policies`:
-
-| Field | Default | Meaning |
-| --- | --- | --- |
-| `dispute_reassessment_enabled` | `true` | Whether a dispute may rerun the review at all |
-| `max_dispute_reassessments_per_head` | `2` | Cap per PR head SHA before disputes become record-only |
+Reassessment reuses the `run_code_review` handler unchanged; only request
+orchestration in `internal/services/codereview` learns the new trigger source and
+the trust gate.
 
 New audit actions: `code_review_dispute.filed`, `code_review_dispute.reassessed`,
-`code_review_dispute.adjudicated`, `code_review_policy_proposal.activated`,
-`code_review_policy_proposal.dismissed`.
+`code_review_dispute.adjudicated`, `code_review_approval_audit.reviewed`,
+`code_review_policy_proposal.activated`, `code_review_policy_proposal.dismissed`.
 
 ## API Contract
 
 All routes are org-scoped and follow existing auth conventions. Filing and
-reading disputes is member-level; adjudication and proposal decisions are
-admin-level.
+reading disputes is member-level; adjudication, spot-check verdicts, and proposal
+decisions are admin-level.
 
 ```
 POST   /api/v1/code-reviews/{session_id}/disputes
@@ -629,35 +801,52 @@ POST   /api/v1/code-reviews/{session_id}/disputes
        201 ->   CodeReviewDispute   // intake_status "pending"; triage runs async
        errors:  404 review not found · 422 empty body
        note:    No 409. Multiple distinct objections on one review are legitimate;
-                only GitHub-sourced disputes dedupe, on comment id.
+                only GitHub-sourced disputes dedupe, on comment id. Direction is
+                inferred by triage, never supplied by the caller.
 
 GET    /api/v1/code-reviews/{session_id}/disputes
-       200 ->   { "data": CodeReviewDispute[] }   // includes routing, reassessment linkage
+       200 ->   { "data": CodeReviewDispute[] }   // routing, trust, reassessment linkage
 
 PATCH  /api/v1/code-review-disputes/{id}            (admin)
        body:    { "corroboration_status": "upheld" | "rejected", "adjudication_note": string? }
        200 ->   CodeReviewDispute
        errors:  403 not an admin · 409 already adjudicated
 
+GET    /api/v1/code-review-approval-audits          (admin)
+       query:   status?, repository_id?
+       200 ->   { "data": CodeReviewApprovalAudit[] }
+       note:    `selection` is omitted from the response while status = "queued";
+                the random control only works if the reviewer cannot see the arm.
+
+POST   /api/v1/code-review-approval-audits/{id}/verdict   (admin)
+       body:    { "verdict": "correct" | "should_not_have_approved", "note": string? }
+       200 ->   { "audit": CodeReviewApprovalAudit, "dispute": CodeReviewDispute? }
+       note:    A "should_not_have_approved" verdict creates an upheld dispute in
+                the should_not_have_approved direction. A "correct" verdict adds
+                the session to the guard set.
+
 GET    /api/v1/code-review-insights
-       query:   repository_id?, from?, to?, decision?, reason_code?
+       query:   repository_id?, from?, to?, decision?, reason_code?, direction?
        200 ->   { "data": {
-                    "decisions_by_reason": [{ "reason_code", "count", "dispute_count",
-                                              "corroborated_count", "dispute_rate" }],
-                    "decision_totals":     { "approved", "comment_only", "needs_human_review", "blocked" },
-                    "outcomes":            { "merged_clean", "human_requested_changes", "reverted" },
+                    "decisions_by_reason":  [{ "reason_code","count","dispute_count",
+                                               "qualifying_count","dispute_rate" }],
+                    "decision_totals":      { "approved","comment_only","needs_human_review","blocked" },
+                    "disputes_by_direction":{ "should_have_approved","should_not_have_approved" },
+                    "reassessment_flip_rate_by_attempt": [{ "attempt","flips","runs" }],
+                    "spot_check":           { "frontier_hit_rate","random_hit_rate","false_approval_rate" },
                     "median_decision_seconds": number,
-                    "false_approval_rate_by_policy_version": [{ "policy_id", "version", "rate" }]
+                    "policy_versions":      [{ "policy_id","version","decision_mix","false_approval_rate" }]
                  } }
 
 GET    /api/v1/code-review-policy-proposals
-       query:   status?, repository_id?
-       200 ->   { "data": CodeReviewPolicyProposal[] }
+       query:   status?, repository_id?, direction?
+       200 ->   { "data": CodeReviewPolicyProposal[] }   // includes replay results
 
 POST   /api/v1/code-review-policy-proposals/{id}/activate      (admin)
        body:    { "proposed_changes": object? }   // optional edited delta
        200 ->   { "policy": CodeReviewPolicy, "proposal": CodeReviewPolicyProposal }
-       errors:  409 not open / base policy superseded · 422 delta fails policy validation
+       errors:  409 not open / replay incomplete / base policy superseded
+                422 delta fails policy validation
                 403 delta touches a locked dimension
 
 POST   /api/v1/code-review-policy-proposals/{id}/dismiss       (admin)
@@ -666,54 +855,54 @@ POST   /api/v1/code-review-policy-proposals/{id}/dismiss       (admin)
 ```
 
 The GitHub path adds no route and parses no syntax. The existing `issue_comment`
-and `pull_request_review_comment` webhook handlers capture replies in the bot's
-rolling-comment thread and comments mentioning the bot on any PR it has reviewed,
-create the record with `source = 'github_comment'` deduplicated on
-`github_delivery_id`, and enqueue triage. Whether a captured comment is a dispute
-at all is decided by triage, not by the handler.
+and `pull_request_review_comment` handlers capture replies in the bot's
+rolling-comment thread and comments mentioning the bot on any PR it reviewed,
+evaluate eligibility via `evaluatePRFeedbackEligibility`, create the record with
+`source = 'github_comment'` deduplicated on `github_delivery_id`, and enqueue
+triage. Whether a captured comment is a dispute at all is decided by triage, not
+by the handler.
 
-Activation validates the delta against the same policy validation used by
+Activation validates the delta against the same validation used by
 `PUT /api/v1/code-review-policies`, then writes a new insert-only version. It
 never patches a policy row in place, so approvals continue to point at the exact
 version that produced them.
 
 ## Success Metrics
 
-- Share of non-approvals where someone objects — the miscalibration signal that
-  does not exist today. Expect this to rise when intake becomes free-text, which
-  is the feature working, not the bot getting worse.
-- Triage accuracy, sampled by hand: objections recorded as `not_a_dispute` are
-  the silent failure this document exists to prevent, and matter far more than
-  the reverse error.
-- Reassessment flip rate, split by whether the dispute asserted new information.
-  Flips on genuinely new facts are the loop working. Flips on identical inputs
-  mean the judgment layer is non-deterministic, which is a different bug and
-  should be fixed rather than tuned around.
-- Median time from objection to a substantive reply, and to a flipped decision
-  where one occurs — the developer-facing latency this feature is judged on.
-- Corroboration rate of disputes, by reason code. A reason code with a high
-  dispute rate *and* high corroboration is a genuinely miscalibrated rule; high
-  dispute rate with low corroboration means the explanation is unclear, not the
-  policy wrong. Phase 0 should move the second number without moving the first.
-- Proposal activation rate, and dismissal reasons.
-- False-approval rate per policy version after activation — the guardrail metric.
-- Median time from non-approval to policy correction, versus today's unbounded.
+- **Share of non-approvals where someone objects.** The miscalibration signal
+  that does not exist today. Expect it to rise when intake becomes free-text —
+  that is the feature working, not the bot getting worse.
+- **Triage accuracy**, sampled by hand. Objections wrongly recorded as
+  `not_a_dispute` are the silent failure this document exists to prevent, and
+  matter far more than the reverse error.
+- **Frontier hit rate vs random hit rate.** If the two are equal, the frontier
+  score is worthless. This is the only check on the sampler.
+- **False approval rate**, from the random control arm — unbiased, and doc 112's
+  headline safety metric, currently uncomputable.
+- **Guard-set regression rate per activated proposal.** How often an activated
+  change flipped decisions that were correct. The metric that says whether
+  one-click activation is safe.
+- **Reassessment flip rate by attempt number.** Flips on new information are the
+  loop working; flips on unchanged inputs mean judgment-layer variance, which is
+  a different bug and should be fixed rather than tuned around.
+- **Median time from objection to a substantive reply**, and to a flipped
+  decision where one occurs. The developer-facing latency this is judged on.
+- **Proposal activation and dismissal rates**, split by `direction`. Persistent
+  asymmetry means the loop is drifting one way.
 
 ## Open Questions
 
-- Should a dispute filed by the PR author carry less clustering weight than one
-  filed by a third party, or is corroboration sufficient to handle bias alone?
-- What is the right corroboration window? 7 days captures most merges; revert and
-  incident signal needs 30.
-- Is 2 the right per-head reassessment cap? Too low and a legitimate two-round
-  clarification hits the wall; too high and rerolling becomes viable. Instrument
-  the flip rate by attempt number before settling it.
-- Should a reassessment that flips to approval require the new information to be
-  verifiable in the diff, rather than merely asserted by the author? Stricter and
-  safer, but it narrows the cases a rerun can resolve.
+- What is the right weekly spot-check queue size, and what frontier/random split?
+  Too large and nobody opens it; too small and the random arm never reaches
+  significance.
+- Should a proposal with any guard-set regression be blocked from one-click
+  activation and require an explicit override, or is showing the number enough?
+  Leaning toward blocking above a threshold, since the number is easy to skim past.
+- How long should the guard set retain a member before it becomes stale? Codebases
+  move, and a two-year-old decision may no longer be the right baseline.
 - Should triage treat a dispute from someone other than the PR author as
   `reassess`-eligible on a wider set of reason codes, given the weaker bias?
-- Should Insights be org-wide only, or per-repository with its own tuning
-  thresholds?
-- Do dismissed proposals suppress the cluster permanently, or decay back after a
-  policy change makes the evidence newly relevant?
+- Does the reviewer-side epoch budget need to be policy-configurable, or is a
+  fixed constant adequate given the marker should prevent the loop outright?
+- Should `should_not_have_approved` disputes on already-merged PRs trigger any
+  notification beyond the proposal, given the code is already in main?


### PR DESCRIPTION
## Summary

Code review decisions are final today with no way for developers to dispute them or for admins to learn from disagreements. This design doc establishes a feedback loop where developers can challenge decisions in plain English, admins can adjudicate disputes, and policy changes are proposed and replayed before activation. The system captures both "should have approved" and "should not have approved" feedback, with evidence rules that prevent complaints from loosening safety controls and spot-checking to catch false approvals.

## Changes

- **Phase 0**: Restructure decision rendering to group blockers by what would fix them (thresholds, findings, human judgment), show advisory findings in collapsed details, separate infrastructure failures from policy violations, and run cheap checks before expensive agent work.
- **Phase 1**: Capture disputes from GitHub comments and in-app UI, triage them to determine if they're genuine disagreements and whether they contain new information, rerun reviews for disputes with new evidence, and queue adjudications for admin review with ranking signals.
- **Phase 2**: Generate scoped prompt-edit proposals from upheld disputes, replay proposals against a guard set of known-good decisions before activation, and spot-check approvals proactively to find false positives.
- **Database schema**: New tables for disputes, proposals, approval audits, and guard-set members; new columns on sessions and PRs to track dispute context and bot-loop budgets.
- **API contract**: Routes for filing and reading disputes, adjudication queue, spot-check verdicts, proposal management, and insights aggregation.
- **Evidence rule**: Only admin adjudication changes policy; all other signals (reruns, human approvals, repeat disputes) rank the queue but decide nothing.

## Validation

Design document only; no implementation changes in this diff. This establishes the specification for subsequent implementation phases.

https://claude.ai/code/session_019BbUCLXKq5kMcEGabi7TkB