### PR TITLE
Benchmark preview spin-up for 143 and generate flame graph to identify slow startup components

### DIFF
--- a/.143/config.json
+++ b/.143/config.json
@@ -11,7 +11,12 @@
       "verify_paths": ["frontend/node_modules/.bin/next"],
       "timeout_seconds": 600,
       "cache": {
-        "paths": ["frontend/.next/cache"]
+        "package_manager": {
+          "enabled": false
+        },
+        "build": {
+          "paths": ["frontend/.next/cache"]
+        }
       }
     },
     "services": {

--- a/docs/design/implemented/93-session-preview-dependency-cache.md
+++ b/docs/design/implemented/93-session-preview-dependency-cache.md
@@ -31,12 +31,13 @@ The cache implementation now treats preview install caching as a generic path-ca
 | pip | `.cache/pip` |
 | uv | `.cache/uv` |
 | poetry | `.cache/pypoetry` |
-| go | `go/pkg/mod`, `.cache/go-build`, before the ownership split below |
+| go | `go/pkg/mod`, `.cache/go-build` |
 
 Package-manager paths reject absolute paths, `..`, globs, broad `.`, sensitive directories such as `.ssh`, `.gnupg`, `.codex`, `.claude`, `.config/gh`, `.143`, and parents/children of those sensitive paths.
 
-Each effective HomeDir path has one cache owner, and ownership follows restore
-*timing* rather than which phase happens to write the directory. The
+Those are the paths each manager infers before ownership is resolved. Each
+effective HomeDir path then gets exactly one cache owner, and ownership follows
+restore *timing* rather than which phase happens to write the directory. The
 package-manager cache restores before `preview.install`; the home build cache
 only afterwards, immediately before service builds. So the build cache owns
 `.cache/go-build` — nothing but a build populates it — while `go/pkg/mod` stays

--- a/docs/design/implemented/93-session-preview-dependency-cache.md
+++ b/docs/design/implemented/93-session-preview-dependency-cache.md
@@ -31,9 +31,22 @@ The cache implementation now treats preview install caching as a generic path-ca
 | pip | `.cache/pip` |
 | uv | `.cache/uv` |
 | poetry | `.cache/pypoetry` |
-| go | `go/pkg/mod`, `.cache/go-build` |
+| go | `go/pkg/mod`, `.cache/go-build` (before build-cache ownership de-duplication) |
 
 Package-manager paths reject absolute paths, `..`, globs, broad `.`, sensitive directories such as `.ssh`, `.gnupg`, `.codex`, `.claude`, `.config/gh`, `.143`, and parents/children of those sensitive paths.
+
+Each effective HomeDir path has one cache owner, and ownership follows restore
+*timing* rather than which phase happens to write the directory. The
+package-manager cache restores before `preview.install`; the home build cache
+only afterwards, immediately before service builds. So the build cache owns
+`.cache/go-build` — nothing but a build populates it — while `go/pkg/mod` stays
+with the package-manager cache whenever that lifecycle is enabled, because an
+install that fetches modules is only warm if they are already on disk when it
+runs. That holds whether the install command is `go mod download` or an opaque
+wrapper script, which the platform cannot inspect. The build cache adopts
+`go/pkg/mod` only when the package-manager cache is disabled, so the directory
+is never left uncached. De-duplicating this way avoids both duplicate archive
+upload and serialized extraction of the same data.
 
 The DB tables `preview_dependency_cache` and `preview_dependency_cache_locations` now include `cache_kind`; uniqueness and placement indexes include `(org_id, repo_id, cache_kind, cache_key)`. Worker-local L1 blob paths are also kind-aware, with legacy install-output local paths still readable during rollout.
 
@@ -42,6 +55,20 @@ Preview dependency and package-manager cache keys use a stable sandbox cache ABI
 Preview startup uses cache placement as a scheduling hint, not a correctness primitive. Exact config-derived placement keys prefer workers with known L1 blobs. When the API cannot know the exact config before worker selection, the repo-level fallback is marked approximate and the scheduler prefers recent repo cache holders before rendezvous hashing. The worker still recomputes exact cache keys inside the hydrated workspace before restore.
 
 Cache saves are kept out of the readiness-critical path. Normal preview launches compute cache keys during install, but defer package-manager and install-output archive/upload work until after the primary readiness path succeeds. Prewarm jobs still save synchronously because cache creation is their primary work.
+
+Retained sandboxes validate the exact install marker and declared `verify_paths`
+before any remote cache lookup. When both already hold, startup reports
+`skipped_install_valid` and avoids package-manager and install-output archive
+download/extraction entirely. The shortcut is a launch-path optimization only:
+prewarm jobs never take it, because their sandbox is cloned or hydrated from a
+workspace that may already have installed, and skipping there would report
+success while producing no cache. Because a launch that takes the shortcut runs
+neither a restore nor an install, it is also the only thing that would notice
+the remote entry backing its marker has been evicted, so it queues one existence
+probe behind readiness and re-archives when nothing backs the key. If a remote
+install-output restore is what makes the contract valid, only that workdir cache
+receives saved-producer benefit; the HomeDir package-manager restore records zero
+benefit unless an install command actually runs.
 
 The preview gateway keeps a short-lived access-session validation cache so asset-heavy preview page loads do not hit Postgres for every JS/CSS/image request. The cache is scoped to the decoded org, public host, and runtime preview ID, and is intentionally short TTL so revocation/expiry changes converge quickly while protecting hot page-load latency.
 
@@ -55,7 +82,11 @@ Failure-path build-cache persistence is best effort. Independent workdir, `GOCAC
 
 Cache admission is cost-aware. `preview_dependency_cache` records compressed bytes, a cold producer baseline, marginal-benefit observations, restore attempts, successful restores, total restore duration, and last restore time. Unknown legacy baselines force one cold sample. After three attempts, restore is skipped when its historical average is at least the measured average marginal benefit; complementary caches share one end-to-end benefit budget rather than each claiming the full cold duration. Failed and timed-out attempts count toward restore cost. A launch whose install or build itself failed records no benefit observation at all — it never measured one, and a zero sample there would let a few broken builds switch off the branch's own warm start. Replacing a blob resets the whole cost history for that key, baseline included. A skipped entry is re-probed after 24 hours so worker, network, or archive-shape improvements can recover automatically. The terminal observer statuses are `skipped_cost` and `restore_timeout`; both are accelerator fallbacks and never fail preview startup.
 
-Prewarming is implemented as a low-priority `preview_cache_prewarm` worker job with branch and session payload sources. The automatic triggers are branch/PR preview target creation or commit update, plus successful snapshot-producing `run_agent` and `continue_session` turns. The runner creates an ephemeral sandbox with purpose `preview_cache_prewarm`, checks out, hydrates, or live-clones the workspace when the session sandbox is still owned by the same worker, reads the selected preview config, and skips only when both install caches and the exact branch startup snapshot are already warm. Session-source jobs still prewarm install/package-manager caches only. Branch-source jobs use providers that support build-snapshot prewarm to run install, restore build caches, run service build commands without starting runtime services, save build caches synchronously, create the exact startup snapshot, and then destroy the sandbox. Capacity exhaustion returns `skipped_capacity` and does not retry or dead-letter. Runtime rollout is controlled by `PREVIEW_CACHE_PREWARM_ENABLED=false` by default, `PREVIEW_CACHE_PREWARM_TIMEOUT=15m`, and `PREVIEW_CACHE_PREWARM_PRIORITY=-50`.
+Prewarming is implemented as low-priority worker jobs. Branch and cache-only session payloads use `preview_cache_prewarm`: the runner creates an ephemeral sandbox with purpose `preview_cache_prewarm`, checks out, hydrates, or live-clones the workspace when the session sandbox is still owned by the same worker, reads the selected preview config, and warms install/package-manager caches. Branch-source jobs additionally use providers that support build-snapshot prewarm to restore build caches, run service build commands without starting runtime services, save build caches synchronously, create the exact startup snapshot, and then destroy the sandbox.
+
+The smart session warm-candidate path uses `session_preview_warm_build`. It launches the exact session workspace revision, completes install, service builds, and readiness, records a worker-local startup-cache marker keyed by session and workspace revision, then stops services while retaining the sandbox and its build artifacts. A click revalidates the session revision, worker placement, stop reason, and startup-cache marker before resuming that retained sandbox. The resume runs service commands and readiness probes but skips remote build-cache restore/save and the already-completed service build phase. Ordinary starts and recycles never receive that exemption.
+
+Capacity exhaustion returns `skipped_capacity` and does not retry or dead-letter. Runtime rollout is controlled by `PREVIEW_CACHE_PREWARM_ENABLED=false` by default, `PREVIEW_CACHE_PREWARM_TIMEOUT=15m`, and `PREVIEW_CACHE_PREWARM_PRIORITY=-50`.
 
 ## Goals
 

--- a/docs/design/implemented/93-session-preview-dependency-cache.md
+++ b/docs/design/implemented/93-session-preview-dependency-cache.md
@@ -31,7 +31,7 @@ The cache implementation now treats preview install caching as a generic path-ca
 | pip | `.cache/pip` |
 | uv | `.cache/uv` |
 | poetry | `.cache/pypoetry` |
-| go | `go/pkg/mod`, `.cache/go-build` (before build-cache ownership de-duplication) |
+| go | `go/pkg/mod`, `.cache/go-build`, before the ownership split below |
 
 Package-manager paths reject absolute paths, `..`, globs, broad `.`, sensitive directories such as `.ssh`, `.gnupg`, `.codex`, `.claude`, `.config/gh`, `.143`, and parents/children of those sensitive paths.
 
@@ -47,6 +47,15 @@ wrapper script, which the platform cannot inspect. The build cache adopts
 `go/pkg/mod` only when the package-manager cache is disabled, so the directory
 is never left uncached. De-duplicating this way avoids both duplicate archive
 upload and serialized extraction of the same data.
+
+Owning `go/pkg/mod` constrains when the package-manager cache may be archived: a
+JS install command does not fill the module cache, the build phase's `go build`
+does, so the save has to happen after service builds rather than at the end of
+install. Normal launches get that for free because their install-phase saves are
+deferred past readiness. The build-snapshot prewarm job has no readiness path, so
+it defers explicitly and drains synchronously after its build phase — it destroys
+its own sandbox on return, so a fire-and-forget drain there would be killed by
+teardown.
 
 The DB tables `preview_dependency_cache` and `preview_dependency_cache_locations` now include `cache_kind`; uniqueness and placement indexes include `(org_id, repo_id, cache_kind, cache_key)`. Worker-local L1 blob paths are also kind-aware, with legacy install-output local paths still readable during rollout.
 

--- a/docs/public/reference/preview-config.mdx
+++ b/docs/public/reference/preview-config.mdx
@@ -52,6 +52,7 @@ Use `preview.default` to auto-select one config. If there are multiple configs a
 <ConfigField name="preview.credentials" type="object" description='Legacy env-only credential injection policy. Omit it or use { "mode": "none" } if no legacy credential set is needed.' />
 <ConfigField name="preview.network" type="object" required description='Network policy. Use { "mode": "managed" } for the default sandbox policy.' />
 <ConfigField name="preview.progressive" type="boolean" description="For multi-service previews, allow partial readiness once the primary service is ready." />
+<ConfigField name="preview.parallel_builds" type="boolean" defaultValue="false" description="Run service build commands concurrently. Enable only when their outputs are independent and their combined peak memory fits preview.resources; concurrent builds add their peaks inside one cgroup, and on a low CPU limit they mostly trade OOM risk for little wall-clock. Sequential support-first, primary-last builds remain the default." />
 <ConfigField name="preview.command" type="string[]" description="Single-service shorthand command." />
 <ConfigField name="preview.cwd" type="string" description="Single-service shorthand working directory." />
 <ConfigField name="preview.port" type="integer" description="Single-service shorthand port." />
@@ -67,13 +68,16 @@ Use `preview.default` to auto-select one config. If there are multiple configs a
 <ConfigField name="preview.install.verify_paths" type="string[]" description="Repo-relative paths that must exist before a cached install can be reused." />
 <ConfigField name="preview.install.cache.enabled" type="boolean" defaultValue="true" description="Set false to opt out of dependency output caching." />
 <ConfigField name="preview.install.cache.paths" type="string[]" description="Additive repo-relative dependency/build cache paths. Effective paths are clean_paths + cache.paths + inferred paths, excluding platform-owned install markers." />
+<ConfigField name="preview.install.cache.package_manager.enabled" type="boolean" defaultValue="true" description="Set false to opt out of package-manager (home directory) caching, such as the npm or Go module download caches restored before install runs." />
+<ConfigField name="preview.install.cache.package_manager.include" type="string[]" description="Additional package managers to cache beyond those inferred from lockfiles and the install command." />
+<ConfigField name="preview.install.cache.package_manager.paths" type="string[]" description="Additive home-relative package-manager cache paths. Absolute paths, globs, and sensitive directories are rejected." />
 <ConfigField name="preview.install.cache.build.enabled" type="boolean" defaultValue="true" description="Set false to opt out of build-output caching (incremental build caches saved after services report ready)." />
 <ConfigField name="preview.install.cache.build.paths" type="string[]" description="Additive repo-relative build cache paths (globs allowed). Effective paths are build.paths + inferred Turborepo cache dirs next to each JS lockfile." />
 <ConfigField name="preview.install.timeout_seconds" type="integer" defaultValue="420" description="Maximum install duration. Max 1800." />
 
 Install caches are keyed from the install command, declared lockfiles, the platform sandbox cache ABI, and effective cache paths. They speed up preview startup without replacing source files from the session workspace. Routine 143 deploys do not change the ABI; platform operators bump it only when sandbox OS/toolchain/runtime compatibility changes.
 
-Use `preview.install` for dependency installation only. Source-dependent builds belong in service commands, where they run against the current workspace on every start.
+Use `preview.install` for dependency installation only. Source-dependent builds belong in each service's `build` field. Normal starts and recycles run them against the current workspace; an exact-revision warm resume may reuse the completed build from its retained sandbox.
 
 Inferred dependency cache paths:
 
@@ -95,6 +99,7 @@ Only cache build directories whose tool validates entries by content hash. A sta
 
 ## Service fields
 
+<ConfigField name="build" type="string[]" description="Optional build command run after cache restore and before services start. With parallel_builds enabled, build commands must write independent outputs." />
 <ConfigField name="command" type="string[]" required description="Command argv executed directly inside the sandbox." />
 <ConfigField name="cwd" type="string" description="Working directory relative to the repo root." />
 <ConfigField name="port" type="integer" required description="Port the service binds to." />

--- a/internal/api/handlers/internal_preview.go
+++ b/internal/api/handlers/internal_preview.go
@@ -307,6 +307,13 @@ func (h *InternalPreviewHandler) RecyclePreview(w http.ResponseWriter, r *http.R
 			return
 		}
 		if err := h.manager.ResumeStoppedWarmPreview(r.Context(), orgID, previewID); err != nil {
+			// Ineligibility is an expected race, not a failure: the preview was
+			// never claimed, so the coordinator can still start it cold. Keep it
+			// distinguishable from a genuine resume failure.
+			if errors.Is(err, previewsvc.ErrWarmResumeNotEligible) {
+				writeError(w, r, http.StatusConflict, previewWarmResumeNotEligibleCode, "preview is no longer eligible for warm resume", err)
+				return
+			}
 			writeError(w, r, http.StatusInternalServerError, "PREVIEW_WARM_RESUME_FAILED", "failed to resume warm preview", err)
 			return
 		}

--- a/internal/api/handlers/preview.go
+++ b/internal/api/handlers/preview.go
@@ -1569,30 +1569,49 @@ func (h *PreviewHandler) sessionPreviewStartMetricPath(ctx context.Context, orgI
 	return "cold_start"
 }
 
-func (h *PreviewHandler) resumeWarmSessionPreview(ctx context.Context, orgID uuid.UUID, instance *models.PreviewInstance) *previewHTTPError {
+// previewWarmResumeNotEligibleCode marks a warm resume the worker declined
+// because the preview stopped qualifying for the shortcut. It travels over the
+// internal worker API so the coordinator can tell it apart from a real failure.
+const previewWarmResumeNotEligibleCode = "PREVIEW_WARM_RESUME_NOT_ELIGIBLE"
+
+// resumeWarmSessionPreview attempts the warm-resume shortcut. It reports
+// resumed=false with no error when the preview turned out not to qualify —
+// every eligibility guard races ordinary user activity (an agent turn bumping
+// the workspace revision, a startup cache being evicted), and the preview is
+// left untouched in that case. Callers must fall through to a normal start
+// rather than surfacing an error the user cannot act on.
+func (h *PreviewHandler) resumeWarmSessionPreview(ctx context.Context, orgID uuid.UUID, instance *models.PreviewInstance) (bool, *previewHTTPError) {
 	if instance == nil {
-		return nil
+		return false, nil
+	}
+	resumeLocal := func() (bool, *previewHTTPError) {
+		if err := h.manager.ResumeStoppedWarmPreview(ctx, orgID, instance.ID); err != nil {
+			if errors.Is(err, preview.ErrWarmResumeNotEligible) {
+				h.logger.Info().Err(err).Str("preview_id", instance.ID.String()).Msg("warm preview resume declined; starting normally")
+				return false, nil
+			}
+			return false, newPreviewHTTPError(http.StatusInternalServerError, "PREVIEW_WARM_RESUME_FAILED", "failed to resume warm preview", err)
+		}
+		return true, nil
 	}
 	if h.workerRoutingEnabled() {
 		worker, err := h.resolvePreviewWorker(ctx, instance.WorkerNodeID)
 		if err != nil {
-			return newPreviewHTTPError(http.StatusBadGateway, "PREVIEW_WORKER_RESOLUTION_FAILED", "failed to resolve preview worker", err)
+			return false, newPreviewHTTPError(http.StatusBadGateway, "PREVIEW_WORKER_RESOLUTION_FAILED", "failed to resolve preview worker", err)
 		}
 		if h.isLocalWorker(worker) {
-			if err := h.manager.ResumeStoppedWarmPreview(ctx, orgID, instance.ID); err != nil {
-				return newPreviewHTTPError(http.StatusInternalServerError, "PREVIEW_WARM_RESUME_FAILED", "failed to resume warm preview", err)
-			}
-			return nil
+			return resumeLocal()
 		}
 		if err := h.workerClient.ResumeWarmPreview(ctx, worker, orgID, instance.ID); err != nil {
-			return workerClientHTTPError(err)
+			if reqErr, ok := preview.AsWorkerRequestError(err); ok && reqErr.Code == previewWarmResumeNotEligibleCode {
+				h.logger.Info().Err(err).Str("preview_id", instance.ID.String()).Msg("warm preview resume declined by worker; starting normally")
+				return false, nil
+			}
+			return false, workerClientHTTPError(err)
 		}
-		return nil
+		return true, nil
 	}
-	if err := h.manager.ResumeStoppedWarmPreview(ctx, orgID, instance.ID); err != nil {
-		return newPreviewHTTPError(http.StatusInternalServerError, "PREVIEW_WARM_RESUME_FAILED", "failed to resume warm preview", err)
-	}
-	return nil
+	return resumeLocal()
 }
 
 func (h *PreviewHandler) previewFreshness(ctx context.Context, orgID, sessionID uuid.UUID, instance *models.PreviewInstance) *models.PreviewFreshness {
@@ -1923,20 +1942,25 @@ func (h *PreviewHandler) ensurePreview(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		if warmInstance != nil {
-			if resumeErr := h.resumeWarmSessionPreview(r.Context(), orgID, warmInstance); resumeErr != nil {
+			resumed, resumeErr := h.resumeWarmSessionPreview(r.Context(), orgID, warmInstance)
+			if resumeErr != nil {
 				writePreviewHTTPError(w, r, resumeErr)
 				return
 			}
-			metrics.RecordSessionPrewarmOpenAfterPrewarm(r.Context(), orgID.String(), "warm_candidate")
-			metrics.RecordSessionPrewarmClickToReady(r.Context(), orgID.String(), "warm_resume", time.Since(clickStarted))
-			refreshed, err := h.store.GetPreviewInstance(r.Context(), orgID, warmInstance.ID)
-			if err != nil {
-				refreshed = warmInstance
+			// resumed=false means the shortcut was declined, not that anything
+			// failed; fall through to the normal start below.
+			if resumed {
+				metrics.RecordSessionPrewarmOpenAfterPrewarm(r.Context(), orgID.String(), "warm_candidate")
+				metrics.RecordSessionPrewarmClickToReady(r.Context(), orgID.String(), "warm_resume", time.Since(clickStarted))
+				refreshed, err := h.store.GetPreviewInstance(r.Context(), orgID, warmInstance.ID)
+				if err != nil {
+					refreshed = warmInstance
+				}
+				writeJSON(w, http.StatusOK, models.SingleResponse[ensurePreviewResponse]{
+					Data: h.ensurePreviewResponse(r.Context(), orgID, "resumed", refreshed),
+				})
+				return
 			}
-			writeJSON(w, http.StatusOK, models.SingleResponse[ensurePreviewResponse]{
-				Data: h.ensurePreviewResponse(r.Context(), orgID, "resumed", refreshed),
-			})
-			return
 		}
 		started, _, startErr := h.startPreviewFromRequest(r.Context(), orgID, user.ID, sessionID, body)
 		if startErr != nil {

--- a/internal/api/handlers/preview_worker_routing_test.go
+++ b/internal/api/handlers/preview_worker_routing_test.go
@@ -15,6 +15,7 @@ import (
 	previewsvc "github.com/assembledhq/143/internal/services/preview"
 	"github.com/google/uuid"
 	"github.com/pashagolub/pgxmock/v4"
+	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/require"
 )
 
@@ -973,4 +974,51 @@ func TestPreviewHandler_ResolveBrowserWorkerUsesSelectedTopology(t *testing.T) {
 			require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
 		})
 	}
+}
+
+// TestPreviewHandler_ResumeWarmSessionPreviewFallsBackWhenIneligible pins the
+// contract that keeps a benign race off the user's screen. Every warm-resume
+// eligibility guard can flip between the handler's own pre-check and the
+// manager's — an agent turn bumps the workspace revision, a startup cache row is
+// evicted — and the preview is left untouched when it does. That must read as
+// "start it normally", never as a 500 on a preview the user just clicked.
+func TestPreviewHandler_ResumeWarmSessionPreviewFallsBackWhenIneligible(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "pgxmock pool should be created")
+	defer mock.Close()
+
+	orgID := uuid.New()
+	previewID := uuid.New()
+	sessionID := uuid.New()
+	userID := uuid.New()
+	now := time.Now()
+
+	row := newActivePreviewRow(previewID, sessionID, orgID, userID, now)
+	for i, column := range previewInstanceTestCols {
+		if column == "status" {
+			row[i] = string(models.PreviewStatusStopped)
+		}
+	}
+	mock.ExpectQuery("SELECT .+ FROM preview_instances WHERE id").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(pgxmock.NewRows(previewInstanceTestCols).AddRow(row...))
+	// Stopped for an unrelated reason: no longer a warm-resume candidate.
+	mock.ExpectQuery("SELECT COALESCE\\(stopped_reason").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(pgxmock.NewRows([]string{"stopped_reason"}).AddRow(string(models.PreviewStoppedReasonExpired)))
+
+	store := db.NewPreviewStore(mock)
+	manager := previewsvc.NewManager(previewsvc.ManagerConfig{
+		Store:        store,
+		Logger:       zerolog.Nop(),
+		WorkerNodeID: "worker-1",
+	})
+	h := &PreviewHandler{manager: manager, store: store, logger: zerolog.Nop()}
+
+	resumed, resumeErr := h.resumeWarmSessionPreview(context.Background(), orgID, &models.PreviewInstance{ID: previewID, OrgID: orgID, SessionID: sessionID})
+	require.Nil(t, resumeErr, "an ineligible warm candidate must not surface an error to the user")
+	require.False(t, resumed, "an ineligible warm candidate must report that it did not resume, so the caller starts normally")
+	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
 }

--- a/internal/db/preview_store.go
+++ b/internal/db/preview_store.go
@@ -1819,8 +1819,9 @@ func (s *PreviewStore) updatePreviewStatusIfActive(ctx context.Context, orgID, i
 
 // BeginStoppedWarmPreviewResume atomically claims a stopped session prewarm
 // preview for user-visible resume. Only previews stopped by the session prewarm
-// policy can be resumed through this path.
-func (s *PreviewStore) BeginStoppedWarmPreviewResume(ctx context.Context, orgID, id uuid.UUID) (bool, error) {
+// policy whose source revision is still the session's current revision can be
+// resumed through this path.
+func (s *PreviewStore) BeginStoppedWarmPreviewResume(ctx context.Context, orgID, id, sessionID uuid.UUID, workspaceRevision int64) (bool, error) {
 	status := models.PreviewStatusStarting
 	phase := previewPhaseForStatus(status)
 	tag, err := s.db.Exec(ctx, `
@@ -1833,14 +1834,25 @@ func (s *PreviewStore) BeginStoppedWarmPreviewResume(ctx context.Context, orgID,
 		    updated_at = now()
 		WHERE id = @id
 		  AND org_id = @org_id
+		  AND session_id = @session_id
+		  AND source_workspace_revision = @workspace_revision
 		  AND status IN ('stopped', 'expired')
-		  AND stopped_reason = @stopped_reason`,
+		  AND stopped_reason = @stopped_reason
+		  AND EXISTS (
+			SELECT 1
+			FROM sessions s
+			WHERE s.id = @session_id
+			  AND s.org_id = @org_id
+			  AND s.workspace_revision = @workspace_revision
+		  )`,
 		pgx.NamedArgs{
-			"id":             id,
-			"org_id":         orgID,
-			"status":         status,
-			"phase":          phase,
-			"stopped_reason": models.PreviewStoppedReasonSessionPrewarmPolicy,
+			"id":                 id,
+			"org_id":             orgID,
+			"session_id":         sessionID,
+			"workspace_revision": workspaceRevision,
+			"status":             status,
+			"phase":              phase,
+			"stopped_reason":     models.PreviewStoppedReasonSessionPrewarmPolicy,
 		},
 	)
 	if err != nil {

--- a/internal/db/preview_store_test.go
+++ b/internal/db/preview_store_test.go
@@ -2215,8 +2215,8 @@ func TestPreviewStore_BeginStoppedWarmPreviewResume(t *testing.T) {
 
 			store := NewPreviewStore(mock)
 
-			mock.ExpectExec("UPDATE preview_instances").
-				WithArgs(previewAnyArgs(5)...).
+			mock.ExpectExec("UPDATE preview_instances(?s:.*)source_workspace_revision = @workspace_revision(?s:.*)EXISTS").
+				WithArgs(previewAnyArgs(7)...).
 				WillReturnResult(pgxmock.NewResult("UPDATE", tt.rows)).
 				WillReturnError(tt.execErr)
 			if tt.rows > 0 && tt.execErr == nil {
@@ -2226,7 +2226,7 @@ func TestPreviewStore_BeginStoppedWarmPreviewResume(t *testing.T) {
 					WillReturnError(tt.syncErr)
 			}
 
-			updated, err := store.BeginStoppedWarmPreviewResume(context.Background(), uuid.New(), uuid.New())
+			updated, err := store.BeginStoppedWarmPreviewResume(context.Background(), uuid.New(), uuid.New(), uuid.New(), 12)
 			if tt.expectErr {
 				require.Error(t, err, "warm resume transition should return database errors")
 				require.False(t, updated, "warm resume transition should not report success on error")

--- a/internal/models/preview.go
+++ b/internal/models/preview.go
@@ -561,8 +561,11 @@ type PreviewConfig struct {
 	Credentials    CredentialConfig                `json:"credentials"`
 	Network        NetworkConfig                   `json:"network"`
 	Progressive    bool                            `json:"progressive,omitempty"`
-	Browser        PreviewBrowserConfig            `json:"browser,omitempty"`
-	Verification   PreviewVerificationConfig       `json:"verification,omitempty"`
+	// ParallelBuilds opts into concurrent service Build commands. Repositories
+	// should enable it only when those commands write independent outputs.
+	ParallelBuilds bool                      `json:"parallel_builds,omitempty"`
+	Browser        PreviewBrowserConfig      `json:"browser,omitempty"`
+	Verification   PreviewVerificationConfig `json:"verification,omitempty"`
 
 	RuntimeSecretEnv   map[string]map[string]string `json:"-"`
 	RuntimeSecretFiles []PreviewRuntimeSecretFile   `json:"-"`
@@ -759,9 +762,10 @@ type ServiceConfig struct {
 	// install phase and after build caches are restored, but before any
 	// service starts. It is the place to compile outputs (e.g. `go build`)
 	// so the start Command can exec a prebuilt binary instead of compiling on
-	// the readiness-probe hot path. Build commands run in dependency order
-	// (support services first, primary last), share the service Env, and
-	// populate build caches that the post-build checkpoint persists.
+	// the readiness-probe hot path. Build commands run support-first and
+	// primary-last unless the preview explicitly opts into concurrent independent
+	// builds. They share the service Env and populate build caches that the
+	// post-build checkpoint persists.
 	Build   []string          `json:"build,omitempty"`
 	Command []string          `json:"command"`
 	Cwd     string            `json:"cwd,omitempty"`

--- a/internal/services/preview/config.go
+++ b/internal/services/preview/config.go
@@ -152,6 +152,7 @@ type rawPreviewConfig struct {
 	Credentials    models.CredentialConfig                `json:"credentials"`
 	Network        models.NetworkConfig                   `json:"network"`
 	Progressive    bool                                   `json:"progressive,omitempty"`
+	ParallelBuilds bool                                   `json:"parallel_builds,omitempty"`
 	Browser        *rawPreviewBrowserConfig               `json:"browser,omitempty"`
 	Verification   *rawPreviewVerificationConfig          `json:"verification,omitempty"`
 
@@ -251,6 +252,7 @@ func ParseNamedConfig(data []byte, name string) (*models.PreviewConfig, error) {
 		Credentials:    raw.Credentials,
 		Network:        raw.Network,
 		Progressive:    raw.Progressive,
+		ParallelBuilds: raw.ParallelBuilds,
 	}
 	secrets, err := parsePreviewSecrets(raw.Secrets)
 	if err != nil {
@@ -1159,13 +1161,16 @@ func ResolvePreviewBuildCachePaths(install *models.PreviewInstallConfig) ([]stri
 // preview.install.lockfiles, the same signal the package-manager cache uses to
 // enable Go caching. Build caching must also not be explicitly disabled.
 //
-// To avoid double-caching the module cache, go/pkg/mod is dropped from the home
-// set when the install *command* already runs go (e.g. `go mod download`): in
-// that case the package-manager cache captures the modules post-install, so the
-// home set only needs the compiled-object cache (.cache/go-build) that the build
-// phase uniquely warms. When install does not run go (the common case: a JS
-// install that happens to sit beside a go.mod), the build phase is the only
-// thing that downloads modules, so the home set owns go/pkg/mod too.
+// To avoid double-caching the module cache, go/pkg/mod is left to the
+// package-manager cache whenever that lifecycle is active. Ownership is decided
+// by restore *timing*, not by which phase happens to populate the directory: the
+// package-manager cache restores before preview.install, the home build cache
+// only afterwards (immediately before service builds). An install that fetches
+// modules — directly via `go mod download` or indirectly via a wrapper script
+// that this package cannot see inside — is therefore only warm if the module
+// cache is restored by the earlier lifecycle. The home set falls back to owning
+// go/pkg/mod when the package-manager cache is disabled, so the directory is
+// never orphaned.
 func ResolvePreviewBuildCacheHomePaths(install *models.PreviewInstallConfig) ([]string, bool) {
 	if install == nil || len(install.Lockfiles) == 0 {
 		return nil, false
@@ -1190,19 +1195,31 @@ func ResolvePreviewBuildCacheHomePaths(install *models.PreviewInstallConfig) ([]
 	// cold-compile cost — and is only populated by an actual build, so the home
 	// build cache always owns it.
 	paths := []string{".cache/go-build"}
-	installRunsGo := false
-	for _, part := range install.Command {
-		if manager, ok := inferPreviewPackageManagerFromCommandPart(part); ok && manager == "go" {
-			installRunsGo = true
-			break
-		}
-	}
-	if !installRunsGo {
-		// Nothing else populates the module cache, so capture it here too.
+	if !previewPackageManagerCacheActive(install) {
+		// No earlier lifecycle will restore the module cache, so capture it
+		// here rather than leaving it uncached entirely.
 		paths = append(paths, "go/pkg/mod")
 	}
 	sort.Strings(paths)
 	return paths, true
+}
+
+// previewPackageManagerCacheActive reports whether the package-manager cache
+// lifecycle runs for this install config, before any build-cache ownership
+// subtraction. It is the ownership input for ResolvePreviewBuildCacheHomePaths,
+// so it deliberately does not call back into
+// ResolvePreviewInstallPackageManagerCachePaths (which would recurse).
+func previewPackageManagerCacheActive(install *models.PreviewInstallConfig) bool {
+	if install == nil || len(install.Lockfiles) == 0 {
+		return false
+	}
+	if install.Cache != nil && install.Cache.Enabled != nil && !*install.Cache.Enabled {
+		return false
+	}
+	if install.Cache != nil && install.Cache.PackageManager != nil && install.Cache.PackageManager.Enabled != nil && !*install.Cache.PackageManager.Enabled {
+		return false
+	}
+	return true
 }
 
 // CacheRestorablePreviewInstallVerifyPaths returns the verify paths that can
@@ -1252,13 +1269,7 @@ func inferPreviewBuildCachePaths(lockfile string) []string {
 }
 
 func ResolvePreviewInstallPackageManagerCachePaths(install *models.PreviewInstallConfig) ([]string, []string, bool) {
-	if install == nil || len(install.Lockfiles) == 0 {
-		return nil, nil, false
-	}
-	if install.Cache != nil && install.Cache.Enabled != nil && !*install.Cache.Enabled {
-		return nil, nil, false
-	}
-	if install.Cache != nil && install.Cache.PackageManager != nil && install.Cache.PackageManager.Enabled != nil && !*install.Cache.PackageManager.Enabled {
+	if !previewPackageManagerCacheActive(install) {
 		return nil, nil, false
 	}
 	managersSeen := make(map[string]struct{})
@@ -1312,6 +1323,27 @@ func ResolvePreviewInstallPackageManagerCachePaths(install *models.PreviewInstal
 			pathsSeen[clean] = struct{}{}
 			paths = append(paths, clean)
 		}
+	}
+	// Home-rooted build caches have a dedicated lifecycle: they are restored
+	// immediately before service builds and saved after those builds complete.
+	// Do not also put the same paths in the package-manager archive. Apart from
+	// doubling storage, a duplicate restore serializes gigabytes of extraction
+	// on the preview startup path. ResolvePreviewBuildCacheHomePaths only claims
+	// .cache/go-build while this lifecycle is active, so go/pkg/mod survives the
+	// subtraction and stays restorable before preview.install runs.
+	if buildPaths, buildEnabled := ResolvePreviewBuildCacheHomePaths(install); buildEnabled {
+		ownedByBuild := make(map[string]struct{}, len(buildPaths))
+		for _, p := range buildPaths {
+			ownedByBuild[p] = struct{}{}
+		}
+		filtered := paths[:0]
+		for _, p := range paths {
+			if _, duplicate := ownedByBuild[p]; duplicate {
+				continue
+			}
+			filtered = append(filtered, p)
+		}
+		paths = filtered
 	}
 	sort.Strings(managers)
 	sort.Strings(paths)
@@ -1577,6 +1609,13 @@ func ResolveConfig(baseCfg, diffCfg *models.PreviewConfig) (*models.PreviewConfi
 		Version:     baseCfg.Version,
 		Name:        baseCfg.Name,
 		Progressive: baseCfg.Progressive,
+		// Concurrent builds add their peak memory inside one cgroup, so whether
+		// a repo's builds fit is a property of the repo, not of a branch. Keep
+		// it a base-branch decision. Note this is an operational choice, not a
+		// security boundary: a non-connected diff already controls Resources and
+		// every service command, so it can create the same pressure by other
+		// means.
+		ParallelBuilds: baseCfg.ParallelBuilds,
 
 		// Security-sensitive: always from base.
 		Primary:     baseCfg.Primary,
@@ -1615,14 +1654,15 @@ func ResolveConfig(baseCfg, diffCfg *models.PreviewConfig) (*models.PreviewConfi
 			resolved.Services[name] = baseSvc
 		} else {
 			// Non-connected: runtime fields from diff, existence from base.
+			//
+			// Take the diff's service wholesale and subtract, rather than
+			// listing the fields to keep: an allowlist silently drops every
+			// field added to ServiceConfig later, which is exactly how `build`
+			// and `hmr` went missing from non-connected previews. There is
+			// nothing to subtract today — the service name itself is the only
+			// base-pinned part, and it is the map key.
 			if diffSvc, ok := diffCfg.Services[name]; ok {
-				resolved.Services[name] = models.ServiceConfig{
-					Command: diffSvc.Command,
-					Cwd:     diffSvc.Cwd,
-					Port:    diffSvc.Port,
-					Env:     diffSvc.Env,
-					Ready:   diffSvc.Ready,
-				}
+				resolved.Services[name] = diffSvc
 			} else {
 				// Service exists in base but not in diff — use base.
 				resolved.Services[name] = baseSvc

--- a/internal/services/preview/config_test.go
+++ b/internal/services/preview/config_test.go
@@ -63,6 +63,7 @@ func TestParseConfig_MultiService(t *testing.T) {
 		"version": "3",
 		"name": "Full Stack",
 		"primary": "frontend",
+		"parallel_builds": true,
 		"services": {
 			"frontend": {
 				"command": ["npm", "run", "dev"],
@@ -91,6 +92,7 @@ func TestParseConfig_MultiService(t *testing.T) {
 	if len(cfg.Services) != 2 {
 		t.Errorf("len(Services) = %d, want 2", len(cfg.Services))
 	}
+	require.True(t, cfg.ParallelBuilds, "parallel_builds should survive config parsing")
 }
 
 func TestParseConfig_BrowserVerificationPolicy(t *testing.T) {
@@ -1257,9 +1259,10 @@ func TestResolveConfig_NonConnected(t *testing.T) {
 	t.Parallel()
 
 	baseCfg := &models.PreviewConfig{
-		Version: "3",
-		Name:    "Test",
-		Primary: "frontend",
+		Version:        "3",
+		Name:           "Test",
+		Primary:        "frontend",
+		ParallelBuilds: true,
 		Install: &models.PreviewInstallConfig{
 			Command:    []string{"npm", "ci"},
 			Lockfiles:  []string{"package-lock.json"},
@@ -1287,7 +1290,7 @@ func TestResolveConfig_NonConnected(t *testing.T) {
 			VerifyPaths: []string{"node_modules/.bin/next"},
 		},
 		Services: map[string]models.ServiceConfig{
-			"frontend": {Command: []string{"npm", "run", "dev"}, Port: 3000, Cwd: "frontend", Ready: models.ReadinessProbe{HTTPPath: "/", TimeoutSeconds: 120}},
+			"frontend": {Build: []string{"npm", "run", "build"}, Command: []string{"npm", "run", "dev"}, Port: 3000, Cwd: "frontend", Ready: models.ReadinessProbe{HTTPPath: "/", TimeoutSeconds: 120}, HMR: true},
 			"backend":  {Command: []string{"python", "app.py", "--debug"}, Port: 4000, Ready: models.ReadinessProbe{HTTPPath: "/health"}},
 		},
 		Infrastructure: map[string]models.InfrastructureConfig{
@@ -1319,6 +1322,8 @@ func TestResolveConfig_NonConnected(t *testing.T) {
 	if fe.Command[0] != "npm" || fe.Command[1] != "run" {
 		t.Errorf("frontend.Command = %v, want [npm run dev]", fe.Command)
 	}
+	require.Equal(t, []string{"npm", "run", "build"}, fe.Build, "non-connected preview should use the diff build command")
+	require.True(t, fe.HMR, "non-connected preview should use the diff HMR declaration")
 
 	be := resolved.Services["backend"]
 	if len(be.Command) != 3 || be.Command[2] != "--debug" {
@@ -1341,6 +1346,7 @@ func TestResolveConfig_NonConnected(t *testing.T) {
 	require.Equal(t, []string{"pnpm", "install", "--frozen-lockfile"}, resolved.Install.Command, "non-connected preview should use install command from diff")
 	require.Equal(t, []string{"apps/*/node_modules"}, resolved.Install.CleanPaths[1:], "non-connected preview should use install cleanup paths from diff")
 	require.Equal(t, diffCfg.Resources, resolved.Resources, "non-connected preview should use resource requirements from diff")
+	require.True(t, resolved.ParallelBuilds, "build concurrency should remain pinned to the trusted base config")
 }
 
 func TestResolveConfig_Connected_PinsEverythingToBase(t *testing.T) {
@@ -1553,13 +1559,27 @@ func TestResolvePreviewInstallPackageManagerCachePaths(t *testing.T) {
 			enabled: true,
 		},
 		{
-			name: "infers go module and build caches",
+			name: "go install keeps module cache while build cache owns compiled objects",
 			install: &models.PreviewInstallConfig{
 				Command:   []string{"go", "mod", "download"},
 				Lockfiles: []string{"go.mod"},
 			},
 			wantPMs: []string{"go"},
-			want:    []string{".cache/go-build", "go/pkg/mod"},
+			want:    []string{"go/pkg/mod"},
+			enabled: true,
+		},
+		{
+			// A wrapper script may run `go mod download` where this package
+			// cannot see it, and only the package-manager cache restores before
+			// install runs. Handing the module cache to the build cache here
+			// would leave every install fetching modules cold.
+			name: "wrapper install keeps the module cache restorable before install",
+			install: &models.PreviewInstallConfig{
+				Command:   []string{"sh", ".143/preview-install.sh"},
+				Lockfiles: []string{"go.mod"},
+			},
+			wantPMs: []string{"go"},
+			want:    []string{"go/pkg/mod"},
 			enabled: true,
 		},
 		{
@@ -2423,19 +2443,19 @@ func TestResolvePreviewBuildCacheHomePaths(t *testing.T) {
 			enabled: false,
 		},
 		{
-			name: "go.mod lockfile enables go build/module caches",
+			name: "go.mod lockfile leaves modules to the package-manager cache",
 			install: &models.PreviewInstallConfig{
 				Lockfiles: []string{"go.mod"},
 			},
-			want:    []string{".cache/go-build", "go/pkg/mod"},
+			want:    []string{".cache/go-build"},
 			enabled: true,
 		},
 		{
-			name: "go.sum alongside javascript lockfile still enables go caches",
+			name: "go.sum alongside javascript lockfile still enables the compiled-object cache",
 			install: &models.PreviewInstallConfig{
 				Lockfiles: []string{"package-lock.json", "go.sum"},
 			},
-			want:    []string{".cache/go-build", "go/pkg/mod"},
+			want:    []string{".cache/go-build"},
 			enabled: true,
 		},
 		{
@@ -2445,6 +2465,33 @@ func TestResolvePreviewBuildCacheHomePaths(t *testing.T) {
 				Lockfiles: []string{"go.mod"},
 			},
 			want:    []string{".cache/go-build"},
+			enabled: true,
+		},
+		{
+			// A wrapper install command is opaque, so it may well run
+			// `go mod download` inside. Ownership must not depend on guessing:
+			// while the package-manager cache is active it keeps the module
+			// directory, because only that lifecycle restores before install.
+			name: "wrapper install command still leaves modules to the package-manager cache",
+			install: &models.PreviewInstallConfig{
+				Command:   []string{"sh", ".143/preview-install.sh"},
+				Lockfiles: []string{"go.mod"},
+			},
+			want:    []string{".cache/go-build"},
+			enabled: true,
+		},
+		{
+			// Nothing restores the module cache before install now, so the
+			// build cache adopts it rather than leaving it uncached.
+			name: "package-manager cache disabled hands the module cache to the build cache",
+			install: &models.PreviewInstallConfig{
+				Command:   []string{"sh", ".143/preview-install.sh"},
+				Lockfiles: []string{"go.mod"},
+				Cache: &models.PreviewInstallCacheConfig{
+					PackageManager: &models.PreviewPackageManagerCacheConfig{Enabled: &disabled},
+				},
+			},
+			want:    []string{".cache/go-build", "go/pkg/mod"},
 			enabled: true,
 		},
 		{

--- a/internal/services/preview/manager.go
+++ b/internal/services/preview/manager.go
@@ -2274,12 +2274,12 @@ func (m *Manager) ResumeStoppedWarmPreview(ctx context.Context, orgID, previewID
 
 	m.logger.Info().Str("preview_id", previewID.String()).Msg("resuming stopped warm preview")
 
-	updated, err := m.store.BeginStoppedWarmPreviewResume(ctx, orgID, previewID)
+	updated, err := m.store.BeginStoppedWarmPreviewResume(ctx, orgID, previewID, instance.SessionID, session.WorkspaceRevision)
 	if err != nil {
 		return fmt.Errorf("claim warm preview resume: %w", err)
 	}
 	if !updated {
-		return fmt.Errorf("warm preview was claimed or stopped for another reason before resume could begin")
+		return fmt.Errorf("%w: preview was claimed, stopped for another reason, or superseded before resume could begin", ErrWarmResumeNotEligible)
 	}
 
 	if err := m.store.RevokeAllForPreview(ctx, orgID, previewID); err != nil {
@@ -2307,11 +2307,12 @@ func (m *Manager) ResumeStoppedWarmPreview(ctx context.Context, orgID, previewID
 	}
 
 	handle, err := m.provider.StartPreview(ctx, input.Sandbox, input.Config, StartPreviewOptions{
-		OrgID:        input.OrgID,
-		RepositoryID: input.RepositoryID,
-		SessionID:    input.SessionID,
-		ConfigDigest: computeConfigDigest(input.Config),
-		ExtraEnv:     m.platformEnv(previewID),
+		OrgID:           input.OrgID,
+		RepositoryID:    input.RepositoryID,
+		SessionID:       input.SessionID,
+		ConfigDigest:    computeConfigDigest(input.Config),
+		ExtraEnv:        m.platformEnv(previewID),
+		RetainedSandbox: true,
 		// The warm-build job ran these exact build commands in this retained
 		// sandbox, and the guards above proved the workspace revision, the
 		// owning worker, and the startup-cache marker all still match.
@@ -2689,11 +2690,12 @@ func (m *Manager) recyclePreview(ctx context.Context, orgID, previewID uuid.UUID
 		}
 	}
 	handle, err := m.provider.StartPreview(ctx, input.Sandbox, input.Config, StartPreviewOptions{
-		OrgID:        input.OrgID,
-		RepositoryID: input.RepositoryID,
-		SessionID:    input.SessionID,
-		ConfigDigest: computeConfigDigest(input.Config),
-		ExtraEnv:     m.platformEnv(previewID),
+		OrgID:           input.OrgID,
+		RepositoryID:    input.RepositoryID,
+		SessionID:       input.SessionID,
+		ConfigDigest:    computeConfigDigest(input.Config),
+		ExtraEnv:        m.platformEnv(previewID),
+		RetainedSandbox: true,
 	}, observer)
 	if err != nil {
 		if recycleRuntime != nil {

--- a/internal/services/preview/manager.go
+++ b/internal/services/preview/manager.go
@@ -1334,7 +1334,7 @@ func (o *managerServiceObserver) OnInstallFailed(errMsg string, tail []string) {
 
 func (o *managerServiceObserver) OnDependencyCacheRestore(status string, cacheKey string, sizeBytes int64, err error) {
 	switch status {
-	case "disabled", "miss", "restore_failed", "restore_timeout", "skipped_cost", "restored", "restored_satisfied_install", "skipped_marker_missing":
+	case "disabled", "miss", "restore_failed", "restore_timeout", "skipped_cost", "restored", "restored_satisfied_install", "skipped_marker_missing", "skipped_install_valid":
 	default:
 		return
 	}
@@ -1367,7 +1367,7 @@ func (o *managerServiceObserver) OnDependencyCacheSave(status string, cacheKey s
 
 func (o *managerServiceObserver) OnPackageManagerCacheRestore(status string, cacheKey string, sizeBytes int64, err error) {
 	switch status {
-	case "disabled", "miss", "restore_failed", "restore_timeout", "skipped_cost", "restored", "key_failed", "skipped_no_paths":
+	case "disabled", "miss", "restore_failed", "restore_timeout", "skipped_cost", "restored", "key_failed", "skipped_no_paths", "skipped_install_valid":
 	default:
 		return
 	}
@@ -2200,10 +2200,22 @@ func (m *Manager) SoftRestartPreviewWithRevision(ctx context.Context, orgID, pre
 	})
 }
 
+// ErrWarmResumeNotEligible reports that a preview cannot take the warm-resume
+// shortcut. Every eligibility guard in ResumeStoppedWarmPreview returns it, and
+// all of them are raced by ordinary user activity: an agent turn can bump the
+// workspace revision, or the startup cache can be evicted, between the caller's
+// own check and this one. Callers must treat it as "start normally", never as a
+// failure — the preview is untouched at that point, so a cold start is always
+// still available.
+var ErrWarmResumeNotEligible = errors.New("preview is not eligible for warm resume")
+
 // ResumeStoppedWarmPreview starts a session preview that was fully warmed and
 // then stopped by the session prewarm policy. It intentionally does not accept
 // arbitrary terminal previews: this path exists only to make a user click on a
 // current warm candidate cheaper than a cold start.
+//
+// Every guard below runs before the preview is claimed, so returning
+// ErrWarmResumeNotEligible leaves the instance exactly as it was found.
 func (m *Manager) ResumeStoppedWarmPreview(ctx context.Context, orgID, previewID uuid.UUID) error {
 	started := time.Now()
 	instance, err := m.store.GetPreviewInstance(ctx, orgID, previewID)
@@ -2215,13 +2227,47 @@ func (m *Manager) ResumeStoppedWarmPreview(ctx context.Context, orgID, previewID
 		return err
 	}
 	if !instance.Status.IsTerminal() || reason != models.PreviewStoppedReasonSessionPrewarmPolicy {
-		return fmt.Errorf("preview is not a stopped session prewarm candidate (status=%s, reason=%s)", instance.Status, reason)
+		return fmt.Errorf("%w: not a stopped session prewarm candidate (status=%s, reason=%s)", ErrWarmResumeNotEligible, instance.Status, reason)
 	}
 	if m.provider == nil {
 		return fmt.Errorf("preview provider is not configured")
 	}
+	if m.sessionStore == nil || instance.SessionID == uuid.Nil {
+		return fmt.Errorf("%w: session metadata is unavailable", ErrWarmResumeNotEligible)
+	}
+	session, err := m.sessionStore.GetByID(ctx, orgID, instance.SessionID)
+	if err != nil {
+		return fmt.Errorf("get warm preview session: %w", err)
+	}
+	if instance.SourceWorkspaceRevision == nil || *instance.SourceWorkspaceRevision != session.WorkspaceRevision {
+		return fmt.Errorf("%w: workspace revision is stale", ErrWarmResumeNotEligible)
+	}
+	if session.RepositoryID == nil || *session.RepositoryID == uuid.Nil || strings.TrimSpace(instance.WorkerNodeID) == "" {
+		return fmt.Errorf("%w: startup cache identity is incomplete", ErrWarmResumeNotEligible)
+	}
+	// SkipServiceBuild below is only safe on the worker that still holds the
+	// retained sandbox and its build outputs. HasSessionPreviewStartupCache
+	// answers "some active worker holds this", so pin it to this process too
+	// rather than trusting the caller to have routed correctly.
+	if m.workerNodeID != "" && instance.WorkerNodeID != m.workerNodeID {
+		return fmt.Errorf("%w: retained sandbox belongs to worker %q, not %q", ErrWarmResumeNotEligible, instance.WorkerNodeID, m.workerNodeID)
+	}
+	startupCacheAvailable, err := m.store.HasSessionPreviewStartupCache(
+		ctx,
+		orgID,
+		*session.RepositoryID,
+		instance.SessionID,
+		session.WorkspaceRevision,
+		instance.WorkerNodeID,
+	)
+	if err != nil {
+		return fmt.Errorf("verify warm preview startup cache: %w", err)
+	}
+	if !startupCacheAvailable {
+		return fmt.Errorf("%w: startup cache is unavailable", ErrWarmResumeNotEligible)
+	}
 
-	input, err := m.loadRecycleInput(ctx, instance)
+	input, err := m.loadRecycleInputForSession(ctx, instance, &session)
 	if err != nil {
 		return fmt.Errorf("load warm resume input: %w", err)
 	}
@@ -2266,6 +2312,11 @@ func (m *Manager) ResumeStoppedWarmPreview(ctx context.Context, orgID, previewID
 		SessionID:    input.SessionID,
 		ConfigDigest: computeConfigDigest(input.Config),
 		ExtraEnv:     m.platformEnv(previewID),
+		// The warm-build job ran these exact build commands in this retained
+		// sandbox, and the guards above proved the workspace revision, the
+		// owning worker, and the startup-cache marker all still match.
+		// Rebuilding here defeats the warm-resume contract.
+		SkipServiceBuild: true,
 	}, observer)
 	if err != nil {
 		if resumeRuntime != nil {
@@ -3030,9 +3081,16 @@ func uuidPointerValue(id *uuid.UUID) uuid.UUID {
 }
 
 func (m *Manager) loadRecycleInput(ctx context.Context, instance *models.PreviewInstance) (StartPreviewInput, error) {
+	return m.loadRecycleInputForSession(ctx, instance, nil)
+}
+
+// loadRecycleInputForSession is loadRecycleInput for callers that already hold
+// the instance's session. Passing it avoids re-reading the same row, which
+// matters on the warm-resume click path where latency is the whole point.
+func (m *Manager) loadRecycleInputForSession(ctx context.Context, instance *models.PreviewInstance, session *models.Session) (StartPreviewInput, error) {
 	input, err := loadRecycleInput(instance)
 	if err == nil {
-		input.RepositoryID = m.recycleRepositoryID(ctx, instance)
+		input.RepositoryID = m.recycleRepositoryID(ctx, instance, session)
 		return input, nil
 	}
 	if !errors.Is(err, errMissingRecycleInput) {
@@ -3049,13 +3107,19 @@ func (m *Manager) loadRecycleInput(ctx context.Context, instance *models.Preview
 	return rebuilt, nil
 }
 
-func (m *Manager) recycleRepositoryID(ctx context.Context, instance *models.PreviewInstance) uuid.UUID {
+// recycleRepositoryID resolves the repository a recycled preview belongs to.
+// session, when non-nil, is the instance's already-loaded session and is used
+// in place of a second read of the same row.
+func (m *Manager) recycleRepositoryID(ctx context.Context, instance *models.PreviewInstance, session *models.Session) uuid.UUID {
 	if instance.PreviewTargetID != nil && *instance.PreviewTargetID != uuid.Nil {
 		target, err := m.store.GetPreviewTarget(ctx, instance.OrgID, *instance.PreviewTargetID)
 		if err == nil {
 			return target.RepositoryID
 		}
 		m.logger.Warn().Err(err).Str("preview_id", instance.ID.String()).Msg("failed to load preview target repository for recycle")
+	}
+	if session != nil {
+		return uuidPointerValue(session.RepositoryID)
 	}
 	if instance.SessionID != uuid.Nil && m.sessionStore != nil {
 		session, err := m.sessionStore.GetByID(ctx, instance.OrgID, instance.SessionID)

--- a/internal/services/preview/manager_test.go
+++ b/internal/services/preview/manager_test.go
@@ -3909,6 +3909,10 @@ func TestManagerServiceObserver_OnDependencyCacheRestore_PersistsNonFailureStatu
 			status:   "skipped_marker_missing",
 			cacheKey: strings.Repeat("b", 64),
 		},
+		{
+			name:   "skipped retained install valid",
+			status: "skipped_install_valid",
+		},
 	}
 
 	for _, tt := range tests {
@@ -3935,6 +3939,29 @@ func TestManagerServiceObserver_OnDependencyCacheRestore_PersistsNonFailureStatu
 			require.NoError(t, mock.ExpectationsWereMet(), "cache restore observer should persist non-failure restore statuses")
 		})
 	}
+}
+
+func TestManagerServiceObserver_OnPackageManagerCacheRestore_PersistsValidInstallSkip(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "pgx mock should initialize")
+	defer mock.Close()
+
+	mgr := newTestManager(mock, &mockProvider{})
+	orgID := uuid.New()
+	previewID := uuid.New()
+	obs := mgr.newServiceObserver(orgID, previewID, "", "", "", 0)
+	logID := uuid.New()
+	mock.ExpectQuery("INSERT INTO preview_logs").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(pgxmock.NewRows([]string{
+			"id", "preview_instance_id", "org_id", "level", "step", "message", "metadata", "created_at",
+		}).AddRow(logID, previewID, orgID, "info", "install", "msg", json.RawMessage(`{}`), time.Now()))
+
+	obs.OnPackageManagerCacheRestore("skipped_install_valid", "", 0, nil)
+	obs.Close()
+	require.NoError(t, mock.ExpectationsWereMet(), "package-manager observer should persist retained-install skips")
 }
 
 func TestManagerServiceObserver_OnCacheRestore_EmitsPreviewHealthCacheEvent(t *testing.T) {
@@ -4342,6 +4369,122 @@ type stopWaitRecorder struct {
 	PreviewCapableProvider
 	gotWait time.Duration
 	called  bool
+}
+
+func TestResumeStoppedWarmPreviewRejectsStaleWorkspaceRevision(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "pgx mock should initialize")
+	defer mock.Close()
+
+	orgID := uuid.New()
+	previewID := uuid.New()
+	sessionID := uuid.New()
+	userID := uuid.New()
+	repositoryID := uuid.New()
+	now := time.Now()
+	previewRow := newPreviewInstanceRow(previewID, sessionID, orgID, userID, models.PreviewStatusStopped, "", now)
+	previewRevision := int64(4)
+	setPreviewInstanceRowColumn(previewRow, "source_workspace_revision", &previewRevision)
+	mock.ExpectQuery("SELECT .+ FROM preview_instances WHERE id").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(pgxmock.NewRows(previewInstanceTestCols).AddRow(previewRow...))
+	mock.ExpectQuery("SELECT COALESCE\\(stopped_reason").
+		WithArgs(previewAnyArgs(2)...).
+		WillReturnRows(pgxmock.NewRows([]string{"stopped_reason"}).AddRow(string(models.PreviewStoppedReasonSessionPrewarmPolicy)))
+	sessionRow := newSessionRow(sessionID, orgID, nil, now)
+	for i, column := range sessionTestCols {
+		switch column {
+		case "repository_id":
+			sessionRow[i] = &repositoryID
+		case "workspace_revision":
+			sessionRow[i] = int64(5)
+		case "workspace_revision_updated_at":
+			sessionRow[i] = now
+		}
+	}
+	mock.ExpectQuery("SELECT .+ FROM sessions").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(pgxmock.NewRows(sessionTestCols).AddRow(sessionRow...))
+
+	provider := &mockProvider{startHandle: &PreviewHandle{Handle: "must-not-start"}}
+	mgr := NewManager(ManagerConfig{
+		Store:        db.NewPreviewStore(mock),
+		SessionStore: db.NewSessionStore(mock),
+		Provider:     provider,
+		Logger:       zerolog.Nop(),
+		WorkerNodeID: "worker-1",
+	})
+	err = mgr.ResumeStoppedWarmPreview(context.Background(), orgID, previewID)
+	require.Error(t, err, "warm resume should reject stale prebuilt output")
+	require.Contains(t, err.Error(), "workspace revision is stale", "warm resume should explain the exact-revision guard")
+	// A revision bump between the caller's check and this one is an ordinary
+	// race with agent activity, not a failure: the preview was never claimed,
+	// so callers must be able to fall back to a normal start.
+	require.ErrorIs(t, err, ErrWarmResumeNotEligible, "a stale revision should be reported as ineligibility, not failure")
+	require.Nil(t, provider.startConfig, "provider must not start a stale warm preview")
+	require.NoError(t, mock.ExpectationsWereMet(), "stale revision guard should use the expected org-scoped queries")
+}
+
+// TestResumeStoppedWarmPreviewRejectsForeignWorkerSandbox covers the guard that
+// makes SkipServiceBuild safe. The startup-cache row proves some active worker
+// holds the retained sandbox and its build outputs; only this check proves it is
+// this process. Resuming elsewhere would start services against artifacts that
+// were never built there.
+func TestResumeStoppedWarmPreviewRejectsForeignWorkerSandbox(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "pgx mock should initialize")
+	defer mock.Close()
+
+	orgID := uuid.New()
+	previewID := uuid.New()
+	sessionID := uuid.New()
+	userID := uuid.New()
+	repositoryID := uuid.New()
+	now := time.Now()
+	previewRow := newPreviewInstanceRow(previewID, sessionID, orgID, userID, models.PreviewStatusStopped, "", now)
+	previewRevision := int64(7)
+	setPreviewInstanceRowColumn(previewRow, "source_workspace_revision", &previewRevision)
+	setPreviewInstanceRowColumn(previewRow, "worker_node_id", "worker-2")
+	mock.ExpectQuery("SELECT .+ FROM preview_instances WHERE id").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(pgxmock.NewRows(previewInstanceTestCols).AddRow(previewRow...))
+	mock.ExpectQuery("SELECT COALESCE\\(stopped_reason").
+		WithArgs(previewAnyArgs(2)...).
+		WillReturnRows(pgxmock.NewRows([]string{"stopped_reason"}).AddRow(string(models.PreviewStoppedReasonSessionPrewarmPolicy)))
+	sessionRow := newSessionRow(sessionID, orgID, nil, now)
+	for i, column := range sessionTestCols {
+		switch column {
+		case "repository_id":
+			sessionRow[i] = &repositoryID
+		case "workspace_revision":
+			sessionRow[i] = previewRevision
+		case "workspace_revision_updated_at":
+			sessionRow[i] = now
+		}
+	}
+	mock.ExpectQuery("SELECT .+ FROM sessions").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(pgxmock.NewRows(sessionTestCols).AddRow(sessionRow...))
+
+	provider := &mockProvider{startHandle: &PreviewHandle{Handle: "must-not-start"}}
+	mgr := NewManager(ManagerConfig{
+		Store:        db.NewPreviewStore(mock),
+		SessionStore: db.NewSessionStore(mock),
+		Provider:     provider,
+		Logger:       zerolog.Nop(),
+		WorkerNodeID: "worker-1",
+	})
+	err = mgr.ResumeStoppedWarmPreview(context.Background(), orgID, previewID)
+	require.Error(t, err, "warm resume should refuse a sandbox retained on another worker")
+	require.ErrorIs(t, err, ErrWarmResumeNotEligible, "a foreign retained sandbox should fall back to a normal start")
+	require.Nil(t, provider.startConfig, "provider must not start a preview whose build outputs live elsewhere")
+	// The startup-cache lookup is never reached: ExpectationsWereMet fails if a
+	// query ran that was not expected above.
+	require.NoError(t, mock.ExpectationsWereMet(), "the worker guard should short-circuit before the startup cache lookup")
 }
 
 func (s *stopWaitRecorder) StopPreviewWithBackgroundWait(_ context.Context, _ string, backgroundWait time.Duration) error {

--- a/internal/services/preview/manager_test.go
+++ b/internal/services/preview/manager_test.go
@@ -32,6 +32,7 @@ type mockProvider struct {
 	startHandle   *PreviewHandle
 	startErr      error
 	startConfig   *models.PreviewConfig
+	startOptions  StartPreviewOptions
 	startObserver ServiceObserver
 	stopErr       error
 	dialErr       error
@@ -40,8 +41,9 @@ type mockProvider struct {
 	statusErr     error
 }
 
-func (m *mockProvider) StartPreview(_ context.Context, _ *agent.Sandbox, cfg *models.PreviewConfig, _ StartPreviewOptions, observer ServiceObserver) (*PreviewHandle, error) {
+func (m *mockProvider) StartPreview(_ context.Context, _ *agent.Sandbox, cfg *models.PreviewConfig, opts StartPreviewOptions, observer ServiceObserver) (*PreviewHandle, error) {
 	m.startConfig = cfg
+	m.startOptions = opts
 	m.startObserver = observer
 	if m.startErr != nil {
 		return nil, m.startErr
@@ -1505,6 +1507,7 @@ func TestRecyclePreview_PreservesPartiallyReadyStatus(t *testing.T) {
 
 	err = mgr.RecyclePreview(context.Background(), orgID, previewID)
 	require.NoError(t, err, "RecyclePreview should succeed for a partially ready restart")
+	require.True(t, mgr.provider.(*mockProvider).startOptions.RetainedSandbox, "recycle should tell the provider that WorkDir and HomeDir were retained")
 	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
 }
 
@@ -4425,6 +4428,72 @@ func TestResumeStoppedWarmPreviewRejectsStaleWorkspaceRevision(t *testing.T) {
 	require.ErrorIs(t, err, ErrWarmResumeNotEligible, "a stale revision should be reported as ineligibility, not failure")
 	require.Nil(t, provider.startConfig, "provider must not start a stale warm preview")
 	require.NoError(t, mock.ExpectationsWereMet(), "stale revision guard should use the expected org-scoped queries")
+}
+
+// TestResumeStoppedWarmPreviewClaimRejectsConcurrentRevisionChange covers the
+// race between the manager's eligibility reads and its state transition. The
+// store's claim rechecks the expected session revision atomically; losing that
+// race is ordinary ineligibility, so the caller can fall through to a normal
+// start instead of serving stale prebuilt output.
+func TestResumeStoppedWarmPreviewClaimRejectsConcurrentRevisionChange(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "pgx mock should initialize")
+	defer mock.Close()
+
+	orgID := uuid.New()
+	previewID := uuid.New()
+	sessionID := uuid.New()
+	userID := uuid.New()
+	repositoryID := uuid.New()
+	now := time.Now()
+	revision := int64(7)
+	previewRow := newPreviewInstanceRow(previewID, sessionID, orgID, userID, models.PreviewStatusStopped, "", now)
+	setPreviewInstanceRowColumn(previewRow, "source_workspace_revision", &revision)
+	setPreviewInstanceRowColumn(previewRow, "worker_node_id", "worker-1")
+	mock.ExpectQuery("SELECT .+ FROM preview_instances WHERE id").
+		WithArgs(previewAnyArgs(2)...).
+		WillReturnRows(pgxmock.NewRows(previewInstanceTestCols).AddRow(previewRow...))
+	mock.ExpectQuery("SELECT COALESCE\\(stopped_reason").
+		WithArgs(previewAnyArgs(2)...).
+		WillReturnRows(pgxmock.NewRows([]string{"stopped_reason"}).AddRow(string(models.PreviewStoppedReasonSessionPrewarmPolicy)))
+	sessionRow := newSessionRow(sessionID, orgID, nil, now)
+	for i, column := range sessionTestCols {
+		switch column {
+		case "repository_id":
+			sessionRow[i] = &repositoryID
+		case "workspace_revision":
+			sessionRow[i] = revision
+		case "workspace_revision_updated_at":
+			sessionRow[i] = now
+		}
+	}
+	mock.ExpectQuery("SELECT .+ FROM sessions").
+		WithArgs(previewAnyArgs(2)...).
+		WillReturnRows(pgxmock.NewRows(sessionTestCols).AddRow(sessionRow...))
+	mock.ExpectQuery("SELECT EXISTS").
+		WithArgs(previewAnyArgs(4)...).
+		WillReturnRows(pgxmock.NewRows([]string{"exists"}).AddRow(true))
+	// Simulate the session revision advancing after the reads above. The
+	// revision-aware claim sees that change and affects no preview row.
+	mock.ExpectExec("UPDATE preview_instances(?s:.*)source_workspace_revision = @workspace_revision(?s:.*)EXISTS").
+		WithArgs(previewAnyArgs(7)...).
+		WillReturnResult(pgxmock.NewResult("UPDATE", 0))
+
+	provider := &mockProvider{startHandle: &PreviewHandle{Handle: "must-not-start"}}
+	mgr := NewManager(ManagerConfig{
+		Store:        db.NewPreviewStore(mock),
+		SessionStore: db.NewSessionStore(mock),
+		Provider:     provider,
+		Logger:       zerolog.Nop(),
+		WorkerNodeID: "worker-1",
+	})
+	err = mgr.ResumeStoppedWarmPreview(context.Background(), orgID, previewID)
+	require.Error(t, err, "warm resume should decline when the atomic claim loses a revision race")
+	require.ErrorIs(t, err, ErrWarmResumeNotEligible, "a concurrent revision change should fall back to a normal start")
+	require.Nil(t, provider.startConfig, "provider must not start stale prebuilt output after a lost claim")
+	require.NoError(t, mock.ExpectationsWereMet(), "warm resume should include the expected revision in its atomic claim")
 }
 
 // TestResumeStoppedWarmPreviewRejectsForeignWorkerSandbox covers the guard that

--- a/internal/services/preview/provider.go
+++ b/internal/services/preview/provider.go
@@ -78,6 +78,11 @@ type StartPreviewOptions struct {
 	SessionID    uuid.UUID
 	ConfigDigest string
 	ExtraEnv     map[string]string
+	// SkipServiceBuild is reserved for an exact-revision warm resume whose
+	// retained sandbox already completed every configured service build. Normal
+	// starts and recycles must leave this false. Service start commands remain
+	// responsible for detecting unexpectedly missing artifacts.
+	SkipServiceBuild bool
 }
 
 // PreviewHandle is returned by StartPreview and contains the information

--- a/internal/services/preview/provider.go
+++ b/internal/services/preview/provider.go
@@ -78,6 +78,12 @@ type StartPreviewOptions struct {
 	SessionID    uuid.UUID
 	ConfigDigest string
 	ExtraEnv     map[string]string
+	// RetainedSandbox asserts that this start is reusing the same sandbox
+	// filesystem as its previous run, including both WorkDir and HomeDir. It
+	// lets install caching skip remote HomeDir restores that cannot add data.
+	// Snapshot-backed starts must leave this false because startup snapshots
+	// contain WorkDir only.
+	RetainedSandbox bool
 	// SkipServiceBuild is reserved for an exact-revision warm resume whose
 	// retained sandbox already completed every configured service build. Normal
 	// starts and recycles must leave this false. Service start commands remain

--- a/internal/services/preview/providers/docker_preview.go
+++ b/internal/services/preview/providers/docker_preview.go
@@ -229,13 +229,24 @@ func (s *previewState) runDeferredCacheSaves() {
 }
 
 // runDeferredCacheSavesAndWait drains the deferred saves and blocks until they
-// finish. Callers that own the sandbox and destroy it on return — the
-// build-snapshot prewarm — need this: a fire-and-forget drain there would be
-// killed by teardown, which is the failure mode the whole job exists to avoid.
-func (s *previewState) runDeferredCacheSavesAndWait() {
+// finish or budget expires. Callers that own the sandbox and destroy it on
+// return — the build-snapshot prewarm — need the wait: a fire-and-forget drain
+// there would be killed by teardown, which is the failure mode the whole job
+// exists to avoid.
+//
+// The wait deliberately ignores ctx cancellation, for the same reason the saves
+// themselves detach via WithoutCancel: honouring an expired job deadline here
+// would abandon the upload mid-flight and destroy the sandbox out from under it.
+// budget is therefore the only ceiling, and it is what keeps a stuck blob store
+// from running the job far past its own deadline.
+//
+// Unlike runDeferredCacheSaves this uses a local WaitGroup rather than state.wg:
+// the caller is blocking on the result here and there is no StopPreview to
+// coordinate with.
+func (s *previewState) runDeferredCacheSavesAndWait(ctx context.Context, budget time.Duration) error {
 	saves := s.takeDeferredCacheSaves()
 	if len(saves) == 0 {
-		return
+		return nil
 	}
 	var wg sync.WaitGroup
 	for _, save := range saves {
@@ -245,9 +256,11 @@ func (s *previewState) runDeferredCacheSavesAndWait() {
 			fn()
 		}(save)
 	}
-	wg.Wait()
+	return waitForGroupBounded(context.WithoutCancel(ctx), &wg, budget)
 }
 
+// takeDeferredCacheSaves removes and returns the queued saves. Both drain
+// helpers go through it so a save can never be started twice.
 func (s *previewState) takeDeferredCacheSaves() []func() {
 	if s == nil || len(s.deferredCacheSaves) == 0 {
 		return nil
@@ -688,7 +701,7 @@ func (d *DockerPreviewProvider) PrewarmPreviewBuildSnapshot(ctx context.Context,
 	if err := d.runServiceBuilds(ctx, state, cfg, opts, observer); err != nil {
 		// The install itself succeeded, so its caches are still worth keeping:
 		// the next attempt should not repeat a download that already worked.
-		state.runDeferredCacheSavesAndWait()
+		d.drainPrewarmCacheSaves(ctx, state)
 		d.flushBuildCachesBeforeCleanup(ctx, state, cfg.Install, opts, observer)
 		return fmt.Errorf("%w: %v", preview.ErrServiceBuildFailed, err)
 	}
@@ -699,9 +712,20 @@ func (d *DockerPreviewProvider) PrewarmPreviewBuildSnapshot(ctx context.Context,
 	if state.serviceBuildDuration > 0 {
 		d.recordBuildCacheProducerBenefits(ctx, state, state.serviceBuildDuration, true)
 	}
-	state.runDeferredCacheSavesAndWait()
+	d.drainPrewarmCacheSaves(ctx, state)
 	d.flushBuildCachesBeforeCleanup(ctx, state, cfg.Install, opts, observer)
 	return nil
+}
+
+// drainPrewarmCacheSaves persists the install-phase archives the build-snapshot
+// prewarm held back until after its build phase. Giving up is not an error for
+// the job — the snapshot it produces is its primary output — but it does mean
+// the next launch pays for whatever did not land, so say so.
+func (d *DockerPreviewProvider) drainPrewarmCacheSaves(ctx context.Context, state *previewState) {
+	if err := state.runDeferredCacheSavesAndWait(ctx, previewPrewarmCacheDrainTimeout); err != nil {
+		d.logger.Warn().Err(err).
+			Msg("preview build prewarm: giving up on install cache archives; sandbox teardown may truncate them")
+	}
 }
 
 // SoftRestartPreview restarts application service processes in-place while
@@ -1001,6 +1025,16 @@ const previewFailureCacheFlushTimeout = 30 * time.Second
 // for cancelled saves to unwind after the budget expires. Returning while a
 // save is still driving the sandbox would let cleanup and teardown race it.
 const previewFailureCacheFlushGrace = 5 * time.Second
+
+// previewPrewarmCacheDrainTimeout bounds how long the build-snapshot prewarm
+// blocks draining its install-phase archives after the build phase. Those saves
+// detach from the job context so a deadline cannot truncate them mid-upload,
+// which leaves this ceiling as the only thing stopping a wedged blob store from
+// running the job far past PREVIEW_CACHE_PREWARM_TIMEOUT while it holds a
+// sandbox and a prewarm capacity slot. It matches previewStopBackgroundWaitCap,
+// the existing budget for machine-driven paths that are willing to wait on a
+// cache upload.
+const previewPrewarmCacheDrainTimeout = previewStopBackgroundWaitCap
 
 // waitForGroupBounded blocks until wg is done, ctx is cancelled, or maxWait
 // elapses — whichever first — returning a non-nil error only when it gives up
@@ -1698,19 +1732,17 @@ func (d *DockerPreviewProvider) runPreviewInstallWithMode(ctx context.Context, s
 	// round-trip is latency off the critical path. Matching that helper, an
 	// empty verify_paths list is satisfied by the marker alone.
 	//
-	// Note this is a workdir-only signal that also suppresses the HomeDir
-	// package-manager restore below. That is sound because the only way the
-	// workdir can satisfy the contract before any restore is sandbox retention
-	// or a whole-container snapshot, both of which carry HOME along with the
-	// workdir. A repo cannot widen the check either: platform-owned cache paths
-	// are stripped from verify_paths (CacheRestorablePreviewInstallVerifyPaths),
-	// so no HomeDir path is declarable here.
+	// This is intentionally a WorkDir-only signal. A startup snapshot can make
+	// it true in a fresh sandbox while HomeDir is still cold because preview
+	// snapshots archive WorkDir only. Only an explicitly retained sandbox may
+	// use it to suppress the HomeDir package-manager restore below.
 	installValidBeforeRestore := markerExists &&
 		(len(cacheRestorableVerifyPaths) == 0 ||
 			d.previewInstallVerifyPathsSatisfied(ctx, state.sandbox, cacheRestorableVerifyPaths))
 	notifyPhaseEnd(observer, "install_marker_check", nil)
 	metrics.RecordSessionPreviewPhaseDuration(ctx, opts.OrgID.String(), "install_marker_check", time.Since(markerCheckStarted))
-	if installValidBeforeRestore && mode.skipWhenAlreadyValid {
+	validInstallFastPath := installValidBeforeRestore && mode.skipWhenAlreadyValid
+	if validInstallFastPath && opts.RetainedSandbox {
 		// The retained sandbox already satisfies the exact install key and its
 		// declared output contract. Restoring either remote cache cannot improve
 		// correctness and only adds archive download/extraction latency.
@@ -1725,7 +1757,7 @@ func (d *DockerPreviewProvider) runPreviewInstallWithMode(ctx context.Context, s
 			metrics.RecordSessionPackageManagerCacheRestore(ctx, opts.OrgID.String(), "skipped_install_valid", 0)
 			metrics.RecordSessionDependencyCacheRestore(ctx, opts.OrgID.String(), "skipped_install_valid", 0)
 		}
-		d.logger.Info().Str("marker", markerPath).Msg("preview install cache hit; remote restores skipped")
+		d.logger.Info().Str("marker", markerPath).Msg("preview install cache hit in retained sandbox; remote restores skipped")
 		d.deferMissingInstallOutputCacheSave(ctx, state, install, opts, observer, dependencyPaths, dependencyCacheEnabled, cacheKey)
 		return nil
 	}
@@ -1807,6 +1839,24 @@ func (d *DockerPreviewProvider) runPreviewInstallWithMode(ctx context.Context, s
 		if opts.OrgID != uuid.Nil {
 			metrics.RecordSessionPackageManagerCacheRestore(ctx, opts.OrgID.String(), "disabled", 0)
 		}
+	}
+
+	if validInstallFastPath {
+		// A WorkDir startup snapshot already supplied the install outputs, so the
+		// dependency-output archive cannot improve this launch. HomeDir is not in
+		// that snapshot, however, and the package-manager lifecycle above must be
+		// allowed to restore it before service builds run.
+		notifyDependencyCacheRestore(observer, "skipped_install_valid", "", 0, nil)
+		if opts.OrgID != uuid.Nil {
+			metrics.RecordSessionDependencyCacheRestore(ctx, opts.OrgID.String(), "skipped_install_valid", 0)
+		}
+		// The valid WorkDir, not the HomeDir restore, caused preview.install to
+		// skip. Record a zero-benefit observation so cost-aware admission does not
+		// incorrectly credit the restore with the full cold-install baseline.
+		d.recordCacheProducerBenefits(ctx, pathCache, nil, []*preview.DependencyCacheHit{packageManagerRestoredHit}, 0, true)
+		d.logger.Info().Str("marker", markerPath).Msg("preview install cache hit; dependency restore skipped after HomeDir cache lifecycle")
+		d.deferMissingInstallOutputCacheSave(ctx, state, install, opts, observer, dependencyPaths, dependencyCacheEnabled, cacheKey)
+		return nil
 	}
 
 	if d.dependencyCache != nil && dependencyCacheEnabled && opts.OrgID != uuid.Nil && opts.RepositoryID != uuid.Nil {
@@ -1917,12 +1967,24 @@ func (d *DockerPreviewProvider) runPreviewInstallWithMode(ctx context.Context, s
 	// files before the install command can use them. With a marker present,
 	// restore can satisfy verify_paths and skip preview.install entirely.
 	if !forceInstallAfterDependencyRestoreFailure && d.previewInstallCacheValid(ctx, state.sandbox, markerPath, cacheRestorableVerifyPaths) {
-		// Only the workdir install-output restore can create verify_paths or the
-		// install marker. The home-directory package-manager cache may make a
-		// subsequently executed install faster, but it cannot cause this skip.
-		d.recordCacheProducerBenefits(ctx, pathCache,
-			[]*preview.DependencyCacheHit{dependencyRestoredHit},
-			[]*preview.DependencyCacheHit{packageManagerRestoredHit}, 0, true)
+		if installValidBeforeRestore {
+			// The sandbox already satisfied the contract before either restore
+			// ran, so neither one caused this skip and neither may claim its
+			// cold baseline as benefit. Only prewarm reaches this with an
+			// already-valid install — the launch path short-circuits above —
+			// and over-crediting here would corrupt the very signal cost-aware
+			// admission uses to decide whether restoring is worth it.
+			d.recordCacheProducerBenefits(ctx, pathCache, nil,
+				[]*preview.DependencyCacheHit{dependencyRestoredHit, packageManagerRestoredHit}, 0, true)
+		} else {
+			// Only the workdir install-output restore can create verify_paths or
+			// the install marker. The home-directory package-manager cache may
+			// make a subsequently executed install faster, but it cannot cause
+			// this skip.
+			d.recordCacheProducerBenefits(ctx, pathCache,
+				[]*preview.DependencyCacheHit{dependencyRestoredHit},
+				[]*preview.DependencyCacheHit{packageManagerRestoredHit}, 0, true)
+		}
 		d.logger.Info().Str("marker", markerPath).Msg("preview install cache hit")
 		if dependencyRestoredThisLaunch {
 			// The blob for this exact key was just extracted into the
@@ -3443,23 +3505,42 @@ func (d *DockerPreviewProvider) runServiceBuilds(ctx context.Context, state *pre
 		// cannot leak — results is buffered for every build — and the sandbox is
 		// torn down on this path anyway.
 		var drainGrace <-chan time.Time
+		collect := func(result serviceBuildResult) {
+			if result.err == nil {
+				return
+			}
+			failures[result.name] = result
+			cancelParallel()
+			if drainGrace == nil {
+				drainGrace = time.After(d.parallelBuildDrainGrace())
+			}
+		}
+	drain:
 		for collected := 0; collected < buildCount; {
 			select {
 			case result := <-results:
 				collected++
-				if result.err != nil {
-					failures[result.name] = result
-					cancelParallel()
-					if drainGrace == nil {
-						drainGrace = time.After(d.parallelBuildDrainGrace())
+				collect(result)
+			case <-drainGrace:
+				// Take whatever already landed before giving up. select picks
+				// uniformly among ready cases, so a result sitting in the buffer
+				// can lose the race to this timer — and it could be the causal
+				// failure, which would then be dropped from the report.
+				for {
+					select {
+					case result := <-results:
+						collected++
+						collect(result)
+					default:
+						if collected < buildCount {
+							d.logger.Warn().
+								Int("collected", collected).
+								Int("build_count", buildCount).
+								Msg("preview service builds: giving up waiting for cancelled sibling builds")
+						}
+						break drain
 					}
 				}
-			case <-drainGrace:
-				d.logger.Warn().
-					Int("collected", collected).
-					Int("build_count", buildCount).
-					Msg("preview service builds: giving up waiting for cancelled sibling builds")
-				collected = buildCount
 			}
 		}
 		// Preserve deterministic support-first/primary-last error selection even

--- a/internal/services/preview/providers/docker_preview.go
+++ b/internal/services/preview/providers/docker_preview.go
@@ -108,6 +108,10 @@ type DockerPreviewProvider struct {
 
 	dependencyCache            preview.DependencyCache
 	packageManagerCacheEnabled bool
+
+	// testParallelBuildDrainGrace overrides parallelBuildCancelDrainGrace in
+	// tests; zero means the production default.
+	testParallelBuildDrainGrace time.Duration
 }
 
 type previewDialer func(ctx context.Context, addr string) (net.Conn, error)
@@ -204,15 +208,53 @@ func (s *previewState) deferCacheSave(save func()) {
 	s.deferredCacheSaves = append(s.deferredCacheSaves, save)
 }
 
+// runDeferredCacheSaves starts the saves that were held back until after the
+// readiness-critical path. Each one is registered on state.wg — the same
+// treatment savePreviewBuildCache gives its uploads — so a stop that arrives
+// moments after readiness (a prewarm stops the instant the preview is ready)
+// waits out the archive instead of racing sandbox teardown. The wait is bounded
+// by StopPreviewWithBackgroundWait, so this cannot hang an interactive stop.
+//
+// The Add happens here, in the caller's goroutine, rather than inside each save:
+// StopPreview may call wg.Wait() as soon as this returns, and an Add racing that
+// Wait would not be observed.
 func (s *previewState) runDeferredCacheSaves() {
-	if s == nil || len(s.deferredCacheSaves) == 0 {
+	for _, save := range s.takeDeferredCacheSaves() {
+		s.wg.Add(1)
+		go func(fn func()) {
+			defer s.wg.Done()
+			fn()
+		}(save)
+	}
+}
+
+// runDeferredCacheSavesAndWait drains the deferred saves and blocks until they
+// finish. Callers that own the sandbox and destroy it on return — the
+// build-snapshot prewarm — need this: a fire-and-forget drain there would be
+// killed by teardown, which is the failure mode the whole job exists to avoid.
+func (s *previewState) runDeferredCacheSavesAndWait() {
+	saves := s.takeDeferredCacheSaves()
+	if len(saves) == 0 {
 		return
+	}
+	var wg sync.WaitGroup
+	for _, save := range saves {
+		wg.Add(1)
+		go func(fn func()) {
+			defer wg.Done()
+			fn()
+		}(save)
+	}
+	wg.Wait()
+}
+
+func (s *previewState) takeDeferredCacheSaves() []func() {
+	if s == nil || len(s.deferredCacheSaves) == 0 {
+		return nil
 	}
 	saves := append([]func(){}, s.deferredCacheSaves...)
 	s.deferredCacheSaves = nil
-	for _, save := range saves {
-		go save()
-	}
+	return saves
 }
 
 // serviceTailLines is the size of the per-service stdout/stderr ring buffer
@@ -631,12 +673,22 @@ func (d *DockerPreviewProvider) PrewarmPreviewBuildSnapshot(ctx context.Context,
 		infra:    map[string]*preview.InfraHandle{},
 		services: map[string]*serviceState{},
 	}
-	if err := d.runPreviewInstallWithMode(ctx, state, cfg.Install, opts, observer, previewInstallRunMode{}); err != nil {
+	// Hold the install-phase archives until after the build phase. The
+	// package-manager cache owns HomeDir directories that a build still writes
+	// to — `go build` populates GOMODCACHE for any module the install command
+	// did not already fetch — so archiving at the end of install would capture
+	// the module cache as it stood before the compile and permanently miss those
+	// downloads. The launch path gets this ordering for free (its deferred saves
+	// drain after readiness); this job has to ask for it.
+	if err := d.runPreviewInstallWithMode(ctx, state, cfg.Install, opts, observer, previewInstallRunMode{saveAsync: true}); err != nil {
 		return fmt.Errorf("%w: %v", preview.ErrInstallFailed, err)
 	}
 	d.restorePreviewBuildCache(ctx, state, cfg.Install, opts, observer)
 	d.restorePreviewBuildCacheHome(ctx, state, cfg.Install, opts, observer)
 	if err := d.runServiceBuilds(ctx, state, cfg, opts, observer); err != nil {
+		// The install itself succeeded, so its caches are still worth keeping:
+		// the next attempt should not repeat a download that already worked.
+		state.runDeferredCacheSavesAndWait()
 		d.flushBuildCachesBeforeCleanup(ctx, state, cfg.Install, opts, observer)
 		return fmt.Errorf("%w: %v", preview.ErrServiceBuildFailed, err)
 	}
@@ -647,6 +699,7 @@ func (d *DockerPreviewProvider) PrewarmPreviewBuildSnapshot(ctx context.Context,
 	if state.serviceBuildDuration > 0 {
 		d.recordBuildCacheProducerBenefits(ctx, state, state.serviceBuildDuration, true)
 	}
+	state.runDeferredCacheSavesAndWait()
 	d.flushBuildCachesBeforeCleanup(ctx, state, cfg.Install, opts, observer)
 	return nil
 }
@@ -1605,7 +1658,6 @@ func (d *DockerPreviewProvider) runPreviewInstallWithMode(ctx context.Context, s
 	if install == nil {
 		return nil
 	}
-	saveAsync := mode.saveAsync
 	timeout := time.Duration(install.TimeoutSeconds) * time.Second
 	if timeout <= 0 {
 		timeout = time.Duration(preview.DefaultInstallTimeoutSeconds) * time.Second
@@ -1674,7 +1726,7 @@ func (d *DockerPreviewProvider) runPreviewInstallWithMode(ctx context.Context, s
 			metrics.RecordSessionDependencyCacheRestore(ctx, opts.OrgID.String(), "skipped_install_valid", 0)
 		}
 		d.logger.Info().Str("marker", markerPath).Msg("preview install cache hit; remote restores skipped")
-		d.deferMissingInstallOutputCacheSave(ctx, state, install, opts, observer, dependencyPaths, dependencyCacheEnabled)
+		d.deferMissingInstallOutputCacheSave(ctx, state, install, opts, observer, dependencyPaths, dependencyCacheEnabled, cacheKey)
 		return nil
 	}
 
@@ -1883,7 +1935,7 @@ func (d *DockerPreviewProvider) runPreviewInstallWithMode(ctx context.Context, s
 			}
 			d.logger.Debug().Str("cache_key", dependencyCacheKey).Msg("preview dependency cache save skipped: blob restored this launch")
 		} else {
-			d.saveDependencyCache(ctx, state, install, opts, dependencyCacheKey, placementKey, dependencyPaths, dependencyLockfiles, observer, saveAsync, 0)
+			d.saveDependencyCache(ctx, state, install, opts, dependencyCacheKey, placementKey, dependencyPaths, dependencyLockfiles, observer, mode.saveAsync, 0)
 		}
 		return nil
 	}
@@ -1933,8 +1985,8 @@ func (d *DockerPreviewProvider) runPreviewInstallWithMode(ctx context.Context, s
 	d.logger.Info().Str("marker", markerPath).Msg("preview install completed")
 	packageManagerProducerDurationMS := observedColdProducerDurationMS(state.installProducerDuration, packageManagerRestoredHit == nil)
 	dependencyProducerDurationMS := observedColdProducerDurationMS(state.installProducerDuration, dependencyRestoredHit == nil)
-	d.savePackageManagerCache(ctx, state, install, opts, packageManagerCacheKey, packageManagerPlacementKey, packageManagerPaths, packageManagers, packageManagerLockfiles, observer, saveAsync, packageManagerProducerDurationMS)
-	d.saveDependencyCache(ctx, state, install, opts, dependencyCacheKey, placementKey, dependencyPaths, dependencyLockfiles, observer, saveAsync, dependencyProducerDurationMS)
+	d.savePackageManagerCache(ctx, state, install, opts, packageManagerCacheKey, packageManagerPlacementKey, packageManagerPaths, packageManagers, packageManagerLockfiles, observer, mode.saveAsync, packageManagerProducerDurationMS)
+	d.saveDependencyCache(ctx, state, install, opts, dependencyCacheKey, placementKey, dependencyPaths, dependencyLockfiles, observer, mode.saveAsync, dependencyProducerDurationMS)
 	return nil
 }
 
@@ -2002,7 +2054,14 @@ func (d *DockerPreviewProvider) savePackageManagerCache(ctx context.Context, sta
 // Everything here — the key computation, the lookup, and the archive — runs
 // behind readiness, so the fast path stays fast. When an entry already exists
 // this costs one metadata query and nothing else.
-func (d *DockerPreviewProvider) deferMissingInstallOutputCacheSave(ctx context.Context, state *previewState, install *models.PreviewInstallConfig, opts preview.StartPreviewOptions, observer preview.ServiceObserver, dependencyPaths []string, dependencyCacheEnabled bool) {
+//
+// installCacheKey is the key whose marker validated at install time. Because the
+// dependency key is computed later than that marker was trusted, the workspace
+// could have moved underneath: an install script or a service running a
+// lockfile-rewriting command (`npm install` rather than `npm ci`) would leave
+// the tree matching the old lockfiles while the new key names the new ones.
+// Recomputing the install key and requiring it to match closes that window.
+func (d *DockerPreviewProvider) deferMissingInstallOutputCacheSave(ctx context.Context, state *previewState, install *models.PreviewInstallConfig, opts preview.StartPreviewOptions, observer preview.ServiceObserver, dependencyPaths []string, dependencyCacheEnabled bool, installCacheKey string) {
 	if d.dependencyCache == nil || !dependencyCacheEnabled || len(dependencyPaths) == 0 {
 		return
 	}
@@ -2012,6 +2071,18 @@ func (d *DockerPreviewProvider) deferMissingInstallOutputCacheSave(ctx context.C
 	state.deferCacheSave(func() {
 		probeCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), previewCacheSaveTimeout)
 		defer cancel()
+		currentInstallKey, err := d.computePreviewInstallCacheKey(probeCtx, state.sandbox, install)
+		if err != nil {
+			d.logger.Warn().Err(err).Msg("preview install-output cache repopulation skipped: install key unavailable")
+			return
+		}
+		if currentInstallKey != installCacheKey {
+			d.logger.Info().
+				Str("install_key", installCacheKey).
+				Str("current_install_key", currentInstallKey).
+				Msg("preview install-output cache repopulation skipped: workspace inputs changed after the install check")
+			return
+		}
 		cacheKey, lockfiles, err := preview.ComputePreviewDependencyCacheKey(probeCtx, d.executor, state.sandbox, install, dependencyPaths)
 		if err != nil {
 			d.logger.Warn().Err(err).Msg("preview install-output cache repopulation skipped: cache key unavailable")
@@ -3137,6 +3208,77 @@ func previewServiceBuildOrder(cfg *models.PreviewConfig) []string {
 	return names
 }
 
+// parallelBuildCancelDrainGrace bounds how long a failed parallel build phase
+// waits for its cancelled siblings to return before reporting. Cancellation
+// normally unblocks ExecStream immediately; this only covers a build command
+// that outlives the cancelled stream, which must not be able to withhold the
+// error for the full defaultServiceBuildTimeout.
+const parallelBuildCancelDrainGrace = 30 * time.Second
+
+// parallelBuildDrainGrace returns the drain budget, honouring the test-only
+// override on the provider. Zero means the production default.
+func (d *DockerPreviewProvider) parallelBuildDrainGrace() time.Duration {
+	if d.testParallelBuildDrainGrace > 0 {
+		return d.testParallelBuildDrainGrace
+	}
+	return parallelBuildCancelDrainGrace
+}
+
+type serviceBuildResult struct {
+	name       string
+	outputTail []string
+	err        error
+	// canceled records that this build's context was already done when the
+	// command returned, i.e. it is cancellation fallout from a sibling failure
+	// rather than a cause. It cannot be inferred from err: a build killed
+	// mid-flight usually surfaces as a plain non-zero exit code (137) that
+	// wraps no context error at all.
+	canceled bool
+}
+
+// selectCausalBuildFailure picks which failure to report from a parallel build
+// phase. Completion order is nondeterministic, so selection walks buildOrder
+// (support-first, primary-last) for a stable answer, and prefers a build that
+// failed on its own merits over one that was killed by a sibling's failure —
+// reporting the victim would show the wrong service name and the wrong output
+// tail. Any other genuine failure is folded into the message so a second broken
+// build is not silently reduced to a log line.
+func selectCausalBuildFailure(buildOrder []string, failures map[string]serviceBuildResult) (serviceBuildResult, bool) {
+	var selected serviceBuildResult
+	found := false
+	for _, name := range buildOrder {
+		result, failed := failures[name]
+		if !failed || result.canceled {
+			continue
+		}
+		selected, found = result, true
+		break
+	}
+	if !found {
+		// Everything that failed was cancellation fallout, which happens when
+		// the cause was a timeout or the launch context itself going away.
+		for _, name := range buildOrder {
+			if result, failed := failures[name]; failed {
+				return result, true
+			}
+		}
+		return serviceBuildResult{}, false
+	}
+	var also []string
+	for _, name := range buildOrder {
+		if name == selected.name {
+			continue
+		}
+		if result, failed := failures[name]; failed && !result.canceled {
+			also = append(also, result.err.Error())
+		}
+	}
+	if len(also) > 0 {
+		selected.err = fmt.Errorf("%w (other failing builds: %s)", selected.err, strings.Join(also, "; "))
+	}
+	return selected, true
+}
+
 // runServiceBuilds runs each service's optional Build command to completion
 // before any service starts. Builds are support-first and primary-last by
 // default. Repositories may explicitly opt into parallel builds when every
@@ -3162,28 +3304,19 @@ func (d *DockerPreviewProvider) runServiceBuilds(ctx context.Context, state *pre
 	}
 
 	// When home build caching is active (a Go project), pin GOCACHE/GOMODCACHE
-	// to the default $HOME locations the platform archives, so a base image that
-	// overrides them can't silently send the build's output somewhere the cache
-	// never captures. These are defaults: a service that sets them explicitly in
-	// its own Env still wins.
+	// to the default $HOME locations the platform archives — GOCACHE via the
+	// build cache, GOMODCACHE via whichever lifecycle owns it (see
+	// ResolvePreviewBuildCacheHomePaths). Without the pin a base image that
+	// overrides them could silently send the build's output somewhere no cache
+	// captures. These are defaults: a service that sets them explicitly in its
+	// own Env still wins.
 	_, pinGoCacheEnv := preview.ResolvePreviewBuildCacheHomePaths(cfg.Install)
 
 	parallel := cfg.ParallelBuilds && buildCount > 1
 	notifyPhaseStart(observer, "service_build")
 	phaseStarted := time.Now()
 	d.logger.Info().Bool("parallel", parallel).Int("build_count", buildCount).Msg("preview service build phase started")
-	type buildResult struct {
-		name       string
-		outputTail []string
-		err        error
-		// canceled records that this build's context was already done when the
-		// command returned, i.e. it is cancellation fallout from a sibling
-		// failure rather than a cause. It cannot be inferred from err: a build
-		// killed mid-flight usually surfaces as a plain non-zero exit code
-		// (137) that wraps no context error at all.
-		canceled bool
-	}
-	runBuild := func(parentCtx context.Context, name string) buildResult {
+	runBuild := func(parentCtx context.Context, name string) serviceBuildResult {
 		buildStarted := time.Now()
 		svcCfg := cfg.Services[name]
 
@@ -3266,7 +3399,7 @@ func (d *DockerPreviewProvider) runServiceBuilds(ctx context.Context, state *pre
 		if err != nil || exitCode != 0 {
 			if err != nil {
 				d.logger.Warn().Err(err).Str("service", name).Bool("canceled", canceled).Int64("duration_ms", time.Since(buildStarted).Milliseconds()).Msg("service build failed")
-				return buildResult{
+				return serviceBuildResult{
 					name:       name,
 					outputTail: append([]string(nil), outputTail...),
 					err:        fmt.Errorf("service %q build: %w", name, err),
@@ -3275,12 +3408,12 @@ func (d *DockerPreviewProvider) runServiceBuilds(ctx context.Context, state *pre
 			}
 			errMsg := fmt.Sprintf("service %q build: %s", name, formatServiceExitError(exitCode, outputTail))
 			d.logger.Warn().Int("exit_code", exitCode).Str("service", name).Bool("canceled", canceled).Int64("duration_ms", time.Since(buildStarted).Milliseconds()).Msg("service build failed")
-			return buildResult{name: name, outputTail: append([]string(nil), outputTail...), err: errors.New(errMsg), canceled: canceled}
+			return serviceBuildResult{name: name, outputTail: append([]string(nil), outputTail...), err: errors.New(errMsg), canceled: canceled}
 		}
 		d.logger.Info().Str("service", name).Int64("duration_ms", time.Since(buildStarted).Milliseconds()).Msg("service build completed")
-		return buildResult{name: name}
+		return serviceBuildResult{name: name}
 	}
-	failBuild := func(result buildResult) error {
+	failBuild := func(result serviceBuildResult) error {
 		state.serviceBuildDuration = 0
 		d.recordBuildCacheProducerBenefits(ctx, state, 0, false)
 		notifyServiceFailed(observer, result.name, result.err.Error(), result.outputTail)
@@ -3290,7 +3423,7 @@ func (d *DockerPreviewProvider) runServiceBuilds(ctx context.Context, state *pre
 	}
 
 	if parallel {
-		results := make(chan buildResult, buildCount)
+		results := make(chan serviceBuildResult, buildCount)
 		parallelCtx, cancelParallel := context.WithCancel(ctx)
 		defer cancelParallel()
 		for _, name := range buildOrder {
@@ -3301,27 +3434,40 @@ func (d *DockerPreviewProvider) runServiceBuilds(ctx context.Context, state *pre
 				results <- runBuild(parallelCtx, serviceName)
 			}(name)
 		}
-		failures := make(map[string]buildResult)
-		for range buildCount {
-			result := <-results
-			if result.err != nil {
-				failures[result.name] = result
-				cancelParallel()
+		failures := make(map[string]serviceBuildResult)
+		// drainGrace stays nil (a nil channel blocks forever) until something
+		// fails. After that it bounds how long a cancelled sibling may take to
+		// notice: sequential builds surfaced a failure immediately, and a build
+		// command that outlives the cancelled stream must not be able to hold the
+		// error back for the full 30-minute build timeout. Abandoned goroutines
+		// cannot leak — results is buffered for every build — and the sandbox is
+		// torn down on this path anyway.
+		var drainGrace <-chan time.Time
+		for collected := 0; collected < buildCount; {
+			select {
+			case result := <-results:
+				collected++
+				if result.err != nil {
+					failures[result.name] = result
+					cancelParallel()
+					if drainGrace == nil {
+						drainGrace = time.After(d.parallelBuildDrainGrace())
+					}
+				}
+			case <-drainGrace:
+				d.logger.Warn().
+					Int("collected", collected).
+					Int("build_count", buildCount).
+					Msg("preview service builds: giving up waiting for cancelled sibling builds")
+				collected = buildCount
 			}
 		}
 		// Preserve deterministic support-first/primary-last error selection even
 		// though completion order is intentionally nondeterministic. Prefer the
 		// underlying build failure over sibling cancellation fallout, so the
 		// reported service name and output tail belong to the actual cause.
-		for _, name := range buildOrder {
-			if result, failed := failures[name]; failed && !result.canceled {
-				return failBuild(result)
-			}
-		}
-		for _, name := range buildOrder {
-			if result, failed := failures[name]; failed {
-				return failBuild(result)
-			}
+		if selected, ok := selectCausalBuildFailure(buildOrder, failures); ok {
+			return failBuild(selected)
 		}
 	} else {
 		for _, name := range buildOrder {

--- a/internal/services/preview/providers/docker_preview.go
+++ b/internal/services/preview/providers/docker_preview.go
@@ -419,8 +419,12 @@ func (d *DockerPreviewProvider) StartPreview(ctx context.Context, sb *agent.Sand
 		// boot-time builds get cache hits. Failures degrade to a cold build.
 		// The home-rooted set (Go's GOCACHE/GOMODCACHE) is restored alongside so
 		// the build phase's `go build` is incremental.
-		d.restorePreviewBuildCache(ctx, state, cfg.Install, opts, observer)
-		d.restorePreviewBuildCacheHome(ctx, state, cfg.Install, opts, observer)
+		if !opts.SkipServiceBuild {
+			d.restorePreviewBuildCache(ctx, state, cfg.Install, opts, observer)
+			d.restorePreviewBuildCacheHome(ctx, state, cfg.Install, opts, observer)
+		} else {
+			d.logger.Info().Msg("build cache restore skipped for exact-revision warm resume")
+		}
 
 		// Phase 4.6: Run per-service build commands. This is deliberately before
 		// runtime secret files (so build steps cannot read app secrets) and
@@ -429,9 +433,13 @@ func (d *DockerPreviewProvider) StartPreview(ctx context.Context, sb *agent.Sand
 		// after readiness (see below); on any failure from here on it is flushed
 		// synchronously before cleanup, so an expensive cold compile warms
 		// subsequent launches even when this launch fails.
-		if err := d.runServiceBuilds(ctx, state, cfg, opts, observer); err != nil {
-			phaseErr = fmt.Errorf("%w: %v", preview.ErrServiceBuildFailed, err)
-			return phaseErr
+		if !opts.SkipServiceBuild {
+			if err := d.runServiceBuilds(ctx, state, cfg, opts, observer); err != nil {
+				phaseErr = fmt.Errorf("%w: %v", preview.ErrServiceBuildFailed, err)
+				return phaseErr
+			}
+		} else {
+			d.logger.Info().Msg("service builds skipped for exact-revision warm resume")
 		}
 
 		// Phase 5: Write generated runtime secret files after install so install
@@ -548,12 +556,14 @@ func (d *DockerPreviewProvider) StartPreview(ctx context.Context, sb *agent.Sand
 				defer state.wg.Done()
 				failure := d.waitForServiceReadinessSet(svcCtx, svcCtx, state, cfg, supportServiceNames(cfg), observer, false, "progressive")
 				readinessElapsed := time.Since(readinessStarted)
-				d.recordBuildCacheProducerBenefits(svcCtx, state, state.serviceBuildDuration+readinessElapsed, failure == nil)
-				// All services finished their readiness window: boot-time
-				// builds are done, so capture the build caches now. Both saves
-				// are async; the launch is already reported ready.
-				d.savePreviewBuildCache(svcCtx, state, cfg.Install, opts, observer)
-				d.savePreviewBuildCacheHome(svcCtx, state, cfg.Install, opts, observer)
+				if !opts.SkipServiceBuild {
+					d.recordBuildCacheProducerBenefits(svcCtx, state, state.serviceBuildDuration+readinessElapsed, failure == nil)
+					// All services finished their readiness window: boot-time
+					// builds are done, so capture the build caches now. Both saves
+					// are async; the launch is already reported ready.
+					d.savePreviewBuildCache(svcCtx, state, cfg.Install, opts, observer)
+					d.savePreviewBuildCacheHome(svcCtx, state, cfg.Install, opts, observer)
+				}
 			}()
 			return nil
 		}
@@ -565,20 +575,24 @@ func (d *DockerPreviewProvider) StartPreview(ctx context.Context, sb *agent.Sand
 			return phaseErr
 		}
 		readinessElapsed := time.Since(phaseStarted)
-		d.recordBuildCacheProducerBenefits(ctx, state, state.serviceBuildDuration+readinessElapsed, true)
-		// All services are ready: boot-time builds are done, so capture the
-		// build caches now. Both saves are async so a large GOCACHE upload does
-		// not delay returning the ready preview.
-		d.savePreviewBuildCache(svcCtx, state, cfg.Install, opts, observer)
-		d.savePreviewBuildCacheHome(svcCtx, state, cfg.Install, opts, observer)
+		if !opts.SkipServiceBuild {
+			d.recordBuildCacheProducerBenefits(ctx, state, state.serviceBuildDuration+readinessElapsed, true)
+			// All services are ready: boot-time builds are done, so capture the
+			// build caches now. Both saves are async so a large GOCACHE upload does
+			// not delay returning the ready preview.
+			d.savePreviewBuildCache(svcCtx, state, cfg.Install, opts, observer)
+			d.savePreviewBuildCacheHome(svcCtx, state, cfg.Install, opts, observer)
+		}
 		return nil
 	}(); err != nil {
 		// Readiness failed, but boot-time builds may have populated their
 		// caches (and a cold compile in the build phase certainly did). Persist
 		// them synchronously before the sandbox is torn down so the next launch
 		// is warm instead of repeating the work that just timed out.
-		d.recordBuildCacheProducerBenefits(svcCtx, state, 0, false)
-		d.flushBuildCachesBeforeCleanup(svcCtx, state, cfg.Install, opts, observer)
+		if !opts.SkipServiceBuild {
+			d.recordBuildCacheProducerBenefits(svcCtx, state, 0, false)
+			d.flushBuildCachesBeforeCleanup(svcCtx, state, cfg.Install, opts, observer)
+		}
 		d.cleanupState(handle)
 		return nil, err
 	}
@@ -602,7 +616,7 @@ func (d *DockerPreviewProvider) PrewarmPreviewInstallCaches(ctx context.Context,
 		config:  cfg,
 		infra:   map[string]*preview.InfraHandle{},
 	}
-	return d.runPreviewInstallWithSaveMode(ctx, state, cfg.Install, opts, observer, false)
+	return d.runPreviewInstallWithMode(ctx, state, cfg.Install, opts, observer, previewInstallRunMode{})
 }
 
 func (d *DockerPreviewProvider) PrewarmPreviewBuildSnapshot(ctx context.Context, sb *agent.Sandbox, cfg *models.PreviewConfig, opts preview.StartPreviewOptions, observer preview.ServiceObserver) error {
@@ -617,7 +631,7 @@ func (d *DockerPreviewProvider) PrewarmPreviewBuildSnapshot(ctx context.Context,
 		infra:    map[string]*preview.InfraHandle{},
 		services: map[string]*serviceState{},
 	}
-	if err := d.runPreviewInstallWithSaveMode(ctx, state, cfg.Install, opts, observer, false); err != nil {
+	if err := d.runPreviewInstallWithMode(ctx, state, cfg.Install, opts, observer, previewInstallRunMode{}); err != nil {
 		return fmt.Errorf("%w: %v", preview.ErrInstallFailed, err)
 	}
 	d.restorePreviewBuildCache(ctx, state, cfg.Install, opts, observer)
@@ -1564,14 +1578,34 @@ type previewInstallLockfileKey struct {
 	SHA256 string `json:"sha256"`
 }
 
-func (d *DockerPreviewProvider) runPreviewInstall(ctx context.Context, state *previewState, install *models.PreviewInstallConfig, opts preview.StartPreviewOptions, observer preview.ServiceObserver) error {
-	return d.runPreviewInstallWithSaveMode(ctx, state, install, opts, observer, true)
+// previewInstallRunMode selects how the install phase treats cache work. The
+// launch path optimizes for time-to-ready; prewarm jobs optimize for producing
+// caches, which is the opposite trade in both fields.
+type previewInstallRunMode struct {
+	// saveAsync defers archive/upload work until after the readiness-critical
+	// path. Prewarm jobs save synchronously because cache creation is the whole
+	// job and there is no readiness path to protect.
+	saveAsync bool
+	// skipWhenAlreadyValid lets a launch whose sandbox already satisfies the
+	// exact install marker and verify_paths return before any remote cache
+	// lookup. Prewarm jobs must never take it: a prewarm sandbox cloned or
+	// hydrated from a workspace that already installed would otherwise report
+	// success while producing nothing.
+	skipWhenAlreadyValid bool
 }
 
-func (d *DockerPreviewProvider) runPreviewInstallWithSaveMode(ctx context.Context, state *previewState, install *models.PreviewInstallConfig, opts preview.StartPreviewOptions, observer preview.ServiceObserver, saveAsync bool) error {
+func (d *DockerPreviewProvider) runPreviewInstall(ctx context.Context, state *previewState, install *models.PreviewInstallConfig, opts preview.StartPreviewOptions, observer preview.ServiceObserver) error {
+	return d.runPreviewInstallWithMode(ctx, state, install, opts, observer, previewInstallRunMode{
+		saveAsync:            true,
+		skipWhenAlreadyValid: true,
+	})
+}
+
+func (d *DockerPreviewProvider) runPreviewInstallWithMode(ctx context.Context, state *previewState, install *models.PreviewInstallConfig, opts preview.StartPreviewOptions, observer preview.ServiceObserver, mode previewInstallRunMode) error {
 	if install == nil {
 		return nil
 	}
+	saveAsync := mode.saveAsync
 	timeout := time.Duration(install.TimeoutSeconds) * time.Second
 	if timeout <= 0 {
 		timeout = time.Duration(preview.DefaultInstallTimeoutSeconds) * time.Second
@@ -1611,11 +1645,38 @@ func (d *DockerPreviewProvider) runPreviewInstallWithSaveMode(ctx context.Contex
 	// we just read. This runs on every warm launch, so the saved sandbox
 	// round-trip is latency off the critical path. Matching that helper, an
 	// empty verify_paths list is satisfied by the marker alone.
+	//
+	// Note this is a workdir-only signal that also suppresses the HomeDir
+	// package-manager restore below. That is sound because the only way the
+	// workdir can satisfy the contract before any restore is sandbox retention
+	// or a whole-container snapshot, both of which carry HOME along with the
+	// workdir. A repo cannot widen the check either: platform-owned cache paths
+	// are stripped from verify_paths (CacheRestorablePreviewInstallVerifyPaths),
+	// so no HomeDir path is declarable here.
 	installValidBeforeRestore := markerExists &&
 		(len(cacheRestorableVerifyPaths) == 0 ||
 			d.previewInstallVerifyPathsSatisfied(ctx, state.sandbox, cacheRestorableVerifyPaths))
 	notifyPhaseEnd(observer, "install_marker_check", nil)
 	metrics.RecordSessionPreviewPhaseDuration(ctx, opts.OrgID.String(), "install_marker_check", time.Since(markerCheckStarted))
+	if installValidBeforeRestore && mode.skipWhenAlreadyValid {
+		// The retained sandbox already satisfies the exact install key and its
+		// declared output contract. Restoring either remote cache cannot improve
+		// correctness and only adds archive download/extraction latency.
+		//
+		// Skipping the restore also skips the only place a launch would have
+		// noticed that no remote entry backs this key, so queue a best-effort
+		// repopulation behind readiness. Without it an evicted entry could only
+		// ever be healed by a cold sandbox.
+		notifyPackageManagerCacheRestore(observer, "skipped_install_valid", "", 0, nil)
+		notifyDependencyCacheRestore(observer, "skipped_install_valid", "", 0, nil)
+		if opts.OrgID != uuid.Nil {
+			metrics.RecordSessionPackageManagerCacheRestore(ctx, opts.OrgID.String(), "skipped_install_valid", 0)
+			metrics.RecordSessionDependencyCacheRestore(ctx, opts.OrgID.String(), "skipped_install_valid", 0)
+		}
+		d.logger.Info().Str("marker", markerPath).Msg("preview install cache hit; remote restores skipped")
+		d.deferMissingInstallOutputCacheSave(ctx, state, install, opts, observer, dependencyPaths, dependencyCacheEnabled)
+		return nil
+	}
 
 	pathCache, hasPathCache := d.dependencyCache.(preview.PreviewPathCache)
 	if d.packageManagerCacheEnabled && d.dependencyCache != nil && hasPathCache && packageManagerCacheEnabled && opts.OrgID != uuid.Nil && opts.RepositoryID != uuid.Nil {
@@ -1804,12 +1865,12 @@ func (d *DockerPreviewProvider) runPreviewInstallWithSaveMode(ctx context.Contex
 	// files before the install command can use them. With a marker present,
 	// restore can satisfy verify_paths and skip preview.install entirely.
 	if !forceInstallAfterDependencyRestoreFailure && d.previewInstallCacheValid(ctx, state.sandbox, markerPath, cacheRestorableVerifyPaths) {
-		installHits := []*preview.DependencyCacheHit{packageManagerRestoredHit, dependencyRestoredHit}
-		if installValidBeforeRestore {
-			d.recordCacheProducerBenefits(ctx, pathCache, nil, installHits, 0, true)
-		} else {
-			d.recordCacheProducerBenefits(ctx, pathCache, installHits, nil, 0, true)
-		}
+		// Only the workdir install-output restore can create verify_paths or the
+		// install marker. The home-directory package-manager cache may make a
+		// subsequently executed install faster, but it cannot cause this skip.
+		d.recordCacheProducerBenefits(ctx, pathCache,
+			[]*preview.DependencyCacheHit{dependencyRestoredHit},
+			[]*preview.DependencyCacheHit{packageManagerRestoredHit}, 0, true)
 		d.logger.Info().Str("marker", markerPath).Msg("preview install cache hit")
 		if dependencyRestoredThisLaunch {
 			// The blob for this exact key was just extracted into the
@@ -1929,6 +1990,63 @@ func (d *DockerPreviewProvider) savePackageManagerCache(ctx context.Context, sta
 		return
 	}
 	save()
+}
+
+// deferMissingInstallOutputCacheSave queues a repopulation of the install-output
+// cache for a launch that skipped both the remote restore and preview.install
+// because the sandbox already satisfied the install contract. Such a launch
+// never looks the key up, so an entry that was evicted, expired, or lost to a
+// failed save on the cold launch that created this sandbox would otherwise stay
+// missing until some unrelated cold sandbox happened to recreate it.
+//
+// Everything here — the key computation, the lookup, and the archive — runs
+// behind readiness, so the fast path stays fast. When an entry already exists
+// this costs one metadata query and nothing else.
+func (d *DockerPreviewProvider) deferMissingInstallOutputCacheSave(ctx context.Context, state *previewState, install *models.PreviewInstallConfig, opts preview.StartPreviewOptions, observer preview.ServiceObserver, dependencyPaths []string, dependencyCacheEnabled bool) {
+	if d.dependencyCache == nil || !dependencyCacheEnabled || len(dependencyPaths) == 0 {
+		return
+	}
+	if opts.OrgID == uuid.Nil || opts.RepositoryID == uuid.Nil {
+		return
+	}
+	state.deferCacheSave(func() {
+		probeCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), previewCacheSaveTimeout)
+		defer cancel()
+		cacheKey, lockfiles, err := preview.ComputePreviewDependencyCacheKey(probeCtx, d.executor, state.sandbox, install, dependencyPaths)
+		if err != nil {
+			d.logger.Warn().Err(err).Msg("preview install-output cache repopulation skipped: cache key unavailable")
+			return
+		}
+		hit, err := d.dependencyCache.Find(probeCtx, opts.OrgID, opts.RepositoryID, cacheKey)
+		if err != nil {
+			d.logger.Warn().Err(err).Str("cache_key", cacheKey).Msg("preview install-output cache repopulation skipped: lookup failed")
+			return
+		}
+		if hit != nil {
+			return
+		}
+		configDigest := opts.ConfigDigest
+		if configDigest == "" {
+			if digest, digestErr := preview.ComputePreviewConfigDigest(state.config); digestErr == nil {
+				configDigest = digest
+			}
+		}
+		var placementKey string
+		if computed, placementErr := preview.ComputePreviewDependencyCachePlacementKey(opts.OrgID, opts.RepositoryID, state.config.Name, configDigest, install, dependencyPaths); placementErr != nil {
+			d.logger.Warn().Err(placementErr).Str("cache_key", cacheKey).Msg("preview install-output cache repopulation placement key unavailable")
+		} else {
+			placementKey = computed
+		}
+		d.logger.Info().Str("cache_key", cacheKey).Msg("preview install-output cache missing behind a valid install marker; repopulating")
+		// Already inside a deferred save goroutine: saving asynchronously here
+		// would append to a queue that has been drained and will never run
+		// again, so this save must be synchronous.
+		//
+		// The producer duration is unknown — no install ran — so it is recorded
+		// as a legacy baseline, which forces one cold sample before the entry
+		// takes part in cost-aware admission.
+		d.saveDependencyCache(probeCtx, state, install, opts, cacheKey, placementKey, dependencyPaths, lockfiles, observer, false, 0)
+	})
 }
 
 func (d *DockerPreviewProvider) saveDependencyCache(ctx context.Context, state *previewState, install *models.PreviewInstallConfig, opts preview.StartPreviewOptions, cacheKey, placementKey string, paths []string, lockfiles []preview.PreviewInstallLockfileKey, observer preview.ServiceObserver, async bool, producerDurationMS int64) {
@@ -3019,8 +3137,10 @@ func previewServiceBuildOrder(cfg *models.PreviewConfig) []string {
 	return names
 }
 
-// runServiceBuilds runs each service's optional Build command to completion,
-// in dependency order, before any service starts. It is the place to compile
+// runServiceBuilds runs each service's optional Build command to completion
+// before any service starts. Builds are support-first and primary-last by
+// default. Repositories may explicitly opt into parallel builds when every
+// build command writes independent outputs. It is the place to compile
 // outputs (e.g. `go build`) so the start command can exec a prebuilt binary
 // off the readiness-probe hot path. Build commands run with the service's own
 // Env plus the platform context env (ONEFORTYTHREE, ONEFORTYTHREE_ENV,
@@ -3030,14 +3150,14 @@ func previewServiceBuildOrder(cfg *models.PreviewConfig) []string {
 // runtime-only, so build steps still cannot read app secrets. A non-zero exit
 // or timeout fails the launch.
 func (d *DockerPreviewProvider) runServiceBuilds(ctx context.Context, state *previewState, cfg *models.PreviewConfig, opts preview.StartPreviewOptions, observer preview.ServiceObserver) error {
-	hasBuild := false
-	for _, svcCfg := range cfg.Services {
-		if len(svcCfg.Build) > 0 {
-			hasBuild = true
-			break
+	buildOrder := previewServiceBuildOrder(cfg)
+	buildCount := 0
+	for _, name := range buildOrder {
+		if len(cfg.Services[name].Build) > 0 {
+			buildCount++
 		}
 	}
-	if !hasBuild {
+	if buildCount == 0 {
 		return nil
 	}
 
@@ -3048,13 +3168,24 @@ func (d *DockerPreviewProvider) runServiceBuilds(ctx context.Context, state *pre
 	// its own Env still wins.
 	_, pinGoCacheEnv := preview.ResolvePreviewBuildCacheHomePaths(cfg.Install)
 
+	parallel := cfg.ParallelBuilds && buildCount > 1
 	notifyPhaseStart(observer, "service_build")
 	phaseStarted := time.Now()
-	for _, name := range previewServiceBuildOrder(cfg) {
+	d.logger.Info().Bool("parallel", parallel).Int("build_count", buildCount).Msg("preview service build phase started")
+	type buildResult struct {
+		name       string
+		outputTail []string
+		err        error
+		// canceled records that this build's context was already done when the
+		// command returned, i.e. it is cancellation fallout from a sibling
+		// failure rather than a cause. It cannot be inferred from err: a build
+		// killed mid-flight usually surfaces as a plain non-zero exit code
+		// (137) that wraps no context error at all.
+		canceled bool
+	}
+	runBuild := func(parentCtx context.Context, name string) buildResult {
+		buildStarted := time.Now()
 		svcCfg := cfg.Services[name]
-		if len(svcCfg.Build) == 0 {
-			continue
-		}
 
 		var cmdParts []string
 		if svcCfg.Cwd != "" {
@@ -3125,29 +3256,87 @@ func (d *DockerPreviewProvider) runServiceBuilds(ctx context.Context, state *pre
 			d.logger.Debug().Str("service", name).Str("output", text).Msg("service build output")
 		}
 		stderrSplitter := &previewLineSplitter{onLine: appendTail}
-		buildCtx, cancel := context.WithTimeout(ctx, defaultServiceBuildTimeout)
+		buildCtx, cancel := context.WithTimeout(parentCtx, defaultServiceBuildTimeout)
 		exitCode, err := d.executor.ExecStream(buildCtx, state.sandbox, cmd, appendTail, stderrSplitter)
 		stderrSplitter.flush()
 		cancel()
+		// Sample the parent, not buildCtx: buildCtx is also done once its own
+		// build timeout fires, and a timeout is a genuine cause.
+		canceled := parentCtx.Err() != nil
 		if err != nil || exitCode != 0 {
-			state.serviceBuildDuration = 0
-			d.recordBuildCacheProducerBenefits(ctx, state, 0, false)
-			var errMsg string
 			if err != nil {
-				errMsg = fmt.Sprintf("service %q build: %v", name, err)
-			} else {
-				errMsg = fmt.Sprintf("service %q build: %s", name, formatServiceExitError(exitCode, outputTail))
+				d.logger.Warn().Err(err).Str("service", name).Bool("canceled", canceled).Int64("duration_ms", time.Since(buildStarted).Milliseconds()).Msg("service build failed")
+				return buildResult{
+					name:       name,
+					outputTail: append([]string(nil), outputTail...),
+					err:        fmt.Errorf("service %q build: %w", name, err),
+					canceled:   canceled,
+				}
 			}
-			notifyServiceFailed(observer, name, errMsg, append([]string(nil), outputTail...))
-			notifyPhaseEnd(observer, "service_build", fmt.Errorf("%s", errMsg))
-			metrics.RecordSessionPreviewPhaseDuration(ctx, opts.OrgID.String(), "service_build", time.Since(phaseStarted))
-			return fmt.Errorf("%s", errMsg)
+			errMsg := fmt.Sprintf("service %q build: %s", name, formatServiceExitError(exitCode, outputTail))
+			d.logger.Warn().Int("exit_code", exitCode).Str("service", name).Bool("canceled", canceled).Int64("duration_ms", time.Since(buildStarted).Milliseconds()).Msg("service build failed")
+			return buildResult{name: name, outputTail: append([]string(nil), outputTail...), err: errors.New(errMsg), canceled: canceled}
 		}
-		d.logger.Info().Str("service", name).Msg("service build completed")
+		d.logger.Info().Str("service", name).Int64("duration_ms", time.Since(buildStarted).Milliseconds()).Msg("service build completed")
+		return buildResult{name: name}
+	}
+	failBuild := func(result buildResult) error {
+		state.serviceBuildDuration = 0
+		d.recordBuildCacheProducerBenefits(ctx, state, 0, false)
+		notifyServiceFailed(observer, result.name, result.err.Error(), result.outputTail)
+		notifyPhaseEnd(observer, "service_build", result.err)
+		metrics.RecordSessionPreviewPhaseDuration(ctx, opts.OrgID.String(), "service_build", time.Since(phaseStarted))
+		return result.err
+	}
+
+	if parallel {
+		results := make(chan buildResult, buildCount)
+		parallelCtx, cancelParallel := context.WithCancel(ctx)
+		defer cancelParallel()
+		for _, name := range buildOrder {
+			if len(cfg.Services[name].Build) == 0 {
+				continue
+			}
+			go func(serviceName string) {
+				results <- runBuild(parallelCtx, serviceName)
+			}(name)
+		}
+		failures := make(map[string]buildResult)
+		for range buildCount {
+			result := <-results
+			if result.err != nil {
+				failures[result.name] = result
+				cancelParallel()
+			}
+		}
+		// Preserve deterministic support-first/primary-last error selection even
+		// though completion order is intentionally nondeterministic. Prefer the
+		// underlying build failure over sibling cancellation fallout, so the
+		// reported service name and output tail belong to the actual cause.
+		for _, name := range buildOrder {
+			if result, failed := failures[name]; failed && !result.canceled {
+				return failBuild(result)
+			}
+		}
+		for _, name := range buildOrder {
+			if result, failed := failures[name]; failed {
+				return failBuild(result)
+			}
+		}
+	} else {
+		for _, name := range buildOrder {
+			if len(cfg.Services[name].Build) == 0 {
+				continue
+			}
+			if result := runBuild(ctx, name); result.err != nil {
+				return failBuild(result)
+			}
+		}
 	}
 	notifyPhaseEnd(observer, "service_build", nil)
 	state.serviceBuildDuration = time.Since(phaseStarted)
 	metrics.RecordSessionPreviewPhaseDuration(ctx, opts.OrgID.String(), "service_build", state.serviceBuildDuration)
+	d.logger.Info().Bool("parallel", parallel).Int("build_count", buildCount).Int64("duration_ms", state.serviceBuildDuration.Milliseconds()).Msg("preview service build phase completed")
 	return nil
 }
 

--- a/internal/services/preview/providers/docker_preview_test.go
+++ b/internal/services/preview/providers/docker_preview_test.go
@@ -11,6 +11,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -879,6 +880,9 @@ type fakeDependencyCache struct {
 	producerBaselines   []time.Duration
 	producerBaselineIDs []uuid.UUID
 	saveStarted         chan models.PreviewCacheKind
+	// saveHook, when set, runs at the start of every SavePathCache. Tests use it
+	// to observe save ordering relative to other launch phases.
+	saveHook func(models.PreviewCacheKind)
 	// buildSaveBlock, when set, makes build-output saves block until the channel
 	// is closed — used to prove StopPreview awaits the save.
 	buildSaveBlock chan struct{}
@@ -947,6 +951,9 @@ func (f *fakeDependencyCache) RestorePathCache(_ context.Context, _ *agent.Sandb
 }
 
 func (f *fakeDependencyCache) SavePathCache(ctx context.Context, _ *agent.Sandbox, spec preview.PreviewPathCacheSaveSpec) (preview.DependencyCacheSaveResult, error) {
+	if f.saveHook != nil {
+		f.saveHook(spec.Kind)
+	}
 	if f.saveStarted != nil {
 		select {
 		case f.saveStarted <- spec.Kind:
@@ -3983,6 +3990,95 @@ func TestDockerPreviewProvider_ParallelBuildReportsCauseNotCancellationVictim(t 
 	require.Contains(t, strings.Join(failures[0].tail, "\n"), "undefined symbol", "the observer should carry the causal build's output tail")
 }
 
+// TestDockerPreviewProvider_ParallelBuildFailureDoesNotWaitOutStuckSibling
+// covers the drain bound. Sequential builds surfaced a failure the moment it
+// happened; a parallel phase has to collect its siblings first, and a build
+// command that outlives its cancelled stream must not be able to hold the error
+// back for the full 30-minute build timeout.
+func TestDockerPreviewProvider_ParallelBuildFailureDoesNotWaitOutStuckSibling(t *testing.T) {
+	t.Parallel()
+
+	stuck := make(chan struct{})
+	t.Cleanup(func() { close(stuck) })
+	exec := &fakeServiceExecutor{execStreamFn: func(_ context.Context, cmd string, _ func([]byte)) (int, error) {
+		if strings.Contains(cmd, "build-web") {
+			return 1, nil
+		}
+		// Deliberately ignores ctx: models a build process that survives the
+		// cancelled exec stream.
+		<-stuck
+		return 0, nil
+	}}
+	provider := &DockerPreviewProvider{
+		executor:                    exec,
+		logger:                      zerolog.Nop(),
+		testParallelBuildDrainGrace: 50 * time.Millisecond,
+	}
+	cfg := &models.PreviewConfig{
+		Primary:        "web",
+		ParallelBuilds: true,
+		Services: map[string]models.ServiceConfig{
+			"api": {Build: []string{"build-api"}},
+			"web": {Build: []string{"build-web"}},
+		},
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		done <- provider.runServiceBuilds(context.Background(), &previewState{sandbox: &agent.Sandbox{}}, cfg, preview.StartPreviewOptions{OrgID: uuid.New()}, nil)
+	}()
+	select {
+	case err := <-done:
+		require.Error(t, err, "the build phase should fail")
+		require.Contains(t, err.Error(), `service "web" build`, "the failure should name the build that actually failed")
+	case <-time.After(10 * time.Second):
+		require.Fail(t, "a failed parallel build must not wait out a sibling that ignores cancellation")
+	}
+}
+
+func TestSelectCausalBuildFailure(t *testing.T) {
+	t.Parallel()
+
+	buildOrder := []string{"api", "worker", "web"}
+
+	t.Run("prefers a genuine failure over cancellation fallout", func(t *testing.T) {
+		t.Parallel()
+		selected, ok := selectCausalBuildFailure(buildOrder, map[string]serviceBuildResult{
+			"api": {name: "api", err: errors.New(`service "api" build: exited with code 137`), canceled: true},
+			"web": {name: "web", err: errors.New(`service "web" build: exited with code 1`)},
+		})
+		require.True(t, ok, "a failure should be selected")
+		require.Equal(t, "web", selected.name, "the cancellation victim must not be reported as the cause")
+	})
+
+	t.Run("reports every genuine failure", func(t *testing.T) {
+		t.Parallel()
+		selected, ok := selectCausalBuildFailure(buildOrder, map[string]serviceBuildResult{
+			"api": {name: "api", err: errors.New(`service "api" build: missing header`)},
+			"web": {name: "web", err: errors.New(`service "web" build: undefined symbol`)},
+		})
+		require.True(t, ok, "a failure should be selected")
+		require.Equal(t, "api", selected.name, "selection should follow support-first build order")
+		require.Contains(t, selected.err.Error(), "missing header", "the selected failure should be reported")
+		require.Contains(t, selected.err.Error(), "undefined symbol", "a second genuine failure must not be dropped silently")
+	})
+
+	t.Run("falls back to cancellation fallout when that is all there is", func(t *testing.T) {
+		t.Parallel()
+		selected, ok := selectCausalBuildFailure(buildOrder, map[string]serviceBuildResult{
+			"web": {name: "web", err: errors.New(`service "web" build: context canceled`), canceled: true},
+		})
+		require.True(t, ok, "an all-cancelled phase still has to report something")
+		require.Equal(t, "web", selected.name, "the only failure should be reported")
+	})
+
+	t.Run("reports nothing when every build succeeded", func(t *testing.T) {
+		t.Parallel()
+		_, ok := selectCausalBuildFailure(buildOrder, map[string]serviceBuildResult{})
+		require.False(t, ok, "a phase with no failures must not synthesize one")
+	})
+}
+
 func TestStartPreview_ExactWarmResumeSkipsServiceBuilds(t *testing.T) {
 	t.Parallel()
 
@@ -4054,12 +4150,11 @@ func TestStartPreview_ExactWarmResumeSkipsServiceBuilds(t *testing.T) {
 
 // goBuildPreviewConfig is a Go service with a build step and a go.mod lockfile,
 // so the build phase runs and the home build cache (GOCACHE/GOMODCACHE) is
-// active. The package-manager cache is disabled, which is what makes the home
-// set own go/pkg/mod as well as .cache/go-build: with that lifecycle active it
-// keeps the module cache, because only it restores before install. Install is a
-// no-op cache hit in these tests.
+// active. The install command is JS-only, so the modules the build downloads are
+// the interesting case: the package-manager cache owns go/pkg/mod here and must
+// not archive it until after the build phase. Install is a no-op cache hit in
+// these tests.
 func goBuildPreviewConfig() *models.PreviewConfig {
-	packageManagerDisabled := false
 	return &models.PreviewConfig{
 		Name:    "test-app",
 		Primary: "web",
@@ -4067,9 +4162,6 @@ func goBuildPreviewConfig() *models.PreviewConfig {
 			Command:     []string{"npm", "ci"},
 			Lockfiles:   []string{"package-lock.json", "go.mod"},
 			VerifyPaths: []string{"node_modules/.bin/next"},
-			Cache: &models.PreviewInstallCacheConfig{
-				PackageManager: &models.PreviewPackageManagerCacheConfig{Enabled: &packageManagerDisabled},
-			},
 		},
 		Services: map[string]models.ServiceConfig{
 			"web": {
@@ -4080,6 +4172,81 @@ func goBuildPreviewConfig() *models.PreviewConfig {
 			},
 		},
 	}
+}
+
+// TestPrewarmPreviewBuildSnapshot_ArchivesModuleCacheAfterBuild pins the save
+// ordering the package-manager cache depends on. That cache owns go/pkg/mod
+// (only it restores before install), but a JS install command does not fill the
+// module cache — the build phase's `go build` does. Archiving at the end of
+// install would therefore capture the module cache as it stood before the
+// compile and permanently miss every module the build downloaded. The launch
+// path gets this ordering from its deferred saves; this job must ask for it.
+func TestPrewarmPreviewBuildSnapshot_ArchivesModuleCacheAfterBuild(t *testing.T) {
+	t.Parallel()
+
+	var mu sync.Mutex
+	var order []string
+	record := func(event string) {
+		mu.Lock()
+		defer mu.Unlock()
+		order = append(order, event)
+	}
+	exec := &fakeServiceExecutor{
+		execStreamFn: func(_ context.Context, cmd string, _ func([]byte)) (int, error) {
+			switch {
+			case strings.Contains(cmd, "cmd/web"):
+				record("build")
+			case strings.Contains(cmd, "'npm' 'ci'"):
+				record("install")
+			}
+			return 0, nil
+		},
+		execFn: func(_ context.Context, _ string) (int, error) { return 0, nil },
+		readFileFn: func(_ context.Context, path string) ([]byte, error) {
+			if strings.Contains(path, ".143/cache/preview-install/") {
+				// No marker: install must actually run, which is what makes the
+				// package-manager cache save reachable.
+				return nil, os.ErrNotExist
+			}
+			if path == "package-lock.json" {
+				return []byte(`{"lockfileVersion":3}`), nil
+			}
+			return []byte("ok"), nil
+		},
+	}
+	cache := &fakeDependencyCache{}
+	cache.saveHook = func(kind models.PreviewCacheKind) { record("save:" + string(kind)) }
+	d := NewDockerPreviewProvider(previewReachableClient(), exec, zerolog.Nop(), WithPreviewDialer(successfulPreviewDialer), WithDependencyCache(cache))
+
+	err := d.PrewarmPreviewBuildSnapshot(context.Background(), &agent.Sandbox{ID: "prewarm", WorkDir: "/workspace/repo", HomeDir: "/home/codex"}, goBuildPreviewConfig(), preview.StartPreviewOptions{
+		OrgID:        uuid.New(),
+		RepositoryID: uuid.New(),
+		SessionID:    uuid.New(),
+	}, nil)
+	require.NoError(t, err, "build-snapshot prewarm should succeed")
+
+	mu.Lock()
+	observed := append([]string(nil), order...)
+	mu.Unlock()
+	buildIdx := slices.Index(observed, "build")
+	saveIdx := slices.Index(observed, "save:"+string(models.PreviewCacheKindPackageManager))
+	require.GreaterOrEqual(t, buildIdx, 0, "the service build should run: %v", observed)
+	require.GreaterOrEqual(t, saveIdx, 0, "the package-manager cache should be archived: %v", observed)
+	require.Greater(t, saveIdx, buildIdx, "the module cache must be archived after the build that fills it: %v", observed)
+}
+
+// goBuildPreviewConfigWithoutPackageManagerCache is goBuildPreviewConfig with
+// the package-manager lifecycle switched off, which is what makes the home build
+// cache own go/pkg/mod in addition to .cache/go-build. Use it for assertions
+// about the home set's contents; use goBuildPreviewConfig for the default
+// ownership split.
+func goBuildPreviewConfigWithoutPackageManagerCache() *models.PreviewConfig {
+	cfg := goBuildPreviewConfig()
+	packageManagerDisabled := false
+	cfg.Install.Cache = &models.PreviewInstallCacheConfig{
+		PackageManager: &models.PreviewPackageManagerCacheConfig{Enabled: &packageManagerDisabled},
+	}
+	return cfg
 }
 
 // TestStartPreview_BuildPhaseInjectsPlatformEnv verifies the platform context
@@ -4186,7 +4353,7 @@ func TestStartPreview_BuildPhaseRunsBeforeStartAndSavesHomeCache(t *testing.T) {
 	d := NewDockerPreviewProvider(previewReachableClient(), exec, zerolog.Nop(), WithPreviewDialer(successfulPreviewDialer), WithDependencyCache(cache))
 	obs := &recordingObserver{}
 
-	handle, err := d.StartPreview(context.Background(), &agent.Sandbox{ID: "sb", WorkDir: "/workspace/repo", HomeDir: "/home/codex"}, goBuildPreviewConfig(), preview.StartPreviewOptions{
+	handle, err := d.StartPreview(context.Background(), &agent.Sandbox{ID: "sb", WorkDir: "/workspace/repo", HomeDir: "/home/codex"}, goBuildPreviewConfigWithoutPackageManagerCache(), preview.StartPreviewOptions{
 		OrgID:        uuid.New(),
 		RepositoryID: uuid.New(),
 		SessionID:    uuid.New(),

--- a/internal/services/preview/providers/docker_preview_test.go
+++ b/internal/services/preview/providers/docker_preview_test.go
@@ -2097,9 +2097,10 @@ func TestStartPreview_ValidRetainedInstallSkipsRemoteCacheRestore(t *testing.T) 
 	obs := &recordingObserver{}
 
 	handle, err := d.StartPreview(context.Background(), &agent.Sandbox{ID: "sb", WorkDir: "/workspace/repo"}, previewInstallTestConfig(), preview.StartPreviewOptions{
-		OrgID:        uuid.New(),
-		RepositoryID: uuid.New(),
-		SessionID:    uuid.New(),
+		OrgID:           uuid.New(),
+		RepositoryID:    uuid.New(),
+		SessionID:       uuid.New(),
+		RetainedSandbox: true,
 	}, obs)
 	require.NoError(t, err, "StartPreview should reuse an already valid retained install")
 	require.NotNil(t, handle, "StartPreview should return a handle")
@@ -2129,6 +2130,57 @@ func TestStartPreview_ValidRetainedInstallSkipsRemoteCacheRestore(t *testing.T) 
 
 	close(release)
 	require.NoError(t, d.StopPreview(context.Background(), handle.Handle), "StopPreview should clean up the started preview")
+}
+
+// TestStartPreview_WorkdirSnapshotStillRestoresHomeCache guards the boundary
+// between startup snapshots and retained sandboxes. A startup snapshot carries
+// the install marker and dependency outputs from WorkDir, but it does not carry
+// HomeDir. The valid marker may skip preview.install and the dependency-output
+// restore, but it must not suppress a package-manager cache restore needed by a
+// subsequent service build.
+func TestStartPreview_WorkdirSnapshotStillRestoresHomeCache(t *testing.T) {
+	t.Parallel()
+
+	release := make(chan struct{})
+	var releaseOnce sync.Once
+	t.Cleanup(func() { releaseOnce.Do(func() { close(release) }) })
+	exec := previewInstallValidMarkerExecutor(nil)
+	exec.execStreamFn = func(ctx context.Context, _ string, _ func([]byte)) (int, error) {
+		select {
+		case <-release:
+		case <-ctx.Done():
+		}
+		return 0, nil
+	}
+	packageManagerID := uuid.New()
+	cache := &fakeDependencyCache{pmFindHit: &preview.DependencyCacheHit{Entry: models.PreviewDependencyCache{
+		ID: packageManagerID, CacheKind: models.PreviewCacheKindPackageManager,
+	}}}
+	d := NewDockerPreviewProvider(previewReachableClient(), exec, zerolog.Nop(), WithPreviewDialer(successfulPreviewDialer), WithDependencyCache(cache))
+	obs := &recordingObserver{}
+
+	handle, err := d.StartPreview(context.Background(), &agent.Sandbox{ID: "snapshot", WorkDir: "/workspace/repo", HomeDir: "/home/codex"}, previewInstallTestConfig(), preview.StartPreviewOptions{
+		OrgID:        uuid.New(),
+		RepositoryID: uuid.New(),
+		SessionID:    uuid.New(),
+	}, obs)
+	require.NoError(t, err, "snapshot-backed preview should start from valid WorkDir install outputs")
+	require.NotNil(t, handle, "snapshot-backed preview should return a handle")
+
+	finds, restores, _, roots, _ := cache.pathCounts()
+	require.Equal(t, 1, finds[models.PreviewCacheKindPackageManager], "fresh snapshot sandbox should look up the HomeDir package-manager cache")
+	require.Equal(t, 1, restores[models.PreviewCacheKindPackageManager], "fresh snapshot sandbox should restore the HomeDir package-manager cache")
+	require.Contains(t, roots, models.PreviewCacheRootHomeDir, "package-manager archive should extract into HomeDir")
+	require.Zero(t, finds[models.PreviewCacheKindInstallOutput], "valid WorkDir snapshot should not synchronously look up the dependency-output cache")
+	dependencyRestores := obs.dependencyCacheRestores()
+	require.Len(t, dependencyRestores, 1, "dependency restore lifecycle should report one result")
+	require.Equal(t, "skipped_install_valid", dependencyRestores[0].status, "valid snapshot outputs should explain why dependency extraction was skipped")
+	packageManagerRestores := obs.packageManagerCacheRestores()
+	require.Len(t, packageManagerRestores, 1, "HomeDir restore lifecycle should report one result")
+	require.Equal(t, "restored", packageManagerRestores[0].status, "HomeDir package-manager cache should be restored")
+
+	releaseOnce.Do(func() { close(release) })
+	require.NoError(t, d.StopPreview(context.Background(), handle.Handle), "snapshot-backed preview should stop cleanly")
 }
 
 func TestStartPreview_DependencyCacheRestoreSkippedWhenInstallMarkerMissing(t *testing.T) {
@@ -3049,6 +3101,130 @@ func TestPrewarmPreviewInstallCaches_SavesEvenWhenSandboxInstallIsValid(t *testi
 	require.NotEmpty(t, restoresObserved, "prewarm should still run the normal restore lifecycle")
 	for _, restore := range restoresObserved {
 		require.NotEqual(t, "skipped_install_valid", restore.status, "prewarm must never take the launch path's skip")
+	}
+}
+
+// TestStopPreview_WaitsForDeferredInstallCacheSave pins the reason the deferred
+// saves are registered on state.wg. They are started after readiness, so a stop
+// arriving moments later — a prewarm stops the instant the preview is ready —
+// would otherwise destroy the sandbox out from under an archive that is still
+// reading from it, and the cache the run existed to produce would be lost.
+func TestStopPreview_WaitsForDeferredInstallCacheSave(t *testing.T) {
+	t.Parallel()
+
+	release := make(chan struct{})
+	var releaseOnce sync.Once
+	t.Cleanup(func() { releaseOnce.Do(func() { close(release) }) })
+	exec := &fakeServiceExecutor{
+		execStreamFn: func(ctx context.Context, cmd string, _ func([]byte)) (int, error) {
+			if strings.Contains(cmd, "'npm' 'ci'") {
+				return 0, nil
+			}
+			select {
+			case <-release:
+			case <-ctx.Done():
+			}
+			return 0, nil
+		},
+		execFn: func(_ context.Context, _ string) (int, error) { return 0, nil },
+		readFileFn: func(_ context.Context, path string) ([]byte, error) {
+			if strings.Contains(path, ".143/cache/preview-install/") {
+				// Cold: install runs, so its archive is deferred past readiness.
+				return nil, os.ErrNotExist
+			}
+			if path == "package-lock.json" {
+				return []byte(`{"lockfileVersion":3}`), nil
+			}
+			return []byte("ok"), nil
+		},
+	}
+	saveRunning := make(chan struct{})
+	var saveRunningOnce sync.Once
+	releaseSave := make(chan struct{})
+	var releaseSaveOnce sync.Once
+	t.Cleanup(func() { releaseSaveOnce.Do(func() { close(releaseSave) }) })
+	cache := &fakeDependencyCache{}
+	cache.saveHook = func(kind models.PreviewCacheKind) {
+		if kind != models.PreviewCacheKindInstallOutput {
+			return
+		}
+		saveRunningOnce.Do(func() { close(saveRunning) })
+		<-releaseSave
+	}
+	d := NewDockerPreviewProvider(previewReachableClient(), exec, zerolog.Nop(), WithPreviewDialer(successfulPreviewDialer), WithDependencyCache(cache))
+
+	handle, err := d.StartPreview(context.Background(), &agent.Sandbox{ID: "sb", WorkDir: "/workspace/repo"}, previewInstallTestConfig(), preview.StartPreviewOptions{
+		OrgID:        uuid.New(),
+		RepositoryID: uuid.New(),
+		SessionID:    uuid.New(),
+	}, nil)
+	require.NoError(t, err, "StartPreview should succeed")
+	require.NotNil(t, handle, "StartPreview should return a handle")
+
+	select {
+	case <-saveRunning:
+	case <-time.After(10 * time.Second):
+		require.Fail(t, "the install-output archive should start once readiness releases the deferred saves")
+	}
+
+	stopDone := make(chan error, 1)
+	go func() { stopDone <- d.StopPreview(context.Background(), handle.Handle) }()
+	select {
+	case <-stopDone:
+		require.Fail(t, "StopPreview must not return while a deferred install-output archive is still reading the sandbox")
+	case <-time.After(200 * time.Millisecond):
+	}
+
+	releaseSaveOnce.Do(func() { close(releaseSave) })
+	select {
+	case stopErr := <-stopDone:
+		require.NoError(t, stopErr, "StopPreview should succeed once the archive finishes")
+	case <-time.After(10 * time.Second):
+		require.Fail(t, "StopPreview should return once the deferred archive completes")
+	}
+	_, _, saves, _ := cache.counts()
+	require.Equal(t, 1, saves, "the deferred install-output archive should have completed before teardown")
+}
+
+// TestPrewarmPreviewInstallCaches_AlreadyValidInstallRecordsNoRestoreBenefit
+// guards the benefit attribution on the one path that still reaches the
+// "install cache hit" branch with the contract already satisfied before any
+// restore ran. Prewarm does not take the launch path's early return, so a
+// restore can succeed there without having caused anything: the sandbox was
+// already valid. Crediting it with its cold baseline would inflate the marginal
+// benefit that cost-aware admission compares against restore cost, which is the
+// signal deciding whether this cache gets restored at all.
+func TestPrewarmPreviewInstallCaches_AlreadyValidInstallRecordsNoRestoreBenefit(t *testing.T) {
+	t.Parallel()
+
+	dependencyID := uuid.New()
+	packageManagerID := uuid.New()
+	exec := previewInstallValidMarkerExecutor(nil)
+	cache := &fakeDependencyCache{
+		findHit: &preview.DependencyCacheHit{Entry: models.PreviewDependencyCache{
+			ID: dependencyID, SizeBytes: 123, ProducerDurationMS: 90_000,
+		}},
+		pmFindHit: &preview.DependencyCacheHit{Entry: models.PreviewDependencyCache{
+			ID: packageManagerID, CacheKind: models.PreviewCacheKindPackageManager, ProducerDurationMS: 90_000,
+		}},
+	}
+	d := NewDockerPreviewProvider(previewReachableClient(), exec, zerolog.Nop(), WithPreviewDialer(successfulPreviewDialer), WithDependencyCache(cache))
+
+	err := d.PrewarmPreviewInstallCaches(context.Background(), &agent.Sandbox{ID: "prewarm", WorkDir: "/workspace/repo"}, previewInstallTestConfig(), preview.StartPreviewOptions{
+		OrgID:        uuid.New(),
+		RepositoryID: uuid.New(),
+		SessionID:    uuid.New(),
+	}, nil)
+	require.NoError(t, err, "prewarm should succeed against an already-installed workspace")
+
+	cache.mu.Lock()
+	benefits := append([]time.Duration(nil), cache.producerBenefits...)
+	benefitIDs := append([]uuid.UUID(nil), cache.producerBenefitIDs...)
+	cache.mu.Unlock()
+	require.ElementsMatch(t, []uuid.UUID{dependencyID, packageManagerID}, benefitIDs,
+		"both restores should record an observation so their cost history stays honest")
+	for i, benefit := range benefits {
+		require.Zero(t, benefit, "restore %d cannot claim benefit for a skip it did not cause", i)
 	}
 }
 

--- a/internal/services/preview/providers/docker_preview_test.go
+++ b/internal/services/preview/providers/docker_preview_test.go
@@ -797,6 +797,12 @@ func (r *recordingObserver) output() []recordedOutput {
 	return append([]recordedOutput(nil), r.outputCalls...)
 }
 
+func (r *recordingObserver) serviceFailures() []recordedFailed {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return append([]recordedFailed(nil), r.failedCalls...)
+}
+
 func (r *recordingObserver) dependencyCacheRestores() []recordedCacheEvent {
 	r.mu.Lock()
 	defer r.mu.Unlock()
@@ -2050,7 +2056,7 @@ func TestSoftRestartPreview_CancelsReplacementServicesOnReadinessFailure(t *test
 	}
 }
 
-func TestStartPreview_DependencyCacheHitRestoresBeforeMarkerValidation(t *testing.T) {
+func TestStartPreview_ValidRetainedInstallSkipsRemoteCacheRestore(t *testing.T) {
 	t.Parallel()
 
 	release := make(chan struct{})
@@ -2088,25 +2094,31 @@ func TestStartPreview_DependencyCacheHitRestoresBeforeMarkerValidation(t *testin
 		RepositoryID: uuid.New(),
 		SessionID:    uuid.New(),
 	}, obs)
-	require.NoError(t, err, "StartPreview should continue after dependency cache restore")
+	require.NoError(t, err, "StartPreview should reuse an already valid retained install")
 	require.NotNil(t, handle, "StartPreview should return a handle")
 
+	// The readiness-critical path performs no lookup at all. A single existence
+	// probe runs behind readiness so an evicted entry can still be healed; it
+	// finds this entry present and archives nothing.
+	require.Eventually(t, func() bool {
+		finds, _, _, _ := cache.counts()
+		return finds == 1
+	}, 5*time.Second, 10*time.Millisecond, "the deferred repopulation probe should look the key up exactly once")
 	finds, restores, saves, _ := cache.counts()
-	require.Equal(t, 1, finds, "dependency cache should be looked up once")
-	require.Equal(t, 1, restores, "dependency cache hit should restore before marker validation")
-	require.Equal(t, 0, saves, "a blob restored this launch must not be re-archived under the same key")
+	require.Equal(t, 1, finds, "a valid retained install should only look the key up behind readiness")
+	require.Equal(t, 0, restores, "a valid retained install should avoid archive extraction")
+	require.Equal(t, 0, saves, "an entry that already exists must not be re-archived")
 	restoresObserved := obs.dependencyCacheRestores()
 	require.Len(t, restoresObserved, 1, "observer should receive one restore event")
-	require.Equal(t, "restored", restoresObserved[0].status, "observer should report a restored cache hit")
+	require.Equal(t, "skipped_install_valid", restoresObserved[0].status, "observer should explain that the retained install made restore unnecessary")
 	savesObserved := obs.dependencyCacheSaves()
-	require.Len(t, savesObserved, 1, "observer should receive one save event")
-	require.Equal(t, "skipped_fresh_restore", savesObserved[0].status, "observer should explain why the save was skipped")
+	require.Empty(t, savesObserved, "no remote restore means there is no cache save lifecycle to report")
 
 	mu.Lock()
 	calls := append([]string(nil), streamCalls...)
 	mu.Unlock()
 	require.Len(t, calls, 1, "valid marker after restore should skip preview.install and only start service")
-	require.NotContains(t, calls[0], "'npm' 'ci'", "preview.install should be skipped after restored cache satisfies marker validation")
+	require.NotContains(t, calls[0], "'npm' 'ci'", "preview.install should be skipped when retained outputs already satisfy marker validation")
 
 	close(release)
 	require.NoError(t, d.StopPreview(context.Background(), handle.Handle), "StopPreview should clean up the started preview")
@@ -2229,7 +2241,16 @@ func TestStartPreview_ColdStartRestoreSatisfiesVerifyPaths(t *testing.T) {
 			}
 		},
 	}
-	cache := &fakeDependencyCache{findHit: &preview.DependencyCacheHit{Entry: models.PreviewDependencyCache{SizeBytes: 123}}}
+	dependencyID := uuid.New()
+	packageManagerID := uuid.New()
+	cache := &fakeDependencyCache{
+		findHit: &preview.DependencyCacheHit{Entry: models.PreviewDependencyCache{
+			ID: dependencyID, SizeBytes: 123, ProducerDurationMS: 100_000,
+		}},
+		pmFindHit: &preview.DependencyCacheHit{Entry: models.PreviewDependencyCache{
+			ID: packageManagerID, CacheKind: models.PreviewCacheKindPackageManager, ProducerDurationMS: 100_000,
+		}},
+	}
 	d := NewDockerPreviewProvider(previewReachableClient(), exec, zerolog.Nop(), WithPreviewDialer(successfulPreviewDialer), WithDependencyCache(cache))
 	obs := &recordingObserver{}
 
@@ -2251,6 +2272,12 @@ func TestStartPreview_ColdStartRestoreSatisfiesVerifyPaths(t *testing.T) {
 	savesObserved := obs.dependencyCacheSaves()
 	require.Len(t, savesObserved, 1, "observer should receive one save event")
 	require.Equal(t, "skipped_fresh_restore", savesObserved[0].status, "observer should explain why the save was skipped")
+	cache.mu.Lock()
+	benefits := append([]time.Duration(nil), cache.producerBenefits...)
+	benefitIDs := append([]uuid.UUID(nil), cache.producerBenefitIDs...)
+	cache.mu.Unlock()
+	require.Equal(t, []uuid.UUID{dependencyID, packageManagerID}, benefitIDs, "only the dependency restore should receive causal credit for satisfying install outputs")
+	require.Equal(t, []time.Duration{100 * time.Second, 0}, benefits, "package-manager restore should record zero benefit when no install command ran")
 
 	mu.Lock()
 	calls := append([]string(nil), streamCalls...)
@@ -2642,7 +2669,7 @@ func TestStartPreview_InstallOutputStreamsToObserver(t *testing.T) {
 	require.NoError(t, d.StopPreview(context.Background(), handle.Handle), "StopPreview should clean up the started preview")
 }
 
-func TestStartPreview_DependencyCacheRestoreFailureForcesInstallDespiteMarker(t *testing.T) {
+func TestStartPreview_ValidInstallAvoidsMutatingDependencyRestoreFailure(t *testing.T) {
 	t.Parallel()
 
 	release := make(chan struct{})
@@ -2696,18 +2723,23 @@ func TestStartPreview_DependencyCacheRestoreFailureForcesInstallDespiteMarker(t 
 		RepositoryID: uuid.New(),
 		SessionID:    uuid.New(),
 	}, obs)
-	require.NoError(t, err, "StartPreview should continue cold after dependency cache restore failure")
+	require.NoError(t, err, "StartPreview should reuse valid retained outputs without attempting a remote restore")
 	require.NotNil(t, handle, "StartPreview should return a handle")
 
 	mu.Lock()
 	calls := append([]string(nil), streamCalls...)
 	mu.Unlock()
-	require.Len(t, calls, 2, "restore failure should force preview.install before starting service")
-	require.Contains(t, calls[0], "'npm' 'ci'", "preview.install should run even when the marker appears valid after restore failure")
-	require.Contains(t, calls[1], "'npm' 'run' 'dev'", "service should start after forced install succeeds")
+	require.Len(t, calls, 1, "valid retained outputs should skip both restore and preview.install")
+	require.Contains(t, calls[0], "'npm' 'run' 'dev'", "service should start directly from retained install outputs")
 	restoresObserved := obs.dependencyCacheRestores()
 	require.Len(t, restoresObserved, 1, "observer should receive one restore event")
-	require.Equal(t, "restore_failed", restoresObserved[0].status, "observer should report the restore failure")
+	require.Equal(t, "skipped_install_valid", restoresObserved[0].status, "observer should report why the risky restore was not attempted")
+	// The deferred repopulation probe may look the key up behind readiness, but
+	// it must never reach the mutating restore that this test is about.
+	require.Never(t, func() bool {
+		_, restores, _, _ := cache.counts()
+		return restores > 0
+	}, 250*time.Millisecond, 10*time.Millisecond, "valid retained outputs should never trigger dependency-cache extraction")
 
 	close(release)
 	require.NoError(t, d.StopPreview(context.Background(), handle.Handle), "StopPreview should clean up the started preview")
@@ -2955,6 +2987,114 @@ func previewInstallTestConfig() *models.PreviewConfig {
 			"web": {Command: []string{"npm", "run", "dev"}, Port: 3000, Ready: models.ReadinessProbe{HTTPPath: "/"}},
 		},
 	}
+}
+
+// previewInstallValidMarkerExecutor is a sandbox whose workspace already
+// satisfies the exact install marker and the declared verify_paths — the shape
+// of a retained preview sandbox, or of a prewarm sandbox cloned/hydrated from a
+// workspace that already installed.
+func previewInstallValidMarkerExecutor(onStream func(cmd string)) *fakeServiceExecutor {
+	return &fakeServiceExecutor{
+		execStreamFn: func(_ context.Context, cmd string, _ func([]byte)) (int, error) {
+			if onStream != nil {
+				onStream(cmd)
+			}
+			return 0, nil
+		},
+		execFn: func(_ context.Context, _ string) (int, error) { return 0, nil },
+		readFileFn: func(_ context.Context, path string) ([]byte, error) {
+			if path == "package-lock.json" {
+				return []byte(`{"lockfileVersion":3}`), nil
+			}
+			return []byte("ok"), nil
+		},
+	}
+}
+
+// TestPrewarmPreviewInstallCaches_SavesEvenWhenSandboxInstallIsValid pins the
+// one thing the prewarm job exists to do. Its sandbox is cloned or hydrated
+// from a workspace that may already have installed, so it routinely arrives
+// with a valid install marker. Taking the launch path's "already valid, skip
+// everything" shortcut there would make the job report success while producing
+// no cache at all — and the runner only schedules the job when the remote entry
+// is missing, i.e. exactly when there is work to do.
+func TestPrewarmPreviewInstallCaches_SavesEvenWhenSandboxInstallIsValid(t *testing.T) {
+	t.Parallel()
+
+	exec := previewInstallValidMarkerExecutor(nil)
+	cache := &fakeDependencyCache{}
+	d := NewDockerPreviewProvider(previewReachableClient(), exec, zerolog.Nop(), WithPreviewDialer(successfulPreviewDialer), WithDependencyCache(cache))
+	obs := &recordingObserver{}
+
+	err := d.PrewarmPreviewInstallCaches(context.Background(), &agent.Sandbox{ID: "prewarm", WorkDir: "/workspace/repo"}, previewInstallTestConfig(), preview.StartPreviewOptions{
+		OrgID:        uuid.New(),
+		RepositoryID: uuid.New(),
+		SessionID:    uuid.New(),
+	}, obs)
+	require.NoError(t, err, "prewarm should succeed against an already-installed workspace")
+
+	_, _, saves, _ := cache.counts()
+	require.Equal(t, 1, saves, "prewarm must archive the install output rather than reporting success for nothing")
+	savesObserved := obs.dependencyCacheSaves()
+	require.Len(t, savesObserved, 1, "prewarm should report the save it performed")
+	require.Equal(t, "saved", savesObserved[0].status, "prewarm should report a completed save")
+	restoresObserved := obs.dependencyCacheRestores()
+	require.NotEmpty(t, restoresObserved, "prewarm should still run the normal restore lifecycle")
+	for _, restore := range restoresObserved {
+		require.NotEqual(t, "skipped_install_valid", restore.status, "prewarm must never take the launch path's skip")
+	}
+}
+
+// TestStartPreview_ValidRetainedInstallRepopulatesMissingCache covers the other
+// half of the skip: a launch that runs neither a restore nor an install is the
+// only thing that would ever notice the remote entry backing its marker has
+// been evicted. Without a repopulation behind readiness, that entry could only
+// come back via an unrelated cold sandbox.
+func TestStartPreview_ValidRetainedInstallRepopulatesMissingCache(t *testing.T) {
+	t.Parallel()
+
+	release := make(chan struct{})
+	var mu sync.Mutex
+	var streamCalls []string
+	exec := previewInstallValidMarkerExecutor(nil)
+	exec.execStreamFn = func(ctx context.Context, cmd string, _ func([]byte)) (int, error) {
+		mu.Lock()
+		streamCalls = append(streamCalls, cmd)
+		mu.Unlock()
+		select {
+		case <-release:
+		case <-ctx.Done():
+		}
+		return 0, nil
+	}
+	// findHit nil: the marker is valid but nothing backs it remotely.
+	cache := &fakeDependencyCache{}
+	d := NewDockerPreviewProvider(previewReachableClient(), exec, zerolog.Nop(), WithPreviewDialer(successfulPreviewDialer), WithDependencyCache(cache))
+	obs := &recordingObserver{}
+
+	handle, err := d.StartPreview(context.Background(), &agent.Sandbox{ID: "sb", WorkDir: "/workspace/repo"}, previewInstallTestConfig(), preview.StartPreviewOptions{
+		OrgID:        uuid.New(),
+		RepositoryID: uuid.New(),
+		SessionID:    uuid.New(),
+	}, obs)
+	require.NoError(t, err, "StartPreview should reuse the valid retained install")
+	require.NotNil(t, handle, "StartPreview should return a handle")
+
+	mu.Lock()
+	calls := append([]string(nil), streamCalls...)
+	mu.Unlock()
+	require.Len(t, calls, 1, "the fast path should skip preview.install and only start the service")
+	require.NotContains(t, calls[0], "'npm' 'ci'", "preview.install should stay skipped")
+
+	require.Eventually(t, func() bool {
+		_, _, saves, _ := cache.counts()
+		return saves == 1
+	}, 5*time.Second, 10*time.Millisecond, "a missing entry behind a valid marker should be repopulated behind readiness")
+	_, restores, _, _ := cache.counts()
+	require.Zero(t, restores, "repopulation must not extract anything into the sandbox")
+
+	close(release)
+	require.NoError(t, d.StopPreview(context.Background(), handle.Handle), "StopPreview should clean up the started preview")
 }
 
 // TestStartPreview_ProgressiveMode_NotifiesObserver covers Phase 6's
@@ -3691,11 +3831,235 @@ func TestPreviewServiceBuildOrder(t *testing.T) {
 		"absent primary should not be appended")
 }
 
+func TestDockerPreviewProvider_RunServiceBuildsConcurrency(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name             string
+		parallel         bool
+		secondStartsSoon bool
+	}{
+		{name: "sequential by default", parallel: false, secondStartsSoon: false},
+		{name: "parallel when explicitly enabled", parallel: true, secondStartsSoon: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			started := make(chan string, 2)
+			release := make(chan struct{})
+			var releaseOnce sync.Once
+			t.Cleanup(func() { releaseOnce.Do(func() { close(release) }) })
+			exec := &fakeServiceExecutor{execStreamFn: func(ctx context.Context, cmd string, _ func([]byte)) (int, error) {
+				started <- cmd
+				select {
+				case <-release:
+					return 0, nil
+				case <-ctx.Done():
+					return -1, ctx.Err()
+				}
+			}}
+			provider := &DockerPreviewProvider{executor: exec, logger: zerolog.Nop()}
+			cfg := &models.PreviewConfig{
+				Primary:        "web",
+				ParallelBuilds: tt.parallel,
+				Services: map[string]models.ServiceConfig{
+					"api": {Build: []string{"build-api"}},
+					"web": {Build: []string{"build-web"}},
+				},
+			}
+			done := make(chan error, 1)
+			go func() {
+				done <- provider.runServiceBuilds(context.Background(), &previewState{sandbox: &agent.Sandbox{}}, cfg, preview.StartPreviewOptions{OrgID: uuid.New()}, nil)
+			}()
+
+			first := <-started
+			require.NotEmpty(t, first, "the first configured build should start")
+			if tt.secondStartsSoon {
+				// Both builds are blocked on `release`, so the second start can
+				// only be waiting on goroutine scheduling. Wait generously: the
+				// timeout is the failure path here, not the assertion, so a
+				// loaded machine cannot turn a correct run into a failure.
+				select {
+				case second := <-started:
+					require.NotEqual(t, first, second, "parallel execution should start both distinct build commands")
+				case <-time.After(10 * time.Second):
+					require.Fail(t, "parallel execution should start both builds before either finishes")
+				}
+			} else {
+				// The negative direction cannot be made timing-free, but it is
+				// safe: the first build never returns until `release` closes, so
+				// a slow machine only ever makes this assertion more true.
+				select {
+				case second := <-started:
+					require.Fail(t, "a second build must wait until the first finishes unless parallel_builds is enabled", "unexpected concurrent build %q", second)
+				case <-time.After(250 * time.Millisecond):
+				}
+			}
+
+			releaseOnce.Do(func() { close(release) })
+			require.NoError(t, <-done, "all service builds should finish after their shared test gate is released")
+		})
+	}
+}
+
+func TestDockerPreviewProvider_ParallelBuildFailureCancelsSiblings(t *testing.T) {
+	t.Parallel()
+
+	siblingCanceled := make(chan struct{})
+	exec := &fakeServiceExecutor{execStreamFn: func(ctx context.Context, cmd string, _ func([]byte)) (int, error) {
+		if strings.Contains(cmd, "build-api") {
+			return 1, nil
+		}
+		<-ctx.Done()
+		close(siblingCanceled)
+		return -1, ctx.Err()
+	}}
+	provider := &DockerPreviewProvider{executor: exec, logger: zerolog.Nop()}
+	cfg := &models.PreviewConfig{
+		Primary:        "web",
+		ParallelBuilds: true,
+		Services: map[string]models.ServiceConfig{
+			"api": {Build: []string{"build-api"}},
+			"web": {Build: []string{"build-web"}},
+		},
+	}
+
+	err := provider.runServiceBuilds(context.Background(), &previewState{sandbox: &agent.Sandbox{}}, cfg, preview.StartPreviewOptions{OrgID: uuid.New()}, nil)
+	require.Error(t, err, "a failed parallel build should fail the build phase")
+	require.Contains(t, err.Error(), `service "api" build`, "the causal build failure should win over sibling cancellation")
+	require.NotErrorIs(t, err, context.Canceled, "the causal build failure should win over sibling cancellation")
+	select {
+	case <-siblingCanceled:
+	default:
+		require.Fail(t, "a failed parallel build should cancel in-flight sibling builds")
+	}
+}
+
+// TestDockerPreviewProvider_ParallelBuildReportsCauseNotCancellationVictim
+// pins the hard case for error attribution: the failure comes from the primary
+// (last in build order) while the support service (first in build order) is
+// killed by the resulting cancellation and reports a plain non-zero exit code —
+// no wrapped context.Canceled to filter on. Reporting the victim would show the
+// user the wrong service name and the wrong output tail.
+func TestDockerPreviewProvider_ParallelBuildReportsCauseNotCancellationVictim(t *testing.T) {
+	t.Parallel()
+
+	supportRunning := make(chan struct{})
+	exec := &fakeServiceExecutor{execStreamFn: func(ctx context.Context, cmd string, onOut func([]byte)) (int, error) {
+		if strings.Contains(cmd, "build-api") {
+			close(supportRunning)
+			<-ctx.Done()
+			// A killed container process surfaces as an exit code, not as a
+			// context error, which is exactly why cancellation has to be
+			// tracked rather than sniffed out of the error.
+			onOut([]byte("api: killed"))
+			return 137, nil
+		}
+		<-supportRunning
+		onOut([]byte("web: undefined symbol"))
+		return 1, nil
+	}}
+	provider := &DockerPreviewProvider{executor: exec, logger: zerolog.Nop()}
+	cfg := &models.PreviewConfig{
+		Primary:        "web",
+		ParallelBuilds: true,
+		Services: map[string]models.ServiceConfig{
+			"api": {Build: []string{"build-api"}},
+			"web": {Build: []string{"build-web"}},
+		},
+	}
+	obs := &recordingObserver{}
+
+	err := provider.runServiceBuilds(context.Background(), &previewState{sandbox: &agent.Sandbox{}}, cfg, preview.StartPreviewOptions{OrgID: uuid.New()}, obs)
+	require.Error(t, err, "a failed parallel build should fail the build phase")
+	require.Contains(t, err.Error(), `service "web" build`, "the reported failure should be the build that actually failed")
+	require.NotContains(t, err.Error(), `service "api" build`, "a build killed by sibling cancellation must not be reported as the cause")
+
+	failures := obs.serviceFailures()
+	require.Len(t, failures, 1, "exactly one build failure should be reported")
+	require.Equal(t, "web", failures[0].name, "the observer should name the causal service")
+	require.Contains(t, strings.Join(failures[0].tail, "\n"), "undefined symbol", "the observer should carry the causal build's output tail")
+}
+
+func TestStartPreview_ExactWarmResumeSkipsServiceBuilds(t *testing.T) {
+	t.Parallel()
+
+	release := make(chan struct{})
+	var releaseOnce sync.Once
+	t.Cleanup(func() { releaseOnce.Do(func() { close(release) }) })
+	var mu sync.Mutex
+	buildCalls := 0
+	exec := &fakeServiceExecutor{
+		execStreamFn: func(ctx context.Context, cmd string, _ func([]byte)) (int, error) {
+			if strings.Contains(cmd, "build-preview") {
+				mu.Lock()
+				buildCalls++
+				mu.Unlock()
+				return 0, nil
+			}
+			select {
+			case <-release:
+				return 0, nil
+			case <-ctx.Done():
+				return -1, ctx.Err()
+			}
+		},
+		execFn: func(_ context.Context, _ string) (int, error) { return 0, nil },
+		readFileFn: func(_ context.Context, _ string) ([]byte, error) {
+			return []byte("ok\n"), nil
+		},
+	}
+	cache := &fakeDependencyCache{
+		buildFindHit: &preview.DependencyCacheHit{Entry: models.PreviewDependencyCache{CacheKind: models.PreviewCacheKindBuildOutput}},
+	}
+	provider := NewDockerPreviewProvider(previewReachableClient(), exec, zerolog.Nop(), WithPreviewDialer(successfulPreviewDialer), WithDependencyCache(cache))
+	cfg := &models.PreviewConfig{
+		Name:    "warm",
+		Primary: "web",
+		Install: &models.PreviewInstallConfig{
+			Command:   []string{"sh", "install.sh"},
+			Lockfiles: []string{"go.mod"},
+		},
+		Services: map[string]models.ServiceConfig{
+			"web": {
+				Build:   []string{"build-preview"},
+				Command: []string{"run-preview"},
+				Port:    3000,
+				Ready:   models.ReadinessProbe{HTTPPath: "/"},
+			},
+		},
+	}
+
+	handle, err := provider.StartPreview(context.Background(), &agent.Sandbox{ID: "warm-sandbox", WorkDir: "/workspace/repo"}, cfg, preview.StartPreviewOptions{
+		OrgID:            uuid.New(),
+		RepositoryID:     uuid.New(),
+		SessionID:        uuid.New(),
+		SkipServiceBuild: true,
+	}, nil)
+	require.NoError(t, err, "an exact-revision warm resume should start from its retained build output")
+	require.NotNil(t, handle, "warm resume should return a running preview handle")
+	mu.Lock()
+	require.Zero(t, buildCalls, "warm resume must not repeat service build commands")
+	mu.Unlock()
+	finds, restores, saves, _, _ := cache.pathCounts()
+	require.Zero(t, finds[models.PreviewCacheKindBuildOutput], "warm resume must not restore remote build caches over retained outputs")
+	require.Zero(t, restores[models.PreviewCacheKindBuildOutput], "warm resume must not extract remote build caches over retained outputs")
+	require.Zero(t, saves[models.PreviewCacheKindBuildOutput], "warm resume must not re-archive build caches it did not produce")
+
+	releaseOnce.Do(func() { close(release) })
+	require.NoError(t, provider.StopPreview(context.Background(), handle.Handle), "warm preview should stop cleanly")
+}
+
 // goBuildPreviewConfig is a Go service with a build step and a go.mod lockfile,
 // so the build phase runs and the home build cache (GOCACHE/GOMODCACHE) is
-// active. The install command is JS-only, so the home set owns go/pkg/mod and
-// install is a no-op cache hit in these tests.
+// active. The package-manager cache is disabled, which is what makes the home
+// set own go/pkg/mod as well as .cache/go-build: with that lifecycle active it
+// keeps the module cache, because only it restores before install. Install is a
+// no-op cache hit in these tests.
 func goBuildPreviewConfig() *models.PreviewConfig {
+	packageManagerDisabled := false
 	return &models.PreviewConfig{
 		Name:    "test-app",
 		Primary: "web",
@@ -3703,6 +4067,9 @@ func goBuildPreviewConfig() *models.PreviewConfig {
 			Command:     []string{"npm", "ci"},
 			Lockfiles:   []string{"package-lock.json", "go.mod"},
 			VerifyPaths: []string{"node_modules/.bin/next"},
+			Cache: &models.PreviewInstallCacheConfig{
+				PackageManager: &models.PreviewPackageManagerCacheConfig{Enabled: &packageManagerDisabled},
+			},
 		},
 		Services: map[string]models.ServiceConfig{
 			"web": {


### PR DESCRIPTION
## Summary

Warm preview resume could incorrectly attach to stale compiled output, causing reliability issues during restore/resume. This PR makes session/workspace claims atomic and revision-scoped, preserves the intended “skip redundant restore” behavior for explicitly sandboxes, and keeps snapshot-backed starts restoring `$HOME` package-manager caches. Together, this prevents stale cache artifacts from being resumed while maintaining warm-start performance.

## Changes

- **Atomic warm resume claims:** update `preview_store` to claim only the expected session and workspace revision, preventing stale compiled output from being resumed.
- **Correct restore/caching semantics:** ensure explicit sandboxes skip redundant restores while snapshot-backed flows still restore `$HOME` package-manager caches as before.
- **Regression coverage:** add tests covering both the warm-resume race and the docker/snapshot restore + caching behavior.

## Validation

- `go test ./...`
- Race tests for preview provider, preview service, and database packages
- `go vet ./...`
- `git diff --check`

[143.dev](https://143.dev) | [session 94699d1d](https://143.dev/sessions/94699d1d-92ff-4993-808c-db2e66078a0e)

<!-- 143-publication session=94699d1d-92ff-4993-808c-db2e66078a0e changeset=14c06326-cd27-48a1-be5c-9e7ec2432d8f -->

Preview: https://143.dev/previews/github/assembledhq/143/pull/2068?launch=1