### PR TITLE
Blend session details review card into design on right-hand page with refined UI styling

### DIFF
--- a/frontend/src/app/(dashboard)/sessions/[id]/page-overview.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/page-overview.test.tsx
@@ -471,6 +471,9 @@ describe('SessionDetailPage overview and review loop', () => {
     // of its own, so keep the structure asserted instead of the spacing utilities.
     expect(reviewSuggestion).toContainElement(reviewAction);
     expect(reviewSuggestion?.closest('[data-slot="card"]')).toBeNull();
+    // The row carries no accessible name of its own, so it stays a plain group
+    // rather than adding a landmark that just repeats the visible title.
+    expect(screen.queryByRole('region', { name: 'Review before creating a PR' })).not.toBeInTheDocument();
     expect(reviewSuggestion?.querySelector('[data-slot="overview-action-icon"] .lucide-scan-search')).toBeInTheDocument();
     expect(splitSuggestion?.querySelector('[data-slot="overview-suggestion-icon"] .lucide-git-branch')).toBeInTheDocument();
     expect(splitTitle.closest('[data-slot="card"]')).toBeNull();
@@ -577,9 +580,11 @@ describe('SessionDetailPage overview and review loop', () => {
 
     expect(statusRow).not.toBeNull();
     expect(statusRow).toHaveAttribute('role', 'status');
+    expect(statusRow).toHaveAttribute('aria-live', 'polite');
+    expect(statusRow).toHaveAttribute('aria-atomic', 'true');
     expect(statusRow?.closest('[data-slot="card"]')).toBeNull();
     expect(statusRow?.querySelector('[data-slot="overview-review-status-control"]')).toBeNull();
-    expect(statusRow?.querySelector('.lucide-loader-circle')).toBeInTheDocument();
+    expect(statusRow?.querySelector('[data-slot="overview-review-status-icon"] .lucide-loader-circle')).toBeInTheDocument();
     expect(within(statusRow as HTMLElement).getByText('The review loop is checking the changes and applying fixes.')).toBeInTheDocument();
     expect(screen.queryByRole('button', { name: 'Review & fix' })).not.toBeInTheDocument();
   });

--- a/frontend/src/app/(dashboard)/sessions/[id]/page-overview.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/page-overview.test.tsx
@@ -428,7 +428,7 @@ describe('SessionDetailPage overview and review loop', () => {
 
     await screen.findByText('Could not reproduce the error in test environment');
     expect(screen.queryByRole('button', { name: 'Review & fix' })).not.toBeInTheDocument();
-    expect(screen.queryByText('Review before creating a PR?')).not.toBeInTheDocument();
+    expect(screen.queryByText('Review before creating a PR')).not.toBeInTheDocument();
     expect(within(screen.getByLabelText('Session detail actions')).queryByRole('button', { name: 'Review' })).not.toBeInTheDocument();
     expect(screen.queryByRole('button', { name: 'Code review' })).not.toBeInTheDocument();
   });
@@ -458,26 +458,20 @@ describe('SessionDetailPage overview and review loop', () => {
 
     const reviewButton = await screen.findByRole('button', { name: 'Review & fix' });
     expect(reviewButton).toBeDisabled();
-    expect(screen.getByText('Review before creating a PR?')).toBeInTheDocument();
-    expect(screen.getByText('Ask a review agent to check the current diff and apply fixes.')).toBeInTheDocument();
+    expect(screen.getByText('Review before creating a PR')).toBeInTheDocument();
+    expect(screen.getByText('Check the current diff and apply any fixes before publishing.')).toBeInTheDocument();
     expect(reviewButton).toHaveAttribute('title', 'A reusable sandbox snapshot is required before review');
-    const reviewAction = reviewButton.closest('[data-slot="agent-action-card-action"]');
-    expect(reviewAction).toHaveClass('ml-11', 'w-fit', 'self-start');
-    expect(reviewAction).toHaveClass('@min-[24rem]/agent-action:ml-0');
-    expect(reviewAction).not.toHaveClass('w-full');
+    const reviewAction = reviewButton.closest<HTMLElement>('[data-slot="overview-action-control"]');
     expect(reviewButton).not.toHaveClass('w-full');
-    const reviewTitle = screen.getByText('Review before creating a PR?');
+    const reviewTitle = screen.getByText('Review before creating a PR');
     const splitTitle = screen.getByText('Large change · 750 additions · 1 file');
-    const reviewCard = reviewTitle.closest('[data-slot="card"]');
+    const reviewSuggestion = reviewTitle.closest('[data-slot="overview-action"]');
     const splitSuggestion = splitTitle.closest('[data-slot="overview-suggestion"]');
-    expect(reviewCard?.querySelector('[data-slot="agent-action-card-icon"] .lucide-scan-search')).toBeInTheDocument();
-    // jsdom cannot evaluate container queries, so guard the placement instead:
-    // an element is never its own query container, so the row layout would be
-    // dead if the container were declared on the element that queries it.
-    const reviewCardContent = reviewCard?.querySelector('[data-slot="card-content"]');
-    expect(reviewCard?.className).toContain('@container/agent-action');
-    expect(reviewCardContent?.className).toContain('@min-[24rem]/agent-action:flex-row');
-    expect(reviewCardContent?.className).not.toContain('@container/agent-action');
+    // The action sits in the same quiet row as the copy rather than in a card
+    // of its own, so keep the structure asserted instead of the spacing utilities.
+    expect(reviewSuggestion).toContainElement(reviewAction);
+    expect(reviewSuggestion?.closest('[data-slot="card"]')).toBeNull();
+    expect(reviewSuggestion?.querySelector('[data-slot="overview-action-icon"] .lucide-scan-search')).toBeInTheDocument();
     expect(splitSuggestion?.querySelector('[data-slot="overview-suggestion-icon"] .lucide-git-branch')).toBeInTheDocument();
     expect(splitTitle.closest('[data-slot="card"]')).toBeNull();
     expect(reviewTitle.compareDocumentPosition(splitTitle) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
@@ -542,7 +536,7 @@ describe('SessionDetailPage overview and review loop', () => {
     expect(resultSection).not.toHaveClass('pt-4');
   });
 
-  it('shows a compact status card while the Overview review loop is running', async () => {
+  it('shows a quiet inline status while the Overview review loop is running', async () => {
     server.use(
       http.get('/api/v1/sessions/:id', () => {
         return HttpResponse.json({
@@ -579,11 +573,14 @@ describe('SessionDetailPage overview and review loop', () => {
     renderWithProviders(<SessionDetailContent id="session-98765432-abcd-ef01" />);
 
     const reviewStatus = await screen.findByText('Fixing with Claude Code');
-    const statusCard = reviewStatus.closest('[data-slot="card"]');
+    const statusRow = reviewStatus.closest('[data-slot="overview-review-status"]');
 
-    expect(statusCard).not.toBeNull();
-    expect(statusCard?.querySelector('.lucide-loader-circle')).toBeInTheDocument();
-    expect(within(statusCard as HTMLElement).getByText('The review loop is checking the changes and applying fixes.')).toBeInTheDocument();
+    expect(statusRow).not.toBeNull();
+    expect(statusRow).toHaveAttribute('role', 'status');
+    expect(statusRow?.closest('[data-slot="card"]')).toBeNull();
+    expect(statusRow?.querySelector('[data-slot="overview-review-status-control"]')).toBeNull();
+    expect(statusRow?.querySelector('.lucide-loader-circle')).toBeInTheDocument();
+    expect(within(statusRow as HTMLElement).getByText('The review loop is checking the changes and applying fixes.')).toBeInTheDocument();
     expect(screen.queryByRole('button', { name: 'Review & fix' })).not.toBeInTheDocument();
   });
 

--- a/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
@@ -3484,6 +3484,53 @@ export function PullRequestList({
   );
 }
 
+type OverviewRowSlot = "overview-suggestion" | "overview-action" | "overview-review-status";
+
+// Shared chrome for the quiet, card-free Overview rows, so a suggestion, an
+// action and a status row cannot drift apart on spacing or typography. `slot`
+// names the row and its derived `-icon`/`-control` query hooks; it is applied
+// after the forwarded props, along with `className`, so callers can pass role
+// and aria attributes but cannot rename or restyle the row.
+function OverviewRow({
+  icon,
+  title,
+  description,
+  action,
+  slot,
+  ...regionProps
+}: {
+  icon: ReactNode;
+  title: string;
+  description: string;
+  action?: ReactNode;
+  slot: OverviewRowSlot;
+} & Omit<ComponentProps<"section">, "title" | "children" | "className">) {
+  return (
+    <section
+      {...regionProps}
+      data-slot={slot}
+      className="flex items-center gap-2.5 px-1 py-1.5"
+    >
+      <div
+        data-slot={`${slot}-icon`}
+        aria-hidden="true"
+        className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md bg-muted text-muted-foreground"
+      >
+        {icon}
+      </div>
+      <div className="min-w-0 flex-1">
+        <p className="text-xs font-medium text-foreground">{title}</p>
+        <p className="text-xs leading-relaxed text-muted-foreground">{description}</p>
+      </div>
+      {action != null ? (
+        <div data-slot={`${slot}-control`} className="shrink-0">
+          {action}
+        </div>
+      ) : null}
+    </section>
+  );
+}
+
 export function ChangesetSplitPrompt({
   additions,
   filesChanged,
@@ -3503,82 +3550,24 @@ export function ChangesetSplitPrompt({
     : ` · ${filesChanged.toLocaleString()} ${filesChanged === 1 ? "file" : "files"}`;
 
   return (
-    <div
+    <OverviewRow
+      slot="overview-suggestion"
       role="region"
       aria-label="Pull request size suggestion"
-      data-slot="overview-suggestion"
-      className="flex items-center gap-2.5 px-1 py-1.5"
-    >
-      <div
-        data-slot="overview-suggestion-icon"
-        aria-hidden="true"
-        className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md bg-muted text-muted-foreground"
-      >
-        <GitBranch className="h-4 w-4" />
-      </div>
-      <div className="min-w-0 flex-1">
-        <p className="text-xs font-medium text-foreground">
-          Large change · {additionCount.toLocaleString()} additions{fileLabel}
-        </p>
-        <p className="text-xs leading-relaxed text-muted-foreground">
-          Split this diff into smaller, reviewable pull requests.
-        </p>
-      </div>
-      <Button
-        size="xs"
-        variant="ghost"
-        className="shrink-0"
-        disabled={requestSplitPending || !onRequestSplit}
-        onClick={onRequestSplit}
-      >
-        Split into PRs
-      </Button>
-    </div>
-  );
-}
-
-// Shared row chrome for the quiet, card-free Overview prompts. `slot` names the
-// row so callers can keep distinct test/query hooks; anything else (role,
-// aria-live, …) is forwarded so a status row and an action row cannot drift
-// apart on spacing or typography.
-function OverviewAction({
-  icon,
-  title,
-  description,
-  action,
-  slot = "overview-action",
-  ...regionProps
-}: {
-  icon: ReactNode;
-  title: string;
-  description: string;
-  action?: ReactNode;
-  slot?: string;
-} & Omit<ComponentProps<"section">, "title" | "children" | "className">) {
-  return (
-    <section
-      aria-label={title}
-      {...regionProps}
-      data-slot={slot}
-      className="flex items-center gap-2.5 px-1 py-1.5"
-    >
-      <div
-        data-slot={`${slot}-icon`}
-        aria-hidden="true"
-        className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md bg-muted text-muted-foreground"
-      >
-        {icon}
-      </div>
-      <div className="min-w-0 flex-1">
-        <p className="text-xs font-medium text-foreground">{title}</p>
-        <p className="text-xs leading-relaxed text-muted-foreground">{description}</p>
-      </div>
-      {action ? (
-        <div data-slot={`${slot}-control`} className="shrink-0">
-          {action}
-        </div>
-      ) : null}
-    </section>
+      icon={<GitBranch className="h-4 w-4" />}
+      title={`Large change · ${additionCount.toLocaleString()} additions${fileLabel}`}
+      description="Split this diff into smaller, reviewable pull requests."
+      action={(
+        <Button
+          size="xs"
+          variant="ghost"
+          disabled={requestSplitPending || !onRequestSplit}
+          onClick={onRequestSplit}
+        >
+          Split into PRs
+        </Button>
+      )}
+    />
   );
 }
 
@@ -6749,7 +6738,7 @@ export function SessionDetailContent({ id }: { id: string }) {
           )}
           {selectedIsPrimary && canManageSession && canUseNativeReviewLoop && !hasPR && !selectedPublicationOwnsActions && hasSessionChanges ? (
             reviewLoopRunning ? (
-              <OverviewAction
+              <OverviewRow
                 slot="overview-review-status"
                 role="status"
                 aria-live="polite"
@@ -6760,7 +6749,8 @@ export function SessionDetailContent({ id }: { id: string }) {
                 description="The review loop is checking the changes and applying fixes."
               />
             ) : (
-              <OverviewAction
+              <OverviewRow
+                slot="overview-action"
                 icon={<ScanSearch className="h-4 w-4" />}
                 title="Review before creating a PR"
                 description="Check the current diff and apply any fixes before publishing."

--- a/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { memo, useCallback, useDeferredValue, useEffect, useLayoutEffect, useMemo, useRef, useState, type ReactNode } from "react";
+import { memo, useCallback, useDeferredValue, useEffect, useLayoutEffect, useMemo, useRef, useState, type ComponentProps, type ReactNode } from "react";
 import dynamic from "next/dynamic";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
@@ -3537,43 +3537,48 @@ export function ChangesetSplitPrompt({
   );
 }
 
-function AgentActionCard({
+// Shared row chrome for the quiet, card-free Overview prompts. `slot` names the
+// row so callers can keep distinct test/query hooks; anything else (role,
+// aria-live, …) is forwarded so a status row and an action row cannot drift
+// apart on spacing or typography.
+function OverviewAction({
   icon,
   title,
   description,
   action,
+  slot = "overview-action",
+  ...regionProps
 }: {
   icon: ReactNode;
   title: string;
   description: string;
-  action: ReactNode;
-}) {
+  action?: ReactNode;
+  slot?: string;
+} & Omit<ComponentProps<"section">, "title" | "children" | "className">) {
   return (
-    // The container must live on an ancestor of the elements querying it: an
-    // element is never its own query container.
-    <Card className="@container/agent-action border-border/60">
-      <CardContent className="flex flex-col gap-3 p-4 @min-[24rem]/agent-action:flex-row @min-[24rem]/agent-action:items-center @min-[24rem]/agent-action:justify-between">
-        <div className="flex min-w-0 items-start gap-3">
-          <div
-            data-slot="agent-action-card-icon"
-            aria-hidden="true"
-            className="flex h-8 w-8 shrink-0 items-center justify-center rounded-md bg-muted text-muted-foreground"
-          >
-            {icon}
-          </div>
-          <div className="min-w-0">
-            <p className="text-sm font-medium text-foreground">{title}</p>
-            <p className="text-xs leading-relaxed text-muted-foreground">{description}</p>
-          </div>
-        </div>
-        <div
-          data-slot="agent-action-card-action"
-          className="ml-11 w-fit shrink-0 self-start @min-[24rem]/agent-action:ml-0 @min-[24rem]/agent-action:self-auto"
-        >
+    <section
+      aria-label={title}
+      {...regionProps}
+      data-slot={slot}
+      className="flex items-center gap-2.5 px-1 py-1.5"
+    >
+      <div
+        data-slot={`${slot}-icon`}
+        aria-hidden="true"
+        className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md bg-muted text-muted-foreground"
+      >
+        {icon}
+      </div>
+      <div className="min-w-0 flex-1">
+        <p className="text-xs font-medium text-foreground">{title}</p>
+        <p className="text-xs leading-relaxed text-muted-foreground">{description}</p>
+      </div>
+      {action ? (
+        <div data-slot={`${slot}-control`} className="shrink-0">
           {action}
         </div>
-      </CardContent>
-    </Card>
+      ) : null}
+    </section>
   );
 }
 
@@ -6744,34 +6749,27 @@ export function SessionDetailContent({ id }: { id: string }) {
           )}
           {selectedIsPrimary && canManageSession && canUseNativeReviewLoop && !hasPR && !selectedPublicationOwnsActions && hasSessionChanges ? (
             reviewLoopRunning ? (
-              <Card className="border-border/60">
-                <CardContent className="p-4">
-                  <div className="flex min-w-0 items-start gap-2">
-                    <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-muted text-muted-foreground">
-                      <Loader2 className="h-4 w-4 animate-spin" />
-                    </div>
-                    <div className="min-w-0">
-                      <p className="text-sm font-medium text-foreground">
-                        Fixing with {AGENTS_BY_KEY[latestReviewLoop?.agent_type ?? ""]?.label ?? "review agent"}
-                      </p>
-                      <p className="text-xs leading-relaxed text-muted-foreground">
-                        The review loop is checking the changes and applying fixes.
-                      </p>
-                    </div>
-                  </div>
-                </CardContent>
-              </Card>
+              <OverviewAction
+                slot="overview-review-status"
+                role="status"
+                aria-live="polite"
+                aria-atomic="true"
+                aria-label="Review in progress"
+                icon={<Loader2 className="h-4 w-4 animate-spin" />}
+                title={`Fixing with ${AGENTS_BY_KEY[latestReviewLoop?.agent_type ?? ""]?.label ?? "review agent"}`}
+                description="The review loop is checking the changes and applying fixes."
+              />
             ) : (
-              <AgentActionCard
+              <OverviewAction
                 icon={<ScanSearch className="h-4 w-4" />}
-                title="Review before creating a PR?"
-                description="Ask a review agent to check the current diff and apply fixes."
+                title="Review before creating a PR"
+                description="Check the current diff and apply any fixes before publishing."
                 action={(
                   <DisabledTooltip disabled={reviewActionDisabled} content={reviewActionDisabledReason}>
                     <Button
                       type="button"
-                      variant="outline"
-                      size="sm"
+                      variant="ghost"
+                      size="xs"
                       disabled={reviewActionDisabled}
                       title={reviewActionDisabledReason}
                       onClick={() => setReviewConfigOpen(true)}


### PR DESCRIPTION
## Summary

The session detail overview page was showing the “Review before creating a PR” CTA in a structure that made layout/styling brittle, causing UI regressions and harder-to-maintain tests. This change aligns the review CTA with the new right-hand-page “blend” design by moving it into the shared overview action row and refining the styling, then updating the existing page-overview tests to assert the new DOM structure and copy.

## Changes

- Updated the “Review before creating a PR” CTA text and description to match the new review workflow wording.
- Changed the DOM/layout assertions for the review action: it now lives under the `overview-action` container (not a standalone `agent-action-card`), and card/spacing utility classes are no longer expected.
- Refined/adjusted related UI structure expectations (e.g., no extra `region` landmark with an accessible name for the row).

## Validation

- Updated and ran `frontend/src/app/(dashboard)/sessions/[id]/page-overview.test.tsx` to reflect the new overview action markup and ensure the CTA renders correctly.
- Verified existing test cases continue to pass for both “cannot reproduce” and disabled-review states in the session detail overview.

[143.dev](https://143.dev) | [session e18bed84](https://143.dev/sessions/e18bed84-c628-44e7-9446-50f0f0bf40ae)

<!-- 143-publication session=e18bed84-c628-44e7-9446-50f0f0bf40ae changeset=46b9211f-83a8-4e78-950d-d3ba2316bfe4 -->

Preview: https://143.dev/previews/github/assembledhq/143/pull/2074?launch=1