### PR TITLE
Record reassessment starts in code review history

### DIFF
--- a/internal/services/codereview/github_submitter.go
+++ b/internal/services/codereview/github_submitter.go
@@ -1257,10 +1257,25 @@ func withCodeReviewHistory(body, previousBody string, decision SubmitReviewDecis
 	if entry := codeReviewHistoryEntry(decision, decidedAt); entry != "" && !containsString(entries, entry) {
 		entries = append(entries, entry)
 	}
+	return withCodeReviewHistoryEntries(body, entries)
+}
+
+// WithCodeReviewReassessmentHistory adds the active reassessment to the same
+// marker-backed history that records completed review decisions.
+func WithCodeReviewReassessmentHistory(body, headSHA string, startedAt time.Time, sessionURL string) string {
+	entries := codeReviewHistoryEntries(body)
+	if entry := codeReviewReassessmentHistoryEntry(headSHA, startedAt, sessionURL); entry != "" && !containsString(entries, entry) {
+		entries = append(entries, entry)
+	}
+	return withCodeReviewHistoryEntries(body, entries)
+}
+
+func withCodeReviewHistoryEntries(body string, entries []string) string {
+	body = stripCodeReviewHistory(body)
 	if len(entries) == 0 {
 		return body
 	}
-	history := codeReviewHistoryStartMarker + "\nPrevious 143 code reviews:\n" + strings.Join(entries, "\n") + "\n" + codeReviewHistoryEndMarker
+	history := codeReviewHistoryStartMarker + "\nHistory of 143 code reviews:\n" + strings.Join(entries, "\n") + "\n" + codeReviewHistoryEndMarker
 	if body == "" {
 		return history
 	}
@@ -1314,6 +1329,21 @@ func codeReviewHistoryEntry(decision SubmitReviewDecision, decidedAt time.Time) 
 		return ""
 	}
 	return fmt.Sprintf("- `%s` — **%s**", decidedAt.UTC().Format(time.RFC3339), codeReviewDecisionLabel(decision))
+}
+
+func codeReviewReassessmentHistoryEntry(headSHA string, startedAt time.Time, sessionURL string) string {
+	headSHA = strings.TrimSpace(headSHA)
+	if headSHA == "" || startedAt.IsZero() {
+		return ""
+	}
+	if len(headSHA) > 7 {
+		headSHA = headSHA[:7]
+	}
+	entry := fmt.Sprintf("- `%s` — **Reassessment started** for `%s`", startedAt.UTC().Format(time.RFC3339), headSHA)
+	if sessionURL != "" {
+		entry += " — [Follow the review session](" + sessionURL + ")"
+	}
+	return entry
 }
 
 func codeReviewDecisionLabel(decision SubmitReviewDecision) string {

--- a/internal/services/codereview/github_submitter_test.go
+++ b/internal/services/codereview/github_submitter_test.go
@@ -422,7 +422,7 @@ func TestGitHubSubmitter_SubmitReviewUpdatesExistingAssessment(t *testing.T) {
 	require.Equal(t, int64(143), result.ID, "updated assessment should retain the original review id")
 	require.Equal(t, "https://github.com/acme/repo/pull/42#pullrequestreview-143", result.URL, "updated assessment should retain the original review URL")
 	expectedVisibleBody := "143 Code Reviewer did not approve this PR\n\nWhy: required checks are failing.\n\n" +
-		codeReviewHistoryStartMarker + "\nPrevious 143 code reviews:\n- `2026-07-23T02:14:08Z` — **Not approved — blocked**\n" + codeReviewHistoryEndMarker
+		codeReviewHistoryStartMarker + "\nHistory of 143 code reviews:\n- `2026-07-23T02:14:08Z` — **Not approved — blocked**\n" + codeReviewHistoryEndMarker
 	require.Equal(t, expectedVisibleBody, result.Body, "updated assessment should return the visible review body with prior decision history")
 	require.Equal(t, withCodeReviewOutputMarker(expectedVisibleBody, "updated-output"), reviewUpdate["body"], "formal review update should retain the visible fallback until the rolling comment is published")
 	require.Equal(t, withCodeReviewFindingMarker("Updated finding.", "finding-key"), commentUpdate["body"], "matching prior inline finding should be updated in place with a stable reassessment marker")
@@ -595,7 +595,7 @@ func TestWithCodeReviewHistory(t *testing.T) {
 
 	firstDecisionAt := time.Date(2026, time.July, 20, 10, 30, 0, 0, time.UTC)
 	secondDecisionAt := time.Date(2026, time.July, 21, 15, 45, 12, 0, time.UTC)
-	firstHistory := codeReviewHistoryStartMarker + "\nPrevious 143 code reviews:\n" +
+	firstHistory := codeReviewHistoryStartMarker + "\nHistory of 143 code reviews:\n" +
 		"- `2026-07-20T10:30:00Z` — **Not approved — needs human review**\n" + codeReviewHistoryEndMarker
 	tests := []struct {
 		name         string
@@ -625,7 +625,7 @@ func TestWithCodeReviewHistory(t *testing.T) {
 			previousBody: "Prior assessment.\n\n" + firstHistory,
 			decision:     SubmitReviewDecisionCommentOnly,
 			decidedAt:    secondDecisionAt,
-			expected: "Newest assessment.\n\n" + codeReviewHistoryStartMarker + "\nPrevious 143 code reviews:\n" +
+			expected: "Newest assessment.\n\n" + codeReviewHistoryStartMarker + "\nHistory of 143 code reviews:\n" +
 				"- `2026-07-20T10:30:00Z` — **Not approved — needs human review**\n" +
 				"- `2026-07-21T15:45:12Z` — **Not approved**\n" + codeReviewHistoryEndMarker,
 		},
@@ -647,6 +647,27 @@ func TestWithCodeReviewHistory(t *testing.T) {
 			require.Equal(t, tt.expected, actual, "history rendering should preserve the current assessment and expected prior-decision lines")
 		})
 	}
+}
+
+func TestWithCodeReviewReassessmentHistory(t *testing.T) {
+	t.Parallel()
+
+	startedAt := time.Date(2026, time.August, 5, 20, 18, 7, 0, time.UTC)
+	previousBody := "Previous assessment.\n\n" + codeReviewHistoryStartMarker + "\nPrevious 143 code reviews:\n" +
+		"- `2026-08-05T18:30:56Z` — **Not approved — needs human review**\n" + codeReviewHistoryEndMarker
+
+	actual := WithCodeReviewReassessmentHistory(
+		previousBody,
+		"a38531c4f6b35b0fbcfdf9d3457ed70c79f118c1",
+		startedAt,
+		"https://143.test/sessions/reassessment",
+	)
+
+	expected := "Previous assessment.\n\n" + codeReviewHistoryStartMarker + "\nHistory of 143 code reviews:\n" +
+		"- `2026-08-05T18:30:56Z` — **Not approved — needs human review**\n" +
+		"- `2026-08-05T20:18:07Z` — **Reassessment started** for `a38531c` — [Follow the review session](https://143.test/sessions/reassessment)\n" +
+		codeReviewHistoryEndMarker
+	require.Equal(t, expected, actual, "reassessment history should preserve completed decisions and include the active review's kickoff time, head, and session link")
 }
 
 func TestCodeReviewDecisionLabel(t *testing.T) {

--- a/internal/worker/code_review_status_comment_handler.go
+++ b/internal/worker/code_review_status_comment_handler.go
@@ -195,15 +195,12 @@ func codeReviewStatusCommentBody(metadata models.CodeReviewSessionMetadata, prev
 			paragraphs = append(paragraphs, "143 Code Reviewer has started reviewing this pull request.")
 			break
 		}
-		paragraphs = append(paragraphs, fmt.Sprintf(
-			"143 Code Reviewer is reassessing this pull request at `%s`.",
-			codeReviewStatusShortSHA(metadata.HeadSHA),
+		paragraphs = append(paragraphs, codereviewsvc.WithCodeReviewReassessmentHistory(
+			previousBody,
+			metadata.HeadSHA,
+			metadata.CreatedAt,
+			sessionURL,
 		))
-		paragraphs = append(paragraphs, fmt.Sprintf(
-			"The previous completed assessment for `%s` remains visible until the new review finishes.",
-			codeReviewStatusShortSHA(previousCompleted.HeadSHA),
-		))
-		paragraphs = append(paragraphs, previousBody)
 	}
 	if sessionURL != "" && !strings.Contains(strings.Join(paragraphs, "\n\n"), sessionURL) {
 		label := "Follow the review session"
@@ -213,14 +210,6 @@ func codeReviewStatusCommentBody(metadata models.CodeReviewSessionMetadata, prev
 		paragraphs = append(paragraphs, fmt.Sprintf("[%s](%s)", label, sessionURL))
 	}
 	return strings.Join(paragraphs, "\n\n")
-}
-
-func codeReviewStatusShortSHA(value string) string {
-	value = strings.TrimSpace(value)
-	if len(value) > 7 {
-		return value[:7]
-	}
-	return value
 }
 
 func enqueueCodeReviewStatusCommentSync(ctx context.Context, stores *Stores, services *Services, logger zerolog.Logger, job runCodeReviewPayload, stage string) {

--- a/internal/worker/code_review_status_comment_handler_test.go
+++ b/internal/worker/code_review_status_comment_handler_test.go
@@ -32,6 +32,7 @@ func TestSyncCodeReviewStatusCommentHandlerRendersCurrentDurableState(t *testing
 		expectedExistingCommentID *int64
 		expectedBody              string
 		expectedAdditionalBody    string
+		expectReassessmentHistory bool
 		expectedCalls             []string
 		hideErr                   error
 		expectErr                 bool
@@ -44,15 +45,15 @@ func TestSyncCodeReviewStatusCommentHandlerRendersCurrentDurableState(t *testing
 			expectedCalls: []string{"upsert"},
 		},
 		{
-			name:              "keeps the previous verdict visible during reassessment",
-			initialStatus:     models.CodeReviewSessionStatusRunning,
-			lockedStatus:      models.CodeReviewSessionStatusRunning,
-			previousFinalBody: statusCommentStringPtr("❌ **143 Code Reviewer needs human review**\n\n**Why:** Sensitive workflow changes require a human decision."),
-			previousHeadSHA:   "previous-head-sha",
-			expectedBody:      "143 Code Reviewer is reassessing this pull request at `head`.",
-			expectedAdditionalBody: "The previous completed assessment for `previou` remains visible until the new review finishes.\n\n" +
-				"❌ **143 Code Reviewer needs human review**\n\n**Why:** Sensitive workflow changes require a human decision.",
-			expectedCalls: []string{"upsert"},
+			name:                      "keeps the previous verdict visible during reassessment",
+			initialStatus:             models.CodeReviewSessionStatusRunning,
+			lockedStatus:              models.CodeReviewSessionStatusRunning,
+			previousFinalBody:         statusCommentStringPtr("❌ **143 Code Reviewer needs human review**\n\n**Why:** Sensitive workflow changes require a human decision."),
+			previousHeadSHA:           "previous-head-sha",
+			expectedBody:              "❌ **143 Code Reviewer needs human review**\n\n**Why:** Sensitive workflow changes require a human decision.",
+			expectedAdditionalBody:    "History of 143 code reviews:",
+			expectReassessmentHistory: true,
+			expectedCalls:             []string{"upsert"},
 		},
 		{
 			name:                      "refreshes state under lock before publishing completed result",
@@ -196,6 +197,12 @@ func TestSyncCodeReviewStatusCommentHandlerRendersCurrentDurableState(t *testing
 			require.Contains(t, submitter.request.Body, tt.expectedBody, "status comment should render the current durable outcome")
 			if tt.expectedAdditionalBody != "" {
 				require.Contains(t, submitter.request.Body, tt.expectedAdditionalBody, "status comment should retain the complete previous verdict during reassessment")
+			}
+			if tt.expectReassessmentHistory {
+				expectedEntry := "- `" + now.Format(time.RFC3339) + "` — **Reassessment started** for `head` — [Follow the review session](https://143.test/sessions/" + sessionID.String() + ")"
+				require.Contains(t, submitter.request.Body, expectedEntry, "reassessment history should identify when the active assessment started and link to its session")
+				require.NotContains(t, submitter.request.Body, "143 Code Reviewer is reassessing this pull request", "reassessment status should appear in history instead of a standalone paragraph")
+				require.NotContains(t, submitter.request.Body, "remains visible until the new review finishes", "reassessment history should replace the redundant visibility explanation")
 			}
 			require.Contains(t, submitter.request.Body, "https://143.test/sessions/"+sessionID.String(), "status comment should link to the review session")
 			require.Equal(t, tt.expectedCalls, submitter.calls, "fallback summary should only be hidden after the rolling comment is published")


### PR DESCRIPTION
## Summary

- Rename the rolling comment section from “Previous 143 code reviews” to “History of 143 code reviews.”
- Add the active reassessment to that history with its kickoff time, commit SHA, and session link.
- Remove the standalone reassessment and previous-assessment visibility paragraphs while retaining the last completed verdict as the main body.

## Why

The reassessment state was split across multiple parts of the comment and repeated that the prior assessment remained visible. Keeping the active reassessment in the same chronological history makes the rolling comment easier to scan.

## User impact

During an active reassessment, pull request authors now see one coherent review timeline and can follow the current session directly from its history entry.

## Validation

- `go test ./internal/services/codereview ./internal/worker`
- `go vet ./internal/services/codereview ./internal/worker`
