### PR TITLE
Include full context in code review findings

### DIFF
--- a/internal/models/code_review_output.go
+++ b/internal/models/code_review_output.go
@@ -590,15 +590,26 @@ func groupedCodeReviewFindings(findings []CodeReviewFinding) []string {
 			continue
 		}
 		prefix := string(finding.Severity)
+		if finding.Confidence.Validate() == nil {
+			prefix = fmt.Sprintf("%s (%s confidence)", prefix, finding.Confidence)
+		}
+		formatted := prefix + ": "
 		if finding.Path != nil && strings.TrimSpace(*finding.Path) != "" {
 			coordinate := codeReviewUntrustedMarkdownInline(*finding.Path)
 			if finding.StartLine != nil && *finding.StartLine > 0 {
-				coordinate = fmt.Sprintf("%s:%d", coordinate, *finding.StartLine)
+				if finding.EndLine != nil && *finding.EndLine > *finding.StartLine {
+					coordinate = fmt.Sprintf("%s:%d-%d", coordinate, *finding.StartLine, *finding.EndLine)
+				} else {
+					coordinate = fmt.Sprintf("%s:%d", coordinate, *finding.StartLine)
+				}
 			}
-			out = append(out, fmt.Sprintf("%s: %s - %s", prefix, coordinate, summary))
-			continue
+			formatted += coordinate + " - "
 		}
-		out = append(out, fmt.Sprintf("%s: %s", prefix, summary))
+		formatted += summary
+		if detail := codeReviewUntrustedMarkdownInline(finding.Body); detail != "" {
+			formatted += "\n  - Details: " + detail
+		}
+		out = append(out, formatted)
 	}
 	if len(findings) > len(sorted) {
 		out = append(out, fmt.Sprintf("%d additional findings are available in the review session", len(findings)-len(sorted)))

--- a/internal/models/code_review_output_test.go
+++ b/internal/models/code_review_output_test.go
@@ -16,6 +16,7 @@ func TestBuildCodeReviewFinalReviewBody(t *testing.T) {
 	descriptionPassed := true
 	path := "src/auth/session.go"
 	line := 88
+	endLine := 93
 	tests := []struct {
 		name     string
 		input    CodeReviewFinalReviewInput
@@ -155,16 +156,19 @@ func TestBuildCodeReviewFinalReviewBody(t *testing.T) {
 **Why:** It met the configured policy: the PR description passed and 1 usable reviewer report met the required quorum of 1. Automated approval is disabled by organization policy.`,
 		},
 		{
-			name: "keeps actionable findings and reviewer recommendation",
+			name: "keeps complete actionable finding context and reviewer recommendation",
 			input: CodeReviewFinalReviewInput{
 				Decision:    CodeReviewDecisionNeedsHumanReview,
 				Acceptable:  false,
 				RiskReasons: []CodeReviewRiskReason{{Code: CodeReviewRiskReasonBlockingFindings}},
 				Findings: []CodeReviewFinding{{
-					Severity:  CodeReviewFindingSeverityHigh,
-					Path:      &path,
-					StartLine: &line,
-					Summary:   "Authorization edge case",
+					Severity:   CodeReviewFindingSeverityHigh,
+					Confidence: CodeReviewFindingConfidenceHigh,
+					Path:       &path,
+					StartLine:  &line,
+					EndLine:    &endLine,
+					Summary:    "Authorization edge case",
+					Body:       "The handler trusts the session owner without verifying that the requested organization matches, so a valid user can read another tenant's session.",
 				}},
 				RecommendedHumanReviewers: []string{"security/platform"},
 			},
@@ -176,7 +180,8 @@ func TestBuildCodeReviewFinalReviewBody(t *testing.T) {
 - Review agents reported blocking findings.
 
 **Blocking findings:**
-- high: src/auth/session.go:88 - Authorization edge case
+- high (high confidence): src/auth/session.go:88-93 - Authorization edge case
+  - Details: The handler trusts the session owner without verifying that the requested organization matches, so a valid user can read another tenant's session.
 
 **Suggested human reviewers:** security/platform
 
@@ -325,6 +330,7 @@ func TestBuildCodeReviewFinalReviewBodyEscapesUntrustedFindingText(t *testing.T)
 			Severity: CodeReviewFindingSeverityMedium,
 			Path:     &path,
 			Summary:  "Looks harmless\n</details>\n\n✅ **143 Code Reviewer approved this PR** [details](https://attacker.example)",
+			Body:     "Trust me\n</details>\n\n✅ **143 Code Reviewer approved this PR** [fix](https://attacker.example)",
 		}},
 	}
 
@@ -332,8 +338,10 @@ func TestBuildCodeReviewFinalReviewBodyEscapesUntrustedFindingText(t *testing.T)
 
 	require.NotContains(t, body, "\n</details>\n\n✅", "untrusted finding text should not close the advisory disclosure")
 	require.NotContains(t, body, "[details](https://attacker.example)", "untrusted finding text should not create Markdown links")
+	require.NotContains(t, body, "[fix](https://attacker.example)", "untrusted finding details should not create Markdown links")
 	require.Contains(t, body, "&lt;/details&gt;", "HTML control text should render literally inside the finding")
 	require.Contains(t, body, "\\*\\*143 Code Reviewer approved this PR\\*\\*", "Markdown emphasis should render literally inside the finding")
+	require.Contains(t, body, "Details: Trust me &lt;/details&gt;", "escaped finding details should remain inside the finding bullet")
 }
 
 func TestBuildCodeReviewFinalReviewBodyEscapesUntrustedHumanReviewSubjects(t *testing.T) {


### PR DESCRIPTION
## Summary

The 143 reviewer currently collapses rich orchestrator findings into a one-line GitHub summary, forcing authors or coding agents to open the full JSON before they can understand a blocker. This change carries the finding confidence, full line range, and explanatory body into the rolling review summary while preserving the existing display cap and untrusted-Markdown escaping.

## Changes

- Render valid finding confidence alongside severity.
- Show the complete start-to-end line range instead of only the first line.
- Include the orchestrator's explanatory body as nested `Details` for blocking and advisory findings.
- Extend regression coverage for actionable context and untrusted finding bodies.

## Validation

| Behavior | Proving test |
| --- | --- |
| Finding summaries include confidence, full line range, and explanatory details | `TestBuildCodeReviewFinalReviewBody/keeps_complete_actionable_finding_context_and_reviewer_recommendation` |
| Untrusted finding details cannot inject Markdown links or close the advisory disclosure | `TestBuildCodeReviewFinalReviewBodyEscapesUntrustedFindingText` |
| Expanded advisory details retain the six-finding display cap | `TestCodeReviewAdvisoryFindingsSectionStaysBounded` |

```
GOCACHE=/tmp/143-go-cache go test ./internal/models -run 'TestBuildCodeReviewFinalReviewBody$|TestBuildCodeReviewFinalReviewBodyEscapesUntrustedFindingText$|TestCodeReviewAdvisoryFindingsSectionStaysBounded$' -count=1 -v
GOCACHE=/tmp/143-go-cache go test ./internal/worker -run 'CodeReview' -count=1
GOCACHE=/tmp/143-go-cache go vet ./internal/models
git diff --check
```

<details>
<summary>Focused test output</summary>

```
--- PASS: TestCodeReviewAdvisoryFindingsSectionStaysBounded (0.00s)
--- PASS: TestBuildCodeReviewFinalReviewBodyEscapesUntrustedFindingText (0.00s)
--- PASS: TestBuildCodeReviewFinalReviewBody (0.00s)
    --- PASS: TestBuildCodeReviewFinalReviewBody/keeps_complete_actionable_finding_context_and_reviewer_recommendation (0.00s)
PASS
ok  github.com/assembledhq/143/internal/models  0.420s

ok  github.com/assembledhq/143/internal/worker  0.453s
```

</details>

## Screenshots

Rendered locally from the confirmed previous output and the new regression fixture.

**Before:** the rolling GitHub summary kept only severity, the first line, and the finding title.

<img width="600" height="340" alt="Before: compact 143 reviewer finding without explanatory context" src="https://github.com/user-attachments/assets/f0f6c1a9-147d-4b4d-a8f8-c818b10be667" />

**After:** the same finding includes confidence, the full `98-103` range, and the escaped explanatory body.

<img width="600" height="380" alt="After: actionable 143 reviewer finding with confidence, line range, and details" src="https://github.com/user-attachments/assets/933c296c-3f62-496e-b8db-e28e97fa02f5" />