### PR TITLE
Make explicit Create PR bypass existing review workflows

### DIFF
--- a/frontend/src/app/(dashboard)/sessions/[id]/page-pr-creation.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/page-pr-creation.test.tsx
@@ -545,7 +545,7 @@ describe('SessionDetailPage PR creation', () => {
     const workflow = await screen.findByTestId('publication-workflow-card');
     expect(within(workflow).getByText('Needs attention')).toBeInTheDocument();
     expect(within(workflow).getByRole('button', { name: 'Resume publication' })).toBeInTheDocument();
-    expect(within(workflow).queryByRole('button', { name: 'Create draft PR' })).not.toBeInTheDocument();
+    expect(within(workflow).queryByRole('button', { name: 'Create PR' })).not.toBeInTheDocument();
     expect(screen.queryByRole('button', { name: 'Create PR' })).not.toBeInTheDocument();
     expect(screen.queryByRole('button', { name: 'Review & fix' })).not.toBeInTheDocument();
   });
@@ -594,7 +594,7 @@ describe('SessionDetailPage PR creation', () => {
     const workflow = await screen.findByTestId('publication-workflow-card');
     expect(within(workflow).getByText('Needs attention')).toBeInTheDocument();
     expect(within(workflow).getByText(/temporarily paused/)).toBeInTheDocument();
-    expect(within(workflow).getByRole('button', { name: 'Create draft PR' })).toBeInTheDocument();
+    expect(within(workflow).getByRole('button', { name: 'Create PR' })).toBeInTheDocument();
     expect(within(workflow).getByRole('button', { name: 'Continue with agent' })).toBeInTheDocument();
     expect(within(workflow).queryByText('Reviewing')).not.toBeInTheDocument();
   });
@@ -658,9 +658,9 @@ describe('SessionDetailPage PR creation', () => {
     expect(screen.getAllByTestId('publication-workflow-card')).toHaveLength(1);
   });
 
-  it('offers the audited draft bypass when publication review needs attention', async () => {
+  it('offers direct PR creation when an older publication review needs attention', async () => {
     const now = '2026-07-15T12:00:00Z';
-    let requestBody: unknown;
+    let requestBody = 'not-requested';
     const detail: SessionDetail = {
       ...mockSessions[0],
       status: 'completed',
@@ -687,7 +687,7 @@ describe('SessionDetailPage PR creation', () => {
       http.get('/api/v1/sessions/:id', () => HttpResponse.json({ data: detail } satisfies SingleResponse<SessionDetail>)),
       http.get('/api/v1/sessions/:id/pr', () => HttpResponse.json({ error: { code: 'NOT_FOUND', message: 'pull request not found' } }, { status: 404 })),
       http.post('/api/v1/sessions/:id/pr', async ({ request }) => {
-        requestBody = await request.json();
+        requestBody = await request.text();
         return HttpResponse.json({ status: 'pr_queued', session_id: detail.id }, { status: 202 });
       }),
     );
@@ -696,10 +696,10 @@ describe('SessionDetailPage PR creation', () => {
 
     const workflow = await screen.findByTestId('publication-workflow-card');
     expect(within(workflow).getByText('Needs attention')).toBeInTheDocument();
-    await userEvent.click(within(workflow).getByRole('button', { name: 'Create draft PR' }));
+    await userEvent.click(within(workflow).getByRole('button', { name: 'Create PR' }));
 
     await waitFor(() => {
-      expect(requestBody).toMatchObject({ draft: true });
+      expect(requestBody).toBe('{}');
     });
   });
 

--- a/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
@@ -309,7 +309,7 @@ function PublicationWorkflowCard({
   executionPaused,
   reviewExecutionPaused,
   actionPending,
-  onCreateDraft,
+  onCreatePR,
   onOpenReview,
   onContinue,
   onRetry,
@@ -322,7 +322,7 @@ function PublicationWorkflowCard({
   executionPaused: boolean;
   reviewExecutionPaused: boolean;
   actionPending: boolean;
-  onCreateDraft: () => void;
+  onCreatePR: () => void;
   onOpenReview: () => void;
   onContinue: () => void;
   onRetry: () => void;
@@ -411,9 +411,9 @@ function PublicationWorkflowCard({
             publication.review_gate_state === "needs_human" ||
             (executionActuallyPaused && reviewExecutionPaused && publication.review_gate_state === "pending")
           ) ? (
-            <Button size="sm" disabled={actionPending} onClick={onCreateDraft}>
+            <Button size="sm" disabled={actionPending} onClick={onCreatePR}>
               {actionPending ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <GitPullRequest className="h-3.5 w-3.5" />}
-              Create draft PR
+              Create PR
             </Button>
           ) : null}
           {needsAttention && reviewLoop?.thread_id ? <Button size="sm" variant="outline" onClick={onOpenReview}>Open review</Button> : null}
@@ -6857,7 +6857,7 @@ export function SessionDetailContent({ id }: { id: string }) {
                 session.publication_policy?.review_execution_enabled === false
               }
               actionPending={createPRMutation.isPending}
-              onCreateDraft={() => createPRMutation.mutate({ draft: true })}
+              onCreatePR={() => createPRMutation.mutate(undefined)}
               onOpenReview={() => {
                 if (publicationReviewLoop?.thread_id) setActiveThreadId(publicationReviewLoop.thread_id);
               }}

--- a/internal/api/handlers/sessions.go
+++ b/internal/api/handlers/sessions.go
@@ -3009,7 +3009,10 @@ func (h *SessionHandler) rejoinPublicationIntent(
 		memberDraftBypass := privilegedUserAction && requestedRole != string(models.RoleBuilder) &&
 			draft != nil && *draft &&
 			(publication.ReviewGateState == models.SessionPublicationReviewGateNeedsHuman || parked)
-		if !retryable && !memberDraftBypass && !(parked && privilegedUserAction) {
+		explicitReviewReplacement := privilegedUserAction && !publication.State.Terminal() &&
+			(publication.ReviewGateState == models.SessionPublicationReviewGatePending ||
+				publication.ReviewGateState == models.SessionPublicationReviewGateNeedsHuman)
+		if !retryable && !memberDraftBypass && !(parked && privilegedUserAction) && !explicitReviewReplacement {
 			return publicationintent.ExistingPublicationResult(publication), true, nil
 		}
 		return nil, false, nil

--- a/internal/api/handlers/sessions_test.go
+++ b/internal/api/handlers/sessions_test.go
@@ -128,6 +128,48 @@ func TestSessionHandlerCreatePRRejoinsCompletedPublicationBeforeSnapshotChecks(t
 	require.Empty(t, coordinator.requests, "a harmless replay should not enqueue or mutate publication work")
 }
 
+func TestSessionHandlerCreatePRDoesNotRejoinExistingReviewForExplicitAction(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "test should create the database mock")
+	t.Cleanup(mock.Close)
+	handler := newSessionHandler(t, mock)
+	handler.SetPublicationStore(db.NewSessionPublicationStore(mock))
+	handler.SetPublicationIntentCoordinator(&internalPRCoordinatorStub{}, true)
+
+	orgID, sessionID, changesetID, repositoryID, userID := uuid.New(), uuid.New(), uuid.New(), uuid.New(), uuid.New()
+	now := time.Now().UTC()
+	loopID := uuid.New()
+	maxPasses := 2
+	publication := models.SessionPublication{
+		ID: uuid.New(), OrgID: orgID, SessionID: sessionID, ChangesetID: changesetID, RepositoryID: repositoryID,
+		State: models.SessionPublicationStateReviewPending, Source: models.SessionPublicationSourceUser,
+		TriggerKind: models.SessionPublicationTriggerExplicitAction, HandoffMode: models.PRHandoffModePrePublish,
+		AutomaticPolicySource: models.PublicationPolicySourceExplicitAction,
+		ReviewPolicySource:    models.PublicationPolicySourceProductDefault, ReviewMaxPasses: &maxPasses,
+		ReviewLoopID: &loopID, ReviewGateState: models.SessionPublicationReviewGatePending,
+		JobQueue: models.SessionPublicationJobQueueAgent, RequestPayload: json.RawMessage(`{"session_id":"old"}`),
+		RequestGenerationAt: now, BaseBranch: "main", HeadBranch: "143/change",
+		RequestedAt: now, CreatedAt: now, UpdatedAt: now,
+	}
+	mock.ExpectQuery("(?s)SELECT .*FROM session_publications").
+		WithArgs(pgx.NamedArgs{"org_id": orgID, "session_id": sessionID, "changeset_id": changesetID}).
+		WillReturnRows(pgxmock.NewRows(handlerSessionPublicationColumns).AddRow(handlerSessionPublicationRow(publication)...))
+
+	result, found, err := handler.rejoinPublicationIntent(
+		context.Background(), orgID, sessionID,
+		models.SessionChangeset{ID: changesetID, OrgID: orgID, SessionID: sessionID, IsPrimary: true},
+		nil, models.SessionPublicationSourceUser, models.SessionPublicationTriggerExplicitAction,
+		&userID, string(models.RoleMember),
+	)
+
+	require.NoError(t, err, "explicit Create PR should inspect the existing publication without failing")
+	require.False(t, found, "an older review-pending intent should continue to the coordinator for explicit takeover")
+	require.Nil(t, result, "the rejoin helper should not return the older review workflow")
+	require.NoError(t, mock.ExpectationsWereMet(), "the publication lookup should remain tenant and changeset scoped")
+}
+
 type failingSSEWriter struct {
 	header       http.Header
 	failOnSubstr string

--- a/internal/db/job_store_test.go
+++ b/internal/db/job_store_test.go
@@ -128,15 +128,20 @@ func TestJobStoreQueueChangesetPRCreationIsAtomic(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name        string
-		reserveRows int64
-		enqueueErr  error
-		wantQueued  bool
-		wantErr     bool
+		name            string
+		reserveRows     int64
+		existingState   *models.PRCreationState
+		enqueueConflict bool
+		enqueueErr      error
+		wantEnqueue     bool
+		wantQueued      bool
+		wantErr         bool
 	}{
-		{name: "commits reservation and job together", reserveRows: 1, wantQueued: true},
-		{name: "does not enqueue when reservation is held", reserveRows: 0},
-		{name: "rolls back reservation when enqueue fails", reserveRows: 1, enqueueErr: errors.New("insert failed"), wantErr: true},
+		{name: "commits reservation and job together", reserveRows: 1, wantEnqueue: true, wantQueued: true},
+		{name: "does not enqueue when publication already succeeded", existingState: ptrTo(models.PRCreationStateSucceeded)},
+		{name: "requeues work after review left the reservation queued", existingState: ptrTo(models.PRCreationStateQueued), wantEnqueue: true, wantQueued: true},
+		{name: "joins an active job that still owns the reservation", existingState: ptrTo(models.PRCreationStatePushing), wantEnqueue: true, enqueueConflict: true},
+		{name: "rolls back reservation when enqueue fails", reserveRows: 1, wantEnqueue: true, enqueueErr: errors.New("insert failed"), wantErr: true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -150,11 +155,19 @@ func TestJobStoreQueueChangesetPRCreationIsAtomic(t *testing.T) {
 			mock.ExpectExec(`UPDATE session_changesets SET pr_creation_state = 'queued'.+WHERE org_id = .+ AND session_id = .+ AND id =`).
 				WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
 				WillReturnResult(pgxmock.NewResult("UPDATE", tt.reserveRows))
-			if tt.reserveRows == 1 {
+			if tt.reserveRows == 0 {
+				mock.ExpectQuery(`SELECT pr_creation_state FROM session_changesets`).
+					WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+					WillReturnRows(pgxmock.NewRows([]string{"pr_creation_state"}).AddRow(*tt.existingState))
+			}
+			if tt.wantEnqueue {
 				query := mock.ExpectQuery("INSERT INTO jobs").
 					WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg())
 				if tt.enqueueErr != nil {
 					query.WillReturnError(tt.enqueueErr)
+				} else if tt.enqueueConflict {
+					query.WillReturnRows(pgxmock.NewRows([]string{"id"}))
+					mock.ExpectCommit()
 				} else {
 					query.WillReturnRows(pgxmock.NewRows([]string{"id"}).AddRow(jobID))
 					mock.ExpectCommit()
@@ -171,7 +184,7 @@ func TestJobStoreQueueChangesetPRCreationIsAtomic(t *testing.T) {
 			} else {
 				require.NoError(t, err, "atomic enqueue should complete without an error")
 			}
-			require.Equal(t, tt.wantQueued, queued, "result should identify whether this caller reserved the changeset")
+			require.Equal(t, tt.wantQueued, queued, "result should identify whether this caller created runnable publication work")
 			if tt.wantQueued {
 				require.Equal(t, jobID, gotJobID, "committed enqueue should return its durable job ID")
 			} else {

--- a/internal/db/jobs.go
+++ b/internal/db/jobs.go
@@ -265,9 +265,11 @@ func (s *JobStore) GetActiveByDedupeKey(ctx context.Context, orgID uuid.UUID, qu
 	return active, nil
 }
 
-// QueueChangesetPRCreation atomically reserves a changeset's PR slot and
-// inserts its open_pr job. A false queued result means another caller already
-// owns the slot or PR creation has completed; it is not an error.
+// QueueChangesetPRCreation atomically reserves a changeset's PR slot when
+// needed and ensures it has an active open_pr job. A queued or pushing slot
+// may outlive the job that started a pre-publication review, so those states
+// are eligible for a deduplicated requeue. A false queued result means an
+// active job already satisfies the request or PR creation has completed.
 func (s *JobStore) QueueChangesetPRCreation(
 	ctx context.Context,
 	orgID, sessionID, changesetID uuid.UUID,
@@ -295,7 +297,22 @@ func (s *JobStore) QueueChangesetPRCreation(
 		return uuid.Nil, false, fmt.Errorf("reserve changeset PR creation: %w", err)
 	}
 	if result.RowsAffected() == 0 {
-		return uuid.Nil, false, nil
+		var state models.PRCreationState
+		err = tx.QueryRow(ctx, `SELECT pr_creation_state
+			FROM session_changesets
+			WHERE org_id = @org_id AND session_id = @session_id AND id = @changeset_id
+			FOR UPDATE`, pgx.NamedArgs{
+			"org_id": orgID, "session_id": sessionID, "changeset_id": changesetID,
+		}).Scan(&state)
+		if errors.Is(err, pgx.ErrNoRows) {
+			return uuid.Nil, false, nil
+		}
+		if err != nil {
+			return uuid.Nil, false, fmt.Errorf("load reserved changeset PR creation: %w", err)
+		}
+		if state != models.PRCreationStateQueued && state != models.PRCreationStatePushing {
+			return uuid.Nil, false, nil
+		}
 	}
 
 	dedupeKey := OpenPRDedupeKey(changesetID)
@@ -308,8 +325,11 @@ func (s *JobStore) QueueChangesetPRCreation(
 	if err := tx.Commit(ctx); err != nil {
 		return uuid.Nil, false, fmt.Errorf("commit changeset PR enqueue: %w", err)
 	}
-	s.notify(ctx, jobID)
-	return jobID, true, nil
+	queued = jobID != uuid.Nil
+	if queued {
+		s.notify(ctx, jobID)
+	}
+	return jobID, queued, nil
 }
 
 // EnqueueWithTarget is the positional-args wrapper for callers (typically

--- a/internal/db/session_publications.go
+++ b/internal/db/session_publications.go
@@ -390,11 +390,11 @@ func (s *SessionPublicationStore) EnsureRequested(ctx context.Context, orgID uui
 	return nil
 }
 
-// ApplyReviewBypass atomically detaches review evidence from a non-terminal
-// publication and advances it to draft publication. It is deliberately a
-// separate transition from EnsureRequested: replay protection normally keeps
-// terminal review decisions immutable, while this audited user action is the
-// one authorized exception.
+// ApplyReviewBypass atomically retires any linked review loop, detaches its
+// evidence from a non-terminal publication, and advances the publication. It
+// is deliberately separate from EnsureRequested: replay protection normally
+// keeps recorded review decisions immutable, while an explicit authenticated
+// Create PR action is the authorized exception.
 func (s *SessionPublicationStore) ApplyReviewBypass(ctx context.Context, orgID uuid.UUID, publication *models.SessionPublication) error {
 	if publication == nil {
 		return errors.New("session publication is required")
@@ -415,7 +415,23 @@ func (s *SessionPublicationStore) ApplyReviewBypass(ctx context.Context, orgID u
 	if requestPayload == "" {
 		return errors.New("publication review bypass payload is required")
 	}
-	rows, err := s.db.Query(ctx, `UPDATE session_publications
+	rows, err := s.db.Query(ctx, `WITH publication_to_bypass AS (
+		SELECT review_loop_id
+		FROM session_publications
+		WHERE org_id = @org_id AND session_id = @session_id AND changeset_id = @changeset_id
+		  AND state NOT IN ('completed', 'completed_noop', 'terminal_failed')
+		FOR UPDATE
+	), cancelled_review AS (
+		UPDATE session_review_loops AS loop
+		SET status = 'cancelled', review_required = false,
+			latest_summary = 'Review stopped because an explicit Create PR action superseded automatic review.',
+			bypass_reason = 'Explicit Create PR action',
+			completed_at = COALESCE(loop.completed_at, now())
+		FROM publication_to_bypass AS target
+		WHERE loop.org_id = @org_id AND loop.id = target.review_loop_id AND loop.status = 'running'
+		RETURNING loop.id
+	)
+	UPDATE session_publications
 		SET state = 'ready_to_publish', source = @source,
 			trigger_kind = 'explicit_action',
 			automatic_pr_policy_source = @automatic_policy_source,
@@ -428,6 +444,7 @@ func (s *SessionPublicationStore) ApplyReviewBypass(ctx context.Context, orgID u
 			last_error_code = NULL, last_error_message = NULL, updated_at = now()
 		WHERE org_id = @org_id AND session_id = @session_id AND changeset_id = @changeset_id
 		  AND state NOT IN ('completed', 'completed_noop', 'terminal_failed')
+		  AND (SELECT count(*) FROM cancelled_review) >= 0
 		RETURNING `+sessionPublicationSelectColumns, pgx.NamedArgs{
 		"org_id": orgID, "session_id": publication.SessionID, "changeset_id": publication.ChangesetID,
 		"source": publication.Source, "automatic_policy_source": publication.AutomaticPolicySource,

--- a/internal/db/session_publications_test.go
+++ b/internal/db/session_publications_test.go
@@ -270,7 +270,7 @@ func TestSessionPublicationStoreApplyReviewBypassDetachesEvidence(t *testing.T) 
 	stored.ReviewWorkspaceRevision = nil
 	stored.ReviewDesiredHeadSHA = nil
 
-	mock.ExpectQuery(`UPDATE session_publications[\s\S]+review_loop_id = NULL[\s\S]+review_gate_state = 'not_required'[\s\S]+org_id = @org_id AND session_id = @session_id AND changeset_id = @changeset_id`).
+	mock.ExpectQuery(`WITH publication_to_bypass AS[\s\S]+UPDATE session_review_loops AS loop[\s\S]+status = 'cancelled'[\s\S]+UPDATE session_publications[\s\S]+review_loop_id = NULL[\s\S]+review_gate_state = 'not_required'[\s\S]+org_id = @org_id AND session_id = @session_id AND changeset_id = @changeset_id`).
 		WithArgs(pgx.NamedArgs{
 			"org_id": orgID, "session_id": sessionID, "changeset_id": changesetID,
 			"source":                  models.SessionPublicationSourceUser,
@@ -281,7 +281,7 @@ func TestSessionPublicationStoreApplyReviewBypassDetachesEvidence(t *testing.T) 
 		WillReturnRows(pgxmock.NewRows(sessionPublicationTestColumns()).AddRow(sessionPublicationTestRow(stored)...))
 
 	err = NewSessionPublicationStore(mock).ApplyReviewBypass(context.Background(), orgID, &publication)
-	require.NoError(t, err, "authorized draft bypass should atomically detach stale review evidence")
+	require.NoError(t, err, "explicit Create PR should atomically retire review and detach stale evidence")
 	require.Equal(t, stored, publication, "bypassed publication should be ready with review no longer required")
 	require.NoError(t, mock.ExpectationsWereMet(), "review bypass should remain scoped to org, session, and changeset")
 }

--- a/internal/services/publicationintent/coordinator.go
+++ b/internal/services/publicationintent/coordinator.go
@@ -271,18 +271,23 @@ func (c *Coordinator) RequestPullRequest(
 		return nil, &Error{Code: ErrorPublicationFailed, Err: fmt.Errorf("check existing publication intent: %w", publicationErr)}
 	}
 	hasExistingPublication := publicationErr == nil
-	// The audited draft bypass is the resolution offered for a publication whose
-	// review already stopped for human attention. It is deliberately not a way
-	// to open a first-time request without review: "give me a draft PR" and
-	// "skip the review gate" must not be the same request.
+	// Existing review gates predate or originate from automatic handoff. An
+	// authenticated explicit Create PR action is a new publication decision and
+	// replaces that gate, while first-time explicit requests continue to skip
+	// review through the ordinary policy path below.
 	executionParked := hasExistingPublication && !existingPublication.State.Terminal() &&
 		(!c.PublicationExecutionEnabled(existingPublication.Source) ||
 			(existingPublication.ReviewGateState == models.SessionPublicationReviewGatePending &&
 				!c.ReviewExecutionEnabled(existingPublication.Source)))
-	bypassRequested := hasExistingPublication &&
+	explicitReviewReplacement := hasExistingPublication && !existingPublication.State.Terminal() &&
+		(existingPublication.ReviewGateState == models.SessionPublicationReviewGatePending ||
+			existingPublication.ReviewGateState == models.SessionPublicationReviewGateNeedsHuman) &&
+		authorizedManualTakeover(req)
+	draftBypassRequested := hasExistingPublication &&
 		(reviewBlocksPublication(existingPublication) || executionParked) &&
 		authorizedDraftBypass(req)
-	manualTakeoverRequested := executionParked && authorizedManualTakeover(req)
+	bypassRequested := explicitReviewReplacement || draftBypassRequested
+	manualTakeoverRequested := executionParked && authorizedManualTakeover(req) && !bypassRequested
 	// A retryable terminal outcome (no-op or failed) is not a durable answer:
 	// re-requesting must reach EnsureRequested, whose generation-guarded reopen
 	// is the only path back. Anything else is a live intent the caller rejoins.

--- a/internal/services/publicationintent/coordinator_test.go
+++ b/internal/services/publicationintent/coordinator_test.go
@@ -98,6 +98,7 @@ func (s *coordinatorPublicationStore) EnsureRequested(_ context.Context, _ uuid.
 }
 
 func (s *coordinatorPublicationStore) ApplyReviewBypass(_ context.Context, _ uuid.UUID, publication *models.SessionPublication) error {
+	publication.State = models.SessionPublicationStateReadyToPublish
 	publication.ReviewGateState = models.SessionPublicationReviewGateNotRequired
 	publication.ReviewMaxPasses = nil
 	publication.ReviewLoopID = nil
@@ -448,7 +449,7 @@ func TestCoordinatorRequestPullRequest_KillSwitchParksExistingLiveIntent(t *test
 	require.Nil(t, f.jobs.payload, "kill switch should not enqueue another execution job")
 }
 
-func TestCoordinatorRequestPullRequest_ExplicitUserTakesOverParkedAgentIntent(t *testing.T) {
+func TestCoordinatorRequestPullRequest_ExplicitUserReplacesReviewOnParkedAgentIntent(t *testing.T) {
 	t.Parallel()
 
 	f := newCoordinatorFixture(t, models.AutomaticFollowThroughOrgSettings{}, nil, nil, true, nil)
@@ -462,8 +463,9 @@ func TestCoordinatorRequestPullRequest_ExplicitUserTakesOverParkedAgentIntent(t 
 		ReviewGateState: models.SessionPublicationReviewGatePending, ReviewMaxPasses: &maxPasses,
 	}
 	f.publications.ensureReturnsSource = models.SessionPublicationSourceAgentTool
-	// The repository changed after the intent was recorded. A manual takeover
-	// must keep the durable draft-first contract rather than reinterpret it.
+	// The repository changed after the automatic intent was recorded. The
+	// explicit Create PR action is a new publication decision, so it uses the
+	// current direct-publication options instead of replaying automatic review.
 	f.coordinator.SetRepositoryStore(coordinatorRepositoryStore{repository: models.Repository{
 		ID: f.repositoryID, OrgID: f.orgID, Settings: json.RawMessage(`{"pr_handoff_mode":"pre_publish"}`),
 	}})
@@ -475,17 +477,17 @@ func TestCoordinatorRequestPullRequest_ExplicitUserTakesOverParkedAgentIntent(t 
 		RequestedByUserID: &requesterID, RequestedRole: string(models.RoleMember),
 	})
 
-	require.NoError(t, err, "an authorized user should be able to take over parked agent execution")
-	require.Equal(t, ResultReviewInProgress, result.Status, "manual takeover should preserve the pending review gate")
-	require.Equal(t, models.SessionPublicationSourceAgentTool, f.publications.captured.Source, "manual takeover should preserve the durable entry-point provenance")
-	require.Equal(t, models.SessionPublicationReviewGatePending, f.publications.captured.ReviewGateState, "manual takeover must not weaken recorded review")
-	require.Equal(t, string(models.SessionPublicationSourceAgentTool), f.jobs.payload["publication_source"], "queued work should preserve the original entry-point provenance")
-	require.Equal(t, string(models.SessionPublicationSourceUser), f.jobs.payload["publication_execution_source"], "queued work should use the explicit user as runtime authority")
-	require.Equal(t, string(models.PRHandoffModeDraftFirst), f.jobs.payload["publication_handoff_mode"], "manual takeover should retain the recorded handoff mode")
-	require.Equal(t, true, f.jobs.payload["draft"], "manual takeover should retain the original draft choice")
-	require.Equal(t, "app", f.jobs.payload["author_mode"], "manual takeover should retain the original authorship choice")
-	require.Equal(t, issueSnapshotID.String(), f.jobs.payload["issue_snapshot_id"], "manual takeover should retain the original issue snapshot")
-	require.NotNil(t, f.jobs.payload, "manual takeover should resume the parked durable job")
+	require.NoError(t, err, "an authorized user should be able to replace parked automatic review")
+	require.Equal(t, ResultPRQueued, result.Status, "explicit Create PR should queue direct publication")
+	require.True(t, result.ReviewBypassed, "the result should report removal of the persisted automatic review gate")
+	require.Equal(t, models.SessionPublicationSourceUser, f.publications.captured.Source, "the durable intent should record explicit user provenance")
+	require.Equal(t, models.SessionPublicationReviewGateNotRequired, f.publications.captured.ReviewGateState, "explicit Create PR should remove recorded automatic review")
+	require.Equal(t, string(models.SessionPublicationSourceUser), f.jobs.payload["publication_source"], "queued work should use explicit user provenance")
+	require.Equal(t, string(models.PRHandoffModePrePublish), f.jobs.payload["publication_handoff_mode"], "explicit publication should use the current repository handoff shape")
+	require.NotContains(t, f.jobs.payload, "draft", "ordinary Create PR should not replay the automatic draft choice")
+	require.NotContains(t, f.jobs.payload, "author_mode", "ordinary Create PR should not replay automatic authorship")
+	require.NotContains(t, f.jobs.payload, "issue_snapshot_id", "ordinary Create PR should not replay the automatic issue snapshot request")
+	require.NotNil(t, f.jobs.payload, "explicit Create PR should queue the durable job")
 }
 
 func TestCoordinatorRequestPullRequest_NonPrimarySafetyGates(t *testing.T) {
@@ -923,6 +925,39 @@ func TestCoordinatorRequestPullRequestRejoinsOrReopensExistingIntent(t *testing.
 			require.Nil(t, f.jobs.payload, "rejoining a live intent should not queue a duplicate job")
 		})
 	}
+}
+
+func TestCoordinatorRequestPullRequestExplicitActionReplacesExistingReview(t *testing.T) {
+	t.Parallel()
+
+	f := newCoordinatorFixture(t, models.AutomaticFollowThroughOrgSettings{}, nil, nil, true, nil)
+	reviewLoopID := uuid.New()
+	maxPasses := 2
+	existing := models.SessionPublication{
+		ID: f.changesetID, OrgID: f.orgID, SessionID: f.sessionID, ChangesetID: f.changesetID,
+		RepositoryID: f.repositoryID, State: models.SessionPublicationStateReviewPending,
+		Source: models.SessionPublicationSourceUser, TriggerKind: models.SessionPublicationTriggerExplicitAction,
+		HandoffMode: models.PRHandoffModePrePublish, AutomaticPolicySource: models.PublicationPolicySourceExplicitAction,
+		ReviewPolicySource: models.PublicationPolicySourceProductDefault, ReviewMaxPasses: &maxPasses,
+		ReviewLoopID: &reviewLoopID, ReviewGateState: models.SessionPublicationReviewGatePending,
+		JobQueue: models.SessionPublicationJobQueueAgent, RequestPayload: json.RawMessage(`{"session_id":"old"}`),
+		BaseBranch: "main", HeadBranch: "143/change",
+	}
+	f.publications.captured = &existing
+
+	result, err := f.coordinator.RequestPullRequest(context.Background(), f.orgID, f.sessionID, RequestPullRequest{
+		Source: models.SessionPublicationSourceUser, TriggerKind: models.SessionPublicationTriggerExplicitAction,
+		RequestedByUserID: &f.userID, RequestedRole: string(models.RoleMember),
+	})
+
+	require.NoError(t, err, "an explicit Create PR action should replace an older automatic review intent")
+	require.Equal(t, ResultPRQueued, result.Status, "the explicit action should queue pull request creation directly")
+	require.True(t, result.ReviewBypassed, "the result should report that the older persisted review gate was removed")
+	require.Equal(t, models.SessionPublicationStateReadyToPublish, f.publications.captured.State, "the durable intent should advance past review")
+	require.Equal(t, models.SessionPublicationReviewGateNotRequired, f.publications.captured.ReviewGateState, "the durable intent should no longer require review")
+	require.Nil(t, f.publications.captured.ReviewLoopID, "the durable intent should detach the superseded review loop")
+	require.NotNil(t, f.jobs.payload, "the explicit action should queue publication work")
+	require.NotContains(t, f.jobs.payload, "draft", "the ordinary Create PR action should not force a draft")
 }
 
 func TestCoordinatorRequestPullRequestReopensTerminalDraftWithExistingPR(t *testing.T) {


### PR DESCRIPTION
## Summary

- make authenticated **Create PR** actions replace pending or human-blocked automatic review workflows
- atomically retire the linked running review loop and queue direct PR publication
- change the review workflow fallback from **Create draft PR** to the ordinary **Create PR** action
- requeue `open_pr` work when review left the changeset PR slot in `queued` or `pushing`, while preserving active-job deduplication

## Root cause

Explicit Create PR requests correctly skipped review for new publication intents, but the API rejoined older nonterminal review intents before the coordinator could apply that policy. After bypassing such an intent, the initial review job had also left the changeset PR slot reserved, causing the normal atomic queue helper to return success without inserting new work.

## Impact

Clicking **Create PR** now creates the pull request directly without starting or rejoining review. Existing completed publications remain idempotent, and active publication jobs are still deduplicated.

## Validation

- `go test ./internal/db ./internal/services/publicationintent ./internal/api/handlers`
- `go vet ./internal/db ./internal/services/publicationintent ./internal/api/handlers`
- focused frontend PR-creation tests (56 passing)
- touched-file frontend ESLint
- `make lint-tenancy`
- `git diff --check`
