### PR TITLE
Resize mobile Split PRs button to standard width

### DIFF
--- a/frontend/src/app/(dashboard)/sessions/[id]/page-overview.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/page-overview.test.tsx
@@ -432,10 +432,15 @@ describe('SessionDetailPage overview and review loop', () => {
 
     renderWithProviders(<SessionDetailContent id="session-abcdef12-3456-7890" />);
 
-    expect(await screen.findByRole('button', { name: 'Review & fix' })).toBeDisabled();
+    const reviewButton = await screen.findByRole('button', { name: 'Review & fix' });
+    expect(reviewButton).toBeDisabled();
     expect(screen.getByText('Review before creating a PR?')).toBeInTheDocument();
     expect(screen.getByText('Ask a review agent to check the current diff and apply fixes.')).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Review & fix' })).toHaveAttribute('title', 'A reusable sandbox snapshot is required before review');
+    expect(reviewButton).toHaveAttribute('title', 'A reusable sandbox snapshot is required before review');
+    const reviewAction = reviewButton.closest('[data-slot="agent-action-card-action"]');
+    expect(reviewAction).toHaveClass('w-fit', 'self-start');
+    expect(reviewAction).not.toHaveClass('w-full');
+    expect(reviewButton).not.toHaveClass('w-full');
     const reviewTitle = screen.getByText('Review before creating a PR?');
     const splitTitle = screen.getByText('Need smaller pull requests?');
     expect(reviewTitle.compareDocumentPosition(splitTitle) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();

--- a/frontend/src/app/(dashboard)/sessions/[id]/pull-request-list.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/pull-request-list.test.tsx
@@ -134,4 +134,19 @@ describe('ChangesetSplitPrompt', () => {
     expect(content?.className).toContain('@min-[24rem]/agent-action:flex-row');
     expect(content?.className).not.toContain('@container/agent-action');
   });
+
+  it('keeps the split action sized to its label on narrow cards', () => {
+    render(
+      <ChangesetSplitPrompt
+        additions={CHANGESET_SPLIT_MIN_ADDITIONS}
+        onRequestSplit={vi.fn()}
+      />,
+    );
+
+    const button = screen.getByRole('button', { name: 'Split PRs' });
+    const action = button.closest('[data-slot="agent-action-card-action"]');
+    expect(action).toHaveClass('w-fit', 'self-start');
+    expect(action).not.toHaveClass('w-full');
+    expect(button).not.toHaveClass('w-full');
+  });
 });

--- a/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
@@ -3323,7 +3323,10 @@ function AgentActionCard({
           <p className="text-sm font-medium text-foreground">{title}</p>
           <p className="text-xs leading-relaxed text-muted-foreground">{description}</p>
         </div>
-        <div className="w-full shrink-0 [&>span]:w-full [&_[data-slot=button]]:w-full @min-[24rem]/agent-action:w-auto @min-[24rem]/agent-action:[&>span]:w-auto @min-[24rem]/agent-action:[&_[data-slot=button]]:w-auto">
+        <div
+          data-slot="agent-action-card-action"
+          className="w-fit shrink-0 self-start @min-[24rem]/agent-action:self-auto"
+        >
           {action}
         </div>
       </CardContent>


### PR DESCRIPTION
## Summary

On narrow/mobile cards, the “Review & fix” and “Split PRs” CTAs were stretching to full width, breaking the intended layout and making the action feel misaligned with the content. This change updates the shared `AgentActionCard` action container styling to size to the button label on small screens, matching the standard shadcn `Button` behavior and reducing layout jank/reliability risk in responsive views.

## Changes

- Updated `AgentActionCard` to wrap the `action` in a dedicated container (`data-slot="agent-action-card-action"`) sized with `w-fit self-start` instead of forcing full-width.
- Adjusted `Review & fix` test assertions to validate the new action container classes (and ensure the button is not `w-full`).
- Added a regression test for the “Split PRs” action to confirm it remains label-sized on narrow cards.

## Validation

- Ran 46 focused tests (including new/updated regressions for both buttons).
- ESLint checks passed.
- Diff checks passed.
- Visual preview was blocked by an unrelated seed-data foreign-key failure during startup.

[143.dev](https://143.dev) | [session 871fcc5f](https://143.dev/sessions/871fcc5f-9a24-425c-848f-b1aeb06b358d)

<!-- 143-publication session=871fcc5f-9a24-425c-848f-b1aeb06b358d changeset=712626b8-9463-40f2-95a3-454f610543e1 -->

Preview: https://143.dev/previews/github/assembledhq/143/pull/2036?launch=1