### PR TITLE
Make dirty migration repair allowlisted and split hot-table constraint validation

### DIFF
--- a/cmd/migrate/main.go
+++ b/cmd/migrate/main.go
@@ -15,7 +15,10 @@ import (
 // migrateLogger implements migrate.Logger to surface verbose migration output.
 type migrateLogger struct{ verbose bool }
 
-const prReadinessDirtyMigrationVersion = 267
+const (
+	prReadinessDirtyMigrationVersion        = 267
+	codeReviewDisputesDirtyMigrationVersion = 281
+)
 
 type dirtyMigrationRepairer interface {
 	Version() (uint, bool, error)
@@ -35,7 +38,7 @@ func main() {
 	}
 
 	if len(os.Args) < 2 {
-		fmt.Println("Usage: migrate [up|down|repair-pr-readiness]")
+		fmt.Println("Usage: migrate [up|down|repair-known-dirty|repair-pr-readiness]")
 		os.Exit(1)
 	}
 
@@ -67,6 +70,17 @@ func main() {
 			os.Exit(1)
 		}
 		fmt.Println("Migrations rolled back successfully.")
+	case "repair-known-dirty":
+		version, repaired, err := repairKnownDirtyMigration(m)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Failed to repair known dirty migration state: %v\n", err)
+			os.Exit(1)
+		}
+		if repaired {
+			fmt.Printf("Repaired dirty migration %d; migrations can resume from %d.\n", version, version-1)
+		} else {
+			fmt.Println("Known dirty migration repair not needed.")
+		}
 	case "repair-pr-readiness":
 		repaired, err := repairPRReadinessDirtyMigration(m)
 		if err != nil {
@@ -81,6 +95,47 @@ func main() {
 	default:
 		fmt.Fprintf(os.Stderr, "Unknown command: %s\n", os.Args[1]) // #nosec G705 -- writing to stderr, not HTTP response
 		os.Exit(1)
+	}
+}
+
+// repairKnownDirtyMigration clears only dirty markers whose production failure
+// was observed and whose migration transaction was verified to have rolled back
+// completely. This is deliberately an exact allowlist rather than a general
+// force command: an unknown dirty version may have out-of-transaction effects
+// or require a data repair before it is safe to retry.
+func repairKnownDirtyMigration(m dirtyMigrationRepairer) (uint, bool, error) {
+	version, dirty, err := m.Version()
+	if err != nil {
+		if errors.Is(err, migrate.ErrNilVersion) {
+			return 0, false, nil
+		}
+		return 0, false, fmt.Errorf("read migration version: %w", err)
+	}
+	if !dirty {
+		return 0, false, nil
+	}
+
+	previousVersion, known := knownDirtyMigrationPreviousVersion(version)
+	if !known {
+		return 0, false, fmt.Errorf(
+			"database is dirty at version %d; refusing repair because only versions %d and %d are allowlisted",
+			version,
+			prReadinessDirtyMigrationVersion,
+			codeReviewDisputesDirtyMigrationVersion,
+		)
+	}
+	if err := m.Force(previousVersion); err != nil {
+		return 0, false, fmt.Errorf("force migration version to %d: %w", previousVersion, err)
+	}
+	return version, true, nil
+}
+
+func knownDirtyMigrationPreviousVersion(version uint) (int, bool) {
+	switch version {
+	case prReadinessDirtyMigrationVersion, codeReviewDisputesDirtyMigrationVersion:
+		return int(version) - 1, true
+	default:
+		return 0, false
 	}
 }
 

--- a/cmd/migrate/main_test.go
+++ b/cmd/migrate/main_test.go
@@ -31,12 +31,13 @@ func (f *fakeDirtyMigrationRepairer) Force(version int) error {
 	return f.forceErr
 }
 
-func TestRepairPRReadinessDirtyMigration(t *testing.T) {
+func TestRepairKnownDirtyMigration(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
 		name             string
 		repairer         fakeDirtyMigrationRepairer
+		expectedVersion  uint
 		expectedRepaired bool
 		expectedForce    int
 		expectForce      bool
@@ -45,17 +46,26 @@ func TestRepairPRReadinessDirtyMigration(t *testing.T) {
 		{
 			name:             "repairs exact dirty readiness migration",
 			repairer:         fakeDirtyMigrationRepairer{version: prReadinessDirtyMigrationVersion, dirty: true},
+			expectedVersion:  prReadinessDirtyMigrationVersion,
 			expectedRepaired: true,
 			expectedForce:    prReadinessDirtyMigrationVersion - 1,
 			expectForce:      true,
 		},
 		{
+			name:             "repairs exact dirty code review disputes migration",
+			repairer:         fakeDirtyMigrationRepairer{version: codeReviewDisputesDirtyMigrationVersion, dirty: true},
+			expectedVersion:  codeReviewDisputesDirtyMigrationVersion,
+			expectedRepaired: true,
+			expectedForce:    codeReviewDisputesDirtyMigrationVersion - 1,
+			expectForce:      true,
+		},
+		{
 			name:     "does nothing for clean database",
-			repairer: fakeDirtyMigrationRepairer{version: prReadinessDirtyMigrationVersion, dirty: false},
+			repairer: fakeDirtyMigrationRepairer{version: codeReviewDisputesDirtyMigrationVersion, dirty: false},
 		},
 		{
 			name:        "refuses unrelated dirty migration",
-			repairer:    fakeDirtyMigrationRepairer{version: prReadinessDirtyMigrationVersion + 1, dirty: true},
+			repairer:    fakeDirtyMigrationRepairer{version: codeReviewDisputesDirtyMigrationVersion + 1, dirty: true},
 			expectError: true,
 		},
 		{
@@ -69,9 +79,9 @@ func TestRepairPRReadinessDirtyMigration(t *testing.T) {
 		},
 		{
 			name:          "returns force failure",
-			repairer:      fakeDirtyMigrationRepairer{version: prReadinessDirtyMigrationVersion, dirty: true, forceErr: errors.New("force rejected")},
+			repairer:      fakeDirtyMigrationRepairer{version: codeReviewDisputesDirtyMigrationVersion, dirty: true, forceErr: errors.New("force rejected")},
 			expectForce:   true,
-			expectedForce: prReadinessDirtyMigrationVersion - 1,
+			expectedForce: codeReviewDisputesDirtyMigrationVersion - 1,
 			expectError:   true,
 		},
 	}
@@ -81,17 +91,56 @@ func TestRepairPRReadinessDirtyMigration(t *testing.T) {
 			t.Parallel()
 
 			repairer := tt.repairer
+			version, repaired, err := repairKnownDirtyMigration(&repairer)
+			if tt.expectError {
+				require.Error(t, err, "known migration repair should return the expected failure")
+			} else {
+				require.NoError(t, err, "known migration repair should complete without error")
+			}
+			require.Equal(t, tt.expectedVersion, version, "known migration repair should report the repaired version")
+			require.Equal(t, tt.expectedRepaired, repaired, "known migration repair should report whether it changed migration state")
+			require.Equal(t, tt.expectForce, repairer.forceInvoked, "known migration repair should only force an exact allowlisted dirty version")
+			if tt.expectForce {
+				require.Equal(t, tt.expectedForce, repairer.forcedTo, "known migration repair should rewind to the version before the failed transaction")
+			}
+		})
+	}
+}
+
+func TestRepairPRReadinessDirtyMigrationRemainsNarrow(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		version     uint
+		expectForce bool
+		expectError bool
+	}{
+		{
+			name:        "repairs readiness version",
+			version:     prReadinessDirtyMigrationVersion,
+			expectForce: true,
+		},
+		{
+			name:        "refuses code review disputes version",
+			version:     codeReviewDisputesDirtyMigrationVersion,
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			repairer := fakeDirtyMigrationRepairer{version: tt.version, dirty: true}
 			repaired, err := repairPRReadinessDirtyMigration(&repairer)
 			if tt.expectError {
-				require.Error(t, err, "targeted migration repair should return the expected failure")
+				require.Error(t, err, "legacy readiness repair should refuse a different dirty version")
 			} else {
-				require.NoError(t, err, "targeted migration repair should complete without error")
+				require.NoError(t, err, "legacy readiness repair should repair its exact dirty version")
 			}
-			require.Equal(t, tt.expectedRepaired, repaired, "targeted migration repair should report whether it changed migration state")
-			require.Equal(t, tt.expectForce, repairer.forceInvoked, "targeted migration repair should only force the exact known dirty version")
-			if tt.expectForce {
-				require.Equal(t, tt.expectedForce, repairer.forcedTo, "targeted migration repair should rewind to the version before readiness removal")
-			}
+			require.Equal(t, tt.expectForce, repairer.forceInvoked, "legacy readiness repair should remain scoped to version 267")
+			require.Equal(t, tt.expectForce, repaired, "legacy readiness repair should report only its own repair")
 		})
 	}
 }

--- a/deploy/deploy_config_test.go
+++ b/deploy/deploy_config_test.go
@@ -870,18 +870,18 @@ func TestRoutineWorkerDeployBuildsSandboxDNSOnlyWhenMissing(t *testing.T) {
 	}, "\n"), "routine worker deploy must not rebuild sandbox-dns unconditionally because that primes the next reconcile to recreate the sidecar")
 }
 
-func TestAppDeployRepairsKnownReadinessMigrationBeforeMigrating(t *testing.T) {
+func TestAppDeployRepairsKnownDirtyMigrationsBeforeMigrating(t *testing.T) {
 	t.Parallel()
 
 	deployScript, err := os.ReadFile("../deploy/scripts/deploy.sh")
 	require.NoError(t, err, "test should read deploy.sh")
 	deployText := string(deployScript)
-	repairCommand := `docker compose -f "$COMPOSE_FILE" run --rm -T --no-deps api /bin/migrate repair-pr-readiness < /dev/null`
+	repairCommand := `docker compose -f "$COMPOSE_FILE" run --rm -T --no-deps api /bin/migrate repair-known-dirty < /dev/null`
 	upCommand := `docker compose -f "$COMPOSE_FILE" run --rm -T --no-deps api /bin/migrate up < /dev/null`
 	repairIndex := strings.Index(deployText, repairCommand)
 	upIndex := strings.Index(deployText, upCommand)
 
-	require.NotEqual(t, -1, repairIndex, "app deploy should run the narrowly scoped readiness migration repair")
+	require.NotEqual(t, -1, repairIndex, "app deploy should run the allowlisted dirty migration repair")
 	require.NotEqual(t, -1, upIndex, "app deploy should still run normal migrations")
 	require.Less(t, repairIndex, upIndex, "app deploy should repair the known dirty marker before normal migrations")
 }

--- a/deploy/scripts/deploy.sh
+++ b/deploy/scripts/deploy.sh
@@ -2444,7 +2444,7 @@ SELECT COUNT(*) FROM endpoint_blockers;"
   # that the old schema doesn't have yet.
   if [ "$ROLE" = "app" ]; then
     echo "Running database migrations..."
-    docker compose -f "$COMPOSE_FILE" run --rm -T --no-deps api /bin/migrate repair-pr-readiness < /dev/null
+    docker compose -f "$COMPOSE_FILE" run --rm -T --no-deps api /bin/migrate repair-known-dirty < /dev/null
     docker compose -f "$COMPOSE_FILE" run --rm -T --no-deps api /bin/migrate up < /dev/null
   fi
 

--- a/docs/design/121-code-review-decision-feedback-and-policy-tuning.md
+++ b/docs/design/121-code-review-decision-feedback-and-policy-tuning.md
@@ -685,6 +685,14 @@ ALTER TABLE pull_requests
         CHECK (code_review_dispute_cycles_in_epoch >= 0);
 ```
 
+The production rollout installs the final `pull_requests` check constraint as
+`NOT VALID` in migration `000281`, then validates it in migration `000282`.
+This keeps the `ACCESS EXCLUSIVE` portion metadata-only and performs the table
+scan under PostgreSQL's weaker validation lock. The first `000281` production
+attempt timed out waiting for the hot table and rolled its transaction back;
+deploys therefore allowlist exactly dirty version 281 for rewind-and-retry via
+`migrate repair-known-dirty`.
+
 Versioned org/repository policy settings gain `stop_after_deterministic_failure` and
 the semantic-dedupe cooldown. They gain **no reassessment quotas** — no per-PR
 budget, no per-user rate, no per-org ceiling. The operator-wide hard ceiling and kill

--- a/docs/design/implemented/122-remove-pr-readiness.md
+++ b/docs/design/implemented/122-remove-pr-readiness.md
@@ -101,11 +101,12 @@ trigger remains installed between the two transactions.
 
 The failed production attempt left golang-migrate's separately committed dirty
 marker at version 267 even though PostgreSQL rolled back the migration
-transaction. App deploys therefore run `migrate repair-pr-readiness` before
-`migrate up`. That repair is intentionally narrow: it no-ops on clean databases,
-rewinds only an exactly dirty version 267 to 266, and refuses every other dirty
-version. Remove the repair command from the migrator and deploy script in the
-same follow-up that contracts the temporary rejection trigger.
+transaction. App deploys therefore run `migrate repair-known-dirty` before
+`migrate up`. That repair is intentionally narrow: it no-ops on clean databases
+and rewinds only explicitly allowlisted, transactionally rolled-back failures;
+version 267 rewinds to 266. Remove the version 267 allowlist entry (and the
+backward-compatible `repair-pr-readiness` command) in the same follow-up that
+contracts the temporary rejection trigger.
 
 Slack subscriptions that listed only `pr.readiness_attention` are pinned to the
 `custom` preset before the event is stripped. Without that, an emptied `events`

--- a/internal/db/migrations_test.go
+++ b/internal/db/migrations_test.go
@@ -37,13 +37,19 @@ func TestCodeReviewDisputesMigrationEnforcesTenantScopedParents(t *testing.T) {
 		require.Regexp(t, `CREATE UNIQUE INDEX IF NOT EXISTS \w+\n?\s+ON `+parent+` \(org_id, id\)`, sql,
 			"parent index builds should be idempotent so they can be pre-created CONCURRENTLY")
 	}
-	// golang-migrate runs this file as a single implicit transaction, so
-	// ADD CONSTRAINT ... NOT VALID plus VALIDATE would hold ACCESS EXCLUSIVE
-	// across both and buy nothing. Keep the honest single-statement form.
-	require.Contains(t, sql, "CHECK (code_review_dispute_cycles_in_epoch >= 0);",
-		"the loop-guard CHECK should be added and validated in one statement")
+	// Keep the ACCESS EXCLUSIVE portion metadata-only. Validation runs in the
+	// next migration under a weaker lock that does not block normal DML.
+	require.Contains(t, sql, "CHECK (code_review_dispute_cycles_in_epoch >= 0) NOT VALID;",
+		"the loop-guard CHECK should be installed without scanning the hot pull requests table")
 	require.NotContains(t, sql, "VALIDATE CONSTRAINT",
-		"a deferred CHECK validation cannot help inside a single-transaction migration")
+		"the expand migration should not validate while retaining its ACCESS EXCLUSIVE lock")
+
+	validationBody, err := os.ReadFile("../../migrations/000282_validate_code_review_dispute_cycles.up.sql")
+	require.NoError(t, err, "test should read the code review dispute cycle validation migration")
+	validationSQL := string(validationBody)
+	require.Contains(t, validationSQL,
+		"ALTER TABLE pull_requests\n    VALIDATE CONSTRAINT chk_pr_code_review_dispute_cycles;",
+		"the follow-up migration should validate the loop-guard CHECK under a weaker lock")
 
 	// The adjudication UI always filters to pending; a broader partial index
 	// would accumulate every resolved dispute in the hot path.

--- a/migrations/000281_code_review_decision_disputes.up.sql
+++ b/migrations/000281_code_review_decision_disputes.up.sql
@@ -8,9 +8,10 @@
 -- the composite foreign keys below will then fail with "no unique constraint
 -- matching given keys" -- drop the invalid index before rerunning.
 -- lock_timeout bounds how long each statement waits to ACQUIRE a lock. It does
--- not bound how long an acquired lock is held, so it makes this migration fail
--- fast against concurrent DDL rather than making the index builds cheap.
-SET LOCAL lock_timeout = '5s';
+-- not bound how long an acquired lock is held. Production traffic can keep a
+-- short-lived lock on pull_requests for more than five seconds, so allow a
+-- bounded rolling-deploy window instead of spuriously dirtying the migration.
+SET LOCAL lock_timeout = '30s';
 
 CREATE UNIQUE INDEX IF NOT EXISTS idx_sessions_org_id_id_for_code_review_disputes
     ON sessions (org_id, id);
@@ -238,15 +239,11 @@ ALTER TABLE code_review_session_metadata
         REFERENCES code_review_decision_disputes(org_id, id)
         ON DELETE SET NULL (triggering_dispute_id);
 
--- Adding the columns is metadata-only (non-volatile defaults), but validating
--- the CHECK scans every pull_requests row under ACCESS EXCLUSIVE.
--- ADD CONSTRAINT ... NOT VALID plus a separate VALIDATE would not help here:
--- golang-migrate's postgres driver executes this whole file as one statement,
--- so it runs in a single implicit transaction and the ACCESS EXCLUSIVE lock is
--- held until commit either way. Splitting the validation requires splitting the
--- migration, which is not worth it for a scan of a table this size.
+-- Keep the ACCESS EXCLUSIVE operation metadata-only. Migration 282 validates
+-- the CHECK in a separate transaction under PostgreSQL's weaker validation
+-- lock, which does not block ordinary reads and writes.
 ALTER TABLE pull_requests
     ADD COLUMN code_review_dispute_epoch bigint NOT NULL DEFAULT 0,
     ADD COLUMN code_review_dispute_cycles_in_epoch integer NOT NULL DEFAULT 0,
     ADD CONSTRAINT chk_pr_code_review_dispute_cycles
-        CHECK (code_review_dispute_cycles_in_epoch >= 0);
+        CHECK (code_review_dispute_cycles_in_epoch >= 0) NOT VALID;

--- a/migrations/000282_validate_code_review_dispute_cycles.down.sql
+++ b/migrations/000282_validate_code_review_dispute_cycles.down.sql
@@ -1,0 +1,3 @@
+-- PostgreSQL cannot mark a validated CHECK constraint NOT VALID again. The 281
+-- down migration removes the constraint together with its guarded columns.
+SELECT 1;

--- a/migrations/000282_validate_code_review_dispute_cycles.up.sql
+++ b/migrations/000282_validate_code_review_dispute_cycles.up.sql
@@ -1,0 +1,7 @@
+-- Validation takes SHARE UPDATE EXCLUSIVE rather than the ACCESS EXCLUSIVE lock
+-- used to add the constraint. Keeping it in a separate migration lets the hot
+-- pull_requests table continue serving ordinary reads and writes during its scan.
+SET LOCAL lock_timeout = '30s';
+
+ALTER TABLE pull_requests
+    VALIDATE CONSTRAINT chk_pr_code_review_dispute_cycles;


### PR DESCRIPTION
## Summary

- Add `repair-known-dirty` with an exact allowlist for migrations 267 and 281.
- Update app deploys to repair known dirty states before running migrations.
- Split code review dispute constraint validation into migration 282 to reduce hot-table locking.
- Add coverage for both repair paths and migration sequencing.

## Testing

- Added and updated focused Go tests for migration repair behavior, deploy ordering, and constraint validation.