### PR TITLE
Explain Execution context card on session details page and whether it’s required

### DIFF
--- a/frontend/src/app/(dashboard)/sessions/[id]/page-composer.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/page-composer.test.tsx
@@ -859,6 +859,7 @@ describe('SessionDetailPage composer and session metadata', () => {
   it('shows execution brief without planning reasoning in neutral execution context', async () => {
     const sessionWithExecutionContext: Session = {
       ...mockSessions[0],
+      origin: 'automation',
       planning_reasoning: undefined,
       execution_brief: 'Direct fix approach',
     };
@@ -874,6 +875,27 @@ describe('SessionDetailPage composer and session metadata', () => {
     expect(screen.getAllByText('Direct fix approach').length).toBeGreaterThanOrEqual(1);
     expect(screen.queryByText('Planning reasoning')).not.toBeInTheDocument();
     expect(screen.getByText('Execution brief')).toBeInTheDocument();
+  });
+
+  it('hides execution context for manually created sessions', async () => {
+    const manualSessionWithExecutionContext: Session = {
+      ...mockSessions[0],
+      origin: 'manual',
+      planning_reasoning: 'Consider the smallest safe change',
+      execution_brief: 'Direct fix approach',
+    };
+
+    server.use(
+      http.get('/api/v1/sessions/:id', () => {
+        return HttpResponse.json({ data: manualSessionWithExecutionContext } satisfies SingleResponse<Session>);
+      }),
+    );
+
+    renderWithProviders(<SessionDetailContent id="session-abcdef12-3456-7890" />);
+    await screen.findAllByText('Fixed TypeError by adding null check');
+    expect(screen.queryByText('Execution context')).not.toBeInTheDocument();
+    expect(screen.queryByText('Planning reasoning')).not.toBeInTheDocument();
+    expect(screen.queryByText('Execution brief')).not.toBeInTheDocument();
   });
 
   it('clears message after successful send', async () => {

--- a/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
@@ -1042,27 +1042,28 @@ function OverviewTab({ session, activeThread, members, prStatus }: { session: Se
       </div>
 
       {/* Execution context */}
-      {(session.planning_reasoning || session.execution_brief) && (
-        <Card>
-          <CardHeader className="pb-2">
-            <CardTitle className="text-xs">Execution context</CardTitle>
-          </CardHeader>
-          <CardContent className="space-y-3 text-xs">
-            {session.planning_reasoning && (
-              <div>
-                <p className="text-xs font-medium text-muted-foreground">Planning reasoning</p>
-                <p className="break-words">{session.planning_reasoning}</p>
-              </div>
-            )}
-            {session.execution_brief && (
-              <div>
-                <p className="text-xs font-medium text-muted-foreground">Execution brief</p>
-                <p className="break-words">{session.execution_brief}</p>
-              </div>
-            )}
-          </CardContent>
-        </Card>
-      )}
+      {session.origin !== "manual" &&
+        (session.planning_reasoning || session.execution_brief) && (
+          <Card>
+            <CardHeader className="pb-2">
+              <CardTitle className="text-xs">Execution context</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-3 text-xs">
+              {session.planning_reasoning && (
+                <div>
+                  <p className="text-xs font-medium text-muted-foreground">Planning reasoning</p>
+                  <p className="break-words">{session.planning_reasoning}</p>
+                </div>
+              )}
+              {session.execution_brief && (
+                <div>
+                  <p className="text-xs font-medium text-muted-foreground">Execution brief</p>
+                  <p className="break-words">{session.execution_brief}</p>
+                </div>
+              )}
+            </CardContent>
+          </Card>
+        )}
 
     </div>
   );


### PR DESCRIPTION
## Summary

Manual session details pages were showing the “Execution context” card, creating a confusing workflow gap (users expect a cleaner, user-authored view) and a potential reliability risk by exposing internal planning/execution fields unintentionally. This change hides the card only when `session.origin === "manual"` while keeping the existing behavior for automation, issue-triggered, revision, and legacy sessions (no origin).

## Changes

- Update `session-detail-content.tsx` to render the “Execution context” card only when the session is **not** manually created (`origin !== "manual"`).
- Add a focused test in `page-composer.test.tsx` to assert that “Execution context”, “Planning reasoning”, and “Execution brief” are not rendered for `origin: "manual"`.
- Extend test coverage to ensure “Execution context” remains visible for automation sessions.

## Validation

- Updated/added frontend component test coverage:
  - `frontend/src/app/(dashboard)/sessions/[id]/page-composer.test.tsx`
- Note: the targeted Vitest run was not available in this environment (`vitest: not found`), but `git diff --check` passes.

[143.dev](https://143.dev) | [session 89374319](https://143.dev/sessions/89374319-f1c5-4210-9bc8-a604391f459c)

<!-- 143 readiness -->
**143 readiness:** not available for this revision.

<!-- 143-publication session=89374319-f1c5-4210-9bc8-a604391f459c changeset=b9ab8cd4-c296-4d24-9d19-5b83c9bcc14e -->

Preview: https://143.dev/previews/github/assembledhq/143/pull/1988?launch=1