### PR TITLE
Enable decimal precision for median rounding to approval value display

### DIFF
--- a/frontend/src/app/(dashboard)/code-reviews/page.test.tsx
+++ b/frontend/src/app/(dashboard)/code-reviews/page.test.tsx
@@ -662,7 +662,7 @@ describe("CodeReviewsPage", () => {
     expect(within(approvalOutcomes).getByText("First sent to 143 in this period")).toBeInTheDocument();
     expect(within(approvalOutcomes).getByText("17")).toBeInTheDocument();
     expect(within(approvalOutcomes).getByText("53%")).toBeInTheDocument();
-    expect(within(approvalOutcomes).getByText("2")).toBeInTheDocument();
+    expect(within(approvalOutcomes).getByText("2.0")).toBeInTheDocument();
     expect(within(approvalOutcomes).queryByText("128")).not.toBeInTheDocument();
     expect(screen.getByText("Approval by round")).toBeInTheDocument();
     expect(screen.getByText("Why PRs were not approved right away")).toBeInTheDocument();
@@ -702,14 +702,14 @@ describe("CodeReviewsPage", () => {
       "3",
       "75%",
       "6",
-      "2",
+      "2.0",
       "+52",
       "-20",
     ]);
     expect(within(authorTable).getByText("Overall")).toBeInTheDocument();
     expect(within(authorTable).getByLabelText("32 PRs reviewed overall")).toHaveTextContent("32");
     expect(within(authorTable).getByLabelText("53% overall approval rate")).toHaveTextContent("53%");
-    expect(within(authorTable).getByLabelText("2 median rounds to approval overall")).toHaveTextContent("2");
+    expect(within(authorTable).getByLabelText("2.0 median rounds to approval overall")).toHaveTextContent("2.0");
     expect(within(anyaRow).getByRole("link", { name: "12 reviewed PRs by anya" })).toHaveAttribute(
       "href",
       "/code-reviews?tab=reviews&author=anya&range=30d",

--- a/frontend/src/components/code-review-analytics.test.tsx
+++ b/frontend/src/components/code-review-analytics.test.tsx
@@ -92,6 +92,22 @@ describe("CodeReviewAnalyticsReport PR cohort states", () => {
     expect(screen.getByText(/3 PRs had a failed attempt/)).toBeInTheDocument();
   });
 
+  it("shows median rounds to approval with one decimal place", () => {
+    const analytics = emptyAnalytics(3);
+    analytics.summary.approved_by_143 = 2;
+    analytics.summary.median_rounds_to_approval = 1.5;
+    analytics.authors[0]!.approved_by_143 = 2;
+    analytics.authors[0]!.median_rounds_to_approval = 1.5;
+    renderReport(analytics);
+
+    const outcomes = screen.getByLabelText("Approval outcomes");
+    expect(within(outcomes).getByText("1.5")).toBeInTheDocument();
+
+    const authorTable = screen.getByRole("table", { name: "Code review analytics by PR author" });
+    expect(within(authorTable).getAllByText("1.5")).toHaveLength(2);
+    expect(within(authorTable).getByLabelText("1.5 median rounds to approval overall")).toHaveTextContent("1.5");
+  });
+
   it("reports how many PRs backed the author medians", () => {
     const analytics = emptyAnalytics(4);
     analytics.summary.prs_with_change_breakdown = 1;

--- a/frontend/src/components/code-review-analytics.tsx
+++ b/frontend/src/components/code-review-analytics.tsx
@@ -62,6 +62,14 @@ function roundedMetric(value: number | null): string {
   return Math.round(value).toLocaleString();
 }
 
+function decimalMetric(value: number | null): string {
+  if (value === null || !Number.isFinite(value)) return "—";
+  return value.toLocaleString(undefined, {
+    minimumFractionDigits: 1,
+    maximumFractionDigits: 1,
+  });
+}
+
 function signedRoundedMetric(value: number | null, sign: "+" | "-"): string {
   const formatted = roundedMetric(value);
   return formatted === "—" ? formatted : `${sign}${formatted}`;
@@ -185,7 +193,7 @@ function ApprovalOutcomeCards({ summary }: { summary: CodeReviewAnalytics["summa
       />
       <MetricCard
         label="Median rounds to approval"
-        value={roundedMetric(summary.median_rounds_to_approval)}
+        value={decimalMetric(summary.median_rounds_to_approval)}
         context="Approved PRs only"
       />
     </div>
@@ -375,7 +383,7 @@ export function CodeReviewAnalyticsReport({
                       {percentage(author.approved_by_143, author.prs_reviewed)}
                     </TableCell>
                     <TableCell className="text-right tabular-nums">{author.approved_first_round.toLocaleString()}</TableCell>
-                    <TableCell className="text-right tabular-nums">{roundedMetric(author.median_rounds_to_approval)}</TableCell>
+                    <TableCell className="text-right tabular-nums">{decimalMetric(author.median_rounds_to_approval)}</TableCell>
                     <TableCell className="text-right tabular-nums">{signedRoundedMetric(author.median_additions, "+")}</TableCell>
                     <TableCell className="text-right tabular-nums">{signedRoundedMetric(author.median_deletions, "-")}</TableCell>
                   </TableRow>
@@ -410,11 +418,11 @@ export function CodeReviewAnalyticsReport({
                     ariaLabel: `${summary.approved_first_round.toLocaleString()} PRs approved in the first round overall`,
                   },
                   {
-                    content: roundedMetric(summary.median_rounds_to_approval),
+                    content: decimalMetric(summary.median_rounds_to_approval),
                     className: "text-right",
                     ariaLabel: summary.median_rounds_to_approval === null
                       ? "No rounds to approval data overall"
-                      : `${roundedMetric(summary.median_rounds_to_approval)} median rounds to approval overall`,
+                      : `${decimalMetric(summary.median_rounds_to_approval)} median rounds to approval overall`,
                   },
                   {
                     content: signedRoundedMetric(summary.median_additions, "+"),


### PR DESCRIPTION
## Summary

“Median rounds to approval” was being rendered inconsistently (rounded to an integer in some places), creating confusion in the code review analytics dashboard and making it harder to compare values across headline cards and author rows. This change formats the median with a single decimal place everywhere (e.g., `1.5`, `2.0`) and adds regression coverage for decimal inputs to prevent future formatting drift.

## Changes

- Added `decimalMetric()` to format finite values with exactly one decimal place, keeping `—` for missing/invalid data.
- Updated the “median rounds to approval” UI labels and values so both the overall summary and per-author rows show `x.y` consistently.
- Adjusted existing page and component tests to assert decimal rendering (e.g., expecting `2.0` instead of `2`).

## Validation

- `66` focused tests passed
- ESLint passed
- Visual preview unavailable (all preview slots occupied)

[143.dev](https://143.dev) | [session 62bf752f](https://143.dev/sessions/62bf752f-7d11-43e2-8c23-6efbb86316f9)

<!-- 143-publication session=62bf752f-7d11-43e2-8c23-6efbb86316f9 changeset=17cc9877-d0f7-48eb-bd7c-97596965d8ee -->

Preview: https://143.dev/previews/github/assembledhq/143/pull/2025?launch=1