### PR TITLE
Exclude Graphite stack logos from code review visual evidence

### DIFF
--- a/docs/design/implemented/124-code-review-visual-evidence.md
+++ b/docs/design/implemented/124-code-review-visual-evidence.md
@@ -28,6 +28,10 @@ The description is in scope regardless of the PR author's GitHub actor type.
 Discussion images are in scope only when GitHub classifies the author as a
 `User` or `Mannequin`, including outside contributors. Exclude `Bot`, `App`,
 `Organization`, deleted/unknown actors, and therefore 143-authored output.
+Exclude the exact Graphite stack-navigation logo asset as decorative integration
+chrome even when Graphite updates the stack comment under a human user's
+identity. This exclusion happens before retained-source counting, so repeated
+stack icons neither enter provenance nor consume the assessment image limit.
 Human-authored discussion conclusions and review decisions remain excluded as
 risk signals; only the captured visual content and its bounded provenance are
 evidence.
@@ -194,10 +198,11 @@ passing active vector content to agents. Enforce:
 - three redirects; and
 - three transient attempts with bounded backoff.
 
-All human images are eligible. Discovery retains provenance for at most the
-first 32 images in deterministic order across all surfaces. Later sources are
-represented only by `omitted_source_count`; their URLs, captions, authors, and
-other per-image metadata are not persisted, prompted, or returned by the API.
+All human images except explicitly recognized decorative integration chrome are
+eligible. Discovery retains provenance for at most the first 32 images in
+deterministic order across all surfaces. Later sources are represented only by
+`omitted_source_count`; their URLs, captions, authors, and other per-image
+metadata are not persisted, prompted, or returned by the API.
 Materialization deduplicates retained image bytes by SHA-256, and agent-message
 projection attaches each unique hash once without collapsing its provenance.
 An inaccessible or oversized retained image is recorded but cannot satisfy

--- a/internal/services/github/code_review_visual_evidence.go
+++ b/internal/services/github/code_review_visual_evidence.go
@@ -295,7 +295,7 @@ func visualEvidenceSourcesFromHTMLBounded(metadata visualEvidenceSourceMetadata,
 	imageCount := 0
 	var walk func(*html.Node)
 	walk = func(node *html.Node) {
-		if node.Type == html.ElementNode && node.Data == "img" {
+		if node.Type == html.ElementNode && node.Data == "img" && !isDecorativeGraphiteImage(node) {
 			if imageURL := renderedImageURL(node); imageURL != "" {
 				imageCount++
 				if len(sources) < limit {
@@ -326,6 +326,19 @@ func visualEvidenceSourcesFromHTMLBounded(metadata visualEvidenceSourceMetadata,
 		walk(node)
 	}
 	return sources, imageCount
+}
+
+func isDecorativeGraphiteImage(node *html.Node) bool {
+	for _, candidate := range []string{htmlAttribute(node, "data-canonical-src"), htmlAttribute(node, "src")} {
+		parsed, err := url.Parse(strings.TrimSpace(candidate))
+		if err != nil {
+			continue
+		}
+		if strings.EqualFold(parsed.Hostname(), "static.graphite.dev") && parsed.EscapedPath() == "/graphite-32x32-black.png" {
+			return true
+		}
+	}
+	return false
 }
 
 func renderedImageURL(node *html.Node) string {

--- a/internal/services/github/code_review_visual_evidence_test.go
+++ b/internal/services/github/code_review_visual_evidence_test.go
@@ -270,6 +270,13 @@ func TestVisualEvidenceSourcesFromHTML(t *testing.T) {
 			expected: []models.CodeReviewVisualEvidenceSource{{SourceID: codeReviewVisualEvidenceSourceID(metadata.Surface, "99", 1, "https://example.com/large.webp"), Surface: metadata.Surface, ProviderObjectID: "99", AuthorLogin: "human", AuthorType: models.CodeReviewEvidenceAuthorTypeUser, ImageIndex: 1, ImageURL: "https://example.com/large.webp", AltText: "responsive", Untrusted: true}},
 		},
 		{
+			name: "ignores Graphite stack icons without consuming image positions",
+			html: `<ul><li><a href="https://app.graphite.com/github/pr/acme/repo/42"><img src="https://camo.githubusercontent.com/graphite" data-canonical-src="https://static.graphite.dev/graphite-32x32-black.png" alt="Graphite" width="10px" height="10px"></a></li></ul>` +
+				`<img src="https://static.graphite.dev/graphite-32x32-black.png" alt="Graphite">` +
+				`<img src="https://example.com/screenshot.png" alt="Screenshot">`,
+			expected: []models.CodeReviewVisualEvidenceSource{{SourceID: codeReviewVisualEvidenceSourceID(metadata.Surface, "99", 1, "https://example.com/screenshot.png"), Surface: metadata.Surface, ProviderObjectID: "99", AuthorLogin: "human", AuthorType: models.CodeReviewEvidenceAuthorTypeUser, ImageIndex: 1, ImageURL: "https://example.com/screenshot.png", AltText: "Screenshot", Untrusted: true}},
+		},
+		{
 			name:     "bounds untrusted context by runes",
 			html:     `<p>` + longContext + `<img src="https://example.com/long.png" alt="` + longAlt + `"></p>`,
 			expected: []models.CodeReviewVisualEvidenceSource{{SourceID: codeReviewVisualEvidenceSourceID(metadata.Surface, "99", 1, "https://example.com/long.png"), Surface: metadata.Surface, ProviderObjectID: "99", AuthorLogin: "human", AuthorType: models.CodeReviewEvidenceAuthorTypeUser, ImageIndex: 1, ImageURL: "https://example.com/long.png", AltText: strings.Repeat("a", maxVisualEvidenceContextRunes), ContextText: strings.Repeat("é", maxVisualEvidenceContextRunes), Untrusted: true}},


### PR DESCRIPTION
## Summary

- exclude Graphite's 32×32 stack-navigation logo from rendered PR visual-evidence discovery
- recognize both GitHub's camo-rendered `data-canonical-src` form and the direct canonical asset URL
- remove the decorative icon before provenance counting so it does not consume the 32-image assessment limit
- preserve legitimate screenshots and their original first-seen image positions

## Root cause

GitHub reports Graphite's generated stack comment as authored by the human PR author. The visual-evidence collector therefore admitted the comment and treated every Graphite logo `<img>` as review evidence. PR #56201 contained 30 copies of that decorative icon alongside its real screenshot.

PR #2117 already deduplicated identical image content at agent attachment fan-out. This follow-up removes the known decorative Graphite asset from discovery entirely.

## Impact

Large Graphite stacks no longer add logo provenance or attachments to automated review prompts, and the icons cannot crowd meaningful discussion images out of the assessment limit.

## Validation

- `go test ./internal/services/github`
- `go vet ./internal/services/github`
- `git diff --check`