### PR TITLE
Standardize GitHub section Add Repository button prominence on code reviewer policy page

### DIFF
--- a/frontend/src/app/(dashboard)/code-reviews/page.tsx
+++ b/frontend/src/app/(dashboard)/code-reviews/page.tsx
@@ -1618,7 +1618,7 @@ export default function CodeReviewsPage() {
                 headingLevel={3}
               action={
                 <DisabledTooltip disabled={!canManagePolicy} content={!canManagePolicy ? "Only organization administrators can add GitHub reviewer connections." : undefined}>
-                  <Button size="sm" disabled={!canManagePolicy} onClick={openAddRepository}>
+                  <Button size="sm" variant="outline" disabled={!canManagePolicy} onClick={openAddRepository}>
                       <Plus className="h-4 w-4" />
                       Add repository
                     </Button>


### PR DESCRIPTION
## Summary

The code reviewer policy page has an “Add repository” action that can become visually too prominent compared to other section headers, making the reviewer workflow harder to scan. This change updates the button styling to use a less prominent `outline` variant while preserving the existing disabled/permission behavior for non-admin users.

## Changes

- Updated the “Add repository” button on `frontend/src/app/(dashboard)/code-reviews/page.tsx` to use `variant="outline"`.
- Kept the existing `size="sm"`, `disabled={!canManagePolicy}`, and `DisabledTooltip` behavior unchanged so only organization admins can add GitHub reviewer connections.

## Validation

- Manually verified the page renders the button with the intended lower-emphasis styling.
- Confirmed the button remains disabled and shows the tooltip message when `canManagePolicy` is false.

[143.dev](https://143.dev) | [session 1bc4812d](https://143.dev/sessions/1bc4812d-7dea-4b1e-8860-2aa958993b3b)

<!-- 143-publication session=1bc4812d-7dea-4b1e-8860-2aa958993b3b changeset=2448fac2-e8a5-410e-b660-83f743bad59b -->

Preview: https://143.dev/previews/github/assembledhq/143/pull/2094?launch=1