### PR TITLE
Align safeguards card padding and margin with other cards on code review policy page

### DIFF
--- a/frontend/src/app/(dashboard)/code-reviews/page.test.tsx
+++ b/frontend/src/app/(dashboard)/code-reviews/page.test.tsx
@@ -2105,7 +2105,17 @@ describe("CodeReviewsPage", () => {
     const advancedTrigger = screen.getByRole("button", {
       name: "Safeguards",
     });
-    expect(advancedTrigger).toHaveClass("h-auto", "p-4", "sm:h-auto", "sm:p-5");
+    // The trigger owns the card's left inset; the right inset comes from the header
+    // row so the help icon, not the chevron, lands on the card edge.
+    expect(advancedTrigger).toHaveClass("h-auto", "py-4", "pr-2", "pl-4", "sm:h-auto", "sm:py-5", "sm:pl-5");
+    expect(advancedTrigger.closest("h3")?.parentElement).toHaveClass("pr-3", "sm:pr-4");
+    // The chevron must stay wrapped. As a direct child it matches the Button size
+    // variant's `has-[>svg]:px-2`, whose `:has()` specificity outranks the padding
+    // above and silently collapses the title back to an 8px inset. jsdom applies no
+    // CSS, so this structural check — not the class list above — is what catches it:
+    // the button also still carries an unmerged `px-2.5`, and these assertions would
+    // pass even if it started winning.
+    expect(advancedTrigger.querySelector(":scope > svg")).toBeNull();
     // Behavior, then both prompts together, then safeguards, then GitHub setup.
     expect(enablement.compareDocumentPosition(summaryHeading) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
     expect(summaryHeading.compareDocumentPosition(approvalHeading) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();

--- a/frontend/src/app/(dashboard)/code-reviews/page.tsx
+++ b/frontend/src/app/(dashboard)/code-reviews/page.tsx
@@ -2172,15 +2172,25 @@ function AdvancedPolicyControls({ children, forceOpen, onOpened }: { children: R
   return (
     <Collapsible open={open || forceOpen} onOpenChange={(next) => { setOpen(next); if (next) onOpened(); }}>
       <div className="rounded-xl border border-border bg-card">
-        <div className="flex items-center gap-1 pr-3">
+        {/* Padding is split rather than a plain `p-4 sm:p-5`: the trigger is not the
+            full card width, so only its left edge carries the card inset that
+            `CollapsibleContent` and sibling `SectionGroup`s use. The right inset comes
+            from this row's `pr`, which lands the help icon — not the chevron — on it. */}
+        <div className="flex items-center gap-1 pr-3 sm:pr-4">
           <h3 className="min-w-0 flex-1">
             <CollapsibleTrigger asChild>
-              <Button variant="ghost" className="group h-auto w-full min-w-0 justify-between whitespace-normal rounded-xl p-4 text-left sm:h-auto sm:p-5" aria-label="Safeguards">
+              <Button variant="ghost" className="group h-auto w-full min-w-0 justify-between whitespace-normal rounded-xl py-4 pr-2 pl-4 text-left sm:h-auto sm:py-5 sm:pl-5" aria-label="Safeguards">
                 <span className="min-w-0">
                   <span className="block font-display text-lg leading-6 font-semibold tracking-[-0.025em] text-foreground">Safeguards</span>
                   <span className="mt-0.5 block text-xs font-normal text-muted-foreground">These settings apply whether or not this section is open.</span>
                 </span>
-                <ChevronDown className="h-4 w-4 shrink-0 text-muted-foreground transition-transform group-data-[state=open]:rotate-180" />
+                {/* Wrapped so the chevron is not a direct child: `size="default"` carries
+                    `has-[>svg]:px-2`, whose `:has()` specificity silently outranks the plain
+                    padding utilities set above. `DisclosureCard` wraps its chevron too and is
+                    immune for the same reason. */}
+                <span className="flex shrink-0 items-center">
+                  <ChevronDown className="h-4 w-4 text-muted-foreground transition-transform group-data-[state=open]:rotate-180" />
+                </span>
               </Button>
             </CollapsibleTrigger>
           </h3>

--- a/frontend/src/components/ui/button.tsx
+++ b/frontend/src/components/ui/button.tsx
@@ -22,6 +22,11 @@ const buttonVariants = cva(
           "hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50",
         link: "text-primary underline-offset-4 hover:underline",
       },
+      // The `has-[>svg]` tighteners below outrank horizontal padding passed via
+      // `className`: `:has(>svg)` adds the specificity of its argument, so the rule
+      // wins over a plain `px-*`/`pl-*`/`p-*` no matter what `cn` merges. A call site
+      // that needs its own gutter must keep icons out of the button's direct children
+      // — wrap them in a `span`, as `DisclosureCard` does.
       size: {
         default: "h-10 px-2.5 py-1 sm:h-8 has-[>svg]:px-2",
         xs: "h-10 gap-1 rounded-md px-1.5 text-xs sm:h-6 has-[>svg]:px-1.5 [&_svg:not([class*='size-'])]:size-3",

--- a/frontend/src/components/ui/disclosure-card.test.tsx
+++ b/frontend/src/components/ui/disclosure-card.test.tsx
@@ -174,6 +174,11 @@ describe("DisclosureCard", () => {
       name: "Show Nested controls",
     });
     expect(trigger).toHaveClass("px-0");
+    // `px-0` alone does not settle the gutter: a chevron promoted to a direct
+    // child would match the Button size variant's `has-[>svg]:px-2`, whose
+    // `:has()` specificity outranks it and restores an 8px inset. jsdom applies
+    // no CSS, so the assertion above cannot see that — only this structural one.
+    expect(trigger.querySelector(":scope > svg")).toBeNull();
 
     const card = trigger.closest('[data-slot="card"]');
     expect(card).toHaveClass("rounded-none");

--- a/frontend/src/components/ui/disclosure-card.tsx
+++ b/frontend/src/components/ui/disclosure-card.tsx
@@ -98,9 +98,10 @@ function DisclosureCard({
                   ) : null}
                 </span>
               </span>
-              {/* The chevron must stay inside this wrapper. As a direct child of the
-                  button it would match the size variant's `has-[>svg]:px-2`, whose
-                  `:has()` specificity outranks the `px-0` set above. */}
+              {/* This wrapper groups the Hide/Show label with the chevron, and the
+                  chevron has to stay inside it: as a direct child of the button it
+                  would match the size variant's `has-[>svg]:px-2`, whose `:has()`
+                  specificity outranks the `px-0` set above and restores a gutter. */}
               <span
                 data-testid={actionTestId}
                 className="flex shrink-0 items-center gap-2 pt-0.5 text-xs font-medium text-muted-foreground sm:pt-0"

--- a/frontend/src/components/ui/disclosure-card.tsx
+++ b/frontend/src/components/ui/disclosure-card.tsx
@@ -98,6 +98,9 @@ function DisclosureCard({
                   ) : null}
                 </span>
               </span>
+              {/* The chevron must stay inside this wrapper. As a direct child of the
+                  button it would match the size variant's `has-[>svg]:px-2`, whose
+                  `:has()` specificity outranks the `px-0` set above. */}
               <span
                 data-testid={actionTestId}
                 className="flex shrink-0 items-center gap-2 pt-0.5 text-xs font-medium text-muted-foreground sm:pt-0"


### PR DESCRIPTION
## Summary

The code review policy page shows the “Safeguards” card trigger misaligned compared to other cards, causing inconsistent left/right insets (help icon edge vs. chevron/title spacing). This change adjusts the trigger’s padding to match the established card inset model and updates the tests to reliably catch regressions in the trigger structure.

## Changes

- Split the card inset across the header row vs. the trigger: left edge inset stays on the trigger, while the right edge inset comes from the surrounding header container.
- Update `AdvancedPolicyControls` (“Safeguards” `CollapsibleTrigger`) to use `py/pr/pl` utilities instead of a uniform `p-*`, keeping the title spacing consistent across breakpoints.
- Wrap/adjust the chevron markup so button sizing rules (including `:has()`-driven SVG padding) don’t silently collapse the expected inset.
- Strengthen `page.test.tsx` assertions to validate the structural condition (chevron not a direct child) in addition to classnames.

## Validation

- Updated and extended Jest/React Testing Library coverage in `frontend/src/app/(dashboard)/code-reviews/page.test.tsx` to verify the aligned padding classes and the chevron placement behavior.

[143.dev](https://143.dev) | [session b90f4476](https://143.dev/sessions/b90f4476-62ca-4cc7-90e1-05de57de3bd4)

<!-- 143-publication session=b90f4476-62ca-4cc7-90e1-05de57de3bd4 changeset=e224f887-9889-42e7-9324-a1fc5faa2cc9 -->

Preview: https://143.dev/previews/github/assembledhq/143/pull/2067?launch=1