### PR TITLE
Design Linear-style inline editing UX for automations with save/confirm flow

### DIFF
--- a/frontend/src/app/(dashboard)/automations/[id]/page.test.tsx
+++ b/frontend/src/app/(dashboard)/automations/[id]/page.test.tsx
@@ -13,6 +13,14 @@ import { AUTOMATION_GOAL_MAX_LENGTH } from "@/lib/automation-validation";
 
 const pushMock = vi.fn();
 const currentUserRole = vi.hoisted(() => ({ value: "member" }));
+const toast = vi.hoisted(() => ({
+  success: vi.fn(),
+  info: vi.fn(),
+  warning: vi.fn(),
+  error: vi.fn(),
+}));
+
+vi.mock("@/lib/notify", () => ({ notify: toast }));
 
 vi.mock("next/link", () => ({
   default: ({
@@ -46,6 +54,11 @@ vi.mock("./automation-stats-card", () => ({
   AutomationStatsCard: () => <div data-testid="automation-stats-card" />,
 }));
 
+// An unhandled request would REJECT, and the editor deliberately treats a
+// transport failure as "valid" so a dead preview can't wedge unrelated fields.
+// Tests that need the schedule to stay unsettled have to say so explicitly.
+const neverResolves = () => new Promise<never>(() => {});
+
 const selectEmojiOption = async (name: string) => {
   const listbox = await screen.findByRole("listbox");
   const option = listbox.querySelector<HTMLElement>(
@@ -59,6 +72,7 @@ describe("AutomationDetailPage", () => {
   beforeEach(() => {
     currentUserRole.value = "member";
     pushMock.mockReset();
+    toast.error.mockReset();
     server.use(
       http.get("*/api/v1/repositories/repo-1", () =>
         HttpResponse.json({
@@ -158,7 +172,18 @@ describe("AutomationDetailPage", () => {
     expect(headerEmoji).toHaveClass("h-auto", "p-0", "align-baseline");
     expect(headerEmoji).not.toHaveClass("size-9");
 
-    await userEvent.setup().click(screen.getByRole("button", { name: "Edit" }));
+    // The schedule is a compound control, so it lives in a popover hung off the
+    // Triggers property rather than a separate edit mode.
+    await userEvent
+      .setup()
+      .click(screen.getByRole("button", { name: "Triggers" }));
+
+    expect(
+      screen.queryByRole("dialog", { name: "Automation settings" }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Edit" }),
+    ).not.toBeInTheDocument();
 
     const timezoneButton = screen.getByTitle("UTC");
     const scheduleRow = timezoneButton.parentElement;
@@ -174,7 +199,7 @@ describe("AutomationDetailPage", () => {
     expect(screen.queryByText(/Run time is in/i)).not.toBeInTheDocument();
   });
 
-  it("keeps advanced automation controls collapsed by default", async () => {
+  it("keeps everyday properties inline and only rare ones behind Advanced", async () => {
     server.use(
       http.get("*/api/v1/automations/auto-1", () =>
         HttpResponse.json({
@@ -229,25 +254,25 @@ describe("AutomationDetailPage", () => {
       expect(screen.getByText("Weekly audit")).toBeInTheDocument();
     });
 
-    await userEvent.setup().click(screen.getByRole("button", { name: "Edit" }));
-
+    // No edit mode to enter: the goal and the day-to-day properties are already
+    // live controls on first paint.
     expect(screen.getByLabelText("Goal")).toHaveAttribute("rows", "9");
-    expect(
-      screen.queryByRole("combobox", { name: "Model" }),
-    ).not.toBeInTheDocument();
-    expect(
-      screen.queryByRole("button", { name: "Base branch" }),
-    ).not.toBeInTheDocument();
-    expect(screen.queryByLabelText("Review passes")).not.toBeInTheDocument();
-
-    await userEvent
-      .setup()
-      .click(screen.getByRole("button", { name: "Advanced settings" }));
-
     expect(screen.getByRole("combobox", { name: "Model" })).toBeInTheDocument();
     expect(
       screen.getByRole("button", { name: "Base branch" }),
     ).toBeInTheDocument();
+    expect(screen.getByLabelText("Scope")).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Triggers" }),
+    ).toBeInTheDocument();
+
+    // Only the rarely-touched knobs stay folded away.
+    expect(screen.queryByLabelText("Review passes")).not.toBeInTheDocument();
+
+    await userEvent
+      .setup()
+      .click(screen.getByRole("button", { name: "Advanced" }));
+
     expect(screen.getByLabelText("Review passes")).toBeInTheDocument();
   });
 
@@ -369,26 +394,22 @@ describe("AutomationDetailPage", () => {
       expect(screen.getByText("Weekly audit")).toBeInTheDocument();
     });
 
-    await user.click(screen.getByRole("button", { name: "Edit" }));
+    await user.click(screen.getByRole("button", { name: "Triggers" }));
     const intervalInput = screen.getByLabelText("Interval value");
     await user.clear(intervalInput);
 
     expect(intervalInput).toHaveValue(null);
-    expect(screen.getByRole("button", { name: "Save changes" })).toBeDisabled();
 
     await user.tab();
 
     expect(intervalInput).toHaveValue(1);
-    const saveButton = screen.getByRole("button", { name: "Save changes" });
-    await waitFor(() => expect(saveButton).toBeEnabled());
-    await user.click(saveButton);
 
-    // Blur restored the stored value, so the schedule ends up untouched and no
-    // schedule fields are sent — clearing the box must not be enough to make
-    // PATCH recompute next_run_at.
-    await waitFor(() => expect(updateBody).not.toBeNull());
-    expect(updateBody).not.toHaveProperty("interval_value");
-    expect(updateBody).not.toHaveProperty("timezone");
+    // Blur restored the stored value, so the draft never reaches a state that
+    // differs from what was loaded — and an autosave that fires per-field must
+    // not treat a transient empty box as a schedule change, or PATCH would
+    // recompute next_run_at for nothing.
+    await waitFor(() => expect(screen.getByTitle("UTC")).toBeInTheDocument());
+    expect(updateBody).toBeNull();
   });
 
   it("sends the interval when the value actually changes", async () => {
@@ -453,21 +474,15 @@ describe("AutomationDetailPage", () => {
       expect(screen.getByText("Weekly audit")).toBeInTheDocument();
     });
 
-    await user.click(screen.getByRole("button", { name: "Edit" }));
+    await user.click(screen.getByRole("button", { name: "Triggers" }));
     const intervalInput = screen.getByLabelText("Interval value");
     await user.clear(intervalInput);
     await user.type(intervalInput, "6");
     expect(intervalInput).toHaveValue(6);
 
-    // The preview is debounced; validity (and therefore the save button) only
-    // settles once it resolves for the edited draft.
+    // The preview is debounced, and the schedule commits itself only once the
+    // draft settles into a server-previewed state — no Save button involved.
     await screen.findByText(/Next run:/);
-    await waitFor(() =>
-      expect(
-        screen.getByRole("button", { name: "Save changes" }),
-      ).toBeEnabled(),
-    );
-    await user.click(screen.getByRole("button", { name: "Save changes" }));
 
     await waitFor(() => {
       expect(updateBody).toMatchObject({
@@ -544,7 +559,7 @@ describe("AutomationDetailPage", () => {
       expect(screen.getByText("Weekly audit")).toBeInTheDocument();
     });
 
-    await user.click(screen.getByRole("button", { name: "Edit" }));
+    await user.click(screen.getByRole("button", { name: "Triggers" }));
     await user.click(screen.getByRole("combobox", { name: "Interval unit" }));
     await user.click(await screen.findByRole("option", { name: "hours" }));
 
@@ -552,10 +567,6 @@ describe("AutomationDetailPage", () => {
     expect(
       screen.queryByRole("combobox", { name: "Run time" }),
     ).not.toBeInTheDocument();
-
-    const saveButton = screen.getByRole("button", { name: "Save changes" });
-    await waitFor(() => expect(saveButton).toBeEnabled());
-    await user.click(saveButton);
 
     // PATCH treats an absent interval_run_at as "unchanged", so an explicit ""
     // is the only thing that actually unanchors the stored schedule.
@@ -568,7 +579,7 @@ describe("AutomationDetailPage", () => {
     });
   });
 
-  it("sends no schedule fields when the schedule is untouched", async () => {
+  it("sends nothing at all when the trigger popover is opened but untouched", async () => {
     const user = userEvent.setup();
     let updateBody: Record<string, unknown> | null = null;
 
@@ -635,29 +646,20 @@ describe("AutomationDetailPage", () => {
       expect(screen.getByText("Weekly audit")).toBeInTheDocument();
     });
 
-    await user.click(screen.getByRole("button", { name: "Edit" }));
-    const saveButton = screen.getByRole("button", { name: "Save changes" });
-    await waitFor(() => expect(saveButton).toBeEnabled());
-    await user.click(saveButton);
+    await user.click(screen.getByRole("button", { name: "Triggers" }));
+    // Wait for the editor's debounced preview to settle, which is the point at
+    // which a genuine edit would commit.
+    await screen.findByText(/Next run:|Could not preview/);
 
-    await waitFor(() => expect(updateBody).not.toBeNull());
-    // Not just cron_expression: timezone alone is enough to make PATCH
-    // recompute next_run_at, which would push an interval automation's next
-    // run out by a full interval every time an unrelated field is saved.
-    for (const field of [
-      "schedule_type",
-      "cron_expression",
-      "interval_value",
-      "interval_unit",
-      "interval_run_at",
-      "timezone",
-    ]) {
-      expect(updateBody).not.toHaveProperty(field);
-    }
+    // Sunday-as-7 and an unsorted day list both round-trip to a
+    // different-but-equivalent cron expression, so simply looking at the
+    // schedule must not regenerate it. Timezone alone is enough to make PATCH
+    // recompute next_run_at, which would push the next run out by a full
+    // interval every time someone opened the popover to read the cadence.
+    expect(updateBody).toBeNull();
   });
 
   it("does not disturb an interval automation's next run when saving other fields", async () => {
-    const user = userEvent.setup();
     let updateBody: Record<string, unknown> | null = null;
 
     server.use(
@@ -720,26 +722,15 @@ describe("AutomationDetailPage", () => {
       expect(screen.getByText("Weekly audit")).toBeInTheDocument();
     });
 
-    await user.click(screen.getByRole("button", { name: "Edit" }));
-    fireEvent.change(screen.getByLabelText(/^Scope/), {
-      target: { value: "src/" },
-    });
-
-    const saveButton = screen.getByRole("button", { name: "Save changes" });
-    await waitFor(() => expect(saveButton).toBeEnabled());
-    await user.click(saveButton);
+    const scope = screen.getByLabelText("Scope");
+    fireEvent.change(scope, { target: { value: "src/" } });
+    fireEvent.blur(scope);
 
     await waitFor(() => expect(updateBody).not.toBeNull());
-    expect(updateBody).toMatchObject({ scope: "src/" });
-    for (const field of [
-      "schedule_type",
-      "interval_value",
-      "interval_unit",
-      "interval_run_at",
-      "timezone",
-    ]) {
-      expect(updateBody).not.toHaveProperty(field);
-    }
+    // Per-field autosave makes this structural rather than a guard someone has
+    // to remember: editing the scope can only ever send the scope, so PATCH has
+    // no schedule field to recompute next_run_at from.
+    expect(updateBody).toEqual({ scope: "src/" });
   });
 
   it("shows readable metadata and run actions in the details rail", async () => {
@@ -824,9 +815,9 @@ describe("AutomationDetailPage", () => {
 
     await userEvent
       .setup()
-      .click(screen.getByRole("button", { name: "Details" }));
+      .click(screen.getByRole("button", { name: "Properties" }));
     expect(
-      screen.getByRole("dialog", { name: "Automation details" }),
+      screen.getByRole("dialog", { name: "Automation properties" }),
     ).toBeInTheDocument();
     expect(screen.getAllByText("acme/repo").length).toBeGreaterThan(1);
   });
@@ -1052,6 +1043,115 @@ describe("AutomationDetailPage", () => {
     expect(
       screen.queryByRole("button", { name: "Save changes" }),
     ).not.toBeInTheDocument();
+
+    // Inline editing must not become an accidental permission grant: the same
+    // rows render as plain text for someone who cannot manage the automation.
+    expect(
+      screen.queryByRole("combobox", { name: "Repository" }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("combobox", { name: "Run as" }),
+    ).not.toBeInTheDocument();
+    expect(screen.queryByLabelText("Scope")).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Triggers" }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Base branch" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("reports autosave progress and rolls rejected property and trigger edits back", async () => {
+    const user = userEvent.setup();
+
+    server.use(
+      http.get("*/api/v1/automations/auto-1", () =>
+        HttpResponse.json({
+          data: {
+            id: "auto-1",
+            org_id: "org-1",
+            repository_id: "repo-1",
+            name: "Weekly audit",
+            goal: "Check release health",
+            scope: "",
+            identity_scope: "org",
+            interval_value: 1,
+            interval_unit: "weeks",
+            base_branch: "main",
+            enabled: true,
+            timezone: "UTC",
+            last_run_at: null,
+            next_run_at: null,
+            priority: 50,
+            created_at: "2026-01-01T00:00:00Z",
+            updated_at: "2026-01-01T00:00:00Z",
+          },
+        }),
+      ),
+      http.get("*/api/v1/automations/auto-1/runs*", () =>
+        HttpResponse.json({ data: [], meta: {} }),
+      ),
+      http.get("*/api/v1/automations/auto-1/stats*", () =>
+        HttpResponse.json({
+          data: {
+            since: "2026-01-01T00:00:00Z",
+            until: "2026-01-31T00:00:00Z",
+            buckets: [],
+            totals: {
+              total: 0,
+              completed: 0,
+              completed_noop: 0,
+              failed: 0,
+              skipped: 0,
+              running: 0,
+              pending: 0,
+              success_rate: 0,
+              avg_duration_seconds: 0,
+            },
+          },
+        }),
+      ),
+      http.patch("*/api/v1/automations/auto-1", () =>
+        HttpResponse.json({ error: "nope" }, { status: 500 }),
+      ),
+    );
+
+    renderWithProviders(<AutomationDetailPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Weekly audit")).toBeInTheDocument();
+    });
+
+    const runAs = screen.getByRole("combobox", { name: "Run as" });
+    expect(runAs).toHaveTextContent("Organization");
+
+    await user.click(runAs);
+    await user.click(await screen.findByRole("option", { name: "Personal" }));
+
+    // Without a Save button the indicator is the only signal that a click was
+    // persisted, so a failed write has to say so and put the value back.
+    expect(await screen.findByText("Couldn't save")).toBeInTheDocument();
+    await waitFor(() =>
+      expect(
+        screen.getByRole("combobox", { name: "Run as" }),
+      ).toHaveTextContent("Organization"),
+    );
+
+    await user.click(screen.getByRole("button", { name: "Triggers" }));
+    const intervalInput = screen.getByLabelText("Interval value");
+    await user.clear(intervalInput);
+    await user.type(intervalInput, "6");
+    await screen.findByText(/Next run:/);
+
+    // Trigger controls keep a local draft while their popover is open. A
+    // rejected schedule must restore that draft, not merely the query cache.
+    await waitFor(() => expect(intervalInput).toHaveValue(1));
+
+    const mergedTrigger = screen.getByRole("checkbox", {
+      name: "When a PR is merged",
+    });
+    await user.click(mergedTrigger);
+    await waitFor(() => expect(mergedTrigger).not.toBeChecked());
   });
 
   it("renders a back button to the automations list preserving query params", async () => {
@@ -1178,8 +1278,6 @@ describe("AutomationDetailPage", () => {
       expect(screen.getByText("Weekly audit")).toBeInTheDocument();
     });
 
-    await user.click(screen.getByRole("button", { name: "Edit" }));
-    await user.click(screen.getByRole("button", { name: "Advanced settings" }));
     await user.click(
       await screen.findByRole("button", { name: "Base branch" }),
     );
@@ -1188,42 +1286,41 @@ describe("AutomationDetailPage", () => {
       "ops",
     );
     await user.click(await screen.findByText("release/ops"));
-    await user.click(screen.getByRole("button", { name: "Save changes" }));
 
+    // Picking the branch is the save. Nothing else rides along with it.
     await waitFor(() => {
-      expect(updateBody).toMatchObject({
-        base_branch: "release/ops",
-        identity_scope: "org",
-      });
+      expect(updateBody).toEqual({ base_branch: "release/ops" });
     });
   });
 
   it("updates the repository and resets the base branch to its default", async () => {
     const user = userEvent.setup();
     let updateBody: Record<string, unknown> | null = null;
+    // Autosaved rows render whatever the server last returned, so the mock has
+    // to actually apply the patch — otherwise the refetch that follows every
+    // save would replay the pre-edit fixture and mask a real regression.
+    const stored: Record<string, unknown> = {
+      id: "auto-1",
+      org_id: "org-1",
+      repository_id: "repo-1",
+      name: "Weekly audit",
+      goal: "Check release health",
+      scope: "",
+      interval_value: 1,
+      interval_unit: "weeks",
+      base_branch: "main",
+      enabled: true,
+      timezone: "UTC",
+      last_run_at: null,
+      next_run_at: null,
+      priority: 50,
+      created_at: "2026-01-01T00:00:00Z",
+      updated_at: "2026-01-01T00:00:00Z",
+    };
 
     server.use(
       http.get("*/api/v1/automations/auto-1", () =>
-        HttpResponse.json({
-          data: {
-            id: "auto-1",
-            org_id: "org-1",
-            repository_id: "repo-1",
-            name: "Weekly audit",
-            goal: "Check release health",
-            scope: "",
-            interval_value: 1,
-            interval_unit: "weeks",
-            base_branch: "main",
-            enabled: true,
-            timezone: "UTC",
-            last_run_at: null,
-            next_run_at: null,
-            priority: 50,
-            created_at: "2026-01-01T00:00:00Z",
-            updated_at: "2026-01-01T00:00:00Z",
-          },
-        }),
+        HttpResponse.json({ data: { ...stored } }),
       ),
       http.get("*/api/v1/repositories", () =>
         HttpResponse.json({
@@ -1287,7 +1384,8 @@ describe("AutomationDetailPage", () => {
       ),
       http.patch("*/api/v1/automations/auto-1", async ({ request }) => {
         updateBody = (await request.json()) as Record<string, unknown>;
-        return HttpResponse.json({ data: { id: "auto-1" } });
+        Object.assign(stored, updateBody);
+        return HttpResponse.json({ data: { ...stored } });
       }),
     );
 
@@ -1297,30 +1395,29 @@ describe("AutomationDetailPage", () => {
       expect(screen.getByText("Weekly audit")).toBeInTheDocument();
     });
 
-    await user.click(screen.getByRole("button", { name: "Edit" }));
     await user.click(screen.getByRole("combobox", { name: "Repository" }));
     await user.click(
       await screen.findByRole("option", { name: "acme/worker" }),
     );
-    await user.click(screen.getByRole("button", { name: "Advanced settings" }));
 
-    expect(
-      screen.getByRole("button", { name: "Base branch" }),
-    ).toHaveTextContent("trunk");
-
-    await user.click(screen.getByRole("button", { name: "Save changes" }));
-
+    // The branch reset has to ride along in the same patch: a repository saved
+    // on its own would momentarily point at a branch the new repo may not have.
     await waitFor(() => {
-      expect(updateBody).toMatchObject({
+      expect(updateBody).toEqual({
         repository_id: "repo-2",
         base_branch: "trunk",
       });
     });
+    await waitFor(() =>
+      expect(
+        screen.getByRole("button", { name: "Base branch" }),
+      ).toHaveTextContent("trunk"),
+    );
   });
 
-  it("saves the selected personal automation identity scope", async () => {
+  it("saves identity scope and publish policy as independent edits", async () => {
     const user = userEvent.setup();
-    let updateBody: Record<string, unknown> | null = null;
+    const updateBodies: Record<string, unknown>[] = [];
 
     server.use(
       http.get("*/api/v1/automations/auto-1", () =>
@@ -1369,7 +1466,7 @@ describe("AutomationDetailPage", () => {
         }),
       ),
       http.patch("*/api/v1/automations/auto-1", async ({ request }) => {
-        updateBody = (await request.json()) as Record<string, unknown>;
+        updateBodies.push((await request.json()) as Record<string, unknown>);
         return HttpResponse.json({ data: { id: "auto-1" } });
       }),
     );
@@ -1380,22 +1477,25 @@ describe("AutomationDetailPage", () => {
       expect(screen.getByText("Weekly audit")).toBeInTheDocument();
     });
 
-    await user.click(screen.getByRole("button", { name: "Edit" }));
     await user.click(screen.getByRole("combobox", { name: "Run as" }));
-    await user.click(await screen.findByText("Personal automation"));
-    await user.click(screen.getByText("Advanced settings"));
+    await user.click(await screen.findByRole("option", { name: "Personal" }));
+
+    await waitFor(() =>
+      expect(updateBodies).toContainEqual({ identity_scope: "personal" }),
+    );
+
     await user.click(
       screen.getByRole("combobox", { name: "After a successful run" }),
     );
-    await user.click(await screen.findByText("Do not publish"));
-    await user.click(screen.getByRole("button", { name: "Save changes" }));
+    await user.click(
+      await screen.findByRole("option", { name: "Do not publish" }),
+    );
 
-    await waitFor(() => {
-      expect(updateBody).toMatchObject({
-        identity_scope: "personal",
-        publish_policy: "none",
-      });
-    });
+    // Two separate selects, two separate patches — neither carries the other's
+    // field, so a stale render of one can never overwrite the other.
+    await waitFor(() =>
+      expect(updateBodies).toContainEqual({ publish_policy: "none" }),
+    );
   });
 
   it("saves the selected automation emoji inline", async () => {
@@ -1475,7 +1575,7 @@ describe("AutomationDetailPage", () => {
     });
   });
 
-  it("edits the title inline and keeps title and goal out of settings", async () => {
+  it("edits the title inline without disturbing an in-progress scope edit", async () => {
     const user = userEvent.setup();
     let updateBody: Record<string, unknown> | null = null;
     let updatedAt = "2026-01-01T00:00:00Z";
@@ -1543,8 +1643,7 @@ describe("AutomationDetailPage", () => {
     renderWithProviders(<AutomationDetailPage />);
 
     await screen.findByText("Weekly audit");
-    await user.click(screen.getByRole("button", { name: "Edit" }));
-    const scope = screen.getByLabelText(/Scope/);
+    const scope = screen.getByLabelText("Scope");
     await user.type(scope, "backend services");
 
     const title = screen.getByLabelText("Automation title");
@@ -1555,14 +1654,13 @@ describe("AutomationDetailPage", () => {
       expect(updateBody).toEqual({ name: "Release audit" });
     });
 
+    // The title's save (and the refetch it triggers) must not stomp text the
+    // user is still typing in a different field.
     await waitFor(() => {
-      expect(screen.getByLabelText(/Scope/)).toHaveValue("backend services");
+      expect(screen.getByLabelText("Scope")).toHaveValue("backend services");
     });
     expect(screen.queryByLabelText("Name")).not.toBeInTheDocument();
     expect(screen.queryByLabelText("Goal")).toBeInTheDocument();
-    expect(
-      screen.queryByRole("button", { name: "Automation emoji" }),
-    ).not.toBeInTheDocument();
   });
 
   it("reverts a cleared title on blur instead of saving or leaving it blank", async () => {
@@ -1799,8 +1897,6 @@ describe("AutomationDetailPage", () => {
       expect(screen.getByText("Weekly audit")).toBeInTheDocument();
     });
 
-    await user.click(screen.getByRole("button", { name: "Edit" }));
-
     const goalInput = screen.getByLabelText("Goal");
     await user.clear(goalInput);
     await user.type(goalInput, "Inspect @serv");
@@ -1810,9 +1906,7 @@ describe("AutomationDetailPage", () => {
 
     expect(goalInput).toHaveValue("Inspect @internal/services ");
     expect(await screen.findByText("Saving…")).toBeInTheDocument();
-    expect(
-      screen.getByRole("button", { name: "Improve goal" }),
-    ).toBeEnabled();
+    expect(screen.getByRole("button", { name: "Improve goal" })).toBeEnabled();
   });
 
   it("inserts selected slash commands into the edit goal field", async () => {
@@ -1902,8 +1996,6 @@ describe("AutomationDetailPage", () => {
       expect(screen.getByText("Weekly audit")).toBeInTheDocument();
     });
 
-    await user.click(screen.getByRole("button", { name: "Edit" }));
-
     const goalInput = screen.getByLabelText("Goal");
     await user.clear(goalInput);
     await user.type(goalInput, "/rev");
@@ -1966,8 +2058,6 @@ describe("AutomationDetailPage", () => {
     await waitFor(() => {
       expect(screen.getByText("Weekly audit")).toBeInTheDocument();
     });
-
-    await userEvent.setup().click(screen.getByRole("button", { name: "Edit" }));
 
     fireEvent.change(screen.getByLabelText("Goal"), {
       target: { value: "x".repeat(AUTOMATION_GOAL_MAX_LENGTH + 1) },
@@ -2090,20 +2180,17 @@ describe("AutomationDetailPage", () => {
       expect(screen.getByText("Weekly audit")).toBeInTheDocument();
     });
 
-    await user.click(screen.getByRole("button", { name: "Edit" }));
-    await user.click(screen.getByRole("button", { name: "Advanced settings" }));
     await user.click(screen.getByRole("combobox", { name: "Model" }));
     await user.click(await screen.findByText("claude-sonnet-4-6"));
-    await user.click(screen.getByRole("button", { name: "Save changes" }));
 
     await waitFor(() => {
-      expect(updateBody).toMatchObject({ model: "claude-sonnet-4-6" });
+      expect(updateBody).toEqual({ model: "claude-sonnet-4-6" });
     });
   });
 
-  it("saves product triggers from automation settings", async () => {
+  it("holds back a schedule removal until another trigger replaces it", async () => {
     const user = userEvent.setup();
-    let updateBody: Record<string, unknown> | null = null;
+    const updateBodies: Record<string, unknown>[] = [];
 
     server.use(
       http.get("*/api/v1/settings", () =>
@@ -2165,7 +2252,7 @@ describe("AutomationDetailPage", () => {
         }),
       ),
       http.patch("*/api/v1/automations/auto-1", async ({ request }) => {
-        updateBody = (await request.json()) as Record<string, unknown>;
+        updateBodies.push((await request.json()) as Record<string, unknown>);
         return HttpResponse.json({ data: { id: "auto-1" } });
       }),
     );
@@ -2176,25 +2263,38 @@ describe("AutomationDetailPage", () => {
       expect(screen.getByText("Weekly audit")).toBeInTheDocument();
     });
 
-    await user.click(screen.getByRole("button", { name: "Edit" }));
+    await user.click(screen.getByRole("button", { name: "Triggers" }));
     await user.click(screen.getByRole("button", { name: "Remove schedule" }));
+
+    // Removing the only trigger would leave an automation that can never fire,
+    // so it is refused rather than saved — with an inline reason.
+    expect(screen.getByText(/Select at least one trigger/)).toBeInTheDocument();
+    expect(updateBodies).toHaveLength(0);
+
     await user.click(
       screen.getByRole("checkbox", { name: "When a PR is merged" }),
     );
-    await user.click(screen.getByRole("button", { name: "Save changes" }));
 
-    await waitFor(() => {
-      expect(updateBody).toMatchObject({
-        schedule_type: "none",
-        triggers: ["github.pr.merged"],
-      });
-    });
-    expect(updateBody).not.toHaveProperty("interval_value");
-    expect(updateBody).not.toHaveProperty("interval_unit");
-    expect(updateBody).not.toHaveProperty("interval_run_at");
+    // Once a PR trigger restores the invariant, the held-back schedule removal
+    // lands too.
+    await waitFor(() =>
+      expect(updateBodies).toContainEqual(
+        expect.objectContaining({ triggers: ["github.pr.merged"] }),
+      ),
+    );
+    await waitFor(() =>
+      expect(updateBodies).toContainEqual(
+        expect.objectContaining({ schedule_type: "none" }),
+      ),
+    );
+    for (const body of updateBodies) {
+      expect(body).not.toHaveProperty("interval_value");
+      expect(body).not.toHaveProperty("interval_unit");
+      expect(body).not.toHaveProperty("interval_run_at");
+    }
   });
 
-  it("preserves a saved unavailable model when saving another field", async () => {
+  it("never re-sends an unrelated saved model when another field is edited", async () => {
     const user = userEvent.setup();
     let updateBody: Record<string, unknown> | null = null;
 
@@ -2287,8 +2387,6 @@ describe("AutomationDetailPage", () => {
       expect(screen.getByText("Weekly audit")).toBeInTheDocument();
     });
 
-    await user.click(screen.getByRole("button", { name: "Edit" }));
-    await user.click(screen.getByRole("button", { name: "Advanced settings" }));
     await user.click(
       await screen.findByRole("button", { name: "Base branch" }),
     );
@@ -2297,13 +2395,12 @@ describe("AutomationDetailPage", () => {
       "ops",
     );
     await user.click(await screen.findByText("release/ops"));
-    await user.click(screen.getByRole("button", { name: "Save changes" }));
 
+    // The saved model is unavailable to this org, so a batch save had to echo
+    // it back to avoid clearing it. Per-field patches never mention it, which
+    // removes the failure mode instead of working around it.
     await waitFor(() => {
-      expect(updateBody).toMatchObject({
-        base_branch: "release/ops",
-        model: "claude-sonnet-4-6",
-      });
+      expect(updateBody).toEqual({ base_branch: "release/ops" });
     });
   });
 
@@ -2404,14 +2501,468 @@ describe("AutomationDetailPage", () => {
       expect(screen.getByText("Weekly audit")).toBeInTheDocument();
     });
 
-    await user.click(screen.getByRole("button", { name: "Edit" }));
-    await user.click(screen.getByRole("button", { name: "Advanced settings" }));
     await user.click(screen.getByRole("combobox", { name: "Reasoning" }));
     await user.click(await screen.findByText("High"));
-    await user.click(screen.getByRole("button", { name: "Save changes" }));
 
     await waitFor(() => {
-      expect(updateBody).toMatchObject({ reasoning_effort: "high" });
+      expect(updateBody).toEqual({ reasoning_effort: "high" });
     });
+  });
+
+  it("clears an unsupported reasoning override in the same patch as the model switch", async () => {
+    const user = userEvent.setup();
+    let updateBody: Record<string, unknown> | null = null;
+    const stored: Record<string, unknown> = {
+      id: "auto-1",
+      org_id: "org-1",
+      repository_id: "repo-1",
+      name: "Weekly audit",
+      goal: "Check release health",
+      scope: "",
+      // No agent_type: the effective agent comes from the model, which is
+      // exactly the shape the API infers from too.
+      model_override: "gpt-5.4",
+      reasoning_effort: "high",
+      interval_value: 1,
+      interval_unit: "weeks",
+      base_branch: "main",
+      enabled: true,
+      timezone: "UTC",
+      last_run_at: null,
+      next_run_at: null,
+      priority: 50,
+      created_at: "2026-01-01T00:00:00Z",
+      updated_at: "2026-01-01T00:00:00Z",
+    };
+
+    server.use(
+      // Amp is the org default, so its modes are offered without a credential.
+      // Amp has no reasoning levels — picking one has to clear the override.
+      http.get("*/api/v1/settings", () =>
+        HttpResponse.json({
+          data: { settings: { default_agent_type: "amp" } },
+        }),
+      ),
+      http.get("*/api/v1/settings/codex-auth/status", () =>
+        HttpResponse.json({ data: null }),
+      ),
+      http.get("*/api/v1/coding-credentials*", () =>
+        HttpResponse.json({ data: [], meta: {} }),
+      ),
+      http.get("*/api/v1/automations/auto-1", () =>
+        HttpResponse.json({ data: { ...stored } }),
+      ),
+      http.get("*/api/v1/automations/auto-1/runs*", () =>
+        HttpResponse.json({ data: [], meta: {} }),
+      ),
+      // Stateful, so the refetch that follows the save can't replay the
+      // pre-edit fixture and hide whether the reset actually landed.
+      http.patch("*/api/v1/automations/auto-1", async ({ request }) => {
+        updateBody = (await request.json()) as Record<string, unknown>;
+        const { model, reasoning_effort } = updateBody as {
+          model?: string;
+          reasoning_effort?: string;
+        };
+        if (model !== undefined) stored.model_override = model;
+        if (reasoning_effort !== undefined) {
+          stored.reasoning_effort = reasoning_effort;
+        }
+        return HttpResponse.json({ data: { ...stored } });
+      }),
+    );
+
+    renderWithProviders(<AutomationDetailPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Weekly audit")).toBeInTheDocument();
+    });
+    // Codex today, so the reasoning row is on screen and the override is live.
+    expect(
+      screen.getByRole("combobox", { name: "Reasoning" }),
+    ).toBeInTheDocument();
+
+    await user.click(screen.getByRole("combobox", { name: "Model" }));
+    await user.click(await screen.findByRole("option", { name: "smart" }));
+
+    // The API re-validates the STORED reasoning override against the new
+    // model's agent, so a lone `model` patch would come back 400 and the row
+    // the user would have to clear is the one that disappears with the switch.
+    await waitFor(() => {
+      expect(updateBody).toEqual({ model: "smart", reasoning_effort: "" });
+    });
+    await waitFor(() =>
+      expect(
+        screen.queryByRole("combobox", { name: "Reasoning" }),
+      ).not.toBeInTheDocument(),
+    );
+  });
+
+  it("leaves a still-supported reasoning override alone when the model changes", async () => {
+    const user = userEvent.setup();
+    let updateBody: Record<string, unknown> | null = null;
+
+    server.use(
+      http.get("*/api/v1/settings", () =>
+        HttpResponse.json({
+          data: { settings: { default_agent_type: "claude_code" } },
+        }),
+      ),
+      http.get("*/api/v1/settings/codex-auth/status", () =>
+        HttpResponse.json({ data: null }),
+      ),
+      http.get("*/api/v1/coding-credentials*", () =>
+        HttpResponse.json({ data: [], meta: {} }),
+      ),
+      http.get("*/api/v1/automations/auto-1", () =>
+        HttpResponse.json({
+          data: {
+            id: "auto-1",
+            org_id: "org-1",
+            repository_id: "repo-1",
+            name: "Weekly audit",
+            goal: "Check release health",
+            scope: "",
+            model_override: "gpt-5.4",
+            reasoning_effort: "high",
+            interval_value: 1,
+            interval_unit: "weeks",
+            base_branch: "main",
+            enabled: true,
+            timezone: "UTC",
+            last_run_at: null,
+            next_run_at: null,
+            priority: 50,
+            created_at: "2026-01-01T00:00:00Z",
+            updated_at: "2026-01-01T00:00:00Z",
+          },
+        }),
+      ),
+      http.get("*/api/v1/automations/auto-1/runs*", () =>
+        HttpResponse.json({ data: [], meta: {} }),
+      ),
+      http.patch("*/api/v1/automations/auto-1", async ({ request }) => {
+        updateBody = (await request.json()) as Record<string, unknown>;
+        return HttpResponse.json({ data: { id: "auto-1" } });
+      }),
+    );
+
+    renderWithProviders(<AutomationDetailPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Weekly audit")).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole("combobox", { name: "Model" }));
+    await user.click(await screen.findByRole("option", { name: "claude-sonnet-4-6" }));
+
+    // Claude Code has reasoning levels, so the reset must NOT ride along —
+    // clearing an override the user never touched would be its own bug.
+    await waitFor(() => {
+      expect(updateBody).toEqual({ model: "claude-sonnet-4-6" });
+    });
+  });
+
+  it("commits a pending trigger-filter edit when the popover closes", async () => {
+    const user = userEvent.setup();
+    const updateBodies: Record<string, unknown>[] = [];
+
+    server.use(
+      // Pin the preview as never-settling. An unmocked preview FAILS, and the
+      // editor treats a transport failure as valid — which lets the settled
+      // path emit a byte-identical patch and satisfy this test without the
+      // unmount flush ever running.
+      http.post("*/api/v1/automations/schedule-preview", () => neverResolves()),
+      http.get("*/api/v1/automations/auto-1", () =>
+        HttpResponse.json({
+          data: {
+            id: "auto-1",
+            org_id: "org-1",
+            repository_id: "repo-1",
+            name: "Weekly audit",
+            goal: "Check release health",
+            scope: "",
+            interval_value: 1,
+            interval_unit: "weeks",
+            base_branch: "main",
+            enabled: true,
+            timezone: "UTC",
+            last_run_at: null,
+            next_run_at: null,
+            priority: 50,
+            github_event_triggers: ["github.pr.merged"],
+            github_event_filters: { authors: [] },
+            created_at: "2026-01-01T00:00:00Z",
+            updated_at: "2026-01-01T00:00:00Z",
+          },
+        }),
+      ),
+      http.get("*/api/v1/automations/auto-1/runs*", () =>
+        HttpResponse.json({ data: [], meta: {} }),
+      ),
+      http.patch("*/api/v1/automations/auto-1", async ({ request }) => {
+        updateBodies.push((await request.json()) as Record<string, unknown>);
+        return HttpResponse.json({ data: { id: "auto-1" } });
+      }),
+    );
+
+    renderWithProviders(<AutomationDetailPage />);
+    await screen.findByText("Weekly audit");
+
+    await user.click(screen.getByRole("button", { name: "Triggers" }));
+    await user.click(screen.getByRole("button", { name: /Trigger filters/ }));
+    fireEvent.change(await screen.findByLabelText("Authors"), {
+      target: { value: "octocat" },
+    });
+
+    // Closing the popover removes the focused input from the DOM, which does
+    // NOT dispatch focusout — so onBlur never runs and the debounced edit has
+    // to be flushed on unmount or it is lost with no error and no indicator.
+    await user.keyboard("{Escape}");
+
+    await waitFor(() =>
+      expect(updateBodies).toContainEqual({
+        github_event_filters: { authors: ["octocat"] },
+      }),
+    );
+  });
+
+  it("commits a pending schedule edit when the popover closes", async () => {
+    const user = userEvent.setup();
+    const updateBodies: Record<string, unknown>[] = [];
+
+    server.use(
+      // Never-settling, so `valid` stays false for the whole test and the only
+      // thing that can produce a patch is the unmount flush under test.
+      http.post("*/api/v1/automations/schedule-preview", () => neverResolves()),
+      http.get("*/api/v1/automations/auto-1", () =>
+        HttpResponse.json({
+          data: {
+            id: "auto-1",
+            org_id: "org-1",
+            repository_id: "repo-1",
+            name: "Weekly audit",
+            goal: "Check release health",
+            scope: "",
+            interval_value: 1,
+            interval_unit: "weeks",
+            base_branch: "main",
+            enabled: true,
+            timezone: "UTC",
+            last_run_at: null,
+            next_run_at: null,
+            priority: 50,
+            created_at: "2026-01-01T00:00:00Z",
+            updated_at: "2026-01-01T00:00:00Z",
+          },
+        }),
+      ),
+      http.get("*/api/v1/automations/auto-1/runs*", () =>
+        HttpResponse.json({ data: [], meta: {} }),
+      ),
+      http.patch("*/api/v1/automations/auto-1", async ({ request }) => {
+        updateBodies.push((await request.json()) as Record<string, unknown>);
+        return HttpResponse.json({ data: { id: "auto-1" } });
+      }),
+    );
+
+    renderWithProviders(<AutomationDetailPage />);
+    await screen.findByText("Weekly audit");
+
+    await user.click(screen.getByRole("button", { name: "Triggers" }));
+    const intervalInput = await screen.findByLabelText("Interval value");
+    await user.clear(intervalInput);
+    await user.type(intervalInput, "6");
+
+    // The schedule has no blur to fall back on: it normally commits only after
+    // the editor's 300ms debounce AND a server preview round-trip. Closing
+    // inside that window must still persist the draft, on the client-side
+    // verdict — the API validates it again on write.
+    await user.keyboard("{Escape}");
+
+    await waitFor(() =>
+      expect(updateBodies).toContainEqual(
+        expect.objectContaining({
+          schedule_type: "interval",
+          interval_value: 6,
+        }),
+      ),
+    );
+  });
+
+  it("does not commit a client-invalid schedule when the popover closes", async () => {
+    const user = userEvent.setup();
+    const updateBodies: Record<string, unknown>[] = [];
+
+    server.use(
+      http.get("*/api/v1/automations/auto-1", () =>
+        HttpResponse.json({
+          data: {
+            id: "auto-1",
+            org_id: "org-1",
+            repository_id: "repo-1",
+            name: "Weekly audit",
+            goal: "Check release health",
+            scope: "",
+            interval_value: 1,
+            interval_unit: "weeks",
+            base_branch: "main",
+            enabled: true,
+            timezone: "UTC",
+            last_run_at: null,
+            next_run_at: null,
+            priority: 50,
+            created_at: "2026-01-01T00:00:00Z",
+            updated_at: "2026-01-01T00:00:00Z",
+          },
+        }),
+      ),
+      http.get("*/api/v1/automations/auto-1/runs*", () =>
+        HttpResponse.json({ data: [], meta: {} }),
+      ),
+      http.patch("*/api/v1/automations/auto-1", async ({ request }) => {
+        updateBodies.push((await request.json()) as Record<string, unknown>);
+        return HttpResponse.json({ data: { id: "auto-1" } });
+      }),
+    );
+
+    renderWithProviders(<AutomationDetailPage />);
+    await screen.findByText("Weekly audit");
+
+    await user.click(screen.getByRole("button", { name: "Triggers" }));
+    // 999 is past the API's 1-365 bound, so validateScheduleDraft rejects the
+    // draft locally. Flushing on unmount must not turn that into a certain 400.
+    const intervalInput = await screen.findByLabelText("Interval value");
+    await user.clear(intervalInput);
+    await user.type(intervalInput, "999");
+    await user.keyboard("{Escape}");
+
+    await new Promise((resolve) => setTimeout(resolve, 600));
+    expect(updateBodies).toEqual([]);
+  });
+
+  it("does not commit a schedule the preview already refused when the popover closes", async () => {
+    const user = userEvent.setup();
+    const updateBodies: Record<string, unknown>[] = [];
+
+    server.use(
+      // The API has already told us, on screen, that this draft is unusable.
+      http.post("*/api/v1/automations/schedule-preview", () =>
+        HttpResponse.json(
+          {
+            error: {
+              code: "INVALID_SCHEDULE",
+              message: "No future occurrence.",
+            },
+          },
+          { status: 400 },
+        ),
+      ),
+      http.get("*/api/v1/automations/auto-1", () =>
+        HttpResponse.json({
+          data: {
+            id: "auto-1",
+            org_id: "org-1",
+            repository_id: "repo-1",
+            name: "Weekly audit",
+            goal: "Check release health",
+            scope: "",
+            interval_value: 1,
+            interval_unit: "weeks",
+            base_branch: "main",
+            enabled: true,
+            timezone: "UTC",
+            last_run_at: null,
+            next_run_at: null,
+            priority: 50,
+            created_at: "2026-01-01T00:00:00Z",
+            updated_at: "2026-01-01T00:00:00Z",
+          },
+        }),
+      ),
+      http.get("*/api/v1/automations/auto-1/runs*", () =>
+        HttpResponse.json({ data: [], meta: {} }),
+      ),
+      http.patch("*/api/v1/automations/auto-1", async ({ request }) => {
+        updateBodies.push((await request.json()) as Record<string, unknown>);
+        return HttpResponse.json({ data: { id: "auto-1" } });
+      }),
+    );
+
+    renderWithProviders(<AutomationDetailPage />);
+    await screen.findByText("Weekly audit");
+
+    await user.click(screen.getByRole("button", { name: "Triggers" }));
+    const intervalInput = await screen.findByLabelText("Interval value");
+    await user.clear(intervalInput);
+    await user.type(intervalInput, "6");
+
+    // Wait until the refusal for THIS draft is on screen — that is the state
+    // the user walks away from.
+    await screen.findByText("No future occurrence.");
+    await user.keyboard("{Escape}");
+
+    // The write cannot succeed, so sending it would buy nothing but a failed
+    // request and an error toast for a schedule the user watched get rejected.
+    await new Promise((resolve) => setTimeout(resolve, 600));
+    expect(updateBodies).toEqual([]);
+    expect(toast.error).not.toHaveBeenCalled();
+  });
+
+  it("surfaces the API's reason when an inline property save is rejected", async () => {
+    const user = userEvent.setup();
+
+    server.use(
+      http.get("*/api/v1/automations/auto-1", () =>
+        HttpResponse.json({
+          data: {
+            id: "auto-1",
+            org_id: "org-1",
+            repository_id: "repo-1",
+            name: "Weekly audit",
+            goal: "Check release health",
+            scope: "",
+            identity_scope: "org",
+            interval_value: 1,
+            interval_unit: "weeks",
+            base_branch: "main",
+            enabled: true,
+            timezone: "UTC",
+            last_run_at: null,
+            next_run_at: null,
+            priority: 50,
+            created_at: "2026-01-01T00:00:00Z",
+            updated_at: "2026-01-01T00:00:00Z",
+          },
+        }),
+      ),
+      http.get("*/api/v1/automations/auto-1/runs*", () =>
+        HttpResponse.json({ data: [], meta: {} }),
+      ),
+      http.patch("*/api/v1/automations/auto-1", () =>
+        HttpResponse.json(
+          {
+            error: {
+              code: "INVALID_IDENTITY_SCOPE",
+              message: "identity_scope=personal requires automation.created_by",
+            },
+          },
+          { status: 400 },
+        ),
+      ),
+    );
+
+    renderWithProviders(<AutomationDetailPage />);
+    await screen.findByText("Weekly audit");
+
+    await user.click(screen.getByRole("combobox", { name: "Run as" }));
+    await user.click(await screen.findByRole("option", { name: "Personal" }));
+
+    // With no Save button, this toast is the only thing that can tell the user
+    // WHICH row the server refused and why. A fixed string throws that away.
+    await waitFor(() =>
+      expect(toast.error).toHaveBeenCalledWith(
+        "Couldn\u2019t save automation: identity_scope=personal requires automation.created_by",
+      ),
+    );
   });
 });

--- a/frontend/src/app/(dashboard)/automations/[id]/page.tsx
+++ b/frontend/src/app/(dashboard)/automations/[id]/page.tsx
@@ -1,17 +1,17 @@
 "use client";
 
-import { useMemo, useRef, useState, type ReactNode } from "react";
+import {
+  useCallback,
+  useEffect,
+  useId,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react";
 import dynamic from "next/dynamic";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
-import {
-  ChevronDown,
-  Play,
-  Pause,
-  Loader2,
-  Minus,
-  Plus,
-  Settings2,
-} from "lucide-react";
+import { ChevronDown, Play, Pause, Loader2, Minus, Plus } from "lucide-react";
 import { useParams, useRouter } from "next/navigation";
 import Link from "next/link";
 import { Badge } from "@/components/ui/badge";
@@ -32,12 +32,18 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import {
   Sheet,
   SheetContent,
   SheetDescription,
   SheetHeader,
   SheetTitle,
 } from "@/components/ui/sheet";
+import { AutosaveIndicator } from "@/components/AutosaveIndicator";
 import { MobileBackButton } from "@/components/mobile-back-button";
 import { PageContainer } from "@/components/page-container";
 import { PageHeader } from "@/components/page-header";
@@ -51,17 +57,15 @@ import {
 } from "@/components/automation-capabilities-editor";
 import { BranchPicker } from "@/components/branch-picker";
 import { AutomationModelSelect } from "@/components/automation-model-select";
-import {
-  AutomationScheduleEditor,
-  AutomationScheduleSummary,
-} from "@/components/automation-schedule-editor";
-import { api } from "@/lib/api";
+import { AutomationScheduleEditor } from "@/components/automation-schedule-editor";
+import { ApiError, api } from "@/lib/api";
 import {
   automationScheduleTimezone,
   automationToScheduleDraft,
   formatAutomationSchedule,
   sameScheduleDraft,
   scheduleDraftToAPI,
+  validateScheduleDraft,
   type ScheduleDraft,
 } from "@/lib/automation-schedule";
 import {
@@ -72,13 +76,15 @@ import { queryKeys } from "@/lib/query-keys";
 import { agentTypeForModel } from "@/lib/agents";
 import {
   automationProductTriggerOptions,
+  automationProductTriggersToGitHubEvents,
   githubEventsToAutomationProductTriggers,
   type AutomationProductTrigger,
 } from "@/lib/automation-triggers";
 import { automationGoalLengthState } from "@/lib/automation-validation";
 import { useAuth } from "@/hooks/use-auth";
 import { usePageTitle } from "@/hooks/use-page-title";
-import { useAutosave, type AutosaveStatus } from "@/hooks/useAutosave";
+import { useAutosave, type UseAutosaveResult } from "@/hooks/useAutosave";
+import { useAutosaveNumericField } from "@/hooks/useAutosaveNumericField";
 import { useDebouncedTextField } from "@/hooks/useDebouncedTextField";
 import type {
   AgentCapabilityDefinition,
@@ -121,36 +127,265 @@ function commaList(value: string): string[] {
     .filter(Boolean);
 }
 
-function SettingsTab({
+// ---------------------------------------------------------------------------
+// Autosave scope
+// ---------------------------------------------------------------------------
+
+/**
+ * Every editable control on this page — the title, the goal, and each property
+ * row — commits through one autosave scope keyed by the automation detail
+ * query.
+ *
+ * `body` is what PATCH receives; `optimistic` is how the cached `Automation`
+ * should look once it lands. The two are kept separate because a few API field
+ * names differ from the model's (`model` vs `model_override`, `triggers` vs
+ * `github_event_triggers`), and because `useAutosave` diffs the optimistic
+ * result against the cache to skip saves that would change nothing.
+ */
+type AutomationPatch = {
+  body: Record<string, unknown>;
+  optimistic: Partial<Automation>;
+  onError?: () => void;
+};
+
+// Module-level so every caller on this queryKey passes one identity —
+// `useAutosave` throws in dev when two components sharing a scope disagree
+// about how to merge.
+const coalesceAutomationPatch = (
+  queued: AutomationPatch,
+  incoming: AutomationPatch,
+): AutomationPatch => ({
+  body: { ...queued.body, ...incoming.body },
+  optimistic: { ...queued.optimistic, ...incoming.optimistic },
+  onError:
+    queued.onError || incoming.onError
+      ? () => {
+          queued.onError?.();
+          incoming.onError?.();
+        }
+      : undefined,
+});
+
+const applyAutomationPatch = (
+  previous: unknown,
+  patch: AutomationPatch,
+): unknown => {
+  const response = previous as { data?: Automation } | undefined;
+  if (!response?.data) return previous;
+  return { ...response, data: { ...response.data, ...patch.optimistic } };
+};
+
+type AutomationAutosave = UseAutosaveResult<AutomationPatch>;
+
+const GENERIC_SAVE_ERROR = "Couldn’t save automation. Your change was reverted.";
+
+// Without a Save button every property fails on its own, and the API refuses
+// these writes for reasons the user can actually act on — a model that needs a
+// credential, a cron expression it won't accept, a personal identity scope on
+// an automation with no creator. Collapsing all of that into one fixed string
+// leaves no way to tell which row was refused or what to do about it.
+const automationSaveError = (error: unknown): string => {
+  if (error instanceof ApiError && error.message.trim()) {
+    return `Couldn’t save automation: ${error.message}`;
+  }
+  return GENERIC_SAVE_ERROR;
+};
+
+function useAutomationAutosave(automationId: string): AutomationAutosave {
+  const queryClient = useQueryClient();
+  return useAutosave<AutomationPatch>({
+    queryKey: queryKeys.automations.detail(automationId),
+    debounceMs: 0,
+    mutationFn: async (patch) => {
+      const response = await api.automations.update(automationId, patch.body);
+      upsertAutomationInListCaches(queryClient, response.data);
+      return response;
+    },
+    applyOptimistic: applyAutomationPatch,
+    coalesce: coalesceAutomationPatch,
+    errorMessage: automationSaveError,
+    onError: (_error, patch) => patch.onError?.(),
+  });
+}
+
+// Capabilities live behind their own endpoint and cache entry, so they get
+// their own scope. A later grant list always supersedes an earlier one.
+const coalesceCapabilityGrants = (
+  _queued: AgentCapabilityGrant[],
+  incoming: AgentCapabilityGrant[],
+): AgentCapabilityGrant[] => incoming;
+
+const applyCapabilityGrants = (
+  previous: unknown,
+  grants: AgentCapabilityGrant[],
+): unknown => {
+  const response = previous as
+    { data?: { capabilities?: AgentCapabilityGrant[] } } | undefined;
+  if (!response?.data) return previous;
+  return { ...response, data: { ...response.data, capabilities: grants } };
+};
+
+// ---------------------------------------------------------------------------
+// Inline property rows
+// ---------------------------------------------------------------------------
+
+// A property reads as plain text until it is hovered or focused, at which point
+// it reveals that it was the control all along — so there is no separate "edit
+// mode" to enter and no second place to look for the value. Heights follow the
+// app's `h-<mobile> sm:h-<desktop>` convention: full-size touch targets on
+// small screens, a tight 28px rhythm in the desktop rail.
+const inlineControlClass =
+  "h-9 sm:h-7 w-full justify-between rounded-md border border-transparent bg-transparent px-1.5 text-xs font-normal shadow-none hover:border-border hover:bg-muted/40 focus-visible:border-border data-[state=open]:border-border";
+
+// SelectTrigger sizes itself through `data-[size]` variants, which
+// tailwind-merge scopes separately from a bare `h-*`, so the same heights have
+// to be restated against those variants to win.
+const inlineSelectTriggerClass = cn(
+  inlineControlClass,
+  "data-[size=default]:h-9 sm:data-[size=default]:h-7",
+);
+
+// `htmlFor` is required, not optional: a `<Label>` with nothing bound to it is
+// a dead click target next to rows that do respond, and emits a `<label>`
+// pointing at no control. Every row here has an addressable control, so the
+// type makes forgetting one a compile error rather than a silent nit.
+function PropertyRow({
+  label,
+  htmlFor,
+  children,
+}: {
+  label: string;
+  htmlFor: string;
+  children: ReactNode;
+}) {
+  return (
+    <div className="grid grid-cols-[6.5rem_minmax(0,1fr)] items-center gap-2">
+      <Label
+        htmlFor={htmlFor}
+        className="text-xs font-medium text-muted-foreground"
+      >
+        {label}
+      </Label>
+      <div className="min-w-0">{children}</div>
+    </div>
+  );
+}
+
+/** Read-only counterpart to `PropertyRow`, on the same optical grid. */
+function StaticPropertyRow({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="grid grid-cols-[6.5rem_minmax(0,1fr)] items-center gap-2">
+      <span className="text-xs font-medium text-muted-foreground">{label}</span>
+      <span className="min-w-0 break-words px-1.5 text-xs text-foreground">
+        {value}
+      </span>
+    </div>
+  );
+}
+
+function triggerSummaryText(automation: Automation, schedule: string): string {
+  const prTriggerLabels = githubEventsToAutomationProductTriggers(
+    automation.github_event_triggers ?? [],
+  )
+    .map(
+      (trigger) =>
+        automationProductTriggerOptions.find(
+          (option) => option.value === trigger,
+        )?.label,
+    )
+    .filter((label): label is string => Boolean(label));
+
+  return (
+    [automation.schedule_type === "none" ? null : schedule, ...prTriggerLabels]
+      .filter((value): value is string => Boolean(value))
+      .join(", ") || "No triggers"
+  );
+}
+
+function TriggersProperty({
   automation,
+  schedule,
   canManage,
+  autosave,
 }: {
   automation: Automation;
+  schedule: string;
   canManage: boolean;
+  autosave: AutomationAutosave;
+}) {
+  const [open, setOpen] = useState(false);
+  // Two rails can be mounted at once (see AutomationDetailRail), so the id has
+  // to be per-instance for the label to bind to its own trigger.
+  const uid = useId();
+  const summary = triggerSummaryText(automation, schedule);
+
+  if (!canManage) {
+    return <StaticPropertyRow label="Triggers" value={summary} />;
+  }
+
+  return (
+    <PropertyRow label="Triggers" htmlFor={`automation-triggers-${uid}`}>
+      <Popover open={open} onOpenChange={setOpen}>
+        <PopoverTrigger asChild>
+          <Button
+            type="button"
+            id={`automation-triggers-${uid}`}
+            variant="outline"
+            size="sm"
+            aria-label="Triggers"
+            className={cn(inlineControlClass, "text-left")}
+          >
+            <span className="min-w-0 truncate">{summary}</span>
+            <ChevronDown className="h-3 w-3 shrink-0 text-muted-foreground" />
+          </Button>
+        </PopoverTrigger>
+        {/* Radix unmounts closed content, so every open re-seeds the schedule
+            draft from the freshest automation instead of holding a long-lived
+            local copy that the page's 10s poll could stale out. */}
+        <PopoverContent
+          align="start"
+          className="w-[22rem] max-w-[calc(100vw-2rem)] p-3"
+        >
+          <TriggersEditor automation={automation} autosave={autosave} />
+        </PopoverContent>
+      </Popover>
+    </PropertyRow>
+  );
+}
+
+function TriggersEditor({
+  automation,
+  autosave,
+}: {
+  automation: Automation;
+  autosave: AutomationAutosave;
 }) {
   const queryClient = useQueryClient();
-  const [repositoryId, setRepositoryId] = useState(
-    automation.repository_id ?? "",
+  const { save } = autosave;
+  // Memoised per mount: stability keeps the TimezonePicker's `detected` prop
+  // from changing identity mid-edit.
+  const detectedTimezone = useMemo(() => browserTimezone(), []);
+  const [scheduleDraft, setScheduleDraft] = useState<ScheduleDraft | null>(() =>
+    automationToScheduleDraft(automation),
   );
-  const [scope, setScope] = useState(automation.scope ?? "");
-  // Form state is seeded from the automation prop on first mount only. The
-  // parent polls every 10s and may refetch into a new `automation` object.
-  // Keep this local draft mounted while the sheet is open so unrelated inline
-  // title/goal autosaves cannot discard mechanics edits in progress.
-  const [scheduleDraft, setScheduleDraft] = useState<ScheduleDraft | null>(
-    () => automationToScheduleDraft(automation),
-  );
-  // Snapshot the seed draft so the mutation can tell an edited schedule from an
-  // untouched one and send no schedule fields at all in the latter case. That
-  // matters beyond avoiding a cron rewrite: PATCH recomputes next_run_at
-  // whenever any schedule field (timezone included) is present, so re-sending
-  // an unchanged schedule while saving a goal would push an interval
-  // automation's next run out by a full interval.
-  const initialScheduleDraftRef = useRef(scheduleDraft);
-  const [scheduleValid, setScheduleValid] = useState(
-    automation.schedule_type !== "none",
-  );
-  const scheduleEnabled = scheduleDraft !== null;
+  // Validity is tracked as "which draft got which verdict", not as a bare
+  // boolean. The editor reports validity from an effect, one render after the
+  // draft it describes — so a boolean flag is briefly true for a draft that has
+  // already been replaced by an invalid one, and an autosave reading that flag
+  // would persist the invalid draft. Holding the draft reference alongside the
+  // verdict makes the pairing explicit.
+  //
+  // "rejected" is recorded as well as "valid" because the two failure modes
+  // pull in opposite directions on unmount: a draft that simply hasn't settled
+  // yet must still be committed (otherwise closing the popover drops the edit),
+  // while one the API has already refused must not be (that write cannot
+  // succeed, so sending it only buys a failed request and an error toast).
+  // Anything else — still previewing — records nothing and leaves the previous
+  // verdict alone.
+  const [verdict, setVerdict] = useState<{
+    draft: ScheduleDraft | null;
+    status: "valid" | "rejected";
+  } | null>(null);
   const [productTriggers, setProductTriggers] = useState<
     AutomationProductTrigger[]
   >(() =>
@@ -158,86 +393,381 @@ function SettingsTab({
       automation.github_event_triggers ?? [],
     ),
   );
-  const [triggerBaseBranches, setTriggerBaseBranches] = useState(
-    (automation.github_event_filters?.base_branches ?? []).join(", "),
-  );
-  const [triggerAuthors, setTriggerAuthors] = useState(
-    (automation.github_event_filters?.authors ?? []).join(", "),
-  );
-  const [triggerPaths, setTriggerPaths] = useState(
-    (automation.github_event_filters?.paths ?? []).join(", "),
-  );
-  const [triggerFeedbackTypes, setTriggerFeedbackTypes] = useState(
-    (automation.github_event_filters?.feedback_types ?? []).join(", "),
-  );
-  const [triggerReviewStates, setTriggerReviewStates] = useState(
-    (automation.github_event_filters?.review_states ?? []).join(", "),
-  );
-  // Memoised per mount: Intl.DateTimeFormat() is cheap but there's no reason
-  // to re-evaluate it on every render, and stability prevents the
-  // TimezonePicker's `detected` prop from changing identity.
-  const detectedTimezone = useMemo(() => browserTimezone(), []);
-  const [baseBranch, setBaseBranch] = useState(automation.base_branch);
-  const [model, setModel] = useState<string | undefined>(
-    automation.model_override,
-  );
-  const [identityScope, setIdentityScope] = useState<"org" | "personal">(
-    automation.identity_scope ?? "org",
-  );
-  const [publishPolicy, setPublishPolicy] = useState<"pull_request" | "none">(
-    automation.publish_policy ?? "pull_request",
-  );
-  const [prePRReviewLoops, setPrePRReviewLoops] = useState(
-    automation.pre_pr_review_loops ?? 0,
-  );
-  const [reasoningEffort, setReasoningEffort] =
-    useState<CodingAgentReasoningEffort>(automation.reasoning_effort ?? "");
-  const [capabilityDraft, setCapabilityDraft] = useState<
-    AgentCapabilityGrant[] | null
-  >(null);
+  const hasTrigger = scheduleDraft !== null || productTriggers.length > 0;
 
-  const { data: repositoriesResponse } = useQuery<ListResponse<Repository>>({
-    queryKey: queryKeys.repositories.all,
-    queryFn: () => api.repositories.list(),
-  });
-  const repositories = useMemo(
-    () => repositoriesResponse?.data ?? [],
-    [repositoriesResponse?.data],
-  );
-  const selectedRepository = repositories.find(
-    (repository) => repository.id === repositoryId,
+  // The schedule is a compound control — an interval, a unit, a wall clock and
+  // a timezone that only mean anything together — so it commits as one unit
+  // once the editor reports a settled, server-previewed draft rather than on
+  // each keystroke. The editor's own 300ms preview debounce is what paces this.
+  const committedScheduleRef = useRef(scheduleDraft);
+  const restoreTriggerDraft = useCallback((restored: Automation) => {
+    // These controls keep a local draft while the popover is open, so restore
+    // it explicitly on failure; otherwise the rejected values would remain
+    // visible and the advanced committed snapshot would prevent a retry of the
+    // same schedule.
+    const restoredSchedule = automationToScheduleDraft(restored);
+    committedScheduleRef.current = restoredSchedule;
+    setScheduleDraft(restoredSchedule);
+    setVerdict(null);
+    setProductTriggers(
+      githubEventsToAutomationProductTriggers(
+        restored.github_event_triggers ?? [],
+      ),
+    );
+  }, []);
+
+  const commitSchedule = useCallback(
+    (draft: ScheduleDraft | null, restoreOnError: boolean) => {
+      committedScheduleRef.current = draft;
+      const payload = scheduleDraftToAPI(draft, automation.timezone);
+      let onError: (() => void) | undefined;
+      if (restoreOnError) {
+        // Read the pre-optimistic snapshot now, while it is still the truth to
+        // restore to. Skipped entirely on the unmount path, where there is no
+        // local draft left to put back.
+        const savedAutomation =
+          queryClient.getQueryData<{ data?: Automation }>(
+            queryKeys.automations.detail(automation.id),
+          )?.data ?? automation;
+        onError = () => restoreTriggerDraft(savedAutomation);
+      }
+      save({
+        body: payload,
+        optimistic: payload as Partial<Automation>,
+        onError,
+      });
+    },
+    [automation, queryClient, restoreTriggerDraft, save],
   );
 
-  const { data: settingsResponse } = useQuery({
-    queryKey: ["settings"],
-    queryFn: () => api.settings.get(),
+  useEffect(() => {
+    if (verdict?.draft !== scheduleDraft || verdict.status !== "valid") return;
+    // Dropping the last trigger would leave an automation that can never fire
+    // again; refuse the commit and let the inline notice below explain why.
+    // Once a trigger is restored this effect re-runs and the held-back schedule
+    // change lands.
+    if (!hasTrigger) return;
+    if (sameScheduleDraft(scheduleDraft, committedScheduleRef.current)) return;
+    commitSchedule(scheduleDraft, true);
+  }, [commitSchedule, hasTrigger, scheduleDraft, verdict]);
+
+  // One dep-less effect mirrors everything the unmount cleanup needs, matching
+  // how the autosave hooks keep their refs fresh. Intentionally no dep array:
+  // the cleanup below cannot read render state, so these must track every
+  // commit.
+  const latestScheduleRef = useRef({
+    scheduleDraft,
+    hasTrigger,
+    verdict,
+    commitSchedule,
   });
-  const settings = (settingsResponse?.data?.settings ?? {}) as {
-    default_agent_type?: string;
+  useEffect(() => {
+    latestScheduleRef.current = {
+      scheduleDraft,
+      hasTrigger,
+      verdict,
+      commitSchedule,
+    };
+  });
+
+  // Closing the popover unmounts this editor, and the schedule has no blur to
+  // fall back on: it commits only from the effect above, which waits on the
+  // editor's 300ms debounce AND a server preview round-trip. Picking a run time
+  // and clicking away would otherwise drop the change with no toast, no
+  // indicator, and no visible difference.
+  useEffect(() => {
+    return () => {
+      const {
+        scheduleDraft: draft,
+        hasTrigger: has,
+        verdict: lastVerdict,
+        commitSchedule: commit,
+      } = latestScheduleRef.current;
+      // Same guards as the settled path. `sameScheduleDraft` is also what keeps
+      // StrictMode's simulated cleanup inert: the seed draft always matches the
+      // committed snapshot until the user actually edits something.
+      if (!has) return;
+      if (sameScheduleDraft(draft, committedScheduleRef.current)) return;
+      if (draft && validateScheduleDraft(draft)) return;
+      // The API already refused this exact draft during preview, so sending it
+      // buys a guaranteed-failed request and an error toast for a schedule the
+      // user watched the editor reject and then walked away from.
+      if (lastVerdict?.draft === draft && lastVerdict.status === "rejected") {
+        return;
+      }
+      commit(draft, false);
+    };
+  }, []);
+
+  const toggleProductTrigger = (
+    trigger: AutomationProductTrigger,
+    checked: boolean,
+  ) => {
+    const next = checked
+      ? productTriggers.includes(trigger)
+        ? productTriggers
+        : [...productTriggers, trigger]
+      : productTriggers.filter((item) => item !== trigger);
+    setProductTriggers(next);
+    if (next.length === 0 && scheduleDraft === null) return;
+    const savedAutomation =
+      queryClient.getQueryData<{ data?: Automation }>(
+        queryKeys.automations.detail(automation.id),
+      )?.data ?? automation;
+    save({
+      body: { triggers: next },
+      optimistic: {
+        github_event_triggers: automationProductTriggersToGitHubEvents(next),
+      },
+      onError: () => restoreTriggerDraft(savedAutomation),
+    });
   };
-  const defaultAgentType = settings.default_agent_type ?? "codex";
-  const effectiveAgentType = model
-    ? (agentTypeForModel(model) ?? automation.agent_type ?? defaultAgentType)
-    : (automation.agent_type ?? defaultAgentType);
-  const supportsNativeReviewLoop = [
-    "codex",
-    "claude_code",
-    "amp",
-    "pi",
-    "opencode",
-  ].includes(effectiveAgentType);
-  const effectivePrePRReviewLoops = supportsNativeReviewLoop
-    ? prePRReviewLoops
-    : 0;
-  let prePRReviewDescription = "Off for agents without review-loop support.";
-  if (supportsNativeReviewLoop) {
-    prePRReviewDescription =
-      effectivePrePRReviewLoops === 0
+
+  const saveFilter = useCallback(
+    (key: keyof AutomationGitHubEventFilters, value: string) => {
+      // Read the base from the cache rather than a render closure: two filters
+      // edited inside one coalesce window would otherwise clobber each other,
+      // and the cache is advanced synchronously by each optimistic apply.
+      const cached = queryClient.getQueryData<{ data?: Automation }>(
+        queryKeys.automations.detail(automation.id),
+      );
+      const latest = cached?.data?.github_event_filters ?? {};
+      const merged: AutomationGitHubEventFilters = {
+        ...latest,
+        [key]: commaList(value),
+      };
+      save({
+        body: { github_event_filters: merged },
+        optimistic: { github_event_filters: merged },
+      });
+    },
+    [automation.id, queryClient, save],
+  );
+
+  const filters = automation.github_event_filters ?? {};
+
+  return (
+    <div className="space-y-3">
+      <AutomationScheduleEditor
+        value={scheduleDraft}
+        onChange={setScheduleDraft}
+        detectedTimezone={detectedTimezone}
+        // Deliberately an inline closure: the editor re-runs this on every
+        // render, so `scheduleDraft` here is always the same draft the verdict
+        // was computed from. Returning `prev` unchanged keeps that per-render
+        // call from looping.
+        onValidityChange={(valid, { serverRejected }) => {
+          // Still previewing: record nothing rather than overwriting an older
+          // verdict with "we don't know yet".
+          const status = valid ? "valid" : serverRejected ? "rejected" : null;
+          if (!status) return;
+          setVerdict((prev) =>
+            prev?.draft === scheduleDraft && prev.status === status
+              ? prev
+              : { draft: scheduleDraft, status },
+          );
+        }}
+      />
+      <div className="space-y-2">
+        <span className="text-xs font-medium leading-none text-muted-foreground">
+          Pull requests
+        </span>
+        <div className="space-y-1.5">
+          {automationProductTriggerOptions.map((option) => (
+            <Label
+              key={option.value}
+              className="flex min-h-7 cursor-pointer items-center gap-2 text-xs font-normal"
+            >
+              <Checkbox
+                checked={productTriggers.includes(option.value)}
+                onCheckedChange={(checked) =>
+                  toggleProductTrigger(option.value, checked === true)
+                }
+                aria-label={option.label}
+              />
+              <span>{option.label}</span>
+            </Label>
+          ))}
+        </div>
+      </div>
+      {!hasTrigger ? (
+        <p className="text-xs text-destructive">
+          Select at least one trigger. Nothing is saved until you do.
+        </p>
+      ) : null}
+      <Collapsible className="rounded-md border border-border">
+        <CollapsibleTrigger asChild>
+          <Button
+            type="button"
+            variant="ghost"
+            className="group h-8 w-full justify-between rounded-md px-2 text-left text-xs font-normal"
+          >
+            <span>Trigger filters</span>
+            <ChevronDown className="h-3.5 w-3.5 text-muted-foreground transition-transform group-data-[state=open]:rotate-180" />
+          </Button>
+        </CollapsibleTrigger>
+        <CollapsibleContent className="space-y-2.5 border-t border-border p-2.5">
+          <p className="text-xs text-muted-foreground">
+            Comma-separated filters applied when GitHub sends matching context.
+          </p>
+          <TriggerFilterField
+            id="trigger-base-branches"
+            label="Target branches"
+            serverValue={(filters.base_branches ?? []).join(", ")}
+            onCommit={(value) => saveFilter("base_branches", value)}
+          />
+          <TriggerFilterField
+            id="trigger-authors"
+            label="Authors"
+            serverValue={(filters.authors ?? []).join(", ")}
+            onCommit={(value) => saveFilter("authors", value)}
+          />
+          <TriggerFilterField
+            id="trigger-paths"
+            label="Paths"
+            serverValue={(filters.paths ?? []).join(", ")}
+            onCommit={(value) => saveFilter("paths", value)}
+          />
+          <TriggerFilterField
+            id="trigger-feedback-types"
+            label="Feedback types"
+            serverValue={(filters.feedback_types ?? []).join(", ")}
+            onCommit={(value) => saveFilter("feedback_types", value)}
+          />
+          <TriggerFilterField
+            id="trigger-review-states"
+            label="Review states"
+            serverValue={(filters.review_states ?? []).join(", ")}
+            onCommit={(value) => saveFilter("review_states", value)}
+          />
+        </CollapsibleContent>
+      </Collapsible>
+    </div>
+  );
+}
+
+function TriggerFilterField({
+  id,
+  label,
+  serverValue,
+  onCommit,
+}: {
+  id: string;
+  label: string;
+  serverValue: string;
+  onCommit: (value: string) => void;
+}) {
+  // Lives inside the Triggers popover, so it can be unmounted mid-edit.
+  const field = useDebouncedTextField({
+    serverValue,
+    onCommit,
+    flushOnUnmount: true,
+  });
+
+  return (
+    <div className="space-y-1">
+      <Label htmlFor={id} className="text-xs font-normal text-muted-foreground">
+        {label}
+      </Label>
+      <Input
+        id={id}
+        value={field.value}
+        onChange={(event) => field.onChange(event.target.value)}
+        onBlur={field.onBlur}
+        className="h-9 text-xs sm:h-7"
+      />
+    </div>
+  );
+}
+
+function PrePRReviewProperty({
+  automation,
+  autosave,
+  supported,
+  canManage,
+}: {
+  automation: Automation;
+  autosave: AutomationAutosave;
+  supported: boolean;
+  canManage: boolean;
+}) {
+  const uid = useId();
+  const field = useAutosaveNumericField<AutomationPatch>({
+    serverValue: supported ? (automation.pre_pr_review_loops ?? 0) : 0,
+    autosave,
+    // Lives inside the Advanced collapsible, so it can be unmounted mid-edit.
+    flushOnUnmount: true,
+    clamp: (raw) => Math.min(5, Math.max(0, raw)),
+    toPatch: (loops) => ({
+      body: { pre_pr_review_loops: loops },
+      optimistic: { pre_pr_review_loops: loops },
+    }),
+  });
+  const current = Number(field.value) || 0;
+  const disabled = !canManage || !supported;
+
+  let description = "Off for agents without review-loop support.";
+  if (supported) {
+    description =
+      current === 0
         ? "Off"
         : "Runs the coding agent's review/fix loop before opening a PR.";
   }
-  const showReasoningSelector = supportsReasoningEffort(effectiveAgentType);
-  const reasoningOptions = getCodingAgentReasoningOptions(effectiveAgentType);
+
+  return (
+    <div className="space-y-1.5">
+      <Label
+        htmlFor={`pre-pr-review-loops-${uid}`}
+        className="text-xs font-medium text-muted-foreground"
+      >
+        Pre-PR review
+      </Label>
+      <div className="flex items-center gap-1.5">
+        <Button
+          type="button"
+          variant="outline"
+          size="icon-sm"
+          aria-label="Decrease review passes"
+          onClick={() => field.setValueAndSave(Math.max(0, current - 1))}
+          disabled={disabled}
+        >
+          <Minus className="h-3.5 w-3.5" />
+        </Button>
+        <Input
+          id={`pre-pr-review-loops-${uid}`}
+          aria-label="Review passes"
+          type="number"
+          min={0}
+          max={5}
+          value={field.value}
+          onChange={field.onChange}
+          onBlur={field.onBlur}
+          disabled={disabled}
+          className="h-9 w-14 text-center text-xs sm:h-7"
+        />
+        <Button
+          type="button"
+          variant="outline"
+          size="icon-sm"
+          aria-label="Increase review passes"
+          onClick={() => field.setValueAndSave(Math.min(5, current + 1))}
+          disabled={disabled}
+        >
+          <Plus className="h-3.5 w-3.5" />
+        </Button>
+      </div>
+      <p className="text-xs text-muted-foreground">{description}</p>
+    </div>
+  );
+}
+
+function CapabilitiesProperty({
+  automation,
+  canManage,
+}: {
+  automation: Automation;
+  canManage: boolean;
+}) {
   const { data: capabilityCatalogResponse } = useQuery<
     ListResponse<AgentCapabilityDefinition>
   >({
@@ -252,7 +782,16 @@ function SettingsTab({
     queryKey: ["automation-capabilities", automation.id],
     queryFn: () => api.automations.getCapabilities(automation.id),
   });
-  const savedCapabilityGrants = useMemo(
+  const autosave = useAutosave<AgentCapabilityGrant[]>({
+    queryKey: ["automation-capabilities", automation.id],
+    debounceMs: 0,
+    mutationFn: (grants) =>
+      api.automations.updateCapabilities(automation.id, grants),
+    applyOptimistic: applyCapabilityGrants,
+    coalesce: coalesceCapabilityGrants,
+    errorMessage: "Couldn’t save capabilities. Your change was reverted.",
+  });
+  const grants = useMemo(
     () =>
       normalizeCapabilityGrants(
         capabilityCatalog,
@@ -260,471 +799,25 @@ function SettingsTab({
       ),
     [automationCapabilityResponse?.data?.capabilities, capabilityCatalog],
   );
-  const capabilityGrants = capabilityDraft ?? savedCapabilityGrants;
-  const githubEventFilters: AutomationGitHubEventFilters = useMemo(
-    () => ({
-      base_branches: commaList(triggerBaseBranches),
-      authors: commaList(triggerAuthors),
-      paths: commaList(triggerPaths),
-      feedback_types: commaList(triggerFeedbackTypes),
-      review_states: commaList(triggerReviewStates),
-    }),
-    [
-      triggerAuthors,
-      triggerBaseBranches,
-      triggerFeedbackTypes,
-      triggerPaths,
-      triggerReviewStates,
-    ],
-  );
-  const hasTrigger = scheduleEnabled || productTriggers.length > 0;
-
-  const toggleProductTrigger = (
-    trigger: AutomationProductTrigger,
-    checked: boolean,
-  ) => {
-    setProductTriggers((current) => {
-      if (checked) {
-        return current.includes(trigger) ? current : [...current, trigger];
-      }
-      return current.filter((item) => item !== trigger);
-    });
-  };
-
-  const updateMutation = useMutation({
-    mutationFn: () =>
-      api.automations.update(automation.id, {
-        ...(repositoryId === (automation.repository_id ?? "")
-          ? {}
-          : { repository_id: repositoryId }),
-        scope: scope.trim() || undefined,
-        ...(sameScheduleDraft(scheduleDraft, initialScheduleDraftRef.current)
-          ? {}
-          : scheduleDraftToAPI(scheduleDraft, automation.timezone)),
-        triggers: productTriggers,
-        github_event_filters: githubEventFilters,
-        model: model ?? "",
-        identity_scope: identityScope,
-        publish_policy: publishPolicy,
-        pre_pr_review_loops: effectivePrePRReviewLoops,
-        reasoning_effort:
-          showReasoningSelector && reasoningEffort ? reasoningEffort : "",
-        base_branch: baseBranch.trim() || undefined,
-      }),
-    onSuccess: (res) => {
-      upsertAutomationInListCaches(queryClient, res.data);
-      queryClient.setQueryData(queryKeys.automations.detail(res.data.id), res);
-      queryClient.invalidateQueries({
-        queryKey: queryKeys.automations.detail(res.data.id),
-      });
-      queryClient.invalidateQueries({ queryKey: queryKeys.automations.all });
-    },
-  });
-  const capabilityMutation = useMutation({
-    mutationFn: (capabilities: AgentCapabilityGrant[]) =>
-      api.automations.updateCapabilities(automation.id, capabilities),
-    onSuccess: () => {
-      setCapabilityDraft(null);
-      queryClient.invalidateQueries({
-        queryKey: ["automation-capabilities", automation.id],
-      });
-    },
-  });
 
   return (
-    <div className="space-y-4 rounded-lg border border-border bg-card p-5">
-      <div className="space-y-1.5">
-        <Label htmlFor="automation-repository">Repository</Label>
-        <Select
-          value={repositoryId}
-          onValueChange={(nextRepositoryId) => {
-            setRepositoryId(nextRepositoryId);
-            const nextRepository = repositories.find(
-              (repository) => repository.id === nextRepositoryId,
-            );
-            if (nextRepository) {
-              setBaseBranch(nextRepository.default_branch);
-            }
-          }}
-          disabled={!canManage || repositories.length === 0}
-        >
-          <SelectTrigger id="automation-repository" aria-label="Repository">
-            <SelectValue placeholder="Select repository" />
-          </SelectTrigger>
-          <SelectContent>
-            {repositories.map((repository) => (
-              <SelectItem key={repository.id} value={repository.id}>
-                {repository.full_name}
-              </SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
-        <p className="text-xs text-muted-foreground">
-          Changing the repository resets the base branch to that
-          repository&apos;s default.
-        </p>
-      </div>
-      <div className="space-y-1.5">
-        <Label htmlFor="scope">
-          Scope{" "}
-          <span className="text-muted-foreground font-normal">(optional)</span>
+    <div className="space-y-1.5">
+      <div className="flex items-center justify-between gap-2">
+        <Label className="text-xs font-medium text-muted-foreground">
+          Capabilities
         </Label>
-        <Input
-          id="scope"
-          value={scope}
-          onChange={(e) => setScope(e.target.value)}
-        />
+        <AutosaveIndicator status={autosave.status} className="min-w-0" />
       </div>
-      <div className="space-y-1.5">
-        <Label>Run as</Label>
-        <Select
-          value={identityScope}
-          onValueChange={(value: "org" | "personal") => setIdentityScope(value)}
-        >
-          <SelectTrigger aria-label="Run as">
-            <SelectValue />
-          </SelectTrigger>
-          <SelectContent>
-            <SelectItem value="org">Organization automation</SelectItem>
-            <SelectItem value="personal">Personal automation</SelectItem>
-          </SelectContent>
-        </Select>
-        <p className="text-xs text-muted-foreground">
-          Organization automations use team credentials and publish as 143-bot.
-          Personal automations use the creator&apos;s coding-agent preferences and
-          GitHub identity.
-        </p>
-      </div>
-      <div className="space-y-2">
-        <Label>Triggers</Label>
-        <div className="space-y-3 rounded-md border border-border p-3">
-          {canManage ? (
-            <AutomationScheduleEditor
-              value={scheduleDraft}
-              onChange={setScheduleDraft}
-              detectedTimezone={detectedTimezone}
-              onValidityChange={setScheduleValid}
-            />
-          ) : (
-            <AutomationScheduleSummary
-              schedule={scheduleDraft}
-              nextRunAt={automation.next_run_at}
-              enabled={automation.enabled}
-            />
-          )}
-          <div className="space-y-2">
-            <span className="text-xs font-medium leading-none text-muted-foreground">
-              Pull requests
-            </span>
-            <div className="grid gap-2 md:grid-cols-2">
-              {automationProductTriggerOptions.map((option) => (
-                <Label
-                  key={option.value}
-                  className="flex min-h-7 cursor-pointer items-center gap-2 text-sm font-normal"
-                >
-                  <Checkbox
-                    checked={productTriggers.includes(option.value)}
-                    onCheckedChange={(checked) =>
-                      toggleProductTrigger(option.value, checked === true)
-                    }
-                    aria-label={option.label}
-                    disabled={!canManage}
-                  />
-                  <span>{option.label}</span>
-                </Label>
-              ))}
-            </div>
-          </div>
-          {!hasTrigger ? (
-            <p className="text-xs text-destructive">
-              Select at least one trigger.
-            </p>
-          ) : null}
-        </div>
-      </div>
-      <Collapsible className="rounded-md border border-border">
-        <CollapsibleTrigger asChild>
-          <Button
-            type="button"
-            variant="ghost"
-            className="group h-10 w-full justify-between rounded-md px-3 text-left"
-          >
-            <span>Advanced settings</span>
-            <ChevronDown className="h-4 w-4 text-muted-foreground transition-transform group-data-[state=open]:rotate-180" />
-          </Button>
-        </CollapsibleTrigger>
-        <CollapsibleContent className="space-y-4 border-t border-border p-3">
-          <div className="space-y-1.5">
-            <Label htmlFor="automation-model">Model</Label>
-            <AutomationModelSelect
-              id="automation-model"
-              ariaLabel="Model"
-              value={model}
-              onValueChange={setModel}
-            />
-          </div>
-          {showReasoningSelector ? (
-            <div className="space-y-1.5">
-              <Label htmlFor="automation-reasoning">Reasoning</Label>
-              <Select
-                value={reasoningEffort || "__default__"}
-                onValueChange={(value) =>
-                  setReasoningEffort(
-                    value === "__default__"
-                      ? ""
-                      : toCodingAgentReasoningEffort(value),
-                  )
-                }
-              >
-                <SelectTrigger id="automation-reasoning" aria-label="Reasoning">
-                  <SelectValue placeholder="Default reasoning" />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="__default__">Default reasoning</SelectItem>
-                  {reasoningOptions.map((option) => (
-                    <SelectItem key={option.value} value={option.value}>
-                      {option.label}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-            </div>
-          ) : null}
-          <div className="space-y-1.5">
-            <Label>Base branch</Label>
-            <BranchPicker
-              repositoryId={repositoryId}
-              value={baseBranch}
-              defaultBranch={
-                selectedRepository?.default_branch ?? automation.base_branch
-              }
-              onValueChange={setBaseBranch}
-              label="Base branch"
-              buttonClassName="w-full justify-between"
-              contentClassName="w-[var(--radix-popover-trigger-width)]"
-            />
-          </div>
-          <div className="space-y-1.5">
-            <Label>After a successful run</Label>
-            <Select
-              value={publishPolicy}
-              onValueChange={(value) => {
-                if (value === "pull_request" || value === "none") {
-                  setPublishPolicy(value);
-                }
-              }}
-              disabled={!canManage}
-            >
-              <SelectTrigger aria-label="After a successful run">
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="pull_request">Open a pull request</SelectItem>
-                <SelectItem value="none">Do not publish</SelectItem>
-              </SelectContent>
-            </Select>
-            <p className="text-xs text-muted-foreground">
-              Pull requests are also skipped when the run produces no diff.
-            </p>
-          </div>
-          <div className="space-y-2">
-            <div className="flex items-center justify-between gap-3">
-              <Label>Capabilities</Label>
-              <span className="truncate text-xs text-muted-foreground">
-                {capabilitySummary(capabilityCatalog, capabilityGrants)}
-              </span>
-            </div>
-            <AutomationCapabilitiesEditor
-              catalog={capabilityCatalog}
-              grants={capabilityGrants}
-              onChange={setCapabilityDraft}
-              disabled={!canManage}
-            />
-            {capabilityDraft ? (
-              <div className="flex items-center gap-2">
-                <Button
-                  type="button"
-                  size="sm"
-                  onClick={() => capabilityMutation.mutate(capabilityDraft)}
-                  disabled={capabilityMutation.isPending}
-                >
-                  {capabilityMutation.isPending && (
-                    <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                  )}
-                  Save capabilities
-                </Button>
-                <Button
-                  type="button"
-                  size="sm"
-                  variant="outline"
-                  onClick={() => setCapabilityDraft(null)}
-                >
-                  Reset
-                </Button>
-                {capabilityMutation.isError ? (
-                  <span className="text-xs text-destructive">
-                    Failed to save capabilities.
-                  </span>
-                ) : null}
-              </div>
-            ) : null}
-          </div>
-          <div className="space-y-3 rounded-md border border-border p-3">
-            <div className="space-y-1">
-              <Label>Trigger filters</Label>
-              <p className="text-xs text-muted-foreground">
-                Comma-separated filters applied when GitHub sends matching
-                context.
-              </p>
-            </div>
-            <div className="grid gap-3 sm:grid-cols-2">
-              <div className="space-y-1.5">
-                <Label htmlFor="trigger-base-branches">Target branches</Label>
-                <Input
-                  id="trigger-base-branches"
-                  value={triggerBaseBranches}
-                  onChange={(e) => setTriggerBaseBranches(e.target.value)}
-                  disabled={!canManage}
-                />
-              </div>
-              <div className="space-y-1.5">
-                <Label htmlFor="trigger-authors">Authors</Label>
-                <Input
-                  id="trigger-authors"
-                  value={triggerAuthors}
-                  onChange={(e) => setTriggerAuthors(e.target.value)}
-                  disabled={!canManage}
-                />
-              </div>
-              <div className="space-y-1.5">
-                <Label htmlFor="trigger-paths">Paths</Label>
-                <Input
-                  id="trigger-paths"
-                  value={triggerPaths}
-                  onChange={(e) => setTriggerPaths(e.target.value)}
-                  disabled={!canManage}
-                />
-              </div>
-              <div className="space-y-1.5">
-                <Label htmlFor="trigger-feedback-types">Feedback types</Label>
-                <Input
-                  id="trigger-feedback-types"
-                  value={triggerFeedbackTypes}
-                  onChange={(e) => setTriggerFeedbackTypes(e.target.value)}
-                  disabled={!canManage}
-                />
-              </div>
-              <div className="space-y-1.5 sm:col-span-2">
-                <Label htmlFor="trigger-review-states">Review states</Label>
-                <Input
-                  id="trigger-review-states"
-                  value={triggerReviewStates}
-                  onChange={(e) => setTriggerReviewStates(e.target.value)}
-                  disabled={!canManage}
-                />
-              </div>
-            </div>
-          </div>
-          <div className="space-y-1.5">
-            <Label htmlFor="pre-pr-review-loops">Pre-PR review</Label>
-            <div className="flex items-center gap-2">
-              <Button
-                type="button"
-                variant="outline"
-                size="icon"
-                aria-label="Decrease review passes"
-                onClick={() =>
-                  setPrePRReviewLoops((value) => Math.max(0, value - 1))
-                }
-                disabled={!canManage || !supportsNativeReviewLoop}
-              >
-                <Minus className="h-4 w-4" />
-              </Button>
-              <Input
-                id="pre-pr-review-loops"
-                aria-label="Review passes"
-                type="number"
-                min={0}
-                max={5}
-                value={effectivePrePRReviewLoops}
-                onChange={(e) => {
-                  const parsed = parseInt(e.target.value, 10);
-                  setPrePRReviewLoops(
-                    Number.isNaN(parsed) ? 0 : Math.min(5, Math.max(0, parsed)),
-                  );
-                }}
-                disabled={!canManage || !supportsNativeReviewLoop}
-                className="w-20 text-center"
-              />
-              <Button
-                type="button"
-                variant="outline"
-                size="icon"
-                aria-label="Increase review passes"
-                onClick={() =>
-                  setPrePRReviewLoops((value) => Math.min(5, value + 1))
-                }
-                disabled={!canManage || !supportsNativeReviewLoop}
-              >
-                <Plus className="h-4 w-4" />
-              </Button>
-            </div>
-            <p className="text-xs text-muted-foreground">
-              {prePRReviewDescription}
-            </p>
-          </div>
-        </CollapsibleContent>
-      </Collapsible>
-      {canManage && (
-        <div className="flex items-center gap-3 pt-2">
-          <Button
-            onClick={() => updateMutation.mutate()}
-            disabled={
-              updateMutation.isPending ||
-              !hasTrigger ||
-              (scheduleEnabled && !scheduleValid)
-            }
-          >
-            {updateMutation.isPending && (
-              <Loader2 className="h-4 w-4 mr-2 animate-spin" />
-            )}
-            Save changes
-          </Button>
-          {updateMutation.isError && (
-            <p className="text-xs text-destructive">Failed to save changes.</p>
-          )}
-          {updateMutation.isSuccess && !updateMutation.isPending && (
-            <p className="text-xs text-muted-foreground">Saved.</p>
-          )}
-        </div>
-      )}
+      <p className="truncate text-xs text-muted-foreground">
+        {capabilitySummary(capabilityCatalog, grants)}
+      </p>
+      <AutomationCapabilitiesEditor
+        catalog={capabilityCatalog}
+        grants={grants}
+        onChange={(next) => autosave.save(next)}
+        disabled={!canManage}
+      />
     </div>
-  );
-}
-
-type AutomationTextPatch = Partial<Pick<Automation, "name" | "goal">>;
-const coalesceAutomationTextPatches = (
-  queued: AutomationTextPatch,
-  incoming: AutomationTextPatch,
-): AutomationTextPatch => ({ ...queued, ...incoming });
-
-function AutosaveIndicator({ status }: { status: AutosaveStatus }) {
-  if (status === "idle") return null;
-
-  return (
-    <span
-      role="status"
-      className={cn(
-        "text-xs",
-        status === "error" ? "text-destructive" : "text-muted-foreground",
-      )}
-    >
-      {status === "saving"
-        ? "Saving…"
-        : status === "saved"
-          ? "Saved"
-          : "Couldn’t save"}
-    </span>
   );
 }
 
@@ -739,33 +832,27 @@ function InlineAutomationText({
 }) {
   const queryClient = useQueryClient();
   const detailKey = queryKeys.automations.detail(automation.id);
-  const autosave = useAutosave<AutomationTextPatch>({
-    queryKey: detailKey,
-    debounceMs: 0,
-    mutationFn: async (patch) => {
-      const response = await api.automations.update(automation.id, patch);
-      upsertAutomationInListCaches(queryClient, response.data);
-      return response;
-    },
-    applyOptimistic: (previous, patch) => {
-      const response = previous as { data?: Automation } | undefined;
-      if (!response?.data) return previous;
-      return { ...response, data: { ...response.data, ...patch } };
-    },
-    coalesce: coalesceAutomationTextPatches,
-    errorMessage: "Couldn’t save automation text. Your change was reverted.",
-  });
+  const autosave = useAutomationAutosave(automation.id);
+  // Both flush on unmount so a title or goal typed right before navigating away
+  // isn't dropped inside the 400ms window — the autosave scope outlives this
+  // component, so the dispatch still lands.
   const nameField = useDebouncedTextField({
     serverValue: automation.name,
-    onCommit: (name) => autosave.save({ name: name.trim() }),
+    flushOnUnmount: true,
+    onCommit: (rawName) => {
+      const name = rawName.trim();
+      autosave.save({ body: { name }, optimistic: { name } });
+    },
     // A required field: an empty title is rejected (never saved) and reverts to
     // the last saved name on blur rather than being left silently blank.
     rejectValue: (name) => name.trim() === "",
   });
   const goalField = useDebouncedTextField({
     serverValue: automation.goal,
+    flushOnUnmount: true,
     onCommit: (goal) => {
-      if (!automationGoalLengthState(goal).isTooLong) autosave.save({ goal });
+      if (automationGoalLengthState(goal).isTooLong) return;
+      autosave.save({ body: { goal }, optimistic: { goal } });
     },
   });
   const goalLength = automationGoalLengthState(goalField.value);
@@ -910,7 +997,6 @@ export default function AutomationDetailPage() {
   const { user } = useAuth();
   const automationId = params?.id as string;
   const canManage = user?.role === "admin" || user?.role === "member";
-  const [settingsOpen, setSettingsOpen] = useState(false);
   const [detailsOpen, setDetailsOpen] = useState(false);
 
   const { data, isLoading } = useQuery({
@@ -1135,29 +1221,16 @@ export default function AutomationDetailPage() {
       </Button>
     </div>
   ) : undefined;
-  const headerActions = canManage ? (
-    <div className="flex flex-wrap items-center gap-2">
-      <Button variant="outline" size="sm" onClick={() => setSettingsOpen(true)}>
-        <Settings2 className="mr-1.5 h-3.5 w-3.5" />
-        Edit
-      </Button>
-      <Button
-        variant="outline"
-        size="sm"
-        className="lg:hidden"
-        onClick={() => setDetailsOpen(true)}
-      >
-        Details
-      </Button>
-    </div>
-  ) : (
+  // No "Edit" button: every property is already editable where it is displayed,
+  // so the only header affordance left is reaching the rail on small screens.
+  const headerActions = (
     <Button
       variant="outline"
       size="sm"
       className="lg:hidden"
       onClick={() => setDetailsOpen(true)}
     >
-      Details
+      Properties
     </Button>
   );
   const repositoryName =
@@ -1167,29 +1240,13 @@ export default function AutomationDetailPage() {
     <PageContainer size="wide">
       <div className="space-y-6">
         <MobileBackButton to="/automations" label="Back to automations" />
-        <Sheet modal={false} open={settingsOpen} onOpenChange={setSettingsOpen}>
-          <SheetContent className="sm:max-w-2xl">
-            <SheetHeader>
-              <SheetTitle>Automation settings</SheetTitle>
-              <SheetDescription>
-                Update triggers and recurring execution defaults.
-              </SheetDescription>
-            </SheetHeader>
-            <div className="mt-6">
-              <SettingsTab
-                key={automation.id}
-                automation={automation}
-                canManage={canManage}
-              />
-            </div>
-          </SheetContent>
-        </Sheet>
         <Sheet open={detailsOpen} onOpenChange={setDetailsOpen}>
           <SheetContent className="sm:max-w-md">
             <SheetHeader>
-              <SheetTitle>Automation details</SheetTitle>
+              <SheetTitle>Automation properties</SheetTitle>
               <SheetDescription>
-                Schedule, identity, model, and recent run controls.
+                Triggers, identity, model, and recent run controls. Changes save
+                as you make them.
               </SheetDescription>
             </SheetHeader>
             <div className="mt-6">
@@ -1197,6 +1254,7 @@ export default function AutomationDetailPage() {
                 automation={automation}
                 schedule={schedule}
                 repositoryName={repositoryName}
+                canManage={canManage}
                 runActions={runActions}
               />
             </div>
@@ -1253,9 +1311,11 @@ export default function AutomationDetailPage() {
 
           <aside className="hidden space-y-4 lg:sticky lg:top-4 lg:block">
             <AutomationDetailRail
+              key={automation.id}
               automation={automation}
               schedule={schedule}
               repositoryName={repositoryName}
+              canManage={canManage}
               runActions={runActions}
             />
             <AutomationStatsCard automationId={automationId} />
@@ -1270,96 +1330,417 @@ function AutomationDetailRail({
   automation,
   schedule,
   repositoryName,
+  canManage,
   runActions,
 }: {
   automation: Automation;
   schedule: string;
   repositoryName: string;
+  canManage: boolean;
   runActions?: ReactNode;
 }) {
-  const prTriggerLabels = githubEventsToAutomationProductTriggers(
-    automation.github_event_triggers ?? [],
-  )
-    .map(
-      (trigger) =>
-        automationProductTriggerOptions.find(
-          (option) => option.value === trigger,
-        )?.label,
-    )
-    .filter((label): label is string => Boolean(label));
-  const triggerSummary =
-    [automation.schedule_type === "none" ? null : schedule, ...prTriggerLabels]
-      .filter((value): value is string => Boolean(value))
-      .join(", ") || "-";
+  const autosave = useAutomationAutosave(automation.id);
+  const { save } = autosave;
+  // The desktop aside is `hidden lg:block` rather than unmounted, so opening the
+  // mobile properties sheet puts two copies of this rail in the DOM at once.
+  // Scope the control ids per instance to keep every label bound to its own
+  // control instead of silently pointing at the other copy's.
+  const uid = useId();
+
+  const { data: repositoriesResponse } = useQuery<ListResponse<Repository>>({
+    queryKey: queryKeys.repositories.all,
+    queryFn: () => api.repositories.list(),
+    enabled: canManage,
+  });
+  const repositories = useMemo(
+    () => repositoriesResponse?.data ?? [],
+    [repositoriesResponse?.data],
+  );
+  const repositoryId = automation.repository_id ?? "";
+  const selectedRepository = repositories.find(
+    (repository) => repository.id === repositoryId,
+  );
+
+  const { data: settingsResponse } = useQuery({
+    queryKey: ["settings"],
+    queryFn: () => api.settings.get(),
+  });
+  const settings = (settingsResponse?.data?.settings ?? {}) as {
+    default_agent_type?: string;
+  };
+  const defaultAgentType = settings.default_agent_type ?? "codex";
+  const model = automation.model_override;
+  // Shared by the row that renders the current model and by the handler that
+  // patches a new one — the two have to agree on which agent a model implies,
+  // or the reasoning reset stops matching what the rail is showing.
+  const effectiveAgentTypeFor = (candidate: string | undefined) =>
+    candidate
+      ? (agentTypeForModel(candidate) ??
+        automation.agent_type ??
+        defaultAgentType)
+      : (automation.agent_type ?? defaultAgentType);
+  const effectiveAgentType = effectiveAgentTypeFor(model);
+  const supportsNativeReviewLoop = [
+    "codex",
+    "claude_code",
+    "amp",
+    "pi",
+    "opencode",
+  ].includes(effectiveAgentType);
+  const showReasoningSelector = supportsReasoningEffort(effectiveAgentType);
+  const reasoningOptions = getCodingAgentReasoningOptions(effectiveAgentType);
+
+  const scopeField = useDebouncedTextField({
+    serverValue: automation.scope ?? "",
+    // The mobile properties sheet mounts a second copy of this rail and
+    // unmounts it on close, so this field can go away mid-edit.
+    flushOnUnmount: true,
+    onCommit: (raw) => {
+      const scope = raw.trim();
+      save({ body: { scope }, optimistic: { scope } });
+    },
+  });
 
   return (
     <section className="rounded-lg border border-border bg-card p-4">
       <div className="space-y-4">
-        <div className="flex items-center justify-between gap-3">
-          <h2 className="text-sm font-semibold text-foreground">Status</h2>
-          <Badge variant={automation.enabled ? "default" : "secondary"}>
-            {automation.enabled ? "Active" : "Paused"}
-          </Badge>
+        <div className="flex items-center justify-between gap-2">
+          <h2 className="text-sm font-semibold text-foreground">Properties</h2>
+          <div className="flex items-center gap-2">
+            <AutosaveIndicator status={autosave.status} className="min-w-0" />
+            <Badge variant={automation.enabled ? "default" : "secondary"}>
+              {automation.enabled ? "Active" : "Paused"}
+            </Badge>
+          </div>
         </div>
         {runActions}
-        <DetailList
-          items={[
-            [
-              "Next run",
+
+        <div className="space-y-2">
+          <StaticPropertyRow
+            label="Next run"
+            value={
               automation.next_run_at
                 ? formatDateTime(automation.next_run_at)
-                : "-",
-            ],
-            [
-              "Last ran",
+                : "-"
+            }
+          />
+          <StaticPropertyRow
+            label="Last ran"
+            value={
               automation.last_run_at
                 ? formatDateTime(automation.last_run_at)
-                : "-",
-            ],
-            ["Repository", repositoryName],
-            ["Triggers", triggerSummary],
-            [
-              "Runs as",
-              automation.identity_scope === "personal"
-                ? "Personal"
-                : "Organization",
-            ],
-            [
-              "Model",
-              automation.model_override || automation.agent_type || "Auto",
-            ],
-            ["Reasoning", automation.reasoning_effort || "Default"],
-            ["Base branch", automation.base_branch || "-"],
-            [
-              "After success",
-              automation.publish_policy === "none"
-                ? "Do not publish"
-                : "Open a pull request",
-            ],
-            ["Priority", priorityLabel(automation.priority)],
-            ["Scope", automation.scope || "-"],
-          ]}
-        />
+                : "-"
+            }
+          />
+
+          <TriggersProperty
+            automation={automation}
+            schedule={schedule}
+            canManage={canManage}
+            autosave={autosave}
+          />
+
+          {canManage ? (
+            <PropertyRow
+              label="Repository"
+              htmlFor={`automation-repository-${uid}`}
+            >
+              <Select
+                value={repositoryId}
+                onValueChange={(nextRepositoryId) => {
+                  const nextRepository = repositories.find(
+                    (repository) => repository.id === nextRepositoryId,
+                  );
+                  // Changing repositories invalidates the stored base branch,
+                  // so both fields move as one patch rather than leaving a
+                  // branch that does not exist on the new repo.
+                  save({
+                    body: {
+                      repository_id: nextRepositoryId,
+                      ...(nextRepository
+                        ? { base_branch: nextRepository.default_branch }
+                        : {}),
+                    },
+                    optimistic: {
+                      repository_id: nextRepositoryId,
+                      ...(nextRepository
+                        ? { base_branch: nextRepository.default_branch }
+                        : {}),
+                    },
+                  });
+                }}
+                disabled={repositories.length === 0}
+              >
+                <SelectTrigger
+                  id={`automation-repository-${uid}`}
+                  aria-label="Repository"
+                  className={inlineSelectTriggerClass}
+                >
+                  <SelectValue placeholder={repositoryName} />
+                </SelectTrigger>
+                <SelectContent>
+                  {/* The repository list loads separately from the automation,
+                      so keep an entry for the current value until it arrives —
+                      otherwise Radix has no item to render and the row reads as
+                      blank on first paint. */}
+                  {repositoryId && !selectedRepository ? (
+                    <SelectItem value={repositoryId}>
+                      {repositoryName}
+                    </SelectItem>
+                  ) : null}
+                  {repositories.map((repository) => (
+                    <SelectItem key={repository.id} value={repository.id}>
+                      {repository.full_name}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </PropertyRow>
+          ) : (
+            <StaticPropertyRow label="Repository" value={repositoryName} />
+          )}
+
+          {canManage ? (
+            <PropertyRow
+              label="Runs as"
+              htmlFor={`automation-identity-scope-${uid}`}
+            >
+              <Select
+                value={automation.identity_scope ?? "org"}
+                onValueChange={(value: "org" | "personal") =>
+                  save({
+                    body: { identity_scope: value },
+                    optimistic: { identity_scope: value },
+                  })
+                }
+              >
+                <SelectTrigger
+                  id={`automation-identity-scope-${uid}`}
+                  aria-label="Run as"
+                  className={inlineSelectTriggerClass}
+                >
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="org">Organization</SelectItem>
+                  <SelectItem value="personal">Personal</SelectItem>
+                </SelectContent>
+              </Select>
+            </PropertyRow>
+          ) : (
+            <StaticPropertyRow
+              label="Runs as"
+              value={
+                automation.identity_scope === "personal"
+                  ? "Personal"
+                  : "Organization"
+              }
+            />
+          )}
+
+          {canManage ? (
+            <PropertyRow label="Model" htmlFor={`automation-model-${uid}`}>
+              <AutomationModelSelect
+                id={`automation-model-${uid}`}
+                ariaLabel="Model"
+                value={model}
+                triggerClassName={inlineSelectTriggerClass}
+                onValueChange={(value) => {
+                  // The API re-validates the STORED reasoning override against
+                  // the model's agent, so a lone `model` patch is rejected
+                  // outright when the new agent can't accept it. The old batch
+                  // save cleared it in the same request; a per-field patch has
+                  // to carry that reset too, or the switch fails and the row
+                  // the user would need to clear is the one that disappears.
+                  const nextAgentType = effectiveAgentTypeFor(value);
+                  const clearsReasoning =
+                    Boolean(automation.reasoning_effort) &&
+                    !supportsReasoningEffort(nextAgentType);
+                  save({
+                    body: {
+                      model: value ?? "",
+                      ...(clearsReasoning ? { reasoning_effort: "" } : {}),
+                    },
+                    optimistic: {
+                      model_override: value ?? "",
+                      ...(clearsReasoning
+                        ? { reasoning_effort: undefined }
+                        : {}),
+                    },
+                  });
+                }}
+              />
+            </PropertyRow>
+          ) : (
+            <StaticPropertyRow
+              label="Model"
+              value={model || automation.agent_type || "Auto"}
+            />
+          )}
+
+          {canManage && showReasoningSelector ? (
+            <PropertyRow
+              label="Reasoning"
+              htmlFor={`automation-reasoning-${uid}`}
+            >
+              <Select
+                value={automation.reasoning_effort || "__default__"}
+                onValueChange={(value) => {
+                  const reasoning_effort: CodingAgentReasoningEffort =
+                    value === "__default__"
+                      ? ""
+                      : toCodingAgentReasoningEffort(value);
+                  save({
+                    // The API clears the override with "", but the model types
+                    // "no override" as absent — so the cache gets `undefined`.
+                    body: { reasoning_effort },
+                    optimistic: {
+                      reasoning_effort: reasoning_effort || undefined,
+                    },
+                  });
+                }}
+              >
+                <SelectTrigger
+                  id={`automation-reasoning-${uid}`}
+                  aria-label="Reasoning"
+                  className={inlineSelectTriggerClass}
+                >
+                  <SelectValue placeholder="Default" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="__default__">Default</SelectItem>
+                  {reasoningOptions.map((option) => (
+                    <SelectItem key={option.value} value={option.value}>
+                      {option.label}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </PropertyRow>
+          ) : showReasoningSelector ? (
+            <StaticPropertyRow
+              label="Reasoning"
+              value={automation.reasoning_effort || "Default"}
+            />
+          ) : null}
+
+          {canManage ? (
+            <PropertyRow
+              label="Base branch"
+              htmlFor={`automation-base-branch-${uid}`}
+            >
+              <BranchPicker
+                id={`automation-base-branch-${uid}`}
+                repositoryId={repositoryId}
+                value={automation.base_branch}
+                defaultBranch={
+                  selectedRepository?.default_branch ?? automation.base_branch
+                }
+                onValueChange={(base_branch) =>
+                  save({
+                    body: { base_branch },
+                    optimistic: { base_branch },
+                  })
+                }
+                label="Base branch"
+                buttonClassName={inlineControlClass}
+                contentClassName="w-[var(--radix-popover-trigger-width)]"
+              />
+            </PropertyRow>
+          ) : (
+            <StaticPropertyRow
+              label="Base branch"
+              value={automation.base_branch || "-"}
+            />
+          )}
+
+          {canManage ? (
+            <PropertyRow
+              label="After success"
+              htmlFor={`automation-publish-policy-${uid}`}
+            >
+              <Select
+                value={automation.publish_policy ?? "pull_request"}
+                onValueChange={(value) => {
+                  if (value !== "pull_request" && value !== "none") return;
+                  save({
+                    body: { publish_policy: value },
+                    optimistic: { publish_policy: value },
+                  });
+                }}
+              >
+                <SelectTrigger
+                  id={`automation-publish-policy-${uid}`}
+                  aria-label="After a successful run"
+                  className={inlineSelectTriggerClass}
+                >
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="pull_request">Open a PR</SelectItem>
+                  <SelectItem value="none">Do not publish</SelectItem>
+                </SelectContent>
+              </Select>
+            </PropertyRow>
+          ) : (
+            <StaticPropertyRow
+              label="After success"
+              value={
+                automation.publish_policy === "none"
+                  ? "Do not publish"
+                  : "Open a pull request"
+              }
+            />
+          )}
+
+          <StaticPropertyRow
+            label="Priority"
+            value={priorityLabel(automation.priority)}
+          />
+
+          {canManage ? (
+            <PropertyRow label="Scope" htmlFor={`automation-scope-${uid}`}>
+              <Input
+                id={`automation-scope-${uid}`}
+                aria-label="Scope"
+                placeholder="Optional"
+                value={scopeField.value}
+                onChange={(event) => scopeField.onChange(event.target.value)}
+                onBlur={scopeField.onBlur}
+                className={inlineControlClass}
+              />
+            </PropertyRow>
+          ) : (
+            <StaticPropertyRow label="Scope" value={automation.scope || "-"} />
+          )}
+        </div>
+
+        <Collapsible className="rounded-md border border-border">
+          <CollapsibleTrigger asChild>
+            <Button
+              type="button"
+              variant="ghost"
+              className="group h-8 w-full justify-between rounded-md px-2 text-left text-xs font-normal"
+            >
+              <span>Advanced</span>
+              <ChevronDown className="h-3.5 w-3.5 text-muted-foreground transition-transform group-data-[state=open]:rotate-180" />
+            </Button>
+          </CollapsibleTrigger>
+          <CollapsibleContent className="space-y-3 border-t border-border p-2.5">
+            <PrePRReviewProperty
+              automation={automation}
+              autosave={autosave}
+              supported={supportsNativeReviewLoop}
+              canManage={canManage}
+            />
+            <CapabilitiesProperty
+              automation={automation}
+              canManage={canManage}
+            />
+          </CollapsibleContent>
+        </Collapsible>
       </div>
     </section>
-  );
-}
-
-function DetailList({ items }: { items: Array<[string, string]> }) {
-  return (
-    <dl className="space-y-3 text-sm">
-      {items.map(([label, value]) => (
-        <div
-          key={label}
-          className="grid grid-cols-[6.5rem_minmax(0,1fr)] gap-3"
-        >
-          <dt className="text-xs font-medium text-muted-foreground">{label}</dt>
-          <dd className="min-w-0 break-words text-xs text-foreground">
-            {value}
-          </dd>
-        </div>
-      ))}
-    </dl>
   );
 }
 

--- a/frontend/src/app/(dashboard)/automations/new/page.tsx
+++ b/frontend/src/app/(dashboard)/automations/new/page.tsx
@@ -765,7 +765,11 @@ export default function NewAutomationPage() {
                     value={scheduleDraft}
                     onChange={setScheduleDraft}
                     detectedTimezone={detectedTimezone}
-                    onValidityChange={setScheduleValid}
+                    // Wrapped rather than passed raw: the editor now sends a
+                    // second `detail` argument, and handing extra arguments to
+                    // a state setter is the kind of thing that silently changes
+                    // meaning later. This form only ever wants the boolean.
+                    onValidityChange={(valid) => setScheduleValid(valid)}
                   />
                   <div className="space-y-1">
                     <span className="text-xs font-medium text-muted-foreground">

--- a/frontend/src/app/(dashboard)/settings/AGENTS.md
+++ b/frontend/src/app/(dashboard)/settings/AGENTS.md
@@ -65,6 +65,20 @@ handler that flushes on Tab-away — wire that directly to the input
 composite controls (e.g. the "Done" button on a sheet) that need to force a
 flush outside of blur.
 
+> **Pass `flushOnUnmount: true` for any field that can be unmounted mid-edit** —
+> inside a popover, a collapsible, a sheet, or a tab. Removing a focused input
+> from the DOM does *not* dispatch `focusout`, so `onBlur` never fires and the
+> debounced edit is dropped with no toast, no indicator, and no visible change.
+> The autosave scope outlives the field, so the dispatch still lands after the
+> field is gone.
+>
+> It defaults to off only to keep the blast radius of the change that introduced
+> it contained — *not* because off is the safer behaviour. The flush fires only
+> when a debounce timer is actually armed, so it is inert for a field that never
+> unmounts mid-edit; `true` would arguably be the better default. If you are
+> touching these hooks broadly, flipping the default and making the opt-*out*
+> explicit is worth considering.
+
 ### Optimistic update helpers
 
 For org-level settings, use the helpers in `@/lib/settings-autosave`:

--- a/frontend/src/components/automation-model-select.tsx
+++ b/frontend/src/components/automation-model-select.tsx
@@ -29,6 +29,8 @@ interface AutomationModelSelectProps {
   onValueChange: (value: string | undefined) => void;
   id?: string;
   ariaLabel?: string;
+  /** Restyles the trigger — used by inline property rows to render it ghosted. */
+  triggerClassName?: string;
 }
 
 export function AutomationModelSelect({
@@ -36,6 +38,7 @@ export function AutomationModelSelect({
   onValueChange,
   id,
   ariaLabel = "Automation model",
+  triggerClassName,
 }: AutomationModelSelectProps) {
   const { data: settingsResponse } = useQuery({
     queryKey: ["settings"],
@@ -102,7 +105,7 @@ export function AutomationModelSelect({
         onValueChange(nextValue === AUTO_MODEL_VALUE ? undefined : nextValue)
       }
     >
-      <SelectTrigger id={id} aria-label={ariaLabel}>
+      <SelectTrigger id={id} aria-label={ariaLabel} className={triggerClassName}>
         <SelectValue placeholder="Auto" />
       </SelectTrigger>
       <SelectContent>

--- a/frontend/src/components/automation-schedule-editor.test.tsx
+++ b/frontend/src/components/automation-schedule-editor.test.tsx
@@ -7,10 +7,7 @@ import {
   waitFor,
 } from "@/test/test-utils";
 import { server } from "@/test/mocks/server";
-import {
-  AutomationScheduleEditor,
-  AutomationScheduleSummary,
-} from "./automation-schedule-editor";
+import { AutomationScheduleEditor } from "./automation-schedule-editor";
 
 describe("AutomationScheduleEditor", () => {
   it("adds a calendar schedule with a valid preview", async () => {
@@ -67,7 +64,9 @@ describe("AutomationScheduleEditor", () => {
 
     expect(await screen.findByText(/Next run:/)).toBeInTheDocument();
     await waitFor(() =>
-      expect(onValidityChange).toHaveBeenLastCalledWith(true),
+      expect(onValidityChange).toHaveBeenLastCalledWith(true, {
+        serverRejected: false,
+      }),
     );
   });
 
@@ -97,7 +96,9 @@ describe("AutomationScheduleEditor", () => {
     // The API revalidates the schedule on write, so a dead preview must not
     // block saving — on the detail page it would block unrelated fields too.
     await waitFor(() =>
-      expect(onValidityChange).toHaveBeenLastCalledWith(true),
+      expect(onValidityChange).toHaveBeenLastCalledWith(true, {
+        serverRejected: false,
+      }),
     );
   });
 
@@ -127,7 +128,9 @@ describe("AutomationScheduleEditor", () => {
 
     expect(await screen.findByText("No future occurrence.")).toBeInTheDocument();
     await waitFor(() =>
-      expect(onValidityChange).toHaveBeenLastCalledWith(false),
+      expect(onValidityChange).toHaveBeenLastCalledWith(false, {
+        serverRejected: true,
+      }),
     );
   });
 
@@ -347,23 +350,3 @@ describe("AutomationScheduleEditor", () => {
   });
 });
 
-describe("AutomationScheduleSummary", () => {
-  it("uses the same sentence and paused state in presentation", () => {
-    renderWithProviders(
-      <AutomationScheduleSummary
-        schedule={{
-          frequency: "weekly",
-          weekdays: ["monday", "thursday"],
-          time: "09:00",
-          timezone: "UTC",
-        }}
-        enabled={false}
-      />,
-    );
-
-    expect(
-      screen.getByText("Every week on Monday and Thursday at 9:00 AM"),
-    ).toBeInTheDocument();
-    expect(screen.getByText("Paused")).toBeInTheDocument();
-  });
-});

--- a/frontend/src/components/automation-schedule-editor.tsx
+++ b/frontend/src/components/automation-schedule-editor.tsx
@@ -22,7 +22,6 @@ import {
   defaultRunAt,
   defaultScheduleDraft,
   formatNextRun,
-  formatScheduleSentence,
   formatWeekdays,
   intervalHasRunAt,
   scheduleDraftToAPI,
@@ -53,7 +52,18 @@ type Props = {
   onChange: (value: ScheduleDraft | null) => void;
   detectedTimezone: string;
   disabled?: boolean;
-  onValidityChange?: (valid: boolean) => void;
+  /**
+   * `valid` answers "can this be committed now?". `serverRejected` separates
+   * the two very different reasons it can be false: the preview has not
+   * settled yet (keep waiting) versus the API has refused this exact draft
+   * (never send it). A caller that autosaves on unmount needs that
+   * distinction — treating "not settled" as "refused" drops the edit, and
+   * treating "refused" as "not settled" guarantees a failed write.
+   */
+  onValidityChange?: (
+    valid: boolean,
+    detail: { serverRejected: boolean },
+  ) => void;
 };
 
 export function AutomationScheduleEditor({
@@ -102,7 +112,14 @@ export function AutomationScheduleEditor({
     (!clientError &&
       (previewTransportError || (isCurrent && preview.isSuccess)));
 
-  useEffect(() => onValidityChange?.(valid), [onValidityChange, valid]);
+  // Scoped to `isCurrent` so a verdict about a superseded draft can't be read
+  // as one about the draft on screen.
+  const serverRejected = Boolean(isCurrent && previewValidationError);
+
+  useEffect(
+    () => onValidityChange?.(valid, { serverRejected }),
+    [onValidityChange, serverRejected, valid],
+  );
 
   if (!value) {
     return (
@@ -327,30 +344,6 @@ export function AutomationScheduleEditor({
           </span>
         ) : null}
       </div>
-    </div>
-  );
-}
-
-export function AutomationScheduleSummary({
-  schedule,
-  nextRunAt,
-  enabled = true,
-}: {
-  schedule: ScheduleDraft | null;
-  nextRunAt?: string;
-  enabled?: boolean;
-}) {
-  if (!schedule) return <span>No schedule</span>;
-  return (
-    <div className="space-y-0.5">
-      <p>{formatScheduleSentence(schedule)}</p>
-      <p className="text-xs text-muted-foreground">
-        {!enabled
-          ? "Paused"
-          : nextRunAt
-            ? `Next run ${formatNextRun(nextRunAt, schedule.timezone)}`
-            : "Next run unavailable"}
-      </p>
     </div>
   );
 }

--- a/frontend/src/hooks/useAutosave.test.ts
+++ b/frontend/src/hooks/useAutosave.test.ts
@@ -253,6 +253,68 @@ describe("useAutosave", () => {
     expect(queryClient.getQueryData(queryKey)).toEqual({ data: { settings: { existing: "value" } } });
   });
 
+  it("derives the toast from the rejection when errorMessage is a function", async () => {
+    // A surface with many independently-failing writes and no Save button has
+    // nothing but this toast to say which field the server refused and why.
+    const mutationFn = vi.fn().mockRejectedValue(new Error("cron_expression is invalid"));
+    const queryKey = ["settings", "test-error-resolver"];
+    queryClient.setQueryData(queryKey, { data: { settings: { existing: "value" } } });
+
+    const { result } = renderHook(
+      () =>
+        useAutosave<{ settings: { new: string } }>({
+          queryKey,
+          mutationFn,
+          applyOptimistic,
+          errorMessage: (error) =>
+            `Couldn't save: ${(error as Error).message}`,
+          debounceMs: 0,
+        }),
+      { wrapper: makeWrapper(queryClient) },
+    );
+
+    act(() => {
+      result.current.save({ settings: { new: "x" } });
+    });
+
+    await waitFor(() =>
+      expect(toast.error).toHaveBeenCalledWith(
+        "Couldn't save: cron_expression is invalid",
+      ),
+    );
+    expect(queryClient.getQueryData(queryKey)).toEqual({ data: { settings: { existing: "value" } } });
+  });
+
+  it("still rolls back and toasts when the errorMessage resolver itself throws", async () => {
+    const mutationFn = vi.fn().mockRejectedValue(new Error("500 boom"));
+    const queryKey = ["settings", "test-error-resolver-throws"];
+    queryClient.setQueryData(queryKey, { data: { settings: { existing: "value" } } });
+
+    const { result } = renderHook(
+      () =>
+        useAutosave<{ settings: { new: string } }>({
+          queryKey,
+          mutationFn,
+          applyOptimistic,
+          errorMessage: () => {
+            throw new Error("resolver blew up");
+          },
+          debounceMs: 0,
+        }),
+      { wrapper: makeWrapper(queryClient) },
+    );
+
+    act(() => {
+      result.current.save({ settings: { new: "x" } });
+    });
+
+    await waitFor(() => expect(toast.error).toHaveBeenCalledTimes(1));
+    expect(toast.error).toHaveBeenCalledWith(
+      "Couldn't save. Your change was reverted.",
+    );
+    expect(queryClient.getQueryData(queryKey)).toEqual({ data: { settings: { existing: "value" } } });
+  });
+
   it("skips dispatch when the optimistic end state is unchanged", async () => {
     const mutationFn = vi.fn().mockResolvedValue(undefined);
     const queryKey = ["settings", "test-noop"];

--- a/frontend/src/hooks/useAutosave.ts
+++ b/frontend/src/hooks/useAutosave.ts
@@ -18,7 +18,14 @@ export interface UseAutosaveOptions<TVars> {
   applyOptimistic: (previous: unknown, vars: TVars) => unknown;
   coalesce?: (queued: TVars, incoming: TVars) => TVars;
   debounceMs?: number;
-  errorMessage?: string;
+  /**
+   * Toast copy for a failed save. Pass a function to derive it from the
+   * rejection — a surface with many independently-failing writes and no Save
+   * button has nothing but this toast to explain which field the server
+   * refused and why, so a fixed string throws away the only diagnosis the user
+   * can act on.
+   */
+  errorMessage?: string | ((error: unknown) => string);
   invalidateOnSettled?: boolean;
   onError?: (error: unknown, vars: TVars) => void;
   onSuccess?: (vars: TVars) => void;
@@ -60,7 +67,7 @@ interface QueueEntry {
   coalesce?: (queued: unknown, incoming: unknown) => unknown;
   mutationFn?: (vars: unknown) => Promise<unknown>;
   applyOptimistic?: (previous: unknown, vars: unknown) => unknown;
-  errorMessage?: string;
+  errorMessage?: string | ((error: unknown) => string);
   invalidateOnSettled: boolean;
   onError?: (error: unknown, vars: unknown) => void;
   onSuccess?: (vars: unknown) => void;
@@ -160,7 +167,7 @@ async function run(
   const previous = queryClient.getQueryData(queryKey);
   const applyOptimistic = entry.applyOptimistic!;
   const mutationFn = entry.mutationFn!;
-  const errorMessage = entry.errorMessage ?? DEFAULT_ERROR_MESSAGE;
+  const resolveErrorMessage = entry.errorMessage ?? DEFAULT_ERROR_MESSAGE;
   const invalidateOnSettled = entry.invalidateOnSettled;
   queryClient.setQueryData(queryKey, (current: unknown) => applyOptimistic(current, vars));
 
@@ -172,7 +179,18 @@ async function run(
     entry.onError?.(err, vars);
     captureError(err, { feature: "useAutosave" });
     queryClient.setQueryData(queryKey, previous);
-    toast.error(errorMessage);
+    // A resolver that itself throws must not swallow the rollback + toast, so
+    // fall back to the generic copy rather than letting it escape.
+    let message = DEFAULT_ERROR_MESSAGE;
+    try {
+      message =
+        typeof resolveErrorMessage === "function"
+          ? resolveErrorMessage(err)
+          : resolveErrorMessage;
+    } catch {
+      message = DEFAULT_ERROR_MESSAGE;
+    }
+    toast.error(message);
     emit(entry, "error", ownerIds);
   } finally {
     // NOTE: `inFlight` flips to false only after `invalidateQueries` settles.

--- a/frontend/src/hooks/useAutosaveNumericField.test.ts
+++ b/frontend/src/hooks/useAutosaveNumericField.test.ts
@@ -119,4 +119,122 @@ describe("useAutosaveNumericField", () => {
     expect(result.current.value).toBe("7");
     expect(autosave.save).not.toHaveBeenCalled();
   });
+
+  it("drops a pending edit on unmount by default", async () => {
+    const autosave = makeAutosaveStub<{ settings: { n: number } }>();
+    const { result, unmount } = renderHook(() =>
+      useAutosaveNumericField({
+        serverValue: 1,
+        autosave,
+        debounceMs: 5_000,
+        toPatch: (n) => ({ settings: { n } }),
+      }),
+    );
+
+    act(() => result.current.onChange(changeEvent("4")));
+    unmount();
+
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    expect(autosave.save).not.toHaveBeenCalled();
+  });
+
+  it("commits a pending edit on unmount when flushOnUnmount is set", () => {
+    // A numeric field inside a collapsible is unmounted without a focusout, so
+    // onBlur never runs and the debounced edit would be silently dropped.
+    const autosave = makeAutosaveStub<{ settings: { n: number } }>();
+    const { result, unmount } = renderHook(() =>
+      useAutosaveNumericField({
+        serverValue: 1,
+        autosave,
+        debounceMs: 5_000,
+        flushOnUnmount: true,
+        clamp: (raw) => Math.min(5, Math.max(0, raw)),
+        toPatch: (n) => ({ settings: { n } }),
+      }),
+    );
+
+    act(() => result.current.onChange(changeEvent("9")));
+    unmount();
+
+    expect(autosave.save).toHaveBeenCalledTimes(1);
+    // Clamped on the way out, exactly as the debounced path would have.
+    expect(autosave.save).toHaveBeenCalledWith({ settings: { n: 5 } });
+  });
+
+  it("does not flush on unmount when nothing is pending", () => {
+    const autosave = makeAutosaveStub<{ settings: { n: number } }>();
+    const { unmount } = renderHook(() =>
+      useAutosaveNumericField({
+        serverValue: 1,
+        autosave,
+        flushOnUnmount: true,
+        toPatch: (n) => ({ settings: { n } }),
+      }),
+    );
+
+    unmount();
+
+    expect(autosave.save).not.toHaveBeenCalled();
+  });
+
+  it("cancels the queued save when the box is cleared after typing", async () => {
+    // All three exits from this state have to agree. Previously the debounce
+    // timer (and therefore the unmount flush) persisted the digit the user had
+    // just deleted, while onBlur reset to the server value and saved nothing.
+    const autosave = makeAutosaveStub<{ settings: { n: number } }>();
+    const { result, unmount } = renderHook(() =>
+      useAutosaveNumericField({
+        serverValue: 1,
+        autosave,
+        debounceMs: 20,
+        flushOnUnmount: true,
+        toPatch: (n) => ({ settings: { n } }),
+      }),
+    );
+
+    act(() => result.current.onChange(changeEvent("4")));
+    act(() => result.current.onChange(changeEvent("")));
+
+    await new Promise((resolve) => setTimeout(resolve, 80));
+    expect(autosave.save).not.toHaveBeenCalled();
+
+    unmount();
+    expect(autosave.save).not.toHaveBeenCalled();
+  });
+
+  it("cancels the queued save when the box is garbled after typing", async () => {
+    const autosave = makeAutosaveStub<{ settings: { n: number } }>();
+    const { result } = renderHook(() =>
+      useAutosaveNumericField({
+        serverValue: 1,
+        autosave,
+        debounceMs: 20,
+        toPatch: (n) => ({ settings: { n } }),
+      }),
+    );
+
+    act(() => result.current.onChange(changeEvent("4")));
+    act(() => result.current.onChange(changeEvent("abc")));
+
+    await new Promise((resolve) => setTimeout(resolve, 80));
+    expect(autosave.save).not.toHaveBeenCalled();
+  });
+
+  it("does not flush on unmount after the stepper already saved the value", () => {
+    const autosave = makeAutosaveStub<{ settings: { n: number } }>();
+    const { result, unmount } = renderHook(() =>
+      useAutosaveNumericField({
+        serverValue: 1,
+        autosave,
+        debounceMs: 5_000,
+        flushOnUnmount: true,
+        toPatch: (n) => ({ settings: { n } }),
+      }),
+    );
+
+    act(() => result.current.setValueAndSave(3));
+    unmount();
+
+    expect(autosave.save).toHaveBeenCalledTimes(1);
+  });
 });

--- a/frontend/src/hooks/useAutosaveNumericField.ts
+++ b/frontend/src/hooks/useAutosaveNumericField.ts
@@ -16,6 +16,15 @@ export interface UseAutosaveNumericFieldOptions<TVars> {
    * a time and need the field-level pacing here.
    */
   debounceMs?: number;
+  /**
+   * Commit a pending (debounced but not yet dispatched) edit when the field
+   * unmounts, instead of dropping it. Opt-in for the same reason as
+   * `useDebouncedTextField`'s option of the same name: turn it on for any field
+   * that can be unmounted mid-edit — inside a popover, a collapsible, a sheet,
+   * or a tab — because removing a focused input from the DOM does NOT dispatch
+   * `focusout`, so `onBlur` never runs and the edit would be silently lost.
+   */
+  flushOnUnmount?: boolean;
 }
 
 export interface UseAutosaveNumericFieldResult {
@@ -54,6 +63,7 @@ export function useAutosaveNumericField<TVars>({
   toPatch,
   clamp,
   debounceMs = 400,
+  flushOnUnmount = false,
 }: UseAutosaveNumericFieldOptions<TVars>): UseAutosaveNumericFieldResult {
   const [trackedServer, setTrackedServer] = useState(serverValue);
   const [local, setLocal] = useState(() => String(serverValue));
@@ -61,6 +71,11 @@ export function useAutosaveNumericField<TVars>({
 
   const debounceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const pendingValueRef = useRef<number | null>(null);
+  // Mirrored into refs so the unmount cleanup, which cannot read render state,
+  // can re-check "did this already go out?" and still reach the autosave scope.
+  const lastSentRef = useRef(lastSent);
+  const flushOnUnmountRef = useRef(flushOnUnmount);
+  const saveRef = useRef(autosave.save);
 
   // Guard against the double-debounce footgun: if the outer `useAutosave` also
   // debounces, keystrokes wait out BOTH windows before hitting the network,
@@ -93,6 +108,9 @@ export function useAutosaveNumericField<TVars>({
   useEffect(() => {
     toPatchRef.current = toPatch;
     clampRef.current = clamp;
+    lastSentRef.current = lastSent;
+    flushOnUnmountRef.current = flushOnUnmount;
+    saveRef.current = autosave.save;
   });
 
   // Resync when the server value changes for reasons other than our own
@@ -113,26 +131,56 @@ export function useAutosaveNumericField<TVars>({
     }
   }
 
+  // Only an ARMED timer represents an uncommitted edit, which is also what
+  // makes this safe under StrictMode: on the dev double-invoke's simulated
+  // cleanup no user event has run yet, so there is no timer and nothing fires.
   useEffect(() => {
     return () => {
-      if (debounceTimerRef.current) {
-        clearTimeout(debounceTimerRef.current);
-        debounceTimerRef.current = null;
-      }
+      if (!debounceTimerRef.current) return;
+      clearTimeout(debounceTimerRef.current);
+      debounceTimerRef.current = null;
+      const pending = pendingValueRef.current;
+      pendingValueRef.current = null;
+      if (!flushOnUnmountRef.current || pending === null) return;
+      if (pending === lastSentRef.current) return;
+      // Deliberately no `setLastSent` here — the component is going away, and
+      // the autosave scope outlives it, so the dispatch still lands.
+      lastSentRef.current = pending;
+      saveRef.current(toPatchRef.current(pending));
     };
   }, []);
 
   const dispatch = (clamped: number) => {
+    lastSentRef.current = clamped;
     setLastSent(clamped);
     autosave.save(toPatchRef.current(clamped));
+  };
+
+  // Emptying or garbling the box CANCELS the armed save rather than leaving
+  // the last parseable value queued behind it. Without this, typing "4" and
+  // then clearing the field still persists 4 once the timer fires — and `onBlur`
+  // in that same state resets to the server value and saves nothing, so the two
+  // exits from one input state disagreed about what the user meant.
+  const cancelPending = () => {
+    if (debounceTimerRef.current) {
+      clearTimeout(debounceTimerRef.current);
+      debounceTimerRef.current = null;
+    }
+    pendingValueRef.current = null;
   };
 
   const onChange = (event: ChangeEvent<HTMLInputElement>) => {
     const raw = event.target.value;
     setLocal(raw);
-    if (raw.trim() === "") return;
+    if (raw.trim() === "") {
+      cancelPending();
+      return;
+    }
     const parsed = Number.parseInt(raw, 10);
-    if (Number.isNaN(parsed)) return;
+    if (Number.isNaN(parsed)) {
+      cancelPending();
+      return;
+    }
     const clamped = clampRef.current ? clampRef.current(parsed) : parsed;
     pendingValueRef.current = clamped;
     if (debounceTimerRef.current) clearTimeout(debounceTimerRef.current);

--- a/frontend/src/hooks/useDebouncedTextField.test.ts
+++ b/frontend/src/hooks/useDebouncedTextField.test.ts
@@ -268,6 +268,93 @@ describe("useDebouncedTextField", () => {
     expect(result.current.value).toBe("Escalate uncertain changes");
   });
 
+  it("drops a pending edit on unmount by default", async () => {
+    const onCommit: Mock<(value: string) => void> = vi.fn();
+    const { result, unmount } = renderHook(() =>
+      useDebouncedTextField({ serverValue: "", onCommit, debounceMs: 5_000 }),
+    );
+
+    act(() => result.current.onChange("typed"));
+    unmount();
+
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    expect(onCommit).not.toHaveBeenCalled();
+  });
+
+  it("commits a pending edit on unmount when flushOnUnmount is set", async () => {
+    // Removing a focused input from the DOM does not dispatch focusout, so a
+    // field inside a popover/collapsible/sheet never gets its onBlur. Without
+    // this flush the edit is lost with no error and no visible change.
+    const onCommit: Mock<(value: string) => void> = vi.fn();
+    const { result, unmount } = renderHook(() =>
+      useDebouncedTextField({
+        serverValue: "",
+        onCommit,
+        debounceMs: 5_000,
+        flushOnUnmount: true,
+      }),
+    );
+
+    act(() => result.current.onChange("typed"));
+    unmount();
+
+    expect(onCommit).toHaveBeenCalledTimes(1);
+    expect(onCommit).toHaveBeenCalledWith("typed");
+  });
+
+  it("does not flush on unmount when nothing is pending", () => {
+    // Also what keeps StrictMode's simulated cleanup inert: no user event has
+    // run, so no timer is armed and there is nothing to send.
+    const onCommit: Mock<(value: string) => void> = vi.fn();
+    const { unmount } = renderHook(() =>
+      useDebouncedTextField({
+        serverValue: "saved",
+        onCommit,
+        flushOnUnmount: true,
+      }),
+    );
+
+    unmount();
+
+    expect(onCommit).not.toHaveBeenCalled();
+  });
+
+  it("does not flush a rejected value on unmount", () => {
+    const onCommit: Mock<(value: string) => void> = vi.fn();
+    const { result, unmount } = renderHook(() =>
+      useDebouncedTextField({
+        serverValue: "saved",
+        onCommit,
+        debounceMs: 5_000,
+        flushOnUnmount: true,
+        rejectValue: (value) => value.trim() === "",
+      }),
+    );
+
+    act(() => result.current.onChange("   "));
+    unmount();
+
+    expect(onCommit).not.toHaveBeenCalled();
+  });
+
+  it("does not flush an already-committed value on unmount", async () => {
+    const onCommit: Mock<(value: string) => void> = vi.fn();
+    const { result, unmount } = renderHook(() =>
+      useDebouncedTextField({
+        serverValue: "",
+        onCommit,
+        debounceMs: 20,
+        flushOnUnmount: true,
+      }),
+    );
+
+    act(() => result.current.onChange("typed"));
+    await waitFor(() => expect(onCommit).toHaveBeenCalledTimes(1));
+    unmount();
+
+    expect(onCommit).toHaveBeenCalledTimes(1);
+  });
+
   it("replaces local text immediately and cancels a pending commit", async () => {
     const onCommit: Mock<(value: string) => void> = vi.fn();
     const { result } = renderHook(() => useDebouncedTextField({ serverValue: "repository", onCommit, debounceMs: 30 }));

--- a/frontend/src/hooks/useDebouncedTextField.ts
+++ b/frontend/src/hooks/useDebouncedTextField.ts
@@ -21,6 +21,17 @@ export interface UseDebouncedTextFieldOptions {
    * visible with its own error affordance (e.g. an over-length editor).
    */
   rejectValue?: (value: string) => boolean;
+  /**
+   * Commit a pending (debounced but not yet dispatched) edit when the field
+   * unmounts, instead of dropping it. Opt-in rather than the default because
+   * most callers live in always-mounted forms where it can never fire; turn it
+   * on for any field that can be unmounted mid-edit — inside a popover, a
+   * collapsible, a sheet, or a tab — since removing a focused input from the
+   * DOM does NOT dispatch `focusout`, so `onBlur` never runs and the edit would
+   * be lost with no error and no visible change. Mirrors the unmount flush
+   * `useAutosave` already performs for its own debounce window.
+   */
+  flushOnUnmount?: boolean;
   preserveLocalOnServerChange?: boolean;
   /**
    * Optional semantic equality check for fields whose server canonicalizes
@@ -66,6 +77,7 @@ export function useDebouncedTextField({
   onCommit,
   debounceMs = 400,
   rejectValue,
+  flushOnUnmount = false,
   preserveLocalOnServerChange = false,
   valuesEqual = Object.is,
 }: UseDebouncedTextFieldOptions): UseDebouncedTextFieldResult {
@@ -73,6 +85,12 @@ export function useDebouncedTextField({
   const [local, setLocal] = useState(serverValue);
   const [lastSent, setLastSent] = useState(serverValue);
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // The value the armed timer will commit. Held in a ref so the unmount
+  // cleanup — which cannot read render state — knows what is outstanding.
+  const pendingValueRef = useRef<string | null>(null);
+  // `lastSent` mirrored into a ref for the same reason: the cleanup has to
+  // re-check "did this already go out?" without a render closure.
+  const lastSentRef = useRef(lastSent);
 
   // Hold `onCommit` in a ref so the debounce timer reads the latest
   // closure at fire time. Without this, a timer armed during render N
@@ -83,10 +101,13 @@ export function useDebouncedTextField({
   const onCommitRef = useRef(onCommit);
   const rejectValueRef = useRef(rejectValue);
   const valuesEqualRef = useRef(valuesEqual);
+  const flushOnUnmountRef = useRef(flushOnUnmount);
   useEffect(() => {
     onCommitRef.current = onCommit;
     rejectValueRef.current = rejectValue;
     valuesEqualRef.current = valuesEqual;
+    flushOnUnmountRef.current = flushOnUnmount;
+    lastSentRef.current = lastSent;
   });
 
   // Resync when the server value changes for reasons other than our own
@@ -107,9 +128,24 @@ export function useDebouncedTextField({
     }
   }
 
+  // Only an ARMED timer represents an uncommitted edit, which is also what
+  // makes this safe under StrictMode: on the dev double-invoke's simulated
+  // cleanup no user event has run yet, so there is no timer and nothing fires.
   useEffect(() => {
     return () => {
-      if (debounceRef.current) clearTimeout(debounceRef.current);
+      if (!debounceRef.current) return;
+      clearTimeout(debounceRef.current);
+      debounceRef.current = null;
+      const pending = pendingValueRef.current;
+      pendingValueRef.current = null;
+      if (!flushOnUnmountRef.current || pending === null) return;
+      // Deliberately no `setLastSent` here — the component is going away, and
+      // the same guards `commit` applies still decide whether this is worth
+      // sending.
+      if (valuesEqualRef.current(pending, lastSentRef.current)) return;
+      if (rejectValueRef.current?.(pending)) return;
+      lastSentRef.current = pending;
+      onCommitRef.current(pending);
     };
   }, []);
 
@@ -118,6 +154,7 @@ export function useDebouncedTextField({
     // A rejected value is never sent and never recorded as `lastSent`, so it
     // can't poison the resync baseline or be mistaken for a saved value.
     if (rejectValueRef.current?.(value)) return;
+    lastSentRef.current = value;
     setLastSent(value);
     onCommitRef.current(value);
   };
@@ -125,8 +162,10 @@ export function useDebouncedTextField({
   const onChange = (next: string) => {
     setLocal(next);
     if (debounceRef.current) clearTimeout(debounceRef.current);
+    pendingValueRef.current = next;
     debounceRef.current = setTimeout(() => {
       debounceRef.current = null;
+      pendingValueRef.current = null;
       commit(next);
     }, debounceMs);
   };
@@ -136,6 +175,7 @@ export function useDebouncedTextField({
       clearTimeout(debounceRef.current);
       debounceRef.current = null;
     }
+    pendingValueRef.current = null;
     // Revert an invalid value on blur so a required field can't be left in a
     // dropped/blank state with the stale server value silently still in effect.
     if (rejectValueRef.current?.(local)) {
@@ -150,7 +190,9 @@ export function useDebouncedTextField({
       clearTimeout(debounceRef.current);
       debounceRef.current = null;
     }
+    pendingValueRef.current = null;
     setLocal(next);
+    lastSentRef.current = next;
     setLastSent(next);
   };
 


### PR DESCRIPTION
## Summary

The automation detail page currently forces a modal-style “Edit” workflow that’s easy to get out of sync and can block previewing unrelated fields. This change redesigns the UX to use Linear-style inline editing for everyday properties, with autosave hooks that keep fields responsive and introduce an explicit confirm flow for schedule-related updates so the UI can’t get stuck mid-edit.

## Changes

- Updated the automation detail page to remove the global “Edit” mode for common fields; key properties (e.g., model, base branch, triggers) are now live controls on initial render.
- Redesigned schedule/triggers as a compound popover control anchored to the “Triggers” property; tests now assert the “Automation settings” dialog and “Edit” button are not shown.
- Extended autosave behavior to treat transport failures as “valid” for the purpose of preventing dead previews from wedging other controls; added/updated tests and toast mocking accordingly.
- Refactored autosave hooks (text, numeric, debounced) and schedule editor tests to align with the new save/confirm UX contract.

## Validation

- Frontend test updates/coverage: `frontend/src/app/(dashboard)/automations/[id]/page.test.tsx`
- Hook unit tests: `frontend/src/hooks/useAutosave*.test.ts`, `frontend/src/hooks/useDebouncedTextField.test.ts`
- Component tests: `frontend/src/components/automation-schedule-editor.test.tsx`

[143.dev](https://143.dev) | [session 2e3162ea](https://143.dev/sessions/2e3162ea-4b04-4a66-9bcf-fba014c6c7ca)

<!-- 143 readiness -->
**143 readiness:** not available for this revision.

<!-- 143-publication session=2e3162ea-4b04-4a66-9bcf-fba014c6c7ca changeset=16de102d-b0c5-401a-97f8-fc8947b1d2eb -->

Preview: https://143.dev/previews/github/assembledhq/143/pull/1980?launch=1