### PR TITLE
Sync Code Reviews Analytics with Reviews filters and sortable backend-sorted tables

### DIFF
--- a/frontend/src/app/(dashboard)/code-reviews/page.test.tsx
+++ b/frontend/src/app/(dashboard)/code-reviews/page.test.tsx
@@ -468,9 +468,9 @@ describe("CodeReviewsPage", () => {
     expect(within(stats).getByText("Automatically approved")).toBeInTheDocument();
     expect(within(stats).getByText("92")).toBeInTheDocument();
     expect(within(stats).getByText("72% of completed reviews")).toBeInTheDocument();
-    expect(within(stats).getByText("Needs human review")).toBeInTheDocument();
-    expect(within(stats).getByText("21")).toBeInTheDocument();
-    expect(within(stats).getByText("16% of completed reviews")).toBeInTheDocument();
+    expect(within(stats).getByText("Approval rate")).toBeInTheDocument();
+    expect(within(stats).getByText("72%")).toBeInTheDocument();
+    expect(within(stats).getByText("21 need human review")).toBeInTheDocument();
     expect(within(stats).getByText("Median turnaround")).toBeInTheDocument();
     expect(within(stats).getByText("8m")).toBeInTheDocument();
     const timeWindow = screen.getByRole("combobox", { name: "Time window" });
@@ -624,6 +624,16 @@ describe("CodeReviewsPage", () => {
     await user.click(await screen.findByRole("tab", { name: "Analytics" }));
 
     expect(await screen.findByText("Usage by PR author")).toBeInTheDocument();
+    // The headline cards have to come from the same report as the tables below
+    // them. The stats endpoint answers a different question (current activity
+    // only, ignoring the status filter) and reports 128/92 for this fixture.
+    expect(screen.queryByRole("region", { name: "Code review statistics" })).not.toBeInTheDocument();
+    const approvalOutcomes = screen.getByLabelText("Approval outcomes");
+    expect(within(approvalOutcomes).getByText("28")).toBeInTheDocument();
+    expect(within(approvalOutcomes).getByText("32 total attempts")).toBeInTheDocument();
+    expect(within(approvalOutcomes).getByText("17")).toBeInTheDocument();
+    expect(within(approvalOutcomes).getByText("11")).toBeInTheDocument();
+    expect(within(approvalOutcomes).queryByText("128")).not.toBeInTheDocument();
     expect(screen.getByText("PR size and policy fit")).toBeInTheDocument();
     expect(screen.getByText("Why reviews were not approved")).toBeInTheDocument();
     expect(screen.getByText("Review findings")).toBeInTheDocument();
@@ -650,6 +660,9 @@ describe("CodeReviewsPage", () => {
     await waitFor(() => expect(analyticsRequests).toHaveLength(1));
     expectCreatedAfterDaysAgo(analyticsRequests[0]?.get("created_after") ?? undefined, 30);
     expect(analyticsRequests[0]?.has("repository_id")).toBe(false);
+    await user.click(within(authorTable).getByRole("button", { name: "Sort by PR author ascending" }));
+    await waitFor(() => expect(analyticsRequests.at(-1)?.get("author_sort_by")).toBe("author"));
+    expect(analyticsRequests.at(-1)?.get("author_sort_order")).toBe("asc");
   });
 
   it("shows failed and stale attempts when no review completed", async () => {
@@ -734,6 +747,16 @@ describe("CodeReviewsPage", () => {
       expect(listRequests.at(-1)?.get("activity_status")).toBe("current");
       expect(statsRequests.at(-1)?.get("activity_status")).toBe("current");
     });
+    await user.click(screen.getByRole("button", { name: "Sort by Repo ascending" }));
+    await waitFor(() => expect(listRequests.at(-1)?.get("sort_by")).toBe("repository"));
+    expect(listRequests.at(-1)?.get("sort_order")).toBe("asc");
+    await user.click(screen.getByRole("button", { name: "Sort by Repo descending" }));
+    await waitFor(() => expect(listRequests.at(-1)?.get("sort_order")).toBe("desc"));
+    // A third click has to reach the default newest-first order again;
+    // otherwise the two-state cycle strands the user in an explicit sort.
+    await user.click(screen.getByRole("button", { name: "Stop sorting by Repo" }));
+    await waitFor(() => expect(listRequests.at(-1)?.has("sort_by")).toBe(false));
+    expect(listRequests.at(-1)?.has("sort_order")).toBe(false);
     const initialListCreatedAfter = listRequests.at(-1)?.get("created_after");
     const initialStatsCreatedAfter = statsRequests.at(-1)?.get("created_after");
 

--- a/frontend/src/app/(dashboard)/code-reviews/page.tsx
+++ b/frontend/src/app/(dashboard)/code-reviews/page.tsx
@@ -17,7 +17,6 @@ import {
   PowerOff,
   RefreshCw,
   Settings2,
-  SlidersHorizontal,
   Trash2,
   Users,
 } from "lucide-react";
@@ -35,7 +34,6 @@ import { ExternalLink } from "@/components/ui/external-link";
 import { DisabledTooltip } from "@/components/ui/disabled-tooltip";
 import { ErrorNotice } from "@/components/ui/error-notice";
 import { Badge } from "@/components/ui/badge";
-import { Card, CardContent } from "@/components/ui/card";
 import { Select, SelectContent, SelectGroup, SelectItem, SelectLabel, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
@@ -66,6 +64,17 @@ import { useAuth } from "@/hooks/use-auth";
 import { AutosaveIndicator } from "@/components/AutosaveIndicator";
 import { AuditLogTrigger } from "@/components/audit/audit-log-trigger";
 import { CodeReviewAnalyticsReport } from "@/components/code-review-analytics";
+import { SortableTableHeader } from "@/components/sortable-table-header";
+import {
+  ALL_OUTCOMES,
+  ALL_REPOSITORIES,
+  ALL_RISKS,
+  AUTOMATICALLY_APPROVED,
+  COMPLETED_NOT_APPROVED,
+  CodeReviewFilters,
+  CodeReviewSummaryCards,
+  type CodeReviewFilterValues,
+} from "@/components/code-review-overview";
 import { applyCodeReviewPolicyOptimistic, coalesceCodeReviewPolicy } from "@/lib/code-review-autosave";
 import { getCodingAgentReasoningOptions } from "@/lib/coding-agent-reasoning";
 import { AGENTS_BY_KEY, availableAgentModelGroups, modelOptionLabel, pmUsableResolvedCredentials, type AgentModelGroup } from "@/lib/agents";
@@ -87,27 +96,25 @@ import type {
   CodeReviewAutomatedApprovalExampleOption,
   CodeReviewResolvedPolicy,
   CodeReviewSessionStatus,
-  CodeReviewStats,
   ListResponse,
   OrgSettings,
   SingleResponse,
 } from "@/lib/types";
 
-const ALL_REPOSITORIES = "all";
-const ALL_OUTCOMES = "all";
-const ALL_RISKS = "all";
 type CodeReviewTab = "reviews" | "analytics" | "policy";
 const TIME_RANGE_FILTER_VALUES = ["7d", "30d", "90d", "all"] as const;
 type TimeRangeFilter = (typeof TIME_RANGE_FILTER_VALUES)[number];
 const DEFAULT_TIME_RANGE = "30d" satisfies TimeRangeFilter;
-const AUTOMATICALLY_APPROVED = "automatically_approved" satisfies CodeReviewListOutcome;
-const COMPLETED_NOT_APPROVED = "completed_not_approved" satisfies CodeReviewListOutcome;
 const OUTCOME_FILTER_VALUES = [ALL_OUTCOMES, AUTOMATICALLY_APPROVED, COMPLETED_NOT_APPROVED, "needs_human_review", "comment_only", "blocked"] as const;
 type OutcomeFilter = (typeof OUTCOME_FILTER_VALUES)[number];
 const RISK_FILTER_VALUES = [ALL_RISKS, "acceptable", "needs_review"] as const;
 const STATUS_FILTER_VALUES = ["current", "completed", "in_progress", "failed", "cancelled", "superseded", "all"] as const;
 type StatusFilter = (typeof STATUS_FILTER_VALUES)[number];
 const DEFAULT_STATUS_FILTER = "current" satisfies StatusFilter;
+const REVIEW_SORT_VALUES = ["pull_request", "outcome", "risk", "run_status", "repository", "completed"] as const;
+type ReviewSort = (typeof REVIEW_SORT_VALUES)[number];
+const AUTHOR_SORT_VALUES = ["author", "reviews", "approved", "not_approved", "approval_rate", "split_sample", "average_additions", "median_additions", "average_deletions", "median_deletions"] as const;
+type AuthorSort = (typeof AUTHOR_SORT_VALUES)[number];
 const STATUS_FILTER_PARSER = createParser<StatusFilter>({
   parse: (value) => {
     if ((STATUS_FILTER_VALUES as readonly string[]).includes(value)) return value as StatusFilter;
@@ -195,21 +202,6 @@ function createdAfterForTimeRange(range: TimeRangeFilter, anchor: Date): string 
   if (range === "all") return undefined;
   const days = Number.parseInt(range, 10);
   return new Date(anchor.getTime() - days * 24 * 60 * 60 * 1000).toISOString();
-}
-
-function formatReviewTurnaround(seconds: number | null): string {
-  if (seconds === null || !Number.isFinite(seconds)) return "—";
-  if (seconds < 60) return `${Math.round(seconds)}s`;
-  const minutes = Math.round(seconds / 60);
-  if (minutes < 60) return `${minutes}m`;
-  const hours = Math.floor(minutes / 60);
-  const remainingMinutes = minutes % 60;
-  return remainingMinutes === 0 ? `${hours}h` : `${hours}h ${remainingMinutes}m`;
-}
-
-function percentageContext(value: number, total: number): string {
-  if (total === 0) return "No completed reviews";
-  return `${Math.round((value / total) * 100)}% of completed reviews`;
 }
 
 function trackCodeReviewPolicyEvent(event: CodeReviewPolicyAnalyticsEvent): void {
@@ -479,81 +471,6 @@ function normalizeOrchestratorReasoningEffort(config: CodeReviewPolicyConfig): v
   );
 }
 
-function CodeReviewStatsCards({
-  stats,
-  isLoading,
-  isError,
-  onRetry,
-}: {
-  stats?: CodeReviewStats;
-  isLoading: boolean;
-  isError: boolean;
-  onRetry: () => void;
-}) {
-  const unavailableContext = isError ? "Metrics unavailable" : "Loading selected time window";
-  const cards = stats
-    ? [
-        {
-          label: "Reviews completed",
-          value: stats.reviews_completed.toLocaleString(),
-          context: "In selected time window",
-        },
-        {
-          label: "Automatically approved",
-          value: stats.automatically_approved.toLocaleString(),
-          context: percentageContext(stats.automatically_approved, stats.reviews_completed),
-        },
-        {
-          label: "Needs human review",
-          value: stats.needs_human_review.toLocaleString(),
-          context: percentageContext(stats.needs_human_review, stats.reviews_completed),
-        },
-        {
-          label: "Median turnaround",
-          value: formatReviewTurnaround(stats.median_turnaround_seconds),
-          context: "Queued to completed",
-        },
-      ]
-    : [
-        { label: "Reviews completed", value: "—", context: unavailableContext },
-        { label: "Automatically approved", value: "—", context: unavailableContext },
-        { label: "Needs human review", value: "—", context: unavailableContext },
-        { label: "Median turnaround", value: "—", context: unavailableContext },
-      ];
-
-  return (
-    <div
-      className="space-y-3"
-      role="region"
-      aria-label="Code review statistics"
-      aria-busy={isLoading}
-    >
-      {isError ? (
-        <ErrorNotice
-          title={stats ? "Metrics may be out of date" : "Metrics unavailable"}
-          description={
-            stats
-              ? "Showing the last successful result because the latest refresh failed."
-              : "The selected review metrics could not be loaded."
-          }
-          action={{ label: "Retry", onClick: onRetry }}
-        />
-      ) : null}
-      <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
-        {cards.map((card) => (
-          <Card key={card.label}>
-            <CardContent className="space-y-1.5">
-              <p className="text-xs font-medium text-muted-foreground">{card.label}</p>
-              <p className="text-2xl font-semibold tabular-nums text-foreground">{card.value}</p>
-              <p className="text-xs text-muted-foreground">{card.context}</p>
-            </CardContent>
-          </Card>
-        ))}
-      </div>
-    </div>
-  );
-}
-
 export default function CodeReviewsPage() {
   const queryClient = useQueryClient();
   const { user } = useAuth();
@@ -582,6 +499,10 @@ export default function CodeReviewsPage() {
     STATUS_FILTER_PARSER,
   );
   const [searchParam, setSearchParam] = useQueryState("search", parseAsString.withDefault(""));
+  const [reviewSort, setReviewSort] = useQueryState("sort", parseAsStringLiteral(REVIEW_SORT_VALUES));
+  const [reviewSortOrder, setReviewSortOrder] = useQueryState("order", parseAsStringLiteral(["asc", "desc"] as const).withDefault("asc"));
+  const [authorSort, setAuthorSort] = useQueryState("author_sort", parseAsStringLiteral(AUTHOR_SORT_VALUES).withDefault("reviews"));
+  const [authorSortOrder, setAuthorSortOrder] = useQueryState("author_order", parseAsStringLiteral(["asc", "desc"] as const).withDefault("desc"));
   const [search, setSearch] = useState(searchParam);
   useEffect(() => {
     setSearch(searchParam);
@@ -632,7 +553,9 @@ export default function CodeReviewsPage() {
     }),
     [outcomeFilter, reviewRepositoryId, riskFilter, searchParam],
   );
-  const listReviewFilters = useMemo(
+  // Which review attempts are in scope. The analytics report answers questions
+  // about the same set, so it shares this; the ordering below is list-only.
+  const scopedReviewFilters = useMemo(
     () => statusFilter === "cancelled"
       ? {
           ...baseReviewFilters,
@@ -644,6 +567,14 @@ export default function CodeReviewsPage() {
           activity_status: statusFilter as CodeReviewActivityStatus,
         },
     [baseReviewFilters, statusFilter],
+  );
+  const listReviewFilters = useMemo(
+    () => ({
+      ...scopedReviewFilters,
+      sort_by: reviewSort ?? undefined,
+      sort_order: reviewSort ? reviewSortOrder : undefined,
+    }),
+    [reviewSort, reviewSortOrder, scopedReviewFilters],
   );
   const statsReviewFilters = useMemo(
     () => ({
@@ -659,12 +590,16 @@ export default function CodeReviewsPage() {
     }),
     [listReviewFilters, timeRangeFilter],
   );
+  // Keyed on the scope it actually sends: including the list sort would mint a
+  // fresh cache entry for an identical request every time the table is re-sorted.
   const analyticsScopeQueryKey = useMemo(
     () => ({
-      repository_id: reviewRepositoryId,
+      ...scopedReviewFilters,
       time_range: timeRangeFilter,
+      author_sort_by: authorSort,
+      author_sort_order: authorSortOrder,
     }),
-    [reviewRepositoryId, timeRangeFilter],
+    [authorSort, authorSortOrder, scopedReviewFilters, timeRangeFilter],
   );
   const statsScopeQueryKey = useMemo(
     () => ({
@@ -695,13 +630,15 @@ export default function CodeReviewsPage() {
   );
   const currentAnalyticsFilters = useCallback(
     () => ({
-      repository_id: reviewRepositoryId,
+      ...scopedReviewFilters,
+      author_sort_by: authorSort,
+      author_sort_order: authorSortOrder,
       created_after: createdAfterForTimeRange(
         timeRangeFilter,
         new Date(timeRangeAnchorMsRef.current),
       ),
     }),
-    [reviewRepositoryId, timeRangeFilter],
+    [authorSort, authorSortOrder, scopedReviewFilters, timeRangeFilter],
   );
   const reviewFiltersQueryKey = useMemo(
     () => ({
@@ -1093,11 +1030,28 @@ export default function CodeReviewsPage() {
       next.description_policy.requirements[index] = updater(next.description_policy.requirements[index]);
     });
   };
+  const sortHeader = (label: string, sort: ReviewSort) => {
+    const active = reviewSort === sort;
+    return (
+      <SortableTableHeader
+        label={label}
+        direction={active ? reviewSortOrder : false}
+        // The list has a default order (newest first), so the third click on a
+        // column returns to it rather than cycling back to ascending.
+        allowUnsorted
+        onSort={(nextOrder) => {
+          void setReviewSort(nextOrder === false ? null : sort);
+          void setReviewSortOrder(nextOrder === false ? null : nextOrder);
+        }}
+      />
+    );
+  };
 
   const reviewColumns: ResponsiveResourceListColumn<CodeReviewListItem>[] = [
     {
       id: "pull-request",
-      header: "PR",
+      header: sortHeader("PR", "pull_request"),
+      sortDirection: reviewSort === "pull_request" ? reviewSortOrder : false,
       cellClassName: "min-w-[18rem]",
       render: (review) => (
         <>
@@ -1112,14 +1066,16 @@ export default function CodeReviewsPage() {
     },
     {
       id: "outcome",
-      header: "Outcome",
+      header: sortHeader("Outcome", "outcome"),
+      sortDirection: reviewSort === "outcome" ? reviewSortOrder : false,
       render: (review) => (
         <StatusLabel label={decisionLabel(review)} tone={reviewDecisionTone(review)} indicator={false} />
       ),
     },
     {
       id: "risk",
-      header: "Risk",
+      header: sortHeader("Risk", "risk"),
+      sortDirection: reviewSort === "risk" ? reviewSortOrder : false,
       render: (review) => (
         <StatusLabel
           label={reviewRiskLabel(review)}
@@ -1130,17 +1086,20 @@ export default function CodeReviewsPage() {
     },
     {
       id: "run-status",
-      header: "Run status",
+      header: sortHeader("Run status", "run_status"),
+      sortDirection: reviewSort === "run_status" ? reviewSortOrder : false,
       render: (review) => <ReviewOperationalStatus review={review} nowMs={countdownNowMs} />,
     },
     {
       id: "repository",
-      header: "Repo",
+      header: sortHeader("Repo", "repository"),
+      sortDirection: reviewSort === "repository" ? reviewSortOrder : false,
       render: (review) => review.repository_name || review.github_repo,
     },
     {
       id: "completed",
-      header: "Completed",
+      header: sortHeader("Completed", "completed"),
+      sortDirection: reviewSort === "completed" ? reviewSortOrder : false,
       render: (review) => formatDate(review.completed_at),
     },
     {
@@ -1162,6 +1121,36 @@ export default function CodeReviewsPage() {
       ),
     },
   ];
+  const sharedFilterValues: CodeReviewFilterValues = {
+    repository: repositoryFilter,
+    outcome: outcomeFilter,
+    risk: riskFilter,
+    status: statusFilter,
+    search,
+    timeRange: timeRangeFilter,
+  };
+  const changeSharedFilter = (field: keyof CodeReviewFilterValues, value: string) => {
+    switch (field) {
+      case "repository":
+        void setRepositoryFilter(value === ALL_REPOSITORIES ? null : value);
+        break;
+      case "outcome":
+        setOutcomeFilter(value);
+        break;
+      case "risk":
+        void setRiskFilter(value === ALL_RISKS ? null : value as (typeof RISK_FILTER_VALUES)[number]);
+        break;
+      case "status":
+        void setStatusFilter(value === DEFAULT_STATUS_FILTER ? null : value as StatusFilter);
+        break;
+      case "search":
+        setSearch(value);
+        break;
+      case "timeRange":
+        setTimeRangeFilter(value);
+        break;
+    }
+  };
 
   return (
     <ListPage
@@ -1185,76 +1174,13 @@ export default function CodeReviewsPage() {
         </TabsList>
 
         <TabsContent value="reviews" className="space-y-3">
-            <CodeReviewStatsCards
+            <CodeReviewSummaryCards
               stats={statsQuery.data?.data}
               isLoading={statsQuery.isLoading}
               isError={statsQuery.isError}
               onRetry={() => void statsQuery.refetch()}
             />
-            <Button
-              type="button"
-              variant="outline"
-              size="sm"
-              className="w-full justify-between md:hidden"
-              aria-expanded={mobileFiltersOpen}
-              aria-controls="code-review-filters"
-              onClick={() => setMobileFiltersOpen((open) => !open)}
-            >
-              <span className="flex items-center gap-2">
-                <SlidersHorizontal className="h-4 w-4" />
-                Filter reviews
-              </span>
-              <ChevronDown className={`h-4 w-4 transition-transform ${mobileFiltersOpen ? "rotate-180" : ""}`} />
-            </Button>
-            <div
-              id="code-review-filters"
-              className={`${mobileFiltersOpen ? "grid" : "hidden"} gap-3 rounded-xl border border-border bg-card p-3 shadow-sm md:grid md:grid-cols-2 md:rounded-none md:border-0 md:bg-transparent md:p-0 md:shadow-none lg:grid-cols-3 xl:grid-cols-[minmax(12rem,18rem)_repeat(3,minmax(9rem,11rem))_minmax(12rem,1fr)_minmax(9rem,11rem)]`}
-            >
-              <FilterSelect label="Repository" value={repositoryFilter} onValueChange={(value) => void setRepositoryFilter(value === ALL_REPOSITORIES ? null : value)}>
-                <SelectItem value={ALL_REPOSITORIES}>All repositories</SelectItem>
-                {repositories.map((repo) => (
-                  <SelectItem key={repo.id} value={repo.id}>
-                    {repo.full_name}
-                  </SelectItem>
-                ))}
-              </FilterSelect>
-              <FilterSelect label="Outcome" value={outcomeFilter} onValueChange={setOutcomeFilter}>
-                <SelectItem value={ALL_OUTCOMES}>All outcomes</SelectItem>
-                <SelectItem value={AUTOMATICALLY_APPROVED}>Automatically approved</SelectItem>
-                <SelectItem value={COMPLETED_NOT_APPROVED}>Ran successfully — not approved</SelectItem>
-                <SelectItem value="needs_human_review">Needs human review</SelectItem>
-                <SelectItem value="comment_only">Comment-only decision</SelectItem>
-                <SelectItem value="blocked">Blocked</SelectItem>
-              </FilterSelect>
-              <FilterSelect label="Risk" value={riskFilter} onValueChange={(value) => void setRiskFilter(value === ALL_RISKS ? null : value as (typeof RISK_FILTER_VALUES)[number])}>
-                <SelectItem value={ALL_RISKS}>All risk</SelectItem>
-                <SelectItem value="acceptable">Acceptable</SelectItem>
-                <SelectItem value="needs_review">Needs review</SelectItem>
-              </FilterSelect>
-              <FilterSelect label="Status" value={statusFilter} onValueChange={(value) => void setStatusFilter(value === DEFAULT_STATUS_FILTER ? null : value as StatusFilter)}>
-                <SelectItem value="current">Current reviews</SelectItem>
-                <SelectItem value="completed">Completed</SelectItem>
-                <SelectItem value="in_progress">In progress</SelectItem>
-                <SelectItem value="failed">Failed</SelectItem>
-                <SelectItem value="cancelled">Cancelled</SelectItem>
-                <SelectItem value="superseded">Superseded history</SelectItem>
-                <SelectItem value="all">All attempts</SelectItem>
-              </FilterSelect>
-              <div className="flex flex-col gap-2">
-                <Label className="text-xs text-muted-foreground">Search</Label>
-                <Input value={search} onChange={(event) => setSearch(event.target.value)} placeholder="PR, repo, or title" aria-label="Search code reviews" />
-              </div>
-              <FilterSelect
-                label="Time window"
-                value={timeRangeFilter}
-                onValueChange={setTimeRangeFilter}
-              >
-                <SelectItem value="7d">Last 7 days</SelectItem>
-                <SelectItem value="30d">Last 30 days</SelectItem>
-                <SelectItem value="90d">Last 90 days</SelectItem>
-                <SelectItem value="all">All time</SelectItem>
-              </FilterSelect>
-            </div>
+            <CodeReviewFilters id="code-review-filters" values={sharedFilterValues} repositories={repositories} mobileOpen={mobileFiltersOpen} onMobileOpenChange={setMobileFiltersOpen} onChange={changeSharedFilter} />
             <SectionGroup
               title="Review activity"
               description="Pull requests reviewed by the team policy and their current outcome."
@@ -1397,31 +1323,18 @@ export default function CodeReviewsPage() {
           </TabsContent>
 
           <TabsContent value="analytics" className="space-y-4">
-            <div className="grid gap-3 sm:grid-cols-2 sm:justify-end lg:ml-auto lg:max-w-md">
-              <FilterSelect
-                label="Repository"
-                value={repositoryFilter}
-                onValueChange={(value) => void setRepositoryFilter(value === ALL_REPOSITORIES ? null : value)}
-              >
-                <SelectItem value={ALL_REPOSITORIES}>All repositories</SelectItem>
-                {repositories.map((repo) => (
-                  <SelectItem key={repo.id} value={repo.id}>
-                    {repo.full_name}
-                  </SelectItem>
-                ))}
-              </FilterSelect>
-              <FilterSelect label="Time window" value={timeRangeFilter} onValueChange={setTimeRangeFilter}>
-                <SelectItem value="7d">Last 7 days</SelectItem>
-                <SelectItem value="30d">Last 30 days</SelectItem>
-                <SelectItem value="90d">Last 90 days</SelectItem>
-                <SelectItem value="all">All time</SelectItem>
-              </FilterSelect>
-            </div>
+            <CodeReviewFilters id="code-review-analytics-filters" values={sharedFilterValues} repositories={repositories} mobileOpen={mobileFiltersOpen} onMobileOpenChange={setMobileFiltersOpen} onChange={changeSharedFilter} />
             <CodeReviewAnalyticsReport
               analytics={analyticsQuery.data?.data}
               isLoading={analyticsQuery.isLoading}
               isError={analyticsQuery.isError}
               onRetry={() => void analyticsQuery.refetch()}
+              authorSort={authorSort}
+              authorSortOrder={authorSortOrder}
+              onAuthorSort={(sort: AuthorSort, order) => {
+                void setAuthorSort(sort);
+                void setAuthorSortOrder(order);
+              }}
             />
           </TabsContent>
 

--- a/frontend/src/app/(dashboard)/sessions/sessions-page-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/sessions-page-content.tsx
@@ -9,7 +9,7 @@ import {
   type ColumnDef,
   type SortingState,
 } from "@tanstack/react-table";
-import { ArrowUpDown, CalendarClock, Plus } from "lucide-react";
+import { CalendarClock, Plus } from "lucide-react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
@@ -30,6 +30,7 @@ import { api } from "@/lib/api";
 import { queryKeys } from "@/lib/query-keys";
 import { formatTimeAgo, sessionTitle } from "@/lib/utils";
 import { StatusDot } from "@/components/status-dot";
+import { SortableTableHeader, sortDirectionAriaValue } from "@/components/sortable-table-header";
 import { AnimatedEllipsis } from "@/components/animated-ellipsis";
 import { AgentBadge } from "@/components/agent-badge";
 import { usePeopleFilter } from "@/hooks/use-people-filter";
@@ -63,15 +64,8 @@ function SessionStatusDot({ displayStatus }: { displayStatus: SessionDisplayStat
 }
 
 function SortableHeader({ label, column }: { label: string; column: { toggleSorting: (desc?: boolean) => void; getIsSorted: () => false | "asc" | "desc" } }) {
-  return (
-    <button
-      className="flex items-center gap-1 hover:text-foreground transition-colors -ml-1 px-1 py-0.5 rounded"
-      onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}
-    >
-      {label}
-      <ArrowUpDown className="h-3 w-3 opacity-50" />
-    </button>
-  );
+  const direction = column.getIsSorted();
+  return <SortableTableHeader label={label} direction={direction} onSort={(next) => column.toggleSorting(next === "desc")} />;
 }
 
 // ---------------------------------------------------------------------------
@@ -426,6 +420,7 @@ export function SessionsPageContent() {
                         <TableHead
                           key={header.id}
                           className="uppercase"
+                          aria-sort={header.column.getCanSort() ? sortDirectionAriaValue(header.column.getIsSorted()) : undefined}
                           style={{ width: header.column.getSize() !== 150 ? header.column.getSize() : undefined }}
                         >
                           {header.isPlaceholder

--- a/frontend/src/components/code-review-analytics.tsx
+++ b/frontend/src/components/code-review-analytics.tsx
@@ -4,6 +4,7 @@ import { ChartNoAxesColumnIncreasing } from "lucide-react";
 import { EmptyState } from "@/components/empty-state";
 import { SectionGroup } from "@/components/section-group";
 import { Badge } from "@/components/ui/badge";
+import { SortableTableHeader, sortDirectionAriaValue } from "@/components/sortable-table-header";
 import { Card, CardContent } from "@/components/ui/card";
 import { ErrorNotice } from "@/components/ui/error-notice";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
@@ -18,6 +19,7 @@ const SIZE_BUCKET_LABELS: Record<CodeReviewSizeBucket, string> = {
   "200_499": "200–499 total lines",
   "500_plus": "500+ total lines",
 };
+type AuthorSort = "author" | "reviews" | "approved" | "not_approved" | "approval_rate" | "split_sample" | "average_additions" | "median_additions" | "average_deletions" | "median_deletions";
 
 const NON_APPROVAL_REASON_LABELS: Record<string, string> = {
   reviewer_disabled: "Automatic approval was disabled",
@@ -86,16 +88,9 @@ function MetricCard({
   );
 }
 
-function LoadingReport() {
-  return (
-    <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4" aria-label="Loading code review analytics">
-      {["Reviews completed", "Automatically approved", "Not approved", "Approval rate"].map((label) => (
-        <MetricCard key={label} label={label} value="—" context="Loading selected time window" />
-      ))}
-    </div>
-  );
-}
-
+// Derived from the same report as the tables below, so the headline numbers
+// always agree with them. The reviews tab's cards deliberately describe current
+// review activity only and answer a different question.
 function ApprovalOutcomeCards({ summary }: { summary: CodeReviewAnalytics["summary"] }) {
   return (
     <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4" aria-label="Approval outcomes">
@@ -128,14 +123,20 @@ export function CodeReviewAnalyticsReport({
   isLoading,
   isError,
   onRetry,
+  authorSort,
+  authorSortOrder,
+  onAuthorSort,
 }: {
   analytics?: CodeReviewAnalytics;
   isLoading: boolean;
   isError: boolean;
   onRetry: () => void;
+  authorSort: AuthorSort;
+  authorSortOrder: "asc" | "desc";
+  onAuthorSort: (sort: AuthorSort, order: "asc" | "desc") => void;
 }) {
   if (!analytics && isLoading) {
-    return <LoadingReport />;
+    return <p className="py-12 text-center text-sm text-muted-foreground">Loading code review analytics…</p>;
   }
   if (!analytics) {
     return (
@@ -148,6 +149,19 @@ export function CodeReviewAnalyticsReport({
   }
 
   const { summary } = analytics;
+  const authorHeader = (label: string, sort: AuthorSort) => {
+    const active = authorSort === sort;
+    return (
+      <SortableTableHeader
+        label={label}
+        direction={active ? authorSortOrder : false}
+        align={sort === "author" ? "left" : "right"}
+        // The author table always has an ordering, so allowUnsorted stays off
+        // and the callback only ever receives a direction.
+        onSort={(next) => { if (next) onAuthorSort(sort, next); }}
+      />
+    );
+  };
   if (summary.reviews_requested === 0) {
     return (
       <div className="space-y-3">
@@ -210,16 +224,26 @@ export function CodeReviewAnalyticsReport({
             <Table aria-label="Code review analytics by PR author">
               <TableHeader>
                 <TableRow>
-                  <TableHead>PR author</TableHead>
-                  <TableHead className="text-right">Reviews</TableHead>
-                  <TableHead className="text-right">Approved</TableHead>
-                  <TableHead className="text-right">Not approved</TableHead>
-                  <TableHead className="text-right">Approval rate</TableHead>
-                  <TableHead className="text-right">Split sample</TableHead>
-                  <TableHead className="text-right">Avg. additions</TableHead>
-                  <TableHead className="text-right">Median additions</TableHead>
-                  <TableHead className="text-right">Avg. deletions</TableHead>
-                  <TableHead className="text-right">Median deletions</TableHead>
+                  {([
+                    ["PR author", "author"],
+                    ["Reviews", "reviews"],
+                    ["Approved", "approved"],
+                    ["Not approved", "not_approved"],
+                    ["Approval rate", "approval_rate"],
+                    ["Split sample", "split_sample"],
+                    ["Avg. additions", "average_additions"],
+                    ["Median additions", "median_additions"],
+                    ["Avg. deletions", "average_deletions"],
+                    ["Median deletions", "median_deletions"],
+                  ] as const).map(([label, sort]) => (
+                    <TableHead
+                      key={sort}
+                      className={sort === "author" ? undefined : "text-right"}
+                      aria-sort={sortDirectionAriaValue(authorSort === sort ? authorSortOrder : false)}
+                    >
+                      {authorHeader(label, sort)}
+                    </TableHead>
+                  ))}
                 </TableRow>
               </TableHeader>
               <TableBody>

--- a/frontend/src/components/code-review-overview.test.tsx
+++ b/frontend/src/components/code-review-overview.test.tsx
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest";
+import { formatReviewTurnaround } from "./code-review-overview";
+
+describe("formatReviewTurnaround", () => {
+  it.each([
+    { seconds: null, expected: "—" },
+    { seconds: 45, expected: "45s" },
+    { seconds: 8 * 60, expected: "8m" },
+    { seconds: 90 * 60, expected: "1h 30m" },
+    { seconds: 48 * 60 * 60, expected: "48h" },
+  ])("formats $seconds seconds as $expected", ({ seconds, expected }) => {
+    expect(formatReviewTurnaround(seconds)).toBe(expected);
+  });
+});

--- a/frontend/src/components/code-review-overview.tsx
+++ b/frontend/src/components/code-review-overview.tsx
@@ -1,0 +1,182 @@
+"use client";
+
+import { ChevronDown, SlidersHorizontal } from "lucide-react";
+import type { ReactNode } from "react";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import { ErrorNotice } from "@/components/ui/error-notice";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import type { CodeReviewListOutcome, CodeReviewStats, Repository } from "@/lib/types";
+
+export const ALL_REPOSITORIES = "all";
+export const ALL_OUTCOMES = "all";
+export const ALL_RISKS = "all";
+export const AUTOMATICALLY_APPROVED = "automatically_approved" satisfies CodeReviewListOutcome;
+export const COMPLETED_NOT_APPROVED = "completed_not_approved" satisfies CodeReviewListOutcome;
+
+function percentage(value: number, total: number): string {
+  return total > 0 ? `${Math.round((value / total) * 100)}%` : "0%";
+}
+
+export function formatReviewTurnaround(seconds: number | null): string {
+  if (seconds === null || !Number.isFinite(seconds)) return "—";
+  if (seconds < 60) return `${Math.round(seconds)}s`;
+  const minutes = Math.round(seconds / 60);
+  if (minutes < 60) return `${minutes}m`;
+  const hours = Math.floor(minutes / 60);
+  const remainingMinutes = minutes % 60;
+  return remainingMinutes === 0 ? `${hours}h` : `${hours}h ${remainingMinutes}m`;
+}
+
+export function CodeReviewSummaryCards({
+  stats,
+  isLoading,
+  isError,
+  onRetry,
+}: {
+  stats?: CodeReviewStats;
+  isLoading: boolean;
+  isError: boolean;
+  onRetry: () => void;
+}) {
+  const unavailable = isError ? "Metrics unavailable" : "Loading selected time window";
+  const cards = stats
+    ? [
+        { label: "Reviews completed", value: stats.reviews_completed.toLocaleString(), context: "In selected time window" },
+        {
+          label: "Automatically approved",
+          value: stats.automatically_approved.toLocaleString(),
+          context: `${percentage(stats.automatically_approved, stats.reviews_completed)} of completed reviews`,
+        },
+        {
+          label: "Approval rate",
+          value: percentage(stats.automatically_approved, stats.reviews_completed),
+          context: `${stats.needs_human_review.toLocaleString()} need human review`,
+        },
+        { label: "Median turnaround", value: formatReviewTurnaround(stats.median_turnaround_seconds), context: "Queued to completed" },
+      ]
+    : ["Reviews completed", "Automatically approved", "Approval rate", "Median turnaround"].map((label) => ({
+        label,
+        value: "—",
+        context: unavailable,
+      }));
+
+  return (
+    <div className="space-y-3" role="region" aria-label="Code review statistics" aria-busy={isLoading}>
+      {isError ? (
+        <ErrorNotice
+          title={stats ? "Metrics may be out of date" : "Metrics unavailable"}
+          description={stats ? "Showing the last successful result because the latest refresh failed." : "The selected review metrics could not be loaded."}
+          action={{ label: "Retry", onClick: onRetry }}
+        />
+      ) : null}
+      <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
+        {cards.map((card) => (
+          <Card key={card.label}>
+            <CardContent className="space-y-1.5">
+              <p className="text-xs font-medium text-muted-foreground">{card.label}</p>
+              <p className="text-2xl font-semibold tabular-nums text-foreground">{card.value}</p>
+              <p className="text-xs text-muted-foreground">{card.context}</p>
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function FilterSelect({
+  label,
+  value,
+  onValueChange,
+  children,
+}: {
+  label: string;
+  value: string;
+  onValueChange: (value: string) => void;
+  children: ReactNode;
+}) {
+  return (
+    <div className="flex flex-col gap-2">
+      <Label className="text-xs text-muted-foreground">{label}</Label>
+      <Select value={value} onValueChange={onValueChange}>
+        <SelectTrigger aria-label={label}><SelectValue /></SelectTrigger>
+        <SelectContent>{children}</SelectContent>
+      </Select>
+    </div>
+  );
+}
+
+export interface CodeReviewFilterValues {
+  repository: string;
+  outcome: string;
+  risk: string;
+  status: string;
+  search: string;
+  timeRange: string;
+}
+
+export function CodeReviewFilters({
+  values,
+  repositories,
+  mobileOpen,
+  onMobileOpenChange,
+  onChange,
+  id,
+}: {
+  values: CodeReviewFilterValues;
+  repositories: Repository[];
+  mobileOpen: boolean;
+  onMobileOpenChange: (open: boolean) => void;
+  onChange: (field: keyof CodeReviewFilterValues, value: string) => void;
+  id: string;
+}) {
+  return (
+    <>
+      <Button type="button" variant="outline" size="sm" className="w-full justify-between md:hidden" aria-expanded={mobileOpen} aria-controls={id} onClick={() => onMobileOpenChange(!mobileOpen)}>
+        <span className="flex items-center gap-2"><SlidersHorizontal className="h-4 w-4" />Filter reviews</span>
+        <ChevronDown className={`h-4 w-4 transition-transform ${mobileOpen ? "rotate-180" : ""}`} />
+      </Button>
+      <div id={id} className={`${mobileOpen ? "grid" : "hidden"} gap-3 rounded-xl border border-border bg-card p-3 shadow-sm md:grid md:grid-cols-2 md:rounded-none md:border-0 md:bg-transparent md:p-0 md:shadow-none lg:grid-cols-3 xl:grid-cols-[minmax(12rem,18rem)_repeat(3,minmax(9rem,11rem))_minmax(12rem,1fr)_minmax(9rem,11rem)]`}>
+        <FilterSelect label="Repository" value={values.repository} onValueChange={(value) => onChange("repository", value)}>
+          <SelectItem value={ALL_REPOSITORIES}>All repositories</SelectItem>
+          {repositories.map((repo) => <SelectItem key={repo.id} value={repo.id}>{repo.full_name}</SelectItem>)}
+        </FilterSelect>
+        <FilterSelect label="Outcome" value={values.outcome} onValueChange={(value) => onChange("outcome", value)}>
+          <SelectItem value={ALL_OUTCOMES}>All outcomes</SelectItem>
+          <SelectItem value={AUTOMATICALLY_APPROVED}>Automatically approved</SelectItem>
+          <SelectItem value={COMPLETED_NOT_APPROVED}>Ran successfully — not approved</SelectItem>
+          <SelectItem value="needs_human_review">Needs human review</SelectItem>
+          <SelectItem value="comment_only">Comment-only decision</SelectItem>
+          <SelectItem value="blocked">Blocked</SelectItem>
+        </FilterSelect>
+        <FilterSelect label="Risk" value={values.risk} onValueChange={(value) => onChange("risk", value)}>
+          <SelectItem value={ALL_RISKS}>All risk</SelectItem>
+          <SelectItem value="acceptable">Acceptable</SelectItem>
+          <SelectItem value="needs_review">Needs review</SelectItem>
+        </FilterSelect>
+        <FilterSelect label="Status" value={values.status} onValueChange={(value) => onChange("status", value)}>
+          <SelectItem value="current">Current reviews</SelectItem>
+          <SelectItem value="completed">Completed</SelectItem>
+          <SelectItem value="in_progress">In progress</SelectItem>
+          <SelectItem value="failed">Failed</SelectItem>
+          <SelectItem value="cancelled">Cancelled</SelectItem>
+          <SelectItem value="superseded">Superseded history</SelectItem>
+          <SelectItem value="all">All attempts</SelectItem>
+        </FilterSelect>
+        <div className="flex flex-col gap-2">
+          <Label className="text-xs text-muted-foreground">Search</Label>
+          <Input value={values.search} onChange={(event) => onChange("search", event.target.value)} placeholder="PR, repo, or title" aria-label="Search code reviews" />
+        </div>
+        <FilterSelect label="Time window" value={values.timeRange} onValueChange={(value) => onChange("timeRange", value)}>
+          <SelectItem value="7d">Last 7 days</SelectItem>
+          <SelectItem value="30d">Last 30 days</SelectItem>
+          <SelectItem value="90d">Last 90 days</SelectItem>
+          <SelectItem value="all">All time</SelectItem>
+        </FilterSelect>
+      </div>
+    </>
+  );
+}

--- a/frontend/src/components/responsive-resource-list.test.tsx
+++ b/frontend/src/components/responsive-resource-list.test.tsx
@@ -75,4 +75,26 @@ describe("ResponsiveResourceList", () => {
     );
     expect(screen.queryByRole("table")).not.toBeInTheDocument();
   });
+
+  it("exposes shared sortable-column state on the column header", () => {
+    render(
+      <ResponsiveResourceList
+        ariaLabel="Automations"
+        items={[{ id: "automation-1", name: "Release check", status: "Enabled" }]}
+        getItemKey={(item) => item.id}
+        columns={[
+          {
+            id: "name",
+            header: "Name",
+            sortDirection: "desc",
+            render: (item) => item.name,
+          },
+        ]}
+        emptyState="No automations."
+        renderMobileItem={(item) => <div>{item.name}</div>}
+      />,
+    );
+
+    expect(screen.getByRole("columnheader", { name: "Name" })).toHaveAttribute("aria-sort", "descending");
+  });
 });

--- a/frontend/src/components/responsive-resource-list.tsx
+++ b/frontend/src/components/responsive-resource-list.tsx
@@ -11,10 +11,12 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
+import { sortDirectionAriaValue, type SortDirection } from "@/components/sortable-table-header";
 
 export type ResponsiveResourceListColumn<TItem> = {
   id: string;
   header: ReactNode;
+  sortDirection?: SortDirection | false;
   className?: string;
   cellClassName?: string;
   render: (item: TItem) => ReactNode;
@@ -69,7 +71,11 @@ export function ResponsiveResourceList<TItem>({
             <TableHeader>
               <TableRow>
                 {columns.map((column) => (
-                  <TableHead key={column.id} className={column.className}>
+                  <TableHead
+                    key={column.id}
+                    className={column.className}
+                    aria-sort={column.sortDirection === undefined ? undefined : sortDirectionAriaValue(column.sortDirection)}
+                  >
                     {column.header}
                   </TableHead>
                 ))}

--- a/frontend/src/components/sortable-table-header.test.tsx
+++ b/frontend/src/components/sortable-table-header.test.tsx
@@ -1,0 +1,46 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { SortableTableHeader, nextSortDirection, sortDirectionAriaValue } from "./sortable-table-header";
+
+describe("SortableTableHeader", () => {
+  it.each([
+    { direction: false as const, expected: "asc" as const },
+    { direction: "asc" as const, expected: "desc" as const },
+    { direction: "desc" as const, expected: "asc" as const },
+  ])("requests $expected after $direction", async ({ direction, expected }) => {
+    const user = userEvent.setup();
+    const onSort = vi.fn();
+    render(<SortableTableHeader label="Repository" direction={direction} onSort={onSort} />);
+
+    const button = screen.getByRole("button", {
+      name: `Sort by Repository ${expected === "asc" ? "ascending" : "descending"}`,
+    });
+    expect(button).toHaveAttribute("data-sort-direction", direction || "none");
+    await user.click(button);
+    expect(onSort).toHaveBeenCalledWith(expected);
+  });
+
+  it("returns to the table's default order on the third click when unsorting is allowed", async () => {
+    const user = userEvent.setup();
+    const onSort = vi.fn();
+    render(<SortableTableHeader label="Repository" direction="desc" allowUnsorted onSort={onSort} />);
+
+    await user.click(screen.getByRole("button", { name: "Stop sorting by Repository" }));
+
+    expect(onSort).toHaveBeenCalledWith(false);
+  });
+
+  it("exposes the shared direction cycle for table adapters", () => {
+    expect(nextSortDirection(false)).toBe("asc");
+    expect(nextSortDirection("asc")).toBe("desc");
+    expect(nextSortDirection("desc")).toBe("asc");
+    // Tables with their own default order cycle back to it instead.
+    expect(nextSortDirection(false, true)).toBe("asc");
+    expect(nextSortDirection("asc", true)).toBe("desc");
+    expect(nextSortDirection("desc", true)).toBe(false);
+    expect(sortDirectionAriaValue(false)).toBe("none");
+    expect(sortDirectionAriaValue("asc")).toBe("ascending");
+    expect(sortDirectionAriaValue("desc")).toBe("descending");
+  });
+});

--- a/frontend/src/components/sortable-table-header.tsx
+++ b/frontend/src/components/sortable-table-header.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import { ArrowDown, ArrowUp, ArrowUpDown } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+export type SortDirection = "asc" | "desc";
+
+// Tables that own a default order (the reviews list sorts newest-first until a
+// column is picked) pass allowUnsorted so the cycle can return to it. Adapters
+// over a table library that has no unsorted state leave it off.
+export function nextSortDirection(direction: SortDirection | false, allowUnsorted = false): SortDirection | false {
+  if (direction === "asc") return "desc";
+  if (direction === "desc") return allowUnsorted ? false : "asc";
+  return "asc";
+}
+
+export function sortDirectionAriaValue(direction: SortDirection | false): "ascending" | "descending" | "none" {
+  if (direction === "asc") return "ascending";
+  if (direction === "desc") return "descending";
+  return "none";
+}
+
+export function SortableTableHeader({
+  label,
+  direction,
+  onSort,
+  align = "left",
+  allowUnsorted = false,
+  className,
+}: {
+  label: string;
+  direction: SortDirection | false;
+  onSort: (direction: SortDirection | false) => void;
+  align?: "left" | "right";
+  allowUnsorted?: boolean;
+  className?: string;
+}) {
+  const nextDirection = nextSortDirection(direction, allowUnsorted);
+  const Icon = direction === "asc" ? ArrowUp : direction === "desc" ? ArrowDown : ArrowUpDown;
+
+  return (
+    <Button
+      type="button"
+      variant="ghost"
+      size="sm"
+      className={cn(
+        "h-8 gap-1.5 px-2",
+        align === "left" ? "-ml-2" : "-mr-2",
+        className,
+      )}
+      aria-label={
+        nextDirection === false
+          ? `Stop sorting by ${label}`
+          : `Sort by ${label} ${nextDirection === "asc" ? "ascending" : "descending"}`
+      }
+      data-sort-direction={direction || "none"}
+      onClick={() => onSort(nextDirection)}
+    >
+      {label}
+      <Icon className={cn("h-3.5 w-3.5", direction === false && "opacity-50")} />
+    </Button>
+  );
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -275,6 +275,8 @@ export const api = {
       search?: string;
       created_after?: string;
       created_before?: string;
+      sort_by?: "pull_request" | "outcome" | "risk" | "run_status" | "repository" | "completed";
+      sort_order?: "asc" | "desc";
       limit?: number;
       cursor?: string;
     }) => {
@@ -288,6 +290,8 @@ export const api = {
       if (params?.search) searchParams.set('search', params.search);
       if (params?.created_after) searchParams.set('created_after', params.created_after);
       if (params?.created_before) searchParams.set('created_before', params.created_before);
+      if (params?.sort_by) searchParams.set('sort_by', params.sort_by);
+      if (params?.sort_order) searchParams.set('sort_order', params.sort_order);
       if (params?.limit) searchParams.set('limit', String(params.limit));
       if (params?.cursor) searchParams.set('cursor', params.cursor);
       const qs = searchParams.toString();
@@ -319,11 +323,27 @@ export const api = {
     },
     analytics: (params?: {
       repository_id?: string;
+      decision?: import('./types').CodeReviewDecision;
+      outcome?: import('./types').CodeReviewListOutcome;
+      activity_status?: import('./types').CodeReviewActivityStatus;
+      status?: import('./types').CodeReviewSessionStatus;
+      risk?: "acceptable" | "needs_review";
+      search?: string;
+      author_sort_by?: "author" | "reviews" | "approved" | "not_approved" | "approval_rate" | "split_sample" | "average_additions" | "median_additions" | "average_deletions" | "median_deletions";
+      author_sort_order?: "asc" | "desc";
       created_after?: string;
       created_before?: string;
     }) => {
       const searchParams = new URLSearchParams();
       if (params?.repository_id) searchParams.set('repository_id', params.repository_id);
+      if (params?.decision) searchParams.set('decision', params.decision);
+      if (params?.outcome) searchParams.set('outcome', params.outcome);
+      if (params?.activity_status) searchParams.set('activity_status', params.activity_status);
+      if (params?.status) searchParams.set('status', params.status);
+      if (params?.risk) searchParams.set('risk', params.risk);
+      if (params?.search) searchParams.set('search', params.search);
+      if (params?.author_sort_by) searchParams.set('author_sort_by', params.author_sort_by);
+      if (params?.author_sort_order) searchParams.set('author_sort_order', params.author_sort_order);
       if (params?.created_after) searchParams.set('created_after', params.created_after);
       if (params?.created_before) searchParams.set('created_before', params.created_before);
       const qs = searchParams.toString();

--- a/internal/api/handlers/code_reviews.go
+++ b/internal/api/handlers/code_reviews.go
@@ -6,6 +6,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"strconv"
 	"strings"
@@ -41,9 +42,17 @@ type codeReviewRetryService interface {
 }
 
 type codeReviewListCursor struct {
-	ID        uuid.UUID `json:"id"`
-	CreatedAt time.Time `json:"created_at"`
-	Scope     [32]byte  `json:"scope"`
+	ID        uuid.UUID             `json:"id"`
+	CreatedAt time.Time             `json:"created_at"`
+	Sort      *codeReviewSortCursor `json:"sort,omitempty"`
+	Scope     [32]byte              `json:"scope"`
+}
+
+type codeReviewSortCursor struct {
+	Null bool       `json:"null,omitempty"`
+	Text *string    `json:"text,omitempty"`
+	Int  *int       `json:"int,omitempty"`
+	Time *time.Time `json:"time,omitempty"`
 }
 
 type codeReviewCursorScope struct {
@@ -57,6 +66,8 @@ type codeReviewCursorScope struct {
 	Search         string                           `json:"search,omitempty"`
 	CreatedAfter   *time.Time                       `json:"created_after,omitempty"`
 	CreatedBefore  *time.Time                       `json:"created_before,omitempty"`
+	SortBy         string                           `json:"sort_by,omitempty"`
+	SortOrder      string                           `json:"sort_order,omitempty"`
 }
 
 func codeReviewListCursorScopeHash(orgID uuid.UUID, filters db.CodeReviewListFilters) ([32]byte, error) {
@@ -71,6 +82,8 @@ func codeReviewListCursorScopeHash(orgID uuid.UUID, filters db.CodeReviewListFil
 		Search:         strings.TrimSpace(filters.Search),
 		CreatedAfter:   filters.CreatedAfter,
 		CreatedBefore:  filters.CreatedBefore,
+		SortBy:         filters.SortBy,
+		SortOrder:      filters.SortOrder,
 	})
 	if err != nil {
 		return [32]byte{}, err
@@ -78,38 +91,112 @@ func codeReviewListCursorScopeHash(orgID uuid.UUID, filters db.CodeReviewListFil
 	return sha256.Sum256(encoded), nil
 }
 
-func encodeCodeReviewListCursor(orgID uuid.UUID, filters db.CodeReviewListFilters, id uuid.UUID, createdAt time.Time) (string, error) {
+func encodeCodeReviewListCursor(orgID uuid.UUID, filters db.CodeReviewListFilters, id uuid.UUID, createdAt time.Time, sort *codeReviewSortCursor) (string, error) {
 	scope, err := codeReviewListCursorScopeHash(orgID, filters)
 	if err != nil {
 		return "", err
 	}
-	encoded, err := json.Marshal(codeReviewListCursor{ID: id, CreatedAt: createdAt, Scope: scope})
+	encoded, err := json.Marshal(codeReviewListCursor{ID: id, CreatedAt: createdAt, Sort: sort, Scope: scope})
 	if err != nil {
 		return "", err
 	}
 	return base64.RawURLEncoding.EncodeToString(encoded), nil
 }
 
-func decodeCodeReviewListCursor(raw string, orgID uuid.UUID, filters db.CodeReviewListFilters) (uuid.UUID, time.Time, error) {
+func decodeCodeReviewListCursor(raw string, orgID uuid.UUID, filters db.CodeReviewListFilters) (codeReviewListCursor, error) {
 	encoded, err := base64.RawURLEncoding.DecodeString(raw)
 	if err != nil {
-		return uuid.Nil, time.Time{}, err
+		return codeReviewListCursor{}, err
 	}
 	var cursor codeReviewListCursor
 	if err := json.Unmarshal(encoded, &cursor); err != nil {
-		return uuid.Nil, time.Time{}, err
+		return codeReviewListCursor{}, err
 	}
 	if cursor.ID == uuid.Nil || cursor.CreatedAt.IsZero() {
-		return uuid.Nil, time.Time{}, errors.New("cursor anchor is incomplete")
+		return codeReviewListCursor{}, errors.New("cursor anchor is incomplete")
 	}
 	scope, err := codeReviewListCursorScopeHash(orgID, filters)
 	if err != nil {
-		return uuid.Nil, time.Time{}, err
+		return codeReviewListCursor{}, err
 	}
 	if cursor.Scope != scope {
-		return uuid.Nil, time.Time{}, errors.New("cursor does not match the active filters")
+		return codeReviewListCursor{}, errors.New("cursor does not match the active filters")
 	}
-	return cursor.ID, cursor.CreatedAt, nil
+	if filters.SortBy != "" && cursor.Sort == nil {
+		return codeReviewListCursor{}, errors.New("sorted cursor anchor is incomplete")
+	}
+	return cursor, nil
+}
+
+func codeReviewSortCursorForItem(sortBy string, item models.CodeReviewListItem) (*codeReviewSortCursor, error) {
+	if sortBy == "" {
+		return nil, nil
+	}
+	// Outcome, risk, and run status order by the rank of the label the row
+	// displays, so the cursor has to anchor on that same rank.
+	if rank, ok := db.CodeReviewSortRankForItem(sortBy, item); ok {
+		return &codeReviewSortCursor{Int: &rank}, nil
+	}
+	switch sortBy {
+	case "pull_request":
+		value := item.GitHubPRNumber
+		return &codeReviewSortCursor{Int: &value}, nil
+	case "repository":
+		// repositories.full_name is NOT NULL behind an inner join. A null
+		// anchor here would query a partition holding no rows and end
+		// pagination early, so surface the broken invariant instead.
+		if item.RepositoryName == nil {
+			return nil, errors.New("review is missing the repository name its cursor sorts on")
+		}
+		return &codeReviewSortCursor{Text: item.RepositoryName}, nil
+	case "completed":
+		if item.CompletedAt == nil {
+			return &codeReviewSortCursor{Null: true}, nil
+		}
+		return &codeReviewSortCursor{Time: item.CompletedAt}, nil
+	default:
+		return nil, fmt.Errorf("unsupported code review sort: %q", sortBy)
+	}
+}
+
+func applyCodeReviewSortCursor(filters *db.CodeReviewListFilters, sort *codeReviewSortCursor) error {
+	if filters.SortBy == "" {
+		return nil
+	}
+	if sort == nil {
+		return errors.New("sorted cursor anchor is missing")
+	}
+	// The scope hash covers the filters, not the anchor, so a client can edit a
+	// legitimate cursor's null flag. Reject an anchor the sort cannot produce
+	// here rather than letting the query layer fail the whole request.
+	nullable, err := db.CodeReviewListSortIsNullable(filters.SortBy)
+	if err != nil {
+		return err
+	}
+	if sort.Null && !nullable {
+		return fmt.Errorf("code review sort %q cannot anchor on a null value", filters.SortBy)
+	}
+	filters.CursorSortNull = sort.Null
+	switch filters.SortBy {
+	case "pull_request", "outcome", "risk", "run_status":
+		if sort.Int != nil {
+			filters.CursorSortValue = *sort.Int
+		}
+	case "repository":
+		if sort.Text != nil {
+			filters.CursorSortValue = *sort.Text
+		}
+	case "completed":
+		if sort.Time != nil {
+			filters.CursorSortValue = *sort.Time
+		}
+	default:
+		return fmt.Errorf("unsupported code review sort: %q", filters.SortBy)
+	}
+	if !sort.Null && filters.CursorSortValue == nil {
+		return errors.New("sorted cursor value has the wrong type")
+	}
+	return nil
 }
 
 type CodeReviewHandler struct {
@@ -328,10 +415,42 @@ func parseCodeReviewFilters(w http.ResponseWriter, r *http.Request) (db.CodeRevi
 	return filters, true
 }
 
+// parseCodeReviewListSort reads the ordering the reviews table asks for. It is
+// list-only: /stats and /analytics share the filter parser but have their own
+// ordering (or none), so they must not accept or reject these parameters.
+func parseCodeReviewListSort(w http.ResponseWriter, r *http.Request, filters *db.CodeReviewListFilters) bool {
+	raw := strings.TrimSpace(r.URL.Query().Get("sort_by"))
+	if raw == "" {
+		return true
+	}
+	switch raw {
+	case "pull_request", "outcome", "risk", "run_status", "repository", "completed":
+		filters.SortBy = raw
+	default:
+		writeError(w, r, http.StatusBadRequest, "INVALID_SORT", "invalid sort_by")
+		return false
+	}
+	order := strings.TrimSpace(r.URL.Query().Get("sort_order"))
+	if order == "" {
+		order = "asc"
+	}
+	if order != "asc" && order != "desc" {
+		writeError(w, r, http.StatusBadRequest, "INVALID_SORT_ORDER", "sort_order must be asc or desc")
+		return false
+	}
+	filters.SortOrder = order
+	return true
+}
+
 func (h *CodeReviewHandler) List(w http.ResponseWriter, r *http.Request) {
 	orgID := middleware.OrgIDFromContext(r.Context())
 	filters, ok := parseCodeReviewFilters(w, r)
 	if !ok {
+		return
+	}
+	// Must run before the cursor is decoded: the sort is part of the cursor
+	// scope hash, so a cursor issued under one order cannot be replayed here.
+	if !parseCodeReviewListSort(w, r, &filters) {
 		return
 	}
 	limit := 50
@@ -346,13 +465,17 @@ func (h *CodeReviewHandler) List(w http.ResponseWriter, r *http.Request) {
 	filters.Limit = limit
 	rawCursor := strings.TrimSpace(r.URL.Query().Get("cursor"))
 	if rawCursor != "" {
-		cursorID, cursorCreatedAt, err := decodeCodeReviewListCursor(rawCursor, orgID, filters)
+		cursor, err := decodeCodeReviewListCursor(rawCursor, orgID, filters)
 		if err != nil {
 			writeError(w, r, http.StatusBadRequest, "INVALID_CURSOR", "cursor is invalid or does not match the active filters")
 			return
 		}
-		filters.Cursor = &cursorID
-		filters.CursorCreatedAt = &cursorCreatedAt
+		filters.Cursor = &cursor.ID
+		filters.CursorCreatedAt = &cursor.CreatedAt
+		if err := applyCodeReviewSortCursor(&filters, cursor.Sort); err != nil {
+			writeError(w, r, http.StatusBadRequest, "INVALID_CURSOR", "cursor sort anchor is invalid")
+			return
+		}
 	}
 	page, err := h.store.ListReviewsPage(r.Context(), orgID, filters)
 	if err != nil {
@@ -366,7 +489,13 @@ func (h *CodeReviewHandler) List(w http.ResponseWriter, r *http.Request) {
 			writeError(w, r, http.StatusInternalServerError, "CODE_REVIEWS_LOAD_FAILED", "failed to encode code review cursor", err)
 			return
 		}
-		nextCursor, err = encodeCodeReviewListCursor(orgID, filters, cursorID, page.NextCursorCreatedAt)
+		lastItem := page.Items[len(page.Items)-1]
+		sortCursor, sortErr := codeReviewSortCursorForItem(filters.SortBy, lastItem)
+		if sortErr != nil {
+			writeError(w, r, http.StatusInternalServerError, "CODE_REVIEWS_LOAD_FAILED", "failed to encode review sort cursor", sortErr)
+			return
+		}
+		nextCursor, err = encodeCodeReviewListCursor(orgID, filters, cursorID, page.NextCursorCreatedAt, sortCursor)
 		if err != nil {
 			writeError(w, r, http.StatusInternalServerError, "CODE_REVIEWS_LOAD_FAILED", "failed to encode code review cursor", err)
 			return
@@ -403,23 +532,43 @@ func (h *CodeReviewHandler) Stats(w http.ResponseWriter, r *http.Request) {
 }
 
 func parseCodeReviewAnalyticsFilters(w http.ResponseWriter, r *http.Request) (db.CodeReviewAnalyticsFilters, bool) {
-	createdAfter, createdBefore, ok := parseCodeReviewTimeFilters(w, r)
-	if !ok {
-		return db.CodeReviewAnalyticsFilters{}, false
-	}
-	filters := db.CodeReviewAnalyticsFilters{
-		CreatedAfter:  createdAfter,
-		CreatedBefore: createdBefore,
-	}
+	// The shared filter parser reports a bad UUID as INVALID_QUERY; this
+	// endpoint has always answered with the more specific
+	// INVALID_REPOSITORY_ID, so check first to keep that contract.
 	if raw := strings.TrimSpace(r.URL.Query().Get("repository_id")); raw != "" {
-		repositoryID, err := uuid.Parse(raw)
-		if err != nil {
+		if _, err := uuid.Parse(raw); err != nil {
 			writeError(w, r, http.StatusBadRequest, "INVALID_REPOSITORY_ID", "invalid repository_id")
 			return db.CodeReviewAnalyticsFilters{}, false
 		}
-		filters.RepositoryID = &repositoryID
 	}
-	return filters, true
+	filters, ok := parseCodeReviewFilters(w, r)
+	if !ok {
+		return db.CodeReviewAnalyticsFilters{}, false
+	}
+	analyticsFilters := db.CodeReviewAnalyticsFilters{
+		RepositoryID: filters.RepositoryID, Decision: filters.Decision, Outcome: filters.Outcome,
+		ActivityStatus: filters.ActivityStatus, Status: filters.Status, Acceptable: filters.Acceptable,
+		Search: filters.Search, CreatedAfter: filters.CreatedAfter, CreatedBefore: filters.CreatedBefore,
+	}
+	if raw := strings.TrimSpace(r.URL.Query().Get("author_sort_by")); raw != "" {
+		switch raw {
+		case "author", "reviews", "approved", "not_approved", "approval_rate", "split_sample", "average_additions", "median_additions", "average_deletions", "median_deletions":
+			analyticsFilters.AuthorSortBy = raw
+		default:
+			writeError(w, r, http.StatusBadRequest, "INVALID_ANALYTICS_SORT", "invalid author_sort_by")
+			return db.CodeReviewAnalyticsFilters{}, false
+		}
+		order := strings.TrimSpace(r.URL.Query().Get("author_sort_order"))
+		if order == "" {
+			order = "asc"
+		}
+		if order != "asc" && order != "desc" {
+			writeError(w, r, http.StatusBadRequest, "INVALID_SORT_ORDER", "author_sort_order must be asc or desc")
+			return db.CodeReviewAnalyticsFilters{}, false
+		}
+		analyticsFilters.AuthorSortOrder = order
+	}
+	return analyticsFilters, true
 }
 
 func (h *CodeReviewHandler) Analytics(w http.ResponseWriter, r *http.Request) {

--- a/internal/api/handlers/code_reviews_test.go
+++ b/internal/api/handlers/code_reviews_test.go
@@ -492,6 +492,8 @@ func TestCodeReviewHandler_AnalyticsRejectsInvalidFilters(t *testing.T) {
 	}{
 		{name: "repository", query: "?repository_id=invalid", expectedCode: "INVALID_REPOSITORY_ID"},
 		{name: "time window", query: "?created_after=invalid", expectedCode: "INVALID_TIMESTAMP"},
+		{name: "author sort", query: "?author_sort_by=unsafe", expectedCode: "INVALID_ANALYTICS_SORT"},
+		{name: "author sort order", query: "?author_sort_by=reviews&author_sort_order=sideways", expectedCode: "INVALID_SORT_ORDER"},
 	}
 
 	for _, tt := range tests {
@@ -520,6 +522,7 @@ func TestCodeReviewHandler_ListRejectsCursorOutsideOrganization(t *testing.T) {
 		db.CodeReviewListFilters{Limit: 50},
 		uuid.New(),
 		time.Date(2026, 7, 28, 12, 0, 0, 0, time.UTC),
+		nil,
 	)
 	require.NoError(t, err, "a cursor for another organization should encode")
 	handler := NewCodeReviewHandler(nil, nil)
@@ -538,28 +541,156 @@ func TestCodeReviewListCursorRejectsChangedFilterButAllowsMutableRowChanges(t *t
 
 	orgID := uuid.New()
 	running := models.CodeReviewSessionStatusRunning
-	filters := db.CodeReviewListFilters{Status: &running, Search: "invoice", Limit: 50}
+	filters := db.CodeReviewListFilters{
+		Status: &running, Search: "invoice", Limit: 50,
+		SortBy: "repository", SortOrder: "asc",
+	}
 	id := uuid.New()
 	createdAt := time.Date(2026, 7, 28, 12, 0, 0, 0, time.UTC)
-	cursor, err := encodeCodeReviewListCursor(orgID, filters, id, createdAt)
+	repository := "acme/api"
+	cursor, err := encodeCodeReviewListCursor(orgID, filters, id, createdAt, &codeReviewSortCursor{Text: &repository})
 	require.NoError(t, err, "the cursor should encode immutable ordering values and filter scope")
 
-	decodedID, decodedCreatedAt, err := decodeCodeReviewListCursor(cursor, orgID, filters)
+	decoded, err := decodeCodeReviewListCursor(cursor, orgID, filters)
 
 	require.NoError(t, err, "the same request filters should decode without consulting mutable row state")
-	require.Equal(t, id, decodedID, "the cursor should preserve the review ID anchor")
-	require.Equal(t, createdAt, decodedCreatedAt, "the cursor should preserve the creation-time anchor")
+	require.Equal(t, id, decoded.ID, "the cursor should preserve the review ID anchor")
+	require.Equal(t, createdAt, decoded.CreatedAt, "the cursor should preserve the creation-time anchor")
+	require.Equal(t, repository, *decoded.Sort.Text, "the cursor should preserve the backend-sort value")
 
 	changedFilters := filters
 	changedFilters.Search = "payments"
-	_, _, err = decodeCodeReviewListCursor(cursor, orgID, changedFilters)
+	_, err = decodeCodeReviewListCursor(cursor, orgID, changedFilters)
 	require.Error(t, err, "a cursor reused with a different filter collection should be rejected")
 
 	current := models.CodeReviewActivityStatusCurrent
 	changedFilters = filters
 	changedFilters.ActivityStatus = &current
-	_, _, err = decodeCodeReviewListCursor(cursor, orgID, changedFilters)
+	_, err = decodeCodeReviewListCursor(cursor, orgID, changedFilters)
 	require.Error(t, err, "a cursor reused with a different activity status should be rejected")
+
+	changedFilters = filters
+	changedFilters.SortOrder = "desc"
+	_, err = decodeCodeReviewListCursor(cursor, orgID, changedFilters)
+	require.Error(t, err, "a cursor reused with a different backend sort should be rejected")
+}
+
+func TestCodeReviewSortCursorRoundTripsEveryListSort(t *testing.T) {
+	t.Parallel()
+
+	orgID := uuid.New()
+	completedAt := time.Date(2026, 7, 28, 12, 0, 0, 0, time.UTC)
+	repository := "acme/api"
+	approved := models.CodeReviewDecisionApproved
+	reviewID := int64(4242)
+	item := models.CodeReviewListItem{
+		CodeReviewSessionMetadata: models.CodeReviewSessionMetadata{
+			ID:          uuid.New(),
+			Status:      models.CodeReviewSessionStatusCompleted,
+			Decision:    &approved,
+			Acceptable:  func() *bool { acceptable := true; return &acceptable }(),
+			CompletedAt: &completedAt,
+		},
+		RepositoryName: &repository,
+		GitHubPRNumber: 143,
+	}
+	item.GitHubReviewID = &reviewID
+
+	tests := []struct {
+		sortBy   string
+		expected any
+	}{
+		{sortBy: "pull_request", expected: 143},
+		// The label-derived sorts anchor on the rank the ORDER BY assigns, not
+		// on the raw column, so a cursor cannot land in the wrong label group.
+		{sortBy: "outcome", expected: 0},
+		{sortBy: "risk", expected: 0},
+		{sortBy: "run_status", expected: 2},
+		{sortBy: "repository", expected: repository},
+		{sortBy: "completed", expected: completedAt},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.sortBy, func(t *testing.T) {
+			t.Parallel()
+
+			for _, order := range []string{"asc", "desc"} {
+				filters := db.CodeReviewListFilters{Limit: 50, SortBy: tt.sortBy, SortOrder: order}
+				sortCursor, err := codeReviewSortCursorForItem(filters.SortBy, item)
+				require.NoError(t, err, "an allowlisted sort should produce a cursor anchor")
+
+				raw, err := encodeCodeReviewListCursor(orgID, filters, item.ID, item.CreatedAt.Add(time.Second), sortCursor)
+				require.NoError(t, err, "the sort anchor should encode")
+
+				decoded, err := decodeCodeReviewListCursor(raw, orgID, filters)
+				require.NoError(t, err, "the sort anchor should decode under the same filters")
+				require.NoError(t, applyCodeReviewSortCursor(&filters, decoded.Sort), "the decoded anchor should apply to the query filters")
+				require.Equal(t, tt.expected, filters.CursorSortValue, "the applied anchor should keep the value and type the ORDER BY compares against")
+				require.False(t, filters.CursorSortNull, "a populated anchor should not select the null partition")
+			}
+		})
+	}
+}
+
+func TestCodeReviewSortCursorRejectsIncompleteAndMistypedAnchors(t *testing.T) {
+	t.Parallel()
+
+	nullableItem := models.CodeReviewListItem{}
+	sortCursor, err := codeReviewSortCursorForItem("completed", nullableItem)
+	require.NoError(t, err, "a review that never completed should still anchor")
+	require.True(t, sortCursor.Null, "a null sort value should anchor on the null partition")
+
+	_, err = codeReviewSortCursorForItem("unsupported", nullableItem)
+	require.Error(t, err, "an unsupported sort should not silently produce an anchor")
+
+	// repositories.full_name is NOT NULL behind an inner join, so a missing name
+	// is a broken invariant, not a null partition to page into.
+	_, err = codeReviewSortCursorForItem("repository", nullableItem)
+	require.Error(t, err, "a repository sort should refuse to anchor on a missing repository name")
+
+	filters := db.CodeReviewListFilters{SortBy: "repository", SortOrder: "asc"}
+	require.Error(t,
+		applyCodeReviewSortCursor(&filters, &codeReviewSortCursor{Null: true}),
+		"a hand-edited null flag should be rejected for a sort that cannot produce one",
+	)
+
+	filters = db.CodeReviewListFilters{SortBy: "completed", SortOrder: "asc"}
+	require.Error(t, applyCodeReviewSortCursor(&filters, nil), "a sorted request needs a sort anchor")
+
+	// A cursor minted for one sort must not be reinterpreted under another: the
+	// scope hash normally blocks this, so this guards the last line of defence.
+	repository := "acme/api"
+	filters = db.CodeReviewListFilters{SortBy: "completed", SortOrder: "asc"}
+	require.Error(t,
+		applyCodeReviewSortCursor(&filters, &codeReviewSortCursor{Text: &repository}),
+		"a text anchor should not satisfy a timestamp sort",
+	)
+
+	filters = db.CodeReviewListFilters{SortBy: "unsupported", SortOrder: "asc"}
+	require.Error(t,
+		applyCodeReviewSortCursor(&filters, &codeReviewSortCursor{Null: true}),
+		"an unsupported sort should be rejected while applying the anchor",
+	)
+
+	filters = db.CodeReviewListFilters{}
+	require.NoError(t, applyCodeReviewSortCursor(&filters, nil), "the default order needs no sort anchor")
+	require.Nil(t, filters.CursorSortValue, "the default order should not set a sort anchor")
+}
+
+func TestCodeReviewAnalyticsIgnoresListOnlySortParameters(t *testing.T) {
+	t.Parallel()
+
+	// sort_by orders the reviews table; the analytics report has its own
+	// ordering, so it must neither honor nor reject the list parameter.
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/code-reviews/analytics?sort_by=unsafe&sort_order=sideways", nil)
+	req = req.WithContext(middleware.WithOrgID(req.Context(), uuid.New()))
+	rr := httptest.NewRecorder()
+
+	filters, ok := parseCodeReviewAnalyticsFilters(rr, req)
+
+	require.True(t, ok, "a list-only sort parameter should not fail the analytics request")
+	require.Equal(t, http.StatusOK, rr.Code, "no error should be written for a list-only sort parameter")
+	require.Empty(t, filters.AuthorSortBy, "the list sort should not leak into the analytics author ordering")
 }
 
 func TestCodeReviewHandler_Retry(t *testing.T) {

--- a/internal/db/code_reviews.go
+++ b/internal/db/code_reviews.go
@@ -1160,19 +1160,31 @@ func (s *CodeReviewStore) GetListItemBySessionID(ctx context.Context, orgID, ses
 }
 
 type CodeReviewListFilters struct {
-	RepositoryID   *uuid.UUID
-	Decision       *models.CodeReviewDecision
-	Outcome        *models.CodeReviewListOutcome
-	ActivityStatus *models.CodeReviewActivityStatus
-	Status         *models.CodeReviewSessionStatus
-	Acceptable     *bool
-	Search         string
-	Limit          int
-	CreatedAfter   *time.Time
-	CreatedBefore  *time.Time
+	RepositoryID    *uuid.UUID
+	Decision        *models.CodeReviewDecision
+	Outcome         *models.CodeReviewListOutcome
+	ActivityStatus  *models.CodeReviewActivityStatus
+	Status          *models.CodeReviewSessionStatus
+	Acceptable      *bool
+	Search          string
+	Limit           int
+	CreatedAfter    *time.Time
+	CreatedBefore   *time.Time
+	SortBy          string
+	SortOrder       string
+	CursorSortValue any
+	CursorSortNull  bool
 	// Cursor is the metadata row ID of the last item from the previous page.
-	// Rows strictly after it in the (created_at DESC, id DESC) order are
-	// returned, matching the session-history keyset pagination contract.
+	// In the default order, rows strictly after it in (created_at DESC, id DESC)
+	// are returned, matching the session-history keyset pagination contract; both
+	// anchors are immutable, so a page boundary never moves.
+	//
+	// An explicit SortBy anchors on CursorSortValue instead, and every sort
+	// except repository and pull_request reads a column that changes as a review
+	// progresses (queued -> running -> completed). A row whose sort value changes
+	// mid-pagination can therefore be skipped or repeated across pages. That is
+	// accepted here: the list polls live and the sorted views are for scanning,
+	// not for exhaustive one-pass export.
 	Cursor          *uuid.UUID
 	CursorCreatedAt *time.Time
 }
@@ -1281,19 +1293,234 @@ func codeReviewListWhere(orgID uuid.UUID, filters CodeReviewListFilters, include
 }
 
 func (s *CodeReviewStore) listReviews(ctx context.Context, orgID uuid.UUID, filters CodeReviewListFilters, limit int) ([]models.CodeReviewListItem, error) {
-	where, args, err := codeReviewListWhere(orgID, filters, true)
+	where, args, err := codeReviewListWhere(orgID, filters, filters.SortBy == "")
 	if err != nil {
 		return nil, err
 	}
+	if filters.SortBy != "" && filters.Cursor != nil {
+		cursorWhere, cursorArgs, err := codeReviewSortedCursorPredicate(filters)
+		if err != nil {
+			return nil, err
+		}
+		where += cursorWhere
+		for key, value := range cursorArgs {
+			args[key] = value
+		}
+	}
 	args["limit"] = limit
-	query := codeReviewListItemSelect + where + `
-		ORDER BY m.created_at DESC, m.id DESC
+	orderBy, err := codeReviewListOrderBy(filters.SortBy, filters.SortOrder)
+	if err != nil {
+		return nil, err
+	}
+	query := codeReviewListItemSelect + where + orderBy + `
 		LIMIT @limit`
 	rows, err := s.db.Query(ctx, query, args)
 	if err != nil {
 		return nil, fmt.Errorf("query code review list: %w", err)
 	}
 	return pgx.CollectRows(rows, pgx.RowToStructByName[models.CodeReviewListItem])
+}
+
+// codeReviewSupersededSQL mirrors the isSupersededReview() predicate the
+// reviews table uses to blank out a row's outcome, risk, and run status.
+const codeReviewSupersededSQL = `(m.stale OR m.status = 'stale' OR m.superseded_by_session_id IS NOT NULL)`
+
+// The outcome, risk, and run status cells render labels derived from several
+// columns rather than the columns themselves, so sorting on the raw column
+// splits one displayed label across the result (a NULL and a false `acceptable`
+// both read "Review needed") and scatters superseded rows through every group.
+// These rank expressions order by the label the row actually shows;
+// CodeReviewSortRankForItem computes the identical rank for the page cursor and
+// is kept in lockstep by TestCodeReviewSortRankMatchesSQL.
+const (
+	codeReviewOutcomeRankSQL = `(CASE
+			WHEN ` + codeReviewSupersededSQL + ` THEN 6
+			WHEN m.status = 'completed' AND m.decision = 'approved' AND m.github_review_id IS NOT NULL THEN 0
+			WHEN m.decision = 'approved' THEN 1
+			WHEN m.decision = 'needs_human_review' THEN 2
+			WHEN m.decision = 'blocked' THEN 3
+			WHEN m.decision = 'comment_only' THEN 4
+			ELSE 5
+		END)`
+	codeReviewRiskRankSQL = `(CASE
+			WHEN ` + codeReviewSupersededSQL + ` THEN 2
+			WHEN m.acceptable THEN 0
+			ELSE 1
+		END)`
+	// Queued and running rows label themselves with their phase; the phase
+	// labels live in the frontend, so those rows sort as one lifecycle group
+	// and fall back to the row ID within it.
+	codeReviewRunStatusRankSQL = `(CASE
+			WHEN ` + codeReviewSupersededSQL + ` THEN 5
+			WHEN m.status = 'queued' THEN 0
+			WHEN m.status = 'running' THEN 1
+			WHEN m.status = 'completed' THEN 2
+			WHEN m.status = 'failed' THEN 3
+			WHEN m.status = 'cancelled' THEN 4
+			ELSE 6
+		END)`
+)
+
+// codeReviewListSort is one allowlisted ordering: the expression it orders by,
+// and whether that expression can be NULL. Nullability decides both the NULLS
+// LAST clause and whether a page cursor may anchor on the null partition.
+type codeReviewListSort struct {
+	expression string
+	nullable   bool
+}
+
+// pull_requests.github_pr_number and repositories.full_name are NOT NULL behind
+// inner joins, and the rank expressions always return an integer, so only
+// completed_at can order a null partition.
+var codeReviewListSorts = map[string]codeReviewListSort{
+	"pull_request": {expression: "pr.github_pr_number"},
+	"outcome":      {expression: codeReviewOutcomeRankSQL},
+	"risk":         {expression: codeReviewRiskRankSQL},
+	"run_status":   {expression: codeReviewRunStatusRankSQL},
+	"repository":   {expression: "r.full_name"},
+	"completed":    {expression: "m.completed_at", nullable: true},
+}
+
+// CodeReviewListSortIsNullable reports whether a page cursor for this sort may
+// anchor on a null value. Anchoring on a partition the column cannot produce
+// would silently return an empty page and end pagination early.
+func CodeReviewListSortIsNullable(sortBy string) (bool, error) {
+	sort, err := codeReviewListSortFor(sortBy)
+	if err != nil {
+		return false, err
+	}
+	return sort.nullable, nil
+}
+
+func codeReviewListSortFor(sortBy string) (codeReviewListSort, error) {
+	sort, ok := codeReviewListSorts[sortBy]
+	if !ok {
+		return codeReviewListSort{}, fmt.Errorf("unsupported code review sort: %q", sortBy)
+	}
+	return sort, nil
+}
+
+// CodeReviewSortRankForItem returns the displayed-label rank for the label-
+// derived sorts, matching the CASE expressions above so a page cursor anchors
+// on the same value the ORDER BY produced. ok is false for sorts that anchor on
+// a plain column value instead.
+func CodeReviewSortRankForItem(sortBy string, item models.CodeReviewListItem) (int, bool) {
+	superseded := item.Stale || item.Status == models.CodeReviewSessionStatusStale || item.SupersededBySessionID != nil
+	decision := ""
+	if item.Decision != nil {
+		decision = string(*item.Decision)
+	}
+	switch sortBy {
+	case "outcome":
+		switch {
+		case superseded:
+			return 6, true
+		case item.Status == models.CodeReviewSessionStatusCompleted && decision == "approved" && item.GitHubReviewID != nil:
+			return 0, true
+		case decision == "approved":
+			return 1, true
+		case decision == "needs_human_review":
+			return 2, true
+		case decision == "blocked":
+			return 3, true
+		case decision == "comment_only":
+			return 4, true
+		default:
+			return 5, true
+		}
+	case "risk":
+		switch {
+		case superseded:
+			return 2, true
+		case item.Acceptable != nil && *item.Acceptable:
+			return 0, true
+		default:
+			return 1, true
+		}
+	case "run_status":
+		switch {
+		case superseded:
+			return 5, true
+		case item.Status == models.CodeReviewSessionStatusQueued:
+			return 0, true
+		case item.Status == models.CodeReviewSessionStatusRunning:
+			return 1, true
+		case item.Status == models.CodeReviewSessionStatusCompleted:
+			return 2, true
+		case item.Status == models.CodeReviewSessionStatusFailed:
+			return 3, true
+		case item.Status == models.CodeReviewSessionStatusCancelled:
+			return 4, true
+		default:
+			return 6, true
+		}
+	default:
+		return 0, false
+	}
+}
+
+// codeReviewSortedRecency is the secondary ordering every explicit sort falls
+// back to. The rank sorts have only a handful of distinct values, so without it
+// the order within a group would come from the random UUID primary key instead
+// of the newest-first order the list shows by default.
+const codeReviewSortedRecency = `m.created_at DESC, m.id DESC`
+
+func codeReviewListOrderBy(sortBy, sortOrder string) (string, error) {
+	if sortBy == "" {
+		return ` ORDER BY ` + codeReviewSortedRecency, nil
+	}
+	sort, err := codeReviewListSortFor(sortBy)
+	if err != nil {
+		return "", err
+	}
+	direction := "ASC"
+	if sortOrder == "desc" {
+		direction = "DESC"
+	} else if sortOrder != "" && sortOrder != "asc" {
+		return "", fmt.Errorf("unsupported code review sort order: %q", sortOrder)
+	}
+	nulls := ""
+	if sort.nullable {
+		nulls = " NULLS LAST"
+	}
+	return ` ORDER BY ` + sort.expression + ` ` + direction + nulls + `, ` + codeReviewSortedRecency, nil
+}
+
+func codeReviewSortedCursorPredicate(filters CodeReviewListFilters) (string, pgx.NamedArgs, error) {
+	sort, err := codeReviewListSortFor(filters.SortBy)
+	if err != nil {
+		return "", nil, err
+	}
+	comparison := ">"
+	if filters.SortOrder == "desc" {
+		comparison = "<"
+	} else if filters.SortOrder != "asc" {
+		return "", nil, fmt.Errorf("unsupported code review sort order: %q", filters.SortOrder)
+	}
+	if filters.CursorCreatedAt == nil {
+		return "", nil, errors.New("sorted code review cursor is missing its recency anchor")
+	}
+	args := pgx.NamedArgs{"cursor": *filters.Cursor, "cursor_created_at": *filters.CursorCreatedAt}
+	// The secondary key is fixed at (created_at DESC, id DESC), so the tuple
+	// comparison stays "<" whichever way the primary key is ordered.
+	recency := `(m.created_at, m.id) < (@cursor_created_at, @cursor)`
+	if filters.CursorSortNull {
+		if !sort.nullable {
+			return "", nil, fmt.Errorf("code review sort %q cannot anchor on a null value", filters.SortBy)
+		}
+		return ` AND (` + sort.expression + ` IS NULL AND ` + recency + `)`, args, nil
+	}
+	if filters.CursorSortValue == nil {
+		return "", nil, errors.New("sorted code review cursor value is missing")
+	}
+	args["cursor_sort_value"] = filters.CursorSortValue
+	predicate := ` AND ((` + sort.expression + ` ` + comparison + ` @cursor_sort_value)
+		OR (` + sort.expression + ` = @cursor_sort_value AND ` + recency + `)`
+	if sort.nullable {
+		predicate += `
+		OR ` + sort.expression + ` IS NULL`
+	}
+	return predicate + `)`, args, nil
 }
 
 type CodeReviewStatsFilters struct {
@@ -1309,9 +1536,17 @@ type CodeReviewStatsFilters struct {
 }
 
 type CodeReviewAnalyticsFilters struct {
-	RepositoryID  *uuid.UUID
-	CreatedAfter  *time.Time
-	CreatedBefore *time.Time
+	RepositoryID    *uuid.UUID
+	Decision        *models.CodeReviewDecision
+	Outcome         *models.CodeReviewListOutcome
+	ActivityStatus  *models.CodeReviewActivityStatus
+	Status          *models.CodeReviewSessionStatus
+	Acceptable      *bool
+	Search          string
+	CreatedAfter    *time.Time
+	CreatedBefore   *time.Time
+	AuthorSortBy    string
+	AuthorSortOrder string
 }
 
 func (s *CodeReviewStore) ListReviews(ctx context.Context, orgID uuid.UUID, filters CodeReviewListFilters) ([]models.CodeReviewListItem, error) {
@@ -1457,22 +1692,12 @@ func (s *CodeReviewStore) GetReviewStats(ctx context.Context, orgID uuid.UUID, f
 	return stats, nil
 }
 
-func codeReviewAnalyticsWhere(orgID uuid.UUID, filters CodeReviewAnalyticsFilters) (string, pgx.NamedArgs) {
-	args := pgx.NamedArgs{"org_id": orgID}
-	query := ` WHERE m.org_id = @org_id`
-	if filters.RepositoryID != nil {
-		query += ` AND m.repository_id = @repository_id`
-		args["repository_id"] = *filters.RepositoryID
-	}
-	if filters.CreatedAfter != nil {
-		query += ` AND m.created_at >= @created_after`
-		args["created_after"] = *filters.CreatedAfter
-	}
-	if filters.CreatedBefore != nil {
-		query += ` AND m.created_at <= @created_before`
-		args["created_before"] = *filters.CreatedBefore
-	}
-	return query, args
+func codeReviewAnalyticsWhere(orgID uuid.UUID, filters CodeReviewAnalyticsFilters) (string, pgx.NamedArgs, error) {
+	return codeReviewListWhere(orgID, CodeReviewListFilters{
+		RepositoryID: filters.RepositoryID, Decision: filters.Decision, Outcome: filters.Outcome,
+		ActivityStatus: filters.ActivityStatus, Status: filters.Status, Acceptable: filters.Acceptable,
+		Search: filters.Search, CreatedAfter: filters.CreatedAfter, CreatedBefore: filters.CreatedBefore,
+	}, false)
 }
 
 func codeReviewOptionalMetric(value float64) *float64 {
@@ -1483,7 +1708,14 @@ func codeReviewOptionalMetric(value float64) *float64 {
 }
 
 func (s *CodeReviewStore) GetReviewAnalytics(ctx context.Context, orgID uuid.UUID, filters CodeReviewAnalyticsFilters) (models.CodeReviewAnalytics, error) {
-	where, args := codeReviewAnalyticsWhere(orgID, filters)
+	where, args, err := codeReviewAnalyticsWhere(orgID, filters)
+	if err != nil {
+		return models.CodeReviewAnalytics{}, err
+	}
+	authorOrder, err := codeReviewAuthorAnalyticsOrder(filters.AuthorSortBy, filters.AuthorSortOrder)
+	if err != nil {
+		return models.CodeReviewAnalytics{}, err
+	}
 	// Keep every report section in one statement so PostgreSQL evaluates the
 	// response against one MVCC snapshot. Materializing the filtered review set
 	// also prevents each aggregation from rescanning unrelated org history.
@@ -1505,6 +1737,7 @@ func (s *CodeReviewStore) GetReviewAnalytics(ctx context.Context, orgID uuid.UUI
 				COALESCE(NULLIF(p.risk_policy->>'max_files_changed', '')::bigint, 9223372036854775807) AS max_files_changed
 			FROM code_review_session_metadata m
 			JOIN sessions s ON s.id = m.session_id AND s.org_id = m.org_id
+			JOIN pull_requests pr ON pr.id = m.pull_request_id AND pr.org_id = m.org_id
 			JOIN code_review_policies p ON p.id = m.policy_id AND p.org_id = m.org_id` + where + `
 		),
 		finding_rollup AS (
@@ -1688,7 +1921,7 @@ func (s *CodeReviewStore) GetReviewAnalytics(ctx context.Context, orgID uuid.UUI
 			summary.reviews_with_blocking_findings,
 			summary.total_findings,
 			COALESCE((
-				SELECT jsonb_agg(to_jsonb(a) ORDER BY a.reviews_completed DESC, a.author ASC)
+				SELECT jsonb_agg(to_jsonb(a) ORDER BY ` + authorOrder + `)
 				FROM authors a
 			), '[]'::jsonb) AS authors,
 			COALESCE((
@@ -1772,6 +2005,34 @@ func (s *CodeReviewStore) GetReviewAnalytics(ctx context.Context, orgID uuid.UUI
 		}
 	}
 	return analytics, nil
+}
+
+func codeReviewAuthorAnalyticsOrder(sortBy, sortOrder string) (string, error) {
+	columns := map[string]string{
+		"author": "a.author", "reviews": "a.reviews_completed", "approved": "a.automatically_approved",
+		"not_approved":  "a.not_approved",
+		"approval_rate": "(a.automatically_approved::double precision / NULLIF(a.reviews_completed, 0))",
+		// The cell shows "<breakdown> / <completed>", so order by that ratio
+		// rather than the numerator alone: "9 / 12" must not outrank "8 / 8".
+		"split_sample":      "(a.reviews_with_change_breakdown::double precision / NULLIF(a.reviews_completed, 0))",
+		"average_additions": "a.average_additions",
+		"median_additions":  "a.median_additions", "average_deletions": "a.average_deletions",
+		"median_deletions": "a.median_deletions",
+	}
+	if sortBy == "" {
+		return "a.reviews_completed DESC, a.author ASC", nil
+	}
+	column, ok := columns[sortBy]
+	if !ok {
+		return "", fmt.Errorf("unsupported code review author sort: %q", sortBy)
+	}
+	direction := "ASC"
+	if sortOrder == "desc" {
+		direction = "DESC"
+	} else if sortOrder != "" && sortOrder != "asc" {
+		return "", fmt.Errorf("unsupported code review author sort order: %q", sortOrder)
+	}
+	return column + " " + direction + " NULLS LAST, a.author ASC", nil
 }
 
 func (s *CodeReviewStore) CreateAgentResult(ctx context.Context, result *models.CodeReviewAgentResult) error {

--- a/internal/db/code_reviews_postgres_test.go
+++ b/internal/db/code_reviews_postgres_test.go
@@ -392,6 +392,7 @@ func TestCodeReviewStore_GetReviewAnalyticsPostgresBehavior(t *testing.T) {
 // they assign the same rank to the same row. Without it, transposing two
 // branches on one side alone would quietly anchor cursors in the wrong label
 // group and drop rows from the sorted list.
+//nolint:paralleltest // sort subtests share one PostgreSQL connection and isolated schema, so they must run serially
 func TestCodeReviewSortRankMatchesPostgresForEveryRow(t *testing.T) {
 	t.Parallel()
 

--- a/internal/db/code_reviews_postgres_test.go
+++ b/internal/db/code_reviews_postgres_test.go
@@ -2,6 +2,7 @@ package db
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"strings"
 	"testing"
@@ -42,6 +43,7 @@ func TestCodeReviewStore_GetReviewAnalyticsPostgresBehavior(t *testing.T) {
 		CREATE TABLE sessions (
 			id uuid PRIMARY KEY,
 			org_id uuid NOT NULL,
+			title text,
 			revision_context jsonb
 		);
 		CREATE TABLE code_review_policies (
@@ -49,13 +51,24 @@ func TestCodeReviewStore_GetReviewAnalyticsPostgresBehavior(t *testing.T) {
 			org_id uuid NOT NULL,
 			risk_policy jsonb NOT NULL
 		);
+		CREATE TABLE pull_requests (
+			id uuid PRIMARY KEY,
+			org_id uuid NOT NULL,
+			title text NOT NULL,
+			github_repo text NOT NULL,
+			github_pr_number int NOT NULL
+		);
 		CREATE TABLE code_review_session_metadata (
 			id uuid PRIMARY KEY,
 			org_id uuid NOT NULL,
 			session_id uuid NOT NULL,
 			repository_id uuid NOT NULL,
+			pull_request_id uuid NOT NULL,
 			policy_id uuid NOT NULL,
 			status text NOT NULL,
+			stale boolean NOT NULL DEFAULT false,
+			superseded_by_session_id uuid,
+			acceptable boolean,
 			decision text,
 			github_review_id bigint,
 			lines_changed integer,
@@ -111,6 +124,7 @@ func TestCodeReviewStore_GetReviewAnalyticsPostgresBehavior(t *testing.T) {
 	)
 	require.NoError(t, err, "test should insert analytics session attribution")
 
+	var insertedPullRequestNumbers []int
 	insertReview := func(
 		id, reviewOrgID, sessionID, reviewRepositoryID, reviewPolicyID uuid.UUID,
 		status string,
@@ -121,13 +135,25 @@ func TestCodeReviewStore_GetReviewAnalyticsPostgresBehavior(t *testing.T) {
 		createdAt time.Time,
 	) {
 		t.Helper()
+		// The analytics report joins pull_requests so it can share the reviews
+		// list filter builder (title/repo/number search), so every fact needs a
+		// pull request of its own.
+		pullRequestID := uuid.New()
+		pullRequestNumber := len(insertedPullRequestNumbers) + 1
+		insertedPullRequestNumbers = append(insertedPullRequestNumbers, pullRequestNumber)
+		_, prErr := conn.Exec(ctx, `
+			INSERT INTO pull_requests (id, org_id, title, github_repo, github_pr_number)
+			VALUES ($1, $2, $3, 'acme/api', $4)`,
+			pullRequestID, reviewOrgID, fmt.Sprintf("Ship feature %d", pullRequestNumber), pullRequestNumber,
+		)
+		require.NoError(t, prErr, "test should insert the pull request a review is attached to")
 		_, insertErr := conn.Exec(ctx, `
 			INSERT INTO code_review_session_metadata (
-				id, org_id, session_id, repository_id, policy_id, status, decision,
+				id, org_id, session_id, repository_id, pull_request_id, policy_id, status, decision,
 				github_review_id, lines_changed, additions, deletions, files_changed,
 				risk_reason_details, created_at
-			) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13::jsonb, $14)`,
-			id, reviewOrgID, sessionID, reviewRepositoryID, reviewPolicyID, status, decision,
+			) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14::jsonb, $15)`,
+			id, reviewOrgID, sessionID, reviewRepositoryID, pullRequestID, reviewPolicyID, status, decision,
 			githubReviewID, linesChanged, additions, deletions, filesChanged, riskReasons, createdAt,
 		)
 		require.NoError(t, insertErr, "test should insert a review analytics fact")
@@ -258,6 +284,49 @@ func TestCodeReviewStore_GetReviewAnalyticsPostgresBehavior(t *testing.T) {
 		},
 	}, analytics, "analytics should preserve outcome, author, size, reason, finding, time, and tenancy semantics")
 
+	// The report now reuses the reviews list WHERE builder, so its SQL reaches
+	// for pull_requests and sessions aliases that only exist because of the
+	// joins in the filtered_reviews CTE, and its author ordering is an
+	// interpolated expression. Execute every one of those against PostgreSQL:
+	// the pgxmock unit tests match on query text and cannot catch an unresolved
+	// alias or a malformed ORDER BY.
+	store := NewCodeReviewStore(conn)
+	currentActivity := models.CodeReviewActivityStatusCurrent
+	approvedOutcome := models.CodeReviewListOutcomeAutomaticallyApproved
+	for _, sortBy := range []string{
+		"", "author", "reviews", "approved", "not_approved", "approval_rate",
+		"split_sample", "average_additions", "median_additions", "average_deletions", "median_deletions",
+	} {
+		for _, sortOrder := range []string{"asc", "desc"} {
+			_, sortErr := store.GetReviewAnalytics(ctx, orgID, CodeReviewAnalyticsFilters{
+				RepositoryID:    &repositoryID,
+				CreatedAfter:    &createdAfter,
+				AuthorSortBy:    sortBy,
+				AuthorSortOrder: sortOrder,
+			})
+			require.NoErrorf(t, sortErr, "author sort %q %s should execute against PostgreSQL", sortBy, sortOrder)
+		}
+	}
+
+	searched, err := store.GetReviewAnalytics(ctx, orgID, CodeReviewAnalyticsFilters{
+		RepositoryID:   &repositoryID,
+		CreatedAfter:   &createdAfter,
+		Search:         "Ship feature",
+		ActivityStatus: &currentActivity,
+		Outcome:        &approvedOutcome,
+	})
+	require.NoError(t, err, "the shared list filters should resolve their joined aliases in the analytics CTE")
+	require.Equal(t, int64(2), searched.Summary.AutomaticallyApproved, "the outcome filter should narrow the report to posted approvals")
+	require.Equal(t, int64(2), searched.Summary.ReviewsRequested, "search, activity, and outcome filters should all apply")
+
+	unmatched, err := store.GetReviewAnalytics(ctx, orgID, CodeReviewAnalyticsFilters{
+		RepositoryID: &repositoryID,
+		CreatedAfter: &createdAfter,
+		Search:       "no pull request has this title",
+	})
+	require.NoError(t, err, "an unmatched search should still execute")
+	require.Equal(t, int64(0), unmatched.Summary.ReviewsRequested, "search should filter on the joined pull request columns")
+
 	otherLines := float64(smallLines)
 	otherAdditions := float64(smallAdditions)
 	otherDeletions := float64(smallDeletions)
@@ -315,4 +384,120 @@ func TestCodeReviewStore_GetReviewAnalyticsPostgresBehavior(t *testing.T) {
 		SizeBuckets:        []models.CodeReviewSizeBucketAnalytics{},
 		NonApprovalReasons: []models.CodeReviewNonApprovalReasonAnalytics{},
 	}, emptyAnalytics, "an organization without reviews should receive zero summary values and empty breakdowns")
+}
+
+// The rank a page cursor anchors on is computed in Go while the rank the
+// ORDER BY applies is computed in SQL. TestCodeReviewSortRankSQLCoversTheSame
+// Branches only proves both sides use the same set of rank values; this proves
+// they assign the same rank to the same row. Without it, transposing two
+// branches on one side alone would quietly anchor cursors in the wrong label
+// group and drop rows from the sorted list.
+func TestCodeReviewSortRankMatchesPostgresForEveryRow(t *testing.T) {
+	t.Parallel()
+
+	databaseURL := os.Getenv("TEST_DATABASE_URL")
+	if databaseURL == "" {
+		t.Skip("set TEST_DATABASE_URL to run the PostgreSQL sort rank equivalence test")
+	}
+
+	ctx := context.Background()
+	conn, err := pgx.Connect(ctx, databaseURL)
+	require.NoError(t, err, "test should connect to TEST_DATABASE_URL")
+	defer func() {
+		require.NoError(t, conn.Close(context.Background()), "test should close the PostgreSQL connection")
+	}()
+
+	schema := "test_code_review_sort_rank_" + strings.ReplaceAll(uuid.NewString(), "-", "_")
+	_, err = conn.Exec(ctx, `CREATE SCHEMA `+schema)
+	require.NoError(t, err, "test should create an isolated sort rank schema")
+	defer func() {
+		_, cleanupErr := conn.Exec(context.Background(), `DROP SCHEMA IF EXISTS `+schema+` CASCADE`)
+		require.NoError(t, cleanupErr, "test should remove the isolated sort rank schema")
+	}()
+	_, err = conn.Exec(ctx, `SET search_path TO `+schema+`, public`)
+	require.NoError(t, err, "test should isolate sort rank objects")
+
+	_, err = conn.Exec(ctx, `
+		CREATE TABLE code_review_session_metadata (
+			id uuid PRIMARY KEY,
+			status text NOT NULL,
+			stale boolean NOT NULL,
+			superseded_by_session_id uuid,
+			decision text,
+			acceptable boolean,
+			github_review_id bigint
+		)`)
+	require.NoError(t, err, "test should create the columns the rank expressions read")
+
+	statuses := []models.CodeReviewSessionStatus{
+		models.CodeReviewSessionStatusQueued, models.CodeReviewSessionStatusRunning,
+		models.CodeReviewSessionStatusCompleted, models.CodeReviewSessionStatusFailed,
+		models.CodeReviewSessionStatusStale, models.CodeReviewSessionStatusCancelled,
+	}
+	decisions := []*models.CodeReviewDecision{nil}
+	for _, decision := range []models.CodeReviewDecision{
+		models.CodeReviewDecisionApproved, models.CodeReviewDecisionNeedsHumanReview,
+		models.CodeReviewDecisionBlocked, models.CodeReviewDecisionCommentOnly,
+	} {
+		decisions = append(decisions, &decision)
+	}
+	reviewID := int64(1)
+	acceptable, notAcceptable := true, false
+	supersededSession := uuid.New()
+
+	expected := map[uuid.UUID]models.CodeReviewListItem{}
+	for _, status := range statuses {
+		for _, decision := range decisions {
+			for _, githubReviewID := range []*int64{nil, &reviewID} {
+				for _, riskValue := range []*bool{nil, &acceptable, &notAcceptable} {
+					for _, superseded := range []*uuid.UUID{nil, &supersededSession} {
+						for _, stale := range []bool{false, true} {
+							id := uuid.New()
+							expected[id] = models.CodeReviewListItem{
+								CodeReviewSessionMetadata: models.CodeReviewSessionMetadata{
+									ID: id, Status: status, Decision: decision, GitHubReviewID: githubReviewID,
+									Acceptable: riskValue, SupersededBySessionID: superseded, Stale: stale,
+								},
+							}
+							_, insertErr := conn.Exec(ctx, `
+								INSERT INTO code_review_session_metadata (
+									id, status, stale, superseded_by_session_id, decision, acceptable, github_review_id
+								) VALUES ($1, $2, $3, $4, $5, $6, $7)`,
+								id, status, stale, superseded, decision, riskValue, githubReviewID,
+							)
+							require.NoError(t, insertErr, "test should insert a rank combination")
+						}
+					}
+				}
+			}
+		}
+	}
+
+	for _, sortBy := range []string{"outcome", "risk", "run_status"} {
+		t.Run(sortBy, func(t *testing.T) {
+			sort, sortErr := codeReviewListSortFor(sortBy)
+			require.NoError(t, sortErr, "the sort should be allowlisted")
+
+			rows, queryErr := conn.Query(ctx, `SELECT m.id, `+sort.expression+` FROM code_review_session_metadata m`)
+			require.NoError(t, queryErr, "the rank expression should execute against PostgreSQL")
+			defer rows.Close()
+
+			seen := 0
+			for rows.Next() {
+				var id uuid.UUID
+				var sqlRank int
+				require.NoError(t, rows.Scan(&id, &sqlRank), "the rank expression should return an integer")
+				goRank, ok := CodeReviewSortRankForItem(sortBy, expected[id])
+				require.True(t, ok, "the Go rank should be defined for a label-derived sort")
+				require.Equalf(t, sqlRank, goRank,
+					"row %s (status=%s stale=%t superseded=%t decision=%v approval_posted=%t acceptable=%v) should rank identically in Go and SQL",
+					id, expected[id].Status, expected[id].Stale, expected[id].SupersededBySessionID != nil,
+					expected[id].Decision, expected[id].GitHubReviewID != nil, expected[id].Acceptable,
+				)
+				seen++
+			}
+			require.NoError(t, rows.Err(), "the rank query should complete")
+			require.Equal(t, len(expected), seen, "every seeded combination should be compared")
+		})
+	}
 }

--- a/internal/db/code_reviews_test.go
+++ b/internal/db/code_reviews_test.go
@@ -6,6 +6,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"regexp"
+	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -1470,6 +1472,376 @@ func TestCodeReviewStore_GetReviewAnalyticsReturnsDecisionReport(t *testing.T) {
 		},
 	}, analytics, "GetReviewAnalytics should return exact summary, author, size, and reason metrics")
 	require.NoError(t, mock.ExpectationsWereMet(), "the single analytics query should remain org and filter scoped")
+}
+
+func TestCodeReviewListOrderBy(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		sortBy    string
+		sortOrder string
+		expected  string
+		expectErr bool
+	}{
+		{name: "default", expected: " ORDER BY m.created_at DESC, m.id DESC"},
+		// Recency stays the secondary key so rows within one sort group keep the
+		// newest-first order instead of falling back to the random UUID key, and
+		// NULLS LAST appears only for the one sort that can produce a null.
+		{name: "repository ascending", sortBy: "repository", sortOrder: "asc", expected: " ORDER BY r.full_name ASC, m.created_at DESC, m.id DESC"},
+		{name: "completed descending", sortBy: "completed", sortOrder: "desc", expected: " ORDER BY m.completed_at DESC NULLS LAST, m.created_at DESC, m.id DESC"},
+		{name: "rank sorts break ties by recency", sortBy: "risk", sortOrder: "asc", expected: " ORDER BY " + codeReviewRiskRankSQL + " ASC, m.created_at DESC, m.id DESC"},
+		{name: "rejects unknown column", sortBy: "created_at; DROP TABLE sessions", expectErr: true},
+		{name: "rejects unknown direction", sortBy: "outcome", sortOrder: "sideways", expectErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			actual, err := codeReviewListOrderBy(tt.sortBy, tt.sortOrder)
+			if tt.expectErr {
+				require.Error(t, err, "invalid sort input should be rejected")
+				return
+			}
+			require.NoError(t, err, "supported sort input should be accepted")
+			require.Equal(t, tt.expected, actual, "sort input should map to the exact allowlisted SQL clause")
+		})
+	}
+}
+
+func TestCodeReviewSortedCursorPredicate(t *testing.T) {
+	t.Parallel()
+
+	cursorID := uuid.New()
+	cursorCreatedAt := time.Date(2026, 7, 20, 9, 30, 0, 0, time.UTC)
+	tests := []struct {
+		name           string
+		filters        CodeReviewListFilters
+		expectedWhere  string
+		expectedValue  any
+		expectsNullArm bool
+	}{
+		{
+			name: "ascending non-null value",
+			filters: CodeReviewListFilters{
+				SortBy: "repository", SortOrder: "asc", CursorSortValue: "acme/api",
+			},
+			expectedWhere: "r.full_name > @cursor_sort_value",
+			expectedValue: "acme/api",
+		},
+		{
+			name: "descending non-null value includes later nulls",
+			filters: CodeReviewListFilters{
+				SortBy: "completed", SortOrder: "desc", CursorSortValue: time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC),
+			},
+			expectedWhere:  "m.completed_at < @cursor_sort_value",
+			expectedValue:  time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC),
+			expectsNullArm: true,
+		},
+		{
+			name: "null value remains within null partition",
+			filters: CodeReviewListFilters{
+				SortBy: "completed", SortOrder: "asc", CursorSortNull: true,
+			},
+			expectedWhere: "m.completed_at IS NULL AND (m.created_at, m.id) < (@cursor_created_at, @cursor)",
+		},
+		{
+			name: "label-derived sort anchors on the displayed rank",
+			filters: CodeReviewListFilters{
+				SortBy: "risk", SortOrder: "asc", CursorSortValue: 1,
+			},
+			expectedWhere: "WHEN m.acceptable THEN 0",
+			expectedValue: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			filters := tt.filters
+			filters.Cursor = &cursorID
+			filters.CursorCreatedAt = &cursorCreatedAt
+
+			where, args, err := codeReviewSortedCursorPredicate(filters)
+
+			require.NoError(t, err, "valid sorted cursors should produce a keyset predicate")
+			require.Contains(t, where, tt.expectedWhere, "keyset predicate should use the selected direction and null partition")
+			require.Equal(t, cursorID, args["cursor"], "keyset predicate should retain the stable row ID tiebreaker")
+			require.Equal(t, cursorCreatedAt, args["cursor_created_at"], "keyset predicate should bind the recency tiebreaker")
+			if tt.expectedValue != nil {
+				require.Equal(t, tt.expectedValue, args["cursor_sort_value"], "keyset predicate should bind the typed sort anchor")
+				require.Contains(t, where,
+					"AND (m.created_at, m.id) < (@cursor_created_at, @cursor)",
+					"rows tied on the sort value should continue in the newest-first order the table shows",
+				)
+			}
+			// Only completed_at can be null, so only it should widen the page to
+			// the trailing null partition.
+			require.Equal(t, tt.expectsNullArm, strings.Contains(where, "OR m.completed_at IS NULL"),
+				"the trailing null partition should appear only for a nullable sort")
+		})
+	}
+}
+
+func TestCodeReviewSortedCursorPredicateRejectsUnusableAnchors(t *testing.T) {
+	t.Parallel()
+
+	cursorID := uuid.New()
+	cursorCreatedAt := time.Date(2026, 7, 20, 9, 30, 0, 0, time.UTC)
+
+	_, _, err := codeReviewSortedCursorPredicate(CodeReviewListFilters{
+		SortBy: "repository", SortOrder: "asc", Cursor: &cursorID, CursorSortValue: "acme/api",
+	})
+	require.Error(t, err, "a sorted cursor without its recency anchor cannot page deterministically")
+
+	// repositories.full_name is NOT NULL behind an inner join, so a null anchor
+	// would silently select a partition holding no rows.
+	_, _, err = codeReviewSortedCursorPredicate(CodeReviewListFilters{
+		SortBy: "repository", SortOrder: "asc", Cursor: &cursorID,
+		CursorCreatedAt: &cursorCreatedAt, CursorSortNull: true,
+	})
+	require.Error(t, err, "a non-nullable sort should refuse a null cursor anchor")
+
+	nullable, err := CodeReviewListSortIsNullable("completed")
+	require.NoError(t, err, "an allowlisted sort should report its nullability")
+	require.True(t, nullable, "completed_at is the one sort that can order a null partition")
+	for _, sortBy := range []string{"pull_request", "outcome", "risk", "run_status", "repository"} {
+		nullable, err := CodeReviewListSortIsNullable(sortBy)
+		require.NoErrorf(t, err, "%q should be allowlisted", sortBy)
+		require.Falsef(t, nullable, "%q orders a NOT NULL column or a total rank", sortBy)
+	}
+	_, err = CodeReviewListSortIsNullable("unsupported")
+	require.Error(t, err, "an unknown sort should not report nullability")
+}
+
+func TestCodeReviewSortRankForItemGroupsRowsByDisplayedLabel(t *testing.T) {
+	t.Parallel()
+
+	supersededSession := uuid.New()
+	reviewID := int64(9001)
+	approved := models.CodeReviewDecisionApproved
+	needsHuman := models.CodeReviewDecisionNeedsHumanReview
+	blocked := models.CodeReviewDecisionBlocked
+	commentOnly := models.CodeReviewDecisionCommentOnly
+	acceptable, notAcceptable := true, false
+
+	tests := []struct {
+		name     string
+		sortBy   string
+		meta     models.CodeReviewSessionMetadata
+		expected int
+	}{
+		// Outcome: the cell reads "Approved" only once the approval is posted,
+		// and superseded rows read "No outcome" whatever the decision says.
+		{
+			name:   "posted approval outranks an unposted one",
+			sortBy: "outcome",
+			meta: models.CodeReviewSessionMetadata{
+				Status: models.CodeReviewSessionStatusCompleted, Decision: &approved, GitHubReviewID: &reviewID,
+			},
+			expected: 0,
+		},
+		{
+			name:     "approval that was never posted sorts apart from posted approvals",
+			sortBy:   "outcome",
+			meta:     models.CodeReviewSessionMetadata{Status: models.CodeReviewSessionStatusCompleted, Decision: &approved},
+			expected: 1,
+		},
+		{
+			name:     "review needed",
+			sortBy:   "outcome",
+			meta:     models.CodeReviewSessionMetadata{Status: models.CodeReviewSessionStatusCompleted, Decision: &needsHuman},
+			expected: 2,
+		},
+		{
+			name:     "blocked",
+			sortBy:   "outcome",
+			meta:     models.CodeReviewSessionMetadata{Status: models.CodeReviewSessionStatusCompleted, Decision: &blocked},
+			expected: 3,
+		},
+		{
+			name:     "comment only",
+			sortBy:   "outcome",
+			meta:     models.CodeReviewSessionMetadata{Status: models.CodeReviewSessionStatusCompleted, Decision: &commentOnly},
+			expected: 4,
+		},
+		{
+			name:     "an undecided review is pending",
+			sortBy:   "outcome",
+			meta:     models.CodeReviewSessionMetadata{Status: models.CodeReviewSessionStatusRunning},
+			expected: 5,
+		},
+		{
+			name:   "a superseded approval still reads as no outcome",
+			sortBy: "outcome",
+			meta: models.CodeReviewSessionMetadata{
+				Status: models.CodeReviewSessionStatusCompleted, Decision: &approved,
+				GitHubReviewID: &reviewID, SupersededBySessionID: &supersededSession,
+			},
+			expected: 6,
+		},
+		// Risk: an unset acceptable renders "Review needed" exactly like an
+		// explicit false, so the two have to share a rank.
+		{
+			name:     "acceptable risk",
+			sortBy:   "risk",
+			meta:     models.CodeReviewSessionMetadata{Status: models.CodeReviewSessionStatusCompleted, Acceptable: &acceptable},
+			expected: 0,
+		},
+		{
+			name:     "unacceptable risk",
+			sortBy:   "risk",
+			meta:     models.CodeReviewSessionMetadata{Status: models.CodeReviewSessionStatusCompleted, Acceptable: &notAcceptable},
+			expected: 1,
+		},
+		{
+			name:     "unset risk shares the review-needed rank",
+			sortBy:   "risk",
+			meta:     models.CodeReviewSessionMetadata{Status: models.CodeReviewSessionStatusRunning},
+			expected: 1,
+		},
+		{
+			name:   "superseded risk is not applicable",
+			sortBy: "risk",
+			meta: models.CodeReviewSessionMetadata{
+				Status: models.CodeReviewSessionStatusCompleted, Acceptable: &acceptable, Stale: true,
+			},
+			expected: 2,
+		},
+		// Run status: ordered by lifecycle stage rather than the status string.
+		{name: "queued run", sortBy: "run_status", meta: models.CodeReviewSessionMetadata{Status: models.CodeReviewSessionStatusQueued}, expected: 0},
+		{name: "running run", sortBy: "run_status", meta: models.CodeReviewSessionMetadata{Status: models.CodeReviewSessionStatusRunning}, expected: 1},
+		{name: "completed run", sortBy: "run_status", meta: models.CodeReviewSessionMetadata{Status: models.CodeReviewSessionStatusCompleted}, expected: 2},
+		{name: "failed run", sortBy: "run_status", meta: models.CodeReviewSessionMetadata{Status: models.CodeReviewSessionStatusFailed}, expected: 3},
+		{name: "cancelled run", sortBy: "run_status", meta: models.CodeReviewSessionMetadata{Status: models.CodeReviewSessionStatusCancelled}, expected: 4},
+		{
+			name:     "stale run status is superseded",
+			sortBy:   "run_status",
+			meta:     models.CodeReviewSessionMetadata{Status: models.CodeReviewSessionStatusStale},
+			expected: 5,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			rank, ok := CodeReviewSortRankForItem(tt.sortBy, models.CodeReviewListItem{CodeReviewSessionMetadata: tt.meta})
+			require.True(t, ok, "label-derived sorts should produce a rank cursor anchor")
+			require.Equal(t, tt.expected, rank, "the cursor rank should match the rank the ORDER BY assigns")
+		})
+	}
+
+	for _, sortBy := range []string{"", "pull_request", "repository", "completed", "unsupported"} {
+		_, ok := CodeReviewSortRankForItem(sortBy, models.CodeReviewListItem{})
+		require.Falsef(t, ok, "%q anchors on a column value rather than a displayed-label rank", sortBy)
+	}
+}
+
+// The rank the cursor carries and the rank the ORDER BY computes live in two
+// languages, so at minimum every branch on one side must exist on the other.
+func TestCodeReviewSortRankSQLCoversTheSameBranches(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		sortBy string
+		sql    string
+	}{
+		{sortBy: "outcome", sql: codeReviewOutcomeRankSQL},
+		{sortBy: "risk", sql: codeReviewRiskRankSQL},
+		{sortBy: "run_status", sql: codeReviewRunStatusRankSQL},
+	}
+
+	statuses := []models.CodeReviewSessionStatus{
+		models.CodeReviewSessionStatusQueued, models.CodeReviewSessionStatusRunning,
+		models.CodeReviewSessionStatusCompleted, models.CodeReviewSessionStatusFailed,
+		models.CodeReviewSessionStatusStale, models.CodeReviewSessionStatusCancelled,
+		// Both sides keep a defensive fallback for a status neither knows yet.
+		models.CodeReviewSessionStatus("unrecognized_future_status"),
+	}
+	decisions := []*models.CodeReviewDecision{nil}
+	for _, decision := range []models.CodeReviewDecision{
+		models.CodeReviewDecisionApproved, models.CodeReviewDecisionNeedsHumanReview,
+		models.CodeReviewDecisionBlocked, models.CodeReviewDecisionCommentOnly,
+	} {
+		decisions = append(decisions, &decision)
+	}
+	reviewID := int64(1)
+	acceptable, notAcceptable := true, false
+	supersededSession := uuid.New()
+
+	var items []models.CodeReviewListItem
+	for _, status := range statuses {
+		for _, decision := range decisions {
+			for _, githubReviewID := range []*int64{nil, &reviewID} {
+				for _, riskValue := range []*bool{nil, &acceptable, &notAcceptable} {
+					for _, superseded := range []*uuid.UUID{nil, &supersededSession} {
+						for _, stale := range []bool{false, true} {
+							items = append(items, models.CodeReviewListItem{
+								CodeReviewSessionMetadata: models.CodeReviewSessionMetadata{
+									Status: status, Decision: decision, GitHubReviewID: githubReviewID,
+									Acceptable: riskValue, SupersededBySessionID: superseded, Stale: stale,
+								},
+							})
+						}
+					}
+				}
+			}
+		}
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.sortBy, func(t *testing.T) {
+			t.Parallel()
+
+			goRanks := map[int]bool{}
+			for _, item := range items {
+				rank, ok := CodeReviewSortRankForItem(tt.sortBy, item)
+				require.True(t, ok, "every combination should rank")
+				goRanks[rank] = true
+			}
+
+			sqlRanks := map[int]bool{}
+			for _, match := range regexp.MustCompile(`THEN (\d+)|ELSE (\d+)`).FindAllStringSubmatch(tt.sql, -1) {
+				digits := match[1]
+				if digits == "" {
+					digits = match[2]
+				}
+				rank, convErr := strconv.Atoi(digits)
+				require.NoError(t, convErr, "rank branches should be integers")
+				sqlRanks[rank] = true
+			}
+
+			require.Equal(t, sqlRanks, goRanks, "the Go cursor rank and the SQL ORDER BY rank should cover identical branches")
+		})
+	}
+}
+
+func TestCodeReviewAuthorAnalyticsOrder(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		sortBy    string
+		sortOrder string
+		expectErr bool
+	}{
+		{name: "default"},
+		{name: "author ascending", sortBy: "author", sortOrder: "asc"},
+		{name: "approval rate descending", sortBy: "approval_rate", sortOrder: "desc"},
+		{name: "rejects unknown column", sortBy: "unsafe", expectErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			order, err := codeReviewAuthorAnalyticsOrder(tt.sortBy, tt.sortOrder)
+			if tt.expectErr {
+				require.Error(t, err, "invalid analytics sort input should be rejected")
+				return
+			}
+			require.NoError(t, err, "supported analytics sort input should be accepted")
+			require.NotEmpty(t, order, "supported analytics sort input should produce an order clause")
+		})
+	}
 }
 
 func TestCodeReviewStore_ListReviewsPageReturnsExactCountForEmptyPage(t *testing.T) {


### PR DESCRIPTION
## Summary

Users can’t reliably correlate Code Reviews list ordering, analytics tables, and cursor-based pagination: ties inside sort groups could return rows in arbitrary order, and analytics/table sort cycles could leave the UI “stuck” in explicit sorting. This PR standardizes backend sort keys (including cursor predicates and nullable anchors), syncs frontend sort behavior with the backend contract, and tightens SQL-to-Go rank equivalence to prevent branch-grouping mismatches.

## Changes

- **Deterministic sorting inside sort groups + stable cursor keyset**
  - Updated code review sort SQL to use recency as the consistent secondary key and rebuilt the cursor predicate around the cursor’s existing recency anchor.
- **Restore 3-state sort cycle (unsorted/default reachable)**
  - Frontend sortable header now supports an `allowUnsorted` mode and the Code Reviews list opts in, so the third click clears `sort`/`order` back to newest-first. Accessibility label updated to match the unsorted state.
- **Correctness: null anchors & rank equivalence**
  - Backend now marks which sort anchors are nullable (only `completed_at`), emits `NULLS LAST`/`IS NULL` arms only where applicable, and rejects unusable/null repository cursor anchors with a 400 boundary error instead of a query-layer 500.
  - Added stronger Postgres parity testing to assert rank evaluation matches Go logic **row-by-row** across the full status/decision/review-id matrix.
- **Analytics/table mismatch fixes**
  - Fixed “split sample” ordering to sort by the displayed ratio (not just the numerator table).

## Validation

- `go build ./...`
- `go vet`
- `gofmt`
- `go test ./internal/db/... ./internal/api/handlers/...`
- Frontend: `tsc --noEmit`, `eslint src/`, `vitest`
- Note: Postgres-backed rank tests are skipped in this environment (no server), but the updated tests compile/vet clean and columns were verified against expected SQL/Go logic.

[143.dev](https://143.dev) | [session 813761db](https://143.dev/sessions/813761db-463b-41dc-97fa-2bf9c7e96411)

<!-- 143 readiness -->
**143 readiness:** not available for this revision.

<!-- 143-publication session=813761db-463b-41dc-97fa-2bf9c7e96411 changeset=b547ecc2-3d56-4e40-a5ed-54464af8147f -->

Preview: https://143.dev/previews/github/assembledhq/143/pull/1981?launch=1