### PR TITLE
Persist code review tabs and filters in the URL

### DIFF
--- a/frontend/src/app/(dashboard)/code-reviews/page.test.tsx
+++ b/frontend/src/app/(dashboard)/code-reviews/page.test.tsx
@@ -1,7 +1,7 @@
 import { beforeEach, describe, it, expect, vi } from "vitest";
 import { act } from "react";
 import { delay, http, HttpResponse } from "msw";
-import { createTestQueryClient, fireEvent, renderWithProviders, screen, userEvent, waitFor, within } from "@/test/test-utils";
+import { createTestQueryClient, fireEvent, renderWithProviders as renderWithBaseProviders, screen, userEvent, waitFor, within } from "@/test/test-utils";
 import { server } from "@/test/mocks/server";
 import { queryKeys } from "@/lib/query-keys";
 
@@ -17,6 +17,13 @@ const sse = vi.hoisted(() => ({
 vi.mock("@/lib/notify", () => ({ notify: toast }));
 
 import CodeReviewsPage from "./page";
+
+function renderWithProviders(
+  ui: Parameters<typeof renderWithBaseProviders>[0],
+  options?: Parameters<typeof renderWithBaseProviders>[1],
+) {
+  return renderWithBaseProviders(ui, { nuqsHasMemory: true, ...options });
+}
 
 // jsdom has no EventSource; stub the SSE hook so the live-refresh subscription
 // is a no-op in tests (the list refreshes via React Query as usual). Mirrors
@@ -722,6 +729,46 @@ describe("CodeReviewsPage", () => {
 
     expect(await screen.findByRole("tab", { name: "Analytics" })).toHaveAttribute("data-state", "active");
     expect(await screen.findByText("Usage by PR author")).toBeInTheDocument();
+  });
+
+  it("writes tab navigation to the URL without dropping filters", async () => {
+    const user = userEvent.setup();
+    const onUrlUpdate = vi.fn();
+    mockCodeReviewBaseHandlers();
+    server.use(
+      http.get("/api/v1/code-reviews/analytics", () =>
+        HttpResponse.json({ data: reviewAnalytics } satisfies SingleResponse<CodeReviewAnalytics>)),
+    );
+
+    renderWithProviders(<CodeReviewsPage />, {
+      searchParams: {
+        repository: repo.id,
+        range: "7d",
+        outcome: "blocked",
+      },
+      nuqsHasMemory: true,
+      nuqsOnUrlUpdate: onUrlUpdate,
+    });
+
+    await user.click(await screen.findByRole("tab", { name: "Analytics" }));
+    await waitFor(() => {
+      const update = onUrlUpdate.mock.calls.at(-1)?.[0];
+      expect(update?.searchParams.get("tab")).toBe("analytics");
+      expect(update?.searchParams.get("repository")).toBe(repo.id);
+      expect(update?.searchParams.get("range")).toBe("7d");
+      expect(update?.searchParams.get("outcome")).toBe("blocked");
+      expect(update?.options.history).toBe("push");
+    });
+
+    await user.click(screen.getByRole("tab", { name: "Policy" }));
+    await waitFor(() => {
+      const update = onUrlUpdate.mock.calls.at(-1)?.[0];
+      expect(update?.searchParams.get("tab")).toBe("policy");
+      expect(update?.searchParams.get("repository")).toBe(repo.id);
+      expect(update?.searchParams.get("range")).toBe("7d");
+      expect(update?.searchParams.get("outcome")).toBe("blocked");
+      expect(update?.options.history).toBe("push");
+    });
   });
 
   it("shows failed and stale attempts when no review completed", async () => {

--- a/frontend/src/app/(dashboard)/code-reviews/page.test.tsx
+++ b/frontend/src/app/(dashboard)/code-reviews/page.test.tsx
@@ -760,6 +760,19 @@ describe("CodeReviewsPage", () => {
       expect(update?.options.history).toBe("push");
     });
 
+    const updatesBeforeDrilldown = onUrlUpdate.mock.calls.length;
+    const drilldown = await screen.findByRole("link", { name: "12 reviewed PRs by anya" });
+    drilldown.addEventListener("click", (event) => event.preventDefault(), { capture: true, once: true });
+    await user.click(drilldown);
+    await act(async () => {
+      await new Promise((resolve) => window.setTimeout(resolve, 25));
+    });
+    expect(
+      onUrlUpdate.mock.calls
+        .slice(updatesBeforeDrilldown)
+        .every(([update]) => update.searchParams.get("tab") === "analytics"),
+    ).toBe(true);
+
     await user.click(screen.getByRole("tab", { name: "Policy" }));
     await waitFor(() => {
       const update = onUrlUpdate.mock.calls.at(-1)?.[0];

--- a/frontend/src/app/(dashboard)/code-reviews/page.tsx
+++ b/frontend/src/app/(dashboard)/code-reviews/page.tsx
@@ -1352,7 +1352,6 @@ export default function CodeReviewsPage() {
                 repository: reviewRepositoryId,
                 range: timeRangeFilter,
               }}
-              onNavigateToReviews={() => setActiveTab("reviews")}
               filters={(
                 <CodeReviewFilters
                   id="code-review-analytics-filters"

--- a/frontend/src/app/(dashboard)/code-reviews/page.tsx
+++ b/frontend/src/app/(dashboard)/code-reviews/page.tsx
@@ -485,19 +485,17 @@ export default function CodeReviewsPage() {
   const { user } = useAuth();
   const canManagePolicy = user?.role === "admin";
   const canRetryReviews = user?.role === "admin" || user?.role === "member";
-  const [tabParam] = useQueryState(
+  const [activeTab, setTabParam] = useQueryState(
     "tab",
-    parseAsStringLiteral(CODE_REVIEW_TAB_VALUES).withDefault("reviews"),
+    parseAsStringLiteral(CODE_REVIEW_TAB_VALUES)
+      .withDefault("reviews")
+      .withOptions({ history: "push" }),
   );
-  const [activeTab, setActiveTabState] = useState<CodeReviewTab>(tabParam);
-  useEffect(() => {
-    setActiveTabState(tabParam);
-  }, [tabParam]);
   const setActiveTab = useCallback(
     (value: string) => {
-      setActiveTabState(value as CodeReviewTab);
+      void setTabParam(value as CodeReviewTab);
     },
-    [],
+    [setTabParam],
   );
   const [repositoryFilter, setRepositoryFilter] = useQueryState("repository", parseAsString.withDefault(ALL_REPOSITORIES));
   const [outcomeFilter, setOutcomeParam] = useQueryState(

--- a/frontend/src/components/code-review-analytics.test.tsx
+++ b/frontend/src/components/code-review-analytics.test.tsx
@@ -58,7 +58,6 @@ function renderReport(analytics: CodeReviewAnalytics) {
       authorSortOrder="desc"
       onAuthorSort={vi.fn()}
       reviewLinkFilters={{ range: "30d" }}
-      onNavigateToReviews={vi.fn()}
       filters={null}
     />,
   );

--- a/frontend/src/components/code-review-analytics.tsx
+++ b/frontend/src/components/code-review-analytics.tsx
@@ -119,7 +119,6 @@ function AuthorReviewCountLink({
   outcome,
   repository,
   range,
-  onNavigate,
 }: {
   author: string;
   count: number;
@@ -127,24 +126,12 @@ function AuthorReviewCountLink({
   outcome?: "automatically_approved" | "completed_not_approved";
   repository?: string;
   range: string;
-  onNavigate: () => void;
 }) {
   return (
     <Link
       href={authorReviewsHref({ author, outcome, repository, range })}
       className="font-medium text-primary underline-offset-4 hover:underline focus-visible:rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
       aria-label={`${count.toLocaleString()} ${label} by ${author}`}
-      onClick={(event) => {
-        if (
-          event.button === 0
-          && !event.metaKey
-          && !event.ctrlKey
-          && !event.shiftKey
-          && !event.altKey
-        ) {
-          onNavigate();
-        }
-      }}
     >
       {count.toLocaleString()}
     </Link>
@@ -215,7 +202,6 @@ export function CodeReviewAnalyticsReport({
   authorSortOrder,
   onAuthorSort,
   reviewLinkFilters,
-  onNavigateToReviews,
   filters,
 }: {
   analytics?: CodeReviewAnalytics;
@@ -229,7 +215,6 @@ export function CodeReviewAnalyticsReport({
     repository?: string;
     range: string;
   };
-  onNavigateToReviews: () => void;
   filters: ReactNode;
 }) {
   if (!analytics && isLoading) {
@@ -365,7 +350,6 @@ export function CodeReviewAnalyticsReport({
                         label="reviewed PRs"
                         repository={reviewLinkFilters.repository}
                         range={reviewLinkFilters.range}
-                        onNavigate={onNavigateToReviews}
                       />
                     </TableCell>
                     <TableCell className="text-right tabular-nums">
@@ -376,7 +360,6 @@ export function CodeReviewAnalyticsReport({
                         outcome="automatically_approved"
                         repository={reviewLinkFilters.repository}
                         range={reviewLinkFilters.range}
-                        onNavigate={onNavigateToReviews}
                       />
                     </TableCell>
                     <TableCell className="text-right tabular-nums">
@@ -387,7 +370,6 @@ export function CodeReviewAnalyticsReport({
                         outcome="completed_not_approved"
                         repository={reviewLinkFilters.repository}
                         range={reviewLinkFilters.range}
-                        onNavigate={onNavigateToReviews}
                       />
                     </TableCell>
                     <TableCell className="text-right tabular-nums">

--- a/frontend/src/test/test-utils.tsx
+++ b/frontend/src/test/test-utils.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { render, type RenderOptions } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { NuqsTestingAdapter } from 'nuqs/adapters/testing';
+import { NuqsTestingAdapter, type OnUrlUpdateFunction } from 'nuqs/adapters/testing';
 import { OptimisticSessionsProvider } from '@/contexts/optimistic-sessions';
 
 function createTestQueryClient() {
@@ -32,6 +32,7 @@ interface RenderWithProvidersOptions extends Omit<RenderOptions, 'wrapper'> {
   searchParams?: Record<string, string>;
   queryClient?: QueryClient;
   nuqsHasMemory?: boolean;
+  nuqsOnUrlUpdate?: OnUrlUpdateFunction;
 }
 
 function renderWithProviders(
@@ -42,14 +43,19 @@ function renderWithProviders(
     searchParams,
     queryClient: providedQueryClient,
     nuqsHasMemory,
+    nuqsOnUrlUpdate,
     ...renderOptions
   } = options ?? {};
 
-  if (searchParams || providedQueryClient || nuqsHasMemory) {
+  if (searchParams || providedQueryClient || nuqsHasMemory || nuqsOnUrlUpdate) {
     const wrapper = ({ children }: { children: React.ReactNode }) => {
       const queryClient = providedQueryClient ?? createTestQueryClient();
       return (
-        <NuqsTestingAdapter searchParams={searchParams} hasMemory={nuqsHasMemory}>
+        <NuqsTestingAdapter
+          searchParams={searchParams}
+          hasMemory={nuqsHasMemory}
+          onUrlUpdate={nuqsOnUrlUpdate}
+        >
           <QueryClientProvider client={queryClient}>
             <OptimisticSessionsProvider>
               {children}


### PR DESCRIPTION
## Summary

- Persist the active code review tab in the URL while preserving existing filters
- Keep analytics drill-down links on the analytics tab
- Extend nuqs test helpers and coverage for URL navigation behavior

## Testing

- Added and updated Vitest tests covering tab persistence, filter preservation, and analytics drill-down navigation