### PR TITLE
Add consistent bottom spacing across app by updating design system page layout

### DIFF
--- a/frontend/AGENTS.md
+++ b/frontend/AGENTS.md
@@ -147,6 +147,7 @@ Numbers that users compare or scan (counts, costs, durations, dates in tables/me
 | Context | Pattern |
 |---------|---------|
 | Page-level section spacing | `space-y-6` |
+| Page-bottom scroll clearance | `pb-24 md:pb-20` via `PageContainer` |
 | Within sections (header → content) | `space-y-3` |
 | Within cards | `space-y-4` to `space-y-6` |
 | Form field groups (label → input → hint) | `space-y-2` |
@@ -167,7 +168,7 @@ Cards use `shadow-sm` by default. Buttons (default/outline/destructive variants)
 
 ### Page Container
 
-Use `PageContainer` (`src/components/page-container.tsx`) for ALL dashboard pages:
+Use `PageContainer` (`src/components/page-container.tsx`) for ALL dashboard pages. It owns the standard width constraint and responsive bottom scroll clearance, so pages must not add one-off bottom padding:
 
 ```tsx
 <PageContainer size="default">
@@ -496,7 +497,7 @@ State tokens (`success`, `warning`, `attention`, `info`, `destructive`) adapt to
 
 | Component | Location | Purpose |
 |-----------|----------|---------|
-| `PageContainer` | `src/components/page-container.tsx` | Page width constraint |
+| `PageContainer` | `src/components/page-container.tsx` | Page width constraint + bottom scroll clearance |
 | `PageHeader` | `src/components/page-header.tsx` | Standard page title + description + action |
 | `EmptyState` | `src/components/empty-state.tsx` | Empty list/data placeholder |
 | `AuthenticatedLayout` | `src/components/authenticated-layout.tsx` | Sidebar + main content shell |

--- a/frontend/src/app/(dashboard)/settings/layout.test.tsx
+++ b/frontend/src/app/(dashboard)/settings/layout.test.tsx
@@ -249,7 +249,7 @@ describe('SettingsLayout', () => {
     expect(screen.queryByRole('link')).not.toBeInTheDocument();
   });
 
-  it('adds shared bottom scroll padding for settings page containers', () => {
+  it('applies the shared settings copy treatment', () => {
     useAuthMock.mockReturnValue({ user: { role: 'admin' }, isLoading: false });
 
     const { container } = renderWithProviders(
@@ -258,9 +258,8 @@ describe('SettingsLayout', () => {
       </SettingsLayout>
     );
 
-    const paddingScope = container.querySelector('[data-slot="settings-layout-padding-scope"]');
-    expect(paddingScope).not.toBeNull();
-    expect(paddingScope).toHaveClass('[&_[data-slot=page-container]]:pb-24');
-    expect(paddingScope).toHaveClass('md:[&_[data-slot=page-container]]:pb-20');
+    const settingsLayout = container.querySelector('[data-slot="settings-layout"]');
+    expect(settingsLayout).not.toBeNull();
+    expect(settingsLayout).toHaveClass('settings-readable-copy');
   });
 });

--- a/frontend/src/app/(dashboard)/settings/layout.tsx
+++ b/frontend/src/app/(dashboard)/settings/layout.tsx
@@ -94,8 +94,8 @@ export default function SettingsLayout({
 
   return (
     <div
-      data-slot="settings-layout-padding-scope"
-      className="settings-readable-copy [&_[data-slot=page-container]]:pb-24 md:[&_[data-slot=page-container]]:pb-20"
+      data-slot="settings-layout"
+      className="settings-readable-copy"
     >
       {children}
     </div>

--- a/frontend/src/components/page-container.test.tsx
+++ b/frontend/src/components/page-container.test.tsx
@@ -3,12 +3,14 @@ import { render, screen } from "@testing-library/react";
 import { PageContainer } from "./page-container";
 
 describe("PageContainer", () => {
-  it("uses default max width and centers content", () => {
+  it("uses the default width and shared page-bottom clearance", () => {
     render(<PageContainer>Default container</PageContainer>);
 
     const container = screen.getByText("Default container");
     expect(container).toHaveClass("max-w-5xl");
     expect(container).toHaveClass("mx-auto");
+    expect(container).toHaveClass("pb-24");
+    expect(container).toHaveClass("md:pb-20");
   });
 
   it("applies narrow width for narrow size and wider max for wide", () => {

--- a/frontend/src/components/page-container.tsx
+++ b/frontend/src/components/page-container.tsx
@@ -21,7 +21,7 @@ export function PageContainer({ children, size = "default", className }: PageCon
     <div
       data-slot="page-container"
       data-size={size}
-      className={cn("w-full mx-auto", sizeClassMap[size], className)}
+      className={cn("w-full mx-auto pb-24 md:pb-20", sizeClassMap[size], className)}
     >
       {children}
     </div>


### PR DESCRIPTION
## Summary

Dashboard pages can end up with inconsistent bottom spacing, causing either cramped scroll-to-end UX or ad-hoc padding. This PR centralizes the standard bottom scroll clearance in `PageContainer` and adjusts Settings to use the shared treatment, aligning the layout with the design system guidance.

## Changes

- Update design system guidance so `PageContainer` owns both the width constraint and the standard responsive bottom scroll clearance (and pages should avoid one-off bottom padding).
- Simplify `SettingsLayout` to apply the shared `settings-readable-copy` treatment instead of injecting bottom padding selectors into nested `PageContainer`s.
- Update `SettingsLayout` test to validate the new class/treatment contract.
- Add/adjust `PageContainer` tests to cover the intended padding behavior via the component rather than per-page wrappers.

## Validation

- Ran frontend unit tests (including `frontend/src/app/(dashboard)/settings/layout.test.tsx` and `frontend/src/components/page-container.test.tsx`).
- Lint/TypeScript checks passed in CI for the touched frontend package.

[143.dev](https://143.dev) | [session 4c00689e](https://143.dev/sessions/4c00689e-d8ee-42b1-b30c-df6c02c121d9)

<!-- 143 readiness -->
**143 readiness:** not available for this revision.

<!-- 143-publication session=4c00689e-d8ee-42b1-b30c-df6c02c121d9 changeset=e2084fd6-9c54-42da-84ed-efa92adf2f72 -->

Preview: https://143.dev/previews/github/assembledhq/143/pull/2010?launch=1