### PR TITLE
Move analytics headline metrics above filters and detail tables

### DIFF
--- a/frontend/src/app/(dashboard)/code-reviews/page.test.tsx
+++ b/frontend/src/app/(dashboard)/code-reviews/page.test.tsx
@@ -803,7 +803,7 @@ describe("CodeReviewsPage", () => {
     expect(within(evidenceSheet).getByText("Required checks were not passing")).toBeInTheDocument();
   });
 
-  it("renders the PR-centric Analytics report with author usage first", async () => {
+  it("renders the PR-centric Analytics report with headline metrics first", async () => {
     const user = userEvent.setup();
     const analyticsRequests: URLSearchParams[] = [];
     // The retired insights report has no handler in the base mocks, so a
@@ -848,20 +848,10 @@ describe("CodeReviewsPage", () => {
     const authorUsage = screen.getByText("Usage by PR author");
     const authorTable = screen.getByRole("table", { name: "Code review analytics by PR author" });
     expect(
+      approvalOutcomes.compareDocumentPosition(analyticsFilters as Node) & Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+    expect(
       (analyticsFilters as Node).compareDocumentPosition(authorUsage) & Node.DOCUMENT_POSITION_FOLLOWING,
-    ).toBeTruthy();
-    // Anchor on the table rather than the section heading: the cards following
-    // the heading also holds when they render inside the author section above
-    // the table, which is the one-line regression this is guarding against.
-    expect(
-      authorTable.compareDocumentPosition(approvalOutcomes) & Node.DOCUMENT_POSITION_FOLLOWING,
-    ).toBeTruthy();
-    // Pin the far side too. The filters/author-section check above still held
-    // before the cards moved, so only the full author-table → cards → request-table
-    // window proves the new placement.
-    expect(
-      approvalOutcomes.compareDocumentPosition(screen.getByText("Direct review requests by user")) &
-        Node.DOCUMENT_POSITION_FOLLOWING,
     ).toBeTruthy();
     expect(screen.getByText("Line-count limit exceeded")).toBeInTheDocument();
     expect(screen.getByText("Reviewers found a blocking issue")).toBeInTheDocument();

--- a/frontend/src/components/code-review-analytics.test.tsx
+++ b/frontend/src/components/code-review-analytics.test.tsx
@@ -118,6 +118,8 @@ describe("CodeReviewAnalyticsReport PR cohort states", () => {
 
     const authorUsage = screen.getByText("Usage by PR author");
     const approvalByRound = screen.getByText("Approval by round");
+    expect(outcomes.compareDocumentPosition(authorUsage) & Node.DOCUMENT_POSITION_FOLLOWING)
+      .toBeTruthy();
     expect(authorUsage.compareDocumentPosition(approvalByRound) & Node.DOCUMENT_POSITION_FOLLOWING)
       .toBeTruthy();
   });

--- a/frontend/src/components/code-review-analytics.tsx
+++ b/frontend/src/components/code-review-analytics.tsx
@@ -266,6 +266,8 @@ export function CodeReviewAnalyticsReport({
         />
       ) : null}
 
+      <ApprovalOutcomeCards summary={summary} />
+
       {filters}
 
       <SectionGroup
@@ -407,8 +409,6 @@ export function CodeReviewAnalyticsReport({
           </>
         )}
       </SectionGroup>
-
-      <ApprovalOutcomeCards summary={summary} />
 
       <SectionGroup
         title="Direct review requests by user"


### PR DESCRIPTION
## Summary

- Move approval outcome headline metrics to the top of the PR-centric analytics report.
- Update page and component tests to verify the revised report ordering.

## Testing

- Updated frontend tests for analytics layout and section ordering.