### PR TITLE
Increase default PR review loop from two to three passes

### DIFF
--- a/docs/design/implemented/123-agent-initiated-pr-publication.md
+++ b/docs/design/implemented/123-agent-initiated-pr-publication.md
@@ -1,6 +1,6 @@
 # Design: Agent-Initiated PR Publication with Automatic Review
 
-> **Status:** Implemented | **Last reviewed:** 2026-08-02
+> **Status:** Implemented | **Last reviewed:** 2026-08-03
 >
 > **Depends on:** [overall.md](../overall.md),
 > [review agent loops](../implemented/78-review-agent-loops.md),
@@ -16,7 +16,7 @@
 agent implements and verifies
   -> agent runs `143-tools pr create`
   -> 143 records durable publication intent
-  -> optional two-pass review/fix loop
+  -> optional three-pass review/fix loop
   -> clean review queues durable PR publication
   -> linked session remains available for CI, conflicts, and feedback
 ```
@@ -27,7 +27,7 @@ how** the external side effect occurs.
 Two organization settings govern the workflow:
 
 1. **Create a PR when the coding agent is ready**
-2. **Run a two-pass review/fix cycle before creating the PR**
+2. **Run a three-pass review/fix cycle before creating the PR**
 
 Both default on for existing and new organizations. Users may override either
 with `inherit`, `on`, or `off`.
@@ -274,7 +274,7 @@ create_pr
   -> persist publication intent and caller options
   -> pre_publish + review off: queue open_pr
   -> pre_publish + review on:
-       reuse fresh clean review, or start/join two-pass loop
+       reuse fresh clean review, or start/join three-pass loop
        clean -> atomically queue open_pr
        other terminal result -> block for in-product attention
   -> draft_first:
@@ -894,7 +894,7 @@ Session detail adds resolved policy:
     "review_execution_enabled": true,
     "agent_publication_execution_enabled": true,
     "review_source": "personal",
-    "review_max_passes": 2,
+    "review_max_passes": 3,
     "pr_handoff_mode": "pre_publish"
   }
 }
@@ -963,7 +963,7 @@ closure/revert, publication success, cost, and latency.
    roll forward. Response changes up to this point are additive only; the
    `409` retirement waits for this step to drain and lands in PR 3.
 3. Enable prompt/tool states internally.
-4. Enable two-pass review internally and inspect churn/block rates.
+4. Enable three-pass review internally and inspect churn/block rates.
 5. Enable for selected organizations with visible default-on settings.
 6. Enable generally.
 7. Remove the generic manual-session completion trigger after agent-tool
@@ -1099,7 +1099,7 @@ Scope:
   automation loop parks the intent as `review_in_progress` instead of
   stranding it, and resume when that loop terminates. Do not relax
   `idx_session_review_loops_one_running_per_session`.
-- Run the bounded two-pass review/fix cycle for agent- and user-initiated
+- Run the bounded three-pass review/fix cycle for agent- and user-initiated
   publication, honor an automation's `pre_pr_review_loops` when that is the
   trigger, prefer and persist an independent reviewer, and block when the final
   pass changes code.

--- a/docs/design/implemented/78-review-agent-loops.md
+++ b/docs/design/implemented/78-review-agent-loops.md
@@ -1,6 +1,6 @@
 # Design: Review Agent Loops
 
-> **Status:** Implemented | **Last reviewed:** 2026-05-15
+> **Status:** Implemented | **Last reviewed:** 2026-08-03
 >
 > **Depends on:** [implemented/48-automations-separation.md](../implemented/48-automations-separation.md), [backlog/11-review-feedback-loop.md](../backlog/11-review-feedback-loop.md), [implemented/40-pr-creation-revamp.md](../implemented/40-pr-creation-revamp.md), [implemented/68-sandbox-agent-tabs-and-threads.md](../implemented/68-sandbox-agent-tabs-and-threads.md), [implemented/64-session-composer-slash-commands.md](../implemented/64-session-composer-slash-commands.md)
 
@@ -17,12 +17,12 @@ completion callback, the worker marks the running loop terminal `failed` while
 also releasing the thread. The session overview must therefore render the
 review as failed instead of continuing to show a stale loading/running state.
 
-Manual session detail now exposes a `Review` action that starts a two-pass loop
+Manual session detail now exposes a `Review` action that starts a three-pass loop
 in the current sandbox. Manual setup includes a fix-mode choice: the default
 `minimal` mode preserves the original behavior by fixing only the minimum
 needed to clear the review, while `exhaustive` instructs fix turns to address
 every finding from the previous review pass before the next pass. Automations persist `pre_pr_review_loops`; new
-automations default to one pass, existing rows backfill to zero, and the
+automations default to three passes, existing rows backfill to zero, and the
 `open_pr` worker gate starts or waits for the automation review loop before
 publication. Clean automation loops enqueue PR creation again; loops that hit
 the pass limit block PR creation for human decision.
@@ -590,7 +590,7 @@ Automation create/update/get payloads expose:
 
 ```json
 {
-  "pre_pr_review_loops": 1
+  "pre_pr_review_loops": 3
 }
 ```
 
@@ -600,7 +600,7 @@ Start request:
 {
   "agent_type": "claude_code",
   "model": "claude-sonnet-4-5",
-  "max_passes": 2
+  "max_passes": 3
 }
 ```
 
@@ -759,7 +759,7 @@ changes.
    after the session snapshot expires?
 2. What is the right cost preview for 3-5 pass loops on large diffs?
 3. Should manual review keep the full pass-count setup dialog, or add a
-   fast-start default of two passes?
+   fast-start path that uses the three-pass default?
 4. Should the review-loop tab be reusable for future review loops in the same
    session, or should each click create a fresh tab?
 

--- a/docs/public/getting-started/review-and-ship.mdx
+++ b/docs/public/getting-started/review-and-ship.mdx
@@ -65,7 +65,7 @@ recovery.
 
 Eligible coding sessions can request publication after the agent has completed
 the change and appropriate verification. Organization admins control **Create
-a PR when the coding agent is ready** and **Run a two-pass review/fix cycle
+a PR when the coding agent is ready** and **Run a three-pass review/fix cycle
 before creating the PR** under **Settings → Session automation**. Both default
 to on. Each user can choose **Use organization default (On/Off)**, **On**, or
 **Off** under **Account settings → Session automation**.

--- a/frontend/src/app/(dashboard)/automations/new/page.test.tsx
+++ b/frontend/src/app/(dashboard)/automations/new/page.test.tsx
@@ -362,7 +362,7 @@ describe("NewAutomationPage", () => {
               max_concurrent: 1,
               base_branch: "main",
               identity_scope: "org",
-              pre_pr_review_loops: 1,
+              pre_pr_review_loops: requestBody.pre_pr_review_loops as number,
               schedule_type: requestBody.schedule_type,
               github_event_triggers: [],
               timezone: "UTC",
@@ -397,6 +397,7 @@ describe("NewAutomationPage", () => {
     expect(requestBody).toMatchObject({
       schedule_type: "none",
       triggers: ["github.pr.feedback"],
+      pre_pr_review_loops: 3,
     });
     expect(requestBody).not.toHaveProperty("interval_value");
     expect(requestBody).not.toHaveProperty("interval_unit");
@@ -578,7 +579,7 @@ describe("NewAutomationPage", () => {
               max_concurrent: 1,
               base_branch: "main",
               identity_scope: "org",
-              pre_pr_review_loops: 1,
+              pre_pr_review_loops: requestBody.pre_pr_review_loops as number,
               schedule_type: requestBody.schedule_type,
               github_event_triggers: [],
               timezone: "UTC",
@@ -736,7 +737,7 @@ describe("NewAutomationPage", () => {
               max_concurrent: 1,
               base_branch: "main",
               identity_scope: "org",
-              pre_pr_review_loops: 1,
+              pre_pr_review_loops: requestBody.pre_pr_review_loops as number,
               schedule_type: requestBody.schedule_type,
               github_event_triggers: [],
               timezone: "UTC",
@@ -1036,7 +1037,7 @@ describe("NewAutomationPage", () => {
               max_concurrent: 1,
               base_branch: "main",
               identity_scope: "org",
-              pre_pr_review_loops: 1,
+              pre_pr_review_loops: requestBody.pre_pr_review_loops as number,
               schedule_type: "interval",
               github_event_triggers: [],
               timezone: "UTC",

--- a/frontend/src/app/(dashboard)/sessions/[id]/page-overview.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/page-overview.test.tsx
@@ -582,7 +582,7 @@ describe('SessionDetailPage overview and review loop', () => {
     expect(dialog.querySelector('.lucide-clipboard-list')).not.toBeInTheDocument();
   });
 
-  it('starts a manual review loop with the selected pass count and default minimal fix mode', async () => {
+  it('starts a manual review loop with three passes and minimal fixes by default', async () => {
     const user = userEvent.setup();
     let postedBody: { max_passes: number; fix_mode?: ReviewLoopFixMode } | null = null;
 
@@ -629,7 +629,7 @@ describe('SessionDetailPage overview and review loop', () => {
     renderWithProviders(<SessionDetailContent id="session-98765432-abcd-ef01" />);
 
     await user.click(await screen.findByRole('button', { name: 'Review & fix' }));
-    await user.click(await screen.findByRole('button', { name: 'Increase review passes' }));
+    expect(screen.getByRole('spinbutton', { name: 'Review passes' })).toHaveValue(3);
     await user.click(screen.getByRole('button', { name: 'Start review' }));
 
     await waitFor(() => {
@@ -749,7 +749,7 @@ describe('SessionDetailPage overview and review loop', () => {
     await user.click(screen.getByRole('button', { name: 'Start review' }));
 
     await waitFor(() => {
-      expect(postedBody).toEqual({ agent_type: 'claude_code', max_passes: 2, fix_mode: 'minimal' });
+      expect(postedBody).toEqual({ agent_type: 'claude_code', max_passes: 3, fix_mode: 'minimal' });
     });
   });
 

--- a/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
@@ -106,6 +106,11 @@ import {
   syncReferencesWithMessage,
 } from "@/lib/session-composer-mentions";
 import { queryKeys } from "@/lib/query-keys";
+import {
+  DEFAULT_REVIEW_MAX_PASSES,
+  MAX_REVIEW_MAX_PASSES,
+  MIN_REVIEW_MAX_PASSES,
+} from "@/lib/review-loop-constants";
 import { api, ApiError } from "@/lib/api";
 import { AGENTS, AGENTS_BY_KEY } from "@/lib/agents";
 import { getActiveOrgId } from "@/lib/active-org";
@@ -341,8 +346,13 @@ function PublicationWorkflowCard({
   const reviewQueued = reviewing && !reviewLoop;
   const reviewPassed = publication.review_gate_state === "passed";
   const activePass = reviewLoop?.passes?.at(-1);
-  const passNumber = activePass?.pass_index ?? Math.min((reviewLoop?.completed_passes ?? 0) + 1, publication.review_max_passes ?? reviewLoop?.max_passes ?? 2);
-  const maxPasses = publication.review_max_passes ?? reviewLoop?.max_passes ?? 2;
+  const passNumber = activePass?.pass_index ?? Math.min(
+    (reviewLoop?.completed_passes ?? 0) + 1,
+    publication.review_max_passes ?? reviewLoop?.max_passes ?? DEFAULT_REVIEW_MAX_PASSES,
+  );
+  const maxPasses = publication.review_max_passes
+    ?? reviewLoop?.max_passes
+    ?? DEFAULT_REVIEW_MAX_PASSES;
   const activity = activePass?.status === "fixing"
     ? "Applying fixes"
     : activePass?.status === "deciding"
@@ -3580,7 +3590,7 @@ export function SessionDetailContent({ id }: { id: string }) {
   const [mobileRenameOpen, setMobileRenameOpen] = useState(false);
   const [keyboardHelpOpen, setKeyboardHelpOpen] = useState(false);
   const [reviewConfigOpen, setReviewConfigOpen] = useState(false);
-  const [reviewPasses, setReviewPasses] = useState(2);
+  const [reviewPasses, setReviewPasses] = useState(DEFAULT_REVIEW_MAX_PASSES);
   const [reviewAgentType, setReviewAgentType] = useState<string>("codex");
   const [reviewFixMode, setReviewFixMode] = useState<ReviewLoopFixMode>("minimal");
   const [detailWidth, setDetailWidth] = useState(SESSION_DETAIL_PANEL_DEFAULT_WIDTH);
@@ -7335,8 +7345,8 @@ export function SessionDetailContent({ id }: { id: string }) {
                   size="icon"
                   className="h-9 w-9 shrink-0"
                   aria-label="Decrease review passes"
-                  disabled={reviewPasses <= 1 || startReviewLoopMutation.isPending}
-                  onClick={() => setReviewPasses((current) => Math.max(1, current - 1))}
+                  disabled={reviewPasses <= MIN_REVIEW_MAX_PASSES || startReviewLoopMutation.isPending}
+                  onClick={() => setReviewPasses((current) => Math.max(MIN_REVIEW_MAX_PASSES, current - 1))}
                 >
                   <Minus className="h-3.5 w-3.5" />
                 </Button>
@@ -7344,19 +7354,22 @@ export function SessionDetailContent({ id }: { id: string }) {
                   id="review-pass-count"
                   aria-label="Review passes"
                   type="number"
-                  min={1}
-                  max={5}
+                  min={MIN_REVIEW_MAX_PASSES}
+                  max={MAX_REVIEW_MAX_PASSES}
                   value={reviewPasses}
                   disabled={startReviewLoopMutation.isPending}
                   onChange={(event) => {
                     const next = Number.parseInt(event.target.value, 10);
                     if (Number.isNaN(next)) {
-                      setReviewPasses(1);
+                      setReviewPasses(MIN_REVIEW_MAX_PASSES);
                       return;
                     }
-                    setReviewPasses(Math.min(5, Math.max(1, next)));
+                    setReviewPasses(Math.min(
+                      MAX_REVIEW_MAX_PASSES,
+                      Math.max(MIN_REVIEW_MAX_PASSES, next),
+                    ));
                   }}
-                      className="text-center"
+                  className="text-center"
                 />
                 <Button
                   type="button"
@@ -7364,8 +7377,8 @@ export function SessionDetailContent({ id }: { id: string }) {
                   size="icon"
                   className="h-9 w-9 shrink-0"
                   aria-label="Increase review passes"
-                  disabled={reviewPasses >= 5 || startReviewLoopMutation.isPending}
-                  onClick={() => setReviewPasses((current) => Math.min(5, current + 1))}
+                  disabled={reviewPasses >= MAX_REVIEW_MAX_PASSES || startReviewLoopMutation.isPending}
+                  onClick={() => setReviewPasses((current) => Math.min(MAX_REVIEW_MAX_PASSES, current + 1))}
                 >
                   <Plus className="h-3.5 w-3.5" />
                 </Button>

--- a/frontend/src/app/(dashboard)/settings/account/page.tsx
+++ b/frontend/src/app/(dashboard)/settings/account/page.tsx
@@ -251,8 +251,8 @@ const PERSONAL_AUTOMATION_COPY: Record<PersonalAutomationKey, { title: string; d
     description: "Choose whether eligible coding agents hand off your verified changes automatically.",
   },
   review_before_pr: {
-    title: "Run a two-pass review/fix cycle before creating the PR",
-    description: "Choose whether automatic PR handoff runs the two-pass review/fix cycle. Clicking Create PR publishes directly.",
+    title: "Run a three-pass review/fix cycle before creating the PR",
+    description: "Choose whether automatic PR handoff runs the three-pass review/fix cycle. Clicking Create PR publishes directly.",
   },
   resolve_conflicts_when_idle: {
     title: "Resolve conflicts when idle",

--- a/frontend/src/app/(dashboard)/settings/page.test.tsx
+++ b/frontend/src/app/(dashboard)/settings/page.test.tsx
@@ -237,7 +237,7 @@ describe('SettingsPage', () => {
     renderWithProviders(<SettingsPage />);
 
     const createSwitch = await screen.findByRole('switch', { name: 'Create a PR when the coding agent is ready' });
-    const reviewSwitch = screen.getByRole('switch', { name: 'Run a two-pass review/fix cycle before creating the PR' });
+    const reviewSwitch = screen.getByRole('switch', { name: 'Run a three-pass review/fix cycle before creating the PR' });
     expect(createSwitch).toBeChecked();
     expect(reviewSwitch).toBeChecked();
 
@@ -273,7 +273,7 @@ describe('SettingsPage', () => {
     });
     renderWithProviders(<SettingsPage />);
 
-    await userEvent.click(await screen.findByRole('switch', { name: 'Run a two-pass review/fix cycle before creating the PR' }));
+    await userEvent.click(await screen.findByRole('switch', { name: 'Run a three-pass review/fix cycle before creating the PR' }));
 
     await waitFor(() => {
       expect(settingsUpdateMock).toHaveBeenCalledWith({

--- a/frontend/src/app/(dashboard)/settings/page.tsx
+++ b/frontend/src/app/(dashboard)/settings/page.tsx
@@ -43,7 +43,7 @@ const PUBLICATION_AUTOMATION_COPY: Record<PublicationAutomationKey, { title: str
     description: "Let eligible coding agents hand off verified changes for publication when their work is complete.",
   },
   review_before_pr: {
-    title: "Run a two-pass review/fix cycle before creating the PR",
+    title: "Run a three-pass review/fix cycle before creating the PR",
     description: "Review the current changes, apply fixes, and confirm the result before automatic publication. Clicking Create PR publishes directly.",
   },
 };

--- a/frontend/src/lib/automation-draft.test.ts
+++ b/frontend/src/lib/automation-draft.test.ts
@@ -123,7 +123,9 @@ describe("automation-draft storage", () => {
   });
 
   it("keeps the canonical form state keys explicit", () => {
-    expect(Object.keys(defaultAutomationFormState()).sort()).toEqual(FORM_STATE_KEYS);
+    const defaults = defaultAutomationFormState();
+    expect(Object.keys(defaults).sort()).toEqual(FORM_STATE_KEYS);
+    expect(defaults.prePRReviewLoops).toBe(3);
   });
 
   it("round-trips a populated draft", () => {

--- a/frontend/src/lib/automation-draft.ts
+++ b/frontend/src/lib/automation-draft.ts
@@ -1,6 +1,7 @@
 import { toCodingAgentReasoningEffort, type CodingAgentReasoningEffort } from "@/lib/coding-agent-reasoning";
 import type { AutomationProductTrigger } from "@/lib/automation-triggers";
 import { isScheduleDraft, type ScheduleDraft } from "@/lib/automation-schedule";
+import { DEFAULT_REVIEW_MAX_PASSES } from "@/lib/review-loop-constants";
 import type {
   AgentCapabilityGrant,
   AutomationPublishPolicy,
@@ -149,7 +150,7 @@ export function defaultAutomationFormState(
     model: undefined,
     identityScope: "org",
     publishPolicy: "pull_request",
-    prePRReviewLoops: 1,
+    prePRReviewLoops: DEFAULT_REVIEW_MAX_PASSES,
     reasoningEffort: "",
     priority: 50,
     capabilityOverride: null,
@@ -217,7 +218,12 @@ export function automationFormStateFromDraft(
     model: typeof parsed.model === "string" ? parsed.model : undefined,
     identityScope: parsed.identityScope === "personal" ? "personal" : "org",
     publishPolicy: parsed.publishPolicy === "none" ? "none" : "pull_request",
-    prePRReviewLoops: clampInteger(parsed.prePRReviewLoops, 0, 5, 1),
+    prePRReviewLoops: clampInteger(
+      parsed.prePRReviewLoops,
+      0,
+      5,
+      DEFAULT_REVIEW_MAX_PASSES,
+    ),
     reasoningEffort: toCodingAgentReasoningEffort(
       typeof parsed.reasoningEffort === "string" ? parsed.reasoningEffort : "",
     ),
@@ -336,7 +342,7 @@ function isEmptyDraft(draft: AutomationDraft): boolean {
     && Object.keys(draft.baseBranchByRepoId).length === 0
     && draft.model === undefined
     && draft.identityScope === "org"
-    && draft.prePRReviewLoops === 1
+    && draft.prePRReviewLoops === DEFAULT_REVIEW_MAX_PASSES
     && draft.reasoningEffort === ""
     && draft.priority === 50
     && draft.capabilityOverride === null

--- a/frontend/src/lib/review-loop-constants.ts
+++ b/frontend/src/lib/review-loop-constants.ts
@@ -1,0 +1,3 @@
+export const DEFAULT_REVIEW_MAX_PASSES = 3;
+export const MIN_REVIEW_MAX_PASSES = 1;
+export const MAX_REVIEW_MAX_PASSES = 5;

--- a/frontend/src/test/mocks/handlers.ts
+++ b/frontend/src/test/mocks/handlers.ts
@@ -1,5 +1,6 @@
 import { http, HttpResponse } from 'msw';
 import type { APIClient, APIToken, AuthProviders, CliToken, EvalReleaseGate, Issue, Session, SessionDiff, SessionLog, SessionMessage, SessionReviewComment, SessionReviewLoop, SessionThread, SessionThreadFileEvent, SessionTimelineEntry, User, PullRequest, PullRequestHealthResponse, PullRequestRepairResponse, ListResponse, SingleResponse, Project, ProjectDetail, SessionTranscriptWindowResponse, AgentCapabilityDefinition, AgentCapabilityPolicyResponse, JoinToken, JoinTokenLink, OpenCodeModelInfo } from '@/lib/types';
+import { DEFAULT_REVIEW_MAX_PASSES } from '@/lib/review-loop-constants';
 
 export const mockIssues: Issue[] = [
   {
@@ -468,7 +469,7 @@ export const handlers = [
         status: 'running',
         source: 'manual',
         agent_type: body.agent_type || 'codex',
-        max_passes: body.max_passes ?? 2,
+        max_passes: body.max_passes ?? DEFAULT_REVIEW_MAX_PASSES,
         fix_mode: body.fix_mode ?? 'minimal',
         completed_passes: 0,
         review_required: false,

--- a/internal/api/handlers/automations.go
+++ b/internal/api/handlers/automations.go
@@ -530,7 +530,7 @@ func (h *AutomationHandler) Create(w http.ResponseWriter, r *http.Request) {
 	}
 	prePRReviewLoops := 0
 	if models.AgentSupportsNativeReview(effectiveAgentType) {
-		prePRReviewLoops = 1
+		prePRReviewLoops = models.DefaultReviewLoopMaxPasses
 	}
 	if req.PrePRReviewLoops != nil {
 		if *req.PrePRReviewLoops < 0 || *req.PrePRReviewLoops > 5 {

--- a/internal/api/handlers/automations_test.go
+++ b/internal/api/handlers/automations_test.go
@@ -731,6 +731,7 @@ func TestAutomationHandler_Create_OK(t *testing.T) {
 	require.Equal(t, models.ReasoningEffortXHigh, *resp.Data.ReasoningEffort)
 	require.Equal(t, models.AutomationIdentityScopeOrg, resp.Data.IdentityScope)
 	require.Equal(t, models.AutomationPublishPolicyPullRequest, resp.Data.PublishPolicy)
+	require.Equal(t, models.DefaultReviewLoopMaxPasses, resp.Data.PrePRReviewLoops, "supported agents should default automations to three review passes")
 	require.Equal(t, models.AutomationIconTypeEmoji, resp.Data.IconType)
 	require.Equal(t, "🧹", resp.Data.IconValue)
 	require.NoError(t, mock.ExpectationsWereMet())

--- a/internal/models/review_loop.go
+++ b/internal/models/review_loop.go
@@ -7,6 +7,9 @@ import (
 	"github.com/google/uuid"
 )
 
+// DefaultReviewLoopMaxPasses is the product-wide default for enabled review loops.
+const DefaultReviewLoopMaxPasses = 3
+
 type ReviewLoopStatus string
 
 const (

--- a/internal/services/publicationintent/policy.go
+++ b/internal/services/publicationintent/policy.go
@@ -2,7 +2,7 @@ package publicationintent
 
 import "github.com/assembledhq/143/internal/models"
 
-const UserInitiatedReviewMaxPasses = 2
+const UserInitiatedReviewMaxPasses = models.DefaultReviewLoopMaxPasses
 
 type EffectivePolicy struct {
 	CreatePRWhenAgentReady bool

--- a/internal/services/publicationintent/policy_test.go
+++ b/internal/services/publicationintent/policy_test.go
@@ -10,6 +10,7 @@ import (
 
 func TestResolvePolicy(t *testing.T) {
 	t.Parallel()
+	require.Equal(t, 3, UserInitiatedReviewMaxPasses, "user-initiated publication should default to three review passes")
 
 	enabled, disabled := true, false
 	tests := []struct {


### PR DESCRIPTION
## Summary

- Set the default review loop length to three passes across backend and frontend workflows.
- Centralize review-pass constants and update manual review controls, automation defaults, publication policy, settings copy, and documentation.
- Update frontend and backend tests for the new defaults.

## Testing

- Updated focused frontend and backend tests to cover the three-pass defaults.
- Test suite not run (not requested).