### PR TITLE
Sync calendar display with selected preset date range UI

### DIFF
--- a/frontend/src/components/code-review-overview.test.tsx
+++ b/frontend/src/components/code-review-overview.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { subDays } from "date-fns";
+import { endOfMonth, format, startOfMonth, subDays, subMonths } from "date-fns";
 import { CodeReviewSummaryCards, formatReviewTurnaround } from "./code-review-overview";
 import { TimeRangePicker, timeRangeLabel } from "./time-range-picker";
 import { customTimeRange } from "@/lib/time-range";
@@ -102,6 +102,24 @@ describe("TimeRangePicker", () => {
 
     expect(onValueChange).toHaveBeenCalledWith("last_month");
     expect(screen.queryByRole("dialog", { name: "Choose time range" })).not.toBeInTheDocument();
+  });
+
+  it("shows the active preset range in the calendar", async () => {
+    const user = userEvent.setup();
+    const anchor = new Date();
+    const expectedStart = startOfMonth(subMonths(anchor, 1));
+    const expectedEnd = endOfMonth(subMonths(anchor, 1));
+    render(<TimeRangePicker label="Time window" value="last_month" onValueChange={vi.fn()} />);
+
+    await user.click(screen.getByRole("button", { name: "Time window" }));
+
+    expect(document.querySelector(`[data-day="${expectedStart.toLocaleDateString()}"]`))
+      .toHaveAttribute("data-range-start", "true");
+    expect(document.querySelector(`[data-day="${expectedEnd.toLocaleDateString()}"]`))
+      .toHaveAttribute("data-range-end", "true");
+    expect(screen.getByText(
+      `${format(expectedStart, "MMM d, yyyy")} – ${format(expectedEnd, "MMM d, yyyy")}`,
+    )).toBeInTheDocument();
   });
 
   it("formats a custom range for the trigger", () => {

--- a/frontend/src/components/code-review-overview.test.tsx
+++ b/frontend/src/components/code-review-overview.test.tsx
@@ -1,10 +1,11 @@
+import { useState } from "react";
 import { render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { endOfMonth, format, startOfMonth, subDays, subMonths } from "date-fns";
 import { CodeReviewSummaryCards, formatReviewTurnaround } from "./code-review-overview";
 import { TimeRangePicker, timeRangeLabel } from "./time-range-picker";
-import { customTimeRange } from "@/lib/time-range";
+import { customTimeRange, type TimeRangeFilter } from "@/lib/time-range";
 
 function setDesktopMatch(matches: boolean) {
   Object.defineProperty(window, "matchMedia", {
@@ -120,6 +121,27 @@ describe("TimeRangePicker", () => {
     expect(screen.getByText(
       `${format(expectedStart, "MMM d, yyyy")} – ${format(expectedEnd, "MMM d, yyyy")}`,
     )).toBeInTheDocument();
+  });
+
+  it("keeps the calendar in sync after applying a preset", async () => {
+    const user = userEvent.setup();
+    const expectedStart = startOfMonth(subMonths(new Date(), 1));
+    const expectedEnd = endOfMonth(subMonths(new Date(), 1));
+
+    function Harness() {
+      const [value, setValue] = useState<TimeRangeFilter>("30d");
+      return <TimeRangePicker label="Time window" value={value} onValueChange={setValue} />;
+    }
+    render(<Harness />);
+
+    await user.click(screen.getByRole("button", { name: "Time window" }));
+    await user.click(screen.getByRole("button", { name: "Last month" }));
+    await user.click(screen.getByRole("button", { name: "Time window" }));
+
+    expect(document.querySelector(`[data-day="${expectedStart.toLocaleDateString()}"]`))
+      .toHaveAttribute("data-range-start", "true");
+    expect(document.querySelector(`[data-day="${expectedEnd.toLocaleDateString()}"]`))
+      .toHaveAttribute("data-range-end", "true");
   });
 
   it("formats a custom range for the trigger", () => {

--- a/frontend/src/components/time-range-picker.tsx
+++ b/frontend/src/components/time-range-picker.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useMemo, useState } from "react";
-import { format, subDays } from "date-fns";
+import { format } from "date-fns";
 import { CalendarRange, Check, ChevronDown } from "lucide-react";
 import type { DateRange } from "react-day-picker";
 
@@ -15,6 +15,7 @@ import { Separator } from "@/components/ui/separator";
 import {
   customTimeRange,
   customTimeRangeDates,
+  timeRangeDisplayDates,
   type PresetTimeRange,
   type TimeRangeFilter,
 } from "@/lib/time-range";
@@ -48,10 +49,7 @@ const PRESET_GROUPS: Array<{
 const PRESETS = PRESET_GROUPS.flatMap((group) => group.presets);
 
 function defaultDraft(value: TimeRangeFilter): DateRange {
-  const custom = customTimeRangeDates(value);
-  if (custom) return custom;
-  const today = new Date();
-  return { from: subDays(today, 30), to: today };
+  return timeRangeDisplayDates(value, new Date()) ?? { from: undefined, to: undefined };
 }
 
 export function timeRangeLabel(value: TimeRangeFilter): string {
@@ -87,6 +85,7 @@ export function TimeRangePicker({
   };
 
   const applyPreset = (preset: PresetTimeRange) => {
+    setDraft(defaultDraft(preset));
     onValueChange(preset);
     setOpen(false);
   };

--- a/frontend/src/lib/time-range.test.ts
+++ b/frontend/src/lib/time-range.test.ts
@@ -4,6 +4,7 @@ import {
   customTimeRangeDates,
   isRollingTimeRange,
   parseTimeRange,
+  timeRangeDisplayDates,
   timeRangeRefreshDelayMs,
   timeRangeBounds,
 } from "./time-range";
@@ -52,6 +53,26 @@ describe("time ranges", () => {
     expect(isRollingTimeRange("last_week")).toBe(false);
     expect(isRollingTimeRange("all")).toBe(false);
     expect(isRollingTimeRange("custom:2026-07-01:2026-07-31")).toBe(false);
+  });
+
+  it.each([
+    {
+      range: "7d" as const,
+      expected: {
+        from: new Date(2026, 6, 25, 12, 0, 0, 0),
+        to: new Date(2026, 7, 1, 12, 0, 0, 0),
+      },
+    },
+    {
+      range: "last_month" as const,
+      expected: {
+        from: new Date(2026, 6, 1, 0, 0, 0, 0),
+        to: new Date(2026, 6, 31, 23, 59, 59, 999),
+      },
+    },
+    { range: "all" as const, expected: null },
+  ])("returns calendar display dates for $range", ({ range, expected }) => {
+    expect(timeRangeDisplayDates(range, new Date(2026, 7, 1, 12, 0, 0, 0))).toEqual(expected);
   });
 
   it.each([

--- a/frontend/src/lib/time-range.test.ts
+++ b/frontend/src/lib/time-range.test.ts
@@ -70,6 +70,13 @@ describe("time ranges", () => {
         to: new Date(2026, 6, 31, 23, 59, 59, 999),
       },
     },
+    {
+      range: "custom:2026-07-01:2026-07-31" as const,
+      expected: {
+        from: new Date(2026, 6, 1),
+        to: new Date(2026, 6, 31),
+      },
+    },
     { range: "all" as const, expected: null },
   ])("returns calendar display dates for $range", ({ range, expected }) => {
     expect(timeRangeDisplayDates(range, new Date(2026, 7, 1, 12, 0, 0, 0))).toEqual(expected);

--- a/frontend/src/lib/time-range.ts
+++ b/frontend/src/lib/time-range.ts
@@ -7,6 +7,7 @@ import {
   endOfWeek,
   startOfMonth,
   startOfWeek,
+  subDays,
   subMonths,
   subWeeks,
 } from "date-fns";
@@ -77,6 +78,23 @@ export function customTimeRangeDates(range: TimeRangeFilter): { from: Date; to: 
 
 export function isRollingTimeRange(range: TimeRangeFilter): range is RollingTimeRange {
   return (ROLLING_TIME_RANGE_VALUES as readonly string[]).includes(range);
+}
+
+export function timeRangeDisplayDates(
+  range: TimeRangeFilter,
+  anchor: Date,
+): { from: Date; to: Date } | null {
+  const custom = customTimeRangeDates(range);
+  if (custom) return custom;
+
+  const calendarRange = calendarTimeRangeDates(range, anchor);
+  if (calendarRange) return calendarRange;
+
+  if (!isRollingTimeRange(range)) return null;
+  return {
+    from: subDays(anchor, Number.parseInt(range, 10)),
+    to: anchor,
+  };
 }
 
 export function timeRangeRefreshDelayMs(

--- a/frontend/src/lib/time-range.ts
+++ b/frontend/src/lib/time-range.ts
@@ -93,7 +93,7 @@ export function timeRangeDisplayDates(
   if (!isRollingTimeRange(range)) return null;
   return {
     from: subDays(anchor, Number.parseInt(range, 10)),
-    to: anchor,
+    to: new Date(anchor),
   };
 }
 


### PR DESCRIPTION
## Summary

The TimeRangePicker UI could show a preset label while the underlying calendar selection wasn’t aligned, leading to a confusing “wrong range” state for reviewers. This change makes the calendar highlight the exact start/end days for the currently selected preset and keeps that highlight consistent as users open the picker and switch presets.

## Changes

- Compute and use `timeRangeDisplayDates` from `frontend/src/lib/time-range` so preset selections translate into concrete calendar start/end dates.
- Update `frontend/src/components/time-range-picker.tsx` to set `CalendarRange`’s `from/to` (and day markers) based on the active preset/custom value, not just the trigger label.
- Add/extend unit tests to verify the active preset range is highlighted in the calendar and that applying a preset keeps the calendar in sync.

## Validation

- `vitest` (including updated `frontend/src/components/code-review-overview.test.tsx`, `frontend/src/lib/time-range.test.ts` coverage)

[143.dev](https://143.dev) | [session 81448845](https://143.dev/sessions/81448845-51be-46bf-9331-0d949480c786)

<!-- 143-publication session=81448845-51be-46bf-9331-0d949480c786 changeset=365396bb-d730-4ee8-91d5-5293772d3e4d -->

Preview: https://143.dev/previews/github/assembledhq/143/pull/2053?launch=1