### PR TITLE
Explore polished UI alternatives for Session Details page without white-card layout

### DIFF
--- a/.143/seed/43_session_detail_showcase.sql
+++ b/.143/seed/43_session_detail_showcase.sql
@@ -1,0 +1,436 @@
+-- A single rich session for reviewing the session-detail UI. Its three tabs
+-- cover a completed implementation, a clean review, and a failed experiment,
+-- while the parent session supplies issue provenance, result, diff, review,
+-- question, validation, message, and log surfaces from one stable URL.
+
+INSERT INTO sessions (
+  id, org_id, repository_id, triggered_by_user_id, title, working_branch,
+  target_branch, agent_type, status, autonomy_level, token_mode,
+  sandbox_state, current_turn, last_activity_at, started_at, completed_at,
+  created_at
+)
+VALUES (
+  '00000000-0000-4000-a000-000000000308'::uuid,
+  '00000000-0000-4000-a000-000000000001'::uuid,
+  '00000000-0000-4000-a000-000000000100'::uuid,
+  '00000000-0000-4000-a000-000000000003'::uuid,
+  'Session detail UI showcase',
+  'preview/session-detail-showcase',
+  'main',
+  'codex',
+  'completed',
+  'semi',
+  'low',
+  'snapshotted',
+  3,
+  now() - interval '18 minutes',
+  now() - interval '52 minutes',
+  now() - interval '18 minutes',
+  now() - interval '52 minutes'
+)
+ON CONFLICT (id) DO UPDATE
+SET title = EXCLUDED.title,
+    working_branch = EXCLUDED.working_branch,
+    target_branch = EXCLUDED.target_branch,
+    agent_type = EXCLUDED.agent_type,
+    status = EXCLUDED.status,
+    sandbox_state = EXCLUDED.sandbox_state,
+    current_turn = EXCLUDED.current_turn,
+    last_activity_at = EXCLUDED.last_activity_at,
+    started_at = EXCLUDED.started_at,
+    completed_at = EXCLUDED.completed_at;
+
+UPDATE sessions
+SET origin = 'issue_trigger',
+    interaction_mode = 'interactive',
+    validation_policy = 'on_session_end',
+    model_used = 'gpt-5.1-codex-max',
+    result_summary = 'Condensed session metadata into a two-line hierarchy, added representative states, and kept secondary detail available on demand.',
+    diff = $diff$diff --git a/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx b/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
+index 1234567..89abcde 100644
+--- a/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
++++ b/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
+@@ -940,8 +940,7 @@ function OverviewTab({ session }: { session: Session }) {
+-  <div className="space-y-2">
+-    <p>{originDisplay.detail}</p>
++  <div className="space-y-1.5">
++    <Badge variant="outline">Issue</Badge>
+     <span>{repoBranchLabel}</span>
+   </div>
+ }
+$diff$,
+    diff_stats = '{"files_changed":2,"added":24,"removed":31}'::jsonb,
+    diff_history = '[{"pass":1,"diff_stats":{"files_changed":2,"added":24,"removed":31},"summary":"Reduced session metadata to a compact two-tier hierarchy.","created_at":"2026-08-04T03:30:00Z"}]'::jsonb,
+    diff_collected_at = now() - interval '20 minutes'
+WHERE id = '00000000-0000-4000-a000-000000000308'::uuid
+  AND org_id = '00000000-0000-4000-a000-000000000001'::uuid;
+
+INSERT INTO session_issue_links (
+  id, org_id, session_id, issue_id, role, position, added_by_user_id, created_at
+)
+VALUES (
+  '00000000-0000-4000-a000-000000000638'::uuid,
+  '00000000-0000-4000-a000-000000000001'::uuid,
+  '00000000-0000-4000-a000-000000000308'::uuid,
+  '00000000-0000-4000-a000-000000000600'::uuid,
+  'primary',
+  0,
+  '00000000-0000-4000-a000-000000000003'::uuid,
+  now() - interval '52 minutes'
+)
+ON CONFLICT (session_id, issue_id) DO UPDATE
+SET role = EXCLUDED.role,
+    position = EXCLUDED.position,
+    added_by_user_id = EXCLUDED.added_by_user_id;
+
+INSERT INTO session_turn_issue_snapshots (
+  id, org_id, session_id, turn_number, linked_issues, created_at
+)
+VALUES (
+  '00000000-0000-4000-a000-000000000645'::uuid,
+  '00000000-0000-4000-a000-000000000001'::uuid,
+  '00000000-0000-4000-a000-000000000308'::uuid,
+  1,
+  '[{"id":"00000000-0000-4000-a000-000000000600","role":"primary","title":"Dashboard filters drop archived sessions","source":"linear","severity":"high"}]'::jsonb,
+  now() - interval '51 minutes'
+)
+ON CONFLICT (session_id, turn_number) DO UPDATE
+SET linked_issues = EXCLUDED.linked_issues,
+    created_at = EXCLUDED.created_at;
+
+INSERT INTO session_threads (
+  id, session_id, org_id, agent_type, model_override, label, instructions,
+  file_scope, status, agent_session_id, current_turn, last_activity_at,
+  result_summary, diff, failure_explanation, failure_category, started_at,
+  completed_at, created_at, base_snapshot_key, cost_cents, pending_message_count,
+  created_by_source
+)
+VALUES
+  (
+    '00000000-0000-4000-a000-000000000708'::uuid,
+    '00000000-0000-4000-a000-000000000308'::uuid,
+    '00000000-0000-4000-a000-000000000001'::uuid,
+    'codex',
+    NULL,
+    'Overview polish',
+    'Refine the session Overview hierarchy and remove redundant provenance copy.',
+    ARRAY['frontend/src/app/(dashboard)/sessions/[id]'],
+    'completed',
+    'seeded-thread-308-overview',
+    3,
+    now() - interval '18 minutes',
+    'Reworked the Overview metadata into a quiet two-line hierarchy.',
+    NULL,
+    NULL,
+    NULL,
+    now() - interval '52 minutes',
+    now() - interval '18 minutes',
+    now() - interval '52 minutes',
+    'seeded/snapshots/session-308/base',
+    18.40,
+    0,
+    'seed'
+  ),
+  (
+    '00000000-0000-4000-a000-000000000709'::uuid,
+    '00000000-0000-4000-a000-000000000308'::uuid,
+    '00000000-0000-4000-a000-000000000001'::uuid,
+    'claude_code',
+    NULL,
+    'Copy review',
+    'Review session-detail copy for redundancy, hierarchy, and actionability.',
+    ARRAY['frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx'],
+    'completed',
+    'seeded-thread-308-review',
+    1,
+    now() - interval '22 minutes',
+    'Review clean: source, repository, and timing remain clear without explanatory sentences.',
+    NULL,
+    NULL,
+    NULL,
+    now() - interval '38 minutes',
+    now() - interval '22 minutes',
+    now() - interval '38 minutes',
+    'seeded/snapshots/session-308/review',
+    7.60,
+    0,
+    'seed'
+  ),
+  (
+    '00000000-0000-4000-a000-000000000710'::uuid,
+    '00000000-0000-4000-a000-000000000308'::uuid,
+    '00000000-0000-4000-a000-000000000001'::uuid,
+    'codex',
+    'gpt-5.1-codex-max',
+    'Rejected experiment',
+    'Try a dense property-grid treatment and record why it should not ship.',
+    ARRAY['frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx'],
+    'failed',
+    'seeded-thread-308-experiment',
+    1,
+    now() - interval '27 minutes',
+    NULL,
+    NULL,
+    'The property grid increased visual density and made the Overview harder to scan.',
+    'design_validation',
+    now() - interval '33 minutes',
+    now() - interval '27 minutes',
+    now() - interval '33 minutes',
+    'seeded/snapshots/session-308/experiment',
+    3.20,
+    0,
+    'seed'
+  )
+ON CONFLICT (id) DO UPDATE
+SET agent_type = EXCLUDED.agent_type,
+    model_override = EXCLUDED.model_override,
+    label = EXCLUDED.label,
+    instructions = EXCLUDED.instructions,
+    file_scope = EXCLUDED.file_scope,
+    status = EXCLUDED.status,
+    current_turn = EXCLUDED.current_turn,
+    last_activity_at = EXCLUDED.last_activity_at,
+    result_summary = EXCLUDED.result_summary,
+    failure_explanation = EXCLUDED.failure_explanation,
+    failure_category = EXCLUDED.failure_category,
+    started_at = EXCLUDED.started_at,
+    completed_at = EXCLUDED.completed_at,
+    base_snapshot_key = EXCLUDED.base_snapshot_key,
+    cost_cents = EXCLUDED.cost_cents,
+    pending_message_count = EXCLUDED.pending_message_count;
+
+DELETE FROM session_thread_file_events
+WHERE session_id = '00000000-0000-4000-a000-000000000308'::uuid;
+
+INSERT INTO session_thread_file_events (
+  org_id, session_id, thread_id, turn, path, event_type,
+  before_hash, after_hash, observed_at
+)
+VALUES
+  (
+    '00000000-0000-4000-a000-000000000001'::uuid,
+    '00000000-0000-4000-a000-000000000308'::uuid,
+    '00000000-0000-4000-a000-000000000708'::uuid,
+    2,
+    'frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx',
+    'modified',
+    'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+    'cccccccccccccccccccccccccccccccccccccccc',
+    now() - interval '24 minutes'
+  ),
+  (
+    '00000000-0000-4000-a000-000000000001'::uuid,
+    '00000000-0000-4000-a000-000000000308'::uuid,
+    '00000000-0000-4000-a000-000000000708'::uuid,
+    3,
+    'frontend/src/app/(dashboard)/sessions/[id]/page-overview.test.tsx',
+    'modified',
+    'dddddddddddddddddddddddddddddddddddddddd',
+    'eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee',
+    now() - interval '20 minutes'
+  );
+
+INSERT INTO session_diff_snapshots (
+  id, session_id, org_id, turn_number, sequence_number, source,
+  base_commit_sha, head_commit_sha, working_branch, target_branch, diff,
+  files_changed, lines_added, lines_removed, captured_at, workspace_dirty
+)
+VALUES (
+  '00000000-0000-4000-a000-000000000722'::uuid,
+  '00000000-0000-4000-a000-000000000308'::uuid,
+  '00000000-0000-4000-a000-000000000001'::uuid,
+  3,
+  1,
+  'turn_complete',
+  'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+  'cccccccccccccccccccccccccccccccccccccccc',
+  'preview/session-detail-showcase',
+  'main',
+  'diff --git a/frontend/src/app/session-detail-content.tsx b/frontend/src/app/session-detail-content.tsx',
+  2,
+  24,
+  31,
+  now() - interval '20 minutes',
+  false
+)
+ON CONFLICT (id) DO UPDATE
+SET turn_number = EXCLUDED.turn_number,
+    sequence_number = EXCLUDED.sequence_number,
+    source = EXCLUDED.source,
+    head_commit_sha = EXCLUDED.head_commit_sha,
+    diff = EXCLUDED.diff,
+    files_changed = EXCLUDED.files_changed,
+    lines_added = EXCLUDED.lines_added,
+    lines_removed = EXCLUDED.lines_removed,
+    captured_at = EXCLUDED.captured_at,
+    workspace_dirty = EXCLUDED.workspace_dirty;
+
+UPDATE sessions
+SET latest_diff_snapshot_id = '00000000-0000-4000-a000-000000000722'::uuid
+WHERE id = '00000000-0000-4000-a000-000000000308'::uuid
+  AND org_id = '00000000-0000-4000-a000-000000000001'::uuid;
+
+INSERT INTO session_review_comments (
+  id, session_id, org_id, user_id, file_path, line_number, diff_side,
+  body, resolved, resolved_at, resolved_by_pass, pass_number,
+  created_at, updated_at
+)
+VALUES (
+  '00000000-0000-4000-a000-000000000732'::uuid,
+  '00000000-0000-4000-a000-000000000308'::uuid,
+  '00000000-0000-4000-a000-000000000001'::uuid,
+  '00000000-0000-4000-a000-000000000002'::uuid,
+  'frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx',
+  948,
+  'new',
+  'Keep the full repository and branch available through the title while truncating the narrow summary.',
+  true,
+  now() - interval '19 minutes',
+  1,
+  1,
+  now() - interval '23 minutes',
+  now() - interval '19 minutes'
+)
+ON CONFLICT (id) DO UPDATE
+SET body = EXCLUDED.body,
+    resolved = EXCLUDED.resolved,
+    resolved_at = EXCLUDED.resolved_at,
+    resolved_by_pass = EXCLUDED.resolved_by_pass,
+    updated_at = EXCLUDED.updated_at;
+
+INSERT INTO session_questions (
+  id, session_id, org_id, question_text, options, context, blocks_phase,
+  answer_text, answered_by, answered_at, status, created_at
+)
+VALUES (
+  '00000000-0000-4000-a000-000000000742'::uuid,
+  '00000000-0000-4000-a000-000000000308'::uuid,
+  '00000000-0000-4000-a000-000000000001'::uuid,
+  'Should origin remain visible after removing the explanatory sentence?',
+  ARRAY['Keep a compact badge','Remove origin entirely'],
+  'The source is useful for orientation, but it should not compete with status or repository context.',
+  'implementation',
+  'Keep a compact badge.',
+  '00000000-0000-4000-a000-000000000003'::uuid,
+  now() - interval '32 minutes',
+  'answered',
+  now() - interval '36 minutes'
+)
+ON CONFLICT (id) DO UPDATE
+SET answer_text = EXCLUDED.answer_text,
+    answered_by = EXCLUDED.answered_by,
+    answered_at = EXCLUDED.answered_at,
+    status = EXCLUDED.status;
+
+INSERT INTO validations (
+  id, session_id, org_id, status, direction_check, correctness_check,
+  quality_check, security_scan, regression_test_check, coverage_delta,
+  ci_check, details, started_at, completed_at, created_at
+)
+VALUES (
+  '00000000-0000-4000-a000-000000000752'::uuid,
+  '00000000-0000-4000-a000-000000000308'::uuid,
+  '00000000-0000-4000-a000-000000000001'::uuid,
+  'passed',
+  'pass',
+  'pass',
+  'pass',
+  'pass',
+  'pass',
+  '{"line_delta":-7,"covered_lines_delta":12}'::jsonb,
+  'pass',
+  '{"summary":"Session detail showcase passes layout, copy, and regression checks."}'::jsonb,
+  now() - interval '21 minutes',
+  now() - interval '19 minutes',
+  now() - interval '21 minutes'
+)
+ON CONFLICT (id) DO UPDATE
+SET status = EXCLUDED.status,
+    direction_check = EXCLUDED.direction_check,
+    correctness_check = EXCLUDED.correctness_check,
+    quality_check = EXCLUDED.quality_check,
+    security_scan = EXCLUDED.security_scan,
+    regression_test_check = EXCLUDED.regression_test_check,
+    coverage_delta = EXCLUDED.coverage_delta,
+    ci_check = EXCLUDED.ci_check,
+    details = EXCLUDED.details,
+    completed_at = EXCLUDED.completed_at;
+
+DELETE FROM session_messages
+WHERE session_id = '00000000-0000-4000-a000-000000000308'::uuid;
+
+INSERT INTO session_messages (
+  session_id, org_id, user_id, turn_number, role, content, thread_id, created_at
+)
+VALUES
+  (
+    '00000000-0000-4000-a000-000000000308'::uuid,
+    '00000000-0000-4000-a000-000000000001'::uuid,
+    '00000000-0000-4000-a000-000000000003'::uuid,
+    1,
+    'user',
+    'The Overview feels like a wall of metadata. Keep what helps me orient, and remove anything redundant.',
+    '00000000-0000-4000-a000-000000000708'::uuid,
+    now() - interval '52 minutes'
+  ),
+  (
+    '00000000-0000-4000-a000-000000000308'::uuid,
+    '00000000-0000-4000-a000-000000000001'::uuid,
+    NULL,
+    2,
+    'assistant',
+    'I reduced the summary to status and ownership on the first line, then origin, repository, branch, and time on a compact context rail.',
+    '00000000-0000-4000-a000-000000000708'::uuid,
+    now() - interval '30 minutes'
+  ),
+  (
+    '00000000-0000-4000-a000-000000000308'::uuid,
+    '00000000-0000-4000-a000-000000000001'::uuid,
+    '00000000-0000-4000-a000-000000000003'::uuid,
+    1,
+    'user',
+    'Review the new hierarchy and flag any copy that merely repeats the source badge.',
+    '00000000-0000-4000-a000-000000000709'::uuid,
+    now() - interval '38 minutes'
+  ),
+  (
+    '00000000-0000-4000-a000-000000000308'::uuid,
+    '00000000-0000-4000-a000-000000000001'::uuid,
+    NULL,
+    1,
+    'assistant',
+    'Review clean. The badge communicates provenance; the longer workflow sentence can be omitted.',
+    '00000000-0000-4000-a000-000000000709'::uuid,
+    now() - interval '22 minutes'
+  ),
+  (
+    '00000000-0000-4000-a000-000000000308'::uuid,
+    '00000000-0000-4000-a000-000000000001'::uuid,
+    '00000000-0000-4000-a000-000000000003'::uuid,
+    1,
+    'user',
+    'Try the dense property-grid version so we can compare it with the continuous canvas.',
+    '00000000-0000-4000-a000-000000000710'::uuid,
+    now() - interval '33 minutes'
+  ),
+  (
+    '00000000-0000-4000-a000-000000000308'::uuid,
+    '00000000-0000-4000-a000-000000000001'::uuid,
+    NULL,
+    1,
+    'assistant',
+    'The experiment failed the design review because the grid added labels and density without improving decisions.',
+    '00000000-0000-4000-a000-000000000710'::uuid,
+    now() - interval '27 minutes'
+  );
+
+DELETE FROM session_logs
+WHERE session_id = '00000000-0000-4000-a000-000000000308'::uuid;
+
+INSERT INTO session_logs (
+  session_id, org_id, timestamp, level, message, turn_number, thread_id
+)
+VALUES
+  ('00000000-0000-4000-a000-000000000308'::uuid, '00000000-0000-4000-a000-000000000001'::uuid, now() - interval '30 minutes', 'info', 'condensed session overview metadata', 2, '00000000-0000-4000-a000-000000000708'::uuid),
+  ('00000000-0000-4000-a000-000000000308'::uuid, '00000000-0000-4000-a000-000000000001'::uuid, now() - interval '22 minutes', 'info', 'copy review completed cleanly', 1, '00000000-0000-4000-a000-000000000709'::uuid),
+  ('00000000-0000-4000-a000-000000000308'::uuid, '00000000-0000-4000-a000-000000000001'::uuid, now() - interval '27 minutes', 'error', 'dense property-grid experiment rejected', 1, '00000000-0000-4000-a000-000000000710'::uuid);

--- a/.143/seed/README.md
+++ b/.143/seed/README.md
@@ -13,6 +13,7 @@ Fragment map:
 - `40_sessions_base.sql` - seeded session rows, session updates, issue links, and issue snapshots.
 - `41_session_records.sql` - session threads, file events, diffs, reviews, questions, and validations.
 - `42_session_conversation.sql` - session diff body, messages, and logs.
+- `43_session_detail_showcase.sql` - one rich multi-tab session for reviewing success, review, failure, diff, and metadata states.
 - `50_preview_targets.sql` - preview natural-key cleanup, groups, targets, and links.
 - `51_preview_runtime.sql` - preview instances, services, infrastructure, runtime, snapshots, and logs.
 - `60_pull_requests.sql` - pull requests, PR health, and PR preview state.

--- a/frontend/src/app/(dashboard)/sessions/[id]/page-composer.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/page-composer.test.tsx
@@ -613,8 +613,9 @@ describe('SessionDetailPage composer and session metadata', () => {
     renderWithProviders(<SessionDetailContent id="session-abcdef12-3456-7890" />);
 
     await screen.findAllByText('Fixed TypeError by adding null check');
-    expect(screen.getByText('Created by automation')).toBeInTheDocument();
-    expect(screen.getByText('Automation run')).toBeInTheDocument();
+    expect(screen.getByText('Automation')).toBeInTheDocument();
+    expect(screen.queryByText('Created by automation')).not.toBeInTheDocument();
+    expect(screen.queryByText('Automation run')).not.toBeInTheDocument();
   });
 
   it('does not show automation provenance for manually created sessions', async () => {
@@ -634,6 +635,7 @@ describe('SessionDetailPage composer and session metadata', () => {
     renderWithProviders(<SessionDetailContent id="session-abcdef12-3456-7890" />);
 
     await screen.findAllByText('Fixed TypeError by adding null check');
+    expect(screen.queryByText('Automation')).not.toBeInTheDocument();
     expect(screen.queryByText('Created by automation')).not.toBeInTheDocument();
     expect(screen.queryByText('Automation run')).not.toBeInTheDocument();
   });

--- a/frontend/src/app/(dashboard)/sessions/[id]/page-overview.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/page-overview.test.tsx
@@ -371,11 +371,35 @@ describe('SessionDetailPage overview and review loop', () => {
 
     const repoBranchRow = screen.getByTestId('session-overview-repo-branch');
     expect(repoBranchRow).toHaveTextContent('assembledhq/143 · 143/feature-session-details');
+    expect(repoBranchRow).toHaveAttribute('title', 'assembledhq/143 · 143/feature-session-details');
+    expect(repoBranchRow).toHaveClass('truncate');
     expect(repoBranchRow).not.toHaveTextContent(/feature-session-details\s*·/);
 
     const metadataRow = screen.getByTestId('session-overview-timing');
     expect(metadataRow).not.toHaveTextContent('assembledhq/143');
     expect(metadataRow).toHaveTextContent(/Completed/);
+  });
+
+  it('keeps issue-trigger provenance compact without redundant workflow copy', async () => {
+    server.use(
+      http.get('/api/v1/sessions/:id', () => {
+        return HttpResponse.json({
+          data: {
+            ...mockSessions[0],
+            origin: 'issue_trigger',
+          },
+        } satisfies SingleResponse<Session>);
+      }),
+    );
+
+    renderWithProviders(<SessionDetailContent id={mockSessions[0].id} />);
+
+    const context = await screen.findByTestId('session-overview-context');
+    expect(within(context).getByText('Issue')).toBeInTheDocument();
+    expect(context).toContainElement(screen.getByTestId('session-overview-repo-branch'));
+    expect(context).toContainElement(screen.getByTestId('session-overview-timing'));
+    expect(screen.queryByText('Created from issue intake')).not.toBeInTheDocument();
+    expect(screen.queryByText('Started automatically from issue workflow')).not.toBeInTheDocument();
   });
 
   it('renders the session Linear chip as an outbound link when only linear_identifier_hint is available', async () => {
@@ -460,7 +484,7 @@ describe('SessionDetailPage overview and review loop', () => {
     expect(within(screen.getByLabelText('Session detail actions')).queryByRole('button', { name: 'Review' })).not.toBeInTheDocument();
   });
 
-  it('orders PR details, Result, then the quiet split suggestion', async () => {
+  it('orders the card-free PR details and Result sections before the quiet split suggestion', async () => {
     server.use(
       http.get('/api/v1/sessions/:id', () => {
         return HttpResponse.json({
@@ -474,13 +498,48 @@ describe('SessionDetailPage overview and review loop', () => {
 
     renderWithProviders(<SessionDetailContent id={mockSessions[0].id} />);
 
-    const prDetailsCard = await screen.findByRole('region', { name: 'Pull request #42' });
-    const resultCard = screen.getByTestId('session-result-card');
+    const prDetailsSection = await screen.findByRole('region', { name: 'Pull request #42' });
+    const resultSection = screen.getByTestId('session-result-section');
     const splitSuggestion = screen.getByRole('region', { name: 'Pull request size suggestion' });
 
-    expect(prDetailsCard?.parentElement?.firstElementChild).toBe(prDetailsCard);
-    expect(prDetailsCard.compareDocumentPosition(resultCard) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
-    expect(resultCard.compareDocumentPosition(splitSuggestion) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    expect(prDetailsSection?.parentElement?.firstElementChild).toBe(prDetailsSection);
+    expect(prDetailsSection.closest('[data-slot="card"]')).toBeNull();
+    expect(resultSection.closest('[data-slot="card"]')).toBeNull();
+    expect(resultSection).toHaveClass('border-t', 'pt-4');
+    expect(prDetailsSection.compareDocumentPosition(resultSection) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    expect(resultSection.compareDocumentPosition(splitSuggestion) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+  });
+
+  it('keeps the PR health placeholder card-free and still divides Result while health loads', async () => {
+    server.use(
+      http.get('/api/v1/pull-requests/:id/health', () => new Promise(() => {})),
+    );
+
+    renderWithProviders(<SessionDetailContent id={mockSessions[0].id} />);
+
+    const loadingSection = (await screen.findByText('Loading PR health...')).closest('[data-slot="pr-health-loading-section"]');
+    expect(loadingSection).toBeInTheDocument();
+    expect(loadingSection?.closest('[data-slot="card"]')).toBeNull();
+    expect(screen.getByTestId('session-result-section')).toHaveClass('border-t', 'pt-4');
+  });
+
+  it('renders Result without a leading divider when no pull request section precedes it', async () => {
+    server.use(
+      http.get('/api/v1/sessions/:id/pr', () => {
+        return HttpResponse.json({ data: null });
+      }),
+    );
+
+    renderWithProviders(<SessionDetailContent id={mockSessions[0].id} />);
+
+    const resultSection = await screen.findByTestId('session-result-section');
+
+    expect(screen.queryByRole('region', { name: /^Pull request #/ })).not.toBeInTheDocument();
+    expect(resultSection.closest('[data-slot="card"]')).toBeNull();
+    // Asserted separately: `.not.toHaveClass(a, b)` only requires one of the
+    // two classes to be absent, so a single call would pass on a half-divider.
+    expect(resultSection).not.toHaveClass('border-t');
+    expect(resultSection).not.toHaveClass('pt-4');
   });
 
   it('shows a compact status card while the Overview review loop is running', async () => {

--- a/frontend/src/app/(dashboard)/sessions/[id]/page-pr-health.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/page-pr-health.test.tsx
@@ -425,6 +425,10 @@ describe('SessionDetailPage PR health and merge', () => {
 
     expect((await screen.findAllByText('PR #42 closed')).length).toBeGreaterThanOrEqual(2);
     expect(screen.getByText('PR #42 was closed without merging.')).toBeInTheDocument();
+    const closedSection = screen.getByText('PR #42 was closed without merging.').closest('[data-slot="pr-closed-section"]');
+    expect(closedSection).toBeInTheDocument();
+    expect(closedSection?.closest('[data-slot="card"]')).toBeNull();
+    expect(screen.getByTestId('session-result-section')).toHaveClass('border-t', 'pt-4');
     expect(screen.getByRole('link', { name: 'View PR' })).toBeInTheDocument();
     expect(screen.queryByRole('region', { name: 'Pull request #42' })).not.toBeInTheDocument();
     expect(screen.queryByRole('button', { name: 'Resolve conflicts' })).not.toBeInTheDocument();
@@ -621,6 +625,10 @@ describe('SessionDetailPage PR health and merge', () => {
     expect(screen.getByText('This change has landed. Open a follow-up session if you need to make another revision.')).toHaveClass('text-xs');
     expect(screen.getByRole('link', { name: 'View PR' })).toBeInTheDocument();
     expect(screen.getByLabelText('Merged PR status')).toHaveClass('text-success');
+    const mergedSection = screen.getByLabelText('Merged PR status').closest('[data-slot="pr-merged-section"]');
+    expect(mergedSection).toBeInTheDocument();
+    expect(mergedSection?.closest('[data-slot="card"]')).toBeNull();
+    expect(screen.getByTestId('session-result-section')).toHaveClass('border-t', 'pt-4');
     expect(screen.queryAllByText('PR created')).toHaveLength(0);
     expect(within(screen.getByLabelText('Session detail actions')).queryByText('PR #42 merged')).not.toBeInTheDocument();
     expect(screen.queryByRole('region', { name: 'Pull request #42' })).not.toBeInTheDocument();

--- a/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
@@ -529,8 +529,6 @@ function buildReviewLoopThreadPreview(loop: SessionReviewLoop, session?: Session
 
 type SessionOriginDisplay = {
   badge: string;
-  title: string;
-  detail?: string;
 };
 
 function getSessionOriginDisplay(session: Session): SessionOriginDisplay | null {
@@ -538,26 +536,18 @@ function getSessionOriginDisplay(session: Session): SessionOriginDisplay | null 
     case "automation":
       return {
         badge: "Automation",
-        title: "Created by automation",
-        detail: session.automation_run_id ? "Automation run" : "Scheduled or manually triggered automation",
       };
     case "project":
       return {
         badge: "Project",
-        title: "Created from project work",
-        detail: "Started as part of a tracked project task",
       };
     case "issue_trigger":
       return {
         badge: "Issue",
-        title: "Created from issue intake",
-        detail: "Started automatically from issue workflow",
       };
     case "revision":
       return {
         badge: "Revision",
-        title: "Created from a prior session",
-        detail: "Follow-up run spun out from an earlier session",
       };
     default:
       return null;
@@ -722,26 +712,28 @@ function ThreadFailureDetailsCard({ thread }: { thread: SessionThread }) {
   );
 }
 
-function SessionResultCard({ summary }: { summary?: string }) {
+function SessionResultSection({ summary, divided }: { summary?: string; divided: boolean }) {
   if (!summary) return null;
 
   return (
-    <Card className="border-border/60" data-testid="session-result-card">
-      <CardContent className="p-3.5">
-        <div className="flex items-start gap-2.5">
-          <div
-            aria-hidden="true"
-            className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md bg-success/10 text-success"
-          >
-            <CheckCircle2 className="h-4 w-4" />
-          </div>
-          <div className="min-w-0 flex-1">
-            <div className="text-sm font-medium text-foreground">Result</div>
-            <LazyMarkdownContent content={summary} className="mt-2 text-xs" />
-          </div>
+    <section
+      aria-label="Session result"
+      className={cn(divided && "border-t border-border/60 pt-4")}
+      data-testid="session-result-section"
+    >
+      <div className="flex items-start gap-2.5">
+        <div
+          aria-hidden="true"
+          className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md bg-success/10 text-success"
+        >
+          <CheckCircle2 className="h-4 w-4" />
         </div>
-      </CardContent>
-    </Card>
+        <div className="min-w-0 flex-1">
+          <div className="text-sm font-medium text-foreground">Result</div>
+          <LazyMarkdownContent content={summary} className="mt-2 text-xs" />
+        </div>
+      </div>
+    </section>
   );
 }
 
@@ -926,7 +918,7 @@ function OverviewTab({ session, activeThread, members, prStatus }: { session: Se
       )}
 
       {/* Session vitals — identity row (status + agent + who triggered) */}
-      <div className="space-y-2">
+      <div className="space-y-1.5">
         <div className="flex items-center gap-x-3 gap-y-1 flex-wrap text-xs">
           <StatusLabel
             label={operationalStatus.label}
@@ -942,62 +934,56 @@ function OverviewTab({ session, activeThread, members, prStatus }: { session: Se
           </span>
         </div>
 
-        {originDisplay && (
-          <div className="flex items-center gap-x-2 gap-y-1 flex-wrap text-xs text-muted-foreground">
+        <div
+          data-testid="session-overview-context"
+          className="flex min-w-0 items-center gap-x-2 gap-y-1 flex-wrap text-xs text-muted-foreground"
+        >
+          {originDisplay && (
             <Badge variant="outline" className="h-5 rounded-full px-2 text-xs font-medium">
               {originDisplay.badge}
             </Badge>
-            <span className="font-medium text-foreground">{originDisplay.title}</span>
-            {originDisplay.detail && (
-              <>
-                <span aria-hidden="true" className="text-muted-foreground/50">·</span>
-                <span>{originDisplay.detail}</span>
-              </>
-            )}
-          </div>
-        )}
-
-        {repoBranchLabel && (
-          <div
-            data-testid="session-overview-repo-branch"
-            className="text-xs text-muted-foreground break-words"
-          >
-            {repoBranchLabel}
-          </div>
-        )}
-
-        {/* Timestamps + audit — secondary reference data, kept separate from long repo/branch labels */}
-        <div
-          data-testid="session-overview-timing"
-          className="flex items-center gap-x-1.5 gap-y-1 flex-wrap text-xs text-muted-foreground"
-        >
-          {terminalSessionStatuses.has(session.status) &&
-            !((session.status === "failed" || session.status === "cancelled") &&
-              !hasMeaningfulDuration(session.started_at, session.completed_at)) && (
-            <span>
-              {formatDuration(session.started_at, session.completed_at)}
-              <span aria-hidden="true" className="ml-1.5 text-muted-foreground/50">·</span>
+          )}
+          {repoBranchLabel && (
+            <span
+              data-testid="session-overview-repo-branch"
+              className="min-w-0 flex-1 basis-40 truncate"
+              title={repoBranchLabel}
+            >
+              {repoBranchLabel}
             </span>
           )}
-          <span>
-            {!isActive && session.completed_at ? (
-              session.status === "failed"
-                ? <>Failed {formatTimeAgo(session.completed_at)}</>
-                : session.status === "cancelled"
-                  ? <>Cancelled {formatTimeAgo(session.completed_at)}</>
-                  : <>Completed {formatTimeAgo(session.completed_at)}</>
-            ) : session.started_at ? (
-              <>Started {formatTimeAgo(session.started_at)}</>
-            ) : (
-              <>Queued {formatTimeAgo(session.created_at)}</>
+          <div
+            data-testid="session-overview-timing"
+            className="inline-flex shrink-0 items-center gap-x-1.5 whitespace-nowrap"
+          >
+            {terminalSessionStatuses.has(session.status) &&
+              !((session.status === "failed" || session.status === "cancelled") &&
+                !hasMeaningfulDuration(session.started_at, session.completed_at)) && (
+              <span>
+                {formatDuration(session.started_at, session.completed_at)}
+                <span aria-hidden="true" className="ml-1.5 text-muted-foreground/50">·</span>
+              </span>
             )}
-          </span>
-          <AuditLogTrigger
-            filters={{ session_id: session.id }}
-            members={members}
-            title="Session activity"
-            variant="inline"
-          />
+            <span>
+              {!isActive && session.completed_at ? (
+                session.status === "failed"
+                  ? <>Failed {formatTimeAgo(session.completed_at)}</>
+                  : session.status === "cancelled"
+                    ? <>Cancelled {formatTimeAgo(session.completed_at)}</>
+                    : <>Completed {formatTimeAgo(session.completed_at)}</>
+              ) : session.started_at ? (
+                <>Started {formatTimeAgo(session.started_at)}</>
+              ) : (
+                <>Queued {formatTimeAgo(session.created_at)}</>
+              )}
+            </span>
+            <AuditLogTrigger
+              filters={{ session_id: session.id }}
+              members={members}
+              title="Session activity"
+              variant="inline"
+            />
+          </div>
         </div>
       </div>
 
@@ -6440,6 +6426,92 @@ export function SessionDetailContent({ id }: { id: string }) {
   };
   const detailActionSize = isMobileReviewViewport ? "xs" : "sm";
   const detailActionIconSize = isMobileReviewViewport ? "icon-xs" : "icon-sm";
+  // The PR summary that leads the Overview column. Built as a single value so
+  // the Result divider below is derived from whether this actually rendered
+  // instead of from a second copy of these conditions.
+  const prOverviewSection = !pullRequestId ? null : prStatus === "open" ? (
+    prHealth ? (
+      <PRHealthBanner
+        health={prHealth}
+        currentSessionId={id}
+        currentThreadId={activeThread?.id ?? null}
+        pendingAction={pendingPRAction}
+        repairError={repairActionError}
+        mergeAuthRequired={ghBlocked}
+        mergeWhenReadyPending={pendingMergeWhenReady}
+        onFixTests={() => startRepairMutation.mutate({ action: "fix_tests", pushChanges: true })}
+        onFixTestsWithoutPushing={() => startRepairMutation.mutate({ action: "fix_tests", pushChanges: false })}
+        onResolveConflicts={() => startRepairMutation.mutate({ action: "resolve_conflicts", pushChanges: true })}
+        onResolveConflictsWithoutPushing={() => startRepairMutation.mutate({ action: "resolve_conflicts", pushChanges: false })}
+        onMerge={handleMergeAction}
+        onQueueMergeWhenReady={handleQueueMergeWhenReady}
+        onCancelMergeWhenReady={handleCancelMergeWhenReady}
+        onOpenRepairSession={(sessionId, threadId) => {
+          if (sessionId === id && threadId) {
+            setActiveThreadId(threadId);
+            return;
+          }
+          router.push(`/sessions/${sessionId}`);
+        }}
+        onStopAutoRepair={(sessionId, threadId) => stopAutoRepairMutation.mutate({ sessionId, threadId })}
+        stopAutoRepairPending={stopAutoRepairMutation.isPending}
+        reviewAction={selectedIsPrimary && canManageSession && canUseNativeReviewLoop ? {
+          disabled: reviewActionDisabled,
+          spinning: startReviewLoopMutation.isPending || reviewLoopRunning,
+          title: reviewActionDisabledReason,
+          onClick: () => setReviewConfigOpen(true),
+        } : undefined}
+        pushChanges={showPushAction ? {
+          label: pushActionLabel,
+          disabled: pushActionDisabled,
+          spinning: pushActionSpinning || (pushActionRequiresBranchSync && continueFromPRBranchMutation.isPending),
+          showError: pushState === "failed" || !!localPushActionError,
+          title: pushActionTitle,
+          onClick: () => {
+            if (pushActionRequiresBranchSync) {
+              continueFromPRBranchMutation.mutate();
+              return;
+            }
+            pushChangesMutation.mutate(undefined);
+          },
+        } : undefined}
+      />
+    ) : isPRHealthLoading ? (
+      <section
+        className="flex items-center gap-2 text-sm text-muted-foreground"
+        data-slot="pr-health-loading-section"
+      >
+        <Loader2 className="h-4 w-4 animate-spin" />
+        <span>Loading PR health...</span>
+      </section>
+    ) : null
+  ) : prStatus === "closed" ? (
+    <section className="flex items-start gap-2.5" data-slot="pr-closed-section">
+      <div aria-hidden="true" className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md bg-muted text-muted-foreground">
+        <XCircle className="h-4 w-4" />
+      </div>
+      <div className="min-w-0 space-y-1">
+        <div className="text-sm font-medium text-foreground">{closedPRLabel}</div>
+        <p className="text-xs text-foreground">{closedPRSummary}</p>
+        <p className="text-xs text-muted-foreground">
+          This pull request is no longer active. Create a follow-up revision if you want to ship a new attempt.
+        </p>
+      </div>
+    </section>
+  ) : prStatus === "merged" ? (
+    <section className="flex items-start gap-2.5" data-slot="pr-merged-section">
+      <div aria-label="Merged PR status" className={cn("flex h-7 w-7 shrink-0 items-center justify-center rounded-md", prMergedAccent.bg, prMergedAccent.text)}>
+        <CheckCircle2 className="h-4 w-4" />
+      </div>
+      <div className="min-w-0 space-y-1">
+        <div className="text-sm font-medium text-foreground">{mergedPRLabel}</div>
+        <p className="text-xs text-foreground">{mergedPRSummary}</p>
+        <p className="text-xs text-muted-foreground">
+          This change has landed. Open a follow-up session if you need to make another revision.
+        </p>
+      </div>
+    </section>
+  ) : null;
   // Right-panel content. Rendered inline on desktop and inside a bottom sheet
   // on mobile — the same JSX in both places so tab state stays consistent.
   const panelTabsEl = (
@@ -6632,99 +6704,8 @@ export function SessionDetailContent({ id }: { id: string }) {
       </TabsContent>
       <TabsContent value="overview" className="flex-1 overflow-y-auto scrollbar-hide p-4">
         <div className="space-y-4">
-          {pullRequestId && prStatus === "open" && (
-            prHealth ? (
-              <PRHealthBanner
-                health={prHealth}
-                currentSessionId={id}
-                currentThreadId={activeThread?.id ?? null}
-                pendingAction={pendingPRAction}
-                repairError={repairActionError}
-                mergeAuthRequired={ghBlocked}
-                mergeWhenReadyPending={pendingMergeWhenReady}
-                onFixTests={() => startRepairMutation.mutate({ action: "fix_tests", pushChanges: true })}
-                onFixTestsWithoutPushing={() => startRepairMutation.mutate({ action: "fix_tests", pushChanges: false })}
-                onResolveConflicts={() => startRepairMutation.mutate({ action: "resolve_conflicts", pushChanges: true })}
-                onResolveConflictsWithoutPushing={() => startRepairMutation.mutate({ action: "resolve_conflicts", pushChanges: false })}
-                onMerge={handleMergeAction}
-                onQueueMergeWhenReady={handleQueueMergeWhenReady}
-                onCancelMergeWhenReady={handleCancelMergeWhenReady}
-                onOpenRepairSession={(sessionId, threadId) => {
-                  if (sessionId === id && threadId) {
-                    setActiveThreadId(threadId);
-                    return;
-                  }
-                  router.push(`/sessions/${sessionId}`);
-                }}
-                onStopAutoRepair={(sessionId, threadId) => stopAutoRepairMutation.mutate({ sessionId, threadId })}
-                stopAutoRepairPending={stopAutoRepairMutation.isPending}
-                reviewAction={selectedIsPrimary && canManageSession && canUseNativeReviewLoop ? {
-                  disabled: reviewActionDisabled,
-                  spinning: startReviewLoopMutation.isPending || reviewLoopRunning,
-                  title: reviewActionDisabledReason,
-                  onClick: () => setReviewConfigOpen(true),
-                } : undefined}
-                pushChanges={showPushAction ? {
-                  label: pushActionLabel,
-                  disabled: pushActionDisabled,
-                  spinning: pushActionSpinning || (pushActionRequiresBranchSync && continueFromPRBranchMutation.isPending),
-                  showError: pushState === "failed" || !!localPushActionError,
-                  title: pushActionTitle,
-                  onClick: () => {
-                    if (pushActionRequiresBranchSync) {
-                      continueFromPRBranchMutation.mutate();
-                      return;
-                    }
-                    pushChangesMutation.mutate(undefined);
-                  },
-                } : undefined}
-              />
-            ) : isPRHealthLoading ? (
-              <Card className="border-border/60">
-                <CardContent className="flex items-center gap-2 p-4 text-sm text-muted-foreground">
-                  <Loader2 className="h-4 w-4 animate-spin" />
-                  <span>Loading PR health...</span>
-                </CardContent>
-              </Card>
-            ) : null
-          )}
-          {pullRequestId && prStatus === "closed" && (
-            <Card className="border-border/60">
-              <CardContent className="p-3.5">
-                <div className="flex items-start gap-2.5">
-                  <div className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md bg-muted text-muted-foreground">
-                    <XCircle className="h-4 w-4" />
-                  </div>
-                  <div className="min-w-0 space-y-1">
-                    <div className="text-sm font-medium text-foreground">{closedPRLabel}</div>
-                    <p className="text-xs text-foreground">{closedPRSummary}</p>
-                    <p className="text-xs text-muted-foreground">
-                      This pull request is no longer active. Create a follow-up revision if you want to ship a new attempt.
-                    </p>
-                  </div>
-                </div>
-              </CardContent>
-            </Card>
-          )}
-          {pullRequestId && prStatus === "merged" && (
-            <Card className="border-border/60">
-              <CardContent className="p-3.5">
-                <div className="flex items-start gap-2.5">
-                  <div aria-label="Merged PR status" className={cn("flex h-7 w-7 shrink-0 items-center justify-center rounded-md", prMergedAccent.bg, prMergedAccent.text)}>
-                    <CheckCircle2 className="h-4 w-4" />
-                  </div>
-                  <div className="min-w-0 space-y-1">
-                    <div className="text-sm font-medium text-foreground">{mergedPRLabel}</div>
-                    <p className="text-xs text-foreground">{mergedPRSummary}</p>
-                    <p className="text-xs text-muted-foreground">
-                      This change has landed. Open a follow-up session if you need to make another revision.
-                    </p>
-                  </div>
-                </div>
-              </CardContent>
-            </Card>
-          )}
-          <SessionResultCard summary={session.result_summary} />
+          {prOverviewSection}
+          <SessionResultSection summary={session.result_summary} divided={prOverviewSection !== null} />
           <PullRequestList
             changesets={changesets}
             selectedID={selectedChangeset?.id ?? ""}

--- a/frontend/src/components/pr-health-banner.test.tsx
+++ b/frontend/src/components/pr-health-banner.test.tsx
@@ -50,7 +50,10 @@ describe("PRHealthBanner", () => {
       />,
     );
 
-    expect(screen.getByRole("region", { name: "Pull request #42" })).toBeInTheDocument();
+    const prHealthSection = screen.getByRole("region", { name: "Pull request #42" });
+    expect(prHealthSection).toBeInTheDocument();
+    expect(prHealthSection).toHaveAttribute("data-slot", "pr-health-section");
+    expect(prHealthSection.closest('[data-slot="card"]')).toBeNull();
     expect(screen.getByText("PR #42")).toHaveClass("text-sm");
     expect(screen.getByText("Ready")).toHaveAttribute("data-variant", "success");
     expect(screen.getByText("acme/widgets")).toHaveClass("text-xs");

--- a/frontend/src/components/pr-health-banner.tsx
+++ b/frontend/src/components/pr-health-banner.tsx
@@ -8,7 +8,6 @@ import { cn } from "@/lib/utils";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { ButtonGroup } from "@/components/ui/button-group";
-import { Card, CardContent } from "@/components/ui/card";
 import { DisabledTooltip } from "@/components/ui/disabled-tooltip";
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "@/components/ui/dropdown-menu";
 import { HoverCard, HoverCardContent, HoverCardTrigger } from "@/components/ui/hover-card";
@@ -149,406 +148,403 @@ export function PRHealthBanner({
   const compactSummary = compactPRHealthSummary(health.summary, health.pull_request_number);
 
   return (
-    <Card
+    <section
       role="region"
       aria-label={`Pull request #${health.pull_request_number}`}
-      className="border-border/60"
+      className="space-y-2.5"
+      data-slot="pr-health-section"
     >
-      <CardContent className="p-3.5">
-        <div className="space-y-2.5">
-          <div className="flex items-start gap-2.5">
-            <div className="flex min-w-0 flex-1 items-start gap-2.5">
-              <div className={cn(
-                "flex h-7 w-7 shrink-0 items-center justify-center rounded-md",
-                prHealthStatusIconClassName(statusPresentation.variant),
-              )}>
-                {statusPresentation.variant === "success" ? <CheckCircle2 className="h-4 w-4" /> : isRepositoryDisconnected ? <AlertTriangle className="h-4 w-4" /> : <GitPullRequest className="h-4 w-4" />}
-              </div>
-              <div className="min-w-0">
-                <div className="flex flex-wrap items-center gap-1.5">
-                  <div className="text-sm font-medium text-foreground">PR #{health.pull_request_number}</div>
-                  <Badge variant={statusPresentation.variant} className="h-5 px-1.5 py-0 text-xs">
-                    {statusPresentation.label}
-                  </Badge>
-                </div>
-                <div className="truncate text-xs text-muted-foreground">{health.repository}</div>
-              </div>
-            </div>
-            {isRepositoryDisconnected ? (
-              <span className="shrink-0 whitespace-nowrap text-xs font-medium text-warning">Sync blocked</span>
-            ) : (
-              <SyncTimeText
-                syncedAt={health.github_state_synced_at}
-                className="shrink-0 whitespace-nowrap text-xs"
-              />
-            )}
+      <div className="flex items-start gap-2.5">
+        <div className="flex min-w-0 flex-1 items-start gap-2.5">
+          <div className={cn(
+            "flex h-7 w-7 shrink-0 items-center justify-center rounded-md",
+            prHealthStatusIconClassName(statusPresentation.variant),
+          )}>
+            {statusPresentation.variant === "success" ? <CheckCircle2 className="h-4 w-4" /> : isRepositoryDisconnected ? <AlertTriangle className="h-4 w-4" /> : <GitPullRequest className="h-4 w-4" />}
           </div>
+          <div className="min-w-0">
+            <div className="flex flex-wrap items-center gap-1.5">
+              <div className="text-sm font-medium text-foreground">PR #{health.pull_request_number}</div>
+              <Badge variant={statusPresentation.variant} className="h-5 px-1.5 py-0 text-xs">
+                {statusPresentation.label}
+              </Badge>
+            </div>
+            <div className="truncate text-xs text-muted-foreground">{health.repository}</div>
+          </div>
+        </div>
+        {isRepositoryDisconnected ? (
+          <span className="shrink-0 whitespace-nowrap text-xs font-medium text-warning">Sync blocked</span>
+        ) : (
+          <SyncTimeText
+            syncedAt={health.github_state_synced_at}
+            className="shrink-0 whitespace-nowrap text-xs"
+          />
+        )}
+      </div>
 
-          {/* Indent matches the header's icon tile (h-7) plus its gap-2.5 so the
-              body copy lines up with "PR #<n>" instead of the icon. */}
-          <div className="space-y-2 pl-[2.375rem]">
-            <p className="text-xs text-foreground">{compactSummary}</p>
+      {/* Indent matches the header's icon tile (h-7) plus its gap-2.5 so the
+          body copy lines up with "PR #<n>" instead of the icon. */}
+      <div className="space-y-2 pl-[2.375rem]">
+        <p className="text-xs text-foreground">{compactSummary}</p>
 
-            {hasStatusBadges && (
-              <div className="flex flex-wrap items-center gap-2">
-                {isRepositoryDisconnected && (
-                  <Badge variant="secondary" className="bg-warning/10 text-warning text-xs">
-                    Repository disconnected
-                  </Badge>
-                )}
-                {canShowSnapshotDetails && hasFailedCheckDetails && (
-                  orderedChecks.length > 0 ? (
-                    <HoverCard openDelay={100} closeDelay={100}>
-                      <HoverCardTrigger asChild>
-                        <Badge variant="secondary" className="bg-destructive/10 text-destructive text-xs cursor-default">
-                          {failedSummaryLabel}
-                        </Badge>
-                      </HoverCardTrigger>
-                      <HoverCardContent align="start" className="w-80 p-3">
-                        <div className="space-y-2">
-                          <div className="text-xs font-medium text-foreground">CI jobs</div>
-                          <div className="space-y-1.5">
-                            {orderedChecks.map((check) => (
-                              check.details_url ? (
-                                <a
-                                  key={`${check.name}-${check.status}`}
-                                  href={check.details_url}
-                                  target="_blank"
-                                  rel="noopener noreferrer"
-                                  className="flex items-center justify-between gap-3 rounded-sm px-1 py-1 text-xs transition-colors hover:bg-muted/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-                                >
-                                  <div className="flex min-w-0 items-center gap-1.5">
-                                    <span className="min-w-0 truncate text-foreground">{check.name}</span>
-                                    <ExternalLink aria-hidden="true" className="h-3 w-3 shrink-0 text-muted-foreground" />
-                                  </div>
-                                  <Badge variant="secondary" className={cn("shrink-0 text-xs", checkStatusBadgeClassName(check.status))}>
-                                    {checkStatusLabel(check.status)}
-                                  </Badge>
-                                </a>
-                              ) : (
-                                <div key={`${check.name}-${check.status}`} className="flex items-center justify-between gap-3 px-1 py-1">
-                                  <div className="min-w-0 text-xs text-foreground truncate">{check.name}</div>
-                                  <Badge variant="secondary" className={cn("shrink-0 text-xs", checkStatusBadgeClassName(check.status))}>
-                                    {checkStatusLabel(check.status)}
-                                  </Badge>
-                                </div>
-                              )
-                            ))}
-                          </div>
-                        </div>
-                      </HoverCardContent>
-                    </HoverCard>
-                  ) : (
-                    <Badge variant="secondary" className="bg-destructive/10 text-destructive text-xs">
+        {hasStatusBadges && (
+          <div className="flex flex-wrap items-center gap-2">
+            {isRepositoryDisconnected && (
+              <Badge variant="secondary" className="bg-warning/10 text-warning text-xs">
+                Repository disconnected
+              </Badge>
+            )}
+            {canShowSnapshotDetails && hasFailedCheckDetails && (
+              orderedChecks.length > 0 ? (
+                <HoverCard openDelay={100} closeDelay={100}>
+                  <HoverCardTrigger asChild>
+                    <Badge variant="secondary" className="bg-destructive/10 text-destructive text-xs cursor-default">
                       {failedSummaryLabel}
                     </Badge>
-                  )
+                  </HoverCardTrigger>
+                  <HoverCardContent align="start" className="w-80 p-3">
+                    <div className="space-y-2">
+                      <div className="text-xs font-medium text-foreground">CI jobs</div>
+                      <div className="space-y-1.5">
+                        {orderedChecks.map((check) => (
+                          check.details_url ? (
+                            <a
+                              key={`${check.name}-${check.status}`}
+                              href={check.details_url}
+                              target="_blank"
+                              rel="noopener noreferrer"
+                              className="flex items-center justify-between gap-3 rounded-sm px-1 py-1 text-xs transition-colors hover:bg-muted/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                            >
+                              <div className="flex min-w-0 items-center gap-1.5">
+                                <span className="min-w-0 truncate text-foreground">{check.name}</span>
+                                <ExternalLink aria-hidden="true" className="h-3 w-3 shrink-0 text-muted-foreground" />
+                              </div>
+                              <Badge variant="secondary" className={cn("shrink-0 text-xs", checkStatusBadgeClassName(check.status))}>
+                                {checkStatusLabel(check.status)}
+                              </Badge>
+                            </a>
+                          ) : (
+                            <div key={`${check.name}-${check.status}`} className="flex items-center justify-between gap-3 px-1 py-1">
+                              <div className="min-w-0 text-xs text-foreground truncate">{check.name}</div>
+                              <Badge variant="secondary" className={cn("shrink-0 text-xs", checkStatusBadgeClassName(check.status))}>
+                                {checkStatusLabel(check.status)}
+                              </Badge>
+                            </div>
+                          )
+                        ))}
+                      </div>
+                    </div>
+                  </HoverCardContent>
+                </HoverCard>
+              ) : (
+                <Badge variant="secondary" className="bg-destructive/10 text-destructive text-xs">
+                  {failedSummaryLabel}
+                </Badge>
+              )
+            )}
+            {canShowSnapshotDetails && health.obsolete_active_repair_sessions && (
+              <Badge variant="secondary" className="text-xs">
+                newer repair context available
+              </Badge>
+            )}
+          </div>
+        )}
+
+        {repairError && (
+          <div className="flex items-start gap-2 rounded-md border border-destructive/20 bg-destructive/5 px-3 py-2 text-xs text-destructive">
+            <AlertTriangle className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+            <span>{repairError}</span>
+          </div>
+        )}
+
+        {isRepositoryDisconnected && (
+          <div className="flex flex-col gap-2 rounded-md border border-warning/20 bg-warning/5 px-3 py-2 text-xs text-warning sm:flex-row sm:items-center sm:justify-between">
+            <div className="flex min-w-0 items-start gap-2">
+              <AlertTriangle className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+              <span className="text-warning">Reconnect this repository to update PR status and resume PR actions.</span>
+            </div>
+            <Button asChild size="xs" variant="outline" className="w-fit bg-background text-foreground">
+              <Link href="/settings/integrations">
+                Open GitHub settings
+              </Link>
+            </Button>
+          </div>
+        )}
+
+        {hasActionableButton && (
+          <div className="space-y-2">
+            {canShowActiveRepairState && pendingAction === null && (
+              <div className="flex flex-wrap items-center gap-2">
+                <Badge variant="secondary" className="text-xs">
+                  {activeRepairState.label}
+                </Badge>
+                {activeRepairState.openSessionID && onOpenRepairSession && (
+                  <Button
+                    size="xs"
+                    variant="outline"
+                    onClick={() => onOpenRepairSession(activeRepairState.openSessionID!, activeRepairState.openThreadID ?? undefined)}
+                  >
+                    Open repair session
+                  </Button>
                 )}
-                {canShowSnapshotDetails && health.obsolete_active_repair_sessions && (
-                  <Badge variant="secondary" className="text-xs">
-                    newer repair context available
-                  </Badge>
+                {activeRepairState.isAutoRepair && activeRepairState.repairSessionID && onStopAutoRepair && (
+                  <Button
+                    size="xs"
+                    variant="outline"
+                    loading={stopAutoRepairPending}
+                    onClick={() => onStopAutoRepair(activeRepairState.repairSessionID!, activeRepairState.openThreadID ?? undefined)}
+                  >
+                    Stop auto-repair for this PR
+                  </Button>
                 )}
               </div>
             )}
-
-            {repairError && (
-              <div className="flex items-start gap-2 rounded-md border border-destructive/20 bg-destructive/5 px-3 py-2 text-xs text-destructive">
-                <AlertTriangle className="mt-0.5 h-3.5 w-3.5 shrink-0" />
-                <span>{repairError}</span>
-              </div>
-            )}
-
-            {isRepositoryDisconnected && (
-              <div className="flex flex-col gap-2 rounded-md border border-warning/20 bg-warning/5 px-3 py-2 text-xs text-warning sm:flex-row sm:items-center sm:justify-between">
-                <div className="flex min-w-0 items-start gap-2">
-                  <AlertTriangle className="mt-0.5 h-3.5 w-3.5 shrink-0" />
-                  <span className="text-warning">Reconnect this repository to update PR status and resume PR actions.</span>
-                </div>
-                <Button asChild size="xs" variant="outline" className="w-fit bg-background text-foreground">
-                  <Link href="/settings/integrations">
-                    Open GitHub settings
-                  </Link>
-                </Button>
-              </div>
-            )}
-
-            {hasActionableButton && (
-              <div className="space-y-2">
-                {canShowActiveRepairState && pendingAction === null && (
-                  <div className="flex flex-wrap items-center gap-2">
-                    <Badge variant="secondary" className="text-xs">
-                      {activeRepairState.label}
-                    </Badge>
-                    {activeRepairState.openSessionID && onOpenRepairSession && (
-                      <Button
-                        size="xs"
-                        variant="outline"
-                        onClick={() => onOpenRepairSession(activeRepairState.openSessionID!, activeRepairState.openThreadID ?? undefined)}
-                      >
-                        Open repair session
-                      </Button>
+            <div className="flex flex-wrap items-stretch gap-2">
+              {canShowMergeButton && (
+                promoteMergeWhenReady ? (
+                  <Button
+                    size="xs"
+                    variant="default"
+                    disabled={mergeWhenReadyAction.disabled}
+                    title={mergeWhenReadyAction.disabledReason ?? "Merge when GitHub requirements pass"}
+                    onClick={onQueueMergeWhenReady}
+                  >
+                    {mergeWhenReadyAction.spinning ? (
+                      <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                    ) : (
+                      <GitMerge className="h-3.5 w-3.5" />
                     )}
-                    {activeRepairState.isAutoRepair && activeRepairState.repairSessionID && onStopAutoRepair && (
+                    {mergeWhenReadyAction.label}
+                  </Button>
+                ) : (
+                  <ButtonGroup size="xs">
+                    <DisabledTooltip disabled={mergeAction.disabled} content={mergeAction.disabledReason}>
                       <Button
                         size="xs"
-                        variant="outline"
-                        loading={stopAutoRepairPending}
-                        onClick={() => onStopAutoRepair(activeRepairState.repairSessionID!, activeRepairState.openThreadID ?? undefined)}
+                        variant={mergeAction.disabled ? "outline" : "default"}
+                        className={cn("shadow-none", canShowMergeWhenReady && "rounded-r-none")}
+                        disabled={mergeAction.disabled}
+                        title={mergeAction.disabledReason ?? "Merge PR (p m)"}
+                        onClick={onMerge}
                       >
-                        Stop auto-repair for this PR
-                      </Button>
-                    )}
-                  </div>
-                )}
-                <div className="flex flex-wrap items-stretch gap-2">
-                  {canShowMergeButton && (
-                    promoteMergeWhenReady ? (
-                      <Button
-                        size="xs"
-                        variant="default"
-                        disabled={mergeWhenReadyAction.disabled}
-                        title={mergeWhenReadyAction.disabledReason ?? "Merge when GitHub requirements pass"}
-                        onClick={onQueueMergeWhenReady}
-                      >
-                        {mergeWhenReadyAction.spinning ? (
+                        {mergeAction.spinning ? (
                           <Loader2 className="h-3.5 w-3.5 animate-spin" />
                         ) : (
                           <GitMerge className="h-3.5 w-3.5" />
                         )}
-                        {mergeWhenReadyAction.label}
+                        {mergeAction.label}
                       </Button>
-                    ) : (
-                      <ButtonGroup size="xs">
-                        <DisabledTooltip disabled={mergeAction.disabled} content={mergeAction.disabledReason}>
+                    </DisabledTooltip>
+                    {canShowMergeWhenReady && (
+                      <DropdownMenu>
+                        <DropdownMenuTrigger asChild>
                           <Button
-                            size="xs"
+                            size="icon-xs"
                             variant={mergeAction.disabled ? "outline" : "default"}
-                            className={cn("shadow-none", canShowMergeWhenReady && "rounded-r-none")}
-                            disabled={mergeAction.disabled}
-                            title={mergeAction.disabledReason ?? "Merge PR (p m)"}
-                            onClick={onMerge}
+                            className="w-8 rounded-l-none border-l-0 shadow-none sm:w-6"
+                            disabled={mergeWhenReadyAction.disabled}
+                            title={mergeWhenReadyAction.disabledReason ?? "More merge actions"}
+                            aria-label="More merge actions"
                           >
-                            {mergeAction.spinning ? (
+                            {mergeWhenReadyAction.spinning ? (
                               <Loader2 className="h-3.5 w-3.5 animate-spin" />
                             ) : (
-                              <GitMerge className="h-3.5 w-3.5" />
+                              <ChevronDown className="h-3.5 w-3.5" />
                             )}
-                            {mergeAction.label}
                           </Button>
-                        </DisabledTooltip>
-                        {canShowMergeWhenReady && (
-                          <DropdownMenu>
-                            <DropdownMenuTrigger asChild>
-                              <Button
-                                size="icon-xs"
-                                variant={mergeAction.disabled ? "outline" : "default"}
-                                className="w-8 rounded-l-none border-l-0 shadow-none sm:w-6"
-                                disabled={mergeWhenReadyAction.disabled}
-                                title={mergeWhenReadyAction.disabledReason ?? "More merge actions"}
-                                aria-label="More merge actions"
-                              >
-                                {mergeWhenReadyAction.spinning ? (
-                                  <Loader2 className="h-3.5 w-3.5 animate-spin" />
-                                ) : (
-                                  <ChevronDown className="h-3.5 w-3.5" />
-                                )}
-                              </Button>
-                            </DropdownMenuTrigger>
-                            <DropdownMenuContent align="end">
-                              <DropdownMenuItem
-                                onClick={health.merge_when_ready.state === "queued" ? onCancelMergeWhenReady : onQueueMergeWhenReady}
-                                disabled={mergeWhenReadyAction.disabled}
-                                title={mergeWhenReadyAction.disabledReason}
-                              >
-                                <GitMerge className="h-3.5 w-3.5" />
-                                {mergeWhenReadyAction.label}
-                              </DropdownMenuItem>
-                            </DropdownMenuContent>
-                          </DropdownMenu>
-                        )}
-                      </ButtonGroup>
-                    )
-                  )}
-                  {canShowResolveConflictsButton && (
-                    <DisabledTooltip disabled={pendingAction !== null} content="Wait for the current PR action to finish">
-                      <ButtonGroup size="xs">
-                        <Button
-                          size="xs"
-                          variant={mergeAction.disabled ? "default" : "outline"}
-                          className={onResolveConflictsWithoutPushing ? "rounded-r-none" : undefined}
-                          disabled={pendingAction !== null}
-                          title={pendingAction !== null ? "Wait for the current PR action to finish" : "Resolve conflicts (p r)"}
-                          onClick={onResolveConflicts}
-                        >
-                          {pendingAction === "resolve_conflicts" ? (
-                            <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />
-                          ) : (
-                            <Wrench className="mr-1.5 h-3.5 w-3.5" />
-                          )}
-                          {pendingAction === "resolve_conflicts" ? "Opening repair session…" : resolveConflictsAutoExhausted ? "Resolve conflicts again" : "Resolve conflicts"}
-                        </Button>
-                        {onResolveConflictsWithoutPushing && (
-                          <DropdownMenu>
-                            <DropdownMenuTrigger asChild>
-                              <Button
-                                size="icon-xs"
-                                variant={mergeAction.disabled ? "default" : "outline"}
-                                className="rounded-l-none border-l-0"
-                                disabled={pendingAction !== null}
-                                title={pendingAction !== null ? "Wait for the current PR action to finish" : "More resolve conflicts actions"}
-                                aria-label="More resolve conflicts actions"
-                              >
-                                <ChevronDown className="h-3.5 w-3.5" />
-                              </Button>
-                            </DropdownMenuTrigger>
-                            <DropdownMenuContent align="end">
-                              <DropdownMenuItem onClick={onResolveConflictsWithoutPushing} disabled={pendingAction !== null}>
-                                <Wrench className="h-3.5 w-3.5" />
-                                Resolve without pushing changes
-                              </DropdownMenuItem>
-                            </DropdownMenuContent>
-                          </DropdownMenu>
-                        )}
-                      </ButtonGroup>
-                    </DisabledTooltip>
-                  )}
-                  {canShowFixTestsButton && (
-                    <DisabledTooltip disabled={pendingAction !== null} content="Wait for the current PR action to finish">
-                      <ButtonGroup size="xs">
-                        <Button
-                          size="xs"
-                          variant={mergeAction.disabled && !canShowResolveConflictsButton ? "default" : "outline"}
-                          className={onFixTestsWithoutPushing ? "rounded-r-none" : undefined}
-                          disabled={pendingAction !== null}
-                          title={pendingAction !== null ? "Wait for the current PR action to finish" : "Fix tests (p t)"}
-                          onClick={onFixTests}
-                        >
-                          {pendingAction === "fix_tests" ? (
-                            <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />
-                          ) : (
-                            <Wrench className="mr-1.5 h-3.5 w-3.5" />
-                          )}
-                          {pendingAction === "fix_tests" ? "Opening repair session…" : fixTestsAutoExhausted ? "Fix tests again" : "Fix tests"}
-                        </Button>
-                        {onFixTestsWithoutPushing && (
-                          <DropdownMenu>
-                            <DropdownMenuTrigger asChild>
-                              <Button
-                                size="icon-xs"
-                                variant={mergeAction.disabled && !canShowResolveConflictsButton ? "default" : "outline"}
-                                className="rounded-l-none border-l-0"
-                                disabled={pendingAction !== null}
-                                title={pendingAction !== null ? "Wait for the current PR action to finish" : "More fix tests actions"}
-                                aria-label="More fix tests actions"
-                              >
-                                <ChevronDown className="h-3.5 w-3.5" />
-                              </Button>
-                            </DropdownMenuTrigger>
-                            <DropdownMenuContent align="end">
-                              <DropdownMenuItem onClick={onFixTestsWithoutPushing} disabled={pendingAction !== null}>
-                                <Wrench className="h-3.5 w-3.5" />
-                                Fix without pushing changes
-                              </DropdownMenuItem>
-                            </DropdownMenuContent>
-                          </DropdownMenu>
-                        )}
-                      </ButtonGroup>
-                    </DisabledTooltip>
-                  )}
-                  {canShowReviewAction && reviewAction && (
-                    <DisabledTooltip
-                      disabled={reviewAction.disabled || pendingAction !== null}
-                      content={pendingAction !== null ? "Wait for the current PR action to finish" : reviewAction.title}
-                    >
-                      <Button
-                        size="xs"
-                        variant="outline"
-                        disabled={reviewAction.disabled || pendingAction !== null}
-                        title={pendingAction !== null ? "Wait for the current PR action to finish" : reviewAction.title}
-                        onClick={reviewAction.onClick}
-                      >
-                        {reviewAction.spinning ? (
-                          <Loader2 className="h-3.5 w-3.5 animate-spin" />
-                        ) : (
-                          <ClipboardList className="h-3.5 w-3.5" />
-                        )}
-                        Review
-                      </Button>
-                    </DisabledTooltip>
-                  )}
-                  {canShowPushChanges && pushChanges && (
-                    <DisabledTooltip
-                      disabled={pushChanges.disabled || pendingAction !== null}
-                      content={pendingAction !== null ? "Wait for the current PR action to finish" : pushChanges.title}
-                    >
-                      <Button
-                        size="xs"
-                        variant="outline"
-                        disabled={pushChanges.disabled || pendingAction !== null}
-                        title={pendingAction !== null ? "Wait for the current PR action to finish" : pushChanges.title ?? "Push changes (p p)"}
-                        aria-keyshortcuts="p p"
-                        onClick={pushChanges.onClick}
-                      >
-                        {pushChanges.spinning ? (
-                          <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />
-                        ) : pushChanges.showError ? (
-                          <AlertTriangle className="mr-1.5 h-3.5 w-3.5" />
-                        ) : (
-                          <Upload className="mr-1.5 h-3.5 w-3.5" />
-                        )}
-                        {pushChanges.label}
-                      </Button>
-                    </DisabledTooltip>
-                  )}
-                </div>
-                {canShowResolveConflictsButton && canShowFixTestsButton && (
-                  <p className="text-xs text-muted-foreground">
-                    Resolve conflicts first. CI may need to rerun afterward.
-                  </p>
-                )}
-                {mergeAuthRequired && canShowMergeButton && (
-                  <p className="text-xs text-muted-foreground">
-                    Connect your GitHub account to merge this pull request as yourself.
-                  </p>
-                )}
-                {health.merge_when_ready.state === "queued" && (
-                  <p className="text-xs text-muted-foreground">
-                    Waiting for GitHub requirements.
-                  </p>
-                )}
-                {health.merge_when_ready.state === "failed" && health.merge_when_ready.last_error && (
-                  <div
-                    role="status"
-                    aria-label="Merge when ready stopped"
-                    className="flex flex-col gap-1.5 text-xs text-muted-foreground sm:flex-row sm:items-center sm:justify-between sm:gap-2"
-                  >
-                    <span className="min-w-0">
-                      Merge when ready stopped: {health.merge_when_ready.last_error}
-                    </span>
-                    {onQueueMergeWhenReady && (
-                      <DisabledTooltip disabled={mergeWhenReadyAction.disabled || mergeWhenReadyPending} content={mergeWhenReadyAction.disabledReason}>
-                        <Button
-                          size="xs"
-                          variant="ghost"
-                          className="w-fit shrink-0"
-                          onClick={onQueueMergeWhenReady}
-                          disabled={mergeWhenReadyAction.disabled || mergeWhenReadyPending}
-                          title={mergeWhenReadyAction.disabledReason}
-                          aria-label="Retry merge when ready"
-                        >
-                          {mergeWhenReadyAction.spinning ? "Retrying…" : "Retry"}
-                        </Button>
-                      </DisabledTooltip>
+                        </DropdownMenuTrigger>
+                        <DropdownMenuContent align="end">
+                          <DropdownMenuItem
+                            onClick={health.merge_when_ready.state === "queued" ? onCancelMergeWhenReady : onQueueMergeWhenReady}
+                            disabled={mergeWhenReadyAction.disabled}
+                            title={mergeWhenReadyAction.disabledReason}
+                          >
+                            <GitMerge className="h-3.5 w-3.5" />
+                            {mergeWhenReadyAction.label}
+                          </DropdownMenuItem>
+                        </DropdownMenuContent>
+                      </DropdownMenu>
                     )}
-                  </div>
+                  </ButtonGroup>
+                )
+              )}
+              {canShowResolveConflictsButton && (
+                <DisabledTooltip disabled={pendingAction !== null} content="Wait for the current PR action to finish">
+                  <ButtonGroup size="xs">
+                    <Button
+                      size="xs"
+                      variant={mergeAction.disabled ? "default" : "outline"}
+                      className={onResolveConflictsWithoutPushing ? "rounded-r-none" : undefined}
+                      disabled={pendingAction !== null}
+                      title={pendingAction !== null ? "Wait for the current PR action to finish" : "Resolve conflicts (p r)"}
+                      onClick={onResolveConflicts}
+                    >
+                      {pendingAction === "resolve_conflicts" ? (
+                        <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />
+                      ) : (
+                        <Wrench className="mr-1.5 h-3.5 w-3.5" />
+                      )}
+                      {pendingAction === "resolve_conflicts" ? "Opening repair session…" : resolveConflictsAutoExhausted ? "Resolve conflicts again" : "Resolve conflicts"}
+                    </Button>
+                    {onResolveConflictsWithoutPushing && (
+                      <DropdownMenu>
+                        <DropdownMenuTrigger asChild>
+                          <Button
+                            size="icon-xs"
+                            variant={mergeAction.disabled ? "default" : "outline"}
+                            className="rounded-l-none border-l-0"
+                            disabled={pendingAction !== null}
+                            title={pendingAction !== null ? "Wait for the current PR action to finish" : "More resolve conflicts actions"}
+                            aria-label="More resolve conflicts actions"
+                          >
+                            <ChevronDown className="h-3.5 w-3.5" />
+                          </Button>
+                        </DropdownMenuTrigger>
+                        <DropdownMenuContent align="end">
+                          <DropdownMenuItem onClick={onResolveConflictsWithoutPushing} disabled={pendingAction !== null}>
+                            <Wrench className="h-3.5 w-3.5" />
+                            Resolve without pushing changes
+                          </DropdownMenuItem>
+                        </DropdownMenuContent>
+                      </DropdownMenu>
+                    )}
+                  </ButtonGroup>
+                </DisabledTooltip>
+              )}
+              {canShowFixTestsButton && (
+                <DisabledTooltip disabled={pendingAction !== null} content="Wait for the current PR action to finish">
+                  <ButtonGroup size="xs">
+                    <Button
+                      size="xs"
+                      variant={mergeAction.disabled && !canShowResolveConflictsButton ? "default" : "outline"}
+                      className={onFixTestsWithoutPushing ? "rounded-r-none" : undefined}
+                      disabled={pendingAction !== null}
+                      title={pendingAction !== null ? "Wait for the current PR action to finish" : "Fix tests (p t)"}
+                      onClick={onFixTests}
+                    >
+                      {pendingAction === "fix_tests" ? (
+                        <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />
+                      ) : (
+                        <Wrench className="mr-1.5 h-3.5 w-3.5" />
+                      )}
+                      {pendingAction === "fix_tests" ? "Opening repair session…" : fixTestsAutoExhausted ? "Fix tests again" : "Fix tests"}
+                    </Button>
+                    {onFixTestsWithoutPushing && (
+                      <DropdownMenu>
+                        <DropdownMenuTrigger asChild>
+                          <Button
+                            size="icon-xs"
+                            variant={mergeAction.disabled && !canShowResolveConflictsButton ? "default" : "outline"}
+                            className="rounded-l-none border-l-0"
+                            disabled={pendingAction !== null}
+                            title={pendingAction !== null ? "Wait for the current PR action to finish" : "More fix tests actions"}
+                            aria-label="More fix tests actions"
+                          >
+                            <ChevronDown className="h-3.5 w-3.5" />
+                          </Button>
+                        </DropdownMenuTrigger>
+                        <DropdownMenuContent align="end">
+                          <DropdownMenuItem onClick={onFixTestsWithoutPushing} disabled={pendingAction !== null}>
+                            <Wrench className="h-3.5 w-3.5" />
+                            Fix without pushing changes
+                          </DropdownMenuItem>
+                        </DropdownMenuContent>
+                      </DropdownMenu>
+                    )}
+                  </ButtonGroup>
+                </DisabledTooltip>
+              )}
+              {canShowReviewAction && reviewAction && (
+                <DisabledTooltip
+                  disabled={reviewAction.disabled || pendingAction !== null}
+                  content={pendingAction !== null ? "Wait for the current PR action to finish" : reviewAction.title}
+                >
+                  <Button
+                    size="xs"
+                    variant="outline"
+                    disabled={reviewAction.disabled || pendingAction !== null}
+                    title={pendingAction !== null ? "Wait for the current PR action to finish" : reviewAction.title}
+                    onClick={reviewAction.onClick}
+                  >
+                    {reviewAction.spinning ? (
+                      <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                    ) : (
+                      <ClipboardList className="h-3.5 w-3.5" />
+                    )}
+                    Review
+                  </Button>
+                </DisabledTooltip>
+              )}
+              {canShowPushChanges && pushChanges && (
+                <DisabledTooltip
+                  disabled={pushChanges.disabled || pendingAction !== null}
+                  content={pendingAction !== null ? "Wait for the current PR action to finish" : pushChanges.title}
+                >
+                  <Button
+                    size="xs"
+                    variant="outline"
+                    disabled={pushChanges.disabled || pendingAction !== null}
+                    title={pendingAction !== null ? "Wait for the current PR action to finish" : pushChanges.title ?? "Push changes (p p)"}
+                    aria-keyshortcuts="p p"
+                    onClick={pushChanges.onClick}
+                  >
+                    {pushChanges.spinning ? (
+                      <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />
+                    ) : pushChanges.showError ? (
+                      <AlertTriangle className="mr-1.5 h-3.5 w-3.5" />
+                    ) : (
+                      <Upload className="mr-1.5 h-3.5 w-3.5" />
+                    )}
+                    {pushChanges.label}
+                  </Button>
+                </DisabledTooltip>
+              )}
+            </div>
+            {canShowResolveConflictsButton && canShowFixTestsButton && (
+              <p className="text-xs text-muted-foreground">
+                Resolve conflicts first. CI may need to rerun afterward.
+              </p>
+            )}
+            {mergeAuthRequired && canShowMergeButton && (
+              <p className="text-xs text-muted-foreground">
+                Connect your GitHub account to merge this pull request as yourself.
+              </p>
+            )}
+            {health.merge_when_ready.state === "queued" && (
+              <p className="text-xs text-muted-foreground">
+                Waiting for GitHub requirements.
+              </p>
+            )}
+            {health.merge_when_ready.state === "failed" && health.merge_when_ready.last_error && (
+              <div
+                role="status"
+                aria-label="Merge when ready stopped"
+                className="flex flex-col gap-1.5 text-xs text-muted-foreground sm:flex-row sm:items-center sm:justify-between sm:gap-2"
+              >
+                <span className="min-w-0">
+                  Merge when ready stopped: {health.merge_when_ready.last_error}
+                </span>
+                {onQueueMergeWhenReady && (
+                  <DisabledTooltip disabled={mergeWhenReadyAction.disabled || mergeWhenReadyPending} content={mergeWhenReadyAction.disabledReason}>
+                    <Button
+                      size="xs"
+                      variant="ghost"
+                      className="w-fit shrink-0"
+                      onClick={onQueueMergeWhenReady}
+                      disabled={mergeWhenReadyAction.disabled || mergeWhenReadyPending}
+                      title={mergeWhenReadyAction.disabledReason}
+                      aria-label="Retry merge when ready"
+                    >
+                      {mergeWhenReadyAction.spinning ? "Retrying…" : "Retry"}
+                    </Button>
+                  </DisabledTooltip>
                 )}
               </div>
             )}
           </div>
-        </div>
-      </CardContent>
-    </Card>
+        )}
+      </div>
+    </section>
   );
 }
 

--- a/internal/demoseed/seed.go
+++ b/internal/demoseed/seed.go
@@ -33,6 +33,7 @@ const (
 	DemoBuilderEmail   = "preview-builder@143.dev"
 	DemoViewerEmail    = "preview-viewer@143.dev"
 	PrimarySessionID   = "00000000-0000-4000-a000-000000000300"
+	ShowcaseSessionID  = "00000000-0000-4000-a000-000000000308"
 	PreviewGroupID     = "00000000-0000-4000-a000-000000000430"
 	PreviewTargetID    = "00000000-0000-4000-a000-000000000431"
 	DemoPullRequestID  = "00000000-0000-4000-a000-000000000501"
@@ -248,6 +249,16 @@ func AssertDemoSeedState(ctx context.Context, pool seedDB) error {
 			name:     "demo sessions exist",
 			query:    `SELECT count(*) FROM sessions WHERE org_id = '00000000-0000-4000-a000-000000000001'::uuid AND id IN ('00000000-0000-4000-a000-000000000300'::uuid, '00000000-0000-4000-a000-000000000301'::uuid, '00000000-0000-4000-a000-000000000302'::uuid, '00000000-0000-4000-a000-000000000303'::uuid, '00000000-0000-4000-a000-000000000304'::uuid)`,
 			expected: 5,
+		},
+		{
+			name:     "session detail showcase exists",
+			query:    `SELECT count(*) FROM sessions WHERE org_id = '00000000-0000-4000-a000-000000000001'::uuid AND id = '00000000-0000-4000-a000-000000000308'::uuid AND origin = 'issue_trigger' AND result_summary IS NOT NULL AND diff IS NOT NULL`,
+			expected: 1,
+		},
+		{
+			name:     "session detail showcase threads exist",
+			query:    `SELECT count(*) FROM session_threads WHERE org_id = '00000000-0000-4000-a000-000000000001'::uuid AND session_id = '00000000-0000-4000-a000-000000000308'::uuid AND id IN ('00000000-0000-4000-a000-000000000708'::uuid, '00000000-0000-4000-a000-000000000709'::uuid, '00000000-0000-4000-a000-000000000710'::uuid)`,
+			expected: 3,
 		},
 		{
 			name:     "demo issues exist",

--- a/internal/demoseed/seed_test.go
+++ b/internal/demoseed/seed_test.go
@@ -218,6 +218,23 @@ func TestCurrentSeedCoversRepresentativeProductTables(t *testing.T) {
 	}
 }
 
+func TestCurrentSeedIncludesSessionDetailShowcase(t *testing.T) {
+	t.Parallel()
+
+	seed := string(readCurrentSeed(t))
+	requiredContent := []string{
+		ShowcaseSessionID,
+		"Session detail UI showcase",
+		"Overview polish",
+		"Copy review",
+		"Rejected experiment",
+	}
+
+	for _, content := range requiredContent {
+		require.Contains(t, seed, content, "session detail showcase should seed representative detail content")
+	}
+}
+
 func TestCurrentSeedUsesConvergentConflictHandlers(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

Session Details page metadata/provenance is currently noisy and harder to scan (e.g., redundant automation/workflow copy), and long repo/branch strings can break the overview layout. This change tightens the provenance UI, ensures long values truncate cleanly with full content available on hover, and adds a rich multi-tab seed session to validate success/failure and metadata states in one place.

## Changes

- Updated Session Details overview/provenance rendering to remove redundant “Created by automation / Automation run” wording and keep “issue-trigger” context compact (covered by updated composer tests).
- Improved overview rows for repo/branch to truncate gracefully, with the full value preserved via `title` and `truncate` styling (covered by overview tests).
- Added a new rich preview seed session (`43_session_detail_showcase.sql`) with multiple tabs and comprehensive metadata/diff/provenance/review artifacts for faster UI verification.
- Extended seed infrastructure/tests and related UI banner/health component coverage to support the new showcase states.

## Validation

- 155 focused frontend tests (composer/overview/pr-health-related)
- ESLint
- TypeScript
- Go tests and vet
- Seed safety and content assertions (migrated seed check could not run without a local PostgreSQL server)
- Manual preview reload: failed due to browser service + remains on prior workspace revision

[143.dev](https://143.dev) | [session 187956f1](https://143.dev/sessions/187956f1-5a03-4cf8-b6ac-e1f231af1dd3)

<!-- 143-publication session=187956f1-5a03-4cf8-b6ac-e1f231af1dd3 changeset=a648730c-2693-41df-9ce8-6d5cafc3a9fb -->

Preview: https://143.dev/previews/github/assembledhq/143/pull/2066?launch=1