### PR TITLE
Analyze and improve side panel small-screen button wrapping UX with options and recommendation

### DIFF
--- a/frontend/src/app/(dashboard)/sessions/[id]/page-pr-creation.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/page-pr-creation.test.tsx
@@ -637,6 +637,13 @@ describe('SessionDetailPage PR creation', () => {
       'data-variant',
       'outline',
     );
+    expect(screen.getByTestId('readiness-actions')).toHaveClass(
+      'grid-cols-1',
+      '@min-[24rem]/readiness:grid-cols-[max-content_max-content]',
+    );
+    expect(screen.getByTestId('readiness-actions').closest('[data-slot="card-content"]')).toHaveClass(
+      '@container/readiness',
+    );
     expect(screen.queryByText('Issue-less context')).not.toBeInTheDocument();
     expect(screen.queryByDisplayValue('Maintenance follow-up requested in Slack')).not.toBeInTheDocument();
     expect(screen.queryByRole('button', { name: 'Save context' })).not.toBeInTheDocument();

--- a/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
@@ -6834,7 +6834,7 @@ export function SessionDetailContent({ id }: { id: string }) {
           )}
           {selectedIsPrimary && canManageSession && !hasPR && hasSessionChanges ? (
             <Card className="border-border/60">
-              <CardContent className="space-y-3 p-4">
+              <CardContent className="@container/readiness space-y-3 p-4">
                 <div className="flex flex-col gap-3">
                   <div className="flex min-w-0 flex-1 items-start gap-2">
                     <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-muted text-muted-foreground">
@@ -6854,7 +6854,10 @@ export function SessionDetailContent({ id }: { id: string }) {
                     </div>
                   </div>
                   {readinessPrimaryAction || readinessSecondaryReviewAction ? (
-                    <div className="flex shrink-0 flex-col gap-2 sm:flex-row sm:items-center">
+                    <div
+                      className="grid shrink-0 grid-cols-1 gap-2 @min-[24rem]/readiness:grid-cols-[max-content_max-content] @min-[24rem]/readiness:items-center"
+                      data-testid="readiness-actions"
+                    >
                       {readinessPrimaryAction ? (
                         readinessPrimaryAction.label === "Review & fix" ? (
                           <DisabledTooltip disabled={readinessPrimaryAction.disabled} content={reviewActionDisabledReason}>


### PR DESCRIPTION
## Summary

Side panel “readiness” actions were wrapping based on the viewport instead of the card/container width, causing cramped or inconsistent button layouts in narrow panels. This change makes the actions layout container-aware: buttons stack on small container widths and switch to side-by-side once there’s enough space, preserving label readability and predictable heights.

## Changes

- Updated `SessionDetailContent` so the readiness actions area uses a container query (`@container/readiness`) and switches layout at `24rem`.
- Replaced the previous responsive flex layout with a grid that:
  - stacks buttons as full-width (`grid-cols-1`) on narrow containers
  - lays out actions side-by-side at natural widths (`grid-cols-[max-content_max-content]`) when space allows.
- Added a regression assertion in the PR creation page test to verify both the container wiring (`@container/readiness`) and the responsive grid classes.

## Validation

- Added/updated assertions in `page-pr-creation.test.tsx` for the readiness actions layout.
- Verified via existing test suite: 50 focused tests passed.
- ESLint passed for touched files.
- `git diff --check` passed.
- Visual preview was unavailable because all preview slots were occupied.

[143.dev](https://143.dev) | [session 77a5dca1](https://143.dev/sessions/77a5dca1-8c18-43b6-a3d0-8ce258632d69)

<!-- 143 readiness -->
**143 readiness:** not available for this revision.

<!-- 143-publication session=77a5dca1-8c18-43b6-a3d0-8ce258632d69 changeset=5dd1923e-ecda-4c4f-ab75-c0b13a246dc5 -->

Preview: https://143.dev/previews/github/assembledhq/143/pull/1993?launch=1