### PR TITLE
Fix code review synthesis timeouts

### DIFF
--- a/internal/worker/code_review_handler.go
+++ b/internal/worker/code_review_handler.go
@@ -313,7 +313,7 @@ func newRunCodeReviewHandler(stores *Stores, services *Services, logger zerolog.
 			if err := ensureCodeReviewOrchestratorThread(ctx, stores, services, logger, job, pr, health, policy, metadata, changedFiles, agentResults, findings, visualEvidence); err != nil {
 				return err
 			}
-			if err := harvestCodeReviewOrchestratorResult(ctx, stores, services, logger, job, policy, metadata, changedFiles, visualEvidence); err != nil {
+			if err := harvestCodeReviewOrchestratorResult(ctx, stores, services, logger, job, policy, changedFiles, visualEvidence); err != nil {
 				return err
 			}
 			agentResults, err = stores.CodeReviews.ListAgentResults(ctx, job.OrgID, job.SessionID)
@@ -1077,7 +1077,10 @@ func ensureCodeReviewReviewerThreads(ctx context.Context, stores *Stores, servic
 				ReviewerIndex:   idx,
 				ThreadID:        thread.ID.String(),
 				PromptRecordKey: recordKey,
+				NativeReview:    codeReviewAgentHasBuiltinReviewCommand(agentType),
+				ReadOnly:        true,
 				Error:           raw,
+				CompletedAt:     time.Now().UTC().Format(time.RFC3339),
 			})); updateErr != nil {
 				logger.Warn().Err(updateErr).
 					Str("session_id", job.SessionID.String()).
@@ -1205,9 +1208,18 @@ func harvestCodeReviewReviewerResults(ctx context.Context, stores *Stores, servi
 			continue
 		}
 		state, ok := parseCodeReviewReviewerStructuredResult(result.StructuredResult)
-		if !ok || strings.TrimSpace(state.ThreadID) == "" {
-			raw := "reviewer result is missing its thread id"
+		if !ok {
+			raw := "reviewer result has a malformed structured result"
 			if _, err := stores.CodeReviews.UpdateAgentResultOutcome(ctx, job.OrgID, result.ID, models.CodeReviewAgentResultStatusFailed, &raw, result.StructuredResult); err != nil {
+				return fmt.Errorf("mark malformed reviewer result failed: %w", err)
+			}
+			continue
+		}
+		if strings.TrimSpace(state.ThreadID) == "" {
+			raw := "reviewer result is missing its thread id"
+			state.Error = raw
+			state.CompletedAt = time.Now().UTC().Format(time.RFC3339)
+			if _, err := stores.CodeReviews.UpdateAgentResultOutcome(ctx, job.OrgID, result.ID, models.CodeReviewAgentResultStatusFailed, &raw, marshalCodeReviewReviewerStructuredResult(state)); err != nil {
 				return fmt.Errorf("mark malformed reviewer result failed: %w", err)
 			}
 			continue
@@ -1215,7 +1227,9 @@ func harvestCodeReviewReviewerResults(ctx context.Context, stores *Stores, servi
 		threadID, err := uuid.Parse(state.ThreadID)
 		if err != nil {
 			raw := "reviewer result has an invalid thread id: " + err.Error()
-			if _, err := stores.CodeReviews.UpdateAgentResultOutcome(ctx, job.OrgID, result.ID, models.CodeReviewAgentResultStatusFailed, &raw, result.StructuredResult); err != nil {
+			state.Error = raw
+			state.CompletedAt = time.Now().UTC().Format(time.RFC3339)
+			if _, err := stores.CodeReviews.UpdateAgentResultOutcome(ctx, job.OrgID, result.ID, models.CodeReviewAgentResultStatusFailed, &raw, marshalCodeReviewReviewerStructuredResult(state)); err != nil {
 				return fmt.Errorf("mark invalid reviewer result failed: %w", err)
 			}
 			continue
@@ -1231,9 +1245,11 @@ func harvestCodeReviewReviewerResults(ctx context.Context, stores *Stores, servi
 		if timedOut && !codeReviewThreadCompletedByDeadline(thread, deadline) {
 			raw := "reviewer did not produce a completed turn before the review deadline"
 			state.Error = raw
+			completedAt := codeReviewThreadCompletionTime(thread)
 			if codeReviewThreadStillRunning(thread.Status) {
 				if cancelledThread, cancelErr := cancelCodeReviewThread(ctx, stores, logger, job, threadID); cancelErr == nil {
 					state.CostCents = cancelledThread.CostCents
+					completedAt = codeReviewThreadCompletionTime(cancelledThread)
 				} else {
 					logger.Warn().Err(cancelErr).
 						Str("session_id", job.SessionID.String()).
@@ -1241,6 +1257,7 @@ func harvestCodeReviewReviewerResults(ctx context.Context, stores *Stores, servi
 						Msg("failed to cancel timed-out code review reviewer thread")
 				}
 			}
+			state.CompletedAt = completedAt.Format(time.RFC3339)
 			if _, err := stores.CodeReviews.UpdateAgentResultOutcome(ctx, job.OrgID, result.ID, models.CodeReviewAgentResultStatusTimedOut, &raw, marshalCodeReviewReviewerStructuredResult(state)); err != nil {
 				return fmt.Errorf("mark reviewer timed out: %w", err)
 			}
@@ -1276,7 +1293,7 @@ func harvestCodeReviewReviewerResults(ctx context.Context, stores *Stores, servi
 				failure = raw
 			}
 			state.Error = failure
-			state.CompletedAt = time.Now().UTC().Format(time.RFC3339)
+			state.CompletedAt = codeReviewThreadCompletionTime(thread).Format(time.RFC3339)
 			rawOutput, rawRecordKey, err := codeReviewRawOutputForStorage(ctx, stores, job, result.ID, models.CodeReviewAgentRoleReviewer, result.AgentProvider, raw)
 			if err != nil {
 				return err
@@ -1301,7 +1318,7 @@ func harvestCodeReviewReviewerResults(ctx context.Context, stores *Stores, servi
 					raw = "reviewer thread produced workspace changes without persisted assistant output"
 				}
 				state.Error = raw
-				state.CompletedAt = time.Now().UTC().Format(time.RFC3339)
+				state.CompletedAt = codeReviewThreadCompletionTime(thread).Format(time.RFC3339)
 				rawOutput, rawRecordKey, err := codeReviewRawOutputForStorage(ctx, stores, job, result.ID, models.CodeReviewAgentRoleReviewer, result.AgentProvider, raw)
 				if err != nil {
 					return err
@@ -1323,7 +1340,7 @@ func harvestCodeReviewReviewerResults(ctx context.Context, stores *Stores, servi
 			}
 		}
 		state.FindingCount = len(findings)
-		state.CompletedAt = time.Now().UTC().Format(time.RFC3339)
+		state.CompletedAt = codeReviewThreadCompletionTime(thread).Format(time.RFC3339)
 		rawOutput, rawRecordKey, err := codeReviewRawOutputForStorage(ctx, stores, job, result.ID, models.CodeReviewAgentRoleReviewer, result.AgentProvider, raw)
 		if err != nil {
 			return err
@@ -2334,7 +2351,7 @@ func codeReviewInFlightAgentPhase(ctx context.Context, stores *Stores, job runCo
 	if stores == nil || stores.CodeReviews == nil || stores.SessionThreads == nil {
 		return codeReviewAgentPhaseNone, nil
 	}
-	if codeReviewHeadChanged(job.HeadSHA, pr, nil) || codeReviewReviewTimedOut(policy, metadata) {
+	if codeReviewHeadChanged(job.HeadSHA, pr, nil) {
 		return codeReviewAgentPhaseNone, nil
 	}
 	results, err := stores.CodeReviews.ListAgentResults(ctx, job.OrgID, job.SessionID)
@@ -2355,7 +2372,26 @@ func codeReviewInFlightAgentPhase(ctx context.Context, stores *Stores, job runCo
 	if err != nil {
 		return codeReviewAgentPhaseNone, fmt.Errorf("list code review threads for in-flight check: %w", err)
 	}
-	return codeReviewInFlightAgentPhaseFromState(policy, results, threads), nil
+	phase := codeReviewInFlightAgentPhaseFromState(policy, results, threads)
+	if codeReviewInFlightAgentPhaseTimedOut(time.Now(), policy, metadata, results, phase) {
+		return codeReviewAgentPhaseNone, nil
+	}
+	return phase, nil
+}
+
+func codeReviewInFlightAgentPhaseTimedOut(now time.Time, policy models.CodeReviewPolicyConfig, metadata models.CodeReviewSessionMetadata, results []models.CodeReviewAgentResult, phase codeReviewAgentPhase) bool {
+	switch phase {
+	case codeReviewAgentPhaseReviewers:
+		return now.After(codeReviewReviewDeadline(policy, metadata))
+	case codeReviewAgentPhaseOrchestrator:
+		for _, result := range results {
+			if result.Role == models.CodeReviewAgentRoleOrchestrator && !codeReviewReviewerResultTerminal(result.Status) {
+				return now.After(codeReviewOrchestratorResultDeadline(policy, result))
+			}
+		}
+		return true
+	}
+	return false
 }
 
 func codeReviewInFlightAgentPhaseFromState(policy models.CodeReviewPolicyConfig, results []models.CodeReviewAgentResult, threads []models.SessionThread) codeReviewAgentPhase {
@@ -2418,17 +2454,50 @@ func codeReviewReviewTimedOut(policy models.CodeReviewPolicyConfig, metadata mod
 }
 
 func codeReviewReviewDeadline(policy models.CodeReviewPolicyConfig, metadata models.CodeReviewSessionMetadata) time.Time {
+	return codeReviewAgentDeadline(policy, metadata.CreatedAt)
+}
+
+func codeReviewOrchestratorDispatchDeadline(policy models.CodeReviewPolicyConfig, metadata models.CodeReviewSessionMetadata, results []models.CodeReviewAgentResult) time.Time {
+	startedAt := metadata.CreatedAt
+	for _, result := range results {
+		if result.Role != models.CodeReviewAgentRoleReviewer || !codeReviewReviewerResultTerminal(result.Status) {
+			continue
+		}
+		state, ok := parseCodeReviewReviewerStructuredResult(result.StructuredResult)
+		if !ok {
+			continue
+		}
+		completedAt, err := time.Parse(time.RFC3339, state.CompletedAt)
+		if err == nil && completedAt.After(startedAt) {
+			startedAt = completedAt
+		}
+	}
+	return codeReviewAgentDeadline(policy, startedAt)
+}
+
+func codeReviewOrchestratorResultDeadline(policy models.CodeReviewPolicyConfig, result models.CodeReviewAgentResult) time.Time {
+	return codeReviewAgentDeadline(policy, result.CreatedAt)
+}
+
+func codeReviewAgentDeadline(policy models.CodeReviewPolicyConfig, startedAt time.Time) time.Time {
 	timeout := time.Duration(policy.AgentRoster.TimeoutSeconds) * time.Second
 	if timeout <= 0 {
 		timeout = 30 * time.Minute
 	}
-	return metadata.CreatedAt.Add(timeout)
+	return startedAt.Add(timeout)
 }
 
 func codeReviewThreadCompletedByDeadline(thread models.SessionThread, deadline time.Time) bool {
 	return !codeReviewThreadStillRunning(thread.Status) &&
 		thread.CompletedAt != nil &&
 		!thread.CompletedAt.After(deadline)
+}
+
+func codeReviewThreadCompletionTime(thread models.SessionThread) time.Time {
+	if !codeReviewThreadStillRunning(thread.Status) && thread.CompletedAt != nil {
+		return thread.CompletedAt.UTC()
+	}
+	return time.Now().UTC()
 }
 
 func codeReviewThreadStillRunning(status models.ThreadStatus) bool {
@@ -2533,7 +2602,7 @@ func ensureCodeReviewOrchestratorThread(ctx context.Context, stores *Stores, ser
 			Msg("skipped unavailable code review orchestrator")
 		return nil
 	}
-	if codeReviewReviewTimedOut(cfg, metadata) {
+	if time.Now().After(codeReviewOrchestratorDispatchDeadline(cfg, metadata, agentResults)) {
 		raw := "orchestrator timed out before the worker could start the orchestrator thread"
 		result := &models.CodeReviewAgentResult{
 			OrgID:         job.OrgID,
@@ -2679,6 +2748,7 @@ func ensureCodeReviewOrchestratorThread(ctx context.Context, stores *Stores, ser
 				PromptRecordKey:      recordKey,
 				DescriptionInputHash: descriptionInputHash,
 				Error:                raw,
+				CompletedAt:          time.Now().UTC().Format(time.RFC3339),
 			}),
 		}
 		if createErr := stores.CodeReviews.CreateAgentResult(ctx, failed); createErr != nil {
@@ -2721,22 +2791,29 @@ func codeReviewReasoningEffortsEqual(left, right *models.ReasoningEffort) bool {
 	return *left == *right
 }
 
-func harvestCodeReviewOrchestratorResult(ctx context.Context, stores *Stores, services *Services, logger zerolog.Logger, job runCodeReviewPayload, policy models.CodeReviewPolicyRecord, metadata models.CodeReviewSessionMetadata, changedFiles []codereviewsvc.PullRequestFile, visualEvidence models.CodeReviewVisualEvidenceSnapshot) error {
+func harvestCodeReviewOrchestratorResult(ctx context.Context, stores *Stores, services *Services, logger zerolog.Logger, job runCodeReviewPayload, policy models.CodeReviewPolicyRecord, changedFiles []codereviewsvc.PullRequestFile, visualEvidence models.CodeReviewVisualEvidenceSnapshot) error {
 	results, err := stores.CodeReviews.ListAgentResults(ctx, job.OrgID, job.SessionID)
 	if err != nil {
 		return fmt.Errorf("list code review orchestrator results for harvest: %w", err)
 	}
-	deadline := codeReviewReviewDeadline(policy.Config(), metadata)
-	timedOut := time.Now().After(deadline)
 	changedPaths := codeReviewChangedPaths(changedFiles)
 	for _, result := range results {
 		if result.Role != models.CodeReviewAgentRoleOrchestrator || codeReviewReviewerResultTerminal(result.Status) {
 			continue
 		}
 		state, ok := parseCodeReviewOrchestratorStructuredResult(result.StructuredResult)
-		if !ok || strings.TrimSpace(state.ThreadID) == "" {
-			raw := "orchestrator result is missing its thread id"
+		if !ok {
+			raw := "orchestrator result has a malformed structured result"
 			if _, err := stores.CodeReviews.UpdateAgentResultOutcome(ctx, job.OrgID, result.ID, models.CodeReviewAgentResultStatusFailed, &raw, result.StructuredResult); err != nil {
+				return fmt.Errorf("mark malformed orchestrator result failed: %w", err)
+			}
+			continue
+		}
+		if strings.TrimSpace(state.ThreadID) == "" {
+			raw := "orchestrator result is missing its thread id"
+			state.Error = raw
+			state.CompletedAt = time.Now().UTC().Format(time.RFC3339)
+			if _, err := stores.CodeReviews.UpdateAgentResultOutcome(ctx, job.OrgID, result.ID, models.CodeReviewAgentResultStatusFailed, &raw, marshalCodeReviewOrchestratorStructuredResult(state)); err != nil {
 				return fmt.Errorf("mark malformed orchestrator result failed: %w", err)
 			}
 			continue
@@ -2744,7 +2821,9 @@ func harvestCodeReviewOrchestratorResult(ctx context.Context, stores *Stores, se
 		threadID, err := uuid.Parse(state.ThreadID)
 		if err != nil {
 			raw := "orchestrator result has an invalid thread id: " + err.Error()
-			if _, err := stores.CodeReviews.UpdateAgentResultOutcome(ctx, job.OrgID, result.ID, models.CodeReviewAgentResultStatusFailed, &raw, result.StructuredResult); err != nil {
+			state.Error = raw
+			state.CompletedAt = time.Now().UTC().Format(time.RFC3339)
+			if _, err := stores.CodeReviews.UpdateAgentResultOutcome(ctx, job.OrgID, result.ID, models.CodeReviewAgentResultStatusFailed, &raw, marshalCodeReviewOrchestratorStructuredResult(state)); err != nil {
 				return fmt.Errorf("mark invalid orchestrator result failed: %w", err)
 			}
 			continue
@@ -2753,6 +2832,8 @@ func harvestCodeReviewOrchestratorResult(ctx context.Context, stores *Stores, se
 		if err != nil {
 			return fmt.Errorf("load code review orchestrator thread: %w", err)
 		}
+		deadline := codeReviewOrchestratorResultDeadline(policy.Config(), result)
+		timedOut := time.Now().After(deadline)
 		state.CostCents = thread.CostCents
 		state = codeReviewOrchestratorObserveRepairCompletion(state, thread.CurrentTurn)
 		// A terminal synthesis is useful evidence even when a delayed job resume
@@ -2760,13 +2841,16 @@ func harvestCodeReviewOrchestratorResult(ctx context.Context, stores *Stores, se
 		if timedOut && !codeReviewThreadCompletedByDeadline(thread, deadline) {
 			raw := "orchestrator did not produce a completed turn before the review deadline"
 			state.Error = raw
+			completedAt := codeReviewThreadCompletionTime(thread)
 			if codeReviewThreadStillRunning(thread.Status) {
 				if cancelledThread, cancelErr := cancelCodeReviewThread(ctx, stores, logger, job, threadID); cancelErr == nil {
 					state.CostCents = cancelledThread.CostCents
+					completedAt = codeReviewThreadCompletionTime(cancelledThread)
 				} else {
 					logger.Warn().Err(cancelErr).Str("thread_id", threadID.String()).Msg("failed to cancel timed-out code review orchestrator thread")
 				}
 			}
+			state.CompletedAt = completedAt.Format(time.RFC3339)
 			if _, err := stores.CodeReviews.UpdateAgentResultOutcome(ctx, job.OrgID, result.ID, models.CodeReviewAgentResultStatusTimedOut, &raw, marshalCodeReviewOrchestratorStructuredResult(state)); err != nil {
 				return fmt.Errorf("mark orchestrator timed out: %w", err)
 			}
@@ -2799,6 +2883,7 @@ func harvestCodeReviewOrchestratorResult(ctx context.Context, stores *Stores, se
 					raw = "orchestrator thread did not complete successfully"
 				}
 				state.Error = raw
+				state.CompletedAt = codeReviewThreadCompletionTime(thread).Format(time.RFC3339)
 				rawOutput, rawRecordKey, err := codeReviewRawOutputForStorage(ctx, stores, job, result.ID, models.CodeReviewAgentRoleOrchestrator, result.AgentProvider, raw)
 				if err != nil {
 					return err
@@ -2845,7 +2930,7 @@ func harvestCodeReviewOrchestratorResult(ctx context.Context, stores *Stores, se
 			state.Synthesis = codeReviewOrchestratorSynthesis{}
 			state.SynthesisValidated = false
 			state.Error = "invalid orchestrator synthesis: " + synthesisErr.Error()
-			state.CompletedAt = time.Now().UTC().Format(time.RFC3339)
+			state.CompletedAt = codeReviewThreadCompletionTime(thread).Format(time.RFC3339)
 			rawOutput, rawRecordKey, err := codeReviewRawOutputForStorage(ctx, stores, job, result.ID, models.CodeReviewAgentRoleOrchestrator, result.AgentProvider, combinedRaw)
 			if err != nil {
 				return err
@@ -2867,7 +2952,7 @@ func harvestCodeReviewOrchestratorResult(ctx context.Context, stores *Stores, se
 		if findingCount > state.FindingCount {
 			state.FindingCount = findingCount
 		}
-		state.CompletedAt = time.Now().UTC().Format(time.RFC3339)
+		state.CompletedAt = codeReviewThreadCompletionTime(thread).Format(time.RFC3339)
 		state.Error = ""
 		rawOutput, rawRecordKey, err := codeReviewRawOutputForStorage(ctx, stores, job, result.ID, models.CodeReviewAgentRoleOrchestrator, result.AgentProvider, combinedRaw)
 		if err != nil {

--- a/internal/worker/code_review_handler_test.go
+++ b/internal/worker/code_review_handler_test.go
@@ -1730,7 +1730,7 @@ func TestHarvestCodeReviewReviewerResultsPreservesCompletedOutputAfterDeadline(t
 				stringPtr("internal/db/users.go"), intPtr(42), intPtr(42), "Missing org filter",
 				"This query can read another org's rows.", false, nil, now))
 	mock.ExpectQuery("UPDATE code_review_agent_results").
-		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WithArgs(models.CodeReviewAgentResultStatusCompleted, &rawReview, completedReviewerResultArg{expectedCompletedAt: &completedAt}, orgID, resultID).
 		WillReturnRows(newCodeReviewAgentResultRows().
 			AddRow(resultID, orgID, sessionID, "codex", nil, models.CodeReviewAgentRoleReviewer, models.CodeReviewAgentResultStatusCompleted, &rawReview, updatedState, now))
 
@@ -2393,7 +2393,7 @@ func TestHarvestCodeReviewOrchestratorResultPreservesCompletedOutputAfterDeadlin
 	err = harvestCodeReviewOrchestratorResult(context.Background(), stores, nil, zerolog.Nop(), runCodeReviewPayload{
 		OrgID:     orgID,
 		SessionID: sessionID,
-	}, policy, models.CodeReviewSessionMetadata{CreatedAt: reviewStartedAt}, []codereview.PullRequestFile{{Filename: "internal/worker/code_review_handler.go"}}, models.CodeReviewVisualEvidenceSnapshot{})
+	}, policy, []codereview.PullRequestFile{{Filename: "internal/worker/code_review_handler.go"}}, models.CodeReviewVisualEvidenceSnapshot{})
 
 	require.NoError(t, err, "a completed orchestrator output should be harvested even when the worker resumes after the deadline")
 	require.NoError(t, mock.ExpectationsWereMet(), "orchestrator harvest should preserve terminal output and findings instead of replacing them with a timeout")
@@ -2457,8 +2457,12 @@ func TestHarvestCodeReviewAgentResultRejectsTerminalOutputAfterDeadline(t *testi
 						&reviewStartedAt, &now, reviewStartedAt, models.ThreadCreatedBySourceSystem, nil, nil,
 						nil, 0.25, 0, nil, "", nil, "", "", json.RawMessage(`[]`),
 						models.ThreadExecutionModeReview, models.ThreadFilesystemModeReadOnly))
+			var structuredArg any = completedOrchestratorResultArg{expectedError: tt.expectedRaw, expectedCompletedAt: &now}
+			if tt.role == models.CodeReviewAgentRoleReviewer {
+				structuredArg = completedReviewerResultArg{expectedError: tt.expectedRaw, expectedCompletedAt: &now}
+			}
 			mock.ExpectQuery("UPDATE code_review_agent_results").
-				WithArgs(models.CodeReviewAgentResultStatusTimedOut, &tt.expectedRaw, pgxmock.AnyArg(), orgID, resultID).
+				WithArgs(models.CodeReviewAgentResultStatusTimedOut, &tt.expectedRaw, structuredArg, orgID, resultID).
 				WillReturnRows(newCodeReviewAgentResultRows().
 					AddRow(resultID, orgID, sessionID, "codex", nil, tt.role, models.CodeReviewAgentResultStatusTimedOut, &tt.expectedRaw, structuredResult, now))
 
@@ -2472,13 +2476,287 @@ func TestHarvestCodeReviewAgentResultRejectsTerminalOutputAfterDeadline(t *testi
 			if tt.role == models.CodeReviewAgentRoleReviewer {
 				err = harvestCodeReviewReviewerResults(context.Background(), stores, nil, zerolog.Nop(), job, policy, metadata, nil)
 			} else {
-				err = harvestCodeReviewOrchestratorResult(context.Background(), stores, nil, zerolog.Nop(), job, policy, metadata, nil, models.CodeReviewVisualEvidenceSnapshot{})
+				err = harvestCodeReviewOrchestratorResult(context.Background(), stores, nil, zerolog.Nop(), job, policy, nil, models.CodeReviewVisualEvidenceSnapshot{})
 			}
 
 			require.NoError(t, err, "late terminal output should be classified as timed out")
 			require.NoError(t, mock.ExpectationsWereMet(), "late terminal output should not be harvested after the configured deadline")
 		})
 	}
+}
+
+func TestHarvestCodeReviewReviewerResultsPersistsTerminalEvidence(t *testing.T) {
+	t.Parallel()
+
+	_, invalidThreadIDErr := uuid.Parse("not-a-uuid")
+	tests := []struct {
+		name             string
+		structuredResult json.RawMessage
+		expectedRaw      string
+		preserveRaw      bool
+	}{
+		{
+			name: "missing thread id",
+			structuredResult: marshalCodeReviewReviewerStructuredResult(codeReviewReviewerStructuredResult{
+				ReviewerKey: codeReviewReviewerKey(0, models.AgentTypeCodex),
+			}),
+			expectedRaw: "reviewer result is missing its thread id",
+		},
+		{
+			name:             "malformed structured result",
+			structuredResult: json.RawMessage(`{`),
+			expectedRaw:      "reviewer result has a malformed structured result",
+			preserveRaw:      true,
+		},
+		{
+			name: "invalid thread id",
+			structuredResult: marshalCodeReviewReviewerStructuredResult(codeReviewReviewerStructuredResult{
+				ReviewerKey: codeReviewReviewerKey(0, models.AgentTypeCodex),
+				ThreadID:    "not-a-uuid",
+			}),
+			expectedRaw: "reviewer result has an invalid thread id: " + invalidThreadIDErr.Error(),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			mock, err := pgxmock.NewPool()
+			require.NoError(t, err, "pgxmock pool should initialize")
+			defer mock.Close()
+
+			orgID := uuid.New()
+			sessionID := uuid.New()
+			resultID := uuid.New()
+			now := time.Now().UTC()
+			mock.ExpectQuery("(?s)SELECT .*FROM code_review_agent_results").
+				WithArgs(pgx.NamedArgs{"org_id": orgID, "session_id": sessionID}).
+				WillReturnRows(newCodeReviewAgentResultRows().
+					AddRow(resultID, orgID, sessionID, "codex", nil, models.CodeReviewAgentRoleReviewer, models.CodeReviewAgentResultStatusRunning, nil, tt.structuredResult, now))
+			var structuredArg any = completedReviewerResultArg{expectedError: tt.expectedRaw}
+			if tt.preserveRaw {
+				structuredArg = preservedJSONArg{expected: tt.structuredResult}
+			}
+			mock.ExpectQuery("UPDATE code_review_agent_results").
+				WithArgs(models.CodeReviewAgentResultStatusFailed, &tt.expectedRaw, structuredArg, orgID, resultID).
+				WillReturnRows(newCodeReviewAgentResultRows().
+					AddRow(resultID, orgID, sessionID, "codex", nil, models.CodeReviewAgentRoleReviewer, models.CodeReviewAgentResultStatusFailed, &tt.expectedRaw, tt.structuredResult, now))
+
+			stores := &Stores{CodeReviews: db.NewCodeReviewStore(mock)}
+			err = harvestCodeReviewReviewerResults(context.Background(), stores, nil, zerolog.Nop(), runCodeReviewPayload{
+				OrgID:     orgID,
+				SessionID: sessionID,
+			}, codeReviewPolicyRecordForTest(models.DefaultCodeReviewPolicyConfig()), models.CodeReviewSessionMetadata{CreatedAt: now}, nil)
+
+			require.NoError(t, err, "malformed reviewer results should become terminal without losing diagnostic evidence")
+			require.NoError(t, mock.ExpectationsWereMet(), "malformed reviewer result update should preserve raw evidence or persist terminal timing")
+		})
+	}
+}
+
+func TestHarvestCodeReviewOrchestratorResultPersistsTerminalEvidence(t *testing.T) {
+	t.Parallel()
+
+	_, invalidThreadIDErr := uuid.Parse("not-a-uuid")
+	tests := []struct {
+		name             string
+		structuredResult json.RawMessage
+		expectedRaw      string
+		preserveRaw      bool
+	}{
+		{
+			name:             "missing thread id",
+			structuredResult: marshalCodeReviewOrchestratorStructuredResult(codeReviewOrchestratorStructuredResult{}),
+			expectedRaw:      "orchestrator result is missing its thread id",
+		},
+		{
+			name:             "malformed structured result",
+			structuredResult: json.RawMessage(`{`),
+			expectedRaw:      "orchestrator result has a malformed structured result",
+			preserveRaw:      true,
+		},
+		{
+			name: "invalid thread id",
+			structuredResult: marshalCodeReviewOrchestratorStructuredResult(codeReviewOrchestratorStructuredResult{
+				ThreadID: "not-a-uuid",
+			}),
+			expectedRaw: "orchestrator result has an invalid thread id: " + invalidThreadIDErr.Error(),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			mock, err := pgxmock.NewPool()
+			require.NoError(t, err, "pgxmock pool should initialize")
+			defer mock.Close()
+
+			orgID := uuid.New()
+			sessionID := uuid.New()
+			resultID := uuid.New()
+			now := time.Now().UTC()
+			mock.ExpectQuery("(?s)SELECT .*FROM code_review_agent_results").
+				WithArgs(pgx.NamedArgs{"org_id": orgID, "session_id": sessionID}).
+				WillReturnRows(newCodeReviewAgentResultRows().
+					AddRow(resultID, orgID, sessionID, "codex", nil, models.CodeReviewAgentRoleOrchestrator, models.CodeReviewAgentResultStatusRunning, nil, tt.structuredResult, now))
+			var structuredArg any = completedOrchestratorResultArg{expectedError: tt.expectedRaw}
+			if tt.preserveRaw {
+				structuredArg = preservedJSONArg{expected: tt.structuredResult}
+			}
+			mock.ExpectQuery("UPDATE code_review_agent_results").
+				WithArgs(models.CodeReviewAgentResultStatusFailed, &tt.expectedRaw, structuredArg, orgID, resultID).
+				WillReturnRows(newCodeReviewAgentResultRows().
+					AddRow(resultID, orgID, sessionID, "codex", nil, models.CodeReviewAgentRoleOrchestrator, models.CodeReviewAgentResultStatusFailed, &tt.expectedRaw, tt.structuredResult, now))
+
+			stores := &Stores{CodeReviews: db.NewCodeReviewStore(mock)}
+			err = harvestCodeReviewOrchestratorResult(context.Background(), stores, nil, zerolog.Nop(), runCodeReviewPayload{
+				OrgID:     orgID,
+				SessionID: sessionID,
+			}, codeReviewPolicyRecordForTest(models.DefaultCodeReviewPolicyConfig()), nil, models.CodeReviewVisualEvidenceSnapshot{})
+
+			require.NoError(t, err, "malformed orchestrator results should become terminal without losing diagnostic evidence")
+			require.NoError(t, mock.ExpectationsWereMet(), "malformed orchestrator result update should preserve raw evidence or persist terminal timing")
+		})
+	}
+}
+
+func TestHarvestCodeReviewOrchestratorResultClassifiesFailedThreadOutput(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		status models.ThreadStatus
+	}{
+		{name: "failed thread", status: models.ThreadStatusFailed},
+		{name: "cancelled thread", status: models.ThreadStatusCancelled},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			mock, err := pgxmock.NewPool()
+			require.NoError(t, err, "pgxmock pool should initialize")
+			defer mock.Close()
+
+			orgID := uuid.New()
+			sessionID := uuid.New()
+			threadID := uuid.New()
+			resultID := uuid.New()
+			now := time.Now().UTC()
+			completedAt := now.Add(-10 * time.Minute)
+			failure := "orchestrator execution failed"
+			state := marshalCodeReviewOrchestratorStructuredResult(codeReviewOrchestratorStructuredResult{ThreadID: threadID.String()})
+			mock.ExpectQuery("(?s)SELECT .*FROM code_review_agent_results").
+				WithArgs(pgx.NamedArgs{"org_id": orgID, "session_id": sessionID}).
+				WillReturnRows(newCodeReviewAgentResultRows().
+					AddRow(resultID, orgID, sessionID, "codex", nil, models.CodeReviewAgentRoleOrchestrator, models.CodeReviewAgentResultStatusRunning, nil, state, now.Add(-20*time.Minute)))
+			mock.ExpectQuery("(?s)SELECT .*FROM session_threads").
+				WithArgs(pgx.NamedArgs{"id": threadID, "org_id": orgID}).
+				WillReturnRows(newSessionThreadRows().
+					AddRow(threadID, sessionID, orgID, models.AgentTypeCodex, nil, nil,
+						"Main", nil, []string{"internal/worker/code_review_handler.go"}, tt.status,
+						nil, 1, &completedAt, nil, nil, &failure, stringPtr("provider_error"),
+						&now, &completedAt, now.Add(-20*time.Minute), models.ThreadCreatedBySourceSystem, nil, nil,
+						nil, 0.25, 0, nil, "", nil, "", "", json.RawMessage(`[]`),
+						models.ThreadExecutionModeWork, models.ThreadFilesystemModeReadWrite))
+			mock.ExpectQuery("(?s)SELECT .*FROM session_messages").
+				WithArgs(pgx.NamedArgs{"org_id": orgID, "thread_id": threadID}).
+				WillReturnRows(newSessionMessageRows())
+			mock.ExpectQuery("UPDATE code_review_agent_results").
+				WithArgs(models.CodeReviewAgentResultStatusFailed, &failure, completedOrchestratorResultArg{expectedError: failure, expectedCompletedAt: &completedAt}, orgID, resultID).
+				WillReturnRows(newCodeReviewAgentResultRows().
+					AddRow(resultID, orgID, sessionID, "codex", nil, models.CodeReviewAgentRoleOrchestrator, models.CodeReviewAgentResultStatusFailed, &failure, state, now))
+
+			stores := &Stores{
+				CodeReviews:     db.NewCodeReviewStore(mock),
+				SessionThreads:  db.NewSessionThreadStore(mock),
+				SessionMessages: db.NewSessionMessageStore(mock),
+			}
+			err = harvestCodeReviewOrchestratorResult(context.Background(), stores, nil, zerolog.Nop(), runCodeReviewPayload{
+				OrgID:     orgID,
+				SessionID: sessionID,
+			}, codeReviewPolicyRecordForTest(models.DefaultCodeReviewPolicyConfig()), nil, models.CodeReviewVisualEvidenceSnapshot{})
+
+			require.NoError(t, err, "failed orchestrator threads should persist durable terminal timing")
+			require.NoError(t, mock.ExpectationsWereMet(), "orchestrator failure classification should use the thread completion time")
+		})
+	}
+}
+
+type preservedJSONArg struct {
+	expected json.RawMessage
+}
+
+func (matcher preservedJSONArg) Match(value any) bool {
+	switch typed := value.(type) {
+	case json.RawMessage:
+		return string(typed) == string(matcher.expected)
+	case []byte:
+		return string(typed) == string(matcher.expected)
+	case string:
+		return typed == string(matcher.expected)
+	default:
+		return false
+	}
+}
+
+type completedReviewerResultArg struct {
+	expectedError       string
+	expectedCompletedAt *time.Time
+}
+
+func (matcher completedReviewerResultArg) Match(value any) bool {
+	var raw json.RawMessage
+	switch typed := value.(type) {
+	case json.RawMessage:
+		raw = typed
+	case []byte:
+		raw = typed
+	case string:
+		raw = json.RawMessage(typed)
+	default:
+		return false
+	}
+	state, ok := parseCodeReviewReviewerStructuredResult(raw)
+	if !ok || state.Error != matcher.expectedError {
+		return false
+	}
+	completedAt, err := time.Parse(time.RFC3339, state.CompletedAt)
+	if err != nil {
+		return false
+	}
+	return matcher.expectedCompletedAt == nil || completedAt.Equal(matcher.expectedCompletedAt.UTC().Truncate(time.Second))
+}
+
+type completedOrchestratorResultArg struct {
+	expectedError       string
+	expectedCompletedAt *time.Time
+}
+
+func (matcher completedOrchestratorResultArg) Match(value any) bool {
+	var raw json.RawMessage
+	switch typed := value.(type) {
+	case json.RawMessage:
+		raw = typed
+	case []byte:
+		raw = typed
+	case string:
+		raw = json.RawMessage(typed)
+	default:
+		return false
+	}
+	state, ok := parseCodeReviewOrchestratorStructuredResult(raw)
+	if !ok || state.Error != matcher.expectedError {
+		return false
+	}
+	completedAt, err := time.Parse(time.RFC3339, state.CompletedAt)
+	if err != nil {
+		return false
+	}
+	return matcher.expectedCompletedAt == nil || completedAt.Equal(matcher.expectedCompletedAt.UTC().Truncate(time.Second))
 }
 
 type validatedOrchestratorResultArg struct{}
@@ -3050,7 +3328,7 @@ func TestHarvestCodeReviewOrchestratorResultRejectsMalformedSynthesis(t *testing
 	err = harvestCodeReviewOrchestratorResult(context.Background(), stores, nil, zerolog.Nop(), runCodeReviewPayload{
 		OrgID:     orgID,
 		SessionID: sessionID,
-	}, policy, models.CodeReviewSessionMetadata{CreatedAt: now}, []codereview.PullRequestFile{{Filename: "internal/worker/code_review_handler.go"}}, models.CodeReviewVisualEvidenceSnapshot{})
+	}, policy, []codereview.PullRequestFile{{Filename: "internal/worker/code_review_handler.go"}}, models.CodeReviewVisualEvidenceSnapshot{})
 
 	require.NoError(t, err, "orchestrator harvest should record malformed synthesis as an agent failure")
 	require.NoError(t, mock.ExpectationsWereMet(), "malformed synthesis should be retained as raw output and never marked completed")
@@ -3182,7 +3460,6 @@ func TestCodeReviewInFlightAgentPhaseFromState(t *testing.T) {
 func TestCodeReviewInFlightAgentPhaseRejectsInvalidContext(t *testing.T) {
 	t.Parallel()
 
-	now := time.Now().UTC()
 	reviewedHead := "reviewed-head"
 	differentHead := "different-head"
 	policy := models.DefaultCodeReviewPolicyConfig()
@@ -3193,16 +3470,10 @@ func TestCodeReviewInFlightAgentPhaseRejectsInvalidContext(t *testing.T) {
 		metadata models.CodeReviewSessionMetadata
 	}{
 		{
-			name:     "reviewer timeout falls through",
-			job:      runCodeReviewPayload{HeadSHA: reviewedHead},
-			pr:       models.PullRequest{HeadSHA: &reviewedHead},
-			metadata: models.CodeReviewSessionMetadata{CreatedAt: now.Add(-time.Hour)},
-		},
-		{
 			name:     "persisted head mismatch falls through",
 			job:      runCodeReviewPayload{HeadSHA: reviewedHead},
 			pr:       models.PullRequest{HeadSHA: &differentHead},
-			metadata: models.CodeReviewSessionMetadata{CreatedAt: now},
+			metadata: models.CodeReviewSessionMetadata{CreatedAt: time.Now().UTC()},
 		},
 	}
 
@@ -3223,6 +3494,192 @@ func TestCodeReviewInFlightAgentPhaseRejectsInvalidContext(t *testing.T) {
 			require.NoError(t, mock.ExpectationsWereMet(), "invalid context should not query durable agent state")
 		})
 	}
+}
+
+func TestCodeReviewInFlightAgentPhaseKeepsActiveOrchestratorAfterReviewerDeadline(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "pgxmock pool should initialize")
+	defer mock.Close()
+
+	orgID := uuid.New()
+	sessionID := uuid.New()
+	threadID := uuid.New()
+	resultID := uuid.New()
+	now := time.Now().UTC()
+	reviewedHead := "reviewed-head"
+	resultState := marshalCodeReviewOrchestratorStructuredResult(codeReviewOrchestratorStructuredResult{ThreadID: threadID.String()})
+	mock.ExpectQuery("(?s)SELECT .*FROM code_review_agent_results").
+		WithArgs(pgx.NamedArgs{"org_id": orgID, "session_id": sessionID}).
+		WillReturnRows(newCodeReviewAgentResultRows().
+			AddRow(resultID, orgID, sessionID, "codex", nil, models.CodeReviewAgentRoleOrchestrator, models.CodeReviewAgentResultStatusRunning, nil, resultState, now.Add(-10*time.Minute)))
+	mock.ExpectQuery("(?s)SELECT .*FROM session_threads").
+		WithArgs(pgx.NamedArgs{"org_id": orgID, "session_id": sessionID}).
+		WillReturnRows(newSessionThreadRows().
+			AddRow(threadID, sessionID, orgID, models.AgentTypeCodex, nil, nil,
+				"Main", nil, []string{"internal/worker/code_review_handler.go"}, models.ThreadStatusRunning,
+				nil, 1, nil, nil, nil, nil, nil,
+				&now, nil, now.Add(-10*time.Minute), models.ThreadCreatedBySourceSystem, nil, nil,
+				nil, 0.25, 0, nil, "", nil, "", "", json.RawMessage(`[]`),
+				models.ThreadExecutionModeWork, models.ThreadFilesystemModeReadWrite))
+
+	phase, err := codeReviewInFlightAgentPhase(context.Background(), &Stores{
+		CodeReviews:    db.NewCodeReviewStore(mock),
+		SessionThreads: db.NewSessionThreadStore(mock),
+	}, runCodeReviewPayload{OrgID: orgID, SessionID: sessionID, HeadSHA: reviewedHead}, models.PullRequest{HeadSHA: &reviewedHead}, models.DefaultCodeReviewPolicyConfig(), models.CodeReviewSessionMetadata{CreatedAt: now.Add(-time.Hour)})
+
+	require.NoError(t, err, "active orchestrator phase should be resolved from durable state")
+	require.Equal(t, codeReviewAgentPhaseOrchestrator, phase, "active orchestrator should retain the fast path after the reviewer deadline")
+	require.NoError(t, mock.ExpectationsWereMet(), "phase detection should inspect the active orchestrator result and thread")
+}
+
+func TestCodeReviewInFlightAgentPhaseTimedOut(t *testing.T) {
+	t.Parallel()
+
+	policy := models.DefaultCodeReviewPolicyConfig()
+	now := time.Now().UTC().Truncate(time.Second)
+	tests := []struct {
+		name     string
+		metadata models.CodeReviewSessionMetadata
+		results  []models.CodeReviewAgentResult
+		phase    codeReviewAgentPhase
+		expected bool
+	}{
+		{
+			name:     "expired reviewer window falls through to harvest",
+			metadata: models.CodeReviewSessionMetadata{CreatedAt: now.Add(-time.Hour)},
+			phase:    codeReviewAgentPhaseReviewers,
+			expected: true,
+		},
+		{
+			name:     "active reviewer window keeps fast path",
+			metadata: models.CodeReviewSessionMetadata{CreatedAt: now.Add(-10 * time.Minute)},
+			phase:    codeReviewAgentPhaseReviewers,
+		},
+		{
+			name:     "active orchestrator keeps fast path after reviewer deadline",
+			metadata: models.CodeReviewSessionMetadata{CreatedAt: now.Add(-time.Hour)},
+			results: []models.CodeReviewAgentResult{{
+				Role:      models.CodeReviewAgentRoleOrchestrator,
+				Status:    models.CodeReviewAgentResultStatusRunning,
+				CreatedAt: now.Add(-10 * time.Minute),
+			}},
+			phase: codeReviewAgentPhaseOrchestrator,
+		},
+		{
+			name:     "expired orchestrator window falls through to harvest",
+			metadata: models.CodeReviewSessionMetadata{CreatedAt: now.Add(-2 * time.Hour)},
+			results: []models.CodeReviewAgentResult{{
+				Role:      models.CodeReviewAgentRoleOrchestrator,
+				Status:    models.CodeReviewAgentResultStatusRunning,
+				CreatedAt: now.Add(-time.Hour),
+			}},
+			phase:    codeReviewAgentPhaseOrchestrator,
+			expected: true,
+		},
+		{
+			name:     "orchestrator phase without result falls through safely",
+			metadata: models.CodeReviewSessionMetadata{CreatedAt: now.Add(-time.Hour)},
+			phase:    codeReviewAgentPhaseOrchestrator,
+			expected: true,
+		},
+		{
+			name:     "no in-flight phase has no deadline",
+			metadata: models.CodeReviewSessionMetadata{CreatedAt: now.Add(-time.Hour)},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			actual := codeReviewInFlightAgentPhaseTimedOut(now, policy, tt.metadata, tt.results, tt.phase)
+
+			require.Equal(t, tt.expected, actual, "in-flight fast path should use the active agent phase deadline")
+		})
+	}
+}
+
+func TestCodeReviewOrchestratorDispatchDeadline(t *testing.T) {
+	t.Parallel()
+
+	policy := models.DefaultCodeReviewPolicyConfig()
+	assessmentStartedAt := time.Now().UTC().Add(-time.Hour).Truncate(time.Second)
+	reviewerResult := func(status models.CodeReviewAgentResultStatus, createdAt time.Time, completedAt string) models.CodeReviewAgentResult {
+		return models.CodeReviewAgentResult{
+			Role:      models.CodeReviewAgentRoleReviewer,
+			Status:    status,
+			CreatedAt: createdAt,
+			StructuredResult: marshalCodeReviewReviewerStructuredResult(codeReviewReviewerStructuredResult{
+				CompletedAt: completedAt,
+			}),
+		}
+	}
+	tests := []struct {
+		name     string
+		results  []models.CodeReviewAgentResult
+		expected time.Time
+	}{
+		{
+			name: "starts after latest terminal reviewer completion",
+			results: []models.CodeReviewAgentResult{
+				reviewerResult(models.CodeReviewAgentResultStatusCompleted, assessmentStartedAt, assessmentStartedAt.Add(20*time.Minute).Format(time.RFC3339)),
+				reviewerResult(models.CodeReviewAgentResultStatusCompleted, assessmentStartedAt, assessmentStartedAt.Add(50*time.Minute).Format(time.RFC3339)),
+				reviewerResult(models.CodeReviewAgentResultStatusRunning, assessmentStartedAt, assessmentStartedAt.Add(55*time.Minute).Format(time.RFC3339)),
+				{Role: models.CodeReviewAgentRoleOrchestrator, Status: models.CodeReviewAgentResultStatusCompleted, StructuredResult: marshalCodeReviewReviewerStructuredResult(codeReviewReviewerStructuredResult{CompletedAt: assessmentStartedAt.Add(59 * time.Minute).Format(time.RFC3339)})},
+			},
+			expected: assessmentStartedAt.Add(80 * time.Minute),
+		},
+		{
+			name: "starts after timed out reviewer terminal transition",
+			results: []models.CodeReviewAgentResult{
+				reviewerResult(models.CodeReviewAgentResultStatusCompleted, assessmentStartedAt, assessmentStartedAt.Add(5*time.Minute).Format(time.RFC3339)),
+				reviewerResult(models.CodeReviewAgentResultStatusTimedOut, assessmentStartedAt, assessmentStartedAt.Add(30*time.Minute).Format(time.RFC3339)),
+			},
+			expected: assessmentStartedAt.Add(60 * time.Minute),
+		},
+		{
+			name: "ignores missing and malformed completion timestamps",
+			results: []models.CodeReviewAgentResult{
+				reviewerResult(models.CodeReviewAgentResultStatusCompleted, assessmentStartedAt, assessmentStartedAt.Add(25*time.Minute).Format(time.RFC3339)),
+				reviewerResult(models.CodeReviewAgentResultStatusFailed, assessmentStartedAt.Add(29*time.Minute), ""),
+				reviewerResult(models.CodeReviewAgentResultStatusFailed, assessmentStartedAt.Add(30*time.Minute), "not-a-timestamp"),
+				{Role: models.CodeReviewAgentRoleReviewer, Status: models.CodeReviewAgentResultStatusFailed, CreatedAt: assessmentStartedAt.Add(30 * time.Minute), StructuredResult: json.RawMessage(`{`)},
+			},
+			expected: assessmentStartedAt.Add(55 * time.Minute),
+		},
+		{
+			name: "falls back to assessment start for legacy results without completion timestamps",
+			results: []models.CodeReviewAgentResult{
+				reviewerResult(models.CodeReviewAgentResultStatusFailed, assessmentStartedAt.Add(30*time.Minute), ""),
+			},
+			expected: assessmentStartedAt.Add(30 * time.Minute),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			metadata := models.CodeReviewSessionMetadata{CreatedAt: assessmentStartedAt}
+			deadline := codeReviewOrchestratorDispatchDeadline(policy, metadata, tt.results)
+
+			require.Equal(t, tt.expected, deadline, "orchestrator dispatch should derive its stable deadline from persisted timestamps")
+		})
+	}
+}
+
+func TestCodeReviewOrchestratorResultDeadlineStartsAtDispatch(t *testing.T) {
+	t.Parallel()
+
+	policy := models.DefaultCodeReviewPolicyConfig()
+	orchestratorStartedAt := time.Now().UTC().Add(-10 * time.Minute).Truncate(time.Second)
+	result := models.CodeReviewAgentResult{CreatedAt: orchestratorStartedAt}
+
+	deadline := codeReviewOrchestratorResultDeadline(policy, result)
+
+	require.Equal(t, orchestratorStartedAt.Add(30*time.Minute), deadline, "running synthesis should receive the configured timeout from orchestrator dispatch")
 }
 
 func TestCodeReviewReviewerExecutionFailed(t *testing.T) {
@@ -4183,6 +4640,45 @@ func TestCodeReviewThreadCompletedByDeadline(t *testing.T) {
 			actual := codeReviewThreadCompletedByDeadline(tt.thread, deadline)
 
 			require.Equal(t, tt.expected, actual, "deadline check should accept only terminal threads with an on-time persisted completion")
+		})
+	}
+}
+
+func TestCodeReviewThreadCompletionTime(t *testing.T) {
+	t.Parallel()
+
+	staleCompletion := time.Date(2026, time.July, 26, 12, 30, 0, 0, time.UTC)
+	tests := []struct {
+		name            string
+		thread          models.SessionThread
+		preservesStored bool
+	}{
+		{
+			name:            "preserves terminal thread completion time",
+			thread:          models.SessionThread{Status: models.ThreadStatusCompleted, CompletedAt: &staleCompletion},
+			preservesStored: true,
+		},
+		{
+			name:   "ignores stale completion time on running thread",
+			thread: models.SessionThread{Status: models.ThreadStatusRunning, CompletedAt: &staleCompletion},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			before := time.Now().UTC()
+			actual := codeReviewThreadCompletionTime(tt.thread)
+			after := time.Now().UTC()
+
+			if tt.preservesStored {
+				require.Equal(t, staleCompletion, actual, "terminal threads should preserve their durable completion time")
+				return
+			}
+			require.False(t, actual.Before(before), "in-flight threads should use a current completion time instead of stale persisted state")
+			require.False(t, actual.After(after), "in-flight thread completion fallback should be captured during evaluation")
+			require.NotEqual(t, staleCompletion, actual, "in-flight threads should not reuse a prior turn completion time")
 		})
 	}
 }


### PR DESCRIPTION
## Summary

Code Reviewer runs could finish every individual review successfully but still require human review because the final synthesis reused the reviewer fan-out deadline. This separates reviewer, orchestrator-dispatch, and orchestrator-execution timing while preserving durable terminal evidence so delayed workers can distinguish completed work from genuine timeouts.

## Changes

- Derive synthesis dispatch timing from the latest terminal reviewer completion and execution timing from the orchestrator result creation time.
- Make in-flight polling phase-aware so a valid synthesis can continue after the reviewer deadline without creating an unbounded retry loop.
- Preserve malformed result evidence while recording terminal errors and completion timestamps for recoverable structured states.
- Ignore stale prior-turn `completed_at` values on running threads, including after asynchronous cancellation, with focused regression coverage.

## Validation

- `GOCACHE=/private/tmp/143-go-cache go test ./internal/worker -count=1`
- `GOCACHE=/private/tmp/143-go-cache go vet ./internal/worker`
- `git diff --check`
- Crew review panel: Claude Opus and agy approved with no actionable findings.
