### PR TITLE
Reject 143 auto-approval for schema/migration PRs and surface migration comment

### DIFF
--- a/internal/models/code_review.go
+++ b/internal/models/code_review.go
@@ -1284,24 +1284,25 @@ func CodeReviewAutomatedApprovalExamples() []CodeReviewAutomatedApprovalExampleO
 }
 
 type CodeReviewRiskInput struct {
-	FilesChanged          int
-	LinesChanged          int
-	ChangedPaths          []string
-	ChecksPassing         bool
-	RequiredChecksPassing map[string]bool
-	DescriptionPassed     bool
-	UpToDate              bool
-	Author                string
-	AuthorClass           string
-	AuthorTeams           []string
-	FromFork              bool
-	BlockingFindings      int
-	ReviewerDisagreement  bool
-	ScopeMismatch         bool
-	UnresolvedUncertainty bool
-	PromptInjectionFound  bool
-	ContextFetchFailed    bool
-	HeadSHAChanged        bool
+	FilesChanged            int
+	LinesChanged            int
+	ChangedPaths            []string
+	ChecksPassing           bool
+	RequiredChecksPassing   map[string]bool
+	DescriptionPassed       bool
+	UpToDate                bool
+	Author                  string
+	AuthorClass             string
+	AuthorTeams             []string
+	FromFork                bool
+	BlockingFindings        int
+	ReviewerDisagreement    bool
+	ScopeMismatch           bool
+	UnresolvedUncertainty   bool
+	PromptInjectionFound    bool
+	ContextFetchFailed      bool
+	HeadSHAChanged          bool
+	DBMigrationMessageFound bool
 }
 
 type CodeReviewRiskReasonCode string
@@ -1329,6 +1330,8 @@ const (
 	CodeReviewRiskReasonSensitivePath         CodeReviewRiskReasonCode = "sensitive_path"
 	CodeReviewRiskReasonPathOutsideScope      CodeReviewRiskReasonCode = "path_outside_scope"
 	CodeReviewRiskReasonBlockedPath           CodeReviewRiskReasonCode = "blocked_path"
+	CodeReviewRiskReasonApplicationSchema     CodeReviewRiskReasonCode = "application_schema"
+	CodeReviewRiskReasonDatabaseMigration     CodeReviewRiskReasonCode = "database_migration"
 	// Retained so historical decisions remain renderable; new evaluations do not emit these reasons.
 	CodeReviewRiskReasonPolicyPathChanged            CodeReviewRiskReasonCode = "policy_path_changed"
 	CodeReviewRiskReasonExcludedCategory             CodeReviewRiskReasonCode = "excluded_category"
@@ -1381,7 +1384,9 @@ func (c CodeReviewRiskReasonCode) Validate() error {
 		CodeReviewRiskReasonOwnership,
 		CodeReviewRiskReasonOperationalRisk,
 		CodeReviewRiskReasonSensitiveChange,
-		CodeReviewRiskReasonPolicyRequirement:
+		CodeReviewRiskReasonPolicyRequirement,
+		CodeReviewRiskReasonApplicationSchema,
+		CodeReviewRiskReasonDatabaseMigration:
 		return nil
 	default:
 		return fmt.Errorf("invalid CodeReviewRiskReasonCode: %q", c)
@@ -1402,6 +1407,7 @@ var codeReviewStableDeterministicRiskReasonCodes = []CodeReviewRiskReasonCode{
 	CodeReviewRiskReasonBlockedPath,
 	CodeReviewRiskReasonPathOutsideScope,
 	CodeReviewRiskReasonSensitivePath,
+	CodeReviewRiskReasonApplicationSchema,
 	CodeReviewRiskReasonForkIneligible,
 	CodeReviewRiskReasonAuthorIneligible,
 }
@@ -1476,6 +1482,10 @@ func (r CodeReviewRiskReason) Message() string {
 		return "path is outside allowed policy scope: " + r.Subject
 	case CodeReviewRiskReasonBlockedPath:
 		return "blocked path changed: " + r.Subject
+	case CodeReviewRiskReasonApplicationSchema:
+		return "application schema file changed: " + r.Subject
+	case CodeReviewRiskReasonDatabaseMigration:
+		return "this migration adheres to the correct syntax, style, etc... Request a human reviewer to ensure adherence to the migration protocol"
 	case CodeReviewRiskReasonPolicyPathChanged:
 		return "code review policy/config path changed: " + r.Subject
 	case CodeReviewRiskReasonExcludedCategory:
@@ -1629,6 +1639,14 @@ func EvaluateCodeReviewRisk(policy CodeReviewPolicyConfig, input CodeReviewRiskI
 			risk.AddReason(CodeReviewRiskReason{Code: CodeReviewRiskReasonBlockedPath, Subject: path})
 		}
 	}
+	for _, path := range input.ChangedPaths {
+		if codeReviewPathIsApplicationSchema(path) {
+			risk.AddReason(CodeReviewRiskReason{Code: CodeReviewRiskReasonApplicationSchema, Subject: path})
+		}
+	}
+	if input.DBMigrationMessageFound {
+		risk.AddReason(CodeReviewRiskReason{Code: CodeReviewRiskReasonDatabaseMigration})
+	}
 	return risk
 }
 
@@ -1747,6 +1765,23 @@ func matchesAnyCodeReviewPath(path string, patterns []string) bool {
 			continue
 		}
 		if codeReviewPathPatternMatches(pattern, path) {
+			return true
+		}
+	}
+	return false
+}
+
+func codeReviewPathIsApplicationSchema(path string) bool {
+	path = normalizeCodeReviewPath(path)
+	for _, fragment := range []string{
+		"application_schema",
+		"application_indexes",
+		"cached_metrics_schema",
+		"raw_schema",
+		"raw_indexes",
+		"/migrations/",
+	} {
+		if strings.Contains(path, fragment) {
 			return true
 		}
 	}

--- a/internal/models/code_review_test.go
+++ b/internal/models/code_review_test.go
@@ -753,6 +753,35 @@ func TestEvaluateCodeReviewRisk(t *testing.T) {
 				CodeReviewRiskReason{Code: CodeReviewRiskReasonLinesLimitExceeded, Actual: 607, Limit: 300},
 			),
 		},
+		{
+			name: "blocks application schema changes",
+			input: CodeReviewRiskInput{
+				FilesChanged:      1,
+				LinesChanged:      20,
+				ChangedPaths:      []string{"gocode/postgresdb/application_schema.go"},
+				ChecksPassing:     true,
+				DescriptionPassed: true,
+				Author:            "devin",
+			},
+			expected: codeReviewRiskEvaluationForTest(
+				CodeReviewRiskReason{Code: CodeReviewRiskReasonApplicationSchema, Subject: "gocode/postgresdb/application_schema.go"},
+			),
+		},
+		{
+			name: "blocks DB migration message",
+			input: CodeReviewRiskInput{
+				FilesChanged:            1,
+				LinesChanged:            20,
+				ChangedPaths:            []string{"internal/db/users.go"},
+				ChecksPassing:           true,
+				DescriptionPassed:       true,
+				Author:                  "devin",
+				DBMigrationMessageFound: true,
+			},
+			expected: codeReviewRiskEvaluationForTest(
+				CodeReviewRiskReason{Code: CodeReviewRiskReasonDatabaseMigration},
+			),
+		},
 	}
 
 	for _, tt := range tests {
@@ -817,6 +846,8 @@ func TestCodeReviewRiskReasonCodeValidate(t *testing.T) {
 		CodeReviewRiskReasonOperationalRisk,
 		CodeReviewRiskReasonSensitiveChange,
 		CodeReviewRiskReasonPolicyRequirement,
+		CodeReviewRiskReasonApplicationSchema,
+		CodeReviewRiskReasonDatabaseMigration,
 	}
 	tests := make([]struct {
 		name      string
@@ -889,6 +920,8 @@ func TestCodeReviewRiskReasonMessage(t *testing.T) {
 		{name: "operational risk", reason: CodeReviewRiskReason{Code: CodeReviewRiskReasonOperationalRisk, Subject: "requires a coordinated rollout"}, expected: "human review is required for operational-risk judgment: requires a coordinated rollout"},
 		{name: "sensitive change", reason: CodeReviewRiskReason{Code: CodeReviewRiskReasonSensitiveChange, Subject: "changes production data access"}, expected: "human review is required for sensitive-change judgment: changes production data access"},
 		{name: "policy requirement", reason: CodeReviewRiskReason{Code: CodeReviewRiskReasonPolicyRequirement, Subject: "requires domain-owner signoff"}, expected: "human review is required for an automated approval policy requirement: requires domain-owner signoff"},
+		{name: "application schema", reason: CodeReviewRiskReason{Code: CodeReviewRiskReasonApplicationSchema, Subject: "gocode/postgresdb/application_schema.go"}, expected: "application schema file changed: gocode/postgresdb/application_schema.go"},
+		{name: "database migration", reason: CodeReviewRiskReason{Code: CodeReviewRiskReasonDatabaseMigration}, expected: "this migration adheres to the correct syntax, style, etc... Request a human reviewer to ensure adherence to the migration protocol"},
 	}
 
 	for _, tt := range tests {

--- a/internal/services/github/pr.go
+++ b/internal/services/github/pr.go
@@ -4946,6 +4946,46 @@ func (s *PRService) findPRPreviewComment(ctx context.Context, token, owner, repo
 	return nil, "", nil
 }
 
+func (s *PRService) CodeReviewIssueCommentBodies(ctx context.Context, orgID, repositoryID uuid.UUID, number int) ([]string, error) {
+	if s == nil || s.repos == nil {
+		return nil, fmt.Errorf("repository store is unavailable")
+	}
+	if orgID == uuid.Nil || repositoryID == uuid.Nil || number <= 0 {
+		return nil, fmt.Errorf("org_id, repository_id, and positive pull request number are required")
+	}
+
+	repository, err := s.repos.GetByID(ctx, orgID, repositoryID)
+	if err != nil {
+		return nil, fmt.Errorf("load repository for issue comments: %w", err)
+	}
+	token, err := s.getInstallationTokenForRepo(ctx, orgID, &repository)
+	if err != nil {
+		return nil, fmt.Errorf("load installation token for issue comments: %w", err)
+	}
+	owner, repo := splitRepo(repository.FullName)
+
+	const maxPages = 50
+	var bodies []string
+	for page := 1; page <= maxPages; page++ {
+		path := fmt.Sprintf("/repos/%s/%s/issues/%d/comments?per_page=100&page=%d", owner, repo, number, page)
+		resp, err := s.doGitHubRequest(ctx, token, http.MethodGet, path, nil)
+		if err != nil {
+			return nil, fmt.Errorf("list issue comments: %w", err)
+		}
+		var comments []githubIssueComment
+		if err := json.Unmarshal(resp, &comments); err != nil {
+			return nil, fmt.Errorf("decode issue comments: %w", err)
+		}
+		for _, comment := range comments {
+			bodies = append(bodies, comment.Body)
+		}
+		if len(comments) < 100 {
+			break
+		}
+	}
+	return bodies, nil
+}
+
 func (s *PRService) createIssueComment(ctx context.Context, token, owner, repo string, prNumber int, body string) (int64, error) {
 	path := fmt.Sprintf("/repos/%s/%s/issues/%d/comments", owner, repo, prNumber)
 	resp, err := s.doGitHubRequest(ctx, token, http.MethodPost, path, map[string]string{"body": body})

--- a/internal/services/github/pr_test.go
+++ b/internal/services/github/pr_test.go
@@ -385,6 +385,49 @@ func TestGetCodeReviewPullRequestSnapshot(t *testing.T) {
 	require.NoError(t, mock.ExpectationsWereMet(), "snapshot loader should use an org-scoped repository lookup")
 }
 
+func TestCodeReviewIssueCommentBodies(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/repos/assembledhq/assembled/issues/54903/comments", r.URL.Path, "issue comment loader should request the tagged issue comments")
+		require.Equal(t, "per_page=100&page=1", r.URL.RawQuery, "issue comment loader should paginate")
+		require.Equal(t, "token installation-token", r.Header.Get("Authorization"), "issue comment loader should use the repository installation token")
+		_, err := fmt.Fprint(w, `[{"id":1,"body":"A DB migration was added in this PR."}]`)
+		require.NoError(t, err, "GitHub test response should be written")
+	}))
+	t.Cleanup(server.Close)
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "pgxmock should initialize")
+	defer mock.Close()
+	orgID := uuid.New()
+	repositoryID := uuid.New()
+	integrationID := uuid.New()
+	now := time.Now().UTC()
+	mock.ExpectQuery("SELECT id, org_id, integration_id, github_id").
+		WithArgs(pgx.NamedArgs{"id": repositoryID, "org_id": orgID}).
+		WillReturnRows(pgxmock.NewRows(prTestRepoColumns).AddRow(
+			repositoryID, orgID, integrationID, int64(1001), "assembledhq/assembled", "main",
+			false, nil, nil, "https://github.com/assembledhq/assembled.git", int64(456), "active",
+			nil, nil, []byte(`{}`), now, now,
+		))
+	svc := &PRService{
+		tokenProvider: &Service{cache: map[int64]*cachedToken{
+			456: {Token: "installation-token", ExpiresAt: time.Now().Add(time.Hour)},
+		}},
+		repos:      db.NewRepositoryStore(mock),
+		logger:     zerolog.Nop(),
+		baseURL:    server.URL,
+		httpClient: server.Client(),
+	}
+
+	bodies, err := svc.CodeReviewIssueCommentBodies(context.Background(), orgID, repositoryID, 54903)
+
+	require.NoError(t, err, "issue comment loader should return comment bodies")
+	require.Equal(t, []string{"A DB migration was added in this PR."}, bodies, "issue comment loader should preserve bodies")
+	require.NoError(t, mock.ExpectationsWereMet(), "issue comment loader should use an org-scoped repository lookup")
+}
+
 func TestFormatPRTitle(t *testing.T) {
 	t.Parallel()
 

--- a/internal/worker/code_review_handler.go
+++ b/internal/worker/code_review_handler.go
@@ -58,6 +58,41 @@ const codeReviewOrchestratorHumanReviewReasonLimit = 10
 const codeReviewOrchestratorFindingSummaryLimit = 500
 const codeReviewOrchestratorFindingBodyLimit = 2_000
 const codeReviewOrchestratorHumanReviewSummaryLimit = 500
+const codeReviewDBMigrationMessageMarker = "A DB migration was added in this PR"
+
+type codeReviewIssueCommentLister interface {
+	CodeReviewIssueCommentBodies(ctx context.Context, orgID, repositoryID uuid.UUID, number int) ([]string, error)
+}
+
+func codeReviewTextContainsDBMigrationMessage(text string) bool {
+	return strings.Contains(strings.ToLower(text), strings.ToLower(codeReviewDBMigrationMessageMarker))
+}
+
+func codeReviewPullRequestHasDBMigrationMessage(ctx context.Context, services *Services, pr models.PullRequest, job runCodeReviewPayload) bool {
+	if codeReviewTextContainsDBMigrationMessage(stringPtrValue(pr.Body)) {
+		return true
+	}
+	if job.RequestContext != nil && codeReviewTextContainsDBMigrationMessage(job.RequestContext.Body) {
+		return true
+	}
+	if services == nil || services.PR == nil {
+		return false
+	}
+	lister, ok := services.PR.(codeReviewIssueCommentLister)
+	if !ok {
+		return false
+	}
+	bodies, err := lister.CodeReviewIssueCommentBodies(ctx, job.OrgID, job.RepositoryID, pr.GitHubPRNumber)
+	if err != nil {
+		return false
+	}
+	for _, body := range bodies {
+		if codeReviewTextContainsDBMigrationMessage(body) {
+			return true
+		}
+	}
+	return false
+}
 
 type codeReviewDescriptionEvaluation struct {
 	Passed               bool
@@ -379,20 +414,22 @@ func newRunCodeReviewHandler(stores *Stores, services *Services, logger zerolog.
 		if err != nil {
 			return err
 		}
+		dbMigrationMessageFound := codeReviewPullRequestHasDBMigrationMessage(ctx, services, pr, job)
 		decision, body := evaluateLiveCodeReviewOutcome(liveCodeReviewOutcomeInput{
-			Policy:                policy.Config(),
-			Job:                   job,
-			SessionURL:            codeReviewSessionURL(services.FrontendURL, job.SessionID),
-			PolicySettingsURL:     codeReviewPolicySettingsURL(services.FrontendURL),
-			PullRequest:           pr,
-			Health:                health,
-			AgentResults:          agentResults,
-			Findings:              findings,
-			ChangedFiles:          changedFiles,
-			ChangedFilesAvailable: changedFilesAvailable,
-			OrchestratorSynthesis: codeReviewOrchestratorSynthesisFromResults(agentResults),
-			VisualEvidence:        visualEvidence,
-			AssessedAt:            time.Now().UTC(),
+			Policy:                  policy.Config(),
+			Job:                     job,
+			SessionURL:              codeReviewSessionURL(services.FrontendURL, job.SessionID),
+			PolicySettingsURL:       codeReviewPolicySettingsURL(services.FrontendURL),
+			PullRequest:             pr,
+			Health:                  health,
+			AgentResults:            agentResults,
+			Findings:                findings,
+			ChangedFiles:            changedFiles,
+			ChangedFilesAvailable:   changedFilesAvailable,
+			OrchestratorSynthesis:   codeReviewOrchestratorSynthesisFromResults(agentResults),
+			VisualEvidence:          visualEvidence,
+			DBMigrationMessageFound: dbMigrationMessageFound,
+			AssessedAt:              time.Now().UTC(),
 		})
 		if err := ensureCodeReviewInlineSelection(ctx, stores.CodeReviews, job, findings, changedFiles, policy.Config().InlineCommentLimit); err != nil {
 			return fmt.Errorf("select code review inline findings: %w", err)
@@ -3101,19 +3138,20 @@ type codeReviewAuthorTeamMembershipChecker interface {
 }
 
 type liveCodeReviewOutcomeInput struct {
-	Policy                models.CodeReviewPolicyConfig
-	Job                   runCodeReviewPayload
-	SessionURL            string
-	PolicySettingsURL     string
-	PullRequest           models.PullRequest
-	Health                *models.PullRequestHealthResponse
-	AgentResults          []models.CodeReviewAgentResult
-	Findings              []models.CodeReviewFinding
-	ChangedFiles          []codereviewsvc.PullRequestFile
-	ChangedFilesAvailable bool
-	OrchestratorSynthesis codeReviewOrchestratorSynthesis
-	VisualEvidence        models.CodeReviewVisualEvidenceSnapshot
-	AssessedAt            time.Time
+	Policy                  models.CodeReviewPolicyConfig
+	Job                     runCodeReviewPayload
+	SessionURL              string
+	PolicySettingsURL       string
+	PullRequest             models.PullRequest
+	Health                  *models.PullRequestHealthResponse
+	AgentResults            []models.CodeReviewAgentResult
+	Findings                []models.CodeReviewFinding
+	ChangedFiles            []codereviewsvc.PullRequestFile
+	ChangedFilesAvailable   bool
+	OrchestratorSynthesis   codeReviewOrchestratorSynthesis
+	VisualEvidence          models.CodeReviewVisualEvidenceSnapshot
+	DBMigrationMessageFound bool
+	AssessedAt              time.Time
 }
 
 func codeReviewStableDeterministicRisk(policy models.CodeReviewPolicyConfig, job runCodeReviewPayload, pr models.PullRequest, changedFiles []codereviewsvc.PullRequestFile, changedFilesAvailable bool) models.CodeReviewRiskEvaluation {
@@ -3238,24 +3276,25 @@ func evaluateLiveCodeReviewOutcome(input liveCodeReviewOutcomeInput) (models.Cod
 		descriptionEvaluationValid = descriptionErr == nil
 	}
 	risk := models.EvaluateCodeReviewRisk(policy, models.CodeReviewRiskInput{
-		FilesChanged:          len(input.ChangedFiles),
-		LinesChanged:          codeReviewLinesChanged(input.ChangedFiles),
-		ChangedPaths:          codeReviewChangedPaths(input.ChangedFiles),
-		ChecksPassing:         codeReviewChecksPassing(policy, input.Health),
-		RequiredChecksPassing: codeReviewRequiredChecksPassing(policy, input.Health),
-		DescriptionPassed:     !orchestratorSynthesisUsable || (descriptionEvaluationValid && descriptionEvaluation.Passed),
-		UpToDate:              codeReviewUpToDate(input.Health),
-		Author:                codeReviewAuthor(input.Job, input.PullRequest),
-		AuthorClass:           codeReviewAuthorClass(input.PullRequest),
-		AuthorTeams:           input.Job.PullRequestAuthorTeams,
-		FromFork:              input.Job.FromFork,
-		ContextFetchFailed:    input.Health == nil || !input.ChangedFilesAvailable,
-		HeadSHAChanged:        codeReviewHeadChanged(input.Job.HeadSHA, input.PullRequest, input.Health),
-		BlockingFindings:      blockingFindings,
-		ReviewerDisagreement:  input.OrchestratorSynthesis.ReviewerDisagreement,
-		ScopeMismatch:         input.OrchestratorSynthesis.ScopeMismatch,
-		UnresolvedUncertainty: input.OrchestratorSynthesis.UnresolvedUncertainty,
-		PromptInjectionFound:  codeReviewPromptInjectionLikely(stringPtrValue(input.PullRequest.Body), input.Job.RequestContext) || codeReviewVisualEvidencePromptInjectionLikely(input.VisualEvidence) || input.OrchestratorSynthesis.PromptInjectionDetected,
+		FilesChanged:            len(input.ChangedFiles),
+		LinesChanged:            codeReviewLinesChanged(input.ChangedFiles),
+		ChangedPaths:            codeReviewChangedPaths(input.ChangedFiles),
+		ChecksPassing:           codeReviewChecksPassing(policy, input.Health),
+		RequiredChecksPassing:   codeReviewRequiredChecksPassing(policy, input.Health),
+		DescriptionPassed:       !orchestratorSynthesisUsable || (descriptionEvaluationValid && descriptionEvaluation.Passed),
+		UpToDate:                codeReviewUpToDate(input.Health),
+		Author:                  codeReviewAuthor(input.Job, input.PullRequest),
+		AuthorClass:             codeReviewAuthorClass(input.PullRequest),
+		AuthorTeams:             input.Job.PullRequestAuthorTeams,
+		FromFork:                input.Job.FromFork,
+		ContextFetchFailed:      input.Health == nil || !input.ChangedFilesAvailable,
+		HeadSHAChanged:          codeReviewHeadChanged(input.Job.HeadSHA, input.PullRequest, input.Health),
+		BlockingFindings:        blockingFindings,
+		ReviewerDisagreement:    input.OrchestratorSynthesis.ReviewerDisagreement,
+		ScopeMismatch:           input.OrchestratorSynthesis.ScopeMismatch,
+		UnresolvedUncertainty:   input.OrchestratorSynthesis.UnresolvedUncertainty,
+		PromptInjectionFound:    codeReviewPromptInjectionLikely(stringPtrValue(input.PullRequest.Body), input.Job.RequestContext) || codeReviewVisualEvidencePromptInjectionLikely(input.VisualEvidence) || input.OrchestratorSynthesis.PromptInjectionDetected,
+		DBMigrationMessageFound: input.DBMigrationMessageFound,
 	})
 	if reviewerQuorum < requiredReviewerQuorum {
 		risk.AddReason(models.CodeReviewRiskReason{Code: models.CodeReviewRiskReasonReviewerQuorum, Actual: reviewerQuorum, Limit: requiredReviewerQuorum})

--- a/internal/worker/code_review_handler_test.go
+++ b/internal/worker/code_review_handler_test.go
@@ -661,6 +661,70 @@ func TestCodeReviewSubmitDecision(t *testing.T) {
 	}
 }
 
+type codeReviewIssueCommentStub struct {
+	stubPRService
+	bodies []string
+	err    error
+}
+
+func (s *codeReviewIssueCommentStub) CodeReviewIssueCommentBodies(ctx context.Context, orgID, repositoryID uuid.UUID, number int) ([]string, error) {
+	return s.bodies, s.err
+}
+
+func TestCodeReviewPullRequestHasDBMigrationMessage(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		pr       models.PullRequest
+		job      runCodeReviewPayload
+		services *Services
+		expected bool
+	}{
+		{
+			name:     "detects marker in PR body",
+			pr:       models.PullRequest{Body: stringPtr("A DB migration was added in this PR. Please follow instructions.")},
+			expected: true,
+		},
+		{
+			name: "detects marker in review request context body",
+			job: runCodeReviewPayload{
+				RequestContext: &codereview.ReviewRequestContext{Body: "a db migration was added in this pr"},
+			},
+			expected: true,
+		},
+		{
+			name:     "detects marker in issue comments",
+			pr:       models.PullRequest{GitHubPRNumber: 42},
+			job:      runCodeReviewPayload{RepositoryID: uuid.MustParse("11111111-1111-1111-1111-111111111111")},
+			services: &Services{PR: &codeReviewIssueCommentStub{bodies: []string{"A DB migration was added in this PR."}}},
+			expected: true,
+		},
+		{
+			name:     "returns false when marker is absent",
+			pr:       models.PullRequest{Body: stringPtr("Routine refactor.")},
+			services: &Services{PR: &codeReviewIssueCommentStub{bodies: []string{"Looks good."}}},
+			expected: false,
+		},
+		{
+			name:     "returns false when comment listing fails",
+			pr:       models.PullRequest{GitHubPRNumber: 42},
+			services: &Services{PR: &codeReviewIssueCommentStub{err: errors.New("github unavailable")}},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			actual := codeReviewPullRequestHasDBMigrationMessage(context.Background(), tt.services, tt.pr, tt.job)
+
+			require.Equal(t, tt.expected, actual, "DB migration message detection should match expected")
+		})
+	}
+}
+
 func TestSubmitCodeReviewToGitHubUsesPublicationLock(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

143 was auto-approving PRs that changed the application schema or carried the Assembled-CICD-Bot DB migration comment. These changes can break production data and should be reviewed by a human before merging, so the reviewer now treats them as blocking risks and does not approve.

## Changes

- Added `CodeReviewRiskReasonApplicationSchema` and `CodeReviewRiskReasonDatabaseMigration` to the deterministic risk model; paths containing `application_schema`, `/migrations/`, and related schema/index fragments raise the schema risk.
- The code-review worker now searches the PR body, review request context, and issue comments for the DB migration marker (`A DB migration was added in this PR`) and passes the result into risk evaluation.
- Added `PRService.CodeReviewIssueCommentBodies` to list issue comment bodies for the worker, exposed behind a local interface so `prCreator` stubs remain unchanged.
- For database migration PRs the rendered review body surfaces: *"this migration adheres to the correct syntax, style, etc... Request a human reviewer to ensure adherence to the migration protocol"* without approving.

## Validation

- `go vet ./internal/models ./internal/worker ./internal/services/github`
- `go test ./internal/models ./internal/worker ./internal/services/github`
- `.githooks/pre-commit` (gofmt, lint-stores) passed

Link to Devin session: https://app.devin.ai/sessions/eacc0de0703a4eb29219329370548dcc
Open in Devin Desktop: https://app.devin.ai/desktop/session/eacc0de0703a4eb29219329370548dcc?variant=devin
Requested by: @phager