### PR TITLE
Fix mobile Time Range selector layout to full-screen height without clipping presets

### DIFF
--- a/frontend/src/components/code-review-overview.test.tsx
+++ b/frontend/src/components/code-review-overview.test.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { render, screen, within } from "@testing-library/react";
+import { act, render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { endOfMonth, format, startOfMonth, subDays, subMonths } from "date-fns";
@@ -7,20 +7,40 @@ import { CodeReviewSummaryCards, formatReviewTurnaround } from "./code-review-ov
 import { TimeRangePicker, timeRangeLabel } from "./time-range-picker";
 import { customTimeRange, type TimeRangeFilter } from "@/lib/time-range";
 
+// `matches` is a live getter and listeners are real, so `changeViewport` can
+// move a mounted component across the breakpoint the way a rotation does.
+let desktopMatches = true;
+const queryListeners = new Set<() => void>();
+
 function setDesktopMatch(matches: boolean) {
+  desktopMatches = matches;
+  queryListeners.clear();
   Object.defineProperty(window, "matchMedia", {
     configurable: true,
     writable: true,
-    value: vi.fn().mockImplementation((query: string) => ({
-      matches: query === "(min-width: 768px)" ? matches : false,
-      media: query,
-      onchange: null,
-      addEventListener: vi.fn(),
-      removeEventListener: vi.fn(),
-      addListener: vi.fn(),
-      removeListener: vi.fn(),
-      dispatchEvent: vi.fn(),
-    })),
+    value: vi.fn().mockImplementation((query: string) => {
+      const listeners = new Set<() => void>();
+      queryListeners.add(() => listeners.forEach((listener) => listener()));
+      return {
+        get matches() {
+          return { "(min-width: 768px)": desktopMatches, "(max-width: 767px)": !desktopMatches }[query] ?? false;
+        },
+        media: query,
+        onchange: null,
+        addEventListener: (_: string, listener: () => void) => listeners.add(listener),
+        removeEventListener: (_: string, listener: () => void) => listeners.delete(listener),
+        addListener: (listener: () => void) => listeners.add(listener),
+        removeListener: (listener: () => void) => listeners.delete(listener),
+        dispatchEvent: vi.fn(),
+      };
+    }),
+  });
+}
+
+async function changeViewport(matches: boolean) {
+  desktopMatches = matches;
+  await act(async () => {
+    queryListeners.forEach((notify) => notify());
   });
 }
 
@@ -86,6 +106,125 @@ describe("TimeRangePicker", () => {
     expect(document.querySelectorAll(".rdp-month")).toHaveLength(expectedMonths);
   });
 
+  it("uses the full mobile screen instead of an anchored popover", async () => {
+    setDesktopMatch(false);
+    const user = userEvent.setup();
+    render(<TimeRangePicker label="Time window" value="30d" onValueChange={vi.fn()} />);
+
+    await user.click(screen.getByRole("button", { name: "Time window" }));
+
+    const dialog = screen.getByRole("dialog", { name: "Choose time range" });
+    expect(dialog).toHaveAttribute("data-slot", "sheet-content");
+    expect(dialog).toHaveClass("inset-0", "h-dvh", "max-h-dvh", "max-w-none", "rounded-none");
+    expect(document.querySelector('[data-slot="popover-content"]')).not.toBeInTheDocument();
+    expect(within(dialog).getByRole("button", { name: "Last 30 days" })).toBeInTheDocument();
+  });
+
+  it("pins the mobile range actions outside the scrolling body", async () => {
+    setDesktopMatch(false);
+    const user = userEvent.setup();
+    render(<TimeRangePicker label="Time window" value="30d" onValueChange={vi.fn()} />);
+
+    await user.click(screen.getByRole("button", { name: "Time window" }));
+
+    const dialog = screen.getByRole("dialog", { name: "Choose time range" });
+    const body = dialog.querySelector('[data-slot="time-range-picker-body"]');
+    const month = document.querySelector<HTMLElement>(".rdp-month");
+    expect(body).not.toBeNull();
+    expect(month).not.toBeNull();
+    // The calendar scrolls; Cancel/Apply must stay reachable without scrolling.
+    expect(body).toContainElement(month);
+    for (const name of ["Cancel", "Apply range"]) {
+      const action = within(dialog).getByRole("button", { name });
+      expect(body).not.toContainElement(action);
+    }
+  });
+
+  it("leaves the value untouched when the mobile sheet is dismissed", async () => {
+    setDesktopMatch(false);
+    const user = userEvent.setup();
+    const onValueChange = vi.fn();
+    const start = subDays(new Date(), 12);
+    render(<TimeRangePicker label="Time window" value="30d" onValueChange={onValueChange} />);
+
+    await user.click(screen.getByRole("button", { name: "Time window" }));
+    const day = document.querySelector<HTMLElement>(`[data-day="${start.toLocaleDateString()}"]`);
+    expect(day).not.toBeNull();
+    await user.click(day as HTMLElement);
+    await user.click(screen.getByRole("button", { name: "Close" }));
+
+    expect(screen.queryByRole("dialog", { name: "Choose time range" })).not.toBeInTheDocument();
+    expect(onValueChange).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    { desktop: false, surface: "mobile sheet" },
+    { desktop: true, surface: "desktop popover" },
+  ])("discards a half-selected range when Cancel is clicked in the $surface", async ({ desktop }) => {
+    setDesktopMatch(desktop);
+    const user = userEvent.setup();
+    const onValueChange = vi.fn();
+    const start = subDays(new Date(), 12);
+    render(<TimeRangePicker label="Time window" value="30d" onValueChange={onValueChange} />);
+
+    await user.click(screen.getByRole("button", { name: "Time window" }));
+    const day = document.querySelector<HTMLElement>(`[data-day="${start.toLocaleDateString()}"]`);
+    expect(day).not.toBeNull();
+    await user.click(day as HTMLElement);
+    await user.click(screen.getByRole("button", { name: "Cancel" }));
+
+    expect(screen.queryByRole("dialog", { name: "Choose time range" })).not.toBeInTheDocument();
+    expect(onValueChange).not.toHaveBeenCalled();
+
+    // Reopening starts from the applied value again, not the abandoned draft:
+    // the summary shows a complete range instead of a dangling start date.
+    await user.click(screen.getByRole("button", { name: "Time window" }));
+    expect(screen.queryByText(/Select an end date$/)).not.toBeInTheDocument();
+    expect(screen.queryByText("Select a start date")).not.toBeInTheDocument();
+  });
+
+  it("keeps the picker open and the draft intact when the viewport crosses the breakpoint", async () => {
+    setDesktopMatch(false);
+    const user = userEvent.setup();
+    const start = subDays(new Date(), 12);
+    render(<TimeRangePicker label="Time window" value="30d" onValueChange={vi.fn()} />);
+
+    await user.click(screen.getByRole("button", { name: "Time window" }));
+    const day = document.querySelector<HTMLElement>(`[data-day="${start.toLocaleDateString()}"]`);
+    expect(day).not.toBeNull();
+    await user.click(day as HTMLElement);
+    expect(screen.getByRole("dialog", { name: "Choose time range" }))
+      .toHaveAttribute("data-slot", "sheet-content");
+
+    // e.g. rotating a phone to landscape crosses 768px mid-selection.
+    await changeViewport(true);
+
+    const dialog = screen.getByRole("dialog", { name: "Choose time range" });
+    expect(dialog).toHaveAttribute("data-slot", "popover-content");
+    expect(within(dialog).getByText(`${format(start, "MMM d, yyyy")} – Select an end date`))
+      .toBeInTheDocument();
+  });
+
+  it("applies a custom range from the mobile sheet", async () => {
+    setDesktopMatch(false);
+    const user = userEvent.setup();
+    const onValueChange = vi.fn();
+    const start = subDays(new Date(), 12);
+    const end = subDays(new Date(), 6);
+    render(<TimeRangePicker label="Time window" value="30d" onValueChange={onValueChange} />);
+
+    await user.click(screen.getByRole("button", { name: "Time window" }));
+    for (const date of [start, end]) {
+      const day = document.querySelector<HTMLElement>(`[data-day="${date.toLocaleDateString()}"]`);
+      expect(day).not.toBeNull();
+      await user.click(day as HTMLElement);
+    }
+    await user.click(screen.getByRole("button", { name: "Apply range" }));
+
+    expect(onValueChange).toHaveBeenCalledWith(customTimeRange(start, end));
+    expect(screen.queryByRole("dialog", { name: "Choose time range" })).not.toBeInTheDocument();
+  });
+
   it("shows presets and applies one immediately", async () => {
     const user = userEvent.setup();
     const onValueChange = vi.fn();
@@ -93,6 +232,8 @@ describe("TimeRangePicker", () => {
 
     await user.click(screen.getByRole("button", { name: "Time window" }));
     const dialog = screen.getByRole("dialog", { name: "Choose time range" });
+    expect(dialog).toHaveAttribute("data-slot", "popover-content");
+    expect(document.querySelector('[data-slot="sheet-content"]')).not.toBeInTheDocument();
     expect(within(dialog).getByText("Custom range")).toBeInTheDocument();
     expect(within(dialog).getByRole("button", { name: /Last 30 days/ })).toHaveAttribute("data-variant", "secondary");
     for (const label of ["This week", "Last week", "Last 2 weeks", "This month", "Last month"]) {

--- a/frontend/src/components/time-range-picker.tsx
+++ b/frontend/src/components/time-range-picker.tsx
@@ -9,10 +9,18 @@ import { Button } from "@/components/ui/button";
 import { Calendar } from "@/components/ui/calendar";
 import { ControlTrigger } from "@/components/ui/control-trigger";
 import { DisabledTooltip } from "@/components/ui/disabled-tooltip";
-import { useMediaQuery } from "@/hooks/use-media-query";
 import { Label } from "@/components/ui/label";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { Separator } from "@/components/ui/separator";
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+  SheetTrigger,
+} from "@/components/ui/sheet";
+import { useMediaQuery } from "@/hooks/use-media-query";
 import {
   customTimeRange,
   customTimeRangeDates,
@@ -49,6 +57,12 @@ const PRESET_GROUPS: Array<{
 
 const PRESETS = PRESET_GROUPS.flatMap((group) => group.presets);
 
+// Deliberately two queries instead of one negated query: both use the hook's
+// false server snapshot, so SSR and the first hydration render fall back to
+// the desktop popover rather than a full-screen sheet.
+const MOBILE_QUERY = "(max-width: 767px)";
+const TWO_MONTH_QUERY = "(min-width: 768px)";
+
 function defaultDraft(value: TimeRangeFilter): DateRange {
   return timeRangeDisplayDates(value, new Date()) ?? { from: undefined, to: undefined };
 }
@@ -73,7 +87,8 @@ export function TimeRangePicker({
 }) {
   const [open, setOpen] = useState(false);
   const [draft, setDraft] = useState<DateRange>(() => defaultDraft(value));
-  const showTwoMonths = useMediaQuery("(min-width: 768px)");
+  const isMobile = useMediaQuery(MOBILE_QUERY);
+  const showTwoMonths = useMediaQuery(TWO_MONTH_QUERY);
   const today = useMemo(() => {
     const date = new Date();
     date.setHours(23, 59, 59, 999);
@@ -99,97 +114,144 @@ export function TimeRangePicker({
     setOpen(false);
   };
 
+  const trigger = (
+    <ControlTrigger
+      type="button"
+      variant="outline"
+      density="compact"
+      className="w-full justify-start gap-2 px-2.5 font-normal"
+      aria-label={label}
+    >
+      <CalendarRange className="size-4 shrink-0 text-muted-foreground" />
+      <span className="min-w-0 flex-1 truncate text-left">{timeRangeLabel(value)}</span>
+      <ChevronDown className={cn("size-4 shrink-0 text-muted-foreground transition-transform", open && "rotate-180")} />
+    </ControlTrigger>
+  );
+
+  const rangeActions = (
+    <div className="flex flex-col gap-2 p-2 sm:flex-row sm:items-center sm:justify-between">
+      <p className="text-xs text-muted-foreground">
+        {draft.from && draft.to
+          ? `${format(draft.from, "MMM d, yyyy")} – ${format(draft.to, "MMM d, yyyy")}`
+          : draft.from
+            ? `${format(draft.from, "MMM d, yyyy")} – Select an end date`
+            : "Select a start date"}
+      </p>
+      <div className="flex justify-end gap-2">
+        <Button type="button" variant="ghost" size="sm" onClick={() => handleOpenChange(false)}>
+          Cancel
+        </Button>
+        <DisabledTooltip
+          disabled={rangeIncomplete}
+          content={draft.from ? "Select an end date to apply this range." : "Select a start and end date to apply this range."}
+        >
+          <Button type="button" size="sm" disabled={rangeIncomplete} onClick={applyCustomRange}>
+            Apply range
+          </Button>
+        </DisabledTooltip>
+      </div>
+    </div>
+  );
+
+  const pickerBody = (
+    <div className="flex flex-col md:flex-row">
+      <div className="space-y-3 p-2 md:w-36 md:shrink-0">
+        {PRESET_GROUPS.map((group) => (
+          <div key={group.label} className="space-y-0.5">
+            <p className="px-2 pb-0.5 text-xs font-medium text-muted-foreground">{group.label}</p>
+            {group.presets.map((preset) => {
+              const selected = value === preset.value;
+              return (
+                <Button
+                  key={preset.value}
+                  type="button"
+                  size="sm"
+                  variant={selected ? "secondary" : "ghost"}
+                  className="w-full justify-start px-2"
+                  onClick={() => applyPreset(preset.value)}
+                >
+                  <span className="min-w-0 flex-1 truncate text-left">{preset.label}</span>
+                  {selected ? <Check className="size-3.5 text-primary" aria-hidden="true" /> : null}
+                </Button>
+              );
+            })}
+          </div>
+        ))}
+      </div>
+      <Separator className="md:hidden" />
+      <Separator orientation="vertical" className="hidden self-stretch md:block" />
+      <div className="min-w-0 flex-1">
+        <div className="px-3 pt-3">
+          <p className="text-sm font-medium">Custom range</p>
+        </div>
+        {/* 40px cells on phones — the full-screen sheet has the room, and it
+            matches Button's mobile height. 44px (the control minimum in
+            AGENTS.md) would make the grid 324px and overflow a 320px viewport.
+            The compact rhythm starts at `sm` like every other control. */}
+        <Calendar
+          mode="range"
+          selected={draft}
+          onSelect={(nextRange) => setDraft(nextRange ?? { from: undefined, to: undefined })}
+          defaultMonth={draft.from}
+          numberOfMonths={showTwoMonths ? 2 : 1}
+          showOutsideDays={false}
+          disabled={{ after: today }}
+          resetOnSelect
+          className="mx-auto p-2 [--cell-size:--spacing(10)] sm:[--cell-size:--spacing(7)] [&_.rdp-month]:gap-2 [&_.rdp-months]:gap-3 [&_.rdp-week]:mt-1"
+        />
+        {/* On mobile the actions are pinned below the scroll area instead. */}
+        {isMobile ? null : (
+          <>
+            <Separator />
+            {rangeActions}
+          </>
+        )}
+      </div>
+    </div>
+  );
+
   return (
     <div className="flex flex-col gap-2">
       <Label className="text-xs text-muted-foreground">{label}</Label>
-      <Popover open={open} onOpenChange={handleOpenChange}>
-        <PopoverTrigger asChild>
-          <ControlTrigger
-            type="button"
-            variant="outline"
-            density="compact"
-            className="w-full justify-start gap-2 px-2.5 font-normal"
-            aria-label={label}
+      {isMobile ? (
+        <Sheet open={open} onOpenChange={handleOpenChange}>
+          <SheetTrigger asChild>{trigger}</SheetTrigger>
+          <SheetContent
+            side="bottom"
+            className="inset-0 flex h-dvh max-h-dvh max-w-none flex-col gap-0 overflow-hidden rounded-none border-0 p-0"
           >
-            <CalendarRange className="size-4 shrink-0 text-muted-foreground" />
-            <span className="min-w-0 flex-1 truncate text-left">{timeRangeLabel(value)}</span>
-            <ChevronDown className={cn("size-4 shrink-0 text-muted-foreground transition-transform", open && "rotate-180")} />
-          </ControlTrigger>
-        </PopoverTrigger>
-        <PopoverContent
-          align="end"
-          className="max-h-[calc(100vh-2rem)] w-[min(40rem,calc(100vw-2rem))] overflow-y-auto p-0"
-          role="dialog"
-          aria-label="Choose time range"
-        >
-          <div className="flex flex-col md:flex-row">
-            <div className="space-y-3 p-2 md:w-36 md:shrink-0">
-              {PRESET_GROUPS.map((group) => (
-                <div key={group.label} className="space-y-0.5">
-                  <p className="px-2 pb-0.5 text-xs font-medium text-muted-foreground">{group.label}</p>
-                  {group.presets.map((preset) => {
-                    const selected = value === preset.value;
-                    return (
-                      <Button
-                        key={preset.value}
-                        type="button"
-                        size="sm"
-                        variant={selected ? "secondary" : "ghost"}
-                        className="w-full justify-start px-2"
-                        onClick={() => applyPreset(preset.value)}
-                      >
-                        <span className="min-w-0 flex-1 truncate text-left">{preset.label}</span>
-                        {selected ? <Check className="size-3.5 text-primary" aria-hidden="true" /> : null}
-                      </Button>
-                    );
-                  })}
-                </div>
-              ))}
+            <SheetHeader className="shrink-0 border-b border-border px-4 py-3 pr-12">
+              <SheetTitle>Choose time range</SheetTitle>
+              <SheetDescription className="sr-only">
+                Choose a preset or select a custom date range.
+              </SheetDescription>
+            </SheetHeader>
+            <div
+              data-slot="time-range-picker-body"
+              className="min-h-0 flex-1 overflow-y-auto overscroll-contain"
+            >
+              {pickerBody}
             </div>
-            <Separator className="md:hidden" />
-            <Separator orientation="vertical" className="hidden self-stretch md:block" />
-            <div className="min-w-0 flex-1">
-              <div className="px-3 pt-3">
-                <p className="text-sm font-medium">Custom range</p>
-              </div>
-              <Calendar
-                mode="range"
-                selected={draft}
-                onSelect={(nextRange) => setDraft(nextRange ?? { from: undefined, to: undefined })}
-                defaultMonth={draft.from}
-                numberOfMonths={showTwoMonths ? 2 : 1}
-                showOutsideDays={false}
-                disabled={{ after: today }}
-                resetOnSelect
-                className="mx-auto p-2 [--cell-size:--spacing(8)] sm:[--cell-size:--spacing(7)] [&_.rdp-month]:gap-2 [&_.rdp-months]:gap-3 [&_.rdp-week]:mt-1"
-              />
-              <Separator />
-              <div className="flex flex-col gap-2 p-2 sm:flex-row sm:items-center sm:justify-between">
-                <p className="text-xs text-muted-foreground">
-                  {draft.from && draft.to
-                    ? `${format(draft.from, "MMM d, yyyy")} – ${format(draft.to, "MMM d, yyyy")}`
-                    : draft.from
-                      ? `${format(draft.from, "MMM d, yyyy")} – Select an end date`
-                      : "Select a start date"}
-                </p>
-                <div className="flex justify-end gap-2">
-                  <Button type="button" variant="ghost" size="sm" onClick={() => setOpen(false)}>
-                    Cancel
-                  </Button>
-                  <DisabledTooltip
-                    disabled={rangeIncomplete}
-                    content={draft.from ? "Select an end date to apply this range." : "Select a start and end date to apply this range."}
-                  >
-                    <Button type="button" size="sm" disabled={rangeIncomplete} onClick={applyCustomRange}>
-                      Apply range
-                    </Button>
-                  </DisabledTooltip>
-                </div>
-              </div>
+            {/* The safe-area half of this padding only engages if the app ever
+                sets `viewportFit: "cover"`; today it resolves to the 0.5rem. */}
+            <div className="shrink-0 border-t border-border bg-background pb-[max(0.5rem,env(safe-area-inset-bottom))]">
+              {rangeActions}
             </div>
-          </div>
-        </PopoverContent>
-      </Popover>
+          </SheetContent>
+        </Sheet>
+      ) : (
+        <Popover open={open} onOpenChange={handleOpenChange}>
+          <PopoverTrigger asChild>{trigger}</PopoverTrigger>
+          <PopoverContent
+            align="end"
+            className="max-h-[calc(100vh-2rem)] w-[min(40rem,calc(100vw-2rem))] overflow-y-auto p-0"
+            role="dialog"
+            aria-label="Choose time range"
+          >
+            {pickerBody}
+          </PopoverContent>
+        </Popover>
+      )}
     </div>
   );
 }

--- a/frontend/src/hooks/use-media-query.test.ts
+++ b/frontend/src/hooks/use-media-query.test.ts
@@ -1,6 +1,15 @@
+import { createElement } from "react";
+import { hydrateRoot, type Root } from "react-dom/client";
+import { renderToString } from "react-dom/server";
+import { act, renderHook, waitFor } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
-import { renderHook } from "@testing-library/react";
 import { useMediaQuery } from "./use-media-query";
+
+const MOBILE_QUERY = "(max-width: 767px)";
+
+function MediaQueryProbe() {
+  return createElement("span", null, useMediaQuery(MOBILE_QUERY) ? "mobile" : "desktop");
+}
 
 describe("useMediaQuery", () => {
   it("reads the current match state on the first render", () => {
@@ -22,7 +31,7 @@ describe("useMediaQuery", () => {
     });
 
     renderHook(() => {
-      const matches = useMediaQuery("(max-width: 767px)");
+      const matches = useMediaQuery(MOBILE_QUERY);
       seen.push(matches);
       return matches;
     });
@@ -47,7 +56,7 @@ describe("useMediaQuery", () => {
       })),
     });
 
-    const { result, unmount } = renderHook(() => useMediaQuery("(max-width: 767px)"));
+    const { result, unmount } = renderHook(() => useMediaQuery(MOBILE_QUERY));
 
     expect(result.current).toBe(true);
     expect(addListener).toHaveBeenCalledTimes(1);
@@ -55,5 +64,57 @@ describe("useMediaQuery", () => {
     unmount();
 
     expect(removeListener).toHaveBeenCalledTimes(1);
+  });
+
+  it("hydrates with the server snapshot before applying the mobile match", async () => {
+    const originalMatchMedia = Object.getOwnPropertyDescriptor(window, "matchMedia");
+    Object.defineProperty(window, "matchMedia", {
+      writable: true,
+      configurable: true,
+      value: undefined,
+    });
+    const serverMarkup = renderToString(createElement(MediaQueryProbe));
+
+    Object.defineProperty(window, "matchMedia", {
+      writable: true,
+      configurable: true,
+      value: vi.fn().mockImplementation(() => ({
+        matches: true,
+        media: MOBILE_QUERY,
+        onchange: null,
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+      })),
+    });
+
+    const container = document.createElement("div");
+    container.innerHTML = serverMarkup;
+    document.body.appendChild(container);
+    const onRecoverableError = vi.fn();
+    let root: Root | undefined;
+
+    try {
+      await act(async () => {
+        root = hydrateRoot(container, createElement(MediaQueryProbe), { onRecoverableError });
+      });
+
+      expect(onRecoverableError).not.toHaveBeenCalled();
+      await waitFor(() => expect(container).toHaveTextContent("mobile"));
+    } finally {
+      await act(async () => root?.unmount());
+      container.remove();
+      if (originalMatchMedia) {
+        Object.defineProperty(window, "matchMedia", originalMatchMedia);
+      } else {
+        Object.defineProperty(window, "matchMedia", {
+          writable: true,
+          configurable: true,
+          value: undefined,
+        });
+      }
+    }
   });
 });

--- a/frontend/src/hooks/use-media-query.ts
+++ b/frontend/src/hooks/use-media-query.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useCallback, useSyncExternalStore } from "react";
 
 function getMatch(query: string): boolean {
   if (typeof window === "undefined" || typeof window.matchMedia !== "function") {
@@ -9,34 +9,35 @@ function getMatch(query: string): boolean {
   return window.matchMedia(query).matches;
 }
 
-export function useMediaQuery(query: string): boolean {
-  const [matches, setMatches] = useState(() => getMatch(query));
+function getServerMatch(): boolean {
+  return false;
+}
 
-  useEffect(() => {
+export function useMediaQuery(query: string): boolean {
+  const subscribe = useCallback((onChange: () => void) => {
     if (typeof window === "undefined" || typeof window.matchMedia !== "function") {
-      return;
+      return () => undefined;
     }
 
     const mediaQuery = window.matchMedia(query);
-    const update = () => setMatches(mediaQuery.matches);
     const supportsEventListener =
       typeof mediaQuery.addEventListener === "function" &&
       typeof mediaQuery.removeEventListener === "function";
 
-    update();
     if (supportsEventListener) {
-      mediaQuery.addEventListener("change", update);
+      mediaQuery.addEventListener("change", onChange);
     } else {
-      mediaQuery.addListener(update);
+      mediaQuery.addListener(onChange);
     }
     return () => {
       if (supportsEventListener) {
-        mediaQuery.removeEventListener("change", update);
+        mediaQuery.removeEventListener("change", onChange);
       } else {
-        mediaQuery.removeListener(update);
+        mediaQuery.removeListener(onChange);
       }
     };
   }, [query]);
+  const getSnapshot = useCallback(() => getMatch(query), [query]);
 
-  return matches;
+  return useSyncExternalStore(subscribe, getSnapshot, getServerMatch);
 }


### PR DESCRIPTION
## Summary

Fix the mobile Time Range selector layout getting clipped/anchored because the component could render the wrong control variant before hydration. This change updates `useMediaQuery` to use `useSyncExternalStore` with a stable server snapshot, then adjusts the `TimeRangePicker` behavior so mobile switches only after hydration, avoiding mismatched Sheet/Popover markup.

## Changes

- Updated `frontend/src/hooks/use-media-query.ts` to use `useSyncExternalStore` for hydration-safe breakpoint detection, and adjusted related hook tests.
- Updated `frontend/src/components/time-range-picker.tsx` to ensure mobile uses the full-screen Sheet layout (`inset-0`, `h-dvh`, `max-h-dvh`) rather than an anchored popover during initial render.
- Strengthened `TimeRangePicker` coverage in `frontend/src/components/code-review-overview.test.tsx` with viewport-change simulation to prevent regressions in mobile layout/full-height behavior.

## Validation

- `vitest` test suite (30 tests passed)
- TypeScript compile passed
- ESLint passed

Note: PR publication was paused due to `manual_publication_required` (browser capture/preview not available), but the automated checks above ran successfully.

[143.dev](https://143.dev) | [session 1ad48c4d](https://143.dev/sessions/1ad48c4d-cb3a-41e4-b428-c352e1c7b095)

<!-- 143-publication session=1ad48c4d-cb3a-41e4-b428-c352e1c7b095 changeset=fe5e9d67-b1de-47d4-b33c-d94d6f1fd31d -->

Preview: https://143.dev/previews/github/assembledhq/143/pull/2072?launch=1