### PR TITLE
Unify Review and Fix Card UI to match Split PR Card Layout

### DIFF
--- a/frontend/src/app/(dashboard)/sessions/[id]/page-overview.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/page-overview.test.tsx
@@ -436,11 +436,9 @@ describe('SessionDetailPage overview and review loop', () => {
     expect(screen.getByText('Review before creating a PR?')).toBeInTheDocument();
     expect(screen.getByText('Ask a review agent to check the current diff and apply fixes.')).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Review & fix' })).toHaveAttribute('title', 'A reusable sandbox snapshot is required before review');
-    const reviewCard = screen.getByText('Review before creating a PR?').closest('[data-slot="card"]');
-    const splitCard = screen.getByText('Need smaller pull requests?').closest('[data-slot="card"]');
-    expect(reviewCard).not.toBeNull();
-    expect(splitCard).not.toBeNull();
-    expect(reviewCard?.compareDocumentPosition(splitCard as Node) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    const reviewTitle = screen.getByText('Review before creating a PR?');
+    const splitTitle = screen.getByText('Need smaller pull requests?');
+    expect(reviewTitle.compareDocumentPosition(splitTitle) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
     expect(within(screen.getByLabelText('Session detail actions')).queryByRole('button', { name: 'Review' })).not.toBeInTheDocument();
   });
 

--- a/frontend/src/app/(dashboard)/sessions/[id]/page-overview.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/page-overview.test.tsx
@@ -5,7 +5,7 @@ import { QueryClient } from '@tanstack/react-query';
 import { act } from '@testing-library/react';
 import { server } from '@/test/mocks/server';
 import { mockSessions, mockMembers, mockPR, mockPRHealth } from '@/test/mocks/handlers';
-import { SessionDetailContent } from './session-detail-content';
+import { CHANGESET_SPLIT_MIN_ADDITIONS, SessionDetailContent } from './session-detail-content';
 import { queryKeys } from '@/lib/query-keys';
 import { markProvisionalSessionDetail } from '@/lib/session-detail-cache';
 import { SESSION_THREAD_STRIP_HEIGHT_CLASSNAME } from './session-detail-geometry';
@@ -404,12 +404,12 @@ describe('SessionDetailPage overview and review loop', () => {
 
     await screen.findByText('Could not reproduce the error in test environment');
     expect(screen.queryByRole('button', { name: 'Review & fix' })).not.toBeInTheDocument();
-    expect(screen.queryByText('Review before PR')).not.toBeInTheDocument();
+    expect(screen.queryByText('Review before creating a PR?')).not.toBeInTheDocument();
     expect(within(screen.getByLabelText('Session detail actions')).queryByRole('button', { name: 'Review' })).not.toBeInTheDocument();
     expect(screen.queryByRole('button', { name: 'Code review' })).not.toBeInTheDocument();
   });
 
-  it('shows a disabled review action in Overview when changes exist but no snapshot is available', async () => {
+  it('shows a disabled review action before the split suggestion when no snapshot is available', async () => {
     server.use(
       http.get('/api/v1/sessions/:id', () => {
         return HttpResponse.json({
@@ -418,7 +418,7 @@ describe('SessionDetailPage overview and review loop', () => {
             snapshot_key: undefined,
             sandbox_state: 'none',
             diff: '--- a/file.ts\n+++ b/file.ts\n@@ -1 +1 @@\n-old\n+new',
-            diff_stats: { added: 1, removed: 1, files_changed: 1 },
+            diff_stats: { added: CHANGESET_SPLIT_MIN_ADDITIONS, removed: 1, files_changed: 1 },
           },
         } satisfies SingleResponse<Session>);
       }),
@@ -433,12 +433,18 @@ describe('SessionDetailPage overview and review loop', () => {
     renderWithProviders(<SessionDetailContent id="session-abcdef12-3456-7890" />);
 
     expect(await screen.findByRole('button', { name: 'Review & fix' })).toBeDisabled();
-    expect(screen.getByText('Review before PR')).toBeInTheDocument();
+    expect(screen.getByText('Review before creating a PR?')).toBeInTheDocument();
+    expect(screen.getByText('Ask a review agent to check the current diff and apply fixes.')).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Review & fix' })).toHaveAttribute('title', 'A reusable sandbox snapshot is required before review');
+    const reviewCard = screen.getByText('Review before creating a PR?').closest('[data-slot="card"]');
+    const splitCard = screen.getByText('Need smaller pull requests?').closest('[data-slot="card"]');
+    expect(reviewCard).not.toBeNull();
+    expect(splitCard).not.toBeNull();
+    expect(reviewCard?.compareDocumentPosition(splitCard as Node) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
     expect(within(screen.getByLabelText('Session detail actions')).queryByRole('button', { name: 'Review' })).not.toBeInTheDocument();
   });
 
-  it('keeps the Overview review card header stacked inside the constrained detail panel', async () => {
+  it('shows a compact status card while the Overview review loop is running', async () => {
     server.use(
       http.get('/api/v1/sessions/:id', () => {
         return HttpResponse.json({
@@ -475,11 +481,11 @@ describe('SessionDetailPage overview and review loop', () => {
     renderWithProviders(<SessionDetailContent id="session-98765432-abcd-ef01" />);
 
     const reviewStatus = await screen.findByText('Fixing with Claude Code');
-    const header = reviewStatus.closest('.flex.flex-col.gap-3');
+    const statusCard = reviewStatus.closest('[data-slot="card"]');
 
-    expect(header).not.toBeNull();
-    expect(header?.className).not.toContain('lg:flex-row');
-    expect(header?.className).not.toContain('lg:justify-between');
+    expect(statusCard).not.toBeNull();
+    expect(statusCard?.querySelector('.lucide-loader-circle')).toBeInTheDocument();
+    expect(within(statusCard as HTMLElement).getByText('The review loop is checking the changes and applying fixes.')).toBeInTheDocument();
     expect(screen.queryByRole('button', { name: 'Review & fix' })).not.toBeInTheDocument();
   });
 

--- a/frontend/src/app/(dashboard)/sessions/[id]/pull-request-list.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/pull-request-list.test.tsx
@@ -111,6 +111,8 @@ describe('ChangesetSplitPrompt', () => {
 
     await userEvent.click(await screen.findByRole('button', { name: 'Split PRs' }));
 
+    expect(screen.getByText('Need smaller pull requests?')).toBeInTheDocument();
+    expect(screen.getByText('Ask the coding agent to split the current diff into reviewable branches.')).toBeInTheDocument();
     expect(onRequestSplit).toHaveBeenCalledOnce();
   });
 });

--- a/frontend/src/app/(dashboard)/sessions/[id]/pull-request-list.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/pull-request-list.test.tsx
@@ -115,4 +115,23 @@ describe('ChangesetSplitPrompt', () => {
     expect(screen.getByText('Ask the coding agent to split the current diff into reviewable branches.')).toBeInTheDocument();
     expect(onRequestSplit).toHaveBeenCalledOnce();
   });
+
+  it('declares the layout container above the elements that query it', () => {
+    render(
+      <ChangesetSplitPrompt
+        additions={CHANGESET_SPLIT_MIN_ADDITIONS}
+        onRequestSplit={vi.fn()}
+      />,
+    );
+
+    const card = screen.getByText('Need smaller pull requests?').closest('[data-slot="card"]');
+    const content = card?.querySelector('[data-slot="card-content"]');
+
+    // jsdom cannot evaluate container queries, so guard the placement instead:
+    // an element is never its own query container, so the row layout would be
+    // dead if the container were declared on the element that queries it.
+    expect(card?.className).toContain('@container/agent-action');
+    expect(content?.className).toContain('@min-[24rem]/agent-action:flex-row');
+    expect(content?.className).not.toContain('@container/agent-action');
+  });
 });

--- a/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { memo, useCallback, useDeferredValue, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
+import { memo, useCallback, useDeferredValue, useEffect, useLayoutEffect, useMemo, useRef, useState, type ReactNode } from "react";
 import dynamic from "next/dynamic";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
@@ -3293,10 +3293,37 @@ export function ChangesetSplitPrompt({
   if (!shouldOfferChangesetSplit(additions)) return null;
 
   return (
+    <AgentActionCard
+      title="Need smaller pull requests?"
+      description="Ask the coding agent to split the current diff into reviewable branches."
+      action={(
+        <Button size="sm" variant="outline" disabled={requestSplitPending || !onRequestSplit} onClick={onRequestSplit}>
+          Split PRs
+        </Button>
+      )}
+    />
+  );
+}
+
+function AgentActionCard({
+  title,
+  description,
+  action,
+}: {
+  title: string;
+  description: string;
+  action: ReactNode;
+}) {
+  return (
     <Card className="border-border/60">
-      <CardContent className="flex items-center justify-between gap-3 p-4">
-        <div><p className="text-sm font-medium">Need smaller pull requests?</p><p className="text-xs text-muted-foreground">Ask the coding agent to split the current diff into reviewable branches.</p></div>
-        <Button size="sm" variant="outline" disabled={requestSplitPending || !onRequestSplit} onClick={onRequestSplit}>Split PRs</Button>
+      <CardContent className="@container/agent-action flex flex-col gap-3 p-4 @min-[24rem]/agent-action:flex-row @min-[24rem]/agent-action:items-center @min-[24rem]/agent-action:justify-between">
+        <div className="min-w-0">
+          <p className="text-sm font-medium text-foreground">{title}</p>
+          <p className="text-xs leading-relaxed text-muted-foreground">{description}</p>
+        </div>
+        <div className="w-full shrink-0 [&>span]:w-full [&_[data-slot=button]]:w-full @min-[24rem]/agent-action:w-auto @min-[24rem]/agent-action:[&>span]:w-auto @min-[24rem]/agent-action:[&_[data-slot=button]]:w-auto">
+          {action}
+        </div>
       </CardContent>
     </Card>
   );
@@ -6276,6 +6303,46 @@ export function SessionDetailContent({ id }: { id: string }) {
               </CardContent>
             </Card>
           )}
+          {selectedIsPrimary && canManageSession && canUseNativeReviewLoop && !hasPR && hasSessionChanges ? (
+            reviewLoopRunning ? (
+              <Card className="border-border/60">
+                <CardContent className="p-4">
+                  <div className="flex min-w-0 flex-1 items-start gap-2">
+                    <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-muted text-muted-foreground">
+                      <Loader2 className="h-4 w-4 animate-spin" />
+                    </div>
+                    <div className="min-w-0">
+                      <p className="text-sm font-medium text-foreground">
+                        Fixing with {AGENTS_BY_KEY[latestReviewLoop?.agent_type ?? ""]?.label ?? "review agent"}
+                      </p>
+                      <p className="text-xs leading-relaxed text-muted-foreground">
+                        The review loop is checking the changes and applying fixes.
+                      </p>
+                    </div>
+                  </div>
+                </CardContent>
+              </Card>
+            ) : (
+              <AgentActionCard
+                title="Review before creating a PR?"
+                description="Ask a review agent to check the current diff and apply fixes."
+                action={(
+                  <DisabledTooltip disabled={reviewActionDisabled} content={reviewActionDisabledReason}>
+                    <Button
+                      type="button"
+                      variant="outline"
+                      size="sm"
+                      disabled={reviewActionDisabled}
+                      title={reviewActionDisabledReason}
+                      onClick={() => setReviewConfigOpen(true)}
+                    >
+                      Review &amp; fix
+                    </Button>
+                  </DisabledTooltip>
+                )}
+              />
+            )
+          ) : null}
           <ChangesetSplitPrompt
             additions={session.diff_stats?.added}
             onRequestSplit={() => queueSend({
@@ -6403,49 +6470,6 @@ export function SessionDetailContent({ id }: { id: string }) {
               </Card>
             ) : null
           )}
-          {selectedIsPrimary && canManageSession && canUseNativeReviewLoop && !hasPR && hasSessionChanges ? (
-            <Card className="border-border/60">
-              <CardContent className="@container/review space-y-3 p-4">
-                <div className="flex flex-col gap-3">
-                  <div className="flex min-w-0 flex-1 items-start gap-2">
-                    <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-muted text-muted-foreground">
-                      {reviewLoopRunning ? <Loader2 className="h-4 w-4 animate-spin" /> : <CheckCircle2 className="h-4 w-4" />}
-                    </div>
-                    <div className="min-w-0">
-                      <p className="text-sm font-medium text-foreground">
-                        {reviewLoopRunning
-                          ? `Fixing with ${AGENTS_BY_KEY[latestReviewLoop?.agent_type ?? ""]?.label ?? "review agent"}`
-                          : "Review before PR"}
-                      </p>
-                      <p className="text-xs leading-relaxed text-muted-foreground">
-                        {reviewLoopRunning
-                          ? "The review loop is checking the changes and applying fixes."
-                          : "Run an agent review loop before creating the pull request."}
-                      </p>
-                    </div>
-                  </div>
-                  {!reviewLoopRunning ? (
-                    <div className="grid shrink-0 grid-cols-1 gap-2 @min-[24rem]/review:grid-cols-[max-content] @min-[24rem]/review:items-center">
-                      <DisabledTooltip disabled={reviewActionDisabled} content={reviewActionDisabledReason}>
-                        <Button
-                          type="button"
-                          variant="outline"
-                          size="sm"
-                          className="w-full gap-1.5 sm:w-fit"
-                          disabled={reviewActionDisabled}
-                          title={reviewActionDisabledReason}
-                          onClick={() => setReviewConfigOpen(true)}
-                        >
-                          <CheckCircle2 className="h-3.5 w-3.5" />
-                          Review &amp; fix
-                        </Button>
-                      </DisabledTooltip>
-                    </div>
-                  ) : null}
-                </div>
-              </CardContent>
-            </Card>
-          ) : null}
           {pullRequestId && prStatus === "closed" && (
             <Card className="border-border/60">
               <CardContent className="p-4">

--- a/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
@@ -3315,8 +3315,10 @@ function AgentActionCard({
   action: ReactNode;
 }) {
   return (
-    <Card className="border-border/60">
-      <CardContent className="@container/agent-action flex flex-col gap-3 p-4 @min-[24rem]/agent-action:flex-row @min-[24rem]/agent-action:items-center @min-[24rem]/agent-action:justify-between">
+    // The container must live on an ancestor of the elements querying it: an
+    // element is never its own query container.
+    <Card className="@container/agent-action border-border/60">
+      <CardContent className="flex flex-col gap-3 p-4 @min-[24rem]/agent-action:flex-row @min-[24rem]/agent-action:items-center @min-[24rem]/agent-action:justify-between">
         <div className="min-w-0">
           <p className="text-sm font-medium text-foreground">{title}</p>
           <p className="text-xs leading-relaxed text-muted-foreground">{description}</p>
@@ -6307,7 +6309,7 @@ export function SessionDetailContent({ id }: { id: string }) {
             reviewLoopRunning ? (
               <Card className="border-border/60">
                 <CardContent className="p-4">
-                  <div className="flex min-w-0 flex-1 items-start gap-2">
+                  <div className="flex min-w-0 items-start gap-2">
                     <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-muted text-muted-foreground">
                       <Loader2 className="h-4 w-4 animate-spin" />
                     </div>


### PR DESCRIPTION
## Summary

Users viewing a session’s overview/review loop could see the “Review before PR” card rendered in an order that didn’t match the Split PR card layout, creating a confusing scan path. This PR unifies the DOM/UI ordering so the Review card/status consistently renders first, followed immediately by the split PR suggestion, and adds a regression test to prevent future reorderings.

## Changes

- Updated `SessionDetailContent` layout so the review card/status is rendered before the Split PR card (using `data-slot="card"` ordering).
- Refined copy/labels around the disabled “Review & fix” state to match the intended workflow text (“Review before creating a PR?” and agent prompt).
- Added/updated tests to assert the rendered DOM order and behavior when no snapshot is available or when the review loop is running.

## Validation

- Ran `frontend` test suite for affected coverage: **44 focused tests passed**.
- `ESLint` passed.
- `git diff --check` passed.

[143.dev](https://143.dev) | [session 7286dab5](https://143.dev/sessions/7286dab5-860e-45b5-838b-1f7837c01b03)

<!-- 143-publication session=7286dab5-860e-45b5-838b-1f7837c01b03 changeset=926d6093-8f36-4c4f-b1b4-703bec927a22 -->

Preview: https://143.dev/previews/github/assembledhq/143/pull/2032?launch=1