### PR TITLE
Replace code review heading subdescriptions with hover infotooltips for metric definitions

### DIFF
--- a/frontend/src/app/(dashboard)/code-reviews/page.test.tsx
+++ b/frontend/src/app/(dashboard)/code-reviews/page.test.tsx
@@ -495,10 +495,10 @@ describe("CodeReviewsPage", () => {
     expect(within(stats).getByText("128")).toBeInTheDocument();
     expect(within(stats).getByText("Automatically approved")).toBeInTheDocument();
     expect(within(stats).getByText("92")).toBeInTheDocument();
-    expect(within(stats).getByText("72% of completed reviews")).toBeInTheDocument();
+    expect(within(stats).getByRole("button", { name: "About Automatically approved" })).toBeInTheDocument();
     expect(within(stats).getByText("Approval rate")).toBeInTheDocument();
     expect(within(stats).getByText("72%")).toBeInTheDocument();
-    expect(within(stats).getByText("21 need human review")).toBeInTheDocument();
+    expect(within(stats).getByRole("button", { name: "About Approval rate" })).toBeInTheDocument();
     expect(within(stats).getByText("Median turnaround")).toBeInTheDocument();
     expect(within(stats).getByText("8m")).toBeInTheDocument();
     const timeWindow = screen.getByRole("button", { name: "Time window" });
@@ -659,7 +659,7 @@ describe("CodeReviewsPage", () => {
     expect(screen.queryByRole("region", { name: "Code review statistics" })).not.toBeInTheDocument();
     const approvalOutcomes = screen.getByLabelText("Approval outcomes");
     expect(within(approvalOutcomes).getByText("32")).toBeInTheDocument();
-    expect(within(approvalOutcomes).getByText("First sent to 143 in this period")).toBeInTheDocument();
+    expect(within(approvalOutcomes).getByRole("button", { name: "About PRs reviewed" })).toBeInTheDocument();
     expect(within(approvalOutcomes).getByText("17")).toBeInTheDocument();
     expect(within(approvalOutcomes).getByText("53%")).toBeInTheDocument();
     expect(within(approvalOutcomes).getByText("2")).toBeInTheDocument();
@@ -790,7 +790,7 @@ describe("CodeReviewsPage", () => {
     renderWithProviders(<CodeReviewsPage />, { nuqsHasMemory: true });
     await user.click(await screen.findByRole("tab", { name: "Analytics" }));
 
-    expect(await screen.findByText("First sent to 143 in this period")).toBeInTheDocument();
+    expect(await screen.findByRole("button", { name: "About PRs reviewed" })).toBeInTheDocument();
     expect(screen.getByText(/4 PRs had a failed attempt/)).toBeInTheDocument();
     expect(screen.getByText("Not yet approved")).toBeInTheDocument();
   });

--- a/frontend/src/components/code-review-analytics.test.tsx
+++ b/frontend/src/components/code-review-analytics.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
 import { CodeReviewAnalyticsReport } from "@/components/code-review-analytics";
 import type { CodeReviewAnalytics } from "@/lib/types";
@@ -64,6 +65,29 @@ function renderReport(analytics: CodeReviewAnalytics) {
 }
 
 describe("CodeReviewAnalyticsReport PR cohort states", () => {
+  it("shows headline metric definitions in tooltips without subdescriptions", async () => {
+    const user = userEvent.setup();
+    const analytics = emptyAnalytics(4);
+    analytics.summary.approved_by_143 = 2;
+    analytics.summary.median_rounds_to_approval = 2;
+    renderReport(analytics);
+
+    const outcomes = screen.getByLabelText("Approval outcomes");
+    expect(within(outcomes).queryByText("First sent to 143 in this period")).not.toBeInTheDocument();
+    expect(within(outcomes).queryByText("50% of PRs reviewed")).not.toBeInTheDocument();
+    expect(within(outcomes).queryByText("Approved PRs only")).not.toBeInTheDocument();
+
+    const trigger = within(outcomes).getByRole("button", { name: "About Median rounds to approval" });
+    await user.hover(trigger);
+    expect(await screen.findByRole("tooltip")).toHaveTextContent(
+      "The median number of distinct completed revisions before 143 first posted an approval, among approved pull requests.",
+    );
+
+    expect(within(outcomes).getByRole("button", { name: "About PRs reviewed" })).toBeInTheDocument();
+    expect(within(outcomes).getByRole("button", { name: "About Approved by 143" })).toBeInTheDocument();
+    expect(within(outcomes).getByRole("button", { name: "About Approval rate" })).toBeInTheDocument();
+  });
+
   it("shows PR-oriented empty copy when the cohort has no PRs", () => {
     renderReport(emptyAnalytics());
 

--- a/frontend/src/components/code-review-analytics.tsx
+++ b/frontend/src/components/code-review-analytics.tsx
@@ -5,6 +5,7 @@ import type { ReactNode } from "react";
 import { ChartNoAxesColumnIncreasing } from "lucide-react";
 import { DataTableSummaryRow } from "@/components/data-table-summary-row";
 import { EmptyState } from "@/components/empty-state";
+import { MetricInfoTooltip } from "@/components/metric-info-tooltip";
 import { SectionGroup } from "@/components/section-group";
 import { Badge } from "@/components/ui/badge";
 import { SortableTableHeader, sortDirectionAriaValue } from "@/components/sortable-table-header";
@@ -146,17 +147,22 @@ function MetricCard({
   label,
   value,
   context,
+  definition,
 }: {
   label: string;
   value: string;
-  context: string;
+  context?: string;
+  definition?: string;
 }) {
   return (
     <Card>
       <CardContent className="space-y-1.5">
-        <p className="text-xs font-medium text-muted-foreground">{label}</p>
+        <div className="flex items-center gap-1 text-xs font-medium text-muted-foreground">
+          <span>{label}</span>
+          {definition ? <MetricInfoTooltip label={label} definition={definition} /> : null}
+        </div>
         <p className="text-2xl font-semibold tabular-nums text-foreground">{value}</p>
-        <p className="text-xs text-muted-foreground">{context}</p>
+        {context ? <p className="text-xs text-muted-foreground">{context}</p> : null}
       </CardContent>
     </Card>
   );
@@ -171,22 +177,22 @@ function ApprovalOutcomeCards({ summary }: { summary: CodeReviewAnalytics["summa
       <MetricCard
         label="PRs reviewed"
         value={summary.prs_reviewed.toLocaleString()}
-        context="First sent to 143 in this period"
+        definition="Unique pull requests first sent to 143 during the selected time period."
       />
       <MetricCard
         label="Approved by 143"
         value={summary.approved_by_143.toLocaleString()}
-        context={`${percentage(summary.approved_by_143, summary.prs_reviewed)} of PRs reviewed`}
+        definition="Reviewed pull requests where 143 posted an approval on GitHub."
       />
       <MetricCard
         label="Approval rate"
         value={percentage(summary.approved_by_143, summary.prs_reviewed)}
-        context={`${summary.approved_by_143.toLocaleString()} approved PRs`}
+        definition="The percentage of reviewed pull requests where 143 posted an approval on GitHub."
       />
       <MetricCard
         label="Median rounds to approval"
         value={roundedMetric(summary.median_rounds_to_approval)}
-        context="Approved PRs only"
+        definition="The median number of distinct completed revisions before 143 first posted an approval, among approved pull requests."
       />
     </div>
   );

--- a/frontend/src/components/code-review-overview.test.tsx
+++ b/frontend/src/components/code-review-overview.test.tsx
@@ -2,9 +2,43 @@ import { render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
 import { subDays } from "date-fns";
-import { formatReviewTurnaround } from "./code-review-overview";
+import { CodeReviewSummaryCards, formatReviewTurnaround } from "./code-review-overview";
 import { TimeRangePicker, timeRangeLabel } from "./time-range-picker";
 import { customTimeRange } from "@/lib/time-range";
+
+describe("CodeReviewSummaryCards", () => {
+  it("moves metric definitions from subdescriptions into heading tooltips", async () => {
+    const user = userEvent.setup();
+    render(
+      <CodeReviewSummaryCards
+        stats={{
+          reviews_completed: 128,
+          automatically_approved: 92,
+          needs_human_review: 21,
+          median_turnaround_seconds: 480,
+        }}
+        isLoading={false}
+        isError={false}
+        onRetry={vi.fn()}
+      />,
+    );
+
+    const summary = screen.getByRole("region", { name: "Code review statistics" });
+    expect(within(summary).queryByText("72% of completed reviews")).not.toBeInTheDocument();
+    expect(within(summary).queryByText("21 need human review")).not.toBeInTheDocument();
+    expect(within(summary).queryByText("Queued to completed")).not.toBeInTheDocument();
+
+    const trigger = within(summary).getByRole("button", { name: "About Approval rate" });
+    await user.hover(trigger);
+    expect(await screen.findByRole("tooltip")).toHaveTextContent(
+      "The percentage of completed review sessions where 143 posted an approval on GitHub.",
+    );
+
+    expect(within(summary).getByRole("button", { name: "About Reviews completed" })).toBeInTheDocument();
+    expect(within(summary).getByRole("button", { name: "About Automatically approved" })).toBeInTheDocument();
+    expect(within(summary).getByRole("button", { name: "About Median turnaround" })).toBeInTheDocument();
+  });
+});
 
 describe("formatReviewTurnaround", () => {
   it.each([

--- a/frontend/src/components/code-review-overview.tsx
+++ b/frontend/src/components/code-review-overview.tsx
@@ -9,6 +9,7 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { TimeRangePicker } from "@/components/time-range-picker";
+import { MetricInfoTooltip } from "@/components/metric-info-tooltip";
 import type { CodeReviewListOutcome, CodeReviewStats, Repository } from "@/lib/types";
 import type { TimeRangeFilter } from "@/lib/time-range";
 
@@ -17,6 +18,13 @@ export const ALL_OUTCOMES = "all";
 export const ALL_RISKS = "all";
 export const AUTOMATICALLY_APPROVED = "automatically_approved" satisfies CodeReviewListOutcome;
 export const COMPLETED_NOT_APPROVED = "completed_not_approved" satisfies CodeReviewListOutcome;
+
+const REVIEW_SUMMARY_DEFINITIONS = {
+  "Reviews completed": "Review sessions matching the selected filters that finished successfully.",
+  "Automatically approved": "Completed review sessions where 143 posted an approval on GitHub.",
+  "Approval rate": "The percentage of completed review sessions where 143 posted an approval on GitHub.",
+  "Median turnaround": "The median time from a review being queued to that review finishing successfully.",
+} as const;
 
 function percentage(value: number, total: number): string {
   return total > 0 ? `${Math.round((value / total) * 100)}%` : "0%";
@@ -43,26 +51,33 @@ export function CodeReviewSummaryCards({
   isError: boolean;
   onRetry: () => void;
 }) {
-  const unavailable = isError ? "Metrics unavailable" : "Loading selected time window";
   const cards = stats
     ? [
-        { label: "Reviews completed", value: stats.reviews_completed.toLocaleString(), context: "In selected time window" },
+        {
+          label: "Reviews completed",
+          value: stats.reviews_completed.toLocaleString(),
+          definition: REVIEW_SUMMARY_DEFINITIONS["Reviews completed"],
+        },
         {
           label: "Automatically approved",
           value: stats.automatically_approved.toLocaleString(),
-          context: `${percentage(stats.automatically_approved, stats.reviews_completed)} of completed reviews`,
+          definition: REVIEW_SUMMARY_DEFINITIONS["Automatically approved"],
         },
         {
           label: "Approval rate",
           value: percentage(stats.automatically_approved, stats.reviews_completed),
-          context: `${stats.needs_human_review.toLocaleString()} need human review`,
+          definition: REVIEW_SUMMARY_DEFINITIONS["Approval rate"],
         },
-        { label: "Median turnaround", value: formatReviewTurnaround(stats.median_turnaround_seconds), context: "Queued to completed" },
+        {
+          label: "Median turnaround",
+          value: formatReviewTurnaround(stats.median_turnaround_seconds),
+          definition: REVIEW_SUMMARY_DEFINITIONS["Median turnaround"],
+        },
       ]
-    : ["Reviews completed", "Automatically approved", "Approval rate", "Median turnaround"].map((label) => ({
+    : (Object.keys(REVIEW_SUMMARY_DEFINITIONS) as Array<keyof typeof REVIEW_SUMMARY_DEFINITIONS>).map((label) => ({
         label,
         value: "—",
-        context: unavailable,
+        definition: REVIEW_SUMMARY_DEFINITIONS[label],
       }));
 
   return (
@@ -78,9 +93,11 @@ export function CodeReviewSummaryCards({
         {cards.map((card) => (
           <Card key={card.label}>
             <CardContent className="space-y-1.5">
-              <p className="text-xs font-medium text-muted-foreground">{card.label}</p>
+              <div className="flex items-center gap-1 text-xs font-medium text-muted-foreground">
+                <span>{card.label}</span>
+                <MetricInfoTooltip label={card.label} definition={card.definition} />
+              </div>
               <p className="text-2xl font-semibold tabular-nums text-foreground">{card.value}</p>
-              <p className="text-xs text-muted-foreground">{card.context}</p>
             </CardContent>
           </Card>
         ))}

--- a/frontend/src/components/metric-info-tooltip.tsx
+++ b/frontend/src/components/metric-info-tooltip.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+import { Info } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+
+export function MetricInfoTooltip({ label, definition }: { label: string; definition: string }) {
+  return (
+    <TooltipProvider delayDuration={150}>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon-compact"
+            className="rounded-full text-muted-foreground hover:text-foreground"
+            aria-label={`About ${label}`}
+          >
+            <Info className="size-3.5" />
+          </Button>
+        </TooltipTrigger>
+        <TooltipContent side="top" sideOffset={6} className="max-w-72 leading-5">
+          {definition}
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  );
+}


### PR DESCRIPTION
## Summary

Code review headline cards were showing hard-to-discover subdescriptions that are less accessible and harder to test reliably. This change removes the subtext and replaces it with an accessible info icon that reveals metric definitions via hover/focus tooltips, updating tests to assert the new user workflow.

## Changes

- Updated Reviews/Analytics headline UI to remove metric subdescriptions and add “About …” info buttons for metric definitions.
- Implemented/used a shared `metric-info-tooltip` component to ensure consistent tooltip behavior and accessible labeling.
- Extended UI tests to verify tooltip triggers (button presence, and absence of old subdescription text) and focused tooltip behavior.

## Validation

- 75 tests
- ESLint
- TypeScript typecheck
- `git diff --check`

[143.dev](https://143.dev) | [session 17b36c65](https://143.dev/sessions/17b36c65-635d-46e2-ba51-e05196904936)

<!-- 143-publication session=17b36c65-635d-46e2-ba51-e05196904936 changeset=545409bc-ff61-4663-93cd-c8d7bc04bb3d -->

Preview: https://143.dev/previews/github/assembledhq/143/pull/2027?launch=1