### PR TITLE
Index latest code reviews by pull request

### DIFF
--- a/migrations/000274_code_review_pull_request_history_index.down.sql
+++ b/migrations/000274_code_review_pull_request_history_index.down.sql
@@ -1,0 +1,1 @@
+DROP INDEX IF EXISTS idx_code_review_metadata_pull_request_created;

--- a/migrations/000274_code_review_pull_request_history_index.up.sql
+++ b/migrations/000274_code_review_pull_request_history_index.up.sql
@@ -1,0 +1,3 @@
+-- Support latest-review lookups and stable newest-first history queries for a pull request.
+CREATE INDEX idx_code_review_metadata_pull_request_created
+    ON code_review_session_metadata (org_id, pull_request_id, created_at DESC, id DESC);


### PR DESCRIPTION
## Summary

Add the remaining composite index needed for newest-first code review history and latest-review lookups scoped to a pull request.

## Root cause

The original generated PR #1956 used migration slot `000262`, which is already occupied on `main`, and also recreated the organization-wide history index that has since landed. Only the per-pull-request index remains missing.

## Changes

- Add `idx_code_review_metadata_pull_request_created` on `(org_id, pull_request_id, created_at DESC, id DESC)`.
- Use the next available migration slot, `000274`.
- Include the matching down migration.

## Validation

- `go test ./cmd/migrate -run 'TestMigrationVersionsAreUnique|TestMigrationsDoNotUseConcurrentIndexes' -count=1`
- `go test ./cmd/lint-schema -count=1`
- `git diff --check`
