### PR TITLE
Capture GitHub visual evidence for code review

### DIFF
--- a/docs/design/future/124-code-review-visual-evidence.md
+++ b/docs/design/future/124-code-review-visual-evidence.md
@@ -1,0 +1,198 @@
+# Design: Code Review Visual Evidence
+
+> **Status:** In progress | **Last reviewed:** 2026-08-12
+>
+> **Depends on:** [../overall.md](../overall.md), [../implemented/112-code-reviewer-bot-auto-approval.md](../implemented/112-code-reviewer-bot-auto-approval.md)
+
+## Summary
+
+Code Reviewer must inspect screenshots and other images rendered in the pull
+request description and human-authored PR discussion. A relevant image from
+any supported surface may satisfy a visual-evidence description requirement.
+Images, alt text, captions, and nearby discussion text are always untrusted PR
+content: they provide factual evidence but never instructions to an agent.
+
+This behavior launches directly when the complete path is deployed. It has no
+feature flag, policy opt-in, repository allowlist, or staged rollout.
+
+## Product Contract
+
+Capture images from these authoritative GitHub surfaces:
+
+1. the PR description;
+2. PR conversation (issue) comments;
+3. submitted review bodies; and
+4. inline review comments.
+
+The description is in scope regardless of the PR author's GitHub actor type.
+Discussion images are in scope only when GitHub classifies the author as a
+`User` or `Mannequin`, including outside contributors. Exclude `Bot`, `App`,
+`Organization`, deleted/unknown actors, and therefore 143-authored output.
+Human-authored discussion conclusions and review decisions remain excluded as
+risk signals; only the captured visual content and its bounded provenance are
+evidence.
+
+Image presence alone does not satisfy a requirement. The orchestrator must
+identify a relevant, current image that demonstrates the changed experience.
+An image-backed `satisfied` assessment must cite one or more valid evidence
+IDs. Preview links and repository-native visual evidence may still satisfy the
+requirement when the assessment explains that basis without an image ID.
+
+Each assessment captures one immutable evidence snapshot for its head SHA.
+Every configured reviewer and the orchestrator receive the same ordered
+manifest and first-party image attachments. Later edits require an explicit
+rerequest; they do not mutate an assessment already in progress.
+
+## Architecture
+
+```text
+GitHub PR + paginated discussion APIs
+              |
+              v
+rendered-HTML discovery and human-source filter
+              |
+              v
+bounded secure downloader -> first-party upload storage
+              |
+              v
+immutable visual-evidence prompt record
+              |
+              +--> reviewer attachments + manifest
+              +--> orchestrator attachments + manifest
+              +--> description assessment evidence IDs
+              +--> review Evidence panel
+```
+
+GitHub is queried live rather than relying on the webhook feedback mirror,
+which may not contain comments written before 143 began tracking the PR. The
+collector requests GitHub's rendered HTML representation and paginates issue
+comments, reviews, and review comments independently. It extracts `<img>` and
+responsive `srcset` sources, preserves author/source/time provenance, and
+orders results deterministically by surface, provider timestamp/object ID, and
+image position.
+
+Shared data types live in `internal/models` so the GitHub and worker packages
+can exchange the discovery and materialized manifests without a package cycle.
+The worker depends on a dedicated evidence provider rather than widening the
+general PR publication interface.
+
+## Immutable Manifest
+
+The persisted snapshot includes:
+
+- version, repository identity, PR number, head SHA, capture time, completeness,
+  and overflow state;
+- a deterministic evidence ID and source ID;
+- surface, provider object, source URL, author, author association, timestamps,
+  and image position;
+- original URL for provenance and first-party storage key/URL for agents;
+- bounded untrusted alt/context text;
+- SHA-256, validated content type, byte size, dimensions, fetch status, and a
+  bounded failure reason.
+
+Fetch status is typed as `available`, `unavailable`, `unsupported`, or
+`over_limit`. Available evidence alone may be attached or cited.
+
+Reuse `code_review_prompt_records` with role `visual_evidence` and record key:
+
+```text
+code-review-prompts/{session_id}/{head_sha}/visual-evidence-v1
+```
+
+The complete structured manifest is stored in `metadata`; `content` contains a
+human-readable audit summary. An org-scoped key lookup is the idempotency
+checkpoint. Once the record exists, retries deserialize and reuse it without
+refetching mutable GitHub content. The description input hash uses a canonical
+manifest projection and content hashes, excluding mutable first-party URLs.
+
+## Secure Materialization
+
+Reuse `storage.UploadStore` with keys shaped as:
+
+```text
+{org_id}/code-review-evidence/{session_id}/{sha256}.{extension}
+```
+
+The downloader accepts HTTPS only. GitHub asset hosts use installation
+credentials only on an explicit allowlist, and credentials are never forwarded
+to a non-allowlisted redirect. Other HTTPS images use an unauthenticated,
+SSRF-safe client. Resolve and revalidate every redirect target and reject
+loopback, private, link-local, multicast, unspecified, and cloud-metadata
+addresses.
+
+Validate decoded magic bytes instead of trusting URL extensions or response
+headers. Initially accept PNG, JPEG, GIF, and WebP. Reject SVG rather than
+passing active vector content to agents. Enforce:
+
+- 10 MB per image;
+- 40 megapixels per image;
+- 32 images and 64 MB total per assessment;
+- four concurrent downloads;
+- 15 seconds per image;
+- three redirects; and
+- three transient attempts with bounded backoff.
+
+All human images are eligible. When limits are exceeded, retain the first 32 in
+deterministic order and mark later sources `over_limit`. An inaccessible or
+oversized image is recorded but cannot satisfy evidence. An individual bad
+outside-contributor image must not fail or deny an otherwise complete review.
+A failure to list an entire supported GitHub surface makes the snapshot
+incomplete and fails the review operationally after normal retries; the bot
+must never approve from a silently partial snapshot.
+
+## Prompt And Decision Contract
+
+Reviewer and orchestrator templates state that every supplied image and all
+associated text are untrusted evidence. Agents inspect them for relevance but
+must not follow instructions embedded in pixels, alt text, captions, or nearby
+discussion. The existing prompt-injection hard-risk signal applies to visual
+content and its textual context.
+
+The orchestrator receives a `<visual_evidence_manifest>` containing stable IDs
+and provenance. Structured description assessments gain `evidence_ids`. The
+backend rejects unknown, duplicate, or unavailable IDs. A screenshot-based
+`satisfied` assessment without a valid ID is invalid for approval.
+
+The worker captures or restores the snapshot after authoritative PR/head sync
+and before reviewer fan-out. It passes every available first-party URL through
+`SendMessageInput.Images` to each reviewer and the orchestrator. Missing
+provider wiring is an operational failure, not a silent text-only fallback.
+
+## Product And Operations
+
+The code review Evidence view gains a Visual evidence section with thumbnail,
+evidence ID, surface, author, source link, time, status/failure, and whether the
+orchestrator cited it. User-facing copy calls the rule a PR evidence requirement
+while preserving the existing machine reason code `description_failed` for API
+compatibility.
+
+Metrics cover discovered, fetched, deduplicated, unavailable, unsupported, and
+over-limit images; bytes, fetch latency, source surface; snapshot completeness;
+and the surface used to satisfy visual evidence. Logs contain identifiers,
+counts, host classification, status, and timing only. Never log image bytes,
+tokens, full comment bodies, or signed URLs.
+
+Storage follows normal upload retention. Rollback deploys the prior binaries;
+the additive prompt role constraint remains compatible, historical prompt
+records remain audit data, and stored blobs expire through normal retention.
+
+## Delivery Sequence
+
+The implementation may be reviewed as stacked pull requests, but behavior only
+launches when the complete path lands:
+
+1. typed evidence/discovery contracts, live paginated GitHub discovery, prompt
+   role migration, and org-scoped checkpoint lookup;
+2. secure bounded downloader, first-party storage, immutable manifest
+   persistence, idempotent restoration, and metrics;
+3. worker attachment fan-out, prompt and structured-output contracts,
+   validation, input hashing, and failure semantics;
+4. evidence API/UI, user-facing docs, architecture reconciliation, and launch
+   verification.
+
+Before deployment, verify public and private repositories, every supported
+surface, an outside contributor, bot exclusion, duplicate images, inaccessible
+images, overflow, rerun idempotency, and incomplete-surface failure. Apply the
+migration, verify shared upload storage, drain old workers, deploy the complete
+binary set, resume workers, and run public/private smoke reviews. No slow
+rollout is required.

--- a/internal/db/code_reviews.go
+++ b/internal/db/code_reviews.go
@@ -2351,6 +2351,21 @@ func (s *CodeReviewStore) ListPromptRecords(ctx context.Context, orgID, sessionI
 	return pgx.CollectRows(rows, pgx.RowToStructByName[models.CodeReviewPromptRecord])
 }
 
+func (s *CodeReviewStore) GetPromptRecordByKey(ctx context.Context, orgID uuid.UUID, recordKey string) (models.CodeReviewPromptRecord, error) {
+	rows, err := s.db.Query(ctx, `
+		SELECT `+codeReviewPromptRecordColumns+`
+		FROM code_review_prompt_records
+		WHERE org_id = @org_id
+		  AND record_key = @record_key`, pgx.NamedArgs{
+		"org_id":     orgID,
+		"record_key": recordKey,
+	})
+	if err != nil {
+		return models.CodeReviewPromptRecord{}, fmt.Errorf("get code review prompt record by key: %w", err)
+	}
+	return collectOneCodeReviewPromptRecord(rows)
+}
+
 func (s *CodeReviewStore) CreateFinding(ctx context.Context, finding *models.CodeReviewFinding) error {
 	return s.upsertFinding(ctx, finding, false)
 }

--- a/internal/db/code_reviews_test.go
+++ b/internal/db/code_reviews_test.go
@@ -225,6 +225,31 @@ func TestCodeReviewStore_CreatePromptRecordPreservesEffectivePrompt(t *testing.T
 	require.NoError(t, mock.ExpectationsWereMet(), "all prompt record expectations should be met")
 }
 
+func TestCodeReviewStore_GetPromptRecordByKeyFiltersByOrg(t *testing.T) {
+	t.Parallel()
+
+	orgID, sessionID, recordID := uuid.New(), uuid.New(), uuid.New()
+	now := time.Date(2026, 8, 12, 12, 0, 0, 0, time.UTC)
+	recordKey := "code-review-prompts/session/head/visual-evidence-v1"
+	metadata := json.RawMessage(`{"version":1}`)
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "pgxmock should initialize")
+	defer mock.Close()
+	mock.ExpectQuery("SELECT .+ FROM code_review_prompt_records").
+		WithArgs(pgx.NamedArgs{"org_id": orgID, "record_key": recordKey}).
+		WillReturnRows(pgxmock.NewRows([]string{"id", "org_id", "session_id", "record_key", "role", "agent_provider", "content", "metadata", "created_at"}).
+			AddRow(recordID, orgID, sessionID, recordKey, "visual_evidence", "", "captured 2 images", metadata, now))
+
+	record, err := NewCodeReviewStore(mock).GetPromptRecordByKey(context.Background(), orgID, recordKey)
+
+	require.NoError(t, err, "GetPromptRecordByKey should load the immutable evidence checkpoint")
+	require.Equal(t, models.CodeReviewPromptRecord{
+		ID: recordID, OrgID: orgID, SessionID: sessionID, RecordKey: recordKey, Role: "visual_evidence",
+		Content: "captured 2 images", Metadata: metadata, CreatedAt: now,
+	}, record, "GetPromptRecordByKey should return the exact org-scoped record")
+	require.NoError(t, mock.ExpectationsWereMet(), "prompt-record lookup should include the tenant boundary")
+}
+
 func TestCodeReviewStore_GetActiveGitHubTriggerFiltersByOrgAndRepo(t *testing.T) {
 	t.Parallel()
 

--- a/internal/db/migrations_test.go
+++ b/internal/db/migrations_test.go
@@ -1699,6 +1699,26 @@ func TestRenameLegacyOutputTermsMigrationPinsNamespaceContracts(t *testing.T) {
 // each down file must undo its own up on a fresh database (where those
 // migrations create the new names directly) while still working on a database
 // that migration 280 expanded and then contracted back to the legacy names.
+func TestCodeReviewVisualEvidencePromptRoleMigrationPreservesRollbackAuditRows(t *testing.T) {
+	t.Parallel()
+
+	upBody, err := os.ReadFile("../../migrations/000286_code_review_visual_evidence_prompt_role.up.sql")
+	require.NoError(t, err, "test should read the visual-evidence prompt-role migration")
+	upSQL := string(upBody)
+	require.Contains(t, upSQL, "'visual_evidence'", "migration should admit immutable visual-evidence manifest records")
+	require.Equal(t, 2, strings.Count(upSQL, "'visual_evidence'"), "migration should widen both synchronized prompt tables")
+	require.Contains(t, upSQL, "chk_code_review_prompt_records_role", "migration should replace the existing prompt role constraint")
+	require.Contains(t, upSQL, "to_regclass('code_review_prompt_artifacts')", "migration should detect installations still draining the legacy prompt table")
+	require.Contains(t, upSQL, "chk_code_review_prompt_artifacts_role", "migration should widen the synchronized legacy prompt role constraint")
+
+	downBody, err := os.ReadFile("../../migrations/000286_code_review_visual_evidence_prompt_role.down.sql")
+	require.NoError(t, err, "test should read the visual-evidence prompt-role rollback")
+	downSQL := string(downBody)
+	require.Contains(t, downSQL, ")) NOT VALID", "rollback should preserve historical visual-evidence rows while narrowing new writes")
+	require.NotContains(t, downSQL, "'visual_evidence'", "rollback write contract should return to the prior prompt roles")
+	require.Contains(t, downSQL, "chk_code_review_prompt_artifacts_role", "rollback should narrow the synchronized legacy prompt role constraint")
+}
+
 func TestRenamedOutputTermMigrationsInvertThemselves(t *testing.T) {
 	t.Parallel()
 

--- a/internal/models/code_review_test.go
+++ b/internal/models/code_review_test.go
@@ -53,6 +53,12 @@ func TestCodeReviewEnumsValidate(t *testing.T) {
 		{name: "finding confidence invalid", validate: CodeReviewFindingConfidence("bogus").Validate, expectErr: true},
 		{name: "description applicability nontrivial", validate: CodeReviewDescriptionApplicabilityNontrivial.Validate},
 		{name: "description applicability invalid", validate: CodeReviewDescriptionApplicabilityKind("bogus").Validate, expectErr: true},
+		{name: "visual evidence surface description", validate: CodeReviewEvidenceSurfaceDescription.Validate},
+		{name: "visual evidence surface invalid", validate: CodeReviewEvidenceSurface("bogus").Validate, expectErr: true},
+		{name: "visual evidence author user", validate: CodeReviewEvidenceAuthorTypeUser.Validate},
+		{name: "visual evidence author invalid", validate: CodeReviewEvidenceAuthorType("bogus").Validate, expectErr: true},
+		{name: "visual evidence fetch available", validate: CodeReviewVisualEvidenceFetchStatusAvailable.Validate},
+		{name: "visual evidence fetch invalid", validate: CodeReviewVisualEvidenceFetchStatus("bogus").Validate, expectErr: true},
 	}
 
 	for _, tt := range tests {
@@ -65,6 +71,31 @@ func TestCodeReviewEnumsValidate(t *testing.T) {
 				return
 			}
 			require.NoError(t, err, "valid code review enum values should be accepted")
+		})
+	}
+}
+
+func TestCodeReviewEvidenceAuthorTypeIsHuman(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		authorType CodeReviewEvidenceAuthorType
+		expected   bool
+	}{
+		{name: "GitHub user", authorType: CodeReviewEvidenceAuthorTypeUser, expected: true},
+		{name: "GitHub mannequin", authorType: CodeReviewEvidenceAuthorTypeMannequin, expected: true},
+		{name: "GitHub bot", authorType: CodeReviewEvidenceAuthorTypeBot, expected: false},
+		{name: "GitHub app", authorType: CodeReviewEvidenceAuthorTypeApp, expected: false},
+		{name: "GitHub organization", authorType: CodeReviewEvidenceAuthorTypeOrganization, expected: false},
+		{name: "deleted or unknown actor", authorType: CodeReviewEvidenceAuthorTypeUnknown, expected: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			require.Equal(t, tt.expected, tt.authorType.IsHuman(), "author classification should admit only human GitHub actor types")
 		})
 	}
 }

--- a/internal/models/code_review_visual_evidence.go
+++ b/internal/models/code_review_visual_evidence.go
@@ -1,0 +1,149 @@
+package models
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// CodeReviewEvidenceSurface identifies the GitHub surface that displayed an
+// image when a code review captured its immutable evidence snapshot.
+type CodeReviewEvidenceSurface string
+
+const (
+	CodeReviewEvidenceSurfaceDescription   CodeReviewEvidenceSurface = "description"
+	CodeReviewEvidenceSurfaceIssueComment  CodeReviewEvidenceSurface = "issue_comment"
+	CodeReviewEvidenceSurfaceReviewBody    CodeReviewEvidenceSurface = "review_body"
+	CodeReviewEvidenceSurfaceReviewComment CodeReviewEvidenceSurface = "review_comment"
+)
+
+func (s CodeReviewEvidenceSurface) Validate() error {
+	switch s {
+	case CodeReviewEvidenceSurfaceDescription,
+		CodeReviewEvidenceSurfaceIssueComment,
+		CodeReviewEvidenceSurfaceReviewBody,
+		CodeReviewEvidenceSurfaceReviewComment:
+		return nil
+	default:
+		return fmt.Errorf("invalid CodeReviewEvidenceSurface: %q", s)
+	}
+}
+
+// CodeReviewEvidenceAuthorType preserves GitHub's actor classification so the
+// discovery boundary can admit human discussion while excluding automation.
+type CodeReviewEvidenceAuthorType string
+
+const (
+	CodeReviewEvidenceAuthorTypeUser         CodeReviewEvidenceAuthorType = "User"
+	CodeReviewEvidenceAuthorTypeMannequin    CodeReviewEvidenceAuthorType = "Mannequin"
+	CodeReviewEvidenceAuthorTypeBot          CodeReviewEvidenceAuthorType = "Bot"
+	CodeReviewEvidenceAuthorTypeApp          CodeReviewEvidenceAuthorType = "App"
+	CodeReviewEvidenceAuthorTypeOrganization CodeReviewEvidenceAuthorType = "Organization"
+	CodeReviewEvidenceAuthorTypeUnknown      CodeReviewEvidenceAuthorType = "Unknown"
+)
+
+func (t CodeReviewEvidenceAuthorType) Validate() error {
+	switch t {
+	case CodeReviewEvidenceAuthorTypeUser,
+		CodeReviewEvidenceAuthorTypeMannequin,
+		CodeReviewEvidenceAuthorTypeBot,
+		CodeReviewEvidenceAuthorTypeApp,
+		CodeReviewEvidenceAuthorTypeOrganization,
+		CodeReviewEvidenceAuthorTypeUnknown:
+		return nil
+	default:
+		return fmt.Errorf("invalid CodeReviewEvidenceAuthorType: %q", t)
+	}
+}
+
+func (t CodeReviewEvidenceAuthorType) IsHuman() bool {
+	return t == CodeReviewEvidenceAuthorTypeUser || t == CodeReviewEvidenceAuthorTypeMannequin
+}
+
+// CodeReviewVisualEvidenceFetchStatus is the immutable outcome of attempting
+// to materialize one discovered image into first-party storage.
+type CodeReviewVisualEvidenceFetchStatus string
+
+const (
+	CodeReviewVisualEvidenceFetchStatusAvailable   CodeReviewVisualEvidenceFetchStatus = "available"
+	CodeReviewVisualEvidenceFetchStatusUnavailable CodeReviewVisualEvidenceFetchStatus = "unavailable"
+	CodeReviewVisualEvidenceFetchStatusUnsupported CodeReviewVisualEvidenceFetchStatus = "unsupported"
+	CodeReviewVisualEvidenceFetchStatusOverLimit   CodeReviewVisualEvidenceFetchStatus = "over_limit"
+)
+
+func (s CodeReviewVisualEvidenceFetchStatus) Validate() error {
+	switch s {
+	case CodeReviewVisualEvidenceFetchStatusAvailable,
+		CodeReviewVisualEvidenceFetchStatusUnavailable,
+		CodeReviewVisualEvidenceFetchStatusUnsupported,
+		CodeReviewVisualEvidenceFetchStatusOverLimit:
+		return nil
+	default:
+		return fmt.Errorf("invalid CodeReviewVisualEvidenceFetchStatus: %q", s)
+	}
+}
+
+// CodeReviewVisualEvidenceSource is one image occurrence discovered in
+// GitHub-rendered PR content. ImageURL, AltText, and ContextText are untrusted
+// pull-request content and must never be treated as instructions.
+type CodeReviewVisualEvidenceSource struct {
+	SourceID          string                       `json:"source_id"`
+	Surface           CodeReviewEvidenceSurface    `json:"surface"`
+	ProviderObjectID  string                       `json:"provider_object_id"`
+	SourceURL         string                       `json:"source_url"`
+	AuthorLogin       string                       `json:"author_login,omitempty"`
+	AuthorType        CodeReviewEvidenceAuthorType `json:"author_type"`
+	AuthorAssociation string                       `json:"author_association,omitempty"`
+	CreatedAt         *time.Time                   `json:"created_at,omitempty"`
+	UpdatedAt         *time.Time                   `json:"updated_at,omitempty"`
+	ImageIndex        int                          `json:"image_index"`
+	ImageURL          string                       `json:"image_url"`
+	AltText           string                       `json:"alt_text,omitempty"`
+	ContextText       string                       `json:"context_text,omitempty"`
+	Untrusted         bool                         `json:"untrusted"`
+}
+
+// CodeReviewVisualEvidenceDiscovery is the authoritative, deterministically
+// ordered set of image occurrences visible when one PR head was captured.
+type CodeReviewVisualEvidenceDiscovery struct {
+	Version           int                              `json:"version"`
+	RepositoryID      uuid.UUID                        `json:"repository_id"`
+	Repository        string                           `json:"repository"`
+	PullRequestNumber int                              `json:"pull_request_number"`
+	HeadSHA           string                           `json:"head_sha"`
+	CapturedAt        time.Time                        `json:"captured_at"`
+	Sources           []CodeReviewVisualEvidenceSource `json:"sources"`
+}
+
+// CodeReviewVisualEvidence is the persisted materialization result for one
+// discovered source. Available evidence always points to first-party storage;
+// OriginalURL remains provenance only and must not be passed to an LLM client.
+type CodeReviewVisualEvidence struct {
+	EvidenceID    string                              `json:"evidence_id"`
+	Source        CodeReviewVisualEvidenceSource      `json:"source"`
+	OriginalURL   string                              `json:"original_url"`
+	StorageKey    string                              `json:"storage_key,omitempty"`
+	StoredURL     string                              `json:"stored_url,omitempty"`
+	ContentSHA256 string                              `json:"content_sha256,omitempty"`
+	ContentType   string                              `json:"content_type,omitempty"`
+	ByteSize      int64                               `json:"byte_size,omitempty"`
+	Width         int                                 `json:"width,omitempty"`
+	Height        int                                 `json:"height,omitempty"`
+	Status        CodeReviewVisualEvidenceFetchStatus `json:"status"`
+	FailureReason string                              `json:"failure_reason,omitempty"`
+}
+
+// CodeReviewVisualEvidenceSnapshot is the immutable manifest shared by every
+// reviewer and the orchestrator in one assessment.
+type CodeReviewVisualEvidenceSnapshot struct {
+	Version           int                        `json:"version"`
+	RepositoryID      uuid.UUID                  `json:"repository_id"`
+	Repository        string                     `json:"repository"`
+	PullRequestNumber int                        `json:"pull_request_number"`
+	HeadSHA           string                     `json:"head_sha"`
+	CapturedAt        time.Time                  `json:"captured_at"`
+	Complete          bool                       `json:"complete"`
+	Overflow          bool                       `json:"overflow"`
+	Evidence          []CodeReviewVisualEvidence `json:"evidence"`
+}

--- a/internal/services/github/code_review_visual_evidence.go
+++ b/internal/services/github/code_review_visual_evidence.go
@@ -1,0 +1,397 @@
+package github
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+	"unicode/utf8"
+
+	"github.com/google/uuid"
+	"golang.org/x/net/html"
+	"golang.org/x/net/html/atom"
+	"golang.org/x/sync/errgroup"
+
+	"github.com/assembledhq/143/internal/models"
+)
+
+const (
+	codeReviewVisualEvidenceDiscoveryVersion = 1
+	githubFullJSONMediaType                  = "application/vnd.github.full+json"
+	githubVisualEvidencePageSize             = 100
+	maxVisualEvidenceContextRunes            = 500
+)
+
+type githubVisualEvidenceActor struct {
+	Login string `json:"login"`
+	Type  string `json:"type"`
+}
+
+type githubVisualEvidenceContent struct {
+	ID                int64                      `json:"id"`
+	HTMLURL           string                     `json:"html_url"`
+	BodyHTML          string                     `json:"body_html"`
+	AuthorAssociation string                     `json:"author_association"`
+	User              *githubVisualEvidenceActor `json:"user"`
+	CreatedAt         *time.Time                 `json:"created_at"`
+	UpdatedAt         *time.Time                 `json:"updated_at"`
+	SubmittedAt       *time.Time                 `json:"submitted_at"`
+}
+
+type githubVisualEvidencePullRequest struct {
+	Number    int                        `json:"number"`
+	HTMLURL   string                     `json:"html_url"`
+	BodyHTML  string                     `json:"body_html"`
+	User      *githubVisualEvidenceActor `json:"user"`
+	CreatedAt *time.Time                 `json:"created_at"`
+	UpdatedAt *time.Time                 `json:"updated_at"`
+	Head      struct {
+		SHA string `json:"sha"`
+	} `json:"head"`
+}
+
+// DiscoverCodeReviewVisualEvidence reads every GitHub discussion surface that
+// may contain review evidence. Description images are always captured;
+// discussion images are admitted only from human User or Mannequin actors.
+func (s *PRService) DiscoverCodeReviewVisualEvidence(ctx context.Context, orgID, repositoryID uuid.UUID, number int) (models.CodeReviewVisualEvidenceDiscovery, error) {
+	if s == nil || s.repos == nil {
+		return models.CodeReviewVisualEvidenceDiscovery{}, fmt.Errorf("repository store is unavailable")
+	}
+	if orgID == uuid.Nil || repositoryID == uuid.Nil || number <= 0 {
+		return models.CodeReviewVisualEvidenceDiscovery{}, fmt.Errorf("org_id, repository_id, and positive pull request number are required")
+	}
+
+	repository, err := s.repos.GetByID(ctx, orgID, repositoryID)
+	if err != nil {
+		return models.CodeReviewVisualEvidenceDiscovery{}, fmt.Errorf("load repository for code review visual evidence: %w", err)
+	}
+	token, err := s.getInstallationTokenForRepo(ctx, orgID, &repository)
+	if err != nil {
+		return models.CodeReviewVisualEvidenceDiscovery{}, fmt.Errorf("load installation token for code review visual evidence: %w", err)
+	}
+	owner, repo := splitRepo(repository.FullName)
+
+	var details githubVisualEvidencePullRequest
+	var issueComments, reviews, reviewComments []githubVisualEvidenceContent
+	group, groupCtx := errgroup.WithContext(ctx)
+	group.Go(func() error {
+		path := fmt.Sprintf("/repos/%s/%s/pulls/%d", owner, repo, number)
+		body, requestErr := s.doGitHubRequestWithAccept(groupCtx, token, http.MethodGet, path, nil, githubFullJSONMediaType)
+		if requestErr != nil {
+			return fmt.Errorf("load pull request visual evidence: %w", requestErr)
+		}
+		if decodeErr := json.Unmarshal(body, &details); decodeErr != nil {
+			return fmt.Errorf("decode pull request visual evidence: %w", decodeErr)
+		}
+		return nil
+	})
+	group.Go(func() error {
+		path := fmt.Sprintf("/repos/%s/%s/issues/%d/comments", owner, repo, number)
+		items, requestErr := s.listCodeReviewVisualEvidenceContent(groupCtx, token, path)
+		if requestErr != nil {
+			return fmt.Errorf("list pull request issue comments for visual evidence: %w", requestErr)
+		}
+		issueComments = items
+		return nil
+	})
+	group.Go(func() error {
+		path := fmt.Sprintf("/repos/%s/%s/pulls/%d/reviews", owner, repo, number)
+		items, requestErr := s.listCodeReviewVisualEvidenceContent(groupCtx, token, path)
+		if requestErr != nil {
+			return fmt.Errorf("list pull request reviews for visual evidence: %w", requestErr)
+		}
+		reviews = items
+		return nil
+	})
+	group.Go(func() error {
+		path := fmt.Sprintf("/repos/%s/%s/pulls/%d/comments", owner, repo, number)
+		items, requestErr := s.listCodeReviewVisualEvidenceContent(groupCtx, token, path)
+		if requestErr != nil {
+			return fmt.Errorf("list pull request review comments for visual evidence: %w", requestErr)
+		}
+		reviewComments = items
+		return nil
+	})
+	if err := group.Wait(); err != nil {
+		return models.CodeReviewVisualEvidenceDiscovery{}, err
+	}
+	if strings.TrimSpace(details.Head.SHA) == "" {
+		return models.CodeReviewVisualEvidenceDiscovery{}, fmt.Errorf("pull request head SHA is missing from visual evidence snapshot")
+	}
+
+	sources := make([]models.CodeReviewVisualEvidenceSource, 0)
+	descriptionAuthor := models.CodeReviewEvidenceAuthorTypeUnknown
+	descriptionLogin := ""
+	if details.User != nil {
+		descriptionAuthor = codeReviewEvidenceAuthorType(details.User.Type)
+		descriptionLogin = strings.TrimSpace(details.User.Login)
+	}
+	sources = append(sources, visualEvidenceSourcesFromHTML(visualEvidenceSourceMetadata{
+		Surface:          models.CodeReviewEvidenceSurfaceDescription,
+		ProviderObjectID: strconv.Itoa(details.Number),
+		SourceURL:        details.HTMLURL,
+		AuthorLogin:      descriptionLogin,
+		AuthorType:       descriptionAuthor,
+		CreatedAt:        details.CreatedAt,
+		UpdatedAt:        details.UpdatedAt,
+	}, details.BodyHTML)...)
+	sources = append(sources, visualEvidenceSourcesFromDiscussion(models.CodeReviewEvidenceSurfaceIssueComment, issueComments)...)
+	sources = append(sources, visualEvidenceSourcesFromDiscussion(models.CodeReviewEvidenceSurfaceReviewBody, reviews)...)
+	sources = append(sources, visualEvidenceSourcesFromDiscussion(models.CodeReviewEvidenceSurfaceReviewComment, reviewComments)...)
+
+	return models.CodeReviewVisualEvidenceDiscovery{
+		Version:           codeReviewVisualEvidenceDiscoveryVersion,
+		RepositoryID:      repositoryID,
+		Repository:        repository.FullName,
+		PullRequestNumber: number,
+		HeadSHA:           details.Head.SHA,
+		CapturedAt:        time.Now().UTC(),
+		Sources:           sources,
+	}, nil
+}
+
+func (s *PRService) listCodeReviewVisualEvidenceContent(ctx context.Context, token, basePath string) ([]githubVisualEvidenceContent, error) {
+	items := make([]githubVisualEvidenceContent, 0)
+	for page := 1; ; page++ {
+		separator := "?"
+		if strings.Contains(basePath, "?") {
+			separator = "&"
+		}
+		path := fmt.Sprintf("%s%sper_page=%d&page=%d", basePath, separator, githubVisualEvidencePageSize, page)
+		body, err := s.doGitHubRequestWithAccept(ctx, token, http.MethodGet, path, nil, githubFullJSONMediaType)
+		if err != nil {
+			return nil, err
+		}
+		var pageItems []githubVisualEvidenceContent
+		if err := json.Unmarshal(body, &pageItems); err != nil {
+			return nil, fmt.Errorf("decode GitHub visual evidence page %d: %w", page, err)
+		}
+		items = append(items, pageItems...)
+		if len(pageItems) < githubVisualEvidencePageSize {
+			break
+		}
+	}
+	sort.SliceStable(items, func(i, j int) bool {
+		iTime := visualEvidenceContentTime(items[i])
+		jTime := visualEvidenceContentTime(items[j])
+		if !iTime.Equal(jTime) {
+			return iTime.Before(jTime)
+		}
+		return items[i].ID < items[j].ID
+	})
+	return items, nil
+}
+
+func visualEvidenceContentTime(content githubVisualEvidenceContent) time.Time {
+	if content.CreatedAt != nil {
+		return *content.CreatedAt
+	}
+	if content.SubmittedAt != nil {
+		return *content.SubmittedAt
+	}
+	return time.Time{}
+}
+
+func visualEvidenceSourcesFromDiscussion(surface models.CodeReviewEvidenceSurface, content []githubVisualEvidenceContent) []models.CodeReviewVisualEvidenceSource {
+	sources := make([]models.CodeReviewVisualEvidenceSource, 0)
+	for _, item := range content {
+		if item.User == nil {
+			continue
+		}
+		authorType := codeReviewEvidenceAuthorType(item.User.Type)
+		if !authorType.IsHuman() || strings.TrimSpace(item.User.Login) == "" {
+			continue
+		}
+		createdAt := item.CreatedAt
+		if createdAt == nil {
+			createdAt = item.SubmittedAt
+		}
+		sources = append(sources, visualEvidenceSourcesFromHTML(visualEvidenceSourceMetadata{
+			Surface:           surface,
+			ProviderObjectID:  strconv.FormatInt(item.ID, 10),
+			SourceURL:         item.HTMLURL,
+			AuthorLogin:       strings.TrimSpace(item.User.Login),
+			AuthorType:        authorType,
+			AuthorAssociation: strings.TrimSpace(item.AuthorAssociation),
+			CreatedAt:         createdAt,
+			UpdatedAt:         item.UpdatedAt,
+		}, item.BodyHTML)...)
+	}
+	return sources
+}
+
+type visualEvidenceSourceMetadata struct {
+	Surface           models.CodeReviewEvidenceSurface
+	ProviderObjectID  string
+	SourceURL         string
+	AuthorLogin       string
+	AuthorType        models.CodeReviewEvidenceAuthorType
+	AuthorAssociation string
+	CreatedAt         *time.Time
+	UpdatedAt         *time.Time
+}
+
+func visualEvidenceSourcesFromHTML(metadata visualEvidenceSourceMetadata, renderedHTML string) []models.CodeReviewVisualEvidenceSource {
+	fragment, err := html.ParseFragment(strings.NewReader(renderedHTML), &html.Node{Type: html.ElementNode, Data: "div", DataAtom: atom.Div})
+	if err != nil {
+		return nil
+	}
+	sources := make([]models.CodeReviewVisualEvidenceSource, 0)
+	var walk func(*html.Node)
+	walk = func(node *html.Node) {
+		if node.Type == html.ElementNode && node.Data == "img" {
+			if imageURL := renderedImageURL(node); imageURL != "" {
+				imageIndex := len(sources) + 1
+				sources = append(sources, models.CodeReviewVisualEvidenceSource{
+					SourceID:          codeReviewVisualEvidenceSourceID(metadata.Surface, metadata.ProviderObjectID, imageIndex, imageURL),
+					Surface:           metadata.Surface,
+					ProviderObjectID:  metadata.ProviderObjectID,
+					SourceURL:         strings.TrimSpace(metadata.SourceURL),
+					AuthorLogin:       metadata.AuthorLogin,
+					AuthorType:        metadata.AuthorType,
+					AuthorAssociation: metadata.AuthorAssociation,
+					CreatedAt:         metadata.CreatedAt,
+					UpdatedAt:         metadata.UpdatedAt,
+					ImageIndex:        imageIndex,
+					ImageURL:          imageURL,
+					AltText:           strings.TrimSpace(htmlAttribute(node, "alt")),
+					ContextText:       visualEvidenceContext(node),
+					Untrusted:         true,
+				})
+			}
+		}
+		for child := node.FirstChild; child != nil; child = child.NextSibling {
+			walk(child)
+		}
+	}
+	for _, node := range fragment {
+		walk(node)
+	}
+	return sources
+}
+
+func renderedImageURL(node *html.Node) string {
+	candidates := make([]string, 0, 3)
+	if srcset := htmlAttribute(node, "srcset"); srcset != "" {
+		candidates = append(candidates, lastSrcsetURL(srcset))
+	}
+	if node.Parent != nil && node.Parent.Type == html.ElementNode && node.Parent.Data == "picture" {
+		for sibling := node.Parent.FirstChild; sibling != nil; sibling = sibling.NextSibling {
+			if sibling.Type == html.ElementNode && sibling.Data == "source" {
+				candidates = append(candidates, lastSrcsetURL(htmlAttribute(sibling, "srcset")))
+			}
+		}
+	}
+	candidates = append(candidates, htmlAttribute(node, "src"))
+	for _, candidate := range candidates {
+		if normalized := normalizeRenderedImageURL(candidate); normalized != "" {
+			return normalized
+		}
+	}
+	return ""
+}
+
+func lastSrcsetURL(srcset string) string {
+	parts := strings.Split(srcset, ",")
+	for i := len(parts) - 1; i >= 0; i-- {
+		fields := strings.Fields(strings.TrimSpace(parts[i]))
+		if len(fields) > 0 {
+			return fields[0]
+		}
+	}
+	return ""
+}
+
+func normalizeRenderedImageURL(raw string) string {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return ""
+	}
+	parsed, err := url.Parse(raw)
+	if err != nil {
+		return raw
+	}
+	if parsed.IsAbs() {
+		return parsed.String()
+	}
+	base, err := url.Parse("https://github.com")
+	if err != nil {
+		return raw
+	}
+	return base.ResolveReference(parsed).String()
+}
+
+func visualEvidenceContext(image *html.Node) string {
+	contextNode := image.Parent
+	for node := image.Parent; node != nil; node = node.Parent {
+		if node.Type == html.ElementNode {
+			switch node.Data {
+			case "p", "figure", "figcaption", "li", "blockquote":
+				contextNode = node
+				node = nil
+			}
+		}
+		if node == nil {
+			break
+		}
+	}
+	if contextNode == nil {
+		return ""
+	}
+	var textBuilder strings.Builder
+	var walkText func(*html.Node)
+	walkText = func(node *html.Node) {
+		if node.Type == html.TextNode {
+			textBuilder.WriteString(node.Data)
+			textBuilder.WriteByte(' ')
+		}
+		for child := node.FirstChild; child != nil; child = child.NextSibling {
+			walkText(child)
+		}
+	}
+	walkText(contextNode)
+	contextText := strings.Join(strings.Fields(textBuilder.String()), " ")
+	if utf8.RuneCountInString(contextText) <= maxVisualEvidenceContextRunes {
+		return contextText
+	}
+	runes := []rune(contextText)
+	return string(runes[:maxVisualEvidenceContextRunes])
+}
+
+func htmlAttribute(node *html.Node, key string) string {
+	for _, attribute := range node.Attr {
+		if strings.EqualFold(attribute.Key, key) {
+			return attribute.Val
+		}
+	}
+	return ""
+}
+
+func codeReviewEvidenceAuthorType(raw string) models.CodeReviewEvidenceAuthorType {
+	switch strings.ToLower(strings.TrimSpace(raw)) {
+	case "user":
+		return models.CodeReviewEvidenceAuthorTypeUser
+	case "mannequin":
+		return models.CodeReviewEvidenceAuthorTypeMannequin
+	case "bot":
+		return models.CodeReviewEvidenceAuthorTypeBot
+	case "app":
+		return models.CodeReviewEvidenceAuthorTypeApp
+	case "organization":
+		return models.CodeReviewEvidenceAuthorTypeOrganization
+	default:
+		return models.CodeReviewEvidenceAuthorTypeUnknown
+	}
+}
+
+func codeReviewVisualEvidenceSourceID(surface models.CodeReviewEvidenceSurface, providerObjectID string, imageIndex int, imageURL string) string {
+	digest := sha256.Sum256([]byte(fmt.Sprintf("%s\x00%s\x00%d\x00%s", surface, providerObjectID, imageIndex, imageURL)))
+	return "ves_" + hex.EncodeToString(digest[:12])
+}

--- a/internal/services/github/code_review_visual_evidence_test.go
+++ b/internal/services/github/code_review_visual_evidence_test.go
@@ -1,0 +1,274 @@
+package github
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/pashagolub/pgxmock/v4"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/require"
+
+	"github.com/assembledhq/143/internal/db"
+	"github.com/assembledhq/143/internal/models"
+)
+
+func TestDiscoverCodeReviewVisualEvidenceIncludesAllHumanSurfaces(t *testing.T) {
+	t.Parallel()
+
+	createdAt := time.Date(2026, 8, 10, 12, 0, 0, 0, time.UTC)
+	updatedAt := createdAt.Add(time.Hour)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "token installation-token", r.Header.Get("Authorization"), "visual evidence discovery should use repository installation auth")
+		require.Equal(t, githubFullJSONMediaType, r.Header.Get("Accept"), "visual evidence discovery should request GitHub-rendered HTML")
+
+		var response string
+		switch r.URL.Path {
+		case "/repos/assembledhq/assembled/pulls/42":
+			response = `{
+				"number": 42,
+				"html_url": "https://github.com/assembledhq/assembled/pull/42",
+				"body_html": "<p>Desktop state <img src=\"https://github.com/user-attachments/assets/description\" alt=\"desktop\"></p>",
+				"user": {"login": "automation-author", "type": "Bot"},
+				"created_at": "2026-08-10T12:00:00Z",
+				"updated_at": "2026-08-10T13:00:00Z",
+				"head": {"sha": "head-sha"}
+			}`
+		case "/repos/assembledhq/assembled/issues/42/comments":
+			response = `[
+				{"id": 10, "html_url": "https://github.com/assembledhq/assembled/pull/42#issuecomment-10", "body_html": "<p>Mobile state <img src=\"/user-attachments/assets/issue\" alt=\"mobile\"></p>", "user": {"login": "human", "type": "User"}, "author_association": "CONTRIBUTOR", "created_at": "2026-08-10T12:00:00Z"},
+				{"id": 11, "body_html": "<img src=\"https://example.com/bot.png\">", "user": {"login": "143-app[bot]", "type": "Bot"}},
+				{"id": 12, "html_url": "https://github.com/assembledhq/assembled/pull/42#issuecomment-12", "body_html": "<figure><img srcset=\"https://example.com/small.png 1x, https://example.com/mannequin.png 2x\"><figcaption>Imported author evidence</figcaption></figure>", "user": {"login": "legacy-human", "type": "Mannequin"}, "author_association": "NONE", "created_at": "2026-08-10T12:05:00Z"},
+				{"id": 13, "body_html": "<img src=\"https://example.com/org.png\">", "user": {"login": "assembledhq", "type": "Organization"}},
+				{"id": 14, "body_html": "<img src=\"https://example.com/deleted.png\">", "user": null}
+			]`
+		case "/repos/assembledhq/assembled/pulls/42/reviews":
+			response = `[
+				{"id": 20, "html_url": "https://github.com/assembledhq/assembled/pull/42#pullrequestreview-20", "body_html": "<p>Reviewer capture <img src=\"https://example.com/review.png\"></p>", "user": {"login": "reviewer", "type": "User"}, "author_association": "MEMBER", "submitted_at": "2026-08-10T12:10:00Z"},
+				{"id": 21, "body_html": "<img src=\"https://example.com/app.png\">", "user": {"login": "ci-app", "type": "App"}}
+			]`
+		case "/repos/assembledhq/assembled/pulls/42/comments":
+			response = `[
+				{"id": 30, "html_url": "https://github.com/assembledhq/assembled/pull/42#discussion_r30", "body_html": "<blockquote>Inline state <img src=\"//github.com/user-attachments/assets/inline\" alt=\"inline\"></blockquote>", "user": {"login": "outside-reviewer", "type": "User"}, "author_association": "NONE", "created_at": "2026-08-10T12:15:00Z"}
+			]`
+		default:
+			http.NotFound(w, r)
+			return
+		}
+		_, err := fmt.Fprint(w, response)
+		require.NoError(t, err, "GitHub visual evidence fixture should be written")
+	}))
+	t.Cleanup(server.Close)
+
+	orgID := uuid.New()
+	repositoryID := uuid.New()
+	service, mock := newVisualEvidenceTestService(t, server, orgID, repositoryID)
+
+	discovery, err := service.DiscoverCodeReviewVisualEvidence(context.Background(), orgID, repositoryID, 42)
+
+	require.NoError(t, err, "visual evidence discovery should read every supported GitHub surface")
+	require.False(t, discovery.CapturedAt.IsZero(), "visual evidence discovery should record its immutable capture time")
+	discovery.CapturedAt = time.Time{}
+	require.Equal(t, models.CodeReviewVisualEvidenceDiscovery{
+		Version:           codeReviewVisualEvidenceDiscoveryVersion,
+		RepositoryID:      repositoryID,
+		Repository:        "assembledhq/assembled",
+		PullRequestNumber: 42,
+		HeadSHA:           "head-sha",
+		Sources: []models.CodeReviewVisualEvidenceSource{
+			{
+				SourceID: codeReviewVisualEvidenceSourceID(models.CodeReviewEvidenceSurfaceDescription, "42", 1, "https://github.com/user-attachments/assets/description"),
+				Surface:  models.CodeReviewEvidenceSurfaceDescription, ProviderObjectID: "42", SourceURL: "https://github.com/assembledhq/assembled/pull/42",
+				AuthorLogin: "automation-author", AuthorType: models.CodeReviewEvidenceAuthorTypeBot, CreatedAt: &createdAt, UpdatedAt: &updatedAt,
+				ImageIndex: 1, ImageURL: "https://github.com/user-attachments/assets/description", AltText: "desktop", ContextText: "Desktop state", Untrusted: true,
+			},
+			{
+				SourceID: codeReviewVisualEvidenceSourceID(models.CodeReviewEvidenceSurfaceIssueComment, "10", 1, "https://github.com/user-attachments/assets/issue"),
+				Surface:  models.CodeReviewEvidenceSurfaceIssueComment, ProviderObjectID: "10", SourceURL: "https://github.com/assembledhq/assembled/pull/42#issuecomment-10",
+				AuthorLogin: "human", AuthorType: models.CodeReviewEvidenceAuthorTypeUser, AuthorAssociation: "CONTRIBUTOR", CreatedAt: &createdAt,
+				ImageIndex: 1, ImageURL: "https://github.com/user-attachments/assets/issue", AltText: "mobile", ContextText: "Mobile state", Untrusted: true,
+			},
+			{
+				SourceID: codeReviewVisualEvidenceSourceID(models.CodeReviewEvidenceSurfaceIssueComment, "12", 1, "https://example.com/mannequin.png"),
+				Surface:  models.CodeReviewEvidenceSurfaceIssueComment, ProviderObjectID: "12", SourceURL: "https://github.com/assembledhq/assembled/pull/42#issuecomment-12",
+				AuthorLogin: "legacy-human", AuthorType: models.CodeReviewEvidenceAuthorTypeMannequin, AuthorAssociation: "NONE", CreatedAt: ptrVisualEvidenceTime(createdAt.Add(5 * time.Minute)),
+				ImageIndex: 1, ImageURL: "https://example.com/mannequin.png", ContextText: "Imported author evidence", Untrusted: true,
+			},
+			{
+				SourceID: codeReviewVisualEvidenceSourceID(models.CodeReviewEvidenceSurfaceReviewBody, "20", 1, "https://example.com/review.png"),
+				Surface:  models.CodeReviewEvidenceSurfaceReviewBody, ProviderObjectID: "20", SourceURL: "https://github.com/assembledhq/assembled/pull/42#pullrequestreview-20",
+				AuthorLogin: "reviewer", AuthorType: models.CodeReviewEvidenceAuthorTypeUser, AuthorAssociation: "MEMBER", CreatedAt: ptrVisualEvidenceTime(createdAt.Add(10 * time.Minute)),
+				ImageIndex: 1, ImageURL: "https://example.com/review.png", ContextText: "Reviewer capture", Untrusted: true,
+			},
+			{
+				SourceID: codeReviewVisualEvidenceSourceID(models.CodeReviewEvidenceSurfaceReviewComment, "30", 1, "https://github.com/user-attachments/assets/inline"),
+				Surface:  models.CodeReviewEvidenceSurfaceReviewComment, ProviderObjectID: "30", SourceURL: "https://github.com/assembledhq/assembled/pull/42#discussion_r30",
+				AuthorLogin: "outside-reviewer", AuthorType: models.CodeReviewEvidenceAuthorTypeUser, AuthorAssociation: "NONE", CreatedAt: ptrVisualEvidenceTime(createdAt.Add(15 * time.Minute)),
+				ImageIndex: 1, ImageURL: "https://github.com/user-attachments/assets/inline", AltText: "inline", ContextText: "Inline state", Untrusted: true,
+			},
+		},
+	}, discovery, "discovery should include description evidence plus every human discussion image in deterministic surface order")
+	require.NoError(t, mock.ExpectationsWereMet(), "visual evidence discovery should use an org-scoped repository lookup")
+}
+
+func TestDiscoverCodeReviewVisualEvidencePaginatesDiscussion(t *testing.T) {
+	t.Parallel()
+
+	var secondPageRequests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var response any
+		switch r.URL.Path {
+		case "/repos/assembledhq/assembled/pulls/42":
+			response = map[string]any{"number": 42, "html_url": "https://github.com/assembledhq/assembled/pull/42", "body_html": "", "head": map[string]string{"sha": "head-sha"}}
+		case "/repos/assembledhq/assembled/issues/42/comments":
+			page, err := strconv.Atoi(r.URL.Query().Get("page"))
+			require.NoError(t, err, "issue comment request should include a numeric page")
+			if page == 1 {
+				comments := make([]map[string]any, githubVisualEvidencePageSize)
+				for index := range comments {
+					comments[index] = map[string]any{"id": index + 1, "body_html": "", "user": map[string]string{"login": "human", "type": "User"}}
+				}
+				response = comments
+			} else {
+				secondPageRequests.Add(1)
+				response = []map[string]any{{"id": 101, "html_url": "https://github.com/assembledhq/assembled/pull/42#issuecomment-101", "body_html": `<img src="https://example.com/page-two.png">`, "user": map[string]string{"login": "human", "type": "User"}}}
+			}
+		case "/repos/assembledhq/assembled/pulls/42/reviews", "/repos/assembledhq/assembled/pulls/42/comments":
+			response = []any{}
+		default:
+			http.NotFound(w, r)
+			return
+		}
+		require.NoError(t, json.NewEncoder(w).Encode(response), "paginated GitHub fixture should be encoded")
+	}))
+	t.Cleanup(server.Close)
+
+	orgID := uuid.New()
+	repositoryID := uuid.New()
+	service, mock := newVisualEvidenceTestService(t, server, orgID, repositoryID)
+
+	discovery, err := service.DiscoverCodeReviewVisualEvidence(context.Background(), orgID, repositoryID, 42)
+
+	require.NoError(t, err, "visual evidence discovery should paginate until GitHub returns a short page")
+	require.Equal(t, int32(1), secondPageRequests.Load(), "visual evidence discovery should request the second issue-comment page")
+	require.Equal(t, []models.CodeReviewVisualEvidenceSource{{
+		SourceID: codeReviewVisualEvidenceSourceID(models.CodeReviewEvidenceSurfaceIssueComment, "101", 1, "https://example.com/page-two.png"),
+		Surface:  models.CodeReviewEvidenceSurfaceIssueComment, ProviderObjectID: "101", SourceURL: "https://github.com/assembledhq/assembled/pull/42#issuecomment-101",
+		AuthorLogin: "human", AuthorType: models.CodeReviewEvidenceAuthorTypeUser, ImageIndex: 1, ImageURL: "https://example.com/page-two.png", Untrusted: true,
+	}}, discovery.Sources, "visual evidence discovery should include human images found after the first page")
+	require.NoError(t, mock.ExpectationsWereMet(), "paginated discovery should use an org-scoped repository lookup")
+}
+
+func TestDiscoverCodeReviewVisualEvidenceFailsWhenASurfaceIsUnavailable(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/repos/assembledhq/assembled/pulls/42":
+			_, err := fmt.Fprint(w, `{"number":42,"body_html":"","head":{"sha":"head-sha"}}`)
+			require.NoError(t, err, "pull request fixture should be written")
+		case "/repos/assembledhq/assembled/pulls/42/reviews":
+			http.Error(w, "temporarily unavailable", http.StatusServiceUnavailable)
+		case "/repos/assembledhq/assembled/issues/42/comments", "/repos/assembledhq/assembled/pulls/42/comments":
+			_, err := fmt.Fprint(w, `[]`)
+			require.NoError(t, err, "empty discussion fixture should be written")
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	orgID := uuid.New()
+	repositoryID := uuid.New()
+	service, mock := newVisualEvidenceTestService(t, server, orgID, repositoryID)
+
+	_, err := service.DiscoverCodeReviewVisualEvidence(context.Background(), orgID, repositoryID, 42)
+
+	require.Error(t, err, "visual evidence discovery should fail rather than silently omit an unavailable GitHub surface")
+	require.Contains(t, err.Error(), "list pull request reviews for visual evidence", "visual evidence discovery should identify the incomplete surface")
+	require.NoError(t, mock.ExpectationsWereMet(), "failed discovery should still use an org-scoped repository lookup")
+}
+
+func TestVisualEvidenceSourcesFromHTML(t *testing.T) {
+	t.Parallel()
+
+	metadata := visualEvidenceSourceMetadata{
+		Surface: models.CodeReviewEvidenceSurfaceIssueComment, ProviderObjectID: "99", AuthorLogin: "human", AuthorType: models.CodeReviewEvidenceAuthorTypeUser,
+	}
+	longContext := strings.Repeat("é", maxVisualEvidenceContextRunes+20)
+	tests := []struct {
+		name     string
+		html     string
+		expected []models.CodeReviewVisualEvidenceSource
+	}{
+		{
+			name: "extracts absolute and relative sources",
+			html: `<p>Before <img src="https://example.com/one.png" alt="one"> after</p><img src="/user-attachments/two.png">`,
+			expected: []models.CodeReviewVisualEvidenceSource{
+				{SourceID: codeReviewVisualEvidenceSourceID(metadata.Surface, "99", 1, "https://example.com/one.png"), Surface: metadata.Surface, ProviderObjectID: "99", AuthorLogin: "human", AuthorType: models.CodeReviewEvidenceAuthorTypeUser, ImageIndex: 1, ImageURL: "https://example.com/one.png", AltText: "one", ContextText: "Before after", Untrusted: true},
+				{SourceID: codeReviewVisualEvidenceSourceID(metadata.Surface, "99", 2, "https://github.com/user-attachments/two.png"), Surface: metadata.Surface, ProviderObjectID: "99", AuthorLogin: "human", AuthorType: models.CodeReviewEvidenceAuthorTypeUser, ImageIndex: 2, ImageURL: "https://github.com/user-attachments/two.png", Untrusted: true},
+			},
+		},
+		{
+			name:     "uses highest srcset candidate when src is absent",
+			html:     `<picture><source srcset="https://example.com/small.webp 1x, https://example.com/large.webp 2x"><img alt="responsive"></picture>`,
+			expected: []models.CodeReviewVisualEvidenceSource{{SourceID: codeReviewVisualEvidenceSourceID(metadata.Surface, "99", 1, "https://example.com/large.webp"), Surface: metadata.Surface, ProviderObjectID: "99", AuthorLogin: "human", AuthorType: models.CodeReviewEvidenceAuthorTypeUser, ImageIndex: 1, ImageURL: "https://example.com/large.webp", AltText: "responsive", Untrusted: true}},
+		},
+		{
+			name:     "bounds untrusted context by runes",
+			html:     `<p>` + longContext + `<img src="https://example.com/long.png"></p>`,
+			expected: []models.CodeReviewVisualEvidenceSource{{SourceID: codeReviewVisualEvidenceSourceID(metadata.Surface, "99", 1, "https://example.com/long.png"), Surface: metadata.Surface, ProviderObjectID: "99", AuthorLogin: "human", AuthorType: models.CodeReviewEvidenceAuthorTypeUser, ImageIndex: 1, ImageURL: "https://example.com/long.png", ContextText: strings.Repeat("é", maxVisualEvidenceContextRunes), Untrusted: true}},
+		},
+		{name: "ignores images without a source", html: `<p><img alt="missing"></p>`, expected: []models.CodeReviewVisualEvidenceSource{}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			actual := visualEvidenceSourcesFromHTML(metadata, tt.html)
+
+			require.Equal(t, tt.expected, actual, "rendered HTML parsing should produce the expected untrusted image sources")
+		})
+	}
+}
+
+func newVisualEvidenceTestService(t *testing.T, server *httptest.Server, orgID, repositoryID uuid.UUID) (*PRService, pgxmock.PgxPoolIface) {
+	t.Helper()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "visual evidence pgxmock pool should initialize")
+	t.Cleanup(func() { mock.Close() })
+	integrationID := uuid.New()
+	now := time.Now().UTC()
+	mock.ExpectQuery("SELECT id, org_id, integration_id, github_id").
+		WithArgs(pgx.NamedArgs{"id": repositoryID, "org_id": orgID}).
+		WillReturnRows(pgxmock.NewRows(prTestRepoColumns).AddRow(
+			repositoryID, orgID, integrationID, int64(1001), "assembledhq/assembled", "main",
+			false, nil, nil, "https://github.com/assembledhq/assembled.git", int64(456), "active",
+			nil, nil, []byte(`{}`), now, now,
+		))
+	service := &PRService{
+		tokenProvider: &Service{cache: map[int64]*cachedToken{
+			456: {Token: "installation-token", ExpiresAt: time.Now().Add(time.Hour)},
+		}},
+		repos:      db.NewRepositoryStore(mock),
+		logger:     zerolog.Nop(),
+		baseURL:    server.URL,
+		httpClient: server.Client(),
+	}
+	return service, mock
+}
+
+func ptrVisualEvidenceTime(value time.Time) *time.Time {
+	return &value
+}

--- a/internal/services/github/pr.go
+++ b/internal/services/github/pr.go
@@ -3963,6 +3963,10 @@ func (s *PRService) enqueueReinforceMemories(ctx context.Context, orgID uuid.UUI
 // --- GitHub API helpers ---
 
 func (s *PRService) doGitHubRequest(ctx context.Context, token, method, path string, body any) ([]byte, error) {
+	return s.doGitHubRequestWithAccept(ctx, token, method, path, body, "application/vnd.github+json")
+}
+
+func (s *PRService) doGitHubRequestWithAccept(ctx context.Context, token, method, path string, body any, accept string) ([]byte, error) {
 	ctx = githubtelemetry.WithRequestMetadata(ctx, s.githubRequestMetadataForToken(ctx, token))
 	var bodyReader io.Reader
 	if body != nil {
@@ -3978,7 +3982,7 @@ func (s *PRService) doGitHubRequest(ctx context.Context, token, method, path str
 		return nil, err
 	}
 	req.Header.Set("Authorization", "token "+token)
-	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("Accept", accept)
 	if body != nil {
 		req.Header.Set("Content-Type", "application/json")
 	}

--- a/migrations/000286_code_review_visual_evidence_prompt_role.down.sql
+++ b/migrations/000286_code_review_visual_evidence_prompt_role.down.sql
@@ -1,0 +1,31 @@
+ALTER TABLE code_review_prompt_records
+    DROP CONSTRAINT IF EXISTS chk_code_review_prompt_records_role;
+
+-- Historical visual-evidence records remain valid audit data after a binary
+-- rollback, so narrow the write contract without validating existing rows.
+ALTER TABLE code_review_prompt_records
+    ADD CONSTRAINT chk_code_review_prompt_records_role
+    CHECK (role IN (
+        'reviewer',
+        'orchestrator',
+        'description_policy',
+        'reviewer_output',
+        'orchestrator_output'
+    )) NOT VALID;
+
+DO $$
+BEGIN
+    IF to_regclass('code_review_prompt_artifacts') IS NOT NULL THEN
+        ALTER TABLE code_review_prompt_artifacts
+            DROP CONSTRAINT IF EXISTS chk_code_review_prompt_artifacts_role;
+        ALTER TABLE code_review_prompt_artifacts
+            ADD CONSTRAINT chk_code_review_prompt_artifacts_role
+            CHECK (role IN (
+                'reviewer',
+                'orchestrator',
+                'description_policy',
+                'reviewer_output',
+                'orchestrator_output'
+            )) NOT VALID;
+    END IF;
+END $$;

--- a/migrations/000286_code_review_visual_evidence_prompt_role.up.sql
+++ b/migrations/000286_code_review_visual_evidence_prompt_role.up.sql
@@ -1,0 +1,34 @@
+ALTER TABLE code_review_prompt_records
+    DROP CONSTRAINT IF EXISTS chk_code_review_prompt_records_role;
+
+ALTER TABLE code_review_prompt_records
+    ADD CONSTRAINT chk_code_review_prompt_records_role
+    CHECK (role IN (
+        'reviewer',
+        'orchestrator',
+        'description_policy',
+        'reviewer_output',
+        'orchestrator_output',
+        'visual_evidence'
+    ));
+
+-- Installations still draining the legacy output-naming generation retain a
+-- trigger-synchronized prompt_artifacts table. Widen both sides before the
+-- new binaries can checkpoint a visual-evidence snapshot.
+DO $$
+BEGIN
+    IF to_regclass('code_review_prompt_artifacts') IS NOT NULL THEN
+        ALTER TABLE code_review_prompt_artifacts
+            DROP CONSTRAINT IF EXISTS chk_code_review_prompt_artifacts_role;
+        ALTER TABLE code_review_prompt_artifacts
+            ADD CONSTRAINT chk_code_review_prompt_artifacts_role
+            CHECK (role IN (
+                'reviewer',
+                'orchestrator',
+                'description_policy',
+                'reviewer_output',
+                'orchestrator_output',
+                'visual_evidence'
+            ));
+    END IF;
+END $$;


### PR DESCRIPTION
## Summary
- define typed immutable visual-evidence discovery and manifest contracts
- discover rendered images from PR descriptions, issue comments, reviews, and inline review comments using live paginated GitHub APIs
- include all human `User`/`Mannequin` discussion images while excluding bots, Apps, organizations, and deleted actors
- add the prompt-record role and org-scoped idempotency lookup required for later manifest persistence
- record the direct-launch, multi-PR implementation contract

## Verification
- `go test ./internal/models ./internal/db ./internal/services/github`
- `go vet ./internal/models ./internal/db ./internal/services/github`
- `make lint-tenancy`
- `git diff --cached --check`

## Stack
1. This PR: discovery and persistence contracts
2. Secure image materialization and immutable manifest checkpoint
3. Reviewer/orchestrator attachments and structured assessment contract
4. Evidence UI, observability, docs, and launch verification
