### PR TITLE
Stabilize time range picker test dates

### DIFF
--- a/frontend/src/components/code-review-overview.test.tsx
+++ b/frontend/src/components/code-review-overview.test.tsx
@@ -144,7 +144,7 @@ describe("TimeRangePicker", () => {
     setDesktopMatch(false);
     const user = userEvent.setup();
     const onValueChange = vi.fn();
-    const start = subDays(new Date(), 12);
+    const start = addDays(startOfMonth(subDays(new Date(), 30)), 4);
     render(<TimeRangePicker label="Time window" value="30d" onValueChange={onValueChange} />);
 
     await user.click(screen.getByRole("button", { name: "Time window" }));
@@ -164,7 +164,7 @@ describe("TimeRangePicker", () => {
     setDesktopMatch(desktop);
     const user = userEvent.setup();
     const onValueChange = vi.fn();
-    const start = subDays(new Date(), 12);
+    const start = addDays(startOfMonth(subDays(new Date(), 30)), 4);
     render(<TimeRangePicker label="Time window" value="30d" onValueChange={onValueChange} />);
 
     await user.click(screen.getByRole("button", { name: "Time window" }));
@@ -186,7 +186,7 @@ describe("TimeRangePicker", () => {
   it("keeps the picker open and the draft intact when the viewport crosses the breakpoint", async () => {
     setDesktopMatch(false);
     const user = userEvent.setup();
-    const start = subDays(new Date(), 12);
+    const start = addDays(startOfMonth(subDays(new Date(), 30)), 4);
     render(<TimeRangePicker label="Time window" value="30d" onValueChange={vi.fn()} />);
 
     await user.click(screen.getByRole("button", { name: "Time window" }));


### PR DESCRIPTION
## Summary

- Use a deterministic relative start date aligned with the month boundary in time range picker tests.
- Prevent date-dependent failures caused by calendar range calculations.

## Testing

- Not run (not requested)