### PR TITLE
Preserve generated pull request titles

### DIFF
--- a/internal/services/github/pr.go
+++ b/internal/services/github/pr.go
@@ -45,6 +45,10 @@ const (
 	maxBranchSlugLen  = 60
 	maxLabelsToCreate = 5
 	maxPRTitleLen     = 120
+	// defaultPrimaryChangesetTitle is the schema fallback for sessions that
+	// do not have a title when their primary changeset is created. It is a
+	// placeholder, not an explicit instruction to overwrite generated PR copy.
+	defaultPrimaryChangesetTitle = "Pull request"
 	// minPRTitleSubjectChars is the smallest descriptive subject we'll allow
 	// after Linear key prefixes are applied. Prefixes are trimmed (secondaries
 	// first) before the subject so a session linked to many issues can never
@@ -1212,12 +1216,7 @@ func (s *PRService) CreatePR(ctx context.Context, run *models.Session, params ..
 	} else {
 		s.logger.Warn().Err(genErr).Msg("LLM PR content generation failed, falling back to static")
 	}
-	if title == "" {
-		title = formatPRTitle(run, issue)
-	}
-	if targetChangeset != nil && strings.TrimSpace(targetChangeset.Title) != "" {
-		title = strings.TrimSpace(targetChangeset.Title)
-	}
+	title = resolvePRTitle(run, issue, title, targetChangeset)
 	if body == "" {
 		body = s.formatPRBody(ctx, run, issue)
 	}
@@ -4886,6 +4885,29 @@ func formatPRTitle(session *models.Session, issue *models.Issue) string {
 		return applyLinearKeyPrefixes(session, title, nil)
 	}
 	return applyLinearKeyPrefixes(session, fmt.Sprintf("Session %s", session.ID.String()[:8]), nil)
+}
+
+// resolvePRTitle lets explicit changeset metadata win while preventing the
+// primary changeset's schema placeholder from erasing generated PR content.
+// Non-primary changesets always treat a non-empty title as explicit because
+// those rows are created intentionally for split or stacked publications.
+func resolvePRTitle(session *models.Session, issue *models.Issue, generated string, changeset *models.SessionChangeset) string {
+	title := strings.TrimSpace(generated)
+	if title == "" {
+		title = formatPRTitle(session, issue)
+	}
+	if changeset == nil {
+		return title
+	}
+
+	changesetTitle := strings.TrimSpace(changeset.Title)
+	if changesetTitle == "" {
+		return title
+	}
+	if changeset.IsPrimary && strings.EqualFold(changesetTitle, defaultPrimaryChangesetTitle) {
+		return title
+	}
+	return changesetTitle
 }
 
 // issueWithLinearHumanKey returns the input issue when no rewrite is needed,

--- a/internal/services/github/pr_test.go
+++ b/internal/services/github/pr_test.go
@@ -500,6 +500,63 @@ func TestFormatPRTitle(t *testing.T) {
 	}
 }
 
+func TestResolvePRTitle(t *testing.T) {
+	t.Parallel()
+
+	sessionID := uuid.MustParse("abcdef01-2345-6789-abcd-ef0123456789")
+	tests := []struct {
+		name      string
+		generated string
+		changeset *models.SessionChangeset
+		expected  string
+	}{
+		{
+			name:      "uses generated title without changeset",
+			generated: "Fix attachment removal sizing",
+			expected:  "Fix attachment removal sizing",
+		},
+		{
+			name:      "explicit primary changeset title wins",
+			generated: "Generated title",
+			changeset: &models.SessionChangeset{IsPrimary: true, Title: "Explicit changeset title"},
+			expected:  "Explicit changeset title",
+		},
+		{
+			name:      "primary placeholder preserves generated title",
+			generated: "Centralize audit log construction",
+			changeset: &models.SessionChangeset{IsPrimary: true, Title: "Pull request"},
+			expected:  "Centralize audit log construction",
+		},
+		{
+			name:      "primary placeholder preserves static fallback",
+			changeset: &models.SessionChangeset{IsPrimary: true, Title: " Pull request "},
+			expected:  "Session abcdef01",
+		},
+		{
+			name:      "blank primary title preserves generated title",
+			generated: "Normalize mention index entries",
+			changeset: &models.SessionChangeset{IsPrimary: true, Title: "  "},
+			expected:  "Normalize mention index entries",
+		},
+		{
+			name:      "non primary placeholder remains an explicit changeset title",
+			generated: "Generated stacked title",
+			changeset: &models.SessionChangeset{Title: "Pull request"},
+			expected:  "Pull request",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			session := &models.Session{ID: sessionID}
+			actual := resolvePRTitle(session, nil, tt.generated, tt.changeset)
+			require.Equal(t, tt.expected, actual, "resolved PR title should respect generated and explicit changeset precedence")
+		})
+	}
+}
+
 func TestPRService_SettersAndCheckRunHandler(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

Prevent primary changesets with the schema fallback title `Pull request` from overwriting generated pull request titles.

## Root cause

Sessions without a title create a primary changeset whose required title field falls back to `Pull request`. PR publication generated a descriptive title correctly, then unconditionally replaced it with that changeset title immediately before calling GitHub. Scheduled automation sessions commonly have no session title, which is why their PRs all received the generic name.

## Changes

- Centralize PR title precedence in `resolvePRTitle`.
- Preserve generated or static fallback titles when the primary changeset only contains the system placeholder.
- Keep explicit primary changeset titles authoritative.
- Keep non-primary split/stacked changeset titles authoritative, including titles that happen to equal `Pull request`.
- Add table-driven regression coverage for generated, fallback, explicit, blank, primary, and non-primary cases.

## Validation

- `go test ./internal/services/github`
- `go vet ./internal/services/github`
- `git diff --check`
