### PR TITLE
Coordinate sandbox capacity across worker processes

### DIFF
--- a/cmd/migrate/main.go
+++ b/cmd/migrate/main.go
@@ -251,6 +251,12 @@ func prepareSandboxWorkloadRoutingOnConn(ctx context.Context, conn migrationPrep
 	if _, err := conn.Exec(ctx, `SET lock_timeout = '0'`); err != nil {
 		return fmt.Errorf("reset lock timeout before concurrent indexes: %w", err)
 	}
+	// Concurrent builds may legitimately outlive the normal request timeout,
+	// but they still need a finite ceiling so a deploy cannot hang forever on a
+	// stalled snapshot or storage failure.
+	if _, err := conn.Exec(ctx, `SET statement_timeout = '30min'`); err != nil {
+		return fmt.Errorf("set statement timeout before concurrent indexes: %w", err)
+	}
 
 	for _, index := range sandboxRoutingConcurrentIndexes {
 		var invalid bool
@@ -272,6 +278,9 @@ func prepareSandboxWorkloadRoutingOnConn(ctx context.Context, conn migrationPrep
 		if _, err := conn.Exec(ctx, index.createSQL); err != nil {
 			return fmt.Errorf("create concurrent index %s: %w", index.name, err)
 		}
+	}
+	if _, err := conn.Exec(ctx, `SET statement_timeout = '0'`); err != nil {
+		return fmt.Errorf("reset statement timeout after concurrent indexes: %w", err)
 	}
 
 	// Build the partial active-turn index before the one-time classification

--- a/cmd/migrate/main.go
+++ b/cmd/migrate/main.go
@@ -188,10 +188,13 @@ func sandboxWorkloadRoutingPreparationRequired(reader migrationVersionReader) (b
 		}
 		return false, fmt.Errorf("read migration version: %w", err)
 	}
+	if dirty {
+		return false, fmt.Errorf("database is dirty at migration %d; repair it before sandbox workload routing preparation", version)
+	}
 	if version < sandboxWorkloadRoutingMigrationVersion {
 		return true, nil
 	}
-	return version == sandboxWorkloadRoutingMigrationVersion && dirty, nil
+	return false, nil
 }
 
 // prepareSandboxWorkloadRouting performs the non-transactional portion of the
@@ -236,14 +239,13 @@ func prepareSandboxWorkloadRoutingOnConn(ctx context.Context, conn migrationPrep
 		{name: "add routing columns", sql: `ALTER TABLE jobs
 			ADD COLUMN IF NOT EXISTS workload_class text NOT NULL DEFAULT 'interactive',
 			ADD COLUMN IF NOT EXISTS sandbox_slot_reserved_until timestamptz`},
-		{name: "backfill active code reviews", sql: sandboxWorkloadBackfillSQL},
 	}
 	for _, statement := range statements {
 		if _, err := conn.Exec(ctx, statement.sql); err != nil {
 			return fmt.Errorf("%s: %w", statement.name, err)
 		}
 	}
-	// The short timeout protects only the blocking ALTER/UPDATE phase. Concurrent
+	// The short timeout protects only blocking table/row locks. Concurrent
 	// index construction is intentionally allowed to wait for the brief locks it
 	// needs instead of turning ordinary jobs-table traffic into a deploy failure.
 	if _, err := conn.Exec(ctx, `SET lock_timeout = '0'`); err != nil {
@@ -270,6 +272,19 @@ func prepareSandboxWorkloadRoutingOnConn(ctx context.Context, conn migrationPrep
 		if _, err := conn.Exec(ctx, index.createSQL); err != nil {
 			return fmt.Errorf("create concurrent index %s: %w", index.name, err)
 		}
+	}
+
+	// Build the partial active-turn index before the one-time classification
+	// repair so the backfill walks the small active sandbox-job set instead of
+	// scanning the entire hot queue table.
+	if _, err := conn.Exec(ctx, `SET lock_timeout = '5s'`); err != nil {
+		return fmt.Errorf("set lock timeout before sandbox workload backfill: %w", err)
+	}
+	if _, err := conn.Exec(ctx, sandboxWorkloadBackfillSQL); err != nil {
+		return fmt.Errorf("backfill active code reviews: %w", err)
+	}
+	if _, err := conn.Exec(ctx, `SET lock_timeout = '0'`); err != nil {
+		return fmt.Errorf("reset lock timeout after sandbox workload backfill: %w", err)
 	}
 	return nil
 }

--- a/cmd/migrate/main_test.go
+++ b/cmd/migrate/main_test.go
@@ -72,8 +72,6 @@ func TestPrepareSandboxWorkloadRoutingOnConn(t *testing.T) {
 					WillReturnResult(pgxmock.NewResult("SET", 0))
 				mock.ExpectExec(`(?s)ALTER TABLE jobs.*ADD COLUMN IF NOT EXISTS workload_class.*sandbox_slot_reserved_until`).
 					WillReturnResult(pgxmock.NewResult("ALTER TABLE", 0))
-				mock.ExpectExec(`(?s)WITH active_sandbox_jobs AS MATERIALIZED.*j\.status IN \('pending', 'running'\).*UPDATE jobs j.*JOIN sessions s.*s\.id = active\.session_id.*s\.origin = 'code_review'`).
-					WillReturnResult(pgxmock.NewResult("UPDATE", 2))
 				mock.ExpectExec(`SET lock_timeout = '0'`).
 					WillReturnResult(pgxmock.NewResult("SET", 0))
 				for _, index := range sandboxRoutingConcurrentIndexes {
@@ -88,6 +86,12 @@ func TestPrepareSandboxWorkloadRoutingOnConn(t *testing.T) {
 					mock.ExpectExec(`(?s)CREATE INDEX CONCURRENTLY IF NOT EXISTS ` + index.name).
 						WillReturnResult(pgxmock.NewResult("CREATE INDEX", 0))
 				}
+				mock.ExpectExec(`SET lock_timeout = '5s'`).
+					WillReturnResult(pgxmock.NewResult("SET", 0))
+				mock.ExpectExec(`(?s)WITH active_sandbox_jobs AS MATERIALIZED.*j\.status IN \('pending', 'running'\).*UPDATE jobs j.*JOIN sessions s.*s\.id = active\.session_id.*s\.origin = 'code_review'`).
+					WillReturnResult(pgxmock.NewResult("UPDATE", 2))
+				mock.ExpectExec(`SET lock_timeout = '0'`).
+					WillReturnResult(pgxmock.NewResult("SET", 0))
 			}
 
 			err = prepareSandboxWorkloadRoutingOnConn(context.Background(), mock)
@@ -188,9 +192,14 @@ func TestSandboxWorkloadRoutingPreparationRequired(t *testing.T) {
 			expected: true,
 		},
 		{
-			name:     "allows recovery from dirty routing migration",
-			reader:   fakeDirtyMigrationRepairer{version: sandboxWorkloadRoutingMigrationVersion, dirty: true},
-			expected: true,
+			name:      "requires routing migration repair before preparation",
+			reader:    fakeDirtyMigrationRepairer{version: sandboxWorkloadRoutingMigrationVersion, dirty: true},
+			expectErr: true,
+		},
+		{
+			name:      "refuses unrelated earlier dirty migration",
+			reader:    fakeDirtyMigrationRepairer{version: sandboxWorkloadRoutingMigrationVersion - 1, dirty: true},
+			expectErr: true,
 		},
 		{
 			name:   "skips after routing migration is applied",

--- a/cmd/migrate/main_test.go
+++ b/cmd/migrate/main_test.go
@@ -74,6 +74,8 @@ func TestPrepareSandboxWorkloadRoutingOnConn(t *testing.T) {
 					WillReturnResult(pgxmock.NewResult("ALTER TABLE", 0))
 				mock.ExpectExec(`SET lock_timeout = '0'`).
 					WillReturnResult(pgxmock.NewResult("SET", 0))
+				mock.ExpectExec(`SET statement_timeout = '30min'`).
+					WillReturnResult(pgxmock.NewResult("SET", 0))
 				for _, index := range sandboxRoutingConcurrentIndexes {
 					invalid := tt.invalidIndexes[index.name]
 					mock.ExpectQuery(`(?s)SELECT EXISTS.*pg_index.*NOT i\.indisvalid`).
@@ -86,6 +88,8 @@ func TestPrepareSandboxWorkloadRoutingOnConn(t *testing.T) {
 					mock.ExpectExec(`(?s)CREATE INDEX CONCURRENTLY IF NOT EXISTS ` + index.name).
 						WillReturnResult(pgxmock.NewResult("CREATE INDEX", 0))
 				}
+				mock.ExpectExec(`SET statement_timeout = '0'`).
+					WillReturnResult(pgxmock.NewResult("SET", 0))
 				mock.ExpectExec(`SET lock_timeout = '5s'`).
 					WillReturnResult(pgxmock.NewResult("SET", 0))
 				mock.ExpectExec(`(?s)WITH active_sandbox_jobs AS MATERIALIZED.*j\.status IN \('pending', 'running'\).*UPDATE jobs j.*JOIN sessions s.*s\.id = active\.session_id.*s\.origin = 'code_review'`).

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -322,6 +322,7 @@ func main() {
 			maxActiveSandboxes := resolveWorkerMaxActiveSandboxes(cfg.WorkerProcessCount, cfg.WorkerMaxActiveSandboxes)
 			sandboxCapacity = agent.NewSandboxCapacityGate(agent.SandboxCapacityGateConfig{
 				Counter:             sandboxExec,
+				SharedReservations:  db.NewSandboxCapacityReservationStore(pool),
 				MaxActive:           maxActiveSandboxes,
 				InteractiveReserved: cfg.WorkerInteractiveReservedSandboxes,
 				NodeID:              cfg.NodeID,

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -325,7 +325,7 @@ func main() {
 				SharedReservations:  db.NewSandboxCapacityReservationStore(pool),
 				MaxActive:           maxActiveSandboxes,
 				InteractiveReserved: cfg.WorkerInteractiveReservedSandboxes,
-				NodeID:              cfg.NodeID,
+				NodeID:              cfg.EffectiveWorkerCapacityNodeID(),
 				Logger:              logger,
 			})
 			logger.Info().
@@ -1111,6 +1111,7 @@ func buildWorkerMetadataProvider(workers []*worker.Worker, previewCapable bool, 
 			metadata["sandbox_turn_reserved_count"] = snapshot.SandboxTurnReserved
 			metadata["max_active_sandboxes"] = snapshot.MaxActive
 			metadata["interactive_reserved_sandbox_slots"] = snapshot.InteractiveReserved
+			metadata["sandbox_capacity_node_id"] = sandboxCapacity.CapacityNodeID()
 			if snapshot.CountError != "" {
 				metadata["live_sandbox_count_error"] = snapshot.CountError
 			}

--- a/cmd/server/main_test.go
+++ b/cmd/server/main_test.go
@@ -454,6 +454,7 @@ func TestBuildWorkerMetadataProvider_IncludesSandboxCapacity(t *testing.T) {
 	require.Equal(t, 0, metadata["sandbox_turn_reserved_count"], "worker metadata should distinguish reservations already represented by routed jobs")
 	require.Equal(t, 4, metadata["max_active_sandboxes"], "worker metadata should expose the per-machine sandbox cap")
 	require.Equal(t, 0, metadata["interactive_reserved_sandbox_slots"], "worker metadata should expose capacity reserved from code-review workloads")
+	require.Equal(t, "worker-1", metadata["sandbox_capacity_node_id"], "worker metadata should expose its host-stable sandbox admission identity")
 }
 
 // TestMainStartupReconcilesSocketsBeforeWorkers guards the sandbox-auth socket

--- a/cmd/server/session_executor_main.go
+++ b/cmd/server/session_executor_main.go
@@ -202,6 +202,7 @@ func buildSessionExecutorRuntime(ctx context.Context, cfg *config.Config, pool *
 		maxActiveSandboxes := resolveWorkerMaxActiveSandboxes(cfg.WorkerProcessCount, cfg.WorkerMaxActiveSandboxes)
 		sandboxCapacity = agent.NewSandboxCapacityGate(agent.SandboxCapacityGateConfig{
 			Counter:             sandboxExec,
+			SharedReservations:  db.NewSandboxCapacityReservationStore(pool),
 			MaxActive:           maxActiveSandboxes,
 			InteractiveReserved: cfg.WorkerInteractiveReservedSandboxes,
 			NodeID:              cfg.NodeID,

--- a/cmd/server/session_executor_main.go
+++ b/cmd/server/session_executor_main.go
@@ -205,7 +205,7 @@ func buildSessionExecutorRuntime(ctx context.Context, cfg *config.Config, pool *
 			SharedReservations:  db.NewSandboxCapacityReservationStore(pool),
 			MaxActive:           maxActiveSandboxes,
 			InteractiveReserved: cfg.WorkerInteractiveReservedSandboxes,
-			NodeID:              cfg.NodeID,
+			NodeID:              cfg.EffectiveWorkerCapacityNodeID(),
 			Logger:              logger,
 		})
 		oldShutdown := shutdown

--- a/deploy/deploy_config_test.go
+++ b/deploy/deploy_config_test.go
@@ -948,6 +948,8 @@ func TestWorkerDeployUsesBlueGreenGenerations(t *testing.T) {
 
 	require.Contains(t, deploy, "deploy_worker_blue_green", "worker deploy should use a blue/green generation rollout")
 	require.Contains(t, deploy, "start_worker_generation", "worker deploy should start the new generation before draining old containers")
+	require.Contains(t, deploy, `WORKER_CAPACITY_NODE_ID="$capacity_node_id"`, "overlapping worker generations should share a physical-host sandbox capacity identity")
+	require.Contains(t, deploy, `start_worker_generation "$node_id" "$host_port" "$base_url" "$project" "$base_node_id"`, "worker rollout should pass the stable base node id into the generation capacity fence")
 	require.Contains(t, deploy, `preflight_node_id="$(first_running_worker_node_id "$old_containers" || true)"`, "worker deploy preflight should use the existing worker node id instead of the host's physical hostname")
 	require.Contains(t, deploy, `--node-id "$preflight_node_id"`, "worker deploy preflight should load status by node id")
 	require.Contains(t, deploy, `wait_worker_db_heartbeat "$node_id"`, "worker deploy should verify the green generation has registered a fresh DB heartbeat before draining blue")

--- a/deploy/scripts/deploy.sh
+++ b/deploy/scripts/deploy.sh
@@ -1955,17 +1955,18 @@ SELECT COUNT(*) FROM endpoint_blockers;"
   }
 
   start_worker_generation() {
-    local node_id="$1" host_port="$2" base_url="$3" project="$4"
+    local node_id="$1" host_port="$2" base_url="$3" project="$4" capacity_node_id="$5"
     local cid
 
     echo "Starting worker generation node_id=$node_id port=$host_port project=$project..."
     NODE_ID="$node_id" \
+      WORKER_CAPACITY_NODE_ID="$capacity_node_id" \
       WORKER_HOST_PORT="$host_port" \
       PREVIEW_INTERNAL_BASE_URL="$base_url" \
       IMAGE_TAG="$IMAGE_TAG" \
       docker compose -p "$project" -f "$COMPOSE_FILE" up -d --no-deps "$HEALTH_SERVICE"
 
-    cid="$(NODE_ID="$node_id" WORKER_HOST_PORT="$host_port" PREVIEW_INTERNAL_BASE_URL="$base_url" IMAGE_TAG="$IMAGE_TAG" docker compose -p "$project" -f "$COMPOSE_FILE" ps -q "$HEALTH_SERVICE" | head -1)"
+    cid="$(NODE_ID="$node_id" WORKER_CAPACITY_NODE_ID="$capacity_node_id" WORKER_HOST_PORT="$host_port" PREVIEW_INTERNAL_BASE_URL="$base_url" IMAGE_TAG="$IMAGE_TAG" docker compose -p "$project" -f "$COMPOSE_FILE" ps -q "$HEALTH_SERVICE" | head -1)"
     if [ -z "$cid" ]; then
       echo "ERROR: could not find new worker generation container"
       return 1
@@ -2146,7 +2147,7 @@ SELECT COUNT(*) FROM endpoint_blockers;"
     fi
 
     STARTED_WORKER_CID=""
-    start_worker_generation "$node_id" "$host_port" "$base_url" "$project"
+    start_worker_generation "$node_id" "$host_port" "$base_url" "$project" "$base_node_id"
     new_cid="$STARTED_WORKER_CID"
     if ! wait_worker_db_heartbeat "$node_id" "${WORKER_BLUE_GREEN_DB_HEARTBEAT_TIMEOUT_SECONDS:-120}"; then
       echo "Rolling back worker generation ${new_cid:0:12} after DB heartbeat readiness failure..."

--- a/docker-compose.single-node.yml
+++ b/docker-compose.single-node.yml
@@ -74,6 +74,7 @@ services:
       FRONTEND_URL: ${FRONTEND_URL:?set FRONTEND_URL in .env.single-node}
       CORS_ALLOWED_ORIGINS: ${CORS_ALLOWED_ORIGINS:?set CORS_ALLOWED_ORIGINS in .env.single-node}
       NODE_ID: ${NODE_ID:-single-node}
+      WORKER_CAPACITY_NODE_ID: ${WORKER_CAPACITY_NODE_ID:-${NODE_ID:-single-node}}
       NODE_REGION: ${NODE_REGION:-single-node}
       PREVIEW_INTERNAL_BASE_URL: http://api:8080
       PREVIEW_ORIGIN_TEMPLATE: ${PREVIEW_ORIGIN_TEMPLATE:?set PREVIEW_ORIGIN_TEMPLATE in .env.single-node}

--- a/docker-compose.worker.yml
+++ b/docker-compose.worker.yml
@@ -89,10 +89,11 @@ services:
       # working DNS and fail their first preview-infra lookup.
       sandbox-dns:
         condition: service_healthy
-    # NODE_ID, WORKER_PRIVATE_IP, PREVIEW_INTERNAL_BASE_URL, WORKER_HOST_PORT,
-    # and DOCKER_GID are runtime identity values. The stable host defaults live
-    # in /opt/143/.env.local and deploy.sh overrides NODE_ID/HOST_PORT/BASE_URL
-    # per blue/green generation so old and new worker containers can overlap.
+    # NODE_ID, WORKER_CAPACITY_NODE_ID, WORKER_PRIVATE_IP,
+    # PREVIEW_INTERNAL_BASE_URL, WORKER_HOST_PORT, and DOCKER_GID are runtime
+    # identity values. The stable host defaults live in /opt/143/.env.local;
+    # deploy.sh overrides NODE_ID/HOST_PORT/BASE_URL per blue/green generation
+    # while keeping WORKER_CAPACITY_NODE_ID stable across overlapping containers.
     # The :? syntax fails the deploy loudly if required host values are missing
     # — without it, the internal preview API could bind to the public interface
     # or the node could heartbeat without a preview_internal_base_url.
@@ -104,6 +105,7 @@ services:
       CHROME_WS_URL: ${CHROME_WS_URL:-ws://chrome:9222}
       MAX_CONCURRENT_RUNS: ${MAX_CONCURRENT_RUNS:-5}
       NODE_ID: ${NODE_ID:?missing in /opt/143/.env.local}
+      WORKER_CAPACITY_NODE_ID: ${WORKER_CAPACITY_NODE_ID:-${NODE_ID:?missing in /opt/143/.env.local}}
       WORKER_INTERACTIVE_RESERVED_SANDBOXES: ${WORKER_INTERACTIVE_RESERVED_SANDBOXES:-1}
       WORKER_PREVIEW_DRAIN_TIMEOUT: ${WORKER_PREVIEW_DRAIN_TIMEOUT:-2h}
       PREVIEW_INTERNAL_BASE_URL: ${PREVIEW_INTERNAL_BASE_URL:?missing in /opt/143/.env.local}

--- a/docs/design/implemented/01-database-schema.md
+++ b/docs/design/implemented/01-database-schema.md
@@ -1115,7 +1115,7 @@ that worker next admits work.
 | Column | Type | Notes |
 |--------|------|-------|
 | id | uuid | PK |
-| node_id | text | worker whose Docker capacity is reserved |
+| node_id | text | stable physical-host capacity ID shared by worker generations using one Docker daemon |
 | job_id | uuid | nullable job identity; null for non-job consumers such as previews |
 | workload_class | text | `interactive` or `code_review` |
 | expires_at | timestamptz | lease expiry used for crash recovery |

--- a/docs/design/implemented/01-database-schema.md
+++ b/docs/design/implemented/01-database-schema.md
@@ -1079,7 +1079,7 @@ Durable, database-backed async work queue for the full pipeline (`ingest_webhook
 | queue | text | queue name (`ingestion`, `prioritization`, `agent`, `validation`, `pr`, `observability`) |
 | job_type | text | e.g. `ingest_webhook`, `run_agent`, `open_pr` |
 | workload_class | text | sandbox admission class: `interactive` or `code_review`; defaults to `interactive` |
-| payload | jsonb | typed job input payload |
+| payload | jsonb | typed job input payload; sandbox retries may add `failed_sandbox_capacity_node_ids` and `failed_sandbox_capacity_node_exclusion_until` runtime routing metadata |
 | priority | int | higher number = higher priority (default 0) |
 | status | text | `pending`, `running`, `succeeded`, `failed`, `cancelled`, `dead_letter` |
 | attempts | int | attempts made so far |

--- a/docs/design/implemented/01-database-schema.md
+++ b/docs/design/implemented/01-database-schema.md
@@ -1117,6 +1117,7 @@ that worker next admits work.
 | id | uuid | PK |
 | node_id | text | stable physical-host capacity ID shared by worker generations using one Docker daemon |
 | job_id | uuid | nullable job identity; null for non-job consumers such as previews |
+| job_lock_token | uuid | nullable queue-claim fencing token; required with `job_id` for job-backed leases |
 | workload_class | text | `interactive` or `code_review` |
 | expires_at | timestamptz | lease expiry used for crash recovery |
 | created_at | timestamptz | |
@@ -1124,6 +1125,15 @@ that worker next admits work.
 **Indexes:**
 - `(job_id)` unique where `job_id IS NOT NULL` — one final-admission lease per job
 - `(node_id, expires_at)` — active worker lease count and expiry cleanup
+
+**Constraints and triggers:**
+- `chk_sandbox_capacity_reservations_job_attempt` — `job_id` and `job_lock_token` must either both be set or both be null; added `NOT VALID` so unmatched pre-migration leases can expire naturally while new writes are enforced
+- `trg_sandbox_capacity_require_attempt_token` — rejects tokenless job-backed inserts before legacy `ON CONFLICT` handling can reuse a fenced lease during rolling deploys
+
+Job-backed acquisition verifies that the supplied lock token still owns the
+running queue attempt. A replacement attempt cannot reuse a prior attempt's
+live lease, and release matches both reservation identity and lock token so a
+late stale owner cannot delete its replacement's lease.
 
 ### `nodes`
 

--- a/docs/design/implemented/01-database-schema.md
+++ b/docs/design/implemented/01-database-schema.md
@@ -1,6 +1,6 @@
 # Design: Database Schema
 
-> **Status:** Implemented | **Last reviewed:** 2026-08-10
+> **Status:** Implemented | **Last reviewed:** 2026-08-12
 
 This document defines the PostgreSQL schema for 143.dev. All entities flow through the pipeline: ingestion -> prioritization -> agent run -> validation -> PR -> deploy -> observation.
 
@@ -1103,6 +1103,26 @@ Durable, database-backed async work queue for the full pipeline (`ingest_webhook
 - `(priority DESC, (CASE WHEN workload_class = 'interactive' THEN 0 ELSE 1 END), created_at ASC, run_at)` partial for pending `run_agent`/`continue_session` — capacity-aware sandbox routing and interactive-first ordering
 - `(org_id, status)` partial for pending/running `run_agent`/`continue_session` — shared organization sandbox-turn admission counts
 - `(queue, dedupe_key)` unique where `dedupe_key IS NOT NULL AND status IN ('pending', 'running')` — in-flight dedupe
+
+### `sandbox_capacity_reservations`
+
+Short-lived final-admission leases shared by every process using one worker's
+Docker host. This is cluster runtime state rather than tenant data, so it has no
+`org_id`. Its worker and optional job references cascade on parent deletion;
+lease expiry and admission cleanup bound rows left by a crashed process.
+
+| Column | Type | Notes |
+|--------|------|-------|
+| id | uuid | PK |
+| node_id | text | worker whose Docker capacity is reserved; FK to `nodes(id)` with cascade delete |
+| job_id | uuid | nullable FK to `jobs(id)` with cascade delete; null for non-job consumers such as previews |
+| workload_class | text | `interactive` or `code_review` |
+| expires_at | timestamptz | lease expiry used for crash recovery |
+| created_at | timestamptz | |
+
+**Indexes:**
+- `(job_id)` unique where `job_id IS NOT NULL` — one final-admission lease per job
+- `(node_id, expires_at)` — active worker lease count and expiry cleanup
 
 ### `nodes`
 

--- a/docs/design/implemented/01-database-schema.md
+++ b/docs/design/implemented/01-database-schema.md
@@ -1108,14 +1108,15 @@ Durable, database-backed async work queue for the full pipeline (`ingest_webhook
 
 Short-lived final-admission leases shared by every process using one worker's
 Docker host. This is cluster runtime state rather than tenant data, so it has no
-`org_id`. Its worker and optional job references cascade on parent deletion;
-lease expiry and admission cleanup bound rows left by a crashed process.
+`org_id`. It intentionally has no foreign keys to the hot `nodes` or `jobs`
+tables; expired leases stop affecting admission and cleanup removes them when
+that worker next admits work.
 
 | Column | Type | Notes |
 |--------|------|-------|
 | id | uuid | PK |
-| node_id | text | worker whose Docker capacity is reserved; FK to `nodes(id)` with cascade delete |
-| job_id | uuid | nullable FK to `jobs(id)` with cascade delete; null for non-job consumers such as previews |
+| node_id | text | worker whose Docker capacity is reserved |
+| job_id | uuid | nullable job identity; null for non-job consumers such as previews |
 | workload_class | text | `interactive` or `code_review` |
 | expires_at | timestamptz | lease expiry used for crash recovery |
 | created_at | timestamptz | |

--- a/docs/design/implemented/01-database-schema.md
+++ b/docs/design/implemented/01-database-schema.md
@@ -1100,7 +1100,7 @@ Durable, database-backed async work queue for the full pipeline (`ingest_webhook
 - `(queue, status, run_at, priority DESC)` — queue-specific workers
 - `(org_id, created_at DESC)` — org job history
 - `(locked_by_node_id, locked_at)` — dead-worker recovery
-- `(priority DESC, (CASE WHEN workload_class = 'interactive' THEN 0 ELSE 1 END), created_at ASC, run_at)` partial for pending `run_agent`/`continue_session` — capacity-aware sandbox routing and interactive-first ordering
+- `(priority DESC, (CASE WHEN workload_class = 'interactive' THEN 0 ELSE 1 END), run_at ASC, created_at ASC)` partial for pending `run_agent`/`continue_session` — capacity-aware sandbox routing and interactive-first ordering
 - `(org_id, status)` partial for pending/running `run_agent`/`continue_session` — shared organization sandbox-turn admission counts
 - `(queue, dedupe_key)` unique where `dedupe_key IS NOT NULL AND status IN ('pending', 'running')` — in-flight dedupe
 

--- a/docs/design/implemented/101-session-transcript-refactor.md
+++ b/docs/design/implemented/101-session-transcript-refactor.md
@@ -74,13 +74,16 @@ loaded history. The frontend still keeps the established transcript UI:
 - Pending sessions or tabs render one of two transcript notices. Because the
   `pending` status covers both normal container/environment setup and a session
   queued behind the org's concurrency limit, the frontend consults the runtime
-  capacity signal (`GET /settings/runtime/status`) to disambiguate. It compares
-  the agent-run counts (`active_agent_runs >= max_concurrent_agent_runs`) rather
-  than the response's conflated `state`, which also flips to `limited` for the
-  unrelated preview quota. When agent-run concurrency is exhausted it shows an
-  explicit "waiting for capacity" notice (with the configured limit and that the
-  session starts automatically once capacity frees up or the limit is raised);
-  otherwise it shows the standard "setting up environment" message.
+  capacity signal (`GET /settings/runtime/status?session_id=...`) to
+  disambiguate. The returned session-specific flag excludes that session's own
+  pending reservation, while aggregate counts still describe overall pressure.
+  This avoids showing a false capacity wait during admitted environment setup;
+  it also avoids the response's conflated `state`, which can flip to `limited`
+  for the unrelated preview quota. Older servers fall back to the aggregate
+  agent-run comparison. When the queried session is blocked it shows an
+  explicit "waiting for capacity" notice (with the configured limit and that
+  the session starts automatically once capacity frees up or the limit is
+  raised); otherwise it shows the standard "setting up environment" message.
 
 The older thread message and log APIs remain available for compatibility,
 internal tools, and direct log inspection.

--- a/docs/design/implemented/121-sandbox-workload-routing.md
+++ b/docs/design/implemented/121-sandbox-workload-routing.md
@@ -196,6 +196,9 @@ the same per-node advisory lock to atomically compare the current Docker count,
 durable job reservations, and shared final-admission leases before inserting a
 15-minute shared lease. Cross-process coordination has a 10-second bound while
 the Docker inspection inside the lock keeps its shorter two-second bound. The
+queue claim token fences each job-backed lease: admission transactionally
+validates the current owner, a replacement attempt waits for a live prior lease
+instead of sharing it, and release can delete only the acquiring attempt's row.
 lease is released under the same per-node admission lock as soon as sandbox
 creation or hydration finishes. Transient release failures retry within the
 shared coordination budget; the TTL bounds leaks if a process dies or the

--- a/docs/design/implemented/121-sandbox-workload-routing.md
+++ b/docs/design/implemented/121-sandbox-workload-routing.md
@@ -142,7 +142,10 @@ input, not a generic transient dependency. It retries on the short admission
 cadence without consuming attempts or the generic eight-minute retry window;
 session/thread terminal-state checks remain the independent termination path.
 After any successful requeue, the worker publishes the queue wake-up only once
-the pending transition (including a new target) has committed.
+the pending transition (including a new target) has committed. Immediately
+runnable work publishes at commit; positive-delay retries arm a best-effort
+wake-up for `run_at`, with the normal database poll remaining the recovery path
+if that worker process exits first.
 
 ## Capacity isolation
 

--- a/docs/design/implemented/121-sandbox-workload-routing.md
+++ b/docs/design/implemented/121-sandbox-workload-routing.md
@@ -199,13 +199,19 @@ the Docker inspection inside the lock keeps its shorter two-second bound. The
 queue claim token fences each job-backed lease: admission transactionally
 validates the current owner, a replacement attempt waits for a live prior lease
 instead of sharing it, and release can delete only the acquiring attempt's row.
-lease is released under the same per-node admission lock as soon as sandbox
+The lease is released under the same per-node admission lock as soon as sandbox
 creation or hydration finishes. Transient release failures retry within the
 shared coordination budget; the TTL bounds leaks if a process dies or the
 database remains unavailable. Admission coordination failures emit the
 structured `sandbox_capacity_coordination_failure` signal and timeout value for
-alerting. A fenced executor also clears its durable routing reservation after
-creation or hydration.
+alerting. After successful creation or hydration, a fenced executor also clears
+its durable routing reservation. A worker-local startup failure instead records
+the failed physical capacity-node identity in the job payload and atomically
+reserves another host when one is available. Every later routing pass honors
+the accumulated exclusions for a one-minute recovery window, so ordinary job
+retries cannot bounce back to a broken host or its blue/green sibling
+generation while a transiently failed host can eventually rejoin a small
+fleet.
 
 The capacity node ID identifies the physical Docker host, not a deploy
 generation. Blue/green worker generations keep distinct routing node IDs but

--- a/docs/design/implemented/121-sandbox-workload-routing.md
+++ b/docs/design/implemented/121-sandbox-workload-routing.md
@@ -169,9 +169,11 @@ interval without permanently pinning work if a dispatcher dies. At final
 admission, the main worker, isolated session executors, and preview paths use
 the same per-node advisory lock to atomically compare the current Docker count,
 durable job reservations, and shared final-admission leases before inserting a
-15-minute shared lease. The lease is released as soon as sandbox creation or
-hydration finishes; its TTL bounds leaks if a process dies. A fenced executor
-also clears its durable routing reservation after creation or hydration.
+15-minute shared lease. Cross-process coordination has a 10-second bound while
+the Docker inspection inside the lock keeps its shorter two-second bound. The
+lease is released as soon as sandbox creation or hydration finishes; its TTL
+bounds leaks if a process dies. A fenced executor also clears its durable
+routing reservation after creation or hydration.
 
 Pressure cleanup runs only when the worker is physically full. A code-review
 request rejected solely because it reached the interactive reserve boundary

--- a/docs/design/implemented/121-sandbox-workload-routing.md
+++ b/docs/design/implemented/121-sandbox-workload-routing.md
@@ -65,8 +65,11 @@ errors remain unchanged: `400 INVALID_JSON` or `400 INVALID_SETTINGS`.
 
 Worker capacity reservation is an internal queue/heartbeat contract, not a
 public API. Heartbeat metadata adds
-`interactive_reserved_sandbox_slots` and `sandbox_turn_reserved_count`; no SSE
-or external event payload changes.
+`sandbox_capacity_node_id`, `interactive_reserved_sandbox_slots`, and
+`sandbox_turn_reserved_count`; no SSE or external event payload changes.
+Runtime status counts both running turns and pending turns holding a live
+durable reservation, while final post-claim admission retains its running-only
+count.
 
 ## Admission and routing
 
@@ -90,6 +93,9 @@ Before normal queue claim, a dispatcher transaction:
 Unbound sandbox jobs cannot be claimed before this routing step. Dispatchers
 prefer interactive work at equal queue priority and continue routing after a
 capacity deferral, so an older org-limited review cannot monopolize each poll.
+If a selected job has malformed settings or another deterministic routing
+error, a savepoint rolls back only that routing attempt, records the error, and
+durably moves that job behind other due work instead of stopping fleet dispatch.
 
 Existing sandbox affinity remains authoritative and is only released through
 the existing dead/draining-worker recovery path. Claiming any affinity-bound
@@ -104,12 +110,12 @@ deadlocks and keeps runtime-settings writes independent of a long claim scan.
 
 If a worker's authoritative local gate still rejects a fresh sandbox, the
 running job immediately performs the same atomic reservation against an
-alternate worker. A successful alternate reservation retries after one second,
-which avoids hot handoff loops while heartbeat metadata catches up. The
-existing 10-second delay is retained only when no fleet slot is available.
+alternate worker. A successful alternate reservation becomes runnable
+immediately and publishes the normal cross-worker wake-up. The existing
+10-second delay is retained only when no fleet slot is available.
 The shared org limit uses a shorter policy retry, while advisory-lock contention
-leaves the job immediately runnable so another dispatcher can retry without
-pretending the fleet is full.
+uses a 500-millisecond floor so another dispatcher can retry promptly without
+pretending the fleet is full or creating a tight loop.
 
 If fresh workers exist but none advertises usable `max_active_sandboxes`
 metadata, the router does not treat the fleet as saturated for eight minutes.
@@ -153,7 +159,8 @@ pool. The shared local admission layer remains the authoritative final fence
 after claim.
 
 Worker heartbeats publish
-`interactive_reserved_sandbox_slots` and `sandbox_turn_reserved_count`
+`sandbox_capacity_node_id`, `interactive_reserved_sandbox_slots`, and
+`sandbox_turn_reserved_count`
 alongside live, total local-reserved, and max sandbox counts. The router treats
 pending durable reservations as additional load, but overlaps running durable
 reservations with the heartbeat's sandbox-turn reservation subtype using the
@@ -176,6 +183,11 @@ creation or hydration finishes. Transient release failures retry within the
 shared coordination budget; the TTL bounds leaks if a process dies or the
 database remains unavailable. A fenced executor also clears its durable
 routing reservation after creation or hydration.
+
+The capacity node ID identifies the physical Docker host, not a deploy
+generation. Blue/green worker generations keep distinct routing node IDs but
+share this host-stable identity for advisory locks and reservation accounting,
+so an overlapping rollout cannot present one daemon as multiple capacity pools.
 
 Pressure cleanup runs only when the worker is physically full. A code-review
 request rejected solely because it reached the interactive reserve boundary

--- a/docs/design/implemented/121-sandbox-workload-routing.md
+++ b/docs/design/implemented/121-sandbox-workload-routing.md
@@ -170,9 +170,11 @@ self-hosted worker remains usable for code review.
 
 `max_concurrent_runs` is the single organization limit for interactive and
 code-review turns. The router and affinity-aware claim path serialize this
-decision per organization and count both workload classes in the same active
-pool. The shared local admission layer remains the authoritative final fence
-after claim.
+decision per organization and count admitted sandbox-producing jobs from both
+workload classes in the same active pool. This is deliberately a turn/job
+limit, not a distinct-session limit: concurrent threads that can each exercise
+the shared sandbox draw independently from the fence. The shared local
+admission layer remains the authoritative final fence after claim.
 
 Worker heartbeats publish
 `sandbox_capacity_node_id`, `interactive_reserved_sandbox_slots`, and
@@ -197,8 +199,10 @@ the Docker inspection inside the lock keeps its shorter two-second bound. The
 lease is released under the same per-node admission lock as soon as sandbox
 creation or hydration finishes. Transient release failures retry within the
 shared coordination budget; the TTL bounds leaks if a process dies or the
-database remains unavailable. A fenced executor also clears its durable
-routing reservation after creation or hydration.
+database remains unavailable. Admission coordination failures emit the
+structured `sandbox_capacity_coordination_failure` signal and timeout value for
+alerting. A fenced executor also clears its durable routing reservation after
+creation or hydration.
 
 The capacity node ID identifies the physical Docker host, not a deploy
 generation. Blue/green worker generations keep distinct routing node IDs but

--- a/docs/design/implemented/121-sandbox-workload-routing.md
+++ b/docs/design/implemented/121-sandbox-workload-routing.md
@@ -194,9 +194,13 @@ interval without permanently pinning work if a dispatcher dies. At final
 admission, the main worker, isolated session executors, and preview paths use
 the same per-node advisory lock to atomically compare the current Docker count,
 durable job reservations, and shared final-admission leases before inserting a
-15-minute shared lease. Cross-process coordination has a 10-second bound while
-the Docker inspection inside the lock keeps its shorter two-second bound. The
-queue claim token fences each job-backed lease: admission transactionally
+shared lease. Job-backed leases carry a two-minute TTL and are renewed by the
+job-lease heartbeat (~20 seconds), so expiry only ever fences an attempt whose
+process died and a blocked replacement waits minutes, not a long static TTL.
+Preview leases have no renewal path and keep a conservative 15-minute TTL that
+outlives slow image pulls. Cross-process coordination has a 10-second bound
+while the Docker inspection inside the lock keeps its shorter two-second bound.
+The queue claim token fences each job-backed lease: admission transactionally
 validates the current owner, a replacement attempt waits for a live prior lease
 instead of sharing it, and release can delete only the acquiring attempt's row.
 The lease is released under the same per-node admission lock as soon as sandbox
@@ -204,7 +208,8 @@ creation or hydration finishes. Transient release failures retry within the
 shared coordination budget; the TTL bounds leaks if a process dies or the
 database remains unavailable. Admission coordination failures emit the
 structured `sandbox_capacity_coordination_failure` signal and timeout value for
-alerting. After successful creation or hydration, a fenced executor also clears
+alerting; a replacement attempt deferred by a prior attempt's live lease is an
+expected fencing condition and intentionally does not emit that signal. After successful creation or hydration, a fenced executor also clears
 its durable routing reservation. A worker-local startup failure instead records
 the failed physical capacity-node identity in the job payload and atomically
 reserves another host when one is available. Every later routing pass honors

--- a/docs/design/implemented/121-sandbox-workload-routing.md
+++ b/docs/design/implemented/121-sandbox-workload-routing.md
@@ -50,9 +50,10 @@ timeout as the rollout-safe fallback.
 Migration `000288_shared_sandbox_capacity_reservations` adds the ephemeral,
 worker-scoped `sandbox_capacity_reservations` table for final-admission leases
 shared by every process using the same Docker host. These leases are not
-tenant-owned data and therefore intentionally have no `org_id`. Foreign keys
-to `nodes` and `jobs` remove leases when their worker or job is deleted, while
-`expires_at` bounds leases left by a crashed process. A partial unique index
+tenant-owned data and therefore intentionally have no `org_id`. As ephemeral
+runtime state, they avoid foreign keys to the hot `nodes` and `jobs` tables so
+the rollout does not lock queue writes; `expires_at` bounds their admission
+effect and worker-local cleanup removes expired rows. A partial unique index
 ensures at most one final-admission lease exists for a job.
 
 ## API contract
@@ -158,9 +159,10 @@ pending durable reservations as additional load, but overlaps running durable
 reservations with the heartbeat's sandbox-turn reservation subtype using the
 larger count. Non-turn local reservations, such as preview startup, remain
 additive. It also counts unexpired shared final-admission leases, deduplicated
-against durable reservations for the same job. This prevents one admitted turn
-from appearing as both a local and a durable reservation while preserving
-independent capacity consumers.
+against durable reservations for the same job and overlapped with the matching
+heartbeat reservation subtype. This prevents one admitted turn or preview from
+appearing twice while preserving independent capacity consumers running in
+other processes.
 
 Durable routing reservations expire after 30 seconds, bridging the heartbeat
 interval without permanently pinning work if a dispatcher dies. At final

--- a/docs/design/implemented/121-sandbox-workload-routing.md
+++ b/docs/design/implemented/121-sandbox-workload-routing.md
@@ -1,6 +1,6 @@
 # Design: Workload-aware sandbox routing
 
-> **Status:** Implemented | **Last reviewed:** 2026-08-10
+> **Status:** Implemented | **Last reviewed:** 2026-08-12
 
 ## Problem
 
@@ -45,8 +45,15 @@ interactive-first workload class, and FIFO dispatch.
 and running sandbox turns.
 Because `jobs` is hot and migrations are transactional, production pre-builds
 both indexes concurrently; the migration uses `IF NOT EXISTS` and a short lock
-timeout as the rollout-safe fallback. No new table is introduced;
-`jobs.org_id` remains the tenant boundary.
+timeout as the rollout-safe fallback.
+
+Migration `000288_shared_sandbox_capacity_reservations` adds the ephemeral,
+worker-scoped `sandbox_capacity_reservations` table for final-admission leases
+shared by every process using the same Docker host. These leases are not
+tenant-owned data and therefore intentionally have no `org_id`. Foreign keys
+to `nodes` and `jobs` remove leases when their worker or job is deleted, while
+`expires_at` bounds leases left by a crashed process. A partial unique index
+ensures at most one final-admission lease exists for a job.
 
 ## API contract
 
@@ -75,8 +82,8 @@ Before normal queue claim, a dispatcher transaction:
    code-review turns against `max_concurrent_runs`;
 3. chooses a fresh active worker from heartbeat capacity metadata;
 4. obtains a transaction-scoped advisory lock for that worker and rechecks its
-   live, local-reserved, and durable-reserved counts without counting the same
-   running sandbox-turn reservation twice;
+   live, local-reserved, durable-reserved, and shared final-admission counts
+   without counting the same job reservation twice;
 5. persists the target worker and expiring reservation atomically.
 
 Unbound sandbox jobs cannot be claimed before this routing step. Dispatchers
@@ -96,8 +103,9 @@ deadlocks and keeps runtime-settings writes independent of a long claim scan.
 
 If a worker's authoritative local gate still rejects a fresh sandbox, the
 running job immediately performs the same atomic reservation against an
-alternate worker. A successful alternate reservation retries with zero delay.
-The existing 10-second delay is retained only when no fleet slot is available.
+alternate worker. A successful alternate reservation retries after one second,
+which avoids hot handoff loops while heartbeat metadata catches up. The
+existing 10-second delay is retained only when no fleet slot is available.
 The shared org limit uses a shorter policy retry, while advisory-lock contention
 leaves the job immediately runnable so another dispatcher can retry without
 pretending the fleet is full.
@@ -149,14 +157,19 @@ alongside live, total local-reserved, and max sandbox counts. The router treats
 pending durable reservations as additional load, but overlaps running durable
 reservations with the heartbeat's sandbox-turn reservation subtype using the
 larger count. Non-turn local reservations, such as preview startup, remain
-additive. This prevents one admitted turn from appearing as both a local and a
-durable reservation while preserving independent capacity consumers.
+additive. It also counts unexpired shared final-admission leases, deduplicated
+against durable reservations for the same job. This prevents one admitted turn
+from appearing as both a local and a durable reservation while preserving
+independent capacity consumers.
 
-Durable reservations expire after 30 seconds, bridging the heartbeat interval
-without permanently pinning work if a dispatcher dies. A fenced executor
-clears its durable reservation as soon as sandbox creation or hydration
-finishes, avoiding double-counting the reservation and live container for the
-remainder of the TTL.
+Durable routing reservations expire after 30 seconds, bridging the heartbeat
+interval without permanently pinning work if a dispatcher dies. At final
+admission, the main worker, isolated session executors, and preview paths use
+the same per-node advisory lock to atomically compare the current Docker count,
+durable job reservations, and shared final-admission leases before inserting a
+15-minute shared lease. The lease is released as soon as sandbox creation or
+hydration finishes; its TTL bounds leaks if a process dies. A fenced executor
+also clears its durable routing reservation after creation or hydration.
 
 Pressure cleanup runs only when the worker is physically full. A code-review
 request rejected solely because it reached the interactive reserve boundary

--- a/docs/design/implemented/121-sandbox-workload-routing.md
+++ b/docs/design/implemented/121-sandbox-workload-routing.md
@@ -171,8 +171,10 @@ the same per-node advisory lock to atomically compare the current Docker count,
 durable job reservations, and shared final-admission leases before inserting a
 15-minute shared lease. Cross-process coordination has a 10-second bound while
 the Docker inspection inside the lock keeps its shorter two-second bound. The
-lease is released as soon as sandbox creation or hydration finishes; its TTL
-bounds leaks if a process dies. A fenced executor also clears its durable
+lease is released under the same per-node admission lock as soon as sandbox
+creation or hydration finishes. Transient release failures retry within the
+shared coordination budget; the TTL bounds leaks if a process dies or the
+database remains unavailable. A fenced executor also clears its durable
 routing reservation after creation or hydration.
 
 Pressure cleanup runs only when the worker is physically full. A code-review

--- a/docs/design/implemented/121-sandbox-workload-routing.md
+++ b/docs/design/implemented/121-sandbox-workload-routing.md
@@ -60,8 +60,13 @@ ensures at most one final-admission lease exists for a job.
 
 No new route or setting is introduced. The existing authenticated settings
 APIs expose `max_concurrent_runs`, and the Runtime settings page describes it as
-the shared limit for interactive and code-review turns. Existing settings
-errors remain unchanged: `400 INVALID_JSON` or `400 INVALID_SETTINGS`.
+the shared limit for interactive and code-review turns. The runtime-status
+route accepts an optional tenant-scoped `session_id` query parameter and then
+returns `capacity.session_waiting_for_capacity`; this distinguishes a pending
+session blocked by other admitted turns from one whose own reservation is
+already included in the aggregate count. A malformed identifier returns
+`400 INVALID_SESSION_ID`. Existing settings errors remain unchanged:
+`400 INVALID_JSON` or `400 INVALID_SETTINGS`.
 
 Worker capacity reservation is an internal queue/heartbeat contract, not a
 public API. Heartbeat metadata adds
@@ -107,6 +112,9 @@ work can be considered. Each candidate is handled in its own transaction, so
 committing an org-limit deferral releases that organization's row lock before
 the dispatcher examines another tenant. This prevents cross-org lock-order
 deadlocks and keeps runtime-settings writes independent of a long claim scan.
+The claim path also wraps sandbox-specific workload resolution and admission in
+a per-candidate savepoint. A malformed tenant setting therefore records and
+defers only that job; unrelated job types remain claimable on the worker.
 
 If a worker's authoritative local gate still rejects a fresh sandbox, the
 running job immediately performs the same atomic reservation against an
@@ -141,11 +149,16 @@ Accepted `continue_session` work waiting on an org turn limit is a durable user
 input, not a generic transient dependency. It retries on the short admission
 cadence without consuming attempts or the generic eight-minute retry window;
 session/thread terminal-state checks remain the independent termination path.
+Compatibility placements for an initial `run_agent` preserve the job creation
+time as their terminal-probe deadline even when claim-time org admission
+repeatedly defers them, so an older worker heartbeat format cannot leave the
+job pending forever.
 After any successful requeue, the worker publishes the queue wake-up only once
 the pending transition (including a new target) has committed. Immediately
-runnable work publishes at commit; positive-delay retries arm a best-effort
-wake-up for `run_at`, with the normal database poll remaining the recovery path
-if that worker process exits first.
+runnable work publishes at commit; retry delays up to ten seconds arm a
+best-effort, worker-lifecycle-bound wake-up for `run_at`. Longer generic
+backoffs and process exits rely on the normal database poll, avoiding detached
+timers that outlive the worker.
 
 ## Capacity isolation
 

--- a/docs/public/reference/environment-variables.mdx
+++ b/docs/public/reference/environment-variables.mdx
@@ -36,7 +36,8 @@ Use these settings as the deployment contract for a self-hosted 143 environment.
 
 ## Workers
 
-<ConfigField name="NODE_ID" type="string" description="Stable node identifier used for worker heartbeats and preview routing." />
+<ConfigField name="NODE_ID" type="string" description="Worker routing identifier used for heartbeats, job ownership, and preview routing. Blue/green deployments assign a generation-specific value." />
+<ConfigField name="WORKER_CAPACITY_NODE_ID" type="string" description="Stable physical-host identifier shared by worker generations that use the same Docker daemon. Defaults to NODE_ID outside blue/green deployments." />
 <ConfigField name="WORKER_PROCESS_COUNT" type="integer" description="Worker loops per host." />
 <ConfigField name="WORKER_MAX_ACTIVE_SANDBOXES" type="integer" description="Maximum live sandboxes on a worker host." />
 <ConfigField name="WORKER_INTERACTIVE_RESERVED_SANDBOXES" type="integer" description="Sandbox slots per worker reserved from code-review work for interactive sessions. Defaults to 1 and is clamped for single-slot workers." />

--- a/frontend/src/app/(dashboard)/sessions/[id]/page-session-states.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/page-session-states.test.tsx
@@ -252,7 +252,8 @@ describe('SessionDetailPage session states', () => {
       http.get('/api/v1/sessions/:id', () => {
         return HttpResponse.json({ data: pendingSession } satisfies SingleResponse<Session>);
       }),
-      http.get('/api/v1/settings/runtime/status', () => {
+      http.get('/api/v1/settings/runtime/status', ({ request }) => {
+        expect(new URL(request.url).searchParams.get('session_id')).toBe(pendingSession.id);
         return HttpResponse.json({
           data: {
             static_egress: { available: true, enabled: false },
@@ -260,6 +261,7 @@ describe('SessionDetailPage session states', () => {
               state: 'limited',
               active_agent_runs: 1,
               active_sandbox_turns: 2,
+              session_waiting_for_capacity: true,
               max_concurrent_agent_runs: 2,
               active_previews: 0,
               max_previews_per_user: 5,
@@ -320,6 +322,43 @@ describe('SessionDetailPage session states', () => {
 
     expect(await screen.findByText('Waiting for capacity')).toBeInTheDocument();
     expect(await screen.findByText('Your organization is already at its max concurrency limit of 2 active runs.')).toBeInTheDocument();
+  });
+
+  it("shows setup when the aggregate includes this session's own admitted reservation", async () => {
+    const pendingSession: Session = {
+      ...mockSessions[0],
+      status: 'pending',
+      completed_at: undefined,
+      current_turn: 0,
+      sandbox_state: 'none',
+    };
+
+    server.use(
+      http.get('/api/v1/sessions/:id', () => {
+        return HttpResponse.json({ data: pendingSession } satisfies SingleResponse<Session>);
+      }),
+      http.get('/api/v1/settings/runtime/status', () => {
+        return HttpResponse.json({
+          data: {
+            static_egress: { available: true, enabled: false },
+            capacity: {
+              state: 'limited',
+              active_agent_runs: 0,
+              active_sandbox_turns: 1,
+              session_waiting_for_capacity: false,
+              max_concurrent_agent_runs: 1,
+              active_previews: 0,
+              max_previews_per_user: 5,
+            },
+          },
+        });
+      }),
+    );
+
+    renderWithProviders(<SessionDetailContent id={pendingSession.id} />);
+
+    expect(await screen.findByText('Setting up environment')).toBeInTheDocument();
+    expect(screen.queryByText('Waiting for capacity')).not.toBeInTheDocument();
   });
 
   it('shows the environment setup message for a pending session when the org is below its concurrency limit', async () => {

--- a/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
@@ -2460,23 +2460,23 @@ function ChatPanel({
   const isPending = activeThread ? activeThread.status === "pending" : session.status === "pending";
   const isSnapshotExpired = session.sandbox_state === "destroyed";
   const canSendMessage = session.status !== "skipped" && session.status !== "pending" && !isSnapshotExpired;
-  // `pending` covers both the normal environment-setup window and a session
-  // that is queued because the org is at its concurrency limit. The two look
-  // identical on the session row, so consult the runtime capacity signal to
-  // decide which message to show instead of assuming every pending session is
-  // capacity-blocked. Gate on the shared sandbox-turn count rather than the
-  // conflated `state`, which also flips to "limited" when only the unrelated
-  // preview limit is reached.
+  // `pending` covers both environment setup and a durable capacity deferral.
+  // Ask for this session's own wait state: the aggregate count includes an
+  // admitted pending session's reservation and cannot distinguish it from work
+  // waiting behind other turns. Older servers omit the per-session field, so
+  // retain the aggregate fallback during rolling deploys.
   const runtimeStatusQuery = useQuery({
-    queryKey: queryKeys.settings.runtimeStatus,
-    queryFn: () => api.settings.getRuntimeStatus(),
+    queryKey: [...queryKeys.settings.runtimeStatus, sessionId],
+    queryFn: () => api.settings.getRuntimeStatus(sessionId),
     enabled: isPending,
     staleTime: 15_000,
     refetchInterval: 15_000,
   });
   const capacity = runtimeStatusQuery.data?.data.capacity;
   const activeSandboxTurns = capacity?.active_sandbox_turns ?? capacity?.active_agent_runs;
-  const isCapacityLimited = capacity != null && activeSandboxTurns != null && activeSandboxTurns >= capacity.max_concurrent_agent_runs;
+  const isCapacityLimited = capacity?.session_waiting_for_capacity ?? (
+    capacity != null && activeSandboxTurns != null && activeSandboxTurns >= capacity.max_concurrent_agent_runs
+  );
   const maxConcurrentRuns = capacity?.max_concurrent_agent_runs;
   const initialThreadAnchorPosition = useMemo<SessionAnchorPosition | null>(() => {
     if (!activeThreadId || !viewerScope || typeof window === "undefined") return null;

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -858,7 +858,9 @@ export const api = {
     updateAgentCapabilityPolicy: (capabilities: import('./types').AgentCapabilityGrant[]) =>
       patch<import('./types').SingleResponse<import('./types').AgentCapabilityPolicyResponse>>('/api/v1/settings/agent/capabilities', { capabilities }),
     getNetworkStatus: () => get<import('./types').SingleResponse<import('./types').NetworkSettingsStatus>>('/api/v1/settings/network'),
-    getRuntimeStatus: () => get<import('./types').SingleResponse<import('./types').RuntimeSettingsStatus>>('/api/v1/settings/runtime/status'),
+    getRuntimeStatus: (sessionId?: string) => get<import('./types').SingleResponse<import('./types').RuntimeSettingsStatus>>(
+      `/api/v1/settings/runtime/status${sessionId ? `?session_id=${encodeURIComponent(sessionId)}` : ''}`,
+    ),
     getLLMDefaults: () => get<{ data: Record<string, string> }>('/api/v1/settings/llm-defaults'),
     getLLMModels: () => get<{ data: Record<string, string[]> }>('/api/v1/settings/llm-models'),
     getOpenCodeModels: () =>

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -2343,6 +2343,7 @@ export interface RuntimeSettingsStatus {
     state: "normal" | "limited";
     active_agent_runs: number;
     active_sandbox_turns?: number;
+    session_waiting_for_capacity?: boolean;
     max_concurrent_agent_runs: number;
     active_previews: number;
     max_previews_per_user: number;

--- a/internal/api/handlers/session_review_comments.go
+++ b/internal/api/handlers/session_review_comments.go
@@ -434,17 +434,7 @@ func (h *SessionReviewCommentHandler) SendToAgent(w http.ResponseWriter, r *http
 			"session_id": sessionID.String(),
 			"org_id":     orgID.String(),
 		}
-		enqueueOpts := db.EnqueueOpts{
-			Queue:        "agent",
-			JobType:      "continue_session",
-			Payload:      payload,
-			Priority:     5,
-			DedupeKey:    &dedupeKey,
-			TargetNodeID: models.SessionWorkerTarget(&session),
-		}
-		if models.SandboxWorkloadClassForSession(&session) == models.SandboxWorkloadClassCodeReview {
-			enqueueOpts.WorkloadClass = models.SandboxWorkloadClassCodeReview
-		}
+		enqueueOpts := db.ContinueSessionEnqueueOpts(&session, payload, &dedupeKey)
 		if _, err := h.jobStore.EnqueueWithOpts(r.Context(), orgID, enqueueOpts); err != nil {
 			// Delete the orphaned message and revert session status.
 			if msg.ID != 0 {

--- a/internal/api/handlers/sessions.go
+++ b/internal/api/handlers/sessions.go
@@ -2302,17 +2302,7 @@ func (h *SessionHandler) retrySessionFromCheckpoint(w http.ResponseWriter, r *ht
 		"thread_id":  claimedThread.ID.String(),
 		"org_id":     orgID.String(),
 	}
-	enqueueOpts := db.EnqueueOpts{
-		Queue:        "agent",
-		JobType:      "continue_session",
-		Payload:      payload,
-		Priority:     5,
-		DedupeKey:    &dedupeKey,
-		TargetNodeID: models.SessionWorkerTarget(&claimedSession),
-	}
-	if models.SandboxWorkloadClassForSession(&claimedSession) == models.SandboxWorkloadClassCodeReview {
-		enqueueOpts.WorkloadClass = models.SandboxWorkloadClassCodeReview
-	}
+	enqueueOpts := db.ContinueSessionEnqueueOpts(&claimedSession, payload, &dedupeKey)
 	if _, err := h.jobStore.EnqueueWithOpts(r.Context(), orgID, enqueueOpts); err != nil {
 		h.revertCheckpointRetry(r.Context(), orgID, sessionID, claimedThread.ID, targetThread.Status)
 		writeError(w, r, http.StatusInternalServerError, "ENQUEUE_FAILED", "failed to enqueue session continuation job", err)
@@ -4280,17 +4270,7 @@ func (h *SessionHandler) SendMessage(w http.ResponseWriter, r *http.Request) {
 	if humanInputRequestID != nil {
 		payload["human_input_request_id"] = humanInputRequestID.String()
 	}
-	enqueueOpts := db.EnqueueOpts{
-		Queue:        "agent",
-		JobType:      "continue_session",
-		Payload:      payload,
-		Priority:     5,
-		DedupeKey:    &dedupeKey,
-		TargetNodeID: models.SessionWorkerTarget(&session),
-	}
-	if models.SandboxWorkloadClassForSession(&session) == models.SandboxWorkloadClassCodeReview {
-		enqueueOpts.WorkloadClass = models.SandboxWorkloadClassCodeReview
-	}
+	enqueueOpts := db.ContinueSessionEnqueueOpts(&session, payload, &dedupeKey)
 	if _, err := h.jobStore.EnqueueInTxWithOpts(r.Context(), tx, orgID, enqueueOpts); err != nil {
 		writeError(w, r, http.StatusInternalServerError, "ENQUEUE_FAILED", "failed to enqueue continue_session job", err)
 		return

--- a/internal/api/handlers/settings.go
+++ b/internal/api/handlers/settings.go
@@ -39,7 +39,7 @@ type RuntimeStatusSessionCounter interface {
 }
 
 type RuntimeStatusSandboxTurnCounter interface {
-	CountActiveSandboxTurnsByOrg(ctx context.Context, orgID uuid.UUID) (int, error)
+	CountAdmittedSandboxTurnsByOrg(ctx context.Context, orgID uuid.UUID) (int, error)
 }
 
 type RuntimeStatusPreviewCounter interface {
@@ -227,7 +227,7 @@ func (h *SettingsHandler) GetRuntimeStatus(w http.ResponseWriter, r *http.Reques
 	}
 	activeSandboxTurns := activeAgentRuns
 	if h.sandboxTurns != nil {
-		activeSandboxTurns, err = h.sandboxTurns.CountActiveSandboxTurnsByOrg(r.Context(), orgID)
+		activeSandboxTurns, err = h.sandboxTurns.CountAdmittedSandboxTurnsByOrg(r.Context(), orgID)
 		if err != nil {
 			writeError(w, r, http.StatusInternalServerError, "RUNTIME_STATUS_FAILED", "failed to count active sandbox turns", err)
 			return

--- a/internal/api/handlers/settings.go
+++ b/internal/api/handlers/settings.go
@@ -40,6 +40,7 @@ type RuntimeStatusSessionCounter interface {
 
 type RuntimeStatusSandboxTurnCounter interface {
 	CountAdmittedSandboxTurnsByOrg(ctx context.Context, orgID uuid.UUID) (int, error)
+	IsSessionWaitingForSandboxCapacity(ctx context.Context, orgID, sessionID uuid.UUID, maxConcurrentRuns int) (bool, error)
 }
 
 type RuntimeStatusPreviewCounter interface {
@@ -84,6 +85,7 @@ type runtimeStatusCapacityResponse struct {
 	State                  string `json:"state"`
 	ActiveAgentRuns        int    `json:"active_agent_runs"`
 	ActiveSandboxTurns     int    `json:"active_sandbox_turns"`
+	SessionWaitingCapacity *bool  `json:"session_waiting_for_capacity,omitempty"`
 	MaxConcurrentAgentRuns int    `json:"max_concurrent_agent_runs"`
 	ActivePreviews         int    `json:"active_previews"`
 	MaxPreviewsPerUser     int    `json:"max_previews_per_user"`
@@ -211,6 +213,15 @@ func (h *SettingsHandler) GetRuntimeStatus(w http.ResponseWriter, r *http.Reques
 		writeError(w, r, http.StatusInternalServerError, "INVALID_SETTINGS", "failed to parse organization settings", err)
 		return
 	}
+	var requestedSessionID *uuid.UUID
+	if rawSessionID := strings.TrimSpace(r.URL.Query().Get("session_id")); rawSessionID != "" {
+		sessionID, parseErr := uuid.Parse(rawSessionID)
+		if parseErr != nil {
+			writeError(w, r, http.StatusBadRequest, "INVALID_SESSION_ID", "session_id must be a valid UUID", parseErr)
+			return
+		}
+		requestedSessionID = &sessionID
+	}
 
 	status, _, availabilityErr := h.staticEgressAvailability(r.Context(), false)
 	if availabilityErr != nil {
@@ -226,11 +237,20 @@ func (h *SettingsHandler) GetRuntimeStatus(w http.ResponseWriter, r *http.Reques
 		}
 	}
 	activeSandboxTurns := activeAgentRuns
+	var sessionWaitingCapacity *bool
 	if h.sandboxTurns != nil {
 		activeSandboxTurns, err = h.sandboxTurns.CountAdmittedSandboxTurnsByOrg(r.Context(), orgID)
 		if err != nil {
 			writeError(w, r, http.StatusInternalServerError, "RUNTIME_STATUS_FAILED", "failed to count active sandbox turns", err)
 			return
+		}
+		if requestedSessionID != nil {
+			waiting, waitErr := h.sandboxTurns.IsSessionWaitingForSandboxCapacity(r.Context(), orgID, *requestedSessionID, settings.MaxConcurrentRuns)
+			if waitErr != nil {
+				writeError(w, r, http.StatusInternalServerError, "RUNTIME_STATUS_FAILED", "failed to inspect session capacity wait", waitErr)
+				return
+			}
+			sessionWaitingCapacity = &waiting
 		}
 	}
 
@@ -258,6 +278,7 @@ func (h *SettingsHandler) GetRuntimeStatus(w http.ResponseWriter, r *http.Reques
 			State:                  capacityState,
 			ActiveAgentRuns:        activeAgentRuns,
 			ActiveSandboxTurns:     activeSandboxTurns,
+			SessionWaitingCapacity: sessionWaitingCapacity,
 			MaxConcurrentAgentRuns: settings.MaxConcurrentRuns,
 			ActivePreviews:         activePreviews,
 			MaxPreviewsPerUser:     settings.PreviewMaxPreviewsPerUser,

--- a/internal/api/handlers/settings_test.go
+++ b/internal/api/handlers/settings_test.go
@@ -47,12 +47,17 @@ type testRuntimeStatusSessionCounter struct {
 }
 
 type testRuntimeStatusSandboxTurnCounter struct {
-	count int
-	err   error
+	count   int
+	waiting bool
+	err     error
 }
 
 func (c testRuntimeStatusSandboxTurnCounter) CountAdmittedSandboxTurnsByOrg(context.Context, uuid.UUID) (int, error) {
 	return c.count, c.err
+}
+
+func (c testRuntimeStatusSandboxTurnCounter) IsSessionWaitingForSandboxCapacity(context.Context, uuid.UUID, uuid.UUID, int) (bool, error) {
+	return c.waiting, c.err
 }
 
 func (c testRuntimeStatusSessionCounter) CountRunningByOrg(context.Context, uuid.UUID) (int, error) {
@@ -240,18 +245,48 @@ func TestSettingsHandler_GetRuntimeStatus(t *testing.T) {
 		testRuntimeStatusSessionCounter{count: 2},
 		testRuntimeStatusPreviewCounter{count: 3},
 	)
-	handler.SetRuntimeStatusSandboxTurnCounter(testRuntimeStatusSandboxTurnCounter{count: 4})
+	handler.SetRuntimeStatusSandboxTurnCounter(testRuntimeStatusSandboxTurnCounter{count: 4, waiting: true})
 
-	req := httptest.NewRequest(http.MethodGet, "/api/v1/settings/runtime/status", nil)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/settings/runtime/status?session_id="+uuid.NewString(), nil)
 	req = req.WithContext(middleware.WithOrgID(req.Context(), orgID))
 	w := httptest.NewRecorder()
 
 	handler.GetRuntimeStatus(w, req)
 	require.Equal(t, http.StatusOK, w.Code, "runtime status should return success")
 	require.Contains(t, w.Body.String(), `"static_egress":{"available":true,"enabled":true,"public_ip":"203.0.113.10"}`, "runtime status should include sanitized static egress state")
-	require.Contains(t, w.Body.String(), `"capacity":{"state":"normal","active_agent_runs":2,"active_sandbox_turns":4,"max_concurrent_agent_runs":5,"active_previews":3,"max_previews_per_user":4}`, "runtime status should report both session activity and the shared sandbox-turn admission count")
+	require.Contains(t, w.Body.String(), `"capacity":{"state":"normal","active_agent_runs":2,"active_sandbox_turns":4,"session_waiting_for_capacity":true,"max_concurrent_agent_runs":5,"active_previews":3,"max_previews_per_user":4}`, "runtime status should report aggregate activity and the queried session's own capacity wait state")
 	require.NotContains(t, w.Body.String(), "static_egress_unavailable_reason", "runtime status must not expose backend diagnostics")
 	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
+}
+
+func TestSettingsHandler_GetRuntimeStatusRejectsInvalidSessionID(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "should create pgxmock pool without error")
+	defer mock.Close()
+
+	orgID := uuid.New()
+	now := time.Now()
+	mock.ExpectQuery("SELECT .+ FROM organizations WHERE id").
+		WithArgs(pgxmock.AnyArg()).
+		WillReturnRows(pgxmock.NewRows(orgColumns()).AddRow(
+			orgID,
+			"Test Org",
+			json.RawMessage(`{"max_concurrent_runs":2}`),
+			now,
+			now,
+		))
+
+	handler := NewSettingsHandler(db.NewOrganizationStore(mock), nil)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/settings/runtime/status?session_id=not-a-uuid", nil)
+	req = req.WithContext(middleware.WithOrgID(req.Context(), orgID))
+	w := httptest.NewRecorder()
+
+	handler.GetRuntimeStatus(w, req)
+	require.Equal(t, http.StatusBadRequest, w.Code, "runtime status should reject a malformed session identifier")
+	require.Contains(t, w.Body.String(), `"code":"INVALID_SESSION_ID"`, "runtime status should return the stable validation error code")
+	require.NoError(t, mock.ExpectationsWereMet(), "invalid session lookup should stop before runtime counters")
 }
 
 func TestSettingsHandler_GetLLMDefaults(t *testing.T) {

--- a/internal/api/handlers/settings_test.go
+++ b/internal/api/handlers/settings_test.go
@@ -51,7 +51,7 @@ type testRuntimeStatusSandboxTurnCounter struct {
 	err   error
 }
 
-func (c testRuntimeStatusSandboxTurnCounter) CountActiveSandboxTurnsByOrg(context.Context, uuid.UUID) (int, error) {
+func (c testRuntimeStatusSandboxTurnCounter) CountAdmittedSandboxTurnsByOrg(context.Context, uuid.UUID) (int, error) {
 	return c.count, c.err
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -383,13 +383,18 @@ type Config struct {
 var workerGenerationNodeIDPattern = regexp.MustCompile(`^(.*)-g[0-9]{14}-[A-Za-z0-9._-]+$`)
 
 // EffectiveWorkerCapacityNodeID returns the physical-host identity used for
-// sandbox admission. Explicit configuration wins; the generation suffix
-// fallback keeps older worker env files safe during rollout.
+// sandbox admission. Normalize both explicit configuration and the NODE_ID
+// fallback because compose-style defaults may copy a generation-scoped node ID
+// into WORKER_CAPACITY_NODE_ID before the process starts.
 func (c Config) EffectiveWorkerCapacityNodeID() string {
 	if configured := strings.TrimSpace(c.WorkerCapacityNodeID); configured != "" {
-		return configured
+		return normalizeWorkerCapacityNodeID(configured)
 	}
-	nodeID := strings.TrimSpace(c.NodeID)
+	return normalizeWorkerCapacityNodeID(c.NodeID)
+}
+
+func normalizeWorkerCapacityNodeID(value string) string {
+	nodeID := strings.TrimSpace(value)
 	if matches := workerGenerationNodeIDPattern.FindStringSubmatch(nodeID); len(matches) == 2 {
 		return matches[1]
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net"
 	"net/url"
+	"regexp"
 	"strings"
 	"time"
 
@@ -38,11 +39,15 @@ type Config struct {
 	SessionSecret           string        `env:"SESSION_SECRET"` // #nosec G117 -- env config field
 	PreviewRPCSecrets       []string      `env:"PREVIEW_RPC_SECRETS"   envSeparator:","`
 	NodeID                  string        `env:"NODE_ID"`
-	NodeRegion              string        `env:"NODE_REGION"`
-	BaseURL                 string        `env:"BASE_URL"              envDefault:"http://localhost:8080"`
-	FrontendURL             string        `env:"FRONTEND_URL"`
-	CORSAllowedOrigins      []string      `env:"CORS_ALLOWED_ORIGINS"  envSeparator:","`
-	Mode                    string        `env:"MODE"                  envDefault:"all"`
+	// WorkerCapacityNodeID is stable for every blue/green worker generation
+	// sharing one Docker daemon. It scopes host-level sandbox admission locks
+	// independently from the generation-specific NodeID used for job ownership.
+	WorkerCapacityNodeID string   `env:"WORKER_CAPACITY_NODE_ID"`
+	NodeRegion           string   `env:"NODE_REGION"`
+	BaseURL              string   `env:"BASE_URL"              envDefault:"http://localhost:8080"`
+	FrontendURL          string   `env:"FRONTEND_URL"`
+	CORSAllowedOrigins   []string `env:"CORS_ALLOWED_ORIGINS"  envSeparator:","`
+	Mode                 string   `env:"MODE"                  envDefault:"all"`
 	// DemoMode tells the server it is running a dogfood preview with seeded
 	// data and no real GitHub App. Enables a credential banner on the login
 	// page and short-circuits GitHub client construction.
@@ -373,6 +378,22 @@ type Config struct {
 	RedisMasterName string `env:"REDIS_MASTER_NAME"`
 	RedisPassword   string `env:"REDIS_PASSWORD"`
 	RedisPoolSize   int    `env:"REDIS_POOL_SIZE" envDefault:"0"`
+}
+
+var workerGenerationNodeIDPattern = regexp.MustCompile(`^(.*)-g[0-9]{14}-[A-Za-z0-9._-]+$`)
+
+// EffectiveWorkerCapacityNodeID returns the physical-host identity used for
+// sandbox admission. Explicit configuration wins; the generation suffix
+// fallback keeps older worker env files safe during rollout.
+func (c Config) EffectiveWorkerCapacityNodeID() string {
+	if configured := strings.TrimSpace(c.WorkerCapacityNodeID); configured != "" {
+		return configured
+	}
+	nodeID := strings.TrimSpace(c.NodeID)
+	if matches := workerGenerationNodeIDPattern.FindStringSubmatch(nodeID); len(matches) == 2 {
+		return matches[1]
+	}
+	return nodeID
 }
 
 // ResolvePreviewDependencyCacheLocalDir normalizes the optional worker-local

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -887,6 +887,7 @@ func TestConfig_EffectiveWorkerCapacityNodeID(t *testing.T) {
 		expected   string
 	}{
 		{name: "explicit physical host identity wins", configured: "worker-host-a", nodeID: "worker-host-a-g20260813001234-deadbeef", expected: "worker-host-a"},
+		{name: "compose copied generation id is normalized", configured: "worker-host-a-g20260813001234-deadbeef", nodeID: "worker-host-a-g20260813001234-deadbeef", expected: "worker-host-a"},
 		{name: "blue green generation suffix falls back to physical host", nodeID: "worker-host-a-g20260813001234-deadbeef", expected: "worker-host-a"},
 		{name: "ordinary node id remains unchanged", nodeID: "single-node", expected: "single-node"},
 	}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -876,3 +876,27 @@ func TestPreviewOriginHostIsLocal(t *testing.T) {
 		})
 	}
 }
+
+func TestConfig_EffectiveWorkerCapacityNodeID(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		configured string
+		nodeID     string
+		expected   string
+	}{
+		{name: "explicit physical host identity wins", configured: "worker-host-a", nodeID: "worker-host-a-g20260813001234-deadbeef", expected: "worker-host-a"},
+		{name: "blue green generation suffix falls back to physical host", nodeID: "worker-host-a-g20260813001234-deadbeef", expected: "worker-host-a"},
+		{name: "ordinary node id remains unchanged", nodeID: "single-node", expected: "single-node"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			cfg := Config{NodeID: tt.nodeID, WorkerCapacityNodeID: tt.configured}
+			require.Equal(t, tt.expected, cfg.EffectiveWorkerCapacityNodeID(), "capacity identity should remain stable across deploy generations")
+		})
+	}
+}

--- a/internal/db/job_store_test.go
+++ b/internal/db/job_store_test.go
@@ -643,6 +643,7 @@ func TestJobStore_ClaimNextRunnable(t *testing.T) {
 					WithArgs(pgxmock.AnyArg(), "worker-1").
 					WillReturnRows(pgxmock.NewRows([]string{"id", "org_id", "job_type", "session_id", "workload_class", "status", "retry_window_started_at", "created_at"}).
 						AddRow(jobID, orgID, "run_agent", nil, models.SandboxWorkloadClassInteractive, models.JobStatusPending, nil, now))
+				expectSandboxClaimCandidateSavepoint(mock)
 				mock.ExpectQuery(`(?s)SELECT settings.*FROM organizations.*FOR NO KEY UPDATE`).
 					WithArgs(orgID).
 					WillReturnRows(pgxmock.NewRows([]string{"settings"}).AddRow([]byte(`{"max_concurrent_runs":3}`)))
@@ -676,6 +677,7 @@ func TestJobStore_ClaimNextRunnable(t *testing.T) {
 					WithArgs(pgxmock.AnyArg(), "worker-1").
 					WillReturnRows(pgxmock.NewRows([]string{"id", "org_id", "job_type", "session_id", "workload_class", "status", "retry_window_started_at", "created_at"}).
 						AddRow(jobID, orgID, "run_agent", nil, models.SandboxWorkloadClassInteractive, models.JobStatusPending, nil, now))
+				expectSandboxClaimCandidateSavepoint(mock)
 				mock.ExpectQuery(`(?s)SELECT settings.*FROM organizations.*FOR NO KEY UPDATE`).
 					WithArgs(orgID).
 					WillReturnRows(pgxmock.NewRows([]string{"settings"}).AddRow([]byte(`{"max_concurrent_runs":3}`)))
@@ -709,6 +711,7 @@ func TestJobStore_ClaimNextRunnable(t *testing.T) {
 					WithArgs(pgxmock.AnyArg(), "worker-1").
 					WillReturnRows(pgxmock.NewRows([]string{"id", "org_id", "job_type", "session_id", "workload_class", "status", "retry_window_started_at", "created_at"}).
 						AddRow(jobID, orgID, "run_agent", nil, models.SandboxWorkloadClassInteractive, models.JobStatusPending, persistedRetryStart, persistedRetryStart))
+				expectSandboxClaimCandidateSavepoint(mock)
 				mock.ExpectQuery("UPDATE jobs j[\\s\\S]*RETURNING j.id, j.org_id, j.queue, j.job_type").
 					WithArgs("worker-1", "worker-1", lockToken, int(leaseDuration.Seconds()), jobID).
 					WillReturnRows(pgxmock.NewRows([]string{
@@ -828,6 +831,7 @@ func TestJobStore_ClaimNextRunnableAtomicallyDefersAffinitySandboxTurnAtSharedOr
 				WithArgs(pgxmock.AnyArg(), "worker-1").
 				WillReturnRows(pgxmock.NewRows([]string{"id", "org_id", "job_type", "session_id", "workload_class", "status", "retry_window_started_at", "created_at"}).
 					AddRow(jobID, orgID, "continue_session", nil, tt.workloadClass, models.JobStatusPending, nil, time.Now().Add(-sandboxRoutingTerminalProbeAge-time.Minute)))
+			expectSandboxClaimCandidateSavepoint(mock)
 			mock.ExpectQuery(`(?s)SELECT settings.*FROM organizations.*FOR NO KEY UPDATE`).
 				WithArgs(orgID).
 				WillReturnRows(pgxmock.NewRows([]string{"settings"}).AddRow([]byte(`{"max_concurrent_runs":2}`)))
@@ -835,7 +839,7 @@ func TestJobStore_ClaimNextRunnableAtomicallyDefersAffinitySandboxTurnAtSharedOr
 				WithArgs(orgID, jobID).
 				WillReturnRows(pgxmock.NewRows([]string{"count"}).AddRow(2))
 			mock.ExpectExec(`(?s)UPDATE jobs.*jsonb_set\(payload, '\{capacity_waited\}'.*retry_window_started_at = CASE.*WHEN job_type = 'continue_session' THEN NULL.*target_node_id = CASE.*sandbox_slot_reserved_until IS NULL THEN target_node_id.*sandbox_slot_reserved_until = NULL`).
-				WithArgs(tt.workloadClass, int(sandboxOrgLimitRetryDelay.Seconds()), jobID).
+				WithArgs(tt.workloadClass, int(SandboxOrgLimitRetryDelay.Seconds()), jobID).
 				WillReturnResult(pgxmock.NewResult("UPDATE", 1))
 			mock.ExpectCommit()
 			mock.ExpectRollback()
@@ -851,6 +855,79 @@ func TestJobStore_ClaimNextRunnableAtomicallyDefersAffinitySandboxTurnAtSharedOr
 			require.NoError(t, mock.ExpectationsWereMet(), "claim should lock the org before counting all active turns and preserve ordinary affinity")
 		})
 	}
+}
+
+func TestJobStore_ClaimNextRunnableIsolatesInvalidSandboxCandidate(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "should create mock pool")
+	defer mock.Close()
+
+	jobID, orgID := uuid.New(), uuid.New()
+	mock.ExpectBegin()
+	mock.ExpectQuery(`(?s)WITH unavailable_target_nodes AS.*SELECT j.id, j.org_id, j.job_type`).
+		WithArgs(pgxmock.AnyArg(), "worker-1").
+		WillReturnRows(pgxmock.NewRows([]string{"id", "org_id", "job_type", "session_id", "workload_class", "status", "retry_window_started_at", "created_at"}).
+			AddRow(jobID, orgID, "run_agent", nil, models.SandboxWorkloadClassInteractive, models.JobStatusPending, nil, time.Now()))
+	expectSandboxClaimCandidateSavepoint(mock)
+	mock.ExpectQuery(`(?s)SELECT settings.*FROM organizations.*FOR NO KEY UPDATE`).
+		WithArgs(orgID).
+		WillReturnRows(pgxmock.NewRows([]string{"settings"}).AddRow([]byte(`{"session_automation":{"automatic_follow_through":{"pr_feedback_mode":"invalid"}}}`)))
+	mock.ExpectExec(`ROLLBACK TO SAVEPOINT sandbox_claim_candidate`).WillReturnResult(pgxmock.NewResult("ROLLBACK", 0))
+	mock.ExpectExec(`(?s)UPDATE jobs.*last_error = @last_error.*run_at = @run_at.*target_node_id = CASE.*sandbox_slot_reserved_until IS NULL THEN target_node_id.*sandbox_slot_reserved_until = NULL.*org_id = @org_id.*status = 'pending'`).
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), jobID, orgID).
+		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
+	mock.ExpectExec(`RELEASE SAVEPOINT sandbox_claim_candidate`).WillReturnResult(pgxmock.NewResult("RELEASE", 0))
+	mock.ExpectCommit()
+	mock.ExpectRollback()
+	mock.ExpectBegin()
+	mock.ExpectQuery(`(?s)WITH unavailable_target_nodes AS.*SELECT j.id, j.org_id, j.job_type`).
+		WithArgs(pgxmock.AnyArg(), "worker-1").
+		WillReturnError(pgx.ErrNoRows)
+	mock.ExpectRollback()
+
+	job, err := NewJobStore(mock).ClaimNextRunnable(context.Background(), "worker-1", "worker-1", uuid.New(), time.Minute)
+	require.NoError(t, err, "one invalid sandbox candidate should not fail the worker claim pass")
+	require.Nil(t, job, "invalid candidate should be deferred instead of claimed")
+	require.NoError(t, mock.ExpectationsWereMet(), "claim should isolate the failed candidate and continue its bounded scan")
+}
+
+func TestJobStore_ClaimNextRunnablePreservesInitialRunTerminalDeadlineAtOrgLimit(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "should create mock pool")
+	defer mock.Close()
+
+	jobID, orgID := uuid.New(), uuid.New()
+	mock.ExpectBegin()
+	mock.ExpectQuery(`(?s)WITH unavailable_target_nodes AS.*SELECT j.id, j.org_id, j.job_type`).
+		WithArgs(pgxmock.AnyArg(), "worker-1").
+		WillReturnRows(pgxmock.NewRows([]string{"id", "org_id", "job_type", "session_id", "workload_class", "status", "retry_window_started_at", "created_at"}).
+			AddRow(jobID, orgID, "run_agent", nil, models.SandboxWorkloadClassInteractive, models.JobStatusPending, nil, time.Now()))
+	expectSandboxClaimCandidateSavepoint(mock)
+	mock.ExpectQuery(`(?s)SELECT settings.*FROM organizations.*FOR NO KEY UPDATE`).
+		WithArgs(orgID).
+		WillReturnRows(pgxmock.NewRows([]string{"settings"}).AddRow([]byte(`{"max_concurrent_runs":1}`)))
+	mock.ExpectQuery(`(?s)SELECT COUNT\(\*\).*FROM jobs.*id <>.*job_type IN`).
+		WithArgs(orgID, jobID).
+		WillReturnRows(pgxmock.NewRows([]string{"count"}).AddRow(1))
+	mock.ExpectExec(`(?s)UPDATE jobs.*retry_window_started_at = CASE.*WHEN job_type = 'run_agent' AND attempts = 0 THEN created_at.*target_node_id = CASE`).
+		WithArgs(models.SandboxWorkloadClassInteractive, int(SandboxOrgLimitRetryDelay.Seconds()), jobID).
+		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
+	mock.ExpectCommit()
+	mock.ExpectRollback()
+	mock.ExpectBegin()
+	mock.ExpectQuery(`(?s)WITH unavailable_target_nodes AS.*SELECT j.id, j.org_id, j.job_type`).
+		WithArgs(pgxmock.AnyArg(), "worker-1").
+		WillReturnError(pgx.ErrNoRows)
+	mock.ExpectRollback()
+
+	job, err := NewJobStore(mock).ClaimNextRunnable(context.Background(), "worker-1", "worker-1", uuid.New(), time.Minute)
+	require.NoError(t, err, "metadata-fallback initial run should defer cleanly at the org limit")
+	require.Nil(t, job, "org-limited initial run should remain pending until its terminal deadline")
+	require.NoError(t, mock.ExpectationsWereMet(), "first claim deferral should anchor the terminal deadline to job creation")
 }
 
 func TestJobStore_ClaimNextRunnableBypassesOrgLimitForCancelledContinuation(t *testing.T) {
@@ -869,6 +946,7 @@ func TestJobStore_ClaimNextRunnableBypassesOrgLimitForCancelledContinuation(t *t
 		WithArgs(pgxmock.AnyArg(), "worker-1").
 		WillReturnRows(pgxmock.NewRows([]string{"id", "org_id", "job_type", "session_id", "workload_class", "status", "retry_window_started_at", "created_at"}).
 			AddRow(jobID, orgID, "continue_session", sessionID.String(), models.SandboxWorkloadClassCodeReview, models.JobStatusPending, nil, now))
+	expectSandboxClaimCandidateSavepoint(mock)
 	mock.ExpectQuery(`(?s)SELECT settings.*FROM organizations.*FOR NO KEY UPDATE`).
 		WithArgs(orgID).
 		WillReturnRows(pgxmock.NewRows([]string{"settings"}).AddRow([]byte(`{"max_concurrent_runs":1}`)))
@@ -1582,6 +1660,11 @@ func expectSandboxRoutingCandidateSavepoint(mock pgxmock.PgxPoolIface) {
 		WillReturnResult(pgxmock.NewResult("SAVEPOINT", 0))
 }
 
+func expectSandboxClaimCandidateSavepoint(mock pgxmock.PgxPoolIface) {
+	mock.ExpectExec(`SAVEPOINT sandbox_claim_candidate`).
+		WillReturnResult(pgxmock.NewResult("SAVEPOINT", 0))
+}
+
 func TestJobStore_RouteNextSandboxJob(t *testing.T) {
 	t.Parallel()
 
@@ -1648,7 +1731,7 @@ func TestJobStore_RouteNextSandboxJob(t *testing.T) {
 				WithArgs(orgID, jobID).
 				WillReturnRows(pgxmock.NewRows([]string{"count"}).AddRow(tt.activeTurns))
 			if tt.expectedReason != SandboxRoutingReasonOrgLimit {
-				candidateQuery := mock.ExpectQuery(`(?s)WITH raw_load AS.*candidate_load AS.*SELECT id.*FROM candidate_load`).
+				candidateQuery := mock.ExpectQuery(`(?s)WITH candidate_nodes AS.*raw_load AS.*candidate_load AS.*SELECT id.*FROM candidate_load`).
 					WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), tt.workloadClass)
 				if tt.candidateNodeID == "" {
 					candidateQuery.WillReturnRows(pgxmock.NewRows([]string{"id"}))
@@ -1752,7 +1835,7 @@ func TestJobStore_RouteNextSandboxJobFallsBackWhenFleetCapacityMetadataIsMissing
 	mock.ExpectQuery(`(?s)SELECT COUNT\(\*\).*FROM jobs.*id <>.*job_type IN`).
 		WithArgs(orgID, jobID).
 		WillReturnRows(pgxmock.NewRows([]string{"count"}).AddRow(0))
-	mock.ExpectQuery(`(?s)WITH raw_load AS.*candidate_load AS.*SELECT id.*FROM candidate_load`).
+	mock.ExpectQuery(`(?s)WITH candidate_nodes AS.*raw_load AS.*candidate_load AS.*SELECT id.*FROM candidate_load`).
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), models.SandboxWorkloadClassInteractive).
 		WillReturnError(pgx.ErrNoRows)
 	mock.ExpectQuery(`(?s)SELECT EXISTS.*max_active_sandboxes`).
@@ -1797,7 +1880,7 @@ func TestJobStore_RouteNextSandboxJobUsesTerminalProbeAfterBoundedDeferral(t *te
 	mock.ExpectQuery(`(?s)SELECT COUNT\(\*\).*FROM jobs.*id <>.*job_type IN`).
 		WithArgs(orgID, jobID).
 		WillReturnRows(pgxmock.NewRows([]string{"count"}).AddRow(0))
-	mock.ExpectQuery(`(?s)WITH raw_load AS.*candidate_load AS.*SELECT id.*FROM candidate_load`).
+	mock.ExpectQuery(`(?s)WITH candidate_nodes AS.*raw_load AS.*candidate_load AS.*SELECT id.*FROM candidate_load`).
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), models.SandboxWorkloadClassInteractive).
 		WillReturnError(pgx.ErrNoRows)
 	mock.ExpectQuery(`(?s)SELECT n.id.*FROM nodes n.*active_job_count`).
@@ -1840,7 +1923,7 @@ func TestJobStore_RouteNextSandboxJobUsesTerminalProbeForFleetBlockedContinuatio
 	mock.ExpectQuery(`(?s)SELECT COUNT\(\*\).*FROM jobs.*id <>.*job_type IN`).
 		WithArgs(orgID, jobID).
 		WillReturnRows(pgxmock.NewRows([]string{"count"}).AddRow(0))
-	mock.ExpectQuery(`(?s)WITH raw_load AS.*candidate_load AS.*SELECT id.*FROM candidate_load`).
+	mock.ExpectQuery(`(?s)WITH candidate_nodes AS.*raw_load AS.*candidate_load AS.*SELECT id.*FROM candidate_load`).
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), models.SandboxWorkloadClassInteractive).
 		WillReturnError(pgx.ErrNoRows)
 	mock.ExpectQuery(`(?s)SELECT n.id.*FROM nodes n.*active_job_count`).
@@ -1882,7 +1965,7 @@ func TestJobStore_RouteNextSandboxJobStartsFleetWindowAfterOrgWait(t *testing.T)
 	mock.ExpectQuery(`(?s)SELECT COUNT\(\*\).*FROM jobs.*id <>.*job_type IN`).
 		WithArgs(orgID, jobID).
 		WillReturnRows(pgxmock.NewRows([]string{"count"}).AddRow(0))
-	mock.ExpectQuery(`(?s)WITH raw_load AS.*candidate_load AS.*SELECT id.*FROM candidate_load`).
+	mock.ExpectQuery(`(?s)WITH candidate_nodes AS.*raw_load AS.*candidate_load AS.*SELECT id.*FROM candidate_load`).
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), models.SandboxWorkloadClassInteractive).
 		WillReturnError(pgx.ErrNoRows)
 	mock.ExpectQuery(`(?s)SELECT EXISTS.*max_active_sandboxes`).
@@ -2013,7 +2096,7 @@ func TestJobStore_RouteNextSandboxJobBypassesFleetCapacityForCancelledContinuati
 	mock.ExpectQuery(`(?s)SELECT COUNT\(\*\).*FROM jobs.*id <>.*job_type IN`).
 		WithArgs(orgID, jobID).
 		WillReturnRows(pgxmock.NewRows([]string{"count"}).AddRow(0))
-	mock.ExpectQuery(`(?s)WITH raw_load AS.*candidate_load AS.*SELECT id.*FROM candidate_load`).
+	mock.ExpectQuery(`(?s)WITH candidate_nodes AS.*raw_load AS.*candidate_load AS.*SELECT id.*FROM candidate_load`).
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), models.SandboxWorkloadClassInteractive).
 		WillReturnError(pgx.ErrNoRows)
 	mock.ExpectQuery(`(?s)SELECT s.status.*session_cancel_requests.*session_threads.*JOIN jobs payload_job.*capacity_cleanup.*s.deleted_at IS NULL`).
@@ -2253,6 +2336,38 @@ func TestJobStore_CountAdmittedSandboxTurnsByOrgIncludesPendingReservations(t *t
 	require.NoError(t, err, "admitted turn count should succeed")
 	require.Equal(t, 5, count, "runtime capacity should include running turns and pending durable reservations")
 	require.NoError(t, mock.ExpectationsWereMet(), "admitted turn count should remain scoped to the organization")
+}
+
+func TestJobStore_IsSessionWaitingForSandboxCapacity(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		waiting  bool
+		expected bool
+	}{
+		{name: "reports durable capacity wait", waiting: true, expected: true},
+		{name: "does not classify admitted reservation as waiting", expected: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			mock, err := pgxmock.NewPool()
+			require.NoError(t, err, "should create mock pool")
+			defer mock.Close()
+
+			orgID, sessionID := uuid.New(), uuid.New()
+			mock.ExpectQuery(`(?s)SELECT EXISTS.*FROM jobs.*org_id = @org_id.*payload->>'session_id' = @session_id.*sandbox_slot_reserved_until IS NULL.*sandbox_slot_reserved_until <= now\(\).*capacity_cleanup.*retry_window_started_at = waiting_job.created_at.*terminal_probe_seconds.*COUNT\(\*\).*>= @max_concurrent_runs`).
+				WithArgs(orgID, sessionID.String(), int(sandboxRoutingTerminalProbeAge.Seconds()), 2).
+				WillReturnRows(pgxmock.NewRows([]string{"waiting"}).AddRow(tt.waiting))
+
+			waiting, err := NewJobStore(mock).IsSessionWaitingForSandboxCapacity(context.Background(), orgID, sessionID, 2)
+			require.NoError(t, err, "session capacity wait lookup should succeed")
+			require.Equal(t, tt.expected, waiting, "session wait state should distinguish blocked work from its own reservation")
+			require.NoError(t, mock.ExpectationsWereMet(), "session wait lookup should remain tenant scoped")
+		})
+	}
 }
 
 func jobDedupeKeyPtr(s string) *string {

--- a/internal/db/job_store_test.go
+++ b/internal/db/job_store_test.go
@@ -1655,7 +1655,7 @@ func TestJobStore_RouteNextSandboxJob(t *testing.T) {
 						WillReturnRows(pgxmock.NewRows([]string{"locked"}).AddRow(true))
 					mock.ExpectQuery(`(?s)SELECT.*FROM nodes n.*WHERE n.id =`).
 						WithArgs(jobID, tt.candidateNodeID, pgxmock.AnyArg()).
-						WillReturnRows(pgxmock.NewRows([]string{"live", "local_reserved", "sandbox_turn_local_reserved", "max_active", "interactive_reserved", "pending_durable_reserved", "running_durable_reserved"}).AddRow(1, 0, 0, 4, 1, 0, 0))
+						WillReturnRows(pgxmock.NewRows([]string{"live", "local_reserved", "sandbox_turn_local_reserved", "max_active", "interactive_reserved", "pending_durable_reserved", "running_durable_reserved", "shared_turn_reserved", "shared_non_turn_reserved"}).AddRow(1, 0, 0, 4, 1, 0, 0, 0, 0))
 					mock.ExpectExec(`(?s)UPDATE jobs.*sandbox_slot_reserved_until =`).
 						WithArgs(tt.workloadClass, tt.candidateNodeID, pgxmock.AnyArg(), jobID, models.JobStatusPending).
 						WillReturnResult(pgxmock.NewResult("UPDATE", 1))
@@ -2084,11 +2084,17 @@ func TestSandboxRoutingCapacityLoadDoesNotDoubleCountRunningTurns(t *testing.T) 
 		sandboxTurnLocalReserved int
 		pendingDurable           int
 		runningDurable           int
+		sharedTurnReserved       int
+		sharedNonTurnReserved    int
 		expected                 int
 	}{
 		{name: "running turn overlaps local reservation", localReserved: 1, sandboxTurnLocalReserved: 1, runningDurable: 1, expected: 1},
 		{name: "pending reservation remains additive", localReserved: 1, sandboxTurnLocalReserved: 1, runningDurable: 1, pendingDurable: 1, expected: 2},
 		{name: "preview reservation remains independent", localReserved: 2, sandboxTurnLocalReserved: 1, runningDurable: 1, expected: 2},
+		{name: "shared preview reservation remains additive", runningDurable: 1, sharedNonTurnReserved: 1, expected: 2},
+		{name: "heartbeat and shared preview reservation overlap", localReserved: 1, sharedNonTurnReserved: 1, expected: 1},
+		{name: "heartbeat and shared turn reservation overlap", sandboxTurnLocalReserved: 1, sharedTurnReserved: 1, expected: 1},
+		{name: "shared executor turns exceed main-process heartbeat", sandboxTurnLocalReserved: 1, sharedTurnReserved: 2, expected: 2},
 		{name: "durable reservation covers pre-admission heartbeat lag", runningDurable: 1, expected: 1},
 		{name: "live sandboxes remain additive", live: 2, localReserved: 1, sandboxTurnLocalReserved: 1, runningDurable: 1, expected: 3},
 	}
@@ -2097,7 +2103,7 @@ func TestSandboxRoutingCapacityLoadDoesNotDoubleCountRunningTurns(t *testing.T) 
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			actual := sandboxRoutingCapacityLoad(tt.live, tt.localReserved, tt.sandboxTurnLocalReserved, tt.pendingDurable, tt.runningDurable)
+			actual := sandboxRoutingCapacityLoad(tt.live, tt.localReserved, tt.sandboxTurnLocalReserved, tt.pendingDurable, tt.runningDurable, tt.sharedTurnReserved, tt.sharedNonTurnReserved)
 			require.Equal(t, tt.expected, actual, "capacity load should count each distinct sandbox or reservation exactly once")
 		})
 	}

--- a/internal/db/job_store_test.go
+++ b/internal/db/job_store_test.go
@@ -2281,6 +2281,24 @@ func TestJobStore_ReleaseSandboxRoutingPlacementWithLease(t *testing.T) {
 	require.NoError(t, mock.ExpectationsWereMet(), "placement release should clear the target only for a durable reservation owned by the current lease")
 }
 
+func TestJobStore_ClearSandboxRoutingPlacementWithLease(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "should create mock pool")
+	defer mock.Close()
+
+	jobID, lockToken := uuid.New(), uuid.New()
+	mock.ExpectExec(`(?s)UPDATE jobs.*target_node_id = NULL.*sandbox_slot_reserved_until = NULL.*lock_token = \$2`).
+		WithArgs(jobID, lockToken).
+		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
+
+	cleared, err := NewJobStore(mock).ClearSandboxRoutingPlacementWithLease(context.Background(), jobID, lockToken)
+	require.NoError(t, err, "fenced fresh-sandbox failure cleanup should succeed")
+	require.True(t, cleared, "matching running job lease should clear worker affinity even without a durable slot")
+	require.NoError(t, mock.ExpectationsWereMet(), "fresh-sandbox failure cleanup should require the current fencing token")
+}
+
 func TestJobStore_ReserveSandboxSlotForRetryRequiresCurrentLease(t *testing.T) {
 	t.Parallel()
 

--- a/internal/db/job_store_test.go
+++ b/internal/db/job_store_test.go
@@ -1,6 +1,7 @@
 package db
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"os"
@@ -1146,6 +1147,32 @@ func TestJobStore_RenewLease(t *testing.T) {
 			require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
 		})
 	}
+}
+
+func TestJobStore_RenewSandboxCapacityLease_LogsFailure(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "should create mock pool")
+	defer mock.Close()
+
+	jobID := uuid.MustParse("11111111-1111-1111-1111-111111111111")
+	lockToken := uuid.MustParse("22222222-2222-2222-2222-222222222222")
+	mock.ExpectExec(`(?s)UPDATE sandbox_capacity_reservations.*SET expires_at = GREATEST\(expires_at, now\(\) \+.*job_id = @job_id.*job_lock_token = @lock_token`).
+		WithArgs(int(sandboxCapacityJobLeaseRenewalTTL.Seconds()), jobID, lockToken).
+		WillReturnError(errors.New("renewal failed"))
+
+	var logOutput bytes.Buffer
+	store := NewJobStore(mock)
+	store.SetLogger(zerolog.New(&logOutput))
+	store.renewSandboxCapacityLease(context.Background(), jobID, lockToken)
+
+	require.Equal(t,
+		"{\"level\":\"warn\",\"error\":\"renewal failed\",\"job_id\":\"11111111-1111-1111-1111-111111111111\",\"message\":\"failed to renew sandbox capacity lease\"}\n",
+		logOutput.String(),
+		"capacity lease renewal failures should emit a structured warning without failing the job lease",
+	)
+	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
 }
 
 func TestJobStore_RenewLease_GuardsSessionJobsAgainstTerminalSessions(t *testing.T) {

--- a/internal/db/job_store_test.go
+++ b/internal/db/job_store_test.go
@@ -1075,6 +1075,9 @@ func TestJobStore_RenewLease_GuardsSessionJobsAgainstTerminalSessions(t *testing
 	require.Contains(t, sql, "payload->>'session_id'", "RenewLease should inspect the durable session reference in session job payloads")
 	require.Contains(t, sql, "s.status NOT IN ('completed', 'failed', 'cancelled', 'skipped')", "RenewLease should refuse renewal when the referenced session is terminal")
 	require.Contains(t, sql, "s.org_id = jobs.org_id", "RenewLease should scope the session guard to the job org")
+	require.NotContains(t, sql, "sandbox_session.id::text = payload->>'session_id'", "reservation renewal should not cast away the sessions primary-key index")
+	require.NotContains(t, sql, "s.id::text = payload->>'session_id'", "terminal-session renewal checks should not cast away the sessions primary-key index")
+	require.Contains(t, sql, "THEN (payload->>'session_id')::uuid", "renewal should guard and cast the payload value for indexed UUID lookup")
 }
 
 func TestJobStore_TerminalizeRunningSessionJobs(t *testing.T) {
@@ -2095,6 +2098,8 @@ func TestSandboxRoutingCapacityLoadDoesNotDoubleCountRunningTurns(t *testing.T) 
 		{name: "heartbeat and shared preview reservation overlap", localReserved: 1, sharedNonTurnReserved: 1, expected: 1},
 		{name: "heartbeat and shared turn reservation overlap", sandboxTurnLocalReserved: 1, sharedTurnReserved: 1, expected: 1},
 		{name: "shared executor turns exceed main-process heartbeat", sandboxTurnLocalReserved: 1, sharedTurnReserved: 2, expected: 2},
+		{name: "durable and shared turns are disjoint", runningDurable: 1, sharedTurnReserved: 1, expected: 2},
+		{name: "heartbeat overlaps combined durable and shared turns", sandboxTurnLocalReserved: 2, runningDurable: 1, sharedTurnReserved: 1, expected: 2},
 		{name: "durable reservation covers pre-admission heartbeat lag", runningDurable: 1, expected: 1},
 		{name: "live sandboxes remain additive", live: 2, localReserved: 1, sandboxTurnLocalReserved: 1, runningDurable: 1, expected: 3},
 	}

--- a/internal/db/job_store_test.go
+++ b/internal/db/job_store_test.go
@@ -1577,6 +1577,11 @@ func TestJobStore_SelectWorkerWithSandboxCapacity_NoAvailableWorker(t *testing.T
 	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
 }
 
+func expectSandboxRoutingCandidateSavepoint(mock pgxmock.PgxPoolIface) {
+	mock.ExpectExec(`SAVEPOINT sandbox_route_candidate`).
+		WillReturnResult(pgxmock.NewResult("SAVEPOINT", 0))
+}
+
 func TestJobStore_RouteNextSandboxJob(t *testing.T) {
 	t.Parallel()
 
@@ -1631,6 +1636,7 @@ func TestJobStore_RouteNextSandboxJob(t *testing.T) {
 				WithArgs(pgxmock.AnyArg()).
 				WillReturnRows(pgxmock.NewRows([]string{"id", "org_id", "job_type", "session_id", "workload_class", "status", "retry_window_started_at", "created_at"}).
 					AddRow(jobID, orgID, tt.jobType, nil, tt.workloadClass, models.JobStatusPending, nil, time.Now().Add(-tt.jobAge)))
+			expectSandboxRoutingCandidateSavepoint(mock)
 			orgSettings := tt.orgSettings
 			if orgSettings == "" {
 				orgSettings = `{"max_concurrent_runs":3}`
@@ -1657,7 +1663,7 @@ func TestJobStore_RouteNextSandboxJob(t *testing.T) {
 						WithArgs(tt.candidateNodeID).
 						WillReturnRows(pgxmock.NewRows([]string{"locked"}).AddRow(true))
 					mock.ExpectQuery(`(?s)SELECT.*FROM nodes n.*WHERE n.id =`).
-						WithArgs(jobID, tt.candidateNodeID, pgxmock.AnyArg()).
+						WithArgs(tt.candidateNodeID, pgxmock.AnyArg(), jobID).
 						WillReturnRows(pgxmock.NewRows([]string{"live", "local_reserved", "sandbox_turn_local_reserved", "max_active", "interactive_reserved", "pending_durable_reserved", "running_durable_reserved", "shared_turn_reserved", "shared_non_turn_reserved"}).AddRow(1, 0, 0, 4, 1, 0, 0, 0, 0))
 					mock.ExpectExec(`(?s)UPDATE jobs.*sandbox_slot_reserved_until =`).
 						WithArgs(tt.workloadClass, tt.candidateNodeID, pgxmock.AnyArg(), jobID, models.JobStatusPending).
@@ -1691,6 +1697,41 @@ func TestJobStore_RouteNextSandboxJob(t *testing.T) {
 	}
 }
 
+func TestJobStore_RouteNextSandboxJobIsolatesInvalidOrgSettings(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "should create mock pool")
+	defer mock.Close()
+
+	jobID, orgID := uuid.New(), uuid.New()
+	mock.ExpectBegin()
+	mock.ExpectQuery(`(?s)SELECT j.id, j.org_id,.*FROM jobs j.*FOR UPDATE OF j SKIP LOCKED`).
+		WithArgs(pgxmock.AnyArg()).
+		WillReturnRows(pgxmock.NewRows([]string{"id", "org_id", "job_type", "session_id", "workload_class", "status", "retry_window_started_at", "created_at"}).
+			AddRow(jobID, orgID, "run_agent", nil, models.SandboxWorkloadClassInteractive, models.JobStatusPending, nil, time.Now()))
+	expectSandboxRoutingCandidateSavepoint(mock)
+	mock.ExpectQuery(`(?s)SELECT settings.*FROM organizations.*FOR NO KEY UPDATE`).
+		WithArgs(orgID).
+		WillReturnRows(pgxmock.NewRows([]string{"settings"}).AddRow([]byte(`{"session_automation":{"automatic_follow_through":{"pr_feedback_mode":"invalid"}}}`)))
+	mock.ExpectExec(`ROLLBACK TO SAVEPOINT sandbox_route_candidate`).WillReturnResult(pgxmock.NewResult("ROLLBACK", 0))
+	mock.ExpectExec(`(?s)UPDATE jobs.*target_node_id = NULL.*sandbox_slot_reserved_until = NULL.*last_error = @last_error.*run_at = @run_at.*org_id = @org_id.*status = 'pending'`).
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), jobID, orgID).
+		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
+	mock.ExpectExec(`RELEASE SAVEPOINT sandbox_route_candidate`).WillReturnResult(pgxmock.NewResult("RELEASE", 0))
+	mock.ExpectCommit()
+	mock.ExpectRollback()
+
+	result, err := NewJobStore(mock).RouteNextSandboxJob(context.Background())
+	require.NoError(t, err, "invalid settings on one job should not fail the fleet routing pass")
+	require.NotNil(t, result, "isolated routing failure should return a durable deferral result")
+	require.Equal(t, jobID, result.JobID, "routing failure should identify only the affected job")
+	require.Equal(t, SandboxRoutingReasonJobError, result.Reason, "routing failure should expose its operational reason")
+	require.True(t, result.Deferred, "routing failure should move the affected job behind other due work")
+	require.Contains(t, result.RoutingError, "invalid PR feedback human mode", "routing result should preserve the actionable configuration error")
+	require.NoError(t, mock.ExpectationsWereMet(), "invalid job configuration should roll back routing before deferring only that job")
+}
+
 func TestJobStore_RouteNextSandboxJobFallsBackWhenFleetCapacityMetadataIsMissing(t *testing.T) {
 	t.Parallel()
 
@@ -1704,6 +1745,7 @@ func TestJobStore_RouteNextSandboxJobFallsBackWhenFleetCapacityMetadataIsMissing
 		WithArgs(pgxmock.AnyArg()).
 		WillReturnRows(pgxmock.NewRows([]string{"id", "org_id", "job_type", "session_id", "workload_class", "status", "retry_window_started_at", "created_at"}).
 			AddRow(jobID, orgID, "run_agent", nil, models.SandboxWorkloadClassInteractive, models.JobStatusPending, nil, time.Now()))
+	expectSandboxRoutingCandidateSavepoint(mock)
 	mock.ExpectQuery(`(?s)SELECT settings.*FROM organizations`).
 		WithArgs(orgID).
 		WillReturnRows(pgxmock.NewRows([]string{"settings"}).AddRow([]byte(`{"max_concurrent_runs":3}`)))
@@ -1748,6 +1790,7 @@ func TestJobStore_RouteNextSandboxJobUsesTerminalProbeAfterBoundedDeferral(t *te
 		WithArgs(pgxmock.AnyArg()).
 		WillReturnRows(pgxmock.NewRows([]string{"id", "org_id", "job_type", "session_id", "workload_class", "status", "retry_window_started_at", "created_at"}).
 			AddRow(jobID, orgID, "run_agent", nil, models.SandboxWorkloadClassInteractive, models.JobStatusPending, time.Now().Add(-time.Minute), time.Now().Add(-sandboxRoutingTerminalProbeAge-time.Minute)))
+	expectSandboxRoutingCandidateSavepoint(mock)
 	mock.ExpectQuery(`(?s)SELECT settings.*FROM organizations`).
 		WithArgs(orgID).
 		WillReturnRows(pgxmock.NewRows([]string{"settings"}).AddRow([]byte(`{"max_concurrent_runs":3}`)))
@@ -1790,6 +1833,7 @@ func TestJobStore_RouteNextSandboxJobUsesTerminalProbeForFleetBlockedContinuatio
 		WithArgs(pgxmock.AnyArg()).
 		WillReturnRows(pgxmock.NewRows([]string{"id", "org_id", "job_type", "session_id", "workload_class", "status", "retry_window_started_at", "created_at"}).
 			AddRow(jobID, orgID, "continue_session", nil, models.SandboxWorkloadClassInteractive, models.JobStatusPending, fleetWaitStartedAt, time.Now().Add(-2*sandboxRoutingTerminalProbeAge)))
+	expectSandboxRoutingCandidateSavepoint(mock)
 	mock.ExpectQuery(`(?s)SELECT settings.*FROM organizations`).
 		WithArgs(orgID).
 		WillReturnRows(pgxmock.NewRows([]string{"settings"}).AddRow([]byte(`{"max_concurrent_runs":3}`)))
@@ -1831,6 +1875,7 @@ func TestJobStore_RouteNextSandboxJobStartsFleetWindowAfterOrgWait(t *testing.T)
 		WithArgs(pgxmock.AnyArg()).
 		WillReturnRows(pgxmock.NewRows([]string{"id", "org_id", "job_type", "session_id", "workload_class", "status", "retry_window_started_at", "created_at"}).
 			AddRow(jobID, orgID, "continue_session", nil, models.SandboxWorkloadClassInteractive, models.JobStatusPending, nil, time.Now().Add(-2*sandboxRoutingTerminalProbeAge)))
+	expectSandboxRoutingCandidateSavepoint(mock)
 	mock.ExpectQuery(`(?s)SELECT settings.*FROM organizations.*FOR NO KEY UPDATE`).
 		WithArgs(orgID).
 		WillReturnRows(pgxmock.NewRows([]string{"settings"}).AddRow([]byte(`{"max_concurrent_runs":3}`)))
@@ -1871,6 +1916,7 @@ func TestJobStore_RouteNextSandboxJobUsesTerminalProbeAtOrgLimitForInitialRun(t 
 		WithArgs(pgxmock.AnyArg()).
 		WillReturnRows(pgxmock.NewRows([]string{"id", "org_id", "job_type", "session_id", "workload_class", "status", "retry_window_started_at", "created_at"}).
 			AddRow(jobID, orgID, "run_agent", nil, models.SandboxWorkloadClassInteractive, models.JobStatusPending, time.Now().Add(-time.Minute), time.Now().Add(-sandboxRoutingTerminalProbeAge-time.Minute)))
+	expectSandboxRoutingCandidateSavepoint(mock)
 	mock.ExpectQuery(`(?s)SELECT settings.*FROM organizations`).
 		WithArgs(orgID).
 		WillReturnRows(pgxmock.NewRows([]string{"settings"}).AddRow([]byte(`{"max_concurrent_runs":2}`)))
@@ -1910,6 +1956,7 @@ func TestJobStore_RouteNextSandboxJobBypassesOrgLimitForCancelledContinuation(t 
 		WithArgs(pgxmock.AnyArg()).
 		WillReturnRows(pgxmock.NewRows([]string{"id", "org_id", "job_type", "session_id", "workload_class", "status", "retry_window_started_at", "created_at"}).
 			AddRow(jobID, orgID, "continue_session", sessionID.String(), models.SandboxWorkloadClassCodeReview, models.JobStatusPending, nil, createdAt))
+	expectSandboxRoutingCandidateSavepoint(mock)
 	mock.ExpectQuery(`(?s)SELECT settings.*FROM organizations.*FOR NO KEY UPDATE`).
 		WithArgs(orgID).
 		WillReturnRows(pgxmock.NewRows([]string{"settings"}).AddRow([]byte(`{"max_concurrent_runs":1}`)))
@@ -1956,6 +2003,7 @@ func TestJobStore_RouteNextSandboxJobBypassesFleetCapacityForCancelledContinuati
 		WithArgs(pgxmock.AnyArg()).
 		WillReturnRows(pgxmock.NewRows([]string{"id", "org_id", "job_type", "session_id", "workload_class", "status", "retry_window_started_at", "created_at"}).
 			AddRow(jobID, orgID, "continue_session", sessionID.String(), models.SandboxWorkloadClassInteractive, models.JobStatusPending, nil, createdAt))
+	expectSandboxRoutingCandidateSavepoint(mock)
 	mock.ExpectQuery(`(?s)SELECT origin.*FROM sessions.*org_id = @org_id.*id = @session_id`).
 		WithArgs(orgID, sessionID).
 		WillReturnRows(pgxmock.NewRows([]string{"origin"}).AddRow(models.SessionOriginManual))
@@ -2185,8 +2233,26 @@ func TestJobStore_CountActiveSandboxTurnsByOrgUsesSharedPool(t *testing.T) {
 
 	count, err := NewJobStore(mock).CountActiveSandboxTurnsByOrg(context.Background(), orgID)
 	require.NoError(t, err, "shared turn count should succeed")
-	require.Equal(t, 4, count, "shared turn count should include interactive and code-review jobs")
+	require.Equal(t, 4, count, "shared turn count should include running turns across both workload classes")
 	require.NoError(t, mock.ExpectationsWereMet(), "shared turn count should remain scoped to the organization")
+}
+
+func TestJobStore_CountAdmittedSandboxTurnsByOrgIncludesPendingReservations(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "should create mock pool")
+	defer mock.Close()
+
+	orgID := uuid.New()
+	mock.ExpectQuery(`(?s)SELECT COUNT\(\*\).*FROM jobs.*org_id = @org_id.*job_type IN.*status = 'running'.*status = 'pending'.*sandbox_slot_reserved_until > now\(\)`).
+		WithArgs(orgID).
+		WillReturnRows(pgxmock.NewRows([]string{"count"}).AddRow(5))
+
+	count, err := NewJobStore(mock).CountAdmittedSandboxTurnsByOrg(context.Background(), orgID)
+	require.NoError(t, err, "admitted turn count should succeed")
+	require.Equal(t, 5, count, "runtime capacity should include running turns and pending durable reservations")
+	require.NoError(t, mock.ExpectationsWereMet(), "admitted turn count should remain scoped to the organization")
 }
 
 func jobDedupeKeyPtr(s string) *string {

--- a/internal/db/job_store_test.go
+++ b/internal/db/job_store_test.go
@@ -1073,6 +1073,12 @@ func TestJobStore_RenewLease(t *testing.T) {
 				mock.ExpectQuery("UPDATE jobs SET lease_expires_at = now\\(\\) \\+[\\s\\S]*sandbox_slot_reserved_until = CASE[\\s\\S]*sandbox_session.container_id IS NOT NULL[\\s\\S]*ELSE now\\(\\) \\+").
 					WithArgs(int(leaseDuration.Seconds()), uuid.MustParse("11111111-1111-1111-1111-111111111111"), lockToken).
 					WillReturnRows(pgxmock.NewRows([]string{"lease_expires_at"}).AddRow(time.Now().Add(leaseDuration)))
+				// A successful renewal also keeps the job-backed shared
+				// final-admission lease fresh so its short TTL only fences
+				// dead attempts.
+				mock.ExpectExec(`(?s)UPDATE sandbox_capacity_reservations.*SET expires_at = GREATEST\(expires_at, now\(\) \+.*job_id = @job_id.*job_lock_token = @lock_token`).
+					WithArgs(int(sandboxCapacityJobLeaseRenewalTTL.Seconds()), uuid.MustParse("11111111-1111-1111-1111-111111111111"), lockToken).
+					WillReturnResult(pgxmock.NewResult("UPDATE", 1))
 			},
 			wantActive: true,
 		},

--- a/internal/db/job_store_test.go
+++ b/internal/db/job_store_test.go
@@ -640,7 +640,7 @@ func TestJobStore_ClaimNextRunnable(t *testing.T) {
 				now := time.Now()
 				mock.ExpectBegin()
 				mock.ExpectQuery("WITH unavailable_target_nodes AS[\\s\\S]*SELECT j.id, j.org_id, j.job_type").
-					WithArgs(pgxmock.AnyArg(), "worker-1").
+					WithArgs(pgxmock.AnyArg(), "worker-1", []uuid.UUID{}).
 					WillReturnRows(pgxmock.NewRows([]string{"id", "org_id", "job_type", "session_id", "workload_class", "status", "retry_window_started_at", "created_at"}).
 						AddRow(jobID, orgID, "run_agent", nil, models.SandboxWorkloadClassInteractive, models.JobStatusPending, nil, now))
 				expectSandboxClaimCandidateSavepoint(mock)
@@ -674,7 +674,7 @@ func TestJobStore_ClaimNextRunnable(t *testing.T) {
 				completedAt := now.Add(time.Minute)
 				mock.ExpectBegin()
 				mock.ExpectQuery("WITH unavailable_target_nodes AS[\\s\\S]*SELECT j.id, j.org_id, j.job_type").
-					WithArgs(pgxmock.AnyArg(), "worker-1").
+					WithArgs(pgxmock.AnyArg(), "worker-1", []uuid.UUID{}).
 					WillReturnRows(pgxmock.NewRows([]string{"id", "org_id", "job_type", "session_id", "workload_class", "status", "retry_window_started_at", "created_at"}).
 						AddRow(jobID, orgID, "run_agent", nil, models.SandboxWorkloadClassInteractive, models.JobStatusPending, nil, now))
 				expectSandboxClaimCandidateSavepoint(mock)
@@ -708,7 +708,7 @@ func TestJobStore_ClaimNextRunnable(t *testing.T) {
 				now := time.Now()
 				mock.ExpectBegin()
 				mock.ExpectQuery("WITH unavailable_target_nodes AS[\\s\\S]*SELECT j.id, j.org_id, j.job_type").
-					WithArgs(pgxmock.AnyArg(), "worker-1").
+					WithArgs(pgxmock.AnyArg(), "worker-1", []uuid.UUID{}).
 					WillReturnRows(pgxmock.NewRows([]string{"id", "org_id", "job_type", "session_id", "workload_class", "status", "retry_window_started_at", "created_at"}).
 						AddRow(jobID, orgID, "run_agent", nil, models.SandboxWorkloadClassInteractive, models.JobStatusPending, persistedRetryStart, persistedRetryStart))
 				expectSandboxClaimCandidateSavepoint(mock)
@@ -733,7 +733,7 @@ func TestJobStore_ClaimNextRunnable(t *testing.T) {
 			setupMock: func(mock pgxmock.PgxPoolIface, leaseDuration time.Duration, lockToken uuid.UUID) {
 				mock.ExpectBegin()
 				mock.ExpectQuery("WITH unavailable_target_nodes AS[\\s\\S]*SELECT j.id, j.org_id, j.job_type").
-					WithArgs(pgxmock.AnyArg(), "worker-1").
+					WithArgs(pgxmock.AnyArg(), "worker-1", []uuid.UUID{}).
 					WillReturnError(pgx.ErrNoRows)
 				mock.ExpectRollback()
 			},
@@ -744,7 +744,7 @@ func TestJobStore_ClaimNextRunnable(t *testing.T) {
 			setupMock: func(mock pgxmock.PgxPoolIface, leaseDuration time.Duration, lockToken uuid.UUID) {
 				mock.ExpectBegin()
 				mock.ExpectQuery("WITH unavailable_target_nodes AS[\\s\\S]*SELECT j.id, j.org_id, j.job_type").
-					WithArgs(pgxmock.AnyArg(), "worker-1").
+					WithArgs(pgxmock.AnyArg(), "worker-1", []uuid.UUID{}).
 					WillReturnError(errors.New("db down"))
 				mock.ExpectRollback()
 			},
@@ -796,7 +796,7 @@ func TestJobStore_ClaimNextRunnableRequiresSandboxRouting(t *testing.T) {
 	lockToken := uuid.New()
 	mock.ExpectBegin()
 	mock.ExpectQuery(`(?s)WITH unavailable_target_nodes AS.*j.job_type NOT IN \('run_agent', 'continue_session'\) OR j.target_node_id IS NOT NULL.*d.id IS NOT NULL AND j.sandbox_slot_reserved_until IS NULL.*ORDER BY.*j.priority DESC,.*CASE.*j.run_at ASC,.*j.created_at ASC`).
-		WithArgs(pgxmock.AnyArg(), "worker-1").
+		WithArgs(pgxmock.AnyArg(), "worker-1", []uuid.UUID{}).
 		WillReturnError(pgx.ErrNoRows)
 	mock.ExpectRollback()
 
@@ -828,7 +828,7 @@ func TestJobStore_ClaimNextRunnableAtomicallyDefersAffinitySandboxTurnAtSharedOr
 			jobID, orgID := uuid.New(), uuid.New()
 			mock.ExpectBegin()
 			mock.ExpectQuery(`(?s)WITH unavailable_target_nodes AS.*SELECT j.id, j.org_id, j.job_type`).
-				WithArgs(pgxmock.AnyArg(), "worker-1").
+				WithArgs(pgxmock.AnyArg(), "worker-1", []uuid.UUID{}).
 				WillReturnRows(pgxmock.NewRows([]string{"id", "org_id", "job_type", "session_id", "workload_class", "status", "retry_window_started_at", "created_at"}).
 					AddRow(jobID, orgID, "continue_session", nil, tt.workloadClass, models.JobStatusPending, nil, time.Now().Add(-sandboxRoutingTerminalProbeAge-time.Minute)))
 			expectSandboxClaimCandidateSavepoint(mock)
@@ -845,7 +845,7 @@ func TestJobStore_ClaimNextRunnableAtomicallyDefersAffinitySandboxTurnAtSharedOr
 			mock.ExpectRollback()
 			mock.ExpectBegin()
 			mock.ExpectQuery(`(?s)WITH unavailable_target_nodes AS.*SELECT j.id, j.org_id, j.job_type`).
-				WithArgs(pgxmock.AnyArg(), "worker-1").
+				WithArgs(pgxmock.AnyArg(), "worker-1", []uuid.UUID{orgID}).
 				WillReturnError(pgx.ErrNoRows)
 			mock.ExpectRollback()
 
@@ -867,7 +867,7 @@ func TestJobStore_ClaimNextRunnableIsolatesInvalidSandboxCandidate(t *testing.T)
 	jobID, orgID := uuid.New(), uuid.New()
 	mock.ExpectBegin()
 	mock.ExpectQuery(`(?s)WITH unavailable_target_nodes AS.*SELECT j.id, j.org_id, j.job_type`).
-		WithArgs(pgxmock.AnyArg(), "worker-1").
+		WithArgs(pgxmock.AnyArg(), "worker-1", []uuid.UUID{}).
 		WillReturnRows(pgxmock.NewRows([]string{"id", "org_id", "job_type", "session_id", "workload_class", "status", "retry_window_started_at", "created_at"}).
 			AddRow(jobID, orgID, "run_agent", nil, models.SandboxWorkloadClassInteractive, models.JobStatusPending, nil, time.Now()))
 	expectSandboxClaimCandidateSavepoint(mock)
@@ -883,7 +883,7 @@ func TestJobStore_ClaimNextRunnableIsolatesInvalidSandboxCandidate(t *testing.T)
 	mock.ExpectRollback()
 	mock.ExpectBegin()
 	mock.ExpectQuery(`(?s)WITH unavailable_target_nodes AS.*SELECT j.id, j.org_id, j.job_type`).
-		WithArgs(pgxmock.AnyArg(), "worker-1").
+		WithArgs(pgxmock.AnyArg(), "worker-1", []uuid.UUID{}).
 		WillReturnError(pgx.ErrNoRows)
 	mock.ExpectRollback()
 
@@ -903,7 +903,7 @@ func TestJobStore_ClaimNextRunnablePreservesInitialRunTerminalDeadlineAtOrgLimit
 	jobID, orgID := uuid.New(), uuid.New()
 	mock.ExpectBegin()
 	mock.ExpectQuery(`(?s)WITH unavailable_target_nodes AS.*SELECT j.id, j.org_id, j.job_type`).
-		WithArgs(pgxmock.AnyArg(), "worker-1").
+		WithArgs(pgxmock.AnyArg(), "worker-1", []uuid.UUID{}).
 		WillReturnRows(pgxmock.NewRows([]string{"id", "org_id", "job_type", "session_id", "workload_class", "status", "retry_window_started_at", "created_at"}).
 			AddRow(jobID, orgID, "run_agent", nil, models.SandboxWorkloadClassInteractive, models.JobStatusPending, nil, time.Now()))
 	expectSandboxClaimCandidateSavepoint(mock)
@@ -920,7 +920,7 @@ func TestJobStore_ClaimNextRunnablePreservesInitialRunTerminalDeadlineAtOrgLimit
 	mock.ExpectRollback()
 	mock.ExpectBegin()
 	mock.ExpectQuery(`(?s)WITH unavailable_target_nodes AS.*SELECT j.id, j.org_id, j.job_type`).
-		WithArgs(pgxmock.AnyArg(), "worker-1").
+		WithArgs(pgxmock.AnyArg(), "worker-1", []uuid.UUID{orgID}).
 		WillReturnError(pgx.ErrNoRows)
 	mock.ExpectRollback()
 
@@ -943,7 +943,7 @@ func TestJobStore_ClaimNextRunnableBypassesOrgLimitForCancelledContinuation(t *t
 	leaseDuration := time.Minute
 	mock.ExpectBegin()
 	mock.ExpectQuery(`(?s)WITH unavailable_target_nodes AS.*SELECT j.id, j.org_id, j.job_type`).
-		WithArgs(pgxmock.AnyArg(), "worker-1").
+		WithArgs(pgxmock.AnyArg(), "worker-1", []uuid.UUID{}).
 		WillReturnRows(pgxmock.NewRows([]string{"id", "org_id", "job_type", "session_id", "workload_class", "status", "retry_window_started_at", "created_at"}).
 			AddRow(jobID, orgID, "continue_session", sessionID.String(), models.SandboxWorkloadClassCodeReview, models.JobStatusPending, nil, now))
 	expectSandboxClaimCandidateSavepoint(mock)
@@ -1731,8 +1731,8 @@ func TestJobStore_RouteNextSandboxJob(t *testing.T) {
 				WithArgs(orgID, jobID).
 				WillReturnRows(pgxmock.NewRows([]string{"count"}).AddRow(tt.activeTurns))
 			if tt.expectedReason != SandboxRoutingReasonOrgLimit {
-				candidateQuery := mock.ExpectQuery(`(?s)WITH candidate_nodes AS.*raw_load AS.*candidate_load AS.*SELECT id.*FROM candidate_load`).
-					WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), tt.workloadClass)
+				candidateQuery := mock.ExpectQuery(`(?s)WITH excluded_capacity_nodes AS.*candidate_nodes AS.*raw_load AS.*reserved_job.status = 'pending'.*reserved_job.id <> @job_id.*reserved_job.status = 'running'.*reserved_job.id <> @job_id.*candidate_load AS.*SELECT id.*FROM candidate_load`).
+					WithArgs(jobID, orgID, pgxmock.AnyArg(), pgxmock.AnyArg(), tt.workloadClass)
 				if tt.candidateNodeID == "" {
 					candidateQuery.WillReturnRows(pgxmock.NewRows([]string{"id"}))
 					if tt.expectedReason == SandboxRoutingReasonFleetCapacity {
@@ -1835,14 +1835,14 @@ func TestJobStore_RouteNextSandboxJobFallsBackWhenFleetCapacityMetadataIsMissing
 	mock.ExpectQuery(`(?s)SELECT COUNT\(\*\).*FROM jobs.*id <>.*job_type IN`).
 		WithArgs(orgID, jobID).
 		WillReturnRows(pgxmock.NewRows([]string{"count"}).AddRow(0))
-	mock.ExpectQuery(`(?s)WITH candidate_nodes AS.*raw_load AS.*candidate_load AS.*SELECT id.*FROM candidate_load`).
-		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), models.SandboxWorkloadClassInteractive).
+	mock.ExpectQuery(`(?s)WITH excluded_capacity_nodes AS.*candidate_nodes AS.*raw_load AS.*candidate_load AS.*SELECT id.*FROM candidate_load`).
+		WithArgs(jobID, orgID, pgxmock.AnyArg(), pgxmock.AnyArg(), models.SandboxWorkloadClassInteractive).
 		WillReturnError(pgx.ErrNoRows)
 	mock.ExpectQuery(`(?s)SELECT EXISTS.*max_active_sandboxes`).
 		WithArgs(pgxmock.AnyArg()).
 		WillReturnRows(pgxmock.NewRows([]string{"available"}).AddRow(false))
-	mock.ExpectQuery(`(?s)SELECT n.id.*FROM nodes n.*active_job_count`).
-		WithArgs(pgxmock.AnyArg()).
+	mock.ExpectQuery(`(?s)WITH excluded_capacity_nodes AS.*candidate_nodes AS.*SELECT n.id.*FROM candidate_nodes n.*active_job_count`).
+		WithArgs(jobID, orgID, pgxmock.AnyArg(), pgxmock.AnyArg()).
 		WillReturnRows(pgxmock.NewRows([]string{"id"}).AddRow("worker-without-capacity-metadata"))
 	mock.ExpectExec(`(?s)UPDATE jobs.*target_node_id =.*sandbox_slot_reserved_until =.*status =`).
 		WithArgs(models.SandboxWorkloadClassInteractive, "worker-without-capacity-metadata", (*time.Time)(nil), jobID, models.JobStatusPending).
@@ -1880,11 +1880,11 @@ func TestJobStore_RouteNextSandboxJobUsesTerminalProbeAfterBoundedDeferral(t *te
 	mock.ExpectQuery(`(?s)SELECT COUNT\(\*\).*FROM jobs.*id <>.*job_type IN`).
 		WithArgs(orgID, jobID).
 		WillReturnRows(pgxmock.NewRows([]string{"count"}).AddRow(0))
-	mock.ExpectQuery(`(?s)WITH candidate_nodes AS.*raw_load AS.*candidate_load AS.*SELECT id.*FROM candidate_load`).
-		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), models.SandboxWorkloadClassInteractive).
+	mock.ExpectQuery(`(?s)WITH excluded_capacity_nodes AS.*candidate_nodes AS.*raw_load AS.*candidate_load AS.*SELECT id.*FROM candidate_load`).
+		WithArgs(jobID, orgID, pgxmock.AnyArg(), pgxmock.AnyArg(), models.SandboxWorkloadClassInteractive).
 		WillReturnError(pgx.ErrNoRows)
-	mock.ExpectQuery(`(?s)SELECT n.id.*FROM nodes n.*active_job_count`).
-		WithArgs(pgxmock.AnyArg()).
+	mock.ExpectQuery(`(?s)WITH excluded_capacity_nodes AS.*candidate_nodes AS.*SELECT n.id.*FROM candidate_nodes n.*active_job_count`).
+		WithArgs(jobID, orgID, pgxmock.AnyArg(), pgxmock.AnyArg()).
 		WillReturnRows(pgxmock.NewRows([]string{"id"}).AddRow("worker-terminal-probe"))
 	mock.ExpectExec(`(?s)UPDATE jobs.*target_node_id =.*sandbox_slot_reserved_until = NULL.*retry_window_started_at =.*status =`).
 		WithArgs(models.SandboxWorkloadClassInteractive, "worker-terminal-probe", pgxmock.AnyArg(), jobID, models.JobStatusPending).
@@ -1923,11 +1923,11 @@ func TestJobStore_RouteNextSandboxJobUsesTerminalProbeForFleetBlockedContinuatio
 	mock.ExpectQuery(`(?s)SELECT COUNT\(\*\).*FROM jobs.*id <>.*job_type IN`).
 		WithArgs(orgID, jobID).
 		WillReturnRows(pgxmock.NewRows([]string{"count"}).AddRow(0))
-	mock.ExpectQuery(`(?s)WITH candidate_nodes AS.*raw_load AS.*candidate_load AS.*SELECT id.*FROM candidate_load`).
-		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), models.SandboxWorkloadClassInteractive).
+	mock.ExpectQuery(`(?s)WITH excluded_capacity_nodes AS.*candidate_nodes AS.*raw_load AS.*candidate_load AS.*SELECT id.*FROM candidate_load`).
+		WithArgs(jobID, orgID, pgxmock.AnyArg(), pgxmock.AnyArg(), models.SandboxWorkloadClassInteractive).
 		WillReturnError(pgx.ErrNoRows)
-	mock.ExpectQuery(`(?s)SELECT n.id.*FROM nodes n.*active_job_count`).
-		WithArgs(pgxmock.AnyArg()).
+	mock.ExpectQuery(`(?s)WITH excluded_capacity_nodes AS.*candidate_nodes AS.*SELECT n.id.*FROM candidate_nodes n.*active_job_count`).
+		WithArgs(jobID, orgID, pgxmock.AnyArg(), pgxmock.AnyArg()).
 		WillReturnRows(pgxmock.NewRows([]string{"id"}).AddRow("worker-continuation-terminal-probe"))
 	mock.ExpectExec(`(?s)UPDATE jobs.*target_node_id =.*sandbox_slot_reserved_until = NULL.*retry_window_started_at =.*status =`).
 		WithArgs(models.SandboxWorkloadClassInteractive, "worker-continuation-terminal-probe", fleetWaitStartedAt, jobID, models.JobStatusPending).
@@ -1965,8 +1965,8 @@ func TestJobStore_RouteNextSandboxJobStartsFleetWindowAfterOrgWait(t *testing.T)
 	mock.ExpectQuery(`(?s)SELECT COUNT\(\*\).*FROM jobs.*id <>.*job_type IN`).
 		WithArgs(orgID, jobID).
 		WillReturnRows(pgxmock.NewRows([]string{"count"}).AddRow(0))
-	mock.ExpectQuery(`(?s)WITH candidate_nodes AS.*raw_load AS.*candidate_load AS.*SELECT id.*FROM candidate_load`).
-		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), models.SandboxWorkloadClassInteractive).
+	mock.ExpectQuery(`(?s)WITH excluded_capacity_nodes AS.*candidate_nodes AS.*raw_load AS.*candidate_load AS.*SELECT id.*FROM candidate_load`).
+		WithArgs(jobID, orgID, pgxmock.AnyArg(), pgxmock.AnyArg(), models.SandboxWorkloadClassInteractive).
 		WillReturnError(pgx.ErrNoRows)
 	mock.ExpectQuery(`(?s)SELECT EXISTS.*max_active_sandboxes`).
 		WithArgs(pgxmock.AnyArg()).
@@ -2006,8 +2006,8 @@ func TestJobStore_RouteNextSandboxJobUsesTerminalProbeAtOrgLimitForInitialRun(t 
 	mock.ExpectQuery(`(?s)SELECT COUNT\(\*\).*FROM jobs.*id <>.*job_type IN`).
 		WithArgs(orgID, jobID).
 		WillReturnRows(pgxmock.NewRows([]string{"count"}).AddRow(2))
-	mock.ExpectQuery(`(?s)SELECT n.id.*FROM nodes n.*active_job_count`).
-		WithArgs(pgxmock.AnyArg()).
+	mock.ExpectQuery(`(?s)WITH excluded_capacity_nodes AS.*candidate_nodes AS.*SELECT n.id.*FROM candidate_nodes n.*active_job_count`).
+		WithArgs(jobID, orgID, pgxmock.AnyArg(), pgxmock.AnyArg()).
 		WillReturnRows(pgxmock.NewRows([]string{"id"}).AddRow("worker-org-terminal-probe"))
 	mock.ExpectExec(`(?s)UPDATE jobs.*target_node_id =.*sandbox_slot_reserved_until = NULL.*retry_window_started_at =.*status =`).
 		WithArgs(models.SandboxWorkloadClassInteractive, "worker-org-terminal-probe", pgxmock.AnyArg(), jobID, models.JobStatusPending).
@@ -2050,8 +2050,8 @@ func TestJobStore_RouteNextSandboxJobBypassesOrgLimitForCancelledContinuation(t 
 		WithArgs(orgID, sessionID, jobID).
 		WillReturnRows(pgxmock.NewRows([]string{"status", "pending_cancel", "stopped_thread", "capacity_cleanup"}).
 			AddRow(models.SessionStatusRunning, true, false, false))
-	mock.ExpectQuery(`(?s)SELECT n.id.*FROM nodes n.*active_job_count`).
-		WithArgs(pgxmock.AnyArg()).
+	mock.ExpectQuery(`(?s)WITH excluded_capacity_nodes AS.*candidate_nodes AS.*SELECT n.id.*FROM candidate_nodes n.*active_job_count`).
+		WithArgs(jobID, orgID, pgxmock.AnyArg(), pgxmock.AnyArg()).
 		WillReturnRows(pgxmock.NewRows([]string{"id"}).AddRow("worker-cleanup"))
 	mock.ExpectExec(`(?s)UPDATE jobs.*capacity_waited.*capacity_cleanup.*org_id = @org_id.*job_type = 'continue_session'`).
 		WithArgs(jobID, orgID, models.JobStatusPending).
@@ -2096,15 +2096,15 @@ func TestJobStore_RouteNextSandboxJobBypassesFleetCapacityForCancelledContinuati
 	mock.ExpectQuery(`(?s)SELECT COUNT\(\*\).*FROM jobs.*id <>.*job_type IN`).
 		WithArgs(orgID, jobID).
 		WillReturnRows(pgxmock.NewRows([]string{"count"}).AddRow(0))
-	mock.ExpectQuery(`(?s)WITH candidate_nodes AS.*raw_load AS.*candidate_load AS.*SELECT id.*FROM candidate_load`).
-		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), models.SandboxWorkloadClassInteractive).
+	mock.ExpectQuery(`(?s)WITH excluded_capacity_nodes AS.*candidate_nodes AS.*raw_load AS.*candidate_load AS.*SELECT id.*FROM candidate_load`).
+		WithArgs(jobID, orgID, pgxmock.AnyArg(), pgxmock.AnyArg(), models.SandboxWorkloadClassInteractive).
 		WillReturnError(pgx.ErrNoRows)
 	mock.ExpectQuery(`(?s)SELECT s.status.*session_cancel_requests.*session_threads.*JOIN jobs payload_job.*capacity_cleanup.*s.deleted_at IS NULL`).
 		WithArgs(orgID, sessionID, jobID).
 		WillReturnRows(pgxmock.NewRows([]string{"status", "pending_cancel", "stopped_thread", "capacity_cleanup"}).
 			AddRow(models.SessionStatusRunning, true, false, false))
-	mock.ExpectQuery(`(?s)SELECT n.id.*FROM nodes n.*active_job_count`).
-		WithArgs(pgxmock.AnyArg()).
+	mock.ExpectQuery(`(?s)WITH excluded_capacity_nodes AS.*candidate_nodes AS.*SELECT n.id.*FROM candidate_nodes n.*active_job_count`).
+		WithArgs(jobID, orgID, pgxmock.AnyArg(), pgxmock.AnyArg()).
 		WillReturnRows(pgxmock.NewRows([]string{"id"}).AddRow("worker-fleet-cleanup"))
 	mock.ExpectExec(`(?s)UPDATE jobs.*capacity_waited.*capacity_cleanup.*org_id = @org_id.*job_type = 'continue_session'`).
 		WithArgs(jobID, orgID, models.JobStatusPending).
@@ -2320,6 +2320,27 @@ func TestJobStore_ReserveSandboxSlotForRetryRequiresCurrentLease(t *testing.T) {
 	require.NoError(t, mock.ExpectationsWereMet(), "retry routing should fence its locked select with the current lock token")
 }
 
+func TestJobStore_RerouteSandboxAfterStartupFailureRequiresCurrentLease(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "should create startup-failure routing mock")
+	defer mock.Close()
+
+	jobID, staleLockToken := uuid.New(), uuid.New()
+	mock.ExpectBegin()
+	mock.ExpectQuery(`(?s)SELECT j.id, j.org_id,.*effective_workload_class.*j.status,.*j.created_at.*lock_token = @lock_token`).
+		WithArgs(jobID, staleLockToken).
+		WillReturnError(pgx.ErrNoRows)
+	mock.ExpectRollback()
+
+	result, err := NewJobStore(mock).RerouteSandboxAfterStartupFailure(context.Background(), jobID, staleLockToken, "worker-old")
+	require.Error(t, err, "a stale startup attempt should not persist a failed-host exclusion")
+	require.Nil(t, result, "stale startup rerouting should not return a placement")
+	require.ErrorIs(t, err, pgx.ErrNoRows, "lease mismatch should be reported as lost ownership")
+	require.NoError(t, mock.ExpectationsWereMet(), "failed-host persistence should be fenced before any payload mutation")
+}
+
 func TestJobStore_CountActiveSandboxTurnsByOrgUsesSharedPool(t *testing.T) {
 	t.Parallel()
 
@@ -2376,7 +2397,7 @@ func TestJobStore_IsSessionWaitingForSandboxCapacity(t *testing.T) {
 			defer mock.Close()
 
 			orgID, sessionID := uuid.New(), uuid.New()
-			mock.ExpectQuery(`(?s)SELECT EXISTS.*FROM jobs.*org_id = @org_id.*payload->>'session_id' = @session_id.*sandbox_slot_reserved_until IS NULL.*sandbox_slot_reserved_until <= now\(\).*capacity_cleanup.*retry_window_started_at = waiting_job.created_at.*terminal_probe_seconds.*COUNT\(\*\).*>= @max_concurrent_runs`).
+			mock.ExpectQuery(`(?s)SELECT EXISTS.*FROM jobs.*org_id = @org_id.*payload->>'session_id' = @session_id.*sandbox_slot_reserved_until IS NULL.*sandbox_slot_reserved_until <= now\(\).*capacity_cleanup.*retry_window_started_at IS NOT DISTINCT FROM waiting_job.created_at.*terminal_probe_seconds.*COUNT\(\*\).*>= @max_concurrent_runs`).
 				WithArgs(orgID, sessionID.String(), int(sandboxRoutingTerminalProbeAge.Seconds()), 2).
 				WillReturnRows(pgxmock.NewRows([]string{"waiting"}).AddRow(tt.waiting))
 
@@ -2417,6 +2438,48 @@ func TestRunAgentEnqueueOptsPreservesSessionWorkloadClass(t *testing.T) {
 			require.Equal(t, &dedupeKey, opts.DedupeKey, "canonical enqueue policy should preserve caller deduplication")
 		})
 	}
+}
+
+func TestContinueSessionEnqueueOptsCentralizesSchedulingPolicy(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		session        *models.Session
+		expectedClass  models.SandboxWorkloadClass
+		expectedTarget *string
+	}{
+		{name: "missing session uses unpinned interactive fallback", expectedClass: models.SandboxWorkloadClassInteractive},
+		{name: "interactive session retains its live worker", session: continuationSchedulingSession(models.SessionOriginManual, "worker-a"), expectedTarget: jobStringPtr("worker-a")},
+		{name: "code review persists its workload class", session: continuationSchedulingSession(models.SessionOriginCodeReview, "worker-review"), expectedClass: models.SandboxWorkloadClassCodeReview, expectedTarget: jobStringPtr("worker-review")},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			payload := map[string]string{"session_id": uuid.NewString()}
+			dedupeKey := ContinueSessionDedupeKey(uuid.New())
+			opts := ContinueSessionEnqueueOpts(tt.session, payload, &dedupeKey)
+
+			require.Equal(t, "agent", opts.Queue, "canonical continuation policy should always use the agent queue")
+			require.Equal(t, "continue_session", opts.JobType, "canonical continuation policy should always schedule a continuation")
+			require.Equal(t, payload, opts.Payload, "canonical continuation policy should preserve the caller payload")
+			require.Equal(t, 5, opts.Priority, "canonical continuation policy should preserve continuation priority")
+			require.Equal(t, &dedupeKey, opts.DedupeKey, "canonical continuation policy should preserve caller deduplication")
+			require.Equal(t, tt.expectedTarget, opts.TargetNodeID, "canonical continuation policy should derive affinity from the session runtime")
+			require.Equal(t, tt.expectedClass, opts.WorkloadClass, "canonical continuation policy should persist code-review classification")
+		})
+	}
+}
+
+func continuationSchedulingSession(origin models.SessionOrigin, workerNodeID string) *models.Session {
+	containerID := "sandbox-1"
+	return &models.Session{Origin: origin, ContainerID: &containerID, WorkerNodeID: &workerNodeID}
+}
+
+func jobStringPtr(value string) *string {
+	return &value
 }
 
 func TestOpenPRDedupeKeyUsesChangesetScope(t *testing.T) {

--- a/internal/db/jobs.go
+++ b/internal/db/jobs.go
@@ -762,6 +762,7 @@ const (
 	sandboxSlotReservationTTL      = 30 * time.Second
 	sandboxFleetRetryDelay         = 10 * time.Second
 	sandboxOrgLimitRetryDelay      = 5 * time.Second
+	sandboxRoutingErrorRetryDelay  = 10 * time.Second
 	sandboxRoutingTerminalProbeAge = 8 * time.Minute
 	maxClaimAdmissionSkips         = 16
 )
@@ -775,6 +776,7 @@ const (
 	SandboxRoutingReasonLockContention   SandboxRoutingReason = "lock_contention"
 	SandboxRoutingReasonTerminalProbe    SandboxRoutingReason = "terminal_probe"
 	SandboxRoutingReasonMetadataFallback SandboxRoutingReason = "capacity_metadata_unavailable"
+	SandboxRoutingReasonJobError         SandboxRoutingReason = "job_error"
 )
 
 // SandboxRoutingResult reports the durable placement decision made before a
@@ -787,6 +789,7 @@ type SandboxRoutingResult struct {
 	TargetNodeID  *string
 	Deferred      bool
 	Reason        SandboxRoutingReason
+	RoutingError  string
 }
 
 type sandboxRoutingJob struct {
@@ -864,19 +867,22 @@ func (s *JobStore) RouteNextSandboxJob(ctx context.Context) (*SandboxRoutingResu
 		startedAt := retryWindowStartedAt.Time
 		job.RetryWindowStartedAt = &startedAt
 	}
+	if _, err := tx.Exec(ctx, `SAVEPOINT sandbox_route_candidate`); err != nil {
+		return nil, fmt.Errorf("create sandbox routing candidate savepoint: %w", err)
+	}
 	if err := resolveSandboxRoutingWorkloadClass(ctx, tx, &job); err != nil {
-		return nil, err
+		return s.deferSandboxRoutingJobError(ctx, tx, job, err)
 	}
 
 	result, err := reserveSandboxSlotForLockedJob(ctx, tx, job, "")
 	if err != nil {
-		return nil, err
+		return s.deferSandboxRoutingJobError(ctx, tx, job, err)
 	}
 	durableTerminalProbe := false
 	if result.TargetNodeID == nil && (result.Reason == SandboxRoutingReasonOrgLimit || result.Reason == SandboxRoutingReasonFleetCapacity) {
 		durableTerminalProbe, err = continueSessionNeedsTerminalProbe(ctx, tx, job)
 		if err != nil {
-			return nil, err
+			return s.deferSandboxRoutingJobError(ctx, tx, job, err)
 		}
 	}
 	if result.TargetNodeID == nil && result.Reason != SandboxRoutingReasonLockContention {
@@ -893,7 +899,7 @@ func (s *JobStore) RouteNextSandboxJob(ctx context.Context) (*SandboxRoutingResu
 		} else if result.Reason == SandboxRoutingReasonFleetCapacity {
 			metadataConfigured, metadataErr := sandboxCapacityMetadataConfigured(ctx, tx)
 			if metadataErr != nil {
-				return nil, metadataErr
+				return s.deferSandboxRoutingJobError(ctx, tx, job, metadataErr)
 			}
 			if !metadataConfigured {
 				fallbackReason = SandboxRoutingReasonMetadataFallback
@@ -902,14 +908,14 @@ func (s *JobStore) RouteNextSandboxJob(ctx context.Context) (*SandboxRoutingResu
 		if fallbackReason != "" {
 			targetNodeID, fallbackErr := selectSandboxRoutingFallbackNode(ctx, tx)
 			if fallbackErr != nil && !errors.Is(fallbackErr, pgx.ErrNoRows) {
-				return nil, fallbackErr
+				return s.deferSandboxRoutingJobError(ctx, tx, job, fallbackErr)
 			}
 			if fallbackErr == nil {
 				var placementErr error
 				if fallbackReason == SandboxRoutingReasonTerminalProbe {
 					if durableTerminalProbe {
 						if err := markSandboxCancellationCleanup(ctx, tx, job); err != nil {
-							return nil, err
+							return s.deferSandboxRoutingJobError(ctx, tx, job, err)
 						}
 					}
 					placementErr = updateSandboxTerminalProbePlacement(ctx, tx, job, targetNodeID)
@@ -917,7 +923,7 @@ func (s *JobStore) RouteNextSandboxJob(ctx context.Context) (*SandboxRoutingResu
 					placementErr = updateSandboxRoutingPlacement(ctx, tx, job, targetNodeID, nil)
 				}
 				if placementErr != nil {
-					return nil, placementErr
+					return s.deferSandboxRoutingJobError(ctx, tx, job, placementErr)
 				}
 				result.TargetNodeID = &targetNodeID
 				result.Reason = fallbackReason
@@ -954,10 +960,10 @@ func (s *JobStore) RouteNextSandboxJob(ctx context.Context) (*SandboxRoutingResu
 			"workload_class":     job.WorkloadClass,
 		})
 		if err != nil {
-			return nil, fmt.Errorf("defer sandbox job without capacity: %w", err)
+			return s.deferSandboxRoutingJobError(ctx, tx, job, fmt.Errorf("defer sandbox job without capacity: %w", err))
 		}
 		if resultTag.RowsAffected() != 1 {
-			return nil, fmt.Errorf("defer sandbox job without capacity: pending job %s changed ownership", job.ID)
+			return s.deferSandboxRoutingJobError(ctx, tx, job, fmt.Errorf("defer sandbox job without capacity: pending job %s changed ownership", job.ID))
 		}
 		result.Deferred = true
 	}
@@ -968,6 +974,50 @@ func (s *JobStore) RouteNextSandboxJob(ctx context.Context) (*SandboxRoutingResu
 		s.notify(ctx, job.ID)
 	}
 	return result, nil
+}
+
+// deferSandboxRoutingJobError rolls back only the failed routing work before
+// moving the still-locked candidate behind other due work. Keeping the job row
+// lock across rollback-to-savepoint and deferral prevents another dispatcher
+// from selecting the same malformed candidate in between those operations.
+func (s *JobStore) deferSandboxRoutingJobError(ctx context.Context, tx pgx.Tx, job sandboxRoutingJob, routingErr error) (*SandboxRoutingResult, error) {
+	if _, rollbackErr := tx.Exec(ctx, `ROLLBACK TO SAVEPOINT sandbox_route_candidate`); rollbackErr != nil {
+		return nil, fmt.Errorf("rollback failed sandbox routing work for job %s after %v: %w", job.ID, routingErr, rollbackErr)
+	}
+	result, err := tx.Exec(ctx, `
+		UPDATE jobs
+		SET target_node_id = NULL,
+			sandbox_slot_reserved_until = NULL,
+			last_error = @last_error,
+			run_at = @run_at,
+			updated_at = now()
+		WHERE id = @job_id
+		  AND org_id = @org_id
+		  AND status = 'pending'`, pgx.NamedArgs{
+		"job_id":     job.ID,
+		"last_error": fmt.Sprintf("sandbox routing deferred: %v", routingErr),
+		"org_id":     job.OrgID,
+		"run_at":     time.Now().Add(sandboxRoutingErrorRetryDelay),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("defer failed sandbox routing for job %s after %v: %w", job.ID, routingErr, err)
+	}
+	if result.RowsAffected() != 1 {
+		return nil, fmt.Errorf("defer failed sandbox routing for job %s after %v: pending job changed ownership", job.ID, routingErr)
+	}
+	if _, err := tx.Exec(ctx, `RELEASE SAVEPOINT sandbox_route_candidate`); err != nil {
+		return nil, fmt.Errorf("release failed sandbox routing savepoint for job %s after %v: %w", job.ID, routingErr, err)
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return nil, fmt.Errorf("commit failed sandbox routing deferral for job %s after %v: %w", job.ID, routingErr, err)
+	}
+	return &SandboxRoutingResult{
+		JobID:         job.ID,
+		WorkloadClass: job.WorkloadClass,
+		Deferred:      true,
+		Reason:        SandboxRoutingReasonJobError,
+		RoutingError:  routingErr.Error(),
+	}, nil
 }
 
 // lint:allow-no-orgid reason="fleet routing readiness intentionally inspects worker heartbeat metadata across organizations"
@@ -1102,7 +1152,19 @@ func reserveSandboxSlotForLockedJob(ctx context.Context, tx pgx.Tx, job sandboxR
 		}
 
 		var locked bool
-		if err := tx.QueryRow(ctx, `SELECT pg_try_advisory_xact_lock(hashtextextended(@node_id, 143))`, pgx.NamedArgs{
+		// Blue/green generations have distinct routing node IDs but share one
+		// Docker daemon. Lock their host-stable capacity identity so overlapping
+		// generations cannot admit against independent views of the same host.
+		if err := tx.QueryRow(ctx, `
+			SELECT pg_try_advisory_xact_lock(hashtextextended(
+				COALESCE(
+					NULLIF(metadata->>'sandbox_capacity_node_id', ''),
+					regexp_replace(id, '-g[0-9]{14}-[A-Za-z0-9._-]+$', '')
+				),
+				143
+			))
+			FROM nodes
+			WHERE id = @node_id`, pgx.NamedArgs{
 			"node_id": candidate,
 		}).Scan(&locked); err != nil {
 			return nil, fmt.Errorf("lock sandbox routing candidate %s: %w", candidate, err)
@@ -1489,6 +1551,19 @@ func selectSandboxRoutingCandidate(ctx context.Context, tx pgx.Tx, workloadClass
 func sandboxRoutingCandidateHasCapacity(ctx context.Context, tx pgx.Tx, nodeID string, jobID uuid.UUID, workloadClass models.SandboxWorkloadClass) (bool, error) {
 	var live, localReserved, sandboxTurnLocalReserved, maxActive, interactiveReserved, pendingDurableReserved, runningDurableReserved, sharedTurnReserved, sharedNonTurnReserved int
 	err := tx.QueryRow(ctx, `
+		WITH candidate_node AS (
+			SELECT n.*,
+				COALESCE(
+					NULLIF(n.metadata->>'sandbox_capacity_node_id', ''),
+					regexp_replace(n.id, '-g[0-9]{14}-[A-Za-z0-9._-]+$', '')
+				) AS capacity_node_id
+			FROM nodes n
+			WHERE n.id = @node_id
+			  AND n.mode IN ('worker', 'all')
+			  AND n.status = 'active'
+			  AND n.last_heartbeat_at >= @dead_before
+			  AND COALESCE(n.metadata->>'live_sandbox_count_error', '') = ''
+		)
 		SELECT
 			COALESCE(NULLIF(n.metadata->>'live_sandbox_count', '')::int, 0),
 			COALESCE(NULLIF(n.metadata->>'reserved_sandbox_count', '')::int, 0),
@@ -1501,7 +1576,11 @@ func sandboxRoutingCandidateHasCapacity(ctx context.Context, tx pgx.Tx, nodeID s
 			(
 				SELECT COUNT(*)
 				FROM jobs reserved_job
-				WHERE reserved_job.target_node_id = n.id
+				JOIN nodes reserved_node ON reserved_node.id = reserved_job.target_node_id
+				WHERE COALESCE(
+						NULLIF(reserved_node.metadata->>'sandbox_capacity_node_id', ''),
+						regexp_replace(reserved_node.id, '-g[0-9]{14}-[A-Za-z0-9._-]+$', '')
+					) = n.capacity_node_id
 				  AND reserved_job.id <> @job_id
 				  AND reserved_job.sandbox_slot_reserved_until > now()
 				  AND reserved_job.status = 'pending'
@@ -1509,7 +1588,11 @@ func sandboxRoutingCandidateHasCapacity(ctx context.Context, tx pgx.Tx, nodeID s
 			(
 				SELECT COUNT(*)
 				FROM jobs reserved_job
-				WHERE reserved_job.target_node_id = n.id
+				JOIN nodes reserved_node ON reserved_node.id = reserved_job.target_node_id
+				WHERE COALESCE(
+						NULLIF(reserved_node.metadata->>'sandbox_capacity_node_id', ''),
+						regexp_replace(reserved_node.id, '-g[0-9]{14}-[A-Za-z0-9._-]+$', '')
+					) = n.capacity_node_id
 				  AND reserved_job.id <> @job_id
 				  AND reserved_job.sandbox_slot_reserved_until > now()
 				  AND reserved_job.status = 'running'
@@ -1517,15 +1600,19 @@ func sandboxRoutingCandidateHasCapacity(ctx context.Context, tx pgx.Tx, nodeID s
 			(
 				SELECT COUNT(*)
 				FROM sandbox_capacity_reservations shared_reservation
-				WHERE shared_reservation.node_id = n.id
+				WHERE shared_reservation.node_id = n.capacity_node_id
 				  AND shared_reservation.expires_at > now()
 				  AND shared_reservation.job_id IS NOT NULL
 				  AND shared_reservation.job_id <> @job_id
 				  AND NOT EXISTS (
 					SELECT 1
 					FROM jobs reserved_job
+					JOIN nodes reserved_node ON reserved_node.id = reserved_job.target_node_id
 					WHERE reserved_job.id = shared_reservation.job_id
-					  AND reserved_job.target_node_id = n.id
+					  AND COALESCE(
+							NULLIF(reserved_node.metadata->>'sandbox_capacity_node_id', ''),
+							regexp_replace(reserved_node.id, '-g[0-9]{14}-[A-Za-z0-9._-]+$', '')
+						) = n.capacity_node_id
 					  AND reserved_job.sandbox_slot_reserved_until > now()
 					  AND reserved_job.status IN ('pending', 'running')
 				  )
@@ -1533,16 +1620,11 @@ func sandboxRoutingCandidateHasCapacity(ctx context.Context, tx pgx.Tx, nodeID s
 			(
 				SELECT COUNT(*)
 				FROM sandbox_capacity_reservations shared_reservation
-				WHERE shared_reservation.node_id = n.id
+				WHERE shared_reservation.node_id = n.capacity_node_id
 				  AND shared_reservation.expires_at > now()
 				  AND shared_reservation.job_id IS NULL
 			)
-		FROM nodes n
-		WHERE n.id = @node_id
-		  AND n.mode IN ('worker', 'all')
-		  AND n.status = 'active'
-		  AND n.last_heartbeat_at >= @dead_before
-		  AND COALESCE(n.metadata->>'live_sandbox_count_error', '') = ''`, pgx.NamedArgs{
+		FROM candidate_node n`, pgx.NamedArgs{
 		"job_id":      jobID,
 		"node_id":     nodeID,
 		"dead_before": time.Now().Add(-nodeDeadHeartbeatThreshold),
@@ -1568,7 +1650,7 @@ func sandboxRoutingCapacityLoad(live, localReserved, sandboxTurnLocalReserved, p
 }
 
 // CountActiveSandboxTurnsByOrg returns claimed interactive and code-review
-// turns for the shared organization admission fence. The current job is
+// turns for the final organization admission fence. The current job is
 // included, so callers reject only when the count is greater than the limit.
 func (s *JobStore) CountActiveSandboxTurnsByOrg(ctx context.Context, orgID uuid.UUID) (int, error) {
 	var count int
@@ -1582,6 +1664,28 @@ func (s *JobStore) CountActiveSandboxTurnsByOrg(ctx context.Context, orgID uuid.
 	}).Scan(&count)
 	if err != nil {
 		return 0, fmt.Errorf("count active sandbox turns: %w", err)
+	}
+	return count, nil
+}
+
+// CountAdmittedSandboxTurnsByOrg returns claimed turns plus pending turns with
+// a live durable worker reservation. Runtime status uses this broader count so
+// it reports the same capacity pressure as the atomic routing fence.
+func (s *JobStore) CountAdmittedSandboxTurnsByOrg(ctx context.Context, orgID uuid.UUID) (int, error) {
+	var count int
+	err := s.db.QueryRow(ctx, `
+		SELECT COUNT(*)
+		FROM jobs
+		WHERE org_id = @org_id
+		  AND job_type IN ('run_agent', 'continue_session')
+		  AND (
+			status = 'running'
+			OR (status = 'pending' AND sandbox_slot_reserved_until > now())
+		  )`, pgx.NamedArgs{
+		"org_id": orgID,
+	}).Scan(&count)
+	if err != nil {
+		return 0, fmt.Errorf("count admitted sandbox turns by org: %w", err)
 	}
 	return count, nil
 }

--- a/internal/db/jobs.go
+++ b/internal/db/jobs.go
@@ -759,9 +759,11 @@ const claimedJobColumns = `j.id, j.org_id, j.queue, j.job_type, j.payload, j.pri
 const nodeDeadHeartbeatThreshold = 90 * time.Second
 
 const (
-	sandboxSlotReservationTTL      = 30 * time.Second
-	sandboxFleetRetryDelay         = 10 * time.Second
-	sandboxOrgLimitRetryDelay      = 5 * time.Second
+	sandboxSlotReservationTTL = 30 * time.Second
+	// SandboxFleetRetryDelay and SandboxOrgLimitRetryDelay are exported so the
+	// routing transaction and worker handler cannot silently drift apart.
+	SandboxFleetRetryDelay         = 10 * time.Second
+	SandboxOrgLimitRetryDelay      = 5 * time.Second
 	sandboxRoutingErrorRetryDelay  = 10 * time.Second
 	sandboxRoutingTerminalProbeAge = 8 * time.Minute
 	maxClaimAdmissionSkips         = 16
@@ -931,9 +933,9 @@ func (s *JobStore) RouteNextSandboxJob(ctx context.Context) (*SandboxRoutingResu
 		}
 	}
 	if result.TargetNodeID == nil && result.Reason != SandboxRoutingReasonLockContention {
-		retryDelay := sandboxFleetRetryDelay
+		retryDelay := SandboxFleetRetryDelay
 		if result.Reason == SandboxRoutingReasonOrgLimit {
-			retryDelay = sandboxOrgLimitRetryDelay
+			retryDelay = SandboxOrgLimitRetryDelay
 		}
 		deferredUntil := time.Now().Add(retryDelay)
 		clearRetryWindow := job.JobType == "continue_session" && result.Reason == SandboxRoutingReasonOrgLimit
@@ -1457,7 +1459,20 @@ func selectSandboxRoutingFallbackNode(ctx context.Context, tx pgx.Tx) (string, e
 func selectSandboxRoutingCandidate(ctx context.Context, tx pgx.Tx, workloadClass models.SandboxWorkloadClass, excludedNodeIDs []string) (string, error) {
 	var nodeID string
 	err := tx.QueryRow(ctx, `
-		WITH raw_load AS (
+		WITH candidate_nodes AS (
+			SELECT n.*,
+				COALESCE(
+					NULLIF(n.metadata->>'sandbox_capacity_node_id', ''),
+					regexp_replace(n.id, '-g[0-9]{14}-[A-Za-z0-9._-]+$', '')
+				) AS capacity_node_id
+			FROM nodes n
+			WHERE n.mode IN ('worker', 'all')
+			  AND n.status = 'active'
+			  AND n.last_heartbeat_at >= @dead_before
+			  AND COALESCE(n.metadata->>'live_sandbox_count_error', '') = ''
+			  AND NOT (n.id = ANY(@excluded_node_ids::text[]))
+		),
+		raw_load AS (
 			SELECT
 				n.id,
 				COALESCE(NULLIF(n.metadata->>'live_sandbox_count', '')::int, 0) AS live_sandboxes,
@@ -1472,28 +1487,40 @@ func selectSandboxRoutingCandidate(ctx context.Context, tx pgx.Tx, workloadClass
 				(
 					SELECT COUNT(*)
 					FROM jobs reserved_job
-					WHERE reserved_job.target_node_id = n.id
+					JOIN nodes reserved_node ON reserved_node.id = reserved_job.target_node_id
+					WHERE COALESCE(
+							NULLIF(reserved_node.metadata->>'sandbox_capacity_node_id', ''),
+							regexp_replace(reserved_node.id, '-g[0-9]{14}-[A-Za-z0-9._-]+$', '')
+						) = n.capacity_node_id
 					  AND reserved_job.sandbox_slot_reserved_until > now()
 					  AND reserved_job.status = 'pending'
 				) AS pending_durable_reservations,
 				(
 					SELECT COUNT(*)
 					FROM jobs reserved_job
-					WHERE reserved_job.target_node_id = n.id
+					JOIN nodes reserved_node ON reserved_node.id = reserved_job.target_node_id
+					WHERE COALESCE(
+							NULLIF(reserved_node.metadata->>'sandbox_capacity_node_id', ''),
+							regexp_replace(reserved_node.id, '-g[0-9]{14}-[A-Za-z0-9._-]+$', '')
+						) = n.capacity_node_id
 					  AND reserved_job.sandbox_slot_reserved_until > now()
 					  AND reserved_job.status = 'running'
 				) AS running_durable_reservations,
 				(
 					SELECT COUNT(*)
 					FROM sandbox_capacity_reservations shared_reservation
-					WHERE shared_reservation.node_id = n.id
+					WHERE shared_reservation.node_id = n.capacity_node_id
 					  AND shared_reservation.expires_at > now()
 					  AND shared_reservation.job_id IS NOT NULL
 					  AND NOT EXISTS (
 						SELECT 1
 						FROM jobs reserved_job
+						JOIN nodes reserved_node ON reserved_node.id = reserved_job.target_node_id
 						WHERE reserved_job.id = shared_reservation.job_id
-						  AND reserved_job.target_node_id = n.id
+						  AND COALESCE(
+								NULLIF(reserved_node.metadata->>'sandbox_capacity_node_id', ''),
+								regexp_replace(reserved_node.id, '-g[0-9]{14}-[A-Za-z0-9._-]+$', '')
+							) = n.capacity_node_id
 						  AND reserved_job.sandbox_slot_reserved_until > now()
 						  AND reserved_job.status IN ('pending', 'running')
 					  )
@@ -1501,17 +1528,12 @@ func selectSandboxRoutingCandidate(ctx context.Context, tx pgx.Tx, workloadClass
 				(
 					SELECT COUNT(*)
 					FROM sandbox_capacity_reservations shared_reservation
-					WHERE shared_reservation.node_id = n.id
+					WHERE shared_reservation.node_id = n.capacity_node_id
 					  AND shared_reservation.expires_at > now()
 					  AND shared_reservation.job_id IS NULL
 				) AS shared_non_turn_reservations,
 				n.last_heartbeat_at
-			FROM nodes n
-			WHERE n.mode IN ('worker', 'all')
-			  AND n.status = 'active'
-			  AND n.last_heartbeat_at >= @dead_before
-			  AND COALESCE(n.metadata->>'live_sandbox_count_error', '') = ''
-			  AND NOT (n.id = ANY(@excluded_node_ids::text[]))
+			FROM candidate_nodes n
 		),
 		candidate_load AS (
 			SELECT
@@ -1690,6 +1712,56 @@ func (s *JobStore) CountAdmittedSandboxTurnsByOrg(ctx context.Context, orgID uui
 	return count, nil
 }
 
+// IsSessionWaitingForSandboxCapacity reports whether a pending turn for the
+// session is blocked by other admitted turns at the shared organization limit.
+// The candidate's own live reservation is excluded so an admitted session is
+// not mislabeled as waiting while its environment starts.
+func (s *JobStore) IsSessionWaitingForSandboxCapacity(ctx context.Context, orgID, sessionID uuid.UUID, maxConcurrentRuns int) (bool, error) {
+	var waiting bool
+	err := s.db.QueryRow(ctx, `
+		SELECT EXISTS (
+			SELECT 1
+			FROM jobs waiting_job
+			WHERE waiting_job.org_id = @org_id
+			  AND waiting_job.job_type IN ('run_agent', 'continue_session')
+			  AND waiting_job.status = 'pending'
+			  AND waiting_job.payload->>'session_id' = @session_id
+			  AND (
+				waiting_job.sandbox_slot_reserved_until IS NULL
+				OR waiting_job.sandbox_slot_reserved_until <= now()
+			  )
+			  AND waiting_job.payload->>'capacity_cleanup' IS DISTINCT FROM 'true'
+			  AND NOT (
+				waiting_job.job_type = 'run_agent'
+				AND waiting_job.retry_window_started_at = waiting_job.created_at
+				AND waiting_job.created_at <= now() - (@terminal_probe_seconds * interval '1 second')
+			  )
+			  AND (
+				SELECT COUNT(*)
+				FROM jobs admitted_job
+				WHERE admitted_job.org_id = @org_id
+				  AND admitted_job.id <> waiting_job.id
+				  AND admitted_job.job_type IN ('run_agent', 'continue_session')
+				  AND (
+					admitted_job.status = 'running'
+					OR (
+						admitted_job.status = 'pending'
+						AND admitted_job.sandbox_slot_reserved_until > now()
+					)
+				  )
+			  ) >= @max_concurrent_runs
+		)`, pgx.NamedArgs{
+		"max_concurrent_runs":    maxConcurrentRuns,
+		"org_id":                 orgID,
+		"session_id":             sessionID.String(),
+		"terminal_probe_seconds": int(sandboxRoutingTerminalProbeAge.Seconds()),
+	}).Scan(&waiting)
+	if err != nil {
+		return false, fmt.Errorf("inspect session sandbox capacity wait: %w", err)
+	}
+	return waiting, nil
+}
+
 // ReleaseSandboxSlotReservationWithLease clears a routing reservation once
 // the authoritative local gate has finished creating or hydrating the
 // sandbox. The fencing token prevents a stale executor from clearing a newer
@@ -1841,8 +1913,11 @@ func (s *JobStore) claimNextRunnableAttempt(ctx context.Context, nodeID, ownerID
 
 	isSandboxJob := candidate.JobType == "run_agent" || candidate.JobType == "continue_session"
 	if isSandboxJob {
+		if _, err := tx.Exec(ctx, `SAVEPOINT sandbox_claim_candidate`); err != nil {
+			return nil, false, fmt.Errorf("create sandbox claim candidate savepoint: %w", err)
+		}
 		if err := resolveSandboxRoutingWorkloadClass(ctx, tx, &candidate); err != nil {
-			return nil, false, err
+			return s.deferSandboxClaimJobError(ctx, tx, candidate, err)
 		}
 	}
 	// A terminal placement stamps the initial job creation time into the retry
@@ -1855,12 +1930,12 @@ func (s *JobStore) claimNextRunnableAttempt(ctx context.Context, nodeID, ownerID
 	if isSandboxJob && !isTerminalInitialRun {
 		admitted, admissionErr := admitLockedSandboxTurn(ctx, tx, candidate)
 		if admissionErr != nil {
-			return nil, false, admissionErr
+			return s.deferSandboxClaimJobError(ctx, tx, candidate, admissionErr)
 		}
 		if !admitted {
 			terminalProbe, probeErr := continueSessionNeedsTerminalProbe(ctx, tx, candidate)
 			if probeErr != nil {
-				return nil, false, probeErr
+				return s.deferSandboxClaimJobError(ctx, tx, candidate, probeErr)
 			}
 			if terminalProbe {
 				probeResult, markErr := tx.Exec(ctx, `
@@ -1875,10 +1950,10 @@ func (s *JobStore) claimNextRunnableAttempt(ctx context.Context, nodeID, ownerID
 					  AND status = 'pending'
 					  AND job_type = 'continue_session'`, pgx.NamedArgs{"job_id": candidate.ID})
 				if markErr != nil {
-					return nil, false, fmt.Errorf("mark org-limited continuation for terminal cleanup: %w", markErr)
+					return s.deferSandboxClaimJobError(ctx, tx, candidate, fmt.Errorf("mark org-limited continuation for terminal cleanup: %w", markErr))
 				}
 				if probeResult.RowsAffected() != 1 {
-					return nil, false, fmt.Errorf("mark org-limited continuation for terminal cleanup: pending job %s changed ownership", candidate.ID)
+					return s.deferSandboxClaimJobError(ctx, tx, candidate, fmt.Errorf("mark org-limited continuation for terminal cleanup: pending job %s changed ownership", candidate.ID))
 				}
 			} else {
 				deferResult, deferErr := tx.Exec(ctx, `
@@ -1891,6 +1966,7 @@ func (s *JobStore) claimNextRunnableAttempt(ctx context.Context, nodeID, ownerID
 						run_at = now() + (@retry_seconds * interval '1 second'),
 						retry_window_started_at = CASE
 							WHEN job_type = 'continue_session' THEN NULL
+							WHEN job_type = 'run_agent' AND attempts = 0 THEN created_at
 							ELSE COALESCE(retry_window_started_at, now())
 						END,
 						target_node_id = CASE
@@ -1902,14 +1978,14 @@ func (s *JobStore) claimNextRunnableAttempt(ctx context.Context, nodeID, ownerID
 					WHERE id = @job_id
 					  AND status = 'pending'`, pgx.NamedArgs{
 					"job_id":         candidate.ID,
-					"retry_seconds":  int(sandboxOrgLimitRetryDelay.Seconds()),
+					"retry_seconds":  int(SandboxOrgLimitRetryDelay.Seconds()),
 					"workload_class": candidate.WorkloadClass,
 				})
 				if deferErr != nil {
-					return nil, false, fmt.Errorf("defer affinity-bound sandbox job at org limit: %w", deferErr)
+					return s.deferSandboxClaimJobError(ctx, tx, candidate, fmt.Errorf("defer affinity-bound sandbox job at org limit: %w", deferErr))
 				}
 				if deferResult.RowsAffected() != 1 {
-					return nil, false, fmt.Errorf("defer affinity-bound sandbox job at org limit: pending job %s changed ownership", candidate.ID)
+					return s.deferSandboxClaimJobError(ctx, tx, candidate, fmt.Errorf("defer affinity-bound sandbox job at org limit: pending job %s changed ownership", candidate.ID))
 				}
 				if err := tx.Commit(ctx); err != nil {
 					return nil, false, fmt.Errorf("commit sandbox org-limit deferral: %w", err)
@@ -1941,12 +2017,62 @@ func (s *JobStore) claimNextRunnableAttempt(ctx context.Context, nodeID, ownerID
 		"lease_seconds": int(leaseDuration.Seconds()),
 	}))
 	if err != nil {
+		if isSandboxJob {
+			return s.deferSandboxClaimJobError(ctx, tx, candidate, fmt.Errorf("claim next runnable job: %w", err))
+		}
 		return nil, false, fmt.Errorf("claim next runnable job: %w", err)
 	}
 	if err := tx.Commit(ctx); err != nil {
 		return nil, false, fmt.Errorf("commit claim next runnable job: %w", err)
 	}
 	return job, false, nil
+}
+
+// deferSandboxClaimJobError recovers the candidate transaction after a
+// deterministic sandbox admission error, then advances only that locked job.
+// ClaimNextRunnable can continue its bounded scan instead of letting one
+// malformed tenant configuration block every job type on the worker.
+func (s *JobStore) deferSandboxClaimJobError(ctx context.Context, tx pgx.Tx, candidate sandboxRoutingJob, claimErr error) (*models.Job, bool, error) {
+	if _, rollbackErr := tx.Exec(ctx, `ROLLBACK TO SAVEPOINT sandbox_claim_candidate`); rollbackErr != nil {
+		return nil, false, fmt.Errorf("rollback failed sandbox claim work for job %s after %v: %w", candidate.ID, claimErr, rollbackErr)
+	}
+	result, err := tx.Exec(ctx, `
+		UPDATE jobs
+		SET last_error = @last_error,
+			run_at = @run_at,
+			target_node_id = CASE
+				WHEN sandbox_slot_reserved_until IS NULL THEN target_node_id
+				ELSE NULL
+			END,
+			sandbox_slot_reserved_until = NULL,
+			updated_at = now()
+		WHERE id = @job_id
+		  AND org_id = @org_id
+		  AND status = 'pending'`, pgx.NamedArgs{
+		"job_id":     candidate.ID,
+		"last_error": fmt.Sprintf("sandbox claim deferred: %v", claimErr),
+		"org_id":     candidate.OrgID,
+		"run_at":     time.Now().Add(sandboxRoutingErrorRetryDelay),
+	})
+	if err != nil {
+		return nil, false, fmt.Errorf("defer failed sandbox claim for job %s after %v: %w", candidate.ID, claimErr, err)
+	}
+	if result.RowsAffected() != 1 {
+		return nil, false, fmt.Errorf("defer failed sandbox claim for job %s after %v: pending job changed ownership", candidate.ID, claimErr)
+	}
+	if _, err := tx.Exec(ctx, `RELEASE SAVEPOINT sandbox_claim_candidate`); err != nil {
+		return nil, false, fmt.Errorf("release failed sandbox claim savepoint for job %s after %v: %w", candidate.ID, claimErr, err)
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return nil, false, fmt.Errorf("commit failed sandbox claim deferral for job %s after %v: %w", candidate.ID, claimErr, err)
+	}
+	s.logger.Error().
+		Err(claimErr).
+		Str("job_id", candidate.ID.String()).
+		Str("org_id", candidate.OrgID.String()).
+		Str("job_type", candidate.JobType).
+		Msg("sandbox claim failed; deferred only the affected job")
+	return nil, true, nil
 }
 
 func scanJobRow(row pgx.Row) (*models.Job, error) {

--- a/internal/db/jobs.go
+++ b/internal/db/jobs.go
@@ -1803,6 +1803,28 @@ func (s *JobStore) ReleaseSandboxRoutingPlacementWithLease(ctx context.Context, 
 	return result.RowsAffected() == 1, nil
 }
 
+// ClearSandboxRoutingPlacementWithLease clears worker affinity when a fresh
+// sandbox create or hydrate attempt fails. Unlike admission-rejection cleanup,
+// this also clears compatibility and terminal-probe placements that have a
+// target without sandbox_slot_reserved_until. Callers must use it only after a
+// fresh-sandbox failure, never for an existing-sandbox affinity turn.
+// lint:allow-no-orgid reason="fenced worker cleanup addresses a globally unique job id"
+func (s *JobStore) ClearSandboxRoutingPlacementWithLease(ctx context.Context, jobID, lockToken uuid.UUID) (bool, error) {
+	result, err := s.db.Exec(ctx, `
+		UPDATE jobs
+		SET target_node_id = NULL,
+			sandbox_slot_reserved_until = NULL,
+			updated_at = now()
+		WHERE id = $1
+		  AND status = 'running'
+		  AND lock_token = $2
+		  AND (target_node_id IS NOT NULL OR sandbox_slot_reserved_until IS NOT NULL)`, jobID, lockToken)
+	if err != nil {
+		return false, fmt.Errorf("clear sandbox routing placement with lease: %w", err)
+	}
+	return result.RowsAffected() == 1, nil
+}
+
 type jobExecer interface {
 	Exec(ctx context.Context, sql string, arguments ...any) (pgconn.CommandTag, error)
 }

--- a/internal/db/jobs.go
+++ b/internal/db/jobs.go
@@ -1457,7 +1457,7 @@ func selectSandboxRoutingCandidate(ctx context.Context, tx pgx.Tx, workloadClass
 				live_sandboxes
 					+ GREATEST(local_reservations - sandbox_turn_local_reservations, shared_non_turn_reservations, 0)
 					+ pending_durable_reservations
-					+ GREATEST(sandbox_turn_local_reservations, running_durable_reservations, shared_sandbox_turn_reservations) AS capacity_load
+					+ GREATEST(sandbox_turn_local_reservations, running_durable_reservations + shared_sandbox_turn_reservations) AS capacity_load
 			FROM raw_load
 		)
 		SELECT id
@@ -1563,7 +1563,7 @@ func sandboxRoutingCandidateHasCapacity(ctx context.Context, tx pgx.Tx, nodeID s
 
 func sandboxRoutingCapacityLoad(live, localReserved, sandboxTurnLocalReserved, pendingDurableReserved, runningDurableReserved, sharedTurnReserved, sharedNonTurnReserved int) int {
 	overlappingNonTurns := max(localReserved-sandboxTurnLocalReserved, sharedNonTurnReserved, 0)
-	overlappingSandboxTurns := max(sandboxTurnLocalReserved, runningDurableReserved, sharedTurnReserved)
+	overlappingSandboxTurns := max(sandboxTurnLocalReserved, runningDurableReserved+sharedTurnReserved)
 	return live + overlappingNonTurns + pendingDurableReserved + overlappingSandboxTurns
 }
 
@@ -1985,12 +1985,15 @@ func (s *JobStore) RenewLeaseForSessionExecutor(ctx context.Context, orgID, jobI
 		SET lease_expires_at = now() + (@lease_seconds * interval '1 second'),
 			sandbox_slot_reserved_until = CASE
 				WHEN sandbox_slot_reserved_until IS NULL THEN NULL
-				WHEN NULLIF(payload->>'session_id', '') IS NOT NULL
+				WHEN payload->>'session_id' ~* '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$'
 					AND EXISTS (
 						SELECT 1
 						FROM sessions sandbox_session
 						WHERE sandbox_session.org_id = jobs.org_id
-						  AND sandbox_session.id::text = payload->>'session_id'
+						  AND sandbox_session.id = CASE
+							WHEN payload->>'session_id' ~* '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$'
+							THEN (payload->>'session_id')::uuid
+						  END
 						  AND sandbox_session.container_id IS NOT NULL
 					) THEN NULL
 				ELSE now() + (@lease_seconds * interval '1 second')
@@ -2009,7 +2012,10 @@ func (s *JobStore) RenewLeaseForSessionExecutor(ctx context.Context, orgID, jobI
 		      SELECT 1
 		      FROM sessions s
 		      WHERE s.org_id = jobs.org_id
-		        AND s.id::text = payload->>'session_id'
+		        AND s.id = CASE
+		          WHEN payload->>'session_id' ~* '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$'
+		          THEN (payload->>'session_id')::uuid
+		        END
 		        AND s.status NOT IN ('completed', 'failed', 'cancelled', 'skipped')
 		    )
 		  )
@@ -2044,12 +2050,15 @@ func (s *JobStore) RenewLease(ctx context.Context, jobID, lockToken uuid.UUID, l
 		SET lease_expires_at = now() + (@lease_seconds * interval '1 second'),
 			sandbox_slot_reserved_until = CASE
 				WHEN sandbox_slot_reserved_until IS NULL THEN NULL
-				WHEN NULLIF(payload->>'session_id', '') IS NOT NULL
+				WHEN payload->>'session_id' ~* '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$'
 					AND EXISTS (
 						SELECT 1
 						FROM sessions sandbox_session
 						WHERE sandbox_session.org_id = jobs.org_id
-						  AND sandbox_session.id::text = payload->>'session_id'
+						  AND sandbox_session.id = CASE
+							WHEN payload->>'session_id' ~* '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$'
+							THEN (payload->>'session_id')::uuid
+						  END
 						  AND sandbox_session.container_id IS NOT NULL
 					) THEN NULL
 				ELSE now() + (@lease_seconds * interval '1 second')
@@ -2065,7 +2074,10 @@ func (s *JobStore) RenewLease(ctx context.Context, jobID, lockToken uuid.UUID, l
 		      SELECT 1
 		      FROM sessions s
 		      WHERE s.org_id = jobs.org_id
-		        AND s.id::text = payload->>'session_id'
+		        AND s.id = CASE
+		          WHEN payload->>'session_id' ~* '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$'
+		          THEN (payload->>'session_id')::uuid
+		        END
 		        AND s.status NOT IN ('completed', 'failed', 'cancelled', 'skipped')
 		    )
 		  )

--- a/internal/db/jobs.go
+++ b/internal/db/jobs.go
@@ -1517,6 +1517,7 @@ func selectSandboxRoutingCandidate(ctx context.Context, tx pgx.Tx, workloadClass
 						FROM jobs reserved_job
 						JOIN nodes reserved_node ON reserved_node.id = reserved_job.target_node_id
 						WHERE reserved_job.id = shared_reservation.job_id
+						  AND reserved_job.lock_token = shared_reservation.job_lock_token
 						  AND COALESCE(
 								NULLIF(reserved_node.metadata->>'sandbox_capacity_node_id', ''),
 								regexp_replace(reserved_node.id, '-g[0-9]{14}-[A-Za-z0-9._-]+$', '')
@@ -1625,12 +1626,12 @@ func sandboxRoutingCandidateHasCapacity(ctx context.Context, tx pgx.Tx, nodeID s
 				WHERE shared_reservation.node_id = n.capacity_node_id
 				  AND shared_reservation.expires_at > now()
 				  AND shared_reservation.job_id IS NOT NULL
-				  AND shared_reservation.job_id <> @job_id
 				  AND NOT EXISTS (
 					SELECT 1
 					FROM jobs reserved_job
 					JOIN nodes reserved_node ON reserved_node.id = reserved_job.target_node_id
 					WHERE reserved_job.id = shared_reservation.job_id
+					  AND reserved_job.lock_token = shared_reservation.job_lock_token
 					  AND COALESCE(
 							NULLIF(reserved_node.metadata->>'sandbox_capacity_node_id', ''),
 							regexp_replace(reserved_node.id, '-g[0-9]{14}-[A-Za-z0-9._-]+$', '')

--- a/internal/db/jobs.go
+++ b/internal/db/jobs.go
@@ -173,7 +173,7 @@ func (s *JobStore) SetNotifier(notifier *cache.JobNotifier) {
 	s.notifier = notifier
 }
 
-// SetLogger injects the structured logger used for best-effort notifier failures.
+// SetLogger injects the structured logger used for best-effort store failures.
 // lint:allow-no-orgid reason="process-wide dependency injection for store logging"
 func (s *JobStore) SetLogger(logger zerolog.Logger) {
 	s.logger = logger
@@ -2501,13 +2501,13 @@ func (s *JobStore) RenewLeaseForSessionExecutor(ctx context.Context, orgID, jobI
 
 // renewSandboxCapacityLease keeps the shared final-admission lease for a live
 // job attempt fresh so its short TTL only ever fences dead processes. Failures
-// are deliberately swallowed: the job-lease renewal that precedes this call
-// already proved attempt ownership, the next renewal retries within seconds,
-// and an expired lease costs at most one bounded over-admission on the host —
-// far cheaper than failing the job's own lease renewal.
+// remain best-effort because the job-lease renewal that precedes this call
+// already proved attempt ownership and the next renewal retries within seconds.
+// Log failures so repeated renewal problems and any bounded over-admission can
+// be diagnosed without failing the job's own lease renewal.
 // lint:allow-no-orgid reason="fenced by globally unique job id and claim token; extends the cross-org job-lease renewal path"
 func (s *JobStore) renewSandboxCapacityLease(ctx context.Context, jobID, lockToken uuid.UUID) {
-	_, _ = s.db.Exec(ctx, `
+	_, err := s.db.Exec(ctx, `
 		UPDATE sandbox_capacity_reservations
 		SET expires_at = GREATEST(expires_at, now() + (@ttl_seconds * interval '1 second'))
 		WHERE job_id = @job_id
@@ -2516,6 +2516,12 @@ func (s *JobStore) renewSandboxCapacityLease(ctx context.Context, jobID, lockTok
 		"lock_token":  lockToken,
 		"ttl_seconds": int(sandboxCapacityJobLeaseRenewalTTL.Seconds()),
 	})
+	if err != nil {
+		s.logger.Warn().
+			Err(err).
+			Str("job_id", jobID.String()).
+			Msg("failed to renew sandbox capacity lease")
+	}
 }
 
 // RenewLease extends the lease for a running job owned by the provided fencing

--- a/internal/db/jobs.go
+++ b/internal/db/jobs.go
@@ -1421,6 +1421,28 @@ func selectSandboxRoutingCandidate(ctx context.Context, tx pgx.Tx, workloadClass
 					  AND reserved_job.sandbox_slot_reserved_until > now()
 					  AND reserved_job.status = 'running'
 				) AS running_durable_reservations,
+				(
+					SELECT COUNT(*)
+					FROM sandbox_capacity_reservations shared_reservation
+					WHERE shared_reservation.node_id = n.id
+					  AND shared_reservation.expires_at > now()
+					  AND shared_reservation.job_id IS NOT NULL
+					  AND NOT EXISTS (
+						SELECT 1
+						FROM jobs reserved_job
+						WHERE reserved_job.id = shared_reservation.job_id
+						  AND reserved_job.target_node_id = n.id
+						  AND reserved_job.sandbox_slot_reserved_until > now()
+						  AND reserved_job.status IN ('pending', 'running')
+					  )
+				) AS shared_sandbox_turn_reservations,
+				(
+					SELECT COUNT(*)
+					FROM sandbox_capacity_reservations shared_reservation
+					WHERE shared_reservation.node_id = n.id
+					  AND shared_reservation.expires_at > now()
+					  AND shared_reservation.job_id IS NULL
+				) AS shared_non_turn_reservations,
 				n.last_heartbeat_at
 			FROM nodes n
 			WHERE n.mode IN ('worker', 'all')
@@ -1433,9 +1455,9 @@ func selectSandboxRoutingCandidate(ctx context.Context, tx pgx.Tx, workloadClass
 			SELECT
 				*,
 				live_sandboxes
-					+ GREATEST(local_reservations - sandbox_turn_local_reservations, 0)
+					+ GREATEST(local_reservations - sandbox_turn_local_reservations, shared_non_turn_reservations, 0)
 					+ pending_durable_reservations
-					+ GREATEST(sandbox_turn_local_reservations, running_durable_reservations) AS capacity_load
+					+ GREATEST(sandbox_turn_local_reservations, running_durable_reservations, shared_sandbox_turn_reservations) AS capacity_load
 			FROM raw_load
 		)
 		SELECT id
@@ -1465,7 +1487,7 @@ func selectSandboxRoutingCandidate(ctx context.Context, tx pgx.Tx, workloadClass
 
 // lint:allow-no-orgid reason="worker capacity routing intentionally aggregates reservations across organizations"
 func sandboxRoutingCandidateHasCapacity(ctx context.Context, tx pgx.Tx, nodeID string, jobID uuid.UUID, workloadClass models.SandboxWorkloadClass) (bool, error) {
-	var live, localReserved, sandboxTurnLocalReserved, maxActive, interactiveReserved, pendingDurableReserved, runningDurableReserved int
+	var live, localReserved, sandboxTurnLocalReserved, maxActive, interactiveReserved, pendingDurableReserved, runningDurableReserved, sharedTurnReserved, sharedNonTurnReserved int
 	err := tx.QueryRow(ctx, `
 		SELECT
 			COALESCE(NULLIF(n.metadata->>'live_sandbox_count', '')::int, 0),
@@ -1491,6 +1513,29 @@ func sandboxRoutingCandidateHasCapacity(ctx context.Context, tx pgx.Tx, nodeID s
 				  AND reserved_job.id <> @job_id
 				  AND reserved_job.sandbox_slot_reserved_until > now()
 				  AND reserved_job.status = 'running'
+			),
+			(
+				SELECT COUNT(*)
+				FROM sandbox_capacity_reservations shared_reservation
+				WHERE shared_reservation.node_id = n.id
+				  AND shared_reservation.expires_at > now()
+				  AND shared_reservation.job_id IS NOT NULL
+				  AND shared_reservation.job_id <> @job_id
+				  AND NOT EXISTS (
+					SELECT 1
+					FROM jobs reserved_job
+					WHERE reserved_job.id = shared_reservation.job_id
+					  AND reserved_job.target_node_id = n.id
+					  AND reserved_job.sandbox_slot_reserved_until > now()
+					  AND reserved_job.status IN ('pending', 'running')
+				  )
+			),
+			(
+				SELECT COUNT(*)
+				FROM sandbox_capacity_reservations shared_reservation
+				WHERE shared_reservation.node_id = n.id
+				  AND shared_reservation.expires_at > now()
+				  AND shared_reservation.job_id IS NULL
 			)
 		FROM nodes n
 		WHERE n.id = @node_id
@@ -1501,7 +1546,7 @@ func sandboxRoutingCandidateHasCapacity(ctx context.Context, tx pgx.Tx, nodeID s
 		"job_id":      jobID,
 		"node_id":     nodeID,
 		"dead_before": time.Now().Add(-nodeDeadHeartbeatThreshold),
-	}).Scan(&live, &localReserved, &sandboxTurnLocalReserved, &maxActive, &interactiveReserved, &pendingDurableReserved, &runningDurableReserved)
+	}).Scan(&live, &localReserved, &sandboxTurnLocalReserved, &maxActive, &interactiveReserved, &pendingDurableReserved, &runningDurableReserved, &sharedTurnReserved, &sharedNonTurnReserved)
 	if errors.Is(err, pgx.ErrNoRows) {
 		return false, nil
 	}
@@ -1512,14 +1557,14 @@ func sandboxRoutingCandidateHasCapacity(ctx context.Context, tx pgx.Tx, nodeID s
 	if workloadClass == models.SandboxWorkloadClassCodeReview {
 		effectiveMax -= interactiveReserved
 	}
-	load := sandboxRoutingCapacityLoad(live, localReserved, sandboxTurnLocalReserved, pendingDurableReserved, runningDurableReserved)
+	load := sandboxRoutingCapacityLoad(live, localReserved, sandboxTurnLocalReserved, pendingDurableReserved, runningDurableReserved, sharedTurnReserved, sharedNonTurnReserved)
 	return effectiveMax > 0 && load < effectiveMax, nil
 }
 
-func sandboxRoutingCapacityLoad(live, localReserved, sandboxTurnLocalReserved, pendingDurableReserved, runningDurableReserved int) int {
-	localOnlyReserved := max(localReserved-sandboxTurnLocalReserved, 0)
-	overlappingSandboxTurns := max(sandboxTurnLocalReserved, runningDurableReserved)
-	return live + localOnlyReserved + pendingDurableReserved + overlappingSandboxTurns
+func sandboxRoutingCapacityLoad(live, localReserved, sandboxTurnLocalReserved, pendingDurableReserved, runningDurableReserved, sharedTurnReserved, sharedNonTurnReserved int) int {
+	overlappingNonTurns := max(localReserved-sandboxTurnLocalReserved, sharedNonTurnReserved, 0)
+	overlappingSandboxTurns := max(sandboxTurnLocalReserved, runningDurableReserved, sharedTurnReserved)
+	return live + overlappingNonTurns + pendingDurableReserved + overlappingSandboxTurns
 }
 
 // CountActiveSandboxTurnsByOrg returns claimed interactive and code-review

--- a/internal/db/jobs.go
+++ b/internal/db/jobs.go
@@ -797,6 +797,13 @@ const (
 	sandboxRoutingTerminalProbeAge = 8 * time.Minute
 	sandboxFailedNodeExclusionTTL  = time.Minute
 	maxClaimAdmissionSkips         = 16
+	// sandboxCapacityJobLeaseRenewalTTL matches the job-backed shared
+	// final-admission lease TTL used at acquisition in
+	// internal/services/agent. Job-lease renewal (every ~20s) keeps a live
+	// attempt's lease fresh, so expiry only fences attempts whose process
+	// died, and a replacement attempt waits at most this long for the stale
+	// lease instead of a long static TTL.
+	sandboxCapacityJobLeaseRenewalTTL = 2 * time.Minute
 )
 
 type SandboxRoutingReason string
@@ -2488,7 +2495,27 @@ func (s *JobStore) RenewLeaseForSessionExecutor(ctx context.Context, orgID, jobI
 	if err != nil {
 		return nil, false, fmt.Errorf("renew session executor job lease: %w", err)
 	}
+	s.renewSandboxCapacityLease(ctx, jobID, lockToken)
 	return &models.Job{ID: jobID, LockToken: &lockToken, LeaseExpiresAt: &leaseExpiresAt}, true, nil
+}
+
+// renewSandboxCapacityLease keeps the shared final-admission lease for a live
+// job attempt fresh so its short TTL only ever fences dead processes. Failures
+// are deliberately swallowed: the job-lease renewal that precedes this call
+// already proved attempt ownership, the next renewal retries within seconds,
+// and an expired lease costs at most one bounded over-admission on the host —
+// far cheaper than failing the job's own lease renewal.
+// lint:allow-no-orgid reason="fenced by globally unique job id and claim token; extends the cross-org job-lease renewal path"
+func (s *JobStore) renewSandboxCapacityLease(ctx context.Context, jobID, lockToken uuid.UUID) {
+	_, _ = s.db.Exec(ctx, `
+		UPDATE sandbox_capacity_reservations
+		SET expires_at = GREATEST(expires_at, now() + (@ttl_seconds * interval '1 second'))
+		WHERE job_id = @job_id
+		  AND job_lock_token = @lock_token`, pgx.NamedArgs{
+		"job_id":      jobID,
+		"lock_token":  lockToken,
+		"ttl_seconds": int(sandboxCapacityJobLeaseRenewalTTL.Seconds()),
+	})
 }
 
 // RenewLease extends the lease for a running job owned by the provided fencing
@@ -2548,6 +2575,7 @@ func (s *JobStore) RenewLease(ctx context.Context, jobID, lockToken uuid.UUID, l
 	if err != nil {
 		return nil, false, fmt.Errorf("renew job lease: %w", err)
 	}
+	s.renewSandboxCapacityLease(ctx, jobID, lockToken)
 	return &models.Job{ID: jobID, LockToken: &lockToken, LeaseExpiresAt: &leaseExpiresAt}, true, nil
 }
 

--- a/internal/db/jobs.go
+++ b/internal/db/jobs.go
@@ -83,6 +83,33 @@ func ContinueSessionDedupeKey(scopeID uuid.UUID) string {
 	return "continue_session:" + scopeID.String()
 }
 
+// ContinueSessionEnqueueOpts is the canonical scheduling policy for every
+// continuation turn. Callers provide the payload and dedupe scope, while this
+// helper keeps queue, priority, worker affinity, and workload classification
+// consistent across API, integration, and worker-originated resumes.
+//
+// A nil session deliberately produces an unpinned interactive fallback for
+// paths that accept input while the authoritative session lookup is
+// temporarily unavailable.
+func ContinueSessionEnqueueOpts(session *models.Session, payload any, dedupeKey *string) EnqueueOpts {
+	opts := EnqueueOpts{
+		Queue:        "agent",
+		JobType:      "continue_session",
+		Payload:      payload,
+		Priority:     5,
+		DedupeKey:    dedupeKey,
+		TargetNodeID: models.SessionWorkerTarget(session),
+	}
+	if session == nil {
+		// The fallback must be explicit because the authoritative classification
+		// could not be loaded; routing will repair it from the session row later.
+		opts.WorkloadClass = models.SandboxWorkloadClassInteractive
+	} else if models.SandboxWorkloadClassForSession(session) == models.SandboxWorkloadClassCodeReview {
+		opts.WorkloadClass = models.SandboxWorkloadClassCodeReview
+	}
+	return opts
+}
+
 type JobStore struct {
 	db       DBTX
 	notifier *cache.JobNotifier
@@ -766,6 +793,7 @@ const (
 	SandboxOrgLimitRetryDelay      = 5 * time.Second
 	sandboxRoutingErrorRetryDelay  = 10 * time.Second
 	sandboxRoutingTerminalProbeAge = 8 * time.Minute
+	sandboxFailedNodeExclusionTTL  = time.Minute
 	maxClaimAdmissionSkips         = 16
 )
 
@@ -876,7 +904,7 @@ func (s *JobStore) RouteNextSandboxJob(ctx context.Context) (*SandboxRoutingResu
 		return s.deferSandboxRoutingJobError(ctx, tx, job, err)
 	}
 
-	result, err := reserveSandboxSlotForLockedJob(ctx, tx, job, "")
+	result, err := reserveSandboxSlotForLockedJob(ctx, tx, job, nil)
 	if err != nil {
 		return s.deferSandboxRoutingJobError(ctx, tx, job, err)
 	}
@@ -908,7 +936,7 @@ func (s *JobStore) RouteNextSandboxJob(ctx context.Context) (*SandboxRoutingResu
 			}
 		}
 		if fallbackReason != "" {
-			targetNodeID, fallbackErr := selectSandboxRoutingFallbackNode(ctx, tx)
+			targetNodeID, fallbackErr := selectSandboxRoutingFallbackNode(ctx, tx, job.ID, job.OrgID, nil)
 			if fallbackErr != nil && !errors.Is(fallbackErr, pgx.ErrNoRows) {
 				return s.deferSandboxRoutingJobError(ctx, tx, job, fallbackErr)
 			}
@@ -1047,6 +1075,20 @@ func sandboxCapacityMetadataConfigured(ctx context.Context, tx pgx.Tx) (bool, er
 // preserves the target and reservation selected here.
 // lint:allow-no-orgid reason="worker retry routes a globally identified job across worker nodes"
 func (s *JobStore) ReserveSandboxSlotForRetry(ctx context.Context, jobID, lockToken uuid.UUID, excludeNodeID string) (*SandboxRoutingResult, error) {
+	return s.reserveSandboxSlotForRunningAttempt(ctx, jobID, lockToken, excludeNodeID, false)
+}
+
+// RerouteSandboxAfterStartupFailure records the failed physical capacity node
+// and atomically reserves a healthy alternate for the same running attempt.
+// Persisting a bounded exclusion on the job keeps ordinary retries off that
+// Docker host when no alternate is immediately available without permanently
+// removing a recovered host from a small fleet.
+// lint:allow-no-orgid reason="fenced worker retry routes a globally identified job across worker nodes"
+func (s *JobStore) RerouteSandboxAfterStartupFailure(ctx context.Context, jobID, lockToken uuid.UUID, failedNodeID string) (*SandboxRoutingResult, error) {
+	return s.reserveSandboxSlotForRunningAttempt(ctx, jobID, lockToken, failedNodeID, true)
+}
+
+func (s *JobStore) reserveSandboxSlotForRunningAttempt(ctx context.Context, jobID, lockToken uuid.UUID, excludeNodeID string, persistExclusion bool) (*SandboxRoutingResult, error) {
 	txStarter, ok := s.db.(TxStarter)
 	if !ok {
 		return nil, fmt.Errorf("job store does not support sandbox routing transactions")
@@ -1085,8 +1127,63 @@ func (s *JobStore) ReserveSandboxSlotForRetry(ctx context.Context, jobID, lockTo
 	if err := resolveSandboxRoutingWorkloadClass(ctx, tx, &job); err != nil {
 		return nil, err
 	}
+	if persistExclusion {
+		if excludeNodeID == "" {
+			return nil, fmt.Errorf("record failed sandbox startup worker: node id is empty")
+		}
+		var failedCapacityNodeID string
+		if err := tx.QueryRow(ctx, `
+			SELECT COALESCE(
+				(
+					SELECT COALESCE(
+						NULLIF(metadata->>'sandbox_capacity_node_id', ''),
+						regexp_replace(id, '-g[0-9]{14}-[A-Za-z0-9._-]+$', '')
+					)
+					FROM nodes
+					WHERE id = @node_id
+				),
+				regexp_replace(@node_id, '-g[0-9]{14}-[A-Za-z0-9._-]+$', '')
+			)`, pgx.NamedArgs{"node_id": excludeNodeID}).Scan(&failedCapacityNodeID); err != nil {
+			return nil, fmt.Errorf("resolve failed sandbox capacity node %s: %w", excludeNodeID, err)
+		}
+		resultTag, err := tx.Exec(ctx, `
+			UPDATE jobs
+			SET payload = jsonb_set(
+					CASE
+						WHEN COALESCE(payload->'failed_sandbox_capacity_node_ids', '[]'::jsonb) ? @capacity_node_id THEN payload
+						ELSE jsonb_set(
+							payload,
+							'{failed_sandbox_capacity_node_ids}',
+							COALESCE(payload->'failed_sandbox_capacity_node_ids', '[]'::jsonb) || to_jsonb(@capacity_node_id::text),
+							true
+						)
+					END,
+					'{failed_sandbox_capacity_node_exclusion_until}',
+					to_jsonb(now() + (@exclusion_seconds * interval '1 second')),
+					true
+				),
+				updated_at = now()
+			WHERE id = @job_id
+			  AND status = 'running'
+			  AND lock_token = @lock_token`, pgx.NamedArgs{
+			"capacity_node_id":  failedCapacityNodeID,
+			"exclusion_seconds": int(sandboxFailedNodeExclusionTTL.Seconds()),
+			"job_id":            job.ID,
+			"lock_token":        lockToken,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("record failed sandbox capacity node: %w", err)
+		}
+		if resultTag.RowsAffected() != 1 {
+			return nil, fmt.Errorf("record failed sandbox capacity node: job %s lease changed", job.ID)
+		}
+	}
 
-	result, err := reserveSandboxSlotForLockedJob(ctx, tx, job, excludeNodeID)
+	excludedNodeIDs := []string{}
+	if excludeNodeID != "" {
+		excludedNodeIDs = append(excludedNodeIDs, excludeNodeID)
+	}
+	result, err := reserveSandboxSlotForLockedJob(ctx, tx, job, excludedNodeIDs)
 	if err != nil {
 		return nil, err
 	}
@@ -1117,7 +1214,7 @@ func (s *JobStore) ReserveSandboxSlotForRetry(ctx context.Context, jobID, lockTo
 	return result, nil
 }
 
-func reserveSandboxSlotForLockedJob(ctx context.Context, tx pgx.Tx, job sandboxRoutingJob, excludeNodeID string) (*SandboxRoutingResult, error) {
+func reserveSandboxSlotForLockedJob(ctx context.Context, tx pgx.Tx, job sandboxRoutingJob, excludedNodeIDs []string) (*SandboxRoutingResult, error) {
 	result := &SandboxRoutingResult{
 		JobID:         job.ID,
 		WorkloadClass: job.WorkloadClass,
@@ -1136,13 +1233,9 @@ func reserveSandboxSlotForLockedJob(ctx context.Context, tx pgx.Tx, job sandboxR
 		return result, nil
 	}
 
-	excludedNodeIDs := []string{}
-	if excludeNodeID != "" {
-		excludedNodeIDs = append(excludedNodeIDs, excludeNodeID)
-	}
 	lockContended := false
 	for {
-		candidate, err := selectSandboxRoutingCandidate(ctx, tx, job.WorkloadClass, excludedNodeIDs)
+		candidate, err := selectSandboxRoutingCandidate(ctx, tx, job.ID, job.OrgID, job.WorkloadClass, excludedNodeIDs)
 		if errors.Is(err, pgx.ErrNoRows) {
 			if lockContended {
 				result.Reason = SandboxRoutingReasonLockContention
@@ -1434,20 +1527,56 @@ func markSandboxCancellationCleanup(ctx context.Context, tx pgx.Tx, job sandboxR
 }
 
 // lint:allow-no-orgid reason="terminal capacity probe selects a fresh worker across organizations"
-func selectSandboxRoutingFallbackNode(ctx context.Context, tx pgx.Tx) (string, error) {
+func selectSandboxRoutingFallbackNode(ctx context.Context, tx pgx.Tx, jobID, orgID uuid.UUID, excludedNodeIDs []string) (string, error) {
 	var nodeID string
 	err := tx.QueryRow(ctx, `
+		WITH excluded_capacity_nodes AS (
+			SELECT jsonb_array_elements_text(COALESCE(j.payload->'failed_sandbox_capacity_node_ids', '[]'::jsonb)) AS capacity_node_id
+			FROM jobs j
+			WHERE j.id = @job_id
+			  AND j.org_id = @org_id
+			  AND COALESCE((j.payload->>'failed_sandbox_capacity_node_exclusion_until')::timestamptz, '-infinity'::timestamptz) > now()
+			UNION
+			SELECT COALESCE(
+				(
+					SELECT COALESCE(
+						NULLIF(excluded_node.metadata->>'sandbox_capacity_node_id', ''),
+						regexp_replace(excluded_node.id, '-g[0-9]{14}-[A-Za-z0-9._-]+$', '')
+					)
+					FROM nodes excluded_node
+					WHERE excluded_node.id = excluded_id
+				),
+				regexp_replace(excluded_id, '-g[0-9]{14}-[A-Za-z0-9._-]+$', '')
+			)
+			FROM unnest(@excluded_node_ids::text[]) excluded_id
+		),
+		candidate_nodes AS (
+			SELECT n.*,
+				COALESCE(
+					NULLIF(n.metadata->>'sandbox_capacity_node_id', ''),
+					regexp_replace(n.id, '-g[0-9]{14}-[A-Za-z0-9._-]+$', '')
+				) AS capacity_node_id
+			FROM nodes n
+			WHERE n.mode IN ('worker', 'all')
+			  AND n.status = 'active'
+			  AND n.last_heartbeat_at >= @dead_before
+		)
 		SELECT n.id
-		FROM nodes n
-		WHERE n.mode IN ('worker', 'all')
-		  AND n.status = 'active'
-		  AND n.last_heartbeat_at >= @dead_before
+		FROM candidate_nodes n
+		WHERE NOT EXISTS (
+			SELECT 1
+			FROM excluded_capacity_nodes excluded
+			WHERE excluded.capacity_node_id = n.capacity_node_id
+		)
 		ORDER BY
 			COALESCE(NULLIF(n.metadata->>'active_job_count', '')::int, 0) ASC,
 			n.last_heartbeat_at DESC,
 			n.id ASC
 		LIMIT 1`, pgx.NamedArgs{
-		"dead_before": time.Now().Add(-nodeDeadHeartbeatThreshold),
+		"dead_before":       time.Now().Add(-nodeDeadHeartbeatThreshold),
+		"excluded_node_ids": excludedNodeIDs,
+		"job_id":            jobID,
+		"org_id":            orgID,
 	}).Scan(&nodeID)
 	if err != nil {
 		return "", fmt.Errorf("select worker for terminal sandbox capacity probe: %w", err)
@@ -1456,10 +1585,30 @@ func selectSandboxRoutingFallbackNode(ctx context.Context, tx pgx.Tx) (string, e
 }
 
 // lint:allow-no-orgid reason="worker capacity routing intentionally aggregates reservations across organizations"
-func selectSandboxRoutingCandidate(ctx context.Context, tx pgx.Tx, workloadClass models.SandboxWorkloadClass, excludedNodeIDs []string) (string, error) {
+func selectSandboxRoutingCandidate(ctx context.Context, tx pgx.Tx, jobID, orgID uuid.UUID, workloadClass models.SandboxWorkloadClass, excludedNodeIDs []string) (string, error) {
 	var nodeID string
 	err := tx.QueryRow(ctx, `
-		WITH candidate_nodes AS (
+		WITH excluded_capacity_nodes AS (
+			SELECT jsonb_array_elements_text(COALESCE(j.payload->'failed_sandbox_capacity_node_ids', '[]'::jsonb)) AS capacity_node_id
+			FROM jobs j
+			WHERE j.id = @job_id
+			  AND j.org_id = @org_id
+			  AND COALESCE((j.payload->>'failed_sandbox_capacity_node_exclusion_until')::timestamptz, '-infinity'::timestamptz) > now()
+			UNION
+			SELECT COALESCE(
+				(
+					SELECT COALESCE(
+						NULLIF(excluded_node.metadata->>'sandbox_capacity_node_id', ''),
+						regexp_replace(excluded_node.id, '-g[0-9]{14}-[A-Za-z0-9._-]+$', '')
+					)
+					FROM nodes excluded_node
+					WHERE excluded_node.id = excluded_id
+				),
+				regexp_replace(excluded_id, '-g[0-9]{14}-[A-Za-z0-9._-]+$', '')
+			)
+			FROM unnest(@excluded_node_ids::text[]) excluded_id
+		),
+		candidate_nodes AS (
 			SELECT n.*,
 				COALESCE(
 					NULLIF(n.metadata->>'sandbox_capacity_node_id', ''),
@@ -1470,7 +1619,14 @@ func selectSandboxRoutingCandidate(ctx context.Context, tx pgx.Tx, workloadClass
 			  AND n.status = 'active'
 			  AND n.last_heartbeat_at >= @dead_before
 			  AND COALESCE(n.metadata->>'live_sandbox_count_error', '') = ''
-			  AND NOT (n.id = ANY(@excluded_node_ids::text[]))
+			  AND NOT EXISTS (
+				SELECT 1
+				FROM excluded_capacity_nodes excluded
+				WHERE excluded.capacity_node_id = COALESCE(
+					NULLIF(n.metadata->>'sandbox_capacity_node_id', ''),
+					regexp_replace(n.id, '-g[0-9]{14}-[A-Za-z0-9._-]+$', '')
+				)
+			  )
 		),
 		raw_load AS (
 			SELECT
@@ -1494,6 +1650,7 @@ func selectSandboxRoutingCandidate(ctx context.Context, tx pgx.Tx, workloadClass
 						) = n.capacity_node_id
 					  AND reserved_job.sandbox_slot_reserved_until > now()
 					  AND reserved_job.status = 'pending'
+					  AND reserved_job.id <> @job_id
 				) AS pending_durable_reservations,
 				(
 					SELECT COUNT(*)
@@ -1505,6 +1662,7 @@ func selectSandboxRoutingCandidate(ctx context.Context, tx pgx.Tx, workloadClass
 						) = n.capacity_node_id
 					  AND reserved_job.sandbox_slot_reserved_until > now()
 					  AND reserved_job.status = 'running'
+					  AND reserved_job.id <> @job_id
 				) AS running_durable_reservations,
 				(
 					SELECT COUNT(*)
@@ -1562,6 +1720,8 @@ func selectSandboxRoutingCandidate(ctx context.Context, tx pgx.Tx, workloadClass
 		LIMIT 1`, pgx.NamedArgs{
 		"dead_before":       time.Now().Add(-nodeDeadHeartbeatThreshold),
 		"excluded_node_ids": excludedNodeIDs,
+		"job_id":            jobID,
+		"org_id":            orgID,
 		"workload_class":    workloadClass,
 	}).Scan(&nodeID)
 	if err != nil {
@@ -1734,7 +1894,7 @@ func (s *JobStore) IsSessionWaitingForSandboxCapacity(ctx context.Context, orgID
 			  AND waiting_job.payload->>'capacity_cleanup' IS DISTINCT FROM 'true'
 			  AND NOT (
 				waiting_job.job_type = 'run_agent'
-				AND waiting_job.retry_window_started_at = waiting_job.created_at
+				AND waiting_job.retry_window_started_at IS NOT DISTINCT FROM waiting_job.created_at
 				AND waiting_job.created_at <= now() - (@terminal_probe_seconds * interval '1 second')
 			  )
 			  AND (
@@ -1840,8 +2000,9 @@ type jobExecer interface {
 // turn starves until the node dies; the claimer hydrates from the snapshot.
 // lint:allow-no-orgid reason="worker queue consumer scans cross-org jobs by design"
 func (s *JobStore) ClaimNextRunnable(ctx context.Context, nodeID, ownerID string, lockToken uuid.UUID, leaseDuration time.Duration) (*models.Job, error) {
+	excludedSandboxOrgIDs := []uuid.UUID{}
 	for attempt := 0; attempt < maxClaimAdmissionSkips; attempt++ {
-		job, deferred, err := s.claimNextRunnableAttempt(ctx, nodeID, ownerID, lockToken, leaseDuration)
+		job, deferred, err := s.claimNextRunnableAttempt(ctx, nodeID, ownerID, lockToken, leaseDuration, &excludedSandboxOrgIDs)
 		if err != nil {
 			return nil, err
 		}
@@ -1856,7 +2017,7 @@ func (s *JobStore) ClaimNextRunnable(ctx context.Context, nodeID, ownerID string
 // particular, an org-limit deferral commits before the next candidate is
 // examined, so organization row locks can never accumulate in cross-org scan
 // order and deadlock another dispatcher or a settings update.
-func (s *JobStore) claimNextRunnableAttempt(ctx context.Context, nodeID, ownerID string, lockToken uuid.UUID, leaseDuration time.Duration) (*models.Job, bool, error) {
+func (s *JobStore) claimNextRunnableAttempt(ctx context.Context, nodeID, ownerID string, lockToken uuid.UUID, leaseDuration time.Duration, excludedSandboxOrgIDs *[]uuid.UUID) (*models.Job, bool, error) {
 	txStarter, ok := s.db.(TxStarter)
 	if !ok {
 		return nil, false, fmt.Errorf("job store does not support claim transactions")
@@ -1892,6 +2053,10 @@ func (s *JobStore) claimNextRunnableAttempt(ctx context.Context, nodeID, ownerID
 			WHERE j.status = 'pending' AND j.run_at <= now()
 			  AND (j.job_type NOT IN ('run_agent', 'continue_session') OR j.target_node_id IS NOT NULL)
 			  AND (
+				j.job_type NOT IN ('run_agent', 'continue_session')
+				OR NOT (j.org_id = ANY(@excluded_sandbox_org_ids::uuid[]))
+			  )
+			  AND (
 			    j.target_node_id IS NULL
 			    OR j.target_node_id = @node_id
 			    OR (d.id IS NOT NULL AND j.sandbox_slot_reserved_until IS NULL)
@@ -1910,8 +2075,9 @@ func (s *JobStore) claimNextRunnableAttempt(ctx context.Context, nodeID, ownerID
 				j.created_at ASC
 			FOR UPDATE OF j SKIP LOCKED
 			LIMIT 1`, pgx.NamedArgs{
-		"dead_before": time.Now().Add(-nodeDeadHeartbeatThreshold),
-		"node_id":     nodeID,
+		"dead_before":              time.Now().Add(-nodeDeadHeartbeatThreshold),
+		"excluded_sandbox_org_ids": *excludedSandboxOrgIDs,
+		"node_id":                  nodeID,
 	}).Scan(
 		&candidate.ID,
 		&candidate.OrgID,
@@ -2013,6 +2179,7 @@ func (s *JobStore) claimNextRunnableAttempt(ctx context.Context, nodeID, ownerID
 				if err := tx.Commit(ctx); err != nil {
 					return nil, false, fmt.Errorf("commit sandbox org-limit deferral: %w", err)
 				}
+				*excludedSandboxOrgIDs = append(*excludedSandboxOrgIDs, candidate.OrgID)
 				return nil, true, nil
 			}
 		}

--- a/internal/db/pull_request_feedback.go
+++ b/internal/db/pull_request_feedback.go
@@ -433,17 +433,7 @@ func (s *PullRequestFeedbackStore) QueueContinuation(ctx context.Context, orgID,
 	}
 	payload := map[string]any{"org_id": orgID.String(), "session_id": batch.SessionID.String(), "thread_id": threadID.String(), "queued_message_id": strconv.FormatInt(message.ID, 10), "feedback_batch_id": batch.ID.String(), "pull_request_id": batch.PullRequestID.String(), "pull_request_number": pullRequestNumber, "head_sha": batch.ExpectedHeadSHA, "workspace_mode": models.PRFeedbackWorkspaceModePRHeadReconstruction, "structured_prompt": structuredPrompt}
 	dedupeKey := "continue_pr_feedback:" + batch.ID.String()
-	enqueueOpts := EnqueueOpts{
-		Queue:        "agent",
-		JobType:      "continue_session",
-		Payload:      payload,
-		Priority:     5,
-		DedupeKey:    &dedupeKey,
-		TargetNodeID: models.SessionWorkerTarget(&session),
-	}
-	if models.SandboxWorkloadClassForSession(&session) == models.SandboxWorkloadClassCodeReview {
-		enqueueOpts.WorkloadClass = models.SandboxWorkloadClassCodeReview
-	}
+	enqueueOpts := ContinueSessionEnqueueOpts(&session, payload, &dedupeKey)
 	jobID, err := s.jobs.EnqueueInTxWithOpts(ctx, tx, orgID, enqueueOpts)
 	if err != nil {
 		return nil, fmt.Errorf("enqueue PR feedback continuation: %w", err)

--- a/internal/db/sandbox_capacity_reservations.go
+++ b/internal/db/sandbox_capacity_reservations.go
@@ -134,16 +134,36 @@ func (s *SandboxCapacityReservationStore) ReserveSandboxCapacity(
 }
 
 // ReleaseSandboxCapacity removes a final-admission lease once sandbox creation
-// either completes or aborts.
+// either completes or aborts. Release takes the same per-node advisory lock as
+// admission so a new admission cannot observe the container before it appears
+// in Docker while simultaneously missing the lease that protected its start.
 // lint:allow-no-orgid reason="reservation id is globally unique and release runs before tenant context may be available"
-func (s *SandboxCapacityReservationStore) ReleaseSandboxCapacity(ctx context.Context, reservationID uuid.UUID) error {
+func (s *SandboxCapacityReservationStore) ReleaseSandboxCapacity(ctx context.Context, nodeID string, reservationID uuid.UUID) error {
 	if s == nil || s.db == nil || reservationID == uuid.Nil {
 		return nil
 	}
-	if _, err := s.db.Exec(ctx, `
+	tx, err := s.db.Begin(ctx)
+	if err != nil {
+		return fmt.Errorf("begin shared sandbox capacity release: %w", err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	if _, err := tx.Exec(ctx, `SELECT pg_advisory_xact_lock(hashtextextended(@node_id, 143))`, pgx.NamedArgs{
+		"node_id": nodeID,
+	}); err != nil {
+		return fmt.Errorf("lock sandbox capacity release for worker %s: %w", nodeID, err)
+	}
+	if _, err := tx.Exec(ctx, `
 		DELETE FROM sandbox_capacity_reservations
-		WHERE id = $1`, reservationID); err != nil {
+		WHERE id = @reservation_id
+		  AND node_id = @node_id`, pgx.NamedArgs{
+		"node_id":        nodeID,
+		"reservation_id": reservationID,
+	}); err != nil {
 		return fmt.Errorf("release shared sandbox capacity reservation: %w", err)
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return fmt.Errorf("commit shared sandbox capacity release: %w", err)
 	}
 	return nil
 }

--- a/internal/db/sandbox_capacity_reservations.go
+++ b/internal/db/sandbox_capacity_reservations.go
@@ -1,0 +1,146 @@
+package db
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/assembledhq/143/internal/models"
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+)
+
+// SandboxCapacityReservationStore coordinates final worker-local admission
+// across the main worker and isolated session-executor processes.
+type SandboxCapacityReservationStore struct {
+	db TxStarter
+}
+
+func NewSandboxCapacityReservationStore(db TxStarter) *SandboxCapacityReservationStore {
+	return &SandboxCapacityReservationStore{db: db}
+}
+
+// ReserveSandboxCapacity atomically reserves one worker slot after combining
+// routed job reservations with short-lived final-admission leases. jobID may be
+// nil for non-job consumers such as previews. The current job is excluded from
+// the routed count because this call replaces its durable routing reservation
+// with a final-admission lease.
+// lint:allow-no-orgid reason="worker-local capacity admission intentionally coordinates jobs and previews across organizations"
+func (s *SandboxCapacityReservationStore) ReserveSandboxCapacity(
+	ctx context.Context,
+	nodeID string,
+	jobID *uuid.UUID,
+	workloadClass models.SandboxWorkloadClass,
+	countLiveSandboxes func(context.Context) (int, error),
+	effectiveMax int,
+	expiresAt time.Time,
+) (uuid.UUID, int, int, bool, error) {
+	if s == nil || s.db == nil {
+		return uuid.Nil, 0, 0, false, fmt.Errorf("reserve sandbox capacity: store is not configured")
+	}
+	if countLiveSandboxes == nil {
+		return uuid.Nil, 0, 0, false, fmt.Errorf("reserve sandbox capacity: live sandbox counter is not configured")
+	}
+	tx, err := s.db.Begin(ctx)
+	if err != nil {
+		return uuid.Nil, 0, 0, false, fmt.Errorf("begin sandbox capacity reservation: %w", err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	// Use the same per-node advisory namespace as durable job routing. This
+	// closes the count/insert race between a routed turn and a preview or
+	// executor doing final admission on the same Docker host.
+	if _, err := tx.Exec(ctx, `SELECT pg_advisory_xact_lock(hashtextextended(@node_id, 143))`, pgx.NamedArgs{
+		"node_id": nodeID,
+	}); err != nil {
+		return uuid.Nil, 0, 0, false, fmt.Errorf("lock sandbox capacity for worker %s: %w", nodeID, err)
+	}
+	if _, err := tx.Exec(ctx, `
+		DELETE FROM sandbox_capacity_reservations
+		WHERE node_id = @node_id
+		  AND expires_at <= now()`, pgx.NamedArgs{"node_id": nodeID}); err != nil {
+		return uuid.Nil, 0, 0, false, fmt.Errorf("delete expired sandbox capacity reservations: %w", err)
+	}
+
+	// Count only after taking the node lock. Otherwise another process could
+	// finish creating a container and release its lease between this count and
+	// the reservation insert, leaving admission based on a stale Docker view.
+	liveSandboxes, err := countLiveSandboxes(ctx)
+	if err != nil {
+		return uuid.Nil, 0, 0, false, fmt.Errorf("count live sandboxes for shared admission: %w", err)
+	}
+
+	var reserved int
+	err = tx.QueryRow(ctx, `
+		WITH active_capacity_keys AS (
+			SELECT 'job:' || reserved_job.id::text AS capacity_key
+			FROM jobs reserved_job
+			WHERE reserved_job.target_node_id = @node_id
+			  AND reserved_job.sandbox_slot_reserved_until > now()
+			  AND reserved_job.status IN ('pending', 'running')
+			  AND (@job_id::uuid IS NULL OR reserved_job.id <> @job_id)
+			UNION
+			SELECT CASE
+					WHEN local_reservation.job_id IS NOT NULL THEN 'job:' || local_reservation.job_id::text
+					ELSE 'local:' || local_reservation.id::text
+				END AS capacity_key
+			FROM sandbox_capacity_reservations local_reservation
+			WHERE local_reservation.node_id = @node_id
+			  AND local_reservation.expires_at > now()
+			  AND (@job_id::uuid IS NULL OR local_reservation.job_id IS DISTINCT FROM @job_id)
+		)
+		SELECT COUNT(*) FROM active_capacity_keys`, pgx.NamedArgs{
+		"job_id":  jobID,
+		"node_id": nodeID,
+	}).Scan(&reserved)
+	if err != nil {
+		return uuid.Nil, liveSandboxes, liveSandboxes, false, fmt.Errorf("count shared sandbox capacity reservations: %w", err)
+	}
+	total := liveSandboxes + reserved
+	if effectiveMax <= 0 || total >= effectiveMax {
+		if err := tx.Commit(ctx); err != nil {
+			return uuid.Nil, liveSandboxes, total, false, fmt.Errorf("commit rejected sandbox capacity reservation: %w", err)
+		}
+		return uuid.Nil, liveSandboxes, total, false, nil
+	}
+
+	var reservationID uuid.UUID
+	err = tx.QueryRow(ctx, `
+		INSERT INTO sandbox_capacity_reservations (
+			node_id, job_id, workload_class, expires_at
+		)
+		VALUES (@node_id, @job_id, @workload_class, @expires_at)
+		ON CONFLICT (job_id) WHERE job_id IS NOT NULL
+		DO UPDATE SET
+			node_id = EXCLUDED.node_id,
+			workload_class = EXCLUDED.workload_class,
+			expires_at = EXCLUDED.expires_at
+		RETURNING id`, pgx.NamedArgs{
+		"expires_at":     expiresAt,
+		"job_id":         jobID,
+		"node_id":        nodeID,
+		"workload_class": workloadClass,
+	}).Scan(&reservationID)
+	if err != nil {
+		return uuid.Nil, liveSandboxes, total, false, fmt.Errorf("insert shared sandbox capacity reservation: %w", err)
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return uuid.Nil, liveSandboxes, total, false, fmt.Errorf("commit shared sandbox capacity reservation: %w", err)
+	}
+	return reservationID, liveSandboxes, total + 1, true, nil
+}
+
+// ReleaseSandboxCapacity removes a final-admission lease once sandbox creation
+// either completes or aborts.
+// lint:allow-no-orgid reason="reservation id is globally unique and release runs before tenant context may be available"
+func (s *SandboxCapacityReservationStore) ReleaseSandboxCapacity(ctx context.Context, reservationID uuid.UUID) error {
+	if s == nil || s.db == nil || reservationID == uuid.Nil {
+		return nil
+	}
+	if _, err := s.db.Exec(ctx, `
+		DELETE FROM sandbox_capacity_reservations
+		WHERE id = $1`, reservationID); err != nil {
+		return fmt.Errorf("release shared sandbox capacity reservation: %w", err)
+	}
+	return nil
+}

--- a/internal/db/sandbox_capacity_reservations.go
+++ b/internal/db/sandbox_capacity_reservations.go
@@ -75,7 +75,11 @@ func (s *SandboxCapacityReservationStore) ReserveSandboxCapacity(
 		WITH active_capacity_keys AS (
 			SELECT 'job:' || reserved_job.id::text AS capacity_key
 			FROM jobs reserved_job
-			WHERE reserved_job.target_node_id = @node_id
+			JOIN nodes reserved_node ON reserved_node.id = reserved_job.target_node_id
+			WHERE COALESCE(
+					NULLIF(reserved_node.metadata->>'sandbox_capacity_node_id', ''),
+					regexp_replace(reserved_node.id, '-g[0-9]{14}-[A-Za-z0-9._-]+$', '')
+				) = @node_id
 			  AND reserved_job.sandbox_slot_reserved_until > now()
 			  AND reserved_job.status IN ('pending', 'running')
 			  AND (@job_id::uuid IS NULL OR reserved_job.id <> @job_id)

--- a/internal/db/sandbox_capacity_reservations.go
+++ b/internal/db/sandbox_capacity_reservations.go
@@ -2,6 +2,7 @@ package db
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -29,7 +30,7 @@ func NewSandboxCapacityReservationStore(db TxStarter) *SandboxCapacityReservatio
 func (s *SandboxCapacityReservationStore) ReserveSandboxCapacity(
 	ctx context.Context,
 	nodeID string,
-	jobID *uuid.UUID,
+	jobID, jobLockToken *uuid.UUID,
 	workloadClass models.SandboxWorkloadClass,
 	countLiveSandboxes func(context.Context) (int, error),
 	effectiveMax int,
@@ -40,6 +41,9 @@ func (s *SandboxCapacityReservationStore) ReserveSandboxCapacity(
 	}
 	if countLiveSandboxes == nil {
 		return uuid.Nil, 0, 0, false, fmt.Errorf("reserve sandbox capacity: live sandbox counter is not configured")
+	}
+	if (jobID == nil) != (jobLockToken == nil) {
+		return uuid.Nil, 0, 0, false, fmt.Errorf("reserve sandbox capacity: job id and lock token must be provided together")
 	}
 	tx, err := s.db.Begin(ctx)
 	if err != nil {
@@ -61,6 +65,39 @@ func (s *SandboxCapacityReservationStore) ReserveSandboxCapacity(
 		  AND expires_at <= now()`, pgx.NamedArgs{"node_id": nodeID}); err != nil {
 		return uuid.Nil, 0, 0, false, fmt.Errorf("delete expired sandbox capacity reservations: %w", err)
 	}
+	if jobID != nil {
+		var ownedJobID uuid.UUID
+		err := tx.QueryRow(ctx, `
+			SELECT id
+			FROM jobs
+			WHERE id = @job_id
+			  AND status = 'running'
+			  AND lock_token = @job_lock_token
+			FOR UPDATE`, pgx.NamedArgs{
+			"job_id":         jobID,
+			"job_lock_token": jobLockToken,
+		}).Scan(&ownedJobID)
+		if errors.Is(err, pgx.ErrNoRows) {
+			return uuid.Nil, 0, 0, false, fmt.Errorf("reserve sandbox capacity: job attempt no longer owns the running job")
+		}
+		if err != nil {
+			return uuid.Nil, 0, 0, false, fmt.Errorf("validate sandbox capacity job attempt: %w", err)
+		}
+		// A reclaimed attempt may be routed to a different capacity node. Remove
+		// an expired lease from the prior attempt before inserting so the unique
+		// job index does not reuse its reservation identity. A late release from
+		// the stale process must never be able to target the replacement lease.
+		if _, err := tx.Exec(ctx, `
+			DELETE FROM sandbox_capacity_reservations
+			WHERE job_id = @job_id
+			  AND expires_at <= now()
+			  AND job_lock_token IS DISTINCT FROM @job_lock_token`, pgx.NamedArgs{
+			"job_id":         jobID,
+			"job_lock_token": jobLockToken,
+		}); err != nil {
+			return uuid.Nil, 0, 0, false, fmt.Errorf("delete expired prior sandbox capacity job attempt: %w", err)
+		}
+	}
 
 	// Count only after taking the node lock. Otherwise another process could
 	// finish creating a container and release its lease between this count and
@@ -73,7 +110,7 @@ func (s *SandboxCapacityReservationStore) ReserveSandboxCapacity(
 	var reserved int
 	err = tx.QueryRow(ctx, `
 		WITH active_capacity_keys AS (
-			SELECT 'job:' || reserved_job.id::text AS capacity_key
+			SELECT 'job:' || reserved_job.id::text || ':attempt:' || COALESCE(reserved_job.lock_token::text, 'pending') AS capacity_key
 			FROM jobs reserved_job
 			JOIN nodes reserved_node ON reserved_node.id = reserved_job.target_node_id
 			WHERE COALESCE(
@@ -82,26 +119,52 @@ func (s *SandboxCapacityReservationStore) ReserveSandboxCapacity(
 				) = @node_id
 			  AND reserved_job.sandbox_slot_reserved_until > now()
 			  AND reserved_job.status IN ('pending', 'running')
-			  AND (@job_id::uuid IS NULL OR reserved_job.id <> @job_id)
+			  AND (
+				@job_id::uuid IS NULL
+				OR reserved_job.id <> @job_id
+				OR reserved_job.lock_token IS DISTINCT FROM @job_lock_token
+			  )
 			UNION
 			SELECT CASE
-					WHEN local_reservation.job_id IS NOT NULL THEN 'job:' || local_reservation.job_id::text
+					WHEN local_reservation.job_id IS NOT NULL THEN 'job:' || local_reservation.job_id::text || ':attempt:' || COALESCE(local_reservation.job_lock_token::text, 'legacy')
 					ELSE 'local:' || local_reservation.id::text
 				END AS capacity_key
 			FROM sandbox_capacity_reservations local_reservation
 			WHERE local_reservation.node_id = @node_id
 			  AND local_reservation.expires_at > now()
-			  AND (@job_id::uuid IS NULL OR local_reservation.job_id IS DISTINCT FROM @job_id)
+			  AND (
+				@job_id::uuid IS NULL
+				OR local_reservation.job_id IS DISTINCT FROM @job_id
+				OR local_reservation.job_lock_token IS DISTINCT FROM @job_lock_token
+			  )
 		)
 		SELECT COUNT(*) FROM active_capacity_keys`, pgx.NamedArgs{
-		"job_id":  jobID,
-		"node_id": nodeID,
+		"job_id":         jobID,
+		"job_lock_token": jobLockToken,
+		"node_id":        nodeID,
 	}).Scan(&reserved)
 	if err != nil {
 		return uuid.Nil, liveSandboxes, liveSandboxes, false, fmt.Errorf("count shared sandbox capacity reservations: %w", err)
 	}
 	total := liveSandboxes + reserved
-	if effectiveMax <= 0 || total >= effectiveMax {
+	var conflictingJobAttempt bool
+	if jobID != nil {
+		err = tx.QueryRow(ctx, `
+			SELECT EXISTS (
+				SELECT 1
+				FROM sandbox_capacity_reservations
+				WHERE job_id = @job_id
+				  AND expires_at > now()
+				  AND job_lock_token IS DISTINCT FROM @job_lock_token
+			)`, pgx.NamedArgs{
+			"job_id":         jobID,
+			"job_lock_token": jobLockToken,
+		}).Scan(&conflictingJobAttempt)
+		if err != nil {
+			return uuid.Nil, liveSandboxes, total, false, fmt.Errorf("inspect prior sandbox capacity job attempt: %w", err)
+		}
+	}
+	if conflictingJobAttempt || effectiveMax <= 0 || total >= effectiveMax {
 		if err := tx.Commit(ctx); err != nil {
 			return uuid.Nil, liveSandboxes, total, false, fmt.Errorf("commit rejected sandbox capacity reservation: %w", err)
 		}
@@ -109,22 +172,26 @@ func (s *SandboxCapacityReservationStore) ReserveSandboxCapacity(
 	}
 
 	var reservationID uuid.UUID
-	// A fenced job has at most one live admission attempt. The upsert makes a
-	// retry before release idempotent; callers must still release the single
-	// returned lease exactly once after sandbox creation or failure.
+	// A job has one live admission lease. The attempt token makes retries by the
+	// current owner idempotent; the conflicting-attempt check above prevents a
+	// replacement owner from taking over the stale process's row before that
+	// process releases it or its lease expires.
 	err = tx.QueryRow(ctx, `
 		INSERT INTO sandbox_capacity_reservations (
-			node_id, job_id, workload_class, expires_at
+			node_id, job_id, job_lock_token, workload_class, expires_at
 		)
-		VALUES (@node_id, @job_id, @workload_class, @expires_at)
+		VALUES (@node_id, @job_id, @job_lock_token, @workload_class, @expires_at)
 		ON CONFLICT (job_id) WHERE job_id IS NOT NULL
 		DO UPDATE SET
 			node_id = EXCLUDED.node_id,
+			job_lock_token = EXCLUDED.job_lock_token,
 			workload_class = EXCLUDED.workload_class,
 			expires_at = EXCLUDED.expires_at
+		WHERE sandbox_capacity_reservations.job_lock_token IS NOT DISTINCT FROM EXCLUDED.job_lock_token
 		RETURNING id`, pgx.NamedArgs{
 		"expires_at":     expiresAt,
 		"job_id":         jobID,
+		"job_lock_token": jobLockToken,
 		"node_id":        nodeID,
 		"workload_class": workloadClass,
 	}).Scan(&reservationID)
@@ -142,7 +209,7 @@ func (s *SandboxCapacityReservationStore) ReserveSandboxCapacity(
 // admission so a new admission cannot observe the container before it appears
 // in Docker while simultaneously missing the lease that protected its start.
 // lint:allow-no-orgid reason="reservation id is globally unique and release runs before tenant context may be available"
-func (s *SandboxCapacityReservationStore) ReleaseSandboxCapacity(ctx context.Context, nodeID string, reservationID uuid.UUID) error {
+func (s *SandboxCapacityReservationStore) ReleaseSandboxCapacity(ctx context.Context, nodeID string, reservationID uuid.UUID, jobLockToken *uuid.UUID) error {
 	if s == nil || s.db == nil || reservationID == uuid.Nil {
 		return nil
 	}
@@ -160,7 +227,12 @@ func (s *SandboxCapacityReservationStore) ReleaseSandboxCapacity(ctx context.Con
 	if _, err := tx.Exec(ctx, `
 		DELETE FROM sandbox_capacity_reservations
 		WHERE id = @reservation_id
-		  AND node_id = @node_id`, pgx.NamedArgs{
+		  AND node_id = @node_id
+		  AND (
+			(@job_lock_token::uuid IS NULL AND job_id IS NULL)
+			OR job_lock_token = @job_lock_token
+		  )`, pgx.NamedArgs{
+		"job_lock_token": jobLockToken,
 		"node_id":        nodeID,
 		"reservation_id": reservationID,
 	}); err != nil {

--- a/internal/db/sandbox_capacity_reservations.go
+++ b/internal/db/sandbox_capacity_reservations.go
@@ -17,6 +17,11 @@ type SandboxCapacityReservationStore struct {
 	db TxStarter
 }
 
+// ErrSandboxCapacityAttemptConflict means a replacement executor reached final
+// admission while the prior fenced attempt still owns a live reservation. It
+// is a coordination condition, not evidence that the physical fleet is full.
+var ErrSandboxCapacityAttemptConflict = errors.New("prior sandbox capacity job attempt still owns a live reservation")
+
 func NewSandboxCapacityReservationStore(db TxStarter) *SandboxCapacityReservationStore {
 	return &SandboxCapacityReservationStore{db: db}
 }
@@ -164,7 +169,13 @@ func (s *SandboxCapacityReservationStore) ReserveSandboxCapacity(
 			return uuid.Nil, liveSandboxes, total, false, fmt.Errorf("inspect prior sandbox capacity job attempt: %w", err)
 		}
 	}
-	if conflictingJobAttempt || effectiveMax <= 0 || total >= effectiveMax {
+	if conflictingJobAttempt {
+		if err := tx.Commit(ctx); err != nil {
+			return uuid.Nil, liveSandboxes, total, false, fmt.Errorf("commit conflicting sandbox capacity attempt: %w", err)
+		}
+		return uuid.Nil, liveSandboxes, total, false, ErrSandboxCapacityAttemptConflict
+	}
+	if effectiveMax <= 0 || total >= effectiveMax {
 		if err := tx.Commit(ctx); err != nil {
 			return uuid.Nil, liveSandboxes, total, false, fmt.Errorf("commit rejected sandbox capacity reservation: %w", err)
 		}

--- a/internal/db/sandbox_capacity_reservations.go
+++ b/internal/db/sandbox_capacity_reservations.go
@@ -22,6 +22,22 @@ type SandboxCapacityReservationStore struct {
 // is a coordination condition, not evidence that the physical fleet is full.
 var ErrSandboxCapacityAttemptConflict = errors.New("prior sandbox capacity job attempt still owns a live reservation")
 
+// SandboxCapacityAttemptConflictError reports when the stale attempt's lease
+// will stop fencing a replacement. Callers can wait directly for this durable
+// deadline instead of repeatedly launching executors or applying the shorter
+// fleet-capacity retry budget.
+type SandboxCapacityAttemptConflictError struct {
+	ExpiresAt time.Time
+}
+
+func (e *SandboxCapacityAttemptConflictError) Error() string {
+	return fmt.Sprintf("%s until %s", ErrSandboxCapacityAttemptConflict, e.ExpiresAt.UTC().Format(time.RFC3339Nano))
+}
+
+func (e *SandboxCapacityAttemptConflictError) Unwrap() error {
+	return ErrSandboxCapacityAttemptConflict
+}
+
 func NewSandboxCapacityReservationStore(db TxStarter) *SandboxCapacityReservationStore {
 	return &SandboxCapacityReservationStore{db: db}
 }
@@ -152,28 +168,31 @@ func (s *SandboxCapacityReservationStore) ReserveSandboxCapacity(
 		return uuid.Nil, liveSandboxes, liveSandboxes, false, fmt.Errorf("count shared sandbox capacity reservations: %w", err)
 	}
 	total := liveSandboxes + reserved
-	var conflictingJobAttempt bool
+	var conflictingJobAttemptExpiresAt time.Time
 	if jobID != nil {
 		err = tx.QueryRow(ctx, `
-			SELECT EXISTS (
-				SELECT 1
-				FROM sandbox_capacity_reservations
-				WHERE job_id = @job_id
-				  AND expires_at > now()
-				  AND job_lock_token IS DISTINCT FROM @job_lock_token
-			)`, pgx.NamedArgs{
+			SELECT expires_at
+			FROM sandbox_capacity_reservations
+			WHERE job_id = @job_id
+			  AND expires_at > now()
+			  AND job_lock_token IS DISTINCT FROM @job_lock_token
+			ORDER BY expires_at DESC
+			LIMIT 1`, pgx.NamedArgs{
 			"job_id":         jobID,
 			"job_lock_token": jobLockToken,
-		}).Scan(&conflictingJobAttempt)
+		}).Scan(&conflictingJobAttemptExpiresAt)
+		if errors.Is(err, pgx.ErrNoRows) {
+			err = nil
+		}
 		if err != nil {
 			return uuid.Nil, liveSandboxes, total, false, fmt.Errorf("inspect prior sandbox capacity job attempt: %w", err)
 		}
 	}
-	if conflictingJobAttempt {
+	if !conflictingJobAttemptExpiresAt.IsZero() {
 		if err := tx.Commit(ctx); err != nil {
 			return uuid.Nil, liveSandboxes, total, false, fmt.Errorf("commit conflicting sandbox capacity attempt: %w", err)
 		}
-		return uuid.Nil, liveSandboxes, total, false, ErrSandboxCapacityAttemptConflict
+		return uuid.Nil, liveSandboxes, total, false, &SandboxCapacityAttemptConflictError{ExpiresAt: conflictingJobAttemptExpiresAt}
 	}
 	if effectiveMax <= 0 || total >= effectiveMax {
 		if err := tx.Commit(ctx); err != nil {

--- a/internal/db/sandbox_capacity_reservations.go
+++ b/internal/db/sandbox_capacity_reservations.go
@@ -105,6 +105,9 @@ func (s *SandboxCapacityReservationStore) ReserveSandboxCapacity(
 	}
 
 	var reservationID uuid.UUID
+	// A fenced job has at most one live admission attempt. The upsert makes a
+	// retry before release idempotent; callers must still release the single
+	// returned lease exactly once after sandbox creation or failure.
 	err = tx.QueryRow(ctx, `
 		INSERT INTO sandbox_capacity_reservations (
 			node_id, job_id, workload_class, expires_at

--- a/internal/db/sandbox_capacity_reservations_test.go
+++ b/internal/db/sandbox_capacity_reservations_test.go
@@ -25,10 +25,11 @@ func TestSandboxCapacityReservationStore_ReserveSandboxCapacity(t *testing.T) {
 		expectInsert     bool
 		expectedTotal    int
 		expectedAcquired bool
+		expectConflict   bool
 	}{
 		{name: "reserves below shared capacity", reserved: 1, effectiveMax: 3, expectInsert: true, expectedTotal: 3, expectedAcquired: true},
 		{name: "rejects at shared capacity", reserved: 2, effectiveMax: 3, expectedTotal: 3},
-		{name: "waits for prior job attempt lease", reserved: 1, effectiveMax: 3, conflicting: true, expectedTotal: 2},
+		{name: "reports prior job attempt lease as coordination", reserved: 1, effectiveMax: 3, conflicting: true, expectedTotal: 2, expectConflict: true},
 	}
 
 	for _, tt := range tests {
@@ -74,7 +75,11 @@ func TestSandboxCapacityReservationStore_ReserveSandboxCapacity(t *testing.T) {
 				func(context.Context) (int, error) { return 1, nil }, tt.effectiveMax, expiresAt,
 			)
 
-			require.NoError(t, err, "shared capacity reservation should complete")
+			if tt.expectConflict {
+				require.ErrorIs(t, err, ErrSandboxCapacityAttemptConflict, "replacement attempt should report stale-attempt coordination separately from fleet saturation")
+			} else {
+				require.NoError(t, err, "shared capacity reservation should complete")
+			}
 			require.Equal(t, 1, live, "shared capacity reservation should report the live Docker count")
 			require.Equal(t, tt.expectedTotal, total, "shared capacity reservation should report the combined live and reserved load")
 			require.Equal(t, tt.expectedAcquired, acquired, "shared capacity reservation should enforce the effective worker limit")

--- a/internal/db/sandbox_capacity_reservations_test.go
+++ b/internal/db/sandbox_capacity_reservations_test.go
@@ -143,12 +143,18 @@ func TestSandboxCapacityReservationStore_ReleaseSandboxCapacity(t *testing.T) {
 	defer mock.Close()
 
 	reservationID := uuid.New()
-	mock.ExpectExec(`(?s)DELETE FROM sandbox_capacity_reservations.*WHERE id = \$1`).
-		WithArgs(reservationID).
+	mock.ExpectBegin()
+	mock.ExpectExec(`SELECT pg_advisory_xact_lock`).
+		WithArgs("worker-1").
+		WillReturnResult(pgxmock.NewResult("SELECT", 1))
+	mock.ExpectExec(`(?s)DELETE FROM sandbox_capacity_reservations.*WHERE id = @reservation_id.*AND node_id = @node_id`).
+		WithArgs(reservationID, "worker-1").
 		WillReturnResult(pgxmock.NewResult("DELETE", 1))
+	mock.ExpectCommit()
+	mock.ExpectRollback()
 
-	err = NewSandboxCapacityReservationStore(mock).ReleaseSandboxCapacity(context.Background(), reservationID)
+	err = NewSandboxCapacityReservationStore(mock).ReleaseSandboxCapacity(context.Background(), "worker-1", reservationID)
 
 	require.NoError(t, err, "shared capacity release should delete the reservation")
-	require.NoError(t, mock.ExpectationsWereMet(), "shared capacity release should target the exact reservation")
+	require.NoError(t, mock.ExpectationsWereMet(), "shared capacity release should hold the worker admission lock and target the exact reservation")
 }

--- a/internal/db/sandbox_capacity_reservations_test.go
+++ b/internal/db/sandbox_capacity_reservations_test.go
@@ -1,0 +1,154 @@
+package db
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/pashagolub/pgxmock/v4"
+	"github.com/stretchr/testify/require"
+
+	"github.com/assembledhq/143/internal/models"
+)
+
+func TestSandboxCapacityReservationStore_ReserveSandboxCapacity(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name             string
+		reserved         int
+		effectiveMax     int
+		expectInsert     bool
+		expectedTotal    int
+		expectedAcquired bool
+	}{
+		{name: "reserves below shared capacity", reserved: 1, effectiveMax: 3, expectInsert: true, expectedTotal: 3, expectedAcquired: true},
+		{name: "rejects at shared capacity", reserved: 2, effectiveMax: 3, expectedTotal: 3},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			mock, err := pgxmock.NewPool()
+			require.NoError(t, err, "should create mock pool")
+			defer mock.Close()
+
+			jobID, reservationID := uuid.New(), uuid.New()
+			expiresAt := time.Now().Add(time.Minute)
+			mock.ExpectBegin()
+			mock.ExpectExec(`SELECT pg_advisory_xact_lock`).
+				WithArgs("worker-1").
+				WillReturnResult(pgxmock.NewResult("SELECT", 1))
+			mock.ExpectExec(`(?s)DELETE FROM sandbox_capacity_reservations.*node_id = @node_id`).
+				WithArgs("worker-1").
+				WillReturnResult(pgxmock.NewResult("DELETE", 0))
+			mock.ExpectQuery(`(?s)WITH active_capacity_keys AS.*FROM jobs reserved_job.*UNION.*FROM sandbox_capacity_reservations.*SELECT COUNT`).
+				WithArgs("worker-1", &jobID).
+				WillReturnRows(pgxmock.NewRows([]string{"count"}).AddRow(tt.reserved))
+			if tt.expectInsert {
+				mock.ExpectQuery(`(?s)INSERT INTO sandbox_capacity_reservations.*ON CONFLICT \(job_id\).*RETURNING id`).
+					WithArgs("worker-1", &jobID, models.SandboxWorkloadClassInteractive, expiresAt).
+					WillReturnRows(pgxmock.NewRows([]string{"id"}).AddRow(reservationID))
+			}
+			mock.ExpectCommit()
+			mock.ExpectRollback()
+
+			store := NewSandboxCapacityReservationStore(mock)
+			actualID, live, total, acquired, err := store.ReserveSandboxCapacity(
+				context.Background(), "worker-1", &jobID, models.SandboxWorkloadClassInteractive,
+				func(context.Context) (int, error) { return 1, nil }, tt.effectiveMax, expiresAt,
+			)
+
+			require.NoError(t, err, "shared capacity reservation should complete")
+			require.Equal(t, 1, live, "shared capacity reservation should report the live Docker count")
+			require.Equal(t, tt.expectedTotal, total, "shared capacity reservation should report the combined live and reserved load")
+			require.Equal(t, tt.expectedAcquired, acquired, "shared capacity reservation should enforce the effective worker limit")
+			if tt.expectInsert {
+				require.Equal(t, reservationID, actualID, "successful admission should return the persisted reservation id")
+			} else {
+				require.Equal(t, uuid.Nil, actualID, "rejected admission should not return a reservation id")
+			}
+			require.NoError(t, mock.ExpectationsWereMet(), "shared admission should lock, count, and reserve in one transaction")
+		})
+	}
+}
+
+func TestSandboxCapacityReservationStore_ReserveSandboxCapacityFailsClosed(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "should create mock pool")
+	defer mock.Close()
+
+	mock.ExpectBegin()
+	mock.ExpectExec(`SELECT pg_advisory_xact_lock`).
+		WithArgs("worker-1").
+		WillReturnError(errors.New("lock unavailable"))
+	mock.ExpectRollback()
+
+	reservationID, _, _, acquired, err := NewSandboxCapacityReservationStore(mock).ReserveSandboxCapacity(
+		context.Background(), "worker-1", nil, models.SandboxWorkloadClassInteractive,
+		func(context.Context) (int, error) { return 0, nil }, 2, time.Now().Add(time.Minute),
+	)
+
+	require.ErrorContains(t, err, "lock unavailable", "shared capacity admission should surface coordination failures")
+	require.False(t, acquired, "failed shared capacity admission should fail closed")
+	require.Equal(t, uuid.Nil, reservationID, "failed shared capacity admission should not return a reservation")
+	require.NoError(t, mock.ExpectationsWereMet(), "failed admission should roll back its transaction")
+}
+
+func TestSandboxCapacityReservationStore_CountsLiveSandboxesInsideTransaction(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "should create mock pool")
+	defer mock.Close()
+
+	countErr := errors.New("docker unavailable")
+	mock.ExpectBegin()
+	mock.ExpectExec(`SELECT pg_advisory_xact_lock`).
+		WithArgs("worker-1").
+		WillReturnResult(pgxmock.NewResult("SELECT", 1))
+	mock.ExpectExec(`(?s)DELETE FROM sandbox_capacity_reservations.*node_id = @node_id`).
+		WithArgs("worker-1").
+		WillReturnResult(pgxmock.NewResult("DELETE", 0))
+	mock.ExpectRollback()
+
+	reservationID, live, total, acquired, err := NewSandboxCapacityReservationStore(mock).ReserveSandboxCapacity(
+		context.Background(),
+		"worker-1",
+		nil,
+		models.SandboxWorkloadClassInteractive,
+		func(context.Context) (int, error) { return 0, countErr },
+		2,
+		time.Now().Add(time.Minute),
+	)
+
+	require.ErrorIs(t, err, countErr, "shared admission should propagate the authoritative Docker count failure")
+	require.Equal(t, uuid.Nil, reservationID, "failed live counting should not insert a shared reservation")
+	require.Equal(t, 0, live, "failed live counting should not report a partial Docker count")
+	require.Equal(t, 0, total, "failed live counting should not report a misleading combined load")
+	require.False(t, acquired, "failed live counting should fail admission closed")
+	require.NoError(t, mock.ExpectationsWereMet(), "live counting should occur only after the transaction and node lock are acquired")
+}
+
+func TestSandboxCapacityReservationStore_ReleaseSandboxCapacity(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "should create mock pool")
+	defer mock.Close()
+
+	reservationID := uuid.New()
+	mock.ExpectExec(`(?s)DELETE FROM sandbox_capacity_reservations.*WHERE id = \$1`).
+		WithArgs(reservationID).
+		WillReturnResult(pgxmock.NewResult("DELETE", 1))
+
+	err = NewSandboxCapacityReservationStore(mock).ReleaseSandboxCapacity(context.Background(), reservationID)
+
+	require.NoError(t, err, "shared capacity release should delete the reservation")
+	require.NoError(t, mock.ExpectationsWereMet(), "shared capacity release should target the exact reservation")
+}

--- a/internal/db/sandbox_capacity_reservations_test.go
+++ b/internal/db/sandbox_capacity_reservations_test.go
@@ -42,6 +42,7 @@ func TestSandboxCapacityReservationStore_ReserveSandboxCapacity(t *testing.T) {
 
 			jobID, lockToken, reservationID := uuid.New(), uuid.New(), uuid.New()
 			expiresAt := time.Now().Add(time.Minute)
+			conflictingExpiresAt := time.Now().Add(30 * time.Second)
 			mock.ExpectBegin()
 			mock.ExpectExec(`SELECT pg_advisory_xact_lock`).
 				WithArgs("worker-1").
@@ -58,9 +59,13 @@ func TestSandboxCapacityReservationStore_ReserveSandboxCapacity(t *testing.T) {
 			mock.ExpectQuery(`(?s)WITH active_capacity_keys AS.*FROM jobs reserved_job.*UNION.*FROM sandbox_capacity_reservations.*SELECT COUNT`).
 				WithArgs("worker-1", &jobID, &lockToken).
 				WillReturnRows(pgxmock.NewRows([]string{"count"}).AddRow(tt.reserved))
-			mock.ExpectQuery(`(?s)SELECT EXISTS.*FROM sandbox_capacity_reservations.*job_id = @job_id.*job_lock_token IS DISTINCT FROM @job_lock_token`).
+			conflictRows := pgxmock.NewRows([]string{"expires_at"})
+			if tt.conflicting {
+				conflictRows.AddRow(conflictingExpiresAt)
+			}
+			mock.ExpectQuery(`(?s)SELECT expires_at.*FROM sandbox_capacity_reservations.*job_id = @job_id.*job_lock_token IS DISTINCT FROM @job_lock_token.*ORDER BY expires_at DESC.*LIMIT 1`).
 				WithArgs(&jobID, &lockToken).
-				WillReturnRows(pgxmock.NewRows([]string{"exists"}).AddRow(tt.conflicting))
+				WillReturnRows(conflictRows)
 			if tt.expectInsert {
 				mock.ExpectQuery(`(?s)INSERT INTO sandbox_capacity_reservations.*job_lock_token.*ON CONFLICT \(job_id\).*job_lock_token = EXCLUDED.job_lock_token.*WHERE sandbox_capacity_reservations.job_lock_token IS NOT DISTINCT FROM EXCLUDED.job_lock_token.*RETURNING id`).
 					WithArgs("worker-1", &jobID, &lockToken, models.SandboxWorkloadClassInteractive, expiresAt).
@@ -77,6 +82,9 @@ func TestSandboxCapacityReservationStore_ReserveSandboxCapacity(t *testing.T) {
 
 			if tt.expectConflict {
 				require.ErrorIs(t, err, ErrSandboxCapacityAttemptConflict, "replacement attempt should report stale-attempt coordination separately from fleet saturation")
+				var conflictErr *SandboxCapacityAttemptConflictError
+				require.ErrorAs(t, err, &conflictErr, "replacement attempt should expose the stale lease deadline")
+				require.Equal(t, conflictingExpiresAt, conflictErr.ExpiresAt, "replacement attempt should wait for the persisted stale lease expiry")
 			} else {
 				require.NoError(t, err, "shared capacity reservation should complete")
 			}

--- a/internal/db/sandbox_capacity_reservations_test.go
+++ b/internal/db/sandbox_capacity_reservations_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
 	"github.com/pashagolub/pgxmock/v4"
 	"github.com/stretchr/testify/require"
 
@@ -20,12 +21,14 @@ func TestSandboxCapacityReservationStore_ReserveSandboxCapacity(t *testing.T) {
 		name             string
 		reserved         int
 		effectiveMax     int
+		conflicting      bool
 		expectInsert     bool
 		expectedTotal    int
 		expectedAcquired bool
 	}{
 		{name: "reserves below shared capacity", reserved: 1, effectiveMax: 3, expectInsert: true, expectedTotal: 3, expectedAcquired: true},
 		{name: "rejects at shared capacity", reserved: 2, effectiveMax: 3, expectedTotal: 3},
+		{name: "waits for prior job attempt lease", reserved: 1, effectiveMax: 3, conflicting: true, expectedTotal: 2},
 	}
 
 	for _, tt := range tests {
@@ -36,7 +39,7 @@ func TestSandboxCapacityReservationStore_ReserveSandboxCapacity(t *testing.T) {
 			require.NoError(t, err, "should create mock pool")
 			defer mock.Close()
 
-			jobID, reservationID := uuid.New(), uuid.New()
+			jobID, lockToken, reservationID := uuid.New(), uuid.New(), uuid.New()
 			expiresAt := time.Now().Add(time.Minute)
 			mock.ExpectBegin()
 			mock.ExpectExec(`SELECT pg_advisory_xact_lock`).
@@ -45,12 +48,21 @@ func TestSandboxCapacityReservationStore_ReserveSandboxCapacity(t *testing.T) {
 			mock.ExpectExec(`(?s)DELETE FROM sandbox_capacity_reservations.*node_id = @node_id`).
 				WithArgs("worker-1").
 				WillReturnResult(pgxmock.NewResult("DELETE", 0))
+			mock.ExpectQuery(`(?s)SELECT id.*FROM jobs.*status = 'running'.*lock_token = @job_lock_token.*FOR UPDATE`).
+				WithArgs(&jobID, &lockToken).
+				WillReturnRows(pgxmock.NewRows([]string{"id"}).AddRow(jobID))
+			mock.ExpectExec(`(?s)DELETE FROM sandbox_capacity_reservations.*job_id = @job_id.*expires_at <= now\(\).*job_lock_token IS DISTINCT FROM @job_lock_token`).
+				WithArgs(&jobID, &lockToken).
+				WillReturnResult(pgxmock.NewResult("DELETE", 0))
 			mock.ExpectQuery(`(?s)WITH active_capacity_keys AS.*FROM jobs reserved_job.*UNION.*FROM sandbox_capacity_reservations.*SELECT COUNT`).
-				WithArgs("worker-1", &jobID).
+				WithArgs("worker-1", &jobID, &lockToken).
 				WillReturnRows(pgxmock.NewRows([]string{"count"}).AddRow(tt.reserved))
+			mock.ExpectQuery(`(?s)SELECT EXISTS.*FROM sandbox_capacity_reservations.*job_id = @job_id.*job_lock_token IS DISTINCT FROM @job_lock_token`).
+				WithArgs(&jobID, &lockToken).
+				WillReturnRows(pgxmock.NewRows([]string{"exists"}).AddRow(tt.conflicting))
 			if tt.expectInsert {
-				mock.ExpectQuery(`(?s)INSERT INTO sandbox_capacity_reservations.*ON CONFLICT \(job_id\).*RETURNING id`).
-					WithArgs("worker-1", &jobID, models.SandboxWorkloadClassInteractive, expiresAt).
+				mock.ExpectQuery(`(?s)INSERT INTO sandbox_capacity_reservations.*job_lock_token.*ON CONFLICT \(job_id\).*job_lock_token = EXCLUDED.job_lock_token.*WHERE sandbox_capacity_reservations.job_lock_token IS NOT DISTINCT FROM EXCLUDED.job_lock_token.*RETURNING id`).
+					WithArgs("worker-1", &jobID, &lockToken, models.SandboxWorkloadClassInteractive, expiresAt).
 					WillReturnRows(pgxmock.NewRows([]string{"id"}).AddRow(reservationID))
 			}
 			mock.ExpectCommit()
@@ -58,7 +70,7 @@ func TestSandboxCapacityReservationStore_ReserveSandboxCapacity(t *testing.T) {
 
 			store := NewSandboxCapacityReservationStore(mock)
 			actualID, live, total, acquired, err := store.ReserveSandboxCapacity(
-				context.Background(), "worker-1", &jobID, models.SandboxWorkloadClassInteractive,
+				context.Background(), "worker-1", &jobID, &lockToken, models.SandboxWorkloadClassInteractive,
 				func(context.Context) (int, error) { return 1, nil }, tt.effectiveMax, expiresAt,
 			)
 
@@ -90,7 +102,7 @@ func TestSandboxCapacityReservationStore_ReserveSandboxCapacityFailsClosed(t *te
 	mock.ExpectRollback()
 
 	reservationID, _, _, acquired, err := NewSandboxCapacityReservationStore(mock).ReserveSandboxCapacity(
-		context.Background(), "worker-1", nil, models.SandboxWorkloadClassInteractive,
+		context.Background(), "worker-1", nil, nil, models.SandboxWorkloadClassInteractive,
 		func(context.Context) (int, error) { return 0, nil }, 2, time.Now().Add(time.Minute),
 	)
 
@@ -98,6 +110,37 @@ func TestSandboxCapacityReservationStore_ReserveSandboxCapacityFailsClosed(t *te
 	require.False(t, acquired, "failed shared capacity admission should fail closed")
 	require.Equal(t, uuid.Nil, reservationID, "failed shared capacity admission should not return a reservation")
 	require.NoError(t, mock.ExpectationsWereMet(), "failed admission should roll back its transaction")
+}
+
+func TestSandboxCapacityReservationStore_ReserveSandboxCapacityRejectsStaleJobAttempt(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "should create mock pool")
+	defer mock.Close()
+
+	jobID, staleLockToken := uuid.New(), uuid.New()
+	mock.ExpectBegin()
+	mock.ExpectExec(`SELECT pg_advisory_xact_lock`).
+		WithArgs("worker-1").
+		WillReturnResult(pgxmock.NewResult("SELECT", 1))
+	mock.ExpectExec(`(?s)DELETE FROM sandbox_capacity_reservations.*node_id = @node_id`).
+		WithArgs("worker-1").
+		WillReturnResult(pgxmock.NewResult("DELETE", 0))
+	mock.ExpectQuery(`(?s)SELECT id.*FROM jobs.*status = 'running'.*lock_token = @job_lock_token.*FOR UPDATE`).
+		WithArgs(&jobID, &staleLockToken).
+		WillReturnError(pgx.ErrNoRows)
+	mock.ExpectRollback()
+
+	reservationID, _, _, acquired, err := NewSandboxCapacityReservationStore(mock).ReserveSandboxCapacity(
+		context.Background(), "worker-1", &jobID, &staleLockToken, models.SandboxWorkloadClassInteractive,
+		func(context.Context) (int, error) { return 0, nil }, 2, time.Now().Add(time.Minute),
+	)
+
+	require.ErrorContains(t, err, "job attempt no longer owns", "stale queue attempts must fail final admission")
+	require.False(t, acquired, "stale queue attempts must not acquire shared capacity")
+	require.Equal(t, uuid.Nil, reservationID, "stale queue attempts must not receive a reservation")
+	require.NoError(t, mock.ExpectationsWereMet(), "stale attempt admission should stop before counting or inserting capacity")
 }
 
 func TestSandboxCapacityReservationStore_CountsLiveSandboxesInsideTransaction(t *testing.T) {
@@ -120,6 +163,7 @@ func TestSandboxCapacityReservationStore_CountsLiveSandboxesInsideTransaction(t 
 	reservationID, live, total, acquired, err := NewSandboxCapacityReservationStore(mock).ReserveSandboxCapacity(
 		context.Background(),
 		"worker-1",
+		nil,
 		nil,
 		models.SandboxWorkloadClassInteractive,
 		func(context.Context) (int, error) { return 0, countErr },
@@ -147,13 +191,14 @@ func TestSandboxCapacityReservationStore_ReleaseSandboxCapacity(t *testing.T) {
 	mock.ExpectExec(`SELECT pg_advisory_xact_lock`).
 		WithArgs("worker-1").
 		WillReturnResult(pgxmock.NewResult("SELECT", 1))
-	mock.ExpectExec(`(?s)DELETE FROM sandbox_capacity_reservations.*WHERE id = @reservation_id.*AND node_id = @node_id`).
-		WithArgs(reservationID, "worker-1").
+	lockToken := uuid.New()
+	mock.ExpectExec(`(?s)DELETE FROM sandbox_capacity_reservations.*WHERE id = @reservation_id.*AND node_id = @node_id.*job_lock_token = @job_lock_token`).
+		WithArgs(reservationID, "worker-1", &lockToken).
 		WillReturnResult(pgxmock.NewResult("DELETE", 1))
 	mock.ExpectCommit()
 	mock.ExpectRollback()
 
-	err = NewSandboxCapacityReservationStore(mock).ReleaseSandboxCapacity(context.Background(), "worker-1", reservationID)
+	err = NewSandboxCapacityReservationStore(mock).ReleaseSandboxCapacity(context.Background(), "worker-1", reservationID, &lockToken)
 
 	require.NoError(t, err, "shared capacity release should delete the reservation")
 	require.NoError(t, mock.ExpectationsWereMet(), "shared capacity release should hold the worker admission lock and target the exact reservation")

--- a/internal/db/session_store.go
+++ b/internal/db/session_store.go
@@ -1333,6 +1333,36 @@ func (s *SessionStore) CancelPendingCapacityWait(ctx context.Context, orgID, ses
 		return false, nil, nil
 	}
 
+	// Fence the session lifecycle before consuming the durable request. A
+	// concurrent completion may win while this cleanup waits for job/org locks;
+	// terminal state is authoritative and must never be overwritten by a late
+	// capacity-wait cancellation.
+	rows, err := tx.Query(ctx, `
+		UPDATE sessions
+		SET status = @status,
+			completed_at = now(),
+			last_activity_at = now()
+		WHERE id = @session_id
+		  AND org_id = @org_id
+		  AND deleted_at IS NULL
+		  AND status IN ('pending', 'running', 'idle', 'awaiting_input', 'needs_human_guidance')
+		RETURNING `+sessionSelectColumns, pgx.NamedArgs{
+		"org_id":     orgID,
+		"session_id": sessionID,
+		"status":     string(models.SessionStatusCancelled),
+	})
+	if err != nil {
+		return false, nil, fmt.Errorf("cancel active session while waiting for capacity: %w", err)
+	}
+	session, err := pgx.CollectOneRow(rows, pgx.RowToStructByName[models.Session])
+	if errors.Is(err, pgx.ErrNoRows) {
+		return false, nil, nil
+	}
+	if err != nil {
+		return false, nil, fmt.Errorf("collect capacity-wait cancelled session: %w", err)
+	}
+	hydrateSessionPolicy(&session)
+
 	consumeResult, err := tx.Exec(ctx, `
 		UPDATE session_cancel_requests
 		SET delivered_at = now()
@@ -1347,11 +1377,6 @@ func (s *SessionStore) CancelPendingCapacityWait(ctx context.Context, orgID, ses
 	}
 	if consumeResult.RowsAffected() == 0 {
 		return false, nil, nil
-	}
-
-	session, err := s.updateStatusRow(ctx, tx, orgID, sessionID, models.SessionStatusCancelled)
-	if err != nil {
-		return false, nil, fmt.Errorf("cancel session while waiting for capacity: %w", err)
 	}
 
 	if len(queuedSiblingJobIDs) > 0 {

--- a/internal/db/session_store_test.go
+++ b/internal/db/session_store_test.go
@@ -144,12 +144,14 @@ func TestSessionStore_CancelPendingCapacityWait(t *testing.T) {
 		liveSibling        bool
 		queuedSiblingCount int
 		activeThreadCount  int
+		terminalSession    bool
 		expectedCancelled  bool
 	}{
 		{name: "no pending cancellation"},
 		{name: "cancels session without thread", pendingCancel: true, expectedCancelled: true},
 		{name: "atomically cancels queued siblings and all active threads", pendingCancel: true, queuedSiblingCount: 3, activeThreadCount: 2, expectedCancelled: true},
 		{name: "preserves cancellation for live sibling turn", pendingCancel: true, liveSibling: true},
+		{name: "preserves a concurrently completed session", pendingCancel: true, terminalSession: true},
 	}
 
 	for _, tt := range tests {
@@ -196,6 +198,26 @@ func TestSessionStore_CancelPendingCapacityWait(t *testing.T) {
 				require.NoError(t, mock.ExpectationsWereMet(), "live sibling should leave cancellation delivery untouched")
 				return
 			}
+			if tt.terminalSession {
+				mock.ExpectQuery(`(?s)UPDATE sessions.*status = @status.*status IN \('pending', 'running', 'idle', 'awaiting_input', 'needs_human_guidance'\).*RETURNING`).
+					WithArgs(string(models.SessionStatusCancelled), sessionID, orgID).
+					WillReturnRows(pgxmock.NewRows(sessionTestColumns))
+				mock.ExpectRollback()
+				cancelled, actualThreadIDs, err := NewSessionStore(mock).CancelPendingCapacityWait(context.Background(), orgID, sessionID, currentJobID)
+				require.NoError(t, err, "terminal session check should complete")
+				require.False(t, cancelled, "late cleanup must preserve terminal session state")
+				require.Empty(t, actualThreadIDs, "late cleanup must not finalize threads after session completion")
+				require.NoError(t, mock.ExpectationsWereMet(), "terminal session should preserve the cancellation request")
+				return
+			}
+
+			now := time.Now()
+			sessionRow := newAgentSessionRow(sessionID, issueID, orgID, now)
+			setSessionTestColumnValue(sessionRow, "status", string(models.SessionStatusCancelled))
+			mock.ExpectQuery(`(?s)UPDATE sessions.*status = @status.*status IN \('pending', 'running', 'idle', 'awaiting_input', 'needs_human_guidance'\).*RETURNING`).
+				WithArgs(string(models.SessionStatusCancelled), sessionID, orgID).
+				WillReturnRows(pgxmock.NewRows(sessionTestColumns).AddRow(sessionRow...))
+
 			consumeResult := int64(0)
 			if tt.pendingCancel {
 				consumeResult = 1
@@ -204,12 +226,6 @@ func TestSessionStore_CancelPendingCapacityWait(t *testing.T) {
 				WithArgs(orgID, sessionID).
 				WillReturnResult(pgxmock.NewResult("UPDATE", consumeResult))
 			if tt.pendingCancel {
-				now := time.Now()
-				sessionRow := newAgentSessionRow(sessionID, issueID, orgID, now)
-				setSessionTestColumnValue(sessionRow, "status", string(models.SessionStatusCancelled))
-				mock.ExpectQuery(`(?s)UPDATE sessions SET status = @status, completed_at = now\(\).*id = @id AND org_id = @org_id.*RETURNING`).
-					WithArgs(string(models.SessionStatusCancelled), sessionID, orgID).
-					WillReturnRows(pgxmock.NewRows(sessionTestColumns).AddRow(sessionRow...))
 				if len(queuedSiblingJobIDs) > 0 {
 					mock.ExpectExec(`(?s)UPDATE jobs.*status = 'cancelled'.*id = ANY\(@sibling_job_ids\).*job_type = 'continue_session'.*status = 'pending'.*payload->>'session_id' = @session_id`).
 						WithArgs(orgID, queuedSiblingJobIDs, sessionID.String()).

--- a/internal/integration/testdb.go
+++ b/internal/integration/testdb.go
@@ -126,6 +126,7 @@ func resolveMigrationSource() (string, error) {
 // schema_migrations is intentionally excluded — re-running migrations between
 // tests would dominate the wall-clock budget.
 var truncatedTables = []string{
+	"sandbox_capacity_reservations",
 	"nodes",
 	"jobs",
 	"session_messages",

--- a/internal/integration/worker_dispatch_test.go
+++ b/internal/integration/worker_dispatch_test.go
@@ -101,6 +101,71 @@ func TestIntegration_SharedSandboxAdmissionDeduplicatesCurrentRoutingReservation
 	require.Equal(t, 0, remainingReservations, "shared capacity release should delete its lease after the admission lock is available")
 }
 
+// TestIntegration_BlueGreenGenerationsSharePhysicalHostCapacity verifies that
+// generation-specific routing IDs cannot make one Docker daemon look like two
+// independent capacity pools during a rolling deploy.
+//
+// This test cannot run in parallel because the integration suite shares one
+// database and setup truncates queue state between tests.
+func TestIntegration_BlueGreenGenerationsSharePhysicalHostCapacity(t *testing.T) {
+	pool := setup(t)
+	ctx := context.Background()
+	orgID := seedOrg(t, pool)
+	capacityNodeID := "physical-worker-" + orgID.String()[:8]
+	nodeIDs := []string{
+		capacityNodeID + "-g20260813000101-blue",
+		capacityNodeID + "-g20260813000202-green",
+	}
+	for i, nodeID := range nodeIDs {
+		seedWorkerNode(t, pool, nodeID)
+		setWorkerSandboxCapacity(t, pool, nodeID, 1)
+		if i > 0 {
+			_, err := pool.Exec(ctx, `
+				UPDATE nodes
+				SET metadata = metadata || jsonb_build_object('sandbox_capacity_node_id', $2::text)
+				WHERE id = $1`, nodeID, capacityNodeID)
+			require.NoError(t, err, "new worker generation should advertise the shared physical-host capacity identity")
+		}
+	}
+
+	store := db.NewJobStore(pool)
+	for range 2 {
+		session := seedSession(t, pool, orgID, sessionOpts{Status: models.SessionStatusPending})
+		_, err := store.EnqueueWithOpts(ctx, orgID, db.EnqueueOpts{
+			Queue:         "agent",
+			JobType:       "run_agent",
+			Payload:       map[string]string{"session_id": session.ID.String(), "org_id": orgID.String()},
+			Priority:      5,
+			WorkloadClass: models.SandboxWorkloadClassInteractive,
+		})
+		require.NoError(t, err, "test sandbox job should enqueue")
+	}
+
+	first, err := store.RouteNextSandboxJob(ctx)
+	require.NoError(t, err, "first generation should reserve the physical host slot")
+	require.NotNil(t, first, "first route should return a capacity decision")
+	require.NotNil(t, first.TargetNodeID, "first route should select one worker generation")
+	_, _, finalLoad, admitted, err := db.NewSandboxCapacityReservationStore(pool).ReserveSandboxCapacity(
+		ctx,
+		capacityNodeID,
+		nil,
+		models.SandboxWorkloadClassInteractive,
+		func(context.Context) (int, error) { return 0, nil },
+		1,
+		time.Now().Add(time.Minute),
+	)
+	require.NoError(t, err, "final admission should resolve generation job ownership to the physical host")
+	require.False(t, admitted, "final admission should not bypass the routed generation's durable reservation")
+	require.Equal(t, 1, finalLoad, "final admission should count the durable reservation across worker generations")
+
+	second, err := store.RouteNextSandboxJob(ctx)
+	require.NoError(t, err, "second generation should share the physical host admission fence")
+	require.NotNil(t, second, "second route should return a capacity decision")
+	require.Nil(t, second.TargetNodeID, "second generation must not expose another slot on the same Docker host")
+	require.True(t, second.Deferred, "second job should defer when the shared physical host is full")
+	require.Equal(t, db.SandboxRoutingReasonFleetCapacity, second.Reason, "shared-host saturation should retain the fleet-capacity reason")
+}
+
 // TestIntegration_CodeReviewJobsUseFleetCapacityAndPreserveInteractiveReserve
 // uses the real queue and Postgres locking path to exercise a mixed-version
 // code-review burst. It intentionally enqueues review jobs with the legacy

--- a/internal/integration/worker_dispatch_test.go
+++ b/internal/integration/worker_dispatch_test.go
@@ -175,7 +175,7 @@ func TestIntegration_SharedSandboxAdmissionFencesReclaimedJobAttempt(t *testing.
 		ctx, replacementNodeID, &jobID, &secondLockToken, models.SandboxWorkloadClassInteractive,
 		func(context.Context) (int, error) { return 0, nil }, 3, time.Now().Add(time.Minute),
 	)
-	require.NoError(t, err, "replacement attempt should receive a serialized capacity decision")
+	require.ErrorIs(t, err, db.ErrSandboxCapacityAttemptConflict, "replacement attempt should distinguish stale-attempt coordination from physical capacity saturation")
 	require.False(t, replacementAcquired, "replacement attempt must wait for the stale attempt's live reservation on another worker")
 	require.Equal(t, 0, blockedTotal, "another worker's lease is a fencing conflict rather than local capacity load")
 
@@ -207,19 +207,31 @@ func TestIntegration_SharedSandboxAdmissionFencesReclaimedJobAttempt(t *testing.
 	require.NoError(t, capacityStore.ReleaseSandboxCapacity(ctx, replacementNodeID, secondReservationID, &secondLockToken), "replacement attempt should release its own reservation")
 }
 
-// TestIntegration_FailedFreshSandboxClearsTargetWithoutDurableSlot verifies
-// the failure cleanup used by compatibility and terminal-probe placements.
-// Those jobs intentionally have a target without sandbox_slot_reserved_until,
-// but a node-local create failure must still make the retry fleet-routable.
+// TestIntegration_FailedFreshSandboxReroutesOffPhysicalHost verifies the
+// failure cleanup used by compatibility and terminal-probe placements. Those
+// jobs intentionally have a target without sandbox_slot_reserved_until, but a
+// node-local create failure must reserve an alternate while excluding every
+// blue/green generation that shares the failed Docker host.
 //
 // This test cannot run in parallel because the integration suite shares one
 // database and setup truncates queue state between tests.
-func TestIntegration_FailedFreshSandboxClearsTargetWithoutDurableSlot(t *testing.T) {
+func TestIntegration_FailedFreshSandboxReroutesOffPhysicalHost(t *testing.T) {
 	pool := setup(t)
 	ctx := context.Background()
 	orgID := seedOrg(t, pool)
-	nodeID := "failed-create-worker-" + orgID.String()[:8]
-	seedWorkerNode(t, pool, nodeID)
+	failedCapacityNodeID := "failed-create-worker-" + orgID.String()[:8]
+	failedNodeID := failedCapacityNodeID + "-g20260813000101-blue"
+	failedSiblingNodeID := failedCapacityNodeID + "-g20260813000202-green"
+	healthyNodeID := "healthy-create-worker-" + orgID.String()[:8]
+	for _, nodeID := range []string{failedNodeID, failedSiblingNodeID, healthyNodeID} {
+		seedWorkerNode(t, pool, nodeID)
+		setWorkerSandboxCapacity(t, pool, nodeID, 2)
+	}
+	_, err := pool.Exec(ctx, `
+		UPDATE nodes
+		SET metadata = metadata || jsonb_build_object('sandbox_capacity_node_id', $2::text)
+		WHERE id = $1`, failedSiblingNodeID, failedCapacityNodeID)
+	require.NoError(t, err, "sibling worker generation should advertise the failed physical-host identity")
 	session := seedSession(t, pool, orgID, sessionOpts{Status: models.SessionStatusPending})
 
 	jobStore := db.NewJobStore(pool)
@@ -241,27 +253,84 @@ func TestIntegration_FailedFreshSandboxClearsTargetWithoutDurableSlot(t *testing
 			locked_by_node_id = $2,
 			run_owner_id = $2,
 			lease_expires_at = now() + interval '1 minute'
-		WHERE org_id = $1 AND id = $4`, orgID, nodeID, lockToken, jobID)
+		WHERE org_id = $1 AND id = $4`, orgID, failedNodeID, lockToken, jobID)
 	require.NoError(t, err, "test should create a running terminal-probe-style placement")
 
 	staleCleared, err := jobStore.ClearSandboxRoutingPlacementWithLease(ctx, jobID, uuid.New())
 	require.NoError(t, err, "stale-attempt cleanup should be a harmless no-op")
 	require.False(t, staleCleared, "stale attempt must not clear the current worker placement")
 
-	cleared, err := jobStore.ClearSandboxRoutingPlacementWithLease(ctx, jobID, lockToken)
-	require.NoError(t, err, "fresh sandbox failure cleanup should succeed")
-	require.True(t, cleared, "current attempt should clear its placement even when no durable slot remains")
+	routed, err := jobStore.RerouteSandboxAfterStartupFailure(ctx, jobID, lockToken, failedNodeID)
+	require.NoError(t, err, "fresh sandbox failure cleanup should reserve an alternate worker")
+	require.NotNil(t, routed, "fresh sandbox failure cleanup should return a routing decision")
+	require.NotNil(t, routed.TargetNodeID, "healthy alternate capacity should be reserved immediately")
+	require.Equal(t, healthyNodeID, *routed.TargetNodeID, "retry must exclude every generation on the failed physical host")
 
-	var clearedRows int
+	var reservedRows int
 	err = pool.QueryRow(ctx, `
 		SELECT COUNT(*)
 		FROM jobs
 		WHERE org_id = $1
 		  AND id = $2
-		  AND target_node_id IS NULL
-		  AND sandbox_slot_reserved_until IS NULL`, orgID, jobID).Scan(&clearedRows)
-	require.NoError(t, err, "test should inspect the failed job placement")
-	require.Equal(t, 1, clearedRows, "failed fresh sandbox should become eligible for fleet routing")
+		  AND target_node_id = $3
+		  AND sandbox_slot_reserved_until > now()`, orgID, jobID, healthyNodeID).Scan(&reservedRows)
+	require.NoError(t, err, "test should inspect the replacement worker placement")
+	require.Equal(t, 1, reservedRows, "failed fresh sandbox should atomically hold the healthy alternate slot")
+	var failedCapacityNodeIDs []string
+	err = pool.QueryRow(ctx, `
+		SELECT payload->'failed_sandbox_capacity_node_ids'
+		FROM jobs
+		WHERE org_id = $1 AND id = $2`, orgID, jobID).Scan(&failedCapacityNodeIDs)
+	require.NoError(t, err, "test should inspect durable failed-host exclusions")
+	require.Equal(t, []string{failedCapacityNodeID}, failedCapacityNodeIDs, "retry should persist the failed physical host for later routing passes")
+	var exclusionUntil time.Time
+	err = pool.QueryRow(ctx, `
+		SELECT (payload->>'failed_sandbox_capacity_node_exclusion_until')::timestamptz
+		FROM jobs
+		WHERE org_id = $1 AND id = $2`, orgID, jobID).Scan(&exclusionUntil)
+	require.NoError(t, err, "test should inspect the failed-host exclusion deadline")
+	require.True(t, exclusionUntil.After(time.Now()), "failed-host exclusion should survive immediate retry routing")
+
+	// When the only healthy alternate is temporarily unavailable, the fenced
+	// failure write must retain its physical-host exclusion for the later fleet
+	// routing pass instead of falling back to either failed generation.
+	_, err = pool.Exec(ctx, `UPDATE nodes SET status = 'draining' WHERE id = $1`, healthyNodeID)
+	require.NoError(t, err, "test should temporarily remove the healthy alternate")
+	queuedSession := seedSession(t, pool, orgID, sessionOpts{Status: models.SessionStatusPending})
+	queuedJobID, err := jobStore.EnqueueWithOpts(ctx, orgID, db.EnqueueOpts{
+		Queue:         "agent",
+		JobType:       "run_agent",
+		Payload:       map[string]string{"session_id": queuedSession.ID.String(), "org_id": orgID.String()},
+		Priority:      5,
+		WorkloadClass: models.SandboxWorkloadClassInteractive,
+	})
+	require.NoError(t, err, "capacity-wait sandbox job should enqueue")
+	queuedLockToken := uuid.New()
+	_, err = pool.Exec(ctx, `
+		UPDATE jobs
+		SET status = 'running', target_node_id = $2, sandbox_slot_reserved_until = NULL,
+			lock_token = $3, locked_by_node_id = $2, run_owner_id = $2,
+			lease_expires_at = now() + interval '1 minute'
+		WHERE org_id = $1 AND id = $4`, orgID, failedSiblingNodeID, queuedLockToken, queuedJobID)
+	require.NoError(t, err, "test should create a second failed startup attempt")
+
+	waitingRoute, err := jobStore.RerouteSandboxAfterStartupFailure(ctx, queuedJobID, queuedLockToken, failedSiblingNodeID)
+	require.NoError(t, err, "failed startup should persist its exclusion even with no immediate alternate")
+	require.Nil(t, waitingRoute.TargetNodeID, "genuinely unavailable alternate capacity should clear worker affinity")
+	_, err = pool.Exec(ctx, `
+		UPDATE jobs
+		SET status = 'pending', run_at = now(), lock_token = NULL,
+			locked_by_node_id = NULL, run_owner_id = NULL, lease_expires_at = NULL
+		WHERE org_id = $1 AND id = $2`, orgID, queuedJobID)
+	require.NoError(t, err, "test should simulate the worker's fenced retry write")
+	_, err = pool.Exec(ctx, `UPDATE nodes SET status = 'active', last_heartbeat_at = now() WHERE id = $1`, healthyNodeID)
+	require.NoError(t, err, "test should restore the healthy alternate")
+
+	laterRoute, err := jobStore.RouteNextSandboxJob(ctx)
+	require.NoError(t, err, "later routing pass should honor the durable failed-host exclusion")
+	require.NotNil(t, laterRoute, "later routing should inspect the waiting sandbox job")
+	require.NotNil(t, laterRoute.TargetNodeID, "newly available healthy capacity should be reserved")
+	require.Equal(t, healthyNodeID, *laterRoute.TargetNodeID, "later routing must not return to either generation on the failed physical host")
 }
 
 // TestIntegration_BlueGreenGenerationsSharePhysicalHostCapacity verifies that
@@ -471,6 +540,52 @@ func TestIntegration_SessionCapacityStatusExcludesOwnReservation(t *testing.T) {
 	waiting, err := store.IsSessionWaitingForSandboxCapacity(ctx, orgID, waitingSession.ID, 1)
 	require.NoError(t, err, "queued session capacity lookup should succeed")
 	require.True(t, waiting, "a queued session should report waiting when another admitted turn consumes the organization limit")
+}
+
+// TestIntegration_ClaimSkipsSaturatedOrgBacklog verifies that one tenant's
+// affinity-bound sandbox burst cannot consume the bounded claim scan and hide
+// ordinary runnable work. One deferral excludes only that tenant's sandbox
+// jobs for the rest of the pass; non-sandbox work from the same tenant remains
+// eligible.
+//
+// This test cannot run in parallel because the integration suite shares one
+// database and setup truncates queue state between tests.
+func TestIntegration_ClaimSkipsSaturatedOrgBacklog(t *testing.T) {
+	pool := setup(t)
+	ctx := context.Background()
+	orgID := seedOrg(t, pool)
+	_, err := pool.Exec(ctx, `UPDATE organizations SET settings = jsonb_set(settings, '{max_concurrent_runs}', '1'::jsonb, true) WHERE id = $1`, orgID)
+	require.NoError(t, err, "test organization should enforce one shared sandbox turn")
+	nodeID := "backlog-worker-" + orgID.String()[:8]
+	seedWorkerNode(t, pool, nodeID)
+	store := db.NewJobStore(pool)
+
+	blockerID, err := store.EnqueueWithOpts(ctx, orgID, db.EnqueueOpts{
+		Queue: "agent", JobType: "run_agent", Payload: map[string]string{"org_id": orgID.String()},
+		Priority: 5, TargetNodeID: &nodeID,
+	})
+	require.NoError(t, err, "blocking sandbox turn should enqueue")
+	_, err = pool.Exec(ctx, `
+		UPDATE jobs
+		SET status = 'running', lock_token = $3, locked_by_node_id = $2,
+			run_owner_id = $2, lease_expires_at = now() + interval '1 minute'
+		WHERE org_id = $1 AND id = $4`, orgID, nodeID, uuid.New(), blockerID)
+	require.NoError(t, err, "test should consume the organization sandbox turn")
+
+	for i := 0; i < 20; i++ {
+		_, err = store.EnqueueWithOpts(ctx, orgID, db.EnqueueOpts{
+			Queue: "agent", JobType: "run_agent", Payload: map[string]string{"org_id": orgID.String()},
+			Priority: 5, TargetNodeID: &nodeID,
+		})
+		require.NoError(t, err, "saturated sandbox backlog job should enqueue")
+	}
+	ordinaryJobID, err := store.Enqueue(ctx, orgID, "agent", "ordinary_maintenance", map[string]string{"org_id": orgID.String()}, 5, nil)
+	require.NoError(t, err, "ordinary work should enqueue behind the sandbox backlog")
+
+	claimed, err := store.ClaimNextRunnable(ctx, nodeID, nodeID, uuid.New(), time.Minute)
+	require.NoError(t, err, "claim pass should skip the saturated tenant sandbox backlog")
+	require.NotNil(t, claimed, "ordinary work should remain visible within the bounded claim pass")
+	require.Equal(t, ordinaryJobID, claimed.ID, "claim should reach non-sandbox work after one tenant-level sandbox deferral")
 }
 
 // TestIntegration_CodeReviewJobsUseFleetCapacityAndPreserveInteractiveReserve

--- a/internal/integration/worker_dispatch_test.go
+++ b/internal/integration/worker_dispatch_test.go
@@ -207,6 +207,63 @@ func TestIntegration_SharedSandboxAdmissionFencesReclaimedJobAttempt(t *testing.
 	require.NoError(t, capacityStore.ReleaseSandboxCapacity(ctx, replacementNodeID, secondReservationID, &secondLockToken), "replacement attempt should release its own reservation")
 }
 
+// TestIntegration_FailedFreshSandboxClearsTargetWithoutDurableSlot verifies
+// the failure cleanup used by compatibility and terminal-probe placements.
+// Those jobs intentionally have a target without sandbox_slot_reserved_until,
+// but a node-local create failure must still make the retry fleet-routable.
+//
+// This test cannot run in parallel because the integration suite shares one
+// database and setup truncates queue state between tests.
+func TestIntegration_FailedFreshSandboxClearsTargetWithoutDurableSlot(t *testing.T) {
+	pool := setup(t)
+	ctx := context.Background()
+	orgID := seedOrg(t, pool)
+	nodeID := "failed-create-worker-" + orgID.String()[:8]
+	seedWorkerNode(t, pool, nodeID)
+	session := seedSession(t, pool, orgID, sessionOpts{Status: models.SessionStatusPending})
+
+	jobStore := db.NewJobStore(pool)
+	jobID, err := jobStore.EnqueueWithOpts(ctx, orgID, db.EnqueueOpts{
+		Queue:         "agent",
+		JobType:       "run_agent",
+		Payload:       map[string]string{"session_id": session.ID.String(), "org_id": orgID.String()},
+		Priority:      5,
+		WorkloadClass: models.SandboxWorkloadClassInteractive,
+	})
+	require.NoError(t, err, "fresh sandbox job should enqueue")
+	lockToken := uuid.New()
+	_, err = pool.Exec(ctx, `
+		UPDATE jobs
+		SET status = 'running',
+			target_node_id = $2,
+			sandbox_slot_reserved_until = NULL,
+			lock_token = $3,
+			locked_by_node_id = $2,
+			run_owner_id = $2,
+			lease_expires_at = now() + interval '1 minute'
+		WHERE org_id = $1 AND id = $4`, orgID, nodeID, lockToken, jobID)
+	require.NoError(t, err, "test should create a running terminal-probe-style placement")
+
+	staleCleared, err := jobStore.ClearSandboxRoutingPlacementWithLease(ctx, jobID, uuid.New())
+	require.NoError(t, err, "stale-attempt cleanup should be a harmless no-op")
+	require.False(t, staleCleared, "stale attempt must not clear the current worker placement")
+
+	cleared, err := jobStore.ClearSandboxRoutingPlacementWithLease(ctx, jobID, lockToken)
+	require.NoError(t, err, "fresh sandbox failure cleanup should succeed")
+	require.True(t, cleared, "current attempt should clear its placement even when no durable slot remains")
+
+	var clearedRows int
+	err = pool.QueryRow(ctx, `
+		SELECT COUNT(*)
+		FROM jobs
+		WHERE org_id = $1
+		  AND id = $2
+		  AND target_node_id IS NULL
+		  AND sandbox_slot_reserved_until IS NULL`, orgID, jobID).Scan(&clearedRows)
+	require.NoError(t, err, "test should inspect the failed job placement")
+	require.Equal(t, 1, clearedRows, "failed fresh sandbox should become eligible for fleet routing")
+}
+
 // TestIntegration_BlueGreenGenerationsSharePhysicalHostCapacity verifies that
 // generation-specific routing IDs cannot make one Docker daemon look like two
 // independent capacity pools during a rolling deploy.

--- a/internal/integration/worker_dispatch_test.go
+++ b/internal/integration/worker_dispatch_test.go
@@ -77,7 +77,28 @@ func TestIntegration_SharedSandboxAdmissionDeduplicatesCurrentRoutingReservation
 	require.False(t, otherAcquired, "independent admission should not exceed the worker limit")
 	require.Equal(t, uuid.Nil, otherReservationID, "rejected admission should not persist another lease")
 	require.Equal(t, 1, blockedTotal, "shared and durable reservations for the admitted job should remain deduplicated")
-	require.NoError(t, capacityStore.ReleaseSandboxCapacity(ctx, reservationID), "test should release its shared admission lease")
+	lockTx, err := pool.Begin(ctx)
+	require.NoError(t, err, "test should open a competing node-admission transaction")
+	defer func() { _ = lockTx.Rollback(ctx) }()
+	_, err = lockTx.Exec(ctx, `SELECT pg_advisory_xact_lock(hashtextextended($1, 143))`, nodeID)
+	require.NoError(t, err, "test should hold the worker admission lock")
+
+	releaseDone := make(chan error, 1)
+	go func() {
+		releaseDone <- capacityStore.ReleaseSandboxCapacity(ctx, nodeID, reservationID)
+	}()
+	select {
+	case releaseErr := <-releaseDone:
+		require.Failf(t, "shared capacity release should wait for admission lock", "release returned early: %v", releaseErr)
+	case <-time.After(100 * time.Millisecond):
+	}
+	require.NoError(t, lockTx.Commit(ctx), "test should release the competing worker admission lock")
+	require.NoError(t, <-releaseDone, "shared capacity release should complete after acquiring the admission lock")
+
+	var remainingReservations int
+	err = pool.QueryRow(ctx, `SELECT COUNT(*) FROM sandbox_capacity_reservations WHERE id = $1`, reservationID).Scan(&remainingReservations)
+	require.NoError(t, err, "test should inspect the released shared reservation")
+	require.Equal(t, 0, remainingReservations, "shared capacity release should delete its lease after the admission lock is available")
 }
 
 // TestIntegration_CodeReviewJobsUseFleetCapacityAndPreserveInteractiveReserve

--- a/internal/integration/worker_dispatch_test.go
+++ b/internal/integration/worker_dispatch_test.go
@@ -166,6 +166,149 @@ func TestIntegration_BlueGreenGenerationsSharePhysicalHostCapacity(t *testing.T)
 	require.Equal(t, db.SandboxRoutingReasonFleetCapacity, second.Reason, "shared-host saturation should retain the fleet-capacity reason")
 }
 
+// TestIntegration_ClaimIsolationSkipsMalformedSandboxCandidate verifies the
+// real savepoint path: one tenant's invalid settings cannot stop unrelated
+// worker queue claims.
+func TestIntegration_ClaimIsolationSkipsMalformedSandboxCandidate(t *testing.T) {
+	pool := setup(t)
+	ctx := context.Background()
+	poisonOrgID := seedOrg(t, pool)
+	healthyOrgID := seedOrg(t, pool)
+	nodeID := "claim-worker-" + poisonOrgID.String()[:8]
+	seedWorkerNode(t, pool, nodeID)
+
+	_, err := pool.Exec(ctx, `
+		UPDATE organizations
+		SET settings = '{"session_automation":{"automatic_follow_through":{"pr_feedback_mode":"invalid"}}}'::jsonb
+		WHERE id = $1`, poisonOrgID)
+	require.NoError(t, err, "test should persist semantically invalid org settings")
+
+	store := db.NewJobStore(pool)
+	poisonSession := seedSession(t, pool, poisonOrgID, sessionOpts{Status: models.SessionStatusPending})
+	poisonJobID, err := store.EnqueueWithOpts(ctx, poisonOrgID, db.EnqueueOpts{
+		Queue:         "agent",
+		JobType:       "run_agent",
+		Payload:       map[string]string{"session_id": poisonSession.ID.String(), "org_id": poisonOrgID.String()},
+		Priority:      10,
+		TargetNodeID:  &nodeID,
+		WorkloadClass: models.SandboxWorkloadClassInteractive,
+	})
+	require.NoError(t, err, "poison sandbox job should enqueue")
+	healthyJobID, err := store.EnqueueWithOpts(ctx, healthyOrgID, db.EnqueueOpts{
+		Queue:    "default",
+		JobType:  "integration_noop",
+		Payload:  map[string]string{"org_id": healthyOrgID.String()},
+		Priority: 1,
+	})
+	require.NoError(t, err, "healthy non-sandbox job should enqueue")
+
+	claimed, err := store.ClaimNextRunnable(ctx, nodeID, nodeID, uuid.New(), time.Minute)
+	require.NoError(t, err, "claim pass should isolate invalid sandbox admission")
+	require.NotNil(t, claimed, "claim pass should continue to unrelated work")
+	require.Equal(t, healthyJobID, claimed.ID, "lower-priority healthy job should bypass the durably deferred poison candidate")
+
+	var poisonStatus models.JobStatus
+	var poisonLastError *string
+	err = pool.QueryRow(ctx, `SELECT status, last_error FROM jobs WHERE org_id = $1 AND id = $2`, poisonOrgID, poisonJobID).Scan(&poisonStatus, &poisonLastError)
+	require.NoError(t, err, "poison job state should remain queryable")
+	require.Equal(t, models.JobStatusPending, poisonStatus, "poison candidate should remain pending for repair and retry")
+	require.NotNil(t, poisonLastError, "poison candidate should record its isolated admission error")
+	require.Contains(t, *poisonLastError, "invalid PR feedback human mode", "recorded error should identify the malformed setting")
+}
+
+// TestIntegration_MetadataFallbackClaimKeepsInitialRunDeadline verifies that a
+// null-reservation compatibility placement still reaches the bounded terminal
+// path after repeated organization-limit deferrals.
+func TestIntegration_MetadataFallbackClaimKeepsInitialRunDeadline(t *testing.T) {
+	pool := setup(t)
+	ctx := context.Background()
+	orgID := seedOrg(t, pool)
+	nodeID := "fallback-worker-" + orgID.String()[:8]
+	seedWorkerNode(t, pool, nodeID)
+	_, err := pool.Exec(ctx, `UPDATE organizations SET settings = jsonb_set(settings, '{max_concurrent_runs}', '1'::jsonb, true) WHERE id = $1`, orgID)
+	require.NoError(t, err, "test org should use a single shared turn")
+
+	store := db.NewJobStore(pool)
+	blockingSession := seedSession(t, pool, orgID, sessionOpts{Status: models.SessionStatusRunning})
+	_, err = store.EnqueueWithOpts(ctx, orgID, db.EnqueueOpts{
+		Queue:        "agent",
+		JobType:      "run_agent",
+		Payload:      map[string]string{"session_id": blockingSession.ID.String(), "org_id": orgID.String()},
+		Priority:     5,
+		TargetNodeID: &nodeID,
+	})
+	require.NoError(t, err, "blocking job should enqueue")
+	blockingJob, err := store.ClaimNextRunnable(ctx, nodeID, nodeID, uuid.New(), time.Minute)
+	require.NoError(t, err, "blocking job should claim")
+	require.NotNil(t, blockingJob, "blocking job should consume the org turn")
+
+	pendingSession := seedSession(t, pool, orgID, sessionOpts{Status: models.SessionStatusPending})
+	pendingJobID, err := store.EnqueueWithOpts(ctx, orgID, db.EnqueueOpts{
+		Queue:        "agent",
+		JobType:      "run_agent",
+		Payload:      map[string]string{"session_id": pendingSession.ID.String(), "org_id": orgID.String()},
+		Priority:     5,
+		TargetNodeID: &nodeID,
+	})
+	require.NoError(t, err, "metadata-fallback job should enqueue with a target and no reservation")
+
+	claimed, err := store.ClaimNextRunnable(ctx, nodeID, nodeID, uuid.New(), time.Minute)
+	require.NoError(t, err, "org-limited metadata fallback should defer cleanly")
+	require.Nil(t, claimed, "org-limited metadata fallback should remain pending")
+	var createdAt time.Time
+	var retryStartedAt *time.Time
+	err = pool.QueryRow(ctx, `SELECT created_at, retry_window_started_at FROM jobs WHERE org_id = $1 AND id = $2`, orgID, pendingJobID).Scan(&createdAt, &retryStartedAt)
+	require.NoError(t, err, "deferred fallback job should remain queryable")
+	require.NotNil(t, retryStartedAt, "first claim deferral should persist the terminal deadline marker")
+	require.WithinDuration(t, createdAt, *retryStartedAt, time.Microsecond, "initial-run terminal deadline should remain anchored to job creation")
+}
+
+// TestIntegration_SessionCapacityStatusExcludesOwnReservation verifies the
+// runtime-status distinction between an admitted pending session and another
+// session that is genuinely waiting behind the organization limit.
+//
+// This test cannot run in parallel because the integration suite shares one
+// database and setup truncates queue state between tests.
+func TestIntegration_SessionCapacityStatusExcludesOwnReservation(t *testing.T) {
+	pool := setup(t)
+	ctx := context.Background()
+	orgID := seedOrg(t, pool)
+	nodeID := "status-worker-" + orgID.String()[:8]
+	seedWorkerNode(t, pool, nodeID)
+	store := db.NewJobStore(pool)
+
+	admittedSession := seedSession(t, pool, orgID, sessionOpts{Status: models.SessionStatusPending})
+	admittedJobID, err := store.EnqueueWithOpts(ctx, orgID, db.EnqueueOpts{
+		Queue:        "agent",
+		JobType:      "run_agent",
+		Payload:      map[string]string{"session_id": admittedSession.ID.String(), "org_id": orgID.String()},
+		Priority:     5,
+		TargetNodeID: &nodeID,
+	})
+	require.NoError(t, err, "admitted session job should enqueue")
+	_, err = pool.Exec(ctx, `
+		UPDATE jobs
+		SET sandbox_slot_reserved_until = now() + interval '1 minute'
+		WHERE org_id = $1 AND id = $2`, orgID, admittedJobID)
+	require.NoError(t, err, "test should give the admitted session a live worker reservation")
+
+	waitingSession := seedSession(t, pool, orgID, sessionOpts{Status: models.SessionStatusPending})
+	_, err = store.EnqueueWithOpts(ctx, orgID, db.EnqueueOpts{
+		Queue:    "agent",
+		JobType:  "run_agent",
+		Payload:  map[string]string{"session_id": waitingSession.ID.String(), "org_id": orgID.String()},
+		Priority: 5,
+	})
+	require.NoError(t, err, "waiting session job should enqueue")
+
+	admittedWaiting, err := store.IsSessionWaitingForSandboxCapacity(ctx, orgID, admittedSession.ID, 1)
+	require.NoError(t, err, "admitted session capacity lookup should succeed")
+	require.False(t, admittedWaiting, "a session's own live reservation should not make it appear capacity-blocked")
+	waiting, err := store.IsSessionWaitingForSandboxCapacity(ctx, orgID, waitingSession.ID, 1)
+	require.NoError(t, err, "queued session capacity lookup should succeed")
+	require.True(t, waiting, "a queued session should report waiting when another admitted turn consumes the organization limit")
+}
+
 // TestIntegration_CodeReviewJobsUseFleetCapacityAndPreserveInteractiveReserve
 // uses the real queue and Postgres locking path to exercise a mixed-version
 // code-review burst. It intentionally enqueues review jobs with the legacy

--- a/internal/integration/worker_dispatch_test.go
+++ b/internal/integration/worker_dispatch_test.go
@@ -17,6 +17,69 @@ import (
 	"github.com/assembledhq/143/internal/worker"
 )
 
+// TestIntegration_SharedSandboxAdmissionDeduplicatesCurrentRoutingReservation
+// exercises the real advisory-lock and lease-union query. The final gate must
+// replace, rather than add to, its own durable routing reservation while still
+// rejecting an independent consumer once that worker slot is occupied.
+//
+// This test cannot run in parallel because the integration suite shares one
+// database and setup truncates queue state between tests.
+func TestIntegration_SharedSandboxAdmissionDeduplicatesCurrentRoutingReservation(t *testing.T) {
+	pool := setup(t)
+	ctx := context.Background()
+	orgID := seedOrg(t, pool)
+	nodeID := "shared-admission-worker-" + orgID.String()[:8]
+	seedWorkerNode(t, pool, nodeID)
+	setWorkerSandboxCapacity(t, pool, nodeID, 1)
+
+	session := seedSession(t, pool, orgID, sessionOpts{Status: models.SessionStatusPending})
+	jobStore := db.NewJobStore(pool)
+	jobID, err := jobStore.EnqueueWithOpts(ctx, orgID, db.EnqueueOpts{
+		Queue:         "agent",
+		JobType:       "run_agent",
+		Payload:       map[string]string{"session_id": session.ID.String(), "org_id": orgID.String()},
+		Priority:      5,
+		WorkloadClass: models.SandboxWorkloadClassInteractive,
+	})
+	require.NoError(t, err, "sandbox-producing job should enqueue")
+	routed, err := jobStore.RouteNextSandboxJob(ctx)
+	require.NoError(t, err, "sandbox-producing job should receive a durable worker reservation")
+	require.NotNil(t, routed, "routing should return the reserved job")
+	require.NotNil(t, routed.TargetNodeID, "routing should select the only worker")
+	require.Equal(t, nodeID, *routed.TargetNodeID, "routing should target the configured worker")
+
+	capacityStore := db.NewSandboxCapacityReservationStore(pool)
+	reservationID, live, total, acquired, err := capacityStore.ReserveSandboxCapacity(
+		ctx,
+		nodeID,
+		&jobID,
+		models.SandboxWorkloadClassInteractive,
+		func(context.Context) (int, error) { return 0, nil },
+		1,
+		time.Now().Add(time.Minute),
+	)
+	require.NoError(t, err, "final admission should replace the current job's durable routing reservation")
+	require.True(t, acquired, "current job should acquire the one worker slot")
+	require.Equal(t, 0, live, "final admission should use the live Docker count taken under the node lock")
+	require.Equal(t, 1, total, "durable and final reservations for the same job should count once")
+	require.NotEqual(t, uuid.Nil, reservationID, "successful final admission should persist a lease")
+
+	otherReservationID, _, blockedTotal, otherAcquired, err := capacityStore.ReserveSandboxCapacity(
+		ctx,
+		nodeID,
+		nil,
+		models.SandboxWorkloadClassInteractive,
+		func(context.Context) (int, error) { return 0, nil },
+		1,
+		time.Now().Add(time.Minute),
+	)
+	require.NoError(t, err, "independent admission should return a capacity decision")
+	require.False(t, otherAcquired, "independent admission should not exceed the worker limit")
+	require.Equal(t, uuid.Nil, otherReservationID, "rejected admission should not persist another lease")
+	require.Equal(t, 1, blockedTotal, "shared and durable reservations for the admitted job should remain deduplicated")
+	require.NoError(t, capacityStore.ReleaseSandboxCapacity(ctx, reservationID), "test should release its shared admission lease")
+}
+
 // TestIntegration_CodeReviewJobsUseFleetCapacityAndPreserveInteractiveReserve
 // uses the real queue and Postgres locking path to exercise a mixed-version
 // code-review burst. It intentionally enqueues review jobs with the legacy

--- a/internal/integration/worker_dispatch_test.go
+++ b/internal/integration/worker_dispatch_test.go
@@ -143,9 +143,10 @@ func TestIntegration_SharedSandboxAdmissionFencesReclaimedJobAttempt(t *testing.
 	require.NotNil(t, claimed, "first queue attempt should own the job before final admission")
 
 	capacityStore := db.NewSandboxCapacityReservationStore(pool)
+	firstReservationExpiresAt := time.Now().Add(time.Minute)
 	firstReservationID, _, _, acquired, err := capacityStore.ReserveSandboxCapacity(
 		ctx, nodeID, &jobID, &firstLockToken, models.SandboxWorkloadClassInteractive,
-		func(context.Context) (int, error) { return 0, nil }, 3, time.Now().Add(time.Minute),
+		func(context.Context) (int, error) { return 0, nil }, 3, firstReservationExpiresAt,
 	)
 	require.NoError(t, err, "first queue attempt should reserve final-admission capacity")
 	require.True(t, acquired, "first queue attempt should acquire final-admission capacity")
@@ -176,6 +177,9 @@ func TestIntegration_SharedSandboxAdmissionFencesReclaimedJobAttempt(t *testing.
 		func(context.Context) (int, error) { return 0, nil }, 3, time.Now().Add(time.Minute),
 	)
 	require.ErrorIs(t, err, db.ErrSandboxCapacityAttemptConflict, "replacement attempt should distinguish stale-attempt coordination from physical capacity saturation")
+	var conflictErr *db.SandboxCapacityAttemptConflictError
+	require.ErrorAs(t, err, &conflictErr, "replacement attempt should receive the stale lease deadline")
+	require.WithinDuration(t, firstReservationExpiresAt, conflictErr.ExpiresAt, time.Millisecond, "replacement attempt should wait for the persisted stale lease expiry")
 	require.False(t, replacementAcquired, "replacement attempt must wait for the stale attempt's live reservation on another worker")
 	require.Equal(t, 0, blockedTotal, "another worker's lease is a fencing conflict rather than local capacity load")
 

--- a/internal/integration/worker_dispatch_test.go
+++ b/internal/integration/worker_dispatch_test.go
@@ -47,12 +47,18 @@ func TestIntegration_SharedSandboxAdmissionDeduplicatesCurrentRoutingReservation
 	require.NotNil(t, routed, "routing should return the reserved job")
 	require.NotNil(t, routed.TargetNodeID, "routing should select the only worker")
 	require.Equal(t, nodeID, *routed.TargetNodeID, "routing should target the configured worker")
+	lockToken := uuid.New()
+	claimed, err := jobStore.ClaimNextRunnable(ctx, nodeID, nodeID, lockToken, time.Minute)
+	require.NoError(t, err, "routed sandbox job should be claimed by its target worker")
+	require.NotNil(t, claimed, "routed sandbox job should be available to final admission")
+	require.Equal(t, jobID, claimed.ID, "final admission should use the claimed routing job")
 
 	capacityStore := db.NewSandboxCapacityReservationStore(pool)
 	reservationID, live, total, acquired, err := capacityStore.ReserveSandboxCapacity(
 		ctx,
 		nodeID,
 		&jobID,
+		&lockToken,
 		models.SandboxWorkloadClassInteractive,
 		func(context.Context) (int, error) { return 0, nil },
 		1,
@@ -67,6 +73,7 @@ func TestIntegration_SharedSandboxAdmissionDeduplicatesCurrentRoutingReservation
 	otherReservationID, _, blockedTotal, otherAcquired, err := capacityStore.ReserveSandboxCapacity(
 		ctx,
 		nodeID,
+		nil,
 		nil,
 		models.SandboxWorkloadClassInteractive,
 		func(context.Context) (int, error) { return 0, nil },
@@ -85,7 +92,7 @@ func TestIntegration_SharedSandboxAdmissionDeduplicatesCurrentRoutingReservation
 
 	releaseDone := make(chan error, 1)
 	go func() {
-		releaseDone <- capacityStore.ReleaseSandboxCapacity(ctx, nodeID, reservationID)
+		releaseDone <- capacityStore.ReleaseSandboxCapacity(ctx, nodeID, reservationID, &lockToken)
 	}()
 	select {
 	case releaseErr := <-releaseDone:
@@ -99,6 +106,105 @@ func TestIntegration_SharedSandboxAdmissionDeduplicatesCurrentRoutingReservation
 	err = pool.QueryRow(ctx, `SELECT COUNT(*) FROM sandbox_capacity_reservations WHERE id = $1`, reservationID).Scan(&remainingReservations)
 	require.NoError(t, err, "test should inspect the released shared reservation")
 	require.Equal(t, 0, remainingReservations, "shared capacity release should delete its lease after the admission lock is available")
+}
+
+// TestIntegration_SharedSandboxAdmissionFencesReclaimedJobAttempt verifies
+// that a replacement queue owner cannot share or overwrite the stale owner's
+// final-admission lease. The replacement waits for the prior attempt to
+// release (or expire), and either attempt can release only its own lease.
+//
+// This test cannot run in parallel because the integration suite shares one
+// database and setup truncates queue state between tests.
+func TestIntegration_SharedSandboxAdmissionFencesReclaimedJobAttempt(t *testing.T) {
+	pool := setup(t)
+	ctx := context.Background()
+	orgID := seedOrg(t, pool)
+	nodeID := "attempt-fence-worker-" + orgID.String()[:8]
+	seedWorkerNode(t, pool, nodeID)
+	setWorkerSandboxCapacity(t, pool, nodeID, 3)
+
+	session := seedSession(t, pool, orgID, sessionOpts{Status: models.SessionStatusPending})
+	jobStore := db.NewJobStore(pool)
+	jobID, err := jobStore.EnqueueWithOpts(ctx, orgID, db.EnqueueOpts{
+		Queue:         "agent",
+		JobType:       "run_agent",
+		Payload:       map[string]string{"session_id": session.ID.String(), "org_id": orgID.String()},
+		Priority:      5,
+		WorkloadClass: models.SandboxWorkloadClassInteractive,
+	})
+	require.NoError(t, err, "sandbox-producing job should enqueue")
+	routed, err := jobStore.RouteNextSandboxJob(ctx)
+	require.NoError(t, err, "sandbox-producing job should receive a durable worker reservation")
+	require.NotNil(t, routed, "routing should return the sandbox-producing job")
+
+	firstLockToken := uuid.New()
+	claimed, err := jobStore.ClaimNextRunnable(ctx, nodeID, nodeID, firstLockToken, time.Minute)
+	require.NoError(t, err, "first queue attempt should claim the routed job")
+	require.NotNil(t, claimed, "first queue attempt should own the job before final admission")
+
+	capacityStore := db.NewSandboxCapacityReservationStore(pool)
+	firstReservationID, _, _, acquired, err := capacityStore.ReserveSandboxCapacity(
+		ctx, nodeID, &jobID, &firstLockToken, models.SandboxWorkloadClassInteractive,
+		func(context.Context) (int, error) { return 0, nil }, 3, time.Now().Add(time.Minute),
+	)
+	require.NoError(t, err, "first queue attempt should reserve final-admission capacity")
+	require.True(t, acquired, "first queue attempt should acquire final-admission capacity")
+	_, err = pool.Exec(ctx, `
+		INSERT INTO sandbox_capacity_reservations (node_id, job_id, workload_class, expires_at)
+		VALUES ($1, $2, 'interactive', now() + interval '1 minute')
+		ON CONFLICT (job_id) WHERE job_id IS NOT NULL
+		DO UPDATE SET node_id = EXCLUDED.node_id, expires_at = EXCLUDED.expires_at`, nodeID, jobID)
+	require.ErrorContains(t, err, "requires a matching job lock token", "rolling-deploy legacy admission must fail closed instead of sharing the current attempt's row")
+
+	replacementNodeID := nodeID + "-replacement"
+	seedWorkerNode(t, pool, replacementNodeID)
+	setWorkerSandboxCapacity(t, pool, replacementNodeID, 3)
+	secondLockToken := uuid.New()
+	_, err = pool.Exec(ctx, `
+		UPDATE jobs
+		SET lock_token = $3,
+			locked_by_node_id = $2,
+			run_owner_id = $2,
+			target_node_id = $2,
+			locked_at = now(),
+			lease_expires_at = now() + interval '1 minute'
+		WHERE org_id = $1 AND id = $4`, orgID, replacementNodeID, secondLockToken, jobID)
+	require.NoError(t, err, "test should simulate the queue reclaiming the job on another worker with a new fencing token")
+
+	_, _, blockedTotal, replacementAcquired, err := capacityStore.ReserveSandboxCapacity(
+		ctx, replacementNodeID, &jobID, &secondLockToken, models.SandboxWorkloadClassInteractive,
+		func(context.Context) (int, error) { return 0, nil }, 3, time.Now().Add(time.Minute),
+	)
+	require.NoError(t, err, "replacement attempt should receive a serialized capacity decision")
+	require.False(t, replacementAcquired, "replacement attempt must wait for the stale attempt's live reservation on another worker")
+	require.Equal(t, 0, blockedTotal, "another worker's lease is a fencing conflict rather than local capacity load")
+
+	_, _, _, staleAcquired, err := capacityStore.ReserveSandboxCapacity(
+		ctx, nodeID, &jobID, &firstLockToken, models.SandboxWorkloadClassInteractive,
+		func(context.Context) (int, error) { return 0, nil }, 3, time.Now().Add(time.Minute),
+	)
+	require.ErrorContains(t, err, "job attempt no longer owns", "stale attempt should fail transactional ownership validation")
+	require.False(t, staleAcquired, "stale attempt must not reacquire final-admission capacity")
+
+	_, err = pool.Exec(ctx, `
+		UPDATE sandbox_capacity_reservations
+		SET expires_at = now() - interval '1 second'
+		WHERE id = $1`, firstReservationID)
+	require.NoError(t, err, "test should expire the stale attempt lease without releasing it")
+	secondReservationID, _, _, replacementAcquired, err := capacityStore.ReserveSandboxCapacity(
+		ctx, replacementNodeID, &jobID, &secondLockToken, models.SandboxWorkloadClassInteractive,
+		func(context.Context) (int, error) { return 0, nil }, 3, time.Now().Add(time.Minute),
+	)
+	require.NoError(t, err, "replacement attempt should reserve after the prior lease expires")
+	require.True(t, replacementAcquired, "replacement attempt should acquire its own final-admission lease")
+	require.NotEqual(t, firstReservationID, secondReservationID, "replacement attempt should receive a distinct reservation identity")
+
+	require.NoError(t, capacityStore.ReleaseSandboxCapacity(ctx, nodeID, firstReservationID, &firstLockToken), "late stale release should be harmless")
+	var replacementRows int
+	err = pool.QueryRow(ctx, `SELECT COUNT(*) FROM sandbox_capacity_reservations WHERE id = $1 AND job_lock_token = $2`, secondReservationID, secondLockToken).Scan(&replacementRows)
+	require.NoError(t, err, "test should inspect the replacement attempt reservation")
+	require.Equal(t, 1, replacementRows, "stale release must not delete the replacement attempt's reservation")
+	require.NoError(t, capacityStore.ReleaseSandboxCapacity(ctx, replacementNodeID, secondReservationID, &secondLockToken), "replacement attempt should release its own reservation")
 }
 
 // TestIntegration_BlueGreenGenerationsSharePhysicalHostCapacity verifies that
@@ -148,6 +254,7 @@ func TestIntegration_BlueGreenGenerationsSharePhysicalHostCapacity(t *testing.T)
 	_, _, finalLoad, admitted, err := db.NewSandboxCapacityReservationStore(pool).ReserveSandboxCapacity(
 		ctx,
 		capacityNodeID,
+		nil,
 		nil,
 		models.SandboxWorkloadClassInteractive,
 		func(context.Context) (int, error) { return 0, nil },

--- a/internal/models/enum_db_sync_test.go
+++ b/internal/models/enum_db_sync_test.go
@@ -269,6 +269,9 @@ func TestEnumValuesMatchCheckConstraints(t *testing.T) {
 		"jobs_workload_class": toStrings(
 			SandboxWorkloadClassInteractive, SandboxWorkloadClassCodeReview,
 		),
+		"sandbox_capacity_reservations_workload_class": toStrings(
+			SandboxWorkloadClassInteractive, SandboxWorkloadClassCodeReview,
+		),
 	}
 
 	for _, c := range constraints {

--- a/internal/services/agent/orchestrator.go
+++ b/internal/services/agent/orchestrator.go
@@ -5623,6 +5623,7 @@ func (o *Orchestrator) nonDrainableCodeReviewThreadsForDrain(ctx context.Context
 		switch thread.Status {
 		case models.ThreadStatusPending,
 			models.ThreadStatusRunning,
+			models.ThreadStatusAwaitingInput,
 			models.ThreadStatusCompleted,
 			models.ThreadStatusFailed,
 			models.ThreadStatusCancelled:

--- a/internal/services/agent/orchestrator.go
+++ b/internal/services/agent/orchestrator.go
@@ -5504,7 +5504,7 @@ func (o *Orchestrator) drainQueuedMessagesAfterProcessedID(ctx context.Context, 
 		log.Warn().Err(err).Msg("failed to fetch messages for post-turn queue drain")
 		return
 	}
-	terminalCodeReviewThreads := o.terminalCodeReviewThreadsForDrain(ctx, session, log)
+	nonDrainableCodeReviewThreads := o.nonDrainableCodeReviewThreadsForDrain(ctx, session, log)
 	var queued *models.SessionMessage
 	for i := range messages {
 		m := messages[i]
@@ -5519,12 +5519,12 @@ func (o *Orchestrator) drainQueuedMessagesAfterProcessedID(ctx context.Context, 
 			continue
 		}
 		if m.ThreadID != nil {
-			if terminalThread, terminal := terminalCodeReviewThreads[*m.ThreadID]; terminal {
+			if nonDrainableThread, nonDrainable := nonDrainableCodeReviewThreads[*m.ThreadID]; nonDrainable {
 				log.Info().
-					Str("thread_id", terminalThread.ID.String()).
+					Str("thread_id", nonDrainableThread.ID.String()).
 					Int64("message_id", m.ID).
-					Str("thread_status", string(terminalThread.Status)).
-					Msg("skipping queued message for terminal code review thread")
+					Str("thread_status", string(nonDrainableThread.Status)).
+					Msg("skipping queued message for non-drainable code review thread")
 				continue
 			}
 		}
@@ -5588,33 +5588,37 @@ func (o *Orchestrator) drainQueuedMessagesAfterProcessedID(ctx context.Context, 
 	}
 }
 
-func (o *Orchestrator) terminalCodeReviewThreadsForDrain(ctx context.Context, session *models.Session, log zerolog.Logger) map[uuid.UUID]models.SessionThread {
-	terminal := make(map[uuid.UUID]models.SessionThread)
+func (o *Orchestrator) nonDrainableCodeReviewThreadsForDrain(ctx context.Context, session *models.Session, log zerolog.Logger) map[uuid.UUID]models.SessionThread {
+	nonDrainable := make(map[uuid.UUID]models.SessionThread)
 	if session == nil || session.Origin != models.SessionOriginCodeReview || o.sessionThreads == nil {
-		return terminal
+		return nonDrainable
 	}
 	lister, ok := o.sessionThreads.(sessionThreadDrainLister)
 	if !ok {
 		log.Warn().Msg("session thread store does not support batched code review queue-drain lookup")
-		return terminal
+		return nonDrainable
 	}
 	threads, err := lister.ListBySessionWithOptions(ctx, session.OrgID, session.ID, true)
 	if err != nil {
 		log.Warn().Err(err).
 			Str("session_id", session.ID.String()).
 			Msg("failed to list code review threads during queue drain")
-		return terminal
+		return nonDrainable
 	}
 	for _, thread := range threads {
 		if thread.ExecutionMode != models.ThreadExecutionModeReview || thread.FilesystemMode != models.ThreadFilesystemModeReadOnly {
 			continue
 		}
 		switch thread.Status {
-		case models.ThreadStatusCompleted, models.ThreadStatusFailed, models.ThreadStatusCancelled:
-			terminal[thread.ID] = thread
+		case models.ThreadStatusPending,
+			models.ThreadStatusRunning,
+			models.ThreadStatusCompleted,
+			models.ThreadStatusFailed,
+			models.ThreadStatusCancelled:
+			nonDrainable[thread.ID] = thread
 		}
 	}
-	return terminal
+	return nonDrainable
 }
 
 func (o *Orchestrator) admitNextQueuedThread(ctx context.Context, session *models.Session, log zerolog.Logger) {

--- a/internal/services/agent/orchestrator.go
+++ b/internal/services/agent/orchestrator.go
@@ -3090,14 +3090,18 @@ func (o *Orchestrator) RunAgent(ctx context.Context, run *models.Session) error 
 	if capacityReservation != nil {
 		capacityReservation.Release()
 	}
-	o.releaseSandboxRoutingReservation(ctx, log)
 	if err != nil {
+		// Creation failed before this worker published a sandbox. Clear both the
+		// durable slot and its worker target so the retry can choose a healthy
+		// node instead of remaining pinned to the node-local failure.
+		o.clearFailedFreshSandboxRoutingPlacement(ctx, log)
 		if sandboxCfg.AuthSocketPath != "" {
 			o.closeSandboxAuth(run.ID, log)
 		}
 		o.failRun(ctx, run, fmt.Sprintf("create sandbox: %s", err))
 		return fmt.Errorf("create sandbox: %w", err)
 	}
+	o.releaseSandboxRoutingReservation(ctx, log)
 	sandbox.Env = cloneStringMap(sandboxCfg.Env)
 	// Record the turn hold so a concurrent StartPreview can attach to this
 	// container (same ID, same filesystem) instead of hydrating a duplicate.
@@ -4621,8 +4625,10 @@ func (o *Orchestrator) ContinueSession(ctx context.Context, session *models.Sess
 		if capacityReservation != nil {
 			capacityReservation.Release()
 		}
-		o.releaseSandboxRoutingReservation(ctx, log)
 		if err != nil {
+			// Hydration failed before a sandbox was attached to the session. Drop
+			// the pre-claim target along with its slot so a retry can reroute.
+			o.clearFailedFreshSandboxRoutingPlacement(ctx, log)
 			o.closeSandboxAuth(session.ID, log)
 			log.Error().Err(err).Msg("sandbox hydrate failed during continue_session")
 			o.cleanupContinueSessionStartupFailure(
@@ -4638,13 +4644,16 @@ func (o *Orchestrator) ContinueSession(ctx context.Context, session *models.Sess
 			)
 			return fmt.Errorf("hydrate sandbox: %w", err)
 		}
+		o.releaseSandboxRoutingReservation(ctx, log)
 	default:
 		sandbox, err = o.provider.Create(ctx, sandboxCfg)
 		if capacityReservation != nil {
 			capacityReservation.Release()
 		}
-		o.releaseSandboxRoutingReservation(ctx, log)
 		if err != nil {
+			// Creation failed before this worker established affinity. Clear the
+			// fenced placement so the generic retry can use another worker.
+			o.clearFailedFreshSandboxRoutingPlacement(ctx, log)
 			o.closeSandboxAuth(session.ID, log)
 			log.Error().Err(err).Msg("sandbox creation failed during continue_session")
 			o.cleanupContinueSessionStartupFailure(
@@ -4660,6 +4669,7 @@ func (o *Orchestrator) ContinueSession(ctx context.Context, session *models.Sess
 			)
 			return fmt.Errorf("create sandbox: %w", err)
 		}
+		o.releaseSandboxRoutingReservation(ctx, log)
 	}
 	sandbox.Env = cloneStringMap(sandboxCfg.Env)
 	// Re-populate sandbox.Metadata["base_commit_sha"] from the DB so that

--- a/internal/services/agent/orchestrator.go
+++ b/internal/services/agent/orchestrator.go
@@ -22,6 +22,7 @@ import (
 	"github.com/rs/zerolog"
 
 	"github.com/assembledhq/143/internal/auth"
+	"github.com/assembledhq/143/internal/db"
 	"github.com/assembledhq/143/internal/internalapi"
 	"github.com/assembledhq/143/internal/jobctx"
 	"github.com/assembledhq/143/internal/metrics"
@@ -5677,16 +5678,15 @@ func (o *Orchestrator) enqueueContinueSessionTurn(ctx context.Context, session *
 	if o == nil || o.jobs == nil || session == nil {
 		return uuid.Nil, fmt.Errorf("enqueue continue session turn: dependencies are not configured")
 	}
-	targetNodeID := models.SessionWorkerTarget(session)
-	workloadClass := models.SandboxWorkloadClassForSession(session)
-	if workloadClass == models.SandboxWorkloadClassCodeReview {
+	enqueueOpts := db.ContinueSessionEnqueueOpts(session, payload, dedupeKey)
+	if enqueueOpts.WorkloadClass == models.SandboxWorkloadClassCodeReview {
 		classified, ok := o.jobs.(workloadClassJobStore)
 		if !ok {
 			return uuid.Nil, fmt.Errorf("enqueue code-review continuation: job store does not support workload classes")
 		}
-		return classified.EnqueueWithTargetAndWorkload(ctx, session.OrgID, "agent", "continue_session", payload, 5, dedupeKey, targetNodeID, workloadClass)
+		return classified.EnqueueWithTargetAndWorkload(ctx, session.OrgID, enqueueOpts.Queue, enqueueOpts.JobType, enqueueOpts.Payload, enqueueOpts.Priority, enqueueOpts.DedupeKey, enqueueOpts.TargetNodeID, enqueueOpts.WorkloadClass)
 	}
-	return o.jobs.EnqueueWithTarget(ctx, session.OrgID, "agent", "continue_session", payload, 5, dedupeKey, targetNodeID)
+	return o.jobs.EnqueueWithTarget(ctx, session.OrgID, enqueueOpts.Queue, enqueueOpts.JobType, enqueueOpts.Payload, enqueueOpts.Priority, enqueueOpts.DedupeKey, enqueueOpts.TargetNodeID)
 }
 
 // drainAcceptableStatus returns true for session states that can absorb

--- a/internal/services/agent/orchestrator_drain_internal_test.go
+++ b/internal/services/agent/orchestrator_drain_internal_test.go
@@ -466,44 +466,61 @@ func TestDrainQueuedMessages_ThreadScopeDrainsQueuedSiblingThread(t *testing.T) 
 	require.Equal(t, threadB.String(), payload["thread_id"], "thread-scope drain must target the queued sibling thread")
 }
 
-func TestDrainQueuedMessages_SkipsTerminalCodeReviewReviewerThread(t *testing.T) {
+func TestDrainQueuedMessages_SkipsNonDrainableCodeReviewReviewerThread(t *testing.T) {
 	t.Parallel()
 
-	orgID := uuid.New()
-	sessionID := uuid.New()
-	completedReviewerThreadID := uuid.New()
-	failedReviewerThreadID := uuid.New()
-	processed := &models.SessionMessage{
-		ID:        5,
-		OrgID:     orgID,
-		SessionID: sessionID,
-		Role:      models.MessageRoleUser,
-		ThreadID:  &completedReviewerThreadID,
+	tests := []struct {
+		name   string
+		status models.ThreadStatus
+	}{
+		{name: "pending reviewer", status: models.ThreadStatusPending},
+		{name: "running reviewer", status: models.ThreadStatusRunning},
+		{name: "completed reviewer", status: models.ThreadStatusCompleted},
+		{name: "failed reviewer", status: models.ThreadStatusFailed},
+		{name: "cancelled reviewer", status: models.ThreadStatusCancelled},
 	}
-	messages := &drainStubMessages{messages: []models.SessionMessage{
-		*processed,
-		{ID: 6, OrgID: orgID, SessionID: sessionID, Role: models.MessageRoleUser, ThreadID: &failedReviewerThreadID, Content: "run the failed reviewer again"},
-	}}
-	sessions := &drainStubSessions{session: models.Session{Status: models.SessionStatusIdle, Origin: models.SessionOriginCodeReview}}
-	jobs := &drainStubJobs{}
-	threads := &drainStubThreads{threadsByID: map[uuid.UUID]models.SessionThread{
-		failedReviewerThreadID: {
-			ID:             failedReviewerThreadID,
-			OrgID:          orgID,
-			SessionID:      sessionID,
-			Status:         models.ThreadStatusFailed,
-			ExecutionMode:  models.ThreadExecutionModeReview,
-			FilesystemMode: models.ThreadFilesystemModeReadOnly,
-		},
-	}}
-	o := newDrainOrchestrator(messages, sessions, jobs, threads)
-	session := &models.Session{ID: sessionID, OrgID: orgID, Origin: models.SessionOriginCodeReview}
 
-	o.drainQueuedMessages(context.Background(), session, processed, &completedReviewerThreadID, zerolog.Nop())
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 
-	require.Empty(t, jobs.enqueues, "a failed code-review reviewer prompt must not be redispatched by a sibling's post-turn queue drain")
-	require.Empty(t, threads.clearedThreadIDs, "skipped terminal reviewer messages should retain their pending count for auditability")
-	require.Equal(t, 1, threads.listBySessionCalls, "queue drain should batch all reviewer thread states into one store read")
+			orgID := uuid.New()
+			sessionID := uuid.New()
+			processedThreadID := uuid.New()
+			targetReviewerThreadID := uuid.New()
+			processed := &models.SessionMessage{
+				ID:        5,
+				OrgID:     orgID,
+				SessionID: sessionID,
+				Role:      models.MessageRoleUser,
+				ThreadID:  &processedThreadID,
+			}
+			messages := &drainStubMessages{messages: []models.SessionMessage{
+				*processed,
+				{ID: 6, OrgID: orgID, SessionID: sessionID, Role: models.MessageRoleUser, ThreadID: &targetReviewerThreadID, Content: "review prompt"},
+			}}
+			sessions := &drainStubSessions{session: models.Session{Status: models.SessionStatusIdle, Origin: models.SessionOriginCodeReview}}
+			jobs := &drainStubJobs{}
+			threads := &drainStubThreads{threadsByID: map[uuid.UUID]models.SessionThread{
+				targetReviewerThreadID: {
+					ID:             targetReviewerThreadID,
+					OrgID:          orgID,
+					SessionID:      sessionID,
+					Status:         tt.status,
+					ExecutionMode:  models.ThreadExecutionModeReview,
+					FilesystemMode: models.ThreadFilesystemModeReadOnly,
+				},
+			}}
+			o := newDrainOrchestrator(messages, sessions, jobs, threads)
+			session := &models.Session{ID: sessionID, OrgID: orgID, Origin: models.SessionOriginCodeReview}
+
+			o.drainQueuedMessages(context.Background(), session, processed, &processedThreadID, zerolog.Nop())
+
+			require.Empty(t, jobs.enqueues, "a non-drainable code-review prompt must not be redispatched by a sibling's post-turn queue drain")
+			require.Empty(t, threads.clearedThreadIDs, "skipped reviewer messages should retain their pending count for auditability")
+			require.Equal(t, 1, threads.listBySessionCalls, "queue drain should batch all reviewer thread states into one store read")
+		})
+	}
 }
 
 func TestDrainQueuedMessages_ThreadScopeClearsAndEnqueues(t *testing.T) {

--- a/internal/services/agent/orchestrator_drain_internal_test.go
+++ b/internal/services/agent/orchestrator_drain_internal_test.go
@@ -475,6 +475,7 @@ func TestDrainQueuedMessages_SkipsNonDrainableCodeReviewReviewerThread(t *testin
 	}{
 		{name: "pending reviewer", status: models.ThreadStatusPending},
 		{name: "running reviewer", status: models.ThreadStatusRunning},
+		{name: "reviewer awaiting human input", status: models.ThreadStatusAwaitingInput},
 		{name: "completed reviewer", status: models.ThreadStatusCompleted},
 		{name: "failed reviewer", status: models.ThreadStatusFailed},
 		{name: "cancelled reviewer", status: models.ThreadStatusCancelled},

--- a/internal/services/agent/orchestrator_test.go
+++ b/internal/services/agent/orchestrator_test.go
@@ -1271,6 +1271,12 @@ type mockJobStore struct {
 	clearedPlacementJobID          uuid.UUID
 	clearedPlacementLockToken      uuid.UUID
 	clearSandboxPlacementCalls     int
+	reserveRetryJobID              uuid.UUID
+	reserveRetryLockToken          uuid.UUID
+	reserveRetryExcludedNodeID     string
+	reserveSandboxRetryCalls       int
+	reserveRetryResult             *db.SandboxRoutingResult
+	reserveRetryErr                error
 }
 
 func (m *mockJobStore) Enqueue(ctx context.Context, orgID uuid.UUID, queue, jobType string, payload any, priority int, dedupeKey *string) (uuid.UUID, error) {
@@ -1325,6 +1331,26 @@ func (m *mockJobStore) ClearSandboxRoutingPlacementWithLease(_ context.Context, 
 	m.clearedPlacementLockToken = lockToken
 	m.clearSandboxPlacementCalls++
 	return true, nil
+}
+
+func (m *mockJobStore) ReserveSandboxSlotForRetry(_ context.Context, jobID, lockToken uuid.UUID, excludeNodeID string) (*db.SandboxRoutingResult, error) {
+	return m.RerouteSandboxAfterStartupFailure(context.Background(), jobID, lockToken, excludeNodeID)
+}
+
+func (m *mockJobStore) RerouteSandboxAfterStartupFailure(_ context.Context, jobID, lockToken uuid.UUID, excludeNodeID string) (*db.SandboxRoutingResult, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.reserveRetryJobID = jobID
+	m.reserveRetryLockToken = lockToken
+	m.reserveRetryExcludedNodeID = excludeNodeID
+	m.reserveSandboxRetryCalls++
+	if m.reserveRetryErr != nil {
+		return nil, m.reserveRetryErr
+	}
+	if m.reserveRetryResult != nil {
+		return m.reserveRetryResult, nil
+	}
+	return &db.SandboxRoutingResult{Reason: db.SandboxRoutingReasonFleetCapacity}, nil
 }
 
 func (m *mockJobStore) getEnqueued() []string {
@@ -4316,7 +4342,7 @@ func TestRunAgent_SandboxCleanupOnCreateFailure(t *testing.T) {
 	}
 
 	jobID, lockToken := uuid.New(), uuid.New()
-	ctx := jobctx.WithLockToken(jobctx.WithJobID(context.Background(), jobID), lockToken)
+	ctx := jobctx.WithWorkerNodeID(jobctx.WithLockToken(jobctx.WithJobID(context.Background(), jobID), lockToken), "worker-a")
 	orch := buildOrchestrator(d)
 	err := orch.RunAgent(ctx, run)
 	require.Error(t, err)
@@ -4334,10 +4360,12 @@ func TestRunAgent_SandboxCleanupOnCreateFailure(t *testing.T) {
 		}
 	}
 	require.True(t, foundFailed)
-	require.Equal(t, 1, d.jobs.clearSandboxPlacementCalls, "sandbox creation failure should clear the durable worker placement")
-	require.Equal(t, jobID, d.jobs.clearedPlacementJobID, "placement cleanup should target the current job")
-	require.Equal(t, lockToken, d.jobs.clearedPlacementLockToken, "placement cleanup should be fenced to the current attempt")
+	require.Equal(t, 1, d.jobs.reserveSandboxRetryCalls, "sandbox creation failure should atomically reroute the durable placement")
+	require.Equal(t, jobID, d.jobs.reserveRetryJobID, "rerouting should target the current job")
+	require.Equal(t, lockToken, d.jobs.reserveRetryLockToken, "rerouting should be fenced to the current attempt")
+	require.Equal(t, "worker-a", d.jobs.reserveRetryExcludedNodeID, "rerouting should exclude the failed worker capacity node")
 	require.Equal(t, 0, d.jobs.releaseSandboxReservationCalls, "failed creation should not clear only the slot and leave worker affinity behind")
+	require.Equal(t, 0, d.jobs.clearSandboxPlacementCalls, "successful atomic rerouting should not need the compatibility clearing fallback")
 }
 
 func TestRunAgent_SandboxCleanupOnCloneFailure(t *testing.T) {
@@ -8511,7 +8539,7 @@ func TestContinueSession_AuthSocketClosedOnHydrateFailure(t *testing.T) {
 	}
 
 	jobID, lockToken := uuid.New(), uuid.New()
-	ctx := jobctx.WithLockToken(jobctx.WithJobID(context.Background(), jobID), lockToken)
+	ctx := jobctx.WithWorkerNodeID(jobctx.WithLockToken(jobctx.WithJobID(context.Background(), jobID), lockToken), "worker-a")
 	orch := buildOrchestrator(d)
 	err := orch.ContinueSession(ctx, session, nil)
 	require.Error(t, err, "ContinueSession should propagate the hydrate failure")
@@ -8519,10 +8547,12 @@ func TestContinueSession_AuthSocketClosedOnHydrateFailure(t *testing.T) {
 
 	require.Equal(t, 1, authStub.listenCalls, "auth socket must be opened before hydrate")
 	require.Equal(t, 1, authStub.closeCalls, "auth socket must be closed when hydrate fails after the listener was opened")
-	require.Equal(t, 1, d.jobs.clearSandboxPlacementCalls, "hydrate failure should clear the durable worker placement")
-	require.Equal(t, jobID, d.jobs.clearedPlacementJobID, "hydrate cleanup should target the current job")
-	require.Equal(t, lockToken, d.jobs.clearedPlacementLockToken, "hydrate cleanup should be fenced to the current attempt")
+	require.Equal(t, 1, d.jobs.reserveSandboxRetryCalls, "hydrate failure should atomically reroute the durable placement")
+	require.Equal(t, jobID, d.jobs.reserveRetryJobID, "hydrate rerouting should target the current job")
+	require.Equal(t, lockToken, d.jobs.reserveRetryLockToken, "hydrate rerouting should be fenced to the current attempt")
+	require.Equal(t, "worker-a", d.jobs.reserveRetryExcludedNodeID, "hydrate rerouting should exclude the failed worker capacity node")
 	require.Equal(t, 0, d.jobs.releaseSandboxReservationCalls, "failed hydration should not retain worker affinity by clearing only its slot")
+	require.Equal(t, 0, d.jobs.clearSandboxPlacementCalls, "successful atomic rerouting should not need the compatibility clearing fallback")
 }
 
 func TestContinueSession_CreateFailureClearsRoutingPlacement(t *testing.T) {
@@ -8542,15 +8572,20 @@ func TestContinueSession_CreateFailureClearsRoutingPlacement(t *testing.T) {
 	d.provider.CreateFn = func(context.Context, agent.SandboxConfig) (*agent.Sandbox, error) {
 		return nil, errors.New("worker disk full")
 	}
+	d.jobs.reserveRetryErr = errors.New("routing unavailable")
 
 	jobID, lockToken := uuid.New(), uuid.New()
-	ctx := jobctx.WithLockToken(jobctx.WithJobID(context.Background(), jobID), lockToken)
+	ctx := jobctx.WithWorkerNodeID(jobctx.WithLockToken(jobctx.WithJobID(context.Background(), jobID), lockToken), "worker-a")
 	err := buildOrchestrator(d).ContinueSession(ctx, session, nil)
 
 	require.ErrorContains(t, err, "create sandbox", "ContinueSession should propagate the worker-local creation failure")
-	require.Equal(t, 1, d.jobs.clearSandboxPlacementCalls, "creation failure should clear the durable worker placement")
-	require.Equal(t, jobID, d.jobs.clearedPlacementJobID, "creation cleanup should target the current job")
-	require.Equal(t, lockToken, d.jobs.clearedPlacementLockToken, "creation cleanup should be fenced to the current attempt")
+	require.Equal(t, 1, d.jobs.reserveSandboxRetryCalls, "creation failure should first try to atomically reserve an alternate placement")
+	require.Equal(t, jobID, d.jobs.reserveRetryJobID, "alternate routing should target the current job")
+	require.Equal(t, lockToken, d.jobs.reserveRetryLockToken, "alternate routing should be fenced to the current attempt")
+	require.Equal(t, "worker-a", d.jobs.reserveRetryExcludedNodeID, "alternate routing should exclude the failed worker capacity node")
+	require.Equal(t, 1, d.jobs.clearSandboxPlacementCalls, "routing failure should fall back to clearing the stale worker placement")
+	require.Equal(t, jobID, d.jobs.clearedPlacementJobID, "fallback cleanup should target the current job")
+	require.Equal(t, lockToken, d.jobs.clearedPlacementLockToken, "fallback cleanup should be fenced to the current attempt")
 	require.Equal(t, 0, d.jobs.releaseSandboxReservationCalls, "failed creation should not retain worker affinity by clearing only its slot")
 }
 

--- a/internal/services/agent/orchestrator_test.go
+++ b/internal/services/agent/orchestrator_test.go
@@ -1265,6 +1265,12 @@ type mockJobStore struct {
 	releasedReservationJobID       uuid.UUID
 	releasedReservationLockToken   uuid.UUID
 	releaseSandboxReservationCalls int
+	releasedPlacementJobID         uuid.UUID
+	releasedPlacementLockToken     uuid.UUID
+	releaseSandboxPlacementCalls   int
+	clearedPlacementJobID          uuid.UUID
+	clearedPlacementLockToken      uuid.UUID
+	clearSandboxPlacementCalls     int
 }
 
 func (m *mockJobStore) Enqueue(ctx context.Context, orgID uuid.UUID, queue, jobType string, payload any, priority int, dedupeKey *string) (uuid.UUID, error) {
@@ -1300,6 +1306,24 @@ func (m *mockJobStore) ReleaseSandboxSlotReservationWithLease(_ context.Context,
 	m.releasedReservationJobID = jobID
 	m.releasedReservationLockToken = lockToken
 	m.releaseSandboxReservationCalls++
+	return true, nil
+}
+
+func (m *mockJobStore) ReleaseSandboxRoutingPlacementWithLease(_ context.Context, jobID, lockToken uuid.UUID) (bool, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.releasedPlacementJobID = jobID
+	m.releasedPlacementLockToken = lockToken
+	m.releaseSandboxPlacementCalls++
+	return true, nil
+}
+
+func (m *mockJobStore) ClearSandboxRoutingPlacementWithLease(_ context.Context, jobID, lockToken uuid.UUID) (bool, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.clearedPlacementJobID = jobID
+	m.clearedPlacementLockToken = lockToken
+	m.clearSandboxPlacementCalls++
 	return true, nil
 }
 
@@ -4291,8 +4315,10 @@ func TestRunAgent_SandboxCleanupOnCreateFailure(t *testing.T) {
 		return nil, errors.New("docker daemon not running")
 	}
 
+	jobID, lockToken := uuid.New(), uuid.New()
+	ctx := jobctx.WithLockToken(jobctx.WithJobID(context.Background(), jobID), lockToken)
 	orch := buildOrchestrator(d)
-	err := orch.RunAgent(context.Background(), run)
+	err := orch.RunAgent(ctx, run)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "create sandbox")
 
@@ -4308,6 +4334,10 @@ func TestRunAgent_SandboxCleanupOnCreateFailure(t *testing.T) {
 		}
 	}
 	require.True(t, foundFailed)
+	require.Equal(t, 1, d.jobs.clearSandboxPlacementCalls, "sandbox creation failure should clear the durable worker placement")
+	require.Equal(t, jobID, d.jobs.clearedPlacementJobID, "placement cleanup should target the current job")
+	require.Equal(t, lockToken, d.jobs.clearedPlacementLockToken, "placement cleanup should be fenced to the current attempt")
+	require.Equal(t, 0, d.jobs.releaseSandboxReservationCalls, "failed creation should not clear only the slot and leave worker affinity behind")
 }
 
 func TestRunAgent_SandboxCleanupOnCloneFailure(t *testing.T) {
@@ -8480,13 +8510,48 @@ func TestContinueSession_AuthSocketClosedOnHydrateFailure(t *testing.T) {
 		return hydrateErr
 	}
 
+	jobID, lockToken := uuid.New(), uuid.New()
+	ctx := jobctx.WithLockToken(jobctx.WithJobID(context.Background(), jobID), lockToken)
 	orch := buildOrchestrator(d)
-	err := orch.ContinueSession(context.Background(), session, nil)
+	err := orch.ContinueSession(ctx, session, nil)
 	require.Error(t, err, "ContinueSession should propagate the hydrate failure")
 	require.Contains(t, err.Error(), "hydrate sandbox", "ContinueSession should surface the hydrate failure")
 
 	require.Equal(t, 1, authStub.listenCalls, "auth socket must be opened before hydrate")
 	require.Equal(t, 1, authStub.closeCalls, "auth socket must be closed when hydrate fails after the listener was opened")
+	require.Equal(t, 1, d.jobs.clearSandboxPlacementCalls, "hydrate failure should clear the durable worker placement")
+	require.Equal(t, jobID, d.jobs.clearedPlacementJobID, "hydrate cleanup should target the current job")
+	require.Equal(t, lockToken, d.jobs.clearedPlacementLockToken, "hydrate cleanup should be fenced to the current attempt")
+	require.Equal(t, 0, d.jobs.releaseSandboxReservationCalls, "failed hydration should not retain worker affinity by clearing only its slot")
+}
+
+func TestContinueSession_CreateFailureClearsRoutingPlacement(t *testing.T) {
+	t.Parallel()
+
+	orgID := testOrg()
+	issue := testIssue(orgID)
+	session := testRun(orgID, issue.ID)
+	session.Status = models.SessionStatusIdle
+	session.CurrentTurn = 1
+
+	d := defaultDeps()
+	d.issues.issue = issue
+	d.messages.messages = []models.SessionMessage{
+		{ID: 1, SessionID: session.ID, OrgID: orgID, TurnNumber: 2, Role: models.MessageRoleUser, Content: "retry me"},
+	}
+	d.provider.CreateFn = func(context.Context, agent.SandboxConfig) (*agent.Sandbox, error) {
+		return nil, errors.New("worker disk full")
+	}
+
+	jobID, lockToken := uuid.New(), uuid.New()
+	ctx := jobctx.WithLockToken(jobctx.WithJobID(context.Background(), jobID), lockToken)
+	err := buildOrchestrator(d).ContinueSession(ctx, session, nil)
+
+	require.ErrorContains(t, err, "create sandbox", "ContinueSession should propagate the worker-local creation failure")
+	require.Equal(t, 1, d.jobs.clearSandboxPlacementCalls, "creation failure should clear the durable worker placement")
+	require.Equal(t, jobID, d.jobs.clearedPlacementJobID, "creation cleanup should target the current job")
+	require.Equal(t, lockToken, d.jobs.clearedPlacementLockToken, "creation cleanup should be fenced to the current attempt")
+	require.Equal(t, 0, d.jobs.releaseSandboxReservationCalls, "failed creation should not retain worker affinity by clearing only its slot")
 }
 
 func TestContinueSession_HydrateFailureCleanupUsesDetachedContext(t *testing.T) {

--- a/internal/services/agent/sandbox_capacity.go
+++ b/internal/services/agent/sandbox_capacity.go
@@ -40,8 +40,8 @@ type LiveSandboxCounter interface {
 // SharedSandboxCapacityStore coordinates final admission across processes that
 // share one worker node and Docker daemon.
 type SharedSandboxCapacityStore interface {
-	ReserveSandboxCapacity(ctx context.Context, nodeID string, jobID *uuid.UUID, workloadClass models.SandboxWorkloadClass, countLiveSandboxes func(context.Context) (int, error), effectiveMax int, expiresAt time.Time) (reservationID uuid.UUID, liveSandboxes, total int, acquired bool, err error)
-	ReleaseSandboxCapacity(ctx context.Context, nodeID string, reservationID uuid.UUID) error
+	ReserveSandboxCapacity(ctx context.Context, nodeID string, jobID, jobLockToken *uuid.UUID, workloadClass models.SandboxWorkloadClass, countLiveSandboxes func(context.Context) (int, error), effectiveMax int, expiresAt time.Time) (reservationID uuid.UUID, liveSandboxes, total int, acquired bool, err error)
+	ReleaseSandboxCapacity(ctx context.Context, nodeID string, reservationID uuid.UUID, jobLockToken *uuid.UUID) error
 }
 
 // SandboxPressureCleaner performs a best-effort local cleanup pass when a
@@ -73,6 +73,7 @@ type SandboxCapacityRequest struct {
 	SessionID     string
 	OrgID         string
 	JobID         *uuid.UUID
+	JobLockToken  *uuid.UUID
 	WorkloadClass models.SandboxWorkloadClass
 }
 
@@ -292,6 +293,7 @@ func (g *SandboxCapacityGate) acquireSharedReservation(
 		reservationCtx,
 		g.nodeID,
 		req.JobID,
+		req.JobLockToken,
 		req.WorkloadClass,
 		countLiveSandboxes,
 		effectiveMax,
@@ -342,6 +344,7 @@ func (g *SandboxCapacityGate) acquireSharedReservation(
 		gate:                g,
 		sandboxTurn:         sandboxTurnReservation,
 		sharedReservationID: reservationID,
+		jobLockToken:        req.JobLockToken,
 	}, false, nil
 }
 
@@ -435,6 +438,7 @@ type SandboxCapacityReservation struct {
 	gate                *SandboxCapacityGate
 	sandboxTurn         bool
 	sharedReservationID uuid.UUID
+	jobLockToken        *uuid.UUID
 	once                sync.Once
 }
 
@@ -475,7 +479,7 @@ func (r *SandboxCapacityReservation) Release() {
 func (r *SandboxCapacityReservation) releaseSharedReservation(ctx context.Context) error {
 	delay := defaultSharedSandboxReleaseRetryMin
 	for {
-		err := r.gate.sharedReservations.ReleaseSandboxCapacity(ctx, r.gate.nodeID, r.sharedReservationID)
+		err := r.gate.sharedReservations.ReleaseSandboxCapacity(ctx, r.gate.nodeID, r.sharedReservationID, r.jobLockToken)
 		if err == nil {
 			return nil
 		}

--- a/internal/services/agent/sandbox_capacity.go
+++ b/internal/services/agent/sandbox_capacity.go
@@ -300,7 +300,11 @@ func (g *SandboxCapacityGate) acquireSharedReservation(
 	cancel()
 	if err != nil {
 		wrapped := fmt.Errorf("%w: %w: reserve shared sandbox capacity: %w", ErrSandboxCapacity, ErrSandboxCapacityCoordination, err)
-		g.logCapacity(req, live, g.ReservedCount()).Err(err).Msg("failed to reserve shared sandbox capacity; rejecting sandbox admission")
+		g.logCapacity(req, live, g.ReservedCount()).
+			Bool("sandbox_capacity_coordination_failure", true).
+			Dur("shared_admission_timeout", g.sharedAdmissionTimeout).
+			Err(err).
+			Msg("failed to reserve shared sandbox capacity; rejecting sandbox admission")
 		return nil, false, wrapped
 	}
 	if !acquired {

--- a/internal/services/agent/sandbox_capacity.go
+++ b/internal/services/agent/sandbox_capacity.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/rs/zerolog"
 
 	"github.com/assembledhq/143/internal/models"
@@ -19,11 +20,19 @@ var ErrSandboxCapacity = errors.New("sandbox capacity reached")
 const (
 	defaultSandboxCapacityCountTimeout   = 2 * time.Second
 	defaultSandboxPressureCleanupTimeout = 5 * time.Second
+	defaultSharedSandboxReservationTTL   = 15 * time.Minute
 )
 
 // LiveSandboxCounter counts live sandbox containers on the local machine.
 type LiveSandboxCounter interface {
 	CountLiveSandboxes(ctx context.Context) (int, error)
+}
+
+// SharedSandboxCapacityStore coordinates final admission across processes that
+// share one worker node and Docker daemon.
+type SharedSandboxCapacityStore interface {
+	ReserveSandboxCapacity(ctx context.Context, nodeID string, jobID *uuid.UUID, workloadClass models.SandboxWorkloadClass, countLiveSandboxes func(context.Context) (int, error), effectiveMax int, expiresAt time.Time) (reservationID uuid.UUID, liveSandboxes, total int, acquired bool, err error)
+	ReleaseSandboxCapacity(ctx context.Context, reservationID uuid.UUID) error
 }
 
 // SandboxPressureCleaner performs a best-effort local cleanup pass when a
@@ -35,6 +44,7 @@ type SandboxPressureCleaner interface {
 // SandboxCapacityGateConfig configures local sandbox admission control.
 type SandboxCapacityGateConfig struct {
 	Counter                LiveSandboxCounter
+	SharedReservations     SharedSandboxCapacityStore
 	PressureCleaner        SandboxPressureCleaner
 	MaxActive              int
 	InteractiveReserved    int
@@ -49,6 +59,7 @@ type SandboxCapacityRequest struct {
 	Purpose       string
 	SessionID     string
 	OrgID         string
+	JobID         *uuid.UUID
 	WorkloadClass models.SandboxWorkloadClass
 }
 
@@ -66,6 +77,7 @@ type SandboxCapacitySnapshot struct {
 // live Docker count plus in-flight reservations.
 type SandboxCapacityGate struct {
 	counter             LiveSandboxCounter
+	sharedReservations  SharedSandboxCapacityStore
 	cleaner             SandboxPressureCleaner
 	maxActive           int
 	interactiveReserved int
@@ -93,6 +105,7 @@ func NewSandboxCapacityGate(cfg SandboxCapacityGateConfig) *SandboxCapacityGate 
 	}
 	return &SandboxCapacityGate{
 		counter:             cfg.Counter,
+		sharedReservations:  cfg.SharedReservations,
 		cleaner:             cfg.PressureCleaner,
 		maxActive:           cfg.MaxActive,
 		interactiveReserved: clampInteractiveSandboxReserve(cfg.MaxActive, cfg.InteractiveReserved),
@@ -161,6 +174,22 @@ func (g *SandboxCapacityGate) Acquire(ctx context.Context, req SandboxCapacityRe
 		return nil, err
 	}
 
+	effectiveMax := g.maxActive
+	if req.WorkloadClass == models.SandboxWorkloadClassCodeReview {
+		effectiveMax -= g.interactiveReserved
+	}
+	if g.sharedReservations != nil {
+		cleanedForPressure := false
+		for {
+			reservation, retry, err := g.acquireSharedReservation(ctx, req, effectiveMax, cleanedForPressure)
+			if retry {
+				cleanedForPressure = true
+				continue
+			}
+			return reservation, err
+		}
+	}
+
 	cleanedForPressure := false
 	for {
 		g.mu.Lock()
@@ -181,10 +210,6 @@ func (g *SandboxCapacityGate) Acquire(ctx context.Context, req SandboxCapacityRe
 		}
 
 		total := live + g.reserved
-		effectiveMax := g.maxActive
-		if req.WorkloadClass == models.SandboxWorkloadClassCodeReview {
-			effectiveMax -= g.interactiveReserved
-		}
 		if total >= effectiveMax {
 			reserved := g.reserved
 			cleaner := g.cleaner
@@ -217,6 +242,66 @@ func (g *SandboxCapacityGate) Acquire(ctx context.Context, req SandboxCapacityRe
 		g.logCapacity(req, live, reserved).Msg("sandbox capacity reserved")
 		return &SandboxCapacityReservation{gate: g, sandboxTurn: sandboxTurnReservation}, nil
 	}
+}
+
+func (g *SandboxCapacityGate) acquireSharedReservation(
+	ctx context.Context,
+	req SandboxCapacityRequest,
+	effectiveMax int,
+	cleanedForPressure bool,
+) (*SandboxCapacityReservation, bool, error) {
+	reservationCtx, cancel := context.WithTimeout(ctx, g.countTTL)
+	reservationID, live, total, acquired, err := g.sharedReservations.ReserveSandboxCapacity(
+		reservationCtx,
+		g.nodeID,
+		req.JobID,
+		req.WorkloadClass,
+		g.counter.CountLiveSandboxes,
+		effectiveMax,
+		time.Now().Add(defaultSharedSandboxReservationTTL),
+	)
+	cancel()
+	if err != nil {
+		wrapped := fmt.Errorf("%w: reserve shared sandbox capacity: %w", ErrSandboxCapacity, err)
+		g.logCapacity(req, live, g.ReservedCount()).Err(err).Msg("failed to reserve shared sandbox capacity; rejecting sandbox admission")
+		return nil, false, wrapped
+	}
+	if !acquired {
+		g.mu.Lock()
+		cleaner := g.cleaner
+		g.mu.Unlock()
+		physicallyFull := live >= g.maxActive
+		if physicallyFull && !cleanedForPressure && cleaner != nil {
+			cleanCtx, cleanCancel := context.WithTimeout(ctx, g.cleanTTL)
+			cleanErr := cleaner.ReapForCapacity(cleanCtx, time.Now())
+			cleanCancel()
+			if cleanErr != nil {
+				g.logCapacity(req, live, g.ReservedCount()).Err(cleanErr).Msg("sandbox pressure cleanup failed before shared admission retry")
+			} else {
+				g.logCapacity(req, live, g.ReservedCount()).Msg("sandbox pressure cleanup completed before shared admission retry")
+			}
+			return nil, true, nil
+		}
+		capacityErr := fmt.Errorf("%w: %d/%d sandboxes active or reserved for %s workload", ErrSandboxCapacity, total, effectiveMax, req.WorkloadClass)
+		g.logCapacity(req, live, g.ReservedCount()).Msg("shared sandbox capacity reached; rejecting sandbox admission")
+		return nil, false, capacityErr
+	}
+
+	g.mu.Lock()
+	g.reserved++
+	sandboxTurnReservation := isSandboxTurnCapacityPurpose(req.Purpose)
+	if sandboxTurnReservation {
+		g.sandboxTurnReserved++
+	}
+	reserved := g.reserved
+	g.mu.Unlock()
+
+	g.logCapacity(req, live, reserved).Msg("shared sandbox capacity reserved")
+	return &SandboxCapacityReservation{
+		gate:                g,
+		sandboxTurn:         sandboxTurnReservation,
+		sharedReservationID: reservationID,
+	}, false, nil
 }
 
 // Snapshot returns a best-effort point-in-time capacity view for metadata.
@@ -306,9 +391,10 @@ func (g *SandboxCapacityGate) HasSpeculativeHeadroom(ctx context.Context, minFre
 
 // SandboxCapacityReservation releases a previously acquired slot.
 type SandboxCapacityReservation struct {
-	gate        *SandboxCapacityGate
-	sandboxTurn bool
-	once        sync.Once
+	gate                *SandboxCapacityGate
+	sandboxTurn         bool
+	sharedReservationID uuid.UUID
+	once                sync.Once
 }
 
 // Release returns the reservation to the gate. It is safe to call repeatedly.
@@ -318,7 +404,6 @@ func (r *SandboxCapacityReservation) Release() {
 	}
 	r.once.Do(func() {
 		r.gate.mu.Lock()
-		defer r.gate.mu.Unlock()
 		if r.gate.reserved > 0 {
 			r.gate.reserved--
 		}
@@ -326,5 +411,17 @@ func (r *SandboxCapacityReservation) Release() {
 			r.gate.sandboxTurnReserved--
 		}
 		r.gate.releaseGeneration++
+		r.gate.mu.Unlock()
+
+		if r.sharedReservationID != uuid.Nil && r.gate.sharedReservations != nil {
+			releaseCtx, cancel := context.WithTimeout(context.Background(), defaultSandboxCapacityCountTimeout)
+			defer cancel()
+			if err := r.gate.sharedReservations.ReleaseSandboxCapacity(releaseCtx, r.sharedReservationID); err != nil {
+				r.gate.logger.Warn().Err(err).
+					Str("node_id", r.gate.nodeID).
+					Str("reservation_id", r.sharedReservationID.String()).
+					Msg("failed to release shared sandbox capacity reservation")
+			}
+		}
 	})
 }

--- a/internal/services/agent/sandbox_capacity.go
+++ b/internal/services/agent/sandbox_capacity.go
@@ -28,6 +28,8 @@ const (
 	defaultSandboxPressureCleanupTimeout = 5 * time.Second
 	defaultSharedSandboxAdmissionTimeout = 10 * time.Second
 	defaultSharedSandboxReservationTTL   = 15 * time.Minute
+	defaultSharedSandboxReleaseRetryMin  = 100 * time.Millisecond
+	defaultSharedSandboxReleaseRetryMax  = time.Second
 )
 
 // LiveSandboxCounter counts live sandbox containers on the local machine.
@@ -39,7 +41,7 @@ type LiveSandboxCounter interface {
 // share one worker node and Docker daemon.
 type SharedSandboxCapacityStore interface {
 	ReserveSandboxCapacity(ctx context.Context, nodeID string, jobID *uuid.UUID, workloadClass models.SandboxWorkloadClass, countLiveSandboxes func(context.Context) (int, error), effectiveMax int, expiresAt time.Time) (reservationID uuid.UUID, liveSandboxes, total int, acquired bool, err error)
-	ReleaseSandboxCapacity(ctx context.Context, reservationID uuid.UUID) error
+	ReleaseSandboxCapacity(ctx context.Context, nodeID string, reservationID uuid.UUID) error
 }
 
 // SandboxPressureCleaner performs a best-effort local cleanup pass when a
@@ -440,9 +442,14 @@ func (r *SandboxCapacityReservation) Release() {
 		r.gate.mu.Unlock()
 
 		if r.sharedReservationID != uuid.Nil && r.gate.sharedReservations != nil {
-			releaseCtx, cancel := context.WithTimeout(context.Background(), defaultSandboxCapacityCountTimeout)
+			// Release takes the same per-node database lock as admission. Give it
+			// the full coordination budget rather than the shorter Docker-count
+			// budget so a concurrent admission can finish first, and retry
+			// transient database failures within that budget so a one-off blip
+			// does not strand the slot until the lease TTL expires.
+			releaseCtx, cancel := context.WithTimeout(context.Background(), r.gate.sharedAdmissionTimeout)
 			defer cancel()
-			if err := r.gate.sharedReservations.ReleaseSandboxCapacity(releaseCtx, r.sharedReservationID); err != nil {
+			if err := r.releaseSharedReservation(releaseCtx); err != nil {
 				r.gate.logger.Warn().Err(err).
 					Str("node_id", r.gate.nodeID).
 					Str("reservation_id", r.sharedReservationID.String()).
@@ -450,4 +457,21 @@ func (r *SandboxCapacityReservation) Release() {
 			}
 		}
 	})
+}
+
+func (r *SandboxCapacityReservation) releaseSharedReservation(ctx context.Context) error {
+	delay := defaultSharedSandboxReleaseRetryMin
+	for {
+		err := r.gate.sharedReservations.ReleaseSandboxCapacity(ctx, r.gate.nodeID, r.sharedReservationID)
+		if err == nil {
+			return nil
+		}
+
+		select {
+		case <-ctx.Done():
+			return errors.Join(err, ctx.Err())
+		case <-time.After(delay):
+		}
+		delay = min(delay*2, defaultSharedSandboxReleaseRetryMax)
+	}
 }

--- a/internal/services/agent/sandbox_capacity.go
+++ b/internal/services/agent/sandbox_capacity.go
@@ -17,9 +17,16 @@ import (
 // more sandbox container right now. Callers should treat it as transient.
 var ErrSandboxCapacity = errors.New("sandbox capacity reached")
 
+// ErrSandboxCapacityCoordination distinguishes a retry caused by the shared
+// admission fence being unavailable from a normal at-capacity rejection.
+// Coordination failures also wrap ErrSandboxCapacity so worker retry policy
+// remains conservative and does not consume the job attempt.
+var ErrSandboxCapacityCoordination = errors.New("sandbox capacity coordination unavailable")
+
 const (
 	defaultSandboxCapacityCountTimeout   = 2 * time.Second
 	defaultSandboxPressureCleanupTimeout = 5 * time.Second
+	defaultSharedSandboxAdmissionTimeout = 10 * time.Second
 	defaultSharedSandboxReservationTTL   = 15 * time.Minute
 )
 
@@ -43,12 +50,16 @@ type SandboxPressureCleaner interface {
 
 // SandboxCapacityGateConfig configures local sandbox admission control.
 type SandboxCapacityGateConfig struct {
-	Counter                LiveSandboxCounter
+	Counter LiveSandboxCounter
+	// SharedReservations is required in production so every process on the
+	// worker uses the same final fence. A nil value retains the in-process path
+	// for isolated embedders and unit tests that do not have Postgres.
 	SharedReservations     SharedSandboxCapacityStore
 	PressureCleaner        SandboxPressureCleaner
 	MaxActive              int
 	InteractiveReserved    int
 	CountTimeout           time.Duration
+	SharedAdmissionTimeout time.Duration
 	PressureCleanupTimeout time.Duration
 	NodeID                 string
 	Logger                 zerolog.Logger
@@ -76,15 +87,16 @@ type SandboxCapacitySnapshot struct {
 // SandboxCapacityGate gates new local sandbox creation against the current
 // live Docker count plus in-flight reservations.
 type SandboxCapacityGate struct {
-	counter             LiveSandboxCounter
-	sharedReservations  SharedSandboxCapacityStore
-	cleaner             SandboxPressureCleaner
-	maxActive           int
-	interactiveReserved int
-	countTTL            time.Duration
-	cleanTTL            time.Duration
-	nodeID              string
-	logger              zerolog.Logger
+	counter                LiveSandboxCounter
+	sharedReservations     SharedSandboxCapacityStore
+	cleaner                SandboxPressureCleaner
+	maxActive              int
+	interactiveReserved    int
+	countTTL               time.Duration
+	sharedAdmissionTimeout time.Duration
+	cleanTTL               time.Duration
+	nodeID                 string
+	logger                 zerolog.Logger
 
 	mu                  sync.Mutex
 	reserved            int
@@ -99,20 +111,25 @@ func NewSandboxCapacityGate(cfg SandboxCapacityGateConfig) *SandboxCapacityGate 
 	if countTTL <= 0 {
 		countTTL = defaultSandboxCapacityCountTimeout
 	}
+	sharedAdmissionTimeout := cfg.SharedAdmissionTimeout
+	if sharedAdmissionTimeout <= 0 {
+		sharedAdmissionTimeout = defaultSharedSandboxAdmissionTimeout
+	}
 	cleanTTL := cfg.PressureCleanupTimeout
 	if cleanTTL <= 0 {
 		cleanTTL = defaultSandboxPressureCleanupTimeout
 	}
 	return &SandboxCapacityGate{
-		counter:             cfg.Counter,
-		sharedReservations:  cfg.SharedReservations,
-		cleaner:             cfg.PressureCleaner,
-		maxActive:           cfg.MaxActive,
-		interactiveReserved: clampInteractiveSandboxReserve(cfg.MaxActive, cfg.InteractiveReserved),
-		countTTL:            countTTL,
-		cleanTTL:            cleanTTL,
-		nodeID:              cfg.NodeID,
-		logger:              cfg.Logger,
+		counter:                cfg.Counter,
+		sharedReservations:     cfg.SharedReservations,
+		cleaner:                cfg.PressureCleaner,
+		maxActive:              cfg.MaxActive,
+		interactiveReserved:    clampInteractiveSandboxReserve(cfg.MaxActive, cfg.InteractiveReserved),
+		countTTL:               countTTL,
+		sharedAdmissionTimeout: sharedAdmissionTimeout,
+		cleanTTL:               cleanTTL,
+		nodeID:                 cfg.NodeID,
+		logger:                 cfg.Logger,
 	}
 }
 
@@ -213,7 +230,7 @@ func (g *SandboxCapacityGate) Acquire(ctx context.Context, req SandboxCapacityRe
 		if total >= effectiveMax {
 			reserved := g.reserved
 			cleaner := g.cleaner
-			physicallyFull := total >= g.maxActive
+			physicallyFull := live >= g.maxActive
 			g.mu.Unlock()
 			if physicallyFull && !cleanedForPressure && cleaner != nil {
 				cleanedForPressure = true
@@ -250,19 +267,28 @@ func (g *SandboxCapacityGate) acquireSharedReservation(
 	effectiveMax int,
 	cleanedForPressure bool,
 ) (*SandboxCapacityReservation, bool, error) {
-	reservationCtx, cancel := context.WithTimeout(ctx, g.countTTL)
+	// The cross-process transaction may wait behind another admission's node
+	// lock, so it needs a wider budget than one Docker count. Keep the actual
+	// container-runtime call bounded by countTTL once this admission owns the
+	// shared lock.
+	reservationCtx, cancel := context.WithTimeout(ctx, g.sharedAdmissionTimeout)
+	countLiveSandboxes := func(countCtx context.Context) (int, error) {
+		boundedCountCtx, countCancel := context.WithTimeout(countCtx, g.countTTL)
+		defer countCancel()
+		return g.counter.CountLiveSandboxes(boundedCountCtx)
+	}
 	reservationID, live, total, acquired, err := g.sharedReservations.ReserveSandboxCapacity(
 		reservationCtx,
 		g.nodeID,
 		req.JobID,
 		req.WorkloadClass,
-		g.counter.CountLiveSandboxes,
+		countLiveSandboxes,
 		effectiveMax,
 		time.Now().Add(defaultSharedSandboxReservationTTL),
 	)
 	cancel()
 	if err != nil {
-		wrapped := fmt.Errorf("%w: reserve shared sandbox capacity: %w", ErrSandboxCapacity, err)
+		wrapped := fmt.Errorf("%w: %w: reserve shared sandbox capacity: %w", ErrSandboxCapacity, ErrSandboxCapacityCoordination, err)
 		g.logCapacity(req, live, g.ReservedCount()).Err(err).Msg("failed to reserve shared sandbox capacity; rejecting sandbox admission")
 		return nil, false, wrapped
 	}

--- a/internal/services/agent/sandbox_capacity.go
+++ b/internal/services/agent/sandbox_capacity.go
@@ -10,6 +10,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/rs/zerolog"
 
+	"github.com/assembledhq/143/internal/db"
 	"github.com/assembledhq/143/internal/models"
 )
 
@@ -27,9 +28,17 @@ const (
 	defaultSandboxCapacityCountTimeout   = 2 * time.Second
 	defaultSandboxPressureCleanupTimeout = 5 * time.Second
 	defaultSharedSandboxAdmissionTimeout = 10 * time.Second
-	defaultSharedSandboxReservationTTL   = 15 * time.Minute
-	defaultSharedSandboxReleaseRetryMin  = 100 * time.Millisecond
-	defaultSharedSandboxReleaseRetryMax  = time.Second
+	// Non-job (preview) leases have no renewal path, so they keep a long
+	// conservative TTL that outlives slow image pulls.
+	defaultSharedSandboxReservationTTL = 15 * time.Minute
+	// Job-backed leases are renewed by the job-lease heartbeat (~20s) in
+	// internal/db, so a short TTL only ever fences attempts whose process
+	// died. A replacement attempt blocked on a stale lease therefore waits
+	// minutes, not the preview TTL. Must stay in sync with
+	// sandboxCapacityJobLeaseRenewalTTL in internal/db.
+	defaultSharedSandboxJobReservationTTL = 2 * time.Minute
+	defaultSharedSandboxReleaseRetryMin   = 100 * time.Millisecond
+	defaultSharedSandboxReleaseRetryMax   = time.Second
 )
 
 // LiveSandboxCounter counts live sandbox containers on the local machine.
@@ -289,6 +298,10 @@ func (g *SandboxCapacityGate) acquireSharedReservation(
 		defer countCancel()
 		return g.counter.CountLiveSandboxes(boundedCountCtx)
 	}
+	leaseTTL := defaultSharedSandboxReservationTTL
+	if req.JobID != nil {
+		leaseTTL = defaultSharedSandboxJobReservationTTL
+	}
 	reservationID, live, total, acquired, err := g.sharedReservations.ReserveSandboxCapacity(
 		reservationCtx,
 		g.nodeID,
@@ -297,10 +310,21 @@ func (g *SandboxCapacityGate) acquireSharedReservation(
 		req.WorkloadClass,
 		countLiveSandboxes,
 		effectiveMax,
-		time.Now().Add(defaultSharedSandboxReservationTTL),
+		time.Now().Add(leaseTTL),
 	)
 	cancel()
 	if err != nil {
+		var attemptConflict *db.SandboxCapacityAttemptConflictError
+		if errors.As(err, &attemptConflict) {
+			// An expected fencing condition, not a coordination failure: a
+			// prior attempt's lease is still live and the caller will wait for
+			// its persisted deadline. Skip the alerting signal so it keeps
+			// meaning "the shared fence itself is broken".
+			g.logCapacity(req, live, g.ReservedCount()).
+				Time("prior_attempt_lease_expires_at", attemptConflict.ExpiresAt).
+				Msg("prior attempt still holds the shared sandbox lease; deferring admission")
+			return nil, false, fmt.Errorf("%w: reserve shared sandbox capacity: %w", ErrSandboxCapacity, err)
+		}
 		wrapped := fmt.Errorf("%w: %w: reserve shared sandbox capacity: %w", ErrSandboxCapacity, ErrSandboxCapacityCoordination, err)
 		g.logCapacity(req, live, g.ReservedCount()).
 			Bool("sandbox_capacity_coordination_failure", true).

--- a/internal/services/agent/sandbox_capacity.go
+++ b/internal/services/agent/sandbox_capacity.go
@@ -152,6 +152,15 @@ func (g *SandboxCapacityGate) InteractiveReserved() int {
 	return g.interactiveReserved
 }
 
+// CapacityNodeID returns the physical-host identity used by the shared
+// admission fence. Multiple worker generations on one Docker host share it.
+func (g *SandboxCapacityGate) CapacityNodeID() string {
+	if g == nil {
+		return ""
+	}
+	return g.nodeID
+}
+
 // SetPressureCleaner installs or replaces the cleanup hook used when a worker
 // host is full. It is safe to call during startup before workers begin polling.
 func (g *SandboxCapacityGate) SetPressureCleaner(cleaner SandboxPressureCleaner) {

--- a/internal/services/agent/sandbox_capacity_test.go
+++ b/internal/services/agent/sandbox_capacity_test.go
@@ -35,6 +35,25 @@ type fakeSharedSandboxCapacityStore struct {
 	releaseCalls  atomic.Int64
 }
 
+type contextWaitingSharedSandboxCapacityStore struct{}
+
+func (contextWaitingSharedSandboxCapacityStore) ReserveSandboxCapacity(
+	ctx context.Context,
+	_ string,
+	_ *uuid.UUID,
+	_ models.SandboxWorkloadClass,
+	_ func(context.Context) (int, error),
+	_ int,
+	_ time.Time,
+) (uuid.UUID, int, int, bool, error) {
+	<-ctx.Done()
+	return uuid.Nil, 0, 0, false, ctx.Err()
+}
+
+func (contextWaitingSharedSandboxCapacityStore) ReleaseSandboxCapacity(context.Context, uuid.UUID) error {
+	return nil
+}
+
 func (f *fakeSharedSandboxCapacityStore) ReserveSandboxCapacity(ctx context.Context, _ string, jobID *uuid.UUID, workloadClass models.SandboxWorkloadClass, countLiveSandboxes func(context.Context) (int, error), effectiveMax int, _ time.Time) (uuid.UUID, int, int, bool, error) {
 	f.reserveCalls.Add(1)
 	f.jobID = jobID
@@ -275,6 +294,7 @@ func TestSandboxCapacityGate_AcquireFailsClosedWhenSharedReservationFails(t *tes
 	reservation, err := gate.Acquire(context.Background(), agent.SandboxCapacityRequest{Purpose: "branch_preview"})
 
 	require.ErrorIs(t, err, agent.ErrSandboxCapacity, "shared reservation failures should fail closed")
+	require.ErrorIs(t, err, agent.ErrSandboxCapacityCoordination, "shared reservation failures should be distinguishable from genuine saturation")
 	require.ErrorContains(t, err, "database unavailable", "capacity error should retain the shared reservation failure")
 	require.Nil(t, reservation, "failed shared reservations should not reserve local capacity")
 }
@@ -479,6 +499,31 @@ func TestSandboxCapacityGate_AcquireUsesCountTimeout(t *testing.T) {
 	require.Nil(t, reservation, "Acquire should not return a reservation when counting times out")
 	require.Less(t, time.Since(started), 500*time.Millisecond, "Acquire should use the configured short count timeout instead of the caller's long-lived context")
 	require.Equal(t, int64(1), counter.calls.Load(), "Acquire should invoke the live counter once")
+}
+
+func TestSandboxCapacityGate_AcquireUsesSeparateSharedAdmissionTimeout(t *testing.T) {
+	t.Parallel()
+
+	gate := agent.NewSandboxCapacityGate(agent.SandboxCapacityGateConfig{
+		Counter:                &fakeLiveSandboxCounter{},
+		SharedReservations:     contextWaitingSharedSandboxCapacityStore{},
+		MaxActive:              2,
+		CountTimeout:           20 * time.Millisecond,
+		SharedAdmissionTimeout: 80 * time.Millisecond,
+		NodeID:                 "worker-1",
+		Logger:                 zerolog.Nop(),
+	})
+
+	started := time.Now()
+	reservation, err := gate.Acquire(context.Background(), agent.SandboxCapacityRequest{Purpose: "agent_run"})
+	elapsed := time.Since(started)
+
+	require.ErrorIs(t, err, agent.ErrSandboxCapacity, "shared admission timeout should remain retryable as worker capacity")
+	require.ErrorIs(t, err, agent.ErrSandboxCapacityCoordination, "shared admission timeout should be distinguishable from genuine saturation")
+	require.ErrorIs(t, err, context.DeadlineExceeded, "shared admission should retain its timeout cause")
+	require.Nil(t, reservation, "timed-out shared admission should not return a reservation")
+	require.GreaterOrEqual(t, elapsed, 50*time.Millisecond, "shared lock contention should not consume only the shorter Docker count budget")
+	require.Less(t, elapsed, 500*time.Millisecond, "shared admission should remain bounded by its dedicated timeout")
 }
 
 func TestSandboxCapacityGate_ReleaseDoesNotWaitForBlockedCount(t *testing.T) {

--- a/internal/services/agent/sandbox_capacity_test.go
+++ b/internal/services/agent/sandbox_capacity_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/require"
 
+	"github.com/assembledhq/143/internal/db"
 	"github.com/assembledhq/143/internal/models"
 	"github.com/assembledhq/143/internal/services/agent"
 )
@@ -32,6 +33,7 @@ type fakeSharedSandboxCapacityStore struct {
 	workloadClass models.SandboxWorkloadClass
 	live          int
 	effectiveMax  int
+	expiresAt     time.Time
 	releasedNode  string
 	releasedID    uuid.UUID
 	releasedToken *uuid.UUID
@@ -62,12 +64,13 @@ func (contextWaitingSharedSandboxCapacityStore) ReleaseSandboxCapacity(context.C
 	return nil
 }
 
-func (f *fakeSharedSandboxCapacityStore) ReserveSandboxCapacity(ctx context.Context, _ string, jobID, jobLockToken *uuid.UUID, workloadClass models.SandboxWorkloadClass, countLiveSandboxes func(context.Context) (int, error), effectiveMax int, _ time.Time) (uuid.UUID, int, int, bool, error) {
+func (f *fakeSharedSandboxCapacityStore) ReserveSandboxCapacity(ctx context.Context, _ string, jobID, jobLockToken *uuid.UUID, workloadClass models.SandboxWorkloadClass, countLiveSandboxes func(context.Context) (int, error), effectiveMax int, expiresAt time.Time) (uuid.UUID, int, int, bool, error) {
 	f.reserveCalls.Add(1)
 	f.jobID = jobID
 	f.jobLockToken = jobLockToken
 	f.workloadClass = workloadClass
 	f.effectiveMax = effectiveMax
+	f.expiresAt = expiresAt
 	if f.err != nil {
 		return uuid.Nil, 0, f.total, false, f.err
 	}
@@ -348,6 +351,75 @@ func TestSandboxCapacityGate_AcquireFailsClosedWhenSharedReservationFails(t *tes
 	require.Nil(t, reservation, "failed shared reservations should not reserve local capacity")
 	require.Contains(t, logs.String(), `"sandbox_capacity_coordination_failure":true`, "coordination failures should emit an alertable structured signal")
 	require.Contains(t, logs.String(), `"shared_admission_timeout":10000`, "coordination failures should report the configured admission budget in milliseconds")
+}
+
+func TestSandboxCapacityGate_JobBackedLeaseUsesShortRenewableTTL(t *testing.T) {
+	t.Parallel()
+
+	jobID, lockToken := uuid.New(), uuid.New()
+	shared := &fakeSharedSandboxCapacityStore{reservationID: uuid.New(), total: 1, acquired: true}
+	gate := agent.NewSandboxCapacityGate(agent.SandboxCapacityGateConfig{
+		Counter:            &fakeLiveSandboxCounter{},
+		SharedReservations: shared,
+		MaxActive:          2,
+		NodeID:             "worker-1",
+		Logger:             zerolog.Nop(),
+	})
+
+	before := time.Now()
+	reservation, err := gate.Acquire(context.Background(), agent.SandboxCapacityRequest{Purpose: "continue_session", JobID: &jobID, JobLockToken: &lockToken})
+	require.NoError(t, err, "job-backed admission should acquire a shared lease")
+	defer reservation.Release()
+
+	ttl := shared.expiresAt.Sub(before)
+	require.Greater(t, ttl, time.Minute, "job-backed lease should keep a TTL comfortably above the ~20s renewal cadence")
+	require.LessOrEqual(t, ttl, 3*time.Minute, "job-backed lease must stay short so a dead attempt fences its replacement for minutes, not the preview TTL")
+}
+
+func TestSandboxCapacityGate_PreviewLeaseKeepsConservativeTTL(t *testing.T) {
+	t.Parallel()
+
+	shared := &fakeSharedSandboxCapacityStore{reservationID: uuid.New(), total: 1, acquired: true}
+	gate := agent.NewSandboxCapacityGate(agent.SandboxCapacityGateConfig{
+		Counter:            &fakeLiveSandboxCounter{},
+		SharedReservations: shared,
+		MaxActive:          2,
+		NodeID:             "worker-1",
+		Logger:             zerolog.Nop(),
+	})
+
+	before := time.Now()
+	reservation, err := gate.Acquire(context.Background(), agent.SandboxCapacityRequest{Purpose: "branch_preview"})
+	require.NoError(t, err, "preview admission should acquire a shared lease")
+	defer reservation.Release()
+
+	require.Greater(t, shared.expiresAt.Sub(before), 10*time.Minute, "preview leases have no renewal path and must keep the long conservative TTL")
+}
+
+func TestSandboxCapacityGate_AttemptConflictSkipsCoordinationSignal(t *testing.T) {
+	t.Parallel()
+
+	jobID, lockToken := uuid.New(), uuid.New()
+	conflict := &db.SandboxCapacityAttemptConflictError{ExpiresAt: time.Now().Add(90 * time.Second)}
+	shared := &fakeSharedSandboxCapacityStore{err: conflict}
+	var logs bytes.Buffer
+	gate := agent.NewSandboxCapacityGate(agent.SandboxCapacityGateConfig{
+		Counter:            &fakeLiveSandboxCounter{},
+		SharedReservations: shared,
+		MaxActive:          2,
+		NodeID:             "worker-1",
+		Logger:             zerolog.New(&logs),
+	})
+
+	reservation, err := gate.Acquire(context.Background(), agent.SandboxCapacityRequest{Purpose: "continue_session", JobID: &jobID, JobLockToken: &lockToken})
+
+	require.Nil(t, reservation, "a fenced prior attempt must block admission")
+	require.ErrorIs(t, err, agent.ErrSandboxCapacity, "the conflict should keep the conservative capacity sentinel for retry policy")
+	require.NotErrorIs(t, err, agent.ErrSandboxCapacityCoordination, "an expected fencing condition is not a coordination failure")
+	var conflictErr *db.SandboxCapacityAttemptConflictError
+	require.ErrorAs(t, err, &conflictErr, "the caller must still see the conflict deadline to wait on it")
+	require.Equal(t, conflict.ExpiresAt, conflictErr.ExpiresAt, "the persisted deadline must survive the wrap")
+	require.NotContains(t, logs.String(), "sandbox_capacity_coordination_failure", "attempt conflicts must not fire the coordination alert signal")
 }
 
 func TestSandboxCapacityGate_SnapshotSeparatesSandboxTurnReservations(t *testing.T) {

--- a/internal/services/agent/sandbox_capacity_test.go
+++ b/internal/services/agent/sandbox_capacity_test.go
@@ -1,6 +1,7 @@
 package agent_test
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"sync"
@@ -322,12 +323,13 @@ func TestSandboxCapacityGate_AcquireFailsClosedWhenSharedReservationFails(t *tes
 	t.Parallel()
 
 	shared := &fakeSharedSandboxCapacityStore{err: errors.New("database unavailable")}
+	var logs bytes.Buffer
 	gate := agent.NewSandboxCapacityGate(agent.SandboxCapacityGateConfig{
 		Counter:            &fakeLiveSandboxCounter{},
 		SharedReservations: shared,
 		MaxActive:          2,
 		NodeID:             "worker-1",
-		Logger:             zerolog.Nop(),
+		Logger:             zerolog.New(&logs),
 	})
 
 	reservation, err := gate.Acquire(context.Background(), agent.SandboxCapacityRequest{Purpose: "branch_preview"})
@@ -336,6 +338,8 @@ func TestSandboxCapacityGate_AcquireFailsClosedWhenSharedReservationFails(t *tes
 	require.ErrorIs(t, err, agent.ErrSandboxCapacityCoordination, "shared reservation failures should be distinguishable from genuine saturation")
 	require.ErrorContains(t, err, "database unavailable", "capacity error should retain the shared reservation failure")
 	require.Nil(t, reservation, "failed shared reservations should not reserve local capacity")
+	require.Contains(t, logs.String(), `"sandbox_capacity_coordination_failure":true`, "coordination failures should emit an alertable structured signal")
+	require.Contains(t, logs.String(), `"shared_admission_timeout":10000`, "coordination failures should report the configured admission budget in milliseconds")
 }
 
 func TestSandboxCapacityGate_SnapshotSeparatesSandboxTurnReservations(t *testing.T) {

--- a/internal/services/agent/sandbox_capacity_test.go
+++ b/internal/services/agent/sandbox_capacity_test.go
@@ -31,6 +31,10 @@ type fakeSharedSandboxCapacityStore struct {
 	workloadClass models.SandboxWorkloadClass
 	live          int
 	effectiveMax  int
+	releasedNode  string
+	releasedID    uuid.UUID
+	releaseErr    error
+	releaseFails  int64
 	reserveCalls  atomic.Int64
 	releaseCalls  atomic.Int64
 }
@@ -50,7 +54,7 @@ func (contextWaitingSharedSandboxCapacityStore) ReserveSandboxCapacity(
 	return uuid.Nil, 0, 0, false, ctx.Err()
 }
 
-func (contextWaitingSharedSandboxCapacityStore) ReleaseSandboxCapacity(context.Context, uuid.UUID) error {
+func (contextWaitingSharedSandboxCapacityStore) ReleaseSandboxCapacity(context.Context, string, uuid.UUID) error {
 	return nil
 }
 
@@ -70,9 +74,14 @@ func (f *fakeSharedSandboxCapacityStore) ReserveSandboxCapacity(ctx context.Cont
 	return f.reservationID, liveSandboxes, f.total, f.acquired, nil
 }
 
-func (f *fakeSharedSandboxCapacityStore) ReleaseSandboxCapacity(context.Context, uuid.UUID) error {
-	f.releaseCalls.Add(1)
-	return f.err
+func (f *fakeSharedSandboxCapacityStore) ReleaseSandboxCapacity(_ context.Context, nodeID string, reservationID uuid.UUID) error {
+	call := f.releaseCalls.Add(1)
+	f.releasedNode = nodeID
+	f.releasedID = reservationID
+	if call <= f.releaseFails {
+		return f.releaseErr
+	}
+	return nil
 }
 
 type contextWaitingLiveSandboxCounter struct {
@@ -277,6 +286,36 @@ func TestSandboxCapacityGate_AcquireReleasesSharedReservation(t *testing.T) {
 	reservation.Release()
 	require.Equal(t, 0, gate.ReservedCount(), "reservation release should clear local heartbeat state")
 	require.Equal(t, int64(1), shared.releaseCalls.Load(), "reservation release should remove the shared capacity lease")
+	require.Equal(t, "worker-1", shared.releasedNode, "reservation release should use the same worker admission-lock namespace")
+	require.Equal(t, shared.reservationID, shared.releasedID, "reservation release should remove the acquired lease")
+}
+
+func TestSandboxCapacityGate_ReleaseRetriesTransientSharedStoreFailure(t *testing.T) {
+	t.Parallel()
+
+	shared := &fakeSharedSandboxCapacityStore{
+		reservationID: uuid.New(),
+		total:         1,
+		acquired:      true,
+		releaseErr:    errors.New("database temporarily unavailable"),
+		releaseFails:  2,
+	}
+	gate := agent.NewSandboxCapacityGate(agent.SandboxCapacityGateConfig{
+		Counter:                &fakeLiveSandboxCounter{},
+		SharedReservations:     shared,
+		MaxActive:              2,
+		SharedAdmissionTimeout: time.Second,
+		NodeID:                 "worker-1",
+		Logger:                 zerolog.Nop(),
+	})
+
+	reservation, err := gate.Acquire(context.Background(), agent.SandboxCapacityRequest{Purpose: "branch_preview"})
+	require.NoError(t, err, "capacity admission should persist a shared reservation before release retry")
+
+	reservation.Release()
+
+	require.Equal(t, int64(3), shared.releaseCalls.Load(), "release should retry transient database failures within the coordination budget")
+	require.Equal(t, 0, gate.ReservedCount(), "release retry should still clear process-local reservation state exactly once")
 }
 
 func TestSandboxCapacityGate_AcquireFailsClosedWhenSharedReservationFails(t *testing.T) {

--- a/internal/services/agent/sandbox_capacity_test.go
+++ b/internal/services/agent/sandbox_capacity_test.go
@@ -34,8 +34,10 @@ type fakeSharedSandboxCapacityStore struct {
 	effectiveMax  int
 	releasedNode  string
 	releasedID    uuid.UUID
+	releasedToken *uuid.UUID
 	releaseErr    error
 	releaseFails  int64
+	jobLockToken  *uuid.UUID
 	reserveCalls  atomic.Int64
 	releaseCalls  atomic.Int64
 }
@@ -46,6 +48,7 @@ func (contextWaitingSharedSandboxCapacityStore) ReserveSandboxCapacity(
 	ctx context.Context,
 	_ string,
 	_ *uuid.UUID,
+	_ *uuid.UUID,
 	_ models.SandboxWorkloadClass,
 	_ func(context.Context) (int, error),
 	_ int,
@@ -55,13 +58,14 @@ func (contextWaitingSharedSandboxCapacityStore) ReserveSandboxCapacity(
 	return uuid.Nil, 0, 0, false, ctx.Err()
 }
 
-func (contextWaitingSharedSandboxCapacityStore) ReleaseSandboxCapacity(context.Context, string, uuid.UUID) error {
+func (contextWaitingSharedSandboxCapacityStore) ReleaseSandboxCapacity(context.Context, string, uuid.UUID, *uuid.UUID) error {
 	return nil
 }
 
-func (f *fakeSharedSandboxCapacityStore) ReserveSandboxCapacity(ctx context.Context, _ string, jobID *uuid.UUID, workloadClass models.SandboxWorkloadClass, countLiveSandboxes func(context.Context) (int, error), effectiveMax int, _ time.Time) (uuid.UUID, int, int, bool, error) {
+func (f *fakeSharedSandboxCapacityStore) ReserveSandboxCapacity(ctx context.Context, _ string, jobID, jobLockToken *uuid.UUID, workloadClass models.SandboxWorkloadClass, countLiveSandboxes func(context.Context) (int, error), effectiveMax int, _ time.Time) (uuid.UUID, int, int, bool, error) {
 	f.reserveCalls.Add(1)
 	f.jobID = jobID
+	f.jobLockToken = jobLockToken
 	f.workloadClass = workloadClass
 	f.effectiveMax = effectiveMax
 	if f.err != nil {
@@ -75,10 +79,11 @@ func (f *fakeSharedSandboxCapacityStore) ReserveSandboxCapacity(ctx context.Cont
 	return f.reservationID, liveSandboxes, f.total, f.acquired, nil
 }
 
-func (f *fakeSharedSandboxCapacityStore) ReleaseSandboxCapacity(_ context.Context, nodeID string, reservationID uuid.UUID) error {
+func (f *fakeSharedSandboxCapacityStore) ReleaseSandboxCapacity(_ context.Context, nodeID string, reservationID uuid.UUID, jobLockToken *uuid.UUID) error {
 	call := f.releaseCalls.Add(1)
 	f.releasedNode = nodeID
 	f.releasedID = reservationID
+	f.releasedToken = jobLockToken
 	if call <= f.releaseFails {
 		return f.releaseErr
 	}
@@ -246,7 +251,7 @@ func TestSandboxCapacityGate_AcquireRejectsWhenFull(t *testing.T) {
 func TestSandboxCapacityGate_AcquireIncludesCrossProcessReservations(t *testing.T) {
 	t.Parallel()
 
-	jobID := uuid.New()
+	jobID, lockToken := uuid.New(), uuid.New()
 	shared := &fakeSharedSandboxCapacityStore{total: 3}
 	cleaner := &fakeSandboxPressureCleaner{}
 	gate := agent.NewSandboxCapacityGate(agent.SandboxCapacityGateConfig{
@@ -258,11 +263,12 @@ func TestSandboxCapacityGate_AcquireIncludesCrossProcessReservations(t *testing.
 		Logger:             zerolog.Nop(),
 	})
 
-	reservation, err := gate.Acquire(context.Background(), agent.SandboxCapacityRequest{Purpose: "continue_session", JobID: &jobID})
+	reservation, err := gate.Acquire(context.Background(), agent.SandboxCapacityRequest{Purpose: "continue_session", JobID: &jobID, JobLockToken: &lockToken})
 
 	require.ErrorIs(t, err, agent.ErrSandboxCapacity, "other processes' reservations should participate in final local admission")
 	require.Nil(t, reservation, "admission at shared capacity should not return a local reservation")
 	require.Equal(t, &jobID, shared.jobID, "shared admission should identify the current job so its routing reservation is not double counted")
+	require.Equal(t, &lockToken, shared.jobLockToken, "shared admission should identify the current claim attempt")
 	require.Equal(t, int64(1), shared.reserveCalls.Load(), "final admission should use the shared reservation store once")
 	require.Equal(t, int64(0), cleaner.calls.Load(), "shared reservations should not trigger physical pressure cleanup while Docker still has capacity")
 }
@@ -270,6 +276,7 @@ func TestSandboxCapacityGate_AcquireIncludesCrossProcessReservations(t *testing.
 func TestSandboxCapacityGate_AcquireReleasesSharedReservation(t *testing.T) {
 	t.Parallel()
 
+	jobID, lockToken := uuid.New(), uuid.New()
 	shared := &fakeSharedSandboxCapacityStore{reservationID: uuid.New(), total: 1, acquired: true}
 	gate := agent.NewSandboxCapacityGate(agent.SandboxCapacityGateConfig{
 		Counter:            &fakeLiveSandboxCounter{},
@@ -279,7 +286,7 @@ func TestSandboxCapacityGate_AcquireReleasesSharedReservation(t *testing.T) {
 		Logger:             zerolog.Nop(),
 	})
 
-	reservation, err := gate.Acquire(context.Background(), agent.SandboxCapacityRequest{Purpose: "branch_preview"})
+	reservation, err := gate.Acquire(context.Background(), agent.SandboxCapacityRequest{Purpose: "continue_session", JobID: &jobID, JobLockToken: &lockToken})
 	require.NoError(t, err, "capacity admission should persist a shared cross-process reservation")
 	require.Equal(t, 1, gate.ReservedCount(), "shared admission should remain visible in local heartbeat metadata")
 	require.Equal(t, int64(0), shared.releaseCalls.Load(), "shared reservation should remain active during sandbox creation")
@@ -289,6 +296,7 @@ func TestSandboxCapacityGate_AcquireReleasesSharedReservation(t *testing.T) {
 	require.Equal(t, int64(1), shared.releaseCalls.Load(), "reservation release should remove the shared capacity lease")
 	require.Equal(t, "worker-1", shared.releasedNode, "reservation release should use the same worker admission-lock namespace")
 	require.Equal(t, shared.reservationID, shared.releasedID, "reservation release should remove the acquired lease")
+	require.Equal(t, &lockToken, shared.releasedToken, "reservation release should be fenced to the acquiring job attempt")
 }
 
 func TestSandboxCapacityGate_ReleaseRetriesTransientSharedStoreFailure(t *testing.T) {

--- a/internal/services/agent/sandbox_capacity_test.go
+++ b/internal/services/agent/sandbox_capacity_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/require"
 
@@ -19,6 +20,40 @@ type fakeLiveSandboxCounter struct {
 	count int
 	err   error
 	calls atomic.Int64
+}
+
+type fakeSharedSandboxCapacityStore struct {
+	reservationID uuid.UUID
+	total         int
+	acquired      bool
+	err           error
+	jobID         *uuid.UUID
+	workloadClass models.SandboxWorkloadClass
+	live          int
+	effectiveMax  int
+	reserveCalls  atomic.Int64
+	releaseCalls  atomic.Int64
+}
+
+func (f *fakeSharedSandboxCapacityStore) ReserveSandboxCapacity(ctx context.Context, _ string, jobID *uuid.UUID, workloadClass models.SandboxWorkloadClass, countLiveSandboxes func(context.Context) (int, error), effectiveMax int, _ time.Time) (uuid.UUID, int, int, bool, error) {
+	f.reserveCalls.Add(1)
+	f.jobID = jobID
+	f.workloadClass = workloadClass
+	f.effectiveMax = effectiveMax
+	if f.err != nil {
+		return uuid.Nil, 0, f.total, false, f.err
+	}
+	liveSandboxes, err := countLiveSandboxes(ctx)
+	if err != nil {
+		return uuid.Nil, 0, f.total, false, err
+	}
+	f.live = liveSandboxes
+	return f.reservationID, liveSandboxes, f.total, f.acquired, nil
+}
+
+func (f *fakeSharedSandboxCapacityStore) ReleaseSandboxCapacity(context.Context, uuid.UUID) error {
+	f.releaseCalls.Add(1)
+	return f.err
 }
 
 type contextWaitingLiveSandboxCounter struct {
@@ -177,6 +212,71 @@ func TestSandboxCapacityGate_AcquireRejectsWhenFull(t *testing.T) {
 	require.ErrorIs(t, err, agent.ErrSandboxCapacity, "Acquire should reject when live sandboxes are already at capacity")
 	require.Nil(t, reservation, "Acquire should not return a reservation when capacity is exhausted")
 	require.Equal(t, 0, gate.ReservedCount(), "Rejected acquire should not leak a reservation")
+}
+
+func TestSandboxCapacityGate_AcquireIncludesCrossProcessReservations(t *testing.T) {
+	t.Parallel()
+
+	jobID := uuid.New()
+	shared := &fakeSharedSandboxCapacityStore{total: 3}
+	cleaner := &fakeSandboxPressureCleaner{}
+	gate := agent.NewSandboxCapacityGate(agent.SandboxCapacityGateConfig{
+		Counter:            &fakeLiveSandboxCounter{count: 1},
+		SharedReservations: shared,
+		PressureCleaner:    cleaner,
+		MaxActive:          3,
+		NodeID:             "worker-1",
+		Logger:             zerolog.Nop(),
+	})
+
+	reservation, err := gate.Acquire(context.Background(), agent.SandboxCapacityRequest{Purpose: "continue_session", JobID: &jobID})
+
+	require.ErrorIs(t, err, agent.ErrSandboxCapacity, "other processes' reservations should participate in final local admission")
+	require.Nil(t, reservation, "admission at shared capacity should not return a local reservation")
+	require.Equal(t, &jobID, shared.jobID, "shared admission should identify the current job so its routing reservation is not double counted")
+	require.Equal(t, int64(1), shared.reserveCalls.Load(), "final admission should use the shared reservation store once")
+	require.Equal(t, int64(0), cleaner.calls.Load(), "shared reservations should not trigger physical pressure cleanup while Docker still has capacity")
+}
+
+func TestSandboxCapacityGate_AcquireReleasesSharedReservation(t *testing.T) {
+	t.Parallel()
+
+	shared := &fakeSharedSandboxCapacityStore{reservationID: uuid.New(), total: 1, acquired: true}
+	gate := agent.NewSandboxCapacityGate(agent.SandboxCapacityGateConfig{
+		Counter:            &fakeLiveSandboxCounter{},
+		SharedReservations: shared,
+		MaxActive:          2,
+		NodeID:             "worker-1",
+		Logger:             zerolog.Nop(),
+	})
+
+	reservation, err := gate.Acquire(context.Background(), agent.SandboxCapacityRequest{Purpose: "branch_preview"})
+	require.NoError(t, err, "capacity admission should persist a shared cross-process reservation")
+	require.Equal(t, 1, gate.ReservedCount(), "shared admission should remain visible in local heartbeat metadata")
+	require.Equal(t, int64(0), shared.releaseCalls.Load(), "shared reservation should remain active during sandbox creation")
+
+	reservation.Release()
+	require.Equal(t, 0, gate.ReservedCount(), "reservation release should clear local heartbeat state")
+	require.Equal(t, int64(1), shared.releaseCalls.Load(), "reservation release should remove the shared capacity lease")
+}
+
+func TestSandboxCapacityGate_AcquireFailsClosedWhenSharedReservationFails(t *testing.T) {
+	t.Parallel()
+
+	shared := &fakeSharedSandboxCapacityStore{err: errors.New("database unavailable")}
+	gate := agent.NewSandboxCapacityGate(agent.SandboxCapacityGateConfig{
+		Counter:            &fakeLiveSandboxCounter{},
+		SharedReservations: shared,
+		MaxActive:          2,
+		NodeID:             "worker-1",
+		Logger:             zerolog.Nop(),
+	})
+
+	reservation, err := gate.Acquire(context.Background(), agent.SandboxCapacityRequest{Purpose: "branch_preview"})
+
+	require.ErrorIs(t, err, agent.ErrSandboxCapacity, "shared reservation failures should fail closed")
+	require.ErrorContains(t, err, "database unavailable", "capacity error should retain the shared reservation failure")
+	require.Nil(t, reservation, "failed shared reservations should not reserve local capacity")
 }
 
 func TestSandboxCapacityGate_SnapshotSeparatesSandboxTurnReservations(t *testing.T) {

--- a/internal/services/agent/sandbox_turn_admission.go
+++ b/internal/services/agent/sandbox_turn_admission.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/assembledhq/143/internal/db"
 	"github.com/assembledhq/143/internal/jobctx"
 	"github.com/assembledhq/143/internal/models"
 	"github.com/google/uuid"
@@ -35,6 +36,10 @@ type failedFreshSandboxRoutingPlacementReleaser interface {
 	ClearSandboxRoutingPlacementWithLease(ctx context.Context, jobID, lockToken uuid.UUID) (bool, error)
 }
 
+type failedFreshSandboxRetryRouter interface {
+	RerouteSandboxAfterStartupFailure(ctx context.Context, jobID, lockToken uuid.UUID, failedNodeID string) (*db.SandboxRoutingResult, error)
+}
+
 // admitSandboxTurn is the shared admission boundary for RunAgent and
 // ContinueSession. Every workload draws from the same organization turn limit;
 // workload class only affects worker placement and reserved interactive
@@ -54,7 +59,7 @@ func (o *Orchestrator) admitSandboxTurn(
 	if err := workloadClass.Validate(); err != nil {
 		return nil, fmt.Errorf("admit sandbox turn: %w", err)
 	}
-	if err := o.checkSharedTurnConcurrency(ctx, session.OrgID, excludeCurrentRunningSession); err != nil {
+	if err := o.checkSharedTurnConcurrency(ctx, session.OrgID, purpose, excludeCurrentRunningSession); err != nil {
 		o.releaseRejectedSandboxRoutingPlacement(ctx, o.logger)
 		return nil, err
 	}
@@ -85,7 +90,7 @@ func (o *Orchestrator) admitSandboxTurn(
 	return reservation, nil
 }
 
-func (o *Orchestrator) checkSharedTurnConcurrency(ctx context.Context, orgID uuid.UUID, excludeCurrentRunning bool) error {
+func (o *Orchestrator) checkSharedTurnConcurrency(ctx context.Context, orgID uuid.UUID, jobType string, excludeCurrentRunning bool) error {
 	if o.orgs == nil {
 		return o.checkConcurrency(ctx, orgID, excludeCurrentRunning)
 	}
@@ -105,7 +110,8 @@ func (o *Orchestrator) checkSharedTurnConcurrency(ctx context.Context, orgID uui
 	if err != nil {
 		return err
 	}
-	_, currentJobIncluded := jobctx.JobIDFromContext(ctx)
+	_, hasCurrentJob := jobctx.JobIDFromContext(ctx)
+	currentJobIncluded := hasCurrentJob && (jobType == "run_agent" || jobType == "continue_session")
 	// The shared job counter identifies the current claimed turn directly, so
 	// its greater-than comparison supersedes the legacy session-row
 	// excludeCurrentRunning adjustment used by the fallbacks above.
@@ -159,19 +165,35 @@ func (o *Orchestrator) releaseRejectedSandboxRoutingPlacement(ctx context.Contex
 	}
 }
 
-// clearFailedFreshSandboxRoutingPlacement removes worker affinity after a
-// create or hydrate failure. Unlike admission rejection cleanup, this is
-// unconditional on sandbox_slot_reserved_until: compatibility/terminal-probe
-// placements have a target without a durable slot, and a renewal may also have
-// cleared the slot before the provider reports its failure.
+// clearFailedFreshSandboxRoutingPlacement atomically reserves an alternate
+// worker after a create or hydrate failure while excluding every generation
+// on the failed physical capacity node. If no alternate has capacity, routing
+// clears affinity so a later fleet pass can retry. The simpler fenced clearer
+// remains a compatibility fallback for test or alternate JobStore adapters.
 func (o *Orchestrator) clearFailedFreshSandboxRoutingPlacement(ctx context.Context, log zerolog.Logger) {
-	releaser, ok := o.jobs.(failedFreshSandboxRoutingPlacementReleaser)
-	if !ok {
-		return
-	}
 	jobID, hasJobID := jobctx.JobIDFromContext(ctx)
 	lockToken, hasLockToken := jobctx.LockTokenFromContext(ctx)
 	if !hasJobID || !hasLockToken {
+		return
+	}
+	if router, ok := o.jobs.(failedFreshSandboxRetryRouter); ok {
+		failedNodeID, _ := jobctx.WorkerNodeIDFromContext(ctx)
+		routingCtx, routingCancel := context.WithTimeout(context.WithoutCancel(ctx), sandboxRoutingCleanupTimeout)
+		result, err := router.RerouteSandboxAfterStartupFailure(routingCtx, jobID, lockToken, failedNodeID)
+		routingCancel()
+		if err == nil {
+			event := log.Debug().Str("job_id", jobID.String()).Str("failed_node_id", failedNodeID)
+			if result != nil && result.TargetNodeID != nil {
+				event.Str("target_node_id", *result.TargetNodeID).Msg("reserved alternate worker after fresh sandbox failure")
+			} else {
+				event.Msg("cleared sandbox routing placement after no alternate worker was available")
+			}
+			return
+		}
+		log.Warn().Err(err).Str("job_id", jobID.String()).Str("failed_node_id", failedNodeID).Msg("failed to reserve alternate worker after fresh sandbox failure; falling back to clearing placement")
+	}
+	releaser, ok := o.jobs.(failedFreshSandboxRoutingPlacementReleaser)
+	if !ok {
 		return
 	}
 	releaseCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), sandboxRoutingCleanupTimeout)

--- a/internal/services/agent/sandbox_turn_admission.go
+++ b/internal/services/agent/sandbox_turn_admission.go
@@ -90,7 +90,7 @@ func (o *Orchestrator) admitSandboxTurn(
 	return reservation, nil
 }
 
-func (o *Orchestrator) checkSharedTurnConcurrency(ctx context.Context, orgID uuid.UUID, jobType string, excludeCurrentRunning bool) error {
+func (o *Orchestrator) checkSharedTurnConcurrency(ctx context.Context, orgID uuid.UUID, purpose string, excludeCurrentRunning bool) error {
 	if o.orgs == nil {
 		return o.checkConcurrency(ctx, orgID, excludeCurrentRunning)
 	}
@@ -111,7 +111,7 @@ func (o *Orchestrator) checkSharedTurnConcurrency(ctx context.Context, orgID uui
 		return err
 	}
 	_, hasCurrentJob := jobctx.JobIDFromContext(ctx)
-	currentJobIncluded := hasCurrentJob && (jobType == "run_agent" || jobType == "continue_session")
+	currentJobIncluded := hasCurrentJob && (purpose == "agent_run" || purpose == "continue_session")
 	// The shared job counter identifies the current claimed turn directly, so
 	// its greater-than comparison supersedes the legacy session-row
 	// excludeCurrentRunning adjustment used by the fallbacks above.

--- a/internal/services/agent/sandbox_turn_admission.go
+++ b/internal/services/agent/sandbox_turn_admission.go
@@ -97,6 +97,9 @@ func (o *Orchestrator) checkSharedTurnConcurrency(ctx context.Context, orgID uui
 		return err
 	}
 	_, currentJobIncluded := jobctx.JobIDFromContext(ctx)
+	// The shared job counter identifies the current claimed turn directly, so
+	// its greater-than comparison supersedes the legacy session-row
+	// excludeCurrentRunning adjustment used by the fallbacks above.
 	if active > settings.MaxConcurrentRuns || (!currentJobIncluded && active >= settings.MaxConcurrentRuns) {
 		return fmt.Errorf("%w: %d/%d agent turns active", ErrSandboxTurnConcurrency, active, settings.MaxConcurrentRuns)
 	}

--- a/internal/services/agent/sandbox_turn_admission.go
+++ b/internal/services/agent/sandbox_turn_admission.go
@@ -59,14 +59,19 @@ func (o *Orchestrator) admitSandboxTurn(
 		return nil, nil
 	}
 	var jobID *uuid.UUID
+	var jobLockToken *uuid.UUID
 	if currentJobID, ok := jobctx.JobIDFromContext(ctx); ok && currentJobID != uuid.Nil {
 		jobID = &currentJobID
+	}
+	if currentLockToken, ok := jobctx.LockTokenFromContext(ctx); ok && currentLockToken != uuid.Nil {
+		jobLockToken = &currentLockToken
 	}
 	reservation, err := o.sandboxCapacity.Acquire(ctx, SandboxCapacityRequest{
 		Purpose:       purpose,
 		SessionID:     session.ID.String(),
 		OrgID:         session.OrgID.String(),
 		JobID:         jobID,
+		JobLockToken:  jobLockToken,
 		WorkloadClass: workloadClass,
 	})
 	if err != nil {

--- a/internal/services/agent/sandbox_turn_admission.go
+++ b/internal/services/agent/sandbox_turn_admission.go
@@ -31,6 +31,10 @@ type sandboxRoutingPlacementReleaser interface {
 	ReleaseSandboxRoutingPlacementWithLease(ctx context.Context, jobID, lockToken uuid.UUID) (bool, error)
 }
 
+type failedFreshSandboxRoutingPlacementReleaser interface {
+	ClearSandboxRoutingPlacementWithLease(ctx context.Context, jobID, lockToken uuid.UUID) (bool, error)
+}
+
 // admitSandboxTurn is the shared admission boundary for RunAgent and
 // ContinueSession. Every workload draws from the same organization turn limit;
 // workload class only affects worker placement and reserved interactive
@@ -152,5 +156,32 @@ func (o *Orchestrator) releaseRejectedSandboxRoutingPlacement(ctx context.Contex
 	}
 	if released {
 		log.Debug().Str("job_id", jobID.String()).Msg("released rejected sandbox routing placement")
+	}
+}
+
+// clearFailedFreshSandboxRoutingPlacement removes worker affinity after a
+// create or hydrate failure. Unlike admission rejection cleanup, this is
+// unconditional on sandbox_slot_reserved_until: compatibility/terminal-probe
+// placements have a target without a durable slot, and a renewal may also have
+// cleared the slot before the provider reports its failure.
+func (o *Orchestrator) clearFailedFreshSandboxRoutingPlacement(ctx context.Context, log zerolog.Logger) {
+	releaser, ok := o.jobs.(failedFreshSandboxRoutingPlacementReleaser)
+	if !ok {
+		return
+	}
+	jobID, hasJobID := jobctx.JobIDFromContext(ctx)
+	lockToken, hasLockToken := jobctx.LockTokenFromContext(ctx)
+	if !hasJobID || !hasLockToken {
+		return
+	}
+	releaseCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), sandboxRoutingCleanupTimeout)
+	defer cancel()
+	released, err := releaser.ClearSandboxRoutingPlacementWithLease(releaseCtx, jobID, lockToken)
+	if err != nil {
+		log.Warn().Err(err).Str("job_id", jobID.String()).Msg("failed to clear sandbox routing placement after fresh sandbox failure")
+		return
+	}
+	if released {
+		log.Debug().Str("job_id", jobID.String()).Msg("cleared sandbox routing placement after fresh sandbox failure")
 	}
 }

--- a/internal/services/agent/sandbox_turn_admission.go
+++ b/internal/services/agent/sandbox_turn_admission.go
@@ -58,10 +58,15 @@ func (o *Orchestrator) admitSandboxTurn(
 	if !needsFreshSandbox || o.sandboxCapacity == nil {
 		return nil, nil
 	}
+	var jobID *uuid.UUID
+	if currentJobID, ok := jobctx.JobIDFromContext(ctx); ok && currentJobID != uuid.Nil {
+		jobID = &currentJobID
+	}
 	reservation, err := o.sandboxCapacity.Acquire(ctx, SandboxCapacityRequest{
 		Purpose:       purpose,
 		SessionID:     session.ID.String(),
 		OrgID:         session.OrgID.String(),
+		JobID:         jobID,
 		WorkloadClass: workloadClass,
 	})
 	if err != nil {

--- a/internal/services/agent/sandbox_turn_admission_test.go
+++ b/internal/services/agent/sandbox_turn_admission_test.go
@@ -99,7 +99,7 @@ func TestAdmitSandboxTurnAppliesSharedOrgLimit(t *testing.T) {
 		jobType   string
 		expectErr bool
 	}{
-		{name: "allows claimed interactive turn at the shared limit", origin: models.SessionOriginManual, active: 2, jobType: "continue_session"},
+		{name: "allows claimed initial turn at the shared limit", origin: models.SessionOriginManual, active: 2, jobType: "agent_run"},
 		{name: "rejects interactive turn beyond the shared limit", origin: models.SessionOriginManual, active: 3, jobType: "continue_session", expectErr: true},
 		{name: "allows claimed code-review turn at the shared limit", origin: models.SessionOriginCodeReview, active: 2, jobType: "continue_session"},
 		{name: "rejects code-review turn beyond the shared limit", origin: models.SessionOriginCodeReview, active: 3, jobType: "continue_session", expectErr: true},

--- a/internal/services/agent/sandbox_turn_admission_test.go
+++ b/internal/services/agent/sandbox_turn_admission_test.go
@@ -36,19 +36,21 @@ func (sandboxAdmissionLiveCounter) CountLiveSandboxes(context.Context) (int, err
 }
 
 type sandboxAdmissionSharedCapacityStore struct {
-	jobID *uuid.UUID
+	jobID        *uuid.UUID
+	jobLockToken *uuid.UUID
 }
 
 func (s *sandboxAdmissionSharedCapacityStore) ReserveSandboxCapacity(
 	ctx context.Context,
 	_ string,
-	jobID *uuid.UUID,
+	jobID, jobLockToken *uuid.UUID,
 	_ models.SandboxWorkloadClass,
 	countLiveSandboxes func(context.Context) (int, error),
 	_ int,
 	_ time.Time,
 ) (uuid.UUID, int, int, bool, error) {
 	s.jobID = jobID
+	s.jobLockToken = jobLockToken
 	live, err := countLiveSandboxes(ctx)
 	if err != nil {
 		return uuid.Nil, 0, 0, false, err
@@ -56,7 +58,7 @@ func (s *sandboxAdmissionSharedCapacityStore) ReserveSandboxCapacity(
 	return uuid.New(), live, live + 1, true, nil
 }
 
-func (*sandboxAdmissionSharedCapacityStore) ReleaseSandboxCapacity(context.Context, string, uuid.UUID) error {
+func (*sandboxAdmissionSharedCapacityStore) ReleaseSandboxCapacity(context.Context, string, uuid.UUID, *uuid.UUID) error {
 	return nil
 }
 
@@ -158,7 +160,7 @@ func TestAdmitSandboxTurnReleasesRejectedDurablePlacement(t *testing.T) {
 func TestAdmitSandboxTurnIdentifiesCurrentJobToSharedCapacityFence(t *testing.T) {
 	t.Parallel()
 
-	jobID := uuid.New()
+	jobID, lockToken := uuid.New(), uuid.New()
 	sharedCapacity := &sandboxAdmissionSharedCapacityStore{}
 	orchestrator := &Orchestrator{
 		orgs: &sandboxAdmissionOrgStore{settings: json.RawMessage(`{"max_concurrent_runs":2}`)},
@@ -172,7 +174,7 @@ func TestAdmitSandboxTurnIdentifiesCurrentJobToSharedCapacityFence(t *testing.T)
 		}),
 		logger: zerolog.Nop(),
 	}
-	ctx := jobctx.WithJobID(context.Background(), jobID)
+	ctx := jobctx.WithLockToken(jobctx.WithJobID(context.Background(), jobID), lockToken)
 
 	reservation, err := orchestrator.admitSandboxTurn(ctx, &models.Session{
 		ID:     uuid.New(),
@@ -184,5 +186,7 @@ func TestAdmitSandboxTurnIdentifiesCurrentJobToSharedCapacityFence(t *testing.T)
 	require.NotNil(t, reservation, "fresh sandbox admission should return the shared capacity reservation")
 	require.NotNil(t, sharedCapacity.jobID, "shared capacity admission should receive the claimed job id")
 	require.Equal(t, jobID, *sharedCapacity.jobID, "shared admission should exclude the current job's durable routing reservation")
+	require.NotNil(t, sharedCapacity.jobLockToken, "shared capacity admission should receive the claim fencing token")
+	require.Equal(t, lockToken, *sharedCapacity.jobLockToken, "shared admission should fence the reservation to the current claim attempt")
 	reservation.Release()
 }

--- a/internal/services/agent/sandbox_turn_admission_test.go
+++ b/internal/services/agent/sandbox_turn_admission_test.go
@@ -96,12 +96,14 @@ func TestAdmitSandboxTurnAppliesSharedOrgLimit(t *testing.T) {
 		name      string
 		origin    models.SessionOrigin
 		active    int
+		jobType   string
 		expectErr bool
 	}{
-		{name: "allows claimed interactive turn at the shared limit", origin: models.SessionOriginManual, active: 2},
-		{name: "rejects interactive turn beyond the shared limit", origin: models.SessionOriginManual, active: 3, expectErr: true},
-		{name: "allows claimed code-review turn at the shared limit", origin: models.SessionOriginCodeReview, active: 2},
-		{name: "rejects code-review turn beyond the shared limit", origin: models.SessionOriginCodeReview, active: 3, expectErr: true},
+		{name: "allows claimed interactive turn at the shared limit", origin: models.SessionOriginManual, active: 2, jobType: "continue_session"},
+		{name: "rejects interactive turn beyond the shared limit", origin: models.SessionOriginManual, active: 3, jobType: "continue_session", expectErr: true},
+		{name: "allows claimed code-review turn at the shared limit", origin: models.SessionOriginCodeReview, active: 2, jobType: "continue_session"},
+		{name: "rejects code-review turn beyond the shared limit", origin: models.SessionOriginCodeReview, active: 3, jobType: "continue_session", expectErr: true},
+		{name: "does not credit a non-sandbox job context", origin: models.SessionOriginManual, active: 2, jobType: "unrelated_job", expectErr: true},
 	}
 
 	for _, tt := range tests {
@@ -119,7 +121,7 @@ func TestAdmitSandboxTurnAppliesSharedOrgLimit(t *testing.T) {
 				ID:     uuid.New(),
 				OrgID:  orgID,
 				Origin: tt.origin,
-			}, "continue_session", false, false)
+			}, tt.jobType, false, false)
 
 			if tt.expectErr {
 				require.ErrorIs(t, err, ErrSandboxTurnConcurrency, "turn above the shared org limit should wait without consuming an attempt")

--- a/internal/services/agent/sandbox_turn_admission_test.go
+++ b/internal/services/agent/sandbox_turn_admission_test.go
@@ -56,7 +56,7 @@ func (s *sandboxAdmissionSharedCapacityStore) ReserveSandboxCapacity(
 	return uuid.New(), live, live + 1, true, nil
 }
 
-func (*sandboxAdmissionSharedCapacityStore) ReleaseSandboxCapacity(context.Context, uuid.UUID) error {
+func (*sandboxAdmissionSharedCapacityStore) ReleaseSandboxCapacity(context.Context, string, uuid.UUID) error {
 	return nil
 }
 

--- a/internal/services/agent/sandbox_turn_admission_test.go
+++ b/internal/services/agent/sandbox_turn_admission_test.go
@@ -29,6 +29,37 @@ type sandboxAdmissionJobStore struct {
 	releasedLockToken uuid.UUID
 }
 
+type sandboxAdmissionLiveCounter struct{}
+
+func (sandboxAdmissionLiveCounter) CountLiveSandboxes(context.Context) (int, error) {
+	return 0, nil
+}
+
+type sandboxAdmissionSharedCapacityStore struct {
+	jobID *uuid.UUID
+}
+
+func (s *sandboxAdmissionSharedCapacityStore) ReserveSandboxCapacity(
+	ctx context.Context,
+	_ string,
+	jobID *uuid.UUID,
+	_ models.SandboxWorkloadClass,
+	countLiveSandboxes func(context.Context) (int, error),
+	_ int,
+	_ time.Time,
+) (uuid.UUID, int, int, bool, error) {
+	s.jobID = jobID
+	live, err := countLiveSandboxes(ctx)
+	if err != nil {
+		return uuid.Nil, 0, 0, false, err
+	}
+	return uuid.New(), live, live + 1, true, nil
+}
+
+func (*sandboxAdmissionSharedCapacityStore) ReleaseSandboxCapacity(context.Context, uuid.UUID) error {
+	return nil
+}
+
 func (s *sandboxAdmissionJobStore) Enqueue(context.Context, uuid.UUID, string, string, any, int, *string) (uuid.UUID, error) {
 	return uuid.New(), nil
 }
@@ -122,4 +153,36 @@ func TestAdmitSandboxTurnReleasesRejectedDurablePlacement(t *testing.T) {
 	require.Equal(t, 1, jobs.releaseCalls, "rejected admission should release its durable routing placement exactly once")
 	require.Equal(t, jobID, jobs.releasedJobID, "placement release should be fenced to the claimed job")
 	require.Equal(t, lockToken, jobs.releasedLockToken, "placement release should use the current attempt lock token")
+}
+
+func TestAdmitSandboxTurnIdentifiesCurrentJobToSharedCapacityFence(t *testing.T) {
+	t.Parallel()
+
+	jobID := uuid.New()
+	sharedCapacity := &sandboxAdmissionSharedCapacityStore{}
+	orchestrator := &Orchestrator{
+		orgs: &sandboxAdmissionOrgStore{settings: json.RawMessage(`{"max_concurrent_runs":2}`)},
+		jobs: &sandboxAdmissionJobStore{active: 1},
+		sandboxCapacity: NewSandboxCapacityGate(SandboxCapacityGateConfig{
+			Counter:            sandboxAdmissionLiveCounter{},
+			SharedReservations: sharedCapacity,
+			MaxActive:          2,
+			NodeID:             "worker-1",
+			Logger:             zerolog.Nop(),
+		}),
+		logger: zerolog.Nop(),
+	}
+	ctx := jobctx.WithJobID(context.Background(), jobID)
+
+	reservation, err := orchestrator.admitSandboxTurn(ctx, &models.Session{
+		ID:     uuid.New(),
+		OrgID:  uuid.New(),
+		Origin: models.SessionOriginCodeReview,
+	}, "continue_session", true, false)
+
+	require.NoError(t, err, "fresh sandbox admission should acquire shared worker capacity")
+	require.NotNil(t, reservation, "fresh sandbox admission should return the shared capacity reservation")
+	require.NotNil(t, sharedCapacity.jobID, "shared capacity admission should receive the claimed job id")
+	require.Equal(t, jobID, *sharedCapacity.jobID, "shared admission should exclude the current job's durable routing reservation")
+	reservation.Release()
 }

--- a/internal/services/github/pr_health_service.go
+++ b/internal/services/github/pr_health_service.go
@@ -1815,17 +1815,7 @@ func (s *PRService) resumeRepairSession(ctx context.Context, pr models.PullReque
 	if threadID != nil {
 		payload["thread_id"] = threadID.String()
 	}
-	enqueueOpts := db.EnqueueOpts{
-		Queue:        "agent",
-		JobType:      "continue_session",
-		Payload:      payload,
-		Priority:     5,
-		DedupeKey:    &continueDedupeKey,
-		TargetNodeID: models.SessionWorkerTarget(&claimed),
-	}
-	if models.SandboxWorkloadClassForSession(&claimed) == models.SandboxWorkloadClassCodeReview {
-		enqueueOpts.WorkloadClass = models.SandboxWorkloadClassCodeReview
-	}
+	enqueueOpts := db.ContinueSessionEnqueueOpts(&claimed, payload, &continueDedupeKey)
 	if _, err := s.jobs.EnqueueInTxWithOpts(ctx, tx, pr.OrgID, enqueueOpts); err != nil {
 		return nil, err
 	}

--- a/internal/services/humaninput/db_repository.go
+++ b/internal/services/humaninput/db_repository.go
@@ -141,16 +141,6 @@ func (t *dbTx) EnqueueContinue(ctx context.Context, orgID, sessionID uuid.UUID, 
 		payload["thread_id"] = threadID.String()
 	}
 	dedupeKey := db.ContinueSessionDedupeKey(scopeID)
-	enqueueOpts := db.EnqueueOpts{
-		Queue:        "agent",
-		JobType:      "continue_session",
-		Payload:      payload,
-		Priority:     5,
-		DedupeKey:    &dedupeKey,
-		TargetNodeID: models.SessionWorkerTarget(target),
-	}
-	if models.SandboxWorkloadClassForSession(target) == models.SandboxWorkloadClassCodeReview {
-		enqueueOpts.WorkloadClass = models.SandboxWorkloadClassCodeReview
-	}
+	enqueueOpts := db.ContinueSessionEnqueueOpts(target, payload, &dedupeKey)
 	return t.jobs.EnqueueInTxWithOpts(ctx, t.tx, orgID, enqueueOpts)
 }

--- a/internal/services/thread/actions.go
+++ b/internal/services/thread/actions.go
@@ -185,14 +185,7 @@ func (s *Service) enqueueThreadContinuation(ctx context.Context, orgID, sessionI
 		"org_id":     orgID.String(),
 	}
 	dedupeKey := db.ContinueSessionDedupeKey(threadID)
-	enqueueOpts := db.EnqueueOpts{
-		Queue:         "agent",
-		JobType:       "continue_session",
-		Payload:       payload,
-		Priority:      5,
-		DedupeKey:     &dedupeKey,
-		WorkloadClass: models.SandboxWorkloadClassInteractive,
-	}
+	enqueueOpts := db.ContinueSessionEnqueueOpts(nil, payload, &dedupeKey)
 	// Session lookup enriches the enqueue with affinity and workload class, but
 	// it is not required to preserve the accepted message. When the dependency
 	// is absent or temporarily unavailable, leave the job unpinned and use the
@@ -206,8 +199,7 @@ func (s *Service) enqueueThreadContinuation(ctx context.Context, orgID, sessionI
 				Str("thread_id", threadID.String()).
 				Msg("failed to enrich thread continuation routing; enqueueing unpinned interactive fallback")
 		} else {
-			enqueueOpts.TargetNodeID = models.SessionWorkerTarget(&session)
-			enqueueOpts.WorkloadClass = models.SandboxWorkloadClassForSession(&session)
+			enqueueOpts = db.ContinueSessionEnqueueOpts(&session, payload, &dedupeKey)
 		}
 	}
 	_, err := s.jobStore.EnqueueWithOpts(ctx, orgID, enqueueOpts)

--- a/internal/services/thread/service.go
+++ b/internal/services/thread/service.go
@@ -905,17 +905,7 @@ func (s *Service) SendMessage(ctx context.Context, input SendMessageInput) (*Sen
 	if answeredHumanInput != nil {
 		payload["human_input_request_id"] = answeredHumanInput.ID.String()
 	}
-	enqueueOpts := db.EnqueueOpts{
-		Queue:        "agent",
-		JobType:      "continue_session",
-		Payload:      payload,
-		Priority:     5,
-		DedupeKey:    &dedupeKey,
-		TargetNodeID: models.SessionWorkerTarget(&claimedSession),
-	}
-	if models.SandboxWorkloadClassForSession(&claimedSession) == models.SandboxWorkloadClassCodeReview {
-		enqueueOpts.WorkloadClass = models.SandboxWorkloadClassCodeReview
-	}
+	enqueueOpts := db.ContinueSessionEnqueueOpts(&claimedSession, payload, &dedupeKey)
 	if _, err := s.jobStore.EnqueueWithOpts(ctx, input.OrgID, enqueueOpts); err != nil {
 		// Note: we do NOT roll back the resolved comments or answered
 		// question here. The message has been committed and is durably in

--- a/internal/worker/handlers.go
+++ b/internal/worker/handlers.go
@@ -207,8 +207,11 @@ func sandboxCapacityAttemptConflictRetry(err error) (*RetryableError, bool) {
 	// reservation is still alive. Wait directly for its persisted deadline so
 	// the queue does not repeatedly launch replacement executors before the
 	// conflict can clear. The reservation expiry is the bounded terminal
-	// condition, so it replaces the generic eight-minute retry window. Keep the
-	// existing target: changing workers cannot resolve a job-global conflict.
+	// condition, so it replaces the generic eight-minute retry window; live
+	// attempts renew their lease on the job-lease heartbeat, so this deadline
+	// only fences dead processes and stays short. Admission cleanup already
+	// released this attempt's durable placement, so the job re-routes fresh
+	// once the wait elapses.
 	retryAfter := time.Until(conflictErr.ExpiresAt) + sandboxAttemptConflictRetryBuffer
 	if retryAfter < sandboxLockContentionRetryDelay {
 		retryAfter = sandboxLockContentionRetryDelay

--- a/internal/worker/handlers.go
+++ b/internal/worker/handlers.go
@@ -44,10 +44,11 @@ import (
 )
 
 const (
-	sandboxCapacityRetryDelay        = db.SandboxFleetRetryDelay
-	sandboxAlternateWorkerRetryDelay = time.Duration(0)
-	sandboxOrgLimitRetryDelay        = db.SandboxOrgLimitRetryDelay
-	sandboxLockContentionRetryDelay  = 500 * time.Millisecond
+	sandboxCapacityRetryDelay         = db.SandboxFleetRetryDelay
+	sandboxAlternateWorkerRetryDelay  = time.Duration(0)
+	sandboxOrgLimitRetryDelay         = db.SandboxOrgLimitRetryDelay
+	sandboxLockContentionRetryDelay   = 500 * time.Millisecond
+	sandboxAttemptConflictRetryBuffer = time.Second
 )
 const previewCapacityRetryDelay = 5 * time.Second
 const previewStartupInterruptedRetryDelay = 2 * time.Second
@@ -191,6 +192,28 @@ func sandboxTurnRoutingRetryDelay(reason db.SandboxRoutingReason) time.Duration 
 	default:
 		return sandboxCapacityRetryDelay
 	}
+}
+
+func sandboxCapacityAttemptConflictRetry(err error) (*RetryableError, bool) {
+	var conflictErr *db.SandboxCapacityAttemptConflictError
+	if !errors.As(err, &conflictErr) {
+		return nil, false
+	}
+	// A reclaimed job can reach final admission while the old, fenced attempt's
+	// reservation is still alive. Wait directly for its persisted deadline so
+	// the queue does not repeatedly launch replacement executors before the
+	// conflict can clear. The reservation expiry is the bounded terminal
+	// condition, so it replaces the generic eight-minute retry window. Keep the
+	// existing target: changing workers cannot resolve a job-global conflict.
+	retryAfter := time.Until(conflictErr.ExpiresAt) + sandboxAttemptConflictRetryBuffer
+	if retryAfter < sandboxLockContentionRetryDelay {
+		retryAfter = sandboxLockContentionRetryDelay
+	}
+	return &RetryableError{
+		Err:                    err,
+		RetryAfter:             &retryAfter,
+		BypassMaxRetryDuration: true,
+	}, true
 }
 
 func sandboxCapacityRetryTarget(ctx context.Context, stores *Stores, logger zerolog.Logger) (*string, bool) {
@@ -8359,6 +8382,14 @@ func newRunAgentHandler(stores *Stores, services *Services, logger zerolog.Logge
 			runErr = services.Orchestrator.RunAgent(jobCtx, &run)
 		}
 		if err := runErr; err != nil {
+			if retryable, ok := sandboxCapacityAttemptConflictRetry(err); ok {
+				logger.Info().
+					Str("session_id", runID.String()).
+					Dur("retry_after", *retryable.RetryAfter).
+					Err(err).
+					Msg("prior sandbox capacity attempt still owns a live reservation; waiting for its lease deadline")
+				return retryable
+			}
 			if errors.Is(err, agent.ErrSandboxCapacity) {
 				targetNodeID, clearTargetNodeID, retryAfter := sandboxTurnCapacityRetryTarget(ctx, stores, logger)
 				registerSandboxCapacityDeadLetter(ctx, stores, services, logger, run, run.PrimaryThreadID, "run_agent")
@@ -9868,6 +9899,14 @@ func newContinueSessionHandler(stores *Stores, services *Services, logger zerolo
 					Msg("sandbox turn concurrency reached; retrying continue_session")
 				retryAfter := sandboxOrgLimitRetryDelay
 				return &RetryableError{Err: err, RetryAfter: &retryAfter, BypassMaxRetryDuration: true}
+			}
+			if retryable, ok := sandboxCapacityAttemptConflictRetry(err); ok {
+				logger.Info().
+					Str("session_id", sessionID.String()).
+					Dur("retry_after", *retryable.RetryAfter).
+					Err(err).
+					Msg("prior sandbox capacity attempt still owns a live reservation; waiting for its lease deadline")
+				return retryable
 			}
 			if errors.Is(err, agent.ErrSandboxCapacity) {
 				targetNodeID, clearTargetNodeID, retryAfter := sandboxTurnCapacityRetryTarget(ctx, stores, logger)

--- a/internal/worker/handlers.go
+++ b/internal/worker/handlers.go
@@ -44,9 +44,9 @@ import (
 )
 
 const (
-	sandboxCapacityRetryDelay        = 10 * time.Second
+	sandboxCapacityRetryDelay        = db.SandboxFleetRetryDelay
 	sandboxAlternateWorkerRetryDelay = time.Duration(0)
-	sandboxOrgLimitRetryDelay        = 5 * time.Second
+	sandboxOrgLimitRetryDelay        = db.SandboxOrgLimitRetryDelay
 	sandboxLockContentionRetryDelay  = 500 * time.Millisecond
 )
 const previewCapacityRetryDelay = 5 * time.Second

--- a/internal/worker/handlers.go
+++ b/internal/worker/handlers.go
@@ -45,7 +45,7 @@ import (
 
 const (
 	sandboxCapacityRetryDelay        = 10 * time.Second
-	sandboxAlternateWorkerRetryDelay = time.Second
+	sandboxAlternateWorkerRetryDelay = time.Duration(0)
 	sandboxOrgLimitRetryDelay        = 5 * time.Second
 	sandboxLockContentionRetryDelay  = 500 * time.Millisecond
 )
@@ -170,10 +170,9 @@ func sandboxTurnCapacityRetryTarget(ctx context.Context, stores *Stores, logger 
 			Str("excluded_node_id", excludeNodeID).
 			Str("routing_reason", string(result.Reason)).
 			Msg("quickly routing sandbox capacity retry to reserved worker slot")
-		// The reservation makes the handoff atomic, but worker heartbeat load can
-		// lag the authoritative local capacity gate. A small delay prevents a job
-		// from hot-looping between workers while that metadata converges, while
-		// remaining well below the full-fleet backoff.
+		// The durable reservation makes the handoff atomic. Requeue immediately
+		// so RetryWithLease publishes a cross-worker wake-up; retain the longer
+		// delay only when the authoritative routing pass finds no capacity.
 		return result.TargetNodeID, false, sandboxAlternateWorkerRetryDelay
 	}
 	logger.Info().

--- a/internal/worker/handlers.go
+++ b/internal/worker/handlers.go
@@ -6262,17 +6262,7 @@ func enqueueSlackSessionContinuationMessage(ctx context.Context, stores *Stores,
 		"session_id": session.ID.String(),
 		"thread_id":  thread.ID.String(),
 	}
-	enqueueOpts := db.EnqueueOpts{
-		Queue:        "agent",
-		JobType:      "continue_session",
-		Payload:      payload,
-		Priority:     5,
-		DedupeKey:    &dedupeKey,
-		TargetNodeID: models.SessionWorkerTarget(&session),
-	}
-	if models.SandboxWorkloadClassForSession(&session) == models.SandboxWorkloadClassCodeReview {
-		enqueueOpts.WorkloadClass = models.SandboxWorkloadClassCodeReview
-	}
+	enqueueOpts := db.ContinueSessionEnqueueOpts(&session, payload, &dedupeKey)
 	_, err = stores.Jobs.EnqueueWithOpts(ctx, orgID, enqueueOpts)
 	return err
 }
@@ -6691,17 +6681,7 @@ func handleSlackHumanInputAnswer(ctx context.Context, stores *Stores, services *
 	if req.ThreadID != nil {
 		payload["thread_id"] = req.ThreadID.String()
 	}
-	enqueueOpts := db.EnqueueOpts{
-		Queue:        "agent",
-		JobType:      "continue_session",
-		Payload:      payload,
-		Priority:     5,
-		DedupeKey:    &dedupeKey,
-		TargetNodeID: models.SessionWorkerTarget(&session),
-	}
-	if models.SandboxWorkloadClassForSession(&session) == models.SandboxWorkloadClassCodeReview {
-		enqueueOpts.WorkloadClass = models.SandboxWorkloadClassCodeReview
-	}
+	enqueueOpts := db.ContinueSessionEnqueueOpts(&session, payload, &dedupeKey)
 	_, err = stores.Jobs.EnqueueWithOpts(ctx, orgID, enqueueOpts)
 	return err
 }

--- a/internal/worker/handlers.go
+++ b/internal/worker/handlers.go
@@ -47,6 +47,7 @@ const (
 	sandboxCapacityRetryDelay        = 10 * time.Second
 	sandboxAlternateWorkerRetryDelay = time.Second
 	sandboxOrgLimitRetryDelay        = 5 * time.Second
+	sandboxLockContentionRetryDelay  = 500 * time.Millisecond
 )
 const previewCapacityRetryDelay = 5 * time.Second
 const previewStartupInterruptedRetryDelay = 2 * time.Second
@@ -179,13 +180,18 @@ func sandboxTurnCapacityRetryTarget(ctx context.Context, stores *Stores, logger 
 		Str("excluded_node_id", excludeNodeID).
 		Str("routing_reason", string(result.Reason)).
 		Msg("no alternate worker slot reserved; clearing retry target pin")
-	if result.Reason == db.SandboxRoutingReasonLockContention {
-		return nil, true, 0
+	return nil, true, sandboxTurnRoutingRetryDelay(result.Reason)
+}
+
+func sandboxTurnRoutingRetryDelay(reason db.SandboxRoutingReason) time.Duration {
+	switch reason {
+	case db.SandboxRoutingReasonLockContention:
+		return sandboxLockContentionRetryDelay
+	case db.SandboxRoutingReasonOrgLimit:
+		return sandboxOrgLimitRetryDelay
+	default:
+		return sandboxCapacityRetryDelay
 	}
-	if result.Reason == db.SandboxRoutingReasonOrgLimit {
-		return nil, true, sandboxOrgLimitRetryDelay
-	}
-	return nil, true, sandboxCapacityRetryDelay
 }
 
 func sandboxCapacityRetryTarget(ctx context.Context, stores *Stores, logger zerolog.Logger) (*string, bool) {
@@ -10341,9 +10347,28 @@ func shouldStopContinueSessionForDurableState(
 	if err != nil {
 		return false, err
 	}
-	if cancelled && stores.SessionThreads != nil {
+	if stores.SessionThreads != nil {
 		for _, cancelledThreadID := range cancelledThreadIDs {
 			stores.SessionThreads.PublishRuntimeUpdate(ctx, orgID, cancelledThreadID)
+		}
+	}
+	if !cancelled && hasThread && stores.SessionThreads != nil {
+		// A live sibling keeps ownership of the session-scoped cancellation,
+		// but this claimed continuation is about to be consumed. Finalize its
+		// distinct queued thread so it cannot remain active without a backing
+		// job while the sibling delivers the cancel signal.
+		thread, loadErr := stores.SessionThreads.GetByID(ctx, orgID, threadID)
+		if loadErr != nil {
+			return false, fmt.Errorf("reload queued session thread during sibling cancellation: %w", loadErr)
+		}
+		if thread.SessionID != sessionID {
+			return false, fmt.Errorf("session thread %s does not belong to session %s", threadID, sessionID)
+		}
+		switch thread.Status {
+		case models.ThreadStatusPending, models.ThreadStatusRunning, models.ThreadStatusAwaitingInput:
+			if updateErr := stores.SessionThreads.UpdateStatus(ctx, orgID, threadID, models.ThreadStatusCancelled); updateErr != nil {
+				return false, fmt.Errorf("cancel queued session thread while sibling owns session cancellation: %w", updateErr)
+			}
 		}
 	}
 	// If another cancellation consumer won the race after the durable read,

--- a/internal/worker/handlers_linear_agent_prompted.go
+++ b/internal/worker/handlers_linear_agent_prompted.go
@@ -562,19 +562,8 @@ func enqueueContinueForLinearAgentInTx(ctx context.Context, jobs *db.JobStore, t
 
 func continueLinearAgentEnqueueOpts(orgID uuid.UUID, session models.Session) db.EnqueueOpts {
 	dedupe := db.ContinueSessionDedupeKey(session.ID)
-	opts := db.EnqueueOpts{
-		Queue:   "agent",
-		JobType: "continue_session",
-		Payload: map[string]any{
-			"org_id":     orgID.String(),
-			"session_id": session.ID.String(),
-		},
-		Priority:     5,
-		DedupeKey:    &dedupe,
-		TargetNodeID: models.SessionWorkerTarget(&session),
-	}
-	if models.SandboxWorkloadClassForSession(&session) == models.SandboxWorkloadClassCodeReview {
-		opts.WorkloadClass = models.SandboxWorkloadClassCodeReview
-	}
-	return opts
+	return db.ContinueSessionEnqueueOpts(&session, map[string]any{
+		"org_id":     orgID.String(),
+		"session_id": session.ID.String(),
+	}, &dedupe)
 }

--- a/internal/worker/handlers_test.go
+++ b/internal/worker/handlers_test.go
@@ -10844,6 +10844,30 @@ func TestSandboxTurnCapacityRetryTargetClearsPinWhenFencingTokenIsMissing(t *tes
 	require.NoError(t, mock.ExpectationsWereMet(), "missing fencing token should be detected before any database routing call")
 }
 
+func TestSandboxTurnRoutingRetryDelay(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		reason   db.SandboxRoutingReason
+		expected time.Duration
+	}{
+		{name: "lock contention has a positive retry floor", reason: db.SandboxRoutingReasonLockContention, expected: sandboxLockContentionRetryDelay},
+		{name: "organization limit uses policy retry", reason: db.SandboxRoutingReasonOrgLimit, expected: sandboxOrgLimitRetryDelay},
+		{name: "fleet saturation keeps full retry", reason: db.SandboxRoutingReasonFleetCapacity, expected: sandboxCapacityRetryDelay},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			retryAfter := sandboxTurnRoutingRetryDelay(tt.reason)
+			require.Equal(t, tt.expected, retryAfter, "routing reason should map to the expected bounded retry delay")
+			require.Positive(t, retryAfter, "every routing retry should yield instead of immediately waking the same job")
+		})
+	}
+}
+
 func TestRunAgentHandler_SandboxCapacityRetriesClearsTargetWhenNoWorkerAvailable(t *testing.T) {
 	t.Parallel()
 
@@ -12124,13 +12148,14 @@ func TestContinueSessionHandler_CancelsAssociatedThreadForPendingSessionCancella
 	require.NoError(t, mock.ExpectationsWereMet(), "session, matching thread, and cancel request should finalize in one transaction")
 }
 
-func TestContinueSessionHandler_PreservesCancellationForLiveSiblingTurn(t *testing.T) {
+func TestContinueSessionHandler_PreservesCancellationForLiveSiblingTurnAndFinalizesQueuedThread(t *testing.T) {
 	t.Parallel()
 
 	stores, mock := newTestStores(t)
 	defer mock.Close()
+	stores.SessionThreads = db.NewSessionThreadStore(mock)
 
-	orgID, sessionID, issueID, currentJobID := uuid.New(), uuid.New(), uuid.New(), uuid.New()
+	orgID, sessionID, threadID, issueID, currentJobID := uuid.New(), uuid.New(), uuid.New(), uuid.New(), uuid.New()
 	mock.ExpectQuery("SELECT .* FROM sessions").
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
 		WillReturnRows(pgxmock.NewRows(workerSessionColumns).AddRow(
@@ -12150,16 +12175,23 @@ func TestContinueSessionHandler_PreservesCancellationForLiveSiblingTurn(t *testi
 		WithArgs(orgID, currentJobID, sessionID.String()).
 		WillReturnRows(pgxmock.NewRows([]string{"exists"}).AddRow(true))
 	mock.ExpectRollback()
+	threadRow := workerSessionThreadRow(threadID, sessionID, orgID, models.AgentTypeCodex, nil, models.ThreadStatusRunning)
+	mock.ExpectQuery("SELECT .* FROM session_threads").
+		WithArgs(threadID, orgID).
+		WillReturnRows(pgxmock.NewRows(workerSessionThreadColumns).AddRow(threadRow...))
+	mock.ExpectExec("UPDATE session_threads SET status = @status").
+		WithArgs(models.ThreadStatusCancelled, threadID, orgID).
+		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
 
 	orch := &orchestratorServiceStub{}
 	handler := newContinueSessionHandler(stores, &Services{Orchestrator: orch}, zerolog.Nop())
-	payload := json.RawMessage(`{"session_id":"` + sessionID.String() + `","org_id":"` + orgID.String() + `","capacity_waited":true,"capacity_cleanup":true}`)
+	payload := json.RawMessage(`{"session_id":"` + sessionID.String() + `","org_id":"` + orgID.String() + `","thread_id":"` + threadID.String() + `","capacity_waited":true,"capacity_cleanup":true}`)
 	ctx := jobctx.WithJobID(context.Background(), currentJobID)
 
 	err := handler(ctx, "continue_session", payload)
-	require.NoError(t, err, "queued cleanup should stop without stealing a live sibling turn's cancellation")
+	require.NoError(t, err, "queued cleanup should stop without stealing a live sibling turn's cancellation and finalize its own thread")
 	require.Equal(t, 0, orch.continueSessionCalls, "cancellation cleanup must not reach the orchestrator")
-	require.NoError(t, mock.ExpectationsWereMet(), "live sibling should retain the undelivered session cancellation request")
+	require.NoError(t, mock.ExpectationsWereMet(), "live sibling should retain the undelivered session cancellation while the consumed job's thread is cancelled")
 }
 
 func TestContinueSessionHandler_StopsCleanupAfterCancellationWasConsumed(t *testing.T) {

--- a/internal/worker/handlers_test.go
+++ b/internal/worker/handlers_test.go
@@ -10804,8 +10804,8 @@ func TestSandboxTurnCapacityRetryTargetQuicklyReservesAlternateWorker(t *testing
 	mock.ExpectQuery(`(?s)SELECT COUNT\(\*\).*FROM jobs.*id <>.*job_type IN`).
 		WithArgs(orgID, jobID).
 		WillReturnRows(pgxmock.NewRows([]string{"count"}).AddRow(0))
-	mock.ExpectQuery(`(?s)WITH candidate_nodes AS.*raw_load AS.*candidate_load AS.*SELECT id.*FROM candidate_load`).
-		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), models.SandboxWorkloadClassInteractive).
+	mock.ExpectQuery(`(?s)WITH excluded_capacity_nodes AS.*candidate_nodes AS.*raw_load AS.*candidate_load AS.*SELECT id.*FROM candidate_load`).
+		WithArgs(jobID, orgID, pgxmock.AnyArg(), pgxmock.AnyArg(), models.SandboxWorkloadClassInteractive).
 		WillReturnRows(pgxmock.NewRows([]string{"id"}).AddRow("worker-with-space"))
 	mock.ExpectQuery(`SELECT pg_try_advisory_xact_lock`).
 		WithArgs("worker-with-space").
@@ -12061,14 +12061,14 @@ func TestContinueSessionHandler_StopsCapacityRetryAfterTerminalOrCancel(t *testi
 				mock.ExpectQuery(`(?s)SELECT EXISTS.*FROM jobs j.*j\.id <> @current_job_id.*capacity_cleanup`).
 					WithArgs(orgID, uuid.Nil, sessionID.String()).
 					WillReturnRows(pgxmock.NewRows([]string{"exists"}).AddRow(false))
-				mock.ExpectExec(`(?s)UPDATE session_cancel_requests.*SET delivered_at = now\(\).*delivered_at IS NULL`).
-					WithArgs(orgID, sessionID).
-					WillReturnResult(pgxmock.NewResult("UPDATE", 1))
-				mock.ExpectQuery(`(?s)UPDATE sessions SET status = @status, completed_at = now\(\).*RETURNING`).
+				mock.ExpectQuery(`(?s)UPDATE sessions.*status = @status.*status IN \('pending', 'running', 'idle', 'awaiting_input', 'needs_human_guidance'\).*RETURNING`).
 					WithArgs(string(models.SessionStatusCancelled), sessionID, orgID).
 					WillReturnRows(pgxmock.NewRows(workerSessionColumns).AddRow(
 						workerSessionRow(sessionID, issueID, orgID, models.SessionStatusCancelled, 2, nil, nil)...,
 					))
+				mock.ExpectExec(`(?s)UPDATE session_cancel_requests.*SET delivered_at = now\(\).*delivered_at IS NULL`).
+					WithArgs(orgID, sessionID).
+					WillReturnResult(pgxmock.NewResult("UPDATE", 1))
 				mock.ExpectExec(`(?s)UPDATE jobs.*status = 'cancelled'.*id = ANY\(@sibling_job_ids\).*job_type = 'continue_session'.*payload->>'session_id' = @session_id`).
 					WithArgs(orgID, []uuid.UUID{siblingJobID}, sessionID.String()).
 					WillReturnResult(pgxmock.NewResult("UPDATE", 1))
@@ -12121,14 +12121,14 @@ func TestContinueSessionHandler_CancelsAssociatedThreadForPendingSessionCancella
 	mock.ExpectQuery(`(?s)SELECT EXISTS.*FROM jobs j.*j\.id <> @current_job_id.*capacity_cleanup`).
 		WithArgs(orgID, uuid.Nil, sessionID.String()).
 		WillReturnRows(pgxmock.NewRows([]string{"exists"}).AddRow(false))
-	mock.ExpectExec(`(?s)UPDATE session_cancel_requests.*SET delivered_at = now\(\).*delivered_at IS NULL`).
-		WithArgs(orgID, sessionID).
-		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
-	mock.ExpectQuery(`(?s)UPDATE sessions SET status = @status, completed_at = now\(\).*RETURNING`).
+	mock.ExpectQuery(`(?s)UPDATE sessions.*status = @status.*status IN \('pending', 'running', 'idle', 'awaiting_input', 'needs_human_guidance'\).*RETURNING`).
 		WithArgs(string(models.SessionStatusCancelled), sessionID, orgID).
 		WillReturnRows(pgxmock.NewRows(workerSessionColumns).AddRow(
 			workerSessionRow(sessionID, issueID, orgID, models.SessionStatusCancelled, 2, nil, nil)...,
 		))
+	mock.ExpectExec(`(?s)UPDATE session_cancel_requests.*SET delivered_at = now\(\).*delivered_at IS NULL`).
+		WithArgs(orgID, sessionID).
+		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
 	mock.ExpectExec(`(?s)UPDATE jobs.*status = 'cancelled'.*id = ANY\(@sibling_job_ids\).*job_type = 'continue_session'.*payload->>'session_id' = @session_id`).
 		WithArgs(orgID, []uuid.UUID{siblingJobID}, sessionID.String()).
 		WillReturnResult(pgxmock.NewResult("UPDATE", 1))

--- a/internal/worker/handlers_test.go
+++ b/internal/worker/handlers_test.go
@@ -10811,7 +10811,7 @@ func TestSandboxTurnCapacityRetryTargetQuicklyReservesAlternateWorker(t *testing
 		WithArgs("worker-with-space").
 		WillReturnRows(pgxmock.NewRows([]string{"locked"}).AddRow(true))
 	mock.ExpectQuery(`(?s)SELECT.*FROM nodes n.*WHERE n.id =`).
-		WithArgs(jobID, "worker-with-space", pgxmock.AnyArg()).
+		WithArgs("worker-with-space", pgxmock.AnyArg(), jobID).
 		WillReturnRows(pgxmock.NewRows([]string{"live", "local_reserved", "sandbox_turn_local_reserved", "max_active", "interactive_reserved", "pending_durable_reserved", "running_durable_reserved", "shared_turn_reserved", "shared_non_turn_reserved"}).AddRow(1, 0, 0, 4, 1, 0, 0, 0, 0))
 	mock.ExpectExec(`(?s)UPDATE jobs.*sandbox_slot_reserved_until =`).
 		WithArgs(models.SandboxWorkloadClassInteractive, "worker-with-space", pgxmock.AnyArg(), jobID, models.JobStatusRunning, lockToken).
@@ -10824,7 +10824,7 @@ func TestSandboxTurnCapacityRetryTargetQuicklyReservesAlternateWorker(t *testing
 	require.NotNil(t, targetNodeID, "capacity retry should return the atomically reserved alternate worker")
 	require.Equal(t, "worker-with-space", *targetNodeID, "capacity retry should exclude the full worker")
 	require.False(t, clearTargetNodeID, "capacity retry should preserve the new target reservation")
-	require.Equal(t, sandboxAlternateWorkerRetryDelay, retryAfter, "capacity retry should use the short alternate-worker handoff delay")
+	require.Equal(t, sandboxAlternateWorkerRetryDelay, retryAfter, "capacity retry should make an atomically reserved alternate-worker handoff immediately runnable")
 	require.Less(t, retryAfter, sandboxCapacityRetryDelay, "alternate-worker handoff should remain faster than a full-fleet retry")
 	require.NoError(t, mock.ExpectationsWereMet(), "alternate selection and reservation should commit before the quick retry")
 }

--- a/internal/worker/handlers_test.go
+++ b/internal/worker/handlers_test.go
@@ -10812,7 +10812,7 @@ func TestSandboxTurnCapacityRetryTargetQuicklyReservesAlternateWorker(t *testing
 		WillReturnRows(pgxmock.NewRows([]string{"locked"}).AddRow(true))
 	mock.ExpectQuery(`(?s)SELECT.*FROM nodes n.*WHERE n.id =`).
 		WithArgs(jobID, "worker-with-space", pgxmock.AnyArg()).
-		WillReturnRows(pgxmock.NewRows([]string{"live", "local_reserved", "sandbox_turn_local_reserved", "max_active", "interactive_reserved", "pending_durable_reserved", "running_durable_reserved"}).AddRow(1, 0, 0, 4, 1, 0, 0))
+		WillReturnRows(pgxmock.NewRows([]string{"live", "local_reserved", "sandbox_turn_local_reserved", "max_active", "interactive_reserved", "pending_durable_reserved", "running_durable_reserved", "shared_turn_reserved", "shared_non_turn_reserved"}).AddRow(1, 0, 0, 4, 1, 0, 0, 0, 0))
 	mock.ExpectExec(`(?s)UPDATE jobs.*sandbox_slot_reserved_until =`).
 		WithArgs(models.SandboxWorkloadClassInteractive, "worker-with-space", pgxmock.AnyArg(), jobID, models.JobStatusRunning, lockToken).
 		WillReturnResult(pgxmock.NewResult("UPDATE", 1))

--- a/internal/worker/handlers_test.go
+++ b/internal/worker/handlers_test.go
@@ -10786,6 +10786,48 @@ func TestRunAgentHandler_SandboxCapacityRetries(t *testing.T) {
 	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
 }
 
+func TestRunAgentHandler_SandboxCapacityAttemptConflictWaitsOnCurrentTarget(t *testing.T) {
+	t.Parallel()
+
+	stores, mock := newTestStores(t)
+	defer mock.Close()
+
+	orgID := uuid.New()
+	runID := uuid.New()
+	issueID := uuid.New()
+
+	mock.ExpectQuery("SELECT .* FROM sessions").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(
+			pgxmock.NewRows(workerSessionColumns).AddRow(
+				workerSessionRow(runID, issueID, orgID, models.SessionStatusPending, 0, nil, nil)...,
+			),
+		)
+
+	conflictExpiresAt := time.Now().Add(10 * time.Minute)
+	orch := &orchestratorServiceStub{
+		runAgentFn: func(ctx context.Context, run *models.Session) error {
+			return fmt.Errorf("shared admission: %w: %w", agent.ErrSandboxCapacity, &db.SandboxCapacityAttemptConflictError{ExpiresAt: conflictExpiresAt})
+		},
+	}
+	handler := newRunAgentHandler(stores, &Services{Orchestrator: orch}, zerolog.Nop())
+	payload := json.RawMessage(`{"session_id":"` + runID.String() + `","org_id":"` + orgID.String() + `"}`)
+
+	err := handler(jobctx.WithWorkerNodeID(context.Background(), "worker-current"), "run_agent", payload)
+
+	require.Error(t, err, "run_agent should retry while a stale attempt reservation is live")
+	var retryable *RetryableError
+	require.ErrorAs(t, err, &retryable, "attempt conflicts should be returned as retryable errors")
+	require.ErrorIs(t, retryable.Err, db.ErrSandboxCapacityAttemptConflict, "retry should preserve the attempt-conflict sentinel")
+	require.True(t, retryable.BypassMaxRetryDuration, "attempt-conflict retries should outlive the shorter generic retry window")
+	require.NotNil(t, retryable.RetryAfter, "attempt-conflict retries should wait for the stale lease deadline")
+	require.Greater(t, *retryable.RetryAfter, 9*time.Minute, "attempt-conflict retries should avoid relaunching executors before the stale lease expires")
+	require.LessOrEqual(t, *retryable.RetryAfter, 10*time.Minute+sandboxAttemptConflictRetryBuffer, "attempt-conflict retries should resume immediately after the stale lease expires")
+	require.Nil(t, retryable.TargetNodeID, "job-global attempt conflicts should not retarget another worker")
+	require.False(t, retryable.ClearTargetNodeID, "job-global attempt conflicts should preserve the current worker target")
+	require.NoError(t, mock.ExpectationsWereMet(), "attempt-conflict retry should not query fleet routing")
+}
+
 func TestSandboxTurnCapacityRetryTargetQuicklyReservesAlternateWorker(t *testing.T) {
 	t.Parallel()
 
@@ -12397,6 +12439,49 @@ func TestContinueSessionHandler_SandboxCapacityRetries(t *testing.T) {
 	require.False(t, retryable.ClearTargetNodeID, "sandbox capacity retries should not clear the target pin when a replacement worker is selected")
 	require.Equal(t, 1, orch.continueSessionCalls, "continue_session should call the orchestrator once before returning the retry")
 	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
+}
+
+func TestContinueSessionHandler_SandboxCapacityAttemptConflictWaitsOnCurrentTarget(t *testing.T) {
+	t.Parallel()
+
+	stores, mock := newTestStores(t)
+	defer mock.Close()
+
+	orgID := uuid.New()
+	sessionID := uuid.New()
+	issueID := uuid.New()
+
+	mock.ExpectQuery("SELECT .* FROM sessions").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(
+			pgxmock.NewRows(workerSessionColumns).AddRow(
+				workerSessionRow(sessionID, issueID, orgID, models.SessionStatusIdle, 2, nil, nil)...,
+			),
+		)
+
+	conflictExpiresAt := time.Now().Add(10 * time.Minute)
+	orch := &orchestratorServiceStub{
+		continueSessionFn: func(ctx context.Context, session *models.Session, opts *agent.ContinueSessionOptions) error {
+			return fmt.Errorf("shared admission: %w: %w", agent.ErrSandboxCapacity, &db.SandboxCapacityAttemptConflictError{ExpiresAt: conflictExpiresAt})
+		},
+	}
+	handler := newContinueSessionHandler(stores, &Services{Orchestrator: orch}, zerolog.Nop())
+	payload := json.RawMessage(`{"session_id":"` + sessionID.String() + `","org_id":"` + orgID.String() + `"}`)
+
+	err := handler(jobctx.WithWorkerNodeID(context.Background(), "worker-current"), "continue_session", payload)
+
+	require.Error(t, err, "continue_session should retry while a stale attempt reservation is live")
+	var retryable *RetryableError
+	require.ErrorAs(t, err, &retryable, "attempt conflicts should be returned as retryable errors")
+	require.ErrorIs(t, retryable.Err, db.ErrSandboxCapacityAttemptConflict, "retry should preserve the attempt-conflict sentinel")
+	require.True(t, retryable.BypassMaxRetryDuration, "attempt-conflict retries should outlive the shorter generic retry window")
+	require.NotNil(t, retryable.RetryAfter, "attempt-conflict retries should wait for the stale lease deadline")
+	require.Greater(t, *retryable.RetryAfter, 9*time.Minute, "attempt-conflict retries should avoid relaunching executors before the stale lease expires")
+	require.LessOrEqual(t, *retryable.RetryAfter, 10*time.Minute+sandboxAttemptConflictRetryBuffer, "attempt-conflict retries should resume immediately after the stale lease expires")
+	require.Nil(t, retryable.TargetNodeID, "job-global attempt conflicts should not retarget another worker")
+	require.False(t, retryable.ClearTargetNodeID, "job-global attempt conflicts should preserve the current worker target")
+	require.Equal(t, 1, orch.continueSessionCalls, "continue_session should call the orchestrator once before returning the retry")
+	require.NoError(t, mock.ExpectationsWereMet(), "attempt-conflict retry should not query fleet routing")
 }
 
 func TestContinueSessionHandler_SandboxCapacityRetriesClearsTargetWhenNoWorkerAvailable(t *testing.T) {

--- a/internal/worker/handlers_test.go
+++ b/internal/worker/handlers_test.go
@@ -10804,7 +10804,7 @@ func TestSandboxTurnCapacityRetryTargetQuicklyReservesAlternateWorker(t *testing
 	mock.ExpectQuery(`(?s)SELECT COUNT\(\*\).*FROM jobs.*id <>.*job_type IN`).
 		WithArgs(orgID, jobID).
 		WillReturnRows(pgxmock.NewRows([]string{"count"}).AddRow(0))
-	mock.ExpectQuery(`(?s)WITH raw_load AS.*candidate_load AS.*SELECT id.*FROM candidate_load`).
+	mock.ExpectQuery(`(?s)WITH candidate_nodes AS.*raw_load AS.*candidate_load AS.*SELECT id.*FROM candidate_load`).
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), models.SandboxWorkloadClassInteractive).
 		WillReturnRows(pgxmock.NewRows([]string{"id"}).AddRow("worker-with-space"))
 	mock.ExpectQuery(`SELECT pg_try_advisory_xact_lock`).

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -241,6 +241,14 @@ func (w *Worker) poll(ctx context.Context) {
 				event.Str("target_node_id", *result.TargetNodeID)
 			}
 			event.Msg("sandbox job routing evaluated")
+			if result.RoutingError != "" {
+				w.logger.Error().
+					Str("job_id", result.JobID.String()).
+					Str("workload_class", string(result.WorkloadClass)).
+					Str("routing_reason", string(result.Reason)).
+					Str("routing_error", result.RoutingError).
+					Msg("sandbox job routing failed; deferred only the affected job")
+			}
 			if result.Reason == db.SandboxRoutingReasonMetadataFallback {
 				w.logger.Warn().
 					Str("job_id", result.JobID.String()).

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -130,6 +130,11 @@ type sandboxJobRouter interface {
 // the pass immediately because no later sandbox job can be placed either.
 const maxSandboxRoutingDecisionsPerPoll = 16
 
+// Delayed wake-ups are an optimization for the short capacity retry paths.
+// Longer generic backoffs rely on the durable database poll instead of keeping
+// a worker and notifier alive for the full retry window.
+const maxScheduledRetryWakeDelay = db.SandboxFleetRetryDelay
+
 // maxRetryableDuration is the maximum wall-clock time a retryable job is
 // allowed to keep retrying before being dead-lettered. This prevents jobs
 // from retrying indefinitely (e.g. when stuck behind a concurrency limit).
@@ -176,8 +181,10 @@ func (w *Worker) SetJobNotifier(notifier *cache.JobNotifier) {
 }
 
 func New(pool db.DBTX, logger zerolog.Logger, nodeID string) *Worker {
+	jobStore := db.NewJobStore(pool)
+	jobStore.SetLogger(logger)
 	return &Worker{
-		jobs:                      db.NewJobStore(pool),
+		jobs:                      jobStore,
 		logger:                    logger,
 		nodeID:                    nodeID,
 		handlers:                  make(map[string]JobHandler),
@@ -579,16 +586,28 @@ func (w *Worker) retryJobWithDelay(ctx context.Context, jobID, lockToken uuid.UU
 		w.notifyRunnableJob(ctx, jobID)
 		return
 	}
-	// Postgres notifications are edge-triggered: publishing before run_at would
-	// only make peers poll too early, while publishing nothing leaves the job at
-	// the mercy of the five-second fallback poll. Wake the fleet when the
-	// persisted retry actually becomes runnable.
-	time.AfterFunc(backoff, func() {
-		wakeCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	if backoff <= maxScheduledRetryWakeDelay {
+		w.scheduleRunnableJobNotification(ctx, jobID, backoff)
+	}
+}
+
+func (w *Worker) scheduleRunnableJobNotification(ctx context.Context, jobID uuid.UUID, delay time.Duration) {
+	go func() {
+		timer := time.NewTimer(delay)
+		defer timer.Stop()
+		select {
+		case <-ctx.Done():
+			return
+		case <-timer.C:
+		}
+		if ctx.Err() != nil {
+			return
+		}
+		wakeCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
 		defer cancel()
 		w.notifyRunnableJob(wakeCtx, jobID)
 		w.Wake()
-	})
+	}()
 }
 
 func (w *Worker) notifyRunnableJob(ctx context.Context, jobID uuid.UUID) {

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -577,7 +577,18 @@ func (w *Worker) retryJobWithDelay(ctx context.Context, jobID, lockToken uuid.UU
 	}
 	if backoff <= 0 {
 		w.notifyRunnableJob(ctx, jobID)
+		return
 	}
+	// Postgres notifications are edge-triggered: publishing before run_at would
+	// only make peers poll too early, while publishing nothing leaves the job at
+	// the mercy of the five-second fallback poll. Wake the fleet when the
+	// persisted retry actually becomes runnable.
+	time.AfterFunc(backoff, func() {
+		wakeCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		w.notifyRunnableJob(wakeCtx, jobID)
+		w.Wake()
+	})
 }
 
 func (w *Worker) notifyRunnableJob(ctx context.Context, jobID uuid.UUID) {

--- a/internal/worker/worker_test.go
+++ b/internal/worker/worker_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -52,17 +53,28 @@ type retryWindowLeaseStoreStub struct {
 
 type retryNotifyStore struct {
 	wakeTestStore
+	mu            sync.Mutex
 	retriedJobID  uuid.UUID
 	notifiedJobID uuid.UUID
 }
 
 func (s *retryNotifyStore) RetryWithLease(_ context.Context, jobID, _ uuid.UUID, _ string, _ time.Time) (bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	s.retriedJobID = jobID
 	return true, nil
 }
 
 func (s *retryNotifyStore) Notify(_ context.Context, jobID uuid.UUID) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	s.notifiedJobID = jobID
+}
+
+func (s *retryNotifyStore) retryState() (uuid.UUID, uuid.UUID) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.retriedJobID, s.notifiedJobID
 }
 
 func (s *retryWindowLeaseStoreStub) EnsureRetryWindowStartedAtWithLease(context.Context, uuid.UUID, uuid.UUID, time.Time) (time.Time, bool, error) {
@@ -128,13 +140,14 @@ func TestWorker_RetryNotifiesOnlyAfterJobBecomesImmediatelyRunnable(t *testing.T
 	t.Parallel()
 
 	zeroDelay := time.Duration(0)
+	shortDelay := 20 * time.Millisecond
 	tests := []struct {
-		name             string
-		override         *time.Duration
-		expectedNotified bool
+		name      string
+		override  *time.Duration
+		immediate bool
 	}{
-		{name: "immediate retry wakes workers", override: &zeroDelay, expectedNotified: true},
-		{name: "delayed retry waits for polling", expectedNotified: false},
+		{name: "immediate retry wakes workers", override: &zeroDelay, immediate: true},
+		{name: "delayed retry wakes workers when due", override: &shortDelay},
 	}
 
 	for _, tt := range tests {
@@ -142,16 +155,21 @@ func TestWorker_RetryNotifiesOnlyAfterJobBecomesImmediatelyRunnable(t *testing.T
 			t.Parallel()
 
 			store := &retryNotifyStore{}
-			w := &Worker{jobs: store, logger: zerolog.Nop()}
+			w := &Worker{jobs: store, logger: zerolog.Nop(), wakeCh: make(chan struct{}, 1)}
 			jobID := uuid.New()
 
 			w.retryJobWithDelay(context.Background(), jobID, uuid.New(), "capacity moved", 1, false, tt.override, nil, false)
 
-			require.Equal(t, jobID, store.retriedJobID, "retry should first persist the pending job transition")
-			if tt.expectedNotified {
-				require.Equal(t, jobID, store.notifiedJobID, "an immediately runnable retry should wake workers")
+			retriedJobID, notifiedJobID := store.retryState()
+			require.Equal(t, jobID, retriedJobID, "retry should first persist the pending job transition")
+			if tt.immediate {
+				require.Equal(t, jobID, notifiedJobID, "an immediately runnable retry should wake workers")
 			} else {
-				require.Equal(t, uuid.Nil, store.notifiedJobID, "a delayed retry should not wake the fleet before run_at")
+				require.Equal(t, uuid.Nil, notifiedJobID, "a delayed retry should not wake the fleet before run_at")
+				require.Eventually(t, func() bool {
+					_, notifiedJobID = store.retryState()
+					return notifiedJobID == jobID && len(w.wakeCh) == 1
+				}, time.Second, 5*time.Millisecond, "a delayed retry should publish and wake the local worker when run_at arrives")
 			}
 		})
 	}

--- a/internal/worker/worker_test.go
+++ b/internal/worker/worker_test.go
@@ -355,7 +355,7 @@ func TestWorker_Poll(t *testing.T) {
 				t.Helper()
 				mock.ExpectBegin()
 				mock.ExpectQuery("WITH unavailable_target_nodes AS").
-					WithArgs(pgxmock.AnyArg(), "test-node").
+					WithArgs(pgxmock.AnyArg(), "test-node", []uuid.UUID{}).
 					WillReturnError(pgx.ErrNoRows)
 				mock.ExpectRollback()
 			},
@@ -693,7 +693,7 @@ func TestWorker_Poll(t *testing.T) {
 				now := time.Now()
 				mock.ExpectBegin()
 				mock.ExpectQuery("WITH unavailable_target_nodes AS").
-					WithArgs(pgxmock.AnyArg(), "test-node").
+					WithArgs(pgxmock.AnyArg(), "test-node", []uuid.UUID{}).
 					WillReturnRows(pgxmock.NewRows([]string{"id", "org_id", "job_type", "session_id", "workload_class", "status", "retry_window_started_at", "created_at"}).
 						AddRow(jobID, orgID, "missing_token", nil, models.SandboxWorkloadClassInteractive, models.JobStatusPending, nil, now))
 				mock.ExpectQuery("UPDATE jobs j").
@@ -1175,7 +1175,7 @@ func TestWorker_Start_StopsOnContextCancel(t *testing.T) {
 	for range 5 {
 		mock.ExpectBegin()
 		mock.ExpectQuery("WITH unavailable_target_nodes AS").
-			WithArgs(pgxmock.AnyArg(), "test-node").
+			WithArgs(pgxmock.AnyArg(), "test-node", []uuid.UUID{}).
 			WillReturnError(pgx.ErrNoRows)
 		mock.ExpectRollback()
 	}
@@ -1371,7 +1371,7 @@ func expectClaimWithAttemptsAndTarget(mock pgxmock.PgxPoolIface, jobID, orgID uu
 	}
 	mock.ExpectBegin()
 	mock.ExpectQuery("WITH unavailable_target_nodes AS").
-		WithArgs(pgxmock.AnyArg(), "test-node").
+		WithArgs(pgxmock.AnyArg(), "test-node", []uuid.UUID{}).
 		WillReturnRows(pgxmock.NewRows([]string{"id", "org_id", "job_type", "session_id", "workload_class", "status", "retry_window_started_at", "created_at"}).
 			AddRow(jobID, orgID, jobType, nil, models.SandboxWorkloadClassInteractive, models.JobStatusPending, nil, createdAt))
 	if jobType == "run_agent" || jobType == "continue_session" {

--- a/internal/worker/worker_test.go
+++ b/internal/worker/worker_test.go
@@ -175,6 +175,24 @@ func TestWorker_RetryNotifiesWhenJobBecomesRunnable(t *testing.T) {
 	}
 }
 
+func TestWorker_DelayedRetryWakeStopsWithWorkerContext(t *testing.T) {
+	t.Parallel()
+
+	delay := 20 * time.Millisecond
+	store := &retryNotifyStore{}
+	w := &Worker{jobs: store, logger: zerolog.Nop(), wakeCh: make(chan struct{}, 1)}
+	jobID := uuid.New()
+	ctx, cancel := context.WithCancel(context.Background())
+
+	w.retryJobWithDelay(ctx, jobID, uuid.New(), "capacity moved", 1, false, &delay, nil, false)
+	cancel()
+
+	require.Never(t, func() bool {
+		_, notifiedJobID := store.retryState()
+		return notifiedJobID != uuid.Nil || len(w.wakeCh) != 0
+	}, 100*time.Millisecond, 5*time.Millisecond, "worker shutdown should cancel delayed retry wake-ups")
+}
+
 func TestRetryableDurationExceeded(t *testing.T) {
 	t.Parallel()
 
@@ -1357,6 +1375,8 @@ func expectClaimWithAttemptsAndTarget(mock pgxmock.PgxPoolIface, jobID, orgID uu
 		WillReturnRows(pgxmock.NewRows([]string{"id", "org_id", "job_type", "session_id", "workload_class", "status", "retry_window_started_at", "created_at"}).
 			AddRow(jobID, orgID, jobType, nil, models.SandboxWorkloadClassInteractive, models.JobStatusPending, nil, createdAt))
 	if jobType == "run_agent" || jobType == "continue_session" {
+		mock.ExpectExec(`SAVEPOINT sandbox_claim_candidate`).
+			WillReturnResult(pgxmock.NewResult("SAVEPOINT", 0))
 		mock.ExpectQuery(`(?s)SELECT settings.*FROM organizations.*FOR NO KEY UPDATE`).
 			WithArgs(orgID).
 			WillReturnRows(pgxmock.NewRows([]string{"settings"}).AddRow([]byte(`{"max_concurrent_runs":3}`)))

--- a/internal/worker/worker_test.go
+++ b/internal/worker/worker_test.go
@@ -136,7 +136,7 @@ func TestRetryableError(t *testing.T) {
 	require.ErrorIs(t, retryable.Unwrap(), cause, "Unwrap should expose the wrapped error")
 }
 
-func TestWorker_RetryNotifiesOnlyAfterJobBecomesImmediatelyRunnable(t *testing.T) {
+func TestWorker_RetryNotifiesWhenJobBecomesRunnable(t *testing.T) {
 	t.Parallel()
 
 	zeroDelay := time.Duration(0)

--- a/migrations/000288_shared_sandbox_capacity_reservations.down.sql
+++ b/migrations/000288_shared_sandbox_capacity_reservations.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS sandbox_capacity_reservations;

--- a/migrations/000288_shared_sandbox_capacity_reservations.up.sql
+++ b/migrations/000288_shared_sandbox_capacity_reservations.up.sql
@@ -7,6 +7,8 @@ CREATE TABLE sandbox_capacity_reservations ( -- lint:no-org-id reason="ephemeral
     -- Runtime leases intentionally avoid parent FKs: creating them during a
     -- rolling deploy would lock the hot nodes/jobs tables, while orphaned
     -- leases are harmless after expires_at and are cleaned on admission.
+    -- Stable physical-host capacity ID. Blue/green worker generations that
+    -- share one Docker daemon intentionally use the same value.
     node_id text NOT NULL,
     job_id uuid,
     workload_class text NOT NULL,

--- a/migrations/000288_shared_sandbox_capacity_reservations.up.sql
+++ b/migrations/000288_shared_sandbox_capacity_reservations.up.sql
@@ -4,8 +4,11 @@
 -- process-local counters alone.
 CREATE TABLE sandbox_capacity_reservations ( -- lint:no-org-id reason="ephemeral fleet capacity leases are worker-scoped and may represent work from any organization"
     id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
-    node_id text NOT NULL REFERENCES nodes(id) ON DELETE CASCADE,
-    job_id uuid REFERENCES jobs(id) ON DELETE CASCADE,
+    -- Runtime leases intentionally avoid parent FKs: creating them during a
+    -- rolling deploy would lock the hot nodes/jobs tables, while orphaned
+    -- leases are harmless after expires_at and are cleaned on admission.
+    node_id text NOT NULL,
+    job_id uuid,
     workload_class text NOT NULL,
     expires_at timestamptz NOT NULL,
     created_at timestamptz NOT NULL DEFAULT now(),

--- a/migrations/000288_shared_sandbox_capacity_reservations.up.sql
+++ b/migrations/000288_shared_sandbox_capacity_reservations.up.sql
@@ -1,0 +1,21 @@
+-- Final sandbox admission runs in both the main worker process and isolated
+-- session-executor processes. Persist short-lived admission leases so those
+-- processes serialize against the same worker capacity instead of relying on
+-- process-local counters alone.
+CREATE TABLE sandbox_capacity_reservations ( -- lint:no-org-id reason="ephemeral fleet capacity leases are worker-scoped and may represent work from any organization"
+    id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    node_id text NOT NULL REFERENCES nodes(id) ON DELETE CASCADE,
+    job_id uuid REFERENCES jobs(id) ON DELETE CASCADE,
+    workload_class text NOT NULL,
+    expires_at timestamptz NOT NULL,
+    created_at timestamptz NOT NULL DEFAULT now(),
+    CONSTRAINT chk_sandbox_capacity_reservations_workload_class
+        CHECK (workload_class IN ('interactive', 'code_review'))
+);
+
+CREATE UNIQUE INDEX idx_sandbox_capacity_reservations_job
+    ON sandbox_capacity_reservations (job_id)
+    WHERE job_id IS NOT NULL;
+
+CREATE INDEX idx_sandbox_capacity_reservations_node_expiry
+    ON sandbox_capacity_reservations (node_id, expires_at);

--- a/migrations/000289_fence_shared_sandbox_capacity_reservations.down.sql
+++ b/migrations/000289_fence_shared_sandbox_capacity_reservations.down.sql
@@ -1,0 +1,7 @@
+DROP TRIGGER IF EXISTS trg_sandbox_capacity_require_attempt_token
+    ON sandbox_capacity_reservations;
+DROP FUNCTION IF EXISTS reject_unfenced_sandbox_capacity_reservation();
+
+ALTER TABLE sandbox_capacity_reservations
+    DROP CONSTRAINT IF EXISTS chk_sandbox_capacity_reservations_job_attempt,
+    DROP COLUMN IF EXISTS job_lock_token;

--- a/migrations/000289_fence_shared_sandbox_capacity_reservations.up.sql
+++ b/migrations/000289_fence_shared_sandbox_capacity_reservations.up.sql
@@ -1,0 +1,42 @@
+-- Fence job-backed final-admission leases to the queue claim attempt. Existing
+-- live rows are backfilled when their job is still owned; unmatched ephemeral
+-- rows remain valid until their short TTL expires, so the constraint is added
+-- NOT VALID while still enforcing the invariant on new writes.
+ALTER TABLE sandbox_capacity_reservations
+    ADD COLUMN job_lock_token uuid;
+
+UPDATE sandbox_capacity_reservations reservation
+SET job_lock_token = job.lock_token
+FROM jobs job
+WHERE reservation.job_id = job.id
+  AND reservation.job_lock_token IS NULL
+  AND job.status = 'running'
+  AND job.lock_token IS NOT NULL;
+
+ALTER TABLE sandbox_capacity_reservations
+    ADD CONSTRAINT chk_sandbox_capacity_reservations_job_attempt
+    CHECK ((job_id IS NULL) = (job_lock_token IS NULL)) NOT VALID;
+
+-- A pre-289 worker does not send the attempt token. A BEFORE INSERT trigger is
+-- required in addition to the check constraint: its legacy ON CONFLICT update
+-- could otherwise reuse a new worker's valid row without ever producing an
+-- invalid final tuple. Fail those job-backed admissions closed during the
+-- brief rolling overlap; preview reservations (job_id NULL) remain compatible.
+CREATE FUNCTION reject_unfenced_sandbox_capacity_reservation()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    IF (NEW.job_id IS NULL) <> (NEW.job_lock_token IS NULL) THEN
+        RAISE EXCEPTION 'job-backed sandbox capacity reservation requires a matching job lock token'
+            USING ERRCODE = '23514';
+    END IF;
+    RETURN NEW;
+END;
+$$;
+
+CREATE TRIGGER trg_sandbox_capacity_require_attempt_token
+    BEFORE INSERT OR UPDATE OF job_id, job_lock_token
+    ON sandbox_capacity_reservations
+    FOR EACH ROW
+    EXECUTE FUNCTION reject_unfenced_sandbox_capacity_reservation();


### PR DESCRIPTION
## Stack

3 of 3, based on #2114.

- #2113: reuse normal session routing for code-review turns and remove avoidable alternate-worker delay
- #2114: shared admission and durable pre-claim worker reservations
- **#2115:** cross-process final admission, attempt fencing, and rollout hardening

## Summary

This PR extracts the cross-process correctness layer from #2103:

- introduces ephemeral `sandbox_capacity_reservations` leases shared by the main worker, isolated session executors, and other processes using the same Docker host;
- serializes durable routing and final admission with a physical-host advisory lock;
- fences job-backed leases to the current queue claim token;
- prevents stale attempts from releasing or reusing a replacement attempt's capacity;
- uses a host-stable capacity identity across blue/green worker generations;
- renews/releases reservations through sandbox startup, hydration, cancellation, and retry paths;
- reroutes startup failures away from the failed physical host;
- hardens delayed wakeups, poisoned routing candidates, cancellation cleanup, and stale lease handling;
- adds migrations 289–290 for shared leases and attempt fencing.

Migration numbers were advanced to follow #2114's migrations 287–288 and migration 286 now present on `main`.

## Why this is separate

Atomic pre-claim placement can only be authoritative if the process that creates the container participates in the same capacity accounting. Production hands session turns to isolated executor processes, and blue/green generations can overlap on one Docker daemon. This PR owns that process/host coordination without obscuring the simpler code-review behavior in #2113.

## Validation

- `go test ./cmd/migrate ./internal/db ./internal/services/agent ./internal/worker -count=1`
- `go vet ./cmd/migrate ./internal/db ./internal/services/agent ./internal/worker`
- `go test -tags integration ./internal/integration -run '^$' -count=1`
- tenancy/schema pre-commit lints
- `git diff --check`
