### PR TITLE
Implement design doc for collapsible session work activity PR 2

### DIFF
--- a/internal/db/migrations_test.go
+++ b/internal/db/migrations_test.go
@@ -1396,3 +1396,41 @@ func TestSessionActivityPhaseMigrationEnforcesLifecycleAndDeliveryIdentity(t *te
 	require.Less(t, phaseDrop, batchDrop, "down migration should remove the dependent phase table before delivery batches")
 	require.Less(t, batchDrop, columnDrop, "down migration should remove delivery batches before the inbox column")
 }
+
+func TestActivityPhaseTranscriptAssociationMigration(t *testing.T) {
+	t.Parallel()
+
+	upBody, err := os.ReadFile("../../migrations/000265_activity_phase_transcript_associations.up.sql")
+	require.NoError(t, err, "test should read the transcript association up migration")
+	downBody, err := os.ReadFile("../../migrations/000265_activity_phase_transcript_associations.down.sql")
+	require.NoError(t, err, "test should read the transcript association down migration")
+
+	upSQL := string(upBody)
+	requiredFragments := []string{
+		"ALTER TABLE session_logs\n    ADD COLUMN activity_phase_id uuid;",
+		"ALTER TABLE session_messages\n    ADD COLUMN activity_phase_id uuid;",
+		"REFERENCES session_activity_phases(id) ON DELETE SET NULL",
+		"idx_session_logs_activity_phase",
+		"idx_session_messages_activity_phase",
+		"idx_session_human_input_requests_activity_phase",
+	}
+	for _, fragment := range requiredFragments {
+		require.Contains(t, upSQL, fragment, "transcript association migration should add every phase column and index")
+	}
+	require.Equal(
+		t,
+		3,
+		strings.Count(upSQL, "WHERE activity_phase_id IS NOT NULL"),
+		"every phase index should be partial so unassociated historical rows stay out of it",
+	)
+
+	downSQL := string(downBody)
+	for _, table := range []string{"session_logs", "session_messages", "session_human_input_requests"} {
+		require.Contains(
+			t,
+			downSQL,
+			"ALTER TABLE "+table+" DROP COLUMN IF EXISTS activity_phase_id",
+			"down migration should remove the phase column from every transcript table",
+		)
+	}
+}

--- a/internal/db/session_human_input_requests.go
+++ b/internal/db/session_human_input_requests.go
@@ -30,7 +30,8 @@ const humanInputRequestSelectColumns = `
 	provider_request_id, request_kind, status, title, body, context,
 	blocks_phase, assigned_user_id, sensitivity, preferred_channel,
 	choices, response_schema, provider_payload,
-	answer_text, answer_payload, answered_by, answered_at, expires_at, created_at`
+	answer_text, answer_payload, answered_by, answered_at, expires_at, created_at,
+	activity_phase_id`
 
 func (s *SessionHumanInputRequestStore) Create(ctx context.Context, req *models.HumanInputRequest) error {
 	if req.Status == "" {
@@ -63,7 +64,7 @@ func (s *SessionHumanInputRequestStore) Create(ctx context.Context, req *models.
 		)
 		RETURNING id, created_at`
 
-	row := s.db.QueryRow(ctx, query, pgx.NamedArgs{
+	args := pgx.NamedArgs{
 		"org_id":              req.OrgID,
 		"session_id":          req.SessionID,
 		"thread_id":           req.ThreadID,
@@ -84,8 +85,39 @@ func (s *SessionHumanInputRequestStore) Create(ctx context.Context, req *models.
 		"provider_payload":    nullRawMessage(req.ProviderPayload),
 		"answer_text":         req.AnswerText,
 		"answer_payload":      nullRawMessage(req.AnswerPayload),
-	})
+	}
+	if req.ActivityPhaseID != nil {
+		// The phase must belong to the same org, session, thread, and turn as the
+		// request. Phase status is deliberately not constrained: a human input
+		// request is itself a phase-closing event and can be persisted after the
+		// phase reaches its terminal status.
+		query = `
+			INSERT INTO session_human_input_requests (
+				org_id, session_id, thread_id, turn_number, agent_type,
+				provider_request_id, request_kind, status, title, body, context,
+				blocks_phase, assigned_user_id, sensitivity, preferred_channel,
+				choices, response_schema, provider_payload,
+				answer_text, answer_payload, activity_phase_id
+			)
+			SELECT
+				@org_id, @session_id, @thread_id, @turn_number, @agent_type,
+				@provider_request_id, @request_kind, @status, @title, @body, @context,
+				@blocks_phase, @assigned_user_id, @sensitivity, @preferred_channel,
+				@choices, @response_schema, @provider_payload,
+				@answer_text, @answer_payload, @activity_phase_id
+			FROM session_activity_phases p
+			WHERE p.id = @activity_phase_id AND p.org_id = @org_id
+			  AND p.session_id = @session_id
+			  AND p.thread_id IS NOT DISTINCT FROM @thread_id
+			  AND p.turn_number = @turn_number
+			RETURNING id, created_at`
+		args["activity_phase_id"] = req.ActivityPhaseID
+	}
+	row := s.db.QueryRow(ctx, query, args)
 	if err := row.Scan(&req.ID, &req.CreatedAt); err != nil {
+		if req.ActivityPhaseID != nil && errors.Is(err, pgx.ErrNoRows) {
+			return wrapPhaseOwnershipError("create session human input request", req.ActivityPhaseID, err)
+		}
 		return fmt.Errorf("create session human input request: %w", err)
 	}
 	return nil
@@ -467,6 +499,7 @@ func scanHumanInputRequest(rows pgx.Rows) (models.HumanInputRequest, error) {
 		&req.AnsweredAt,
 		&req.ExpiresAt,
 		&req.CreatedAt,
+		&req.ActivityPhaseID,
 	); err != nil {
 		return models.HumanInputRequest{}, err
 	}

--- a/internal/db/session_human_input_requests_test.go
+++ b/internal/db/session_human_input_requests_test.go
@@ -12,12 +12,15 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+const humanInputPhaseInsertPattern = `(?s)FROM session_activity_phases p.+p\.id = @activity_phase_id AND p\.org_id = @org_id.+p\.session_id = @session_id.+p\.thread_id IS NOT DISTINCT FROM @thread_id.+p\.turn_number = @turn_number`
+
 var humanInputRequestColumns = []string{
 	"id", "org_id", "session_id", "thread_id", "turn_number", "agent_type",
 	"provider_request_id", "request_kind", "status", "title", "body",
 	"context", "blocks_phase", "assigned_user_id", "sensitivity", "preferred_channel",
 	"choices", "response_schema", "provider_payload",
 	"answer_text", "answer_payload", "answered_by", "answered_at", "expires_at", "created_at",
+	"activity_phase_id",
 }
 
 func newHumanInputRequestRow(id, orgID, sessionID uuid.UUID, now time.Time) []any {
@@ -30,6 +33,7 @@ func newHumanInputRequestRow(id, orgID, sessionID uuid.UUID, now time.Time) []an
 		(*string)(nil), (*string)(nil), (*uuid.UUID)(nil), models.HumanInputSensitivityTeam,
 		models.HumanInputPreferredChannelSlackThread, choiceJSON, json.RawMessage(nil), json.RawMessage(`{"raw":true}`),
 		(*string)(nil), json.RawMessage(nil), (*uuid.UUID)(nil), (*time.Time)(nil), (*time.Time)(nil), now,
+		(*uuid.UUID)(nil),
 	}
 }
 
@@ -72,6 +76,76 @@ func TestSessionHumanInputRequestStore_Create(t *testing.T) {
 	require.Equal(t, requestID, req.ID, "Create should hydrate the generated id")
 	require.Equal(t, now, req.CreatedAt, "Create should hydrate created_at")
 	require.NoError(t, mock.ExpectationsWereMet(), "all expectations should be met")
+}
+
+func TestSessionHumanInputRequestStore_Create_ValidatesActivityPhaseOwnership(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "database mock should initialize")
+	t.Cleanup(mock.Close)
+
+	phaseID := uuid.New()
+	threadID := uuid.New()
+	req := models.HumanInputRequest{
+		OrgID: uuid.New(), SessionID: uuid.New(), ThreadID: &threadID, TurnNumber: 1,
+		AgentType: models.AgentTypeCodex, Kind: models.HumanInputRequestKindFreeText,
+		Title: "Question", Body: "Choose", ActivityPhaseID: &phaseID,
+	}
+	mock.ExpectQuery(humanInputPhaseInsertPattern).
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), &phaseID).
+		WillReturnRows(pgxmock.NewRows([]string{"id", "created_at"}).AddRow(uuid.New(), time.Now()))
+
+	err = NewSessionHumanInputRequestStore(mock).Create(context.Background(), &req)
+	require.NoError(t, err, "phase-associated human input should be inserted after full ownership validation")
+	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
+}
+
+func TestSessionHumanInputRequestStore_Create_DoesNotRequireRunningActivityPhase(t *testing.T) {
+	t.Parallel()
+
+	mock, capturedSQL := newSQLCapturingPool(t)
+
+	phaseID := uuid.New()
+	threadID := uuid.New()
+	req := models.HumanInputRequest{
+		OrgID: uuid.New(), SessionID: uuid.New(), ThreadID: &threadID, TurnNumber: 1,
+		AgentType: models.AgentTypeCodex, Kind: models.HumanInputRequestKindFreeText,
+		Title: "Question", Body: "Choose", ActivityPhaseID: &phaseID,
+	}
+	mock.ExpectQuery(humanInputPhaseInsertPattern).
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), &phaseID).
+		WillReturnRows(pgxmock.NewRows([]string{"id", "created_at"}).AddRow(uuid.New(), time.Now()))
+
+	err := NewSessionHumanInputRequestStore(mock).Create(context.Background(), &req)
+	require.NoError(t, err, "phase-closing human input should be inserted regardless of the phase's terminal status")
+	// A human input request is itself a phase-closing event, so it is written
+	// after the phase reaches a terminal status.
+	require.NotContains(t, *capturedSQL, "p.status", "validated insert should not constrain the phase status")
+	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
+}
+
+func TestSessionHumanInputRequestStore_Create_RejectsMismatchedActivityPhase(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "database mock should initialize")
+	t.Cleanup(mock.Close)
+
+	phaseID := uuid.New()
+	threadID := uuid.New()
+	req := models.HumanInputRequest{
+		OrgID: uuid.New(), SessionID: uuid.New(), ThreadID: &threadID, TurnNumber: 1,
+		AgentType: models.AgentTypeCodex, Kind: models.HumanInputRequestKindFreeText,
+		Title: "Question", Body: "Choose", ActivityPhaseID: &phaseID,
+	}
+	mock.ExpectQuery(humanInputPhaseInsertPattern).
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), &phaseID).
+		WillReturnRows(pgxmock.NewRows([]string{"id", "created_at"}))
+
+	err = NewSessionHumanInputRequestStore(mock).Create(context.Background(), &req)
+	require.ErrorContains(t, err, "does not match org/session/thread/turn ownership", "mismatched phase should return a diagnosable ownership error")
+	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
 }
 
 func TestSessionHumanInputRequestStore_ListBySession(t *testing.T) {

--- a/internal/db/session_log_store_test.go
+++ b/internal/db/session_log_store_test.go
@@ -16,14 +16,38 @@ import (
 )
 
 var logColumns = []string{
-	"id", "session_id", "org_id", "thread_id", "timestamp", "level", "message", "metadata", "turn_number",
+	"id", "session_id", "org_id", "thread_id", "timestamp", "level", "message", "metadata", "turn_number", "activity_phase_id",
+}
+
+// logRowPhaseID is the phase every fixture row carries, so read paths prove the
+// association survives the round trip out of the store.
+var logRowPhaseID = uuid.New()
+
+// newSQLCapturingPool returns a mock pool that records the SQL of the last
+// query it matched, so tests can assert on what a store did *not* emit. Shared
+// by the phase-validated insert tests in this package.
+func newSQLCapturingPool(t *testing.T) (pgxmock.PgxPoolIface, *string) {
+	t.Helper()
+
+	captured := new(string)
+	mock, err := pgxmock.NewPool(pgxmock.QueryMatcherOption(pgxmock.QueryMatcherFunc(
+		func(expectedSQL, actualSQL string) error {
+			*captured = actualSQL
+			return pgxmock.QueryMatcherRegexp.Match(expectedSQL, actualSQL)
+		},
+	)))
+	require.NoError(t, err, "database mock should initialize")
+	t.Cleanup(mock.Close)
+	return mock, captured
 }
 
 const sessionLogValidatedInsertPattern = `(?s)INSERT INTO session_logs[\s\S]+FROM sessions s\s+WHERE s\.id = @session_id\s+AND s\.org_id = @org_id\s+RETURNING id, timestamp`
 
+const sessionLogPhaseInsertPattern = `(?s)JOIN session_activity_phases p.+p\.id = @activity_phase_id AND p\.org_id = @org_id.+p\.session_id = @session_id.+p\.thread_id IS NOT DISTINCT FROM @thread_id.+p\.turn_number = @turn_number`
+
 func newLogRow(id int64, sessionID uuid.UUID, now time.Time) []any {
 	return []any{
-		id, sessionID, uuid.New(), nil, now, "info", "doing something", json.RawMessage(`{}`), 0,
+		id, sessionID, uuid.New(), nil, now, "info", "doing something", json.RawMessage(`{}`), 0, &logRowPhaseID,
 	}
 }
 
@@ -54,6 +78,112 @@ func TestSessionLogStore_Create_Success(t *testing.T) {
 	require.NoError(t, err, "should create agent run log without error")
 	require.Equal(t, int64(1), log.ID, "should set the generated ID on the log")
 	require.Equal(t, now, log.Timestamp, "should set the timestamp on the log")
+	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
+}
+
+func TestSessionLogStore_Create_ValidatesActivityPhaseOwnership(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "database mock should initialize")
+	t.Cleanup(mock.Close)
+
+	phaseID := uuid.New()
+	threadID := uuid.New()
+	log := &models.SessionLog{
+		SessionID: uuid.New(), OrgID: uuid.New(), ThreadID: &threadID,
+		Level: models.SessionLogLevelInfo, Message: "working", TurnNumber: 1,
+		ActivityPhaseID: &phaseID,
+	}
+	mock.ExpectQuery(sessionLogPhaseInsertPattern).
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), &phaseID).
+		WillReturnRows(pgxmock.NewRows([]string{"id", "timestamp"}).AddRow(int64(1), time.Now()))
+
+	err = NewSessionLogStore(mock).Create(context.Background(), log)
+	require.NoError(t, err, "phase-associated log should be inserted after full ownership validation")
+	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
+}
+
+func TestSessionLogStore_Create_DoesNotRequireRunningActivityPhase(t *testing.T) {
+	t.Parallel()
+
+	mock, capturedSQL := newSQLCapturingPool(t)
+
+	phaseID := uuid.New()
+	threadID := uuid.New()
+	log := &models.SessionLog{
+		SessionID: uuid.New(), OrgID: uuid.New(), ThreadID: &threadID,
+		Level: models.SessionLogLevelOutput, Message: "final answer", TurnNumber: 1,
+		ActivityPhaseID: &phaseID,
+	}
+	mock.ExpectQuery(sessionLogPhaseInsertPattern).
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), &phaseID).
+		WillReturnRows(pgxmock.NewRows([]string{"id", "timestamp"}).AddRow(int64(7), time.Now()))
+
+	err := NewSessionLogStore(mock).Create(context.Background(), log)
+	require.NoError(t, err, "phase-closing log should be inserted regardless of the phase's terminal status")
+	// An entry that closes a phase is written after the phase reaches a terminal
+	// status, so the validated insert must not filter on phase status.
+	require.NotContains(t, *capturedSQL, "p.status", "validated insert should not constrain the phase status")
+	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
+}
+
+func TestSessionLogStore_Create_RejectsMismatchedActivityPhase(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "database mock should initialize")
+	t.Cleanup(mock.Close)
+
+	phaseID := uuid.New()
+	threadID := uuid.New()
+	log := &models.SessionLog{
+		SessionID: uuid.New(), OrgID: uuid.New(), ThreadID: &threadID,
+		Level: models.SessionLogLevelInfo, Message: "working", TurnNumber: 1,
+		ActivityPhaseID: &phaseID,
+	}
+	mock.ExpectQuery(sessionLogPhaseInsertPattern).
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), &phaseID).
+		WillReturnRows(pgxmock.NewRows([]string{"id", "timestamp"}))
+	// Follow-up check: the session/org pair is valid, so the phase is at fault.
+	mock.ExpectQuery(`SELECT EXISTS\(SELECT 1 FROM sessions WHERE id = @id AND org_id = @org_id\)`).
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(pgxmock.NewRows([]string{"exists"}).AddRow(true))
+
+	err = NewSessionLogStore(mock).Create(context.Background(), log)
+	require.ErrorContains(t, err, "does not match org/session/thread/turn ownership", "mismatched phase should return an ownership error")
+	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
+}
+
+func TestSessionLogStore_Create_PhaseInsertReportsOrgMismatchOverPhaseMismatch(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "database mock should initialize")
+	t.Cleanup(mock.Close)
+
+	store := NewSessionLogStore(mock)
+	store.SetLogger(zerolog.Nop())
+	phaseID := uuid.New()
+	threadID := uuid.New()
+	log := &models.SessionLog{
+		SessionID: uuid.New(), OrgID: uuid.New(), ThreadID: &threadID,
+		Level: models.SessionLogLevelInfo, Message: "working", TurnNumber: 1,
+		ActivityPhaseID: &phaseID,
+	}
+	mock.ExpectQuery(sessionLogPhaseInsertPattern).
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), &phaseID).
+		WillReturnRows(pgxmock.NewRows([]string{"id", "timestamp"}))
+	// The session does not belong to the org, so the phase is not the cause.
+	mock.ExpectQuery(`SELECT EXISTS\(SELECT 1 FROM sessions WHERE id = @id AND org_id = @org_id\)`).
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(pgxmock.NewRows([]string{"exists"}).AddRow(false))
+	mock.ExpectQuery(`SELECT EXISTS\(SELECT 1 FROM sessions WHERE id = @id\)`).
+		WithArgs(pgxmock.AnyArg()).
+		WillReturnRows(pgxmock.NewRows([]string{"exists"}).AddRow(true))
+
+	err = store.Create(context.Background(), log)
+	require.ErrorContains(t, err, "does not belong to org", "a tenant isolation violation must not be masked by the phase check")
 	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
 }
 
@@ -264,6 +394,7 @@ func TestSessionLogStore_ListByRunID_Success(t *testing.T) {
 	require.Equal(t, sessionID, logs[0].SessionID, "first log entry should have the correct session ID")
 	require.Equal(t, models.SessionLogLevelInfo, logs[0].Level, "first log entry should have the correct level")
 	require.Equal(t, "doing something", logs[0].Message, "first log entry should have the correct message")
+	require.Equal(t, &logRowPhaseID, logs[0].ActivityPhaseID, "listed log should carry the phase association it was stored with")
 	require.Equal(t, int64(2), logs[1].ID, "second log entry should have the correct ID")
 	require.Equal(t, sessionID, logs[1].SessionID, "second log entry should have the correct session ID")
 	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
@@ -285,7 +416,7 @@ func TestSessionLogStore_GetByID_Success(t *testing.T) {
 		WithArgs(int64(42), pgxmock.AnyArg(), pgxmock.AnyArg()).
 		WillReturnRows(
 			pgxmock.NewRows(logColumns).
-				AddRow(int64(42), sessionID, orgID, nil, now, "output", "full output", json.RawMessage(`{"type":"tool_result"}`), 3),
+				AddRow(int64(42), sessionID, orgID, nil, now, "output", "full output", json.RawMessage(`{"type":"tool_result"}`), 3, &logRowPhaseID),
 		)
 
 	log, err := store.GetByID(context.Background(), orgID, sessionID, 42)
@@ -294,6 +425,7 @@ func TestSessionLogStore_GetByID_Success(t *testing.T) {
 	require.Equal(t, sessionID, log.SessionID, "GetByID should preserve session ID")
 	require.Equal(t, orgID, log.OrgID, "GetByID should preserve org ID")
 	require.Equal(t, "full output", log.Message, "GetByID should return the full message")
+	require.Equal(t, &logRowPhaseID, log.ActivityPhaseID, "GetByID should return the stored phase association")
 	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
 }
 

--- a/internal/db/session_logs.go
+++ b/internal/db/session_logs.go
@@ -62,10 +62,41 @@ func (s *SessionLogStore) Create(ctx context.Context, log *models.SessionLog) er
 		"metadata":    log.Metadata,
 		"turn_number": log.TurnNumber,
 	}
+	if log.ActivityPhaseID != nil {
+		// The phase must belong to the same org, session, thread, and turn as the
+		// log line. Phase status is deliberately not constrained: an entry that
+		// closes a phase (final output, human input) can be persisted after the
+		// phase reaches its terminal status and still belongs to it.
+		query = `
+			INSERT INTO session_logs (session_id, org_id, thread_id, level, message, metadata, turn_number, activity_phase_id)
+			SELECT @session_id, @org_id, @thread_id, @level, @message, @metadata, @turn_number, @activity_phase_id
+			FROM sessions s
+			JOIN session_activity_phases p
+			  ON p.id = @activity_phase_id AND p.org_id = @org_id
+			 AND p.session_id = @session_id
+			 AND p.thread_id IS NOT DISTINCT FROM @thread_id
+			 AND p.turn_number = @turn_number
+			WHERE s.id = @session_id AND s.org_id = @org_id
+			RETURNING id, timestamp`
+		args["activity_phase_id"] = log.ActivityPhaseID
+	}
 
 	row := s.db.QueryRow(ctx, query, args)
 	if err := row.Scan(&log.ID, &log.Timestamp); err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
+			// A phase-carrying insert can miss for two unrelated reasons: the
+			// session/org pair is invalid, or the phase does not belong to it.
+			// Only claim a phase mismatch once the session/org pair checks out,
+			// so a tenant isolation violation is never masked by the phase.
+			if log.ActivityPhaseID != nil {
+				var sessionInOrg bool
+				if checkErr := s.db.QueryRow(ctx,
+					`SELECT EXISTS(SELECT 1 FROM sessions WHERE id = @id AND org_id = @org_id)`,
+					pgx.NamedArgs{"id": log.SessionID, "org_id": log.OrgID},
+				).Scan(&sessionInOrg); checkErr == nil && sessionInOrg {
+					return wrapPhaseOwnershipError("create session log", log.ActivityPhaseID, err)
+				}
+			}
 			// Distinguish an org_id mismatch (tenant isolation violation) from a
 			// genuinely missing session, so callers and logs can treat them
 			// differently.
@@ -124,7 +155,7 @@ func (s *SessionLogStore) MarkAssistantTranscriptDuplicate(ctx context.Context, 
 
 func (s *SessionLogStore) ListByRunID(ctx context.Context, orgID, sessionID uuid.UUID) ([]models.SessionLog, error) {
 	query := `
-		SELECT sl.id, sl.session_id, sl.org_id, sl.thread_id, sl.timestamp, sl.level, sl.message, sl.metadata, sl.turn_number
+		SELECT sl.id, sl.session_id, sl.org_id, sl.thread_id, sl.timestamp, sl.level, sl.message, sl.metadata, sl.turn_number, sl.activity_phase_id
 		FROM session_logs sl
 		WHERE sl.session_id = @session_id AND sl.org_id = @org_id
 		ORDER BY sl.id ASC`
@@ -136,12 +167,12 @@ func (s *SessionLogStore) ListByRunID(ctx context.Context, orgID, sessionID uuid
 	if err != nil {
 		return nil, fmt.Errorf("query session logs: %w", err)
 	}
-	return pgx.CollectRows(rows, pgx.RowToStructByName[models.SessionLog])
+	return pgx.CollectRows(rows, pgx.RowToStructByNameLax[models.SessionLog])
 }
 
 func (s *SessionLogStore) GetByID(ctx context.Context, orgID, sessionID uuid.UUID, logID int64) (models.SessionLog, error) {
 	query := `
-		SELECT sl.id, sl.session_id, sl.org_id, sl.thread_id, sl.timestamp, sl.level, sl.message, sl.metadata, sl.turn_number
+		SELECT sl.id, sl.session_id, sl.org_id, sl.thread_id, sl.timestamp, sl.level, sl.message, sl.metadata, sl.turn_number, sl.activity_phase_id
 		FROM session_logs sl
 		WHERE sl.id = @id AND sl.session_id = @session_id AND sl.org_id = @org_id`
 
@@ -153,7 +184,7 @@ func (s *SessionLogStore) GetByID(ctx context.Context, orgID, sessionID uuid.UUI
 	if err != nil {
 		return models.SessionLog{}, fmt.Errorf("query session log: %w", err)
 	}
-	log, err := pgx.CollectOneRow(rows, pgx.RowToStructByName[models.SessionLog])
+	log, err := pgx.CollectOneRow(rows, pgx.RowToStructByNameLax[models.SessionLog])
 	if err != nil {
 		return models.SessionLog{}, err
 	}
@@ -162,7 +193,7 @@ func (s *SessionLogStore) GetByID(ctx context.Context, orgID, sessionID uuid.UUI
 
 func (s *SessionLogStore) ListByRunIDSince(ctx context.Context, orgID, sessionID uuid.UUID, sinceID int64) ([]models.SessionLog, error) {
 	query := `
-		SELECT sl.id, sl.session_id, sl.org_id, sl.thread_id, sl.timestamp, sl.level, sl.message, sl.metadata, sl.turn_number
+		SELECT sl.id, sl.session_id, sl.org_id, sl.thread_id, sl.timestamp, sl.level, sl.message, sl.metadata, sl.turn_number, sl.activity_phase_id
 		FROM session_logs sl
 		WHERE sl.session_id = @session_id AND sl.org_id = @org_id AND sl.id > @since_id
 		ORDER BY sl.id ASC`
@@ -175,12 +206,12 @@ func (s *SessionLogStore) ListByRunIDSince(ctx context.Context, orgID, sessionID
 	if err != nil {
 		return nil, fmt.Errorf("query session logs since: %w", err)
 	}
-	return pgx.CollectRows(rows, pgx.RowToStructByName[models.SessionLog])
+	return pgx.CollectRows(rows, pgx.RowToStructByNameLax[models.SessionLog])
 }
 
 func (s *SessionLogStore) ListByThread(ctx context.Context, orgID, threadID uuid.UUID) ([]models.SessionLog, error) {
 	query := `
-		SELECT sl.id, sl.session_id, sl.org_id, sl.thread_id, sl.timestamp, sl.level, sl.message, sl.metadata, sl.turn_number
+		SELECT sl.id, sl.session_id, sl.org_id, sl.thread_id, sl.timestamp, sl.level, sl.message, sl.metadata, sl.turn_number, sl.activity_phase_id
 		FROM session_logs sl
 		WHERE sl.thread_id = @thread_id AND sl.org_id = @org_id
 		ORDER BY sl.id ASC`
@@ -192,7 +223,7 @@ func (s *SessionLogStore) ListByThread(ctx context.Context, orgID, threadID uuid
 	if err != nil {
 		return nil, fmt.Errorf("query thread logs: %w", err)
 	}
-	return pgx.CollectRows(rows, pgx.RowToStructByName[models.SessionLog])
+	return pgx.CollectRows(rows, pgx.RowToStructByNameLax[models.SessionLog])
 }
 
 func (s *SessionLogStore) ListByThreadTurns(ctx context.Context, orgID, threadID uuid.UUID, turnNumbers []int) ([]models.SessionLog, error) {
@@ -210,7 +241,7 @@ func (s *SessionLogStore) ListByThreadTurns(ctx context.Context, orgID, threadID
 		return []models.SessionLog{}, nil
 	}
 	query := `
-		SELECT sl.id, sl.session_id, sl.org_id, sl.thread_id, sl.timestamp, sl.level, sl.message, sl.metadata, sl.turn_number
+		SELECT sl.id, sl.session_id, sl.org_id, sl.thread_id, sl.timestamp, sl.level, sl.message, sl.metadata, sl.turn_number, sl.activity_phase_id
 		FROM session_logs sl
 		WHERE sl.thread_id = @thread_id AND sl.org_id = @org_id
 		  AND sl.turn_number = ANY(@turn_numbers::int[])
@@ -224,7 +255,7 @@ func (s *SessionLogStore) ListByThreadTurns(ctx context.Context, orgID, threadID
 	if err != nil {
 		return nil, fmt.Errorf("query thread logs by turns: %w", err)
 	}
-	return pgx.CollectRows(rows, pgx.RowToStructByName[models.SessionLog])
+	return pgx.CollectRows(rows, pgx.RowToStructByNameLax[models.SessionLog])
 }
 
 // ListByThreadLatestTurns returns the thread's logs for its latestTurns
@@ -235,7 +266,7 @@ func (s *SessionLogStore) ListByThreadLatestTurns(ctx context.Context, orgID, th
 		return []models.SessionLog{}, nil
 	}
 	query := `
-		SELECT sl.id, sl.session_id, sl.org_id, sl.thread_id, sl.timestamp, sl.level, sl.message, sl.metadata, sl.turn_number
+		SELECT sl.id, sl.session_id, sl.org_id, sl.thread_id, sl.timestamp, sl.level, sl.message, sl.metadata, sl.turn_number, sl.activity_phase_id
 		FROM session_logs sl
 		WHERE sl.thread_id = @thread_id AND sl.org_id = @org_id
 		  AND sl.turn_number > (
@@ -253,7 +284,7 @@ func (s *SessionLogStore) ListByThreadLatestTurns(ctx context.Context, orgID, th
 	if err != nil {
 		return nil, fmt.Errorf("query thread logs by latest turns: %w", err)
 	}
-	return pgx.CollectRows(rows, pgx.RowToStructByName[models.SessionLog])
+	return pgx.CollectRows(rows, pgx.RowToStructByNameLax[models.SessionLog])
 }
 
 // DeleteExpired removes session logs older than the given number of days.

--- a/internal/db/session_messages.go
+++ b/internal/db/session_messages.go
@@ -20,7 +20,7 @@ func NewSessionMessageStore(db DBTX) *SessionMessageStore {
 	return &SessionMessageStore{db: db}
 }
 
-const sessionMessageSelectColumns = `id, session_id, org_id, thread_id, user_id, turn_number, role, content, attachments, "references", commands, token_usage, source, created_at`
+const sessionMessageSelectColumns = `id, session_id, org_id, thread_id, user_id, turn_number, role, content, attachments, "references", commands, token_usage, source, created_at, activity_phase_id`
 
 const DefaultSessionMessageWindowLimit = 60
 const MaxSessionMessageWindowLimit = 200
@@ -74,9 +74,67 @@ func (s *SessionMessageStore) Create(ctx context.Context, msg *models.SessionMes
 		"commands":        msg.Commands,
 		"token_usage":     msg.TokenUsage,
 	}
+	if msg.ActivityPhaseID != nil {
+		query = phaseValidatedMessageInsert()
+		args["activity_phase_id"] = msg.ActivityPhaseID
+	}
 
 	row := s.db.QueryRow(ctx, query, args)
-	return row.Scan(&msg.ID, &msg.CreatedAt)
+	if err := row.Scan(&msg.ID, &msg.CreatedAt); err != nil {
+		return wrapPhaseOwnershipError("create session message", msg.ActivityPhaseID, err)
+	}
+	return nil
+}
+
+// phaseValidatedMessageInsert builds the message insert used when the message
+// carries an activity phase.
+func phaseValidatedMessageInsert() string {
+	return buildPhaseValidatedMessageInsert(false)
+}
+
+// phaseValidatedMessageInsertWithSource is phaseValidatedMessageInsert for the
+// write path that also persists the message source.
+func phaseValidatedMessageInsertWithSource() string {
+	return buildPhaseValidatedMessageInsert(true)
+}
+
+// buildPhaseValidatedMessageInsert validates that the phase belongs to the same
+// org, session, thread, and turn as the message. Phase status is deliberately
+// not constrained: a message that closes a phase (the final assistant summary)
+// can be persisted after the phase reaches its terminal status and still
+// belongs to it.
+func buildPhaseValidatedMessageInsert(withSource bool) string {
+	columns := `session_id, org_id, thread_id, user_id, turn_number, role, content, attachments, "references", commands, token_usage`
+	values := `@session_id, @org_id, @thread_id, @user_id, @turn_number, @role, @content, @attachments, @references_data, @commands, @token_usage`
+	if withSource {
+		columns += `, source`
+		values += `, @source`
+	}
+	return `
+		INSERT INTO session_messages (` + columns + `, activity_phase_id)
+		SELECT ` + values + `, @activity_phase_id
+		FROM session_activity_phases p
+		WHERE p.id = @activity_phase_id AND p.org_id = @org_id
+		  AND p.session_id = @session_id
+		  AND p.thread_id IS NOT DISTINCT FROM @thread_id
+		  AND p.turn_number = @turn_number
+		RETURNING id, created_at`
+}
+
+// wrapPhaseOwnershipError annotates the empty result a phase-validated insert
+// returns when the phase does not belong to the same org, session, thread, and
+// turn, so the failure is not reported as a bare "no rows". operation names the
+// failing write (e.g. "create session message").
+func wrapPhaseOwnershipError(operation string, phaseID *uuid.UUID, err error) error {
+	if phaseID != nil && errors.Is(err, pgx.ErrNoRows) {
+		return fmt.Errorf(
+			"%s: activity phase %s does not match org/session/thread/turn ownership: %w",
+			operation,
+			*phaseID,
+			err,
+		)
+	}
+	return err
 }
 
 func (s *SessionMessageStore) CreateWithSource(ctx context.Context, msg *models.SessionMessage) error {
@@ -99,9 +157,16 @@ func (s *SessionMessageStore) CreateWithSource(ctx context.Context, msg *models.
 		"token_usage":     msg.TokenUsage,
 		"source":          msg.Source,
 	}
+	if msg.ActivityPhaseID != nil {
+		query = phaseValidatedMessageInsertWithSource()
+		args["activity_phase_id"] = msg.ActivityPhaseID
+	}
 
 	row := s.db.QueryRow(ctx, query, args)
-	return row.Scan(&msg.ID, &msg.CreatedAt)
+	if err := row.Scan(&msg.ID, &msg.CreatedAt); err != nil {
+		return wrapPhaseOwnershipError("create session message", msg.ActivityPhaseID, err)
+	}
+	return nil
 }
 
 func (s *SessionMessageStore) ListBySession(ctx context.Context, orgID, sessionID uuid.UUID) ([]models.SessionMessage, error) {

--- a/internal/db/session_messages_test.go
+++ b/internal/db/session_messages_test.go
@@ -13,6 +13,8 @@ import (
 	"github.com/assembledhq/143/internal/models"
 )
 
+const sessionMessagePhaseInsertPattern = `(?s)FROM session_activity_phases p.+p\.id = @activity_phase_id AND p\.org_id = @org_id.+p\.session_id = @session_id.+p\.thread_id IS NOT DISTINCT FROM @thread_id.+p\.turn_number = @turn_number`
+
 func TestSessionMessageStore_Create(t *testing.T) {
 	t.Parallel()
 
@@ -63,6 +65,99 @@ func TestSessionMessageStore_Create(t *testing.T) {
 	require.NoError(t, mock.ExpectationsWereMet())
 }
 
+func TestSessionMessageStore_Create_ValidatesActivityPhaseOwnership(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "database mock should initialize")
+	t.Cleanup(mock.Close)
+
+	phaseID := uuid.New()
+	threadID := uuid.New()
+	msg := models.SessionMessage{
+		SessionID: uuid.New(), OrgID: uuid.New(), ThreadID: &threadID,
+		TurnNumber: 1, Role: models.MessageRoleAssistant, Content: "done",
+		ActivityPhaseID: &phaseID,
+	}
+	mock.ExpectQuery(sessionMessagePhaseInsertPattern).
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), &phaseID).
+		WillReturnRows(pgxmock.NewRows([]string{"id", "created_at"}).AddRow(int64(1), time.Now()))
+
+	err = NewSessionMessageStore(mock).Create(context.Background(), &msg)
+	require.NoError(t, err, "phase-associated message should be inserted after full ownership validation")
+	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
+}
+
+func TestSessionMessageStore_Create_DoesNotRequireRunningActivityPhase(t *testing.T) {
+	t.Parallel()
+
+	mock, capturedSQL := newSQLCapturingPool(t)
+
+	phaseID := uuid.New()
+	threadID := uuid.New()
+	msg := models.SessionMessage{
+		SessionID: uuid.New(), OrgID: uuid.New(), ThreadID: &threadID,
+		TurnNumber: 1, Role: models.MessageRoleAssistant, Content: "final answer",
+		ActivityPhaseID: &phaseID,
+	}
+	mock.ExpectQuery(sessionMessagePhaseInsertPattern).
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), &phaseID).
+		WillReturnRows(pgxmock.NewRows([]string{"id", "created_at"}).AddRow(int64(1), time.Now()))
+
+	err := NewSessionMessageStore(mock).Create(context.Background(), &msg)
+	require.NoError(t, err, "phase-closing message should be inserted regardless of the phase's terminal status")
+	// The final assistant summary closes its phase, so it is written after the
+	// phase reaches a terminal status.
+	require.NotContains(t, *capturedSQL, "p.status", "validated insert should not constrain the phase status")
+	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
+}
+
+func TestSessionMessageStore_Create_RejectsMismatchedActivityPhase(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "database mock should initialize")
+	t.Cleanup(mock.Close)
+
+	phaseID := uuid.New()
+	threadID := uuid.New()
+	msg := models.SessionMessage{
+		SessionID: uuid.New(), OrgID: uuid.New(), ThreadID: &threadID,
+		TurnNumber: 1, Role: models.MessageRoleAssistant, Content: "done",
+		ActivityPhaseID: &phaseID,
+	}
+	mock.ExpectQuery(sessionMessagePhaseInsertPattern).
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), &phaseID).
+		WillReturnRows(pgxmock.NewRows([]string{"id", "created_at"}))
+
+	err = NewSessionMessageStore(mock).Create(context.Background(), &msg)
+	require.ErrorContains(t, err, "does not match org/session/thread/turn ownership", "mismatched phase should return a diagnosable ownership error")
+	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
+}
+
+func TestSessionMessageStore_CreateWithSource_RejectsMismatchedActivityPhase(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "database mock should initialize")
+	t.Cleanup(mock.Close)
+
+	phaseID := uuid.New()
+	threadID := uuid.New()
+	msg := models.SessionMessage{
+		SessionID: uuid.New(), OrgID: uuid.New(), ThreadID: &threadID,
+		TurnNumber: 1, Role: models.MessageRoleAssistant, Content: "done",
+		Source: models.SessionMessageSourceAgentTool, ActivityPhaseID: &phaseID,
+	}
+	mock.ExpectQuery(sessionMessagePhaseInsertPattern).
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), &phaseID).
+		WillReturnRows(pgxmock.NewRows([]string{"id", "created_at"}))
+
+	err = NewSessionMessageStore(mock).CreateWithSource(context.Background(), &msg)
+	require.ErrorContains(t, err, "does not match org/session/thread/turn ownership", "mismatched phase should return a diagnosable ownership error")
+	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
+}
+
 func TestSessionMessageStore_CreateWithSource(t *testing.T) {
 	t.Parallel()
 
@@ -105,14 +200,15 @@ func TestSessionMessageStore_ListBySession(t *testing.T) {
 	store := NewSessionMessageStore(mock)
 	orgID := uuid.New()
 	sessionID := uuid.New()
+	phaseID := uuid.New()
 	now := time.Now()
 
 	mock.ExpectQuery("SELECT .+ FROM session_messages WHERE org_id").
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
 		WillReturnRows(
-			pgxmock.NewRows([]string{"id", "session_id", "org_id", "thread_id", "user_id", "turn_number", "role", "content", "attachments", "references", "commands", "token_usage", "source", "created_at"}).
-				AddRow(int64(1), sessionID, orgID, nil, nil, 1, "user", "Fix the bug", nil, []byte(`[{"kind":"file","token":"@internal/api/handlers/sessions.go","path":"internal/api/handlers/sessions.go","display":"internal/api/handlers/sessions.go"}]`), []byte(`[{"kind":"command","agent_type":"claude_code","name":"review","token":"/review","display":"/review"}]`), nil, "agent_tool", now).
-				AddRow(int64(2), sessionID, orgID, nil, nil, 1, "assistant", "Done", nil, nil, nil, nil, "", now),
+			pgxmock.NewRows([]string{"id", "session_id", "org_id", "thread_id", "user_id", "turn_number", "role", "content", "attachments", "references", "commands", "token_usage", "source", "created_at", "activity_phase_id"}).
+				AddRow(int64(1), sessionID, orgID, nil, nil, 1, "user", "Fix the bug", nil, []byte(`[{"kind":"file","token":"@internal/api/handlers/sessions.go","path":"internal/api/handlers/sessions.go","display":"internal/api/handlers/sessions.go"}]`), []byte(`[{"kind":"command","agent_type":"claude_code","name":"review","token":"/review","display":"/review"}]`), nil, "agent_tool", now, nil).
+				AddRow(int64(2), sessionID, orgID, nil, nil, 1, "assistant", "Done", nil, nil, nil, nil, "", now, &phaseID),
 		)
 
 	msgs, err := store.ListBySession(context.Background(), orgID, sessionID)
@@ -127,6 +223,8 @@ func TestSessionMessageStore_ListBySession(t *testing.T) {
 	require.Equal(t, models.AgentTypeClaudeCode, msgs[0].Commands[0].AgentType)
 	require.Equal(t, models.SessionMessageSourceAgentTool, msgs[0].Source)
 	require.Equal(t, "Done", msgs[1].Content)
+	require.Nil(t, msgs[0].ActivityPhaseID, "an unassociated message should list without a phase")
+	require.Equal(t, &phaseID, msgs[1].ActivityPhaseID, "listed message should carry the phase association it was stored with")
 	require.NoError(t, mock.ExpectationsWereMet())
 }
 

--- a/internal/db/session_transcript_store.go
+++ b/internal/db/session_transcript_store.go
@@ -235,7 +235,7 @@ func (s *SessionTranscriptStore) fetchEntriesForTurns(
 	if include.Tools || include.System {
 		// --- session_logs ---
 		logQuery := `
-		SELECT id, session_id, org_id, thread_id, timestamp, level, message, metadata, turn_number
+		SELECT id, session_id, org_id, thread_id, timestamp, level, message, metadata, turn_number, activity_phase_id
 		FROM session_logs
 		WHERE org_id = @org_id AND thread_id = @thread_id
 		  AND turn_number = ANY(@turns)
@@ -250,7 +250,7 @@ func (s *SessionTranscriptStore) fetchEntriesForTurns(
 		if err != nil {
 			return nil, fmt.Errorf("query transcript logs: %w", err)
 		}
-		logs, err := pgx.CollectRows(logRows, pgx.RowToStructByName[models.SessionLog])
+		logs, err := pgx.CollectRows(logRows, pgx.RowToStructByNameLax[models.SessionLog])
 		if err != nil {
 			return nil, fmt.Errorf("collect transcript logs: %w", err)
 		}

--- a/internal/models/human_input.go
+++ b/internal/models/human_input.go
@@ -139,6 +139,7 @@ type HumanInputRequest struct {
 	AnsweredAt        *time.Time                 `db:"answered_at" json:"answered_at,omitempty"`
 	ExpiresAt         *time.Time                 `db:"expires_at" json:"expires_at,omitempty"`
 	CreatedAt         time.Time                  `db:"created_at" json:"created_at"`
+	ActivityPhaseID   *uuid.UUID                 `db:"activity_phase_id" json:"activity_phase_id,omitempty"`
 }
 
 type HumanInputAnswerInput struct {

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -827,15 +827,16 @@ type SessionCounts struct {
 
 // SessionLog represents a log line emitted during an agent run.
 type SessionLog struct {
-	ID         int64           `db:"id" json:"id"`
-	SessionID  uuid.UUID       `db:"session_id" json:"session_id"`
-	OrgID      uuid.UUID       `db:"org_id" json:"org_id"`
-	ThreadID   *uuid.UUID      `db:"thread_id" json:"thread_id,omitempty"`
-	Timestamp  time.Time       `db:"timestamp" json:"created_at"`
-	Level      SessionLogLevel `db:"level" json:"level"`
-	Message    string          `db:"message" json:"message"`
-	Metadata   json.RawMessage `db:"metadata" json:"metadata,omitempty"`
-	TurnNumber int             `db:"turn_number" json:"turn_number"`
+	ID              int64           `db:"id" json:"id"`
+	SessionID       uuid.UUID       `db:"session_id" json:"session_id"`
+	OrgID           uuid.UUID       `db:"org_id" json:"org_id"`
+	ThreadID        *uuid.UUID      `db:"thread_id" json:"thread_id,omitempty"`
+	Timestamp       time.Time       `db:"timestamp" json:"created_at"`
+	Level           SessionLogLevel `db:"level" json:"level"`
+	Message         string          `db:"message" json:"message"`
+	Metadata        json.RawMessage `db:"metadata" json:"metadata,omitempty"`
+	TurnNumber      int             `db:"turn_number" json:"turn_number"`
+	ActivityPhaseID *uuid.UUID      `db:"activity_phase_id" json:"activity_phase_id,omitempty"`
 
 	MessageBytes     int  `db:"-" json:"message_bytes,omitempty"`
 	MessageChars     int  `db:"-" json:"message_chars,omitempty"`
@@ -861,20 +862,21 @@ func (s SessionMessageSource) Validate() error {
 }
 
 type SessionMessage struct {
-	ID          int64                  `db:"id" json:"id"`
-	SessionID   uuid.UUID              `db:"session_id" json:"session_id"`
-	OrgID       uuid.UUID              `db:"org_id" json:"org_id"`
-	ThreadID    *uuid.UUID             `db:"thread_id" json:"thread_id,omitempty"`
-	UserID      *uuid.UUID             `db:"user_id" json:"user_id,omitempty"`
-	TurnNumber  int                    `db:"turn_number" json:"turn_number"`
-	Role        MessageRole            `db:"role" json:"role"`
-	Content     string                 `db:"content" json:"content"`
-	Attachments []string               `db:"attachments" json:"attachments,omitempty"`
-	References  SessionInputReferences `db:"references" json:"references,omitempty"`
-	Commands    SessionInputCommands   `db:"commands" json:"commands,omitempty"`
-	TokenUsage  json.RawMessage        `db:"token_usage" json:"token_usage,omitempty"`
-	Source      SessionMessageSource   `db:"source" json:"source,omitempty"`
-	CreatedAt   time.Time              `db:"created_at" json:"created_at"`
+	ID              int64                  `db:"id" json:"id"`
+	SessionID       uuid.UUID              `db:"session_id" json:"session_id"`
+	OrgID           uuid.UUID              `db:"org_id" json:"org_id"`
+	ThreadID        *uuid.UUID             `db:"thread_id" json:"thread_id,omitempty"`
+	UserID          *uuid.UUID             `db:"user_id" json:"user_id,omitempty"`
+	TurnNumber      int                    `db:"turn_number" json:"turn_number"`
+	Role            MessageRole            `db:"role" json:"role"`
+	Content         string                 `db:"content" json:"content"`
+	Attachments     []string               `db:"attachments" json:"attachments,omitempty"`
+	References      SessionInputReferences `db:"references" json:"references,omitempty"`
+	Commands        SessionInputCommands   `db:"commands" json:"commands,omitempty"`
+	TokenUsage      json.RawMessage        `db:"token_usage" json:"token_usage,omitempty"`
+	Source          SessionMessageSource   `db:"source" json:"source,omitempty"`
+	CreatedAt       time.Time              `db:"created_at" json:"created_at"`
+	ActivityPhaseID *uuid.UUID             `db:"activity_phase_id" json:"activity_phase_id,omitempty"`
 }
 
 // ThreadCreatedBySource identifies what or who created a session thread.

--- a/internal/services/agent/orchestrator.go
+++ b/internal/services/agent/orchestrator.go
@@ -3465,12 +3465,13 @@ func (o *Orchestrator) RunAgent(ctx context.Context, run *models.Session) error 
 
 	// 10. Execute agent with log streaming.
 	o.honorPendingCancelRequest(ctx, run.OrgID, run.ID, log)
+	writeCtx := TranscriptWriteContext{ThreadID: primaryThreadID, TurnNumber: turnNumber}
 	logCh := make(chan LogEntry, 100)
 	var logWg sync.WaitGroup
 	logWg.Add(1)
 	go func() {
 		defer logWg.Done()
-		o.streamLogs(ctx, run.ID, run.OrgID, run.AgentType, primaryThreadID, turnNumber, logCh, runtimeTracker)
+		o.streamLogs(ctx, run.ID, run.OrgID, run.AgentType, writeCtx, logCh, runtimeTracker)
 	}()
 
 	execCtx := WithSandboxProvider(ctx, o.provider)
@@ -3497,13 +3498,13 @@ func (o *Orchestrator) RunAgent(ctx context.Context, run *models.Session) error 
 	logWg.Wait()
 
 	// 10b. Retry once on token expiration for Codex agents.
-	result, err = o.retryOnTokenExpired(ctx, run.AgentType, run.OrgID, run.TriggeredByUserID, run.ID, primaryThreadID, turnNumber, sandbox, adapter, execCtx, prompt, result, err, log)
+	result, err = o.retryOnTokenExpired(ctx, run.AgentType, run.OrgID, run.TriggeredByUserID, run.ID, writeCtx, sandbox, adapter, execCtx, prompt, result, err, log)
 
 	// 10c. Shed the just-picked credential's in-process health-cache slot if
 	// the (possibly retried) result indicates a credential-level failure.
 	// No-ops cleanly for agent types whose auth flows do not pass through
 	// the unified resolver (e.g. Codex subscription via codexauth.Service).
-	result, err, _ = o.retrySessionOnCredentialRateLimit(ctx, run, primaryThreadID, turnNumber, sandboxCfg, sandbox, adapter, execCtx, prompt, result, err, false, log)
+	result, err, _ = o.retrySessionOnCredentialRateLimit(ctx, run, writeCtx, sandboxCfg, sandbox, adapter, execCtx, prompt, result, err, false, log)
 	if _, harvestErr := o.harvestClaudeCodeCredentials(ctx, run, sandbox, authBillingMode, log); harvestErr != nil {
 		log.Warn().
 			Err(harvestErr).
@@ -3671,7 +3672,7 @@ func (o *Orchestrator) RunAgent(ctx context.Context, run *models.Session) error 
 
 	if isInteractive {
 		turnNumber := run.CurrentTurn + 1
-		if err := o.createAssistantMessage(ctx, run.ID, run.OrgID, primaryThreadID, turnNumber, result); err != nil {
+		if err := o.createAssistantMessage(ctx, run.ID, run.OrgID, writeCtx.withTurn(turnNumber), result); err != nil {
 			log.Warn().Err(err).Msg("failed to persist assistant message for interactive turn")
 		}
 
@@ -5100,12 +5101,13 @@ func (o *Orchestrator) ContinueSession(ctx context.Context, session *models.Sess
 	}
 
 	// 6. Execute agent with log streaming.
+	writeCtx := TranscriptWriteContext{ThreadID: threadID, TurnNumber: messageTurnNumber}
 	logCh := make(chan LogEntry, 100)
 	var logWg sync.WaitGroup
 	logWg.Add(1)
 	go func() {
 		defer logWg.Done()
-		o.streamLogs(ctx, session.ID, session.OrgID, session.AgentType, threadID, messageTurnNumber, logCh, runtimeTracker)
+		o.streamLogs(ctx, session.ID, session.OrgID, session.AgentType, writeCtx, logCh, runtimeTracker)
 	}()
 
 	execCtx := WithSandboxProvider(ctx, o.provider)
@@ -5161,12 +5163,12 @@ func (o *Orchestrator) ContinueSession(ctx context.Context, session *models.Sess
 	logWg.Wait()
 
 	// 6b. Retry once on token expiration for Codex agents.
-	result, err = o.retryOnTokenExpired(ctx, session.AgentType, session.OrgID, session.TriggeredByUserID, session.ID, threadID, messageTurnNumber, sandbox, adapter, execCtx, prompt, result, err, log)
+	result, err = o.retryOnTokenExpired(ctx, session.AgentType, session.OrgID, session.TriggeredByUserID, session.ID, writeCtx, sandbox, adapter, execCtx, prompt, result, err, log)
 
 	// 6c. Shed the just-picked credential when the (post-retry) result shows
 	// rate-limit or auth-rejected signals. Same semantics as the entry-turn
 	// path above; see shedOnRunResult.
-	result, err, _ = o.retrySessionOnCredentialRateLimit(ctx, session, threadID, messageTurnNumber, sandboxCfg, sandbox, adapter, execCtx, prompt, result, err, true, log)
+	result, err, _ = o.retrySessionOnCredentialRateLimit(ctx, session, writeCtx, sandboxCfg, sandbox, adapter, execCtx, prompt, result, err, true, log)
 	if _, harvestErr := o.harvestClaudeCodeCredentials(ctx, session, sandbox, authBillingMode, log); harvestErr != nil {
 		log.Warn().
 			Err(harvestErr).
@@ -5263,7 +5265,7 @@ func (o *Orchestrator) ContinueSession(ctx context.Context, session *models.Sess
 	}
 
 	// 7. Create assistant message with result summary.
-	if err := o.createAssistantMessage(ctx, session.ID, session.OrgID, threadID, messageTurnNumber, result); err != nil {
+	if err := o.createAssistantMessage(ctx, session.ID, session.OrgID, writeCtx, result); err != nil {
 		log.Warn().Err(err).Msg("failed to create assistant message")
 	}
 	if opts != nil && opts.ResultAgentSessionID != nil {
@@ -6066,29 +6068,74 @@ func (o *Orchestrator) checkConcurrency(ctx context.Context, orgID uuid.UUID, ex
 	return nil
 }
 
+// TranscriptWriteContext carries the durable execution identity shared by all
+// transcript writers for one provider invocation.
+type TranscriptWriteContext struct {
+	ThreadID        *uuid.UUID
+	TurnNumber      int
+	ActivityPhaseID *uuid.UUID
+}
+
+// withTurn rescopes the context to a different turn. A phase belongs to exactly
+// one turn, so the phase association is dropped when the turn actually changes:
+// writers validate turn ownership and would otherwise reject the whole entry
+// rather than just its association.
+func (c TranscriptWriteContext) withTurn(turnNumber int) TranscriptWriteContext {
+	if turnNumber != c.TurnNumber {
+		c.ActivityPhaseID = nil
+	}
+	c.TurnNumber = turnNumber
+	return c
+}
+
+// phaseAssociation returns the phase to persist alongside an entry written
+// under this context. Phases are thread-scoped and session_activity_phases
+// .thread_id is NOT NULL, so an unthreaded context carries no phase — every
+// transcript writer goes through here so the invariant holds in one place.
+func (c TranscriptWriteContext) phaseAssociation() *uuid.UUID {
+	if c.ThreadID == nil {
+		return nil
+	}
+	return c.ActivityPhaseID
+}
+
+// forThread rescopes the context to the thread an entry actually resolved to.
+// A phase is thread-scoped, so the phase association is dropped when the entry
+// belongs to a different thread than the one the context was opened for —
+// writers validate phase ownership and would otherwise reject the entry
+// entirely rather than just its association.
+func (c TranscriptWriteContext) forThread(threadID *uuid.UUID) TranscriptWriteContext {
+	if threadID == nil || c.ThreadID == nil || *threadID != *c.ThreadID {
+		c.ActivityPhaseID = nil
+	}
+	c.ThreadID = threadID
+	return c
+}
+
 // streamLogs reads LogEntry values from the channel and persists them to the DB.
 // It also normalizes structured or legacy human-input prompts into durable pause records.
-func (o *Orchestrator) streamLogs(ctx context.Context, runID, orgID uuid.UUID, agentType models.AgentType, threadID *uuid.UUID, turnNumber int, logCh <-chan LogEntry, tracker *runtimeProgressTracker) {
+func (o *Orchestrator) streamLogs(ctx context.Context, runID, orgID uuid.UUID, agentType models.AgentType, writeCtx TranscriptWriteContext, logCh <-chan LogEntry, tracker *runtimeProgressTracker) {
 	for entry := range logCh {
 		if tracker != nil {
 			if progressType, strength, toolID, ok := runtimeProgressFromLog(entry); ok {
 				tracker.Record(progressType, strength, entry.Timestamp, toolID, runtimeToolSummaryFromLog(entry))
 			}
 		}
-		effectiveThreadID := threadID
+		effectiveThreadID := writeCtx.ThreadID
 		if effectiveThreadID == nil {
 			effectiveThreadID = entry.ThreadID
 		}
+		entryCtx := writeCtx.forThread(effectiveThreadID)
 
 		var humanInputRecord *models.HumanInputRequest
 		if entry.HumanInput != nil {
-			humanInputRecord = o.handleHumanInputRequest(ctx, runID, orgID, agentType, effectiveThreadID, turnNumber, entry.HumanInput)
+			humanInputRecord = o.handleHumanInputRequest(ctx, runID, orgID, agentType, entryCtx, entry.HumanInput)
 		} else if entry.Level == "question" {
 			req := humanInputRequestFromQuestionLog(entry)
 			entry.HumanInput = &req
 			entry.Level = "human_input"
 			entry.Message = req.Body
-			humanInputRecord = o.handleHumanInputRequest(ctx, runID, orgID, agentType, effectiveThreadID, turnNumber, &req)
+			humanInputRecord = o.handleHumanInputRequest(ctx, runID, orgID, agentType, entryCtx, &req)
 		}
 		if humanInputRecord != nil {
 			annotateHumanInputLogMetadata(&entry, humanInputRecord)
@@ -6105,13 +6152,14 @@ func (o *Orchestrator) streamLogs(ctx context.Context, runID, orgID uuid.UUID, a
 		}
 
 		log := &models.SessionLog{
-			SessionID:  runID,
-			OrgID:      orgID,
-			ThreadID:   effectiveThreadID,
-			Level:      models.SessionLogLevel(entry.Level),
-			Message:    entry.Message,
-			Metadata:   metadata,
-			TurnNumber: turnNumber,
+			SessionID:       runID,
+			OrgID:           orgID,
+			ThreadID:        entryCtx.ThreadID,
+			Level:           models.SessionLogLevel(entry.Level),
+			Message:         entry.Message,
+			Metadata:        metadata,
+			TurnNumber:      entryCtx.TurnNumber,
+			ActivityPhaseID: entryCtx.phaseAssociation(),
 		}
 		if err := o.agentRunLogs.Create(ctx, log); err != nil {
 			o.logger.Error().Err(err).Str("run_id", runID.String()).Msg("failed to persist log entry")
@@ -6123,8 +6171,7 @@ func (o *Orchestrator) handleHumanInputRequest(
 	ctx context.Context,
 	sessionID, orgID uuid.UUID,
 	agentType models.AgentType,
-	threadID *uuid.UUID,
-	turnNumber int,
+	writeCtx TranscriptWriteContext,
 	req *HumanInputRequest,
 ) *models.HumanInputRequest {
 	if req == nil {
@@ -6149,8 +6196,9 @@ func (o *Orchestrator) handleHumanInputRequest(
 		record := &models.HumanInputRequest{
 			OrgID:             orgID,
 			SessionID:         sessionID,
-			ThreadID:          threadID,
-			TurnNumber:        turnNumber,
+			ThreadID:          writeCtx.ThreadID,
+			TurnNumber:        writeCtx.TurnNumber,
+			ActivityPhaseID:   writeCtx.phaseAssociation(),
 			AgentType:         agentType,
 			ProviderRequestID: providerRequestID,
 			Kind:              req.Kind,
@@ -8064,18 +8112,19 @@ func gracefulStopFailure(reason StopReason, checkpointedThisTurn, hadPriorCheckp
 	}
 }
 
-func (o *Orchestrator) createAssistantMessage(ctx context.Context, sessionID, orgID uuid.UUID, threadID *uuid.UUID, turnNumber int, result *AgentResult) error {
+func (o *Orchestrator) createAssistantMessage(ctx context.Context, sessionID, orgID uuid.UUID, writeCtx TranscriptWriteContext, result *AgentResult) error {
 	if o.sessionMessages == nil {
 		return nil
 	}
 
 	assistantMsg := &models.SessionMessage{
-		SessionID:  sessionID,
-		OrgID:      orgID,
-		ThreadID:   threadID,
-		TurnNumber: turnNumber,
-		Role:       models.MessageRoleAssistant,
-		Content:    result.Summary,
+		SessionID:       sessionID,
+		OrgID:           orgID,
+		ThreadID:        writeCtx.ThreadID,
+		TurnNumber:      writeCtx.TurnNumber,
+		Role:            models.MessageRoleAssistant,
+		Content:         result.Summary,
+		ActivityPhaseID: writeCtx.phaseAssociation(),
 	}
 	if HasPersistableTokenUsage(result.TokenUsage) {
 		tokenJSON, err := json.Marshal(result.TokenUsage)
@@ -8090,12 +8139,12 @@ func (o *Orchestrator) createAssistantMessage(ctx context.Context, sessionID, or
 	if marker, ok := o.agentRunLogs.(interface {
 		MarkAssistantTranscriptDuplicate(ctx context.Context, orgID, sessionID uuid.UUID, threadID *uuid.UUID, turnNumber int, message string) error
 	}); ok && result.Summary != "" {
-		if err := marker.MarkAssistantTranscriptDuplicate(ctx, orgID, sessionID, threadID, turnNumber, result.Summary); err != nil {
+		if err := marker.MarkAssistantTranscriptDuplicate(ctx, orgID, sessionID, writeCtx.ThreadID, writeCtx.TurnNumber, result.Summary); err != nil {
 			o.logger.Warn().
 				Err(err).
 				Str("session_id", sessionID.String()).
 				Str("org_id", orgID.String()).
-				Int("turn_number", turnNumber).
+				Int("turn_number", writeCtx.TurnNumber).
 				Msg("failed to mark assistant output log as transcript duplicate")
 		}
 	}
@@ -8393,8 +8442,7 @@ func (o *Orchestrator) retryOnTokenExpired(
 	orgID uuid.UUID,
 	userID *uuid.UUID,
 	sessionID uuid.UUID,
-	threadID *uuid.UUID,
-	turnNumber int,
+	writeCtx TranscriptWriteContext,
 	sandbox *Sandbox,
 	adapter AgentAdapter,
 	execCtx context.Context,
@@ -8423,7 +8471,7 @@ func (o *Orchestrator) retryOnTokenExpired(
 	retryLogWg.Add(1)
 	go func() {
 		defer retryLogWg.Done()
-		o.streamLogs(ctx, sessionID, orgID, agentType, threadID, turnNumber, retryLogCh, nil)
+		o.streamLogs(ctx, sessionID, orgID, agentType, writeCtx, retryLogCh, nil)
 	}()
 
 	result, err = adapter.Execute(execCtx, sandbox, prompt, retryLogCh)
@@ -8437,8 +8485,7 @@ func (o *Orchestrator) retryOnTokenExpired(
 func (o *Orchestrator) retrySessionOnCredentialRateLimit(
 	ctx context.Context,
 	session *models.Session,
-	threadID *uuid.UUID,
-	turnNumber int,
+	writeCtx TranscriptWriteContext,
 	sandboxCfg SandboxConfig,
 	sandbox *Sandbox,
 	adapter AgentAdapter,
@@ -8460,13 +8507,13 @@ func (o *Orchestrator) retrySessionOnCredentialRateLimit(
 	if authErr := o.env.CheckAuth(session.AgentType, refreshedEnv); authErr != nil {
 		logCredentialRateLimitBlocked(log, session, authErr)
 		if createBlockedMessage {
-			o.createContinueAuthFailureMessage(ctx, session, threadID, authErr, log)
+			o.createContinueAuthFailureMessage(ctx, session, writeCtx.ThreadID, authErr, log)
 		}
 		return result, authErr, false
 	}
 
 	sandbox.Env = cloneStringMap(refreshedEnv)
-	if authErr := o.prepareAgentAuthForRetry(ctx, session, threadID, sandbox, refreshedEnv); authErr != nil {
+	if authErr := o.prepareAgentAuthForRetry(ctx, session, writeCtx.ThreadID, sandbox, refreshedEnv); authErr != nil {
 		return result, authErr, false
 	}
 	prompt.UsageHint = o.buildTokenUsageHint(ctx, session.AgentType, session.OrgID, session.TriggeredByUserID, refreshedEnv, prompt.UsageHint)
@@ -8481,20 +8528,20 @@ func (o *Orchestrator) retrySessionOnCredentialRateLimit(
 	retryLogWg.Add(1)
 	go func() {
 		defer retryLogWg.Done()
-		o.streamLogs(ctx, session.ID, session.OrgID, session.AgentType, threadID, turnNumber, retryLogCh, nil)
+		o.streamLogs(ctx, session.ID, session.OrgID, session.AgentType, writeCtx, retryLogCh, nil)
 	}()
 	retryResult, retryErr := adapter.Execute(execCtx, sandbox, prompt, retryLogCh)
 	close(retryLogCh)
 	retryLogWg.Wait()
 
-	retryResult, retryErr = o.retryOnTokenExpired(ctx, session.AgentType, session.OrgID, session.TriggeredByUserID, session.ID, threadID, turnNumber, sandbox, adapter, execCtx, prompt, retryResult, retryErr, log)
+	retryResult, retryErr = o.retryOnTokenExpired(ctx, session.AgentType, session.OrgID, session.TriggeredByUserID, session.ID, writeCtx, sandbox, adapter, execCtx, prompt, retryResult, retryErr, log)
 	if parseCredentialFailureSignal(retryResult, time.Now()).RateLimited {
 		o.shedOnRunResult(ctx, session.AgentType, session.OrgID, session.TriggeredByUserID, retryResult, retryErr, log)
 		refreshedEnv = o.resolveSessionCredentialEnv(ctx, session, sandboxCfg)
 		if authErr := o.env.CheckAuth(session.AgentType, refreshedEnv); authErr != nil {
 			logCredentialRateLimitBlocked(log, session, authErr)
 			if createBlockedMessage {
-				o.createContinueAuthFailureMessage(ctx, session, threadID, authErr, log)
+				o.createContinueAuthFailureMessage(ctx, session, writeCtx.ThreadID, authErr, log)
 			}
 			return retryResult, authErr, true
 		}

--- a/internal/services/agent/orchestrator_internal_test.go
+++ b/internal/services/agent/orchestrator_internal_test.go
@@ -360,6 +360,27 @@ func (s *testInternalSessionMessageStore) ListBySession(ctx context.Context, org
 	return nil, nil
 }
 
+type testInternalHumanInputStore struct {
+	requests []models.HumanInputRequest
+}
+
+func (s *testInternalHumanInputStore) Create(_ context.Context, req *models.HumanInputRequest) error {
+	s.requests = append(s.requests, *req)
+	return nil
+}
+
+func (s *testInternalHumanInputStore) GetByID(context.Context, uuid.UUID, uuid.UUID, uuid.UUID) (models.HumanInputRequest, error) {
+	return models.HumanInputRequest{}, pgx.ErrNoRows
+}
+
+func (s *testInternalHumanInputStore) AnswerLatestPendingFreeTextBySession(context.Context, uuid.UUID, uuid.UUID, string, uuid.UUID) (models.HumanInputRequest, error) {
+	return models.HumanInputRequest{}, pgx.ErrNoRows
+}
+
+func (s *testInternalHumanInputStore) AnswerLatestPendingFreeTextByThread(context.Context, uuid.UUID, uuid.UUID, uuid.UUID, string, uuid.UUID) (models.HumanInputRequest, error) {
+	return models.HumanInputRequest{}, pgx.ErrNoRows
+}
+
 type testInternalUserLookup struct {
 	user models.User
 	err  error
@@ -1531,6 +1552,7 @@ func TestCreateAssistantMessage_CarriesThreadID(t *testing.T) {
 	orgID := uuid.MustParse("22222222-2222-2222-2222-222222222222")
 	sessionID := uuid.MustParse("11111111-1111-1111-1111-111111111111")
 	threadID := uuid.MustParse("33333333-3333-3333-3333-333333333333")
+	phaseID := uuid.MustParse("44444444-4444-4444-4444-444444444444")
 
 	logs := &testInternalSessionLogStore{}
 	messages := &testInternalSessionMessageStore{}
@@ -1540,13 +1562,14 @@ func TestCreateAssistantMessage_CarriesThreadID(t *testing.T) {
 		logger:          zerolog.Nop(),
 	}
 
-	err := orch.createAssistantMessage(context.Background(), sessionID, orgID, &threadID, 4, &AgentResult{
+	err := orch.createAssistantMessage(context.Background(), sessionID, orgID, TranscriptWriteContext{ThreadID: &threadID, TurnNumber: 4, ActivityPhaseID: &phaseID}, &AgentResult{
 		Summary: "Final answer",
 	})
 	require.NoError(t, err, "createAssistantMessage should persist the assistant transcript")
 	require.Len(t, messages.messages, 1, "assistant message should be created")
 	require.NotNil(t, messages.messages[0].ThreadID, "assistant message should preserve the thread id")
 	require.Equal(t, threadID, *messages.messages[0].ThreadID, "assistant message should use the provided thread id")
+	require.Equal(t, &phaseID, messages.messages[0].ActivityPhaseID, "assistant message should preserve the active phase id")
 	require.NotNil(t, logs.markedThreadID, "duplicate marker should preserve the thread id")
 	require.Equal(t, threadID, *logs.markedThreadID, "duplicate marker should use the provided thread id")
 	require.Equal(t, 4, logs.markedTurnNumber, "duplicate marker should use the provided turn number")
@@ -1564,7 +1587,7 @@ func TestCreateAssistantMessage_PersistsCacheOnlyAndNativeCostUsage(t *testing.T
 		logger:          zerolog.Nop(),
 	}
 
-	err := orch.createAssistantMessage(context.Background(), sessionID, orgID, nil, 2, &AgentResult{
+	err := orch.createAssistantMessage(context.Background(), sessionID, orgID, TranscriptWriteContext{TurnNumber: 2}, &AgentResult{
 		Summary: "Cached reply",
 		TokenUsage: TokenUsage{
 			CachedInputTokens:   123,
@@ -1593,7 +1616,7 @@ func TestCreateAssistantMessage_DoesNotPersistUnavailableTokenUsage(t *testing.T
 		logger:          zerolog.Nop(),
 	}
 
-	err := orch.createAssistantMessage(context.Background(), sessionID, orgID, nil, 3, &AgentResult{
+	err := orch.createAssistantMessage(context.Background(), sessionID, orgID, TranscriptWriteContext{TurnNumber: 3}, &AgentResult{
 		Summary: "No usage reported",
 		TokenUsage: FinalizeTokenUsage(TokenUsage{}, TokenUsageHint{
 			AgentType:      models.AgentTypeCodex,
@@ -1763,6 +1786,7 @@ func TestStreamLogs_CarriesThreadID(t *testing.T) {
 	orgID := uuid.MustParse("22222222-2222-2222-2222-222222222222")
 	sessionID := uuid.MustParse("11111111-1111-1111-1111-111111111111")
 	threadID := uuid.MustParse("33333333-3333-3333-3333-333333333333")
+	phaseID := uuid.MustParse("44444444-4444-4444-4444-444444444444")
 
 	logs := &testInternalSessionLogStore{}
 	orch := &Orchestrator{
@@ -1778,14 +1802,144 @@ func TestStreamLogs_CarriesThreadID(t *testing.T) {
 	}
 	close(logCh)
 
-	orch.streamLogs(context.Background(), sessionID, orgID, models.AgentTypeClaudeCode, &threadID, 2, logCh, nil)
+	orch.streamLogs(context.Background(), sessionID, orgID, models.AgentTypeClaudeCode, TranscriptWriteContext{ThreadID: &threadID, TurnNumber: 2, ActivityPhaseID: &phaseID}, logCh, nil)
 
 	require.Len(t, logs.logs, 1, "streamLogs should persist the log entry")
 	require.NotNil(t, logs.logs[0].ThreadID, "persisted log should preserve the thread id")
 	require.Equal(t, threadID, *logs.logs[0].ThreadID, "persisted log should use the provided thread id")
 	require.Equal(t, 2, logs.logs[0].TurnNumber, "persisted log should keep the turn number")
+	require.Equal(t, &phaseID, logs.logs[0].ActivityPhaseID, "persisted log should preserve the active phase id")
 	require.Equal(t, "streamed message", logs.logs[0].Message, "persisted log should keep the message content")
 	require.Nil(t, logs.logs[0].Metadata, "persisted log should leave absent metadata as SQL null")
+}
+
+func TestHandleHumanInputRequest_CarriesActivityPhaseID(t *testing.T) {
+	t.Parallel()
+
+	orgID := uuid.MustParse("22222222-2222-2222-2222-222222222222")
+	sessionID := uuid.MustParse("11111111-1111-1111-1111-111111111111")
+	threadID := uuid.MustParse("33333333-3333-3333-3333-333333333333")
+	phaseID := uuid.MustParse("44444444-4444-4444-4444-444444444444")
+	store := &testInternalHumanInputStore{}
+	orch := &Orchestrator{humanInputRequests: store, logger: zerolog.Nop()}
+
+	created := orch.handleHumanInputRequest(
+		context.Background(),
+		sessionID,
+		orgID,
+		models.AgentTypeCodex,
+		TranscriptWriteContext{ThreadID: &threadID, TurnNumber: 2, ActivityPhaseID: &phaseID},
+		&HumanInputRequest{Kind: models.HumanInputRequestKindFreeText, Title: "Need input", Body: "Choose"},
+	)
+
+	require.NotNil(t, created, "human input request should be persisted")
+	require.Equal(t, &phaseID, created.ActivityPhaseID, "human input request should preserve the active phase id")
+	require.Equal(t, &threadID, created.ThreadID, "human input request should preserve the active thread id")
+	require.Equal(t, 2, created.TurnNumber, "human input request should preserve the active turn number")
+}
+
+func TestStreamLogs_DropsPhaseAssociationForEntriesFromAnotherThread(t *testing.T) {
+	t.Parallel()
+
+	orgID := uuid.MustParse("22222222-2222-2222-2222-222222222222")
+	sessionID := uuid.MustParse("11111111-1111-1111-1111-111111111111")
+	entryThreadID := uuid.MustParse("33333333-3333-3333-3333-333333333333")
+	phaseID := uuid.MustParse("44444444-4444-4444-4444-444444444444")
+
+	logs := &testInternalSessionLogStore{}
+	orch := &Orchestrator{agentRunLogs: logs, logger: zerolog.Nop()}
+
+	logCh := make(chan LogEntry, 1)
+	logCh <- LogEntry{ThreadID: &entryThreadID, Timestamp: time.Now(), Level: "output", Message: "streamed message"}
+	close(logCh)
+
+	// A phase is thread-scoped. When the run context has no thread of its own,
+	// the entry's thread cannot be assumed to own the phase — persisting the
+	// association anyway would make the store reject the whole log line.
+	orch.streamLogs(context.Background(), sessionID, orgID, models.AgentTypeClaudeCode,
+		TranscriptWriteContext{TurnNumber: 2, ActivityPhaseID: &phaseID}, logCh, nil)
+
+	require.Len(t, logs.logs, 1, "streamLogs should still persist the log entry")
+	require.Equal(t, &entryThreadID, logs.logs[0].ThreadID, "persisted log should use the entry's thread id")
+	require.Nil(t, logs.logs[0].ActivityPhaseID, "phase association should be dropped rather than losing the log line")
+}
+
+func TestTranscriptWriteContext_WithTurn(t *testing.T) {
+	t.Parallel()
+
+	threadID := uuid.MustParse("33333333-3333-3333-3333-333333333333")
+	phaseID := uuid.MustParse("44444444-4444-4444-4444-444444444444")
+	writeCtx := TranscriptWriteContext{ThreadID: &threadID, TurnNumber: 2, ActivityPhaseID: &phaseID}
+
+	same := writeCtx.withTurn(2)
+	require.Equal(t, 2, same.TurnNumber, "withTurn should keep the turn number it was given")
+	require.Equal(t, &threadID, same.ThreadID, "withTurn should carry the thread id")
+	require.Equal(t, &phaseID, same.ActivityPhaseID, "an unchanged turn should keep the phase association")
+
+	// A phase belongs to exactly one turn, so carrying it into a different turn
+	// would make the store reject the entry outright.
+	moved := writeCtx.withTurn(5)
+	require.Equal(t, 5, moved.TurnNumber, "withTurn should rescope the turn number")
+	require.Nil(t, moved.ActivityPhaseID, "a changed turn should drop the phase association")
+	require.Equal(t, 2, writeCtx.TurnNumber, "withTurn should not mutate the receiver")
+	require.Equal(t, &phaseID, writeCtx.ActivityPhaseID, "withTurn should not mutate the receiver")
+}
+
+func TestTranscriptWriteContext_PhaseAssociationRequiresThread(t *testing.T) {
+	t.Parallel()
+
+	threadID := uuid.MustParse("33333333-3333-3333-3333-333333333333")
+	phaseID := uuid.MustParse("44444444-4444-4444-4444-444444444444")
+
+	threaded := TranscriptWriteContext{ThreadID: &threadID, TurnNumber: 2, ActivityPhaseID: &phaseID}
+	require.Equal(t, &phaseID, threaded.phaseAssociation(), "a threaded context should persist its phase")
+
+	// session_activity_phases.thread_id is NOT NULL, so an unthreaded write can
+	// never match a phase and must not carry one.
+	unthreaded := TranscriptWriteContext{TurnNumber: 2, ActivityPhaseID: &phaseID}
+	require.Nil(t, unthreaded.phaseAssociation(), "an unthreaded context should not persist a phase")
+}
+
+func TestCreateAssistantMessage_DropsPhaseForUnthreadedContext(t *testing.T) {
+	t.Parallel()
+
+	orgID := uuid.MustParse("22222222-2222-2222-2222-222222222222")
+	sessionID := uuid.MustParse("11111111-1111-1111-1111-111111111111")
+	phaseID := uuid.MustParse("44444444-4444-4444-4444-444444444444")
+
+	messages := &testInternalSessionMessageStore{}
+	orch := &Orchestrator{
+		sessionMessages: messages,
+		agentRunLogs:    &testInternalSessionLogStore{},
+		logger:          zerolog.Nop(),
+	}
+
+	err := orch.createAssistantMessage(context.Background(), sessionID, orgID,
+		TranscriptWriteContext{TurnNumber: 4, ActivityPhaseID: &phaseID},
+		&AgentResult{Summary: "Final answer"})
+
+	require.NoError(t, err, "createAssistantMessage should persist the assistant transcript")
+	require.Len(t, messages.messages, 1, "assistant message should be created")
+	require.Nil(t, messages.messages[0].ActivityPhaseID, "an unthreaded assistant message should not carry a phase")
+}
+
+func TestHandleHumanInputRequest_DropsPhaseForUnthreadedContext(t *testing.T) {
+	t.Parallel()
+
+	orgID := uuid.MustParse("22222222-2222-2222-2222-222222222222")
+	sessionID := uuid.MustParse("11111111-1111-1111-1111-111111111111")
+	phaseID := uuid.MustParse("44444444-4444-4444-4444-444444444444")
+	store := &testInternalHumanInputStore{}
+	orch := &Orchestrator{humanInputRequests: store, logger: zerolog.Nop()}
+
+	created := orch.handleHumanInputRequest(
+		context.Background(), sessionID, orgID, models.AgentTypeCodex,
+		TranscriptWriteContext{TurnNumber: 2, ActivityPhaseID: &phaseID},
+		&HumanInputRequest{Kind: models.HumanInputRequestKindFreeText, Title: "Need input", Body: "Choose"},
+	)
+
+	require.NotNil(t, created, "human input request should be persisted")
+	require.Nil(t, created.ActivityPhaseID, "an unthreaded human input request should not carry a phase")
 }
 
 func TestStreamLogs_PersistsMetadataAsJSON(t *testing.T) {
@@ -1809,7 +1963,7 @@ func TestStreamLogs_PersistsMetadataAsJSON(t *testing.T) {
 	}
 	close(logCh)
 
-	orch.streamLogs(context.Background(), sessionID, orgID, models.AgentTypeClaudeCode, nil, 1, logCh, nil)
+	orch.streamLogs(context.Background(), sessionID, orgID, models.AgentTypeClaudeCode, TranscriptWriteContext{TurnNumber: 1}, logCh, nil)
 
 	require.Len(t, logs.logs, 1, "streamLogs should persist the log entry")
 	require.NotNil(t, logs.logs[0].Metadata, "non-nil metadata should be marshaled and persisted")
@@ -1839,7 +1993,7 @@ func TestStreamLogs_DropsUnmarshalableMetadata(t *testing.T) {
 	}
 	close(logCh)
 
-	orch.streamLogs(context.Background(), sessionID, orgID, models.AgentTypeClaudeCode, nil, 1, logCh, nil)
+	orch.streamLogs(context.Background(), sessionID, orgID, models.AgentTypeClaudeCode, TranscriptWriteContext{TurnNumber: 1}, logCh, nil)
 
 	require.Len(t, logs.logs, 1, "streamLogs should still persist the log entry when metadata fails to marshal")
 	require.Nil(t, logs.logs[0].Metadata, "unmarshalable metadata should be dropped to nil rather than blocking the log")

--- a/internal/services/thread/service_test.go
+++ b/internal/services/thread/service_test.go
@@ -370,6 +370,7 @@ var threadHumanInputRequestColumns = []string{
 	"context", "blocks_phase", "assigned_user_id", "sensitivity", "preferred_channel",
 	"choices", "response_schema", "provider_payload",
 	"answer_text", "answer_payload", "answered_by", "answered_at", "expires_at", "created_at",
+	"activity_phase_id",
 }
 
 func threadHumanInputRequestRow(id, orgID, sessionID, threadID, userID uuid.UUID, answer string, now time.Time) []any {
@@ -380,6 +381,7 @@ func threadHumanInputRequestRow(id, orgID, sessionID, threadID, userID uuid.UUID
 		(*string)(nil), (*string)(nil), (*uuid.UUID)(nil), models.HumanInputSensitivityTeam,
 		models.HumanInputPreferredChannelSlackThread, []byte("[]"), json.RawMessage(nil), json.RawMessage(`{"raw":true}`),
 		&answer, json.RawMessage(`{"answer_text":"` + answer + `"}`), &userID, &now, (*time.Time)(nil), now,
+		(*uuid.UUID)(nil),
 	}
 }
 

--- a/migrations/000265_activity_phase_transcript_associations.down.sql
+++ b/migrations/000265_activity_phase_transcript_associations.down.sql
@@ -1,0 +1,7 @@
+DROP INDEX IF EXISTS idx_session_human_input_requests_activity_phase;
+DROP INDEX IF EXISTS idx_session_messages_activity_phase;
+DROP INDEX IF EXISTS idx_session_logs_activity_phase;
+
+ALTER TABLE session_human_input_requests DROP COLUMN IF EXISTS activity_phase_id;
+ALTER TABLE session_messages DROP COLUMN IF EXISTS activity_phase_id;
+ALTER TABLE session_logs DROP COLUMN IF EXISTS activity_phase_id;

--- a/migrations/000265_activity_phase_transcript_associations.up.sql
+++ b/migrations/000265_activity_phase_transcript_associations.up.sql
@@ -1,0 +1,41 @@
+-- lint:allow-hot-table-no-fk reason="partitioned transcript hot tables validate phase ownership in every write path"
+-- The marker above is the greppable audit trail for this reviewed exception;
+-- cmd/lint-schema only scans CREATE TABLE statements, so it does not enforce
+-- anything in an ALTER-only migration. session_logs and session_messages cannot
+-- support a foreign key to session_activity_phases without including their
+-- partition keys in the referenced identity. Every write path validates that
+-- the phase belongs to the same org, session, thread, and turn instead — see
+-- SessionLogStore.Create and SessionMessageStore.Create.
+--
+-- Deploy note: CREATE INDEX CONCURRENTLY is not supported on a partitioned
+-- parent, so the two parent indexes below build under a lock that blocks
+-- writes on every existing partition of these high-write tables. Apply during
+-- a low-traffic window, or split into `CREATE INDEX ... ON ONLY <parent>`,
+-- per-partition `CREATE INDEX CONCURRENTLY`, then `ALTER INDEX ... ATTACH
+-- PARTITION`.
+--
+-- Orphan note: only session_human_input_requests carries a real FK
+-- (ON DELETE SET NULL). Deleting a phase leaves stale activity_phase_id values
+-- on session_logs/session_messages, so read paths must resolve phase -> entries
+-- rather than joining entries -> phase and assuming referential integrity.
+ALTER TABLE session_logs
+    ADD COLUMN activity_phase_id uuid;
+
+ALTER TABLE session_messages
+    ADD COLUMN activity_phase_id uuid;
+
+ALTER TABLE session_human_input_requests
+    ADD COLUMN activity_phase_id uuid
+    REFERENCES session_activity_phases(id) ON DELETE SET NULL;
+
+CREATE INDEX idx_session_logs_activity_phase
+    ON session_logs (org_id, activity_phase_id, timestamp)
+    WHERE activity_phase_id IS NOT NULL;
+
+CREATE INDEX idx_session_messages_activity_phase
+    ON session_messages (org_id, activity_phase_id, created_at)
+    WHERE activity_phase_id IS NOT NULL;
+
+CREATE INDEX idx_session_human_input_requests_activity_phase
+    ON session_human_input_requests (org_id, activity_phase_id, created_at)
+    WHERE activity_phase_id IS NOT NULL;


### PR DESCRIPTION
## Summary

All findings from the review are fixed. Changes:

**Correctness (findings 1 & 2)**

- **`withTurn` now drops the phase when the turn actually changes** (`orchestrator.go:6079`). Phases are turn-scoped (`p.turn_number = @turn_number` in all three stores), so carrying one into a different turn produced a write the store rejects outright. Benign today — I traced `run.CurrentTurn` and it isn't mutated between `orchestrator.go:2927` and the shadowed derivation at `:3674`, so both values are equal — but it was a live trap once phases get populated.
- **`phaseAssociation()` centralizes the "a phase requires a thread" invariant** (`orchestrator.go:6091`), and all three writers (`streamLogs`, `handleHumanInputRequest`, `createAssistantMessage`) now go through it. `session_activity_phases.thread_id` is `NOT NULL`, so an unthreaded context carrying a phase would have hard-failed every write; previously only `streamLogs` was guarded, and `RunAgent`'s `primaryThreadID` can be nil.

**Test coverage (findings 3 & 4)**

- **Read-path round-trip now covered.** `logColumns`/`newLogRow` and the `ListBySession` message fixture carry `activity_phase_id`, and `ListByRunID`, `GetByID`, and `ListBySession` assert the association survives the scan (including a nil case). Previously every read fixture predated the column and `RowToStructByNameLax` silently masked it, so nothing verified the column was read back at all.
- **"No status filter" assertion extended to messages and human input** via a shared `newSQLCapturingPool` helper, replacing the inline matcher that only covered `session_logs`.
- New orchestrator tests: `TestTranscriptWriteContext_WithTurn`, `TestTranscriptWriteContext_PhaseAssociationRequiresThread`, `TestCreateAssistantMessage_DropsPhaseForUnthreadedContext`, `TestHandleHumanInputRequest_DropsPhaseForUnthreadedContext`.

**Style**

- `wrapActivityPhaseInsertError` → `wrapPhaseOwnershipError(operation, phaseID, err)`, now shared by all three stores instead of each hand-rolling the same wrapping with a hardcoded prefix.
- Boolean call sites replaced with `phaseValidatedMessageInsert()` / `phaseValidatedMessageInsertWithSource()` over a private builder.
- Log store's join states `p.org_id = @org_id` / `p.session_id = @session_id` directly, matching the other two stores instead of relying on transitivity through `sessions`.
- Restored the `lint:allow-hot-table-no-fk` marker on the migration (with a note that it's the greppable audit trail, not something `cmd/lint-schema` enforces in an ALTER-only file) — `AGENTS.md:49` treats that marker as the record of reviewed exceptions.

**Verified:** `go build ./...`, `go vet`, `gofmt -l` clean; `internal/db`, `internal/services/agent/...`, `internal/models` all pass; `cmd/lint-schema` OK.

**Left as-is, deliberately:**

- **No Postgres-backed test of the ownership SQL.** This sandbox has `psql` but no server binaries (`initdb`/`postgres` absent), so I can't execute one; I won't add test code whose first run would be in CI. The `IS NOT DISTINCT FROM` semantics and the join remain verified only at the query-text level.
- **The two `SELECT EXISTS(… sessions …)` probes** in `SessionLogStore.Create`'s error path. Merging them into one query would change the shape the pre-existing `_SessionNotFound`/`_OrgMismatch` tests mock, for a saving that only applies on an already-failing path.
- **`RowToStructByNameLax`** for `SessionLog` (matches the sibling models) — now backed by fixtures that actually include the column, which was the real risk.

## Test plan

Validated by automated agent run.


[143.dev](https://143.dev) | [session 3eee59ee](https://143.dev/sessions/3eee59ee-8521-4912-8487-109745e6eee8)

<!-- 143 readiness -->
**143 readiness:** not available for this revision.

<!-- 143-publication session=3eee59ee-8521-4912-8487-109745e6eee8 changeset=33da368f-58f6-4555-8fdb-3123ed52a0d7 -->

Preview: https://143.dev/previews/github/assembledhq/143/pull/1989?launch=1