### PR TITLE
Optimize session details layout to reduce right-aligned content padding and rebalance icon column real estate

### DIFF
--- a/frontend/src/app/(dashboard)/sessions/[id]/page-overview.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/page-overview.test.tsx
@@ -510,7 +510,7 @@ describe('SessionDetailPage overview and review loop', () => {
     expect(prDetailsSection.closest('[data-slot="card"]')).toBeNull();
     expect(resultSection.closest('[data-slot="card"]')).toBeNull();
     expect(resultSection).toHaveClass('border-t', 'pt-4');
-    expect(resultSection.querySelector('[data-slot="session-result-heading"]')?.parentElement).toBe(resultSection);
+    expect(resultSection.querySelector('[data-slot="section-heading"]')?.parentElement).toBe(resultSection);
     const resultBody = resultSection.querySelector('[data-slot="session-result-body"]');
     expect(resultBody?.parentElement).toBe(resultSection);
     expect(resultBody?.className).not.toContain('pl-');
@@ -592,12 +592,12 @@ describe('SessionDetailPage overview and review loop', () => {
 
     expect(statusCard).not.toBeNull();
     expect(statusCard?.querySelector('.lucide-loader-circle')).toBeInTheDocument();
-    expect(within(statusCard as HTMLElement).getByText('The review loop is checking the changes and applying fixes.')).toBeInTheDocument();
     // Flat block: spinner and title share a row, description is its sibling.
-    const runningBody = statusCard?.querySelector('[data-slot="review-loop-running-body"]');
+    const runningBody = screen.getByTestId('review-loop-running-body');
+    const runningDescription = within(statusCard as HTMLElement).getByText('The review loop is checking the changes and applying fixes.');
     expect(reviewStatus.parentElement?.parentElement).toBe(runningBody);
     expect(reviewStatus.parentElement).toHaveClass('gap-1.5');
-    expect(within(statusCard as HTMLElement).getByText('The review loop is checking the changes and applying fixes.').parentElement).toBe(runningBody);
+    expect(runningDescription.parentElement).toBe(runningBody);
     expect(screen.queryByRole('button', { name: 'Review & fix' })).not.toBeInTheDocument();
   });
 

--- a/frontend/src/app/(dashboard)/sessions/[id]/page-overview.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/page-overview.test.tsx
@@ -593,6 +593,11 @@ describe('SessionDetailPage overview and review loop', () => {
     expect(statusCard).not.toBeNull();
     expect(statusCard?.querySelector('.lucide-loader-circle')).toBeInTheDocument();
     expect(within(statusCard as HTMLElement).getByText('The review loop is checking the changes and applying fixes.')).toBeInTheDocument();
+    // Flat block: spinner and title share a row, description is its sibling.
+    const runningBody = statusCard?.querySelector('[data-slot="review-loop-running-body"]');
+    expect(reviewStatus.parentElement?.parentElement).toBe(runningBody);
+    expect(reviewStatus.parentElement).toHaveClass('gap-1.5');
+    expect(within(statusCard as HTMLElement).getByText('The review loop is checking the changes and applying fixes.').parentElement).toBe(runningBody);
     expect(screen.queryByRole('button', { name: 'Review & fix' })).not.toBeInTheDocument();
   });
 

--- a/frontend/src/app/(dashboard)/sessions/[id]/page-overview.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/page-overview.test.tsx
@@ -462,8 +462,8 @@ describe('SessionDetailPage overview and review loop', () => {
     expect(screen.getByText('Ask a review agent to check the current diff and apply fixes.')).toBeInTheDocument();
     expect(reviewButton).toHaveAttribute('title', 'A reusable sandbox snapshot is required before review');
     const reviewAction = reviewButton.closest('[data-slot="agent-action-card-action"]');
-    expect(reviewAction).toHaveClass('ml-11', 'w-fit', 'self-start');
-    expect(reviewAction).toHaveClass('@min-[24rem]/agent-action:ml-0');
+    expect(reviewAction).toHaveClass('w-fit', 'self-start');
+    expect(reviewAction).not.toHaveClass('ml-11');
     expect(reviewAction).not.toHaveClass('w-full');
     expect(reviewButton).not.toHaveClass('w-full');
     const reviewTitle = screen.getByText('Review before creating a PR?');
@@ -478,6 +478,10 @@ describe('SessionDetailPage overview and review loop', () => {
     expect(reviewCard?.className).toContain('@container/agent-action');
     expect(reviewCardContent?.className).toContain('@min-[24rem]/agent-action:flex-row');
     expect(reviewCardContent?.className).not.toContain('@container/agent-action');
+    const reviewIcon = reviewCard?.querySelector('[data-slot="agent-action-card-icon"]');
+    expect(reviewIcon?.className).not.toContain('h-8');
+    expect(reviewIcon?.className).not.toContain('w-8');
+    expect(reviewIcon?.className).not.toContain('bg-muted');
     expect(splitSuggestion?.querySelector('[data-slot="overview-suggestion-icon"] .lucide-git-branch')).toBeInTheDocument();
     expect(splitTitle.closest('[data-slot="card"]')).toBeNull();
     expect(reviewTitle.compareDocumentPosition(splitTitle) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
@@ -506,6 +510,11 @@ describe('SessionDetailPage overview and review loop', () => {
     expect(prDetailsSection.closest('[data-slot="card"]')).toBeNull();
     expect(resultSection.closest('[data-slot="card"]')).toBeNull();
     expect(resultSection).toHaveClass('border-t', 'pt-4');
+    expect(resultSection.querySelector('[data-slot="session-result-heading"]')?.parentElement).toBe(resultSection);
+    const resultBody = resultSection.querySelector('[data-slot="session-result-body"]');
+    expect(resultBody?.parentElement).toBe(resultSection);
+    expect(resultBody?.className).not.toContain('pl-');
+    expect(resultBody?.className).not.toContain('ml-');
     expect(prDetailsSection.compareDocumentPosition(resultSection) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
     expect(resultSection.compareDocumentPosition(splitSuggestion) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
   });

--- a/frontend/src/app/(dashboard)/sessions/[id]/page-pr-creation.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/page-pr-creation.test.tsx
@@ -356,18 +356,18 @@ describe('SessionDetailPage PR creation', () => {
     renderWithProviders(<SessionDetailContent id={detail.id} />);
 
     const workflow = await screen.findByTestId('publication-workflow-card');
-    expect(within(workflow).getByText('No publication needed')).toBeInTheDocument();
-    expect(within(workflow).getByText('The completed workflow found no changes to publish.')).toBeInTheDocument();
+    const title = within(workflow).getByText('No publication needed');
+    const description = within(workflow).getByText('The completed workflow found no changes to publish.');
+    expect(title).toBeInTheDocument();
+    expect(description).toBeInTheDocument();
     expect(within(workflow).queryByText('Needs attention')).not.toBeInTheDocument();
 
     // Flat block: the status icon leads the title row and the description is a
     // sibling of that row, not a column indented past an icon tile.
-    const heading = within(workflow).getByText('No publication needed').parentElement;
+    const heading = title.parentElement;
     expect(heading).toHaveClass('gap-1.5');
     expect(heading?.querySelector('.lucide-circle-check')).toBeInTheDocument();
-    const description = within(workflow).getByText('The completed workflow found no changes to publish.');
     expect(description.parentElement).toBe(heading?.parentElement);
-    expect(description.className).not.toContain('pl-');
   });
 
   // A no-op publication is the one settled outcome with neither a pull request

--- a/frontend/src/app/(dashboard)/sessions/[id]/page-pr-creation.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/page-pr-creation.test.tsx
@@ -359,6 +359,15 @@ describe('SessionDetailPage PR creation', () => {
     expect(within(workflow).getByText('No publication needed')).toBeInTheDocument();
     expect(within(workflow).getByText('The completed workflow found no changes to publish.')).toBeInTheDocument();
     expect(within(workflow).queryByText('Needs attention')).not.toBeInTheDocument();
+
+    // Flat block: the status icon leads the title row and the description is a
+    // sibling of that row, not a column indented past an icon tile.
+    const heading = within(workflow).getByText('No publication needed').parentElement;
+    expect(heading).toHaveClass('gap-1.5');
+    expect(heading?.querySelector('.lucide-circle-check')).toBeInTheDocument();
+    const description = within(workflow).getByText('The completed workflow found no changes to publish.');
+    expect(description.parentElement).toBe(heading?.parentElement);
+    expect(description.className).not.toContain('pl-');
   });
 
   // A no-op publication is the one settled outcome with neither a pull request

--- a/frontend/src/app/(dashboard)/sessions/[id]/page-pr-health.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/page-pr-health.test.tsx
@@ -428,6 +428,14 @@ describe('SessionDetailPage PR health and merge', () => {
     const closedSection = screen.getByText('PR #42 was closed without merging.').closest('[data-slot="pr-closed-section"]');
     expect(closedSection).toBeInTheDocument();
     expect(closedSection?.closest('[data-slot="card"]')).toBeNull();
+    // Flat block: the icon leads the title row and the body copy runs the full
+    // width underneath rather than being indented past an icon column.
+    const closedIcon = closedSection?.querySelector('[data-slot="pr-closed-icon"]');
+    expect(closedIcon).toHaveAttribute('aria-hidden', 'true');
+    expect(closedIcon?.querySelector('.lucide-circle-x')).toBeInTheDocument();
+    const closedSummary = screen.getByText('PR #42 was closed without merging.');
+    expect(closedSummary.parentElement).toBe(closedSection);
+    expect(closedSummary.className).not.toContain('pl-');
     expect(screen.getByTestId('session-result-section')).toHaveClass('border-t', 'pt-4');
     expect(screen.getByRole('link', { name: 'View PR' })).toBeInTheDocument();
     expect(screen.queryByRole('region', { name: 'Pull request #42' })).not.toBeInTheDocument();
@@ -624,9 +632,14 @@ describe('SessionDetailPage PR health and merge', () => {
     expect(screen.getByText('PR #42 was merged successfully.')).toHaveClass('text-xs');
     expect(screen.getByText('This change has landed. Open a follow-up session if you need to make another revision.')).toHaveClass('text-xs');
     expect(screen.getByRole('link', { name: 'View PR' })).toBeInTheDocument();
-    expect(screen.getByLabelText('Merged PR status')).toHaveClass('text-success');
-    const mergedSection = screen.getByLabelText('Merged PR status').closest('[data-slot="pr-merged-section"]');
+    const mergedSection = document.querySelector('[data-slot="pr-merged-section"]');
     expect(mergedSection).toBeInTheDocument();
+    // The icon repeats the adjacent "PR #<n> merged" text, so it stays out of
+    // the accessibility tree like every other status icon in the overview.
+    const mergedIcon = mergedSection?.querySelector('[data-slot="pr-merged-icon"]');
+    expect(mergedIcon).toHaveClass('text-success');
+    expect(mergedIcon).toHaveAttribute('aria-hidden', 'true');
+    expect(screen.queryByLabelText('Merged PR status')).not.toBeInTheDocument();
     expect(mergedSection?.closest('[data-slot="card"]')).toBeNull();
     expect(screen.getByTestId('session-result-section')).toHaveClass('border-t', 'pt-4');
     expect(screen.queryAllByText('PR created')).toHaveLength(0);

--- a/frontend/src/app/(dashboard)/sessions/[id]/page-pr-health.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/page-pr-health.test.tsx
@@ -425,7 +425,8 @@ describe('SessionDetailPage PR health and merge', () => {
 
     expect((await screen.findAllByText('PR #42 closed')).length).toBeGreaterThanOrEqual(2);
     expect(screen.getByText('PR #42 was closed without merging.')).toBeInTheDocument();
-    const closedSection = screen.getByText('PR #42 was closed without merging.').closest('[data-slot="pr-closed-section"]');
+    const closedSummary = screen.getByText('PR #42 was closed without merging.');
+    const closedSection = closedSummary.closest('[data-slot="pr-closed-section"]');
     expect(closedSection).toBeInTheDocument();
     expect(closedSection?.closest('[data-slot="card"]')).toBeNull();
     // Flat block: the icon leads the title row and the body copy runs the full
@@ -433,9 +434,7 @@ describe('SessionDetailPage PR health and merge', () => {
     const closedIcon = closedSection?.querySelector('[data-slot="pr-closed-icon"]');
     expect(closedIcon).toHaveAttribute('aria-hidden', 'true');
     expect(closedIcon?.querySelector('.lucide-circle-x')).toBeInTheDocument();
-    const closedSummary = screen.getByText('PR #42 was closed without merging.');
     expect(closedSummary.parentElement).toBe(closedSection);
-    expect(closedSummary.className).not.toContain('pl-');
     expect(screen.getByTestId('session-result-section')).toHaveClass('border-t', 'pt-4');
     expect(screen.getByRole('link', { name: 'View PR' })).toBeInTheDocument();
     expect(screen.queryByRole('region', { name: 'Pull request #42' })).not.toBeInTheDocument();
@@ -632,7 +631,7 @@ describe('SessionDetailPage PR health and merge', () => {
     expect(screen.getByText('PR #42 was merged successfully.')).toHaveClass('text-xs');
     expect(screen.getByText('This change has landed. Open a follow-up session if you need to make another revision.')).toHaveClass('text-xs');
     expect(screen.getByRole('link', { name: 'View PR' })).toBeInTheDocument();
-    const mergedSection = document.querySelector('[data-slot="pr-merged-section"]');
+    const mergedSection = screen.getByText('PR #42 was merged successfully.').closest('[data-slot="pr-merged-section"]');
     expect(mergedSection).toBeInTheDocument();
     // The icon repeats the adjacent "PR #<n> merged" text, so it stays out of
     // the accessibility tree like every other status icon in the overview.

--- a/frontend/src/app/(dashboard)/sessions/[id]/page-session-states.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/page-session-states.test.tsx
@@ -274,6 +274,17 @@ describe('SessionDetailPage session states', () => {
     expect(await screen.findByText('Your organization is already at its max concurrency limit of 2 running sessions.')).toBeInTheDocument();
     expect(screen.getByText('This session will start automatically when another session finishes or the limit is raised.')).toBeInTheDocument();
     expect(screen.queryByText('Setting up environment')).not.toBeInTheDocument();
+
+    // Flat block: clock, title and badge share one row, and both body lines are
+    // direct children so nothing is indented past a former icon tile.
+    const body = document.querySelector('[data-slot="pending-capacity-body"]');
+    expect(body).toBeInTheDocument();
+    const heading = screen.getByText('Waiting for capacity').parentElement;
+    expect(heading?.parentElement).toBe(body);
+    expect(heading).toHaveClass('gap-1.5');
+    expect(heading?.querySelector('.lucide-clock')).toBeInTheDocument();
+    expect(screen.getByText('Max concurrency reached').parentElement).toBe(heading);
+    expect(screen.getByText('This session will start automatically when another session finishes or the limit is raised.').parentElement).toBe(body);
   });
 
   it('shows the environment setup message for a pending session when the org is below its concurrency limit', async () => {

--- a/frontend/src/app/(dashboard)/sessions/[id]/page-session-states.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/page-session-states.test.tsx
@@ -277,8 +277,7 @@ describe('SessionDetailPage session states', () => {
 
     // Flat block: clock, title and badge share one row, and both body lines are
     // direct children so nothing is indented past a former icon tile.
-    const body = document.querySelector('[data-slot="pending-capacity-body"]');
-    expect(body).toBeInTheDocument();
+    const body = screen.getByTestId('pending-capacity-body');
     const heading = screen.getByText('Waiting for capacity').parentElement;
     expect(heading?.parentElement).toBe(body);
     expect(heading).toHaveClass('gap-1.5');

--- a/frontend/src/app/(dashboard)/sessions/[id]/pull-request-list.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/pull-request-list.test.tsx
@@ -118,7 +118,7 @@ describe('ChangesetSplitPrompt', () => {
     expect(onRequestSplit).toHaveBeenCalledOnce();
   });
 
-  it('renders as a quiet suggestion row instead of another card', () => {
+  it('renders as a quiet full-width suggestion instead of another card', () => {
     render(
       <ChangesetSplitPrompt
         additions={CHANGESET_SPLIT_MIN_ADDITIONS}
@@ -128,7 +128,8 @@ describe('ChangesetSplitPrompt', () => {
 
     const suggestion = screen.getByRole('region', { name: 'Pull request size suggestion' });
     expect(suggestion).toHaveAttribute('data-slot', 'overview-suggestion');
-    expect(suggestion).toHaveClass('flex', 'items-center');
+    expect(suggestion).toHaveClass('space-y-1.5');
+    expect(screen.getByText('Split this diff into smaller, reviewable pull requests.').parentElement).toBe(suggestion);
     expect(suggestion.closest('[data-slot="card"]')).toBeNull();
   });
 

--- a/frontend/src/app/(dashboard)/sessions/[id]/pull-request-list.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/pull-request-list.test.tsx
@@ -162,6 +162,8 @@ describe('ChangesetSplitPrompt', () => {
     const button = screen.getByRole('button', { name: 'Split into PRs' });
     expect(button).toHaveAttribute('data-size', 'xs');
     expect(button).toHaveAttribute('data-variant', 'ghost');
-    expect(button).toHaveClass('shrink-0');
+    // Pinned to the trailing auto-sized column, so the title column absorbs the
+    // slack instead of squeezing the action.
+    expect(button).toHaveClass('col-start-3');
   });
 });

--- a/frontend/src/app/(dashboard)/sessions/[id]/pull-request-list.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/pull-request-list.test.tsx
@@ -128,9 +128,27 @@ describe('ChangesetSplitPrompt', () => {
 
     const suggestion = screen.getByRole('region', { name: 'Pull request size suggestion' });
     expect(suggestion).toHaveAttribute('data-slot', 'overview-suggestion');
-    expect(suggestion).toHaveClass('space-y-1.5');
-    expect(screen.getByText('Split this diff into smaller, reviewable pull requests.').parentElement).toBe(suggestion);
+    const description = screen.getByText('Split this diff into smaller, reviewable pull requests.');
+    expect(description.parentElement).toBe(suggestion);
+    expect(description).toHaveClass('col-span-3');
     expect(suggestion.closest('[data-slot="card"]')).toBeNull();
+  });
+
+  // The button sits on the title row visually, but a reader should still meet
+  // the sentence explaining the action before the action itself.
+  it('reads the split description before the split action', () => {
+    render(
+      <ChangesetSplitPrompt
+        additions={CHANGESET_SPLIT_MIN_ADDITIONS}
+        onRequestSplit={vi.fn()}
+      />,
+    );
+
+    const description = screen.getByText('Split this diff into smaller, reviewable pull requests.');
+    const action = screen.getByRole('button', { name: 'Split into PRs' });
+
+    expect(description.compareDocumentPosition(action) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    expect(action).toHaveClass('row-start-1');
   });
 
   it('uses a compact ghost action that stays aligned on narrow panels', () => {

--- a/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
@@ -395,16 +395,12 @@ function PublicationWorkflowCard({
   return (
     <Card className={cn("border-border/60", needsAttention && "border-warning/50 bg-warning/5")} data-testid="publication-workflow-card">
       <CardContent className="space-y-3 p-4">
-        <div className="space-y-1">
-          <div className="flex items-center gap-1.5">
-            <div className={cn(
-              "shrink-0",
-              settled ? "text-success" : needsAttention ? "text-warning" : "text-info",
-            )} aria-hidden="true">
-              {settled ? <CheckCircle2 className="h-4 w-4" /> : needsAttention ? <AlertTriangle className="h-4 w-4" /> : <Loader2 className="h-4 w-4 animate-spin" />}
-            </div>
-            <p className="text-sm font-medium text-foreground">{title}</p>
-          </div>
+        <div className="space-y-1.5">
+          <SectionHeading
+            icon={settled ? <CheckCircle2 className="h-4 w-4" /> : needsAttention ? <AlertTriangle className="h-4 w-4" /> : <Loader2 className="h-4 w-4 animate-spin" />}
+            iconClassName={settled ? "text-success" : needsAttention ? "text-warning" : "text-info"}
+            title={title}
+          />
           <p className="text-xs leading-relaxed text-muted-foreground">{description}</p>
           {published && prNumber ? <p className="text-xs text-muted-foreground">Pull request #{prNumber}</p> : null}
         </div>
@@ -728,14 +724,16 @@ function SessionResultSection({ summary, divided }: { summary?: string; divided:
   return (
     <section
       aria-label="Session result"
-      className={cn(divided && "border-t border-border/60 pt-4")}
+      className={cn("space-y-1.5", divided && "border-t border-border/60 pt-4")}
       data-testid="session-result-section"
     >
-      <div className="flex items-center gap-1.5" data-slot="session-result-heading">
-        <CheckCircle2 aria-hidden="true" className="h-4 w-4 shrink-0 text-success" />
-        <div className="text-sm font-medium text-foreground">Result</div>
-      </div>
-      <div className="mt-2 min-w-0" data-slot="session-result-body">
+      <SectionHeading
+        slot="session-result-heading"
+        icon={<CheckCircle2 className="h-4 w-4" />}
+        iconClassName="text-success"
+        title="Result"
+      />
+      <div data-slot="session-result-body">
         <LazyMarkdownContent content={summary} className="text-xs" />
       </div>
     </section>
@@ -3320,8 +3318,8 @@ function PendingCapacityNotice({ maxConcurrentRuns }: { maxConcurrentRuns?: numb
   return (
     <div className="flex justify-center py-8">
       <Card className="w-full max-w-[34rem] border-amber-200/70 bg-amber-50/70 shadow-none dark:border-amber-900/60 dark:bg-amber-950/20">
-        <CardContent className="min-w-0 space-y-1.5 p-4">
-          <div className="flex flex-wrap items-center gap-2">
+        <CardContent className="space-y-1.5 p-4" data-slot="pending-capacity-body">
+          <div className="flex flex-wrap items-center gap-1.5">
             <Clock className="h-4 w-4 shrink-0 text-amber-700 dark:text-amber-300" aria-hidden />
             <p className="text-sm font-semibold text-foreground">Waiting for capacity</p>
             <Badge variant="outline" className="border-amber-300/80 bg-background/70 text-amber-800 dark:border-amber-800 dark:text-amber-300">
@@ -3494,32 +3492,32 @@ export function ChangesetSplitPrompt({
     : ` · ${filesChanged.toLocaleString()} ${filesChanged === 1 ? "file" : "files"}`;
 
   return (
+    // A grid rather than stacked flex rows: the button renders on the title row
+    // but still follows its own description in reading order.
     <div
       role="region"
       aria-label="Pull request size suggestion"
       data-slot="overview-suggestion"
-      className="space-y-1.5 px-1 py-1.5"
+      className="grid grid-cols-[auto_minmax(0,1fr)_auto] items-center gap-x-1.5 gap-y-1.5 px-1 py-1.5"
     >
-      <div className="flex items-center gap-1.5">
-        <div data-slot="overview-suggestion-icon" aria-hidden="true" className="shrink-0 text-muted-foreground">
-          <GitBranch className="h-4 w-4" />
-        </div>
-        <p className="min-w-0 flex-1 text-xs font-medium text-foreground">
-          Large change · {additionCount.toLocaleString()} additions{fileLabel}
-        </p>
-        <Button
-          size="xs"
-          variant="ghost"
-          className="shrink-0"
-          disabled={requestSplitPending || !onRequestSplit}
-          onClick={onRequestSplit}
-        >
-          Split into PRs
-        </Button>
+      <div data-slot="overview-suggestion-icon" aria-hidden="true" className="text-muted-foreground">
+        <GitBranch className="h-4 w-4" />
       </div>
-      <p className="text-xs leading-relaxed text-muted-foreground">
+      <p className="text-xs font-medium text-foreground">
+        Large change · {additionCount.toLocaleString()} additions{fileLabel}
+      </p>
+      <p className="col-span-3 row-start-2 text-xs leading-relaxed text-muted-foreground">
         Split this diff into smaller, reviewable pull requests.
       </p>
+      <Button
+        size="xs"
+        variant="ghost"
+        className="col-start-3 row-start-1 shrink-0"
+        disabled={requestSplitPending || !onRequestSplit}
+        onClick={onRequestSplit}
+      >
+        Split into PRs
+      </Button>
     </div>
   );
 }
@@ -3541,16 +3539,7 @@ function AgentActionCard({
     <Card className="@container/agent-action border-border/60">
       <CardContent className="flex flex-col gap-3 p-4 @min-[24rem]/agent-action:flex-row @min-[24rem]/agent-action:items-center @min-[24rem]/agent-action:justify-between">
         <div className="min-w-0 flex-1 space-y-1.5">
-          <div className="flex items-center gap-1.5">
-            <div
-              data-slot="agent-action-card-icon"
-              aria-hidden="true"
-              className="shrink-0 text-muted-foreground"
-            >
-              {icon}
-            </div>
-            <p className="text-sm font-medium text-foreground">{title}</p>
-          </div>
+          <SectionHeading iconSlot="agent-action-card-icon" iconClassName="text-muted-foreground" icon={icon} title={title} />
           <p className="text-xs leading-relaxed text-muted-foreground">{description}</p>
         </div>
         <div
@@ -3561,6 +3550,32 @@ function AgentActionCard({
         </div>
       </CardContent>
     </Card>
+  );
+}
+
+// Every status block in the overview leads with a 16px icon and a title on one
+// row, then full-width body copy underneath. Sharing the row keeps the icon gap
+// and title type from drifting apart across the nine places that render it.
+function SectionHeading({
+  icon,
+  iconClassName,
+  iconSlot,
+  slot,
+  title,
+}: {
+  icon: ReactNode;
+  iconClassName?: string;
+  iconSlot?: string;
+  slot?: string;
+  title: ReactNode;
+}) {
+  return (
+    <div className="flex items-center gap-1.5" data-slot={slot}>
+      <span aria-hidden="true" data-slot={iconSlot} className={cn("shrink-0", iconClassName)}>
+        {icon}
+      </span>
+      <p className="text-sm font-medium text-foreground">{title}</p>
+    </div>
   );
 }
 
@@ -6483,22 +6498,26 @@ export function SessionDetailContent({ id }: { id: string }) {
       </section>
     ) : null
   ) : prStatus === "closed" ? (
-    <section className="space-y-1" data-slot="pr-closed-section">
-      <div className="flex items-center gap-1.5">
-        <XCircle aria-hidden="true" className="h-4 w-4 shrink-0 text-muted-foreground" />
-        <div className="text-sm font-medium text-foreground">{closedPRLabel}</div>
-      </div>
+    <section className="space-y-1.5" data-slot="pr-closed-section">
+      <SectionHeading
+        iconSlot="pr-closed-icon"
+        icon={<XCircle className="h-4 w-4" />}
+        iconClassName="text-muted-foreground"
+        title={closedPRLabel}
+      />
       <p className="text-xs text-foreground">{closedPRSummary}</p>
       <p className="text-xs text-muted-foreground">
         This pull request is no longer active. Create a follow-up revision if you want to ship a new attempt.
       </p>
     </section>
   ) : prStatus === "merged" ? (
-    <section className="space-y-1" data-slot="pr-merged-section">
-      <div className="flex items-center gap-1.5">
-        <CheckCircle2 aria-label="Merged PR status" className={cn("h-4 w-4 shrink-0", prMergedAccent.text)} />
-        <div className="text-sm font-medium text-foreground">{mergedPRLabel}</div>
-      </div>
+    <section className="space-y-1.5" data-slot="pr-merged-section">
+      <SectionHeading
+        iconSlot="pr-merged-icon"
+        icon={<CheckCircle2 className="h-4 w-4" />}
+        iconClassName={prMergedAccent.text}
+        title={mergedPRLabel}
+      />
       <p className="text-xs text-foreground">{mergedPRSummary}</p>
       <p className="text-xs text-muted-foreground">
         This change has landed. Open a follow-up session if you need to make another revision.
@@ -6728,13 +6747,12 @@ export function SessionDetailContent({ id }: { id: string }) {
           {selectedIsPrimary && canManageSession && canUseNativeReviewLoop && !hasPR && !selectedPublicationOwnsActions && hasSessionChanges ? (
             reviewLoopRunning ? (
               <Card className="border-border/60">
-                <CardContent className="min-w-0 space-y-1.5 p-4">
-                  <div className="flex items-center gap-1.5">
-                    <Loader2 aria-hidden="true" className="h-4 w-4 shrink-0 animate-spin text-muted-foreground" />
-                    <p className="text-sm font-medium text-foreground">
-                      Fixing with {AGENTS_BY_KEY[latestReviewLoop?.agent_type ?? ""]?.label ?? "review agent"}
-                    </p>
-                  </div>
+                <CardContent className="space-y-1.5 p-4" data-slot="review-loop-running-body">
+                  <SectionHeading
+                    icon={<Loader2 className="h-4 w-4 animate-spin" />}
+                    iconClassName="text-muted-foreground"
+                    title={`Fixing with ${AGENTS_BY_KEY[latestReviewLoop?.agent_type ?? ""]?.label ?? "review agent"}`}
+                  />
                   <p className="text-xs leading-relaxed text-muted-foreground">
                     The review loop is checking the changes and applying fixes.
                   </p>

--- a/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
@@ -305,6 +305,30 @@ function publicationErrorDescription(publication: SessionPublication) {
   }
 }
 
+// Every status block in the overview leads with a 16px icon and a title on one
+// row, then full-width body copy underneath. Sharing the row keeps the icon gap
+// and title type from drifting apart across the places that render it.
+function SectionHeading({
+  icon,
+  iconClassName,
+  iconSlot,
+  title,
+}: {
+  icon: ReactNode;
+  iconClassName?: string;
+  iconSlot?: string;
+  title: ReactNode;
+}) {
+  return (
+    <div className="flex items-center gap-1.5" data-slot="section-heading">
+      <span aria-hidden="true" data-slot={iconSlot} className={cn("shrink-0", iconClassName)}>
+        {icon}
+      </span>
+      <p className="text-sm font-medium text-foreground">{title}</p>
+    </div>
+  );
+}
+
 function PublicationWorkflowCard({
   publication,
   reviewLoop,
@@ -722,17 +746,14 @@ function SessionResultSection({ summary, divided }: { summary?: string; divided:
   if (!summary) return null;
 
   return (
+    // Looser than the other status blocks on purpose: the body here is a
+    // markdown block rather than a one-line caption.
     <section
       aria-label="Session result"
-      className={cn("space-y-1.5", divided && "border-t border-border/60 pt-4")}
+      className={cn("space-y-2", divided && "border-t border-border/60 pt-4")}
       data-testid="session-result-section"
     >
-      <SectionHeading
-        slot="session-result-heading"
-        icon={<CheckCircle2 className="h-4 w-4" />}
-        iconClassName="text-success"
-        title="Result"
-      />
+      <SectionHeading icon={<CheckCircle2 className="h-4 w-4" />} iconClassName="text-success" title="Result" />
       <div data-slot="session-result-body">
         <LazyMarkdownContent content={summary} className="text-xs" />
       </div>
@@ -3318,7 +3339,7 @@ function PendingCapacityNotice({ maxConcurrentRuns }: { maxConcurrentRuns?: numb
   return (
     <div className="flex justify-center py-8">
       <Card className="w-full max-w-[34rem] border-amber-200/70 bg-amber-50/70 shadow-none dark:border-amber-900/60 dark:bg-amber-950/20">
-        <CardContent className="space-y-1.5 p-4" data-slot="pending-capacity-body">
+        <CardContent className="space-y-1.5 p-4" data-testid="pending-capacity-body">
           <div className="flex flex-wrap items-center gap-1.5">
             <Clock className="h-4 w-4 shrink-0 text-amber-700 dark:text-amber-300" aria-hidden />
             <p className="text-sm font-semibold text-foreground">Waiting for capacity</p>
@@ -3512,7 +3533,7 @@ export function ChangesetSplitPrompt({
       <Button
         size="xs"
         variant="ghost"
-        className="col-start-3 row-start-1 shrink-0"
+        className="col-start-3 row-start-1"
         disabled={requestSplitPending || !onRequestSplit}
         onClick={onRequestSplit}
       >
@@ -3550,32 +3571,6 @@ function AgentActionCard({
         </div>
       </CardContent>
     </Card>
-  );
-}
-
-// Every status block in the overview leads with a 16px icon and a title on one
-// row, then full-width body copy underneath. Sharing the row keeps the icon gap
-// and title type from drifting apart across the nine places that render it.
-function SectionHeading({
-  icon,
-  iconClassName,
-  iconSlot,
-  slot,
-  title,
-}: {
-  icon: ReactNode;
-  iconClassName?: string;
-  iconSlot?: string;
-  slot?: string;
-  title: ReactNode;
-}) {
-  return (
-    <div className="flex items-center gap-1.5" data-slot={slot}>
-      <span aria-hidden="true" data-slot={iconSlot} className={cn("shrink-0", iconClassName)}>
-        {icon}
-      </span>
-      <p className="text-sm font-medium text-foreground">{title}</p>
-    </div>
   );
 }
 
@@ -6747,7 +6742,7 @@ export function SessionDetailContent({ id }: { id: string }) {
           {selectedIsPrimary && canManageSession && canUseNativeReviewLoop && !hasPR && !selectedPublicationOwnsActions && hasSessionChanges ? (
             reviewLoopRunning ? (
               <Card className="border-border/60">
-                <CardContent className="space-y-1.5 p-4" data-slot="review-loop-running-body">
+                <CardContent className="space-y-1.5 p-4" data-testid="review-loop-running-body">
                   <SectionHeading
                     icon={<Loader2 className="h-4 w-4 animate-spin" />}
                     iconClassName="text-muted-foreground"

--- a/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
@@ -321,7 +321,9 @@ function SectionHeading({
 }) {
   return (
     <div className="flex items-center gap-1.5" data-slot="section-heading">
-      <span aria-hidden="true" data-slot={iconSlot} className={cn("shrink-0", iconClassName)}>
+      {/* Pin the glyph size here so a caller-supplied icon cannot reintroduce
+          the size drift this component exists to prevent. */}
+      <span aria-hidden="true" data-slot={iconSlot} className={cn("shrink-0 [&_svg]:size-4", iconClassName)}>
         {icon}
       </span>
       <p className="text-sm font-medium text-foreground">{title}</p>

--- a/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
@@ -395,18 +395,18 @@ function PublicationWorkflowCard({
   return (
     <Card className={cn("border-border/60", needsAttention && "border-warning/50 bg-warning/5")} data-testid="publication-workflow-card">
       <CardContent className="space-y-3 p-4">
-        <div className="flex items-start gap-3">
-          <div className={cn(
-            "flex h-8 w-8 shrink-0 items-center justify-center rounded-full",
-            settled ? "bg-success/10 text-success" : needsAttention ? "bg-warning/10 text-warning" : "bg-info/10 text-info",
-          )}>
-            {settled ? <CheckCircle2 className="h-4 w-4" /> : needsAttention ? <AlertTriangle className="h-4 w-4" /> : <Loader2 className="h-4 w-4 animate-spin" />}
-          </div>
-          <div className="min-w-0 flex-1 space-y-1">
+        <div className="space-y-1">
+          <div className="flex items-center gap-1.5">
+            <div className={cn(
+              "shrink-0",
+              settled ? "text-success" : needsAttention ? "text-warning" : "text-info",
+            )} aria-hidden="true">
+              {settled ? <CheckCircle2 className="h-4 w-4" /> : needsAttention ? <AlertTriangle className="h-4 w-4" /> : <Loader2 className="h-4 w-4 animate-spin" />}
+            </div>
             <p className="text-sm font-medium text-foreground">{title}</p>
-            <p className="text-xs leading-relaxed text-muted-foreground">{description}</p>
-            {published && prNumber ? <p className="text-xs text-muted-foreground">Pull request #{prNumber}</p> : null}
           </div>
+          <p className="text-xs leading-relaxed text-muted-foreground">{description}</p>
+          {published && prNumber ? <p className="text-xs text-muted-foreground">Pull request #{prNumber}</p> : null}
         </div>
         <div className="flex flex-wrap gap-2">
           {published && prURL ? (
@@ -731,17 +731,12 @@ function SessionResultSection({ summary, divided }: { summary?: string; divided:
       className={cn(divided && "border-t border-border/60 pt-4")}
       data-testid="session-result-section"
     >
-      <div className="flex items-start gap-2.5">
-        <div
-          aria-hidden="true"
-          className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md bg-success/10 text-success"
-        >
-          <CheckCircle2 className="h-4 w-4" />
-        </div>
-        <div className="min-w-0 flex-1">
-          <div className="text-sm font-medium text-foreground">Result</div>
-          <LazyMarkdownContent content={summary} className="mt-2 text-xs" />
-        </div>
+      <div className="flex items-center gap-1.5" data-slot="session-result-heading">
+        <CheckCircle2 aria-hidden="true" className="h-4 w-4 shrink-0 text-success" />
+        <div className="text-sm font-medium text-foreground">Result</div>
+      </div>
+      <div className="mt-2 min-w-0" data-slot="session-result-body">
+        <LazyMarkdownContent content={summary} className="text-xs" />
       </div>
     </section>
   );
@@ -3325,22 +3320,18 @@ function PendingCapacityNotice({ maxConcurrentRuns }: { maxConcurrentRuns?: numb
   return (
     <div className="flex justify-center py-8">
       <Card className="w-full max-w-[34rem] border-amber-200/70 bg-amber-50/70 shadow-none dark:border-amber-900/60 dark:bg-amber-950/20">
-        <CardContent className="flex gap-3 p-4">
-          <div className="mt-0.5 flex h-9 w-9 shrink-0 items-center justify-center rounded-md border border-amber-200 bg-background text-amber-700 dark:border-amber-900/70 dark:text-amber-300">
-            <Clock className="h-4 w-4" aria-hidden />
+        <CardContent className="min-w-0 space-y-1.5 p-4">
+          <div className="flex flex-wrap items-center gap-2">
+            <Clock className="h-4 w-4 shrink-0 text-amber-700 dark:text-amber-300" aria-hidden />
+            <p className="text-sm font-semibold text-foreground">Waiting for capacity</p>
+            <Badge variant="outline" className="border-amber-300/80 bg-background/70 text-amber-800 dark:border-amber-800 dark:text-amber-300">
+              Max concurrency reached
+            </Badge>
           </div>
-          <div className="min-w-0 space-y-1.5">
-            <div className="flex flex-wrap items-center gap-2">
-              <p className="text-sm font-semibold text-foreground">Waiting for capacity</p>
-              <Badge variant="outline" className="border-amber-300/80 bg-background/70 text-amber-800 dark:border-amber-800 dark:text-amber-300">
-                Max concurrency reached
-              </Badge>
-            </div>
-            <p className="text-sm text-muted-foreground">{limitText}</p>
-            <p className="text-sm text-muted-foreground">
-              This session will start automatically when another session finishes or the limit is raised.
-            </p>
-          </div>
+          <p className="text-sm text-muted-foreground">{limitText}</p>
+          <p className="text-sm text-muted-foreground">
+            This session will start automatically when another session finishes or the limit is raised.
+          </p>
         </CardContent>
       </Card>
     </div>
@@ -3507,32 +3498,28 @@ export function ChangesetSplitPrompt({
       role="region"
       aria-label="Pull request size suggestion"
       data-slot="overview-suggestion"
-      className="flex items-center gap-2.5 px-1 py-1.5"
+      className="space-y-1.5 px-1 py-1.5"
     >
-      <div
-        data-slot="overview-suggestion-icon"
-        aria-hidden="true"
-        className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md bg-muted text-muted-foreground"
-      >
-        <GitBranch className="h-4 w-4" />
-      </div>
-      <div className="min-w-0 flex-1">
-        <p className="text-xs font-medium text-foreground">
+      <div className="flex items-center gap-1.5">
+        <div data-slot="overview-suggestion-icon" aria-hidden="true" className="shrink-0 text-muted-foreground">
+          <GitBranch className="h-4 w-4" />
+        </div>
+        <p className="min-w-0 flex-1 text-xs font-medium text-foreground">
           Large change · {additionCount.toLocaleString()} additions{fileLabel}
         </p>
-        <p className="text-xs leading-relaxed text-muted-foreground">
-          Split this diff into smaller, reviewable pull requests.
-        </p>
+        <Button
+          size="xs"
+          variant="ghost"
+          className="shrink-0"
+          disabled={requestSplitPending || !onRequestSplit}
+          onClick={onRequestSplit}
+        >
+          Split into PRs
+        </Button>
       </div>
-      <Button
-        size="xs"
-        variant="ghost"
-        className="shrink-0"
-        disabled={requestSplitPending || !onRequestSplit}
-        onClick={onRequestSplit}
-      >
-        Split into PRs
-      </Button>
+      <p className="text-xs leading-relaxed text-muted-foreground">
+        Split this diff into smaller, reviewable pull requests.
+      </p>
     </div>
   );
 }
@@ -3553,22 +3540,22 @@ function AgentActionCard({
     // element is never its own query container.
     <Card className="@container/agent-action border-border/60">
       <CardContent className="flex flex-col gap-3 p-4 @min-[24rem]/agent-action:flex-row @min-[24rem]/agent-action:items-center @min-[24rem]/agent-action:justify-between">
-        <div className="flex min-w-0 items-start gap-3">
-          <div
-            data-slot="agent-action-card-icon"
-            aria-hidden="true"
-            className="flex h-8 w-8 shrink-0 items-center justify-center rounded-md bg-muted text-muted-foreground"
-          >
-            {icon}
-          </div>
-          <div className="min-w-0">
+        <div className="min-w-0 flex-1 space-y-1.5">
+          <div className="flex items-center gap-1.5">
+            <div
+              data-slot="agent-action-card-icon"
+              aria-hidden="true"
+              className="shrink-0 text-muted-foreground"
+            >
+              {icon}
+            </div>
             <p className="text-sm font-medium text-foreground">{title}</p>
-            <p className="text-xs leading-relaxed text-muted-foreground">{description}</p>
           </div>
+          <p className="text-xs leading-relaxed text-muted-foreground">{description}</p>
         </div>
         <div
           data-slot="agent-action-card-action"
-          className="ml-11 w-fit shrink-0 self-start @min-[24rem]/agent-action:ml-0 @min-[24rem]/agent-action:self-auto"
+          className="w-fit shrink-0 self-start @min-[24rem]/agent-action:self-auto"
         >
           {action}
         </div>
@@ -6496,30 +6483,26 @@ export function SessionDetailContent({ id }: { id: string }) {
       </section>
     ) : null
   ) : prStatus === "closed" ? (
-    <section className="flex items-start gap-2.5" data-slot="pr-closed-section">
-      <div aria-hidden="true" className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md bg-muted text-muted-foreground">
-        <XCircle className="h-4 w-4" />
-      </div>
-      <div className="min-w-0 space-y-1">
+    <section className="space-y-1" data-slot="pr-closed-section">
+      <div className="flex items-center gap-1.5">
+        <XCircle aria-hidden="true" className="h-4 w-4 shrink-0 text-muted-foreground" />
         <div className="text-sm font-medium text-foreground">{closedPRLabel}</div>
-        <p className="text-xs text-foreground">{closedPRSummary}</p>
-        <p className="text-xs text-muted-foreground">
-          This pull request is no longer active. Create a follow-up revision if you want to ship a new attempt.
-        </p>
       </div>
+      <p className="text-xs text-foreground">{closedPRSummary}</p>
+      <p className="text-xs text-muted-foreground">
+        This pull request is no longer active. Create a follow-up revision if you want to ship a new attempt.
+      </p>
     </section>
   ) : prStatus === "merged" ? (
-    <section className="flex items-start gap-2.5" data-slot="pr-merged-section">
-      <div aria-label="Merged PR status" className={cn("flex h-7 w-7 shrink-0 items-center justify-center rounded-md", prMergedAccent.bg, prMergedAccent.text)}>
-        <CheckCircle2 className="h-4 w-4" />
-      </div>
-      <div className="min-w-0 space-y-1">
+    <section className="space-y-1" data-slot="pr-merged-section">
+      <div className="flex items-center gap-1.5">
+        <CheckCircle2 aria-label="Merged PR status" className={cn("h-4 w-4 shrink-0", prMergedAccent.text)} />
         <div className="text-sm font-medium text-foreground">{mergedPRLabel}</div>
-        <p className="text-xs text-foreground">{mergedPRSummary}</p>
-        <p className="text-xs text-muted-foreground">
-          This change has landed. Open a follow-up session if you need to make another revision.
-        </p>
       </div>
+      <p className="text-xs text-foreground">{mergedPRSummary}</p>
+      <p className="text-xs text-muted-foreground">
+        This change has landed. Open a follow-up session if you need to make another revision.
+      </p>
     </section>
   ) : null;
   // Right-panel content. Rendered inline on desktop and inside a bottom sheet
@@ -6745,20 +6728,16 @@ export function SessionDetailContent({ id }: { id: string }) {
           {selectedIsPrimary && canManageSession && canUseNativeReviewLoop && !hasPR && !selectedPublicationOwnsActions && hasSessionChanges ? (
             reviewLoopRunning ? (
               <Card className="border-border/60">
-                <CardContent className="p-4">
-                  <div className="flex min-w-0 items-start gap-2">
-                    <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-muted text-muted-foreground">
-                      <Loader2 className="h-4 w-4 animate-spin" />
-                    </div>
-                    <div className="min-w-0">
-                      <p className="text-sm font-medium text-foreground">
-                        Fixing with {AGENTS_BY_KEY[latestReviewLoop?.agent_type ?? ""]?.label ?? "review agent"}
-                      </p>
-                      <p className="text-xs leading-relaxed text-muted-foreground">
-                        The review loop is checking the changes and applying fixes.
-                      </p>
-                    </div>
+                <CardContent className="min-w-0 space-y-1.5 p-4">
+                  <div className="flex items-center gap-1.5">
+                    <Loader2 aria-hidden="true" className="h-4 w-4 shrink-0 animate-spin text-muted-foreground" />
+                    <p className="text-sm font-medium text-foreground">
+                      Fixing with {AGENTS_BY_KEY[latestReviewLoop?.agent_type ?? ""]?.label ?? "review agent"}
+                    </p>
                   </div>
+                  <p className="text-xs leading-relaxed text-muted-foreground">
+                    The review loop is checking the changes and applying fixes.
+                  </p>
                 </CardContent>
               </Card>
             ) : (

--- a/frontend/src/components/pr-health-banner.test.tsx
+++ b/frontend/src/components/pr-health-banner.test.tsx
@@ -61,6 +61,12 @@ describe("PRHealthBanner", () => {
     const body = prHealthSection.querySelector('[data-slot="pr-health-body"]');
     expect(body?.parentElement).toBe(prHealthSection);
     expect(body?.className).not.toContain("pl-");
+    // The icon carries the status tone as a bare color and repeats the adjacent
+    // badge, so it stays out of the accessibility tree.
+    const icon = prHealthSection.querySelector('[data-slot="pr-health-status-icon"]');
+    expect(icon).toHaveClass("text-success");
+    expect(icon).toHaveAttribute("aria-hidden", "true");
+    expect(icon?.className).not.toContain("bg-");
   });
 
   it.each([
@@ -100,6 +106,7 @@ describe("PRHealthBanner", () => {
     {
       label: "Repairing",
       variant: "info",
+      iconColor: "text-info",
       health: {
         checks_confirmed: true,
         has_conflicts: true,
@@ -114,6 +121,7 @@ describe("PRHealthBanner", () => {
     {
       label: "Conflicts",
       variant: "warning",
+      iconColor: "text-warning",
       health: {
         checks_confirmed: true,
         has_conflicts: true,
@@ -123,6 +131,7 @@ describe("PRHealthBanner", () => {
     {
       label: "Checks failing",
       variant: "destructive",
+      iconColor: "text-destructive",
       health: {
         checks_confirmed: true,
         checks: [{ name: "unit", category: "test", status: "failed" }],
@@ -131,19 +140,22 @@ describe("PRHealthBanner", () => {
     {
       label: "Behind",
       variant: "warning",
+      iconColor: "text-warning",
       health: { checks_confirmed: true, merge_state: "behind" },
     },
     {
       label: "Blocked",
       variant: "warning",
+      iconColor: "text-warning",
       health: { checks_confirmed: true, merge_state: "blocked" },
     },
     {
       label: "Open",
       variant: "secondary",
+      iconColor: "text-muted-foreground",
       health: { checks_confirmed: true, merge_state: "clean" },
     },
-  ])("labels the pull request $label", ({ label, variant, health }) => {
+  ])("labels the pull request $label", ({ label, variant, iconColor, health }) => {
     renderWithProviders(
       <PRHealthBanner
         health={{ ...baseHealth, ...health } as PullRequestHealthResponse}
@@ -157,6 +169,12 @@ describe("PRHealthBanner", () => {
     );
 
     expect(screen.getByText(label, { selector: "[data-slot='badge']" })).toHaveAttribute("data-variant", variant);
+    // The status icon carries the same tone as the badge, as a bare text color.
+    const icon = screen.getByRole("region", { name: "Pull request #42" })
+      .querySelector('[data-slot="pr-health-status-icon"]');
+    expect(icon).toHaveClass(iconColor);
+    expect(icon).toHaveAttribute("aria-hidden", "true");
+    expect(icon?.className).not.toContain("bg-");
   });
 
   it("keeps the Merge button visible but disabled when can_merge is false", async () => {

--- a/frontend/src/components/pr-health-banner.test.tsx
+++ b/frontend/src/components/pr-health-banner.test.tsx
@@ -58,6 +58,9 @@ describe("PRHealthBanner", () => {
     expect(screen.getByText("Ready")).toHaveAttribute("data-variant", "success");
     expect(screen.getByText("acme/widgets")).toHaveClass("text-xs");
     expect(screen.getByText("Healthy.")).toHaveClass("text-xs");
+    const body = prHealthSection.querySelector('[data-slot="pr-health-body"]');
+    expect(body?.parentElement).toBe(prHealthSection);
+    expect(body?.className).not.toContain("pl-");
   });
 
   it.each([

--- a/frontend/src/components/pr-health-banner.tsx
+++ b/frontend/src/components/pr-health-banner.tsx
@@ -157,7 +157,7 @@ export function PRHealthBanner({
       <div className="flex items-start justify-between gap-2.5">
         <div className="min-w-0 flex-1 space-y-1">
           <div className="flex flex-wrap items-center gap-1.5">
-            <div aria-hidden="true" className={cn("shrink-0", prHealthStatusIconClassName(statusPresentation.variant))}>
+            <div aria-hidden="true" className={cn("shrink-0", prHealthStatusIconColor(statusPresentation.variant))}>
               {statusPresentation.variant === "success" ? <CheckCircle2 className="h-4 w-4" /> : isRepositoryDisconnected ? <AlertTriangle className="h-4 w-4" /> : <GitPullRequest className="h-4 w-4" />}
             </div>
             <div className="text-sm font-medium text-foreground">PR #{health.pull_request_number}</div>
@@ -572,7 +572,7 @@ function derivePRHealthStatusPresentation({
   return { label: "Open", variant: "secondary" };
 }
 
-function prHealthStatusIconClassName(variant: PRHealthStatusPresentation["variant"]): string {
+function prHealthStatusIconColor(variant: PRHealthStatusPresentation["variant"]): string {
   switch (variant) {
     case "success":
       return "text-success";

--- a/frontend/src/components/pr-health-banner.tsx
+++ b/frontend/src/components/pr-health-banner.tsx
@@ -154,23 +154,18 @@ export function PRHealthBanner({
       className="space-y-2.5"
       data-slot="pr-health-section"
     >
-      <div className="flex items-start gap-2.5">
-        <div className="flex min-w-0 flex-1 items-start gap-2.5">
-          <div className={cn(
-            "flex h-7 w-7 shrink-0 items-center justify-center rounded-md",
-            prHealthStatusIconClassName(statusPresentation.variant),
-          )}>
-            {statusPresentation.variant === "success" ? <CheckCircle2 className="h-4 w-4" /> : isRepositoryDisconnected ? <AlertTriangle className="h-4 w-4" /> : <GitPullRequest className="h-4 w-4" />}
-          </div>
-          <div className="min-w-0">
-            <div className="flex flex-wrap items-center gap-1.5">
-              <div className="text-sm font-medium text-foreground">PR #{health.pull_request_number}</div>
-              <Badge variant={statusPresentation.variant} className="h-5 px-1.5 py-0 text-xs">
-                {statusPresentation.label}
-              </Badge>
+      <div className="flex items-start justify-between gap-2.5">
+        <div className="min-w-0 flex-1 space-y-1">
+          <div className="flex flex-wrap items-center gap-1.5">
+            <div aria-hidden="true" className={cn("shrink-0", prHealthStatusIconClassName(statusPresentation.variant))}>
+              {statusPresentation.variant === "success" ? <CheckCircle2 className="h-4 w-4" /> : isRepositoryDisconnected ? <AlertTriangle className="h-4 w-4" /> : <GitPullRequest className="h-4 w-4" />}
             </div>
-            <div className="truncate text-xs text-muted-foreground">{health.repository}</div>
+            <div className="text-sm font-medium text-foreground">PR #{health.pull_request_number}</div>
+            <Badge variant={statusPresentation.variant} className="h-5 px-1.5 py-0 text-xs">
+              {statusPresentation.label}
+            </Badge>
           </div>
+          <div className="truncate text-xs text-muted-foreground">{health.repository}</div>
         </div>
         {isRepositoryDisconnected ? (
           <span className="shrink-0 whitespace-nowrap text-xs font-medium text-warning">Sync blocked</span>
@@ -182,9 +177,7 @@ export function PRHealthBanner({
         )}
       </div>
 
-      {/* Indent matches the header's icon tile (h-7) plus its gap-2.5 so the
-          body copy lines up with "PR #<n>" instead of the icon. */}
-      <div className="space-y-2 pl-[2.375rem]">
+      <div className="space-y-2" data-slot="pr-health-body">
         <p className="text-xs text-foreground">{compactSummary}</p>
 
         {hasStatusBadges && (
@@ -582,15 +575,15 @@ function derivePRHealthStatusPresentation({
 function prHealthStatusIconClassName(variant: PRHealthStatusPresentation["variant"]): string {
   switch (variant) {
     case "success":
-      return "bg-success/10 text-success";
+      return "text-success";
     case "destructive":
-      return "bg-destructive/10 text-destructive";
+      return "text-destructive";
     case "warning":
-      return "bg-warning/10 text-warning";
+      return "text-warning";
     case "info":
-      return "bg-info/10 text-info";
+      return "text-info";
     case "secondary":
-      return "bg-muted text-muted-foreground";
+      return "text-muted-foreground";
   }
 }
 

--- a/frontend/src/components/pr-health-banner.tsx
+++ b/frontend/src/components/pr-health-banner.tsx
@@ -155,9 +155,16 @@ export function PRHealthBanner({
       data-slot="pr-health-section"
     >
       <div className="flex items-start justify-between gap-2.5">
+        {/* Tighter than the flat status blocks elsewhere on purpose: this gap
+            separates the title row from its repository sub-label, not from body
+            copy — the body sits below under the section's own space-y-2.5. */}
         <div className="min-w-0 flex-1 space-y-1">
           <div className="flex flex-wrap items-center gap-1.5">
-            <div aria-hidden="true" className={cn("shrink-0", prHealthStatusIconColor(statusPresentation.variant))}>
+            <div
+              aria-hidden="true"
+              data-slot="pr-health-status-icon"
+              className={cn("shrink-0", prHealthStatusIconColor(statusPresentation.variant))}
+            >
               {statusPresentation.variant === "success" ? <CheckCircle2 className="h-4 w-4" /> : isRepositoryDisconnected ? <AlertTriangle className="h-4 w-4" /> : <GitPullRequest className="h-4 w-4" />}
             </div>
             <div className="text-sm font-medium text-foreground">PR #{health.pull_request_number}</div>


### PR DESCRIPTION
## Summary

The session details page has overly padded, right-aligned content that wastes horizontal space and makes the review/PR health area feel misbalanced. This change compacts the layout by removing the extra left margin on the review action, reducing icon sizing/background styling, and flattening certain “running” states so spinner/title/description align consistently. This reduces visual noise and improves reliability of the UI contract via updated tests.

## Changes

- Rebalanced session detail layout spacing: removed the `ml-11` margin from the review action container and adjusted expected Tailwind utility classes in page overview tests.
- Compact icon column: updated assertions to ensure the agent action icon no longer uses the previous fixed `h-8/w-8` sizing or muted background styling.
- Improved structure for review loop “running” state: introduced a stable `data-testid="review-loop-running-body"` wrapper and flattened spinner/title/description layout to match the new visual design.
- Tightened PR health/banner content layout expectations and removed left/right padding/margins from result body sections in tests.

## Validation

- 237 focused tests updated/ran (including session overview, PR creation/health, and session state tests)
- ESLint on touched files
- Full frontend TypeScript check
- Preview started successfully; screenshot capture failed in the preview browser layer, but console showed no app errors

[143.dev](https://143.dev) | [session 54d617a0](https://143.dev/sessions/54d617a0-6f52-47ea-a8a8-deff389b0f9a)

<!-- 143-publication session=54d617a0-6f52-47ea-a8a8-deff389b0f9a changeset=aadd06e2-689a-4014-9bcb-18191ab546e0 -->

Preview: https://143.dev/previews/github/assembledhq/143/pull/2077?launch=1