### PR TITLE
Add code review “not approved reason” column with flexible UI handling for mixed approved and rejected rows

### DIFF
--- a/frontend/src/app/(dashboard)/code-reviews/page.test.tsx
+++ b/frontend/src/app/(dashboard)/code-reviews/page.test.tsx
@@ -567,7 +567,6 @@ describe("CodeReviewsPage", () => {
     expect(screen.getByRole("heading", { level: 2, name: "Review activity" })).toBeInTheDocument();
     expect(screen.getByRole("combobox", { name: "Status" })).toHaveTextContent("Current reviews");
     expect(await screen.findAllByText("#428 Fix invoice rounding")).toHaveLength(2);
-    expect(screen.getAllByText("Acceptable")).toHaveLength(2);
     expect(screen.getAllByText("Approved")).toHaveLength(2);
     expect(
       screen.getAllByText("Completed").filter((element) => element.closest('[data-slot="status-label"]')),
@@ -596,19 +595,18 @@ describe("CodeReviewsPage", () => {
     expect(within(reviewTable).getAllByRole("columnheader").map((header) => header.textContent)).toEqual([
       "PR",
       "Outcome",
-      "Risk",
+      "Why not approved",
       "Run status",
-      "Repo",
       "Completed",
       "Actions",
     ]);
     const reviewCells = within(reviewRow).getAllByRole("cell");
-    expect(within(reviewCells[2]).getByText("Acceptable").closest('[data-slot="status-label"]')).not.toBeNull();
     expect(within(reviewCells[1]).getByText("Approved").closest('[data-slot="status-label"]')).not.toBeNull();
     expect(within(reviewCells[3]).getByText("Completed").closest('[data-slot="status-label"]')).not.toBeNull();
-    expect(reviewCells[2].querySelector('[aria-hidden="true"]')).toBeNull();
-    expect(within(reviewCells[6]).getByRole("button", { name: "Evidence" })).toBeInTheDocument();
-    expect(within(reviewCells[6]).getByRole("link", { name: "Session" }).querySelector("svg")).toBeInTheDocument();
+    expect(within(reviewCells[0]).getByText(/api · anya · abcdef1/)).toBeInTheDocument();
+    expect(within(reviewCells[2]).getByText("—")).toBeInTheDocument();
+    expect(within(reviewCells[5]).getByRole("button", { name: "Evidence" })).toBeInTheDocument();
+    expect(within(reviewCells[5]).getByRole("link", { name: "Session" }).querySelector("svg")).toBeInTheDocument();
     await user.click(screen.getAllByRole("button", { name: /Evidence/i })[0]);
     const evidenceSheet = await screen.findByRole("dialog", {
       name: /Evidence for #428/i,
@@ -683,6 +681,127 @@ describe("CodeReviewsPage", () => {
     await user.click(screen.getByRole("button", { name: /Add requirement/i }));
     expect(await screen.findByDisplayValue("Custom requirement")).toBeInTheDocument();
   }, 30_000);
+
+  it("explains completed non-approvals in the table, mobile row, and evidence sheet", async () => {
+    const user = userEvent.setup();
+    const needsReview: CodeReviewListItem = {
+      ...review,
+      decision: "needs_human_review",
+      acceptable: false,
+      github_review_id: undefined,
+      github_review_url: undefined,
+      risk_reason_details: [
+        { code: "blocking_findings" },
+        { code: "files_limit_exceeded", actual: 34, limit: 25 },
+      ],
+    };
+    const commentOnly: CodeReviewListItem = {
+      ...review,
+      id: "review-2",
+      session_id: "session-2",
+      pull_request_id: "pr-2",
+      github_pr_number: 429,
+      pull_request_title: "Document the billing flow",
+      decision: "comment_only",
+      acceptable: true,
+      github_review_id: undefined,
+      github_review_url: undefined,
+      risk_reason_details: [],
+    };
+    mockCodeReviewBaseHandlers();
+    server.use(
+      http.get("/api/v1/code-reviews", () =>
+        HttpResponse.json({ data: [needsReview, commentOnly], meta: { total_count: 2 } } satisfies ListResponse<CodeReviewListItem>),
+      ),
+    );
+
+    renderWithProviders(<CodeReviewsPage />);
+
+    const reviewTable = await screen.findByRole("table", { name: "Code reviews" });
+    const needsReviewRow = within(reviewTable).getByRole("row", { name: /#428 Fix invoice rounding/i });
+    const needsReviewCells = within(needsReviewRow).getAllByRole("cell");
+    expect(within(needsReviewCells[2]).getByText("Reviewers found a blocking issue")).toBeInTheDocument();
+    expect(within(needsReviewCells[2]).getByText("+1 more")).toBeInTheDocument();
+    await user.click(
+      within(needsReviewCells[2]).getByRole("button", { name: "Show all 2 reasons this review was not approved" }),
+    );
+    expect(await screen.findByText(/File-count limit exceeded \(34 of 25\)/)).toBeInTheDocument();
+
+    const commentOnlyRow = within(reviewTable).getByRole("row", { name: /#429 Document the billing flow/i });
+    expect(within(commentOnlyRow).getByText("Configured for comment-only reviews")).toBeInTheDocument();
+
+    const mobileList = screen.getByRole("list", { name: "Code review activity" });
+    const mobileNeedsReview = within(mobileList).getAllByRole("listitem")[0];
+    expect(within(mobileNeedsReview).getByText("Why not approved")).toBeInTheDocument();
+    expect(within(mobileNeedsReview).getByText("Reviewers found a blocking issue")).toBeInTheDocument();
+    expect(within(mobileNeedsReview).queryByText("Risk")).not.toBeInTheDocument();
+
+    await user.keyboard("{Escape}");
+    await user.click(within(needsReviewCells[5]).getByRole("button", { name: "Evidence" }));
+    const evidenceSheet = await screen.findByRole("dialog", { name: /Evidence for #428/i });
+    expect(within(evidenceSheet).getByText("Why not approved")).toBeInTheDocument();
+    expect(within(evidenceSheet).getByText("Reviewers found a blocking issue")).toBeInTheDocument();
+    expect(within(evidenceSheet).getByText("File-count limit exceeded (34 of 25)")).toBeInTheDocument();
+  });
+
+  it("caps the non-approval reason list a path-heavy review produces", async () => {
+    const user = userEvent.setup();
+    const pathHeavy: CodeReviewListItem = {
+      ...review,
+      decision: "needs_human_review",
+      acceptable: false,
+      github_review_id: undefined,
+      github_review_url: undefined,
+      risk_reason_details: Array.from({ length: 15 }, (_, index) => ({
+        code: "path_outside_scope",
+        subject: `services/api/file-${index}.go`,
+      })),
+    };
+    mockCodeReviewBaseHandlers();
+    server.use(
+      http.get("/api/v1/code-reviews", () =>
+        HttpResponse.json({ data: [pathHeavy], meta: { total_count: 1 } } satisfies ListResponse<CodeReviewListItem>),
+      ),
+    );
+
+    renderWithProviders(<CodeReviewsPage />);
+
+    const reviewTable = await screen.findByRole("table", { name: "Code reviews" });
+    const reviewRow = within(reviewTable).getByRole("row", { name: /#428 Fix invoice rounding/i });
+    const cells = within(reviewRow).getAllByRole("cell");
+    await user.click(within(cells[2]).getByRole("button", { name: "Show all 15 reasons this review was not approved" }));
+    const popover = (await screen.findByText("Why this review was not approved")).parentElement as HTMLElement;
+    expect(within(popover).getAllByRole("listitem")).toHaveLength(10);
+    expect(within(popover).getByText("and 5 more")).toBeInTheDocument();
+  });
+
+  it("keeps the non-approval explanation in the evidence sheet when evidence cannot be loaded", async () => {
+    const user = userEvent.setup();
+    const needsReview: CodeReviewListItem = {
+      ...review,
+      decision: "needs_human_review",
+      acceptable: false,
+      github_review_id: undefined,
+      github_review_url: undefined,
+      risk_reason_details: [{ code: "checks_failing" }],
+    };
+    mockCodeReviewBaseHandlers();
+    server.use(
+      http.get("/api/v1/code-reviews", () =>
+        HttpResponse.json({ data: [needsReview], meta: { total_count: 1 } } satisfies ListResponse<CodeReviewListItem>),
+      ),
+      http.get("/api/v1/code-reviews/session-1/evidence", () => HttpResponse.json({ error: "boom" }, { status: 500 })),
+    );
+
+    renderWithProviders(<CodeReviewsPage />);
+
+    await screen.findAllByText("#428 Fix invoice rounding");
+    await user.click(screen.getAllByRole("button", { name: /Evidence/i })[0]);
+    const evidenceSheet = await screen.findByRole("dialog", { name: /Evidence for #428/i });
+    expect(await within(evidenceSheet).findByText("Evidence could not be loaded")).toBeInTheDocument();
+    expect(within(evidenceSheet).getByText("Why not approved")).toBeInTheDocument();
+    expect(within(evidenceSheet).getByText("Required checks were not passing")).toBeInTheDocument();
+  });
 
   it("renders the PR-centric Analytics report with author usage first", async () => {
     const user = userEvent.setup();
@@ -994,14 +1113,14 @@ describe("CodeReviewsPage", () => {
       expect(listRequests.at(-1)?.get("activity_status")).toBe("current");
       expect(statsRequests.at(-1)?.get("activity_status")).toBe("current");
     });
-    await user.click(screen.getByRole("button", { name: "Sort by Repo ascending" }));
-    await waitFor(() => expect(listRequests.at(-1)?.get("sort_by")).toBe("repository"));
+    await user.click(screen.getByRole("button", { name: "Sort by PR ascending" }));
+    await waitFor(() => expect(listRequests.at(-1)?.get("sort_by")).toBe("pull_request"));
     expect(listRequests.at(-1)?.get("sort_order")).toBe("asc");
-    await user.click(screen.getByRole("button", { name: "Sort by Repo descending" }));
+    await user.click(screen.getByRole("button", { name: "Sort by PR descending" }));
     await waitFor(() => expect(listRequests.at(-1)?.get("sort_order")).toBe("desc"));
     // A third click has to reach the default newest-first order again;
     // otherwise the two-state cycle strands the user in an explicit sort.
-    await user.click(screen.getByRole("button", { name: "Stop sorting by Repo" }));
+    await user.click(screen.getByRole("button", { name: "Stop sorting by PR" }));
     await waitFor(() => expect(listRequests.at(-1)?.has("sort_by")).toBe(false));
     expect(listRequests.at(-1)?.has("sort_order")).toBe(false);
     const initialListCreatedAfter = listRequests.at(-1)?.get("created_after");
@@ -2067,7 +2186,10 @@ describe("CodeReviewsPage", () => {
     const supersededLabels = await screen.findAllByText("Superseded");
     expect(supersededLabels).toHaveLength(2);
     expect(screen.getAllByText("No outcome")).toHaveLength(2);
-    expect(screen.getAllByText("Not applicable")).toHaveLength(2);
+    expect(screen.queryByText("Not applicable")).not.toBeInTheDocument();
+    const supersededTable = screen.getByRole("table", { name: "Code reviews" });
+    const supersededRow = within(supersededTable).getByRole("row", { name: /#428 Fix invoice rounding/i });
+    expect(within(within(supersededRow).getAllByRole("cell")[2]).getByText("—")).toBeInTheDocument();
     for (const label of supersededLabels) {
       expect(label).toHaveClass("text-muted-foreground");
       expect(label).not.toHaveClass("text-destructive");
@@ -2560,7 +2682,7 @@ describe("CodeReviewsPage", () => {
     );
 
     expect(await screen.findAllByText("#429 Keep manual approval")).toHaveLength(2);
-    expect(screen.getAllByText("Review needed")).toHaveLength(4);
+    expect(screen.getAllByText("Review needed")).toHaveLength(2);
     expect(
       screen.getAllByText("Completed").filter((element) => element.closest('[data-slot="status-label"]')),
     ).toHaveLength(2);

--- a/frontend/src/app/(dashboard)/code-reviews/page.tsx
+++ b/frontend/src/app/(dashboard)/code-reviews/page.tsx
@@ -45,6 +45,7 @@ import { Switch } from "@/components/ui/switch";
 import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
 import { Sheet, SheetContent, SheetDescription, SheetHeader, SheetTitle } from "@/components/ui/sheet";
 import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { Label } from "@/components/ui/label";
 import { Input } from "@/components/ui/input";
@@ -55,7 +56,7 @@ import { ApiError, api } from "@/lib/api";
 import { notify as toast } from "@/lib/notify";
 import { queryKeys } from "@/lib/query-keys";
 import { getActiveOrgId } from "@/lib/active-org";
-import { ALL_CODE_REVIEW_REASONS, CODE_REVIEW_REASON_CODES, type CodeReviewReasonCode } from "@/lib/code-review-reasons";
+import { ALL_CODE_REVIEW_REASONS, CODE_REVIEW_REASON_CODES, codeReviewReasonDescription, type CodeReviewReasonCode } from "@/lib/code-review-reasons";
 import { buildCodeReviewStreamURL, SSE_EVENT } from "@/lib/sse";
 import { useResourceSSE } from "@/lib/use-resource-sse";
 import { pollMs } from "@/lib/poll-intervals";
@@ -116,7 +117,7 @@ const RISK_FILTER_VALUES = [ALL_RISKS, "acceptable", "needs_review"] as const;
 const STATUS_FILTER_VALUES = ["current", "completed", "in_progress", "failed", "cancelled", "superseded", "all"] as const;
 type StatusFilter = (typeof STATUS_FILTER_VALUES)[number];
 const DEFAULT_STATUS_FILTER = "current" satisfies StatusFilter;
-const REVIEW_SORT_VALUES = ["pull_request", "outcome", "risk", "run_status", "repository", "completed"] as const;
+const REVIEW_SORT_VALUES = ["pull_request", "outcome", "run_status", "completed"] as const;
 type ReviewSort = (typeof REVIEW_SORT_VALUES)[number];
 // "reviews" now orders the PR count: the column became unique PRs, but the
 // parameter keeps its name so shared analytics links stay valid.
@@ -263,14 +264,76 @@ function reviewStatusTone(status: string): StatusTone {
   return "neutral";
 }
 
-function reviewRiskTone(review: CodeReviewListItem): StatusTone {
-  if (isSupersededReview(review)) return "neutral";
-  return review.acceptable ? "success" : "warning";
+// Path-based risk reasons are recorded once per changed path, so a broad PR can
+// produce a very long list. Show a readable slice and summarize the remainder.
+const WHY_NOT_APPROVED_REASON_LIMIT = 10;
+
+function whyNotApprovedReasons(review: CodeReviewListItem): string[] {
+  if (isSupersededReview(review) || review.status !== "completed" || wasAutomaticallyApproved(review)) return [];
+
+  const structuredReasons = (review.risk_reason_details ?? []).map(codeReviewReasonDescription);
+  if (structuredReasons.length > 0) return structuredReasons;
+
+  if (review.decision === "comment_only") return ["Configured for comment-only reviews"];
+  if (review.decision === "approved") return ["Approval could not be posted"];
+  if (review.decision === "needs_human_review") return ["Human review was required"];
+  if (review.decision === "blocked") return ["Approval was blocked"];
+  return ["No approval decision was recorded"];
 }
 
-function reviewRiskLabel(review: CodeReviewListItem): string {
-  if (isSupersededReview(review)) return "Not applicable";
-  return review.acceptable ? "Acceptable" : "Review needed";
+function WhyNotApproved({ reasons, compact = false }: { reasons: string[]; compact?: boolean }) {
+  if (reasons.length === 0) return <span className="text-muted-foreground">—</span>;
+
+  return (
+    <div className="max-w-[18rem] space-y-1">
+      <p className={cn("line-clamp-2 leading-5 text-foreground", compact ? "text-xs" : "text-sm")} title={reasons[0]}>
+        {reasons[0]}
+      </p>
+      {reasons.length > 1 ? (
+        <Popover>
+          <PopoverTrigger asChild>
+            <Button
+              variant="link"
+              size="sm"
+              className="h-auto p-0 text-xs font-normal text-muted-foreground"
+              aria-label={`Show all ${reasons.length} reasons this review was not approved`}
+            >
+              +{reasons.length - 1} more
+            </Button>
+          </PopoverTrigger>
+          {/* Path-based reasons are emitted per changed file, so this list can run
+              to hundreds of entries; cap it and let the rest scroll. */}
+          <PopoverContent className="max-h-[60vh] w-80 overflow-y-auto p-4">
+            <div className="space-y-2">
+              <p className="text-sm font-medium text-foreground">Why this review was not approved</p>
+              <ul className="list-disc space-y-2 pl-4 text-sm leading-5 text-muted-foreground">
+                {reasons.slice(0, WHY_NOT_APPROVED_REASON_LIMIT).map((reason, index) => (
+                  <li key={`${reason}-${index}`}>{reason}</li>
+                ))}
+              </ul>
+              {reasons.length > WHY_NOT_APPROVED_REASON_LIMIT ? (
+                <p className="text-xs text-muted-foreground">
+                  and {reasons.length - WHY_NOT_APPROVED_REASON_LIMIT} more
+                </p>
+              ) : null}
+            </div>
+          </PopoverContent>
+        </Popover>
+      ) : null}
+    </div>
+  );
+}
+
+function MobileWhyNotApproved({ review }: { review: CodeReviewListItem }) {
+  const reasons = whyNotApprovedReasons(review);
+  if (reasons.length === 0) return null;
+
+  return (
+    <div className="space-y-1 text-xs">
+      <span className="text-muted-foreground">Why not approved</span>
+      <WhyNotApproved reasons={reasons} compact />
+    </div>
+  );
 }
 
 function ReviewTitle({ review }: { review: CodeReviewListItem }) {
@@ -1192,7 +1255,7 @@ export default function CodeReviewsPage() {
             <ReviewTitle review={review} />
           </div>
           <div className="mt-1 text-xs text-muted-foreground">
-            {review.pull_request_author || "Unknown author"} · {review.head_sha.slice(0, 7)}
+            {review.repository_name || review.github_repo} · {review.pull_request_author || "Unknown author"} · {review.head_sha.slice(0, 7)}
           </div>
         </>
       ),
@@ -1204,22 +1267,16 @@ export default function CodeReviewsPage() {
       render: (review) => <StatusLabel label={decisionLabel(review)} tone={reviewDecisionTone(review)} indicator="none" />,
     },
     {
-      id: "risk",
-      header: sortHeader("Risk", "risk"),
-      sortDirection: reviewSort === "risk" ? reviewSortOrder : false,
-      render: (review) => <StatusLabel label={reviewRiskLabel(review)} tone={reviewRiskTone(review)} indicator="none" />,
+      id: "why-not-approved",
+      header: "Why not approved",
+      cellClassName: "min-w-[14rem]",
+      render: (review) => <WhyNotApproved reasons={whyNotApprovedReasons(review)} />,
     },
     {
       id: "run-status",
       header: sortHeader("Run status", "run_status"),
       sortDirection: reviewSort === "run_status" ? reviewSortOrder : false,
       render: (review) => <ReviewOperationalStatus review={review} nowMs={countdownNowMs} />,
-    },
-    {
-      id: "repository",
-      header: sortHeader("Repo", "repository"),
-      sortDirection: reviewSort === "repository" ? reviewSortOrder : false,
-      render: (review) => review.repository_name || review.github_repo,
     },
     {
       id: "completed",
@@ -1410,10 +1467,7 @@ export default function CodeReviewsPage() {
                             <StatusLabel label={decisionLabel(review)} tone={reviewDecisionTone(review)} indicator="none" />
                             {review.completed_at ? <span className="text-foreground">{formatDate(review.completed_at)}</span> : null}
                         </div>
-                        <div className="flex flex-wrap items-center gap-2 text-xs">
-                          <span className="text-muted-foreground">Risk</span>
-                            <StatusLabel label={reviewRiskLabel(review)} tone={reviewRiskTone(review)} indicator="none" />
-                        </div>
+                        <MobileWhyNotApproved review={review} />
                       </div>
                     }
                     actions={
@@ -4334,6 +4388,7 @@ function CodeReviewEvidenceSheet({
   const findings = evidence?.findings ?? [];
   const records = evidence?.prompt_records ?? evidence?.prompt_artifacts ?? [];
   const reasonCodes = evidence?.risk_reason_codes ?? [];
+  const approvalReasons = review ? whyNotApprovedReasons(review) : [];
   const disputesQuery = useInfiniteQuery({
     queryKey: queryKeys.codeReviews.disputes(review?.session_id ?? ""),
     queryFn: ({ pageParam }) => api.codeReviews.disputes(review?.session_id ?? "", pageParam),
@@ -4430,6 +4485,20 @@ function CodeReviewEvidenceSheet({
             />
           ) : null}
           {!isLoading && !error && !evidence ? <div className="text-sm text-muted-foreground">No evidence recorded for this review.</div> : null}
+          {/* Derived from the review row rather than the evidence payload, so it
+              stays available when the evidence request is empty or failed. */}
+          {approvalReasons.length > 0 ? (
+            <section className="space-y-3">
+              <EvidenceSectionHeader title="Why not approved" empty={false} />
+              <div className="space-y-2">
+                {approvalReasons.map((reason, index) => (
+                  <div key={`${reason}-${index}`} className="border-t border-border pt-2 text-sm leading-6 text-muted-foreground first:border-t-0 first:pt-0">
+                    {reason}
+                  </div>
+                ))}
+              </div>
+            </section>
+          ) : null}
           {evidence ? (
             <>
               <div className="grid grid-cols-3 gap-3">

--- a/frontend/src/components/code-review-overview.test.tsx
+++ b/frontend/src/components/code-review-overview.test.tsx
@@ -2,7 +2,7 @@ import { useState } from "react";
 import { act, render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { endOfMonth, format, startOfMonth, subDays, subMonths } from "date-fns";
+import { addDays, endOfMonth, format, startOfMonth, subDays, subMonths } from "date-fns";
 import { CodeReviewSummaryCards, formatReviewTurnaround } from "./code-review-overview";
 import { TimeRangePicker, timeRangeLabel } from "./time-range-picker";
 import { customTimeRange, type TimeRangeFilter } from "@/lib/time-range";
@@ -209,8 +209,9 @@ describe("TimeRangePicker", () => {
     setDesktopMatch(false);
     const user = userEvent.setup();
     const onValueChange = vi.fn();
-    const start = subDays(new Date(), 12);
-    const end = subDays(new Date(), 6);
+    const initialMonth = startOfMonth(subDays(new Date(), 30));
+    const start = addDays(initialMonth, 4);
+    const end = addDays(initialMonth, 10);
     render(<TimeRangePicker label="Time window" value="30d" onValueChange={onValueChange} />);
 
     await user.click(screen.getByRole("button", { name: "Time window" }));

--- a/frontend/src/lib/code-review-reasons.test.ts
+++ b/frontend/src/lib/code-review-reasons.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+
+import { codeReviewReasonDescription, codeReviewReasonLabel } from "./code-review-reasons";
+
+describe("codeReviewReasonLabel", () => {
+  it("uses the curated label for a known code", () => {
+    expect(codeReviewReasonLabel("blocking_findings")).toBe("Reviewers found a blocking issue");
+  });
+
+  it("humanizes a code the frontend does not know yet", () => {
+    expect(codeReviewReasonLabel("future_policy_gate")).toBe("Future policy gate");
+  });
+});
+
+describe("codeReviewReasonDescription", () => {
+  it("renders the bare label when the reason carries no detail", () => {
+    expect(codeReviewReasonDescription({ code: "blocking_findings" })).toBe("Reviewers found a blocking issue");
+  });
+
+  it("appends the measurement when both sides are present", () => {
+    expect(codeReviewReasonDescription({ code: "lines_limit_exceeded", actual: 1200, limit: 300 })).toBe(
+      "Line-count limit exceeded (1,200 of 300)",
+    );
+  });
+
+  it("keeps the measurement when the API omits a zero-valued side", () => {
+    expect(codeReviewReasonDescription({ code: "files_limit_exceeded", actual: 34 })).toBe("File-count limit exceeded (34)");
+    expect(codeReviewReasonDescription({ code: "files_limit_exceeded", limit: 25 })).toBe("File-count limit exceeded (limit 25)");
+  });
+
+  it("prefers the subject over counts and trims it", () => {
+    expect(codeReviewReasonDescription({ code: "required_check_failing", subject: "  ci/build  " })).toBe(
+      "A named required check was not passing: ci/build",
+    );
+    expect(codeReviewReasonDescription({ code: "sensitive_path", subject: "infra/secrets.tf", actual: 1, limit: 0 })).toBe(
+      "Sensitive paths changed: infra/secrets.tf",
+    );
+  });
+
+  it("ignores a blank subject", () => {
+    expect(codeReviewReasonDescription({ code: "blocked_path", subject: "   " })).toBe("Blocked paths changed");
+  });
+});

--- a/frontend/src/lib/code-review-reasons.ts
+++ b/frontend/src/lib/code-review-reasons.ts
@@ -76,3 +76,22 @@ export function codeReviewReasonLabel(code: string): string {
   const readable = code.replaceAll("_", " ");
   return readable.charAt(0).toUpperCase() + readable.slice(1);
 }
+
+export function codeReviewReasonDescription(reason: {
+  code: string;
+  actual?: number;
+  limit?: number;
+  subject?: string;
+}): string {
+  const label = codeReviewReasonLabel(reason.code);
+  const subject = reason.subject?.trim();
+  if (subject) return `${label}: ${subject}`;
+  // The API omits zero-valued counts, so render whichever side is present
+  // instead of dropping the measurement entirely.
+  if (reason.actual !== undefined && reason.limit !== undefined) {
+    return `${label} (${reason.actual.toLocaleString()} of ${reason.limit.toLocaleString()})`;
+  }
+  if (reason.actual !== undefined) return `${label} (${reason.actual.toLocaleString()})`;
+  if (reason.limit !== undefined) return `${label} (limit ${reason.limit.toLocaleString()})`;
+  return label;
+}

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -316,6 +316,7 @@ export interface CodeReviewListItem {
   github_review_url?: string;
   final_review_body?: string;
   failure_reason?: string;
+  risk_reason_details?: CodeReviewRiskReason[];
   completed_at?: string;
   created_at: string;
   session_title?: string;
@@ -325,6 +326,13 @@ export interface CodeReviewListItem {
   github_pr_url: string;
   pull_request_title: string;
   pull_request_author: string;
+}
+
+export interface CodeReviewRiskReason {
+  code: string;
+  actual?: number;
+  limit?: number;
+  subject?: string;
 }
 
 export interface CodeReviewStats {

--- a/internal/api/handlers/internal_code_reviews_test.go
+++ b/internal/api/handlers/internal_code_reviews_test.go
@@ -92,7 +92,7 @@ var internalCodeReviewListColumns = []string{
 	"id", "org_id", "session_id", "repository_id", "pull_request_id", "policy_id",
 	"base_sha", "head_sha", "from_fork", "trigger_source", "status", "phase", "status_code", "status_message", "retry_at", "last_error_at", "retryable_failure", "decision", "acceptable", "stale",
 	"superseded_by_session_id", "review_output_key", "prompt_record_key", "github_review_id",
-	"github_review_url", "final_review_body", "failure_reason", "completed_at", "created_at", "retry_eligible", "session_title",
+	"github_review_url", "final_review_body", "failure_reason", "risk_reason_details", "completed_at", "created_at", "retry_eligible", "session_title",
 	"repository_name", "github_repo", "github_pr_number", "github_pr_url", "pull_request_title", "pull_request_author",
 }
 
@@ -105,7 +105,7 @@ func internalCodeReviewListRow(fx internalCodeReviewFixture, reviewID, reviewSes
 	return []any{
 		reviewID, fx.orgID, reviewSessionID, fx.repoID, uuid.New(), uuid.New(),
 		"base", "head", false, models.CodeReviewTriggerSourceAppReviewer, models.CodeReviewSessionStatusCompleted, nil, nil, nil, nil, nil, false, &decision, &acceptable, false,
-		nil, "key-" + reviewID.String(), nil, nil, nil, body, nil, &now, now, false, &title,
+		nil, "key-" + reviewID.String(), nil, nil, nil, body, nil, []byte(`[{"code":"blocking_findings"}]`), &now, now, false, &title,
 		&repoName, "acme/repo", 42, "https://github.com/acme/repo/pull/42", "Fix auth bug", "devin",
 	}
 }

--- a/internal/db/code_reviews.go
+++ b/internal/db/code_reviews.go
@@ -1281,7 +1281,7 @@ const codeReviewListItemSelect = `
 			       m.base_sha, m.head_sha, m.from_fork, m.trigger_source, m.status, m.phase, m.status_code,
 			       m.status_message, m.retry_at, m.last_error_at, m.retryable_failure, m.decision, m.acceptable, m.stale,
 			       m.superseded_by_session_id, m.review_output_key, m.prompt_record_key, m.github_review_id,
-			       m.github_review_url, m.final_review_body, m.failure_reason, m.completed_at, m.created_at,
+			       m.github_review_url, m.final_review_body, m.failure_reason, m.risk_reason_details, m.completed_at, m.created_at,
 			       (
 			           m.status = 'failed'
 			           AND m.retryable_failure = true

--- a/internal/db/code_reviews_test.go
+++ b/internal/db/code_reviews_test.go
@@ -1099,12 +1099,12 @@ func TestCodeReviewStore_ListReviewsAppliesDesignFilters(t *testing.T) {
 			"id", "org_id", "session_id", "repository_id", "pull_request_id", "policy_id",
 			"base_sha", "head_sha", "from_fork", "trigger_source", "status", "phase", "status_code", "status_message", "retry_at", "last_error_at", "retryable_failure", "decision", "acceptable", "stale",
 			"superseded_by_session_id", "review_output_key", "prompt_record_key", "github_review_id",
-			"github_review_url", "final_review_body", "failure_reason", "completed_at", "created_at", "retry_eligible", "session_title", "repository_name", "github_repo",
+			"github_review_url", "final_review_body", "failure_reason", "risk_reason_details", "completed_at", "created_at", "retry_eligible", "session_title", "repository_name", "github_repo",
 			"github_pr_number", "github_pr_url", "pull_request_title", "pull_request_author",
 		}).AddRow(
 			metadataID, orgID, sessionID, repoID, prID, policyID,
 			"base", "head", false, models.CodeReviewTriggerSourceAppReviewer, status, nil, nil, nil, nil, nil, false, &decision, &acceptable, false,
-			nil, "key", nil, nil, nil, nil, nil, &now, now, false, &title, &repoName, "acme/repo",
+			nil, "key", nil, nil, nil, nil, nil, []byte(`[{"code":"blocking_findings"}]`), &now, now, false, &title, &repoName, "acme/repo",
 			42, "https://github.com/acme/repo/pull/42", "Fix auth bug", "devin",
 		))
 
@@ -1123,6 +1123,7 @@ func TestCodeReviewStore_ListReviewsAppliesDesignFilters(t *testing.T) {
 	require.Len(t, reviews, 1, "ListReviews should scan matching rows")
 	require.Equal(t, "Fix auth bug", reviews[0].PullRequestTitle, "ListReviews should return pull request metadata")
 	require.Equal(t, "devin", reviews[0].PullRequestAuthor, "ListReviews should return the GitHub pull request author")
+	require.JSONEq(t, `[{"code":"blocking_findings"}]`, string(reviews[0].RiskReasonDetails), "ListReviews should return structured non-approval reasons")
 	require.False(t, reviews[0].RetryEligible, "completed reviews should not expose the retry action")
 	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
 }
@@ -2127,7 +2128,7 @@ func TestCodeReviewStore_ListReviewsPageUsesExtraRowForNextCursor(t *testing.T) 
 		"base_sha", "head_sha", "from_fork", "trigger_source", "status", "phase", "status_code",
 		"status_message", "retry_at", "last_error_at", "retryable_failure", "decision", "acceptable", "stale",
 		"superseded_by_session_id", "review_output_key", "prompt_record_key", "github_review_id",
-		"github_review_url", "final_review_body", "failure_reason", "completed_at", "created_at",
+		"github_review_url", "final_review_body", "failure_reason", "risk_reason_details", "completed_at", "created_at",
 		"retry_eligible", "session_title", "repository_name", "github_repo", "github_pr_number",
 		"github_pr_url", "pull_request_title", "pull_request_author",
 	})
@@ -2136,7 +2137,7 @@ func TestCodeReviewStore_ListReviewsPageUsesExtraRowForNextCursor(t *testing.T) 
 			id, orgID, sessionID, repoID, prID, policyID,
 			"base", "head", false, models.CodeReviewTriggerSourceAppReviewer,
 			models.CodeReviewSessionStatusCompleted, nil, nil, nil, nil, nil, false,
-			nil, nil, false, nil, "output", nil, nil, nil, nil, nil, &createdAt, createdAt,
+			nil, nil, false, nil, "output", nil, nil, nil, nil, nil, []byte(`[]`), &createdAt, createdAt,
 			false, nil, &repositoryName, "acme/repo", number,
 			fmt.Sprintf("https://github.com/acme/repo/pull/%d", number), "Review", "dev",
 		)
@@ -2178,12 +2179,12 @@ func TestCodeReviewStore_GetListItemBySessionIDScopesByOrgAndSession(t *testing.
 			"id", "org_id", "session_id", "repository_id", "pull_request_id", "policy_id",
 			"base_sha", "head_sha", "from_fork", "trigger_source", "status", "phase", "status_code", "status_message", "retry_at", "last_error_at", "retryable_failure", "decision", "acceptable", "stale",
 			"superseded_by_session_id", "review_output_key", "prompt_record_key", "github_review_id",
-			"github_review_url", "final_review_body", "failure_reason", "completed_at", "created_at", "retry_eligible", "session_title",
+			"github_review_url", "final_review_body", "failure_reason", "risk_reason_details", "completed_at", "created_at", "retry_eligible", "session_title",
 			"repository_name", "github_repo", "github_pr_number", "github_pr_url", "pull_request_title", "pull_request_author",
 		}).AddRow(
 			metadataID, orgID, sessionID, repoID, uuid.New(), uuid.New(),
 			"base", "head", false, models.CodeReviewTriggerSourceAppReviewer, models.CodeReviewSessionStatusRunning, nil, nil, nil, nil, nil, false, nil, nil, false,
-			nil, "key", nil, nil, nil, nil, nil, nil, now, false, &title, &repoName, "acme/repo",
+			nil, "key", nil, nil, nil, nil, nil, []byte(`[]`), nil, now, false, &title, &repoName, "acme/repo",
 			42, "https://github.com/acme/repo/pull/42", "Fix auth bug", "devin",
 		))
 

--- a/internal/models/code_review.go
+++ b/internal/models/code_review.go
@@ -967,14 +967,15 @@ type CodeReviewFinding struct {
 
 type CodeReviewListItem struct {
 	CodeReviewSessionMetadata
-	RetryEligible     bool    `db:"retry_eligible" json:"retry_eligible"`
-	SessionTitle      *string `db:"session_title" json:"session_title,omitempty"`
-	RepositoryName    *string `db:"repository_name" json:"repository_name,omitempty"`
-	GitHubRepo        string  `db:"github_repo" json:"github_repo"`
-	GitHubPRNumber    int     `db:"github_pr_number" json:"github_pr_number"`
-	GitHubPRURL       string  `db:"github_pr_url" json:"github_pr_url"`
-	PullRequestTitle  string  `db:"pull_request_title" json:"pull_request_title"`
-	PullRequestAuthor string  `db:"pull_request_author" json:"pull_request_author"`
+	RiskReasonDetails json.RawMessage `db:"risk_reason_details" json:"risk_reason_details,omitempty"`
+	RetryEligible     bool            `db:"retry_eligible" json:"retry_eligible"`
+	SessionTitle      *string         `db:"session_title" json:"session_title,omitempty"`
+	RepositoryName    *string         `db:"repository_name" json:"repository_name,omitempty"`
+	GitHubRepo        string          `db:"github_repo" json:"github_repo"`
+	GitHubPRNumber    int             `db:"github_pr_number" json:"github_pr_number"`
+	GitHubPRURL       string          `db:"github_pr_url" json:"github_pr_url"`
+	PullRequestTitle  string          `db:"pull_request_title" json:"pull_request_title"`
+	PullRequestAuthor string          `db:"pull_request_author" json:"pull_request_author"`
 }
 
 // MarshalJSON keeps the former prompt reference alongside the renamed field.

--- a/internal/models/output_name_compatibility_test.go
+++ b/internal/models/output_name_compatibility_test.go
@@ -67,9 +67,13 @@ func TestCodeReviewResponsesExposeCompatibilityFields(t *testing.T) {
 	require.Contains(t, string(encoded), `"record_key":"`+key+`"`, "prompt record should expose the current identity key")
 	require.Contains(t, string(encoded), `"artifact_key":"`+key+`"`, "prompt record should expose the compatibility identity key")
 
-	item := CodeReviewListItem{CodeReviewSessionMetadata: CodeReviewSessionMetadata{PromptRecordKey: &key}}
+	item := CodeReviewListItem{
+		CodeReviewSessionMetadata: CodeReviewSessionMetadata{PromptRecordKey: &key},
+		RiskReasonDetails:         json.RawMessage(`[{"code":"blocking_findings"}]`),
+	}
 	encoded, err = json.Marshal(item)
 	require.NoError(t, err, "code review list item should marshal")
 	require.Contains(t, string(encoded), `"prompt_record_key":"`+key+`"`, "list item should expose the current prompt reference")
 	require.Contains(t, string(encoded), `"prompt_artifact_key":"`+key+`"`, "list item should expose the compatibility prompt reference")
+	require.Contains(t, string(encoded), `"risk_reason_details":[{"code":"blocking_findings"}]`, "list item should expose structured non-approval reasons")
 }


### PR DESCRIPTION
## Summary

The code reviews UI was missing a clear, reliable explanation for items that are not approved, forcing users to guess why a PR is blocked or still needs human review. This change adds a dedicated “Why not approved” column sourced from the backend, removes the old Risk-only behavior from specific rows, and adds frontend fallbacks so comment-only / blocked / human-review / unposted approvals render consistently without breaking layout or tests.

## Changes

- Frontend: Introduced a **Why not approved** column and updated the table rendering and tests to support mixed outcomes in the same list (including mobile row variants and Evidence sheet links).
- Frontend: Added UI fallbacks for non-approval cases where details may be partial or absent (e.g., comment-only, blocked, human-review, and unposted approvals).
- Backend: Added `risk_reason_details` support in the internal code reviews list response so the frontend can render complete, structured “why not approved” reasons.
- Data model/tests: Updated DB/model and related tests to persist and list reason details correctly.

## Validation

- 90 frontend page tests (including updated/added code review table assertions)
- TypeScript typecheck + ESLint
- Production frontend build
- Backend tests (`go test`) and `go vet`

[143.dev](https://143.dev) | [session 5231ba7e](https://143.dev/sessions/5231ba7e-7366-4f82-8bed-95427aad0068)

<!-- 143-publication session=5231ba7e-7366-4f82-8bed-95427aad0068 changeset=2db7f2c9-c8a7-4034-8744-212b4e6f11a6 -->

Preview: https://143.dev/previews/github/assembledhq/143/pull/2099?launch=1