### PR TITLE
Improve back and sun button responsiveness with offline-ready UI patterns

### DIFF
--- a/frontend/src/app/(dashboard)/sessions/[id]/mobile-session-top-bar.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/mobile-session-top-bar.test.tsx
@@ -58,9 +58,9 @@ describe("MobileSessionTopBar", () => {
       />,
     );
 
-    expect(screen.getByRole("link", { name: "Back to sessions" })).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Open session details" })).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Open session actions" })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Back to sessions" })).toHaveClass("size-11", "sm:size-11");
+    expect(screen.getByRole("button", { name: "Open session details" })).toHaveClass("size-11", "sm:size-11");
+    expect(screen.getByRole("button", { name: "Open session actions" })).toHaveClass("size-11", "sm:size-11");
     expect(screen.queryByRole("tablist", { name: "Agent tabs" })).not.toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "Add agent tab" })).not.toBeInTheDocument();
 

--- a/frontend/src/app/(dashboard)/sessions/[id]/mobile-session-top-bar.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/mobile-session-top-bar.tsx
@@ -86,8 +86,8 @@ export function MobileSessionTopBar({
 
   return (
     <>
-      <div className="sticky top-0 z-20 flex items-center gap-1 border-b border-border bg-background/95 px-2 py-2 backdrop-blur supports-[backdrop-filter]:bg-background/85 md:hidden">
-        <MobileBackButton to={backTo} label="Back to sessions" className="h-9 w-9" />
+      <div className="sticky top-0 z-20 flex items-center gap-1 border-b border-border bg-background/95 px-2 py-1.5 backdrop-blur supports-[backdrop-filter]:bg-background/85 md:hidden">
+        <MobileBackButton to={backTo} label="Back to sessions" />
         <p className="min-w-0 flex-1 truncate text-sm font-medium text-foreground">
           {sessionTitle}
         </p>
@@ -95,23 +95,23 @@ export function MobileSessionTopBar({
           type="button"
           size="icon"
           variant="ghost"
-          className="h-9 w-9 shrink-0"
+          className="size-11 shrink-0 sm:size-11"
           aria-label="Open session actions"
           aria-expanded={actionsOpen}
           onClick={() => setActionsOpen(true)}
         >
-          <MoreVertical className="h-5 w-5" />
+          <MoreVertical className="size-5" />
         </Button>
         <Button
           type="button"
           size="icon"
           variant="ghost"
-          className="h-9 w-9 shrink-0"
+          className="size-11 shrink-0 sm:size-11"
           aria-label={detailButtonLabel}
           aria-controls="session-detail-sheet"
           onClick={onOpenDetails}
         >
-          <PanelBottomOpen className="h-5 w-5" />
+          <PanelBottomOpen className="size-5" />
         </Button>
       </div>
 

--- a/frontend/src/components/connectivity-notice.test.tsx
+++ b/frontend/src/components/connectivity-notice.test.tsx
@@ -1,0 +1,74 @@
+import { act, render, screen } from "@testing-library/react";
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { ConnectivityNotice } from "./connectivity-notice";
+
+const notifySuccess = vi.hoisted(() => vi.fn());
+
+vi.mock("@/lib/notify", () => ({
+  notify: {
+    success: notifySuccess,
+  },
+}));
+
+describe("ConnectivityNotice", () => {
+  const originalOnlineDescriptor = Object.getOwnPropertyDescriptor(
+    Navigator.prototype,
+    "onLine",
+  );
+  let isOnline = true;
+
+  beforeAll(() => {
+    Object.defineProperty(Navigator.prototype, "onLine", {
+      configurable: true,
+      get: () => isOnline,
+    });
+  });
+
+  afterAll(() => {
+    if (originalOnlineDescriptor) {
+      Object.defineProperty(
+        Navigator.prototype,
+        "onLine",
+        originalOnlineDescriptor,
+      );
+    }
+  });
+
+  beforeEach(() => {
+    isOnline = true;
+    notifySuccess.mockReset();
+  });
+
+  it("keeps the current view available while clearly explaining the offline state", () => {
+    isOnline = false;
+    render(<ConnectivityNotice />);
+
+    const notice = screen.getByRole("status");
+    expect(notice).toHaveTextContent("You're offline");
+    expect(notice).toHaveTextContent(
+      "You can keep reading this view",
+    );
+    expect(notice).toHaveClass(
+      "pointer-events-none",
+      "top-[calc(env(safe-area-inset-top)+4rem)]",
+      "z-40",
+      "md:top-4",
+    );
+    expect(notice).not.toHaveClass("bottom-3", "z-50");
+  });
+
+  it("confirms recovery after the browser reconnects", () => {
+    isOnline = false;
+    render(<ConnectivityNotice />);
+
+    act(() => {
+      isOnline = true;
+      window.dispatchEvent(new Event("online"));
+    });
+
+    expect(screen.queryByRole("status")).not.toBeInTheDocument();
+    expect(notifySuccess).toHaveBeenCalledWith("Back online", {
+      description: "Live data and network actions are available again.",
+    });
+  });
+});

--- a/frontend/src/components/connectivity-notice.tsx
+++ b/frontend/src/components/connectivity-notice.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import { WifiOff } from "lucide-react";
+import { useEffect, useRef, useSyncExternalStore } from "react";
+import { Card, CardContent } from "@/components/ui/card";
+import { notify } from "@/lib/notify";
+
+function subscribeToConnectivity(onStoreChange: () => void) {
+  window.addEventListener("online", onStoreChange);
+  window.addEventListener("offline", onStoreChange);
+
+  return () => {
+    window.removeEventListener("online", onStoreChange);
+    window.removeEventListener("offline", onStoreChange);
+  };
+}
+
+function getOnlineSnapshot() {
+  return navigator.onLine;
+}
+
+function getServerOnlineSnapshot() {
+  return true;
+}
+
+export function ConnectivityNotice() {
+  const isOnline = useSyncExternalStore(
+    subscribeToConnectivity,
+    getOnlineSnapshot,
+    getServerOnlineSnapshot,
+  );
+  const previousOnlineRef = useRef(true);
+
+  useEffect(() => {
+    if (isOnline && !previousOnlineRef.current) {
+      notify.success("Back online", {
+        description: "Live data and network actions are available again.",
+      });
+    }
+    previousOnlineRef.current = isOnline;
+  }, [isOnline]);
+
+  if (isOnline) return null;
+
+  return (
+    <Card
+      variant="elevated"
+      role="status"
+      aria-live="polite"
+      className="pointer-events-none fixed inset-x-3 top-[calc(env(safe-area-inset-top)+4rem)] z-40 mx-auto max-w-md border-warning/35 bg-card md:top-4"
+    >
+      <CardContent className="flex items-start gap-3 px-3 py-2.5">
+        <WifiOff className="mt-0.5 size-4 shrink-0 text-warning" aria-hidden="true" />
+        <div className="min-w-0">
+          <p className="text-sm font-medium text-foreground">You&apos;re offline</p>
+          <p className="text-xs text-muted-foreground">
+            You can keep reading this view. Some data and actions will be available after you reconnect.
+          </p>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/frontend/src/components/docs/docs-theme-switch.test.tsx
+++ b/frontend/src/components/docs/docs-theme-switch.test.tsx
@@ -1,0 +1,44 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { DocsThemeSwitch } from "./docs-theme-switch";
+
+const themeState = vi.hoisted(() => ({
+  theme: "dark" as string | undefined,
+  resolvedTheme: "dark" as string | undefined,
+  setTheme: vi.fn(),
+}));
+
+vi.mock("next-themes", () => ({
+  useTheme: () => themeState,
+}));
+
+describe("DocsThemeSwitch", () => {
+  beforeEach(() => {
+    themeState.theme = "dark";
+    themeState.resolvedTheme = "dark";
+    themeState.setTheme.mockReset();
+  });
+
+  it("exposes separate local controls with an unambiguous selected theme", async () => {
+    const user = userEvent.setup();
+    render(<DocsThemeSwitch />);
+
+    const lightButton = screen.getByRole("button", { name: "Light theme" });
+    const darkButton = screen.getByRole("button", { name: "Dark theme" });
+
+    expect(lightButton).toHaveAttribute("aria-pressed", "false");
+    expect(lightButton).toHaveClass("size-11", "sm:size-11", "md:size-7");
+    expect(darkButton).toHaveAttribute("aria-pressed", "true");
+
+    await user.click(lightButton);
+
+    expect(themeState.setTheme).toHaveBeenCalledWith("light");
+  });
+
+  it("includes the system preference only when the full mode is requested", () => {
+    render(<DocsThemeSwitch mode="light-dark-system" />);
+
+    expect(screen.getByRole("button", { name: "Use system theme" })).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/docs/docs-theme-switch.tsx
+++ b/frontend/src/components/docs/docs-theme-switch.tsx
@@ -1,14 +1,81 @@
 "use client";
 
-import { ThemeSwitch, type ThemeSwitchProps } from "fumadocs-ui/layouts/shared/slots/theme-switch";
+import type { ThemeSwitchProps } from "fumadocs-ui/layouts/shared/slots/theme-switch";
+import { Monitor, Moon, Sun } from "lucide-react";
+import { useTheme } from "next-themes";
+import { useSyncExternalStore } from "react";
+import { Button } from "@/components/ui/button";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { cn } from "@/lib/utils";
 
-export function DocsThemeSwitch({ className: _className, ...props }: ThemeSwitchProps) {
-  void _className;
+const themeOptions = [
+  { value: "light", label: "Light theme", icon: Sun },
+  { value: "dark", label: "Dark theme", icon: Moon },
+  { value: "system", label: "Use system theme", icon: Monitor },
+] as const;
+
+const emptySubscribe = () => () => {};
+
+export function DocsThemeSwitch({
+  className,
+  mode = "light-dark",
+  ...props
+}: ThemeSwitchProps) {
+  const { resolvedTheme, setTheme, theme } = useTheme();
+  const mounted = useSyncExternalStore(emptySubscribe, () => true, () => false);
+  const options = mode === "light-dark-system" ? themeOptions : themeOptions.slice(0, 2);
+  const selectedTheme = mounted
+    ? mode === "light-dark-system"
+      ? theme
+      : resolvedTheme
+    : undefined;
 
   return (
-    <ThemeSwitch
-      {...props}
-      className="h-8 rounded-lg border border-border bg-background p-0.5 shadow-sm *:rounded-md"
-    />
+    <TooltipProvider>
+      <div
+        {...props}
+        role="group"
+        aria-label="Theme"
+        className={cn(
+          "inline-flex items-center rounded-lg border border-border bg-background p-0.5 shadow-sm",
+          className,
+        )}
+      >
+        {options.map(({ value, label, icon: Icon }) => {
+          const isSelected = selectedTheme === value;
+
+          return (
+            <Tooltip key={value}>
+              <TooltipTrigger asChild>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon-sm"
+                  aria-label={label}
+                  aria-pressed={isSelected}
+                  onClick={() => setTheme(value)}
+                  className={cn(
+                    "size-11 touch-manipulation rounded-md text-muted-foreground shadow-none active:scale-[0.92] sm:size-11 md:size-7",
+                    isSelected && "bg-accent text-foreground",
+                  )}
+                >
+                  <Icon
+                    className="size-4"
+                    fill={isSelected ? "currentColor" : "none"}
+                    aria-hidden="true"
+                  />
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent side="bottom" sideOffset={6}>{label}</TooltipContent>
+            </Tooltip>
+          );
+        })}
+      </div>
+    </TooltipProvider>
   );
 }

--- a/frontend/src/components/mobile-back-button.test.tsx
+++ b/frontend/src/components/mobile-back-button.test.tsx
@@ -1,0 +1,75 @@
+import type { AnchorHTMLAttributes, ReactNode } from "react";
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { MobileBackButton } from "./mobile-back-button";
+
+vi.mock("next/link", () => ({
+  default: ({
+    children,
+    href,
+    onClick,
+    ...props
+  }: AnchorHTMLAttributes<HTMLAnchorElement> & {
+    children: ReactNode;
+    href: string;
+  }) => (
+    <a
+      href={href}
+      onClick={(event) => {
+        onClick?.(event);
+        event.preventDefault();
+      }}
+      {...props}
+    >
+      {children}
+    </a>
+  ),
+}));
+
+vi.mock("next/navigation", () => ({
+  useSearchParams: () => new URLSearchParams("repo=assembledhq%2F143"),
+}));
+
+describe("MobileBackButton", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("acknowledges a route transition immediately and preserves list state", () => {
+    render(
+      <MobileBackButton to="/sessions" label="Back to sessions" />,
+    );
+
+    const link = screen.getByRole("link", { name: "Back to sessions" });
+    expect(link).toHaveAttribute(
+      "href",
+      "/sessions?repo=assembledhq%2F143",
+    );
+    expect(link).toHaveClass("size-11", "sm:size-11", "md:hidden");
+
+    fireEvent.click(link);
+
+    expect(
+      screen.getByRole("link", { name: "Back to sessions, loading" }),
+    ).toHaveAttribute("aria-busy", "true");
+  });
+
+  it("releases the pending state when a slow transition cannot finish", () => {
+    render(
+      <MobileBackButton to="/sessions" label="Back to sessions" />,
+    );
+
+    fireEvent.click(screen.getByRole("link", { name: "Back to sessions" }));
+    act(() => {
+      vi.advanceTimersByTime(8_000);
+    });
+
+    expect(
+      screen.getByRole("link", { name: "Back to sessions" }),
+    ).not.toHaveAttribute("aria-busy");
+  });
+});

--- a/frontend/src/components/mobile-back-button.tsx
+++ b/frontend/src/components/mobile-back-button.tsx
@@ -1,9 +1,13 @@
 "use client";
 
-import { ChevronLeft } from "lucide-react";
+import { ChevronLeft, Loader2 } from "lucide-react";
 import Link from "next/link";
 import { useSearchParams } from "next/navigation";
+import { useEffect, useState } from "react";
+import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
+
+const NAVIGATION_FEEDBACK_TIMEOUT_MS = 8_000;
 
 interface MobileBackButtonProps {
   /** Destination list path, e.g. "/sessions" or "/previews". Search params from
@@ -15,19 +19,58 @@ interface MobileBackButtonProps {
 
 export function MobileBackButton({ to, label, className }: MobileBackButtonProps) {
   const searchParams = useSearchParams();
+  const [isNavigating, setIsNavigating] = useState(false);
   const qs = searchParams.toString();
   const href = qs ? `${to}?${qs}` : to;
 
+  // A route transition can wait on an RSC response when connectivity is poor.
+  // Keep the acknowledgement immediate, but release the control if navigation
+  // cannot finish so a failed request never leaves the UI looking frozen.
+  useEffect(() => {
+    if (!isNavigating) return;
+
+    const timeout = window.setTimeout(
+      () => setIsNavigating(false),
+      NAVIGATION_FEEDBACK_TIMEOUT_MS,
+    );
+    return () => window.clearTimeout(timeout);
+  }, [isNavigating]);
+
   return (
-    <Link
-      href={href}
-      aria-label={label}
+    <Button
+      asChild
+      variant="ghost"
+      size="icon"
       className={cn(
-        "md:hidden inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-md text-muted-foreground hover:bg-accent hover:text-foreground",
+        "size-11 touch-manipulation text-muted-foreground active:scale-[0.94] sm:size-11 md:hidden",
+        isNavigating && "bg-accent text-foreground",
         className,
       )}
     >
-      <ChevronLeft className="h-5 w-5" />
-    </Link>
+      <Link
+        href={href}
+        aria-label={isNavigating ? `${label}, loading` : label}
+        aria-busy={isNavigating || undefined}
+        onClick={(event) => {
+          if (
+            event.defaultPrevented ||
+            event.button !== 0 ||
+            event.metaKey ||
+            event.ctrlKey ||
+            event.shiftKey ||
+            event.altKey
+          ) {
+            return;
+          }
+          setIsNavigating(true);
+        }}
+      >
+        {isNavigating ? (
+          <Loader2 className="size-5 animate-spin" aria-hidden="true" />
+        ) : (
+          <ChevronLeft className="size-5" aria-hidden="true" />
+        )}
+      </Link>
+    </Button>
   );
 }

--- a/frontend/src/components/providers.tsx
+++ b/frontend/src/components/providers.tsx
@@ -4,6 +4,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { NuqsAdapter } from "nuqs/adapters/next/app";
 import { useState, useEffect, useRef } from "react";
 import { ErrorBoundary } from "@/components/error-boundary";
+import { ConnectivityNotice } from "@/components/connectivity-notice";
 import { ThemeProvider } from "@/components/theme-provider";
 import { DocumentTitle } from "@/components/document-title";
 import { ACTIVE_ORG_CHANGED_EVENT, getActiveOrgId } from "@/lib/active-org";
@@ -129,6 +130,7 @@ export function Providers({ children }: { children: React.ReactNode }) {
           <ErrorBoundary>
             <DocumentTitle />
             {children}
+            <ConnectivityNotice />
           </ErrorBoundary>
         </QueryClientProvider>
       </NuqsAdapter>


### PR DESCRIPTION
## Summary

Mobile session headers and back/sun controls were inconsistent at the mobile breakpoint, and the offline notice could visually/interaction-block core UI (composers/actions/dialogs). This change keeps back/action buttons at the intended 44px size across the full mobile range and reworks the connectivity banner to be non-interfering and correctly layered for offline-ready usage.

## Changes

- Standardize mobile header control sizing: remove the header-level 36px override and align MobileBackButton + session header action buttons to `size-11`/`sm:size-11` (44px) for consistent tap targets.  
- Improve back and action icon sizing in `MobileSessionTopBar` by switching from fixed `h-/w-` to `size-*` classes.  
- Update offline notice behavior: reposition below mobile headers, set `z-40`, and disable pointer interaction so it cannot block users from interacting with the page while offline.  

## Validation

- Ran updated unit/component tests for session top bar, mobile back button, and connectivity notice (`*.test.tsx`).  
- `TypeScript` and `ESLint` checks pass.  
- Note: preview/screenshot service timed out during package-cache restoration, so visual screenshot verification was unavailable.

[143.dev](https://143.dev) | [session 2f7ed92b](https://143.dev/sessions/2f7ed92b-d7e4-4389-9a82-a5b00071c03a)

<!-- 143-publication session=2f7ed92b-d7e4-4389-9a82-a5b00071c03a changeset=ef5798e4-8344-4162-84d6-e6c6c809f091 -->

Preview: https://143.dev/previews/github/assembledhq/143/pull/2021?launch=1