### PR TITLE
Add direct filtered links to relevant PR review comments from “Why PRs not approved” section

### DIFF
--- a/frontend/src/app/(dashboard)/code-reviews/page.test.tsx
+++ b/frontend/src/app/(dashboard)/code-reviews/page.test.tsx
@@ -689,6 +689,14 @@ describe("CodeReviewsPage", () => {
     ).toBeTruthy();
     expect(screen.getByText("Line-count limit exceeded")).toBeInTheDocument();
     expect(screen.getByText("Reviewers found a blocking issue")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "View reviews where line-count limit exceeded" })).toHaveAttribute(
+      "href",
+      "/code-reviews?tab=reviews&outcome=completed_not_approved&reason=lines_limit_exceeded&status=all&range=30d",
+    );
+    expect(screen.getByRole("link", { name: "View reviews where reviewers found a blocking issue" })).toHaveAttribute(
+      "href",
+      "/code-reviews?tab=reviews&outcome=completed_not_approved&reason=blocking_findings&status=all&range=30d",
+    );
     expect(screen.queryByText("PR size and policy fit")).not.toBeInTheDocument();
     // The list-only filters stay in the URL for the Reviews tab, so Analytics
     // has to say which of them it ignores rather than silently dropping them.
@@ -948,6 +956,8 @@ describe("CodeReviewsPage", () => {
     await user.click(await screen.findByRole("option", { name: "Blocked" }));
     await user.click(screen.getByRole("combobox", { name: "Risk" }));
     await user.click(await screen.findByRole("option", { name: "Needs review" }));
+    await user.click(screen.getByRole("combobox", { name: "Reason" }));
+    await user.click(await screen.findByRole("option", { name: "Reviewers found a blocking issue" }));
     await user.click(screen.getByRole("combobox", { name: "Status" }));
     await user.click(await screen.findByRole("option", { name: "Completed" }));
     await user.type(screen.getByRole("textbox", { name: "Search code reviews" }), "invoice");
@@ -959,6 +969,7 @@ describe("CodeReviewsPage", () => {
         expect(params?.get("repository_id")).toBe(repo.id);
         expect(params?.get("decision")).toBe("blocked");
         expect(params?.get("risk")).toBe("needs_review");
+        expect(params?.get("reason")).toBe("blocking_findings");
         expect(params?.get("search")).toBe("invoice");
         expectCreatedAfterDaysAgo(params?.get("created_after") ?? undefined, 7);
       }

--- a/frontend/src/app/(dashboard)/code-reviews/page.test.tsx
+++ b/frontend/src/app/(dashboard)/code-reviews/page.test.tsx
@@ -689,11 +689,11 @@ describe("CodeReviewsPage", () => {
     ).toBeTruthy();
     expect(screen.getByText("Line-count limit exceeded")).toBeInTheDocument();
     expect(screen.getByText("Reviewers found a blocking issue")).toBeInTheDocument();
-    expect(screen.getByRole("link", { name: "View reviews where line-count limit exceeded" })).toHaveAttribute(
+    expect(screen.getByRole("link", { name: "View 5 PRs where line-count limit exceeded" })).toHaveAttribute(
       "href",
       "/code-reviews?tab=reviews&outcome=completed_not_approved&reason=lines_limit_exceeded&status=all&range=30d",
     );
-    expect(screen.getByRole("link", { name: "View reviews where reviewers found a blocking issue" })).toHaveAttribute(
+    expect(screen.getByRole("link", { name: "View 3 PRs where reviewers found a blocking issue" })).toHaveAttribute(
       "href",
       "/code-reviews?tab=reviews&outcome=completed_not_approved&reason=blocking_findings&status=all&range=30d",
     );

--- a/frontend/src/app/(dashboard)/code-reviews/page.tsx
+++ b/frontend/src/app/(dashboard)/code-reviews/page.tsx
@@ -54,6 +54,11 @@ import { ApiError, api } from "@/lib/api";
 import { notify as toast } from "@/lib/notify";
 import { queryKeys } from "@/lib/query-keys";
 import { getActiveOrgId } from "@/lib/active-org";
+import {
+  ALL_CODE_REVIEW_REASONS,
+  CODE_REVIEW_REASON_CODES,
+  type CodeReviewReasonCode,
+} from "@/lib/code-review-reasons";
 import { buildCodeReviewStreamURL, SSE_EVENT } from "@/lib/sse";
 import { useResourceSSE } from "@/lib/use-resource-sse";
 import { pollMs } from "@/lib/poll-intervals";
@@ -525,6 +530,11 @@ export default function CodeReviewsPage() {
   );
   const timeRangeAnchorMsRef = useRef(Date.now());
   const [riskFilter, setRiskFilter] = useQueryState("risk", parseAsStringLiteral(RISK_FILTER_VALUES).withDefault(ALL_RISKS));
+  const [reasonFilter, setReasonFilter] = useQueryState(
+    "reason",
+    parseAsStringLiteral([ALL_CODE_REVIEW_REASONS, ...CODE_REVIEW_REASON_CODES] as const)
+      .withDefault(ALL_CODE_REVIEW_REASONS),
+  );
   const [statusFilter, setStatusFilter] = useQueryState(
     "status",
     STATUS_FILTER_PARSER,
@@ -579,10 +589,11 @@ export default function CodeReviewsPage() {
           : undefined,
       outcome: outcomeFilter === AUTOMATICALLY_APPROVED || outcomeFilter === COMPLETED_NOT_APPROVED ? (outcomeFilter as CodeReviewListOutcome) : undefined,
       risk: riskFilter === ALL_RISKS ? undefined : (riskFilter as "acceptable" | "needs_review"),
+      reason: reasonFilter === ALL_CODE_REVIEW_REASONS ? undefined : reasonFilter as CodeReviewReasonCode,
       author: authorFilter.trim() || undefined,
       search: searchParam.trim() || undefined,
     }),
-    [authorFilter, outcomeFilter, reviewRepositoryId, riskFilter, searchParam],
+    [authorFilter, outcomeFilter, reasonFilter, reviewRepositoryId, riskFilter, searchParam],
   );
   // Which review attempts are in scope for the Reviews tab. Analytics selects
   // PR cohorts only by repository and first-request time.
@@ -673,6 +684,7 @@ export default function CodeReviewsPage() {
     reviewRepositoryId
     || outcomeFilter !== ALL_OUTCOMES
     || riskFilter !== ALL_RISKS
+    || reasonFilter !== ALL_CODE_REVIEW_REASONS
     || statusFilter !== DEFAULT_STATUS_FILTER
     || authorFilter.trim()
     || searchParam.trim()
@@ -682,12 +694,13 @@ export default function CodeReviewsPage() {
     void setRepositoryFilter(null);
     void setOutcomeParam(null);
     void setRiskFilter(null);
+    void setReasonFilter(null);
     void setStatusFilter(null);
     void setAuthorFilter(null);
     setSearch("");
     void setSearchParam(null);
     setTimeRangeFilter("all");
-  }, [setAuthorFilter, setOutcomeParam, setRepositoryFilter, setRiskFilter, setSearchParam, setStatusFilter, setTimeRangeFilter]);
+  }, [setAuthorFilter, setOutcomeParam, setReasonFilter, setRepositoryFilter, setRiskFilter, setSearchParam, setStatusFilter, setTimeRangeFilter]);
   const reviewScopeKey = JSON.stringify(reviewFiltersQueryKey);
   const [extraReviewPages, setExtraReviewPages] = useState<CodeReviewListItem[][]>([]);
   const [loadMoreCursor, setLoadMoreCursor] = useState<string | undefined>();
@@ -1194,6 +1207,7 @@ export default function CodeReviewsPage() {
     repository: repositoryFilter,
     outcome: outcomeFilter,
     risk: riskFilter,
+    reason: reasonFilter,
     status: statusFilter,
     author: authorFilter,
     search,
@@ -1209,6 +1223,9 @@ export default function CodeReviewsPage() {
         break;
       case "risk":
         void setRiskFilter(value === ALL_RISKS ? null : value as (typeof RISK_FILTER_VALUES)[number]);
+        break;
+      case "reason":
+        void setReasonFilter(value === ALL_CODE_REVIEW_REASONS ? null : value as CodeReviewReasonCode);
         break;
       case "status":
         void setStatusFilter(value === DEFAULT_STATUS_FILTER ? null : value as StatusFilter);

--- a/frontend/src/components/code-review-analytics.tsx
+++ b/frontend/src/components/code-review-analytics.tsx
@@ -12,38 +12,9 @@ import { SortableTableHeader, sortDirectionAriaValue } from "@/components/sortab
 import { Card, CardContent } from "@/components/ui/card";
 import { ErrorNotice } from "@/components/ui/error-notice";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+import { codeReviewReasonLabel } from "@/lib/code-review-reasons";
 import type { CodeReviewAnalytics } from "@/lib/types";
 type AuthorSort = "author" | "reviews" | "approved" | "not_approved" | "approval_rate" | "first_round" | "median_rounds" | "median_additions" | "median_deletions";
-
-const NON_APPROVAL_REASON_LABELS: Record<string, string> = {
-  reviewer_disabled: "Automatic approval was disabled",
-  context_unavailable: "PR context was unavailable",
-  head_changed: "PR changed during review",
-  files_limit_exceeded: "File-count limit exceeded",
-  lines_limit_exceeded: "Line-count limit exceeded",
-  checks_failing: "Required checks were not passing",
-  required_check_failing: "A named required check was not passing",
-  description_failed: "PR description requirements were not met",
-  branch_out_of_date: "Branch was out of date",
-  fork_ineligible: "Fork PRs were not eligible",
-  author_ineligible: "Author was not eligible",
-  blocking_findings: "Reviewers found a blocking issue",
-  reviewer_disagreement: "Reviewer agents disagreed",
-  scope_mismatch: "Change scope did not match the PR",
-  unresolved_uncertainty: "Important uncertainty remained",
-  prompt_injection: "Prompt-injection risk was detected",
-  sensitive_path: "Sensitive paths changed",
-  path_outside_scope: "Paths were outside the allowed scope",
-  blocked_path: "Blocked paths changed",
-  reviewer_quorum: "Reviewer quorum was not met",
-  orchestrator_synthesis_invalid: "Final synthesis was unavailable",
-  orchestrator_context_stale: "Final synthesis used stale PR context",
-  architecture: "Architecture needed human judgment",
-  ownership: "Ownership needed human judgment",
-  operational_risk: "Operational risk needed human judgment",
-  sensitive_change: "Sensitive change needed human judgment",
-  policy_requirement: "An approval-policy requirement needed human judgment",
-};
 
 const APPROVAL_ROUND_LABELS: Record<CodeReviewAnalytics["approval_rounds"][number]["bucket"], string> = {
   round_1: "Approved in round 1",
@@ -81,13 +52,6 @@ function medianAriaLabel(value: number | null, sign: "+" | "-", noun: string): s
   return formatted === "—" ? `No ${noun} data overall` : `${formatted} ${noun} overall`;
 }
 
-function reasonLabel(code: string): string {
-  const known = NON_APPROVAL_REASON_LABELS[code];
-  if (known) return known;
-  const readable = code.replaceAll("_", " ");
-  return readable.charAt(0).toUpperCase() + readable.slice(1);
-}
-
 function authorReviewsHref({
   author,
   outcome,
@@ -108,6 +72,26 @@ function authorReviewsHref({
     params.set("status", "completed");
     params.set("outcome", outcome);
   }
+  if (repository) params.set("repository", repository);
+  return `/code-reviews?${params.toString()}`;
+}
+
+function reasonReviewsHref({
+  reason,
+  repository,
+  range,
+}: {
+  reason: string;
+  repository?: string;
+  range: string;
+}): string {
+  const params = new URLSearchParams({
+    tab: "reviews",
+    outcome: "completed_not_approved",
+    reason,
+    status: "all",
+    range,
+  });
   if (repository) params.set("repository", repository);
   return `/code-reviews?${params.toString()}`;
 }
@@ -454,10 +438,21 @@ export function CodeReviewAnalyticsReport({
             <Card>
               <CardContent className="divide-y divide-border p-0">
                 {analytics.non_approval_reasons.map((reason) => (
-                  <div key={reason.code} className="flex items-center justify-between gap-4 px-4 py-3">
-                    <span className="text-sm text-foreground">{reasonLabel(reason.code)}</span>
+                  <Link
+                    key={reason.code}
+                    href={reasonReviewsHref({
+                      reason: reason.code,
+                      repository: reviewLinkFilters.repository,
+                      range: reviewLinkFilters.range,
+                    })}
+                    className="group flex items-center justify-between gap-4 px-4 py-3 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring hover:bg-muted/50"
+                    aria-label={`View reviews where ${codeReviewReasonLabel(reason.code).toLowerCase()}`}
+                  >
+                    <span className="text-sm text-foreground underline-offset-4 group-hover:underline">
+                      {codeReviewReasonLabel(reason.code)}
+                    </span>
                     <Badge variant="secondary">{reason.prs.toLocaleString()} PRs</Badge>
-                  </div>
+                  </Link>
                 ))}
               </CardContent>
             </Card>

--- a/frontend/src/components/code-review-analytics.tsx
+++ b/frontend/src/components/code-review-analytics.tsx
@@ -446,7 +446,7 @@ export function CodeReviewAnalyticsReport({
                       range: reviewLinkFilters.range,
                     })}
                     className="group flex items-center justify-between gap-4 px-4 py-3 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring hover:bg-muted/50"
-                    aria-label={`View reviews where ${codeReviewReasonLabel(reason.code).toLowerCase()}`}
+                    aria-label={`View ${reason.prs.toLocaleString()} PRs where ${codeReviewReasonLabel(reason.code).toLowerCase()}`}
                   >
                     <span className="text-sm text-foreground underline-offset-4 group-hover:underline">
                       {codeReviewReasonLabel(reason.code)}

--- a/frontend/src/components/code-review-overview.tsx
+++ b/frontend/src/components/code-review-overview.tsx
@@ -10,6 +10,11 @@ import { Label } from "@/components/ui/label";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { TimeRangePicker } from "@/components/time-range-picker";
 import { MetricInfoTooltip } from "@/components/metric-info-tooltip";
+import {
+  ALL_CODE_REVIEW_REASONS,
+  CODE_REVIEW_REASON_CODES,
+  CODE_REVIEW_REASON_LABELS,
+} from "@/lib/code-review-reasons";
 import type { CodeReviewListOutcome, CodeReviewStats, Repository } from "@/lib/types";
 import type { TimeRangeFilter } from "@/lib/time-range";
 
@@ -134,6 +139,7 @@ export interface CodeReviewFilterValues {
   repository: string;
   outcome: string;
   risk: string;
+  reason: string;
   status: string;
   author: string;
   search: string;
@@ -170,7 +176,7 @@ export function CodeReviewFilters({
         <span className="flex items-center gap-2"><SlidersHorizontal className="h-4 w-4" />{mobileLabel}</span>
         <ChevronDown className={`h-4 w-4 transition-transform ${mobileOpen ? "rotate-180" : ""}`} />
       </Button>
-      <Card id={id} className={`${mobileOpen ? "grid" : "hidden"} gap-3 p-3 shadow-sm md:grid md:grid-cols-2 md:rounded-none md:border-0 md:bg-transparent md:p-0 md:shadow-none ${analyticsMode ? "lg:grid-cols-2 xl:grid-cols-[minmax(12rem,18rem)_minmax(12rem,18rem)]" : "lg:grid-cols-3 xl:grid-cols-[minmax(12rem,18rem)_repeat(3,minmax(9rem,11rem))_minmax(12rem,1fr)_minmax(9rem,11rem)]"}`}>
+      <Card id={id} className={`${mobileOpen ? "grid" : "hidden"} gap-3 p-3 shadow-sm md:grid md:grid-cols-2 md:rounded-none md:border-0 md:bg-transparent md:p-0 md:shadow-none ${analyticsMode ? "lg:grid-cols-2 xl:grid-cols-[minmax(12rem,18rem)_minmax(12rem,18rem)]" : "lg:grid-cols-4"}`}>
         <FilterSelect label="Repository" value={values.repository} onValueChange={(value) => onChange("repository", value)}>
           <SelectItem value={ALL_REPOSITORIES}>All repositories</SelectItem>
           {repositories.map((repo) => <SelectItem key={repo.id} value={repo.id}>{repo.full_name}</SelectItem>)}
@@ -190,6 +196,12 @@ export function CodeReviewFilters({
               <SelectItem value={ALL_RISKS}>All risk</SelectItem>
               <SelectItem value="acceptable">Acceptable</SelectItem>
               <SelectItem value="needs_review">Needs review</SelectItem>
+            </FilterSelect>
+            <FilterSelect label="Reason" value={values.reason} onValueChange={(value) => onChange("reason", value)}>
+              <SelectItem value={ALL_CODE_REVIEW_REASONS}>All reasons</SelectItem>
+              {CODE_REVIEW_REASON_CODES.map((reason) => (
+                <SelectItem key={reason} value={reason}>{CODE_REVIEW_REASON_LABELS[reason]}</SelectItem>
+              ))}
             </FilterSelect>
             <FilterSelect label="Status" value={values.status} onValueChange={(value) => onChange("status", value)}>
               <SelectItem value="current">Current reviews</SelectItem>
@@ -218,8 +230,8 @@ export function CodeReviewFilters({
       </Card>
       {analyticsMode ? (
         <p className="text-xs text-muted-foreground">
-          Analytics covers every PR in the selected repository and window. Outcome, risk, status, author,
-          and search filters apply to the Reviews tab only.
+          Analytics covers every PR in the selected repository and window. Outcome, risk, reason, status,
+          author, and search filters apply to the Reviews tab only.
         </p>
       ) : null}
     </>

--- a/frontend/src/lib/api.test.ts
+++ b/frontend/src/lib/api.test.ts
@@ -116,12 +116,14 @@ describe('api client', () => {
         }),
       );
 
-      await api.codeReviews.list({ activity_status: 'superseded' });
-      await api.codeReviews.stats({ activity_status: 'current' });
+      await api.codeReviews.list({ activity_status: 'superseded', reason: 'blocking_findings' });
+      await api.codeReviews.stats({ activity_status: 'current', reason: 'description_failed' });
 
       expect(capturedUrls).toHaveLength(2);
       expect(new URL(capturedUrls[0]).searchParams.get('activity_status')).toBe('superseded');
       expect(new URL(capturedUrls[1]).searchParams.get('activity_status')).toBe('current');
+      expect(new URL(capturedUrls[0]).searchParams.get('reason')).toBe('blocking_findings');
+      expect(new URL(capturedUrls[1]).searchParams.get('reason')).toBe('description_failed');
     });
   });
 

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -272,6 +272,7 @@ export const api = {
       activity_status?: import('./types').CodeReviewActivityStatus;
       status?: import('./types').CodeReviewSessionStatus;
       risk?: "acceptable" | "needs_review";
+      reason?: import('./code-review-reasons').CodeReviewReasonCode;
       author?: string;
       search?: string;
       created_after?: string;
@@ -288,6 +289,7 @@ export const api = {
       if (params?.activity_status) searchParams.set('activity_status', params.activity_status);
       if (params?.status) searchParams.set('status', params.status);
       if (params?.risk) searchParams.set('risk', params.risk);
+      if (params?.reason) searchParams.set('reason', params.reason);
       if (params?.author) searchParams.set('author', params.author);
       if (params?.search) searchParams.set('search', params.search);
       if (params?.created_after) searchParams.set('created_after', params.created_after);
@@ -306,6 +308,7 @@ export const api = {
       activity_status?: import('./types').CodeReviewActivityStatus;
       status?: import('./types').CodeReviewSessionStatus;
       risk?: "acceptable" | "needs_review";
+      reason?: import('./code-review-reasons').CodeReviewReasonCode;
       author?: string;
       search?: string;
       created_after?: string;
@@ -318,6 +321,7 @@ export const api = {
       if (params?.activity_status) searchParams.set('activity_status', params.activity_status);
       if (params?.status) searchParams.set('status', params.status);
       if (params?.risk) searchParams.set('risk', params.risk);
+      if (params?.reason) searchParams.set('reason', params.reason);
       if (params?.author) searchParams.set('author', params.author);
       if (params?.search) searchParams.set('search', params.search);
       if (params?.created_after) searchParams.set('created_after', params.created_after);

--- a/frontend/src/lib/code-review-reasons.ts
+++ b/frontend/src/lib/code-review-reasons.ts
@@ -1,0 +1,78 @@
+export const ALL_CODE_REVIEW_REASONS = "all";
+
+export const CODE_REVIEW_REASON_CODES = [
+  "reviewer_disabled",
+  "context_unavailable",
+  "head_changed",
+  "files_limit_exceeded",
+  "lines_limit_exceeded",
+  "checks_failing",
+  "required_check_failing",
+  "description_failed",
+  "branch_out_of_date",
+  "fork_ineligible",
+  "author_ineligible",
+  "unresolved_human_review",
+  "blocking_findings",
+  "reviewer_disagreement",
+  "scope_mismatch",
+  "unresolved_uncertainty",
+  "prompt_injection",
+  "sensitive_path",
+  "path_outside_scope",
+  "blocked_path",
+  "policy_path_changed",
+  "excluded_category",
+  "reviewer_quorum",
+  "orchestrator_synthesis_invalid",
+  "orchestrator_escalation",
+  "orchestrator_context_stale",
+  "architecture",
+  "ownership",
+  "operational_risk",
+  "sensitive_change",
+  "policy_requirement",
+] as const;
+
+export type CodeReviewReasonCode = (typeof CODE_REVIEW_REASON_CODES)[number];
+
+export const CODE_REVIEW_REASON_LABELS: Record<CodeReviewReasonCode, string> = {
+  reviewer_disabled: "Automatic approval was disabled",
+  context_unavailable: "PR context was unavailable",
+  head_changed: "PR changed during review",
+  files_limit_exceeded: "File-count limit exceeded",
+  lines_limit_exceeded: "Line-count limit exceeded",
+  checks_failing: "Required checks were not passing",
+  required_check_failing: "A named required check was not passing",
+  description_failed: "PR description requirements were not met",
+  branch_out_of_date: "Branch was out of date",
+  fork_ineligible: "Fork PRs were not eligible",
+  author_ineligible: "Author was not eligible",
+  unresolved_human_review: "Unresolved human review remained",
+  blocking_findings: "Reviewers found a blocking issue",
+  reviewer_disagreement: "Reviewer agents disagreed",
+  scope_mismatch: "Change scope did not match the PR",
+  unresolved_uncertainty: "Important uncertainty remained",
+  prompt_injection: "Prompt-injection risk was detected",
+  sensitive_path: "Sensitive paths changed",
+  path_outside_scope: "Paths were outside the allowed scope",
+  blocked_path: "Blocked paths changed",
+  policy_path_changed: "Policy paths changed",
+  excluded_category: "An excluded change category applied",
+  reviewer_quorum: "Reviewer quorum was not met",
+  orchestrator_synthesis_invalid: "Final synthesis was unavailable",
+  orchestrator_escalation: "Final synthesis needed human review",
+  orchestrator_context_stale: "Final synthesis used stale PR context",
+  architecture: "Architecture needed human judgment",
+  ownership: "Ownership needed human judgment",
+  operational_risk: "Operational risk needed human judgment",
+  sensitive_change: "Sensitive change needed human judgment",
+  policy_requirement: "An approval-policy requirement needed human judgment",
+};
+
+export function codeReviewReasonLabel(code: string): string {
+  const known = CODE_REVIEW_REASON_LABELS[code as CodeReviewReasonCode];
+  if (known) return known;
+  const readable = code.replaceAll("_", " ");
+  return readable.charAt(0).toUpperCase() + readable.slice(1);
+}

--- a/internal/api/handlers/code_reviews.go
+++ b/internal/api/handlers/code_reviews.go
@@ -63,6 +63,7 @@ type codeReviewCursorScope struct {
 	ActivityStatus *models.CodeReviewActivityStatus `json:"activity_status,omitempty"`
 	Status         *models.CodeReviewSessionStatus  `json:"status,omitempty"`
 	Acceptable     *bool                            `json:"acceptable,omitempty"`
+	Reason         *models.CodeReviewRiskReasonCode `json:"reason,omitempty"`
 	Author         string                           `json:"author,omitempty"`
 	Search         string                           `json:"search,omitempty"`
 	CreatedAfter   *time.Time                       `json:"created_after,omitempty"`
@@ -80,6 +81,7 @@ func codeReviewListCursorScopeHash(orgID uuid.UUID, filters db.CodeReviewListFil
 		ActivityStatus: filters.ActivityStatus,
 		Status:         filters.Status,
 		Acceptable:     filters.Acceptable,
+		Reason:         filters.Reason,
 		Author:         strings.TrimSpace(filters.Author),
 		Search:         strings.TrimSpace(filters.Search),
 		CreatedAfter:   filters.CreatedAfter,
@@ -415,6 +417,14 @@ func parseCodeReviewFilters(w http.ResponseWriter, r *http.Request) (db.CodeRevi
 			return db.CodeReviewListFilters{}, false
 		}
 	}
+	if raw := strings.TrimSpace(r.URL.Query().Get("reason")); raw != "" {
+		reason := models.CodeReviewRiskReasonCode(raw)
+		if err := reason.Validate(); err != nil {
+			writeError(w, r, http.StatusBadRequest, "INVALID_REASON", "invalid reason")
+			return db.CodeReviewListFilters{}, false
+		}
+		filters.Reason = &reason
+	}
 	return filters, true
 }
 
@@ -523,6 +533,7 @@ func (h *CodeReviewHandler) Stats(w http.ResponseWriter, r *http.Request) {
 		ActivityStatus: filters.ActivityStatus,
 		Status:         filters.Status,
 		Acceptable:     filters.Acceptable,
+		Reason:         filters.Reason,
 		Author:         filters.Author,
 		Search:         filters.Search,
 		CreatedAfter:   filters.CreatedAfter,

--- a/internal/api/handlers/code_reviews_test.go
+++ b/internal/api/handlers/code_reviews_test.go
@@ -309,6 +309,20 @@ func TestCodeReviewHandler_ListRejectsInvalidActivityStatus(t *testing.T) {
 	require.Contains(t, rr.Body.String(), "INVALID_ACTIVITY_STATUS", "the response should identify the invalid activity status")
 }
 
+func TestCodeReviewHandler_ListRejectsInvalidReason(t *testing.T) {
+	t.Parallel()
+
+	handler := NewCodeReviewHandler(nil, nil)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/code-reviews?reason=bogus", nil)
+	req = req.WithContext(middleware.WithOrgID(req.Context(), uuid.New()))
+	rr := httptest.NewRecorder()
+
+	handler.List(rr, req)
+
+	require.Equal(t, http.StatusBadRequest, rr.Code, "an invalid reason filter should return a bad request")
+	require.Contains(t, rr.Body.String(), "INVALID_REASON", "the response should identify the invalid reason filter")
+}
+
 func TestCodeReviewHandler_ListRejectsInvalidCursor(t *testing.T) {
 	t.Parallel()
 
@@ -397,11 +411,11 @@ func TestCodeReviewHandler_StatsReturnsFilteredAggregates(t *testing.T) {
 	mock, err := pgxmock.NewPool()
 	require.NoError(t, err, "pgxmock should initialize")
 	defer mock.Close()
-	mock.ExpectQuery(`(?s)FROM code_review_session_metadata m.*m\.repository_id = @repository_id.*m\.decision = @decision.*m\.status <> 'stale'.*m\.superseded_by_session_id IS NULL.*m\.status = @status.*m\.acceptable = @acceptable.*LOWER\(COALESCE\(NULLIF\(s\.revision_context->>'pull_request_author', ''\), 'Unknown'\)\) = LOWER\(@author\).*m\.created_at >= @created_after.*pr\.title ILIKE @search`).
+	mock.ExpectQuery(`(?s)FROM code_review_session_metadata m.*m\.repository_id = @repository_id.*m\.decision = @decision.*m\.status <> 'stale'.*m\.superseded_by_session_id IS NULL.*m\.status = @status.*m\.acceptable = @acceptable.*risk_reason->>'code' = @reason.*LOWER\(COALESCE\(NULLIF\(s\.revision_context->>'pull_request_author', ''\), 'Unknown'\)\) = LOWER\(@author\).*m\.created_at >= @created_after.*pr\.title ILIKE @search`).
 		WithArgs(
 			pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
 			pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
-			pgxmock.AnyArg(),
+			pgxmock.AnyArg(), pgxmock.AnyArg(),
 		).
 		WillReturnRows(pgxmock.NewRows([]string{
 			"reviews_completed",
@@ -413,7 +427,7 @@ func TestCodeReviewHandler_StatsReturnsFilteredAggregates(t *testing.T) {
 	req := httptest.NewRequest(
 		http.MethodGet,
 		"/api/v1/code-reviews/stats?repository_id="+repositoryID.String()+
-			"&decision=needs_human_review&activity_status=current&status=completed&risk=needs_review&author=Anya&search=auth&created_after=2026-06-01T00:00:00Z",
+			"&decision=needs_human_review&activity_status=current&status=completed&risk=needs_review&reason=blocking_findings&author=Anya&search=auth&created_after=2026-06-01T00:00:00Z",
 		nil,
 	)
 	req = req.WithContext(middleware.WithOrgID(req.Context(), orgID))
@@ -612,6 +626,12 @@ func TestCodeReviewListCursorRejectsChangedFilterButAllowsMutableRowChanges(t *t
 	changedFilters.Author = "sam"
 	_, err = decodeCodeReviewListCursor(cursor, orgID, changedFilters)
 	require.Error(t, err, "a cursor reused with a different author should be rejected")
+
+	reason := models.CodeReviewRiskReasonBlockingFindings
+	changedFilters = filters
+	changedFilters.Reason = &reason
+	_, err = decodeCodeReviewListCursor(cursor, orgID, changedFilters)
+	require.Error(t, err, "a cursor reused with a different reason should be rejected")
 }
 
 func TestCodeReviewSortCursorRoundTripsEveryListSort(t *testing.T) {

--- a/internal/db/code_reviews.go
+++ b/internal/db/code_reviews.go
@@ -1159,6 +1159,7 @@ type CodeReviewListFilters struct {
 	ActivityStatus  *models.CodeReviewActivityStatus
 	Status          *models.CodeReviewSessionStatus
 	Acceptable      *bool
+	Reason          *models.CodeReviewRiskReasonCode
 	Author          string
 	Search          string
 	Limit           int
@@ -1254,6 +1255,17 @@ func codeReviewListWhere(orgID uuid.UUID, filters CodeReviewListFilters, include
 	if filters.Acceptable != nil {
 		query += ` AND m.acceptable = @acceptable`
 		args["acceptable"] = *filters.Acceptable
+	}
+	if filters.Reason != nil {
+		if err := filters.Reason.Validate(); err != nil {
+			return "", nil, err
+		}
+		query += ` AND EXISTS (
+			SELECT 1
+			FROM jsonb_array_elements(m.risk_reason_details) AS risk_reason
+			WHERE risk_reason->>'code' = @reason
+		)`
+		args["reason"] = *filters.Reason
 	}
 	if author := strings.TrimSpace(filters.Author); author != "" {
 		query += ` AND LOWER(COALESCE(NULLIF(s.revision_context->>'pull_request_author', ''), 'Unknown')) = LOWER(@author)`
@@ -1528,6 +1540,7 @@ type CodeReviewStatsFilters struct {
 	ActivityStatus *models.CodeReviewActivityStatus
 	Status         *models.CodeReviewSessionStatus
 	Acceptable     *bool
+	Reason         *models.CodeReviewRiskReasonCode
 	Author         string
 	Search         string
 	CreatedAfter   *time.Time
@@ -1651,6 +1664,18 @@ func (s *CodeReviewStore) GetReviewStats(ctx context.Context, orgID uuid.UUID, f
 		query += `
 		  AND m.acceptable = @acceptable`
 		args["acceptable"] = *filters.Acceptable
+	}
+	if filters.Reason != nil {
+		if err := filters.Reason.Validate(); err != nil {
+			return models.CodeReviewStats{}, err
+		}
+		query += `
+		  AND EXISTS (
+			SELECT 1
+			FROM jsonb_array_elements(m.risk_reason_details) AS risk_reason
+			WHERE risk_reason->>'code' = @reason
+		  )`
+		args["reason"] = *filters.Reason
 	}
 	if author := strings.TrimSpace(filters.Author); author != "" {
 		query += `

--- a/internal/db/code_reviews_postgres_test.go
+++ b/internal/db/code_reviews_postgres_test.go
@@ -616,3 +616,106 @@ func TestCodeReviewSortRankMatchesPostgresForEveryRow(t *testing.T) {
 		})
 	}
 }
+
+// The reason filter is the only list predicate that reaches into JSONB, and
+// pgxmock never parses SQL: a malformed jsonb_array_elements block, a reason
+// code PostgreSQL cannot compare, or an attempt whose reason array is empty
+// would all satisfy the mocked expectations and only fail in production. Run
+// the generated predicate against PostgreSQL so the stored shape stays covered.
+//
+//nolint:paralleltest // reason subtests share one PostgreSQL connection and isolated schema, so they must run serially
+func TestCodeReviewListWhereReasonFilterMatchesPostgres(t *testing.T) {
+	t.Parallel()
+
+	databaseURL := os.Getenv("TEST_DATABASE_URL")
+	if databaseURL == "" {
+		t.Skip("set TEST_DATABASE_URL to run the PostgreSQL reason filter test")
+	}
+
+	ctx := context.Background()
+	conn, err := pgx.Connect(ctx, databaseURL)
+	require.NoError(t, err, "test should connect to TEST_DATABASE_URL")
+	defer func() {
+		require.NoError(t, conn.Close(context.Background()), "test should close the PostgreSQL connection")
+	}()
+
+	schema := "test_code_review_reason_filter_" + strings.ReplaceAll(uuid.NewString(), "-", "_")
+	_, err = conn.Exec(ctx, `CREATE SCHEMA `+schema)
+	require.NoError(t, err, "test should create an isolated reason filter schema")
+	defer func() {
+		_, cleanupErr := conn.Exec(context.Background(), `DROP SCHEMA IF EXISTS `+schema+` CASCADE`)
+		require.NoError(t, cleanupErr, "test should remove the isolated reason filter schema")
+	}()
+	_, err = conn.Exec(ctx, `SET search_path TO `+schema+`, public`)
+	require.NoError(t, err, "test should isolate reason filter objects")
+
+	_, err = conn.Exec(ctx, `
+		CREATE TABLE code_review_session_metadata (
+			id uuid PRIMARY KEY,
+			org_id uuid NOT NULL,
+			risk_reason_details jsonb NOT NULL DEFAULT '[]'::jsonb
+		)`)
+	require.NoError(t, err, "test should create the columns the reason predicate reads")
+
+	orgID, otherOrgID := uuid.New(), uuid.New()
+	seeded := []struct {
+		name    string
+		orgID   uuid.UUID
+		details string
+	}{
+		{name: "blocking only", orgID: orgID, details: `[{"code": "blocking_findings", "detail": "reviewer flagged a regression"}]`},
+		{name: "blocking and lines", orgID: orgID, details: `[{"code": "lines_limit_exceeded"}, {"code": "blocking_findings"}]`},
+		{name: "no reasons", orgID: orgID, details: `[]`},
+		{name: "other org blocking", orgID: otherOrgID, details: `[{"code": "blocking_findings"}]`},
+	}
+	ids := map[string]uuid.UUID{}
+	for _, row := range seeded {
+		ids[row.name] = uuid.New()
+		_, insertErr := conn.Exec(ctx, `
+			INSERT INTO code_review_session_metadata (id, org_id, risk_reason_details)
+			VALUES ($1, $2, $3::jsonb)`, ids[row.name], row.orgID, row.details)
+		require.NoError(t, insertErr, "test should insert a reason combination")
+	}
+
+	tests := []struct {
+		name     string
+		reason   models.CodeReviewRiskReasonCode
+		expected []uuid.UUID
+	}{
+		{
+			name:     "matches every attempt carrying the reason",
+			reason:   models.CodeReviewRiskReasonBlockingFindings,
+			expected: []uuid.UUID{ids["blocking only"], ids["blocking and lines"]},
+		},
+		{
+			name:     "matches a reason recorded alongside others",
+			reason:   models.CodeReviewRiskReasonLinesLimitExceeded,
+			expected: []uuid.UUID{ids["blocking and lines"]},
+		},
+		{
+			name:     "matches nothing when no attempt recorded the reason",
+			reason:   models.CodeReviewRiskReasonHeadChanged,
+			expected: []uuid.UUID{},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			reason := tt.reason
+			where, args, whereErr := codeReviewListWhere(orgID, CodeReviewListFilters{Reason: &reason}, false)
+			require.NoError(t, whereErr, "the reason predicate should build")
+
+			rows, queryErr := conn.Query(ctx, `SELECT m.id FROM code_review_session_metadata m`+where+` ORDER BY m.id`, args)
+			require.NoError(t, queryErr, "the reason predicate should execute against PostgreSQL")
+			defer rows.Close()
+
+			matched := []uuid.UUID{}
+			for rows.Next() {
+				var id uuid.UUID
+				require.NoError(t, rows.Scan(&id), "the reason query should return attempt IDs")
+				matched = append(matched, id)
+			}
+			require.NoError(t, rows.Err(), "the reason query should complete")
+			require.ElementsMatch(t, tt.expected, matched, "only same-org attempts recording the reason should match")
+		})
+	}
+}

--- a/internal/db/code_reviews_test.go
+++ b/internal/db/code_reviews_test.go
@@ -1014,6 +1014,7 @@ func TestCodeReviewStore_ListReviewsAppliesDesignFilters(t *testing.T) {
 	decision := models.CodeReviewDecisionCommentOnly
 	status := models.CodeReviewSessionStatusCompleted
 	acceptable := false
+	reason := models.CodeReviewRiskReasonBlockingFindings
 	title := "Code review for acme/repo#42"
 	repoName := "acme/repo"
 
@@ -1021,11 +1022,11 @@ func TestCodeReviewStore_ListReviewsAppliesDesignFilters(t *testing.T) {
 	require.NoError(t, err, "pgxmock should initialize")
 	defer mock.Close()
 
-	mock.ExpectQuery("(?s)m.status = 'failed'.*pr.status = 'open'.*current_health.head_sha = m.head_sha.*FROM code_review_session_metadata newer.*approved.status = 'completed'.*policy.active = true.*AS retry_eligible.*m.decision = @decision.*LOWER\\(COALESCE\\(NULLIF\\(s.revision_context->>'pull_request_author', ''\\), 'Unknown'\\)\\) = LOWER\\(@author\\)").
+	mock.ExpectQuery("(?s)m.status = 'failed'.*pr.status = 'open'.*current_health.head_sha = m.head_sha.*FROM code_review_session_metadata newer.*approved.status = 'completed'.*policy.active = true.*AS retry_eligible.*m.decision = @decision.*risk_reason->>'code' = @reason.*LOWER\\(COALESCE\\(NULLIF\\(s.revision_context->>'pull_request_author', ''\\), 'Unknown'\\)\\) = LOWER\\(@author\\)").
 		WithArgs(
 			pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
 			pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
-			pgxmock.AnyArg(),
+			pgxmock.AnyArg(), pgxmock.AnyArg(),
 		).
 		WillReturnRows(pgxmock.NewRows([]string{
 			"id", "org_id", "session_id", "repository_id", "pull_request_id", "policy_id",
@@ -1045,6 +1046,7 @@ func TestCodeReviewStore_ListReviewsAppliesDesignFilters(t *testing.T) {
 		Decision:     &decision,
 		Status:       &status,
 		Acceptable:   &acceptable,
+		Reason:       &reason,
 		Author:       "Devin",
 		Search:       "auth",
 		Limit:        25,
@@ -1288,15 +1290,16 @@ func TestCodeReviewStore_GetReviewStatsScopesToRepositoryAndTimeWindow(t *testin
 	activityStatus := models.CodeReviewActivityStatusCurrent
 	status := models.CodeReviewSessionStatusCompleted
 	acceptable := false
+	reason := models.CodeReviewRiskReasonBlockingFindings
 
 	mock, err := pgxmock.NewPool()
 	require.NoError(t, err, "pgxmock should initialize")
 	defer mock.Close()
 
-	mock.ExpectQuery(`(?s)COUNT\(\*\) FILTER \(WHERE m\.status = 'completed'\).*percentile_cont\(0\.5\).*FROM code_review_session_metadata m.*WHERE m\.org_id = @org_id.*AND m\.repository_id = @repository_id.*AND m\.decision = @decision.*m\.status <> 'stale'.*m\.superseded_by_session_id IS NULL.*AND m\.status = @status.*AND m\.acceptable = @acceptable.*AND m\.created_at >= @created_after.*AND m\.created_at <= @created_before.*pr\.title ILIKE @search`).
+	mock.ExpectQuery(`(?s)COUNT\(\*\) FILTER \(WHERE m\.status = 'completed'\).*percentile_cont\(0\.5\).*FROM code_review_session_metadata m.*WHERE m\.org_id = @org_id.*AND m\.repository_id = @repository_id.*AND m\.decision = @decision.*m\.status <> 'stale'.*m\.superseded_by_session_id IS NULL.*AND m\.status = @status.*AND m\.acceptable = @acceptable.*risk_reason->>'code' = @reason.*AND m\.created_at >= @created_after.*AND m\.created_at <= @created_before.*pr\.title ILIKE @search`).
 		WithArgs(
 			pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
-			pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
+			pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
 		).
 		WillReturnRows(pgxmock.NewRows([]string{
 			"reviews_completed",
@@ -1311,6 +1314,7 @@ func TestCodeReviewStore_GetReviewStatsScopesToRepositoryAndTimeWindow(t *testin
 		ActivityStatus: &activityStatus,
 		Status:         &status,
 		Acceptable:     &acceptable,
+		Reason:         &reason,
 		Search:         "auth",
 		CreatedAfter:   &createdAfter,
 		CreatedBefore:  &createdBefore,


### PR DESCRIPTION
## Summary

Users reviewing “Why PRs not approved” lose time when there are many PRs matching a specific non-approval reason (e.g., line-count limits or blocking findings). This change adds direct, correctly-parameterized links that take you straight from those review comments into the Code Reviews page with matching filters, reducing navigation friction and preventing mis-filtered results.

## Changes

- Added a dedicated `reason` query state to the Code Reviews page so URL filters can represent a specific non-approval reason.
- Introduced reason code constants/types in `frontend/src/lib/code-review-reasons.ts` and wired them into `frontend/src/app/(dashboard)/code-reviews/page.tsx` parsing defaults and query behavior.
- Updated UI behavior/filters so selecting “Reason” produces the expected URL params (and therefore the expected filtered list).
- Extended page tests to assert that “View N PRs where …” links point to the correct `reason` URLs.

## Validation

- Updated and expanded unit/integration tests for the CodeReviews page and related API behavior:
  - `frontend/src/app/(dashboard)/code-reviews/page.test.tsx`
  - `frontend/src/lib/api.test.ts`
  - `internal/api/handlers/code_reviews_test.go`
  - `internal/db/*code_reviews*_test.go`
- Ran the frontend and backend test suites (and relied on existing CI coverage for API/DB contract correctness).

[143.dev](https://143.dev) | [session 7dcf07cd](https://143.dev/sessions/7dcf07cd-aa8d-4026-b67e-f24542c7734e)

<!-- 143-publication session=7dcf07cd-aa8d-4026-b67e-f24542c7734e changeset=598ab465-f29d-4529-b48f-33ee30fc7c03 -->

Preview: https://143.dev/previews/github/assembledhq/143/pull/2059?launch=1