### PR TITLE
Bypass automatic PR review for explicit Create PR actions

### DIFF
--- a/docs/design/implemented/123-agent-initiated-pr-publication.md
+++ b/docs/design/implemented/123-agent-initiated-pr-publication.md
@@ -95,13 +95,16 @@ implement -> create draft PR -> PR-dependent checks/review/fix
 ```
 
 Draft-first is an explicit repository setting, not a model judgment. It covers
-PR-only CI, previews, security scans, and policy bots. 143 never opens a normal
-non-draft PR before self-review.
+PR-only CI, previews, security scans, and policy bots. Automatic handoff never
+opens a normal non-draft PR before self-review; an authenticated user may make
+the explicit publication decision with **Create PR**.
 
 ### Two-pass review gate
 
-When effective pre-PR review is on, publication intent starts or joins one
-review loop tied to the current changeset, workspace revision, and head SHA:
+When effective pre-PR review is on, an automatic agent-ready publication
+intent starts or joins one review loop tied to the current changeset,
+workspace revision, and head SHA. An authenticated user **Create PR** action
+queues publication without this automatic review gate:
 
 1. Pass 1 reviews and fixes actionable findings.
 2. Pass 2 reviews the updated diff.
@@ -232,8 +235,8 @@ cannot grant permissions, bypass review requirements, override automation
 
 Organization **Session automation** shows two independent toggles; Account
 Settings shows `Use organization default (On) / On / Off`. Review remains
-editable when automatic creation is off because it also governs explicit
-publication.
+independently editable so an organization default and a personal automatic
+handoff override can be configured separately.
 
 ### Repository exception
 
@@ -281,6 +284,12 @@ create_pr
        other terminal result -> leave draft and show attention
 ```
 
+An authenticated user-channel `explicit_action` skips the automatic review
+gate and queues `open_pr` directly. It still uses the durable publication row,
+authorship and builder authorization, repository handoff mode, deduplication,
+and recovery paths above. Agent-ready requests continue to use the configured
+review gate.
+
 Repeated requests join existing state; later edits invalidate clean evidence.
 
 ### Missing tool call
@@ -293,8 +302,9 @@ If an eligible implementation turn ends with a diff but no publication intent:
 - emit `agent_pr_intent_missing`
 
 V1 does not spend another model turn asking whether the agent forgot. UI,
-Slack, and API `Create PR` actions are explicit intent: they ignore the
-automatic-creation preference but still respect review or an authorized bypass.
+Slack, and API `Create PR` actions attributed to an authenticated user are
+explicit publication decisions: they ignore automatic-creation and automatic-
+review preferences while retaining authorization and repository policy.
 
 ### Automations and projects
 
@@ -303,9 +313,10 @@ automatic-creation preference but still respect review or an authorized bypass.
   for a successful non-empty result.
 - Project/stack publication remains parent-controlled.
 
-Two passes is the fixed count for **agent- and user-initiated** publication
-only. Automation-initiated publication keeps its configured
-`pre_pr_review_loops` (validated 0-5, passed straight through as `MaxPasses` by
+Two passes is the fixed count for **agent-ready** publication. Explicit
+user-channel publication queues directly. Automation-initiated publication
+keeps its configured `pre_pr_review_loops` (validated 0-5, passed straight
+through as `MaxPasses` by
 the existing worker path) and records that value in `review_max_passes`. The
 schema therefore bounds `review_max_passes` to 1-5 rather than pinning it to 2;
 pinning it would reject every automation not configured for exactly two loops.

--- a/docs/public/getting-started/review-and-ship.mdx
+++ b/docs/public/getting-started/review-and-ship.mdx
@@ -74,7 +74,9 @@ Questions, planning, diagnosis, review-only work, sessions linked to an
 existing PR, incomplete work, and turns with no changes do not create a new
 PR. Completing an agent process is not a publication signal by itself. If an
 eligible turn leaves changes without requesting publication, the session stays
-available with its normal Create PR action.
+available with its normal Create PR action. Clicking **Create PR** is an
+explicit publication decision and queues the PR directly; the automatic
+review/fix preference still applies when a new session hands off its work.
 
 The session Overview shows one workflow card:
 

--- a/frontend/src/app/(dashboard)/settings/account/page.tsx
+++ b/frontend/src/app/(dashboard)/settings/account/page.tsx
@@ -252,7 +252,7 @@ const PERSONAL_AUTOMATION_COPY: Record<PersonalAutomationKey, { title: string; d
   },
   review_before_pr: {
     title: "Run a two-pass review/fix cycle before creating the PR",
-    description: "Choose whether your PR requests run the two-pass review/fix cycle before publication.",
+    description: "Choose whether automatic PR handoff runs the two-pass review/fix cycle. Clicking Create PR publishes directly.",
   },
   resolve_conflicts_when_idle: {
     title: "Resolve conflicts when idle",

--- a/frontend/src/app/(dashboard)/settings/page.tsx
+++ b/frontend/src/app/(dashboard)/settings/page.tsx
@@ -44,7 +44,7 @@ const PUBLICATION_AUTOMATION_COPY: Record<PublicationAutomationKey, { title: str
   },
   review_before_pr: {
     title: "Run a two-pass review/fix cycle before creating the PR",
-    description: "Review the current changes, apply fixes, and confirm the result before publishing. Explicit Create PR actions use this review policy too.",
+    description: "Review the current changes, apply fixes, and confirm the result before automatic publication. Clicking Create PR publishes directly.",
   },
 };
 

--- a/internal/services/publicationintent/coordinator.go
+++ b/internal/services/publicationintent/coordinator.go
@@ -392,10 +392,16 @@ func (c *Coordinator) RequestPullRequest(
 	if req.TriggerKind == models.SessionPublicationTriggerExplicitAction {
 		automaticSource = models.PublicationPolicySourceExplicitAction
 	}
+	// The review-before-PR preference belongs to automatic handoff. An explicit
+	// authenticated-user Create PR action is already the user's publication
+	// decision and must queue the PR directly. Agent-ready requests keep the
+	// configured gate.
+	explicitUserAction := req.Source == models.SessionPublicationSourceUser &&
+		req.TriggerKind == models.SessionPublicationTriggerExplicitAction
 	// Execution switches must never rewrite effective review policy. If review
 	// is required while execution is stopped, persist a pending gate and park
 	// the intent; treating the switch as review=off would publish unreviewed.
-	reviewRequired := !automationRequest && !backendPolicyRequest && policy.ReviewBeforePR
+	reviewRequired := !automationRequest && !backendPolicyRequest && !explicitUserAction && policy.ReviewBeforePR
 	if manualTakeoverRequested && existingPublication.ReviewGateState == models.SessionPublicationReviewGatePending &&
 		existingPublication.ReviewMaxPasses != nil {
 		// A manual takeover changes execution authority, never the review

--- a/internal/services/publicationintent/coordinator_test.go
+++ b/internal/services/publicationintent/coordinator_test.go
@@ -351,19 +351,22 @@ func TestCoordinatorRequestPullRequest_AutomationUsesDurablePolicyPath(t *testin
 	require.Equal(t, 0, f.jobs.priority, "automation should retain its existing queue priority")
 }
 
-func TestCoordinatorRequestPullRequest_PublicationKillSwitchPreservesExplicitUserPublication(t *testing.T) {
+func TestCoordinatorRequestPullRequest_ExecutionKillSwitchesPreserveExplicitUserPublication(t *testing.T) {
 	t.Parallel()
 
 	f := newCoordinatorFixture(t, models.AutomaticFollowThroughOrgSettings{}, nil, nil, true, nil)
 	f.coordinator.SetPublicationEnabled(false)
+	f.coordinator.SetReviewEnabled(false)
 
 	result, err := f.coordinator.RequestPullRequest(context.Background(), f.orgID, f.sessionID, RequestPullRequest{
 		Source: models.SessionPublicationSourceUser, TriggerKind: models.SessionPublicationTriggerExplicitAction,
 	})
 
-	require.NoError(t, err, "agent publication kill switch should preserve explicit user publication")
-	require.Equal(t, ResultReviewInProgress, result.Status, "explicit user publication should retain the configured review workflow")
+	require.NoError(t, err, "automatic publication and review switches should preserve explicit user publication")
+	require.Equal(t, ResultPRQueued, result.Status, "explicit user publication should queue the PR without starting automatic review")
 	require.NotNil(t, f.publications.captured, "explicit user publication should retain durable intent")
+	require.Equal(t, models.SessionPublicationReviewGateNotRequired, f.publications.captured.ReviewGateState, "explicit user publication should not persist an automatic review gate")
+	require.Nil(t, f.publications.captured.ReviewMaxPasses, "explicit user publication should not schedule review passes")
 	require.NotNil(t, f.jobs.payload, "explicit user publication should remain executable as the manual fallback")
 }
 
@@ -380,7 +383,7 @@ func TestCoordinatorRequestPullRequest_TargetsRequestedChangeset(t *testing.T) {
 	})
 
 	require.NoError(t, err, "targeted publication should be coordinated")
-	require.Equal(t, ResultReviewInProgress, result.Status, "targeted explicit publication should retain effective review policy")
+	require.Equal(t, ResultPRQueued, result.Status, "targeted explicit publication should queue without automatic review")
 	require.NotNil(t, f.changesets.requestedID, "coordinator should use the scoped changeset lookup")
 	require.Equal(t, targetID, *f.changesets.requestedID, "coordinator should publish the requested stack changeset")
 	require.Equal(t, targetID.String(), f.jobs.payload["changeset_id"], "queued publication should retain the requested changeset")
@@ -463,8 +466,8 @@ func TestCoordinatorRequestPullRequest_NonPrimarySafetyGates(t *testing.T) {
 			role: models.RoleMember, wantErrCode: ErrorWorkspaceNotReady,
 		},
 		{
-			name:         "materialized changeset queues its own targeted review",
-			materialized: true, role: models.RoleMember, wantQueued: true, wantStatus: ResultReviewInProgress,
+			name:         "materialized changeset queues its pull request directly",
+			materialized: true, role: models.RoleMember, wantQueued: true, wantStatus: ResultPRQueued,
 		},
 		{
 			name:         "builder evidence cannot attest a separate worktree even with publication review off",
@@ -712,7 +715,7 @@ func TestCoordinatorRequestPullRequestExplicitActionBypassesDisabledPolicy(t *te
 		Source: models.SessionPublicationSourceUser, TriggerKind: models.SessionPublicationTriggerExplicitAction,
 	})
 	require.NoError(t, err, "an explicit user request should be accepted")
-	require.Equal(t, ResultReviewInProgress, explicitResult.Status, "explicit user action should override handoff policy while retaining review")
+	require.Equal(t, ResultPRQueued, explicitResult.Status, "explicit user action should override automatic handoff and review policy")
 }
 
 func TestCoordinatorRequestPullRequestRoutesProjectPolicyToDefaultQueue(t *testing.T) {
@@ -759,9 +762,9 @@ func TestCoordinatorRequestPullRequestRepositoryHandoffAndDraftBypass(t *testing
 			expectedReviewSource: models.PublicationPolicySourceProductDefault,
 		},
 		{
-			name:           "a first draft request is not a review bypass",
+			name:           "a first explicit draft request queues without automatic review",
 			req:            explicitDraftRequest,
-			expectedStatus: ResultReviewInProgress, expectedGate: models.SessionPublicationReviewGatePending,
+			expectedStatus: ResultPRQueued, expectedGate: models.SessionPublicationReviewGateNotRequired,
 			expectedReviewSource: models.PublicationPolicySourceProductDefault,
 		},
 		{
@@ -826,13 +829,13 @@ func TestCoordinatorRequestPullRequestRejoinsOrReopensExistingIntent(t *testing.
 		{
 			name:         "a no-op publication can be retried once there is something to publish",
 			existing:     models.SessionPublication{State: models.SessionPublicationStateCompletedNoop},
-			wantStatus:   ResultReviewInProgress,
+			wantStatus:   ResultPRQueued,
 			wantReopened: true,
 		},
 		{
 			name:         "a terminally failed publication can be retried",
 			existing:     models.SessionPublication{State: models.SessionPublicationStateTerminalFailed},
-			wantStatus:   ResultReviewInProgress,
+			wantStatus:   ResultPRQueued,
 			wantReopened: true,
 		},
 		{
@@ -902,7 +905,7 @@ func TestCoordinatorRequestPullRequestReopensTerminalDraftWithExistingPR(t *test
 	})
 
 	require.NoError(t, err, "a terminal draft-first publication should reopen around its existing draft")
-	require.Equal(t, ResultReviewInProgress, result.Status, "the existing draft should resume review instead of reporting an already-published PR")
+	require.Equal(t, ResultPRQueued, result.Status, "the explicit retry should resume the existing draft without starting automatic review")
 	require.NotNil(t, f.jobs.payload, "the reopened draft publication should enqueue its durable worker")
 	require.NotNil(t, f.publications.captured, "the reopened draft publication should be persisted")
 	require.Equal(t, models.PRHandoffModeDraftFirst, f.publications.captured.HandoffMode, "the reopened publication should retain the existing draft handoff")


### PR DESCRIPTION
## Summary

- Make authenticated user-initiated Create PR actions queue directly without the automatic review/fix gate.
- Keep automatic handoff review behavior and publication safeguards unchanged.
- Update settings copy and design/public documentation to clarify the distinction.
- Update coordinator tests for direct queuing and review-gate state.

## Testing

- Not run (not requested)