### PR TITLE
Add horizontal divider and completed status to session details view; reduce bottom info overflow

### DIFF
--- a/frontend/src/app/(dashboard)/sessions/[id]/page-overview.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/page-overview.test.tsx
@@ -386,6 +386,34 @@ describe('SessionDetailPage overview and review loop', () => {
     const vitals = await screen.findByTestId('session-overview-vitals');
     expect(vitals).toHaveClass('border-t', 'border-border/60', 'pt-4');
     expect(within(vitals).getByText('Completed')).toBeInTheDocument();
+    // Load-bearing: re-adding a wrapper around OverviewTab would make the
+    // vitals that wrapper's first child, silently collapsing the rule while
+    // real content still sits above them in the panel.
+    expect(vitals.parentElement!.firstElementChild).not.toBe(vitals);
+  });
+
+  it('keeps the vitals divider below a failure card raised by the same tab', async () => {
+    // The block above comes from inside OverviewTab rather than from the panel;
+    // the rule only draws if the two are flat siblings after the flattening.
+    server.use(
+      http.get('/api/v1/sessions/:id', () => {
+        return HttpResponse.json({
+          data: {
+            ...mockSessions[0],
+            status: 'failed',
+            failure_explanation: 'Could not reproduce the error in test environment',
+            threads: [],
+          },
+        } satisfies SingleResponse<Session>);
+      }),
+    );
+
+    renderWithProviders(<SessionDetailContent id="session-abcdef12-3456-7890" />);
+
+    const vitals = await screen.findByTestId('session-overview-vitals');
+    expect(vitals).toHaveClass('border-t', 'first:pt-0');
+    expect(vitals.previousElementSibling).toHaveTextContent('Failure details');
+    // Not the first child, so `first:pt-0` stays inert and the rule draws.
     expect(vitals.parentElement!.firstElementChild).not.toBe(vitals);
   });
 

--- a/frontend/src/app/(dashboard)/sessions/[id]/page-overview.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/page-overview.test.tsx
@@ -380,25 +380,93 @@ describe('SessionDetailPage overview and review loop', () => {
     expect(metadataRow).toHaveTextContent(/Completed/);
   });
 
-  it('separates completed session vitals and omits low-value audit update metadata', async () => {
+  it('separates the session vitals from the blocks stacked above it', async () => {
+    renderWithProviders(<SessionDetailContent id="session-abcdef12-3456-7890" />);
+
+    const vitals = await screen.findByTestId('session-overview-vitals');
+    expect(vitals).toHaveClass('border-t', 'border-border/60', 'pt-4');
+    expect(within(vitals).getByText('Completed')).toBeInTheDocument();
+    expect(vitals.parentElement!.firstElementChild).not.toBe(vitals);
+  });
+
+  it('collapses the vitals divider when nothing renders above it', async () => {
+    // A bare session — no pull request, no result summary, a single changeset —
+    // renders nothing above the vitals, so the rule has to collapse instead of
+    // drawing across the top of the Overview panel separating nothing.
     server.use(
-      http.get('/api/v1/audit-logs', () => {
+      http.get('/api/v1/sessions/:id', () => {
         return HttpResponse.json({
-          data: [{
-            id: 'audit-1',
-            actor_type: 'system',
-            action: 'session.completed',
-            created_at: new Date(Date.now() - 12 * 60000).toISOString(),
-          }],
-          meta: {},
+          data: {
+            ...mockSessions[0],
+            status: 'pending',
+            started_at: null,
+            completed_at: null,
+            result_summary: null,
+            diff_stats: undefined,
+            threads: [],
+            changesets: [],
+          },
         });
       }),
+      http.get('/api/v1/sessions/:id/pr', () => HttpResponse.json({ data: null })),
+      http.get('/api/v1/sessions/:id/changesets', () => HttpResponse.json({ data: [], meta: {} })),
     );
 
     renderWithProviders(<SessionDetailContent id="session-abcdef12-3456-7890" />);
 
     const vitals = await screen.findByTestId('session-overview-vitals');
-    expect(vitals).toHaveClass('border-t', 'border-border/60', 'pt-4');
+    expect(vitals).toHaveClass('first:border-t-0', 'first:pt-0');
+    // `first:border-t-0` resolves against the vitals' own parent, so the reset
+    // is only reachable while the overview blocks stay flat siblings. Re-adding
+    // a wrapper around OverviewTab would make the vitals a first child of that
+    // wrapper while real content still sits above them in the panel.
+    const panel = vitals.closest('[role="tabpanel"]')!;
+    expect(vitals.parentElement).toBe(panel.firstElementChild);
+    expect(vitals.parentElement!.firstElementChild).toBe(vitals);
+  });
+
+  // The audit trigger only mounts once /auth/me confirms an admin and the
+  // latest-entry query resolves. Both are seeded into the cache so the trigger
+  // renders in the same commit as the vitals block — a `queryByRole` on the
+  // unsettled DOM passes whether or not the status gate exists.
+  function renderWithSeededAuditTrail(sessionId: string) {
+    const latestEntry = {
+      id: 'audit-1',
+      actor_type: 'system',
+      action: 'session.completed',
+      created_at: new Date(Date.now() - 12 * 60000).toISOString(),
+    };
+    // The seed is what makes the assertions synchronous; the handler has to
+    // agree with it so the refetch on mount doesn't wipe the entry back out.
+    server.use(
+      http.get('/api/v1/audit-logs', () => HttpResponse.json({ data: [latestEntry], meta: {} })),
+    );
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    queryClient.setQueryData(['auth', 'me'], { data: mockMembers[0] });
+    queryClient.setQueryData(['audit-logs', 'latest', { session_id: sessionId }], {
+      data: [latestEntry],
+      meta: {},
+    });
+    return renderSessionDetailWithQueryClient(sessionId, queryClient);
+  }
+
+  it('keeps the session activity trigger inline while a session is still running', async () => {
+    server.use(
+      http.get('/api/v1/sessions/:id', () => {
+        return HttpResponse.json({ data: { ...mockSessions[0], status: 'running', completed_at: null } });
+      }),
+    );
+
+    renderWithSeededAuditTrail('session-abcdef12-3456-7890');
+
+    const vitals = await screen.findByTestId('session-overview-vitals');
+    expect(await within(vitals).findByRole('button', { name: /Updated.*ago by/i })).toBeInTheDocument();
+  });
+
+  it('omits low-value audit update metadata once a session has completed', async () => {
+    renderWithSeededAuditTrail('session-abcdef12-3456-7890');
+
+    const vitals = await screen.findByTestId('session-overview-vitals');
     expect(within(vitals).getByText('Completed')).toBeInTheDocument();
     expect(within(vitals).queryByRole('button', { name: /Updated.*ago by/i })).not.toBeInTheDocument();
   });

--- a/frontend/src/app/(dashboard)/sessions/[id]/page-overview.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/page-overview.test.tsx
@@ -380,6 +380,29 @@ describe('SessionDetailPage overview and review loop', () => {
     expect(metadataRow).toHaveTextContent(/Completed/);
   });
 
+  it('separates completed session vitals and omits low-value audit update metadata', async () => {
+    server.use(
+      http.get('/api/v1/audit-logs', () => {
+        return HttpResponse.json({
+          data: [{
+            id: 'audit-1',
+            actor_type: 'system',
+            action: 'session.completed',
+            created_at: new Date(Date.now() - 12 * 60000).toISOString(),
+          }],
+          meta: {},
+        });
+      }),
+    );
+
+    renderWithProviders(<SessionDetailContent id="session-abcdef12-3456-7890" />);
+
+    const vitals = await screen.findByTestId('session-overview-vitals');
+    expect(vitals).toHaveClass('border-t', 'border-border/60', 'pt-4');
+    expect(within(vitals).getByText('Completed')).toBeInTheDocument();
+    expect(within(vitals).queryByRole('button', { name: /Updated.*ago by/i })).not.toBeInTheDocument();
+  });
+
   it('keeps issue-trigger provenance compact without redundant workflow copy', async () => {
     server.use(
       http.get('/api/v1/sessions/:id', () => {

--- a/frontend/src/app/(dashboard)/sessions/[id]/page-overview.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/page-overview.test.tsx
@@ -399,14 +399,12 @@ describe('SessionDetailPage overview and review loop', () => {
           data: {
             ...mockSessions[0],
             status: 'pending',
-            started_at: null,
-            completed_at: null,
-            result_summary: null,
-            diff_stats: undefined,
+            started_at: undefined,
+            completed_at: undefined,
+            result_summary: undefined,
             threads: [],
-            changesets: [],
           },
-        });
+        } satisfies SingleResponse<Session>);
       }),
       http.get('/api/v1/sessions/:id/pr', () => HttpResponse.json({ data: null })),
       http.get('/api/v1/sessions/:id/changesets', () => HttpResponse.json({ data: [], meta: {} })),
@@ -453,7 +451,9 @@ describe('SessionDetailPage overview and review loop', () => {
   it('keeps the session activity trigger inline while a session is still running', async () => {
     server.use(
       http.get('/api/v1/sessions/:id', () => {
-        return HttpResponse.json({ data: { ...mockSessions[0], status: 'running', completed_at: null } });
+        return HttpResponse.json({
+          data: { ...mockSessions[0], status: 'running', completed_at: undefined },
+        } satisfies SingleResponse<Session>);
       }),
     );
 
@@ -463,13 +463,25 @@ describe('SessionDetailPage overview and review loop', () => {
     expect(await within(vitals).findByRole('button', { name: /Updated.*ago by/i })).toBeInTheDocument();
   });
 
-  it('omits low-value audit update metadata once a session has completed', async () => {
-    renderWithSeededAuditTrail('session-abcdef12-3456-7890');
+  // Both success terminals are gated, so both need covering — dropping either
+  // clause otherwise leaves the suite green.
+  it.each(['completed', 'pr_created'] as const)(
+    'omits low-value audit update metadata once a session is %s',
+    async (status) => {
+      server.use(
+        http.get('/api/v1/sessions/:id', () => {
+          return HttpResponse.json({
+            data: { ...mockSessions[0], status },
+          } satisfies SingleResponse<Session>);
+        }),
+      );
 
-    const vitals = await screen.findByTestId('session-overview-vitals');
-    expect(within(vitals).getByText('Completed')).toBeInTheDocument();
-    expect(within(vitals).queryByRole('button', { name: /Updated.*ago by/i })).not.toBeInTheDocument();
-  });
+      renderWithSeededAuditTrail('session-abcdef12-3456-7890');
+
+      const vitals = await screen.findByTestId('session-overview-vitals');
+      expect(within(vitals).queryByRole('button', { name: /Updated.*ago by/i })).not.toBeInTheDocument();
+    },
+  );
 
   it('keeps issue-trigger provenance compact without redundant workflow copy', async () => {
     server.use(

--- a/frontend/src/app/(dashboard)/sessions/[id]/pull-request-list.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/pull-request-list.test.tsx
@@ -128,6 +128,7 @@ describe('ChangesetSplitPrompt', () => {
 
     const suggestion = screen.getByRole('region', { name: 'Pull request size suggestion' });
     expect(suggestion).toHaveAttribute('data-slot', 'overview-suggestion');
+    expect(suggestion).toHaveClass('border-t', 'border-border/60', 'pt-4');
     const description = screen.getByText('Split this diff into smaller, reviewable pull requests.');
     expect(description.parentElement).toBe(suggestion);
     expect(description).toHaveClass('col-span-3');

--- a/frontend/src/app/(dashboard)/sessions/[id]/pull-request-list.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/pull-request-list.test.tsx
@@ -129,6 +129,10 @@ describe('ChangesetSplitPrompt', () => {
     const suggestion = screen.getByRole('region', { name: 'Pull request size suggestion' });
     expect(suggestion).toHaveAttribute('data-slot', 'overview-suggestion');
     expect(suggestion).toHaveClass('border-t', 'border-border/60', 'pt-4');
+    // As a first child the rule collapses, but this row carries its own
+    // `py-1.5`, so the collapse has to fall back to that rather than to zero.
+    expect(suggestion).toHaveClass('first:border-t-0', 'first:pt-1.5');
+    expect(suggestion).not.toHaveClass('first:pt-0');
     const description = screen.getByText('Split this diff into smaller, reviewable pull requests.');
     expect(description.parentElement).toBe(suggestion);
     expect(description).toHaveClass('col-span-3');

--- a/frontend/src/app/(dashboard)/sessions/[id]/pull-request-list.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/pull-request-list.test.tsx
@@ -129,9 +129,10 @@ describe('ChangesetSplitPrompt', () => {
     const suggestion = screen.getByRole('region', { name: 'Pull request size suggestion' });
     expect(suggestion).toHaveAttribute('data-slot', 'overview-suggestion');
     expect(suggestion).toHaveClass('border-t', 'border-border/60', 'pt-4');
-    // As a first child the rule collapses, but this row carries its own
-    // `py-1.5`, so the collapse has to fall back to that rather than to zero.
-    expect(suggestion).toHaveClass('first:border-t-0', 'first:pt-1.5');
+    // As a first child the rule collapses, but this row carries its own top
+    // padding, so it has to fall back to that rather than to zero. Asserted as
+    // a pair: changing the base padding without the reset fails here.
+    expect(suggestion).toHaveClass('py-1.5', 'first:border-t-0', 'first:pt-1.5');
     expect(suggestion).not.toHaveClass('first:pt-0');
     const description = screen.getByText('Split this diff into smaller, reviewable pull requests.');
     expect(description.parentElement).toBe(suggestion);

--- a/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
@@ -744,6 +744,12 @@ function ThreadFailureDetailsCard({ thread }: { thread: SessionThread }) {
   );
 }
 
+// Rule drawn above a stacked Overview block. Every block above any given one is
+// conditional (no PR, no result summary, a single changeset, …), so the `first:`
+// resets keep the divider from drawing across the top of the panel with nothing
+// above it.
+const OVERVIEW_DIVIDER_CLASSNAME = "border-t border-border/60 pt-4 first:border-t-0 first:pt-0";
+
 function SessionResultSection({ summary, divided }: { summary?: string; divided: boolean }) {
   if (!summary) return null;
 
@@ -752,7 +758,7 @@ function SessionResultSection({ summary, divided }: { summary?: string; divided:
     // markdown block rather than a one-line caption.
     <section
       aria-label="Session result"
-      className={cn("space-y-2", divided && "border-t border-border/60 pt-4")}
+      className={cn("space-y-2", divided && OVERVIEW_DIVIDER_CLASSNAME)}
       data-testid="session-result-section"
     >
       <SectionHeading icon={<CheckCircle2 className="h-4 w-4" />} iconClassName="text-success" title="Result" />
@@ -807,7 +813,11 @@ function OverviewTab({ session, activeThread, members, prStatus }: { session: Se
       : "System";
 
   return (
-    <div className="space-y-4">
+    // Fragment rather than a wrapper: the parent panel is already `space-y-4`,
+    // so flattening keeps the same spacing while letting the divider below
+    // resolve `first:` against the whole Overview panel instead of against a
+    // nested div where the vitals block is always the first child.
+    <>
       {isDeployRecovery && (
         <Card className="border-l-2 border-l-warning bg-warning/5">
           <CardHeader className="pb-2">
@@ -946,7 +956,7 @@ function OverviewTab({ session, activeThread, members, prStatus }: { session: Se
       {/* Session vitals — identity row (status + agent + who triggered) */}
       <div
         data-testid="session-overview-vitals"
-        className="space-y-1.5 border-t border-border/60 pt-4"
+        className={cn("space-y-1.5", OVERVIEW_DIVIDER_CLASSNAME)}
       >
         <div className="flex items-center gap-x-3 gap-y-1 flex-wrap text-xs">
           <StatusLabel
@@ -1006,6 +1016,12 @@ function OverviewTab({ session, activeThread, members, prStatus }: { session: Se
                 <>Queued {formatTimeAgo(session.created_at)}</>
               )}
             </span>
+            {/*
+              Suppressed on the two success terminals only: their last audit
+              entry restates the "Completed …" caption immediately to its left.
+              Failed/cancelled/skipped sessions keep the trigger because their
+              activity trail is what explains how they got there.
+            */}
             {session.status !== "completed" && session.status !== "pr_created" && (
               <AuditLogTrigger
                 filters={{ session_id: session.id }}
@@ -1042,7 +1058,7 @@ function OverviewTab({ session, activeThread, members, prStatus }: { session: Se
           </Card>
         )}
 
-    </div>
+    </>
   );
 }
 
@@ -3530,7 +3546,7 @@ function OverviewRow({
       data-slot={slot}
       className={cn(
         "grid grid-cols-[auto_minmax(0,1fr)_auto] items-center gap-x-1.5 gap-y-1.5 px-1 py-1.5",
-        divided && "border-t border-border/60 pt-4",
+        divided && OVERVIEW_DIVIDER_CLASSNAME,
       )}
     >
       <div

--- a/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
@@ -944,7 +944,10 @@ function OverviewTab({ session, activeThread, members, prStatus }: { session: Se
       )}
 
       {/* Session vitals — identity row (status + agent + who triggered) */}
-      <div className="space-y-1.5">
+      <div
+        data-testid="session-overview-vitals"
+        className="space-y-1.5 border-t border-border/60 pt-4"
+      >
         <div className="flex items-center gap-x-3 gap-y-1 flex-wrap text-xs">
           <StatusLabel
             label={operationalStatus.label}
@@ -1003,12 +1006,14 @@ function OverviewTab({ session, activeThread, members, prStatus }: { session: Se
                 <>Queued {formatTimeAgo(session.created_at)}</>
               )}
             </span>
-            <AuditLogTrigger
-              filters={{ session_id: session.id }}
-              members={members}
-              title="Session activity"
-              variant="inline"
-            />
+            {session.status !== "completed" && session.status !== "pr_created" && (
+              <AuditLogTrigger
+                filters={{ session_id: session.id }}
+                members={members}
+                title="Session activity"
+                variant="inline"
+              />
+            )}
           </div>
         </div>
       </div>
@@ -3508,6 +3513,7 @@ function OverviewRow({
   title,
   description,
   action,
+  divided = false,
   slot,
   ...regionProps
 }: {
@@ -3515,13 +3521,17 @@ function OverviewRow({
   title: string;
   description: string;
   action?: ReactNode;
+  divided?: boolean;
   slot: OverviewRowSlot;
 } & Omit<ComponentProps<"section">, "title" | "children" | "className">) {
   return (
     <section
       {...regionProps}
       data-slot={slot}
-      className="grid grid-cols-[auto_minmax(0,1fr)_auto] items-center gap-x-1.5 gap-y-1.5 px-1 py-1.5"
+      className={cn(
+        "grid grid-cols-[auto_minmax(0,1fr)_auto] items-center gap-x-1.5 gap-y-1.5 px-1 py-1.5",
+        divided && "border-t border-border/60 pt-4",
+      )}
     >
       <div
         data-slot={`${slot}-icon`}
@@ -3567,6 +3577,7 @@ export function ChangesetSplitPrompt({
       icon={<GitBranch className="h-4 w-4" />}
       title={`Large change · ${additionCount.toLocaleString()} additions${fileLabel}`}
       description="Split this diff into smaller, reviewable pull requests."
+      divided
       action={(
         <Button
           size="xs"

--- a/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
@@ -745,10 +745,11 @@ function ThreadFailureDetailsCard({ thread }: { thread: SessionThread }) {
 }
 
 // Rule drawn above a stacked Overview block. Every block above any given one is
-// conditional (no PR, no result summary, a single changeset, …), so the `first:`
-// resets keep the divider from drawing across the top of the panel with nothing
-// above it.
-const OVERVIEW_DIVIDER_CLASSNAME = "border-t border-border/60 pt-4 first:border-t-0 first:pt-0";
+// conditional (no PR, no result summary, a single changeset, …), so
+// `first:border-t-0` keeps the rule from drawing across the top of the panel
+// with nothing above it. Call sites pair this with their own `first:pt-*`: the
+// padding the rule collapses back to is whatever that block already had.
+const OVERVIEW_DIVIDER_CLASSNAME = "border-t border-border/60 pt-4 first:border-t-0";
 
 function SessionResultSection({ summary, divided }: { summary?: string; divided: boolean }) {
   if (!summary) return null;
@@ -758,7 +759,7 @@ function SessionResultSection({ summary, divided }: { summary?: string; divided:
     // markdown block rather than a one-line caption.
     <section
       aria-label="Session result"
-      className={cn("space-y-2", divided && OVERVIEW_DIVIDER_CLASSNAME)}
+      className={cn("space-y-2", divided && OVERVIEW_DIVIDER_CLASSNAME, divided && "first:pt-0")}
       data-testid="session-result-section"
     >
       <SectionHeading icon={<CheckCircle2 className="h-4 w-4" />} iconClassName="text-success" title="Result" />
@@ -956,7 +957,7 @@ function OverviewTab({ session, activeThread, members, prStatus }: { session: Se
       {/* Session vitals — identity row (status + agent + who triggered) */}
       <div
         data-testid="session-overview-vitals"
-        className={cn("space-y-1.5", OVERVIEW_DIVIDER_CLASSNAME)}
+        className={cn("space-y-1.5", OVERVIEW_DIVIDER_CLASSNAME, "first:pt-0")}
       >
         <div className="flex items-center gap-x-3 gap-y-1 flex-wrap text-xs">
           <StatusLabel
@@ -3547,9 +3548,8 @@ function OverviewRow({
       className={cn(
         "grid grid-cols-[auto_minmax(0,1fr)_auto] items-center gap-x-1.5 gap-y-1.5 px-1 py-1.5",
         divided && OVERVIEW_DIVIDER_CLASSNAME,
-        // The divider's `first:pt-0` assumes a block with no padding of its
-        // own; restore this row's base `py-1.5` top so a first-child divided
-        // row lines up with the undivided ones.
+        // Collapses back to the `py-1.5` above, not to zero, so a first-child
+        // divided row lines up with the undivided ones.
         divided && "first:pt-1.5",
       )}
     >

--- a/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
@@ -3547,6 +3547,10 @@ function OverviewRow({
       className={cn(
         "grid grid-cols-[auto_minmax(0,1fr)_auto] items-center gap-x-1.5 gap-y-1.5 px-1 py-1.5",
         divided && OVERVIEW_DIVIDER_CLASSNAME,
+        // The divider's `first:pt-0` assumes a block with no padding of its
+        // own; restore this row's base `py-1.5` top so a first-child divided
+        // row lines up with the undivided ones.
+        divided && "first:pt-1.5",
       )}
     >
       <div


### PR DESCRIPTION
## Summary

Not clean — I fixed findings 1, 2, 4, and 5.

## Changes

**1. Constant no longer gets partially retracted** (`session-detail-content.tsx:747-751`)

`OVERVIEW_DIVIDER_CLASSNAME` now carries only what all three consumers share — `border-t border-border/60 pt-4 first:border-t-0`. The `first:pt-*` reset moved to each call site, because "what padding does the rule collapse back to" is the thing that actually varies:

- vitals (`:960`): `first:pt-0` — no padding of its own
- `SessionResultSection` (`:762`): `first:pt-0` — same
- `OverviewRow` (`:3548-3553`): `first:pt-1.5` — has `py-1.5`

No consumer applies the shared string and then overrides part of it, which also dissolves finding 3: the reset that was unreachable for `SessionResultSection` is now an explicit local declaration rather than dead weight inherited from a constant.

**2. Base padding and its reset are asserted as a pair** (`pull-request-list.test.tsx:132-136`)

Added `py-1.5` to the assertion alongside `first:pt-1.5`, so changing the row's base padding without updating the reset now fails.

**3. Failed-session arrangement covered** (`page-overview.test.tsx:392-416`)

New test for the third arrangement — the block above the vitals coming from *inside* `OverviewTab` rather than from the panel. Asserts the failure card is the vitals' immediate previous sibling and that the vitals aren't a first child, so the rule draws.

**4. Comment on the load-bearing assertion** (`page-overview.test.tsx:389`)

Explained why `firstElementChild).not.toBe(vitals)` is there, so it doesn't read as fixture trivia.

## Verification

Mutation-tested the two new guards:

| Mutation | Result |
|---|---|
| `py-1.5` → `py-2` on `OverviewRow`, reset left at `first:pt-1.5` | `renders as a quiet full-width suggestion` **fails** |
| fragment → wrapper `<div>` | the two flattening tests still **fail** (unchanged from before) |

- Full `src/app/(dashboard)/sessions` suite: 617 passed / 30 files.
- `tsc --noEmit` clean; `eslint` clean on all three files.

One honest caveat on the new failed-session test: it passes with or without the flattening, because the failure card and the vitals are siblings in both structures. It covers the *behavior* (rule draws when that card is above), not the flattening — the two earlier tests remain the guards for that.

## Not fixed — needs your call

**Finding 6: the session-scoped audit trail is still unreachable for `completed` / `pr_created` sessions.** That gate is the PR's purpose, and `/settings/audit-log` has no `session_id` filter, so admins lose the only path to a finished session's activity log. Restoring access means adding a demoted entry point — a design decision, so I left the behavior as authored. The in-code justification ("the last audit entry restates the Completed caption") is still an assumption I have not verified against the backend's audit-write paths.

## Left as-is

- **Query-key duplication** (`page-overview.test.tsx:444`) — the paired positive-control test fails loudly if the key drifts; exporting it would mean editing a shared component for test convenience.
- **Positional assertion** (`:424`) — brittle to unrelated `TabsContent` changes, but it's the assertion that actually catches re-nesting.

Still unverified in a browser: jsdom doesn't evaluate Tailwind, so the divider and the padding fallback are confirmed through emitted class strings and DOM position, not computed style.

## Test plan

Validated by automated agent run.


[143.dev](https://143.dev) | [session 1b9fc06e](https://143.dev/sessions/1b9fc06e-f7a3-4c55-a32e-ea5a3159ac6a)

<!-- 143-publication session=1b9fc06e-f7a3-4c55-a32e-ea5a3159ac6a changeset=6e1a27e3-b696-449d-8bba-5c4d927e2c49 -->

Preview: https://143.dev/previews/github/assembledhq/143/pull/2079?launch=1