### PR TITLE
Format median code review diff stats

### DIFF
--- a/frontend/src/app/(dashboard)/code-reviews/page.test.tsx
+++ b/frontend/src/app/(dashboard)/code-reviews/page.test.tsx
@@ -650,8 +650,8 @@ describe("CodeReviewsPage", () => {
       "9",
       "3",
       "75%",
-      "52",
-      "20",
+      "+52",
+      "-20",
     ]);
     await waitFor(() => expect(analyticsRequests).toHaveLength(1));
     expectCreatedAfterDaysAgo(analyticsRequests[0]?.get("created_after") ?? undefined, 30);

--- a/frontend/src/components/code-review-analytics.tsx
+++ b/frontend/src/components/code-review-analytics.tsx
@@ -59,6 +59,11 @@ function roundedMetric(value: number | null): string {
   return Math.round(value).toLocaleString();
 }
 
+function signedRoundedMetric(value: number | null, sign: "+" | "-"): string {
+  const formatted = roundedMetric(value);
+  return formatted === "—" ? formatted : `${sign}${formatted}`;
+}
+
 function reasonLabel(code: string): string {
   const known = NON_APPROVAL_REASON_LABELS[code];
   if (known) return known;
@@ -229,8 +234,8 @@ export function CodeReviewAnalyticsReport({
                     <TableCell className="text-right tabular-nums">
                       {percentage(author.automatically_approved, author.reviews_completed)}
                     </TableCell>
-                    <TableCell className="text-right tabular-nums">{roundedMetric(author.median_additions)}</TableCell>
-                    <TableCell className="text-right tabular-nums">{roundedMetric(author.median_deletions)}</TableCell>
+                    <TableCell className="text-right tabular-nums">{signedRoundedMetric(author.median_additions, "+")}</TableCell>
+                    <TableCell className="text-right tabular-nums">{signedRoundedMetric(author.median_deletions, "-")}</TableCell>
                   </TableRow>
                 ))}
               </TableBody>


### PR DESCRIPTION
## Summary

- Prefix median additions in the Usage by PR author table with `+`
- Prefix median deletions with `-`
- Preserve the existing em dash for unavailable metrics

## Why

The table reused an unsigned number formatter for both median diff columns, so additions and deletions did not match the familiar GitHub diff-stat presentation. This makes the direction of each metric immediately clear without changing the underlying analytics values.

## Validation

- `npm test -- --run 'src/app/(dashboard)/code-reviews/page.test.tsx'` — 58 tests passed
- `npx eslint 'src/components/code-review-analytics.tsx' 'src/app/(dashboard)/code-reviews/page.test.tsx' --max-warnings=0`
- `git diff --check origin/main`