### PR TITLE
Simplify session status indicators to show unread completion dots on left only

### DIFF
--- a/frontend/src/app/(dashboard)/sessions/session-sidebar.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/session-sidebar.test.tsx
@@ -1102,6 +1102,8 @@ describe('SessionSidebar', () => {
     // The unread session title gets "text-foreground" class
     const titleEl = screen.getByText('Unread session');
     expect(titleEl.className).toContain('text-foreground');
+    expect(screen.getByText('(unread)')).toHaveClass('sr-only');
+    expect(document.querySelectorAll('[data-slot="status-indicator"]')).toHaveLength(1);
   });
 
   it('marks sessions with activity but no last_viewed_at as unread', async () => {

--- a/frontend/src/app/(dashboard)/sessions/session-sidebar.tsx
+++ b/frontend/src/app/(dashboard)/sessions/session-sidebar.tsx
@@ -991,19 +991,14 @@ export function SessionSidebar() {
               <div className="min-w-0 flex-1">
                 <div className="flex items-start justify-between gap-2">
                   <p className={cn(
-                    "type-dense flex min-w-0 items-center gap-1.5 font-medium",
+                    "type-dense flex min-w-0 items-center font-medium",
                     hasUnread || isWorkingSession ? "text-foreground" : "text-muted-foreground"
                   )}>
                     <span className={cn(
                       "truncate",
                       hasUnread || isWorkingSession ? "text-foreground" : "text-muted-foreground",
                     )}>{title}</span>
-                    {hasUnread ? (
-                      <span
-                        aria-label="Unread activity"
-                        className="size-1.5 shrink-0 rounded-full bg-primary"
-                      />
-                    ) : null}
+                    {hasUnread ? <span className="sr-only"> (unread)</span> : null}
                   </p>
                 </div>
                 <div className="mt-0.5 flex min-w-0 items-center gap-2">


### PR DESCRIPTION
## Summary

Session status indicators were visually redundant (multiple dots) and risked inconsistent user perception and screen reader output. This change simplifies the sidebar so unread state is conveyed by a single left-side status dot, with stronger visual title contrast for unread sessions and preserved accessibility via hidden “(unread)” text.

## Changes

- Removed the redundant right-side unread dot next to the session title, leaving only the left dot as the visible status indicator.
- For unread sessions, kept the title styling more prominent while adding a screen-reader-only “(unread)” hint.
- Updated/extended `SessionSidebar` tests to assert exactly one status indicator element and that “(unread)” remains `sr-only`.

## Validation

- Ran the test suite: **68 tests passed**.
- ESLint: **focused ESLint passed**.
- Note: automated preview/screenshot wasn’t available because the preview browser operation failed to start.

[143.dev](https://143.dev) | [session b3a98fcd](https://143.dev/sessions/b3a98fcd-c08a-40a2-b7e0-e0d5f4bcf898)

<!-- 143-publication session=b3a98fcd-c08a-40a2-b7e0-e0d5f4bcf898 changeset=42809c47-ff3b-4dd0-8ee3-b1a2c3d7793b -->

Preview: https://143.dev/previews/github/assembledhq/143/pull/2020?launch=1