### PR TITLE
Retry transient worker session guardrail blocks during deploy

### DIFF
--- a/deploy/deploy_config_test.go
+++ b/deploy/deploy_config_test.go
@@ -2486,96 +2486,46 @@ pull_with_retry "test image" "$FAKE_PULL"
 	}
 }
 
-func TestWorkerDeployRetriesTransientSessionGuardrailBlocks(t *testing.T) {
+func TestWorkerDeploySessionGuardrailFailsImmediately(t *testing.T) {
 	t.Parallel()
 
 	deployScript, err := os.ReadFile("../deploy/scripts/deploy.sh")
 	require.NoError(t, err, "test should read deploy script")
-	deployText := string(deployScript)
-	guardrailFn := extractShellFunction(t, deployText, "run_worker_session_deploy_guardrail", "wait_container_healthy")
+	guardrailFn := extractShellFunction(t, string(deployScript), "run_worker_session_deploy_guardrail", "wait_container_healthy")
+	require.NotContains(t, guardrailFn, "sleep", "worker session guardrail should never delay a deploy with retry sleeps")
+	require.NotContains(t, guardrailFn, "GUARDRAIL_ATTEMPTS", "worker session guardrail should perform exactly one safety check")
 
-	require.Contains(t, deployText, `remote_env_assignment WORKER_DEPLOY_GUARDRAIL_ATTEMPTS "${WORKER_DEPLOY_GUARDRAIL_ATTEMPTS:-}"`,
-		"deploy should forward the session guardrail attempt override to the remote host")
-	require.Contains(t, deployText, `remote_env_assignment WORKER_DEPLOY_GUARDRAIL_RETRY_DELAY_SECONDS "${WORKER_DEPLOY_GUARDRAIL_RETRY_DELAY_SECONDS:-}"`,
-		"deploy should forward the session guardrail retry delay override to the remote host")
-	require.Contains(t, guardrailFn, `WORKER_DEPLOY_GUARDRAIL_ATTEMPTS:-31`,
-		"worker deploy should wait up to five minutes for a transient active session to reach a safe boundary")
-
-	tests := []struct {
-		name             string
-		guardrailExit    int
-		succeedOnAttempt int
-		expectedAttempts string
-		expectError      bool
-	}{
-		{
-			name:             "retries explicit guardrail blocks until clear",
-			guardrailExit:    3,
-			succeedOnAttempt: 3,
-			expectedAttempts: "3",
-		},
-		{
-			name:             "fails closed after bounded guardrail attempts",
-			guardrailExit:    3,
-			expectedAttempts: "3",
-			expectError:      true,
-		},
-		{
-			name:             "does not retry infrastructure errors",
-			guardrailExit:    1,
-			expectedAttempts: "1",
-			expectError:      true,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-
-			tempDir := t.TempDir()
-			countFile := filepath.Join(tempDir, "attempts")
-			fakeDocker := filepath.Join(tempDir, "docker")
-			require.NoError(t, os.WriteFile(fakeDocker, []byte(`#!/usr/bin/env bash
+	tempDir := t.TempDir()
+	countFile := filepath.Join(tempDir, "attempts")
+	fakeDocker := filepath.Join(tempDir, "docker")
+	require.NoError(t, os.WriteFile(fakeDocker, []byte(`#!/usr/bin/env bash
 set -euo pipefail
 count=0
 if [ -f "$COUNT_FILE" ]; then
   count="$(cat "$COUNT_FILE")"
 fi
-count=$((count + 1))
-printf '%s' "$count" > "$COUNT_FILE"
-if [ "$SUCCEED_ON_ATTEMPT" -gt 0 ] && [ "$count" -ge "$SUCCEED_ON_ATTEMPT" ]; then
-  exit 0
-fi
-exit "$GUARDRAIL_EXIT"
-`), 0o755), "test should create a fake docker command")
+printf '%s' "$((count + 1))" > "$COUNT_FILE"
+exit 3
+`), 0o755), "test should create a blocked guardrail command")
 
-			script := guardrailFn + `
+	script := guardrailFn + `
 worker_database_url() { printf 'postgres://test'; }
 ROLE=worker
 IMAGE_TAG=test-tag
 run_worker_session_deploy_guardrail
 `
-			cmd := exec.Command("bash", "-c", script)
-			cmd.Env = append(os.Environ(),
-				"PATH="+tempDir+":"+os.Getenv("PATH"),
-				"COUNT_FILE="+countFile,
-				fmt.Sprintf("GUARDRAIL_EXIT=%d", tt.guardrailExit),
-				fmt.Sprintf("SUCCEED_ON_ATTEMPT=%d", tt.succeedOnAttempt),
-				"WORKER_DEPLOY_GUARDRAIL_ATTEMPTS=3",
-				"WORKER_DEPLOY_GUARDRAIL_RETRY_DELAY_SECONDS=0",
-			)
-			output, err := cmd.CombinedOutput()
-			if tt.expectError {
-				require.Error(t, err, "session guardrail helper should preserve the expected failure: %s", string(output))
-			} else {
-				require.NoError(t, err, "session guardrail helper should recover after a transient block: %s", string(output))
-			}
+	cmd := exec.Command("bash", "-c", script)
+	cmd.Env = append(os.Environ(),
+		"PATH="+tempDir+":"+os.Getenv("PATH"),
+		"COUNT_FILE="+countFile,
+	)
+	output, err := cmd.CombinedOutput()
+	require.Error(t, err, "blocked worker session guardrail should fail the deploy immediately: %s", string(output))
+	require.Equal(t, 3, cmd.ProcessState.ExitCode(), "deploy should preserve the guardrail's blocked exit status")
 
-			attempts, readErr := os.ReadFile(countFile)
-			require.NoError(t, readErr, "test should read the fake guardrail attempt count")
-			require.Equal(t, tt.expectedAttempts, string(attempts), "session guardrail helper should execute the expected number of attempts")
-		})
-	}
+	attempts, readErr := os.ReadFile(countFile)
+	require.NoError(t, readErr, "test should read the guardrail attempt count")
+	require.Equal(t, "1", string(attempts), "worker session guardrail should execute exactly once")
 }
 
 func TestWorkerDrainMonitorDeduplicatesPerContainer(t *testing.T) {

--- a/deploy/deploy_config_test.go
+++ b/deploy/deploy_config_test.go
@@ -2486,6 +2486,98 @@ pull_with_retry "test image" "$FAKE_PULL"
 	}
 }
 
+func TestWorkerDeployRetriesTransientSessionGuardrailBlocks(t *testing.T) {
+	t.Parallel()
+
+	deployScript, err := os.ReadFile("../deploy/scripts/deploy.sh")
+	require.NoError(t, err, "test should read deploy script")
+	deployText := string(deployScript)
+	guardrailFn := extractShellFunction(t, deployText, "run_worker_session_deploy_guardrail", "wait_container_healthy")
+
+	require.Contains(t, deployText, `remote_env_assignment WORKER_DEPLOY_GUARDRAIL_ATTEMPTS "${WORKER_DEPLOY_GUARDRAIL_ATTEMPTS:-}"`,
+		"deploy should forward the session guardrail attempt override to the remote host")
+	require.Contains(t, deployText, `remote_env_assignment WORKER_DEPLOY_GUARDRAIL_RETRY_DELAY_SECONDS "${WORKER_DEPLOY_GUARDRAIL_RETRY_DELAY_SECONDS:-}"`,
+		"deploy should forward the session guardrail retry delay override to the remote host")
+	require.Contains(t, guardrailFn, `WORKER_DEPLOY_GUARDRAIL_ATTEMPTS:-31`,
+		"worker deploy should wait up to five minutes for a transient active session to reach a safe boundary")
+
+	tests := []struct {
+		name             string
+		guardrailExit    int
+		succeedOnAttempt int
+		expectedAttempts string
+		expectError      bool
+	}{
+		{
+			name:             "retries explicit guardrail blocks until clear",
+			guardrailExit:    3,
+			succeedOnAttempt: 3,
+			expectedAttempts: "3",
+		},
+		{
+			name:             "fails closed after bounded guardrail attempts",
+			guardrailExit:    3,
+			expectedAttempts: "3",
+			expectError:      true,
+		},
+		{
+			name:             "does not retry infrastructure errors",
+			guardrailExit:    1,
+			expectedAttempts: "1",
+			expectError:      true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			tempDir := t.TempDir()
+			countFile := filepath.Join(tempDir, "attempts")
+			fakeDocker := filepath.Join(tempDir, "docker")
+			require.NoError(t, os.WriteFile(fakeDocker, []byte(`#!/usr/bin/env bash
+set -euo pipefail
+count=0
+if [ -f "$COUNT_FILE" ]; then
+  count="$(cat "$COUNT_FILE")"
+fi
+count=$((count + 1))
+printf '%s' "$count" > "$COUNT_FILE"
+if [ "$SUCCEED_ON_ATTEMPT" -gt 0 ] && [ "$count" -ge "$SUCCEED_ON_ATTEMPT" ]; then
+  exit 0
+fi
+exit "$GUARDRAIL_EXIT"
+`), 0o755), "test should create a fake docker command")
+
+			script := guardrailFn + `
+worker_database_url() { printf 'postgres://test'; }
+ROLE=worker
+IMAGE_TAG=test-tag
+run_worker_session_deploy_guardrail
+`
+			cmd := exec.Command("bash", "-c", script)
+			cmd.Env = append(os.Environ(),
+				"PATH="+tempDir+":"+os.Getenv("PATH"),
+				"COUNT_FILE="+countFile,
+				fmt.Sprintf("GUARDRAIL_EXIT=%d", tt.guardrailExit),
+				fmt.Sprintf("SUCCEED_ON_ATTEMPT=%d", tt.succeedOnAttempt),
+				"WORKER_DEPLOY_GUARDRAIL_ATTEMPTS=3",
+				"WORKER_DEPLOY_GUARDRAIL_RETRY_DELAY_SECONDS=0",
+			)
+			output, err := cmd.CombinedOutput()
+			if tt.expectError {
+				require.Error(t, err, "session guardrail helper should preserve the expected failure: %s", string(output))
+			} else {
+				require.NoError(t, err, "session guardrail helper should recover after a transient block: %s", string(output))
+			}
+
+			attempts, readErr := os.ReadFile(countFile)
+			require.NoError(t, readErr, "test should read the fake guardrail attempt count")
+			require.Equal(t, tt.expectedAttempts, string(attempts), "session guardrail helper should execute the expected number of attempts")
+		})
+	}
+}
+
 func TestWorkerDrainMonitorDeduplicatesPerContainer(t *testing.T) {
 	t.Parallel()
 

--- a/deploy/scripts/deploy.sh
+++ b/deploy/scripts/deploy.sh
@@ -860,6 +860,8 @@ ssh "${SSH_OPTS[@]}" deploy@"$HOST" \
   "$(remote_env_assignment DEPLOY_REQUESTED_BY "${DEPLOY_REQUESTED_BY:-deploy-script}")" \
   "$(remote_env_assignment DEPLOY_REASON "${DEPLOY_REASON:-routine worker rollout}")" \
   "$(remote_env_assignment FORCE_DEPLOY_WITH_ACTIVE_SESSIONS "${FORCE_DEPLOY_WITH_ACTIVE_SESSIONS:-}")" \
+  "$(remote_env_assignment WORKER_DEPLOY_GUARDRAIL_ATTEMPTS "${WORKER_DEPLOY_GUARDRAIL_ATTEMPTS:-}")" \
+  "$(remote_env_assignment WORKER_DEPLOY_GUARDRAIL_RETRY_DELAY_SECONDS "${WORKER_DEPLOY_GUARDRAIL_RETRY_DELAY_SECONDS:-}")" \
   "$(remote_env_assignment FORCE_INTERRUPT_ACTIVE_RUNTIMES "${FORCE_INTERRUPT_ACTIVE_RUNTIMES:-}")" \
   "$(remote_env_assignment SESSION_EXECUTOR_DOCKER_NETWORK "${SESSION_EXECUTOR_DOCKER_NETWORK:-}")" \
   "$(remote_env_assignment DEPLOY_DOCKER_PRUNE "${DEPLOY_DOCKER_PRUNE:-1}")" \
@@ -2264,17 +2266,49 @@ SELECT COUNT(*) FROM endpoint_blockers;"
     if [ "$ROLE" != "worker" ]; then
       return 0
     fi
-    local database_url
+    local database_url attempts retry_delay attempt guardrail_status
     database_url="$(worker_database_url)"
-    echo "Checking active long-running sessions before worker deploy..."
-    docker run --rm -i \
-      --network 143_default \
-      --env-file /opt/143/.env \
-      -e "DATABASE_URL=$database_url" \
-      -e "FORCE_DEPLOY_WITH_ACTIVE_SESSIONS=${FORCE_DEPLOY_WITH_ACTIVE_SESSIONS:-}" \
-      -v /opt/143/.env.production.enc:/app/.env.production.enc:ro \
-      "ghcr.io/assembledhq/143-server:${IMAGE_TAG:-latest}" \
-      /bin/deploy-guardrail worker-sessions < /dev/null
+    attempts="${WORKER_DEPLOY_GUARDRAIL_ATTEMPTS:-31}"
+    retry_delay="${WORKER_DEPLOY_GUARDRAIL_RETRY_DELAY_SECONDS:-10}"
+    if ! [[ "$attempts" =~ ^[1-9][0-9]*$ ]]; then
+      echo "ERROR: WORKER_DEPLOY_GUARDRAIL_ATTEMPTS must be a positive integer, got '$attempts'." >&2
+      return 1
+    fi
+    if ! [[ "$retry_delay" =~ ^[0-9]+$ ]]; then
+      echo "ERROR: WORKER_DEPLOY_GUARDRAIL_RETRY_DELAY_SECONDS must be a non-negative integer, got '$retry_delay'." >&2
+      return 1
+    fi
+
+    for ((attempt = 1; attempt <= attempts; attempt++)); do
+      echo "Checking active long-running sessions before worker deploy (attempt $attempt/$attempts)..."
+      if docker run --rm -i \
+        --network 143_default \
+        --env-file /opt/143/.env \
+        -e "DATABASE_URL=$database_url" \
+        -e "FORCE_DEPLOY_WITH_ACTIVE_SESSIONS=${FORCE_DEPLOY_WITH_ACTIVE_SESSIONS:-}" \
+        -v /opt/143/.env.production.enc:/app/.env.production.enc:ro \
+        "ghcr.io/assembledhq/143-server:${IMAGE_TAG:-latest}" \
+        /bin/deploy-guardrail worker-sessions < /dev/null; then
+        return 0
+      else
+        guardrail_status=$?
+      fi
+
+      # Exit 3 is the guardrail's explicit "active inline session" result.
+      # Those sessions often reach a checkpoint seconds after parallel fleet
+      # workers inspect them, so wait briefly instead of failing the rollout
+      # on a timing race. Infrastructure and configuration failures retain
+      # their original exit status and fail immediately.
+      if [ "$guardrail_status" -ne 3 ]; then
+        return "$guardrail_status"
+      fi
+      if [ "$attempt" -ge "$attempts" ]; then
+        echo "ERROR: worker session deploy guardrail remained blocked after $attempts attempt(s)." >&2
+        return "$guardrail_status"
+      fi
+      echo "Worker session deploy guardrail is temporarily blocked; retrying in ${retry_delay}s..." >&2
+      sleep "$retry_delay"
+    done
   }
 
   # wait_container_healthy CONTAINER_ID TIMEOUT — poll until a specific container

--- a/deploy/scripts/deploy.sh
+++ b/deploy/scripts/deploy.sh
@@ -860,8 +860,6 @@ ssh "${SSH_OPTS[@]}" deploy@"$HOST" \
   "$(remote_env_assignment DEPLOY_REQUESTED_BY "${DEPLOY_REQUESTED_BY:-deploy-script}")" \
   "$(remote_env_assignment DEPLOY_REASON "${DEPLOY_REASON:-routine worker rollout}")" \
   "$(remote_env_assignment FORCE_DEPLOY_WITH_ACTIVE_SESSIONS "${FORCE_DEPLOY_WITH_ACTIVE_SESSIONS:-}")" \
-  "$(remote_env_assignment WORKER_DEPLOY_GUARDRAIL_ATTEMPTS "${WORKER_DEPLOY_GUARDRAIL_ATTEMPTS:-}")" \
-  "$(remote_env_assignment WORKER_DEPLOY_GUARDRAIL_RETRY_DELAY_SECONDS "${WORKER_DEPLOY_GUARDRAIL_RETRY_DELAY_SECONDS:-}")" \
   "$(remote_env_assignment FORCE_INTERRUPT_ACTIVE_RUNTIMES "${FORCE_INTERRUPT_ACTIVE_RUNTIMES:-}")" \
   "$(remote_env_assignment SESSION_EXECUTOR_DOCKER_NETWORK "${SESSION_EXECUTOR_DOCKER_NETWORK:-}")" \
   "$(remote_env_assignment DEPLOY_DOCKER_PRUNE "${DEPLOY_DOCKER_PRUNE:-1}")" \
@@ -2266,49 +2264,17 @@ SELECT COUNT(*) FROM endpoint_blockers;"
     if [ "$ROLE" != "worker" ]; then
       return 0
     fi
-    local database_url attempts retry_delay attempt guardrail_status
+    local database_url
     database_url="$(worker_database_url)"
-    attempts="${WORKER_DEPLOY_GUARDRAIL_ATTEMPTS:-31}"
-    retry_delay="${WORKER_DEPLOY_GUARDRAIL_RETRY_DELAY_SECONDS:-10}"
-    if ! [[ "$attempts" =~ ^[1-9][0-9]*$ ]]; then
-      echo "ERROR: WORKER_DEPLOY_GUARDRAIL_ATTEMPTS must be a positive integer, got '$attempts'." >&2
-      return 1
-    fi
-    if ! [[ "$retry_delay" =~ ^[0-9]+$ ]]; then
-      echo "ERROR: WORKER_DEPLOY_GUARDRAIL_RETRY_DELAY_SECONDS must be a non-negative integer, got '$retry_delay'." >&2
-      return 1
-    fi
-
-    for ((attempt = 1; attempt <= attempts; attempt++)); do
-      echo "Checking active long-running sessions before worker deploy (attempt $attempt/$attempts)..."
-      if docker run --rm -i \
-        --network 143_default \
-        --env-file /opt/143/.env \
-        -e "DATABASE_URL=$database_url" \
-        -e "FORCE_DEPLOY_WITH_ACTIVE_SESSIONS=${FORCE_DEPLOY_WITH_ACTIVE_SESSIONS:-}" \
-        -v /opt/143/.env.production.enc:/app/.env.production.enc:ro \
-        "ghcr.io/assembledhq/143-server:${IMAGE_TAG:-latest}" \
-        /bin/deploy-guardrail worker-sessions < /dev/null; then
-        return 0
-      else
-        guardrail_status=$?
-      fi
-
-      # Exit 3 is the guardrail's explicit "active inline session" result.
-      # Those sessions often reach a checkpoint seconds after parallel fleet
-      # workers inspect them, so wait briefly instead of failing the rollout
-      # on a timing race. Infrastructure and configuration failures retain
-      # their original exit status and fail immediately.
-      if [ "$guardrail_status" -ne 3 ]; then
-        return "$guardrail_status"
-      fi
-      if [ "$attempt" -ge "$attempts" ]; then
-        echo "ERROR: worker session deploy guardrail remained blocked after $attempts attempt(s)." >&2
-        return "$guardrail_status"
-      fi
-      echo "Worker session deploy guardrail is temporarily blocked; retrying in ${retry_delay}s..." >&2
-      sleep "$retry_delay"
-    done
+    echo "Checking active long-running sessions before worker deploy..."
+    docker run --rm -i \
+      --network 143_default \
+      --env-file /opt/143/.env \
+      -e "DATABASE_URL=$database_url" \
+      -e "FORCE_DEPLOY_WITH_ACTIVE_SESSIONS=${FORCE_DEPLOY_WITH_ACTIVE_SESSIONS:-}" \
+      -v /opt/143/.env.production.enc:/app/.env.production.enc:ro \
+      "ghcr.io/assembledhq/143-server:${IMAGE_TAG:-latest}" \
+      /bin/deploy-guardrail worker-sessions < /dev/null
   }
 
   # wait_container_healthy CONTAINER_ID TIMEOUT — poll until a specific container


### PR DESCRIPTION
## Summary

- Retry worker session guardrail blocks that return the explicit active-session status.
- Fail immediately on infrastructure or configuration errors and after bounded retries.
- Forward configurable attempt and retry-delay overrides to the remote deploy.
- Add unit coverage for recovery, bounded failure, and non-retryable errors.

## Testing

- Added Go unit tests covering transient retries, bounded guardrail failure, and infrastructure error handling.