### PR TITLE
Fix shared browser preview error handling

### DIFF
--- a/frontend/src/components/preview/shared-browser-surface.test.tsx
+++ b/frontend/src/components/preview/shared-browser-surface.test.tsx
@@ -1,6 +1,11 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { act } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { renderWithProviders, screen, userEvent, waitFor } from "@/test/test-utils";
-import { mapSharedBrowserPoint, SharedBrowserSurface } from "./shared-browser-surface";
+import {
+  mapSharedBrowserPoint,
+  sharedBrowserErrorMessage,
+  SharedBrowserSurface,
+} from "./shared-browser-surface";
 
 const mocks = vi.hoisted(() => ({
   control: vi.fn(),
@@ -34,6 +39,10 @@ describe("SharedBrowserSurface", () => {
     mocks.acquire.mockResolvedValue({ state: "human_control" });
     mocks.release.mockResolvedValue({ state: "agent_control" });
     mocks.act.mockResolvedValue({});
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
   });
 
   it("shows the agent-owned shared browser as watch-only", async () => {
@@ -82,6 +91,48 @@ describe("SharedBrowserSurface", () => {
     expect(mocks.act).toHaveBeenNthCalledWith(2, "session-1", [{ action: "press", value: "b" }]);
     expect(mocks.act).toHaveBeenNthCalledWith(3, "session-1", [{ action: "press", value: "c" }]);
   });
+
+  it("keeps a transient observation failure quiet when the next poll recovers", async () => {
+    vi.useFakeTimers();
+    mocks.control.mockResolvedValue({ state: "agent_control" });
+    mocks.observe.mockRejectedValueOnce(new Error("temporary preview failure"));
+
+    renderWithProviders(<SharedBrowserSurface sessionId="session-1" />);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(7000);
+    });
+
+    expect(mocks.observe).toHaveBeenCalledTimes(3);
+    expect(screen.getByRole("img", { name: "Dashboard" })).toBeInTheDocument();
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+  });
+
+  it("shows one stable error after a sustained observation outage", async () => {
+    vi.useFakeTimers();
+    mocks.control.mockResolvedValue({ state: "agent_control" });
+    mocks.observe.mockRejectedValue(new Error("preview browser operation failed"));
+
+    renderWithProviders(<SharedBrowserSurface sessionId="session-1" />);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(4999);
+    });
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(5001);
+    });
+    const alert = screen.getByRole("alert");
+    expect(alert).toHaveTextContent("Shared browser unavailable");
+    expect(alert).toHaveTextContent("The session browser is not responding. Retrying automatically.");
+    expect(alert).not.toHaveTextContent("ApiError");
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(10_000);
+    });
+    expect(screen.getAllByRole("alert")).toHaveLength(1);
+  });
 });
 
 describe("mapSharedBrowserPoint", () => {
@@ -89,5 +140,14 @@ describe("mapSharedBrowserPoint", () => {
     const rect = { left: 0, top: 0, width: 1000, height: 500 };
     expect(mapSharedBrowserPoint(rect, { width: 390, height: 844 }, 100, 250)).toBeNull();
     expect(mapSharedBrowserPoint(rect, { width: 390, height: 844 }, 500, 250)).toEqual({ x: 195, y: 422 });
+  });
+});
+
+describe("sharedBrowserErrorMessage", () => {
+  it("uses the readable message without exposing the error class name", () => {
+    const error = new Error("preview browser operation failed");
+    error.name = "ApiError";
+
+    expect(sharedBrowserErrorMessage(error)).toBe("preview browser operation failed");
   });
 });

--- a/frontend/src/components/preview/shared-browser-surface.tsx
+++ b/frontend/src/components/preview/shared-browser-surface.tsx
@@ -10,6 +10,11 @@ import { Input } from "@/components/ui/input";
 import { Badge } from "@/components/ui/badge";
 import { ErrorNotice } from "@/components/ui/error-notice";
 
+const CONTROL_POLL_INTERVAL_MS = 2000;
+const OBSERVATION_POLL_INTERVAL_MS = 1500;
+const FAILED_POLL_INTERVAL_MS = 5000;
+const INITIAL_FAILURE_THRESHOLD = 2;
+
 export function mapSharedBrowserPoint(rect: Pick<DOMRect, "left" | "top" | "width" | "height">, viewport: { width: number; height: number }, clientX: number, clientY: number) {
   const scale = Math.min(rect.width / viewport.width, rect.height / viewport.height);
   const renderedWidth = viewport.width * scale;
@@ -18,6 +23,15 @@ export function mapSharedBrowserPoint(rect: Pick<DOMRect, "left" | "top" | "widt
   const top = rect.top + (rect.height - renderedHeight) / 2;
   if (clientX < left || clientX > left + renderedWidth || clientY < top || clientY > top + renderedHeight) return null;
   return { x: Math.round((clientX - left) / scale), y: Math.round((clientY - top) / scale) };
+}
+
+export function sharedBrowserErrorMessage(error: unknown): string {
+  if (error instanceof Error && error.message.trim()) return error.message;
+  if (typeof error === "object" && error !== null && "message" in error) {
+    const message = (error as { message?: unknown }).message;
+    if (typeof message === "string" && message.trim()) return message;
+  }
+  return String(error);
 }
 
 export function SharedBrowserSurface({ sessionId }: { sessionId: string }) {
@@ -29,12 +43,18 @@ export function SharedBrowserSurface({ sessionId }: { sessionId: string }) {
   const control = useQuery({
     queryKey: ["preview-browser-control", sessionId],
     queryFn: () => api.sessions.preview.browserControl(sessionId),
-    refetchInterval: 2000,
+    retry: false,
+    refetchInterval: (query) => query.state.errorUpdatedAt > query.state.dataUpdatedAt
+      ? FAILED_POLL_INTERVAL_MS
+      : CONTROL_POLL_INTERVAL_MS,
   });
   const observation = useQuery({
     queryKey: ["preview-browser-observation", sessionId],
     queryFn: ({ signal }) => api.sessions.preview.observeBrowser(sessionId, { signal }),
-    refetchInterval: 1500,
+    retry: false,
+    refetchInterval: (query) => query.state.errorUpdatedAt > query.state.dataUpdatedAt
+      ? FAILED_POLL_INTERVAL_MS
+      : OBSERVATION_POLL_INTERVAL_MS,
   });
   const refresh = useCallback(() => {
     void queryClient.invalidateQueries({ queryKey: ["preview-browser-observation", sessionId] });
@@ -60,6 +80,20 @@ export function SharedBrowserSurface({ sessionId }: { sessionId: string }) {
   const isLeaseOwner = isHuman && control.data?.is_lease_owner;
   const label = control.data?.state?.replaceAll("_", " ") ?? "connecting";
   const imageSrc = useMemo(() => image ? `data:image/png;base64,${image}` : undefined, [image]);
+  // React Query resets a no-data query to pending during each interval fetch.
+  // Use the cumulative error count plus update timestamps so a repeated outage
+  // becomes one stable notice instead of blinking off on every retry. Once a
+  // frame has loaded, keep showing that last good frame through refetch errors.
+  const passiveBrowserUnavailable = [control, observation].some((query) =>
+    query.data === undefined &&
+    query.errorUpdateCount >= INITIAL_FAILURE_THRESHOLD &&
+    query.errorUpdatedAt > query.dataUpdatedAt);
+  const actionError = acquire.error || release.error || inputError;
+  const errorDescription = actionError
+    ? sharedBrowserErrorMessage(actionError)
+    : passiveBrowserUnavailable
+      ? "The session browser is not responding. Retrying automatically."
+      : undefined;
 
   const navigate = () => {
     const value = path.trim();
@@ -87,8 +121,8 @@ export function SharedBrowserSurface({ sessionId }: { sessionId: string }) {
           <Button variant="outline" onClick={navigate} disabled={pendingInputCount > 0}>Go</Button>
         </div>
       )}
-      {Boolean(control.error || observation.error || acquire.error || release.error || inputError) && (
-        <ErrorNotice title="Shared browser unavailable" description={String(control.error || observation.error || acquire.error || release.error || inputError)} />
+      {errorDescription && (
+        <ErrorNotice title="Shared browser unavailable" description={errorDescription} />
       )}
       <div className="relative mx-auto aspect-[16/10] max-h-[70vh] bg-background">
         {imageSrc ? (

--- a/internal/services/preview/chromedp_inspector.go
+++ b/internal/services/preview/chromedp_inspector.go
@@ -747,6 +747,13 @@ func (c *ChromeDPInspector) HasPreviewAccess(target models.BrowserTarget) bool {
 	return hasContext && c.previewAccess[key] == target.PreviewID
 }
 
+// awaitPromiseEvaluation must be used for scripts that return a JavaScript
+// Promise. Runtime.evaluate otherwise returns the Promise object itself, which
+// cannot be decoded into the resolved Go result.
+func awaitPromiseEvaluation(params *runtime.EvaluateParams) *runtime.EvaluateParams {
+	return params.WithAwaitPromise(true)
+}
+
 func (c *ChromeDPInspector) BootstrapPreviewAccess(ctx context.Context, target models.BrowserTarget, token string) error {
 	if strings.TrimSpace(token) == "" {
 		return fmt.Errorf("preview bootstrap token is required")
@@ -785,7 +792,7 @@ func (c *ChromeDPInspector) BootstrapPreviewAccess(ctx context.Context, target m
 		timeoutCtx,
 		chromedp.Navigate(bootstrapURL),
 		chromedp.WaitReady("body", chromedp.ByQuery),
-		chromedp.Evaluate(exchangeScript, &exchangeStatus),
+		chromedp.Evaluate(exchangeScript, &exchangeStatus, awaitPromiseEvaluation),
 	); err != nil {
 		c.dropBrowserContext(target)
 		return fmt.Errorf("exchange preview browser access: %w", err)

--- a/internal/services/preview/chromedp_inspector_test.go
+++ b/internal/services/preview/chromedp_inspector_test.go
@@ -7,9 +7,20 @@ import (
 
 	"github.com/assembledhq/143/internal/models"
 	"github.com/chromedp/cdproto/network"
+	"github.com/chromedp/cdproto/runtime"
 	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/require"
 )
+
+func TestAwaitPromiseEvaluation(t *testing.T) {
+	t.Parallel()
+
+	params := runtime.Evaluate("Promise.resolve(200)")
+	require.False(t, params.AwaitPromise, "runtime evaluation should not await promises by default")
+
+	actual := awaitPromiseEvaluation(params)
+	require.True(t, actual.AwaitPromise, "async browser evaluations should await the resolved promise value")
+}
 
 func TestChromeDPInspector_BindsSessionContextIdentity(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
## Summary

- Await asynchronous preview access bootstrap evaluation so ChromeDP receives the resolved result.
- Add resilient polling behavior for transient shared-browser failures.
- Show a single stable, readable error after sustained outages while preserving the last good frame.
- Add frontend and backend regression coverage.

## Testing

- Added Vitest coverage for transient recovery, sustained outages, and readable error messages.
- Added Go unit coverage for promise-aware runtime evaluation.