### PR TITLE
Align Review and Split PR buttons with second column text layout

### DIFF
--- a/frontend/src/app/(dashboard)/sessions/[id]/page-overview.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/page-overview.test.tsx
@@ -438,7 +438,8 @@ describe('SessionDetailPage overview and review loop', () => {
     expect(screen.getByText('Ask a review agent to check the current diff and apply fixes.')).toBeInTheDocument();
     expect(reviewButton).toHaveAttribute('title', 'A reusable sandbox snapshot is required before review');
     const reviewAction = reviewButton.closest('[data-slot="agent-action-card-action"]');
-    expect(reviewAction).toHaveClass('w-fit', 'self-start');
+    expect(reviewAction).toHaveClass('ml-11', 'w-fit', 'self-start');
+    expect(reviewAction).toHaveClass('@min-[24rem]/agent-action:ml-0');
     expect(reviewAction).not.toHaveClass('w-full');
     expect(reviewButton).not.toHaveClass('w-full');
     const reviewTitle = screen.getByText('Review before creating a PR?');

--- a/frontend/src/app/(dashboard)/sessions/[id]/pull-request-list.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/pull-request-list.test.tsx
@@ -146,7 +146,8 @@ describe('ChangesetSplitPrompt', () => {
 
     const button = screen.getByRole('button', { name: 'Split PRs' });
     const action = button.closest('[data-slot="agent-action-card-action"]');
-    expect(action).toHaveClass('w-fit', 'self-start');
+    expect(action).toHaveClass('ml-11', 'w-fit', 'self-start');
+    expect(action).toHaveClass('@min-[24rem]/agent-action:ml-0');
     expect(action).not.toHaveClass('w-full');
     expect(button).not.toHaveClass('w-full');
   });

--- a/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
@@ -3338,7 +3338,7 @@ function AgentActionCard({
         </div>
         <div
           data-slot="agent-action-card-action"
-          className="w-fit shrink-0 self-start @min-[24rem]/agent-action:self-auto"
+          className="ml-11 w-fit shrink-0 self-start @min-[24rem]/agent-action:ml-0 @min-[24rem]/agent-action:self-auto"
         >
           {action}
         </div>


### PR DESCRIPTION
## Summary

On narrow session cards, the **Review** and **Split PRs** action buttons don’t line up with the second-column text layout, causing a noticeable visual shift and increasing the chance users misinterpret which action belongs to the content they’re reading. This PR adjusts the action container styling to maintain the intended wide-layout alignment while correcting the narrow breakpoint positioning.

## Changes

- Update `AgentActionCard` action slot to include `ml-11` spacing on small layouts.
- Add breakpoint-specific override `@min-[24rem]/agent-action:ml-0` to preserve the existing wide layout behavior.
- Strengthen layout regression coverage by updating tests for both **Review** and **Split PRs** action card positioning.

## Validation

- Ran focused tests: **47 passed**
- ESLint: **passed**
- Added layout regression assertions for both actions
- Preview screenshot unavailable due to repeated preview browser timeouts; preview remained healthy

[143.dev](https://143.dev) | [session e23711c8](https://143.dev/sessions/e23711c8-8706-4e71-9674-110543eed60f)

<!-- 143-publication session=e23711c8-8706-4e71-9674-110543eed60f changeset=7cbcdd8a-10f5-409b-b8ae-6a761aa13c64 -->

Preview: https://143.dev/previews/github/assembledhq/143/pull/2040?launch=1