### PR TITLE
Fix publication initiator membership scope

### DIFF
--- a/internal/db/migrations_test.go
+++ b/internal/db/migrations_test.go
@@ -1551,3 +1551,18 @@ func TestActivityPhaseTranscriptAssociationMigration(t *testing.T) {
 		)
 	}
 }
+
+func TestPublicationInitiatorMembershipScopeMigration(t *testing.T) {
+	t.Parallel()
+
+	upBody, err := os.ReadFile("../../migrations/000278_fix_publication_initiator_membership_scope.up.sql")
+	require.NoError(t, err, "test should read the publication initiator membership migration")
+	validateBody, err := os.ReadFile("../../migrations/000279_validate_publication_initiator_membership_scope.up.sql")
+	require.NoError(t, err, "test should read the publication initiator validation migration")
+
+	upSQL := string(upBody)
+	require.Contains(t, upSQL, "REFERENCES organization_memberships(user_id, org_id)", "publication attribution should follow authoritative multi-org membership")
+	require.Contains(t, upSQL, "ON DELETE SET NULL (initiated_by_user_id)", "membership removal should preserve publications while clearing stale attribution")
+	require.Contains(t, upSQL, "NOT VALID", "constraint replacement should avoid scanning rows under the catalog lock")
+	require.Contains(t, string(validateBody), "VALIDATE CONSTRAINT session_publications_initiator_scope_fkey", "a separate migration should validate existing publication attribution")
+}

--- a/migrations/000278_fix_publication_initiator_membership_scope.down.sql
+++ b/migrations/000278_fix_publication_initiator_membership_scope.down.sql
@@ -1,0 +1,10 @@
+SET LOCAL lock_timeout = '5s';
+
+ALTER TABLE session_publications
+    DROP CONSTRAINT IF EXISTS session_publications_initiator_scope_fkey;
+
+ALTER TABLE session_publications
+    ADD CONSTRAINT session_publications_initiator_scope_fkey
+        FOREIGN KEY (initiated_by_user_id, org_id)
+        REFERENCES users(id, org_id)
+        NOT VALID;

--- a/migrations/000278_fix_publication_initiator_membership_scope.up.sql
+++ b/migrations/000278_fix_publication_initiator_membership_scope.up.sql
@@ -1,0 +1,20 @@
+-- session_publications.initiated_by_user_id records a global user identity,
+-- while users.org_id is only that user's legacy/default organization. Retarget
+-- the tenant-scope FK to the authoritative multi-org membership pair so users
+-- can publish sessions from any organization they belong to.
+--
+-- The replacement FK is installed NOT VALID to keep the catalog-locking step
+-- brief. Migration 000279 validates existing rows separately. If a membership
+-- is later removed, preserve the publication record but clear its attribution;
+-- org_id remains intact and continues to scope the publication.
+SET LOCAL lock_timeout = '5s';
+
+ALTER TABLE session_publications
+    DROP CONSTRAINT IF EXISTS session_publications_initiator_scope_fkey;
+
+ALTER TABLE session_publications
+    ADD CONSTRAINT session_publications_initiator_scope_fkey
+        FOREIGN KEY (initiated_by_user_id, org_id)
+        REFERENCES organization_memberships(user_id, org_id)
+        ON DELETE SET NULL (initiated_by_user_id)
+        NOT VALID;

--- a/migrations/000279_validate_publication_initiator_membership_scope.down.sql
+++ b/migrations/000279_validate_publication_initiator_membership_scope.down.sql
@@ -1,0 +1,1 @@
+-- Validation is intentionally irreversible. The constraint remains valid.

--- a/migrations/000279_validate_publication_initiator_membership_scope.up.sql
+++ b/migrations/000279_validate_publication_initiator_membership_scope.up.sql
@@ -1,0 +1,4 @@
+SET LOCAL lock_timeout = '5s';
+
+ALTER TABLE session_publications
+    VALIDATE CONSTRAINT session_publications_initiator_scope_fkey;


### PR DESCRIPTION
## Summary
- Retarget `session_publications.initiated_by_user_id` from the legacy `users(id, org_id)` pair to the authoritative `organization_memberships(user_id, org_id)` pair.
- Clear only publication attribution when a membership is removed, preserving the tenant-scoped publication record.
- Split constraint installation and validation across migrations 278/279 to keep the catalog-locking step brief.
- Keep this PR migration-only so it has no overlapping files with #2041.

## Root cause
A user can belong to multiple organizations, while `users.org_id` is only the legacy/default organization. PR #2041 makes publication policy lookup membership-aware, but without this schema correction the subsequent publication-intent insert can still fail its foreign key for sessions in a secondary organization.

## Impact
This PR can merge before or independently of #2041. Once both are deployed, multi-org users can record publication intent and create PRs from any organization where they have an active membership.

## Validation
- `go test ./internal/db -run 'TestPublicationInitiatorMembershipScopeMigration|TestMigrationFilePairs' -count=1`
- `go vet ./internal/db`
- `make lint-schema`
- PostgreSQL 17 migration rehearsal covering secondary-org insertion and membership removal
- Read-only production audit found no existing attributed rows that would fail validation