### PR TITLE
Fix prompt upserts during reviewer retries

### DIFF
--- a/internal/db/prompt_record_compatibility_migration_postgres_test.go
+++ b/internal/db/prompt_record_compatibility_migration_postgres_test.go
@@ -1,0 +1,178 @@
+package db
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/assembledhq/143/internal/models"
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPromptRecordCompatibilityMigrationPostgres(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		table     string
+		keyColumn string
+	}{
+		{name: "current writer", table: "code_review_prompt_records", keyColumn: "record_key"},
+		{name: "legacy writer", table: "code_review_prompt_artifacts", keyColumn: "artifact_key"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx := context.Background()
+			conn := newPromptRecordCompatibilityTestConn(t)
+			applyPromptRecordCompatibilityTestMigration(t, conn, "000280_rename_legacy_output_terms.up.sql")
+
+			orgID, sessionID := uuid.New(), uuid.New()
+			_, err := conn.Exec(ctx, `INSERT INTO organizations (id) VALUES ($1)`, orgID)
+			require.NoError(t, err, "test should create the prompt organization")
+			_, err = conn.Exec(ctx, `INSERT INTO sessions (id, org_id) VALUES ($1, $2)`, sessionID, orgID)
+			require.NoError(t, err, "test should create the review session")
+
+			expected := models.CodeReviewPromptRecord{
+				ID: uuid.New(), OrgID: orgID, SessionID: sessionID,
+				RecordKey: "reviewer-04-codex", Role: "reviewer", AgentProvider: "codex",
+				Content: "initial prompt", Metadata: json.RawMessage(`{"attempt": 0}`),
+				CreatedAt: time.Date(2026, 9, 2, 18, 0, 0, 0, time.UTC),
+			}
+			upsertSQL := fmt.Sprintf(`
+				INSERT INTO %s (id, org_id, session_id, %s, role, agent_provider, content, metadata, created_at)
+				VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+				ON CONFLICT (org_id, %s) DO UPDATE
+				SET content = EXCLUDED.content, metadata = EXCLUDED.metadata`, tt.table, tt.keyColumn, tt.keyColumn)
+			_, err = conn.Exec(ctx, upsertSQL, expected.ID, orgID, sessionID, expected.RecordKey,
+				expected.Role, expected.AgentProvider, expected.Content, expected.Metadata, expected.CreatedAt)
+			require.NoError(t, err, "initial prompt should be writable by either generation")
+			requirePromptRecordCompatibilityRows(t, conn, orgID, []models.CodeReviewPromptRecord{expected})
+
+			applyPromptRecordCompatibilityTestMigration(t, conn, "000288_fix_code_review_prompt_record_compatibility.up.sql")
+			expected.Content = "retry prompt"
+			expected.Metadata = json.RawMessage(`{"attempt": 1}`)
+			if tt.table == "code_review_prompt_records" {
+				// Exercise the worker's actual retry path, including its conflict update.
+				retry := models.CodeReviewPromptRecord{
+					OrgID: orgID, SessionID: sessionID, RecordKey: expected.RecordKey,
+					Role: expected.Role, AgentProvider: expected.AgentProvider,
+					Content: expected.Content, Metadata: expected.Metadata,
+				}
+				err = NewCodeReviewStore(conn).CreatePromptRecord(ctx, &retry)
+				require.NoError(t, err, "review retries should upsert an existing prompt on an upgraded database")
+				retry.CreatedAt = retry.CreatedAt.UTC()
+				require.Equal(t, expected, retry, "retry should preserve the prompt identity while updating its contents")
+			} else {
+				_, err = conn.Exec(ctx, upsertSQL, uuid.New(), orgID, sessionID, expected.RecordKey,
+					expected.Role, expected.AgentProvider, expected.Content, expected.Metadata, expected.CreatedAt)
+				require.NoError(t, err, "draining workers should still upsert legacy prompt rows")
+			}
+			requirePromptRecordCompatibilityRows(t, conn, orgID, []models.CodeReviewPromptRecord{expected})
+
+			applyPromptRecordCompatibilityTestMigration(t, conn, "000288_fix_code_review_prompt_record_compatibility.down.sql")
+			// Rolling back the repair must keep both worker generations writable.
+			_, err = conn.Exec(ctx, fmt.Sprintf(`UPDATE %s SET %s = $1 WHERE org_id = $2 AND %s = $3`,
+				tt.table, tt.keyColumn, tt.keyColumn), "renamed-prompt", orgID, expected.RecordKey)
+			require.NoError(t, err, "rekeying either generation should retire the old counterpart without a primary-key collision")
+			expected.RecordKey = "renamed-prompt"
+			requirePromptRecordCompatibilityRows(t, conn, orgID, []models.CodeReviewPromptRecord{expected})
+
+			_, err = conn.Exec(ctx, fmt.Sprintf(`DELETE FROM %s WHERE org_id = $1 AND %s = $2`,
+				tt.table, tt.keyColumn), orgID, expected.RecordKey)
+			require.NoError(t, err, "deleting either generation should remove its synchronized counterpart")
+			requirePromptRecordCompatibilityRows(t, conn, orgID, []models.CodeReviewPromptRecord{})
+		})
+	}
+}
+
+func TestPromptRecordCompatibilityMigrationFreshSchemaPostgres(t *testing.T) {
+	t.Parallel()
+
+	conn := newPromptRecordCompatibilityTestConn(t)
+	_, err := conn.Exec(context.Background(), `
+		ALTER TABLE code_review_prompt_artifacts RENAME TO code_review_prompt_records;
+		ALTER TABLE code_review_prompt_records RENAME COLUMN artifact_key TO record_key;
+	`)
+	require.NoError(t, err, "test should model a fresh schema containing only the current prompt table")
+
+	applyPromptRecordCompatibilityTestMigration(t, conn, "000288_fix_code_review_prompt_record_compatibility.up.sql")
+	applyPromptRecordCompatibilityTestMigration(t, conn, "000288_fix_code_review_prompt_record_compatibility.down.sql")
+
+	var currentTable string
+	var legacyTable, compatibilityFunction *string
+	err = conn.QueryRow(context.Background(), `
+		SELECT to_regclass('code_review_prompt_records')::text,
+		       to_regclass('code_review_prompt_artifacts')::text,
+		       to_regprocedure('sync_code_review_prompt_record_compatibility()')::text
+	`).Scan(&currentTable, &legacyTable, &compatibilityFunction)
+	require.NoError(t, err, "test should inspect the fresh schema after applying and rolling back the repair")
+	require.Equal(t, "code_review_prompt_records", currentTable, "the current prompt table should remain available")
+	require.Nil(t, legacyTable, "fresh installations should not acquire a legacy prompt table")
+	require.Nil(t, compatibilityFunction, "fresh installations should not acquire an unused compatibility function")
+}
+
+func newPromptRecordCompatibilityTestConn(t *testing.T) *pgx.Conn {
+	t.Helper()
+
+	databaseURL := os.Getenv("TEST_DATABASE_URL")
+	if databaseURL == "" {
+		t.Skip("set TEST_DATABASE_URL to run the prompt compatibility migration tests")
+	}
+	ctx := context.Background()
+	conn, err := pgx.Connect(ctx, databaseURL)
+	require.NoError(t, err, "test should connect to TEST_DATABASE_URL")
+	t.Cleanup(func() {
+		require.NoError(t, conn.Close(context.Background()), "test should close its PostgreSQL connection")
+	})
+
+	schema := "test_prompt_compatibility_" + strings.ReplaceAll(uuid.NewString(), "-", "_")
+	_, err = conn.Exec(ctx, `CREATE SCHEMA `+schema)
+	require.NoError(t, err, "test should create an isolated migration schema")
+	t.Cleanup(func() {
+		_, cleanupErr := conn.Exec(context.Background(), `DROP SCHEMA IF EXISTS `+schema+` CASCADE`)
+		require.NoError(t, cleanupErr, "test should remove its isolated migration schema")
+	})
+	_, err = conn.Exec(ctx, `SET search_path TO `+schema)
+	require.NoError(t, err, "test should isolate migration objects")
+	_, err = conn.Exec(ctx, legacyOutputNameTestSchema)
+	require.NoError(t, err, "test should create the deployed legacy schema")
+	return conn
+}
+
+func applyPromptRecordCompatibilityTestMigration(t *testing.T, conn *pgx.Conn, name string) {
+	t.Helper()
+
+	body, err := os.ReadFile("../../migrations/" + name)
+	require.NoError(t, err, "test should read migration %s", name)
+	_, err = conn.Exec(context.Background(), string(body))
+	require.NoError(t, err, "test should apply migration %s", name)
+}
+
+func requirePromptRecordCompatibilityRows(t *testing.T, conn *pgx.Conn, orgID uuid.UUID, expected []models.CodeReviewPromptRecord) {
+	t.Helper()
+
+	tables := []struct{ name, key string }{
+		{name: "code_review_prompt_records", key: "record_key"},
+		{name: "code_review_prompt_artifacts", key: "artifact_key"},
+	}
+	for _, table := range tables {
+		rows, err := conn.Query(context.Background(), fmt.Sprintf(`
+			SELECT id, org_id, session_id, %s AS record_key, role, agent_provider, content, metadata, created_at
+			FROM %s WHERE org_id = $1 ORDER BY %s`, table.key, table.name, table.key), orgID)
+		require.NoError(t, err, "test should read synchronized rows from %s", table.name)
+		actual, err := pgx.CollectRows(rows, pgx.RowToStructByName[models.CodeReviewPromptRecord])
+		require.NoError(t, err, "test should decode synchronized prompt rows")
+		for i := range actual {
+			actual[i].CreatedAt = actual[i].CreatedAt.UTC()
+		}
+		require.Equal(t, expected, actual, "%s should contain the exact synchronized prompt rows", table.name)
+	}
+}

--- a/migrations/000288_fix_code_review_prompt_record_compatibility.down.sql
+++ b/migrations/000288_fix_code_review_prompt_record_compatibility.down.sql
@@ -1,0 +1,3 @@
+-- Intentionally no-op: both worker generations require the repaired trigger.
+-- Rolling back this repair must not restore prompt-upsert failures or remove
+-- synchronization. Migration 000280 owns the compatibility function's teardown.

--- a/migrations/000288_fix_code_review_prompt_record_compatibility.up.sql
+++ b/migrations/000288_fix_code_review_prompt_record_compatibility.up.sql
@@ -1,0 +1,85 @@
+-- Migration 000280 installed a shared trigger on tables with different key
+-- columns. PostgreSQL resolves record fields before evaluating an AND guard,
+-- so each table's fields must be referenced in a separate procedural branch.
+DO $migration$
+BEGIN
+    -- Fresh installations have only prompt_records and need no compatibility
+    -- function. Repair only installations retaining both worker generations.
+    IF to_regclass('code_review_prompt_artifacts') IS NULL
+       OR to_regclass('code_review_prompt_records') IS NULL THEN
+        RETURN;
+    END IF;
+
+    CREATE OR REPLACE FUNCTION sync_code_review_prompt_record_compatibility()
+    RETURNS trigger
+    LANGUAGE plpgsql
+    AS $function$
+    BEGIN
+        IF pg_trigger_depth() > 1 THEN
+            IF TG_OP = 'DELETE' THEN
+                RETURN OLD;
+            END IF;
+            RETURN NEW;
+        END IF;
+
+        IF TG_OP = 'DELETE' THEN
+            IF TG_TABLE_NAME = 'code_review_prompt_artifacts' THEN
+                DELETE FROM code_review_prompt_records
+                WHERE org_id = OLD.org_id AND record_key = OLD.artifact_key;
+            ELSE
+                DELETE FROM code_review_prompt_artifacts
+                WHERE org_id = OLD.org_id AND artifact_key = OLD.record_key;
+            END IF;
+            RETURN OLD;
+        END IF;
+
+        -- Retire a rekeyed row's previous counterpart before the insert below
+        -- would collide with that counterpart's primary key.
+        IF TG_OP = 'UPDATE' THEN
+            IF TG_TABLE_NAME = 'code_review_prompt_artifacts' THEN
+                IF NEW.artifact_key IS DISTINCT FROM OLD.artifact_key THEN
+                    DELETE FROM code_review_prompt_records
+                    WHERE org_id = OLD.org_id AND record_key = OLD.artifact_key;
+                END IF;
+            ELSE
+                IF NEW.record_key IS DISTINCT FROM OLD.record_key THEN
+                    DELETE FROM code_review_prompt_artifacts
+                    WHERE org_id = OLD.org_id AND artifact_key = OLD.record_key;
+                END IF;
+            END IF;
+        END IF;
+
+        IF TG_TABLE_NAME = 'code_review_prompt_artifacts' THEN
+            INSERT INTO code_review_prompt_records (
+                id, org_id, session_id, record_key, role, agent_provider, content, metadata, created_at
+            ) VALUES (
+                NEW.id, NEW.org_id, NEW.session_id, NEW.artifact_key, NEW.role,
+                NEW.agent_provider, NEW.content, NEW.metadata, NEW.created_at
+            )
+            ON CONFLICT (org_id, record_key) DO UPDATE SET
+                session_id = EXCLUDED.session_id,
+                role = EXCLUDED.role,
+                agent_provider = EXCLUDED.agent_provider,
+                content = EXCLUDED.content,
+                metadata = EXCLUDED.metadata,
+                created_at = EXCLUDED.created_at;
+        ELSE
+            INSERT INTO code_review_prompt_artifacts (
+                id, org_id, session_id, artifact_key, role, agent_provider, content, metadata, created_at
+            ) VALUES (
+                NEW.id, NEW.org_id, NEW.session_id, NEW.record_key, NEW.role,
+                NEW.agent_provider, NEW.content, NEW.metadata, NEW.created_at
+            )
+            ON CONFLICT (org_id, artifact_key) DO UPDATE SET
+                session_id = EXCLUDED.session_id,
+                role = EXCLUDED.role,
+                agent_provider = EXCLUDED.agent_provider,
+                content = EXCLUDED.content,
+                metadata = EXCLUDED.metadata,
+                created_at = EXCLUDED.created_at;
+        END IF;
+        RETURN NEW;
+    END;
+    $function$;
+END;
+$migration$;


### PR DESCRIPTION
## Summary

Code-review retries could exhaust all attempts when saving an existing prompt failed with `record "new" has no field "artifact_key"`. Add a corrective migration that separates the compatibility trigger's table-specific field checks so current and legacy workers can update prompts safely.

## Changes

- Repair the trigger installed by migration 000280 while retaining synchronization between both prompt tables.
- Keep fresh installations unchanged and preserve the repair on rollback; migration 000280 still owns compatibility teardown.
- Add Postgres regressions for current-store retries, legacy upserts, synchronized key changes and deletes, and fresh installations.

## Validation

**Prompt compatibility test evidence**

Captured against commit `51171ba8db7f19391c91f95a673118e3635c8860` using an isolated local Postgres 17 database. Set `TEST_DATABASE_URL` to a Postgres 17 test database before running the command below.

| Behavior | Proving test |
| --- | --- |
| Current workers can retry an existing prompt through `CodeReviewStore.CreatePromptRecord` while preserving its identity | `TestPromptRecordCompatibilityMigrationPostgres/current_writer` |
| Legacy workers can upsert prompts and synchronize their contents into the current table | `TestPromptRecordCompatibilityMigrationPostgres/legacy_writer` |
| Both tables stay synchronized through key changes and deletes, including after rolling back the repair | Both writer cases in `TestPromptRecordCompatibilityMigrationPostgres` |
| Fresh installations retain only the current prompt table and acquire no compatibility function | `TestPromptRecordCompatibilityMigrationFreshSchemaPostgres` |

```sh
go test ./internal/db -run '^TestPromptRecordCompatibilityMigration.*Postgres$' -count=1 -v -timeout=60s
```

<details>
<summary>Before the repair: captured failure excerpts</summary>

The new regression cases failed before migration 000288 was applied. The current writer reproduced the production error; the legacy writer exposed the inverse missing-column error.

```text
=== NAME  TestPromptRecordCompatibilityMigrationPostgres/current_writer
ERROR: record "new" has no field "artifact_key" (SQLSTATE 42703)
=== NAME  TestPromptRecordCompatibilityMigrationPostgres/legacy_writer
ERROR: record "new" has no field "record_key" (SQLSTATE 42703)
--- FAIL: TestPromptRecordCompatibilityMigrationPostgres (0.00s)
--- FAIL: TestPromptRecordCompatibilityMigrationPostgres/legacy_writer (0.07s)
--- FAIL: TestPromptRecordCompatibilityMigrationPostgres/current_writer (0.07s)
FAIL
FAIL	github.com/assembledhq/143/internal/db	0.423s
FAIL
```

</details>

<details>
<summary>Published commit: captured passing regression output</summary>

```text
=== RUN   TestPromptRecordCompatibilityMigrationPostgres
=== PAUSE TestPromptRecordCompatibilityMigrationPostgres
=== RUN   TestPromptRecordCompatibilityMigrationFreshSchemaPostgres
=== PAUSE TestPromptRecordCompatibilityMigrationFreshSchemaPostgres
=== CONT  TestPromptRecordCompatibilityMigrationPostgres
=== CONT  TestPromptRecordCompatibilityMigrationFreshSchemaPostgres
=== RUN   TestPromptRecordCompatibilityMigrationPostgres/current_writer
=== PAUSE TestPromptRecordCompatibilityMigrationPostgres/current_writer
=== RUN   TestPromptRecordCompatibilityMigrationPostgres/legacy_writer
=== PAUSE TestPromptRecordCompatibilityMigrationPostgres/legacy_writer
=== CONT  TestPromptRecordCompatibilityMigrationPostgres/current_writer
=== CONT  TestPromptRecordCompatibilityMigrationPostgres/legacy_writer
--- PASS: TestPromptRecordCompatibilityMigrationFreshSchemaPostgres (0.07s)
--- PASS: TestPromptRecordCompatibilityMigrationPostgres (0.00s)
    --- PASS: TestPromptRecordCompatibilityMigrationPostgres/legacy_writer (0.11s)
    --- PASS: TestPromptRecordCompatibilityMigrationPostgres/current_writer (0.11s)
PASS
ok  	github.com/assembledhq/143/internal/db	0.437s
```

</details>

<details>
<summary>Captured database package tests and full migration cycle</summary>

`go test ./internal/db ./cmd/migrate -count=1 -timeout=120s` with `TEST_DATABASE_URL` set:

```text
ok  	github.com/assembledhq/143/internal/db	2.640s
ok  	github.com/assembledhq/143/cmd/migrate	0.566s
```

Full local migration up/down/up cycle:

```text
Migrations applied successfully.
Migrations rolled back successfully.
Migrations applied successfully.
```

</details>

The remote [Migration Safety check](https://github.com/assembledhq/143/actions/runs/33676931784/job/100403964450) also passed.

- Reproduced the production error on Postgres 17 before the repair; both writer regressions pass afterward.
- `go test ./internal/db ./cmd/migrate -count=1 -timeout=120s` with `TEST_DATABASE_URL` pointing to a disposable Postgres 17 database.
- `go vet ./internal/db` and `make lint-tenancy`.
- Full migration up/down/up cycle on Postgres 17.

