### PR TITLE
Prevent failed database backups from filling local disk

### DIFF
--- a/deploy/scripts/pg-backup.sh
+++ b/deploy/scripts/pg-backup.sh
@@ -11,9 +11,9 @@ set -euo pipefail
 # /opt/143/.env (written by provision.sh).
 
 BACKUP_DIR="${BACKUP_DIR:-/backups/postgres}"
-# Local retention defaults to 7 days. At ~900 MB/dump every 6h that is ~25 GB;
-# 30 days would be ~108 GB and risk filling the disk. Long-term history is the
-# job of the offsite sync, not the local disk.
+# Local retention defaults to 7 days. Dump sizes grow with the database, so
+# operators must size this window against the DB host's available disk. Long-
+# term history is the job of the offsite sync, not the local disk.
 RETENTION_DAYS="${BACKUP_RETENTION_DAYS:-7}"
 CONTAINER_NAME="${POSTGRES_CONTAINER:-143-postgres-1}"
 DB_USER="${POSTGRES_USER:-onefortythree}"
@@ -32,28 +32,62 @@ fi
 
 mkdir -p "$BACKUP_DIR"
 
+# Retention must not depend on the new dump succeeding. In particular, a run
+# that fails because Postgres is under memory pressure still needs to reclaim
+# completed backups that have aged past the local retention window.
+find "$BACKUP_DIR" -maxdepth 1 -type f -name "*.dump" -mtime +"$RETENTION_DAYS" -delete
+echo "$(date -Iseconds) Cleaned backups older than $RETENTION_DAYS days"
+
+# A normal error or signal removes the in-progress file via the EXIT trap. The
+# stale-file sweep handles the one case traps cannot catch (SIGKILL or a host
+# crash). Twelve hours is twice the cron interval, so it does not interfere
+# with a slow backup from the immediately preceding run.
+find "$BACKUP_DIR" -maxdepth 1 -type f -name ".*.dump.partial.*" -mmin +720 -delete
+
 TIMESTAMP=$(date +%Y%m%d-%H%M%S)
 BACKUP_FILE="$BACKUP_DIR/$DB_NAME-$TIMESTAMP.dump"
+PARTIAL_FILE=""
+
+cleanup_partial_dump() {
+  local status=$?
+  if [ -n "$PARTIAL_FILE" ] && [ -e "$PARTIAL_FILE" ]; then
+    if ! rm -f -- "$PARTIAL_FILE"; then
+      echo "ERROR: Failed to remove incomplete backup $PARTIAL_FILE" >&2
+    fi
+  fi
+  return "$status"
+}
+
+trap cleanup_partial_dump EXIT
+trap 'exit 129' HUP
+trap 'exit 130' INT
+trap 'exit 143' TERM
+
+# Keep the in-progress file hidden and distinguishable from verified dumps.
+# mktemp creates it in the final directory so the promotion below is an atomic
+# rename on the same filesystem.
+PARTIAL_FILE="$(mktemp "$BACKUP_DIR/.${DB_NAME}-${TIMESTAMP}.dump.partial.XXXXXX")"
+chmod 0600 "$PARTIAL_FILE"
 
 # Custom format: compressed, supports selective restore
 docker exec -e PGPASSWORD="$DB_PASSWORD" "$CONTAINER_NAME" \
-  pg_dump -U "$DB_USER" -Fc "$DB_NAME" > "$BACKUP_FILE"
+  pg_dump -U "$DB_USER" -Fc "$DB_NAME" > "$PARTIAL_FILE"
 
 # Verify the backup is valid (runs pg_restore inside the container
 # so we don't require postgresql-client on the host)
 docker exec -i "$CONTAINER_NAME" \
-  pg_restore --list < "$BACKUP_FILE" > /dev/null 2>&1 || {
+  pg_restore --list < "$PARTIAL_FILE" > /dev/null 2>&1 || {
   echo "ERROR: Backup verification failed for $BACKUP_FILE" >&2
-  rm -f "$BACKUP_FILE"
   exit 1
 }
 
+# Only verified dumps receive the public .dump filename used by restores and
+# offsite sync. Clearing PARTIAL_FILE disarms the EXIT cleanup after promotion.
+mv -- "$PARTIAL_FILE" "$BACKUP_FILE"
+PARTIAL_FILE=""
+
 BACKUP_SIZE=$(du -h "$BACKUP_FILE" | cut -f1)
 echo "$(date -Iseconds) Backup complete: $BACKUP_FILE ($BACKUP_SIZE)"
-
-# Clean up old backups
-find "$BACKUP_DIR" -name "*.dump" -mtime +"$RETENTION_DAYS" -delete
-echo "$(date -Iseconds) Cleaned backups older than $RETENTION_DAYS days"
 
 # Offsite sync (true disaster recovery). Without it, dumps live only on this
 # host's disk — a disk/VPS loss takes the backups with it. /opt/143/backup-sync.env

--- a/deploy/scripts/pg_backup_test.sh
+++ b/deploy/scripts/pg_backup_test.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+# Tests for pg-backup.sh: failed or invalid dumps never become retained local
+# backups, expired backups are pruned before a new dump starts, and verified
+# dumps are promoted atomically from a temporary file.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+BACKUP_SCRIPT="$SCRIPT_DIR/pg-backup.sh"
+TEST_ROOT="$(mktemp -d)"
+trap 'rm -rf "$TEST_ROOT"' EXIT
+
+fail() {
+  printf 'FAIL: %s\n' "$*" >&2
+  exit 1
+}
+
+FAKE_BIN="$TEST_ROOT/bin"
+mkdir -p "$FAKE_BIN"
+
+cat > "$FAKE_BIN/docker" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+case " $* " in
+  *" pg_dump "*)
+    printf '%s' "${FAKE_DUMP_CONTENT:-test dump}"
+    exit "${FAKE_PG_DUMP_EXIT:-0}"
+    ;;
+  *" pg_restore --list "*)
+    cat > "${FAKE_RESTORE_INPUT:?FAKE_RESTORE_INPUT is required}"
+    exit "${FAKE_PG_RESTORE_EXIT:-0}"
+    ;;
+  *)
+    printf 'unexpected docker invocation: %s\n' "$*" >&2
+    exit 99
+    ;;
+esac
+EOF
+chmod +x "$FAKE_BIN/docker"
+
+new_case_dir() {
+  local name="$1"
+  local case_dir="$TEST_ROOT/$name"
+  mkdir -p "$case_dir/backups"
+  printf '%s\n' "$case_dir"
+}
+
+run_backup() {
+  local case_dir="$1"
+  shift
+  env \
+    PATH="$FAKE_BIN:$PATH" \
+    BACKUP_DIR="$case_dir/backups" \
+    BACKUP_RETENTION_DAYS=7 \
+    DB_PASSWORD=test-password \
+    BACKUP_SYNC_ENV="$case_dir/missing-sync.env" \
+    FAKE_RESTORE_INPUT="$case_dir/restore-input" \
+    "$@" \
+    bash "$BACKUP_SCRIPT"
+}
+
+assert_no_dump_artifacts() {
+  local case_dir="$1"
+  if find "$case_dir/backups" -maxdepth 1 -type f \( -name '*.dump' -o -name '*.partial.*' \) | grep -q .; then
+    find "$case_dir/backups" -maxdepth 1 -type f -print >&2
+    fail "failed backup should not leave dump artifacts"
+  fi
+}
+
+# A pg_dump failure must remove the bytes already streamed to the temporary
+# file. Retention must also run before pg_dump, even though the new dump fails.
+case_dir="$(new_case_dir pg-dump-failure)"
+old_dump="$case_dir/backups/onefortythree-old.dump"
+stale_partial="$case_dir/backups/.onefortythree-old.dump.partial.abandoned"
+printf 'expired backup' > "$old_dump"
+printf 'abandoned partial backup' > "$stale_partial"
+touch -t 202001010000 "$old_dump" "$stale_partial"
+if run_backup "$case_dir" FAKE_DUMP_CONTENT='partial dump bytes' FAKE_PG_DUMP_EXIT=1 >/dev/null 2>&1; then
+  fail "pg_dump failure should return non-zero"
+fi
+assert_no_dump_artifacts "$case_dir"
+
+# A dump that fails pg_restore verification must likewise disappear and never
+# be published under the final .dump name.
+case_dir="$(new_case_dir verification-failure)"
+if run_backup "$case_dir" FAKE_DUMP_CONTENT='invalid dump bytes' FAKE_PG_RESTORE_EXIT=1 >/dev/null 2>&1; then
+  fail "verification failure should return non-zero"
+fi
+assert_no_dump_artifacts "$case_dir"
+
+# A verified dump is atomically promoted to the final name, with no temporary
+# artifact left behind. Verification must receive the complete dump bytes.
+case_dir="$(new_case_dir success)"
+output="$(run_backup "$case_dir" FAKE_DUMP_CONTENT='verified dump bytes')"
+dump_count="$(find "$case_dir/backups" -maxdepth 1 -type f -name '*.dump' | wc -l | tr -d ' ')"
+[ "$dump_count" = 1 ] || fail "successful backup should leave exactly one final dump"
+if find "$case_dir/backups" -maxdepth 1 -type f -name '*.partial.*' | grep -q .; then
+  fail "successful backup should not leave a temporary dump"
+fi
+final_dump="$(find "$case_dir/backups" -maxdepth 1 -type f -name '*.dump' -print -quit)"
+[ "$(cat "$final_dump")" = 'verified dump bytes' ] || fail "final dump should contain the pg_dump output"
+[ "$(cat "$case_dir/restore-input")" = 'verified dump bytes' ] || fail "verification should inspect the temporary dump"
+case "$output" in
+  *"Backup complete: $final_dump"*) ;;
+  *) fail "successful backup should report the promoted final path" ;;
+esac
+
+echo "PASS: pg_backup_test.sh"


### PR DESCRIPTION
## Summary

- write `pg_dump` output to a hidden temporary file and atomically promote it only after verification
- remove in-progress files on errors and signals, and sweep abandoned partials from hard kills or host crashes
- run local retention cleanup before starting a new dump so failed backups cannot block reclamation
- add regression coverage for dump failure, verification failure, stale partial cleanup, retention, and successful promotion

## Production incident

The database host reached 100% disk usage because repeated `pg_dump` failures exited before verification and cleanup, leaving large partial files with final `.dump` names. The corrected script has already been installed on the production database host; this PR makes that hotfix durable.

## Verification

- `bash -n deploy/scripts/pg-backup.sh deploy/scripts/pg_backup_test.sh`
- `for t in deploy/scripts/*_test.sh; do bash "$t"; done`
- production PostgreSQL healthy after local dump cleanup; deployed script checksum matched this branch