### PR TITLE
Reroute code review turns when worker capacity is available

### DIFF
--- a/internal/worker/handlers.go
+++ b/internal/worker/handlers.go
@@ -44,6 +44,7 @@ import (
 )
 
 const sandboxCapacityRetryDelay = 10 * time.Second
+const sandboxAlternateWorkerRetryDelay = time.Duration(0)
 const previewCapacityRetryDelay = 5 * time.Second
 const previewStartupInterruptedRetryDelay = 2 * time.Second
 const prePRReviewRetryDelay = 5 * time.Second
@@ -156,6 +157,18 @@ func sandboxCapacityRetryTarget(ctx context.Context, stores *Stores, logger zero
 		Str("excluded_node_id", excludeNodeID).
 		Msg("no alternate worker advertises sandbox capacity; clearing retry target pin")
 	return nil, true
+}
+
+// sandboxTurnCapacityRetryTarget keeps the existing fleet-capacity selector,
+// but avoids making a sandbox turn wait after an alternate worker has already
+// advertised a free slot. The longer delay remains the backoff for genuine
+// fleet saturation (or a selector failure).
+func sandboxTurnCapacityRetryTarget(ctx context.Context, stores *Stores, logger zerolog.Logger) (*string, bool, time.Duration) {
+	targetNodeID, clearTargetNodeID := sandboxCapacityRetryTarget(ctx, stores, logger)
+	if targetNodeID != nil {
+		return targetNodeID, clearTargetNodeID, sandboxAlternateWorkerRetryDelay
+	}
+	return nil, clearTargetNodeID, sandboxCapacityRetryDelay
 }
 
 func previewBusyRetryTarget(ctx context.Context, stores *Stores, logger zerolog.Logger, orgID, sessionID uuid.UUID) *string {
@@ -8297,8 +8310,7 @@ func newRunAgentHandler(stores *Stores, services *Services, logger zerolog.Logge
 		}
 		if err := runErr; err != nil {
 			if errors.Is(err, agent.ErrSandboxCapacity) {
-				retryAfter := sandboxCapacityRetryDelay
-				targetNodeID, clearTargetNodeID := sandboxCapacityRetryTarget(ctx, stores, logger)
+				targetNodeID, clearTargetNodeID, retryAfter := sandboxTurnCapacityRetryTarget(ctx, stores, logger)
 				registerSandboxCapacityDeadLetter(ctx, stores, services, logger, run, run.PrimaryThreadID, "run_agent")
 				logger.Info().
 					Str("session_id", runID.String()).
@@ -9754,8 +9766,7 @@ func newContinueSessionHandler(stores *Stores, services *Services, logger zerolo
 
 		if err := services.Orchestrator.ContinueSession(jobCtx, &session, continueOpts); err != nil {
 			if errors.Is(err, agent.ErrSandboxCapacity) {
-				retryAfter := sandboxCapacityRetryDelay
-				targetNodeID, clearTargetNodeID := sandboxCapacityRetryTarget(ctx, stores, logger)
+				targetNodeID, clearTargetNodeID, retryAfter := sandboxTurnCapacityRetryTarget(ctx, stores, logger)
 				var capacityThreadID *uuid.UUID
 				if hasThread {
 					threadIDLocal := threadID

--- a/internal/worker/handlers_test.go
+++ b/internal/worker/handlers_test.go
@@ -10778,7 +10778,7 @@ func TestRunAgentHandler_SandboxCapacityRetries(t *testing.T) {
 	var retryable *RetryableError
 	require.ErrorAs(t, err, &retryable, "ErrSandboxCapacity must be wrapped as RetryableError so the attempt counter is not consumed")
 	require.NotNil(t, retryable.RetryAfter, "sandbox capacity retries should use a fixed short delay")
-	require.Equal(t, 10*time.Second, *retryable.RetryAfter, "sandbox capacity retries should wait briefly before checking the local host again")
+	require.Equal(t, time.Duration(0), *retryable.RetryAfter, "sandbox capacity retries should reroute immediately when another worker has capacity")
 	require.ErrorIs(t, retryable.Err, agent.ErrSandboxCapacity, "the wrapped error must preserve the ErrSandboxCapacity sentinel")
 	require.NotNil(t, retryable.TargetNodeID, "sandbox capacity retries should target a worker that advertises available sandbox capacity")
 	require.Equal(t, "worker-with-space", *retryable.TargetNodeID, "sandbox capacity retries should avoid requeueing onto the full worker when another worker has capacity")
@@ -10819,6 +10819,8 @@ func TestRunAgentHandler_SandboxCapacityRetriesClearsTargetWhenNoWorkerAvailable
 	require.Error(t, err, "run_agent should return a retryable error when local sandbox capacity is full")
 	var retryable *RetryableError
 	require.ErrorAs(t, err, &retryable, "ErrSandboxCapacity must be wrapped as RetryableError so the attempt counter is not consumed")
+	require.NotNil(t, retryable.RetryAfter, "sandbox capacity retries should use an explicit fleet-full delay")
+	require.Equal(t, 10*time.Second, *retryable.RetryAfter, "sandbox capacity retries should retain the backoff when the fleet is genuinely full")
 	require.Nil(t, retryable.TargetNodeID, "sandbox capacity retries should not pin to a worker when none advertise available capacity")
 	require.True(t, retryable.ClearTargetNodeID, "sandbox capacity retries should clear any stale target pin when no replacement worker is selected")
 	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
@@ -11938,11 +11940,13 @@ func TestContinueSessionHandler_SandboxCapacityRetries(t *testing.T) {
 	sessionID := uuid.New()
 	issueID := uuid.New()
 
+	sessionRow := workerSessionRow(sessionID, issueID, orgID, models.SessionStatusIdle, 2, nil, nil)
+	setWorkerSessionColumn(sessionRow, "origin", models.SessionOriginCodeReview)
 	mock.ExpectQuery("SELECT .* FROM sessions").
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
 		WillReturnRows(
 			pgxmock.NewRows(workerSessionColumns).AddRow(
-				workerSessionRow(sessionID, issueID, orgID, models.SessionStatusIdle, 2, nil, nil)...,
+				sessionRow...,
 			),
 		)
 
@@ -11962,7 +11966,7 @@ func TestContinueSessionHandler_SandboxCapacityRetries(t *testing.T) {
 	var retryable *RetryableError
 	require.ErrorAs(t, err, &retryable, "ErrSandboxCapacity must be wrapped as RetryableError so the attempt counter is not consumed")
 	require.NotNil(t, retryable.RetryAfter, "sandbox capacity retries should use a fixed short delay")
-	require.Equal(t, 10*time.Second, *retryable.RetryAfter, "sandbox capacity retries should wait briefly before checking the local host again")
+	require.Equal(t, time.Duration(0), *retryable.RetryAfter, "code-review continuations should reroute immediately when another worker has capacity")
 	require.ErrorIs(t, retryable.Err, agent.ErrSandboxCapacity, "the wrapped error must preserve the ErrSandboxCapacity sentinel")
 	require.NotNil(t, retryable.TargetNodeID, "sandbox capacity retries should target a worker that advertises available sandbox capacity")
 	require.Equal(t, "worker-with-space", *retryable.TargetNodeID, "sandbox capacity retries should avoid requeueing onto the full worker when another worker has capacity")
@@ -12004,6 +12008,8 @@ func TestContinueSessionHandler_SandboxCapacityRetriesClearsTargetWhenNoWorkerAv
 	require.Error(t, err, "continue_session should return a retryable error when local sandbox capacity is full")
 	var retryable *RetryableError
 	require.ErrorAs(t, err, &retryable, "ErrSandboxCapacity must be wrapped as RetryableError so the attempt counter is not consumed")
+	require.NotNil(t, retryable.RetryAfter, "sandbox capacity retries should use an explicit fleet-full delay")
+	require.Equal(t, 10*time.Second, *retryable.RetryAfter, "sandbox capacity retries should retain the backoff when the fleet is genuinely full")
 	require.Nil(t, retryable.TargetNodeID, "sandbox capacity retries should not pin to a worker when none advertise available capacity")
 	require.True(t, retryable.ClearTargetNodeID, "sandbox capacity retries should clear any stale target pin when no replacement worker is selected")
 	require.Equal(t, 1, orch.continueSessionCalls, "continue_session should call the orchestrator once before returning the retry")


### PR DESCRIPTION
## Stack

1 of 3.

- **#2113:** reuse normal session routing for code-review turns and remove avoidable alternate-worker delay
- #2114: general atomic pre-claim sandbox routing and shared turn admission
- #2115: cross-process final-admission leases and worker-generation hardening

## Summary

Code-review reviewer and orchestrator work already runs through the normal `continue_session` worker path. This change keeps that shared execution model and removes an avoidable delay in its existing capacity-aware retry behavior.

When a worker's local sandbox gate is full:

- immediately retarget `run_agent` and `continue_session` work when another worker advertises capacity;
- retain the existing 10-second retry only when no alternate worker has capacity or worker selection fails;
- leave preview retry behavior unchanged.

The regression test uses a `code_review`-origin session to pin the intended review behavior without introducing a separate code-review scheduler.

## Why

The previous implementation selected an alternate worker but still delayed the requeued job by 10 seconds. Code-review bursts therefore accumulated unnecessary wait time even when capacity was available elsewhere.

This is intentionally the small code-review-facing PR extracted from #2103. Atomic pre-claim placement, shared turn admission, and cross-process reservations are isolated in #2114 and #2115.

## Validation

- `go test ./internal/worker -count=1`
- `go vet ./internal/worker`
- `git diff --check`
