### PR TITLE
Fix Code Review policy settings layout under Code Reviews header and tabs

### DIFF
--- a/frontend/src/app/(dashboard)/code-reviews/page.test.tsx
+++ b/frontend/src/app/(dashboard)/code-reviews/page.test.tsx
@@ -2403,7 +2403,13 @@ describe("CodeReviewsPage", () => {
     const safeguardsHeading = screen.getByRole("heading", { level: 3, name: "Safeguards" });
     const safeguardsCard = safeguardsHeading.closest("section");
     const policyPanel = screen.getByRole("tabpanel");
-    expect(policyPanel).toHaveClass("mx-auto", "w-full", "max-w-5xl");
+    // Width and centering belong to the page shell — `ListPage` wraps this page in
+    // `PageContainer size="wide"` — so this panel keeps only the canonical tab
+    // rhythm and its left edge stays flush with the left-aligned tab bar. It carries
+    // no width constraint or centering of its own, so any `mx-auto` or `max-w-*` on
+    // this panel — responsive variants and `max-w-none` included — fails here.
+    expect(policyPanel).toHaveClass("space-y-6");
+    expect(policyPanel.className).not.toMatch(/\bmx-auto\b|\bmax-w-/);
     expect(screen.getByText("Reviewer setup and the rules that gate automatic approval.")).toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "Safeguards" })).not.toBeInTheDocument();
     // Behavior, then both prompts together, then safeguards, then GitHub setup.

--- a/frontend/src/app/(dashboard)/code-reviews/page.tsx
+++ b/frontend/src/app/(dashboard)/code-reviews/page.tsx
@@ -1520,7 +1520,7 @@ export default function CodeReviewsPage() {
             />
           </PageTabContent>
 
-          <PageTabContent value="policy" className="mx-auto w-full max-w-5xl">
+          <PageTabContent value="policy">
             <SectionGroup
               title="Organization review policy"
               description="How the reviewer bot handles pull requests across this organization."


### PR DESCRIPTION
## Summary

The Code Reviews page’s “policy” tab panel was incorrectly centered/constrained, causing the content layout to drift from the left-aligned tab bar and header shell. This broke the expected tab rhythm and could lead to inconsistent spacing/responsiveness across breakpoints. We removed the tab panel’s width/centering utility classes and updated the test to assert the correct, layout-owned-by-shell behavior.

## Changes

- Removed `mx-auto w-full max-w-5xl` from the `PageTabContent value="policy"` so layout is controlled by the shared `ListPage`/`PageContainer` shell.
- Updated `code-reviews/page.test.tsx` to verify the policy tab panel uses only canonical spacing (`space-y-6`) and explicitly does **not** include `mx-auto`/`max-w-*` classes.
- Kept the component structure the same; this is a layout contract fix rather than a behavioral change.

## Validation

- Updated/extended the existing page test for the policy tab panel layout:
  - Ensures the panel has `space-y-6`
  - Ensures `className` does not match `mx-auto` or `max-w-*`
- Run test suite: `pnpm test` (or repo-equivalent CI test command)

[143.dev](https://143.dev) | [session 9587eae3](https://143.dev/sessions/9587eae3-a292-4e10-969c-05d11f5bb308)

<!-- 143-publication session=9587eae3-a292-4e10-969c-05d11f5bb308 changeset=c9690f44-69bc-4dd8-8fc8-b34f130dd886 -->

Preview: https://143.dev/previews/github/assembledhq/143/pull/2098?launch=1