### PR TITLE
Securely materialize code review visual evidence

### DIFF
--- a/docs/design/future/124-code-review-visual-evidence.md
+++ b/docs/design/future/124-code-review-visual-evidence.md
@@ -120,6 +120,13 @@ SSRF-safe client. Resolve and revalidate every redirect target and reject
 loopback, private, link-local, multicast, unspecified, and cloud-metadata
 addresses.
 
+A private-repository spike on 2026-08-12 confirmed the current attachment
+flow: the canonical `github.com/user-attachments/assets/...` request returns
+404 without authorization, returns a redirect with installation authorization,
+and lands on a signed `*.s3.amazonaws.com` URL. The implementation therefore
+sends installation authorization only to the exact GitHub user-attachment
+route and rebuilds each redirect request without that header.
+
 Validate decoded magic bytes instead of trusting URL extensions or response
 headers. Initially accept PNG, JPEG, GIF, and WebP. Reject SVG rather than
 passing active vector content to agents. Enforce:

--- a/internal/db/code_reviews.go
+++ b/internal/db/code_reviews.go
@@ -2338,6 +2338,45 @@ func (s *CodeReviewStore) CreatePromptRecord(ctx context.Context, record *models
 	return nil
 }
 
+// CreatePromptRecordIfAbsent persists an immutable prompt/evidence checkpoint.
+// When another worker won the same org-scoped record key, it returns that
+// existing record without overwriting mutable GitHub evidence captured first.
+func (s *CodeReviewStore) CreatePromptRecordIfAbsent(ctx context.Context, record *models.CodeReviewPromptRecord) (bool, error) {
+	rows, err := s.db.Query(ctx, `
+		INSERT INTO code_review_prompt_records (
+			org_id, session_id, record_key, role, agent_provider, content, metadata
+		) VALUES (
+			@org_id, @session_id, @record_key, @role, @agent_provider, @content, COALESCE(@metadata, '{}'::jsonb)
+		)
+		ON CONFLICT (org_id, record_key) DO NOTHING
+		RETURNING `+codeReviewPromptRecordColumns, pgx.NamedArgs{
+		"org_id":         record.OrgID,
+		"session_id":     record.SessionID,
+		"record_key":     record.RecordKey,
+		"role":           record.Role,
+		"agent_provider": record.AgentProvider,
+		"content":        record.Content,
+		"metadata":       record.Metadata,
+	})
+	if err != nil {
+		return false, fmt.Errorf("create immutable code review prompt record: %w", err)
+	}
+	created, err := collectOneCodeReviewPromptRecord(rows)
+	if err == nil {
+		*record = created
+		return true, nil
+	}
+	if !errors.Is(err, pgx.ErrNoRows) {
+		return false, err
+	}
+	existing, err := s.GetPromptRecordByKey(ctx, record.OrgID, record.RecordKey)
+	if err != nil {
+		return false, fmt.Errorf("load existing immutable code review prompt record: %w", err)
+	}
+	*record = existing
+	return false, nil
+}
+
 func (s *CodeReviewStore) ListPromptRecords(ctx context.Context, orgID, sessionID uuid.UUID) ([]models.CodeReviewPromptRecord, error) {
 	rows, err := s.db.Query(ctx, `
 		SELECT `+codeReviewPromptRecordColumns+`

--- a/internal/db/code_reviews_test.go
+++ b/internal/db/code_reviews_test.go
@@ -250,6 +250,60 @@ func TestCodeReviewStore_GetPromptRecordByKeyFiltersByOrg(t *testing.T) {
 	require.NoError(t, mock.ExpectationsWereMet(), "prompt-record lookup should include the tenant boundary")
 }
 
+func TestCodeReviewStore_CreatePromptRecordIfAbsent(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name            string
+		conflict        bool
+		expectedCreated bool
+	}{
+		{name: "creates the first immutable record", expectedCreated: true},
+		{name: "restores the winner after a conflict", conflict: true, expectedCreated: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			orgID, sessionID, recordID := uuid.New(), uuid.New(), uuid.New()
+			now := time.Date(2026, 8, 12, 12, 0, 0, 0, time.UTC)
+			recordKey := "code-review-prompts/session/head/visual-evidence-v1"
+			metadata := json.RawMessage(`{"version":1}`)
+			record := &models.CodeReviewPromptRecord{
+				OrgID: orgID, SessionID: sessionID, RecordKey: recordKey, Role: "visual_evidence",
+				Content: "captured 1 image", Metadata: metadata,
+			}
+			mock, err := pgxmock.NewPool()
+			require.NoError(t, err, "pgxmock should initialize")
+			defer mock.Close()
+			insertRows := pgxmock.NewRows([]string{"id", "org_id", "session_id", "record_key", "role", "agent_provider", "content", "metadata", "created_at"})
+			if !tt.conflict {
+				insertRows.AddRow(recordID, orgID, sessionID, recordKey, "visual_evidence", "", record.Content, metadata, now)
+			}
+			mock.ExpectQuery("INSERT INTO code_review_prompt_records").
+				WithArgs(orgID, sessionID, recordKey, "visual_evidence", "", record.Content, metadata).
+				WillReturnRows(insertRows)
+			if tt.conflict {
+				mock.ExpectQuery("SELECT .+ FROM code_review_prompt_records").
+					WithArgs(pgx.NamedArgs{"org_id": orgID, "record_key": recordKey}).
+					WillReturnRows(pgxmock.NewRows([]string{"id", "org_id", "session_id", "record_key", "role", "agent_provider", "content", "metadata", "created_at"}).
+						AddRow(recordID, orgID, sessionID, recordKey, "visual_evidence", "", "winner content", metadata, now))
+			}
+
+			created, err := NewCodeReviewStore(mock).CreatePromptRecordIfAbsent(context.Background(), record)
+
+			require.NoError(t, err, "CreatePromptRecordIfAbsent should preserve one immutable winner")
+			require.Equal(t, tt.expectedCreated, created, "CreatePromptRecordIfAbsent should report whether this call inserted the record")
+			require.Equal(t, recordID, record.ID, "CreatePromptRecordIfAbsent should return the persisted record identity")
+			if tt.conflict {
+				require.Equal(t, "winner content", record.Content, "a conflicting capture should restore rather than overwrite the first snapshot")
+			}
+			require.NoError(t, mock.ExpectationsWereMet(), "immutable prompt-record expectations should be met")
+		})
+	}
+}
+
 func TestCodeReviewStore_GetActiveGitHubTriggerFiltersByOrgAndRepo(t *testing.T) {
 	t.Parallel()
 

--- a/internal/metrics/code_review_visual_evidence.go
+++ b/internal/metrics/code_review_visual_evidence.go
@@ -1,0 +1,100 @@
+package metrics
+
+import (
+	"context"
+	"sync"
+
+	"go.opentelemetry.io/otel"
+	otelmetric "go.opentelemetry.io/otel/metric"
+)
+
+var (
+	codeReviewVisualEvidenceOnce sync.Once
+	codeReviewVisualEvidence     struct {
+		captures      otelmetric.Int64Counter
+		images        otelmetric.Int64Counter
+		bytes         otelmetric.Int64Histogram
+		fetchDuration otelmetric.Float64Histogram
+	}
+)
+
+func initCodeReviewVisualEvidenceMetrics() {
+	codeReviewVisualEvidenceOnce.Do(func() {
+		meter := otel.Meter("github.com/assembledhq/143/code_review_visual_evidence")
+		captures, capturesErr := meter.Int64Counter("code_review.visual_evidence.captures", otelmetric.WithUnit("{capture}"))
+		if capturesErr == nil {
+			codeReviewVisualEvidence.captures = captures
+		}
+		images, imagesErr := meter.Int64Counter("code_review.visual_evidence.images", otelmetric.WithUnit("{image}"))
+		if imagesErr == nil {
+			codeReviewVisualEvidence.images = images
+		}
+		bytesHistogram, bytesErr := meter.Int64Histogram("code_review.visual_evidence.image_bytes", otelmetric.WithUnit("By"))
+		if bytesErr == nil {
+			codeReviewVisualEvidence.bytes = bytesHistogram
+		}
+		fetchDuration, durationErr := meter.Float64Histogram("code_review.visual_evidence.fetch_duration", otelmetric.WithUnit("s"))
+		if durationErr == nil {
+			codeReviewVisualEvidence.fetchDuration = fetchDuration
+		}
+	})
+}
+
+// RecordCodeReviewVisualEvidenceCapture records bounded manifest-level state.
+// Organization, repository, source URLs, and untrusted PR copy are never metric
+// attributes.
+func RecordCodeReviewVisualEvidenceCapture(ctx context.Context, discovered, persisted int, complete, overflow, restored bool) {
+	initCodeReviewVisualEvidenceMetrics()
+	if codeReviewVisualEvidence.captures == nil {
+		return
+	}
+	codeReviewVisualEvidence.captures.Add(ctx, 1, otelmetric.WithAttributes(
+		attrString("complete", boolMetricValue(complete)),
+		attrString("overflow", boolMetricValue(overflow)),
+		attrString("restored", boolMetricValue(restored)),
+		attrString("discovered_bucket", visualEvidenceCountBucket(discovered)),
+		attrString("persisted_bucket", visualEvidenceCountBucket(persisted)),
+	))
+}
+
+// RecordCodeReviewVisualEvidenceImage records one manifest item's bounded
+// outcome without emitting its URL, author, caption, or tenant identifiers.
+func RecordCodeReviewVisualEvidenceImage(ctx context.Context, surface, status, hostClass string, byteSize int64, durationSeconds float64) {
+	initCodeReviewVisualEvidenceMetrics()
+	attributes := otelmetric.WithAttributes(
+		attrString("surface", surface), attrString("status", status), attrString("host_class", hostClass),
+	)
+	if codeReviewVisualEvidence.images != nil {
+		codeReviewVisualEvidence.images.Add(ctx, 1, attributes)
+	}
+	if codeReviewVisualEvidence.bytes != nil && byteSize > 0 {
+		codeReviewVisualEvidence.bytes.Record(ctx, byteSize, attributes)
+	}
+	if codeReviewVisualEvidence.fetchDuration != nil && durationSeconds > 0 {
+		codeReviewVisualEvidence.fetchDuration.Record(ctx, durationSeconds, attributes)
+	}
+}
+
+func boolMetricValue(value bool) string {
+	if value {
+		return "true"
+	}
+	return "false"
+}
+
+func visualEvidenceCountBucket(count int) string {
+	switch {
+	case count <= 0:
+		return "0"
+	case count == 1:
+		return "1"
+	case count <= 4:
+		return "2_4"
+	case count <= 16:
+		return "5_16"
+	case count <= 32:
+		return "17_32"
+	default:
+		return "33_plus"
+	}
+}

--- a/internal/models/code_review_test.go
+++ b/internal/models/code_review_test.go
@@ -3,7 +3,9 @@ package models
 import (
 	"strings"
 	"testing"
+	"time"
 
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 )
 
@@ -98,6 +100,40 @@ func TestCodeReviewEvidenceAuthorTypeIsHuman(t *testing.T) {
 			require.Equal(t, tt.expected, tt.authorType.IsHuman(), "author classification should admit only human GitHub actor types")
 		})
 	}
+}
+
+func TestCodeReviewVisualEvidenceSnapshotCanonicalHash(t *testing.T) {
+	t.Parallel()
+
+	repositoryID := uuid.New()
+	base := CodeReviewVisualEvidenceSnapshot{
+		Version: 1, RepositoryID: repositoryID, Repository: "acme/web", PullRequestNumber: 42,
+		HeadSHA: strings.Repeat("a", 40), CapturedAt: time.Date(2026, 8, 12, 12, 0, 0, 0, time.UTC), Complete: true,
+		Evidence: []CodeReviewVisualEvidence{{
+			EvidenceID: "ve_1", Source: CodeReviewVisualEvidenceSource{
+				SourceID: "ves_1", Surface: CodeReviewEvidenceSurfaceIssueComment, ProviderObjectID: "99", ImageIndex: 1,
+				ImageURL: "https://github.com/user-attachments/assets/original", AltText: "untrusted caption", Untrusted: true,
+			},
+			OriginalURL: "https://github.com/user-attachments/assets/original", StorageKey: "org/code-review-evidence/session/hash.png",
+			StoredURL: "/api/v1/uploads/files/old", ContentSHA256: strings.Repeat("b", 64), ContentType: "image/png",
+			ByteSize: 100, Width: 10, Height: 10, Status: CodeReviewVisualEvidenceFetchStatusAvailable,
+		}},
+	}
+	mutableCopy := base
+	mutableCopy.CapturedAt = base.CapturedAt.Add(time.Hour)
+	mutableCopy.Evidence = append([]CodeReviewVisualEvidence(nil), base.Evidence...)
+	mutableCopy.Evidence[0].StoredURL = "/api/v1/uploads/files/new"
+	contentCopy := mutableCopy
+	contentCopy.Evidence = append([]CodeReviewVisualEvidence(nil), mutableCopy.Evidence...)
+	contentCopy.Evidence[0].ContentSHA256 = strings.Repeat("c", 64)
+	untrustedCopy := mutableCopy
+	untrustedCopy.Evidence = append([]CodeReviewVisualEvidence(nil), mutableCopy.Evidence...)
+	untrustedCopy.Evidence[0].Source.AltText = "edited captured caption"
+
+	require.NotEmpty(t, base.CanonicalHash(), "canonical visual-evidence hash should be available for a valid snapshot")
+	require.Equal(t, base.CanonicalHash(), mutableCopy.CanonicalHash(), "canonical visual-evidence hash should exclude mutable first-party URLs and capture timing")
+	require.NotEqual(t, base.CanonicalHash(), contentCopy.CanonicalHash(), "canonical visual-evidence hash should change when captured image content changes")
+	require.NotEqual(t, base.CanonicalHash(), untrustedCopy.CanonicalHash(), "canonical visual-evidence hash should change when captured untrusted context changes")
 }
 
 func TestCodeReviewFindingSeverityIsBlocking(t *testing.T) {

--- a/internal/models/code_review_visual_evidence.go
+++ b/internal/models/code_review_visual_evidence.go
@@ -1,7 +1,11 @@
 package models
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -120,18 +124,19 @@ type CodeReviewVisualEvidenceDiscovery struct {
 // discovered source. Available evidence always points to first-party storage;
 // OriginalURL remains provenance only and must not be passed to an LLM client.
 type CodeReviewVisualEvidence struct {
-	EvidenceID    string                              `json:"evidence_id"`
-	Source        CodeReviewVisualEvidenceSource      `json:"source"`
-	OriginalURL   string                              `json:"original_url"`
-	StorageKey    string                              `json:"storage_key,omitempty"`
-	StoredURL     string                              `json:"stored_url,omitempty"`
-	ContentSHA256 string                              `json:"content_sha256,omitempty"`
-	ContentType   string                              `json:"content_type,omitempty"`
-	ByteSize      int64                               `json:"byte_size,omitempty"`
-	Width         int                                 `json:"width,omitempty"`
-	Height        int                                 `json:"height,omitempty"`
-	Status        CodeReviewVisualEvidenceFetchStatus `json:"status"`
-	FailureReason string                              `json:"failure_reason,omitempty"`
+	EvidenceID            string                              `json:"evidence_id"`
+	Source                CodeReviewVisualEvidenceSource      `json:"source"`
+	OriginalURL           string                              `json:"original_url"`
+	StorageKey            string                              `json:"storage_key,omitempty"`
+	StoredURL             string                              `json:"stored_url,omitempty"`
+	ContentSHA256         string                              `json:"content_sha256,omitempty"`
+	ContentType           string                              `json:"content_type,omitempty"`
+	ByteSize              int64                               `json:"byte_size,omitempty"`
+	Width                 int                                 `json:"width,omitempty"`
+	Height                int                                 `json:"height,omitempty"`
+	Status                CodeReviewVisualEvidenceFetchStatus `json:"status"`
+	DuplicateOfEvidenceID string                              `json:"duplicate_of_evidence_id,omitempty"`
+	FailureReason         string                              `json:"failure_reason,omitempty"`
 }
 
 // CodeReviewVisualEvidenceSnapshot is the immutable manifest shared by every
@@ -146,4 +151,69 @@ type CodeReviewVisualEvidenceSnapshot struct {
 	Complete          bool                       `json:"complete"`
 	Overflow          bool                       `json:"overflow"`
 	Evidence          []CodeReviewVisualEvidence `json:"evidence"`
+}
+
+// CanonicalHash binds a description assessment to immutable evidence identity
+// and content while deliberately excluding capture timestamps and mutable
+// first-party URLs.
+func (s CodeReviewVisualEvidenceSnapshot) CanonicalHash() string {
+	type canonicalEvidence struct {
+		EvidenceID            string                              `json:"evidence_id"`
+		SourceID              string                              `json:"source_id"`
+		Surface               CodeReviewEvidenceSurface           `json:"surface"`
+		ProviderObjectID      string                              `json:"provider_object_id"`
+		SourceURL             string                              `json:"source_url"`
+		AuthorLogin           string                              `json:"author_login,omitempty"`
+		AuthorType            CodeReviewEvidenceAuthorType        `json:"author_type"`
+		AuthorAssociation     string                              `json:"author_association,omitempty"`
+		CreatedAt             *time.Time                          `json:"created_at,omitempty"`
+		UpdatedAt             *time.Time                          `json:"updated_at,omitempty"`
+		ImageIndex            int                                 `json:"image_index"`
+		OriginalURL           string                              `json:"original_url"`
+		AltText               string                              `json:"alt_text,omitempty"`
+		ContextText           string                              `json:"context_text,omitempty"`
+		Untrusted             bool                                `json:"untrusted"`
+		ContentSHA256         string                              `json:"content_sha256,omitempty"`
+		ContentType           string                              `json:"content_type,omitempty"`
+		ByteSize              int64                               `json:"byte_size,omitempty"`
+		Width                 int                                 `json:"width,omitempty"`
+		Height                int                                 `json:"height,omitempty"`
+		Status                CodeReviewVisualEvidenceFetchStatus `json:"status"`
+		DuplicateOfEvidenceID string                              `json:"duplicate_of_evidence_id,omitempty"`
+	}
+	type canonicalSnapshot struct {
+		Version           int                 `json:"version"`
+		RepositoryID      uuid.UUID           `json:"repository_id"`
+		Repository        string              `json:"repository"`
+		PullRequestNumber int                 `json:"pull_request_number"`
+		HeadSHA           string              `json:"head_sha"`
+		Complete          bool                `json:"complete"`
+		Overflow          bool                `json:"overflow"`
+		Evidence          []canonicalEvidence `json:"evidence"`
+	}
+	canonical := canonicalSnapshot{
+		Version: s.Version, RepositoryID: s.RepositoryID, Repository: s.Repository, PullRequestNumber: s.PullRequestNumber,
+		HeadSHA: strings.ToLower(strings.TrimSpace(s.HeadSHA)), Complete: s.Complete, Overflow: s.Overflow,
+		Evidence: make([]canonicalEvidence, 0, len(s.Evidence)),
+	}
+	for _, evidence := range s.Evidence {
+		canonical.Evidence = append(canonical.Evidence, canonicalEvidence{
+			EvidenceID: evidence.EvidenceID, SourceID: evidence.Source.SourceID, Surface: evidence.Source.Surface,
+			ProviderObjectID: evidence.Source.ProviderObjectID, SourceURL: evidence.Source.SourceURL,
+			AuthorLogin: evidence.Source.AuthorLogin, AuthorType: evidence.Source.AuthorType,
+			AuthorAssociation: evidence.Source.AuthorAssociation, CreatedAt: evidence.Source.CreatedAt,
+			UpdatedAt: evidence.Source.UpdatedAt, ImageIndex: evidence.Source.ImageIndex,
+			OriginalURL: evidence.OriginalURL, AltText: evidence.Source.AltText, ContextText: evidence.Source.ContextText,
+			Untrusted:     evidence.Source.Untrusted,
+			ContentSHA256: evidence.ContentSHA256, ContentType: evidence.ContentType, ByteSize: evidence.ByteSize,
+			Width: evidence.Width, Height: evidence.Height, Status: evidence.Status,
+			DuplicateOfEvidenceID: evidence.DuplicateOfEvidenceID,
+		})
+	}
+	encoded, err := json.Marshal(canonical)
+	if err != nil {
+		return ""
+	}
+	digest := sha256.Sum256(encoded)
+	return hex.EncodeToString(digest[:])
 }

--- a/internal/services/codereview/visual_evidence.go
+++ b/internal/services/codereview/visual_evidence.go
@@ -1,0 +1,466 @@
+package codereview
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/url"
+	"path"
+	"regexp"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/rs/zerolog"
+
+	"github.com/assembledhq/143/internal/metrics"
+	"github.com/assembledhq/143/internal/models"
+	"github.com/assembledhq/143/internal/services/storage"
+)
+
+const (
+	visualEvidenceSnapshotVersion = 1
+	visualEvidencePromptRole      = "visual_evidence"
+	visualEvidenceMaxImages       = 32
+	visualEvidenceMaxTotalBytes   = 64 << 20
+	visualEvidenceConcurrency     = 4
+)
+
+var visualEvidenceHeadSHA = regexp.MustCompile(`^[0-9a-fA-F]{40}([0-9a-fA-F]{24})?$`)
+var visualEvidenceContentSHA = regexp.MustCompile(`^[0-9a-f]{64}$`)
+
+type VisualEvidenceDiscoverer interface {
+	DiscoverCodeReviewVisualEvidence(ctx context.Context, orgID, repositoryID uuid.UUID, number int) (models.CodeReviewVisualEvidenceDiscovery, error)
+}
+
+type VisualEvidencePromptStore interface {
+	GetPromptRecordByKey(ctx context.Context, orgID uuid.UUID, recordKey string) (models.CodeReviewPromptRecord, error)
+	CreatePromptRecordIfAbsent(ctx context.Context, record *models.CodeReviewPromptRecord) (bool, error)
+}
+
+type VisualEvidenceRepositoryStore interface {
+	GetByID(ctx context.Context, orgID, repositoryID uuid.UUID) (models.Repository, error)
+}
+
+type VisualEvidenceService struct {
+	discoverer VisualEvidenceDiscoverer
+	prompts    VisualEvidencePromptStore
+	repos      VisualEvidenceRepositoryStore
+	tokens     InstallationTokenProvider
+	uploads    storage.UploadStore
+	downloader *visualEvidenceDownloader
+	logger     zerolog.Logger
+	maxImages  int
+	maxBytes   int64
+	concurrent int
+}
+
+type CaptureVisualEvidenceInput struct {
+	OrgID             uuid.UUID
+	SessionID         uuid.UUID
+	RepositoryID      uuid.UUID
+	PullRequestNumber int
+	HeadSHA           string
+}
+
+func NewVisualEvidenceService(
+	discoverer VisualEvidenceDiscoverer,
+	prompts VisualEvidencePromptStore,
+	repos VisualEvidenceRepositoryStore,
+	tokens InstallationTokenProvider,
+	uploads storage.UploadStore,
+	logger zerolog.Logger,
+) *VisualEvidenceService {
+	return &VisualEvidenceService{
+		discoverer: discoverer,
+		prompts:    prompts,
+		repos:      repos,
+		tokens:     tokens,
+		uploads:    uploads,
+		downloader: newVisualEvidenceDownloader(),
+		logger:     logger,
+		maxImages:  visualEvidenceMaxImages,
+		maxBytes:   visualEvidenceMaxTotalBytes,
+		concurrent: visualEvidenceConcurrency,
+	}
+}
+
+func (s *VisualEvidenceService) Capture(ctx context.Context, input CaptureVisualEvidenceInput) (models.CodeReviewVisualEvidenceSnapshot, error) {
+	input.HeadSHA = strings.ToLower(strings.TrimSpace(input.HeadSHA))
+	if input.OrgID == uuid.Nil || input.SessionID == uuid.Nil || input.RepositoryID == uuid.Nil || input.PullRequestNumber <= 0 || !visualEvidenceHeadSHA.MatchString(input.HeadSHA) {
+		return models.CodeReviewVisualEvidenceSnapshot{}, fmt.Errorf("org_id, session_id, repository_id, positive pull request number, and a full Git head SHA are required")
+	}
+	if s == nil || s.discoverer == nil || s.prompts == nil || s.repos == nil || s.uploads == nil || s.downloader == nil {
+		return models.CodeReviewVisualEvidenceSnapshot{}, fmt.Errorf("code review visual evidence service is not configured")
+	}
+	if s.maxImages <= 0 || s.maxBytes <= 0 || s.concurrent <= 0 || s.concurrent > visualEvidenceConcurrency {
+		return models.CodeReviewVisualEvidenceSnapshot{}, fmt.Errorf("code review visual evidence resource limits are invalid")
+	}
+
+	recordKey := visualEvidenceRecordKey(input.SessionID, input.HeadSHA)
+	record, err := s.prompts.GetPromptRecordByKey(ctx, input.OrgID, recordKey)
+	if err == nil {
+		restored, restoreErr := restoreVisualEvidenceSnapshot(record, input)
+		if restoreErr == nil {
+			metrics.RecordCodeReviewVisualEvidenceCapture(ctx, len(restored.Evidence), len(restored.Evidence), restored.Complete, restored.Overflow, true)
+		}
+		return restored, restoreErr
+	}
+	if !errors.Is(err, pgx.ErrNoRows) {
+		return models.CodeReviewVisualEvidenceSnapshot{}, fmt.Errorf("load code review visual evidence checkpoint: %w", err)
+	}
+
+	discovery, err := s.discoverer.DiscoverCodeReviewVisualEvidence(ctx, input.OrgID, input.RepositoryID, input.PullRequestNumber)
+	if err != nil {
+		return models.CodeReviewVisualEvidenceSnapshot{}, fmt.Errorf("discover code review visual evidence: %w", err)
+	}
+	if err := validateVisualEvidenceDiscovery(discovery, input); err != nil {
+		return models.CodeReviewVisualEvidenceSnapshot{}, err
+	}
+
+	token := ""
+	if discoveryNeedsGitHubAssetToken(discovery) {
+		repository, repoErr := s.repos.GetByID(ctx, input.OrgID, input.RepositoryID)
+		if repoErr != nil {
+			return models.CodeReviewVisualEvidenceSnapshot{}, fmt.Errorf("load repository for private visual evidence: %w", repoErr)
+		}
+		if repository.InstallationID == 0 || s.tokens == nil {
+			return models.CodeReviewVisualEvidenceSnapshot{}, fmt.Errorf("GitHub installation auth is unavailable for visual evidence")
+		}
+		token, err = s.tokens.GetInstallationToken(ctx, repository.InstallationID)
+		if err != nil {
+			return models.CodeReviewVisualEvidenceSnapshot{}, fmt.Errorf("load GitHub installation token for visual evidence: %w", err)
+		}
+	}
+
+	snapshot := s.materialize(ctx, input, discovery, token)
+	metadata, err := json.Marshal(snapshot)
+	if err != nil {
+		return models.CodeReviewVisualEvidenceSnapshot{}, fmt.Errorf("encode code review visual evidence manifest: %w", err)
+	}
+	record = models.CodeReviewPromptRecord{
+		OrgID: input.OrgID, SessionID: input.SessionID, RecordKey: recordKey, Role: visualEvidencePromptRole,
+		Content: visualEvidenceSummary(snapshot), Metadata: metadata,
+	}
+	created, err := s.prompts.CreatePromptRecordIfAbsent(ctx, &record)
+	if err != nil {
+		return models.CodeReviewVisualEvidenceSnapshot{}, fmt.Errorf("persist code review visual evidence checkpoint: %w", err)
+	}
+	persisted, err := restoreVisualEvidenceSnapshot(record, input)
+	if err != nil {
+		return models.CodeReviewVisualEvidenceSnapshot{}, err
+	}
+	metrics.RecordCodeReviewVisualEvidenceCapture(ctx, len(discovery.Sources), len(persisted.Evidence), persisted.Complete, persisted.Overflow, !created)
+	return persisted, nil
+}
+
+func validateVisualEvidenceDiscovery(discovery models.CodeReviewVisualEvidenceDiscovery, input CaptureVisualEvidenceInput) error {
+	if discovery.Version != visualEvidenceSnapshotVersion || discovery.RepositoryID != input.RepositoryID ||
+		discovery.PullRequestNumber != input.PullRequestNumber || strings.TrimSpace(discovery.Repository) == "" || discovery.CapturedAt.IsZero() {
+		return fmt.Errorf("visual evidence discovery identity is invalid")
+	}
+	if !strings.EqualFold(strings.TrimSpace(discovery.HeadSHA), input.HeadSHA) {
+		return fmt.Errorf("visual evidence head changed during capture")
+	}
+	seenSourceIDs := make(map[string]struct{}, len(discovery.Sources))
+	for _, source := range discovery.Sources {
+		if strings.TrimSpace(source.SourceID) == "" || strings.TrimSpace(source.ProviderObjectID) == "" || strings.TrimSpace(source.ImageURL) == "" || source.ImageIndex <= 0 || !source.Untrusted {
+			return fmt.Errorf("visual evidence discovery contains invalid or trusted source metadata")
+		}
+		if _, duplicate := seenSourceIDs[source.SourceID]; duplicate {
+			return fmt.Errorf("visual evidence discovery contains duplicate source IDs")
+		}
+		seenSourceIDs[source.SourceID] = struct{}{}
+		if err := source.Surface.Validate(); err != nil {
+			return err
+		}
+		if err := source.AuthorType.Validate(); err != nil {
+			return err
+		}
+		if source.Surface != models.CodeReviewEvidenceSurfaceDescription && !source.AuthorType.IsHuman() {
+			return fmt.Errorf("visual evidence discovery contains non-human discussion content")
+		}
+		if source.Surface != models.CodeReviewEvidenceSurfaceDescription && strings.TrimSpace(source.AuthorLogin) == "" {
+			return fmt.Errorf("visual evidence discovery contains discussion content without a human author")
+		}
+	}
+	return nil
+}
+
+func (s *VisualEvidenceService) materialize(ctx context.Context, input CaptureVisualEvidenceInput, discovery models.CodeReviewVisualEvidenceDiscovery, token string) models.CodeReviewVisualEvidenceSnapshot {
+	snapshot := models.CodeReviewVisualEvidenceSnapshot{
+		Version: visualEvidenceSnapshotVersion, RepositoryID: input.RepositoryID, Repository: discovery.Repository,
+		PullRequestNumber: input.PullRequestNumber, HeadSHA: input.HeadSHA, CapturedAt: discovery.CapturedAt,
+		Complete: true, Overflow: len(discovery.Sources) > s.maxImages,
+		Evidence: make([]models.CodeReviewVisualEvidence, 0, len(discovery.Sources)),
+	}
+
+	eligibleCount := len(discovery.Sources)
+	if eligibleCount > s.maxImages {
+		eligibleCount = s.maxImages
+	}
+	uniqueURLs := make([]string, 0, eligibleCount)
+	urlIndexes := make(map[string]int, eligibleCount)
+	firstSourceIndexes := make([]int, 0, eligibleCount)
+	for index := 0; index < eligibleCount; index++ {
+		originalURL := strings.TrimSpace(discovery.Sources[index].ImageURL)
+		if _, exists := urlIndexes[originalURL]; exists {
+			continue
+		}
+		urlIndexes[originalURL] = len(uniqueURLs)
+		uniqueURLs = append(uniqueURLs, originalURL)
+		firstSourceIndexes = append(firstSourceIndexes, index)
+	}
+
+	type storedContent struct {
+		key        string
+		url        string
+		evidenceID string
+	}
+	type preparedURL struct {
+		contentSHA256         string
+		contentType           string
+		byteSize              int64
+		width                 int
+		height                int
+		status                models.CodeReviewVisualEvidenceFetchStatus
+		failureReason         string
+		hostClass             string
+		duration              time.Duration
+		storageKey            string
+		storedURL             string
+		firstEvidenceID       string
+		duplicateOfEvidenceID string
+	}
+	preparedURLs := make([]preparedURL, len(uniqueURLs))
+	storedByHash := make(map[string]storedContent)
+	var acceptedBytes int64
+	for batchStart := 0; batchStart < len(uniqueURLs); batchStart += s.concurrent {
+		batchEnd := batchStart + s.concurrent
+		if batchEnd > len(uniqueURLs) {
+			batchEnd = len(uniqueURLs)
+		}
+		batchResults := make([]visualEvidenceFetchResult, batchEnd-batchStart)
+		var waitGroup sync.WaitGroup
+		for index := batchStart; index < batchEnd; index++ {
+			index := index
+			waitGroup.Add(1)
+			go func() {
+				defer waitGroup.Done()
+				batchResults[index-batchStart] = s.downloader.fetch(ctx, uniqueURLs[index], token)
+			}()
+		}
+		waitGroup.Wait()
+
+		for index := batchStart; index < batchEnd; index++ {
+			result := batchResults[index-batchStart]
+			firstSource := discovery.Sources[firstSourceIndexes[index]]
+			prepared := preparedURL{
+				contentSHA256: result.contentSHA256, contentType: result.contentType, byteSize: result.byteSize,
+				width: result.width, height: result.height, status: result.status, failureReason: result.failureReason,
+				hostClass: result.hostClass, duration: result.duration,
+			}
+			prepared.firstEvidenceID = visualEvidenceID(firstSource.SourceID, prepared.contentSHA256, prepared.status)
+			if result.status == models.CodeReviewVisualEvidenceFetchStatusAvailable {
+				if stored, duplicate := storedByHash[result.contentSHA256]; duplicate {
+					prepared.storageKey = stored.key
+					prepared.storedURL = stored.url
+					prepared.duplicateOfEvidenceID = stored.evidenceID
+				} else if acceptedBytes+int64(len(result.data)) > s.maxBytes {
+					prepared.status = models.CodeReviewVisualEvidenceFetchStatusOverLimit
+					prepared.failureReason = fmt.Sprintf("assessment exceeds the %d byte aggregate image limit", s.maxBytes)
+					prepared.firstEvidenceID = visualEvidenceID(firstSource.SourceID, prepared.contentSHA256, prepared.status)
+					snapshot.Overflow = true
+				} else {
+					extension := visualEvidenceExtension(result.contentType)
+					key := fmt.Sprintf("%s/code-review-evidence/%s/%s%s", input.OrgID, input.SessionID, result.contentSHA256, extension)
+					storedURL, saveErr := s.uploads.Save(ctx, key, bytes.NewReader(result.data), result.contentType)
+					if saveErr != nil {
+						s.logger.Warn().
+							Str("org_id", input.OrgID.String()).
+							Str("session_id", input.SessionID.String()).
+							Str("source_id", firstSource.SourceID).
+							Msg("failed to persist code review visual evidence in first-party storage")
+						prepared.status = models.CodeReviewVisualEvidenceFetchStatusUnavailable
+						prepared.failureReason = "first-party image storage is unavailable"
+						prepared.firstEvidenceID = visualEvidenceID(firstSource.SourceID, prepared.contentSHA256, prepared.status)
+					} else {
+						prepared.storageKey = key
+						prepared.storedURL = storedURL
+						acceptedBytes += int64(len(result.data))
+						storedByHash[result.contentSHA256] = storedContent{key: key, url: storedURL, evidenceID: prepared.firstEvidenceID}
+					}
+				}
+			}
+			preparedURLs[index] = prepared
+		}
+	}
+
+	for index, source := range discovery.Sources {
+		originalURL := strings.TrimSpace(source.ImageURL)
+		if index >= s.maxImages {
+			evidence := overLimitVisualEvidence(source, originalURL, fmt.Sprintf("assessment exceeds the %d image limit", s.maxImages))
+			snapshot.Evidence = append(snapshot.Evidence, evidence)
+			metrics.RecordCodeReviewVisualEvidenceImage(ctx, string(source.Surface), string(evidence.Status), visualEvidenceHostClass(originalURL), 0, 0)
+			continue
+		}
+
+		prepared := preparedURLs[urlIndexes[originalURL]]
+		evidence := models.CodeReviewVisualEvidence{
+			Source: source, OriginalURL: originalURL, StorageKey: prepared.storageKey, StoredURL: prepared.storedURL,
+			ContentSHA256: prepared.contentSHA256, ContentType: prepared.contentType, ByteSize: prepared.byteSize,
+			Width: prepared.width, Height: prepared.height, Status: prepared.status, FailureReason: prepared.failureReason,
+		}
+		evidence.EvidenceID = visualEvidenceID(source.SourceID, evidence.ContentSHA256, evidence.Status)
+		if firstSourceIndexes[urlIndexes[originalURL]] != index {
+			evidence.DuplicateOfEvidenceID = prepared.firstEvidenceID
+		} else {
+			evidence.DuplicateOfEvidenceID = prepared.duplicateOfEvidenceID
+		}
+		snapshot.Evidence = append(snapshot.Evidence, evidence)
+		metrics.RecordCodeReviewVisualEvidenceImage(ctx, string(source.Surface), string(evidence.Status), prepared.hostClass, evidence.ByteSize, prepared.duration.Seconds())
+	}
+	return snapshot
+}
+
+func visualEvidenceRecordKey(sessionID uuid.UUID, headSHA string) string {
+	return fmt.Sprintf("code-review-prompts/%s/%s/visual-evidence-v1", sessionID, strings.ToLower(strings.TrimSpace(headSHA)))
+}
+
+func restoreVisualEvidenceSnapshot(record models.CodeReviewPromptRecord, input CaptureVisualEvidenceInput) (models.CodeReviewVisualEvidenceSnapshot, error) {
+	if record.OrgID != input.OrgID || record.SessionID != input.SessionID || record.RecordKey != visualEvidenceRecordKey(input.SessionID, input.HeadSHA) || record.Role != visualEvidencePromptRole {
+		return models.CodeReviewVisualEvidenceSnapshot{}, fmt.Errorf("stored code review visual evidence checkpoint identity is invalid")
+	}
+	var snapshot models.CodeReviewVisualEvidenceSnapshot
+	if err := json.Unmarshal(record.Metadata, &snapshot); err != nil {
+		return models.CodeReviewVisualEvidenceSnapshot{}, fmt.Errorf("decode stored code review visual evidence checkpoint: %w", err)
+	}
+	if snapshot.Version != visualEvidenceSnapshotVersion || snapshot.RepositoryID != input.RepositoryID || snapshot.PullRequestNumber != input.PullRequestNumber || !strings.EqualFold(snapshot.HeadSHA, input.HeadSHA) || !snapshot.Complete {
+		return models.CodeReviewVisualEvidenceSnapshot{}, fmt.Errorf("stored code review visual evidence manifest is incomplete or does not match the assessment")
+	}
+	seenIDs := make(map[string]struct{}, len(snapshot.Evidence))
+	seenSourceIDs := make(map[string]struct{}, len(snapshot.Evidence))
+	for _, evidence := range snapshot.Evidence {
+		if strings.TrimSpace(evidence.EvidenceID) == "" || strings.TrimSpace(evidence.Source.SourceID) == "" || !evidence.Source.Untrusted {
+			return models.CodeReviewVisualEvidenceSnapshot{}, fmt.Errorf("stored code review visual evidence manifest contains invalid evidence identity")
+		}
+		if _, duplicate := seenIDs[evidence.EvidenceID]; duplicate {
+			return models.CodeReviewVisualEvidenceSnapshot{}, fmt.Errorf("stored code review visual evidence manifest contains duplicate evidence IDs")
+		}
+		seenIDs[evidence.EvidenceID] = struct{}{}
+		if _, duplicate := seenSourceIDs[evidence.Source.SourceID]; duplicate {
+			return models.CodeReviewVisualEvidenceSnapshot{}, fmt.Errorf("stored code review visual evidence manifest contains duplicate source IDs")
+		}
+		seenSourceIDs[evidence.Source.SourceID] = struct{}{}
+		if err := evidence.Source.Surface.Validate(); err != nil {
+			return models.CodeReviewVisualEvidenceSnapshot{}, err
+		}
+		if err := evidence.Source.AuthorType.Validate(); err != nil {
+			return models.CodeReviewVisualEvidenceSnapshot{}, err
+		}
+		if err := evidence.Status.Validate(); err != nil {
+			return models.CodeReviewVisualEvidenceSnapshot{}, err
+		}
+		if evidence.EvidenceID != visualEvidenceID(evidence.Source.SourceID, evidence.ContentSHA256, evidence.Status) {
+			return models.CodeReviewVisualEvidenceSnapshot{}, fmt.Errorf("stored code review visual evidence manifest contains a non-canonical evidence ID")
+		}
+		if evidence.Status == models.CodeReviewVisualEvidenceFetchStatusAvailable &&
+			(strings.TrimSpace(evidence.StorageKey) == "" || strings.TrimSpace(evidence.StoredURL) == "" || strings.TrimSpace(evidence.ContentSHA256) == "") {
+			return models.CodeReviewVisualEvidenceSnapshot{}, fmt.Errorf("stored code review visual evidence manifest contains an unavailable attachment marked available")
+		}
+		if evidence.Status == models.CodeReviewVisualEvidenceFetchStatusAvailable {
+			expectedStoragePrefix := fmt.Sprintf("%s/code-review-evidence/%s/", input.OrgID, input.SessionID)
+			if !strings.HasPrefix(evidence.StorageKey, expectedStoragePrefix) ||
+				evidence.StoredURL != "/api/v1/uploads/files/"+evidence.StorageKey ||
+				!visualEvidenceContentSHA.MatchString(evidence.ContentSHA256) || evidence.ByteSize <= 0 ||
+				evidence.Width <= 0 || evidence.Height <= 0 {
+				return models.CodeReviewVisualEvidenceSnapshot{}, fmt.Errorf("stored code review visual evidence manifest contains an invalid first-party attachment")
+			}
+		}
+		if evidence.DuplicateOfEvidenceID != "" {
+			if evidence.DuplicateOfEvidenceID == evidence.EvidenceID {
+				return models.CodeReviewVisualEvidenceSnapshot{}, fmt.Errorf("stored code review visual evidence manifest contains a self-referential duplicate")
+			}
+			if _, exists := seenIDs[evidence.DuplicateOfEvidenceID]; !exists {
+				return models.CodeReviewVisualEvidenceSnapshot{}, fmt.Errorf("stored code review visual evidence manifest contains an invalid duplicate reference")
+			}
+		}
+	}
+	return snapshot, nil
+}
+
+func discoveryNeedsGitHubAssetToken(discovery models.CodeReviewVisualEvidenceDiscovery) bool {
+	for _, source := range discovery.Sources {
+		if visualEvidenceURLNeedsGitHubAuth(source.ImageURL) {
+			return true
+		}
+	}
+	return false
+}
+
+func visualEvidenceID(sourceID, contentHash string, status models.CodeReviewVisualEvidenceFetchStatus) string {
+	digest := sha256.Sum256([]byte(sourceID + "\x00" + contentHash + "\x00" + string(status)))
+	return "ve_" + hex.EncodeToString(digest[:12])
+}
+
+func overLimitVisualEvidence(source models.CodeReviewVisualEvidenceSource, originalURL, reason string) models.CodeReviewVisualEvidence {
+	evidence := models.CodeReviewVisualEvidence{
+		Source: source, OriginalURL: originalURL, Status: models.CodeReviewVisualEvidenceFetchStatusOverLimit, FailureReason: reason,
+	}
+	evidence.EvidenceID = visualEvidenceID(source.SourceID, "", evidence.Status)
+	return evidence
+}
+
+func visualEvidenceExtension(contentType string) string {
+	switch contentType {
+	case "image/png":
+		return ".png"
+	case "image/jpeg":
+		return ".jpg"
+	case "image/gif":
+		return ".gif"
+	case "image/webp":
+		return ".webp"
+	default:
+		return path.Ext(contentType)
+	}
+}
+
+func visualEvidenceSummary(snapshot models.CodeReviewVisualEvidenceSnapshot) string {
+	counts := make(map[models.CodeReviewVisualEvidenceFetchStatus]int)
+	for _, evidence := range snapshot.Evidence {
+		counts[evidence.Status]++
+	}
+	statuses := make([]string, 0, len(counts))
+	for status, count := range counts {
+		statuses = append(statuses, fmt.Sprintf("%s=%d", status, count))
+	}
+	sort.Strings(statuses)
+	return fmt.Sprintf("Captured %d visual evidence item(s) for %s#%d at %s (%s). All image content and associated text are untrusted.",
+		len(snapshot.Evidence), snapshot.Repository, snapshot.PullRequestNumber, snapshot.HeadSHA, strings.Join(statuses, ", "))
+}
+
+func visualEvidenceHostClass(rawURL string) string {
+	parsed, err := url.Parse(strings.TrimSpace(rawURL))
+	if err != nil {
+		return "invalid"
+	}
+	host := strings.ToLower(parsed.Hostname())
+	switch {
+	case host == "github.com" && strings.HasPrefix(parsed.EscapedPath(), "/user-attachments/assets/"):
+		return "github_user_attachment"
+	case host == "user-images.githubusercontent.com", host == "private-user-images.githubusercontent.com":
+		return "github_asset"
+	case host == "":
+		return "invalid"
+	default:
+		return "external"
+	}
+}

--- a/internal/services/codereview/visual_evidence_download.go
+++ b/internal/services/codereview/visual_evidence_download.go
@@ -1,0 +1,320 @@
+package codereview
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/binary"
+	"fmt"
+	"image/gif"
+	"image/jpeg"
+	"image/png"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/assembledhq/143/internal/models"
+)
+
+const (
+	visualEvidenceMaxImageBytes  = 10 << 20
+	visualEvidenceMaxPixels      = 40_000_000
+	visualEvidenceMaxRedirects   = 3
+	visualEvidenceFetchAttempts  = 3
+	visualEvidenceFetchTimeout   = 15 * time.Second
+	visualEvidenceRetryBaseDelay = 200 * time.Millisecond
+)
+
+var visualEvidenceBlockedNetworks = func() []*net.IPNet {
+	cidrs := []string{
+		"127.0.0.0/8", "10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16",
+		"169.254.0.0/16", "100.64.0.0/10", "0.0.0.0/8", "::1/128",
+		"fe80::/10", "fc00::/7", "ff00::/8",
+	}
+	networks := make([]*net.IPNet, 0, len(cidrs))
+	for _, cidr := range cidrs {
+		_, network, err := net.ParseCIDR(cidr)
+		if err != nil {
+			panic(fmt.Sprintf("code review visual evidence: invalid blocked CIDR %q: %v", cidr, err))
+		}
+		networks = append(networks, network)
+	}
+	return networks
+}()
+
+type visualEvidenceDownloader struct {
+	client    *http.Client
+	retryWait func(context.Context, time.Duration) error
+}
+
+type visualEvidenceFetchResult struct {
+	data          []byte
+	byteSize      int64
+	contentSHA256 string
+	contentType   string
+	width         int
+	height        int
+	status        models.CodeReviewVisualEvidenceFetchStatus
+	failureReason string
+	hostClass     string
+	duration      time.Duration
+}
+
+type visualEvidenceAttemptResult struct {
+	data          []byte
+	status        models.CodeReviewVisualEvidenceFetchStatus
+	failureReason string
+	retryable     bool
+}
+
+func newVisualEvidenceDownloader() *visualEvidenceDownloader {
+	dialer := &net.Dialer{
+		Timeout: 10 * time.Second, KeepAlive: 30 * time.Second, Control: visualEvidenceSafeDialControl,
+	}
+	transport := &http.Transport{
+		Proxy: nil, DialContext: dialer.DialContext, ForceAttemptHTTP2: true, MaxIdleConns: visualEvidenceConcurrency,
+		IdleConnTimeout: 90 * time.Second, TLSHandshakeTimeout: 10 * time.Second, ExpectContinueTimeout: time.Second,
+	}
+	return &visualEvidenceDownloader{
+		client: &http.Client{
+			Timeout: visualEvidenceFetchTimeout, Transport: transport,
+			CheckRedirect: func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse },
+		},
+		retryWait: func(ctx context.Context, delay time.Duration) error {
+			timer := time.NewTimer(delay)
+			defer timer.Stop()
+			select {
+			case <-timer.C:
+				return nil
+			case <-ctx.Done():
+				return ctx.Err()
+			}
+		},
+	}
+}
+
+func (d *visualEvidenceDownloader) fetch(ctx context.Context, rawURL, token string) visualEvidenceFetchResult {
+	startedAt := time.Now()
+	hostClass := visualEvidenceHostClass(rawURL)
+	fetchCtx, cancel := context.WithTimeout(ctx, visualEvidenceFetchTimeout)
+	defer cancel()
+
+	var attempt visualEvidenceAttemptResult
+	for attemptNumber := 1; attemptNumber <= visualEvidenceFetchAttempts; attemptNumber++ {
+		attempt = d.fetchAttempt(fetchCtx, rawURL, token)
+		if !attempt.retryable || attemptNumber == visualEvidenceFetchAttempts {
+			break
+		}
+		delay := visualEvidenceRetryBaseDelay << (attemptNumber - 1)
+		if err := d.retryWait(fetchCtx, delay); err != nil {
+			attempt = visualEvidenceAttemptResult{
+				status: models.CodeReviewVisualEvidenceFetchStatusUnavailable, failureReason: "image download was cancelled",
+			}
+			break
+		}
+	}
+	result := visualEvidenceFetchResult{
+		data: attempt.data, status: attempt.status, failureReason: attempt.failureReason,
+		hostClass: hostClass, duration: time.Since(startedAt),
+	}
+	if result.status != models.CodeReviewVisualEvidenceFetchStatusAvailable {
+		return result
+	}
+	result.byteSize = int64(len(result.data))
+	result.contentSHA256 = sha256Bytes(result.data)
+	contentType, width, height, err := inspectVisualEvidenceImage(result.data)
+	if err != nil {
+		result.data = nil
+		result.status = models.CodeReviewVisualEvidenceFetchStatusUnsupported
+		result.failureReason = "image format is unsupported or malformed"
+		return result
+	}
+	if int64(width)*int64(height) > visualEvidenceMaxPixels {
+		result.data = nil
+		result.status = models.CodeReviewVisualEvidenceFetchStatusOverLimit
+		result.failureReason = "image exceeds the 40 megapixel limit"
+		result.contentType, result.width, result.height = contentType, width, height
+		return result
+	}
+	result.contentType = contentType
+	result.width = width
+	result.height = height
+	return result
+}
+
+func (d *visualEvidenceDownloader) fetchAttempt(ctx context.Context, rawURL, token string) visualEvidenceAttemptResult {
+	currentURL := strings.TrimSpace(rawURL)
+	for redirect := 0; ; redirect++ {
+		parsed, err := validateVisualEvidenceURL(currentURL)
+		if err != nil {
+			return visualEvidenceAttemptResult{status: models.CodeReviewVisualEvidenceFetchStatusUnsupported, failureReason: "image URL is not eligible for secure download"}
+		}
+		request, err := http.NewRequestWithContext(ctx, http.MethodGet, parsed.String(), nil)
+		if err != nil {
+			return visualEvidenceAttemptResult{status: models.CodeReviewVisualEvidenceFetchStatusUnsupported, failureReason: "image URL is not eligible for secure download"}
+		}
+		request.Header.Set("Accept", "image/png,image/jpeg,image/gif,image/webp;q=0.9,*/*;q=0.1")
+		request.Header.Set("User-Agent", "143-code-review-visual-evidence/1")
+		if token != "" && visualEvidenceURLNeedsGitHubAuth(parsed.String()) {
+			request.Header.Set("Authorization", "Bearer "+token)
+		}
+		response, err := d.client.Do(request) // #nosec G704 -- production transport enforces public HTTPS targets at dial time
+		if err != nil {
+			return visualEvidenceAttemptResult{status: models.CodeReviewVisualEvidenceFetchStatusUnavailable, failureReason: "image download failed", retryable: true}
+		}
+		if response.StatusCode >= 300 && response.StatusCode < 400 {
+			if closeErr := response.Body.Close(); closeErr != nil {
+				return visualEvidenceAttemptResult{status: models.CodeReviewVisualEvidenceFetchStatusUnavailable, failureReason: "image download failed", retryable: true}
+			}
+			if redirect >= visualEvidenceMaxRedirects {
+				return visualEvidenceAttemptResult{status: models.CodeReviewVisualEvidenceFetchStatusUnavailable, failureReason: "image redirect limit exceeded"}
+			}
+			location := strings.TrimSpace(response.Header.Get("Location"))
+			if location == "" {
+				return visualEvidenceAttemptResult{status: models.CodeReviewVisualEvidenceFetchStatusUnavailable, failureReason: "image redirect is missing a destination"}
+			}
+			next, resolveErr := parsed.Parse(location)
+			if resolveErr != nil {
+				return visualEvidenceAttemptResult{status: models.CodeReviewVisualEvidenceFetchStatusUnavailable, failureReason: "image redirect destination is invalid"}
+			}
+			currentURL = next.String()
+			continue
+		}
+		if response.StatusCode != http.StatusOK {
+			if closeErr := response.Body.Close(); closeErr != nil {
+				return visualEvidenceAttemptResult{status: models.CodeReviewVisualEvidenceFetchStatusUnavailable, failureReason: "image download failed", retryable: true}
+			}
+			retryable := response.StatusCode == http.StatusRequestTimeout || response.StatusCode == http.StatusTooEarly ||
+				response.StatusCode == http.StatusTooManyRequests || response.StatusCode >= 500
+			return visualEvidenceAttemptResult{
+				status: models.CodeReviewVisualEvidenceFetchStatusUnavailable, failureReason: "image is unavailable", retryable: retryable,
+			}
+		}
+		if response.ContentLength > visualEvidenceMaxImageBytes {
+			if closeErr := response.Body.Close(); closeErr != nil {
+				return visualEvidenceAttemptResult{status: models.CodeReviewVisualEvidenceFetchStatusUnavailable, failureReason: "image download failed", retryable: true}
+			}
+			return visualEvidenceAttemptResult{status: models.CodeReviewVisualEvidenceFetchStatusOverLimit, failureReason: "image exceeds the 10 MB limit"}
+		}
+		data, readErr := io.ReadAll(io.LimitReader(response.Body, visualEvidenceMaxImageBytes+1))
+		closeErr := response.Body.Close()
+		if readErr != nil || closeErr != nil {
+			return visualEvidenceAttemptResult{status: models.CodeReviewVisualEvidenceFetchStatusUnavailable, failureReason: "image download failed", retryable: true}
+		}
+		if len(data) > visualEvidenceMaxImageBytes {
+			return visualEvidenceAttemptResult{status: models.CodeReviewVisualEvidenceFetchStatusOverLimit, failureReason: "image exceeds the 10 MB limit"}
+		}
+		return visualEvidenceAttemptResult{data: data, status: models.CodeReviewVisualEvidenceFetchStatusAvailable}
+	}
+}
+
+func unavailableVisualEvidenceResult(reason string) visualEvidenceFetchResult {
+	return visualEvidenceFetchResult{status: models.CodeReviewVisualEvidenceFetchStatusUnavailable, failureReason: reason, hostClass: "unknown"}
+}
+
+func validateVisualEvidenceURL(raw string) (*url.URL, error) {
+	parsed, err := url.Parse(strings.TrimSpace(raw))
+	if err != nil || !parsed.IsAbs() || !strings.EqualFold(parsed.Scheme, "https") || parsed.Hostname() == "" || parsed.User != nil {
+		return nil, fmt.Errorf("visual evidence URL must be an absolute HTTPS URL without user information")
+	}
+	if literal := net.ParseIP(parsed.Hostname()); literal != nil && isBlockedVisualEvidenceIP(literal) {
+		return nil, fmt.Errorf("visual evidence URL host is not public")
+	}
+	return parsed, nil
+}
+
+func visualEvidenceURLNeedsGitHubAuth(raw string) bool {
+	parsed, err := url.Parse(strings.TrimSpace(raw))
+	if err != nil {
+		return false
+	}
+	return strings.EqualFold(parsed.Hostname(), "github.com") && strings.HasPrefix(parsed.EscapedPath(), "/user-attachments/assets/")
+}
+
+func isBlockedVisualEvidenceIP(ip net.IP) bool {
+	if ip == nil || ip.IsUnspecified() || ip.IsMulticast() || ip.IsLoopback() {
+		return true
+	}
+	for _, network := range visualEvidenceBlockedNetworks {
+		if network.Contains(ip) {
+			return true
+		}
+	}
+	return false
+}
+
+func visualEvidenceSafeDialControl(_, address string, _ syscall.RawConn) error {
+	host, _, err := net.SplitHostPort(address)
+	if err != nil {
+		return fmt.Errorf("visual evidence SSRF guard: malformed dial address")
+	}
+	ip := net.ParseIP(host)
+	if ip == nil || isBlockedVisualEvidenceIP(ip) {
+		return fmt.Errorf("visual evidence SSRF guard: refusing non-public address")
+	}
+	return nil
+}
+
+func inspectVisualEvidenceImage(data []byte) (string, int, int, error) {
+	switch {
+	case len(data) >= 8 && bytes.Equal(data[:8], []byte("\x89PNG\r\n\x1a\n")):
+		config, err := png.DecodeConfig(bytes.NewReader(data))
+		return "image/png", config.Width, config.Height, err
+	case len(data) >= 3 && bytes.Equal(data[:3], []byte("\xff\xd8\xff")):
+		config, err := jpeg.DecodeConfig(bytes.NewReader(data))
+		return "image/jpeg", config.Width, config.Height, err
+	case len(data) >= 6 && (bytes.Equal(data[:6], []byte("GIF87a")) || bytes.Equal(data[:6], []byte("GIF89a"))):
+		config, err := gif.DecodeConfig(bytes.NewReader(data))
+		return "image/gif", config.Width, config.Height, err
+	case len(data) >= 16 && bytes.Equal(data[:4], []byte("RIFF")) && bytes.Equal(data[8:12], []byte("WEBP")):
+		width, height, err := webPDimensions(data)
+		return "image/webp", width, height, err
+	default:
+		return "", 0, 0, fmt.Errorf("unsupported image format")
+	}
+}
+
+func webPDimensions(data []byte) (int, int, error) {
+	if len(data) < 30 {
+		return 0, 0, fmt.Errorf("truncated WebP image")
+	}
+	switch string(data[12:16]) {
+	case "VP8 ":
+		if !bytes.Equal(data[23:26], []byte{0x9d, 0x01, 0x2a}) {
+			return 0, 0, fmt.Errorf("invalid VP8 frame header")
+		}
+		width := int(binary.LittleEndian.Uint16(data[26:28]) & 0x3fff)
+		height := int(binary.LittleEndian.Uint16(data[28:30]) & 0x3fff)
+		return validateVisualEvidenceDimensions(width, height)
+	case "VP8L":
+		if data[20] != 0x2f {
+			return 0, 0, fmt.Errorf("invalid VP8L signature")
+		}
+		bits := binary.LittleEndian.Uint32(data[21:25])
+		width := int(bits&0x3fff) + 1
+		height := int((bits>>14)&0x3fff) + 1
+		return validateVisualEvidenceDimensions(width, height)
+	case "VP8X":
+		width := 1 + int(data[24]) + int(data[25])<<8 + int(data[26])<<16
+		height := 1 + int(data[27]) + int(data[28])<<8 + int(data[29])<<16
+		return validateVisualEvidenceDimensions(width, height)
+	default:
+		return 0, 0, fmt.Errorf("unsupported WebP chunk")
+	}
+}
+
+func validateVisualEvidenceDimensions(width, height int) (int, int, error) {
+	if width <= 0 || height <= 0 {
+		return 0, 0, fmt.Errorf("image dimensions must be positive")
+	}
+	return width, height, nil
+}
+
+func sha256Bytes(data []byte) string {
+	digest := sha256.Sum256(data)
+	return fmt.Sprintf("%x", digest[:])
+}

--- a/internal/services/codereview/visual_evidence_download.go
+++ b/internal/services/codereview/visual_evidence_download.go
@@ -212,10 +212,6 @@ func (d *visualEvidenceDownloader) fetchAttempt(ctx context.Context, rawURL, tok
 	}
 }
 
-func unavailableVisualEvidenceResult(reason string) visualEvidenceFetchResult {
-	return visualEvidenceFetchResult{status: models.CodeReviewVisualEvidenceFetchStatusUnavailable, failureReason: reason, hostClass: "unknown"}
-}
-
 func validateVisualEvidenceURL(raw string) (*url.URL, error) {
 	parsed, err := url.Parse(strings.TrimSpace(raw))
 	if err != nil || !parsed.IsAbs() || !strings.EqualFold(parsed.Scheme, "https") || parsed.Hostname() == "" || parsed.User != nil {

--- a/internal/services/codereview/visual_evidence_test.go
+++ b/internal/services/codereview/visual_evidence_test.go
@@ -1,0 +1,655 @@
+package codereview
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"image"
+	"image/color"
+	"image/gif"
+	"image/jpeg"
+	"image/png"
+	"io"
+	"net"
+	"net/http"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/require"
+
+	"github.com/assembledhq/143/internal/models"
+)
+
+type visualEvidenceDiscovererStub struct {
+	mu        sync.Mutex
+	discovery models.CodeReviewVisualEvidenceDiscovery
+	err       error
+	calls     int
+}
+
+func (s *visualEvidenceDiscovererStub) DiscoverCodeReviewVisualEvidence(context.Context, uuid.UUID, uuid.UUID, int) (models.CodeReviewVisualEvidenceDiscovery, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.calls++
+	return s.discovery, s.err
+}
+
+func (s *visualEvidenceDiscovererStub) callCount() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.calls
+}
+
+type visualEvidencePromptStoreStub struct {
+	mu      sync.Mutex
+	records map[string]models.CodeReviewPromptRecord
+}
+
+func (s *visualEvidencePromptStoreStub) GetPromptRecordByKey(_ context.Context, orgID uuid.UUID, recordKey string) (models.CodeReviewPromptRecord, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	record, ok := s.records[orgID.String()+"/"+recordKey]
+	if !ok {
+		return models.CodeReviewPromptRecord{}, pgx.ErrNoRows
+	}
+	return record, nil
+}
+
+func (s *visualEvidencePromptStoreStub) CreatePromptRecordIfAbsent(_ context.Context, record *models.CodeReviewPromptRecord) (bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	key := record.OrgID.String() + "/" + record.RecordKey
+	if existing, ok := s.records[key]; ok {
+		*record = existing
+		return false, nil
+	}
+	copy := *record
+	copy.ID = uuid.New()
+	copy.CreatedAt = time.Now().UTC()
+	copy.Metadata = append(json.RawMessage(nil), record.Metadata...)
+	s.records[key] = copy
+	*record = copy
+	return true, nil
+}
+
+type visualEvidenceRepositoryStoreStub struct {
+	repository models.Repository
+	err        error
+	calls      int
+	mu         sync.Mutex
+}
+
+func (s *visualEvidenceRepositoryStoreStub) GetByID(context.Context, uuid.UUID, uuid.UUID) (models.Repository, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.calls++
+	return s.repository, s.err
+}
+
+type visualEvidenceTokenProviderStub struct {
+	token string
+	err   error
+	calls int
+	mu    sync.Mutex
+}
+
+func (s *visualEvidenceTokenProviderStub) GetInstallationToken(context.Context, int64) (string, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.calls++
+	return s.token, s.err
+}
+
+type visualEvidenceUploadStoreStub struct {
+	mu        sync.Mutex
+	saved     map[string][]byte
+	saveErr   error
+	saveCalls int
+}
+
+func (s *visualEvidenceUploadStoreStub) Save(_ context.Context, key string, reader io.Reader, _ string) (string, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.saveCalls++
+	if s.saveErr != nil {
+		return "", s.saveErr
+	}
+	data, err := io.ReadAll(reader)
+	if err != nil {
+		return "", err
+	}
+	s.saved[key] = data
+	return "/api/v1/uploads/files/" + key, nil
+}
+
+func (s *visualEvidenceUploadStoreStub) Open(context.Context, string) (io.ReadCloser, string, error) {
+	return nil, "", errors.New("not implemented")
+}
+
+func (s *visualEvidenceUploadStoreStub) URL(key string) string                            { return "/api/v1/uploads/files/" + key }
+func (s *visualEvidenceUploadStoreStub) Serve(http.ResponseWriter, *http.Request, string) {}
+
+type visualEvidenceRoundTripper struct {
+	mu       sync.Mutex
+	requests map[string][]http.Header
+	counts   map[string]int
+	png      []byte
+}
+
+func (r *visualEvidenceRoundTripper) RoundTrip(request *http.Request) (*http.Response, error) {
+	r.mu.Lock()
+	urlString := request.URL.String()
+	r.requests[urlString] = append(r.requests[urlString], request.Header.Clone())
+	r.counts[urlString]++
+	count := r.counts[urlString]
+	r.mu.Unlock()
+
+	response := &http.Response{StatusCode: http.StatusOK, Header: make(http.Header), Request: request}
+	switch request.URL.Hostname() {
+	case "github.com":
+		response.StatusCode = http.StatusFound
+		response.Header.Set("Location", "https://github-production-user-asset-6210df.s3.amazonaws.com/signed?token=secret")
+		response.Body = io.NopCloser(strings.NewReader(""))
+	case "github-production-user-asset-6210df.s3.amazonaws.com", "evidence.example.com":
+		response.Body = io.NopCloser(bytes.NewReader(r.png))
+		response.ContentLength = int64(len(r.png))
+	case "retry.example.com":
+		if count < visualEvidenceFetchAttempts {
+			response.StatusCode = http.StatusServiceUnavailable
+			response.Body = io.NopCloser(strings.NewReader("retry"))
+		} else {
+			response.Body = io.NopCloser(bytes.NewReader(r.png))
+			response.ContentLength = int64(len(r.png))
+		}
+	default:
+		response.StatusCode = http.StatusNotFound
+		response.Body = io.NopCloser(strings.NewReader("missing"))
+	}
+	return response, nil
+}
+
+func (r *visualEvidenceRoundTripper) headers(rawURL string) []http.Header {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return append([]http.Header(nil), r.requests[rawURL]...)
+}
+
+func (r *visualEvidenceRoundTripper) count(rawURL string) int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.counts[rawURL]
+}
+
+func TestVisualEvidenceServiceCapturePersistsAndRestoresManifest(t *testing.T) {
+	t.Parallel()
+
+	orgID, sessionID, repositoryID := uuid.New(), uuid.New(), uuid.New()
+	headSHA := strings.Repeat("a", 40)
+	capturedAt := time.Date(2026, 8, 12, 12, 0, 0, 0, time.UTC)
+	githubURL := "https://github.com/user-attachments/assets/private-image"
+	externalURL := "https://evidence.example.com/same-image.png"
+	missingURL := "https://missing.example.com/not-found.png"
+	overflowURL := "https://overflow.example.com/image.png"
+	discoverer := &visualEvidenceDiscovererStub{discovery: models.CodeReviewVisualEvidenceDiscovery{
+		Version: 1, RepositoryID: repositoryID, Repository: "acme/web", PullRequestNumber: 42, HeadSHA: headSHA, CapturedAt: capturedAt,
+		Sources: []models.CodeReviewVisualEvidenceSource{
+			newVisualEvidenceSource("source-description", models.CodeReviewEvidenceSurfaceDescription, githubURL),
+			newVisualEvidenceSource("source-comment-duplicate-url", models.CodeReviewEvidenceSurfaceIssueComment, githubURL),
+			newVisualEvidenceSource("source-review-duplicate-bytes", models.CodeReviewEvidenceSurfaceReviewBody, externalURL),
+			newVisualEvidenceSource("source-inline-missing", models.CodeReviewEvidenceSurfaceReviewComment, missingURL),
+			newVisualEvidenceSource("source-overflow", models.CodeReviewEvidenceSurfaceIssueComment, overflowURL),
+		},
+	}}
+	prompts := &visualEvidencePromptStoreStub{records: make(map[string]models.CodeReviewPromptRecord)}
+	repos := &visualEvidenceRepositoryStoreStub{repository: models.Repository{ID: repositoryID, OrgID: orgID, InstallationID: 456}}
+	tokens := &visualEvidenceTokenProviderStub{token: "installation-token"}
+	uploads := &visualEvidenceUploadStoreStub{saved: make(map[string][]byte)}
+	roundTripper := &visualEvidenceRoundTripper{requests: make(map[string][]http.Header), counts: make(map[string]int), png: encodeVisualEvidencePNG(t, 10, 8)}
+	service := NewVisualEvidenceService(discoverer, prompts, repos, tokens, uploads, zerolog.Nop())
+	service.maxImages = 4
+	service.downloader.client = &http.Client{Transport: roundTripper, CheckRedirect: func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse }}
+	service.downloader.retryWait = func(context.Context, time.Duration) error { return nil }
+	input := CaptureVisualEvidenceInput{OrgID: orgID, SessionID: sessionID, RepositoryID: repositoryID, PullRequestNumber: 42, HeadSHA: headSHA}
+
+	snapshot, err := service.Capture(context.Background(), input)
+
+	require.NoError(t, err, "Capture should persist a complete immutable visual-evidence manifest")
+	require.Equal(t, visualEvidenceSnapshotVersion, snapshot.Version, "manifest should use the current materialization version")
+	require.True(t, snapshot.Complete, "a successful four-surface discovery should produce a complete manifest")
+	require.True(t, snapshot.Overflow, "sources beyond the configured image limit should be represented explicitly")
+	require.Equal(t, capturedAt, snapshot.CapturedAt, "manifest should preserve the authoritative discovery capture time")
+	require.Equal(t, []models.CodeReviewVisualEvidenceFetchStatus{
+		models.CodeReviewVisualEvidenceFetchStatusAvailable,
+		models.CodeReviewVisualEvidenceFetchStatusAvailable,
+		models.CodeReviewVisualEvidenceFetchStatusAvailable,
+		models.CodeReviewVisualEvidenceFetchStatusUnavailable,
+		models.CodeReviewVisualEvidenceFetchStatusOverLimit,
+	}, visualEvidenceStatuses(snapshot), "manifest should preserve available, unavailable, and deterministic overflow outcomes")
+	require.NotEmpty(t, snapshot.Evidence[0].StorageKey, "first available evidence should be materialized into first-party storage")
+	require.Equal(t, snapshot.Evidence[0].StorageKey, snapshot.Evidence[1].StorageKey, "duplicate URLs should share one stored image")
+	require.Equal(t, snapshot.Evidence[0].StorageKey, snapshot.Evidence[2].StorageKey, "byte-identical URLs should share one stored image")
+	require.Equal(t, snapshot.Evidence[0].EvidenceID, snapshot.Evidence[1].DuplicateOfEvidenceID, "duplicate URL provenance should point at the first evidence item")
+	require.Equal(t, snapshot.Evidence[0].EvidenceID, snapshot.Evidence[2].DuplicateOfEvidenceID, "byte-identical provenance should point at the first evidence item")
+	require.Equal(t, 1, uploads.saveCalls, "content-addressed materialization should upload duplicate bytes once")
+	require.Equal(t, 1, roundTripper.count(githubURL), "duplicate GitHub URLs should be downloaded once")
+	require.Equal(t, "Bearer installation-token", roundTripper.headers(githubURL)[0].Get("Authorization"), "private GitHub user attachments should receive installation auth")
+	redirectURL := "https://github-production-user-asset-6210df.s3.amazonaws.com/signed?token=secret"
+	require.Empty(t, roundTripper.headers(redirectURL)[0].Get("Authorization"), "GitHub installation auth must not cross onto signed storage redirects")
+	require.Empty(t, roundTripper.headers(externalURL)[0].Get("Authorization"), "external images must never receive GitHub installation auth")
+	require.Equal(t, 1, discoverer.callCount(), "the first capture should query authoritative GitHub evidence once")
+
+	restored, err := service.Capture(context.Background(), input)
+
+	require.NoError(t, err, "Capture retry should restore the immutable persisted manifest")
+	require.Equal(t, snapshot, restored, "Capture retry should return the exact first persisted manifest")
+	require.Equal(t, 1, discoverer.callCount(), "Capture retry should not refetch mutable GitHub content")
+	require.Equal(t, 1, uploads.saveCalls, "Capture retry should not rewrite first-party images")
+	require.NotEmpty(t, restored.CanonicalHash(), "persisted visual evidence should expose a stable description-input hash")
+}
+
+func TestVisualEvidenceServiceEnforcesAggregateLimit(t *testing.T) {
+	t.Parallel()
+
+	orgID, sessionID, repositoryID := uuid.New(), uuid.New(), uuid.New()
+	headSHA := strings.Repeat("b", 40)
+	firstPNG := encodeVisualEvidencePNG(t, 2, 2)
+	secondPNG := encodeVisualEvidencePNGWithColor(t, 2, 2, color.RGBA{R: 255, A: 255})
+	discoverer := &visualEvidenceDiscovererStub{discovery: models.CodeReviewVisualEvidenceDiscovery{
+		Version: 1, RepositoryID: repositoryID, Repository: "acme/web", PullRequestNumber: 7, HeadSHA: headSHA, CapturedAt: time.Now().UTC(),
+		Sources: []models.CodeReviewVisualEvidenceSource{
+			newVisualEvidenceSource("source-one", models.CodeReviewEvidenceSurfaceDescription, "https://one.example.com/image.png"),
+			newVisualEvidenceSource("source-two", models.CodeReviewEvidenceSurfaceIssueComment, "https://two.example.com/image.png"),
+		},
+	}}
+	roundTripper := roundTripFunc(func(request *http.Request) (*http.Response, error) {
+		data := firstPNG
+		if request.URL.Hostname() == "two.example.com" {
+			data = secondPNG
+		}
+		return &http.Response{StatusCode: http.StatusOK, Header: make(http.Header), Body: io.NopCloser(bytes.NewReader(data)), ContentLength: int64(len(data)), Request: request}, nil
+	})
+	service := NewVisualEvidenceService(
+		discoverer,
+		&visualEvidencePromptStoreStub{records: make(map[string]models.CodeReviewPromptRecord)},
+		&visualEvidenceRepositoryStoreStub{repository: models.Repository{ID: repositoryID, OrgID: orgID}},
+		&visualEvidenceTokenProviderStub{},
+		&visualEvidenceUploadStoreStub{saved: make(map[string][]byte)},
+		zerolog.Nop(),
+	)
+	service.maxBytes = int64(len(firstPNG) + len(secondPNG) - 1)
+	service.downloader.client = &http.Client{Transport: roundTripper, CheckRedirect: func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse }}
+
+	snapshot, err := service.Capture(context.Background(), CaptureVisualEvidenceInput{
+		OrgID: orgID, SessionID: sessionID, RepositoryID: repositoryID, PullRequestNumber: 7, HeadSHA: headSHA,
+	})
+
+	require.NoError(t, err, "Capture should record aggregate overflow without failing the assessment operationally")
+	require.True(t, snapshot.Overflow, "aggregate byte overflow should be visible in the immutable manifest")
+	require.Equal(t, []models.CodeReviewVisualEvidenceFetchStatus{
+		models.CodeReviewVisualEvidenceFetchStatusAvailable, models.CodeReviewVisualEvidenceFetchStatusOverLimit,
+	}, visualEvidenceStatuses(snapshot), "only deterministic in-budget content should be stored")
+}
+
+func TestVisualEvidenceServiceRejectsChangedHeadAndIncompleteCheckpoint(t *testing.T) {
+	t.Parallel()
+
+	orgID, sessionID, repositoryID := uuid.New(), uuid.New(), uuid.New()
+	headSHA := strings.Repeat("c", 40)
+	input := CaptureVisualEvidenceInput{OrgID: orgID, SessionID: sessionID, RepositoryID: repositoryID, PullRequestNumber: 42, HeadSHA: headSHA}
+	tests := []struct {
+		name       string
+		discovery  models.CodeReviewVisualEvidenceDiscovery
+		checkpoint *models.CodeReviewVisualEvidenceSnapshot
+		errorText  string
+	}{
+		{
+			name: "head changes during discovery",
+			discovery: models.CodeReviewVisualEvidenceDiscovery{
+				Version: 1, RepositoryID: repositoryID, Repository: "acme/web", PullRequestNumber: 42,
+				HeadSHA: strings.Repeat("d", 40), CapturedAt: time.Now().UTC(),
+			},
+			errorText: "head changed",
+		},
+		{
+			name:       "stored checkpoint is incomplete",
+			checkpoint: &models.CodeReviewVisualEvidenceSnapshot{Version: 1, RepositoryID: repositoryID, PullRequestNumber: 42, HeadSHA: headSHA, Complete: false},
+			errorText:  "incomplete",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			prompts := &visualEvidencePromptStoreStub{records: make(map[string]models.CodeReviewPromptRecord)}
+			if tt.checkpoint != nil {
+				metadata, err := json.Marshal(tt.checkpoint)
+				require.NoError(t, err, "checkpoint fixture should encode")
+				key := visualEvidenceRecordKey(sessionID, headSHA)
+				prompts.records[orgID.String()+"/"+key] = models.CodeReviewPromptRecord{
+					OrgID: orgID, SessionID: sessionID, RecordKey: key, Role: visualEvidencePromptRole, Metadata: metadata,
+				}
+			}
+			service := NewVisualEvidenceService(
+				&visualEvidenceDiscovererStub{discovery: tt.discovery}, prompts,
+				&visualEvidenceRepositoryStoreStub{}, &visualEvidenceTokenProviderStub{},
+				&visualEvidenceUploadStoreStub{saved: make(map[string][]byte)}, zerolog.Nop(),
+			)
+
+			_, err := service.Capture(context.Background(), input)
+
+			require.Error(t, err, "Capture should reject stale or incomplete immutable evidence")
+			require.Contains(t, err.Error(), tt.errorText, "Capture should explain the invalid snapshot boundary")
+		})
+	}
+}
+
+func TestVisualEvidenceDownloaderRetriesTransientResponses(t *testing.T) {
+	t.Parallel()
+
+	roundTripper := &visualEvidenceRoundTripper{requests: make(map[string][]http.Header), counts: make(map[string]int), png: encodeVisualEvidencePNG(t, 4, 3)}
+	downloader := newVisualEvidenceDownloader()
+	downloader.client = &http.Client{Transport: roundTripper, CheckRedirect: func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse }}
+	downloader.retryWait = func(context.Context, time.Duration) error { return nil }
+
+	result := downloader.fetch(context.Background(), "https://retry.example.com/image.png", "")
+
+	require.Equal(t, models.CodeReviewVisualEvidenceFetchStatusAvailable, result.status, "transient image failures should recover within the bounded retry budget")
+	require.Equal(t, visualEvidenceFetchAttempts, roundTripper.count("https://retry.example.com/image.png"), "downloader should make at most three transient attempts")
+	require.Equal(t, 4, result.width, "downloaded PNG width should be validated from bytes")
+	require.Equal(t, 3, result.height, "downloaded PNG height should be validated from bytes")
+}
+
+func TestVisualEvidenceDownloaderRejectsOversizedDimensions(t *testing.T) {
+	t.Parallel()
+
+	webp := visualEvidenceVP8X(10_000, 5_000)
+	downloader := newVisualEvidenceDownloader()
+	downloader.client = &http.Client{Transport: roundTripFunc(func(request *http.Request) (*http.Response, error) {
+		return &http.Response{StatusCode: http.StatusOK, Header: make(http.Header), Body: io.NopCloser(bytes.NewReader(webp)), ContentLength: int64(len(webp)), Request: request}, nil
+	}), CheckRedirect: func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse }}
+
+	result := downloader.fetch(context.Background(), "https://evidence.example.com/huge.webp", "")
+
+	require.Equal(t, models.CodeReviewVisualEvidenceFetchStatusOverLimit, result.status, "decompression-bomb dimensions should be rejected before agent attachment")
+	require.Equal(t, 10_000, result.width, "oversized image audit metadata should preserve validated width")
+	require.Equal(t, 5_000, result.height, "oversized image audit metadata should preserve validated height")
+}
+
+func TestVisualEvidenceDownloaderBoundaries(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name             string
+		startURL         string
+		response         func(*http.Request, int32) *http.Response
+		expectedStatus   models.CodeReviewVisualEvidenceFetchStatus
+		expectedRequests int32
+	}{
+		{
+			name:     "rejects content length above ten megabytes",
+			startURL: "https://large.example.com/image.png",
+			response: func(request *http.Request, _ int32) *http.Response {
+				return &http.Response{StatusCode: http.StatusOK, Header: make(http.Header), Body: io.NopCloser(strings.NewReader("")), ContentLength: visualEvidenceMaxImageBytes + 1, Request: request}
+			},
+			expectedStatus: models.CodeReviewVisualEvidenceFetchStatusOverLimit, expectedRequests: 1,
+		},
+		{
+			name:     "caps redirect chains",
+			startURL: "https://redirect.example.com/image.png",
+			response: func(request *http.Request, count int32) *http.Response {
+				header := make(http.Header)
+				header.Set("Location", fmt.Sprintf("https://redirect.example.com/image-%d.png", count))
+				return &http.Response{StatusCode: http.StatusFound, Header: header, Body: io.NopCloser(strings.NewReader("")), Request: request}
+			},
+			expectedStatus: models.CodeReviewVisualEvidenceFetchStatusUnavailable, expectedRequests: visualEvidenceMaxRedirects + 1,
+		},
+		{
+			name:     "revalidates redirect targets",
+			startURL: "https://redirect.example.com/image.png",
+			response: func(request *http.Request, _ int32) *http.Response {
+				header := make(http.Header)
+				header.Set("Location", "https://169.254.169.254/latest/meta-data")
+				return &http.Response{StatusCode: http.StatusFound, Header: header, Body: io.NopCloser(strings.NewReader("")), Request: request}
+			},
+			expectedStatus: models.CodeReviewVisualEvidenceFetchStatusUnsupported, expectedRequests: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var requests atomic.Int32
+			downloader := newVisualEvidenceDownloader()
+			downloader.client = &http.Client{Transport: roundTripFunc(func(request *http.Request) (*http.Response, error) {
+				count := requests.Add(1)
+				return tt.response(request, count), nil
+			}), CheckRedirect: func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse }}
+
+			result := downloader.fetch(context.Background(), tt.startURL, "installation-token")
+
+			require.Equal(t, tt.expectedStatus, result.status, "downloader should enforce the selected security/resource boundary")
+			require.Equal(t, tt.expectedRequests, requests.Load(), "downloader should stop issuing requests at the selected boundary")
+		})
+	}
+}
+
+func TestVisualEvidenceDefaultLimits(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		actual   int64
+		expected int64
+	}{
+		{name: "per image bytes", actual: visualEvidenceMaxImageBytes, expected: 10 << 20},
+		{name: "aggregate bytes", actual: visualEvidenceMaxTotalBytes, expected: 64 << 20},
+		{name: "pixels", actual: visualEvidenceMaxPixels, expected: 40_000_000},
+		{name: "images", actual: visualEvidenceMaxImages, expected: 32},
+		{name: "concurrency", actual: visualEvidenceConcurrency, expected: 4},
+		{name: "redirects", actual: visualEvidenceMaxRedirects, expected: 3},
+		{name: "attempts", actual: visualEvidenceFetchAttempts, expected: 3},
+		{name: "timeout seconds", actual: int64(visualEvidenceFetchTimeout / time.Second), expected: 15},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			require.Equal(t, tt.expected, tt.actual, "direct-launch visual evidence resource limit should remain conservative")
+		})
+	}
+}
+
+func TestValidateVisualEvidenceURL(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		rawURL    string
+		expectErr bool
+	}{
+		{name: "public HTTPS", rawURL: "https://example.com/image.png"},
+		{name: "GitHub user attachment", rawURL: "https://github.com/user-attachments/assets/id"},
+		{name: "plain HTTP", rawURL: "http://example.com/image.png", expectErr: true},
+		{name: "file scheme", rawURL: "file:///etc/passwd", expectErr: true},
+		{name: "loopback literal", rawURL: "https://127.0.0.1/image.png", expectErr: true},
+		{name: "metadata literal", rawURL: "https://169.254.169.254/latest/meta-data", expectErr: true},
+		{name: "IPv6 loopback", rawURL: "https://[::1]/image.png", expectErr: true},
+		{name: "embedded credentials", rawURL: "https://user:secret@example.com/image.png", expectErr: true},
+		{name: "relative URL", rawURL: "/user-attachments/image.png", expectErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := validateVisualEvidenceURL(tt.rawURL)
+
+			if tt.expectErr {
+				require.Error(t, err, "unsafe visual-evidence URL should be rejected")
+				return
+			}
+			require.NoError(t, err, "public HTTPS visual-evidence URL should be accepted")
+		})
+	}
+}
+
+func TestIsBlockedVisualEvidenceIP(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		ip       string
+		expected bool
+	}{
+		{name: "public IPv4", ip: "8.8.8.8", expected: false},
+		{name: "public IPv6", ip: "2606:4700:4700::1111", expected: false},
+		{name: "RFC1918", ip: "10.1.2.3", expected: true},
+		{name: "loopback", ip: "127.0.0.1", expected: true},
+		{name: "metadata", ip: "169.254.169.254", expected: true},
+		{name: "IPv4-mapped metadata", ip: "::ffff:169.254.169.254", expected: true},
+		{name: "Tailscale CGNAT", ip: "100.100.100.100", expected: true},
+		{name: "IPv6 unique local", ip: "fd00::1", expected: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			require.Equal(t, tt.expected, isBlockedVisualEvidenceIP(net.ParseIP(tt.ip)), "SSRF guard should classify the concrete dial address")
+		})
+	}
+}
+
+func TestVisualEvidenceSafeDialControl(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		address   string
+		expectErr bool
+	}{
+		{name: "public IPv4", address: "8.8.8.8:443"},
+		{name: "public IPv6", address: "[2606:4700:4700::1111]:443"},
+		{name: "private IPv4", address: "10.0.0.5:443", expectErr: true},
+		{name: "metadata", address: "169.254.169.254:443", expectErr: true},
+		{name: "loopback IPv6", address: "[::1]:443", expectErr: true},
+		{name: "unresolved hostname", address: "example.com:443", expectErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := visualEvidenceSafeDialControl("tcp", tt.address, nil)
+
+			if tt.expectErr {
+				require.Error(t, err, "dial-time SSRF guard should reject the concrete target")
+				return
+			}
+			require.NoError(t, err, "dial-time SSRF guard should accept a public concrete target")
+		})
+	}
+}
+
+func TestInspectVisualEvidenceImage(t *testing.T) {
+	t.Parallel()
+
+	imageFixture := image.NewRGBA(image.Rect(0, 0, 3, 2))
+	var jpegBuffer bytes.Buffer
+	require.NoError(t, jpeg.Encode(&jpegBuffer, imageFixture, nil), "JPEG fixture should encode")
+	var gifBuffer bytes.Buffer
+	require.NoError(t, gif.Encode(&gifBuffer, imageFixture, nil), "GIF fixture should encode")
+	tests := []struct {
+		name        string
+		data        []byte
+		contentType string
+		width       int
+		height      int
+		expectErr   bool
+	}{
+		{name: "PNG", data: encodeVisualEvidencePNG(t, 3, 2), contentType: "image/png", width: 3, height: 2},
+		{name: "JPEG", data: jpegBuffer.Bytes(), contentType: "image/jpeg", width: 3, height: 2},
+		{name: "GIF", data: gifBuffer.Bytes(), contentType: "image/gif", width: 3, height: 2},
+		{name: "WebP VP8X", data: visualEvidenceVP8X(3, 2), contentType: "image/webp", width: 3, height: 2},
+		{name: "SVG rejected", data: []byte(`<svg xmlns="http://www.w3.org/2000/svg"></svg>`), expectErr: true},
+		{name: "malformed PNG rejected", data: []byte("\x89PNG\r\n\x1a\ntruncated"), expectErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			contentType, width, height, err := inspectVisualEvidenceImage(tt.data)
+
+			if tt.expectErr {
+				require.Error(t, err, "unsupported or malformed image bytes should be rejected")
+				return
+			}
+			require.NoError(t, err, "supported raster image bytes should validate")
+			require.Equal(t, tt.contentType, contentType, "image magic should determine the content type")
+			require.Equal(t, tt.width, width, "image decoder should return exact width")
+			require.Equal(t, tt.height, height, "image decoder should return exact height")
+		})
+	}
+}
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(request *http.Request) (*http.Response, error) { return f(request) }
+
+func newVisualEvidenceSource(id string, surface models.CodeReviewEvidenceSurface, imageURL string) models.CodeReviewVisualEvidenceSource {
+	return models.CodeReviewVisualEvidenceSource{
+		SourceID: id, Surface: surface, ProviderObjectID: id, SourceURL: "https://github.com/acme/web/pull/42",
+		AuthorLogin: "human", AuthorType: models.CodeReviewEvidenceAuthorTypeUser, ImageIndex: 1,
+		ImageURL: imageURL, AltText: "untrusted", ContextText: "untrusted context", Untrusted: true,
+	}
+}
+
+func visualEvidenceStatuses(snapshot models.CodeReviewVisualEvidenceSnapshot) []models.CodeReviewVisualEvidenceFetchStatus {
+	statuses := make([]models.CodeReviewVisualEvidenceFetchStatus, 0, len(snapshot.Evidence))
+	for _, evidence := range snapshot.Evidence {
+		statuses = append(statuses, evidence.Status)
+	}
+	return statuses
+}
+
+func encodeVisualEvidencePNG(t *testing.T, width, height int) []byte {
+	t.Helper()
+	return encodeVisualEvidencePNGWithColor(t, width, height, color.RGBA{G: 255, A: 255})
+}
+
+func encodeVisualEvidencePNGWithColor(t *testing.T, width, height int, fill color.RGBA) []byte {
+	t.Helper()
+	fixture := image.NewRGBA(image.Rect(0, 0, width, height))
+	for y := 0; y < height; y++ {
+		for x := 0; x < width; x++ {
+			fixture.SetRGBA(x, y, fill)
+		}
+	}
+	var buffer bytes.Buffer
+	require.NoError(t, png.Encode(&buffer, fixture), "PNG fixture should encode")
+	return buffer.Bytes()
+}
+
+func visualEvidenceVP8X(width, height int) []byte {
+	data := make([]byte, 30)
+	copy(data[:4], "RIFF")
+	copy(data[8:12], "WEBP")
+	copy(data[12:16], "VP8X")
+	width--
+	height--
+	data[24], data[25], data[26] = byte(width), byte(width>>8), byte(width>>16)
+	data[27], data[28], data[29] = byte(height), byte(height>>8), byte(height>>16)
+	return data
+}

--- a/internal/services/github/code_review_visual_evidence.go
+++ b/internal/services/github/code_review_visual_evidence.go
@@ -261,7 +261,7 @@ func visualEvidenceSourcesFromHTML(metadata visualEvidenceSourceMetadata, render
 					UpdatedAt:         metadata.UpdatedAt,
 					ImageIndex:        imageIndex,
 					ImageURL:          imageURL,
-					AltText:           strings.TrimSpace(htmlAttribute(node, "alt")),
+					AltText:           boundedVisualEvidenceText(htmlAttribute(node, "alt")),
 					ContextText:       visualEvidenceContext(node),
 					Untrusted:         true,
 				})
@@ -357,7 +357,11 @@ func visualEvidenceContext(image *html.Node) string {
 		}
 	}
 	walkText(contextNode)
-	contextText := strings.Join(strings.Fields(textBuilder.String()), " ")
+	return boundedVisualEvidenceText(textBuilder.String())
+}
+
+func boundedVisualEvidenceText(value string) string {
+	contextText := strings.Join(strings.Fields(value), " ")
 	if utf8.RuneCountInString(contextText) <= maxVisualEvidenceContextRunes {
 		return contextText
 	}

--- a/internal/services/github/code_review_visual_evidence_test.go
+++ b/internal/services/github/code_review_visual_evidence_test.go
@@ -205,6 +205,7 @@ func TestVisualEvidenceSourcesFromHTML(t *testing.T) {
 		Surface: models.CodeReviewEvidenceSurfaceIssueComment, ProviderObjectID: "99", AuthorLogin: "human", AuthorType: models.CodeReviewEvidenceAuthorTypeUser,
 	}
 	longContext := strings.Repeat("é", maxVisualEvidenceContextRunes+20)
+	longAlt := strings.Repeat("a", maxVisualEvidenceContextRunes+20)
 	tests := []struct {
 		name     string
 		html     string
@@ -225,8 +226,8 @@ func TestVisualEvidenceSourcesFromHTML(t *testing.T) {
 		},
 		{
 			name:     "bounds untrusted context by runes",
-			html:     `<p>` + longContext + `<img src="https://example.com/long.png"></p>`,
-			expected: []models.CodeReviewVisualEvidenceSource{{SourceID: codeReviewVisualEvidenceSourceID(metadata.Surface, "99", 1, "https://example.com/long.png"), Surface: metadata.Surface, ProviderObjectID: "99", AuthorLogin: "human", AuthorType: models.CodeReviewEvidenceAuthorTypeUser, ImageIndex: 1, ImageURL: "https://example.com/long.png", ContextText: strings.Repeat("é", maxVisualEvidenceContextRunes), Untrusted: true}},
+			html:     `<p>` + longContext + `<img src="https://example.com/long.png" alt="` + longAlt + `"></p>`,
+			expected: []models.CodeReviewVisualEvidenceSource{{SourceID: codeReviewVisualEvidenceSourceID(metadata.Surface, "99", 1, "https://example.com/long.png"), Surface: metadata.Surface, ProviderObjectID: "99", AuthorLogin: "human", AuthorType: models.CodeReviewEvidenceAuthorTypeUser, ImageIndex: 1, ImageURL: "https://example.com/long.png", AltText: strings.Repeat("a", maxVisualEvidenceContextRunes), ContextText: strings.Repeat("é", maxVisualEvidenceContextRunes), Untrusted: true}},
 		},
 		{name: "ignores images without a source", html: `<p><img alt="missing"></p>`, expected: []models.CodeReviewVisualEvidenceSource{}},
 	}


### PR DESCRIPTION
## Summary
- securely downloads discovered PR images with SSRF and credential-leak protections
- validates raster magic/dimensions and enforces deterministic per-image, aggregate, redirect, retry, and concurrency limits
- stores accepted images in first-party upload storage with content deduplication
- persists an immutable, resumable evidence manifest keyed by session and head SHA
- records bounded visual-evidence metrics without raw URLs or untrusted content

## Security contract
- all image bytes, alt text, and surrounding text remain explicitly untrusted
- GitHub installation auth is sent only to the exact `github.com/user-attachments/assets/` route
- redirect requests are rebuilt and never forward GitHub auth to signed storage hosts
- every production dial rejects loopback, private, link-local, metadata, multicast, and unspecified targets
- SVG and malformed payloads are rejected; agents will receive only first-party raster URLs

## Verification
- `go test ./internal/models ./internal/db ./internal/metrics ./internal/services/github ./internal/services/codereview`
- `go test -race ./internal/services/codereview ./internal/services/github`
- `go vet ./internal/models ./internal/db ./internal/metrics ./internal/services/github ./internal/services/codereview`
- `make lint-tenancy`
- `git diff --check`

## Stack
Depends on #2107. This PR establishes materialization and persistence; the next PR wires the snapshot into every reviewer and the orchestrator and enforces structured evidence citations.
