### PR TITLE
Fix PR creation UI card sizing and improve capitalization of error message

### DIFF
--- a/frontend/src/app/(dashboard)/sessions/[id]/page-pr-creation.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/page-pr-creation.test.tsx
@@ -969,7 +969,8 @@ describe('SessionDetailPage PR creation', () => {
     renderWithProviders(<SessionDetailContent id="session-abcdef12-3456-7890" />);
 
     const alert = await screen.findByRole('alert');
-    expect(alert.className).toContain('mx-2');
+    expect(alert).toHaveClass('mx-4');
+    expect(alert).not.toHaveClass('mx-2');
   });
 
   it('shows a resume-specific PR error instead of session expiry when the GitHub resume token is stale', async () => {
@@ -1386,7 +1387,7 @@ describe('SessionDetailPage PR creation', () => {
     resolveCreatePR?.();
   });
 
-  it('shows the immediate create PR error in a 10-second toast', async () => {
+  it('shows a polished, aligned create PR error with a 10-second toast', async () => {
     const sessionWithDiff: Session = {
       ...mockSessions[0],
       status: 'completed',
@@ -1408,8 +1409,8 @@ describe('SessionDetailPage PR creation', () => {
       }),
       http.post('/api/v1/sessions/:id/pr', () => {
         return HttpResponse.json(
-          { error: { code: 'PUSH_FAILED', message: 'GitHub rejected the branch push.' } },
-          { status: 500 },
+          { error: { code: 'WORKSPACE_NOT_READY', message: 'pull request publication request was rejected' } },
+          { status: 409 },
         );
       }),
     );
@@ -1425,7 +1426,10 @@ describe('SessionDetailPage PR creation', () => {
     });
     const alert = await screen.findByRole('alert');
     expect(alert).toHaveTextContent("Couldn't create the PR");
-    expect(alert).toHaveTextContent('GitHub rejected the branch push.');
+    expect(alert).toHaveTextContent('This workspace is not ready to publish a pull request. Review its status, then try again.');
+    expect(alert).not.toHaveTextContent('pull request publication request was rejected');
+    expect(alert).toHaveClass('mx-4');
+    expect(alert).not.toHaveClass('mx-2');
     expect(within(alert).getByRole('button', { name: 'Retry' })).toBeInTheDocument();
   });
 

--- a/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
@@ -120,6 +120,7 @@ import { applyPlanModePrefix, buildTimeline, flattenTimelineResponse, flattenTra
 import { formatReviewMessage } from "@/lib/format-review-message";
 import {
   classifyPRSnapshotState,
+  formatPRCreationError,
   prErrorTitle,
   snapshotPRMessage,
 } from "@/lib/session-pr-snapshot";
@@ -6271,7 +6272,7 @@ export function SessionDetailContent({ id }: { id: string }) {
 
   const prErrorNotice = prActionError ? {
     title: prErrorTitle(snapshotState, localPRActionError?.code),
-    description: prActionError,
+    description: formatPRCreationError(localPRActionError?.code, prActionError),
     action: prActionDisabled ? undefined : {
       label: prActionLabel,
       onClick: () => submitCreatePR(undefined),
@@ -6460,7 +6461,7 @@ export function SessionDetailContent({ id }: { id: string }) {
         </div>
         {prErrorNotice && (
           <ErrorNotice
-            className="mx-2 mt-2"
+            className="mx-4 mt-2"
             title={prErrorNotice.title}
             description={prErrorNotice.description}
             action={prErrorNotice.action}

--- a/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
@@ -6160,6 +6160,11 @@ export function SessionDetailContent({ id }: { id: string }) {
     snapshotState,
     localPRActionError?.code ? localPRActionError.message : session.pr_creation_error,
   );
+  // The button tooltip repeats the notice copy, so it reads the same polished
+  // sentence the notice renders instead of the raw server detail.
+  const localPRActionMessage = localPRActionError?.message
+    ? formatPRCreationError(localPRActionError.code, localPRActionError.message)
+    : undefined;
   const prActionError = hasPR
     ? null
     : (localPRActionError?.code && snapshotState ? snapshotMessage : localPRActionError?.message) ||
@@ -6181,7 +6186,7 @@ export function SessionDetailContent({ id }: { id: string }) {
     finalizingPR,
     prState,
     prCreationError: session.pr_creation_error,
-    localError: snapshotUnavailable ? undefined : localPRActionError?.message,
+    localError: snapshotUnavailable ? undefined : localPRActionMessage,
     hasRecoverableError: Boolean(prActionError),
   });
   // A durable publication owns the workflow until it settles. Its Overview

--- a/frontend/src/lib/session-pr-snapshot.test.ts
+++ b/frontend/src/lib/session-pr-snapshot.test.ts
@@ -4,6 +4,7 @@ import {
   SNAPSHOT_NOT_CAPTURED_PR_MESSAGE,
   SNAPSHOT_UNAVAILABLE_PR_MESSAGE,
   classifyPRSnapshotState,
+  formatPRCreationError,
   prErrorTitle,
   snapshotPRMessage,
 } from "./session-pr-snapshot";
@@ -101,6 +102,49 @@ describe("session-pr-snapshot", () => {
 
     it("falls back to the generic PR creation title", () => {
       expect(prErrorTitle(null, "SOMETHING_ELSE")).toBe("Couldn't create the PR");
+    });
+  });
+
+  describe("formatPRCreationError", () => {
+    it.each([
+      {
+        name: "workspace rejection",
+        code: "WORKSPACE_NOT_READY",
+        message: "pull request publication request was rejected",
+        expected: "This workspace is not ready to publish a pull request. Review its status, then try again.",
+      },
+      {
+        name: "ineligible session",
+        code: "SESSION_NOT_PUBLICATION_ELIGIBLE",
+        message: "pull request publication request was rejected",
+        expected: "This session cannot create a pull request in its current state.",
+      },
+      {
+        name: "legacy lowercase detail",
+        code: undefined,
+        message: "pull request was rejected",
+        expected: "Pull request was rejected.",
+      },
+      {
+        name: "already polished detail",
+        code: undefined,
+        message: "GitHub rejected the branch push.",
+        expected: "GitHub rejected the branch push.",
+      },
+      {
+        name: "specific coordinator detail",
+        code: "WORKSPACE_NOT_READY",
+        message: "The working branch is no longer available.",
+        expected: "The working branch is no longer available.",
+      },
+      {
+        name: "missing detail",
+        code: undefined,
+        message: "  ",
+        expected: "Something went wrong while creating the pull request. Try again.",
+      },
+    ])("formats $name as polished product copy", ({ code, message, expected }) => {
+      expect(formatPRCreationError(code, message)).toBe(expected);
     });
   });
 });

--- a/frontend/src/lib/session-pr-snapshot.ts
+++ b/frontend/src/lib/session-pr-snapshot.ts
@@ -74,3 +74,25 @@ export function prErrorTitle(snapshotState: PRSnapshotState | null, errorCode?: 
   }
   return "Couldn't create the PR";
 }
+
+export function formatPRCreationError(errorCode?: string, message?: string | null): string {
+  const trimmedMessage = message?.trim();
+  const useCoordinatorFallback = !trimmedMessage ||
+    /^pull request publication request was rejected[.!]?$/i.test(trimmedMessage);
+
+  if (useCoordinatorFallback && errorCode === "WORKSPACE_NOT_READY") {
+    return "This workspace is not ready to publish a pull request. Review its status, then try again.";
+  }
+  if (useCoordinatorFallback && errorCode === "SESSION_NOT_PUBLICATION_ELIGIBLE") {
+    return "This session cannot create a pull request in its current state.";
+  }
+
+  if (!trimmedMessage) {
+    return "Something went wrong while creating the pull request. Try again.";
+  }
+
+  const sentenceCasedMessage = `${trimmedMessage.charAt(0).toLocaleUpperCase()}${trimmedMessage.slice(1)}`;
+  return /[.!?]$/.test(sentenceCasedMessage)
+    ? sentenceCasedMessage
+    : `${sentenceCasedMessage}.`;
+}

--- a/frontend/src/lib/session-pr-snapshot.ts
+++ b/frontend/src/lib/session-pr-snapshot.ts
@@ -75,6 +75,10 @@ export function prErrorTitle(snapshotState: PRSnapshotState | null, errorCode?: 
   return "Couldn't create the PR";
 }
 
+// The API now sends product copy for typed publication rejections, but a
+// server still running the previous build sends the raw coordinator string.
+// Translating that string here keeps the notice readable across a rollout;
+// anything more specific is already user-facing and passes through untouched.
 export function formatPRCreationError(errorCode?: string, message?: string | null): string {
   const trimmedMessage = message?.trim();
   const useCoordinatorFallback = !trimmedMessage ||
@@ -91,7 +95,7 @@ export function formatPRCreationError(errorCode?: string, message?: string | nul
     return "Something went wrong while creating the pull request. Try again.";
   }
 
-  const sentenceCasedMessage = `${trimmedMessage.charAt(0).toLocaleUpperCase()}${trimmedMessage.slice(1)}`;
+  const sentenceCasedMessage = `${trimmedMessage.charAt(0).toUpperCase()}${trimmedMessage.slice(1)}`;
   return /[.!?]$/.test(sentenceCasedMessage)
     ? sentenceCasedMessage
     : `${sentenceCasedMessage}.`;

--- a/internal/api/handlers/session_changesets_test.go
+++ b/internal/api/handlers/session_changesets_test.go
@@ -245,7 +245,7 @@ func TestSessionHandlerPublishChangesetStackReportsPartialRejection(t *testing.T
 	require.Contains(t, body, `"status":"rejected"`, "the response should surface the rejected changeset")
 	require.Contains(t, body, secondID.String(), "the rejection should name the changeset it belongs to")
 	require.Contains(t, body, string(publicationintent.ErrorWorkspaceNotReady), "the rejection should retain the coordinator's typed error code")
-	require.Contains(t, body, "This pull request is not ready to publish.", "the rejection should return actionable safe copy")
+	require.Contains(t, body, "This workspace is not ready to publish a pull request. Review its status, then try again.", "the rejection should return actionable safe copy")
 	require.NotContains(t, body, "worktree is missing", "the response must not expose the coordinator's internal error detail")
 	require.Contains(t, body, firstID.String(), "the response should still report the changeset that was queued")
 	require.NoError(t, mock.ExpectationsWereMet(), "stack endpoint should consume the scoped session and changeset queries")

--- a/internal/api/handlers/sessions.go
+++ b/internal/api/handlers/sessions.go
@@ -1460,13 +1460,7 @@ func (h *SessionHandler) PublishChangesetStack(w http.ResponseWriter, r *http.Re
 				if errors.As(requestErr, &intentErr) {
 					code = string(intentErr.Code)
 				}
-				message := "This pull request could not be queued."
-				switch code {
-				case string(publicationintent.ErrorWorkspaceNotReady):
-					message = "This pull request is not ready to publish."
-				case string(publicationintent.ErrorSessionNotEligible):
-					message = "This session cannot publish this pull request."
-				}
+				message := publicationIntentRejectionMessage(code)
 				zerolog.Ctx(r.Context()).Error().Err(requestErr).
 					Str("changeset_id", changeset.ID.String()).
 					Str("publication_error_code", code).
@@ -1483,7 +1477,7 @@ func (h *SessionHandler) PublishChangesetStack(w http.ResponseWriter, r *http.Re
 			var intentErr *publicationintent.Error
 			if errors.As(requestErr, &intentErr) &&
 				(intentErr.Code == publicationintent.ErrorSessionNotEligible || intentErr.Code == publicationintent.ErrorWorkspaceNotReady) {
-				writeError(w, r, http.StatusConflict, string(intentErr.Code), "stack publication request was rejected", requestErr)
+				writeError(w, r, http.StatusConflict, string(intentErr.Code), publicationIntentRejectionMessage(string(intentErr.Code)), requestErr)
 				return
 			}
 			writeError(w, r, http.StatusInternalServerError, "PUBLICATION_INTENT_FAILED", "failed to record stack publication intent", requestErr)
@@ -3042,6 +3036,17 @@ func writePublicationIntentAccepted(w http.ResponseWriter, result *publicationin
 	})
 }
 
+func publicationIntentRejectionMessage(code string) string {
+	switch code {
+	case string(publicationintent.ErrorWorkspaceNotReady):
+		return "This workspace is not ready to publish a pull request. Review its status, then try again."
+	case string(publicationintent.ErrorSessionNotEligible):
+		return "This session cannot create a pull request in its current state."
+	default:
+		return "This pull request could not be queued. Try again."
+	}
+}
+
 func (h *SessionHandler) CreatePR(w http.ResponseWriter, r *http.Request) {
 	orgID := middleware.OrgIDFromContext(r.Context())
 	sessionID, err := uuid.Parse(chi.URLParam(r, "id"))
@@ -3248,7 +3253,7 @@ func (h *SessionHandler) CreatePR(w http.ResponseWriter, r *http.Request) {
 			if errors.As(intentErr, &typedErr) {
 				switch typedErr.Code {
 				case publicationintent.ErrorSessionNotEligible, publicationintent.ErrorWorkspaceNotReady:
-					writeError(w, r, http.StatusConflict, string(typedErr.Code), "pull request publication request was rejected", intentErr)
+					writeError(w, r, http.StatusConflict, string(typedErr.Code), publicationIntentRejectionMessage(string(typedErr.Code)), intentErr)
 				default:
 					writeError(w, r, http.StatusInternalServerError, "PUBLICATION_INTENT_FAILED", "failed to record publication intent", intentErr)
 				}

--- a/internal/api/handlers/sessions_test.go
+++ b/internal/api/handlers/sessions_test.go
@@ -11245,11 +11245,12 @@ func TestSessionHandler_CreatePR_CoordinatorOutcomes(t *testing.T) {
 	publicationID := uuid.New()
 	blockedReason := "publication intent is durable, but immediate queueing failed"
 	tests := []struct {
-		name       string
-		status     publicationintent.ResultStatus
-		reason     *string
-		wantCode   int
-		wantInBody string
+		name           string
+		status         publicationintent.ResultStatus
+		reason         *string
+		coordinatorErr error
+		wantCode       int
+		wantInBody     string
 	}{
 		{
 			name:       "queued intent reports queued",
@@ -11270,6 +11271,24 @@ func TestSessionHandler_CreatePR_CoordinatorOutcomes(t *testing.T) {
 			wantCode:   http.StatusAccepted,
 			wantInBody: `"status":"already_published"`,
 		},
+		{
+			name: "workspace rejection returns actionable product copy",
+			coordinatorErr: &publicationintent.Error{
+				Code: publicationintent.ErrorWorkspaceNotReady,
+				Err:  errors.New("primary changeset has no working branch to publish"),
+			},
+			wantCode:   http.StatusConflict,
+			wantInBody: "This workspace is not ready to publish a pull request. Review its status, then try again.",
+		},
+		{
+			name: "ineligible session rejection explains the current state",
+			coordinatorErr: &publicationintent.Error{
+				Code: publicationintent.ErrorSessionNotEligible,
+				Err:  errors.New("session cannot create a new pull request"),
+			},
+			wantCode:   http.StatusConflict,
+			wantInBody: "This session cannot create a pull request in its current state.",
+		},
 	}
 
 	for _, tt := range tests {
@@ -11286,7 +11305,7 @@ func TestSessionHandler_CreatePR_CoordinatorOutcomes(t *testing.T) {
 			handler := newSessionHandler(t, mock)
 			coordinator := &internalPRCoordinatorStub{result: &publicationintent.PublicationIntentResult{
 				Status: tt.status, SessionID: sessionID, PublicationID: &publicationID, Reason: tt.reason,
-			}}
+			}, err: tt.coordinatorErr}
 			handler.SetPublicationIntentCoordinator(coordinator, true)
 
 			diff := "--- a/file.go\n+++ b/file.go\n@@ -1 +1 @@\n-old\n+new"


### PR DESCRIPTION
## Summary

The PR creation UI shows misaligned error card spacing and sometimes surfaces raw/coarse server error copy, which hurts readability and makes it unclear what to do next. This change standardizes the error card layout with the other overview cards and replaces the known rough coordinator message with polished, user-actionable copy while still preserving more-specific server errors.

## Changes

- Align the PR error alert card with Overview card spacing by switching from `mx-2` to `mx-4` (and updating associated tests).
- Improve the “publish PR” error presentation by formatting `localPRActionError` via `formatPRCreationError` so tooltips/notices render the same polished sentence.
- Update PR creation error handling expectations for the workspace readiness/rejection case (copy + HTTP status mapping) and ensure legacy message strings are no longer shown.

## Validation

- Frontend: updated/added component and unit tests (including PR creation and PR snapshot coverage).
- Backend: ran Go handler tests around session/change set behavior.
- CI/linting: ESLint and `go vet` passed.
- Note: preview service returned HTTP 502, so validation relied on the rendered component test suite rather than screenshot verification.

[143.dev](https://143.dev) | [session f54a9cd3](https://143.dev/sessions/f54a9cd3-3a6d-4339-ab09-cc99e8393728)

<!-- 143-publication session=f54a9cd3-3a6d-4339-ab09-cc99e8393728 changeset=e580ec61-dad0-4038-b2da-2b2a395cb7ff -->

Preview: https://143.dev/previews/github/assembledhq/143/pull/2049?launch=1