### PR TITLE
Add direct comment request metrics to code review analytics

### DIFF
--- a/docs/design/implemented/02-api-server.md
+++ b/docs/design/implemented/02-api-server.md
@@ -289,7 +289,7 @@ Using `chi` for the HTTP router. All API routes are under `/api/v1/`.
 ├── /code-reviews
 │   ├── GET    /                    # list code review assessments
 │   ├── GET    /stats               # compact review outcome summary
-│   ├── GET    /analytics           # time/repository-scoped approval, author, finding, and reason report
+│   ├── GET    /analytics           # time/repository-scoped PR outcomes and direct-comment requests by GitHub user
 │   ├── GET    /stream              # org-scoped lifecycle event stream
 │   ├── GET    /templates           # starter policy templates
 │   ├── GET    /prompt-examples     # policy prompt examples

--- a/docs/design/implemented/122-pr-centric-code-review-analytics.md
+++ b/docs/design/implemented/122-pr-centric-code-review-analytics.md
@@ -1,6 +1,6 @@
 # Design: PR-Centric Code Review Analytics
 
-> **Status:** Implemented | **Last reviewed:** 2026-07-31
+> **Status:** Implemented | **Last reviewed:** 2026-08-03
 >
 > **Depends on:** [112-code-reviewer-bot-auto-approval.md](112-code-reviewer-bot-auto-approval.md), [../overall.md](../overall.md)
 
@@ -10,12 +10,14 @@ Change the Code reviews Analytics tab from review-attempt reporting to
 pull-request reporting while preserving the useful metrics and sections already
 on the page.
 
-The page should answer four questions:
+The page should answer five questions:
 
 1. How many PRs did 143 review?
 2. How many of those PRs received an approval from 143?
 3. What percentage of reviewed PRs did 143 approve?
 4. How many rounds did approval usually take?
+5. Which trusted GitHub users directly requested reviews through PR comments,
+   and how often?
 
 Individual review sessions remain available as evidence, but they are not the
 primary analytics unit. This prevents a PR reviewed several times from having
@@ -24,6 +26,11 @@ several times the influence of a PR approved immediately.
 The existing author, finding, non-approval, and operational metrics remain.
 Their labels and calculations change from reviews to unique PRs. First-round
 approval and rounds to approval are added alongside them.
+
+The report also counts trusted PR conversation comments that directly mention
+the configured 143 code reviewer. These comment-request counts are grouped by
+the captured GitHub login and deduplicated by the durable GitHub delivery or
+comment identity. Comment contents are not returned in analytics.
 
 Global PR-size, file-count, size-bucket, and policy-limit analytics are
 intentionally excluded. The author table retains median additions and deletions
@@ -62,8 +69,8 @@ first-round approval rate.
 - Attribute merge speed or engineering productivity to 143.
 - Compare 143 approval with human approval.
 - Add policy tuning, automatic recommendations, or dispute handling.
-- Add new analytics dimensions beyond the existing report and review-round
-  metrics defined here.
+- Add analytics dimensions beyond the existing report, review-round metrics,
+  and direct-comment request counts defined here.
 - Create a new analytics warehouse, event stream, or persisted rollup table.
 - Redesign the Reviews or Policy tabs.
 
@@ -235,6 +242,21 @@ overlap other outcomes: a PR can have a stale attempt and later be approved. The
 copy must make this clear rather than presenting them as mutually exclusive final
 outcomes.
 
+### 6. Direct review requests by user
+
+Show a compact table of trusted GitHub users whose newly created PR conversation
+comments directly mentioned the configured 143 code reviewer:
+
+| Column | Definition |
+| --- | --- |
+| GitHub user | Lowercased captured login from the triggering comment |
+| Direct comment requests | Distinct GitHub delivery/comment identities for PRs in the selected cohort |
+
+Show the total in the table summary. A GitHub webhook redelivery counts once.
+Automatic head reassessments, reviewer assignments, and manual retries do not
+count. Later comment requests for a PR in the selected cohort remain included,
+matching the report's existing full-PR-journey semantics.
+
 ## Suggested layout
 
 ```text
@@ -248,6 +270,9 @@ Approval by round
 
 Usage by PR author
 Author       PRs   Approved   Not approved   First-round approval   Median rounds
+
+Direct review requests by user
+GitHub user                                  Direct comment requests
 
 Why PRs were not approved right away
 Reason                                      PRs
@@ -313,6 +338,11 @@ filters. Change the response contract to PR-oriented fields:
     ],
     "non_approval_reasons": [
       {"code": "blocking_findings", "prs": 12}
+    ],
+    "comment_requests_total": 7,
+    "comment_requests_by_user": [
+      {"github_login": "anya", "requests": 5},
+      {"github_login": "sam", "requests": 2}
     ]
   }
 }
@@ -327,7 +357,14 @@ The implementation should derive this in one org-scoped PostgreSQL query:
 4. order distinct completed heads by completion time to assign round numbers;
 5. select one representative assessment per PR;
 6. aggregate PR outcomes, rounds, authors, representative change-distribution
-   and finding metrics, and distinct per-PR reason codes.
+   and finding metrics, distinct per-PR reason codes, and direct comment-request
+   counts grouped by GitHub login.
+
+Direct comment requests are derived from the existing session
+`revision_context`: `request_context.source = 'issue_comment'` identifies the
+trusted comment trigger, while the non-empty `github_delivery_id` provides the
+dedupe identity. The comment body is neither selected nor returned. No database
+schema change is required.
 
 Continue filtering every source by `org_id`. No migration is expected unless
 focused query testing shows an additional index is required.
@@ -367,6 +404,10 @@ Add focused store tests covering:
 - representative author change-distribution, decision, and finding metrics;
 - unique PR counts for failed and stale attempts;
 - author aggregation and missing authors.
+- direct comment request totals and per-user grouping;
+- case-insensitive GitHub login grouping;
+- GitHub webhook redelivery deduplication;
+- exclusion of automatic reassessments, manual retries, and other organizations.
 
 Update handler contract tests and frontend component tests for:
 
@@ -376,6 +417,7 @@ Update handler contract tests and frontend component tests for:
 - non-approval reasons;
 - finding and outcome sections with PR-based copy;
 - PR-author rows and navigation filters.
+- direct-comment requester rows, totals, and the empty state.
 
 ## Rollout
 
@@ -396,3 +438,5 @@ the report is derived from current durable review and PR records.
   insights remain available with PR-based denominators.
 - No PR contributes more than once to an author row, outcome count,
   or individual non-approval reason.
+- Each trusted direct-comment request contributes once to its captured GitHub
+  user even when GitHub redelivers the webhook.

--- a/frontend/src/app/(dashboard)/code-reviews/page.test.tsx
+++ b/frontend/src/app/(dashboard)/code-reviews/page.test.tsx
@@ -267,6 +267,11 @@ const reviewAnalytics: CodeReviewAnalytics = {
     { code: "lines_limit_exceeded", prs: 5 },
     { code: "blocking_findings", prs: 3 },
   ],
+  comment_requests_total: 7,
+  comment_requests_by_user: [
+    { github_login: "anya", requests: 5 },
+    { github_login: "sam", requests: 2 },
+  ],
 };
 
 const githubTriggerReady: CodeReviewGitHubTriggerResponse = {
@@ -816,6 +821,8 @@ describe("CodeReviewsPage", () => {
       ],
       authors: [],
       non_approval_reasons: [],
+      comment_requests_total: 0,
+      comment_requests_by_user: [],
     };
     mockCodeReviewBaseHandlers();
     server.use(

--- a/frontend/src/components/code-review-analytics.test.tsx
+++ b/frontend/src/components/code-review-analytics.test.tsx
@@ -44,6 +44,8 @@ function emptyAnalytics(prsReviewed = 0): CodeReviewAnalytics {
       median_deletions: null,
     }] : [],
     non_approval_reasons: [],
+    comment_requests_total: 0,
+    comment_requests_by_user: [],
   };
 }
 
@@ -143,5 +145,28 @@ describe("CodeReviewAnalyticsReport PR cohort states", () => {
 
     expect(screen.getByText(/1 of 4 PRs whose representative assessment captured a change/))
       .toBeInTheDocument();
+  });
+
+  it("shows direct comment request totals grouped by GitHub user", () => {
+    const analytics = emptyAnalytics(4);
+    analytics.comment_requests_total = 5;
+    analytics.comment_requests_by_user = [
+      { github_login: "anya", requests: 3 },
+      { github_login: "sam", requests: 2 },
+    ];
+    renderReport(analytics);
+
+    expect(screen.getByText("Direct review requests by user")).toBeInTheDocument();
+    expect(screen.getByText("Direct comment requests")).toBeInTheDocument();
+    const requestTable = screen.getByRole("table", { name: "Direct code review requests by GitHub user" });
+    expect(within(requestTable).getByText("anya")).toBeInTheDocument();
+    expect(within(requestTable).getByText("sam")).toBeInTheDocument();
+    expect(within(requestTable).getByLabelText("5 direct comment requests overall")).toHaveTextContent("5");
+  });
+
+  it("shows an inline empty state when the cohort has no direct comment requests", () => {
+    renderReport(emptyAnalytics(2));
+
+    expect(screen.getByText("No direct comment requests were captured for this PR cohort.")).toBeInTheDocument();
   });
 });

--- a/frontend/src/components/code-review-analytics.tsx
+++ b/frontend/src/components/code-review-analytics.tsx
@@ -426,6 +426,46 @@ export function CodeReviewAnalyticsReport({
       </SectionGroup>
 
       <SectionGroup
+        title="Direct review requests by user"
+        description="For the selected PR cohort, trusted comments that directly mentioned the configured 143 code reviewer. GitHub redeliveries count once."
+      >
+        {analytics.comment_requests_by_user.length === 0 ? (
+          <p className="py-6 text-center text-sm text-muted-foreground">
+            No direct comment requests were captured for this PR cohort.
+          </p>
+        ) : (
+          <Card className="overflow-x-auto">
+            <Table aria-label="Direct code review requests by GitHub user">
+              <TableHeader>
+                <TableRow>
+                  <TableHead>GitHub user</TableHead>
+                  <TableHead className="text-right">Direct comment requests</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {analytics.comment_requests_by_user.map((requester) => (
+                  <TableRow key={requester.github_login}>
+                    <TableCell className="font-medium">{requester.github_login}</TableCell>
+                    <TableCell className="text-right tabular-nums">
+                      {requester.requests.toLocaleString()}
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+              <DataTableSummaryRow
+                description="Direct comment requests across all PRs first sent to 143 in the current repository and time filters."
+                cells={[{
+                  content: analytics.comment_requests_total.toLocaleString(),
+                  className: "text-right",
+                  ariaLabel: `${analytics.comment_requests_total.toLocaleString()} direct comment requests overall`,
+                }]}
+              />
+            </Table>
+          </Card>
+        )}
+      </SectionGroup>
+
+      <SectionGroup
         title="Approval by round"
         description="Each PR appears once, based on the first distinct completed head that received a posted 143 approval."
       >

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -363,6 +363,11 @@ export interface CodeReviewAnalytics {
   }>;
   authors: CodeReviewAuthorAnalytics[];
   non_approval_reasons: CodeReviewNonApprovalReasonAnalytics[];
+  comment_requests_total: number;
+  comment_requests_by_user: Array<{
+    github_login: string;
+    requests: number;
+  }>;
 }
 
 export type CodeReviewPhase =

--- a/internal/api/handlers/code_reviews_test.go
+++ b/internal/api/handlers/code_reviews_test.go
@@ -430,13 +430,14 @@ func TestCodeReviewHandler_AnalyticsReturnsReport(t *testing.T) {
 			"prs_with_change_breakdown", "median_additions", "median_deletions", "prs_with_findings",
 			"prs_with_blocking_findings", "total_findings", "needs_human_review",
 			"comment_only", "blocked", "approval_not_posted", "approval_rounds", "authors",
-			"non_approval_reasons",
+			"non_approval_reasons", "comment_requests_total", "comment_requests_by_user",
 		}).AddRow(
 			6, 5, 3, 2, 2, 1.0, 1, 0,
 			0, -1, -1, 1,
 			1, 2, 2, 0, 0, 0,
 			[]byte(`[{"bucket":"round_1","prs":2},{"bucket":"round_2","prs":1},{"bucket":"round_3","prs":0},{"bucket":"round_4_plus","prs":0},{"bucket":"not_yet_approved","prs":3}]`),
-			[]byte(`[]`), []byte(`[]`),
+			[]byte(`[]`), []byte(`[]`), 4,
+			[]byte(`[{"github_login":"anya","requests":3},{"github_login":"sam","requests":1}]`),
 		))
 	handler := NewCodeReviewHandler(db.NewCodeReviewStore(mock), nil)
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/code-reviews/analytics?repository_id="+repositoryID.String(), nil)
@@ -476,7 +477,12 @@ func TestCodeReviewHandler_AnalyticsReturnsReport(t *testing.T) {
 				{"bucket":"not_yet_approved","prs":3}
 			],
 			"authors": [],
-			"non_approval_reasons": []
+			"non_approval_reasons": [],
+			"comment_requests_total": 4,
+			"comment_requests_by_user": [
+				{"github_login":"anya","requests":3},
+				{"github_login":"sam","requests":1}
+			]
 		}
 	}`, rr.Body.String(), "analytics should return exact nullable metrics and empty breakdowns")
 	require.NoError(t, mock.ExpectationsWereMet(), "analytics handler should apply the repository scope to every query")

--- a/internal/db/code_reviews.go
+++ b/internal/db/code_reviews.go
@@ -1751,6 +1751,33 @@ func (s *CodeReviewStore) GetReviewAnalytics(ctx context.Context, orgID uuid.UUI
 		JOIN cohort c ON c.pull_request_id = m.pull_request_id
 		WHERE m.org_id = @org_id` + scanWhere + `
 	),
+	comment_request_candidates AS (
+		SELECT a.pull_request_id,
+			COALESCE(
+				NULLIF(LOWER(BTRIM(s.revision_context #>> '{request_context,author_login}')), ''),
+				'Unknown'
+			) AS github_login,
+			BTRIM(s.revision_context->>'github_delivery_id') AS request_key,
+			a.created_at, a.id
+		FROM attempts a
+		JOIN sessions s ON s.id = a.session_id AND s.org_id = @org_id
+		WHERE s.revision_context #>> '{request_context,source}' = 'issue_comment'
+		  AND NULLIF(BTRIM(s.revision_context->>'github_delivery_id'), '') IS NOT NULL
+	),
+	comment_requests AS MATERIALIZED (
+		-- A GitHub redelivery or internal retry must not turn one human comment
+		-- into several request observations. Comment-triggered reviews always
+		-- persist the delivery id, falling back to the globally unique comment id.
+		SELECT DISTINCT ON (pull_request_id, request_key)
+			pull_request_id, request_key, github_login
+		FROM comment_request_candidates
+		ORDER BY pull_request_id, request_key, created_at, id
+	),
+	comment_request_users AS (
+		SELECT github_login, COUNT(*)::bigint AS requests
+		FROM comment_requests
+		GROUP BY github_login
+	),
 	attempt_flags AS (
 		-- One grouped pass instead of a correlated EXISTS per cohort PR: an
 		-- EXISTS sublink in a target list cannot become a semi-join, so it
@@ -1877,12 +1904,17 @@ func (s *CodeReviewStore) GetReviewAnalytics(ctx context.Context, orgID uuid.UUI
 	SELECT s.*,
 		(SELECT buckets FROM approval_rounds) AS approval_rounds,
 		COALESCE((SELECT jsonb_agg(to_jsonb(a) ORDER BY ` + authorOrder + `) FROM authors a), '[]') AS authors,
-		COALESCE((SELECT jsonb_agg(to_jsonb(r) ORDER BY r.prs DESC, r.code) FROM reasons r), '[]') AS reasons
+		COALESCE((SELECT jsonb_agg(to_jsonb(r) ORDER BY r.prs DESC, r.code) FROM reasons r), '[]') AS reasons,
+		(SELECT COUNT(*)::bigint FROM comment_requests) AS comment_requests_total,
+		COALESCE((
+			SELECT jsonb_agg(to_jsonb(requester) ORDER BY requester.requests DESC, requester.github_login)
+			FROM comment_request_users requester
+		), '[]') AS comment_requests_by_user
 	FROM summary s`
 
 	var analytics models.CodeReviewAnalytics
 	var medianRounds, medianAdditions, medianDeletions float64
-	var roundsJSON, authorsJSON, reasonsJSON []byte
+	var roundsJSON, authorsJSON, reasonsJSON, commentRequestUsersJSON []byte
 	err = s.db.QueryRow(ctx, query, args).Scan(
 		&analytics.Summary.PRsReviewed, &analytics.Summary.PRsWithCompletedRound,
 		&analytics.Summary.ApprovedBy143, &analytics.Summary.NotApproved,
@@ -1894,7 +1926,7 @@ func (s *CodeReviewStore) GetReviewAnalytics(ctx context.Context, orgID uuid.UUI
 		&analytics.Summary.TotalFindings, &analytics.Summary.NeedsHumanReview,
 		&analytics.Summary.CommentOnly, &analytics.Summary.Blocked,
 		&analytics.Summary.ApprovalNotPosted, &roundsJSON, &authorsJSON,
-		&reasonsJSON,
+		&reasonsJSON, &analytics.CommentRequestsTotal, &commentRequestUsersJSON,
 	)
 	if err != nil {
 		return models.CodeReviewAnalytics{}, fmt.Errorf("query PR-centric code review analytics: %w", err)
@@ -1910,6 +1942,7 @@ func (s *CodeReviewStore) GetReviewAnalytics(ctx context.Context, orgID uuid.UUI
 		{"approval rounds", roundsJSON, &analytics.ApprovalRounds},
 		{"authors", authorsJSON, &analytics.Authors},
 		{"non-approval reasons", reasonsJSON, &analytics.NonApprovalReasons},
+		{"comment requests by user", commentRequestUsersJSON, &analytics.CommentRequestsByUser},
 	} {
 		if err := json.Unmarshal(section.payload, section.target); err != nil {
 			return models.CodeReviewAnalytics{}, fmt.Errorf("decode PR-centric code review analytics %s: %w", section.name, err)

--- a/internal/db/code_reviews_postgres_test.go
+++ b/internal/db/code_reviews_postgres_test.go
@@ -96,12 +96,12 @@ func TestCodeReviewStore_GetReviewAnalyticsPostgresBehavior(t *testing.T) {
 	_, err = conn.Exec(ctx, `
 		INSERT INTO sessions (id, org_id, revision_context)
 		VALUES
-			($1, $2, '{"pull_request_author":"anya"}'),
-			($3, $2, '{"pull_request_author":"sam"}'),
-			($4, $2, '{"pull_request_author":"anya"}'),
-			($5, $2, '{"pull_request_author":"old"}'),
+			($1, $2, '{"pull_request_author":"anya","github_delivery_id":"delivery-1","request_context":{"source":"issue_comment","author_login":"anya"}}'),
+			($3, $2, '{"pull_request_author":"sam","github_delivery_id":"delivery-2","request_context":{"source":"issue_comment","author_login":"anya"}}'),
+			($4, $2, '{"pull_request_author":"anya","github_delivery_id":"","request_context":{"source":"issue_comment","author_login":"anya"}}'),
+			($5, $2, '{"pull_request_author":"old","github_delivery_id":"delivery-old","request_context":{"source":"issue_comment","author_login":"old"}}'),
 			($6, $2, '{"pull_request_author":"anya"}'),
-			($7, $8, '{"pull_request_author":"other"}')`,
+			($7, $8, '{"pull_request_author":"other","github_delivery_id":"delivery-other","request_context":{"source":"issue_comment","author_login":"intruder"}}')`,
 		approvedSessionID, orgID, needsHumanSessionID, failedSessionID, oldSessionID,
 		legacySessionID, otherOrgSessionID, otherOrgID,
 	)
@@ -245,6 +245,10 @@ func TestCodeReviewStore_GetReviewAnalyticsPostgresBehavior(t *testing.T) {
 			{Code: models.CodeReviewRiskReasonFilesLimitExceeded, PRs: 1},
 			{Code: models.CodeReviewRiskReasonLinesLimitExceeded, PRs: 1},
 		},
+		CommentRequestsTotal: 2,
+		CommentRequestsByUser: []models.CodeReviewCommentRequestUserAnalytics{
+			{GitHubLogin: "anya", Requests: 2},
+		},
 	}, analytics, "analytics should preserve outcome, author, size, reason, finding, time, and tenancy semantics")
 
 	// Author ordering is interpolated from a strict allowlist. Execute every
@@ -305,7 +309,11 @@ func TestCodeReviewStore_GetReviewAnalyticsPostgresBehavior(t *testing.T) {
 				MedianDeletions:        &otherDeletions,
 			},
 		},
-		NonApprovalReasons: []models.CodeReviewNonApprovalReasonAnalytics{},
+		NonApprovalReasons:   []models.CodeReviewNonApprovalReasonAnalytics{},
+		CommentRequestsTotal: 1,
+		CommentRequestsByUser: []models.CodeReviewCommentRequestUserAnalytics{
+			{GitHubLogin: "intruder", Requests: 1},
+		},
 	}, otherOrgAnalytics, "analytics should remain isolated to the selected organization")
 
 	emptyAnalytics, err := NewCodeReviewStore(conn).GetReviewAnalytics(ctx, uuid.New(), CodeReviewAnalyticsFilters{})
@@ -319,8 +327,9 @@ func TestCodeReviewStore_GetReviewAnalyticsPostgresBehavior(t *testing.T) {
 			{Bucket: models.CodeReviewApprovalRound4Plus, PRs: 0},
 			{Bucket: models.CodeReviewApprovalRoundNotYet, PRs: 0},
 		},
-		Authors:            []models.CodeReviewAuthorAnalytics{},
-		NonApprovalReasons: []models.CodeReviewNonApprovalReasonAnalytics{},
+		Authors:               []models.CodeReviewAuthorAnalytics{},
+		NonApprovalReasons:    []models.CodeReviewNonApprovalReasonAnalytics{},
+		CommentRequestsByUser: []models.CodeReviewCommentRequestUserAnalytics{},
 	}, emptyAnalytics, "an organization without reviews should receive zero summary values and empty breakdowns")
 }
 
@@ -451,6 +460,34 @@ func TestCodeReviewStore_GetReviewAnalyticsPRJourneys(t *testing.T) {
 		require.NoError(t, insertErr, "test should insert each PR-journey review fact")
 	}
 
+	_, err = conn.Exec(ctx, `
+		UPDATE sessions
+		SET revision_context = revision_context || jsonb_build_object(
+			'github_delivery_id', CASE id
+				WHEN $1 THEN 'delivery-alice'
+				WHEN $2 THEN 'delivery-alice'
+				WHEN $3 THEN 'delivery-reviewer-bob-1'
+				WHEN $4 THEN 'delivery-reviewer-bob-2'
+				WHEN $5 THEN 'delivery-other-org'
+			END,
+			'request_context', jsonb_build_object(
+				'source', 'issue_comment',
+				'author_login', CASE id
+					WHEN $1 THEN 'Alice'
+					WHEN $2 THEN 'alice'
+					WHEN $3 THEN 'reviewer-bob'
+					WHEN $4 THEN 'reviewer-bob'
+					WHEN $5 THEN 'intruder'
+				END
+			)
+		)
+		WHERE id = ANY($6::uuid[])`,
+		facts[0].sessionID, facts[1].sessionID, facts[4].sessionID,
+		facts[8].sessionID, facts[13].sessionID,
+		[]uuid.UUID{facts[0].sessionID, facts[1].sessionID, facts[4].sessionID, facts[8].sessionID, facts[13].sessionID},
+	)
+	require.NoError(t, err, "test should mark direct comment requests and a redelivery in session audit context")
+
 	iteratedApprovalSessionID := facts[8].sessionID
 	_, err = conn.Exec(ctx, `
 		INSERT INTO code_review_findings (org_id, session_id, severity) VALUES
@@ -497,6 +534,11 @@ func TestCodeReviewStore_GetReviewAnalyticsPRJourneys(t *testing.T) {
 		}
 		return authors
 	}(), "author aggregation should use the first captured author and preserve Unknown exactly once")
+	require.Equal(t, int64(3), analytics.CommentRequestsTotal, "comment request total should deduplicate GitHub redeliveries within a PR")
+	require.Equal(t, []models.CodeReviewCommentRequestUserAnalytics{
+		{GitHubLogin: "reviewer-bob", Requests: 2},
+		{GitHubLogin: "alice", Requests: 1},
+	}, analytics.CommentRequestsByUser, "comment requests should group case-insensitive GitHub logins and exclude other tenants")
 }
 
 // The rank a page cursor anchors on is computed in Go while the rank the

--- a/internal/db/code_reviews_test.go
+++ b/internal/db/code_reviews_test.go
@@ -1368,7 +1368,7 @@ func TestCodeReviewStore_GetReviewAnalyticsReturnsDecisionReport(t *testing.T) {
 			"prs_with_change_breakdown", "median_additions", "median_deletions", "prs_with_findings",
 			"prs_with_blocking_findings", "total_findings", "needs_human_review",
 			"comment_only", "blocked", "approval_not_posted", "approval_rounds", "authors",
-			"non_approval_reasons",
+			"non_approval_reasons", "comment_requests_total", "comment_requests_by_user",
 		}).AddRow(
 			32, 28, 17, 11, 10, 2.0, 2, 2,
 			20, medianAdditions, medianDeletions,
@@ -1387,6 +1387,9 @@ func TestCodeReviewStore_GetReviewAnalyticsReturnsDecisionReport(t *testing.T) {
 			[]byte(`[
 				{"code":"lines_limit_exceeded","prs":5},
 				{"code":"blocking_findings","prs":3}
+			]`), 5, []byte(`[
+				{"github_login":"anya","requests":3},
+				{"github_login":"sam","requests":2}
 			]`),
 		))
 
@@ -1439,6 +1442,11 @@ func TestCodeReviewStore_GetReviewAnalyticsReturnsDecisionReport(t *testing.T) {
 			{Code: models.CodeReviewRiskReasonLinesLimitExceeded, PRs: 5},
 			{Code: models.CodeReviewRiskReasonBlockingFindings, PRs: 3},
 		},
+		CommentRequestsTotal: 5,
+		CommentRequestsByUser: []models.CodeReviewCommentRequestUserAnalytics{
+			{GitHubLogin: "anya", Requests: 3},
+			{GitHubLogin: "sam", Requests: 2},
+		},
 	}, analytics, "GetReviewAnalytics should return exact summary, author, and reason metrics")
 	require.NoError(t, mock.ExpectationsWereMet(), "the single analytics query should remain org and filter scoped")
 }
@@ -1487,10 +1495,10 @@ func TestCodeReviewStore_GetReviewAnalyticsRejectsIncompleteApprovalRounds(t *te
 					"prs_with_change_breakdown", "median_additions", "median_deletions", "prs_with_findings",
 					"prs_with_blocking_findings", "total_findings", "needs_human_review",
 					"comment_only", "blocked", "approval_not_posted", "approval_rounds", "authors",
-					"non_approval_reasons",
+					"non_approval_reasons", "comment_requests_total", "comment_requests_by_user",
 				}).AddRow(
 					1, 1, 1, 0, 1, 1.0, 0, 0, 0, -1.0, -1.0, 0, 0, 0, 0, 0, 0, 0,
-					[]byte(tt.rounds), []byte(`[]`), []byte(`[]`),
+					[]byte(tt.rounds), []byte(`[]`), []byte(`[]`), 0, []byte(`[]`),
 				))
 
 			_, err = NewCodeReviewStore(mock).GetReviewAnalytics(context.Background(), uuid.New(), CodeReviewAnalyticsFilters{})

--- a/internal/models/code_review.go
+++ b/internal/models/code_review.go
@@ -986,6 +986,11 @@ type CodeReviewNonApprovalReasonAnalytics struct {
 	PRs  int64                    `db:"prs" json:"prs"`
 }
 
+type CodeReviewCommentRequestUserAnalytics struct {
+	GitHubLogin string `db:"github_login" json:"github_login"`
+	Requests    int64  `db:"requests" json:"requests"`
+}
+
 type CodeReviewApprovalRoundBucket string
 
 const (
@@ -1018,10 +1023,12 @@ type CodeReviewApprovalRoundAnalytics struct {
 }
 
 type CodeReviewAnalytics struct {
-	Summary            CodeReviewAnalyticsSummary             `json:"summary"`
-	ApprovalRounds     []CodeReviewApprovalRoundAnalytics     `json:"approval_rounds"`
-	Authors            []CodeReviewAuthorAnalytics            `json:"authors"`
-	NonApprovalReasons []CodeReviewNonApprovalReasonAnalytics `json:"non_approval_reasons"`
+	Summary               CodeReviewAnalyticsSummary              `json:"summary"`
+	ApprovalRounds        []CodeReviewApprovalRoundAnalytics      `json:"approval_rounds"`
+	Authors               []CodeReviewAuthorAnalytics             `json:"authors"`
+	NonApprovalReasons    []CodeReviewNonApprovalReasonAnalytics  `json:"non_approval_reasons"`
+	CommentRequestsTotal  int64                                   `json:"comment_requests_total"`
+	CommentRequestsByUser []CodeReviewCommentRequestUserAnalytics `json:"comment_requests_by_user"`
 }
 
 type CodeReviewEvidence struct {


### PR DESCRIPTION
## Summary

- Count trusted direct review requests from PR comments in the selected PR cohort.
- Deduplicate GitHub redeliveries and group requests by normalized GitHub login.
- Expose the new metrics through the API and display totals, user rows, and an empty state in the analytics UI.
- Document the updated analytics contract and behavior.

## Testing

- Added Go store and handler tests for aggregation, deduplication, case-insensitive grouping, tenancy isolation, and response contracts.
- Added frontend component and page tests for populated and empty request states.
- Not run (not requested).