### PR TITLE
Center PR creation spinner alignment with session detail list dots

### DIFF
--- a/frontend/src/components/status-indicator.test.tsx
+++ b/frontend/src/components/status-indicator.test.tsx
@@ -19,6 +19,20 @@ describe("StatusIndicator", () => {
     expect(container.querySelectorAll('[data-slot="status-indicator-core"]')).toHaveLength(1);
   });
 
+  it("centers an indeterminate spinner in the same alignment box as a static dot", () => {
+    const { container, rerender } = render(<StatusIndicator tone="primary" activity="indeterminate" />);
+
+    expect(container.querySelector('[data-slot="status-indicator"]')).toHaveClass(
+      "size-2",
+      "items-center",
+      "justify-center",
+    );
+    expect(container.querySelector('[data-slot="status-indicator-spinner"]')).toHaveClass("size-3");
+
+    rerender(<StatusIndicator tone="success" />);
+    expect(container.querySelector('[data-slot="status-indicator"]')).toHaveClass("size-2");
+  });
+
   it("settles once when operational state changes", () => {
     const animate = vi.fn();
     const { container, rerender } = render(<StatusIndicator tone="primary" activity="breathing" stateKey="running" />);

--- a/frontend/src/components/status-indicator.tsx
+++ b/frontend/src/components/status-indicator.tsx
@@ -62,12 +62,17 @@ export function StatusIndicator({
 
   if (activity === "indeterminate") {
     return (
-      <LoaderCircle
+      <span
         data-slot="status-indicator"
         data-activity={activity}
         aria-hidden="true"
-        className={cn("status-indeterminate shrink-0", dimensions.spinner, colors.text, className)}
-      />
+        className={cn("inline-flex shrink-0 items-center justify-center", dimensions.wrapper, className)}
+      >
+        <LoaderCircle
+          data-slot="status-indicator-spinner"
+          className={cn("status-indeterminate shrink-0", dimensions.spinner, colors.text)}
+        />
+      </span>
     );
   }
 


### PR DESCRIPTION
## Summary

Indeterminate status indicators were not consistently centered with the same layout box used by static dots, creating a subtle alignment mismatch in session/detail lists. This change wraps the indeterminate `LoaderCircle` in a centered container that uses the same alignment classes as the dot, while keeping the spinner’s animation and accessibility behavior unchanged.

## Changes

- Refactor `StatusIndicator` indeterminate rendering to use an outer `<span>` (`data-slot="status-indicator"`) with `items-center`/`justify-center` layout.
- Add a dedicated `data-slot="status-indicator-spinner"` on the inner `LoaderCircle` to preserve styling/testing separation.
- Add/extend unit tests to assert the wrapper alignment classes and that spinner sizing/behavior remains stable across prop changes.

## Validation

- Frontend tests: updated/added unit coverage in `frontend/src/components/status-indicator.test.tsx`
- CI: run existing test suite (session-list indicator-related tests + ESLint as configured in pipeline)

[143.dev](https://143.dev) | [session 3c7b0674](https://143.dev/sessions/3c7b0674-04b5-4309-9d10-92237f5a1dbd)

<!-- 143-publication session=3c7b0674-04b5-4309-9d10-92237f5a1dbd changeset=1fc3cb1b-b0b2-47ff-8d10-b93b00b51a4e -->

Preview: https://143.dev/previews/github/assembledhq/143/pull/2022?launch=1