### PR TITLE
Ensure compact view follow-up messages appear in session transcript

### DIFF
--- a/docs/design/118-collapsible-session-work-activity.md
+++ b/docs/design/118-collapsible-session-work-activity.md
@@ -1,6 +1,6 @@
 # Design: Collapsible Session Work Activity
 
-> **Status:** Partially Implemented | **Last reviewed:** 2026-08-04
+> **Status:** Partially Implemented | **Last reviewed:** 2026-08-07
 
 Implementation is complete in the working session changeset. The durable schema, typed
 lifecycle stores, ownership validation, reconciliation, orchestrator phase
@@ -510,8 +510,10 @@ failed phases is expected.
 8. Duration measures actual execution only and excludes queueing, setup,
    waiting, recovery, and post-response cleanup.
 9. Historical inferred capsules never display guessed duration.
-10. Queued steering stays out of the transcript until the runtime applies it,
-    then appears as a normal user message.
+ 10. A queued (not-yet-applied) steering message stays visible in the
+    transcript as a normal user message at its submission time; only a failed
+    delivery (dead_letter/unknown_delivery) is omitted from the transcript and
+    surfaced by the recoverable-inbox notice.
 11. One acknowledged delivery batch has durable identity and creates exactly
     one new phase only when execution actually resumes.
 12. Visible boundary events and final assistant responses are never hidden
@@ -943,7 +945,10 @@ The existing optimistic/queued message path must preserve delivery state.
 
 Before acknowledgment:
 
-- the message stays out of the rendered transcript;
+- the message renders in the transcript as a normal user prompt at its
+  submission time (the transcript is the only surface that shows a not-yet-
+  applied follow-up); a failed delivery is the only case kept out of the
+  rendered transcript and surfaced by the recoverable-inbox notice;
 - the active phase remains open;
 - subsequent old-phase entries retain the old phase ID.
 
@@ -984,14 +989,21 @@ before execution, and it is the state the recoverable-inbox notice offers a
 replay action for. Entries predating the delivery-batch machinery have no batch
 at all and are backfilled as applied.
 
-Adding a new way to reach `acked` without stamping `applied_at` silently
-deletes user messages from the transcript, so it is a contract change, not an
-implementation detail.
+Adding a new way to reach `acked` without stamping `applied_at` no longer
+deletes user messages from the transcript, because the frontend now renders
+in-flight (not-yet-applied) steering messages as visible prompts at their
+submission time. Only the failed/cancelled delivery states
+(`unknown_delivery`, `dead_letter`) are omitted from the transcript, and only
+because the recoverable-inbox notice is the dedicated surface that shows their
+content with retry controls. Stamping `applied_at` still matters for phase
+boundary identity; it just no longer gates transcript visibility of the user's
+own message.
 
-For the same reason the frontend enumerates the unapplied delivery states
-rather than treating a missing `applied_at` as proof of non-application: an
-unrecognized state must leave the message visible, because dropping
-user-authored content from every surface is worse than showing it early.
+For the same reason the frontend enumerates the delivery states it hides
+(`unknown_delivery`, `dead_letter`) rather than treating a missing `applied_at`
+as proof of non-application: an unrecognized state, and every in-flight state,
+must leave the message visible, because dropping user-authored content from
+every surface is worse than showing it early.
 
 Explicit interruption follows confirmation from runtime control rather than
 submission time.
@@ -1183,19 +1195,23 @@ type TimelineNode =
 The final rendered timeline is one ordered `TimelineNode[]`. Visible boundary
 events split inferred historical activity. Authoritative phase IDs determine
 new-session membership; the frontend must not reconstruct authoritative phase
-membership from timestamps. Unapplied inbox messages are excluded before node
-construction and enter the visible timeline as normal user messages only after
-the runtime applies them.
+membership from timestamps. Failed/cancelled inbox messages
+(`unknown_delivery`, `dead_letter`) are excluded before node construction and
+surfaced by the recoverable-inbox notice instead. In-flight (not-yet-applied)
+steering messages are NOT excluded: they enter the visible timeline as normal
+user messages at their submission time so the user always sees the follow-ups
+they have sent.
 
-Queued or acknowledged-but-not-applied user messages are excluded from ordinary
-timestamp ordering and from the rendered timeline. The transcript API supplies
-stable inbox sequence, delivery state, and created/acknowledged/applied
-timestamps. Once the runtime starts the delivery batch, `applied_at` becomes
-its presentation boundary: the message appears atomically between the closed
-prior phase and the newly running phase. `created_at` remains the audit
-timestamp and must not pull the applied message back into older activity.
-Abandoned delivery remains actionable through the existing inbox failure
-behavior outside the transcript.
+Queued or acknowledged-but-not-applied user messages render in the timeline at
+their `created_at` (submission) timestamp. The transcript API supplies stable
+inbox sequence, delivery state, and created/acknowledged/applied timestamps.
+`applied_at` still controls phase boundary identity — the new phase for an
+acknowledged batch starts when execution actually resumes — but it no longer
+gates transcript visibility of the user's own message, so the message no longer
+appears "atomically" only at application time; it is visible from send onward
+and stays in place when the runtime later applies it. `created_at` remains the
+audit timestamp. Abandoned/failed delivery remains actionable through the
+existing inbox failure behavior outside the transcript.
 
 Persisted assistant-role messages are authoritative final responses under the
 current message contract. `assistant_final` metadata remains authoritative for
@@ -1580,10 +1596,12 @@ Use table-driven Vitest cases for:
 - activity-label sanitation;
 - Compact/Detailed effective state;
 - transient override precedence;
-- queued steering omission before acknowledgment and applied-boundary ordering
-  after execution resumes;
-- omission across every unapplied delivery state, and visibility for an
-  unrecognized one;
+- in-flight (not-yet-applied) steering stays visible across every in-flight
+  delivery state and through the optimistic send/refetch handshake, while
+  failed/cancelled delivery (dead_letter/unknown_delivery) is omitted and
+  surfaced by the recoverable-inbox notice;
+- visibility for an unrecognized delivery state (fail open);
+- applied-boundary ordering after execution resumes;
 - optimistic send and refetch agreeing on steering visibility;
 - malformed legacy fallback.
 
@@ -1621,7 +1639,9 @@ Verify:
 - duplicated, missed, and out-of-order lifecycle SSE notifications reconcile
   to the durable transcript state;
 - two phases around human input in one turn;
-- queued steer omitted until the acknowledged new phase starts;
+- queued steer visible from send and still in place once the acknowledged new
+  phase starts; failed delivery omitted and surfaced by the recoverable-inbox
+  notice;
 - multiple messages in one acknowledged batch;
 - interruption and recovery capsules;
 - query refresh preserves transient state;
@@ -1662,8 +1682,8 @@ The browser suite must cover:
 - active streaming and completion collapse;
 - inspection-aware non-collapse;
 - human-input and steering boundaries;
-- queued steering omission before acknowledgment and atomic appearance after
-  application;
+- in-flight steering visible from send and stable through acknowledgment;
+  failed delivery omitted and surfaced by the recoverable-inbox notice;
 - older-window prepend without scroll jumps;
 - deep-link expansion into collapsed activity;
 - Compact/Detailed persistence after reload and a second browser context;
@@ -1735,8 +1755,8 @@ build/test outputs.
 4. Embed phases in transcript windows and live updates.
 5. Add the typed database-backed user preference.
 6. Build the phase-preserving frontend model and capsule UI.
-7. Integrate anchors, pagination, scroll restoration, queued-steering omission,
-   and inspection-aware collapse.
+7. Integrate anchors, pagination, scroll restoration, failed-delivery omission
+   (in-flight steering stays visible), and inspection-aware collapse.
 8. Add unit, integration, Playwright, and manual smoke coverage.
 9. Update public session documentation and final screenshots.
 10. Complete the full launch gate.
@@ -1776,7 +1796,7 @@ settings merge validator correctly rejects unknown fields on old API nodes.
 | Risk | Mitigation |
 | --- | --- |
 | A final answer is hidden in activity. | Persisted assistant messages are visible boundaries; final response and phase completion are atomic; conservative legacy fallback remains visible. |
-| Activity is assigned to the wrong instruction after steering. | Keep the old phase active until runtime acknowledgment; omit queued messages until application; use one phase per acknowledged batch. |
+| Activity is assigned to the wrong instruction after steering. | Keep the old phase active until runtime acknowledgment; use one phase per acknowledged batch. In-flight steering stays visible as the user's prompt at submission time; only failed delivery is omitted and surfaced by the recoverable-inbox notice. |
 | Duration includes waiting or setup. | Start at actual execution and close on confirmed pause/final persistence; store authoritative phase timestamps. |
 | A crash leaves a phase running forever. | Reaper closes lost-runtime phases, guarded by lease/status; alert and reconcile stranded rows. |
 | A stale worker writes to a replacement phase. | Propagate explicit phase ID and runtime/lease identity; reject stale terminal and append operations. |
@@ -1825,8 +1845,9 @@ settings merge validator correctly rejects unknown fields on old API nodes.
 - Expanded headers remain visible.
 - Historical sessions use inferred capsules without guessed duration.
 - Phases are embedded in transcript-window responses.
-- Queued messages stay out of the transcript and appear at their applied
-  boundary only when execution begins.
+- Queued (not-yet-applied) messages stay visible in the transcript from send
+  onward; only failed delivery is omitted and surfaced by the recoverable-inbox
+  notice.
 - Durable lifecycle SSE events invalidate and reconcile to transcript state.
 - Launch is immediate to all users with an emergency rendering kill switch.
 - Open pages refresh kill-switch configuration within 30 seconds.

--- a/frontend/e2e/session-activity.spec.ts
+++ b/frontend/e2e/session-activity.spec.ts
@@ -204,17 +204,22 @@ test("manual inspection protects a terminal phase and disclosure is keyboard ope
   await expect(page.getByRole("button", { name: /Worked for 6s .*1 tool call/ })).toHaveAttribute("aria-expanded", "true");
 });
 
-test("keeps queued steering out of the transcript until it is applied", async ({ page }) => {
-  // Anchor on content the fixture does render before asserting absence:
-  // toHaveCount(0) resolves immediately against a page that has not painted
-  // yet, so unanchored absence checks would pass even if nothing loaded.
+test("shows queued steering in the transcript before the runtime applies it", async ({ page }) => {
+  // Anchor on content the fixture does render before asserting on the queued
+  // messages: toHaveCount(0) resolves immediately against a page that has not
+  // painted yet, so unanchored absence checks would pass even if nothing
+  // loaded.
   await expect(page.getByText("Fix transcript scrolling")).toBeVisible();
   await expect(page.getByRole("button", { name: /^Working for/ })).toBeVisible();
 
+  // No queued-message card; the follow-ups the user just sent render inline as
+  // visible prompts even though the runtime has not applied them yet.
   await expect(page.getByText("Queued")).toHaveCount(0);
-  await expect(page.getByText("Also preserve anchors")).toHaveCount(0);
-  await expect(page.getByText("Keep day separators stable")).toHaveCount(0);
+  await expect(page.getByText("Also preserve anchors")).toBeVisible();
+  await expect(page.getByText("Keep day separators stable")).toBeVisible();
+
   await page.getByRole("button", { name: "Acknowledge steering" }).click();
+  // Acknowledgment applies the messages; they stay visible in place.
   await expect(page.getByText("Also preserve anchors")).toBeVisible();
   await expect(page.getByText("Keep day separators stable")).toBeVisible();
   await expect(page.getByRole("button", { name: /Worked for 6s .*1 tool call/ })).toBeVisible();

--- a/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
@@ -2181,10 +2181,12 @@ function flattenTranscriptPages(
 // (newest) cached transcript page so the optimistic message can be dropped from
 // local state without a flicker before the next /transcript refetch lands.
 //
-// The inbox metadata has to be carried over verbatim: the activity timeline
-// hides a steering message until the runtime applies it, so an entry patched
-// in without its delivery state renders once and then vanishes as soon as the
-// refetch supplies the real state. Same state in, same visibility out.
+// The inbox metadata has to be carried over verbatim: a steering message that
+// failed delivery is hidden from the transcript and surfaced by the
+// recoverable-inbox notice, so an entry patched in without its delivery state
+// would render once and then vanish as soon as the refetch supplies the real
+// state. Same state in, same visibility out. In-flight (not-yet-applied)
+// steering messages stay visible in both the patch and the refetch.
 export function appendMessageToTranscriptCache(
   previous: TranscriptWindowInfiniteData | undefined,
   message: SessionMessage,

--- a/frontend/src/app/(dashboard)/sessions/[id]/transcript-cache-patch.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/transcript-cache-patch.test.tsx
@@ -35,9 +35,10 @@ function inboxEntry(overrides: Partial<ThreadInboxEntry> = {}): ThreadInboxEntry
 }
 
 // The optimistic patch and the eventual /transcript refetch must agree on
-// whether a steering message is visible. When the patch omitted the delivery
-// state the message rendered once and then vanished as soon as the refetch
-// supplied it, reappearing only when the runtime applied it.
+// whether a steering message is visible. A not-yet-applied follow-up must
+// stay visible after send (the transcript is the only surface that shows it
+// once the queued-message card was removed); only a failed delivery is hidden
+// and surfaced by the recoverable-inbox notice.
 function visibleContentAfterPatch(delivery?: {
   deliveryState?: ThreadInboxEntry['delivery_state'];
   inboxEntry?: ThreadInboxEntry;
@@ -52,10 +53,21 @@ function visibleContentAfterPatch(delivery?: {
 }
 
 describe('appendMessageToTranscriptCache', () => {
-  it('hides a still-queued steering message exactly as the refetch will', () => {
+  it('keeps a still-queued steering message visible exactly as the refetch will', () => {
     expect(visibleContentAfterPatch({
       deliveryState: 'pending',
       inboxEntry: inboxEntry(),
+    })).toEqual(['also preserve anchors']);
+  });
+
+  it('hides a failed steering message exactly as the refetch will', () => {
+    expect(visibleContentAfterPatch({
+      deliveryState: 'dead_letter',
+      inboxEntry: inboxEntry({ delivery_state: 'dead_letter' }),
+    })).toEqual([]);
+    expect(visibleContentAfterPatch({
+      deliveryState: 'unknown_delivery',
+      inboxEntry: inboxEntry({ delivery_state: 'unknown_delivery' }),
     })).toEqual([]);
   });
 

--- a/frontend/src/components/session-activity-timeline.test.tsx
+++ b/frontend/src/components/session-activity-timeline.test.tsx
@@ -184,7 +184,7 @@ describe("SessionActivityTimeline", () => {
     expect(screen.getByText("Ran `npm test`")).toBeVisible();
   });
 
-  it("omits queued deliveries and renders runtime boundaries without full-width card treatments", () => {
+  it("renders a not-yet-applied follow-up inline and renders runtime boundaries without full-width card treatments", () => {
     const interruptedPhaseID = "10000000-0000-0000-0000-000000000010";
     const recoveryPhaseID = "10000000-0000-0000-0000-000000000011";
     const interruptedTool = {
@@ -257,6 +257,8 @@ describe("SessionActivityTimeline", () => {
     expect(interruption).not.toHaveClass("rounded-lg", "border-info/30", "bg-info/10");
     expect(recovery).not.toHaveClass("rounded-lg", "border-info/30", "bg-info/10");
     expect(screen.queryByText("Queued")).not.toBeInTheDocument();
-    expect(screen.queryByText("Keep the runtime state intact.")).not.toBeInTheDocument();
+    // A follow-up the user just sent stays visible even before the runtime
+    // applies it; the transcript is the only surface that shows it now.
+    expect(screen.getByText("Keep the runtime state intact.")).toBeVisible();
   });
 });

--- a/frontend/src/lib/activity-timeline.test.ts
+++ b/frontend/src/lib/activity-timeline.test.ts
@@ -45,19 +45,21 @@ describe("buildActivityTimelineNodes", () => {
     }]);
   });
 
-  it("omits steering until the runtime applies it, then renders the normal message", () => {
+  it("keeps an in-flight steering message visible until the runtime applies it", () => {
     const message = {
       id: 7, session_id: "session-1", org_id: "org-1", thread_id: "thread-1", turn_number: 2,
       role: "user" as const, content: "also update the tests", created_at: "2026-08-03T00:00:07Z",
       inbox_sequence: 4, delivery_state: "pending" as const,
     };
     const entry: TimelineEntry = { kind: "message", data: message };
-    expect(buildActivityTimelineNodes([entry], [])).toEqual([]);
+    // Before application the user must still see the message they just sent.
+    expect(buildActivityTimelineNodes([entry], [])).toEqual([{ kind: "visible", entry }]);
 
     const appliedEntry: TimelineEntry = {
       kind: "message",
       data: { ...message, delivery_state: "acked", applied_at: "2026-08-03T00:00:08Z" },
     };
+    // After application it stays in the same visible position.
     expect(buildActivityTimelineNodes([appliedEntry], [])).toEqual([{ kind: "visible", entry: appliedEntry }]);
   });
 
@@ -66,9 +68,22 @@ describe("buildActivityTimelineNodes", () => {
     ["delivering" as const],
     ["delivered" as const],
     ["acked" as const],
+  ])("renders a not-yet-applied steering message in delivery state %s", (deliveryState) => {
+    const entry: TimelineEntry = {
+      kind: "message",
+      data: {
+        id: 7, session_id: "session-1", org_id: "org-1", thread_id: "thread-1", turn_number: 2,
+        role: "user" as const, content: "also update the tests", created_at: "2026-08-03T00:00:07Z",
+        inbox_sequence: 4, delivery_state: deliveryState,
+      },
+    };
+    expect(buildActivityTimelineNodes([entry], [])).toEqual([{ kind: "visible", entry }]);
+  });
+
+  it.each([
     ["unknown_delivery" as const],
     ["dead_letter" as const],
-  ])("omits steering still in delivery state %s", (deliveryState) => {
+  ])("omits a failed steering message in delivery state %s (surfaced by the recoverable inbox)", (deliveryState) => {
     const entry: TimelineEntry = {
       kind: "message",
       data: {
@@ -123,9 +138,9 @@ describe("buildActivityTimelineNodes", () => {
     expect(buildActivityTimelineNodes([entry], [])).toEqual([{ kind: "visible", entry }]);
   });
 
-  it("does not split historical activity around omitted steering", () => {
+  it("splits historical activity around an in-flight steering message", () => {
     const before = { kind: "log", data: log(1, "info") } satisfies TimelineEntry;
-    const queued = {
+    const inFlight = {
       kind: "message",
       data: {
         id: 7, session_id: "session-1", org_id: "org-1", thread_id: "thread-1", turn_number: 1,
@@ -135,7 +150,40 @@ describe("buildActivityTimelineNodes", () => {
     } satisfies TimelineEntry;
     const after = { kind: "log", data: log(2, "info") } satisfies TimelineEntry;
 
-    expect(buildActivityTimelineNodes([before, queued, after], [])).toEqual([{
+    // The user's not-yet-applied follow-up is a real interjection, so it
+    // appears between the two tool/log activities rather than being dropped.
+    expect(buildActivityTimelineNodes([before, inFlight, after], [])).toEqual([
+      {
+        kind: "historical_activity",
+        activity: {
+          id: "historical-1-log-1", turnNumber: 1, entries: [before], toolCallCount: 0, inferredHistorical: true,
+        },
+      },
+      { kind: "visible", entry: inFlight },
+      {
+        kind: "historical_activity",
+        activity: {
+          id: "historical-1-log-2", turnNumber: 1, entries: [after], toolCallCount: 0, inferredHistorical: true,
+        },
+      },
+    ]);
+  });
+
+  it("does not split historical activity around a failed steering message", () => {
+    const before = { kind: "log", data: log(1, "info") } satisfies TimelineEntry;
+    const failed = {
+      kind: "message",
+      data: {
+        id: 7, session_id: "session-1", org_id: "org-1", thread_id: "thread-1", turn_number: 1,
+        role: "user" as const, content: "also update the tests", created_at: "2026-08-03T00:00:02Z",
+        inbox_sequence: 4, delivery_state: "dead_letter" as const,
+      },
+    } satisfies TimelineEntry;
+    const after = { kind: "log", data: log(2, "info") } satisfies TimelineEntry;
+
+    // A failed delivery is omitted from the transcript (the recoverable-inbox
+    // notice surfaces it), so the surrounding tool/log activity stays grouped.
+    expect(buildActivityTimelineNodes([before, failed, after], [])).toEqual([{
       kind: "historical_activity",
       activity: {
         id: "historical-1-log-1", turnNumber: 1, entries: [before, after], toolCallCount: 0, inferredHistorical: true,

--- a/frontend/src/lib/activity-timeline.ts
+++ b/frontend/src/lib/activity-timeline.ts
@@ -1,30 +1,34 @@
 import type { TimelineEntry } from "./timeline";
 import type { SessionTranscriptPhase, SessionTranscriptTurn, ThreadInboxDeliveryState } from "./types";
 
-// Delivery states in which a steering message has not yet been applied to a
-// running phase. Such a message is kept out of the transcript so its content
-// is never attributed to work that has not happened yet; the failure states
-// stay actionable through the recoverable-inbox notice instead.
+// Delivery states in which a steering message has failed (or its delivery is
+// uncertain) but stays actionable through the recoverable-inbox notice, which
+// is the dedicated surface that shows the message content and retry controls.
+// Such a message is kept out of the transcript so a failed delivery never
+// looks like a successfully sent prompt.
+//
+// In-flight unapplied states (pending, delivering, delivered, acked) are NOT
+// hidden: once the queued-message card was removed, the transcript became the
+// only surface that could show a sent follow-up before the runtime applies it,
+// so hiding them would make the user's own message vanish after send. The
+// runtime applying the message (stamping applied_at) does not move it — it
+// stays a visible node at its submission time.
 //
 // Enumerated rather than derived from a missing applied_at: applied_at is only
 // written when an inbox batch actually starts, so treating "no applied_at" as
 // "not applied" also hides entries that will never reach a phase at all. An
 // unrecognised state must fail open and keep the message visible - dropping
 // user-authored content from every surface is the worse failure.
-const UNAPPLIED_DELIVERY_STATES = new Set<ThreadInboxDeliveryState>([
-  "pending",
-  "delivering",
-  "delivered",
-  "acked",
+const RECOVERABLE_DELIVERY_STATES = new Set<ThreadInboxDeliveryState>([
   "unknown_delivery",
   "dead_letter",
 ]);
 
-function isUnappliedSteering(entry: TimelineEntry): boolean {
+function isRecoverableSteering(entry: TimelineEntry): boolean {
   if (entry.kind !== "message" || entry.data.role !== "user") return false;
   const state = entry.data.delivery_state;
   if (!state || entry.data.applied_at) return false;
-  return UNAPPLIED_DELIVERY_STATES.has(state);
+  return RECOVERABLE_DELIVERY_STATES.has(state);
 }
 
 export interface TimelineActivityPhase extends SessionTranscriptPhase {
@@ -155,7 +159,7 @@ export function buildActivityTimelineNodes(entries: TimelineEntry[], turns: Sess
   };
 
   for (const entry of entries) {
-    if (isUnappliedSteering(entry)) {
+    if (isRecoverableSteering(entry)) {
       continue;
     }
     const phaseID = phaseIDForEntry(entry);


### PR DESCRIPTION
## Summary

Session transcripts could incorrectly hide compact view follow-up (“steering”) messages when deliveries are acknowledged without an `applied_at` timestamp. This creates a reliability gap in the user workflow: users see messages disappear or never appear in the transcript even though they were submitted. The change adjusts the transcript/timeline rendering contract so in-flight (not-yet-applied) steering messages remain visible, while only failed delivery states are omitted and surfaced via the recoverable-inbox notice.

## Changes

- Updated activity/timeline rendering logic to keep queued/not-yet-applied steering follow-ups visible as normal user messages at submission time.
- Tightened delivery-state handling so only `unknown_delivery` / `dead_letter` are omitted from the transcript (shown elsewhere with retry controls), and unrecognized states still render instead of dropping content.
- Extended/updated related tests for transcript caching and timeline rendering, including compact view scenarios and follow-up message visibility.

## Validation

- Ran frontend unit tests covering the activity timeline and session transcript behavior:
  - `frontend/src/lib/activity-timeline.test.ts`
  - `frontend/src/components/session-activity-timeline.test.tsx`
  - `frontend/src/app/(dashboard)/sessions/[id]/transcript-cache-patch.test.tsx`
- Ran frontend E2E/session activity spec:
  - `frontend/e2e/session-activity.spec.ts`

[143.dev](https://143.dev) | [session 9ca6b165](https://143.dev/sessions/9ca6b165-d5fa-4c4f-877d-7902cc54210d)

<!-- 143-publication session=9ca6b165-d5fa-4c4f-877d-7902cc54210d changeset=0ddabad4-4ea5-45ec-ab8c-0fafe5236b21 -->

Preview: https://143.dev/previews/github/assembledhq/143/pull/2095?launch=1