### PR TITLE
Preserve durable publication checkpoints for safe PR branch reconciliation

### DIFF
--- a/internal/db/review_loops.go
+++ b/internal/db/review_loops.go
@@ -383,6 +383,7 @@ func (s *SessionReviewLoopStore) RefreshPublicationEvidence(ctx context.Context,
 		SET review_workspace_revision = @workspace_revision,
 			review_desired_head_sha = @desired_head_sha,
 			desired_head_sha = @desired_head_sha,
+			published_head_sha = @desired_head_sha,
 			updated_at = now()
 		WHERE org_id = @org_id AND review_loop_id = @loop_id
 		  AND state NOT IN ('completed', 'completed_noop', 'terminal_failed')`, pgx.NamedArgs{

--- a/internal/db/review_loops_test.go
+++ b/internal/db/review_loops_test.go
@@ -130,6 +130,33 @@ func TestSessionReviewLoopStore_GetFreshCleanPublicationLoopUsesExactEvidence(t 
 	require.NoError(t, mock.ExpectationsWereMet(), "fresh review lookup should filter by tenant, session, changeset, revision, and head")
 }
 
+func TestSessionReviewLoopStore_RefreshPublicationEvidenceAdvancesPublishedCheckpoint(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "test should create a database mock")
+	t.Cleanup(mock.Close)
+	orgID, loopID := uuid.New(), uuid.New()
+	revision := int64(15)
+	headSHA := "0123456789abcdef0123456789abcdef01234567"
+	args := pgx.NamedArgs{
+		"org_id": orgID, "loop_id": loopID, "workspace_revision": revision,
+		"desired_head_sha": headSHA,
+	}
+	mock.ExpectBegin()
+	mock.ExpectExec(`UPDATE session_review_loops[\s\S]+workspace_revision = @workspace_revision[\s\S]+desired_head_sha = @desired_head_sha`).
+		WithArgs(args).
+		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
+	mock.ExpectExec(`UPDATE session_publications[\s\S]+review_workspace_revision = @workspace_revision[\s\S]+review_desired_head_sha = @desired_head_sha[\s\S]+desired_head_sha = @desired_head_sha[\s\S]+published_head_sha = @desired_head_sha`).
+		WithArgs(args).
+		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
+	mock.ExpectCommit()
+
+	err = NewSessionReviewLoopStore(mock).RefreshPublicationEvidence(context.Background(), orgID, loopID, revision, headSHA)
+	require.NoError(t, err, "refreshing pushed review fixes should atomically advance review and publication-owned checkpoints")
+	require.NoError(t, mock.ExpectationsWereMet(), "review evidence refresh should commit both checkpoint updates")
+}
+
 func TestSessionReviewLoopStore_PublicationCleanTransitionIsAtomic(t *testing.T) {
 	t.Parallel()
 

--- a/internal/db/session_publications.go
+++ b/internal/db/session_publications.go
@@ -32,12 +32,14 @@ const sessionPublicationSelectColumns = `id, org_id, session_id, changeset_id, r
 
 // EnsureRequested upserts durable publication intent. Every mutable column is
 // guarded so a later replay cannot undo a decision an earlier writer already
-// made. review_gate_state is the strictest of those: once a coordinator has
-// recorded that review applies (a 'pending' gate with review_max_passes set),
-// no later request may downgrade it to 'not_required'. The open_pr worker
-// re-runs this upsert before it knows anything about review, so without that
-// guard the worker's default gate would silently skip the review it is about
-// to be asked to run.
+// made. The published head is branch-scoped ownership evidence: retries retain
+// it, branch/repository changes clear it, and legacy review publications can
+// recover it from the latest server-written review checkpoint. review_gate_state
+// is the strictest policy field: once a coordinator has recorded that review
+// applies (a 'pending' gate with review_max_passes set), no later request may
+// downgrade it to 'not_required'. The open_pr worker re-runs this upsert before
+// it knows anything about review, so without that guard the worker's default
+// gate would silently skip the review it is about to be asked to run.
 func (s *SessionPublicationStore) EnsureRequested(ctx context.Context, orgID uuid.UUID, publication *models.SessionPublication) error {
 	if publication == nil {
 		return errors.New("session publication is required")
@@ -301,9 +303,25 @@ func (s *SessionPublicationStore) EnsureRequested(ctx context.Context, orgID uui
 			ELSE session_publications.request_payload
 		END,
 		published_head_sha = CASE
-			WHEN session_publications.state IN ('completed_noop', 'terminal_failed')
-			 AND EXCLUDED.request_generation_at > session_publications.request_generation_at
-			THEN NULL ELSE session_publications.published_head_sha
+			WHEN session_publications.state = 'completed'
+			  OR EXCLUDED.request_generation_at < session_publications.request_generation_at
+			  OR (session_publications.state IN ('completed_noop', 'terminal_failed')
+			      AND EXCLUDED.request_generation_at <= session_publications.request_generation_at)
+			THEN session_publications.published_head_sha
+			WHEN EXCLUDED.repository_id IS DISTINCT FROM session_publications.repository_id
+			  OR EXCLUDED.head_branch IS DISTINCT FROM session_publications.head_branch
+			THEN NULL
+			ELSE COALESCE(session_publications.published_head_sha, (
+				SELECT loop.desired_head_sha
+				FROM session_review_loops AS loop
+				WHERE loop.org_id = session_publications.org_id
+				  AND loop.session_id = session_publications.session_id
+				  AND loop.changeset_id = session_publications.changeset_id
+				  AND loop.source = 'publication'
+				  AND loop.desired_head_sha IS NOT NULL
+				ORDER BY loop.started_at DESC, loop.id DESC
+				LIMIT 1
+			))
 		END,
 		github_pr_number = CASE
 			WHEN session_publications.state IN ('completed_noop', 'terminal_failed')
@@ -436,6 +454,7 @@ func (s *SessionPublicationStore) ApplyReviewBypass(ctx context.Context, orgID u
 			trigger_kind = 'explicit_action',
 			automatic_pr_policy_source = @automatic_policy_source,
 			review_policy_source = 'explicit_bypass',
+			published_head_sha = COALESCE(review_desired_head_sha, published_head_sha),
 			review_max_passes = NULL, review_loop_id = NULL,
 			review_workspace_revision = NULL, review_desired_head_sha = NULL,
 			review_gate_state = 'not_required', job_queue = @job_queue,
@@ -712,7 +731,8 @@ func (s *SessionPublicationStore) RecordReviewTarget(ctx context.Context, orgID,
 		return errors.New("review target head SHA is required")
 	}
 	result, err := s.db.Exec(ctx, `UPDATE session_publications
-		SET desired_head_sha = @desired_head_sha, updated_at = now()
+		SET desired_head_sha = @desired_head_sha,
+			published_head_sha = @desired_head_sha, updated_at = now()
 		WHERE org_id = @org_id AND session_id = @session_id AND changeset_id = @changeset_id
 		  AND state NOT IN ('completed', 'completed_noop', 'terminal_failed')`, pgx.NamedArgs{
 		"org_id": orgID, "session_id": sessionID, "changeset_id": changesetID,

--- a/internal/db/session_publications_test.go
+++ b/internal/db/session_publications_test.go
@@ -96,6 +96,7 @@ func TestSessionPublicationStoreEnsureRequestedReopensRetryableTerminalOutcomeFo
 	orgID, sessionID, changesetID, repositoryID := uuid.New(), uuid.New(), uuid.New(), uuid.New()
 	now := time.Now().UTC()
 	headSHA := "0123456789abcdef0123456789abcdef01234567"
+	publishedHeadSHA := "abcdef0123456789abcdef0123456789abcdef01"
 	payload := json.RawMessage(`{"org_id":"` + orgID.String() + `","session_id":"` + sessionID.String() + `","changeset_id":"` + changesetID.String() + `","publication_source":"user","publication_queue":"agent"}`)
 	publication := models.SessionPublication{
 		OrgID: orgID, SessionID: sessionID, ChangesetID: changesetID, RepositoryID: repositoryID,
@@ -107,10 +108,11 @@ func TestSessionPublicationStoreEnsureRequestedReopensRetryableTerminalOutcomeFo
 	stored := publication
 	stored.ID = uuid.New()
 	stored.State = models.SessionPublicationStateRequested
+	stored.PublishedHeadSHA = &publishedHeadSHA
 	stored.RequestedAt = now
 	stored.CreatedAt = now
 	stored.UpdatedAt = now
-	mock.ExpectQuery(`INSERT INTO session_publications[\s\S]+ON CONFLICT[\s\S]+state = CASE[\s\S]+state IN \('completed_noop', 'terminal_failed'\)[\s\S]+EXCLUDED.request_generation_at > session_publications.request_generation_at`).
+	mock.ExpectQuery(`INSERT INTO session_publications[\s\S]+ON CONFLICT[\s\S]+state = CASE[\s\S]+state IN \('completed_noop', 'terminal_failed'\)[\s\S]+EXCLUDED.request_generation_at > session_publications.request_generation_at[\s\S]+published_head_sha = CASE[\s\S]+EXCLUDED\.request_generation_at < session_publications\.request_generation_at[\s\S]+THEN session_publications\.published_head_sha[\s\S]+EXCLUDED\.repository_id IS DISTINCT FROM session_publications\.repository_id[\s\S]+EXCLUDED\.head_branch IS DISTINCT FROM session_publications\.head_branch[\s\S]+THEN NULL[\s\S]+ELSE COALESCE\(session_publications\.published_head_sha,[\s\S]+FROM session_review_loops AS loop[\s\S]+loop\.org_id = session_publications\.org_id[\s\S]+loop\.session_id = session_publications\.session_id[\s\S]+loop\.changeset_id = session_publications\.changeset_id[\s\S]+loop\.source = 'publication'[\s\S]+ORDER BY loop\.started_at DESC, loop\.id DESC`).
 		WithArgs(pgx.NamedArgs{
 			"org_id": orgID, "session_id": sessionID, "changeset_id": changesetID,
 			"repository_id": repositoryID, "source": models.SessionPublicationSourceUser,
@@ -130,7 +132,7 @@ func TestSessionPublicationStoreEnsureRequestedReopensRetryableTerminalOutcomeFo
 
 	err = NewSessionPublicationStore(mock).EnsureRequested(context.Background(), orgID, &publication)
 	require.NoError(t, err, "a newer explicit request should reopen an earlier retryable terminal publication even when the desired head is unchanged")
-	require.Equal(t, stored, publication, "the reopened publication should expose the new durable intent")
+	require.Equal(t, stored, publication, "the reopened publication should preserve the branch-scoped published checkpoint")
 	require.NoError(t, mock.ExpectationsWereMet(), "publication generation reopening should remain tenant scoped")
 }
 
@@ -243,23 +245,48 @@ func TestSessionPublicationStoreEnsureRequestedGuardsPendingReviewGateInSQL(t *t
 	require.NoError(t, mock.ExpectationsWereMet(), "the review gate upsert must guard pending gates that carry a review pass budget")
 }
 
+func TestSessionPublicationStoreRecordReviewTargetAdvancesPublishedCheckpoint(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "test should create the database mock")
+	t.Cleanup(mock.Close)
+	orgID, sessionID, changesetID := uuid.New(), uuid.New(), uuid.New()
+	headSHA := "0123456789abcdef0123456789abcdef01234567"
+	mock.ExpectExec(`UPDATE session_publications[\s\S]+desired_head_sha = @desired_head_sha[\s\S]+published_head_sha = @desired_head_sha[\s\S]+org_id = @org_id[\s\S]+session_id = @session_id[\s\S]+changeset_id = @changeset_id`).
+		WithArgs(pgx.NamedArgs{
+			"org_id": orgID, "session_id": sessionID, "changeset_id": changesetID,
+			"desired_head_sha": headSHA,
+		}).
+		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
+
+	err = NewSessionPublicationStore(mock).RecordReviewTarget(context.Background(), orgID, sessionID, changesetID, headSHA)
+	require.NoError(t, err, "recording a pushed review target should advance the publication-owned remote checkpoint")
+	require.NoError(t, mock.ExpectationsWereMet(), "the review target checkpoint should remain tenant and changeset scoped")
+}
+
 func TestSessionPublicationStoreApplyReviewBypassDetachesEvidence(t *testing.T) {
 	t.Parallel()
 
 	mock, err := pgxmock.NewPool()
 	require.NoError(t, err, "test should create the database mock")
 	t.Cleanup(mock.Close)
-	orgID, sessionID, changesetID, repositoryID := uuid.New(), uuid.New(), uuid.New(), uuid.New()
+	orgID, sessionID, changesetID, repositoryID, loopID := uuid.New(), uuid.New(), uuid.New(), uuid.New(), uuid.New()
 	now := time.Now().UTC()
+	revision := int64(7)
+	reviewHeadSHA := "0123456789abcdef0123456789abcdef01234567"
 	payload := json.RawMessage(`{"org_id":"` + orgID.String() + `","session_id":"` + sessionID.String() + `","changeset_id":"` + changesetID.String() + `","draft":true}`)
 	publication := models.SessionPublication{
 		ID: uuid.New(), OrgID: orgID, SessionID: sessionID, ChangesetID: changesetID, RepositoryID: repositoryID,
 		State: models.SessionPublicationStateReviewPending, Source: models.SessionPublicationSourceUser,
 		TriggerKind: models.SessionPublicationTriggerExplicitAction, HandoffMode: models.PRHandoffModeDraftFirst,
-		AutomaticPolicySource: models.PublicationPolicySourceExplicitAction,
-		ReviewPolicySource:    models.PublicationPolicySourceExplicitBypass,
-		ReviewGateState:       models.SessionPublicationReviewGateNeedsHuman,
-		JobQueue:              models.SessionPublicationJobQueueAgent, RequestPayload: payload, RequestGenerationAt: now,
+		AutomaticPolicySource:   models.PublicationPolicySourceExplicitAction,
+		ReviewPolicySource:      models.PublicationPolicySourceExplicitBypass,
+		ReviewLoopID:            &loopID,
+		ReviewWorkspaceRevision: &revision,
+		ReviewDesiredHeadSHA:    &reviewHeadSHA,
+		ReviewGateState:         models.SessionPublicationReviewGateNeedsHuman,
+		JobQueue:                models.SessionPublicationJobQueueAgent, RequestPayload: payload, RequestGenerationAt: now,
 		BaseBranch: "main", HeadBranch: "143/session", RequestedAt: now, CreatedAt: now, UpdatedAt: now,
 	}
 	stored := publication
@@ -269,8 +296,9 @@ func TestSessionPublicationStoreApplyReviewBypassDetachesEvidence(t *testing.T) 
 	stored.ReviewLoopID = nil
 	stored.ReviewWorkspaceRevision = nil
 	stored.ReviewDesiredHeadSHA = nil
+	stored.PublishedHeadSHA = &reviewHeadSHA
 
-	mock.ExpectQuery(`WITH publication_to_bypass AS[\s\S]+UPDATE session_review_loops AS loop[\s\S]+status = 'cancelled'[\s\S]+UPDATE session_publications[\s\S]+review_loop_id = NULL[\s\S]+review_gate_state = 'not_required'[\s\S]+org_id = @org_id AND session_id = @session_id AND changeset_id = @changeset_id`).
+	mock.ExpectQuery(`WITH publication_to_bypass AS[\s\S]+UPDATE session_review_loops AS loop[\s\S]+status = 'cancelled'[\s\S]+UPDATE session_publications[\s\S]+published_head_sha = COALESCE\(review_desired_head_sha, published_head_sha\)[\s\S]+review_loop_id = NULL[\s\S]+review_gate_state = 'not_required'[\s\S]+org_id = @org_id AND session_id = @session_id AND changeset_id = @changeset_id`).
 		WithArgs(pgx.NamedArgs{
 			"org_id": orgID, "session_id": sessionID, "changeset_id": changesetID,
 			"source":                  models.SessionPublicationSourceUser,

--- a/internal/services/github/pr.go
+++ b/internal/services/github/pr.go
@@ -590,11 +590,11 @@ type CreatePRParams struct {
 	Draft       *bool      `json:"draft,omitempty"`
 	AuthorMode  string     `json:"author_mode,omitempty"`
 	ChangesetID *uuid.UUID `json:"changeset_id,omitempty"`
-	// ExpectedRemoteHeadSHA is an internal revision-bound lease consumed only
-	// by the review evidence refresh paths (CreateBranch and PushChangesToPR).
-	// It permits replacing a non-ancestor branch head when the remote still
-	// equals the exact checkpoint that the review loop inspected. It is
-	// deliberately excluded from persisted/client payloads.
+	// ExpectedRemoteHeadSHA is an internal branch lease derived from a durable
+	// publication or review checkpoint. It permits replacing a non-ancestor
+	// branch head only while the remote still equals the exact head previously
+	// published by this operation. It is deliberately excluded from persisted
+	// and client-controlled payloads.
 	ExpectedRemoteHeadSHA     string                               `json:"-"`
 	PublicationSource         models.SessionPublicationSource      `json:"publication_source,omitempty"`
 	PublicationQueue          models.SessionPublicationJobQueue    `json:"-"`
@@ -843,6 +843,7 @@ func (s *PRService) PreparePublicationAttempt(
 	params.PublicationRequestPayload = append(json.RawMessage(nil), publication.RequestPayload...)
 	params.PublicationGenerationAt = publication.RequestGenerationAt
 	params.PublicationHeadBranch = publication.HeadBranch
+	params.ExpectedRemoteHeadSHA = strings.TrimSpace(stringValue(publication.PublishedHeadSHA))
 
 	started, err := s.publications.StartAttempt(ctx, run.OrgID, run.ID, changeset.ID)
 	if err != nil {
@@ -996,6 +997,9 @@ func (s *PRService) CreatePR(ctx context.Context, run *models.Session, params ..
 		}
 		if param.ChangesetID != nil {
 			opts.ChangesetID = param.ChangesetID
+		}
+		if strings.TrimSpace(param.ExpectedRemoteHeadSHA) != "" {
+			opts.ExpectedRemoteHeadSHA = strings.TrimSpace(param.ExpectedRemoteHeadSHA)
 		}
 		if param.PublicationSource != "" {
 			opts.PublicationSource = param.PublicationSource
@@ -1166,6 +1170,10 @@ func (s *PRService) CreatePR(ctx context.Context, run *models.Session, params ..
 		if publicationErr := s.publications.EnsureRequested(ctx, run.OrgID, publication); publicationErr != nil {
 			return nil, fmt.Errorf("ensure publication operation: %w", publicationErr)
 		}
+		// The durable publication row is authoritative for branch ownership.
+		// Callers cannot grant this lease through request JSON, and reloading it
+		// here keeps direct and replayed CreatePR paths on the same safety model.
+		opts.ExpectedRemoteHeadSHA = strings.TrimSpace(stringValue(publication.PublishedHeadSHA))
 		if gateErr := validatePublicationReviewGateForCreate(run, publication.ReviewGateState); gateErr != nil {
 			return nil, gateErr
 		}
@@ -1184,9 +1192,9 @@ func (s *PRService) CreatePR(ctx context.Context, run *models.Session, params ..
 
 	var pushed *pushResult
 	if materializedTarget {
-		pushed, err = s.pushChangesetBranch(ctx, run, &repo, orgSettings, *targetChangeset, commitMsg, authorName, authorEmail, "")
+		pushed, err = s.pushChangesetBranch(ctx, run, &repo, orgSettings, *targetChangeset, commitMsg, authorName, authorEmail, opts.ExpectedRemoteHeadSHA)
 	} else {
-		pushed, err = s.pushSessionBranch(ctx, run, &repo, orgSettings, *run.SnapshotKey, branchName, defaultBranch, commitMsg, authorName, authorEmail, "")
+		pushed, err = s.pushSessionBranch(ctx, run, &repo, orgSettings, *run.SnapshotKey, branchName, defaultBranch, commitMsg, authorName, authorEmail, opts.ExpectedRemoteHeadSHA)
 	}
 	if err != nil {
 		return nil, err
@@ -1387,7 +1395,7 @@ func (s *PRService) pushChangesetBranch(
 	orgSettings models.OrgSettings,
 	changeset models.SessionChangeset,
 	commitMsg, authorName, authorEmail string,
-	reviewExpectedRemoteHeadSHA string,
+	expectedRemoteHeadSHA string,
 ) (*pushResult, error) {
 	if s.sandboxAuth == nil {
 		return nil, fmt.Errorf("%w: sandbox auth socket not configured", ErrSandboxAuthUnavailable)
@@ -1415,9 +1423,9 @@ func (s *PRService) pushChangesetBranch(
 	if changeset.ExpectedRemoteHeadSHA != nil {
 		expected = strings.TrimSpace(*changeset.ExpectedRemoteHeadSHA)
 	}
-	reviewExpected := strings.TrimSpace(reviewExpectedRemoteHeadSHA)
-	if reviewExpected != "" {
-		expected = reviewExpected
+	publicationExpected := strings.TrimSpace(expectedRemoteHeadSHA)
+	if publicationExpected != "" {
+		expected = publicationExpected
 	}
 	if remoteHead != expected {
 		localHeadCmd := fmt.Sprintf("git -C %s rev-parse HEAD", shellQuote(*changeset.WorktreePath))
@@ -1444,7 +1452,7 @@ func (s *PRService) pushChangesetBranch(
 	if changeset.BaseHeadSHA != nil {
 		baseHead = *changeset.BaseHeadSHA
 	}
-	script := buildPushScriptWithExpectedRemote(sandbox.WorkDir, commitMsgPath, authorName, authorEmail, *changeset.WorkingBranch, changeset.BaseBranch, baseHead, fmt.Sprintf("https://github.com/%s.git", repo.FullName), reviewExpected)
+	script := buildPushScriptWithExpectedRemote(sandbox.WorkDir, commitMsgPath, authorName, authorEmail, *changeset.WorkingBranch, changeset.BaseBranch, baseHead, fmt.Sprintf("https://github.com/%s.git", repo.FullName), publicationExpected)
 	var stdout, stderr bytes.Buffer
 	exitCode, execErr = s.sandboxProvider.Exec(ctx, sandbox, script, &stdout, &stderr)
 	if execErr != nil {
@@ -1466,9 +1474,9 @@ func (s *PRService) pushChangesetBranch(
 			Str("session_id", run.ID.String()).
 			Str("changeset_id", changeset.ID.String()).
 			Str("branch", *changeset.WorkingBranch).
-			Str("expected_remote_head_sha", reviewExpected).
+			Str("expected_remote_head_sha", publicationExpected).
 			Str("head_sha", headSHA).
-			Msg("reconciled review fixes against the expected remote checkpoint")
+			Msg("reconciled publication against the expected remote checkpoint")
 	}
 	return &pushResult{
 		HeadSHA:                  headSHA,
@@ -2084,7 +2092,7 @@ func (s *PRService) pushSessionBranch(
 			Str("branch", branchName).
 			Str("expected_remote_head_sha", expectedRemoteHeadSHA).
 			Str("head_sha", headSHA).
-			Msg("reconciled review fixes against the expected remote checkpoint")
+			Msg("reconciled publication against the expected remote checkpoint")
 	}
 	result := &pushResult{
 		HeadSHA:                  headSHA,
@@ -2231,9 +2239,9 @@ const pushHeadSHASentinel = "__143_HEAD_SHA="
 
 const pushOutcomeSentinel = "__143_PUSH_OUTCOME="
 
-// pushExpectedRemoteReconciledSentinel is emitted only when a revision-bound
-// review push replaces a non-ancestor remote head that still exactly matches
-// the checkpoint persisted on the review loop.
+// pushExpectedRemoteReconciledSentinel is emitted only when a server-owned
+// publication replaces a non-ancestor remote head that still exactly matches
+// its durable publication or review checkpoint.
 const pushExpectedRemoteReconciledSentinel = "__143_EXPECTED_REMOTE_RECONCILED=1"
 
 const pushBranchDivergedMessage = "remote branch has changes that are not present in this session checkpoint; refusing to force push"
@@ -2373,11 +2381,11 @@ func buildPushScript(workDir, commitMsgPath, authorName, authorEmail, branchName
 }
 
 // buildPushScriptWithExpectedRemote extends the normal divergence guard with
-// one narrow exception for revision-bound review fixes. A non-ancestor remote
-// head may be replaced only when it still equals expectedRemoteHeadSHA; the
-// existing --force-with-lease then protects the final observation-to-push
-// race. Callers without durable review evidence use buildPushScript and retain
-// the original fail-closed behavior.
+// one narrow exception for a server-owned publication checkpoint. A
+// non-ancestor remote head may be replaced only when it still equals
+// expectedRemoteHeadSHA; the existing --force-with-lease then protects the
+// final observation-to-push race. Callers without durable ownership evidence
+// use buildPushScript and retain the original fail-closed behavior.
 func buildPushScriptWithExpectedRemote(workDir, commitMsgPath, authorName, authorEmail, branchName, baseBranch, baseCommitSHA, pushURL, expectedRemoteHeadSHA string) string {
 	return fmt.Sprintf(
 		pushScriptTemplate,

--- a/internal/services/github/pr_test.go
+++ b/internal/services/github/pr_test.go
@@ -176,12 +176,12 @@ func TestCreatePRParamsKeepsExpectedRemoteHeadInternal(t *testing.T) {
 	params := CreatePRParams{ExpectedRemoteHeadSHA: "abc1234567890abcdef1234567890abcdef12345"}
 	encoded, err := json.Marshal(params)
 	require.NoError(t, err, "CreatePRParams should remain serializable")
-	require.NotContains(t, string(encoded), "expected_remote_head", "the review-only replacement lease must not enter persisted or client payloads")
+	require.NotContains(t, string(encoded), "expected_remote_head", "the publication-owned replacement lease must not enter persisted or client payloads")
 
 	var decoded CreatePRParams
 	err = json.Unmarshal([]byte(`{"expected_remote_head_sha":"attacker-controlled"}`), &decoded)
 	require.NoError(t, err, "unknown client fields should not break CreatePRParams decoding")
-	require.Empty(t, decoded.ExpectedRemoteHeadSHA, "clients must not be able to grant the review-only replacement lease")
+	require.Empty(t, decoded.ExpectedRemoteHeadSHA, "clients must not be able to grant the publication-owned replacement lease")
 }
 
 type prTestSnapshotStore struct {
@@ -5770,7 +5770,7 @@ func TestPushChangesetBranchRevisionLeaseIsExplicit(t *testing.T) {
 			require.NoError(t, err, "changeset push should succeed with a matching ordinary remote checkpoint")
 			require.Equal(t, headSHA, result.HeadSHA, "changeset push should return the published head")
 			if tt.wantScriptUnbounded {
-				require.Contains(t, provider.lastExecCmd, "expected_remote_head=''", "ordinary changeset pushes must not inherit the review-only replacement lease")
+				require.Contains(t, provider.lastExecCmd, "expected_remote_head=''", "ordinary changeset pushes must not inherit the mutable changeset checkpoint as a publication lease")
 			} else {
 				require.Contains(t, provider.lastExecCmd, "expected_remote_head='"+tt.wantScriptExpected+"'", "review refresh should bind its explicit replacement lease")
 			}
@@ -6344,6 +6344,7 @@ func TestCreatePR_SuccessPushesSnapshotBranchAndStoresPR(t *testing.T) {
 	userID := uuid.New()
 	integrationID := uuid.New()
 	snapshotKey := "snapshots/session.tar"
+	expectedRemoteHeadSHA := "0123456789abcdef0123456789abcdef01234567"
 	body := ""
 
 	mock.ExpectQuery("SELECT .+ FROM pull_requests").
@@ -6456,7 +6457,7 @@ func TestCreatePR_SuccessPushesSnapshotBranchAndStoresPR(t *testing.T) {
 		ResultSummary:     func() *string { s := "Implemented the fix"; return &s }(),
 	}
 
-	pr, err := svc.CreatePR(context.Background(), run)
+	pr, err := svc.CreatePR(context.Background(), run, CreatePRParams{ExpectedRemoteHeadSHA: expectedRemoteHeadSHA})
 	require.NoError(t, err, "CreatePR should succeed for a snapshot-backed session")
 	require.Equal(t, 42, pr.GitHubPRNumber, "CreatePR should store the returned PR number")
 	require.Equal(t, "https://github.com/owner/repo/pull/42", pr.GitHubPRURL, "CreatePR should store the returned PR URL")
@@ -6464,6 +6465,7 @@ func TestCreatePR_SuccessPushesSnapshotBranchAndStoresPR(t *testing.T) {
 	require.Equal(t, 1, labelCalls, "CreatePR should add labels to the created PR")
 	require.Equal(t, true, createPRPayload["draft"], "CreatePR should honor the org default draft setting")
 	require.Contains(t, string(provider.writes[pushCommitMsgPath(agent.DefaultSandboxConfig().HomeDir)]), "Co-authored-by: Alice <alice@example.com>", "CreatePR should include a co-author trailer when using the app token for a user-triggered run")
+	require.Contains(t, provider.lastExecCmd, "expected_remote_head='"+expectedRemoteHeadSHA+"'", "CreatePR should bind the push to the durable publication-owned remote checkpoint")
 	require.Contains(t, provider.lastExecCmd, `git push --force-with-lease="${remote_ref}:${remote_sha}" "$push_url" "HEAD:${remote_ref}"`, "CreatePR should push the restored branch before opening the PR")
 	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
 	_ = body
@@ -6797,14 +6799,24 @@ func TestPreparePublicationAttemptPersistsExactBranchAndGatesTerminalReplay(t *t
 	t.Parallel()
 
 	tests := []struct {
-		name          string
-		state         models.SessionPublicationState
-		workingBranch *string
-		updatedRows   int64
-		wantStarted   bool
+		name                  string
+		state                 models.SessionPublicationState
+		workingBranch         *string
+		publishedHeadSHA      *string
+		updatedRows           int64
+		wantStarted           bool
+		wantExpectedRemoteSHA string
 	}{
 		{name: "derives branch for snapshot-backed session", state: models.SessionPublicationStateRequested, updatedRows: 1, wantStarted: true},
-		{name: "uses materialized changeset branch", state: models.SessionPublicationStateRequested, workingBranch: strPtr("143/custom/stack"), updatedRows: 1, wantStarted: true},
+		{
+			name:                  "uses durable published head for the same materialized branch",
+			state:                 models.SessionPublicationStateRequested,
+			workingBranch:         strPtr("143/custom/stack"),
+			publishedHeadSHA:      strPtr("0123456789abcdef0123456789abcdef01234567"),
+			updatedRows:           1,
+			wantStarted:           true,
+			wantExpectedRemoteSHA: "0123456789abcdef0123456789abcdef01234567",
+		},
 		{name: "blocks terminal replay before side effects", state: models.SessionPublicationStateTerminalFailed, updatedRows: 0, wantStarted: false},
 	}
 
@@ -6834,7 +6846,7 @@ func TestPreparePublicationAttemptPersistsExactBranchAndGatesTerminalReplay(t *t
 				State: tt.state, Source: models.SessionPublicationSourceUser,
 				ReviewGateState: models.SessionPublicationReviewGateNotRequired,
 				JobQueue:        models.SessionPublicationJobQueueAgent, RequestPayload: payload, RequestGenerationAt: now,
-				BaseBranch: "main", HeadBranch: headBranch,
+				BaseBranch: "main", HeadBranch: headBranch, PublishedHeadSHA: tt.publishedHeadSHA,
 				RequestedAt: now, CreatedAt: now, UpdatedAt: now,
 			}
 			mock.ExpectQuery("INSERT INTO session_publications").WithArgs(pgx.NamedArgs{
@@ -6873,6 +6885,7 @@ func TestPreparePublicationAttemptPersistsExactBranchAndGatesTerminalReplay(t *t
 			require.Equal(t, tt.wantStarted, attempt.Started, "publication preparation should report whether side effects may start")
 			require.Equal(t, stored, attempt.Publication, "publication preparation should return the persisted state")
 			require.Equal(t, headBranch, attempt.Params.PublicationHeadBranch, "CreatePR should receive the exact durably recorded branch")
+			require.Equal(t, tt.wantExpectedRemoteSHA, attempt.Params.ExpectedRemoteHeadSHA, "CreatePR should receive only the durable publication-owned remote checkpoint")
 			require.Equal(t, changesetID, *attempt.Params.ChangesetID, "prepared parameters should retain the changeset target")
 			require.NoError(t, mock.ExpectationsWereMet(), "publication preparation should perform only the expected tenant-scoped writes")
 		})


### PR DESCRIPTION
## Summary
- Persist published head SHAs across review refreshes, target recording, bypasses, and publication retries.
- Restore checkpoints from review evidence when needed while clearing them on repository or branch changes.
- Use server-owned checkpoints to safely reconcile non-ancestor remote branches during PR publication.
- Add coverage for checkpoint persistence, recovery, and push lease propagation.

## Testing
- Added and updated focused Go unit tests for database and GitHub publication flows.