### PR TITLE
Implement browser timeout budgets and bootstrap diagnostics; resolve three referenced issues (PR 1)

### DIFF
--- a/internal/api/handlers/helpers.go
+++ b/internal/api/handlers/helpers.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"context"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
@@ -13,6 +14,8 @@ import (
 	"github.com/google/uuid"
 	"github.com/rs/zerolog"
 )
+
+type browserOperationStartContextKey struct{}
 
 // encodeCursor produces an opaque, base64-encoded cursor from a created_at
 // timestamp and a string-encoded ID. Format: "RFC3339Nano,id" → base64.
@@ -175,6 +178,33 @@ func clearWriteDeadline(w http.ResponseWriter, r *http.Request) {
 	if err := http.NewResponseController(w).SetWriteDeadline(time.Time{}); err != nil {
 		zerolog.Ctx(r.Context()).Debug().Err(err).Msg("could not clear write deadline; continuing with server default")
 	}
+}
+
+// setResponseWriteDeadline replaces the server-wide write deadline with a
+// bounded operation-specific deadline. This preserves a useful JSON error when
+// a long browser operation reaches its own timeout instead of surfacing EOF.
+func setResponseWriteDeadline(w http.ResponseWriter, r *http.Request, timeout time.Duration) {
+	if timeout <= 0 {
+		return
+	}
+	if err := http.NewResponseController(w).SetWriteDeadline(time.Now().Add(timeout)); err != nil {
+		zerolog.Ctx(r.Context()).Debug().Err(err).Dur("response_timeout", timeout).Msg("response writer does not support an operation-specific write deadline")
+	}
+}
+
+func withBrowserOperationStart(r *http.Request) *http.Request {
+	return r.WithContext(context.WithValue(r.Context(), browserOperationStartContextKey{}, time.Now()))
+}
+
+func browserOperationElapsed(r *http.Request) time.Duration {
+	if r == nil {
+		return 0
+	}
+	startedAt, _ := r.Context().Value(browserOperationStartContextKey{}).(time.Time)
+	if startedAt.IsZero() {
+		return 0
+	}
+	return time.Since(startedAt)
 }
 
 func writeJSON(w http.ResponseWriter, status int, v any) {

--- a/internal/api/handlers/helpers_test.go
+++ b/internal/api/handlers/helpers_test.go
@@ -7,10 +7,32 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/require"
 )
+
+func TestSetResponseWriteDeadline_ExtendsShortServerDeadline(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		setResponseWriteDeadline(w, r, 500*time.Millisecond)
+		time.Sleep(20 * time.Millisecond)
+		writeJSON(w, http.StatusOK, map[string]string{"status": "ready"})
+	}))
+	server.Config.WriteTimeout = 5 * time.Millisecond
+	server.Start()
+	defer server.Close()
+
+	resp, err := server.Client().Get(server.URL)
+	require.NoError(t, err, "operation-specific response deadline should prevent an EOF from the shorter server timeout")
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode, "delayed handler should complete within its operation-specific budget")
+	var body map[string]string
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&body), "delayed handler should return a complete JSON response")
+	require.Equal(t, map[string]string{"status": "ready"}, body, "delayed handler should preserve its response body")
+}
 
 func TestQueryInt(t *testing.T) {
 	t.Parallel()

--- a/internal/api/handlers/internal_preview.go
+++ b/internal/api/handlers/internal_preview.go
@@ -16,6 +16,7 @@ import (
 	"github.com/assembledhq/143/internal/api/middleware"
 	"github.com/assembledhq/143/internal/auth"
 	"github.com/assembledhq/143/internal/db"
+	"github.com/assembledhq/143/internal/internalapi"
 	"github.com/assembledhq/143/internal/models"
 	previewsvc "github.com/assembledhq/143/internal/services/preview"
 	"github.com/go-chi/chi/v5"
@@ -152,6 +153,26 @@ func (h *InternalPreviewHandler) requireInspector(w http.ResponseWriter, r *http
 		return nil, false
 	}
 	return h.manager.Inspector(), true
+}
+
+func withWorkerBrowserOperation(w http.ResponseWriter, r *http.Request, operation previewsvc.BrowserOperation) (*http.Request, context.CancelFunc) {
+	budget := previewsvc.BrowserOperationBudgetFor(operation)
+	setResponseWriteDeadline(w, r, budget.WorkerResponse)
+	r = withBrowserOperationStart(r)
+	ctx, cancel := context.WithTimeout(r.Context(), budget.Operation)
+	return r.WithContext(ctx), cancel
+}
+
+type browserDiagnosticContextKey struct{}
+
+func withBrowserDiagnosticContext(r *http.Request, workerNodeID string, previewID, sessionID uuid.UUID) *http.Request {
+	logger := zerolog.Ctx(r.Context()).With().
+		Str("preview_id", previewID.String()).
+		Str("session_id", sessionID.String()).
+		Str("worker_node_id", workerNodeID).
+		Logger()
+	ctx := context.WithValue(logger.WithContext(r.Context()), browserDiagnosticContextKey{}, true)
+	return r.WithContext(ctx)
 }
 
 func (h *InternalPreviewHandler) StartPreview(w http.ResponseWriter, r *http.Request) {
@@ -372,6 +393,8 @@ func (h *InternalPreviewHandler) CancelSession(w http.ResponseWriter, r *http.Re
 }
 
 func (h *InternalPreviewHandler) CaptureScreenshot(w http.ResponseWriter, r *http.Request) {
+	r, cancel := withWorkerBrowserOperation(w, r, previewsvc.BrowserOperationScreenshot)
+	defer cancel()
 	previewID, claims, ok := h.authorizePreviewAction(w, r, "screenshot")
 	if !ok {
 		return
@@ -397,6 +420,8 @@ func (h *InternalPreviewHandler) CaptureScreenshot(w http.ResponseWriter, r *htt
 }
 
 func (h *InternalPreviewHandler) Observe(w http.ResponseWriter, r *http.Request) {
+	r, cancel := withWorkerBrowserOperation(w, r, previewsvc.BrowserOperationObserve)
+	defer cancel()
 	previewID, claims, ok := h.authorizePreviewAction(w, r, "observe")
 	if !ok {
 		return
@@ -416,6 +441,7 @@ func (h *InternalPreviewHandler) Observe(w http.ResponseWriter, r *http.Request)
 		writeError(w, r, http.StatusServiceUnavailable, "BROWSER_UNAVAILABLE", "preview browser is unavailable")
 		return
 	}
+	r = withBrowserDiagnosticContext(r, h.nodeID, previewID, body.SessionID)
 	result, err := h.preview.browserSessions.Observe(r.Context(), orgID, body.SessionID, previewID, body.Policy, body.Options)
 	if err != nil {
 		writeBrowserSessionError(w, r, err)
@@ -425,6 +451,8 @@ func (h *InternalPreviewHandler) Observe(w http.ResponseWriter, r *http.Request)
 }
 
 func (h *InternalPreviewHandler) Act(w http.ResponseWriter, r *http.Request) {
+	r, cancel := withWorkerBrowserOperation(w, r, previewsvc.BrowserOperationInteract)
+	defer cancel()
 	previewID, claims, ok := h.authorizePreviewAction(w, r, "act")
 	if !ok {
 		return
@@ -444,6 +472,7 @@ func (h *InternalPreviewHandler) Act(w http.ResponseWriter, r *http.Request) {
 		writeError(w, r, http.StatusServiceUnavailable, "BROWSER_UNAVAILABLE", "preview browser is unavailable")
 		return
 	}
+	r = withBrowserDiagnosticContext(r, h.nodeID, previewID, body.SessionID)
 	result, err := h.preview.browserSessions.Act(r.Context(), orgID, body.SessionID, previewID, body.Policy, body.Steps, body.Options)
 	if err != nil {
 		writeBrowserSessionError(w, r, err)
@@ -453,6 +482,8 @@ func (h *InternalPreviewHandler) Act(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *InternalPreviewHandler) HumanAct(w http.ResponseWriter, r *http.Request) {
+	r, cancel := withWorkerBrowserOperation(w, r, previewsvc.BrowserOperationInteract)
+	defer cancel()
 	middleware.OrgIDFromContext(r.Context())
 	previewID, claims, ok := h.authorizePreviewAction(w, r, "human_act")
 	if !ok {
@@ -472,6 +503,7 @@ func (h *InternalPreviewHandler) HumanAct(w http.ResponseWriter, r *http.Request
 		writeError(w, r, http.StatusServiceUnavailable, "BROWSER_UNAVAILABLE", "preview browser is unavailable")
 		return
 	}
+	r = withBrowserDiagnosticContext(r, h.nodeID, previewID, body.SessionID)
 	result, err := h.preview.browserSessions.ActAsHuman(r.Context(), claims.OrgID, body.SessionID, previewID, body.UserID, body.Policy, body.Steps, body.Options)
 	if err != nil {
 		writeBrowserSessionError(w, r, err)
@@ -481,6 +513,24 @@ func (h *InternalPreviewHandler) HumanAct(w http.ResponseWriter, r *http.Request
 }
 
 func writeBrowserSessionError(w http.ResponseWriter, r *http.Request, err error) {
+	if accessErr, ok := previewsvc.AsBrowserAccessError(err); ok {
+		logContext := zerolog.Ctx(r.Context()).With().Str("browser_stage", string(accessErr.Stage))
+		if elapsed := browserOperationElapsed(r); elapsed > 0 {
+			logContext = logContext.Dur("browser_elapsed", elapsed)
+		}
+		if diagnosticContext, _ := r.Context().Value(browserDiagnosticContextKey{}).(bool); !diagnosticContext {
+			if previewID := firstNonEmptyString(chi.URLParam(r, "previewID"), chi.URLParam(r, "preview_id")); previewID != "" {
+				logContext = logContext.Str("preview_id", previewID)
+			}
+			if sessionID := chi.URLParam(r, "id"); sessionID != "" {
+				logContext = logContext.Str("session_id", sessionID)
+			}
+		}
+		logger := logContext.Logger()
+		r = r.WithContext(logger.WithContext(r.Context()))
+		writeErrorWithDetails(w, r, http.StatusInternalServerError, accessErr.Code(), "preview browser access failed", map[string]string{"stage": string(accessErr.Stage)}, err)
+		return
+	}
 	switch {
 	case errors.Is(err, previewsvc.ErrBrowserUnavailable):
 		writeError(w, r, http.StatusServiceUnavailable, "BROWSER_UNAVAILABLE", "preview browser is unavailable", err)
@@ -494,6 +544,8 @@ func writeBrowserSessionError(w http.ResponseWriter, r *http.Request, err error)
 }
 
 func (h *InternalPreviewHandler) InspectElement(w http.ResponseWriter, r *http.Request) {
+	r, cancel := withWorkerBrowserOperation(w, r, previewsvc.BrowserOperationInspect)
+	defer cancel()
 	previewID, claims, ok := h.authorizePreviewAction(w, r, "inspect")
 	if !ok {
 		return
@@ -543,6 +595,8 @@ func (h *InternalPreviewHandler) ReadConsole(w http.ResponseWriter, r *http.Requ
 }
 
 func (h *InternalPreviewHandler) ExecuteInteraction(w http.ResponseWriter, r *http.Request) {
+	r, cancel := withWorkerBrowserOperation(w, r, previewsvc.BrowserOperationInteract)
+	defer cancel()
 	previewID, claims, ok := h.authorizePreviewAction(w, r, "interact")
 	if !ok {
 		return
@@ -577,6 +631,8 @@ func bindClaimedSessionBrowser(inspector previewsvc.PreviewInspector, previewID 
 }
 
 func (h *InternalPreviewHandler) CaptureMultiViewport(w http.ResponseWriter, r *http.Request) {
+	r, cancel := withWorkerBrowserOperation(w, r, previewsvc.BrowserOperationMultiViewport)
+	defer cancel()
 	previewID, claims, ok := h.authorizePreviewAction(w, r, "multi_viewport")
 	if !ok {
 		return
@@ -601,6 +657,8 @@ func (h *InternalPreviewHandler) CaptureMultiViewport(w http.ResponseWriter, r *
 }
 
 func (h *InternalPreviewHandler) ComputeVisualDiff(w http.ResponseWriter, r *http.Request) {
+	r, cancel := withWorkerBrowserOperation(w, r, previewsvc.BrowserOperationVisualDiff)
+	defer cancel()
 	previewID, claims, ok := h.authorizePreviewAction(w, r, "visual_diff")
 	if !ok {
 		return
@@ -625,6 +683,8 @@ func (h *InternalPreviewHandler) ComputeVisualDiff(w http.ResponseWriter, r *htt
 }
 
 func (h *InternalPreviewHandler) RunAssertions(w http.ResponseWriter, r *http.Request) {
+	r, cancel := withWorkerBrowserOperation(w, r, previewsvc.BrowserOperationAssertions)
+	defer cancel()
 	previewID, claims, ok := h.authorizePreviewAction(w, r, "assert")
 	if !ok {
 		return
@@ -776,6 +836,7 @@ func addInternalPreviewRequestLogFields(event *zerolog.Event, r *http.Request) *
 	requestHost := ""
 	requestPath := ""
 	queryPresent := false
+	parentRequestID := ""
 	if r != nil {
 		requestMethod = r.Method
 		requestHost = r.Host
@@ -783,12 +844,17 @@ func addInternalPreviewRequestLogFields(event *zerolog.Event, r *http.Request) *
 			requestPath = r.URL.Path
 			queryPresent = r.URL.RawQuery != ""
 		}
+		parentRequestID = internalapi.NormalizeParentRequestID(r.Header.Get(internalapi.ParentRequestIDHeader))
 	}
-	return event.
+	event = event.
 		Str("request_method", requestMethod).
 		Str("request_host", requestHost).
 		Str("request_path", requestPath).
 		Bool("query_present", queryPresent)
+	if parentRequestID != "" {
+		event = event.Str("parent_request_id", parentRequestID)
+	}
+	return event
 }
 
 func addPreviewTokenClaimLogFields(event *zerolog.Event, claims *auth.PreviewTokenClaims) *zerolog.Event {

--- a/internal/api/handlers/internal_preview.go
+++ b/internal/api/handlers/internal_preview.go
@@ -420,7 +420,7 @@ func (h *InternalPreviewHandler) CaptureScreenshot(w http.ResponseWriter, r *htt
 }
 
 func (h *InternalPreviewHandler) Observe(w http.ResponseWriter, r *http.Request) {
-	r, cancel := withWorkerBrowserOperation(w, r, previewsvc.BrowserOperationObserve)
+	r, cancel := withWorkerBrowserOperation(w, r, previewsvc.BrowserOperationSessionObserve)
 	defer cancel()
 	previewID, claims, ok := h.authorizePreviewAction(w, r, "observe")
 	if !ok {
@@ -451,7 +451,7 @@ func (h *InternalPreviewHandler) Observe(w http.ResponseWriter, r *http.Request)
 }
 
 func (h *InternalPreviewHandler) Act(w http.ResponseWriter, r *http.Request) {
-	r, cancel := withWorkerBrowserOperation(w, r, previewsvc.BrowserOperationInteract)
+	r, cancel := withWorkerBrowserOperation(w, r, previewsvc.BrowserOperationSessionAct)
 	defer cancel()
 	previewID, claims, ok := h.authorizePreviewAction(w, r, "act")
 	if !ok {
@@ -482,7 +482,7 @@ func (h *InternalPreviewHandler) Act(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *InternalPreviewHandler) HumanAct(w http.ResponseWriter, r *http.Request) {
-	r, cancel := withWorkerBrowserOperation(w, r, previewsvc.BrowserOperationInteract)
+	r, cancel := withWorkerBrowserOperation(w, r, previewsvc.BrowserOperationSessionAct)
 	defer cancel()
 	middleware.OrgIDFromContext(r.Context())
 	previewID, claims, ok := h.authorizePreviewAction(w, r, "human_act")
@@ -515,6 +515,9 @@ func (h *InternalPreviewHandler) HumanAct(w http.ResponseWriter, r *http.Request
 func writeBrowserSessionError(w http.ResponseWriter, r *http.Request, err error) {
 	if accessErr, ok := previewsvc.AsBrowserAccessError(err); ok {
 		logContext := zerolog.Ctx(r.Context()).With().Str("browser_stage", string(accessErr.Stage))
+		if accessErr.PrecedingStage != "" {
+			logContext = logContext.Str("browser_preceding_stage", string(accessErr.PrecedingStage))
+		}
 		if elapsed := browserOperationElapsed(r); elapsed > 0 {
 			logContext = logContext.Dur("browser_elapsed", elapsed)
 		}
@@ -528,7 +531,11 @@ func writeBrowserSessionError(w http.ResponseWriter, r *http.Request, err error)
 		}
 		logger := logContext.Logger()
 		r = r.WithContext(logger.WithContext(r.Context()))
-		writeErrorWithDetails(w, r, http.StatusInternalServerError, accessErr.Code(), "preview browser access failed", map[string]string{"stage": string(accessErr.Stage)}, err)
+		details := map[string]string{"stage": string(accessErr.Stage)}
+		if accessErr.PrecedingStage != "" {
+			details["preceding_stage"] = string(accessErr.PrecedingStage)
+		}
+		writeErrorWithDetails(w, r, http.StatusInternalServerError, accessErr.Code(), "preview browser access failed", details, err)
 		return
 	}
 	switch {

--- a/internal/api/handlers/internal_preview.go
+++ b/internal/api/handlers/internal_preview.go
@@ -844,7 +844,7 @@ func addInternalPreviewRequestLogFields(event *zerolog.Event, r *http.Request) *
 			requestPath = r.URL.Path
 			queryPresent = r.URL.RawQuery != ""
 		}
-		parentRequestID = internalapi.NormalizeParentRequestID(r.Header.Get(internalapi.ParentRequestIDHeader))
+		parentRequestID = internalapi.TrustedParentRequestID(r)
 	}
 	event = event.
 		Str("request_method", requestMethod).

--- a/internal/api/handlers/internal_preview_test.go
+++ b/internal/api/handlers/internal_preview_test.go
@@ -855,19 +855,45 @@ func TestInternalPreviewHandler_BrowserSessionMismatch(t *testing.T) {
 func TestWriteBrowserSessionError_ReturnsSafeBootstrapStage(t *testing.T) {
 	t.Parallel()
 
-	req := httptest.NewRequest(http.MethodPost, "/internal/preview/preview-id/observe", nil)
-	req = withPreviewRouteParam(req, "preview-id")
-	rr := httptest.NewRecorder()
-	secretCause := errors.New("exchange rejected token=must-not-leak")
+	tests := []struct {
+		name        string
+		error       *previewsvc.BrowserAccessError
+		wantDetails map[string]any
+	}{
+		{
+			name:        "single bootstrap failure",
+			error:       &previewsvc.BrowserAccessError{Stage: previewsvc.BrowserAccessStageBootstrapExchange, Err: errors.New("exchange rejected token=must-not-leak")},
+			wantDetails: map[string]any{"stage": "bootstrap_exchange"},
+		},
+		{
+			name: "bootstrap recovery failure after state restore",
+			error: &previewsvc.BrowserAccessError{
+				Stage:          previewsvc.BrowserAccessStageBootstrapExchange,
+				PrecedingStage: previewsvc.BrowserAccessStageStateRestore,
+				Err:            errors.New("exchange rejected cookie=must-not-leak"),
+			},
+			wantDetails: map[string]any{"stage": "bootstrap_exchange", "preceding_stage": "state_restore"},
+		},
+	}
 
-	writeBrowserSessionError(rr, req, &previewsvc.BrowserAccessError{Stage: previewsvc.BrowserAccessStageBootstrapExchange, Err: secretCause})
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 
-	require.Equal(t, http.StatusInternalServerError, rr.Code, "bootstrap stage failure should return a server error")
-	var resp models.ErrorResponse
-	require.NoError(t, json.NewDecoder(rr.Body).Decode(&resp), "bootstrap stage failure should return JSON")
-	require.Equal(t, "PREVIEW_BROWSER_BOOTSTRAP_EXCHANGE_FAILED", resp.Error.Code, "bootstrap stage should have a stable public code")
-	require.Equal(t, map[string]any{"stage": "bootstrap_exchange"}, resp.Error.Details, "bootstrap response should expose only the safe stage")
-	require.NotContains(t, rr.Body.String(), "must-not-leak", "bootstrap response should never include the underlying token or cookie error")
+			req := httptest.NewRequest(http.MethodPost, "/internal/preview/preview-id/observe", nil)
+			req = withPreviewRouteParam(req, "preview-id")
+			rr := httptest.NewRecorder()
+
+			writeBrowserSessionError(rr, req, tt.error)
+
+			require.Equal(t, http.StatusInternalServerError, rr.Code, "bootstrap stage failure should return a server error")
+			var resp models.ErrorResponse
+			require.NoError(t, json.NewDecoder(rr.Body).Decode(&resp), "bootstrap stage failure should return JSON")
+			require.Equal(t, "PREVIEW_BROWSER_BOOTSTRAP_EXCHANGE_FAILED", resp.Error.Code, "bootstrap stage should have a stable public code")
+			require.Equal(t, tt.wantDetails, resp.Error.Details, "bootstrap response should expose only safe structured stages")
+			require.NotContains(t, rr.Body.String(), "must-not-leak", "bootstrap response should never include the underlying token or cookie error")
+		})
+	}
 }
 
 func TestInternalPreviewHandler_InspectorEndpoints_RejectInvalidBodiesAndSurfaceFailures(t *testing.T) {

--- a/internal/api/handlers/internal_preview_test.go
+++ b/internal/api/handlers/internal_preview_test.go
@@ -852,6 +852,24 @@ func TestInternalPreviewHandler_BrowserSessionMismatch(t *testing.T) {
 	}
 }
 
+func TestWriteBrowserSessionError_ReturnsSafeBootstrapStage(t *testing.T) {
+	t.Parallel()
+
+	req := httptest.NewRequest(http.MethodPost, "/internal/preview/preview-id/observe", nil)
+	req = withPreviewRouteParam(req, "preview-id")
+	rr := httptest.NewRecorder()
+	secretCause := errors.New("exchange rejected token=must-not-leak")
+
+	writeBrowserSessionError(rr, req, &previewsvc.BrowserAccessError{Stage: previewsvc.BrowserAccessStageBootstrapExchange, Err: secretCause})
+
+	require.Equal(t, http.StatusInternalServerError, rr.Code, "bootstrap stage failure should return a server error")
+	var resp models.ErrorResponse
+	require.NoError(t, json.NewDecoder(rr.Body).Decode(&resp), "bootstrap stage failure should return JSON")
+	require.Equal(t, "PREVIEW_BROWSER_BOOTSTRAP_EXCHANGE_FAILED", resp.Error.Code, "bootstrap stage should have a stable public code")
+	require.Equal(t, map[string]any{"stage": "bootstrap_exchange"}, resp.Error.Details, "bootstrap response should expose only the safe stage")
+	require.NotContains(t, rr.Body.String(), "must-not-leak", "bootstrap response should never include the underlying token or cookie error")
+}
+
 func TestInternalPreviewHandler_InspectorEndpoints_RejectInvalidBodiesAndSurfaceFailures(t *testing.T) {
 	t.Parallel()
 

--- a/internal/api/handlers/preview.go
+++ b/internal/api/handlers/preview.go
@@ -138,6 +138,7 @@ type previewHTTPError struct {
 	status  int
 	code    string
 	message string
+	details any
 	err     error
 }
 
@@ -188,15 +189,58 @@ func newPreviewHTTPError(status int, code, message string, err error) *previewHT
 	return &previewHTTPError{status: status, code: code, message: message, err: err}
 }
 
+func newPreviewHTTPErrorWithDetails(status int, code, message string, details any, err error) *previewHTTPError {
+	return &previewHTTPError{status: status, code: code, message: message, details: details, err: err}
+}
+
 func writePreviewHTTPError(w http.ResponseWriter, r *http.Request, err *previewHTTPError) {
 	if err == nil {
 		return
 	}
+	if stage := browserStageFromDetails(err.details); stage != "" {
+		logContext := zerolog.Ctx(r.Context()).With().Str("browser_stage", stage)
+		if previewID := chi.URLParam(r, "preview_id"); previewID != "" {
+			logContext = logContext.Str("preview_id", previewID)
+		}
+		if sessionID := chi.URLParam(r, "id"); sessionID != "" {
+			logContext = logContext.Str("session_id", sessionID)
+		}
+		if elapsed := browserOperationElapsed(r); elapsed > 0 {
+			logContext = logContext.Dur("browser_elapsed", elapsed)
+		}
+		logger := logContext.Logger()
+		r = r.WithContext(logger.WithContext(r.Context()))
+	}
 	if err.err != nil {
-		writeError(w, r, err.status, err.code, err.message, err.err)
+		writeErrorWithDetails(w, r, err.status, err.code, err.message, err.details, err.err)
 		return
 	}
-	writeError(w, r, err.status, err.code, err.message)
+	writeErrorWithDetails(w, r, err.status, err.code, err.message, err.details)
+}
+
+func withAPIBrowserOperation(w http.ResponseWriter, r *http.Request, operation preview.BrowserOperation) *http.Request {
+	setResponseWriteDeadline(w, r, preview.BrowserOperationBudgetFor(operation).APIResponse)
+	return withBrowserOperationStart(r)
+}
+
+func browserHandlerTimeout(workerRouting bool, operation preview.BrowserOperation) time.Duration {
+	budget := preview.BrowserOperationBudgetFor(operation)
+	if workerRouting {
+		return budget.WorkerRequest
+	}
+	return budget.Operation
+}
+
+func browserStageFromDetails(details any) string {
+	switch value := details.(type) {
+	case map[string]any:
+		stage, _ := value["stage"].(string)
+		return stage
+	case map[string]string:
+		return value["stage"]
+	default:
+		return ""
+	}
 }
 
 func (h *PreviewHandler) workerRoutingEnabled() bool {
@@ -208,14 +252,30 @@ func (h *PreviewHandler) isLocalWorker(worker preview.WorkerNode) bool {
 }
 
 func (h *PreviewHandler) writeWorkerClientError(w http.ResponseWriter, r *http.Request, err error) {
+	if reqErr, ok := preview.AsWorkerRequestError(err); ok && reqErr.WorkerNodeID != "" {
+		logger := zerolog.Ctx(r.Context()).With().Str("worker_node_id", reqErr.WorkerNodeID).Logger()
+		r = r.WithContext(logger.WithContext(r.Context()))
+	}
 	writePreviewHTTPError(w, r, workerClientHTTPError(err))
 }
 
 func workerClientHTTPError(err error) *previewHTTPError {
 	if reqErr, ok := preview.AsWorkerRequestError(err); ok {
-		return newPreviewHTTPError(reqErr.StatusCode, reqErr.Code, reqErr.Message, nil)
+		return newPreviewHTTPErrorWithDetails(reqErr.StatusCode, reqErr.Code, reqErr.Message, safeWorkerBrowserDetails(reqErr.Code, reqErr.Details), nil)
 	}
 	return newPreviewHTTPError(http.StatusBadGateway, "PREVIEW_WORKER_REQUEST_FAILED", "preview worker request failed", err)
+}
+
+func safeWorkerBrowserDetails(code string, details any) any {
+	stage := browserStageFromDetails(details)
+	if stage == "" {
+		return nil
+	}
+	accessErr := &preview.BrowserAccessError{Stage: preview.BrowserAccessStage(stage)}
+	if accessErr.Code() != code || accessErr.Code() == "PREVIEW_BROWSER_ACCESS_FAILED" {
+		return nil
+	}
+	return map[string]string{"stage": stage}
 }
 
 // =============================================================================
@@ -2652,6 +2712,7 @@ func (h *PreviewHandler) WatchBrowser(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *PreviewHandler) observePreview(w http.ResponseWriter, r *http.Request, body observePreviewRequest) {
+	r = withAPIBrowserOperation(w, r, preview.BrowserOperationObserve)
 	orgID := middleware.OrgIDFromContext(r.Context())
 	instance, ok := h.getPreviewTarget(w, r)
 	if !ok {
@@ -2701,6 +2762,7 @@ func (h *PreviewHandler) observePreview(w http.ResponseWriter, r *http.Request, 
 }
 
 func (h *PreviewHandler) Act(w http.ResponseWriter, r *http.Request) {
+	r = withAPIBrowserOperation(w, r, preview.BrowserOperationInteract)
 	orgID := middleware.OrgIDFromContext(r.Context())
 	instance, ok := h.getPreviewTarget(w, r)
 	if !ok {
@@ -2722,7 +2784,7 @@ func (h *PreviewHandler) Act(w http.ResponseWriter, r *http.Request) {
 	normalizeInteractionStepTimeouts(body.Steps)
 	opts := models.PreviewObservationOpts{ScreenshotOpts: models.ScreenshotOpts{ViewportW: body.ViewportW, ViewportH: body.ViewportH}, Selector: body.Selector, IncludeDOM: body.IncludeDOM, MaxSemanticBytes: body.MaxSemanticBytes, ConsoleCursor: body.ConsoleCursor}
 	policy := browserPolicyForInstance(instance)
-	ctx, cancel := context.WithTimeout(r.Context(), maxInteractionDuration)
+	ctx, cancel := context.WithTimeout(r.Context(), browserHandlerTimeout(h.workerRoutingEnabled(), preview.BrowserOperationInteract))
 	defer cancel()
 	var result *models.PreviewActResult
 	var err error
@@ -2873,6 +2935,7 @@ func (h *PreviewHandler) changeBrowserControl(w http.ResponseWriter, r *http.Req
 }
 
 func (h *PreviewHandler) HumanAct(w http.ResponseWriter, r *http.Request) {
+	r = withAPIBrowserOperation(w, r, preview.BrowserOperationInteract)
 	orgID := middleware.OrgIDFromContext(r.Context())
 	instance, ok := h.getPreviewTarget(w, r)
 	if !ok {
@@ -2895,7 +2958,7 @@ func (h *PreviewHandler) HumanAct(w http.ResponseWriter, r *http.Request) {
 	normalizeInteractionStepTimeouts(body.Steps)
 	opts := models.PreviewObservationOpts{ScreenshotOpts: models.ScreenshotOpts{ViewportW: body.ViewportW, ViewportH: body.ViewportH}, Selector: body.Selector, IncludeDOM: body.IncludeDOM, MaxSemanticBytes: body.MaxSemanticBytes, ConsoleCursor: body.ConsoleCursor}
 	policy := browserPolicyForInstance(instance)
-	ctx, cancel := context.WithTimeout(r.Context(), maxInteractionDuration)
+	ctx, cancel := context.WithTimeout(r.Context(), browserHandlerTimeout(h.workerRoutingEnabled(), preview.BrowserOperationInteract))
 	defer cancel()
 	var result *models.PreviewActResult
 	var err error
@@ -2991,6 +3054,7 @@ func (h *PreviewHandler) emitPreviewToolAudit(r *http.Request, action models.Aud
 }
 
 func (h *PreviewHandler) CaptureScreenshot(w http.ResponseWriter, r *http.Request) {
+	r = withAPIBrowserOperation(w, r, preview.BrowserOperationScreenshot)
 	if !h.workerRoutingEnabled() {
 		if _, ok := h.requireInspector(w, r); !ok {
 			return
@@ -3116,6 +3180,7 @@ type inspectElementRequest struct {
 }
 
 func (h *PreviewHandler) InspectElement(w http.ResponseWriter, r *http.Request) {
+	r = withAPIBrowserOperation(w, r, preview.BrowserOperationInspect)
 	if !h.workerRoutingEnabled() {
 		if _, ok := h.requireInspector(w, r); !ok {
 			return
@@ -3308,9 +3373,8 @@ func (h *PreviewHandler) SubmitDesignFeedback(w http.ResponseWriter, r *http.Req
 // =============================================================================
 
 const (
-	maxInteractionSteps    = 20
-	maxInteractionDuration = 60 * time.Second
-	maxAssertions          = 50
+	maxInteractionSteps = 20
+	maxAssertions       = 50
 )
 
 type executeInteractionRequest struct {
@@ -3318,6 +3382,7 @@ type executeInteractionRequest struct {
 }
 
 func (h *PreviewHandler) ExecuteInteraction(w http.ResponseWriter, r *http.Request) {
+	r = withAPIBrowserOperation(w, r, preview.BrowserOperationInteract)
 	if !h.workerRoutingEnabled() {
 		if _, ok := h.requireInspector(w, r); !ok {
 			return
@@ -3346,7 +3411,7 @@ func (h *PreviewHandler) ExecuteInteraction(w http.ResponseWriter, r *http.Reque
 	normalizeInteractionStepTimeouts(body.Steps)
 
 	// Enforce the max total duration per the design doc (60 seconds).
-	ctx, cancel := context.WithTimeout(r.Context(), maxInteractionDuration)
+	ctx, cancel := context.WithTimeout(r.Context(), browserHandlerTimeout(h.workerRoutingEnabled(), preview.BrowserOperationInteract))
 	defer cancel()
 	if instance.SessionID != uuid.Nil && h.browserSessions != nil {
 		orgID := middleware.OrgIDFromContext(r.Context())
@@ -3468,6 +3533,7 @@ type captureMultiViewportRequest struct {
 }
 
 func (h *PreviewHandler) CaptureMultiViewport(w http.ResponseWriter, r *http.Request) {
+	r = withAPIBrowserOperation(w, r, preview.BrowserOperationMultiViewport)
 	if !h.workerRoutingEnabled() {
 		if _, ok := h.requireInspector(w, r); !ok {
 			return
@@ -3573,6 +3639,7 @@ type computeVisualDiffRequest struct {
 }
 
 func (h *PreviewHandler) ComputeVisualDiff(w http.ResponseWriter, r *http.Request) {
+	r = withAPIBrowserOperation(w, r, preview.BrowserOperationVisualDiff)
 	if !h.workerRoutingEnabled() {
 		if _, ok := h.requireInspector(w, r); !ok {
 			return
@@ -3645,6 +3712,7 @@ type runAssertionsRequest struct {
 }
 
 func (h *PreviewHandler) RunAssertions(w http.ResponseWriter, r *http.Request) {
+	r = withAPIBrowserOperation(w, r, preview.BrowserOperationAssertions)
 	if !h.workerRoutingEnabled() {
 		if _, ok := h.requireInspector(w, r); !ok {
 			return

--- a/internal/api/handlers/preview.go
+++ b/internal/api/handlers/preview.go
@@ -3410,7 +3410,9 @@ func (h *PreviewHandler) ExecuteInteraction(w http.ResponseWriter, r *http.Reque
 	}
 	normalizeInteractionStepTimeouts(body.Steps)
 
-	// Enforce the max total duration per the design doc (60 seconds).
+	// Enforce the max total duration per the design doc (60 seconds), plus
+	// worker-hop headroom when the interaction is routed to another node so the
+	// worker's own 60s budget expires first and returns a structured error.
 	ctx, cancel := context.WithTimeout(r.Context(), browserHandlerTimeout(h.workerRoutingEnabled(), preview.BrowserOperationInteract))
 	defer cancel()
 	if instance.SessionID != uuid.Nil && h.browserSessions != nil {

--- a/internal/api/handlers/preview.go
+++ b/internal/api/handlers/preview.go
@@ -3410,9 +3410,10 @@ func (h *PreviewHandler) ExecuteInteraction(w http.ResponseWriter, r *http.Reque
 	}
 	normalizeInteractionStepTimeouts(body.Steps)
 
-	// Enforce the max total duration per the design doc (60 seconds), plus
-	// worker-hop headroom when the interaction is routed to another node so the
-	// worker's own 60s budget expires first and returns a structured error.
+	// Bound the whole interaction: the design doc's 60s cap applies to the step
+	// loop, and the budget adds room for the observation Act performs after the
+	// steps. Routed interactions get worker-hop headroom on top so the worker's
+	// own budget expires first and returns a structured error.
 	ctx, cancel := context.WithTimeout(r.Context(), browserHandlerTimeout(h.workerRoutingEnabled(), preview.BrowserOperationInteract))
 	defer cancel()
 	if instance.SessionID != uuid.Nil && h.browserSessions != nil {

--- a/internal/api/handlers/preview.go
+++ b/internal/api/handlers/preview.go
@@ -197,8 +197,11 @@ func writePreviewHTTPError(w http.ResponseWriter, r *http.Request, err *previewH
 	if err == nil {
 		return
 	}
-	if stage := browserStageFromDetails(err.details); stage != "" {
+	if stage := browserDetailString(err.details, "stage"); stage != "" {
 		logContext := zerolog.Ctx(r.Context()).With().Str("browser_stage", stage)
+		if preceding := browserDetailString(err.details, "preceding_stage"); preceding != "" {
+			logContext = logContext.Str("browser_preceding_stage", preceding)
+		}
 		if previewID := chi.URLParam(r, "preview_id"); previewID != "" {
 			logContext = logContext.Str("preview_id", previewID)
 		}
@@ -219,25 +222,73 @@ func writePreviewHTTPError(w http.ResponseWriter, r *http.Request, err *previewH
 }
 
 func withAPIBrowserOperation(w http.ResponseWriter, r *http.Request, operation preview.BrowserOperation) *http.Request {
-	setResponseWriteDeadline(w, r, preview.BrowserOperationBudgetFor(operation).APIResponse)
+	setAPIBrowserResponseDeadline(w, r, operation)
 	return withBrowserOperationStart(r)
 }
 
-func browserHandlerTimeout(workerRouting bool, operation preview.BrowserOperation) time.Duration {
+func setAPIBrowserResponseDeadline(w http.ResponseWriter, r *http.Request, operation preview.BrowserOperation) {
+	setResponseWriteDeadline(w, r, preview.BrowserOperationBudgetFor(operation).APIResponse)
+}
+
+func setAPICoordinatedBrowserResponseDeadline(w http.ResponseWriter, r *http.Request, operation preview.BrowserOperation) {
+	setResponseWriteDeadline(w, r, preview.CoordinatedBrowserOperationAPIResponseTimeoutFor(operation))
+}
+
+// browserHandlerTimeout bounds a browser handler. Only a call that actually
+// leaves this process earns the worker-hop headroom; work executed in-process
+// keeps the plain operation budget so the documented ceiling stays honest.
+func browserHandlerTimeout(remote bool, operation preview.BrowserOperation) time.Duration {
 	budget := preview.BrowserOperationBudgetFor(operation)
-	if workerRouting {
+	if remote {
 		return budget.WorkerRequest
 	}
 	return budget.Operation
 }
 
-func browserStageFromDetails(details any) string {
+const browserWorkerResolutionTimeout = 15 * time.Second
+
+// resolveBrowserWorker resolves where a browser operation will execute, so the
+// handler can size its timeout to the real topology rather than to whether
+// worker routing happens to be enabled process-wide. The returned bool reports
+// whether the operation leaves this process. canRunLocally lets a caller say it
+// has no in-process executor, in which case even a local worker is reached over
+// loopback HTTP and does deserve the hop headroom.
+func (h *PreviewHandler) resolveBrowserWorker(w http.ResponseWriter, r *http.Request, workerNodeID string, canRunLocally bool) (preview.WorkerNode, bool, bool) {
+	if !h.workerRoutingEnabled() {
+		return preview.WorkerNode{}, false, true
+	}
+	resolveCtx, cancel := context.WithTimeout(r.Context(), browserWorkerResolutionTimeout)
+	defer cancel()
+	worker, err := h.resolvePreviewWorker(resolveCtx, workerNodeID)
+	if err != nil {
+		writeError(w, r, http.StatusBadGateway, "PREVIEW_WORKER_RESOLUTION_FAILED", "failed to resolve preview worker", err)
+		return preview.WorkerNode{}, false, false
+	}
+	return worker, !canRunLocally || !h.isLocalWorker(worker), true
+}
+
+func (h *PreviewHandler) prepareBrowserExecution(w http.ResponseWriter, r *http.Request, workerNodeID string, canRunLocally bool, operation preview.BrowserOperation) (preview.WorkerNode, bool, bool) {
+	// Re-arm after target lookup and request parsing so a bounded resolution
+	// failure still has time to return a structured error response.
+	setAPIBrowserResponseDeadline(w, r, operation)
+	worker, remote, resolved := h.resolveBrowserWorker(w, r, workerNodeID, canRunLocally)
+	if !resolved {
+		return preview.WorkerNode{}, false, false
+	}
+	// Refresh again after bounded worker resolution so none of that preflight
+	// consumes the response headroom reserved for the actual local operation or
+	// worker request.
+	setAPIBrowserResponseDeadline(w, r, operation)
+	return worker, remote, true
+}
+
+func browserDetailString(details any, key string) string {
 	switch value := details.(type) {
 	case map[string]any:
-		stage, _ := value["stage"].(string)
-		return stage
+		field, _ := value[key].(string)
+		return field
 	case map[string]string:
-		return value["stage"]
+		return value[key]
 	default:
 		return ""
 	}
@@ -267,7 +318,7 @@ func workerClientHTTPError(err error) *previewHTTPError {
 }
 
 func safeWorkerBrowserDetails(code string, details any) any {
-	stage := browserStageFromDetails(details)
+	stage := browserDetailString(details, "stage")
 	if stage == "" {
 		return nil
 	}
@@ -275,7 +326,17 @@ func safeWorkerBrowserDetails(code string, details any) any {
 	if accessErr.Code() != code || accessErr.Code() == "PREVIEW_BROWSER_ACCESS_FAILED" {
 		return nil
 	}
-	return map[string]string{"stage": stage}
+	safe := map[string]string{"stage": stage}
+	// The preceding stage is diagnostic metadata from the same closed set, so
+	// it is safe to forward -- but only after the worker's value is confirmed
+	// to be a stage this build knows, never as an opaque passthrough.
+	if preceding := browserDetailString(details, "preceding_stage"); preceding != "" {
+		precedingErr := &preview.BrowserAccessError{Stage: preview.BrowserAccessStage(preceding)}
+		if precedingErr.Code() != "PREVIEW_BROWSER_ACCESS_FAILED" {
+			safe["preceding_stage"] = preceding
+		}
+	}
+	return safe
 }
 
 // =============================================================================
@@ -2712,7 +2773,7 @@ func (h *PreviewHandler) WatchBrowser(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *PreviewHandler) observePreview(w http.ResponseWriter, r *http.Request, body observePreviewRequest) {
-	r = withAPIBrowserOperation(w, r, preview.BrowserOperationObserve)
+	r = withAPIBrowserOperation(w, r, preview.BrowserOperationSessionObserve)
 	orgID := middleware.OrgIDFromContext(r.Context())
 	instance, ok := h.getPreviewTarget(w, r)
 	if !ok {
@@ -2724,22 +2785,20 @@ func (h *PreviewHandler) observePreview(w http.ResponseWriter, r *http.Request, 
 	}
 	opts := models.PreviewObservationOpts{ScreenshotOpts: models.ScreenshotOpts{Path: body.Path, ViewportW: body.ViewportW, ViewportH: body.ViewportH, FullPage: body.FullPage, Delay: time.Duration(body.DelayMS) * time.Millisecond}, Selector: body.Selector, IncludeDOM: body.IncludeDOM, MaxSemanticBytes: body.MaxSemanticBytes, ConsoleCursor: body.ConsoleCursor, PreserveConsoleCursor: body.PreserveConsoleCursor, ReadOnly: body.ReadOnly, SkipSemantic: body.SkipSemantic}
 	policy := browserPolicyForInstance(instance)
+	worker, remote, resolved := h.prepareBrowserExecution(w, r, instance.WorkerNodeID, h.browserSessions != nil, preview.BrowserOperationSessionObserve)
+	if !resolved {
+		return
+	}
+	ctx, cancel := context.WithTimeout(r.Context(), browserHandlerTimeout(remote, preview.BrowserOperationSessionObserve))
+	defer cancel()
 	var result *models.PreviewObservation
 	var err error
-	if h.workerRoutingEnabled() {
-		worker, resolveErr := h.resolvePreviewWorker(r.Context(), instance.WorkerNodeID)
-		if resolveErr != nil {
-			writeError(w, r, http.StatusBadGateway, "PREVIEW_WORKER_RESOLUTION_FAILED", "failed to resolve preview worker", resolveErr)
-			return
-		}
-		if h.isLocalWorker(worker) && h.browserSessions != nil {
-			result, err = h.browserSessions.Observe(r.Context(), orgID, instance.SessionID, instance.ID, policy, opts)
-		} else {
-			result, err = h.workerClient.Observe(r.Context(), worker, orgID, instance.SessionID, instance.ID, preview.RemoteObserveRequest{SessionID: instance.SessionID, Policy: policy, Options: opts})
-		}
-	} else if h.browserSessions != nil {
-		result, err = h.browserSessions.Observe(r.Context(), orgID, instance.SessionID, instance.ID, policy, opts)
-	} else {
+	switch {
+	case remote:
+		result, err = h.workerClient.Observe(ctx, worker, orgID, instance.SessionID, instance.ID, preview.RemoteObserveRequest{SessionID: instance.SessionID, Policy: policy, Options: opts})
+	case h.browserSessions != nil:
+		result, err = h.browserSessions.Observe(ctx, orgID, instance.SessionID, instance.ID, policy, opts)
+	default:
 		err = preview.ErrBrowserUnavailable
 	}
 	if err != nil {
@@ -2762,7 +2821,7 @@ func (h *PreviewHandler) observePreview(w http.ResponseWriter, r *http.Request, 
 }
 
 func (h *PreviewHandler) Act(w http.ResponseWriter, r *http.Request) {
-	r = withAPIBrowserOperation(w, r, preview.BrowserOperationInteract)
+	r = withAPIBrowserOperation(w, r, preview.BrowserOperationSessionAct)
 	orgID := middleware.OrgIDFromContext(r.Context())
 	instance, ok := h.getPreviewTarget(w, r)
 	if !ok {
@@ -2784,24 +2843,20 @@ func (h *PreviewHandler) Act(w http.ResponseWriter, r *http.Request) {
 	normalizeInteractionStepTimeouts(body.Steps)
 	opts := models.PreviewObservationOpts{ScreenshotOpts: models.ScreenshotOpts{ViewportW: body.ViewportW, ViewportH: body.ViewportH}, Selector: body.Selector, IncludeDOM: body.IncludeDOM, MaxSemanticBytes: body.MaxSemanticBytes, ConsoleCursor: body.ConsoleCursor}
 	policy := browserPolicyForInstance(instance)
-	ctx, cancel := context.WithTimeout(r.Context(), browserHandlerTimeout(h.workerRoutingEnabled(), preview.BrowserOperationInteract))
+	worker, remote, resolved := h.prepareBrowserExecution(w, r, instance.WorkerNodeID, h.browserSessions != nil, preview.BrowserOperationSessionAct)
+	if !resolved {
+		return
+	}
+	ctx, cancel := context.WithTimeout(r.Context(), browserHandlerTimeout(remote, preview.BrowserOperationSessionAct))
 	defer cancel()
 	var result *models.PreviewActResult
 	var err error
-	if h.workerRoutingEnabled() {
-		worker, resolveErr := h.resolvePreviewWorker(ctx, instance.WorkerNodeID)
-		if resolveErr != nil {
-			writeError(w, r, http.StatusBadGateway, "PREVIEW_WORKER_RESOLUTION_FAILED", "failed to resolve preview worker", resolveErr)
-			return
-		}
-		if h.isLocalWorker(worker) && h.browserSessions != nil {
-			result, err = h.browserSessions.Act(ctx, orgID, instance.SessionID, instance.ID, policy, body.Steps, opts)
-		} else {
-			result, err = h.workerClient.Act(ctx, worker, orgID, instance.SessionID, instance.ID, preview.RemoteActRequest{SessionID: instance.SessionID, Policy: policy, Steps: body.Steps, Options: opts})
-		}
-	} else if h.browserSessions != nil {
+	switch {
+	case remote:
+		result, err = h.workerClient.Act(ctx, worker, orgID, instance.SessionID, instance.ID, preview.RemoteActRequest{SessionID: instance.SessionID, Policy: policy, Steps: body.Steps, Options: opts})
+	case h.browserSessions != nil:
 		result, err = h.browserSessions.Act(ctx, orgID, instance.SessionID, instance.ID, policy, body.Steps, opts)
-	} else {
+	default:
 		err = preview.ErrBrowserUnavailable
 	}
 	if err != nil {
@@ -2935,7 +2990,7 @@ func (h *PreviewHandler) changeBrowserControl(w http.ResponseWriter, r *http.Req
 }
 
 func (h *PreviewHandler) HumanAct(w http.ResponseWriter, r *http.Request) {
-	r = withAPIBrowserOperation(w, r, preview.BrowserOperationInteract)
+	r = withAPIBrowserOperation(w, r, preview.BrowserOperationSessionAct)
 	orgID := middleware.OrgIDFromContext(r.Context())
 	instance, ok := h.getPreviewTarget(w, r)
 	if !ok {
@@ -2958,24 +3013,20 @@ func (h *PreviewHandler) HumanAct(w http.ResponseWriter, r *http.Request) {
 	normalizeInteractionStepTimeouts(body.Steps)
 	opts := models.PreviewObservationOpts{ScreenshotOpts: models.ScreenshotOpts{ViewportW: body.ViewportW, ViewportH: body.ViewportH}, Selector: body.Selector, IncludeDOM: body.IncludeDOM, MaxSemanticBytes: body.MaxSemanticBytes, ConsoleCursor: body.ConsoleCursor}
 	policy := browserPolicyForInstance(instance)
-	ctx, cancel := context.WithTimeout(r.Context(), browserHandlerTimeout(h.workerRoutingEnabled(), preview.BrowserOperationInteract))
+	worker, remote, resolved := h.prepareBrowserExecution(w, r, instance.WorkerNodeID, h.browserSessions != nil, preview.BrowserOperationSessionAct)
+	if !resolved {
+		return
+	}
+	ctx, cancel := context.WithTimeout(r.Context(), browserHandlerTimeout(remote, preview.BrowserOperationSessionAct))
 	defer cancel()
 	var result *models.PreviewActResult
 	var err error
-	if h.workerRoutingEnabled() {
-		worker, resolveErr := h.resolvePreviewWorker(ctx, instance.WorkerNodeID)
-		if resolveErr != nil {
-			writeError(w, r, http.StatusBadGateway, "PREVIEW_WORKER_RESOLUTION_FAILED", "failed to resolve preview worker", resolveErr)
-			return
-		}
-		if h.isLocalWorker(worker) && h.browserSessions != nil {
-			result, err = h.browserSessions.ActAsHuman(ctx, orgID, instance.SessionID, instance.ID, user.ID, policy, body.Steps, opts)
-		} else {
-			result, err = h.workerClient.ActAsHuman(ctx, worker, orgID, instance.SessionID, instance.ID, user.ID, preview.RemoteActRequest{SessionID: instance.SessionID, Policy: policy, Steps: body.Steps, Options: opts})
-		}
-	} else if h.browserSessions != nil {
+	switch {
+	case remote:
+		result, err = h.workerClient.ActAsHuman(ctx, worker, orgID, instance.SessionID, instance.ID, user.ID, preview.RemoteActRequest{SessionID: instance.SessionID, Policy: policy, Steps: body.Steps, Options: opts})
+	case h.browserSessions != nil:
 		result, err = h.browserSessions.ActAsHuman(ctx, orgID, instance.SessionID, instance.ID, user.ID, policy, body.Steps, opts)
-	} else {
+	default:
 		err = preview.ErrBrowserUnavailable
 	}
 	if err != nil {
@@ -3089,27 +3140,20 @@ func (h *PreviewHandler) CaptureScreenshot(w http.ResponseWriter, r *http.Reques
 	if body.DelayMS > 0 {
 		opts.Delay = time.Duration(body.DelayMS) * time.Millisecond
 	}
+	worker, remote, resolved := h.prepareBrowserExecution(w, r, instance.WorkerNodeID, true, preview.BrowserOperationScreenshot)
+	if !resolved {
+		return
+	}
+	if instance.SessionID != uuid.Nil && h.browserSessions != nil {
+		setAPICoordinatedBrowserResponseDeadline(w, r, preview.BrowserOperationScreenshot)
+	}
 
 	var result *models.ScreenshotResult
 	orgID := middleware.OrgIDFromContext(r.Context())
 	err := h.runAgentBrowserOperation(r.Context(), orgID, instance, func() error {
 		var operationErr error
-		if h.workerRoutingEnabled() {
-			worker, resolveErr := h.resolvePreviewWorker(r.Context(), instance.WorkerNodeID)
-			if resolveErr != nil {
-				writeError(w, r, http.StatusBadGateway, "PREVIEW_WORKER_RESOLUTION_FAILED", "failed to resolve preview worker", resolveErr)
-				return errPreviewResponseWritten
-			}
-			if h.isLocalWorker(worker) {
-				inspector, inspectorOK := h.requireInspector(w, r)
-				if !inspectorOK {
-					return errPreviewResponseWritten
-				}
-				bindSessionBrowser(inspector, instance)
-				result, operationErr = inspector.CaptureScreenshot(r.Context(), instance.ID.String(), opts)
-			} else {
-				result, operationErr = h.workerClient.CaptureScreenshot(r.Context(), worker, orgID, instance.ID, opts)
-			}
+		if remote {
+			result, operationErr = h.workerClient.CaptureScreenshot(r.Context(), worker, orgID, instance.ID, opts)
 		} else {
 			inspector, inspectorOK := h.requireInspector(w, r)
 			if !inspectorOK {
@@ -3206,32 +3250,18 @@ func (h *PreviewHandler) InspectElement(w http.ResponseWriter, r *http.Request) 
 			return
 		}
 	}
+	worker, remote, resolved := h.prepareBrowserExecution(w, r, instance.WorkerNodeID, true, preview.BrowserOperationInspect)
+	if !resolved {
+		return
+	}
 
 	var element *models.ElementInfo
 	var err error
-	if h.workerRoutingEnabled() {
-		var worker preview.WorkerNode
-		worker, err = h.resolvePreviewWorker(r.Context(), instance.WorkerNodeID)
-		if err != nil {
-			writeError(w, r, http.StatusBadGateway, "PREVIEW_WORKER_RESOLUTION_FAILED", "failed to resolve preview worker", err)
-			return
-		}
-		if h.isLocalWorker(worker) {
-			inspector, inspectorOK := h.requireInspector(w, r)
-			if !inspectorOK {
-				return
-			}
-			if body.Selector != "" {
-				element, err = inspector.InspectElementBySelector(r.Context(), instance.ID.String(), body.Selector)
-			} else {
-				element, err = inspector.InspectElement(r.Context(), instance.ID.String(), body.X, body.Y)
-			}
+	if remote {
+		if body.Selector != "" {
+			element, err = h.workerClient.InspectElementBySelector(r.Context(), worker, middleware.OrgIDFromContext(r.Context()), instance.ID, body.Selector)
 		} else {
-			if body.Selector != "" {
-				element, err = h.workerClient.InspectElementBySelector(r.Context(), worker, middleware.OrgIDFromContext(r.Context()), instance.ID, body.Selector)
-			} else {
-				element, err = h.workerClient.InspectElement(r.Context(), worker, middleware.OrgIDFromContext(r.Context()), instance.ID, body.X, body.Y)
-			}
+			element, err = h.workerClient.InspectElement(r.Context(), worker, middleware.OrgIDFromContext(r.Context()), instance.ID, body.X, body.Y)
 		}
 	} else {
 		inspector, inspectorOK := h.requireInspector(w, r)
@@ -3382,7 +3412,10 @@ type executeInteractionRequest struct {
 }
 
 func (h *PreviewHandler) ExecuteInteraction(w http.ResponseWriter, r *http.Request) {
-	r = withAPIBrowserOperation(w, r, preview.BrowserOperationInteract)
+	// This compatibility endpoint can execute either a raw interaction or a
+	// full browser-session action. Reserve the larger response deadline up
+	// front; the operation context below still uses the exact selected path.
+	r = withAPIBrowserOperation(w, r, preview.BrowserOperationSessionAct)
 	if !h.workerRoutingEnabled() {
 		if _, ok := h.requireInspector(w, r); !ok {
 			return
@@ -3412,30 +3445,29 @@ func (h *PreviewHandler) ExecuteInteraction(w http.ResponseWriter, r *http.Reque
 
 	// Bound the whole interaction: the design doc's 60s cap applies to the step
 	// loop, and the budget adds room for the observation Act performs after the
-	// steps. Routed interactions get worker-hop headroom on top so the worker's
-	// own budget expires first and returns a structured error.
-	ctx, cancel := context.WithTimeout(r.Context(), browserHandlerTimeout(h.workerRoutingEnabled(), preview.BrowserOperationInteract))
+	// steps. An interaction that leaves this process gets worker-hop headroom on
+	// top so the worker's own budget expires first and returns a structured
+	// error.
+	sessionAction := instance.SessionID != uuid.Nil && h.browserSessions != nil
+	operation := preview.BrowserOperationInteract
+	if sessionAction {
+		operation = preview.BrowserOperationSessionAct
+	}
+	worker, remote, resolved := h.prepareBrowserExecution(w, r, instance.WorkerNodeID, true, operation)
+	if !resolved {
+		return
+	}
+	ctx, cancel := context.WithTimeout(r.Context(), browserHandlerTimeout(remote, operation))
 	defer cancel()
-	if instance.SessionID != uuid.Nil && h.browserSessions != nil {
+	if sessionAction {
 		orgID := middleware.OrgIDFromContext(r.Context())
 		policy := browserPolicyForInstance(instance)
 		var actResult *models.PreviewActResult
 		var actErr error
-		if h.workerRoutingEnabled() {
-			worker, resolveErr := h.resolvePreviewWorker(ctx, instance.WorkerNodeID)
-			if resolveErr != nil {
-				writeError(w, r, http.StatusBadGateway, "PREVIEW_WORKER_RESOLUTION_FAILED", "failed to resolve preview worker", resolveErr)
-				return
-			}
-			if h.isLocalWorker(worker) && h.browserSessions != nil {
-				actResult, actErr = h.browserSessions.Act(ctx, orgID, instance.SessionID, instance.ID, policy, body.Steps, models.PreviewObservationOpts{})
-			} else {
-				actResult, actErr = h.workerClient.Act(ctx, worker, orgID, instance.SessionID, instance.ID, preview.RemoteActRequest{SessionID: instance.SessionID, Policy: policy, Steps: body.Steps})
-			}
-		} else if h.browserSessions != nil {
-			actResult, actErr = h.browserSessions.Act(ctx, orgID, instance.SessionID, instance.ID, policy, body.Steps, models.PreviewObservationOpts{})
+		if remote {
+			actResult, actErr = h.workerClient.Act(ctx, worker, orgID, instance.SessionID, instance.ID, preview.RemoteActRequest{SessionID: instance.SessionID, Policy: policy, Steps: body.Steps})
 		} else {
-			actErr = preview.ErrBrowserUnavailable
+			actResult, actErr = h.browserSessions.Act(ctx, orgID, instance.SessionID, instance.ID, policy, body.Steps, models.PreviewObservationOpts{})
 		}
 		if actErr != nil {
 			if _, ok := preview.AsWorkerRequestError(actErr); ok {
@@ -3465,23 +3497,8 @@ func (h *PreviewHandler) ExecuteInteraction(w http.ResponseWriter, r *http.Reque
 
 	var result *models.InteractionResult
 	var err error
-	if h.workerRoutingEnabled() {
-		var worker preview.WorkerNode
-		worker, err = h.resolvePreviewWorker(ctx, instance.WorkerNodeID)
-		if err != nil {
-			writeError(w, r, http.StatusBadGateway, "PREVIEW_WORKER_RESOLUTION_FAILED", "failed to resolve preview worker", err)
-			return
-		}
-		if h.isLocalWorker(worker) {
-			inspector, inspectorOK := h.requireInspector(w, r)
-			if !inspectorOK {
-				return
-			}
-			bindSessionBrowser(inspector, instance)
-			result, err = inspector.ExecuteInteraction(ctx, instance.ID.String(), body.Steps)
-		} else {
-			result, err = h.workerClient.ExecuteInteraction(ctx, worker, middleware.OrgIDFromContext(r.Context()), instance.ID, body.Steps)
-		}
+	if remote {
+		result, err = h.workerClient.ExecuteInteraction(ctx, worker, middleware.OrgIDFromContext(r.Context()), instance.ID, body.Steps)
 	} else {
 		inspector, inspectorOK := h.requireInspector(w, r)
 		if !inspectorOK {
@@ -3573,6 +3590,13 @@ func (h *PreviewHandler) CaptureMultiViewport(w http.ResponseWriter, r *http.Req
 	if body.DelayMS > 0 {
 		opts.Delay = time.Duration(body.DelayMS) * time.Millisecond
 	}
+	worker, remote, resolved := h.prepareBrowserExecution(w, r, instance.WorkerNodeID, true, preview.BrowserOperationMultiViewport)
+	if !resolved {
+		return
+	}
+	if instance.SessionID != uuid.Nil && h.browserSessions != nil {
+		setAPICoordinatedBrowserResponseDeadline(w, r, preview.BrowserOperationMultiViewport)
+	}
 
 	var (
 		result *models.MultiViewportResult
@@ -3580,22 +3604,8 @@ func (h *PreviewHandler) CaptureMultiViewport(w http.ResponseWriter, r *http.Req
 	orgID := middleware.OrgIDFromContext(r.Context())
 	err := h.runAgentBrowserOperation(r.Context(), orgID, instance, func() error {
 		var operationErr error
-		if h.workerRoutingEnabled() {
-			worker, resolveErr := h.resolvePreviewWorker(r.Context(), instance.WorkerNodeID)
-			if resolveErr != nil {
-				writeError(w, r, http.StatusBadGateway, "PREVIEW_WORKER_RESOLUTION_FAILED", "failed to resolve preview worker", resolveErr)
-				return errPreviewResponseWritten
-			}
-			if h.isLocalWorker(worker) {
-				inspector, inspectorOK := h.requireInspector(w, r)
-				if !inspectorOK {
-					return errPreviewResponseWritten
-				}
-				bindSessionBrowser(inspector, instance)
-				result, operationErr = inspector.CaptureMultiViewport(r.Context(), instance.ID.String(), opts)
-			} else {
-				result, operationErr = h.workerClient.CaptureMultiViewport(r.Context(), worker, orgID, instance.ID, opts)
-			}
+		if remote {
+			result, operationErr = h.workerClient.CaptureMultiViewport(r.Context(), worker, orgID, instance.ID, opts)
 		} else {
 			inspector, inspectorOK := h.requireInspector(w, r)
 			if !inspectorOK {
@@ -3663,26 +3673,17 @@ func (h *PreviewHandler) ComputeVisualDiff(w http.ResponseWriter, r *http.Reques
 		writeError(w, r, http.StatusBadRequest, "MISSING_SNAPSHOT_IDS", "before_snapshot_id and after_snapshot_id are required")
 		return
 	}
+	worker, remote, resolved := h.prepareBrowserExecution(w, r, instance.WorkerNodeID, true, preview.BrowserOperationVisualDiff)
+	if !resolved {
+		return
+	}
 
 	var (
 		diff *models.VisualDiff
 		err  error
 	)
-	if h.workerRoutingEnabled() {
-		worker, resolveErr := h.resolvePreviewWorker(r.Context(), instance.WorkerNodeID)
-		if resolveErr != nil {
-			writeError(w, r, http.StatusBadGateway, "PREVIEW_WORKER_RESOLUTION_FAILED", "failed to resolve preview worker", resolveErr)
-			return
-		}
-		if h.isLocalWorker(worker) {
-			inspector, inspectorOK := h.requireInspector(w, r)
-			if !inspectorOK {
-				return
-			}
-			diff, err = inspector.ComputeVisualDiff(r.Context(), instance.ID.String(), body.BeforeSnapshotID, body.AfterSnapshotID)
-		} else {
-			diff, err = h.workerClient.ComputeVisualDiff(r.Context(), worker, middleware.OrgIDFromContext(r.Context()), instance.ID, body.BeforeSnapshotID, body.AfterSnapshotID)
-		}
+	if remote {
+		diff, err = h.workerClient.ComputeVisualDiff(r.Context(), worker, middleware.OrgIDFromContext(r.Context()), instance.ID, body.BeforeSnapshotID, body.AfterSnapshotID)
 	} else {
 		inspector, inspectorOK := h.requireInspector(w, r)
 		if !inspectorOK {
@@ -3741,6 +3742,13 @@ func (h *PreviewHandler) RunAssertions(w http.ResponseWriter, r *http.Request) {
 			fmt.Sprintf("at most %d assertions allowed per call", maxAssertions))
 		return
 	}
+	worker, remote, resolved := h.prepareBrowserExecution(w, r, instance.WorkerNodeID, true, preview.BrowserOperationAssertions)
+	if !resolved {
+		return
+	}
+	if instance.SessionID != uuid.Nil && h.browserSessions != nil {
+		setAPICoordinatedBrowserResponseDeadline(w, r, preview.BrowserOperationAssertions)
+	}
 
 	var (
 		result *preview.AssertionResult
@@ -3748,22 +3756,8 @@ func (h *PreviewHandler) RunAssertions(w http.ResponseWriter, r *http.Request) {
 	orgID := middleware.OrgIDFromContext(r.Context())
 	err := h.runAgentBrowserOperation(r.Context(), orgID, instance, func() error {
 		var operationErr error
-		if h.workerRoutingEnabled() {
-			worker, resolveErr := h.resolvePreviewWorker(r.Context(), instance.WorkerNodeID)
-			if resolveErr != nil {
-				writeError(w, r, http.StatusBadGateway, "PREVIEW_WORKER_RESOLUTION_FAILED", "failed to resolve preview worker", resolveErr)
-				return errPreviewResponseWritten
-			}
-			if h.isLocalWorker(worker) {
-				inspector, inspectorOK := h.requireInspector(w, r)
-				if !inspectorOK {
-					return errPreviewResponseWritten
-				}
-				bindSessionBrowser(inspector, instance)
-				result, operationErr = inspector.RunAssertions(r.Context(), instance.ID.String(), body.Assertions)
-			} else {
-				result, operationErr = h.workerClient.RunAssertions(r.Context(), worker, orgID, instance.ID, body.Assertions)
-			}
+		if remote {
+			result, operationErr = h.workerClient.RunAssertions(r.Context(), worker, orgID, instance.ID, body.Assertions)
 		} else {
 			inspector, inspectorOK := h.requireInspector(w, r)
 			if !inspectorOK {

--- a/internal/api/handlers/preview_worker_routing_test.go
+++ b/internal/api/handlers/preview_worker_routing_test.go
@@ -803,3 +803,48 @@ func TestPreviewHandler_MultiViewport_StripsInlineScreenshotBytes(t *testing.T) 
 	require.Contains(t, body, "\"page_title\":\"Desktop\"", "capture screenshot metadata should still be present")
 	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
 }
+
+func TestWorkerClientHTTPError_PreservesSafeDetails(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		code        string
+		details     any
+		wantDetails any
+	}{
+		{name: "matching browser stage is preserved", code: "PREVIEW_BROWSER_BOOTSTRAP_EXCHANGE_FAILED", details: map[string]any{"stage": "bootstrap_exchange"}, wantDetails: map[string]string{"stage": "bootstrap_exchange"}},
+		{name: "unrelated worker details are dropped", code: "PREVIEW_WORKER_FAILED", details: map[string]any{"token": "secret"}},
+		{name: "mismatched stage and code are dropped", code: "PREVIEW_BROWSER_TOKEN_MINT_FAILED", details: map[string]any{"stage": "bootstrap_exchange"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			httpErr := workerClientHTTPError(&previewsvc.WorkerRequestError{StatusCode: http.StatusInternalServerError, Code: tt.code, Message: "worker failed", Details: tt.details})
+			require.Equal(t, http.StatusInternalServerError, httpErr.status, "worker status should be preserved")
+			require.Equal(t, tt.code, httpErr.code, "worker error code should be preserved")
+			require.Equal(t, tt.wantDetails, httpErr.details, "only allowlisted browser stage details should reach the public API")
+		})
+	}
+}
+
+func TestBrowserHandlerTimeout(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		workerRouting bool
+		want          time.Duration
+	}{
+		{name: "local operation uses inner budget", want: 60 * time.Second},
+		{name: "remote operation includes worker request headroom", workerRouting: true, want: 70 * time.Second},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tt.want, browserHandlerTimeout(tt.workerRouting, previewsvc.BrowserOperationInteract), "handler timeout should match its execution topology")
+		})
+	}
+}

--- a/internal/api/handlers/preview_worker_routing_test.go
+++ b/internal/api/handlers/preview_worker_routing_test.go
@@ -816,6 +816,24 @@ func TestWorkerClientHTTPError_PreservesSafeDetails(t *testing.T) {
 		{name: "matching browser stage is preserved", code: "PREVIEW_BROWSER_BOOTSTRAP_EXCHANGE_FAILED", details: map[string]any{"stage": "bootstrap_exchange"}, wantDetails: map[string]string{"stage": "bootstrap_exchange"}},
 		{name: "unrelated worker details are dropped", code: "PREVIEW_WORKER_FAILED", details: map[string]any{"token": "secret"}},
 		{name: "mismatched stage and code are dropped", code: "PREVIEW_BROWSER_TOKEN_MINT_FAILED", details: map[string]any{"stage": "bootstrap_exchange"}},
+		{
+			name:        "known preceding stage survives the worker hop",
+			code:        "PREVIEW_BROWSER_BOOTSTRAP_EXCHANGE_FAILED",
+			details:     map[string]any{"stage": "bootstrap_exchange", "preceding_stage": "state_restore"},
+			wantDetails: map[string]string{"stage": "bootstrap_exchange", "preceding_stage": "state_restore"},
+		},
+		{
+			name:        "unknown preceding stage is dropped without dropping the stage",
+			code:        "PREVIEW_BROWSER_BOOTSTRAP_EXCHANGE_FAILED",
+			details:     map[string]any{"stage": "bootstrap_exchange", "preceding_stage": "not-a-stage"},
+			wantDetails: map[string]string{"stage": "bootstrap_exchange"},
+		},
+		{
+			name:        "sibling detail keys are never forwarded",
+			code:        "PREVIEW_BROWSER_BOOTSTRAP_EXCHANGE_FAILED",
+			details:     map[string]any{"stage": "bootstrap_exchange", "token": "must-not-leak"},
+			wantDetails: map[string]string{"stage": "bootstrap_exchange"},
+		},
 	}
 
 	for _, tt := range tests {
@@ -833,18 +851,126 @@ func TestBrowserHandlerTimeout(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name          string
-		workerRouting bool
-		want          time.Duration
+		name      string
+		remote    bool
+		operation previewsvc.BrowserOperation
+		want      time.Duration
 	}{
-		{name: "local operation uses inner budget", want: 105 * time.Second},
-		{name: "remote operation includes worker request headroom", workerRouting: true, want: 115 * time.Second},
+		{name: "routing configured and selected worker local uses operation budget", operation: previewsvc.BrowserOperationInteract, want: 105 * time.Second},
+		{name: "remote interaction includes worker request headroom", remote: true, operation: previewsvc.BrowserOperationInteract, want: 115 * time.Second},
+		{name: "local session observation includes lifecycle budget", operation: previewsvc.BrowserOperationSessionObserve, want: 255 * time.Second},
+		{name: "remote session observation includes lifecycle and worker headroom", remote: true, operation: previewsvc.BrowserOperationSessionObserve, want: 265 * time.Second},
+		{name: "local session action includes lifecycle budget", operation: previewsvc.BrowserOperationSessionAct, want: 360 * time.Second},
+		{name: "remote session action includes lifecycle and worker headroom", remote: true, operation: previewsvc.BrowserOperationSessionAct, want: 370 * time.Second},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			require.Equal(t, tt.want, browserHandlerTimeout(tt.workerRouting, previewsvc.BrowserOperationInteract), "handler timeout should match its execution topology")
+			require.Equal(t, tt.want, browserHandlerTimeout(tt.remote, tt.operation), "handler timeout should match its execution topology")
+		})
+	}
+}
+
+func TestBrowserWorkerResolutionHasIndependentBound(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t, 15*time.Second, browserWorkerResolutionTimeout, "worker resolution should be bounded without consuming browser operation headroom")
+}
+
+type browserDeadlineRecorder struct {
+	*httptest.ResponseRecorder
+	deadlines []time.Time
+}
+
+func (w *browserDeadlineRecorder) SetWriteDeadline(deadline time.Time) error {
+	w.deadlines = append(w.deadlines, deadline)
+	return nil
+}
+
+func TestPreviewHandler_PrepareBrowserExecutionRefreshesResponseDeadlineAfterPreflight(t *testing.T) {
+	t.Parallel()
+
+	h := &PreviewHandler{}
+	w := &browserDeadlineRecorder{ResponseRecorder: httptest.NewRecorder()}
+	req := httptest.NewRequest(http.MethodPost, "/preview", nil)
+	req = withAPIBrowserOperation(w, req, previewsvc.BrowserOperationInspect)
+
+	_, remote, resolved := h.prepareBrowserExecution(w, req, "", true, previewsvc.BrowserOperationInspect)
+
+	require.True(t, resolved, "local execution without worker routing should not require topology lookup")
+	require.False(t, remote, "local execution without worker routing should stay in process")
+	require.Len(t, w.deadlines, 3, "browser execution preparation should re-arm before and after bounded worker resolution")
+	require.True(t, w.deadlines[1].After(w.deadlines[0]), "resolution deadline should start after target lookup and request parsing")
+	require.True(t, w.deadlines[2].After(w.deadlines[1]), "operation deadline should start after worker resolution")
+}
+
+func TestPreviewHandler_PrepareBrowserExecutionRetainsDeadlineForResolutionError(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "pgxmock pool should be created")
+	defer mock.Close()
+	h := newPreviewHandlerWithMock(mock)
+	h.SetWorkerRuntime(previewsvc.NewWorkerSelector(db.NewNodeStore(mock), h.store), previewsvc.NewWorkerPreviewClient("test-secret"), "api-node")
+	mock.ExpectQuery("SELECT .+ FROM nodes WHERE id = @id").
+		WithArgs(pgxmock.AnyArg()).
+		WillReturnError(context.DeadlineExceeded)
+
+	w := &browserDeadlineRecorder{ResponseRecorder: httptest.NewRecorder()}
+	req := httptest.NewRequest(http.MethodPost, "/preview", nil)
+	req = withAPIBrowserOperation(w, req, previewsvc.BrowserOperationInspect)
+	_, _, resolved := h.prepareBrowserExecution(w, req, "worker-node", true, previewsvc.BrowserOperationInspect)
+
+	require.False(t, resolved, "worker resolution failure should stop browser execution")
+	require.Equal(t, http.StatusBadGateway, w.Code, "worker resolution failure should remain a structured gateway response")
+	require.Len(t, w.deadlines, 2, "resolution failure should receive a fresh response deadline after request preflight")
+	require.True(t, w.deadlines[1].After(w.deadlines[0]), "resolution error deadline should start after target lookup and request parsing")
+	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
+}
+
+func TestPreviewHandler_ResolveBrowserWorkerUsesSelectedTopology(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		localNodeID   string
+		canRunLocally bool
+		wantRemote    bool
+	}{
+		{name: "selected local worker executes in process", localNodeID: "selected-worker", canRunLocally: true},
+		{name: "selected remote worker uses worker client", localNodeID: "api-node", canRunLocally: true, wantRemote: true},
+		{name: "local worker without in-process executor uses worker client", localNodeID: "selected-worker", wantRemote: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			mock, err := pgxmock.NewPool()
+			require.NoError(t, err, "pgxmock pool should be created")
+			defer mock.Close()
+
+			h := newPreviewHandlerWithMock(mock)
+			nodeStore := db.NewNodeStore(mock)
+			h.SetWorkerRuntime(previewsvc.NewWorkerSelector(nodeStore, h.store), previewsvc.NewWorkerPreviewClient("test-secret"), tt.localNodeID)
+
+			metadata, err := json.Marshal(previewsvc.WorkerNodeMetadata{PreviewInternalBaseURL: "http://selected-worker.internal"})
+			require.NoError(t, err, "worker metadata should marshal")
+			now := time.Now().UTC()
+			mock.ExpectQuery("SELECT .+ FROM nodes WHERE id = @id").
+				WithArgs(pgxmock.AnyArg()).
+				WillReturnRows(pgxmock.NewRows(handlerNodeTestCols).
+					AddRow("selected-worker", "worker", "worker.internal", "active", metadata, now, now))
+
+			req := httptest.NewRequest(http.MethodPost, "/preview", nil)
+			rr := httptest.NewRecorder()
+			worker, remote, resolved := h.resolveBrowserWorker(rr, req, "selected-worker", tt.canRunLocally)
+
+			require.True(t, resolved, "known worker should resolve successfully")
+			require.Equal(t, previewsvc.WorkerNode{ID: "selected-worker", Mode: "worker", BaseURL: "http://selected-worker.internal"}, worker, "resolved worker should preserve routing metadata")
+			require.Equal(t, tt.wantRemote, remote, "selected topology should determine whether the operation leaves the process")
+			require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
 		})
 	}
 }

--- a/internal/api/handlers/preview_worker_routing_test.go
+++ b/internal/api/handlers/preview_worker_routing_test.go
@@ -837,8 +837,8 @@ func TestBrowserHandlerTimeout(t *testing.T) {
 		workerRouting bool
 		want          time.Duration
 	}{
-		{name: "local operation uses inner budget", want: 60 * time.Second},
-		{name: "remote operation includes worker request headroom", workerRouting: true, want: 70 * time.Second},
+		{name: "local operation uses inner budget", want: 105 * time.Second},
+		{name: "remote operation includes worker request headroom", workerRouting: true, want: 115 * time.Second},
 	}
 
 	for _, tt := range tests {

--- a/internal/api/middleware/external_api_test.go
+++ b/internal/api/middleware/external_api_test.go
@@ -34,6 +34,25 @@ func TestLogContext_CorrelatesParentRequestID(t *testing.T) {
 	require.Equal(t, "public-request-123", entry["parent_request_id"], "worker log should include the originating public request id")
 }
 
+func TestLogContext_IgnoresParentRequestIDFromPublicClients(t *testing.T) {
+	t.Parallel()
+
+	var logs bytes.Buffer
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/previews/preview-id/observe", nil)
+	req.Header.Set(internalapi.ParentRequestIDHeader, "forged-request-123")
+	rr := httptest.NewRecorder()
+
+	LogContext(zerolog.New(&logs))(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		zerolog.Ctx(r.Context()).Info().Msg("public browser request")
+		w.WriteHeader(http.StatusNoContent)
+	})).ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusNoContent, rr.Code, "public request should still reach the handler")
+	var entry map[string]any
+	require.NoError(t, json.Unmarshal(logs.Bytes(), &entry), "request-scoped log should be valid JSON")
+	require.NotContains(t, entry, "parent_request_id", "a public caller should not be able to forge a correlation id in structured logs")
+}
+
 func TestLogContext_AllowsAPIIdentityWithoutUser(t *testing.T) {
 	t.Parallel()
 

--- a/internal/api/middleware/external_api_test.go
+++ b/internal/api/middleware/external_api_test.go
@@ -1,17 +1,38 @@
 package middleware
 
 import (
+	"bytes"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 	"time"
 
+	"github.com/assembledhq/143/internal/internalapi"
 	"github.com/assembledhq/143/internal/models"
 	"github.com/google/uuid"
 	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/require"
 )
+
+func TestLogContext_CorrelatesParentRequestID(t *testing.T) {
+	t.Parallel()
+
+	var logs bytes.Buffer
+	req := httptest.NewRequest(http.MethodPost, "/internal/preview/preview-id/observe", nil)
+	req.Header.Set(internalapi.ParentRequestIDHeader, "public-request-123")
+	rr := httptest.NewRecorder()
+
+	LogContext(zerolog.New(&logs))(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		zerolog.Ctx(r.Context()).Info().Msg("worker browser request")
+		w.WriteHeader(http.StatusNoContent)
+	})).ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusNoContent, rr.Code, "correlated worker request should reach the handler")
+	var entry map[string]any
+	require.NoError(t, json.Unmarshal(logs.Bytes(), &entry), "request-scoped log should be valid JSON")
+	require.Equal(t, "public-request-123", entry["parent_request_id"], "worker log should include the originating public request id")
+}
 
 func TestLogContext_AllowsAPIIdentityWithoutUser(t *testing.T) {
 	t.Parallel()

--- a/internal/api/middleware/log_context.go
+++ b/internal/api/middleware/log_context.go
@@ -38,7 +38,7 @@ func LogContext(logger zerolog.Logger) func(http.Handler) http.Handler {
 			if apiVersion != "" {
 				logCtx = logCtx.Str("api_version", apiVersion)
 			}
-			if parentRequestID := internalapi.NormalizeParentRequestID(r.Header.Get(internalapi.ParentRequestIDHeader)); parentRequestID != "" {
+			if parentRequestID := internalapi.TrustedParentRequestID(r); parentRequestID != "" {
 				logCtx = logCtx.Str("parent_request_id", parentRequestID)
 			}
 			l := logCtx.Logger()

--- a/internal/api/middleware/log_context.go
+++ b/internal/api/middleware/log_context.go
@@ -5,6 +5,8 @@ import (
 
 	chiMiddleware "github.com/go-chi/chi/v5/middleware"
 	"github.com/rs/zerolog"
+
+	"github.com/assembledhq/143/internal/internalapi"
 )
 
 // LogContext returns middleware that injects a zerolog.Logger into the request
@@ -35,6 +37,9 @@ func LogContext(logger zerolog.Logger) func(http.Handler) http.Handler {
 			}
 			if apiVersion != "" {
 				logCtx = logCtx.Str("api_version", apiVersion)
+			}
+			if parentRequestID := internalapi.NormalizeParentRequestID(r.Header.Get(internalapi.ParentRequestIDHeader)); parentRequestID != "" {
+				logCtx = logCtx.Str("parent_request_id", parentRequestID)
 			}
 			l := logCtx.Logger()
 			ctx = l.WithContext(ctx)

--- a/internal/internalapi/request_id.go
+++ b/internal/internalapi/request_id.go
@@ -1,10 +1,28 @@
 package internalapi
 
-import "strings"
+import (
+	"net/http"
+	"strings"
+)
 
 // ParentRequestIDHeader correlates a trusted app-to-worker request with the
 // originating public API request. It is diagnostic metadata, not authorization.
 const ParentRequestIDHeader = "X-143-Parent-Request-ID"
+
+// RoutePrefix is the path prefix for service-to-service routes, which are
+// authenticated by the preview worker token rather than by an end user.
+const RoutePrefix = "/internal/"
+
+// TrustedParentRequestID returns correlation metadata only for requests on the
+// internal service-to-service surface. Any client can set the header, so
+// honoring it on public routes would let a caller attach someone else's request
+// id to their own log lines and forge correlation chains.
+func TrustedParentRequestID(r *http.Request) string {
+	if r == nil || r.URL == nil || !strings.HasPrefix(r.URL.Path, RoutePrefix) {
+		return ""
+	}
+	return NormalizeParentRequestID(r.Header.Get(ParentRequestIDHeader))
+}
 
 // NormalizeParentRequestID bounds and validates correlation metadata before it
 // crosses a service boundary or is attached to structured logs.

--- a/internal/internalapi/request_id.go
+++ b/internal/internalapi/request_id.go
@@ -1,0 +1,24 @@
+package internalapi
+
+import "strings"
+
+// ParentRequestIDHeader correlates a trusted app-to-worker request with the
+// originating public API request. It is diagnostic metadata, not authorization.
+const ParentRequestIDHeader = "X-143-Parent-Request-ID"
+
+// NormalizeParentRequestID bounds and validates correlation metadata before it
+// crosses a service boundary or is attached to structured logs.
+func NormalizeParentRequestID(value string) string {
+	value = strings.TrimSpace(value)
+	if value == "" || len(value) > 128 {
+		return ""
+	}
+	for _, char := range value {
+		if (char >= 'a' && char <= 'z') || (char >= 'A' && char <= 'Z') ||
+			(char >= '0' && char <= '9') || strings.ContainsRune("-_.:/", char) {
+			continue
+		}
+		return ""
+	}
+	return value
+}

--- a/internal/internalapi/request_id_test.go
+++ b/internal/internalapi/request_id_test.go
@@ -1,0 +1,31 @@
+package internalapi
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNormalizeParentRequestID(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		value string
+		want  string
+	}{
+		{name: "valid request id", value: " host.example/random-000123 ", want: "host.example/random-000123"},
+		{name: "empty request id", value: " "},
+		{name: "oversized request id", value: strings.Repeat("a", 129)},
+		{name: "header injection", value: "request-id\nspoofed"},
+		{name: "spaces inside id", value: "request id"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tt.want, NormalizeParentRequestID(tt.value), "parent request id should be safe for headers and structured logs")
+		})
+	}
+}

--- a/internal/internalapi/request_id_test.go
+++ b/internal/internalapi/request_id_test.go
@@ -1,6 +1,8 @@
 package internalapi
 
 import (
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 
@@ -26,6 +28,35 @@ func TestNormalizeParentRequestID(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			require.Equal(t, tt.want, NormalizeParentRequestID(tt.value), "parent request id should be safe for headers and structured logs")
+		})
+	}
+}
+
+func TestTrustedParentRequestID(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		path   string
+		header string
+		want   string
+	}{
+		{name: "internal worker route is trusted", path: "/internal/preview/preview-id/observe", header: "public-request-123", want: "public-request-123"},
+		{name: "internal session route is trusted", path: "/internal/sessions/session-id/cancel", header: "public-request-123", want: "public-request-123"},
+		{name: "public api route is not trusted", path: "/api/v1/previews/preview-id/observe", header: "forged-request-123"},
+		{name: "internal prefix must be a path segment", path: "/api/v1/internal/previews", header: "forged-request-123"},
+		{name: "internal route still validates the value", path: "/internal/preview/preview-id/observe", header: "request-id\nspoofed"},
+		{name: "missing header", path: "/internal/preview/preview-id/observe"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			req := httptest.NewRequest(http.MethodPost, tt.path, nil)
+			if tt.header != "" {
+				req.Header.Set(ParentRequestIDHeader, tt.header)
+			}
+			require.Equal(t, tt.want, TrustedParentRequestID(req), "only the internal service-to-service surface should be able to set a correlation id")
 		})
 	}
 }

--- a/internal/services/preview/browser_operation.go
+++ b/internal/services/preview/browser_operation.go
@@ -20,21 +20,43 @@ const (
 	// and then a full observation of the resulting page, so the operation budget
 	// must cover both. Sizing them equally would leave the trailing observation
 	// no time whenever the steps ran long, discarding step results that already
-	// succeeded.
+	// succeeded. Both halves are enforced -- the step loop by
+	// maxInteractionTimeout, the observation by ChromeDPInspector.Observe -- so
+	// the sum is a real ceiling rather than an estimate. Browser-session
+	// lifecycle work is budgeted separately, by BrowserOperationSessionAct.
 	browserInteractionStepsTimeout     = 60 * time.Second
 	browserInteractionOperationTimeout = browserInteractionStepsTimeout + browserObserveOperationTimeout
+
+	// Session lifecycle calls include work outside a raw browser operation. The
+	// access phase covers the session row plus the worst successful recovery
+	// path: bootstrap, failed state restore, and a second bootstrap. Persistence
+	// covers both browser export and the state-store write. Control acquisition
+	// and release split a final default-operation allowance.
+	browserSessionAccessTimeout         = 4 * browserDefaultOperationTimeout
+	browserSessionInitializationTimeout = browserObserveOperationTimeout
+	browserSessionPersistTimeout        = 2 * browserDefaultOperationTimeout
+	browserSessionControlAcquireTimeout = browserDefaultOperationTimeout / 2
+	browserSessionControlReleaseTimeout = browserDefaultOperationTimeout / 2
+	browserSessionCoordinationTimeout   = browserSessionControlAcquireTimeout + browserSessionControlReleaseTimeout
+
+	browserSessionObserveOperationTimeout = browserSessionAccessTimeout +
+		browserObserveOperationTimeout + browserSessionPersistTimeout + browserSessionCoordinationTimeout
+	browserSessionInteractionOperationTimeout = browserSessionAccessTimeout + browserSessionInitializationTimeout +
+		browserInteractionOperationTimeout + browserSessionPersistTimeout + browserSessionCoordinationTimeout
 
 	browserMultiViewportOperationTimeout = 150 * time.Second
 )
 
 const (
-	BrowserOperationScreenshot    BrowserOperation = "screenshot"
-	BrowserOperationObserve       BrowserOperation = "observe"
-	BrowserOperationInteract      BrowserOperation = "interact"
-	BrowserOperationInspect       BrowserOperation = "inspect"
-	BrowserOperationMultiViewport BrowserOperation = "multi_viewport"
-	BrowserOperationVisualDiff    BrowserOperation = "visual_diff"
-	BrowserOperationAssertions    BrowserOperation = "assertions"
+	BrowserOperationScreenshot     BrowserOperation = "screenshot"
+	BrowserOperationObserve        BrowserOperation = "observe"
+	BrowserOperationSessionObserve BrowserOperation = "session_observe"
+	BrowserOperationInteract       BrowserOperation = "interact"
+	BrowserOperationSessionAct     BrowserOperation = "session_act"
+	BrowserOperationInspect        BrowserOperation = "inspect"
+	BrowserOperationMultiViewport  BrowserOperation = "multi_viewport"
+	BrowserOperationVisualDiff     BrowserOperation = "visual_diff"
+	BrowserOperationAssertions     BrowserOperation = "assertions"
 )
 
 // BrowserOperationBudget leaves bounded headroom at each network hop so the
@@ -56,8 +78,12 @@ func BrowserOperationBudgetFor(operation BrowserOperation) BrowserOperationBudge
 	switch operation {
 	case BrowserOperationObserve:
 		operationTimeout = browserObserveOperationTimeout
+	case BrowserOperationSessionObserve:
+		operationTimeout = browserSessionObserveOperationTimeout
 	case BrowserOperationInteract:
 		operationTimeout = browserInteractionOperationTimeout
+	case BrowserOperationSessionAct:
+		operationTimeout = browserSessionInteractionOperationTimeout
 	case BrowserOperationAssertions:
 		operationTimeout = browserAssertionsOperationTimeout
 	case BrowserOperationMultiViewport:
@@ -69,6 +95,15 @@ func BrowserOperationBudgetFor(operation BrowserOperation) BrowserOperationBudge
 		WorkerRequest:  operationTimeout + 10*time.Second,
 		APIResponse:    operationTimeout + 15*time.Second,
 	}
+}
+
+// CoordinatedBrowserOperationAPIResponseTimeoutFor adds the session identity
+// and control fencing that compatibility browser tools perform in the public
+// API before and after their raw inspector/worker operation. The worker itself
+// still executes the raw operation, so only the outer API response deadline
+// needs this additional allowance.
+func CoordinatedBrowserOperationAPIResponseTimeoutFor(operation BrowserOperation) time.Duration {
+	return BrowserOperationBudgetFor(operation).APIResponse + browserDefaultOperationTimeout + browserSessionCoordinationTimeout
 }
 
 // BrowserAccessStage identifies a safe, non-secret preview authentication
@@ -87,7 +122,12 @@ const (
 // tokens, cookies, and underlying implementation details out of API details.
 type BrowserAccessError struct {
 	Stage BrowserAccessStage
-	Err   error
+	// PrecedingStage records the stage that failed first and triggered a
+	// recovery attempt, when that recovery then failed at Stage. Only one stage
+	// survives errors.As on a joined error, so without this the failure that
+	// started the cascade never reaches logs or error details.
+	PrecedingStage BrowserAccessStage
+	Err            error
 }
 
 func (e *BrowserAccessError) Error() string {

--- a/internal/services/preview/browser_operation.go
+++ b/internal/services/preview/browser_operation.go
@@ -11,9 +11,19 @@ import (
 type BrowserOperation string
 
 const (
-	browserDefaultOperationTimeout       = 30 * time.Second
-	browserObserveOperationTimeout       = 45 * time.Second
-	browserInteractionOperationTimeout   = 60 * time.Second
+	browserDefaultOperationTimeout    = 30 * time.Second
+	browserObserveOperationTimeout    = 45 * time.Second
+	browserAssertionsOperationTimeout = 60 * time.Second
+
+	// browserInteractionStepsTimeout is the design doc's cap on the interaction
+	// step loop itself. An interaction is not just that loop: Act runs the steps
+	// and then a full observation of the resulting page, so the operation budget
+	// must cover both. Sizing them equally would leave the trailing observation
+	// no time whenever the steps ran long, discarding step results that already
+	// succeeded.
+	browserInteractionStepsTimeout     = 60 * time.Second
+	browserInteractionOperationTimeout = browserInteractionStepsTimeout + browserObserveOperationTimeout
+
 	browserMultiViewportOperationTimeout = 150 * time.Second
 )
 
@@ -38,14 +48,18 @@ type BrowserOperationBudget struct {
 }
 
 // BrowserOperationBudgetFor returns the canonical timeout stack for an
-// operation. Multi-viewport captures may perform five sequential screenshots.
+// operation. Each operation's budget covers everything that runs inside it:
+// multi-viewport captures may perform five sequential screenshots, and an
+// interaction is a step loop followed by an observation.
 func BrowserOperationBudgetFor(operation BrowserOperation) BrowserOperationBudget {
 	operationTimeout := browserDefaultOperationTimeout
 	switch operation {
 	case BrowserOperationObserve:
 		operationTimeout = browserObserveOperationTimeout
-	case BrowserOperationInteract, BrowserOperationAssertions:
+	case BrowserOperationInteract:
 		operationTimeout = browserInteractionOperationTimeout
+	case BrowserOperationAssertions:
+		operationTimeout = browserAssertionsOperationTimeout
 	case BrowserOperationMultiViewport:
 		operationTimeout = browserMultiViewportOperationTimeout
 	}

--- a/internal/services/preview/browser_operation.go
+++ b/internal/services/preview/browser_operation.go
@@ -1,0 +1,121 @@
+package preview
+
+import (
+	"errors"
+	"fmt"
+	"time"
+)
+
+// BrowserOperation identifies a browser RPC whose timeout budget must remain
+// consistent across the public API, worker client, and worker handler.
+type BrowserOperation string
+
+const (
+	browserDefaultOperationTimeout       = 30 * time.Second
+	browserObserveOperationTimeout       = 45 * time.Second
+	browserInteractionOperationTimeout   = 60 * time.Second
+	browserMultiViewportOperationTimeout = 150 * time.Second
+)
+
+const (
+	BrowserOperationScreenshot    BrowserOperation = "screenshot"
+	BrowserOperationObserve       BrowserOperation = "observe"
+	BrowserOperationInteract      BrowserOperation = "interact"
+	BrowserOperationInspect       BrowserOperation = "inspect"
+	BrowserOperationMultiViewport BrowserOperation = "multi_viewport"
+	BrowserOperationVisualDiff    BrowserOperation = "visual_diff"
+	BrowserOperationAssertions    BrowserOperation = "assertions"
+)
+
+// BrowserOperationBudget leaves bounded headroom at each network hop so the
+// inner operation can return a structured error before an outer connection is
+// closed by its response deadline.
+type BrowserOperationBudget struct {
+	Operation      time.Duration
+	WorkerResponse time.Duration
+	WorkerRequest  time.Duration
+	APIResponse    time.Duration
+}
+
+// BrowserOperationBudgetFor returns the canonical timeout stack for an
+// operation. Multi-viewport captures may perform five sequential screenshots.
+func BrowserOperationBudgetFor(operation BrowserOperation) BrowserOperationBudget {
+	operationTimeout := browserDefaultOperationTimeout
+	switch operation {
+	case BrowserOperationObserve:
+		operationTimeout = browserObserveOperationTimeout
+	case BrowserOperationInteract, BrowserOperationAssertions:
+		operationTimeout = browserInteractionOperationTimeout
+	case BrowserOperationMultiViewport:
+		operationTimeout = browserMultiViewportOperationTimeout
+	}
+	return BrowserOperationBudget{
+		Operation:      operationTimeout,
+		WorkerResponse: operationTimeout + 5*time.Second,
+		WorkerRequest:  operationTimeout + 10*time.Second,
+		APIResponse:    operationTimeout + 15*time.Second,
+	}
+}
+
+// BrowserAccessStage identifies a safe, non-secret preview authentication
+// stage that can be returned to callers and attached to logs.
+type BrowserAccessStage string
+
+const (
+	BrowserAccessStageTokenMint           BrowserAccessStage = "token_mint"
+	BrowserAccessStageBootstrapNavigation BrowserAccessStage = "bootstrap_navigation"
+	BrowserAccessStageBootstrapExchange   BrowserAccessStage = "bootstrap_exchange"
+	BrowserAccessStageAuthenticatedOpen   BrowserAccessStage = "authenticated_open"
+	BrowserAccessStageStateRestore        BrowserAccessStage = "state_restore"
+)
+
+// BrowserAccessError preserves the failed authentication stage while keeping
+// tokens, cookies, and underlying implementation details out of API details.
+type BrowserAccessError struct {
+	Stage BrowserAccessStage
+	Err   error
+}
+
+func (e *BrowserAccessError) Error() string {
+	if e == nil {
+		return ""
+	}
+	if e.Err == nil {
+		return fmt.Sprintf("preview browser access failed at %s", e.Stage)
+	}
+	return fmt.Sprintf("preview browser access failed at %s: %v", e.Stage, e.Err)
+}
+
+func (e *BrowserAccessError) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.Err
+}
+
+// AsBrowserAccessError unwraps a staged browser access error.
+func AsBrowserAccessError(err error) (*BrowserAccessError, bool) {
+	var target *BrowserAccessError
+	if errors.As(err, &target) {
+		return target, true
+	}
+	return nil, false
+}
+
+// Code returns the stable public error code for the failed stage.
+func (e *BrowserAccessError) Code() string {
+	switch e.Stage {
+	case BrowserAccessStageTokenMint:
+		return "PREVIEW_BROWSER_TOKEN_MINT_FAILED"
+	case BrowserAccessStageBootstrapNavigation:
+		return "PREVIEW_BROWSER_BOOTSTRAP_NAVIGATION_FAILED"
+	case BrowserAccessStageBootstrapExchange:
+		return "PREVIEW_BROWSER_BOOTSTRAP_EXCHANGE_FAILED"
+	case BrowserAccessStageAuthenticatedOpen:
+		return "PREVIEW_BROWSER_AUTHENTICATED_OPEN_FAILED"
+	case BrowserAccessStageStateRestore:
+		return "PREVIEW_BROWSER_STATE_RESTORE_FAILED"
+	default:
+		return "PREVIEW_BROWSER_ACCESS_FAILED"
+	}
+}

--- a/internal/services/preview/browser_operation_test.go
+++ b/internal/services/preview/browser_operation_test.go
@@ -18,7 +18,9 @@ func TestBrowserOperationBudgetFor(t *testing.T) {
 	}{
 		{name: "screenshot", operation: BrowserOperationScreenshot, want: BrowserOperationBudget{Operation: 30 * time.Second, WorkerResponse: 35 * time.Second, WorkerRequest: 40 * time.Second, APIResponse: 45 * time.Second}},
 		{name: "observe", operation: BrowserOperationObserve, want: BrowserOperationBudget{Operation: 45 * time.Second, WorkerResponse: 50 * time.Second, WorkerRequest: 55 * time.Second, APIResponse: 60 * time.Second}},
+		{name: "session observe", operation: BrowserOperationSessionObserve, want: BrowserOperationBudget{Operation: 255 * time.Second, WorkerResponse: 260 * time.Second, WorkerRequest: 265 * time.Second, APIResponse: 270 * time.Second}},
 		{name: "interaction", operation: BrowserOperationInteract, want: BrowserOperationBudget{Operation: 105 * time.Second, WorkerResponse: 110 * time.Second, WorkerRequest: 115 * time.Second, APIResponse: 120 * time.Second}},
+		{name: "session action", operation: BrowserOperationSessionAct, want: BrowserOperationBudget{Operation: 360 * time.Second, WorkerResponse: 365 * time.Second, WorkerRequest: 370 * time.Second, APIResponse: 375 * time.Second}},
 		{name: "inspect", operation: BrowserOperationInspect, want: BrowserOperationBudget{Operation: 30 * time.Second, WorkerResponse: 35 * time.Second, WorkerRequest: 40 * time.Second, APIResponse: 45 * time.Second}},
 		{name: "multi viewport", operation: BrowserOperationMultiViewport, want: BrowserOperationBudget{Operation: 150 * time.Second, WorkerResponse: 155 * time.Second, WorkerRequest: 160 * time.Second, APIResponse: 165 * time.Second}},
 		{name: "visual diff", operation: BrowserOperationVisualDiff, want: BrowserOperationBudget{Operation: 30 * time.Second, WorkerResponse: 35 * time.Second, WorkerRequest: 40 * time.Second, APIResponse: 45 * time.Second}},
@@ -42,6 +44,36 @@ func TestBrowserInteractionBudgetCoversStepsAndTrailingObservation(t *testing.T)
 	require.Equal(t, maxInteractionTimeout, browserInteractionStepsTimeout, "the inspector step loop should be capped by the documented step budget")
 	require.GreaterOrEqual(t, interact, browserInteractionStepsTimeout+observe,
 		"Act runs the step loop and then a full observation, so a step loop that uses its whole budget must still leave room to observe the resulting page")
+	require.Equal(t, browserObserveOperationTimeout, observe,
+		"ChromeDPInspector.Observe bounds itself by browserObserveOperationTimeout, so the observe half of the interaction budget must be that same value")
+}
+
+func TestBrowserSessionActionBudgetCoversLifecycleWork(t *testing.T) {
+	t.Parallel()
+
+	sessionAct := BrowserOperationBudgetFor(BrowserOperationSessionAct).Operation
+	required := browserSessionAccessTimeout + browserSessionInitializationTimeout + browserInteractionStepsTimeout + browserObserveOperationTimeout + browserSessionPersistTimeout + browserSessionCoordinationTimeout
+	require.Equal(t, required, sessionAct,
+		"session actions should budget setup, initialization, steps, trailing observation, persistence, and control coordination")
+}
+
+func TestBrowserSessionObserveBudgetCoversLifecycleWork(t *testing.T) {
+	t.Parallel()
+
+	sessionObserve := BrowserOperationBudgetFor(BrowserOperationSessionObserve).Operation
+	required := browserSessionAccessTimeout + browserObserveOperationTimeout + browserSessionPersistTimeout + browserSessionCoordinationTimeout
+	require.Equal(t, required, sessionObserve,
+		"session observations should budget access, page observation, persistence, and control coordination")
+}
+
+func TestCoordinatedBrowserOperationAPIResponseTimeoutCoversIdentityAndControlFencing(t *testing.T) {
+	t.Parallel()
+
+	base := BrowserOperationBudgetFor(BrowserOperationScreenshot)
+	overhead := browserDefaultOperationTimeout + browserSessionCoordinationTimeout
+
+	require.Equal(t, base.APIResponse+overhead, CoordinatedBrowserOperationAPIResponseTimeoutFor(BrowserOperationScreenshot),
+		"public API response should retain raw operation headroom after identity setup and both control phases")
 }
 
 func TestBrowserAccessErrorCode(t *testing.T) {

--- a/internal/services/preview/browser_operation_test.go
+++ b/internal/services/preview/browser_operation_test.go
@@ -1,0 +1,62 @@
+package preview
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestBrowserOperationBudgetFor(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		operation BrowserOperation
+		want      BrowserOperationBudget
+	}{
+		{name: "screenshot", operation: BrowserOperationScreenshot, want: BrowserOperationBudget{Operation: 30 * time.Second, WorkerResponse: 35 * time.Second, WorkerRequest: 40 * time.Second, APIResponse: 45 * time.Second}},
+		{name: "observe", operation: BrowserOperationObserve, want: BrowserOperationBudget{Operation: 45 * time.Second, WorkerResponse: 50 * time.Second, WorkerRequest: 55 * time.Second, APIResponse: 60 * time.Second}},
+		{name: "interaction", operation: BrowserOperationInteract, want: BrowserOperationBudget{Operation: 60 * time.Second, WorkerResponse: 65 * time.Second, WorkerRequest: 70 * time.Second, APIResponse: 75 * time.Second}},
+		{name: "inspect", operation: BrowserOperationInspect, want: BrowserOperationBudget{Operation: 30 * time.Second, WorkerResponse: 35 * time.Second, WorkerRequest: 40 * time.Second, APIResponse: 45 * time.Second}},
+		{name: "multi viewport", operation: BrowserOperationMultiViewport, want: BrowserOperationBudget{Operation: 150 * time.Second, WorkerResponse: 155 * time.Second, WorkerRequest: 160 * time.Second, APIResponse: 165 * time.Second}},
+		{name: "visual diff", operation: BrowserOperationVisualDiff, want: BrowserOperationBudget{Operation: 30 * time.Second, WorkerResponse: 35 * time.Second, WorkerRequest: 40 * time.Second, APIResponse: 45 * time.Second}},
+		{name: "assertions", operation: BrowserOperationAssertions, want: BrowserOperationBudget{Operation: 60 * time.Second, WorkerResponse: 65 * time.Second, WorkerRequest: 70 * time.Second, APIResponse: 75 * time.Second}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tt.want, BrowserOperationBudgetFor(tt.operation), "timeout stack should preserve bounded headroom at every hop")
+		})
+	}
+}
+
+func TestBrowserAccessErrorCode(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		stage BrowserAccessStage
+		code  string
+	}{
+		{name: "token mint", stage: BrowserAccessStageTokenMint, code: "PREVIEW_BROWSER_TOKEN_MINT_FAILED"},
+		{name: "bootstrap navigation", stage: BrowserAccessStageBootstrapNavigation, code: "PREVIEW_BROWSER_BOOTSTRAP_NAVIGATION_FAILED"},
+		{name: "bootstrap exchange", stage: BrowserAccessStageBootstrapExchange, code: "PREVIEW_BROWSER_BOOTSTRAP_EXCHANGE_FAILED"},
+		{name: "authenticated open", stage: BrowserAccessStageAuthenticatedOpen, code: "PREVIEW_BROWSER_AUTHENTICATED_OPEN_FAILED"},
+		{name: "state restore", stage: BrowserAccessStageStateRestore, code: "PREVIEW_BROWSER_STATE_RESTORE_FAILED"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			cause := errors.New("safe test cause")
+			accessErr := &BrowserAccessError{Stage: tt.stage, Err: cause}
+			actual, ok := AsBrowserAccessError(accessErr)
+			require.True(t, ok, "staged errors should remain discoverable through wrapping")
+			require.Equal(t, tt.code, actual.Code(), "stage should map to its stable public error code")
+			require.ErrorIs(t, actual, cause, "staged error should preserve its internal cause")
+		})
+	}
+}

--- a/internal/services/preview/browser_operation_test.go
+++ b/internal/services/preview/browser_operation_test.go
@@ -18,7 +18,7 @@ func TestBrowserOperationBudgetFor(t *testing.T) {
 	}{
 		{name: "screenshot", operation: BrowserOperationScreenshot, want: BrowserOperationBudget{Operation: 30 * time.Second, WorkerResponse: 35 * time.Second, WorkerRequest: 40 * time.Second, APIResponse: 45 * time.Second}},
 		{name: "observe", operation: BrowserOperationObserve, want: BrowserOperationBudget{Operation: 45 * time.Second, WorkerResponse: 50 * time.Second, WorkerRequest: 55 * time.Second, APIResponse: 60 * time.Second}},
-		{name: "interaction", operation: BrowserOperationInteract, want: BrowserOperationBudget{Operation: 60 * time.Second, WorkerResponse: 65 * time.Second, WorkerRequest: 70 * time.Second, APIResponse: 75 * time.Second}},
+		{name: "interaction", operation: BrowserOperationInteract, want: BrowserOperationBudget{Operation: 105 * time.Second, WorkerResponse: 110 * time.Second, WorkerRequest: 115 * time.Second, APIResponse: 120 * time.Second}},
 		{name: "inspect", operation: BrowserOperationInspect, want: BrowserOperationBudget{Operation: 30 * time.Second, WorkerResponse: 35 * time.Second, WorkerRequest: 40 * time.Second, APIResponse: 45 * time.Second}},
 		{name: "multi viewport", operation: BrowserOperationMultiViewport, want: BrowserOperationBudget{Operation: 150 * time.Second, WorkerResponse: 155 * time.Second, WorkerRequest: 160 * time.Second, APIResponse: 165 * time.Second}},
 		{name: "visual diff", operation: BrowserOperationVisualDiff, want: BrowserOperationBudget{Operation: 30 * time.Second, WorkerResponse: 35 * time.Second, WorkerRequest: 40 * time.Second, APIResponse: 45 * time.Second}},
@@ -31,6 +31,17 @@ func TestBrowserOperationBudgetFor(t *testing.T) {
 			require.Equal(t, tt.want, BrowserOperationBudgetFor(tt.operation), "timeout stack should preserve bounded headroom at every hop")
 		})
 	}
+}
+
+func TestBrowserInteractionBudgetCoversStepsAndTrailingObservation(t *testing.T) {
+	t.Parallel()
+
+	interact := BrowserOperationBudgetFor(BrowserOperationInteract).Operation
+	observe := BrowserOperationBudgetFor(BrowserOperationObserve).Operation
+
+	require.Equal(t, maxInteractionTimeout, browserInteractionStepsTimeout, "the inspector step loop should be capped by the documented step budget")
+	require.GreaterOrEqual(t, interact, browserInteractionStepsTimeout+observe,
+		"Act runs the step loop and then a full observation, so a step loop that uses its whole budget must still leave room to observe the resulting page")
 }
 
 func TestBrowserAccessErrorCode(t *testing.T) {

--- a/internal/services/preview/browser_session.go
+++ b/internal/services/preview/browser_session.go
@@ -17,8 +17,7 @@ import (
 )
 
 const (
-	maxBrowserStorageStateBytes      = 1024 * 1024
-	previewBrowserObservationTimeout = 45 * time.Second
+	maxBrowserStorageStateBytes = 1024 * 1024
 )
 
 var (
@@ -134,7 +133,7 @@ func NewBrowserSessionService(store BrowserSessionStore, inspector SessionBrowse
 		store:              store,
 		inspector:          inspector,
 		accessTokenMinter:  accessTokenMinter,
-		observationTimeout: previewBrowserObservationTimeout,
+		observationTimeout: BrowserOperationBudgetFor(BrowserOperationObserve).Operation,
 		locks:              make(map[uuid.UUID]*browserSessionLock),
 	}
 }
@@ -208,7 +207,8 @@ func (s *BrowserSessionService) prepare(ctx context.Context, orgID, sessionID, p
 	}
 	if err := s.inspector.RestoreStorage(ctx, target, record.StorageState); err != nil {
 		if accessErr := s.ensurePreviewAccess(ctx, orgID, sessionID, previewID, target); accessErr != nil {
-			return target, record, models.PreviewBrowserRestorationUnavailable, "preview browser access could not be re-established after restore failure", errors.Join(err, accessErr)
+			restoreErr := &BrowserAccessError{Stage: BrowserAccessStageStateRestore, Err: err}
+			return target, record, models.PreviewBrowserRestorationUnavailable, "preview browser access could not be re-established after restore failure", errors.Join(restoreErr, accessErr)
 		}
 		return target, record, models.PreviewBrowserRestorationReset, "stored browser state was incompatible or could not be restored", nil
 	}
@@ -228,13 +228,16 @@ func (s *BrowserSessionService) ensurePreviewAccess(ctx context.Context, orgID, 
 	}
 	token, err := s.accessTokenMinter.MintBrowserAccessToken(ctx, orgID, sessionID, previewID)
 	if err != nil {
-		return fmt.Errorf("mint preview browser access: %w", err)
+		return &BrowserAccessError{Stage: BrowserAccessStageTokenMint, Err: fmt.Errorf("mint preview browser access: %w", err)}
 	}
 	if strings.TrimSpace(token) == "" {
-		return fmt.Errorf("mint preview browser access: empty token")
+		return &BrowserAccessError{Stage: BrowserAccessStageTokenMint, Err: errors.New("mint preview browser access: empty token")}
 	}
 	if err := accessInspector.BootstrapPreviewAccess(ctx, target, token); err != nil {
-		return fmt.Errorf("bootstrap preview browser access: %w", err)
+		if _, staged := AsBrowserAccessError(err); staged {
+			return err
+		}
+		return &BrowserAccessError{Stage: BrowserAccessStageBootstrapNavigation, Err: fmt.Errorf("bootstrap preview browser access: %w", err)}
 	}
 	return nil
 }
@@ -242,7 +245,7 @@ func (s *BrowserSessionService) ensurePreviewAccess(ctx context.Context, orgID, 
 func (s *BrowserSessionService) Observe(ctx context.Context, orgID, sessionID, previewID uuid.UUID, policy BrowserSessionPolicy, opts models.PreviewObservationOpts) (*models.PreviewObservation, error) {
 	timeout := s.observationTimeout
 	if timeout <= 0 {
-		timeout = previewBrowserObservationTimeout
+		timeout = BrowserOperationBudgetFor(BrowserOperationObserve).Operation
 	}
 	observeCtx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()

--- a/internal/services/preview/browser_session.go
+++ b/internal/services/preview/browser_session.go
@@ -124,8 +124,8 @@ type BrowserAccessTokenMinter interface {
 }
 
 type browserSessionLock struct {
-	mu   sync.Mutex
-	refs int
+	ready chan struct{}
+	refs  int
 }
 
 func NewBrowserSessionService(store BrowserSessionStore, inspector SessionBrowserInspector, accessTokenMinter BrowserAccessTokenMinter) *BrowserSessionService {
@@ -133,7 +133,7 @@ func NewBrowserSessionService(store BrowserSessionStore, inspector SessionBrowse
 		store:              store,
 		inspector:          inspector,
 		accessTokenMinter:  accessTokenMinter,
-		observationTimeout: BrowserOperationBudgetFor(BrowserOperationObserve).Operation,
+		observationTimeout: BrowserOperationBudgetFor(BrowserOperationSessionObserve).Operation,
 		locks:              make(map[uuid.UUID]*browserSessionLock),
 	}
 }
@@ -142,33 +142,46 @@ func (s *BrowserSessionService) EnsureIdentity(ctx context.Context, orgID, sessi
 	if s == nil || s.store == nil {
 		return nil, ErrBrowserUnavailable
 	}
+	identityCtx, cancel := context.WithTimeout(ctx, browserDefaultOperationTimeout)
+	defer cancel()
 	policy = normalizeBrowserPolicy(policy)
 	contextKey := "session:" + sessionID.String()
-	if _, err := s.store.Ensure(ctx, orgID, sessionID, previewID, contextKey, policy.DefaultViewport); err != nil {
+	if _, err := s.store.Ensure(identityCtx, orgID, sessionID, previewID, contextKey, policy.DefaultViewport); err != nil {
 		return nil, fmt.Errorf("ensure browser identity: %w", err)
 	}
 	reused := s.inspector != nil && s.inspector.HasContext(models.BrowserTarget{PreviewID: previewID.String(), SessionID: sessionID.String(), ContextKey: contextKey})
 	return &models.PreviewBrowserContextStatus{ContextKey: contextKey, Reused: reused, Persisted: policy.PersistSession, Restoration: models.PreviewBrowserRestorationUnavailable, StatusDetail: "browser identity is ready; live context starts on first observation"}, nil
 }
 
-func (s *BrowserSessionService) acquireSession(sessionID uuid.UUID) func() {
+func (s *BrowserSessionService) acquireSession(ctx context.Context, sessionID uuid.UUID) (func(), error) {
 	s.locksMu.Lock()
 	entry := s.locks[sessionID]
 	if entry == nil {
-		entry = &browserSessionLock{}
+		entry = &browserSessionLock{ready: make(chan struct{}, 1)}
+		entry.ready <- struct{}{}
 		s.locks[sessionID] = entry
 	}
 	entry.refs++
 	s.locksMu.Unlock()
-	entry.mu.Lock()
-	return func() {
-		entry.mu.Unlock()
+	select {
+	case <-ctx.Done():
 		s.locksMu.Lock()
 		entry.refs--
 		if entry.refs == 0 {
 			delete(s.locks, sessionID)
 		}
 		s.locksMu.Unlock()
+		return nil, ctx.Err()
+	case <-entry.ready:
+		return func() {
+			entry.ready <- struct{}{}
+			s.locksMu.Lock()
+			entry.refs--
+			if entry.refs == 0 {
+				delete(s.locks, sessionID)
+			}
+			s.locksMu.Unlock()
+		}, nil
 	}
 }
 
@@ -208,7 +221,22 @@ func (s *BrowserSessionService) prepare(ctx context.Context, orgID, sessionID, p
 	if err := s.inspector.RestoreStorage(ctx, target, record.StorageState); err != nil {
 		if accessErr := s.ensurePreviewAccess(ctx, orgID, sessionID, previewID, target); accessErr != nil {
 			restoreErr := &BrowserAccessError{Stage: BrowserAccessStageStateRestore, Err: err}
-			return target, record, models.PreviewBrowserRestorationUnavailable, "preview browser access could not be re-established after restore failure", errors.Join(restoreErr, accessErr)
+			// The recovery failure is the terminal and actionable stage. Keep the
+			// preceding restore failure in the chain without allowing it to mask
+			// the bootstrap stage selected by AsBrowserAccessError, and record it
+			// on the recovery error so it stays queryable rather than surviving
+			// only in the joined error text.
+			if recoveryErr, staged := AsBrowserAccessError(accessErr); staged {
+				// Do not mutate an error owned by the inspector: implementations may
+				// reuse error values across calls. A new outer staged error keeps the
+				// terminal stage authoritative and retains the original chain.
+				accessErr = &BrowserAccessError{
+					Stage:          recoveryErr.Stage,
+					PrecedingStage: BrowserAccessStageStateRestore,
+					Err:            accessErr,
+				}
+			}
+			return target, record, models.PreviewBrowserRestorationUnavailable, "preview browser access could not be re-established after restore failure", errors.Join(accessErr, restoreErr)
 		}
 		return target, record, models.PreviewBrowserRestorationReset, "stored browser state was incompatible or could not be restored", nil
 	}
@@ -245,7 +273,7 @@ func (s *BrowserSessionService) ensurePreviewAccess(ctx context.Context, orgID, 
 func (s *BrowserSessionService) Observe(ctx context.Context, orgID, sessionID, previewID uuid.UUID, policy BrowserSessionPolicy, opts models.PreviewObservationOpts) (*models.PreviewObservation, error) {
 	timeout := s.observationTimeout
 	if timeout <= 0 {
-		timeout = BrowserOperationBudgetFor(BrowserOperationObserve).Operation
+		timeout = BrowserOperationBudgetFor(BrowserOperationSessionObserve).Operation
 	}
 	observeCtx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
@@ -268,19 +296,25 @@ func (s *BrowserSessionService) RunAgentOperation(ctx context.Context, orgID, se
 		return ErrBrowserUnavailable
 	}
 	token := uuid.New()
-	started, err := s.store.BeginAgentAction(ctx, orgID, sessionID, token, duration)
+	acquireCtx, acquireCancel := context.WithTimeout(ctx, browserSessionControlAcquireTimeout)
+	started, err := s.store.BeginAgentAction(acquireCtx, orgID, sessionID, token, duration)
 	if err != nil {
+		acquireCancel()
 		return fmt.Errorf("acquire agent browser operation: %w", err)
 	}
 	if !started {
-		control, controlErr := s.GetControl(ctx, orgID, sessionID)
+		control, controlErr := s.GetControl(acquireCtx, orgID, sessionID)
+		acquireCancel()
 		if controlErr == nil && control.State == models.PreviewBrowserControlAgent {
 			return ErrBrowserControlBusy
 		}
 		return ErrBrowserControlHeld
 	}
+	acquireCancel()
 	operationErr := operation()
-	endErr := s.store.EndAgentAction(context.WithoutCancel(ctx), orgID, sessionID, token)
+	releaseCtx, releaseCancel := context.WithTimeout(context.WithoutCancel(ctx), browserSessionControlReleaseTimeout)
+	endErr := s.store.EndAgentAction(releaseCtx, orgID, sessionID, token)
+	releaseCancel()
 	if endErr != nil {
 		endErr = fmt.Errorf("release agent browser operation: %w", endErr)
 	}
@@ -289,9 +323,14 @@ func (s *BrowserSessionService) RunAgentOperation(ctx context.Context, orgID, se
 
 func (s *BrowserSessionService) observe(ctx context.Context, orgID, sessionID, previewID uuid.UUID, policy BrowserSessionPolicy, opts models.PreviewObservationOpts) (*models.PreviewObservation, error) {
 	policy = normalizeBrowserPolicy(policy)
-	release := s.acquireSession(sessionID)
+	release, err := s.acquireSession(ctx, sessionID)
+	if err != nil {
+		return nil, err
+	}
 	defer release()
-	target, record, restoration, restorationDetail, err := s.prepare(ctx, orgID, sessionID, previewID, policy)
+	accessCtx, accessCancel := context.WithTimeout(ctx, browserSessionAccessTimeout)
+	target, record, restoration, restorationDetail, err := s.prepare(accessCtx, orgID, sessionID, previewID, policy)
+	accessCancel()
 	if err != nil {
 		return nil, err
 	}
@@ -310,7 +349,9 @@ func (s *BrowserSessionService) observe(ctx context.Context, orgID, sessionID, p
 	if opts.Path != "" && !pathAllowed(opts.Path, policy.AllowedPaths) {
 		return nil, ErrNavigationNotAllowed
 	}
-	observation, err := s.inspector.Observe(ctx, target, opts)
+	observationCtx, observationCancel := context.WithTimeout(ctx, browserObserveOperationTimeout)
+	observation, err := s.inspector.Observe(observationCtx, target, opts)
+	observationCancel()
 	if err != nil {
 		return nil, err
 	}
@@ -325,34 +366,45 @@ func (s *BrowserSessionService) observe(ctx context.Context, orgID, sessionID, p
 		if opts.PreserveConsoleCursor {
 			persistedCursor = record.ConsoleCursor
 		}
-		if err := s.persist(ctx, orgID, sessionID, target, policy, observation, persistedCursor); err != nil {
-			return nil, err
+		persistCtx, persistCancel := context.WithTimeout(ctx, browserSessionPersistTimeout)
+		persistErr := s.persist(persistCtx, orgID, sessionID, target, policy, observation, persistedCursor)
+		persistCancel()
+		if persistErr != nil {
+			return nil, persistErr
 		}
 	}
 	return observation, nil
 }
 
 func (s *BrowserSessionService) Act(ctx context.Context, orgID, sessionID, previewID uuid.UUID, policy BrowserSessionPolicy, steps []models.InteractionStep, opts models.PreviewObservationOpts) (*models.PreviewActResult, error) {
+	actCtx, cancel := context.WithTimeout(ctx, BrowserOperationBudgetFor(BrowserOperationSessionAct).Operation)
+	defer cancel()
 	var result *models.PreviewActResult
-	err := s.RunAgentOperation(ctx, orgID, sessionID, 5*time.Minute, func() error {
+	err := s.RunAgentOperation(actCtx, orgID, sessionID, 5*time.Minute, func() error {
 		var actErr error
-		result, actErr = s.act(ctx, orgID, sessionID, previewID, policy, steps, opts)
+		result, actErr = s.act(actCtx, orgID, sessionID, previewID, policy, steps, opts)
 		return actErr
 	})
 	return result, err
 }
 
 func (s *BrowserSessionService) ActAsHuman(ctx context.Context, orgID, sessionID, previewID, userID uuid.UUID, policy BrowserSessionPolicy, steps []models.InteractionStep, opts models.PreviewObservationOpts) (*models.PreviewActResult, error) {
+	actCtx, cancel := context.WithTimeout(ctx, BrowserOperationBudgetFor(BrowserOperationSessionAct).Operation)
+	defer cancel()
 	token := uuid.New()
-	allowed, err := s.store.BeginHumanAction(ctx, orgID, sessionID, userID, token, 5*time.Minute)
+	acquireCtx, acquireCancel := context.WithTimeout(actCtx, browserSessionControlAcquireTimeout)
+	allowed, err := s.store.BeginHumanAction(acquireCtx, orgID, sessionID, userID, token, 5*time.Minute)
+	acquireCancel()
 	if err != nil {
 		return nil, fmt.Errorf("acquire human browser action: %w", err)
 	}
 	if !allowed {
 		return nil, ErrBrowserControlHeld
 	}
-	result, actErr := s.act(ctx, orgID, sessionID, previewID, policy, steps, opts)
-	endErr := s.store.EndAgentAction(context.WithoutCancel(ctx), orgID, sessionID, token)
+	result, actErr := s.act(actCtx, orgID, sessionID, previewID, policy, steps, opts)
+	releaseCtx, releaseCancel := context.WithTimeout(context.WithoutCancel(actCtx), browserSessionControlReleaseTimeout)
+	endErr := s.store.EndAgentAction(releaseCtx, orgID, sessionID, token)
+	releaseCancel()
 	if endErr != nil {
 		endErr = fmt.Errorf("release human browser action: %w", endErr)
 	}
@@ -361,14 +413,19 @@ func (s *BrowserSessionService) ActAsHuman(ctx context.Context, orgID, sessionID
 
 func (s *BrowserSessionService) act(ctx context.Context, orgID, sessionID, previewID uuid.UUID, policy BrowserSessionPolicy, steps []models.InteractionStep, opts models.PreviewObservationOpts) (*models.PreviewActResult, error) {
 	policy = normalizeBrowserPolicy(policy)
-	release := s.acquireSession(sessionID)
+	release, err := s.acquireSession(ctx, sessionID)
+	if err != nil {
+		return nil, err
+	}
 	defer release()
 	for _, step := range steps {
 		if step.Action == "navigate" && !pathAllowed(step.Value, policy.AllowedPaths) {
 			return nil, ErrNavigationNotAllowed
 		}
 	}
-	target, record, restoration, restorationDetail, err := s.prepare(ctx, orgID, sessionID, previewID, policy)
+	accessCtx, accessCancel := context.WithTimeout(ctx, browserSessionAccessTimeout)
+	target, record, restoration, restorationDetail, err := s.prepare(accessCtx, orgID, sessionID, previewID, policy)
+	accessCancel()
 	if err != nil {
 		return nil, err
 	}
@@ -392,11 +449,16 @@ func (s *BrowserSessionService) act(ctx context.Context, orgID, sessionID, previ
 	if restoration == models.PreviewBrowserRestorationReset {
 		initialOpts := opts
 		initialOpts.Path = initialBrowserPath(record.CurrentURL, policy.AllowedPaths)
-		if _, initErr := s.inspector.Observe(ctx, target, initialOpts); initErr != nil {
+		initializationCtx, initializationCancel := context.WithTimeout(ctx, browserSessionInitializationTimeout)
+		_, initErr := s.inspector.Observe(initializationCtx, target, initialOpts)
+		initializationCancel()
+		if initErr != nil {
 			return nil, fmt.Errorf("initialize browser page: %w", initErr)
 		}
 	}
-	result, err := s.inspector.Act(ctx, target, steps, opts)
+	interactionCtx, interactionCancel := context.WithTimeout(ctx, browserInteractionOperationTimeout)
+	result, err := s.inspector.Act(interactionCtx, target, steps, opts)
+	interactionCancel()
 	if err != nil {
 		return nil, err
 	}
@@ -407,8 +469,11 @@ func (s *BrowserSessionService) act(ctx context.Context, orgID, sessionID, previ
 		if !urlPathAllowed(result.Observation.URL, policy.AllowedPaths) {
 			return nil, ErrNavigationNotAllowed
 		}
-		if err := s.persist(ctx, orgID, sessionID, target, policy, result.Observation, result.Observation.ConsoleCursor); err != nil {
-			return nil, err
+		persistCtx, persistCancel := context.WithTimeout(ctx, browserSessionPersistTimeout)
+		persistErr := s.persist(persistCtx, orgID, sessionID, target, policy, result.Observation, result.Observation.ConsoleCursor)
+		persistCancel()
+		if persistErr != nil {
+			return nil, persistErr
 		}
 	}
 	return result, nil

--- a/internal/services/preview/browser_session_test.go
+++ b/internal/services/preview/browser_session_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"sync"
 	"testing"
 	"time"
@@ -189,6 +190,7 @@ type fakeSessionBrowserInspector struct {
 	authorizedPreviewID  string
 	bootstrapTokens      []string
 	bootstrapErr         error
+	bootstrapErrs        []error
 	restores             int
 	acts                 int
 	active               int
@@ -197,6 +199,7 @@ type fakeSessionBrowserInspector struct {
 	observeUntilCanceled bool
 	storage              json.RawMessage
 	restoreErr           error
+	restoreClearsAccess  bool
 }
 
 func (i *fakeSessionBrowserInspector) HasContext(models.BrowserTarget) bool {
@@ -213,6 +216,11 @@ func (i *fakeSessionBrowserInspector) BootstrapPreviewAccess(_ context.Context, 
 	i.mu.Lock()
 	defer i.mu.Unlock()
 	i.bootstrapTokens = append(i.bootstrapTokens, token)
+	if len(i.bootstrapErrs) >= len(i.bootstrapTokens) {
+		if err := i.bootstrapErrs[len(i.bootstrapTokens)-1]; err != nil {
+			return err
+		}
+	}
 	if i.bootstrapErr != nil {
 		return i.bootstrapErr
 	}
@@ -260,6 +268,9 @@ func (i *fakeSessionBrowserInspector) RestoreStorage(context.Context, models.Bro
 	defer i.mu.Unlock()
 	i.restores++
 	i.hasContext = true
+	if i.restoreClearsAccess {
+		i.authorizedPreviewID = ""
+	}
 	return i.restoreErr
 }
 
@@ -342,9 +353,10 @@ func TestBrowserSessionService_FailsClosedWhenPreviewAccessCannotBeEstablished(t
 		minterErr     error
 		bootstrapErr  error
 		expectedError string
+		expectedStage BrowserAccessStage
 	}{
-		{name: "token mint fails", minterErr: context.DeadlineExceeded, expectedError: "mint preview browser access"},
-		{name: "token exchange fails", bootstrapErr: context.DeadlineExceeded, expectedError: "bootstrap preview browser access"},
+		{name: "token mint fails", minterErr: context.DeadlineExceeded, expectedError: "mint preview browser access", expectedStage: BrowserAccessStageTokenMint},
+		{name: "bootstrap fails", bootstrapErr: &BrowserAccessError{Stage: BrowserAccessStageBootstrapExchange, Err: context.DeadlineExceeded}, expectedError: "bootstrap_exchange", expectedStage: BrowserAccessStageBootstrapExchange},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -364,8 +376,36 @@ func TestBrowserSessionService_FailsClosedWhenPreviewAccessCannotBeEstablished(t
 
 			require.Error(t, err, "observation should fail without an authorized preview context")
 			require.Contains(t, err.Error(), tt.expectedError, "access setup failure should identify the failed stage")
+			accessErr, ok := AsBrowserAccessError(err)
+			require.True(t, ok, "access setup failure should preserve structured stage information")
+			require.Equal(t, tt.expectedStage, accessErr.Stage, "access setup failure should report the exact failed stage")
 		})
 	}
+}
+
+func TestBrowserSessionService_ClassifiesRestoreFailureWhenAccessRecoveryFails(t *testing.T) {
+	t.Parallel()
+
+	orgID, sessionID, previewID := uuid.New(), uuid.New(), uuid.New()
+	viewport, err := json.Marshal(models.ViewportSpec{Width: 1440, Height: 900})
+	require.NoError(t, err, "test viewport should encode")
+	store := &fakeBrowserSessionStore{record: &models.PreviewBrowserSession{
+		ID: uuid.New(), OrgID: orgID, SessionID: sessionID, PreviewInstanceID: &previewID,
+		ContextKey: "session:" + sessionID.String(), Viewport: viewport, StorageState: json.RawMessage(`{"cookies":[]}`),
+	}}
+	inspector := &fakeSessionBrowserInspector{
+		restoreErr:          errors.New("cookie restore rejected"),
+		restoreClearsAccess: true,
+		bootstrapErrs:       []error{nil, &BrowserAccessError{Stage: BrowserAccessStageBootstrapExchange, Err: errors.New("exchange rejected")}},
+	}
+	service := NewBrowserSessionService(store, inspector, &fakeBrowserAccessTokenMinter{token: "browser-token"})
+
+	_, err = service.Observe(context.Background(), orgID, sessionID, previewID, BrowserSessionPolicy{PersistSession: true}, models.PreviewObservationOpts{})
+
+	require.Error(t, err, "failed state restore and access recovery should fail the observation")
+	accessErr, ok := AsBrowserAccessError(err)
+	require.True(t, ok, "restore failure should retain structured stage information")
+	require.Equal(t, BrowserAccessStageStateRestore, accessErr.Stage, "restore failure should be the primary diagnostic stage")
 }
 
 func TestBrowserSessionService_BoundsObservationDuration(t *testing.T) {

--- a/internal/services/preview/browser_session_test.go
+++ b/internal/services/preview/browser_session_test.go
@@ -15,9 +15,11 @@ import (
 )
 
 type fakeBrowserSessionStore struct {
-	mu     sync.Mutex
-	record *models.PreviewBrowserSession
-	saves  int
+	mu                sync.Mutex
+	record            *models.PreviewBrowserSession
+	saves             int
+	endActionCalls    int
+	endActionDeadline time.Duration
 }
 
 func (s *fakeBrowserSessionStore) GetBySession(context.Context, uuid.UUID, uuid.UUID) (*models.PreviewBrowserSession, error) {
@@ -69,7 +71,14 @@ func (s *fakeBrowserSessionStore) BeginAgentAction(_ context.Context, _, _ uuid.
 	}
 	return false, nil
 }
-func (s *fakeBrowserSessionStore) EndAgentAction(context.Context, uuid.UUID, uuid.UUID, uuid.UUID) error {
+
+func (s *fakeBrowserSessionStore) EndAgentAction(ctx context.Context, _ uuid.UUID, _ uuid.UUID, _ uuid.UUID) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.endActionCalls++
+	if deadline, ok := ctx.Deadline(); ok {
+		s.endActionDeadline = time.Until(deadline)
+	}
 	return nil
 }
 func (s *fakeBrowserSessionStore) BeginHumanAction(_ context.Context, _, _, userID, _ uuid.UUID, _ time.Duration) (bool, error) {
@@ -197,6 +206,8 @@ type fakeSessionBrowserInspector struct {
 	maxActive            int
 	delay                time.Duration
 	observeUntilCanceled bool
+	observeDeadlines     []time.Duration
+	exportDeadline       time.Duration
 	storage              json.RawMessage
 	restoreErr           error
 	restoreClearsAccess  bool
@@ -232,6 +243,9 @@ func (i *fakeSessionBrowserInspector) Observe(ctx context.Context, target models
 	i.mu.Lock()
 	i.hasContext = true
 	waitForCancellation := i.observeUntilCanceled
+	if deadline, ok := ctx.Deadline(); ok {
+		i.observeDeadlines = append(i.observeDeadlines, time.Until(deadline))
+	}
 	i.mu.Unlock()
 	if waitForCancellation {
 		<-ctx.Done()
@@ -257,7 +271,12 @@ func (i *fakeSessionBrowserInspector) Act(ctx context.Context, target models.Bro
 	i.mu.Unlock()
 	return &models.PreviewActResult{Interaction: &models.InteractionResult{Steps: []models.StepResult{{StepIndex: 0, Action: steps[0].Action, Success: true}}}, Observation: observation}, err
 }
-func (i *fakeSessionBrowserInspector) ExportStorage(context.Context, models.BrowserTarget) (json.RawMessage, error) {
+func (i *fakeSessionBrowserInspector) ExportStorage(ctx context.Context, _ models.BrowserTarget) (json.RawMessage, error) {
+	i.mu.Lock()
+	if deadline, ok := ctx.Deadline(); ok {
+		i.exportDeadline = time.Until(deadline)
+	}
+	i.mu.Unlock()
 	if len(i.storage) == 0 {
 		return json.RawMessage(`{"cookies":[]}`), nil
 	}
@@ -383,7 +402,7 @@ func TestBrowserSessionService_FailsClosedWhenPreviewAccessCannotBeEstablished(t
 	}
 }
 
-func TestBrowserSessionService_ClassifiesRestoreFailureWhenAccessRecoveryFails(t *testing.T) {
+func TestBrowserSessionService_ClassifiesAccessRecoveryFailureAfterRestoreFailure(t *testing.T) {
 	t.Parallel()
 
 	orgID, sessionID, previewID := uuid.New(), uuid.New(), uuid.New()
@@ -405,7 +424,29 @@ func TestBrowserSessionService_ClassifiesRestoreFailureWhenAccessRecoveryFails(t
 	require.Error(t, err, "failed state restore and access recovery should fail the observation")
 	accessErr, ok := AsBrowserAccessError(err)
 	require.True(t, ok, "restore failure should retain structured stage information")
-	require.Equal(t, BrowserAccessStageStateRestore, accessErr.Stage, "restore failure should be the primary diagnostic stage")
+	require.Equal(t, BrowserAccessStageBootstrapExchange, accessErr.Stage, "the terminal access recovery failure should be the primary diagnostic stage")
+	require.Contains(t, err.Error(), string(BrowserAccessStageStateRestore), "the preceding restore failure should remain available as diagnostic context")
+	require.Equal(t, BrowserAccessStageStateRestore, accessErr.PrecedingStage,
+		"only one stage survives errors.As, so the failure that triggered recovery must be carried structurally rather than only in the error text")
+}
+
+func TestBrowserSessionService_LeavesPrecedingStageUnsetWithoutACascade(t *testing.T) {
+	t.Parallel()
+
+	orgID, sessionID, previewID := uuid.New(), uuid.New(), uuid.New()
+	store := &fakeBrowserSessionStore{}
+	inspector := &fakeSessionBrowserInspector{
+		bootstrapErrs: []error{&BrowserAccessError{Stage: BrowserAccessStageBootstrapExchange, Err: errors.New("exchange rejected")}},
+	}
+	service := NewBrowserSessionService(store, inspector, &fakeBrowserAccessTokenMinter{token: "browser-token"})
+
+	_, err := service.Observe(context.Background(), orgID, sessionID, previewID, BrowserSessionPolicy{}, models.PreviewObservationOpts{})
+
+	require.Error(t, err, "a failed bootstrap should fail the observation")
+	accessErr, ok := AsBrowserAccessError(err)
+	require.True(t, ok, "bootstrap failure should retain structured stage information")
+	require.Equal(t, BrowserAccessStageBootstrapExchange, accessErr.Stage, "bootstrap failure should report its own stage")
+	require.Empty(t, accessErr.PrecedingStage, "a first-attempt failure has no preceding stage to report")
 }
 
 func TestBrowserSessionService_BoundsObservationDuration(t *testing.T) {
@@ -424,6 +465,63 @@ func TestBrowserSessionService_BoundsObservationDuration(t *testing.T) {
 	)
 
 	require.ErrorIs(t, err, context.DeadlineExceeded, "browser observation should return at its service deadline")
+}
+
+func TestBrowserSessionService_BoundsActionLifecyclePhases(t *testing.T) {
+	t.Parallel()
+
+	inspector := &fakeSessionBrowserInspector{}
+	service := NewBrowserSessionService(&fakeBrowserSessionStore{}, inspector, nil)
+
+	_, err := service.Act(
+		context.Background(),
+		uuid.New(),
+		uuid.New(),
+		uuid.New(),
+		BrowserSessionPolicy{PersistSession: true},
+		[]models.InteractionStep{{Action: "click", Selector: "button"}},
+		models.PreviewObservationOpts{},
+	)
+
+	require.NoError(t, err, "fresh session action should complete")
+	inspector.mu.Lock()
+	observeDeadlines := append([]time.Duration(nil), inspector.observeDeadlines...)
+	exportDeadline := inspector.exportDeadline
+	inspector.mu.Unlock()
+	require.Len(t, observeDeadlines, 2, "fresh actions should separately bound reset-page initialization and the interaction's trailing observation")
+	require.Positive(t, observeDeadlines[0], "initialization deadline should leave time to reset the page")
+	require.LessOrEqual(t, observeDeadlines[0], browserSessionInitializationTimeout, "reset-page initialization should not exceed its phase allowance")
+	require.Positive(t, observeDeadlines[1], "interaction deadline should leave time for the trailing observation")
+	require.LessOrEqual(t, observeDeadlines[1], browserInteractionOperationTimeout, "interaction and its trailing observation should not exceed their shared allowance")
+	require.Positive(t, exportDeadline, "storage export should receive a persistence deadline")
+	require.LessOrEqual(t, exportDeadline, browserSessionPersistTimeout, "storage export should not exceed the persistence allowance")
+}
+
+func TestBrowserSessionService_BoundsObservationLifecyclePhases(t *testing.T) {
+	t.Parallel()
+
+	inspector := &fakeSessionBrowserInspector{}
+	service := NewBrowserSessionService(&fakeBrowserSessionStore{}, inspector, nil)
+
+	_, err := service.Observe(
+		context.Background(),
+		uuid.New(),
+		uuid.New(),
+		uuid.New(),
+		BrowserSessionPolicy{PersistSession: true},
+		models.PreviewObservationOpts{},
+	)
+
+	require.NoError(t, err, "fresh session observation should complete")
+	inspector.mu.Lock()
+	observeDeadlines := append([]time.Duration(nil), inspector.observeDeadlines...)
+	exportDeadline := inspector.exportDeadline
+	inspector.mu.Unlock()
+	require.Len(t, observeDeadlines, 1, "session observation should have one independently bounded browser phase")
+	require.Positive(t, observeDeadlines[0], "browser observation should receive a deadline")
+	require.LessOrEqual(t, observeDeadlines[0], browserObserveOperationTimeout, "browser observation should retain its full phase allowance after access setup")
+	require.Positive(t, exportDeadline, "session observation persistence should receive a deadline")
+	require.LessOrEqual(t, exportDeadline, browserSessionPersistTimeout, "session observation persistence should retain its full phase allowance")
 }
 
 func TestBrowserSessionService_ObserveLifecycle(t *testing.T) {
@@ -525,6 +623,41 @@ func TestBrowserSessionService_SerializesActions(t *testing.T) {
 	require.NoError(t, <-done, "second concurrent action should succeed")
 	require.Equal(t, 1, inspector.maxActive, "one session should execute only one browser action at a time")
 	require.Empty(t, service.locks, "completed actions should release their in-memory session lock")
+}
+
+func TestBrowserSessionService_SessionLockHonorsCancellation(t *testing.T) {
+	t.Parallel()
+
+	service := NewBrowserSessionService(&fakeBrowserSessionStore{}, &fakeSessionBrowserInspector{}, nil)
+	sessionID := uuid.New()
+	release, err := service.acquireSession(context.Background(), sessionID)
+	require.NoError(t, err, "first caller should acquire the session lock")
+
+	waitCtx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+	defer cancel()
+	secondRelease, err := service.acquireSession(waitCtx, sessionID)
+	require.ErrorIs(t, err, context.DeadlineExceeded, "waiting for a busy session lock should honor cancellation")
+	require.Nil(t, secondRelease, "a canceled waiter should not receive a release function")
+
+	release()
+	require.Empty(t, service.locks, "holder release should remove the lock after a canceled waiter exits")
+}
+
+func TestBrowserSessionService_BoundsAgentActionCleanup(t *testing.T) {
+	t.Parallel()
+
+	store := &fakeBrowserSessionStore{}
+	service := NewBrowserSessionService(store, &fakeSessionBrowserInspector{}, nil)
+	err := service.RunAgentOperation(context.Background(), uuid.New(), uuid.New(), time.Minute, func() error { return nil })
+	require.NoError(t, err, "agent operation should complete when cleanup succeeds")
+
+	store.mu.Lock()
+	endActionCalls := store.endActionCalls
+	endActionDeadline := store.endActionDeadline
+	store.mu.Unlock()
+	require.Equal(t, 1, endActionCalls, "agent operation should release its control token exactly once")
+	require.Positive(t, endActionDeadline, "agent action cleanup should receive a deadline")
+	require.LessOrEqual(t, endActionDeadline, browserSessionControlReleaseTimeout, "agent action cleanup should not outlive its release allowance")
 }
 
 func TestBrowserSessionService_IsolatesSessionContextKeys(t *testing.T) {

--- a/internal/services/preview/chromedp_inspector.go
+++ b/internal/services/preview/chromedp_inspector.go
@@ -54,10 +54,10 @@ func mergeContexts(primary, caller context.Context) (context.Context, context.Ca
 
 const (
 	browserIdleTimeout    = 5 * time.Minute
-	defaultOpTimeout      = 30 * time.Second
+	defaultOpTimeout      = browserDefaultOperationTimeout
 	browserResetTimeout   = 5 * time.Second
 	maxInteractionSteps   = 20
-	maxInteractionTimeout = 60 * time.Second
+	maxInteractionTimeout = browserInteractionOperationTimeout
 	maxViewports          = 5
 	maxScreencastDuration = 30 * time.Second
 	maxScreencastFPS      = 4
@@ -756,22 +756,22 @@ func awaitPromiseEvaluation(params *runtime.EvaluateParams) *runtime.EvaluatePar
 
 func (c *ChromeDPInspector) BootstrapPreviewAccess(ctx context.Context, target models.BrowserTarget, token string) error {
 	if strings.TrimSpace(token) == "" {
-		return fmt.Errorf("preview bootstrap token is required")
+		return &BrowserAccessError{Stage: BrowserAccessStageTokenMint, Err: errors.New("preview bootstrap token is required")}
 	}
 	if target.SessionID != "" {
 		c.BindSessionBrowser(target.PreviewID, target.SessionID)
 	}
 	bootstrapURL, err := c.previewURL(target.PreviewID, "/bootstrap")
 	if err != nil {
-		return fmt.Errorf("resolve preview bootstrap URL: %w", err)
+		return &BrowserAccessError{Stage: BrowserAccessStageBootstrapNavigation, Err: fmt.Errorf("resolve preview bootstrap URL: %w", err)}
 	}
 	previewURL, err := c.previewURL(target.PreviewID, "/")
 	if err != nil {
-		return fmt.Errorf("resolve preview URL: %w", err)
+		return &BrowserAccessError{Stage: BrowserAccessStageAuthenticatedOpen, Err: fmt.Errorf("resolve preview URL: %w", err)}
 	}
 	pc, err := c.getOrCreatePreviewCtx(target.PreviewID)
 	if err != nil {
-		return err
+		return &BrowserAccessError{Stage: BrowserAccessStageBootstrapNavigation, Err: err}
 	}
 	merged, mergeCancel := mergeContexts(pc.ctx, ctx)
 	defer mergeCancel()
@@ -792,14 +792,17 @@ func (c *ChromeDPInspector) BootstrapPreviewAccess(ctx context.Context, target m
 		timeoutCtx,
 		chromedp.Navigate(bootstrapURL),
 		chromedp.WaitReady("body", chromedp.ByQuery),
-		chromedp.Evaluate(exchangeScript, &exchangeStatus, awaitPromiseEvaluation),
 	); err != nil {
 		c.dropBrowserContext(target)
-		return fmt.Errorf("exchange preview browser access: %w", err)
+		return &BrowserAccessError{Stage: BrowserAccessStageBootstrapNavigation, Err: fmt.Errorf("open preview bootstrap page: %w", err)}
+	}
+	if err := chromedp.Run(timeoutCtx, chromedp.Evaluate(exchangeScript, &exchangeStatus, awaitPromiseEvaluation)); err != nil {
+		c.dropBrowserContext(target)
+		return &BrowserAccessError{Stage: BrowserAccessStageBootstrapExchange, Err: fmt.Errorf("exchange preview browser access: %w", err)}
 	}
 	if exchangeStatus < http.StatusOK || exchangeStatus >= http.StatusMultipleChoices {
 		c.dropBrowserContext(target)
-		return fmt.Errorf("exchange preview browser access returned status %d", exchangeStatus)
+		return &BrowserAccessError{Stage: BrowserAccessStageBootstrapExchange, Err: fmt.Errorf("exchange preview browser access returned status %d", exchangeStatus)}
 	}
 	var currentURL string
 	if err := chromedp.Run(
@@ -809,11 +812,11 @@ func (c *ChromeDPInspector) BootstrapPreviewAccess(ctx context.Context, target m
 		chromedp.Location(&currentURL),
 	); err != nil {
 		c.dropBrowserContext(target)
-		return fmt.Errorf("open authenticated preview: %w", err)
+		return &BrowserAccessError{Stage: BrowserAccessStageAuthenticatedOpen, Err: fmt.Errorf("open authenticated preview: %w", err)}
 	}
 	if err := validateObservationOrigin(currentURL, previewURL); err != nil {
 		c.dropBrowserContext(target)
-		return fmt.Errorf("authenticated preview left its authorized origin: %w", err)
+		return &BrowserAccessError{Stage: BrowserAccessStageAuthenticatedOpen, Err: fmt.Errorf("authenticated preview left its authorized origin: %w", err)}
 	}
 	key := browserTargetContextKey(target)
 	c.mu.Lock()
@@ -2110,10 +2113,14 @@ func (c *ChromeDPInspector) RunAssertions(ctx context.Context, previewID string,
 	result := &AssertionResult{
 		Total: len(assertions),
 	}
+	merged, mergeCancel := mergeContexts(pc.ctx, ctx)
+	defer mergeCancel()
+	assertionCtx, cancel := context.WithTimeout(merged, BrowserOperationBudgetFor(BrowserOperationAssertions).Operation)
+	defer cancel()
 
 	for _, a := range assertions {
 		// Bail out if the caller context has been cancelled.
-		if err := ctx.Err(); err != nil {
+		if err := assertionCtx.Err(); err != nil {
 			check := AssertionCheck{Assertion: a, Message: fmt.Sprintf("cancelled: %v", err)}
 			result.Failed++
 			result.Results = append(result.Results, check)
@@ -2124,17 +2131,17 @@ func (c *ChromeDPInspector) RunAssertions(ctx context.Context, previewID string,
 
 		switch a.Type {
 		case "element_exists":
-			check = c.assertElementExists(pc, a)
+			check = c.assertElementExists(assertionCtx, a)
 		case "element_text":
-			check = c.assertElementText(pc, a)
+			check = c.assertElementText(assertionCtx, a)
 		case "element_style":
-			check = c.assertElementStyle(pc, a)
+			check = c.assertElementStyle(assertionCtx, a)
 		case "element_count":
-			check = c.assertElementCount(pc, a)
+			check = c.assertElementCount(assertionCtx, a)
 		case "no_console_errors":
 			check = c.assertNoConsoleErrors(pc, a)
 		case "page_title":
-			check = c.assertPageTitle(pc, a)
+			check = c.assertPageTitle(assertionCtx, a)
 		case "viewport_screenshot_match":
 			check = c.assertViewportScreenshotMatch(pc, a)
 		default:
@@ -2152,7 +2159,7 @@ func (c *ChromeDPInspector) RunAssertions(ctx context.Context, previewID string,
 	return result, nil
 }
 
-func (c *ChromeDPInspector) assertElementExists(pc *previewContext, a Assertion) AssertionCheck {
+func (c *ChromeDPInspector) assertElementExists(ctx context.Context, a Assertion) AssertionCheck {
 	check := AssertionCheck{Assertion: a}
 
 	selectorJSON, err := json.Marshal(a.Selector)
@@ -2173,7 +2180,7 @@ func (c *ChromeDPInspector) assertElementExists(pc *previewContext, a Assertion)
 	})()`, string(selectorJSON), a.Visible != nil && *a.Visible)
 
 	var result string
-	if err := chromedp.Run(pc.ctx, chromedp.Evaluate(js, &result)); err != nil {
+	if err := chromedp.Run(ctx, chromedp.Evaluate(js, &result)); err != nil {
 		check.Message = fmt.Sprintf("error: %v", err)
 		return check
 	}
@@ -2193,11 +2200,11 @@ func (c *ChromeDPInspector) assertElementExists(pc *previewContext, a Assertion)
 	return check
 }
 
-func (c *ChromeDPInspector) assertElementText(pc *previewContext, a Assertion) AssertionCheck {
+func (c *ChromeDPInspector) assertElementText(ctx context.Context, a Assertion) AssertionCheck {
 	check := AssertionCheck{Assertion: a}
 
 	var text string
-	if err := chromedp.Run(pc.ctx, chromedp.Text(a.Selector, &text, chromedp.ByQuery)); err != nil {
+	if err := chromedp.Run(ctx, chromedp.Text(a.Selector, &text, chromedp.ByQuery)); err != nil {
 		check.Message = fmt.Sprintf("error: %v", err)
 		return check
 	}
@@ -2218,7 +2225,7 @@ func (c *ChromeDPInspector) assertElementText(pc *previewContext, a Assertion) A
 	return check
 }
 
-func (c *ChromeDPInspector) assertElementStyle(pc *previewContext, a Assertion) AssertionCheck {
+func (c *ChromeDPInspector) assertElementStyle(ctx context.Context, a Assertion) AssertionCheck {
 	check := AssertionCheck{Assertion: a}
 
 	selectorJSON, err := json.Marshal(a.Selector)
@@ -2238,7 +2245,7 @@ func (c *ChromeDPInspector) assertElementStyle(pc *previewContext, a Assertion) 
 	})()`, string(selectorJSON), string(propertyJSON))
 
 	var actual string
-	if err := chromedp.Run(pc.ctx, chromedp.Evaluate(js, &actual)); err != nil {
+	if err := chromedp.Run(ctx, chromedp.Evaluate(js, &actual)); err != nil {
 		check.Message = fmt.Sprintf("error: %v", err)
 		return check
 	}
@@ -2259,7 +2266,7 @@ func (c *ChromeDPInspector) assertElementStyle(pc *previewContext, a Assertion) 
 	return check
 }
 
-func (c *ChromeDPInspector) assertElementCount(pc *previewContext, a Assertion) AssertionCheck {
+func (c *ChromeDPInspector) assertElementCount(ctx context.Context, a Assertion) AssertionCheck {
 	check := AssertionCheck{Assertion: a}
 
 	selectorJSON, err := json.Marshal(a.Selector)
@@ -2269,7 +2276,7 @@ func (c *ChromeDPInspector) assertElementCount(pc *previewContext, a Assertion) 
 	}
 	js := fmt.Sprintf(`document.querySelectorAll(%s).length`, string(selectorJSON))
 	var count int
-	if err := chromedp.Run(pc.ctx, chromedp.Evaluate(js, &count)); err != nil {
+	if err := chromedp.Run(ctx, chromedp.Evaluate(js, &count)); err != nil {
 		check.Message = fmt.Sprintf("error: %v", err)
 		return check
 	}
@@ -2313,11 +2320,11 @@ func (c *ChromeDPInspector) assertNoConsoleErrors(pc *previewContext, a Assertio
 	return check
 }
 
-func (c *ChromeDPInspector) assertPageTitle(pc *previewContext, a Assertion) AssertionCheck {
+func (c *ChromeDPInspector) assertPageTitle(ctx context.Context, a Assertion) AssertionCheck {
 	check := AssertionCheck{Assertion: a}
 
 	var title string
-	if err := chromedp.Run(pc.ctx, chromedp.Title(&title)); err != nil {
+	if err := chromedp.Run(ctx, chromedp.Title(&title)); err != nil {
 		check.Message = fmt.Sprintf("error: %v", err)
 		return check
 	}

--- a/internal/services/preview/chromedp_inspector.go
+++ b/internal/services/preview/chromedp_inspector.go
@@ -607,6 +607,12 @@ func (c *ChromeDPInspector) ReadConsole(ctx context.Context, previewID string) (
 }
 
 func (c *ChromeDPInspector) Observe(ctx context.Context, target models.BrowserTarget, opts models.PreviewObservationOpts) (*models.PreviewObservation, error) {
+	// The screenshot bounds itself, but the AX tree walk and DOM excerpt below
+	// do not. Bound the observation as a whole so it can never overrun the
+	// budget callers reserve for it -- notably Act, whose operation budget is
+	// sized as the step loop plus one observation.
+	ctx, cancel := context.WithTimeout(ctx, browserObserveOperationTimeout)
+	defer cancel()
 	if target.ContextKey == "" {
 		target.ContextKey = target.PreviewID
 	}
@@ -857,8 +863,10 @@ func (c *ChromeDPInspector) ExportStorage(ctx context.Context, target models.Bro
 	}
 	merged, cancel := mergeContexts(pc.ctx, ctx)
 	defer cancel()
+	timeoutCtx, timeoutCancel := context.WithTimeout(merged, defaultOpTimeout)
+	defer timeoutCancel()
 	var state browserStorageState
-	if err := chromedp.Run(merged, chromedp.Location(&state.URL), chromedp.Evaluate(`Object.fromEntries(Object.entries(localStorage))`, &state.LocalStorage), chromedp.ActionFunc(func(runCtx context.Context) error {
+	if err := chromedp.Run(timeoutCtx, chromedp.Location(&state.URL), chromedp.Evaluate(`Object.fromEntries(Object.entries(localStorage))`, &state.LocalStorage), chromedp.ActionFunc(func(runCtx context.Context) error {
 		cookies, cookieErr := network.GetCookies().Do(runCtx)
 		state.Cookies = persistableBrowserCookies(cookies)
 		return cookieErr
@@ -897,6 +905,8 @@ func (c *ChromeDPInspector) RestoreStorage(ctx context.Context, target models.Br
 	}
 	merged, cancel := mergeContexts(pc.ctx, ctx)
 	defer cancel()
+	timeoutCtx, timeoutCancel := context.WithTimeout(merged, defaultOpTimeout)
+	defer timeoutCancel()
 	storageJSON, err := json.Marshal(state.LocalStorage)
 	if err != nil {
 		return fmt.Errorf("marshal local storage: %w", err)
@@ -904,7 +914,7 @@ func (c *ChromeDPInspector) RestoreStorage(ctx context.Context, target models.Br
 	storageScript := fmt.Sprintf(`(values => { localStorage.clear(); for (const [key,value] of Object.entries(values)) localStorage.setItem(key,value) })(%s)`, storageJSON)
 	oldURL, _ := url.Parse(state.URL)
 	newURL, _ := url.Parse(destinationURL)
-	err = chromedp.Run(merged, chromedp.ActionFunc(func(runCtx context.Context) error {
+	err = chromedp.Run(timeoutCtx, chromedp.ActionFunc(func(runCtx context.Context) error {
 		for _, cookie := range state.Cookies {
 			if cookie == nil || isPreviewGatewaySessionCookie(cookie.Name) {
 				continue

--- a/internal/services/preview/chromedp_inspector.go
+++ b/internal/services/preview/chromedp_inspector.go
@@ -57,7 +57,7 @@ const (
 	defaultOpTimeout      = browserDefaultOperationTimeout
 	browserResetTimeout   = 5 * time.Second
 	maxInteractionSteps   = 20
-	maxInteractionTimeout = browserInteractionOperationTimeout
+	maxInteractionTimeout = browserInteractionStepsTimeout
 	maxViewports          = 5
 	maxScreencastDuration = 30 * time.Second
 	maxScreencastFPS      = 4

--- a/internal/services/preview/chromedp_inspector_test.go
+++ b/internal/services/preview/chromedp_inspector_test.go
@@ -32,6 +32,18 @@ func TestChromeDPInspector_BindsSessionContextIdentity(t *testing.T) {
 	require.False(t, inspector.HasContext(models.BrowserTarget{PreviewID: "preview-new", SessionID: "session-1", ContextKey: "session:session-1"}), "binding should not eagerly launch a browser")
 }
 
+func TestChromeDPInspector_BootstrapRejectsEmptyTokenWithStage(t *testing.T) {
+	t.Parallel()
+
+	inspector := NewChromeDPInspector(ChromeDPInspectorConfig{}, zerolog.Nop())
+	err := inspector.BootstrapPreviewAccess(context.Background(), models.BrowserTarget{PreviewID: "preview-1"}, " ")
+
+	require.Error(t, err, "bootstrap should reject an empty access token")
+	accessErr, ok := AsBrowserAccessError(err)
+	require.True(t, ok, "bootstrap token validation should return a staged error")
+	require.Equal(t, BrowserAccessStageTokenMint, accessErr.Stage, "empty bootstrap token should be classified at token mint stage")
+}
+
 func TestChromeDPInspector_BindAdoptsRawContext(t *testing.T) {
 	t.Parallel()
 	inspector := NewChromeDPInspector(ChromeDPInspectorConfig{}, zerolog.Nop())

--- a/internal/services/preview/worker_client.go
+++ b/internal/services/preview/worker_client.go
@@ -11,9 +11,11 @@ import (
 	"strings"
 	"time"
 
+	chiMiddleware "github.com/go-chi/chi/v5/middleware"
 	"github.com/google/uuid"
 
 	"github.com/assembledhq/143/internal/auth"
+	"github.com/assembledhq/143/internal/internalapi"
 	"github.com/assembledhq/143/internal/models"
 )
 
@@ -24,15 +26,17 @@ const previewWorkerTokenTTL = 30 * time.Second
 // probes, each defaulting to 90s) or the API gives up before the worker
 // finishes, surfacing as "context canceled" on a readiness probe.
 const previewWorkerHTTPTimeout = 10 * time.Minute
-const previewWorkerObservationTimeout = 50 * time.Second
-
 const PreviewSoftRestartUnsupportedCode = "PREVIEW_SOFT_RESTART_UNSUPPORTED"
+
+type workerNodeContextKey struct{}
 
 // WorkerRequestError preserves structured worker error responses.
 type WorkerRequestError struct {
-	StatusCode int
-	Code       string
-	Message    string
+	StatusCode   int
+	Code         string
+	Message      string
+	Details      any
+	WorkerNodeID string
 }
 
 func (e *WorkerRequestError) Error() string {
@@ -253,6 +257,7 @@ func (c *WorkerPreviewClient) newRequest(
 		}
 		reader = bytes.NewReader(payload)
 	}
+	ctx = context.WithValue(ctx, workerNodeContextKey{}, claims.TargetNodeID)
 	req, err := http.NewRequestWithContext(ctx, method, url, reader)
 	if err != nil {
 		return nil, fmt.Errorf("build request: %w", err)
@@ -265,6 +270,9 @@ func (c *WorkerPreviewClient) newRequest(
 		return nil, fmt.Errorf("sign preview token: %w", err)
 	}
 	req.Header.Set("Authorization", "Bearer "+token)
+	if parentRequestID := internalapi.NormalizeParentRequestID(chiMiddleware.GetReqID(ctx)); parentRequestID != "" {
+		req.Header.Set(internalapi.ParentRequestIDHeader, parentRequestID)
+	}
 	return req, nil
 }
 
@@ -275,14 +283,17 @@ func decodeWorkerResponse[T any](resp *http.Response) (*T, error) {
 		var payload models.ErrorResponse
 		if err := json.Unmarshal(body, &payload); err == nil && payload.Error.Code != "" {
 			return nil, &WorkerRequestError{
-				StatusCode: resp.StatusCode,
-				Code:       payload.Error.Code,
-				Message:    payload.Error.Message,
+				StatusCode:   resp.StatusCode,
+				Code:         payload.Error.Code,
+				Message:      payload.Error.Message,
+				Details:      payload.Error.Details,
+				WorkerNodeID: responseWorkerNodeID(resp),
 			}
 		}
 		return nil, &WorkerRequestError{
-			StatusCode: resp.StatusCode,
-			Message:    strings.TrimSpace(string(body)),
+			StatusCode:   resp.StatusCode,
+			Message:      strings.TrimSpace(string(body)),
+			WorkerNodeID: responseWorkerNodeID(resp),
 		}
 	}
 	var payload models.SingleResponse[T]
@@ -299,14 +310,17 @@ func decodeWorkerListResponse[T any](resp *http.Response) ([]T, error) {
 		var payload models.ErrorResponse
 		if err := json.Unmarshal(body, &payload); err == nil && payload.Error.Code != "" {
 			return nil, &WorkerRequestError{
-				StatusCode: resp.StatusCode,
-				Code:       payload.Error.Code,
-				Message:    payload.Error.Message,
+				StatusCode:   resp.StatusCode,
+				Code:         payload.Error.Code,
+				Message:      payload.Error.Message,
+				Details:      payload.Error.Details,
+				WorkerNodeID: responseWorkerNodeID(resp),
 			}
 		}
 		return nil, &WorkerRequestError{
-			StatusCode: resp.StatusCode,
-			Message:    strings.TrimSpace(string(body)),
+			StatusCode:   resp.StatusCode,
+			Message:      strings.TrimSpace(string(body)),
+			WorkerNodeID: responseWorkerNodeID(resp),
 		}
 	}
 	var payload models.ListResponse[T]
@@ -316,6 +330,14 @@ func decodeWorkerListResponse[T any](resp *http.Response) ([]T, error) {
 	return payload.Data, nil
 }
 
+func responseWorkerNodeID(resp *http.Response) string {
+	if resp == nil || resp.Request == nil {
+		return ""
+	}
+	workerNodeID, _ := resp.Request.Context().Value(workerNodeContextKey{}).(string)
+	return workerNodeID
+}
+
 // AsWorkerRequestError unwraps a worker client error.
 func AsWorkerRequestError(err error) (*WorkerRequestError, bool) {
 	var target *WorkerRequestError
@@ -323,6 +345,10 @@ func AsWorkerRequestError(err error) (*WorkerRequestError, bool) {
 		return target, true
 	}
 	return nil, false
+}
+
+func withBrowserWorkerRequestTimeout(ctx context.Context, operation BrowserOperation) (context.Context, context.CancelFunc) {
+	return context.WithTimeout(ctx, BrowserOperationBudgetFor(operation).WorkerRequest)
 }
 
 func (c *WorkerPreviewClient) StartPreview(ctx context.Context, worker WorkerNode, reqBody RemoteStartPreviewRequest) (*models.PreviewInstance, error) {
@@ -409,6 +435,8 @@ func (c *WorkerPreviewClient) recyclePreview(ctx context.Context, worker WorkerN
 }
 
 func (c *WorkerPreviewClient) CaptureScreenshot(ctx context.Context, worker WorkerNode, orgID, previewID uuid.UUID, opts models.ScreenshotOpts) (*models.ScreenshotResult, error) {
+	ctx, cancel := withBrowserWorkerRequestTimeout(ctx, BrowserOperationScreenshot)
+	defer cancel()
 	req, err := c.newRequest(ctx, http.MethodPost, fmt.Sprintf("%s/internal/preview/%s/screenshot", worker.BaseURL, previewID), auth.PreviewTokenClaims{
 		OrgID:        orgID,
 		TargetNodeID: worker.ID,
@@ -435,6 +463,8 @@ func (c *WorkerPreviewClient) InspectElementBySelector(ctx context.Context, work
 }
 
 func (c *WorkerPreviewClient) inspectElement(ctx context.Context, worker WorkerNode, orgID, previewID uuid.UUID, body RemoteInspectElementRequest) (*models.ElementInfo, error) {
+	ctx, cancel := withBrowserWorkerRequestTimeout(ctx, BrowserOperationInspect)
+	defer cancel()
 	req, err := c.newRequest(ctx, http.MethodPost, fmt.Sprintf("%s/internal/preview/%s/inspect", worker.BaseURL, previewID), auth.PreviewTokenClaims{
 		OrgID:        orgID,
 		TargetNodeID: worker.ID,
@@ -471,6 +501,8 @@ func (c *WorkerPreviewClient) ReadConsole(ctx context.Context, worker WorkerNode
 }
 
 func (c *WorkerPreviewClient) ExecuteInteraction(ctx context.Context, worker WorkerNode, orgID, previewID uuid.UUID, steps []models.InteractionStep) (*models.InteractionResult, error) {
+	ctx, cancel := withBrowserWorkerRequestTimeout(ctx, BrowserOperationInteract)
+	defer cancel()
 	req, err := c.newRequest(ctx, http.MethodPost, fmt.Sprintf("%s/internal/preview/%s/interact", worker.BaseURL, previewID), auth.PreviewTokenClaims{
 		OrgID:        orgID,
 		TargetNodeID: worker.ID,
@@ -489,7 +521,7 @@ func (c *WorkerPreviewClient) ExecuteInteraction(ctx context.Context, worker Wor
 }
 
 func (c *WorkerPreviewClient) Observe(ctx context.Context, worker WorkerNode, orgID, sessionID, previewID uuid.UUID, body RemoteObserveRequest) (*models.PreviewObservation, error) {
-	observeCtx, cancel := context.WithTimeout(ctx, previewWorkerObservationTimeout)
+	observeCtx, cancel := withBrowserWorkerRequestTimeout(ctx, BrowserOperationObserve)
 	defer cancel()
 	req, err := c.newRequest(observeCtx, http.MethodPost, fmt.Sprintf("%s/internal/preview/%s/observe", worker.BaseURL, previewID), auth.PreviewTokenClaims{OrgID: orgID, TargetNodeID: worker.ID, PreviewID: &previewID, SessionID: &sessionID, Action: "observe", ExpiresAt: time.Now().Add(previewWorkerTokenTTL)}, body)
 	if err != nil {
@@ -503,6 +535,8 @@ func (c *WorkerPreviewClient) Observe(ctx context.Context, worker WorkerNode, or
 }
 
 func (c *WorkerPreviewClient) Act(ctx context.Context, worker WorkerNode, orgID, sessionID, previewID uuid.UUID, body RemoteActRequest) (*models.PreviewActResult, error) {
+	ctx, cancel := withBrowserWorkerRequestTimeout(ctx, BrowserOperationInteract)
+	defer cancel()
 	req, err := c.newRequest(ctx, http.MethodPost, fmt.Sprintf("%s/internal/preview/%s/act", worker.BaseURL, previewID), auth.PreviewTokenClaims{OrgID: orgID, TargetNodeID: worker.ID, PreviewID: &previewID, SessionID: &sessionID, Action: "act", ExpiresAt: time.Now().Add(previewWorkerTokenTTL)}, body)
 	if err != nil {
 		return nil, err
@@ -515,6 +549,8 @@ func (c *WorkerPreviewClient) Act(ctx context.Context, worker WorkerNode, orgID,
 }
 
 func (c *WorkerPreviewClient) ActAsHuman(ctx context.Context, worker WorkerNode, orgID, sessionID, previewID, userID uuid.UUID, body RemoteActRequest) (*models.PreviewActResult, error) {
+	ctx, cancel := withBrowserWorkerRequestTimeout(ctx, BrowserOperationInteract)
+	defer cancel()
 	payload := RemoteHumanActRequest{RemoteActRequest: body, UserID: userID}
 	req, err := c.newRequest(ctx, http.MethodPost, fmt.Sprintf("%s/internal/preview/%s/human-act", worker.BaseURL, previewID), auth.PreviewTokenClaims{OrgID: orgID, TargetNodeID: worker.ID, PreviewID: &previewID, SessionID: &sessionID, Action: "human_act", ExpiresAt: time.Now().Add(previewWorkerTokenTTL)}, payload)
 	if err != nil {
@@ -528,6 +564,8 @@ func (c *WorkerPreviewClient) ActAsHuman(ctx context.Context, worker WorkerNode,
 }
 
 func (c *WorkerPreviewClient) CaptureMultiViewport(ctx context.Context, worker WorkerNode, orgID, previewID uuid.UUID, opts models.MultiViewportOpts) (*models.MultiViewportResult, error) {
+	ctx, cancel := withBrowserWorkerRequestTimeout(ctx, BrowserOperationMultiViewport)
+	defer cancel()
 	req, err := c.newRequest(ctx, http.MethodPost, fmt.Sprintf("%s/internal/preview/%s/multi-viewport", worker.BaseURL, previewID), auth.PreviewTokenClaims{
 		OrgID:        orgID,
 		TargetNodeID: worker.ID,
@@ -546,6 +584,8 @@ func (c *WorkerPreviewClient) CaptureMultiViewport(ctx context.Context, worker W
 }
 
 func (c *WorkerPreviewClient) ComputeVisualDiff(ctx context.Context, worker WorkerNode, orgID, previewID uuid.UUID, beforeSnapshotID, afterSnapshotID string) (*models.VisualDiff, error) {
+	ctx, cancel := withBrowserWorkerRequestTimeout(ctx, BrowserOperationVisualDiff)
+	defer cancel()
 	req, err := c.newRequest(ctx, http.MethodPost, fmt.Sprintf("%s/internal/preview/%s/visual-diff", worker.BaseURL, previewID), auth.PreviewTokenClaims{
 		OrgID:        orgID,
 		TargetNodeID: worker.ID,
@@ -564,6 +604,8 @@ func (c *WorkerPreviewClient) ComputeVisualDiff(ctx context.Context, worker Work
 }
 
 func (c *WorkerPreviewClient) RunAssertions(ctx context.Context, worker WorkerNode, orgID, previewID uuid.UUID, assertions []Assertion) (*AssertionResult, error) {
+	ctx, cancel := withBrowserWorkerRequestTimeout(ctx, BrowserOperationAssertions)
+	defer cancel()
 	req, err := c.newRequest(ctx, http.MethodPost, fmt.Sprintf("%s/internal/preview/%s/assert", worker.BaseURL, previewID), auth.PreviewTokenClaims{
 		OrgID:        orgID,
 		TargetNodeID: worker.ID,

--- a/internal/services/preview/worker_client.go
+++ b/internal/services/preview/worker_client.go
@@ -521,7 +521,7 @@ func (c *WorkerPreviewClient) ExecuteInteraction(ctx context.Context, worker Wor
 }
 
 func (c *WorkerPreviewClient) Observe(ctx context.Context, worker WorkerNode, orgID, sessionID, previewID uuid.UUID, body RemoteObserveRequest) (*models.PreviewObservation, error) {
-	observeCtx, cancel := withBrowserWorkerRequestTimeout(ctx, BrowserOperationObserve)
+	observeCtx, cancel := withBrowserWorkerRequestTimeout(ctx, BrowserOperationSessionObserve)
 	defer cancel()
 	req, err := c.newRequest(observeCtx, http.MethodPost, fmt.Sprintf("%s/internal/preview/%s/observe", worker.BaseURL, previewID), auth.PreviewTokenClaims{OrgID: orgID, TargetNodeID: worker.ID, PreviewID: &previewID, SessionID: &sessionID, Action: "observe", ExpiresAt: time.Now().Add(previewWorkerTokenTTL)}, body)
 	if err != nil {
@@ -535,7 +535,7 @@ func (c *WorkerPreviewClient) Observe(ctx context.Context, worker WorkerNode, or
 }
 
 func (c *WorkerPreviewClient) Act(ctx context.Context, worker WorkerNode, orgID, sessionID, previewID uuid.UUID, body RemoteActRequest) (*models.PreviewActResult, error) {
-	ctx, cancel := withBrowserWorkerRequestTimeout(ctx, BrowserOperationInteract)
+	ctx, cancel := withBrowserWorkerRequestTimeout(ctx, BrowserOperationSessionAct)
 	defer cancel()
 	req, err := c.newRequest(ctx, http.MethodPost, fmt.Sprintf("%s/internal/preview/%s/act", worker.BaseURL, previewID), auth.PreviewTokenClaims{OrgID: orgID, TargetNodeID: worker.ID, PreviewID: &previewID, SessionID: &sessionID, Action: "act", ExpiresAt: time.Now().Add(previewWorkerTokenTTL)}, body)
 	if err != nil {
@@ -549,7 +549,7 @@ func (c *WorkerPreviewClient) Act(ctx context.Context, worker WorkerNode, orgID,
 }
 
 func (c *WorkerPreviewClient) ActAsHuman(ctx context.Context, worker WorkerNode, orgID, sessionID, previewID, userID uuid.UUID, body RemoteActRequest) (*models.PreviewActResult, error) {
-	ctx, cancel := withBrowserWorkerRequestTimeout(ctx, BrowserOperationInteract)
+	ctx, cancel := withBrowserWorkerRequestTimeout(ctx, BrowserOperationSessionAct)
 	defer cancel()
 	payload := RemoteHumanActRequest{RemoteActRequest: body, UserID: userID}
 	req, err := c.newRequest(ctx, http.MethodPost, fmt.Sprintf("%s/internal/preview/%s/human-act", worker.BaseURL, previewID), auth.PreviewTokenClaims{OrgID: orgID, TargetNodeID: worker.ID, PreviewID: &previewID, SessionID: &sessionID, Action: "human_act", ExpiresAt: time.Now().Add(previewWorkerTokenTTL)}, payload)

--- a/internal/services/preview/worker_client_test.go
+++ b/internal/services/preview/worker_client_test.go
@@ -12,7 +12,9 @@ import (
 	"time"
 
 	"github.com/assembledhq/143/internal/auth"
+	"github.com/assembledhq/143/internal/internalapi"
 	"github.com/assembledhq/143/internal/models"
+	chiMiddleware "github.com/go-chi/chi/v5/middleware"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 )
@@ -235,7 +237,7 @@ func TestWorkerPreviewClient_PropagatesStructuredWorkerErrors(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusServiceUnavailable)
 		require.NoError(t, json.NewEncoder(w).Encode(models.ErrorResponse{
-			Error: models.ErrorDetail{Code: PreviewCapacityCode, Message: "all preview slots are in use"},
+			Error: models.ErrorDetail{Code: PreviewCapacityCode, Message: "all preview slots are in use", Details: map[string]string{"stage": "bootstrap_exchange"}},
 		}), "worker error responses should encode structured errors")
 	}))
 	defer server.Close()
@@ -251,7 +253,36 @@ func TestWorkerPreviewClient_PropagatesStructuredWorkerErrors(t *testing.T) {
 	require.True(t, ok, "StartPreview should expose structured worker errors")
 	require.Equal(t, http.StatusServiceUnavailable, reqErr.StatusCode, "worker error status should be preserved")
 	require.Equal(t, PreviewCapacityCode, reqErr.Code, "worker error code should be preserved")
+	require.Equal(t, map[string]any{"stage": "bootstrap_exchange"}, reqErr.Details, "worker error details should be preserved for the public API")
+	require.Equal(t, worker.ID, reqErr.WorkerNodeID, "worker errors should retain the target node for correlated diagnostics")
 	require.Contains(t, reqErr.Error(), PreviewCapacityCode, "worker error string should include the code")
+}
+
+func TestWorkerPreviewClient_PropagatesParentRequestID(t *testing.T) {
+	t.Parallel()
+
+	const requestID = "public-request-123"
+	orgID, previewID := uuid.New(), uuid.New()
+	worker := WorkerNode{ID: "worker-1", Mode: "worker"}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, requestID, r.Header.Get(internalapi.ParentRequestIDHeader), "worker request should correlate to the originating public request")
+		require.NoError(t, json.NewEncoder(w).Encode(models.SingleResponse[*models.ScreenshotResult]{Data: &models.ScreenshotResult{URL: "https://preview.test"}}), "worker response should encode")
+	}))
+	defer server.Close()
+	worker.BaseURL = server.URL
+	client := NewWorkerPreviewClient("worker-secret")
+
+	var callErr error
+	inbound := httptest.NewRequest(http.MethodPost, "/api/v1/previews/preview/screenshot", nil)
+	inbound.Header.Set(chiMiddleware.RequestIDHeader, requestID)
+	rr := httptest.NewRecorder()
+	chiMiddleware.RequestID(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, callErr = client.CaptureScreenshot(r.Context(), worker, orgID, previewID, models.ScreenshotOpts{})
+		w.WriteHeader(http.StatusNoContent)
+	})).ServeHTTP(rr, inbound)
+
+	require.NoError(t, callErr, "correlated worker request should succeed")
+	require.Equal(t, http.StatusNoContent, rr.Code, "test public handler should complete")
 }
 
 func TestWorkerPreviewClient_DecodeFailures(t *testing.T) {


### PR DESCRIPTION
## Summary

Browser preview requests can exceed expected lifetimes and fail with unhelpful EOF/timeout behavior, making it hard to debug and reliably restore session state. This change introduces lifecycle-aware timeout budgets (including response write deadlines), safely preserves bootstrap failure stages for diagnostics, and tightens worker routing/deadline handling to avoid topology/latency overruns.

## Changes

- Add an operation start timestamp to requests and enforce a bounded, operation-specific response write deadline so long browser operations return a useful JSON error instead of surfacing EOF.
- Introduce a lifecycle-aware session-action budget (setup/observation/persistence/coordination allowances) so session work is consistently capped across the request lifecycle.
- Preserve the terminal bootstrap failure stage while exposing `state_restore` safely as `preceding_stage`, improving restore troubleshooting without breaking existing stage semantics.
- Resolve worker topology first with an independent cap, then apply local/remote deadlines and refresh API headroom to keep end-to-end latency within the overall budget.

## Validation

- `go test ./...`
- `go vet ./...`
- Focused tests and vet after the final resolution-timeout change
- `git diff --check`

Files touched include API handlers/helpers, preview worker routing, and preview browser session/operation logic (e.g., `internal/services/preview/browser_operation.go`, `internal/services/preview/browser_session.go`, `internal/api/handlers/preview.go`).  
Note: publication workflow returned `manual_publication_required` for publication `70ec5dc3-a2e2-4143-aed1-36842aec6c25`.

[143.dev](https://143.dev) | [session cd1a0aba](https://143.dev/sessions/cd1a0aba-e26f-4676-bd9f-c7062ab5d5cd)

<!-- 143-publication session=cd1a0aba-e26f-4676-bd9f-c7062ab5d5cd changeset=a9f93c2e-faaa-48d5-b4aa-2eda6666bfa1 -->

Preview: https://143.dev/previews/github/assembledhq/143/pull/2064?launch=1