### PR TITLE
Fix preview session defaults and rebuild stale sandbox tools

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,12 @@
 # Stamp file tracking when the sandbox image was last built.
 SANDBOX_STAMP := sandbox/.build-stamp
-SANDBOX_SOURCES := sandbox/Dockerfile sandbox/versions.json
+# The sandbox image bakes ./cmd/tools into /usr/local/bin/143-tools. Resolve
+# that command's local package graph so make dev cannot pair new orchestrator
+# environment wiring with a stale CLI binary from a cached sandbox image.
+SANDBOX_CLI_PACKAGE_DIRS := $(shell GOOS=linux CGO_ENABLED=0 go list -deps -f '{{if .Module}}{{if eq .Module.Path "github.com/assembledhq/143"}}{{.Dir}}{{end}}{{end}}' ./cmd/tools 2>/dev/null)
+SANDBOX_CLI_GO_SOURCES := $(foreach dir,$(SANDBOX_CLI_PACKAGE_DIRS),$(filter-out %_test.go,$(wildcard $(dir)/*.go)))
+SANDBOX_CLI_EMBED_SOURCES := $(shell GOOS=linux CGO_ENABLED=0 go list -deps -f '{{if .Module}}{{if eq .Module.Path "github.com/assembledhq/143"}}{{range .EmbedFiles}}{{$$.Dir}}/{{.}} {{end}}{{end}}{{end}}' ./cmd/tools 2>/dev/null)
+SANDBOX_SOURCES := sandbox/Dockerfile sandbox/versions.json go.mod go.sum $(SANDBOX_CLI_PACKAGE_DIRS) $(SANDBOX_CLI_GO_SOURCES) $(SANDBOX_CLI_EMBED_SOURCES)
 
 .PHONY: dev dev-ngrok dev-local dev-frontend-only setup test test-race test-coverage test-pr test-coverage-diff test-main test-integration migrate-up migrate-down demo-seed-check build build-cli frontend-dev frontend-lint frontend-typecheck frontend-check lint lint-bootstrap lint-schema lint-stores lint-tenancy hooks-install hooks-uninstall secrets-setup secrets-encrypt secrets-decrypt secrets-edit secrets-rotate single-node-prepare single-node-up single-node-down provision-app provision-worker provision-workers provision-egress provision-db provision-db-backups provision-logging provision-redis tailscale-enroll repair-deploy-sudoers repair-worker-host spin-down-worker deploy deploy-app deploy-worker deploy-worker-preflight deploy-db deploy-logging deploy-fleet logs logs-query setup-readonly-user db-psql db-query
 
@@ -18,7 +24,7 @@ dev:
 	$(MAKE) sandbox-image; \
 	docker compose up --build
 
-# Only rebuild the sandbox image when Dockerfile or versions.json change.
+# Rebuild when the runtime definition or any baked 143-tools input changes.
 $(SANDBOX_STAMP): $(SANDBOX_SOURCES)
 	docker compose build sandbox
 	@touch $@

--- a/docs/design/future/115-agent-native-preview-verification.md
+++ b/docs/design/future/115-agent-native-preview-verification.md
@@ -1,6 +1,6 @@
 # Design: Agent-Native Preview Verification
 
-> **Status:** In progress — Phases 1–2 complete; Phase 3 automatic verification wired, adapter fix re-entry pending | **Last reviewed:** 2026-07-14
+> **Status:** In progress — Phases 1–2 complete; Phase 3 automatic verification wired, adapter fix re-entry pending | **Last reviewed:** 2026-07-30
 
 ## Implementation Status
 
@@ -68,7 +68,7 @@ credential exchange, or artifact plumbing:
 143-tools preview update --wait
 ```
 
-`143_SESSION_ID` is the implicit target. Explicit session and preview IDs remain
+`CODING_SESSION_ID` is the implicit target. Explicit session and preview IDs remain
 available for diagnostics and privileged workflows.
 
 ## Product Principles
@@ -330,7 +330,7 @@ New responsibilities should remain separated:
 
 - **Complete:** Separate public and internal API base URLs and normalize legacy environment
   values.
-- **Complete:** Default preview tools to `143_SESSION_ID` and inject it in every coding-agent
+- **Complete:** Default preview tools to `CODING_SESSION_ID` and inject it in every coding-agent
   launch path.
 - **Complete:** Add explicit preview capability mappings and same-session authorization tests.
 - **Complete:** Verify sandbox-token access to preview endpoints and artifact downloads.

--- a/docs/design/implemented/118-durable-session-publication.md
+++ b/docs/design/implemented/118-durable-session-publication.md
@@ -1,6 +1,6 @@
 # Durable Session Publication
 
-> **Status:** Implemented | **Last reviewed:** 2026-07-16
+> **Status:** Implemented | **Last reviewed:** 2026-07-30
 
 ## Problem
 
@@ -33,8 +33,8 @@ repository exclusively from the signed internal token. The legacy
 `/sessions/{session_id}/pr` route remains compatible, but any explicit ID must
 match the token. `143-tools pr create` uses the token-scoped route unless the
 caller explicitly supplies `session_id`. Sandboxes still receive
-`ASSEMBLED_SESSION_ID` and the legacy `143_SESSION_ID` for other session-aware
-tools, but those environment variables do not select PR authorization.
+`CODING_SESSION_ID` for other session-aware tools, but that contextual
+environment variable does not select PR authorization.
 
 Caller-supplied session IDs are therefore hints for compatibility, never the
 authorization source.

--- a/docs/public/guides/previews.mdx
+++ b/docs/public/guides/previews.mdx
@@ -108,11 +108,11 @@ Agents can run the same workflow from the sandbox:
 143-tools preview ensure --wait
 143-tools preview observe --path /
 143-tools preview update --wait
-143-tools preview multi_viewport --session-id "$143_SESSION_ID" --path /
-143-tools preview console --session-id "$143_SESSION_ID" --level error
+143-tools preview multi_viewport --session-id "$CODING_SESSION_ID" --path /
+143-tools preview console --session-id "$CODING_SESSION_ID" --level error
 ```
 
-The session ID defaults to `143_SESSION_ID` inside coding-agent sandboxes. The
+The session ID defaults to `CODING_SESSION_ID` inside coding-agent sandboxes. The
 session owns a durable browser identity. Cookies, local storage, current path,
 and viewport survive reloads and safe updates; compatible runtime replacements
 restore stored state. Observation responses explicitly report `preserved`,

--- a/docs/public/reference/agent-tools.mdx
+++ b/docs/public/reference/agent-tools.mdx
@@ -418,7 +418,7 @@ Common use: group errors by service, org, or endpoint before drilling into raw l
 
 ## Previews
 
-Preview commands use 143's platform-controlled preview lifecycle and browser inspector. For coding agents, prefer `--session-id` so screenshots and browser checks run against the live session workspace before the branch is published. Browser diagnostics also accept `--preview-id` for a known branch preview.
+Preview commands use 143's platform-controlled preview lifecycle and browser inspector. Inside a coding-agent sandbox, session-scoped commands default to `CODING_SESSION_ID`, so screenshots and browser checks run against the live session workspace before the branch is published. Browser diagnostics also accept an explicit `--session-id` or `--preview-id`.
 
 ### `preview create`
 
@@ -432,7 +432,7 @@ Create or reuse a preview.
 | `--wait` | boolean | No | Wait until the preview is ready or fails. |
 
 ```bash
-143-tools preview create --session-id "$143_SESSION_ID" --wait
+143-tools preview create --session-id "$CODING_SESSION_ID" --wait
 143-tools preview create --repository example-org/example-app --branch feature/foo --wait
 ```
 
@@ -481,7 +481,7 @@ Read status, URL, freshness, and the recommended update mode.
 | `--preview-id` | string | Conditional | Preview UUID for a branch preview. |
 
 ```bash
-143-tools preview status --session-id "$143_SESSION_ID"
+143-tools preview status --session-id "$CODING_SESSION_ID"
 ```
 
 ### `preview update`
@@ -490,7 +490,7 @@ Make a session preview reflect recent workspace edits. The platform selects the 
 
 | Flag | Type | Required | Description |
 |---|---|---:|---|
-| `--session-id` | string | Yes | Session UUID. |
+| `--session-id` | string | No in a coding-agent sandbox | Session UUID. Defaults to `CODING_SESSION_ID` in a coding-agent sandbox. |
 | `--path` | string | No | Path to reload/check. Defaults to `/`. |
 | `--wait` | boolean | No | Wait when a restart is started. |
 | `--force-mode` | string | No | Diagnostic override: `browser_reload`, `soft_service_restart`, `full_recycle`, `cold_relaunch`, or `noop_current`. |
@@ -498,7 +498,7 @@ Make a session preview reflect recent workspace edits. The platform selects the 
 | `--config` | JSON string | No | Optional preview config override. |
 
 ```bash
-143-tools preview update --session-id "$143_SESSION_ID" --wait
+143-tools preview update --session-id "$CODING_SESSION_ID" --wait
 ```
 
 ### Browser Inspection
@@ -516,11 +516,11 @@ Use these after creating or updating a preview. Pass either `--session-id` or `-
 | `preview assert` | target, `--assertions` | Run browser assertions from a JSON assertion array. |
 
 ```bash
-143-tools preview screenshot --session-id "$143_SESSION_ID" --path / --viewport-w 1280 --viewport-h 720 --inline-base64 false
-143-tools preview inspect --session-id "$143_SESSION_ID" --selector '[data-testid=save]'
-143-tools preview interact --session-id "$143_SESSION_ID" --steps '[{"action":"click","selector":"[data-testid=save]","screenshot":true}]'
-143-tools preview multi_viewport --session-id "$143_SESSION_ID" --path /
-143-tools preview console --session-id "$143_SESSION_ID" --level error
+143-tools preview screenshot --session-id "$CODING_SESSION_ID" --path / --viewport-w 1280 --viewport-h 720 --inline-base64 false
+143-tools preview inspect --session-id "$CODING_SESSION_ID" --selector '[data-testid=save]'
+143-tools preview interact --session-id "$CODING_SESSION_ID" --steps '[{"action":"click","selector":"[data-testid=save]","screenshot":true}]'
+143-tools preview multi_viewport --session-id "$CODING_SESSION_ID" --path /
+143-tools preview console --session-id "$CODING_SESSION_ID" --level error
 ```
 
 ## Messaging

--- a/internal/cli/changesets.go
+++ b/internal/cli/changesets.go
@@ -11,6 +11,8 @@ import (
 	"regexp"
 	"strings"
 	"time"
+
+	"github.com/assembledhq/143/internal/internalapi"
 )
 
 func runChangesets(args []string, stdout, stderr io.Writer) int {
@@ -18,7 +20,7 @@ func runChangesets(args []string, stdout, stderr io.Writer) int {
 		fmt.Fprintln(stderr, "Usage: 143-tools changesets <list|current|status|split-status|diff|create|materialize|verify|publish|publish-stack|restack|import-remote>")
 		return 1
 	}
-	sessionID := os.Getenv("143_SESSION_ID")
+	sessionID := codingSessionIDFromEnv()
 	changesetID := ""
 	title := ""
 	stackedOn := ""
@@ -53,7 +55,7 @@ func runChangesets(args []string, stdout, stderr io.Writer) int {
 		}
 	}
 	if sessionID == "" {
-		fmt.Fprintln(stderr, "error: --session-id is required when 143_SESSION_ID is not set")
+		fmt.Fprintf(stderr, "error: --session-id is required when %s is not set\n", internalapi.CodingSessionIDEnvVar)
 		return 1
 	}
 	cfg, err := LoadConfig()

--- a/internal/cli/preview_tools.go
+++ b/internal/cli/preview_tools.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/assembledhq/143/internal/internalapi"
 	"github.com/assembledhq/143/internal/services/mcp"
 )
 
@@ -48,9 +49,9 @@ func (e *previewToolExecutor) tools() []mcp.Tool {
 	return []mcp.Tool{
 		{
 			Name:        "preview_ensure",
-			Description: "Idempotently create or resume the current session preview. Defaults to 143_SESSION_ID.",
+			Description: "Idempotently create or resume the current session preview. Defaults to " + internalapi.CodingSessionIDEnvVar + ".",
 			InputSchema: mcp.ToolSchema{Type: "object", Properties: map[string]mcp.SchemaProperty{
-				"session_id": {Type: "string", Description: "Session ID; defaults to 143_SESSION_ID"},
+				"session_id": {Type: "string", Description: "Session ID; defaults to " + internalapi.CodingSessionIDEnvVar},
 				"wait":       {Type: "boolean", Description: "Wait until the preview is ready or fails"},
 			}},
 		},
@@ -292,7 +293,7 @@ func previewArgsWithSessionDefault(args json.RawMessage) json.RawMessage {
 	sessionID, _ := params["session_id"].(string)
 	previewID, _ := params["preview_id"].(string)
 	if strings.TrimSpace(sessionID) == "" && strings.TrimSpace(previewID) == "" {
-		if sessionID := strings.TrimSpace(os.Getenv("143_SESSION_ID")); sessionID != "" {
+		if sessionID := codingSessionIDFromEnv(); sessionID != "" {
 			params["session_id"] = sessionID
 		}
 	}
@@ -465,7 +466,7 @@ func previewSessionAndWait(args json.RawMessage) (string, bool, error) {
 		}
 	}
 	if params.SessionID == "" {
-		params.SessionID = strings.TrimSpace(os.Getenv("143_SESSION_ID"))
+		params.SessionID = codingSessionIDFromEnv()
 	}
 	if params.SessionID == "" {
 		return "", false, fmt.Errorf("session_id is required")
@@ -515,7 +516,7 @@ func previewTargetFromMap(params map[string]any) previewTarget {
 	internal, _ := params["__internal"].(bool)
 	target := previewTarget{SessionID: strings.TrimSpace(sessionID), PreviewID: strings.TrimSpace(previewID), Internal: internal}
 	if target.SessionID == "" && target.PreviewID == "" {
-		target.SessionID = strings.TrimSpace(os.Getenv("143_SESSION_ID"))
+		target.SessionID = codingSessionIDFromEnv()
 	}
 	return target
 }
@@ -559,7 +560,7 @@ func (e *previewToolExecutor) create(ctx context.Context, args json.RawMessage) 
 		return mcp.ErrorResult("sandbox preview tools operate on the current session; omit repository/branch to create the session preview")
 	}
 	if e.internal && params.SessionID == "" {
-		params.SessionID = strings.TrimSpace(os.Getenv("143_SESSION_ID"))
+		params.SessionID = codingSessionIDFromEnv()
 	}
 	if params.SessionID != "" {
 		if hasBranchTarget {
@@ -577,7 +578,7 @@ func (e *previewToolExecutor) create(ctx context.Context, args json.RawMessage) 
 		return jsonResult(resp.Data.view())
 	}
 	if e.internal {
-		return mcp.ErrorResult("sandbox preview tools require 143_SESSION_ID")
+		return mcp.ErrorResult("sandbox preview tools require " + internalapi.CodingSessionIDEnvVar)
 	}
 	if params.Repository == "" || params.Branch == "" {
 		return mcp.ErrorResult("session_id or repository and branch are required")
@@ -688,7 +689,7 @@ func (e *previewToolExecutor) list(ctx context.Context, args json.RawMessage) *m
 		}
 	}
 	if e.internal && strings.TrimSpace(params.SessionID) == "" {
-		params.SessionID = strings.TrimSpace(os.Getenv("143_SESSION_ID"))
+		params.SessionID = codingSessionIDFromEnv()
 	}
 	if strings.TrimSpace(params.SessionID) != "" {
 		result := e.sessionStatus(ctx, params.SessionID)
@@ -702,7 +703,7 @@ func (e *previewToolExecutor) list(ctx context.Context, args json.RawMessage) *m
 		return jsonResult([]map[string]any{status})
 	}
 	if e.internal {
-		return mcp.ErrorResult("sandbox preview tools require 143_SESSION_ID")
+		return mcp.ErrorResult("sandbox preview tools require " + internalapi.CodingSessionIDEnvVar)
 	}
 	var resp struct {
 		Data []branchPreviewWire `json:"data"`

--- a/internal/cli/preview_tools_test.go
+++ b/internal/cli/preview_tools_test.go
@@ -12,8 +12,10 @@ import (
 	"sync/atomic"
 	"testing"
 
-	"github.com/assembledhq/143/internal/services/mcp"
 	"github.com/stretchr/testify/require"
+
+	"github.com/assembledhq/143/internal/internalapi"
+	"github.com/assembledhq/143/internal/services/mcp"
 )
 
 func TestPreviewToolExecutor_SessionScreenshotOmitsInlineBase64(t *testing.T) {
@@ -47,8 +49,7 @@ func TestPreviewToolExecutor_SessionScreenshotOmitsInlineBase64(t *testing.T) {
 }
 
 func TestPreviewToolExecutor_InternalCreateRejectsBranchTarget(t *testing.T) {
-	// Not parallel: mutates process env via t.Setenv.
-	t.Setenv("143_SESSION_ID", "session-1")
+	t.Parallel()
 
 	executor := &previewToolExecutor{client: NewClient(Config{ServerURL: "http://unused.test", Token: "sandbox-token"}), internal: true}
 	result := executor.create(context.Background(), mustJSON(map[string]any{
@@ -205,10 +206,47 @@ func TestPreviewToolExecutor_RequestHandoffUsesSessionScopedEndpoint(t *testing.
 
 func TestPreviewArgsWithSessionDefault(t *testing.T) {
 	// Environment variables are process-global, so this test cannot run in parallel.
-	t.Setenv("143_SESSION_ID", "session-from-env")
+	t.Setenv(internalapi.CodingSessionIDEnvVar, " session-from-env ")
 	var actual map[string]any
 	require.NoError(t, json.Unmarshal(previewArgsWithSessionDefault(mustJSON(map[string]any{"path": "/"})), &actual), "defaulted arguments should remain valid JSON")
 	require.Equal(t, "session-from-env", actual["session_id"], "preview tools should default to the injected session ID")
+}
+
+func TestPreviewToolExecutor_InternalSessionCommandsDefaultToCodingSessionID(t *testing.T) {
+	// Environment variables are process-global, so this regression test and its subtests cannot run in parallel.
+	t.Setenv(internalapi.CodingSessionIDEnvVar, "session-from-env")
+
+	tests := []struct {
+		name     string
+		toolName string
+	}{
+		{name: "create", toolName: "preview_create"},
+		{name: "ensure", toolName: "preview_ensure"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var gotPath string
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				gotPath = r.URL.Path
+				require.Equal(t, http.MethodPost, r.Method, "session preview creation should use POST")
+				w.Header().Set("Content-Type", "application/json")
+				_, err := w.Write([]byte(`{"data":{"action":"created","instance":{"id":"preview-1","session_id":"session-from-env","status":"provisioning"}}}`))
+				require.NoError(t, err, "session preview response should write")
+			}))
+			defer server.Close()
+
+			executor := &previewToolExecutor{
+				client:   NewClient(Config{ServerURL: server.URL, Token: "sandbox-token"}),
+				internal: true,
+			}
+			result := executor.call(context.Background(), tt.toolName, mustJSON(map[string]any{}))
+
+			require.False(t, result.IsError, "session preview command should resolve the current coding session from the sandbox environment")
+			require.Equal(t, "/api/v1/internal/sessions/session-from-env/preview/ensure", gotPath, "session preview command should target the injected coding session")
+			require.Contains(t, firstText(result), `"preview_id": "preview-1"`, "session preview command should return the created preview")
+		})
+	}
 }
 
 func TestPreviewToolExecutor_ObserveWritesWorkspaceImage(t *testing.T) {

--- a/internal/cli/preview_tools_test.go
+++ b/internal/cli/preview_tools_test.go
@@ -212,6 +212,7 @@ func TestPreviewArgsWithSessionDefault(t *testing.T) {
 	require.Equal(t, "session-from-env", actual["session_id"], "preview tools should default to the injected session ID")
 }
 
+//nolint:paralleltest // uses t.Setenv, so the table subtests must share process-global environment serially
 func TestPreviewToolExecutor_InternalSessionCommandsDefaultToCodingSessionID(t *testing.T) {
 	// Environment variables are process-global, so this regression test and its subtests cannot run in parallel.
 	t.Setenv(internalapi.CodingSessionIDEnvVar, "session-from-env")

--- a/internal/cli/session_context.go
+++ b/internal/cli/session_context.go
@@ -1,0 +1,12 @@
+package cli
+
+import (
+	"os"
+	"strings"
+
+	"github.com/assembledhq/143/internal/internalapi"
+)
+
+func codingSessionIDFromEnv() string {
+	return strings.TrimSpace(os.Getenv(internalapi.CodingSessionIDEnvVar))
+}

--- a/internal/config/sandbox_image_wiring_test.go
+++ b/internal/config/sandbox_image_wiring_test.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -65,6 +66,35 @@ func TestSandboxImageWiring(t *testing.T) {
 				)
 			}
 		})
+	}
+}
+
+func TestSandboxImageRebuildTracksCLIInputs(t *testing.T) {
+	t.Parallel()
+
+	cmd := exec.Command("make", "-pn", "sandbox-image")
+	cmd.Dir = repoPath("")
+	output, err := cmd.Output()
+	require.NoError(t, err, "make should expand the sandbox image dependency graph")
+
+	database := string(output)
+	ruleStart := strings.Index(database, "sandbox/.build-stamp:")
+	require.NotEqual(t, -1, ruleStart, "make database should include the sandbox image stamp rule")
+	ruleEnd := strings.IndexByte(database[ruleStart:], '\n')
+	require.NotEqual(t, -1, ruleEnd, "sandbox image stamp rule should end with a newline")
+	rule := database[ruleStart : ruleStart+ruleEnd]
+
+	repoRoot, err := filepath.Abs(repoPath(""))
+	require.NoError(t, err, "test should resolve the repository root")
+	expectedInputs := []string{
+		"go.mod",
+		"go.sum",
+		filepath.Join(repoRoot, "cmd", "tools"),
+		filepath.Join(repoRoot, "internal", "cli", "preview_tools.go"),
+		filepath.Join(repoRoot, "internal", "internalapi", "env.go"),
+	}
+	for _, expected := range expectedInputs {
+		require.Contains(t, rule, expected, "sandbox image stamp should track every input that can change the baked 143-tools binary")
 	}
 }
 

--- a/internal/internalapi/env.go
+++ b/internal/internalapi/env.go
@@ -1,0 +1,6 @@
+package internalapi
+
+// CodingSessionIDEnvVar identifies the current coding session inside an agent
+// sandbox. It is contextual routing metadata; authorization remains derived
+// from the signed internal API token.
+const CodingSessionIDEnvVar = "CODING_SESSION_ID"

--- a/internal/internalapi/env_test.go
+++ b/internal/internalapi/env_test.go
@@ -1,0 +1,14 @@
+package internalapi
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCodingSessionIDEnvVarIsPortable(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t, "CODING_SESSION_ID", CodingSessionIDEnvVar, "coding session environment variable should use the platform-neutral public contract")
+	require.Regexp(t, `^[A-Za-z_][A-Za-z0-9_]*$`, CodingSessionIDEnvVar, "coding session environment variable should be portable across POSIX-compatible process launchers")
+}

--- a/internal/services/agent/orchestrator.go
+++ b/internal/services/agent/orchestrator.go
@@ -22,6 +22,7 @@ import (
 	"github.com/rs/zerolog"
 
 	"github.com/assembledhq/143/internal/auth"
+	"github.com/assembledhq/143/internal/internalapi"
 	"github.com/assembledhq/143/internal/jobctx"
 	"github.com/assembledhq/143/internal/models"
 	"github.com/assembledhq/143/internal/observability"
@@ -1716,11 +1717,7 @@ func (o *Orchestrator) injectInternalAPIEnv(ctx context.Context, session *models
 	}
 	sandboxCfg.Env["INTERNAL_API_TOKEN"] = internalToken
 	sandboxCfg.Env["INTERNAL_API_URL"] = o.internalAPIURL
-	sandboxCfg.Env["ASSEMBLED_SESSION_ID"] = session.ID.String()
-	// Compatibility for existing skills and older 143-tools binaries. New
-	// clients use the token-derived current-session endpoint and do not depend
-	// on either environment variable for authorization.
-	sandboxCfg.Env["143_SESSION_ID"] = session.ID.String()
+	sandboxCfg.Env[internalapi.CodingSessionIDEnvVar] = session.ID.String()
 	if evalBootstrapRunID != nil {
 		sandboxCfg.Env["EVAL_BOOTSTRAP_TOOLS_ENABLED"] = "true"
 		sandboxCfg.Env["EVAL_BOOTSTRAP_RUN_ID"] = evalBootstrapRunID.String()

--- a/internal/services/agent/orchestrator_internal_test.go
+++ b/internal/services/agent/orchestrator_internal_test.go
@@ -17,12 +17,45 @@ import (
 	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/require"
 
+	"github.com/assembledhq/143/internal/auth"
+	"github.com/assembledhq/143/internal/internalapi"
 	"github.com/assembledhq/143/internal/models"
 	"github.com/assembledhq/143/internal/repoconfig"
 	"github.com/assembledhq/143/internal/services/sandbox"
 	"github.com/assembledhq/143/internal/services/sandboxauth"
 	"github.com/assembledhq/143/internal/services/workspace"
 )
+
+func TestOrchestratorInjectInternalAPIEnvUsesCodingSessionID(t *testing.T) {
+	t.Parallel()
+
+	secret := "test-internal-api-secret"
+	sessionID := uuid.New()
+	orgID := uuid.New()
+	repoID := uuid.New()
+	threadID := uuid.New()
+	session := &models.Session{ID: sessionID, OrgID: orgID}
+	cfg := &SandboxConfig{
+		Timeout: time.Minute,
+		Env:     map[string]string{"EXISTING_ENV": "preserved"},
+	}
+	orchestrator := &Orchestrator{
+		internalAPIURL:    "https://platform.test",
+		internalAPISecret: secret,
+	}
+
+	orchestrator.injectInternalAPIEnv(context.Background(), session, &repoID, &threadID, cfg, zerolog.Nop())
+
+	require.Equal(t, sessionID.String(), cfg.Env[internalapi.CodingSessionIDEnvVar], "sandbox environment should expose the platform-neutral coding session identifier")
+	require.Equal(t, "https://platform.test", cfg.Env["INTERNAL_API_URL"], "sandbox environment should preserve the configured internal API origin")
+	require.Equal(t, "preserved", cfg.Env["EXISTING_ENV"], "session context injection should preserve unrelated environment variables")
+	require.Len(t, cfg.Env, 4, "session context injection should add only the canonical session ID and internal API credentials")
+
+	claims, err := auth.ValidateInternalToken(secret, cfg.Env["INTERNAL_API_TOKEN"])
+	require.NoError(t, err, "injected internal API token should be valid")
+	require.Equal(t, &sessionID, claims.SessionID, "injected internal API token should authorize the same session exposed in the environment")
+	require.Equal(t, &threadID, claims.ThreadID, "injected internal API token should remain scoped to the active thread")
+}
 
 func TestSessionPromptStyleCodeReviewUsesRawTask(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
## Summary

- Replace legacy `143_SESSION_ID`/`ASSEMBLED_SESSION_ID` usage with `CODING_SESSION_ID` across sandbox wiring, CLI tools, and documentation.
- Ensure preview and changeset commands resolve the current coding session from the environment.
- Track `143-tools` dependencies in sandbox image rebuild inputs to prevent stale CLI binaries.
- Add regression coverage for environment injection, preview defaults, and Make dependency tracking.

## Testing

- Added focused Go tests covering session environment wiring and preview command defaults.
- Added sandbox image dependency graph validation.