### PR TITLE
Investigate automations page rerender loop every 10 seconds and reduce to subtle updates

### DIFF
--- a/frontend/src/app/(dashboard)/automations/page.tsx
+++ b/frontend/src/app/(dashboard)/automations/page.tsx
@@ -595,7 +595,10 @@ export default function AutomationsPage() {
   const { data, isLoading } = useQuery({
     queryKey: queryKeys.automations.all,
     queryFn: () => api.automations.list(),
-    refetchInterval: 10000,
+    // The list changes infrequently and mutations already update and
+    // invalidate its cache. Let React Query refresh stale data on focus
+    // instead of redrawing the whole page on a fixed polling cadence.
+    staleTime: 30_000,
   });
 
   const automations = useMemo(() => data?.data ?? [], [data?.data]);


### PR DESCRIPTION
## Summary

The automations page was needlessly rerendering on a fixed 10-second polling loop, creating visual churn and extra network load for a list that changes infrequently. This PR removes interval refetching and instead relies on React Query’s stale-window behavior (refresh on focus/remount), while mutations already handle immediate updates via cache invalidation.

## Changes

- Updated `frontend/src/app/(dashboard)/automations/page.tsx` to remove `refetchInterval: 10000`
- Added `staleTime: 30_000` so the page refreshes only when cached data becomes stale
- Kept the existing memoization of `automations` (`useMemo`) to avoid unnecessary recomputes when data hasn’t changed

## Validation

- `Automations tests`: 7/7 passed
- `ESLint`: passed
- Diff checks: passed
- Note: Browser preview startup timed out, so no visual screenshot comparison was available.

[143.dev](https://143.dev) | [session af246cdb](https://143.dev/sessions/af246cdb-cb46-4fcc-a6d4-8e6436218cd0)

<!-- 143 readiness -->
**143 readiness:** not available for this revision.

<!-- 143-publication session=af246cdb-cb46-4fcc-a6d4-8e6436218cd0 changeset=d0e6e187-37e0-47ba-9d4f-028ad3c47464 -->

Preview: https://143.dev/previews/github/assembledhq/143/pull/1979?launch=1