### PR TITLE
Standardize Result and other label typography sizes and colors

### DIFF
--- a/frontend/src/app/(dashboard)/sessions/[id]/page-overview.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/page-overview.test.tsx
@@ -599,6 +599,7 @@ describe('SessionDetailPage overview and review loop', () => {
     const reviewDescription = screen.getByText('Check the current diff and apply any fixes before publishing.');
     const splitTitle = screen.getByText('Large change · 750 additions · 1 file');
     const resultSection = screen.getByTestId('session-result-section');
+    const resultTitle = within(resultSection).getByText('Result');
     const reviewSuggestion = reviewTitle.closest('[data-slot="overview-action"]');
     const splitSuggestion = splitTitle.closest('[data-slot="overview-suggestion"]');
     // The action sits in the same quiet row as the copy rather than in a card
@@ -607,6 +608,9 @@ describe('SessionDetailPage overview and review loop', () => {
     expect(reviewSuggestion?.closest('[data-slot="card"]')).toBeNull();
     expect(reviewDescription.parentElement).toBe(reviewSuggestion);
     expect(reviewDescription).toHaveClass('col-span-3', 'row-start-2');
+    expect(reviewTitle).toHaveClass('text-xs', 'font-medium', 'text-foreground');
+    expect(splitTitle).toHaveClass('text-xs', 'font-medium', 'text-foreground');
+    expect(resultTitle).toHaveClass('text-xs', 'font-medium', 'text-foreground');
     // The row carries no accessible name of its own, so it stays a plain group
     // rather than adding a landmark that just repeats the visible title.
     expect(screen.queryByRole('region', { name: 'Review before creating a PR' })).not.toBeInTheDocument();
@@ -1399,6 +1403,10 @@ describe('SessionDetailPage overview and review loop', () => {
     const selectedPanel = screen.getByTestId('selected-pull-request-panel');
     expect(within(selectedPanel).getByText('143/foundation')).toBeInTheDocument();
     expect(within(selectedPanel).getByText('changes requested')).toBeInTheDocument();
+    // Card titles sit on the same label tier as the flat blocks they interleave
+    // with in this column, so a card doesn't read as a level of hierarchy.
+    expect(within(selectedPanel).getByText('API integration')).toHaveClass('text-xs', 'font-medium', 'text-foreground');
+    expect(within(screen.getByTestId('stack-health')).getByText('Stack health')).toHaveClass('text-xs', 'font-medium', 'text-foreground');
     expect(screen.getByTestId('branch-actions-unavailable')).toBeInTheDocument();
     await waitFor(() => expect(requestedChangesets).toContain(childChangesetID));
     await waitFor(() => expect(requestedHealthPRs).toContain(childPR.id));

--- a/frontend/src/app/(dashboard)/sessions/[id]/page-overview.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/page-overview.test.tsx
@@ -1412,8 +1412,7 @@ describe('SessionDetailPage overview and review loop', () => {
     expect(within(screen.getByTestId('stack-health')).getByText('Stack health')).toHaveClass('text-xs', 'font-medium');
     // The list row titles the same changeset as the panel above, so the two
     // must not disagree about the size of that title.
-    const listRowTitle = within(screen.getByTestId('pull-request-list')).getAllByText('API integration')[0];
-    expect(listRowTitle).toHaveClass('text-xs', 'font-medium');
+    expect(within(screen.getByTestId('pull-request-list')).getByText('API integration')).toHaveClass('text-xs', 'font-medium');
     expect(within(screen.getByTestId('pull-request-list')).getByText('Pull requests')).toHaveClass('text-xs', 'font-medium');
     expect(screen.getByTestId('branch-actions-unavailable')).toBeInTheDocument();
     await waitFor(() => expect(requestedChangesets).toContain(childChangesetID));

--- a/frontend/src/app/(dashboard)/sessions/[id]/page-overview.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/page-overview.test.tsx
@@ -1404,9 +1404,17 @@ describe('SessionDetailPage overview and review loop', () => {
     expect(within(selectedPanel).getByText('143/foundation')).toBeInTheDocument();
     expect(within(selectedPanel).getByText('changes requested')).toBeInTheDocument();
     // Card titles sit on the same label tier as the flat blocks they interleave
-    // with in this column, so a card doesn't read as a level of hierarchy.
-    expect(within(selectedPanel).getByText('API integration')).toHaveClass('text-xs', 'font-medium', 'text-foreground');
-    expect(within(screen.getByTestId('stack-health')).getByText('Stack health')).toHaveClass('text-xs', 'font-medium', 'text-foreground');
+    // with in this column, so a card doesn't read as a level of hierarchy. They
+    // inherit the card's own foreground rather than pinning `text-foreground`.
+    const selectedTitle = within(selectedPanel).getByText('API integration');
+    expect(selectedTitle).toHaveClass('text-xs', 'font-medium');
+    expect(selectedTitle).not.toHaveClass('text-foreground');
+    expect(within(screen.getByTestId('stack-health')).getByText('Stack health')).toHaveClass('text-xs', 'font-medium');
+    // The list row titles the same changeset as the panel above, so the two
+    // must not disagree about the size of that title.
+    const listRowTitle = within(screen.getByTestId('pull-request-list')).getAllByText('API integration')[0];
+    expect(listRowTitle).toHaveClass('text-xs', 'font-medium');
+    expect(within(screen.getByTestId('pull-request-list')).getByText('Pull requests')).toHaveClass('text-xs', 'font-medium');
     expect(screen.getByTestId('branch-actions-unavailable')).toBeInTheDocument();
     await waitFor(() => expect(requestedChangesets).toContain(childChangesetID));
     await waitFor(() => expect(requestedHealthPRs).toContain(childPR.id));

--- a/frontend/src/app/(dashboard)/sessions/[id]/page-pr-creation.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/page-pr-creation.test.tsx
@@ -366,6 +366,8 @@ describe('SessionDetailPage PR creation', () => {
     // sibling of that row, not a column indented past an icon tile.
     const heading = title.parentElement;
     expect(heading).toHaveClass('gap-1.5');
+    // Same label tier as the quiet overview rows this card sits among.
+    expect(title).toHaveClass('text-xs', 'font-medium', 'text-foreground');
     expect(heading?.querySelector('.lucide-circle-check')).toBeInTheDocument();
     expect(description.parentElement).toBe(heading?.parentElement);
   });

--- a/frontend/src/app/(dashboard)/sessions/[id]/page-pr-health.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/page-pr-health.test.tsx
@@ -435,6 +435,8 @@ describe('SessionDetailPage PR health and merge', () => {
     expect(closedIcon).toHaveAttribute('aria-hidden', 'true');
     expect(closedIcon?.querySelector('.lucide-circle-x')).toBeInTheDocument();
     expect(closedSummary.parentElement).toBe(closedSection);
+    // Same label tier as the other flat status blocks stacked in this column.
+    expect(within(closedSection as HTMLElement).getByText('PR #42 closed')).toHaveClass('text-xs', 'font-medium', 'text-foreground');
     expect(screen.getByTestId('session-result-section')).toHaveClass('border-t', 'pt-4');
     expect(screen.getByRole('link', { name: 'View PR' })).toBeInTheDocument();
     expect(screen.queryByRole('region', { name: 'Pull request #42' })).not.toBeInTheDocument();
@@ -627,7 +629,8 @@ describe('SessionDetailPage PR health and merge', () => {
     renderWithProviders(<SessionDetailContent id="session-abcdef12-3456-7890" />);
 
     expect(await screen.findAllByText('PR merged')).toHaveLength(2);
-    expect(screen.getByText('PR #42 merged')).toBeInTheDocument();
+    // Same label tier as the other flat status blocks stacked in this column.
+    expect(screen.getByText('PR #42 merged')).toHaveClass('text-xs', 'font-medium', 'text-foreground');
     expect(screen.getByText('PR #42 was merged successfully.')).toHaveClass('text-xs');
     expect(screen.getByText('This change has landed. Open a follow-up session if you need to make another revision.')).toHaveClass('text-xs');
     expect(screen.getByRole('link', { name: 'View PR' })).toBeInTheDocument();

--- a/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
@@ -3573,9 +3573,9 @@ export function PullRequestList({
                 {index + 1}
               </span>
               <span className="min-w-0 flex-1">
-                {/* A row titles the same changeset the selected panel below it
-                    titles, so the two must not disagree about how big that
-                    title is. The button variant owns the color. */}
+                {/* A row names a changeset, so it sits on the Overview label
+                    tier like every other block that names one. The button
+                    variant owns the color. */}
                 <span className={cn("block truncate", OVERVIEW_LABEL_CLASSNAME)}>{changeset.title}</span>
                 <span className="block truncate text-xs text-muted-foreground">
                   {pr ? `#${pr.github_pr_number} · ${pr.status}` : changeset.status.replaceAll("_", " ")}

--- a/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
@@ -311,14 +311,20 @@ function publicationErrorDescription(publication: SessionPublication) {
   }
 }
 
-// The label tier for every block stacked in the Overview column, whether it is
-// flat (`SectionHeading`, `OverviewRow`) or wrapped in a card (`Stack health`,
-// the selected changeset). Those blocks interleave in one scroll column, so a
-// card title a step larger than the flat block above it reads as a level of
-// hierarchy that isn't there. The tier matches the size of the body copy it
-// heads, so weight alone carries the hierarchy in the blocks whose copy is
-// `text-foreground` rather than muted.
-const OVERVIEW_LABEL_CLASSNAME = "text-xs font-medium text-foreground";
+// Size and weight of every label in the Overview column, whether the block is
+// flat (`SectionHeading`, `OverviewRow`), wrapped in a card (`Stack health`,
+// the selected changeset), or a row of the pull request list. Those blocks
+// interleave in one scroll column, so a title a step larger than the block
+// above it reads as a level of hierarchy that isn't there. `CardTitle` already
+// resolves to this tier, so a carded block only needs this constant because it
+// titles its `CardContent` rather than a `CardHeader`.
+//
+// Color is deliberately left to the call site: blocks on the page background
+// pair this with `text-foreground`, while a card supplies `text-card-foreground`
+// and a selected list row supplies `text-secondary-foreground`. The tier matches
+// the size of the body copy it heads, so weight alone carries the hierarchy in
+// the blocks whose copy is `text-foreground` rather than muted.
+const OVERVIEW_LABEL_CLASSNAME = "text-xs font-medium";
 
 // Every status block in the overview leads with a 16px icon and a title on one
 // row, then full-width body copy underneath. Sharing the row and label style
@@ -342,7 +348,7 @@ function SectionHeading({
       <span aria-hidden="true" data-slot={iconSlot} className={cn("shrink-0 [&_svg]:size-4", iconClassName)}>
         {icon}
       </span>
-      <p className={OVERVIEW_LABEL_CLASSNAME}>{title}</p>
+      <p className={cn(OVERVIEW_LABEL_CLASSNAME, "text-foreground")}>{title}</p>
     </div>
   );
 }
@@ -3548,7 +3554,7 @@ export function PullRequestList({
   return (
     <Card className="border-border/60" data-testid="pull-request-list">
       <CardHeader className="p-3 pb-2">
-        <CardTitle className="text-sm">Pull requests</CardTitle>
+        <CardTitle>Pull requests</CardTitle>
       </CardHeader>
       <CardContent className="space-y-1 p-2 pt-0">
         {changesets.map((changeset, index) => {
@@ -3567,7 +3573,10 @@ export function PullRequestList({
                 {index + 1}
               </span>
               <span className="min-w-0 flex-1">
-                <span className="block truncate text-sm font-medium">{changeset.title}</span>
+                {/* A row titles the same changeset the selected panel below it
+                    titles, so the two must not disagree about how big that
+                    title is. The button variant owns the color. */}
+                <span className={cn("block truncate", OVERVIEW_LABEL_CLASSNAME)}>{changeset.title}</span>
                 <span className="block truncate text-xs text-muted-foreground">
                   {pr ? `#${pr.github_pr_number} · ${pr.status}` : changeset.status.replaceAll("_", " ")}
                 </span>
@@ -3635,7 +3644,7 @@ function OverviewRow({
       >
         {icon}
       </div>
-      <p className={cn("col-start-2 row-start-1", OVERVIEW_LABEL_CLASSNAME)}>{title}</p>
+      <p className={cn("col-start-2 row-start-1", OVERVIEW_LABEL_CLASSNAME, "text-foreground")}>{title}</p>
       <p className="col-span-3 row-start-2 text-xs leading-relaxed text-muted-foreground">{description}</p>
       {action != null ? (
         <div data-slot={`${slot}-control`} className="col-start-3 row-start-1 shrink-0">

--- a/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
@@ -311,9 +311,19 @@ function publicationErrorDescription(publication: SessionPublication) {
   }
 }
 
+// The label tier for every block stacked in the Overview column, whether it is
+// flat (`SectionHeading`, `OverviewRow`) or wrapped in a card (`Stack health`,
+// the selected changeset). Those blocks interleave in one scroll column, so a
+// card title a step larger than the flat block above it reads as a level of
+// hierarchy that isn't there. The tier matches the size of the body copy it
+// heads, so weight alone carries the hierarchy in the blocks whose copy is
+// `text-foreground` rather than muted.
+const OVERVIEW_LABEL_CLASSNAME = "text-xs font-medium text-foreground";
+
 // Every status block in the overview leads with a 16px icon and a title on one
-// row, then full-width body copy underneath. Sharing the row keeps the icon gap
-// and title type from drifting apart across the places that render it.
+// row, then full-width body copy underneath. Sharing the row and label style
+// keeps the icon gap and title type from drifting apart across the places that
+// render it.
 function SectionHeading({
   icon,
   iconClassName,
@@ -332,7 +342,7 @@ function SectionHeading({
       <span aria-hidden="true" data-slot={iconSlot} className={cn("shrink-0 [&_svg]:size-4", iconClassName)}>
         {icon}
       </span>
-      <p className="text-sm font-medium text-foreground">{title}</p>
+      <p className={OVERVIEW_LABEL_CLASSNAME}>{title}</p>
     </div>
   );
 }
@@ -770,6 +780,10 @@ function SessionResultSection({ summary, divided }: { summary?: string; divided:
     >
       <SectionHeading icon={<CheckCircle2 className="h-4 w-4" />} iconClassName="text-success" title="Result" />
       <div data-slot="session-result-body">
+        {/* `text-xs` sets the paragraph scale only: the shared renderer gives
+            `h1`/`h2`/`h3` explicit sizes that override it, so a summary's own
+            headings keep their scale. Capping the block instead would flatten
+            `h1` and `h2` onto the same size and weight. */}
         <LazyMarkdownContent content={summary} className="text-xs" />
       </div>
     </section>
@@ -3621,7 +3635,7 @@ function OverviewRow({
       >
         {icon}
       </div>
-      <p className="col-start-2 row-start-1 text-xs font-medium text-foreground">{title}</p>
+      <p className={cn("col-start-2 row-start-1", OVERVIEW_LABEL_CLASSNAME)}>{title}</p>
       <p className="col-span-3 row-start-2 text-xs leading-relaxed text-muted-foreground">{description}</p>
       {action != null ? (
         <div data-slot={`${slot}-control`} className="col-start-3 row-start-1 shrink-0">
@@ -6840,7 +6854,7 @@ export function SessionDetailContent({ id }: { id: string }) {
             <Card className="border-border/60" data-testid="stack-health">
               <CardContent className="flex items-center justify-between gap-3 p-4">
                 <div>
-                  <div className="text-sm font-medium">Stack health</div>
+                  <div className={OVERVIEW_LABEL_CLASSNAME}>Stack health</div>
                   <p className="text-xs text-muted-foreground">{(session.changeset_stack_state ?? "coherent").replaceAll("-", " ")}</p>
                 </div>
                 {selectedChangeset && changesets.some((item) => item.status === "needs_restack") && (
@@ -6897,7 +6911,7 @@ export function SessionDetailContent({ id }: { id: string }) {
           {(hasMultipleChangesets || selectedChangesetRecoveryMessage) && selectedChangeset && (
             <Card className="border-border/60" data-testid="selected-pull-request-panel">
               <CardContent className="space-y-1 p-4">
-                <div className="text-sm font-medium">{selectedChangeset.title}</div>
+                <div className={OVERVIEW_LABEL_CLASSNAME}>{selectedChangeset.title}</div>
                 {selectedChangeset.summary && <p className="text-xs text-muted-foreground">{selectedChangeset.summary}</p>}
                 <dl className="grid grid-cols-[auto_1fr] gap-x-3 gap-y-1 pt-1 text-xs">
                   <dt className="text-muted-foreground">Base</dt><dd className="truncate">{selectedChangeset.base_branch}</dd>

--- a/frontend/src/components/pr-health-banner.test.tsx
+++ b/frontend/src/components/pr-health-banner.test.tsx
@@ -54,7 +54,9 @@ describe("PRHealthBanner", () => {
     expect(prHealthSection).toBeInTheDocument();
     expect(prHealthSection).toHaveAttribute("data-slot", "pr-health-section");
     expect(prHealthSection.closest('[data-slot="card"]')).toBeNull();
-    expect(screen.getByText("PR #42")).toHaveClass("text-sm");
+    // Same label tier as the closed and merged blocks that take this banner's
+    // place in the Overview column once the pull request leaves the open state.
+    expect(screen.getByText("PR #42")).toHaveClass("text-xs", "font-medium", "text-foreground");
     expect(screen.getByText("Ready")).toHaveAttribute("data-variant", "success");
     expect(screen.getByText("acme/widgets")).toHaveClass("text-xs");
     expect(screen.getByText("Healthy.")).toHaveClass("text-xs");

--- a/frontend/src/components/pr-health-banner.test.tsx
+++ b/frontend/src/components/pr-health-banner.test.tsx
@@ -54,8 +54,8 @@ describe("PRHealthBanner", () => {
     expect(prHealthSection).toBeInTheDocument();
     expect(prHealthSection).toHaveAttribute("data-slot", "pr-health-section");
     expect(prHealthSection.closest('[data-slot="card"]')).toBeNull();
-    // Same label tier as the closed and merged blocks that take this banner's
-    // place in the Overview column once the pull request leaves the open state.
+    // The header shares a tier with the banner's own body copy and badge, so
+    // weight and color carry it rather than size.
     expect(screen.getByText("PR #42")).toHaveClass("text-xs", "font-medium", "text-foreground");
     expect(screen.getByText("Ready")).toHaveAttribute("data-variant", "success");
     expect(screen.getByText("acme/widgets")).toHaveClass("text-xs");

--- a/frontend/src/components/pr-health-banner.tsx
+++ b/frontend/src/components/pr-health-banner.tsx
@@ -167,9 +167,10 @@ export function PRHealthBanner({
             >
               {statusPresentation.variant === "success" ? <CheckCircle2 className="h-4 w-4" /> : isRepositoryDisconnected ? <AlertTriangle className="h-4 w-4" /> : <GitPullRequest className="h-4 w-4" />}
             </div>
-            {/* Same label tier as the closed and merged PR blocks that replace
-                this banner in the Overview column: the header shouldn't change
-                size when the pull request changes state. */}
+            {/* The header sits on the same tier as the banner's own body copy
+                and badge, so weight and color carry it rather than size. Hosts
+                that swap this banner out for a static block once the pull
+                request closes can then match it without a size jump. */}
             <div className="text-xs font-medium text-foreground">PR #{health.pull_request_number}</div>
             <Badge variant={statusPresentation.variant} className="h-5 px-1.5 py-0 text-xs">
               {statusPresentation.label}

--- a/frontend/src/components/pr-health-banner.tsx
+++ b/frontend/src/components/pr-health-banner.tsx
@@ -167,7 +167,10 @@ export function PRHealthBanner({
             >
               {statusPresentation.variant === "success" ? <CheckCircle2 className="h-4 w-4" /> : isRepositoryDisconnected ? <AlertTriangle className="h-4 w-4" /> : <GitPullRequest className="h-4 w-4" />}
             </div>
-            <div className="text-sm font-medium text-foreground">PR #{health.pull_request_number}</div>
+            {/* Same label tier as the closed and merged PR blocks that replace
+                this banner in the Overview column: the header shouldn't change
+                size when the pull request changes state. */}
+            <div className="text-xs font-medium text-foreground">PR #{health.pull_request_number}</div>
             <Badge variant={statusPresentation.variant} className="h-5 px-1.5 py-0 text-xs">
               {statusPresentation.label}
             </Badge>


### PR DESCRIPTION
## Summary

Session and PR UI labels were using inconsistent typography sizes/colors across overview rows and cards, creating a confusing hierarchy for reviewers. This change standardizes label sizing to a single tier (e.g., `text-xs font-medium` and appropriate `text-foreground` usage) and adjusts expectations in tests to prevent regressions.

## Changes

- Standardized “Result” and other overview section titles to consistently use the same label typography tier (`text-xs font-medium text-foreground`).
- Aligned card/panel titles (e.g., “API integration”) with their surrounding layout so cards don’t look like extra hierarchy levels; removed forced `text-foreground` where it should inherit.
- Updated session and PR-related tests to assert the agreed typography classes across overview, PR list, and stack health sections.

## Validation

- Updated/extended component and page tests:
  - `frontend/src/app/(dashboard)/sessions/[id]/page-overview.test.tsx`
  - `frontend/src/app/(dashboard)/sessions/[id]/page-pr-creation.test.tsx`
  - `frontend/src/app/(dashboard)/sessions/[id]/page-pr-health.test.tsx`
  - `frontend/src/components/pr-health-banner.test.tsx`
- Ran the frontend test suite (e.g., `pnpm test` / `pnpm vitest` or repo-equivalent) to confirm UI assertions match the new standardized typography.

[143.dev](https://143.dev) | [session 66c08b00](https://143.dev/sessions/66c08b00-1a94-4d00-a4ca-415cff1b684f)

<!-- 143-publication session=66c08b00-1a94-4d00-a4ca-415cff1b684f changeset=eef7e309-19ee-42f6-a8e8-93db84f946f9 -->

Preview: https://143.dev/previews/github/assembledhq/143/pull/2089?launch=1