### PR TITLE
Restore condensed styling for conversation activity entries

### DIFF
--- a/frontend/src/components/activity-capsule.test.tsx
+++ b/frontend/src/components/activity-capsule.test.tsx
@@ -24,6 +24,9 @@ describe("ActivityCapsule", () => {
 
     const trigger = screen.getByRole("button", { name: "Worked for 42s · 1 tool call" });
     expect(trigger).toHaveAttribute("aria-expanded", "false");
+    const capsule = trigger.closest("[data-activity-capsule='true']");
+    expect(capsule).toHaveClass("mx-2", "min-w-0");
+    expect(capsule).not.toHaveClass("rounded-lg", "border", "bg-card");
     expect(screen.queryByText("original activity")).not.toBeInTheDocument();
     await user.click(trigger);
     expect(onExpandedChange).toHaveBeenCalledWith(true);
@@ -43,6 +46,8 @@ describe("ActivityCapsule", () => {
       </ActivityCapsule>,
     );
     expect(screen.getByText("original activity")).toBeInTheDocument();
+    const body = document.querySelector("[data-activity-phase-body='true']");
+    expect(body).not.toHaveClass("border-t", "border-border");
   });
 
   it("reports a non-empty text selection inside expanded activity", () => {

--- a/frontend/src/components/activity-capsule.tsx
+++ b/frontend/src/components/activity-capsule.tsx
@@ -77,16 +77,16 @@ export function ActivityCapsule({ activity, expanded, onExpandedChange, onInspec
       data-activity-phase-id={activity.id}
       data-activity-capsule="true"
       data-session-entry-id={activity.inferredHistorical ? undefined : activity.anchor_id}
-      className="rounded-lg border border-border bg-card"
+      className="mx-2 min-w-0"
     >
       <CollapsibleTrigger asChild>
         <Button
           type="button"
           variant="ghost"
-          className="h-auto w-full justify-start gap-2 rounded-lg px-3 py-2 text-left text-sm font-medium"
+          className="h-auto w-full justify-start gap-2 rounded-md px-2 py-1.5 text-left text-xs font-medium text-muted-foreground hover:bg-muted/50 hover:text-foreground"
           aria-label={summary}
         >
-          <ChevronRight className={`h-4 w-4 shrink-0 transition-transform motion-reduce:transition-none ${expanded ? "rotate-90" : ""}`} />
+          <ChevronRight className={`h-3.5 w-3.5 shrink-0 transition-transform motion-reduce:transition-none ${expanded ? "rotate-90" : ""}`} />
           <span className="min-w-0 flex-1 whitespace-normal tabular-nums">{summary}</span>
         </Button>
       </CollapsibleTrigger>
@@ -94,7 +94,7 @@ export function ActivityCapsule({ activity, expanded, onExpandedChange, onInspec
         <CollapsibleContent
           data-activity-phase-body="true"
           data-activity-phase-id={activity.id}
-          className="space-y-2 border-t border-border px-2 py-2"
+          className="mt-1 space-y-2 py-1"
         >
           {children}
         </CollapsibleContent>

--- a/frontend/src/components/session-activity-timeline.test.tsx
+++ b/frontend/src/components/session-activity-timeline.test.tsx
@@ -183,4 +183,80 @@ describe("SessionActivityTimeline", () => {
     expect(screen.getByRole("button", { name: /Activity.*1 tool call/ })).toHaveAttribute("aria-expanded", "true");
     expect(screen.getByText("Ran `npm test`")).toBeVisible();
   });
+
+  it("renders queued deliveries and runtime boundaries without full-width card treatments", () => {
+    const interruptedPhaseID = "10000000-0000-0000-0000-000000000010";
+    const recoveryPhaseID = "10000000-0000-0000-0000-000000000011";
+    const interruptedTool = {
+      ...toolUse,
+      id: 10,
+      activity_phase_id: interruptedPhaseID,
+      created_at: "2026-08-03T00:00:01Z",
+    };
+    const recoveryTool = {
+      ...toolUse,
+      id: 11,
+      activity_phase_id: recoveryPhaseID,
+      created_at: "2026-08-03T00:00:08Z",
+    };
+    const queuedMessage: SessionMessage = {
+      ...finalMessage,
+      id: 12,
+      role: "user",
+      content: "Keep the runtime state intact.",
+      created_at: "2026-08-03T00:00:07Z",
+      activity_phase_id: undefined,
+      inbox_sequence: 1,
+      delivery_state: "pending",
+      accepted_at: "2026-08-03T00:00:07Z",
+    };
+    const scrollRef = { current: document.createElement("div") };
+
+    render(
+      <SessionActivityTimeline
+        entries={[
+          { kind: "tool_group", toolUse: interruptedTool, transcriptEntryId: "tuse_interrupted" },
+          { kind: "message", data: queuedMessage, transcriptEntryId: "msg_queued" },
+          { kind: "tool_group", toolUse: recoveryTool, transcriptEntryId: "tuse_recovery" },
+        ]}
+        isRunning
+        turns={[{
+          turn_number: 1,
+          started_at: "2026-08-03T00:00:00Z",
+          entries: [],
+          phases: [{
+            id: interruptedPhaseID,
+            anchor_id: `aph_${interruptedPhaseID}`,
+            phase_number: 1,
+            status: "interrupted",
+            trigger_kind: "initial",
+            boundary_reason: "runtime_lost",
+            started_at: "2026-08-03T00:00:00Z",
+            completed_at: "2026-08-03T00:00:06Z",
+            tool_call_count: 1,
+          }, {
+            id: recoveryPhaseID,
+            anchor_id: `aph_${recoveryPhaseID}`,
+            phase_number: 2,
+            status: "running",
+            trigger_kind: "recovery",
+            started_at: "2026-08-03T00:00:08Z",
+            tool_call_count: 1,
+          }],
+        }]}
+        detailPreference="compact"
+        threadID="thread-1"
+        scrollContainerRef={scrollRef}
+        userScrollEpoch={0}
+        atLiveEdge
+      />,
+    );
+
+    const interruption = screen.getByText("Execution paused because the runtime was lost.").closest("[role='status']");
+    const recovery = screen.getByText("Runtime recovered and execution resumed.").closest("[role='status']");
+    const delivery = screen.getByText("Queued").closest("[data-activity-delivery]");
+    expect(interruption).not.toHaveClass("rounded-lg", "border-info/30", "bg-info/10");
+    expect(recovery).not.toHaveClass("rounded-lg", "border-info/30", "bg-info/10");
+    expect(delivery).not.toHaveClass("rounded-lg", "border", "bg-card");
+  });
 });

--- a/frontend/src/components/session-activity-timeline.tsx
+++ b/frontend/src/components/session-activity-timeline.tsx
@@ -5,7 +5,6 @@
 import { Fragment, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState, type RefObject } from "react";
 import { ActivityCapsule } from "@/components/activity-capsule";
 import { Badge } from "@/components/ui/badge";
-import { Card } from "@/components/ui/card";
 import { ChatTimeline, DaySeparator, type ChatTimelineProps } from "@/components/chat-timeline";
 import { buildActivityTimelineNodes } from "@/lib/activity-timeline";
 import type { SessionActivityDetail, SessionTranscriptTurn } from "@/lib/types";
@@ -338,8 +337,10 @@ export function SessionActivityTimeline({
           return (
             <Fragment key={node.delivery.id}>
               {prepared.separator}
-              <div className="space-y-1 rounded-lg border border-border bg-card p-2">
-                <Badge variant={node.delivery.deliveryState === "abandoned" ? "destructive" : "secondary"}>{label}</Badge>
+              <div className="space-y-1 py-1" data-activity-delivery={node.delivery.deliveryState}>
+                <div className="mx-2 px-2">
+                  <Badge variant={node.delivery.deliveryState === "abandoned" ? "destructive" : "secondary"}>{label}</Badge>
+                </div>
                 <ChatTimeline {...prepared.props} />
               </div>
             </Fragment>
@@ -350,17 +351,17 @@ export function SessionActivityTimeline({
           return (
             <Fragment key={node.notice.id}>
               {day.showSeparator && day.firstDate ? <DaySeparator dateStr={day.firstDate} /> : null}
-              <Card
+              <div
                 role="status"
-                className="flex items-center gap-2 border-info/30 bg-info/10 px-3 py-2 text-xs text-info"
+                className="mx-2 flex items-center gap-2 px-2 py-1.5 text-xs text-muted-foreground"
                 data-activity-boundary={node.notice.kind}
                 data-activity-phase-id={node.notice.phaseID}
               >
                 {node.notice.kind === "recovery"
-                  ? <RotateCcw className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
-                  : <AlertTriangle className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />}
+                  ? <RotateCcw className="h-3.5 w-3.5 shrink-0 text-info" aria-hidden="true" />
+                  : <AlertTriangle className="h-3.5 w-3.5 shrink-0 text-warning" aria-hidden="true" />}
                 <span>{node.notice.label}</span>
-              </Card>
+              </div>
             </Fragment>
           );
         }


### PR DESCRIPTION
## Summary
- Remove card, border, and background treatments from activity capsules, deliveries, and runtime boundaries
- Tighten activity controls and preserve semantic status colors
- Add coverage for the condensed conversation timeline presentation

## Testing
- Added unit tests covering activity capsule and timeline styling
- Not run (not requested)