### PR TITLE
Differentiate Two Similar UI Components with Distinct Icons

### DIFF
--- a/frontend/src/app/(dashboard)/sessions/[id]/page-overview.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/page-overview.test.tsx
@@ -443,6 +443,10 @@ describe('SessionDetailPage overview and review loop', () => {
     expect(reviewButton).not.toHaveClass('w-full');
     const reviewTitle = screen.getByText('Review before creating a PR?');
     const splitTitle = screen.getByText('Need smaller pull requests?');
+    const reviewCard = reviewTitle.closest('[data-slot="card"]');
+    const splitCard = splitTitle.closest('[data-slot="card"]');
+    expect(reviewCard?.querySelector('[data-slot="agent-action-card-icon"] .lucide-scan-search')).toBeInTheDocument();
+    expect(splitCard?.querySelector('[data-slot="agent-action-card-icon"] .lucide-git-branch')).toBeInTheDocument();
     expect(reviewTitle.compareDocumentPosition(splitTitle) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
     expect(within(screen.getByLabelText('Session detail actions')).queryByRole('button', { name: 'Review' })).not.toBeInTheDocument();
   });

--- a/frontend/src/app/(dashboard)/sessions/[id]/pull-request-list.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/pull-request-list.test.tsx
@@ -113,6 +113,7 @@ describe('ChangesetSplitPrompt', () => {
 
     expect(screen.getByText('Need smaller pull requests?')).toBeInTheDocument();
     expect(screen.getByText('Ask the coding agent to split the current diff into reviewable branches.')).toBeInTheDocument();
+    expect(document.querySelector('[data-slot="agent-action-card-icon"] .lucide-git-branch')).toBeInTheDocument();
     expect(onRequestSplit).toHaveBeenCalledOnce();
   });
 

--- a/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
@@ -31,6 +31,7 @@ import {
   Clock,
   MessageSquare,
   Pencil,
+  ScanSearch,
 } from "lucide-react";
 import { LinearIcon } from "@/components/linear-icon";
 import { looksLikeLinearRef } from "@/lib/linear-refs";
@@ -3294,6 +3295,7 @@ export function ChangesetSplitPrompt({
 
   return (
     <AgentActionCard
+      icon={<GitBranch className="h-4 w-4" />}
       title="Need smaller pull requests?"
       description="Ask the coding agent to split the current diff into reviewable branches."
       action={(
@@ -3306,10 +3308,12 @@ export function ChangesetSplitPrompt({
 }
 
 function AgentActionCard({
+  icon,
   title,
   description,
   action,
 }: {
+  icon: ReactNode;
   title: string;
   description: string;
   action: ReactNode;
@@ -3319,9 +3323,18 @@ function AgentActionCard({
     // element is never its own query container.
     <Card className="@container/agent-action border-border/60">
       <CardContent className="flex flex-col gap-3 p-4 @min-[24rem]/agent-action:flex-row @min-[24rem]/agent-action:items-center @min-[24rem]/agent-action:justify-between">
-        <div className="min-w-0">
-          <p className="text-sm font-medium text-foreground">{title}</p>
-          <p className="text-xs leading-relaxed text-muted-foreground">{description}</p>
+        <div className="flex min-w-0 items-start gap-3">
+          <div
+            data-slot="agent-action-card-icon"
+            aria-hidden="true"
+            className="flex h-8 w-8 shrink-0 items-center justify-center rounded-md bg-muted text-muted-foreground"
+          >
+            {icon}
+          </div>
+          <div className="min-w-0">
+            <p className="text-sm font-medium text-foreground">{title}</p>
+            <p className="text-xs leading-relaxed text-muted-foreground">{description}</p>
+          </div>
         </div>
         <div
           data-slot="agent-action-card-action"
@@ -6329,6 +6342,7 @@ export function SessionDetailContent({ id }: { id: string }) {
               </Card>
             ) : (
               <AgentActionCard
+                icon={<ScanSearch className="h-4 w-4" />}
                 title="Review before creating a PR?"
                 description="Ask a review agent to check the current diff and apply fixes."
                 action={(


### PR DESCRIPTION
## Summary

Users can’t reliably tell apart two similar session actions (“Review & fix” vs “Split PRs”) in the session detail workflow, increasing the chance of selecting the wrong agent action. This change differentiates the UI by introducing distinct icons per action while keeping the existing muted tile styling for consistency.

## Changes

- Updated `AgentActionCard` to accept an `icon` prop and render it in a dedicated, testable icon container (`data-slot="agent-action-card-icon"`).
- Added the correct icon to each prompt: `ScanSearch` for “Review & fix” and `GitBranch` for “Need smaller pull requests?”.
- Strengthened regression coverage in session detail and pull request list tests by asserting the expected icon renders for each card.

## Validation

- 46 focused tests passed
- ESLint passed
- `git diff --check` passed

Note: sandbox preview remained stuck during startup, so no screenshot could be captured.

[143.dev](https://143.dev) | [session b6fa8204](https://143.dev/sessions/b6fa8204-8b3f-4339-a04d-aed6b47f792a)

<!-- 143-publication session=b6fa8204-8b3f-4339-a04d-aed6b47f792a changeset=7cc7968d-9b3e-4ae5-bdc0-a7fe84eafc00 -->

Preview: https://143.dev/previews/github/assembledhq/143/pull/2039?launch=1