### PR TITLE
Recover stuck publication review sessions and wire evidence refresh

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -555,11 +555,7 @@ func main() {
 				if concreteOrchestrator, ok := services.Orchestrator.(*agent.Orchestrator); ok {
 					concreteOrchestrator.SetPublicationIntentCoordinator(workerPublicationCoordinator)
 				}
-				if publicationReviewService, ok := services.ReviewLoops.(*reviewloopservice.Service); ok {
-					publicationReviewService.SetPublicationEvidenceRefresher(
-						worker.NewPublicationReviewEvidenceRefresher(stores, services.PR),
-					)
-				}
+				wirePublicationReviewEvidenceRefresher(services, stores)
 				sandboxAuthShutdown = services.SandboxAuthShutdown
 				registerInternalSandboxAuthRoutes(router, services.SandboxAuthBroker, cfg, logger)
 				if previewManager != nil && pvProvider != nil {

--- a/cmd/server/publication_review_wiring.go
+++ b/cmd/server/publication_review_wiring.go
@@ -1,0 +1,27 @@
+package main
+
+import (
+	reviewloopservice "github.com/assembledhq/143/internal/services/reviewloop"
+	"github.com/assembledhq/143/internal/worker"
+)
+
+type publicationEvidenceRefresherSetter interface {
+	SetPublicationEvidenceRefresher(reviewloopservice.PublicationEvidenceRefresher)
+}
+
+// wirePublicationReviewEvidenceRefresher keeps long-lived workers and
+// isolated session executors on the same publication-review runtime contract.
+// Both processes can finish a review turn, so both need the push/checkpoint
+// dependencies used to bind the next pass to the updated workspace revision.
+func wirePublicationReviewEvidenceRefresher(services *worker.Services, stores *worker.Stores) {
+	if services == nil || stores == nil {
+		return
+	}
+	reviewLoops, ok := services.ReviewLoops.(publicationEvidenceRefresherSetter)
+	if !ok {
+		return
+	}
+	reviewLoops.SetPublicationEvidenceRefresher(
+		worker.NewPublicationReviewEvidenceRefresher(stores, services.PR),
+	)
+}

--- a/cmd/server/publication_review_wiring_test.go
+++ b/cmd/server/publication_review_wiring_test.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/assembledhq/143/internal/models"
+	reviewloopservice "github.com/assembledhq/143/internal/services/reviewloop"
+	"github.com/assembledhq/143/internal/worker"
+)
+
+func TestWirePublicationReviewEvidenceRefresherConfiguresReviewRuntime(t *testing.T) {
+	t.Parallel()
+
+	reviews := &wiringReviewLoops{}
+	services := &worker.Services{ReviewLoops: reviews}
+	stores := &worker.Stores{}
+
+	wirePublicationReviewEvidenceRefresher(services, stores)
+
+	require.NotNil(t, reviews.refresher, "worker and session-executor runtimes should receive publication evidence refresh dependencies")
+}
+
+type wiringReviewLoops struct {
+	refresher reviewloopservice.PublicationEvidenceRefresher
+}
+
+func (w *wiringReviewLoops) SetPublicationEvidenceRefresher(refresher reviewloopservice.PublicationEvidenceRefresher) {
+	w.refresher = refresher
+}
+
+func (w *wiringReviewLoops) OnThreadTurnComplete(context.Context, uuid.UUID, uuid.UUID, string) error {
+	return nil
+}
+
+func (w *wiringReviewLoops) OnThreadTurnFailed(context.Context, uuid.UUID, uuid.UUID, string) error {
+	return nil
+}
+
+func (w *wiringReviewLoops) Start(context.Context, uuid.UUID, uuid.UUID, reviewloopservice.StartReviewLoopRequest) (*models.SessionReviewLoop, error) {
+	return nil, nil
+}
+
+func (w *wiringReviewLoops) ReconcileStrandedPublicationLoops(context.Context, uuid.UUID, time.Time, int) (int, error) {
+	return 0, nil
+}

--- a/cmd/server/session_executor_main.go
+++ b/cmd/server/session_executor_main.go
@@ -318,6 +318,7 @@ func buildSessionExecutorRuntime(ctx context.Context, cfg *config.Config, pool *
 	if services.LinearAgentDeps != nil {
 		services.LinearAgentDeps.Stores = stores
 	}
+	wirePublicationReviewEvidenceRefresher(services, stores)
 
 	oldShutdown := shutdown
 	shutdown = func() {

--- a/cmd/server/session_executor_main_test.go
+++ b/cmd/server/session_executor_main_test.go
@@ -4,10 +4,29 @@ import (
 	"go/ast"
 	"go/parser"
 	"go/token"
+	"os"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 )
+
+func TestSessionExecutorWiresPublicationReviewEvidenceRefresher(t *testing.T) {
+	t.Parallel()
+
+	source, err := os.ReadFile("session_executor_main.go")
+	require.NoError(t, err, "session_executor_main.go should be readable")
+
+	body := string(source)
+	storesBuilt := strings.Index(body, "stores := buildSessionExecutorStores(")
+	wired := strings.Index(body, "wirePublicationReviewEvidenceRefresher(services, stores)")
+	runtimeReturned := strings.Index(body, "return &worker.SessionExecutorRuntime{")
+	require.NotEqual(t, -1, storesBuilt, "session executor should build the complete worker store set")
+	require.NotEqual(t, -1, wired, "session executor should wire publication review evidence refresh after its stores exist")
+	require.NotEqual(t, -1, runtimeReturned, "session executor should return its runtime")
+	require.Greater(t, wired, storesBuilt, "publication evidence refresh should be wired after executor stores are built")
+	require.Less(t, wired, runtimeReturned, "publication evidence refresh should be wired before the executor starts processing jobs")
+}
 
 func TestBuildSessionExecutorStoresIncludesSlackCompletionDependencies(t *testing.T) {
 	t.Parallel()

--- a/internal/db/review_loops.go
+++ b/internal/db/review_loops.go
@@ -17,6 +17,11 @@ type SessionReviewLoopStore struct {
 	db DBTX
 }
 
+type StrandedPublicationReviewLoop struct {
+	LoopID   uuid.UUID `db:"loop_id"`
+	ThreadID uuid.UUID `db:"thread_id"`
+}
+
 func (s *SessionReviewLoopStore) GetPrimaryChangesetID(ctx context.Context, orgID, sessionID uuid.UUID) (uuid.UUID, error) {
 	var changesetID uuid.UUID
 	err := s.db.QueryRow(ctx, `SELECT id FROM session_changesets
@@ -27,6 +32,136 @@ func (s *SessionReviewLoopStore) GetPrimaryChangesetID(ctx context.Context, orgI
 		return uuid.Nil, fmt.Errorf("get primary changeset for review loop: %w", err)
 	}
 	return changesetID, nil
+}
+
+// ListStrandedPublicationLoops returns review loops whose agent thread has
+// been inactive past the recovery cutoff and has no live continuation job. The
+// linked publication predicate prevents manual/automation loops and detached
+// historical rows from being restarted by publication reconciliation.
+func (s *SessionReviewLoopStore) ListStrandedPublicationLoops(
+	ctx context.Context,
+	orgID uuid.UUID,
+	inactiveBefore time.Time,
+	limit int,
+) ([]StrandedPublicationReviewLoop, error) {
+	if limit <= 0 {
+		limit = 50
+	}
+	rows, err := s.db.Query(ctx, `
+		SELECT loop.id AS loop_id, loop.thread_id
+		FROM session_review_loops AS loop
+		JOIN session_threads AS thread
+		  ON thread.org_id = loop.org_id AND thread.id = loop.thread_id
+		JOIN session_publications AS publication
+		  ON publication.org_id = loop.org_id AND publication.review_loop_id = loop.id
+		WHERE loop.org_id = @org_id
+		  AND loop.source = 'publication' AND loop.status = 'running'
+		  AND publication.state = 'review_pending'
+		  AND publication.review_gate_state = 'pending'
+		  AND thread.status IN ('idle', 'completed', 'failed', 'cancelled')
+		  AND COALESCE(thread.last_activity_at, loop.started_at) < @inactive_before
+		  AND NOT EXISTS (
+			SELECT 1
+			FROM jobs
+			WHERE jobs.org_id = loop.org_id
+			  AND jobs.job_type = 'continue_session'
+			  AND jobs.status IN ('pending', 'running')
+			  AND jobs.payload->>'thread_id' = loop.thread_id::text
+		  )
+		ORDER BY COALESCE(thread.last_activity_at, loop.started_at), loop.id
+		LIMIT @limit`, pgx.NamedArgs{
+		"org_id": orgID, "inactive_before": inactiveBefore, "limit": limit,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("list stranded publication review loops: %w", err)
+	}
+	return pgx.CollectRows(rows, pgx.RowToStructByName[StrandedPublicationReviewLoop])
+}
+
+// RestartStrandedPublicationLoop atomically retires one stranded loop, clears
+// its stale evidence link, and requeues the original open_pr request. The new
+// worker attempt checkpoints the current workspace and starts a fresh review,
+// preserving any fixes the prior review wrote before it became stranded.
+func (s *SessionReviewLoopStore) RestartStrandedPublicationLoop(
+	ctx context.Context,
+	orgID, loopID uuid.UUID,
+	inactiveBefore time.Time,
+	summary string,
+) (bool, error) {
+	txStarter, ok := s.db.(TxStarter)
+	if !ok {
+		return false, fmt.Errorf("restart stranded publication review requires transaction support")
+	}
+	tx, err := txStarter.Begin(ctx)
+	if err != nil {
+		return false, fmt.Errorf("begin stranded publication review restart: %w", err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	var sessionID uuid.UUID
+	err = tx.QueryRow(ctx, `
+		UPDATE session_review_loops AS loop
+		SET status = 'failed',
+			latest_summary = @summary,
+			completed_passes = (
+				SELECT count(*)
+				FROM session_review_loop_passes
+				WHERE org_id = @org_id AND loop_id = @loop_id
+				  AND status IN ('clean', 'needs_fix')
+			),
+			completed_at = now()
+		FROM session_threads AS thread
+		WHERE loop.org_id = @org_id AND loop.id = @loop_id
+		  AND loop.source = 'publication' AND loop.status = 'running'
+		  AND thread.org_id = loop.org_id AND thread.id = loop.thread_id
+		  AND thread.status IN ('idle', 'completed', 'failed', 'cancelled')
+		  AND COALESCE(thread.last_activity_at, loop.started_at) < @inactive_before
+		  AND NOT EXISTS (
+			SELECT 1
+			FROM jobs
+			WHERE jobs.org_id = loop.org_id
+			  AND jobs.job_type = 'continue_session'
+			  AND jobs.status IN ('pending', 'running')
+			  AND jobs.payload->>'thread_id' = loop.thread_id::text
+		  )
+		RETURNING loop.session_id`, pgx.NamedArgs{
+		"org_id": orgID, "loop_id": loopID, "inactive_before": inactiveBefore, "summary": summary,
+	}).Scan(&sessionID)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return false, nil
+	}
+	if err != nil {
+		return false, fmt.Errorf("retire stranded publication review loop: %w", err)
+	}
+
+	var payload json.RawMessage
+	var queue models.SessionPublicationJobQueue
+	var changesetID uuid.UUID
+	err = tx.QueryRow(ctx, `
+		UPDATE session_publications
+		SET state = 'review_pending', review_gate_state = 'pending',
+			review_loop_id = NULL, review_workspace_revision = NULL,
+			review_desired_head_sha = NULL, updated_at = now()
+		WHERE org_id = @org_id AND session_id = @session_id
+		  AND review_loop_id = @loop_id
+		  AND state = 'review_pending'
+		  AND review_gate_state = 'pending'
+		RETURNING request_payload, job_queue, changeset_id`, pgx.NamedArgs{
+		"org_id": orgID, "session_id": sessionID, "loop_id": loopID,
+	}).Scan(&payload, &queue, &changesetID)
+	if err != nil {
+		return false, fmt.Errorf("reset stranded publication review intent: %w", err)
+	}
+	dedupeKey := OpenPRDedupeKey(changesetID)
+	if _, err := enqueueOn(ctx, tx, orgID, EnqueueOpts{
+		Queue: string(queue), JobType: "open_pr", Payload: payload, Priority: 5, DedupeKey: &dedupeKey,
+	}); err != nil {
+		return false, fmt.Errorf("requeue stranded publication review: %w", err)
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return false, fmt.Errorf("commit stranded publication review restart: %w", err)
+	}
+	return true, nil
 }
 
 func NewSessionReviewLoopStore(db DBTX) *SessionReviewLoopStore {
@@ -556,7 +691,10 @@ func finishPublicationReviewOn(ctx context.Context, q DBTX, orgID, loopID uuid.U
 	var changesetID uuid.UUID
 	err := q.QueryRow(ctx, `UPDATE session_publications AS publication
 		SET review_gate_state = @gate, state = @state,
-			completed_at = CASE WHEN @state = 'terminal_failed' THEN COALESCE(completed_at, now()) ELSE completed_at END,
+			completed_at = CASE
+				WHEN @state = 'terminal_failed' THEN COALESCE(publication.completed_at, now())
+				ELSE publication.completed_at
+			END,
 			updated_at = now()
 		-- session and changeset are joined for the clean-evidence comparison
 		-- below. They are keyed to the publication here so the join stays

--- a/internal/db/review_loops_postgres_test.go
+++ b/internal/db/review_loops_postgres_test.go
@@ -80,15 +80,18 @@ func TestFinishPublicationReviewPostgresQualifiesCompletedAtAcrossJoinedTables(t
 
 	orgID, sessionID, changesetID, loopID := uuid.New(), uuid.New(), uuid.New(), uuid.New()
 	headSHA := "0123456789abcdef0123456789abcdef01234567"
+	_, err = pool.Exec(ctx, `INSERT INTO sessions (id, org_id, workspace_revision) VALUES ($1, $2, 7)`, sessionID, orgID)
+	require.NoError(t, err, "test should seed the reviewed session")
+	_, err = pool.Exec(ctx, `INSERT INTO session_changesets (id, org_id, session_id, head_sha) VALUES ($1, $2, $3, $4)`, changesetID, orgID, sessionID, headSHA)
+	require.NoError(t, err, "test should seed the reviewed changeset")
+	_, err = pool.Exec(ctx, `INSERT INTO session_review_loops (id, org_id, session_id, workspace_revision, desired_head_sha) VALUES ($1, $2, $3, 7, $4)`, loopID, orgID, sessionID, headSHA)
+	require.NoError(t, err, "test should seed the publication review loop")
 	_, err = pool.Exec(ctx, `
-		INSERT INTO sessions (id, org_id, workspace_revision) VALUES ($1, $2, 7);
-		INSERT INTO session_changesets (id, org_id, session_id, head_sha) VALUES ($3, $2, $1, $5);
-		INSERT INTO session_review_loops (id, org_id, session_id, workspace_revision, desired_head_sha) VALUES ($4, $2, $1, 7, $5);
 		INSERT INTO session_publications (
 			org_id, session_id, changeset_id, review_loop_id, state, review_gate_state,
 			review_workspace_revision, review_desired_head_sha
-		) VALUES ($2, $1, $3, $4, 'review_pending', 'pending', 7, $5)`,
-		sessionID, orgID, changesetID, loopID, headSHA)
+		) VALUES ($1, $2, $3, $4, 'review_pending', 'pending', 7, $5)`,
+		orgID, sessionID, changesetID, loopID, headSHA)
 	require.NoError(t, err, "test should seed a linked publication review")
 
 	err = finishPublicationReviewOn(ctx, pool, orgID, loopID, models.ReviewLoopStatusFailed)

--- a/internal/db/review_loops_postgres_test.go
+++ b/internal/db/review_loops_postgres_test.go
@@ -1,0 +1,108 @@
+package db
+
+import (
+	"context"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/stretchr/testify/require"
+
+	"github.com/assembledhq/143/internal/models"
+)
+
+func TestFinishPublicationReviewPostgresQualifiesCompletedAtAcrossJoinedTables(t *testing.T) {
+	t.Parallel()
+
+	databaseURL := os.Getenv("TEST_DATABASE_URL")
+	if databaseURL == "" {
+		t.Skip("set TEST_DATABASE_URL to run PostgreSQL publication review transition tests")
+	}
+	ctx := context.Background()
+	adminPool, err := pgxpool.New(ctx, databaseURL)
+	require.NoError(t, err, "test should connect to TEST_DATABASE_URL")
+	schema := "test_publication_review_" + strings.ReplaceAll(uuid.NewString(), "-", "_")
+	_, err = adminPool.Exec(ctx, `CREATE SCHEMA `+schema)
+	require.NoError(t, err, "test should create an isolated publication review schema")
+
+	config, err := pgxpool.ParseConfig(databaseURL)
+	require.NoError(t, err, "test should parse the isolated pool configuration")
+	config.ConnConfig.RuntimeParams["search_path"] = schema + ",public"
+	pool, err := pgxpool.NewWithConfig(ctx, config)
+	require.NoError(t, err, "test should connect with the isolated search path")
+	t.Cleanup(func() {
+		pool.Close()
+		_, cleanupErr := adminPool.Exec(context.Background(), `DROP SCHEMA IF EXISTS `+schema+` CASCADE`)
+		require.NoError(t, cleanupErr, "test should remove the isolated publication review schema")
+		adminPool.Close()
+	})
+
+	_, err = pool.Exec(ctx, `
+		CREATE TABLE sessions (
+			id uuid PRIMARY KEY,
+			org_id uuid NOT NULL,
+			workspace_revision bigint NOT NULL,
+			completed_at timestamptz
+		);
+		CREATE TABLE session_changesets (
+			id uuid PRIMARY KEY,
+			org_id uuid NOT NULL,
+			session_id uuid NOT NULL,
+			head_sha text,
+			completed_at timestamptz
+		);
+		CREATE TABLE session_review_loops (
+			id uuid PRIMARY KEY,
+			org_id uuid NOT NULL,
+			session_id uuid NOT NULL,
+			workspace_revision bigint,
+			desired_head_sha text,
+			completed_at timestamptz
+		);
+		CREATE TABLE session_publications (
+			id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+			org_id uuid NOT NULL,
+			session_id uuid NOT NULL,
+			changeset_id uuid NOT NULL,
+			review_loop_id uuid,
+			state text NOT NULL,
+			review_gate_state text NOT NULL,
+			review_workspace_revision bigint,
+			review_desired_head_sha text,
+			request_payload jsonb NOT NULL DEFAULT '{}'::jsonb,
+			job_queue text NOT NULL DEFAULT 'agent',
+			completed_at timestamptz,
+			updated_at timestamptz NOT NULL DEFAULT now()
+		)`)
+	require.NoError(t, err, "test should create the minimal publication review schema")
+
+	orgID, sessionID, changesetID, loopID := uuid.New(), uuid.New(), uuid.New(), uuid.New()
+	headSHA := "0123456789abcdef0123456789abcdef01234567"
+	_, err = pool.Exec(ctx, `
+		INSERT INTO sessions (id, org_id, workspace_revision) VALUES ($1, $2, 7);
+		INSERT INTO session_changesets (id, org_id, session_id, head_sha) VALUES ($3, $2, $1, $5);
+		INSERT INTO session_review_loops (id, org_id, session_id, workspace_revision, desired_head_sha) VALUES ($4, $2, $1, 7, $5);
+		INSERT INTO session_publications (
+			org_id, session_id, changeset_id, review_loop_id, state, review_gate_state,
+			review_workspace_revision, review_desired_head_sha
+		) VALUES ($2, $1, $3, $4, 'review_pending', 'pending', 7, $5)`,
+		sessionID, orgID, changesetID, loopID, headSHA)
+	require.NoError(t, err, "test should seed a linked publication review")
+
+	err = finishPublicationReviewOn(ctx, pool, orgID, loopID, models.ReviewLoopStatusFailed)
+	require.NoError(t, err, "terminal publication review transition should execute against PostgreSQL without an ambiguous completed_at reference")
+
+	var state models.SessionPublicationState
+	var gate models.SessionPublicationReviewGateState
+	var completed bool
+	err = pool.QueryRow(ctx, `
+		SELECT state, review_gate_state, completed_at IS NOT NULL
+		FROM session_publications
+		WHERE org_id = $1 AND review_loop_id = $2`, orgID, loopID).Scan(&state, &gate, &completed)
+	require.NoError(t, err, "test should reload the terminal publication state")
+	require.Equal(t, models.SessionPublicationStateTerminalFailed, state, "failed review should terminally fail publication")
+	require.Equal(t, models.SessionPublicationReviewGateFailed, gate, "failed review should fail the review gate")
+	require.True(t, completed, "terminal publication should record completed_at")
+}

--- a/internal/db/review_loops_test.go
+++ b/internal/db/review_loops_test.go
@@ -143,7 +143,7 @@ func TestSessionReviewLoopStore_PublicationCleanTransitionIsAtomic(t *testing.T)
 		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
 	mock.ExpectQuery("UPDATE session_review_loops").WithArgs(anyArgs(4)...).
 		WillReturnRows(pgxmock.NewRows([]string{"session_id", "source"}).AddRow(sessionID, models.ReviewLoopSourcePublication))
-	mock.ExpectQuery("UPDATE session_publications AS publication").WithArgs(anyArgs(5)...).
+	mock.ExpectQuery(`UPDATE session_publications AS publication[\s\S]+COALESCE\(publication\.completed_at, now\(\)\)[\s\S]+ELSE publication\.completed_at END`).WithArgs(anyArgs(5)...).
 		WillReturnRows(pgxmock.NewRows([]string{"request_payload", "job_queue", "changeset_id"}).AddRow(payload, models.SessionPublicationJobQueueAgent, changesetID))
 	mock.ExpectQuery("INSERT INTO jobs").WithArgs(anyArgs(6)...).
 		WillReturnRows(pgxmock.NewRows([]string{"id"}).AddRow(jobID))
@@ -156,6 +156,59 @@ func TestSessionReviewLoopStore_PublicationCleanTransitionIsAtomic(t *testing.T)
 	)
 	require.NoError(t, err, "clean publication review should advance the gate and enqueue in one transaction")
 	require.NoError(t, mock.ExpectationsWereMet(), "clean publication review should commit loop, gate, and original open_pr enqueue atomically")
+}
+
+func TestSessionReviewLoopStore_ListStrandedPublicationLoopsRequiresInactiveThreadWithoutLiveJob(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "test should create a database mock")
+	t.Cleanup(mock.Close)
+	orgID, loopID, threadID := uuid.New(), uuid.New(), uuid.New()
+	inactiveBefore := time.Now().UTC()
+	mock.ExpectQuery(`SELECT loop\.id AS loop_id, loop\.thread_id[\s\S]+loop\.org_id = @org_id[\s\S]+loop\.source = 'publication'[\s\S]+thread\.status IN \('idle', 'completed', 'failed', 'cancelled'\)[\s\S]+jobs\.status IN \('pending', 'running'\)`).
+		WithArgs(pgx.NamedArgs{"org_id": orgID, "inactive_before": inactiveBefore, "limit": 25}).
+		WillReturnRows(pgxmock.NewRows([]string{"loop_id", "thread_id"}).AddRow(loopID, threadID))
+
+	loops, err := NewSessionReviewLoopStore(mock).ListStrandedPublicationLoops(
+		context.Background(), orgID, inactiveBefore, 25,
+	)
+
+	require.NoError(t, err, "stranded publication review lookup should succeed")
+	require.Equal(t, []StrandedPublicationReviewLoop{{LoopID: loopID, ThreadID: threadID}}, loops, "lookup should return the inactive loop without live continuation work")
+	require.NoError(t, mock.ExpectationsWereMet(), "stranded lookup should enforce tenant, publication, thread, age, and live-job predicates")
+}
+
+func TestSessionReviewLoopStore_RestartStrandedPublicationLoopIsAtomic(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "test should create a database mock")
+	t.Cleanup(mock.Close)
+	orgID, sessionID, loopID, changesetID, jobID := uuid.New(), uuid.New(), uuid.New(), uuid.New(), uuid.New()
+	inactiveBefore := time.Now().UTC()
+	summary := "restart stranded review"
+	payload := json.RawMessage(`{"org_id":"` + orgID.String() + `","session_id":"` + sessionID.String() + `"}`)
+
+	mock.ExpectBegin()
+	mock.ExpectQuery(`UPDATE session_review_loops AS loop[\s\S]+loop\.org_id = @org_id[\s\S]+thread\.status IN \('idle', 'completed', 'failed', 'cancelled'\)[\s\S]+jobs\.status IN \('pending', 'running'\)`).
+		WithArgs(pgx.NamedArgs{"org_id": orgID, "loop_id": loopID, "inactive_before": inactiveBefore, "summary": summary}).
+		WillReturnRows(pgxmock.NewRows([]string{"session_id"}).AddRow(sessionID))
+	mock.ExpectQuery(`UPDATE session_publications[\s\S]+review_loop_id = NULL[\s\S]+org_id = @org_id AND session_id = @session_id`).
+		WithArgs(pgx.NamedArgs{"org_id": orgID, "session_id": sessionID, "loop_id": loopID}).
+		WillReturnRows(pgxmock.NewRows([]string{"request_payload", "job_queue", "changeset_id"}).
+			AddRow(payload, models.SessionPublicationJobQueueAgent, changesetID))
+	mock.ExpectQuery("INSERT INTO jobs").WithArgs(anyArgs(6)...).
+		WillReturnRows(pgxmock.NewRows([]string{"id"}).AddRow(jobID))
+	mock.ExpectCommit()
+
+	restarted, err := NewSessionReviewLoopStore(mock).RestartStrandedPublicationLoop(
+		context.Background(), orgID, loopID, inactiveBefore, summary,
+	)
+
+	require.NoError(t, err, "stranded publication review restart should succeed")
+	require.True(t, restarted, "eligible stranded review should be restarted")
+	require.NoError(t, mock.ExpectationsWereMet(), "restart should retire the loop, clear its evidence, and enqueue the original publication atomically")
 }
 
 func TestFinishPublicationReviewInvalidatesStaleCleanEvidence(t *testing.T) {
@@ -240,7 +293,7 @@ func TestFinishPublicationReviewMapsLoopOutcomeToOneGateMeaning(t *testing.T) {
 			t.Cleanup(mock.Close)
 			orgID, changesetID, loopID, jobID := uuid.New(), uuid.New(), uuid.New(), uuid.New()
 			payload := json.RawMessage(`{"changeset_id":"` + changesetID.String() + `"}`)
-			mock.ExpectQuery("UPDATE session_publications AS publication").
+			mock.ExpectQuery(`UPDATE session_publications AS publication[\s\S]+COALESCE\(publication\.completed_at, now\(\)\)[\s\S]+ELSE publication\.completed_at END`).
 				WithArgs(pgx.NamedArgs{
 					"org_id": orgID, "loop_id": loopID, "gate": tt.expectedGate,
 					"state": tt.expectedState, "status": tt.status,

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -1106,6 +1106,7 @@ const (
 	JobTypeCollectPullRequestFeedback    = "collect_pull_request_feedback"
 	JobTypePublishPRFeedbackResponses    = "publish_pull_request_feedback_responses"
 	JobTypeReconcilePullRequestFeedback  = "reconcile_pull_request_feedback"
+	JobTypeReconcileSessionReviewLoop    = "reconcile_session_review_loop"
 )
 
 // Job represents an async work queue item.

--- a/internal/services/reviewloop/service.go
+++ b/internal/services/reviewloop/service.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
@@ -28,6 +29,8 @@ var (
 )
 
 const MaxReviewPasses = 5
+
+const strandedPublicationReviewSummary = "Publication review became idle without a live continuation job; restarting review from the current workspace."
 
 type Store interface {
 	GetPrimaryChangesetID(ctx context.Context, orgID, sessionID uuid.UUID) (uuid.UUID, error)
@@ -102,12 +105,52 @@ type PublicationEvidenceRefresher interface {
 	RefreshPublicationEvidence(ctx context.Context, loop models.SessionReviewLoop) (workspaceRevision int64, desiredHeadSHA string, err error)
 }
 
+type strandedPublicationReviewStore interface {
+	ListStrandedPublicationLoops(ctx context.Context, orgID uuid.UUID, inactiveBefore time.Time, limit int) ([]db.StrandedPublicationReviewLoop, error)
+	RestartStrandedPublicationLoop(ctx context.Context, orgID, loopID uuid.UUID, inactiveBefore time.Time, summary string) (bool, error)
+}
+
 func NewService(store Store, runtime Runtime) *Service {
 	return &Service{store: store, runtime: runtime, metrics: otelReviewLoopMetrics{}}
 }
 
 func (s *Service) SetPublicationEvidenceRefresher(refresher PublicationEvidenceRefresher) {
 	s.evidenceRefresher = refresher
+}
+
+// ReconcileStrandedPublicationLoops restarts publication reviews that have no
+// live agent work left to advance them. Restarting from the durable workspace
+// is safer than replaying an assistant summary because the failed transition
+// may have stopped before or after applying workspace edits.
+func (s *Service) ReconcileStrandedPublicationLoops(
+	ctx context.Context,
+	orgID uuid.UUID,
+	inactiveBefore time.Time,
+	limit int,
+) (int, error) {
+	recoveryStore, ok := s.store.(strandedPublicationReviewStore)
+	if !ok {
+		return 0, errors.New("publication review recovery store is unavailable")
+	}
+	candidates, err := recoveryStore.ListStrandedPublicationLoops(ctx, orgID, inactiveBefore, limit)
+	if err != nil {
+		return 0, err
+	}
+	restarted := 0
+	var reconcileErr error
+	for _, candidate := range candidates {
+		ok, err := recoveryStore.RestartStrandedPublicationLoop(
+			ctx, orgID, candidate.LoopID, inactiveBefore, strandedPublicationReviewSummary,
+		)
+		if err != nil {
+			reconcileErr = errors.Join(reconcileErr, fmt.Errorf("restart review loop %s: %w", candidate.LoopID, err))
+			continue
+		}
+		if ok {
+			restarted++
+		}
+	}
+	return restarted, reconcileErr
 }
 
 type StartReviewLoopRequest struct {

--- a/internal/services/reviewloop/service_test.go
+++ b/internal/services/reviewloop/service_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/jackc/pgx/v5"
 	"github.com/stretchr/testify/require"
 
+	"github.com/assembledhq/143/internal/db"
 	"github.com/assembledhq/143/internal/models"
 	threadsvc "github.com/assembledhq/143/internal/services/thread"
 )
@@ -134,6 +135,33 @@ func TestService_StartRejectsExistingRunningLoop(t *testing.T) {
 	require.Nil(t, loop, "Start should not return a loop when another loop is running")
 	require.Empty(t, store.createdLoops, "Start should not create another loop row")
 	require.Empty(t, threads.created, "Start should not create an orphan review thread")
+}
+
+func TestService_ReconcileStrandedPublicationLoopsRestartsEveryCandidate(t *testing.T) {
+	t.Parallel()
+
+	orgID := uuid.New()
+	inactiveBefore := time.Now().UTC().Add(-2 * time.Minute)
+	candidates := []db.StrandedPublicationReviewLoop{
+		{LoopID: uuid.New(), ThreadID: uuid.New()},
+		{LoopID: uuid.New(), ThreadID: uuid.New()},
+		{LoopID: uuid.New(), ThreadID: uuid.New()},
+	}
+	store := &fakeRecoveryReviewLoopStore{
+		fakeReviewLoopStore: &fakeReviewLoopStore{},
+		candidates:          candidates,
+	}
+
+	restarted, err := NewService(store, &fakeThreadService{}).ReconcileStrandedPublicationLoops(
+		context.Background(), orgID, inactiveBefore, 25,
+	)
+
+	require.NoError(t, err, "stranded publication review reconciliation should succeed")
+	require.Equal(t, len(candidates), restarted, "reconciliation should restart every eligible loop")
+	require.Equal(t, candidates, store.restarted, "reconciliation should restart the listed loops in order")
+	require.Equal(t, orgID, store.seenOrgID, "reconciliation should remain scoped to the requested organization")
+	require.Equal(t, inactiveBefore, store.seenInactiveBefore, "reconciliation should preserve the inactivity cutoff")
+	require.Equal(t, 25, store.seenLimit, "reconciliation should preserve the bounded batch size")
 }
 
 func TestService_StartPublicationRequiresAndPersistsEvidence(t *testing.T) {
@@ -707,6 +735,43 @@ type fakeReviewLoopStore struct {
 	terminalErr                  error
 	events                       []string
 	primaryChangesetID           uuid.UUID
+}
+
+type fakeRecoveryReviewLoopStore struct {
+	*fakeReviewLoopStore
+	candidates         []db.StrandedPublicationReviewLoop
+	restarted          []db.StrandedPublicationReviewLoop
+	seenOrgID          uuid.UUID
+	seenInactiveBefore time.Time
+	seenLimit          int
+}
+
+func (f *fakeRecoveryReviewLoopStore) ListStrandedPublicationLoops(
+	_ context.Context,
+	orgID uuid.UUID,
+	inactiveBefore time.Time,
+	limit int,
+) ([]db.StrandedPublicationReviewLoop, error) {
+	f.seenOrgID = orgID
+	f.seenInactiveBefore = inactiveBefore
+	f.seenLimit = limit
+	return f.candidates, nil
+}
+
+func (f *fakeRecoveryReviewLoopStore) RestartStrandedPublicationLoop(
+	_ context.Context,
+	_ uuid.UUID,
+	loopID uuid.UUID,
+	_ time.Time,
+	_ string,
+) (bool, error) {
+	for _, candidate := range f.candidates {
+		if candidate.LoopID == loopID {
+			f.restarted = append(f.restarted, candidate)
+			return true, nil
+		}
+	}
+	return false, nil
 }
 
 type recordedReviewLoopMetric struct {

--- a/internal/worker/handlers.go
+++ b/internal/worker/handlers.go
@@ -47,6 +47,10 @@ const sandboxCapacityRetryDelay = 10 * time.Second
 const previewCapacityRetryDelay = 5 * time.Second
 const previewStartupInterruptedRetryDelay = 2 * time.Second
 const prePRReviewRetryDelay = 5 * time.Second
+const reviewLoopRecoveryDelay = 30 * time.Second
+const reviewLoopRecoveryInactiveFor = 15 * time.Second
+const periodicReviewLoopRecoveryInactiveFor = 2 * time.Minute
+const reviewLoopRecoveryBatchSize = 50
 const continuePostSuccessActionPushPRChanges = "push_pr_changes"
 
 var enqueuePRPushChangesJobAfterContinue = enqueuePRPushChangesJob
@@ -450,6 +454,9 @@ func RegisterHandlers(w *Worker, stores *Stores, services *Services, retentionCf
 			w.Register(models.JobTypeStartCodeReviewReassessment, newStartCodeReviewReassessmentHandler(stores, services, logger))
 		}
 	}
+	if services != nil && services.ReviewLoops != nil {
+		w.Register(models.JobTypeReconcileSessionReviewLoop, newReconcileSessionReviewLoopHandler(services, logger))
+	}
 	if services != nil && services.PagerDuty != nil {
 		w.Register(models.JobTypePagerDutyIngestEvent, newPagerDutyIngestEventHandler(services.PagerDuty, logger))
 	}
@@ -824,6 +831,7 @@ type Services struct {
 		OnThreadTurnComplete(ctx context.Context, orgID, threadID uuid.UUID, assistantSummary string) error
 		OnThreadTurnFailed(ctx context.Context, orgID, threadID uuid.UUID, summary string) error
 		Start(ctx context.Context, orgID, sessionID uuid.UUID, req reviewloopsvc.StartReviewLoopRequest) (*models.SessionReviewLoop, error)
+		ReconcileStrandedPublicationLoops(ctx context.Context, orgID uuid.UUID, inactiveBefore time.Time, limit int) (int, error)
 	}
 	// EvalBatchStreams publishes lightweight pub/sub signals on every batch
 	// or run state transition so the eval-batch detail page can replace its
@@ -9988,6 +9996,14 @@ func newContinueSessionHandler(stores *Stores, services *Services, logger zerolo
 							Str("session_id", sessionID.String()).
 							Str("thread_id", threadID.String()).
 							Msg("failed to advance review loop after thread turn")
+						recoveryCtx, cancelRecovery := context.WithTimeout(context.WithoutCancel(ctx), 5*time.Second)
+						if enqueueErr := enqueueSessionReviewLoopReconciliation(recoveryCtx, stores, orgID, threadID, time.Now().UTC()); enqueueErr != nil {
+							logger.Error().Err(enqueueErr).
+								Str("session_id", sessionID.String()).
+								Str("thread_id", threadID.String()).
+								Msg("failed to enqueue review loop recovery")
+						}
+						cancelRecovery()
 					}
 				}
 			} else {
@@ -10840,6 +10856,64 @@ func newSyncPRPreviewSurfacesHandler(services *Services, logger zerolog.Logger) 
 	}
 }
 
+func enqueueSessionReviewLoopReconciliation(
+	ctx context.Context,
+	stores *Stores,
+	orgID, threadID uuid.UUID,
+	now time.Time,
+) error {
+	if stores == nil || stores.Jobs == nil {
+		return errors.New("review loop recovery job store is unavailable")
+	}
+	runAt := now.Add(reviewLoopRecoveryDelay)
+	dedupeKey := models.JobTypeReconcileSessionReviewLoop + ":" + threadID.String()
+	_, err := stores.Jobs.EnqueueWithOpts(ctx, orgID, db.EnqueueOpts{
+		Queue:     "default",
+		JobType:   models.JobTypeReconcileSessionReviewLoop,
+		Payload:   map[string]any{"org_id": orgID.String(), "limit": reviewLoopRecoveryBatchSize},
+		Priority:  5,
+		RunAt:     &runAt,
+		DedupeKey: &dedupeKey,
+	})
+	if err != nil {
+		return fmt.Errorf("enqueue session review loop reconciliation: %w", err)
+	}
+	return nil
+}
+
+func newReconcileSessionReviewLoopHandler(services *Services, logger zerolog.Logger) JobHandler {
+	return func(ctx context.Context, jobType string, payload json.RawMessage) error {
+		var input struct {
+			OrgID string `json:"org_id"`
+			Limit int    `json:"limit"`
+		}
+		if err := json.Unmarshal(payload, &input); err != nil {
+			return fmt.Errorf("unmarshal reconcile_session_review_loop payload: %w", err)
+		}
+		orgID, err := parseOrgID(input.OrgID, ctx)
+		if err != nil {
+			return fmt.Errorf("parse org ID: %w", err)
+		}
+		if input.Limit <= 0 {
+			input.Limit = reviewLoopRecoveryBatchSize
+		}
+		if services == nil || services.ReviewLoops == nil {
+			return errors.New("review loop recovery service is unavailable")
+		}
+		restarted, err := services.ReviewLoops.ReconcileStrandedPublicationLoops(
+			ctx, orgID, time.Now().UTC().Add(-reviewLoopRecoveryInactiveFor), input.Limit,
+		)
+		if err != nil {
+			return fmt.Errorf("reconcile stranded publication reviews: %w", err)
+		}
+		if restarted > 0 {
+			logger.Warn().Str("org_id", orgID.String()).Int("restarted", restarted).
+				Msg("restarted stranded publication review loops")
+		}
+		return nil
+	}
+}
+
 func newReconcilePullRequestStateHandler(services *Services, logger zerolog.Logger) JobHandler {
 	return func(ctx context.Context, jobType string, payload json.RawMessage) error {
 		var input struct {
@@ -10857,7 +10931,19 @@ func newReconcilePullRequestStateHandler(services *Services, logger zerolog.Logg
 			input.Limit = 50
 		}
 		logger.Info().Str("org_id", orgID.String()).Int("limit", input.Limit).Msg("starting reconcile_pull_request_state job")
-		return services.PR.ReconcilePullRequestState(ctx, orgID, input.Limit)
+		prErr := services.PR.ReconcilePullRequestState(ctx, orgID, input.Limit)
+		var reviewErr error
+		if services.ReviewLoops != nil {
+			var restarted int
+			restarted, reviewErr = services.ReviewLoops.ReconcileStrandedPublicationLoops(
+				ctx, orgID, time.Now().UTC().Add(-periodicReviewLoopRecoveryInactiveFor), input.Limit,
+			)
+			if restarted > 0 {
+				logger.Warn().Str("org_id", orgID.String()).Int("restarted", restarted).
+					Msg("periodic reconciliation restarted stranded publication review loops")
+			}
+		}
+		return errors.Join(prErr, reviewErr)
 	}
 }
 

--- a/internal/worker/handlers_test.go
+++ b/internal/worker/handlers_test.go
@@ -5718,6 +5718,66 @@ func TestPullRequestHealthJobHandlers(t *testing.T) {
 	}
 }
 
+func TestEnqueueSessionReviewLoopReconciliationDefersDedicatedRecoveryJob(t *testing.T) {
+	t.Parallel()
+
+	stores, mock := newTestStores(t)
+	t.Cleanup(mock.Close)
+	orgID, threadID, jobID := uuid.New(), uuid.New(), uuid.New()
+	now := time.Date(2026, 8, 3, 7, 0, 0, 0, time.UTC)
+	mock.ExpectQuery("INSERT INTO jobs").
+		WithArgs(workerAnyArgs(7)...).
+		WillReturnRows(pgxmock.NewRows([]string{"id"}).AddRow(jobID))
+
+	err := enqueueSessionReviewLoopReconciliation(context.Background(), stores, orgID, threadID, now)
+
+	require.NoError(t, err, "review advancement failure should enqueue durable recovery")
+	require.NoError(t, mock.ExpectationsWereMet(), "recovery enqueue should include a deferred run time and thread-scoped dedupe key")
+}
+
+func TestReconcileSessionReviewLoopHandlerRestartsStrandedPublicationReviews(t *testing.T) {
+	t.Parallel()
+
+	orgID := uuid.New()
+	reviews := &stubWorkerReviewLoops{restarted: 3}
+	handler := newReconcileSessionReviewLoopHandler(&Services{ReviewLoops: reviews}, zerolog.Nop())
+	startedAt := time.Now().UTC()
+
+	err := handler(
+		context.Background(),
+		models.JobTypeReconcileSessionReviewLoop,
+		json.RawMessage(`{"org_id":"`+orgID.String()+`","limit":25}`),
+	)
+
+	require.NoError(t, err, "review loop recovery handler should restart eligible loops")
+	require.Len(t, reviews.reconciliations, 1, "recovery handler should run one bounded reconciliation pass")
+	require.Equal(t, orgID, reviews.reconciliations[0].orgID, "recovery should remain scoped to the job organization")
+	require.Equal(t, 25, reviews.reconciliations[0].limit, "recovery should preserve the requested batch size")
+	require.WithinDuration(t, startedAt.Add(-reviewLoopRecoveryInactiveFor), reviews.reconciliations[0].inactiveBefore, time.Second, "recovery should only restart threads idle past the safety window")
+}
+
+func TestPullRequestReconciliationAlsoRecoversStrandedPublicationReviews(t *testing.T) {
+	t.Parallel()
+
+	orgID := uuid.New()
+	reviews := &stubWorkerReviewLoops{restarted: 2}
+	services := &Services{PR: &stubPRService{}, ReviewLoops: reviews}
+	handler := newReconcilePullRequestStateHandler(services, zerolog.Nop())
+	startedAt := time.Now().UTC()
+
+	err := handler(
+		context.Background(),
+		"reconcile_pull_request_state",
+		json.RawMessage(`{"org_id":"`+orgID.String()+`","limit":10}`),
+	)
+
+	require.NoError(t, err, "periodic pull request reconciliation should include review recovery")
+	require.Len(t, reviews.reconciliations, 1, "periodic reconciliation should inspect stranded publication reviews")
+	require.Equal(t, orgID, reviews.reconciliations[0].orgID, "periodic recovery should remain tenant scoped")
+	require.Equal(t, 10, reviews.reconciliations[0].limit, "periodic recovery should share the bounded reconciliation batch")
+	require.WithinDuration(t, startedAt.Add(-periodicReviewLoopRecoveryInactiveFor), reviews.reconciliations[0].inactiveBefore, time.Second, "periodic recovery should use the conservative inactivity threshold")
+}
+
 func TestRebuildPullRequestHealthHandlerSkipsAutoRepairAfterNoOp(t *testing.T) {
 	t.Parallel()
 
@@ -8762,8 +8822,11 @@ func workerReviewLoopColumns() []string {
 }
 
 type stubWorkerReviewLoops struct {
-	starts   []stubWorkerReviewLoopStart
-	failures []stubWorkerReviewLoopFailure
+	starts            []stubWorkerReviewLoopStart
+	failures          []stubWorkerReviewLoopFailure
+	reconciliations   []stubWorkerReviewLoopReconciliation
+	restarted         int
+	reconciliationErr error
 }
 
 type stubPublicationExecutionCoordinator struct {
@@ -8802,6 +8865,12 @@ type stubWorkerReviewLoopFailure struct {
 	summary  string
 }
 
+type stubWorkerReviewLoopReconciliation struct {
+	orgID          uuid.UUID
+	inactiveBefore time.Time
+	limit          int
+}
+
 func (s *stubWorkerReviewLoops) OnThreadTurnComplete(context.Context, uuid.UUID, uuid.UUID, string) error {
 	return nil
 }
@@ -8809,6 +8878,18 @@ func (s *stubWorkerReviewLoops) OnThreadTurnComplete(context.Context, uuid.UUID,
 func (s *stubWorkerReviewLoops) OnThreadTurnFailed(_ context.Context, orgID, threadID uuid.UUID, summary string) error {
 	s.failures = append(s.failures, stubWorkerReviewLoopFailure{orgID: orgID, threadID: threadID, summary: summary})
 	return nil
+}
+
+func (s *stubWorkerReviewLoops) ReconcileStrandedPublicationLoops(
+	_ context.Context,
+	orgID uuid.UUID,
+	inactiveBefore time.Time,
+	limit int,
+) (int, error) {
+	s.reconciliations = append(s.reconciliations, stubWorkerReviewLoopReconciliation{
+		orgID: orgID, inactiveBefore: inactiveBefore, limit: limit,
+	})
+	return s.restarted, s.reconciliationErr
 }
 
 func (s *stubWorkerReviewLoops) Start(_ context.Context, orgID, sessionID uuid.UUID, req reviewloopsvc.StartReviewLoopRequest) (*models.SessionReviewLoop, error) {


### PR DESCRIPTION
## Summary

- Detect and atomically restart stranded publication review loops without live continuation jobs.
- Wire publication evidence refreshing for both worker and session-executor runtimes.
- Qualify joined `completed_at` references to avoid PostgreSQL ambiguity.
- Add unit and PostgreSQL-backed coverage for recovery and wiring behavior.

## Testing

Not run (not requested).