### PR TITLE
Match navbar Settings font size with other top-level items in mobile and desktop

### DIFF
--- a/frontend/src/components/sidebar-settings-section.test.tsx
+++ b/frontend/src/components/sidebar-settings-section.test.tsx
@@ -24,7 +24,7 @@ describe("SidebarSettingsSection", () => {
       <SidebarSettingsSection pathname="/sessions" userRole="admin" variant="mobile" />,
     );
 
-    expect(screen.getByRole("button", { name: /Settings/ })).toHaveClass("px-2.5", "py-3", "text-sm");
+    expect(screen.getByRole("button", { name: /Settings/ })).toHaveClass("px-2.5", "py-3", "text-sm!");
   });
 
   it("opens collapsed settings in a floating menu", async () => {

--- a/frontend/src/components/sidebar-settings-section.tsx
+++ b/frontend/src/components/sidebar-settings-section.tsx
@@ -223,7 +223,9 @@ export function SidebarSettingsSection({
           variant="ghost"
           className={cn(
             "relative flex h-auto w-full items-center rounded-md px-2.5 has-[>svg]:px-2.5 font-medium transition-all duration-[175ms]",
-            isMobile ? "gap-2.5 py-3 text-sm" : "gap-2.5 py-[7px] type-dense",
+            // Button's base styles include type-dense. Make the mobile
+            // override important so Settings matches the 14px nav links.
+            isMobile ? "gap-2.5 py-3 text-sm!" : "gap-2.5 py-[7px] type-dense",
             onSettingsPage
               ? "bg-accent/65 text-foreground before:absolute before:inset-y-1.5 before:left-0 before:w-0.5 before:rounded-full before:bg-primary"
               : "text-sidebar-foreground/70 hover:bg-sidebar-accent hover:text-sidebar-foreground"


### PR DESCRIPTION
## Summary

Mobile users were seeing inconsistent typography: the **Settings** button in the sidebar didn’t match the font sizing used by other top-level items/nav links. This created a small but noticeable UI mismatch and extra churn for developers tweaking spacing/type.

## Changes

- Updated `SidebarSettingsSection` so the mobile **Settings** button overrides the base `type-dense` styling with an `!important`-style tailwind class (`text-sm!`)
- Added/adjusted the corresponding unit expectation to match the new class application

## Validation

- Updated and ran: `frontend/src/components/sidebar-settings-section.test.tsx` (jest/unit test) to verify the Settings button class list in mobile mode

[143.dev](https://143.dev) | [session 4d34d5e6](https://143.dev/sessions/4d34d5e6-8716-43fd-b943-42b136900172)

<!-- 143-publication session=4d34d5e6-8716-43fd-b943-42b136900172 changeset=b8a8e5bd-d75c-491d-8743-fe9ae344c225 -->

Preview: https://143.dev/previews/github/assembledhq/143/pull/2048?launch=1