### PR TITLE
Debug session switch rerender and page jump on nested session clicks

### DIFF
--- a/frontend/src/app/(dashboard)/sessions/[id]/agent-tab-strip.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/agent-tab-strip.test.tsx
@@ -3,6 +3,7 @@ import { describe, expect, it, vi } from "vitest";
 import { screen } from "@testing-library/react";
 
 import { AgentTabStrip } from "./agent-tab-strip";
+import { SESSION_THREAD_STRIP_HEIGHT_CLASSNAME } from "./session-detail-geometry";
 import { renderWithProviders, userEvent } from "@/test/test-utils";
 import type { SessionThread } from "@/lib/types";
 
@@ -33,6 +34,53 @@ function makeThread(overrides: Partial<SessionThread>): SessionThread {
 }
 
 describe("AgentTabStrip", () => {
+  // The strip's height is part of the session workspace's stable geometry: a
+  // bare null here collapses the row and shifts the transcript and composer
+  // beneath it. Every "nothing to show" path must hold the same box.
+  describe("holds its footprint when there are no tabs to render", () => {
+    const commonProps = {
+      viewedThreadIds: new Set<string>(),
+      overlapsByThreadId: new Map<string, string[]>(),
+      statusConfig,
+      onActiveThreadChange: vi.fn(),
+      onAddTab: vi.fn(),
+      onRevertThread: vi.fn(),
+      onArchiveThread: vi.fn(),
+      archivePendingThreadId: null,
+    };
+
+    it("labels the row when the session genuinely has no tabs", () => {
+      renderWithProviders(<AgentTabStrip threads={[]} activeThreadId={null} {...commonProps} />);
+
+      const placeholder = screen.getByTestId("session-thread-strip-empty");
+      expect(placeholder).toHaveClass(SESSION_THREAD_STRIP_HEIGHT_CLASSNAME);
+      expect(placeholder).toHaveTextContent("No agent tabs for this session");
+    });
+
+    it("holds the row without an empty label while the selection is unresolved", () => {
+      const thread = makeThread({});
+      renderWithProviders(
+        <AgentTabStrip threads={[thread]} activeThreadId={null} {...commonProps} />,
+      );
+
+      const placeholder = screen.getByTestId("session-thread-strip-empty");
+      expect(placeholder).toHaveClass(SESSION_THREAD_STRIP_HEIGHT_CLASSNAME);
+      // Tabs exist, so calling the session empty would be wrong.
+      expect(placeholder).toHaveTextContent("");
+    });
+
+    it("holds the row when the selected tab is no longer present", () => {
+      const thread = makeThread({});
+      renderWithProviders(
+        <AgentTabStrip threads={[thread]} activeThreadId="thread-that-went-away" {...commonProps} />,
+      );
+
+      const placeholder = screen.getByTestId("session-thread-strip-empty");
+      expect(placeholder).toHaveClass(SESSION_THREAD_STRIP_HEIGHT_CLASSNAME);
+      expect(placeholder).toHaveTextContent("");
+    });
+  });
+
   it("renders a quiet single-agent header with a trailing add button instead of a tab strip", async () => {
     const user = userEvent.setup();
     const thread = makeThread({ pending_message_count: 2 });

--- a/frontend/src/app/(dashboard)/sessions/[id]/agent-tab-strip.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/agent-tab-strip.tsx
@@ -16,6 +16,7 @@ import {
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { AGENTS_BY_KEY } from "@/lib/agents";
 import type { SessionThread, SessionThreadFileEvent } from "@/lib/types";
+import { SESSION_THREAD_STRIP_HEIGHT_CLASSNAME } from "./session-detail-geometry";
 
 // Status helpers — kept in one place so the tab strip and detail panel agree.
 
@@ -148,6 +149,25 @@ interface AgentTabStripProps {
   addTabButtonRef?: RefObject<HTMLButtonElement | null>;
 }
 
+// Stands in for the tab row whenever there is nothing to render in it, so the
+// strip keeps its footprint. Every "no tabs to show" path routes through here
+// rather than returning null: a bare null collapses the row and shifts the
+// transcript and composer beneath it, which is the layout jump the shared
+// session detail frame exists to prevent.
+function ThreadStripPlaceholder({ message }: { message?: string }) {
+  return (
+    <div
+      data-testid="session-thread-strip-empty"
+      className={cn(
+        "flex shrink-0 items-center border-b border-border bg-background px-3 text-xs text-muted-foreground",
+        SESSION_THREAD_STRIP_HEIGHT_CLASSNAME,
+      )}
+    >
+      {message}
+    </div>
+  );
+}
+
 // AgentTabStrip is the user's primary surface for switching between tabs and
 // taking per-tab actions (cancel, fork, revert). It renders a compact
 // Conductor-style row with status, overlap badge, and an actions menu
@@ -176,12 +196,18 @@ export function AgentTabStrip({
   addTabButtonRef,
 }: AgentTabStripProps) {
   const tabs = useMemo(() => threads, [threads]);
-  if (tabs.length === 0 || !activeThreadId) {
-    return null;
+  if (tabs.length === 0) {
+    return <ThreadStripPlaceholder message="No agent tabs for this session" />;
+  }
+  // Tabs exist but none is selected yet — a transient state while the initial
+  // selection resolves, or right after the selected tab disappears. Hold the
+  // row without labelling the session as empty, since it isn't.
+  if (!activeThreadId) {
+    return <ThreadStripPlaceholder />;
   }
   const activeThread = tabs.find((thread) => thread.id === activeThreadId);
   if (!activeThread) {
-    return null;
+    return <ThreadStripPlaceholder />;
   }
 
   if (tabs.length === 1) {

--- a/frontend/src/app/(dashboard)/sessions/[id]/page-overview.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/page-overview.test.tsx
@@ -72,8 +72,25 @@ installSessionDetailPageTestHooks({ toast, routerPush });
 describe('SessionDetailPage overview and review loop', () => {
   it('shows the session details skeleton initially', () => {
     renderWithProviders(<SessionDetailContent id="session-abcdef12-3456-7890" />);
-    expect(screen.getByTestId('session-detail-loading-skeleton')).toBeInTheDocument();
+    const frame = screen.getByTestId('session-detail-loading-skeleton');
+    expect(frame).toBeInTheDocument();
+    expect(frame).toHaveAttribute('data-session-transition', 'initial');
+    expect(frame).toHaveAttribute('data-session-state', 'loading');
     expect(screen.queryByText('Loading session...')).not.toBeInTheDocument();
+  });
+
+  it('reconciles the cold-open skeleton into the loaded workspace in place', async () => {
+    renderWithProviders(<SessionDetailContent id="session-abcdef12-3456-7890" />);
+    // Nothing seeded this open, so the skeleton starts cold rather than
+    // provisional — the frame still has to survive the swap.
+    const frame = screen.getByTestId('session-detail-loading-skeleton');
+    expect(frame).toHaveAttribute('data-session-transition', 'initial');
+
+    await screen.findAllByText('Fixed TypeError by adding null check');
+
+    expect(screen.getByTestId('session-detail-frame')).toBe(frame);
+    expect(frame).not.toHaveAttribute('data-session-state');
+    expect(frame).not.toHaveAttribute('aria-busy');
   });
 
   it('refetches authoritative detail immediately when provisional detail is cached as fresh', async () => {
@@ -131,12 +148,13 @@ describe('SessionDetailPage overview and review loop', () => {
     });
     const transitionFrame = screen.getByTestId('session-detail-loading-skeleton');
     expect(transitionFrame).toHaveAttribute('data-session-transition', 'provisional');
+    expect(transitionFrame).toHaveAttribute('data-session-state', 'loading');
     expect(transitionFrame).toHaveAttribute('aria-busy', 'true');
     // Metadata-first paint: the provisional row's title shows in the skeleton
     // headers (desktop and mobile) immediately, while the data-bearing
     // queries still wait for the authoritative payload.
     expect(screen.getAllByText('Provisional list title').length).toBeGreaterThanOrEqual(1);
-    expect(screen.getByTestId('session-composer-loading')).toHaveAttribute('aria-disabled', 'true');
+    expect(screen.getByTestId('session-composer-loading')).toBeInTheDocument();
     expect(screen.queryByPlaceholderText('Send a follow-up message...')).not.toBeInTheDocument();
     expect(timelineRequests).toBe(0);
     expect(prRequests).toBe(0);
@@ -206,7 +224,10 @@ describe('SessionDetailPage overview and review loop', () => {
     // Nothing is in flight until the user retries, so the frame must not
     // announce itself as busy over the alert.
     expect(transitionFrame).not.toHaveAttribute('aria-busy');
-    expect(transitionFrame).toHaveAttribute('data-session-transition', 'error');
+    expect(transitionFrame).toHaveAttribute('data-session-state', 'error');
+    // A seeded row still backs this failure, so the frame reports what it
+    // is preserving, not just that it failed.
+    expect(transitionFrame).toHaveAttribute('data-session-transition', 'provisional');
     await user.click(screen.getByRole('button', { name: 'Retry' }));
 
     // The query holds its error until the refetch settles, so the error stays
@@ -247,7 +268,11 @@ describe('SessionDetailPage overview and review loop', () => {
     expect(alert).not.toHaveTextContent('preserved');
     expect(screen.queryByTestId('session-thread-strip-loading')).not.toBeInTheDocument();
     expect(screen.queryByTestId('session-composer-loading')).not.toBeInTheDocument();
-    expect(screen.getByTestId('session-detail-loading-skeleton')).not.toHaveAttribute('aria-busy');
+    const coldFrame = screen.getByTestId('session-detail-loading-skeleton');
+    expect(coldFrame).not.toHaveAttribute('aria-busy');
+    // Nothing was seeded, so the frame reports the cold shape of the failure.
+    expect(coldFrame).toHaveAttribute('data-session-state', 'error');
+    expect(coldFrame).toHaveAttribute('data-session-transition', 'initial');
   });
 
   it('keeps the frame mounted and removes stale content when switching from loaded A to provisional B', async () => {

--- a/frontend/src/app/(dashboard)/sessions/[id]/page-overview.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/page-overview.test.tsx
@@ -8,6 +8,7 @@ import { mockSessions, mockMembers, mockPR, mockPRHealth } from '@/test/mocks/ha
 import { SessionDetailContent } from './session-detail-content';
 import { queryKeys } from '@/lib/query-keys';
 import { markProvisionalSessionDetail } from '@/lib/session-detail-cache';
+import { SESSION_THREAD_STRIP_HEIGHT_CLASSNAME } from './session-detail-geometry';
 import type {
   ReviewLoopFixMode,
   Session,
@@ -128,17 +129,188 @@ describe('SessionDetailPage overview and review loop', () => {
     await waitFor(() => {
       expect(detailRequests).toBe(1);
     });
-    expect(screen.getByTestId('session-detail-loading-skeleton')).toBeInTheDocument();
+    const transitionFrame = screen.getByTestId('session-detail-loading-skeleton');
+    expect(transitionFrame).toHaveAttribute('data-session-transition', 'provisional');
+    expect(transitionFrame).toHaveAttribute('aria-busy', 'true');
     // Metadata-first paint: the provisional row's title shows in the skeleton
     // headers (desktop and mobile) immediately, while the data-bearing
     // queries still wait for the authoritative payload.
     expect(screen.getAllByText('Provisional list title').length).toBeGreaterThanOrEqual(1);
+    expect(screen.getByTestId('session-composer-loading')).toHaveAttribute('aria-disabled', 'true');
+    expect(screen.queryByPlaceholderText('Send a follow-up message...')).not.toBeInTheDocument();
     expect(timelineRequests).toBe(0);
     expect(prRequests).toBe(0);
 
     releaseDetail();
 
     expect(await screen.findAllByText('Authoritative detail title')).not.toHaveLength(0);
+    // The shared SessionDetailFrame reconciles in place: loading content is
+    // replaced locally without replacing the workspace root.
+    expect(screen.getByTestId('session-detail-frame')).toBe(transitionFrame);
+  });
+
+  it('keeps target metadata and actions gated when provisional detail fails, then retries in place', async () => {
+    const user = userEvent.setup();
+    const sessionId = 'session-abcdef12-3456-7890';
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false, gcTime: Infinity } },
+    });
+    queryClient.setQueryData(queryKeys.sessions.detail(sessionId), {
+      data: markProvisionalSessionDetail({
+        ...mockSessions[0],
+        result_summary: 'Selected target session',
+        threads: [],
+        changesets: [],
+      }),
+    } satisfies SingleResponse<Session>);
+    let releaseRetry = () => {};
+    const retryBlocked = new Promise<void>((resolve) => {
+      releaseRetry = resolve;
+    });
+    let requests = 0;
+    let prRequests = 0;
+    server.use(
+      http.get(`/api/v1/sessions/${sessionId}`, async () => {
+        requests += 1;
+        if (requests === 1) {
+          return HttpResponse.json(
+            { error: { code: 'DETAIL_UNAVAILABLE', message: 'temporarily unavailable' } },
+            { status: 503 },
+          );
+        }
+        await retryBlocked;
+        return HttpResponse.json({
+          data: {
+            ...mockSessions[0],
+            result_summary: 'Recovered target session',
+            threads: [],
+          },
+        } satisfies SingleResponse<Session>);
+      }),
+      http.get(`/api/v1/sessions/${sessionId}/pr`, () => {
+        prRequests += 1;
+        return HttpResponse.json({ data: null });
+      }),
+    );
+
+    renderSessionDetailWithQueryClient(sessionId, queryClient);
+
+    expect(await screen.findByTestId('session-detail-transition-error')).toBeInTheDocument();
+    expect(screen.getAllByText('Selected target session').length).toBeGreaterThanOrEqual(1);
+    expect(screen.queryByPlaceholderText('Send a follow-up message...')).not.toBeInTheDocument();
+    // A failed detail request must not un-gate the queries that wait for an
+    // authoritative session — we never loaded the session they describe.
+    expect(prRequests).toBe(0);
+
+    const transitionFrame = screen.getByTestId('session-detail-loading-skeleton');
+    // Nothing is in flight until the user retries, so the frame must not
+    // announce itself as busy over the alert.
+    expect(transitionFrame).not.toHaveAttribute('aria-busy');
+    expect(transitionFrame).toHaveAttribute('data-session-transition', 'error');
+    await user.click(screen.getByRole('button', { name: 'Retry' }));
+
+    // The query holds its error until the refetch settles, so the error stays
+    // on screen. Without pending feedback the button would read as dead.
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Retry' })).toBeDisabled();
+    });
+    expect(screen.getByTestId('session-detail-transition-error')).toBeInTheDocument();
+    expect(transitionFrame).toHaveAttribute('aria-busy', 'true');
+
+    releaseRetry();
+
+    expect(await screen.findAllByText('Recovered target session')).not.toHaveLength(0);
+    expect(screen.getByTestId('session-detail-frame')).toBe(transitionFrame);
+    expect(requests).toBe(2);
+  });
+
+  it('reports a cold detail failure as an error rather than an endless skeleton', async () => {
+    const sessionId = 'session-abcdef12-3456-7890';
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false, gcTime: Infinity } },
+    });
+    server.use(
+      http.get(`/api/v1/sessions/${sessionId}`, () =>
+        HttpResponse.json(
+          { error: { code: 'NOT_FOUND', message: 'no such session' } },
+          { status: 404 },
+        ),
+      ),
+    );
+
+    renderSessionDetailWithQueryClient(sessionId, queryClient);
+
+    const alert = await screen.findByTestId('session-detail-transition-error');
+    // Nothing was seeded, so the copy must not claim a preserved selection and
+    // the shimmer chrome must not imply that content is still on its way.
+    expect(alert).toHaveTextContent('could not be found');
+    expect(alert).not.toHaveTextContent('preserved');
+    expect(screen.queryByTestId('session-thread-strip-loading')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('session-composer-loading')).not.toBeInTheDocument();
+    expect(screen.getByTestId('session-detail-loading-skeleton')).not.toHaveAttribute('aria-busy');
+  });
+
+  it('keeps the frame mounted and removes stale content when switching from loaded A to provisional B', async () => {
+    const firstSession = {
+      ...mockSessions[0],
+      result_summary: 'Loaded session A',
+      threads: [],
+      changesets: [],
+    };
+    const secondSession = {
+      ...mockSessions[1],
+      result_summary: 'Selected session B',
+      threads: [],
+      changesets: [],
+    };
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false, gcTime: Infinity } },
+    });
+    queryClient.setQueryData(queryKeys.sessions.detail(firstSession.id), {
+      data: firstSession,
+    } satisfies SingleResponse<Session>);
+    queryClient.setQueryData(queryKeys.sessions.detail(secondSession.id), {
+      data: markProvisionalSessionDetail(secondSession),
+    } satisfies SingleResponse<Session>);
+
+    let releaseSecondDetail = () => {};
+    const secondDetailBlocked = new Promise<void>((resolve) => {
+      releaseSecondDetail = resolve;
+    });
+    let secondTimelineRequests = 0;
+    server.use(
+      http.get(`/api/v1/sessions/${firstSession.id}`, () =>
+        HttpResponse.json({ data: firstSession } satisfies SingleResponse<Session>),
+      ),
+      http.get(`/api/v1/sessions/${secondSession.id}`, async () => {
+        await secondDetailBlocked;
+        return HttpResponse.json({ data: secondSession } satisfies SingleResponse<Session>);
+      }),
+      http.get(`/api/v1/sessions/${secondSession.id}/timeline`, () => {
+        secondTimelineRequests += 1;
+        return HttpResponse.json({ data: [], meta: {} });
+      }),
+    );
+
+    const view = renderWithProviders(<SessionDetailContent id={firstSession.id} />, { queryClient });
+    expect(await screen.findAllByText('Loaded session A')).not.toHaveLength(0);
+    const frame = screen.getByTestId('session-detail-frame');
+    expect(screen.getByPlaceholderText('Send a follow-up message...')).toBeInTheDocument();
+
+    view.rerender(<SessionDetailContent id={secondSession.id} />);
+
+    expect(screen.getByTestId('session-detail-loading-skeleton')).toBe(frame);
+    expect(screen.getAllByText('Selected session B').length).toBeGreaterThanOrEqual(1);
+    expect(screen.queryByText('Loaded session A')).not.toBeInTheDocument();
+    expect(screen.queryByPlaceholderText('Send a follow-up message...')).not.toBeInTheDocument();
+    expect(secondTimelineRequests).toBe(0);
+
+    releaseSecondDetail();
+    expect(await screen.findAllByText('Selected session B')).not.toHaveLength(0);
+    expect(screen.getByTestId('session-detail-frame')).toBe(frame);
+    expect(screen.getByTestId('session-thread-strip-empty')).toHaveClass(
+      SESSION_THREAD_STRIP_HEIGHT_CLASSNAME,
+    );
   });
 
   it('renders session with result summary as title', async () => {

--- a/frontend/src/app/(dashboard)/sessions/[id]/page-transcript.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/page-transcript.test.tsx
@@ -139,8 +139,11 @@ describe('SessionDetailPage transcript and scroll', () => {
 
     renderWithProviders(<SessionDetailContent id="nonexistent" />);
     expect(
-      await screen.findByText('Failed to load session'),
+      await screen.findByText("Couldn't load this session"),
     ).toBeInTheDocument();
+    expect(screen.getByTestId('session-detail-transition-error')).toHaveTextContent(
+      'The session could not be found, or an error occurred while loading it.',
+    );
   });
 
   it('shows result summary card in overview', async () => {

--- a/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
@@ -187,7 +187,6 @@ import {
   SESSION_DETAIL_PANEL_MAX_WIDTH,
   SESSION_DETAIL_PANEL_MIN_WIDTH,
   SESSION_HEADER_HEIGHT_CLASSNAME,
-  SESSION_THREAD_STRIP_HEIGHT_CLASSNAME,
   SESSION_WORKSPACE_MIN_WIDTH_CLASSNAME,
 } from "./session-detail-geometry";
 import {
@@ -6351,8 +6350,8 @@ export function SessionDetailContent({ id }: { id: string }) {
     return (
       <SessionDetailFrame
         testId="session-detail-loading-skeleton"
-        busy
-        transition={rawSession ? "provisional" : "initial"}
+        state="loading"
+        transition={provisionalMetadata ? "provisional" : "initial"}
       >
         <SessionDetailLoadingContent
           detailPanelOpen={showDetailPanel}
@@ -6365,14 +6364,11 @@ export function SessionDetailContent({ id }: { id: string }) {
 
   if (detailLoadState.kind === "error" || !session) {
     return (
-      // Busy only while a retry is actually running: a settled failure marking
-      // itself busy would suppress the alert below, and the query keeps its
-      // error until the refetch settles, so this is what tells the user their
-      // click landed.
       <SessionDetailFrame
         testId="session-detail-loading-skeleton"
-        busy={isRetryingSessionDetail}
-        transition="error"
+        state="error"
+        transition={provisionalMetadata ? "provisional" : "initial"}
+        retrying={isRetryingSessionDetail}
       >
         <SessionDetailLoadingContent
           detailPanelOpen={showDetailPanel}
@@ -7249,35 +7245,26 @@ export function SessionDetailContent({ id }: { id: string }) {
           </>
         ) : null}
 
+        {/* AgentTabStrip holds the row's height itself in every "nothing to
+            show" case, so there is no empty-state branch out here to keep in
+            step with its internal guards. */}
         {!isDedicatedMobileReview ? (
           <div className="hidden md:block">
-            {chromeThreads.length > 0 ? (
-              <AgentTabStrip
-                threads={chromeThreads}
-                activeThreadId={activeThread?.id ?? null}
-                viewedThreadIds={viewedThreadIds}
-                nonInteractiveThreadIds={nonInteractiveThreadIds}
-                overlapsByThreadId={overlapsByThreadId}
-                statusConfig={statusConfig}
-                onActiveThreadChange={setActiveThreadId}
-                onAddTab={handleCreateThread}
-                addTabPending={createThreadMutation.isPending}
-                onRevertThread={(tid) => revertThreadMutation.mutate(tid)}
-                onArchiveThread={(tid) => archiveThreadMutation.mutate(tid)}
-                archivePendingThreadId={archiveThreadMutation.isPending ? archiveThreadMutation.variables ?? null : null}
-                addTabButtonRef={addTabButtonRef}
-              />
-            ) : (
-              <div
-                data-testid="session-thread-strip-empty"
-                className={cn(
-                  "flex shrink-0 items-center border-b border-border bg-background px-3 text-xs text-muted-foreground",
-                  SESSION_THREAD_STRIP_HEIGHT_CLASSNAME,
-                )}
-              >
-                No agent tabs for this session
-              </div>
-            )}
+            <AgentTabStrip
+              threads={chromeThreads}
+              activeThreadId={activeThread?.id ?? null}
+              viewedThreadIds={viewedThreadIds}
+              nonInteractiveThreadIds={nonInteractiveThreadIds}
+              overlapsByThreadId={overlapsByThreadId}
+              statusConfig={statusConfig}
+              onActiveThreadChange={setActiveThreadId}
+              onAddTab={handleCreateThread}
+              addTabPending={createThreadMutation.isPending}
+              onRevertThread={(tid) => revertThreadMutation.mutate(tid)}
+              onArchiveThread={(tid) => archiveThreadMutation.mutate(tid)}
+              archivePendingThreadId={archiveThreadMutation.isPending ? archiveThreadMutation.variables ?? null : null}
+              addTabButtonRef={addTabButtonRef}
+            />
           </div>
         ) : null}
         {/* Center content — either chat or diff review */}

--- a/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
@@ -180,12 +180,22 @@ import { pollMs } from "@/lib/poll-intervals";
 import { activeSet, workingStatusesSet } from "@/lib/session-status-groups";
 import { MobileSessionTopBar } from "./mobile-session-top-bar";
 import { RecoverableInboxNotice } from "./recoverable-inbox-notice";
-import { SessionDetailLoadingSkeleton, SessionTimelineSkeleton } from "./session-detail-loading-skeleton";
+import { SessionDetailLoadingContent, SessionTimelineSkeleton } from "./session-detail-loading-skeleton";
+import { SessionDetailFrame } from "./session-detail-frame";
+import {
+  SESSION_DETAIL_PANEL_DEFAULT_WIDTH,
+  SESSION_DETAIL_PANEL_MAX_WIDTH,
+  SESSION_DETAIL_PANEL_MIN_WIDTH,
+  SESSION_HEADER_HEIGHT_CLASSNAME,
+  SESSION_THREAD_STRIP_HEIGHT_CLASSNAME,
+  SESSION_WORKSPACE_MIN_WIDTH_CLASSNAME,
+} from "./session-detail-geometry";
 import {
   applyThreadInboxEventToThreads,
   applyThreadRuntimeEventToThreads,
   buildChromeThreads,
   capLiveSessionLogMessage,
+  deriveSessionDetailLoadState,
   deriveEffectivePRStatus,
   formatDuration,
   getDisplayStatus,
@@ -3455,11 +3465,7 @@ function FreshThreadShell() {
 // Main component
 // ---------------------------------------------------------------------------
 
-const MIN_DETAIL = 280;
-const MAX_DETAIL = 600;
-const DEFAULT_DETAIL = 384;
 const MOBILE_REVIEW_MEDIA_QUERY = "(max-width: 767px)";
-const SESSION_HEADER_HEIGHT_CLASSNAME = "h-14";
 // Transcript keyboard scroll tuning. Step matches a comfortable line-pair
 // jump; page distance follows browser conventions (~85% viewport with a
 // floor for very short panels).
@@ -3591,7 +3597,7 @@ export function SessionDetailContent({ id }: { id: string }) {
   const [reviewPasses, setReviewPasses] = useState(2);
   const [reviewAgentType, setReviewAgentType] = useState<string>("codex");
   const [reviewFixMode, setReviewFixMode] = useState<ReviewLoopFixMode>("minimal");
-  const [detailWidth, setDetailWidth] = useState(DEFAULT_DETAIL);
+  const [detailWidth, setDetailWidth] = useState(SESSION_DETAIL_PANEL_DEFAULT_WIDTH);
   const [activeFileIndex, setActiveFileIndex] = useState(0);
   // null means "follow the saved user-settings preference"; a boolean means
   // the user toggled full screen in this session (and we persist it).
@@ -3689,7 +3695,7 @@ export function SessionDetailContent({ id }: { id: string }) {
   }, []);
 
   const handleDetailResize = useCallback((delta: number) => {
-    setDetailWidth((w) => Math.min(MAX_DETAIL, Math.max(MIN_DETAIL, w - delta)));
+    setDetailWidth((w) => Math.min(SESSION_DETAIL_PANEL_MAX_WIDTH, Math.max(SESSION_DETAIL_PANEL_MIN_WIDTH, w - delta)));
   }, []);
   const selectedIsPrimaryRef = useRef(true);
 
@@ -3793,7 +3799,13 @@ export function SessionDetailContent({ id }: { id: string }) {
     { name: "session chrome and action state", reset: resetSessionChromeAndActionState },
   ]);
 
-  const { data, isLoading, error } = useQuery({
+  const {
+    data,
+    isLoading,
+    error,
+    isFetching: isFetchingSessionDetail,
+    refetch: refetchSessionDetail,
+  } = useQuery({
     queryKey: queryKeys.sessions.detail(id),
     queryFn: () => api.sessions.get(id),
     // Sidebar navigation may seed this key with list-row data so the detail
@@ -3851,8 +3863,34 @@ export function SessionDetailContent({ id }: { id: string }) {
     [user],
   );
   const rawSession = data?.data;
+  const detailLoadState = deriveSessionDetailLoadState({
+    session: rawSession,
+    isLoading,
+    isFetching: isFetchingSessionDetail,
+    error,
+  });
+  // Gates dependent fetches (the PR query and the diff). Deliberately the raw
+  // predicate rather than `detailLoadState.kind === "provisional"`: the load
+  // state resolves to "error" when a seeded row's detail request fails, which
+  // would un-gate those queries and fire them for a session we never loaded.
   const isProvisionalSession = isProvisionalSessionDetail(rawSession);
-  const session = isProvisionalSession ? undefined : rawSession;
+  const session = detailLoadState.kind === "ready" ? detailLoadState.session : undefined;
+  const isRetryingSessionDetail =
+    detailLoadState.kind === "error" && detailLoadState.retrying;
+  // Metadata-first paint: the provisional row seeded by the sidebar (or a
+  // partially settled payload) already carries the title, status, and agent.
+  // Both the loading and the failed transition render it, and a loaded session
+  // discards it, so memoize rather than recompute on every streaming update.
+  const provisionalMetadata = useMemo(() => {
+    if (!rawSession) return null;
+    const status = getDisplayStatus(rawSession.status);
+    return {
+      title: sessionTitle(rawSession),
+      statusLabel: status.label,
+      statusColor: status.color,
+      agentType: rawSession.agent_type,
+    };
+  }, [rawSession]);
   const changesets = session?.changesets ?? [];
   const primaryChangeset = changesets.find((changeset) => changeset.is_primary) ?? changesets[0];
   const [selectedChangesetID, setSelectedChangesetID] = useState<string | null>(changesetParam);
@@ -4244,7 +4282,12 @@ export function SessionDetailContent({ id }: { id: string }) {
     }
   }, [activeThread, id, session, sessionStopRequest]);
 
-  useEffect(() => {
+  // Layout effect, not passive: the loading skeleton reserves boxes for the
+  // thread strip and the composer, but both are gated on an active thread. If
+  // the initial selection resolved after paint, the first frame of the loaded
+  // workspace would render without either — the skeleton's reserved space
+  // would collapse and then spring back a frame later.
+  useLayoutEffect(() => {
     if (!session) {
       return;
     }
@@ -6301,38 +6344,49 @@ export function SessionDetailContent({ id }: { id: string }) {
     },
   });
 
-  if (isLoading || (isProvisionalSession && !error)) {
-    // Metadata-first paint: the provisional row seeded by the sidebar (or a
-    // partially settled payload) already carries the title, status, and
-    // agent. Show those immediately and confine the shimmer to the parts we
-    // genuinely don't have yet, so opening a session never hides data the
-    // client already holds.
-    const provisionalStatus = rawSession ? getDisplayStatus(rawSession.status) : null;
+  if (detailLoadState.kind === "initial" || detailLoadState.kind === "provisional") {
+    // Show the metadata we already have immediately and confine the shimmer to
+    // the parts we genuinely don't have yet, so opening a session never hides
+    // data the client already holds.
     return (
-      <SessionDetailLoadingSkeleton
-        metadata={
-          rawSession && provisionalStatus
-            ? {
-                title: sessionTitle(rawSession),
-                statusLabel: provisionalStatus.label,
-                statusColor: provisionalStatus.color,
-                agentType: rawSession.agent_type,
-              }
-            : null
-        }
-      />
+      <SessionDetailFrame
+        testId="session-detail-loading-skeleton"
+        busy
+        transition={rawSession ? "provisional" : "initial"}
+      >
+        <SessionDetailLoadingContent
+          detailPanelOpen={showDetailPanel}
+          detailPanelWidth={detailWidth}
+          metadata={provisionalMetadata}
+        />
+      </SessionDetailFrame>
     );
   }
 
-  if (error || !session) {
+  if (detailLoadState.kind === "error" || !session) {
     return (
-      <div className="flex items-center justify-center h-full">
-        <div className="text-center space-y-2 max-w-[280px]">
-          <AlertTriangle className="h-5 w-5 text-muted-foreground/40 mx-auto" />
-          <p className="text-xs font-medium text-muted-foreground">Failed to load session</p>
-          <p className="text-xs text-muted-foreground/60">The session could not be found or an error occurred.</p>
-        </div>
-      </div>
+      // Busy only while a retry is actually running: a settled failure marking
+      // itself busy would suppress the alert below, and the query keeps its
+      // error until the refetch settles, so this is what tells the user their
+      // click landed.
+      <SessionDetailFrame
+        testId="session-detail-loading-skeleton"
+        busy={isRetryingSessionDetail}
+        transition="error"
+      >
+        <SessionDetailLoadingContent
+          detailPanelOpen={showDetailPanel}
+          detailPanelWidth={detailWidth}
+          metadata={provisionalMetadata}
+          errorMessage={
+            provisionalMetadata
+              ? "The session detail could not be loaded. Your current session selection has been preserved."
+              : "The session could not be found, or an error occurred while loading it."
+          }
+          onRetry={() => void refetchSessionDetail()}
+          retrying={isRetryingSessionDetail}
+        />
+      </SessionDetailFrame>
     );
   }
 
@@ -7070,11 +7124,11 @@ export function SessionDetailContent({ id }: { id: string }) {
   );
 
   return (
-    <div className="flex h-full">
+    <SessionDetailFrame>
       {/* Center area: chat or review diff view */}
       <div
         data-testid="session-conversation-workspace"
-        className="flex-1 min-w-0 md:min-w-[440px] flex flex-col"
+        className={cn("flex-1 min-w-0 flex flex-col", SESSION_WORKSPACE_MIN_WIDTH_CLASSNAME)}
       >
         {!isDedicatedMobileReview ? (
           <>
@@ -7197,21 +7251,33 @@ export function SessionDetailContent({ id }: { id: string }) {
 
         {!isDedicatedMobileReview ? (
           <div className="hidden md:block">
-          <AgentTabStrip
-            threads={chromeThreads}
-            activeThreadId={activeThread?.id ?? null}
-            viewedThreadIds={viewedThreadIds}
-            nonInteractiveThreadIds={nonInteractiveThreadIds}
-            overlapsByThreadId={overlapsByThreadId}
-            statusConfig={statusConfig}
-            onActiveThreadChange={setActiveThreadId}
-            onAddTab={handleCreateThread}
-            addTabPending={createThreadMutation.isPending}
-            onRevertThread={(tid) => revertThreadMutation.mutate(tid)}
-            onArchiveThread={(tid) => archiveThreadMutation.mutate(tid)}
-            archivePendingThreadId={archiveThreadMutation.isPending ? archiveThreadMutation.variables ?? null : null}
-            addTabButtonRef={addTabButtonRef}
-          />
+            {chromeThreads.length > 0 ? (
+              <AgentTabStrip
+                threads={chromeThreads}
+                activeThreadId={activeThread?.id ?? null}
+                viewedThreadIds={viewedThreadIds}
+                nonInteractiveThreadIds={nonInteractiveThreadIds}
+                overlapsByThreadId={overlapsByThreadId}
+                statusConfig={statusConfig}
+                onActiveThreadChange={setActiveThreadId}
+                onAddTab={handleCreateThread}
+                addTabPending={createThreadMutation.isPending}
+                onRevertThread={(tid) => revertThreadMutation.mutate(tid)}
+                onArchiveThread={(tid) => archiveThreadMutation.mutate(tid)}
+                archivePendingThreadId={archiveThreadMutation.isPending ? archiveThreadMutation.variables ?? null : null}
+                addTabButtonRef={addTabButtonRef}
+              />
+            ) : (
+              <div
+                data-testid="session-thread-strip-empty"
+                className={cn(
+                  "flex shrink-0 items-center border-b border-border bg-background px-3 text-xs text-muted-foreground",
+                  SESSION_THREAD_STRIP_HEIGHT_CLASSNAME,
+                )}
+              >
+                No agent tabs for this session
+              </div>
+            )}
           </div>
         ) : null}
         {/* Center content — either chat or diff review */}
@@ -7830,6 +7896,6 @@ export function SessionDetailContent({ id }: { id: string }) {
           </AlertDialogFooter>
         </AlertDialogContent>
       </AlertDialog>
-    </div>
+    </SessionDetailFrame>
   );
 }

--- a/frontend/src/app/(dashboard)/sessions/[id]/session-detail-frame.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/session-detail-frame.tsx
@@ -1,10 +1,13 @@
 import type { ReactNode } from "react";
 import { cn } from "@/lib/utils";
 
-// Which transition this frame is standing in for. Absent once the workspace is
-// loaded, so `data-session-transition` only appears while something is
-// standing in for the real page.
-export type SessionDetailTransition = "initial" | "provisional" | "error";
+// What the frame knows about the session it is standing in for: whether a
+// seeded row gave us the title and status, or we have nothing yet.
+export type SessionDetailTransition = "initial" | "provisional";
+
+// Why the frame is standing in. Absent once the workspace is loaded, so both
+// data attributes only appear while the real page is not on screen.
+export type SessionDetailTransitionState = "loading" | "error";
 
 // The single root element for every session detail state. Keeping the same
 // element type at the root of all four of SessionDetailContent's returns lets
@@ -20,24 +23,32 @@ export type SessionDetailTransition = "initial" | "provisional" | "error";
 // component are different element types, so React remounts the frame there.
 export function SessionDetailFrame({
   children,
-  busy = false,
   transition,
+  state,
+  retrying = false,
   className,
   testId = "session-detail-frame",
 }: {
   children: ReactNode;
-  // Whether a request is in flight right now. Independent of `transition`: a
-  // failed transition is idle until the user retries, and busy again while
-  // that retry runs.
-  busy?: boolean;
   transition?: SessionDetailTransition;
+  state?: SessionDetailTransitionState;
+  // Only meaningful for `state: "error"`: the query keeps its error until a
+  // refetch settles, so a retry is a failed frame that is busy again.
+  retrying?: boolean;
   className?: string;
   testId?: string;
 }) {
+  // Derived rather than passed in. `aria-busy` and the state it describes used
+  // to be independent props, which let call sites disagree — a settled failure
+  // announcing itself as busy suppresses the alert it contains, and a loading
+  // frame that forgets the flag announces nothing at all.
+  const busy = state === "loading" || (state === "error" && retrying);
+
   return (
     <div
       data-testid={testId}
       data-session-transition={transition}
+      data-session-state={state}
       aria-busy={busy || undefined}
       className={cn("flex h-full min-h-0 bg-background", className)}
     >

--- a/frontend/src/app/(dashboard)/sessions/[id]/session-detail-frame.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/session-detail-frame.tsx
@@ -1,0 +1,47 @@
+import type { ReactNode } from "react";
+import { cn } from "@/lib/utils";
+
+// Which transition this frame is standing in for. Absent once the workspace is
+// loaded, so `data-session-transition` only appears while something is
+// standing in for the real page.
+export type SessionDetailTransition = "initial" | "provisional" | "error";
+
+// The single root element for every session detail state. Keeping the same
+// element type at the root of all four of SessionDetailContent's returns lets
+// React reconcile it in place, so switching sessions swaps the contents
+// instead of tearing down and rebuilding the workspace. The base classes
+// therefore have to serve the loaded page too, not just the skeleton:
+// `min-h-0` lets the frame shrink inside its flex parent and `bg-background`
+// keeps the surface opaque while the contents swap.
+//
+// The guarantee is scoped to transitions inside SessionDetailContent. The
+// first open of any session still crosses the dynamic() boundary in
+// session-detail-page-client, where the `loading` fallback and the loaded
+// component are different element types, so React remounts the frame there.
+export function SessionDetailFrame({
+  children,
+  busy = false,
+  transition,
+  className,
+  testId = "session-detail-frame",
+}: {
+  children: ReactNode;
+  // Whether a request is in flight right now. Independent of `transition`: a
+  // failed transition is idle until the user retries, and busy again while
+  // that retry runs.
+  busy?: boolean;
+  transition?: SessionDetailTransition;
+  className?: string;
+  testId?: string;
+}) {
+  return (
+    <div
+      data-testid={testId}
+      data-session-transition={transition}
+      aria-busy={busy || undefined}
+      className={cn("flex h-full min-h-0 bg-background", className)}
+    >
+      {children}
+    </div>
+  );
+}

--- a/frontend/src/app/(dashboard)/sessions/[id]/session-detail-geometry.ts
+++ b/frontend/src/app/(dashboard)/sessions/[id]/session-detail-geometry.ts
@@ -1,0 +1,24 @@
+// Session detail geometry.
+//
+// Most of these are read by both the loaded workspace and the loading skeleton
+// that stands in for it during a session transition: the skeleton reserves the
+// same boxes as the real chrome so swapping between them never shifts layout,
+// which only holds if both sides read the same values. The panel width bounds
+// below are session detail geometry too, but only the resize handler consumes
+// them — the skeleton has no counterpart to keep in step.
+
+export const SESSION_HEADER_HEIGHT_CLASSNAME = "h-14";
+
+export const SESSION_WORKSPACE_MIN_WIDTH_CLASSNAME = "md:min-w-[440px]";
+
+// AgentTabStrip: px-3 py-2 wrapper (8px + 8px) around a min-h-9 row (36px)
+// plus its 1px bottom border.
+export const SESSION_THREAD_STRIP_HEIGHT_CLASSNAME = "h-[53px]";
+
+// Composer input surface: the textarea's min-h-[44px] above the h-8 action
+// row in its px-2 pb-2 wrapper (32px + 8px).
+export const SESSION_COMPOSER_SURFACE_HEIGHT_CLASSNAME = "h-[84px]";
+
+export const SESSION_DETAIL_PANEL_DEFAULT_WIDTH = 384;
+export const SESSION_DETAIL_PANEL_MIN_WIDTH = 280;
+export const SESSION_DETAIL_PANEL_MAX_WIDTH = 600;

--- a/frontend/src/app/(dashboard)/sessions/[id]/session-detail-loading-skeleton.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/session-detail-loading-skeleton.test.tsx
@@ -1,12 +1,22 @@
-import { describe, it, expect } from "vitest";
-import { render, screen, within } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import { fireEvent, render, screen, within } from "@testing-library/react";
 import { SessionDetailLoadingSkeleton } from "./session-detail-loading-skeleton";
+import {
+  SESSION_COMPOSER_SURFACE_HEIGHT_CLASSNAME,
+  SESSION_DETAIL_PANEL_DEFAULT_WIDTH,
+  SESSION_THREAD_STRIP_HEIGHT_CLASSNAME,
+  SESSION_WORKSPACE_MIN_WIDTH_CLASSNAME,
+} from "./session-detail-geometry";
 
 describe("SessionDetailLoadingSkeleton", () => {
   it("renders an all-shimmer header when no metadata is known", () => {
     render(<SessionDetailLoadingSkeleton />);
 
     expect(screen.getByTestId("session-detail-loading-skeleton")).toBeInTheDocument();
+    expect(screen.getByTestId("session-detail-loading-skeleton")).toHaveAttribute(
+      "data-session-transition",
+      "initial",
+    );
     expect(screen.queryByRole("heading")).not.toBeInTheDocument();
   });
 
@@ -23,6 +33,10 @@ describe("SessionDetailLoadingSkeleton", () => {
     );
 
     expect(screen.getByTestId("session-detail-loading-skeleton")).toBeInTheDocument();
+    expect(screen.getByTestId("session-detail-loading-skeleton")).toHaveAttribute(
+      "data-session-transition",
+      "provisional",
+    );
     expect(screen.getByRole("heading", { name: "Fix the flaky deploy" })).toBeInTheDocument();
     const statusPill = screen.getByText("Running");
     expect(statusPill).toHaveClass("bg-primary/10", "text-primary");
@@ -64,5 +78,122 @@ describe("SessionDetailLoadingSkeleton", () => {
     );
 
     expect(screen.getByTestId("session-timeline-skeleton")).toBeInTheDocument();
+    expect(screen.getByTestId("session-composer-loading")).toHaveAttribute("aria-disabled", "true");
+    expect(screen.getByTestId("session-composer-loading-surface")).toHaveClass(
+      SESSION_COMPOSER_SURFACE_HEIGHT_CLASSNAME,
+    );
+  });
+
+  it("preserves workspace geometry preferences during a provisional transition", () => {
+    render(
+      <SessionDetailLoadingSkeleton
+        detailPanelOpen
+        detailPanelWidth={428}
+        metadata={{
+          title: "Target session",
+          statusLabel: "Running",
+          statusColor: "bg-primary/10 text-primary",
+        }}
+      />,
+    );
+
+    expect(screen.getByTestId("session-conversation-workspace-loading")).toHaveClass(
+      SESSION_WORKSPACE_MIN_WIDTH_CLASSNAME,
+    );
+    expect(screen.getByTestId("session-thread-strip-loading")).toHaveClass(
+      SESSION_THREAD_STRIP_HEIGHT_CLASSNAME,
+    );
+    expect(screen.getByTestId("session-detail-panel-loading")).toHaveStyle({ width: "428px" });
+  });
+
+  it("defaults the reserved detail panel to the loaded workspace's default width", () => {
+    render(<SessionDetailLoadingSkeleton />);
+
+    expect(screen.getByTestId("session-detail-panel-loading")).toHaveStyle({
+      width: `${SESSION_DETAIL_PANEL_DEFAULT_WIDTH}px`,
+    });
+  });
+
+  it("does not reuse the loaded workspace's test ids", () => {
+    render(<SessionDetailLoadingSkeleton />);
+
+    expect(screen.queryByTestId("session-conversation-workspace")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("session-detail-panel")).not.toBeInTheDocument();
+  });
+
+  it("keeps a failed target in the stable frame and offers retry", () => {
+    const onRetry = vi.fn();
+    render(
+      <SessionDetailLoadingSkeleton
+        metadata={{
+          title: "Target session",
+          statusLabel: "Failed",
+          statusColor: "bg-destructive/10 text-destructive",
+        }}
+        errorMessage="The detail request failed."
+        onRetry={onRetry}
+      />,
+    );
+
+    const frame = screen.getByTestId("session-detail-loading-skeleton");
+    expect(screen.getByTestId("session-detail-transition-error")).toHaveTextContent(
+      "The detail request failed.",
+    );
+    expect(frame).toHaveAttribute("data-session-transition", "error");
+    expect(frame).not.toHaveAttribute("aria-busy");
+    expect(screen.queryByTestId("session-timeline-skeleton")).not.toBeInTheDocument();
+    // Metadata is still worth preserving, so the reserved chrome stays.
+    expect(screen.getByRole("heading", { name: "Target session" })).toBeInTheDocument();
+    expect(screen.getByTestId("session-composer-loading")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Retry" }));
+    expect(onRetry).toHaveBeenCalledOnce();
+  });
+
+  it("marks the retry pending while the refetch is in flight", () => {
+    const onRetry = vi.fn();
+    render(
+      <SessionDetailLoadingSkeleton
+        metadata={{
+          title: "Target session",
+          statusLabel: "Failed",
+          statusColor: "bg-destructive/10 text-destructive",
+        }}
+        errorMessage="The detail request failed."
+        onRetry={onRetry}
+        retrying
+      />,
+    );
+
+    const retry = screen.getByRole("button", { name: "Retry" });
+    expect(retry).toBeDisabled();
+    expect(retry).toHaveAttribute("data-loading", "true");
+    // The error stays on screen during the retry, so the frame is what tells
+    // assistive tech that something is happening.
+    expect(screen.getByTestId("session-detail-loading-skeleton")).toHaveAttribute(
+      "aria-busy",
+      "true",
+    );
+    fireEvent.click(retry);
+    expect(onRetry).not.toHaveBeenCalled();
+  });
+
+  it("drops the shimmer chrome for a cold failure with nothing to preserve", () => {
+    render(
+      <SessionDetailLoadingSkeleton
+        errorMessage="The session could not be found."
+        onRetry={() => {}}
+      />,
+    );
+
+    expect(screen.getByTestId("session-detail-transition-error")).toHaveTextContent(
+      "The session could not be found.",
+    );
+    // Nothing is pending and there is no metadata behind them, so reserving
+    // boxes for chrome that will never arrive would just read as "loading".
+    expect(screen.queryByTestId("session-thread-strip-loading")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("session-composer-loading")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("session-detail-panel-loading")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("session-detail-skeleton-mobile-top-bar")).not.toBeInTheDocument();
+    expect(screen.getByTestId("session-detail-loading-skeleton")).not.toHaveAttribute("aria-busy");
   });
 });

--- a/frontend/src/app/(dashboard)/sessions/[id]/session-detail-loading-skeleton.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/session-detail-loading-skeleton.test.tsx
@@ -78,7 +78,10 @@ describe("SessionDetailLoadingSkeleton", () => {
     );
 
     expect(screen.getByTestId("session-timeline-skeleton")).toBeInTheDocument();
-    expect(screen.getByTestId("session-composer-loading")).toHaveAttribute("aria-disabled", "true");
+    expect(screen.getByTestId("session-composer-loading")).toBeInTheDocument();
+    // The composer is unusable because there is no textbox yet, not because
+    // of an aria-disabled on a plain container (which AT ignores).
+    expect(screen.queryByRole("textbox")).not.toBeInTheDocument();
     expect(screen.getByTestId("session-composer-loading-surface")).toHaveClass(
       SESSION_COMPOSER_SURFACE_HEIGHT_CLASSNAME,
     );
@@ -139,7 +142,8 @@ describe("SessionDetailLoadingSkeleton", () => {
     expect(screen.getByTestId("session-detail-transition-error")).toHaveTextContent(
       "The detail request failed.",
     );
-    expect(frame).toHaveAttribute("data-session-transition", "error");
+    expect(frame).toHaveAttribute("data-session-state", "error");
+    expect(frame).toHaveAttribute("data-session-transition", "provisional");
     expect(frame).not.toHaveAttribute("aria-busy");
     expect(screen.queryByTestId("session-timeline-skeleton")).not.toBeInTheDocument();
     // Metadata is still worth preserving, so the reserved chrome stays.

--- a/frontend/src/app/(dashboard)/sessions/[id]/session-detail-loading-skeleton.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/session-detail-loading-skeleton.tsx
@@ -1,5 +1,14 @@
 import { cn } from "@/lib/utils";
 import { AgentBadge } from "@/components/agent-badge";
+import { Button } from "@/components/ui/button";
+import { SessionDetailFrame } from "./session-detail-frame";
+import {
+  SESSION_COMPOSER_SURFACE_HEIGHT_CLASSNAME,
+  SESSION_DETAIL_PANEL_DEFAULT_WIDTH,
+  SESSION_HEADER_HEIGHT_CLASSNAME,
+  SESSION_THREAD_STRIP_HEIGHT_CLASSNAME,
+  SESSION_WORKSPACE_MIN_WIDTH_CLASSNAME,
+} from "./session-detail-geometry";
 
 export function SessionTimelineSkeleton() {
   const rows: { align: "left" | "right"; widths: string[] }[] = [
@@ -60,18 +69,83 @@ export type SessionDetailSkeletonMetadata = {
   agentType?: string | null;
 };
 
-export function SessionDetailLoadingSkeleton({
-  metadata,
-}: {
+type SessionDetailLoadingProps = {
   metadata?: SessionDetailSkeletonMetadata | null;
+  detailPanelOpen?: boolean;
+  detailPanelWidth?: number;
+  errorMessage?: string;
+  onRetry?: () => void;
+  // A retry keeps the error on screen — the query holds its error until the
+  // refetch settles — so the button is the only place we can show that the
+  // click did something.
+  retrying?: boolean;
+};
+
+function SessionDetailTransitionError({
+  message,
+  onRetry,
+  retrying = false,
+}: {
+  message: string;
+  onRetry?: () => void;
+  retrying?: boolean;
 }) {
   return (
     <div
-      data-testid="session-detail-loading-skeleton"
-      aria-busy="true"
-      className="flex h-full min-h-0 bg-background"
+      role="alert"
+      data-testid="session-detail-transition-error"
+      className="mx-auto max-w-sm space-y-3 rounded-lg border border-border bg-card p-5 text-center"
     >
-      <div className="flex min-w-0 flex-1 flex-col">
+      <p className="text-sm font-medium text-foreground">Couldn&apos;t load this session</p>
+      <p className="text-xs text-muted-foreground">{message}</p>
+      {onRetry ? (
+        <Button type="button" size="sm" variant="outline" loading={retrying} onClick={onRetry}>
+          Retry
+        </Button>
+      ) : null}
+    </div>
+  );
+}
+
+export function SessionDetailLoadingContent({
+  metadata,
+  detailPanelOpen = true,
+  detailPanelWidth = SESSION_DETAIL_PANEL_DEFAULT_WIDTH,
+  errorMessage,
+  onRetry,
+  retrying,
+}: SessionDetailLoadingProps) {
+  // A cold failure has no metadata to preserve and nothing pending, so the
+  // shimmer chrome would be a lie: it reads as "still loading" and reserves
+  // boxes for content that is never going to arrive. Show only the error.
+  //
+  // This does mean the reserved detail panel collapses on the way from the
+  // initial skeleton to a cold failure. That shift is deliberate: there is no
+  // session to show beside the error, and holding a shimmering panel open next
+  // to a dead end is worse than the one-time reflow.
+  if (errorMessage && !metadata) {
+    return (
+      <div
+        data-testid="session-conversation-workspace-loading"
+        className={cn("flex min-w-0 flex-1 flex-col", SESSION_WORKSPACE_MIN_WIDTH_CLASSNAME)}
+      >
+        <div className="flex min-h-0 flex-1 items-center justify-center p-4">
+          <SessionDetailTransitionError
+            message={errorMessage}
+            onRetry={onRetry}
+            retrying={retrying}
+          />
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <>
+      <div
+        data-testid="session-conversation-workspace-loading"
+        className={cn("flex min-w-0 flex-1 flex-col", SESSION_WORKSPACE_MIN_WIDTH_CLASSNAME)}
+      >
         {/* Mirrors MobileSessionTopBar's geometry (back button, title, two
             icon buttons) so the swap to the real page does not shift layout.
             The controls stay shimmer — they need session data to act — but
@@ -97,7 +171,12 @@ export function SessionDetailLoadingSkeleton({
             <SkeletonLine className="h-9 w-9 rounded-md" />
           </span>
         </div>
-        <div className="hidden h-12 shrink-0 border-b border-border px-4 md:flex md:items-center md:justify-between">
+        <div
+          className={cn(
+            "hidden shrink-0 border-b border-border px-4 md:flex md:items-center md:justify-between",
+            SESSION_HEADER_HEIGHT_CLASSNAME,
+          )}
+        >
           {metadata ? (
             // Mirrors the loaded header's title row (same type classes and
             // status pill) so the swap to the real page does not shift layout.
@@ -128,7 +207,18 @@ export function SessionDetailLoadingSkeleton({
           </div>
         </div>
         <div className="flex min-h-0 flex-1 flex-col">
-          <div className="hidden h-10 shrink-0 border-b border-border px-3 md:flex md:items-center">
+          {/* AgentTabStrip renders nothing for a session with no threads, so
+              reserving this box overshoots for those sessions. A provisional
+              list row carries no thread data, so we cannot tell them apart
+              here; reserving is the better bet because nearly every session
+              has at least one thread. */}
+          <div
+            data-testid="session-thread-strip-loading"
+            className={cn(
+              "hidden shrink-0 border-b border-border px-3 md:flex md:items-center",
+              SESSION_THREAD_STRIP_HEIGHT_CLASSNAME,
+            )}
+          >
             <div className="flex gap-2 animate-pulse">
               <SkeletonLine className="h-6 w-24 rounded-md" />
               <SkeletonLine className="h-6 w-28 rounded-md" />
@@ -136,13 +226,33 @@ export function SessionDetailLoadingSkeleton({
           </div>
           <div className="min-h-0 flex-1 overflow-hidden p-4">
             <div className="mx-auto flex h-full max-w-3xl flex-col justify-end gap-3">
-              <SessionTimelineSkeleton />
+              {errorMessage ? (
+                <SessionDetailTransitionError
+                  message={errorMessage}
+                  onRetry={onRetry}
+                  retrying={retrying}
+                />
+              ) : (
+                <SessionTimelineSkeleton />
+              )}
             </div>
           </div>
-          <div className="shrink-0 border-t border-border p-3">
-            <div className="animate-pulse rounded-lg border border-border bg-card p-3">
-              <SkeletonLine className="h-16 w-full rounded-md" />
-              <div className="mt-3 flex items-center justify-between">
+          <div
+            data-testid="session-composer-loading"
+            aria-disabled="true"
+            className="shrink-0 border-t border-border p-3"
+          >
+            <div
+              data-testid="session-composer-loading-surface"
+              className={cn(
+                "flex flex-col rounded-xl border border-border-strong bg-surface-raised animate-pulse",
+                SESSION_COMPOSER_SURFACE_HEIGHT_CLASSNAME,
+              )}
+            >
+              <div className="flex min-h-11 flex-1 items-center px-2.5 py-1.5">
+                <SkeletonLine className="h-3 w-2/5 rounded-md" />
+              </div>
+              <div className="flex h-10 items-center justify-between px-2 pb-2">
                 <div className="flex gap-2">
                   <SkeletonLine className="h-8 w-8 rounded-md" />
                   <SkeletonLine className="h-8 w-24 rounded-md" />
@@ -153,20 +263,40 @@ export function SessionDetailLoadingSkeleton({
           </div>
         </div>
       </div>
-      <div className="hidden w-[360px] shrink-0 border-l border-border bg-background md:flex md:flex-col">
-        <div className="h-12 shrink-0 border-b border-border px-3">
-          <div className="flex h-full items-center gap-2 animate-pulse">
-            <SkeletonLine className="h-7 w-20 rounded-md" />
-            <SkeletonLine className="h-7 w-20 rounded-md" />
-            <SkeletonLine className="h-7 w-20 rounded-md" />
+      {detailPanelOpen ? (
+        <div
+          data-testid="session-detail-panel-loading"
+          style={{ width: detailPanelWidth }}
+          className="hidden shrink-0 border-l border-border bg-background md:flex md:flex-col"
+        >
+          <div className={cn("shrink-0 border-b border-border px-3", SESSION_HEADER_HEIGHT_CLASSNAME)}>
+            <div className="flex h-full items-center gap-2 animate-pulse">
+              <SkeletonLine className="h-7 w-20 rounded-md" />
+              <SkeletonLine className="h-7 w-20 rounded-md" />
+              <SkeletonLine className="h-7 w-20 rounded-md" />
+            </div>
+          </div>
+          <div className="space-y-4 p-4 animate-pulse">
+            <SkeletonLine className="h-24 w-full rounded-md" />
+            <SkeletonLine className="h-16 w-full rounded-md" />
+            <SkeletonLine className="h-32 w-full rounded-md" />
           </div>
         </div>
-        <div className="space-y-4 p-4 animate-pulse">
-          <SkeletonLine className="h-24 w-full rounded-md" />
-          <SkeletonLine className="h-16 w-full rounded-md" />
-          <SkeletonLine className="h-32 w-full rounded-md" />
-        </div>
-      </div>
-    </div>
+      ) : null}
+    </>
+  );
+}
+
+export function SessionDetailLoadingSkeleton(props: SessionDetailLoadingProps) {
+  return (
+    <SessionDetailFrame
+      testId="session-detail-loading-skeleton"
+      busy={!props.errorMessage || Boolean(props.retrying)}
+      transition={
+        props.errorMessage ? "error" : props.metadata ? "provisional" : "initial"
+      }
+    >
+      <SessionDetailLoadingContent {...props} />
+    </SessionDetailFrame>
   );
 }

--- a/frontend/src/app/(dashboard)/sessions/[id]/session-detail-loading-skeleton.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/session-detail-loading-skeleton.tsx
@@ -10,7 +10,12 @@ import {
   SESSION_WORKSPACE_MIN_WIDTH_CLASSNAME,
 } from "./session-detail-geometry";
 
-export function SessionTimelineSkeleton() {
+// `announce` controls the live region. Inside the loading frame the ancestor
+// already carries aria-busy, which suppresses descendant live regions anyway —
+// so the announcement there is dead markup that only looks like coverage. In
+// the loaded transcript, where nothing else marks the region busy, this is the
+// only thing that tells a screen reader the timeline is still filling in.
+export function SessionTimelineSkeleton({ announce = true }: { announce?: boolean } = {}) {
   const rows: { align: "left" | "right"; widths: string[] }[] = [
     { align: "right", widths: ["w-3/5", "w-2/5"] },
     { align: "left", widths: ["w-4/5", "w-3/4", "w-1/2"] },
@@ -20,9 +25,9 @@ export function SessionTimelineSkeleton() {
 
   return (
     <div
-      role="status"
-      aria-live="polite"
-      aria-label="Loading session activity"
+      role={announce ? "status" : undefined}
+      aria-live={announce ? "polite" : undefined}
+      aria-label={announce ? "Loading session activity" : undefined}
       data-testid="session-timeline-skeleton"
       className="space-y-3 py-1"
     >
@@ -47,7 +52,7 @@ export function SessionTimelineSkeleton() {
           </div>
         </div>
       ))}
-      <span className="sr-only">Loading session activity...</span>
+      {announce ? <span className="sr-only">Loading session activity...</span> : null}
     </div>
   );
 }
@@ -207,11 +212,10 @@ export function SessionDetailLoadingContent({
           </div>
         </div>
         <div className="flex min-h-0 flex-1 flex-col">
-          {/* AgentTabStrip renders nothing for a session with no threads, so
-              reserving this box overshoots for those sessions. A provisional
-              list row carries no thread data, so we cannot tell them apart
-              here; reserving is the better bet because nearly every session
-              has at least one thread. */}
+          {/* AgentTabStrip holds this same height even when it has no tabs to
+              show, so reserving it here matches the loaded view for every
+              session — including the zero-thread case a provisional list row
+              cannot tell us about. */}
           <div
             data-testid="session-thread-strip-loading"
             className={cn(
@@ -233,13 +237,15 @@ export function SessionDetailLoadingContent({
                   retrying={retrying}
                 />
               ) : (
-                <SessionTimelineSkeleton />
+                <SessionTimelineSkeleton announce={false} />
               )}
             </div>
           </div>
+          {/* No aria-disabled here: on a plain container it is inert, and the
+              composer's real "not yet usable" signal is that no textbox
+              exists in the tree until the session loads. */}
           <div
             data-testid="session-composer-loading"
-            aria-disabled="true"
             className="shrink-0 border-t border-border p-3"
           >
             <div
@@ -291,10 +297,9 @@ export function SessionDetailLoadingSkeleton(props: SessionDetailLoadingProps) {
   return (
     <SessionDetailFrame
       testId="session-detail-loading-skeleton"
-      busy={!props.errorMessage || Boolean(props.retrying)}
-      transition={
-        props.errorMessage ? "error" : props.metadata ? "provisional" : "initial"
-      }
+      state={props.errorMessage ? "error" : "loading"}
+      transition={props.metadata ? "provisional" : "initial"}
+      retrying={props.retrying}
     >
       <SessionDetailLoadingContent {...props} />
     </SessionDetailFrame>

--- a/frontend/src/app/(dashboard)/sessions/[id]/session-detail-state.test.ts
+++ b/frontend/src/app/(dashboard)/sessions/[id]/session-detail-state.test.ts
@@ -21,11 +21,84 @@ import {
   trackInFlightAgentUpdate,
   buildChromeThreads,
   getPullRequestHealthRefetchInterval,
+  deriveSessionDetailLoadState,
 } from "./session-detail-state";
 import type { PullRequestHealthResponse, SessionDetail, SessionLog, SessionMessage, SessionReviewLoop, SessionThread } from "@/lib/types";
+import { isProvisionalSessionDetail, markProvisionalSessionDetail } from "@/lib/session-detail-cache";
 
 const start = "2026-01-01T00:00:00.000Z";
 const plus = (ms: number) => new Date(new Date(start).getTime() + ms).toISOString();
+
+describe("deriveSessionDetailLoadState", () => {
+  const session = { id: "session-1", status: "running" } as SessionDetail;
+
+  it.each([
+    {
+      name: "uses the cold initial state without cached data",
+      input: { session: undefined, isLoading: true, error: null },
+      expectedKind: "initial",
+    },
+    {
+      name: "identifies list-seeded data as provisional",
+      input: { session: markProvisionalSessionDetail(session), isLoading: false, error: null },
+      expectedKind: "provisional",
+    },
+    {
+      name: "uses a localized error state when provisional detail fails",
+      input: {
+        session: markProvisionalSessionDetail(session),
+        isLoading: false,
+        error: new Error("failed"),
+      },
+      expectedKind: "error",
+    },
+    {
+      name: "keeps authoritative data ready after a background refetch error",
+      input: { session, isLoading: false, error: new Error("failed") },
+      expectedKind: "ready",
+    },
+    {
+      name: "treats an idle query with no data as an error rather than a stuck skeleton",
+      input: { session: undefined, isLoading: false, error: null },
+      expectedKind: "error",
+    },
+  ])("$name", ({ input, expectedKind }) => {
+    expect(deriveSessionDetailLoadState(input).kind).toBe(expectedKind);
+  });
+
+  it("carries the in-flight retry on the error state", () => {
+    const settled = deriveSessionDetailLoadState({
+      session: markProvisionalSessionDetail(session),
+      isLoading: false,
+      isFetching: false,
+      error: new Error("failed"),
+    });
+    const retrying = deriveSessionDetailLoadState({
+      session: markProvisionalSessionDetail(session),
+      isLoading: false,
+      isFetching: true,
+      error: new Error("failed"),
+    });
+
+    expect(settled).toMatchObject({ kind: "error", retrying: false });
+    expect(retrying).toMatchObject({ kind: "error", retrying: true });
+  });
+
+  it("stays provisional for gating purposes only via the raw cache predicate", () => {
+    // Regression guard: a failed detail request moves the load state to
+    // "error" even though the cached row is still provisional. Callers that
+    // gate dependent fetches must not read provisional-ness off the load
+    // state, or they would fire for a session that never loaded.
+    const failed = deriveSessionDetailLoadState({
+      session: markProvisionalSessionDetail(session),
+      isLoading: false,
+      error: new Error("failed"),
+    });
+
+    expect(failed.kind).toBe("error");
+    expect(isProvisionalSessionDetail(failed.session ?? undefined)).toBe(true);
+  });
+});
 
 const baseHealth: PullRequestHealthResponse = {
   pull_request_id: "pr-1",

--- a/frontend/src/app/(dashboard)/sessions/[id]/session-detail-state.ts
+++ b/frontend/src/app/(dashboard)/sessions/[id]/session-detail-state.ts
@@ -17,6 +17,45 @@ import type {
   ThreadRuntimeEvent,
   ThreadStatus,
 } from "@/lib/types";
+import { isProvisionalSessionDetail } from "@/lib/session-detail-cache";
+
+export type SessionDetailLoadState =
+  | { kind: "initial"; session: null }
+  | { kind: "provisional"; session: SessionDetail }
+  | { kind: "ready"; session: SessionDetail }
+  // `retrying` rides on the error variant rather than being tracked
+  // separately by the caller: the query holds its error until a refetch
+  // settles, so the failed UI and the in-flight retry are one state and must
+  // not be able to disagree.
+  | { kind: "error"; session: SessionDetail | null; retrying: boolean };
+
+export function deriveSessionDetailLoadState({
+  session,
+  isLoading,
+  isFetching = false,
+  error,
+}: {
+  session: SessionDetail | undefined;
+  isLoading: boolean;
+  isFetching?: boolean;
+  error: unknown;
+}): SessionDetailLoadState {
+  if (session && !isProvisionalSessionDetail(session)) {
+    // Authoritative cached data remains usable when a background refetch
+    // fails. A refetch error must not replace a loaded workspace.
+    return { kind: "ready", session };
+  }
+  if (error) {
+    return { kind: "error", session: session ?? null, retrying: isFetching };
+  }
+  if (session) {
+    return { kind: "provisional", session };
+  }
+  if (isLoading) {
+    return { kind: "initial", session: null };
+  }
+  return { kind: "error", session: null, retrying: isFetching };
+}
 
 type PendingEditableThreadUpdate = {
   label: string;

--- a/frontend/src/hooks/use-session-scoped-reset.ts
+++ b/frontend/src/hooks/use-session-scoped-reset.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from "react";
+import { useLayoutEffect, useRef } from "react";
 
 export type SessionScopedResetGroup = {
   name: string;
@@ -12,11 +12,14 @@ export function useSessionScopedReset(
   const groupsRef = useRef(groups);
   const previousSessionIdRef = useRef(sessionId);
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     groupsRef.current = groups;
   }, [groups]);
 
-  useEffect(() => {
+  // Session changes are route transitions. Reset session-owned state before
+  // the browser paints the new route so controls from the previous session
+  // cannot flash under the newly selected session's title.
+  useLayoutEffect(() => {
     if (previousSessionIdRef.current === sessionId) {
       return;
     }


### PR DESCRIPTION
## Summary

When switching nested sessions and the authoritative session detail contains no agent threads, the page could collapse/reflow and “jump” (losing the expected layout footprint). This change retains the shared `SessionDetailFrame` strip geometry in-place and surfaces a clear empty state (“No agent tabs for this session”) instead of collapsing the provisional strip.

## Changes

- Updated session detail layout/geometry to keep the thread-strip footprint stable when `threads: []`, preventing the 53px strip jump on session switch.
- Adjusted the session detail frame reconciliation so provisional loading content is replaced locally (same `session-detail-frame`) rather than re-mounted, avoiding workspace-root rerenders.
- Improved gating of actions/composer during provisional/failed authoritative loads, so metadata stays visible while follow-up UI remains disabled until data is ready.
- Extended session detail tests to cover zero-thread authoritative responses and provisional-failure retry behavior in place.

## Validation

- 35 session overview/transition tests passed.
- TypeScript typecheck passed.
- ESLint passed for touched files.
- `git diff --check` passed.

[143.dev](https://143.dev) | [session 95feb90f](https://143.dev/sessions/95feb90f-f3df-4496-9010-53b5116dda79)

<!-- 143 readiness -->
**143 readiness:** not available for this revision.

<!-- 143-publication session=95feb90f-f3df-4496-9010-53b5116dda79 changeset=859e69aa-2de5-4c9a-a313-e2a003523839 -->

Preview: https://143.dev/previews/github/assembledhq/143/pull/2001?launch=1