### PR TITLE
Investigate SentryAPIClient FetchIssues retry test failure due to HTTP CloseIdleConnections error

### DIFF
--- a/internal/services/ingestion/sentry_api.go
+++ b/internal/services/ingestion/sentry_api.go
@@ -38,6 +38,11 @@ const (
 	// sentryMaxRetries is the maximum number of retry attempts for rate-limited
 	// Sentry API requests before giving up.
 	sentryMaxRetries = 3
+
+	// sentryMaxDrainBytes bounds how much of an unread response body is drained
+	// before closing it. The cap keeps a large or slow body from stalling
+	// cleanup; a body that exceeds it simply loses connection reuse.
+	sentryMaxDrainBytes = 64 << 10
 )
 
 // FetchIssues retrieves unresolved issues from a Sentry project since the given time.
@@ -127,11 +132,20 @@ func (c *SentryAPIClient) fetchPage(ctx context.Context, url, authToken string) 
 	return nil, "", fmt.Errorf("sentry API rate limited after %d retries", sentryMaxRetries)
 }
 
-// closeSentryResponseBody closes a response body and preserves any error that
-// was already being returned for the response. Keeping this out of a defer is
-// important in the retry loop: a rate-limited response must release its
-// connection before the client waits and starts the next attempt.
-func closeSentryResponseBody(body io.Closer, responseErr error) error {
+// closeSentryResponseBody drains and closes a response body, preserving any
+// error that was already being returned for the response. Keeping this out of a
+// defer is important in the retry loop: a rate-limited response must be
+// released before the client waits and starts the next attempt.
+//
+// The bounded drain is what lets the transport pool the connection for that
+// retry. Closing a body that was never read forces the transport to tear the
+// connection down, so every rate-limit retry would otherwise pay for a fresh
+// handshake against an API that is already shedding load.
+func closeSentryResponseBody(body io.ReadCloser, responseErr error) error {
+	// A drain failure is not worth reporting: it says nothing the response error
+	// does not already say, and the close below still runs either way.
+	_, _ = io.Copy(io.Discard, io.LimitReader(body, sentryMaxDrainBytes))
+
 	closeErr := body.Close()
 	if closeErr == nil {
 		return responseErr

--- a/internal/services/ingestion/sentry_api.go
+++ b/internal/services/ingestion/sentry_api.go
@@ -3,7 +3,9 @@ package ingestion
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"strconv"
 	"strings"
@@ -84,10 +86,12 @@ func (c *SentryAPIClient) fetchPage(ctx context.Context, url, authToken string) 
 		if err != nil {
 			return nil, "", fmt.Errorf("fetch sentry issues: %w", err)
 		}
-		defer resp.Body.Close()
 
 		if resp.StatusCode == http.StatusTooManyRequests {
 			retryAfter := parseRetryAfter(resp.Header.Get("Retry-After"))
+			if err := closeSentryResponseBody(resp.Body, nil); err != nil {
+				return nil, "", err
+			}
 			c.logger.Warn().
 				Str("url", url).
 				Int("attempt", attempt).
@@ -103,12 +107,17 @@ func (c *SentryAPIClient) fetchPage(ctx context.Context, url, authToken string) 
 		}
 
 		if resp.StatusCode != http.StatusOK {
-			return nil, "", fmt.Errorf("unexpected status %d from sentry API", resp.StatusCode)
+			responseErr := fmt.Errorf("unexpected status %d from sentry API", resp.StatusCode)
+			return nil, "", closeSentryResponseBody(resp.Body, responseErr)
 		}
 
 		var issues []SentryIssue
-		if err := json.NewDecoder(resp.Body).Decode(&issues); err != nil {
-			return nil, "", fmt.Errorf("decode sentry issues: %w", err)
+		decodeErr := json.NewDecoder(resp.Body).Decode(&issues)
+		if decodeErr != nil {
+			decodeErr = fmt.Errorf("decode sentry issues: %w", decodeErr)
+		}
+		if err := closeSentryResponseBody(resp.Body, decodeErr); err != nil {
+			return nil, "", err
 		}
 
 		nextURL := parseLinkHeader(resp.Header.Get("Link"))
@@ -116,6 +125,24 @@ func (c *SentryAPIClient) fetchPage(ctx context.Context, url, authToken string) 
 	}
 
 	return nil, "", fmt.Errorf("sentry API rate limited after %d retries", sentryMaxRetries)
+}
+
+// closeSentryResponseBody closes a response body and preserves any error that
+// was already being returned for the response. Keeping this out of a defer is
+// important in the retry loop: a rate-limited response must release its
+// connection before the client waits and starts the next attempt.
+func closeSentryResponseBody(body io.Closer, responseErr error) error {
+	closeErr := body.Close()
+	if closeErr == nil {
+		return responseErr
+	}
+
+	closeErr = fmt.Errorf("close sentry response body: %w", closeErr)
+	if responseErr == nil {
+		return closeErr
+	}
+
+	return errors.Join(responseErr, closeErr)
 }
 
 func (c *SentryAPIClient) normalizeIssue(integrationID uuid.UUID, issue SentryIssue) NormalizedIssue {

--- a/internal/services/ingestion/sentry_api_test.go
+++ b/internal/services/ingestion/sentry_api_test.go
@@ -3,9 +3,13 @@ package ingestion
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -14,6 +18,23 @@ import (
 	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/require"
 )
+
+type sentryRoundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f sentryRoundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+type trackedResponseBody struct {
+	io.Reader
+	closed   atomic.Bool
+	closeErr error
+}
+
+func (b *trackedResponseBody) Close() error {
+	b.closed.Store(true)
+	return b.closeErr
+}
 
 func TestSentryAPIClient_FetchIssues(t *testing.T) {
 	t.Parallel()
@@ -239,7 +260,7 @@ func TestSentryAPIClient_FetchIssues(t *testing.T) {
 			server := httptest.NewServer(tt.handler)
 			defer server.Close()
 
-			client := NewSentryAPIClient(&http.Client{}, zerolog.Nop())
+			client := NewSentryAPIClient(server.Client(), zerolog.Nop())
 			integrationID := uuid.New()
 			issues, err := client.FetchIssues(context.Background(), integrationID, server.URL, "test-token", "test-project", tt.since)
 
@@ -269,6 +290,94 @@ func TestSentryAPIClient_FetchIssues(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestSentryAPIClient_FetchPageClosesRateLimitedResponseBeforeRetry(t *testing.T) {
+	t.Parallel()
+
+	rateLimitedBody := &trackedResponseBody{Reader: strings.NewReader(`{"detail":"rate limited"}`)}
+	successBody := &trackedResponseBody{Reader: strings.NewReader(`[{"id":"300"}]`)}
+	requestCount := 0
+	httpClient := &http.Client{Transport: sentryRoundTripFunc(func(_ *http.Request) (*http.Response, error) {
+		requestCount++
+		if requestCount == 1 {
+			return &http.Response{
+				StatusCode: http.StatusTooManyRequests,
+				Header:     http.Header{"Retry-After": []string{"0"}},
+				Body:       rateLimitedBody,
+			}, nil
+		}
+
+		require.True(t, rateLimitedBody.closed.Load(), "rate-limited response body should be closed before retrying")
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     make(http.Header),
+			Body:       successBody,
+		}, nil
+	})}
+	client := NewSentryAPIClient(httpClient, zerolog.Nop())
+
+	issues, nextURL, err := client.fetchPage(context.Background(), "https://sentry.example/issues", "test-token")
+
+	require.NoError(t, err, "fetchPage should succeed after the rate-limit retry")
+	require.Equal(t, []SentryIssue{{ID: "300"}}, issues, "fetchPage should return the successful retry response")
+	require.Empty(t, nextURL, "fetchPage should not return a next URL without a Link header")
+	require.Equal(t, 2, requestCount, "fetchPage should make exactly one retry")
+	require.True(t, rateLimitedBody.closed.Load(), "fetchPage should close the rate-limited response body")
+	require.True(t, successBody.closed.Load(), "fetchPage should close the successful response body")
+}
+
+func TestSentryAPIClient_FetchPageReturnsResponseCloseError(t *testing.T) {
+	t.Parallel()
+
+	closeErr := errors.New("close failed")
+	body := &trackedResponseBody{
+		Reader:   strings.NewReader(`[]`),
+		closeErr: closeErr,
+	}
+	httpClient := &http.Client{Transport: sentryRoundTripFunc(func(_ *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     make(http.Header),
+			Body:       body,
+		}, nil
+	})}
+	client := NewSentryAPIClient(httpClient, zerolog.Nop())
+
+	issues, nextURL, err := client.fetchPage(context.Background(), "https://sentry.example/issues", "test-token")
+
+	require.ErrorIs(t, err, closeErr, "fetchPage should propagate response body close failures")
+	require.Contains(t, err.Error(), "close sentry response body", "fetchPage should identify response cleanup failures")
+	require.Nil(t, issues, "fetchPage should not return issues when response cleanup fails")
+	require.Empty(t, nextURL, "fetchPage should not return a next URL when response cleanup fails")
+	require.True(t, body.closed.Load(), "fetchPage should attempt to close the response body")
+}
+
+func TestSentryAPIClient_FetchPagePreservesResponseAndCloseErrors(t *testing.T) {
+	t.Parallel()
+
+	closeErr := errors.New("close failed")
+	body := &trackedResponseBody{
+		Reader:   strings.NewReader(`{"detail":"internal error"}`),
+		closeErr: closeErr,
+	}
+	httpClient := &http.Client{Transport: sentryRoundTripFunc(func(_ *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusInternalServerError,
+			Header:     make(http.Header),
+			Body:       body,
+		}, nil
+	})}
+	client := NewSentryAPIClient(httpClient, zerolog.Nop())
+
+	issues, nextURL, err := client.fetchPage(context.Background(), "https://sentry.example/issues", "test-token")
+
+	require.ErrorIs(t, err, closeErr, "fetchPage should preserve response body close failures")
+	require.Contains(t, err.Error(), "unexpected status 500", "fetchPage should preserve the Sentry API response failure")
+	require.Contains(t, err.Error(), "close sentry response body", "fetchPage should identify the accompanying cleanup failure")
+	require.Nil(t, issues, "fetchPage should not return issues when the response fails")
+	require.Empty(t, nextURL, "fetchPage should not return a next URL when the response fails")
+	require.True(t, body.closed.Load(), "fetchPage should attempt to close a failed response body")
 }
 
 func TestParseLinkHeader(t *testing.T) {

--- a/internal/services/ingestion/sentry_api_test.go
+++ b/internal/services/ingestion/sentry_api_test.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -25,13 +24,25 @@ func (f sentryRoundTripFunc) RoundTrip(req *http.Request) (*http.Response, error
 	return f(req)
 }
 
+// trackedResponseBody records how a response body was consumed so tests can
+// assert that fetchPage drained it before closing it.
 type trackedResponseBody struct {
-	io.Reader
-	closed   atomic.Bool
-	closeErr error
+	payload       *strings.Reader
+	closed        atomic.Bool
+	unreadAtClose atomic.Int64
+	closeErr      error
+}
+
+func newTrackedResponseBody(payload string) *trackedResponseBody {
+	return &trackedResponseBody{payload: strings.NewReader(payload)}
+}
+
+func (b *trackedResponseBody) Read(p []byte) (int, error) {
+	return b.payload.Read(p)
 }
 
 func (b *trackedResponseBody) Close() error {
+	b.unreadAtClose.Store(int64(b.payload.Len()))
 	b.closed.Store(true)
 	return b.closeErr
 }
@@ -295,8 +306,8 @@ func TestSentryAPIClient_FetchIssues(t *testing.T) {
 func TestSentryAPIClient_FetchPageClosesRateLimitedResponseBeforeRetry(t *testing.T) {
 	t.Parallel()
 
-	rateLimitedBody := &trackedResponseBody{Reader: strings.NewReader(`{"detail":"rate limited"}`)}
-	successBody := &trackedResponseBody{Reader: strings.NewReader(`[{"id":"300"}]`)}
+	rateLimitedBody := newTrackedResponseBody(`{"detail":"rate limited"}`)
+	successBody := newTrackedResponseBody(`[{"id":"300"}]`)
 	requestCount := 0
 	httpClient := &http.Client{Transport: sentryRoundTripFunc(func(_ *http.Request) (*http.Response, error) {
 		requestCount++
@@ -325,16 +336,15 @@ func TestSentryAPIClient_FetchPageClosesRateLimitedResponseBeforeRetry(t *testin
 	require.Equal(t, 2, requestCount, "fetchPage should make exactly one retry")
 	require.True(t, rateLimitedBody.closed.Load(), "fetchPage should close the rate-limited response body")
 	require.True(t, successBody.closed.Load(), "fetchPage should close the successful response body")
+	require.Zero(t, rateLimitedBody.unreadAtClose.Load(), "fetchPage should drain the rate-limited response body so the retry can reuse the connection")
 }
 
 func TestSentryAPIClient_FetchPageReturnsResponseCloseError(t *testing.T) {
 	t.Parallel()
 
 	closeErr := errors.New("close failed")
-	body := &trackedResponseBody{
-		Reader:   strings.NewReader(`[]`),
-		closeErr: closeErr,
-	}
+	body := newTrackedResponseBody(`[]`)
+	body.closeErr = closeErr
 	httpClient := &http.Client{Transport: sentryRoundTripFunc(func(_ *http.Request) (*http.Response, error) {
 		return &http.Response{
 			StatusCode: http.StatusOK,
@@ -357,10 +367,8 @@ func TestSentryAPIClient_FetchPagePreservesResponseAndCloseErrors(t *testing.T) 
 	t.Parallel()
 
 	closeErr := errors.New("close failed")
-	body := &trackedResponseBody{
-		Reader:   strings.NewReader(`{"detail":"internal error"}`),
-		closeErr: closeErr,
-	}
+	body := newTrackedResponseBody(`{"detail":"internal error"}`)
+	body.closeErr = closeErr
 	httpClient := &http.Client{Transport: sentryRoundTripFunc(func(_ *http.Request) (*http.Response, error) {
 		return &http.Response{
 			StatusCode: http.StatusInternalServerError,


### PR DESCRIPTION
## Summary

When Sentry responds with 429, our retry loop wasn’t reliably releasing the HTTP response body before the next attempt. This could trigger transport-level `CloseIdleConnections`/reuse failures and mask the original decode/API error, causing flaky `FetchIssues` retry tests.

This change ensures every response body is drained (bounded) and closed on all paths (including before 429 retries), while preserving and joining any close failures with the existing response/decode error.

## Changes

- Added `closeSentryResponseBody` to drain up to `sentryMaxDrainBytes`, close immediately, and `errors.Join` close errors with the original response/decode error.
- Updated `fetchPage` to remove the single defer and explicitly close on:
  - `429 Too Many Requests` (before calculating/scheduling the retry)
  - non-200 responses
  - JSON decode success/failure
- Introduced tests to regress the close-before-retry ordering and ensure error preservation when close fails.

## Validation

- Ingestion package tests: 100 repetitions
- Focused race tests: 20 repetitions
- `go vet ./internal/services/ingestion`
- `git diff --check`

[143.dev](https://143.dev) | [session 72d5af57](https://143.dev/sessions/72d5af57-f3c0-4454-a007-4df2dabeb881)

<!-- 143-publication session=72d5af57-f3c0-4454-a007-4df2dabeb881 changeset=f39b2c40-8bc6-4f6f-99f5-f00747ec3beb -->

Preview: https://143.dev/previews/github/assembledhq/143/pull/2057?launch=1