### PR TITLE
Remove secondary right-side dot on tabs and keep single read/unread indicator

### DIFF
--- a/frontend/src/app/(dashboard)/sessions/[id]/agent-tab-strip.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/agent-tab-strip.test.tsx
@@ -33,6 +33,21 @@ function makeThread(overrides: Partial<SessionThread>): SessionThread {
   };
 }
 
+// Pills (the queued-message Badge) are round too, so match on dot dimensions
+// rather than on rounded-full alone.
+const DOT_SIZED = /(^|\s)(size|h)-(1\.5|2)(\s|$)/;
+
+/**
+ * Every dot inside a tab must belong to the single StatusIndicator — this is
+ * the guard against a tab growing a second dot after its label.
+ */
+function dotsOutsideIndicator(tab: Element): Element[] {
+  return Array.from(tab.querySelectorAll(".rounded-full")).filter(
+    (element) =>
+      !element.closest('[data-slot="status-indicator"]') && DOT_SIZED.test(element.className),
+  );
+}
+
 describe("AgentTabStrip", () => {
   // The strip's height is part of the session workspace's stable geometry: a
   // bare null here collapses the row and shifts the transcript and composer
@@ -221,7 +236,12 @@ describe("AgentTabStrip", () => {
       />,
     );
 
-    expect(screen.getByLabelText("Needs attention")).toBeInTheDocument();
+    // The quiet header names the state instead of drawing a second dot.
+    const header = screen.getByRole("group", { name: "Claude Code Idle (needs attention)" });
+    expect(header.querySelectorAll('[data-slot="status-indicator"]')).toHaveLength(1);
+    expect(dotsOutsideIndicator(header)).toHaveLength(0);
+    expect(header.querySelector('[data-slot="status-indicator-core"]')).toHaveClass("bg-warning");
+
     await user.hover(screen.getByText("Main tab"));
     expect(await screen.findByRole("tooltip")).not.toHaveTextContent("reconnect required");
   });
@@ -490,11 +510,11 @@ describe("AgentTabStrip", () => {
     expect(onArchiveThread).toHaveBeenCalledWith("thread-2");
   });
 
-  it("keeps a blue dot on unseen tabs until they are selected", async () => {
+  it("keeps operational state on the single tab dot and carries unread in the accessible name", async () => {
     const user = userEvent.setup();
     const threads = [
-      makeThread({ id: "thread-1", label: "Main tab" }),
-      makeThread({ id: "thread-2", label: "Review" }),
+      makeThread({ id: "thread-1", label: "Main tab", status: "running" }),
+      makeThread({ id: "thread-2", label: "Review", status: "completed" }),
     ];
 
     function Harness() {
@@ -523,10 +543,118 @@ describe("AgentTabStrip", () => {
 
     const { container } = renderWithProviders(<Harness />);
 
-    expect(container.querySelectorAll(".bg-primary").length).toBe(1);
+    const indicators = container.querySelectorAll('[data-slot="status-indicator"]');
+    expect(indicators).toHaveLength(2);
 
-    await user.click(screen.getByRole("tab", { name: /Review/ }));
+    // The dot tracks status, not unread: the viewed-but-running tab is the
+    // primary/breathing one, while the unread completed tab reads as success.
+    expect(indicators[0].querySelector('[data-slot="status-indicator-core"]')).toHaveClass("bg-primary");
+    expect(indicators[0]).toHaveAttribute("data-activity", "breathing");
+    expect(indicators[1].querySelector('[data-slot="status-indicator-core"]')).toHaveClass("bg-success");
 
-    expect(container.querySelector(".bg-primary")).toBeNull();
+    for (const tab of screen.getAllByRole("tab")) {
+      expect(tab.querySelectorAll('[data-slot="status-indicator"]')).toHaveLength(1);
+      expect(tab.firstElementChild).toHaveAttribute("data-slot", "status-indicator");
+      expect(dotsOutsideIndicator(tab)).toHaveLength(0);
+    }
+
+    // Unread is announced, and drawn as a brighter label rather than a dot.
+    expect(screen.getByRole("tab", { name: /Review\s*\(unread\)/ })).toBeInTheDocument();
+    expect(screen.queryByRole("tab", { name: /Main tab\s*\(unread\)/ })).not.toBeInTheDocument();
+
+    const [activeTab, unreadTab] = screen.getAllByRole("tab");
+    expect(unreadTab.querySelector("span.truncate")).toHaveClass("text-foreground");
+    // The active tab carries its own colour, so it is never brightened here.
+    expect(activeTab.querySelector("span.truncate")).not.toHaveClass("text-foreground");
+
+    await user.click(screen.getByRole("tab", { name: /Review\s*\(unread\)/ }));
+
+    expect(screen.queryByRole("tab", { name: /\(unread\)/ })).not.toBeInTheDocument();
+    const afterSelection = container.querySelectorAll('[data-slot="status-indicator"]');
+    expect(afterSelection).toHaveLength(2);
+    expect(afterSelection[1].querySelector('[data-slot="status-indicator-core"]')).toHaveClass("bg-success");
+
+    const [nowInactiveRunningTab, nowActiveTab] = screen.getAllByRole("tab");
+    // Still working, so it stays prominent even though it has been read.
+    expect(nowInactiveRunningTab.querySelector("span.truncate")).toHaveClass("text-foreground");
+    expect(nowActiveTab.querySelector("span.truncate")).not.toHaveClass("text-foreground");
+    // Reading the tab must not change the label's weight — that would resize
+    // the tab and shift the strip.
+    expect(nowActiveTab.querySelector("span.truncate")).not.toHaveClass("font-semibold");
+  });
+
+  // Being active is itself a prominence condition, so the label must defer to
+  // the tab's own active colour — otherwise text-foreground would override
+  // data-[state=active]:text-primary on every selected tab.
+  it("never brightens the active tab's label, even while it is still unread", () => {
+    const threads = [
+      makeThread({ id: "thread-1", label: "Main tab", status: "completed" }),
+      makeThread({ id: "thread-2", label: "Review", status: "completed" }),
+    ];
+
+    renderWithProviders(
+      <AgentTabStrip
+        threads={threads}
+        activeThreadId={threads[0].id}
+        // Nothing viewed yet: the active tab is unread too, which is the state
+        // that exists between selecting a tab and it being marked read.
+        viewedThreadIds={new Set<string>()}
+        overlapsByThreadId={new Map()}
+        statusConfig={statusConfig}
+        onActiveThreadChange={vi.fn()}
+        onAddTab={vi.fn()}
+        onRevertThread={vi.fn()}
+        onArchiveThread={vi.fn()}
+        archivePendingThreadId={null}
+      />,
+    );
+
+    const [activeTab, inactiveTab] = screen.getAllByRole("tab");
+
+    expect(activeTab).toHaveAttribute("data-state", "active");
+    expect(activeTab).toHaveClass("data-[state=active]:text-primary");
+    expect(activeTab.querySelector("span.truncate")).not.toHaveClass("text-foreground");
+    // Unread is still announced on both tabs, including the active one.
+    expect(activeTab).toHaveAccessibleName(/Main tab\s*\(unread\)/);
+    expect(inactiveTab.querySelector("span.truncate")).toHaveClass("text-foreground");
+  });
+
+  it("folds a needs-attention thread into the tab's own dot instead of trailing a second one", () => {
+    const threads = [
+      // The queued-message badge is round as well; it must not read as a dot.
+      makeThread({ id: "thread-1", label: "Main tab", status: "awaiting_input", pending_message_count: 2 }),
+      makeThread({
+        id: "thread-2",
+        label: "Review",
+        status: "completed",
+        failure_category: "claude_code_auth_expired",
+        failure_explanation: "claude subscription is marked invalid; reconnect required",
+      }),
+    ];
+
+    renderWithProviders(
+      <AgentTabStrip
+        threads={threads}
+        activeThreadId={threads[0].id}
+        viewedThreadIds={new Set(threads.map((thread) => thread.id))}
+        overlapsByThreadId={new Map()}
+        statusConfig={statusConfig}
+        onActiveThreadChange={vi.fn()}
+        onAddTab={vi.fn()}
+        onRevertThread={vi.fn()}
+        onArchiveThread={vi.fn()}
+        archivePendingThreadId={null}
+      />,
+    );
+
+    const [awaitingTab, settledFailureTab] = screen.getAllByRole("tab");
+
+    for (const tab of [awaitingTab, settledFailureTab]) {
+      expect(tab.querySelectorAll('[data-slot="status-indicator"]')).toHaveLength(1);
+      expect(dotsOutsideIndicator(tab)).toHaveLength(0);
+      expect(tab.querySelector('[data-slot="status-indicator-core"]')).toHaveClass("bg-warning");
+    }
+
+    expect(screen.getByRole("tab", { name: /Review\s*\(needs attention\)/ })).toBeInTheDocument();
   });
 });

--- a/frontend/src/app/(dashboard)/sessions/[id]/agent-tab-strip.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/agent-tab-strip.tsx
@@ -19,30 +19,21 @@ import { AGENTS_BY_KEY } from "@/lib/agents";
 import { deriveSessionStatusPresentation } from "@/lib/session-display-status";
 import type { SessionThread, SessionThreadFileEvent } from "@/lib/types";
 import { SESSION_THREAD_STRIP_HEIGHT_CLASSNAME } from "./session-detail-geometry";
+import {
+  canArchiveThread,
+  isActiveThreadStatus,
+  isThreadLabelProminent,
+  isThreadUnread,
+  threadIndicatorTone,
+  threadNeedsAttention,
+  threadStateSuffix,
+} from "./session-thread-presentation";
 
-// Status helpers — kept in one place so the tab strip and detail panel agree.
+// Status label formatting stays local: the strip resolves labels through the
+// statusConfig prop, while the shared rules live in session-thread-presentation.
 
 function threadStatusLabel(status: string, statusConfig: Record<string, { label: string }>): string {
   return statusConfig[status]?.label ?? status.replace(/_/g, " ");
-}
-
-function isActiveStatus(status: string): boolean {
-  return status === "pending" || status === "running" || status === "awaiting_input";
-}
-
-function threadNeedsAttention(thread: SessionThread): boolean {
-  if (thread.status === "awaiting_input" || thread.status === "failed") {
-    return true;
-  }
-  return !isActiveStatus(thread.status) && !!(thread.failure_explanation || thread.failure_category);
-}
-
-function shouldShowUnreadDot(thread: SessionThread, viewedThreadIds: ReadonlySet<string>): boolean {
-  return !viewedThreadIds.has(thread.id);
-}
-
-function canArchiveThread(thread: SessionThread, threadCount: number): boolean {
-  return threadCount > 1 && !isActiveStatus(thread.status);
 }
 
 function addTabButtonClassName(): string {
@@ -101,7 +92,7 @@ export function computeThreadOverlap(
   if (!events || events.length === 0) {
     return result;
   }
-  const activeThreadIds = new Set(threads.filter((t) => isActiveStatus(t.status)).map((t) => t.id));
+  const activeThreadIds = new Set(threads.filter((t) => isActiveThreadStatus(t.status)).map((t) => t.id));
   // path -> set of thread ids that touched it
   const ownersByPath = new Map<string, Set<string>>();
   for (const e of events) {
@@ -174,8 +165,11 @@ function ThreadStripPlaceholder({ message }: { message?: string }) {
 // Design notes:
 // - Single tab degrades into the original "quiet header" look so a session
 //   with one agent does not feel project-board-y.
-// - The tab dot animates when running so a glance at the strip tells the
-//   user which lane is mid-turn.
+// - Exactly one dot per tab, and it owns operational state (including a
+//   settled failure): the tab dot animates when running so a glance at the
+//   strip tells the user which lane is mid-turn. Unread is carried by label
+//   emphasis plus screen-reader text — the same split the session sidebar
+//   uses — so nothing needs a second dot after the label.
 // - Overlap is rendered with an AlertTriangle so the user notices conflict
 //   before reviewing the diff.
 export function AgentTabStrip({
@@ -214,13 +208,16 @@ export function AgentTabStrip({
     const statusLabel = threadStatusLabel(activeThread.status, statusConfig);
     const overlap = overlapsByThreadId.get(activeThread.id) ?? [];
     const isCancelling =
-      activeThread.cancel_requested_at != null && isActiveStatus(activeThread.status);
+      activeThread.cancel_requested_at != null && isActiveThreadStatus(activeThread.status);
     const queued = activeThread.pending_message_count ?? 0;
     const deliverySummary = formatDeliverySummary(activeThread);
     const provenance = formatThreadProvenance(activeThread);
     const needsAttention = threadNeedsAttention(activeThread);
-    const showUnreadDot = shouldShowUnreadDot(activeThread, viewedThreadIds);
+    // The lone tab is the one being viewed, so it is marked read almost
+    // immediately; the state only needs to reach assistive tech.
+    const isUnread = isThreadUnread(activeThread, viewedThreadIds);
     const operationalStatus = deriveSessionStatusPresentation(activeThread.status);
+    const indicatorTone = threadIndicatorTone(operationalStatus, needsAttention);
 
     return (
       <TooltipProvider delayDuration={150}>
@@ -232,18 +229,17 @@ export function AgentTabStrip({
                   <div
                     tabIndex={0}
                     role="group"
-                    aria-label={`${agentLabel} ${statusLabel}`}
+                    aria-label={`${agentLabel} ${statusLabel}${threadStateSuffix(needsAttention, isUnread)}`}
                     className="inline-flex max-w-full min-w-0 items-center gap-2 rounded-md px-1 py-1 outline-none focus-visible:ring-2 focus-visible:ring-ring/40"
                   >
                     <StatusIndicator
-                      tone={operationalStatus.tone}
+                      tone={indicatorTone}
                       activity={isCancelling ? "none" : operationalStatus.activity}
                       stateKey={activeThread.status}
                     />
-                    <span className="truncate text-xs font-medium text-foreground">{activeThread.label}</span>
-                    {showUnreadDot ? (
-                      <span className="size-1.5 shrink-0 rounded-full bg-primary" aria-hidden="true" title="Unread activity" />
-                    ) : null}
+                    <span className="truncate text-xs font-medium text-foreground">
+                      {activeThread.label}
+                    </span>
                     {isCancelling && (
                       <Loader2
                         className="h-3.5 w-3.5 shrink-0 animate-spin text-muted-foreground"
@@ -254,12 +250,6 @@ export function AgentTabStrip({
                       <Badge variant="secondary" className="h-4 px-1 text-xs leading-none">
                         {queued}
                       </Badge>
-                    )}
-                    {needsAttention && (
-                      <span
-                        className="h-1.5 w-1.5 shrink-0 rounded-full bg-warning"
-                        aria-label="Needs attention"
-                      />
                     )}
                     {overlap.length > 0 && (
                       <AlertTriangle
@@ -347,12 +337,19 @@ export function AgentTabStrip({
                   const statusLabel = threadStatusLabel(thread.status, statusConfig);
                   const needsAttention = threadNeedsAttention(thread);
                   const overlap = overlapsByThreadId.get(thread.id) ?? [];
-                  const isCancelling = thread.cancel_requested_at != null && isActiveStatus(thread.status);
+                  const isCancelling = thread.cancel_requested_at != null && isActiveThreadStatus(thread.status);
                   const queued = thread.pending_message_count ?? 0;
                   const deliverySummary = formatDeliverySummary(thread);
                   const provenance = formatThreadProvenance(thread);
-                  const showUnreadDot = shouldShowUnreadDot(thread, viewedThreadIds);
+                  const isUnread = isThreadUnread(thread, viewedThreadIds);
+                  const isActiveTab = thread.id === activeThreadId;
                   const operationalStatus = deriveSessionStatusPresentation(thread.status);
+                  const indicatorTone = threadIndicatorTone(operationalStatus, needsAttention);
+                  const stateSuffix = threadStateSuffix(needsAttention, isUnread);
+                  const isLabelProminent = isThreadLabelProminent(thread, {
+                    isUnread,
+                    isActive: isActiveTab,
+                  });
                   const showArchiveButton = canArchiveThread(thread, tabs.length);
                   const isNonInteractive = nonInteractiveThreadIds?.has(thread.id) ?? false;
                   const closeLabel = `Close ${thread.label}${thread.label.toLowerCase().endsWith(" tab") ? "" : " tab"}`;
@@ -373,14 +370,23 @@ export function AgentTabStrip({
                               )}
                             >
                               <StatusIndicator
-                                tone={operationalStatus.tone}
+                                tone={indicatorTone}
                                 activity={isCancelling ? "none" : operationalStatus.activity}
                                 stateKey={thread.status}
                               />
-                              <span className="truncate">{thread.label}</span>
-                              {showUnreadDot ? (
-                                <span className="size-1.5 shrink-0 rounded-full bg-primary" aria-hidden="true" title="Unread activity" />
-                              ) : null}
+                              {/* Prominence brightens the label rather than
+                                  bolding it: a weight change would resize the
+                                  tab and shift the strip the moment it is read.
+                                  The active tab already has its own colour. */}
+                              <span
+                                className={cn(
+                                  "truncate",
+                                  isLabelProminent && !isActiveTab && "text-foreground",
+                                )}
+                              >
+                                {thread.label}
+                                {stateSuffix ? <span className="sr-only">{stateSuffix}</span> : null}
+                              </span>
                               {isCancelling && (
                                 <Loader2 className="h-3 w-3 animate-spin text-muted-foreground" aria-label="Cancelling" />
                               )}
@@ -388,9 +394,6 @@ export function AgentTabStrip({
                                 <Badge variant="secondary" className="h-4 px-1 text-xs leading-none">
                                   {queued}
                                 </Badge>
-                              )}
-                              {needsAttention && (
-                                <span className="h-1.5 w-1.5 rounded-full bg-warning" aria-label="Needs attention" />
                               )}
                               {overlap.length > 0 && (
                                 <AlertTriangle

--- a/frontend/src/app/(dashboard)/sessions/[id]/mobile-session-top-bar.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/mobile-session-top-bar.test.tsx
@@ -70,7 +70,7 @@ describe("MobileSessionTopBar", () => {
     const tabsSection = within(actionsSheet).getByRole("region", { name: "Tabs" });
     expect(within(tabsSection).getByText("Switch or add a conversation lane.")).toBeInTheDocument();
     expect(within(actionsSheet).getByRole("button", { name: "Switch to Main tab" })).toBeInTheDocument();
-    expect(within(actionsSheet).getByRole("button", { name: "Switch to Review" })).toBeInTheDocument();
+    expect(within(actionsSheet).getByRole("button", { name: "Switch to Review (unread)" })).toBeInTheDocument();
     expect(within(tabsSection).getByRole("button", { name: "Add agent tab" })).toBeInTheDocument();
     expect(within(actionsSheet).getByRole("button", { name: "Rename session" })).toBeInTheDocument();
     expect(within(actionsSheet).getByText("Active tab")).toBeInTheDocument();
@@ -166,7 +166,10 @@ describe("MobileSessionTopBar", () => {
     await user.click(screen.getByRole("button", { name: "Open session actions" }));
 
     let actionsSheet = await screen.findByRole("dialog", { name: "Session actions" });
-    await user.click(within(actionsSheet).getByRole("button", { name: "Switch to Review" }));
+    // Awaiting input and never viewed, so the row announces both states.
+    await user.click(
+      within(actionsSheet).getByRole("button", { name: "Switch to Review (needs attention) (unread)" }),
+    );
 
     await user.click(screen.getByRole("button", { name: "Open session actions" }));
     actionsSheet = await screen.findByRole("dialog", { name: "Session actions" });
@@ -188,7 +191,7 @@ describe("MobileSessionTopBar", () => {
     expect(onRevertThread).toHaveBeenCalledWith("thread-1");
   });
 
-  it("shows a blue dot only for unseen mobile threads and exposes close actions for closable tabs", async () => {
+  it("keeps one status dot per mobile row, announces unread, and exposes close actions for closable tabs", async () => {
     const user = userEvent.setup();
     const onArchiveThread = vi.fn();
 
@@ -220,11 +223,106 @@ describe("MobileSessionTopBar", () => {
     expect(within(actionsSheet).getByText("Tabs")).toBeInTheDocument();
     expect(within(actionsSheet).getByRole("button", { name: "Close Main tab" })).toBeInTheDocument();
     expect(within(actionsSheet).getByRole("button", { name: "Close Review tab" })).toBeInTheDocument();
-    expect(actionsSheet.querySelectorAll(".bg-primary").length).toBe(1);
+    // One dot per row, toned by status (both threads are completed), and
+    // unread rides on the row's accessible name plus a brighter label.
+    expect(actionsSheet.querySelectorAll('[data-slot="status-indicator"]')).toHaveLength(2);
+    expect(actionsSheet.querySelectorAll('[data-slot="status-indicator-core"].bg-success')).toHaveLength(2);
+    const activeRow = within(actionsSheet).getByRole("button", { name: "Switch to Main tab" });
+    const unreadRow = within(actionsSheet).getByRole("button", { name: "Switch to Review (unread)" });
+    expect(unreadRow.querySelector("span.truncate")).toHaveClass("text-foreground");
+    // Weight never changes, so reading a row cannot resize it.
+    expect(unreadRow.querySelector("span.truncate")).toHaveClass("font-medium");
+    expect(activeRow.querySelector("span.truncate")).toHaveClass("font-medium");
 
     await user.click(within(actionsSheet).getByRole("button", { name: "Close Review tab" }));
 
     expect(onArchiveThread).toHaveBeenCalledWith("thread-2");
+  });
+
+  // Only settled lanes the user has already seen should recede: dimming the
+  // lane they are on, or one that is still working, buries the rows that matter.
+  it("keeps the active and working rows prominent while settled read rows recede", async () => {
+    const user = userEvent.setup();
+
+    renderWithProviders(
+      <MobileSessionTopBar
+        sessionTitle="Mobile session title"
+        detailButtonLabel="Open session details"
+        backTo="/sessions"
+        threads={[
+          makeThread({ id: "thread-1", label: "Main tab", status: "completed" }),
+          makeThread({ id: "thread-2", label: "Worker", status: "running", agent_type: "claude_code" }),
+          makeThread({ id: "thread-3", label: "Docs", status: "completed", agent_type: "claude_code" }),
+        ]}
+        activeThreadId="thread-1"
+        viewedThreadIds={new Set(["thread-1", "thread-2", "thread-3"])}
+        onOpenDetails={vi.fn()}
+        onActiveThreadChange={vi.fn()}
+        onAddThread={vi.fn()}
+        onRenameSession={vi.fn()}
+        onRevertThread={vi.fn()}
+        onArchiveThread={vi.fn()}
+        archivePendingThreadId={null}
+        nonInteractiveThreadIds={new Set()}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Open session actions" }));
+
+    const actionsSheet = await screen.findByRole("dialog", { name: "Session actions" });
+    const activeRow = within(actionsSheet).getByRole("button", { name: "Switch to Main tab" });
+    const runningRow = within(actionsSheet).getByRole("button", { name: "Switch to Worker" });
+    const settledRow = within(actionsSheet).getByRole("button", { name: "Switch to Docs" });
+
+    expect(activeRow.querySelector("span.truncate")).toHaveClass("text-foreground");
+    expect(runningRow.querySelector("span.truncate")).toHaveClass("text-foreground");
+    expect(settledRow.querySelector("span.truncate")).toHaveClass("text-muted-foreground");
+  });
+
+  // The desktop strip escalates a settled failure to a warning dot; the sheet
+  // has to agree, or the same thread reads as healthy on mobile.
+  it("warns on a settled thread that carries a failure, matching the desktop strip", async () => {
+    const user = userEvent.setup();
+
+    renderWithProviders(
+      <MobileSessionTopBar
+        sessionTitle="Mobile session title"
+        detailButtonLabel="Open session details"
+        backTo="/sessions"
+        threads={[
+          makeThread({ id: "thread-1", label: "Main tab", status: "completed" }),
+          makeThread({
+            id: "thread-2",
+            label: "Review",
+            status: "completed",
+            agent_type: "claude_code",
+            failure_category: "claude_code_auth_expired",
+            failure_explanation: "claude subscription is marked invalid; reconnect required",
+          }),
+        ]}
+        activeThreadId="thread-1"
+        viewedThreadIds={new Set(["thread-1", "thread-2"])}
+        onOpenDetails={vi.fn()}
+        onActiveThreadChange={vi.fn()}
+        onAddThread={vi.fn()}
+        onRenameSession={vi.fn()}
+        onRevertThread={vi.fn()}
+        onArchiveThread={vi.fn()}
+        archivePendingThreadId={null}
+        nonInteractiveThreadIds={new Set()}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Open session actions" }));
+
+    const actionsSheet = await screen.findByRole("dialog", { name: "Session actions" });
+    const failedRow = within(actionsSheet).getByRole("button", {
+      name: "Switch to Review (needs attention)",
+    });
+    const healthyRow = within(actionsSheet).getByRole("button", { name: "Switch to Main tab" });
+
+    expect(failedRow.querySelector('[data-slot="status-indicator-core"]')).toHaveClass("bg-warning");
+    expect(healthyRow.querySelector('[data-slot="status-indicator-core"]')).toHaveClass("bg-success");
   });
 
   it("does not allow switching to a pending preview thread from the actions sheet", async () => {
@@ -256,7 +354,7 @@ describe("MobileSessionTopBar", () => {
     await user.click(screen.getByRole("button", { name: "Open session actions" }));
 
     const actionsSheet = await screen.findByRole("dialog", { name: "Session actions" });
-    const pendingThreadButton = within(actionsSheet).getByRole("button", { name: "Switch to Codex 2" });
+    const pendingThreadButton = within(actionsSheet).getByRole("button", { name: "Switch to Codex 2 (unread)" });
 
     expect(pendingThreadButton).toBeDisabled();
 

--- a/frontend/src/app/(dashboard)/sessions/[id]/mobile-session-top-bar.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/mobile-session-top-bar.tsx
@@ -26,6 +26,14 @@ import {
 import { cn } from "@/lib/utils";
 import { deriveSessionStatusPresentation } from "@/lib/session-display-status";
 import type { SessionThread } from "@/lib/types";
+import {
+  canArchiveThread,
+  isThreadLabelProminent,
+  isThreadUnread,
+  threadIndicatorTone,
+  threadNeedsAttention,
+  threadStateSuffix,
+} from "./session-thread-presentation";
 
 interface MobileSessionTopBarProps {
   sessionTitle: string;
@@ -46,18 +54,6 @@ interface MobileSessionTopBarProps {
 
 function threadStatusLabel(status: string): string {
   return deriveSessionStatusPresentation(status as SessionThread["status"]).label;
-}
-
-function isActiveStatus(status: string): boolean {
-  return status === "pending" || status === "running" || status === "awaiting_input";
-}
-
-function shouldShowUnreadDot(thread: SessionThread, viewedThreadIds: ReadonlySet<string>): boolean {
-  return !viewedThreadIds.has(thread.id);
-}
-
-function canArchiveThread(thread: SessionThread, threadCount: number): boolean {
-  return threadCount > 1 && !isActiveStatus(thread.status);
 }
 
 export function MobileSessionTopBar({
@@ -143,8 +139,11 @@ export function MobileSessionTopBar({
                   const agent = AGENTS_BY_KEY[thread.agent_type];
                   const statusLabel = threadStatusLabel(thread.status);
                   const isActive = thread.id === activeThreadId;
-                  const showUnreadDot = shouldShowUnreadDot(thread, viewedThreadIds);
+                  const isUnread = isThreadUnread(thread, viewedThreadIds);
+                  const needsAttention = threadNeedsAttention(thread);
                   const operationalStatus = deriveSessionStatusPresentation(thread.status);
+                  const indicatorTone = threadIndicatorTone(operationalStatus, needsAttention);
+                  const isLabelProminent = isThreadLabelProminent(thread, { isUnread, isActive });
                   const showArchiveButton = canArchiveThread(thread, threads.length);
                   const isNonInteractive = nonInteractiveThreadIds?.has(thread.id) ?? false;
                   const closeLabel = `Close ${thread.label}${thread.label.toLowerCase().endsWith(" tab") ? "" : " tab"}`;
@@ -157,7 +156,7 @@ export function MobileSessionTopBar({
                           "h-auto flex-1 justify-start rounded-xl border px-3 py-3 text-left",
                           isActive ? "border-primary/30 bg-primary/5" : "border-border bg-background",
                         )}
-                        aria-label={`Switch to ${thread.label}`}
+                        aria-label={`Switch to ${thread.label}${threadStateSuffix(needsAttention, isUnread)}`}
                         disabled={isNonInteractive}
                         onClick={() => {
                           if (isNonInteractive) return;
@@ -167,17 +166,24 @@ export function MobileSessionTopBar({
                       >
                         <div className="flex w-full items-start gap-3">
                           <StatusIndicator
-                            tone={operationalStatus.tone}
+                            tone={indicatorTone}
                             activity={operationalStatus.activity}
                             stateKey={thread.status}
                             className="mt-1.5"
                           />
                           <div className="min-w-0 flex-1">
                             <div className="flex items-center gap-2">
-                              <span className="truncate text-sm font-medium text-foreground">{thread.label}</span>
-                              {showUnreadDot ? (
-                                <span className="size-1.5 shrink-0 rounded-full bg-primary" aria-label="Unread activity" />
-                              ) : null}
+                              {/* Only settled lanes the user has already seen
+                                  recede; bolding instead of dimming would
+                                  resize the row as soon as it is read. */}
+                              <span
+                                className={cn(
+                                  "truncate text-sm font-medium",
+                                  isLabelProminent ? "text-foreground" : "text-muted-foreground",
+                                )}
+                              >
+                                {thread.label}
+                              </span>
                               {isActive ? <Badge variant="secondary" className="text-xs">Active</Badge> : null}
                             </div>
                             <p className="truncate text-xs text-muted-foreground">

--- a/frontend/src/app/(dashboard)/sessions/[id]/page-agent-tabs.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/page-agent-tabs.test.tsx
@@ -1405,16 +1405,17 @@ describe('SessionDetailPage agent tabs and threads', () => {
     const user = userEvent.setup();
     renderWithProviders(<SessionDetailContent id={sessionId} />);
 
-    expect(await screen.findByRole('tab', { name: 'Review' })).toBeInTheDocument();
+    // The tab has never been viewed, so its name carries the unread suffix.
+    expect(await screen.findByRole('tab', { name: /^Review/ })).toBeInTheDocument();
 
-    await user.click(screen.getByRole('tab', { name: 'Review' }));
+    await user.click(screen.getByRole('tab', { name: /^Review/ }));
     await user.click(screen.getByRole('button', { name: 'Close Review tab' }));
 
     await waitFor(() => {
       expect(archivedThreadId).toBe('thread-review');
     });
     await waitFor(() => {
-      expect(screen.queryByRole('tab', { name: 'Review' })).not.toBeInTheDocument();
+      expect(screen.queryByRole('tab', { name: /^Review/ })).not.toBeInTheDocument();
     });
     expect(screen.getByPlaceholderText('Send a message to Main tab...')).toBeInTheDocument();
   });

--- a/frontend/src/app/(dashboard)/sessions/[id]/page-review-mode.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/page-review-mode.test.tsx
@@ -297,7 +297,9 @@ describe('SessionDetailPage review mode and mobile diff', () => {
 
     const actionsSheet = await screen.findByRole('dialog', { name: 'Session actions' });
     expect(within(actionsSheet).getByRole('button', { name: 'Switch to Main tab' })).toBeInTheDocument();
-    expect(within(actionsSheet).getByRole('button', { name: 'Switch to Review' })).toBeInTheDocument();
+    expect(
+      within(actionsSheet).getByRole('button', { name: 'Switch to Review (needs attention) (unread)' }),
+    ).toBeInTheDocument();
     expect(within(actionsSheet).getByRole('button', { name: 'Add agent tab' })).toBeInTheDocument();
     expect(within(actionsSheet).getByRole('button', { name: 'Rename session' })).toBeInTheDocument();
   });

--- a/frontend/src/app/(dashboard)/sessions/[id]/session-thread-presentation.ts
+++ b/frontend/src/app/(dashboard)/sessions/[id]/session-thread-presentation.ts
@@ -1,0 +1,73 @@
+import type { OperationalStatePresentation, OperationalTone } from "@/lib/operational-state";
+import type { SessionThread } from "@/lib/types";
+
+// Presentation rules shared by the desktop tab strip and the mobile actions
+// sheet. Keeping them here stops a thread from reading as healthy on one
+// surface while it reads as troubled on the other.
+
+export function isActiveThreadStatus(status: string): boolean {
+  return status === "pending" || status === "running" || status === "awaiting_input";
+}
+
+export function isThreadUnread(thread: SessionThread, viewedThreadIds: ReadonlySet<string>): boolean {
+  return !viewedThreadIds.has(thread.id);
+}
+
+export function threadNeedsAttention(thread: SessionThread): boolean {
+  if (thread.status === "awaiting_input" || thread.status === "failed") {
+    return true;
+  }
+  return (
+    !isActiveThreadStatus(thread.status) &&
+    !!(thread.failure_explanation || thread.failure_category)
+  );
+}
+
+/**
+ * A settled thread can still carry a failure its status alone doesn't express.
+ * Fold that into the one dot rather than trailing a second dot after the label.
+ */
+export function threadIndicatorTone(
+  presentation: OperationalStatePresentation,
+  needsAttention: boolean,
+): OperationalTone {
+  if (!needsAttention) {
+    return presentation.tone;
+  }
+  // Statuses that already read as trouble (failed, awaiting input) keep their
+  // own tone; only the reassuring ones get escalated.
+  return presentation.tone === "neutral" || presentation.tone === "success"
+    ? "warning"
+    : presentation.tone;
+}
+
+/**
+ * Suffixes a thread's accessible name so unread/attention survive the
+ * aria-hidden dot. Each surface appends it where its own name comes from:
+ * the desktop tab builds its name from content (sr-only child), while the
+ * mobile row carries an explicit aria-label.
+ */
+export function threadStateSuffix(needsAttention: boolean, isUnread: boolean): string {
+  return `${needsAttention ? " (needs attention)" : ""}${isUnread ? " (unread)" : ""}`;
+}
+
+/**
+ * Whether a thread's label should read as prominent. Unread threads, the lane
+ * the user is on, and lanes that are still working stay bright; settled lanes
+ * the user has already seen recede. This mirrors the session sidebar, which
+ * keeps working rows bright even once they have been read.
+ *
+ * Each surface maps the result onto its own base colour — the desktop strip
+ * brightens above a dimmed tab colour, the mobile sheet mutes below a bright
+ * one — but the rule itself lives here so the two cannot drift apart.
+ */
+export function isThreadLabelProminent(
+  thread: SessionThread,
+  { isUnread, isActive }: { isUnread: boolean; isActive: boolean },
+): boolean {
+  return isUnread || isActive || isActiveThreadStatus(thread.status);
+}
+
+export function canArchiveThread(thread: SessionThread, threadCount: number): boolean {
+  return threadCount > 1 && !isActiveThreadStatus(thread.status);
+}


### PR DESCRIPTION
## Summary

Session tabs could render an extra (secondary) dot after the header’s label, creating a confusing status/read UI and a reliability risk where dots drift apart from the intended indicator component. This change makes every dot inside a tab belong to the single `StatusIndicator`, and shifts unread visibility into the accessible/tab label rather than adding another visual marker.

## Changes

- Enforce “single indicator dot” behavior by updating tests to assert there are **zero dot elements outside** the `data-slot="status-indicator"` area for each tab.
- Update status/read expectations: the dot reflects **operational status** (e.g., breathing/primary vs success) and unread is surfaced via the tab’s accessible name (e.g., `Review (unread)`), not an additional dot.
- Adjust related session header/top bar rendering and tests to align with the new contract, preventing regressions where tabs grow an extra dot alongside the label.

## Validation

- Updated/extended Jest + Testing Library tests for:
  - `agent-tab-strip`
  - `mobile-session-top-bar`
  - `page-agent-tabs`
  - `page-review-mode`
- Ran the frontend test suite to confirm the tab strip and top bar render the correct single `StatusIndicator` and unread labeling behavior.

[143.dev](https://143.dev) | [session 289cffae](https://143.dev/sessions/289cffae-2eca-4f82-acb8-da8d61a9214a)

<!-- 143-publication session=289cffae-2eca-4f82-acb8-da8d61a9214a changeset=a4f3982d-cf4a-4829-ad30-51d7ba2dc8b7 -->

Preview: https://143.dev/previews/github/assembledhq/143/pull/2071?launch=1