### PR TITLE
Use exhaustive fixes for automatic PR review loops

### DIFF
--- a/docs/design/implemented/78-review-agent-loops.md
+++ b/docs/design/implemented/78-review-agent-loops.md
@@ -146,9 +146,10 @@ Design choices:
   pass without creating a separate session. The selector falls back to the main
   session agent when no supported alternative exists.
 - The setup dialog must clearly state that the loop runs in the current sandbox.
-- Minimal fixes is the default fix mode to preserve existing review-loop
-  behavior; Fix every finding is explicit because it can increase scope,
-  latency, and token cost.
+- Minimal fixes is the default for manually configured review loops; Fix every
+  finding is explicit there because it can increase scope, latency, and token
+  cost. Publication- and automation-created review loops always use Fix every
+  finding so an unattended PR workflow does not knowingly defer review issues.
 
 ### Manual session timeline
 

--- a/docs/public/getting-started/review-and-ship.mdx
+++ b/docs/public/getting-started/review-and-ship.mdx
@@ -69,6 +69,8 @@ a PR when the coding agent is ready** and **Run a two-pass review/fix cycle
 before creating the PR** under **Settings → Session automation**. Both default
 to on. Each user can choose **Use organization default (On/Off)**, **On**, or
 **Off** under **Account settings → Session automation**.
+Automatically created review/fix cycles use **Fix every finding** rather than
+the minimal-fixes mode available in the manual review setup.
 
 Questions, planning, diagnosis, review-only work, sessions linked to an
 existing PR, incomplete work, and turns with no changes do not create a new

--- a/internal/services/reviewloop/service.go
+++ b/internal/services/reviewloop/service.go
@@ -185,7 +185,11 @@ func (s *Service) Start(ctx context.Context, orgID, sessionID uuid.UUID, req Sta
 	}
 	fixMode := req.FixMode
 	if fixMode == "" {
-		fixMode = models.ReviewLoopFixModeMinimal
+		if source == models.ReviewLoopSourceManual {
+			fixMode = models.ReviewLoopFixModeMinimal
+		} else {
+			fixMode = models.ReviewLoopFixModeExhaustive
+		}
 	}
 	if err := fixMode.Validate(); err != nil {
 		return nil, ErrInvalidFixMode

--- a/internal/services/reviewloop/service_test.go
+++ b/internal/services/reviewloop/service_test.go
@@ -103,6 +103,51 @@ func TestService_StartStoresRequestedFixMode(t *testing.T) {
 	require.Equal(t, models.ReviewLoopFixModeExhaustive, store.createdLoops[0].FixMode, "Start should persist the requested fix mode")
 }
 
+func TestService_StartDefaultsAutomaticFixModesToExhaustive(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		source models.ReviewLoopSource
+	}{
+		{name: "automation", source: models.ReviewLoopSourceAutomation},
+		{name: "publication", source: models.ReviewLoopSourcePublication},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			orgID := uuid.New()
+			sessionID := uuid.New()
+			threadID := uuid.New()
+			changesetID := uuid.New()
+			workspaceRevision := int64(7)
+			desiredHeadSHA := "reviewed-head"
+			snapshotKey := "snapshots/automatic-review-loop.tar.zst"
+			store := &fakeReviewLoopStore{}
+			threads := &fakeThreadService{
+				session: models.Session{ID: sessionID, OrgID: orgID, AgentType: models.AgentTypeCodex, Status: models.SessionStatusIdle, SandboxState: models.SandboxStateSnapshotted, SnapshotKey: &snapshotKey},
+				thread:  models.SessionThread{ID: threadID, SessionID: sessionID, OrgID: orgID, AgentType: models.AgentTypeCodex, Label: "Codex Review"},
+				message: models.SessionMessage{ID: 77, SessionID: sessionID, OrgID: orgID, ThreadID: &threadID},
+			}
+			req := StartReviewLoopRequest{MaxPasses: 2, Source: tt.source}
+			if tt.source == models.ReviewLoopSourcePublication {
+				req.ChangesetID = &changesetID
+				req.WorkspaceRevision = &workspaceRevision
+				req.DesiredHeadSHA = &desiredHeadSHA
+			}
+
+			loop, err := NewService(store, threads).Start(context.Background(), orgID, sessionID, req)
+
+			require.NoError(t, err, "Start should create an automatic review loop")
+			require.Equal(t, models.ReviewLoopFixModeExhaustive, loop.FixMode, "automatic review loops should default to fixing every finding")
+			require.Equal(t, models.ReviewLoopFixModeExhaustive, store.createdLoops[0].FixMode, "automatic review loops should persist exhaustive fix mode")
+			require.Contains(t, threads.sent[0].Message, "Report every issue you find", "automatic review loops should ask the reviewer to report every finding")
+		})
+	}
+}
+
 func TestService_StartRejectsExistingRunningLoop(t *testing.T) {
 	t.Parallel()
 

--- a/internal/worker/handlers.go
+++ b/internal/worker/handlers.go
@@ -12225,7 +12225,8 @@ func ensurePublicationPrePRReview(
 	}
 	loop, err := services.ReviewLoops.Start(ctx, run.OrgID, run.ID, reviewloopsvc.StartReviewLoopRequest{
 		AgentType: reviewer, Model: model, MaxPasses: *publication.ReviewMaxPasses,
-		Source: models.ReviewLoopSourcePublication, AutomationRunID: run.AutomationRunID,
+		FixMode: models.ReviewLoopFixModeExhaustive,
+		Source:  models.ReviewLoopSourcePublication, AutomationRunID: run.AutomationRunID,
 		StartedByUserID: publication.InitiatedByUserID,
 		ReviewRequired:  true, ChangesetID: changesetID, WorkspaceRevision: &workspaceRevision,
 		DesiredHeadSHA: &desiredHeadSHA,
@@ -12380,6 +12381,7 @@ func ensureAutomationPrePRReview(ctx context.Context, stores *Stores, services *
 		AgentType:       run.AgentType,
 		Model:           stringValue(run.ModelOverride),
 		MaxPasses:       passCount,
+		FixMode:         models.ReviewLoopFixModeExhaustive,
 		Source:          models.ReviewLoopSourceAutomation,
 		AutomationRunID: run.AutomationRunID,
 		StartedByUserID: run.TriggeredByUserID,

--- a/internal/worker/handlers_test.go
+++ b/internal/worker/handlers_test.go
@@ -7062,6 +7062,7 @@ func TestOpenPRHandler_StartsAutomationPrePRReviewBeforePushing(t *testing.T) {
 	require.Len(t, reviews.starts, 1, "open_pr should start exactly one automation review loop")
 	require.Equal(t, models.ReviewLoopSourceAutomation, reviews.starts[0].req.Source, "review loop should be marked automation-owned")
 	require.Equal(t, 1, reviews.starts[0].req.MaxPasses, "review loop should use the snapshotted automation pass count")
+	require.Equal(t, models.ReviewLoopFixModeExhaustive, reviews.starts[0].req.FixMode, "automation-created review loops should fix every finding")
 	require.NotNil(t, reviews.starts[0].req.AutomationRunID, "review loop should retain the automation run id")
 	require.Equal(t, automationRunID, *reviews.starts[0].req.AutomationRunID, "review loop should retain the automation run id")
 	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")


### PR DESCRIPTION
## Summary

- Default publication- and automation-created review loops to fixing every finding.
- Preserve minimal fixes as the default for manually configured review loops.
- Document the behavior and add service and worker coverage.

## Testing

- Added unit tests covering automatic review-loop defaults and worker configuration.
- Not run (not requested)