### PR TITLE
Redesign inconsistent info cards for cleaner UX inspired by modern SaaS design patterns

### DIFF
--- a/frontend/src/app/(dashboard)/sessions/[id]/page-overview.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/page-overview.test.tsx
@@ -443,16 +443,17 @@ describe('SessionDetailPage overview and review loop', () => {
     expect(reviewAction).not.toHaveClass('w-full');
     expect(reviewButton).not.toHaveClass('w-full');
     const reviewTitle = screen.getByText('Review before creating a PR?');
-    const splitTitle = screen.getByText('Need smaller pull requests?');
+    const splitTitle = screen.getByText('Large change · 750 additions · 1 file');
     const reviewCard = reviewTitle.closest('[data-slot="card"]');
-    const splitCard = splitTitle.closest('[data-slot="card"]');
+    const splitSuggestion = splitTitle.closest('[data-slot="overview-suggestion"]');
     expect(reviewCard?.querySelector('[data-slot="agent-action-card-icon"] .lucide-scan-search')).toBeInTheDocument();
-    expect(splitCard?.querySelector('[data-slot="agent-action-card-icon"] .lucide-git-branch')).toBeInTheDocument();
+    expect(splitSuggestion?.querySelector('[data-slot="overview-suggestion-icon"] .lucide-git-branch')).toBeInTheDocument();
+    expect(splitTitle.closest('[data-slot="card"]')).toBeNull();
     expect(reviewTitle.compareDocumentPosition(splitTitle) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
     expect(within(screen.getByLabelText('Session detail actions')).queryByRole('button', { name: 'Review' })).not.toBeInTheDocument();
   });
 
-  it('keeps PR details at the very top of the overview before the split suggestion', async () => {
+  it('orders PR details, Result, then the quiet split suggestion', async () => {
     server.use(
       http.get('/api/v1/sessions/:id', () => {
         return HttpResponse.json({
@@ -466,13 +467,13 @@ describe('SessionDetailPage overview and review loop', () => {
 
     renderWithProviders(<SessionDetailContent id={mockSessions[0].id} />);
 
-    const prDetailsTitle = await screen.findByText('PR health');
-    const splitTitle = screen.getByText('Need smaller pull requests?');
-    const prDetailsCard = prDetailsTitle.closest('[data-slot="card"]');
+    const prDetailsCard = await screen.findByRole('region', { name: 'Pull request #42' });
+    const resultCard = screen.getByTestId('session-result-card');
+    const splitSuggestion = screen.getByRole('region', { name: 'Pull request size suggestion' });
 
-    expect(prDetailsCard).not.toBeNull();
     expect(prDetailsCard?.parentElement?.firstElementChild).toBe(prDetailsCard);
-    expect(prDetailsTitle.compareDocumentPosition(splitTitle) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    expect(prDetailsCard.compareDocumentPosition(resultCard) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    expect(resultCard.compareDocumentPosition(splitSuggestion) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
   });
 
   it('shows a compact status card while the Overview review loop is running', async () => {
@@ -541,7 +542,7 @@ describe('SessionDetailPage overview and review loop', () => {
 
     renderWithProviders(<SessionDetailContent id="session-abcdef12-3456-7890" />);
 
-    expect(await screen.findByText('PR health')).toBeInTheDocument();
+    expect(await screen.findByRole('region', { name: 'Pull request #42' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Review' })).toBeInTheDocument();
     expect(screen.queryByText('Review work')).not.toBeInTheDocument();
     expect(screen.queryByText('Review this work')).not.toBeInTheDocument();

--- a/frontend/src/app/(dashboard)/sessions/[id]/page-overview.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/page-overview.test.tsx
@@ -447,6 +447,13 @@ describe('SessionDetailPage overview and review loop', () => {
     const reviewCard = reviewTitle.closest('[data-slot="card"]');
     const splitSuggestion = splitTitle.closest('[data-slot="overview-suggestion"]');
     expect(reviewCard?.querySelector('[data-slot="agent-action-card-icon"] .lucide-scan-search')).toBeInTheDocument();
+    // jsdom cannot evaluate container queries, so guard the placement instead:
+    // an element is never its own query container, so the row layout would be
+    // dead if the container were declared on the element that queries it.
+    const reviewCardContent = reviewCard?.querySelector('[data-slot="card-content"]');
+    expect(reviewCard?.className).toContain('@container/agent-action');
+    expect(reviewCardContent?.className).toContain('@min-[24rem]/agent-action:flex-row');
+    expect(reviewCardContent?.className).not.toContain('@container/agent-action');
     expect(splitSuggestion?.querySelector('[data-slot="overview-suggestion-icon"] .lucide-git-branch')).toBeInTheDocument();
     expect(splitTitle.closest('[data-slot="card"]')).toBeNull();
     expect(reviewTitle.compareDocumentPosition(splitTitle) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();

--- a/frontend/src/app/(dashboard)/sessions/[id]/page-pr-health.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/page-pr-health.test.tsx
@@ -168,7 +168,7 @@ describe('SessionDetailPage PR health and merge', () => {
 
     renderWithProviders(<SessionDetailContent id="session-abcdef12-3456-7890" />);
 
-    expect(await screen.findByText('PR health')).toBeInTheDocument();
+    expect(await screen.findByRole('region', { name: 'Pull request #42' })).toBeInTheDocument();
     expect(MockEventSource.instances).toHaveLength(1);
     expect(MockEventSource.instances[0].url).toContain(`/api/v1/pull-requests/stream?org_id=${activeOrgId}`);
   });
@@ -176,7 +176,7 @@ describe('SessionDetailPage PR health and merge', () => {
   it('reconnects the PR health stream after an SSE error', async () => {
     renderWithProviders(<SessionDetailContent id="session-abcdef12-3456-7890" />);
 
-    expect(await screen.findByText('PR health')).toBeInTheDocument();
+    expect(await screen.findByRole('region', { name: 'Pull request #42' })).toBeInTheDocument();
     expect(MockEventSource.instances).toHaveLength(1);
 
     MockEventSource.instances[0].onerror?.(new Event('error'));
@@ -389,8 +389,8 @@ describe('SessionDetailPage PR health and merge', () => {
 
     renderWithProviders(<SessionDetailContent id="session-abcdef12-3456-7890" />);
 
-    expect(await screen.findByText('PR health')).toBeInTheDocument();
-    expect(screen.getByText('PR #42 is blocked by conflicts and 2 failing test jobs.')).toBeInTheDocument();
+    expect(await screen.findByRole('region', { name: 'Pull request #42' })).toBeInTheDocument();
+    expect(screen.getByText('Blocked by conflicts and 2 failing test jobs.')).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Resolve conflicts' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Fix tests' })).toBeInTheDocument();
   });
@@ -426,7 +426,7 @@ describe('SessionDetailPage PR health and merge', () => {
     expect((await screen.findAllByText('PR #42 closed')).length).toBeGreaterThanOrEqual(2);
     expect(screen.getByText('PR #42 was closed without merging.')).toBeInTheDocument();
     expect(screen.getByRole('link', { name: 'View PR' })).toBeInTheDocument();
-    expect(screen.queryByText('PR health')).not.toBeInTheDocument();
+    expect(screen.queryByRole('region', { name: 'Pull request #42' })).not.toBeInTheDocument();
     expect(screen.queryByRole('button', { name: 'Resolve conflicts' })).not.toBeInTheDocument();
     expect(screen.queryByRole('button', { name: 'Fix tests' })).not.toBeInTheDocument();
   });
@@ -517,8 +517,8 @@ describe('SessionDetailPage PR health and merge', () => {
 
     renderWithProviders(<SessionDetailContent id="session-abcdef12-3456-7890" />);
 
-    expect(await screen.findByText('PR #42 is waiting for required checks to report passing.')).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: /^Merge$/ })).toBeDisabled();
+    expect(await screen.findByText('Waiting for required checks to report passing.')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Merge when ready' })).not.toBeDisabled();
 
     await waitFor(() => {
       expect(MockEventSource.instances.some((source) => source.url.includes('/api/v1/pull-requests/stream'))).toBe(true);
@@ -623,7 +623,7 @@ describe('SessionDetailPage PR health and merge', () => {
     expect(screen.getByLabelText('Merged PR status')).toHaveClass('text-success');
     expect(screen.queryAllByText('PR created')).toHaveLength(0);
     expect(within(screen.getByLabelText('Session detail actions')).queryByText('PR #42 merged')).not.toBeInTheDocument();
-    expect(screen.queryByText('PR health')).not.toBeInTheDocument();
+    expect(screen.queryByRole('region', { name: 'Pull request #42' })).not.toBeInTheDocument();
   });
 
   it('shows a closed PR with a neutral status tone', async () => {
@@ -695,7 +695,7 @@ describe('SessionDetailPage PR health and merge', () => {
     expect(await screen.findAllByText('PR merged')).toHaveLength(2);
     expect(screen.getByText('PR #42 merged')).toBeInTheDocument();
     expect(screen.getByText('PR #42 was merged successfully.')).toBeInTheDocument();
-    expect(screen.queryByText('PR health')).not.toBeInTheDocument();
+    expect(screen.queryByRole('region', { name: 'Pull request #42' })).not.toBeInTheDocument();
   });
 
   it('updates the header status when the PR stream reports a merge', async () => {
@@ -760,7 +760,7 @@ describe('SessionDetailPage PR health and merge', () => {
     expect(screen.queryAllByText('PR created')).toHaveLength(0);
   });
 
-  it('keeps the Merge button visible but disabled while CI is still in flight', async () => {
+  it('offers Merge when ready while CI is still in flight', async () => {
     server.use(
       http.get('/api/v1/pull-requests/:id/health', () => {
         return HttpResponse.json({
@@ -777,10 +777,10 @@ describe('SessionDetailPage PR health and merge', () => {
     );
 
     renderWithProviders(<SessionDetailContent id="session-abcdef12-3456-7890" />);
-    await screen.findByText('PR health');
-    const mergeButton = screen.getByRole('button', { name: /^Merge$/ });
-    expect(mergeButton).toBeDisabled();
-    expect(mergeButton).toHaveAttribute('title', 'Checks are still running.');
+    await screen.findByRole('region', { name: 'Pull request #42' });
+    const mergeWhenReadyButton = screen.getByRole('button', { name: 'Merge when ready' });
+    expect(mergeWhenReadyButton).not.toBeDisabled();
+    expect(mergeWhenReadyButton).toHaveAttribute('data-variant', 'default');
   });
 
   it('shows a Merge button that opens GitHub auth when the org requires GitHub user auth and the user is disconnected', async () => {
@@ -809,7 +809,7 @@ describe('SessionDetailPage PR health and merge', () => {
 
     renderWithProviders(<SessionDetailContent id="session-abcdef12-3456-7890" />);
 
-    await screen.findByText('PR health');
+    await screen.findByRole('region', { name: 'Pull request #42' });
     const user = userEvent.setup();
     await user.click(screen.getByRole('button', { name: /^Merge$/ }));
 
@@ -872,7 +872,7 @@ describe('SessionDetailPage PR health and merge', () => {
 
     renderWithProviders(<SessionDetailContent id="session-abcdef12-3456-7890" />);
 
-    await screen.findByText('PR health');
+    await screen.findByRole('region', { name: 'Pull request #42' });
     const mergeButton = screen.getByRole('button', { name: /^Merge$/ });
     expect(mergeButton).toBeDisabled();
     expect(mergeButton).toHaveAttribute('title', 'Waiting for GitHub to confirm required checks.');
@@ -962,9 +962,9 @@ describe('SessionDetailPage PR health and merge', () => {
 
     renderWithProviders(<SessionDetailContent id="session-abcdef12-3456-7890" />);
 
-    expect(await screen.findByText('PR #42 is blocked by GitHub merge requirements.')).toBeInTheDocument();
+    expect(await screen.findByText('Blocked by GitHub merge requirements.')).toBeInTheDocument();
     expect(screen.queryByRole('button', { name: 'Resolve conflicts' })).not.toBeInTheDocument();
-    expect(screen.getByRole('button', { name: /^Merge$/ })).toBeDisabled();
+    expect(screen.getByRole('button', { name: 'Merge when ready' })).not.toBeDisabled();
   });
 
   it('stays on the original session after starting a PR repair action', async () => {
@@ -1395,7 +1395,7 @@ describe('SessionDetailPage PR health and merge', () => {
 
     await waitFor(() => {
       expect(screen.queryByText('Fix tests running')).not.toBeInTheDocument();
-      expect(screen.getByText('PR #42 is mergeable and all required test checks are passing.')).toBeInTheDocument();
+      expect(screen.getByText('Mergeable and all required test checks are passing.')).toBeInTheDocument();
     });
   });
 
@@ -1462,7 +1462,7 @@ describe('SessionDetailPage PR health and merge', () => {
 
     await waitFor(() => {
       expect(screen.queryByText('Fix tests running')).not.toBeInTheDocument();
-      expect(screen.getByText('PR #42 is mergeable and all required test checks are passing.')).toBeInTheDocument();
+      expect(screen.getByText('Mergeable and all required test checks are passing.')).toBeInTheDocument();
     });
   });
 

--- a/frontend/src/app/(dashboard)/sessions/[id]/pull-request-list.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/pull-request-list.test.tsx
@@ -105,19 +105,20 @@ describe('ChangesetSplitPrompt', () => {
     render(
       <ChangesetSplitPrompt
         additions={CHANGESET_SPLIT_MIN_ADDITIONS}
+        filesChanged={1}
         onRequestSplit={onRequestSplit}
       />,
     );
 
-    await userEvent.click(await screen.findByRole('button', { name: 'Split PRs' }));
+    await userEvent.click(await screen.findByRole('button', { name: 'Split into PRs' }));
 
-    expect(screen.getByText('Need smaller pull requests?')).toBeInTheDocument();
-    expect(screen.getByText('Ask the coding agent to split the current diff into reviewable branches.')).toBeInTheDocument();
-    expect(document.querySelector('[data-slot="agent-action-card-icon"] .lucide-git-branch')).toBeInTheDocument();
+    expect(screen.getByText('Large change · 750 additions · 1 file')).toBeInTheDocument();
+    expect(screen.getByText('Split this diff into smaller, reviewable pull requests.')).toBeInTheDocument();
+    expect(document.querySelector('[data-slot="overview-suggestion-icon"] .lucide-git-branch')).toBeInTheDocument();
     expect(onRequestSplit).toHaveBeenCalledOnce();
   });
 
-  it('declares the layout container above the elements that query it', () => {
+  it('renders as a quiet suggestion row instead of another card', () => {
     render(
       <ChangesetSplitPrompt
         additions={CHANGESET_SPLIT_MIN_ADDITIONS}
@@ -125,18 +126,13 @@ describe('ChangesetSplitPrompt', () => {
       />,
     );
 
-    const card = screen.getByText('Need smaller pull requests?').closest('[data-slot="card"]');
-    const content = card?.querySelector('[data-slot="card-content"]');
-
-    // jsdom cannot evaluate container queries, so guard the placement instead:
-    // an element is never its own query container, so the row layout would be
-    // dead if the container were declared on the element that queries it.
-    expect(card?.className).toContain('@container/agent-action');
-    expect(content?.className).toContain('@min-[24rem]/agent-action:flex-row');
-    expect(content?.className).not.toContain('@container/agent-action');
+    const suggestion = screen.getByRole('region', { name: 'Pull request size suggestion' });
+    expect(suggestion).toHaveAttribute('data-slot', 'overview-suggestion');
+    expect(suggestion).toHaveClass('flex', 'items-center');
+    expect(suggestion.closest('[data-slot="card"]')).toBeNull();
   });
 
-  it('keeps the split action sized to its label on narrow cards', () => {
+  it('uses a compact ghost action that stays aligned on narrow panels', () => {
     render(
       <ChangesetSplitPrompt
         additions={CHANGESET_SPLIT_MIN_ADDITIONS}
@@ -144,11 +140,9 @@ describe('ChangesetSplitPrompt', () => {
       />,
     );
 
-    const button = screen.getByRole('button', { name: 'Split PRs' });
-    const action = button.closest('[data-slot="agent-action-card-action"]');
-    expect(action).toHaveClass('ml-11', 'w-fit', 'self-start');
-    expect(action).toHaveClass('@min-[24rem]/agent-action:ml-0');
-    expect(action).not.toHaveClass('w-full');
-    expect(button).not.toHaveClass('w-full');
+    const button = screen.getByRole('button', { name: 'Split into PRs' });
+    expect(button).toHaveAttribute('data-size', 'xs');
+    expect(button).toHaveAttribute('data-variant', 'ghost');
+    expect(button).toHaveClass('shrink-0');
   });
 });

--- a/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
@@ -695,6 +695,29 @@ function ThreadFailureDetailsCard({ thread }: { thread: SessionThread }) {
   );
 }
 
+function SessionResultCard({ summary }: { summary?: string }) {
+  if (!summary) return null;
+
+  return (
+    <Card className="border-border/60" data-testid="session-result-card">
+      <CardContent className="p-3.5">
+        <div className="flex items-start gap-2.5">
+          <div
+            aria-hidden="true"
+            className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md bg-success/10 text-success"
+          >
+            <CheckCircle2 className="h-4 w-4" />
+          </div>
+          <div className="min-w-0 flex-1">
+            <div className="text-sm font-medium text-foreground">Result</div>
+            <LazyMarkdownContent content={summary} className="mt-2 text-xs" />
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
 function OverviewTab({ session, activeThread, members, prStatus }: { session: Session; activeThread?: SessionThread | null; members: User[]; prStatus?: PullRequestStatus | null }) {
   const queryClient = useQueryClient();
   const [showDeviceCodeModal, setShowDeviceCodeModal] = useState(false);
@@ -740,21 +763,6 @@ function OverviewTab({ session, activeThread, members, prStatus }: { session: Se
 
   return (
     <div className="space-y-4">
-      {/* Result card — most important for completed sessions, shown first */}
-      {session.result_summary && (
-        <Card className="border-l-2 border-l-success bg-success/5">
-          <CardHeader className="pb-2">
-            <CardTitle className="text-xs flex items-center gap-2">
-              <CheckCircle2 className="h-3.5 w-3.5 text-success" />
-              Result
-            </CardTitle>
-          </CardHeader>
-          <CardContent>
-            <LazyMarkdownContent content={session.result_summary} className="text-xs" />
-          </CardContent>
-        </Card>
-      )}
-
       {isDeployRecovery && (
         <Card className="border-l-2 border-l-warning bg-warning/5">
           <CardHeader className="pb-2">
@@ -3455,26 +3463,54 @@ export function PullRequestList({
 
 export function ChangesetSplitPrompt({
   additions,
+  filesChanged,
   onRequestSplit,
   requestSplitPending = false,
 }: {
   additions?: number;
+  filesChanged?: number;
   onRequestSplit?: () => void;
   requestSplitPending?: boolean;
 }) {
   if (!shouldOfferChangesetSplit(additions)) return null;
 
+  const additionCount = additions ?? 0;
+  const fileLabel = filesChanged === undefined
+    ? ""
+    : ` · ${filesChanged.toLocaleString()} ${filesChanged === 1 ? "file" : "files"}`;
+
   return (
-    <AgentActionCard
-      icon={<GitBranch className="h-4 w-4" />}
-      title="Need smaller pull requests?"
-      description="Ask the coding agent to split the current diff into reviewable branches."
-      action={(
-        <Button size="sm" variant="outline" disabled={requestSplitPending || !onRequestSplit} onClick={onRequestSplit}>
-          Split PRs
-        </Button>
-      )}
-    />
+    <div
+      role="region"
+      aria-label="Pull request size suggestion"
+      data-slot="overview-suggestion"
+      className="flex items-center gap-2.5 px-1 py-1.5"
+    >
+      <div
+        data-slot="overview-suggestion-icon"
+        aria-hidden="true"
+        className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md bg-muted text-muted-foreground"
+      >
+        <GitBranch className="h-4 w-4" />
+      </div>
+      <div className="min-w-0 flex-1">
+        <p className="text-xs font-medium text-foreground">
+          Large change · {additionCount.toLocaleString()} additions{fileLabel}
+        </p>
+        <p className="text-xs leading-relaxed text-muted-foreground">
+          Split this diff into smaller, reviewable pull requests.
+        </p>
+      </div>
+      <Button
+        size="xs"
+        variant="ghost"
+        className="shrink-0"
+        disabled={requestSplitPending || !onRequestSplit}
+        onClick={onRequestSplit}
+      >
+        Split into PRs
+      </Button>
+    </div>
   );
 }
 
@@ -6554,9 +6590,9 @@ export function SessionDetailContent({ id }: { id: string }) {
           )}
           {pullRequestId && prStatus === "closed" && (
             <Card className="border-border/60">
-              <CardContent className="p-4">
-                <div className="flex items-start gap-3">
-                  <div className="flex h-8 w-8 items-center justify-center rounded-full bg-muted text-muted-foreground">
+              <CardContent className="p-3.5">
+                <div className="flex items-start gap-2.5">
+                  <div className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md bg-muted text-muted-foreground">
                     <XCircle className="h-4 w-4" />
                   </div>
                   <div className="min-w-0 space-y-1">
@@ -6572,9 +6608,9 @@ export function SessionDetailContent({ id }: { id: string }) {
           )}
           {pullRequestId && prStatus === "merged" && (
             <Card className="border-border/60">
-              <CardContent className="p-4">
-                <div className="flex items-start gap-3">
-                  <div aria-label="Merged PR status" className={cn("flex h-8 w-8 items-center justify-center rounded-full", prMergedAccent.bg, prMergedAccent.text)}>
+              <CardContent className="p-3.5">
+                <div className="flex items-start gap-2.5">
+                  <div aria-label="Merged PR status" className={cn("flex h-7 w-7 shrink-0 items-center justify-center rounded-md", prMergedAccent.bg, prMergedAccent.text)}>
                     <CheckCircle2 className="h-4 w-4" />
                   </div>
                   <div className="min-w-0 space-y-1">
@@ -6588,6 +6624,7 @@ export function SessionDetailContent({ id }: { id: string }) {
               </CardContent>
             </Card>
           )}
+          <SessionResultCard summary={session.result_summary} />
           <PullRequestList
             changesets={changesets}
             selectedID={selectedChangeset?.id ?? ""}
@@ -6654,6 +6691,7 @@ export function SessionDetailContent({ id }: { id: string }) {
           ) : null}
           <ChangesetSplitPrompt
             additions={session.diff_stats?.added}
+            filesChanged={session.diff_stats?.files_changed}
             onRequestSplit={() => queueSend({
               overrideMessage: "Split the current diff into smaller, independently reviewable pull requests. Before making changes, run `143-tools changesets list`, `143-tools changesets current`, and `143-tools changesets status` so the platform changeset state is authoritative. Then use the changeset tools to create and materialize the split; do not create worktrees manually. Keep each pull request cohesive, account for every changed file, and verify the completed split with the changeset tools.",
             })}

--- a/frontend/src/components/pr-health-banner-sync-copy.test.tsx
+++ b/frontend/src/components/pr-health-banner-sync-copy.test.tsx
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { PullRequestHealthResponse } from "@/lib/types";
 import { renderWithProviders, screen } from "@/test/test-utils";
@@ -37,7 +37,16 @@ const health: PullRequestHealthResponse = {
 };
 
 describe("PRHealthBanner sync copy", () => {
-  it("renders sync status as plain text instead of a badge pill", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-29T12:00:00.000Z"));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("renders the compact sync timestamp as plain text instead of a badge pill", () => {
     renderWithProviders(
       <PRHealthBanner
         health={health}
@@ -50,7 +59,8 @@ describe("PRHealthBanner sync copy", () => {
       />,
     );
 
-    expect(screen.getByText(/Synced/)).toBeInTheDocument();
-    expect(screen.queryByText(/Synced/, { selector: "[data-slot='badge']" })).toBeNull();
+    expect(screen.getByText("3m ago")).toBeInTheDocument();
+    expect(screen.queryByText("3m ago", { selector: "[data-slot='badge']" })).toBeNull();
+    expect(screen.queryByText(/Synced/)).toBeNull();
   });
 });

--- a/frontend/src/components/pr-health-banner.test.tsx
+++ b/frontend/src/components/pr-health-banner.test.tsx
@@ -3,7 +3,7 @@ import { describe, expect, it, vi } from "vitest";
 import type { PullRequestHealthResponse } from "@/lib/types";
 import { renderWithProviders, screen, userEvent } from "@/test/test-utils";
 
-import { PRHealthBanner } from "./pr-health-banner";
+import { compactPRHealthSummary, PRHealthBanner } from "./pr-health-banner";
 
 const baseHealth: PullRequestHealthResponse = {
   pull_request_id: "pr-123",
@@ -1057,5 +1057,25 @@ describe("PRHealthBanner", () => {
 
     expect(container.querySelector("svg.lucide-git-pull-request")).toBeInTheDocument();
     expect(container.querySelector("svg.lucide-check-circle-2")).toBeNull();
+  });
+});
+
+describe("compactPRHealthSummary", () => {
+  it.each([
+    ["PR #42 is mergeable and all required test checks are passing.", "Mergeable and all required test checks are passing."],
+    ["PR #42 has merge conflicts.", "Merge conflicts."],
+    ["PR #42 is blocked by conflicts and 2 failing test jobs.", "Blocked by conflicts and 2 failing test jobs."],
+    // Only a standalone "is"/"has" is dropped, not a word that starts with one.
+    ["PR #42 issues remain.", "Issues remain."],
+  ])("drops the redundant entity prefix from %j", (summary, expected) => {
+    expect(compactPRHealthSummary(summary, 42)).toBe(expected);
+  });
+
+  it.each([
+    ["Draft PR #42 is stale.", "a summary that does not lead with the entity"],
+    ["PR #7 is healthy.", "a summary about a different pull request"],
+    ["", "an empty summary"],
+  ])("leaves %j untouched for %s", (summary) => {
+    expect(compactPRHealthSummary(summary, 42)).toBe(summary);
   });
 });

--- a/frontend/src/components/pr-health-banner.test.tsx
+++ b/frontend/src/components/pr-health-banner.test.tsx
@@ -87,6 +87,72 @@ describe("PRHealthBanner", () => {
     expect(screen.queryByText("Ready")).not.toBeInTheDocument();
   });
 
+  // The status badge is the card's headline state, so every branch of the
+  // derivation needs a guard — the ordering between them is what decides which
+  // one wins when a PR is, say, repairing *and* conflicted.
+  it.each([
+    {
+      label: "Repairing",
+      variant: "info",
+      health: {
+        checks_confirmed: true,
+        has_conflicts: true,
+        active_repairs: [{
+          action_type: "resolve_conflicts",
+          session_id: "session-456",
+          session_status: "running",
+          health_version: 2,
+        }],
+      },
+    },
+    {
+      label: "Conflicts",
+      variant: "warning",
+      health: {
+        checks_confirmed: true,
+        has_conflicts: true,
+        checks: [{ name: "unit", category: "test", status: "failed" }],
+      },
+    },
+    {
+      label: "Checks failing",
+      variant: "destructive",
+      health: {
+        checks_confirmed: true,
+        checks: [{ name: "unit", category: "test", status: "failed" }],
+      },
+    },
+    {
+      label: "Behind",
+      variant: "warning",
+      health: { checks_confirmed: true, merge_state: "behind" },
+    },
+    {
+      label: "Blocked",
+      variant: "warning",
+      health: { checks_confirmed: true, merge_state: "blocked" },
+    },
+    {
+      label: "Open",
+      variant: "secondary",
+      health: { checks_confirmed: true, merge_state: "clean" },
+    },
+  ])("labels the pull request $label", ({ label, variant, health }) => {
+    renderWithProviders(
+      <PRHealthBanner
+        health={{ ...baseHealth, ...health } as PullRequestHealthResponse}
+        pendingAction={null}
+        repairError={null}
+        mergeAuthRequired={false}
+        onFixTests={vi.fn()}
+        onResolveConflicts={vi.fn()}
+        onMerge={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText(label, { selector: "[data-slot='badge']" })).toHaveAttribute("data-variant", variant);
+  });
+
   it("keeps the Merge button visible but disabled when can_merge is false", async () => {
     renderWithProviders(
       <PRHealthBanner

--- a/frontend/src/components/pr-health-banner.test.tsx
+++ b/frontend/src/components/pr-health-banner.test.tsx
@@ -37,10 +37,10 @@ const baseHealth: PullRequestHealthResponse = {
 };
 
 describe("PRHealthBanner", () => {
-  it("uses text-sm for the header and text-xs for non-header copy", () => {
+  it("uses an entity-first header with compact supporting copy", () => {
     renderWithProviders(
       <PRHealthBanner
-        health={{ ...baseHealth, checks_confirmed: true }}
+        health={{ ...baseHealth, checks_confirmed: true, can_merge: true }}
         pendingAction={null}
         repairError={null}
         mergeAuthRequired={false}
@@ -50,9 +50,41 @@ describe("PRHealthBanner", () => {
       />,
     );
 
-    expect(screen.getByText("PR health")).toHaveClass("text-sm");
-    expect(screen.getByText("PR #42 · acme/widgets")).toHaveClass("text-xs");
-    expect(screen.getByText("PR #42 is healthy.")).toHaveClass("text-xs");
+    expect(screen.getByRole("region", { name: "Pull request #42" })).toBeInTheDocument();
+    expect(screen.getByText("PR #42")).toHaveClass("text-sm");
+    expect(screen.getByText("Ready")).toHaveAttribute("data-variant", "success");
+    expect(screen.getByText("acme/widgets")).toHaveClass("text-xs");
+    expect(screen.getByText("Healthy.")).toHaveClass("text-xs");
+  });
+
+  it.each([
+    {
+      name: "unconfirmed checks",
+      health: { checks_confirmed: false, can_merge: true },
+    },
+    {
+      name: "a pending check",
+      health: {
+        checks_confirmed: true,
+        can_merge: true,
+        checks: [{ name: "Unit tests", category: "test", status: "pending" }],
+      },
+    },
+  ])("labels the pull request as checking while $name remain", ({ health }) => {
+    renderWithProviders(
+      <PRHealthBanner
+        health={{ ...baseHealth, ...health } as PullRequestHealthResponse}
+        pendingAction={null}
+        repairError={null}
+        mergeAuthRequired={false}
+        onFixTests={vi.fn()}
+        onResolveConflicts={vi.fn()}
+        onMerge={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("Checking")).toHaveAttribute("data-variant", "info");
+    expect(screen.queryByText("Ready")).not.toBeInTheDocument();
   });
 
   it("keeps the Merge button visible but disabled when can_merge is false", async () => {
@@ -70,11 +102,11 @@ describe("PRHealthBanner", () => {
 
     const button = screen.getByRole("button", { name: /^Merge$/ });
     expect(button).toBeDisabled();
-
+    expect(button).toHaveAttribute("data-variant", "outline");
     expect(button).toHaveAttribute("title", "GitHub is not allowing this PR to merge yet.");
   });
 
-  it("uses compact spacing for the merge and review actions", () => {
+  it("promotes merge when ready while keeping review secondary", () => {
     renderWithProviders(
       <PRHealthBanner
         health={{ ...baseHealth, checks_confirmed: true }}
@@ -90,8 +122,9 @@ describe("PRHealthBanner", () => {
       />,
     );
 
-    expect(screen.getByRole("button", { name: "More merge actions" })).toHaveClass("w-8", "sm:w-6");
-    expect(screen.getByRole("button", { name: /^Merge$/ }).querySelector("svg")).not.toHaveClass("mr-1.5");
+    expect(screen.queryByRole("button", { name: "More merge actions" })).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Merge when ready" })).toHaveAttribute("data-variant", "default");
+    expect(screen.getByRole("button", { name: "Merge when ready" }).querySelector("svg")).not.toHaveClass("mr-1.5");
     expect(screen.getByRole("button", { name: "Review" }).querySelector("svg")).not.toHaveClass("mr-1.5");
   });
 
@@ -250,8 +283,9 @@ describe("PRHealthBanner", () => {
       />,
     );
 
-    expect(screen.getByText("PR health")).toBeInTheDocument();
-    expect(screen.getByText(/cannot be refreshed because acme\/widgets is disconnected from GitHub/)).toBeInTheDocument();
+    expect(screen.getByRole("region", { name: "Pull request #42" })).toBeInTheDocument();
+    expect(screen.getByText("Disconnected")).toHaveAttribute("data-variant", "warning");
+    expect(screen.getByText(/Cannot be refreshed because acme\/widgets is disconnected from GitHub/)).toBeInTheDocument();
     const link = screen.getByRole("link", { name: /Open GitHub settings|Reconnect repository/ });
     expect(link).toHaveAttribute("href", "/settings/integrations");
     expect(screen.queryByRole("button", { name: /Checking mergeability…/ })).not.toBeInTheDocument();
@@ -329,7 +363,7 @@ describe("PRHealthBanner", () => {
     );
   });
 
-  it("keeps merge disabled while allowing merge when ready from the dropdown", async () => {
+  it("offers merge when ready directly when GitHub requirements are pending", async () => {
     const onQueue = vi.fn();
     renderWithProviders(
       <PRHealthBanner
@@ -349,13 +383,12 @@ describe("PRHealthBanner", () => {
       />,
     );
 
-    expect(screen.getByRole("button", { name: "Merge" })).toBeDisabled();
-    await userEvent.setup().click(screen.getByRole("button", { name: "More merge actions" }));
-    await userEvent.setup().click(await screen.findByRole("menuitem", { name: "Merge when ready" }));
+    expect(screen.queryByRole("button", { name: "Merge" })).not.toBeInTheDocument();
+    await userEvent.setup().click(screen.getByRole("button", { name: "Merge when ready" }));
     expect(onQueue).toHaveBeenCalledTimes(1);
   });
 
-  it("uses compact shared sizing for PR actions and keeps the menu aligned", async () => {
+  it("uses compact shared sizing for the promoted merge action", () => {
     renderWithProviders(
       <PRHealthBanner
         health={{
@@ -374,22 +407,11 @@ describe("PRHealthBanner", () => {
       />,
     );
 
-    const mergeAction = screen.getByRole("button", { name: "Merge" });
-    const moreActions = screen.getByRole("button", { name: "More merge actions" });
-    const actionGroup = moreActions.closest("[data-slot='button-group']");
-    expect(actionGroup).toHaveAttribute("data-size", "xs");
+    const mergeAction = screen.getByRole("button", { name: "Merge when ready" });
     expect(mergeAction).toHaveAttribute("data-size", "xs");
-    expect(mergeAction).toHaveClass("h-10", "sm:h-6", "shadow-none");
-    expect(moreActions).toHaveAttribute("data-size", "icon-xs");
-    expect(moreActions).toHaveClass("size-10", "sm:size-6", "rounded-l-none", "shadow-none");
-    expect(moreActions).not.toHaveClass("h-7", "w-7");
-
-    await userEvent.setup().click(moreActions);
-    const menuItem = await screen.findByRole("menuitem", { name: "Merge when ready" });
-    expect(menuItem.closest("[data-slot='dropdown-menu-content']")).toHaveAttribute(
-      "data-align",
-      "end",
-    );
+    expect(mergeAction).toHaveClass("h-10", "sm:h-6");
+    expect(mergeAction).toHaveAttribute("data-variant", "default");
+    expect(screen.queryByRole("button", { name: "More merge actions" })).not.toBeInTheDocument();
   });
 
   it("shows queued auto-merge state and allows turning it off from the merge menu", async () => {
@@ -411,6 +433,7 @@ describe("PRHealthBanner", () => {
     );
 
     expect(screen.getByRole("button", { name: "Auto-merge on" })).toBeDisabled();
+    expect(screen.getByText("Auto-merge on", { selector: "span" })).toHaveAttribute("data-variant", "info");
     expect(screen.getByText("Waiting for GitHub requirements.")).toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "Cancel" })).not.toBeInTheDocument();
     await userEvent.setup().click(screen.getByRole("button", { name: "More merge actions" }));
@@ -418,7 +441,7 @@ describe("PRHealthBanner", () => {
     expect(onCancel).toHaveBeenCalledTimes(1);
   });
 
-  it("shows the disabled Review action reason in a hover tooltip", async () => {
+  it("hides an unavailable secondary Review action", () => {
     renderWithProviders(
       <PRHealthBanner
         health={baseHealth}
@@ -437,12 +460,7 @@ describe("PRHealthBanner", () => {
       />,
     );
 
-    const button = screen.getByRole("button", { name: /^Review$/ });
-    expect(button).toBeDisabled();
-
-    await userEvent.setup().hover(button.parentElement as HTMLElement);
-
-    expect(await screen.findByRole("tooltip", { name: "Review can start after the current turn finishes" })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /^Review$/ })).not.toBeInTheDocument();
   });
 
 	it("renders the Merge button when can_merge is true and invokes onMerge", async () => {
@@ -729,7 +747,7 @@ describe("PRHealthBanner", () => {
       />,
     );
 
-    expect(screen.getByText("PR #42 is blocked by merge conflicts.")).toBeInTheDocument();
+    expect(screen.getByText("Blocked by merge conflicts.")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Resolve conflicts" })).toBeInTheDocument();
     expect(screen.queryByText(/^conflicts$/)).toBeNull();
   });

--- a/frontend/src/components/pr-health-banner.tsx
+++ b/frontend/src/components/pr-health-banner.tsx
@@ -21,6 +21,10 @@ import { deriveMergeActionState, deriveMergeWhenReadyActionState, hasRepairableF
 // each button is type-checked.
 export type PRBannerAction = "fix_tests" | "resolve_conflicts" | "merge" | null;
 type PullRequestCheckStatus = NonNullable<PullRequestHealthResponse["checks"]>[number]["status"];
+type PRHealthStatusPresentation = {
+  label: string;
+  variant: "secondary" | "success" | "warning" | "destructive" | "info";
+};
 
 // PushChangesAction is the descriptor the parent passes when a push-to-PR
 // button should appear in the banner's action row. The parent owns the full
@@ -88,7 +92,6 @@ export function PRHealthBanner({
   const activeRepairState = deriveActiveRepairState(health.active_repairs, currentSessionId, currentThreadId);
   const prHealthBlocked = prHealthBlocksPRActions(health);
   const isRepositoryDisconnected = prHealthBlocked && health.sync_blocker === "repository_disconnected";
-  const isHealthy = !prHealthBlocked && activeRepairState.label === null && health.can_merge;
   const orderedChecks = [...(health.checks ?? [])]
     .map((check) => ({ ...check, status: normalizeCheckStatus(check.status) }))
     .sort((a, b) => statusRank(a.status) - statusRank(b.status) || a.name.localeCompare(b.name));
@@ -109,7 +112,7 @@ export function PRHealthBanner({
   });
   const canShowMergeButton = !prHealthBlocked && mergeAction.visible;
   const canShowMergeWhenReady = !prHealthBlocked && mergeWhenReadyAction.visible && Boolean(onQueueMergeWhenReady || onCancelMergeWhenReady);
-  const canShowReviewAction = !prHealthBlocked && !!reviewAction;
+  const canShowReviewAction = !prHealthBlocked && !!reviewAction && (!reviewAction.disabled || reviewAction.spinning);
   const canShowPushChanges = !prHealthBlocked && !!pushChanges;
   const canShowSnapshotDetails = !prHealthBlocked;
   const canShowActiveRepairState = canShowSnapshotDetails && !!activeRepairState.label;
@@ -127,35 +130,60 @@ export function PRHealthBanner({
   const failedSummaryLabel = orderedChecks.length > 0
     ? `${failedChecks}/${orderedChecks.length} failed`
     : `${health.failing_test_count} failing test${health.failing_test_count === 1 ? "" : "s"}`;
+  const statusPresentation = derivePRHealthStatusPresentation({
+    health: { ...health, checks: orderedChecks },
+    activeRepairLabel: activeRepairState.label,
+    hasFailedChecks: hasFailedCheckDetails,
+  });
+  const promoteMergeWhenReady =
+    canShowMergeWhenReady &&
+    Boolean(onQueueMergeWhenReady) &&
+    mergeAction.disabled &&
+    !mergeWhenReadyAction.disabled &&
+    health.merge_when_ready.state !== "queued";
+  const compactSummary = compactPRHealthSummary(health.summary, health.pull_request_number);
 
   return (
-    <Card className="border-border/60">
-      <CardContent className="p-4">
-        <div className="flex items-start justify-between gap-3">
-          <div className="min-w-0 space-y-2">
-            <div className="flex items-center gap-2">
+    <Card
+      role="region"
+      aria-label={`Pull request #${health.pull_request_number}`}
+      className="border-border/60"
+      data-testid="pr-health-card"
+    >
+      <CardContent className="p-3.5">
+        <div className="space-y-2.5">
+          <div className="flex items-start gap-2.5">
+            <div className="flex min-w-0 flex-1 items-start gap-2.5">
               <div className={cn(
-                "flex h-8 w-8 items-center justify-center rounded-full",
-                isHealthy ? "bg-success/10 text-success" : "bg-warning/10 text-warning",
+                "flex h-7 w-7 shrink-0 items-center justify-center rounded-md",
+                prHealthStatusIconClassName(statusPresentation.variant),
               )}>
-                {isHealthy ? <CheckCircle2 className="h-4 w-4" /> : isRepositoryDisconnected ? <AlertTriangle className="h-4 w-4" /> : <GitPullRequest className="h-4 w-4" />}
+                {statusPresentation.variant === "success" ? <CheckCircle2 className="h-4 w-4" /> : isRepositoryDisconnected ? <AlertTriangle className="h-4 w-4" /> : <GitPullRequest className="h-4 w-4" />}
               </div>
               <div className="min-w-0">
-                <div className="text-sm font-medium text-foreground">PR health</div>
-                <div className="text-xs text-muted-foreground">
-                  PR #{health.pull_request_number} · {health.repository}
+                <div className="flex flex-wrap items-center gap-1.5">
+                  <div className="text-sm font-medium text-foreground">PR #{health.pull_request_number}</div>
+                  <Badge variant={statusPresentation.variant} className="h-5 px-1.5 py-0 text-xs">
+                    {statusPresentation.label}
+                  </Badge>
                 </div>
+                <div className="truncate text-xs text-muted-foreground">{health.repository}</div>
               </div>
             </div>
+            {isRepositoryDisconnected ? (
+              <span className="shrink-0 whitespace-nowrap text-xs font-medium text-warning">Sync blocked</span>
+            ) : (
+              <SyncTimeText
+                syncedAt={health.github_state_synced_at}
+                className="shrink-0 whitespace-nowrap text-xs"
+              />
+            )}
+          </div>
 
-            <p className="text-xs text-foreground">{health.summary}</p>
+          <div className="space-y-2 pl-9">
+            <p className="text-xs text-foreground">{compactSummary}</p>
 
             <div className="flex flex-wrap items-center gap-2">
-              {isRepositoryDisconnected ? (
-                <span className="text-xs font-medium text-warning">Sync blocked</span>
-              ) : (
-                <SyncTimeText syncedAt={health.github_state_synced_at} prefix="Synced" />
-              )}
               {isRepositoryDisconnected && (
                 <Badge variant="secondary" className="bg-warning/10 text-warning text-xs">
                   Repository disconnected
@@ -267,62 +295,79 @@ export function PRHealthBanner({
                 )}
                 <div className="flex flex-wrap items-stretch gap-2">
                   {canShowMergeButton && (
-                    <ButtonGroup size="xs">
-                      <DisabledTooltip disabled={mergeAction.disabled} content={mergeAction.disabledReason}>
-                        <Button
-                          size="xs"
-                          variant="default"
-                          className={cn("shadow-none", canShowMergeWhenReady && "rounded-r-none border-r border-primary-foreground/20")}
-                          disabled={mergeAction.disabled}
-                          title={mergeAction.disabledReason ?? "Merge PR (p m)"}
-                          onClick={onMerge}
-                        >
-                          {mergeAction.spinning ? (
-                            <Loader2 className="h-3.5 w-3.5 animate-spin" />
-                          ) : (
-                            <GitMerge className="h-3.5 w-3.5" />
-                          )}
-                          {mergeAction.label}
-                        </Button>
-                      </DisabledTooltip>
-                      {canShowMergeWhenReady && (
-                        <DropdownMenu>
-                          <DropdownMenuTrigger asChild>
-                            <Button
-                              size="icon-xs"
-                              variant="default"
-                              className="w-8 rounded-l-none shadow-none sm:w-6"
-                              disabled={mergeWhenReadyAction.disabled}
-                              title={mergeWhenReadyAction.disabledReason ?? "More merge actions"}
-                              aria-label="More merge actions"
-                            >
-                              {mergeWhenReadyAction.spinning ? (
-                                <Loader2 className="h-3.5 w-3.5 animate-spin" />
-                              ) : (
-                                <ChevronDown className="h-3.5 w-3.5" />
-                              )}
-                            </Button>
-                          </DropdownMenuTrigger>
-                          <DropdownMenuContent align="end">
-                            <DropdownMenuItem
-                              onClick={health.merge_when_ready.state === "queued" ? onCancelMergeWhenReady : onQueueMergeWhenReady}
-                              disabled={mergeWhenReadyAction.disabled}
-                              title={mergeWhenReadyAction.disabledReason}
-                            >
+                    promoteMergeWhenReady ? (
+                      <Button
+                        size="xs"
+                        variant="default"
+                        disabled={mergeWhenReadyAction.disabled}
+                        title={mergeWhenReadyAction.disabledReason ?? "Merge when GitHub requirements pass"}
+                        onClick={onQueueMergeWhenReady}
+                      >
+                        {mergeWhenReadyAction.spinning ? (
+                          <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                        ) : (
+                          <GitMerge className="h-3.5 w-3.5" />
+                        )}
+                        {mergeWhenReadyAction.label}
+                      </Button>
+                    ) : (
+                      <ButtonGroup size="xs">
+                        <DisabledTooltip disabled={mergeAction.disabled} content={mergeAction.disabledReason}>
+                          <Button
+                            size="xs"
+                            variant={mergeAction.disabled ? "outline" : "default"}
+                            className={cn("shadow-none", canShowMergeWhenReady && "rounded-r-none")}
+                            disabled={mergeAction.disabled}
+                            title={mergeAction.disabledReason ?? "Merge PR (p m)"}
+                            onClick={onMerge}
+                          >
+                            {mergeAction.spinning ? (
+                              <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                            ) : (
                               <GitMerge className="h-3.5 w-3.5" />
-                              {mergeWhenReadyAction.label}
-                            </DropdownMenuItem>
-                          </DropdownMenuContent>
-                        </DropdownMenu>
-                      )}
-                    </ButtonGroup>
+                            )}
+                            {mergeAction.label}
+                          </Button>
+                        </DisabledTooltip>
+                        {canShowMergeWhenReady && (
+                          <DropdownMenu>
+                            <DropdownMenuTrigger asChild>
+                              <Button
+                                size="icon-xs"
+                                variant={mergeAction.disabled ? "outline" : "default"}
+                                className="w-8 rounded-l-none border-l-0 shadow-none sm:w-6"
+                                disabled={mergeWhenReadyAction.disabled}
+                                title={mergeWhenReadyAction.disabledReason ?? "More merge actions"}
+                                aria-label="More merge actions"
+                              >
+                                {mergeWhenReadyAction.spinning ? (
+                                  <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                                ) : (
+                                  <ChevronDown className="h-3.5 w-3.5" />
+                                )}
+                              </Button>
+                            </DropdownMenuTrigger>
+                            <DropdownMenuContent align="end">
+                              <DropdownMenuItem
+                                onClick={health.merge_when_ready.state === "queued" ? onCancelMergeWhenReady : onQueueMergeWhenReady}
+                                disabled={mergeWhenReadyAction.disabled}
+                                title={mergeWhenReadyAction.disabledReason}
+                              >
+                                <GitMerge className="h-3.5 w-3.5" />
+                                {mergeWhenReadyAction.label}
+                              </DropdownMenuItem>
+                            </DropdownMenuContent>
+                          </DropdownMenu>
+                        )}
+                      </ButtonGroup>
+                    )
                   )}
                   {canShowResolveConflictsButton && (
                     <DisabledTooltip disabled={pendingAction !== null} content="Wait for the current PR action to finish">
                       <ButtonGroup size="xs">
                         <Button
                           size="xs"
-                          variant="outline"
+                          variant={mergeAction.disabled ? "default" : "outline"}
                           className={onResolveConflictsWithoutPushing ? "rounded-r-none" : undefined}
                           disabled={pendingAction !== null}
                           title={pendingAction !== null ? "Wait for the current PR action to finish" : "Resolve conflicts (p r)"}
@@ -340,7 +385,7 @@ export function PRHealthBanner({
                             <DropdownMenuTrigger asChild>
                               <Button
                                 size="icon-xs"
-                                variant="outline"
+                                variant={mergeAction.disabled ? "default" : "outline"}
                                 className="rounded-l-none border-l-0"
                                 disabled={pendingAction !== null}
                                 title={pendingAction !== null ? "Wait for the current PR action to finish" : "More resolve conflicts actions"}
@@ -365,7 +410,7 @@ export function PRHealthBanner({
                       <ButtonGroup size="xs">
                         <Button
                           size="xs"
-                          variant="outline"
+                          variant={mergeAction.disabled && !canShowResolveConflictsButton ? "default" : "outline"}
                           className={onFixTestsWithoutPushing ? "rounded-r-none" : undefined}
                           disabled={pendingAction !== null}
                           title={pendingAction !== null ? "Wait for the current PR action to finish" : "Fix tests (p t)"}
@@ -383,7 +428,7 @@ export function PRHealthBanner({
                             <DropdownMenuTrigger asChild>
                               <Button
                                 size="icon-xs"
-                                variant="outline"
+                                variant={mergeAction.disabled && !canShowResolveConflictsButton ? "default" : "outline"}
                                 className="rounded-l-none border-l-0"
                                 disabled={pendingAction !== null}
                                 title={pendingAction !== null ? "Wait for the current PR action to finish" : "More fix tests actions"}
@@ -497,6 +542,60 @@ export function PRHealthBanner({
       </CardContent>
     </Card>
   );
+}
+
+function derivePRHealthStatusPresentation({
+  health,
+  activeRepairLabel,
+  hasFailedChecks,
+}: {
+  health: PullRequestHealthResponse;
+  activeRepairLabel: string | null;
+  hasFailedChecks: boolean;
+}): PRHealthStatusPresentation {
+  if (health.sync_status === "blocked") return { label: "Disconnected", variant: "warning" };
+  if (activeRepairLabel) return { label: "Repairing", variant: "info" };
+  if (health.has_conflicts || health.can_resolve_conflicts || health.merge_state === "conflicted") {
+    return { label: "Conflicts", variant: "warning" };
+  }
+  if (hasFailedChecks) return { label: "Checks failing", variant: "destructive" };
+  if (health.merge_when_ready.state === "queued") return { label: "Auto-merge on", variant: "info" };
+  if (
+    !health.checks_confirmed ||
+    health.checks?.some((check) => check.status === "pending") ||
+    health.sync_status === "pending" ||
+    health.merge_state === "mergeability_pending" ||
+    health.merge_state === "unknown"
+  ) {
+    return { label: "Checking", variant: "info" };
+  }
+  if (health.can_merge) return { label: "Ready", variant: "success" };
+  if (health.merge_state === "behind") return { label: "Behind", variant: "warning" };
+  if (health.merge_state === "blocked") return { label: "Blocked", variant: "warning" };
+  return { label: "Open", variant: "secondary" };
+}
+
+function prHealthStatusIconClassName(variant: PRHealthStatusPresentation["variant"]): string {
+  switch (variant) {
+    case "success":
+      return "bg-success/10 text-success";
+    case "destructive":
+      return "bg-destructive/10 text-destructive";
+    case "warning":
+      return "bg-warning/10 text-warning";
+    case "info":
+      return "bg-info/10 text-info";
+    case "secondary":
+      return "bg-muted text-muted-foreground";
+  }
+}
+
+export function compactPRHealthSummary(summary: string, pullRequestNumber: number): string {
+  const entityPrefix = `PR #${pullRequestNumber} `;
+  if (!summary.startsWith(entityPrefix)) return summary;
+
+  const withoutEntity = summary.slice(entityPrefix.length).replace(/^(?:is|has)\s+/i, "");
+  return withoutEntity.charAt(0).toUpperCase() + withoutEntity.slice(1);
 }
 
 function deriveActiveRepairState(

--- a/frontend/src/components/pr-health-banner.tsx
+++ b/frontend/src/components/pr-health-banner.tsx
@@ -180,7 +180,9 @@ export function PRHealthBanner({
             )}
           </div>
 
-          <div className="space-y-2 pl-9">
+          {/* Indent matches the header's icon tile (h-7) plus its gap-2.5 so the
+              body copy lines up with "PR #<n>" instead of the icon. */}
+          <div className="space-y-2 pl-[2.375rem]">
             <p className="text-xs text-foreground">{compactSummary}</p>
 
             <div className="flex flex-wrap items-center gap-2">

--- a/frontend/src/components/pr-health-banner.tsx
+++ b/frontend/src/components/pr-health-banner.tsx
@@ -127,6 +127,11 @@ export function PRHealthBanner({
     (canShowSnapshotDetails && !!activeRepairState.openSessionID);
   const failedChecks = orderedChecks.filter((check) => check.status === "failed").length;
   const hasFailedCheckDetails = failedChecks > 0 || health.failing_test_count > 0;
+  // The badge row lost its always-present child when the sync time moved into
+  // the header, so it has to be gated or it contributes a stray space-y gap.
+  const hasStatusBadges =
+    isRepositoryDisconnected ||
+    (canShowSnapshotDetails && (hasFailedCheckDetails || !!health.obsolete_active_repair_sessions));
   const failedSummaryLabel = orderedChecks.length > 0
     ? `${failedChecks}/${orderedChecks.length} failed`
     : `${health.failing_test_count} failing test${health.failing_test_count === 1 ? "" : "s"}`;
@@ -185,66 +190,68 @@ export function PRHealthBanner({
           <div className="space-y-2 pl-[2.375rem]">
             <p className="text-xs text-foreground">{compactSummary}</p>
 
-            <div className="flex flex-wrap items-center gap-2">
-              {isRepositoryDisconnected && (
-                <Badge variant="secondary" className="bg-warning/10 text-warning text-xs">
-                  Repository disconnected
-                </Badge>
-              )}
-              {canShowSnapshotDetails && hasFailedCheckDetails && (
-                orderedChecks.length > 0 ? (
-                  <HoverCard openDelay={100} closeDelay={100}>
-                    <HoverCardTrigger asChild>
-                      <Badge variant="secondary" className="bg-destructive/10 text-destructive text-xs cursor-default">
-                        {failedSummaryLabel}
-                      </Badge>
-                    </HoverCardTrigger>
-                    <HoverCardContent align="start" className="w-80 p-3">
-                      <div className="space-y-2">
-                        <div className="text-xs font-medium text-foreground">CI jobs</div>
-                        <div className="space-y-1.5">
-                          {orderedChecks.map((check) => (
-                            check.details_url ? (
-                              <a
-                                key={`${check.name}-${check.status}`}
-                                href={check.details_url}
-                                target="_blank"
-                                rel="noopener noreferrer"
-                                className="flex items-center justify-between gap-3 rounded-sm px-1 py-1 text-xs transition-colors hover:bg-muted/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-                              >
-                                <div className="flex min-w-0 items-center gap-1.5">
-                                  <span className="min-w-0 truncate text-foreground">{check.name}</span>
-                                  <ExternalLink aria-hidden="true" className="h-3 w-3 shrink-0 text-muted-foreground" />
-                                </div>
-                                <Badge variant="secondary" className={cn("shrink-0 text-xs", checkStatusBadgeClassName(check.status))}>
-                                  {checkStatusLabel(check.status)}
-                                </Badge>
-                              </a>
-                            ) : (
-                              <div key={`${check.name}-${check.status}`} className="flex items-center justify-between gap-3 px-1 py-1">
-                                <div className="min-w-0 text-xs text-foreground truncate">{check.name}</div>
-                                <Badge variant="secondary" className={cn("shrink-0 text-xs", checkStatusBadgeClassName(check.status))}>
-                                  {checkStatusLabel(check.status)}
-                                </Badge>
-                              </div>
-                            )
-                          ))}
-                        </div>
-                      </div>
-                    </HoverCardContent>
-                  </HoverCard>
-                ) : (
-                  <Badge variant="secondary" className="bg-destructive/10 text-destructive text-xs">
-                    {failedSummaryLabel}
+            {hasStatusBadges && (
+              <div className="flex flex-wrap items-center gap-2">
+                {isRepositoryDisconnected && (
+                  <Badge variant="secondary" className="bg-warning/10 text-warning text-xs">
+                    Repository disconnected
                   </Badge>
-                )
-              )}
-              {canShowSnapshotDetails && health.obsolete_active_repair_sessions && (
-                <Badge variant="secondary" className="text-xs">
-                  newer repair context available
-                </Badge>
-              )}
-            </div>
+                )}
+                {canShowSnapshotDetails && hasFailedCheckDetails && (
+                  orderedChecks.length > 0 ? (
+                    <HoverCard openDelay={100} closeDelay={100}>
+                      <HoverCardTrigger asChild>
+                        <Badge variant="secondary" className="bg-destructive/10 text-destructive text-xs cursor-default">
+                          {failedSummaryLabel}
+                        </Badge>
+                      </HoverCardTrigger>
+                      <HoverCardContent align="start" className="w-80 p-3">
+                        <div className="space-y-2">
+                          <div className="text-xs font-medium text-foreground">CI jobs</div>
+                          <div className="space-y-1.5">
+                            {orderedChecks.map((check) => (
+                              check.details_url ? (
+                                <a
+                                  key={`${check.name}-${check.status}`}
+                                  href={check.details_url}
+                                  target="_blank"
+                                  rel="noopener noreferrer"
+                                  className="flex items-center justify-between gap-3 rounded-sm px-1 py-1 text-xs transition-colors hover:bg-muted/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                                >
+                                  <div className="flex min-w-0 items-center gap-1.5">
+                                    <span className="min-w-0 truncate text-foreground">{check.name}</span>
+                                    <ExternalLink aria-hidden="true" className="h-3 w-3 shrink-0 text-muted-foreground" />
+                                  </div>
+                                  <Badge variant="secondary" className={cn("shrink-0 text-xs", checkStatusBadgeClassName(check.status))}>
+                                    {checkStatusLabel(check.status)}
+                                  </Badge>
+                                </a>
+                              ) : (
+                                <div key={`${check.name}-${check.status}`} className="flex items-center justify-between gap-3 px-1 py-1">
+                                  <div className="min-w-0 text-xs text-foreground truncate">{check.name}</div>
+                                  <Badge variant="secondary" className={cn("shrink-0 text-xs", checkStatusBadgeClassName(check.status))}>
+                                    {checkStatusLabel(check.status)}
+                                  </Badge>
+                                </div>
+                              )
+                            ))}
+                          </div>
+                        </div>
+                      </HoverCardContent>
+                    </HoverCard>
+                  ) : (
+                    <Badge variant="secondary" className="bg-destructive/10 text-destructive text-xs">
+                      {failedSummaryLabel}
+                    </Badge>
+                  )
+                )}
+                {canShowSnapshotDetails && health.obsolete_active_repair_sessions && (
+                  <Badge variant="secondary" className="text-xs">
+                    newer repair context available
+                  </Badge>
+                )}
+              </div>
+            )}
 
             {repairError && (
               <div className="flex items-start gap-2 rounded-md border border-destructive/20 bg-destructive/5 px-3 py-2 text-xs text-destructive">

--- a/frontend/src/components/pr-health-banner.tsx
+++ b/frontend/src/components/pr-health-banner.tsx
@@ -153,7 +153,6 @@ export function PRHealthBanner({
       role="region"
       aria-label={`Pull request #${health.pull_request_number}`}
       className="border-border/60"
-      data-testid="pr-health-card"
     >
       <CardContent className="p-3.5">
         <div className="space-y-2.5">


### PR DESCRIPTION
## Summary

Session review pages were showing inconsistent, competing card patterns that confused the information hierarchy (PR details vs suggestions vs result), and in some states could surface misleading “Ready” UI. This change updates the cards to a unified, compact “entity-first” design (including consistent styling for closed/merged PRs) and adds status safeguards so unconfirmed checks can’t present as “Ready”.

## Changes

- Reworked session/overview card ordering to ensure PR details come first, then Result, then the quiet “large change / smaller PR” suggestion (no more split suggestion crowding PR context).
- Updated PR health banner/card system to align with the new compact visual language, including consistent status treatment across open/closed/merged states.
- Added status safeguards to prevent rendering “Ready” when checks are unconfirmed; updated tests to cover the new rules.
- Adjusted card layout/test expectations to account for container-query behavior in jsdom (verifying placement and class contracts rather than computed layout).

## Validation

- TypeScript typecheck
- Focused ESLint
- 123 focused tests
- `git diff --check`

Note: visual preview verification was unavailable due to preview service timeouts/failure, and PR creation attempts failed server-side (`PUBLICATION_INTENT_FAILED`), but the verified changes remain in the current workspace.

[143.dev](https://143.dev) | [session 9f3a15dd](https://143.dev/sessions/9f3a15dd-96ae-46bf-8fa7-e9b35afad089)

<!-- 143-publication session=9f3a15dd-96ae-46bf-8fa7-e9b35afad089 changeset=b21e7709-e939-4077-a344-c0f17bc47644 -->

Preview: https://143.dev/previews/github/assembledhq/143/pull/2052?launch=1