### PR TITLE
Adjust Code Review Preset Visibility and Configuration with Options, Pros/Cons, and Recommendation

### DIFF
--- a/docs/design/implemented/112-code-reviewer-bot-auto-approval.md
+++ b/docs/design/implemented/112-code-reviewer-bot-auto-approval.md
@@ -1,6 +1,6 @@
 # Design: Code Reviewer Bot And Acceptable-Risk Auto-Approval
 
-> **Status:** Implemented | **Last reviewed:** 2026-07-30
+> **Status:** Implemented | **Last reviewed:** 2026-08-02
 >
 > **Depends on:** [../overall.md](../overall.md), [78-review-agent-loops.md](78-review-agent-loops.md), [61-pr-state-sync-and-repair-actions.md](61-pr-state-sync-and-repair-actions.md), [../backlog/11-review-feedback-loop.md](../backlog/11-review-feedback-loop.md)
 
@@ -19,7 +19,7 @@ Implemented:
 - lossless policy persistence for final review templates
 - code review session metadata, agent result, finding, and prompt-artifact tables tied to normal `sessions`
 - typed Go models and `pgx` stores for policies, review metadata, agent evidence, and findings
-- deterministic acceptable-risk evaluator, starter policy templates, final-review body rendering, and inline finding selection helpers
+- deterministic acceptable-risk evaluator, final-review body rendering, and inline finding selection helpers
 - GitHub `review_requested` and PR issue-comment mention webhook adapters for configured bot reviewer identities, including authoritative PR snapshot loading and local mirror creation for human-authored PRs
 - event-driven reassessment after the initial reviewer request when the PR head changes, plus delivery-keyed explicit rerequests that can reassess the same head after a non-approval; durable follow-up jobs serialize requests behind active work and a terminal stop applies once 143 approves, while PR metadata, readiness, human reviews/comments/threads, checks, and commit statuses continue to synchronize without starting reviewer sessions
 - service-layer code review request orchestration that resolves/materializes policy, marks stale older heads, reuses running sessions, creates normal code-review sessions, and enqueues `run_code_review`
@@ -36,7 +36,7 @@ Implemented:
 - stale requested-reviewer cleanup after final review submission for reviewer-login and team-slug triggers carried in the durable job payload
 - productized GitHub team-trigger setup that creates or repairs the `143-code-reviewer` org team, grants repository read access, and persists repo-scoped active trigger settings
 - final-review template rendering from persisted policy data with safe fallback to the built-in body
-- `/api/v1/code-reviews`, `/api/v1/code-reviews/stats`, `/api/v1/code-reviews/analytics`, `/api/v1/code-reviews/templates`, `/api/v1/code-reviews/{id}/evidence`, `/api/v1/code-review-policies`, and `/api/v1/code-review-github-trigger` API surface
+- `/api/v1/code-reviews`, `/api/v1/code-reviews/stats`, `/api/v1/code-reviews/analytics`, `/api/v1/code-reviews/{id}/evidence`, `/api/v1/code-review-policies`, and `/api/v1/code-review-github-trigger` API surface
 - top-level `Code reviews` dashboard surface with Reviews, Analytics, and Policy tabs; repository/decision/risk/status/search filtering on the Reviews tab; approval-usage, PR-author, finding, and non-approval-reason reporting; and organization-wide policy controls. The Analytics tab was later narrowed to repository and time-window cohort filters and re-based on unique pull requests; see [122-pr-centric-code-review-analytics.md](122-pr-centric-code-review-analytics.md).
 
 Deferred:
@@ -76,7 +76,7 @@ Recommended v1 scope:
 - `review_requested` trigger for selected repositories.
 - `issue_comment` trigger when a PR conversation comment mentions the configured team, with the bounded comment supplied to the orchestrator as untrusted request context.
 - Normal 143 code review sessions keyed by org, repository, PR, head SHA, and policy version.
-- Editable PR-description policy and acceptable-risk starter templates.
+- Editable PR-description policy and acceptable-risk safeguards.
 - Two reviewer agents plus one orchestrator by default.
 - Each reviewer has a policy-versioned reasoning-effort value aligned by index with `reviewers` and `reviewer_models`; the orchestrator keeps its own `reasoning_effort`. Omitted legacy reviewer values inherit the former roster-wide value, or `high` when that value is also absent.
 - One rolling PR comment with the visible summary, plus a formal GitHub review that converges from a visible fallback to marker-only and a configurable number of inline comments.
@@ -379,22 +379,6 @@ Acceptable risk means:
 ```
 
 Admins can tune this over time based on false positives, false negatives, team trust, and repository-specific risk.
-
-### Acceptable-Risk Templates
-
-The configuration UI should offer starter templates so admins do not start from a blank page.
-
-Recommended templates:
-
-| Template | Default behavior |
-| --- | --- |
-| Docs and comments only | Eligible for approval when only docs, comments, or markdown paths change, PR description passes, and no generated/security/config paths are touched. |
-| Tests only | Eligible for approval when changes are limited to test files and fixtures, no snapshots/golden files exceed configured churn, and required checks pass. |
-| Small frontend change | Eligible for approval when file/line thresholds are low, screenshots or preview link are present when required, and no auth/billing/data-fetching paths are touched. |
-| Small backend change | Eligible for approval only outside sensitive packages, with test evidence, passing checks, and no schema, permissions, auth, billing, dependency, or infra changes. |
-| Small combined feature | Eligible for approval when a limited-scope feature touches both frontend and backend within tighter file/line thresholds, includes test evidence, includes screenshot or preview evidence when UI-visible, and avoids sensitive paths, schema changes, permissions, auth, billing, dependency, and infra changes. |
-
-Each template expands into editable rules rather than hidden presets: thresholds, path categories, PR description prompts, required checks, reviewer quorum, and orchestrator rubric.
 
 ## Bot Identity
 

--- a/docs/design/implemented/112-code-reviewer-bot-auto-approval.md
+++ b/docs/design/implemented/112-code-reviewer-bot-auto-approval.md
@@ -380,6 +380,8 @@ Acceptable risk means:
 
 Admins can tune this over time based on false positives, false negatives, team trust, and repository-specific risk.
 
+This design originally recommended whole-policy acceptable-risk starter templates (docs-only, tests-only, small frontend/backend/combined) so admins would not start from a blank page. Those templates shipped and were later removed, because applying one replaced unrelated safeguards, prompts, thresholds, and agent settings rather than only the setting the user was editing; see [117-code-review-policy-simplification.md](117-code-review-policy-simplification.md).
+
 ## Bot Identity
 
 Recommended long-term shape: a **GitHub App-backed bot identity** named something like `143 Code Reviewer`, with optional repository/team routing layered on top in 143.

--- a/docs/design/implemented/117-code-review-policy-simplification.md
+++ b/docs/design/implemented/117-code-review-policy-simplification.md
@@ -1,6 +1,6 @@
 # Design: Prompt-First Code Review Policy
 
-> **Status:** Implemented | **Last reviewed:** 2026-07-28
+> **Status:** Implemented | **Last reviewed:** 2026-08-02
 >
 > **Depends on:** [../overall.md](../overall.md), [112-code-reviewer-bot-auto-approval.md](112-code-reviewer-bot-auto-approval.md), [../03-frontend.md](../03-frontend.md)
 
@@ -27,7 +27,7 @@ The central mental model is:
 
 ### Problem
 
-The current policy screen exposes GitHub setup, outcome, whole-policy templates, numeric thresholds, quality gates, path and author lists, agent selection, and PR-description requirements in one continuous card. Even though fine-tuning groups are collapsible, the page suggests that a user must understand the full policy model before starting.
+The original policy screen exposed GitHub setup, outcome, numeric thresholds, quality gates, path and author lists, agent selection, and PR-description requirements in one continuous card. Even though fine-tuning groups were collapsible, the page suggested that a user had to understand the full policy model before starting.
 
 The only editable prompt is currently attached to each structured PR-description requirement. It appears near the bottom of the page, behind a requirements table and side sheet, and is visually much smaller than the automation goal editor. Engineers who expect to express behavior in a prompt cannot find a clear, general-purpose place to do that.
 
@@ -36,7 +36,7 @@ This creates four usability problems:
 - **High perceived setup cost:** a safe first review appears to require many decisions.
 - **Weak primary action:** the most familiar control for engineers is visually subordinate.
 - **Mixed concepts:** probabilistic reviewer guidance and deterministic approval gates appear equivalent.
-- **Surprising templates:** a starter template can replace the full policy rather than only the text the user is trying to edit.
+- **Unsafe shortcuts:** whole-policy starter templates could replace unrelated safeguards and agent configuration while a user was trying to establish a starting point.
 
 ### Goals
 
@@ -112,7 +112,7 @@ The Code reviews page retains the existing **Reviews** and **Policy** tabs. The 
 7. **Current behavior summary**
    - Short badges for outcome, reviewer count, quorum, and active safety gates.
 8. **Advanced controls**
-   - One collapsed container holding Safety gates; Paths, authors, and required checks; Review agents; Limits and timeout; Structured PR-description checks; and Advanced policy presets.
+   - One collapsed container holding Safety gates; Paths, authors, and required checks; Review agents; Limits and timeout; and Structured PR-description checks.
 
 The automated approval policy remains prominent whenever approval is enabled. Optional review instructions are available on the main screen but visually secondary. Structured description checks remain advanced because they answer a different question: whether required evidence exists in the PR description.
 
@@ -226,7 +226,7 @@ Initial automated-approval examples:
 
 Applying an automated-approval example does not silently grant approval authority. If the policy is comment-only, the example preview explains that the user must separately choose **Leave comments and approve when acceptable**. Even then, the deterministic evaluator permits approval only when every hard gate passes.
 
-Whole-policy starter templates remain available as **Advanced policy presets**. Their copy must explicitly say that applying one changes safety controls, thresholds, and agent settings. They should not share the same selector as prompt examples.
+Whole-policy starter templates are not offered. They made a full policy replacement look like a normal configuration path and could overwrite unrelated safeguards, prompts, thresholds, and agent settings. Prompt examples remain intentionally scoped to one text field.
 
 ### Interaction details
 
@@ -260,7 +260,7 @@ Whole-policy starter templates remain available as **Advanced policy presets**. 
 
 #### Setting information tooltips
 
-Every editable policy setting must include an adjacent information tooltip. This applies to the two prompt composers, enablement and outcome controls, thresholds, switches, path/author/check lists, reviewer and model selection, quorum, timeout, inline-comment limit, structured PR-description checks, inheritance/reset actions, and advanced policy presets.
+Every editable policy setting must include an adjacent information tooltip. This applies to the two prompt composers, enablement and outcome controls, thresholds, switches, path/author/check lists, reviewer and model selection, quorum, timeout, inline-comment limit, structured PR-description checks, and inheritance/reset actions.
 
 Each tooltip should answer, in concise plain language:
 
@@ -335,7 +335,6 @@ The API currently exposes:
 
 - `GET /api/v1/code-review-policies?repository_id=<uuid>`;
 - `PUT /api/v1/code-review-policies` with the complete config;
-- `GET /api/v1/code-reviews/templates` for whole-policy templates;
 - GitHub trigger status/setup/delete routes.
 
 Reviewer and orchestrator system prompts live in `internal/prompts/templates/` and are rendered through `internal/prompts/prompts.go`. The editable instructions must be included as data inside those platform-owned templates; user text must never become the system prompt itself.
@@ -449,7 +448,7 @@ type CodeReviewAutomatedApprovalExampleOption struct {
 }
 ```
 
-`CodeReviewPromptExamples()` and `CodeReviewAutomatedApprovalExamples()` return deterministic built-in lists. Examples contain no organization data and require no database persistence. The existing `CodeReviewTemplateOption` and whole-policy templates remain supported but are relabeled as advanced presets in the UI.
+`CodeReviewPromptExamples()` and `CodeReviewAutomatedApprovalExamples()` return deterministic built-in lists. Examples contain no organization data and require no database persistence. Whole-policy templates and their API are not supported; examples can replace only their corresponding prompt field.
 
 ### API changes
 
@@ -534,8 +533,6 @@ Response:
 
 No mutation endpoint is needed. Applying an example is a normal policy update, ensuring versioning and audit behavior remain unchanged.
 The two explicitly named collections prevent clients from applying an example to the wrong field.
-
-Keep `GET /api/v1/code-reviews/templates` for compatibility. A future versioned API may rename it to `/policy-presets`, but this project should avoid a breaking route change solely for UI terminology.
 
 #### Authorization, rate limits, and tenancy
 
@@ -800,9 +797,9 @@ Implementation items:
 3. Move thresholds, quality gates, paths/authors/checks, agent roster, limits, and description requirements into one collapsed **Advanced controls** container.
 4. Rename `Description requirements` to `Structured PR-description checks` and `Reviewer instruction` to `Description check instruction`.
 5. Collapse a ready GitHub trigger into a status row with Manage disclosure; retain full actionable error states.
-6. Keep the current whole-policy template selector inside Advanced controls and relabel it **Advanced policy preset** with explicit replacement copy.
+6. Remove the whole-policy template selector and templates API so advanced controls are the only path for changing safeguards, thresholds, and agent settings.
 7. Keep the effective-policy summary visible and update its wording for the new control hierarchy.
-8. Add the shared `SettingInfoTooltip` and require tooltip content for every existing policy input, including prompt, outcome, GitHub setup, advanced, inheritance, and preset controls.
+8. Add the shared `SettingInfoTooltip` and require tooltip content for every existing policy input, including prompt, outcome, GitHub setup, advanced, and inheritance controls.
 9. Add focused frontend tests for information order, enablement/outcome mapping, tooltip presence/accessibility, collapsed advanced state, GitHub statuses, and existing autosave behavior.
 10. Run targeted Vitest and lint for touched files, then verify desktop/mobile states and tooltip interactions using a session preview.
 
@@ -852,7 +849,7 @@ Implementation items:
 1. Add separate typed example collections for review instructions and automated approval policies, served by `GET /api/v1/code-reviews/prompt-examples`.
 2. Add frontend types, query keys, API client, prompt-example preview dialog, and replacement confirmation.
 3. Ensure applying an example replaces only its corresponding prompt field and produces a normal policy version.
-4. Distinguish **Prompt examples** from **Advanced policy presets** in labels, descriptions, and confirmation copy.
+4. Make labels, descriptions, and confirmation copy explicit that a prompt example replaces only its corresponding text field.
 5. Add `Use organization instructions` for repository scope and a customized-control count derived from override fields.
 6. If supported by product/backend semantics, add a full repository-policy reset endpoint that transactionally deactivates the active repository override; otherwise document and defer it.
 7. Add structured API field-error details and use them to open/focus the relevant advanced subsection.
@@ -875,7 +872,7 @@ Exit criteria:
 - Review instructions are optional and empty by default; native `/review` is the recommended baseline.
 - Automated approval policy is the more prominent prompt because it governs the evidence used for the higher-consequence approval decision.
 - Both fields are stored in dedicated versioned columns and inherit independently.
-- Prompt examples and whole-policy presets are separate product concepts.
+- Prompt examples are scoped helpers; whole-policy presets are intentionally not part of the product.
 - Both prompts are editable Markdown but have no template interpolation in this project.
 - The platform system prompt and deterministic evaluator remain authoritative.
 - `/review` remains the required first prefix for every reviewer-agent invocation and is never user-editable.

--- a/docs/design/implemented/117-code-review-policy-simplification.md
+++ b/docs/design/implemented/117-code-review-policy-simplification.md
@@ -797,7 +797,7 @@ Implementation items:
 3. Move thresholds, quality gates, paths/authors/checks, agent roster, limits, and description requirements into one collapsed **Advanced controls** container.
 4. Rename `Description requirements` to `Structured PR-description checks` and `Reviewer instruction` to `Description check instruction`.
 5. Collapse a ready GitHub trigger into a status row with Manage disclosure; retain full actionable error states.
-6. Remove the whole-policy template selector and templates API so advanced controls are the only path for changing safeguards, thresholds, and agent settings.
+6. Keep the whole-policy template selector inside Advanced controls and relabel it **Advanced policy preset** with explicit replacement copy. The selector and its `GET /api/v1/code-reviews/templates` API were later removed outright, so advanced controls are now the only path for changing safeguards, thresholds, and agent settings.
 7. Keep the effective-policy summary visible and update its wording for the new control hierarchy.
 8. Add the shared `SettingInfoTooltip` and require tooltip content for every existing policy input, including prompt, outcome, GitHub setup, advanced, and inheritance controls.
 9. Add focused frontend tests for information order, enablement/outcome mapping, tooltip presence/accessibility, collapsed advanced state, GitHub statuses, and existing autosave behavior.

--- a/docs/public/guides/code-review-policy.mdx
+++ b/docs/public/guides/code-review-policy.mdx
@@ -76,7 +76,7 @@ Use the report to tune policy deliberately:
 
 143 evaluates the current pull request independently of existing human review activity. Human comments, review decisions, and open or resolved review threads—including unresolved change requests—do not become findings or block 143's approval. Repository branch protection and merge rules still apply independently on GitHub.
 
-Use a prompt example when it matches your intent. Previewing and applying an example replaces only its corresponding prompt; it never changes enablement, outcome, reviewers, paths, thresholds, or safety gates. Advanced policy presets are different: they replace the complete policy, including safeguards and agent settings.
+Use a prompt example when it matches your intent. Previewing and applying an example replaces only its corresponding prompt; it never changes enablement, outcome, reviewers, paths, thresholds, or safety gates.
 
 Under **Safeguards → Reviewers & agents**, choose a reasoning level beside each reviewer model. Reviewers can use different levels in the same run. The default is **High**, and the available choices follow the agent selected in that row. Configure the orchestrator's reasoning separately beside its model.
 

--- a/frontend/src/app/(dashboard)/code-reviews/page.test.tsx
+++ b/frontend/src/app/(dashboard)/code-reviews/page.test.tsx
@@ -412,7 +412,6 @@ it("applies an approval example without changing safeguards and does not grant a
 describe("CodeReviewsPage", () => {
   beforeEach(() => {
     toast.success.mockReset();
-    toast.info.mockReset();
     toast.error.mockReset();
     sse.onEvent = undefined;
   });

--- a/frontend/src/app/(dashboard)/code-reviews/page.test.tsx
+++ b/frontend/src/app/(dashboard)/code-reviews/page.test.tsx
@@ -41,7 +41,6 @@ import type {
   CodeReviewPolicyRecord,
   CodeReviewResolvedPolicy,
   CodeReviewStats,
-  CodeReviewTemplateOption,
   CodeReviewPromptExamplesResponse,
   AuditLog,
   ListResponse,
@@ -263,20 +262,6 @@ const reviewAnalytics: CodeReviewAnalytics = {
   ],
 };
 
-const template: CodeReviewTemplateOption = {
-  key: "small_backend_change",
-  title: "Small backend change",
-  description: "Small backend changes outside sensitive packages.",
-  config: {
-    ...policy.config,
-    approval_mode: "approve_acceptable",
-    risk_policy: {
-      ...policy.config.risk_policy,
-      max_files_changed: 4,
-    },
-  },
-};
-
 const githubTriggerReady: CodeReviewGitHubTriggerResponse = {
   status: "ready",
   repository_id: "repo-1",
@@ -343,12 +328,6 @@ function mockCodeReviewBaseHandlers(
       HttpResponse.json({
         data: evidence,
       } satisfies SingleResponse<CodeReviewEvidence>),
-    ),
-    http.get("/api/v1/code-reviews/templates", () =>
-      HttpResponse.json({
-        data: [template],
-        meta: {},
-      } satisfies ListResponse<CodeReviewTemplateOption>),
     ),
     http.get("/api/v1/code-reviews/prompt-examples", () =>
       HttpResponse.json({ data: {
@@ -632,18 +611,6 @@ describe("CodeReviewsPage", () => {
     expect(screen.getByRole("combobox", { name: "Reviewer 1 reasoning level" })).toHaveTextContent("High");
     expect(screen.getByRole("combobox", { name: "Reviewer 2 reasoning level" })).toHaveTextContent("High");
     expect(screen.getByRole("combobox", { name: "Orchestrator reasoning level" })).toHaveTextContent("High");
-
-    // Autosave: applying a template persists without a Save button.
-    await user.click(screen.getByRole("combobox", { name: /Advanced policy preset/i }));
-    await user.click(await screen.findByRole("option", { name: "Small backend change" }));
-    await user.click(screen.getByRole("button", { name: /Apply preset/i }));
-    await waitFor(() => {
-      expect(toast.success).toHaveBeenCalledWith("Applied Small backend change");
-    });
-    await user.click(screen.getByRole("button", { name: /Approval criteria/i }));
-    expect((await screen.findAllByDisplayValue("4")).length).toBeGreaterThan(0);
-    expect(screen.getByLabelText("Timeout value")).toHaveValue(30);
-    expect(screen.getByRole("combobox", { name: "Timeout unit" })).toHaveTextContent("Minutes");
 
     await user.click(screen.getByRole("button", { name: /Add requirement/i }));
     expect(await screen.findByDisplayValue("Custom requirement")).toBeInTheDocument();
@@ -1803,13 +1770,12 @@ describe("CodeReviewsPage", () => {
     expect(screen.getByRole("button", { name: "Disable reviewer" })).toBeInTheDocument();
 
     await user.click(screen.getByRole("button", { name: "Safeguards" }));
-    expect(screen.getByText(/Applying a preset replaces safety controls/i)).toBeVisible();
+    expect(screen.queryByRole("combobox", { name: /Advanced policy preset/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /Apply preset/i })).not.toBeInTheDocument();
     for (const section of ["Approval criteria", "Paths, authors & checks", "Reviewers & agents"]) {
       await user.click(screen.getByRole("button", { name: new RegExp(section, "i") }));
     }
     for (const label of [
-      "Advanced policy preset",
-      "Apply advanced policy preset",
       "Files changed",
       "Lines changed",
       "Inline comments",
@@ -2426,36 +2392,6 @@ describe("CodeReviewsPage", () => {
     expect(within(requiredChecksEditor as HTMLElement).getByText("test")).toBeInTheDocument();
 
     expect(screen.getByRole("button", { name: "Add required check" })).toBeInTheDocument();
-  });
-
-  it("surfaces template apply save failures through the shared toast", async () => {
-    const user = userEvent.setup();
-    mockCodeReviewBaseHandlers();
-    server.use(
-      http.put("/api/v1/code-review-policies", () =>
-        HttpResponse.json(
-          {
-            error: {
-              code: "SAVE_FAILED",
-              message: "Policy could not be saved",
-            },
-          },
-          { status: 500 },
-        ),
-      ),
-    );
-
-    renderWithProviders(<CodeReviewsPage />);
-
-    await user.click(await screen.findByRole("tab", { name: /Policy/i }));
-    await user.click(screen.getByRole("button", { name: "Safeguards" }));
-    await user.click(screen.getByRole("combobox", { name: /Advanced policy preset/i }));
-    await user.click(await screen.findByRole("option", { name: "Small backend change" }));
-    await user.click(screen.getByRole("button", { name: /Apply preset/i }));
-
-    await waitFor(() => {
-      expect(toast.error).toHaveBeenCalledWith("Couldn't save. Your change was reverted.");
-    });
   });
 
   it("saves code review timeout in seconds from the selected unit", async () => {

--- a/frontend/src/app/(dashboard)/code-reviews/page.tsx
+++ b/frontend/src/app/(dashboard)/code-reviews/page.tsx
@@ -136,7 +136,6 @@ const TIME_RANGE_FILTER_PARSER = createParser<TimeRangeFilter>({
   parse: parseTimeRange,
   serialize: (value) => value,
 }).withDefault(DEFAULT_TIME_RANGE);
-const NO_TEMPLATE = "none";
 // Coalesce a burst of SSE lifecycle events into a single list refetch.
 const CODE_REVIEW_INVALIDATE_COALESCE_MS = 300;
 const CODE_REVIEW_PAGE_SIZE = 50;
@@ -531,8 +530,6 @@ export default function CodeReviewsPage() {
     }, CODE_REVIEW_SEARCH_DEBOUNCE_MS);
     return () => window.clearTimeout(timer);
   }, [search, setSearchParam]);
-  const [selectedTemplateKey, setSelectedTemplateKey] = useState(NO_TEMPLATE);
-  const [pendingTemplateApply, setPendingTemplateApply] = useState<{ key: string; title: string } | null>(null);
   const [selectedEvidenceSessionId, setSelectedEvidenceSessionId] = useState<string | null>(null);
   const [mobileFiltersOpen, setMobileFiltersOpen] = useState(false);
   const [editingRequirementKey, setEditingRequirementKey] = useState<string | null>(null);
@@ -829,10 +826,6 @@ export default function CodeReviewsPage() {
       queryFn: () => api.codeReviews.getGitHubTrigger(repository.id),
     })),
   });
-  const templatesQuery = useQuery({
-    queryKey: queryKeys.codeReviews.templates,
-    queryFn: () => api.codeReviews.templates(),
-  });
   const promptExamplesQuery = useQuery({
     queryKey: queryKeys.codeReviews.promptExamples,
     queryFn: () => api.codeReviews.promptExamples(),
@@ -997,8 +990,6 @@ export default function CodeReviewsPage() {
     () => reviews.find((review) => review.session_id === selectedEvidenceSessionId) ?? null,
     [reviews, selectedEvidenceSessionId],
   );
-  const templates = templatesQuery.data?.data ?? [];
-  const selectedTemplate = templates.find((template) => template.key === selectedTemplateKey);
   const orgSettings = (settingsQuery.data?.data?.settings ?? {}) as OrgSettings;
   const orgCodingCredentials = useMemo(() => orgCodingCredentialsQuery.data?.data ?? [], [orgCodingCredentialsQuery.data?.data]);
   const codeReviewResolvedCredentials = useMemo(
@@ -1018,22 +1009,6 @@ export default function CodeReviewsPage() {
     [config, editingRequirementKey],
   );
   const editingRequirement = editingRequirementIndex >= 0 && config ? config.description_policy.requirements[editingRequirementIndex] : null;
-  const selectedTemplateAlreadyApplied = useMemo(() => {
-    if (!selectedTemplate || !config) return false;
-    return JSON.stringify(config) === JSON.stringify(selectedTemplate.config);
-  }, [config, selectedTemplate]);
-  useEffect(() => {
-    setPendingTemplateApply(null);
-  }, [selectedTemplateKey]);
-  useEffect(() => {
-    if (!pendingTemplateApply) return;
-    if (autosave.status === "saved") {
-      toast.success(`Applied ${pendingTemplateApply.title}`);
-      setPendingTemplateApply(null);
-    } else if (autosave.status === "error") {
-      setPendingTemplateApply(null);
-    }
-  }, [autosave.status, pendingTemplateApply]);
   // Build a fully-merged config from the freshest cache value. Returns null
   // only before the policy has loaded (controls are disabled until then).
   const draftFrom = (mutate: (next: CodeReviewPolicyConfig) => void): CodeReviewPolicyConfig | null => {
@@ -1452,14 +1427,7 @@ export default function CodeReviewsPage() {
                   invalidPolicyField={invalidPolicyField}
                 />
                 <AdvancedPolicySettings
-                  selectedTemplateKey={selectedTemplateKey}
-                  setSelectedTemplateKey={setSelectedTemplateKey}
-                  templates={templates}
-                  selectedTemplate={selectedTemplate}
-                  selectedTemplateAlreadyApplied={selectedTemplateAlreadyApplied}
                   config={config}
-                  readLatestConfig={readLatestConfig}
-                  setPendingTemplateApply={setPendingTemplateApply}
                   autosave={autosave}
                   buildConfig={buildConfig}
                   commitPolicy={commitPolicy}
@@ -1740,17 +1708,8 @@ function CodeReviewPromptExampleDialog({ selection, currentConfig, currentDraftV
   </DialogContent></Dialog>;
 }
 
-type CodeReviewPolicyTemplate = Awaited<ReturnType<typeof api.codeReviews.templates>>["data"][number];
-
 type AdvancedPolicySettingsProps = {
-  selectedTemplateKey: string;
-  setSelectedTemplateKey: (value: string) => void;
-  templates: CodeReviewPolicyTemplate[];
-  selectedTemplate?: CodeReviewPolicyTemplate;
-  selectedTemplateAlreadyApplied: boolean;
   config: CodeReviewPolicyConfig | null;
-  readLatestConfig: () => CodeReviewPolicyConfig | null;
-  setPendingTemplateApply: (value: { key: string; title: string }) => void;
   autosave: UseAutosaveResult<CodeReviewPolicyConfig>;
   buildConfig: (mutate: (next: CodeReviewPolicyConfig) => void) => CodeReviewPolicyConfig;
   commitPolicy: (mutate: (next: CodeReviewPolicyConfig) => void) => void;
@@ -1762,14 +1721,7 @@ type AdvancedPolicySettingsProps = {
 };
 
 function AdvancedPolicySettings({
-  selectedTemplateKey,
-  setSelectedTemplateKey,
-  templates,
-  selectedTemplate,
-  selectedTemplateAlreadyApplied,
   config,
-  readLatestConfig,
-  setPendingTemplateApply,
   autosave,
   buildConfig,
   commitPolicy,
@@ -1782,55 +1734,6 @@ function AdvancedPolicySettings({
   return (
                 <AdvancedPolicyControls forceOpen={Boolean(invalidPolicyField && ["risk_policy", "inline_comment_limit", "agent_roster", "description_policy"].includes(invalidPolicyField))} onOpened={() => trackCodeReviewPolicyEvent({ event: "code_review_advanced_opened", scope: analyticsScope, subsection: "all", configured: true })}>
                   {invalidPolicyField ? <ErrorNotice title="Could not save this policy setting" description={`Correct the highlighted ${invalidPolicyField.replaceAll("_", " ")} setting and try again.`} /> : null}
-                  <div className="grid gap-3 md:grid-cols-[1fr_auto] md:items-end">
-                    <FilterSelect
-                      label="Advanced policy preset"
-                      value={selectedTemplateKey}
-                      onValueChange={setSelectedTemplateKey}
-                      info="Selects a whole-policy replacement covering safety controls, thresholds, and agent settings. No selection makes no change; applying a selection autosaves a new policy version."
-                    >
-                      <SelectItem value={NO_TEMPLATE}>No template selected</SelectItem>
-                      {templates.map((template) => (
-                        <SelectItem key={template.key} value={template.key}>
-                          {template.title}
-                        </SelectItem>
-                      ))}
-                    </FilterSelect>
-                    <div className="flex items-center gap-1.5">
-                      <Button
-                        variant="outline"
-                        disabled={!selectedTemplate || !config}
-                        onClick={() => {
-                          if (!selectedTemplate) return;
-                          const latestConfig = readLatestConfig();
-                          const alreadyApplied =
-                            selectedTemplateAlreadyApplied ||
-                            (latestConfig
-                              ? JSON.stringify(latestConfig) === JSON.stringify(selectedTemplate.config)
-                              : false);
-                          if (alreadyApplied) {
-                            toast.info(`${selectedTemplate.title} is already applied`);
-                            return;
-                          }
-                          setPendingTemplateApply({
-                            key: selectedTemplate.key,
-                            title: selectedTemplate.title,
-                          });
-                          autosave.save(clonePolicy(selectedTemplate.config));
-                        }}
-                      >
-                        Apply preset
-                      </Button>
-                      <SettingInfoTooltip
-                        label="Apply advanced policy preset"
-                        description="Replaces the complete effective policy with the selected preset and autosaves a new policy version. This changes safety controls, thresholds, and agent settings—not just visible text."
-                      />
-                    </div>
-                    <p className="text-xs text-muted-foreground md:col-span-2">
-                      Applying a preset replaces safety controls, thresholds, and agent settings across the whole policy.
-                    </p>
-                  </div>
-
                 <div>
                   <div className="text-sm font-medium text-foreground">Fine-tuning</div>
                   <div className="mt-2 divide-y divide-border border-y border-border">
@@ -2038,7 +1941,7 @@ function AdvancedPolicyControls({ children, forceOpen, onOpened }: { children: R
           </h3>
           <SettingInfoTooltip
             label="Safeguards"
-            description="Contains deterministic approval safeguards, reviewer configuration, limits, structured PR-description checks, and whole-policy presets. Defaults remain enforced while this section is closed."
+            description="Contains deterministic approval safeguards, reviewer configuration, limits, and structured PR-description checks. Defaults remain enforced while this section is closed."
           />
         </div>
         <CollapsibleContent className="space-y-4 border-t border-border p-4 sm:p-5">{children}</CollapsibleContent>
@@ -2635,35 +2538,6 @@ function DescriptionRequirementSheet({
         ) : null}
       </SheetContent>
     </Sheet>
-  );
-}
-
-function FilterSelect({
-  label,
-  info,
-  value,
-  onValueChange,
-  children,
-}: {
-  label: string;
-  info?: string;
-  value: string;
-  onValueChange: (value: string) => void;
-  children: ReactNode;
-}) {
-  return (
-    <div className="flex min-w-0 flex-col gap-2">
-      <div className="flex items-center gap-1.5">
-      <Label className="text-xs text-muted-foreground">{label}</Label>
-        {info ? <SettingInfoTooltip label={label} description={info} /> : null}
-      </div>
-      <Select value={value} onValueChange={onValueChange}>
-        <SelectTrigger aria-label={label}>
-          <SelectValue />
-        </SelectTrigger>
-        <SelectContent>{children}</SelectContent>
-      </Select>
-    </div>
   );
 }
 

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -341,7 +341,6 @@ export const api = {
       const qs = searchParams.toString();
       return get<import('./types').SingleResponse<import('./types').CodeReviewAnalytics>>(`/api/v1/code-reviews/analytics${qs ? `?${qs}` : ''}`);
     },
-    templates: () => get<import('./types').ListResponse<import('./types').CodeReviewTemplateOption>>('/api/v1/code-reviews/templates'),
     promptExamples: () => get<import('./types').SingleResponse<import('./types').CodeReviewPromptExamplesResponse>>('/api/v1/code-reviews/prompt-examples'),
     policyEvent: (body: import('./types').CodeReviewPolicyAnalyticsEvent) => post<void>('/api/v1/code-reviews/policy-events', body),
     evidence: (sessionId: string) =>

--- a/frontend/src/lib/query-keys.ts
+++ b/frontend/src/lib/query-keys.ts
@@ -52,7 +52,6 @@ export const queryKeys = {
     analyticsReport: (params?: unknown) => ["code-reviews", "analytics", params ?? null] as const,
     policy: ["code-reviews", "policy"] as const,
     githubTrigger: (repositoryId?: string | null) => ["code-reviews", "github-trigger", repositoryId ?? null] as const,
-    templates: ["code-reviews", "templates"] as const,
     promptExamples: ["code-reviews", "prompt-examples"] as const,
     evidence: (sessionId: string) => ["code-reviews", "evidence", sessionId] as const,
   },

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -250,13 +250,6 @@ export interface CodeReviewGitHubTriggerResponse {
   message?: string;
 }
 
-export interface CodeReviewTemplateOption {
-  key: string;
-  title: string;
-  description: string;
-  config: CodeReviewPolicyConfig;
-}
-
 export interface CodeReviewPromptExampleOption {
   key: "balanced" | "security_focused" | "minimal";
   title: string;

--- a/internal/api/handlers/code_reviews.go
+++ b/internal/api/handlers/code_reviews.go
@@ -590,11 +590,6 @@ func (h *CodeReviewHandler) Analytics(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, models.SingleResponse[models.CodeReviewAnalytics]{Data: analytics})
 }
 
-func (h *CodeReviewHandler) Templates(w http.ResponseWriter, r *http.Request) {
-	_ = middleware.OrgIDFromContext(r.Context())
-	writeJSON(w, http.StatusOK, models.ListResponse[models.CodeReviewTemplateOption]{Data: models.CodeReviewPolicyTemplates()})
-}
-
 func (h *CodeReviewHandler) PromptExamples(w http.ResponseWriter, r *http.Request) {
 	_ = middleware.OrgIDFromContext(r.Context())
 	writeJSON(w, http.StatusOK, models.SingleResponse[models.CodeReviewPromptExamplesResponse]{Data: models.CodeReviewPromptExamplesResponse{

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -1258,7 +1258,6 @@ func NewRouter(cfg *config.Config, pool *pgxpool.Pool, logger zerolog.Logger, se
 				r.Get("/api/v1/code-reviews/stats", codeReviewHandler.Stats)
 				r.Get("/api/v1/code-reviews/analytics", codeReviewHandler.Analytics)
 				r.Get("/api/v1/code-reviews/stream", codeReviewHandler.StreamUpdates)
-				r.Get("/api/v1/code-reviews/templates", codeReviewHandler.Templates)
 				r.Get("/api/v1/code-reviews/prompt-examples", codeReviewHandler.PromptExamples)
 				r.Post("/api/v1/code-reviews/policy-events", codeReviewHandler.PolicyEvent)
 				r.Get("/api/v1/code-reviews/{id}/evidence", codeReviewHandler.Evidence)

--- a/internal/models/code_review.go
+++ b/internal/models/code_review.go
@@ -1030,23 +1030,6 @@ type CodeReviewEvidence struct {
 	PromptArtifacts []CodeReviewPromptArtifact `json:"prompt_artifacts,omitempty"`
 }
 
-type CodeReviewTemplate string
-
-const (
-	CodeReviewTemplateDocsOnly      CodeReviewTemplate = "docs_and_comments_only"
-	CodeReviewTemplateTestsOnly     CodeReviewTemplate = "tests_only"
-	CodeReviewTemplateSmallFrontend CodeReviewTemplate = "small_frontend_change"
-	CodeReviewTemplateSmallBackend  CodeReviewTemplate = "small_backend_change"
-	CodeReviewTemplateSmallCombined CodeReviewTemplate = "small_combined_feature"
-)
-
-type CodeReviewTemplateOption struct {
-	Key         CodeReviewTemplate     `json:"key"`
-	Title       string                 `json:"title"`
-	Description string                 `json:"description"`
-	Config      CodeReviewPolicyConfig `json:"config"`
-}
-
 type CodeReviewPromptExample string
 
 const (
@@ -1096,89 +1079,6 @@ func CodeReviewAutomatedApprovalExamples() []CodeReviewAutomatedApprovalExampleO
 		{Key: CodeReviewAutomatedApprovalExampleDocumentation, Title: "Documentation-only approval", Description: "Approve clear documentation changes while escalating executable or generated changes.", Policy: "Automatically approve clear, accurate documentation-only changes when they match the implementation and contain no executable, configuration, generated, or security-sensitive changes.\n\nRequire human review whenever the change affects runtime behavior, configuration, generated files, permissions, secrets, or the intended documentation behavior is ambiguous." + codeReviewIndependentApprovalPolicy},
 		{Key: CodeReviewAutomatedApprovalExampleSmallRoutine, Title: "Small routine changes", Description: "Approve narrow changes that follow established patterns with proportionate tests.", Policy: "Automatically approve small, narrowly scoped changes that follow established repository patterns, have no blocking findings, and include test evidence proportionate to their risk.\n\nRequire human review for architectural changes, sensitive areas, unclear intent, reviewer disagreement, weak evidence, or any change whose impact cannot be evaluated confidently." + codeReviewIndependentApprovalPolicy},
 	}
-}
-
-func CodeReviewPolicyTemplates() []CodeReviewTemplateOption {
-	base := DefaultCodeReviewPolicyConfig()
-	return []CodeReviewTemplateOption{
-		{
-			Key:         CodeReviewTemplateDocsOnly,
-			Title:       "Docs and comments only",
-			Description: "Approve only documentation/comment-only changes with passing checks.",
-			Config: templatePolicy(base, templatePolicyOptions{
-				maxFiles: 8,
-				maxLines: 400,
-				allowedPaths: []string{
-					"docs/**", "**/*.md", "**/*.mdx", "**/*.txt", "**/*.rst", "**/*.adoc", "**/README*", "**/CHANGELOG*",
-				},
-				blockedPaths: []string{".github/**", "deploy/**", "infra/**", "**/.env*", "**/secrets/**"},
-			}),
-		},
-		{
-			Key:         CodeReviewTemplateTestsOnly,
-			Title:       "Tests only",
-			Description: "Approve isolated test and fixture changes with conservative churn limits.",
-			Config: templatePolicy(base, templatePolicyOptions{
-				maxFiles: 10,
-				maxLines: 500,
-				allowedPaths: []string{
-					"tests/**", "test/**", "**/__tests__/**", "**/*_test.go", "**/*.test.ts", "**/*.test.tsx",
-					"**/*.spec.ts", "**/*.spec.tsx", "fixtures/**", "**/fixtures/**", "testdata/**", "**/testdata/**",
-				},
-				blockedPaths: []string{"**/__snapshots__/**", "**/*.snap", "**/*.golden", "**/golden/**"},
-			}),
-		},
-		{
-			Key:         CodeReviewTemplateSmallFrontend,
-			Title:       "Small frontend change",
-			Description: "Approve small UI changes with screenshot or preview evidence.",
-			Config: templatePolicy(base, templatePolicyOptions{
-				maxFiles: 5,
-				maxLines: 250,
-				blockedPaths: []string{
-					"**/auth/**", "**/billing/**", "**/api/**", "**/queries/**",
-					"**/services/**", "**/data/**", "migrations/**",
-				},
-			}),
-		},
-		{
-			Key:         CodeReviewTemplateSmallBackend,
-			Title:       "Small backend change",
-			Description: "Approve small backend changes outside sensitive packages with test evidence.",
-			Config: templatePolicy(base, templatePolicyOptions{
-				maxFiles:     4,
-				maxLines:     200,
-				blockedPaths: []string{"migrations/**", "**/schema/**", "**/auth/**", "**/billing/**", ".github/**"},
-			}),
-		},
-		{
-			Key:         CodeReviewTemplateSmallCombined,
-			Title:       "Small combined feature",
-			Description: "Approve tightly scoped frontend/backend changes with evidence and passing checks.",
-			Config: templatePolicy(base, templatePolicyOptions{
-				maxFiles:     6,
-				maxLines:     250,
-				blockedPaths: []string{"migrations/**", "**/schema/**", "**/auth/**", "**/billing/**", ".github/**", "deploy/**"},
-			}),
-		},
-	}
-}
-
-type templatePolicyOptions struct {
-	maxFiles     int
-	maxLines     int
-	allowedPaths []string
-	blockedPaths []string
-}
-
-func templatePolicy(base CodeReviewPolicyConfig, opts templatePolicyOptions) CodeReviewPolicyConfig {
-	cfg := base
-	cfg.ApprovalMode = CodeReviewApprovalModeApproveAcceptable
-	cfg.RiskPolicy.MaxFilesChanged = opts.maxFiles
-	cfg.RiskPolicy.MaxLinesChanged = opts.maxLines
-	cfg.RiskPolicy.AllowedPathPatterns = opts.allowedPaths
-	cfg.RiskPolicy.BlockedPathPatterns = opts.blockedPaths
-	return cfg
 }
 
 type CodeReviewRiskInput struct {

--- a/internal/models/code_review_test.go
+++ b/internal/models/code_review_test.go
@@ -347,26 +347,6 @@ func TestResolveCodeReviewPolicyConfigNormalizesPromptFields(t *testing.T) {
 	}
 }
 
-func TestCodeReviewPolicyTemplates(t *testing.T) {
-	t.Parallel()
-
-	templates := CodeReviewPolicyTemplates()
-
-	require.Len(t, templates, 5, "starter templates should cover the product design templates")
-	for _, template := range templates {
-		t.Run(string(template.Key), func(t *testing.T) {
-			t.Parallel()
-
-			require.NotEmpty(t, template.Title, "template should have a display title")
-			require.Equal(t, CodeReviewApprovalModeApproveAcceptable, template.Config.ApprovalMode, "starter templates should be editable approval policies")
-			require.Contains(t, template.Config.AutomatedApprovalPolicy, "Unresolved human review threads must not count against approval.", "starter templates should require an independent decision")
-			require.NotContains(t, template.Config.RiskPolicy.BlockedPathPatterns, "**/*auth*", "starter templates should not block incidental auth substrings")
-			require.NotContains(t, template.Config.RiskPolicy.BlockedPathPatterns, "**/*billing*", "starter templates should not block incidental billing substrings")
-			require.NoError(t, template.Config.Validate(), "template config should be valid")
-		})
-	}
-}
-
 func TestEvaluateCodeReviewRisk(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

The code review preset/template UI and backend still referenced retired “preset” definitions, creating a workflow gap where users could not reliably apply or persist the intended policy—plus a reliability risk of stale routes/types lingering in the product. This change removes the retired preset/template surface area and updates the dashboard + API + models/docs to consistently use persisted code review policies only.

## Changes

- Removed the retired `/api/v1/code-reviews/templates` route/handler and related template catalog/model/test code.
- Updated the frontend Code Reviews page and its tests to eliminate preset selection/apply state and to load existing policy data via the API client/types.
- Consolidated docs and design notes to match the simplified policy surface (removed references to the five retired preset names and template/preset behavior).
- Tightened API/model contracts to reflect only supported persisted policies (and kept evidence/reporting endpoints intact).

## Validation

- Updated and verified frontend unit test coverage for the dashboard page (`page.test.tsx`).
- Ensured backend compile/test correctness via existing Go model tests and handler coverage (`internal/models/code_review_test.go`).
- Ran repo hygiene checks: `git diff --check` (no trailing whitespace/format issues).

[143.dev](https://143.dev) | [session 616c980f](https://143.dev/sessions/616c980f-a0a6-4fdd-a0ca-7a2eab52694f)

<!-- 143-publication session=616c980f-a0a6-4fdd-a0ca-7a2eab52694f changeset=fc757f3e-0005-491b-a8d1-dbc4d1ee2aec -->

Preview: https://143.dev/previews/github/assembledhq/143/pull/2037?launch=1