### PR TITLE
Fix time range edge-month rendering to show dates only for selected month(s)

### DIFF
--- a/frontend/src/components/code-review-overview.test.tsx
+++ b/frontend/src/components/code-review-overview.test.tsx
@@ -39,6 +39,23 @@ describe("TimeRangePicker", () => {
     expect(timeRangeLabel("custom:2026-07-01:2026-07-31")).toBe("Jul 1, 2026 – Jul 31, 2026");
   });
 
+  it("shows boundary dates only in their owning month", async () => {
+    const user = userEvent.setup();
+    render(
+      <TimeRangePicker
+        label="Time window"
+        value="custom:2026-07-30:2026-08-01"
+        onValueChange={vi.fn()}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Time window" }));
+
+    for (const date of [new Date(2026, 6, 30), new Date(2026, 6, 31), new Date(2026, 7, 1)]) {
+      expect(document.querySelectorAll(`[data-day="${date.toLocaleDateString()}"]`)).toHaveLength(1);
+    }
+  });
+
   it("applies a custom range after both dates are selected", async () => {
     const user = userEvent.setup();
     const onValueChange = vi.fn();

--- a/frontend/src/components/time-range-picker.tsx
+++ b/frontend/src/components/time-range-picker.tsx
@@ -135,6 +135,7 @@ export function TimeRangePicker({
                 onSelect={(nextRange) => setDraft(nextRange ?? { from: undefined, to: undefined })}
                 defaultMonth={draft.from}
                 numberOfMonths={2}
+                showOutsideDays={false}
                 disabled={{ after: today }}
                 resetOnSelect
                 className="mx-auto"


### PR DESCRIPTION
## Summary

Time-range selection could show the same boundary dates in adjacent month calendars, confusing users and increasing the risk of selecting/confirming the wrong date. This change updates the `TimeRangePicker` to hide “outside” days so dates only appear in their owning month, and adds a regression test covering a July/August boundary range.

## Changes

- Set `showOutsideDays={false}` on the month-range picker so boundary dates are rendered only in the month that owns them.
- Added a regression test to verify that range boundaries (`2026-07-30` to `2026-08-01`) appear exactly once for their respective months.

## Validation

- Added test: `shows boundary dates only in their owning month` in `code-review-overview.test.tsx`
- All 9 focused tests pass
- ESLint passes

[143.dev](https://143.dev) | [session 7f27690f](https://143.dev/sessions/7f27690f-da5c-4b58-99d1-54dd3e3673a0)

<!-- 143-publication session=7f27690f-da5c-4b58-99d1-54dd3e3673a0 changeset=f8abaf6c-520e-4e43-888d-5d5e15a293d8 -->

Preview: https://143.dev/previews/github/assembledhq/143/pull/2026?launch=1