### PR TITLE
Remove redundant Review policy header and description from page

### DIFF
--- a/frontend/src/app/(dashboard)/code-reviews/page.tsx
+++ b/frontend/src/app/(dashboard)/code-reviews/page.tsx
@@ -1427,8 +1427,6 @@ export default function CodeReviewsPage() {
 
           <TabsContent value="policy" className="space-y-4">
             <SectionGroup
-              title="Review policy"
-              description="Set how reviews run, what guidance they follow, and when approval is allowed."
               action={<AutosaveIndicator status={autosave.status} />}
               className="max-w-5xl"
             >


### PR DESCRIPTION
## Summary

The Code Reviews “Policy” tab shows a redundant “Review policy” header and description, which adds noise to the user’s workflow. This change removes the extra heading/description while keeping the autosave indicator, so the tab focuses on the actual policy controls without duplicating existing context.

## Changes

- Removed the “Review policy” `title` and `description` props from the policy tab `SectionGroup`.
- Kept the `AutosaveIndicator` action unchanged to preserve feedback on saving behavior.

## Validation

- Ran `git diff --check` (passes).
- Frontend lint not run because dependencies are not installed in this environment (`eslint: not found`).

[143.dev](https://143.dev) | [session 9189693f](https://143.dev/sessions/9189693f-654f-4806-982c-7c28b45d32fc)

<!-- 143 readiness -->
**143 readiness:** not available for this revision.

<!-- 143-publication session=9189693f-654f-4806-982c-7c28b45d32fc changeset=ab446908-b1cd-4a12-9119-2236767e7ee1 -->

Preview: https://143.dev/previews/github/assembledhq/143/pull/1977?launch=1