### PR TITLE
Audit GitHub API Request Efficiency and Rate Limit Mitigation

### DIFF
--- a/internal/services/codereview/service.go
+++ b/internal/services/codereview/service.go
@@ -296,7 +296,8 @@ func (s *Service) RetryReview(ctx context.Context, input RetryReviewInput) (Retr
 		return RetryReviewResult{}, err
 	}
 
-	if err := s.pullRequestSyncer.SyncPullRequestState(ctx, input.OrgID, failed.PullRequestID); err != nil && !errors.Is(err, ghservice.ErrPullRequestMergeabilityPending) {
+	syncCtx := ghservice.WithPullRequestSyncReason(ctx, ghservice.PullRequestSyncReasonCodeReview)
+	if err := s.pullRequestSyncer.SyncPullRequestState(syncCtx, input.OrgID, failed.PullRequestID); err != nil && !errors.Is(err, ghservice.ErrPullRequestMergeabilityPending) {
 		return RetryReviewResult{}, fmt.Errorf("refresh pull request before code review retry: %w", err)
 	}
 	pr, err := s.pullRequests.GetByID(ctx, input.OrgID, failed.PullRequestID)

--- a/internal/services/github/pr.go
+++ b/internal/services/github/pr.go
@@ -22,6 +22,7 @@ import (
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/rs/zerolog"
+	"golang.org/x/sync/singleflight"
 
 	"github.com/assembledhq/143/internal/cache"
 	"github.com/assembledhq/143/internal/db"
@@ -135,6 +136,7 @@ type PRService struct {
 	mergeabilityRetryWait    func(context.Context, time.Duration) error
 	linearMilestones         LinearMilestoneEnqueuer // nil-safe: Linear writes disabled if nil
 	prPreviewSurfacesEnabled bool
+	prHealthSyncGroup        singleflight.Group
 
 	// cachedResolverMu guards lazy construction of cachedResolver. The
 	// resolver is built from the currently-wired dependencies on first use
@@ -1716,7 +1718,7 @@ func (s *PRService) PushChangesToPR(ctx context.Context, run *models.Session, pa
 		}
 	}
 	pr.HeadSHA = &pushed.HeadSHA
-	s.enqueuePullRequestStateSync(ctx, pr)
+	s.enqueuePullRequestStateSync(ctx, pr, PullRequestSyncReasonHeadChanged)
 
 	if targetChangeset != nil {
 		return &pr, nil
@@ -2446,11 +2448,33 @@ func (s *PRService) HandlePullRequestEvent(ctx context.Context, event PullReques
 			return fmt.Errorf("refresh edited pull request snapshot: %w", err)
 		}
 		if baseChanged {
-			s.enqueuePullRequestStateSync(ctx, pr)
+			s.enqueuePullRequestStateSync(ctx, pr, PullRequestSyncReasonBaseChanged)
 		}
 		return nil
-	case "opened", "reopened", "ready_for_review", "synchronize":
-		s.enqueuePullRequestStateSync(ctx, pr)
+	case "opened", "reopened":
+		reason := PullRequestSyncReasonInitial
+		if pullRequestHasHealthBaseline(pr) && *pr.HeadSHA != event.PR.Head.SHA {
+			reason = PullRequestSyncReasonHeadChanged
+		}
+		s.enqueuePullRequestStateSync(ctx, pr, reason)
+		return s.handleAutoPreviewEvent(ctx, event)
+	case "ready_for_review":
+		// Unlike every other trigger this one changes GitHub's mergeable_state
+		// ("draft" -> "clean"/"blocked") without moving the head SHA, and
+		// projected check rebuilds never recompute merge state. Skipping the
+		// readback here would leave a PR that 143 opened as a draft stuck at
+		// MergeState=blocked, and therefore CanMerge=false, until the reconcile
+		// sweep catches it. Draft transitions are rare, so always sync.
+		reason := PullRequestSyncReasonReadyForReview
+		if !pullRequestHasHealthBaseline(pr) {
+			reason = PullRequestSyncReasonInitial
+		} else if pr.HeadSHA == nil || *pr.HeadSHA != event.PR.Head.SHA {
+			reason = PullRequestSyncReasonHeadChanged
+		}
+		s.enqueuePullRequestStateSync(ctx, pr, reason)
+		return s.handleAutoPreviewEvent(ctx, event)
+	case "synchronize":
+		s.enqueuePullRequestStateSync(ctx, pr, PullRequestSyncReasonHeadChanged)
 		return s.handleAutoPreviewEvent(ctx, event)
 	case "closed":
 		// handled below
@@ -2462,7 +2486,6 @@ func (s *PRService) HandlePullRequestEvent(ctx context.Context, event PullReques
 		return err
 	}
 
-	s.enqueuePullRequestStateSync(ctx, pr)
 	return s.handleAutoPreviewEvent(ctx, event)
 }
 
@@ -2890,6 +2913,7 @@ func (s *PRService) applyClosedPRTransition(ctx context.Context, pr models.PullR
 			commitSHA = headSHA
 		}
 		s.runMergedPullRequestFollowUps(ctx, pr, commitSHA)
+		s.publishPullRequestTerminalState(ctx, pr)
 		return nil
 	}
 
@@ -2910,6 +2934,7 @@ func (s *PRService) applyClosedPRTransition(ctx context.Context, pr models.PullR
 	}
 	s.teardownPRPreview(ctx, pr, false)
 	s.maybeAutoArchiveSessionOnPRClose(ctx, pr, nil, false)
+	s.publishPullRequestTerminalState(ctx, pr)
 	return nil
 }
 
@@ -3681,7 +3706,7 @@ func (s *PRService) enqueueReinforceMemories(ctx context.Context, orgID uuid.UUI
 // --- GitHub API helpers ---
 
 func (s *PRService) doGitHubRequest(ctx context.Context, token, method, path string, body any) ([]byte, error) {
-	ctx = githubtelemetry.WithRequestMetadata(ctx, s.githubRequestMetadataForToken(token))
+	ctx = githubtelemetry.WithRequestMetadata(ctx, s.githubRequestMetadataForToken(ctx, token))
 	var bodyReader io.Reader
 	if body != nil {
 		b, err := json.Marshal(body)
@@ -3735,7 +3760,7 @@ func (s *PRService) doGitHubRequest(ctx context.Context, token, method, path str
 // GitHub Enterprise Server splits these differently (REST at /api/v3, GraphQL at
 // /api/graphql); revisit this if 143 ever targets a GHES base URL.
 func (s *PRService) doGitHubGraphQL(ctx context.Context, token, query string, variables map[string]any) ([]byte, error) {
-	ctx = githubtelemetry.WithRequestMetadata(ctx, s.githubRequestMetadataForToken(token))
+	ctx = githubtelemetry.WithRequestMetadata(ctx, s.githubRequestMetadataForToken(ctx, token))
 	payload, err := json.Marshal(map[string]any{"query": query, "variables": variables})
 	if err != nil {
 		return nil, err
@@ -3773,10 +3798,13 @@ func (s *PRService) doGitHubGraphQL(ctx context.Context, token, query string, va
 	return respBody, nil
 }
 
-func (s *PRService) githubRequestMetadataForToken(token string) githubtelemetry.RequestMetadata {
+func (s *PRService) githubRequestMetadataForToken(ctx context.Context, token string) githubtelemetry.RequestMetadata {
 	metadata := githubtelemetry.RequestMetadata{
 		Kind:     githubtelemetry.RequestKindAPI,
 		AuthType: githubtelemetry.AuthTypeUser,
+	}
+	if reason, ok := pullRequestSyncReasonAttribute(ctx); ok {
+		metadata.SyncReason = string(reason)
 	}
 	if s != nil && s.tokenProvider != nil {
 		if installationID, ok := s.tokenProvider.installationIDForToken(token); ok {
@@ -5985,11 +6013,24 @@ func (s *PRService) HandleCheckRunEvent(ctx context.Context, event CheckRunEvent
 			continue
 		}
 		state := checkRunEventState(pr, event)
-		_, err = s.pullRequests.UpsertCheckState(ctx, pr.OrgID, state)
+		applied, err := s.pullRequests.UpsertCheckState(ctx, pr.OrgID, state)
 		if err != nil {
 			return err
 		}
-		if err := s.enqueuePullRequestHealthRebuild(ctx, pr); err != nil {
+		if !applied {
+			// The upsert rejected this event as out of order, so the projection
+			// did not move and a rebuild would re-read the same row. Note that
+			// check_run events share a provider_sequence (the run ID) across a
+			// run's lifecycle and GitHub's updated_at is second-granular, so a
+			// run that starts and finishes inside one second also lands here;
+			// the reconcile sweep is what repairs that.
+			continue
+		}
+		requiresSync, err := s.checkStateRequiresAuthoritativeSync(ctx, pr, state)
+		if err != nil {
+			return err
+		}
+		if err := s.enqueuePullRequestCheckProjection(ctx, pr, requiresSync); err != nil {
 			return err
 		}
 	}
@@ -6035,15 +6076,64 @@ func (s *PRService) HandleStatusEvent(ctx context.Context, event StatusEvent) er
 	}
 	for _, pr := range prs {
 		state := statusEventState(pr, event)
-		_, err = s.pullRequests.UpsertCheckState(ctx, pr.OrgID, state)
+		applied, err := s.pullRequests.UpsertCheckState(ctx, pr.OrgID, state)
 		if err != nil {
 			return err
 		}
-		if err := s.enqueuePullRequestHealthRebuild(ctx, pr); err != nil {
+		if !applied {
+			continue
+		}
+		requiresSync, err := s.checkStateRequiresAuthoritativeSync(ctx, pr, state)
+		if err != nil {
+			return err
+		}
+		if err := s.enqueuePullRequestCheckProjection(ctx, pr, requiresSync); err != nil {
 			return err
 		}
 	}
 	return nil
+}
+
+func pullRequestHasHealthBaseline(pr models.PullRequest) bool {
+	return pr.GitHubStateSyncedAt != nil && pr.HealthVersion > 0 && pr.HeadSHA != nil && strings.TrimSpace(*pr.HeadSHA) != ""
+}
+
+func (s *PRService) checkStateRequiresAuthoritativeSync(ctx context.Context, pr models.PullRequest, state models.PullRequestCheckState) (bool, error) {
+	if !pullRequestHasHealthBaseline(pr) {
+		return true, nil
+	}
+	current, err := s.pullRequests.GetHealthCurrent(ctx, pr.OrgID, pr.ID)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return true, nil
+	}
+	if err != nil {
+		return false, fmt.Errorf("load pull request health baseline for webhook check: %w", err)
+	}
+	if current.HeadSHA != state.HeadSHA {
+		return true, nil
+	}
+	var summary models.PullRequestHealthSummary
+	if err := json.Unmarshal(current.SummaryJSON, &summary); err != nil {
+		// Degrade to the authoritative readback rather than failing the webhook.
+		// Returning an error here would 500 the delivery, and every redelivery
+		// would decode the same bad row and fail identically — a poison pill for
+		// this PR's whole check stream. An unreadable baseline is precisely the
+		// case a full sync repairs, because it rewrites the snapshot.
+		s.logger.Warn().Err(err).
+			Str("pull_request_id", pr.ID.String()).
+			Msg("pull request health baseline is undecodable; forcing an authoritative sync")
+		return true, nil
+	}
+	if summary.CheckSetComplete == nil || !*summary.CheckSetComplete {
+		return true, nil
+	}
+	incomingKey := projectedCheckSummaryKey(state.CheckSummary())
+	for _, check := range summary.Checks {
+		if projectedCheckSummaryKey(check) == incomingKey {
+			return false, nil
+		}
+	}
+	return true, nil
 }
 
 func checkRunEventState(pr models.PullRequest, event CheckRunEvent) models.PullRequestCheckState {

--- a/internal/services/github/pr_auto_repair.go
+++ b/internal/services/github/pr_auto_repair.go
@@ -109,7 +109,19 @@ func (s *PRService) MaybeStartAutoRepair(ctx context.Context, orgID uuid.UUID, s
 	// Skip the exhausted-action badges: they are a PR health UI concern, the
 	// budget is rechecked below, and populating them here would repeat the
 	// organization, session, and user loads this function already performed.
-	health, err := s.getPullRequestHealth(ctx, orgID, pr.ID, healthBuildOptions{skipAutoRepairAttemptState: true})
+	//
+	// asyncRefreshAfter keeps this off the interactive staleness budget. The
+	// coordinator runs from the sync_pull_request_state and
+	// rebuild_pull_request_health job handlers, so borrowing the read path's
+	// two-minute threshold would make every projected rebuild pull in the
+	// authoritative readback that checkStateRequiresAuthoritativeSync avoided.
+	// Conflicts — the blocker this path actually reads merge state for — come
+	// from base-branch movement, which produces no webhook on this PR at all
+	// and is detected by the reconcile sweep regardless.
+	health, err := s.getPullRequestHealth(ctx, orgID, pr.ID, healthBuildOptions{
+		skipAutoRepairAttemptState: true,
+		asyncRefreshAfter:          prHealthStaleAfter,
+	})
 	if err != nil {
 		return nil, fmt.Errorf("load pull request health for auto-repair: %w", err)
 	}

--- a/internal/services/github/pr_handlers_test.go
+++ b/internal/services/github/pr_handlers_test.go
@@ -1213,18 +1213,6 @@ func TestHandlePullRequestEvent_ClosedWithoutMergeFlow(t *testing.T) {
 	prMock.ExpectExec("UPDATE pull_requests SET status").
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
 		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
-	dedupeKey := pullRequestStateSyncDedupeKey(prID)
-	jobMock.ExpectQuery("INSERT INTO jobs").
-		WithArgs(pgx.NamedArgs{
-			"org_id":     orgID,
-			"queue":      prHealthSyncQueue,
-			"job_type":   prHealthSyncJobType,
-			"payload":    pgxmock.AnyArg(),
-			"priority":   6,
-			"dedupe_key": &dedupeKey,
-		}).
-		WillReturnRows(pgxmock.NewRows([]string{"id"}).AddRow(uuid.New()))
-
 	event := PullRequestEvent{
 		Action: "closed",
 		Number: 42,
@@ -1235,7 +1223,7 @@ func TestHandlePullRequestEvent_ClosedWithoutMergeFlow(t *testing.T) {
 	err := svc.HandlePullRequestEvent(context.Background(), event)
 	require.NoError(t, err, "HandlePullRequestEvent should not return an error for a closed-without-merge PR")
 	require.NoError(t, prMock.ExpectationsWereMet(), "all PR store expectations should be met")
-	require.NoError(t, jobMock.ExpectationsWereMet(), "closed pull request webhooks should enqueue a state sync with the generic dedupe key")
+	require.NoError(t, jobMock.ExpectationsWereMet(), "closed pull request webhooks should not enqueue a redundant GitHub readback")
 }
 
 func TestHandlePullRequestEvent_ClosedWithoutMergeReturnsStatusUpdateError(t *testing.T) {
@@ -2561,6 +2549,8 @@ func TestHandleCheckRunEvent_CompletedEnqueuesHealthSync(t *testing.T) {
 	prRow := handlerPRRow(prID, &sessionID, orgID, "testorg/testrepo", now)
 	headSHA := "head-sha"
 	prRow[12] = &headSHA
+	prRow[19] = &now
+	prRow[20] = int64(1)
 	prMock.ExpectQuery("SELECT .+ FROM pull_requests WHERE github_repo").
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
 		WillReturnRows(
@@ -2591,6 +2581,21 @@ func TestHandleCheckRunEvent_CompletedEnqueuesHealthSync(t *testing.T) {
 		}).
 		WillReturnRows(pgxmock.NewRows([]string{"exists"}).AddRow(true))
 	prMock.ExpectCommit()
+	checkSetComplete := true
+	baselineJSON, err := json.Marshal(models.PullRequestHealthSummary{
+		CheckSetComplete: &checkSetComplete,
+		Checks: []models.PullRequestCheckSummary{{
+			Name:     "Backend Test",
+			Provider: "github-actions",
+		}},
+	})
+	require.NoError(t, err, "check run test should encode its authoritative baseline")
+	prMock.ExpectQuery("SELECT .+ FROM pull_request_health_current WHERE org_id").
+		WithArgs(pgx.NamedArgs{"org_id": orgID, "pull_request_id": prID}).
+		WillReturnRows(pgxmock.NewRows(prHealthCurrentTestColumns).AddRow(
+			prID, orgID, int64(1), headSHA, "base-sha", baselineJSON, baselineJSON,
+			models.PullRequestHealthEnrichmentStatusNotRequested, nil, int64(0), now, now,
+		))
 	dedupeKey := fmt.Sprintf("%s:%s", prHealthRebuildJobType, prID.String())
 	jobMock.ExpectQuery("INSERT INTO jobs").
 		WithArgs(pgx.NamedArgs{
@@ -2622,10 +2627,202 @@ func TestHandleCheckRunEvent_CompletedEnqueuesHealthSync(t *testing.T) {
 		} `json:"base"`
 	}{Number: 42})
 
-	err := svc.HandleCheckRunEvent(context.Background(), event)
+	err = svc.HandleCheckRunEvent(context.Background(), event)
 	require.NoError(t, err, "HandleCheckRunEvent should project completed check runs")
 	require.NoError(t, prMock.ExpectationsWereMet(), "all pull request expectations should be met")
 	require.NoError(t, jobMock.ExpectationsWereMet(), "check run completion should enqueue a DB-only health rebuild")
+}
+
+func TestPullRequestHasHealthBaseline(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now()
+	headSHA := "head-sha"
+	tests := []struct {
+		name     string
+		pr       models.PullRequest
+		expected bool
+	}{
+		{
+			name: "complete baseline",
+			pr: models.PullRequest{
+				GitHubStateSyncedAt: &now,
+				HealthVersion:       1,
+				HeadSHA:             &headSHA,
+			},
+			expected: true,
+		},
+		{name: "missing sync timestamp", pr: models.PullRequest{HealthVersion: 1, HeadSHA: &headSHA}},
+		{name: "missing health version", pr: models.PullRequest{GitHubStateSyncedAt: &now, HeadSHA: &headSHA}},
+		{name: "missing head", pr: models.PullRequest{GitHubStateSyncedAt: &now, HealthVersion: 1}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tt.expected, pullRequestHasHealthBaseline(tt.pr), "baseline classification should require a synchronized version for a known head")
+		})
+	}
+}
+
+func TestCheckStateRequiresAuthoritativeSyncForUnknownCheck(t *testing.T) {
+	t.Parallel()
+
+	mock := newMockPool(t)
+	orgID := uuid.New()
+	prID := uuid.New()
+	now := time.Now()
+	headSHA := "head-sha"
+	checkSetComplete := true
+	baselineJSON, err := json.Marshal(models.PullRequestHealthSummary{
+		CheckSetComplete: &checkSetComplete,
+		Checks: []models.PullRequestCheckSummary{{
+			Name:     "Existing Test",
+			Provider: "github-actions",
+		}},
+	})
+	require.NoError(t, err, "unknown-check test should encode its authoritative baseline")
+	mock.ExpectQuery("SELECT .+ FROM pull_request_health_current WHERE org_id").
+		WithArgs(pgx.NamedArgs{"org_id": orgID, "pull_request_id": prID}).
+		WillReturnRows(pgxmock.NewRows(prHealthCurrentTestColumns).AddRow(
+			prID, orgID, int64(1), headSHA, "base-sha", baselineJSON, baselineJSON,
+			models.PullRequestHealthEnrichmentStatusNotRequested, nil, int64(0), now, now,
+		))
+	service := &PRService{
+		pullRequests: db.NewPullRequestStore(mock),
+		logger:       zerolog.Nop(),
+	}
+	pr := models.PullRequest{
+		ID:                  prID,
+		OrgID:               orgID,
+		HeadSHA:             &headSHA,
+		HealthVersion:       1,
+		GitHubStateSyncedAt: &now,
+	}
+	state := models.PullRequestCheckState{
+		HeadSHA:  headSHA,
+		Name:     "New Test",
+		Provider: "github-actions",
+	}
+
+	requiresSync, err := service.checkStateRequiresAuthoritativeSync(context.Background(), pr, state)
+
+	require.NoError(t, err, "unknown-check detection should read a valid baseline")
+	require.True(t, requiresSync, "a check absent from the authoritative baseline should trigger a full synchronization")
+	require.NoError(t, mock.ExpectationsWereMet(), "unknown-check detection should use the org-scoped health baseline query")
+}
+
+// An undecodable baseline must not fail the webhook. Returning an error would
+// 500 the delivery, and every redelivery would decode the same bad row and fail
+// identically — a poison pill for this PR's whole check stream. The
+// authoritative readback is what repairs it, because it rewrites the snapshot.
+func TestCheckStateRequiresAuthoritativeSyncOnUndecodableBaseline(t *testing.T) {
+	t.Parallel()
+
+	mock := newMockPool(t)
+	orgID := uuid.New()
+	prID := uuid.New()
+	now := time.Now()
+	headSHA := "head-sha"
+
+	corrupt := []byte(`{"checks":`)
+	mock.ExpectQuery("SELECT .+ FROM pull_request_health_current WHERE org_id").
+		WithArgs(pgx.NamedArgs{"org_id": orgID, "pull_request_id": prID}).
+		WillReturnRows(pgxmock.NewRows(prHealthCurrentTestColumns).AddRow(
+			prID, orgID, int64(1), headSHA, "base-sha", corrupt, corrupt,
+			models.PullRequestHealthEnrichmentStatusNotRequested, nil, int64(0), now, now,
+		))
+	service := &PRService{
+		pullRequests: db.NewPullRequestStore(mock),
+		logger:       zerolog.Nop(),
+	}
+	pr := models.PullRequest{
+		ID:                  prID,
+		OrgID:               orgID,
+		HeadSHA:             &headSHA,
+		HealthVersion:       1,
+		GitHubStateSyncedAt: &now,
+	}
+	state := models.PullRequestCheckState{HeadSHA: headSHA, Name: "Backend Test", Provider: "github-actions"}
+
+	requiresSync, err := service.checkStateRequiresAuthoritativeSync(context.Background(), pr, state)
+
+	require.NoError(t, err, "an undecodable baseline should not fail the webhook delivery")
+	require.True(t, requiresSync, "an undecodable baseline should escalate to the readback that rewrites it")
+	require.NoError(t, mock.ExpectationsWereMet(), "the baseline lookup should still be org-scoped")
+}
+
+// A check webhook that also needs an authoritative readback must still enqueue
+// the DB-only rebuild: the sync enqueue dedupes against running jobs, so a sync
+// already past its race overlay would absorb the request and finish without
+// ever folding this webhook's row into the health summary.
+func TestEnqueuePullRequestCheckProjectionAlwaysRebuilds(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		requiresSync bool
+		wantJobTypes []string
+	}{
+		{
+			name:         "projection covers the event",
+			requiresSync: false,
+			wantJobTypes: []string{prHealthRebuildJobType},
+		},
+		{
+			name:         "event needs authoritative state",
+			requiresSync: true,
+			wantJobTypes: []string{prHealthRebuildJobType, prHealthSyncJobType},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			mock, err := pgxmock.NewPool()
+			require.NoError(t, err, "should create pgx mock pool")
+			defer mock.Close()
+
+			orgID := uuid.New()
+			prID := uuid.New()
+			pr := models.PullRequest{ID: prID, OrgID: orgID}
+
+			rebuildKey := fmt.Sprintf("%s:%s", prHealthRebuildJobType, prID.String())
+			syncKey := pullRequestStateSyncDedupeKey(prID)
+			for _, jobType := range tt.wantJobTypes {
+				args := pgx.NamedArgs{
+					"org_id":     orgID,
+					"queue":      prHealthSyncQueue,
+					"job_type":   jobType,
+					"payload":    pgxmock.AnyArg(),
+					"priority":   4,
+					"dedupe_key": &rebuildKey,
+					"run_at":     pgxmock.AnyArg(),
+				}
+				if jobType == prHealthSyncJobType {
+					args = pgx.NamedArgs{
+						"org_id":     orgID,
+						"queue":      prHealthSyncQueue,
+						"job_type":   jobType,
+						"payload":    pgxmock.AnyArg(),
+						"priority":   6,
+						"dedupe_key": &syncKey,
+					}
+				}
+				mock.ExpectQuery("INSERT INTO jobs").
+					WithArgs(args).
+					WillReturnRows(pgxmock.NewRows([]string{"id"}).AddRow(uuid.New()))
+			}
+
+			service := &PRService{jobs: db.NewJobStore(mock), logger: zerolog.Nop()}
+			require.NoError(t, service.enqueuePullRequestCheckProjection(context.Background(), pr, tt.requiresSync),
+				"check projection follow-up should succeed")
+
+			require.NoError(t, mock.ExpectationsWereMet(),
+				"a check webhook should enqueue exactly %v", tt.wantJobTypes)
+		})
+	}
 }
 
 func TestHandleStatusEvent_EnqueuesHealthSyncForHeadSHA(t *testing.T) {
@@ -2647,6 +2844,8 @@ func TestHandleStatusEvent_EnqueuesHealthSyncForHeadSHA(t *testing.T) {
 	prRow := handlerPRRow(prID, &sessionID, orgID, "testorg/testrepo", now)
 	headSHA := "head-sha"
 	prRow[12] = &headSHA
+	prRow[19] = &now
+	prRow[20] = int64(1)
 	prMock.ExpectQuery("SELECT .+ FROM pull_requests WHERE org_id = .+ AND github_repo = .+ AND head_sha = .+ AND status = 'open'").
 		WithArgs(pgx.NamedArgs{"org_id": orgID, "github_repo": "testorg/testrepo", "head_sha": "head-sha"}).
 		WillReturnRows(
@@ -2677,6 +2876,21 @@ func TestHandleStatusEvent_EnqueuesHealthSyncForHeadSHA(t *testing.T) {
 		}).
 		WillReturnRows(pgxmock.NewRows([]string{"exists"}).AddRow(true))
 	prMock.ExpectCommit()
+	checkSetComplete := true
+	baselineJSON, err := json.Marshal(models.PullRequestHealthSummary{
+		CheckSetComplete: &checkSetComplete,
+		Checks: []models.PullRequestCheckSummary{{
+			Name:     "ci/circleci: frontend_lint_format_license",
+			Provider: "circleci",
+		}},
+	})
+	require.NoError(t, err, "status test should encode its authoritative baseline")
+	prMock.ExpectQuery("SELECT .+ FROM pull_request_health_current WHERE org_id").
+		WithArgs(pgx.NamedArgs{"org_id": orgID, "pull_request_id": prID}).
+		WillReturnRows(pgxmock.NewRows(prHealthCurrentTestColumns).AddRow(
+			prID, orgID, int64(1), headSHA, "base-sha", baselineJSON, baselineJSON,
+			models.PullRequestHealthEnrichmentStatusNotRequested, nil, int64(0), now, now,
+		))
 	dedupeKey := fmt.Sprintf("%s:%s", prHealthRebuildJobType, prID.String())
 	jobMock.ExpectQuery("INSERT INTO jobs").
 		WithArgs(pgx.NamedArgs{
@@ -2703,7 +2917,7 @@ func TestHandleStatusEvent_EnqueuesHealthSyncForHeadSHA(t *testing.T) {
 	}
 	event.Repository.FullName = "testorg/testrepo"
 
-	err := svc.HandleStatusEvent(context.Background(), event)
+	err = svc.HandleStatusEvent(context.Background(), event)
 	require.NoError(t, err, "HandleStatusEvent should project statuses for matching open PR heads")
 	require.NoError(t, prMock.ExpectationsWereMet(), "all pull request expectations should be met")
 	require.NoError(t, jobMock.ExpectationsWereMet(), "status event should enqueue a DB-only health rebuild")
@@ -3521,15 +3735,24 @@ func TestHandlePullRequestEvent_ReadyForReviewWith143GeneratedPRTriggersAutoPrev
 		logger:             zerolog.Nop(),
 	}
 
-	// 1. getWebhookPullRequest returns the tracked 143 PR.
+	// 1. getWebhookPullRequest returns the tracked 143 PR with a valid health
+	// baseline for the same head.
+	event := autoPreviewPullRequestEvent(orgID)
+	event.Action = "ready_for_review"
+	prRow := handlerPRRow(prID, &sessionID, orgID, "acme/app", now)
+	prRow[12] = &event.PR.Head.SHA
+	prRow[19] = &now
+	prRow[20] = int64(1)
 	prMock.ExpectQuery("SELECT .+ FROM pull_requests WHERE org_id").
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
 		WillReturnRows(
 			pgxmock.NewRows(handlerPRColumns).
-				AddRow(handlerPRRow(prID, &sessionID, orgID, "acme/app", now)...),
+				AddRow(prRow...),
 		)
 
-	// 2. enqueuePullRequestStateSync inserts a job.
+	// 2. enqueuePullRequestStateSync inserts a job. Leaving the draft state
+	// changes GitHub's mergeable_state without moving the head, so the readback
+	// runs even though the baseline is current for this SHA.
 	jobMock.ExpectQuery("INSERT INTO jobs").
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
 		WillReturnRows(pgxmock.NewRows([]string{"id"}).AddRow(uuid.New()))
@@ -3546,16 +3769,87 @@ func TestHandlePullRequestEvent_ReadyForReviewWith143GeneratedPRTriggersAutoPrev
 		WillReturnRows(pgxmock.NewRows(githubRepositoryPreviewPolicyTestCols()).
 			AddRow(uuid.New(), orgID, repoID, string(models.PreviewAutoModeWarm), string(models.PreviewSessionPrewarmModeOff), false, false, true, true, "", userID, now, now))
 
-	event := autoPreviewPullRequestEvent(orgID)
-	event.Action = "ready_for_review"
 	err := svc.HandlePullRequestEvent(context.Background(), event)
 
 	require.NoError(t, err, "HandlePullRequestEvent for ready_for_review on tracked PR should not fail")
 	require.True(t, starter.called, "auto preview starter should be invoked for ready_for_review on tracked 143 PRs")
+	require.NoError(t, jobMock.ExpectationsWereMet(), "ready_for_review should enqueue a readback because leaving draft changes mergeability without moving the head")
 	require.NoError(t, prMock.ExpectationsWereMet(), "all PR expectations should be met")
-	require.NoError(t, jobMock.ExpectationsWereMet(), "all job expectations should be met")
 	require.NoError(t, repoMock.ExpectationsWereMet(), "all repo expectations should be met")
 	require.NoError(t, previewMock.ExpectationsWereMet(), "all preview expectations should be met")
+}
+
+// capturedPayload records the JSON payload a job was enqueued with while still
+// matching like pgxmock.AnyArg(). It keeps only the first payload it is offered
+// so that being evaluated against several expectations cannot overwrite the one
+// the test asserts on.
+type capturedPayload struct{ raw []byte }
+
+func (c *capturedPayload) Match(v any) bool {
+	if raw, ok := v.([]byte); ok && c.raw == nil {
+		c.raw = append([]byte(nil), raw...)
+	}
+	return true
+}
+
+// Leaving the draft state is the one trigger that changes GitHub's
+// mergeable_state without moving the head SHA, and projected rebuilds never
+// recompute merge state. Skipping the readback would strand a PR that 143
+// opened as a draft at MergeState=blocked, hence CanMerge=false.
+func TestHandlePullRequestEvent_ReadyForReviewSyncsCurrentBaseline(t *testing.T) {
+	t.Parallel()
+
+	orgID := uuid.New()
+	prID := uuid.New()
+	sessionID := uuid.New()
+	now := time.Now()
+
+	prMock := newMockPool(t)
+	jobMock := newMockPool(t)
+	svc := &PRService{
+		pullRequests: db.NewPullRequestStore(prMock),
+		jobs:         db.NewJobStore(jobMock),
+		logger:       zerolog.Nop(),
+	}
+
+	event := PullRequestEvent{Action: "ready_for_review", Number: 42}
+	event.PR.Head.SHA = "head-sha"
+	event.Repository.FullName = "testorg/testrepo"
+
+	// A fully synchronized baseline for this exact head: the old gate skipped
+	// the readback here.
+	headSHA := event.PR.Head.SHA
+	prRow := handlerPRRow(prID, &sessionID, orgID, "testorg/testrepo", now)
+	prRow[12] = &headSHA
+	prRow[19] = &now
+	prRow[20] = int64(1)
+	prMock.ExpectQuery("SELECT .+ FROM pull_requests WHERE github_repo").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(pgxmock.NewRows(handlerPRColumns).AddRow(prRow...))
+
+	payload := &capturedPayload{}
+	dedupeKey := pullRequestStateSyncDedupeKey(prID)
+	jobMock.ExpectQuery("INSERT INTO jobs").
+		WithArgs(pgx.NamedArgs{
+			"org_id":     orgID,
+			"queue":      prHealthSyncQueue,
+			"job_type":   prHealthSyncJobType,
+			"payload":    payload,
+			"priority":   6,
+			"dedupe_key": &dedupeKey,
+		}).
+		WillReturnRows(pgxmock.NewRows([]string{"id"}).AddRow(uuid.New()))
+
+	require.NoError(t, svc.HandlePullRequestEvent(context.Background(), event),
+		"ready_for_review should be handled without error")
+	require.NoError(t, jobMock.ExpectationsWereMet(),
+		"ready_for_review should enqueue a readback even when the baseline already matches the head")
+
+	var enqueued map[string]string
+	require.NoError(t, json.Unmarshal(payload.raw, &enqueued), "enqueued payload should be valid JSON")
+	require.Equal(t, string(PullRequestSyncReasonReadyForReview), enqueued["sync_reason"],
+		"the draft transition should be attributable in GitHub request telemetry")
+	require.NoError(t, prMock.ExpectationsWereMet(), "all PR store expectations should be met")
 }
 
 // TestHandlePullRequestEvent_ClosedWith143GeneratedPRTeardownAutoPreview confirms

--- a/internal/services/github/pr_health_service.go
+++ b/internal/services/github/pr_health_service.go
@@ -25,7 +25,26 @@ import (
 )
 
 const (
-	prHealthStaleAfter       = 2 * time.Minute
+	// prHealthStaleAfter bounds how far behind GitHub the background reconciler
+	// is allowed to let an open PR drift. It is deliberately loose because that
+	// sweep touches every open PR in the org and is the dominant consumer of the
+	// REST budget.
+	prHealthStaleAfter = 10 * time.Minute
+	// prHealthReadStaleAfter is the tighter budget for interactive reads only —
+	// GetPullRequestHealth serving the HTTP endpoint. Projected check rebuilds
+	// never recompute summary.MergeState (see rebuildProjectedHealthSummary), so
+	// an authoritative readback is the only thing that flips a PR from
+	// behind/blocked to clean once CI goes green; at prHealthStaleAfter the
+	// merge button would stay disabled for ten minutes after the last check
+	// passed.
+	//
+	// Background callers must NOT inherit this budget. getPullRequestHealth is
+	// also reached from the auto-repair coordinator, which both the
+	// sync_pull_request_state and rebuild_pull_request_health job handlers
+	// invoke — letting that path refresh every two minutes would re-request the
+	// readback that checkStateRequiresAuthoritativeSync just avoided. They pass
+	// healthBuildOptions.asyncRefreshAfter instead.
+	prHealthReadStaleAfter   = 2 * time.Minute
 	prHealthSyncQueue        = "default"
 	prHealthSyncJobType      = "sync_pull_request_state"
 	prHealthRebuildJobType   = "rebuild_pull_request_health"
@@ -37,7 +56,78 @@ const (
 	maxRebuildEnqueueHops    = 8
 	requiredChecksCacheTTL   = 24 * time.Hour
 	noRequiredChecksCacheTTL = 6 * time.Hour
+	prHealthSyncTimeout      = 2 * time.Minute
 )
+
+type PullRequestSyncReason string
+
+const (
+	PullRequestSyncReasonInitial          PullRequestSyncReason = "initial"
+	PullRequestSyncReasonHeadChanged      PullRequestSyncReason = "head_changed"
+	PullRequestSyncReasonBaseChanged      PullRequestSyncReason = "base_changed"
+	PullRequestSyncReasonReadyForReview   PullRequestSyncReason = "ready_for_review"
+	PullRequestSyncReasonIncomplete       PullRequestSyncReason = "incomplete_check_set"
+	PullRequestSyncReasonStaleReconcile   PullRequestSyncReason = "stale_reconcile"
+	PullRequestSyncReasonMergeSafety      PullRequestSyncReason = "merge_safety"
+	PullRequestSyncReasonCodeReview       PullRequestSyncReason = "code_review"
+	PullRequestSyncReasonRepair           PullRequestSyncReason = "repair"
+	PullRequestSyncReasonManual           PullRequestSyncReason = "manual"
+	PullRequestSyncReasonMergeabilityWait PullRequestSyncReason = "mergeability_wait"
+)
+
+func (r PullRequestSyncReason) Validate() error {
+	switch r {
+	case PullRequestSyncReasonInitial,
+		PullRequestSyncReasonHeadChanged,
+		PullRequestSyncReasonBaseChanged,
+		PullRequestSyncReasonReadyForReview,
+		PullRequestSyncReasonIncomplete,
+		PullRequestSyncReasonStaleReconcile,
+		PullRequestSyncReasonMergeSafety,
+		PullRequestSyncReasonCodeReview,
+		PullRequestSyncReasonRepair,
+		PullRequestSyncReasonManual,
+		PullRequestSyncReasonMergeabilityWait:
+		return nil
+	default:
+		return fmt.Errorf("invalid pull request sync reason %q", r)
+	}
+}
+
+// coalesces reports whether a sync requested for this reason may be satisfied
+// by an already-running sync for the same PR. Merge safety is the one caller
+// that must not: mergePullRequest documents that its CanMerge gate is only
+// meaningful against GitHub data fetched after the merge was requested, and
+// joining an in-flight sync would hand it a snapshot taken beforehand.
+func (r PullRequestSyncReason) coalesces() bool {
+	return r != PullRequestSyncReasonMergeSafety
+}
+
+type pullRequestSyncReasonContextKey struct{}
+
+func WithPullRequestSyncReason(ctx context.Context, reason PullRequestSyncReason) context.Context {
+	return context.WithValue(ctx, pullRequestSyncReasonContextKey{}, reason)
+}
+
+func PullRequestSyncReasonFromContext(ctx context.Context) PullRequestSyncReason {
+	reason, ok := pullRequestSyncReasonAttribute(ctx)
+	if !ok {
+		return PullRequestSyncReasonManual
+	}
+	return reason
+}
+
+// pullRequestSyncReasonAttribute is the raw lookup behind
+// PullRequestSyncReasonFromContext. It keeps "no reason attached" distinct from
+// "manual" so GitHub request telemetry can leave requests made outside a sync
+// flow unlabeled instead of mislabeling them as operator-initiated.
+func pullRequestSyncReasonAttribute(ctx context.Context) (PullRequestSyncReason, bool) {
+	reason, ok := ctx.Value(pullRequestSyncReasonContextKey{}).(PullRequestSyncReason)
+	if !ok || reason.Validate() != nil {
+		return "", false
+	}
+	return reason, true
+}
 
 var (
 	ErrPullRequestMergeabilityPending    = errors.New("pull request mergeability is still being checked by GitHub")
@@ -143,6 +233,21 @@ type healthBuildOptions struct {
 	// automatic repair coordinator — which resolves its own policy and rechecks
 	// the attempt budget directly — skips it on its webhook-driven path.
 	skipAutoRepairAttemptState bool
+
+	// asyncRefreshAfter overrides how stale the persisted GitHub snapshot may be
+	// before this read enqueues a background readback. Zero means
+	// prHealthReadStaleAfter, the tight budget appropriate for a human waiting
+	// on the merge button. Background callers pass prHealthStaleAfter so they
+	// track the reconcile sweep instead of re-arming the readback that the
+	// check-webhook heuristic just avoided.
+	asyncRefreshAfter time.Duration
+}
+
+func (o healthBuildOptions) staleAfter() time.Duration {
+	if o.asyncRefreshAfter > 0 {
+		return o.asyncRefreshAfter
+	}
+	return prHealthReadStaleAfter
 }
 
 func (s *PRService) GetPullRequestHealth(ctx context.Context, orgID, pullRequestID uuid.UUID) (*models.PullRequestHealthResponse, error) {
@@ -156,7 +261,7 @@ func (s *PRService) getPullRequestHealth(ctx context.Context, orgID, pullRequest
 	}
 
 	needsInlineSync := (pr.GitHubStateSyncedAt == nil || pr.HealthVersion == 0) && pr.Status == models.PullRequestStatusOpen
-	needsAsyncRefresh := pr.Status == models.PullRequestStatusOpen && pr.GitHubStateSyncedAt != nil && time.Since(*pr.GitHubStateSyncedAt) > prHealthStaleAfter
+	needsAsyncRefresh := pr.Status == models.PullRequestStatusOpen && pr.GitHubStateSyncedAt != nil && time.Since(*pr.GitHubStateSyncedAt) > opts.staleAfter()
 	var linkedRepo *models.Repository
 	if pr.Status == models.PullRequestStatusOpen && s.repos != nil {
 		repo, repoErr := s.repos.GetByFullNameAnyStatus(ctx, orgID, pr.GitHubRepo)
@@ -177,9 +282,10 @@ func (s *PRService) getPullRequestHealth(ctx context.Context, orgID, pullRequest
 	}
 
 	if needsInlineSync {
-		if err := s.SyncPullRequestState(ctx, orgID, pullRequestID); err != nil {
+		syncCtx := WithPullRequestSyncReason(ctx, PullRequestSyncReasonInitial)
+		if err := s.SyncPullRequestState(syncCtx, orgID, pullRequestID); err != nil {
 			if errors.Is(err, ErrPullRequestMergeabilityPending) {
-				s.enqueuePullRequestStateSync(ctx, pr)
+				s.enqueuePullRequestStateSync(ctx, pr, PullRequestSyncReasonMergeabilityWait)
 			} else if errors.Is(err, ErrPullRequestRepositoryDisconnected) {
 				resp, buildErr := s.buildPullRequestHealthResponse(ctx, pr, opts)
 				if buildErr != nil {
@@ -199,7 +305,7 @@ func (s *PRService) getPullRequestHealth(ctx context.Context, orgID, pullRequest
 			return nil, err
 		}
 	} else if needsAsyncRefresh {
-		s.enqueuePullRequestStateSync(ctx, pr)
+		s.enqueuePullRequestStateSync(ctx, pr, PullRequestSyncReasonStaleReconcile)
 	}
 
 	resp, err := s.buildPullRequestHealthResponse(ctx, pr, opts)
@@ -506,6 +612,49 @@ func checkSummariesHaveFailedCheck(checks []models.PullRequestCheckSummary) bool
 }
 
 func (s *PRService) SyncPullRequestState(ctx context.Context, orgID, pullRequestID uuid.UUID) error {
+	reason := PullRequestSyncReasonFromContext(ctx)
+	if !reason.coalesces() {
+		s.logger.Info().
+			Str("org_id", orgID.String()).
+			Str("pull_request_id", pullRequestID.String()).
+			Str("sync_reason", string(reason)).
+			Msg("starting uncoalesced github pull request health sync")
+		// Deliberately the caller's context, not a prHealthSyncTimeout copy: a
+		// merge gate has exactly one waiter, so there is nobody to protect from
+		// its deadline and the merge request's own timeout should govern. The
+		// coalesced branch below needs its own budget only because it detaches
+		// from whichever caller happened to lead the flight. Runtime is bounded
+		// regardless by the GitHub client's per-request timeout plus the
+		// mergeability backoff ladder.
+		return s.syncPullRequestState(ctx, orgID, pullRequestID)
+	}
+	key := orgID.String() + ":" + pullRequestID.String()
+	result := s.prHealthSyncGroup.DoChan(key, func() (any, error) {
+		s.logger.Info().
+			Str("org_id", orgID.String()).
+			Str("pull_request_id", pullRequestID.String()).
+			Str("sync_reason", string(reason)).
+			Msg("starting github pull request health sync")
+		syncCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), prHealthSyncTimeout)
+		defer cancel()
+		return nil, s.syncPullRequestState(syncCtx, orgID, pullRequestID)
+	})
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case completed := <-result:
+		if completed.Shared {
+			s.logger.Debug().
+				Str("org_id", orgID.String()).
+				Str("pull_request_id", pullRequestID.String()).
+				Str("requested_sync_reason", string(reason)).
+				Msg("shared in-flight github pull request health sync")
+		}
+		return completed.Err
+	}
+}
+
+func (s *PRService) syncPullRequestState(ctx context.Context, orgID, pullRequestID uuid.UUID) error {
 	pr, err := s.pullRequests.GetByID(ctx, orgID, pullRequestID)
 	if err != nil {
 		return err
@@ -873,7 +1022,8 @@ func (s *PRService) ReconcilePullRequestState(ctx context.Context, orgID uuid.UU
 		return err
 	}
 	for _, pr := range stale {
-		if err := s.SyncPullRequestState(ctx, orgID, pr.ID); err != nil {
+		syncCtx := WithPullRequestSyncReason(ctx, PullRequestSyncReasonStaleReconcile)
+		if err := s.SyncPullRequestState(syncCtx, orgID, pr.ID); err != nil {
 			if errors.Is(err, ErrPullRequestMergeabilityPending) {
 				s.logger.Debug().Str("pull_request_id", pr.ID.String()).Msg("pull request mergeability is still pending during reconciliation")
 				continue
@@ -1929,24 +2079,73 @@ func (s *PRService) fetchCheckRunAnnotations(ctx context.Context, token, owner, 
 	return lines, nil
 }
 
-func (s *PRService) enqueuePullRequestStateSync(ctx context.Context, pr models.PullRequest) {
+// enqueuePullRequestStateSync queues an authoritative GitHub readback. The
+// reason is a required argument rather than an option so that a new trigger
+// cannot silently land in telemetry as "manual".
+//
+// The dedupe key intentionally excludes the reason: a PR only ever needs one
+// pending readback, whatever prompted it. The consequence is that the queued
+// job's payload — and therefore the github_sync_reason dimension on the API
+// calls it makes — keeps whichever reason arrived first. The log event below is
+// emitted for every request, including absorbed ones, so trigger frequency
+// stays measurable even though the per-request attribution is skewed.
+func (s *PRService) enqueuePullRequestStateSync(ctx context.Context, pr models.PullRequest, reason PullRequestSyncReason) {
 	if s.jobs == nil {
 		return
 	}
+	if reason.Validate() != nil {
+		reason = PullRequestSyncReasonManual
+	}
 	dedupeKey := pullRequestStateSyncDedupeKey(pr.ID)
-	_, err := s.jobs.EnqueueWithOpts(ctx, pr.OrgID, db.EnqueueOpts{
+	jobID, err := s.jobs.EnqueueWithOpts(ctx, pr.OrgID, db.EnqueueOpts{
 		Queue:   prHealthSyncQueue,
 		JobType: prHealthSyncJobType,
 		Payload: map[string]string{
 			"org_id":          pr.OrgID.String(),
 			"pull_request_id": pr.ID.String(),
+			"sync_reason":     string(reason),
 		},
 		Priority:  6,
 		DedupeKey: &dedupeKey,
 	})
 	if err != nil {
-		s.logger.Warn().Err(err).Str("pull_request_id", pr.ID.String()).Msg("failed to enqueue pull request health sync")
+		s.logger.Warn().
+			Err(err).
+			Str("pull_request_id", pr.ID.String()).
+			Str("sync_reason", string(reason)).
+			Msg("failed to enqueue pull request health sync")
+		return
 	}
+	event := s.logger.Info().
+		Str("org_id", pr.OrgID.String()).
+		Str("pull_request_id", pr.ID.String()).
+		Str("sync_reason", string(reason)).
+		Bool("deduplicated", jobID == uuid.Nil)
+	if jobID != uuid.Nil {
+		event = event.Str("job_id", jobID.String())
+	}
+	event.Msg("github pull request health sync requested")
+}
+
+// enqueuePullRequestCheckProjection schedules the follow-up work for a check
+// webhook that changed the projection.
+//
+// The DB-only rebuild is enqueued unconditionally, including when an
+// authoritative readback is also needed. It is the only thing guaranteed to
+// fold this row into the health summary: enqueuePullRequestStateSync dedupes
+// against pending *and running* jobs, so a sync that is already past its
+// HasCheckStatesAfter race overlay will absorb the request and finish without
+// ever seeing this write. Returning the rebuild's error also keeps an enqueue
+// failure visible to GitHub as a webhook retry, which the fire-and-forget sync
+// enqueue cannot do.
+func (s *PRService) enqueuePullRequestCheckProjection(ctx context.Context, pr models.PullRequest, requiresSync bool) error {
+	if err := s.enqueuePullRequestHealthRebuild(ctx, pr); err != nil {
+		return err
+	}
+	if requiresSync {
+		s.enqueuePullRequestStateSync(ctx, pr, PullRequestSyncReasonIncomplete)
+	}
+	return nil
 }
 
 func (s *PRService) enqueuePullRequestHealthRebuild(ctx context.Context, pr models.PullRequest) error {
@@ -2035,6 +2234,29 @@ func (s *PRService) enqueueMergeWhenReadyProcessing(ctx context.Context, pr mode
 
 func isMergeWhenReadyProcessable(pr models.PullRequest, now time.Time) bool {
 	return pr.MergeWhenReadyState == models.PullRequestMergeWhenReadyStateQueued || isStaleMergeWhenReadyMerging(pr, now)
+}
+
+// publishPullRequestTerminalState nudges SSE subscribers after a PR reaches
+// merged/closed. Neither terminal path spends a GitHub readback any more — a
+// dead PR has no live health to track — but the sync path used to be the only
+// publisher, so without this a client watching a PR that was merged on
+// github.com would sit on an open-looking snapshot until it refreshed.
+// Subscribers re-read health on the event, and the status column is already
+// updated by the time we get here.
+func (s *PRService) publishPullRequestTerminalState(ctx context.Context, pr models.PullRequest) {
+	if s.prHealthStreams == nil || s.pullRequests == nil {
+		return
+	}
+	current, err := s.pullRequests.GetHealthCurrent(ctx, pr.OrgID, pr.ID)
+	if err != nil {
+		// No snapshot means nothing was ever streamed for this PR, so there is
+		// no stale view to correct.
+		if !errors.Is(err, pgx.ErrNoRows) {
+			s.logger.Warn().Err(err).Str("pull_request_id", pr.ID.String()).Msg("failed to load pull request health while announcing terminal state")
+		}
+		return
+	}
+	s.publishPullRequestUpdated(ctx, pr, current)
 }
 
 func (s *PRService) publishPullRequestUpdated(ctx context.Context, pr models.PullRequest, current models.PullRequestHealthCurrent) {

--- a/internal/services/github/pr_health_service_test.go
+++ b/internal/services/github/pr_health_service_test.go
@@ -1,6 +1,7 @@
 package github
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -9,6 +10,9 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strconv"
+	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -885,7 +889,7 @@ func TestPRServiceGetPullRequestHealthEnqueuesSyncAndEnrichment(t *testing.T) {
 	orgID := uuid.New()
 	pullRequestID := uuid.New()
 	now := time.Now().UTC()
-	stale := now.Add(-5 * time.Minute)
+	stale := now.Add(-15 * time.Minute)
 	summary := models.PullRequestHealthSummary{
 		MergeState:       models.PullRequestMergeStateClean,
 		HasConflicts:     false,
@@ -940,6 +944,88 @@ func TestPRServiceGetPullRequestHealthEnqueuesSyncAndEnrichment(t *testing.T) {
 	require.True(t, resp.CanFixTests, "GetPullRequestHealth should advertise test repair when tests are failing")
 	require.True(t, resp.EnrichmentRequested, "GetPullRequestHealth should mark enrichment as requested after enqueueing it")
 	require.NoError(t, mock.ExpectationsWereMet(), "all stale health expectations should be met")
+}
+
+// getPullRequestHealth is reached from the auto-repair coordinator, which the
+// sync_pull_request_state and rebuild_pull_request_health job handlers invoke.
+// If that background path inherited the interactive staleness budget, every
+// projected rebuild would re-request the authoritative readback that
+// checkStateRequiresAuthoritativeSync just avoided.
+func TestPRServiceGetPullRequestHealthStalenessBudgetIsPerCaller(t *testing.T) {
+	t.Parallel()
+
+	summaryJSON, err := json.Marshal(models.PullRequestHealthSummary{MergeState: models.PullRequestMergeStateClean})
+	require.NoError(t, err, "should marshal health summary")
+
+	tests := []struct {
+		name        string
+		opts        healthBuildOptions
+		wantEnqueue bool
+	}{
+		{
+			name:        "interactive read refreshes past the tight budget",
+			opts:        healthBuildOptions{},
+			wantEnqueue: true,
+		},
+		{
+			name:        "background caller tracks the reconcile budget",
+			opts:        healthBuildOptions{asyncRefreshAfter: prHealthStaleAfter},
+			wantEnqueue: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			mock, err := pgxmock.NewPool()
+			require.NoError(t, err, "should create pgx mock pool")
+			defer mock.Close()
+
+			orgID := uuid.New()
+			pullRequestID := uuid.New()
+			now := time.Now().UTC()
+			// Between the two budgets: stale for a human, fresh for the sweep.
+			syncedAt := now.Add(-5 * time.Minute)
+
+			mock.ExpectQuery("SELECT .+ FROM pull_requests WHERE id").
+				WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+				WillReturnRows(pgxmock.NewRows(prTestPullRequestColumns).AddRow(
+					pullRequestID, nil, orgID, 42, "https://github.com/assembledhq/143/pull/42", "assembledhq/143",
+					"Fix bug", (*string)(nil), "open", "pending", "app", "", nil, nil, nil,
+					models.PullRequestMergeStateUnknown, false, 0, false, &syncedAt, int64(2), models.PullRequestMergeWhenReadyStateOff, (*uuid.UUID)(nil), (*time.Time)(nil), "", (*int64)(nil), "", (*time.Time)(nil), (*time.Time)(nil), now, now,
+				))
+			if tt.wantEnqueue {
+				mock.ExpectQuery("INSERT INTO jobs").
+					WithArgs(pgx.NamedArgs{
+						"org_id":     orgID,
+						"queue":      prHealthSyncQueue,
+						"job_type":   prHealthSyncJobType,
+						"payload":    pgxmock.AnyArg(),
+						"priority":   6,
+						"dedupe_key": pgxmock.AnyArg(),
+					}).
+					WillReturnRows(pgxmock.NewRows([]string{"id"}).AddRow(uuid.New()))
+			}
+			mock.ExpectQuery("SELECT .+ FROM pull_request_health_current WHERE org_id = .+ AND pull_request_id = .+").
+				WithArgs(pgx.NamedArgs{"org_id": orgID, "pull_request_id": pullRequestID}).
+				WillReturnRows(pgxmock.NewRows(prHealthCurrentTestColumns).AddRow(
+					pullRequestID, orgID, int64(3), "head", "base", summaryJSON, summaryJSON,
+					models.PullRequestHealthEnrichmentStatusReady, &now, int64(0), now, now,
+				))
+
+			service := &PRService{
+				pullRequests: db.NewPullRequestStore(mock),
+				jobs:         db.NewJobStore(mock),
+				logger:       zerolog.New(io.Discard),
+			}
+
+			_, err = service.getPullRequestHealth(context.Background(), orgID, pullRequestID, tt.opts)
+			require.NoError(t, err, "health build should succeed")
+			require.NoError(t, mock.ExpectationsWereMet(),
+				"a five-minute-old snapshot should enqueue a readback only for the interactive budget")
+		})
+	}
 }
 
 func TestPRServicePopulateAutoRepairAttemptStateUsesPersonalOverride(t *testing.T) {
@@ -1073,6 +1159,113 @@ func TestPullRequestStateSyncDedupeKey(t *testing.T) {
 		pullRequestStateSyncDedupeKey(prID),
 		"all sync triggers for one pull request should share a dedupe key",
 	)
+}
+
+func TestEnqueuePullRequestStateSyncRecordsEveryDeduplicatedReason(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "should create pgx mock pool")
+	defer mock.Close()
+
+	orgID := uuid.New()
+	prID := uuid.New()
+	dedupeKey := pullRequestStateSyncDedupeKey(prID)
+	for index := range 2 {
+		rows := pgxmock.NewRows([]string{"id"})
+		if index == 0 {
+			rows.AddRow(uuid.New())
+		}
+		mock.ExpectQuery("INSERT INTO jobs").
+			WithArgs(pgx.NamedArgs{
+				"org_id":     orgID,
+				"queue":      prHealthSyncQueue,
+				"job_type":   prHealthSyncJobType,
+				"payload":    pgxmock.AnyArg(),
+				"priority":   6,
+				"dedupe_key": &dedupeKey,
+			}).
+			WillReturnRows(rows)
+	}
+
+	var logs bytes.Buffer
+	service := &PRService{
+		jobs:   db.NewJobStore(mock),
+		logger: zerolog.New(&logs),
+	}
+	pr := models.PullRequest{ID: prID, OrgID: orgID}
+
+	service.enqueuePullRequestStateSync(context.Background(), pr, PullRequestSyncReasonStaleReconcile)
+	service.enqueuePullRequestStateSync(context.Background(), pr, PullRequestSyncReasonHeadChanged)
+
+	lines := strings.Split(strings.TrimSpace(logs.String()), "\n")
+	require.Len(t, lines, 2, "each synchronization trigger should emit its own request event")
+	var first, second map[string]any
+	require.NoError(t, json.Unmarshal([]byte(lines[0]), &first), "first synchronization request log should be valid JSON")
+	require.NoError(t, json.Unmarshal([]byte(lines[1]), &second), "deduplicated synchronization request log should be valid JSON")
+	require.Equal(t, string(PullRequestSyncReasonStaleReconcile), first["sync_reason"], "first event should preserve the initiating reason")
+	require.Equal(t, false, first["deduplicated"], "first event should identify the newly queued job")
+	require.Equal(t, string(PullRequestSyncReasonHeadChanged), second["sync_reason"], "deduplicated event should preserve the later trigger reason")
+	require.Equal(t, true, second["deduplicated"], "second event should identify that the active job absorbed it")
+	require.NoError(t, mock.ExpectationsWereMet(), "both synchronization triggers should exercise durable queue deduplication")
+}
+
+func TestPullRequestSyncReasonValidate(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		reason    PullRequestSyncReason
+		expectErr bool
+	}{
+		{name: "initial", reason: PullRequestSyncReasonInitial},
+		{name: "head changed", reason: PullRequestSyncReasonHeadChanged},
+		{name: "base changed", reason: PullRequestSyncReasonBaseChanged},
+		{name: "ready for review", reason: PullRequestSyncReasonReadyForReview},
+		{name: "incomplete check set", reason: PullRequestSyncReasonIncomplete},
+		{name: "stale reconcile", reason: PullRequestSyncReasonStaleReconcile},
+		{name: "merge safety", reason: PullRequestSyncReasonMergeSafety},
+		{name: "code review", reason: PullRequestSyncReasonCodeReview},
+		{name: "repair", reason: PullRequestSyncReasonRepair},
+		{name: "manual", reason: PullRequestSyncReasonManual},
+		{name: "mergeability wait", reason: PullRequestSyncReasonMergeabilityWait},
+		{name: "unknown", reason: PullRequestSyncReason("unknown"), expectErr: true},
+		{name: "empty", reason: "", expectErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			err := tt.reason.Validate()
+			if tt.expectErr {
+				require.Error(t, err, "unknown sync reasons should fail validation")
+				return
+			}
+			require.NoError(t, err, "known sync reasons should pass validation")
+		})
+	}
+}
+
+// Every trigger except merge safety may ride along on a sync that is already
+// running. Merge safety has its own dedicated test below.
+func TestPullRequestSyncReasonCoalesces(t *testing.T) {
+	t.Parallel()
+
+	require.False(t, PullRequestSyncReasonMergeSafety.coalesces(), "merge safety must observe GitHub state fetched after its own request began")
+	for _, reason := range []PullRequestSyncReason{
+		PullRequestSyncReasonInitial,
+		PullRequestSyncReasonHeadChanged,
+		PullRequestSyncReasonBaseChanged,
+		PullRequestSyncReasonReadyForReview,
+		PullRequestSyncReasonIncomplete,
+		PullRequestSyncReasonStaleReconcile,
+		PullRequestSyncReasonCodeReview,
+		PullRequestSyncReasonRepair,
+		PullRequestSyncReasonManual,
+		PullRequestSyncReasonMergeabilityWait,
+	} {
+		require.True(t, reason.coalesces(), "%s should share an in-flight sync rather than spend a second GitHub round trip", reason)
+	}
 }
 
 func TestEnqueuePullRequestHealthRebuildChainsAfterRunningJob(t *testing.T) {
@@ -1718,6 +1911,162 @@ func TestPRServiceSyncPullRequestStateSelfHealsMergedDrift(t *testing.T) {
 	require.NoError(t, mock.ExpectationsWereMet(), "self-heal should issue UpdateStatus(merged) and skip the health snapshot path")
 }
 
+// driftSyncGate lets a test hold a SyncPullRequestState inside its GitHub call
+// so the sync is observably in flight, and counts the round trips it made.
+type driftSyncGate struct {
+	fetches     atomic.Int32
+	started     chan struct{}
+	release     chan struct{}
+	startedOnce sync.Once
+	releaseOnce sync.Once
+}
+
+// awaitInFlight returns once the sync has entered its GitHub request.
+func (g *driftSyncGate) awaitInFlight() { <-g.started }
+
+func (g *driftSyncGate) releaseNow() { g.releaseOnce.Do(func() { close(g.release) }) }
+
+// newDriftSyncService builds the smallest service that can complete a
+// SyncPullRequestState: GitHub reports the PR closed, so the sync self-heals
+// the status and returns without touching the check-run or snapshot paths. The
+// returned gate holds that single GitHub call open until the test releases it.
+func newDriftSyncService(t *testing.T, orgID, pullRequestID uuid.UUID) (*PRService, *driftSyncGate) {
+	t.Helper()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "should create pgx mock pool")
+	t.Cleanup(mock.Close)
+
+	repoID := uuid.New()
+	integrationID := uuid.New()
+	now := time.Now().UTC()
+
+	gate := &driftSyncGate{started: make(chan struct{}), release: make(chan struct{})}
+	t.Cleanup(gate.releaseNow)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/repos/assembledhq/143/pulls/42":
+			gate.fetches.Add(1)
+			gate.startedOnce.Do(func() { close(gate.started) })
+			<-gate.release
+			_, _ = w.Write([]byte(`{"number":42,"html_url":"https://github.com/assembledhq/143/pull/42","state":"closed","merged":false,"mergeable":false,"mergeable_state":"dirty","head":{"ref":"feature","sha":"head-sync"},"base":{"ref":"main","sha":"base-sync"}}`))
+		default:
+			t.Errorf("drift sync should not call %s", r.URL.Path)
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	mock.ExpectQuery("SELECT .+ FROM pull_requests WHERE id").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(pgxmock.NewRows(prTestPullRequestColumns).AddRow(
+			pullRequestID, (*uuid.UUID)(nil), orgID, 42, "https://github.com/assembledhq/143/pull/42", "assembledhq/143",
+			"Fix bug", (*string)(nil), "open", "pending", "app", "", nil, nil, nil,
+			models.PullRequestMergeStateUnknown, false, 0, false, (*time.Time)(nil), int64(0), models.PullRequestMergeWhenReadyStateOff, (*uuid.UUID)(nil), (*time.Time)(nil), "", (*int64)(nil), "", (*time.Time)(nil), (*time.Time)(nil), now, now,
+		))
+	mock.ExpectQuery("SELECT .+ FROM repositories WHERE org_id = .+ AND full_name = .+ AND status = 'active'").
+		WithArgs(pgx.NamedArgs{"org_id": orgID, "full_name": "assembledhq/143"}).
+		WillReturnRows(pgxmock.NewRows(prTestRepoColumns).AddRow(
+			repoID, orgID, integrationID, int64(1), "assembledhq/143", "main", false, nil, nil, "https://github.com/assembledhq/143.git", int64(123), "active", nil, nil, []byte(`{}`), now, now,
+		))
+	expectReserveCheckStateVersion(mock, orgID, pullRequestID, 0)
+	mock.ExpectExec("UPDATE pull_requests SET status").
+		WithArgs(pgx.NamedArgs{"id": pullRequestID, "org_id": orgID, "status": models.PullRequestStatusClosed}).
+		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
+
+	service := &PRService{
+		tokenProvider: &Service{cache: map[int64]*cachedToken{}},
+		pullRequests:  db.NewPullRequestStore(mock),
+		repos:         db.NewRepositoryStore(mock),
+		logger:        zerolog.New(io.Discard),
+		baseURL:       server.URL,
+		httpClient:    server.Client(),
+		// No backoff ladder: mergeability retries would inflate the round-trip
+		// count these tests assert on.
+		mergeabilityRetryDelays: []time.Duration{},
+	}
+	service.tokenProvider.cache[123] = &cachedToken{Token: "install-token", ExpiresAt: time.Now().Add(time.Hour)}
+	return service, gate
+}
+
+// A coalescing reason occupies the shared group key, so a concurrent caller
+// rides along instead of spending its own GitHub round trip.
+//
+// singleflight.DoChan registers the caller before it returns the channel, so
+// the follower's membership is settled the moment the call returns — there is
+// no window to sleep through.
+func TestPRServiceSyncPullRequestStateCoalescesConcurrentRequests(t *testing.T) {
+	t.Parallel()
+
+	orgID := uuid.New()
+	pullRequestID := uuid.New()
+	service, gate := newDriftSyncService(t, orgID, pullRequestID)
+
+	leaderErr := make(chan error, 1)
+	go func() {
+		leaderErr <- service.SyncPullRequestState(
+			WithPullRequestSyncReason(context.Background(), PullRequestSyncReasonStaleReconcile),
+			orgID, pullRequestID,
+		)
+	}()
+	gate.awaitInFlight()
+
+	var followerRan atomic.Bool
+	follower := service.prHealthSyncGroup.DoChan(orgID.String()+":"+pullRequestID.String(), func() (any, error) {
+		followerRan.Store(true)
+		return nil, nil
+	})
+	gate.releaseNow()
+
+	result := <-follower
+	require.NoError(t, <-leaderErr, "the leading sync should complete")
+	require.True(t, result.Shared, "a coalescing sync should hold the shared group key so concurrent callers join it")
+	require.False(t, followerRan.Load(), "the joining caller should not start a second flight")
+	require.Equal(t, int32(1), gate.fetches.Load(), "coalesced callers should share one GitHub round trip")
+}
+
+// mergePullRequest documents that its CanMerge gate is only meaningful against
+// GitHub data fetched after the merge was requested, so a merge-safety sync
+// must not occupy the coalescing group: a later caller has to be free to fetch
+// for itself, and the merge itself must never inherit an earlier snapshot.
+func TestPRServiceSyncPullRequestStateBypassesCoalescingForMergeSafety(t *testing.T) {
+	t.Parallel()
+
+	orgID := uuid.New()
+	pullRequestID := uuid.New()
+	service, gate := newDriftSyncService(t, orgID, pullRequestID)
+
+	leaderErr := make(chan error, 1)
+	go func() {
+		leaderErr <- service.SyncPullRequestState(
+			WithPullRequestSyncReason(context.Background(), PullRequestSyncReasonMergeSafety),
+			orgID, pullRequestID,
+		)
+	}()
+	gate.awaitInFlight()
+
+	var followerRan atomic.Bool
+	follower := service.prHealthSyncGroup.DoChan(orgID.String()+":"+pullRequestID.String(), func() (any, error) {
+		followerRan.Store(true)
+		return nil, nil
+	})
+
+	// The merge-safety sync is still mid-flight. Because it never registered on
+	// the group, this call runs its own function immediately rather than
+	// blocking on it. The timeout only bounds the failure path.
+	select {
+	case result := <-follower:
+		require.False(t, result.Shared, "a merge-safety sync must not hold the shared group key")
+		require.True(t, followerRan.Load(), "a concurrent caller should be free to start its own flight")
+	case <-time.After(5 * time.Second):
+		t.Fatal("merge-safety sync occupied the coalescing group; a concurrent caller was forced to wait on it")
+	}
+
+	gate.releaseNow()
+	require.NoError(t, <-leaderErr, "merge safety should run its own sync to completion")
+	require.Equal(t, int32(1), gate.fetches.Load(), "merge safety should read authoritative GitHub state for itself")
+}
+
 // Same drift, but the PR was closed without merging. Sync should flip status
 // to "closed" and skip the snapshot path. Distinct from the merged case
 // because the close branch runs different follow-ups (no deploy row, no
@@ -2247,6 +2596,66 @@ func TestPRServiceStartPullRequestRepairReturnsBusyWhenCanonicalSessionRunning(t
 	require.Nil(t, resp, "StartPullRequestRepair should not launch a second repair turn while the canonical session is running")
 	require.ErrorIs(t, err, ErrRepairSessionBusy, "StartPullRequestRepair should return a handled busy error when the canonical session is not resumable")
 	require.NoError(t, mock.ExpectationsWereMet(), "all busy repair expectations should be met")
+}
+
+// The closed webhook deliberately skips the GitHub readback, so the sync path
+// is no longer around to notify SSE subscribers. Without an explicit publish, a
+// client watching a PR that was merged on github.com would keep rendering the
+// open snapshot until it happened to refetch.
+func TestPRServiceApplyClosedPRTransitionPublishesTerminalState(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "should create pgx mock pool")
+	defer mock.Close()
+
+	mr := miniredis.RunT(t)
+	redisMetrics, err := cache.NewMetrics()
+	require.NoError(t, err, "redis metrics should initialize")
+	redisClient := cache.New(cache.Config{Topology: "standalone", URL: "redis://" + mr.Addr()}, zerolog.Nop(), redisMetrics)
+	require.NotNil(t, redisClient, "redis client should initialize")
+	t.Cleanup(func() {
+		require.NoError(t, redisClient.Close(), "redis client should close cleanly")
+	})
+	streams := cache.NewPullRequestStreams(redisClient, zerolog.Nop())
+
+	orgID := uuid.New()
+	pullRequestID := uuid.New()
+	now := time.Now().UTC()
+	summaryJSON := json.RawMessage(`{"merge_state":"clean","has_conflicts":false,"failing_test_count":0,"needs_agent_action":false}`)
+
+	sub, err := streams.Subscribe(orgID)
+	require.NoError(t, err, "test should subscribe to pull request updates")
+	defer sub.Close()
+
+	mock.ExpectExec("UPDATE pull_requests SET status").
+		WithArgs(pgx.NamedArgs{"id": pullRequestID, "org_id": orgID, "status": models.PullRequestStatusClosed}).
+		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
+	mock.ExpectQuery("SELECT .+ FROM pull_request_health_current WHERE org_id = .+ AND pull_request_id = .+").
+		WithArgs(pgx.NamedArgs{"org_id": orgID, "pull_request_id": pullRequestID}).
+		WillReturnRows(pgxmock.NewRows(prHealthCurrentTestColumns).AddRow(
+			pullRequestID, orgID, int64(7), "head-closed", "base-closed", summaryJSON, summaryJSON,
+			models.PullRequestHealthEnrichmentStatusReady, nil, int64(0), now, now,
+		))
+
+	service := &PRService{
+		pullRequests:    db.NewPullRequestStore(mock),
+		prHealthStreams: streams,
+		logger:          zerolog.New(io.Discard),
+	}
+	pr := models.PullRequest{ID: pullRequestID, OrgID: orgID, GitHubRepo: "assembledhq/143", GitHubPRNumber: 42}
+
+	require.NoError(t, service.applyClosedPRTransition(context.Background(), pr, false, "", "head-closed"),
+		"closing a pull request should succeed")
+	require.Eventually(t, func() bool {
+		select {
+		case event := <-sub.C:
+			return event.PullRequestID == pullRequestID && event.Version == 7 && event.HeadSHA == "head-closed"
+		default:
+			return false
+		}
+	}, 2*time.Second, 20*time.Millisecond, "closing a pull request should publish an update so subscribers refetch the terminal state")
+	require.NoError(t, mock.ExpectationsWereMet(), "the terminal publish should read the existing snapshot instead of calling GitHub")
 }
 
 func TestPRServiceCompletePullRequestRepairRunPublishesUpdate(t *testing.T) {

--- a/internal/services/github/pr_merge.go
+++ b/internal/services/github/pr_merge.go
@@ -99,7 +99,8 @@ func (s *PRService) mergePullRequest(ctx context.Context, orgID, pullRequestID, 
 	// CanMerge gate downstream is meaningful only if it ran against fresh
 	// GitHub data — falling through on a stale snapshot would defeat the
 	// safety check, so we surface the failure and let the user retry.
-	if err := s.SyncPullRequestState(ctx, orgID, pullRequestID); err != nil {
+	syncCtx := WithPullRequestSyncReason(ctx, PullRequestSyncReasonMergeSafety)
+	if err := s.SyncPullRequestState(syncCtx, orgID, pullRequestID); err != nil {
 		return nil, fmt.Errorf("%w: %w", ErrMergeStateRefreshFailed, err)
 	}
 	// Reload PR after the sync so we see the freshest persisted state.
@@ -217,15 +218,15 @@ func (s *PRService) mergePullRequest(ctx context.Context, orgID, pullRequestID, 
 	}
 	s.runMergedPullRequestFollowUps(ctx, pr, mergeResp.SHA)
 
-	// Match every other state-mutating PR path (HandlePullRequestEvent,
-	// repair completions) by enqueuing a state sync so other clients
-	// subscribed to this PR's SSE stream see the merged state without having
-	// to wait for the webhook round-trip.
-	s.enqueuePullRequestStateSync(ctx, pr)
-
-	if current, err := s.pullRequests.GetHealthCurrent(ctx, orgID, pullRequestID); err == nil {
-		s.publishPullRequestUpdated(ctx, pr, current)
-	}
+	// Tell other clients subscribed to this PR's SSE stream about the merge
+	// without waiting for the webhook round-trip. This deliberately publishes
+	// from the existing snapshot rather than enqueuing a state sync: a merged
+	// PR has no live health left to read, and by this point UpdateStatus above
+	// has already flipped the row, so a sync would skip its closed-PR
+	// self-heal and spend a full details + check-runs + statuses readback
+	// writing a snapshot nobody reads. HandlePullRequestEvent's closed branch
+	// makes the same call for PRs merged on github.com.
+	s.publishPullRequestTerminalState(ctx, pr)
 
 	s.logger.Info().
 		Str("pull_request_id", pullRequestID.String()).

--- a/internal/services/github/pr_merge_test.go
+++ b/internal/services/github/pr_merge_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -536,8 +537,20 @@ func TestPRServiceMergePullRequestRunsMergedFollowUps(t *testing.T) {
 				AddRow(uuid.New(), now, now),
 		)
 
+	// Pinned to evaluate_experiment on purpose: the merge path must not also
+	// enqueue a sync_pull_request_state readback. A merged PR has no live
+	// health left to fetch, and the SSE nudge that enqueue used to provide now
+	// comes from publishPullRequestTerminalState reading the stored snapshot.
+	evaluateExperimentKey := fmt.Sprintf("evaluate_experiment:%s", prID)
 	jobMock.ExpectQuery("INSERT INTO jobs").
-		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WithArgs(pgx.NamedArgs{
+			"org_id":     orgID,
+			"queue":      "default",
+			"job_type":   "evaluate_experiment",
+			"payload":    pgxmock.AnyArg(),
+			"priority":   5,
+			"dedupe_key": &evaluateExperimentKey,
+		}).
 		WillReturnRows(pgxmock.NewRows([]string{"id"}).AddRow(uuid.New()))
 
 	service := &PRService{

--- a/internal/services/github/pr_merge_when_ready.go
+++ b/internal/services/github/pr_merge_when_ready.go
@@ -111,7 +111,8 @@ func (s *PRService) ProcessMergeWhenReady(ctx context.Context, orgID, pullReques
 		return s.pullRequests.MarkMergeWhenReadyFailed(ctx, orgID, pullRequestID, err.Error())
 	}
 
-	if err := s.SyncPullRequestState(ctx, orgID, pullRequestID); err != nil && !errors.Is(err, ErrPullRequestMergeabilityPending) {
+	syncCtx := WithPullRequestSyncReason(ctx, PullRequestSyncReasonMergeSafety)
+	if err := s.SyncPullRequestState(syncCtx, orgID, pullRequestID); err != nil && !errors.Is(err, ErrPullRequestMergeabilityPending) {
 		return fmt.Errorf("sync pull request before merge when ready: %w", err)
 	}
 
@@ -225,7 +226,8 @@ func isStaleMergeWhenReadyMerging(pr models.PullRequest, now time.Time) bool {
 
 func (s *PRService) currentMergeWhenReadyHealth(ctx context.Context, pr models.PullRequest) (*models.PullRequestHealthResponse, error) {
 	if pr.GitHubStateSyncedAt == nil || pr.HealthVersion == 0 {
-		if err := s.SyncPullRequestState(ctx, pr.OrgID, pr.ID); err != nil && !errors.Is(err, ErrPullRequestMergeabilityPending) {
+		syncCtx := WithPullRequestSyncReason(ctx, PullRequestSyncReasonInitial)
+		if err := s.SyncPullRequestState(syncCtx, pr.OrgID, pr.ID); err != nil && !errors.Is(err, ErrPullRequestMergeabilityPending) {
 			return nil, fmt.Errorf("sync pull request before queueing merge when ready: %w", err)
 		}
 		refreshed, err := s.pullRequests.GetByID(ctx, pr.OrgID, pr.ID)

--- a/internal/services/github/service.go
+++ b/internal/services/github/service.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/golang-jwt/jwt/v5"
 	"github.com/rs/zerolog"
+	"golang.org/x/sync/singleflight"
 
 	githubtelemetry "github.com/assembledhq/143/internal/services/github/telemetry"
 )
@@ -27,7 +28,10 @@ type Service struct {
 	cache        map[int64]*cachedToken
 	sandboxCache map[sandboxTokenCacheKey]*cachedToken
 	mu           sync.RWMutex
+	tokenGroup   singleflight.Group
 }
+
+const sharedTokenRequestTimeout = 15 * time.Second
 
 type sandboxTokenCacheKey struct {
 	InstallationID int64
@@ -116,28 +120,52 @@ func (s *Service) GitHubAppID() int64 {
 }
 
 func (s *Service) GetInstallationToken(ctx context.Context, installationID int64) (string, error) {
+	if token, ok := s.cachedInstallationToken(installationID); ok {
+		return token, nil
+	}
+
+	result := s.tokenGroup.DoChan(fmt.Sprintf("installation:%d", installationID), func() (any, error) {
+		if token, ok := s.cachedInstallationToken(installationID); ok {
+			return token, nil
+		}
+
+		requestCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), sharedTokenRequestTimeout)
+		defer cancel()
+		jwtToken, err := s.generateJWT()
+		if err != nil {
+			return "", err
+		}
+
+		token, expiresAt, err := s.exchangeForInstallationToken(requestCtx, jwtToken, installationID)
+		if err != nil {
+			return "", err
+		}
+
+		s.mu.Lock()
+		s.cache[installationID] = &cachedToken{Token: token, ExpiresAt: expiresAt}
+		s.mu.Unlock()
+
+		return token, nil
+	})
+	select {
+	case <-ctx.Done():
+		return "", ctx.Err()
+	case completed := <-result:
+		if completed.Err != nil {
+			return "", completed.Err
+		}
+		return completed.Val.(string), nil
+	}
+}
+
+func (s *Service) cachedInstallationToken(installationID int64) (string, bool) {
 	s.mu.RLock()
 	cached, ok := s.cache[installationID]
 	s.mu.RUnlock()
 	if ok && time.Now().Add(5*time.Minute).Before(cached.ExpiresAt) {
-		return cached.Token, nil
+		return cached.Token, true
 	}
-
-	jwtToken, err := s.generateJWT()
-	if err != nil {
-		return "", err
-	}
-
-	token, expiresAt, err := s.exchangeForInstallationToken(ctx, jwtToken, installationID)
-	if err != nil {
-		return "", err
-	}
-
-	s.mu.Lock()
-	s.cache[installationID] = &cachedToken{Token: token, ExpiresAt: expiresAt}
-	s.mu.Unlock()
-
-	return token, nil
+	return "", false
 }
 
 // GetSandboxInstallationToken returns a repository-bound installation token
@@ -169,32 +197,56 @@ func (s *Service) GetSandboxInstallationToken(ctx context.Context, installationI
 	}
 
 	key := sandboxTokenCacheKey{InstallationID: installationID, RepositoryID: repositoryID, Action: action}
+	if token, ok := s.cachedSandboxInstallationToken(key); ok {
+		return token, nil
+	}
+
+	result := s.tokenGroup.DoChan(fmt.Sprintf("sandbox:%d:%d:%s", installationID, repositoryID, action), func() (any, error) {
+		if token, ok := s.cachedSandboxInstallationToken(key); ok {
+			return token, nil
+		}
+
+		requestCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), sharedTokenRequestTimeout)
+		defer cancel()
+		jwtToken, err := s.generateJWT()
+		if err != nil {
+			return "", err
+		}
+		token, expiresAt, err := s.exchangeForScopedInstallationToken(requestCtx, jwtToken, installationID, installationTokenRequest{
+			RepositoryIDs: []int64{repositoryID},
+			Permissions:   permissions,
+		})
+		if err != nil {
+			return "", err
+		}
+
+		s.mu.Lock()
+		if s.sandboxCache == nil {
+			s.sandboxCache = make(map[sandboxTokenCacheKey]*cachedToken)
+		}
+		s.sandboxCache[key] = &cachedToken{Token: token, ExpiresAt: expiresAt}
+		s.mu.Unlock()
+		return token, nil
+	})
+	select {
+	case <-ctx.Done():
+		return "", ctx.Err()
+	case completed := <-result:
+		if completed.Err != nil {
+			return "", completed.Err
+		}
+		return completed.Val.(string), nil
+	}
+}
+
+func (s *Service) cachedSandboxInstallationToken(key sandboxTokenCacheKey) (string, bool) {
 	s.mu.RLock()
 	cached, ok := s.sandboxCache[key]
 	s.mu.RUnlock()
 	if ok && time.Now().Add(5*time.Minute).Before(cached.ExpiresAt) {
-		return cached.Token, nil
+		return cached.Token, true
 	}
-
-	jwtToken, err := s.generateJWT()
-	if err != nil {
-		return "", err
-	}
-	token, expiresAt, err := s.exchangeForScopedInstallationToken(ctx, jwtToken, installationID, installationTokenRequest{
-		RepositoryIDs: []int64{repositoryID},
-		Permissions:   permissions,
-	})
-	if err != nil {
-		return "", err
-	}
-
-	s.mu.Lock()
-	if s.sandboxCache == nil {
-		s.sandboxCache = make(map[sandboxTokenCacheKey]*cachedToken)
-	}
-	s.sandboxCache[key] = &cachedToken{Token: token, ExpiresAt: expiresAt}
-	s.mu.Unlock()
-	return token, nil
+	return "", false
 }
 
 func (s *Service) generateJWT() (string, error) {

--- a/internal/services/github/service_test.go
+++ b/internal/services/github/service_test.go
@@ -11,6 +11,8 @@ import (
 	"io"
 	"net/http"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -218,6 +220,104 @@ func TestService_GetInstallationToken_FetchesAndCaches(t *testing.T) {
 	require.NoError(t, err, "second GetInstallationToken call should not return an error")
 	require.Equal(t, "ghs_cached", second, "second GetInstallationToken call should return the cached token")
 	require.Equal(t, 1, callCount, "GetInstallationToken should exchange only once and use cache on subsequent calls")
+}
+
+func TestService_GetInstallationToken_CoalescesConcurrentCacheMisses(t *testing.T) {
+	t.Parallel()
+
+	svc, err := NewService(143, testPrivateKeyPEM(t))
+	require.NoError(t, err, "NewService should create a valid GitHub service")
+
+	var callCount atomic.Int32
+	requestStarted := make(chan struct{})
+	releaseRequest := make(chan struct{})
+	var startedOnce sync.Once
+	svc.httpClient = &http.Client{
+		Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+			callCount.Add(1)
+			startedOnce.Do(func() { close(requestStarted) })
+			<-releaseRequest
+			return &http.Response{
+				StatusCode: http.StatusCreated,
+				Body: io.NopCloser(strings.NewReader(
+					`{"token":"ghs_shared","expires_at":"2030-01-01T00:00:00Z"}`,
+				)),
+				Header: make(http.Header),
+			}, nil
+		}),
+	}
+
+	const callers = 20
+	results := make(chan string, callers)
+	errs := make(chan error, callers)
+	var callersReady sync.WaitGroup
+	callersReady.Add(callers)
+	for range callers {
+		go func() {
+			callersReady.Done()
+			token, callErr := svc.GetInstallationToken(context.Background(), 77)
+			results <- token
+			errs <- callErr
+		}()
+	}
+	callersReady.Wait()
+	<-requestStarted
+	close(releaseRequest)
+
+	for range callers {
+		require.NoError(t, <-errs, "concurrent GetInstallationToken call should not return an error")
+		require.Equal(t, "ghs_shared", <-results, "concurrent GetInstallationToken call should share the exchanged token")
+	}
+	require.Equal(t, int32(1), callCount.Load(), "concurrent cache misses should perform one installation token exchange")
+}
+
+func TestService_GetInstallationToken_CanceledCallerDoesNotPoisonSharedExchange(t *testing.T) {
+	t.Parallel()
+
+	svc, err := NewService(143, testPrivateKeyPEM(t))
+	require.NoError(t, err, "NewService should create a valid GitHub service")
+
+	var callCount atomic.Int32
+	requestStarted := make(chan struct{})
+	releaseRequest := make(chan struct{})
+	svc.httpClient = &http.Client{
+		Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+			callCount.Add(1)
+			close(requestStarted)
+			<-releaseRequest
+			return &http.Response{
+				StatusCode: http.StatusCreated,
+				Body: io.NopCloser(strings.NewReader(
+					`{"token":"ghs_shared","expires_at":"2030-01-01T00:00:00Z"}`,
+				)),
+				Header: make(http.Header),
+			}, nil
+		}),
+	}
+
+	firstCtx, cancelFirst := context.WithCancel(context.Background())
+	firstErr := make(chan error, 1)
+	go func() {
+		_, callErr := svc.GetInstallationToken(firstCtx, 77)
+		firstErr <- callErr
+	}()
+	<-requestStarted
+
+	secondResult := make(chan string, 1)
+	secondErr := make(chan error, 1)
+	go func() {
+		token, callErr := svc.GetInstallationToken(context.Background(), 77)
+		secondResult <- token
+		secondErr <- callErr
+	}()
+
+	cancelFirst()
+	require.ErrorIs(t, <-firstErr, context.Canceled, "the canceled caller should stop waiting for the shared token exchange")
+	close(releaseRequest)
+
+	require.NoError(t, <-secondErr, "a healthy waiter should receive the shared token despite another caller canceling")
+	require.Equal(t, "ghs_shared", <-secondResult, "the healthy waiter should receive the exchanged token")
+	require.Equal(t, int32(1), callCount.Load(), "caller cancellation should not start a second token exchange")
 }
 
 func TestService_GetInstallationToken_PreservesRateLimitHeaders(t *testing.T) {

--- a/internal/services/github/telemetry/transport.go
+++ b/internal/services/github/telemetry/transport.go
@@ -34,6 +34,7 @@ type RequestMetadata struct {
 	Kind           string
 	AuthType       string
 	InstallationID int64
+	SyncReason     string
 }
 
 // WithRequestMetadata attaches safe GitHub telemetry dimensions to a request.
@@ -163,6 +164,9 @@ func (t *transport) logRequest(req *http.Request, resp *http.Response, requestEr
 	}
 	if metadata.InstallationID > 0 {
 		event = event.Int64("github_installation_id", metadata.InstallationID)
+	}
+	if metadata.SyncReason != "" {
+		event = event.Str("github_sync_reason", metadata.SyncReason)
 	}
 	if rateLimitKind != "" {
 		event = event.Str("github_rate_limit_kind", rateLimitKind)

--- a/internal/services/github/telemetry/transport_test.go
+++ b/internal/services/github/telemetry/transport_test.go
@@ -41,6 +41,7 @@ func TestTransportRoundTripLogsStructuredGitHubTelemetry(t *testing.T) {
 				Kind:           RequestKindAPI,
 				AuthType:       AuthTypeAppInstallation,
 				InstallationID: 42,
+				SyncReason:     "stale_reconcile",
 			},
 			requestURL: "https://api.github.com/repos/assembledhq/143/pulls/99?ignored=true",
 			response: &http.Response{
@@ -63,6 +64,7 @@ func TestTransportRoundTripLogsStructuredGitHubTelemetry(t *testing.T) {
 				"github_repository":               "assembledhq/143",
 				"github_auth_type":                AuthTypeAppInstallation,
 				"github_installation_id":          float64(42),
+				"github_sync_reason":              "stale_reconcile",
 				"github_status_code":              float64(http.StatusOK),
 				"github_status_class":             "2xx",
 				"github_result":                   "success",

--- a/internal/worker/code_review_handler.go
+++ b/internal/worker/code_review_handler.go
@@ -642,7 +642,8 @@ func syncCodeReviewPullRequestState(ctx context.Context, services *Services, log
 	if services == nil || services.PR == nil {
 		return nil
 	}
-	if err := services.PR.SyncPullRequestState(ctx, job.OrgID, job.PullRequestID); err != nil {
+	syncCtx := ghservice.WithPullRequestSyncReason(ctx, ghservice.PullRequestSyncReasonCodeReview)
+	if err := services.PR.SyncPullRequestState(syncCtx, job.OrgID, job.PullRequestID); err != nil {
 		if errors.Is(err, ghservice.ErrPullRequestMergeabilityPending) {
 			delay := 5 * time.Second
 			return &RetryableError{Err: err, RetryAfter: &delay, BypassMaxRetryDuration: true}

--- a/internal/worker/handlers.go
+++ b/internal/worker/handlers.go
@@ -9773,7 +9773,8 @@ func newContinueSessionHandler(stores *Stores, services *Services, logger zerolo
 			}
 			if errors.Is(err, agent.ErrStalePullRequestHead) {
 				if input.PullRequestID != "" && services.PR != nil {
-					if syncErr := services.PR.SyncPullRequestState(ctx, orgID, uuid.MustParse(input.PullRequestID)); syncErr != nil {
+					syncCtx := ghservice.WithPullRequestSyncReason(ctx, ghservice.PullRequestSyncReasonHeadChanged)
+					if syncErr := services.PR.SyncPullRequestState(syncCtx, orgID, uuid.MustParse(input.PullRequestID)); syncErr != nil {
 						logger.Warn().Err(syncErr).Str("pull_request_id", input.PullRequestID).Msg("failed to sync pull request state after stale repair head")
 					}
 				}
@@ -10027,7 +10028,8 @@ func newContinueSessionHandler(stores *Stores, services *Services, logger zerolo
 			if input.AutoAttempt {
 				metrics.RecordPRAutoRepairOutcome(ctx, orgID.String(), "", string(continueOpts.PRRepair.CommandType), "completed")
 			}
-			if syncErr := services.PR.SyncPullRequestState(ctx, orgID, continueOpts.PRRepair.PullRequestID); syncErr != nil {
+			syncCtx := ghservice.WithPullRequestSyncReason(ctx, ghservice.PullRequestSyncReasonRepair)
+			if syncErr := services.PR.SyncPullRequestState(syncCtx, orgID, continueOpts.PRRepair.PullRequestID); syncErr != nil {
 				if errors.Is(syncErr, ghservice.ErrPullRequestMergeabilityPending) {
 					// The health snapshot was refreshed to the post-repair head;
 					// only GitHub's mergeability flag is still settling. The
@@ -10691,6 +10693,7 @@ func newSyncPullRequestStateHandler(services *Services, logger zerolog.Logger) J
 		var input struct {
 			OrgID         string `json:"org_id"`
 			PullRequestID string `json:"pull_request_id"`
+			SyncReason    string `json:"sync_reason"`
 		}
 		if err := json.Unmarshal(payload, &input); err != nil {
 			return fmt.Errorf("unmarshal sync_pull_request_state payload: %w", err)
@@ -10703,8 +10706,17 @@ func newSyncPullRequestStateHandler(services *Services, logger zerolog.Logger) J
 		if err != nil {
 			return fmt.Errorf("parse pull request ID: %w", err)
 		}
-		logger.Info().Str("org_id", orgID.String()).Str("pull_request_id", pullRequestID.String()).Msg("starting sync_pull_request_state job")
-		if err := services.PR.SyncPullRequestState(ctx, orgID, pullRequestID); err != nil {
+		syncReason := ghservice.PullRequestSyncReason(input.SyncReason)
+		if syncReason.Validate() != nil {
+			syncReason = ghservice.PullRequestSyncReasonManual
+		}
+		logger.Info().
+			Str("org_id", orgID.String()).
+			Str("pull_request_id", pullRequestID.String()).
+			Str("sync_reason", string(syncReason)).
+			Msg("starting sync_pull_request_state job")
+		syncCtx := ghservice.WithPullRequestSyncReason(ctx, syncReason)
+		if err := services.PR.SyncPullRequestState(syncCtx, orgID, pullRequestID); err != nil {
 			if errors.Is(err, ghservice.ErrPullRequestMergeabilityPending) {
 				return &RetryableError{Err: err, ConsumeAttempt: true}
 			}

--- a/internal/worker/handlers_test.go
+++ b/internal/worker/handlers_test.go
@@ -5772,6 +5772,28 @@ func TestSyncPullRequestStateHandlerDefersPendingMergeability(t *testing.T) {
 	require.True(t, retryable.ConsumeAttempt, "pending mergeability should consume attempts so exponential backoff advances")
 }
 
+func TestSyncPullRequestStateHandlerPropagatesSyncReason(t *testing.T) {
+	t.Parallel()
+
+	orgID := uuid.New()
+	prID := uuid.New()
+	var actualReason ghservice.PullRequestSyncReason
+	services := &Services{
+		PR: &stubPRService{
+			syncPullRequestStateFn: func(ctx context.Context, _ uuid.UUID, _ uuid.UUID) error {
+				actualReason = ghservice.PullRequestSyncReasonFromContext(ctx)
+				return nil
+			},
+		},
+	}
+	payload := json.RawMessage(`{"org_id":"` + orgID.String() + `","pull_request_id":"` + prID.String() + `","sync_reason":"head_changed"}`)
+
+	err := newSyncPullRequestStateHandler(services, zerolog.Nop())(context.Background(), "sync_pull_request_state", payload)
+
+	require.NoError(t, err, "sync handler should complete when the GitHub refresh succeeds")
+	require.Equal(t, ghservice.PullRequestSyncReasonHeadChanged, actualReason, "sync handler should propagate the durable sync reason to GitHub telemetry")
+}
+
 func TestSyncPullRequestStateHandlerWaitsForGitHubRateLimit(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

Fixes a reliability and rate-limit issue where concurrent PR sync triggers could fan out into redundant GitHub API reads/requests, and where incoming check/status webhook data could cause missed or incorrect syncs. This change deduplicates PR health sync work, makes sync triggers carry an explicit “reason,” and ensures webhook-driven rebuilds only happen when authoritative baseline data changes.

## Changes

- Introduced a singleflight-backed PR health sync group and switched sync triggers to pass a `PullRequestSyncReason` so concurrent events coalesce instead of multiplying GitHub API calls.
- Corrected webhook handling logic: check/status webhook payloads are compared against the authoritative baseline; missing/incomplete/mismatched/unknown checks enqueue a full sync, preventing “stale partial state” drift.
- Prevented stale/out-of-order webhook states from triggering rebuilds or GitHub requests by rejecting invalid projection transitions.
- Updated token exchange/sync context wiring to use bounded, cancellation-independent shared contexts so a canceled caller stops waiting without poisoning healthy concurrent callers, and enhanced structured telemetry for every sync trigger (including dedupe behavior).

## Validation

- Full GitHub, telemetry, code-review, and worker test suites
- Focused regression tests
- Race detector for concurrent token acquisition
- `go vet` across affected packages
- `git diff --check`

[143.dev](https://143.dev) | [session 62db547a](https://143.dev/sessions/62db547a-39e0-4aae-b8d9-8fe6209d19a4)

<!-- 143 readiness -->
**143 readiness:** not available for this revision.

<!-- 143-publication session=62db547a-39e0-4aae-b8d9-8fe6209d19a4 changeset=7f4e8108-f33a-41bd-8261-f4eabe5d4c10 -->

Preview: https://143.dev/previews/github/assembledhq/143/pull/2008?launch=1