### PR TITLE
Reorder primary navigation by workflow

### DIFF
--- a/frontend/src/components/authenticated-layout.test.tsx
+++ b/frontend/src/components/authenticated-layout.test.tsx
@@ -52,6 +52,24 @@ beforeEach(() => {
 });
 
 describe("AuthenticatedLayout", () => {
+  it("orders the primary navigation by workflow", () => {
+    const { container } = renderWithProviders(
+      <AuthenticatedLayout>
+        <div>content</div>
+      </AuthenticatedLayout>
+    );
+
+    const sidebar = container.querySelector("[data-testid='app-sidebar']");
+    const primaryNav = sidebar?.querySelector("nav");
+    const primaryHrefs = new Set(["/sessions", "/code-reviews", "/automations", "/previews"]);
+    const primaryLabels = within(primaryNav as HTMLElement)
+      .getAllByRole("link")
+      .filter((link) => primaryHrefs.has(link.getAttribute("href") ?? ""))
+      .map((link) => link.textContent);
+
+    expect(primaryLabels).toEqual(["Sessions", "Code reviews", "Automations", "Previews"]);
+  });
+
   it("hides projects from the primary navigation", () => {
     renderWithProviders(
       <AuthenticatedLayout>

--- a/frontend/src/components/authenticated-layout.tsx
+++ b/frontend/src/components/authenticated-layout.tsx
@@ -136,8 +136,8 @@ type NavItem = {
 
 const navItems: NavItem[] = [
   { label: "Sessions", icon: Play, href: "/sessions" },
-  { label: "Automations", icon: RefreshCw, href: "/automations" },
   { label: "Code reviews", icon: ClipboardCheck, href: "/code-reviews" },
+  { label: "Automations", icon: RefreshCw, href: "/automations" },
   { label: "Previews", icon: MonitorPlay, href: "/previews" },
 ];
 


### PR DESCRIPTION
## Summary

- Reorder the authenticated sidebar navigation to: Sessions, Code reviews, Automations, and Previews.
- Add a regression test covering the intended navigation order.

## Testing

- Added and ran the authenticated layout navigation-order test.