### PR TITLE
Standardize Session Details Overview footer styling and simplify displayed fields and timestamps

### DIFF
--- a/frontend/src/app/(dashboard)/sessions/[id]/page-overview.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/page-overview.test.tsx
@@ -365,6 +365,68 @@ describe('SessionDetailPage overview and review loop', () => {
     expect(screen.getAllByText(/Claude Code/).length).toBeGreaterThanOrEqual(1);
   });
 
+  it('uses the shared overview heading tier for session status and compact agent metadata', async () => {
+    renderWithProviders(<SessionDetailContent id="session-abcdef12-3456-7890" />);
+
+    const vitals = await screen.findByTestId('session-overview-vitals');
+    const statusHeading = within(vitals).getByText('Completed');
+    // Shared tier for size and weight; tone still owns the color, so the
+    // overview and the page header render one status the same way.
+    expect(statusHeading).toHaveClass('text-xs', 'font-medium', 'text-success');
+    expect(statusHeading).not.toHaveClass('text-foreground');
+    expect(statusHeading.parentElement).toHaveAttribute('data-slot', 'section-heading');
+
+    const agentLabel = within(vitals).getByText('Claude Code');
+    expect(agentLabel).toHaveClass('text-xs');
+    // Both halves matter: the badge's own default is `h-5 w-5`, and only
+    // tailwind-merge drops it. Asserting `size-4` alone passes just as well
+    // when the 20px default survives next to it and wins on stylesheet order.
+    expect(agentLabel.previousElementSibling).toHaveClass('size-4');
+    expect(agentLabel.previousElementSibling).not.toHaveClass('h-5', 'w-5');
+
+    // The indicator is an 8px dot; the slot around it stays 16px so this title
+    // and the ones on the sibling overview blocks share a left edge.
+    const iconSlot = statusHeading.previousElementSibling!;
+    expect(iconSlot).toHaveClass('w-4');
+
+    // A heading whose title is not a status keeps the default foreground
+    // color — the tone branch must not bleed into the rest of the column.
+    expect(within(vitals.parentElement!).getByText('Result')).toHaveClass('text-xs', 'font-medium', 'text-foreground');
+  });
+
+  it('lets the status indicator size its own spinner inside the overview heading', async () => {
+    server.use(
+      http.get('/api/v1/sessions/:id', () => {
+        return HttpResponse.json({
+          data: { ...mockSessions[0], status: 'pending', completed_at: undefined },
+        } satisfies SingleResponse<Session>);
+      }),
+    );
+
+    renderWithProviders(<SessionDetailContent id="session-abcdef12-3456-7890" />);
+
+    const vitals = await screen.findByTestId('session-overview-vitals');
+    const statusHeading = within(vitals).getByText('Starting');
+    // The neutral tones are the ones with no color to spend, so this title
+    // lands muted — the same rendering the page header gives this status.
+    // Without a case here, a silent fall back to `text-foreground` for the
+    // half of the statuses that are neutral would keep the suite green.
+    expect(statusHeading).toHaveClass('text-muted-foreground');
+    expect(statusHeading).not.toHaveClass('text-foreground');
+
+    const iconSlot = statusHeading.parentElement!.firstElementChild!;
+    // The heading pins bare caller icons to 16px, but a descendant selector
+    // outranks the spinner's own `size-3` (0,1,1 over 0,1,0) and bursts it out
+    // of the 8px indicator wrapper. Scope stays on the direct child. Asserting
+    // the spinner's own class instead would prove nothing: the class list is
+    // identical either way, and only the parent selector decides which wins.
+    expect(iconSlot.className).toContain('[&>svg]:size-4');
+    // Scoped to the sizing utility: an unrelated `[&_svg]:` rule added later is
+    // not the regression this case is guarding against.
+    expect(iconSlot.className).not.toContain('[&_svg]:size');
+    expect(iconSlot.querySelector('svg')).toBeInTheDocument();
+  });
+
   it('shows the current repository and branch in the overview details', async () => {
     renderWithProviders(<SessionDetailContent id="session-abcdef12-3456-7890" />);
     await screen.findAllByText('Fixed TypeError by adding null check');
@@ -451,19 +513,20 @@ describe('SessionDetailPage overview and review loop', () => {
     expect(vitals.parentElement!.firstElementChild).toBe(vitals);
   });
 
-  // The audit trigger only mounts once /auth/me confirms an admin and the
-  // latest-entry query resolves. Both are seeded into the cache so the trigger
-  // renders in the same commit as the vitals block — a `queryByRole` on the
-  // unsettled DOM passes whether or not the status gate exists.
+  // Seeding is what makes the audit assertions load-bearing. The trigger only
+  // mounts once /auth/me confirms an admin AND the latest-entry query returns a
+  // non-empty page — the default handler returns `[]`, so an unseeded render
+  // shows no trigger whether or not the component still renders one, and the
+  // assertion passes for the wrong reason. The handler has to agree with the
+  // seed so the refetch on mount doesn't wipe the entry back out.
   function renderWithSeededAuditTrail(sessionId: string) {
     const latestEntry = {
       id: 'audit-1',
-      actor_type: 'system',
-      action: 'session.completed',
+      actor_type: 'user',
+      user_id: mockMembers[0].id,
+      action: 'session.status_changed',
       created_at: new Date(Date.now() - 12 * 60000).toISOString(),
     };
-    // The seed is what makes the assertions synchronous; the handler has to
-    // agree with it so the refetch on mount doesn't wipe the entry back out.
     server.use(
       http.get('/api/v1/audit-logs', () => HttpResponse.json({ data: [latestEntry], meta: {} })),
     );
@@ -476,30 +539,31 @@ describe('SessionDetailPage overview and review loop', () => {
     return renderSessionDetailWithQueryClient(sessionId, queryClient);
   }
 
-  it('keeps the session activity trigger inline while a session is still running', async () => {
-    server.use(
-      http.get('/api/v1/sessions/:id', () => {
-        return HttpResponse.json({
-          data: { ...mockSessions[0], status: 'running', completed_at: undefined },
-        } satisfies SingleResponse<Session>);
-      }),
-    );
-
-    renderWithSeededAuditTrail('session-abcdef12-3456-7890');
-
-    const vitals = await screen.findByTestId('session-overview-vitals');
-    expect(await within(vitals).findByRole('button', { name: /Updated.*ago by/i })).toBeInTheDocument();
-  });
-
-  // Both success terminals are gated, so both need covering — dropping either
-  // clause otherwise leaves the suite green.
-  it.each(['completed', 'pr_created'] as const)(
-    'omits low-value audit update metadata once a session is %s',
-    async (status) => {
+  // Every status, not just the terminals: the audit caption used to be gated on
+  // status, and a status-shaped gate is exactly what a regression would restore.
+  // The trigger's accessible name is its caption ("Updated … ago by …") — the
+  // `title` prop only names the sidesheet, so matching on that would never fail.
+  it.each([
+    // `pr_created` shares the "Completed" caption; naming the expected caption
+    // per status keeps the case from passing on a neighbouring terminal's copy.
+    { status: 'running', caption: /Started / },
+    { status: 'completed', caption: /Completed / },
+    { status: 'pr_created', caption: /Completed / },
+    { status: 'failed', caption: /Failed / },
+    { status: 'cancelled', caption: /Cancelled / },
+  ] as const)(
+    'shows one concise session timestamp without duplicate audit attribution when $status',
+    async ({ status, caption }) => {
+      const isTerminal = status !== 'running';
       server.use(
         http.get('/api/v1/sessions/:id', () => {
           return HttpResponse.json({
-            data: { ...mockSessions[0], status },
+            data: {
+              ...mockSessions[0],
+              status,
+              completed_at: isTerminal ? mockSessions[0].completed_at : undefined,
+              triggered_by_user_id: mockMembers[0].id,
+            },
           } satisfies SingleResponse<Session>);
         }),
       );
@@ -507,7 +571,21 @@ describe('SessionDetailPage overview and review loop', () => {
       renderWithSeededAuditTrail('session-abcdef12-3456-7890');
 
       const vitals = await screen.findByTestId('session-overview-vitals');
+      const timing = within(vitals).getByTestId('session-overview-timing');
+      expect(timing).toHaveTextContent(caption);
+      expect(timing).not.toHaveTextContent('Updated');
       expect(within(vitals).queryByRole('button', { name: /Updated.*ago by/i })).not.toBeInTheDocument();
+      expect(await within(vitals).findByRole('button', { name: 'Session activity' })).toBeInTheDocument();
+      // Settle the members query before asserting absence: the identity row
+      // reads "Unknown user" until it lands, and the seeded trigger resolves
+      // its actor name from that same query — so once this name is on screen,
+      // a restored trigger would have rendered its caption alongside it.
+      await within(vitals).findByText('Alice Smith');
+      // Match the whole caption, not the bare name. The trigger renders
+      // "Updated … by Alice Smith" as one node, so an exact-string
+      // `getAllByText('Alice Smith')` never matches it — counting the name
+      // would return 1 with the trigger present and prove nothing.
+      expect(within(vitals).queryAllByText(/Updated .* by Alice Smith/)).toHaveLength(0);
     },
   );
 

--- a/frontend/src/app/(dashboard)/sessions/[id]/page-transcript.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/page-transcript.test.tsx
@@ -84,49 +84,6 @@ describe('SessionDetailPage transcript and scroll', () => {
     expect(screen.getByText('Could not reproduce the error in test environment')).toBeInTheDocument();
   });
 
-  it('keeps failed and updated timestamps visually aligned', async () => {
-    server.use(
-      http.get('/api/v1/sessions/:id', () => {
-        return HttpResponse.json({
-          data: {
-            ...mockSessions[1],
-            failure_explanation: 'Could not reproduce the error in test environment',
-          },
-        });
-      }),
-      http.get('/api/v1/audit-logs', () => {
-        return HttpResponse.json({
-          data: [{
-            id: 'audit-1',
-            actor_type: 'user',
-            user_id: mockMembers[0].id,
-            action: 'session.failed',
-            created_at: new Date(Date.now() - 12 * 60000).toISOString(),
-          }],
-          meta: {},
-        });
-      }),
-    );
-
-    renderWithProviders(<SessionDetailContent id="session-98765432-abcd-ef01" />);
-
-    const updatedTrigger = await screen.findByRole('button', { name: /Updated.*ago by/i });
-    const metadataRow = updatedTrigger.parentElement;
-
-    // The audit trigger now shares the timestamps flex row so "Failed X ago"
-    // and "Updated X ago by Y" sit on the same baseline.
-    expect(metadataRow?.className).toContain('flex');
-    expect(metadataRow?.className).toContain('items-center');
-    expect(metadataRow?.textContent).toMatch(/Failed.*ago/);
-
-    // Inline variant: zero horizontal padding, muted color, preceded by a
-    // decorative middle-dot separator marked aria-hidden.
-    expect(updatedTrigger.className).toContain('px-0');
-    expect(updatedTrigger.className).toContain('text-muted-foreground');
-    expect(updatedTrigger.previousElementSibling?.getAttribute('aria-hidden')).toBe('true');
-    expect(updatedTrigger.previousElementSibling?.textContent).toBe('·');
-  });
-
   it('shows error state when session not found', async () => {
     server.use(
       http.get('/api/v1/sessions/:id', () => {

--- a/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
@@ -91,7 +91,8 @@ import { ChatTimeline } from "@/components/chat-timeline";
 import { SessionActivityTimeline } from "@/components/session-activity-timeline";
 import { ContextHeader } from "@/components/context-header";
 import { StatusLabel } from "@/components/status-label";
-import { StatusIndicator } from "@/components/status-indicator";
+import { StatusIndicator, statusToneTextClass } from "@/components/status-indicator";
+import type { OperationalTone } from "@/lib/operational-state";
 import { SessionComposerAttachmentMenu } from "@/components/session-composer-attachment-menu";
 import { SessionComposerTriggerPicker, flattenGroups, type TriggerPickerGroup, type TriggerPickerPosition } from "@/components/session-composer-trigger-picker";
 import { useSessionComposerSlashCommands } from "@/hooks/use-session-composer-slash-commands";
@@ -324,6 +325,11 @@ function publicationErrorDescription(publication: SessionPublication) {
 // and a selected list row supplies `text-secondary-foreground`. The tier matches
 // the size of the body copy it heads, so weight alone carries the hierarchy in
 // the blocks whose copy is `text-foreground` rather than muted.
+//
+// One exception: a title that *is* an operational status takes that status'
+// tone instead (`SectionHeading`'s `tone`), which lands muted for the neutral
+// tones. The page header renders the same status through `StatusLabel`, and one
+// status reading two colors on one screen is the worse trade.
 const OVERVIEW_LABEL_CLASSNAME = "text-xs font-medium";
 
 // Every status block in the overview leads with a 16px icon and a title on one
@@ -335,20 +341,34 @@ function SectionHeading({
   iconClassName,
   iconSlot,
   title,
+  // Tier is fixed; color is not. A heading whose title *is* an operational
+  // status carries that status' tone, the same way `StatusLabel` does in the
+  // page header, so the two renderings of one status never disagree. The tone
+  // arrives as an axis rather than a class so no caller hand-picks a status
+  // color — `AGENTS.md` keeps that mapping inside the status primitives.
+  tone,
 }: {
   icon: ReactNode;
   iconClassName?: string;
   iconSlot?: string;
   title: ReactNode;
+  tone?: OperationalTone;
 }) {
   return (
     <div className="flex items-center gap-1.5" data-slot="section-heading">
-      {/* Pin the glyph size here so a caller-supplied icon cannot reintroduce
-          the size drift this component exists to prevent. */}
-      <span aria-hidden="true" data-slot={iconSlot} className={cn("shrink-0 [&_svg]:size-4", iconClassName)}>
+      {/* Pin the glyph size here so a caller-supplied bare icon cannot
+          reintroduce the size drift this component exists to prevent. The
+          child combinator is load-bearing: a composite indicator like
+          `StatusIndicator` scales its own nested svg against its own wrapper,
+          and a descendant selector would outrank that sizing (0,1,1 beats the
+          0,1,0 of the svg's own class) and burst the glyph out of its box.
+          The cost is that the pin now reaches bare svgs only — an icon handed
+          over inside a wrapper element sizes itself, so a caller that composes
+          one owes the slot a width through `iconClassName`. */}
+      <span aria-hidden="true" data-slot={iconSlot} className={cn("shrink-0 [&>svg]:size-4", iconClassName)}>
         {icon}
       </span>
-      <p className={cn(OVERVIEW_LABEL_CLASSNAME, "text-foreground")}>{title}</p>
+      <p className={cn(OVERVIEW_LABEL_CLASSNAME, tone ? statusToneTextClass(tone) : "text-foreground")}>{title}</p>
     </div>
   );
 }
@@ -980,21 +1000,36 @@ function OverviewTab({ session, activeThread, members, prStatus }: { session: Se
         />
       )}
 
-      {/* Session vitals — identity row (status + agent + who triggered) */}
+      {/* Session vitals — status heading with compact identity and timing metadata. */}
       <div
         data-testid="session-overview-vitals"
         className={cn("space-y-1.5", OVERVIEW_DIVIDER_CLASSNAME, "first:pt-0")}
       >
-        <div className="flex items-center gap-x-3 gap-y-1 flex-wrap text-xs">
-          <StatusLabel
-            label={operationalStatus.label}
+        <div className="flex flex-wrap items-center gap-x-3 gap-y-1">
+          {/* `iconClassName` holds the slot at 16px because the indicator is an
+              8px dot, not a 16px glyph: without it this title starts on a
+              different left edge than every other heading in the column, and
+              sharing the type tier is only half of what makes these blocks read
+              as one list. */}
+          <SectionHeading
+            icon={(
+              <StatusIndicator
+                tone={operationalStatus.tone}
+                activity={operationalStatus.activity}
+                stateKey={`${session.status}:${operationalStatus.kind}`}
+                size="sm"
+              />
+            )}
+            iconClassName="inline-flex w-4 items-center justify-center"
+            title={operationalStatus.label}
             tone={operationalStatus.tone}
-            activity={operationalStatus.activity}
-            stateKey={`${session.status}:${operationalStatus.kind}`}
-            size="md"
           />
-          <span className="inline-flex items-center gap-x-1.5 text-muted-foreground">
-            <AgentBadge agentType={session.agent_type} labelClassName="text-xs" />
+          <span className="inline-flex items-center gap-x-1.5 text-xs text-muted-foreground">
+            <AgentBadge
+              agentType={session.agent_type}
+              className="size-4"
+              labelClassName="text-xs"
+            />
             <span aria-hidden="true" className="text-muted-foreground/50">·</span>
             <span>{triggeredByLabel}</span>
           </span>
@@ -1002,7 +1037,7 @@ function OverviewTab({ session, activeThread, members, prStatus }: { session: Se
 
         <div
           data-testid="session-overview-context"
-          className="flex min-w-0 items-center gap-x-2 gap-y-1 flex-wrap text-xs text-muted-foreground"
+          className="flex min-w-0 flex-wrap items-center gap-x-2 gap-y-1 text-xs text-muted-foreground"
         >
           {originDisplay && (
             <Badge variant="outline" className="h-5 rounded-full px-2 text-xs font-medium">
@@ -1043,20 +1078,12 @@ function OverviewTab({ session, activeThread, members, prStatus }: { session: Se
                 <>Queued {formatTimeAgo(session.created_at)}</>
               )}
             </span>
-            {/*
-              Suppressed on the two success terminals only: their last audit
-              entry restates the "Completed …" caption immediately to its left.
-              Failed/cancelled/skipped sessions keep the trigger because their
-              activity trail is what explains how they got there.
-            */}
-            {session.status !== "completed" && session.status !== "pr_created" && (
-              <AuditLogTrigger
-                filters={{ session_id: session.id }}
-                members={members}
-                title="Session activity"
-                variant="inline"
-              />
-            )}
+            <AuditLogTrigger
+              filters={{ session_id: session.id }}
+              members={members}
+              title="Session activity"
+              variant="icon"
+            />
           </div>
         </div>
       </div>

--- a/frontend/src/components/audit/audit-log-trigger.test.tsx
+++ b/frontend/src/components/audit/audit-log-trigger.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
-import { renderWithProviders, screen, waitFor } from '@/test/test-utils';
+import { renderWithProviders, screen, userEvent, waitFor } from '@/test/test-utils';
 import { AuditLogTrigger } from './audit-log-trigger';
 import type { User } from '@/lib/types';
 
@@ -95,6 +95,35 @@ describe('AuditLogTrigger', () => {
     const separator = container.querySelector('span[aria-hidden="true"]');
     expect(separator?.textContent).toBe('·');
     expect(container.querySelector('svg')).toBeNull();
+  });
+
+  it('icon variant: opens audit activity without rendering timestamp or actor metadata', async () => {
+    auditLogListMock.mockResolvedValue({
+      data: [{
+        id: 'audit-icon',
+        actor_type: 'user',
+        user_id: 'user-1',
+        action: 'session.created',
+        created_at: new Date(Date.now() - 2 * 60000).toISOString(),
+      }],
+      meta: {},
+    });
+
+    renderWithProviders(
+      <AuditLogTrigger
+        filters={{ session_id: 'sess-1' }}
+        members={mockMembers}
+        title="Session activity"
+        variant="icon"
+      />
+    );
+
+    const trigger = await screen.findByRole('button', { name: 'Session activity' });
+    expect(screen.queryByText(/Updated.*ago by Alice/)).not.toBeInTheDocument();
+
+    const user = userEvent.setup();
+    await user.click(trigger);
+    expect(screen.getByRole('heading', { name: 'Session activity' })).toBeInTheDocument();
   });
 
   it('footer variant: renders as low-priority last activity text', async () => {

--- a/frontend/src/components/audit/audit-log-trigger.tsx
+++ b/frontend/src/components/audit/audit-log-trigger.tsx
@@ -23,9 +23,11 @@ interface AuditLogTriggerProps {
    * - `default`: standalone row with a leading Clock icon.
    * - `inline`: drops the icon, adds a leading middle-dot separator, and removes
    *   horizontal padding so the trigger reads as part of a surrounding sentence.
+   * - `icon`: keeps the activity sidesheet available without rendering audit
+   *   timestamp or actor metadata.
    * - `footer`: muted page footer for low-priority settings activity metadata.
    */
-  variant?: "default" | "inline" | "footer";
+  variant?: "default" | "inline" | "icon" | "footer";
 }
 
 export function AuditLogTrigger({ filters, members: membersProp, title, variant = "default" }: AuditLogTriggerProps) {
@@ -86,7 +88,33 @@ export function AuditLogTrigger({ filters, members: membersProp, title, variant 
   })();
 
   const isInline = variant === "inline";
+  const isIcon = variant === "icon";
   const isFooter = variant === "footer";
+
+  if (isIcon) {
+    const accessibleTitle = title ?? "View activity";
+    return (
+      <>
+        <Button
+          variant="ghost"
+          size="icon-compact"
+          onClick={() => setOpen(true)}
+          className="text-muted-foreground transition-colors hover:text-foreground"
+          aria-label={accessibleTitle}
+          title={accessibleTitle}
+        >
+          <Clock className="size-3.5" />
+        </Button>
+        <AuditLogSidesheet
+          open={open}
+          onOpenChange={setOpen}
+          filters={sidesheetFilters}
+          title={title}
+          members={members}
+        />
+      </>
+    );
+  }
 
   if (isFooter) {
     return (


### PR DESCRIPTION
## Summary

The session details workflow lost quick access to session activity via the compact clock icon, forcing users to hunt for the audit entry point. This PR restores that access (clicking the icon opens the existing audit sidesheet) and standardizes the session overview footer/heading styling so status and metadata render consistently without unintended “Updated by …” noise.

## Changes

- Reintroduced the compact “clock”/activity affordance for session activity, wired to open the existing audit log sidesheet.
- Standardized session overview heading/timestamp/icon slot sizing so status/agent metadata use a shared typography/heading tier while keeping tone-specific color scoped correctly.
- Adjusted rendered fields so “Updated … by …” is not shown in the overview, aligning with the intended product surface.
- Added/expanded tests to cover the icon variant(s) and the sidesheet interaction.

## Validation

- Ran frontend unit tests: **85 tests passed**
- Ran targeted linting: **ESLint passed**

[143.dev](https://143.dev) | [session a4fbe470](https://143.dev/sessions/a4fbe470-0020-43ca-a610-08abf8d2345f)

<!-- 143-publication session=a4fbe470-0020-43ca-a610-08abf8d2345f changeset=7155c42a-c2b4-457e-8594-6cf41fd6fad2 -->

Preview: https://143.dev/previews/github/assembledhq/143/pull/2100?launch=1