### PR TITLE
Fix WorkerSelector SelectCachePlacementWorkerBatchesCapacityChecks timeout on dependency cache worker lookup

### DIFF
--- a/internal/services/preview/worker_routing_test.go
+++ b/internal/services/preview/worker_routing_test.go
@@ -779,6 +779,9 @@ func TestWorkerSelector_SelectCachePlacementWorkerBatchesCapacityChecks(t *testi
 			AddRow("worker-2", 0))
 
 	selector := NewWorkerSelectorWithMaxPerWorker(db.NewNodeStore(mock), db.NewPreviewStore(mock), 2)
+	// Keep this mocked database test independent of scheduler delays under
+	// coverage instrumentation in CI without changing the production timeout.
+	selector.cacheLookupTimeout = 5 * time.Second
 	worker, ok, err := selector.selectCachePlacementWorker(context.Background(), orgID, repoID, []WorkerCachePlacement{{Kind: models.PreviewCacheKindInstallArtifact, PlacementKey: "placement"}}, true, WorkerSelectionRequirements{})
 	require.NoError(t, err, "cache placement worker lookup should not fail")
 	require.True(t, ok, "cache placement worker lookup should find a candidate")


### PR DESCRIPTION
## Summary

Fixes a flaky test in `TestWorkerSelector_SelectCachePlacementWorkerBatchesCapacityChecks` caused by CI scheduler/coverage delays during a cache worker lookup. This change keeps the production behavior intact by overriding the selector’s *test-only* cache lookup timeout to 5s, instead of the production 250ms.

## Changes

- Set `selector.cacheLookupTimeout = 5 * time.Second` inside the affected unit test to prevent intermittent lookup failures under CI load.
- Added a comment clarifying that production timeout behavior is unchanged and this is only to keep the mocked DB test reliable.

## Validation

- Ran targeted test: 100 iterations
- Ran full preview package with coverage: 3 iterations
- Ran targeted race test: 50 iterations
- `git diff --check` clean

[143.dev](https://143.dev) | [session 1780ceae](https://143.dev/sessions/1780ceae-5bd7-4814-9c33-3ef28424b286)

<!-- 143-publication session=1780ceae-5bd7-4814-9c33-3ef28424b286 changeset=1412b304-b50b-49b6-83e8-52d927f05997 -->

Preview: https://143.dev/previews/github/assembledhq/143/pull/2024?launch=1