### PR TITLE
Preserve provider credential errors and parse dated rate-limit retries

### DIFF
--- a/internal/services/agent/adapters/claude_code.go
+++ b/internal/services/agent/adapters/claude_code.go
@@ -205,10 +205,18 @@ func (a *ClaudeCodeAdapter) Execute(ctx context.Context, sandbox *agent.Sandbox,
 	}
 
 	if exitCode != 0 {
-		result.Error = fmt.Sprintf("claude CLI exited with code %d", exitCode)
-		if len(stderr) > 0 {
-			result.Error += ": " + string(stderr)
+		var lastSummary string
+		if len(summaryParts) > 0 {
+			lastSummary = summaryParts[len(summaryParts)-1]
 		}
+		result.Error = finalizeCLIExitError(
+			"claude",
+			exitCode,
+			result.Error,
+			string(stderr),
+			lastSummary,
+			lastAssistantContent,
+		)
 	}
 
 	// Collect the git diff from the sandbox.
@@ -483,13 +491,41 @@ output({
 // the UI, so we walk the nested blocks here and emit one structured LogEntry
 // per block.
 func parseClaudeStreamLine(line []byte, result *agent.AgentResult, logCh chan<- agent.LogEntry, summaryParts *[]string, lastAssistant *string) {
+	// Error events vary between Claude Code versions and Anthropic API
+	// passthroughs: message/error/content may each be a string or a nested
+	// object. Decode this small envelope before the strongly typed event so a
+	// nested error cannot make the whole line fall back to plain output.
+	var failureEvent struct {
+		Type    string          `json:"type"`
+		Error   json.RawMessage `json:"error,omitempty"`
+		Message json.RawMessage `json:"message,omitempty"`
+		Content json.RawMessage `json:"content,omitempty"`
+	}
+	if err := json.Unmarshal(line, &failureEvent); err == nil && failureEvent.Type == "error" {
+		msg := firstNonEmpty(
+			decodeStreamError(failureEvent.Error),
+			decodeStreamError(failureEvent.Message),
+			decodeStreamError(failureEvent.Content),
+			"unknown error",
+		)
+		setResultError(result, msg)
+		logCh <- agent.LogEntry{
+			Timestamp: time.Now(),
+			Level:     "error",
+			Message:   msg,
+		}
+		return
+	}
+
 	var event claudeStreamEvent
 	if err := json.Unmarshal(line, &event); err != nil {
+		text := string(line)
 		logCh <- agent.LogEntry{
 			Timestamp: time.Now(),
 			Level:     "output",
-			Message:   string(line),
+			Message:   text,
 		}
+		*summaryParts = append(*summaryParts, text)
 		return
 	}
 	if event.SessionID != "" {
@@ -512,18 +548,11 @@ func parseClaudeStreamLine(line []byte, result *agent.AgentResult, logCh chan<- 
 	case "user":
 		emitClaudeUserBlocks(event, logCh)
 
-	case "error":
-		// `error` is not part of the documented stream-json schema but we keep
-		// the case so unexpected-but-typed errors still surface as errors
-		// rather than as raw debug blobs.
-		logCh <- agent.LogEntry{
-			Timestamp: time.Now(),
-			Level:     "error",
-			Message:   string(line),
-		}
-
 	case "result":
 		summary := decodeClaudeResultSummary(event)
+		if event.IsError || strings.HasPrefix(strings.ToLower(strings.TrimSpace(event.Subtype)), "error") {
+			setResultError(result, firstNonEmpty(summary, event.Content, event.Subtype, "unknown error"))
+		}
 		logCh <- agent.LogEntry{
 			Timestamp: time.Now(),
 			Level:     "info",

--- a/internal/services/agent/adapters/claude_code_test.go
+++ b/internal/services/agent/adapters/claude_code_test.go
@@ -180,6 +180,21 @@ func TestClaudeCodeAdapter_Execute(t *testing.T) {
 			},
 		},
 		{
+			name:           "non-zero exit preserves rate-limit result event",
+			claudeOutput:   `{"type":"result","subtype":"error_during_execution","is_error":true,"result":"Claude Code usage limit reached. Try again at 8:50 AM.","session_id":"sess-rate-limit"}`,
+			claudeExitCode: 1,
+			stderrOutput:   "Claude diagnostic warning",
+			diffOutput:     "",
+			diffExitCode:   0,
+			checkResult: func(t *testing.T, result *agent.AgentResult, logs []agent.LogEntry) {
+				t.Helper()
+				require.Equal(t, 1, result.ExitCode, "Claude execution should preserve the CLI exit code")
+				require.Contains(t, result.Error, "claude CLI exited with code 1", "Claude execution should retain the generic exit context")
+				require.Contains(t, result.Error, "usage limit reached", "Claude execution should retain the provider rate-limit detail for fallback classification")
+				require.Contains(t, result.Error, "Claude diagnostic warning", "Claude execution should preserve stderr alongside the parsed provider error")
+			},
+		},
+		{
 			name:           "empty output",
 			claudeOutput:   "",
 			claudeExitCode: 0,
@@ -803,6 +818,25 @@ func TestParseStreamOutput(t *testing.T) {
 				require.Equal(t, 1000, result.TokenUsage.InputTokens)
 				require.Equal(t, 500, result.TokenUsage.OutputTokens)
 				require.Equal(t, "sess-z", result.AgentSessionID)
+			},
+		},
+		{
+			name:   "error result populates result error",
+			output: `{"type":"result","subtype":"error_during_execution","is_error":true,"result":"Claude Code usage limit reached. Try again at 8:50 AM.","session_id":"sess-rate-limit"}`,
+			checkResult: func(t *testing.T, result *agent.AgentResult, logs []agent.LogEntry) {
+				t.Helper()
+				require.Equal(t, "Claude Code usage limit reached. Try again at 8:50 AM.", result.Error, "is_error result events should populate the adapter result error")
+				require.Equal(t, "sess-rate-limit", result.AgentSessionID, "error result events should still preserve the Claude session id")
+			},
+		},
+		{
+			name:   "typed error event preserves nested message",
+			output: `{"type":"error","error":{"type":"rate_limit_error","message":"rate limit exceeded"}}`,
+			checkResult: func(t *testing.T, result *agent.AgentResult, logs []agent.LogEntry) {
+				t.Helper()
+				require.Equal(t, "rate_limit_error: rate limit exceeded", result.Error, "typed Claude errors should preserve nested provider details")
+				require.Len(t, logs, 1, "typed Claude errors should emit one error log")
+				require.Equal(t, "error", logs[0].Level, "typed Claude errors should be logged as errors")
 			},
 		},
 		{

--- a/internal/services/agent/adapters/codex.go
+++ b/internal/services/agent/adapters/codex.go
@@ -234,10 +234,8 @@ func (a *CodexAdapter) Execute(ctx context.Context, sandbox *agent.Sandbox, prom
 	}
 
 	if exitCode != 0 {
-		result.Error = fmt.Sprintf("codex CLI exited with code %d", exitCode)
-		if filteredStderr != "" {
-			result.Error += ": " + filteredStderr
-		}
+		parsedError := result.Error
+		result.Error = finalizeCLIExitError("codex", exitCode, parsedError, filteredStderr)
 
 		// Surface abnormal exits to the structured logger (and thus
 		// VictoriaLogs). Codex's raw stderr otherwise lands only in per-session
@@ -249,6 +247,9 @@ func (a *CodexAdapter) Execute(ctx context.Context, sandbox *agent.Sandbox, prom
 		// (e.g. a resume that the orchestrator recovers via fallback) that never
 		// reach the terminal FailureService classification.
 		snippet := filteredStderr
+		if snippet == "" {
+			snippet = parsedError
+		}
 		if len(snippet) > 600 {
 			snippet = snippet[:600]
 		}
@@ -341,8 +342,8 @@ func parseCodexStreamLine(line []byte, result *agent.AgentResult, logCh chan<- a
 	// Handle legacy single-object JSON format (no type field).
 	if event.Type == "" {
 		var legacy codexJSONOutput
-		if err := json.Unmarshal(line, &legacy); err == nil && legacy.Response != "" {
-			if !isDuplicateOutput("legacy", legacy.Response, lastByType) {
+		if err := json.Unmarshal(line, &legacy); err == nil && (legacy.Response != "" || legacy.Error != "") {
+			if legacy.Response != "" && !isDuplicateOutput("legacy", legacy.Response, lastByType) {
 				logCh <- agent.LogEntry{
 					Timestamp: time.Now(),
 					Level:     "output",
@@ -356,6 +357,14 @@ func parseCodexStreamLine(line []byte, result *agent.AgentResult, logCh chan<- a
 					InputTokens:  legacy.Stats.InputTokens,
 					OutputTokens: legacy.Stats.OutputTokens,
 				})
+			}
+			if legacy.Error != "" {
+				setResultError(result, legacy.Error)
+				logCh <- agent.LogEntry{
+					Timestamp: time.Now(),
+					Level:     "error",
+					Message:   legacy.Error,
+				}
 			}
 			return
 		}
@@ -447,14 +456,8 @@ func parseCodexStreamLine(line []byte, result *agent.AgentResult, logCh chan<- a
 			Metadata:  map[string]interface{}{"type": "thinking"},
 		}
 
-	case "error":
-		msg := event.Error
-		if msg == "" {
-			msg = event.Message
-		}
-		if msg == "" {
-			msg = event.Content
-		}
+	case "error", "turn.failed":
+		msg := firstNonEmpty(decodeStreamError(event.Error), event.Message, event.Content, "unknown error")
 		// Suppress refresh-token errors entirely — they are expected when
 		// tokens are shared and showing them is alarming and unhelpful.
 		if isRefreshTokenError(msg) {
@@ -469,6 +472,7 @@ func parseCodexStreamLine(line []byte, result *agent.AgentResult, logCh chan<- a
 			}
 			return
 		}
+		setResultError(result, msg)
 		logCh <- agent.LogEntry{
 			Timestamp: time.Now(),
 			Level:     "error",
@@ -636,6 +640,7 @@ func parseCodexOutput(output []byte, result *agent.AgentResult, logCh chan<- age
 			})
 		}
 		if codexResp.Error != "" {
+			setResultError(result, codexResp.Error)
 			logCh <- agent.LogEntry{
 				Timestamp: time.Now(),
 				Level:     "error",
@@ -681,7 +686,7 @@ type codexStreamEvent struct {
 		InputTokens  int `json:"inputTokens"`
 		OutputTokens int `json:"outputTokens"`
 	} `json:"stats,omitempty"`
-	Error string          `json:"error,omitempty"`
+	Error json.RawMessage `json:"error,omitempty"`
 	Item  *codexItem      `json:"item,omitempty"`
 	Usage json.RawMessage `json:"usage,omitempty"`
 	// ThreadID is emitted by Codex on the `thread.started` event at the start

--- a/internal/services/agent/adapters/codex_test.go
+++ b/internal/services/agent/adapters/codex_test.go
@@ -227,6 +227,7 @@ func TestParseCodexOutput_JSONWithError(t *testing.T) {
 	if result.Summary != "Attempted fix." {
 		t.Errorf("expected summary 'Attempted fix.', got %q", result.Summary)
 	}
+	require.Equal(t, "rate limit exceeded", result.Error, "legacy Codex errors should populate the adapter result error")
 
 	// Verify error log entry was sent.
 	foundError := false
@@ -351,6 +352,17 @@ func TestParseCodexStreamOutput(t *testing.T) {
 					}
 				}
 				require.True(t, hasError, "should have error log entry")
+				require.Equal(t, "context deadline exceeded", result.Error, "error events should populate the adapter result error")
+			},
+		},
+		{
+			name:   "turn failed event preserves nested provider message",
+			output: `{"type":"turn.failed","error":{"message":"You've hit your usage limit. Visit https://chatgpt.com/codex/settings/usage to purchase more credits or try again at Aug 8th, 2026 4:11 AM."}}`,
+			checkResult: func(t *testing.T, result *agent.AgentResult, logs []agent.LogEntry) {
+				t.Helper()
+				require.Equal(t, "You've hit your usage limit. Visit https://chatgpt.com/codex/settings/usage to purchase more credits or try again at Aug 8th, 2026 4:11 AM.", result.Error, "turn.failed should preserve the nested Codex provider message")
+				require.Len(t, logs, 1, "turn.failed should emit one error log")
+				require.Equal(t, "error", logs[0].Level, "turn.failed should be logged as an error")
 			},
 		},
 		{
@@ -639,6 +651,20 @@ func TestCodexAdapter_Execute(t *testing.T) {
 				require.Equal(t, 1, result.ExitCode)
 				require.Contains(t, result.Error, "exited with code 1")
 				require.Contains(t, result.Error, "command not found")
+			},
+		},
+		{
+			name: "non-zero exit preserves stdout usage-limit event",
+			codexOutput: `{"type":"error","message":"You've hit your usage limit. Try again at Aug 8th, 2026 4:11 AM."}
+{"type":"turn.failed","error":{"message":"You've hit your usage limit. Try again at Aug 8th, 2026 4:11 AM."}}`,
+			codexExitCode: 1,
+			diffOutput:    "",
+			diffExitCode:  0,
+			checkResult: func(t *testing.T, result *agent.AgentResult, logs []agent.LogEntry) {
+				t.Helper()
+				require.Equal(t, 1, result.ExitCode, "Codex execution should preserve the CLI exit code")
+				require.Contains(t, result.Error, "codex CLI exited with code 1", "Codex execution should retain the generic exit context")
+				require.Contains(t, result.Error, "You've hit your usage limit", "Codex execution should retain the provider rate-limit detail for fallback classification")
 			},
 		},
 		{

--- a/internal/services/agent/adapters/opencode_test.go
+++ b/internal/services/agent/adapters/opencode_test.go
@@ -383,6 +383,8 @@ func TestOpenCodeAdapter_Execute_CapturesFailureLogs(t *testing.T) {
 	provider.ExecStreamFn = func(ctx context.Context, sb *agent.Sandbox, cmd string, onLine func(line []byte), stderr io.Writer) (int, error) {
 		require.Contains(t, cmd, "opencode run", "OpenCode adapter should execute the OpenCode CLI")
 		onLine([]byte(`{"type":"error","sessionID":"ses_opencode","error":{"name":"UnknownError","data":{"message":"Unexpected server error. Check server logs for details.","ref":"err_123"}}}`))
+		_, writeErr := stderr.Write([]byte("OpenCode diagnostic warning"))
+		require.NoError(t, writeErr, "OpenCode test transport should write stderr")
 		return 1, nil
 	}
 	provider.ExecFn = func(ctx context.Context, sb *agent.Sandbox, cmd string, stdout, stderr io.Writer) (int, error) {
@@ -410,6 +412,7 @@ func TestOpenCodeAdapter_Execute_CapturesFailureLogs(t *testing.T) {
 	require.Equal(t, 1, result.ExitCode, "OpenCode execution should preserve the CLI exit code")
 	require.Contains(t, result.Error, "opencode CLI exited with code 1", "OpenCode execution should surface the non-zero exit")
 	require.Contains(t, result.Error, "UnknownError: Unexpected server error. Check server logs for details. (ref: err_123)", "OpenCode execution should preserve parsed terminal error details")
+	require.Contains(t, result.Error, "OpenCode diagnostic warning", "OpenCode execution should preserve stderr alongside the parsed provider error")
 	close(logCh)
 
 	logs := drain(logCh)

--- a/internal/services/agent/adapters/stream_parser.go
+++ b/internal/services/agent/adapters/stream_parser.go
@@ -1,6 +1,7 @@
 package adapters
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -163,6 +164,7 @@ func parseAgentStreamLine(
 		if msg == "" {
 			msg = "unknown error"
 		}
+		setResultError(result, msg)
 		logCh <- agent.LogEntry{
 			Timestamp: time.Now(),
 			Level:     "error",
@@ -255,6 +257,112 @@ func firstNonEmpty(values ...string) string {
 		}
 	}
 	return ""
+}
+
+// decodeStreamError normalizes the error shapes used by coding-agent JSONL
+// protocols. Providers have emitted errors as strings, nested error objects,
+// and objects whose useful message lives under data/error/message. Keeping the
+// normalization here lets the orchestrator classify a stable AgentResult.Error
+// without knowing each provider's wire format.
+func decodeStreamError(raw json.RawMessage) string {
+	return decodeStreamErrorDepth(raw, 0)
+}
+
+func decodeStreamErrorDepth(raw json.RawMessage, depth int) string {
+	trimmed := bytes.TrimSpace(raw)
+	if len(trimmed) == 0 || bytes.Equal(trimmed, []byte("null")) {
+		return ""
+	}
+	if depth >= 5 {
+		return string(trimmed)
+	}
+
+	var text string
+	if err := json.Unmarshal(trimmed, &text); err == nil {
+		return strings.TrimSpace(text)
+	}
+
+	var object map[string]json.RawMessage
+	if err := json.Unmarshal(trimmed, &object); err == nil && object != nil {
+		label := firstNonEmpty(
+			decodeStreamErrorDepth(object["name"], depth+1),
+			decodeStreamErrorDepth(object["type"], depth+1),
+			decodeStreamErrorDepth(object["code"], depth+1),
+		)
+		detail := firstNonEmpty(
+			decodeStreamErrorDepth(object["message"], depth+1),
+			decodeStreamErrorDepth(object["detail"], depth+1),
+			decodeStreamErrorDepth(object["reason"], depth+1),
+			decodeStreamErrorDepth(object["error"], depth+1),
+			decodeStreamErrorDepth(object["data"], depth+1),
+		)
+		switch {
+		case label != "" && detail != "" && !strings.EqualFold(label, detail):
+			return label + ": " + detail
+		case detail != "":
+			return detail
+		case label != "":
+			return label
+		default:
+			return string(trimmed)
+		}
+	}
+
+	return string(trimmed)
+}
+
+// setResultError records provider-reported failures without duplicating the
+// same message when a CLI emits both an error event and a terminal failed
+// event for one failure.
+func setResultError(result *agent.AgentResult, detail string) {
+	if result == nil {
+		return
+	}
+	detail = strings.TrimSpace(detail)
+	if detail == "" {
+		return
+	}
+	current := strings.TrimSpace(result.Error)
+	if current == "" {
+		result.Error = detail
+		return
+	}
+	if current == detail || strings.Contains(current, detail) {
+		return
+	}
+	result.Error = current + "; " + detail
+}
+
+// finalizeCLIExitError preserves provider output and stderr alongside the
+// generic process-exit context. Rate-limit classification depends on the
+// provider detail, while the generic context remains useful for operators.
+func finalizeCLIExitError(cliName string, exitCode int, parsedError, stderr string, fallbackDetails ...string) string {
+	parts := []string{fmt.Sprintf("%s CLI exited with code %d", cliName, exitCode)}
+	appendUniqueErrorPart := func(value string) {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			return
+		}
+		for _, part := range parts {
+			if part == value {
+				return
+			}
+		}
+		parts = append(parts, value)
+	}
+
+	appendUniqueErrorPart(parsedError)
+	appendUniqueErrorPart(stderr)
+	if len(parts) == 1 {
+		for _, detail := range fallbackDetails {
+			if strings.TrimSpace(detail) != "" {
+				appendUniqueErrorPart(detail)
+				break
+			}
+		}
+	}
+
+	return strings.Join(parts, ": ")
 }
 
 // streamingAgentConfig drives runStreamingAgent. BuildCmd receives the already
@@ -354,24 +462,18 @@ func runStreamingAgent(
 	}
 
 	if exitCode != 0 {
-		parsedError := strings.TrimSpace(result.Error)
-		result.Error = fmt.Sprintf("%s CLI exited with code %d", cfg.CLIName, exitCode)
-		errorDetail := strings.TrimSpace(string(stderr))
-		if errorDetail == "" {
-			if parsedError != "" {
-				errorDetail = parsedError
-			}
-			// TTY transports merge stderr into the visible output stream, so
-			// preserve the last visible line as the best-effort failure detail.
-			if errorDetail == "" && len(summaryParts) > 0 {
-				errorDetail = strings.TrimSpace(summaryParts[len(summaryParts)-1])
-			} else if errorDetail == "" && lastAssistantContent != "" {
-				errorDetail = strings.TrimSpace(lastAssistantContent)
-			}
+		var lastSummary string
+		if len(summaryParts) > 0 {
+			lastSummary = summaryParts[len(summaryParts)-1]
 		}
-		if errorDetail != "" {
-			result.Error += ": " + errorDetail
-		}
+		result.Error = finalizeCLIExitError(
+			cfg.CLIName,
+			exitCode,
+			result.Error,
+			string(stderr),
+			lastSummary,
+			lastAssistantContent,
+		)
 	}
 
 	diff, err := collectDiff(ctx, provider, sandbox, logger)

--- a/internal/services/agent/adapters/stream_parser_test.go
+++ b/internal/services/agent/adapters/stream_parser_test.go
@@ -311,6 +311,7 @@ func TestParseAgentStreamLine_EmptyErrorFallsBackToUnknown(t *testing.T) {
 	require.Equal(t, "error", logs[0].Level)
 	require.Equal(t, "unknown error", logs[0].Message,
 		"empty error events must surface a placeholder instead of a blank message")
+	require.Equal(t, "unknown error", result.Error, "empty error events should still populate the adapter result error")
 }
 
 func TestParseAgentStreamLine_NormalizesActionChoiceHumanInput(t *testing.T) {

--- a/internal/services/agent/orchestrator.go
+++ b/internal/services/agent/orchestrator.go
@@ -9020,6 +9020,7 @@ func isInvalidAuthTokenMessage(errMsg string) bool {
 
 var (
 	retryAfterRe     = regexp.MustCompile(`retry-after[=: ]+([0-9]+)`)
+	tryAgainOnDateRe = regexp.MustCompile(`try again at ([a-z]{3,9}) ([0-9]{1,2})(?:st|nd|rd|th)?,?\s+([0-9]{4})\s+([0-9]{1,2})(?::([0-9]{2}))?\s*(am|pm)?`)
 	tryAgainAtRe     = regexp.MustCompile(`try again at ([0-9]{1,2})(?::([0-9]{2}))?\s*(am|pm)?`)
 	resetInSecondsRe = regexp.MustCompile(`(?:reset|retry)[^0-9]{0,20}in ([0-9]+) seconds?`)
 )
@@ -9033,6 +9034,40 @@ func parseCredentialRateLimitUntil(msg string, now time.Time) time.Time {
 	if match := resetInSecondsRe.FindStringSubmatch(msg); len(match) == 2 {
 		if seconds, err := strconv.Atoi(match[1]); err == nil && seconds > 0 {
 			return now.Add(time.Duration(seconds) * time.Second)
+		}
+	}
+	if match := tryAgainOnDateRe.FindStringSubmatch(msg); len(match) == 7 {
+		monthName := strings.ToUpper(match[1][:1]) + match[1][1:]
+		monthLayout := "January"
+		if len(monthName) == 3 {
+			monthLayout = "Jan"
+		}
+		parsedMonth, monthErr := time.Parse(monthLayout, monthName)
+		day, dayErr := strconv.Atoi(match[2])
+		year, yearErr := strconv.Atoi(match[3])
+		hour, hourErr := strconv.Atoi(match[4])
+		minute := 0
+		var minuteErr error
+		if match[5] != "" {
+			minute, minuteErr = strconv.Atoi(match[5])
+		}
+		if monthErr == nil && dayErr == nil && yearErr == nil && hourErr == nil && minuteErr == nil {
+			switch match[6] {
+			case "pm":
+				if hour < 12 {
+					hour += 12
+				}
+			case "am":
+				if hour == 12 {
+					hour = 0
+				}
+			}
+			if day > 0 && hour >= 0 && hour <= 23 && minute >= 0 && minute <= 59 {
+				candidate := time.Date(year, parsedMonth.Month(), day, hour, minute, 0, 0, now.Location())
+				if candidate.After(now) && candidate.Day() == day {
+					return candidate
+				}
+			}
 		}
 	}
 	if match := tryAgainAtRe.FindStringSubmatch(msg); len(match) >= 2 {

--- a/internal/services/agent/orchestrator_helpers_internal_test.go
+++ b/internal/services/agent/orchestrator_helpers_internal_test.go
@@ -1258,6 +1258,11 @@ func TestParseCredentialFailureSignalRateLimitMetadata(t *testing.T) {
 			errorText: "You've hit your usage limit. try again at 8:50 AM.",
 			wantUntil: time.Date(now.Year(), now.Month(), now.Day(), 8, 50, 0, 0, now.Location()),
 		},
+		{
+			name:      "codex try again full date",
+			errorText: "You've hit your usage limit. try again at Aug 8th, 2026 4:11 AM.",
+			wantUntil: time.Date(2026, time.August, 8, 4, 11, 0, 0, now.Location()),
+		},
 	}
 	for _, tc := range cases {
 		tc := tc


### PR DESCRIPTION
## Summary

- Preserve parsed provider errors and stderr when coding-agent CLIs exit non-zero.
- Normalize nested error payloads across Claude, Codex, and shared stream parsers.
- Handle Claude result/error events and Codex `turn.failed` events consistently.
- Parse full-date retry timestamps for credential rate-limit classification.

## Testing

- Added focused adapter and orchestrator tests for nested errors, usage limits, stderr preservation, and dated retry windows.
- Existing affected tests updated to verify `AgentResult.Error` population.