### PR TITLE
Fall back to available models for code review synthesis

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -503,6 +503,7 @@ func main() {
 			SessionMessages:     sessionMessageStore,
 			SessionThreads:      sessionThreadStore,
 			ThreadInbox:         db.NewThreadInboxStore(pool),
+			ThreadSendTx:        pool,
 			HumanInputRequests:  sessionHumanInputStore,
 			ThreadFileEvents:    db.NewSessionThreadFileEventStore(pool),
 			SandboxHolders:      db.NewSessionSandboxHolderStore(pool),

--- a/cmd/server/session_executor_main.go
+++ b/cmd/server/session_executor_main.go
@@ -454,6 +454,7 @@ func buildSessionExecutorStores(deps sessionExecutorStoreDeps) *worker.Stores {
 		SessionMessages:     deps.SessionMessages,
 		SessionThreads:      deps.SessionThreads,
 		ThreadInbox:         db.NewThreadInboxStore(pool),
+		ThreadSendTx:        pool,
 		HumanInputRequests:  db.NewSessionHumanInputRequestStore(pool),
 		ThreadFileEvents:    db.NewSessionThreadFileEventStore(pool),
 		SandboxHolders:      db.NewSessionSandboxHolderStore(pool),

--- a/internal/db/session_thread_archival_postgres_test.go
+++ b/internal/db/session_thread_archival_postgres_test.go
@@ -1,0 +1,322 @@
+package db
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/stretchr/testify/require"
+
+	"github.com/assembledhq/143/internal/models"
+)
+
+func TestSessionThreadStorePostgresArchiveWinsAgainstQueuedAppend(t *testing.T) {
+	t.Parallel()
+
+	pool := newThreadArchivalPostgresTestPool(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	orgID, sessionID, threadID := seedThreadArchivalPostgresThread(t, pool)
+
+	archiveTx, err := pool.Begin(ctx)
+	require.NoError(t, err, "test should begin the archiving transaction")
+	t.Cleanup(func() {
+		rollbackErr := archiveTx.Rollback(context.Background())
+		if rollbackErr != nil && !errors.Is(rollbackErr, pgx.ErrTxClosed) {
+			require.NoError(t, rollbackErr, "archive transaction cleanup should rollback cleanly")
+		}
+	})
+
+	archived, err := NewSessionThreadStore(archiveTx).Archive(ctx, orgID, sessionID, threadID)
+	require.NoError(t, err, "archive transaction should mark the thread archived before commit")
+	require.NotNil(t, archived.ArchivedAt, "archive transaction should stamp archived_at")
+
+	appendConn := acquireThreadArchivalTestConn(t, ctx, pool)
+	appendPID := backendPID(t, ctx, appendConn)
+	appendDone := make(chan error, 1)
+	appendStarted := make(chan struct{})
+	go func() {
+		close(appendStarted)
+		_, appendErr := NewThreadInboxStore(appendConn).AppendForMessage(ctx, orgID, AppendThreadInboxEntryParams{
+			SessionID: sessionID,
+			ThreadID:  threadID,
+			MessageID: 42,
+			EntryType: models.ThreadInboxEntryTypeUserMessage,
+			Payload:   json.RawMessage(`{"message_id":42}`),
+		})
+		appendDone <- appendErr
+	}()
+
+	<-appendStarted
+	waitForBlockedBackend(t, ctx, archiveTx, appendPID)
+
+	require.NoError(t, archiveTx.Commit(ctx), "archive transaction should commit cleanly")
+	require.ErrorIs(t, waitForResult(t, ctx, appendDone), pgx.ErrNoRows, "append should reject the archived thread after the archive commits")
+
+	err = NewSessionThreadStore(pool).IncrementPendingMessages(ctx, orgID, threadID)
+	require.ErrorIs(t, err, pgx.ErrNoRows, "pending counter should reject archived threads after archive wins")
+}
+
+func TestSessionThreadStorePostgresQueuedAppendWinsAgainstArchive(t *testing.T) {
+	t.Parallel()
+
+	pool := newThreadArchivalPostgresTestPool(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	orgID, sessionID, threadID := seedThreadArchivalPostgresThread(t, pool)
+
+	queueTx, err := pool.Begin(ctx)
+	require.NoError(t, err, "test should begin the queueing transaction")
+	t.Cleanup(func() {
+		rollbackErr := queueTx.Rollback(context.Background())
+		if rollbackErr != nil && !errors.Is(rollbackErr, pgx.ErrTxClosed) {
+			require.NoError(t, rollbackErr, "queue transaction cleanup should rollback cleanly")
+		}
+	})
+
+	queueInbox := NewThreadInboxStore(queueTx)
+	entry, err := queueInbox.AppendForMessage(ctx, orgID, AppendThreadInboxEntryParams{
+		SessionID: sessionID,
+		ThreadID:  threadID,
+		MessageID: 77,
+		EntryType: models.ThreadInboxEntryTypeUserMessage,
+		Payload:   json.RawMessage(`{"message_id":77}`),
+	})
+	require.NoError(t, err, "queueing transaction should append a pending inbox entry")
+	require.Equal(t, int64(1), entry.SequenceNo, "first queued message should take sequence 1")
+
+	err = NewSessionThreadStore(queueTx).IncrementPendingMessages(ctx, orgID, threadID)
+	require.NoError(t, err, "queueing transaction should increment pending_message_count before commit")
+
+	archiveConn := acquireThreadArchivalTestConn(t, ctx, pool)
+	archivePID := backendPID(t, ctx, archiveConn)
+	archiveDone := make(chan error, 1)
+	archiveStarted := make(chan struct{})
+	go func() {
+		close(archiveStarted)
+		_, archiveErr := NewSessionThreadStore(archiveConn).Archive(ctx, orgID, sessionID, threadID)
+		archiveDone <- archiveErr
+	}()
+
+	<-archiveStarted
+	waitForBlockedBackend(t, ctx, queueTx, archivePID)
+
+	require.NoError(t, queueTx.Commit(ctx), "queueing transaction should commit cleanly")
+	require.ErrorIs(t, waitForResult(t, ctx, archiveDone), pgx.ErrNoRows, "archive should refuse the thread once the committed row shows queued work")
+
+	var pendingCount int
+	err = pool.QueryRow(ctx, `
+		SELECT pending_message_count
+		FROM session_threads
+		WHERE org_id = $1 AND session_id = $2 AND id = $3`,
+		orgID, sessionID, threadID).Scan(&pendingCount)
+	require.NoError(t, err, "test should reload the thread after the queueing commit")
+	require.Equal(t, 1, pendingCount, "queueing commit should persist the pending message count that blocks archive")
+}
+
+func acquireThreadArchivalTestConn(t *testing.T, ctx context.Context, pool *pgxpool.Pool) *pgxpool.Conn {
+	t.Helper()
+
+	conn, err := pool.Acquire(ctx)
+	require.NoError(t, err, "test should acquire a dedicated contender connection")
+	t.Cleanup(conn.Release)
+	return conn
+}
+
+func backendPID(t *testing.T, ctx context.Context, conn interface {
+	QueryRow(context.Context, string, ...any) pgx.Row
+}) int32 {
+	t.Helper()
+
+	var pid int32
+	err := conn.QueryRow(ctx, `SELECT pg_backend_pid()`).Scan(&pid)
+	require.NoError(t, err, "test should read the contender backend pid")
+	return pid
+}
+
+func waitForBlockedBackend(t *testing.T, ctx context.Context, locker interface {
+	QueryRow(context.Context, string, ...any) pgx.Row
+}, blockedPID int32) {
+	t.Helper()
+
+	lockerPID := backendPID(t, ctx, locker)
+	var observed atomic.Bool
+	require.Eventually(t, func() bool {
+		var isBlocked bool
+		err := locker.QueryRow(ctx, `
+			SELECT EXISTS (
+				SELECT 1
+				FROM unnest(pg_blocking_pids($1)) AS blocker_pid
+				WHERE blocker_pid = $2
+			)`,
+			blockedPID, lockerPID).Scan(&isBlocked)
+		require.NoError(t, err, "test should query pg_blocking_pids for the contender")
+		if isBlocked {
+			observed.Store(true)
+		}
+		return isBlocked
+	}, 2*time.Second, 20*time.Millisecond, "contender backend should block on the owner transaction before commit")
+	require.True(t, observed.Load(), "test should observe the contender blocked by the owner transaction")
+}
+
+func waitForResult[T any](t *testing.T, ctx context.Context, resultCh <-chan T) T {
+	t.Helper()
+
+	select {
+	case result := <-resultCh:
+		return result
+	case <-ctx.Done():
+		require.FailNow(t, "timed out waiting for contender result", "context error: %v", ctx.Err())
+		var zero T
+		return zero
+	}
+}
+
+func newThreadArchivalPostgresTestPool(t *testing.T) *pgxpool.Pool {
+	t.Helper()
+
+	databaseURL := os.Getenv("TEST_DATABASE_URL")
+	if databaseURL == "" {
+		t.Skip("set TEST_DATABASE_URL to run PostgreSQL thread archival concurrency tests")
+	}
+
+	ctx := context.Background()
+	adminConfig, err := pgxpool.ParseConfig(databaseURL)
+	require.NoError(t, err, "test should parse TEST_DATABASE_URL")
+	adminPool, err := pgxpool.NewWithConfig(ctx, adminConfig)
+	require.NoError(t, err, "test should connect to TEST_DATABASE_URL")
+
+	schema := "test_thread_archival_" + strings.ReplaceAll(uuid.NewString(), "-", "_")
+	_, err = adminPool.Exec(ctx, `CREATE SCHEMA `+schema)
+	require.NoError(t, err, "test should create an isolated thread archival schema")
+
+	config, err := pgxpool.ParseConfig(databaseURL)
+	require.NoError(t, err, "test should parse the isolated pool configuration")
+	config.ConnConfig.RuntimeParams["search_path"] = schema + ",public"
+	pool, err := pgxpool.NewWithConfig(ctx, config)
+	require.NoError(t, err, "test should connect with the isolated search path")
+	t.Cleanup(func() {
+		pool.Close()
+		_, cleanupErr := adminPool.Exec(context.Background(), `DROP SCHEMA IF EXISTS `+schema+` CASCADE`)
+		require.NoError(t, cleanupErr, "test should remove the isolated thread archival schema")
+		adminPool.Close()
+	})
+
+	_, err = pool.Exec(ctx, `
+		CREATE FUNCTION gen_random_uuid() RETURNS uuid
+		LANGUAGE sql
+		AS $$
+			SELECT (
+				substr(hash, 1, 8) || '-' ||
+				substr(hash, 9, 4) || '-' ||
+				substr(hash, 13, 4) || '-' ||
+				substr(hash, 17, 4) || '-' ||
+				substr(hash, 21, 12)
+			)::uuid
+			FROM (
+				SELECT md5(random()::text || clock_timestamp()::text) AS hash
+			) s;
+		$$;
+		CREATE TABLE organizations (
+			id uuid PRIMARY KEY
+		);
+		CREATE TABLE sessions (
+			id uuid PRIMARY KEY,
+			org_id uuid NOT NULL REFERENCES organizations(id)
+		);
+		CREATE TABLE session_threads (
+			id uuid PRIMARY KEY,
+			session_id uuid NOT NULL REFERENCES sessions(id),
+			org_id uuid NOT NULL REFERENCES organizations(id),
+			agent_type text NOT NULL DEFAULT '',
+			model_override text,
+			reasoning_effort text,
+			label text NOT NULL DEFAULT '',
+			instructions text NOT NULL DEFAULT '',
+			file_scope jsonb,
+			status text NOT NULL,
+			agent_session_id text,
+			current_turn integer NOT NULL DEFAULT 0,
+			last_activity_at timestamptz NOT NULL DEFAULT now(),
+			result_summary text,
+			diff text,
+			failure_explanation text,
+			failure_category text,
+			started_at timestamptz,
+			completed_at timestamptz,
+			created_at timestamptz NOT NULL DEFAULT now(),
+			created_by_source text NOT NULL DEFAULT 'user',
+			created_by_thread_id uuid,
+			archived_at timestamptz,
+			base_snapshot_key text,
+			cost_cents double precision NOT NULL DEFAULT 0,
+			pending_message_count integer NOT NULL DEFAULT 0,
+			cancel_requested_at timestamptz,
+			runtime_stop_reason text NOT NULL DEFAULT '',
+			runtime_graceful_stop_at timestamptz,
+			recovery_state text NOT NULL DEFAULT '',
+			recovery_reason text NOT NULL DEFAULT '',
+			recovery_event_history jsonb NOT NULL DEFAULT '[]'::jsonb,
+			execution_mode text NOT NULL DEFAULT 'work',
+			filesystem_mode text NOT NULL DEFAULT 'read_write'
+		);
+		CREATE TABLE thread_inbox_entries (
+			id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+			org_id uuid NOT NULL REFERENCES organizations(id),
+			session_id uuid NOT NULL REFERENCES sessions(id),
+			thread_id uuid NOT NULL REFERENCES session_threads(id),
+			sequence_no bigint NOT NULL,
+			message_id bigint,
+			client_message_id text,
+			entry_type text NOT NULL,
+			payload jsonb NOT NULL DEFAULT '{}'::jsonb,
+			delivery_state text NOT NULL,
+			delivery_attempts integer NOT NULL DEFAULT 0,
+			last_error text,
+			owner_node_id text,
+			runtime_id uuid,
+			accepted_at timestamptz NOT NULL DEFAULT now(),
+			delivered_at timestamptz,
+			acked_at timestamptz,
+			applied_at timestamptz,
+			created_at timestamptz NOT NULL DEFAULT now(),
+			updated_at timestamptz NOT NULL DEFAULT now()
+		);
+		CREATE UNIQUE INDEX thread_inbox_entries_client_message_unique
+			ON thread_inbox_entries (org_id, thread_id, client_message_id)
+			WHERE client_message_id IS NOT NULL;`)
+	require.NoError(t, err, "test should create the minimal thread archival schema")
+	return pool
+}
+
+func seedThreadArchivalPostgresThread(t *testing.T, pool *pgxpool.Pool) (uuid.UUID, uuid.UUID, uuid.UUID) {
+	t.Helper()
+
+	orgID := uuid.New()
+	sessionID := uuid.New()
+	threadID := uuid.New()
+	siblingThreadID := uuid.New()
+	ctx := context.Background()
+
+	_, err := pool.Exec(ctx, `INSERT INTO organizations (id) VALUES ($1)`, orgID)
+	require.NoError(t, err, "test should seed an organization")
+	_, err = pool.Exec(ctx, `INSERT INTO sessions (id, org_id) VALUES ($1, $2)`, sessionID, orgID)
+	require.NoError(t, err, "test should seed a session")
+	_, err = pool.Exec(ctx, `
+		INSERT INTO session_threads (id, session_id, org_id, status, label)
+		VALUES
+			($1, $2, $3, 'completed', 'Target thread'),
+			($4, $2, $3, 'completed', 'Visible sibling')`,
+		threadID, sessionID, orgID, siblingThreadID)
+	require.NoError(t, err, "test should seed two visible completed threads so archiving remains allowed absent queued work")
+
+	return orgID, sessionID, threadID
+}

--- a/internal/db/session_thread_store.go
+++ b/internal/db/session_thread_store.go
@@ -272,7 +272,7 @@ func (s *SessionThreadStore) CountBySession(ctx context.Context, orgID, sessionI
 func (s *SessionThreadStore) Archive(ctx context.Context, orgID, sessionID, threadID uuid.UUID) (models.SessionThread, error) {
 	query := `
 		WITH visible_threads AS (
-			SELECT id, status
+			SELECT id, status, pending_message_count
 			FROM session_threads
 			WHERE session_id = @session_id
 			  AND org_id = @org_id
@@ -289,6 +289,7 @@ func (s *SessionThreadStore) Archive(ctx context.Context, orgID, sessionID, thre
 		  AND org_id = @org_id
 		  AND archived_at IS NULL
 		  AND (SELECT count FROM visible_count) > 1
+		  AND COALESCE((SELECT pending_message_count FROM visible_threads WHERE id = @id), 0) = 0
 		  AND (SELECT status FROM visible_threads WHERE id = @id) NOT IN ('pending', 'running', 'awaiting_input')
 		RETURNING ` + sessionThreadSelectColumns
 
@@ -896,14 +897,20 @@ func (s *SessionThreadStore) AddCost(ctx context.Context, orgID, threadID uuid.U
 // that is currently busy with another turn. The composer reads this counter
 // to render a "queued (N)" affordance.
 func (s *SessionThreadStore) IncrementPendingMessages(ctx context.Context, orgID, threadID uuid.UUID) error {
-	_, err := s.db.Exec(ctx,
-		`UPDATE session_threads SET pending_message_count = pending_message_count + 1 WHERE id = @id AND org_id = @org_id`,
+	tag, err := s.db.Exec(ctx,
+		`UPDATE session_threads
+		 SET pending_message_count = pending_message_count + 1
+		 WHERE id = @id AND org_id = @org_id AND archived_at IS NULL`,
 		pgx.NamedArgs{"id": threadID, "org_id": orgID},
 	)
-	if err == nil {
-		s.publishThreadInboxByID(ctx, orgID, threadID, models.SessionStreamEventThreadInboxQueued)
+	if err != nil {
+		return err
 	}
-	return err
+	if tag.RowsAffected() == 0 {
+		return pgx.ErrNoRows
+	}
+	s.publishThreadInboxByID(ctx, orgID, threadID, models.SessionStreamEventThreadInboxQueued)
+	return nil
 }
 
 // ClearPendingMessages resets the queued-message counter when a turn drains

--- a/internal/db/session_thread_store_test.go
+++ b/internal/db/session_thread_store_test.go
@@ -504,6 +504,27 @@ func TestSessionThreadStore_Archive(t *testing.T) {
 	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
 }
 
+func TestSessionThreadStore_ArchiveRejectsQueuedWork(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "should create mock pool")
+	defer mock.Close()
+
+	store := NewSessionThreadStore(mock)
+	orgID := uuid.New()
+	sessionID := uuid.New()
+	threadID := uuid.New()
+
+	mock.ExpectQuery(`WITH visible_threads AS[\s\S]*pending_message_count[\s\S]*FOR UPDATE[\s\S]*pending_message_count FROM visible_threads WHERE id = @id[\s\S]*RETURNING`).
+		WithArgs(anyArgs(3)...).
+		WillReturnRows(pgxmock.NewRows(sessionThreadTestColumns))
+
+	_, err = store.Archive(context.Background(), orgID, sessionID, threadID)
+	require.ErrorIs(t, err, pgx.ErrNoRows, "Archive should refuse a thread once the locked row shows queued work")
+	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
+}
+
 func TestSessionThreadStore_UpdateStatus(t *testing.T) {
 	t.Parallel()
 
@@ -561,6 +582,52 @@ func TestSessionThreadStore_UpdateStatus(t *testing.T) {
 				require.Error(t, err, "UpdateStatus should return an error when no rows affected")
 			} else {
 				require.NoError(t, err, "UpdateStatus should not return an error")
+			}
+			require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
+		})
+	}
+}
+
+func TestSessionThreadStore_IncrementPendingMessages(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		rowsAffected int64
+		expectErr    error
+	}{
+		{
+			name:         "increments visible thread",
+			rowsAffected: 1,
+		},
+		{
+			name:         "rejects archived or missing thread",
+			rowsAffected: 0,
+			expectErr:    pgx.ErrNoRows,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			mock, err := pgxmock.NewPool()
+			require.NoError(t, err, "should create mock pool")
+			defer mock.Close()
+
+			store := NewSessionThreadStore(mock)
+			orgID := uuid.New()
+			threadID := uuid.New()
+
+			mock.ExpectExec(`UPDATE session_threads[\s\S]*pending_message_count = pending_message_count \+ 1[\s\S]*archived_at IS NULL`).
+				WithArgs(anyArgs(2)...).
+				WillReturnResult(pgxmock.NewResult("UPDATE", tt.rowsAffected))
+
+			err = store.IncrementPendingMessages(context.Background(), orgID, threadID)
+			if tt.expectErr != nil {
+				require.ErrorIs(t, err, tt.expectErr, "IncrementPendingMessages should reject archived or missing threads")
+			} else {
+				require.NoError(t, err, "IncrementPendingMessages should succeed for visible threads")
 			}
 			require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
 		})

--- a/internal/db/thread_inbox_store.go
+++ b/internal/db/thread_inbox_store.go
@@ -85,6 +85,7 @@ func (s *ThreadInboxStore) AppendForMessage(ctx context.Context, orgID uuid.UUID
 			WHERE org_id = @org_id
 			  AND session_id = @session_id
 			  AND id = @thread_id
+			  AND archived_at IS NULL
 			FOR UPDATE
 		), next_sequence AS (
 			SELECT COALESCE(MAX(sequence_no), 0) + 1 AS sequence_no

--- a/internal/db/thread_inbox_store_test.go
+++ b/internal/db/thread_inbox_store_test.go
@@ -59,6 +59,35 @@ func TestThreadInboxStore_AppendForMessage(t *testing.T) {
 	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
 }
 
+func TestThreadInboxStore_AppendForMessageRejectsArchivedThread(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "pgx mock should be created")
+	defer mock.Close()
+
+	orgID := uuid.New()
+	sessionID := uuid.New()
+	threadID := uuid.New()
+	payload := json.RawMessage(`{"message_id":42}`)
+
+	mock.ExpectQuery(`WITH locked_thread AS[\s\S]*archived_at IS NULL[\s\S]*FOR UPDATE`).
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(pgxmock.NewRows(threadInboxEntryTestColumns))
+
+	store := NewThreadInboxStore(mock)
+	_, err = store.AppendForMessage(context.Background(), orgID, AppendThreadInboxEntryParams{
+		SessionID: sessionID,
+		ThreadID:  threadID,
+		MessageID: 42,
+		EntryType: models.ThreadInboxEntryTypeUserMessage,
+		Payload:   payload,
+	})
+
+	require.ErrorIs(t, err, pgx.ErrNoRows, "AppendForMessage should reject archived threads after taking the lock")
+	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
+}
+
 func TestThreadInboxStore_MarkDeliveredForEntry(t *testing.T) {
 	t.Parallel()
 

--- a/internal/services/thread/service.go
+++ b/internal/services/thread/service.go
@@ -584,7 +584,7 @@ func (s *Service) ArchiveThread(ctx context.Context, orgID, sessionID, threadID 
 			if target.ArchivedAt != nil {
 				return models.SessionThread{}, ErrThreadNotFound
 			}
-			if isActiveStatus(target.Status) {
+			if isActiveStatus(target.Status) || target.PendingMessageCount > 0 {
 				return models.SessionThread{}, ErrThreadActive
 			}
 
@@ -985,6 +985,9 @@ func (s *Service) queueMessageWaitingForSlot(ctx context.Context, input SendMess
 	if s.txStarter != nil && s.inboxStore != nil {
 		answeredQuestion, answeredHumanInput, inboxEntry, err = s.createQueuedMessageAndInboxInTx(ctx, msg, input, thread.Status)
 		if err != nil {
+			if errors.Is(err, pgx.ErrNoRows) {
+				return nil, ErrThreadNotFound
+			}
 			return nil, fmt.Errorf("create queued message: %w", err)
 		}
 	} else {
@@ -994,9 +997,15 @@ func (s *Service) queueMessageWaitingForSlot(ctx context.Context, input SendMess
 		}
 		inboxEntry, err = s.appendInboxForMessage(ctx, input, msg)
 		if err != nil {
+			if errors.Is(err, pgx.ErrNoRows) {
+				return nil, ErrThreadNotFound
+			}
 			return nil, fmt.Errorf("append queued inbox entry: %w", err)
 		}
 		if err := s.threadStore.IncrementPendingMessages(ctx, input.OrgID, input.ThreadID); err != nil {
+			if errors.Is(err, pgx.ErrNoRows) {
+				return nil, ErrThreadNotFound
+			}
 			return nil, fmt.Errorf("increment queued message count: %w", err)
 		}
 	}

--- a/internal/services/thread/service.go
+++ b/internal/services/thread/service.go
@@ -823,8 +823,18 @@ func (s *Service) SendMessage(ctx context.Context, input SendMessageInput) (*Sen
 	)
 	inboxAppendedInTx := false
 	var inboxEntry *models.ThreadInboxEntry
-	if resolvingComments || answerPendingQuestion || answerPendingHumanInput || (s.inboxStore != nil && s.txStarter != nil) {
-		resolvedComments, answeredQuestion, answeredHumanInput, inboxEntry, err = s.createMessageInTx(ctx, msg, input, claimedSession, answerPendingQuestion, answerPendingHumanInput, s.inboxStore != nil)
+	appendInboxInTx := s.inboxStore != nil && s.txStarter != nil
+	if resolvingComments || answerPendingQuestion || answerPendingHumanInput || appendInboxInTx {
+		resolvedComments, answeredQuestion, answeredHumanInput, inboxEntry, err = s.createMessageInTx(
+			ctx,
+			msg,
+			input,
+			claimedSession,
+			answerPendingQuestion,
+			answerPendingHumanInput,
+			appendInboxInTx,
+			queueOnly && appendInboxInTx,
+		)
 		inboxAppendedInTx = err == nil && s.inboxStore != nil
 	} else {
 		err = s.createMessage(ctx, s.messageStore, msg)
@@ -840,6 +850,9 @@ func (s *Service) SendMessage(ctx context.Context, input SendMessageInput) (*Sen
 		var notInSession *db.ErrReviewCommentsNotInSession
 		if errors.As(err, &notInSession) {
 			return nil, err
+		}
+		if queueOnly && errors.Is(err, pgx.ErrNoRows) {
+			return nil, ErrThreadNotFound
 		}
 		return nil, fmt.Errorf("create message: %w", err)
 	}
@@ -858,10 +871,14 @@ func (s *Service) SendMessage(ctx context.Context, input SendMessageInput) (*Sen
 	// continue_session — the in-flight job will drain the queue when it
 	// finishes (see ContinueSession's post-turn drain).
 	if queueOnly {
-		if incErr := s.threadStore.IncrementPendingMessages(ctx, input.OrgID, input.ThreadID); incErr != nil {
-			s.logger.Warn().Err(incErr).
-				Str("thread_id", input.ThreadID.String()).
-				Msg("failed to increment pending_message_count for queued message")
+		if !appendInboxInTx {
+			if incErr := s.threadStore.IncrementPendingMessages(ctx, input.OrgID, input.ThreadID); incErr != nil {
+				s.logger.Warn().Err(incErr).
+					Str("thread_id", input.ThreadID.String()).
+					Msg("failed to increment pending_message_count for queued message")
+			} else {
+				s.recoverLostOwnerAfterQueuedSend(ctx, input.OrgID, input.SessionID, input.ThreadID)
+			}
 		} else {
 			s.recoverLostOwnerAfterQueuedSend(ctx, input.OrgID, input.SessionID, input.ThreadID)
 		}
@@ -1037,7 +1054,7 @@ func (s *Service) createQueuedMessage(ctx context.Context, msg *models.SessionMe
 	if !answerPendingQuestion {
 		return nil, nil, s.createMessage(ctx, s.messageStore, msg)
 	}
-	_, answeredQuestion, _, _, err := s.createMessageInTx(ctx, msg, input, models.Session{}, true, false, false)
+	_, answeredQuestion, _, _, err := s.createMessageInTx(ctx, msg, input, models.Session{}, true, false, false, false)
 	return answeredQuestion, nil, err
 }
 
@@ -1403,6 +1420,7 @@ func (s *Service) createMessageInTx(
 	answerPendingQuestion bool,
 	answerPendingHumanInput bool,
 	appendInbox bool,
+	incrementPending bool,
 ) ([]models.SessionReviewComment, *models.SessionQuestion, *models.HumanInputRequest, *models.ThreadInboxEntry, error) {
 	if s.txStarter == nil {
 		return nil, nil, nil, nil, fmt.Errorf("tx starter not configured")
@@ -1489,6 +1507,12 @@ func (s *Service) createMessageInTx(
 		inboxEntry, err = s.appendInboxForMessageWithStore(ctx, txInboxStore, input, msg)
 		if err != nil {
 			return nil, nil, nil, nil, fmt.Errorf("append inbox entry: %w", err)
+		}
+	}
+	if incrementPending {
+		txThreadStore := db.NewSessionThreadStore(tx)
+		if err := txThreadStore.IncrementPendingMessages(ctx, input.OrgID, input.ThreadID); err != nil {
+			return nil, nil, nil, nil, fmt.Errorf("increment queued message count: %w", err)
 		}
 	}
 

--- a/internal/services/thread/service_test.go
+++ b/internal/services/thread/service_test.go
@@ -2311,6 +2311,93 @@ func TestService_SendMessage_RunningThreadEnqueuesLiveInboxDelivery(t *testing.T
 	require.Nil(t, enqueued[0].TargetNodeID, "live delivery job should let the runtime registry route to the current owner")
 }
 
+func TestService_SendMessage_QueueOnlyWithTxCommitsInboxAndPendingCountAtomically(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "should create pgx mock")
+	defer mock.Close()
+
+	orgID := uuid.New()
+	sessionID := uuid.New()
+	threadID := uuid.New()
+	userID := uuid.New()
+	now := time.Now().UTC()
+	threadInboxColumns := []string{
+		"id", "org_id", "session_id", "thread_id", "sequence_no", "message_id", "client_message_id",
+		"entry_type", "payload", "delivery_state", "delivery_attempts",
+		"last_error", "owner_node_id", "runtime_id", "accepted_at",
+		"delivered_at", "acked_at", "applied_at", "created_at", "updated_at",
+	}
+
+	mock.ExpectBegin()
+	mock.ExpectQuery("INSERT INTO session_messages").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
+			pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
+			pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(pgxmock.NewRows([]string{"id", "created_at"}).AddRow(int64(456), now))
+	mock.ExpectQuery(`WITH locked_thread AS[\s\S]*archived_at IS NULL[\s\S]*FOR UPDATE`).
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(pgxmock.NewRows(threadInboxColumns).AddRow(
+			uuid.New(), orgID, sessionID, threadID, int64(3), int64(456), "message:456",
+			models.ThreadInboxEntryTypeUserMessage, json.RawMessage(`{"content":"keep going","message_id":456,"plan_mode":false,"turn_number":5}`),
+			models.ThreadInboxDeliveryStatePending, 0,
+			nil, nil, nil, now, nil, nil, nil, now, now,
+		))
+	mock.ExpectExec(`UPDATE session_threads[\s\S]*pending_message_count = pending_message_count \+ 1[\s\S]*archived_at IS NULL`).
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
+	mock.ExpectCommit()
+
+	svc, deps := newTestService(t)
+	svc.SetThreadInboxStore(deps.inboxStore, mock)
+	deps.threadStore.claimIdleFn = func(_ context.Context, _, _, _ uuid.UUID) (models.SessionThread, error) {
+		return models.SessionThread{}, fmt.Errorf("thread is already running")
+	}
+	deps.threadStore.getByIDFn = func(_ context.Context, _, _ uuid.UUID) (models.SessionThread, error) {
+		return models.SessionThread{
+			ID:          threadID,
+			SessionID:   sessionID,
+			OrgID:       orgID,
+			CurrentTurn: 3,
+			Status:      models.ThreadStatusRunning,
+		}, nil
+	}
+	var enqueued []db.EnqueueOpts
+	deps.jobStore.enqueueWithOptsFn = func(_ context.Context, gotOrgID uuid.UUID, opts db.EnqueueOpts) (uuid.UUID, error) {
+		require.Equal(t, orgID, gotOrgID, "live delivery enqueue should stay org scoped")
+		enqueued = append(enqueued, opts)
+		return uuid.New(), nil
+	}
+
+	result, err := svc.SendMessage(context.Background(), SendMessageInput{
+		SessionID: sessionID,
+		OrgID:     orgID,
+		ThreadID:  threadID,
+		UserID:    &userID,
+		Message:   "keep going",
+	})
+
+	require.NoError(t, err, "queue-only send should succeed when the transactional admission path commits")
+	require.NotNil(t, result, "queue-only send should return the accepted message")
+	require.Equal(t, "keep going", result.Message.Content, "queue-only send should preserve the submitted message content")
+	require.NotNil(t, result.Message.UserID, "queue-only send should preserve user attribution")
+	require.Equal(t, userID, *result.Message.UserID, "queue-only send should preserve the submitting user")
+	require.Equal(t, 5, result.Message.TurnNumber, "queue-only send should target the turn after the in-flight one")
+	require.NotNil(t, result.InboxEntry, "queue-only send should return the durable inbox entry")
+	require.Equal(t, models.ThreadInboxDeliveryStatePending, result.DeliveryState, "queue-only send should report a pending durable inbox delivery state")
+	expectedDedupeKey := "deliver_thread_inbox:" + threadID.String()
+	require.Equal(t, []db.EnqueueOpts{{
+		Queue:     "agent",
+		JobType:   "deliver_thread_inbox",
+		Payload:   map[string]string{"org_id": orgID.String(), "session_id": sessionID.String(), "thread_id": threadID.String()},
+		Priority:  7,
+		DedupeKey: &expectedDedupeKey,
+	}}, enqueued, "queue-only send should enqueue the exact live-delivery job after the transaction commits")
+	require.Empty(t, deps.threadStore.pendingCalls, "queue-only transactional admission should not call the non-transactional thread store increment path")
+	require.NoError(t, mock.ExpectationsWereMet(), "all transaction expectations should be met")
+}
+
 func TestService_SendMessage_LiveInboxDeliveryEnqueueFailureDoesNotRejectAcceptedMessage(t *testing.T) {
 	t.Parallel()
 
@@ -2355,6 +2442,182 @@ func TestService_SendMessage_LiveInboxDeliveryEnqueueFailureDoesNotRejectAccepte
 	require.NotNil(t, result, "SendMessage should return the accepted message despite notification failure")
 	require.Len(t, deps.inboxStore.appendCalls, 1, "SendMessage should keep durable inbox state for later recovery")
 	require.Equal(t, []uuid.UUID{threadID}, deps.threadStore.pendingCalls, "SendMessage should still reflect queued input in pending counts")
+}
+
+func TestService_SendMessage_QueueOnlyWithTxReturnsNotFoundWhenArchiveWinsAtInboxAdmission(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "should create pgx mock")
+	defer mock.Close()
+
+	orgID := uuid.New()
+	sessionID := uuid.New()
+	threadID := uuid.New()
+	now := time.Now().UTC()
+	mock.ExpectBegin()
+	mock.ExpectQuery("INSERT INTO session_messages").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
+			pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
+			pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(pgxmock.NewRows([]string{"id", "created_at"}).AddRow(int64(42), now))
+	mock.ExpectQuery(`WITH locked_thread AS[\s\S]*archived_at IS NULL[\s\S]*FOR UPDATE`).
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(pgxmock.NewRows([]string{
+			"id", "org_id", "session_id", "thread_id", "sequence_no", "message_id", "client_message_id",
+			"entry_type", "payload", "delivery_state", "delivery_attempts",
+			"last_error", "owner_node_id", "runtime_id", "accepted_at",
+			"delivered_at", "acked_at", "applied_at", "created_at", "updated_at",
+		}))
+	mock.ExpectRollback()
+
+	svc, deps := newTestService(t)
+	svc.SetThreadInboxStore(deps.inboxStore, mock)
+	deps.threadStore.claimIdleFn = func(_ context.Context, _, _, _ uuid.UUID) (models.SessionThread, error) {
+		return models.SessionThread{}, fmt.Errorf("thread is already running")
+	}
+	deps.threadStore.getByIDFn = func(_ context.Context, _, _ uuid.UUID) (models.SessionThread, error) {
+		return models.SessionThread{
+			ID:          threadID,
+			SessionID:   sessionID,
+			OrgID:       orgID,
+			CurrentTurn: 1,
+			Status:      models.ThreadStatusRunning,
+		}, nil
+	}
+
+	result, err := svc.SendMessage(context.Background(), SendMessageInput{
+		SessionID: sessionID,
+		OrgID:     orgID,
+		ThreadID:  threadID,
+		Message:   "queue after archive race",
+	})
+
+	require.Nil(t, result, "queue-only send should not return a partial result when the transactional admission path rolls back")
+	require.ErrorIs(t, err, ErrThreadNotFound, "queue-only send should surface archive-guard rejection as not found")
+	require.Empty(t, deps.threadStore.pendingCalls, "queue-only transactional rollback should not call the non-transactional increment path")
+	require.NoError(t, mock.ExpectationsWereMet(), "all transaction expectations should be met")
+}
+
+func TestService_SendMessage_QueueOnlyWithTxRollsBackOnPendingCountWriteFailure(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "should create pgx mock")
+	defer mock.Close()
+
+	orgID := uuid.New()
+	sessionID := uuid.New()
+	threadID := uuid.New()
+	now := time.Now().UTC()
+	threadInboxColumns := []string{
+		"id", "org_id", "session_id", "thread_id", "sequence_no", "message_id", "client_message_id",
+		"entry_type", "payload", "delivery_state", "delivery_attempts",
+		"last_error", "owner_node_id", "runtime_id", "accepted_at",
+		"delivered_at", "acked_at", "applied_at", "created_at", "updated_at",
+	}
+
+	mock.ExpectBegin()
+	mock.ExpectQuery("INSERT INTO session_messages").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
+			pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
+			pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(pgxmock.NewRows([]string{"id", "created_at"}).AddRow(int64(43), now))
+	mock.ExpectQuery(`WITH locked_thread AS[\s\S]*archived_at IS NULL[\s\S]*FOR UPDATE`).
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(pgxmock.NewRows(threadInboxColumns).AddRow(
+			uuid.New(), orgID, sessionID, threadID, int64(1), int64(43), "message:43",
+			models.ThreadInboxEntryTypeUserMessage, json.RawMessage(`{"message_id":43}`),
+			models.ThreadInboxDeliveryStatePending, 0,
+			nil, nil, nil, now, nil, nil, nil, now, now,
+		))
+	mock.ExpectExec(`UPDATE session_threads[\s\S]*pending_message_count = pending_message_count \+ 1[\s\S]*archived_at IS NULL`).
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnError(fmt.Errorf("write failed"))
+	mock.ExpectRollback()
+
+	svc, deps := newTestService(t)
+	svc.SetThreadInboxStore(deps.inboxStore, mock)
+	deps.threadStore.claimIdleFn = func(_ context.Context, _, _, _ uuid.UUID) (models.SessionThread, error) {
+		return models.SessionThread{}, fmt.Errorf("thread is already running")
+	}
+	deps.threadStore.getByIDFn = func(_ context.Context, _, _ uuid.UUID) (models.SessionThread, error) {
+		return models.SessionThread{
+			ID:          threadID,
+			SessionID:   sessionID,
+			OrgID:       orgID,
+			CurrentTurn: 1,
+			Status:      models.ThreadStatusRunning,
+		}, nil
+	}
+
+	result, err := svc.SendMessage(context.Background(), SendMessageInput{
+		SessionID: sessionID,
+		OrgID:     orgID,
+		ThreadID:  threadID,
+		Message:   "queue after counter failure",
+	})
+
+	require.Nil(t, result, "queue-only send should not return a partial result when the pending count write fails")
+	require.EqualError(t, err, "create message: increment queued message count: write failed", "queue-only send should surface the transactional pending-count failure")
+	require.Empty(t, deps.threadStore.pendingCalls, "queue-only transactional rollback should not call the non-transactional increment path")
+	require.NoError(t, mock.ExpectationsWereMet(), "all transaction expectations should be met")
+}
+
+func TestService_SendMessage_WithTxInboxDoesNotIncrementPendingForNormalSend(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "should create pgx mock")
+	defer mock.Close()
+
+	orgID := uuid.New()
+	sessionID := uuid.New()
+	threadID := uuid.New()
+	now := time.Now().UTC()
+	threadInboxColumns := []string{
+		"id", "org_id", "session_id", "thread_id", "sequence_no", "message_id", "client_message_id",
+		"entry_type", "payload", "delivery_state", "delivery_attempts",
+		"last_error", "owner_node_id", "runtime_id", "accepted_at",
+		"delivered_at", "acked_at", "applied_at", "created_at", "updated_at",
+	}
+
+	mock.ExpectBegin()
+	mock.ExpectQuery("INSERT INTO session_messages").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
+			pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
+			pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(pgxmock.NewRows([]string{"id", "created_at"}).AddRow(int64(123), now))
+	mock.ExpectQuery(`WITH locked_thread AS[\s\S]*archived_at IS NULL[\s\S]*FOR UPDATE`).
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(pgxmock.NewRows(threadInboxColumns).AddRow(
+			uuid.New(), orgID, sessionID, threadID, int64(1), int64(123), "message:123",
+			models.ThreadInboxEntryTypeUserMessage, json.RawMessage(`{"content":"continue","message_id":123,"plan_mode":false,"turn_number":3}`),
+			models.ThreadInboxDeliveryStatePending, 0,
+			nil, nil, nil, now, nil, nil, nil, now, now,
+		))
+	mock.ExpectCommit()
+
+	svc, deps := newTestService(t)
+	svc.SetThreadInboxStore(deps.inboxStore, mock)
+	deps.threadStore.claimIdleFn = func(_ context.Context, _, _, _ uuid.UUID) (models.SessionThread, error) {
+		return models.SessionThread{ID: threadID, SessionID: sessionID, OrgID: orgID, CurrentTurn: 2, Status: models.ThreadStatusRunning}, nil
+	}
+	deps.jobStore.enqueueFn = func(_ context.Context, _ uuid.UUID, _, _ string, _ any, _ int, _ *string) (uuid.UUID, error) {
+		return uuid.New(), nil
+	}
+
+	result, err := svc.SendMessage(context.Background(), SendMessageInput{
+		SessionID: sessionID,
+		OrgID:     orgID,
+		ThreadID:  threadID,
+		Message:   "continue",
+	})
+
+	require.NoError(t, err, "normal send should still succeed with transactional inbox wiring")
+	require.NotNil(t, result, "normal send should return a result")
+	require.Empty(t, deps.threadStore.pendingCalls, "normal send should not increment pending messages")
+	require.NoError(t, mock.ExpectationsWereMet(), "all transaction expectations should be met")
 }
 
 func TestService_ListRecoverableInboxEntries(t *testing.T) {

--- a/internal/services/thread/service_test.go
+++ b/internal/services/thread/service_test.go
@@ -1107,6 +1107,34 @@ func TestService_ArchiveThread(t *testing.T) {
 			},
 			expectErr: ErrThreadActive,
 		},
+		{
+			name: "rejects archiving a thread with queued work",
+			setupDeps: func(deps *testDeps) {
+				deps.sessionStore.getByIDFn = func(_ context.Context, _, _ uuid.UUID) (models.Session, error) {
+					return models.Session{ID: sessionID, OrgID: orgID, Status: "running"}, nil
+				}
+				deps.threadStore.archiveFn = func(_ context.Context, _, _, _ uuid.UUID) (models.SessionThread, error) {
+					return models.SessionThread{}, pgx.ErrNoRows
+				}
+				deps.threadStore.getByIDFn = func(_ context.Context, _, _ uuid.UUID) (models.SessionThread, error) {
+					return models.SessionThread{
+						ID:                  threadID,
+						SessionID:           sessionID,
+						OrgID:               orgID,
+						Status:              models.ThreadStatusCompleted,
+						PendingMessageCount: 1,
+						Label:               "Queued tab",
+					}, nil
+				}
+				deps.threadStore.listBySessionFn = func(_ context.Context, _, _ uuid.UUID) ([]models.SessionThread, error) {
+					return []models.SessionThread{
+						{ID: uuid.New(), SessionID: sessionID, OrgID: orgID, Status: models.ThreadStatusCompleted, Label: "Main tab"},
+						{ID: threadID, SessionID: sessionID, OrgID: orgID, Status: models.ThreadStatusCompleted, PendingMessageCount: 1, Label: "Queued tab"},
+					}, nil
+				}
+			},
+			expectErr: ErrThreadActive,
+		},
 	}
 
 	for _, tt := range tests {
@@ -2548,6 +2576,105 @@ func TestService_QueueMessageWaitingForSlot_DoesNotAnswerHumanInputRequest(t *te
 	require.Nil(t, result.AnsweredHumanInput, "queue path should not mark human input answered before a resume job can carry the request id")
 	require.NotNil(t, created, "queue path should still create the user message")
 	require.Equal(t, []uuid.UUID{threadID}, deps.threadStore.pendingCalls, "queue path should increment pending message count")
+}
+
+func TestService_QueueMessageWaitingForSlot_ReturnsNotFoundWhenArchiveWinsBeforeInboxAppend(t *testing.T) {
+	t.Parallel()
+
+	orgID := uuid.New()
+	sessionID := uuid.New()
+	threadID := uuid.New()
+
+	svc, deps := newTestService(t)
+	deps.threadStore.getByIDFn = func(_ context.Context, _, _ uuid.UUID) (models.SessionThread, error) {
+		return models.SessionThread{
+			ID:          threadID,
+			SessionID:   sessionID,
+			OrgID:       orgID,
+			CurrentTurn: 4,
+			Status:      models.ThreadStatusCompleted,
+		}, nil
+	}
+	deps.messageStore.createFn = func(_ context.Context, msg *models.SessionMessage) error {
+		msg.ID = 99
+		return nil
+	}
+	deps.inboxStore.appendFn = func(_ context.Context, _ uuid.UUID, _ db.AppendThreadInboxEntryParams) (models.ThreadInboxEntry, error) {
+		return models.ThreadInboxEntry{}, pgx.ErrNoRows
+	}
+	svc.SetThreadInboxStore(deps.inboxStore)
+
+	result, err := svc.queueMessageWaitingForSlot(context.Background(), SendMessageInput{
+		SessionID: sessionID,
+		OrgID:     orgID,
+		ThreadID:  threadID,
+		Message:   "resume after sibling frees a slot",
+	})
+
+	require.Nil(t, result, "archive-win queue admission should not return a partial result")
+	require.ErrorIs(t, err, ErrThreadNotFound, "archive-win queue admission should surface the archived thread as not found")
+	require.Empty(t, deps.threadStore.pendingCalls, "archive-win queue admission should not increment the queued counter after append rejection")
+}
+
+func TestService_QueueMessageWaitingForSlot_RollsBackTxWhenArchiveWinsBeforePendingIncrement(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "should create pgx mock")
+	defer mock.Close()
+
+	orgID := uuid.New()
+	sessionID := uuid.New()
+	threadID := uuid.New()
+	now := time.Now().UTC()
+	threadInboxColumns := []string{
+		"id", "org_id", "session_id", "thread_id", "sequence_no", "message_id", "client_message_id",
+		"entry_type", "payload", "delivery_state", "delivery_attempts",
+		"last_error", "owner_node_id", "runtime_id", "accepted_at",
+		"delivered_at", "acked_at", "applied_at", "created_at", "updated_at",
+	}
+
+	mock.ExpectBegin()
+	mock.ExpectQuery("INSERT INTO session_messages").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
+			pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
+			pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(pgxmock.NewRows([]string{"id", "created_at"}).AddRow(int64(42), now))
+	mock.ExpectQuery(`WITH locked_thread AS[\s\S]*archived_at IS NULL[\s\S]*FOR UPDATE`).
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(pgxmock.NewRows(threadInboxColumns).AddRow(
+			uuid.New(), orgID, sessionID, threadID, int64(1), int64(42), "message:42",
+			models.ThreadInboxEntryTypeUserMessage, json.RawMessage(`{"message_id":42}`),
+			models.ThreadInboxDeliveryStatePending, 0,
+			nil, nil, nil, now, nil, nil, nil, now, now,
+		))
+	mock.ExpectExec(`UPDATE session_threads[\s\S]*pending_message_count = pending_message_count \+ 1[\s\S]*archived_at IS NULL`).
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnResult(pgxmock.NewResult("UPDATE", 0))
+	mock.ExpectRollback()
+
+	svc, deps := newTestService(t)
+	deps.threadStore.getByIDFn = func(_ context.Context, _, _ uuid.UUID) (models.SessionThread, error) {
+		return models.SessionThread{
+			ID:          threadID,
+			SessionID:   sessionID,
+			OrgID:       orgID,
+			CurrentTurn: 1,
+			Status:      models.ThreadStatusIdle,
+		}, nil
+	}
+	svc.SetThreadInboxStore(deps.inboxStore, mock)
+
+	result, err := svc.queueMessageWaitingForSlot(context.Background(), SendMessageInput{
+		SessionID: sessionID,
+		OrgID:     orgID,
+		ThreadID:  threadID,
+		Message:   "queue after archive race",
+	})
+
+	require.Nil(t, result, "transactional archive-win queue admission should not return a partial result")
+	require.ErrorIs(t, err, ErrThreadNotFound, "transactional archive-win queue admission should surface the archived thread as not found")
+	require.NoError(t, mock.ExpectationsWereMet(), "all transaction expectations should be met")
 }
 
 // TestService_SendMessage_ResumesAcrossAllResumableStatuses pins the

--- a/internal/worker/code_review_handler.go
+++ b/internal/worker/code_review_handler.go
@@ -2057,7 +2057,8 @@ func codeReviewOrchestratorSynthesisFromResults(results []models.CodeReviewAgent
 }
 
 func codeReviewOrchestratorEvidence(results []models.CodeReviewAgentResult) (present, usable bool) {
-	for _, result := range results {
+	for i := len(results) - 1; i >= 0; i-- {
+		result := results[i]
 		if result.Role != models.CodeReviewAgentRoleOrchestrator {
 			continue
 		}
@@ -2078,7 +2079,8 @@ func codeReviewOrchestratorOperationalSummary(results []models.CodeReviewAgentRe
 		return ""
 	}
 
-	for _, result := range results {
+	for i := len(results) - 1; i >= 0; i-- {
+		result := results[i]
 		if result.Role != models.CodeReviewAgentRoleOrchestrator {
 			continue
 		}
@@ -2091,8 +2093,8 @@ func codeReviewOrchestratorOperationalSummary(results []models.CodeReviewAgentRe
 			if detail == "" && result.RawOutput != nil {
 				detail = strings.ToLower(strings.TrimSpace(*result.RawOutput))
 			}
-			if strings.Contains(detail, "no authenticated coding agent") {
-				return "143 could not run the final synthesis because no authenticated orchestrator was available. The automated review is incomplete; this is a configuration issue, not a code-quality finding."
+			if summary := codeReviewOrchestratorUnavailableSummary(detail); summary != "" {
+				return summary
 			}
 			if strings.Contains(detail, "synthesis") || strings.Contains(detail, "required field") || strings.Contains(detail, "valid json") {
 				return "143 received reviewer output, but the final synthesis did not match the required response format. The automated review is incomplete; this is not a code-quality finding."
@@ -2106,6 +2108,19 @@ func codeReviewOrchestratorOperationalSummary(results []models.CodeReviewAgentRe
 	}
 
 	return "143 could not complete the final synthesis because the orchestration step did not return a usable result. The automated review is incomplete; this is not a code-quality finding."
+}
+
+func codeReviewOrchestratorUnavailableSummary(detail string) string {
+	switch {
+	case strings.Contains(detail, "no authenticated coding agent"):
+		return "143 could not run the final synthesis because no authenticated orchestrator was available. The automated review is incomplete; this is a configuration issue, not a code-quality finding."
+	case strings.Contains(detail, "no configured coding agent has available authentication and model capacity"):
+		return "143 could not run the final synthesis because no configured orchestrator currently had both authentication and model capacity available. The automated review is incomplete; this is an operational availability issue, not a code-quality finding."
+	case strings.Contains(detail, codeReviewOrchestratorFallbackCapacityUnavailableMessage):
+		return "143 could not complete the final synthesis because no fallback thread slot was safely available. The automated review is incomplete; this is an operational availability issue, not a code-quality finding."
+	default:
+		return ""
+	}
 }
 
 func codeReviewRiskReasonsContain(reasons []models.CodeReviewRiskReason, expected models.CodeReviewRiskReasonCode) bool {
@@ -2682,8 +2697,35 @@ func ensureCodeReviewOrchestratorThread(ctx context.Context, stores *Stores, ser
 	var threadID uuid.UUID
 	dispatch := true
 	if attempt > 0 {
-		thread, err := ensureCodeReviewFallbackOrchestratorThread(ctx, threads, job, selection, attempt, codeReviewChangedPaths(changedFiles))
+		primaryThreadID, err := primaryThreadIDForSession(ctx, stores, session)
 		if err != nil {
+			return fmt.Errorf("resolve code review primary thread before fallback dispatch: %w", err)
+		}
+		thread, err := ensureCodeReviewFallbackOrchestratorThread(ctx, threads, job, selection, attempt, codeReviewChangedPaths(changedFiles), primaryThreadID, agentResults)
+		if err != nil {
+			if errors.Is(err, errCodeReviewFallbackCapacityExhausted) {
+				raw := codeReviewOrchestratorFallbackCapacityUnavailableMessage
+				result := &models.CodeReviewAgentResult{
+					OrgID:         job.OrgID,
+					SessionID:     job.SessionID,
+					AgentProvider: string(agentType),
+					AgentModel:    agentModel,
+					Role:          models.CodeReviewAgentRoleOrchestrator,
+					Status:        models.CodeReviewAgentResultStatusFailed,
+					RawOutput:     &raw,
+					StructuredResult: marshalCodeReviewOrchestratorStructuredResult(codeReviewOrchestratorStructuredResult{
+						Error:       raw,
+						CompletedAt: time.Now().UTC().Format(time.RFC3339),
+					}),
+				}
+				if err := stores.CodeReviews.CreateAgentResult(ctx, result); err != nil {
+					return fmt.Errorf("create exhausted code review orchestrator fallback result: %w", err)
+				}
+				logger.Warn().Str("session_id", job.SessionID.String()).Int("fallback", attempt).
+					Str("orchestrator", string(agentType)).Str("model", stringPtrValue(agentModel)).
+					Msg("skipped code review fallback orchestrator because no thread slot was safely available")
+				return nil
+			}
 			return err
 		}
 		threadID = thread.ID

--- a/internal/worker/code_review_handler.go
+++ b/internal/worker/code_review_handler.go
@@ -320,6 +320,15 @@ func newRunCodeReviewHandler(stores *Stores, services *Services, logger zerolog.
 			if err != nil {
 				return fmt.Errorf("list synthesized code review agent results: %w", err)
 			}
+			if codeReviewOrchestratorNeedsFallback(agentResults) {
+				if err := ensureCodeReviewOrchestratorThread(ctx, stores, services, logger, job, pr, health, policy, metadata, changedFiles, agentResults, findings, visualEvidence); err != nil {
+					return err
+				}
+				agentResults, err = stores.CodeReviews.ListAgentResults(ctx, job.OrgID, job.SessionID)
+				if err != nil {
+					return fmt.Errorf("list fallback code review agent results: %w", err)
+				}
+			}
 			if !codeReviewOrchestratorTerminal(agentResults) {
 				return codeReviewWaitingForOrchestrator(policy.Config())
 			}
@@ -1136,41 +1145,24 @@ func resolveCodeReviewReviewerAvailability(ctx context.Context, services *Servic
 	return selections, nil
 }
 
-func resolveCodeReviewOrchestratorAvailability(ctx context.Context, services *Services, orgID uuid.UUID, cfg models.CodeReviewPolicyConfig) (codeReviewOrchestratorSelection, error) {
-	configured := codeReviewOrchestratorSelection{
-		AgentType:       cfg.AgentRoster.Orchestrator,
-		AgentModel:      codeReviewOrchestratorAgentModel(cfg),
-		ReasoningEffort: reasoningEffortPtr(cfg.AgentRoster.ReasoningEffort),
-		Available:       true,
-	}
-	if services == nil || services.CodingAgents == nil {
-		return configured, nil
-	}
-
-	available, err := services.CodingAgents.IsAgentAvailable(ctx, orgID, nil, configured.AgentType, stringPtrValue(configured.AgentModel))
-	if err != nil {
-		return codeReviewOrchestratorSelection{}, fmt.Errorf("resolve code review orchestrator %s availability: %w", configured.AgentType, err)
-	}
-	if available {
-		return configured, nil
-	}
-
-	for idx, agentType := range cfg.AgentRoster.Reviewers {
-		agentModel := codeReviewReviewerAgentModel(cfg, idx, agentType)
-		available, err := services.CodingAgents.IsAgentAvailable(ctx, orgID, nil, agentType, stringPtrValue(agentModel))
-		if err != nil {
-			return codeReviewOrchestratorSelection{}, fmt.Errorf("resolve code review orchestrator fallback %s availability: %w", agentType, err)
+func resolveCodeReviewOrchestratorAvailability(ctx context.Context, services *Services, orgID uuid.UUID, cfg models.CodeReviewPolicyConfig, results []models.CodeReviewAgentResult) (codeReviewOrchestratorSelection, error) {
+	candidates := codeReviewOrchestratorCandidates(cfg)
+	for _, candidate := range candidates {
+		if codeReviewOrchestratorCandidateExhausted(candidate, results) {
+			continue
 		}
-		if available {
-			return codeReviewOrchestratorSelection{
-				AgentType:       agentType,
-				AgentModel:      agentModel,
-				ReasoningEffort: reasoningEffortPtr(cfg.AgentRoster.ReviewerReasoningEffort(idx)),
-				Available:       true,
-			}, nil
+		if services != nil && services.CodingAgents != nil {
+			available, err := services.CodingAgents.IsAgentAvailable(ctx, orgID, nil, candidate.AgentType, stringPtrValue(candidate.AgentModel))
+			if err != nil {
+				return codeReviewOrchestratorSelection{}, fmt.Errorf("resolve code review orchestrator %s availability: %w", candidate.AgentType, err)
+			}
+			if !available {
+				continue
+			}
 		}
+		return candidate, nil
 	}
-
+	configured := candidates[0]
 	configured.Available = false
 	return configured, nil
 }
@@ -2401,12 +2393,14 @@ func codeReviewInFlightAgentPhaseFromState(policy models.CodeReviewPolicyConfig,
 	}
 
 	orchestratorResults := make([]models.CodeReviewAgentResult, 0, 1)
+	hasOrchestrator := false
 	for _, result := range results {
 		if result.Role != models.CodeReviewAgentRoleOrchestrator {
 			continue
 		}
+		hasOrchestrator = true
 		if codeReviewReviewerResultTerminal(result.Status) {
-			return codeReviewAgentPhaseNone
+			continue
 		}
 		orchestratorResults = append(orchestratorResults, result)
 	}
@@ -2420,6 +2414,9 @@ func codeReviewInFlightAgentPhaseFromState(policy models.CodeReviewPolicyConfig,
 			}
 		}
 		return codeReviewAgentPhaseOrchestrator
+	}
+	if hasOrchestrator {
+		return codeReviewAgentPhaseNone
 	}
 
 	byKey := codeReviewReviewerResultsByKey(results)
@@ -2566,13 +2563,12 @@ func codeReviewWaitingForReviewers(policy models.CodeReviewPolicyConfig) error {
 }
 
 func ensureCodeReviewOrchestratorThread(ctx context.Context, stores *Stores, services *Services, logger zerolog.Logger, job runCodeReviewPayload, pr models.PullRequest, health *models.PullRequestHealthResponse, policy models.CodeReviewPolicyRecord, metadata models.CodeReviewSessionMetadata, changedFiles []codereviewsvc.PullRequestFile, agentResults []models.CodeReviewAgentResult, findings []models.CodeReviewFinding, visualEvidence models.CodeReviewVisualEvidenceSnapshot) error {
-	for _, result := range agentResults {
-		if result.Role == models.CodeReviewAgentRoleOrchestrator {
-			return nil
-		}
-	}
 	cfg := policy.Config()
-	selection, err := resolveCodeReviewOrchestratorAvailability(ctx, services, job.OrgID, cfg)
+	attempt := codeReviewOrchestratorAttemptCount(agentResults)
+	if attempt > 0 && (!codeReviewOrchestratorNeedsFallback(agentResults) || time.Now().After(codeReviewOrchestratorDispatchDeadline(cfg, metadata, agentResults))) {
+		return nil
+	}
+	selection, err := resolveCodeReviewOrchestratorAvailability(ctx, services, job.OrgID, cfg, agentResults)
 	if err != nil {
 		return err
 	}
@@ -2580,7 +2576,12 @@ func ensureCodeReviewOrchestratorThread(ctx context.Context, stores *Stores, ser
 	agentModel := selection.AgentModel
 	reasoningEffort := selection.ReasoningEffort
 	if !selection.Available {
-		raw := "orchestrator skipped because no authenticated coding agent is configured"
+		if attempt > 0 {
+			logger.Warn().Str("session_id", job.SessionID.String()).Int("attempts", attempt).
+				Msg("code review orchestrator fallback models exhausted")
+			return nil
+		}
+		raw := "orchestrator skipped because no configured coding agent has available authentication and model capacity"
 		result := &models.CodeReviewAgentResult{
 			OrgID:         job.OrgID,
 			SessionID:     job.SessionID,
@@ -2625,6 +2626,9 @@ func ensureCodeReviewOrchestratorThread(ctx context.Context, stores *Stores, ser
 	}
 	rootKey := codeReviewPromptRecordRoot(metadata, job)
 	recordKey := fmt.Sprintf("%s/orchestrator-%s", rootKey, agentType)
+	if attempt > 0 {
+		recordKey = fmt.Sprintf("%s/orchestrator-fallback-%02d-%s", rootKey, attempt, agentType)
+	}
 	promptText := codeReviewOrchestratorPrompt(job, pr, health, cfg, policy.Version, metadata.BaseSHA, changedFiles, agentResults, findings, visualEvidence)
 	descriptionInputHash := codeReviewDescriptionInputHash(pr, visualEvidence)
 	if err := storeCodeReviewPromptRecord(ctx, stores, models.CodeReviewPromptRecord{
@@ -2645,11 +2649,8 @@ func ensureCodeReviewOrchestratorThread(ctx context.Context, stores *Stores, ser
 		return err
 	}
 	threads := threadsvc.NewService(stores.SessionThreads, stores.Sessions, stores.SessionMessages, stores.SessionLogs, stores.Jobs, logger)
-	// Run the orchestrator on the session's primary ("Main") thread rather than
-	// spinning up a dedicated tab. The primary thread starts with the policy's
-	// configured orchestrator and is retargeted below when only a reviewer agent
-	// is authenticated. The reviewers keep their own read-only tabs; only the
-	// final synthesis is folded back onto the main thread.
+	// The first synthesis uses Main. Runtime fallbacks use separate threads
+	// because an agent's provider cannot be edited after its first turn.
 	session, err := stores.Sessions.GetByID(ctx, job.OrgID, job.SessionID)
 	if err != nil {
 		return fmt.Errorf("load code review session for orchestrator: %w", err)
@@ -2678,84 +2679,101 @@ func ensureCodeReviewOrchestratorThread(ctx context.Context, stores *Stores, ser
 		}
 	}
 
-	threadID, err := primaryThreadIDForSession(ctx, stores, session)
-	if err != nil {
-		return fmt.Errorf("resolve code review primary thread for orchestrator: %w", err)
-	}
-	primaryThread, err := stores.SessionThreads.GetByID(ctx, job.OrgID, threadID)
-	if err != nil {
-		return fmt.Errorf("load code review primary thread for orchestrator: %w", err)
-	}
-	if primaryThread.AgentType != agentType ||
-		!codeReviewAgentModelsEqual(primaryThread.ModelOverride, agentModel) ||
-		!codeReviewReasoningEffortsEqual(primaryThread.ReasoningEffort, reasoningEffort) {
-		model := ""
-		if agentModel != nil {
-			model = *agentModel
+	var threadID uuid.UUID
+	dispatch := true
+	if attempt > 0 {
+		thread, err := ensureCodeReviewFallbackOrchestratorThread(ctx, threads, job, selection, attempt, codeReviewChangedPaths(changedFiles))
+		if err != nil {
+			return err
 		}
-		_, updateErr := threads.UpdateThread(ctx, threadsvc.UpdateThreadInput{
-			SessionID:       job.SessionID,
-			OrgID:           job.OrgID,
-			ThreadID:        threadID,
-			AgentType:       string(agentType),
-			Model:           &model,
-			ReasoningEffort: reasoningEffort,
-			Label:           primaryThread.Label,
-		})
-		if updateErr != nil {
-			return fmt.Errorf("retarget code review primary thread to available orchestrator %s: %w", agentType, updateErr)
+		threadID = thread.ID
+		// A poll may recover an already dispatched fallback whose result write
+		// failed. Harvest that turn instead of sending the synthesis twice.
+		dispatch = thread.Status == models.ThreadStatusIdle && thread.CurrentTurn == 0
+		logger.Warn().Str("session_id", job.SessionID.String()).Str("thread_id", threadID.String()).
+			Str("orchestrator", string(agentType)).Str("model", stringPtrValue(agentModel)).Int("fallback", attempt).
+			Msg("using fallback code review orchestrator after model availability failure")
+	} else {
+		threadID, err = primaryThreadIDForSession(ctx, stores, session)
+		if err != nil {
+			return fmt.Errorf("resolve code review primary thread for orchestrator: %w", err)
 		}
-		logger.Info().
-			Str("session_id", job.SessionID.String()).
-			Str("thread_id", threadID.String()).
-			Str("orchestrator", string(agentType)).
-			Msg("retargeted code review primary thread to available orchestrator")
+		primaryThread, err := stores.SessionThreads.GetByID(ctx, job.OrgID, threadID)
+		if err != nil {
+			return fmt.Errorf("load code review primary thread for orchestrator: %w", err)
+		}
+		if primaryThread.AgentType != agentType ||
+			!codeReviewAgentModelsEqual(primaryThread.ModelOverride, agentModel) ||
+			!codeReviewReasoningEffortsEqual(primaryThread.ReasoningEffort, reasoningEffort) {
+			model := ""
+			if agentModel != nil {
+				model = *agentModel
+			}
+			_, updateErr := threads.UpdateThread(ctx, threadsvc.UpdateThreadInput{
+				SessionID:       job.SessionID,
+				OrgID:           job.OrgID,
+				ThreadID:        threadID,
+				AgentType:       string(agentType),
+				Model:           &model,
+				ReasoningEffort: reasoningEffort,
+				Label:           primaryThread.Label,
+			})
+			if updateErr != nil {
+				return fmt.Errorf("retarget code review primary thread to available orchestrator %s: %w", agentType, updateErr)
+			}
+			logger.Info().
+				Str("session_id", job.SessionID.String()).
+				Str("thread_id", threadID.String()).
+				Str("orchestrator", string(agentType)).
+				Msg("retargeted code review primary thread to available orchestrator")
+		}
 	}
 	structured := marshalCodeReviewOrchestratorStructuredResult(codeReviewOrchestratorStructuredResult{
 		ThreadID:             threadID.String(),
 		PromptRecordKey:      recordKey,
 		DescriptionInputHash: descriptionInputHash,
-		ReadOnly:             false,
+		ReadOnly:             attempt > 0,
 	})
 	// The orchestrator agent result is created only once the thread is actually
 	// dispatched. A transient claim race leaves no result behind, so the next
 	// run_code_review poll re-enters this function cleanly and retries.
-	if _, err := threads.SendMessage(ctx, codeReviewAgentMessageInput(job, threadID, promptText, nil, visualEvidence)); err != nil {
-		// Transient: the session was momentarily non-resumable despite the reset
-		// above (e.g. re-parked by a sibling's sandbox-node retry between the
-		// reset and the claim). Don't record a permanent orchestrator failure —
-		// let run_code_review re-poll so synthesis dispatches once the session
-		// settles. The orchestrator runs on the Main thread, so there is no
-		// transient tab to clean up, and no agent result exists yet, so the next
-		// pass re-enters this function cleanly.
-		if errors.Is(err, threadsvc.ErrSessionNotResumable) {
-			logger.Warn().Err(err).Str("thread_id", threadID.String()).Msg("code review session was not resumable for orchestrator dispatch; retrying")
-			return codeReviewWaitingForOrchestrator(cfg)
+	if dispatch {
+		if _, err := threads.SendMessage(ctx, codeReviewAgentMessageInput(job, threadID, promptText, nil, visualEvidence)); err != nil {
+			// Transient: the session was momentarily non-resumable despite the reset
+			// above (e.g. re-parked by a sibling's sandbox-node retry between the
+			// reset and the claim). Don't record a permanent orchestrator failure —
+			// let run_code_review re-poll so synthesis dispatches once the session
+			// settles. No result exists yet; the next pass reuses Main or the
+			// deterministically named fallback thread.
+			if errors.Is(err, threadsvc.ErrSessionNotResumable) {
+				logger.Warn().Err(err).Str("thread_id", threadID.String()).Msg("code review session was not resumable for orchestrator dispatch; retrying")
+				return codeReviewWaitingForOrchestrator(cfg)
+			}
+			// Permanent failure: record a terminal orchestrator result so the review
+			// can finish in a degraded state instead of looping forever.
+			raw := err.Error()
+			failed := &models.CodeReviewAgentResult{
+				OrgID:         job.OrgID,
+				SessionID:     job.SessionID,
+				AgentProvider: string(agentType),
+				AgentModel:    agentModel,
+				Role:          models.CodeReviewAgentRoleOrchestrator,
+				Status:        models.CodeReviewAgentResultStatusFailed,
+				RawOutput:     &raw,
+				StructuredResult: marshalCodeReviewOrchestratorStructuredResult(codeReviewOrchestratorStructuredResult{
+					ThreadID:             threadID.String(),
+					PromptRecordKey:      recordKey,
+					DescriptionInputHash: descriptionInputHash,
+					Error:                raw,
+					CompletedAt:          time.Now().UTC().Format(time.RFC3339),
+				}),
+			}
+			if createErr := stores.CodeReviews.CreateAgentResult(ctx, failed); createErr != nil {
+				return fmt.Errorf("create failed code review orchestrator result: %w", createErr)
+			}
+			logger.Warn().Err(err).Str("thread_id", threadID.String()).Msg("failed to start code review orchestrator thread")
+			return nil
 		}
-		// Permanent failure: record a terminal orchestrator result so the review
-		// can finish in a degraded state instead of looping forever.
-		raw := err.Error()
-		failed := &models.CodeReviewAgentResult{
-			OrgID:         job.OrgID,
-			SessionID:     job.SessionID,
-			AgentProvider: string(agentType),
-			AgentModel:    agentModel,
-			Role:          models.CodeReviewAgentRoleOrchestrator,
-			Status:        models.CodeReviewAgentResultStatusFailed,
-			RawOutput:     &raw,
-			StructuredResult: marshalCodeReviewOrchestratorStructuredResult(codeReviewOrchestratorStructuredResult{
-				ThreadID:             threadID.String(),
-				PromptRecordKey:      recordKey,
-				DescriptionInputHash: descriptionInputHash,
-				Error:                raw,
-				CompletedAt:          time.Now().UTC().Format(time.RFC3339),
-			}),
-		}
-		if createErr := stores.CodeReviews.CreateAgentResult(ctx, failed); createErr != nil {
-			return fmt.Errorf("create failed code review orchestrator result: %w", createErr)
-		}
-		logger.Warn().Err(err).Str("thread_id", threadID.String()).Msg("failed to start code review orchestrator thread")
-		return nil
 	}
 	result := &models.CodeReviewAgentResult{
 		OrgID:            job.OrgID,
@@ -2875,6 +2893,32 @@ func harvestCodeReviewOrchestratorResult(ctx context.Context, stores *Stores, se
 		raw, ok, err := latestAssistantMessageForThread(ctx, stores, job.OrgID, threadID)
 		if err != nil {
 			return err
+		}
+		if thread.Status == models.ThreadStatusFailed &&
+			(codeReviewModelUnavailable(stringPtrValue(thread.FailureExplanation)) || codeReviewModelUnavailable(raw)) {
+			// Capacity/rate-limit output is a runtime failure, not malformed
+			// synthesis. Preserve it and let another model run rather than asking
+			// the same unavailable model to repair its JSON.
+			failure := strings.TrimSpace(stringPtrValue(thread.FailureExplanation))
+			if !codeReviewModelUnavailable(failure) {
+				failure = raw
+			}
+			if !ok {
+				raw = failure
+			}
+			state.Error = failure
+			state.Synthesis = codeReviewOrchestratorSynthesis{}
+			state.SynthesisValidated = false
+			state.CompletedAt = codeReviewThreadCompletionTime(thread).Format(time.RFC3339)
+			rawOutput, rawRecordKey, err := codeReviewRawOutputForStorage(ctx, stores, job, result.ID, models.CodeReviewAgentRoleOrchestrator, result.AgentProvider, raw)
+			if err != nil {
+				return err
+			}
+			state.RawRecordKey = rawRecordKey
+			if _, err := stores.CodeReviews.UpdateAgentResultOutcome(ctx, job.OrgID, result.ID, models.CodeReviewAgentResultStatusFailed, rawOutput, marshalCodeReviewOrchestratorStructuredResult(state)); err != nil {
+				return fmt.Errorf("record unavailable code review orchestrator model: %w", err)
+			}
+			continue
 		}
 		if !ok {
 			if thread.Status == models.ThreadStatusFailed || thread.Status == models.ThreadStatusCancelled {
@@ -3002,12 +3046,17 @@ func codeReviewVisualEvidenceSatisfactions(synthesis codeReviewOrchestratorSynth
 }
 
 func codeReviewOrchestratorTerminal(results []models.CodeReviewAgentResult) bool {
+	found := false
 	for _, result := range results {
-		if result.Role == models.CodeReviewAgentRoleOrchestrator && codeReviewReviewerResultTerminal(result.Status) {
-			return true
+		if result.Role != models.CodeReviewAgentRoleOrchestrator {
+			continue
+		}
+		found = true
+		if !codeReviewReviewerResultTerminal(result.Status) {
+			return false
 		}
 	}
-	return false
+	return found
 }
 
 func codeReviewWaitingForOrchestrator(policy models.CodeReviewPolicyConfig) error {

--- a/internal/worker/code_review_handler_test.go
+++ b/internal/worker/code_review_handler_test.go
@@ -4201,6 +4201,39 @@ func TestCodeReviewOrchestratorOperationalSummary(t *testing.T) {
 			expected: "143 could not run the final synthesis because no authenticated orchestrator was available. The automated review is incomplete; this is a configuration issue, not a code-quality finding.",
 		},
 		{
+			name: "explains orchestrator availability exhaustion",
+			results: []models.CodeReviewAgentResult{{
+				Role:   models.CodeReviewAgentRoleOrchestrator,
+				Status: models.CodeReviewAgentResultStatusFailed,
+				StructuredResult: marshalCodeReviewOrchestratorStructuredResult(codeReviewOrchestratorStructuredResult{
+					Error: "orchestrator skipped because no configured coding agent has available authentication and model capacity",
+				}),
+			}},
+			reasons:  invalidSynthesis,
+			expected: "143 could not run the final synthesis because no configured orchestrator currently had both authentication and model capacity available. The automated review is incomplete; this is an operational availability issue, not a code-quality finding.",
+		},
+		{
+			name: "uses the latest orchestrator failure when fallback capacity is exhausted after a primary capacity failure",
+			results: []models.CodeReviewAgentResult{
+				{
+					Role:   models.CodeReviewAgentRoleOrchestrator,
+					Status: models.CodeReviewAgentResultStatusFailed,
+					StructuredResult: marshalCodeReviewOrchestratorStructuredResult(codeReviewOrchestratorStructuredResult{
+						Error: codeReviewCapacityFailureForTest,
+					}),
+				},
+				{
+					Role:   models.CodeReviewAgentRoleOrchestrator,
+					Status: models.CodeReviewAgentResultStatusFailed,
+					StructuredResult: marshalCodeReviewOrchestratorStructuredResult(codeReviewOrchestratorStructuredResult{
+						Error: codeReviewOrchestratorFallbackCapacityUnavailableMessage,
+					}),
+				},
+			},
+			reasons:  invalidSynthesis,
+			expected: "143 could not complete the final synthesis because no fallback thread slot was safely available. The automated review is incomplete; this is an operational availability issue, not a code-quality finding.",
+		},
+		{
 			name:     "explains a missing orchestrator result",
 			reasons:  invalidSynthesis,
 			expected: "143 could not complete the final synthesis because the orchestration step did not return a usable result. The automated review is incomplete; this is not a code-quality finding.",
@@ -4216,6 +4249,89 @@ func TestCodeReviewOrchestratorOperationalSummary(t *testing.T) {
 			require.Equal(t, tt.expected, actual, "operational summary should safely explain why automated synthesis is incomplete")
 		})
 	}
+}
+
+func TestEnsureCodeReviewOrchestratorThreadUnavailableSummaryUsesPersistedAvailabilityFailure(t *testing.T) {
+	t.Parallel()
+
+	stores, mock := newTestStores(t)
+	defer mock.Close()
+	stores.CodeReviews = db.NewCodeReviewStore(mock)
+
+	job := runCodeReviewPayload{OrgID: uuid.New(), SessionID: uuid.New()}
+	policy := codeReviewPolicyRecordForTest(models.DefaultCodeReviewPolicyConfig())
+	raw := "orchestrator skipped because no configured coding agent has available authentication and model capacity"
+	now := time.Now().UTC()
+	resultID := uuid.New()
+	expectedAgentType := policy.Config().AgentRoster.Orchestrator
+	expectedModel := codeReviewOrchestratorAgentModel(policy.Config())
+	var persistedRaw *string
+	var persistedStructured json.RawMessage
+	mock.ExpectQuery("INSERT INTO code_review_agent_results").
+		WithArgs(job.OrgID, job.SessionID, string(expectedAgentType), expectedModel, models.CodeReviewAgentRoleOrchestrator,
+			models.CodeReviewAgentResultStatusFailed, codeReviewFallbackArg(func(value any) bool {
+				text, ok := value.(*string)
+				persistedRaw = text
+				return ok && text != nil && *text == raw
+			}), codeReviewFallbackArg(func(value any) bool {
+				encoded, ok := value.(json.RawMessage)
+				persistedStructured = encoded
+				if !ok {
+					return false
+				}
+				state, ok := parseCodeReviewOrchestratorStructuredResult(encoded)
+				return ok && state.Error == raw && state.CompletedAt != ""
+			})).
+		WillReturnRows(newCodeReviewAgentResultRows().AddRow(
+			resultID, job.OrgID, job.SessionID, string(expectedAgentType), expectedModel,
+			models.CodeReviewAgentRoleOrchestrator, models.CodeReviewAgentResultStatusFailed, &raw,
+			marshalCodeReviewOrchestratorStructuredResult(codeReviewOrchestratorStructuredResult{
+				Error:       raw,
+				CompletedAt: now.Format(time.RFC3339),
+			}), now,
+		))
+
+	err := ensureCodeReviewOrchestratorThread(
+		context.Background(),
+		stores,
+		&Services{CodingAgents: codeReviewAgentAvailabilityStub{available: map[models.AgentType]bool{}}},
+		zerolog.Nop(),
+		job,
+		models.PullRequest{},
+		nil,
+		policy,
+		models.CodeReviewSessionMetadata{},
+		nil,
+		nil,
+		nil,
+		models.CodeReviewVisualEvidenceSnapshot{},
+	)
+
+	require.NoError(t, err, "unavailable orchestrator selection should persist a terminal failure instead of raising a worker error")
+	require.NoError(t, mock.ExpectationsWereMet(), "unavailable orchestrator selection should save the availability failure result")
+	require.NotNil(t, persistedRaw, "unavailable orchestrator selection should persist the concrete raw failure output")
+	require.NotEmpty(t, persistedStructured, "unavailable orchestrator selection should persist the concrete structured failure payload")
+
+	summary := codeReviewOrchestratorOperationalSummary(
+		[]models.CodeReviewAgentResult{{
+			ID:               resultID,
+			OrgID:            job.OrgID,
+			SessionID:        job.SessionID,
+			AgentProvider:    string(expectedAgentType),
+			AgentModel:       expectedModel,
+			Role:             models.CodeReviewAgentRoleOrchestrator,
+			Status:           models.CodeReviewAgentResultStatusFailed,
+			RawOutput:        persistedRaw,
+			StructuredResult: persistedStructured,
+		}},
+		[]models.CodeReviewRiskReason{{Code: models.CodeReviewRiskReasonOrchestratorSynthesisInvalid}},
+	)
+
+	require.Equal(t,
+		"143 could not run the final synthesis because no configured orchestrator currently had both authentication and model capacity available. The automated review is incomplete; this is an operational availability issue, not a code-quality finding.",
+		summary,
+		"operational summary should explain the actual persisted no-available-orchestrator failure",
+	)
 }
 
 func TestCodeReviewOrchestratorAgentModel(t *testing.T) {

--- a/internal/worker/code_review_handler_test.go
+++ b/internal/worker/code_review_handler_test.go
@@ -4124,7 +4124,7 @@ func TestResolveCodeReviewOrchestratorAvailability(t *testing.T) {
 			if tt.configure != nil {
 				tt.configure(&testConfig)
 			}
-			actual, err := resolveCodeReviewOrchestratorAvailability(context.Background(), tt.services, uuid.New(), testConfig)
+			actual, err := resolveCodeReviewOrchestratorAvailability(context.Background(), tt.services, uuid.New(), testConfig, nil)
 			if tt.expectErr {
 				require.Error(t, err, "orchestrator availability resolution should propagate lookup failures")
 				return

--- a/internal/worker/code_review_orchestrator_fallback.go
+++ b/internal/worker/code_review_orchestrator_fallback.go
@@ -3,15 +3,21 @@ package worker
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
 
+	"github.com/assembledhq/143/internal/db"
 	"github.com/assembledhq/143/internal/models"
 	"github.com/assembledhq/143/internal/services/agent"
 	threadsvc "github.com/assembledhq/143/internal/services/thread"
 	"github.com/google/uuid"
 )
+
+var errCodeReviewFallbackCapacityExhausted = errors.New("code review fallback capacity exhausted")
+
+const codeReviewOrchestratorFallbackCapacityUnavailableMessage = "orchestrator skipped because no fallback thread slot was safely available"
 
 // Use the captured roster, including each model's own reasoning effort. A
 // capacity failure must not silently introduce an agent outside that policy.
@@ -116,9 +122,10 @@ func codeReviewOrchestratorNeedsFallback(results []models.CodeReviewAgentResult)
 type codeReviewFallbackThreadService interface {
 	ListThreads(context.Context, uuid.UUID, uuid.UUID) ([]models.SessionThread, error)
 	CreateThread(context.Context, threadsvc.CreateThreadInput) (*models.SessionThread, error)
+	ArchiveThread(context.Context, uuid.UUID, uuid.UUID, uuid.UUID) (models.SessionThread, error)
 }
 
-func ensureCodeReviewFallbackOrchestratorThread(ctx context.Context, threads codeReviewFallbackThreadService, job runCodeReviewPayload, selection codeReviewOrchestratorSelection, attempt int, fileScope []string) (*models.SessionThread, error) {
+func ensureCodeReviewFallbackOrchestratorThread(ctx context.Context, threads codeReviewFallbackThreadService, job runCodeReviewPayload, selection codeReviewOrchestratorSelection, attempt int, fileScope []string, primaryThreadID uuid.UUID, results []models.CodeReviewAgentResult) (*models.SessionThread, error) {
 	// A used thread's provider is immutable. Keep each failed attempt intact,
 	// and recover the next thread if dispatch succeeded before result storage.
 	label := fmt.Sprintf("Code review synthesis: %s (fallback %d)", selection.AgentType, attempt)
@@ -130,6 +137,18 @@ func ensureCodeReviewFallbackOrchestratorThread(ctx context.Context, threads cod
 		if thread.Label == label && thread.CreatedBySource == models.ThreadCreatedBySourceSystem &&
 			thread.AgentType == selection.AgentType && codeReviewAgentModelsEqual(thread.ModelOverride, selection.AgentModel) {
 			return &thread, nil
+		}
+	}
+	if codeReviewVisibleThreadCount(existing) >= models.MaxThreadsPerSession {
+		candidate := codeReviewFallbackArchivalCandidate(existing, results, primaryThreadID)
+		if candidate == nil {
+			return nil, errCodeReviewFallbackCapacityExhausted
+		}
+		if _, err := threads.ArchiveThread(ctx, job.OrgID, job.SessionID, candidate.ID); err != nil {
+			if codeReviewFallbackCapacityRace(err) {
+				return nil, errCodeReviewFallbackCapacityExhausted
+			}
+			return nil, fmt.Errorf("archive code review fallback slot: %w", err)
 		}
 	}
 	thread, err := threads.CreateThread(ctx, threadsvc.CreateThreadInput{
@@ -145,7 +164,128 @@ func ensureCodeReviewFallbackOrchestratorThread(ctx context.Context, threads cod
 		CreatedBySource: models.ThreadCreatedBySourceSystem,
 	})
 	if err != nil {
+		if errors.Is(err, db.ErrThreadLimitReached) {
+			return nil, errCodeReviewFallbackCapacityExhausted
+		}
 		return nil, fmt.Errorf("create code review fallback orchestrator thread: %w", err)
 	}
 	return thread, nil
+}
+
+func codeReviewVisibleThreadCount(threads []models.SessionThread) int {
+	count := 0
+	for _, thread := range threads {
+		if thread.ArchivedAt == nil {
+			count++
+		}
+	}
+	return count
+}
+
+func codeReviewFallbackArchivalCandidate(threads []models.SessionThread, results []models.CodeReviewAgentResult, primaryThreadID uuid.UUID) *models.SessionThread {
+	resultStates := codeReviewAgentThreadResultStates(results)
+	var best *models.SessionThread
+	bestPriority := codeReviewFallbackThreadPriorityUnavailable
+	for i := range threads {
+		thread := &threads[i]
+		priority, ok := codeReviewFallbackArchivalPriority(*thread, resultStates, primaryThreadID)
+		if !ok || priority >= bestPriority {
+			continue
+		}
+		best = thread
+		bestPriority = priority
+	}
+	return best
+}
+
+type codeReviewAgentThreadResultState struct {
+	terminal         bool
+	nonTerminal      bool
+	orchestrator     bool
+	orchestratorFail bool
+}
+
+func codeReviewAgentThreadResultStates(results []models.CodeReviewAgentResult) map[uuid.UUID]codeReviewAgentThreadResultState {
+	states := make(map[uuid.UUID]codeReviewAgentThreadResultState, len(results))
+	for _, result := range results {
+		threadID, ok := codeReviewAgentResultThreadID(result)
+		if !ok {
+			continue
+		}
+		state := states[threadID]
+		if codeReviewReviewerResultTerminal(result.Status) {
+			state.terminal = true
+		} else {
+			state.nonTerminal = true
+		}
+		if result.Role == models.CodeReviewAgentRoleOrchestrator {
+			state.orchestrator = true
+			if result.Status == models.CodeReviewAgentResultStatusFailed {
+				state.orchestratorFail = true
+			}
+		}
+		states[threadID] = state
+	}
+	return states
+}
+
+func codeReviewAgentResultThreadID(result models.CodeReviewAgentResult) (uuid.UUID, bool) {
+	var rawThreadID string
+	switch result.Role {
+	case models.CodeReviewAgentRoleReviewer:
+		state, ok := parseCodeReviewReviewerStructuredResult(result.StructuredResult)
+		if !ok {
+			return uuid.Nil, false
+		}
+		rawThreadID = strings.TrimSpace(state.ThreadID)
+	case models.CodeReviewAgentRoleOrchestrator:
+		state, ok := parseCodeReviewOrchestratorStructuredResult(result.StructuredResult)
+		if !ok {
+			return uuid.Nil, false
+		}
+		rawThreadID = strings.TrimSpace(state.ThreadID)
+	default:
+		return uuid.Nil, false
+	}
+	if rawThreadID == "" {
+		return uuid.Nil, false
+	}
+	threadID, err := uuid.Parse(rawThreadID)
+	if err != nil {
+		return uuid.Nil, false
+	}
+	return threadID, true
+}
+
+const codeReviewFallbackThreadPriorityUnavailable = 100
+
+func codeReviewFallbackArchivalPriority(thread models.SessionThread, states map[uuid.UUID]codeReviewAgentThreadResultState, primaryThreadID uuid.UUID) (int, bool) {
+	if thread.ArchivedAt != nil ||
+		thread.CreatedBySource != models.ThreadCreatedBySourceSystem ||
+		thread.ID == primaryThreadID ||
+		thread.PendingMessageCount > 0 {
+		return codeReviewFallbackThreadPriorityUnavailable, false
+	}
+	switch thread.Status {
+	case models.ThreadStatusCompleted, models.ThreadStatusFailed, models.ThreadStatusCancelled:
+	default:
+		return codeReviewFallbackThreadPriorityUnavailable, false
+	}
+	state, ok := states[thread.ID]
+	if !ok || !state.terminal || state.nonTerminal {
+		return codeReviewFallbackThreadPriorityUnavailable, false
+	}
+	if state.orchestratorFail {
+		return 0, true
+	}
+	if state.orchestrator {
+		return 1, true
+	}
+	return 2, true
+}
+
+func codeReviewFallbackCapacityRace(err error) bool {
+	return errors.Is(err, threadsvc.ErrThreadActive) ||
+		errors.Is(err, threadsvc.ErrThreadNotFound) ||
+		errors.Is(err, threadsvc.ErrCannotArchiveLastThread)
 }

--- a/internal/worker/code_review_orchestrator_fallback.go
+++ b/internal/worker/code_review_orchestrator_fallback.go
@@ -1,0 +1,151 @@
+package worker
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/assembledhq/143/internal/models"
+	"github.com/assembledhq/143/internal/services/agent"
+	threadsvc "github.com/assembledhq/143/internal/services/thread"
+	"github.com/google/uuid"
+)
+
+// Use the captured roster, including each model's own reasoning effort. A
+// capacity failure must not silently introduce an agent outside that policy.
+func codeReviewOrchestratorCandidates(cfg models.CodeReviewPolicyConfig) []codeReviewOrchestratorSelection {
+	candidates := []codeReviewOrchestratorSelection{{
+		AgentType:       cfg.AgentRoster.Orchestrator,
+		AgentModel:      codeReviewOrchestratorAgentModel(cfg),
+		ReasoningEffort: reasoningEffortPtr(cfg.AgentRoster.ReasoningEffort),
+		Available:       true,
+	}}
+	for idx, agentType := range cfg.AgentRoster.Reviewers {
+		candidate := codeReviewOrchestratorSelection{
+			AgentType:       agentType,
+			AgentModel:      codeReviewReviewerAgentModel(cfg, idx, agentType),
+			ReasoningEffort: reasoningEffortPtr(cfg.AgentRoster.ReviewerReasoningEffort(idx)),
+			Available:       true,
+		}
+		duplicate := false
+		for _, existing := range candidates {
+			if existing.AgentType == candidate.AgentType && codeReviewAgentModelsEqual(existing.AgentModel, candidate.AgentModel) {
+				duplicate = true
+				break
+			}
+		}
+		if !duplicate {
+			candidates = append(candidates, candidate)
+		}
+	}
+	return candidates
+}
+
+func codeReviewModelUnavailable(message string) bool {
+	lower := strings.ToLower(message)
+	for _, marker := range []string{
+		"model is at capacity", "model is overloaded", "overloaded_error", "server is overloaded", "service unavailable",
+	} {
+		if strings.Contains(lower, marker) {
+			return true
+		}
+	}
+	// Reuse the runtime's rate-limit vocabulary without changing credential
+	// health: a model-capacity error does not mean its credential is unhealthy.
+	return agent.CredentialFailureSignalFromResult(&agent.AgentResult{Error: message}, time.Now()).RateLimited
+}
+
+func codeReviewAgentModelUnavailable(result models.CodeReviewAgentResult) bool {
+	if result.Status != models.CodeReviewAgentResultStatusFailed {
+		return false
+	}
+	var state struct {
+		Error string `json:"error"`
+	}
+	if err := json.Unmarshal(result.StructuredResult, &state); err == nil && strings.TrimSpace(state.Error) != "" {
+		return codeReviewModelUnavailable(state.Error)
+	}
+	return codeReviewModelUnavailable(stringPtrValue(result.RawOutput))
+}
+
+func codeReviewOrchestratorCandidateExhausted(candidate codeReviewOrchestratorSelection, results []models.CodeReviewAgentResult) bool {
+	for _, result := range results {
+		if result.AgentProvider != string(candidate.AgentType) {
+			continue
+		}
+		model := result.AgentModel
+		if model == nil || strings.TrimSpace(*model) == "" {
+			model = codeReviewDefaultAgentModel(candidate.AgentType)
+		}
+		if !codeReviewAgentModelsEqual(model, candidate.AgentModel) {
+			continue
+		}
+		if result.Role == models.CodeReviewAgentRoleOrchestrator || codeReviewAgentModelUnavailable(result) {
+			return true
+		}
+	}
+	return false
+}
+
+func codeReviewOrchestratorAttemptCount(results []models.CodeReviewAgentResult) int {
+	count := 0
+	for _, result := range results {
+		if result.Role == models.CodeReviewAgentRoleOrchestrator {
+			count++
+		}
+	}
+	return count
+}
+
+func codeReviewOrchestratorNeedsFallback(results []models.CodeReviewAgentResult) bool {
+	found := false
+	for _, result := range results {
+		if result.Role != models.CodeReviewAgentRoleOrchestrator {
+			continue
+		}
+		found = true
+		if !codeReviewAgentModelUnavailable(result) {
+			return false
+		}
+	}
+	return found
+}
+
+type codeReviewFallbackThreadService interface {
+	ListThreads(context.Context, uuid.UUID, uuid.UUID) ([]models.SessionThread, error)
+	CreateThread(context.Context, threadsvc.CreateThreadInput) (*models.SessionThread, error)
+}
+
+func ensureCodeReviewFallbackOrchestratorThread(ctx context.Context, threads codeReviewFallbackThreadService, job runCodeReviewPayload, selection codeReviewOrchestratorSelection, attempt int, fileScope []string) (*models.SessionThread, error) {
+	// A used thread's provider is immutable. Keep each failed attempt intact,
+	// and recover the next thread if dispatch succeeded before result storage.
+	label := fmt.Sprintf("Code review synthesis: %s (fallback %d)", selection.AgentType, attempt)
+	existing, err := threads.ListThreads(ctx, job.OrgID, job.SessionID)
+	if err != nil {
+		return nil, fmt.Errorf("list code review fallback threads: %w", err)
+	}
+	for _, thread := range existing {
+		if thread.Label == label && thread.CreatedBySource == models.ThreadCreatedBySourceSystem &&
+			thread.AgentType == selection.AgentType && codeReviewAgentModelsEqual(thread.ModelOverride, selection.AgentModel) {
+			return &thread, nil
+		}
+	}
+	thread, err := threads.CreateThread(ctx, threadsvc.CreateThreadInput{
+		SessionID:       job.SessionID,
+		OrgID:           job.OrgID,
+		AgentType:       string(selection.AgentType),
+		Model:           stringPtrValue(selection.AgentModel),
+		ReasoningEffort: selection.ReasoningEffort,
+		Label:           label,
+		FileScope:       fileScope,
+		ExecutionMode:   models.ThreadExecutionModeReview,
+		FilesystemMode:  models.ThreadFilesystemModeReadOnly,
+		CreatedBySource: models.ThreadCreatedBySourceSystem,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("create code review fallback orchestrator thread: %w", err)
+	}
+	return thread, nil
+}

--- a/internal/worker/code_review_orchestrator_fallback_test.go
+++ b/internal/worker/code_review_orchestrator_fallback_test.go
@@ -1,0 +1,473 @@
+package worker
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/assembledhq/143/internal/db"
+	"github.com/assembledhq/143/internal/models"
+	threadsvc "github.com/assembledhq/143/internal/services/thread"
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/pashagolub/pgxmock/v4"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/require"
+)
+
+const codeReviewCapacityFailureForTest = "Selected model is at capacity. Please try a different model."
+
+func codeReviewFailedModelForTest(agentType models.AgentType, model string, role models.CodeReviewAgentRole) models.CodeReviewAgentResult {
+	return models.CodeReviewAgentResult{
+		AgentProvider: string(agentType),
+		AgentModel:    stringPtr(model),
+		Role:          role,
+		Status:        models.CodeReviewAgentResultStatusFailed,
+		RawOutput:     stringPtr(codeReviewCapacityFailureForTest),
+		StructuredResult: marshalCodeReviewOrchestratorStructuredResult(codeReviewOrchestratorStructuredResult{
+			Error: codeReviewCapacityFailureForTest,
+		}),
+	}
+}
+
+func TestCodeReviewModelUnavailable(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		message  string
+		expected bool
+	}{
+		{name: "Codex capacity", message: "codex CLI exited with code 1: " + codeReviewCapacityFailureForTest, expected: true},
+		{name: "case insensitive capacity", message: "Selected MODEL IS AT CAPACITY", expected: true},
+		{name: "provider overload", message: `{"type":"overloaded_error"}`, expected: true},
+		{name: "service temporarily unavailable", message: "503 Service Unavailable", expected: true},
+		{name: "rate limited", message: "429 Too many requests", expected: true},
+		{name: "subscription usage limit", message: "You have reached your usage limit", expected: true},
+		{name: "sandbox capacity is unrelated", message: "sandbox capacity reached: 2/2 sandboxes active"},
+		{name: "malformed synthesis is unrelated", message: "orchestrator synthesis is missing required fields"},
+		{name: "invalid model is unrelated", message: "model does not exist"},
+		{name: "cancellation is unrelated", message: "context canceled"},
+		{name: "deadline is unrelated", message: "context deadline exceeded"},
+		{name: "empty failure"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tt.expected, codeReviewModelUnavailable(tt.message), "only upstream model availability failures should trigger fallback")
+		})
+	}
+}
+
+func TestResolveCodeReviewOrchestratorRuntimeFallbacks(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		results        func() []models.CodeReviewAgentResult
+		available      map[models.AgentType]bool
+		expectedAgent  models.AgentType
+		expectedModel  string
+		expectedEffort models.ReasoningEffort
+		expectedReady  bool
+	}{
+		{
+			name: "skips the model that already failed during review",
+			results: func() []models.CodeReviewAgentResult {
+				return []models.CodeReviewAgentResult{codeReviewFailedModelForTest(models.AgentTypeCodex, models.DefaultCodexModel, models.CodeReviewAgentRoleReviewer)}
+			},
+			expectedAgent: models.AgentTypeClaudeCode, expectedModel: models.DefaultClaudeCodeModel, expectedEffort: models.ReasoningEffortMax, expectedReady: true,
+		},
+		{
+			name: "moves from failed primary to first fallback",
+			results: func() []models.CodeReviewAgentResult {
+				return []models.CodeReviewAgentResult{codeReviewFailedModelForTest(models.AgentTypeCodex, models.DefaultCodexModel, models.CodeReviewAgentRoleOrchestrator)}
+			},
+			expectedAgent: models.AgentTypeClaudeCode, expectedModel: models.DefaultClaudeCodeModel, expectedEffort: models.ReasoningEffortMax, expectedReady: true,
+		},
+		{
+			name: "another model on the same provider can be a second fallback",
+			results: func() []models.CodeReviewAgentResult {
+				return []models.CodeReviewAgentResult{
+					codeReviewFailedModelForTest(models.AgentTypeCodex, models.DefaultCodexModel, models.CodeReviewAgentRoleOrchestrator),
+					codeReviewFailedModelForTest(models.AgentTypeClaudeCode, models.DefaultClaudeCodeModel, models.CodeReviewAgentRoleOrchestrator),
+				}
+			},
+			expectedAgent: models.AgentTypeCodex, expectedModel: models.CodexModelGPT55, expectedEffort: models.ReasoningEffortMedium, expectedReady: true,
+		},
+		{
+			name: "all attempted models exhaust the chain",
+			results: func() []models.CodeReviewAgentResult {
+				return []models.CodeReviewAgentResult{
+					codeReviewFailedModelForTest(models.AgentTypeCodex, models.DefaultCodexModel, models.CodeReviewAgentRoleOrchestrator),
+					codeReviewFailedModelForTest(models.AgentTypeClaudeCode, models.DefaultClaudeCodeModel, models.CodeReviewAgentRoleOrchestrator),
+					codeReviewFailedModelForTest(models.AgentTypeCodex, models.CodexModelGPT55, models.CodeReviewAgentRoleOrchestrator),
+				}
+			},
+			expectedAgent: models.AgentTypeCodex, expectedModel: models.DefaultCodexModel, expectedEffort: models.ReasoningEffortHigh,
+		},
+		{
+			name: "unavailable credentials skip to next model",
+			results: func() []models.CodeReviewAgentResult {
+				return []models.CodeReviewAgentResult{codeReviewFailedModelForTest(models.AgentTypeCodex, models.DefaultCodexModel, models.CodeReviewAgentRoleOrchestrator)}
+			},
+			available:     map[models.AgentType]bool{models.AgentTypeCodex: true},
+			expectedAgent: models.AgentTypeCodex, expectedModel: models.CodexModelGPT55, expectedEffort: models.ReasoningEffortMedium, expectedReady: true,
+		},
+		{
+			name: "completed reviewer text cannot mark a model unavailable",
+			results: func() []models.CodeReviewAgentResult {
+				result := codeReviewFailedModelForTest(models.AgentTypeCodex, models.DefaultCodexModel, models.CodeReviewAgentRoleReviewer)
+				result.Status = models.CodeReviewAgentResultStatusCompleted
+				return []models.CodeReviewAgentResult{result}
+			},
+			expectedAgent: models.AgentTypeCodex, expectedModel: models.DefaultCodexModel, expectedEffort: models.ReasoningEffortHigh, expectedReady: true,
+		},
+		{
+			name: "legacy omitted model uses provider default",
+			results: func() []models.CodeReviewAgentResult {
+				result := codeReviewFailedModelForTest(models.AgentTypeCodex, models.DefaultCodexModel, models.CodeReviewAgentRoleReviewer)
+				result.AgentModel = nil
+				result.StructuredResult = nil
+				return []models.CodeReviewAgentResult{result}
+			},
+			expectedAgent: models.AgentTypeClaudeCode, expectedModel: models.DefaultClaudeCodeModel, expectedEffort: models.ReasoningEffortMax, expectedReady: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			cfg := models.DefaultCodeReviewPolicyConfig()
+			cfg.AgentRoster.Orchestrator = models.AgentTypeCodex
+			cfg.AgentRoster.OrchestratorModel = stringPtr(models.DefaultCodexModel)
+			cfg.AgentRoster.Reviewers = []models.AgentType{models.AgentTypeCodex, models.AgentTypeClaudeCode, models.AgentTypeCodex}
+			cfg.AgentRoster.ReviewerModels = []string{models.DefaultCodexModel, models.DefaultClaudeCodeModel, models.CodexModelGPT55}
+			cfg.AgentRoster.ReviewerReasoningEfforts = []models.ReasoningEffort{models.ReasoningEffortLow, models.ReasoningEffortMax, models.ReasoningEffortMedium}
+			var services *Services
+			if tt.available != nil {
+				services = &Services{CodingAgents: codeReviewAgentAvailabilityStub{available: tt.available}}
+			}
+			selection, err := resolveCodeReviewOrchestratorAvailability(context.Background(), services, uuid.New(), cfg, tt.results())
+			require.NoError(t, err, "saved runtime failures should allow fallback selection")
+			require.Equal(t, codeReviewOrchestratorSelection{
+				AgentType: tt.expectedAgent, AgentModel: stringPtr(tt.expectedModel), ReasoningEffort: reasoningEffortPtr(tt.expectedEffort), Available: tt.expectedReady,
+			}, selection, "fallback should use the next unattempted configured model and its own reasoning effort")
+			require.Equal(t, []codeReviewOrchestratorSelection{
+				{AgentType: models.AgentTypeCodex, AgentModel: stringPtr(models.DefaultCodexModel), ReasoningEffort: reasoningEffortPtr(models.ReasoningEffortHigh), Available: true},
+				{AgentType: models.AgentTypeClaudeCode, AgentModel: stringPtr(models.DefaultClaudeCodeModel), ReasoningEffort: reasoningEffortPtr(models.ReasoningEffortMax), Available: true},
+				{AgentType: models.AgentTypeCodex, AgentModel: stringPtr(models.CodexModelGPT55), ReasoningEffort: reasoningEffortPtr(models.ReasoningEffortMedium), Available: true},
+			}, codeReviewOrchestratorCandidates(cfg), "duplicate primary/reviewer models should be attempted only once")
+		})
+	}
+}
+
+func TestCodeReviewOrchestratorCompletionAcrossFallbacks(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		statuses      []models.CodeReviewAgentResultStatus
+		terminal      bool
+		fallback      bool
+		expectedPhase codeReviewAgentPhase
+	}{
+		{name: "not started"},
+		{name: "primary failed", statuses: []models.CodeReviewAgentResultStatus{models.CodeReviewAgentResultStatusFailed}, terminal: true, fallback: true},
+		{name: "fallback running", statuses: []models.CodeReviewAgentResultStatus{models.CodeReviewAgentResultStatusFailed, models.CodeReviewAgentResultStatusRunning}, expectedPhase: codeReviewAgentPhaseOrchestrator},
+		{name: "fallback queued", statuses: []models.CodeReviewAgentResultStatus{models.CodeReviewAgentResultStatusFailed, models.CodeReviewAgentResultStatusQueued}, expectedPhase: codeReviewAgentPhaseOrchestrator},
+		{name: "fallback completed", statuses: []models.CodeReviewAgentResultStatus{models.CodeReviewAgentResultStatusFailed, models.CodeReviewAgentResultStatusCompleted}, terminal: true},
+		{name: "two capacity failures", statuses: []models.CodeReviewAgentResultStatus{models.CodeReviewAgentResultStatusFailed, models.CodeReviewAgentResultStatusFailed}, terminal: true, fallback: true},
+		{name: "timeout stops retries", statuses: []models.CodeReviewAgentResultStatus{models.CodeReviewAgentResultStatusFailed, models.CodeReviewAgentResultStatusTimedOut}, terminal: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			var results []models.CodeReviewAgentResult
+			var threads []models.SessionThread
+			for _, status := range tt.statuses {
+				threadID := uuid.New()
+				result := codeReviewFailedModelForTest(models.AgentTypeCodex, models.DefaultCodexModel, models.CodeReviewAgentRoleOrchestrator)
+				result.Status = status
+				result.StructuredResult = marshalCodeReviewOrchestratorStructuredResult(codeReviewOrchestratorStructuredResult{ThreadID: threadID.String(), Error: codeReviewCapacityFailureForTest})
+				results = append(results, result)
+				threads = append(threads, models.SessionThread{ID: threadID, Status: models.ThreadStatusRunning})
+			}
+			require.Equal(t, tt.terminal, codeReviewOrchestratorTerminal(results), "historical failures must not complete an active fallback")
+			require.Equal(t, tt.fallback, codeReviewOrchestratorNeedsFallback(results), "only terminal availability failures should request another model")
+			require.Equal(t, tt.expectedPhase, codeReviewInFlightAgentPhaseFromState(models.DefaultCodeReviewPolicyConfig(), results, threads), "historical failures must not disable synthesis polling")
+		})
+	}
+}
+
+func TestHarvestCodeReviewOrchestratorCapacityFailure(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		output      *string
+		explanation string
+	}{
+		{name: "failure in transcript", output: stringPtr(codeReviewCapacityFailureForTest), explanation: codeReviewCapacityFailureForTest},
+		{name: "failure without assistant output", explanation: codeReviewCapacityFailureForTest},
+		{name: "generic explanation with provider error in output", output: stringPtr(codeReviewCapacityFailureForTest), explanation: "agent runtime failed"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			mock, err := pgxmock.NewPool()
+			require.NoError(t, err, "pgxmock should initialize")
+			defer mock.Close()
+			orgID, sessionID, threadID, resultID := uuid.New(), uuid.New(), uuid.New(), uuid.New()
+			now := time.Now().UTC()
+			state := marshalCodeReviewOrchestratorStructuredResult(codeReviewOrchestratorStructuredResult{ThreadID: threadID.String()})
+			mock.ExpectQuery("(?s)SELECT .*FROM code_review_agent_results").
+				WithArgs(pgx.NamedArgs{"org_id": orgID, "session_id": sessionID}).
+				WillReturnRows(newCodeReviewAgentResultRows().AddRow(resultID, orgID, sessionID, "codex", stringPtr(models.DefaultCodexModel), models.CodeReviewAgentRoleOrchestrator, models.CodeReviewAgentResultStatusRunning, nil, state, now))
+			row := workerSessionThreadRow(threadID, sessionID, orgID, models.AgentTypeCodex, stringPtr(models.DefaultCodexModel), models.ThreadStatusFailed)
+			setWorkerSessionThreadColumn(row, "failure_explanation", &tt.explanation)
+			setWorkerSessionThreadColumn(row, "completed_at", &now)
+			mock.ExpectQuery("(?s)SELECT .*FROM session_threads").WithArgs(pgx.NamedArgs{"id": threadID, "org_id": orgID}).
+				WillReturnRows(newSessionThreadRows().AddRow(row...))
+			messages := newSessionMessageRows()
+			if tt.output != nil {
+				messages.AddRow(int64(1), sessionID, orgID, &threadID, nil, 1, models.MessageRoleAssistant, *tt.output, nil, nil, nil, nil, "", now)
+			}
+			mock.ExpectQuery("(?s)SELECT .*FROM session_messages").WithArgs(pgx.NamedArgs{"org_id": orgID, "thread_id": threadID}).WillReturnRows(messages)
+			mock.ExpectQuery("UPDATE code_review_agent_results").
+				WithArgs(models.CodeReviewAgentResultStatusFailed, stringPtr(codeReviewCapacityFailureForTest), codeReviewCapacityStateArg{}, orgID, resultID).
+				WillReturnRows(newCodeReviewAgentResultRows().AddRow(resultID, orgID, sessionID, "codex", stringPtr(models.DefaultCodexModel), models.CodeReviewAgentRoleOrchestrator, models.CodeReviewAgentResultStatusFailed, stringPtr(codeReviewCapacityFailureForTest), state, now))
+			err = harvestCodeReviewOrchestratorResult(context.Background(), &Stores{
+				CodeReviews: db.NewCodeReviewStore(mock), SessionThreads: db.NewSessionThreadStore(mock), SessionMessages: db.NewSessionMessageStore(mock),
+			}, nil, zerolog.Nop(), runCodeReviewPayload{OrgID: orgID, SessionID: sessionID}, codeReviewPolicyRecordForTest(models.DefaultCodeReviewPolicyConfig()), nil, models.CodeReviewVisualEvidenceSnapshot{})
+			require.NoError(t, err, "capacity output should be saved as a runtime failure")
+			require.NoError(t, mock.ExpectationsWereMet(), "capacity failure should not send a repair turn or create findings")
+		})
+	}
+}
+
+type codeReviewCapacityStateArg struct{}
+
+func (codeReviewCapacityStateArg) Match(value any) bool {
+	raw, ok := value.(json.RawMessage)
+	if !ok {
+		return false
+	}
+	state, ok := parseCodeReviewOrchestratorStructuredResult(raw)
+	return ok && state.Error == codeReviewCapacityFailureForTest && state.CompletedAt != "" &&
+		!state.SynthesisValidated && state.SynthesisRepairCount == 0 && !state.SynthesisRepairPending
+}
+
+type codeReviewFallbackThreadStub struct {
+	existing  []models.SessionThread
+	created   *models.SessionThread
+	input     *threadsvc.CreateThreadInput
+	listErr   error
+	createErr error
+}
+
+func (s *codeReviewFallbackThreadStub) ListThreads(context.Context, uuid.UUID, uuid.UUID) ([]models.SessionThread, error) {
+	return s.existing, s.listErr
+}
+
+func (s *codeReviewFallbackThreadStub) CreateThread(_ context.Context, input threadsvc.CreateThreadInput) (*models.SessionThread, error) {
+	s.input = &input
+	return s.created, s.createErr
+}
+
+func TestEnsureCodeReviewFallbackOrchestratorThread(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		existing  bool
+		status    models.ThreadStatus
+		listErr   error
+		createErr error
+	}{
+		{name: "creates a separate synthesis thread"},
+		{name: "reuses idle fallback after a claim race", existing: true, status: models.ThreadStatusIdle},
+		{name: "recovers running fallback after result write failure", existing: true, status: models.ThreadStatusRunning},
+		{name: "recovers completed fallback without rerunning", existing: true, status: models.ThreadStatusCompleted},
+		{name: "recovers failed fallback without retrying model", existing: true, status: models.ThreadStatusFailed},
+		{name: "propagates list failure", listErr: errors.New("list failed")},
+		{name: "propagates create failure", createErr: errors.New("create failed")},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			job := runCodeReviewPayload{OrgID: uuid.New(), SessionID: uuid.New()}
+			selection := codeReviewOrchestratorSelection{AgentType: models.AgentTypeClaudeCode, AgentModel: stringPtr(models.DefaultClaudeCodeModel), ReasoningEffort: reasoningEffortPtr(models.ReasoningEffortMax), Available: true}
+			thread := models.SessionThread{ID: uuid.New(), OrgID: job.OrgID, SessionID: job.SessionID, AgentType: selection.AgentType, ModelOverride: selection.AgentModel,
+				Label: "Code review synthesis: claude_code (fallback 1)", CreatedBySource: models.ThreadCreatedBySourceSystem, Status: tt.status}
+			stub := &codeReviewFallbackThreadStub{created: &thread, listErr: tt.listErr, createErr: tt.createErr}
+			if tt.existing {
+				stub.existing = []models.SessionThread{thread}
+			}
+			actual, err := ensureCodeReviewFallbackOrchestratorThread(context.Background(), stub, job, selection, 1, []string{"handler.go"})
+			if tt.listErr != nil || tt.createErr != nil {
+				require.Error(t, err, "thread storage errors should propagate for worker retry")
+				return
+			}
+			require.NoError(t, err, "fallback thread should be available")
+			require.Equal(t, &thread, actual, "fallback should preserve the selected thread and its execution state")
+			if tt.existing {
+				require.Nil(t, stub.input, "retrying the controller must reuse its existing fallback thread")
+			} else {
+				require.Equal(t, &threadsvc.CreateThreadInput{
+					SessionID: job.SessionID, OrgID: job.OrgID, AgentType: string(selection.AgentType), Model: *selection.AgentModel,
+					ReasoningEffort: selection.ReasoningEffort, Label: thread.Label, FileScope: []string{"handler.go"},
+					ExecutionMode: models.ThreadExecutionModeReview, FilesystemMode: models.ThreadFilesystemModeReadOnly, CreatedBySource: models.ThreadCreatedBySourceSystem,
+				}, stub.input, "fallback should preserve model settings and use a fresh read-only synthesis thread")
+			}
+		})
+	}
+}
+
+func TestEnsureCodeReviewOrchestratorFallbackStops(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		status models.CodeReviewAgentResultStatus
+		error  string
+		age    time.Duration
+	}{
+		{name: "running attempt", status: models.CodeReviewAgentResultStatusRunning},
+		{name: "completed attempt", status: models.CodeReviewAgentResultStatusCompleted},
+		{name: "invalid synthesis", status: models.CodeReviewAgentResultStatusFailed, error: "invalid orchestrator synthesis"},
+		{name: "timed out attempt", status: models.CodeReviewAgentResultStatusTimedOut},
+		{name: "expired review budget", status: models.CodeReviewAgentResultStatusFailed, error: codeReviewCapacityFailureForTest, age: time.Hour},
+		{name: "all candidates exhausted", status: models.CodeReviewAgentResultStatusFailed, error: codeReviewCapacityFailureForTest},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			cfg := models.DefaultCodeReviewPolicyConfig()
+			var results []models.CodeReviewAgentResult
+			for _, candidate := range codeReviewOrchestratorCandidates(cfg) {
+				result := codeReviewFailedModelForTest(candidate.AgentType, *candidate.AgentModel, models.CodeReviewAgentRoleOrchestrator)
+				result.Status = tt.status
+				result.StructuredResult = marshalCodeReviewOrchestratorStructuredResult(codeReviewOrchestratorStructuredResult{Error: tt.error})
+				result.RawOutput = stringPtr(tt.error)
+				results = append(results, result)
+			}
+			err := ensureCodeReviewOrchestratorThread(context.Background(), nil, nil, zerolog.Nop(), runCodeReviewPayload{}, models.PullRequest{}, nil,
+				codeReviewPolicyRecordForTest(cfg), models.CodeReviewSessionMetadata{CreatedAt: time.Now().Add(-tt.age)}, nil, results, nil, models.CodeReviewVisualEvidenceSnapshot{})
+			require.NoError(t, err, "terminal, running, expired, or exhausted attempts must not dispatch more synthesis work")
+		})
+	}
+}
+
+type codeReviewFallbackArg func(any) bool
+
+func (match codeReviewFallbackArg) Match(value any) bool { return match(value) }
+
+func TestCodeReviewOrchestratorFallbackRecoversAndCompletes(t *testing.T) {
+	t.Parallel()
+
+	stores, mock := newTestStores(t)
+	defer mock.Close()
+	stores.CodeReviews = db.NewCodeReviewStore(mock)
+	stores.SessionThreads = db.NewSessionThreadStore(mock)
+	stores.SessionMessages = db.NewSessionMessageStore(mock)
+	orgID, sessionID, threadID, resultID := uuid.New(), uuid.New(), uuid.New(), uuid.New()
+	now := time.Now().UTC()
+	job := runCodeReviewPayload{OrgID: orgID, SessionID: sessionID, HeadSHA: "reviewed-head"}
+	// Reviewer time must not consume the separate synthesis dispatch budget.
+	metadata := models.CodeReviewSessionMetadata{CreatedAt: now.Add(-time.Hour), PromptRecordKey: stringPtr("captured-prompts")}
+	cfg := models.DefaultCodeReviewPolicyConfig()
+	cfg.AgentRoster.Orchestrator = models.AgentTypeCodex
+	cfg.AgentRoster.OrchestratorModel = stringPtr(models.DefaultCodexModel)
+	policy := codeReviewPolicyRecordForTest(cfg)
+	failed := codeReviewFailedModelForTest(models.AgentTypeCodex, models.DefaultCodexModel, models.CodeReviewAgentRoleOrchestrator)
+	failed.ID = uuid.New()
+	reviewer := models.CodeReviewAgentResult{
+		ID: uuid.New(), AgentProvider: "claude_code", AgentModel: stringPtr(models.DefaultClaudeCodeModel),
+		Role: models.CodeReviewAgentRoleReviewer, Status: models.CodeReviewAgentResultStatusCompleted,
+		RawOutput: stringPtr("Completed reviewer evidence must survive fallback."),
+		StructuredResult: marshalCodeReviewReviewerStructuredResult(codeReviewReviewerStructuredResult{
+			ReviewerKey: codeReviewReviewerKey(1, models.AgentTypeClaudeCode), CompletedAt: now.Format(time.RFC3339),
+		}),
+	}
+	results := []models.CodeReviewAgentResult{failed, reviewer}
+	recordKey := "captured-prompts/orchestrator-fallback-01-claude_code"
+	var capturedPrompt string
+	mock.ExpectQuery("INSERT INTO code_review_prompt_records").
+		WithArgs(orgID, sessionID, recordKey, "orchestrator", "claude_code", codeReviewFallbackArg(func(value any) bool {
+			capturedPrompt, _ = value.(string)
+			return capturedPrompt != ""
+		}), pgxmock.AnyArg()).
+		WillReturnRows(pgxmock.NewRows([]string{"id", "org_id", "session_id", "record_key", "role", "agent_provider", "content", "metadata", "created_at"}).
+			AddRow(uuid.New(), orgID, sessionID, recordKey, "orchestrator", "claude_code", "captured", json.RawMessage(`{}`), now))
+	sessionRow := workerSessionRow(sessionID, uuid.Nil, orgID, models.SessionStatusRunning, 0, nil, nil)
+	setWorkerSessionColumn(sessionRow, "origin", models.SessionOriginCodeReview)
+	for range 2 {
+		mock.ExpectQuery("(?s)SELECT .*FROM sessions").WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+			WillReturnRows(pgxmock.NewRows(workerSessionColumns).AddRow(sessionRow...))
+	}
+	threadRow := workerSessionThreadRow(threadID, sessionID, orgID, models.AgentTypeClaudeCode, stringPtr(models.DefaultClaudeCodeModel), models.ThreadStatusRunning)
+	setWorkerSessionThreadColumn(threadRow, "label", "Code review synthesis: claude_code (fallback 1)")
+	setWorkerSessionThreadColumn(threadRow, "created_by_source", models.ThreadCreatedBySourceSystem)
+	setWorkerSessionThreadColumn(threadRow, "execution_mode", models.ThreadExecutionModeReview)
+	setWorkerSessionThreadColumn(threadRow, "filesystem_mode", models.ThreadFilesystemModeReadOnly)
+	mock.ExpectQuery("(?s)SELECT .*FROM session_threads").WithArgs(pgx.NamedArgs{"org_id": orgID, "session_id": sessionID}).
+		WillReturnRows(newSessionThreadRows().AddRow(threadRow...))
+	var runningState json.RawMessage
+	mock.ExpectQuery("INSERT INTO code_review_agent_results").
+		WithArgs(orgID, sessionID, "claude_code", stringPtr(models.DefaultClaudeCodeModel), models.CodeReviewAgentRoleOrchestrator,
+			models.CodeReviewAgentResultStatusRunning, (*string)(nil), codeReviewFallbackArg(func(value any) bool {
+				runningState, _ = value.(json.RawMessage)
+				state, ok := parseCodeReviewOrchestratorStructuredResult(runningState)
+				return ok && state.ThreadID == threadID.String() && state.PromptRecordKey == recordKey && state.ReadOnly
+			})).
+		WillReturnRows(newCodeReviewAgentResultRows().AddRow(resultID, orgID, sessionID, "claude_code", stringPtr(models.DefaultClaudeCodeModel),
+			models.CodeReviewAgentRoleOrchestrator, models.CodeReviewAgentResultStatusRunning, nil, json.RawMessage(`{}`), now))
+
+	err := ensureCodeReviewOrchestratorThread(context.Background(), stores, nil, zerolog.Nop(), job, models.PullRequest{}, nil, policy, metadata, nil, results, nil, models.CodeReviewVisualEvidenceSnapshot{})
+	require.NoError(t, err, "a dispatched fallback should recover its result without sending another turn")
+	require.Contains(t, capturedPrompt, *reviewer.RawOutput, "fallback synthesis should reuse the completed review")
+	require.Contains(t, capturedPrompt, job.HeadSHA, "fallback synthesis should stay scoped to the captured PR head")
+	require.NotContains(t, capturedPrompt, "/review ", "fallback should synthesize existing reviews rather than dispatch another native review")
+	require.NoError(t, mock.ExpectationsWereMet(), "recovery should create only its missing result, without changing Main or redispatching reviewers")
+
+	running := models.CodeReviewAgentResult{ID: resultID, OrgID: orgID, SessionID: sessionID, AgentProvider: "claude_code", AgentModel: stringPtr(models.DefaultClaudeCodeModel),
+		Role: models.CodeReviewAgentRoleOrchestrator, Status: models.CodeReviewAgentResultStatusRunning, StructuredResult: runningState, CreatedAt: now}
+	results = append(results, running)
+	require.False(t, codeReviewOrchestratorTerminal(results), "the failed primary must not finish the review while fallback is running")
+
+	raw := `{"approval_recommended":true,"description_assessments":[{"key":"description","status":"satisfied","evidence_basis":"pull_request_description","evidence_ids":[],"reason":"Clear intent."}],"findings":[],"human_review_reasons":[],"scope_mismatch":false,"unresolved_uncertainty":false,"reviewer_disagreement":false,"prompt_injection_detected":false,"summary":"The change is focused.","review_summary":"The completed review supports the change.","risk_notes":[]}`
+	raw = "```json\n" + raw + "\n```"
+	resultRows := newCodeReviewAgentResultRows()
+	for _, result := range results {
+		resultRows.AddRow(result.ID, orgID, sessionID, result.AgentProvider, result.AgentModel, result.Role, result.Status, result.RawOutput, result.StructuredResult, now)
+	}
+	mock.ExpectQuery("(?s)SELECT .*FROM code_review_agent_results").WithArgs(pgx.NamedArgs{"org_id": orgID, "session_id": sessionID}).WillReturnRows(resultRows)
+	setWorkerSessionThreadColumn(threadRow, "status", models.ThreadStatusCompleted)
+	setWorkerSessionThreadColumn(threadRow, "completed_at", &now)
+	mock.ExpectQuery("(?s)SELECT .*FROM session_threads").WithArgs(pgx.NamedArgs{"id": threadID, "org_id": orgID}).WillReturnRows(newSessionThreadRows().AddRow(threadRow...))
+	mock.ExpectQuery("(?s)SELECT .*FROM session_messages").WithArgs(pgx.NamedArgs{"org_id": orgID, "thread_id": threadID}).
+		WillReturnRows(newSessionMessageRows().AddRow(int64(1), sessionID, orgID, &threadID, nil, 1, models.MessageRoleAssistant, raw, nil, nil, nil, nil, "", now))
+	var completedState json.RawMessage
+	mock.ExpectQuery("UPDATE code_review_agent_results").WithArgs(models.CodeReviewAgentResultStatusCompleted, &raw, codeReviewFallbackArg(func(value any) bool {
+		completedState, _ = value.(json.RawMessage)
+		state, ok := parseCodeReviewOrchestratorStructuredResult(completedState)
+		return ok && state.SynthesisValidated && state.Error == ""
+	}), orgID, resultID).
+		WillReturnRows(newCodeReviewAgentResultRows().AddRow(resultID, orgID, sessionID, "claude_code", stringPtr(models.DefaultClaudeCodeModel),
+			models.CodeReviewAgentRoleOrchestrator, models.CodeReviewAgentResultStatusCompleted, &raw, runningState, now))
+	err = harvestCodeReviewOrchestratorResult(context.Background(), stores, nil, zerolog.Nop(), job, policy, nil, models.CodeReviewVisualEvidenceSnapshot{})
+	require.NoError(t, err, "the successful fallback should be harvested despite the failed primary")
+	require.NoError(t, mock.ExpectationsWereMet(), "harvest should update only the fallback result")
+	completed := running
+	completed.Status = models.CodeReviewAgentResultStatusCompleted
+	completed.StructuredResult = completedState
+	finalResults := []models.CodeReviewAgentResult{failed, reviewer, completed}
+	present, usable := codeReviewOrchestratorEvidence(finalResults)
+	require.Equal(t, []bool{true, true, true, false}, []bool{present, usable, codeReviewOrchestratorTerminal(finalResults), codeReviewOrchestratorNeedsFallback(finalResults)}, "validated fallback should complete synthesis without starting another attempt")
+	quorum, failures := codeReviewReviewerEvidence(finalResults)
+	require.Equal(t, []int{1, 0}, []int{quorum, failures}, "fallback attempts must not count toward reviewer quorum or discard completed reviewers")
+	require.Equal(t, "The change is focused.", strings.TrimSpace(codeReviewOrchestratorSynthesisFromResults(finalResults).Summary), "final decision should use the successful fallback's synthesis")
+}

--- a/internal/worker/code_review_orchestrator_fallback_test.go
+++ b/internal/worker/code_review_orchestrator_fallback_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -261,11 +262,14 @@ func (codeReviewCapacityStateArg) Match(value any) bool {
 }
 
 type codeReviewFallbackThreadStub struct {
-	existing  []models.SessionThread
-	created   *models.SessionThread
-	input     *threadsvc.CreateThreadInput
-	listErr   error
-	createErr error
+	existing   []models.SessionThread
+	created    *models.SessionThread
+	archived   *models.SessionThread
+	input      *threadsvc.CreateThreadInput
+	archiveID  uuid.UUID
+	listErr    error
+	archiveErr error
+	createErr  error
 }
 
 func (s *codeReviewFallbackThreadStub) ListThreads(context.Context, uuid.UUID, uuid.UUID) ([]models.SessionThread, error) {
@@ -274,56 +278,354 @@ func (s *codeReviewFallbackThreadStub) ListThreads(context.Context, uuid.UUID, u
 
 func (s *codeReviewFallbackThreadStub) CreateThread(_ context.Context, input threadsvc.CreateThreadInput) (*models.SessionThread, error) {
 	s.input = &input
-	return s.created, s.createErr
+	if s.createErr != nil {
+		return nil, s.createErr
+	}
+	if codeReviewVisibleThreadCount(s.existing) >= models.MaxThreadsPerSession {
+		return nil, db.ErrThreadLimitReached
+	}
+	if s.created != nil {
+		created := *s.created
+		s.existing = append(s.existing, created)
+		return &created, nil
+	}
+	created := models.SessionThread{
+		ID:              uuid.New(),
+		SessionID:       input.SessionID,
+		OrgID:           input.OrgID,
+		AgentType:       models.AgentType(input.AgentType),
+		ModelOverride:   stringPtr(input.Model),
+		ReasoningEffort: input.ReasoningEffort,
+		Label:           input.Label,
+		FileScope:       append([]string(nil), input.FileScope...),
+		Status:          models.ThreadStatusIdle,
+		CreatedBySource: input.CreatedBySource,
+		ExecutionMode:   input.ExecutionMode,
+		FilesystemMode:  input.FilesystemMode,
+	}
+	s.existing = append(s.existing, created)
+	return &created, nil
+}
+
+func (s *codeReviewFallbackThreadStub) ArchiveThread(_ context.Context, _, _, threadID uuid.UUID) (models.SessionThread, error) {
+	s.archiveID = threadID
+	if s.archiveErr != nil {
+		return models.SessionThread{}, s.archiveErr
+	}
+	for i := range s.existing {
+		if s.existing[i].ID != threadID {
+			continue
+		}
+		now := time.Now().UTC()
+		s.existing[i].ArchivedAt = &now
+		if s.archived != nil {
+			archived := *s.archived
+			archived.ID = threadID
+			return archived, nil
+		}
+		return s.existing[i], nil
+	}
+	return models.SessionThread{}, threadsvc.ErrThreadNotFound
+}
+
+func codeReviewTerminalReviewerResultForThread(threadID uuid.UUID, agentType models.AgentType, model string) models.CodeReviewAgentResult {
+	return models.CodeReviewAgentResult{
+		AgentProvider: string(agentType),
+		AgentModel:    stringPtr(model),
+		Role:          models.CodeReviewAgentRoleReviewer,
+		Status:        models.CodeReviewAgentResultStatusCompleted,
+		StructuredResult: marshalCodeReviewReviewerStructuredResult(codeReviewReviewerStructuredResult{
+			ThreadID:    threadID.String(),
+			CompletedAt: time.Now().UTC().Format(time.RFC3339),
+		}),
+	}
+}
+
+func codeReviewOrchestratorResultForThread(threadID uuid.UUID, agentType models.AgentType, model string, status models.CodeReviewAgentResultStatus) models.CodeReviewAgentResult {
+	result := codeReviewFailedModelForTest(agentType, model, models.CodeReviewAgentRoleOrchestrator)
+	result.Status = status
+	result.StructuredResult = marshalCodeReviewOrchestratorStructuredResult(codeReviewOrchestratorStructuredResult{
+		ThreadID:    threadID.String(),
+		Error:       stringPtrValue(result.RawOutput),
+		CompletedAt: time.Now().UTC().Format(time.RFC3339),
+	})
+	if status != models.CodeReviewAgentResultStatusFailed {
+		result.RawOutput = nil
+	}
+	return result
 }
 
 func TestEnsureCodeReviewFallbackOrchestratorThread(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name      string
-		existing  bool
-		status    models.ThreadStatus
-		listErr   error
-		createErr error
+		name            string
+		attempt         int
+		existingThreads func(job runCodeReviewPayload, selection codeReviewOrchestratorSelection) []models.SessionThread
+		results         func(threads []models.SessionThread) []models.CodeReviewAgentResult
+		primaryThreadID func(threads []models.SessionThread) uuid.UUID
+		listErr         error
+		archiveErr      error
+		createErr       error
+		expectArchiveID func(threads []models.SessionThread) uuid.UUID
+		expectErrIs     error
+		expectCreate    bool
+		expectReuse     bool
 	}{
-		{name: "creates a separate synthesis thread"},
-		{name: "reuses idle fallback after a claim race", existing: true, status: models.ThreadStatusIdle},
-		{name: "recovers running fallback after result write failure", existing: true, status: models.ThreadStatusRunning},
-		{name: "recovers completed fallback without rerunning", existing: true, status: models.ThreadStatusCompleted},
-		{name: "recovers failed fallback without retrying model", existing: true, status: models.ThreadStatusFailed},
-		{name: "propagates list failure", listErr: errors.New("list failed")},
-		{name: "propagates create failure", createErr: errors.New("create failed")},
+		{
+			name:         "creates a separate synthesis thread below the visible-thread limit",
+			expectCreate: true,
+		},
+		{
+			name: "reuses deterministic fallback before reclaiming any slot",
+			existingThreads: func(job runCodeReviewPayload, selection codeReviewOrchestratorSelection) []models.SessionThread {
+				return []models.SessionThread{{
+					ID:              uuid.New(),
+					OrgID:           job.OrgID,
+					SessionID:       job.SessionID,
+					AgentType:       selection.AgentType,
+					ModelOverride:   selection.AgentModel,
+					Label:           "Code review synthesis: claude_code (fallback 1)",
+					CreatedBySource: models.ThreadCreatedBySourceSystem,
+					Status:          models.ThreadStatusCompleted,
+				}}
+			},
+			expectReuse: true,
+		},
+		{
+			name: "archives one persisted terminal reviewer to make room for the first fallback",
+			existingThreads: func(job runCodeReviewPayload, selection codeReviewOrchestratorSelection) []models.SessionThread {
+				return []models.SessionThread{
+					{ID: uuid.New(), OrgID: job.OrgID, SessionID: job.SessionID, AgentType: models.AgentTypeCodex, Label: "Main", CreatedBySource: models.ThreadCreatedBySourceSystem, Status: models.ThreadStatusIdle},
+					{ID: uuid.New(), OrgID: job.OrgID, SessionID: job.SessionID, AgentType: models.AgentTypeCodex, Label: "Reviewer 1", CreatedBySource: models.ThreadCreatedBySourceSystem, Status: models.ThreadStatusCompleted},
+					{ID: uuid.New(), OrgID: job.OrgID, SessionID: job.SessionID, AgentType: models.AgentTypeClaudeCode, Label: "Reviewer 2", CreatedBySource: models.ThreadCreatedBySourceSystem, Status: models.ThreadStatusCompleted},
+					{ID: uuid.New(), OrgID: job.OrgID, SessionID: job.SessionID, AgentType: models.AgentTypeOpenCode, Label: "Reviewer 3", CreatedBySource: models.ThreadCreatedBySourceSystem, Status: models.ThreadStatusCompleted},
+				}
+			},
+			results: func(threads []models.SessionThread) []models.CodeReviewAgentResult {
+				return []models.CodeReviewAgentResult{
+					codeReviewTerminalReviewerResultForThread(threads[1].ID, models.AgentTypeCodex, models.DefaultCodexModel),
+					codeReviewTerminalReviewerResultForThread(threads[2].ID, models.AgentTypeClaudeCode, models.DefaultClaudeCodeModel),
+					codeReviewTerminalReviewerResultForThread(threads[3].ID, models.AgentTypeOpenCode, models.OpenCodeModelGPT55),
+				}
+			},
+			primaryThreadID: func(threads []models.SessionThread) uuid.UUID { return threads[0].ID },
+			expectArchiveID: func(threads []models.SessionThread) uuid.UUID { return threads[1].ID },
+			expectCreate:    true,
+		},
+		{
+			name:    "archives a failed prior fallback before touching reviewer evidence on the second fallback",
+			attempt: 2,
+			existingThreads: func(job runCodeReviewPayload, selection codeReviewOrchestratorSelection) []models.SessionThread {
+				return []models.SessionThread{
+					{ID: uuid.New(), OrgID: job.OrgID, SessionID: job.SessionID, AgentType: models.AgentTypeCodex, Label: "Main", CreatedBySource: models.ThreadCreatedBySourceSystem, Status: models.ThreadStatusIdle},
+					{ID: uuid.New(), OrgID: job.OrgID, SessionID: job.SessionID, AgentType: models.AgentTypeCodex, Label: "Reviewer 1", CreatedBySource: models.ThreadCreatedBySourceSystem, Status: models.ThreadStatusCompleted},
+					{ID: uuid.New(), OrgID: job.OrgID, SessionID: job.SessionID, AgentType: models.AgentTypeClaudeCode, Label: "Reviewer 2", CreatedBySource: models.ThreadCreatedBySourceSystem, Status: models.ThreadStatusCompleted},
+					{ID: uuid.New(), OrgID: job.OrgID, SessionID: job.SessionID, AgentType: models.AgentTypeClaudeCode, ModelOverride: selection.AgentModel, Label: "Code review synthesis: claude_code (fallback 1)", CreatedBySource: models.ThreadCreatedBySourceSystem, Status: models.ThreadStatusFailed},
+				}
+			},
+			results: func(threads []models.SessionThread) []models.CodeReviewAgentResult {
+				return []models.CodeReviewAgentResult{
+					codeReviewTerminalReviewerResultForThread(threads[1].ID, models.AgentTypeCodex, models.DefaultCodexModel),
+					codeReviewTerminalReviewerResultForThread(threads[2].ID, models.AgentTypeClaudeCode, models.DefaultClaudeCodeModel),
+					codeReviewOrchestratorResultForThread(threads[3].ID, models.AgentTypeClaudeCode, models.DefaultClaudeCodeModel, models.CodeReviewAgentResultStatusFailed),
+				}
+			},
+			primaryThreadID: func(threads []models.SessionThread) uuid.UUID { return threads[0].ID },
+			expectArchiveID: func(threads []models.SessionThread) uuid.UUID { return threads[3].ID },
+			expectCreate:    true,
+		},
+		{
+			name: "leaves Main, active, user-created, and unpersisted threads untouched when no safe archival slot exists",
+			existingThreads: func(job runCodeReviewPayload, selection codeReviewOrchestratorSelection) []models.SessionThread {
+				return []models.SessionThread{
+					{ID: uuid.New(), OrgID: job.OrgID, SessionID: job.SessionID, AgentType: models.AgentTypeCodex, Label: "Main", CreatedBySource: models.ThreadCreatedBySourceSystem, Status: models.ThreadStatusCompleted},
+					{ID: uuid.New(), OrgID: job.OrgID, SessionID: job.SessionID, AgentType: models.AgentTypeCodex, Label: "Reviewer 1", CreatedBySource: models.ThreadCreatedBySourceUser, Status: models.ThreadStatusCompleted},
+					{ID: uuid.New(), OrgID: job.OrgID, SessionID: job.SessionID, AgentType: models.AgentTypeClaudeCode, Label: "Reviewer 2", CreatedBySource: models.ThreadCreatedBySourceSystem, Status: models.ThreadStatusCompleted},
+					{ID: uuid.New(), OrgID: job.OrgID, SessionID: job.SessionID, AgentType: models.AgentTypeOpenCode, Label: "Reviewer 3", CreatedBySource: models.ThreadCreatedBySourceSystem, Status: models.ThreadStatusRunning},
+				}
+			},
+			results: func(threads []models.SessionThread) []models.CodeReviewAgentResult {
+				duplicateRunning := codeReviewTerminalReviewerResultForThread(threads[2].ID, models.AgentTypeClaudeCode, models.DefaultClaudeCodeModel)
+				duplicateRunning.Status = models.CodeReviewAgentResultStatusRunning
+				duplicateRunning.StructuredResult = marshalCodeReviewReviewerStructuredResult(codeReviewReviewerStructuredResult{
+					ThreadID: threads[2].ID.String(),
+				})
+				return []models.CodeReviewAgentResult{
+					codeReviewTerminalReviewerResultForThread(threads[0].ID, models.AgentTypeCodex, models.DefaultCodexModel),
+					codeReviewTerminalReviewerResultForThread(threads[1].ID, models.AgentTypeCodex, models.DefaultCodexModel),
+					codeReviewTerminalReviewerResultForThread(threads[2].ID, models.AgentTypeClaudeCode, models.DefaultClaudeCodeModel),
+					duplicateRunning,
+					codeReviewTerminalReviewerResultForThread(threads[3].ID, models.AgentTypeOpenCode, models.OpenCodeModelGPT55),
+				}
+			},
+			primaryThreadID: func(threads []models.SessionThread) uuid.UUID { return threads[0].ID },
+			expectErrIs:     errCodeReviewFallbackCapacityExhausted,
+		},
+		{
+			name: "protects terminal threads with pending queued follow-up work",
+			existingThreads: func(job runCodeReviewPayload, selection codeReviewOrchestratorSelection) []models.SessionThread {
+				return []models.SessionThread{
+					{ID: uuid.New(), OrgID: job.OrgID, SessionID: job.SessionID, AgentType: models.AgentTypeCodex, Label: "Main", CreatedBySource: models.ThreadCreatedBySourceSystem, Status: models.ThreadStatusIdle},
+					{ID: uuid.New(), OrgID: job.OrgID, SessionID: job.SessionID, AgentType: models.AgentTypeCodex, Label: "Reviewer 1", CreatedBySource: models.ThreadCreatedBySourceSystem, Status: models.ThreadStatusCompleted, PendingMessageCount: 1},
+					{ID: uuid.New(), OrgID: job.OrgID, SessionID: job.SessionID, AgentType: models.AgentTypeClaudeCode, Label: "Reviewer 2", CreatedBySource: models.ThreadCreatedBySourceSystem, Status: models.ThreadStatusCompleted},
+					{ID: uuid.New(), OrgID: job.OrgID, SessionID: job.SessionID, AgentType: models.AgentTypeOpenCode, Label: "Reviewer 3", CreatedBySource: models.ThreadCreatedBySourceSystem, Status: models.ThreadStatusCompleted},
+				}
+			},
+			results: func(threads []models.SessionThread) []models.CodeReviewAgentResult {
+				return []models.CodeReviewAgentResult{
+					codeReviewTerminalReviewerResultForThread(threads[1].ID, models.AgentTypeCodex, models.DefaultCodexModel),
+					codeReviewTerminalReviewerResultForThread(threads[2].ID, models.AgentTypeClaudeCode, models.DefaultClaudeCodeModel),
+					codeReviewTerminalReviewerResultForThread(threads[3].ID, models.AgentTypeOpenCode, models.OpenCodeModelGPT55),
+				}
+			},
+			primaryThreadID: func(threads []models.SessionThread) uuid.UUID { return threads[0].ID },
+			expectArchiveID: func(threads []models.SessionThread) uuid.UUID { return threads[2].ID },
+			expectCreate:    true,
+		},
+		{
+			name: "gracefully treats an archive race as exhausted fallback capacity",
+			existingThreads: func(job runCodeReviewPayload, selection codeReviewOrchestratorSelection) []models.SessionThread {
+				return []models.SessionThread{
+					{ID: uuid.New(), OrgID: job.OrgID, SessionID: job.SessionID, AgentType: models.AgentTypeCodex, Label: "Main", CreatedBySource: models.ThreadCreatedBySourceSystem, Status: models.ThreadStatusIdle},
+					{ID: uuid.New(), OrgID: job.OrgID, SessionID: job.SessionID, AgentType: models.AgentTypeCodex, Label: "Reviewer 1", CreatedBySource: models.ThreadCreatedBySourceSystem, Status: models.ThreadStatusCompleted},
+					{ID: uuid.New(), OrgID: job.OrgID, SessionID: job.SessionID, AgentType: models.AgentTypeClaudeCode, Label: "Reviewer 2", CreatedBySource: models.ThreadCreatedBySourceSystem, Status: models.ThreadStatusCompleted},
+					{ID: uuid.New(), OrgID: job.OrgID, SessionID: job.SessionID, AgentType: models.AgentTypeOpenCode, Label: "Reviewer 3", CreatedBySource: models.ThreadCreatedBySourceSystem, Status: models.ThreadStatusCompleted},
+				}
+			},
+			results: func(threads []models.SessionThread) []models.CodeReviewAgentResult {
+				return []models.CodeReviewAgentResult{codeReviewTerminalReviewerResultForThread(threads[1].ID, models.AgentTypeCodex, models.DefaultCodexModel)}
+			},
+			primaryThreadID: func(threads []models.SessionThread) uuid.UUID { return threads[0].ID },
+			archiveErr:      threadsvc.ErrThreadActive,
+			expectArchiveID: func(threads []models.SessionThread) uuid.UUID { return threads[1].ID },
+			expectErrIs:     errCodeReviewFallbackCapacityExhausted,
+		},
+		{
+			name:         "gracefully treats a create limit race as exhausted fallback capacity",
+			createErr:    db.ErrThreadLimitReached,
+			expectErrIs:  errCodeReviewFallbackCapacityExhausted,
+			expectCreate: true,
+		},
+		{name: "propagates list failure", listErr: errors.New("list failed"), expectErrIs: errors.New("list failed")},
+		{name: "propagates create failure", createErr: errors.New("create failed"), expectErrIs: errors.New("create failed"), expectCreate: true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			job := runCodeReviewPayload{OrgID: uuid.New(), SessionID: uuid.New()}
 			selection := codeReviewOrchestratorSelection{AgentType: models.AgentTypeClaudeCode, AgentModel: stringPtr(models.DefaultClaudeCodeModel), ReasoningEffort: reasoningEffortPtr(models.ReasoningEffortMax), Available: true}
-			thread := models.SessionThread{ID: uuid.New(), OrgID: job.OrgID, SessionID: job.SessionID, AgentType: selection.AgentType, ModelOverride: selection.AgentModel,
-				Label: "Code review synthesis: claude_code (fallback 1)", CreatedBySource: models.ThreadCreatedBySourceSystem, Status: tt.status}
-			stub := &codeReviewFallbackThreadStub{created: &thread, listErr: tt.listErr, createErr: tt.createErr}
-			if tt.existing {
-				stub.existing = []models.SessionThread{thread}
+			thread := models.SessionThread{
+				ID:              uuid.New(),
+				OrgID:           job.OrgID,
+				SessionID:       job.SessionID,
+				AgentType:       selection.AgentType,
+				ModelOverride:   selection.AgentModel,
+				Label:           "Code review synthesis: claude_code (fallback 1)",
+				CreatedBySource: models.ThreadCreatedBySourceSystem,
+				Status:          models.ThreadStatusIdle,
 			}
-			actual, err := ensureCodeReviewFallbackOrchestratorThread(context.Background(), stub, job, selection, 1, []string{"handler.go"})
-			if tt.listErr != nil || tt.createErr != nil {
-				require.Error(t, err, "thread storage errors should propagate for worker retry")
+			attempt := tt.attempt
+			if attempt == 0 {
+				attempt = 1
+			}
+			thread.Label = fmt.Sprintf("Code review synthesis: claude_code (fallback %d)", attempt)
+			stub := &codeReviewFallbackThreadStub{created: &thread, archived: &models.SessionThread{}, listErr: tt.listErr, archiveErr: tt.archiveErr, createErr: tt.createErr}
+			if tt.existingThreads != nil {
+				stub.existing = tt.existingThreads(job, selection)
+			}
+			var results []models.CodeReviewAgentResult
+			if tt.results != nil {
+				results = tt.results(stub.existing)
+			}
+			primaryThreadID := uuid.Nil
+			if tt.primaryThreadID != nil {
+				primaryThreadID = tt.primaryThreadID(stub.existing)
+			}
+			actual, err := ensureCodeReviewFallbackOrchestratorThread(context.Background(), stub, job, selection, attempt, []string{"handler.go"}, primaryThreadID, results)
+			if tt.expectErrIs != nil {
+				if tt.expectErrIs == errCodeReviewFallbackCapacityExhausted {
+					require.ErrorIs(t, err, errCodeReviewFallbackCapacityExhausted, "fallback slot exhaustion should stop retries without bubbling a worker infrastructure error")
+				} else {
+					require.ErrorContains(t, err, tt.expectErrIs.Error(), "unexpected storage failures should still propagate")
+				}
+				require.Nil(t, actual, "failed fallback allocation should not return a thread")
+				if tt.expectCreate {
+					require.NotNil(t, stub.input, "creation races should still capture the attempted thread input")
+				} else {
+					require.Nil(t, stub.input, "failed fallback allocation should not create a new thread input")
+				}
+				if tt.expectArchiveID == nil {
+					require.Equal(t, uuid.Nil, stub.archiveID, "protected threads should not be archived")
+				}
 				return
 			}
 			require.NoError(t, err, "fallback thread should be available")
-			require.Equal(t, &thread, actual, "fallback should preserve the selected thread and its execution state")
-			if tt.existing {
+			if tt.expectReuse {
+				require.Equal(t, &stub.existing[0], actual, "fallback should reuse the deterministic thread that already exists for this provider and attempt")
 				require.Nil(t, stub.input, "retrying the controller must reuse its existing fallback thread")
 			} else {
+				require.Equal(t, &thread, actual, "fallback should preserve the newly created thread and its execution state")
+				if tt.expectCreate {
+					require.NotNil(t, stub.input, "fallback creation should use the selected model on a new thread")
+				}
 				require.Equal(t, &threadsvc.CreateThreadInput{
 					SessionID: job.SessionID, OrgID: job.OrgID, AgentType: string(selection.AgentType), Model: *selection.AgentModel,
 					ReasoningEffort: selection.ReasoningEffort, Label: thread.Label, FileScope: []string{"handler.go"},
 					ExecutionMode: models.ThreadExecutionModeReview, FilesystemMode: models.ThreadFilesystemModeReadOnly, CreatedBySource: models.ThreadCreatedBySourceSystem,
 				}, stub.input, "fallback should preserve model settings and use a fresh read-only synthesis thread")
 			}
+			if tt.expectArchiveID != nil {
+				require.Equal(t, tt.expectArchiveID(stub.existing), stub.archiveID, "fallback should reclaim exactly one eligible persisted terminal thread when the visible-thread cap is full")
+			} else {
+				require.Equal(t, uuid.Nil, stub.archiveID, "fallback creation should not archive any thread unless the visible-thread cap requires it")
+			}
 		})
 	}
+}
+
+func TestEnsureCodeReviewFallbackOrchestratorThreadSequentialAttemptsStayWithinVisibleLimit(t *testing.T) {
+	t.Parallel()
+
+	job := runCodeReviewPayload{OrgID: uuid.New(), SessionID: uuid.New()}
+	primaryThreadID := uuid.New()
+	firstSelection := codeReviewOrchestratorSelection{AgentType: models.AgentTypeClaudeCode, AgentModel: stringPtr(models.DefaultClaudeCodeModel), ReasoningEffort: reasoningEffortPtr(models.ReasoningEffortMax), Available: true}
+	secondSelection := codeReviewOrchestratorSelection{AgentType: models.AgentTypeCodex, AgentModel: stringPtr(models.CodexModelGPT55), ReasoningEffort: reasoningEffortPtr(models.ReasoningEffortMedium), Available: true}
+	stub := &codeReviewFallbackThreadStub{
+		existing: []models.SessionThread{
+			{ID: primaryThreadID, OrgID: job.OrgID, SessionID: job.SessionID, AgentType: models.AgentTypeCodex, Label: "Main", CreatedBySource: models.ThreadCreatedBySourceSystem, Status: models.ThreadStatusIdle},
+			{ID: uuid.New(), OrgID: job.OrgID, SessionID: job.SessionID, AgentType: models.AgentTypeCodex, Label: "Reviewer 1", CreatedBySource: models.ThreadCreatedBySourceSystem, Status: models.ThreadStatusCompleted},
+			{ID: uuid.New(), OrgID: job.OrgID, SessionID: job.SessionID, AgentType: models.AgentTypeClaudeCode, Label: "Reviewer 2", CreatedBySource: models.ThreadCreatedBySourceSystem, Status: models.ThreadStatusCompleted},
+			{ID: uuid.New(), OrgID: job.OrgID, SessionID: job.SessionID, AgentType: models.AgentTypeOpenCode, Label: "Reviewer 3", CreatedBySource: models.ThreadCreatedBySourceSystem, Status: models.ThreadStatusCompleted},
+		},
+	}
+	firstResults := []models.CodeReviewAgentResult{
+		codeReviewTerminalReviewerResultForThread(stub.existing[1].ID, models.AgentTypeCodex, models.DefaultCodexModel),
+		codeReviewTerminalReviewerResultForThread(stub.existing[2].ID, models.AgentTypeClaudeCode, models.DefaultClaudeCodeModel),
+		codeReviewTerminalReviewerResultForThread(stub.existing[3].ID, models.AgentTypeOpenCode, models.OpenCodeModelGPT55),
+	}
+
+	firstFallback, err := ensureCodeReviewFallbackOrchestratorThread(context.Background(), stub, job, firstSelection, 1, []string{"handler.go"}, primaryThreadID, firstResults)
+	require.NoError(t, err, "first fallback should reclaim one reviewer slot and create a fallback thread")
+	require.Equal(t, models.MaxThreadsPerSession, codeReviewVisibleThreadCount(stub.existing), "first fallback should keep the visible thread count within the session cap")
+
+	firstFallback.Status = models.ThreadStatusFailed
+	for i := range stub.existing {
+		if stub.existing[i].ID == firstFallback.ID {
+			stub.existing[i].Status = models.ThreadStatusFailed
+			break
+		}
+	}
+	secondResults := append(append([]models.CodeReviewAgentResult{}, firstResults...), codeReviewOrchestratorResultForThread(firstFallback.ID, firstSelection.AgentType, models.DefaultClaudeCodeModel, models.CodeReviewAgentResultStatusFailed))
+
+	secondFallback, err := ensureCodeReviewFallbackOrchestratorThread(context.Background(), stub, job, secondSelection, 2, []string{"handler.go"}, primaryThreadID, secondResults)
+	require.NoError(t, err, "second fallback should archive the failed prior fallback before creating the next one")
+	require.Equal(t, firstFallback.ID, stub.archiveID, "second fallback should reclaim the failed prior fallback before touching persisted reviewer evidence")
+	require.NotEqual(t, firstFallback.ID, secondFallback.ID, "second fallback should use a new deterministic thread after archiving the failed prior fallback")
+	require.Equal(t, models.MaxThreadsPerSession, codeReviewVisibleThreadCount(stub.existing), "sequential fallback attempts should never exceed the visible thread cap")
+	quorum, failures := codeReviewReviewerEvidence(secondResults)
+	require.Equal(t, 3, quorum, "sequential fallback attempts should preserve the original completed reviewer quorum")
+	require.Equal(t, 0, failures, "sequential fallback attempts should not convert persisted reviewer evidence into failures")
 }
 
 func TestEnsureCodeReviewOrchestratorFallbackStops(t *testing.T) {
@@ -404,15 +706,21 @@ func TestCodeReviewOrchestratorFallbackRecoversAndCompletes(t *testing.T) {
 			AddRow(uuid.New(), orgID, sessionID, recordKey, "orchestrator", "claude_code", "captured", json.RawMessage(`{}`), now))
 	sessionRow := workerSessionRow(sessionID, uuid.Nil, orgID, models.SessionStatusRunning, 0, nil, nil)
 	setWorkerSessionColumn(sessionRow, "origin", models.SessionOriginCodeReview)
-	for range 2 {
-		mock.ExpectQuery("(?s)SELECT .*FROM sessions").WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
-			WillReturnRows(pgxmock.NewRows(workerSessionColumns).AddRow(sessionRow...))
-	}
+	mock.ExpectQuery("(?s)SELECT .*FROM sessions").WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(pgxmock.NewRows(workerSessionColumns).AddRow(sessionRow...))
+	mainThreadID := uuid.New()
+	mainThreadRow := workerSessionThreadRow(mainThreadID, sessionID, orgID, models.AgentTypeCodex, stringPtr(models.DefaultCodexModel), models.ThreadStatusIdle)
+	setWorkerSessionThreadColumn(mainThreadRow, "label", "Main")
+	setWorkerSessionThreadColumn(mainThreadRow, "created_by_source", models.ThreadCreatedBySourceSystem)
 	threadRow := workerSessionThreadRow(threadID, sessionID, orgID, models.AgentTypeClaudeCode, stringPtr(models.DefaultClaudeCodeModel), models.ThreadStatusRunning)
 	setWorkerSessionThreadColumn(threadRow, "label", "Code review synthesis: claude_code (fallback 1)")
 	setWorkerSessionThreadColumn(threadRow, "created_by_source", models.ThreadCreatedBySourceSystem)
 	setWorkerSessionThreadColumn(threadRow, "execution_mode", models.ThreadExecutionModeReview)
 	setWorkerSessionThreadColumn(threadRow, "filesystem_mode", models.ThreadFilesystemModeReadOnly)
+	mock.ExpectQuery("(?s)SELECT .*FROM session_threads").WithArgs(pgx.NamedArgs{"org_id": orgID, "session_id": sessionID}).
+		WillReturnRows(newSessionThreadRows().AddRow(mainThreadRow...).AddRow(threadRow...))
+	mock.ExpectQuery("(?s)SELECT .*FROM sessions").WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(pgxmock.NewRows(workerSessionColumns).AddRow(sessionRow...))
 	mock.ExpectQuery("(?s)SELECT .*FROM session_threads").WithArgs(pgx.NamedArgs{"org_id": orgID, "session_id": sessionID}).
 		WillReturnRows(newSessionThreadRows().AddRow(threadRow...))
 	var runningState json.RawMessage

--- a/internal/worker/handlers.go
+++ b/internal/worker/handlers.go
@@ -644,6 +644,7 @@ type Stores struct {
 	SessionMessages     *db.SessionMessageStore // nil-safe: needed for title regeneration
 	SessionThreads      *db.SessionThreadStore  // nil-safe: needed for thread-scoped continuation status
 	ThreadInbox         *db.ThreadInboxStore    // nil-safe: settles queued input when a thread is cancelled
+	ThreadSendTx        db.TxStarter            // nil-safe: enables atomic queued thread-message admission
 	HumanInputRequests  *db.SessionHumanInputRequestStore
 	ThreadFileEvents    *db.SessionThreadFileEventStore // nil-safe: tab-level file write attribution
 	SandboxHolders      *db.SessionSandboxHolderStore   // nil-safe: snapshot quiescence for shared sandbox thread runtimes
@@ -12754,6 +12755,9 @@ func enqueuePRPushReconciliation(ctx context.Context, stores *Stores, logger zer
 	clientMessageID := fmt.Sprintf("push-reconcile:%s:%d", run.ID, revision)
 	dedupeKey := fmt.Sprintf("continue_session_push_reconcile:%s:%d", run.ID, revision)
 	threadService := threadsvc.NewService(stores.SessionThreads, stores.Sessions, stores.SessionMessages, stores.SessionLogs, stores.Jobs, logger)
+	if stores.ThreadInbox != nil && stores.ThreadSendTx != nil {
+		threadService.SetThreadInboxStore(stores.ThreadInbox, stores.ThreadSendTx)
+	}
 	_, err = threadService.SendMessage(ctx, threadsvc.SendMessageInput{
 		SessionID:                     run.ID,
 		OrgID:                         run.OrgID,

--- a/internal/worker/handlers_test.go
+++ b/internal/worker/handlers_test.go
@@ -5136,6 +5136,8 @@ func TestPushPRChangesHandler_BranchDivergedQueuesReconciliation(t *testing.T) {
 	defer mock.Close()
 	stores.SessionThreads = db.NewSessionThreadStore(mock)
 	stores.SessionMessages = db.NewSessionMessageStore(mock)
+	stores.ThreadInbox = db.NewThreadInboxStore(mock)
+	stores.ThreadSendTx = mock
 	stores.PullRequests = db.NewPullRequestStore(mock)
 
 	orgID := uuid.New()
@@ -5150,6 +5152,12 @@ func TestPushPRChangesHandler_BranchDivergedQueuesReconciliation(t *testing.T) {
 	runningRow := workerSessionRowWithStatus(completedRow, models.SessionStatusRunning)
 	completedThreadRow := workerSessionThreadRow(threadID, sessionID, orgID, models.AgentTypeCodex, nil, models.ThreadStatusCompleted)
 	runningThreadRow := workerSessionThreadRow(threadID, sessionID, orgID, models.AgentTypeCodex, nil, models.ThreadStatusRunning)
+	threadInboxColumns := []string{
+		"id", "org_id", "session_id", "thread_id", "sequence_no", "message_id", "client_message_id",
+		"entry_type", "payload", "delivery_state", "delivery_attempts",
+		"last_error", "owner_node_id", "runtime_id", "accepted_at",
+		"delivered_at", "acked_at", "applied_at", "created_at", "updated_at",
+	}
 	var capturedMessage string
 
 	mock.ExpectQuery("SELECT .* FROM sessions").
@@ -5181,27 +5189,72 @@ func TestPushPRChangesHandler_BranchDivergedQueuesReconciliation(t *testing.T) {
 	mock.ExpectQuery(`(?s)SELECT.*FROM pull_requests.*WHERE session_id.*org_id`).
 		WithArgs(workerAnyArgs(2)...).
 		WillReturnRows(pgxmock.NewRows(workerPullRequestColumns).AddRow(workerPullRequestRow(prID, sessionID, orgID, repo, headRef, now)...))
+	mock.ExpectQuery(`SELECT .* FROM thread_inbox_entries`).
+		WithArgs(orgID, threadID, "push-reconcile:"+sessionID.String()+":0").
+		WillReturnRows(pgxmock.NewRows(threadInboxColumns))
+	mock.ExpectQuery(`SELECT count\(\*\)\s+FROM thread_inbox_entries\s+WHERE org_id = \$1\s+AND thread_id = \$2`).
+		WithArgs(orgID, threadID).
+		WillReturnRows(pgxmock.NewRows([]string{"count"}).AddRow(0))
+	mock.ExpectQuery(`SELECT count\(\*\)\s+FROM thread_inbox_entries\s+WHERE org_id = \$1\s+AND session_id = \$2`).
+		WithArgs(orgID, sessionID).
+		WillReturnRows(pgxmock.NewRows([]string{"count"}).AddRow(0))
 	mock.ExpectQuery(`(?s)WITH locked_threads AS.*UPDATE session_threads.*RETURNING`).
-		WithArgs(workerAnyArgs(5)...).
+		WithArgs(pgx.NamedArgs{
+			"id":                 threadID,
+			"org_id":             orgID,
+			"session_id":         sessionID,
+			"max_running":        models.MaxRunningThreadsPerSession,
+			"claimable_statuses": []string{string(models.ThreadStatusIdle)},
+		}).
 		WillReturnRows(pgxmock.NewRows(workerSessionThreadColumns))
 	mock.ExpectQuery(`(?s)SELECT\s+COALESCE`).
-		WithArgs(workerAnyArgs(3)...).
+		WithArgs(pgx.NamedArgs{
+			"id":         threadID,
+			"org_id":     orgID,
+			"session_id": sessionID,
+		}).
 		WillReturnRows(pgxmock.NewRows([]string{"target_status", "sibling_active"}).AddRow(string(models.ThreadStatusCompleted), 0))
 	mock.ExpectQuery("SELECT .* FROM session_threads").
 		WithArgs(workerAnyArgs(2)...).
 		WillReturnRows(pgxmock.NewRows(workerSessionThreadColumns).AddRow(completedThreadRow...))
 	mock.ExpectQuery(`(?s)WITH locked_threads AS.*UPDATE session_threads.*RETURNING`).
-		WithArgs(workerAnyArgs(5)...).
+		WithArgs(pgx.NamedArgs{
+			"id":          threadID,
+			"org_id":      orgID,
+			"session_id":  sessionID,
+			"max_running": models.MaxRunningThreadsPerSession,
+			"claimable_statuses": []string{
+				string(models.ThreadStatusCompleted),
+				string(models.ThreadStatusFailed),
+				string(models.ThreadStatusCancelled),
+				string(models.ThreadStatusAwaitingInput),
+			},
+		}).
 		WillReturnRows(pgxmock.NewRows(workerSessionThreadColumns).AddRow(runningThreadRow...))
 	mock.ExpectQuery(`(?s)UPDATE sessions.*status = 'running'.*status = 'idle'.*RETURNING`).
-		WithArgs(workerAnyArgs(2)...).
+		WithArgs(pgx.NamedArgs{
+			"id":     sessionID,
+			"org_id": orgID,
+		}).
 		WillReturnRows(pgxmock.NewRows(workerSessionColumns))
 	mock.ExpectQuery("SELECT .* FROM sessions").
 		WithArgs(workerAnyArgs(2)...).
 		WillReturnRows(pgxmock.NewRows(workerSessionColumns).AddRow(completedRow...))
 	mock.ExpectQuery(`(?s)UPDATE sessions.*status = 'running'.*status = ANY\(@statuses\).*RETURNING`).
-		WithArgs(workerAnyArgs(3)...).
+		WithArgs(pgx.NamedArgs{
+			"id":     sessionID,
+			"org_id": orgID,
+			"statuses": []string{
+				string(models.SessionStatusCompleted),
+				string(models.SessionStatusPRCreated),
+				string(models.SessionStatusFailed),
+				string(models.SessionStatusCancelled),
+				string(models.SessionStatusAwaitingInput),
+				string(models.SessionStatusNeedsHumanGuidance),
+			},
+		}).
 		WillReturnRows(pgxmock.NewRows(workerSessionColumns).AddRow(runningRow...))
+	mock.ExpectBegin()
 	mock.ExpectQuery("INSERT INTO session_messages").
 		WithArgs(
 			sessionID,
@@ -5218,6 +5271,15 @@ func TestPushPRChangesHandler_BranchDivergedQueuesReconciliation(t *testing.T) {
 			models.SessionMessageSourceAgentTool,
 		).
 		WillReturnRows(pgxmock.NewRows([]string{"id", "created_at"}).AddRow(int64(1001), now))
+	mock.ExpectQuery(`WITH locked_thread AS[\s\S]*archived_at IS NULL[\s\S]*FOR UPDATE`).
+		WithArgs(workerAnyArgs(7)...).
+		WillReturnRows(pgxmock.NewRows(threadInboxColumns).AddRow(
+			uuid.New(), orgID, sessionID, threadID, int64(1), int64(1001), "push-reconcile:"+sessionID.String()+":0",
+			models.ThreadInboxEntryTypeUserMessage, json.RawMessage(`{"message_id":1001}`),
+			models.ThreadInboxDeliveryStatePending, 0,
+			nil, nil, nil, now, nil, nil, nil, now, now,
+		))
+	mock.ExpectCommit()
 	mock.ExpectQuery("INSERT INTO jobs").
 		WithArgs(
 			orgID,


### PR DESCRIPTION
## Summary

Final review synthesis can fail on model capacity even when another reviewer has completed successfully. Retry synthesis with the next available model from the configured reviewer roster so completed review work can still produce a result.

## Changes

- Recognize capacity and rate-limit failures, skip exhausted models, and avoid sending JSON repairs to an unavailable model.
- Preserve reviewer evidence and record each fallback in a separate read-only thread, recovering already-started attempts after worker retries.
- Stay within the session thread limit by archiving finished system review threads after their results are saved, and report availability failures clearly when no slot is available.
- Preserve synthesis deadlines and protect queued input with archival guards and atomic message, inbox, and pending-count writes, including worker follow-ups.

## Validation

- `go test ./internal/services/thread ./internal/worker ./cmd/server -count=1`
- `go vet ./internal/services/thread ./internal/worker ./cmd/server`
- Atomic-admission regression test fails against the previous service implementation at its premature transaction commit.
- Database unit tests and PostgreSQL 14 concurrency tests for both archive/queue orderings.
- `git diff --check`
