### PR TITLE
Fix Redis stream helper to exit cleanly on context cancellation after setup

### DIFF
--- a/internal/api/handlers/sessions_test.go
+++ b/internal/api/handlers/sessions_test.go
@@ -3819,7 +3819,7 @@ func TestSessionHandler_StreamLogsViaRedis_ContextCanceledAfterSetup(t *testing.
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
 		WillReturnRows(pgxmock.NewRows([]string{"id", "session_id", "org_id", "thread_id", "timestamp", "level", "message", "metadata", "turn_number"}))
 
-	rec := httptest.NewRecorder()
+	rec := newLockedRecorder()
 	sw := sse.NewWriter(rec)
 	require.NotNil(t, sw, "SSE writer should initialize")
 
@@ -3828,7 +3828,9 @@ func TestSessionHandler_StreamLogsViaRedis_ContextCanceledAfterSetup(t *testing.
 	go func() {
 		done <- handler.streamLogsViaRedis(ctx, sw, orgID, run, "")
 	}()
-	time.Sleep(20 * time.Millisecond)
+	require.Eventually(t, func() bool {
+		return strings.Contains(rec.BodyString(), "event: status")
+	}, 2*time.Second, 20*time.Millisecond, "Redis stream helper should finish setup before the context is canceled")
 	cancel()
 
 	select {
@@ -3837,7 +3839,7 @@ func TestSessionHandler_StreamLogsViaRedis_ContextCanceledAfterSetup(t *testing.
 	case <-time.After(2 * time.Second):
 		t.Fatal("Redis stream helper did not return after context cancellation")
 	}
-	require.Contains(t, rec.Body.String(), "event: status", "Redis stream helper should still emit the initial status event before honoring cancellation")
+	require.Contains(t, rec.BodyString(), "event: status", "Redis stream helper should still emit the initial status event before honoring cancellation")
 	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
 }
 


### PR DESCRIPTION
## Summary

`TestSessionHandler_StreamLogsViaRedis_ContextCanceledAfterSetup` was flaky because it assumed the Redis/SSE setup would complete within a fixed 20ms window, then canceled the context. This created a reliability risk where the test sometimes canceled before the initial SSE `status` event was written, producing intermittent failures.  

This change makes the test deterministic by using a thread-safe recorder and waiting (with `require.Eventually`) for the initial `event: status` to appear before calling `cancel()`.

## Changes

- Use `newLockedRecorder()` instead of `httptest.NewRecorder()` to safely read SSE output while the stream goroutine writes to it.
- Replace the fixed `time.Sleep(20 * time.Millisecond)` with an `require.Eventually` wait until the initial `event: status` is present (2s max).
- Use `rec.BodyString()` consistently for assertions to avoid race-prone direct body reads.

## Validation

- Focused test: `100 runs` with `-race`
- Full handlers package tests with race/atomic coverage
- `go test ./internal/... -race -covermode=atomic`
- `go vet ./internal/api/handlers`
- `git diff --check`

[143.dev](https://143.dev) | [session bb74f81b](https://143.dev/sessions/bb74f81b-9ecf-482a-89b2-5b07e685dc81)

<!-- 143-publication session=bb74f81b-9ecf-482a-89b2-5b07e685dc81 changeset=57352b99-5cea-405b-9bc6-c297333e7ddf -->

Preview: https://143.dev/previews/github/assembledhq/143/pull/2030?launch=1