### PR TITLE
Audit and remove remaining Check readiness UI and related settings from session details and admin pages

### DIFF
--- a/cmd/migrate/main.go
+++ b/cmd/migrate/main.go
@@ -15,6 +15,13 @@ import (
 // migrateLogger implements migrate.Logger to surface verbose migration output.
 type migrateLogger struct{ verbose bool }
 
+const prReadinessDirtyMigrationVersion = 267
+
+type dirtyMigrationRepairer interface {
+	Version() (uint, bool, error)
+	Force(version int) error
+}
+
 func (l migrateLogger) Printf(format string, v ...interface{}) {
 	fmt.Printf("[migrate] "+format, v...)
 }
@@ -28,7 +35,7 @@ func main() {
 	}
 
 	if len(os.Args) < 2 {
-		fmt.Println("Usage: migrate [up|down]")
+		fmt.Println("Usage: migrate [up|down|repair-pr-readiness]")
 		os.Exit(1)
 	}
 
@@ -60,10 +67,46 @@ func main() {
 			os.Exit(1)
 		}
 		fmt.Println("Migrations rolled back successfully.")
+	case "repair-pr-readiness":
+		repaired, err := repairPRReadinessDirtyMigration(m)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Failed to repair PR readiness migration state: %v\n", err)
+			os.Exit(1)
+		}
+		if repaired {
+			fmt.Printf("Repaired dirty migration %d; migrations can resume from %d.\n", prReadinessDirtyMigrationVersion, prReadinessDirtyMigrationVersion-1)
+		} else {
+			fmt.Println("PR readiness migration repair not needed.")
+		}
 	default:
 		fmt.Fprintf(os.Stderr, "Unknown command: %s\n", os.Args[1]) // #nosec G705 -- writing to stderr, not HTTP response
 		os.Exit(1)
 	}
+}
+
+// repairPRReadinessDirtyMigration repairs only the known production failure of
+// the original migration 267. PostgreSQL executed that migration file as one
+// transaction, so its deadlock rolled back every schema/data statement while
+// golang-migrate's separately-written dirty marker remained at 267. Refuse to
+// clear any other dirty version so this cannot become a general force bypass.
+func repairPRReadinessDirtyMigration(m dirtyMigrationRepairer) (bool, error) {
+	version, dirty, err := m.Version()
+	if err != nil {
+		if errors.Is(err, migrate.ErrNilVersion) {
+			return false, nil
+		}
+		return false, fmt.Errorf("read migration version: %w", err)
+	}
+	if !dirty {
+		return false, nil
+	}
+	if version != prReadinessDirtyMigrationVersion {
+		return false, fmt.Errorf("database is dirty at version %d; refusing targeted repair for version %d", version, prReadinessDirtyMigrationVersion)
+	}
+	if err := m.Force(prReadinessDirtyMigrationVersion - 1); err != nil {
+		return false, fmt.Errorf("force migration version to %d: %w", prReadinessDirtyMigrationVersion-1, err)
+	}
+	return true, nil
 }
 
 func resolveMigrationSource(exists func(string) bool) (string, error) {

--- a/cmd/migrate/main_test.go
+++ b/cmd/migrate/main_test.go
@@ -1,14 +1,100 @@
 package main
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"regexp"
 	"strings"
 	"testing"
 
+	"github.com/golang-migrate/migrate/v4"
 	"github.com/stretchr/testify/require"
 )
+
+type fakeDirtyMigrationRepairer struct {
+	version      uint
+	dirty        bool
+	versionErr   error
+	forceErr     error
+	forcedTo     int
+	forceInvoked bool
+}
+
+func (f *fakeDirtyMigrationRepairer) Version() (uint, bool, error) {
+	return f.version, f.dirty, f.versionErr
+}
+
+func (f *fakeDirtyMigrationRepairer) Force(version int) error {
+	f.forceInvoked = true
+	f.forcedTo = version
+	return f.forceErr
+}
+
+func TestRepairPRReadinessDirtyMigration(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name             string
+		repairer         fakeDirtyMigrationRepairer
+		expectedRepaired bool
+		expectedForce    int
+		expectForce      bool
+		expectError      bool
+	}{
+		{
+			name:             "repairs exact dirty readiness migration",
+			repairer:         fakeDirtyMigrationRepairer{version: prReadinessDirtyMigrationVersion, dirty: true},
+			expectedRepaired: true,
+			expectedForce:    prReadinessDirtyMigrationVersion - 1,
+			expectForce:      true,
+		},
+		{
+			name:     "does nothing for clean database",
+			repairer: fakeDirtyMigrationRepairer{version: prReadinessDirtyMigrationVersion, dirty: false},
+		},
+		{
+			name:        "refuses unrelated dirty migration",
+			repairer:    fakeDirtyMigrationRepairer{version: prReadinessDirtyMigrationVersion + 1, dirty: true},
+			expectError: true,
+		},
+		{
+			name:        "returns version read failure",
+			repairer:    fakeDirtyMigrationRepairer{versionErr: errors.New("version unavailable")},
+			expectError: true,
+		},
+		{
+			name:     "does nothing before the first migration",
+			repairer: fakeDirtyMigrationRepairer{versionErr: migrate.ErrNilVersion},
+		},
+		{
+			name:          "returns force failure",
+			repairer:      fakeDirtyMigrationRepairer{version: prReadinessDirtyMigrationVersion, dirty: true, forceErr: errors.New("force rejected")},
+			expectForce:   true,
+			expectedForce: prReadinessDirtyMigrationVersion - 1,
+			expectError:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			repairer := tt.repairer
+			repaired, err := repairPRReadinessDirtyMigration(&repairer)
+			if tt.expectError {
+				require.Error(t, err, "targeted migration repair should return the expected failure")
+			} else {
+				require.NoError(t, err, "targeted migration repair should complete without error")
+			}
+			require.Equal(t, tt.expectedRepaired, repaired, "targeted migration repair should report whether it changed migration state")
+			require.Equal(t, tt.expectForce, repairer.forceInvoked, "targeted migration repair should only force the exact known dirty version")
+			if tt.expectForce {
+				require.Equal(t, tt.expectedForce, repairer.forcedTo, "targeted migration repair should rewind to the version before readiness removal")
+			}
+		})
+	}
+}
 
 func TestResolveMigrationSource(t *testing.T) {
 	t.Parallel()

--- a/deploy/deploy_config_test.go
+++ b/deploy/deploy_config_test.go
@@ -870,6 +870,22 @@ func TestRoutineWorkerDeployBuildsSandboxDNSOnlyWhenMissing(t *testing.T) {
 	}, "\n"), "routine worker deploy must not rebuild sandbox-dns unconditionally because that primes the next reconcile to recreate the sidecar")
 }
 
+func TestAppDeployRepairsKnownReadinessMigrationBeforeMigrating(t *testing.T) {
+	t.Parallel()
+
+	deployScript, err := os.ReadFile("../deploy/scripts/deploy.sh")
+	require.NoError(t, err, "test should read deploy.sh")
+	deployText := string(deployScript)
+	repairCommand := `docker compose -f "$COMPOSE_FILE" run --rm -T --no-deps api /bin/migrate repair-pr-readiness < /dev/null`
+	upCommand := `docker compose -f "$COMPOSE_FILE" run --rm -T --no-deps api /bin/migrate up < /dev/null`
+	repairIndex := strings.Index(deployText, repairCommand)
+	upIndex := strings.Index(deployText, upCommand)
+
+	require.NotEqual(t, -1, repairIndex, "app deploy should run the narrowly scoped readiness migration repair")
+	require.NotEqual(t, -1, upIndex, "app deploy should still run normal migrations")
+	require.Less(t, repairIndex, upIndex, "app deploy should repair the known dirty marker before normal migrations")
+}
+
 func TestMaintenanceWorkerSupportServiceRecreateRetriesSandboxDNSAddressConflict(t *testing.T) {
 	t.Parallel()
 

--- a/deploy/scripts/deploy.sh
+++ b/deploy/scripts/deploy.sh
@@ -2444,6 +2444,7 @@ SELECT COUNT(*) FROM endpoint_blockers;"
   # that the old schema doesn't have yet.
   if [ "$ROLE" = "app" ]; then
     echo "Running database migrations..."
+    docker compose -f "$COMPOSE_FILE" run --rm -T --no-deps api /bin/migrate repair-pr-readiness < /dev/null
     docker compose -f "$COMPOSE_FILE" run --rm -T --no-deps api /bin/migrate up < /dev/null
   fi
 

--- a/docs/design/future/116-automatic-pr-feedback-follow-through.md
+++ b/docs/design/future/116-automatic-pr-feedback-follow-through.md
@@ -129,7 +129,7 @@ GitHub webhook
   -> continue PR feedback thread against verified PR head
   -> if diff: control-plane push
   -> compose and publish one response per item
-  -> drain pending feedback, then conflicts, tests, readiness
+  -> drain pending feedback, then conflicts and tests
 ~~~
 
 Batching:
@@ -140,7 +140,7 @@ Batching:
 - items arriving after execution starts wait for the next batch
 - one active collecting/queued/running/pushing/responding batch per PR
 
-Automatic priority is human-or-bot PR feedback, conflicts, failing checks, then readiness. Running work is never interrupted.
+Automatic priority is human-or-bot PR feedback, conflicts, then failing checks. Running work is never interrupted.
 
 The session uses one PR feedback thread and SessionMessageSource github_pr_feedback. The visible message summarizes author/count; full bodies and coordinates stay in structured context.
 

--- a/docs/design/future/116-scalable-live-updates-sse.md
+++ b/docs/design/future/116-scalable-live-updates-sse.md
@@ -682,7 +682,7 @@ Session detail uses:
 - optimistic pending state for the user's PR/branch/push actions
 - short scoped polling only for a server-side state machine that is actively converging
 
-Healthy backup is 60s while active and disabled or 5 minutes after terminal settle. Newly unhealthy detail refreshes immediately and then every 5-15s. Transcript, human input, file events, timeline, readiness, and detail must not independently poll every 3-5s when the resource stream is healthy.
+Healthy backup is 60s while active and disabled or 5 minutes after terminal settle. Newly unhealthy detail refreshes immediately and then every 5-15s. Transcript, human input, file events, timeline, review loops, and detail must not independently poll every 3-5s when the resource stream is healthy.
 
 As a follow-up consolidation, merge the current three per-session Redis readers into one typed per-session Redis Stream so a focused session costs one backend blocking reader rather than separate log, status, and event readers. This is not required to prove the org bus but is required before resource-stream concurrency materially exceeds current levels.
 
@@ -958,7 +958,7 @@ Run transport tests through the production-equivalent edge/proxy path, not only 
 1. Acting-user session, preview, and automation mutations render an honest optimistic state in the next frame and reconcile without flicker.
 2. Other-client critical status changes render with p95 under 750ms and p99 under 2s when the live path is healthy.
 3. Sessions list/count/sidebar no longer poll every 10s when live updates are healthy.
-4. Session detail no longer runs independent 3-5s polls for detail, transcript, human input, timeline, readiness, and file events while streams are healthy.
+4. Session detail no longer runs independent 3-5s polls for detail, transcript, human input, timeline, review loops, and file events while streams are healthy.
 5. Previews index no longer polls running previews every 5s when healthy.
 6. Automations list/detail/runs no longer poll every 10s when healthy.
 7. Redis live-bus connection count is bounded by configured shards/topology and does not grow with org/client count.

--- a/docs/design/future/123-agent-initiated-pr-publication.md
+++ b/docs/design/future/123-agent-initiated-pr-publication.md
@@ -68,7 +68,7 @@ second model-produced readiness field.
 If automatic creation is off, the agent leaves verified changes ready for
 manual publication. An explicit user instruction such as "create the PR"
 overrides that automatic preference, but never overrides authorization,
-repository policy, review requirements, or readiness gates.
+repository policy, review requirements, or publication gates.
 
 The tool returns a typed asynchronous state (`review_started`,
 `review_in_progress`, `pr_queued`, `already_published`,

--- a/docs/design/implemented/118-durable-session-publication.md
+++ b/docs/design/implemented/118-durable-session-publication.md
@@ -163,7 +163,7 @@ Recovery has two independent paths:
   webhook/worker crash after local association still converges. When no local
   or GitHub PR exists, it re-enqueues the exact stored request payload on its
   original queue. The normal `open_pr` worker then re-runs snapshot quiescence,
-  builder-readiness, draft/authorship, and automation-review guards; the
+  builder-review, draft/authorship, and automation-review guards; the
   reconciler never calls the low-level PR creator directly. A failed candidate
   is checkpointed as `retryable_failed`, advancing its `updated_at` so a bounded
   oldest-first batch cannot be monopolized by permanently broken rows.

--- a/docs/design/implemented/122-remove-pr-readiness.md
+++ b/docs/design/implemented/122-remove-pr-readiness.md
@@ -1,6 +1,6 @@
 # 122 - Remove PR Readiness
 
-> **Status:** Implemented | **Last reviewed:** 2026-07-31
+> **Status:** Implemented | **Last reviewed:** 2026-08-01
 >
 > **Applies to:** PR readiness runs, checks, bypasses, contexts, policies, and
 > custom checks; the `run_pr_readiness` job; readiness org/user follow-through
@@ -61,12 +61,12 @@ evidence rather than widening this gate.
 - Removing review-agent loops, the `Review` action, or the builder pre-PR gate.
 - Removing PR health synchronization, repair actions, or code review.
 - Preserving readiness history. Readiness runs, checks, and bypasses are
-  destroyed by migration `000267` and cannot be reconstructed from within 143.
+  destroyed by migration `000271` and cannot be reconstructed from within 143.
 
 ## Rollout Order
 
-Migration `000267_remove_pr_readiness` is the rolling-deploy barrier, following
-the pattern established by `000259_cancel_pending_pm_jobs`:
+Migration `000267_remove_pr_readiness` is the jobs-only rolling-deploy barrier,
+following the pattern established by `000259_cancel_pending_pm_jobs`:
 
 1. `LOCK TABLE jobs IN SHARE ROW EXCLUSIVE MODE` before the drain check, so a
    worker cannot claim a pending readiness job between the check and the
@@ -80,10 +80,32 @@ the pattern established by `000259_cancel_pending_pm_jobs`:
    `job_type` has no standalone index. `delete_expired_completed_jobs` does not
    cover `cancelled`, so these rows persist, as the PM shutdown's cancelled rows
    do; the queued readiness backlog is small and bounded.
-5. Clear `readiness` changeset leases, then narrow the lease `holder_type`
+
+Migration `000271_remove_pr_readiness_state` runs after the barrier transaction
+commits:
+
+1. Clear `readiness` changeset leases, then narrow the lease `holder_type`
    check constraint.
-6. Strip retired org/user settings keys and the `pr.readiness_attention` Slack
-   subscription, then drop the six readiness tables.
+2. Strip retired org/user settings keys and the `pr.readiness_attention` Slack
+   subscription.
+3. Drop the six readiness tables.
+
+The split is required because golang-migrate sends each migration file as one
+transaction. The original all-in-one `000267` held a `SHARE ROW EXCLUSIVE` lock
+on `jobs` while acquiring locks on settings, lease, and readiness relations. A
+concurrent application transaction that already held one of those locks and
+then enqueued a job produced a lock inversion and deadlocked the production
+rollout. Keeping `000267` jobs-only releases the barrier lock before `000271`
+touches any other application table without reopening the enqueue race: the
+trigger remains installed between the two transactions.
+
+The failed production attempt left golang-migrate's separately committed dirty
+marker at version 267 even though PostgreSQL rolled back the migration
+transaction. App deploys therefore run `migrate repair-pr-readiness` before
+`migrate up`. That repair is intentionally narrow: it no-ops on clean databases,
+rewinds only an exactly dirty version 267 to 266, and refuses every other dirty
+version. Remove the repair command from the migrator and deploy script in the
+same follow-up that contracts the temporary rejection trigger.
 
 Slack subscriptions that listed only `pr.readiness_attention` are pinned to the
 `custom` preset before the event is stripped. Without that, an emptied `events`
@@ -98,7 +120,8 @@ by a follow-up migration once no pre-removal process can still be running.
 
 - **User settings strict decoding.** `ParseUserSettings` uses
   `DisallowUnknownFields`, so a retired key is a hard decode failure. The
-  migration strips `automatic_pr_follow_through.readiness_after_review_loop`,
+  state-cleanup migration strips
+  `automatic_pr_follow_through.readiness_after_review_loop`,
   but an old API process serving a cached frontend bundle during the rollout
   window could write it back, after which that one user's settings row fails to
   decode until it is cleared. Org settings decode leniently and are not exposed

--- a/internal/db/migrations_test.go
+++ b/internal/db/migrations_test.go
@@ -50,21 +50,37 @@ func TestSessionChangesetSplitMigrationPinsPhaseThreeContracts(t *testing.T) {
 func TestRemovePRReadinessMigrationPinsShutdownContracts(t *testing.T) {
 	t.Parallel()
 
-	body, err := os.ReadFile("../../migrations/000267_remove_pr_readiness.up.sql")
-	require.NoError(t, err, "test should read the PR readiness removal migration")
-	sql := string(body)
+	barrierBody, err := os.ReadFile("../../migrations/000267_remove_pr_readiness.up.sql")
+	require.NoError(t, err, "test should read the PR readiness jobs-barrier migration")
+	barrierSQL := string(barrierBody)
 
-	require.Contains(t, sql, "LOCK TABLE jobs", "migration should close the rolling-deploy enqueue race")
-	require.Contains(t, sql, "status = 'running'", "migration should refuse to drop readiness state while a worker is using it")
-	require.Contains(t, sql, "trg_reject_removed_pr_readiness_jobs", "migration should prevent old processes from enqueueing removed jobs")
-	require.Contains(t, sql, "status = 'cancelled'", "migration should cancel pending readiness jobs")
-	require.NotContains(t, sql, "DELETE FROM jobs", "migration should cancel rather than delete readiness jobs so history survives and the jobs lock is not held for a sequential scan")
-	require.Contains(t, sql, "DELETE FROM session_changeset_leases", "migration should clear readiness leases before narrowing the lease constraint")
-	require.Contains(t, sql, "UPDATE organizations", "migration should remove retired organization settings before strict decoding")
-	require.Contains(t, sql, "UPDATE users", "migration should remove retired user settings before strict decoding")
-	require.Contains(t, sql, "UPDATE slack_bot_settings", "migration should remove retired bot-level Slack subscriptions")
-	require.Contains(t, sql, "UPDATE slack_channel_settings", "migration should remove retired channel-level Slack subscriptions")
-	require.Contains(t, sql, `"pr.readiness_attention"`, "migration should identify the retired Slack event exactly")
+	require.Contains(t, barrierSQL, "LOCK TABLE jobs", "jobs barrier should close the rolling-deploy enqueue race")
+	require.Contains(t, barrierSQL, "status = 'running'", "jobs barrier should refuse cleanup while a worker is using readiness state")
+	require.Contains(t, barrierSQL, "trg_reject_removed_pr_readiness_jobs", "jobs barrier should prevent old processes from enqueueing removed jobs")
+	require.Contains(t, barrierSQL, "status = 'cancelled'", "jobs barrier should cancel pending readiness jobs")
+	require.NotContains(t, barrierSQL, "DELETE FROM jobs", "jobs barrier should cancel rather than delete readiness jobs so history survives")
+	for _, crossTableStatement := range []string{
+		"DELETE FROM session_changeset_leases",
+		"UPDATE organizations",
+		"UPDATE users",
+		"UPDATE slack_bot_settings",
+		"UPDATE slack_channel_settings",
+		"DROP TABLE",
+	} {
+		require.NotContains(t, barrierSQL, crossTableStatement, "jobs barrier should not hold the jobs lock while changing other application tables")
+	}
+
+	cleanupBody, err := os.ReadFile("../../migrations/000271_remove_pr_readiness_state.up.sql")
+	require.NoError(t, err, "test should read the PR readiness state-cleanup migration")
+	cleanupSQL := string(cleanupBody)
+
+	require.Contains(t, cleanupSQL, "DELETE FROM session_changeset_leases", "state cleanup should clear readiness leases before narrowing the lease constraint")
+	require.Contains(t, cleanupSQL, "UPDATE organizations", "state cleanup should remove retired organization settings")
+	require.Contains(t, cleanupSQL, "UPDATE users", "state cleanup should remove retired user settings before strict decoding")
+	require.Contains(t, cleanupSQL, "UPDATE slack_bot_settings", "state cleanup should remove retired bot-level Slack subscriptions")
+	require.Contains(t, cleanupSQL, "UPDATE slack_channel_settings", "state cleanup should remove retired channel-level Slack subscriptions")
+	require.Contains(t, cleanupSQL, `"pr.readiness_attention"`, "state cleanup should identify the retired Slack event exactly")
+	require.NotContains(t, cleanupSQL, "DROP TRIGGER IF EXISTS trg_reject_removed_pr_readiness_jobs", "state cleanup should retain the rolling guard until a later fleet contraction")
 	for _, table := range []string{
 		"pr_readiness_bypasses",
 		"pr_readiness_checks",
@@ -73,7 +89,7 @@ func TestRemovePRReadinessMigrationPinsShutdownContracts(t *testing.T) {
 		"pr_readiness_policies",
 		"pr_readiness_contexts",
 	} {
-		require.Contains(t, sql, "DROP TABLE "+table, "migration should drop every readiness table")
+		require.Contains(t, cleanupSQL, "DROP TABLE IF EXISTS "+table, "state cleanup should idempotently drop every readiness table")
 	}
 }
 

--- a/migrations/000267_remove_pr_readiness.down.sql
+++ b/migrations/000267_remove_pr_readiness.down.sql
@@ -1,10 +1,4 @@
--- Removed readiness data cannot be reconstructed. This down migration restores
--- only the shared job/lease contracts; rolling back application code also
--- requires restoring the readiness tables from backup.
+-- Restore only the rolling-deploy jobs barrier. Migration 000271 owns the
+-- shared lease contract and destructive readiness-state cleanup.
 DROP TRIGGER IF EXISTS trg_reject_removed_pr_readiness_jobs ON jobs;
 DROP FUNCTION IF EXISTS reject_removed_pr_readiness_jobs();
-
-ALTER TABLE session_changeset_leases
-    DROP CONSTRAINT session_changeset_leases_holder_type_check,
-    ADD CONSTRAINT session_changeset_leases_holder_type_check
-        CHECK (holder_type IN ('agent_turn', 'materialize', 'publish', 'restack', 'readiness', 'preview'));

--- a/migrations/000267_remove_pr_readiness.up.sql
+++ b/migrations/000267_remove_pr_readiness.up.sql
@@ -1,6 +1,9 @@
--- PR readiness is a removed product subsystem. Block rolling deploys while an
--- old worker is executing a readiness job, then prevent old API/worker
--- processes from enqueueing new work after this migration commits.
+-- PR readiness is a removed product subsystem. This migration is deliberately
+-- limited to the jobs table: golang-migrate executes each file as one
+-- transaction, so holding the jobs lock while also changing settings, leases,
+-- and readiness tables can deadlock with application transactions that touch
+-- those relations before enqueueing work. Migration 000271 performs the
+-- cross-table cleanup after this barrier transaction commits.
 LOCK TABLE jobs IN SHARE ROW EXCLUSIVE MODE;
 
 DO $$
@@ -47,83 +50,3 @@ SET status = 'cancelled',
     last_error = 'cancelled: PR readiness subsystem removed'
 WHERE status = 'pending'
   AND job_type = 'run_pr_readiness';
-
-DELETE FROM session_changeset_leases
-WHERE holder_type = 'readiness';
-
--- ParseUserSettings decodes with DisallowUnknownFields, so a retired user
--- preference is a hard decode failure once the new version ships. Org settings
--- decode leniently; strip them too so the stored documents stay truthful.
-UPDATE organizations
-SET settings = settings
-    #- '{session_automation,automatic_follow_through,readiness_after_review_loop}'
-    #- '{session_automation,automatic_follow_through,readiness_after_review_loop_states}'
-WHERE (settings #> '{session_automation,automatic_follow_through}') ?| ARRAY[
-    'readiness_after_review_loop',
-    'readiness_after_review_loop_states'
-];
-
-UPDATE users
-SET settings = settings
-    #- '{automatic_pr_follow_through,readiness_after_review_loop}'
-WHERE (settings #> '{automatic_pr_follow_through}') ? 'readiness_after_review_loop';
-
--- Remove the retired event from custom Slack subscriptions. If it was the
--- only explicit event, pin the preset to custom before producing an empty
--- array so subscription matching does not fall back to a broader preset.
-UPDATE slack_bot_settings
-SET notification_preset = 'custom'
-WHERE notification_subscriptions->'events' @> '["pr.readiness_attention"]'::jsonb
-  AND NOT EXISTS (
-      SELECT 1
-      FROM jsonb_array_elements(notification_subscriptions->'events') AS item(value)
-      WHERE item.value <> '"pr.readiness_attention"'::jsonb
-  );
-
-UPDATE slack_channel_settings
-SET notification_preset = 'custom'
-WHERE notification_subscriptions->'events' @> '["pr.readiness_attention"]'::jsonb
-  AND NOT EXISTS (
-      SELECT 1
-      FROM jsonb_array_elements(notification_subscriptions->'events') AS item(value)
-      WHERE item.value <> '"pr.readiness_attention"'::jsonb
-  );
-
-UPDATE slack_bot_settings
-SET notification_subscriptions = jsonb_set(
-    notification_subscriptions,
-    '{events}',
-    COALESCE((
-        SELECT jsonb_agg(item.value)
-        FROM jsonb_array_elements(notification_subscriptions->'events') AS item(value)
-        WHERE item.value <> '"pr.readiness_attention"'::jsonb
-    ), '[]'::jsonb)
-)
-WHERE notification_subscriptions->'events' @> '["pr.readiness_attention"]'::jsonb;
-
-UPDATE slack_channel_settings
-SET notification_subscriptions = jsonb_set(
-    notification_subscriptions,
-    '{events}',
-    COALESCE((
-        SELECT jsonb_agg(item.value)
-        FROM jsonb_array_elements(notification_subscriptions->'events') AS item(value)
-        WHERE item.value <> '"pr.readiness_attention"'::jsonb
-    ), '[]'::jsonb)
-)
-WHERE notification_subscriptions->'events' @> '["pr.readiness_attention"]'::jsonb;
-
-ALTER TABLE session_changeset_leases
-    DROP CONSTRAINT session_changeset_leases_holder_type_check,
-    ADD CONSTRAINT session_changeset_leases_holder_type_check
-        CHECK (holder_type IN ('agent_turn', 'materialize', 'publish', 'restack', 'preview'));
-
-DROP TRIGGER IF EXISTS trg_pr_readiness_assign_primary_changeset ON pr_readiness_runs;
-DROP FUNCTION IF EXISTS assign_pr_readiness_primary_changeset();
-
-DROP TABLE pr_readiness_bypasses;
-DROP TABLE pr_readiness_checks;
-DROP TABLE pr_readiness_runs;
-DROP TABLE pr_readiness_custom_checks;
-DROP TABLE pr_readiness_policies;
-DROP TABLE pr_readiness_contexts;

--- a/migrations/000271_remove_pr_readiness_state.down.sql
+++ b/migrations/000271_remove_pr_readiness_state.down.sql
@@ -1,0 +1,7 @@
+-- Removed readiness data cannot be reconstructed. This down migration restores
+-- only the shared lease contract; restoring application readiness behavior also
+-- requires restoring the six readiness tables and their data from backup.
+ALTER TABLE session_changeset_leases
+    DROP CONSTRAINT session_changeset_leases_holder_type_check,
+    ADD CONSTRAINT session_changeset_leases_holder_type_check
+        CHECK (holder_type IN ('agent_turn', 'materialize', 'publish', 'restack', 'readiness', 'preview'));

--- a/migrations/000271_remove_pr_readiness_state.up.sql
+++ b/migrations/000271_remove_pr_readiness_state.up.sql
@@ -1,0 +1,91 @@
+-- Complete the destructive PR-readiness cleanup after migration 000267 has
+-- committed its jobs-only rolling barrier. Keep this migration idempotent so
+-- databases that successfully applied the original all-in-one 000267 can move
+-- forward alongside production, where that original migration rolled back.
+
+DELETE FROM session_changeset_leases
+WHERE holder_type = 'readiness';
+
+-- ParseUserSettings decodes with DisallowUnknownFields, so a retired user
+-- preference is a hard decode failure once the new version ships. Org settings
+-- decode leniently; strip them too so the stored documents stay truthful.
+UPDATE organizations
+SET settings = settings
+    #- '{session_automation,automatic_follow_through,readiness_after_review_loop}'
+    #- '{session_automation,automatic_follow_through,readiness_after_review_loop_states}'
+WHERE (settings #> '{session_automation,automatic_follow_through}') ?| ARRAY[
+    'readiness_after_review_loop',
+    'readiness_after_review_loop_states'
+];
+
+UPDATE users
+SET settings = settings
+    #- '{automatic_pr_follow_through,readiness_after_review_loop}'
+WHERE (settings #> '{automatic_pr_follow_through}') ? 'readiness_after_review_loop';
+
+-- Remove the retired event from custom Slack subscriptions. If it was the
+-- only explicit event, pin the preset to custom before producing an empty
+-- array so subscription matching does not fall back to a broader preset.
+UPDATE slack_bot_settings
+SET notification_preset = 'custom'
+WHERE notification_subscriptions->'events' @> '["pr.readiness_attention"]'::jsonb
+  AND NOT EXISTS (
+      SELECT 1
+      FROM jsonb_array_elements(notification_subscriptions->'events') AS item(value)
+      WHERE item.value <> '"pr.readiness_attention"'::jsonb
+  );
+
+UPDATE slack_channel_settings
+SET notification_preset = 'custom'
+WHERE notification_subscriptions->'events' @> '["pr.readiness_attention"]'::jsonb
+  AND NOT EXISTS (
+      SELECT 1
+      FROM jsonb_array_elements(notification_subscriptions->'events') AS item(value)
+      WHERE item.value <> '"pr.readiness_attention"'::jsonb
+  );
+
+UPDATE slack_bot_settings
+SET notification_subscriptions = jsonb_set(
+    notification_subscriptions,
+    '{events}',
+    COALESCE((
+        SELECT jsonb_agg(item.value)
+        FROM jsonb_array_elements(notification_subscriptions->'events') AS item(value)
+        WHERE item.value <> '"pr.readiness_attention"'::jsonb
+    ), '[]'::jsonb)
+)
+WHERE notification_subscriptions->'events' @> '["pr.readiness_attention"]'::jsonb;
+
+UPDATE slack_channel_settings
+SET notification_subscriptions = jsonb_set(
+    notification_subscriptions,
+    '{events}',
+    COALESCE((
+        SELECT jsonb_agg(item.value)
+        FROM jsonb_array_elements(notification_subscriptions->'events') AS item(value)
+        WHERE item.value <> '"pr.readiness_attention"'::jsonb
+    ), '[]'::jsonb)
+)
+WHERE notification_subscriptions->'events' @> '["pr.readiness_attention"]'::jsonb;
+
+ALTER TABLE session_changeset_leases
+    DROP CONSTRAINT session_changeset_leases_holder_type_check,
+    ADD CONSTRAINT session_changeset_leases_holder_type_check
+        CHECK (holder_type IN ('agent_turn', 'materialize', 'publish', 'restack', 'preview'));
+
+DO $$
+BEGIN
+    IF to_regclass('pr_readiness_runs') IS NOT NULL THEN
+        DROP TRIGGER IF EXISTS trg_pr_readiness_assign_primary_changeset ON pr_readiness_runs;
+    END IF;
+END
+$$;
+
+DROP FUNCTION IF EXISTS assign_pr_readiness_primary_changeset();
+
+DROP TABLE IF EXISTS pr_readiness_bypasses;
+DROP TABLE IF EXISTS pr_readiness_checks;
+DROP TABLE IF EXISTS pr_readiness_runs;
+DROP TABLE IF EXISTS pr_readiness_custom_checks;
+DROP TABLE IF EXISTS pr_readiness_policies;
+DROP TABLE IF EXISTS pr_readiness_contexts;


### PR DESCRIPTION
## Summary

PR readiness removal was at risk of getting stuck in a PostgreSQL “dirty” migration state (migration 267), blocking subsequent schema changes and deployments. This PR introduces a safe first rollout by splitting the readiness-state cleanup and adding a narrowly scoped `repair-pr-readiness` command that only clears the known dirty marker for 267—preventing a broad “force bypass” while allowing normal migrations to resume.

## Changes

- Split the migration strategy: keep `267` as a jobs-only barrier and move readiness-state cleanup into a replay-safe `271` workflow.
- Added `cmd/migrate` support for `repair-pr-readiness`, which clears *only* dirty migration version `267` (and refuses to touch any other dirty version).
- Wired the repair step to occur before normal deployment migrations to avoid deployment races.
- Updated migrations/tests and deployment scripts to enforce the safer rollout ordering (plus removed stale/incorrect design references).

## Validation

- `go test ./...`
- `go vet ./...`
- `go build ./...`
- `bash -n deploy/scripts/deploy.sh`
- Focused migration/deployment regression tests
- `git diff --check`

Note: this rollout is intentionally the “safe first deployment.” The follow-up step that removes the temporary trigger and repeats JSON/Slack cleanup is scheduled for a subsequent deployment after the readiness-free fleet has fully rolled, to avoid reopening the rolling-deploy race this guard prevents.

[143.dev](https://143.dev) | [session c517dfe9](https://143.dev/sessions/c517dfe9-de0e-4da7-a616-e0a50eee1cd0)

<!-- 143 readiness -->
**143 readiness:** not available for this revision.

<!-- 143-publication session=c517dfe9-de0e-4da7-a616-e0a50eee1cd0 changeset=6e7946e9-cd55-4339-ba07-cd71fad62169 -->

Preview: https://143.dev/previews/github/assembledhq/143/pull/2018?launch=1