### PR TITLE
Make PR author analytics counts filter reviews

### DIFF
--- a/frontend/src/app/(dashboard)/code-reviews/page.test.tsx
+++ b/frontend/src/app/(dashboard)/code-reviews/page.test.tsx
@@ -653,9 +653,36 @@ describe("CodeReviewsPage", () => {
       "52",
       "20",
     ]);
+    expect(within(anyaRow).getByRole("link", { name: "12 completed reviews by anya" })).toHaveAttribute(
+      "href",
+      "/code-reviews?tab=reviews&author=anya&status=completed&range=30d",
+    );
+    expect(within(anyaRow).getByRole("link", { name: "9 automatically approved reviews by anya" })).toHaveAttribute(
+      "href",
+      "/code-reviews?tab=reviews&author=anya&status=completed&range=30d&outcome=automatically_approved",
+    );
+    expect(within(anyaRow).getByRole("link", { name: "3 not approved reviews by anya" })).toHaveAttribute(
+      "href",
+      "/code-reviews?tab=reviews&author=anya&status=completed&range=30d&outcome=completed_not_approved",
+    );
     await waitFor(() => expect(analyticsRequests).toHaveLength(1));
     expectCreatedAfterDaysAgo(analyticsRequests[0]?.get("created_after") ?? undefined, 30);
     expect(analyticsRequests[0]?.has("repository_id")).toBe(false);
+  });
+
+  it("restores the analytics section from the URL", async () => {
+    mockCodeReviewBaseHandlers();
+    server.use(
+      http.get("/api/v1/code-reviews/analytics", () =>
+        HttpResponse.json({ data: reviewAnalytics } satisfies SingleResponse<CodeReviewAnalytics>)),
+    );
+
+    renderWithProviders(<CodeReviewsPage />, {
+      searchParams: { tab: "analytics" },
+    });
+
+    expect(await screen.findByRole("tab", { name: "Analytics" })).toHaveAttribute("data-state", "active");
+    expect(await screen.findByText("Usage by PR author")).toBeInTheDocument();
   });
 
   it("shows failed and stale attempts when no review completed", async () => {
@@ -1735,10 +1762,12 @@ describe("CodeReviewsPage", () => {
         outcome: "blocked",
         risk: "needs_review",
         status: "completed",
+        author: "anya",
         search: "invoice",
       },
     });
 
+    expect(await screen.findByRole("textbox", { name: "PR author" })).toHaveValue("anya");
     expect(await screen.findByRole("textbox", { name: "Search code reviews" })).toHaveValue("invoice");
     await waitFor(() => {
       expect(requests.some((params) =>
@@ -1747,6 +1776,7 @@ describe("CodeReviewsPage", () => {
         && params.get("risk") === "needs_review"
         && params.get("activity_status") === "completed"
         && params.get("status") === null
+        && params.get("author") === "anya"
         && params.get("search") === "invoice"
         && params.get("limit") === "50",
       )).toBe(true);

--- a/frontend/src/app/(dashboard)/code-reviews/page.tsx
+++ b/frontend/src/app/(dashboard)/code-reviews/page.tsx
@@ -96,7 +96,8 @@ import type {
 const ALL_REPOSITORIES = "all";
 const ALL_OUTCOMES = "all";
 const ALL_RISKS = "all";
-type CodeReviewTab = "reviews" | "analytics" | "policy";
+const CODE_REVIEW_TAB_VALUES = ["reviews", "analytics", "policy"] as const;
+type CodeReviewTab = (typeof CODE_REVIEW_TAB_VALUES)[number];
 const TIME_RANGE_FILTER_VALUES = ["7d", "30d", "90d", "all"] as const;
 type TimeRangeFilter = (typeof TIME_RANGE_FILTER_VALUES)[number];
 const DEFAULT_TIME_RANGE = "30d" satisfies TimeRangeFilter;
@@ -559,7 +560,14 @@ export default function CodeReviewsPage() {
   const { user } = useAuth();
   const canManagePolicy = user?.role === "admin";
   const canRetryReviews = user?.role === "admin" || user?.role === "member";
-  const [activeTab, setActiveTabState] = useState<CodeReviewTab>("reviews");
+  const [tabParam] = useQueryState(
+    "tab",
+    parseAsStringLiteral(CODE_REVIEW_TAB_VALUES).withDefault("reviews"),
+  );
+  const [activeTab, setActiveTabState] = useState<CodeReviewTab>(tabParam);
+  useEffect(() => {
+    setActiveTabState(tabParam);
+  }, [tabParam]);
   const setActiveTab = useCallback(
     (value: string) => {
       setActiveTabState(value as CodeReviewTab);
@@ -581,6 +589,7 @@ export default function CodeReviewsPage() {
     "status",
     STATUS_FILTER_PARSER,
   );
+  const [authorFilter, setAuthorFilter] = useQueryState("author", parseAsString.withDefault(""));
   const [searchParam, setSearchParam] = useQueryState("search", parseAsString.withDefault(""));
   const [search, setSearch] = useState(searchParam);
   useEffect(() => {
@@ -628,9 +637,10 @@ export default function CodeReviewsPage() {
           : undefined,
       outcome: outcomeFilter === AUTOMATICALLY_APPROVED || outcomeFilter === COMPLETED_NOT_APPROVED ? (outcomeFilter as CodeReviewListOutcome) : undefined,
       risk: riskFilter === ALL_RISKS ? undefined : (riskFilter as "acceptable" | "needs_review"),
+      author: authorFilter.trim() || undefined,
       search: searchParam.trim() || undefined,
     }),
-    [outcomeFilter, reviewRepositoryId, riskFilter, searchParam],
+    [authorFilter, outcomeFilter, reviewRepositoryId, riskFilter, searchParam],
   );
   const listReviewFilters = useMemo(
     () => statusFilter === "cancelled"
@@ -715,6 +725,7 @@ export default function CodeReviewsPage() {
     || outcomeFilter !== ALL_OUTCOMES
     || riskFilter !== ALL_RISKS
     || statusFilter !== DEFAULT_STATUS_FILTER
+    || authorFilter.trim()
     || searchParam.trim()
     || timeRangeFilter !== "all"
   );
@@ -723,10 +734,11 @@ export default function CodeReviewsPage() {
     void setOutcomeParam(null);
     void setRiskFilter(null);
     void setStatusFilter(null);
+    void setAuthorFilter(null);
     setSearch("");
     void setSearchParam(null);
     setTimeRangeFilter("all");
-  }, [setOutcomeParam, setRepositoryFilter, setRiskFilter, setSearchParam, setStatusFilter, setTimeRangeFilter]);
+  }, [setAuthorFilter, setOutcomeParam, setRepositoryFilter, setRiskFilter, setSearchParam, setStatusFilter, setTimeRangeFilter]);
   const reviewScopeKey = JSON.stringify(reviewFiltersQueryKey);
   const [extraReviewPages, setExtraReviewPages] = useState<CodeReviewListItem[][]>([]);
   const [loadMoreCursor, setLoadMoreCursor] = useState<string | undefined>();
@@ -1208,7 +1220,7 @@ export default function CodeReviewsPage() {
             </Button>
             <div
               id="code-review-filters"
-              className={`${mobileFiltersOpen ? "grid" : "hidden"} gap-3 rounded-xl border border-border bg-card p-3 shadow-sm md:grid md:grid-cols-2 md:rounded-none md:border-0 md:bg-transparent md:p-0 md:shadow-none lg:grid-cols-3 xl:grid-cols-[minmax(12rem,18rem)_repeat(3,minmax(9rem,11rem))_minmax(12rem,1fr)_minmax(9rem,11rem)]`}
+              className={`${mobileFiltersOpen ? "grid" : "hidden"} gap-3 rounded-xl border border-border bg-card p-3 shadow-sm md:grid md:grid-cols-2 md:rounded-none md:border-0 md:bg-transparent md:p-0 md:shadow-none lg:grid-cols-3 xl:grid-cols-[minmax(12rem,18rem)_repeat(4,minmax(9rem,11rem))_minmax(12rem,1fr)_minmax(9rem,11rem)]`}
             >
               <FilterSelect label="Repository" value={repositoryFilter} onValueChange={(value) => void setRepositoryFilter(value === ALL_REPOSITORIES ? null : value)}>
                 <SelectItem value={ALL_REPOSITORIES}>All repositories</SelectItem>
@@ -1240,6 +1252,15 @@ export default function CodeReviewsPage() {
                 <SelectItem value="superseded">Superseded history</SelectItem>
                 <SelectItem value="all">All attempts</SelectItem>
               </FilterSelect>
+              <div className="flex flex-col gap-2">
+                <Label className="text-xs text-muted-foreground">PR author</Label>
+                <Input
+                  value={authorFilter}
+                  onChange={(event) => void setAuthorFilter(event.target.value || null)}
+                  placeholder="GitHub handle"
+                  aria-label="PR author"
+                />
+              </div>
               <div className="flex flex-col gap-2">
                 <Label className="text-xs text-muted-foreground">Search</Label>
                 <Input value={search} onChange={(event) => setSearch(event.target.value)} placeholder="PR, repo, or title" aria-label="Search code reviews" />
@@ -1422,6 +1443,11 @@ export default function CodeReviewsPage() {
               isLoading={analyticsQuery.isLoading}
               isError={analyticsQuery.isError}
               onRetry={() => void analyticsQuery.refetch()}
+              reviewLinkFilters={{
+                repository: reviewRepositoryId,
+                range: timeRangeFilter,
+              }}
+              onNavigateToReviews={() => setActiveTab("reviews")}
             />
           </TabsContent>
 

--- a/frontend/src/components/code-review-analytics.tsx
+++ b/frontend/src/components/code-review-analytics.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import Link from "next/link";
 import { ChartNoAxesColumnIncreasing } from "lucide-react";
 import { EmptyState } from "@/components/empty-state";
 import { SectionGroup } from "@/components/section-group";
@@ -66,6 +67,67 @@ function reasonLabel(code: string): string {
   return readable.charAt(0).toUpperCase() + readable.slice(1);
 }
 
+function authorReviewsHref({
+  author,
+  outcome,
+  repository,
+  range,
+}: {
+  author: string;
+  outcome?: "automatically_approved" | "completed_not_approved";
+  repository?: string;
+  range: string;
+}): string {
+  const params = new URLSearchParams({
+    tab: "reviews",
+    author,
+    status: "completed",
+    range,
+  });
+  if (outcome) params.set("outcome", outcome);
+  if (repository) params.set("repository", repository);
+  return `/code-reviews?${params.toString()}`;
+}
+
+function AuthorReviewCountLink({
+  author,
+  count,
+  label,
+  outcome,
+  repository,
+  range,
+  onNavigate,
+}: {
+  author: string;
+  count: number;
+  label: string;
+  outcome?: "automatically_approved" | "completed_not_approved";
+  repository?: string;
+  range: string;
+  onNavigate: () => void;
+}) {
+  return (
+    <Link
+      href={authorReviewsHref({ author, outcome, repository, range })}
+      className="font-medium text-primary underline-offset-4 hover:underline focus-visible:rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+      aria-label={`${count.toLocaleString()} ${label} by ${author}`}
+      onClick={(event) => {
+        if (
+          event.button === 0
+          && !event.metaKey
+          && !event.ctrlKey
+          && !event.shiftKey
+          && !event.altKey
+        ) {
+          onNavigate();
+        }
+      }}
+    >
+      {count.toLocaleString()}
+    </Link>
+  );
+}
+
 function MetricCard({
   label,
   value,
@@ -128,11 +190,18 @@ export function CodeReviewAnalyticsReport({
   isLoading,
   isError,
   onRetry,
+  reviewLinkFilters,
+  onNavigateToReviews,
 }: {
   analytics?: CodeReviewAnalytics;
   isLoading: boolean;
   isError: boolean;
   onRetry: () => void;
+  reviewLinkFilters: {
+    repository?: string;
+    range: string;
+  };
+  onNavigateToReviews: () => void;
 }) {
   if (!analytics && isLoading) {
     return <LoadingReport />;
@@ -223,9 +292,38 @@ export function CodeReviewAnalyticsReport({
                 {analytics.authors.map((author) => (
                   <TableRow key={author.author}>
                     <TableCell className="font-medium">{author.author}</TableCell>
-                    <TableCell className="text-right tabular-nums">{author.reviews_completed.toLocaleString()}</TableCell>
-                    <TableCell className="text-right tabular-nums">{author.automatically_approved.toLocaleString()}</TableCell>
-                    <TableCell className="text-right tabular-nums">{author.not_approved.toLocaleString()}</TableCell>
+                    <TableCell className="text-right tabular-nums">
+                      <AuthorReviewCountLink
+                        author={author.author}
+                        count={author.reviews_completed}
+                        label="completed reviews"
+                        repository={reviewLinkFilters.repository}
+                        range={reviewLinkFilters.range}
+                        onNavigate={onNavigateToReviews}
+                      />
+                    </TableCell>
+                    <TableCell className="text-right tabular-nums">
+                      <AuthorReviewCountLink
+                        author={author.author}
+                        count={author.automatically_approved}
+                        label="automatically approved reviews"
+                        outcome="automatically_approved"
+                        repository={reviewLinkFilters.repository}
+                        range={reviewLinkFilters.range}
+                        onNavigate={onNavigateToReviews}
+                      />
+                    </TableCell>
+                    <TableCell className="text-right tabular-nums">
+                      <AuthorReviewCountLink
+                        author={author.author}
+                        count={author.not_approved}
+                        label="not approved reviews"
+                        outcome="completed_not_approved"
+                        repository={reviewLinkFilters.repository}
+                        range={reviewLinkFilters.range}
+                        onNavigate={onNavigateToReviews}
+                      />
+                    </TableCell>
                     <TableCell className="text-right tabular-nums">
                       {percentage(author.automatically_approved, author.reviews_completed)}
                     </TableCell>

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -272,6 +272,7 @@ export const api = {
       activity_status?: import('./types').CodeReviewActivityStatus;
       status?: import('./types').CodeReviewSessionStatus;
       risk?: "acceptable" | "needs_review";
+      author?: string;
       search?: string;
       created_after?: string;
       created_before?: string;
@@ -285,6 +286,7 @@ export const api = {
       if (params?.activity_status) searchParams.set('activity_status', params.activity_status);
       if (params?.status) searchParams.set('status', params.status);
       if (params?.risk) searchParams.set('risk', params.risk);
+      if (params?.author) searchParams.set('author', params.author);
       if (params?.search) searchParams.set('search', params.search);
       if (params?.created_after) searchParams.set('created_after', params.created_after);
       if (params?.created_before) searchParams.set('created_before', params.created_before);
@@ -300,6 +302,7 @@ export const api = {
       activity_status?: import('./types').CodeReviewActivityStatus;
       status?: import('./types').CodeReviewSessionStatus;
       risk?: "acceptable" | "needs_review";
+      author?: string;
       search?: string;
       created_after?: string;
       created_before?: string;
@@ -311,6 +314,7 @@ export const api = {
       if (params?.activity_status) searchParams.set('activity_status', params.activity_status);
       if (params?.status) searchParams.set('status', params.status);
       if (params?.risk) searchParams.set('risk', params.risk);
+      if (params?.author) searchParams.set('author', params.author);
       if (params?.search) searchParams.set('search', params.search);
       if (params?.created_after) searchParams.set('created_after', params.created_after);
       if (params?.created_before) searchParams.set('created_before', params.created_before);

--- a/internal/api/handlers/code_reviews.go
+++ b/internal/api/handlers/code_reviews.go
@@ -54,6 +54,7 @@ type codeReviewCursorScope struct {
 	ActivityStatus *models.CodeReviewActivityStatus `json:"activity_status,omitempty"`
 	Status         *models.CodeReviewSessionStatus  `json:"status,omitempty"`
 	Acceptable     *bool                            `json:"acceptable,omitempty"`
+	Author         string                           `json:"author,omitempty"`
 	Search         string                           `json:"search,omitempty"`
 	CreatedAfter   *time.Time                       `json:"created_after,omitempty"`
 	CreatedBefore  *time.Time                       `json:"created_before,omitempty"`
@@ -68,6 +69,7 @@ func codeReviewListCursorScopeHash(orgID uuid.UUID, filters db.CodeReviewListFil
 		ActivityStatus: filters.ActivityStatus,
 		Status:         filters.Status,
 		Acceptable:     filters.Acceptable,
+		Author:         strings.TrimSpace(filters.Author),
 		Search:         strings.TrimSpace(filters.Search),
 		CreatedAfter:   filters.CreatedAfter,
 		CreatedBefore:  filters.CreatedBefore,
@@ -276,6 +278,7 @@ func parseCodeReviewFilters(w http.ResponseWriter, r *http.Request) (db.CodeRevi
 	}
 	filters := db.CodeReviewListFilters{
 		RepositoryID:  repositoryID,
+		Author:        strings.TrimSpace(r.URL.Query().Get("author")),
 		Search:        strings.TrimSpace(r.URL.Query().Get("search")),
 		CreatedAfter:  createdAfter,
 		CreatedBefore: createdBefore,
@@ -391,6 +394,7 @@ func (h *CodeReviewHandler) Stats(w http.ResponseWriter, r *http.Request) {
 		ActivityStatus: filters.ActivityStatus,
 		Status:         filters.Status,
 		Acceptable:     filters.Acceptable,
+		Author:         filters.Author,
 		Search:         filters.Search,
 		CreatedAfter:   filters.CreatedAfter,
 		CreatedBefore:  filters.CreatedBefore,

--- a/internal/api/handlers/code_reviews_test.go
+++ b/internal/api/handlers/code_reviews_test.go
@@ -363,10 +363,11 @@ func TestCodeReviewHandler_StatsReturnsFilteredAggregates(t *testing.T) {
 	mock, err := pgxmock.NewPool()
 	require.NoError(t, err, "pgxmock should initialize")
 	defer mock.Close()
-	mock.ExpectQuery(`(?s)FROM code_review_session_metadata m.*m\.repository_id = @repository_id.*m\.decision = @decision.*m\.status <> 'stale'.*m\.superseded_by_session_id IS NULL.*m\.status = @status.*m\.acceptable = @acceptable.*m\.created_at >= @created_after.*pr\.title ILIKE @search`).
+	mock.ExpectQuery(`(?s)FROM code_review_session_metadata m.*m\.repository_id = @repository_id.*m\.decision = @decision.*m\.status <> 'stale'.*m\.superseded_by_session_id IS NULL.*m\.status = @status.*m\.acceptable = @acceptable.*LOWER\(COALESCE\(NULLIF\(s\.revision_context->>'pull_request_author', ''\), 'Unknown'\)\) = LOWER\(@author\).*m\.created_at >= @created_after.*pr\.title ILIKE @search`).
 		WithArgs(
 			pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
 			pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
+			pgxmock.AnyArg(),
 		).
 		WillReturnRows(pgxmock.NewRows([]string{
 			"reviews_completed",
@@ -378,7 +379,7 @@ func TestCodeReviewHandler_StatsReturnsFilteredAggregates(t *testing.T) {
 	req := httptest.NewRequest(
 		http.MethodGet,
 		"/api/v1/code-reviews/stats?repository_id="+repositoryID.String()+
-			"&decision=needs_human_review&activity_status=current&status=completed&risk=needs_review&search=auth&created_after=2026-06-01T00:00:00Z",
+			"&decision=needs_human_review&activity_status=current&status=completed&risk=needs_review&author=Anya&search=auth&created_after=2026-06-01T00:00:00Z",
 		nil,
 	)
 	req = req.WithContext(middleware.WithOrgID(req.Context(), orgID))
@@ -538,7 +539,7 @@ func TestCodeReviewListCursorRejectsChangedFilterButAllowsMutableRowChanges(t *t
 
 	orgID := uuid.New()
 	running := models.CodeReviewSessionStatusRunning
-	filters := db.CodeReviewListFilters{Status: &running, Search: "invoice", Limit: 50}
+	filters := db.CodeReviewListFilters{Status: &running, Author: "anya", Search: "invoice", Limit: 50}
 	id := uuid.New()
 	createdAt := time.Date(2026, 7, 28, 12, 0, 0, 0, time.UTC)
 	cursor, err := encodeCodeReviewListCursor(orgID, filters, id, createdAt)
@@ -560,6 +561,11 @@ func TestCodeReviewListCursorRejectsChangedFilterButAllowsMutableRowChanges(t *t
 	changedFilters.ActivityStatus = &current
 	_, _, err = decodeCodeReviewListCursor(cursor, orgID, changedFilters)
 	require.Error(t, err, "a cursor reused with a different activity status should be rejected")
+
+	changedFilters = filters
+	changedFilters.Author = "sam"
+	_, _, err = decodeCodeReviewListCursor(cursor, orgID, changedFilters)
+	require.Error(t, err, "a cursor reused with a different author should be rejected")
 }
 
 func TestCodeReviewHandler_Retry(t *testing.T) {

--- a/internal/db/code_reviews.go
+++ b/internal/db/code_reviews.go
@@ -1166,6 +1166,7 @@ type CodeReviewListFilters struct {
 	ActivityStatus *models.CodeReviewActivityStatus
 	Status         *models.CodeReviewSessionStatus
 	Acceptable     *bool
+	Author         string
 	Search         string
 	Limit          int
 	CreatedAfter   *time.Time
@@ -1249,6 +1250,10 @@ func codeReviewListWhere(orgID uuid.UUID, filters CodeReviewListFilters, include
 		query += ` AND m.acceptable = @acceptable`
 		args["acceptable"] = *filters.Acceptable
 	}
+	if author := strings.TrimSpace(filters.Author); author != "" {
+		query += ` AND LOWER(COALESCE(NULLIF(s.revision_context->>'pull_request_author', ''), 'Unknown')) = LOWER(@author)`
+		args["author"] = author
+	}
 	if filters.CreatedAfter != nil {
 		query += ` AND m.created_at >= @created_after`
 		args["created_after"] = *filters.CreatedAfter
@@ -1303,6 +1308,7 @@ type CodeReviewStatsFilters struct {
 	ActivityStatus *models.CodeReviewActivityStatus
 	Status         *models.CodeReviewSessionStatus
 	Acceptable     *bool
+	Author         string
 	Search         string
 	CreatedAfter   *time.Time
 	CreatedBefore  *time.Time
@@ -1423,6 +1429,11 @@ func (s *CodeReviewStore) GetReviewStats(ctx context.Context, orgID uuid.UUID, f
 		query += `
 		  AND m.acceptable = @acceptable`
 		args["acceptable"] = *filters.Acceptable
+	}
+	if author := strings.TrimSpace(filters.Author); author != "" {
+		query += `
+		  AND LOWER(COALESCE(NULLIF(s.revision_context->>'pull_request_author', ''), 'Unknown')) = LOWER(@author)`
+		args["author"] = author
 	}
 	if filters.CreatedAfter != nil {
 		query += `

--- a/internal/db/code_reviews_test.go
+++ b/internal/db/code_reviews_test.go
@@ -994,10 +994,11 @@ func TestCodeReviewStore_ListReviewsAppliesDesignFilters(t *testing.T) {
 	require.NoError(t, err, "pgxmock should initialize")
 	defer mock.Close()
 
-	mock.ExpectQuery("(?s)m.status = 'failed'.*pr.status = 'open'.*current_health.head_sha = m.head_sha.*FROM code_review_session_metadata newer.*approved.status = 'completed'.*policy.active = true.*AS retry_eligible.*m.decision = @decision").
+	mock.ExpectQuery("(?s)m.status = 'failed'.*pr.status = 'open'.*current_health.head_sha = m.head_sha.*FROM code_review_session_metadata newer.*approved.status = 'completed'.*policy.active = true.*AS retry_eligible.*m.decision = @decision.*LOWER\\(COALESCE\\(NULLIF\\(s.revision_context->>'pull_request_author', ''\\), 'Unknown'\\)\\) = LOWER\\(@author\\)").
 		WithArgs(
 			pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
 			pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
+			pgxmock.AnyArg(),
 		).
 		WillReturnRows(pgxmock.NewRows([]string{
 			"id", "org_id", "session_id", "repository_id", "pull_request_id", "policy_id",
@@ -1017,6 +1018,7 @@ func TestCodeReviewStore_ListReviewsAppliesDesignFilters(t *testing.T) {
 		Decision:     &decision,
 		Status:       &status,
 		Acceptable:   &acceptable,
+		Author:       "Devin",
 		Search:       "auth",
 		Limit:        25,
 	})


### PR DESCRIPTION
## Summary

- make the Reviews, Approved, and Not approved counts in Usage by PR author link to the Reviews tab
- preserve the analytics repository and time-window scope while selecting the matching author, completed status, and approval outcome
- add a URL-backed PR author filter to the review list and statistics endpoints
- include the author in pagination cursor scope so cursors cannot be reused across authors

## Why

This is a follow-up to the merged code review analytics work in #1975. The author usage counts were displayed as static values, and the reviews API did not expose an exact author filter, so analytics users could not drill into the reviews behind each count or share that filtered view by URL.

## Validation

- `npm test -- --run 'src/app/(dashboard)/code-reviews/page.test.tsx'` — 59 tests passed
- `npm run typecheck`
- touched-file ESLint
- `go test ./internal/api/handlers ./internal/db`
- `go vet ./internal/api/handlers ./internal/db`
- pre-commit tenancy/store lints