### PR TITLE
Convert Safeguards section to standard policy cards and simplify copy on code review policy page

### DIFF
--- a/docs/design/implemented/117-code-review-policy-simplification.md
+++ b/docs/design/implemented/117-code-review-policy-simplification.md
@@ -113,6 +113,7 @@ The Code reviews page retains the existing **Reviews** and **Policy** tabs. The 
    - Short badges for outcome, reviewer count, quorum, and active safety gates.
 8. **Advanced controls**
    - One collapsed container holding Safety gates; Paths, authors, and required checks; Review agents; Limits and timeout; and Structured PR-description checks.
+   - Later change: the outer container was converted into a standard always-visible **Safeguards** policy card, so the page no longer nests a disclosure inside a disclosure. Progressive disclosure now lives entirely in the five subsections, which all start collapsed; the relevant one still opens automatically for a limit deep link or a structured validation error. Wherever this document says advanced controls start collapsed or carry their own `aria-expanded` state, read it as applying to those subsections.
 
 The automated approval policy remains prominent whenever approval is enabled. Optional review instructions are available on the main screen but visually secondary. Structured description checks remain advanced because they answer a different question: whether required evidence exists in the PR description.
 

--- a/frontend/src/app/(dashboard)/code-reviews/page.test.tsx
+++ b/frontend/src/app/(dashboard)/code-reviews/page.test.tsx
@@ -668,14 +668,13 @@ describe("CodeReviewsPage", () => {
     expect(screen.queryByRole("button", { name: /Repair GitHub reviewer/i })).not.toBeInTheDocument();
     expect(screen.queryByRole("button", { name: /Set up GitHub reviewer/i })).not.toBeInTheDocument();
 
-    // Safeguards and their focused groups are collapsed by default.
-    const advancedControls = screen.getByRole("button", {
-      name: "Safeguards",
-    });
-    expect(advancedControls).toHaveAttribute("aria-expanded", "false");
-    expect(screen.queryByRole("button", { name: /Approval criteria/i })).not.toBeInTheDocument();
-    await user.click(advancedControls);
-    expect(advancedControls).toHaveAttribute("aria-expanded", "true");
+    // Safeguard categories are visible without opening a second disclosure, but
+    // their details still start collapsed — that is now the only progressive
+    // disclosure left on this card.
+    expect(screen.getByRole("heading", { level: 3, name: "Safeguards" })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Safeguards" })).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Approval criteria/i })).toHaveAttribute("aria-expanded", "false");
+    expect(screen.queryByLabelText("Files changed")).not.toBeInTheDocument();
     await user.click(screen.getByRole("button", { name: /Paths, authors & checks/i }));
     expect(await screen.findByText("*auth*")).toBeInTheDocument();
     expect(screen.getByText("internal/**")).toBeInTheDocument();
@@ -2211,26 +2210,16 @@ describe("CodeReviewsPage", () => {
     const approvalRegion = screen.getByRole("region", { name: "Automated approval policy" });
     const instructionsRegion = screen.getByRole("region", { name: "Additional review instructions (optional)" });
     const summaryHeading = screen.getByText("Current behavior:");
-    const advancedTrigger = screen.getByRole("button", {
-      name: "Safeguards",
-    });
-    // The trigger owns the card's left inset; the right inset comes from the header
-    // row so the help icon, not the chevron, lands on the card edge.
-    expect(advancedTrigger).toHaveClass("h-auto", "py-4", "pr-2", "pl-4", "sm:h-auto", "sm:py-5", "sm:pl-5");
-    expect(advancedTrigger.closest("h3")?.parentElement).toHaveClass("pr-3", "sm:pr-4");
-    // The chevron must stay wrapped. As a direct child it matches the Button size
-    // variant's `has-[>svg]:px-2`, whose `:has()` specificity outranks the padding
-    // above and silently collapses the title back to an 8px inset. jsdom applies no
-    // CSS, so this structural check — not the class list above — is what catches it:
-    // the button also still carries an unmerged `px-2.5`, and these assertions would
-    // pass even if it started winning.
-    expect(advancedTrigger.querySelector(":scope > svg")).toBeNull();
+    const safeguardsHeading = screen.getByRole("heading", { level: 3, name: "Safeguards" });
+    const safeguardsCard = safeguardsHeading.closest("section");
+    expect(screen.getByText("Reviewer setup and the rules that gate automatic approval.")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Safeguards" })).not.toBeInTheDocument();
     // Behavior, then both prompts together, then safeguards, then GitHub setup.
     expect(enablement.compareDocumentPosition(summaryHeading) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
     expect(summaryHeading.compareDocumentPosition(approvalHeading) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
     expect(approvalHeading.compareDocumentPosition(instructionsHeading) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
-    expect(instructionsHeading.compareDocumentPosition(advancedTrigger) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
-    expect(advancedTrigger.compareDocumentPosition(githubHeading) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    expect(instructionsHeading.compareDocumentPosition(safeguardsHeading) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    expect(safeguardsHeading.compareDocumentPosition(githubHeading) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
     // Prominence comes from order and size only — no badge, tint, ring, or shadow.
     expect(within(approvalRegion).queryByText("Primary policy")).not.toBeInTheDocument();
     expect(approvalRegion.className).toBe(instructionsRegion.className);
@@ -2239,15 +2228,18 @@ describe("CodeReviewsPage", () => {
     // Every section title is a real heading, nested under the tab's own h2,
     // and all of them share one size.
     expect(screen.getByRole("heading", { level: 2, name: "Review policy" })).toBeInTheDocument();
-    for (const name of ["Review behavior", "Automated approval policy", "Additional review instructions (optional)", "GitHub reviewer connections"]) {
+    for (const name of ["Review behavior", "Automated approval policy", "Additional review instructions (optional)", "Safeguards", "GitHub reviewer connections"]) {
       expect(screen.getByRole("heading", { level: 3, name })).toBeInTheDocument();
     }
-    // Safeguards wraps its disclosure trigger, so the heading carries the
-    // trigger's descriptive line too.
-    expect(screen.getByRole("heading", { level: 3, name: /^Safeguards/ })).toBeInTheDocument();
-    for (const heading of [approvalHeading, instructionsHeading]) {
+    for (const heading of [approvalHeading, instructionsHeading, safeguardsHeading]) {
       expect(heading).toHaveClass("font-display", "text-lg", "font-semibold");
     }
+    // Safeguards is a plain bordered card like its siblings — no extra tint, ring,
+    // or shadow. Asserted by class rather than string-equality with approvalRegion:
+    // that card hardcodes its chrome while this one comes from `SectionGroup`, and
+    // the shared component is allowed to evolve (the fix then is to move the prompt
+    // composers onto it too, not to re-pin this test).
+    expect(safeguardsCard).toHaveClass("rounded-xl", "border", "border-border", "bg-card", "p-4", "sm:p-5");
 
     const outcomeInfo = screen.getByRole("button", {
       name: "About Review outcome",
@@ -2261,7 +2253,7 @@ describe("CodeReviewsPage", () => {
     act(() => enablementInfo.blur());
     const advancedInfo = screen.getByRole("button", { name: "About Safeguards" });
     await user.hover(advancedInfo);
-    expect(await screen.findByRole("tooltip")).toHaveTextContent(/deterministic approval safeguards/i);
+    expect(await screen.findByRole("tooltip")).toHaveTextContent(/Reviewer models, limits.*always enforced.*require human review/i);
     await user.unhover(advancedInfo);
     const instructionsInfo = screen.getByRole("button", { name: "About Additional review instructions (optional)" });
     await user.click(instructionsInfo);
@@ -2281,7 +2273,6 @@ describe("CodeReviewsPage", () => {
     expect(screen.getByText("Repository access")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Disable reviewer" })).toBeInTheDocument();
 
-    await user.click(screen.getByRole("button", { name: "Safeguards" }));
     expect(screen.queryByRole("combobox", { name: /Advanced policy preset/i })).not.toBeInTheDocument();
     expect(screen.queryByRole("button", { name: /Apply preset/i })).not.toBeInTheDocument();
     for (const section of ["Approval criteria", "Paths, authors & checks", "Reviewers & agents"]) {
@@ -2511,7 +2502,6 @@ describe("CodeReviewsPage", () => {
     renderWithProviders(<CodeReviewsPage />);
 
     await user.click(await screen.findByRole("tab", { name: /Policy/i }));
-    await user.click(await screen.findByRole("button", { name: "Safeguards" }));
     await user.click(
       await screen.findByRole("button", {
         name: /Structured PR-description checks/i,
@@ -2588,7 +2578,6 @@ describe("CodeReviewsPage", () => {
 
     renderWithProviders(<CodeReviewsPage />);
     await user.click(await screen.findByRole("tab", { name: /Policy/i }));
-    await user.click(screen.getByRole("button", { name: "Safeguards" }));
     await user.click(screen.getByRole("button", { name: /Reviewers & agents/i }));
     await user.click(await screen.findByRole("combobox", { name: "Reviewer 1 reasoning level" }));
     await user.click(await screen.findByRole("option", { name: "Extra high" }));
@@ -2652,7 +2641,6 @@ describe("CodeReviewsPage", () => {
 
     renderWithProviders(<CodeReviewsPage />);
     await user.click(await screen.findByRole("tab", { name: /Policy/i }));
-    await user.click(screen.getByRole("button", { name: "Safeguards" }));
     await user.click(screen.getByRole("button", { name: /Reviewers & agents/i }));
 
     const reasoningSelect = await screen.findByRole("combobox", { name: "Reviewer 1 reasoning level" });
@@ -2860,7 +2848,6 @@ describe("CodeReviewsPage", () => {
     renderWithProviders(<CodeReviewsPage />);
 
     await user.click(await screen.findByRole("tab", { name: /Policy/i }));
-    await user.click(await screen.findByRole("button", { name: "Safeguards" }));
     await user.click(await screen.findByRole("button", { name: /Paths, authors & checks/i }));
 
     const sensitivePathsInput = await screen.findByRole("textbox", {
@@ -2926,7 +2913,6 @@ describe("CodeReviewsPage", () => {
     renderWithProviders(<CodeReviewsPage />);
 
     await user.click(await screen.findByRole("tab", { name: /Policy/i }));
-    await user.click(screen.getByRole("button", { name: "Safeguards" }));
     await user.click(screen.getByRole("button", { name: /Approval criteria/i }));
 
     expect(await screen.findByLabelText("Timeout value")).toHaveValue(30);
@@ -2998,7 +2984,6 @@ describe("CodeReviewsPage", () => {
     renderWithProviders(<CodeReviewsPage />);
 
     await user.click(await screen.findByRole("tab", { name: /Policy/i }));
-    await user.click(await screen.findByRole("button", { name: "Safeguards" }));
     await user.click(await screen.findByRole("button", { name: /Reviewers & agents/i }));
     await user.click(await screen.findByRole("combobox", { name: "Reviewer 1 model" }));
 
@@ -3651,6 +3636,12 @@ describe("CodeReviewsPage", () => {
     await user.click(screen.getByRole("switch", { name: "Code reviews enabled" }));
     const subsection = await screen.findByRole("button", { name: /Reviewers & agents/i });
     await waitFor(() => expect(subsection).toHaveFocus());
-    expect(screen.getByRole("button", { name: "Safeguards" })).toHaveAttribute("aria-expanded", "true");
+    expect(subsection).toHaveAttribute("aria-expanded", "true");
+    // The save error sits in the Safeguards card above the divided subsection list,
+    // not inside it, so no divider hairline lands against the notice's card border.
+    const notice = screen.getByRole("alert");
+    expect(notice).toHaveTextContent("Could not save this policy setting");
+    expect(notice.parentElement).toBe(screen.getByRole("heading", { level: 3, name: "Safeguards" }).closest("section"));
+    expect(notice.compareDocumentPosition(subsection) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
   });
 });

--- a/frontend/src/app/(dashboard)/code-reviews/page.tsx
+++ b/frontend/src/app/(dashboard)/code-reviews/page.tsx
@@ -2186,25 +2186,15 @@ function AdvancedPolicySettings({
   }, []);
   return (
     <AdvancedPolicyControls
-      forceOpen={limitDeepLinkOpen || Boolean(invalidPolicyField && ["risk_policy", "inline_comment_limit", "agent_roster", "description_policy"].includes(invalidPolicyField))}
-      onOpened={() =>
-        trackCodeReviewPolicyEvent({
-          event: "code_review_advanced_opened",
-          scope: analyticsScope,
-          subsection: "all",
-          configured: true,
-        })
+      notice={
+        invalidPolicyField ? (
+          <ErrorNotice title="Could not save this policy setting" description={`Correct the highlighted ${invalidPolicyField.replaceAll("_", " ")} setting and try again.`} />
+        ) : null
       }
     >
-      {invalidPolicyField ? (
-        <ErrorNotice title="Could not save this policy setting" description={`Correct the highlighted ${invalidPolicyField.replaceAll("_", " ")} setting and try again.`} />
-      ) : null}
-                <div>
-                  <div className="text-sm font-medium text-foreground">Fine-tuning</div>
-                  <div className="mt-2 divide-y divide-border border-y border-border">
           <FineTuningSection
             title="Approval criteria"
-            summary="Size thresholds, limits, timeout, and reviewer quorum"
+            summary="Set limits for change size, review time, and reviewer agreement."
             forceOpen={limitDeepLinkOpen || invalidPolicyField === "risk_policy" || invalidPolicyField === "inline_comment_limit"}
             onOpened={() =>
               trackCodeReviewPolicyEvent({
@@ -2315,7 +2305,7 @@ function AdvancedPolicySettings({
 
           <FineTuningSection
             title="Quality gates"
-            summary="Merge and check requirements before approval"
+            summary="Choose what a pull request must pass before approval."
             onOpened={() =>
               trackCodeReviewPolicyEvent({
                 event: "code_review_advanced_opened",
@@ -2397,7 +2387,7 @@ function AdvancedPolicySettings({
 
           <FineTuningSection
             title="Paths, authors & checks"
-            summary="Path filters, eligible authors, and required checks"
+            summary="Choose which changes are eligible for approval."
             onOpened={() =>
               trackCodeReviewPolicyEvent({
                 event: "code_review_advanced_opened",
@@ -2482,7 +2472,7 @@ function AdvancedPolicySettings({
 
           <FineTuningSection
             title="Reviewers & agents"
-            summary="Reviewer agents and the orchestrating agent"
+            summary="Choose who reviews the code and weighs the evidence."
             forceOpen={invalidPolicyField === "agent_roster"}
             onOpened={() =>
               trackCodeReviewPolicyEvent({
@@ -2504,7 +2494,7 @@ function AdvancedPolicySettings({
 
           <FineTuningSection
             title="Structured PR-description checks"
-            summary="PR description rules checked before approval"
+            summary="Define what a pull request description must include."
             forceOpen={invalidPolicyField === "description_policy"}
             onOpened={() =>
               trackCodeReviewPolicyEvent({
@@ -2534,53 +2524,31 @@ function AdvancedPolicySettings({
                       }}
                     />
                   </FineTuningSection>
-                  </div>
-                </div>
-                </AdvancedPolicyControls>
+    </AdvancedPolicyControls>
   );
 }
 
-function AdvancedPolicyControls({ children, forceOpen, onOpened }: { children: ReactNode; forceOpen: boolean; onOpened: () => void }) {
-  const [open, setOpen] = useState(false);
+function AdvancedPolicyControls({ children, notice }: { children: ReactNode; notice?: ReactNode }) {
   return (
-    <Collapsible
-      open={open || forceOpen}
-      onOpenChange={(next) => {
-        setOpen(next);
-        if (next) onOpened();
-      }}
+    // Standard bordered policy card, same as the sibling sections, with the help
+    // icon in the header's action slot.
+    <SectionGroup
+      title="Safeguards"
+      description="Reviewer setup and the rules that gate automatic approval."
+      variant="bordered"
+      headingLevel={3}
+      action={
+        <SettingInfoTooltip
+          label="Safeguards"
+          description="Reviewer models, limits, and the deterministic rules that are always enforced. These rules can require human review even when the reviewers recommend approval."
+        />
+      }
     >
-      <div className="rounded-xl border border-border bg-card">
-        {/* Padding is split rather than a plain `p-4 sm:p-5`: the trigger is not the
-            full card width, so only its left edge carries the card inset that
-            `CollapsibleContent` and sibling `SectionGroup`s use. The right inset comes
-            from this row's `pr`, which lands the help icon — not the chevron — on it. */}
-        <div className="flex items-center gap-1 pr-3 sm:pr-4">
-          <h3 className="min-w-0 flex-1">
-            <CollapsibleTrigger asChild>
-              <Button variant="ghost" className="group h-auto w-full min-w-0 justify-between whitespace-normal rounded-xl py-4 pr-2 pl-4 text-left sm:h-auto sm:py-5 sm:pl-5" aria-label="Safeguards">
-                <span className="min-w-0">
-                  <span className="block font-display text-lg leading-6 font-semibold tracking-[-0.025em] text-foreground">Safeguards</span>
-                  <span className="mt-0.5 block text-xs font-normal text-muted-foreground">These settings apply whether or not this section is open.</span>
-                </span>
-                {/* Wrapped so the chevron is not a direct child: `size="default"` carries
-                    `has-[>svg]:px-2`, whose `:has()` specificity silently outranks the plain
-                    padding utilities set above. `DisclosureCard` wraps its chevron too and is
-                    immune for the same reason. */}
-                <span className="flex shrink-0 items-center">
-                  <ChevronDown className="h-4 w-4 text-muted-foreground transition-transform group-data-[state=open]:rotate-180" />
-                </span>
-              </Button>
-            </CollapsibleTrigger>
-          </h3>
-          <SettingInfoTooltip
-            label="Safeguards"
-            description="Contains deterministic approval safeguards, reviewer configuration, limits, and structured PR-description checks. Defaults remain enforced while this section is closed."
-          />
-        </div>
-        <CollapsibleContent className="space-y-4 border-t border-border p-4 sm:p-5">{children}</CollapsibleContent>
-      </div>
-    </Collapsible>
+      {/* Save errors stay outside the divided list: an ErrorNotice is a bordered
+          card of its own, so a divider hairline against its edge reads as a seam. */}
+      {notice}
+      <div className="divide-y divide-border border-y border-border">{children}</div>
+    </SectionGroup>
   );
 }
 
@@ -2597,8 +2565,7 @@ function PolicySummary({ config }: { config: CodeReviewPolicyConfig | null }) {
   const outcome = policyOutcome(config);
   const reviewers = config.agent_roster.reviewers.length;
   // Deliberately excludes the selected outcome: the switch and radio group
-  // immediately above already state it. This line's job is to report the
-  // settings that live inside the collapsed Safeguards section.
+  // immediately above already state it.
   const summaryItems = [
     ...(outcome === "disabled" ? ["Reviews paused"] : []),
     `${reviewers} ${reviewers === 1 ? "reviewer" : "reviewers"}`,


### PR DESCRIPTION
## Summary

The Code Reviews page had nested “disclosure inside disclosure” behavior for Safeguards, which created a confusing progressive-disclosure workflow and a reliability risk for UI state (e.g., `aria-expanded`) and deep links. This change converts Safeguards into a standard, always-visible policy card and keeps progressive disclosure only within its subsections, while preserving the automatic opening behavior for relevant deep links/validation errors.

## Changes

- Convert the outer Safeguards control from a collapsible container into a standard always-visible **Safeguards** policy card (no second disclosure nesting).
- Ensure all Safeguards categories/subsections use the single remaining progressive disclosure pattern and start collapsed consistently, with the appropriate subsection auto-opening when needed.
- Update CodeReviewsPage tests to reflect the new DOM/accessibility contract: Safeguards header is now a visible heading, category buttons remain collapsed by default, and “Approval criteria” remains closed.

## Validation

- Updated and verified `frontend/src/app/(dashboard)/code-reviews/page.test.tsx` expectations around Safeguards rendering and `aria-expanded` behavior.
- Ensured existing deep-link/structured-validation behavior assumptions remain represented in tests (via the updated Safeguards progressive disclosure model).

[143.dev](https://143.dev) | [session 0d49d70f](https://143.dev/sessions/0d49d70f-56f1-4d0d-a4a4-8fd6173b252e)

<!-- 143-publication session=0d49d70f-56f1-4d0d-a4a4-8fd6173b252e changeset=0c5801a0-9fa4-487b-adf5-11b0b6b627e2 -->

Preview: https://143.dev/previews/github/assembledhq/143/pull/2087?launch=1